### PR TITLE
Jaunt fix + airflow fix

### DIFF
--- a/code/ZAS/Airflow.dm
+++ b/code/ZAS/Airflow.dm
@@ -51,7 +51,7 @@ atom/movable/RepelAirflowDest(n)
 mob/var/tmp/last_airflow_stun = 0
 mob/proc/airflow_stun()
 	//writepanic("[__FILE__].[__LINE__] ([src.type])([usr ? usr.ckey : ""])  \\mob/proc/airflow_stun() called tick#: [world.time]")
-	if(stat == 2)
+	if(stat == 2 || (flags & INVULNERABLE))
 		return 0
 	if(last_airflow_stun > world.time - zas_settings.Get(/datum/ZAS_Setting/airflow_stun_cooldown))	return 0
 	if(!(status_flags & CANSTUN) && !(status_flags & CANWEAKEN))
@@ -71,7 +71,7 @@ mob/living/carbon/metroid/airflow_stun()
 
 mob/living/carbon/human/airflow_stun()
 	if(last_airflow_stun > world.time - zas_settings.Get(/datum/ZAS_Setting/airflow_stun_cooldown))	return 0
-	if(buckled) return 0
+	if(buckled || (flags & INVULNERABLE)) return 0
 	if(shoes)
 		if(shoes.flags & NOSLIP) return 0
 	if(!(status_flags & CANSTUN) && !(status_flags & CANWEAKEN))
@@ -101,6 +101,9 @@ mob/dead/observer/check_airflow_movable()
 	return 0
 
 mob/living/silicon/check_airflow_movable()
+	return 0
+
+mob/virtualhearer/check_airflow_movable()
 	return 0
 
 
@@ -256,14 +259,16 @@ proc/AirflowSpace(zone/A)
 	if(airflow_dest == loc)
 		return
 	if(ismob(src))
-		if(src:status_flags & GODMODE)
+		var/mob/M = src
+		if(M.status_flags & GODMODE || (flags & INVULNERABLE))
 			return
 		if(istype(src, /mob/living/carbon/human))
-			if(src:buckled)
+			var/mob/living/carbon/human/H = src
+			if(H.buckled)
 				return
-			if(src:shoes)
-				if(istype(src:shoes, /obj/item/clothing/shoes/magboots))
-					if(src:shoes:magpulse)
+			if(H.shoes)
+				if(istype(H.shoes, /obj/item/clothing/shoes/magboots))
+					if(H.shoes.flags & NOSLIP)
 						return
 		src << "<SPAN CLASS='warning'>You are sucked away by airflow!</SPAN>"
 	var/airflow_falloff = 9 - ul_FalloffAmount(airflow_dest) //It's a fast falloff calc.  Very useful.
@@ -316,14 +321,16 @@ proc/AirflowSpace(zone/A)
 	if(airflow_dest == loc)
 		step_away(src,loc)
 	if(ismob(src))
-		if(src:status_flags & GODMODE)
+		var/mob/M = src
+		if(M.status_flags & GODMODE || (flags & INVULNERABLE))
 			return
 		if(istype(src, /mob/living/carbon/human))
-			if(src:buckled)
+			var/mob/living/carbon/human/H = src
+			if(H.buckled)
 				return
-			if(src:shoes)
-				if(istype(src:shoes, /obj/item/clothing/shoes/magboots))
-					if(src:shoes.flags & NOSLIP)
+			if(H.shoes)
+				if(istype(H.shoes, /obj/item/clothing/shoes/magboots))
+					if(H.shoes.flags & NOSLIP)
 						return
 		src << "<SPAN CLASS='warning'>You are pushed away by airflow!</SPAN>"
 		last_airflow = world.time

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -32,6 +32,8 @@ proc/process_med_hud(var/mob/M, var/mob/eye)
 	else
 		T = get_turf(M)
 	for(var/mob/living/carbon/human/patient in range(T))
+		if(M.see_invisible < patient.invisibility)
+			continue
 		var/foundVirus = 0
 		for(var/datum/disease/D in patient.viruses)
 			if(!D.hidden[SCANNER])
@@ -76,6 +78,8 @@ proc/process_sec_hud(var/mob/M, var/advanced_mode,var/mob/eye)
 	else
 		T = get_turf(M)
 	for(var/mob/living/carbon/human/perp in range(T))
+		if(M.see_invisible < perp.invisibility)
+			continue
 		holder = perp.hud_list[ID_HUD]
 		if(!holder)
 			continue

--- a/code/modules/mob/hearing/virtualhearer.dm
+++ b/code/modules/mob/hearing/virtualhearer.dm
@@ -9,6 +9,9 @@ var/global/list/mob/virtualhearer/virtualhearers = list()
 	anchored = 1
 	density = 0
 	invisibility = INVISIBILITY_MAXIMUM
+	flags = INVULNERABLE
+	status_flags = GODMODE
+
 	alpha = 0
 	animate_movement = 0
 	//This can be expanded with vision flags to make a device to hear through walls for example
@@ -24,15 +27,6 @@ var/global/list/mob/virtualhearer/virtualhearers = list()
 /mob/virtualhearer/Destroy()
 	virtualhearers -= src
 	attached = null
-/*
-/mob/virtualhearer/proc/process()
-	//writepanic("[__FILE__].[__LINE__] ([src.type])([usr ? usr.ckey : ""])  \\/mob/virtualhearer/proc/process() called tick#: [world.time]")
-	var/atom/A
-	while(attached)
-		for(A=attached.loc, A && !isturf(A), A=A.loc);
-		loc = A
-		sleep(10)
-	returnToPool(src)*/
 
 /mob/virtualhearer/resetVariables()
 	return

--- a/code/modules/spells/spell_code.dm
+++ b/code/modules/spells/spell_code.dm
@@ -14,7 +14,7 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 	var/charge_counter = 0 //can only cast spells if it equals recharge, ++ each decisecond if charge_type = Sp_RECHARGE or -- each cast if charge_type = Sp_CHARGES
 	var/still_recharging_msg = "<span class='notice'>The spell is still recharging.</span>"
 
-	var/silenced = 0 //not a binary - the length of time we can't cast this for
+	var/silenced = 0 //not a binary (though it seems that it is at the moment) - the length of time we can't cast this for, set by the spell_master silence_spells()
 
 	var/holder_var_type = "bruteloss" //only used if charge_type equals to "holder_var"
 	var/holder_var_amount = 20 //same. The amount adjusted with the mob's var when the spell is used

--- a/code/modules/spells/targeted/ethereal_jaunt.dm
+++ b/code/modules/spells/targeted/ethereal_jaunt.dm
@@ -30,6 +30,8 @@
 	var/mobloc = get_turf(target)
 	var/previncorp = target.incorporeal_move //This shouldn't ever matter under usual circumstances
 	var/prevalpha = target.alpha
+	if(target.incorporeal_move == 3) //they're already jaunting, we have another fix for this but this is sane)
+		return
 	if(target.buckled)
 		target.buckled.unbuckle()
 	//Begin jaunting with an animation
@@ -44,6 +46,10 @@
 	target.invisibility = INVISIBILITY_MAXIMUM
 	target.flags |= INVULNERABLE
 	target.alpha = 125 //Spoopy mode to know you are jaunting
+	for(var/obj/screen/movable/spell_master/SM in target.spell_masters)
+		SM.silence_spells(duration+25)
+	target.delayNextAttack(duration+25)
+	target.click_delayer.setDelay(duration+25)
 	sleep(duration)
 	//Begin unjaunting
 	mobloc = get_turf(target)
@@ -52,12 +58,15 @@
 		steam.set_up(10, 0, mobloc)
 		steam.start()
 	target.delayNextMove(25)
+	target.dir = SOUTH
 	sleep(20)
 	anim(location = mobloc, target = target, a_icon = 'icons/mob/mob.dmi', flick_anim = exitanim, direction = target.dir, name = "water")
 	sleep(5)
 	//Forcemove him onto the tile and make him visible and vulnerable
 	target.forceMove(mobloc)
 	target.invisibility = 0
+	for(var/obj/screen/movable/spell_master/SM in target.spell_masters)
+		SM.silence_spells(0)
 	target.flags &= ~INVULNERABLE
 	target.incorporeal_move = previncorp
 	target.alpha = prevalpha


### PR DESCRIPTION
Details:

Jaunt with a low enough cooldown would allow you to double cast jaunt making it flip the fuck out, so instead your spells are now silenced during jaunt. Your click and attack delayers as a jaunter are now delayed until the end of the jaunting session.

Airflow now checks for flags & invulnerable, which is the flag that is meant to prevent effects from occurring to that atom. This should fix an issue I've been seeing since hellish ZAS was recently turned on from virtualhearers and jaunters being blown into things.

Also fixed another reported bug that huds would report on invisible people, they lacked the see_invisible check that mechs had.