### PR TITLE
Patch up artifact cell charge and drain

### DIFF
--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_cellcharge.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_cellcharge.dm
@@ -9,6 +9,8 @@
 		if(R.cell)
 			R.cell.charge += rand() * 100
 			R << "<span class='notice'>SYSTEM ALERT: Large energy boost detected!</span>"
+		if(world.time >= next_message)
+			next_message = world.time + 50
 		return 1
 
 /datum/artifact_effect/cellcharge/DoEffectAura()
@@ -24,7 +26,7 @@
 				if(world.time >= next_message)
 					M << "<span class='notice'>SYSTEM ALERT: Energy boost detected!</span>"
 		if(world.time >= next_message)
-			next_message = world.time + 100
+			next_message = world.time + 300
 		return 1
 
 /datum/artifact_effect/cellcharge/DoEffectPulse()
@@ -40,5 +42,5 @@
 				if(world.time >= next_message)
 					M << "<span class='notice'>SYSTEM ALERT: Large energy boost detected!</span>"
 		if(world.time >= next_message)
-			next_message = world.time + 100
+			next_message = world.time + 300
 		return 1

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_cellcharge.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_cellcharge.dm
@@ -39,4 +39,6 @@
 				M.cell.charge += rand() * 100
 				if(world.time >= next_message)
 					M << "<span class='notice'>SYSTEM ALERT: Large energy boost detected!</span>"
+		if(world.time >= next_message)
+			next_message = world.time + 100
 		return 1

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_cellcharge.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_cellcharge.dm
@@ -1,29 +1,26 @@
-
-//todo
 /datum/artifact_effect/cellcharge
 	effecttype = "cellcharge"
 	effect_type = 3
 	var/next_message
 
 /datum/artifact_effect/cellcharge/DoEffectTouch(var/mob/user)
-	if(user)
-		if(istype(user, /mob/living/silicon/robot))
-			var/mob/living/silicon/robot/R = user
-			for (var/obj/item/weapon/cell/D in R.contents)
-				D.charge += rand() * 100 + 50
-				R << "<span class='notice'>SYSTEM ALERT: Large energy boost detected!</span>"
-			return 1
+	if(isrobot(user))
+		var/mob/living/silicon/robot/R = user
+		if(R.cell)
+			R.cell.charge += rand() * 100
+			R << "<span class='notice'>SYSTEM ALERT: Large energy boost detected!</span>"
+		return 1
 
 /datum/artifact_effect/cellcharge/DoEffectAura()
 	if(holder)
-		for (var/obj/machinery/power/apc/C in range(200, holder))
-			for (var/obj/item/weapon/cell/B in C.contents)
-				B.charge += 25
-		for (var/obj/machinery/power/battery/S in range (src.effectrange,src))
+		for(var/obj/machinery/power/apc/C in range(effectrange, holder))
+			if(C.cell)
+				C.cell.charge += 25
+		for(var/obj/machinery/power/battery/S in range(effectrange, holder))
 			S.charge += 25
-		for (var/mob/living/silicon/robot/M in mob_list)
-			for (var/obj/item/weapon/cell/D in M.contents)
-				D.charge += 25
+		for(var/mob/living/silicon/robot/M in mob_list)
+			if(M.cell)
+				M.cell.charge += 25
 				if(world.time >= next_message)
 					M << "<span class='notice'>SYSTEM ALERT: Energy boost detected!</span>"
 		if(world.time >= next_message)
@@ -32,13 +29,14 @@
 
 /datum/artifact_effect/cellcharge/DoEffectPulse()
 	if(holder)
-		for (var/obj/machinery/power/apc/C in range(200, holder))
-			for (var/obj/item/weapon/cell/B in C.contents)
-				B.charge += rand() * 100
-		for (var/obj/machinery/power/battery/S in range (src.effectrange,src))
-			S.charge += 250
-		for (var/mob/living/silicon/robot/M in mob_list)
-			for (var/obj/item/weapon/cell/D in M.contents)
-				D.charge += rand() * 100
-				M << "<span class='notice'>SYSTEM ALERT: Energy boost detected!</span>"
+		for(var/obj/machinery/power/apc/C in range(effectrange, holder))
+			if(C.cell)
+				C.cell.charge += rand() * 100
+		for(var/obj/machinery/power/battery/S in range(effectrange, holder))
+			S.charge += rand() * 100
+		for(var/mob/living/silicon/robot/M in mob_list)
+			if(M.cell)
+				M.cell.charge += rand() * 100
+				if(world.time >= next_message)
+					M << "<span class='notice'>SYSTEM ALERT: Large energy boost detected!</span>"
 		return 1

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_celldrain.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_celldrain.dm
@@ -11,6 +11,8 @@
 		if(R.cell)
 			R.cell.charge = max(R.cell.charge - rand() * 100, 0)
 			R << "<span class='danger'>SYSTEM ALERT: Large energy drain detected!</span>"
+		if(world.time >= next_message)
+			next_message = world.time + 50
 		return 1
 
 /datum/artifact_effect/celldrain/DoEffectAura()
@@ -26,7 +28,7 @@
 				if(world.time >= next_message)
 					M << "<span class='warning'>SYSTEM ALERT: Energy drain detected!</span>"
 		if(world.time >= next_message)
-			next_message = world.time + 100
+			next_message = world.time + 300
 		return 1
 
 /datum/artifact_effect/celldrain/DoEffectPulse()
@@ -42,5 +44,5 @@
 				if(world.time >= next_message)
 					M << "<span class='danger'>SYSTEM ALERT: Large energy drain detected!</span>"
 		if(world.time >= next_message)
-			next_message = world.time + 100
+			next_message = world.time + 300
 		return 1

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_celldrain.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_celldrain.dm
@@ -3,12 +3,13 @@
 /datum/artifact_effect/celldrain
 	effecttype = "celldrain"
 	effect_type = 3
+	var/next_message
 
 /datum/artifact_effect/celldrain/DoEffectTouch(var/mob/user)
 	if(isrobot(user))
 		var/mob/living/silicon/robot/R = user
 		if(R.cell)
-			R.cell.charge = max(D.charge - rand() * 100, 0)
+			R.cell.charge = max(R.charge - rand() * 100, 0)
 			R << "<span class='danger'>SYSTEM ALERT: Large energy drain detected!</span>"
 		return 1
 
@@ -16,12 +17,12 @@
 	if(holder)
 		for(var/obj/machinery/power/apc/C in range(effectrange, holder))
 			if(C.cell)
-				C.cell.charge = max(B.charge - 50, 0)
+				C.cell.charge = max(C.charge - 50, 0)
 		for(var/obj/machinery/power/battery/S in range(effectrange, holder))
-			S.charge = max(B.charge - 50, 0)
+			S.charge = max(S.charge - 50, 0)
 		for(var/mob/living/silicon/robot/M in mob_list)
 			if(M.cell)
-				M.cell.charge = max(B.charge - 50, 0)
+				M.cell.charge = max(M.charge - 50, 0)
 				if(world.time >= next_message)
 					M << "<span class='warning'>SYSTEM ALERT: Energy drain detected!</span>"
 		if(world.time >= next_message)
@@ -32,12 +33,14 @@
 	if(holder)
 		for(var/obj/machinery/power/apc/C in range(effectrange, holder))
 			if(C.cell)
-				C.cell.charge = max(D.charge - rand() * 100, 0)
+				C.cell.charge = max(C.charge - rand() * 100, 0)
 		for(var/obj/machinery/power/battery/S in range(effectrange, holder))
-			S.charge = max(D.charge - rand() * 100, 0)
+			S.charge = max(S.charge - rand() * 100, 0)
 		for(var/mob/living/silicon/robot/M in mob_list)
 			if(M.cell)
-				M.cell.charge = max(D.charge - rand() * 100, 0)
+				M.cell.charge = max(M.charge - rand() * 100, 0)
 				if(world.time >= next_message)
 					M << "<span class='danger'>SYSTEM ALERT: Large energy drain detected!</span>"
+		if(world.time >= next_message)
+			next_message = world.time + 100
 		return 1

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_celldrain.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_celldrain.dm
@@ -5,38 +5,39 @@
 	effect_type = 3
 
 /datum/artifact_effect/celldrain/DoEffectTouch(var/mob/user)
-	if(user)
-		if(istype(user, /mob/living/silicon/robot))
-			var/mob/living/silicon/robot/R = user
-			for (var/obj/item/weapon/cell/D in R.contents)
-				D.charge = max(D.charge - rand() * 100, 0)
-				R << "<span class='notice'>SYSTEM ALERT: Energy drain detected!</span>"
-			return 1
-
+	if(isrobot(user))
+		var/mob/living/silicon/robot/R = user
+		if(R.cell)
+			R.cell.charge = max(D.charge - rand() * 100, 0)
+			R << "<span class='danger'>SYSTEM ALERT: Large energy drain detected!</span>"
 		return 1
 
 /datum/artifact_effect/celldrain/DoEffectAura()
 	if(holder)
-		for (var/obj/machinery/power/apc/C in range(200, holder))
-			for (var/obj/item/weapon/cell/B in C.contents)
-				B.charge = max(B.charge - 50,0)
-		for (var/obj/machinery/power/battery/S in range (src.effectrange,src))
-			S.charge = max(S.charge - 100,0)
-		for (var/mob/living/silicon/robot/M in mob_list)
-			for (var/obj/item/weapon/cell/D in M.contents)
-				D.charge = max(D.charge - 50,0)
-				M << "<span class='warning'>SYSTEM ALERT: Energy drain detected!</span>"
-	return 1
+		for(var/obj/machinery/power/apc/C in range(effectrange, holder))
+			if(C.cell)
+				C.cell.charge = max(B.charge - 50, 0)
+		for(var/obj/machinery/power/battery/S in range(effectrange, holder))
+			S.charge = max(B.charge - 50, 0)
+		for(var/mob/living/silicon/robot/M in mob_list)
+			if(M.cell)
+				M.cell.charge = max(B.charge - 50, 0)
+				if(world.time >= next_message)
+					M << "<span class='warning'>SYSTEM ALERT: Energy drain detected!</span>"
+		if(world.time >= next_message)
+			next_message = world.time + 100
+		return 1
 
 /datum/artifact_effect/celldrain/DoEffectPulse()
 	if(holder)
-		for (var/obj/machinery/power/apc/C in range(200, holder))
-			for (var/obj/item/weapon/cell/B in C.contents)
-				B.charge = max(B.charge - rand() * 150,0)
-		for (var/obj/machinery/power/battery/S in range (src.effectrange,src))
-			S.charge = max(S.charge - 250,0)
-		for (var/mob/living/silicon/robot/M in mob_list)
-			for (var/obj/item/weapon/cell/D in M.contents)
-				D.charge = max(D.charge - rand() * 150,0)
-				M << "<span class='warning'>SYSTEM ALERT: Energy drain detected!</span>"
-	return 1
+		for(var/obj/machinery/power/apc/C in range(effectrange, holder))
+			if(C.cell)
+				C.cell.charge = max(D.charge - rand() * 100, 0)
+		for(var/obj/machinery/power/battery/S in range(effectrange, holder))
+			S.charge = max(D.charge - rand() * 100, 0)
+		for(var/mob/living/silicon/robot/M in mob_list)
+			if(M.cell)
+				M.cell.charge = max(D.charge - rand() * 100, 0)
+				if(world.time >= next_message)
+					M << "<span class='danger'>SYSTEM ALERT: Large energy drain detected!</span>"
+		return 1

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_celldrain.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_celldrain.dm
@@ -9,7 +9,7 @@
 	if(isrobot(user))
 		var/mob/living/silicon/robot/R = user
 		if(R.cell)
-			R.cell.charge = max(R.charge - rand() * 100, 0)
+			R.cell.charge = max(R.cell.charge - rand() * 100, 0)
 			R << "<span class='danger'>SYSTEM ALERT: Large energy drain detected!</span>"
 		return 1
 
@@ -17,12 +17,12 @@
 	if(holder)
 		for(var/obj/machinery/power/apc/C in range(effectrange, holder))
 			if(C.cell)
-				C.cell.charge = max(C.charge - 50, 0)
+				C.cell.charge = max(C.cell.charge - 50, 0)
 		for(var/obj/machinery/power/battery/S in range(effectrange, holder))
 			S.charge = max(S.charge - 50, 0)
 		for(var/mob/living/silicon/robot/M in mob_list)
 			if(M.cell)
-				M.cell.charge = max(M.charge - 50, 0)
+				M.cell.charge = max(M.cell.charge - 50, 0)
 				if(world.time >= next_message)
 					M << "<span class='warning'>SYSTEM ALERT: Energy drain detected!</span>"
 		if(world.time >= next_message)
@@ -33,12 +33,12 @@
 	if(holder)
 		for(var/obj/machinery/power/apc/C in range(effectrange, holder))
 			if(C.cell)
-				C.cell.charge = max(C.charge - rand() * 100, 0)
+				C.cell.charge = max(C.cell.charge - rand() * 100, 0)
 		for(var/obj/machinery/power/battery/S in range(effectrange, holder))
 			S.charge = max(S.charge - rand() * 100, 0)
 		for(var/mob/living/silicon/robot/M in mob_list)
 			if(M.cell)
-				M.cell.charge = max(M.charge - rand() * 100, 0)
+				M.cell.charge = max(M.cell.charge - rand() * 100, 0)
 				if(world.time >= next_message)
 					M << "<span class='danger'>SYSTEM ALERT: Large energy drain detected!</span>"
 		if(world.time >= next_message)


### PR DESCRIPTION
- Use proper helper procs and correct checks (notably check for cell instead of looping through contents)
- Use effectrange consistently, this should also reduce lag massively since the artifact will no longer loop through all of the station's APC contents when triggered
- Streamline effects. Aura is +25 or -50 charge. Pulse and touch are rand() \* 100 + or -
- Use warning and danger for charge drains, because that's REALLY bad
- All broadcasted warnings use the delay

Fixes #6596
