### PR TITLE
Change ticklag compensation

### DIFF
--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -276,15 +276,18 @@
 				move_delay += 7+config.walk_speed
 		move_delay += mob.movement_delay()
 
+		var/obj/item/weapon/grab/Findgrab = locate() in mob
+		if(Findgrab)
+			move_delay += 7
+
 		if(config.Tickcomp)
-			move_delay += ((1/(world.tick_lag))*1.3) - 1.3
+			move_delay *= (1/(2*world.tick_lag))
 
 		//We are now going to move
 		moving = 1
 		mob.delayNextMove(move_delay)
 		//Something with pulling things
-		if(locate(/obj/item/weapon/grab, mob))
-			mob.delayNextMove(7)
+		if(Findgrab)
 			var/list/L = mob.ret_grab()
 			if(istype(L, /list))
 				if(L.len == 2)


### PR DESCRIPTION
The old system would go from have x1 move delay to like x5 on a ticklag that is only half of the original. Which is pretty shit and forces you to disable tick compensation if you want to be able to move at a reasonable speed on low ticklags.

This just makes move delay inversely proportional to ticklag directly. Which ideally would preserve the move delay at any ticklag.

Fixes #4289 