### PR TITLE
New Malf Module

### DIFF
--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -47,8 +47,7 @@ rcd light flash thingy on matter drain
 	set name = "Fireproof Core"
 	//writepanic("[__FILE__].[__LINE__] ([src.type])([usr ? usr.ckey : ""])  \\/mob/living/silicon/ai/proc/fireproof_core() called tick#: [world.time]")
 
-	for(var/mob/living/silicon/ai/ai in player_list)
-		ai.fire_res_on_core = 1
+	ai_flags |= COREFIRERESIST
 	src.verbs -= /mob/living/silicon/ai/proc/fireproof_core
 	src << "<span class='warning'>Core fireproofed.</span>"
 
@@ -182,6 +181,23 @@ rcd light flash thingy on matter drain
 	src.can_shunt = 0
 	PCT.uses -= 1
 	src << "You cannot shunt anymore."
+
+/datum/AI_Module/large/highrescams
+	module_name = "High Resolution Cameras"
+	mod_pick_name = "High Res Cameras"
+	description = "Allows the AI to read papers and the lips of crewmembers from his cameras!"
+	cost = 10
+
+	power_type = /mob/living/silicon/ai/proc/highrescameras
+
+/mob/living/silicon/ai/proc/highrescameras()
+	set category = "Malfunction"
+	set name = "High Res Cams"
+
+	ai_flags |= HIGHRESCAMS
+
+	eyeobj.addHear()
+	src.verbs -= /mob/living/silicon/ai/proc/highrescameras
 
 
 /datum/AI_Module/small/blackout

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -41,7 +41,7 @@ var/list/ai_list = list()
 	var/datum/module_picker/malf_picker
 	var/processing_time = 100
 	var/list/datum/AI_Module/current_modules = list()
-	var/fire_res_on_core = 0
+	var/ai_flags = 0
 
 	var/control_disabled = 0 // Set to 1 to stop AI from interacting via Click() -- TLE
 	var/malfhacking = 0 // More or less a copy of the above var, so that malf AIs can hack and still get new cyborgs -- NeoFite

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -32,6 +32,19 @@
 /mob/camera/aiEye/Move()
 	return 0
 
+//An AI eyeobj mob cant have a virtualhearer to hear with unless it gets one from a malf module
+/mob/camera/aiEye/Hear(message, atom/movable/speaker, var/datum/language/speaking, raw_message, radio_freq)
+	if(radio_freq) //HOW CAN IT POSSIBLY READ LIPS THROUGH RADIOS
+		return
+
+	var/mob/M = speaker
+	if(istype(M))
+		if(ishuman(M))
+			var/mob/living/carbon/human/H = speaker
+			if(H.check_body_part_coverage(MOUTH)) //OR MASKS
+				return
+		ai.Hear(args) //He can only read the lips of mobs, I cant think of objects using lips
+
 
 // AI MOVEMENT
 

--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -164,7 +164,7 @@
 		health = maxHealth
 		stat = CONSCIOUS
 	else
-		if(fire_res_on_core)
+		if(ai_flags & COREFIRERESIST)
 			health = maxHealth - getOxyLoss() - getToxLoss() - getBruteLoss()
 		else
 			health = maxHealth - getOxyLoss() - getToxLoss() - getFireLoss() - getBruteLoss()

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -92,7 +92,7 @@
 		dist = get_dist(src, user.current)
 	else //cyborg or AI not seeing through a camera
 		dist = get_dist(src, user)
-	if(dist < 2)
+	if(dist < 2 || (user.ai_flags & HIGHRESCAMS))
 		usr << browse("<HTML><HEAD><TITLE>[name]</TITLE></HEAD><BODY[color ? " bgcolor=[src.color]":""]>[info][stamps]</BODY></HTML>", "window=[name]")
 		onclose(usr, "[name]")
 	else

--- a/code/setup.dm
+++ b/code/setup.dm
@@ -1207,3 +1207,8 @@ var/proccalls = 1
 #define ORE_PROCESSING_ALLOY 2
 
 #define SOUND_AMBIANCE			485	//Literally arbitrary.
+
+
+//MALFUNCTION FLAGS
+#define COREFIRERESIST 1
+#define HIGHRESCAMS 2

--- a/html/changelogs/Clusterfack_5618.yml
+++ b/html/changelogs/Clusterfack_5618.yml
@@ -1,0 +1,4 @@
+author: Clusterfack
+delete-after: true
+changes:
+- rscadd: Adds a new malf module High Res Cams - for 10 points it lets you stealthily read the lips of people with your vision and also read paper from long range


### PR DESCRIPTION
High res cameras, inspired by scene in 2001 where HAL reads the lips of the crew.

- Costs 15 (now 10) datapoints, 
- Allow the AI eye object to hear the words of crewmembers in vision
- Allows the AI to read from any paper regardless of its distance from the camera by clicking on it as usual (allowing an AI to get the monitor code by himself).