### PR TITLE
Fixes #4129

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -101,7 +101,7 @@
 
 	add_fingerprint(user)
 
-	var/turf/curloc = get_turf(user)
+	var/turf/curloc = user.loc
 	var/turf/targloc = get_turf(target)
 	if (!istype(targloc) || !istype(curloc))
 		return


### PR DESCRIPTION
Guns now check user.loc, if user.loc is not a turf they will not fire. So you shouldn't be able to fire while inside a locker or recharger station or what have you.