### PR TITLE
Fix #5563, Fix #5477

### DIFF
--- a/code/modules/html_interface/map/map_shared.js
+++ b/code/modules/html_interface/map/map_shared.js
@@ -282,6 +282,8 @@ function setzoom(val){
 function changezlevels()
 {
 	var newZ = parseInt(Math.min(Math.max(prompt("View which Z-Level?", z), 1), 6));
+	if(newZ == z)
+		return
 	window.location.href = "byond://?src=" + hSrc + "&action=changez&value=" + newZ;
 }
 


### PR DESCRIPTION
You can no longer break the UI for the crew monitor causing it to disappear by improperly changing zlevel