### PR TITLE
Plasmaman Mining Suits & Goliath Hides

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -411,7 +411,7 @@
 
 /obj/item/asteroid/goliath_hide/afterattack(atom/target, mob/user, proximity_flag)
 	if(proximity_flag)
-		if(istype(target, /obj/item/clothing/suit/space/rig/mining) || istype(target, /obj/item/clothing/head/helmet/space/rig/mining))
+		if(istype(target, /obj/item/clothing/suit/space/rig/mining) || istype(target, /obj/item/clothing/head/helmet/space/rig/mining) || istype(target, /obj/item/clothing/suit/space/plasmaman/miner) || istype(target, /obj/item/clothing/head/helmet/space/plasmaman/miner))
 			var/obj/item/clothing/C = target
 			var/current_armor = C.armor
 			if(current_armor.["melee"] < 90)

--- a/html/changelogs/Boxe-plasmaman_goliathhides.yml
+++ b/html/changelogs/Boxe-plasmaman_goliathhides.yml
@@ -1,0 +1,4 @@
+author: Boxed
+delete-after: True
+changes:
+	- tweak: Plasmaman mining suits can now be upgraded with goliath hides. Takes 6 hides compared to the normal 5 to reach 90 DR.

--- a/html/changelogs/Boxe-plasmaman_goliathhides.yml
+++ b/html/changelogs/Boxe-plasmaman_goliathhides.yml
@@ -1,4 +1,4 @@
 author: Boxed
 delete-after: True
 changes:
-	- tweak: Plasmaman mining suits can now be upgraded with goliath hides. Takes 6 hides compared to the normal 5 to reach 90 DR.
+  -tweak: Plasmaman mining suits can now be upgraded with goliath hides. Takes 6 hides compared to the normal 5 to reach 90 DR.


### PR DESCRIPTION
you can upgrade plasmaman mining suits with goliath hides

takes 6 hides to reach 90 melee DR
normal mining rigs take 5 hides to reach that amount

Fixes #3716