### PR TITLE
Narsie Optimizations + Power Failure Fix

### DIFF
--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -120,6 +120,11 @@ Pipelines + Other Objects -> Pipe network
 	error("[src] does not define a buildFrom!")
 	return FALSE
 
+/obj/machinery/atmospherics/cultify()
+	if(src.invisibility != INVISIBILITY_MAXIMUM)
+		src.invisibility = INVISIBILITY_MAXIMUM
+
+
 /obj/machinery/atmospherics/attackby(var/obj/item/W, mob/user)
 	if (!istype(W, /obj/item/weapon/wrench))
 		return ..()

--- a/code/ATMOSPHERICS/datum_pipeline.dm
+++ b/code/ATMOSPHERICS/datum_pipeline.dm
@@ -1,4 +1,4 @@
-datum/pipeline
+/datum/pipeline
 	var/datum/gas_mixture/air
 
 	var/list/obj/machinery/atmospherics/pipe/members
@@ -11,215 +11,215 @@ datum/pipeline
 
 	var/const/PRESSURE_CHECK_DELAY=5 // 5s delay between pchecks to give pipenets time to recover.
 
-	Del()
-		if(network)
-			del(network)
+/datum/pipeline/Del()
+	if(network)
+		del(network)
 
-		if(air && air.volume)
-			temporarily_store_air()
-			del(air)
+	if(air && air.volume)
+		temporarily_store_air()
+		del(air)
 
-		..()
+	..()
 
-	proc/process()//This use to be called called from the pipe networks
-		if((world.timeofday - last_pressure_check) / 10 >= PRESSURE_CHECK_DELAY)
-			//Check to see if pressure is within acceptable limits
-			var/pressure = air.return_pressure()
-			if(pressure > alert_pressure)
-				for(var/obj/machinery/atmospherics/pipe/member in members)
-					if(!member.check_pressure(pressure))
-						// Delay next update so we have a chance to recalculate.
-						last_pressure_check=world.timeofday
-						break //Only delete 1 pipe per process
+datum/pipeline/proc/process()//This use to be called called from the pipe networks
+	if((world.timeofday - last_pressure_check) / 10 >= PRESSURE_CHECK_DELAY)
+		//Check to see if pressure is within acceptable limits
+		var/pressure = air.return_pressure()
+		if(pressure > alert_pressure)
+			for(var/obj/machinery/atmospherics/pipe/member in members)
+				if(!member.check_pressure(pressure))
+					// Delay next update so we have a chance to recalculate.
+					last_pressure_check=world.timeofday
+					break //Only delete 1 pipe per process
 
 
-		//Allow for reactions
-		//air.react() //Should be handled by pipe_network now
+	//Allow for reactions
+	//air.react() //Should be handled by pipe_network now
 
-	proc/temporarily_store_air()
-		//Update individual gas_mixtures by volume ratio
+/datum/pipeline/proc/temporarily_store_air()
+	//Update individual gas_mixtures by volume ratio
 
-		for(var/obj/machinery/atmospherics/pipe/member in members)
-			member.air_temporary = new
-			member.air_temporary.volume = member.volume
+	for(var/obj/machinery/atmospherics/pipe/member in members)
+		member.air_temporary = new
+		member.air_temporary.volume = member.volume
 
-			member.air_temporary.oxygen = air.oxygen*member.volume/air.volume
-			member.air_temporary.nitrogen = air.nitrogen*member.volume/air.volume
-			member.air_temporary.toxins = air.toxins*member.volume/air.volume
-			member.air_temporary.carbon_dioxide = air.carbon_dioxide*member.volume/air.volume
+		member.air_temporary.oxygen = air.oxygen*member.volume/air.volume
+		member.air_temporary.nitrogen = air.nitrogen*member.volume/air.volume
+		member.air_temporary.toxins = air.toxins*member.volume/air.volume
+		member.air_temporary.carbon_dioxide = air.carbon_dioxide*member.volume/air.volume
 
-			member.air_temporary.temperature = air.temperature
+		member.air_temporary.temperature = air.temperature
 
-			if(air.trace_gases.len)
-				for(var/datum/gas/trace_gas in air.trace_gases)
-					var/datum/gas/corresponding = new trace_gas.type()
-					member.air_temporary.trace_gases += corresponding
+		if(air.trace_gases.len)
+			for(var/datum/gas/trace_gas in air.trace_gases)
+				var/datum/gas/corresponding = new trace_gas.type()
+				member.air_temporary.trace_gases += corresponding
 
-					corresponding.moles = trace_gas.moles*member.volume/air.volume
-			member.air_temporary.update_values()
+				corresponding.moles = trace_gas.moles*member.volume/air.volume
+		member.air_temporary.update_values()
 
-	proc/build_pipeline(obj/machinery/atmospherics/pipe/base)
+/datum/pipeline/proc/build_pipeline(obj/machinery/atmospherics/pipe/base)
+	air = new
+
+	var/list/possible_expansions = list(base)
+	members = list(base)
+	edges = list()
+
+	var/volume = base.volume
+	base.parent = src
+	alert_pressure = base.alert_pressure
+
+	if(base.air_temporary)
+		air = base.air_temporary
+		base.air_temporary = null
+	else
 		air = new
 
-		var/list/possible_expansions = list(base)
-		members = list(base)
-		edges = list()
+	while(possible_expansions.len>0)
+		for(var/obj/machinery/atmospherics/pipe/borderline in possible_expansions)
 
-		var/volume = base.volume
-		base.parent = src
-		alert_pressure = base.alert_pressure
+			var/list/result = borderline.pipeline_expansion()
+			var/edge_check = result.len
 
-		if(base.air_temporary)
-			air = base.air_temporary
-			base.air_temporary = null
-		else
-			air = new
+			if(result.len>0)
+				for(var/obj/machinery/atmospherics/pipe/item in result)
+					if(!members.Find(item))
+						members += item
+						possible_expansions += item
 
-		while(possible_expansions.len>0)
-			for(var/obj/machinery/atmospherics/pipe/borderline in possible_expansions)
+						volume += item.volume
+						item.parent = src
 
-				var/list/result = borderline.pipeline_expansion()
-				var/edge_check = result.len
+						alert_pressure = min(alert_pressure, item.alert_pressure)
 
-				if(result.len>0)
-					for(var/obj/machinery/atmospherics/pipe/item in result)
-						if(!members.Find(item))
-							members += item
-							possible_expansions += item
+						if(item.air_temporary)
+							air.merge(item.air_temporary)
 
-							volume += item.volume
-							item.parent = src
+					edge_check--
 
-							alert_pressure = min(alert_pressure, item.alert_pressure)
+			if(edge_check>0)
+				edges += borderline
 
-							if(item.air_temporary)
-								air.merge(item.air_temporary)
+			possible_expansions -= borderline
 
-						edge_check--
+	air.volume = volume
 
-				if(edge_check>0)
-					edges += borderline
+/datum/pipeline/proc/network_expand(datum/pipe_network/new_network, obj/machinery/atmospherics/pipe/reference)
 
-				possible_expansions -= borderline
+	if(new_network.line_members.Find(src))
+		return 0
 
-		air.volume = volume
+	new_network.line_members += src
 
-	proc/network_expand(datum/pipe_network/new_network, obj/machinery/atmospherics/pipe/reference)
+	network = new_network
 
-		if(new_network.line_members.Find(src))
-			return 0
+	for(var/obj/machinery/atmospherics/pipe/edge in edges)
+		for(var/obj/machinery/atmospherics/result in edge.pipeline_expansion())
+			if(!istype(result,/obj/machinery/atmospherics/pipe) && (result!=reference))
+				result.network_expand(new_network, edge)
 
-		new_network.line_members += src
+	return 1
 
-		network = new_network
+/datum/pipeline/proc/return_network(obj/machinery/atmospherics/reference)
+	if(!network)
+		network = new /datum/pipe_network()
+		network.build_network(src, null)
+			//technically passing these parameters should not be allowed
+			//however pipe_network.build_network(..) and pipeline.network_extend(...)
+			//		were setup to properly handle this case
 
-		for(var/obj/machinery/atmospherics/pipe/edge in edges)
-			for(var/obj/machinery/atmospherics/result in edge.pipeline_expansion())
-				if(!istype(result,/obj/machinery/atmospherics/pipe) && (result!=reference))
-					result.network_expand(new_network, edge)
+	return network
 
-		return 1
+/datum/pipeline/proc/mingle_with_turf(turf/simulated/target, mingle_volume)
+	var/datum/gas_mixture/air_sample = air.remove_ratio(mingle_volume/air.volume)
+	air_sample.volume = mingle_volume
 
-	proc/return_network(obj/machinery/atmospherics/reference)
-		if(!network)
-			network = new /datum/pipe_network()
-			network.build_network(src, null)
-				//technically passing these parameters should not be allowed
-				//however pipe_network.build_network(..) and pipeline.network_extend(...)
-				//		were setup to properly handle this case
+	if(istype(target) && target.zone && !iscatwalk(target))
+		//Have to consider preservation of group statuses
+		var/datum/gas_mixture/turf_copy = new
 
-		return network
+		turf_copy.copy_from(target.zone.air)
+		turf_copy.volume = target.zone.air.volume //Copy a good representation of the turf from parent group
 
-	proc/mingle_with_turf(turf/simulated/target, mingle_volume)
-		var/datum/gas_mixture/air_sample = air.remove_ratio(mingle_volume/air.volume)
-		air_sample.volume = mingle_volume
+		equalize_gases(list(air_sample, turf_copy))
+		air.merge(air_sample)
 
-		if(istype(target) && target.zone && !iscatwalk(target))
-			//Have to consider preservation of group statuses
-			var/datum/gas_mixture/turf_copy = new
+		turf_copy.subtract(target.zone.air)
 
-			turf_copy.copy_from(target.zone.air)
-			turf_copy.volume = target.zone.air.volume //Copy a good representation of the turf from parent group
+		target.zone.air.merge(turf_copy)
 
-			equalize_gases(list(air_sample, turf_copy))
-			air.merge(air_sample)
+	else
+		var/datum/gas_mixture/turf_air = target.return_air()
 
-			turf_copy.subtract(target.zone.air)
+		equalize_gases(list(air_sample, turf_air))
+		air.merge(air_sample)
+		//turf_air already modified by equalize_gases()
 
-			target.zone.air.merge(turf_copy)
+	/*
+	if(istype(target) && !target.processing && !iscatwalk(target))
+		if(target.air)
+			if(target.air.check_tile_graphic())
+				target.update_visuals(target.air)
+	*/
+	if(network)
+		network.update = 1
 
-		else
-			var/datum/gas_mixture/turf_air = target.return_air()
+/datum/pipeline/proc/temperature_interact(turf/target, share_volume, thermal_conductivity)
+	var/total_heat_capacity = air.heat_capacity()
+	var/partial_heat_capacity = total_heat_capacity*(share_volume/air.volume)
 
-			equalize_gases(list(air_sample, turf_air))
-			air.merge(air_sample)
-			//turf_air already modified by equalize_gases()
+	if(istype(target, /turf/simulated))
+		var/turf/simulated/modeled_location = target
 
-		/*
-		if(istype(target) && !target.processing && !iscatwalk(target))
-			if(target.air)
-				if(target.air.check_tile_graphic())
-					target.update_visuals(target.air)
-		*/
-		if(network)
-			network.update = 1
+		if(modeled_location.blocks_air)
 
-	proc/temperature_interact(turf/target, share_volume, thermal_conductivity)
-		var/total_heat_capacity = air.heat_capacity()
-		var/partial_heat_capacity = total_heat_capacity*(share_volume/air.volume)
-
-		if(istype(target, /turf/simulated))
-			var/turf/simulated/modeled_location = target
-
-			if(modeled_location.blocks_air)
-
-				if((modeled_location.heat_capacity>0) && (partial_heat_capacity>0))
-					var/delta_temperature = air.temperature - modeled_location.temperature
-
-					var/heat = thermal_conductivity*delta_temperature* \
-						(partial_heat_capacity*modeled_location.heat_capacity/(partial_heat_capacity+modeled_location.heat_capacity))
-
-					air.temperature -= heat/total_heat_capacity
-					modeled_location.temperature += heat/modeled_location.heat_capacity
-
-			else
-				var/delta_temperature = 0
-				var/sharer_heat_capacity = 0
-
-				if(modeled_location.zone)
-					delta_temperature = (air.temperature - modeled_location.zone.air.temperature)
-					sharer_heat_capacity = modeled_location.zone.air.heat_capacity()
-				else
-					delta_temperature = (air.temperature - modeled_location.air.temperature)
-					sharer_heat_capacity = modeled_location.air.heat_capacity()
-
-				var/self_temperature_delta = 0
-				var/sharer_temperature_delta = 0
-
-				if((sharer_heat_capacity>0) && (partial_heat_capacity>0))
-					var/heat = thermal_conductivity*delta_temperature* \
-						(partial_heat_capacity*sharer_heat_capacity/(partial_heat_capacity+sharer_heat_capacity))
-
-					self_temperature_delta = -heat/total_heat_capacity
-					sharer_temperature_delta = heat/sharer_heat_capacity
-				else
-					return 1
-
-				air.temperature += self_temperature_delta
-
-				if(modeled_location.zone)
-					modeled_location.zone.air.temperature += sharer_temperature_delta/modeled_location.zone.air.group_multiplier
-				else
-					modeled_location.air.temperature += sharer_temperature_delta
-
-
-		else
-			if((target.heat_capacity>0) && (partial_heat_capacity>0))
-				var/delta_temperature = air.temperature - target.temperature
+			if((modeled_location.heat_capacity>0) && (partial_heat_capacity>0))
+				var/delta_temperature = air.temperature - modeled_location.temperature
 
 				var/heat = thermal_conductivity*delta_temperature* \
-					(partial_heat_capacity*target.heat_capacity/(partial_heat_capacity+target.heat_capacity))
+					(partial_heat_capacity*modeled_location.heat_capacity/(partial_heat_capacity+modeled_location.heat_capacity))
 
 				air.temperature -= heat/total_heat_capacity
-		if(network)
-			network.update = 1
+				modeled_location.temperature += heat/modeled_location.heat_capacity
+
+		else
+			var/delta_temperature = 0
+			var/sharer_heat_capacity = 0
+
+			if(modeled_location.zone)
+				delta_temperature = (air.temperature - modeled_location.zone.air.temperature)
+				sharer_heat_capacity = modeled_location.zone.air.heat_capacity()
+			else
+				delta_temperature = (air.temperature - modeled_location.air.temperature)
+				sharer_heat_capacity = modeled_location.air.heat_capacity()
+
+			var/self_temperature_delta = 0
+			var/sharer_temperature_delta = 0
+
+			if((sharer_heat_capacity>0) && (partial_heat_capacity>0))
+				var/heat = thermal_conductivity*delta_temperature* \
+					(partial_heat_capacity*sharer_heat_capacity/(partial_heat_capacity+sharer_heat_capacity))
+
+				self_temperature_delta = -heat/total_heat_capacity
+				sharer_temperature_delta = heat/sharer_heat_capacity
+			else
+				return 1
+
+			air.temperature += self_temperature_delta
+
+			if(modeled_location.zone)
+				modeled_location.zone.air.temperature += sharer_temperature_delta/modeled_location.zone.air.group_multiplier
+			else
+				modeled_location.air.temperature += sharer_temperature_delta
+
+
+	else
+		if((target.heat_capacity>0) && (partial_heat_capacity>0))
+			var/delta_temperature = air.temperature - target.temperature
+
+			var/heat = thermal_conductivity*delta_temperature* \
+				(partial_heat_capacity*target.heat_capacity/(partial_heat_capacity+target.heat_capacity))
+
+			air.temperature -= heat/total_heat_capacity
+	if(network)
+		network.update = 1

--- a/code/controllers/shuttle_controller.dm
+++ b/code/controllers/shuttle_controller.dm
@@ -239,6 +239,8 @@ datum/shuttle_controller
 									AM.Move(D)
 								// Remove windows, grills, lattice, etc.
 								if(istype(A,/obj/structure) || istype(A,/obj/machinery))
+									if(istype(A,/obj/machinery/singularity))
+										continue
 									qdel(A)
 								// NOTE: Commenting this out to avoid recreating mass driver glitch
 								/*

--- a/code/game/gamemodes/cult/hell_universe.dm
+++ b/code/game/gamemodes/cult/hell_universe.dm
@@ -97,12 +97,9 @@ In short:
 
 		A.updateicon()
 
-<<<<<<< HEAD
-	/*for(var/turf/space/spess in world)
-=======
 /datum/universal_state/hell/proc/OverlaySet()
+/*
 	for(var/turf/space/spess in world)
->>>>>>> f2ca7d7... Narsie Fixes, Lag Fixes, Power Failure Fixes
 		spess.overlays += "hell01"
 	*/
 	var/image/I = image("icon" = 'icons/turf/space.dmi', "icon_state" = "hell01", "layer" = 10)
@@ -124,8 +121,7 @@ In short:
 		if (!(APC.stat & BROKEN) && !istype(APC.areaMaster,/area/turret_protected/ai))
 			APC.chargemode = 0
 			if(APC.cell)
-				qdel(APC.cell)
-				APC.cell = null
+				APC.cell.charge = 0
 				power_machines -= APC
 			APC.emagged = 1
 			APC.queue_icon_update()

--- a/code/game/gamemodes/cult/hell_universe.dm
+++ b/code/game/gamemodes/cult/hell_universe.dm
@@ -51,6 +51,20 @@ In short:
 
 	suspend_alert = 1
 
+	//Separated into separate procs for profiling
+	AreaSet()
+	OverlaySet()
+	MiscSet()
+	APCSet()
+	KillMobs()
+
+	runedec += 9000	//basically removing the rune cap
+
+	ticker.StartThematic("endgame")
+
+
+
+/datum/universal_state/hell/proc/AreaSet()
 	for(var/area/ca in world)
 		var/area/A=get_area_master(ca)
 		if(!istype(A,/area) || A.name=="Space")
@@ -83,7 +97,12 @@ In short:
 
 		A.updateicon()
 
+<<<<<<< HEAD
 	/*for(var/turf/space/spess in world)
+=======
+/datum/universal_state/hell/proc/OverlaySet()
+	for(var/turf/space/spess in world)
+>>>>>>> f2ca7d7... Narsie Fixes, Lag Fixes, Power Failure Fixes
 		spess.overlays += "hell01"
 	*/
 	var/image/I = image("icon" = 'icons/turf/space.dmi', "icon_state" = "hell01", "layer" = 10)
@@ -91,6 +110,7 @@ In short:
 	if(space.name == "Space")
 		space.overlays += I
 
+/datum/universal_state/hell/proc/MiscSet()
 	for(var/turf/simulated/floor/T in world)
 		if(!T.holy && prob(1))
 			new /obj/effect/gateway/active/cult(T)
@@ -99,8 +119,10 @@ In short:
 		if (!(alm.stat & BROKEN))
 			alm.ex_act(2)
 
+/datum/universal_state/hell/proc/APCSet()
 	for (var/obj/machinery/power/apc/APC in power_machines)
 		if (!(APC.stat & BROKEN) && !istype(APC.areaMaster,/area/turret_protected/ai))
+			APC.chargemode = 0
 			if(APC.cell)
 				qdel(APC.cell)
 				APC.cell = null
@@ -108,10 +130,7 @@ In short:
 			APC.emagged = 1
 			APC.queue_icon_update()
 
+/datum/universal_state/hell/proc/KillMobs()
 	for(var/mob/living/simple_animal/M in mob_list)
 		if(M && !M.client)
 			M.stat = DEAD
-
-	runedec += 9000	//basically removing the rune cap
-
-	ticker.StartThematic("endgame")

--- a/code/game/gamemodes/cult/trash_machinery.dm
+++ b/code/game/gamemodes/cult/trash_machinery.dm
@@ -20,9 +20,6 @@
 /obj/machinery/hologram/cultify()
 	qdel(src)
 
-/obj/machinery/atmospherics/cultify()
-	qdel(src)
-
 /obj/machinery/status_display/cultify()
 	qdel(src)
 

--- a/code/game/gamemodes/endgame/supermatter_cascade/universe.dm
+++ b/code/game/gamemodes/endgame/supermatter_cascade/universe.dm
@@ -81,6 +81,7 @@
 
 	for (var/obj/machinery/power/apc/APC in world)
 		if (!(APC.stat & BROKEN) && !APC.is_critical)
+			APC.chargemode = 0
 			if(APC.cell)
 				APC.cell.charge = 0
 			APC.emagged = 1

--- a/code/game/gamemodes/events/power_failure.dm
+++ b/code/game/gamemodes/events/power_failure.dm
@@ -38,14 +38,13 @@
 	for(var/obj/machinery/power/apc/C in power_machines)
 		if(C.cell && C.z == 1)
 			var/area/A = get_area(C)
-
 			var/skip = 0
 			for(var/area_type in skipped_areas)
 				if(istype(A,area_type))
 					skip = 1
 					break
 			if(skip) continue
-
+			C.chargemode = 0
 			C.cell.charge = 0
 
 /proc/power_restore(var/announce = 1)
@@ -57,6 +56,7 @@
 	for(var/obj/machinery/power/apc/C in power_machines)
 		if(C.cell && C.z == 1)
 			C.cell.charge = C.cell.maxcharge
+			C.chargemode = 1
 	for(var/obj/machinery/power/smes/S in power_machines)
 		if(S.z != 1)
 			continue

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -40,6 +40,7 @@
 				if(do_after(user,10))
 					user << "<span class='notice'>You unscrew the cover blocking the inner wiring of \the [src].</span>"
 					buildstage = 1
+					on = areaMaster.lightswitch
 			return
 		if(1)
 			if(isscrewdriver(W))

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -131,7 +131,6 @@
 			stat |= NOPOWER
 			src.islocked = 0
 			src.isopen = 1
-			src.dump_everything()
 			src.update_icon()
 
 
@@ -579,6 +578,11 @@
 	src.updateUsrDialog()
 
 /obj/machinery/suit_storage_unit/attackby(obj/item/I as obj, mob/user as mob)
+	if((stat & NOPOWER) && iscrowbar(I) && !islocked)
+		playsound(get_turf(src), 'sound/items/Deconstruct.ogg', 50, 1)
+		user << "<span class='notice'>You begin prying the equipment out of the suit storage unit</span>"
+		if(do_after(20))
+			dump_everything()
 	if(stat & NOPOWER)
 		return
 	if(..())

--- a/code/modules/media/jukebox.dm
+++ b/code/modules/media/jukebox.dm
@@ -480,7 +480,7 @@ var/global/loopModeNames=list(
 			return
 	if(playing)
 		var/datum/song_info/song
-		if(current_song)
+		if(current_song && playlist.len)
 			song = playlist[current_song]
 		if(!current_song || (song && world.time >= media_start_time + song.length))
 			current_song=1

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -150,12 +150,20 @@
 	if((N.z == src.z)&&(get_dist(N,src) <= (N.consume_range+10)))
 		if(!narsimage)
 			narsimage = image('icons/obj/narsie.dmi',src.loc,"narsie",9,1)
-		narsimage.pixel_x = 32 * (N.x - src.x) + N.pixel_x
-		narsimage.pixel_y = 32 * (N.y - src.y) + N.pixel_y
+		var/new_x = 32 * (N.x - src.x) + N.pixel_x
+		var/new_y = 32 * (N.y - src.y) + N.pixel_y
+		var/thing = abs(new_x+new_y-narsimage.pixel_x-narsimage.pixel_y)
+		world << "[thing]"
+		if((thing == 0) || (thing == 32) || (thing == 64)) //lel cant believe I coded this
+			animate(narsimage, pixel_x = new_x, pixel_y = new_y, time = 8)
+		narsimage.pixel_x = new_x
+		narsimage.pixel_y = new_y
 		narsimage.loc = src.loc
 		narsimage.mouse_opacity = 0
 		if(!narglow)
 			narglow = image('icons/obj/narsie.dmi',narsimage.loc,"glow-narsie",LIGHTING_LAYER+2,1)
+		if((thing == 0) || (thing == 32) || (thing == 64)) //lel cant believe I coded this
+			animate(narglow, pixel_x = narsimage.pixel_x, pixel_y = narsimage.pixel_y, time = 8)
 		narglow.pixel_x = narsimage.pixel_x
 		narglow.pixel_y = narsimage.pixel_y
 		narglow.loc = narsimage.loc
@@ -166,6 +174,7 @@
 		if(narsimage)
 			del(narsimage)
 			del(narglow)
+
 
 /mob/proc/get_item_by_slot(slot_id)
 	switch(slot_id)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -173,27 +173,27 @@
 			world << "[dir]"
 			switch(dir) //I bet somewhere out there a proc does something like this already
 				if(1)
-					x_diff = 32
+					x_diff = 1
 				if(2)
-					x_diff = -32
+					x_diff = -1
 				if(4)
-					y_diff = 32
+					y_diff = 1
 				if(8)
-					y_diff = -32
+					y_diff = -1
 				if(5)
-					x_diff = 32
-					y_diff = 32
+					x_diff = 1
+					y_diff = 1
 				if(6)
-					x_diff = 32
-					y_diff = -32
+					x_diff = 1
+					y_diff = -1
 				if(9)
-					x_diff = -32
-					y_diff = 32
+					x_diff = -1
+					y_diff = 1
 				if(10)
-					x_diff = -32
-					y_diff = -32
-			animate(narsimage, pixel_x = old_pixel_x+x_diff, pixel_y = old_pixel_y+y_diff, time = 8) //Animate the movement of narsie to narsie's new location
-			animate(narglow, pixel_x = old_pixel_x+x_diff, pixel_y = old_pixel_y+y_diff, time = 8)
+					x_diff = -1
+					y_diff = -1
+			animate(narsimage, x = x+x_diff, y = y+y_diff, time = 8) //Animate the movement of narsie to narsie's new location
+			animate(narglow, x = x+x_diff, y = y+y_diff, time = 8)
 		else
 			//Else if no dir is given, simply send them the image of narsie
 			var/new_x = 32 * (N.x - src.x) + N.pixel_x

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -141,33 +141,68 @@
 /mob/proc/Life()
 	return
 
-/mob/proc/see_narsie(var/obj/machinery/singularity/narsie/large/N)
+/mob/proc/see_narsie(var/obj/machinery/singularity/narsie/large/N, var/dir)
 	if(N.chained)
 		if(narsimage)
 			del(narsimage)
 			del(narglow)
 		return
 	if((N.z == src.z)&&(get_dist(N,src) <= (N.consume_range+10)))
-		if(!narsimage)
+		if(!narsimage) //Create narsimage
 			narsimage = image('icons/obj/narsie.dmi',src.loc,"narsie",9,1)
-		var/new_x = 32 * (N.x - src.x) + N.pixel_x
-		var/new_y = 32 * (N.y - src.y) + N.pixel_y
-		var/thing = abs(new_x+new_y-narsimage.pixel_x-narsimage.pixel_y)
-		world << "[thing]"
-		if((thing == 0) || (thing == 32) || (thing == 64)) //lel cant believe I coded this
-			animate(narsimage, pixel_x = new_x, pixel_y = new_y, time = 8)
-		narsimage.pixel_x = new_x
-		narsimage.pixel_y = new_y
-		narsimage.loc = src.loc
-		narsimage.mouse_opacity = 0
-		if(!narglow)
+			narsimage.mouse_opacity = 0
+		if(!narglow) //Create narglow
 			narglow = image('icons/obj/narsie.dmi',narsimage.loc,"glow-narsie",LIGHTING_LAYER+2,1)
-		if((thing == 0) || (thing == 32) || (thing == 64)) //lel cant believe I coded this
-			animate(narglow, pixel_x = narsimage.pixel_x, pixel_y = narsimage.pixel_y, time = 8)
-		narglow.pixel_x = narsimage.pixel_x
-		narglow.pixel_y = narsimage.pixel_y
-		narglow.loc = narsimage.loc
-		narglow.mouse_opacity = 0
+			narglow.mouse_opacity = 0
+		if(!N.old_x || !N.old_y)
+			N.old_x = src.x
+			N.old_y = src.y
+		//Reset narsie's location to the mob
+		var/old_pixel_x = 32 * (N.old_x - src.x) + N.pixel_x
+		var/old_pixel_y = 32 * (N.old_y - src.y) + N.pixel_y
+		narsimage.pixel_x = old_pixel_x
+		narsimage.pixel_y = old_pixel_y
+		narglow.pixel_x = old_pixel_x
+		narglow.pixel_y = old_pixel_y
+		narsimage.loc = src.loc
+		narglow.loc = src.loc
+		//Animate narsie based on dir
+		if(dir)
+			var/x_diff = 0
+			var/y_diff = 0
+			world << "[dir]"
+			switch(dir) //I bet somewhere out there a proc does something like this already
+				if(1)
+					x_diff = 32
+				if(2)
+					x_diff = -32
+				if(4)
+					y_diff = 32
+				if(8)
+					y_diff = -32
+				if(5)
+					x_diff = 32
+					y_diff = 32
+				if(6)
+					x_diff = 32
+					y_diff = -32
+				if(9)
+					x_diff = -32
+					y_diff = 32
+				if(10)
+					x_diff = -32
+					y_diff = -32
+			animate(narsimage, pixel_x = old_pixel_x+x_diff, pixel_y = old_pixel_y+y_diff, time = 8) //Animate the movement of narsie to narsie's new location
+			animate(narglow, pixel_x = old_pixel_x+x_diff, pixel_y = old_pixel_y+y_diff, time = 8)
+		else
+			//Else if no dir is given, simply send them the image of narsie
+			var/new_x = 32 * (N.x - src.x) + N.pixel_x
+			var/new_y = 32 * (N.y - src.y) + N.pixel_y
+			narsimage.pixel_x = new_x
+			narsimage.pixel_y = new_y
+			narglow.pixel_x = new_x
+			narglow.pixel_y = new_y
+		//Display the new narsimage to the player
 		src << narsimage
 		src << narglow
 	else

--- a/code/modules/power/singularity/narsie.dm
+++ b/code/modules/power/singularity/narsie.dm
@@ -29,6 +29,8 @@ var/global/narsie_cometh = 0
 	current_size = 12
 	consume_range = 12 // How many tiles out do we eat.
 	var/announce=1
+	var/old_x
+	var/old_y
 
 /obj/machinery/singularity/narsie/large/New()
 	..()
@@ -48,7 +50,11 @@ var/global/narsie_cometh = 0
 
 	SetUniversalState(/datum/universal_state/hell)
 	narsie_cometh = 1
-	sleep(10)
+
+	//Begin narsie vision
+	for(var/mob/M in player_list)
+		if(M.client)
+			M.see_narsie(src)
 	alpha = 0
 /*
 	updateicon()
@@ -126,19 +132,22 @@ var/global/narsie_cometh = 0
 
 	if(target && prob(60))
 		movement_dir = get_dir(src,target)
-
 	spawn(0)
+		old_x = src.x
+		old_y = src.y
 		step(src, movement_dir)
 		narsiefloor(get_turf(loc))
-		for(var/mob/M in mob_list)
+		for(var/mob/M in player_list)
 			if(M.client)
-				M.see_narsie(src)
+				M.see_narsie(src,movement_dir)
 	spawn(10)
+		old_x = src.x
+		old_y = src.y
 		step(src, movement_dir)
 		narsiefloor(get_turf(loc))
-		for(var/mob/M in mob_list)
+		for(var/mob/M in player_list)
 			if(M.client)
-				M.see_narsie(src)
+				M.see_narsie(src,movement_dir)
 	return 1
 
 /obj/machinery/singularity/narsie/proc/narsiefloor(var/turf/T)//leaving "footprints"
@@ -351,10 +360,10 @@ var/global/narsie_cometh = 0
 /obj/machinery/singularity/narsie/large/on_capture()
 	chained = 1
 	move_self = 0
-	icon_state ="narsie-chains"/*
+	icon_state ="narsie-chains"
 	for(var/mob/M in mob_list)//removing the client image of nar-sie while it is chained
 		if(M.client)
-			M.see_narsie(src)*/
+			M.see_narsie(src)
 
 /obj/machinery/singularity/narsie/large/on_release()
 	chained = 0

--- a/code/modules/power/singularity/narsie.dm
+++ b/code/modules/power/singularity/narsie.dm
@@ -26,7 +26,6 @@ var/global/narsie_cometh = 0
 	luminosity = 1
 	l_color = "#3e0000"
 
-
 	current_size = 12
 	consume_range = 12 // How many tiles out do we eat.
 	var/announce=1
@@ -43,12 +42,14 @@ var/global/narsie_cometh = 0
 			mode_ticker.third_phase()
 
 	if (emergency_shuttle)
-		emergency_shuttle.incall(0.3)
+		emergency_shuttle.incall()
 		emergency_shuttle.can_recall = 0
 		emergency_shuttle.settimeleft(600)
 
 	SetUniversalState(/datum/universal_state/hell)
 	narsie_cometh = 1
+	sleep(10)
+	alpha = 0
 /*
 	updateicon()
 */
@@ -69,7 +70,7 @@ var/global/narsie_cometh = 0
 
 	if (defer_powernet_rebuild != 2)
 		defer_powernet_rebuild = 1
-	for (var/atom/A in orange(consume_range, src))
+	for (var/turf/A in orange(consume_range, src))
 		consume(A)
 	if (defer_powernet_rebuild != 2)
 		defer_powernet_rebuild = 0
@@ -89,16 +90,12 @@ var/global/narsie_cometh = 0
 		narsiewall(A)
 	else if(istype(A, /obj/structure/cult))
 		qdel(A)
-	else
-		consume(A)
 
 /obj/machinery/singularity/narsie/Bumped(atom/A)
 	if(isturf(A))
 		narsiewall(A)
 	else if(istype(A, /obj/structure/cult))
 		qdel(A)
-	else
-		consume(A)
 
 /obj/machinery/singularity/narsie/move(var/force_move = 0)
 	if(!move_self)
@@ -136,7 +133,7 @@ var/global/narsie_cometh = 0
 		for(var/mob/M in mob_list)
 			if(M.client)
 				M.see_narsie(src)
-	spawn(1)
+	spawn(10)
 		step(src, movement_dir)
 		narsiefloor(get_turf(loc))
 		for(var/mob/M in mob_list)
@@ -181,9 +178,6 @@ var/global/narsie_cometh = 0
 			var/dist = get_dist(A, src)
 
 			for (var/atom/movable/AM in A.contents)
-				if (AM == src) // This is the snowflake.
-					continue
-
 				if (dist <= consume_range)
 					consume(AM)
 					continue
@@ -357,10 +351,10 @@ var/global/narsie_cometh = 0
 /obj/machinery/singularity/narsie/large/on_capture()
 	chained = 1
 	move_self = 0
-	icon_state ="narsie-chains"
+	icon_state ="narsie-chains"/*
 	for(var/mob/M in mob_list)//removing the client image of nar-sie while it is chained
 		if(M.client)
-			M.see_narsie(src)
+			M.see_narsie(src)*/
 
 /obj/machinery/singularity/narsie/large/on_release()
 	chained = 0

--- a/html/changelogs/Clusterfack_3209.yml
+++ b/html/changelogs/Clusterfack_3209.yml
@@ -1,0 +1,7 @@
+author: Clusterfack
+delete-after: true
+changes:
+- bugfix: Made suit storage units not drop all equipment on power failure, instead it must be crowbarred open
+- rscadd: Made narsie not lag
+- bugfix: Fixes a bug in powernet not fully shutting off power
+- bugfix: Shuttle shouldn't kill singulo/narsie if it lands on it anymore


### PR DESCRIPTION
Well I finally came back to this, a little wiser and much more experienced. And this time I can honestly say I think these changes should really FEEL different and like they made a large impact on the performance.

-Fixes narsie double consuming all atoms in range
-Commented out see_narsie until someone fixes it causing narsie double vision
-Instead of deleting pipelines, narsie will now set them to invisible

-Fixes #2587, powernet shutdown should work perfectly well now
-As above, fixes apcs recharging somewhat during different events like narsie, supermatter cascade,and powerfailure and then starting things back up

-Absolute pathed datum_pipeline.dm
-Disallowed shuttle controller deleting narsie/singulo on entry
-Added better lag logging for setting the universal state to hell_universe
-Lightswitches should start with the areas current light status
-Fixes a jukebox runtime during narsie's summoning for servers with no media server access

-Also makes suit storage not drop everything when they lose power. Why this was even a thing to start with, I will never know.