### PR TITLE
Fix mommi low power mode

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -141,8 +141,8 @@
 			if(src == user:tool_state || src == user:sight_state)
 				return 0
 			attack_hand(user)
-	if(istype(src.loc, /obj/item/weapon/robot_module))
-		if(!isrobot(user)) 	return
+	else if(isrobot(user))
+		if(!istype(src.loc, /obj/item/weapon/robot_module)) return
 		var/mob/living/silicon/robot/R = user
 		R.activate_module(src)
 		R.hud_used.update_robot_modules_display()

--- a/code/modules/mob/living/silicon/mommi/inventory.dm
+++ b/code/modules/mob/living/silicon/mommi/inventory.dm
@@ -22,10 +22,15 @@
 	else
 		return locate(W) in src.module.modules
 
+#define MOMMI_LOW_POWER 100
+
 /mob/living/silicon/robot/mommi/put_in_hands(var/obj/item/W)
 	// Fixing NPEs caused by PDAs giving me NULLs to hold :V - N3X
 	// And before you ask, this is how /mob handles NULLs, too.
 	if(!W)
+		return 0
+	if(cell && cell.charge <= MOMMI_LOW_POWER)
+		drop_item(W)
 		return 0
 	// Make sure we're not picking up something that's in our factory-supplied toolbox.
 	//if(is_type_in_list(W,src.module.modules))
@@ -74,7 +79,6 @@
 		unequip_sight()
 	else if (W == head_state)
 		unequip_head()
-
 
 
 // Override the default /mob version since we only have one hand slot.

--- a/code/modules/mob/living/silicon/mommi/life.dm
+++ b/code/modules/mob/living/silicon/mommi/life.dm
@@ -42,11 +42,8 @@
 		if(src.cell.charge <= 0)
 			uneq_all()
 			src.stat = 1
-		else if (src.cell.charge <= 100)
-			src.module_active = null
-			src.sight_state = null
-			src.tool_state = null
-			src.sight_mode = 0
+		else if (src.cell.charge <= MOMMI_LOW_POWER)
+			uneq_all()
 			src.cell.use(1)
 		else
 			if(src.sight_state)
@@ -292,3 +289,5 @@
 /mob/living/silicon/robot/mommi/update_canmove()
 	canmove = !(paralysis || stunned || weakened || buckled || lockcharge || anchored)
 	return canmove
+
+#undef MOMMI_LOW_POWER


### PR DESCRIPTION
Fixes #4812

Mommi low power mode has been broken since its inception.

It now properly makes you unequip everything, and disallows equipping items while in the low power mode.