### PR TITLE
Adds more blueprint functionality

### DIFF
--- a/code/ATMOSPHERICS/components/unary/vent_pump.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_pump.dm
@@ -358,3 +358,11 @@
 		return MT_UPDATE
 
 	return ..()
+
+/obj/machinery/atmospherics/unary/vent_pump/change_area(oldarea, newarea)
+	areaMaster.air_vent_info.Remove(id_tag)
+	areaMaster.air_vent_names.Remove(id_tag)
+	..()
+	name = replacetext(name,newarea,oldarea)
+	area_uid = areaMaster.uid
+	broadcast_status()

--- a/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
@@ -356,3 +356,11 @@
 		return MT_UPDATE
 
 	return ..()
+
+/obj/machinery/atmospherics/unary/vent_scrubber/change_area(oldarea, newarea)
+	areaMaster.air_scrub_info.Remove(id_tag)
+	areaMaster.air_scrub_names.Remove(id_tag)
+	..()
+	name = replacetext(name,newarea,oldarea)
+	area_uid = areaMaster.uid
+	broadcast_status()

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -662,3 +662,9 @@ its easier to just keep the beam vertical.
 
 /atom/proc/mop_act(obj/item/weapon/mop/M, mob/user)
 	return 0
+
+/atom/proc/change_area(var/area/oldarea, var/area/newarea)
+	if(istype(oldarea))
+		oldarea = "[oldarea.name]"
+	if(istype(newarea))
+		newarea = "[newarea.name]"

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -292,6 +292,9 @@
 	src.throwing = 0
 	if(isobj(src)) src.throw_impact(get_turf(src), throw_speed, user)
 
+/atom/movable/change_area(oldarea, newarea)
+	areaMaster = newarea
+	..()
 
 //Overlays
 /atom/movable/overlay

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -861,6 +861,10 @@
 	if (buildstage < 1)
 		user << "<span class='info'>The circuit is missing.</span>"
 
+/obj/machinery/alarm/change_area(oldarea, newarea)
+	..()
+	name = replacetext(name,oldarea,newarea)
+
 /*
 FIRE ALARM
 */
@@ -1126,6 +1130,10 @@ FIRE ALARM
 
 	machines.Remove(src)
 	update_icon()
+
+/obj/machinery/firealarm/change_area(oldarea, newarea)
+	..()
+	name = replacetext(name,oldarea,newarea)
 
 /obj/machinery/partyalarm
 	name = "\improper PARTY BUTTON"

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -60,19 +60,27 @@ var/list/camera_names=list()
 		ASSERT(src.network.len > 0)
 
 	if(!c_tag)
-		var/area/A=get_area(src)
-		var/basename=A.name
-		var/nethash=english_list(network)
-		var/suffix = 0
-		while(1)
-			c_tag = "[basename]"
-			if(suffix)
-				c_tag += " [suffix]"
-			if(!(nethash+c_tag in camera_names))
-				camera_names[nethash+c_tag]=src
-				break
-			suffix++
+		name_camera()
 	..()
+
+/obj/machinery/camera/proc/name_camera()
+	var/area/A=get_area(src)
+	var/basename=A.name
+	var/nethash=english_list(network)
+	var/suffix = 0
+	while(!suffix || nethash+c_tag in camera_names)
+		c_tag = "[basename]"
+		if(suffix)
+			c_tag += " [suffix]"
+		suffix++
+	camera_names[nethash+c_tag]=src
+
+/obj/machinery/camera/change_area(oldarea, newarea)
+	var/nethash=english_list(network)
+	camera_names[nethash+c_tag]=null
+	..()
+	if(name != replacetext(name,oldarea,newarea))
+		name_camera()
 
 /obj/machinery/camera/Destroy()
 	deactivate(null, 0) //kick anyone viewing out

--- a/code/game/machinery/door_control.dm
+++ b/code/game/machinery/door_control.dm
@@ -126,6 +126,10 @@
 	else
 		icon_state = "doorctrl0"
 
+/obj/machinery/door_control/change_area(oldarea, newarea)
+	..()
+	name = replacetext(name,oldarea,newarea)
+
 /obj/machinery/driver_button/attack_ai(mob/user as mob)
 	src.add_hiddenprint(user)
 	return src.attack_hand(user)
@@ -198,3 +202,7 @@
 
 	icon_state = "launcherbtt"
 	active = 0
+
+/obj/machinery/driver_button/change_area(oldarea, newarea)
+	..()
+	name = replacetext(name,oldarea,newarea)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -403,6 +403,10 @@ var/list/all_doors = list()
 		else
 			source.thermal_conductivity = initial(source.thermal_conductivity)
 
+/obj/machinery/door/change_area(oldarea, newarea)
+	..()
+	name = replacetext(name,oldarea,newarea)
+
 /obj/machinery/door/Move(new_loc, new_dir)
 	update_nearby_tiles()
 	. = ..()

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -121,3 +121,7 @@
 		return
 	power_change()
 	..(severity)
+
+/obj/machinery/light_switch/change_area(oldarea, newarea)
+	..()
+	name = replacetext(name,oldarea,newarea)

--- a/code/game/objects/items/mommiprints.dm
+++ b/code/game/objects/items/mommiprints.dm
@@ -10,17 +10,10 @@
 	return
 
 /obj/item/blueprints/mommiprints/Topic(href, href_list)
-	..()
 	if ((usr.restrained() || usr.stat || usr.get_active_hand() != src))
-		return
-	if (!href_list["action"])
-		return
-	switch(href_list["action"])
-		if ("create_area")
-			if (get_area_type()!=AREA_SPACE)
-				interact()
-				return
-			create_area()
+		return 1
+	if(..())
+		return 1
 
 /obj/item/blueprints/mommiprints/interact()
 	var/area/A = get_area()
@@ -48,3 +41,18 @@
 	text += "</BODY></HTML>"
 	usr << browse(text, "window=blueprints")
 	onclose(usr, "blueprints")
+
+# undef AREA_ERRNONE
+# undef AREA_STATION
+# undef AREA_SPACE
+# undef AREA_SPECIAL
+
+# undef BORDER_ERROR
+# undef BORDER_NONE
+# undef BORDER_BETWEEN
+# undef BORDER_2NDTILE
+# undef BORDER_SPACE
+
+# undef ROOM_ERR_LOLWAT
+# undef ROOM_ERR_SPACE
+# undef ROOM_ERR_TOOLARGE

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -581,6 +581,9 @@
 /turf/proc/dismantle_wall()
 	return
 
+/turf/change_area(oldarea, newarea)
+	lighting_build_overlays()
+
 /////////////////////////////////////////////////////
 
 /turf/proc/spawn_powerup()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1285,4 +1285,8 @@ obj/machinery/power/apc/proc/autoset(var/val, var/on)
 	if(src.invisibility != INVISIBILITY_MAXIMUM)
 		src.invisibility = INVISIBILITY_MAXIMUM
 
+/obj/machinery/power/apc/change_area(oldarea, newarea)
+	..()
+	name = replacetext(name,oldarea,newarea)
+
 #undef APC_UPDATE_ICON_COOLDOWN


### PR DESCRIPTION
Addresses #2914, adds renaming for several more machinery types that take their name from the area. 

Unfortunately does not work properly as it should be readding the vents/scrubbers to the new area as well as renaming all the machinery properly from space. If someone could let me know how I fucked up the procs I added to create area that they would not readd vents/scrubbers or rename that would be great because I've been banging my head against it for a few hours.