### PR TITLE
[Autism] Anti-toxin (Dylovene) renamed to Dylovene

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -383,7 +383,7 @@
 			return
 
 /datum/reagent/anti_toxin
-	name = "Anti-Toxin (Dylovene)"
+	name = "Dylovene"
 	id = "anti_toxin"
 	description = "Dylovene is a broad-spectrum antitoxin."
 	reagent_state = LIQUID

--- a/html/changelogs/ShiggyPiggy_4.yml
+++ b/html/changelogs/ShiggyPiggy_4.yml
@@ -1,4 +1,4 @@
 author: ShiggyPiggy
 changes:
-  bugfix: Anti-Toxin (Dylovene) is now just Dylovene.
+ -bugfix: Anti-Toxin (Dylovene) is now just Dylovene.
 delete-after: true

--- a/html/changelogs/ShiggyPiggy_4.yml
+++ b/html/changelogs/ShiggyPiggy_4.yml
@@ -1,0 +1,4 @@
+author: ShiggyPiggy
+changes:
+  bugfix: Anti-Toxin (Dylovene) is now just Dylovene.
+delete-after: true


### PR DESCRIPTION
Not really a bug, but it's the only reagent whatsoever that has a double name.
The description's the same, so it wouldn't be a problem for anyone not familiar with the name.