### PR TITLE
Fix #4846

### DIFF
--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -691,6 +691,22 @@
 						<td><A href='?priv_msg=\ref[M]'>PM</A></td>"}
 					// END AUTOFIX
 			dat += "</table>"
+		if(ticker.mode.raiders.len)
+			dat += "<br><table cellspacing=5><tr><td><B>Thralls</B></td><td></td><td></td></tr>"
+			for(var/datum/mind/vox in ticker.mode.raiders)
+				var/mob/M = vox.current
+				if(M)
+					dat += {"<tr><td><a href='?src=\ref[src];adminplayeropts=\ref[M]'>[M.real_name]</a>[M.client ? "" : " <i>(logged out)</i>"][M.stat == 2 ? " <b><font color=red>(DEAD)</font></b>" : ""]</td>
+						<td><A href='?src=\ref[usr];priv_msg=\ref[M]'>PM</A></td></tr>"}
+				else
+					dat += "<tr><td><i>Vox Raider not found!</i></td></tr>"
+			dat += "</table>"
+		if(istype(ticker.mode, /datum/game_mode/heist))
+			var/datum/game_mode/heist/mode_ticker = ticker.mode
+			var/objective_count = 1
+			dat += "<br><B>Raider Objectives:</B>"
+			for(var/datum/objective/objective in mode_ticker.raid_objectives)
+				dat += "<BR><B>Objective #[objective_count++]</B>: [objective.explanation_text]</td></tr>"
 
 		if(ticker.mode.ert.len > 0)
 			dat += "<br><table cellspacing=5><tr><td><B>ERT</B></td><td></td><td></td></tr>"


### PR DESCRIPTION
Vox raiders and their objective (during their gamemode) will show up on check antagonists.

Someone give this a cursory check and make sure it looks right. I know the objective part at least worked out from my testing and the loop is copypasted pretty well straight from the other types.