### PR TITLE
Bugfixes

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -464,7 +464,7 @@
 			usr << "There is no coin in this machine."
 			return
 
-		coin.loc = src.loc
+		coin.loc = get_turf(src)
 		if(!usr.get_active_hand())
 			usr.put_in_hands(coin)
 		usr << "\blue You remove the [coin] from the [src]"

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -166,18 +166,17 @@
 	var/list/icons = usr.hud_used.adding + usr.hud_used.other +usr.hud_used.hotkeybuttons
 	icons.Add(usr.zone_sel)
 
-	for(var/obj/screen/I in icons)
-		if(I.color && I.alpha)
-			I.icon = ui_style2icon(UI_style_new)
-			I.color = UI_style_color_new
-			I.alpha = UI_style_alpha_new
-
 	if(alert("Like it? Save changes?",,"Yes", "No") == "Yes")
 		prefs.UI_style = UI_style_new
 		prefs.UI_style_alpha = UI_style_alpha_new
 		prefs.UI_style_color = UI_style_color_new
 		prefs.save_preferences_sqlite(src, ckey)
 		usr << "UI was saved"
+		for(var/obj/screen/I in icons)
+			if(I.color && I.alpha)
+				I.icon = ui_style2icon(UI_style_new)
+				I.color = UI_style_color_new
+				I.alpha = UI_style_alpha_new
 
 /client/verb/toggle_media()
 	set name = "Hear/Silence Streaming"

--- a/code/modules/mining/money_bag.dm
+++ b/code/modules/mining/money_bag.dm
@@ -56,7 +56,9 @@
 		var/obj/item/weapon/coin/COIN=locate(typepath, src.contents)
 		if(!COIN)
 			return
-		COIN.loc = src.loc
+		COIN.loc = get_turf(src)
+		if(!usr.get_active_hand())
+			usr.put_in_hands(COIN)
 	return
 
 /obj/item/weapon/moneybag/MouseDrop(obj/over_object as obj)

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -153,12 +153,6 @@
 				M.show_message("\red [user] gently taps [src] with [O]. ")
 
 
-/mob/living/simple_animal/construct/airflow_stun()
-	return
-
-/mob/living/simple_animal/construct/airflow_hit(atom/A)
-	return
-
 /////////////////Juggernaut///////////////
 
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -89,6 +89,12 @@
 /mob/living/simple_animal/updatehealth()
 	return
 
+/mob/living/simple_animal/airflow_stun()
+	return
+
+/mob/living/simple_animal/airflow_hit(atom/A)
+	return
+
 /mob/living/simple_animal/Life()
 
 	//Health


### PR DESCRIPTION
Fixes #2512, by extending construct immunity to make simple animals immune to ZAS stun. 
Fixes #2634, fixes removing coins from money bags with your hand.
Fixes #2209, fixes resetting UI to new style before asking if player wants to save it