### PR TITLE
Gives dead mice different names

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -53,6 +53,7 @@
 	// Mice IDs
 	if(name == initial(name))
 		name = "[name] ([rand(1, 1000)])"
+	real_name = name
 	if(!_color)
 		_color = pick( list("brown","gray","white") )
 	icon_state = "mouse_[_color]"


### PR DESCRIPTION
Addresses #4071, the real name of mice wasn't being set and therefore when talking in deadchat they were simply being called 'mouse'