### PR TITLE
Makes mat synth display name instead of type

### DIFF
--- a/code/game/objects/items/devices/mat_synth.dm
+++ b/code/game/objects/items/devices/mat_synth.dm
@@ -57,7 +57,7 @@
 				modifier = MAT_COST_MEDIUM
 			if(initial(active_material.perunit) < 2000)
 				modifier = MAT_COST_RARE
-			var/amount = Clamp(round(input("How many sheets of [material_type] do you want to synthesize") as num), 0, 50)
+			var/amount = Clamp(round(input("How many sheets of [material_type.name] do you want to synthesize") as num), 0, 50)
 			if(amount)
 				if(TakeCost(amount, modifier, R))
 					var/obj/item/stack/sheet/inside_sheet = (locate(material_type) in R.module.modules)
@@ -66,21 +66,21 @@
 						R.module.modules += created_sheet
 						if((created_sheet.amount + amount) <= created_sheet.max_amount)
 							created_sheet.amount += (amount-1)
-							R << "Added [amount] of [material_type] to the stack."
+							R << "Added [amount] of [material_type.name] to the stack."
 						else
 							if(created_sheet.amount <= created_sheet.max_amount)
 								var/transfer_amount = min(created_sheet.max_amount - created_sheet.amount, amount)
 								created_sheet.amount += (transfer_amount-1)
 								amount -= transfer_amount
 							if(amount >= 1 && (created_sheet.amount >= created_sheet.max_amount))
-								R << "Dropping [amount], you cannot hold anymore of [material_type]."
+								R << "Dropping [amount], you cannot hold anymore of [material_type.name]."
 								var/obj/item/stack/sheet/dropped_sheet = new material_type(get_turf(src))
 								dropped_sheet.amount = (amount - 1)
 
 					else
 						if((inside_sheet.amount + amount) <= inside_sheet.max_amount)
 							inside_sheet.amount += amount
-							R << "Added [amount] of [material_type] to the stack."
+							R << "Added [amount] of [material_type.name] to the stack."
 							return
 						else
 							if(inside_sheet.amount <= inside_sheet.max_amount)
@@ -88,14 +88,14 @@
 								inside_sheet.amount += transfer_amount
 								amount -= transfer_amount
 							if(amount >= 1 && (inside_sheet.amount >= inside_sheet.max_amount))
-								R << "Dropping [amount], you cannot hold anymore of [material_type]."
+								R << "Dropping [amount], you cannot hold anymore of [material_type.name]."
 								var/obj/item/stack/sheet/dropped_sheet = new material_type(get_turf(src))
 								dropped_sheet.amount = amount
 					R.module.rebuild()
 					R.hud_used.update_robot_modules_display()
 					return
 				else
-					R << "<span class='warning'>You can't make that much [material_type] without shutting down!</span>"
+					R << "<span class='warning'>You can't make that much [material_type.name] without shutting down!</span>"
 					return
 
 				return
@@ -110,7 +110,7 @@
 				modifier = MAT_COST_MEDIUM
 			if(initial(active_material.perunit) < 2000)
 				modifier = MAT_COST_RARE
-			var/tospawn = Clamp(round(input("How many sheets of [material_type] do you want to synthesize? (0 - [matter / modifier])") as num), 0, round(matter / modifier))
+			var/tospawn = Clamp(round(input("How many sheets of [material_type.name] do you want to synthesize? (0 - [matter / modifier])") as num), 0, round(matter / modifier))
 			if(tospawn && material_type)
 				var/obj/item/stack/sheet/spawned_sheet = new material_type(get_turf(src))
 				spawned_sheet.amount = tospawn


### PR DESCRIPTION
Fixes #3508, the issue was pretty clearly a result of the fact it uess typepaths the way it does. Since only [src] would give a name instead of a typepath, the [material_type] was displaying the actual typepath instead of the name.