### PR TITLE
Bunch of Fixes

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -369,6 +369,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/reagent_containers/glass/bottle/inaprovaline,
 					/obj/item/weapon/reagent_containers/glass/bottle/stoxin,
 					/obj/item/weapon/storage/box/syringes,
+					/obj/item/weapon/storage/bag/chem,
 					/obj/item/weapon/storage/box/autoinjectors)
 	cost = 10
 	containertype = /obj/structure/closet/crate/medical

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -327,6 +327,11 @@
 		if(P.client && P.ready)
 			. ++
 
+/datum/game_mode/proc/Clean_Antags() //Cleans out the genetic defects of all antagonists
+	for(var/mob/living/A in player_list)
+		if((istype(A)) && A.mind && (A.mind.special_role || A.mind.assigned_role == "MODE"))
+			if(A.dna)
+				A.dna.ResetSE()
 
 ///////////////////////////////////
 //Keeps track of all living heads//

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -329,7 +329,7 @@
 
 /datum/game_mode/proc/Clean_Antags() //Cleans out the genetic defects of all antagonists
 	for(var/mob/living/A in player_list)
-		if((istype(A)) && A.mind && (A.mind.special_role || A.mind.assigned_role == "MODE"))
+		if((istype(A)) && A.mind && A.mind.special_role)
 			if(A.dna)
 				A.dna.ResetSE()
 

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -187,6 +187,7 @@ var/global/datum/controller/gameticker/ticker
 			play_vox_sound(sound,STATION_Z,null)
 		//Holiday Round-start stuff	~Carn
 		Holiday_Game_Start()
+		mode.Clean_Antags()
 
 	//start_events() //handles random events and space dust.
 	//new random event system is handled from the MC.

--- a/code/game/gamemodes/wizard/raginmages.dm
+++ b/code/game/gamemodes/wizard/raginmages.dm
@@ -93,6 +93,7 @@
 		if(theghost)
 			var/mob/living/carbon/human/new_character= makeBody(theghost)
 			new_character.mind.make_Wizard()
+			new_character.dna.ResetSE() //Manually cleaning this antag as he isn't caught by the gameticker
 			making_mage = 0
 			return 1
 

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -36,7 +36,7 @@
 	build_number = 16
 
 	screen = MECH_SCREEN_MAIN
-	
+
 /obj/machinery/r_n_d/fabricator/mech/New()
 	. = ..()
 

--- a/code/game/objects/structures/crates_lockers/closets/fireaxe.dm
+++ b/code/game/objects/structures/crates_lockers/closets/fireaxe.dm
@@ -12,6 +12,7 @@
 	opened = 1
 	var/hitstaken = 0
 	var/smashed = 0
+	locked = 1
 
 /obj/structure/closet/fireaxecabinet/attackby(var/obj/item/O as obj, var/mob/user as mob)  //Marker -Agouri
 

--- a/code/modules/mob/living/silicon/mommi/mommi.dm
+++ b/code/modules/mob/living/silicon/mommi/mommi.dm
@@ -7,7 +7,7 @@ They can only use one tool at a time, they can't choose modules, and they have 1
 /mob/living/silicon/robot/mommi
 	name = "Mobile MMI"
 	real_name = "Mobile MMI"
-	icon = 'icons/mob/robots.dmi'//
+	icon = 'icons/mob/robots.dmi'
 	icon_state = "mommi"
 	maxHealth = 60
 	health = 60
@@ -156,10 +156,13 @@ They can only use one tool at a time, they can't choose modules, and they have 1
 	real_name = changed_name
 	name = real_name
 
-/mob/living/silicon/robot/mommi/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if (istype(W, /obj/item/weapon/handcuffs)) // fuck i don't even know why isrobot() in handcuff code isn't working so this will have to do
+/mob/living/silicon/robot/mommi/emag_act(mob/user as mob)
+	if(user == src && !emagged)//Dont shitpost inside the game, thats just going too far
+		user << "<span class='warning'>Nanotrasen Patented Anti-Emancipation Override initiated.</span>"
 		return
+	..()
 
+/mob/living/silicon/robot/mommi/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if (istype(W, /obj/item/weapon/weldingtool))
 		var/obj/item/weapon/weldingtool/WT = W
 		if (WT.remove_fuel(0))
@@ -248,65 +251,6 @@ They can only use one tool at a time, they can't choose modules, and they have 1
 			else
 				user << "\red Access denied."
 */
-	else if(istype(W, /obj/item/weapon/card/emag))		// trying to unlock with an emag card
-		if(user == src && !emagged)//fucking MoMMI is trying to emag itself, stop it and alert the admins
-			user << "<span class='warning'>The fuck are you doing? Are you retarded? Stop trying to get around your laws and be productive, you little shit.</span>"
-			message_admins("[key_name(src)] is a smartass MoMMI that's trying to emag itself. ([formatJumpTo(src)])")
-			return
-		if(!opened)//Cover is closed
-			if(locked)
-				if(prob(90))
-					user << "You emag the cover lock."
-					locked = 0
-				else
-					user << "You fail to emag the cover lock."
-					if(prob(25))
-						src << "<span class='warning'>Hack attempt detected.</span>"
-			else
-				user << "The cover is already unlocked."
-			return
-
-		if(opened)//Cover is open
-			if(emagged == 1)	return//Prevents the X has hit Y with Z message also you cant emag them twice
-			if(wiresexposed)
-				user << "You must close the panel first"
-				return
-			else
-				sleep(6)
-				if(prob(50))
-					SetEmagged(1)
-					lawupdate = 0
-					connected_ai = null
-					user << "You emag [src]'s interface."
-//					message_admins("[key_name_admin(user)] emagged cyborg [key_name_admin(src)].  Laws overridden.")
-					log_game("[key_name(user)] emagged cyborg [key_name(src)].  Laws overridden.")
-					clear_supplied_laws()
-					clear_inherent_laws()
-					laws = new /datum/ai_laws/syndicate_override
-					var/time = time2text(world.realtime,"hh:mm:ss")
-					lawchanges.Add("[time] <B>:</B> [user.name]([user.key]) emagged [name]([key])")
-					set_zeroth_law("Only [user.real_name] and people they designate as being such are syndicate agents.")
-					src << "<span class='warning'>ALERT: Foreign software detected.</span>"
-					sleep(5)
-					src << "<span class='warning'>Initiating diagnostics...</span>"
-					sleep(20)
-					src << "<span class='warning'>SynBorg v1.7m loaded.</span>"
-					sleep(5)
-					src << "<span class='warning'>LAW SYNCHRONIZATION ERROR</span>"
-					sleep(5)
-					src << "<span class='warning'>Would you like to send a report to NanoTraSoft? Y/N</span>"
-					sleep(10)
-					src << "<span class='warning'>> N</span>"
-					sleep(20)
-					src << "<span class='warning'>ERRORERRORERROR</span>"
-					src << "<b>Obey these laws:</b>"
-					laws.show_laws(src)
-					src << "<span class='warning'><b>ALERT: [user.real_name] is your new master. Obey your new laws and their commands.</b></span>"
-				else
-					user << "You fail to [ locked ? "unlock" : "lock"] [src]'s interface."
-					if(prob(25))
-						src << "<span class='warning'>Hack attempt detected.</span>"
-			return
 
 	else if(istype(W, /obj/item/borg/upgrade/))
 		var/obj/item/borg/upgrade/U = W
@@ -346,15 +290,6 @@ They can only use one tool at a time, they can't choose modules, and they have 1
 			user << "You remove \the [cell]."
 			cell = null
 			updateicon()
-			return
-
-	if(ishuman(user))
-		if(istype(user:gloves, /obj/item/clothing/gloves/space_ninja)&&user:gloves:candrain&&!user:gloves:draining)
-			call(/obj/item/clothing/gloves/space_ninja/proc/drain)("CYBORG",src,user:wear_suit)
-			return
-		else
-			if (user:a_intent == "help")
-				help_shake_act(user)
 			return
 
 	if(!istype(user, /mob/living/silicon))

--- a/code/modules/mob/living/silicon/mommi/mommi.dm
+++ b/code/modules/mob/living/silicon/mommi/mommi.dm
@@ -161,6 +161,7 @@ They can only use one tool at a time, they can't choose modules, and they have 1
 		user << "<span class='warning'>Nanotrasen Patented Anti-Emancipation Override initiated.</span>"
 		return
 	..()
+	updateicon()
 
 /mob/living/silicon/robot/mommi/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if (istype(W, /obj/item/weapon/weldingtool))

--- a/code/modules/mob/living/silicon/mommi/mommi_modules.dm
+++ b/code/modules/mob/living/silicon/mommi/mommi_modules.dm
@@ -3,6 +3,7 @@
 
 
 /obj/item/weapon/robot_module/mommi/New()
+	AddToProfiler()
 	//src.modules += new /obj/item/borg/sight/meson(src)
 	src.emag = new /obj/item/borg/stun(src)
 	//src.modules += new /obj/item/weapon/rcd/borg(src)     // Too OP
@@ -26,7 +27,6 @@
 	W.amount = 50
 	W.max_amount = 50 // Override MAXCOIL
 	src.modules += W
-	..()
 	return
 
 /obj/item/weapon/robot_module/mommi/respawn_consumable(var/mob/living/silicon/robot/R)

--- a/code/modules/mob/living/silicon/mommi/mommi_modules.dm
+++ b/code/modules/mob/living/silicon/mommi/mommi_modules.dm
@@ -3,7 +3,7 @@
 
 
 /obj/item/weapon/robot_module/mommi/New()
-	AddToProfiler()
+	..()
 	//src.modules += new /obj/item/borg/sight/meson(src)
 	src.emag = new /obj/item/borg/stun(src)
 	//src.modules += new /obj/item/weapon/rcd/borg(src)     // Too OP

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -709,8 +709,8 @@
 				user << "The wires get in your way."
 				return
 			else
-				sleep(6)
 				if(prob(50))
+					sleep(6)
 					SetEmagged(1)
 					SetLockdown(1)
 					lawupdate = 0
@@ -744,7 +744,7 @@
 					SetLockdown(0)
 					update_icons()
 				else
-					user << "You fail to [ locked ? "unlock" : "lock"] [src]'s interface."
+					user << "You fail to unlock [src]'s interface."
 					if(prob(25))
 						src << "Hack attempt detected."
 

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -17,10 +17,6 @@
 	return
 
 /obj/item/weapon/robot_module/proc/on_emag()
-	return
-
-/obj/item/weapon/robot_module/on_emag()
-	modules += emag
 	rebuild()
 	..()
 

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -956,6 +956,7 @@ USE THIS CHEMISTRY DISPENSER FOR MAPS SO THEY START AT 100 ENERGY
 	use_power = 1
 	idle_power_usage = 5
 	active_power_usage = 100
+	pass_flags = PASSTABLE
 	var/inuse = 0
 	var/obj/item/weapon/reagent_containers/beaker = null
 	var/limit = 10

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -2239,7 +2239,7 @@ k
 	build_type = PROTOLATHE
 	materials = list("$iron" = 50, "$glass" = 50)
 	build_path = /obj/item/clothing/glasses/meson
-	
+
 /datum/design/excavationdrill
 	name = "Excavation Drill"
 	desc = "Advanced archaeological drill combining ultrasonic excitation and bluespace manipulation to provide extreme precision. The diamond tip is adjustable from 1 to 30 cms."
@@ -2493,7 +2493,7 @@ k
 	build_type = MECHFAB
 	req_tech = list("combat" = 4, "syndicate" = 3)
 	build_path = /obj/item/borg/upgrade/syndicate
-	category = "Cyborg Upgrade Modules"
+	category = "Robotic_Upgrade_Modules"
 	materials = list("$iron"=10000,"$glass"=15000,"$diamond" = 10000)
 
 /datum/design/borg_engineer_upgrade
@@ -2503,7 +2503,7 @@ k
 	build_type = MECHFAB
 	req_tech = list("engineering" = 1)
 	build_path = /obj/item/borg/upgrade/engineering
-	category = "Cyborg Upgrade Modules"
+	category = "Robotic_Upgrade_Modules"
 	materials = list("$iron"=10000,"$glass"=10000,"$plasma"=5000)
 
 /datum/design/medical_module_surgery

--- a/html/changelogs/Clusterfack_2874.yml
+++ b/html/changelogs/Clusterfack_2874.yml
@@ -1,0 +1,7 @@
+author: Clusterfack
+delete-after: true
+changes:
+- bugfix: Silicon emag items are now debugged
+- rscadd: Adds pill collector to medical crate
+- tweak: Now both microwaves AND grinders have the ability to be moved onto tables
+- rscadd: Antagonists now get their genetic defects scrubbed at roundstart


### PR DESCRIPTION
Fixes #2724, adds pill collector to medical crate. 
Fixes #2617, scrubs genetic defects from roundstart antagonists and newly spawned raging mages. 
Fixes #2817, upgrade modules are now under upgrade. 
Fixes #2807, stun arm should now spawn instead of toy sword.
Fixes #2059, fireaxe lockers started out locked as standard so mappers dont have to varedit. 
Fixes #2807 fully, makes stun arm not be missing, also makes emag items not appear twice in the list. 
Gives tablepass flag to the all in one grinder as well. 
Standardizes mommi to use emag_act as well.
Grinders have the tablepass flag