### PR TITLE
Runtimes

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -54,8 +54,10 @@ proc/random_name(gender, speciesName = "Human")
 	if(S)
 		return S.makeName(gender)
 	else
-		var/datum/species/human/H
+		var/datum/species/human/H = new
 		return H.makeName(gender)
+
+
 
 proc/random_skin_tone()
 	switch(pick(60;"caucasian", 15;"afroamerican", 10;"african", 10;"latino", 5;"albino"))

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -33,7 +33,7 @@
 
 /mob/living/carbon/proc/update_minimap()
 	var/obj/item/device/pda/pda_device = machine
-	if(machine && istype(machine))
+	if(machine && istype(pda_device))
 		var/turf/user_loc = get_turf(src)
 		var/turf/pda_loc = get_turf(pda_device)
 		if(get_dist(user_loc,pda_loc) <= 1)


### PR DESCRIPTION
Fix two runtimes, one old as shit one that occurs on every local server involving making a random name. The other coming from my recent removal of call() from client/move, istype is being called upon the object instead of the variable which isn't blocking other types.