### PR TITLE
Fixed Optimization

### DIFF
--- a/code/__HELPERS/experimental.dm
+++ b/code/__HELPERS/experimental.dm
@@ -82,7 +82,6 @@ var/list/exclude = list("inhand_states", "loc", "locs", "parent_type", "vars", "
 
 	if(isnull(masterPool["[AM.type]"]))
 		masterPool["[AM.type]"] = list()
-
 	AM.Destroy()
 	AM.resetVariables()
 	masterPool["[AM.type]"] |= AM
@@ -121,23 +120,4 @@ var/list/exclude = list("inhand_states", "loc", "locs", "parent_type", "vars", "
 
 /atom/movable/resetVariables()
 	loc = null
-
-	var/list/exclude = global.exclude + args // explicit var exclusion
-
-	for(var/key in vars)
-		if(key in exclude)
-			continue
-
-		vars[key] = initial(vars[key])
-
-/proc/isInTypes(atom/Object, types)
-	if(!Object)
-		return 0
-	var/prototype = Object.type
-	Object = null
-
-	for (var/type in params2list(types))
-		if (ispath(prototype, text2path(type)))
-			return 1
-
-	return 0
+	..("loc",args)


### PR DESCRIPTION
Makes material datums not lag by not calling del() when a datum pool is overrun, instead just cutting the oldest one loose from the pool. This can be fixed if/when qdel() for datums is EVER FIXED.

Made the pull from earlier called 'optimizations' work properly, this method is almost identical except it works fully and is just as efficient.

-Instead of looping through the exclusion lists every time, it only loops through the variables. 
-Instead of calling initial every time, it merely copies a value from an associative list.