### PR TITLE
Fix a terminal issue

### DIFF
--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -93,6 +93,9 @@
 	return 1
 
 /obj/machinery/power/smes/attackby(var/obj/item/weapon/W as obj, var/mob/user as mob) //these can only be moved by being reconstructed, solves having to remake the powernet.
+	if(iscrowbar(W) && panel_open && terminal)
+		user << "<span class='warning'>You must first cut the terminal from the SMES!</span>"
+		return 1
 	if(..())
 		return 1
 	if(panel_open)

--- a/code/modules/power/terminal.dm
+++ b/code/modules/power/terminal.dm
@@ -35,3 +35,10 @@
 		master = null
 
 	..()
+
+/obj/machinery/power/terminal/attackby(obj/item/W, mob/user)
+	if(iswirecutter(W) && !master) //Sanity in the rare case something destroys a machine and leaves a terminal
+		getFromPool(/obj/item/stack/cable_coil, get_turf(src), 10)
+		qdel(src)
+		return
+	..()


### PR DESCRIPTION
An issue as yet unreported on github, SMES can be crowbar destroyed before their terminal is destroyed leaving an immortal terminal. Also adds a way to deconstruct terminals that have been left behind by a machine without getting destroyed for the purposes of sanity.