### PR TITLE
Nukedisk fixes

### DIFF
--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -78,6 +78,10 @@
 				return
 
 			var/list/disk_search = A.search_contents_for(/obj/item/weapon/disk/nuclear)
+			if(istype(A, /obj/structure/stool/bed/chair/vehicle))
+				var/obj/structure/stool/bed/chair/vehicle/B = A
+				if(B.buckled_mob)
+					disk_search = B.buckled_mob.search_contents_for(/obj/item/weapon/disk/nuclear)
 			if(!isemptylist(disk_search))
 				if(istype(A, /mob/living))
 					var/mob/living/MM = A

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -136,12 +136,17 @@ proc/move_mining_shuttle()
 			if(ticker.mode:declared)
 				usr << "Under directive 7-10, [station_name()] is quarantined until further notice."
 				return
-
+		var/area/A = locate(/area/shuttle/mining/station)
+		if(!mining_shuttle_location)
+			var/list/search = A.search_contents_for(/obj/item/weapon/disk/nuclear)
+			if(!isemptylist(search))
+				usr << "<span class='notice'>The nuclear disk is too precious for Nanotrasen to send it to an Asteroid.</span>"
+				return
 		if (!mining_shuttle_moving)
-			usr << "\blue Shuttle recieved message and will be sent shortly."
+			usr << "<span class='notice'>Shuttle recieved message and will be sent shortly.</span>"
 			move_mining_shuttle()
 		else
-			usr << "\blue Shuttle is already moving."
+			usr << "<span class='notice'>Shuttle is already moving.</span>"
 
 /obj/machinery/computer/mining_shuttle/attackby(obj/item/weapon/W as obj, mob/user as mob)
 
@@ -161,12 +166,12 @@ proc/move_mining_shuttle()
 			A.anchored = 1
 
 			if (src.stat & BROKEN)
-				user << "\blue The broken glass falls out."
+				user << "<span class='notice'>The broken glass falls out.</span>"
 				getFromPool(/obj/item/weapon/shard, loc)
 				A.state = 3
 				A.icon_state = "3"
 			else
-				user << "\blue You disconnect the monitor."
+				user << "<span class='notice'>You disconnect the monitor.</span>"
 				A.state = 4
 				A.icon_state = "4"
 

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -58,6 +58,10 @@ proc/move_mining_shuttle()
 		else
 			fromArea = locate(/area/shuttle/mining/station)
 			toArea = locate(/area/shuttle/mining/outpost)
+			var/list/search = fromArea.search_contents_for(/obj/item/weapon/disk/nuclear)
+			if(!isemptylist(search))
+				mining_shuttle_moving = 0
+				return
 
 		var/list/dstturfs = list()
 		var/throwy = world.maxy
@@ -114,9 +118,8 @@ proc/move_mining_shuttle()
 	icon_state = "shuttle"
 	req_access = list(access_mining)
 	circuit = "/obj/item/weapon/circuitboard/mining_shuttle"
-	var/hacked = 0
 	var/location = 0 //0 = station, 1 = mining base
-
+	machine_flags = EMAGGABLE | SCREWTOGGLE
 	l_color = "#7BF9FF"
 
 /obj/machinery/computer/mining_shuttle/attack_hand(user as mob)
@@ -131,6 +134,9 @@ proc/move_mining_shuttle()
 		return
 	usr.set_machine(src)
 	src.add_fingerprint(usr)
+	if(!src.allowed(usr))
+		usr << "<span class='warning'>Unauthorized Access.</span>"
+		return
 	if(href_list["move"])
 		if(ticker.mode.name == "blob")
 			if(ticker.mode:declared)
@@ -148,34 +154,10 @@ proc/move_mining_shuttle()
 		else
 			usr << "<span class='notice'>Shuttle is already moving.</span>"
 
-/obj/machinery/computer/mining_shuttle/attackby(obj/item/weapon/W as obj, mob/user as mob)
-
-	if (istype(W, /obj/item/weapon/card/emag))
-		src.req_access = list()
-		hacked = 1
-		usr << "You disable the console's access requirement."
-
-	else if(istype(W, /obj/item/weapon/screwdriver))
-		playsound(get_turf(src), 'sound/items/Screwdriver.ogg', 50, 1)
-		if(do_after(user, 20))
-			var/obj/structure/computerframe/A = new /obj/structure/computerframe(src.loc)
-			var/obj/item/weapon/circuitboard/mining_shuttle/M = new /obj/item/weapon/circuitboard/mining_shuttle(A)
-			for (var/obj/C in src)
-				C.loc = src.loc
-			A.circuit = M
-			A.anchored = 1
-
-			if (src.stat & BROKEN)
-				user << "<span class='notice'>The broken glass falls out.</span>"
-				getFromPool(/obj/item/weapon/shard, loc)
-				A.state = 3
-				A.icon_state = "3"
-			else
-				user << "<span class='notice'>You disconnect the monitor.</span>"
-				A.state = 4
-				A.icon_state = "4"
-
-			del(src)
+/obj/machinery/computer/mining_shuttle/emag(mob/user as mob)
+	..()
+	src.req_access = list()
+	usr << "You disable the console's access requirement."
 
 /******************************Lantern*******************************/
 

--- a/code/modules/research/research_shuttle.dm
+++ b/code/modules/research/research_shuttle.dm
@@ -97,12 +97,17 @@ proc/move_research_shuttle()
 			if(ticker.mode:declared)
 				usr << "Under directive 7-10, [station_name()] is quarantined until further notice."
 				return
-
+		var/area/A = locate(/area/shuttle/research/station)
+		if(!research_shuttle_location)
+			var/list/search = A.search_contents_for(/obj/item/weapon/disk/nuclear)
+			if(!isemptylist(search))
+				usr << "<span class='notice'>The nuclear disk is too precious for Nanotrasen to send it to an Asteroid.</span>"
+				return
 		if (!research_shuttle_moving)
-			usr << "\blue Shuttle recieved message and will be sent shortly."
+			usr << "<span class='notice'>Shuttle recieved message and will be sent shortly.</span>"
 			move_research_shuttle()
 		else
-			usr << "\blue Shuttle is already moving."
+			usr << "<span class='notice'>Shuttle is already moving.</span>"
 
 /obj/machinery/computer/research_shuttle/attackby(obj/item/weapon/W as obj, mob/user as mob)
 
@@ -122,12 +127,12 @@ proc/move_research_shuttle()
 			A.anchored = 1
 
 			if (src.stat & BROKEN)
-				user << "\blue The broken glass falls out."
+				user << "<span class='notice'>The broken glass falls out.</span>"
 				getFromPool(/obj/item/weapon/shard, loc)
 				A.state = 3
 				A.icon_state = "3"
 			else
-				user << "\blue You disconnect the monitor."
+				user << "<span class='notice'>You disconnect the monitor.</span>"
 				A.state = 4
 				A.icon_state = "4"
 

--- a/html/changelogs/Clusterfack_2826.yml
+++ b/html/changelogs/Clusterfack_2826.yml
@@ -2,3 +2,4 @@ author: Clusterfack
 delete-after: true
 changes:
 - bugfix: The nuke disk can no longer be taken off the station using vehicles or mining/research shuttles
+- bugfix: The shuttles now require access as originally intended

--- a/html/changelogs/Clusterfack_2826.yml
+++ b/html/changelogs/Clusterfack_2826.yml
@@ -1,0 +1,4 @@
+author: Clusterfack
+delete-after: true
+changes:
+- bugfix: The nuke disk can no longer be taken off the station using vehicles or mining/research shuttles


### PR DESCRIPTION
Fixes #2631, the nuke disk can no longer be taken off by either shuttle to the asteroid
Fixes #1675, people riding vehicles can no longer take the nukedisc off the zlevel with them