### PR TITLE
RSF Bugfix

### DIFF
--- a/code/modules/RCD/RSF.dm
+++ b/code/modules/RCD/RSF.dm
@@ -61,3 +61,10 @@
 /obj/item/device/rcd/borg/rsf/attack_self(var/mob/living/user)
 	if(!selected || user.shown_schematics_background || !selected.show(user))
 		user.hud_used.toggle_show_schematics_display(schematics["Service"], 0, src)
+
+//Override of preattack to perform a check on what is being attacked
+/obj/item/device/rcd/matter/rsf/preattack(var/atom/A, mob/user, proximity_flag)
+	if (istype(A, /obj/structure/table))
+		afterattack(A,user) //If it's a table call afterattack now, and return 1 so it doesn't call the table attackby proc.
+		return 1
+	return 0 //Otherwise proceed as normal.

--- a/code/modules/RCD/schematics/service.dm
+++ b/code/modules/RCD/schematics/service.dm
@@ -13,14 +13,6 @@
 	returnToPool(A)
 	..()
 
-//Override attackby from table so RSF doesn't end up on table when creating stuff.
-/obj/structure/table/attackby(obj/item/W as obj, mob/user as mob, params)
-	if (!W)
-		return
-	if (istype(W, /obj/item/device/rcd/matter/rsf))
-		return
-	..() //super call so we don't break functionality.
-
 /datum/rcd_schematic/rsf/attack(var/atom/A, var/mob/user)
 	if(!is_type_in_list(A, list(/obj/structure/table, /turf/simulated/floor)))
 		return 1

--- a/code/modules/RCD/schematics/service.dm
+++ b/code/modules/RCD/schematics/service.dm
@@ -13,6 +13,14 @@
 	returnToPool(A)
 	..()
 
+//Override attackby from table so RSF doesn't end up on table when creating stuff.
+/obj/structure/table/attackby(obj/item/W as obj, mob/user as mob, params)
+	if (!W)
+		return
+	if (istype(W, /obj/item/device/rcd/matter/rsf))
+		return
+	..() //super call so we don't break functionality.
+
 /datum/rcd_schematic/rsf/attack(var/atom/A, var/mob/user)
 	if(!is_type_in_list(A, list(/obj/structure/table, /turf/simulated/floor)))
 		return 1

--- a/html/changelogs/Sircrab-MyBranch.yml
+++ b/html/changelogs/Sircrab-MyBranch.yml
@@ -1,0 +1,35 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general adding of nice things)
+#   rscadd (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: Sircrab
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+changes: 
+  - bugfix: Rapid Service Fabricator is no longer put on a table when fabricating objects on one.


### PR DESCRIPTION
While using the RSF, when trying to create stuff on a table, the RSF would end up in the table because of the attackby method from the table. By overriding the method so that it first checks if the object itself is an RSF and if not passing the call to the original method, the RSF now behaves correctly and stays on the user's hand. As a consequence RSF cannot be put on tables by clicking now (Much like how wrenches cannot be put either if you click with one in your hand).
