### PR TITLE
Janicart round 2. Now with proper grammar!

### DIFF
--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -38,19 +38,22 @@
 		if((INFINITY * -1) to 0)
 			user << "<span class='danger'>It appears completely unsalvageable</span>"
 	if(mybag)
-		user << "\A [mybag] is hanging on the pimpin' ride."
+		user << "\A [mybag] is hanging on \the [nick]."
 
 /obj/structure/bed/chair/vehicle/janicart/attackby(obj/item/W, mob/user)
 	..()
 	if(istype(W, /obj/item/mecha_parts/janicart_upgrade) && !upgraded && !destroyed)
 		user.drop_item(W)
 		qdel(W)
-		user << "<span class='notice'>You upgrade the Pussy Wagon.</span>"
+		user << "<span class='notice'>You upgrade \the [nick].</span>"
 		upgraded = 1
-		name = "upgraded janicart"
+		name = "upgraded [name]"
 		icon_state = "pussywagon_upgraded"
 	else if(istype(W, /obj/item/weapon/storage/bag/trash))
-		user << "<span class='notice'>You hook the trashbag onto the pimpin' ride.</span>"
+		if(mybag)
+			user << "<span class='warning'>There's already a [W.name] on \the [nick]!</span>"
+			return
+		user << "<span class='notice'>You hook \the [W] onto \the [nick].</span>"
 		user.drop_item(W, src)
 		mybag = W
 
@@ -58,16 +61,16 @@
 	if(istype(M))
 		if(reagents.total_volume >= 2)
 			reagents.trans_to(M, 3)
-			user << "<span class='notice'>You wet the mop in the pimpin' ride.</span>"
+			user << "<span class='notice'>You wet the mop in \the [nick].</span>"
 			playsound(get_turf(src), 'sound/effects/slosh.ogg', 25, 1)
 		if(reagents.total_volume < 1)
-			user << "<span class='notice'>This pimpin' ride is out of water!</span>"
+			user << "<span class='notice'>\The [nick] is out of water!</span>"
 	return 1
 
 /obj/structure/bed/chair/vehicle/janicart/attack_hand(mob/user)
 	if(mybag)
 		if(occupant && occupant == user)
-			switch(alert("Choose an action","Janicart","Get off the ride","Remove the bag","Cancel"))
+			switch(alert("Choose an action.","Janicart","Get off the ride","Remove the bag","Cancel"))
 				if("Get off the ride")
 					return ..()
 

--- a/html/changelogs/Wizardcrying.yml
+++ b/html/changelogs/Wizardcrying.yml
@@ -1,0 +1,6 @@
+author: Wizardcrying
+
+delete-after: true
+
+changes:
+  - bugfix: Disallows the destruction of a janicart's trashbag and its contents by putting on another trashbag. No atom smashing janicart for you, janitors.  


### PR DESCRIPTION
Fixes #6491 - disallows adding a second janicart, and allows the preservation of grammar with a nick change to a capitalized string. In addition, naming is also preserved when adding a janicart upgrade module (thing -> upgraded thing).
