### PR TITLE
Improves Machine Frame

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -50,8 +50,7 @@
 						if(C && C.amount >= 5) // Check again
 							C.use(5)
 							user << "<span class='notice'>You add cables to the frame.</span>"
-							build_state = 2
-							icon_state = "box_1"
+							set_build_state(2)
 			else if(istype(P, /obj/item/stack/sheet/glass/glass))
 				var/obj/item/stack/sheet/glass/glass/G=P
 				if(G.amount<1)
@@ -61,7 +60,7 @@
 				user << "<span class='notice'>You add the glass to the frame.</span>"
 				playsound(get_turf(src), 'sound/items/Deconstruct.ogg', 50, 1)
 				new /obj/structure/displaycase_frame(src.loc)
-				del(src)
+				qdel(src)
 				return
 			else
 				if(istype(P, /obj/item/weapon/wrench))
@@ -70,7 +69,7 @@
 					//new /obj/item/stack/sheet/metal(src.loc, 5)
 					var/obj/item/stack/sheet/metal/M = getFromPool(/obj/item/stack/sheet/metal, src.loc)
 					M.amount = 5
-					del(src)
+					qdel(src)
 		if(2)
 			if(!..())
 				if(istype(P, /obj/item/weapon/circuitboard))
@@ -80,18 +79,21 @@
 						user << "<span class='notice'>You add the circuit board to the frame.</span>"
 						circuit = P
 						user.drop_item(B, src)
-						icon_state = "box_2"
-						build_state = 3
+						set_build_state(3)
 						components = list()
 						req_components = circuit.req_components.Copy()
 						for(var/A in circuit.req_components)
 							req_components[A] = circuit.req_components[A]
 						req_component_names = circuit.req_components.Copy()
+						/* Are you fucking kidding me
 						for(var/A in req_components)
 							var/cp = text2path(A)
 							var/obj/ct = new cp() // have to quickly instantiate it get name
 							req_component_names[A] = ct.name
-							del(ct)
+							del(ct)*/
+						for(var/A in req_components)
+							var/atom/path = text2path(A)
+							req_component_names[A] = initial(path.name)
 						if(circuit.frame_desc)
 							desc = circuit.frame_desc
 						else
@@ -103,8 +105,7 @@
 					if(istype(P, /obj/item/weapon/wirecutters))
 						playsound(get_turf(src), 'sound/items/Wirecutter.ogg', 50, 1)
 						user << "<span class='notice'>You remove the cables.</span>"
-						build_state = 1
-						icon_state = "box_0"
+						set_build_state(1)
 						var/obj/item/stack/cable_coil/A = new /obj/item/stack/cable_coil( src.loc )
 						A.amount = 5
 
@@ -112,7 +113,7 @@
 			if(!..())
 				if(istype(P, /obj/item/weapon/crowbar))
 					playsound(get_turf(src), 'sound/items/Crowbar.ogg', 50, 1)
-					build_state = 2
+					set_build_state(2)
 					circuit.loc = src.loc
 					circuit = null
 					if(components.len == 0)
@@ -124,7 +125,6 @@
 					desc = initial(desc)
 					req_components = null
 					components = null
-					icon_state = "box_1"
 				else
 					if(istype(P, /obj/item/weapon/screwdriver))
 						var/component_check = 1
@@ -136,7 +136,7 @@
 							playsound(get_turf(src), 'sound/items/Screwdriver.ogg', 50, 1)
 							var/obj/machinery/new_machine = new src.circuit.build_path(src.loc)
 							for(var/obj/O in new_machine.component_parts)
-								del(O)
+								returnToPool(O)
 							new_machine.component_parts = list()
 							for(var/obj/O in src)
 								if(circuit.contain_parts) // things like disposal don't want their parts in them
@@ -149,7 +149,8 @@
 							else
 								circuit.loc = null
 							new_machine.RefreshParts()
-							del(src)
+							components = null
+							qdel(src)
 					else
 						if(istype(P, /obj/item/weapon)||istype(P, /obj/item/stack))
 							for(var/I in req_components)
@@ -192,6 +193,15 @@
 							if(P && P.loc != src && !istype(P, /obj/item/stack/cable_coil))
 								user << "<span class='warning'>You cannot add that component to the machine!</span>"
 
+/obj/machinery/constructable_frame/machine_frame/proc/set_build_state(var/state)
+	build_state = state
+	switch(state)
+		if(1)
+			icon_state = "box_0"
+		if(2)
+			icon_state = "box_1"
+		if(3)
+			icon_state = "box_2"
 
 //Machine Frame Circuit Boards
 /*Common Parts: Parts List: Ignitor, Timer, Infra-red laser, Infra-red sensor, t_scanner, Capacitor, Valve, sensor unit,

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -451,9 +451,8 @@ Class Procs:
 
 /obj/machinery/proc/dropFrame()
 	var/obj/machinery/constructable_frame/machine_frame/M = new /obj/machinery/constructable_frame/machine_frame(src.loc)
-	M.build_state = 2
+	M.set_build_state(2)
 	M.state = 1
-	M.icon_state = "box_1"
 
 /obj/machinery/proc/crowbarDestroy(mob/user)
 	user.visible_message(	"[user] begins to pry out the circuitboard from \the [src].",

--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -90,7 +90,7 @@
 
 					// Create a machine frame and delete the current machine
 					var/obj/machinery/constructable_frame/machine_frame/F = new
-					F.build_state = 2
+					F.set_build_state(2)
 					F.loc = src.loc
 					del(src)
 

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -18,7 +18,7 @@
 			if(istype(W, /obj/item/weapon/crowbar))
 				var/obj/machinery/constructable_frame/machine_frame/MF = new /obj/machinery/constructable_frame/machine_frame(T)
 				MF.state = 1
-				MF.build_state = 2
+				MF.set_build_state(2)
 				new /obj/item/stack/sheet/glass/glass(T)
 				del(src)
 				playsound(get_turf(src), 'sound/items/Crowbar.ogg', 50, 1)

--- a/code/modules/hydroponics/biogenerator.dm
+++ b/code/modules/hydroponics/biogenerator.dm
@@ -249,8 +249,7 @@
 			playsound(get_turf(src), 'sound/items/Crowbar.ogg', 50, 1)
 			var/obj/machinery/constructable_frame/machine_frame/M = new /obj/machinery/constructable_frame/machine_frame(src.loc)
 			M.state = 1
-			M.build_state = 2
-			M.icon_state = "box_1"
+			M.set_build_state(2)
 			for(var/obj/I in component_parts)
 				if(I.reliability != 100 && crit_fail)
 					I.crit_fail = 1

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -331,8 +331,7 @@
 			if(do_after(user, src, 50))
 				var/obj/machinery/constructable_frame/machine_frame/M = new /obj/machinery/constructable_frame/machine_frame(src.loc)
 				M.state = 1
-				M.build_state = 2
-				M.icon_state = "box_1"
+				M.set_build_state(2)
 				for(var/obj/I in component_parts)
 					if(I.reliability != 100 && crit_fail)
 						I.crit_fail = 1

--- a/code/modules/power/pacman2.dm
+++ b/code/modules/power/pacman2.dm
@@ -113,9 +113,8 @@
 					I.crit_fail = 1
 				I.loc = src.loc
 			new_frame.state = 1
-			new_frame.build_state = 2
-			new_frame.icon_state = "box_1"
-			del(src)
+			new_frame.set_build_state(2)
+			qdel(src)
 
 /obj/machinery/power/port_gen/pacman2/attack_hand(mob/user as mob)
 	..()


### PR DESCRIPTION
Fixes #4942
Makes setting a build state use a proc which automatically updates the icon of the machine frame so nobody accidentally sets build state without updating the look of the machine frame.

Improves some of the machine frame's attackby code, including - and this is beautiful, a system by which it spawns every object required to build when a circuit board is attached, reads the name, then deletes it immediately.