### PR TITLE
Move blood loss display back to previous

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -239,13 +239,13 @@ Subject's pulse: ??? BPM"}
 				if(BLOOD_VOLUME_SAFE to 1000000000)
 					message += "<br><span class='notice'>Blood Level Normal: [blood_percent]% ([blood_volume]cl)</span>"
 				if(BLOOD_VOLUME_OKAY to BLOOD_VOLUME_SAFE)
-					message += "<br><span class='notice'>Notice: Blood Level Fine: [blood_percent]% [blood_volume]cl</span>" //Still about fine
+					message += "<br><span class='warning'>Warning: Blood Level Low: [blood_percent]% [blood_volume]cl</span>" //Still about fine
 				if(BLOOD_VOLUME_BAD to BLOOD_VOLUME_OKAY)
-					message += "<br><span class='warning'>Warning: Blood Level Low: [blood_percent]% [blood_volume]cl</span>"
+					message += "<br><span class='danger'>Danger: Blood Level Serious: [blood_percent]% [blood_volume]cl</span>"
 				if(BLOOD_VOLUME_SURVIVE to BLOOD_VOLUME_BAD)
-					message += "<br><span class='warning'><b>Danger: Blood Level Serious: [blood_percent]% [blood_volume]cl</span>"
+					message += "<br><span class='danger'>Danger: Blood Level Critical: [blood_percent]% [blood_volume]cl</span>"
 				if(-1000000000 to BLOOD_VOLUME_SURVIVE)
-					message += "<br><span class='warning'><b>Danger: Blood Level Critical: [blood_percent]% [blood_volume]cl</span>"
+					message += "<br><span class='danger'>Danger: Blood Level Fatal: [blood_percent]% [blood_volume]cl</span>"
 		message += "<br><span class='notice'>Subject's pulse: <font color='[H.pulse == PULSE_THREADY || H.pulse == PULSE_NONE ? "red" : "blue"]'>[H.get_pulse(GETPULSE_TOOL)] BPM</font></span>"
 	user << message //Here goes
 	return message //To read last scan


### PR DESCRIPTION
I really wish this is something we could have a civil discussion about, without screaming for a revert or repository bans
- Urgency of all blood level displays moved one tier. Notice Fine is now Warning Low, Warning Low is now Danger Serious, etc

Fixes #6375
