### PR TITLE
Fix Sleeper Construction Typo

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -592,7 +592,7 @@ obj/item/weapon/circuitboard/rdserver
 	build_path = "/obj/machinery/dna_scannernew"
 	board_type = "machine"
 	origin_tech = "programming=3;biotech=2"
-	frame_desc = "Requires 1 Scanning module, 1 Manipulator, 1 Micro-Laser, and 1 Console Screen."
+	frame_desc = "Requires 1 Scanning Module, 1 Manipulator, 1 Micro-Laser, and 1 Console Screen."
 	req_components = list(
 							"/obj/item/weapon/stock_parts/scanning_module" = 1,
 							"/obj/item/weapon/stock_parts/manipulator" = 1,
@@ -613,7 +613,7 @@ obj/item/weapon/circuitboard/rdserver
 	build_path = "/obj/machinery/sleeper"
 	board_type = "machine"
 	origin_tech = "biotech=2"
-	frame_desc = "Requires 2 Scanning Module, 2 Manipulator."
+	frame_desc = "Requires 1 Scanning Module, 2 Manipulator."
 	req_components = list(
 							"/obj/item/weapon/stock_parts/scanning_module" = 1,
 							"/obj/item/weapon/stock_parts/manipulator" = 2)


### PR DESCRIPTION
- Sleeper takes one scanning module, not two
- Fixed another error I noticed right above it

Those descriptions should really be created dynamically when the frame is created, otherwise every time machine components are updated, this needs to be too. For further notice I guess

Fixes #6642
