### PR TITLE
Stat fix

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1197,7 +1197,7 @@ var/list/slot_equipment_priority = list( \
 						statpanel(S.panel,"[S.charge_counter]/[S.charge_max]",S)
 					if(Sp_HOLDVAR)
 						statpanel(S.panel,"[S.holder_var_type] [S.holder_var_amount]",S)
-	if(world.tick_lag < 0.5) sleep(1)
+	sleep(4) //Prevent updating the stat panel for the next .4 seconds, prevents clientside latency from updates
 
 
 


### PR DESCRIPTION
Change stat from if(ticklag < .5), sleep(1) to a simple sleep(4).

Sleep(1) should only delay the update if the ticklag was less than .1, however byond-wise sleep(4) is assured to delay any stat() update that is attempted before .4 seconds are up.