### PR TITLE
Fix #6176

### DIFF
--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -41,6 +41,8 @@
 		return
 	if(!istype(target))
 		return
+	if(target.abiotic())
+		occupant_message("<span class='notice'><B>Subject cannot have abiotic items on.</B></span>")
 	if(target.locked_to)
 		occupant_message("[target] will not fit into the sleeper because they are buckled to [target.locked_to].")
 		return
@@ -55,7 +57,7 @@
 	chassis.visible_message("[chassis] starts putting [target] into the [src].")
 	var/C = chassis.loc
 	var/T = target.loc
-	if(do_after_cooldown(target))
+	if(do_after_cooldown(target,2) && chassis.Adjacent(target))
 		if(chassis.loc!=C || target.loc!=T)
 			return
 		if(occupant)


### PR DESCRIPTION
You cannot put a target into your mounted sleeper with abiotic items in (basically nothing in your hands).

This fixes the issue while also providing two slight nerfs to the insanely powerful way this mech tool works
- Requires 4 seconds to pick up a person from 2
- Requires you ACTUALLY BE ADJACENT after the do_after (what the fuck is do_after_cooldown this shit probably needs to be replaced)
- Requires they not have shit in their hands like a regular sleeper does already