### PR TITLE
Fix SMES issues

### DIFF
--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -169,7 +169,7 @@
 		var/excess = terminal.surplus()
 
 		if (charging)
-			if (excess >= 0) // If there's power available, try to charge
+			if (excess >= chargelevel) // If there's power available, try to charge
 				var/load = min((capacity - charge) / SMESRATE, chargelevel) // Charge at set rate, limited to spare capacity
 
 				charge += load * SMESRATE // Increase the charge
@@ -204,6 +204,7 @@
 
 		if (charge < 0.0001)
 			online = FALSE
+			lastout = 0
 
 	// Only update icon if state changed
 	if(_charging != charging || _online != online)


### PR DESCRIPTION
Fixes #4095, why exactly was it just checking if there was ANY POWER and then draining MORE POWER THAN EXISTED in the powernet? Better question, how did it ever work properly like this in the past?

Fixes #4076, lastout wasn't being set to 0 when smes stopped outputting

Obviously SMES are delicate special snowflakes so make sure to look this over carefully