### PR TITLE
Adds Local Zlevel Drift

### DIFF
--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -91,8 +91,8 @@
 			crewmemberData["x"] = pos.x
 			crewmemberData["y"] = pos.y
 			crewmemberData["z"] = pos.z
-			crewmemberData["xoffset"] = pos.x-WORLD_X_OFFSET
-			crewmemberData["yoffset"] = pos.y-WORLD_Y_OFFSET
+			crewmemberData["xoffset"] = pos.x-WORLD_X_OFFSET[pos.z]
+			crewmemberData["yoffset"] = pos.y-WORLD_Y_OFFSET[pos.z]
 			crewmembers += list(crewmemberData)
 
 
@@ -129,8 +129,8 @@
 				crewmemberData["x"] = pos.x
 				crewmemberData["y"] = pos.y
 				crewmemberData["z"] = pos.z
-				crewmemberData["xoffset"] = pos.x-WORLD_X_OFFSET
-				crewmemberData["yoffset"] = pos.y-WORLD_Y_OFFSET
+				crewmemberData["xoffset"] = pos.x-WORLD_X_OFFSET[pos.z]
+				crewmemberData["yoffset"] = pos.y-WORLD_Y_OFFSET[pos.z]
 
 				crewmembers += list(crewmemberData)
 				// Works around list += list2 merging lists; it's not pretty but it works

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -114,7 +114,7 @@
 						if(M.z != src.z)	continue	//only find medibots on the same z-level as the computer
 						var/turf/bl = get_turf(M)
 						if(bl)	//if it can't find a turf for the medibot, then it probably shouldn't be showing up
-							bdat += "[M.name] - <b>\[[bl.x-WORLD_X_OFFSET],[bl.y-WORLD_Y_OFFSET]\]</b> - [M.on ? "Online" : "Offline"]<br>"
+							bdat += "[M.name] - <b>\[[bl.x-WORLD_X_OFFSET[bl.z]],[bl.y-WORLD_Y_OFFSET[bl.z]]\]</b> - [M.on ? "Online" : "Offline"]<br>"
 							if((!isnull(M.reagent_glass)) && M.use_beaker)
 								bdat += "Reservoir: \[[M.reagent_glass.reagents.total_volume]/[M.reagent_glass.reagents.maximum_volume]\]<br>"
 							else

--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -48,8 +48,8 @@ var/list/doppler_arrays = list()
 		bang_data["heavy"] = bangarangs["heavy"]
 		bang_data["light"] = bangarangs["light"]
 		bang_data["took"] = bangarangs["took"]
-		bang_data["xoffset"] = bang_data["x"]-WORLD_X_OFFSET
-		bang_data["yoffset"] = bang_data["y"]-WORLD_Y_OFFSET
+		bang_data["xoffset"] = bang_data["x"]-WORLD_X_OFFSET[z]
+		bang_data["yoffset"] = bang_data["y"]-WORLD_Y_OFFSET[z]
 		explosions += list(bang_data)
 	data["explosions"]=explosions
 	data["explosion_cap"] = MAX_EXPLOSION_RANGE
@@ -125,9 +125,9 @@ var/list/doppler_arrays = list()
 	if(!(direct & dir))	return
 	*/
 
-	var/message = "Explosive disturbance detected - Epicenter at: grid ([x0-WORLD_X_OFFSET],[y0-WORLD_Y_OFFSET], [z0]). [cap ? "\[Theoretical Results\] " : ""]Epicenter radius: [devastation_range]. Outer radius: [heavy_impact_range]. Shockwave radius: [light_impact_range]. Temporal displacement of tachyons: [took] second\s.  Data logged."
+	var/message = "Explosive disturbance detected - Epicenter at: grid ([x0-WORLD_X_OFFSET[z0]],[y0-WORLD_Y_OFFSET[z0]], [z0]). [cap ? "\[Theoretical Results\] " : ""]Epicenter radius: [devastation_range]. Outer radius: [heavy_impact_range]. Shockwave radius: [light_impact_range]. Temporal displacement of tachyons: [took] second\s.  Data logged."
 	say(message)
-	//var/list/bang = params2list("x=[x0]&y=[y0]&z=[z0]&text=<tr><td>([worldtime2text()]) - ([x0-WORLD_X_OFFSET],[y0-WORLD_Y_OFFSET], [z0])</td><td>([cap ? "\[Theoretical Results\] " : ""][devastation_range],[heavy_impact_range],[light_impact_range])</td><td>[took]s</td></tr>")
+	//var/list/bang = params2list("x=[x0]&y=[y0]&z=[z0]&text=<tr><td>([worldtime2text()]) - ([x0-WORLD_X_OFFSET(z0)],[y0-WORLD_Y_OFFSET(z0)], [z0])</td><td>([cap ? "\[Theoretical Results\] " : ""][devastation_range],[heavy_impact_range],[light_impact_range])</td><td>[took]s</td></tr>")
 	var/list/bang = list()
 	bang["x"] = x0
 	bang["y"] = y0

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1398,14 +1398,14 @@ var/global/list/obj/item/device/pda/PDAs = list()
 				switch(href_list["mMark"])
 					if("x")
 						var/new_x = input("Please input desired X coordinate.", "Station Map App", app.markx) as num
-						var/x_validate=new_x+WORLD_X_OFFSET
+						var/x_validate=new_x+WORLD_X_OFFSET[map.zMainStation]
 						if(x_validate < 1 || x_validate > 255)
 							usr << "<span class='caution'>Error: Invalid X coordinate.</span>"
 						else
 							app.markx = new_x
 					if("y")
 						var/new_y = input("Please input desired Y coordinate.", "Station Map App", app.marky) as num
-						var/y_validate=new_y+WORLD_Y_OFFSET
+						var/y_validate=new_y+WORLD_Y_OFFSET[map.zMainStation]
 						if(y_validate < 1 || y_validate > 255)
 							usr << "<span class='caution'>Error: Invalid Y coordinate.</span>"
 						else

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -665,7 +665,7 @@ Code:
 
 				// AUTOFIXED BY fix_string_idiocy.py
 				// C:\Users\Rob\Documents\Projects\vgstation13\code\game\objects\items\devices\PDA\cart.dm:565: menu += "Current Orbital Location: <b>\[[cl.x],[cl.y]\]</b>"
-				menu += {"Current Orbital Location: <b>\[[cl.x-WORLD_X_OFFSET],[cl.y-WORLD_Y_OFFSET]\]</b>
+				menu += {"Current Orbital Location: <b>\[[cl.x-WORLD_X_OFFSET[cl.z]],[cl.y-WORLD_Y_OFFSET[cl.z]]\]</b>
 					<h4>Located Mops:</h4>"}
 				// END AUTOFIX
 				var/ldat
@@ -676,7 +676,7 @@ Code:
 						if (ml.z != cl.z)
 							continue
 						var/direction = get_dir(src, M)
-						ldat += "Mop - <b>\[[ml.x-WORLD_X_OFFSET],[ml.y-WORLD_Y_OFFSET] ([uppertext(dir2text(direction))])\]</b> - [M.reagents.total_volume ? "Wet" : "Dry"]<br>"
+						ldat += "Mop - <b>\[[ml.x-WORLD_X_OFFSET[ml.z]],[ml.y-WORLD_Y_OFFSET[ml.z]] ([uppertext(dir2text(direction))])\]</b> - [M.reagents.total_volume ? "Wet" : "Dry"]<br>"
 
 				if (!ldat)
 					menu += "None"
@@ -693,7 +693,7 @@ Code:
 						if (bl.z != cl.z)
 							continue
 						var/direction = get_dir(src, B)
-						ldat += "Bucket - <b>\[[bl.x-WORLD_X_OFFSET],[bl.y-WORLD_Y_OFFSET] ([uppertext(dir2text(direction))])\]</b> - Water level: [B.reagents.total_volume]/100<br>"
+						ldat += "Bucket - <b>\[[bl.x-WORLD_X_OFFSET[bl.z]],[bl.y-WORLD_Y_OFFSET[bl.z]] ([uppertext(dir2text(direction))])\]</b> - Water level: [B.reagents.total_volume]/100<br>"
 
 				if (!ldat)
 					menu += "None"
@@ -710,7 +710,7 @@ Code:
 						if (bl.z != cl.z)
 							continue
 						var/direction = get_dir(src, B)
-						ldat += "Cleanbot - <b>\[[bl.x-WORLD_X_OFFSET],[bl.y-WORLD_Y_OFFSET] ([uppertext(dir2text(direction))])\]</b> - [B.on ? "Online" : "Offline"]<br>"
+						ldat += "Cleanbot - <b>\[[bl.x-WORLD_X_OFFSET[bl.z]],[bl.y-WORLD_Y_OFFSET[bl.z]] ([uppertext(dir2text(direction))])\]</b> - [B.on ? "Online" : "Offline"]<br>"
 
 				if (!ldat)
 					menu += "None"

--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -102,7 +102,7 @@ Frequency:
 									direct = "weak"
 							src.temp += "[W.id]-[dir2text(get_dir(sr, tr))]-[direct]<BR>"
 
-				src.temp += "<B>You are at \[[sr.x-WORLD_X_OFFSET],[sr.y-WORLD_Y_OFFSET],[sr.z]\]</B> in orbital coordinates.<BR><BR><A href='byond://?src=\ref[src];refresh=1'>Refresh</A><BR>"
+				src.temp += "<B>You are at \[[sr.x-WORLD_X_OFFSET[sr.z]],[sr.y-WORLD_Y_OFFSET[sr.z]],[sr.z]\]</B> in orbital coordinates.<BR><BR><A href='byond://?src=\ref[src];refresh=1'>Refresh</A><BR>"
 			else
 				src.temp += "<B><FONT color='red'>Processing Error:</FONT></B> Unable to locate orbital position.<BR>"
 		else

--- a/code/global.dm
+++ b/code/global.dm
@@ -170,8 +170,8 @@ var/CHARGELEVEL = 0.001 // Cap for how fast cells charge, as a percentage-per-ti
 // Used for telescience.  Only apply to GPSes and other things that display coordinates to players.
 // The idea is that coordinates given will be entirely different from those displayed on the map in DreamMaker,
 //  while still making it very simple to lock onto someone who is drifting in space.
-var/WORLD_X_OFFSET=0
-var/WORLD_Y_OFFSET=0
+var/list/WORLD_X_OFFSET = list()
+var/list/WORLD_Y_OFFSET = list()
 
 var/shuttle_z = 2	//default
 var/airtunnel_start = 68 // default

--- a/code/modules/research/xenoarchaeology/tools/tools.dm
+++ b/code/modules/research/xenoarchaeology/tools/tools.dm
@@ -12,7 +12,7 @@
 
 /obj/item/device/gps/attack_self(var/mob/user as mob)
 	var/turf/T = get_turf(src)
-	user << "<span class='notice'>\icon[src] [src] flashes <i>[T.x-WORLD_X_OFFSET].[rand(0,9)]:[T.y-WORLD_Y_OFFSET].[rand(0,9)]:[T.z].[rand(0,9)]</i>.</span>"
+	user << "<span class='notice'>\icon[src] [src] flashes <i>[T.x-WORLD_X_OFFSET[T.z]].[rand(0,9)]:[T.y-WORLD_Y_OFFSET[T.z]].[rand(0,9)]:[T.z].[rand(0,9)]</i>.</span>"
 
 /obj/item/device/measuring_tape
 	name = "measuring tape"

--- a/code/modules/research/xenoarchaeology/tools/tools_depthscanner.dm
+++ b/code/modules/research/xenoarchaeology/tools/tools_depthscanner.dm
@@ -32,7 +32,7 @@
 
 			//create a new scanlog entry
 			var/datum/depth_scan/D = new()
-			D.coords = "[M.x-WORLD_X_OFFSET].[rand(0,9)]:[M.y-WORLD_Y_OFFSET].[rand(0,9)]:[10 * M.z].[rand(0,9)]"
+			D.coords = "[M.x-WORLD_X_OFFSET[M.z]].[rand(0,9)]:[M.y-WORLD_Y_OFFSET[M.z]].[rand(0,9)]:[10 * M.z].[rand(0,9)]"
 			D.time = worldtime2text()
 			D.record_index = positive_locations.len + 1
 			D.material = M.mineral ? M.mineral.display_name : "Rock"
@@ -61,7 +61,7 @@
 		if(B.artifact_find)
 			//create a new scanlog entry
 			var/datum/depth_scan/D = new()
-			D.coords = "[10 * (B.x-WORLD_X_OFFSET)].[rand(0,9)]:[10 * (B.y-WORLD_Y_OFFSET)].[rand(0,9)]:[10 * B.z].[rand(0,9)]"
+			D.coords = "[10 * (B.x-WORLD_X_OFFSET[B.z])].[rand(0,9)]:[10 * (B.y-WORLD_Y_OFFSET[B.z])].[rand(0,9)]:[10 * B.z].[rand(0,9)]"
 			D.time = worldtime2text()
 			D.record_index = positive_locations.len + 1
 

--- a/code/modules/telesci/gps.dm
+++ b/code/modules/telesci/gps.dm
@@ -45,7 +45,7 @@ var/list/GPS_list = list()
 			if(G.emped == 1)
 				t += "<BR>[tracked_gpstag]: ERROR"
 			else
-				t += "<BR>[tracked_gpstag]: [format_text(gps_area.name)] ([pos.x-WORLD_X_OFFSET], [pos.y-WORLD_Y_OFFSET], [pos.z])"
+				t += "<BR>[tracked_gpstag]: [format_text(gps_area.name)] ([pos.x-WORLD_X_OFFSET[pos.z]], [pos.y-WORLD_Y_OFFSET[pos.z]], [pos.z])"
 
 	var/datum/browser/popup = new(user, "GPS", name, 600, 450)
 	popup.set_content(t)

--- a/code/modules/telesci/telesci_computer.dm
+++ b/code/modules/telesci/telesci_computer.dm
@@ -230,8 +230,8 @@ var/global/list/telesci_warnings = list(/obj/machinery/power/supermatter,
 										/obj/item/device/onetankbomb,
 										/obj/machinery/portable_atmospherics/canister)
 /obj/machinery/computer/telescience/proc/doteleport(mob/user)
-	var/trueX = x_co + x_off - x_player_off + WORLD_X_OFFSET
-	var/trueY = y_co + y_off - y_player_off + WORLD_Y_OFFSET
+	var/trueX = x_co + x_off - x_player_off + WORLD_X_OFFSET[z_co]
+	var/trueY = y_co + y_off - y_player_off + WORLD_Y_OFFSET[z_co]
 	trueX = Clamp(trueX, 1, world.maxx)
 	trueY = Clamp(trueY, 1, world.maxy)
 	if(telepad)
@@ -311,27 +311,25 @@ var/global/list/telesci_warnings = list(/obj/machinery/power/supermatter,
 
 	if(href_list["setx"])
 		var/new_x = input("Please input desired X coordinate.", name, x_co) as num
-		var/x_validate=new_x+x_off+WORLD_X_OFFSET
-		if(x_validate < 1 || x_validate > 255)
+		var/x_validate=new_x+x_off
+		if(x_validate < -49 || x_validate > world.maxx+50)
 			usr << "<span class='caution'>Error: Invalid X coordinate.</span>"
-			testing("new_x=[new_x] -> NOT 1 < [x_validate] < 255")
 		else
 			x_co = new_x
 		return 1
 
 	if(href_list["sety"])
 		var/new_y = input("Please input desired Y coordinate.", name, y_co) as num
-		var/y_validate=new_y+y_off+WORLD_Y_OFFSET
-		if(y_validate < 1 || y_validate > 255)
+		var/y_validate=new_y+y_off
+		if(y_validate < -49 || y_validate > world.maxy+50)
 			usr << "<span class='caution'>Error: Invalid Y coordinate.</span>"
-			testing("new_y=[new_y] -> NOT 1 < [y_validate] < 255")
 		else
 			y_co = new_y
 		return 1
 
 	if(href_list["setz"])
 		var/new_z = input("Please input desired Z coordinate.", name, z_co) as num
-		if(new_z == 2 || new_z < 1 || new_z > 7)
+		if(new_z == map.zCentcomm || new_z < 1 || new_z > map.zLevels.len)
 			usr << "<span class='caution'>Error: Invalid Z coordinate.</span>"
 		else
 			z_co = new_z

--- a/code/world.dm
+++ b/code/world.dm
@@ -10,8 +10,9 @@
 /world/New()
 	// Honk honk, fuck you science
 	populate_seed_list()
-	WORLD_X_OFFSET=rand(-50,50)
-	WORLD_Y_OFFSET=rand(-50,50)
+	for(var/i=1, i<=map.zLevels.len, i++)
+		WORLD_X_OFFSET += rand(-50,50)
+		WORLD_Y_OFFSET += rand(-50,50)
 
 	// Initialize world events as early as possible.
 	on_login = new ()


### PR DESCRIPTION
Resolves #4319.

Adds a zlevel drift for all zlevels at roundstart. Hopefully it doesn't go list index out of bounds or something. Also stopped a method for determining zlevel drift using only the teleport computer and inputting 6 values to bisect the possible offsets until you find the specific one.