### PR TITLE
Datum Initialization Hotfix

### DIFF
--- a/code/ATMOSPHERICS/datum_pipe_network.dm
+++ b/code/ATMOSPHERICS/datum_pipe_network.dm
@@ -26,6 +26,11 @@ var/global/list/datum/pipe_network/pipe_networks = list()
 		objects.unassign_network(src)
 	pipe_networks -= src //Final ref
 
+/datum/pipe_network/resetVariables()
+	..("gases", "normal_members", "line_members")
+	gases = list()
+	normal_members = list()
+	line_members = list()
 
 /datum/pipe_network/proc/process()
 	//Equalize gases amongst pipe if called for

--- a/code/ATMOSPHERICS/datum_pipeline.dm
+++ b/code/ATMOSPHERICS/datum_pipeline.dm
@@ -1,8 +1,8 @@
 /datum/pipeline
 	var/datum/gas_mixture/air
 
-	var/list/obj/machinery/atmospherics/pipe/members
-	var/list/obj/machinery/atmospherics/pipe/edges //Used for building networks
+	var/list/obj/machinery/atmospherics/pipe/members = list()
+	var/list/obj/machinery/atmospherics/pipe/edges = list() //Used for building networks
 
 	var/datum/pipe_network/network
 
@@ -24,6 +24,11 @@
 	//Null the fuck out of all these references
 	for(var/obj/machinery/atmospherics/pipe/M in members) //Edges are a subset of members
 		M.parent = null
+
+/datum/pipeline/resetVariables()
+	..("members", "edges")
+	members = list()
+	edges = list()
 
 /datum/pipeline/proc/process()//This use to be called called from the pipe networks
 	if((world.timeofday - last_pressure_check) / 10 >= PRESSURE_CHECK_DELAY)

--- a/code/__HELPERS/datumpool.dm
+++ b/code/__HELPERS/datumpool.dm
@@ -76,6 +76,10 @@ var/global/list/masterdatumPool = new
 #undef DEBUG_DATUM_POOL
 #endif
 
+//RETURNS NULL WHEN INITIALIZED AS A LIST() AND POSSIBLY OTHER DISCRIMINATORS
+//IF YOU ARE USING SPECIAL VARIABLES SUCH A LIST() INITIALIZE THEM USING RESET VARIABLES
+//SEE http://www.byond.com/forum/?post=76850 AS A REFERENCE ON THIS
+
 /datum/proc/resetVariables()
 	var/list/exclude = global.exclude + args // explicit var exclusion
 	for(var/key in vars)

--- a/code/__HELPERS/experimental.dm
+++ b/code/__HELPERS/experimental.dm
@@ -142,6 +142,11 @@ var/list/exclude = list("inhand_states", "loc", "locs", "parent_type", "vars", "
  * /obj/item/weapon/resetVariables()
  * 	..("var4")
  */
+
+//RETURNS NULL WHEN INITIALIZED AS A LIST() AND POSSIBLY OTHER DISCRIMINATORS
+//IF YOU ARE USING SPECIAL VARIABLES SUCH A LIST() INITIALIZE THEM USING RESET VARIABLES
+//SEE http://www.byond.com/forum/?post=76850 AS A REFERENCE ON THIS
+
 /atom/movable/resetVariables()
 	loc = null
 

--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -43,7 +43,8 @@ var/global/list/blood_list = list()
 	viruses = list()
 	virus2 = list()
 	blood_DNA = list()
-	..("viruses","virus2", "blood_DNA", args)
+	..("viruses","virus2", "blood_DNA", "random_icon_states", args)
+
 /obj/effect/decal/cleanable/blood/New()
 	..()
 	blood_list += src


### PR DESCRIPTION
Another datum pooling initialization hotfix. Initial does not actually create lists causing type mismatches after being pooled.
See: http://www.byond.com/forum/?post=76850, reported to byond 5 years ago but never fixed

Causes the following runtimes:
runtime error: type mismatch:  += the digital switching valve (/obj/machinery/atmospherics/trinary/tvalve/digital/mirrored)
proc name: build network (/obj/machinery/atmospherics/trinary/build_network)
  source file: trinary_base.dm,128
  usr: null
  src: the digital switching valve (/obj/machinery/atmospherics/trinary/tvalve/digital/mirrored)
  call stack:
the digital switching valve (/obj/machinery/atmospherics/trinary/tvalve/digital/mirrored): build network()
the digital switching valve (/obj/machinery/atmospherics/trinary/tvalve/digital/mirrored): go straight()
the digital switching valve (/obj/machinery/atmospherics/trinary/tvalve/digital/mirrored): initialize()
the digital switching valve (/obj/machinery/atmospherics/trinary/tvalve/digital/mirrored): initialize()
/datum/controller/game_control... (/datum/controller/game_controller): setup objects()
/datum/controller/game_control... (/datum/controller/game_controller): setup()
: New()

runtime error: type mismatch:  |= /list (/list)
proc name: merge (/datum/pipe_network/proc/merge)
  source file: datum_pipe_network.dm,61
  usr: null
  src: /datum/pipe_network (/datum/pipe_network)
  call stack:
/datum/pipe_network (/datum/pipe_network): merge(/datum/pipe_network (/datum/pipe_network))
the digital switching valve (/obj/machinery/atmospherics/trinary/tvalve/digital/mirrored): go straight()
the digital switching valve (/obj/machinery/atmospherics/trinary/tvalve/digital/mirrored): initialize()
the digital switching valve (/obj/machinery/atmospherics/trinary/tvalve/digital/mirrored): initialize()
/datum/controller/game_control... (/datum/controller/game_controller): setup objects()
/datum/controller/game_control... (/datum/controller/game_controller): setup()
: New()