### PR TITLE
Fixes #3177

### DIFF
--- a/code/modules/hydroponics/vines.dm
+++ b/code/modules/hydroponics/vines.dm
@@ -326,6 +326,7 @@
 
 	spawn(0)
 		spawn_piece(src.loc)
+		loc = null
 
 	processing_objects.Add(src)
 
@@ -347,7 +348,7 @@
 /obj/effect/plant_controller/process()
 
 	// Space vines exterminated. Remove the controller
-	if(!vines)
+	if(!vines.len)
 		qdel(src)
 		return
 


### PR DESCRIPTION
We were using a master controller object for vine spreading, where the start location of the vines was where the master controller object was spawned. However it's location was never set to null after that so it just stayed there. Also the sanity checks on the object not having any vines didn't work because it was a list which would still exist even with zero vines.