### PR TITLE
Hotfix for floor plating

### DIFF
--- a/code/game/turfs/simulated/floor_types.dm
+++ b/code/game/turfs/simulated/floor_types.dm
@@ -137,8 +137,14 @@
 /turf/simulated/floor/plating
 	name = "plating"
 	icon_state = "plating"
-	floor_tile = null
 	intact = 0
+
+/turf/simulated/floor/plating/New()
+	..()
+	if(floor_tile)
+		returnToPool(floor_tile)
+		floor_tile = null
+
 
 /turf/simulated/floor/plating/airless
 	icon_state = "plating"


### PR DESCRIPTION
Plating's start with floor tiles. This returns them to the pool and set's their reference to null.

This is problematic for the reasons
-crowbaring up tiles from platings without tiles
-being unable to place wires on plating until you crowbar up the tile