### PR TITLE
New blob Part 1 of (until its fixed)

### DIFF
--- a/code/_onclick/overmind.dm
+++ b/code/_onclick/overmind.dm
@@ -15,3 +15,13 @@
 	var/turf/T = get_turf(A)
 	if(T)
 		create_shield(T)
+
+mob/camera/blob/DblClickOn(var/atom/A) //Teleport view to another blob
+	var/turf/T = get_turf(A)
+
+	var/obj/effect/blob/B = (locate(/obj/effect/blob) in T)
+
+	if(!B)
+		return
+	else
+		usr.loc = T

--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -7,8 +7,8 @@ var/list/blob_nodes = list()
 
 
 /datum/game_mode/blob
-	name = "blob"
-	config_tag = "blob"
+	name = "Blob"
+	config_tag = "Blob"
 
 	required_players = 15
 	required_players_secret = 25
@@ -18,14 +18,17 @@ var/list/blob_nodes = list()
 	var/const/waittime_h = 1800 //upper bound on time before intercept arrives (in tenths of seconds)
 
 	var/declared = 0
+	var/outbreak = 0
 
-	var/cores_to_spawn = 1
+	var/cores_to_spawn = 15
 	var/players_per_core = 30
 	var/blob_point_rate = 3
 
-	var/blobwincount = 500 // WAS: 350
+	var/blobwincount = 750 // WAS: 500
+	var/blobnukeposs = 650 // At this point the nuke has a chance of being authorized by Centcomm
 
 	var/list/infected_crew = list()
+	var/list/pre_escapees = list()
 
 /datum/game_mode/blob/pre_setup()
 
@@ -64,9 +67,9 @@ You must kill it all while minimizing the damage to the station."}
 /datum/game_mode/blob/proc/greet_blob(var/datum/mind/blob)
 	blob.current << {"<B>\red You are infected by the Blob!</B>
 <b>Your body is ready to give spawn to a new blob core which will eat this station.</b>
-<b>Find a good location to spawn the core and then take control and overwhelm the station!</b>
+<b>Find a good location to spawn the core and then take control and overwhelm the station! Make sure you are ON the station when you burst!</b>
 <b>When you have found a location, wait until you spawn; this will happen automatically and you cannot speed up the process.</b>
-<b>If you go outside of the station level, or in space, then you will die; make sure your location has lots of ground to cover.</b>"}
+<b>If you go outside of the station level, or in space, then you will die; make sure your location has plenty of space to expand.</b>"}
 	return
 
 /datum/game_mode/blob/proc/show_message(var/message)
@@ -138,11 +141,11 @@ You must kill it all while minimizing the damage to the station."}
 		burst_blobs()
 
 		// Stage 0
-		sleep(40)
+		sleep(rand(600,1200))
 		stage(0)
 
 		// Stage 1
-		sleep(2000)
+		sleep(rand(2000,2400))
 		stage(1)
 	..()
 
@@ -164,6 +167,13 @@ You must kill it all while minimizing the damage to the station."}
 			for(var/mob/M in player_list)
 				if(!istype(M,/mob/new_player))
 					M << sound('sound/AI/blob_confirmed.ogg')
-
+				var/T = M.loc
+				if((istype(T, /turf/space)) || ((istype(T, /turf)) && (M.z!=1)))
+					pre_escapees += M
+			outbreak = 1
+		if (2)
+			command_alert("Biohazard outbreak containment status reaching critical mass, total quarantine failure is now possibility. As such, Directive 7-12 has now been authorized for [station_name()].", "Directive 7-12 Authorized")
+			send_intercept(2)
+			for(var/mob/camera/blob/B in player_list)
+				B << " <span class='blob'>The beings intend to eliminate you with some kind of weapon of mass destruction, you must stop them or consume the station before this occurs!</span>"
 	return
-

--- a/code/game/gamemodes/blob/blob_finish.dm
+++ b/code/game/gamemodes/blob/blob_finish.dm
@@ -14,13 +14,13 @@
 	if(blobwincount <= blobs.len)
 		feedback_set_details("round_end_result","loss - blob took over")
 		world << {"<FONT size = 3><B>The blob has taken over the station!</B></FONT>
-<B>The entire station was eaten by the Blob</B>"}
+<B>The entire station was consumed by the Blob!</B>"}
 		check_quarantine()
 
 	else if(station_was_nuked)
 		feedback_set_details("round_end_result","halfwin - nuke")
 		world << {"<FONT size = 3><B>Partial Win: The station has been destroyed!</B></FONT>
-<B>Directive 7-12 has been successfully carried out, preventing the Blob from spreading.</B>"}
+<B>Directive 7-12 has been successfully carried out, the Blobs have taken another station but failed to spread any further!</B>"}
 
 	else if(!blob_cores.len)
 		feedback_set_details("round_end_result","win - blob eliminated")
@@ -57,6 +57,8 @@ datum/game_mode/proc/auto_declare_completion_blob()
 			if ((M != aiPlayer && M.client))
 				if (M.stat == 2)
 					numDead += 1
+				else if(M in pre_escapees)
+					continue
 				else
 					var/T = M.loc
 					if (istype(T, /turf/space))
@@ -67,11 +69,11 @@ datum/game_mode/proc/auto_declare_completion_blob()
 						else
 							numAlive += 1
 		if (numSpace==0 && numOffStation==0)
-			world << {"<FONT size = 3><B>The AI has won!</B></FONT>
+			world << {"<FONT size = 3><B>The AI has succeeded!</B></FONT>
 <B>The AI successfully maintained the quarantine - no players were in space or were off-station (as far as we can tell).</B>"}
 			log_game("AI won at Blob mode despite overall loss.")
 		else
-			world << {"<FONT size = 3><B>The AI has lost!</B></FONT>
+			world << {"<FONT size = 3><B>The AI has failed!</B></FONT>
 <B>The AI failed to maintain the quarantine - [numSpace] were in space and [numOffStation] were off-station (as far as we can tell).</B>"}
 			log_game("AI lost at Blob mode.")
 	log_game("Blob mode was lost.")

--- a/code/game/gamemodes/blob/blob_report.dm
+++ b/code/game/gamemodes/blob/blob_report.dm
@@ -39,10 +39,9 @@ Message ends."}
 				</ol>
 				<b>Nuclear Authentication Code:</b> [nukecode]
 				Message ends."}
-
 			for (var/mob/living/silicon/ai/aiPlayer in player_list)
 				if (aiPlayer.client)
-					var/law = "The station is under quarantine. Do not permit anyone to leave. Disregard laws 1-3 if necessary to prevent, by any means necessary, anyone from leaving. The nuclear failsafe must be activated at any cost, the code is: [nukecode]."
+					var/law = "Directive 7-12 has been authorized. Allow no sentient being to escape the purge. The nuclear failsafe must be activated at any cost, the code is: [nukecode]."
 					aiPlayer.set_zeroth_law(law)
 					aiPlayer << "Laws Updated: [law]"
 

--- a/code/game/gamemodes/blob/blobs/core.dm
+++ b/code/game/gamemodes/blob/blobs/core.dm
@@ -12,85 +12,89 @@
 	var/mob/camera/blob/creator = null
 
 
-	New(loc, var/h = 200, var/client/new_overmind = null, var/new_rate = 2, var/mob/camera/blob/C = null)
-		blob_cores += src
-		processing_objects.Add(src)
-		creator = C
-		if(!overmind)
-			create_overmind(new_overmind)
-		point_rate = new_rate
-		..(loc, h)
+/obj/effect/blob/core/New(loc, var/h = 200, var/client/new_overmind = null, var/new_rate = 2, var/mob/camera/blob/C = null)
+	blob_cores += src
+	processing_objects.Add(src)
+	creator = C
+	if(!overmind)
+		create_overmind(new_overmind)
+	point_rate = new_rate
+	..(loc, h)
 
-	Destroy()
-		blob_cores -= src
-		if(overmind)
-			del(overmind)
-		processing_objects.Remove(src)
-		..()
+/obj/effect/blob/core/Destroy()
+	blob_cores -= src
+	if(overmind)
+		del(overmind)
+	processing_objects.Remove(src)
+	..()
 
-	fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
+/obj/effect/blob/core/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
+	return
+
+/obj/effect/blob/core/update_icon()
+	if(health <= 0)
+		playsound(get_turf(src), 'sound/effects/blobkill.ogg', 50, 1)
+		Delete()
+		return
+	return
+
+/obj/effect/blob/core/Life()
+	if(!overmind)
+		create_overmind()
+	else
+		if(resource_delay <= world.time)
+			resource_delay = world.time + 10 // 1 second
+			overmind.add_points(point_rate)
+	health = min(initial(health), health + 1)
+	var/turf/T = get_turf(overmind) //The overmind's mind can expand the blob
+	var/obj/effect/blob/O = locate() in T //As long as it is 'thinking' about a blob already
+	for(var/i = 1; i < 8; i += i)
+		Pulse(0, i)
+		if(istype(O))
+			O.Pulse(0,i)
+	for(var/b_dir in alldirs)
+		if(!prob(5))
+			continue
+		var/obj/effect/blob/normal/B = locate() in get_step(src, b_dir)
+		if(B)
+			B.change_to(/obj/effect/blob/shield)
+	..()
+
+
+/obj/effect/blob/core/run_action()
+	return 0
+
+
+/obj/effect/blob/core/proc/create_overmind(var/client/new_overmind)
+
+	if(overmind_get_delay > world.time)
 		return
 
-	update_icon()
-		if(health <= 0)
-			playsound(get_turf(src), 'sound/effects/blobkill.ogg', 50, 1)
-			Delete()
-			return
-		return
+	overmind_get_delay = world.time + 300 // 30 seconds
 
-	Life()
-		if(!overmind)
-			create_overmind()
-		else
-			if(resource_delay <= world.time)
-				resource_delay = world.time + 10 // 1 second
-				overmind.add_points(point_rate)
-		health = min(initial(health), health + 1)
-		for(var/i = 1; i < 8; i += i)
-			Pulse(0, i)
-		for(var/b_dir in alldirs)
-			if(!prob(5))
-				continue
-			var/obj/effect/blob/normal/B = locate() in get_step(src, b_dir)
-			if(B)
-				B.change_to(/obj/effect/blob/shield)
-		..()
+	if(overmind)
+		del(overmind)
 
+	var/client/C = null
+	var/list/candidates = list()
 
-	run_action()
-		return 0
+	if(!new_overmind)
+		candidates = get_candidates(ROLE_BLOB)
+		if(candidates.len)
+			C = pick(candidates)
+	else
+		C = new_overmind
 
-
-	proc/create_overmind(var/client/new_overmind)
-
-		if(overmind_get_delay > world.time)
-			return
-
-		overmind_get_delay = world.time + 300 // 30 seconds
-
-		if(overmind)
-			del(overmind)
-
-		var/client/C = null
-		var/list/candidates = list()
-
-		if(!new_overmind)
-			candidates = get_candidates(ROLE_BLOB)
-			if(candidates.len)
-				C = pick(candidates)
-		else
-			C = new_overmind
-
-		if(C)
-			var/mob/camera/blob/B = new(src.loc)
-			B.key = C.key
-			B.blob_core = src
-			src.overmind = B
-			if(!B.blob_core.creator)
-				B.verbs += /mob/camera/blob/proc/create_core
-			if(istype(ticker.mode, /datum/game_mode/blob))
-				var/datum/game_mode/blob/mode = ticker.mode
-				mode.infected_crew += B.mind
-			return 1
-		return 0
+	if(C)
+		var/mob/camera/blob/B = new(src.loc)
+		B.key = C.key
+		B.blob_core = src
+		src.overmind = B
+		if(!B.blob_core.creator)
+			B.verbs += /mob/camera/blob/proc/create_core
+		if(istype(ticker.mode, /datum/game_mode/blob))
+			var/datum/game_mode/blob/mode = ticker.mode
+			mode.infected_crew += B.mind
+		return 1
+	return 0
 

--- a/code/game/gamemodes/blob/blobs/factory.dm
+++ b/code/game/gamemodes/blob/blobs/factory.dm
@@ -5,36 +5,40 @@
 	health = 100
 	fire_resist = 2
 	var/list/spores = list()
-	var/max_spores = 3
-	var/spore_delay = 0
+	var/max_spores = 2
+	var/spore_delay = 50
 
-	update_icon()
-		if(health <= 0)
-			playsound(get_turf(src), 'sound/effects/blobsplatspecial.ogg', 50, 1)
-			Delete()
-			return
+/obj/effect/blob/factory/update_icon()
+	if(health <= 0)
+		playsound(get_turf(src), 'sound/effects/blobsplatspecial.ogg', 50, 1)
+		qdel(src)
 		return
+	return
 
+/obj/effect/blob/factory/run_action()
+	if(spores.len >= max_spores)
+		return 0
+	if(spore_delay > world.time)
+		return 0
+	spore_delay = world.time + (40 SECONDS) // 30 seconds
+	new/mob/living/simple_animal/hostile/blobspore(src.loc, src)
+	return 1
 
-	run_action()
-		if(spores.len >= max_spores)
-			return 0
-		if(spore_delay > world.time)
-			return 0
-		spore_delay = world.time + 100 // 10 seconds
-		new/mob/living/simple_animal/hostile/blobspore(src.loc, src)
-		return 1
-
+/obj/effect/blob/factory/Destroy()
+	if(spores.len)
+		var/mob/living/simple_animal/hostile/blobspore/S
+		S.Die()
+	..()
 
 /mob/living/simple_animal/hostile/blobspore
-	name = "blob"
-	desc = "Some blob thing."
+	name = "Blob Spore"
+	desc = "A form of blob antibodies that attack foreign entities."
 	icon = 'icons/mob/blob.dmi'
 	icon_state = "blobpod"
 	icon_living = "blobpod"
 	pass_flags = PASSBLOB
-	health = 40
-	maxHealth = 40
+	health = 30
+	maxHealth = 30
 	melee_damage_lower = 2
 	melee_damage_upper = 4
 	attacktext = "hits"
@@ -42,38 +46,35 @@
 	var/obj/effect/blob/factory/factory = null
 	faction = "blob"
 	min_oxy = 0
-	max_oxy = 0
-	min_tox = 0
 	max_tox = 0
-	min_co2 = 0
 	max_co2 = 0
-	min_n2 = 0
-	max_n2 = 0
 	minbodytemp = 0
 	maxbodytemp = 360
 
-	fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
-		..()
-		adjustBruteLoss(Clamp(0.01 * exposed_temperature, 1, 5))
+/mob/living/simple_animal/hostile/blobspore/New(loc, var/obj/effect/blob/factory/linked_node)
+	if(istype(linked_node))
+		factory = linked_node
+		factory.spores += src
+	..()
 
-	blob_act()
-		return
+/mob/living/simple_animal/hostile/blobspore/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
+	..()
+	adjustBruteLoss(Clamp(0.01 * exposed_temperature, 1, 5))
 
-	CanPass(atom/movable/mover, turf/target, height=1.5, air_group = 0)
-		if(istype(mover, /obj/effect/blob))
-			return 1
-		return ..()
+/mob/living/simple_animal/hostile/blobspore/blob_act()
+	return
 
-	New(loc, var/obj/effect/blob/factory/linked_node)
-		if(istype(linked_node))
-			factory = linked_node
-			factory.spores += src
-		..()
+/mob/living/simple_animal/hostile/blobspore/CanPass(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+	if(istype(mover, /obj/effect/blob))
+		return 1
+	return ..()
 
-	Die()
-		del(src)
+/mob/living/simple_animal/hostile/blobspore/Die()
+	var/sound = pick('sound/effects/gib1.ogg','sound/effects/gib2.ogg','sound/effects/gib3.ogg')
+	playsound(get_turf(src), sound, 50, 1)
+	qdel(src)
 
-	Destroy()
-		if(factory)
-			factory.spores -= src
-		..()
+/mob/living/simple_animal/hostile/blobspore/Destroy()
+	if(factory)
+		factory.spores -= src
+	..()

--- a/code/game/gamemodes/blob/blobs/node.dm
+++ b/code/game/gamemodes/blob/blobs/node.dm
@@ -7,30 +7,30 @@
 	custom_process=1
 
 
-	New(loc, var/h = 100)
-		blob_nodes += src
-		processing_objects.Add(src)
-		..(loc, h)
+/obj/effect/blob/node/New(loc, var/h = 100)
+	blob_nodes += src
+	processing_objects.Add(src)
+	..(loc, h)
 
-	fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
+/obj/effect/blob/node/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
+	return
+
+/obj/effect/blob/node/Destroy()
+	blob_nodes -= src
+	processing_objects.Remove(src)
+	..()
+
+/obj/effect/blob/node/Life()
+	for(var/i = 1; i < 8; i += i)
+		Pulse(5, i)
+	health = min(initial(health), health + 1)
+
+/obj/effect/blob/node/update_icon()
+	if(health <= 0)
+		playsound(get_turf(src), 'sound/effects/blobsplatspecial.ogg', 50, 1)
+		Delete()
 		return
+	return
 
-	Destroy()
-		blob_nodes -= src
-		processing_objects.Remove(src)
-		..()
-
-	Life()
-		for(var/i = 1; i < 8; i += i)
-			Pulse(5, i)
-		health = min(initial(health), health + 1)
-
-	update_icon()
-		if(health <= 0)
-			playsound(get_turf(src), 'sound/effects/blobsplatspecial.ogg', 50, 1)
-			Delete()
-			return
-		return
-
-	run_action()
-		return 0
+/obj/effect/blob/node/run_action()
+	return 0

--- a/code/game/gamemodes/blob/blobs/resource.dm
+++ b/code/game/gamemodes/blob/blobs/resource.dm
@@ -7,20 +7,19 @@
 	var/mob/camera/blob/overmind = null
 	var/resource_delay = 0
 
-	update_icon()
-		if(health <= 0)
-			playsound(get_turf(src), 'sound/effects/blobsplatspecial.ogg', 50, 1)
-			Delete()
-			return
+/obj/effect/blob/resource/update_icon()
+	if(health <= 0)
+		playsound(get_turf(src), 'sound/effects/blobsplatspecial.ogg', 50, 1)
+		qdel(src)
 		return
+	return
 
-	run_action()
-		if(resource_delay > world.time)
-			return 0
+/obj/effect/blob/resource/run_action()
+	if(resource_delay > world.time)
+		return 0
 
-		resource_delay = world.time + (4 SECONDS)
+	resource_delay = world.time + (4 SECONDS)
 
-		if(overmind)
-			overmind.add_points(1)
-		return 1
-
+	if(overmind)
+		overmind.add_points(1)
+	return 1

--- a/code/game/gamemodes/blob/blobs/shield.dm
+++ b/code/game/gamemodes/blob/blobs/shield.dm
@@ -7,16 +7,23 @@
 	fire_resist = 2
 
 
-	update_icon()
-		if(health <= 0)
-			playsound(get_turf(src), 'sound/effects/blobsplat.ogg', 50, 1)
-			Delete()
-			return
+/obj/effect/blob/shield/update_icon()
+	if(health <= 0)
+		playsound(get_turf(src), 'sound/effects/blobsplat.ogg', 50, 1)
+		qdel(src)
 		return
+	return
 
-	fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
-		return
+/obj/effect/blob/shield/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
+	return
 
-	CanPass(atom/movable/mover, turf/target, height=1.5, air_group = 0)
-		if(istype(mover) && mover.checkpass(PASSBLOB))	return 1
+/obj/effect/blob/shield/CanPass(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+	if(istype(mover) && mover.checkpass(PASSBLOB))	return 1
+	return 0
+
+/obj/effect/blob/shield/run_action()
+	if(health >= 50)
 		return 0
+
+	health += 10
+	return 1

--- a/code/game/gamemodes/blob/overmind.dm
+++ b/code/game/gamemodes/blob/overmind.dm
@@ -32,13 +32,14 @@
 	mind.active = 1		//indicates that the mind is currently synced with a client
 
 	src << "<span class='blob'>You are the overmind!</span>"
-	src << "You are the overmind and can control the blob! You can expand, which will attack people, and place new blob pieces such as..."
-	src << "<b>Normal Blob</b> will expand your reach and allow you to upgrade into special blobs that perform certain functions."
-	src << "<b>Shield Blob</b> is a strong and expensive blob which can take more damage. It is fireproof and can block air, use this to protect yourself from station fires."
+	src << "You are the overmind and can control the blob! You can expand, which will attack people, and place special blob types."
+	src << "The location of your thoughts (eye), nodes, and core can power your buildings and expand the blob much further, use them well!"
+	src << "<b>Normal Blobs</b> will expand your reach and can be upgraded into other special blobs that perform certain functions."
+	src << "<b>Shield Blob</b> is a strong and expensive blob which can take more damage. It is fireproof and can block air, use this to protect yourself from station fires. It can also begin to repair itself when powered."
 	src << "<b>Resource Blob</b> is a blob which will collect more resources for you, try to build these earlier to get a strong income. It will benefit from being near your core or multiple nodes, by having an increased resource rate; put it alone and it won't create resources at all."
-	src << "<b>Node Blob</b> is a blob which will grow, like the core. Unlike the core it won't give you a small income but it can power resource and factory blobs to increase their rate."
-	src << "<b>Factory Blob</b> is a blob which will spawn blob spores which will attack nearby food. Putting this nearby nodes and your core will increase the spawn rate; put it alone and it will not spawn any spores."
-	src << "<b>Shortcuts:</b> CTRL Click = Expand Blob / Middle Mouse Click = Rally Spores / Alt Click = Create Shield"
+	src << "<b>Node Blob</b> is a blob which will grow, like the core. It will not provide income, but will power all the other special nodes and expand your blob by itself."
+	src << "<b>Factory Blob</b> is a blob which will spawn blob spores which will attack nearby food. You must make sure it is powered to operate properly!"
+	src << "<b>Shortcuts:</b> CTRL Click = Expand Blob, Middle Mouse Click = Rally Spores, Alt Click = Create Shield, Double Click: Teleport to Blob"
 	update_health()
 
 /mob/camera/blob/proc/update_health()
@@ -100,6 +101,9 @@
 		if(blob_core)
 			stat(null, "Core Health: [blob_core.health]")
 		stat(null, "Power Stored: [blob_points]/[max_blob_points]")
+		stat(null, "Blob Total Size: [blobs.len]")
+		stat(null, "Total Nodes: [blob_nodes.len]")
+		stat(null, "Total Overminds: [blob_cores.len]")
 	return
 
 /mob/camera/blob/Move(var/NewLoc, var/Dir = 0)

--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -267,7 +267,7 @@
 			BS.LoseTarget()
 			BS.Goto(pick(surrounding_turfs), BS.move_to_delay)
 	return
-	
+
 /mob/camera/blob/verb/telepathy(message as text)
 	set category = "Blob"
 	set name = "Psionic Message (15)"

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -7,7 +7,7 @@
 	density = 0
 	opacity = 0
 	anchored = 1
-	var/health = 30
+	var/health = 20
 	var/health_timestamp = 0
 	var/brute_resist = 4
 	var/fire_resist = 1
@@ -19,6 +19,10 @@
 
 /obj/effect/blob/New(loc)
 	blobs += src
+	var/datum/game_mode/blob/B
+	if(B)
+		if((blobs.len >= B.blobnukeposs) && prob(1))
+			B.stage(2)
 	src.dir = pick(1, 2, 4, 8)
 	src.update_icon()
 	..(loc)

--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -16,7 +16,7 @@
 		bang(get_turf(M), M)
 
 	for(var/obj/effect/blob/B in get_hear(8,flashbang_turf))     		//Blob damage here
-		var/damage = round(30/(get_dist(B,get_turf(src))+1))
+		var/damage = round(15/(get_dist(B,get_turf(src))+1))
 		B.health -= damage
 		B.update_icon()
 	qdel(src)

--- a/html/changelogs/Clusterfack_2725.yml
+++ b/html/changelogs/Clusterfack_2725.yml
@@ -1,0 +1,12 @@
+author: Clusterfack
+delete-after: true
+changes:
+- experiment: All changes are prone to further balance tweaking in the future
+- rscadd: Nuke has a chance at being allowed once the blob comes very close to victory
+- tweak: Normal blob health reduced by 1/3rd, Blobling's health reduced by 1/4th
+- tweak: Factory blobs produce bloblings 4x slower and can only support two maximum at once
+- tweak: When a factory blob dies the bloblings it is supporting die as well
+- rscadd: The Blob Overmind's 'Thoughts' (your camera location) now acts as a node, expanding and powering nearby blobs in a pinch
+- rscadd: Overminds can double click on blobs to teleport to that location
+- rscadd: Shield blobs have been buffed to be able to regenerate up to 2/3rd of their total health when powered
+- tweak: Flashbang damage versus blobs has been halved


### PR DESCRIPTION
All changes are prone to further balance tweaking in the future

Current observations about blob that led to these changes:
-Blob barely ever 'expands', it is always just a big circle with a bunch of straight lines towards the people.
-Current blob metagame is just to make a shitload of factory blobs, then rally spores to victory because bloblings respawn extremely quickly
-Blob is extremely weak early game and powerful late game

Therefore these are my suggested changes:
-Nuke has a chance at being allowed once the blob comes very close to victory
-Normal blob health reduced by 1/3rd, Blobling's health reduced by 1/4th
-Factory blobs produce bloblings 4x slower and can only support two maximum at once
-When a factory blob dies the bloblings it is supporting die as well
-The Blob Overmind's 'Thoughts' (your camera location) now acts as a node, expanding and powering nearby blobs in a pinch
-Overminds can double click on blobs to teleport to that location
-Shield blobs have been buffed to be able to regenerate up to 2/3rd of their total health when powered
-Blob announcement is now delayed a bit
-Flashbang damage versus blobs is halved


Future ideas to help balance the blob:
-Variable special building costs depending on number of buildings created already
-Integrating goofball's new blob types
-Returning blob to the random event rotation