### PR TITLE
Fix #6561

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
@@ -246,6 +246,9 @@
 
 	return
 
+/mob/living/simple_animal/spiderbot/verb_pickup()
+	return get_item()
+
 /mob/living/simple_animal/spiderbot/verb/get_item()
 	set name = "Pick up item"
 	set category = "Spiderbot"


### PR DESCRIPTION
You know technically it worked the whole time but player errors result from inconsistencies such as 'pick up' and 'pick up item' being separate verbs. 

Now for spiderbots 'pick up' redirects to the unique spiderbot 'pick up item' verb.