### PR TITLE
Sets suiciding to 0 upon calling rejuvenate/anything that uses it

### DIFF
--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -517,56 +517,7 @@
 		living_mob_list |= list(C)
 		C.stat = CONSCIOUS
 		C.tod = null
-		C.setToxLoss(0)
-		C.setOxyLoss(0)
-		C.setCloneLoss(0)
-		C.setBrainLoss(0)
-		C.SetParalysis(0)
-		C.SetStunned(0)
-		C.SetWeakened(0)
-		C.radiation = 0
-		C.heal_overall_damage(C.getBruteLoss(), C.getFireLoss())
-		C.reagents.clear_reagents()
-		C.germ_level = 0
-		C.next_pain_time = 0
-		C.traumatic_shock = 0
-		if(ishuman(C))
-			var/mob/living/carbon/human/H = C
-			H.timeofdeath = 0
-			H.vessel.reagent_list = list()
-			H.vessel.add_reagent("blood",560)
-			H.shock_stage = 0
-			spawn(1)
-				H.fixblood()
-			for(var/organ_name in H.organs_by_name)
-				var/datum/organ/external/O = H.organs_by_name[organ_name]
-				for(var/obj/item/weapon/shard/shrapnel/s in O.implants)
-					if(istype(s))
-						O.implants -= s
-						H.contents -= s
-						qdel(s)
-				O.amputated = 0
-				O.brute_dam = 0
-				O.burn_dam = 0
-				O.damage_state = "00"
-				O.germ_level = 0
-				O.hidden = null
-				O.number_wounds = 0
-				O.open = 0
-				O.perma_injury = 0
-				O.stage = 0
-				O.status = 0
-				O.trace_chemicals = list()
-				O.wounds = list()
-				O.wound_update_accuracy = 1
-			for(var/organ_name in H.internal_organs_by_name)
-				var/datum/organ/internal/IO = H.internal_organs_by_name[organ_name]
-				IO.damage = 0
-				IO.trace_chemicals.len = 0
-				IO.germ_level = 0
-				IO.status = 0
-				IO.robotic = 0
-			H.updatehealth()
+		C.revive(0)
 		C << "<span class='notice'>We have regenerated.</span>"
 		C.visible_message("<span class='warning'>[src] appears to wake from the dead, having healed all wounds.</span>")
 		C.status_flags &= ~(FAKEDEATH)
@@ -584,6 +535,10 @@
 	if(!changeling)	return
 
 	var/mob/living/carbon/C = src
+	if(C.suiciding)
+		C << "<span class='warning'>Why would we wish to regenerate if we have already committed suicide?"
+		return
+
 	if(!C.stat && alert("Are we sure we wish to fake our death?",,"Yes","No") == "No")//Confirmation for living changelings if they want to fake their death
 		return
 	C << "<span class='notice'>We will attempt to regenerate our form.</span>"

--- a/code/game/objects/structures/vehicles/adminbus_powers.dm
+++ b/code/game/objects/structures/vehicles/adminbus_powers.dm
@@ -198,6 +198,7 @@
 
 	for(var/mob/living/M in orange(src,3))
 		M.revive(1)
+		M.suiciding = 0
 		M << "<span class='notice'>THE ADMINBUS IS LOVE. THE ADMINBUS IS LIFE.</span>"
 		sleep(2)
 	update_rearview()

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1452,7 +1452,7 @@
 		if(config.allow_admin_rev)
 			L.revive(0)
 			message_admins("<span class='warning'>Admin [key_name_admin(usr)] healed / revived [key_name_admin(L)]!</span>", 1)
-			log_admin("[key_name(usr)] healed / Rrvived [key_name(L)]")
+			log_admin("[key_name(usr)] healed / revived [key_name(L)]")
 		else
 			usr << "Admin Rejuvinates have been disabled"
 

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -576,6 +576,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		return
 	if(config.allow_admin_rev)
 		M.revive(0)
+		M.suiciding = 0
 
 		log_admin("[key_name(usr)] healed / revived [key_name(M)]")
 		message_admins("<span class='warning'>Admin [key_name_admin(usr)] healed / revived [key_name_admin(M)]!</span>", 1)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -424,6 +424,7 @@
 	eye_blurry = 0
 	ear_deaf = 0
 	ear_damage = 0
+	suiciding = 0
 	if(!reagents)
 		create_reagents(1000)
 	else

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -378,7 +378,13 @@
 /mob/living/proc/restore_all_organs()
 	return
 
-
+/*
+NOTE TO ANYONE MAKING A PROC THAT USES REVIVE/REJUVENATE:
+If the proc calling either of these is:
+	-meant to be an admin/overpowered revival proc, make sure you set suiciding = 0
+	-meant to be something that a player uses to heal/revive themself or others, check if suiciding = 1 and prevent them from reviving if true.
+Thanks.
+*/
 
 /mob/living/proc/revive(animation = 0)
 	rejuvenate(animation)
@@ -424,7 +430,6 @@
 	eye_blurry = 0
 	ear_deaf = 0
 	ear_damage = 0
-	suiciding = 0
 	if(!reagents)
 		create_reagents(1000)
 	else


### PR DESCRIPTION
Fixes #4978, as well as an oversight that allows changelings that have committed suicide to regen themselves.
