### PR TITLE
Fix spellmaster loss

### DIFF
--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -33,7 +33,7 @@
 
 	if(spell_masters)
 		for(var/obj/screen/movable/spell_master/spell_master in spell_masters)
-			spell_master.toggle_open()
+			spell_master.toggle_open(1)
 			client.screen -= spell_master
 
 	client.reset_screen()				//remove hud items just in case

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -30,6 +30,12 @@
 
 	if(hud_used)	qdel(hud_used)		//remove the hud objects
 	client.images = null				//remove the images such as AIs being unable to see runes
+
+	if(spell_masters)
+		for(var/obj/screen/movable/spell_master/spell_master in spell_masters)
+			spell_master.toggle_open()
+			client.screen -= spell_master
+
 	client.reset_screen()				//remove hud items just in case
 	hud_used = new /datum/hud(src)
 	gui_icons = new /datum/ui_icons(src)


### PR DESCRIPTION
This fixes spellmasters being lost upon reenter corpse and any other login due to it being deleted in reset_screen() instead of preserved