### PR TITLE
Silences the metaclub's private beach

### DIFF
--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -2245,6 +2245,7 @@ var/list/the_station_areas = list (
 	requires_power = 0
 	var/sound/mysound = null
 
+/* We have a jukebox now, fuck that
 /area/beach/New()
 	..()
 	var/sound/S = new/sound()
@@ -2265,6 +2266,7 @@ var/list/the_station_areas = list (
 			Obj << mysound
 	return
 
+//This only works when using Move() to exit the area
 /area/beach/Exited(atom/movable/Obj)
 	if(ismob(Obj))
 		if(Obj:client)
@@ -2293,3 +2295,4 @@ var/list/the_station_areas = list (
 
 	spawn(60) .()
 
+*/

--- a/html/changelogs/Duny-beach.yml
+++ b/html/changelogs/Duny-beach.yml
@@ -1,0 +1,4 @@
+author: Duny
+delete-after: True
+changes: 
+  - bugfix: Fixed metaclub beach sound looping repeatedly by getting rid of those sounds entirely. All hail the superjuke.


### PR DESCRIPTION
The sound never stops because you have to use Move() to exit the beach for it to be detected apparently.
I tried to fix it at first then I realized we have a superjuke.
This shit is a mess so I just commented it all out. Might delete it later if nobody misses the sounds.

Closes https://github.com/d3athrow/vgstation13/issues/2364