### PR TITLE
Batch of Bugfixes

### DIFF
--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -79,8 +79,8 @@
 								newpath = text2path(I)
 								var/obj/item/s = new newpath
 								s.loc = user.loc
-								if(istype(P, /obj/item/weapon/cable_coil))
-									var/obj/item/weapon/cable_coil/A = P
+								if(istype(s, /obj/item/weapon/cable_coil))
+									var/obj/item/weapon/cable_coil/A = s
 									A.amount = 1
 
 						// Drop a circuit board too

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -72,6 +72,9 @@ would spawn and follow the beaker, even if it is carried or thrown.
 
 	proc/start()
 
+/obj/effect/canSingulothPull(var/obj/machinery/singularity/singulo)
+	return 0
+
 /////////////////////////////////////////////
 // GENERIC STEAM SPREAD SYSTEM
 

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -22,18 +22,19 @@
 
 /obj/item/stack/rods/attackby(obj/item/W as obj, mob/user as mob)
 	..()
-	if (istype(W, /obj/item/weapon/weldingtool))
+	if(iswelder(W))
 		var/obj/item/weapon/weldingtool/WT = W
 
 		if(amount < 2)
-			user << "\red You need at least two rods to do this."
+			user << "<span class='warning'>You need at least two rods to do this.</span>"
 			return
 
 		if(WT.remove_fuel(0,user))
 			var/obj/item/stack/sheet/metal/new_item = new(usr.loc)
 			new_item.add_to_stacks(usr)
-			for (var/mob/M in viewers(src))
-				M.show_message("\red [src] is shaped into metal by [user.name] with the weldingtool.", 3, "\red You hear welding.", 2)
+			user.visible_message("<span class='warning'>[src] is shaped into metal by [user.name] with the weldingtool.</span>", \
+			"<span class='warning'>You shape the [src] into metal with the weldingtool.</span>", \
+			"<span class='warning'>You hear welding.</span>")
 			var/obj/item/stack/rods/R = src
 			src = null
 			var/replace = (user.get_inactive_hand()==R)

--- a/code/game/objects/items/stacks/tiles/plasteel.dm
+++ b/code/game/objects/items/stacks/tiles/plasteel.dm
@@ -49,3 +49,26 @@
 //	var/turf/simulated/floor/W = S.ReplaceWithFloor()
 //	W.make_plating()
 	return
+
+/obj/item/stack/tile/plasteel/attackby(obj/item/W as obj, mob/user as mob)
+	..()
+	if(iswelder(W))
+		var/obj/item/weapon/weldingtool/WT = W
+		if(amount < 4)
+			user << "<span class='warning'>You need at least four tiles to do this.</span>"
+			return
+
+		if(WT.remove_fuel(0,user))
+			var/obj/item/stack/sheet/metal/new_item = new(usr.loc)
+			new_item.add_to_stacks(usr)
+			user.visible_message("<span class='warning'>[src] is shaped into metal by [user.name] with the weldingtool.</span>", \
+			"<span class='warning'>You shape the [src] into metal with the weldingtool.</span>", \
+			"<span class='warning'>You hear welding.</span>")
+			var/obj/item/stack/tile/plasteel/R = src
+			src = null
+			var/replace = (user.get_inactive_hand()==R)
+			R.use(4)
+			if (!R && replace)
+				user.put_in_hands(new_item)
+		return
+	..()

--- a/code/modules/food/cooking_machines.dm
+++ b/code/modules/food/cooking_machines.dm
@@ -104,19 +104,21 @@ var/global/ingredientLimit = 10
 	if(src.cooks_in_reagents) user << "<span class='info'>It seems to have [reagents.total_volume] units left.</span>"
 
 /obj/machinery/cooking/attack_hand(mob/user)
-	if(istype(user,/mob/dead/observer))	user << "Your ghostly hand goes straight through."
-	else if(istype(user,/mob/living/silicon)) user << "This is old analog equipment. You can't interface with it."
+	if(isobserver(user))	user << "Your ghostly hand goes straight through."
+	else if(issilicon(user)) user << "This is old analog equipment. You can't interface with it."
 	else if(src.active)
-		if(src.ingredient && (get_turf(src.ingredient)==get_turf(src)))
-			if(alert(user,"Remove the [src.ingredient.name]?",,"Yes","No") == "Yes")
-				src.active = 0
-				src.icon_state = initial(src.icon_state)
-				src.ingredient.mouse_opacity = 1
-				user.put_in_hands(src.ingredient)
-				user << "<span class='notice'>You remove the [src.ingredient.name] from the [src.name].</span>"
-				src.ingredient = null
-			else user << "You leave the [src.name] alone."
-		else src.active = 0
+		if(alert(user,"Remove the [src.ingredient.name]?",,"Yes","No") == "Yes")
+			if(src.ingredient && (get_turf(src.ingredient)==get_turf(src)))
+				if(get_dist(src, user) <= 1)
+					src.active = 0
+					src.icon_state = initial(src.icon_state)
+					src.ingredient.mouse_opacity = 1
+					user.put_in_hands(src.ingredient)
+					user << "<span class='notice'>You remove the [src.ingredient.name] from the [src.name].</span>"
+					src.ingredient = null
+				else user << "You are too far away from [src.name]."
+			else src.active = 0
+		else user << "You leave the [src.name] alone."
 	else . = ..()
 	return
 

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/base_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/base_spider.dm
@@ -83,6 +83,8 @@ var/global/list/spider_types = typesof(/mob/living/simple_animal/hostile/giant_s
 /mob/living/simple_animal/hostile/giant_spider/CanAttack(var/atom/the_target)
 	if(istype(the_target,/mob/living/simple_animal/hostile/giant_spider))
 		return 0
+	if(istype(the_target,/obj/effect))
+		return 0
 	if(istype(the_target,/obj/machinery/door))
 		return CanOpenDoor(the_target)
 	if(istype(the_target,/obj/machinery/light))

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -391,6 +391,7 @@
 			on = (status == LIGHT_OK)
 			update(0)
 		flickering = 0
+		on = has_power()
 
 /obj/machinery/light/attack_ghost(mob/user)
 	if(blessed) return

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -952,7 +952,7 @@ USE THIS CHEMISTRY DISPENSER FOR MAPS SO THEY START AT 100 ENERGY
 
 
 		//archaeology!
-		/obj/item/weapon/rocksliver = list("ground_rock" = 50),
+		/obj/item/weapon/rocksliver = list("ground_rock" = 30),
 
 		//All types that you can put into the grinder to transfer the reagents to the beaker. !Put all recipes above this.!
 		/obj/item/weapon/reagent_containers/pill = list(),

--- a/code/modules/research/xenoarchaeology/artifact/artifact_unknown.dm
+++ b/code/modules/research/xenoarchaeology/artifact/artifact_unknown.dm
@@ -225,8 +225,11 @@ var/list/valid_secondary_effect_types = list(\
 			secondary_effect.ToggleActivate(0)
 
 /obj/machinery/artifact/attack_hand(var/mob/user as mob)
+	if(isobserver(user))
+		user << "<span class='rose'>Your ghostly hand goes right through!</span>"
+		return
 	if (get_dist(user, src) > 1)
-		user << "\red You can't reach [src] from here."
+		user << "<span class='warning'>You can't reach [src] from here.</span>"
 		return
 	if(ishuman(user) && user:gloves)
 		user << "<b>You touch [src]</b> with your gloved hands, [pick("but nothing of note happens","but nothing happens","but nothing interesting happens","but you notice nothing different","but nothing seems to have happened")]."

--- a/html/changelogs/Clusterfack_2579.yml
+++ b/html/changelogs/Clusterfack_2579.yml
@@ -1,0 +1,6 @@
+author: Clusterfack
+delete-after: true
+changes:
+- bugfix: Ghosts can no longer activate unknown artifacts
+- bugfix: Tcomms machines should no longer give extra cable coil
+- rscadd: You can now weld floor tiles back into metal


### PR DESCRIPTION
Fixes tcomms machines giving a whole cable coil during deconstruction. 
Fixes #2500 

Singularity no longer pulls obj/effects like beams, fires. etc. And giant spiders no longer target them, should help with giant spider latency, since they can not being able to target things like cocoons or webs they created anymore. Hopefully a good performance increase.

Floor tiles can now be welded down into metal. 
Fixes #2555 

Cooking machines now have a proper range check and cannot be activated by clicking and walking away. 
Fixes  #1554

Booing lights will no longer break if you turn off the light. 
Fixes #2504 

Ground samples in xenoarch now give 30 units instead of 50 because you would NEVER have a reason to use that much, even 30 is a bit much.

Ghosts can no longer activate unknown artifacts
Fixes #1645 
and #2575 