### PR TITLE
Power Machines can connect to powernets on all turfs

### DIFF
--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -109,10 +109,7 @@
 
 // connect the machine to a powernet if a node cable is present on the turf
 /obj/machinery/power/proc/connect_to_network()
-	var/turf/T = src.loc
-
-	if(!T || !istype(T))
-		return 0
+	var/turf/T = get_turf(src)
 
 	var/obj/structure/cable/C = T.get_cable_node() // check if we have a node cable on the machine turf, the first found is picked
 
@@ -188,9 +185,6 @@
 // return a knot cable (O-X) if one is present in the turf
 // null if there's none
 /turf/proc/get_cable_node()
-	if(!istype(src, /turf/simulated/floor))
-		return null
-
 	for(var/obj/structure/cable/C in src)
 		if(C.d1 == 0)
 			return C


### PR DESCRIPTION
Fixes #4119, while connect_to_network was just checking to see if a powermachine was on a turf, get_cable_node was also doubly making sure it was on a simulated floor. Making it impossible to allow power machines to work while on catwalk.

Fun fact, this MAY fix solar trackers. Because while solars are currently placed on a regular simulated turfs, solar trackers were built upon catwalks. After dylan made catwalks into a nonturf they were no longer connecting to any powernets and doing literally nothing anymore.