### PR TITLE
Xenomorphs can now slash atmos canisters

### DIFF
--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -171,7 +171,7 @@
 		playsound(get_turf(src), 'sound/effects/spray.ogg', 10, 1, -3)
 		src.density = 0
 		update_icon()
-		investigation_log(I_ATMOS, "was destoyed by heat/gunfire.")
+		investigation_log(I_ATMOS, "was destoyed by excessive damage.")
 
 		if (src.holding)
 			src.holding.loc = src.loc
@@ -294,6 +294,16 @@
 
 /obj/machinery/portable_atmospherics/canister/attack_hand(var/mob/user as mob)
 	return src.ui_interact(user)
+
+/obj/machinery/portable_atmospherics/canister/attack_alien(var/mob/living/carbon/alien/user as mob)
+	src.add_hiddenprint(user)
+	health -= rand(15, 30)
+	user.visible_message("<span class='danger'>\The [user] slashes away at \the [src]!</span>", \
+						 "<span class='danger'>You slash away at \the [src]!</span>")
+	user.delayNextAttack(10) //Hold on there amigo
+	investigation_log(I_ATMOS, "<span style='danger'>was slashed at by alien [key_name(user)]</span>")
+	playsound(get_turf(src), 'sound/weapons/slice.ogg', 25, 1, -1)
+	healthcheck()
 
 /obj/machinery/portable_atmospherics/canister/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null)
 	if (src.destroyed || gcDestroyed || !get_turf(src))

--- a/html/changelogs/Dylanstrategie_Aliuminium.yml
+++ b/html/changelogs/Dylanstrategie_Aliuminium.yml
@@ -1,0 +1,4 @@
+author: Dylanstrategie
+delete-after: True
+changes:
+  - rscadd: Xenomorphs can now slash atmospheric canisters open


### PR DESCRIPTION
- Canisters destroyed because they lost all their health now specify the cause of rupture is excessive damage, instead of specifically heat/gunfire
- Xenomorphs can now slash canisters for 15 to 30 damage a hit. Naturally, hitting the canister multiple times will cause it to rupture, useful if you get your hand on spare Plasma canisters
- Xenomorphs have a one second attack delay when slashing canisters

Changelog included. Fixes #6455
