### PR TITLE
Fix #5150

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -291,11 +291,11 @@
 
 		switch(slot)
 			if(slot_l_hand)
-				if(H.l_hand)
+				if(H.l_hand || H.handcuffed)
 					return 0
 				return 1
 			if(slot_r_hand)
-				if(H.r_hand)
+				if(H.r_hand || H.handcuffed)
 					return 0
 				return 1
 			if(slot_wear_mask)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -465,11 +465,15 @@
 	user.set_machine(src)
 	var/has_breathable_mask = istype(wear_mask, /obj/item/clothing/mask)
 	var/TAB = "&nbsp;&nbsp;&nbsp;&nbsp;"
+	var/dat = ""
 
-	var/dat = {"
-	<B>Left Hand:</B> <A href='?src=\ref[src];item=l_hand'>		[(l_hand && !( src.l_hand.abstract ))		? l_hand	: "<font color=grey>Empty</font>"]</A><BR>
-	<B>Right Hand:</B> <A href='?src=\ref[src];item=r_hand'>		[(r_hand && !( src.r_hand.abstract ))		? r_hand	: "<font color=grey>Empty</font>"]</A><BR>
-	"}
+	if(handcuffed)
+		dat += "<BR><B>Handcuffed:</B> <A href='?src=\ref[src];item=handcuff'>Remove</A>"
+	else
+		dat += {"
+		<B>Left Hand:</B> <A href='?src=\ref[src];item=l_hand'>		[(l_hand && !( src.l_hand.abstract ))		? l_hand	: "<font color=grey>Empty</font>"]</A><BR>
+		<B>Right Hand:</B> <A href='?src=\ref[src];item=r_hand'>		[(r_hand && !( src.r_hand.abstract ))		? r_hand	: "<font color=grey>Empty</font>"]</A><BR>
+		"}
 
 	dat += "<BR><B>Back:</B> <A href='?src=\ref[src];item=back'> [(back && !(src.back.abstract)) ? back : "<font color=grey>Empty</font>"]</A>"
 	if(has_breathable_mask && istype(back, /obj/item/weapon/tank))
@@ -479,10 +483,6 @@
 
 
 	dat += "<BR><B>Mask:</B> <A href='?src=\ref[src];item=mask'>		[(wear_mask && !(src.wear_mask.abstract))	? wear_mask	: "<font color=grey>Empty</font>"]</A>"
-
-
-	if(handcuffed)
-		dat += "<BR><B>Handcuffed:</B> <A href='?src=\ref[src];item=handcuff'>Remove</A>"
 
 	dat += {"
 	<BR>


### PR DESCRIPTION
Now the show inventory menu no longer shows l_hand and r_hand as options when handcuffed, and the mob_can_equip proc returns 0 when handcuffed to prevent someone FUCKING GETTING AROUND THAT SOMEHOW so nobody can equip something into a handcuffed person's hand anyway.