### PR TITLE
Fixes #2702

### DIFF
--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -40,12 +40,12 @@
 	if(!(src.on))
 		return 0
 	if((num < 0.005 || src.air_contents.total_moles() < num))
-		src.ion_trail.stop()
+		src.toggle()
 		return 0
 
 	var/datum/gas_mixture/G = src.air_contents.remove(num)
+	var/allgases = G.total_moles()
 
-	var/allgases = G.carbon_dioxide + G.nitrogen + G.oxygen + G.toxins	//fuck trace gases	-Pete
 	if(allgases >= 0.005)
 		return 1
 

--- a/html/changelogs/clusterfack_3992.yml
+++ b/html/changelogs/clusterfack_3992.yml
@@ -1,0 +1,7 @@
+author: Clusterfack
+delete-after: true
+changes:
+- bugfix: Fixes a bug where using N2O to refuel your jetpack would cause it to no longer function
+- rscadd: Also made wrenching multiple dense machines down on the same time impossible
+- bugfix: Made deleting cryotubes by unwrenching them impossible
+- bugfix: Fixed an issue where blob centcomm reports wouldn't be sent to the station (so no nuke code)


### PR DESCRIPTION
Jetpacks wouldn't regard trace gases as gases, therefore any jetpack using trace gases like N2O would break when there's really no reason for it to disallow trace gases at all.