### PR TITLE
Fixes

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -5,6 +5,7 @@
 /area
 	var/global/global_uid = 0
 	var/uid
+	var/obj/machinery/power/apc/areaapc = null
 
 /area/New()
 	icon_state = ""
@@ -38,6 +39,12 @@
 //	spawn(15)
 	power_change()		// all machines set to current power level, also updates lighting icon
 	InitializeLighting()
+
+/area/Destroy()
+	..()
+	for(var/area/A in src.related)
+		A.related -= src
+	areaapc = null
 
 /*
  * Added to fix mech fabs 05/2013 ~Sayu.
@@ -498,3 +505,11 @@
 
 	mob << "Gravity!"
 
+/area/proc/set_apc(var/obj/machinery/power/apc/apctoset)
+	for(var/area/A in src.related)
+		A.areaapc = apctoset
+
+/area/proc/remove_apc(var/obj/machinery/power/apc/apctoremove)
+	for(var/area/A in src.related)
+		if(A.areaapc == apctoremove)
+			A.areaapc = null

--- a/code/game/gamemodes/endgame/supermatter_cascade/universe.dm
+++ b/code/game/gamemodes/endgame/supermatter_cascade/universe.dm
@@ -141,7 +141,7 @@ AUTOMATED ALERT: Link to [command_name()] lost."}
 			alm.ex_act(2)
 
 /datum/universal_state/supermatter_cascade/proc/APCSet()
-	for (var/obj/machinery/power/apc/APC in machines)
+	for (var/obj/machinery/power/apc/APC in power_machines)
 		if (!(APC.stat & BROKEN) && !APC.is_critical)
 			APC.chargemode = 0
 			if(APC.cell)

--- a/code/game/gamemodes/events.dm
+++ b/code/game/gamemodes/events.dm
@@ -253,20 +253,20 @@
 /proc/prison_break() // -- Callagan
 
 
-	var/list/area/areas = list()
+	var/list/area/theareas = list()
 	for(var/area/A in areas)
 		if(istype(A, /area/security/prison) || istype(A, /area/security/brig))
-			areas += A
+			theareas += A
 
-	if(areas && areas.len > 0)
+	if(theareas && theareas.len > 0)
 
-		for(var/area/A in areas)
+		for(var/area/A in theareas)
 			for(var/obj/machinery/light/L in A)
 				L.flicker(10)
 
 		sleep(100)
 
-		for(var/area/A in areas)
+		for(var/area/A in theareas)
 			for (var/obj/machinery/power/apc/temp_apc in A)
 				temp_apc.overload_lighting()
 

--- a/code/game/gamemodes/events/ninja_equipment.dm
+++ b/code/game/gamemodes/events/ninja_equipment.dm
@@ -1038,7 +1038,7 @@ ________________________________________________________________________________
 				var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread()
 				spark_system.set_up(5, 0, A.loc)
 
-				var/obj/machinery/power/apc/B = A.loc.loc:get_apc()//Object.turf.area find APC
+				var/obj/machinery/power/apc/B = A.areaMaster.areaapc//Object.turf.area find APC
 				if(B)//If APC exists. Might not if the area is unpowered like CentCom.
 					var/datum/powernet/PN = B.terminal.powernet
 					while(G.candrain&&!maxcapacity&&!isnull(A))//And start a proc similar to drain from wire.

--- a/code/game/gamemodes/events/power_failure.dm
+++ b/code/game/gamemodes/events/power_failure.dm
@@ -5,7 +5,7 @@
 		command_alert("Abnormal activity detected in [station_name()]'s powernet. As a precautionary measure, the station's power will be shut off for an indeterminate duration.", "Critical Power Failure")
 		for(var/mob/M in player_list)
 			if(M.client) M << sound('sound/AI/poweroff.ogg')
-	for(var/obj/machinery/power/smes/S in machines)
+	for(var/obj/machinery/power/smes/S in power_machines)
 		if(istype(get_area(S), /area/turret_protected) || S.z != 1)
 			continue
 		S.charge = 0
@@ -77,7 +77,7 @@
 		command_alert("All SMESs on [station_name()] have been recharged. We apologize for the inconvenience.", "Power Systems Nominal")
 		for(var/mob/M in player_list)
 			if(M.client) M << sound('sound/AI/poweron.ogg')
-	for(var/obj/machinery/power/smes/S in machines)
+	for(var/obj/machinery/power/smes/S in power_machines)
 		if(S.z != 1)
 			continue
 		S.charge = S.capacity

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -97,7 +97,7 @@ rcd light flash thingy on matter drain
 
 	power_type = /mob/living/silicon/ai/proc/overload_machine
 
-/mob/living/silicon/ai/proc/overload_machine(obj/machinery/M in machines)
+/mob/living/silicon/ai/proc/overload_machine(obj/machinery/M as obj in machines)
 	set name = "Overload Machine"
 	set category = "Malfunction"
 	if (istype(M, /obj/machinery))
@@ -190,7 +190,7 @@ rcd light flash thingy on matter drain
 	for(var/datum/AI_Module/small/blackout/blackout in current_modules)
 		if(blackout.uses > 0)
 			blackout.uses --
-			for(var/obj/machinery/power/apc/apc in machines)
+			for(var/obj/machinery/power/apc/apc in power_machines)
 				if(prob(30*apc.overload))
 					apc.overload_lighting()
 				else apc.overload++

--- a/code/game/machinery/camera/presets.dm
+++ b/code/game/machinery/camera/presets.dm
@@ -41,7 +41,7 @@
 		number = 1
 		var/area/A = get_area(src)
 		if(A)
-			for(var/obj/machinery/camera/autoname/C in machines)
+			for(var/obj/machinery/camera/autoname/C in cameranet.cameras)
 				if(C == src) continue
 				var/area/CA = get_area(C)
 				if(CA.type == A.type)

--- a/code/game/machinery/computer/camera_monitor.dm
+++ b/code/game/machinery/computer/camera_monitor.dm
@@ -39,7 +39,7 @@
 		user.reset_view(src.current)
 
 	var/list/L = new/list
-	for (var/obj/machinery/camera/C in machines)
+	for (var/obj/machinery/camera/C in cameranet.cameras)
 		L.Add(C)
 
 	camera_network_sort(L)

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -36,7 +36,6 @@
 	smoke.start()
 	return
 
-
 /obj/machinery/computer/emp_act(severity)
 	if(prob(20/severity)) set_broken()
 	..()

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1220,7 +1220,7 @@ About the new airlock wires panel:
 	wires = new(src)
 	if(src.closeOtherId != null)
 		spawn (5)
-			for (var/obj/machinery/door/airlock/A in machines)
+			for (var/obj/machinery/door/airlock/A in all_doors)
 				if(A.closeOtherId == src.closeOtherId && A != src)
 					src.closeOther = A
 					break

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -30,11 +30,11 @@
 		pixel_y = ((src.dir & 3)? (src.dir ==1 ? 24 : -32) : (0))
 
 		spawn(20)
-			for(var/obj/machinery/door/window/brigdoor/M in machines)
+			for(var/obj/machinery/door/window/brigdoor/M in all_doors)
 				if (M.id_tag == src.id_tag)
 					targets += M
 
-			for(var/obj/machinery/flasher/F in machines)
+			for(var/obj/machinery/flasher/F in flashers)
 				if(F.id_tag == src.id_tag)
 					targets += F
 

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -1,4 +1,5 @@
 // It is a gizmo that flashes a small area
+var/list/obj/machinery/flasher/flashers = list()
 
 /obj/machinery/flasher
 	name = "Mounted flash"
@@ -17,6 +18,13 @@
 	min_harm_label = 15 //Seems low, but this is going by the sprite. May need to be changed for balance.
 	harm_label_examine = list("<span class='info'>A label is on the bulb, but doesn't cover it.</span>", "<span class='warning'>A label covers the bulb!</span>")
 
+/obj/machinery/flasher/New()
+	..()
+	flashers += src
+
+/obj/machinery/flasher/Destroy()
+	..()
+	flashers -= src
 
 /obj/machinery/flasher/portable //Portable version of the flasher. Only flashes when anchored
 	name = "portable flasher"
@@ -150,7 +158,7 @@
 	active = 1
 	icon_state = "launcheract"
 
-	for(var/obj/machinery/flasher/M in machines)
+	for(var/obj/machinery/flasher/M in flashers)
 		if(M.id_tag == src.id_tag)
 			spawn()
 				M.flash()

--- a/code/game/machinery/holosign.dm
+++ b/code/game/machinery/holosign.dm
@@ -1,4 +1,6 @@
 ////////////////////HOLOSIGN///////////////////////////////////////
+var/list/obj/machinery/holosign/holosigns = list()
+
 /obj/machinery/holosign
 	name = "holosign"
 	desc = "Small wall-mounted holographic projector"
@@ -12,22 +14,30 @@
 	var/id_tag = null
 	var/on_icon = "sign_on"
 
-	proc/toggle()
-		if (stat & (BROKEN|NOPOWER))
-			return
-		lit = !lit
-		update_icon()
+/obj/machinery/holosign/New()
+	..()
+	holosigns += src
 
+/obj/machinery/holosign/proc/toggle()
+	if (stat & (BROKEN|NOPOWER))
+		return
+	lit = !lit
 	update_icon()
-		if (!lit)
-			icon_state = "sign_off"
-		else
-			icon_state = on_icon
 
-	power_change()
-		if (stat & NOPOWER)
-			lit = 0
-		update_icon()
+/obj/machinery/holosign/update_icon()
+	if (!lit)
+		icon_state = "sign_off"
+	else
+		icon_state = on_icon
+
+/obj/machinery/holosign/power_change()
+	if (stat & NOPOWER)
+		lit = 0
+	update_icon()
+
+/obj/machinery/holosign/Destroy()
+	..()
+	holosigns -= src
 
 /obj/machinery/holosign/surgery
 	name = "surgery holosign"
@@ -73,7 +83,7 @@ obj/machinery/holosign_switch/attack_paw(mob/user as mob)
 	else
 		icon_state = "light0"
 
-	for(var/obj/machinery/holosign/M in machines)
+	for(var/obj/machinery/holosign/M in holosigns)
 		if (M.id_tag == src.id_tag)
 			spawn( 0 )
 				M.toggle()

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -291,7 +291,7 @@ var/list/obj/machinery/requests_console/allConsoles = list()
 		screen = 7 //if it's successful, this will get overrwritten (7 = unsufccessfull, 6 = successfull)
 		if (sending)
 			var/pass = 0
-			for (var/obj/machinery/message_server/MS in machines)
+			for (var/obj/machinery/message_server/MS in message_servers)
 				if(!MS.active) continue
 				MS.send_rc_message(href_list["department"],department,log_msg,msgStamped,msgVerified,priority)
 				pass = 1

--- a/code/game/objects/items/mountable_frames/apc_frame.dm
+++ b/code/game/objects/items/mountable_frames/apc_frame.dm
@@ -11,7 +11,7 @@
 	if(..())
 		var/turf/turf_loc = get_turf(user)
 
-		if (areaMaster.get_apc())
+		if (areaMaster.areaapc)
 			user << "<span class='rose'>This area already has an APC.</span>"
 			return //only one APC per area
 		for(var/obj/machinery/power/terminal/T in turf_loc)

--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -144,13 +144,13 @@ Frequency:
 		user << "<span class='notice'>\The [src] is malfunctioning.</span>"
 		return
 	var/list/L = list(  )
-	for(var/obj/machinery/teleport/hub/R in machines)
-		var/obj/machinery/computer/teleporter/com = locate(/obj/machinery/computer/teleporter, locate(R.x - 2, R.y, R.z))
-		if (istype(com, /obj/machinery/computer/teleporter) && com.locked && !com.one_time_use)
-			if(R.engaged)
-				L["[com.id] (Active)"] = com.locked
-			else
-				L["[com.id] (Inactive)"] = com.locked
+	for(var/obj/machinery/computer/teleporter/R in machines)
+		for(var/obj/machinery/teleport/hub/com in locate(R.x + 2, R.y, R.z))
+			if(R.locked && !R.one_time_use)
+				if(com.engaged)
+					L["[R.id] (Active)"] = R.locked
+				else
+					L["[R.id] (Inactive)"] = R.locked
 	var/list/turfs = list(	)
 	for(var/turf/T in orange(10))
 		if(T.x>world.maxx-8 || T.x<8)	continue	//putting them at the edge is dumb

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -10,6 +10,7 @@
 	intact = 0 //No seriously, that's not a joke. Allows cable to be laid PROPERLY on catwalks
 
 /turf/space/New()
+	turfs |= src
 	if(!istype(src, /turf/space/transit))
 		icon_state = "[((x + y) ^ ~(x * y) + z) % 25]"
 

--- a/code/game/turfs/space/transit.dm
+++ b/code/game/turfs/space/transit.dm
@@ -2,6 +2,7 @@
 	var/pushdirection // push things that get caught in the transit tile this direction
 
 /turf/space/transit/New()
+	turfs |= src
 	var/dira=""
 	var/i=0
 	switch(pushdirection)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2506,7 +2506,7 @@
 			if("whiteout")
 				feedback_inc("admin_secrets_fun_used",1)
 				feedback_add_details("admin_secrets_fun_used","WO")
-				for(var/obj/machinery/light/L in machines)
+				for(var/obj/machinery/light/L in alllights)
 					L.fix()
 				message_admins("[key_name_admin(usr)] fixed all lights", 1)
 			if("aliens")
@@ -2615,7 +2615,7 @@
 			if("eagles")//SCRAW
 				feedback_inc("admin_secrets_fun_used",1)
 				feedback_add_details("admin_secrets_fun_used","EgL")
-				for(var/obj/machinery/door/airlock/W in machines)
+				for(var/obj/machinery/door/airlock/W in all_doors)
 					if(W.z == 1 && !istype(get_area(W), /area/bridge) && !istype(get_area(W), /area/crew_quarters) && !istype(get_area(W), /area/security/prison))
 						W.req_access = list()
 				message_admins("[key_name_admin(usr)] activated Egalitarian Station mode")
@@ -2800,7 +2800,7 @@
 				var/choice = alert("Activate Cuban Pete mode? Note that newly spawned BBD will still have player damage deactivated.","Activating Bomberman Bombs Player Damage","Confirm","Cancel")
 				if(choice=="Confirm")
 					bomberman_hurt = 1
-					for(var/obj/item/weapon/bomberman/B in world)
+					for(var/obj/item/weapon/bomberman/B in bombermangear)
 						if(!B.arena)
 							B.hurt_players = 1
 				message_admins("[key_name_admin(usr)] enabled the player damage of the Bomberman Bomb Dispensers currently in the world. Cuban Pete approves.")
@@ -2811,7 +2811,7 @@
 				var/choice = alert("Activate Michael Bay mode? Note that newly spawned BBD will still have environnement damage deactivated.","Activating Bomberman Bombs Environnement Damage","Confirm","Cancel")
 				if(choice=="Confirm")
 					bomberman_destroy = 1
-					for(var/obj/item/weapon/bomberman/B in world)
+					for(var/obj/item/weapon/bomberman/B in bombermangear)
 						if(!B.arena)
 							B.destroy_environnement = 1
 				message_admins("[key_name_admin(usr)] enabled the environnement damage of the Bomberman Bomb Dispensers currently in the world. Michael Bay approves.")
@@ -2822,7 +2822,7 @@
 				var/choice = alert("Disable Cuban Pete mode.","Disable Bomberman Bombs Player Damage","Confirm","Cancel")
 				if(choice=="Confirm")
 					bomberman_hurt = 0
-					for(var/obj/item/weapon/bomberman/B in world)
+					for(var/obj/item/weapon/bomberman/B in bombermangear)
 						if(!B.arena)
 							B.hurt_players = 0
 				message_admins("[key_name_admin(usr)] disabled the player damage of the Bomberman Bomb Dispensers currently in the world.")
@@ -2833,7 +2833,7 @@
 				var/choice = alert("Disable Michael Bay mode?","Disable Bomberman Bombs Environnement Damage","Confirm","Cancel")
 				if(choice=="Confirm")
 					bomberman_destroy = 0
-					for(var/obj/item/weapon/bomberman/B in world)
+					for(var/obj/item/weapon/bomberman/B in bombermangear)
 						if(!B.arena)
 							B.destroy_environnement = 0
 				message_admins("[key_name_admin(usr)] disabled the environnement damage of the Bomberman Bomb Dispensers currently in the world.")
@@ -2955,12 +2955,12 @@
 					dat += "No-one has done anything this round!"
 				usr << browse(dat, "window=admin_log")
 			if("maint_access_brig")
-				for(var/obj/machinery/door/airlock/maintenance/M in machines)
+				for(var/obj/machinery/door/airlock/maintenance/M in all_doors)
 					if (access_maint_tunnels in M.req_access)
 						M.req_access = list(access_brig)
 				message_admins("[key_name_admin(usr)] made all maint doors brig access-only.")
 			if("maint_access_engiebrig")
-				for(var/obj/machinery/door/airlock/maintenance/M in machines)
+				for(var/obj/machinery/door/airlock/maintenance/M in all_doors)
 					if (access_maint_tunnels in M.req_access)
 						M.req_access = list()
 						M.req_one_access = list(access_brig,access_engine)

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -458,7 +458,7 @@ Pressure: [env.return_pressure()]"}
 		if(!(A.type in areas_all))
 			areas_all.Add(A.type)
 
-	for(var/obj/machinery/power/apc/APC in machines)
+	for(var/obj/machinery/power/apc/APC in power_machines)
 		var/area/A = get_area(APC)
 		if(!(A.type in areas_with_APC))
 			areas_with_APC.Add(A.type)
@@ -468,17 +468,17 @@ Pressure: [env.return_pressure()]"}
 		if(!(A.type in areas_with_air_alarm))
 			areas_with_air_alarm.Add(A.type)
 
-	for(var/obj/machinery/requests_console/RC in machines)
+	for(var/obj/machinery/requests_console/RC in allConsoles)
 		var/area/A = get_area(RC)
 		if(!(A.type in areas_with_RC))
 			areas_with_RC.Add(A.type)
 
-	for(var/obj/machinery/light/L in machines)
+	for(var/obj/machinery/light/L in alllights)
 		var/area/A = get_area(L)
 		if(!(A.type in areas_with_light))
 			areas_with_light.Add(A.type)
 
-	for(var/obj/machinery/light_switch/LS in machines)
+	for(var/obj/machinery/light_switch/LS in world)
 		var/area/A = get_area(LS)
 		if(!(A.type in areas_with_LS))
 			areas_with_LS.Add(A.type)
@@ -488,7 +488,7 @@ Pressure: [env.return_pressure()]"}
 		if(!(A.type in areas_with_intercom))
 			areas_with_intercom.Add(A.type)
 
-	for(var/obj/machinery/camera/C in machines)
+	for(var/obj/machinery/camera/C in cameranet.cameras)
 		var/area/A = get_area(C)
 		if(!(A.type in areas_with_camera))
 			areas_with_camera.Add(A.type)
@@ -1044,7 +1044,7 @@ Pressure: [env.return_pressure()]"}
 			if(!Rad.active)
 				Rad.toggle_power()
 
-	for(var/obj/machinery/power/smes/SMES in machines)
+	for(var/obj/machinery/power/smes/SMES in power_machines)
 		if(SMES.anchored)
 			SMES.connect_to_network() // Just in case.
 			SMES.chargemode = 1
@@ -1062,7 +1062,7 @@ Pressure: [env.return_pressure()]"}
 	log_admin("[key_name(usr)] haxed the powergrid with magic SMES.")
 	message_admins("<span class='notice'>[key_name_admin(usr)] haxed the powergrid with magic SMES.</span>", 1)
 
-	for(var/obj/machinery/power/smes/SMES in machines)
+	for(var/obj/machinery/power/smes/SMES in power_machines)
 		var/turf/T=SMES.loc
 		del(SMES)
 		var/obj/machinery/power/smes/magical/magic = new(T)
@@ -1363,13 +1363,13 @@ client/proc/delete_all_bomberman()
 	if(alert(usr, "Remove all Bomberman-related objects in the game world?", "Remove Bomberman", "Yes", "No") != "Yes")
 		return
 
-	for(var/obj/structure/bomberflame/O in world)
+	for(var/obj/structure/bomberflame/O in bombermangear)
 		qdel(O)
 
-	for(var/obj/structure/bomberman/O in world)
+	for(var/obj/structure/bomberman/O in bombermangear)
 		qdel(O)
 
-	for(var/obj/item/weapon/bomberman/O in world)
+	for(var/obj/item/weapon/bomberman/O in bombermangear)
 		if(istype(O.loc, /mob/living/carbon/))
 			var/mob/living/carbon/C = O.loc
 			C.u_equip(O,1)
@@ -1377,7 +1377,7 @@ client/proc/delete_all_bomberman()
 			//O.dropped(C)
 		qdel(O)
 
-	for(var/obj/item/clothing/suit/space/bomberman/O in world)
+	for(var/obj/item/clothing/suit/space/bomberman/O in bombermangear)
 		if(istype(O.loc, /mob/living/carbon/))
 			var/mob/living/carbon/C = O.loc
 			C.u_equip(O,1)
@@ -1385,7 +1385,7 @@ client/proc/delete_all_bomberman()
 			//O.dropped(C)
 		qdel(O)
 
-	for(var/obj/item/clothing/head/helmet/space/bomberman/O in world)
+	for(var/obj/item/clothing/head/helmet/space/bomberman/O in bombermangear)
 		if(istype(O.loc, /mob/living/carbon/))
 			var/mob/living/carbon/C = O.loc
 			C.u_equip(O,1)
@@ -1393,14 +1393,14 @@ client/proc/delete_all_bomberman()
 			//O.dropped(C)
 		qdel(O)
 
-	for(var/obj/structure/softwall/O in world)
+	for(var/obj/structure/softwall/O in bombermangear)
 		qdel(O)
 
 	for(var/turf/unsimulated/wall/bomberman/T in turfs)
 		T.ChangeTurf(/turf/simulated/wall)
 
 
-	for(var/obj/structure/powerup/O in world)
+	for(var/obj/structure/powerup/O in bombermangear)
 		qdel(O)
 
 client/proc/create_bomberman_arena()

--- a/code/modules/bomberman/bomberman.dm
+++ b/code/modules/bomberman/bomberman.dm
@@ -29,6 +29,7 @@
 */
 
 ///////////////////////////////BOMB DISPENSER//////////////////////////
+var/global/list/bombermangear = list()
 /obj/item/weapon/bomberman/
 	name = "Bomberman's Bomb Dispenser"
 	desc = "Now to not get yourself stuck in a corner."
@@ -64,6 +65,11 @@
 		hurt_players = 1
 	if(bomberman_destroy)
 		destroy_environnement = 1
+	bombermangear += src
+
+/obj/item/weapon/bomberman/Destroy()
+	..()
+	bombermangear -= src
 
 /obj/item/weapon/bomberman/attack_self(mob/user)
 	var/turf/T = get_turf(src)
@@ -150,6 +156,7 @@
 	destroy_environnement = destroy
 	hurt_players = hurt
 	parent = dispenser
+	bombermangear += src
 
 	if((!parent || !parent.arena) && bomberman_hurt)
 		hurt_players = 1
@@ -219,6 +226,7 @@
 /obj/structure/bomberman/Destroy()
 	if(parent)
 		parent.bomblimit++
+	bombermangear -= src
 	..()
 
 /obj/structure/bomberman/emp_act(severity)	//EMPs can safely remove the bombs
@@ -275,6 +283,7 @@
 			return
 	else
 		T2 = T1
+	bombermangear += src
 
 	collisions(T2)
 
@@ -287,6 +296,10 @@
 
 	sleep(5)
 	qdel(src)
+
+obj/structure/bomberflame/Destroy()
+	..()
+	bombermangear -= src
 
 /obj/structure/bomberflame/proc/collisions(var/turf/T)
 
@@ -391,6 +404,14 @@
 	density = 1
 	anchored = 1
 
+/obj/structure/softwall/New()
+	..()
+	bombermangear += src
+
+/obj/structure/softwall/Destroy()
+	..()
+	bombermangear -= src
+
 /obj/structure/softwall/proc/pulverized()
 	icon_state = "softwall_break"
 	density = 0
@@ -448,6 +469,14 @@
 	icon_state = "powerup"
 	density = 1
 	anchored = 1
+
+/obj/structure/powerup/New()
+	..()
+	bombermangear += src
+
+/obj/structure/powerup/Destroy()
+	..()
+	bombermangear -= src
 
 /obj/structure/powerup/bombup
 	name = "bomb-up"
@@ -632,6 +661,14 @@
 	species_restricted = list("exclude")
 	var/never_removed = 1
 
+/obj/item/clothing/suit/space/bomberman/New()
+	..()
+	bombermangear += src
+
+/obj/item/clothing/suit/space/bomberman/Destroy()
+	..()
+	bombermangear -= src
+
 /obj/item/clothing/suit/space/bomberman/dropped(mob/user as mob)
 	..()
 	never_removed = 0
@@ -647,6 +684,14 @@
 	siemens_coefficient = 0
 	species_restricted = list("exclude")
 	var/never_removed = 1
+
+/obj/item/clothing/head/helmet/space/bomberman/New()
+	..()
+	bombermangear += src
+
+/obj/item/clothing/head/helmet/space/bomberman/Destroy()
+	..()
+	bombermangear -= src
 
 /obj/item/clothing/head/helmet/space/bomberman/dropped(mob/user as mob)
 	..()

--- a/code/modules/events/money_hacker.dm
+++ b/code/modules/events/money_hacker.dm
@@ -35,7 +35,7 @@
 	var/sending = message + "<font color='blue'><b>Message dispatched by [my_department].</b></font>"
 
 	var/pass = 0
-	for(var/obj/machinery/message_server/MS in machines)
+	for(var/obj/machinery/message_server/MS in message_servers)
 		if(!MS.active) continue
 		// /obj/machinery/message_server/proc/send_rc_message(var/recipient = "",var/sender = "",var/message = "",var/stamp = "", var/id_auth = "", var/priority = 1)
 		MS.send_rc_message("Engineering/Security/Bridge", my_department, message, "", "", 2)
@@ -91,7 +91,7 @@
 		var/sending = message + "<font color='blue'><b>Message dispatched by [my_department].</b></font>"
 
 		var/pass = 0
-		for(var/obj/machinery/message_server/MS in machines)
+		for(var/obj/machinery/message_server/MS in message_servers)
 			if(!MS.active) continue
 			// /obj/machinery/message_server/proc/send_rc_message(var/recipient = "",var/sender = "",var/message = "",var/stamp = "", var/id_auth = "", var/priority = 1)
 			MS.send_rc_message("Engineering/Security/Bridge", my_department, message, "", "", 2)

--- a/code/modules/power/antimatter/computer.dm
+++ b/code/modules/power/antimatter/computer.dm
@@ -18,10 +18,10 @@
 /obj/machinery/computer/am_engine/New()
 	..()
 	spawn( 24 )
-		for(var/obj/machinery/power/am_engine/engine/E in machines)
+		for(var/obj/machinery/power/am_engine/engine/E in power_machines)
 			if(E.engine_id == src.engine_id)
 				src.connected_E = E
-		for(var/obj/machinery/power/am_engine/injector/I in machines)
+		for(var/obj/machinery/power/am_engine/injector/I in power_machines)
 			if(I.engine_id == src.engine_id)
 				src.connected_I = I
 	return

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -105,6 +105,12 @@
 	src.tdir = dir		// to fix Vars bug
 	dir = SOUTH
 
+	if(areaMaster.areaapc)
+		world.log << "Secondary APC detected in area: [areaMaster.name], deleting the second APC"
+		qdel(src)
+		return
+	areaMaster.set_apc(src)
+
 	if(src.tdir & 3)
 		pixel_x = 0
 		pixel_y = (src.tdir == 1 ? 24 : -24)
@@ -1265,6 +1271,7 @@ obj/machinery/power/apc/proc/autoset(var/val, var/on)
 					sleep(1)
 
 /obj/machinery/power/apc/Destroy()
+	areaMaster.remove_apc(src)
 	if(malfai && operating)
 		if (ticker.mode.config_tag == "malfunction")
 			if (STATION_Z == z)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -124,6 +124,8 @@
 	fixture_type = "bulb"
 	sheets_refunded = 1
 
+var/global/list/obj/machinery/light/alllights = list()
+
 // the standard tube light fixture
 /obj/machinery/light
 	name = "light fixture"
@@ -193,6 +195,7 @@
 // create a new lighting fixture
 /obj/machinery/light/New()
 	..()
+	alllights += src
 
 	spawn(2)
 		switch(fitting)
@@ -208,6 +211,7 @@
 /obj/machinery/light/Destroy()
 	seton(0)
 	..()
+	alllights -= src
 
 /obj/machinery/light/update_icon()
 

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -193,13 +193,6 @@
 		if(C.d1 == 0)
 			return C
 
-/area/proc/get_apc()
-	for(var/area/RA in src.related)
-		var/obj/machinery/power/apc/FINDME = locate() in RA
-
-		if(FINDME)
-			return FINDME
-
 /obj/machinery/proc/addStaticPower(value, powerchannel)
 	if(!areaMaster)
 		return

--- a/code/modules/power/powernet.dm
+++ b/code/modules/power/powernet.dm
@@ -266,7 +266,7 @@ var/global/powernets_broke = 0
 
 	if(isarea(power_source))
 		source_area = power_source
-		power_source = source_area.get_apc()
+		power_source = source_area.areaapc
 
 	if(istype(power_source, /obj/structure/cable))
 		var/obj/structure/cable/Cable = power_source

--- a/code/modules/security levels/keycard authentication.dm
+++ b/code/modules/security levels/keycard authentication.dm
@@ -1,3 +1,5 @@
+var/global/list/obj/machinery/keycard_auth/authenticators = list()
+
 /obj/machinery/keycard_auth
 	name = "Keycard Authentication Device"
 	desc = "This device is used to trigger station functions, which require more than one ID card to authenticate."
@@ -19,6 +21,10 @@
 	idle_power_usage = 2
 	active_power_usage = 6
 	power_channel = ENVIRON
+
+/obj/machinery/keycard_auth/New()
+	..()
+	authenticators += src
 
 /obj/machinery/keycard_auth/attack_ai(mob/user as mob)
 	user << "The station AI is not to interact with these devices."
@@ -50,6 +56,10 @@
 		icon_state = "auth_off"
 	else
 		stat |= NOPOWER
+
+/obj/machinery/keycard_auth/Destroy()
+	..()
+	authenticators -= src
 
 /obj/machinery/keycard_auth/attack_hand(mob/user as mob)
 	if(user.stat || stat & (NOPOWER|BROKEN))
@@ -126,7 +136,7 @@
 
 /obj/machinery/keycard_auth/proc/broadcast_request()
 	icon_state = "auth_on"
-	for(var/obj/machinery/keycard_auth/KA in machines)
+	for(var/obj/machinery/keycard_auth/KA in authenticators)
 		if(KA == src) continue
 		KA.reset()
 		spawn()


### PR DESCRIPTION
Painstakingly goes through the 'in world' commit again to use the proper lists for all objects that are autoremoved from the machines list.

Also removes an extremely laggy proc called get_apc() which called locate throughout all related areas until it found an apc, instead apcs are linked to the areas they are in as only one is allowed per area in any case.