### PR TITLE
Nightvision Goggles update + RPD on lattices

### DIFF
--- a/code/game/objects/items/weapons/RPD.dm
+++ b/code/game/objects/items/weapons/RPD.dm
@@ -476,8 +476,6 @@ var/global/list/RPD_recipes=list(
 		return 0
 	if(istype(A,/area/shuttle)||istype(A,/turf/space/transit))
 		return 0
-	if(istype(A, /obj/structure/lattice))
-		A = get_turf(A)
 
 	switch(p_class)
 		if(-2) // Paint pipes

--- a/code/game/objects/items/weapons/RPD.dm
+++ b/code/game/objects/items/weapons/RPD.dm
@@ -476,6 +476,8 @@ var/global/list/RPD_recipes=list(
 		return 0
 	if(istype(A,/area/shuttle)||istype(A,/turf/space/transit))
 		return 0
+	if(istype(A, /obj/structure/lattice))
+		A = get_turf(A)
 
 	switch(p_class)
 		if(-2) // Paint pipes

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -47,21 +47,16 @@
 	return
 
 /obj/structure/lattice/attackby(obj/item/C as obj, mob/user as mob)
-
-	// /vg/ - Rods for catwalks - N3X
-	if (istype(C, /obj/item/stack/tile/plasteel) || istype(C, /obj/item/stack/rods))
-		var/turf/T = get_turf(src)
-		T.attackby(C, user) //BubbleWrap - hand this off to the underlying turf instead
-		return
-
 	if(istype(C, /obj/item/weapon/weldingtool))
 		var/obj/item/weapon/weldingtool/WeldingTool = C
-
 		if(WeldingTool.remove_fuel(0, user))
 			user << "<span class='notice'>Slicing lattice joints...</span>"
-
 		new/obj/item/stack/rods(loc)
 		qdel(src)
+	else
+		var/turf/T = get_turf(src)
+		T.attackby(C, user) //Attacking to the lattice will attack to the space turf
+		return T.attackby(C, user)
 
 /obj/structure/lattice/proc/updateOverlays()
 	set waitfor = 0

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -77,6 +77,8 @@
 	var/darkness_view = 0//Base human is 2
 	var/invisa_view = 0
 	var/cover_hair = 0
+	var/see_invisible = 0
+	var/see_in_dark = 0
 	species_restricted = list("exclude","Muton")
 /*
 SEE_SELF  // can see self, no matter what

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -36,8 +36,8 @@
 	icon_state = "night"
 	item_state = "glasses"
 	origin_tech = "magnets=2"
-	vision_flags = SEE_TURFS
-	darkness_view = 3
+	see_invisible = SEE_INVISIBLE_OBSERVER_NOLIGHTING
+	see_in_dark = 8
 	species_fit = list("Vox")
 
 /obj/item/clothing/glasses/eyepatch

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1408,11 +1408,15 @@ var/global/list/organ_damage_overlays = list(
 			if(glasses)
 				var/obj/item/clothing/glasses/G = glasses
 				if(istype(G))
+					if(G.see_in_dark)
+						see_in_dark = G.see_in_dark
 					see_in_dark += G.darkness_view
 					if(G.vision_flags)		// MESONS
 						sight |= G.vision_flags
 						if(!druggy)
 							see_invisible = SEE_INVISIBLE_MINIMUM
+					if(G.see_invisible)
+						see_invisible = G.see_invisible
 
 	/* HUD shit goes here, as long as it doesn't modify sight flags */
 	// The purpose of this is to stop xray and w/e from preventing you from using huds -- Love, Doohl

--- a/html/changelogs/Clusterfack_2418
+++ b/html/changelogs/Clusterfack_2418
@@ -1,0 +1,5 @@
+author: Clusterfack
+delete-after: true
+changes:
+- rscadd: RPDs can build on lattices
+- rscadd: Night vision goggles give night vision and no longer see through walls


### PR DESCRIPTION
Night vision goggles work like night vision goggles, they let you see through the dark, they dont let you see through walls, and they illuminate all darkness.

RPDs can now build on lattice when you click on them.