### PR TITLE
Fixes #4027

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -124,10 +124,12 @@ var/global/list/alert_overlays_global = list()
 	areas_added = list(A)
 
 	for(var/direction in cardinal)
-		A = get_area(get_step(src,direction))
-		if(istype(A) && !(A in areas_added))
-			A.all_doors.Add(src)
-			areas_added += A
+		var/turf/T = get_step(src,direction)
+		if(istype(T,/turf/simulated/floor))
+			A = get_area(get_step(src,direction))
+			if(A)
+				A.all_doors |= src
+				areas_added |= A
 
 
 /obj/machinery/door/firedoor/Destroy()


### PR DESCRIPTION
Only areas connected to a firedoor by a floor will be recongized as an area in which the firedoor exists.
i.e. A firedoor connected to a wall of another area will not trigger that firedoor