### PR TITLE
Optimization

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -19,6 +19,7 @@
 #include "code\__HELPERS\_macros.dm"
 #include "code\__HELPERS\cmp.dm"
 #include "code\__HELPERS\constants.dm"
+#include "code\__HELPERS\datumpool.dm"
 #include "code\__HELPERS\experimental.dm"
 #include "code\__HELPERS\files.dm"
 #include "code\__HELPERS\game.dm"

--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -103,6 +103,8 @@ Pipelines + Other Objects -> Pipe network
 
 	return null
 
+/obj/machinery/atmospherics/proc/unassign_network(datum/pipe_network/reference)
+
 /obj/machinery/atmospherics/proc/reassign_network(datum/pipe_network/old_network, datum/pipe_network/new_network)
 	// Used when two pipe_networks are combining
 

--- a/code/ATMOSPHERICS/components/binary_devices/binary_atmos_base.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/binary_atmos_base.dm
@@ -69,10 +69,12 @@
 /obj/machinery/atmospherics/binary/Destroy()
 	if(node1)
 		node1.disconnect(src)
-		del(network1)
+		if(network1)
+			returnToDPool(network1)
 	if(node2)
 		node2.disconnect(src)
-		del(network2)
+		if(network2)
+			returnToDPool(network2)
 
 	node1 = null
 	node2 = null
@@ -89,12 +91,12 @@
 
 /obj/machinery/atmospherics/binary/build_network()
 	if(!network1 && node1)
-		network1 = new /datum/pipe_network()
+		network1 = getFromDPool(/datum/pipe_network)
 		network1.normal_members += src
 		network1.build_network(node1, src)
 
 	if(!network2 && node2)
-		network2 = new /datum/pipe_network()
+		network2 = getFromDPool(/datum/pipe_network)
 		network2.normal_members += src
 		network2.build_network(node2, src)
 
@@ -130,11 +132,19 @@
 
 /obj/machinery/atmospherics/binary/disconnect(obj/machinery/atmospherics/reference)
 	if(reference==node1)
-		del(network1)
+		if(network1)
+			returnToDPool(network1)
 		node1 = null
 
 	else if(reference==node2)
-		del(network2)
+		if(network2)
+			returnToDPool(network2)
 		node2 = null
 
 	return null
+
+/obj/machinery/atmospherics/binary/unassign_network(datum/pipe_network/reference)
+	if(network1 == reference)
+		network1 = null
+	if(network2 == reference)
+		network2 = null

--- a/code/ATMOSPHERICS/components/binary_devices/circulator.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/circulator.dm
@@ -91,10 +91,12 @@
 	else
 		if(node1)
 			node1.disconnect(src)
-			del(network1)
+			if(network1)
+				returnToDPool(network1)
 		if(node2)
 			node2.disconnect(src)
-			del(network2)
+			if(network2)
+				returnToDPool(network2)
 
 		node1 = null
 		node2 = null

--- a/code/ATMOSPHERICS/components/binary_devices/valve.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/valve.dm
@@ -58,9 +58,11 @@
 	update_icon()
 
 	if(network1)
-		del(network1)
+		if(network1)
+			returnToDPool(network1)
 	if(network2)
-		del(network2)
+		if(network1)
+			returnToDPool(network2)
 
 	build_network()
 

--- a/code/ATMOSPHERICS/components/trinary_devices/t_valve.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/t_valve.dm
@@ -74,9 +74,9 @@
 	update_icon()
 
 	if(network1)
-		del(network1)
+		returnToDPool(network1)
 	if(network3)
-		del(network3)
+		returnToDPool(network3)
 	build_network()
 
 	if(network1&&network2)
@@ -99,9 +99,9 @@
 	update_icon()
 
 	if(network1)
-		del(network1)
+		returnToDPool(network1)
 	if(network2)
-		del(network2)
+		returnToDPool(network2)
 	build_network()
 
 	if(network1&&network3)

--- a/code/ATMOSPHERICS/components/trinary_devices/trinary_base.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/trinary_base.dm
@@ -85,13 +85,16 @@ obj/machinery/atmospherics/trinary/network_expand(datum/pipe_network/new_network
 obj/machinery/atmospherics/trinary/Destroy()
 	if(node1)
 		node1.disconnect(src)
-		del(network1)
+		if(network1)
+			returnToDPool(network1)
 	if(node2)
 		node2.disconnect(src)
-		del(network2)
+		if(network2)
+			returnToDPool(network2)
 	if(node3)
 		node3.disconnect(src)
-		del(network3)
+		if(network3)
+			returnToDPool(network3)
 
 	node1 = null
 	node2 = null
@@ -121,17 +124,17 @@ obj/machinery/atmospherics/trinary/initialize()
 
 obj/machinery/atmospherics/trinary/build_network()
 	if(!network1 && node1)
-		network1 = new /datum/pipe_network()
+		network1 = getFromDPool(/datum/pipe_network)
 		network1.normal_members += src
 		network1.build_network(node1, src)
 
 	if(!network2 && node2)
-		network2 = new /datum/pipe_network()
+		network2 = getFromDPool(/datum/pipe_network)
 		network2.normal_members += src
 		network2.build_network(node2, src)
 
 	if(!network3 && node3)
-		network3 = new /datum/pipe_network()
+		network3 = getFromDPool(/datum/pipe_network)
 		network3.normal_members += src
 		network3.build_network(node3, src)
 
@@ -174,15 +177,26 @@ obj/machinery/atmospherics/trinary/return_network_air(datum/pipe_network/referen
 
 obj/machinery/atmospherics/trinary/disconnect(obj/machinery/atmospherics/reference)
 	if(reference==node1)
-		del(network1)
+		if(network1)
+			returnToDPool(network1)
 		node1 = null
 
 	else if(reference==node2)
-		del(network2)
+		if(network2)
+			returnToDPool(network2)
 		node2 = null
 
 	else if(reference==node3)
-		del(network3)
+		if(network3)
+			returnToDPool(network3)
 		node3 = null
 
 	return null
+
+/obj/machinery/atmospherics/trinary/unassign_network(datum/pipe_network/reference)
+	if(network1 == reference)
+		network1 = null
+	if(network2 == reference)
+		network2 = null
+	if(network3 == reference)
+		network3 = null

--- a/code/ATMOSPHERICS/components/unary/portables_connector.dm
+++ b/code/ATMOSPHERICS/components/unary/portables_connector.dm
@@ -49,7 +49,8 @@
 
 	if(node)
 		node.disconnect(src)
-		del(network)
+		if(network)
+			returnToDPool(network)
 
 	node = null
 

--- a/code/ATMOSPHERICS/components/unary/unary_base.dm
+++ b/code/ATMOSPHERICS/components/unary/unary_base.dm
@@ -41,7 +41,8 @@
 /obj/machinery/atmospherics/unary/Destroy()
 	if(node)
 		node.disconnect(src)
-		del(network)
+		if(network)
+			returnToDPool(network)
 	node = null
 	..()
 
@@ -56,7 +57,7 @@
 
 /obj/machinery/atmospherics/unary/build_network()
 	if(!network && node)
-		network = new /datum/pipe_network()
+		network = getFromDPool(/datum/pipe_network)
 		network.normal_members += src
 		network.build_network(node, src)
 
@@ -80,6 +81,11 @@
 
 /obj/machinery/atmospherics/unary/disconnect(obj/machinery/atmospherics/reference)
 	if(reference==node)
-		del(network)
+		if(network)
+			returnToDPool(network)
 		node = null
 	return null
+
+/obj/machinery/atmospherics/unary/unassign_network(datum/pipe_network/reference)
+	if(network == reference)
+		network = null

--- a/code/ATMOSPHERICS/datum_pipe_network.dm
+++ b/code/ATMOSPHERICS/datum_pipe_network.dm
@@ -15,6 +15,18 @@ var/global/list/datum/pipe_network/pipe_networks = list()
 
 	..()
 
+/datum/pipeline/Del()
+	Destroy()
+	return ..()
+
+/datum/pipe_network/Destroy()
+	for(var/datum/pipeline/pipeline in line_members) //This will remove the pipeline references for us
+		pipeline.network = null
+	for(var/obj/machinery/atmospherics/objects in normal_members) //Procs for the different bases will remove the references
+		objects.unassign_network(src)
+	pipe_networks -= src //Final ref
+
+
 /datum/pipe_network/proc/process()
 	//Equalize gases amongst pipe if called for
 	if(update)

--- a/code/ATMOSPHERICS/pipes.dm
+++ b/code/ATMOSPHERICS/pipes.dm
@@ -47,38 +47,35 @@
 
 /obj/machinery/atmospherics/pipe/return_air()
 	if(!parent)
-		parent = new /datum/pipeline()
+		parent = getFromDPool(/datum/pipeline)
 		parent.build_pipeline(src)
-
 	return parent.air
 
 
 /obj/machinery/atmospherics/pipe/build_network()
 	if(!parent)
-		parent = new /datum/pipeline()
+		parent = getFromDPool(/datum/pipeline)
 		parent.build_pipeline(src)
-
 	return parent.return_network()
 
 
 /obj/machinery/atmospherics/pipe/network_expand(datum/pipe_network/new_network, obj/machinery/atmospherics/pipe/reference)
 	if(!parent)
-		parent = new /datum/pipeline()
+		parent = getFromDPool(/datum/pipeline)
 		parent.build_pipeline(src)
-
 	return parent.network_expand(new_network, reference)
 
 
 /obj/machinery/atmospherics/pipe/return_network(obj/machinery/atmospherics/reference)
 	if(!parent)
-		parent = new /datum/pipeline()
+		parent = getFromDPool(/datum/pipeline)
 		parent.build_pipeline(src)
-
 	return parent.return_network(reference)
 
 
 /obj/machinery/atmospherics/pipe/Destroy()
-	del(parent)
+	if(parent)
+		returnToDPool(parent)
 	for(var/obj/machinery/meter/M in src.loc)
 		if(M.target == src)
 			new /obj/item/pipe_meter(src.loc)
@@ -323,12 +320,12 @@
 /obj/machinery/atmospherics/pipe/simple/disconnect(obj/machinery/atmospherics/reference)
 	if(reference == node1)
 		if(istype(node1, /obj/machinery/atmospherics/pipe))
-			del(parent)
+			returnToDPool(parent)
 		node1 = null
 
 	if(reference == node2)
 		if(istype(node2, /obj/machinery/atmospherics/pipe))
-			del(parent)
+			returnToDPool(parent)
 		node2 = null
 
 	update_icon()
@@ -532,17 +529,17 @@
 /obj/machinery/atmospherics/pipe/manifold/disconnect(obj/machinery/atmospherics/reference)
 	if(reference == node1)
 		if(istype(node1, /obj/machinery/atmospherics/pipe))
-			del(parent)
+			returnToDPool(parent)
 		node1 = null
 
 	if(reference == node2)
 		if(istype(node2, /obj/machinery/atmospherics/pipe))
-			del(parent)
+			returnToDPool(parent)
 		node2 = null
 
 	if(reference == node3)
 		if(istype(node3, /obj/machinery/atmospherics/pipe))
-			del(parent)
+			returnToDPool(parent)
 		node3 = null
 
 	update_icon()
@@ -769,22 +766,22 @@
 /obj/machinery/atmospherics/pipe/manifold4w/disconnect(obj/machinery/atmospherics/reference)
 	if(reference == node1)
 		if(istype(node1, /obj/machinery/atmospherics/pipe))
-			del(parent)
+			returnToDPool(parent)
 		node1 = null
 
 	if(reference == node2)
 		if(istype(node2, /obj/machinery/atmospherics/pipe))
-			del(parent)
+			returnToDPool(parent)
 		node2 = null
 
 	if(reference == node3)
 		if(istype(node3, /obj/machinery/atmospherics/pipe))
-			del(parent)
+			returnToDPool(parent)
 		node3 = null
 
 	if(reference == node4)
 		if(istype(node4, /obj/machinery/atmospherics/pipe))
-			del(parent)
+			returnToDPool(parent)
 		node4 = null
 
 	update_icon()

--- a/code/__HELPERS/datumpool.dm
+++ b/code/__HELPERS/datumpool.dm
@@ -1,0 +1,79 @@
+//This was made pretty explicity for atmospherics devices which could not delete their datums properly
+//Make sure you go around and null out those references to the datum
+//It was also pretty explicitly and shamelessly stolen from regular object pooling, thanks esword
+
+//#define DEBUG_DATUM_POOL
+
+#define MAINTAINING_DATUM_POOL_COUNT 100
+var/global/list/masterdatumPool = new
+
+/*
+ * @args : datum type, normal arguments
+ * Example call: getFromPool(/datum/pipeline, args)
+ */
+/proc/getFromDPool()
+	var/A = args[1]
+	var/list/B = list()
+	B += (args - A)
+	if(length(masterdatumPool["[A]"]) <= 0)
+		#ifdef DEBUG_DATUM_POOL
+		world << text("DEBUG_DATUM_POOL: new proc has been called ([] | []).", A, list2params(B))
+		#endif
+		//so the GC knows we're pooling this type.
+		if(isnull(masterdatumPool["[A]"]))
+			masterdatumPool["[A]"] = list(new A)
+		if(B && B.len)
+			return new A(arglist(B))
+		else
+			return new A()
+
+	var/datum/O = masterdatumPool["[A]"][1]
+	masterdatumPool["[A]"] -= O
+
+	#ifdef DEBUG_DATUM_POOL
+	world << text("DEBUG_DATUM_POOL: getFromPool([]) [] left arglist([]).", A, length(masterdatumPool[A]), list2params(B))
+	#endif
+	if(!O || !istype(O))
+		O = new A(arglist(B))
+	else
+		O.New(arglist(B))
+	return O
+
+/*
+ * @args
+ * A, datum instance
+ *
+ * @return
+ * -1, if A is not a movable atom
+ *
+ * Example call: returnToDPool(src)
+ */
+/proc/returnToDPool(const/datum/D)
+	if(length(masterdatumPool["[D.type]"]) > MAINTAINING_DATUM_POOL_COUNT)
+		#ifdef DEBUG_DATUM_POOL
+		world << text("DEBUG_DATUM_POOL: returnToPool([]) exceeds [] discarding...", D.type, MAINTAINING_DATUM_POOL_COUNT)
+		#endif
+		del(D)
+		return
+	if(isnull(masterdatumPool["[D.type]"]))
+		masterdatumPool["[D.type]"] = list()
+	D.Destroy()
+	D.resetVariables()
+	masterdatumPool["[D.type]"] += D
+
+	#ifdef DEBUG_DATUM_POOL
+	world << text("DEBUG_DATUM_POOL: returnToPool([]) [] left.", D.type, length(masterdatumPool["[D.type]"]))
+	#endif
+
+#undef MAINTAINING_DATUM_POOL_COUNT
+
+#ifdef DEBUG_DATUM_POOL
+#undef DEBUG_DATUM_POOL
+#endif
+
+/datum/proc/resetVariables()
+	var/list/exclude = global.exclude + args // explicit var exclusion
+	for(var/key in vars)
+		if(key in exclude)
+			continue
+		vars[key] = initial(vars[key])

--- a/code/__HELPERS/experimental.dm
+++ b/code/__HELPERS/experimental.dm
@@ -142,7 +142,7 @@ var/list/exclude = list("inhand_states", "loc", "locs", "parent_type", "vars", "
  * /obj/item/weapon/resetVariables()
  * 	..("var4")
  */
-/atom/movable/proc/resetVariables()
+/atom/movable/resetVariables()
 	loc = null
 
 	var/list/exclude = global.exclude + args // explicit var exclusion

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -65,7 +65,7 @@ var/list/camera_names=list()
 	if(assembly)
 		qdel(assembly)
 		assembly = null
-	qdel(wires)
+	wires = null
 	cameranet.removeCamera(src) //Will handle removal from the camera network and the chunks, so we don't need to worry about that
 	..()
 

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -56,7 +56,6 @@
 		initialize()
 
 /obj/item/device/radio/Destroy()
-	qdel(wires)
 	wires = null
 	remove_radio_all(src) //Just to be sure
 	..()


### PR DESCRIPTION
Adds a datum pooling proc, shamelessly stolen from regular object pooling

Applies datum pooling to pipelines and pipenetwork for major performance improvements in their deletion.
These improvements should be especially noticeable in anything that deletes pipelines/networks once per tick, ie singulo narsie and supermatter, narsie will actually have no improvement because trying to solve this same issue I made him simply not delete pipes and set them to invisible instead
Removes the camera/radio wires qdel, just why

Before: http://puu.sh/gJVR4/a72a508961.png
After: http://puu.sh/gJSKv/96e79f9ea6.png