### PR TITLE
Fix #4845

### DIFF
--- a/code/modules/mob/living/silicon/mommi/inventory.dm
+++ b/code/modules/mob/living/silicon/mommi/inventory.dm
@@ -32,6 +32,9 @@
 	//if(is_in_modules(W))
 		//src << "<span class='warning'>Picking up something that's built-in to you seems a bit silly.</span>"
 		//return 0
+	if(W.type == /obj/item/device/material_synth)
+		drop_item(W)
+		return 0
 	if(tool_state)
 		//var/obj/item/found = locate(tool_state) in src.module.modules
 		var/obj/item/TS = tool_state


### PR DESCRIPTION
Fix #4845
Mommis can no longer pick up the standard material synthesizer, seeing as it does and should not work properly in their hands. Somewhat hacky exception ahoy to prevent this specific non-module object that breaks when picked up and used by a mommi.