### PR TITLE
Allows xenobiology to create mimics, slight change to mimic meat

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -124,8 +124,13 @@ var/global/list/crate_mimic_disguises = list(\
 	maxHealth = 100
 	health = 100
 
-/mob/living/simple_animal/hostile/mimic/crate/New()
-	environment_disguise() //Disguise ourselves appropriately
+/mob/living/simple_animal/hostile/mimic/crate/New(loc, atom/new_disguise = null)
+	if(ispath(new_disguise))
+		copied_object = new_disguise
+	else if(istype(new_disguise))
+		copied_object = new_disguise.type
+	else
+		environment_disguise()
 
 	..()
 
@@ -395,10 +400,6 @@ var/global/list/item_mimic_disguises = list(
 	copied_object = /obj/item/target //Default form for us if we accidentally morph into an item with no icon. Gets overridden on New()
 
 	var/icon/mouth_overlay = icon('icons/mob/mob.dmi', icon_state = "mimic_mouth")
-
-/mob/living/simple_animal/hostile/mimic/crate/item/New()
-	environment_disguise()
-	..()
 
 /mob/living/simple_animal/hostile/mimic/crate/item/initialize()
 	return //Don't take any items!

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -792,7 +792,7 @@ datum
 
 					if(ismob(holder.my_atom.loc))
 						var/mob/mob_holder = holder.my_atom.loc
-						mob_holder.update_icons() //Without this, the item visually disappears from the mob's hand!
+						mob_holder.drop_item(holder.my_atom) //Bandaid to work around items becoming invisible when their appearance is changed!
 
 
 /////////////////////////////////////OLD SLIME CORE REACTIONS ///////////////////////////////

--- a/code/modules/reagents/reagent_containers/food/snacks/meat.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/meat.dm
@@ -100,16 +100,6 @@
 
 		shapeshift()
 
-/obj/item/weapon/reagent_containers/food/snacks/meat/mimic/attackby(obj/item/W, mob/user)
-	if(istype(W,/obj/item/weapon/kitchen/rollingpin))
-		user.visible_message("<span class='notice'>[user] starts smacking \the [src] with \the [W].</span>", "<span class='info'>You start reshaping \the [src] with \the [W].</span>")
-
-		if(do_after(user, src, 10))
-			if(prob(80))
-				shapeshift() //Turn into a random foodstuff
-			else
-				src.appearance = initial(src.appearance) //Turn into "mimic meat"
-
 /obj/item/weapon/reagent_containers/food/snacks/meat/mimic/bless()
 	visible_message("<span class='info'>\The [src] starts fizzling!</span>")
 	spawn(10)

--- a/html/changelogs/unid-memecs.yml
+++ b/html/changelogs/unid-memecs.yml
@@ -1,0 +1,7 @@
+author: Unid
+
+delete-after: True
+
+changes: 
+  - tweak: Mimic meat now transforms when injected by 5u blood. It no longer transforms when hit by a rolling pin.
+  - rscadd: Injecting a golden slime core with water spawns a mimic after a slight delay. The resulting mimic's shape and size is affected by the objects closest to it. Putting the core in a crate will create a crate mimic, dropping it near a bunch of items will create an item mimic, and holding it in your hands... What would that do?


### PR DESCRIPTION
- Mimic meat now transforms when injected with 5u blood, instead of when it's hit by a rolling pin
- **Injecting a golden slime core with 5u water summons a mimic after 5 seconds. The mimic's shape and size is affected by its location and surroundings (at the time of the summon)**
- If the golden slime core injected with water is stored in a crate, a crate mimic spawns to replace the crate. All items inside are moved inside the crate mimic, and the old crate is deleted.
- If the golden slime core injected with water is held by (or otherwise stored in) a mob, _a mimic that looks exactly like the mob_ is summoned. The mob mimics behave just like crate mimics, and will spawn a naked corpse when dead. Note that examining it doesn't show any of its items, just the human mob's description, which is a way to identify mob mimics.
- Otherwise, it summons a random item/crate mimic

![](http://puu.sh/l9fUW/fb21f0bc65.png)

I'll update the wiki if this gets merged
