### PR TITLE
Wheelchair Balance

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -234,9 +234,9 @@ var/list/uplink_items = list()
 //Medical Doctor
 /datum/uplink_item/jobspecific/wheelchair
 	name = "Syndicate Wheelchair"
-	desc = "A combat-modified motorized wheelchair pre-loaded with a hyper power cell. Forward thrust is sufficient to knock down and run over victims."
+	desc = "A combat-modified motorized wheelchair. Forward thrust is sufficient to knock down and run over victims."
 	item = /obj/item/syndicate_wheelchair_kit
-	cost = 5
+	cost = 6
 	job = list("Medical Doctor", "Chief Medical Officer")
 
 //Engineer

--- a/code/game/objects/structures/vehicles/wheelchair.dm
+++ b/code/game/objects/structures/vehicles/wheelchair.dm
@@ -157,7 +157,7 @@
 	nick = "cripplin' revenge"
 	desc = "A chair with fitted wheels which is powered by an internal cell. It propels itself without the need for hands as long as it is charged."
 	var/maintenance = 0
-	var/default_cell_path = /obj/item/weapon/cell/high
+	var/const/default_cell_path = /obj/item/weapon/cell/high
 	var/obj/item/weapon/cell/internal_battery = null
 
 
@@ -207,7 +207,9 @@
 /obj/structure/bed/chair/vehicle/wheelchair/motorized/syndicate
 	nick = "medical malpractice"
 	desc = "A chair with fitted wheels which is powered by an internal cell. It seems to ride higher than other wheelchairs."
-	default_cell_path = /obj/item/weapon/cell/hyper
+
+/obj/structure/bed/chair/vehicle/wheelchair/motorized/syndicate/getMovementDelay()
+	return (..() + 1) //Somewhat slower
 
 /obj/structure/bed/chair/vehicle/wheelchair/motorized/syndicate/Bump(var/atom/A)
 	if(isliving(A))
@@ -229,13 +231,10 @@
 /obj/structure/bed/chair/vehicle/wheelchair/motorized/syndicate/proc/crush(var/mob/living/H,var/bloodcolor) //Basically identical to the MULE, see mulebot.dm
 	src.visible_message("<span class='warning'>[src] drives over [H]!</span>")
 	playsound(get_turf(src), 'sound/effects/splat.ogg', 50, 1)
-	var/damage = rand(5,10) //We're not as heavy as a MULE. Where it does 30-90 damage, we do 20-40 damage
-	H.apply_damage(damage, BRUTE, "head")
+	var/damage = rand(5,10) //We're not as heavy as a MULE. Where it does 30-90 damage, we do 15-30 damage
 	H.apply_damage(damage, BRUTE, "chest")
-	H.apply_damage(0.5*damage, BRUTE, "l_leg")
-	H.apply_damage(0.5*damage, BRUTE, "r_leg")
-	H.apply_damage(0.5*damage, BRUTE, "l_arm")
-	H.apply_damage(0.5*damage, BRUTE, "r_arm")
+	H.apply_damage(damage, BRUTE, "l_leg")
+	H.apply_damage(damage, BRUTE, "r_leg")
 
 /obj/item/syndicate_wheelchair_kit
 	name = "Compressed Wheelchair Kit"

--- a/html/changelogs/Kurfurst-chairbalance.yml
+++ b/html/changelogs/Kurfurst-chairbalance.yml
@@ -1,0 +1,4 @@
+author: Kurfurst
+delete-after: True
+changes:
+ - tweak: The Syndicate Wheelchair now moves slower than a person (instead of equal speed), deals 25% less damage, costs +1 TC (total 6), does not have an enlarged power cell, and deals no damage to arms or head zones.


### PR DESCRIPTION
I am loathe to nerf something after it has appeared in only two shifts - I think more data should be gathered first to see where it's at in terms of power. Still, with such a violent reaction from the thread (as murderboners are wont to create), this update will tone down the wheelchair considerably.
- Increases the cost to 6TC (Increase of 1, equal to revolver, 2 more than Esword)
- Lowers damage by 25% and restricts damage to the leg and chest zones
- No longer has an enlarged energy cell. Traitors will need to be somewhat conscious of how much power they have in their pack and acquire more - which may not be easy for a medical doctor.
- **Now slower than a person** instead of equal speed.
