### PR TITLE
Fixes inventory bugs

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -26,6 +26,9 @@
 	maptext_height = 480
 	maptext_width = 480
 
+/obj/screen/proc/pool_on_reset() //This proc should be redefined to 0 for ANY obj/screen that is shared between more than 1 mob, ie storage screens
+	. = 1
+
 
 /obj/screen/inventory
 	var/slot_id	//The indentifier for the slot. It has nothing to do with ID cards.
@@ -43,6 +46,9 @@
 			var/obj/item/clothing/suit/storage/S = master
 			S.close(usr)
 	return 1
+
+/obj/screen/close/pool_on_reset()
+	. = 0
 
 
 /obj/screen/item_action
@@ -103,6 +109,9 @@
 			master.attackby(I, usr, params)
 			//usr.next_move = world.time+2
 	return 1
+
+/obj/screen/storage/pool_on_reset()
+	. = 0
 
 /obj/screen/gun
 	name = "gun"
@@ -750,5 +759,6 @@
 
 client/proc/reset_screen()
 	for(var/obj/screen/objects in src.screen)
-		returnToPool(objects)
+		if(objects.pool_on_reset())
+			returnToPool(objects)
 	src.screen = null

--- a/code/_onclick/hud/spell_screen_objects.dm
+++ b/code/_onclick/hud/spell_screen_objects.dm
@@ -12,6 +12,9 @@
 
 	var/mob/spell_holder
 
+/obj/screen/movable/spell_master/pool_on_reset()
+	. = 0
+
 /obj/screen/movable/spell_master/Destroy()
 	..()
 	for(var/obj/screen/spell/spells in spell_objects)
@@ -139,6 +142,9 @@
 	var/obj/screen/movable/spell_master/spellmaster
 
 	var/icon/last_charged_icon
+
+/obj/screen/spell/pool_on_reset()
+	. = 0
 
 /obj/screen/spell/Destroy()
 	..()

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -72,7 +72,7 @@
 	if(spell_masters)
 		for(var/obj/screen/movable/spell_master/spell_master in spell_masters)
 			client.screen += spell_master
-			spell_master.toggle_open(spell_master.showing + 1)
+			spell_master.toggle_open(1)
 
 	if (isobj(loc))
 		var/obj/location = loc

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -7,9 +7,12 @@
 	unset_machine()
 	qdel(hud_used)
 	if(client)
+		for(var/obj/screen/movable/spell_master/spell_master in spell_masters)
+			returnToPool(spell_master)
 		remove_screen_obj_references()
 		for(var/atom/movable/AM in client.screen)
-			if(istype(AM,/obj/screen))
+			var/obj/screen/screenobj = AM
+			if(istype(screenobj) && screenobj.pool_on_reset())
 				returnToPool(AM)
 			else
 				qdel(AM)

--- a/html/changelogs/Clusterfack_4820.yml
+++ b/html/changelogs/Clusterfack_4820.yml
@@ -1,0 +1,5 @@
+author: Clusterfack
+delete-after: true
+changes:
+- bugfix: Fixes a bug where you could lose your spell icons as wizard by leaving your body
+- bugfix: Another fix that should hopefully resolve all issues revolving around storage containers


### PR DESCRIPTION
Fixes #4605
Fixes #4628

I found out why these were being improperly pooled, thanks to skowron for producing a case to reproduce and view the variables of. On login or when reset_screen() was called for a mob that had an inventory open the inventory obj/screen's were being pooled and being reused elsewhere on other objects.

Hilarity ensues!

Updates the spellmaster fix to bring it in line with the new system to prevent improperly pooled screen objects.