### PR TITLE
Runtime fix for lighting

### DIFF
--- a/code/modules/lighting/light_source.dm
+++ b/code/modules/lighting/light_source.dm
@@ -185,7 +185,7 @@
 			T.affecting_lights -= src
 
 		#if LIGHTING_RESOLUTION == 1
-		if(T.dynamic_lighting)
+		if(T.dynamic_lighting && T.lighting_overlay)
 			T.lighting_overlay.update_lumcount(-effect_r[T.lighting_overlay], -effect_g[T.lighting_overlay], -effect_b[T.lighting_overlay])
 		#else
 		for(var/atom/movable/lighting_overlay/L in T.lighting_overlays)


### PR DESCRIPTION
Might be an issue where you actually want to have a lighting overlay but dont. PJB should look it all over when he gets back.

runtime error: Cannot execute null.update lumcount().
proc name: remove lum (/datum/light_source/proc/remove_lum)
  source file: light_source.dm,189
  usr: null
  src: /datum/light_source (/datum/light_source)
  call stack:
/datum/light_source (/datum/light_source): remove lum()
lighting (/datum/controller/process/lighting): doWork()
lighting (/datum/controller/process/lighting): process()
/datum/controller/processSched... (/datum/controller/processScheduler): runProcess(lighting (/datum/controller/process/lighting))