### PR TITLE
Final examine hotfix

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -231,7 +231,7 @@
 	This is overridden in ai.dm
 */
 /mob/proc/ShiftClickOn(var/atom/A)
-	A.ShiftClick()
+	A.ShiftClick(src)
 	return
 /atom/proc/ShiftClick(var/mob/user)
 	if(user.client && user.client.eye == user)

--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -46,7 +46,7 @@
 
 // We don't need a fucking toggle.
 /mob/dead/observer/ShiftClickOn(var/atom/A)
-	usr.examination(src)
+	user.examination(src)
 
 /atom/proc/attack_ghost(mob/user as mob)
 	var/ghost_flags = 0

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -296,9 +296,6 @@ its easier to just keep the beam vertical.
 	if(desc)
 		user << desc
 
-	// *****RM
-	//user << "[name]: Dn:[density] dir:[dir] cont:[contents] icon:[icon] is:[icon_state] loc:[loc]"
-
 	if(reagents && is_open_container()) //is_open_container() isn't really the right proc for this, but w/e
 		user << "It contains:"
 		if(reagents.reagent_list.len)

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -128,7 +128,7 @@
 	if(in_range(user,src))
 		if(contents)
 			user << "You can just about make out some properties of the cryo's murky depths:"
-			for(var/atom/movable/floater in contents)
+			for(var/atom/movable/floater in (contents - beaker))
 				user << "A figure floats in the depths, they appear to be [floater.name]"
 			if(beaker)
 				user << "A beaker is releasing the following chemicals into the fluids:"

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -107,8 +107,8 @@
 	src.loc = T
 
 /obj/item/examine(mob/user)
+	..() //TODO: Make The following code simply append to the description instead of a separate line
 	var/size
-	var/odesc = desc
 	switch(src.w_class)
 		if(1.0)
 			size = "tiny"
@@ -127,12 +127,7 @@
 		pronoun = "They are"
 	else
 		pronoun = "It is"
-	if (!desc)
-		user << "[pronoun] a [size] item."
-	else
-		desc += " [pronoun] a [size] item."
-	..()
-	desc = odesc
+	user << " [pronoun] a [size] item."
 
 
 /obj/item/attack_ai(mob/user as mob)

--- a/code/game/objects/items/weapons/cash.dm
+++ b/code/game/objects/items/weapons/cash.dm
@@ -35,10 +35,14 @@ var/global/list/moneytypes=list(
 	update_icon()
 
 /obj/item/weapon/spacecash/examine(mob/user)
-	..()
 	if(amount>1)
+		gender = PLURAL
+		..()
 		user << "It is a stack holding [amount] chips."
 		user << "<span class='info'>It's worth [worth*amount] credits.</span>"
+	else
+		gender = NEUTER
+		..()
 
 /obj/item/weapon/spacecash/update_icon()
 	icon_state = "cash[worth]"

--- a/html/changelogs/Clusterfack_2467.yml
+++ b/html/changelogs/Clusterfack_2467.yml
@@ -1,0 +1,4 @@
+author: Clusterfack
+delete-after: true
+changes:
+- rscadd: Large scale examine changes, please report broken/duplicated text.


### PR DESCRIPTION
Most examining reagent problems have been resolved at this point. But in the long term some kind of 'transparent' variable should be added to atoms that allows people to view the reagents inside of them

This hotfix
-Makes ghosts examine things properly when shiftclicking
-Makes serb not commit sudoku when people log on