### PR TITLE
Bag Exploit Fix

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -334,6 +334,8 @@
 
 //This proc is called when you want to place an item into the storage item.
 /obj/item/weapon/storage/attackby(obj/item/W as obj, mob/user as mob)
+	if(!Adjacent(user,src))
+		return
 	..()
 
 	// /vg/ #11: Recursion.
@@ -412,6 +414,10 @@
 
 /obj/item/weapon/storage/attack_paw(mob/user as mob)
 	return attack_hand(user)
+
+/obj/item/weapon/storage/throw_at()
+	close_all() //How are you going to see whats inside this thing while throwing it
+	..()
 
 /obj/item/weapon/storage/verb/toggle_gathering_mode()
 	set name = "Switch Gathering Method"


### PR DESCRIPTION
Fixes #3752, prevents the exploitation of menus not closing when bags are thrown to transfer items over distances. Also checks adjacent before placing items into bags in the first place, solving the issue for any further potential exploits.