### PR TITLE
Add attack delayers to resin doors and alien nests

### DIFF
--- a/code/game/machinery/doors/mineral.dm
+++ b/code/game/machinery/doors/mineral.dm
@@ -86,6 +86,7 @@
 	else
 		hardness -= W.force/100
 		user << "You hit \the [src] with your [W.name]!"
+		user.delayNextAttack(10)
 		CheckHardness()
 	return
 

--- a/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
@@ -51,8 +51,9 @@
 	var/aforce = W.force
 	health = max(0, health - aforce)
 	playsound(loc, 'sound/effects/attackblob.ogg', 100, 1)
-	for(var/mob/M in viewers(src, 7))
-		M.show_message("<span class='warning'>[user] hits [src] with [W]!</span>", 1)
+	user.visible_message("<span class='warning'>[user] hits \the [src] with \the [W]!</span>", \
+						 "<span class='warning'>You hit \the [src] with \the [W]!</span>")
+	user.delayNextAttack(10)
 	healthcheck()
 
 /obj/structure/bed/nest/proc/healthcheck()


### PR DESCRIPTION
Standard one second delay, same as the resin walls and membranes

Removed a dumb show_message proc while in here

Fixes #6660
