### PR TITLE
Forensics Console Fix

### DIFF
--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -245,6 +245,10 @@
 	name = "Circuit board (Telepad Control Console)"
 	build_path = "/obj/machinery/computer/telescience"
 	origin_tech = "programming=3;bluespace=2"
+/obj/item/weapon/circuitboard/forensic_computer
+	name = "Circuit board (Forensics Console)"
+	build_path = "/obj/machinery/computer/forensic_scanning"
+	origin_tech = "programming=2"
 /obj/item/weapon/circuitboard/pda_terminal
 	name = "Circuit board (PDA Terminal)"
 	build_path = "/obj/machinery/computer/pda_terminal"

--- a/code/modules/detectivework/detective_work.dm
+++ b/code/modules/detectivework/detective_work.dm
@@ -58,7 +58,7 @@ var/const/FINGERPRINT_COMPLETE = 6	//This is the output of the stringpercent(pri
 	var/temp = ""
 	var/canclear = 1
 	var/authenticated = 0
-
+	circuit = "/obj/item/weapon/circuitboard/forensic_computer"
 	light_color = LIGHT_COLOR_RED
 
 //Here's the structure for files: each entry is a list, and entry one in that list is the string of their

--- a/html/changelogs/Sircrab-Computer-Fix.yml
+++ b/html/changelogs/Sircrab-Computer-Fix.yml
@@ -1,0 +1,35 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general adding of nice things)
+#   rscadd (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: Sircrab
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+changes: 
+  - bugfix: Broken Forensics Console can now be repaired when broken.


### PR DESCRIPTION
Fix for Issue #6760, the problem occured because the Forensics Console computer had no circuitboard associated, causing it to not be able to be repaired (default behaviour for computers with no circuitboard) a circuitboard item and a reference to it in the Console were added.
