### PR TITLE
Runtimes

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -51,7 +51,11 @@ proc/random_facial_hair_style(gender, species = "Human")
 
 proc/random_name(gender, speciesName = "Human")
 	var/datum/species/S = all_species[speciesName]
-	return S.makeName(gender)
+	if(S)
+		return S.makeName(gender)
+	else
+		var/datum/species/human/H
+		return H.makeName(gender)
 
 proc/random_skin_tone()
 	switch(pick(60;"caucasian", 15;"afroamerican", 10;"african", 10;"latino", 5;"albino"))

--- a/code/game/machinery/metaldetector.dm
+++ b/code/game/machinery/metaldetector.dm
@@ -44,27 +44,23 @@
 			&& !istype(perp.r_hand, /obj/item/weapon/gun/energy/laser/practice))
 				threatcount += 4
 
-		if(ishuman(perp))
-			if(istype(perp.belt, /obj/item/weapon/gun) || istype(perp.belt, /obj/item/weapon/melee))
-				if(!istype(perp.belt, /obj/item/weapon/gun/energy/laser/bluetag) \
-				&& !istype(perp.belt, /obj/item/weapon/gun/energy/laser/redtag) \
-				&& !istype(perp.belt, /obj/item/weapon/gun/energy/laser/practice))
-					threatcount += 2
-
 		if(istype(perp.back, /obj/item/weapon/gun) || istype(perp.back, /obj/item/weapon/melee))
 			if(!istype(perp.back, /obj/item/weapon/gun/energy/laser/bluetag) \
 			&& !istype(perp.back, /obj/item/weapon/gun/energy/laser/redtag) \
 			&& !istype(perp.back, /obj/item/weapon/gun/energy/laser/practice))
 				threatcount += 2
 
-
-
-		if(istype(perp.s_store, /obj/item/weapon/gun) || istype(perp.s_store, /obj/item/weapon/melee))
-			if(!istype(perp.s_store, /obj/item/weapon/gun/energy/laser/bluetag) \
-			&& !istype(perp.s_store, /obj/item/weapon/gun/energy/laser/redtag) \
-			&& !istype(perp.s_store, /obj/item/weapon/gun/energy/laser/practice))
-				threatcount += 2
-
+		if(ishuman(perp))
+			if(istype(perp.belt, /obj/item/weapon/gun) || istype(perp.belt, /obj/item/weapon/melee))
+				if(!istype(perp.belt, /obj/item/weapon/gun/energy/laser/bluetag) \
+				&& !istype(perp.belt, /obj/item/weapon/gun/energy/laser/redtag) \
+				&& !istype(perp.belt, /obj/item/weapon/gun/energy/laser/practice))
+					threatcount += 2
+			if(istype(perp.s_store, /obj/item/weapon/gun) || istype(perp.s_store, /obj/item/weapon/melee))
+				if(!istype(perp.s_store, /obj/item/weapon/gun/energy/laser/bluetag) \
+				&& !istype(perp.s_store, /obj/item/weapon/gun/energy/laser/redtag) \
+				&& !istype(perp.s_store, /obj/item/weapon/gun/energy/laser/practice))
+					threatcount += 2
 
 		if(scanmode)
 			//

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -975,7 +975,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 						dat += {"<span class='warning'>It appears that our services have yet to produce a minimap of this station. We apologize for the inconvenience.</span>"}
 
 					if(T.z == map.zMainStation)
-						dat += {"Current Location: <b>[T.loc.name] ([T.x-WORLD_X_OFFSET],[T.y-WORLD_Y_OFFSET],1)</b><br>"}	//it's a "Station Map" app, so it only gives information reguarding
+						dat += {"Current Location: <b>[T.loc.name] ([T.x-WORLD_X_OFFSET[map.zMainStation]],[T.y-WORLD_Y_OFFSET[map.zMainStation]],1)</b><br>"}	//it's a "Station Map" app, so it only gives information reguarding
 					else																									//the station's z-level
 						dat += {"Current Location: <b>Unknown</b><br>"}
 
@@ -987,7 +987,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 						if(T.z == map.zMainStation)
 							dat += {"<img src="pda_minimap_loc.gif" style="position: absolute; top: [(T.y * -1) + 247]px; left: [T.x-8]px;"/>"}
 						for(var/datum/minimap_marker/mkr in app.markers)
-							dat += {"<img src="pda_minimap_mkr.gif" style="position: absolute; top: [((mkr.y+WORLD_Y_OFFSET) * -1) + 247]px; left: [mkr.x+WORLD_X_OFFSET-8]px;"/>"}
+							dat += {"<img src="pda_minimap_mkr.gif" style="position: absolute; top: [((mkr.y+WORLD_Y_OFFSET[map.zMainStation]) * -1) + 247]px; left: [mkr.x+WORLD_X_OFFSET[map.zMainStation]-8]px;"/>"}
 						dat += {"</div>"}
 
 					else
@@ -998,7 +998,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 						if(T.z == map.zMainStation)
 							dat += {"<img src="pda_minimap_loc.gif" style="position: absolute; top: [(T.y * -1) + 247]px; left: [T.x-8]px;"/>"}
 						for(var/datum/minimap_marker/mkr in app.markers)
-							dat += {"<img src="pda_minimap_mkr.gif" style="position: absolute; top: [((mkr.y+WORLD_Y_OFFSET) * -1) + 247]px; left: [mkr.x+WORLD_X_OFFSET-8]px;"/>"}
+							dat += {"<img src="pda_minimap_mkr.gif" style="position: absolute; top: [((mkr.y+WORLD_Y_OFFSET[map.zMainStation]) * -1) + 247]px; left: [mkr.x+WORLD_X_OFFSET[map.zMainStation]-8]px;"/>"}
 						dat += {"</div>"}
 
 /*

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -31,7 +31,7 @@
 	if(src.engraving)
 		user << src.engraving
 
-/turf/simulated/wall/proc/dismantle_wall(devastated = 0, explode = 0)
+/turf/simulated/wall/dismantle_wall(devastated = 0, explode = 0)
 	if(istype(src, /turf/simulated/wall/r_wall)) //Reinforced girder has deconstruction steps too. If no girder, drop ONE plasteel sheet AND rods
 		if(!devastated)
 			getFromPool(/obj/item/stack/sheet/plasteel, get_turf(src))

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -562,6 +562,9 @@
 /turf/proc/canBuildPlating()
 	return BUILD_SILENT_FAILURE
 
+/turf/proc/dismantle_wall()
+	return
+
 /////////////////////////////////////////////////////
 
 /turf/proc/spawn_powerup()

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -263,7 +263,7 @@ It's fairly easy to fix if dealing with single letters but not so much with comp
 	return copytext(sanitize(t),1,MAX_MESSAGE_LEN)
 
 
-/proc/shake_camera(mob/M, duration, strength=1)
+/proc/shake_camera(mob/M, duration=0, strength=1)
 	if(!M || !M.client || M.shakecamera)
 		return
 	spawn(1)

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -27,6 +27,9 @@
 
 
 /obj/item/weapon/gun/energy/update_icon()
+	if(!power_supply.maxcharge)
+		ASSERT(power_supply.maxcharge > 0)
+		return
 	var/ratio = power_supply.charge / power_supply.maxcharge
 	ratio = round(ratio, 0.25) * 100
 	if(modifystate && charge_states)


### PR DESCRIPTION
Fixes a runtime if someone called shake screen without specifying duration and thus being passed as null

Fixes a zlevel offset runtime error in pda maps

Fixes a runtime where the all species list wasn't defined yet when calling random make name for a new client

Fixes another runtime with dismantlewall stemming from the fact byond turfs are **never deleted** merely changed to another type, so a proc defined on a lower level being called on the new turf doesn't exist.
^**Protip**: if you are going to call a turf proc after sleep(), make sure it is defined on the most base turf level so it doesn't runtime.

Fix metal detector runtime as suit storage wasn being checked after carbon lifeforms but before an ishuman check

Adds sanity against energy guns having 0 maximum charge on their power supply causing a division by zero runtime and adds an assert to cause a stacktrace to get more information on how this ever happened.