### PR TITLE
Thermal Plate Optimization

### DIFF
--- a/code/ATMOSPHERICS/components/unary/thermal_plate.dm
+++ b/code/ATMOSPHERICS/components/unary/thermal_plate.dm
@@ -69,6 +69,9 @@
 	return
 
 /obj/machinery/atmospherics/unary/thermal_plate/proc/radiate()
+	if(network && network.radiate) //Since each member of a network has the same gases each tick
+		air_contents.copy_from(network.radiate) //We can cut down on processing time by only calculating radiate() once and then applying the result
+		return 1
 
 	var/internal_transfer_moles = 0.25 * air_contents.total_moles()
 	var/datum/gas_mixture/internal_removed = air_contents.remove(internal_transfer_moles)
@@ -86,5 +89,6 @@
 
 	if (network)
 		network.update = 1
+		network.radiate = air_contents
 
 	return 1

--- a/code/ATMOSPHERICS/datum_pipe_network.dm
+++ b/code/ATMOSPHERICS/datum_pipe_network.dm
@@ -9,6 +9,7 @@ var/global/list/datum/pipe_network/pipe_networks = list()
 
 	var/update = 1
 	var/datum/gas_mixture/air_transient = null
+	var/datum/gas_mixture/radiate = null
 
 /datum/pipe_network/New()
 	air_transient = new()
@@ -37,6 +38,7 @@ var/global/list/datum/pipe_network/pipe_networks = list()
 	if(update)
 		update = 0
 		reconcile_air() //equalize_gases(gases)
+		radiate = null //Reset our last ticks calculation for the post-radiate() gases inside a thermal plate
 
 #ifdef ATMOS_PIPELINE_PROCESSING
 	//Give pipelines their process call for pressure checking and what not. Have to remove pressure checks for the time being as pipes dont radiate heat - Mport


### PR DESCRIPTION
Optimization to the radiation of thermal plates. 

Instead of each thermal plate calling radiate() every single tick, thermal plates in the same network (which equalizes all gases within every tick) will simply copy over the gases once the first radiate() is called. Then the networks radiate() value will then be reset. If the network is destroyed between ticks it wont matter, as then the thermal plates will instead all call radiate() as they would usually.