### PR TITLE
Secondfix

### DIFF
--- a/code/game/gamemodes/cult/hell_universe.dm
+++ b/code/game/gamemodes/cult/hell_universe.dm
@@ -122,7 +122,6 @@ In short:
 			APC.chargemode = 0
 			if(APC.cell)
 				APC.cell.charge = 0
-				power_machines -= APC
 			APC.emagged = 1
 			APC.queue_icon_update()
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -147,13 +147,14 @@
 			del(narsimage)
 			del(narglow)
 		return
-	if((N.z == src.z)&&(get_dist(N,src) <= (N.consume_range+10)))
+	if((N.z == src.z)&&(get_dist(N,src) <= (N.consume_range+10)) && ((get_dist(N,src)) > (src.world.view)))
 		if(!narsimage) //Create narsimage
 			narsimage = image('icons/obj/narsie.dmi',src.loc,"narsie",9,1)
 			narsimage.mouse_opacity = 0
 		if(!narglow) //Create narglow
 			narglow = image('icons/obj/narsie.dmi',narsimage.loc,"glow-narsie",LIGHTING_LAYER+2,1)
 			narglow.mouse_opacity = 0
+/* Animating narsie works like shit thanks to fucking byond
 		if(!N.old_x || !N.old_y)
 			N.old_x = src.x
 			N.old_y = src.y
@@ -193,14 +194,16 @@
 					y_diff = -32
 			animate(narsimage, pixel_x = old_pixel_x+x_diff, pixel_y = old_pixel_y+y_diff, time = 8) //Animate the movement of narsie to narsie's new location
 			animate(narglow, pixel_x = old_pixel_x+x_diff, pixel_y = old_pixel_y+y_diff, time = 8)
-		else
-			//Else if no dir is given, simply send them the image of narsie
-			var/new_x = 32 * (N.x - src.x) + N.pixel_x
-			var/new_y = 32 * (N.y - src.y) + N.pixel_y
-			narsimage.pixel_x = new_x
-			narsimage.pixel_y = new_y
-			narglow.pixel_x = new_x
-			narglow.pixel_y = new_y
+*/
+		//Else if no dir is given, simply send them the image of narsie
+		var/new_x = 32 * (N.x - src.x) + N.pixel_x
+		var/new_y = 32 * (N.y - src.y) + N.pixel_y
+		narsimage.pixel_x = new_x
+		narsimage.pixel_y = new_y
+		narglow.pixel_x = new_x
+		narglow.pixel_y = new_y
+		narsimage.loc = src.loc
+		narglow.loc = src.loc
 		//Display the new narsimage to the player
 		src << narsimage
 		src << narglow

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -147,7 +147,7 @@
 			del(narsimage)
 			del(narglow)
 		return
-	if((N.z == src.z)&&(get_dist(N,src) <= (N.consume_range+10)) && ((get_dist(N,src)) > (src.world.view)))
+	if((N.z == src.z)&&(get_dist(N,src) <= (N.consume_range+10)) && !(N in view(src)))
 		if(!narsimage) //Create narsimage
 			narsimage = image('icons/obj/narsie.dmi',src.loc,"narsie",9,1)
 			narsimage.mouse_opacity = 0

--- a/code/modules/power/singularity/narsie.dm
+++ b/code/modules/power/singularity/narsie.dm
@@ -29,8 +29,8 @@ var/global/narsie_cometh = 0
 	current_size = 12
 	consume_range = 12 // How many tiles out do we eat.
 	var/announce=1
-	var/old_x
-	var/old_y
+//	var/old_x
+//	var/old_y
 
 /obj/machinery/singularity/narsie/large/New()
 	..()

--- a/code/modules/power/singularity/narsie.dm
+++ b/code/modules/power/singularity/narsie.dm
@@ -51,11 +51,13 @@ var/global/narsie_cometh = 0
 	SetUniversalState(/datum/universal_state/hell)
 	narsie_cometh = 1
 
+	/* //For animating narsie manually, doesn't work well
 	//Begin narsie vision
 	for(var/mob/M in player_list)
 		if(M.client)
 			M.see_narsie(src)
 	alpha = 0
+	*/
 /*
 	updateicon()
 */
@@ -133,16 +135,16 @@ var/global/narsie_cometh = 0
 	if(target && prob(60))
 		movement_dir = get_dir(src,target)
 	spawn(0)
-		old_x = src.x
-		old_y = src.y
+//		old_x = src.x
+//		old_y = src.y
 		step(src, movement_dir)
 		narsiefloor(get_turf(loc))
 		for(var/mob/M in player_list)
 			if(M.client)
 				M.see_narsie(src,movement_dir)
 	spawn(10)
-		old_x = src.x
-		old_y = src.y
+//		old_x = src.x
+//		old_y = src.y
 		step(src, movement_dir)
 		narsiefloor(get_turf(loc))
 		for(var/mob/M in player_list)


### PR DESCRIPTION
Apparently nothing actually happens to change the power if you take the apcs off the power machine list. Cue - power_change and update danger level continuously because nothing is depowered despite apc charge being at 0.

Also fuck my see_narsie rewrite works terribly, going back to the old system except disabling it when in view range of narsie himself to prevent double narnar vision.


Honk honk honk.