### PR TITLE
Probably stops huds breaking

### DIFF
--- a/code/_onclick/hud/ai.dm
+++ b/code/_onclick/hud/ai.dm
@@ -124,6 +124,18 @@
 	using.layer = 20
 	adding += using
 
-	mymob.client.screen += adding + other
+	mymob.flash = getFromPool(/obj/screen)
+	mymob.flash.icon_state = "blank"
+	mymob.flash.name = "flash"
+	mymob.flash.screen_loc = "1,1 to 15,15"
+	mymob.flash.layer = 17
+
+	mymob.blind = getFromPool(/obj/screen)
+	mymob.blind.icon_state = "black"
+	mymob.blind.name = " "
+	mymob.blind.screen_loc = "1,1 to 15,15"
+	mymob.blind.layer = 0
+
+	mymob.client.screen += adding + other + list(mymob.flash, mymob.blind)
 
 	return

--- a/code/modules/mob/living/silicon/ai/login.dm
+++ b/code/modules/mob/living/silicon/ai/login.dm
@@ -3,17 +3,6 @@
 	for(var/obj/effect/rune/rune in rune_list) //HOLY FUCK WHO THOUGHT LOOPING THROUGH THE WORLD WAS A GOOD IDEA
 		client.images += rune.blood_image
 	regenerate_icons()
-	flash = getFromPool(/obj/screen)
-	flash.icon_state = "blank"
-	flash.name = "flash"
-	flash.screen_loc = "1,1 to 15,15"
-	flash.layer = 17
-	blind = getFromPool(/obj/screen)
-	blind.icon_state = "black"
-	blind.name = " "
-	blind.screen_loc = "1,1 to 15,15"
-	blind.layer = 0
-	client.screen.Add( blind, flash )
 
 	if(stat != DEAD)
 		for(var/obj/machinery/ai_status_display/O in machines) //change status

--- a/code/modules/mob/living/silicon/mommi/mommi.dm
+++ b/code/modules/mob/living/silicon/mommi/mommi.dm
@@ -166,9 +166,11 @@ They can only use one tool at a time, they can't choose modules, and they have 1
 		nmmi.invisibility = 0
 	..()
 
-/mob/living/silicon/robot/mommi/remove_screen_obj_references()
+/mob/living/silicon/robot/mommi/remove_screen_objs()
 	..()
-	inv_tool = null
+	if(inv_tool)
+		returnToPool(inv_tool)
+		inv_tool = null
 
 /mob/living/silicon/robot/mommi/updatename(var/prefix as text)
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -187,12 +187,23 @@
 		mmi = null
 	..()
 
-/mob/living/silicon/robot/remove_screen_obj_references()
+/mob/living/silicon/robot/remove_screen_objs()
 	..()
-	cells = null //TODO: Move to mob level helper
-	inv1 = null
-	inv2 = null
-	inv3 = null
+	if(cells)
+		returnToPool(cells)
+		cells = null //TODO: Move to mob level helper
+	if(inv1)
+		returnToPool(inv1)
+		inv1 = null
+	if(inv2)
+		returnToPool(inv2)
+		inv2 = null
+	if(inv3)
+		returnToPool(inv3)
+		inv3 = null
+	if(robot_modules_background)
+		returnToPool(robot_modules_background)
+		robot_modules_background = null
 
 /proc/getAvailableRobotModules()
 	//writepanic("[__FILE__].[__LINE__] (no type)([usr ? usr.ckey : ""])  \\/proc/getAvailableRobotModules() called tick#: [world.time]")

--- a/code/modules/mob/logout.dm
+++ b/code/modules/mob/logout.dm
@@ -13,6 +13,8 @@
 
 	log_access("Logout: [key_name(src)] ([formatLocation(loc)])")
 
+	remove_screen_objs() //Used to remove hud elements
+
 	if(admin_datums[src.ckey])
 		if (ticker && ticker.current_state == GAME_STATE_PLAYING) //Only report this stuff if we are currently playing.
 			var/admins_number = admins.len

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -24,7 +24,7 @@ var/global/obj/screen/fuckstat/FUCK = new
 			returnToPool(spell_master)
 		spell_masters = null
 		spells = null
-		remove_screen_obj_references()
+		remove_screen_objs()
 		for(var/atom/movable/AM in client.screen)
 			var/obj/screen/screenobj = AM
 			if(istype(screenobj))
@@ -45,39 +45,101 @@ var/global/obj/screen/fuckstat/FUCK = new
 	qdel(hud_used)
 	..()
 
-/mob/proc/remove_screen_obj_references()
+/mob/proc/remove_screen_objs()
 	//writepanic("[__FILE__].[__LINE__] ([src.type])([usr ? usr.ckey : ""])  \\/mob/proc/remove_screen_obj_references() called tick#: [world.time]")
-	flash = null
-	blind = null
-	hands = null
-	pullin = null
-	visible = null
-	purged = null
-	internals = null
-	oxygen = null
-	i_select = null
-	m_select = null
-	toxin = null
-	fire = null
-	bodytemp = null
-	healths = null
-	throw_icon = null
-	nutrition_icon = null
-	pressure = null
-	damageoverlay = null
-	pain = null
-	item_use_icon = null
-	gun_move_icon = null
-	gun_run_icon = null
-	gun_setting_icon = null
-	m_suitclothes = null
-	m_suitclothesbg = null
-	m_hat = null
-	m_hatbg = null
-	m_glasses = null
-	m_glassesbg = null
-	spell_masters = null
-	zone_sel = null
+	if(flash)
+		returnToPool(flash)
+		flash = null
+	if(blind)
+		returnToPool(blind)
+		blind = null
+	if(hands)
+		returnToPool(hands)
+		hands = null
+	if(pullin)
+		returnToPool(pullin)
+		pullin = null
+	if(visible)
+		returnToPool(visible)
+		visible = null
+	if(purged)
+		returnToPool(purged)
+		purged = null
+	if(internals)
+		returnToPool(internals)
+		internals = null
+	if(oxygen)
+		returnToPool(oxygen)
+		oxygen = null
+	if(i_select)
+		returnToPool(i_select)
+		i_select = null
+	if(m_select)
+		returnToPool(m_select)
+		m_select = null
+	if(toxin)
+		returnToPool(toxin)
+		toxin = null
+	if(fire)
+		returnToPool(fire)
+		fire = null
+	if(bodytemp)
+		returnToPool(bodytemp)
+		bodytemp = null
+	if(healths)
+		returnToPool(healths)
+		healths = null
+	if(throw_icon)
+		returnToPool(throw_icon)
+		throw_icon = null
+	if(nutrition_icon)
+		returnToPool(nutrition_icon)
+		nutrition_icon = null
+	if(pressure)
+		returnToPool(pressure)
+		pressure = null
+	if(damageoverlay)
+		returnToPool(damageoverlay)
+		damageoverlay = null
+	if(pain)
+		returnToPool(pain)
+		pain = null
+	if(item_use_icon)
+		returnToPool(item_use_icon)
+		item_use_icon = null
+	if(gun_move_icon)
+		returnToPool(gun_move_icon)
+		gun_move_icon = null
+	if(gun_run_icon)
+		returnToPool(gun_run_icon)
+		gun_run_icon = null
+	if(gun_setting_icon)
+		returnToPool(gun_setting_icon)
+		gun_setting_icon = null
+	if(m_suitclothes)
+		returnToPool(m_suitclothes)
+		m_suitclothes = null
+	if(m_suitclothesbg)
+		returnToPool(m_suitclothesbg)
+		m_suitclothesbg = null
+	if(m_hat)
+		returnToPool(m_hat)
+		m_hat = null
+	if(m_hatbg)
+		returnToPool(m_hatbg)
+		m_hatbg = null
+	if(m_glasses)
+		returnToPool(m_glasses)
+		m_glasses = null
+	if(m_glassesbg)
+		returnToPool(m_glassesbg)
+		m_glasses = null
+	if(m_glassesbg)
+		returnToPool(m_glassesbg)
+		m_glasses = null
+	if(zone_sel)
+		returnToPool(zone_sel)
+		zone_sel = null
 
 /mob/proc/cultify()
 	//writepanic("[__FILE__].[__LINE__] ([src.type])([usr ? usr.ckey : ""])  \\/mob/proc/cultify() called tick#: [world.time]")

--- a/code/modules/projectiles/targeting.dm
+++ b/code/modules/projectiles/targeting.dm
@@ -274,9 +274,15 @@ client/proc/remove_gun_icons()
 	screen -= usr.gun_move_icon
 	if (target_can_move)
 		screen -= usr.gun_run_icon
-	if(usr.gun_move_icon) returnToPool(usr.gun_move_icon)
-	if(usr.item_use_icon) returnToPool(usr.item_use_icon)
-	if(usr.gun_run_icon) returnToPool(usr.gun_run_icon)
+	if(usr.gun_move_icon)
+		returnToPool(usr.gun_move_icon)
+		usr.gun_move_icon = null
+	if(usr.item_use_icon)
+		returnToPool(usr.item_use_icon)
+		usr.item_use_icon = null
+	if(usr.gun_run_icon)
+		returnToPool(usr.gun_run_icon)
+		usr.gun_run_icon = null
 
 client/verb/ToggleGunMode()
 	set hidden = 1


### PR DESCRIPTION
Alright let's see

- Added a thing to remove screen obj references to logout in addition to being called in destroy instead of relying fully on the reset screen obj proc.
- Moved some hud creation from AI to the hud datums where it should have been, might fix an issue or two
- My teeth still hurt from the dentist so there's that
- Adds robot module backgrounds to one of the screen objs that should be removed on logout as well so all screen objs should always be accounted for going in/out

Man you have to be reeeally careful with pooling about this kind of shit.