### PR TITLE
Fix being able to use Newscasters when incapped and dead

### DIFF
--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -223,8 +223,15 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 	return src.attack_hand(user)
 
 /obj/machinery/newscaster/attack_hand(mob/user as mob)            //########### THE MAIN BEEF IS HERE! And in the proc below this...############
-	if((stat & NOPOWER) || (stat & BROKEN) || buildstage != 1)
+
+	. = ..()
+
+	if (.)
 		return
+
+	if(buildstage != 1)
+		return
+
 	if(istype(user, /mob/living/carbon/human) || istype(user,/mob/living/silicon) || isobserver(user))
 		var/mob/M = user
 		var/dat

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -224,13 +224,17 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 
 /obj/machinery/newscaster/attack_hand(mob/user as mob)            //########### THE MAIN BEEF IS HERE! And in the proc below this...############
 
-	. = ..()
-
-	if (.)
-		return
-
 	if(buildstage != 1)
 		return
+
+	if(isobserver(user))
+		continue
+
+	else
+		. = ..()
+
+		if (.)
+			return
 
 	if(istype(user, /mob/living/carbon/human) || istype(user,/mob/living/silicon) || isobserver(user))
 		var/mob/M = user

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -32,6 +32,7 @@
 	var/backup_body =""
 	var/backup_author =""
 	var/is_admin_message = 0
+	var/ghost_read = 1 //The newscaster handles observers properly enough
 	var/icon/img = null
 	var/icon/backup_img
 
@@ -227,14 +228,10 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 	if(buildstage != 1)
 		return
 
-	if(isobserver(user))
-		continue
+	. = ..()
 
-	else
-		. = ..()
-
-		if (.)
-			return
+	if (.)
+		return
 
 	if(istype(user, /mob/living/carbon/human) || istype(user,/mob/living/silicon) || isobserver(user))
 		var/mob/M = user

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -82,7 +82,6 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 	var/buildstage = 1 // 1 = complete, 0 = unscrewed
 
 	// Allow ghosts to send Topic()s.
-	ghost_read = 1
 	ghost_write = 1
 	custom_aghost_alerts=1 // We handle our own logging.
 

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -32,7 +32,6 @@
 	var/backup_body =""
 	var/backup_author =""
 	var/is_admin_message = 0
-	var/ghost_read = 1 //The newscaster handles observers properly enough
 	var/icon/img = null
 	var/icon/backup_img
 
@@ -83,7 +82,8 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 	var/buildstage = 1 // 1 = complete, 0 = unscrewed
 
 	// Allow ghosts to send Topic()s.
-	ghost_write=1
+	ghost_read = 1
+	ghost_write = 1
 	custom_aghost_alerts=1 // We handle our own logging.
 
 	//var/isbroken = 0  //1 if someone banged it with something heavy


### PR DESCRIPTION
- Newscasters now use inheritance on attack_hand, preventing incapped or dead players from using them

Newscasters are still a heap of shitty oldcode, but at least now you can't exploit them to phone home to your metabuddies

Fixes #5723
