### PR TITLE
Hopefully finally fix droplimb()

### DIFF
--- a/code/game/dna/genes/goon_powers.dm
+++ b/code/game/dna/genes/goon_powers.dm
@@ -360,40 +360,43 @@
 	if(!targets || !targets.len)
 		return 0
 	var/atom/movable/the_item = targets[1]
-	if(!the_item || !the_item.Adjacent(usr))
+	if(!the_item || !the_item.Adjacent(user))
 		return
 	if(ishuman(the_item))
 		//My gender
-		var/m_his="his"
-		if(user.gender==FEMALE)
-			m_his="her"
-		// Their gender
-		var/t_his="his"
-		if(the_item.gender==FEMALE)
-			t_his="her"
+		var/m_his = "its"
+		if(user.gender == MALE)
+			m_his = "his"
+		if(user.gender == FEMALE)
+			m_his = "her"
 		var/mob/living/carbon/human/H = the_item
 		var/datum/organ/external/limb = H.get_organ(usr.zone_sel.selecting)
 		if(!istype(limb))
-			user << "<span class='warning'> You can't eat this part of them!</span>"
+			user << "<span class='warning'>You can't eat this part of them!</span>"
 			return 0
-		if(istype(limb,/datum/organ/external/head))
-			// Bullshit, but prevents being unable to clone someone.
-			user << "<span class='warning'> You try to put \the [limb] in your mouth, but [t_his] ears tickle your throat!</span>"
+		if(istype(limb, /datum/organ/external/head))
+			//Bullshit, but prevents being unable to clone someone.
+			user << "<span class='warning'>You try to put [the_item]'s [limb.display_name] in your mouth, but \his ears tickle your throat!</span>"
 			return 0
-		if(istype(limb,/datum/organ/external/chest))
-			// Bullshit, but prevents being able to instagib someone.
-			user << "<span class='warning'> You try to put their [limb] in your mouth, but it's too big to fit!</span>"
+		if(istype(limb, /datum/organ/external/chest))
+			//Bullshit, but you cannot break it anyways
+			user << "<span class='warning'>You try to put [the_item]'s [limb.display_name] in your mouth, but it's too big to fit!</span>"
 			return 0
-		usr.visible_message("<span class='danger'>[usr] begins stuffing [the_item]'s [limb.display_name] into [m_his] gaping maw!</span>")
-		if(!do_mob(user,the_item,EAT_MOB_DELAY))
-			user << "<span class='warning'>You were interrupted before you could eat [the_item]!</span>"
+		if(istype(limb, /datum/organ/external/groin))
+			//Bullshit, but you cannot break it anyways
+			user << "<span class='warning'>You try to put [the_item]'s [limb.display_name] in your mouth, but it feels far too inappropriate!</span>"
+			return 0
+		user.visible_message("<span class='danger'>[user] begins stuffing [the_item]'s [limb.display_name] into [m_his] gaping maw!</span>")
+		if(!do_mob(user, the_item,EAT_MOB_DELAY))
+			user << "<span class='warning'>You were interrupted before you could eat [the_item]'s [limb.display_name]!</span>"
 		else
-			user.visible_message("<span class='warning'>[user] eats \the [limb].</span>")
+			user.visible_message("<span class='danger'>[user] eats [the_item]'s [limb.display_name].</span>", \
+			"<span class='danger'>You eat [the_item]'s [limb.display_name].</span>")
 			limb.droplimb("override" = 1, "spawn_limb" = 0)
 			doHeal(user)
 	else
-		usr.visible_message("<span class='warning'> [usr] eats \the [the_item].")
-		playsound(usr.loc, 'sound/items/eatfood.ogg', 50, 0)
+		user.visible_message("<span class='warning'>[usr] eats \the [the_item].")
+		playsound(get_turf(user), 'sound/items/eatfood.ogg', 50, 0)
 		qdel(the_item)
 		doHeal(usr)
 	return

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -580,11 +580,11 @@ Note that amputating the affected organ does in fact remove the infection from t
 	//writepanic("[__FILE__].[__LINE__] ([src.type])([usr ? usr.ckey : ""])  \\/datum/organ/external/proc/droplimb() called tick#: [world.time]")
 	if(destspawn)
 		return
+	if(body_part == (UPPER_TORSO || LOWER_TORSO)) //We can't lose either, those cannot be amputated and will cause extremely serious problems
+		return
 	if(override)
 		status |= ORGAN_DESTROYED
 	if(status & ORGAN_DESTROYED)
-		if(body_part == UPPER_TORSO)
-			return
 
 		src.status &= ~ORGAN_BROKEN
 		src.status &= ~ORGAN_BLEEDING

--- a/code/modules/virus2/effect.dm
+++ b/code/modules/virus2/effect.dm
@@ -268,75 +268,61 @@
 /datum/disease2/effect/necrosis
 	name = "Necrosis"
 	stage = 4
-/datum/disease2/effect/necrosis/activate(var/mob/living/carbon/mob,var/multiplier)
-	//
-	var/mob/living/carbon/human/H = mob
-		//
-	var/inst = pick(1,2,3)
-	switch(inst)
-		if(1)
-			mob << "<span class = 'warning'>A chunk of meat falls off you!</span>"
-			var/totalslabs = 1
-			var/obj/item/weapon/reagent_containers/food/snacks/meat/allmeat[totalslabs]
-			if( istype(mob, /mob/living/carbon/human/) )
-					//
-				var/sourcename = mob.real_name
-				var/sourcejob = mob.job
-				var/sourcenutriment = mob.nutrition / 15
+/datum/disease2/effect/necrosis/activate(var/mob/living/carbon/mob, var/multiplier)
+
+	if(ishuman(mob)) //Only works on humans properly since it needs to do organ work
+		var/mob/living/carbon/human/H = mob
+		var/inst = pick(1, 2, 3)
+
+		switch(inst)
+
+			if(1)
+				H << "<span class='warning'>A chunk of meat falls off of you!</span>"
+				var/totalslabs = 1
+				var/obj/item/weapon/reagent_containers/food/snacks/meat/allmeat[totalslabs]
+				var/sourcename = H.real_name
+				var/sourcejob = H.job
+				var/sourcenutriment = H.nutrition / 15
 				//var/sourcetotalreagents = mob.reagents.total_volume
 
-				for(var/i=1 to totalslabs)
+				for(var/i = 1 to totalslabs)
 					var/obj/item/weapon/reagent_containers/food/snacks/meat/human/newmeat = new
 					newmeat.name = sourcename + newmeat.name
 					newmeat.subjectname = sourcename
 					newmeat.subjectjob = sourcejob
-					newmeat.reagents.add_reagent("nutriment", sourcenutriment / totalslabs) // Thehehe. Fat guys go first
+					newmeat.reagents.add_reagent("nutriment", sourcenutriment / totalslabs) //Thehehe. Fat guys go first
 					//src.occupant.reagents.trans_to(newmeat, round (sourcetotalreagents / totalslabs, 1)) // Transfer all the reagents from the
 					allmeat[i] = newmeat
 
-
-
 					var/obj/item/meatslab = allmeat[i]
 					var/turf/Tx = locate(mob.x, mob.y, mob.z)
-					meatslab.loc = mob.loc
-					meatslab.throw_at(Tx,i,3)
-					if (!Tx.density)
+					meatslab.loc = get_turf(H)
+					meatslab.throw_at(Tx, i, 3)
 
+					if(!Tx.density)
 						var/obj/effect/decal/cleanable/blood/gibs/D = getFromPool(/obj/effect/decal/cleanable/blood/gibs, Tx)
 						D.New(Tx,i)
 
+			if(2)
+				for(var/datum/organ/external/E in H.organs)
+					if(pick(1, 0))
+						E.droplimb(1)
 
-		if(2)
-			//mob << "<span class='warning'>i dont think i need this here</span>"
+			if(3)
+				if(H.species.name != "Skellington")
+					H << "<span class='warning'>Your necrotic skin ruptures!</span>"
 
-			for (var/datum/organ/external/E in H.organs)
-				if(pick(1,0))
-					E.droplimb(1)
+					for(var/datum/organ/external/E in H.organs)
+						if(pick(1,0))
+							E.createwound(CUT, pick(2, 4, 6, 8, 10))
 
-
-		if(3)
-			if(H.species.name != "Skellington")
-				mob << "<span class = 'warning'> Your necrotic skin ruptures!</span>"
-
-
-				for (var/datum/organ/external/E in H.organs)
-					if(pick(1,0))
-						E.createwound(CUT, pick(2,4,6,8,10))
-
-
-				if(prob(30))
-					//
-
-					if(H.species.name != "Skellington")
-						if(H.set_species("Skellington"))
-							mob << "<span class = 'warning'> A massive amount of flesh sloughs off your bones!</span>"
-							H.regenerate_icons()
-			else
-				return
-
-
-
-
+					if(prob(30))
+						if(H.species.name != "Skellington")
+							if(H.set_species("Skellington"))
+								mob << "<span class='warning'>A massive amount of flesh sloughs off your bones!</span>"
+								H.regenerate_icons()
+				else
+					return
 
 /datum/disease2/effect/fizzle
 	name = "Fizzle Effect"


### PR DESCRIPTION
Eat Genetic Power : 
- You can no longer eat groins (which caused extremely serious technical problems because that limb cannot actually be amputated). Now you'll be told that it is inappropriate (this is a christian server after all) and will return
- Please stop using usr for fucks sakes
- Remove t_his because it isn't actually needed. Tweak m_his to be compatible with neutral in case a robot somehow gets that genetic power
- Always use limb.display_name when limbs are cast in text

Necrosis : 
- Remove a lot of blankspace and empty indents
- Now only works on humans because organs are a human thing (at least properly, casting a mob that you haven't checked as human is shitcode of the highest order)
- Basically formatting

Organ System : 
- droplimp() will now flat out return from the start if it is passed a UPPER_TORSO or LOWER_TORSO external organ (Read : Torso and groin exclusively) instead of applying a flag, even if overridden. This breaks shit bad otherwise

Fixes #6616 and a bunch of organ gibbing issues that were reported or not
