### PR TITLE
Fixes ghosts getting to nullspace

### DIFF
--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -21,7 +21,7 @@
 			if(targetloc.holy && ((src.invisibility == 0) || iscult(src)))
 				usr << "<span class='warning'>These are sacred grounds, you cannot go there!</span>"
 			else
-				loc = targetloc
+				forceMove(targetloc)
 
 /mob/dead/observer/ClickOn(var/atom/A, var/params)
 	if(client.buildmode)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -372,7 +372,7 @@
 				if((T && T.holy) && isobserver(mob) && ((mob.invisibility == 0) || (ticker.mode && (mob.mind in ticker.mode.cult))))
 					mob << "<span class='warning'>You cannot get past holy grounds while you are in this plane of existence!</span>"
 				else
-					mob.loc = get_step(mob, direct)
+					mob.forceMove(get_step(mob, direct))
 					mob.dir = direct
 		if(2)
 			if(prob(50))
@@ -412,19 +412,13 @@
 			else
 				spawn(0)
 					anim(mobloc,mob,'icons/mob/mob.dmi',,"shadow",,mob.dir)
-				mob.loc = get_step(mob, direct)
+				mob.forceMove(get_step(mob, direct))
 			mob.dir = direct
 	// Crossed is always a bit iffy
 	for(var/obj/S in mob.loc)
 		if(istype(S,/obj/effect/step_trigger) || istype(S,/obj/effect/beam))
 			S.Crossed(mob)
 
-	var/area/A = get_area_master(mob)
-	if(A)
-		A.Entered(mob)
-	if(isturf(mob.loc))
-		var/turf/T = mob.loc
-		T.Entered(mob)
 	return 1
 
 


### PR DESCRIPTION
Fixes #4151, ghosts were managing to get to nullspace by click teleporting to the edge of the map. This resolves that issue by making it so click teleporting calls entered just like any other and all other forms of movement.