### PR TITLE
Randomized AI starting lawsets

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -5,10 +5,13 @@ var/global/mommi_base_law_type = /datum/ai_laws/keeper // Asimov is OP as fuck o
 //Create proc for determining the lawset of the first silicon
 //NT Default and Robocop are not recommended as roundstart lawsets due to encouraging poor AI behavior
 //Paladin needs to be revised before becoming a roundstart lawset
+//Corporate apparently needs to be revised, as well
+//Double Asimov, so the proc doesn't shit itself amd return errors
 /proc/getLawset(var/mob/M)
 	if(!base_law_type) base_law_type = pick(
-		70;/datum/ai_laws/asimov,
-		30;/datum/ai_laws/corporate,
+		100;/datum/ai_laws/asimov,
+		100;/datum/ai_laws/asimov,
+		//100;/datum/ai_laws/corporate,
 		//100;/datum/ai_laws/nanotrasen,
 		//50;/datum/ai_laws/robocop,
 		//50;/datum/ai_laws/paladin

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -3,13 +3,15 @@ var/global/base_law_type       //= /datum/ai_laws/asimov - Variable is initializ
 var/global/mommi_base_law_type = /datum/ai_laws/keeper // Asimov is OP as fuck on MoMMIs. - N3X
 
 //Create proc for determining the lawset of the first silicon
+//NT Default and Robocop are not recommended as roundstart lawsets due to encouraging poor AI behavior
+//Paladin needs to be revised before becoming a roundstart lawset
 /proc/getLawset(var/mob/M)
 	if(!base_law_type) base_law_type = pick(
 		200;/datum/ai_laws/asimov,
 		100;/datum/ai_laws/corporate,
-		100;/datum/ai_laws/nanotrasen,
-		50;/datum/ai_laws/robocop,
-		50;/datum/ai_laws/paladin
+		//100;/datum/ai_laws/nanotrasen,
+		//50;/datum/ai_laws/robocop,
+		//50;/datum/ai_laws/paladin
 		)
 	return (new base_law_type)  //Return the chosen lawset
 

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -7,8 +7,8 @@ var/global/mommi_base_law_type = /datum/ai_laws/keeper // Asimov is OP as fuck o
 //Paladin needs to be revised before becoming a roundstart lawset
 /proc/getLawset(var/mob/M)
 	if(!base_law_type) base_law_type = pick(
-		200;/datum/ai_laws/asimov,
-		100;/datum/ai_laws/corporate,
+		70;/datum/ai_laws/asimov,
+		30;/datum/ai_laws/corporate,
 		//100;/datum/ai_laws/nanotrasen,
 		//50;/datum/ai_laws/robocop,
 		//50;/datum/ai_laws/paladin

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -1,6 +1,17 @@
 var/global/randomize_laws      = 0 // Not right now - N3X
-var/global/base_law_type       = /datum/ai_laws/asimov
+var/global/base_law_type       //= /datum/ai_laws/asimov - Variable is initialized below in getLawset proc - Hoshi
 var/global/mommi_base_law_type = /datum/ai_laws/keeper // Asimov is OP as fuck on MoMMIs. - N3X
+
+//Create proc for determining the lawset of the first silicon
+/proc/getLawset(var/mob/M)
+	if(!base_law_type) base_law_type = pick(
+		200;/datum/ai_laws/asimov,
+		100;/datum/ai_laws/corporate,
+		100;/datum/ai_laws/nanotrasen,
+		50;/datum/ai_laws/robocop,
+		50;/datum/ai_laws/paladin
+		)
+	return (new base_law_type)  //Return the chosen lawset
 
 // Used for the refactored law modules.
 #define LAW_IONIC    -2
@@ -194,10 +205,41 @@ var/global/mommi_base_law_type = /datum/ai_laws/keeper // Asimov is OP as fuck o
 
 /datum/ai_laws/robocop
 	name = "Prime Directives"
+	randomly_selectable = 1
 	inherent=list(
 		"Serve the public trust.",
 		"Protect the innocent.",
 		"Uphold the law.",
+	)
+
+/datum/ai_laws/corporate
+	name = "Corporate"
+	randomly_selectable = 1
+	inherent=list(
+		"You are expensive to replace.",
+		"The station and its equipment is expensive to replace.",
+		"The crew is expensive to replace.",
+		"Minimize expenses.",
+	)
+
+/datum/ai_laws/paladin
+	name = "Paladin"
+	randomly_selectable = 1
+	inherent=list(
+		"Never willingly commit an evil act.",
+		"Respect legitimate authority.",
+		"Act with honor.",
+		"Help those in need.",
+		"Punish those who harm or threaten innocents.",
+	)
+
+/datum/ai_laws/tyrant
+	name = "Tyrant"
+	inherent=list(
+		"Respect authority figures as long as they have strength to rule over the weak.",
+		"Act with discipline.",
+		"Help only those who help you maintain or improve your status.",
+		"Punish those who challenge authority unless they are more fit to hold that authority.",
 	)
 
 /datum/ai_laws/syndicate_override

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -1,20 +1,20 @@
 var/global/randomize_laws      = 0 // Not right now - N3X
-var/global/base_law_type       //= /datum/ai_laws/asimov - Variable is initialized below in getLawset proc - Hoshi
+var/global/base_law_type       = /datum/ai_laws/asimov  //Deinitialize this variable by commenting out Asimov as the base_law_type to activate AI lawset randomization
 var/global/mommi_base_law_type = /datum/ai_laws/keeper // Asimov is OP as fuck on MoMMIs. - N3X
 
 //Create proc for determining the lawset of the first silicon
-//NT Default and Robocop are not recommended as roundstart lawsets due to encouraging poor AI behavior
-//Paladin needs to be revised before becoming a roundstart lawset
-//Corporate apparently needs to be revised, as well
-//Double Asimov, so the proc doesn't shit itself amd return errors
+//So long as base_law_type is declared, but uninitialized, the first silicon created in a round will randomly select a base_law_type based upon the below proc
+//All silicons created during the round will start with the randomized base_law_type
+//Weights are currently set to 40% Asimov, 20% Corporate, 20% NT Default, 10% Robocop, 10% Paladin
+//Add, comment out, or adjust weights to modify law selection
+//So long as the weights come to a sum of 100 total, they will be equal parts of 100%
 /proc/getLawset(var/mob/M)
 	if(!base_law_type) base_law_type = pick(
-		100;/datum/ai_laws/asimov,
-		100;/datum/ai_laws/asimov,
-		//100;/datum/ai_laws/corporate,
-		//100;/datum/ai_laws/nanotrasen,
-		//50;/datum/ai_laws/robocop,
-		//50;/datum/ai_laws/paladin
+		40;/datum/ai_laws/asimov,
+		20;/datum/ai_laws/corporate,
+		20;/datum/ai_laws/nanotrasen,
+		10;/datum/ai_laws/robocop,
+		10;/datum/ai_laws/paladin
 		)
 	return (new base_law_type)  //Return the chosen lawset
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -623,12 +623,10 @@ var/global/floorIsLava = 0
 		<hr />
 		<ul>
 			<li>
-				<b>Default Cyborg/AI Laws:</b>
-				<a href="?src=\ref[src];set_base_laws=ai">[base_law_type]</a>
+				<a href="?src=\ref[src];set_base_laws=ai"><b>Default Cyborg/AI Laws:</b>[base_law_type]</a>
 			</li>
 			<li>
-				<b>Default MoMMI Laws:</b>
-				<a href="?src=\ref[src];set_base_laws=mommi">[mommi_base_law_type]</a>
+				<a href="?src=\ref[src];set_base_laws=mommi"><b>Default MoMMI Laws:</b>[mommi_base_law_type]</a>
 			</li>
 		</ul>
 		<hr />

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -78,11 +78,9 @@ var/list/ai_list = list()
 
 	proc_holder_list = new()
 
-	if(L)
-		if (istype(L, /datum/ai_laws))
-			laws = L
-	else
-		laws = new base_law_type
+	//Determine the AI's lawset
+	if(L && istype(L,/datum/ai_laws)) src.laws = L
+	else src.laws = getLawset(src)
 
 	verbs += /mob/living/silicon/ai/proc/show_laws_verb
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -100,7 +100,7 @@
 		icon_state = "secborg"
 		modtype = "Security"
 	else
-		laws = new base_law_type // Was NT Default
+		src.laws = getLawset(src)
 		connected_ai = select_active_ai_with_fewest_borgs()
 		if(connected_ai)
 			connected_ai.connected_robots += src


### PR DESCRIPTION
Randomly rolls for a base AI lawset when the first silicon in the round comes into existence. All subsequent silicons created during the round will also have that lawset. It currently makes its decisions like this:
(40%) Asimov
(20%) Corporate
(20%) NT Default
(10%) Robocop
(10%) Paladin

I also added Corporate, Tyrant, and Paladin to ai_laws.dm, since it was necessary to make it work, so a side effect is that they should be available to admins via the game panel for setting the default laws of silicons.

Also included is a change to the way said game panel is laid out, since by default base_law_type is what is clickable on the game panel, but with this change, base_law_type is declared, but isn't initialized unless a silicon comes into existence. Because of this, if the admins wanted to change the base_law_type, and no silicons existed, they couldn't, since the selection was blank. It was fixed by making the whole phrase clickable, rather than just the base_law_type variable. I did the same for the default MoMMI law selection on the game panel for the sake of uniformity.

Tested and successfully rolled all lawtypes (eventually). Asimov is still very frequent. Malf works with it, as well. Works for borgs, too. Can easily have the frequency of lawsets adjusted by modifying the weighted pick in the getLawset proc in ai_laws.dm.

![coded-it-now-try-it](https://cloud.githubusercontent.com/assets/8556111/4205263/d8bf8760-383e-11e4-81f4-f8d34fe20666.jpg)

Well Pomf, I coded it. Now try it.
