### PR TITLE
A process scheduler thing

### DIFF
--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -93,7 +93,7 @@ Pipelines + Other Objects -> Pipe network
 // I asked /tg/ and bay and they have no idea why this is here, so into the trash it goes. - N3X
 // Re-enabled for debugging.
 /obj/machinery/atmospherics/process()
-	build_network()
+	. = build_network()
 	//testing("[src] called parent process to build_network()")
 
 /obj/machinery/atmospherics/proc/network_expand(datum/pipe_network/new_network, obj/machinery/atmospherics/pipe/reference)

--- a/code/ATMOSPHERICS/components/binary_devices/circulator.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/circulator.dm
@@ -53,7 +53,7 @@
 		return removed
 
 /obj/machinery/atmospherics/binary/circulator/process()
-	..()
+	. = ..()
 
 	if(last_worldtime_transfer < world.time - 50)
 		recent_moles_transferred = 0

--- a/code/ATMOSPHERICS/components/binary_devices/dp_vent_pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/dp_vent_pump.dm
@@ -67,10 +67,10 @@
 	"}
 
 /obj/machinery/atmospherics/binary/dp_vent_pump/process()
-	..()
+	. = ..()
 
 	if(!on)
-		return 0
+		return
 
 	var/datum/gas_mixture/environment = loc.return_air()
 	var/environment_pressure = environment.return_pressure()

--- a/code/ATMOSPHERICS/components/binary_devices/passive_gate.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/passive_gate.dm
@@ -29,9 +29,9 @@
 	return
 
 /obj/machinery/atmospherics/binary/passive_gate/process()
-	..()
+	. = ..()
 	if(!on)
-		return 0
+		return
 
 	var/output_starting_pressure = air2.return_pressure()
 	var/input_starting_pressure = air1.return_pressure()
@@ -39,7 +39,7 @@
 	if(output_starting_pressure >= min(target_pressure,input_starting_pressure-10))
 		//No need to pump gas if target is already reached or input pressure is too low
 		//Need at least 10 KPa difference to overcome friction in the mechanism
-		return 1
+		return
 
 	//Calculate necessary moles to transfer using PV = nRT
 	if((air1.total_moles() > 0) && (air1.temperature>0))
@@ -57,6 +57,8 @@
 
 		if(network2)
 			network2.update = 1
+
+	return 1
 
 
 //Radio remote control

--- a/code/ATMOSPHERICS/components/binary_devices/pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/pump.dm
@@ -51,17 +51,15 @@ Thus, the two variables affect pump operation are set in New():
 	return
 
 /obj/machinery/atmospherics/binary/pump/process()
-//		..()
-	if(stat & (NOPOWER|BROKEN))
+	. = ..()
+	if((stat & (NOPOWER|BROKEN)) || !on)
 		return
-	if(!on)
-		return 0
 
 	var/output_starting_pressure = air2.return_pressure()
 
 	if( (target_pressure - output_starting_pressure) < 0.01)
 		//No need to pump gas if target is already reached!
-		return 1
+		return
 
 	//Calculate necessary moles to transfer using PV=nRT
 	if((air1.total_moles() > 0) && (air1.temperature>0))

--- a/code/ATMOSPHERICS/components/binary_devices/valve.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/valve.dm
@@ -148,10 +148,6 @@
 	</ul>
 	"}
 
-/obj/machinery/atmospherics/binary/valve/digital/process()
-	..()
-	return 0
-
 /obj/machinery/atmospherics/binary/valve/digital/Topic(href, href_list)
 	if(..())
 		return

--- a/code/ATMOSPHERICS/components/binary_devices/volume_pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/volume_pump.dm
@@ -45,11 +45,9 @@ Thus, the two variables affect pump operation are set in New():
 	return
 
 /obj/machinery/atmospherics/binary/volume_pump/process()
-//		..()
-	if(stat & (NOPOWER|BROKEN))
+	. = ..()
+	if((stat & (NOPOWER|BROKEN)) || !on || transfer_rate < 1)
 		return
-	if(!on || transfer_rate < 1)
-		return 0
 
 // Pump mechanism just won't do anything if the pressure is too high/too low
 
@@ -57,7 +55,7 @@ Thus, the two variables affect pump operation are set in New():
 	var/output_starting_pressure = air2.return_pressure()
 
 	if((input_starting_pressure < 0.01) || (output_starting_pressure > 9000))
-		return 1
+		return
 
 	var/transfer_ratio = max(1, transfer_rate/air1.volume)
 

--- a/code/ATMOSPHERICS/components/trinary_devices/filter.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/filter.dm
@@ -54,15 +54,15 @@ obj/machinery/atmospherics/trinary/filter/power_change()
 		update_icon()
 
 obj/machinery/atmospherics/trinary/filter/process()
-	..()
+	. = ..()
 	if(!on)
-		return 0
+		return
 
 	var/output_starting_pressure = air3.return_pressure()
 
 	if(output_starting_pressure >= target_pressure || air2.return_pressure() >= target_pressure )
 		//No need to mix if target is already full!
-		return 1
+		return
 
 	//Calculate necessary moles to transfer using PV=nRT
 

--- a/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
@@ -36,15 +36,15 @@ obj/machinery/atmospherics/trinary/mixer/New()
 	air3.volume = 300
 
 obj/machinery/atmospherics/trinary/mixer/process()
-	..()
+	. = ..()
 	if(!on)
-		return 0
+		return
 
 	var/output_starting_pressure = air3.return_pressure()
 
 	if(output_starting_pressure >= target_pressure)
 		//No need to mix if target is already full!
-		return 1
+		return
 
 	//Calculate necessary moles to transfer using PV=nRT
 

--- a/code/ATMOSPHERICS/components/trinary_devices/t_valve.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/t_valve.dm
@@ -136,11 +136,12 @@
 	else
 		src.go_to_side()
 
+/*
 /obj/machinery/atmospherics/trinary/tvalve/process()
-	..()
+	. = ..()
 	//machines.Remove(src)
 
-/*		if(open && (!node1 || !node2))
+		if(open && (!node1 || !node2))
 			close()
 		if(!node1)
 			if(!nodealert)
@@ -153,7 +154,6 @@
 		else if (nodealert)
 			nodealert = 0
 */
-	return
 
 /obj/machinery/atmospherics/trinary/tvalve/return_network_air(datum/network/reference)
 	return null

--- a/code/ATMOSPHERICS/components/unary/cold_sink.dm
+++ b/code/ATMOSPHERICS/components/unary/cold_sink.dm
@@ -23,9 +23,9 @@
 	return
 
 /obj/machinery/atmospherics/unary/cold_sink/process()
-	..()
+	. = ..()
 	if(!on || !network)
-		return 0
+		return
 	var/air_heat_capacity = air_contents.heat_capacity()
 	var/combined_heat_capacity = current_heat_capacity + air_heat_capacity
 	var/old_temperature = air_contents.temperature

--- a/code/ATMOSPHERICS/components/unary/heat_exchanger.dm
+++ b/code/ATMOSPHERICS/components/unary/heat_exchanger.dm
@@ -31,12 +31,9 @@
 	..()
 
 /obj/machinery/atmospherics/unary/heat_exchanger/process()
-	..()
-	if(!partner)
-		return 0
-
-	if(!air_master || air_master.current_cycle <= update_cycle)
-		return 0
+	. = ..()
+	if(!partner || !air_master || air_master.current_cycle <= update_cycle)
+		return
 
 	update_cycle = air_master.current_cycle
 	partner.update_cycle = air_master.current_cycle

--- a/code/ATMOSPHERICS/components/unary/heat_source.dm
+++ b/code/ATMOSPHERICS/components/unary/heat_source.dm
@@ -25,9 +25,9 @@
 	return
 
 /obj/machinery/atmospherics/unary/heat_reservoir/process()
-	..()
+	. = ..()
 	if(!on)
-		return 0
+		return
 	var/air_heat_capacity = air_contents.heat_capacity()
 	var/combined_heat_capacity = current_heat_capacity + air_heat_capacity
 	var/old_temperature = air_contents.temperature

--- a/code/ATMOSPHERICS/components/unary/outlet_injector.dm
+++ b/code/ATMOSPHERICS/components/unary/outlet_injector.dm
@@ -38,11 +38,11 @@
 
 
 /obj/machinery/atmospherics/unary/outlet_injector/process()
-	..()
+	. = ..()
 	injecting = 0
 
 	if(!on || stat & NOPOWER)
-		return 0
+		return
 
 	if(air_contents.temperature > 0)
 		var/transfer_moles = (air_contents.return_pressure())*volume_rate/(air_contents.temperature * R_IDEAL_GAS_EQUATION)

--- a/code/ATMOSPHERICS/components/unary/oxygen_generator.dm
+++ b/code/ATMOSPHERICS/components/unary/oxygen_generator.dm
@@ -29,9 +29,9 @@ obj/machinery/atmospherics/unary/oxygen_generator/New()
 	air_contents.volume = 50
 
 obj/machinery/atmospherics/unary/oxygen_generator/process()
-	..()
+	. = ..()
 	if(!on)
-		return 0
+		return
 
 	var/total_moles = air_contents.total_moles()
 

--- a/code/ATMOSPHERICS/components/unary/portables_connector.dm
+++ b/code/ATMOSPHERICS/components/unary/portables_connector.dm
@@ -33,7 +33,7 @@
 		icon_state = "exposed"
 
 /obj/machinery/atmospherics/unary/portables_connector/process()
-	..()
+	. = ..()
 	if(!on)
 		return
 	if(!connected_device)

--- a/code/ATMOSPHERICS/components/unary/tank.dm
+++ b/code/ATMOSPHERICS/components/unary/tank.dm
@@ -11,9 +11,8 @@
 
 /obj/machinery/atmospherics/unary/tank/process()
 	if(!network)
-		..()
-	else
-		. = PROCESS_KILL
+		. = ..()
+	atmos_machines.Remove(src)
 	/*			if(!node1)
 		parent.mingle_with_turf(loc, 200)
 		if(!nodealert)

--- a/code/ATMOSPHERICS/components/unary/thermal_plate.dm
+++ b/code/ATMOSPHERICS/components/unary/thermal_plate.dm
@@ -20,7 +20,7 @@
 	icon_state = "[prefix]off"
 
 /obj/machinery/atmospherics/unary/thermal_plate/process()
-	..()
+	. = ..()
 
 	var/datum/gas_mixture/environment = loc.return_air()
 
@@ -42,7 +42,7 @@
 
 	if (!internal_removed)
 		environment.merge(external_removed)
-		return 1
+		return
 
 	var/combined_heat_capacity = internal_removed.heat_capacity() + external_removed.heat_capacity()
 	var/combined_energy = internal_removed.temperature * internal_removed.heat_capacity() + external_removed.heat_capacity() * external_removed.temperature
@@ -71,13 +71,13 @@
 /obj/machinery/atmospherics/unary/thermal_plate/proc/radiate()
 	if(network && network.radiate) //Since each member of a network has the same gases each tick
 		air_contents.copy_from(network.radiate) //We can cut down on processing time by only calculating radiate() once and then applying the result
-		return 1
+		return
 
 	var/internal_transfer_moles = 0.25 * air_contents.total_moles()
 	var/datum/gas_mixture/internal_removed = air_contents.remove(internal_transfer_moles)
 
 	if (!internal_removed)
-		return 1
+		return
 
 	var/combined_heat_capacity = internal_removed.heat_capacity() + RADIATION_CAPACITY
 	var/combined_energy = internal_removed.temperature * internal_removed.heat_capacity() + (RADIATION_CAPACITY * 6.4)

--- a/code/ATMOSPHERICS/components/unary/vent.dm
+++ b/code/ATMOSPHERICS/components/unary/vent.dm
@@ -18,11 +18,11 @@
 	air_contents.volume=volume
 
 /obj/machinery/atmospherics/unary/vent/process()
-	..()
+	. = ..()
 
 	CHECK_DISABLED(vents)
 	if (!node)
-		return // Turning off the vent is a PITA. - N3X
+		return// Turning off the vent is a PITA. - N3X
 
 	// New GC does this sometimes
 	if(!loc) return
@@ -32,6 +32,8 @@
 	var/datum/gas_mixture/removed = air_contents.remove(volume)
 
 	loc.assume_air(removed)
+
+	return 1
 
 
 /obj/machinery/atmospherics/unary/vent/update_icon()

--- a/code/ATMOSPHERICS/components/unary/vent_pump.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_pump.dm
@@ -74,7 +74,7 @@
 	return
 
 /obj/machinery/atmospherics/unary/vent_pump/process()
-	..()
+	. = ..()
 	CHECK_DISABLED(vents)
 	if (!node)
 		return // Turning off the vent is a PITA. - N3X
@@ -84,10 +84,10 @@
 
 	//broadcast_status() // from now air alarm/control computer should request update purposely --rastaf0
 	if(!on)
-		return 0
+		return
 
 	if(welded)
-		return 0
+		return
 
 	// New GC does this sometimes
 	if(!loc) return

--- a/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
@@ -105,17 +105,17 @@
 		set_frequency(frequency)
 
 /obj/machinery/atmospherics/unary/vent_scrubber/process()
-	..()
+	. = ..()
 	CHECK_DISABLED(scrubbers)
 	if(stat & (NOPOWER|BROKEN))
 		return
 	if (!node)
-		return 0 // Let's not shut it off, for now.
+		return // Let's not shut it off, for now.
 	if(welded)
-		return 0
+		return
 	//broadcast_status()
 	if(!on)
-		return 0
+		return
 	// New GC does this sometimes
 	if(!loc) return
 

--- a/code/ATMOSPHERICS/datum_pipe_network.dm
+++ b/code/ATMOSPHERICS/datum_pipe_network.dm
@@ -50,16 +50,18 @@
 
 	if(!start_normal)
 		returnToDPool(src)
+		return
 
 	start_normal.network_expand(src, reference)
 
 	update_network_gases()
 
 	if((normal_members.len>0)||(line_members.len>0))
-		if(!(src in pipe_networks)) //Pooling makes it disposed, which causes it to no longer process while pooled
-			pipe_networks += src
+		pipe_networks |= src
 	else
 		returnToDPool(src)
+		return
+	return 1
 
 /datum/pipe_network/proc/merge(datum/pipe_network/giver)
 	if(giver==src) return 0

--- a/code/ATMOSPHERICS/he_pipes.dm
+++ b/code/ATMOSPHERICS/he_pipes.dm
@@ -52,7 +52,7 @@
 
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/process()
 	if(!parent)
-		return ..()
+		. = ..()
 
 	// Get gas from pipenet
 	var/datum/gas_mixture/internal = return_air()
@@ -80,7 +80,7 @@
 	// No internal gas.  Screw this, we're out.
 	if (!internal_removed)
 		environment.merge(external_removed)
-		return 1
+		return
 
 	//Get same info from connected gas
 	var/combined_heat_capacity = internal_removed.heat_capacity() + external_removed.heat_capacity()
@@ -99,6 +99,7 @@
 
 	if(parent && parent.network)
 		parent.network.update = 1
+	return 1
 
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/proc/radiate()
 	var/datum/gas_mixture/internal = return_air()
@@ -106,7 +107,7 @@
 	var/datum/gas_mixture/internal_removed = internal.remove(internal_transfer_moles)
 
 	if (!internal_removed)
-		return 1
+		return
 
 	var/combined_heat_capacity = internal_removed.heat_capacity() + RADIATION_CAPACITY
 	var/combined_energy = internal_removed.temperature * internal_removed.heat_capacity() + (RADIATION_CAPACITY * ENERGY_MULT)

--- a/code/ATMOSPHERICS/pipes.dm
+++ b/code/ATMOSPHERICS/pipes.dm
@@ -152,9 +152,8 @@
 
 /obj/machinery/atmospherics/pipe/simple/process()
 	if(!parent) //This should cut back on the overhead calling build_network thousands of times per cycle
-		build_network()
-	else
-		. = PROCESS_KILL
+		. = ..()
+	atmos_machines.Remove(src)
 
 	/*if(!node1)
 		parent.mingle_with_turf(loc, volume)
@@ -491,9 +490,8 @@
 
 /obj/machinery/atmospherics/pipe/manifold/process()
 	if(!parent)
-		..()
-	else
-		. = PROCESS_KILL
+		. = ..()
+	atmos_machines.Remove(src)
 	/*
 	if(!node1)
 		parent.mingle_with_turf(loc, 70)
@@ -726,9 +724,8 @@
 
 /obj/machinery/atmospherics/pipe/manifold4w/process()
 	if(!parent)
-		..()
-	else
-		. = PROCESS_KILL
+		. = ..()
+	atmos_machines.Remove(src)
 	/*
 	if(!node1)
 		parent.mingle_with_turf(loc, 70)

--- a/code/controllers/Processes/pipenet.dm
+++ b/code/controllers/Processes/pipenet.dm
@@ -1,14 +1,20 @@
 var/global/list/datum/pipe_network/pipe_networks = list()
+var/global/list/obj/machinery/atmospherics/atmos_machines = list()
 
 /datum/controller/process/pipenet/setup()
 	name = "pipenet"
 	schedule_interval = 20 // every 2 seconds
 
 /datum/controller/process/pipenet/doWork()
+	for(var/obj/machinery/atmospherics/atmosmachinery in atmos_machines)
+		ASSERT(istype(atmosmachinery))
+		if(!atmosmachinery.disposed)
+			if(atmosmachinery.process())
+				scheck()
 	for(var/datum/pipe_network/pipeNetwork in pipe_networks)
-		if(istype(pipeNetwork) && !pipeNetwork.disposed)
+		ASSERT(istype(pipeNetwork))
+		if(!pipeNetwork.disposed)
 			pipeNetwork.process()
 			scheck()
-			continue
 
 		pipe_networks.Remove(pipeNetwork)

--- a/code/controllers/Processes/power_machinery.dm
+++ b/code/controllers/Processes/power_machinery.dm
@@ -18,7 +18,8 @@ var/global/list/power_machines = list()
 			var/time_start = world.timeofday
 			#endif
 
-			M.check_rebuild() //Checks to make sure the powernet doesn't need to be rebuilt, rebuilds it if it does
+			if(M.check_rebuild()) //Checks to make sure the powernet doesn't need to be rebuilt, rebuilds it if it does
+				scheck()
 
 			if(M.process() == PROCESS_KILL)
 				M.inMachineList = 0

--- a/code/controllers/Processes/powernet.dm
+++ b/code/controllers/Processes/powernet.dm
@@ -9,7 +9,8 @@ var/global/list/cable_list = list() //Index for all cables, so that powernets do
 
 	for(var/obj/structure/cable/PC in cable_list)
 		if(PC.build_status)
-			PC.rebuild_from() //Does a powernet need rebuild? Lets do it!
+			if(PC.rebuild_from()) //Does a powernet need rebuild? Lets do it!
+				scheck()
 
 	for(var/datum/powernet/powerNetwork in powernets)
 		if(istype(powerNetwork) && !powerNetwork.disposed)

--- a/code/game/gamemodes/events.dm
+++ b/code/game/gamemodes/events.dm
@@ -184,7 +184,7 @@
 	//command_alert("Unidentified lifesigns detected coming aboard [station_name()]. Secure any exterior access, including ducting and ventilation.", "Lifesign Alert")
 	//world << sound('sound/AI/aliens.ogg')
 	var/list/vents = list()
-	for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in machines)
+	for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in atmos_machines)
 		if(temp_vent.loc.z == 1 && !temp_vent.welded && temp_vent.network && temp_vent.canSpawnMice)
 			if(temp_vent.network.normal_members.len > 50) // Stops Aliens getting stuck in small networks. See: Security, Virology
 				vents += temp_vent

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -156,7 +156,7 @@ Class Procs:
 	..()
 
 /obj/machinery/New()
-	machines += src
+	machines |= src
 	return ..()
 
 /obj/machinery/examine(mob/user)
@@ -166,9 +166,11 @@ Class Procs:
 
 /obj/machinery/Destroy()
 	if(src in machines)
-		machines -= src
+		machines.Remove(src)
 	if(src in power_machines)
-		power_machines -= src
+		power_machines.Remove(src)
+	if(src in atmos_machines)
+		atmos_machines.Remove(src)
 /*
 	if(component_parts)
 		for(var/atom/movable/AM in component_parts)

--- a/code/modules/atmos_automation/implementation/digital_valves.dm
+++ b/code/modules/atmos_automation/implementation/digital_valves.dm
@@ -31,7 +31,7 @@
 			return 1
 		if(href_list["set_subject"])
 			var/list/valves=list()
-			for(var/obj/machinery/atmospherics/binary/valve/digital/V in machines)
+			for(var/obj/machinery/atmospherics/binary/valve/digital/V in atmos_machines)
 				if(!isnull(V.id_tag) && V.frequency == parent.frequency)
 					valves|=V.id_tag
 			if(valves.len==0)

--- a/code/modules/atmos_automation/implementation/injectors.dm
+++ b/code/modules/atmos_automation/implementation/injectors.dm
@@ -33,7 +33,7 @@
 			return 1
 		if(href_list["set_injector"])
 			var/list/injector_names=list()
-			for(var/obj/machinery/atmospherics/unary/outlet_injector/I in machines)
+			for(var/obj/machinery/atmospherics/unary/outlet_injector/I in atmos_machines)
 				if(!isnull(I.id_tag) && I.frequency == parent.frequency)
 					injector_names|=I.id_tag
 			injector = input("Select an injector:", "Sensor Data", injector) as null|anything in injector_names
@@ -71,7 +71,7 @@
 			return 1
 		if(href_list["set_injector"])
 			var/list/injector_names=list()
-			for(var/obj/machinery/atmospherics/unary/outlet_injector/I in machines)
+			for(var/obj/machinery/atmospherics/unary/outlet_injector/I in atmos_machines)
 				if(!isnull(I.id_tag) && I.frequency == parent.frequency)
 					injector_names|=I.id_tag
 			injector = input("Select an injector:", "Sensor Data", injector) as null|anything in injector_names

--- a/code/modules/atmos_automation/implementation/scrubbers.dm
+++ b/code/modules/atmos_automation/implementation/scrubbers.dm
@@ -35,7 +35,7 @@
 		return 1
 	if(href_list["set_scrubber"])
 		var/list/injector_names=list()
-		for(var/obj/machinery/atmospherics/unary/vent_scrubber/S in machines)
+		for(var/obj/machinery/atmospherics/unary/vent_scrubber/S in atmos_machines)
 			if(!isnull(S.id_tag) && S.frequency == parent.frequency)
 				injector_names|=S.id_tag
 		scrubber = input("Select a scrubber:", "Scrubbers", scrubber) as null|anything in injector_names
@@ -77,7 +77,7 @@
 		return 1
 	if(href_list["set_scrubber"])
 		var/list/injector_names=list()
-		for(var/obj/machinery/atmospherics/unary/vent_scrubber/S in machines)
+		for(var/obj/machinery/atmospherics/unary/vent_scrubber/S in atmos_machines)
 			if(!isnull(S.id_tag) && S.frequency == parent.frequency)
 				injector_names|=S.id_tag
 		scrubber = input("Select a scrubber:", "Scrubbers", scrubber) as null|anything in injector_names
@@ -145,7 +145,7 @@ var/global/list/gas_labels=list(
 		return 1
 	if(href_list["set_scrubber"])
 		var/list/injector_names=list()
-		for(var/obj/machinery/atmospherics/unary/vent_scrubber/S in machines)
+		for(var/obj/machinery/atmospherics/unary/vent_scrubber/S in atmos_machines)
 			if(!isnull(S.id_tag) && S.frequency == parent.frequency)
 				injector_names|=S.id_tag
 		scrubber = input("Select a scrubber:", "Scrubbers", scrubber) as null|anything in injector_names

--- a/code/modules/atmos_automation/implementation/vent_pump.dm
+++ b/code/modules/atmos_automation/implementation/vent_pump.dm
@@ -36,10 +36,10 @@
 		return 1
 	if(href_list["set_vent_pump"])
 		var/list/injector_names=list()
-		for(var/obj/machinery/atmospherics/unary/vent_pump/I in machines)
+		for(var/obj/machinery/atmospherics/unary/vent_pump/I in atmos_machines)
 			if(!isnull(I.id_tag) && I.frequency == parent.frequency)
 				injector_names|=I.id_tag
-		for(var/obj/machinery/atmospherics/binary/dp_vent_pump/I in machines)
+		for(var/obj/machinery/atmospherics/binary/dp_vent_pump/I in atmos_machines)
 			if(!isnull(I.id_tag) && I.frequency == parent.frequency)
 				injector_names|=I.id_tag
 		vent_pump = input("Select a vent:", "Vent Pumps", vent_pump) as null|anything in injector_names
@@ -80,10 +80,10 @@
 		return 1
 	if(href_list["set_vent_pump"])
 		var/list/injector_names=list()
-		for(var/obj/machinery/atmospherics/unary/vent_pump/I in machines)
+		for(var/obj/machinery/atmospherics/unary/vent_pump/I in atmos_machines)
 			if(!isnull(I.id_tag) && I.frequency == parent.frequency)
 				injector_names|=I.id_tag
-		for(var/obj/machinery/atmospherics/binary/dp_vent_pump/I in machines)
+		for(var/obj/machinery/atmospherics/binary/dp_vent_pump/I in atmos_machines)
 			if(!isnull(I.id_tag) && I.frequency == parent.frequency)
 				injector_names|=I.id_tag
 		vent_pump = input("Select a vent:", "Vent Pumps", vent_pump) as null|anything in injector_names
@@ -161,11 +161,11 @@
 	if(href_list["set_vent_pump"])
 		var/list/injector_names=list()
 		if(mode)//DP vent selection
-			for(var/obj/machinery/atmospherics/binary/dp_vent_pump/I in world)
+			for(var/obj/machinery/atmospherics/binary/dp_vent_pump/I in atmos_machines)
 				if(!isnull(I.id_tag) && I.frequency == parent.frequency)
 					injector_names|=I.id_tag
 		else
-			for(var/obj/machinery/atmospherics/unary/vent_pump/I in machines)
+			for(var/obj/machinery/atmospherics/unary/vent_pump/I in atmos_machines)
 				if(!isnull(I.id_tag) && I.frequency == parent.frequency)
 					injector_names|=I.id_tag
 		vent_pump = input("Select a vent:", "Vent Pumps", vent_pump) as null|anything in injector_names
@@ -253,11 +253,11 @@ checks bitflags
 	if(href_list["set_vent_pump"])
 		var/list/injector_names=list()
 		if(mode)//DP vent selection
-			for(var/obj/machinery/atmospherics/binary/dp_vent_pump/I in world)
+			for(var/obj/machinery/atmospherics/binary/dp_vent_pump/I in atmos_machines)
 				if(!isnull(I.id_tag) && I.frequency == parent.frequency)
 					injector_names|=I.id_tag
 		else
-			for(var/obj/machinery/atmospherics/unary/vent_pump/I in machines)
+			for(var/obj/machinery/atmospherics/unary/vent_pump/I in atmos_machines)
 				if(!isnull(I.id_tag) && I.frequency == parent.frequency)
 					injector_names|=I.id_tag
 		vent_pump = input("Select a vent:", "Vent Pumps", vent_pump) as null|anything in injector_names

--- a/code/modules/events/alien_infestation.dm
+++ b/code/modules/events/alien_infestation.dm
@@ -22,7 +22,7 @@
 
 /datum/event/alien_infestation/start()
 	var/list/vents = list()
-	for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in machines)
+	for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in atmos_machines)
 		if(temp_vent.loc.z == 1 && !temp_vent.welded && temp_vent.network)
 			if(temp_vent.network.normal_members.len > 50)	//Stops Aliens getting stuck in small networks. See: Security, Virology
 				vents += temp_vent

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -21,7 +21,7 @@
 /obj/machinery/power/New()
 	. = ..()
 	machines -= src
-	power_machines += src
+	power_machines |= src
 	return .
 
 /obj/machinery/power/Destroy()
@@ -60,9 +60,10 @@
 
 /obj/machinery/power/check_rebuild()
 	if(!build_status)
-		return
+		return 0
 	for(var/obj/structure/cable/C in src.loc)
-		C.check_rebuild()
+		if(C.check_rebuild())
+			return 1
 
 /obj/machinery/power/proc/getPowernetNodes()
 	if(!get_powernet())

--- a/code/modules/power/powernet.dm
+++ b/code/modules/power/powernet.dm
@@ -31,8 +31,7 @@ Powernet procs :
 */
 
 /datum/powernet/New()
-	if(!(src in powernets)) //Pooling changes a disposed variable to 1, causing it to no longer process from the list
-		powernets += src
+	powernets |= src
 
 /datum/powernet/Del()
 	powernets -= src
@@ -147,6 +146,8 @@ var/global/powernets_broke = 0
 			C.build_status = 0
 		for(var/obj/machinery/power/P in NewPN.nodes)
 			P.build_status = 0
+		return 1
+	return 0
 
 ///////////////////////////////////////////
 // GLOBAL PROCS for powernets handling


### PR DESCRIPTION
Included:
-The process lists use |= instead of += due to the increased stability of the former against double additions.

-Atmospherics machinery is moved under the pipenet processing.

-Modified the atmospherics processes to return 1 when theyve done something, and 0 if they aint done jack shit. Then called scheck() if they return 1, possibly  reducing unnecessary scheck calls while still managing to smooth out the atmospherics processing.

-If a powernet happens to get rebuilt by either powernets or power machinery scheck() is also called
