### PR TITLE
Speeds up some human loops

### DIFF
--- a/code/game/dna/dna2_domutcheck.dm
+++ b/code/game/dna/dna2_domutcheck.dm
@@ -6,11 +6,12 @@
 #define MUTCHK_FORCED        1
 /proc/domutcheck(var/mob/living/M, var/connected=null, var/flags=0)
 	//writepanic("[__FILE__].[__LINE__] (no type)([usr ? usr.ckey : ""])  \\/proc/domutcheck() called tick#: [world.time]")
+	if(!M)
+		//testing("[gene.name] has No mob")
+		return
+
 	for(var/datum/dna/gene/gene in dna_genes)
 		//testing("Checking [gene.name]")
-		if(!M)
-			//testing("[gene.name] has No mob")
-			return
 		if(!gene.block)
 			//testing("[gene.name] has no block")
 			continue

--- a/code/game/dna/genes/gene.dm
+++ b/code/game/dna/genes/gene.dm
@@ -28,10 +28,6 @@
 /**
 * Is the gene active in this mob's DNA?
 */
-/datum/dna/gene/proc/is_active(var/mob/M)
-	//writepanic("[__FILE__].[__LINE__] ([src.type])([usr ? usr.ckey : ""])  \\/datum/dna/gene/proc/is_active() called tick#: [world.time]")
-	return M.active_genes && (type in M.active_genes)
-
 // Return 1 if we can activate.
 // HANDLE MUTCHK_FORCED HERE!
 /datum/dna/gene/proc/can_activate(var/mob/M, var/flags)

--- a/code/game/gamemodes/setupgame.dm
+++ b/code/game/gamemodes/setupgame.dm
@@ -120,7 +120,7 @@
 		if(G.block)
 			if(G.block in blocks_assigned)
 				warning("DNA2: Gene [G.name] trying to use already-assigned block [G.block] (used by [english_list(blocks_assigned[G.block])])")
-			dna_genes.Add(G)
+			dna_genes[G.type] = G
 			var/list/assignedToBlock[0]
 			if(blocks_assigned[G.block])
 				assignedToBlock=blocks_assigned[G.block]

--- a/code/modules/mob/living/carbon/human/life/handle_mutations_and_radiation.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_mutations_and_radiation.dm
@@ -8,11 +8,11 @@
 		if((M_RESIST_HEAT in mutations))
 			heal_organ_damage(0,1)
 
-	for(var/datum/dna/gene/gene in dna_genes)
+	for(var/gene_type in active_genes)
+		var/datum/dna/gene/gene = dna_genes[gene_type]
 		if(!gene.block)
 			continue
-		if(gene.is_active(src))
-			gene.OnMobLife(src)
+		gene.OnMobLife(src)
 
 	if(radiation)
 

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -374,16 +374,16 @@ var/global/list/damage_icon_parts = list()
 	if(gender == FEMALE)	g = "f"
 	// DNA2 - Drawing underlays.
 	var/hulk = 0
-	for(var/datum/dna/gene/gene in dna_genes)
+	for(var/gene_type in active_genes)
+		var/datum/dna/gene/gene = dna_genes[gene_type]
 		if(!gene.block)
 			continue
-		if(gene.is_active(src))
-			if(gene.name == "Hulk") hulk = 1
-			var/underlay=gene.OnDrawUnderlays(src,g,fat)
-			if(underlay)
-				//standing.underlays += underlay
-				O.underlays += underlay
-				add_image = 1
+		if(gene.name == "Hulk") hulk = 1
+		var/underlay=gene.OnDrawUnderlays(src,g,fat)
+		if(underlay)
+			//standing.underlays += underlay
+			O.underlays += underlay
+			add_image = 1
 	for(var/mut in mutations)
 		switch(mut)
 			if(M_HULK)

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -122,18 +122,18 @@ var/global/list/whitelisted_species = list("Human")
 
 	//If we will apply mutant race overlays or not.
 	var/has_mutant_race = 1
-	
+
 	var/move_speed_mod = 0 //Higher value is slower, lower is faster.
 
 /datum/species/proc/handle_speech(message, mob/living/carbon/human/H)
 	//writepanic("[__FILE__].[__LINE__] ([src.type])([usr ? usr.ckey : ""])  \\/datum/species/proc/handle_speech() called tick#: [world.time]")
 	if(H.dna)
 		if(length(message) >= 2)
-			for(var/datum/dna/gene/gene in dna_genes)
+			for(var/gene_type in H.active_genes)
+				var/datum/dna/gene/gene = dna_genes[gene_type]
 				if(!gene.block)
 					continue
-				if(gene.is_active(H))
-					message = gene.OnSay(H,message)
+				message = gene.OnSay(H,message)
 	return message
 
 /datum/species/proc/create_organs(var/mob/living/carbon/human/H) //Handles creation of mob organs.
@@ -405,11 +405,11 @@ var/global/list/whitelisted_species = list("Human")
 
 	default_mutations=list(SKELETON)
 	brute_mod = 2.0
-	
+
 	has_organ = list(
 		"brain" =    /datum/organ/internal/brain,
 		)
-	
+
 	move_speed_mod = 3
 
 /datum/species/skellington/handle_speech(message, mob/living/carbon/human/H)
@@ -527,7 +527,7 @@ var/global/list/whitelisted_species = list("Human")
 		// Unequip existing suits and hats.
 		H.u_equip(H.wear_suit,1)
 		H.u_equip(H.head,1)
-	
+
 	move_speed_mod = 1
 
 /datum/species/skrell
@@ -706,6 +706,6 @@ var/global/list/whitelisted_species = list("Human")
 
 	has_mutant_race = 0
 	burn_mod = 2.5 //treeeeees
-	
+
 	move_speed_mod = 7
 

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1248,17 +1248,25 @@
 	if(!M) M = holder.my_atom
 
 	var/needs_update = M.mutations.len > 0
-	if(ishuman(M))
-		M:hulk_time = 0
-	for(var/datum/dna/gene/G in dna_genes)
-		if(G.is_active(M))
-			if(G.name == "Hulk" && ishuman(M))
-				G.OnMobLife(M)
+
+	var/mob/living/carbon/human/H = M
+	if(istype(H))
+		H.hulk_time = 0
+		for(var/gene_type in H.active_genes)
+			var/datum/dna/gene/gene = dna_genes[gene_type]
 			var/tempflag = 0
-			if(ishuman(M) && M:species && (G.block in M:species:default_blocks))
+			if(H.species && (gene.block in H.species.default_blocks))
 				tempflag |= GENE_NATURAL
-			if(G.can_deactivate(M, tempflag))
-				G.deactivate(M,0, tempflag)
+			if(gene.name == "Hulk")
+				gene.OnMobLife(H)
+			if(gene.can_deactivate(H, tempflag))
+				gene.deactivate(H, 0, tempflag)
+	else
+		for(var/gene_type in M.active_genes)
+			var/datum/dna/gene/gene = dna_genes[gene_type]
+			if(gene.can_deactivate(M, 0))
+				gene.deactivate(M, 0, 0)
+
 	M.alpha = 255
 	//M.mutations = list()
 	//M.active_genes = list()
@@ -1270,8 +1278,7 @@
 	M.jitteriness = 0
 
 	// Might need to update appearance for hulk etc.
-	if(needs_update && ishuman(M))
-		var/mob/living/carbon/human/H = M
+	if(needs_update && istype(H))
 		H.update_mutations()
 
 	..()


### PR DESCRIPTION
Imagine: loop through ALL possible genes, only to loop through ALL active genes to see if we have them for each one. So thats already a possible genes * active genes loop for each mob.

Instead we loop through active genes only and grab the gene through an associative list. So loop of 54 * x is now a loop of x maximum.

Now dna_genes is an associative list if that isn't clear.
1. Removes the is_active proc entirely 
2. Speeds the FUCK out of handle_mutations_and_radiation by **extremely** lowering looping
![](http://puu.sh/klkC9/06de9f80c8.png)