### PR TITLE
I JUST MASH ON THE KEYBOARD AND IT WERKS

### DIFF
--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -126,7 +126,7 @@
 	if(.)
 		return
 	if(isturf(A))
-		A.AltClick(src)
+		A.RobotAltClick(src)
 		return
 	A.RobotAltClick(src)
 	return


### PR DESCRIPTION
Fixes #5967
Robots can once again alt click on turfs and it will bring up the alt click menu. It was previously broken for turfs but worked for objects. It now works for both.