### PR TITLE
Fixes extremely mysterious and incomprehensible pooling bug

### DIFF
--- a/code/__HELPERS/datumpool.dm
+++ b/code/__HELPERS/datumpool.dm
@@ -70,7 +70,7 @@ var/global/list/masterdatumPool = new
 	if(D in masterdatumPool["[D.type]"])
 		world << text("returnToPool has been called twice for the same datum of type [] time to panic.", D.type)
 	#endif
-	masterdatumPool["[D.type]"] += D
+	masterdatumPool["[D.type]"] |= D
 
 	#ifdef DEBUG_DATUM_POOL
 	world << text("DEBUG_DATUM_POOL: returnToPool([]) [] left.", D.type, length(masterdatumPool["[D.type]"]))

--- a/code/__HELPERS/experimental.dm
+++ b/code/__HELPERS/experimental.dm
@@ -84,7 +84,7 @@ var/list/exclude = list("inhand_states", "loc", "locs", "parent_type", "vars", "
 
 	AM.Destroy()
 	AM.resetVariables()
-	masterPool["[AM.type]"] += AM
+	masterPool["[AM.type]"] |= AM
 
 	#ifdef DEBUG_OBJECT_POOL
 	world << text("DEBUG_OBJECT_POOL: returnToPool([]) [] left.", AM.type, length(masterPool["[AM.type]"]))


### PR DESCRIPTION
Debugmin wins
Fixes #3251
Fixes #3898

Probe helped me figure out this one because I saw the wires teleporting around after a singularity ripped him a new one. It had to be a double pooling issue, and since I couldn't replicate it normally I started testing around the singularity specifically. 

I added
>ASSERT(!(AM in masterPool["[AM.type]"]))

to experimental.dm line#87, which confirmed my suspicions when I loosed a singulo.

Turns out someone added extra sanity to singularity act to make sure it destroys objects, however both ex_act(1) and qdel(src) use returntopool, thus double pooling.  I'm sure this is the cause of anytime someone has objects mysteriously disappear on them (if they are the type that are pooled).