### PR TITLE
[DNM] Light Replacer Snazzification

### DIFF
--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -305,7 +305,7 @@
 					//Janitor
 					if(istype(O, /obj/item/device/lightreplacer))
 						var/obj/item/device/lightreplacer/LR = O
-						LR.Charge(R)
+						LR.add_glass(500) //Note: Adjust if the default borg light replacer efficiency is changed.
 
 				if(R)
 					if(R.module)

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -41,7 +41,7 @@
 /obj/item/device/lightreplacer
 
 	name = "light replacer"
-	desc = "A device to automatically replace lights. Refill with working lightbulbs."
+	desc = "A device to automatically replace lights. Takes lights from a supply box and puts the spent ones in a waste box."
 
 	icon = 'icons/obj/janitor.dmi'
 	icon_state = "lightreplacer0"
@@ -52,30 +52,46 @@
 	slot_flags = SLOT_BELT
 	origin_tech = "magnets=3;materials=2"
 
-	var/max_uses = 20
-	var/uses = 0
+	var/obj/item/weapon/storage/box/lights/supply = null //Takes bulbs from here to replace
+	var/obj/item/weapon/storage/box/lights/waste = null //Places replaced bulbs here
 	var/emagged = 0
-	var/failmsg = ""
-	// How much to increase per each glass?
-	var/increment = 5
-	// How much to take from the glass?
-	var/decrement = 1
 	var/charge = 1
 
-/obj/item/device/lightreplacer/New()
-	uses = max_uses / 2
-	failmsg = "The [name]'s refill light blinks red."
+/obj/item/device/lightreplacer/loaded/New() //Contains only a waste box. Exists mainly just as a parent of the other loaded ones, but I guess you can use it.
 	..()
+	waste = new(src)
+
+/obj/item/device/lightreplacer/loaded/mixed/New() //Contains a box of normal mixed lights plus a waste box.
+	..()
+	supply = new /obj/item/weapon/storage/box/lights/mixed(src)
+
+/obj/item/device/lightreplacer/loaded/he/New() //Contains a box of high-efficiency mixed lights plus a waste box.
+	..()
+	supply = new /obj/item/weapon/storage/box/lights/he(src)
+
 
 /obj/item/device/lightreplacer/examine(mob/user)
 	..()
-	user << "<span class='info'>It has [uses] light\s remaining.</span>"
+	if(supply)
+		if(supply.contents.len)
+			user << "<span class='info'>It has [supply.contents.len] light\s remaining. Check its interface to see what type[supply.contents.len ? "s" : ""].</span>"
+		else
+			user << "<span class='info'>Its supply container is empty.</span>"
+	else
+		user << "<span class='info'>It has no supply container.</span>"
+
+	if(waste)
+		user << "<span class='info'>Its waste container has [waste.contents.len] slots full.</span>"
+	else
+		user << "<span class='info'>It has no waste container.</span>"
+
 
 /obj/item/device/lightreplacer/attackby(obj/item/W, mob/user)
 	if(istype(W,  /obj/item/weapon/card/emag) && emagged == 0)
 		Emag()
 		return
 
+/* //May or may not be added back in, but not just yet.
 	if(istype(W, /obj/item/stack/sheet/glass/glass))
 		var/obj/item/stack/sheet/glass/glass/G = W
 		if(G.amount - decrement >= 0 && uses < max_uses)
@@ -90,20 +106,36 @@
 			AddUses(increment)
 			user << "You insert a piece of glass into the [src.name]. You have [uses] lights remaining."
 			return
+*/
 
 	if(istype(W, /obj/item/weapon/light))
-		var/obj/item/weapon/light/L = W
-		if(L.status == 0) // LIGHT OKAY
-			if(uses < max_uses)
-				AddUses(1)
-				user << "You insert the [L.name] into the [src.name]. You have [uses] lights remaining."
-				user.drop_item(L)
-				del(L)
-				return
-		else
-			user << "You need a working light."
-			return
+		switch(insert_if_possible(W))
+			if(0)
+				if(W:status ? istype(waste) : istype(supply)) //The expression returns true if the correct box for the light is valid, which implies that it is full.
+					user << "<span class='warning'>\The [src]'s [W:status ? "waste" : "supply"] container is full!</span>"
+				else
+					user << "<span class='warning'>\The [src] has no [W:status ? "waste" : "supply"] container!</span>"
+			if(1)
+				user.visible_message("[user] inserts \a [W] into \the [src]", "You insert \the [W] into \the [src]'s [W:status ? "waste" : "supply"] container.")
+			else
+				user << "<span class='bnotice'>Something very strange has happened. Please adminhelp and ask someone to view the variables of that light, especially status.</span>"
+		return
 
+	if(istype(W, /obj/item/weapon/storage/box/lights))
+		if(!supply)
+			user.drop_item(W, src)
+			user.visible_message("[user] inserts \a [W] into \the [src]", "You insert \the [W] into \the [src] to be used as the supply container.")
+			supply = W
+			return
+		else if(!waste)
+			user.drop_item(W, src)
+			user.visible_message("[user] inserts \a [W] into \the [src]", "You insert \the [W] into \the [src] to be used as the waste container.")
+			waste = W
+			return
+		else
+			user << "<span class='notice'>\The [src] has both a supply box and a waste box. Remove one first if you want to insert a new one.</span>"
+			return
+		
 
 /obj/item/device/lightreplacer/attack_self(mob/user)
 	/* // This would probably be a bit OP. If you want it though, uncomment the code.
@@ -114,72 +146,95 @@
 			usr << "You shortcircuit the [src]."
 			return
 	*/
-	usr << "It has [uses] lights remaining."
+
+	var/dat = "<TITLE>Light Replacer Interface</TITLE>"
+
+	if(supply)
+		dat += "<h3>Supply Container:</h3>"
+		var/list/light_types = new()
+		for(var/obj/item/weapon/light/L in supply)
+			if(!light_types[L.name])
+				light_types[L.name] = 0
+			light_types[L.name]++
+	
+		for(var/T in light_types)
+			dat += "<br><b>[T]: </b>[light_types[T]]"
+
+		dat += "<br><b><a href='?src=\ref[src];eject=supply'>Eject Supply Container</a></b>"
+
+	else
+		dat += "<h3>No supply container inserted</h3>"
+
+	if(waste)
+		dat += {"<br><br><br><h3>Waste Container:</h3>
+	
+		<b>Filled: </b>[waste.contents.len]/[waste.storage_slots]<br>
+		<b><a href='?src=\ref[src];eject=waste'>Eject Waste Container</a></b>
+		"}
+	else
+		dat += "<br><br><br><h3>No waste container inserted</h3>"
+
+	user << browse(dat, "window=lightreplacer")
 
 /obj/item/device/lightreplacer/update_icon()
 	icon_state = "lightreplacer[emagged]"
 
 
-/obj/item/device/lightreplacer/proc/Use(var/mob/user)
-
-	playsound(get_turf(src), 'sound/machines/click.ogg', 50, 1)
-	AddUses(-1)
-	return 1
-
-// Negative numbers will subtract
-/obj/item/device/lightreplacer/proc/AddUses(var/amount = 1)
-	uses = min(max(uses + amount, 0), max_uses)
-
 /obj/item/device/lightreplacer/proc/Charge(var/mob/user)
 	charge += 1
 	if(charge > 7)
-		AddUses(1)
 		charge = 1
 
-/obj/item/device/lightreplacer/proc/ReplaceLight(var/obj/machinery/light/target, var/mob/living/U)
-
-	if(target.status != LIGHT_OK)
-		if(CanUse(U))
-			if(!Use(U)) return
-			U << "<span class='notice'>You replace the [target.fitting] with the [src].</span>"
-
-			if(target.status != LIGHT_EMPTY)
-
-				var/obj/item/weapon/light/L1 = new target.light_type(target.loc)
-				L1.status = target.status
-				L1.rigged = target.rigged
-				L1.brightness_range = target.brightness_range
-				L1.brightness_power = target.brightness_power
-				L1.brightness_color = target.brightness_color
-				L1.switchcount = target.switchcount
-				target.switchcount = 0
-				L1.update()
-
-				target.status = LIGHT_EMPTY
-				target.update()
-
-			var/obj/item/weapon/light/L2 = new target.light_type()
-
-			target.status = L2.status
-			target.switchcount = L2.switchcount
-			target.rigged = emagged
-			target.brightness_range = L2.brightness_range
-			target.brightness_power = L2.brightness_power
-			target.brightness_color = L2.brightness_color
-			target.on = target.has_power()
-			target.update()
-			del(L2)
-
-			if(target.on && target.rigged)
-				target.explode()
-			return
-
-		else
-			U << failmsg
-			return
-	else
-		U << "There is a working [target.fitting] already inserted."
+/obj/item/device/lightreplacer/proc/ReplaceLight(var/obj/machinery/light/target, var/mob/living/user)
+	var/obj/item/weapon/light/best_light = get_best_light(target)
+	if(best_light == 0)
+		user << "<span class='warning'>\The [src] has no supply container!</span>"
 		return
+	else if(!best_light)
+		user << "<span class='warning'>\The [src] has no compatible light!</span>"
+		return
+	if(!is_light_better(best_light, target))
+		user << "<span class='notice'>\The [src] has no light better than the one already in \the [target].</span>"
+		return
+
+	user << "<span class='notice'>You replace the [target.fitting] with \the [src].</span>"
+	playsound(get_turf(src), 'sound/machines/click.ogg', 50, 1)
+
+	supply.remove_from_storage(best_light)
+
+	if(target.status != LIGHT_EMPTY)
+		var/obj/item/weapon/light/L1 = new target.light_type(target.loc)
+		L1.status = target.status
+		L1.rigged = target.rigged
+		L1.brightness_range = target.brightness_range
+		L1.brightness_power = target.brightness_power
+		L1.brightness_color = target.brightness_color
+		L1.switchcount = target.switchcount
+		target.switchcount = 0
+		L1.update()
+		target.status = LIGHT_EMPTY
+		target.update()
+		if(!insert_if_possible(L1))
+			if(istype(waste))
+				user << "<span class='warning'>\The [src]'s waste container is full and it drops the removed light on the floor!</span>"
+			else
+				user << "<span class='warning'>\The [src] has no waste container and it drops the removed light on the floor!</span>"
+
+	target.status = best_light.status
+	target.switchcount = best_light.switchcount
+	target.rigged = emagged || best_light.rigged
+	target.brightness_range = best_light.brightness_range
+	target.brightness_power = best_light.brightness_power
+	target.brightness_color = best_light.brightness_color
+	target.cost = best_light.cost
+	target.base_state = best_light.base_state
+	target.light_type = best_light.type
+	target.on = target.has_power()
+	target.update()
+	del(best_light)
+	if(target.on && target.rigged)
+		target.explode()
+
 
 /obj/item/device/lightreplacer/proc/Emag()
 	emagged = !emagged
@@ -190,15 +245,98 @@
 		name = initial(name)
 	update_icon()
 
+
+//Attempts to insert a light into the light replacer's storage.
+//If the light works, attempts to place it in the supply box. Otherwise, attempts to place it in the waste box.
+//Fails if the light cannot be placed into the correct box for any reason.
+//Returns 0 if the light is successfully inserted into the correct box, 1 if the insertion fails, and null if the item to be inserted is not a light or something very strange happens.
+/obj/item/device/lightreplacer/proc/insert_if_possible(var/obj/item/weapon/light/L) 
+	if(!istype(L))
+		return
+	if(L.status == LIGHT_OK)
+		if(supply && supply.can_be_inserted(L, TRUE))
+			supply.handle_item_insertion(L, TRUE)
+			return 1
+		else
+			return 0
+	else if(L.status == LIGHT_BROKEN || L.status == LIGHT_BURNED)
+		if(waste && waste.can_be_inserted(L, TRUE))
+			waste.handle_item_insertion(L, TRUE)
+			return 1
+		else
+			return 0
+
+//Returns the best light currently in the supply container that is compatible with target.
+//For the standard light replacer, it just prioritizes HE lights over standard lights. I may add an advanced replacer with better light selection later.
+//Returns null if no compatible bulb is found and 0 if the light replacer has no (valid) supply box.
+/obj/item/device/lightreplacer/proc/get_best_light(var/obj/machinery/light/target)
+	if(!istype(supply))
+		return 0
+	var/best_light
+	switch(target.fitting)
+		if("bulb")
+			best_light = (locate(/obj/item/weapon/light/bulb/he) in supply) || (locate(/obj/item/weapon/light/bulb) in supply)
+		if("tube")
+			best_light = (locate(/obj/item/weapon/light/tube/he) in supply) || (locate(/obj/item/weapon/light/tube) in supply)
+		if("large tube")
+			best_light = locate(/obj/item/weapon/light/tube/large) in supply
+	return best_light
+
+//Returns 1 if the first argument is considered better, 0 if the second is better or they are equal, and null if either argument is invalid.
+//To be valid, each argument must be an instance of either /obj/item/weapon/light or /obj/machinery/light.
+//Again, standard replacer just checks as follows:
+//HE light < standard light < no light < broken light = burned-out light
+//In normal operation, tested should never be no light and very rarely be a broken light.
+/obj/item/device/lightreplacer/proc/is_light_better(var/obj/tested, var/obj/comparison)
+	if(!(istype(tested, /obj/item/weapon/light) || istype(tested, /obj/machinery/light)) || !(istype(comparison, /obj/item/weapon/light) || istype(comparison, /obj/machinery/light)))
+		return
+	if(tested:status >= LIGHT_BROKEN) //Is tested broken or burnt out? If so, it cannot win.
+		return 0
+	if(tested:status < comparison:status) //Is tested closer to functional than comparison? If so, it wins.
+		return 1
+	if(tested:status) //Is tested empty? If so, either it must be a tie or comparison wins, so tested cannot win.
+		return 0
+
+	//Now we know both work, so all that is left is to test is if tested wins by being HE.
+	if(findtextEx(tested:base_state, "he", 1, 3) && !findtextEx(comparison:base_state, "he", 1, 3))
+		return 1
+	else
+		return 0
+
 //Can you use it?
+//This used to actually check if it wasn't empty, but that's handled in ReplaceLight() now.
 
 /obj/item/device/lightreplacer/proc/CanUse(var/mob/living/user)
 	src.add_fingerprint(user)
 	//Not sure what else to check for. Maybe if clumsy?
-	if(uses > 0)
-		return 1
-	else
-		return 0
+	return 1
+
+/obj/item/device/lightreplacer/Topic(href, href_list)
+	if(..()) return 1
+
+	if(href_list["eject"])
+		switch(href_list["eject"])
+
+			if("supply")
+				if(usr)
+					usr.put_in_hands(supply)
+					usr.visible_message("[usr] removes \the [supply] from \the [src].", "You remove \the [src]'s supply container, \the [supply].")
+				else
+					supply.loc = get_turf(src)
+				supply = null
+				if(usr) attack_self(usr)
+				return 1
+
+			if("waste")
+				if(usr)
+					usr.put_in_hands(waste)
+					usr.visible_message("[usr] removes \the [waste] from \the [src].", "You remove \the [src]'s waste container, \the [waste].")
+				else
+					waste.loc = get_turf(src)
+				waste = null
+				if(usr) attack_self(usr)
+				return 1
+
 
 #undef LIGHT_OK
 #undef LIGHT_EMPTY

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -60,11 +60,10 @@
 	var/prod_quality = 30 //Starting switchcount for lights this builds out of glass
 	var/prod_eff = 10 //How many times more glass it uses to build lights than would an autolathe
 	var/emagged = 0
-	var/charge = 1
 
 /obj/item/device/lightreplacer/borg //Since it will mainly be loaded by processing glass, it is MUCH better at it than the standard version.
-	glass_stor = 10 * CC_PER_SHEET_GLASS //Twice the capacity of the standard version
-	glass_stor_max = 10 * CC_PER_SHEET_GLASS //Starts full
+	glass_stor_max = 10 * CC_PER_SHEET_GLASS //Twice the capacity of the standard version
+	glass_stor = 0 //Actually starts full, but this is done in New()
 	prod_quality = 0 //Just as good as lights from a box/autolathe
 	prod_eff = 5 //Half the glass per light as the standard version
 
@@ -80,10 +79,11 @@
 	..()
 	supply = new /obj/item/weapon/storage/box/lights/he(src)
 
-/obj/item/device/lightreplacer/borg/New() //Contains a box of mixed lights and a waste box.
+/obj/item/device/lightreplacer/borg/New() //Contains a box of mixed lights and a waste box and starts full of glass.
 	..()
 	supply = new /obj/item/weapon/storage/box/lights/mixed(src)
 	waste = new /obj/item/weapon/storage/box/lights(src)
+	glass_stor = glass_stor_max
 
 /obj/item/device/lightreplacer/examine(mob/user)
 	..()
@@ -194,11 +194,6 @@
 /obj/item/device/lightreplacer/update_icon()
 	icon_state = "lightreplacer[emagged]"
 
-
-/obj/item/device/lightreplacer/proc/Charge(var/mob/user)
-	charge += 1
-	if(charge > 7)
-		charge = 1
 
 /obj/item/device/lightreplacer/proc/ReplaceLight(var/obj/machinery/light/target, var/mob/living/user)
 	var/obj/item/weapon/light/best_light = get_best_light(target)

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -83,19 +83,7 @@
 /obj/item/device/lightreplacer/borg/New() //Contains a box of mixed lights and a special recycling box.
 	..()
 	supply = new /obj/item/weapon/storage/box/lights/mixed(src)
-	waste = new /obj/item/weapon/storage/box/lights/lrdisposal(src)
-
-/obj/item/weapon/storage/box/lights/lrdisposal
-	name = "light recycler"
-	desc = "A special unit capable of recycling lights into glass. Unfortunately, the metal is lost."
-
-/obj/item/weapon/storage/box/lights/lrdisposal/handle_item_insertion(obj/item/W as obj, prevent_warning = 0)
-	. = ..()
-	if(!istype(loc, /obj/item/device/lightreplacer) || !istype(W, /obj/item/weapon/light))
-		return
-	var/obj/item/device/lightreplacer/LR = loc
-	LR.add_glass(W.g_amt, 2)
-	del(W)
+	waste = new /obj/item/weapon/storage/box/lights(src)
 
 /obj/item/device/lightreplacer/examine(mob/user)
 	..()

--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -54,7 +54,7 @@
 	new /obj/item/weapon/caution(src)
 	new /obj/item/weapon/caution(src)
 	new /obj/item/weapon/storage/bag/trash(src)
-	new /obj/item/device/lightreplacer(src)
+	new /obj/item/device/lightreplacer/loaded/mixed(src)
 	new /obj/item/clothing/gloves/black(src)
 	new /obj/item/clothing/head/soft/purple(src)
 	new /obj/item/weapon/storage/box/lights/he(src)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -280,7 +280,7 @@
 	src.modules += new /obj/item/weapon/soap/nanotrasen(src)
 	src.modules += new /obj/item/weapon/storage/bag/trash(src)
 	src.modules += new /obj/item/weapon/mop(src)
-	src.modules += new /obj/item/device/lightreplacer(src)
+	src.modules += new /obj/item/device/lightreplacer/borg(src)
 	src.modules += new /obj/item/weapon/reagent_containers/glass/bucket(src)
 	src.modules += new /obj/item/weapon/crowbar(src)
 	src.emag = new /obj/item/weapon/reagent_containers/spray(src)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -621,6 +621,7 @@ var/global/list/obj/machinery/light/alllights = list()
 	name = "high efficiency light tube"
 	desc = "An efficient light used to reduce strain on the station's power grid."
 	base_state = "hetube"
+	g_amt = 300
 	cost = 2
 
 /obj/item/weapon/light/tube/large
@@ -628,6 +629,8 @@ var/global/list/obj/machinery/light/alllights = list()
 	name = "large light tube"
 	brightness_range = 15
 	brightness_power = 4
+	g_amt = 200
+	m_amt = 100
 	cost = 15
 
 /obj/item/weapon/light/bulb
@@ -637,7 +640,8 @@ var/global/list/obj/machinery/light/alllights = list()
 	base_state = "bulb"
 	item_state = "contvapour"
 	fitting = "bulb"
-	g_amt = 100
+	m_amt = 30
+	g_amt = 50
 	brightness_range = 5
 	brightness_power = 2
 	brightness_color = "#a0a080"
@@ -649,6 +653,7 @@ var/global/list/obj/machinery/light/alllights = list()
 	desc = "An efficient light used to reduce strain on the station's power grid."
 	base_state = "hebulb"
 	cost = 1
+	g_amt = 150
 	brightness_color = null//These should be white
 
 /obj/item/weapon/light/throw_impact(atom/hit_atom)
@@ -661,7 +666,7 @@ var/global/list/obj/machinery/light/alllights = list()
 	icon_state = "fbulb"
 	base_state = "fbulb"
 	item_state = "egg4"
-	g_amt = 100
+	g_amt = 300
 	brightness_range = 5
 	brightness_power = 2
 


### PR DESCRIPTION
I started working on this yesterday. It's almost finished, but not quite.
To do:
- [x] Change the one in the janitor's locker to loaded/mixed
- [ ] Make borg light replacers... work
- ~~Possibly make advanced variant with more customizability in where it puts removed lights (ex: option to only put HE lights in supply and put normal lights in waste whether they work or not)~~ Nah I'll do that later (if ever)
- [x] Think of more things for this list
- [x] Fix silly description error and huge space in interface window
- [ ] Changelog
- [x] Re-add manufacturing of bulbs from glass
- [x] `target.rigged = emagged || best_light.rigged`

This PR greatly alters the light replacer. Rather than magically transmuting all lights and glass sheets into whatever light it happens to be used on and dropping the old one on the ground, the light replacer now draws lights from an inventory and places the ones taken from fixtures into an inventory.
- Light replacer now holds two boxes
  - Only accepts /obj/item/weapon/storage/box/lights and its subtypes for these boxes
  - One box is its light supply
    - Lights inserted into fixtures are drawn from this supply
    - Chooses the "best" light in its supply box that is compatible with the fixture it is used on
      - At the moment, it just prioritizes HE lights over regular ones
    - If it has a light that is "better" than the current one in the fixture, it will replace the one in the fixture, regardless of whether or not the one in the fixture works
      - If it does work, it is placed into the supply box
    - Interface popup (accessed by clicking the light replacer in your active hand) says how many of each type of light the supply box has
  - The other box is its waste container
    - Broken or burnt-out lights inserted into the light replacer go in here
    - Interface readout says how full this is, but not what types of lights it contains, as they should all be broken
  - Interface popup allows either box to be ejected
  - Boxes can, of course, be inserted
    - If you attempt to insert a box, it first tries to use it as the supply, then tries to use it as the waste container if it already has a supply container. Obviously fails if it has both.
  - Lights can be inserted the same way as before, too, though it's generally much slower than just replacing the supply/waste box
    - Working ones inserted this way go into the supply box, broken/burnt-out ones go into the waste box

Webm demo: https://www.dropbox.com/s/8s2hployrjt155y/2015-06-01_16-20-05.webm?dl=0

Fixes #4972 
Fixes #4988 
