### PR TITLE
Relativity for Movable Screen Elements

### DIFF
--- a/code/_onclick/hud/_defines.dm
+++ b/code/_onclick/hud/_defines.dm
@@ -102,8 +102,8 @@
 #define ui_construct_fire "EAST-1:16,CENTER+1:13" //above health, slightly to the left
 #define ui_construct_pull "EAST-1:28,SOUTH+1:10" //above the zone_sel icon
 
-#define ui_spell_master "14:16,14:16"
-#define ui_genetic_master "14:16,12:16"
+#define ui_spell_master "EAST-1:16,NORTH-1:16"
+#define ui_genetic_master "EAST-1:16,NORTH-3:16"
 
 //Pop-up inventory
 #define ui_shoes "WEST+1:8,SOUTH:5"

--- a/code/_onclick/hud/movable_screen_objects.dm
+++ b/code/_onclick/hud/movable_screen_objects.dm
@@ -31,9 +31,10 @@
 
 	//Split X+Pixel_X up into list(X, Pixel_X)
 	var/list/screen_loc_X = text2list(screen_loc_params[1],":")
-
+	screen_loc_X[1] = encode_screen_X(text2num(screen_loc_X[1]))
 	//Split Y+Pixel_Y up into list(Y, Pixel_Y)
 	var/list/screen_loc_Y = text2list(screen_loc_params[2],":")
+	screen_loc_Y[1] = encode_screen_Y(text2num(screen_loc_Y[1]))
 
 	if(snap2grid) //Discard Pixel Values
 		screen_loc = "[screen_loc_X[1]],[screen_loc_Y[1]]"
@@ -43,7 +44,50 @@
 		var/pix_Y = text2num(screen_loc_Y[2]) - 16
 		screen_loc = "[screen_loc_X[1]]:[pix_X],[screen_loc_Y[1]]:[pix_Y]"
 
+/obj/screen/movable/proc/encode_screen_X(X)
+	if(X > usr.client.view+1)
+		. = "EAST-[usr.client.view*2 + 1-X]"
+	else if(X < usr.client.view+1)
+		. = "WEST+[X-1]"
+	else
+		. = "CENTER"
 
+/obj/screen/movable/proc/decode_screen_X(X)
+	//Find EAST/WEST implementations
+	if(findtext(X,"EAST-"))
+		var/num = text2num(copytext(X,6)) //Trim EAST-
+		if(!num)
+			num = 0
+		. = usr.client.view*2 + 1 - num
+	else if(findtext(X,"WEST+"))
+		var/num = text2num(copytext(X,6)) //Trim WEST+
+		if(!num)
+			num = 0
+		. = num+1
+	else if(findtext(X,"CENTER"))
+		. = usr.client.view+1
+
+/obj/screen/movable/proc/encode_screen_Y(Y)
+	if(Y > usr.client.view+1)
+		. = "NORTH-[usr.client.view*2 + 1-Y]"
+	else if(Y < usr.client.view+1)
+		. = "SOUTH+[Y-1]"
+	else
+		. = "CENTER"
+
+/obj/screen/movable/proc/decode_screen_Y(Y)
+	if(findtext(Y,"NORTH-"))
+		var/num = text2num(copytext(Y,7)) //Trim NORTH-
+		if(!num)
+			num = 0
+		. = usr.client.view*2 + 1 - num
+	else if(findtext(Y,"SOUTH+"))
+		var/num = text2num(copytext(Y,7)) //Time SOUTH+
+		if(!num)
+			num = 0
+		. = num+1
+	else if(findtext(Y,"CENTER"))
+		. = usr.client.view+1
 
 //Debug procs
 /client/proc/test_movable_UI()

--- a/code/_onclick/hud/spell_screen_objects.dm
+++ b/code/_onclick/hud/spell_screen_objects.dm
@@ -53,24 +53,33 @@
 		overlays.len = 0
 		overlays.Add(closed_state)
 	else if(forced_state != 1)
-		var/temp_loc = screen_loc
-
-		var/x_position = text2num(copytext(temp_loc, 1, findtext(temp_loc, ":")))
-		var/x_pix = text2num(copytext(temp_loc, findtext(temp_loc, ":") + 1, findtext(temp_loc, ",")))
-		temp_loc = copytext(temp_loc, findtext(temp_loc, ",") + 1)
-		var/y_position = text2num(copytext(temp_loc, 1, findtext(temp_loc, ":")))
-		var/y_pix = text2num(copytext(temp_loc, findtext(temp_loc, ":")+1))
-
-		for(var/i = 1; i <= spell_objects.len; i++)
-			var/obj/screen/spell/S = spell_objects[i]
-			S.screen_loc = "[x_position + (x_position < 8 ? 1 : -1)*(i%7)]:[x_pix],[y_position + (y_position < 8 ? round(i/7) : -round(i/7))]:[y_pix]"
-			if(spell_holder && spell_holder.client)
-				spell_holder.client.screen += S
-				S.handle_icon_updates = 1
+		open_spellmaster()
 		update_spells(1)
 		showing = 1
 		overlays.len = 0
 		overlays.Add(open_state)
+
+/obj/screen/movable/spell_master/proc/open_spellmaster()
+	var/list/screen_loc_xy = text2list(screen_loc,",")
+
+	//Create list of X offsets
+	var/list/screen_loc_X = text2list(screen_loc_xy[1],":")
+	var/x_position = decode_screen_X(screen_loc_X[1])
+	var/x_pix = screen_loc_X[2]
+
+	//Create list of Y offsets
+	var/list/screen_loc_Y = text2list(screen_loc_xy[2],":")
+	var/y_position = decode_screen_Y(screen_loc_Y[1])
+	var/y_pix = screen_loc_Y[2]
+
+	for(var/i = 1; i <= spell_objects.len; i++)
+		var/obj/screen/spell/S = spell_objects[i]
+		var/xpos = x_position + (x_position < 8 ? 1 : -1)*(i%7)
+		var/ypos = y_position + (y_position < 8 ? round(i/7) : -round(i/7))
+		S.screen_loc = "[encode_screen_X(xpos)]:[x_pix],[encode_screen_Y(ypos)]:[y_pix]"
+		if(spell_holder && spell_holder.client)
+			spell_holder.client.screen += S
+			S.handle_icon_updates = 1
 
 /obj/screen/movable/spell_master/proc/add_spell(var/spell/spell)
 	if(!spell) return


### PR DESCRIPTION
Movable screen elements are now also locked to a corner so that they can change position with view size changes, it can be forced to hook to a wall with encode screen and the original value can be re-obtained using decode

http://puu.sh/lE3a0/11fc50d3a4.webm