### PR TITLE
Spawned Bombs Nerf

### DIFF
--- a/code/game/objects/effects/spawners/bombspawner.dm
+++ b/code/game/objects/effects/spawners/bombspawner.dm
@@ -137,12 +137,11 @@
 	OT.master = V
 
 	PT.air_contents.temperature = PLASMA_FLASHPOINT
-	PT.air_contents.toxins = 15
-	PT.air_contents.carbon_dioxide = 33
+	PT.air_contents.toxins = 16
 	PT.air_contents.update_values()
 
 	OT.air_contents.temperature = PLASMA_FLASHPOINT
-	OT.air_contents.oxygen = 48
+	OT.air_contents.oxygen = 16
 	OT.air_contents.update_values()
 
 	var/obj/item/device/assembly/S

--- a/html/changelogs/Clusterfack_2804.yml
+++ b/html/changelogs/Clusterfack_2804.yml
@@ -1,0 +1,4 @@
+author: Clusterfack
+delete-after: true
+changes:
+- tweak: Spawned bombs such as those from cuban pete, nukes ops shuttle, and syndie uplink are nerfed down to the strenght allowed by the lowest bombcap: 3/7/14.


### PR DESCRIPTION
This lowers the explosion strength of bombs spawned from things such as cuban pete, syndicate uplinks, and the nuclear operative shuttle to 3/7/14. This is done in consideration of the fact on an increased bombcap absolutely destroys the station, and the fact destruction from such bombs significantly higher on a higher bombcap.

The current strength of these bombs is around devastation 8, which on higher bombcaps absolutely destroys the station.

Fixes #2413 