### PR TITLE
External airlocks now spawn with their timers lowered

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -95,6 +95,7 @@
 	name = "External Airlock"
 	icon = 'icons/obj/doors/Doorext.dmi'
 	assembly_type = /obj/structure/door_assembly/door_assembly_ext
+	normalspeed = 0 //So they close fast, not letting the air to depressurize in a fucking second
 
 /obj/machinery/door/airlock/external/cultify()
 	new /obj/machinery/door/mineral/wood(loc)

--- a/html/changelogs/Zth.yml
+++ b/html/changelogs/Zth.yml
@@ -1,0 +1,6 @@
+author: Zth
+
+delete-after: True
+
+changes: 
+  - rscadd: External airlocks now start with their timers lowered.

--- a/html/changelogs/Zth.yml
+++ b/html/changelogs/Zth.yml
@@ -3,4 +3,4 @@ author: Zth
 delete-after: True
 
 changes: 
-  - rscadd: External airlocks now start with their timers lowered.
+  - rscadd: External airlocks now close faster by default to minimize depressurization.


### PR DESCRIPTION
# BECAUSE IT MAKES SENSE

Fixes #5790 
