### PR TITLE
Could fix a ban evasion method.

### DIFF
--- a/code/modules/admin/IsBanned.dm
+++ b/code/modules/admin/IsBanned.dm
@@ -1,4 +1,8 @@
-world/IsBanned(key,address,computer_id)
+/world/IsBanned(key, address, computer_id)
+	if (!key || !address || !computer_id)
+		log_access("Failed Login (invalid data): [key] [address]-[computer_id]")
+		return list("reason" = "invalid login data", "desc" = "Your computer provided invalid or blank information to the server on connection (byond username, IP, and Computer ID.) Provided information for reference: Username: '[key]' IP: '[address]' Computer ID: '[computer_id]', If you continue to get this error, please restart byond or contact byond support.")
+
 	log_access("IsBanned: Checking [ckey(key)], [address], [computer_id]")
 	//Guest Checking
 	if(!guests_allowed && IsGuestKey(key))


### PR DESCRIPTION
The method was to use an external DLL to prevent BYOND from sending a CID.

Credits to @mrstonedone for this fix and snapshot on #codershuttle for bringing it up.
