### PR TITLE
Fix lag during Hell Universe

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -323,19 +323,10 @@ var/list/all_doors = list()
 	update_nearby_tiles()
 
 /obj/machinery/door/cultify()
-	icon_state = "null"
-	density = 0
-	c_animation = new /atom/movable/overlay(src.loc)
-	c_animation.name = "cultification"
-	c_animation.density = 0
-	c_animation.anchored = 1
-	c_animation.icon = 'icons/effects/effects.dmi'
-	c_animation.layer = 5
-	c_animation.master = src.loc
-	c_animation.icon_state = "breakdoor"
-	flick("cultification",c_animation)
-	spawn(10)
-		del(c_animation)
+	if(invisibility != INVISIBILITY_MAXIMUM)
+		invisibility = INVISIBILITY_MAXIMUM
+		density = 0
+		anim(target = src, a_icon = 'icons/effects/effects.dmi', a_icon_state = "breakdoor", sleeptime = 10)
 		qdel(src)
 
 /obj/machinery/door/Destroy()

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -31,14 +31,13 @@
 			T.update_icon()
 
 /obj/structure/table/cultify()
-	new /obj/structure/table/woodentable(loc)
-	..()
+	new /obj/structure/table/woodentable(loc) //See New() for qdel
 
 /obj/structure/table/New()
 	..()
 	for(var/obj/structure/table/T in src.loc)
 		if(T != src)
-			del(T)
+			qdel(T)
 	update_icon()
 	update_adjacent()
 

--- a/code/game/turfs/turf_flick_animations.dm
+++ b/code/game/turfs/turf_flick_animations.dm
@@ -23,6 +23,10 @@
 proc/anim(turf/location as turf,target as mob|obj,a_icon,a_icon_state as text,flick_anim as text,sleeptime = 0,direction as num)
 //This proc throws up either an icon or an animation for a specified amount of time.
 //The variables should be apparent enough.
+	if(!location && target)
+		location = get_turf(target)
+	if(location && !target)
+		target = location
 	var/atom/movable/overlay/animation = getFromPool(/atom/movable/overlay, location)
 	if(direction)
 		animation.dir = direction
@@ -34,8 +38,8 @@ proc/anim(turf/location as turf,target as mob|obj,a_icon,a_icon_state as text,fl
 		animation.icon_state = "blank"
 		animation.master = target
 		flick(flick_anim, animation)
-	sleep(max(sleeptime, 15))
-	returnToPool(animation)
+	spawn(max(sleeptime, 15))
+		returnToPool(animation)
 
 /*
 //called when the tile is cultified

--- a/code/modules/mob/living/simple_animal/hostile/bat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bat.dm
@@ -82,9 +82,9 @@
 				shuttletarget = pick(escape_list) //Pick a shuttle target
 			enroute = 1
 			stop_automated_movement = 1
-			spawn()
+/*			spawn()
 				if(!src.stat)
-					horde()
+					horde()*/
 
 		if(get_dist(src, shuttletarget) <= 2)		//The monster reached the escape hallway
 			enroute = 0

--- a/code/modules/mob/living/simple_animal/hostile/creature.dm
+++ b/code/modules/mob/living/simple_animal/hostile/creature.dm
@@ -42,9 +42,9 @@
 				shuttletarget = pick(escape_list) //Pick a shuttle target
 			enroute = 1
 			stop_automated_movement = 1
-			spawn()
+/*			spawn()
 				if(!src.stat)
-					horde()
+					horde()*/
 
 		if(get_dist(src, shuttletarget) <= 2) //The monster reached the escape hallway
 			enroute = 0

--- a/code/modules/mob/living/simple_animal/hostile/faithless.dm
+++ b/code/modules/mob/living/simple_animal/hostile/faithless.dm
@@ -66,9 +66,9 @@
 				shuttletarget = pick(escape_list) //Pick a shuttle target
 			enroute = 1
 			stop_automated_movement = 1
-			spawn()
+/*			spawn()
 				if(!src.stat)
-					horde()
+					horde()*/
 
 		if(get_dist(src, shuttletarget) <= 2)		//The monster reached the escape hallway
 			enroute = 0


### PR DESCRIPTION
1. Found the major leak of atom/movable/overlay deletions, it was being caused by door/cultify

2. Found the last major source of regular deletions, it was being caused by table/New() deleting any prior tables when cultify intentionally spawned tables on top of the tables

3. Commented out horde because it barely works, it adds little since everything is already dead by this point, and it uses over 100% of the cpu of any server to run even normally.
Related: http://www.byond.com/forum/?post=1288063