### PR TITLE
Fix #2881

### DIFF
--- a/code/modules/hydroponics/hydro_tray.dm
+++ b/code/modules/hydroponics/hydro_tray.dm
@@ -379,7 +379,7 @@
 			if(weedkiller_reagents[R.id])
 				weedlevel -= weedkiller_reagents[R.id] * reagent_total
 			if(pestkiller_reagents[R.id])
-				pestlevel -= pestkiller_reagents[R.id] * reagent_total
+				pestlevel += pestkiller_reagents[R.id] * reagent_total //Pest reducing reagents have negative pest level
 
 			// Beneficial reagents have a few impacts along with health buffs.
 			if(beneficial_reagents[R.id])


### PR DESCRIPTION
Pest levels were being subtracted by the amount of relevant pest killer, but pest killers already used negative values for pest reducing reagents and positive values for pest increasing reagents causing the opposite effect.