### PR TITLE
Fixes mob delayers at extremely low ticklags

### DIFF
--- a/code/modules/mob/delays.dm
+++ b/code/modules/mob/delays.dm
@@ -6,7 +6,7 @@
 /datum/delay_controller
 	// Delay clamps (for adminbus, effects)
 	var/min_delay = 1
-	var/max_delay = 100 // arbitrary number, should be set to a sane value
+	var/max_delay = 10000 // arbitrary number, should be set to a sane value
 
 	var/next_allowed = 0
 
@@ -34,11 +34,11 @@
 // Constructor args are currently all the same, but placed here for ease of tuning.
 /client // Yep, clients are snowflakes.
 	// Walking speed is 7, as is grab speed.
-	var/datum/delay_controller/move_delayer    = new (1, 100) // /mob/delayNextMove()
+	var/datum/delay_controller/move_delayer    = new (1,10000) // /mob/delayNextMove()
 /mob
-	var/datum/delay_controller/click_delayer   = new (1, 100) // (Handled in Click())
-	var/datum/delay_controller/attack_delayer  = new (1, 100) // delayNextAttack()
-	var/datum/delay_controller/special_delayer = new (1, 100) // delayNextSpecial()
+	var/datum/delay_controller/click_delayer   = new (1,10000) // (Handled in Click())
+	var/datum/delay_controller/attack_delayer  = new (1,10000) // delayNextAttack()
+	var/datum/delay_controller/special_delayer = new (1,10000) // delayNextSpecial()
 
 // Convenience procs.
 /mob/proc/delayNextMove(var/delay, var/additive=0)

--- a/code/modules/mob/delays.dm
+++ b/code/modules/mob/delays.dm
@@ -1,3 +1,4 @@
+# define ARBITRARILY_LARGE_NUMBER 10000
 //////////////////////////////////
 // /vg/ MODULARIZED DELAYS - by N3X15
 //////////////////////////////////
@@ -6,7 +7,7 @@
 /datum/delay_controller
 	// Delay clamps (for adminbus, effects)
 	var/min_delay = 1
-	var/max_delay = 10000 // arbitrary number, should be set to a sane value
+	var/max_delay = ARBITRARILY_LARGE_NUMBER // arbitrary number, should be set to a sane value
 
 	var/next_allowed = 0
 
@@ -34,11 +35,11 @@
 // Constructor args are currently all the same, but placed here for ease of tuning.
 /client // Yep, clients are snowflakes.
 	// Walking speed is 7, as is grab speed.
-	var/datum/delay_controller/move_delayer    = new (1,10000) // /mob/delayNextMove()
+	var/datum/delay_controller/move_delayer    = new (1,ARBITRARILY_LARGE_NUMBER) // /mob/delayNextMove()
 /mob
-	var/datum/delay_controller/click_delayer   = new (1,10000) // (Handled in Click())
-	var/datum/delay_controller/attack_delayer  = new (1,10000) // delayNextAttack()
-	var/datum/delay_controller/special_delayer = new (1,10000) // delayNextSpecial()
+	var/datum/delay_controller/click_delayer   = new (1,ARBITRARILY_LARGE_NUMBER) // (Handled in Click())
+	var/datum/delay_controller/attack_delayer  = new (1,ARBITRARILY_LARGE_NUMBER) // delayNextAttack()
+	var/datum/delay_controller/special_delayer = new (1,ARBITRARILY_LARGE_NUMBER) // delayNextSpecial()
 
 // Convenience procs.
 /mob/proc/delayNextMove(var/delay, var/additive=0)
@@ -55,3 +56,5 @@
 	if(types & DELAY_MOVE) delayNextMove(delay,additive)
 	if(types & DELAY_ATTACK) delayNextAttack(delay,additive)
 	if(types & DELAY_SPECIAL) delayNextSpecial(delay,additive)
+
+# undef ARBITRARILY_LARGE_NUMBER

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -209,13 +209,13 @@
 
 	if(mob.control_object)	Move_object(dir)
 
-	if(mob.incorporeal_move)
-		Process_Incorpmove(dir)
-		return
-
 	if(moving)	return 0
 
 	if(move_delayer.blocked()) return
+
+	if(mob.incorporeal_move)
+		Process_Incorpmove(dir)
+		return
 
 	if(locate(/obj/effect/stop/, mob.loc))
 		for(var/obj/effect/stop/S in mob.loc)


### PR DESCRIPTION
Fixes #4528 
"Arbitrarily high numbers" need to actually be high if you don't want to break my future shit nexis

Literally does nothing but raise an arbitrary cap to move delays imposed by nexis, because low ticklags require high delays.