### PR TITLE
Update bookcase code

### DIFF
--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -22,7 +22,7 @@
 	fire_fuel = 10
 
 	var/health = 50
-	var/busy = 0
+	var/tmp/busy = 0
 	var/list/valid_types = list(/obj/item/weapon/book, \
 								/obj/item/weapon/tome, \
 								/obj/item/weapon/spellbook, \
@@ -42,7 +42,7 @@
 	if(health <= 0)
 		visible_message("<span class='warning'>\The [src] breaks apart!</span>")
 		getFromPool(/obj/item/stack/sheet/wood, get_turf(src), 3)
-		Destroy(src)
+		qdel(src)
 
 /obj/structure/bookcase/attackby(obj/O as obj, mob/user as mob)
 
@@ -51,7 +51,7 @@
 	if(is_type_in_list(O, valid_types))
 		user.drop_item(O, src)
 		update_icon()
-	else if(istype(O, /obj/item/weapon/crowbar) && user.a_intent == I_HELP) //Only way to deconstruct, needs help intent
+	else if(iscrowbar(O) && user.a_intent == I_HELP) //Only way to deconstruct, needs help intent
 		playsound(get_turf(src), 'sound/items/Crowbar.ogg', 75, 1)
 		user.visible_message("<span class='warning'>[user] starts disassembling \the [src].</span>", \
 		"<span class='notice'>You start disassembling \the [src].</span>")
@@ -63,12 +63,12 @@
 			"<span class='notice'>You disassemble \the [src].</span>")
 			busy = 0
 			getFromPool(/obj/item/stack/sheet/wood, get_turf(src), 5)
-			Destroy(src)
+			qdel(src)
 			return
 		else
 			busy = 0
 		return
-	else if(istype(O, /obj/item/weapon/wrench))
+	else if(iswrench(O))
 		anchored = !anchored
 		playsound(get_turf(src), 'sound/items/Ratchet.ogg', 50, 1)
 		user.visible_message("<span class='warning'>[user] [anchored ? "":"un"]anchors \the [src] [anchored ? "to":"from"] the floor.</span>", \
@@ -85,10 +85,8 @@
 		user.visible_message("<span class='warning'>\The [user] hits \the [src] with \the [O].</span>", \
 		"<span class='warning'>You hit \the [src] with \the [O].</span>")
 		healthcheck()
-		return
-
 	else
-		..() //Weapon checks for weapons without brute or burn damage type and grab check
+		return ..() //Weapon checks for weapons without brute or burn damage type and grab check
 
 /obj/structure/bookcase/attack_hand(var/mob/user as mob)
 	if(contents.len)
@@ -107,23 +105,22 @@
 		if(1.0)
 			for(var/obj/item/I in contents)
 				qdel(I)
-			Destroy(src)
+			qdel(src)
 			return
 		if(2.0)
 			for(var/obj/item/I in contents)
 				if(prob(50))
 					qdel(I)
-			Destroy(src)
+			qdel(src)
 			return
 		if(3.0)
 			if(prob(50))
-				Destroy(src)
+				qdel(src)
 			return
 	return
 
 /obj/structure/bookcase/Destroy()
 
-	density = 0 //Sanity while we do the rest
 	for(var/obj/item/I in contents)
 		if(is_type_in_list(I, valid_types))
 			I.forceMove(get_turf(src))

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -18,105 +18,122 @@
 	anchored = 1
 	density = 1
 	opacity = 1
-	var/health = 50
-
 	autoignition_temperature = AUTOIGNITION_WOOD
 	fire_fuel = 10
+
+	var/health = 50
+	var/busy = 0
+	var/list/valid_types = list(/obj/item/weapon/book, \
+								/obj/item/weapon/tome, \
+								/obj/item/weapon/spellbook, \
+								/obj/item/weapon/storage/bible)
 
 /obj/structure/bookcase/cultify()
 	return
 
 /obj/structure/bookcase/initialize()
 	for(var/obj/item/I in loc)
-		if(istype(I, /obj/item/weapon/book))
-			I.loc = src
+		if(is_type_in_list(I, valid_types))
+			I.forceMove(src)
 	update_icon()
 
+/obj/structure/bookcase/proc/healthcheck()
+
+	if(health <= 0)
+		visible_message("<span class='warning'>\The [src] breaks apart!</span>")
+		getFromPool(/obj/item/stack/sheet/wood, get_turf(src), 3)
+		Destroy(src)
+
 /obj/structure/bookcase/attackby(obj/O as obj, mob/user as mob)
-	if(istype(O, /obj/item/weapon/book))
+
+	if(busy) //So that you can't mess with it while deconstructing
+		return
+	if(is_type_in_list(O, valid_types))
 		user.drop_item(O, src)
 		update_icon()
-	else if(istype(O, /obj/item/weapon/tome))
-		user.drop_item(O, src)
-		update_icon()
-	else if(istype(O, /obj/item/weapon/spellbook))
-		user.drop_item(O, src)
-		update_icon()
-	else if(istype(O, /obj/item/weapon/storage/bible))
-		user.drop_item(O, src)
-		update_icon()
-	else if(istype(O, /obj/item/weapon/screwdriver))
-		user << "<span class='notice'>Now disassembling [src]</span>"
-		playsound(get_turf(src), 'sound/items/Ratchet.ogg', 50, 1)
-		if(do_after(user, src,50))
+	else if(istype(O, /obj/item/weapon/crowbar) && user.a_intent == I_HELP) //Only way to deconstruct, needs help intent
+		playsound(get_turf(src), 'sound/items/Crowbar.ogg', 75, 1)
+		user.visible_message("<span class='warning'>[user] starts disassembling \the [src].</span>", \
+		"<span class='notice'>You start disassembling \the [src].</span>")
+		busy = 1
+
+		if(do_after(user, src, 50))
+			playsound(get_turf(src), 'sound/items/Deconstruct.ogg', 75, 1)
+			user.visible_message("<span class='warning'>[user] disassembles \the [src].</span>", \
+			"<span class='notice'>You disassemble \the [src].</span>")
+			busy = 0
 			getFromPool(/obj/item/stack/sheet/wood, get_turf(src), 5)
-			density = 0
-			qdel(src)
+			Destroy(src)
+			return
+		else
+			busy = 0
 		return
 	else if(istype(O, /obj/item/weapon/wrench))
-		playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
-		user << (anchored ? "<span class='notice'>You unfasten the [src] from the floor.</span>" : "<span class='notice'>You secure the [src] to the floor.</span>")
 		anchored = !anchored
+		playsound(get_turf(src), 'sound/items/Ratchet.ogg', 50, 1)
+		user.visible_message("<span class='warning'>[user] [anchored ? "":"un"]anchors \the [src] [anchored ? "to":"from"] the floor.</span>", \
+		"<span class='notice'>You [anchored ? "":"un"]anchor the [src] [anchored ? "to":"from"] the floor.</span>")
 	else if(istype(O, /obj/item/weapon/pen))
-		var/newname = stripped_input(usr, "What would you like to title this bookshelf?")
+		var/newname = stripped_input(user, "What category title would you like to give to this [name]?")
 		if(!newname)
 			return
 		else
 			name = ("bookcase ([sanitize(newname)])")
+	else if(O.damtype == BRUTE || O.damtype == BURN)
+		user.delayNextAttack(10) //We are attacking the bookshelf
+		health -= O.force
+		user.visible_message("<span class='warning'>\The [user] hits \the [src] with \the [O].</span>", \
+		"<span class='warning'>You hit \the [src] with \the [O].</span>")
+		healthcheck()
+		return
+
 	else
-		switch(O.damtype)
-			if("fire")
-				src.health -= O.force * 1
-			if("brute")
-				src.health -= O.force * 0.75
-			else
-		if (src.health <= 0)
-			visible_message("<span class=warning>The bookcase is smashed apart!</span>")
-			getFromPool(/obj/item/stack/sheet/wood, get_turf(src), 3)
-			qdel(src)
-		..()
+		..() //Weapon checks for weapons without brute or burn damage type and grab check
 
 /obj/structure/bookcase/attack_hand(var/mob/user as mob)
 	if(contents.len)
-		var/obj/item/weapon/book/choice = input("Which book would you like to remove from the shelf?") as null|obj in contents
+		var/obj/item/weapon/book/choice = input("Which book would you like to remove from \the [src]?") as null|obj in contents
 		if(choice)
-			if(!usr.canmove || usr.stat || usr.restrained() || !in_range(loc, usr))
+			if(user.restrained() || user.stat || user.weakened || user.stunned || user.paralysis || user.resting || get_dist(user, src) > 1)
 				return
-			if(ishuman(user))
-				if(!user.get_active_hand())
-					user.put_in_hands(choice)
+			if(!user.get_active_hand())
+				user.put_in_hands(choice)
 			else
-				choice.loc = get_turf(src)
+				choice.forceMove(get_turf(src))
 			update_icon()
 
 /obj/structure/bookcase/ex_act(severity)
 	switch(severity)
 		if(1.0)
-			for(var/obj/item/weapon/book/b in contents)
-				qdel(b)
-			qdel(src)
+			for(var/obj/item/I in contents)
+				qdel(I)
+			Destroy(src)
 			return
 		if(2.0)
-			for(var/obj/item/weapon/book/b in contents)
-				if (prob(50)) b.loc = (get_turf(src))
-				else qdel(b)
-			qdel(src)
+			for(var/obj/item/I in contents)
+				if(prob(50))
+					qdel(I)
+			Destroy(src)
 			return
 		if(3.0)
-			if (prob(50))
-				for(var/obj/item/weapon/book/b in contents)
-					b.loc = (get_turf(src))
-				qdel(src)
+			if(prob(50))
+				Destroy(src)
 			return
-		else
 	return
+
+/obj/structure/bookcase/Destroy()
+
+	density = 0 //Sanity while we do the rest
+	for(var/obj/item/I in contents)
+		if(is_type_in_list(I, valid_types))
+			I.forceMove(get_turf(src))
+	..()
 
 /obj/structure/bookcase/update_icon()
 	if(contents.len < 5)
 		icon_state = "book-[contents.len]"
 	else
 		icon_state = "book-5"
-
 
 /obj/structure/bookcase/manuals/medical
 	name = "Medical Manuals bookcase"


### PR DESCRIPTION
- Update general check when trying to remove a book from the shelf. This means you should now be able to grab books from the shelf while sitting on a chair or on a vehicle
- Use a type list to clarify what can fit in the bookcase. Fixes bibles, tomes and spell books not auto-entering the bookcase on initialize and getting nuked by explosions no matter what
- Changed deconstruction method from screwdriver to help intent crowbar to align with wiki. Deconstruction now refunds the books
- Standardized healthcheck() and Destroy() procs, attack messages, busy checks on decon
- Use visible_message, typecasts and forceMove() whenever applicable

Fixed #3842
