### PR TITLE
Fix Isolation Centrifuge Board

### DIFF
--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -220,7 +220,7 @@
 	build_path = "/obj/machinery/computer/diseasesplicer"
 	origin_tech = "programming=3;biotech=4"
 /obj/item/weapon/circuitboard/centrifuge
-	name = "Circuit board (Disease Splicer)"
+	name = "Circuit board (Isolation Centrifuge)"
 	build_path = "/obj/machinery/computer/centrifuge"
 	origin_tech = "programming=3;biotech=3"
 


### PR DESCRIPTION
Fixes #3987, the only issue was it wasn't named properly. It was called disease splicer instead when it actually wasn't.