### PR TITLE
Datumpool runtime fix

### DIFF
--- a/code/__HELPERS/datumpool.dm
+++ b/code/__HELPERS/datumpool.dm
@@ -52,6 +52,8 @@ var/global/list/masterdatumPool = new
  * Example call: returnToDPool(src)
  */
 /proc/returnToDPool(const/datum/D)
+	if(!D)
+		return
 	if(length(masterdatumPool["[D.type]"]) > MAINTAINING_DATUM_POOL_COUNT)
 		#ifdef DEBUG_DATUM_POOL
 		world << text("DEBUG_DATUM_POOL: returnToPool([]) exceeds [] discarding...", D.type, MAINTAINING_DATUM_POOL_COUNT)

--- a/code/__HELPERS/datumpool.dm
+++ b/code/__HELPERS/datumpool.dm
@@ -36,7 +36,10 @@ var/global/list/masterdatumPool = new
 	if(!O || !istype(O))
 		O = new A(arglist(B))
 	else
-		O.New(arglist(B))
+		if(B && B.len)
+			O.New(arglist(B))
+		else
+			O.New()
 	return O
 
 /*


### PR DESCRIPTION
Runtime fix that should stop the following runtime:

runtime error: illegal use of list2args() or named parameters
proc name: getFromDPool (/proc/getFromDPool)
  source file: datumpool.dm,39

Fix another issue where the GC would collect a datum before it makes it into the pool.

Fixes https://github.com/d3athrow/vgstation13/issues/3542