### PR TITLE
Fix health analyzer sound, add extra error catcher in sound.dm

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -122,7 +122,7 @@ proc/healthanalyze(mob/living/M as mob, mob/living/user as mob, var/mode = 0, va
 		if(((M_CLUMSY in user.mutations) || user.getBrainLoss() >= 60) && prob(50))
 			user.visible_message("<span class='warning'>[user] analyzes the floor's vitals!</span>", \
 			"<span class='warning'>You analyze the floor's vitals!</span>")
-			playsound(get_turf(src), 'sound/items/healthanalyzer.ogg', 50, 1)
+			playsound(user, 'sound/items/healthanalyzer.ogg', 50, 1)
 			user << {"<span class='notice'>Analyzing Results for the floor:<br>Overall Status: Healthy</span>
 Key: <font color='blue'>Suffocation</font>/<font color='green'>Toxin</font>/<font color='#FFA500'>Burns</font>/<font color='red'>Brute</font>
 Damage Specifics: <font color='blue'>0</font> - <font color='green'>0</font> - <font color='#FFA500'>0</font> - <font color='red'>0</font>
@@ -136,7 +136,7 @@ Subject's pulse: ??? BPM"}
 	if(!silent)
 		user.visible_message("<span class='notice'>[user] analyzes [M]'s vitals.</span>", \
 		"<span class='notice'>You analyze [M]'s vitals.</span>")
-		playsound(get_turf(src), 'sound/items/healthanalyzer.ogg', 50, 1)
+		playsound(user, 'sound/items/healthanalyzer.ogg', 50, 1)
 	var/fake_oxy = max(rand(1, 40), M.getOxyLoss(), (300 - (M.getToxLoss() + M.getFireLoss() + M.getBruteLoss())))
 	var/OX = M.getOxyLoss() > 50   ? "<b>[M.getOxyLoss()]</b>"   : M.getOxyLoss()
 	var/TX = M.getToxLoss() > 50   ? "<b>[M.getToxLoss()]</b>"   : M.getToxLoss()

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -30,7 +30,6 @@ var/list/lightning_sound = list('sound/effects/lightning/chainlightning1.ogg', '
 	var/turf/turf_source = get_turf(source)
 	if(!turf_source)
 		error("Warning : [source] trying to play sound '[soundin]', but turf could not be found.")
-		world << "Warning : [source] trying to play sound '[soundin]', but turf could not be found."
 		return
 
 /* What's going on in this block?

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -29,6 +29,8 @@ var/list/lightning_sound = list('sound/effects/lightning/chainlightning1.ogg', '
 	var/frequency = get_rand_frequency() // Same frequency for everybody
 	var/turf/turf_source = get_turf(source)
 	if(!turf_source)
+		error("Warning : [source] trying to play sound '[soundin]', but turf could not be found.")
+		world << "Warning : [source] trying to play sound '[soundin]', but turf could not be found."
 		return
 
 /* What's going on in this block?


### PR DESCRIPTION
- Health analyzer was trying to cast a sound to get_turf(src), but since that particular proc is global (or something of the sort) the playsound proc couldn't make sense out of src, nor find its turf. The sound is now cast to user, which is functionally identical
- An error will now fire if playsound fails to play a sound because it couldn't find the sound origin's turf, which should now find both nullspace problems and non-existent/incorrect sources
