### PR TITLE
Bugfixes.

### DIFF
--- a/code/game/objects/items/devices/silicate sprayer.dm
+++ b/code/game/objects/items/devices/silicate sprayer.dm
@@ -76,13 +76,17 @@
 	if(!iswindow(A)) // We can only fix windows.
 		return
 
+	if(!get_amount())
+		user << "<span class='notice'>\The [src] is out of silicate!</span>"
+		return 1
+
 	var/obj/structure/window/W = A
 
 	var/diff = initial(W.health) - W.health
 	if(!diff) // Not damaged.
 		user << "<span class='notice'>\The [W] is already in perfect condition!</span>"
 		return 1
-
+		
 	diff = min(diff, get_amount() / SILICATE_PER_DAMAGE)
 		
 	W.health += diff
@@ -134,6 +138,10 @@
 
 	if(!iswindow(A))
 		return
+
+	if(!get_amount())
+		user << "<span class='notice'>\The [src] is out of silicate!</span>"
+		return 1
 
 	var/obj/structure/window/W = A
 	var/initial_health = initial(W.health)

--- a/code/modules/RCD/RCD.dm
+++ b/code/modules/RCD/RCD.dm
@@ -117,7 +117,10 @@
 		if(!istype(C))
 			return 1
 
-		if(!(selected ? selected.deselect(usr, C) : 1 && C.select(usr, selected)))
+		if(selected && !selected.deselect(usr, C))
+			return 1
+
+		if(!C.select(usr, selected))
 			return 1
 
 		spark()


### PR DESCRIPTION
**RCD & RPD bugfixes:**
- Fixed calling of `select()` from the base RCD class.
- Fixed pipe layer adapters in the RPD. Fixes #6318.
- Made pipe layers stay when you switch beween pipe schematics.
- Fixed the pipe layer selector not loading if you didn't select the straight pipes first.
- Fixed bent pipes not having a correct director selected initially.
- Fixed disposals pipes having an (unusable) layer selector in the RPD.

**Silicate sprayer fixes:**
- Silicate sprayer now says if it's out of silicate, Fixes #6367.
