### PR TITLE
Optimizations

### DIFF
--- a/code/__HELPERS/experimental.dm
+++ b/code/__HELPERS/experimental.dm
@@ -17,6 +17,7 @@
 #define MAINTAINING_OBJECT_POOL_COUNT 500
 
 var/global/list/masterPool = new
+var/global/list/variables = new
 
 // Read-only or compile-time vars and special exceptions.
 var/list/exclude = list("inhand_states", "loc", "locs", "parent_type", "vars", "verbs", "type", "x", "y", "z","group", "animate_movement")
@@ -82,6 +83,7 @@ var/list/exclude = list("inhand_states", "loc", "locs", "parent_type", "vars", "
 
 	if(isnull(masterPool["[AM.type]"]))
 		masterPool["[AM.type]"] = list()
+		createvariables(AM)
 
 	AM.Destroy()
 	AM.resetVariables()
@@ -96,6 +98,14 @@ var/list/exclude = list("inhand_states", "loc", "locs", "parent_type", "vars", "
 #ifdef DEBUG_OBJECT_POOL
 #undef DEBUG_OBJECT_POOL
 #endif
+
+
+
+/proc/createvariables(var/datum/AM)
+	variables["[AM.type]"] = new/list()
+
+	for(var/key in AM.vars)
+		variables["[AM.type]"]["[key]"] = initial(key)
 
 /*
  * if you have a variable that needed to be preserve, override this and call ..
@@ -115,20 +125,19 @@ var/list/exclude = list("inhand_states", "loc", "locs", "parent_type", "vars", "
  * 	..("var4")
  */
 
-//RETURNS NULL WHEN INITIALIZED AS A LIST() AND POSSIBLY OTHER DISCRIMINATORS
-//IF YOU ARE USING SPECIAL VARIABLES SUCH A LIST() INITIALIZE THEM USING RESET VARIABLES
+//RETURNS NULL WHEN INITIALIZED AS A LIST() AND POSSIBLY WITH OTHER TYPES OF VALUES BEYOND REGULAR VARS
+//IF YOU ARE USING SPECIAL VARIABLES SUCH A LIST() INITIALIZE THEM USING THE RESET VARIABLES EXCEPTION
 //SEE http://www.byond.com/forum/?post=76850 AS A REFERENCE ON THIS
 
 /atom/movable/resetVariables()
-	loc = null
-
 	var/list/exclude = global.exclude + args // explicit var exclusion
 
-	for(var/key in vars)
-		if(key in exclude)
-			continue
+	var/list/reset = variables["[src.type]"]
 
-		vars[key] = initial(vars[key])
+	for(var/key in vars-exclude)
+		vars["[key]"] = reset["[key]"]
+
+	loc = null
 
 /proc/isInTypes(atom/Object, types)
 	if(!Object)

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -227,8 +227,8 @@
 		return hear
 
 	var/list/range = get_hear(R, T)
-	for(var/atom/movable/A in range)
-		hear |= recursive_hear_check(A)
+	for(var/turf/A in range)
+		hear += recursive_hear_check(A)
 
 	return hear
 


### PR DESCRIPTION
## Optimizes reset variables
Initial costs about 1e-5 to 1e-6, whereas an operation that just sets a variable in an associative list using another variable in an associative list has a negligible cost even at extremely high calls. Therefore all the variables are initialized only once in a single associative type list holding all the vars.

## Optimizes recursive_hear_check as used within say() code. 

Currently it checks all atom/movables within view which is can be up to 225 lighting overlays in view, and checks each of these atom/movables recursively and then uses the list OR operator to add them in due to possible overlap. Instead recursively checks turfs only once and adds them to the found list due to eliminating the possibility of overlap.