### PR TITLE
Added 'Blood' spreadtype.

### DIFF
--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -2,7 +2,7 @@ var/global/list/disease2_list = list()
 /datum/disease2/disease
 	var/infectionchance = 70
 	var/speed = 1
-	var/spreadtype = "Contact" // Can also be "Airborne"
+	var/spreadtype = "Contact" // Can also be "Airborne" or "Blood"
 	var/stage = 1
 	var/stageprob = 10
 	var/dead = 0
@@ -36,7 +36,7 @@ var/global/list/disease2_list = list()
 	infectionchance = rand(60,90)
 	antigen |= text2num(pick(ANTIGENS))
 	antigen |= text2num(pick(ANTIGENS))
-	spreadtype = prob(70) ? "Airborne" : "Contact"
+	spreadtype = prob(70) ? "Airborne" : prob(20) ? "Blood" :"Contact" //Try for airborne then try for blood.
 
 /proc/virus2_make_custom(client/C)
 	//writepanic("[__FILE__].[__LINE__] (no type)([usr ? usr.ckey : ""])  \\/proc/virus2_make_custom() called tick#: [world.time]")
@@ -70,7 +70,7 @@ var/global/list/disease2_list = list()
 	D.antigen |= text2num(pick(ANTIGENS))
 	D.antigen |= text2num(pick(ANTIGENS))
 
-	D.spreadtype = input(C, "Select spread type", "Spread Type") in list("Airborne", "Contact") // select how the disease is spread
+	D.spreadtype = input(C, "Select spread type", "Spread Type") in list("Airborne", "Contact", "Blood") // select how the disease is spread
 	infectedMob.virus2["[D.uniqueID]"] = D // assign the disease datum to the infectedMob/ selected user.
 	log_admin("[infectedMob] was infected with a virus with uniqueID : [D.uniqueID] by [C.ckey]")
 	message_admins("[infectedMob] was infected with a virus with uniqueID : [D.uniqueID] by [C.ckey]")

--- a/html/changelogs/Faptastic.yml
+++ b/html/changelogs/Faptastic.yml
@@ -1,2 +1,3 @@
 author: Faptastic
-changes: []
+changes:
+  - rscadd: Added 'Blood' transmission vector for virus samples.


### PR DESCRIPTION
20% chance after the initial 70% chance of it being airborne to be blood, so relatively rare.

Blood transmission does not spread via air or contact and is therefore safer to utilise in strains you want to control the spread of. Some symptoms will still spread it regardless but in general there needs to be blood contact at some point.

Main uses include safer (for the most part) strains you can use to make fun monkeys that would otherwise be unviable due to rampant spreading and bespoke torture strains to be safely administered to a single victim without fear of accidental infections (more or less).

Combined with no mutations from radstorms = fun!
