### PR TITLE
Experimental Saycode Optimization

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -28,12 +28,17 @@
 /atom/movable/New()
 	. = ..()
 	areaMaster = get_area_master(src)
+	if(flags & HEAR && !ismob(src))
+		getFromPool(/mob/virtualhearer, src)
 
 /atom/movable/Destroy()
+	if(flags & HEAR && !ismob(src))
+		for(var/mob/virtualhearer/VH in virtualhearers)
+			if(VH.attached == src)
+				returnToPool(VH)
 	gcDestroyed = "Bye, world!"
 	tag = null
 	loc = null
-
 	..()
 
 /proc/delete_profile(var/type, code = 0)
@@ -338,3 +343,17 @@
 
 /atom/movable/proc/say_understands(var/mob/other)
 	return 1
+
+////////////
+/// HEAR ///
+////////////
+/atom/movable/proc/addHear()
+	flags |= HEAR
+	getFromPool(/mob/virtualhearer, src)
+
+/atom/movable/proc/removeHear()
+	flags &= ~HEAR
+	for(var/mob/virtualhearer/VH in virtualhearers)
+		if(VH.attached == src)
+			returnToPool(VH)
+

--- a/code/game/machinery/bots/buttbot.dm
+++ b/code/game/machinery/bots/buttbot.dm
@@ -21,6 +21,7 @@ Here it is: Buttbot.
 	maxhealth = 25
 	var/buttchance = 80 //Like an 80% chance of it working. It's just a butt with an arm in it.
 	var/sincelastfart = 0
+	flags = HEAR
 
 /obj/machinery/bot/buttbot/attack_hand(mob/living/user as mob)
 	. = ..()

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -180,7 +180,7 @@ Implant Specifics:<BR>"}
 	phrase = sanitize_simple(phrase, replacechars)
 	usr.mind.store_memory("Explosive implant in [source] can be activated by saying something containing the phrase ''[src.phrase]'', <B>say [src.phrase]</B> to attempt to activate.", 0, 0)
 	usr << "The implanted explosive implant in [source] can be activated by saying something containing the phrase ''[src.phrase]'', <B>say [src.phrase]</B> to attempt to activate."
-	flags |= HEAR
+	addHear()
 	return 1
 
 /obj/item/weapon/implant/explosive/emp_act(severity)
@@ -443,7 +443,7 @@ the implant may become unstable and either pre-maturely inject the subject or si
 		if("death")
 			if(!announcement_intercom || !istype(announcement_intercom))
 				announcement_intercom = new(null)
-			
+
 			if(istype(t, /area/syndicate_station) || istype(t, /area/syndicate_mothership) || istype(t, /area/shuttle/syndicate_elite) )
 				//give the syndies a bit of stealth
 				Broadcast_Message(announcement_intercom, all_languages["Sol Common"], null, announcement_intercom, "[mobname] has died in Space!", "[mobname]'s Death Alarm", "Death Alarm", "[mobname]'s Death Alarm", 0, 0, list(0,1), 1459)

--- a/code/modules/mob/hearing/virtualhearer.dm
+++ b/code/modules/mob/hearing/virtualhearer.dm
@@ -1,0 +1,52 @@
+var/global/list/mob/virtualhearer/virtualhearers = list()
+
+/mob/virtualhearer
+	name = ""
+	see_in_dark = 8
+	icon = null
+	icon_state = null
+	var/atom/movable/attached = null
+	anchored = 1
+	density = 0
+	invisibility = INVISIBILITY_MAXIMUM
+	alpha = 0
+	animate_movement = 0
+	//This can be expanded with vision flags to make a device to hear through walls for example
+
+/mob/virtualhearer/New(attachedto)
+	AddToProfiler()
+	virtualhearers += src
+	loc = get_turf(attachedto)
+	attached = attachedto
+	if(istype(attached,/obj/item/device/radio/intercom))
+		virtualhearers -= src
+
+/mob/virtualhearer/Destroy()
+	virtualhearers -= src
+	attached = null
+/*
+/mob/virtualhearer/proc/process()
+	var/atom/A
+	while(attached)
+		for(A=attached.loc, A && !isturf(A), A=A.loc);
+		loc = A
+		sleep(10)
+	returnToPool(src)*/
+
+/mob/virtualhearer/resetVariables()
+	return
+
+/mob/virtualhearer/Hear(message, atom/movable/speaker, var/datum/language/speaking, raw_message, radio_freq)
+	if(attached)
+		attached.Hear(args)
+	else
+		returnToPool(src)
+
+/mob/virtualhearer/ex_act()
+	return
+
+/mob/virtualhearer/singularity_act()
+	return
+
+/mob/virtualhearer/singularity_pull()
+	return

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -51,6 +51,9 @@
 
 	reset_view()
 
+	if(flags & HEAR)
+		getFromPool(/mob/virtualhearer, src)
+
 	//Clear ability list and update from mob.
 	client.verbs -= ability_verbs
 

--- a/code/modules/mob/logout.dm
+++ b/code/modules/mob/logout.dm
@@ -3,6 +3,10 @@
 		var/obj/location = loc
 		location.on_log()
 
+	for(var/mob/virtualhearer/VH in virtualhearers)
+		if(VH.attached == src)
+			returnToPool(VH)
+
 	nanomanager.user_logout(src) // this is used to clean up (remove) this user's Nano UIs
 
 	player_list -= src

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -1146,6 +1146,7 @@
 #include "code\modules\mob\dead\observer\observer.dm"
 #include "code\modules\mob\dead\observer\say.dm"
 #include "code\modules\mob\dead\observer\spells.dm"
+#include "code\modules\mob\hearing\virtualhearer.dm"
 #include "code\modules\mob\living\damage_procs.dm"
 #include "code\modules\mob\living\default_language.dm"
 #include "code\modules\mob\living\living.dm"


### PR DESCRIPTION
Every hearer in the game is now attached what I call a virtualhearer. These are mobs that are set at the hearers location. The virtualhearers have max invisibility, alpha at 0, name = "", so by all rights they are full undetectable to a normal player. They have an attached var to the hearer they represent, and when that normal hearer is destroyed it will find its attached hearer and pluck it back into pooling.

These virtualhearers will all update their location when either hearers_in_view, (regular say), or get_mobs_in_radio_ranges, (radio code) is called. Updating each loc has a relatively small cost, on my slower private server about 6e-6. They will update only every .5s at most to prevent spam calls.

The advantage to these virtualhearers is that get_hear is no longer a requirement. Get_hear itself costs 1e-4, which itself still gathers every object you must then recursively loop through. Updating all virtualhearers costs 2-3e-4, but only must be called once if a mob speaks through a radio. Instead of using get_hear we can uses either viewers() or hearers() on every location we want to check and get the results much more quickly.

Compare get_mobs_in_radio_ranges
Before
![](http://puu.sh/iVu3G/27290b4bd8.png)
After
![](http://puu.sh/iUWvS/d4810f30e8.png)
