### PR TITLE
Artifact Fix

### DIFF
--- a/code/modules/research/xenoarchaeology/artifact/artifact_communication.dm
+++ b/code/modules/research/xenoarchaeology/artifact/artifact_communication.dm
@@ -10,6 +10,8 @@
 	idle_power_usage = 1000
 	var/list/obj/item/commstone/allstones = list()
 	var/remaining = 6
+	ghost_read = 0
+	machine_flags = WRENCHMOVE
 
 /obj/machinery/communication/attackby(obj/item/W as obj, mob/user as mob)
 	if(istype(W,/obj/item/commstone))


### PR DESCRIPTION
Two fixes for the new xenoarch artifact

Whoever thought ghost_read = 1 should be the standard inheritance for machinery was a fucking dumbass.