### PR TITLE
FUCKING HELL CAEL.

### DIFF
--- a/code/modules/medical/computer/cloning.dm
+++ b/code/modules/medical/computer/cloning.dm
@@ -465,17 +465,9 @@
 
 /obj/machinery/computer/cloning/update_icon()
 	overlays = 0
-	if(stat & BROKEN)
-		icon_state = "cloningb"
-	else if(powered())
-		icon_state = initial(icon_state)
-		stat &= ~NOPOWER
-
+	if(!(stat & (NOPOWER | BROKEN)))
 		if(scanner && scanner.occupant)
 			overlays += "cloning-scan"
 		if(pod1 && pod1.occupant)
 			overlays += "cloning-pod"
-	else
-		spawn(rand(0, 15))
-			src.icon_state = "c_unpowered"
-			stat |= NOPOWER
+


### PR DESCRIPTION
Fixes #5595

Due to shitcode, some machines depower after a random amount of time, with a SPAWN, couple that WITH SOME MORON NAMED CAEL putting THE POWER_CHANGE CODE in UPDATE_ICON, you get this bollocks.
