### PR TITLE
Robot hud element

### DIFF
--- a/code/_onclick/hud/mommi.dm
+++ b/code/_onclick/hud/mommi.dm
@@ -92,6 +92,15 @@
 	using.layer = 19
 	src.adding += using
 
+	//Robot Module Hud
+	using = getFromPool(/obj/screen)
+	using.dir = SOUTHWEST
+	using.icon = 'icons/mob/screen1.dmi'
+	using.icon_state = "block"
+	using.layer = 19
+	src.adding += using
+	M.robot_modules_background = using
+
 	// Store
 	mymob.throw_icon = getFromPool(/obj/screen)
 	mymob.throw_icon.icon = 'icons/mob/screen1_robot.dmi'

--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -48,6 +48,14 @@
 	src.adding += using
 	mymob:inv3 = using
 
+	using = getFromPool(/obj/screen)
+	using.dir = SOUTHWEST
+	using.icon = 'icons/mob/screen1.dmi'
+	using.icon_state = "block"
+	using.layer = 19
+	src.adding += using
+	mymob:robot_modules_background = using
+
 //End of module select
 
 //Intent

--- a/code/modules/mob/living/silicon/mommi/mommi.dm
+++ b/code/modules/mob/living/silicon/mommi/mommi.dm
@@ -164,6 +164,10 @@ They can only use one tool at a time, they can't choose modules, and they have 1
 		nmmi.invisibility = 0
 	..()
 
+/mob/living/silicon/robot/mommi/remove_screen_obj_references()
+	..()
+	inv_tool = null
+
 /mob/living/silicon/robot/mommi/updatename(var/prefix as text)
 
 	var/changed_name = ""

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -87,10 +87,6 @@
 	else
 		wires = new(src)
 
-	robot_modules_background = new()
-	robot_modules_background.icon_state = "block"
-	robot_modules_background.layer = 19
-
 	ident = rand(1, 999)
 	updatename("Default")
 	updateicon()
@@ -189,6 +185,13 @@
 			mmi.brainmob.locked_to_z = locked_to_z
 		mmi = null
 	..()
+
+/mob/living/silicon/robot/remove_screen_obj_references()
+	..()
+	cells = null //TODO: Move to mob level helper
+	inv1 = null
+	inv2 = null
+	inv3 = null
 
 /proc/getAvailableRobotModules()
 	var/list/modules = list("Standard", "Engineering", "Medical", "Miner", "Janitor", "Service", "Security")


### PR DESCRIPTION
Patches up another obj/screen leak, this time with robot hud storage. Obj/screen pooling breaks when pooling objects aren't refreshed by a new hud in mob/login(), due to the fact all objects currently on the client.screen are pooled so they can be refreshed at login()

Robot module huds were not replaced properly by this thanks to someone *cough* ririchiyo *cough* putting them in new() instead of where all other hud elements are kept.