### PR TITLE
Bugfixes

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -150,7 +150,6 @@
 #include "code\datums\mind.dm"
 #include "code\datums\mixed.dm"
 #include "code\datums\modules.dm"
-#include "code\datums\organs.dm"
 #include "code\datums\plugin.dm"
 #include "code\datums\recipe.dm"
 #include "code\datums\sun.dm"

--- a/code/ATMOSPHERICS/datum_pipeline.dm
+++ b/code/ATMOSPHERICS/datum_pipeline.dm
@@ -68,8 +68,6 @@
 		member.air_temporary.update_values()
 
 /datum/pipeline/proc/build_pipeline(obj/machinery/atmospherics/pipe/base)
-	air = new
-
 	var/list/possible_expansions = list(base)
 	members = list(base)
 	edges = list()
@@ -112,6 +110,7 @@
 			possible_expansions -= borderline
 
 	air.volume = volume
+	air.update_values()
 
 /datum/pipeline/proc/network_expand(datum/pipe_network/new_network, obj/machinery/atmospherics/pipe/reference)
 

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -190,7 +190,7 @@
 			continue
 		if (item.amount>=item.max_amount)
 			continue
-		src.preattack(item, usr)
+		src.preattack(item, usr,1)
 		break
 
 /obj/item/stack/attack_hand(mob/user as mob)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -682,6 +682,8 @@ var/list/admin_verbs_mod = list(
 	set category = "Admin"
 
 	if(holder)
+		if(alert("Are you sure you want to deadmin?","Deadmin","Yes","No")=="No")
+			return
 		log_admin("[src] deadminned themself.")
 		message_admins("[src] deadminned themself.")
 		deadmin()

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/nurse.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/nurse.dm
@@ -24,6 +24,8 @@
 			stop_automated_movement = 0
 
 /mob/living/simple_animal/hostile/giant_spider/nurse/Life()
+	if(istype(loc,/obj/item/device/mobcapsule)) //Dont bother trying to do shit while inside of a capsule, stops self-web spinning
+		return
 	..()
 	if(!stat)
 		if(stance == HOSTILE_STANCE_IDLE)


### PR DESCRIPTION
Removes unused file organs.dm

Fixes bug with add2stacks under the new proximity flag

Adds an alert before admins become deadminned because HOLY SHIT WHY IS THAT RIGHT NEXT TO CHECK ANTAGONISTS WITH NO CONFIRMATION WHO THOUGHT THAT WOULD BE A GOOD IDEA?

Fixes #2106,Stops giant spiders from webbing themself inside their own capsule in a somewhat snowflakey way, but I've never seen nor heard of this occuring any other way

Fixes a bug where pipeline rebuilds didn't update_values causing improper presure values
