### PR TITLE
Bugfixes

### DIFF
--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -10,6 +10,7 @@
 	idle_power_usage = 5
 	active_power_usage = 100
 	flags = OPENCONTAINER | NOREACT
+	pass_flags = PASSTABLE
 	var/operating = 0 // Is it on?
 	var/opened = 0.0
 	var/dirty = 0 // = {0..100} Does it need cleaning?

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -79,8 +79,8 @@
 		icon_state = "brokenpack"
 
 /obj/item/weapon/storage/backpack/holding/singularity_act(current_size)
-//	var/dist = max((current_size - 2), 1)
-//	explosion(src.loc,(dist),(dist*2),(dist*4))
+	var/dist = max((current_size - 2), 1)
+	explosion(src.loc,(dist),(dist*2),(dist*4))
 	return
 
 

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -752,6 +752,7 @@
 	throwforce = 5.0
 	throw_speed = 3
 	throw_range = 5
+	w_class = 1
 	item_state = "beer"
 	attack_verb = list("stabbed", "slashed", "attacked")
 	var/icon/broken_outline = icon('icons/obj/drinks.dmi', "broken")

--- a/html/changelogs/Clusterfack_2830.yml
+++ b/html/changelogs/Clusterfack_2830.yml
@@ -1,0 +1,6 @@
+author: Clusterfack
+delete-after: true
+changes:
+- bugfix: Bag of holdings now explode upon collision with a singularity again
+- tweak: Broken bottles have had their size changed and now fit in trash bags
+- rscadd: Microwaves can be moved onto tables now


### PR DESCRIPTION
Fixes #2796, reduces broken bottle size to the same size as bottles
Also gives microwaves the PASSTABLE flags since it is designed to be placed on top of tables.
Fixes #2814, bag of holdings will now properly explode upon a singularity act, a recent TG port commented out the function