### PR TITLE
Fix #6007

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -375,16 +375,23 @@ var/list/all_doors = list()
 /obj/machinery/door/proc/requiresID()
 	return 1
 
-/obj/machinery/door/proc/update_nearby_tiles()
+/obj/machinery/door/proc/update_nearby_tiles(var/turf/T)
 	if(!air_master)
 		return 0
 
-	for(var/turf in locs)
-		update_heat_protection(turf)
-		air_master.mark_for_update(turf)
+	if(!T)
+		T = get_turf(src)
+	update_heat_protection(T)
+	air_master.mark_for_update(T)
 
 	update_freelok_sight()
 	return 1
+
+/obj/machinery/door/forceMove(var/atom/A)
+	var/turf/T = loc
+	..()
+	update_nearby_tiles(T)
+	update_nearby_tiles()
 
 /obj/machinery/door/proc/update_heat_protection(var/turf/simulated/source)
 	if(istype(source))

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -440,13 +440,14 @@
 	update_nearby_tiles()
 
 //This proc has to do with airgroups and atmos, it has nothing to do with smoothwindows, that's update_nearby_tiles().
-/obj/structure/window/proc/update_nearby_tiles()
+/obj/structure/window/proc/update_nearby_tiles(var/turf/T)
 
 
 	if(isnull(air_master))
 		return 0
 
-	var/T = get_turf(src)
+	if(!T)
+		T = get_turf(src)
 
 	if(isturf(T))
 		air_master.mark_for_update(T)
@@ -454,17 +455,27 @@
 	return 1
 
 //This proc is used to update the icons of nearby windows. It should not be confused with update_nearby_tiles(), which is an atmos proc!
-/obj/structure/window/proc/update_nearby_icons()
+/obj/structure/window/proc/update_nearby_icons(var/turf/T)
 
 
 	if(!loc)
 		return 0
+	if(!T)
+		T = get_turf(src)
 
 	update_icon()
 
 	for(var/direction in cardinal)
-		for(var/obj/structure/window/W in get_step(src,direction))
+		for(var/obj/structure/window/W in get_step(T,direction))
 			W.update_icon()
+
+/obj/structure/window/forceMove(var/atom/A)
+	var/turf/T = loc
+	..()
+	update_nearby_icons(T)
+	update_nearby_icons()
+	update_nearby_tiles(T)
+	update_nearby_tiles()
 
 /obj/structure/window/update_icon()
 

--- a/code/modules/events/bluespaceanomaly.dm
+++ b/code/modules/events/bluespaceanomaly.dm
@@ -67,7 +67,7 @@
 			var/x_distance = TO.x - FROM.x
 			for (var/atom/movable/A in range(12, FROM )) // iterate thru list of mobs in the area
 				if(istype(A, /obj/item/beacon)) continue // don't teleport beacons because that's just insanely stupid
-				if(A.anchored && istype(A, /obj/machinery)) continue
+				if(A.anchored && (istype(A, /obj/machinery) || istype(A,/obj/structure))) continue
 				if(istype(A, /obj/structure/disposalpipe )) continue
 				if(istype(A, /obj/structure/cable )) continue
 				if(istype(A, /atom/movable/lighting_overlay)) continue


### PR DESCRIPTION
- Forcemove updates windows air and icon smoothing properties
- Forcemove updates door properties as well
- Bluespace anomaly no longer moves structures as it was already unable to move anchored machinery, it seems to be the intention to just move objects and unanchored things in general