### PR TITLE
Dealing with cult-jobbanned conversions

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -211,8 +211,12 @@
 						log_admin("[M]([ckey(M.key)]) ghosted/disconnected less than a minute after having been converted to the cult! ([T.x],[T.y],[T.z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>JMP</a>)")
 			return 1
 		else
-			usr << "<span class='danger'>The ritual didn't work, either something is disrupting it, or this person just isn't suited to be part of our cult.</span>"
-			if(M.silent && M.weakened)
+			if(jobban_isbanned(M, "cultist"))
+				M.Sleeping(300)//putting them to sleep for 5 minutes.
+				usr << "<span class='danger'>The ritual didn't work! Looks like this person just isn't suited to be part of our cult.</span>"
+				usr << "<span class='notice'>It appears that the ritual at least put the target to sleep. Try to figure a way to deal with them before they wake up.</span>"
+			else if(M.weakened)
+				usr << "<span class='danger'>The ritual didn't work, either something is disrupting it, or this person just isn't suited to be part of our cult.</span>"
 				usr << "<span class='danger'>You have to restrain him before the talisman's effects wear off!</span>"
 			M << "<span class='sinister'>Your blood pulses. Your head throbs. The world goes red. All at once you are aware of a horrible, horrible truth. The veil of reality has been ripped away and in the festering wound left behind something sinister takes root.</span>"
 			M << "<span class='danger'>And you were able to force it out of your mind. You now know the truth, there's something horrible out there, stop it and its minions at all costs.</span>"

--- a/html/changelogs/DeityLink_6587.yml
+++ b/html/changelogs/DeityLink_6587.yml
@@ -1,0 +1,4 @@
+author: Deity Link
+delete-after: true
+changes:
+  - tweak: Trying to convert a cult-banned player will now force them asleep for 10 minute and give the cultist who tried to convert them an explicit message about it. This doesn't convert loyalty implanted players.


### PR DESCRIPTION
Trying to convert a cult-banned player puts him to sleep for 5-10 minutes and gives the cultist who tried to convert him an explicit message about it.

This doesn't concerns loyalty implanted players.

At least now cultists know if the ritual failed because of a jobban or an implant (or other reasons).

Fixes #6252
Fixes #5976
