### PR TITLE
Mommi Spawn Improvements

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -93,7 +93,7 @@ var/list/uplink_items = list()
 //Librarian
 /datum/uplink_item/jobspecific/etwenty
 	name = "The E20"
-	desc = "A seemingly innocent dice, those who are not afraid to roll for attack will find it's effects quite explosive. Has a four second timer."
+	desc = "A seemingly innocent die, those who are not afraid to roll for attack will find it's effects quite explosive. Has a four second timer."
 	item = /obj/item/weapon/dice/d20/e20
 	cost = 3
 	job = list("Librarian")

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -119,6 +119,8 @@ var/list/camera_names=list()
 /obj/machinery/camera/attack_paw(mob/living/carbon/alien/humanoid/user as mob)
 	if(!istype(user))
 		return
+	if(!status)
+		return
 	status = 0
 	visible_message("<span class='warning'>\The [user] slashes at [src]!</span>")
 	playsound(get_turf(src), 'sound/weapons/slash.ogg', 100, 1)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -51,6 +51,7 @@
 	autoclose = 1
 	var/busy = 0
 	soundeffect = 'sound/machines/airlock.ogg'
+	var/pitch = 30
 
 	emag_cost = 1 // in MJ
 
@@ -100,6 +101,8 @@
 	icon = 'icons/obj/doors/Doorglass.dmi'
 	opacity = 0
 	glass = 1
+	soundeffect = 'sound/machines/windowdoor.ogg'
+	pitch = 100
 
 /obj/machinery/door/airlock/centcom
 	name = "Airlock"
@@ -1109,7 +1112,7 @@ About the new airlock wires panel:
 		if( !arePowerSystemsOn() || (stat & NOPOWER) || isWireCut(AIRLOCK_WIRE_OPEN_DOOR) )
 			return 0
 	use_power(50)
-	playsound(get_turf(src), soundeffect, 30, 1)
+	playsound(get_turf(src), soundeffect, pitch, 1)
 	if(src.closeOther != null && istype(src.closeOther, /obj/machinery/door/airlock/) && !src.closeOther.density)
 		src.closeOther.close()
 	// This worries me - N3X

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -155,12 +155,12 @@ Class Procs:
 		machines -= src
 	if(src in power_machines)
 		power_machines -= src
-
+/*
 	if(component_parts)
 		for(var/atom/movable/AM in component_parts)
 			AM.loc = loc
 			component_parts -= AM
-
+*/
 		component_parts = null
 
 	..()

--- a/code/game/machinery/mommi_spawner.dm
+++ b/code/game/machinery/mommi_spawner.dm
@@ -166,6 +166,7 @@
 	user.loc = M//Should fix cybros run time erroring when blown up. It got deleted before, along with the frame.
 
 	M.mmi = new /obj/item/device/mmi(M)
+	M.mmi.transfer_identity(user)
 	M.Namepick()
 	M.updatename()
 

--- a/code/game/machinery/mommi_spawner.dm
+++ b/code/game/machinery/mommi_spawner.dm
@@ -45,6 +45,13 @@
 	if(building)
 		user << "\red \The [src] is busy building something already."
 		return 1
+
+	var/timedifference = world.time - user.client.time_died_as_mouse
+	if(user.client.time_died_as_mouse && timedifference <= mouse_respawn_time * 600)
+		var/timedifference_text
+		timedifference_text = time2text(mouse_respawn_time * 600 - timedifference,"mm:ss")
+		user << "<span class='warning'>You may only spawn again as a mouse or MoMMI more than [mouse_respawn_time] minutes after your death. You have [timedifference_text] left.</span>"
+		return
 	/*
 	if(!mmi.brainmob)
 		user << "\red \The [mmi] appears to be devoid of any soul."
@@ -76,7 +83,7 @@
 		user << "\red \The [src] doesn't have enough metal to complete this task."
 		return 1
 
-	if(alert(src, "Do you wish to be turned into a MoMMI at this position?", "Confirm", "Yes", "No") != "Yes") return
+	if(alert(user, "Do you wish to be turned into a MoMMI at this position?", "Confirm", "Yes", "No") != "Yes") return
 
 	building=1
 	update_icon()
@@ -141,20 +148,17 @@
 	if(!M)	return
 
 	M.invisibility = 0
-
 	if (locked_to_zlevel)
 		M.add_ion_law("You belong to the station where you were created; do not leave it.")
 		M.locked_to_z = T.z
 
-	if(user.mind)		//TODO
+	if(user.mind)
 		user.mind.transfer_to(M)
 		if(M.mind.assigned_role == "MoMMI")
 			M.mind.original = M
 		else if(user.mind.special_role)
 			M.mind.store_memory("In case you look at this after being borged, the objectives are only here until I find a way to make them not show up for you, as I can't simply delete them without screwing up round-end reporting. --NeoFite")
-	else
-		M.key = user.key
-
+	M.key = user.key
 	M.job = "Mobile MMI"
 
 	//M.cell = locate(/obj/item/weapon/cell) in contents
@@ -162,7 +166,6 @@
 	user.loc = M//Should fix cybros run time erroring when blown up. It got deleted before, along with the frame.
 
 	M.mmi = new /obj/item/device/mmi(M)
-	M.mmi.transfer_identity(user)//Does not transfer key/client.
 	M.Namepick()
 	M.updatename()
 

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -126,7 +126,7 @@
 		if(M in player_list)
 			M << msg
 
-	log_admin("DirectNarrate: [key_name(usr)] at [formatJumpTo(get_turf(usr))]: [msg]")
+	log_admin("LocalNarrate: [key_name(usr)] at [formatJumpTo(get_turf(usr))]: [msg]")
 	message_admins("\blue \bold DirectNarrate: [key_name(usr)] at [formatJumpTo(get_turf(usr))]: [msg]<BR>", 1)
 	feedback_add_details("admin_verb","LIRN") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -762,16 +762,25 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		return
 
 	//find a viable mouse candidate
-	var/obj/machinery/mommi_spawner/spawner
 	var/list/found_spawners = list()
-	for(var/obj/machinery/mommi_spawner/s in world)
-		if(s.z == src.z && s.canSpawn())
+	for(var/obj/machinery/mommi_spawner/s in machines)
+		if(s.canSpawn())
 			found_spawners.Add(s)
 	if(found_spawners.len)
-		spawner = pick(found_spawners)
-		spawner.attack_ghost(src)
+		var/options[found_spawners.len]
+		for(var/t=1,t<=found_spawners.len,t++)
+			var/obj/machinery/mommi_spawner/S = found_spawners[t]
+			var/dat = text("[] on z-level = []",get_area(S),S.z)
+			options[t] = dat
+		var/selection = input(src,"Select a MoMMI spawn location", "Become MoMMI",null) as null|anything in options
+		if(selection)
+			for(var/i = 1, i<=options.len, i++)
+				if(options[i] == selection)
+					var/obj/machinery/mommi_spawner/final = found_spawners[i]
+					final.attack_ghost(src)
+					break
 	else
-		src << "<span class='warning'>Unable to find any powered MoMMI Spawners on this z-level.</span>"
+		src << "<span class='warning'>Unable to find any MoMMI Spawners ready to build a MoMMI in the universe. Please try again.</span>"
 
 	//if(host)
 	//	host.ckey = src.ckey

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -75,7 +75,7 @@
 		if(M.mind && M.mind.special_role)
 			M.mind.store_memory("In case you look at this after being borged, the objectives are only here until I find a way to make them not show up for you, as I can't simply delete them without screwing up round-end reporting. --NeoFite")
 
-		M.job = "Cyborg"
+		M.job = "MoMMI"
 
 		M.cell = locate(/obj/item/weapon/cell) in contents
 		M.cell.loc = M

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -524,8 +524,6 @@ var/global/list/organ_damage_overlays = list(
 	var/datum/organ/internal/lungs/L = internal_organs_by_name["lungs"]
 	if(L)
 		L.process()
-	else
-		src << "<span class='warning'>You have no lungs which to breathe with, panic and tell a coder.</span>"
 
 	var/datum/gas_mixture/environment = loc.return_air()
 	var/datum/gas_mixture/breath

--- a/html/changelogs/Clusterfack_3332.yml
+++ b/html/changelogs/Clusterfack_3332.yml
@@ -1,0 +1,14 @@
+author: Clusterfack
+delete-after: true
+changes:
+- bugfix: Fixed a bug where you could use rpd's from far away
+- bugfix: Fixes a bug where wrapping paper would magically reduce the size of objects
+- bugfix: Made machine frames dropped from machines spawn at the right buildstage so you can wirecut them
+- rscadd: Added a local narrate button for admins
+- bugfix: Made stacks properly stack beneath you when welding shards for example
+- bugfix: Made Mr. Clean not act like narsie and set the universal state
+- rscadd: Made mommis/borgs able to interface with the all in one grinder
+- rscadd: Improvements made to the become mommi verb for observers
+- bugfix: Fixed a bug where using attack ghost on a mommi spawner wouldn't check your respawn timer
+- bugfix: Fixed another bug where ghosts wouldn't always be put inside the spawned mommis body
+- tweak: Fixes chem dispenser UI size so it properly shows all three columns


### PR DESCRIPTION
-Improves become_mommi button for observers, gives an option of all the areas in which mommi spawners that are ready to spawn are located
-Fixes a bug where mobs with a mind would not be transferred into a built mommi from a mommi spawner
-Fixes a few typos
-Removes the 'you have no lungs panic and tell a coder' message, since you can actually have no lungs now