### PR TITLE
Complete - (Not an actual) Powernet Optimization

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1357,6 +1357,7 @@
 #include "code\modules\power\monitor.dm"
 #include "code\modules\power\port_gen.dm"
 #include "code\modules\power\power.dm"
+#include "code\modules\power\powernet.dm"
 #include "code\modules\power\smes.dm"
 #include "code\modules\power\solar.dm"
 #include "code\modules\power\terminal.dm"

--- a/code/ATMOSPHERICS/datum_pipe_network.dm
+++ b/code/ATMOSPHERICS/datum_pipe_network.dm
@@ -1,5 +1,3 @@
-var/global/list/datum/pipe_network/pipe_networks = list()
-
 /datum/pipe_network
 	var/list/datum/gas_mixture/gases = list() //All of the gas_mixtures continuously connected in this network
 
@@ -11,20 +9,20 @@ var/global/list/datum/pipe_network/pipe_networks = list()
 	var/datum/gas_mixture/air_transient = null
 
 /datum/pipe_network/New()
+
 	air_transient = new()
 
 	..()
 
 /datum/pipeline/Del()
-	Destroy()
-	return ..()
+	pipe_networks -= src
+	..()
 
 /datum/pipe_network/Destroy()
 	for(var/datum/pipeline/pipeline in line_members) //This will remove the pipeline references for us
 		pipeline.network = null
 	for(var/obj/machinery/atmospherics/objects in normal_members) //Procs for the different bases will remove the references
 		objects.unassign_network(src)
-	pipe_networks -= src //Final ref
 
 /datum/pipe_network/resetVariables()
 	..("gases", "normal_members", "line_members")
@@ -49,16 +47,17 @@ var/global/list/datum/pipe_network/pipe_networks = list()
 	//Notes: Assuming that members will add themselves to appropriate roster in network_expandz()
 
 	if(!start_normal)
-		qdel(src)
+		returnToDPool(src)
 
 	start_normal.network_expand(src, reference)
 
 	update_network_gases()
 
 	if((normal_members.len>0)||(line_members.len>0))
-		pipe_networks += src
+		if(!(src in pipe_networks)) //Pooling makes it disposed, which causes it to no longer process while pooled
+			pipe_networks += src
 	else
-		qdel(src)
+		returnToDPool(src)
 
 /datum/pipe_network/proc/merge(datum/pipe_network/giver)
 	if(giver==src) return 0

--- a/code/ATMOSPHERICS/datum_pipeline.dm
+++ b/code/ATMOSPHERICS/datum_pipeline.dm
@@ -11,10 +11,6 @@
 
 	var/const/PRESSURE_CHECK_DELAY=5 // 5s delay between pchecks to give pipenets time to recover.
 
-/datum/pipeline/Del()
-	Destroy()
-	return ..()
-
 /datum/pipeline/Destroy()
 	if(network) //For the pipenet rebuild
 		returnToDPool(network)

--- a/code/__HELPERS/datumpool.dm
+++ b/code/__HELPERS/datumpool.dm
@@ -66,6 +66,10 @@ var/global/list/masterdatumPool = new
 	D.Destroy()
 	D.resetVariables()
 	D.disposed = 1 //Set to stop processing while pooled
+	#ifdef DEBUG_DATUM_POOL
+	if(D in masterdatumPool["[D.type]"])
+		world << text("returnToPool has been called twice for the same datum of type [] time to panic.", D.type)
+	#endif
 	masterdatumPool["[D.type]"] += D
 
 	#ifdef DEBUG_DATUM_POOL

--- a/code/__HELPERS/datumpool.dm
+++ b/code/__HELPERS/datumpool.dm
@@ -40,6 +40,7 @@ var/global/list/masterdatumPool = new
 			O.New(arglist(B))
 		else
 			O.New()
+		O.disposed = null //Set to process once again
 	return O
 
 /*
@@ -64,6 +65,7 @@ var/global/list/masterdatumPool = new
 		masterdatumPool["[D.type]"] = list()
 	D.Destroy()
 	D.resetVariables()
+	D.disposed = 1 //Set to stop processing while pooled
 	masterdatumPool["[D.type]"] += D
 
 	#ifdef DEBUG_DATUM_POOL

--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -10,7 +10,6 @@ var/global/list/mob_list = list()					//List of all mobs, including clientless
 var/global/list/living_mob_list = list()			//List of all alive mobs, including clientless. Excludes /mob/new_player
 var/global/list/dead_mob_list = list()				//List of all dead mobs, including clientless. Excludes /mob/new_player
 
-var/global/list/cable_list = list()					//Index for all cables, so that powernets don't have to look through the entire world all the time
 var/global/list/chemical_reactions_list				//list of all /datum/chemical_reaction datums. Used during chemical reactions
 var/global/list/chemical_reagents_list				//list of all /datum/reagent datums indexed by reagent id. Used by chemistry stuff
 var/global/list/landmarks_list = list()				//list of all landmarks created

--- a/code/controllers/Processes/disease.dm
+++ b/code/controllers/Processes/disease.dm
@@ -1,3 +1,5 @@
+var/global/list/active_diseases = list()
+
 /datum/controller/process/disease
 	var/tmp/datum/updateQueue/updateQueueInstance
 

--- a/code/controllers/Processes/event.dm
+++ b/code/controllers/Processes/event.dm
@@ -1,3 +1,5 @@
+var/global/list/events = list()
+
 /datum/controller/process/event
 	var/tmp/datum/updateQueue/updateQueueInstance
 

--- a/code/controllers/Processes/machinery.dm
+++ b/code/controllers/Processes/machinery.dm
@@ -1,3 +1,5 @@
+var/global/list/machines = list()
+
 /datum/controller/process/machinery/setup()
 	name = "machinery"
 	schedule_interval = 20 // every 2 seconds

--- a/code/controllers/Processes/mob.dm
+++ b/code/controllers/Processes/mob.dm
@@ -1,3 +1,5 @@
+//Mob_List located in global_lists.dm
+
 /datum/controller/process/mob
 	var/tmp/datum/updateQueue/updateQueueInstance
 

--- a/code/controllers/Processes/obj.dm
+++ b/code/controllers/Processes/obj.dm
@@ -1,4 +1,6 @@
 var/global/list/object_profiling = list()
+var/global/list/processing_objects = list()
+
 /datum/controller/process/obj
 	var/tmp/datum/updateQueue/updateQueueInstance
 

--- a/code/controllers/Processes/pipenet.dm
+++ b/code/controllers/Processes/pipenet.dm
@@ -1,3 +1,5 @@
+var/global/list/datum/pipe_network/pipe_networks = list()
+
 /datum/controller/process/pipenet/setup()
 	name = "pipenet"
 	schedule_interval = 20 // every 2 seconds

--- a/code/controllers/Processes/power_machinery.dm
+++ b/code/controllers/Processes/power_machinery.dm
@@ -1,4 +1,5 @@
 var/global/list/power_machinery_profiling = list()
+var/global/list/power_machines = list()
 
 /datum/controller/process/power_machinery
 	var/tmp/datum/updateQueue/updateQueueInstance

--- a/code/controllers/Processes/power_machinery.dm
+++ b/code/controllers/Processes/power_machinery.dm
@@ -12,11 +12,13 @@ var/global/list/power_machines = list()
 	for(var/i = 1 to power_machines.len)
 		if(i > power_machines.len)
 			break
-		var/obj/machinery/M = power_machines[i]
+		var/obj/machinery/power/M = power_machines[i]
 		if(istype(M) && !M.gcDestroyed)
 			#ifdef PROFILE_MACHINES
 			var/time_start = world.timeofday
 			#endif
+
+			M.check_rebuild() //Checks to make sure the powernet doesn't need to be rebuilt, rebuilds it if it does
 
 			if(M.process() == PROCESS_KILL)
 				M.inMachineList = 0

--- a/code/controllers/Processes/powernet.dm
+++ b/code/controllers/Processes/powernet.dm
@@ -1,13 +1,15 @@
-var/list/powernets = list()
+var/global/list/datum/powernet/powernets = list()
 
 /datum/controller/process/powernet/setup()
 	name = "powernet"
 	schedule_interval = 20 // every 2 seconds
 
 /datum/controller/process/powernet/doWork()
+
 	for(var/obj/structure/cable/PC in cable_list)
-		if(PC.build_status == 1)
+		if(PC.build_status)
 			PC.rebuild_from()
+
 	for(var/datum/powernet/powerNetwork in powernets)
 		if(istype(powerNetwork) && !powerNetwork.disposed)
 			powerNetwork.reset()

--- a/code/controllers/Processes/powernet.dm
+++ b/code/controllers/Processes/powernet.dm
@@ -1,8 +1,13 @@
+var/list/powernets = list()
+
 /datum/controller/process/powernet/setup()
 	name = "powernet"
 	schedule_interval = 20 // every 2 seconds
 
 /datum/controller/process/powernet/doWork()
+	for(var/obj/structure/cable/PC in cable_list)
+		if(PC.build_status == 1)
+			PC.rebuild_from()
 	for(var/datum/powernet/powerNetwork in powernets)
 		if(istype(powerNetwork) && !powerNetwork.disposed)
 			powerNetwork.reset()

--- a/code/controllers/Processes/powernet.dm
+++ b/code/controllers/Processes/powernet.dm
@@ -1,4 +1,5 @@
-var/global/list/datum/powernet/powernets = list()
+var/global/list/datum/powernet/powernets = list() //Holds all powernet datums in use or pooled
+var/global/list/cable_list = list() //Index for all cables, so that powernets don't have to look through the entire world all the time
 
 /datum/controller/process/powernet/setup()
 	name = "powernet"
@@ -8,12 +9,11 @@ var/global/list/datum/powernet/powernets = list()
 
 	for(var/obj/structure/cable/PC in cable_list)
 		if(PC.build_status)
-			PC.rebuild_from()
+			PC.rebuild_from() //Does a powernet need rebuild? Lets do it!
 
 	for(var/datum/powernet/powerNetwork in powernets)
 		if(istype(powerNetwork) && !powerNetwork.disposed)
 			powerNetwork.reset()
 			scheck()
 			continue
-
 		powernets.Remove(powerNetwork)

--- a/code/datums/mixed.dm
+++ b/code/datums/mixed.dm
@@ -27,32 +27,5 @@
 	var/data = null
 
 
-
-/datum/powernet
-	var/list/cables = list()	// all cables & junctions
-	var/list/nodes = list()		// all connected machines
-	var/load = 0				// the current load on the powernet, increased by each machine at processing
-	var/newavail = 0			// what available power was gathered last tick, then becomes...
-	var/avail = 0				// ...the current available power in the powernet
-	var/viewload = 0			// the load as it appears on the power console (gradually updated)
-	var/number = 0				// Unused // TODEL
-	var/netexcess = 0			// excess power on the powernet (typically avail-load)
-
-/*
-Powernet procs :
-
-In modules/power/power.dm :
-
-/datum/powernet/New()
-/datum/powernet/Destroy()
-/datum/powernet/proc/is_empty()
-/datum/powernet/proc/remove_cable(var/obj/structure/cable/C)
-/datum/powernet/proc/add_cable(var/obj/structure/cable/C)
-/datum/powernet/proc/remove_machine(var/obj/machinery/power/M)
-/datum/powernet/proc/add_machine(var/obj/machinery/power/M)
-/datum/powernet/proc/reset()
-/datum/powernet/proc/get_electrocute_damage()
-*/
-
 /datum/debug
 	var/list/debuglist

--- a/code/game/gamemodes/meteor/meteor.dm
+++ b/code/game/gamemodes/meteor/meteor.dm
@@ -34,7 +34,6 @@
 	return 0
 
 /datum/game_mode/meteor/post_setup()
-	defer_powernet_rebuild = 2//Might help with the lag
 
 		//Let's set up the announcement and meteor delay immediatly to send to admins and use later
 	meteorannouncedelay = rand((meteorannouncedelay_l/600), (meteorannouncedelay_h/600))*600 //Minute interval for simplicity

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -83,10 +83,6 @@
 		var/datum/controller/process/lighting = processScheduler.getProcess("lighting")
 		lighting.disable()
 
-		var/powernet_rebuild_was_deferred_already = defer_powernet_rebuild
-		if(defer_powernet_rebuild != 2)
-			defer_powernet_rebuild = 1
-
 		if(heavy_impact_range > 1)
 			var/datum/effect/system/explosion/E = new/datum/effect/system/explosion()
 			E.set_up(epicenter)
@@ -126,10 +122,6 @@
 		sleep(8)
 
 		lighting.enable()
-
-		if(!powernet_rebuild_was_deferred_already)
-			if(defer_powernet_rebuild != 2)
-				defer_powernet_rebuild = 0
 
 	return 1
 

--- a/code/game/objects/items/stacks/cable.dm
+++ b/code/game/objects/items/stacks/cable.dm
@@ -156,7 +156,7 @@ var/global/list/datum/stack_recipe/cable_recipes = list ( \
 		C.update_icon()
 
 		//create a new powernet with the cable, if needed it will be merged later
-		var/datum/powernet/PN = new()
+		var/datum/powernet/PN = getFromDPool(/datum/powernet)
 		PN.add_cable(C)
 
 		C.mergeConnectedNetworks(C.d2)		// merge the powernet with adjacents powernets

--- a/code/global.dm
+++ b/code/global.dm
@@ -7,18 +7,6 @@ var/global/list/type_instances[0]
 /var/global/datum/map/active/map = new() //Current loaded map
 //Defined in its .dm, see maps/_map.dm for more info.
 
-//FIXME: These are lists of things that get called every tick.
-// All of these badly need optimizing, half of them don't
-// actually need to be called every tick, many of them busy-wait
-// (come on people we're not writing assembly), and many should
-// be using tickers instead (eg narsie, singulo). Major target
-// for cutting down on lag and boosting overall performance.
-var/global/list/machines = list()
-var/global/list/power_machines = list()
-var/global/list/processing_objects = list()
-var/global/list/active_diseases = list()
-var/global/list/events = list()
-
 var/global/obj/effect/datacore/data_core = null
 var/global/obj/effect/overlay/plmaster = null
 var/global/obj/effect/overlay/slmaster = null

--- a/code/global.dm
+++ b/code/global.dm
@@ -25,8 +25,6 @@ var/global/obj/effect/overlay/slmaster = null
 
 var/global/list/account_DBs = list()
 
-var/global/defer_powernet_rebuild = 0		// true if net rebuild will be called manually after an event
-
 // Used only by space turfs. TODO: Remove.
 // The comment below is no longer accurate.
 var/global/list/global_map = null
@@ -232,7 +230,6 @@ var/list/OOClog = list()
 var/list/adminlog = list()
 
 var/suspend_alert = 0
-var/list/powernets = list()
 
 var/Debug = 0	// global debug switch
 var/Debug2 = 0

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -488,7 +488,7 @@
 		user << "You begin to cut the cables..."
 		playsound(get_turf(src), 'sound/items/Deconstruct.ogg', 50, 1)
 		if(do_after(user, 50))
-			if (prob(50) && electrocute_mob(usr, terminal.powernet, terminal))
+			if (prob(50) && electrocute_mob(usr, terminal.get_powernet(), terminal))
 				var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
 				s.set_up(5, 1, src)
 				s.start()
@@ -997,7 +997,7 @@
 		return 0
 
 /obj/machinery/power/apc/add_load(var/amount)
-	if(terminal && terminal.powernet)
+	if(terminal && terminal.get_powernet())
 		terminal.powernet.load += amount
 
 /obj/machinery/power/apc/avail()

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -239,24 +239,36 @@ By design, d1 is the smallest direction and d2 is the highest
 ///////////////////////////////////////////
 
 /obj/structure/cable/proc/add_avail(var/amount)
+	check_rebuild()
 	if(powernet)
 		powernet.newavail += amount
 
 /obj/structure/cable/proc/add_load(var/amount)
+	check_rebuild()
 	if(powernet)
 		powernet.load += amount
 
 /obj/structure/cable/proc/surplus()
+	check_rebuild()
 	if(powernet)
 		return powernet.avail-powernet.load
 	else
 		return 0
 
 /obj/structure/cable/proc/avail()
+	check_rebuild()
 	if(powernet)
 		return powernet.avail
 	else
 		return 0
+
+/obj/structure/cable/proc/check_rebuild()
+	if(build_status == 0)
+		return
+	var/list/cables = locate(/obj/structure/cable/) in loc
+	for(var/obj/structure/cable/C in cables)
+		if(C.build_status == 1)
+			C.rebuild_from()
 
 /////////////////////////////////////////////////
 // Cable laying helpers
@@ -441,6 +453,7 @@ By design, d1 is the smallest direction and d2 is the highest
 		if(PN.is_empty()) // can happen with machines made nodeless when smoothing cables
 			returnToDPool(PN) //powernets do not get qdelled
 
+/* No longer used due to applying the pipenet method of rebuilding when needed or during the next powernet tick
 // cut the cable's powernet at this cable and updates the powergrid
 /obj/structure/cable/proc/cut_cable_from_powernet()
 	var/turf/T1 = loc
@@ -476,3 +489,4 @@ By design, d1 is the smallest direction and d2 is the highest
 		for(var/obj/machinery/power/P in T1)
 			if(!P.connect_to_network()) // can't find a node cable on a the turf to connect to
 				P.disconnect_from_network() // remove from current network
+*/

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -15,6 +15,9 @@
 	idle_power_usage = 0
 	active_power_usage = 0
 
+	//For powernet rebuilding
+	var/build_status = 0 //1 means it needs rebuilding during the next tick or on usage
+
 /obj/machinery/power/New()
 	. = ..()
 	machines -= src
@@ -32,24 +35,36 @@
 
 // common helper procs for all power machines
 /obj/machinery/power/proc/add_avail(var/amount)
+	check_rebuild()
 	if(powernet)
 		powernet.newavail += amount
 
 /obj/machinery/power/proc/add_load(var/amount)
+	check_rebuild()
 	if(powernet)
 		powernet.load += amount
 
 /obj/machinery/power/proc/surplus()
+	check_rebuild()
 	if(powernet)
 		return powernet.avail-powernet.load
 	else
 		return 0
 
 /obj/machinery/power/proc/avail()
+	check_rebuild()
 	if(powernet)
 		return powernet.avail
 	else
 		return 0
+
+/obj/machinery/power/proc/check_rebuild()
+	if(build_status == 0)
+		return
+	var/list/cables = locate(/obj/structure/cable/) in loc
+	for(var/obj/structure/cable/C in cables)
+		if(C.build_status == 1)
+			C.rebuild_from()
 
 /obj/machinery/power/proc/disconnect_terminal() // machines without a terminal will just return, no harm no fowl.
 	return
@@ -98,6 +113,9 @@
 
 	var/obj/structure/cable/C = T.get_cable_node() // check if we have a node cable on the machine turf, the first found is picked
 
+	if(C && C.build_status == 1)
+		C.rebuild_from()
+
 	if(!C || !C.powernet)
 		return 0
 
@@ -107,6 +125,7 @@
 // remove and disconnect the machine from its current powernet
 /obj/machinery/power/proc/disconnect_from_network()
 	if(!powernet)
+		build_status = 0
 		return 0
 
 	powernet.remove_machine(src)
@@ -161,271 +180,6 @@
 
 		if(C.d1 == 0) // the cable is a node cable
 			. += C
-
-///////////////////////////////////////////
-// GLOBAL PROCS for powernets handling
-//////////////////////////////////////////
-
-// returns a list of all power-related objects (nodes, cable, junctions) in turf,
-// excluding source, that match the direction d
-// if unmarked==1, only return those with no powernet
-/proc/power_list(var/turf/T, var/source, var/d, var/unmarked=0, var/cable_only = 0)
-	. = list()
-	//var/fdir = (!d) ? 0 : turn(d, 180)			// the opposite direction to d (or 0 if d==0)
-
-	for(var/AM in T)
-		if(AM == source)						// we don't want to return source
-			continue
-
-		if(!cable_only && istype(AM, /obj/machinery/power))
-			var/obj/machinery/power/P = AM
-
-			if(P.powernet == 0)					// exclude APCs which have powernet = 0
-				continue
-
-			if(!unmarked || !P.powernet)		// if unmarked=1 we only return things with no powernet
-				if(d == 0)
-					. += P
-		else if(istype(AM,/obj/structure/cable))
-			var/obj/structure/cable/C = AM
-
-			if(!unmarked || !C.powernet)
-				if(C.d1 == d || C.d2 == d)
-					. += C
-
-// rebuild all power networks from scratch - only called at world creation or by the admin verb
-/proc/makepowernets()
-	for(var/datum/powernet/PN in powernets)
-		del(PN)
-
-	powernets.len = 0
-
-	for(var/obj/structure/cable/PC in cable_list)
-		if(!PC.powernet)
-			var/datum/powernet/NewPN = new()
-			NewPN.add_cable(PC)
-			propagate_network(PC, PC.powernet)
-
-// remove the old powernet and replace it with a new one throughout the network.
-/proc/propagate_network(var/obj/O, var/datum/powernet/PN)
-	//world.log << "propagating new network"
-	var/list/worklist = list()
-	var/list/found_machines = list()
-	var/index = 1
-	var/obj/P = null
-
-	worklist += O									// start propagating from the passed object
-
-	while(index <= worklist.len)					//until we've exhausted all power objects
-		P = worklist[index]							//get the next power object found
-		index++
-
-		if(istype(P, /obj/structure/cable))
-			var/obj/structure/cable/C = P
-
-			if(C.powernet != PN)					// add it to the powernet, if it isn't already there
-				PN.add_cable(C)
-
-			worklist |= C.get_connections()	//get adjacents power objects, with or without a powernet
-		else if(P.anchored && istype(P, /obj/machinery/power))
-			var/obj/machinery/power/M = P
-			found_machines |= M						// we wait until the powernet is fully propagates to connect the machines
-		else
-			continue
-
-	// now that the powernet is set, connect found machines to it
-	for(var/obj/machinery/power/PM in found_machines)
-		if(!PM.connect_to_network())				// couldn't find a node on its turf...
-			PM.disconnect_from_network()			//... so disconnect if already on a powernet
-
-// merge two powernets, the bigger (in cable length term) absorbing the other
-/proc/merge_powernets(datum/powernet/net1, datum/powernet/net2)
-	if(!net1 || !net2)									// if one of the powernet doesn't exist, return
-		return
-
-	if(net1 == net2)									// don't merge same powernets
-		return
-
-	// we assume net1 is larger. If net2 is in fact larger we are just going to make them switch places to reduce on code.
-	if(net1.cables.len < net2.cables.len)				//net2 is larger than net1. Let's switch them around
-		var/temp = net1
-		net1 = net2
-		net2 = temp
-
-	// merge net2 into net1
-	for(var/obj/structure/cable/Cable in net2.cables) // merge cables
-		net1.add_cable(Cable)
-
-	if(net2) // not nulled, there are still nodes need to be merged
-		for(var/obj/machinery/power/Node in net2.nodes) // merge power machines
-			if(!Node.connect_to_network())
-				Node.disconnect_from_network() // if somehow we can't connect the machine to the new powernet, disconnect it from the old nonetheless
-
-	return net1
-
-// determines how strong could be shock, deals damage to mob, uses power.
-// M is a mob who touched wire/whatever
-// power_source is a source of electricity, can be powercell, area, apc, cable, powernet or null
-// source is an object caused electrocuting (airlock, grille, etc)
-// no animations will be performed by this proc.
-/proc/electrocute_mob(mob/living/carbon/M, power_source, obj/source, siemens_coeff = 1.0)
-	if(istype(M.loc, /obj/mecha))											// feckin mechs are dumb
-		return 0
-
-	if(istype(M, /mob/living/carbon/human))
-		var/mob/living/carbon/human/H = M
-
-		if(H.gloves)
-			var/obj/item/clothing/gloves/G = H.gloves
-
-			if(G.siemens_coefficient == 0)									// to avoid spamming with insulated glvoes on
-				return 0
-
-	var/area/source_area
-
-	if(isarea(power_source))
-		source_area = power_source
-		power_source = source_area.get_apc()
-
-	if(istype(power_source, /obj/structure/cable))
-		var/obj/structure/cable/Cable = power_source
-		power_source = Cable.powernet
-
-	var/datum/powernet/PN
-	var/obj/item/weapon/cell/cell
-
-	if(istype(power_source, /datum/powernet))
-		PN = power_source
-	else if(istype(power_source, /obj/item/weapon/cell))
-		cell = power_source
-	else if(istype(power_source, /obj/machinery/power/apc))
-		var/obj/machinery/power/apc/apc = power_source
-		cell = apc.cell
-
-		if(apc.terminal)
-			PN = apc.terminal.powernet
-	else if(!power_source)
-		return 0
-	else
-		log_admin("ERROR: /proc/electrocute_mob([M], [power_source], [source]): wrong power_source")
-		return 0
-
-	if(!cell && !PN)
-		return 0
-
-	var/PN_damage = 0
-	var/cell_damage = 0
-
-	if(PN)
-		PN_damage = PN.get_electrocute_damage()
-
-	if(cell)
-		cell_damage = cell.get_electrocute_damage()
-
-	var/shock_damage = 0
-
-	if(PN_damage >= cell_damage)
-		power_source = PN
-		shock_damage = PN_damage
-	else
-		power_source = cell
-		shock_damage = cell_damage
-
-	var/drained_hp = M.electrocute_act(shock_damage, source, siemens_coeff)	//zzzzzzap!
-	var/drained_energy = drained_hp * 20
-
-	if(source_area)
-		source_area.use_power(drained_energy / CELLRATE)
-	else if(istype(power_source, /datum/powernet))
-		var/drained_power = drained_energy / CELLRATE						// convert from "joules" to "watts"
-		PN.load += drained_power
-	else if(istype(power_source, /obj/item/weapon/cell))
-		cell.use(drained_energy)
-
-	return drained_energy
-
-////////////////////////////////////////////
-// POWERNET DATUM PROCS
-// each contiguous network of cables & nodes
-////////////////////////////////////////////
-
-/datum/powernet/New()
-	powernets += src
-
-/datum/powernet/Destroy()
-	powernets -= src
-
-/datum/powernet/proc/is_empty()
-	return !cables.len && !nodes.len
-
-// remove a cable from the current powernet
-// if the powernet is then empty, delete it
-// warning : this proc DON'T check if the cable exists
-/datum/powernet/proc/remove_cable(obj/structure/cable/C)
-	cables -= C
-	C.powernet = null
-
-	if(is_empty())	// the powernet is now empty...
-		del(src)	// ... delete it
-
-// add a cable to the current powernet
-// warning : this proc DON'T check if the cable exists
-/datum/powernet/proc/add_cable(obj/structure/cable/C)
-	if(C.powernet)						// if C already has a powernet...
-		if(C.powernet == src)
-			return
-		else
-			C.powernet.remove_cable(C)	// ..remove it
-
-	C.powernet = src
-	cables += C
-
-// remove a power machine from the current powernet
-// if the powernet is then empty, delete it
-// warning : this proc DON'T check if the machine exists
-/datum/powernet/proc/remove_machine(obj/machinery/power/M)
-	nodes -= M
-	M.powernet = null
-
-	if(is_empty())	// the powernet is now empty...
-		del(src)	// ... delete it
-
-// add a power machine to the current powernet
-// warning : this proc DON'T check if the machine exists
-/datum/powernet/proc/add_machine(obj/machinery/power/M)
-	if(M.powernet)							// if M already has a powernet...
-		if(M.powernet == src)
-			return
-		else
-			M.disconnect_from_network()		// ..remove it
-
-	M.powernet = src
-	nodes += M
-
-// handles the power changes in the powernet
-// called every ticks by the powernet controller
-/datum/powernet/proc/reset()
-	// see if there's a surplus of power remaining in the powernet and stores unused power in the SMES
-	netexcess = avail - load
-
-	if(netexcess > 100 && nodes && nodes.len) // if there was excess power last cycle
-		for(var/obj/machinery/power/smes/S in nodes) // find the SMESes in the network
-			S.restore() // and restore some of the power that was used
-
-	// updates the viewed load (as seen on power computers)
-	viewload = 0.8 * viewload + 0.2 * load
-	viewload = round(viewload)
-
-	// reset the powernet
-	load = 0
-	avail = newavail
-	newavail = 0
-
-/datum/powernet/proc/get_electrocute_damage()
-	// cube root of power times 1,5 to 2 in increments of 10^-1
-	// for instance, gives an average of 38 damage for 10k W, 81 damage for 100k W and 175 for 1M W
-	// best you're getting with BYOND's mathematical funcs. Not even a fucking exponential or neperian logarithm
-	return round(avail ** (1 / 3) * (rand(100, 125) / 100))
 
 ////////////////////////////////////////////////
 // Misc.

--- a/code/modules/power/powernet.dm
+++ b/code/modules/power/powernet.dm
@@ -1,0 +1,330 @@
+//Powernets
+/datum/powernet
+	var/list/obj/structure/cable/cables = list()	// all cables & junctions
+	var/list/obj/machinery/power/nodes = list()		// all connected machines
+	var/load = 0				// the current load on the powernet, increased by each machine at processing
+	var/newavail = 0			// what available power was gathered last tick, then becomes...
+	var/avail = 0				// ...the current available power in the powernet
+	var/viewload = 0			// the load as it appears on the power console (gradually updated)
+	var/number = 0
+	var/netexcess = 0			// excess power on the powernet (typically avail-load)
+
+////////////////////////////////////////////
+// POWERNET DATUM PROCS
+// each contiguous network of cables & nodes
+////////////////////////////////////////////
+
+/datum/powernet/New()
+	powernets += src
+
+/datum/powernet/Destroy()
+	powernets -= src
+	for(var/obj/structure/cable/C in cables)
+		remove_cable(C)
+	for(var/obj/machinery/power/P in nodes)
+		remove_machine(P)
+
+/datum/powernet/resetVariables()
+	..("cables","nodes")
+	cables = list()
+	nodes = list()
+
+/datum/powernet/proc/is_empty()
+	return !cables.len && !nodes.len
+
+// remove a cable from the current powernet
+// if the powernet is then empty, delete it
+// warning : this proc DON'T check if the cable exists
+/datum/powernet/proc/remove_cable(obj/structure/cable/C)
+	cables -= C
+	C.powernet = null
+
+	if(is_empty())	// the powernet is now empty...
+		returnToDPool(src)	// ... delete it
+
+// add a cable to the current powernet
+// warning : this proc DON'T check if the cable exists
+/datum/powernet/proc/add_cable(obj/structure/cable/C)
+	if(!C)
+		return 1
+	if(C.powernet)						// if C already has a powernet...
+		if(C.powernet == src)
+			return
+		else
+			C.powernet.remove_cable(C)	// ..remove it
+
+	C.build_status = 0
+	C.powernet = src
+	cables += C
+
+// remove a power machine from the current powernet
+// if the powernet is then empty, delete it
+// warning : this proc DON'T check if the machine exists
+/datum/powernet/proc/remove_machine(obj/machinery/power/M)
+	nodes -= M
+	M.powernet = null
+
+	if(is_empty())	// the powernet is now empty...
+		returnToDPool(src)	// ... delete it
+
+// add a power machine to the current powernet
+// warning : this proc DON'T check if the machine exists
+/datum/powernet/proc/add_machine(obj/machinery/power/M)
+	if(M.powernet)							// if M already has a powernet...
+		if(M.powernet == src)
+			return
+		else
+			M.disconnect_from_network()		// ..remove it
+
+	M.powernet = src
+	nodes += M
+
+// handles the power changes in the powernet
+// called every ticks by the powernet controller
+/datum/powernet/proc/reset()
+	// see if there's a surplus of power remaining in the powernet and stores unused power in the SMES
+	netexcess = avail - load
+
+	if(netexcess > 100 && nodes && nodes.len) // if there was excess power last cycle
+		for(var/obj/machinery/power/smes/S in nodes) // find the SMESes in the network
+			S.restore() // and restore some of the power that was used
+
+	// updates the viewed load (as seen on power computers)
+	viewload = 0.8 * viewload + 0.2 * load
+	viewload = round(viewload)
+
+	// reset the powernet
+	load = 0
+	avail = newavail
+	newavail = 0
+
+/datum/powernet/proc/get_electrocute_damage()
+	// cube root of power times 1,5 to 2 in increments of 10^-1
+	// for instance, gives an average of 38 damage for 10k W, 81 damage for 100k W and 175 for 1M W
+	// best you're getting with BYOND's mathematical funcs. Not even a fucking exponential or neperian logarithm
+	return round(avail ** (1 / 3) * (rand(100, 125) / 100))
+
+/datum/powernet/proc/set_to_build()
+	for(var/obj/structure/cable/C in cables)
+		C.build_status = 1
+		C.oldload = load
+		C.oldavail = avail
+		C.oldnewavail = newavail
+	for(var/obj/machinery/power/P in nodes)
+		P.build_status = 1
+	returnToDPool(src)
+
+//This should rebuild a powernet properly during a new ticks cycle
+/obj/structure/cable/proc/rebuild_from()
+	if(!powernet)
+		var/datum/powernet/NewPN = getFromDPool(/datum/powernet)
+		NewPN.add_cable(src)
+		propagate_network(src, src.powernet)
+		NewPN.load = oldload
+		NewPN.avail = oldavail
+		NewPN.newavail = oldnewavail //Ha
+		NewPN.netexcess = oldavail - oldload
+		for(var/obj/structure/cable/C in NewPN.cables)
+			C.oldload = 0
+			C.oldavail = 0
+			C.oldnewavail = 0
+
+/*
+Powernet procs :
+
+In modules/power/power.dm :
+
+/datum/powernet/New()
+/datum/powernet/Destroy()
+/datum/powernet/proc/is_empty()
+/datum/powernet/proc/remove_cable(var/obj/structure/cable/C)
+/datum/powernet/proc/add_cable(var/obj/structure/cable/C)
+/datum/powernet/proc/remove_machine(var/obj/machinery/power/M)
+/datum/powernet/proc/add_machine(var/obj/machinery/power/M)
+/datum/powernet/proc/reset()
+/datum/powernet/proc/get_electrocute_damage()
+*/
+
+
+///////////////////////////////////////////
+// GLOBAL PROCS for powernets handling
+//////////////////////////////////////////
+
+// returns a list of all power-related objects (nodes, cable, junctions) in turf,
+// excluding source, that match the direction d
+// if unmarked==1, only return those with no powernet
+/proc/power_list(var/turf/T, var/source, var/d, var/unmarked=0, var/cable_only = 0)
+	. = list()
+	//var/fdir = (!d) ? 0 : turn(d, 180)			// the opposite direction to d (or 0 if d==0)
+
+	for(var/AM in T)
+		if(AM == source)						// we don't want to return source
+			continue
+
+		if(!cable_only && istype(AM, /obj/machinery/power))
+			var/obj/machinery/power/P = AM
+
+			if(P.powernet == 0)					// exclude APCs which have powernet = 0
+				continue
+
+			if(!unmarked || !P.powernet)		// if unmarked=1 we only return things with no powernet
+				if(d == 0)
+					. += P
+		else if(istype(AM,/obj/structure/cable))
+			var/obj/structure/cable/C = AM
+
+			if(!unmarked || !C.powernet)
+				if(C.d1 == d || C.d2 == d)
+					. += C
+
+// rebuild all power networks from scratch - only called at world creation or by the admin verb
+/proc/makepowernets()
+	for(var/datum/powernet/PN in powernets)
+		returnToDPool(src)
+
+	powernets.len = 0
+
+	for(var/obj/structure/cable/PC in cable_list)
+		if(!PC.powernet)
+			var/datum/powernet/NewPN = getFromDPool(/datum/powernet/)
+			powernets += NewPN
+			NewPN.add_cable(PC)
+			propagate_network(PC, PC.powernet)
+
+// remove the old powernet and replace it with a new one throughout the network.
+/proc/propagate_network(var/obj/O, var/datum/powernet/PN)
+	//world.log << "propagating new network"
+	var/list/worklist = list()
+	var/list/found_machines = list()
+	var/index = 1
+	var/obj/P = null
+
+	worklist += O									// start propagating from the passed object
+
+	while(index <= worklist.len)					//until we've exhausted all power objects
+		P = worklist[index]							//get the next power object found
+		index++
+
+		if(istype(P, /obj/structure/cable))
+			var/obj/structure/cable/C = P
+
+			if(C.powernet != PN)					// add it to the powernet, if it isn't already there
+				PN.add_cable(C)
+
+			worklist |= C.get_connections()	//get adjacents power objects, with or without a powernet
+		else if(P.anchored && istype(P, /obj/machinery/power))
+			var/obj/machinery/power/M = P
+			found_machines |= M						// we wait until the powernet is fully propagates to connect the machines
+		else
+			continue
+
+	// now that the powernet is set, connect found machines to it
+	for(var/obj/machinery/power/PM in found_machines)
+		if(!PM.connect_to_network())				// couldn't find a node on its turf...
+			PM.disconnect_from_network()			//... so disconnect if already on a powernet
+
+// merge two powernets, the bigger (in cable length term) absorbing the other
+/proc/merge_powernets(datum/powernet/net1, datum/powernet/net2)
+	if(!net1 || !net2)									// if one of the powernet doesn't exist, return
+		return
+
+	if(net1 == net2)									// don't merge same powernets
+		return
+
+	// we assume net1 is larger. If net2 is in fact larger we are just going to make them switch places to reduce on code.
+	if(net1.cables.len < net2.cables.len)				//net2 is larger than net1. Let's switch them around
+		var/temp = net1
+		net1 = net2
+		net2 = temp
+
+	// merge net2 into net1
+	for(var/obj/structure/cable/Cable in net2.cables) // merge cables
+		net1.add_cable(Cable)
+
+	if(net2) // not nulled, there are still nodes need to be merged
+		for(var/obj/machinery/power/Node in net2.nodes) // merge power machines
+			if(!Node.connect_to_network())
+				Node.disconnect_from_network() // if somehow we can't connect the machine to the new powernet, disconnect it from the old nonetheless
+
+	return net1
+
+// determines how strong could be shock, deals damage to mob, uses power.
+// M is a mob who touched wire/whatever
+// power_source is a source of electricity, can be powercell, area, apc, cable, powernet or null
+// source is an object caused electrocuting (airlock, grille, etc)
+// no animations will be performed by this proc.
+/proc/electrocute_mob(mob/living/carbon/M, power_source, obj/source, siemens_coeff = 1.0)
+	if(istype(M.loc, /obj/mecha))											// feckin mechs are dumb
+		return 0
+
+	if(istype(M, /mob/living/carbon/human))
+		var/mob/living/carbon/human/H = M
+
+		if(H.gloves)
+			var/obj/item/clothing/gloves/G = H.gloves
+
+			if(G.siemens_coefficient == 0)									// to avoid spamming with insulated glvoes on
+				return 0
+
+	var/area/source_area
+
+	if(isarea(power_source))
+		source_area = power_source
+		power_source = source_area.get_apc()
+
+	if(istype(power_source, /obj/structure/cable))
+		var/obj/structure/cable/Cable = power_source
+		power_source = Cable.powernet
+
+	var/datum/powernet/PN
+	var/obj/item/weapon/cell/cell
+
+	if(istype(power_source, /datum/powernet))
+		PN = power_source
+	else if(istype(power_source, /obj/item/weapon/cell))
+		cell = power_source
+	else if(istype(power_source, /obj/machinery/power/apc))
+		var/obj/machinery/power/apc/apc = power_source
+		cell = apc.cell
+
+		if(apc.terminal)
+			PN = apc.terminal.powernet
+	else if(!power_source)
+		return 0
+	else
+		log_admin("ERROR: /proc/electrocute_mob([M], [power_source], [source]): wrong power_source")
+		return 0
+
+	if(!cell && !PN)
+		return 0
+
+	var/PN_damage = 0
+	var/cell_damage = 0
+
+	if(PN)
+		PN_damage = PN.get_electrocute_damage()
+
+	if(cell)
+		cell_damage = cell.get_electrocute_damage()
+
+	var/shock_damage = 0
+
+	if(PN_damage >= cell_damage)
+		power_source = PN
+		shock_damage = PN_damage
+	else
+		power_source = cell
+		shock_damage = cell_damage
+
+	var/drained_hp = M.electrocute_act(shock_damage, source, siemens_coeff)	//zzzzzzap!
+	var/drained_energy = drained_hp * 20
+
+	if(source_area)
+		source_area.use_power(drained_energy / CELLRATE)
+	else if(istype(power_source, /datum/powernet))
+		var/drained_power = drained_energy / CELLRATE						// convert from "joules" to "watts"
+		PN.load += drained_power
+	else if(istype(power_source, /obj/item/weapon/cell))
+		cell.use(drained_energy)
+
+	return drained_energy

--- a/code/modules/power/powernet.dm
+++ b/code/modules/power/powernet.dm
@@ -15,10 +15,14 @@
 ////////////////////////////////////////////
 
 /datum/powernet/New()
-	powernets += src
+	if(!(src in powernets)) //Pooling changes a disposed variable to 1, causing it to no longer process from the list
+		powernets += src
+
+/datum/powernet/Del()
+	powernets -= src
+	..()
 
 /datum/powernet/Destroy()
-	powernets -= src
 	for(var/obj/structure/cable/C in cables)
 		remove_cable(C)
 	for(var/obj/machinery/power/P in nodes)
@@ -123,7 +127,6 @@
 		NewPN.load = oldload
 		NewPN.avail = oldavail
 		NewPN.newavail = oldnewavail //Ha
-		NewPN.netexcess = oldavail - oldload
 		for(var/obj/structure/cable/C in NewPN.cables)
 			C.oldload = 0
 			C.oldavail = 0
@@ -182,12 +185,9 @@ In modules/power/power.dm :
 	for(var/datum/powernet/PN in powernets)
 		returnToDPool(src)
 
-	powernets.len = 0
-
 	for(var/obj/structure/cable/PC in cable_list)
 		if(!PC.powernet)
 			var/datum/powernet/NewPN = getFromDPool(/datum/powernet/)
-			powernets += NewPN
 			NewPN.add_cable(PC)
 			propagate_network(PC, PC.powernet)
 

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -122,7 +122,7 @@
 	..()
 
 /obj/machinery/power/emitter/update_icon()
-	if (active && powernet && avail(active_power_usage))
+	if (active && get_powernet() && avail(active_power_usage))
 		icon_state = "emitter_+a"
 	else
 		icon_state = "emitter"
@@ -134,7 +134,7 @@
 		return
 	src.add_fingerprint(user)
 	if(state == 2)
-		if(!powernet)
+		if(!get_powernet())
 			user << "The emitter isn't connected to a wire."
 			return 1
 		if(!src.locked)
@@ -173,7 +173,7 @@
 	return 0
 
 /obj/machinery/power/emitter/process()
-	if(!anchored)
+	if(!anchored) //If it got unanchored "inexplicably"... fucking badmins
 		active = 0
 		update_icon()
 		update_beam()
@@ -181,23 +181,25 @@
 	if(stat & BROKEN)
 		return
 
-	if(state != 2 || (!powernet && active_power_usage))
+	if(state != 2 || (!powernet && active_power_usage)) //Not welded to the floor, or no more wire underneath and requires power
 		active = 0
 		update_icon()
 		update_beam()
 		return
 
-	if(((last_shot + fire_delay) <= world.time) && (active == 1))
-		if(!active_power_usage || avail(active_power_usage))
-			add_load(active_power_usage)
+	if(((last_shot + fire_delay) <= world.time) && (active == 1)) //It's currently activated and it hasn't processed in a bit
+		if(!active_power_usage || avail(active_power_usage)) //Doesn't require power or powernet has enough supply
+			add_load(active_power_usage) //Drain it then bitch
 
-			if(!powered)
+			if(!powered) //Yay its powered
 				powered = 1
 				update_icon()
 				investigation_log(I_SINGULO,"regained power and turned <font color='green'>on</font>")
 		else
-			if(powered)
+			if(powered) //Fuck its not anymore
 				powered = 0
+				active = 0 //Whelp time to kill it then
+				update_beam() //Update its beam and icon
 				update_icon()
 				investigation_log(I_SINGULO,"lost power and turned <font color='red'>off</font>")
 			return

--- a/code/modules/power/singularity/narsie.dm
+++ b/code/modules/power/singularity/narsie.dm
@@ -87,12 +87,8 @@ var/global/list/narsie_list = list()
 /obj/machinery/singularity/narsie/large/eat()
 	set background = BACKGROUND_ENABLED
 
-	if (defer_powernet_rebuild != 2)
-		defer_powernet_rebuild = 1
 	for (var/turf/A in orange(consume_range, src))
 		consume(A)
-	if (defer_powernet_rebuild != 2)
-		defer_powernet_rebuild = 0
 
 /obj/machinery/singularity/narsie/mezzer()
 	for(var/mob/living/carbon/M in oviewers(8, src))
@@ -405,14 +401,8 @@ var/global/list/narsie_list = list()
 /obj/machinery/singularity/narsie/wizard/eat()
 	set background = BACKGROUND_ENABLED
 
-	if (defer_powernet_rebuild != 2)
-		defer_powernet_rebuild = 1
-
 	for (var/turf/T in trange(consume_range, src))
 		consume(T)
-
-	if (defer_powernet_rebuild != 2)
-		defer_powernet_rebuild = 0
 
 /**
  * MR. CLEAN

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -282,10 +282,6 @@
 /obj/machinery/singularity/proc/eat()
 	set background = BACKGROUND_ENABLED
 
-
-	if (defer_powernet_rebuild != 2)
-		defer_powernet_rebuild = 1
-
 	for(var/atom/X in orange(grav_pull, src))
 		var/dist = get_dist(X, src)
 		var/obj/machinery/singularity/S = src
@@ -298,9 +294,6 @@
 
 	//for (var/turf/T in trange(grav_pull, src)) // TODO: Create a similar trange for orange to prevent snowflake of self check.
 	//	consume(T)
-
-	if (defer_powernet_rebuild != 2)
-		defer_powernet_rebuild = 0
 
 	return
 /*

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -121,7 +121,7 @@
 			user << "You begin to cut the cables..."
 			playsound(get_turf(src), 'sound/items/Deconstruct.ogg', 50, 1)
 			if(do_after(user, 50))
-				if (prob(50) && electrocute_mob(usr, terminal.powernet, terminal))
+				if (prob(50) && electrocute_mob(usr, terminal.get_powernet(), terminal))
 					var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
 					s.set_up(5, 1, src)
 					s.start()
@@ -238,7 +238,7 @@
 		updateicon()
 
 /obj/machinery/power/smes/add_load(var/amount)
-	if(terminal && terminal.powernet)
+	if(terminal && terminal.get_powernet())
 		terminal.powernet.load += amount
 
 /obj/machinery/power/smes/attack_ai(mob/user)

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -7,12 +7,6 @@ var/list/solars_list = list()
 	icon = 'icons/obj/power.dmi'
 	density = 1
 
-/obj/machinery/power/proc/getPowernetNodes()
-	if(!powernet)
-		return list()
-
-	return powernet.nodes
-
 /obj/machinery/power/solar/New(loc)
 	..(loc)
 	solars_list += src

--- a/code/modules/power/solars/control.dm
+++ b/code/modules/power/solars/control.dm
@@ -20,7 +20,7 @@
 /obj/machinery/power/solar/control/initialize()
 	..()
 
-	if(powernet)
+	if(get_powernet())
 		set_panels(cdir)
 
 /obj/machinery/power/solar/control/Destroy()


### PR DESCRIPTION
This sets to put right the 'optimization' someone made to powernets a long time ago so that they could handle large explosions. Unfortunately the "defer powernet rebuild" never actually rebuilt the powernets causing them to simply pretend powernets were connected when destroyed by explosions or singularities.

At some point this problem has been further exacerbated to the point where disconnecting powernets doesn't work in the first place. So this PR aims to take a hybrid of the pipenet method of datum networks.

1. Expand properly when adding something to the powernet (pipenets currently dont do this for shame)
2. When the powernet is destroyed by cutting or explosions or something, null the powernet out and store some data about it in the cables
3. When the powernet is used by a machine/cable or by the next tick, rebuild it from the cables giving it its old properties for the new tick update

To be clear: this has no performance gain or loss on the primary server, because the primary server uses defer_powernet_rebuild which results in the same performance but bugs out powernets. Whereas this doesn't bug out powernets.

Also on a related note, this makes make powernets not be slow.

Fixes #3388
Fixes #3368
Fixes #3266