### PR TITLE
Fixes spacepod cell stat() bug

### DIFF
--- a/code/WorkInProgress/pomf/spacepods/spacepods.dm
+++ b/code/WorkInProgress/pomf/spacepods/spacepods.dm
@@ -14,7 +14,7 @@
 	infra_luminosity = 15
 	var/mob/living/carbon/occupant
 	var/datum/spacepod/equipment/equipment_system
-	var/obj/item/weapon/cell/high/battery
+	var/obj/item/weapon/cell/battery
 	var/datum/gas_mixture/cabin_air
 	var/obj/machinery/portable_atmospherics/canister/internal_tank
 	var/datum/effect/effect/system/trail/space_trail/ion_trail
@@ -36,7 +36,7 @@
 	bound_width = 64
 	bound_height = 64
 	dir = EAST
-	battery = new()
+	battery = new /obj/item/weapon/cell/high()
 	add_cabin()
 	add_airtank()
 	src.ion_trail = new /datum/effect/effect/system/trail/space_trail()


### PR DESCRIPTION
Fixes #3517, apparently the stat() for spacepod cells checked that the battery has an object of type cell within it. But since spacepods typecast their cell for specific initialization of a high power cell, the istype(S.battery) check fails if you placed a different type of cell into it. Causing it to instead display no cell detected.