### PR TITLE
Could fix #6641

### DIFF
--- a/code/modules/medical/computer/cloning.dm
+++ b/code/modules/medical/computer/cloning.dm
@@ -351,27 +351,19 @@
 			else if(!config.revival_cloning)
 				temp = "Error: Unable to initiate cloning cycle."
 
-			var/success = pod1.growclone(C)
-			if(success)
+			var/mob/selected = find_dead_player("[C.ckey]")
+			if(!selected)
+				temp = "Initiating cloning cycle...<br>Error: Post-initialisation failed. Cloning cycle aborted."
+				return
+			selected << 'sound/machines/chime.ogg'	//probably not the best sound but I think it's reasonable
+			var/answer = alert(selected,"Do you want to return to life?","Cloning","Yes","No")
+			if(answer != "No" && pod1.growclone(C))
 				temp = "Initiating cloning cycle..."
 				records.Remove(C)
 				del(C)
 				menu = 1
 			else
-
-				var/mob/selected = find_dead_player("[C.ckey]")
-				if(!selected)
-					temp = "Initiating cloning cycle...<br>Error: Post-initialisation failed. Cloning cycle aborted."
-					return
-				selected << 'sound/machines/chime.ogg'	//probably not the best sound but I think it's reasonable
-				var/answer = alert(selected,"Do you want to return to life?","Cloning","Yes","No")
-				if(answer != "No" && pod1.growclone(C))
-					temp = "Initiating cloning cycle..."
-					records.Remove(C)
-					del(C)
-					menu = 1
-				else
-					temp = "Initiating cloning cycle...<br>Error: Post-initialisation failed. Cloning cycle aborted."
+				temp = "Initiating cloning cycle...<br>Error: Post-initialisation failed. Cloning cycle aborted."
 
 		else
 			temp = "Error: Data corruption."


### PR DESCRIPTION
Needs more testing at the moment which I don't know how to pull off myself.

The more stringent check of find_dead_player wasn't occurring because a previous change tried to growclone BEFORE the find_dead_player, thus if something passed the growclone checks it would get cloned even if there was no dead player associated with the ckey.