### PR TITLE
Fix strangerocks

### DIFF
--- a/code/modules/research/xenoarchaeology/finds/finds.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds.dm
@@ -58,6 +58,7 @@
 			if(w.get_fuel() >= 4 && !src.method)
 				if(inside)
 					inside.loc = get_turf(src)
+					inside = null
 					for(var/mob/M in viewers(world.view, user))
 						M.show_message("<span class='info'>[src] burns away revealing [inside].</span>",1)
 				else


### PR DESCRIPTION
The reference to the inner object wasn't nulled before being before the strangerock was being deleted, therefore it was getting deleted too.
Fixes #5402 