### PR TITLE
Fixes secondary main power and secondary backup power wires in airlocks

### DIFF
--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -144,7 +144,7 @@ var/const/AIRLOCK_WIRE_LIGHT = 2048
 			//Sending a pulse through this flashes the red light on the door (if the door has power).
 			if((A.arePowerSystemsOn()) && (!(A.stat & NOPOWER)) && A.density)
 				A.door_animate("deny")
-		if(AIRLOCK_WIRE_MAIN_POWER1 || AIRLOCK_WIRE_MAIN_POWER2)
+		if(AIRLOCK_WIRE_MAIN_POWER1, AIRLOCK_WIRE_MAIN_POWER2)
 			//Sending a pulse through either one causes a breaker to trip, disabling the door for 10 seconds if backup power is connected, or 1 minute if not (or until backup power comes back on, whichever is shorter).
 			A.loseMainPower()
 		if(AIRLOCK_WIRE_DOOR_BOLTS)
@@ -161,7 +161,7 @@ var/const/AIRLOCK_WIRE_LIGHT = 2048
 						M << "You hear a click from the bottom of the door."
 			A.update_icon()
 
-		if(AIRLOCK_WIRE_BACKUP_POWER1 || AIRLOCK_WIRE_BACKUP_POWER2)
+		if(AIRLOCK_WIRE_BACKUP_POWER1, AIRLOCK_WIRE_BACKUP_POWER2)
 			//two wires for backup power. Sending a pulse through either one causes a breaker to trip, but this does not disable it unless main power is down too (in which case it is disabled for 1 minute or however long it takes main power to come back, whichever is shorter).
 			A.loseBackupPower()
 		if(AIRLOCK_WIRE_AI_CONTROL)

--- a/html/changelogs/9600bauds_is_sorry.yml
+++ b/html/changelogs/9600bauds_is_sorry.yml
@@ -1,0 +1,35 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general adding of nice things)
+#   rscadd (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: 9600bauds
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+changes: 
+  - bugfix: Fixed secondary main power and backup power wires in airlocks not working when pulsed (yes, there are 2 test wires)
+  - experiment: In unrelated news, reports of greytide have suddenly increased by over two thousand percent.


### PR DESCRIPTION
Airlocks have two main power lines (aka test wire) and two secondary power lines.
However, only one of each of those wires worked when pulsed. This is why the term "test wire" is singular in game lingo: If you use a wirecutter to test the wires, you'll see that there are actually two main power wires, however, only one of them will actually work with a multitool (which is the most popular hacking choice).
What does this fix mean?
Yes, it will be twice as easy to find the test wire with a multitool, since there will actually be two like there were intended to be. Yes, you will be more likely to find the test wire than the shock wire. I am so, so sorry.
