### PR TITLE
Light Replacer Snazzification: Finally done Jesus fuck

### DIFF
--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -309,10 +309,9 @@
 						var/obj/item/weapon/melee/defibrillator/D = O
 						D.charges = initial(D.charges)
 					//Janitor
-					if(istype(O, /obj/item/device/lightreplacer))
-						var/obj/item/device/lightreplacer/LR = O
+					if(istype(O, /obj/item/device/lightreplacer/borg))
+						var/obj/item/device/lightreplacer/borg/LR = O
 						LR.Charge(R)
-
 				if(R)
 					if(R.module)
 						R.module.respawn_consumable(R)

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -150,7 +150,18 @@
 			waste = W
 			return
 		else
-			to_chat(user, "<span class='notice'>\The [src] has both a supply box and a waste box. Remove one first if you want to insert a new one.</span>")
+			var/obj/item/weapon/storage/box/lights/lsource = W
+			if(!lsource.contents.len)
+				to_chat(user, "<span class='notice'>\The [src] has both a supply box and a waste box and this box is empty. Remove one first if you want to insert a new one or use a light box with lights in it to insert them.</span>")
+				return
+			var/hasinserted = 0
+			for(var/obj/item/weapon/light/L in lsource)
+				if(insert_if_possible(L))
+					hasinserted = 1
+			if(hasinserted)
+				to_chat(user, "<span class='notice'>\The [src] accepts the lights in \the [lsource].</span>")
+			else
+				to_chat(user, "<span class='warning'>\The [src] cannot accept any of the lights in \the [lsource]!</span>")
 			return
 		
 
@@ -180,7 +191,7 @@
 			light_types[lightname] += L
 
 		var/list/light_type_cur
-		var/list/to_dump_5 = list()//I guess I could do this without this variable, but it would include more string concatenation, and nobody wants that.
+		var/list/to_dump_5 = list()//I guess I could do this without this variable, but it would involve more string concatenation, and nobody wants that.
 		var/list/to_dump_all = list() //This too
 	
 		for(var/T in light_types)
@@ -355,13 +366,21 @@
 		return
 	if(L.status == LIGHT_OK)
 		if(supply && supply.can_be_inserted(L, TRUE))
-			supply.handle_item_insertion(L, TRUE)
+			if(istype(L.loc, /obj/item/weapon/storage))
+				var/obj/item/weapon/storage/lsource = L.loc
+				lsource.remove_from_storage(L, supply)
+			else
+				supply.handle_item_insertion(L, TRUE)
 			return 1
 		else
 			return 0
 	else if(L.status == LIGHT_BROKEN || L.status == LIGHT_BURNED)
 		if(waste && waste.can_be_inserted(L, TRUE))
-			waste.handle_item_insertion(L, TRUE)
+			if(istype(L.loc, /obj/item/weapon/storage))
+				var/obj/item/weapon/storage/lsource = L.loc
+				lsource.remove_from_storage(L, waste)
+			else
+				waste.handle_item_insertion(L, TRUE)
 			return 1
 		else
 			return 0

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -541,7 +541,7 @@
 		if(cardboard_stor <= 0)
 			if(usr) to_chat(usr, "<span class='warning'>\The [src] is out of cardboard!</span>")
 			return 1
-		switch[href_list["fold"]]
+		switch(href_list["fold"])
 			if("supply")
 				if(!supply) //Topic is technically asynchronous, I believe, so this sanity is a good idea
 					supply = new(src)

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -9,14 +9,15 @@
 //
 // HOW IT WORKS
 //
-// You attack a light fixture with it, if the light fixture is broken it will replace the
-// light fixture with a working light; the broken light is then placed on the floor for the
-// user to then pickup with a trash bag. If it's empty then it will just place a light in the fixture.
+// You attack a light fixture with it. If the light fixture is broken, it will replace the
+// light fixture with a working light. The broken light is then placed into the device's waste box.
+// If the fixture is empty then it will just place a light in the fixture.
 //
 // HOW TO REFILL THE DEVICE
 //
-// It will need to be manually refilled with lights.
-// If it's part of a robot module, it will charge when the Robot is inside a Recharge Station.
+// The supply box can be removed and replaced to refill the whole thing at once or lights can be inserted into the device.
+// Additionally, it can process glass into any type of light, though it uses much more than other methods of making lights
+// and lights made this way start out with a high switchcount.
 //
 // EMAGGED FEATURES
 //
@@ -41,7 +42,7 @@
 /obj/item/device/lightreplacer
 
 	name = "light replacer"
-	desc = "A device to automatically replace lights. Refill with working lightbulbs."
+	desc = "A device to automatically replace lights. Takes lights from a supply box and puts the spent ones in a waste box. It is slotted to accept specifically light bulb/tube boxes."
 
 	icon = 'icons/obj/janitor.dmi'
 	icon_state = "lightreplacer0"
@@ -52,24 +53,62 @@
 	slot_flags = SLOT_BELT
 	origin_tech = "magnets=3;materials=2"
 
-	var/max_uses = 20
-	var/uses = 0
+	var/obj/item/weapon/storage/box/lights/supply = null //Takes bulbs from here to replace
+	var/obj/item/weapon/storage/box/lights/waste = null //Places replaced bulbs here
+	var/glass_stor = 0 //How much glass it contains for producing lights
+	var/glass_stor_max = 5 * CC_PER_SHEET_GLASS //Max glass it can hold
+	var/prod_quality = 30 //Starting switchcount for lights this builds out of glass
+	var/prod_eff = 10 //How many times more glass it uses to build lights than would an autolathe
 	var/emagged = 0
-	var/failmsg = ""
-	// How much to increase per each glass?
-	var/increment = 5
-	// How much to take from the glass?
-	var/decrement = 1
-	var/charge = 1
+	var/light_types_glass = list() //An associative list with the starting glass amount for each type of light that is fabricated.
+								   //Populated with a new entry each time a new type of light is made by the replacer for the first time in a given round.
+								   //The key is the part of the typepath after /obj/item/weapon/light/ in string form. The value is its starting glass amount.
 
-/obj/item/device/lightreplacer/New()
-	uses = max_uses / 2
-	failmsg = "The [name]'s refill light blinks red."
+/obj/item/device/lightreplacer/borg //Since it will mainly be loaded by processing glass, it is MUCH better at it than the standard version.
+	desc = "A device to automatically replace lights. Takes lights from a supply container and puts the spent ones in a waste container. It is fitted with a rudimentary recycling system to recover some glass from the waste lights."
+	glass_stor_max = 10 * CC_PER_SHEET_GLASS //Twice the capacity of the standard version. It also starts full, but this is done in New().
+	prod_quality = 0 //Just as good as lights from a box/autolathe
+	prod_eff = 5 //Half the glass per light as the standard version
+	var/recycle_eff_broken = 0.5 //Proportion of glass returned by the built-in recycler.
+	var/recycle_eff_burned = 0.9 //Proportion of glass returned by the built-in recycler.
+	var/recycle_eff_ok = 1       //Proportion of glass returned by the built-in recycler. Note that this does not allow infinite fabrication and recycling due to production losses.
+	var/glass_per_charge = 500 //Note: Adjust if the default borg light replacer efficiency is changed.
+
+/obj/item/device/lightreplacer/loaded/New() //Contains only a waste box. Exists mainly just as a parent of the other loaded ones, but I guess you can use it.
 	..()
+	waste = new(src)
+
+/obj/item/device/lightreplacer/loaded/mixed/New() //Contains a box of normal mixed lights plus a waste box.
+	..()
+	supply = new /obj/item/weapon/storage/box/lights/mixed(src)
+
+/obj/item/device/lightreplacer/loaded/he/New() //Contains a box of high-efficiency mixed lights plus a waste box.
+	..()
+	supply = new /obj/item/weapon/storage/box/lights/he(src)
+
+/obj/item/device/lightreplacer/borg/New() //Contains a box of mixed lights and a waste box and starts full of glass.
+	..()
+	supply = new /obj/item/weapon/storage/box/lights/mixed(src)
+	waste = new /obj/item/weapon/storage/box/lights(src)
+	add_glass(glass_stor_max, force_fill = 2)
 
 /obj/item/device/lightreplacer/examine(mob/user)
 	..()
-	to_chat(user, "<span class='info'>It has [uses] light\s remaining.</span>")
+	if(supply)
+		if(supply.contents.len)
+			to_chat(user, "<span class='info'>It has [supply.contents.len] light[supply.contents.len == 1 ? "" : "s"] remaining. Check its interface to see what type[supply.contents.len == 1 ? "" : "s"].</span>")
+		else
+			to_chat(user, "<span class='info'>Its supply container is empty.</span>")
+	else
+		to_chat(user, "<span class='info'>It has no supply container.</span>")
+
+	if(waste)
+		to_chat(user, "<span class='info'>Its waste container has [waste.contents.len] slot[waste.contents.len == 1 ? "" : "s"] full.</span>")
+	else
+		to_chat(user, "<span class='info'>It has no waste container.</span>")
+
+	to_chat(user, "<span class='info'>Its glass storage contains [glass_stor] unit[waste.contents.len == 1 ? "" : "s"].</span>")
+
 
 /obj/item/device/lightreplacer/attackby(obj/item/W, mob/user)
 	if(istype(W,  /obj/item/weapon/card/emag) && emagged == 0)
@@ -77,37 +116,102 @@
 		return
 
 	if(istype(W, /obj/item/stack/sheet/glass/glass))
-		var/obj/item/stack/sheet/glass/glass/G = W
-		if(G.amount - decrement >= 0 && uses < max_uses)
-			var/remaining = max(G.amount - decrement, 0)
-			if(!remaining && !(G.amount - decrement) == 0)
-				to_chat(user, "There isn't enough glass.")
-				return
-			G.amount = remaining
-			if(!G.amount)
-				user.drop_item(G)
-				qdel(G)
-				G = null
-			AddUses(increment)
-			to_chat(user, "You insert a piece of glass into the [src.name]. You have [uses] lights remaining.")
+		if(!add_glass(CC_PER_SHEET_GLASS, force_fill = 1))
+			to_chat(user, "<span class='warning'>\The [src] can't hold any more glass!</span>")
 			return
+		var/obj/item/stack/sheet/glass/glass/G = W
+		G.use(1)
+		to_chat(user, "<span class='notice'>You insert \the [G] into \the [src].</span>")
+		return
 
 	if(istype(W, /obj/item/weapon/light))
 		var/obj/item/weapon/light/L = W
-		if(L.status == 0) // LIGHT OKAY
-			if(uses < max_uses)
-				AddUses(1)
-				to_chat(user, "You insert the [L.name] into the [src.name]. You have [uses] lights remaining.")
-				user.drop_item(L)
-				qdel(L)
-				L = null
-				return
-		else
-			to_chat(user, "You need a working light.")
-			return
+		switch(insert_if_possible(L))
+			if(0)
+				if(L.status ? istype(waste) : istype(supply)) //The expression returns true if the correct box for the light is valid, which implies that it is full because the insertion failed.
+					to_chat(user, "<span class='warning'>\The [src]'s [L.status ? "waste" : "supply"] container is full!</span>")
+				else
+					to_chat(user, "<span class='warning'>\The [src] has no [L.status ? "waste" : "supply"] container!</span>")
+			if(1)
+				user.visible_message("[user] inserts \a [L] into \the [src]", "You insert \the [L] into \the [src]'s [L.status ? "waste" : "supply"] container.")
+			else
+				to_chat(user, "<span class='bnotice'>Something very strange has happened. Please adminhelp and ask someone to view the variables of that light, especially status.</span>")
+		return
 
+	if(istype(W, /obj/item/weapon/storage/box/lights))
+		if(!supply)
+			user.drop_item(W, src)
+			user.visible_message("[user] inserts \a [W] into \the [src]", "You insert \the [W] into \the [src] to be used as the supply container.")
+			supply = W
+			return
+		else if(!waste)
+			user.drop_item(W, src)
+			user.visible_message("[user] inserts \a [W] into \the [src]", "You insert \the [W] into \the [src] to be used as the waste container.")
+			waste = W
+			return
+		else
+			to_chat(user, "<span class='notice'>\The [src] has both a supply box and a waste box. Remove one first if you want to insert a new one.</span>")
+			return
+		
 
 /obj/item/device/lightreplacer/attack_self(mob/user)
+	var/dat = {"<TITLE>Light Replacer Interface</TITLE>
+
+	Glass storage: [glass_stor]/[glass_stor_max]<br>"}
+
+	if(supply)
+		dat += {"<a href='?src=\ref[src];build=tube'>Fabricate Tube</a>
+		<a href='?src=\ref[src];build=bulb'>Fabricate Bulb</a>
+
+
+
+		<h3>Supply Container:</h3>"} //It's not clear here, but the argument to build is the part of the typepath after /obj/item/weapon/light/
+		var/list/light_types = new()
+		var/lightname
+		for(var/obj/item/weapon/light/L in supply)
+			lightname = ""
+			if(L.status == LIGHT_BROKEN)
+				lightname += "broken "
+			else if(L.status == LIGHT_BURNED)
+				lightname += "burned-out "
+			lightname += L.name
+			if(!light_types[lightname])
+				light_types[lightname] = list()
+			light_types[lightname] += L
+
+		var/list/light_type_cur
+		var/list/to_dump_5 = list()//I guess I could do this without this variable, but it would include more string concatenation, and nobody wants that.
+		var/list/to_dump_all = list() //This too
+	
+		for(var/T in light_types)
+			light_type_cur = light_types[T] //The way you'd expect to be the good way to do this doesn't work. This is dumb, but necessary.
+			for(var/light_to_ref in light_type_cur)
+				to_dump_all += "\ref[light_to_ref]"
+			to_dump_5 = to_dump_all.Copy(1, min(6, to_dump_all.len + 1))
+			dat += "<br><b>[T]: </b>[light_type_cur.len] | Dump to Waste: <a href='?src=\ref[src];dump=\ref[light_type_cur[1]]'>1</a><a href='?src=\ref[src];dump=[list2text(to_dump_5, ", ")]'>5</a><a href='?src=\ref[src];dump=[list2text(to_dump_all, ", ")]'>All</a>"
+
+		dat += "<br><b><a href='?src=\ref[src];eject=supply'>Eject Supply Container</a></b>"
+
+	else
+		dat += "<h3>No supply container inserted</h3>"
+
+	if(supply || waste)
+		dat += "<a href='?src=\ref[src];swap=1'>Swap Supply and Waste Containers</a>"
+
+	if(waste)
+		dat += {"<br><br><br><h3>Waste Container:</h3>
+	
+		<b>Filled: </b>[waste.contents.len]/[waste.storage_slots]<br>
+		<b><a href='?src=\ref[src];eject=waste'>Eject Waste Container</a></b>
+		"}
+	else
+		dat += "<br><br><br><h3>No waste container inserted</h3>"
+
+	var/datum/browser/popup = new(user, "lightreplacer", "", nref = src)
+	popup.set_content(dat)
+	popup.open()
+
+/obj/item/device/lightreplacer/borg/attack_self(mob/user) //The menu must be different to accomodate the differences necessary for the borg version.
 	/* // This would probably be a bit OP. If you want it though, uncomment the code.
 	if(isrobot(user))
 		var/mob/living/silicon/robot/R = user
@@ -116,75 +220,121 @@
 			to_chat(usr, "You shortcircuit the [src].")
 			return
 	*/
-	to_chat(usr, "It has [uses] lights remaining.")
+
+	var/dat = {"<TITLE>Light Replacer Interface</TITLE>
+
+	Glass storage: [glass_stor]/[glass_stor_max]<br>"}
+
+	if(supply)
+		dat += {"<a href='?src=\ref[src];build=tube'>Fabricate Tube</a>
+		<a href='?src=\ref[src];build=bulb'>Fabricate Bulb</a>
+		<a href='?src=\ref[src];build=tube/he'>Fabricate High Efficiency Tube</a>
+		<a href='?src=\ref[src];build=bulb/he'>Fabricate High Efficiency Bulb</a>
+
+
+
+		<h3>Supply Container:</h3>"}
+		var/list/light_types = new()
+		var/lightname
+		for(var/obj/item/weapon/light/L in supply)
+			lightname = ""
+			if(L.status == LIGHT_BROKEN)
+				lightname += "broken "
+			else if(L.status == LIGHT_BURNED)
+				lightname += "burned-out "
+			lightname += L.name
+			if(!light_types[lightname])
+				light_types[lightname] = list()
+			light_types[lightname] += L
+
+		var/list/light_type_cur
+		var/list/to_dump_5 = list()//I guess I could do this without this variable, but it would include more string concatenation, and nobody wants that.
+		var/list/to_dump_all = list() //This too
+	
+		for(var/T in light_types)
+			light_type_cur = light_types[T] //The way you'd expect to be the good way to do this doesn't work. This is dumb, but necessary.
+			for(var/light_to_ref in light_type_cur)
+				to_dump_all += "\ref[light_to_ref]"
+			to_dump_5 = to_dump_all.Copy(1, min(6, to_dump_all.len + 1))
+			dat += "<br><b>[T]: </b>[light_type_cur.len] | Dump to Waste: <a href='?src=\ref[src];dump=\ref[light_type_cur[1]]'>1</a><a href='?src=\ref[src];dump=[list2text(to_dump_5, ", ")]'>5</a><a href='?src=\ref[src];dump=[list2text(to_dump_all, ", ")]'>All</a>"
+
+	else
+		dat += "<h3>No supply container inserted. This should be impossible. Please ahelp this.</h3>"
+
+	if(supply || waste)
+		dat += "<a href='?src=\ref[src];swap=1'>Swap Supply and Waste Containers</a>"
+
+	if(waste)
+		dat += {"<br><br><br><h3>Waste Container:</h3>
+	
+		<b>Filled: </b>[waste.contents.len]/[waste.storage_slots]<br>
+		<b><a href='?src=\ref[src];recycle=1'>Recycle Contents</a></b>
+		"}
+	else
+		dat += "<br><br><br><h3>No waste container inserted. This should be impossible. Please ahelp this.</h3>"
+
+	var/datum/browser/popup = new(user, "lightreplacer", "", nref = src)
+	popup.set_content(dat)
+	popup.open()
 
 /obj/item/device/lightreplacer/update_icon()
 	icon_state = "lightreplacer[emagged]"
 
 
-/obj/item/device/lightreplacer/proc/Use(var/mob/user)
-
-
-	playsound(get_turf(src), 'sound/machines/click.ogg', 50, 1)
-	AddUses(-1)
-	return 1
-
-// Negative numbers will subtract
-/obj/item/device/lightreplacer/proc/AddUses(var/amount = 1)
-	uses = min(max(uses + amount, 0), max_uses)
-
-/obj/item/device/lightreplacer/proc/Charge(var/mob/user)
-	charge += 1
-	if(charge > 7)
-		AddUses(1)
-		charge = 1
-
-/obj/item/device/lightreplacer/proc/ReplaceLight(var/obj/machinery/light/target, var/mob/living/U)
-
-
-	if(target.status != LIGHT_OK)
-		if(CanUse(U))
-			if(!Use(U)) return
-			to_chat(U, "<span class='notice'>You replace the [target.fitting] with the [src].</span>")
-
-			if(target.status != LIGHT_EMPTY)
-
-				var/obj/item/weapon/light/L1 = new target.light_type(target.loc)
-				L1.status = target.status
-				L1.rigged = target.rigged
-				L1.brightness_range = target.brightness_range
-				L1.brightness_power = target.brightness_power
-				L1.brightness_color = target.brightness_color
-				L1.switchcount = target.switchcount
-				target.switchcount = 0
-				L1.update()
-
-				target.status = LIGHT_EMPTY
-				target.update()
-
-			var/obj/item/weapon/light/L2 = new target.light_type()
-
-			target.status = L2.status
-			target.switchcount = L2.switchcount
-			target.rigged = emagged
-			target.brightness_range = L2.brightness_range
-			target.brightness_power = L2.brightness_power
-			target.brightness_color = L2.brightness_color
-			target.on = target.has_power()
-			target.update()
-			qdel(L2)
-			L2 = null
-
-			if(target.on && target.rigged)
-				target.explode()
-			return
-
-		else
-			to_chat(U, failmsg)
-			return
-	else
-		to_chat(U, "There is a working [target.fitting] already inserted.")
+/obj/item/device/lightreplacer/proc/ReplaceLight(var/obj/machinery/light/target, var/mob/living/user)
+	var/obj/item/weapon/light/best_light = get_best_light(target)
+	if(best_light == 0)
+		to_chat(user, "<span class='warning'>\The [src] has no supply container!</span>")
 		return
+	else if(!best_light)
+		to_chat(user, "<span class='warning'>\The [src] has no compatible light!</span>")
+		return
+	if(!is_light_better(best_light, target))
+		to_chat(user, "<span class='notice'>\The [src] has no light better than the one already in \the [target].</span>")
+		return
+
+
+	to_chat(user, "<span class='notice'>You replace the [target.fitting] with \the [src].</span>")
+	playsound(get_turf(src), 'sound/machines/click.ogg', 50, 1)
+
+	supply.remove_from_storage(best_light)
+
+	if(target.status != LIGHT_EMPTY)
+		var/obj/item/weapon/light/L1 = new target.light_type(target.loc)
+		L1.status = target.status
+		L1.rigged = target.rigged
+		L1.brightness_range = target.brightness_range
+		L1.brightness_power = target.brightness_power
+		L1.brightness_color = target.brightness_color
+		L1.cost = target.cost
+		L1.base_state = target.base_state
+		L1.switchcount = target.switchcount
+		target.switchcount = 0
+		L1.update()
+		target.status = LIGHT_EMPTY
+		target.update()
+		if(!insert_if_possible(L1))
+			if(istype(waste))
+				to_chat(user, "<span class='warning'>\The [src]'s waste container is full and it drops the removed light on the floor!</span>")
+			else
+				to_chat(user, "<span class='warning'>\The [src] has no waste container and it drops the removed light on the floor!</span>")
+
+	target.status = best_light.status
+	target.switchcount = best_light.switchcount
+	target.rigged = emagged || best_light.rigged
+	target.brightness_range = best_light.brightness_range
+	target.brightness_power = best_light.brightness_power
+	target.brightness_color = best_light.brightness_color
+	target.cost = best_light.cost
+	target.base_state = best_light.base_state
+	target.light_type = best_light.type
+	target.on = target.has_power()
+	target.update()
+	qdel(best_light)
+	best_light = null
+	if(target.on && target.rigged)
+		target.explode()
+
 
 /obj/item/device/lightreplacer/proc/Emag()
 	emagged = !emagged
@@ -195,15 +345,189 @@
 		name = initial(name)
 	update_icon()
 
+
+//Attempts to insert a light into the light replacer's storage.
+//If the light works, attempts to place it in the supply box. Otherwise, attempts to place it in the waste box.
+//Fails if the light cannot be placed into the correct box for any reason.
+//Returns 1 if the light is successfully inserted into the correct box, 0 if the insertion fails, and null if the item to be inserted is not a light or something very strange happens.
+/obj/item/device/lightreplacer/proc/insert_if_possible(var/obj/item/weapon/light/L) 
+	if(!istype(L))
+		return
+	if(L.status == LIGHT_OK)
+		if(supply && supply.can_be_inserted(L, TRUE))
+			supply.handle_item_insertion(L, TRUE)
+			return 1
+		else
+			return 0
+	else if(L.status == LIGHT_BROKEN || L.status == LIGHT_BURNED)
+		if(waste && waste.can_be_inserted(L, TRUE))
+			waste.handle_item_insertion(L, TRUE)
+			return 1
+		else
+			return 0
+
+//Returns the best light currently in the supply container that is compatible with target.
+//For the standard light replacer, it just prioritizes HE lights over standard lights. I may add an advanced replacer with better light selection later.
+//Returns null if no compatible bulb is found and 0 if the light replacer has no (valid) supply box.
+/obj/item/device/lightreplacer/proc/get_best_light(var/obj/machinery/light/target)
+	if(!istype(supply))
+		return 0
+	var/best_light
+	switch(target.fitting)
+		if("bulb")
+			best_light = (locate(/obj/item/weapon/light/bulb/he) in supply) || (locate(/obj/item/weapon/light/bulb) in supply)
+		if("tube")
+			best_light = (locate(/obj/item/weapon/light/tube/he) in supply) || (locate(/obj/item/weapon/light/tube) in supply)
+		if("large tube")
+			best_light = locate(/obj/item/weapon/light/tube/large) in supply
+	return best_light
+
+//Returns 1 if the first argument is considered better, 0 if the second is better or they are equal, and null if either argument is invalid.
+//To be valid, each argument must be an instance of either /obj/item/weapon/light or /obj/machinery/light.
+//Again, standard replacer just checks as follows:
+//HE light < standard light < no light < broken light = burned-out light
+//In normal operation, tested should never be no light and very rarely be a broken light.
+/obj/item/device/lightreplacer/proc/is_light_better(var/obj/tested, var/obj/comparison)
+	if(!(istype(tested, /obj/item/weapon/light) || istype(tested, /obj/machinery/light)) || !(istype(comparison, /obj/item/weapon/light) || istype(comparison, /obj/machinery/light)))
+		return
+	if(tested:status >= LIGHT_BROKEN) //Is tested broken or burnt out? If so, it cannot win.
+		return 0
+	if(tested:status < comparison:status) //Is tested closer to functional than comparison? If so, it wins.
+		return 1
+	if(tested:status) //Is tested empty? If so, either it must be a tie or comparison wins, so tested cannot win.
+		return 0
+
+	//Now we know both work, so all that is left is to test if tested wins by being HE.
+	if(findtextEx(tested:base_state, "he", 1, 3) && !findtextEx(comparison:base_state, "he", 1, 3))
+		return 1
+	else
+		return 0
+
 //Can you use it?
+//This used to actually check if it wasn't empty, but that's handled in ReplaceLight() now.
 
 /obj/item/device/lightreplacer/proc/CanUse(var/mob/living/user)
 	src.add_fingerprint(user)
 	//Not sure what else to check for. Maybe if clumsy?
-	if(uses > 0)
-		return 1
-	else
+	return 1
+
+/obj/item/device/lightreplacer/borg/proc/Charge(var/mob/user)
+	add_glass(glass_per_charge, force_fill = 2)
+
+//Adds amt glass to the glass storage if possible.
+//If force_fill is 0, fails if there is not enough room for all of amt.
+//If force_fill is 1, fails only if amt is totally full.
+//If force_fill is 2, never fails.
+//Returns 1 on success and 0 on fail.
+/obj/item/device/lightreplacer/proc/add_glass(var/amt, var/force_fill = 0)
+	if(!force_fill)
+		if(glass_stor + amt > glass_stor_max)
+			return 0
+	else if(force_fill == 1)
+		if(glass_stor >= glass_stor_max)
+			return 0
+	glass_stor = min(glass_stor_max, glass_stor + amt)
+	return 1
+
+//Attempts to use amt glass from storage. Returns 1 on success and 0 on failure.
+/obj/item/device/lightreplacer/proc/use_glass(var/amt)
+	if(amt > glass_stor)
 		return 0
+	glass_stor -= amt
+	return 1
+
+/obj/item/device/lightreplacer/Topic(href, href_list)
+	if(..()) return 1
+
+	if(href_list["eject"])
+		switch(href_list["eject"])
+
+			if("supply")
+				if(usr)
+					usr.put_in_hands(supply)
+					usr.visible_message("[usr] removes \the [supply] from \the [src].", "You remove \the [src]'s supply container, \the [supply].")
+				else
+					supply.loc = get_turf(src)
+				supply = null
+				if(usr) attack_self(usr)
+				return 1
+
+			if("waste")
+				if(usr)
+					usr.put_in_hands(waste)
+					usr.visible_message("[usr] removes \the [waste] from \the [src].", "You remove \the [src]'s waste container, \the [waste].")
+				else
+					waste.loc = get_turf(src)
+				waste = null
+				if(usr) attack_self(usr)
+				return 1
+
+	if(href_list["build"])
+		var/light_type = href_list["build"]
+		var/light_path = text2path("/obj/item/weapon/light/[light_type]")
+		var/obj/item/weapon/light/L
+		if(!light_types_glass[light_type])
+			L = new light_path
+			light_types_glass[light_type] = L.starting_materials[MAT_GLASS]
+		if(!use_glass(light_types_glass[light_type] * prod_eff))
+			if(usr) to_chat(usr, "<span class='warning'>\The [src] doesn't have enough glass to make that!</span>")
+			if(L)
+				qdel(L)
+				L = null
+			return 1
+		if(!L)
+			L = new light_path
+		L.switchcount = prod_quality
+		if(!insert_if_possible(L))
+			L.loc = get_turf(src)
+			if(usr) to_chat(usr, "<span class='notice'>\The [src] successfully fabricates \a [L], but it drops it on the floor.</span>")
+		else if(usr) to_chat(usr, "<span class='notice'>\The [src] successfully fabricates \a [L].</span>")
+		if(usr) attack_self(usr)
+		return 1
+
+	if(href_list["dump"])
+		if(!supply)
+			if(usr) to_chat(usr, "<span class='warning'>\The [src] doesn't have a supply container!</span>")
+			return 1
+		if(!waste)
+			if(usr) to_chat(usr, "<span class='warning'>\The [src] doesn't have a waste container!</span>")
+			return 1
+		var/list/dumplist = text2list(href_list["dump"], ", ")
+		for(var/lightref in dumplist)
+			var/obj/item/weapon/light/L = locate(lightref)
+			if(L.loc == supply)
+				supply.remove_from_storage(L, waste)
+		if(usr) attack_self(usr)
+		return 1
+
+	if(href_list["swap"])
+		var/swapholder = waste
+		waste = supply
+		supply = swapholder
+		if(usr) attack_self(usr)
+		return 1
+
+/obj/item/device/lightreplacer/borg/Topic(href, href_list)
+	if(..()) return 1
+
+	if(href_list["recycle"])
+		if(waste)
+			var/recycledglass = 0 //How much glass is successfully recycled
+			for(var/obj/item/weapon/light/L in waste)
+				if(istype(L))
+					switch(L.status)
+						if(LIGHT_OK)
+							recycledglass += (L.materials.storage[MAT_GLASS] * recycle_eff_ok)
+						if(LIGHT_BROKEN)
+							recycledglass += (L.materials.storage[MAT_GLASS] * recycle_eff_broken)
+						if(LIGHT_BURNED)
+							recycledglass += (L.materials.storage[MAT_GLASS] * recycle_eff_burned)
+					qdel(L)
+					L = null
+			add_glass(recycledglass, force_fill = 2)
+			if(usr) attack_self(usr)
+			return 1
+
 
 #undef LIGHT_OK
 #undef LIGHT_EMPTY

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -224,8 +224,7 @@ var/global/list/datum/stack_recipe/wood_recipes = list (
 var/global/list/datum/stack_recipe/cardboard_recipes = list (
 	new/datum/stack_recipe("box",				/obj/item/weapon/storage/box							),
 	new/datum/stack_recipe("large box",			/obj/item/weapon/storage/box/large,					4	),
-	new/datum/stack_recipe("light tubes box",	/obj/item/weapon/storage/box/lights/tubes				),
-	new/datum/stack_recipe("light bulbs box",	/obj/item/weapon/storage/box/lights/bulbs				),
+	new/datum/stack_recipe("lights box",		/obj/item/weapon/storage/box/lights						),
 	new/datum/stack_recipe("mouse traps box",	/obj/item/weapon/storage/box/mousetraps					),
 	new/datum/stack_recipe("candle box",		/obj/item/weapon/storage/fancy/candle_box/empty			),
 	new/datum/stack_recipe("crayon box",		/obj/item/weapon/storage/fancy/crayons/empty			),

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -224,7 +224,8 @@ var/global/list/datum/stack_recipe/wood_recipes = list (
 var/global/list/datum/stack_recipe/cardboard_recipes = list (
 	new/datum/stack_recipe("box",				/obj/item/weapon/storage/box							),
 	new/datum/stack_recipe("large box",			/obj/item/weapon/storage/box/large,					4	),
-	new/datum/stack_recipe("lights box",		/obj/item/weapon/storage/box/lights						),
+	new/datum/stack_recipe("light tubes box",	/obj/item/weapon/storage/box/lights/tubes				),
+	new/datum/stack_recipe("light bulbs box",	/obj/item/weapon/storage/box/lights/bulbs				),
 	new/datum/stack_recipe("mouse traps box",	/obj/item/weapon/storage/box/mousetraps					),
 	new/datum/stack_recipe("candle box",		/obj/item/weapon/storage/fancy/candle_box/empty			),
 	new/datum/stack_recipe("crayon box",		/obj/item/weapon/storage/fancy/crayons/empty			),

--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -54,7 +54,7 @@
 	new /obj/item/weapon/caution(src)
 	new /obj/item/weapon/caution(src)
 	new /obj/item/weapon/storage/bag/trash(src)
-	new /obj/item/device/lightreplacer(src)
+	new /obj/item/device/lightreplacer/loaded/mixed(src)
 	new /obj/item/clothing/gloves/black(src)
 	new /obj/item/clothing/head/soft/purple(src)
 	new /obj/item/weapon/storage/box/lights/he(src)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -279,7 +279,7 @@
 	src.modules += new /obj/item/weapon/soap/nanotrasen(src)
 	src.modules += new /obj/item/weapon/storage/bag/trash(src)
 	src.modules += new /obj/item/weapon/mop(src)
-	src.modules += new /obj/item/device/lightreplacer(src)
+	src.modules += new /obj/item/device/lightreplacer/borg(src)
 	src.modules += new /obj/item/weapon/reagent_containers/glass/bucket(src)
 	src.modules += new /obj/item/weapon/crowbar(src)
 	src.emag = new /obj/item/weapon/reagent_containers/spray(src)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -575,7 +575,7 @@ var/global/list/obj/machinery/light/alllights = list()
 	var/status = 0		// LIGHT_OK, LIGHT_BURNED or LIGHT_BROKEN
 	var/base_state
 	var/switchcount = 0	// number of times switched
-	starting_materials = list(MAT_IRON = 60)
+	//starting_materials = list(MAT_IRON = 60) //Not necessary, as this exact type should never appear and each subtype has its materials defined.
 	var/rigged = 0		// true if rigged to explode
 	var/brightness_range = 2 //how much light it gives off
 	var/brightness_power = 1
@@ -589,7 +589,7 @@ var/global/list/obj/machinery/light/alllights = list()
 	icon_state = "tube"
 	base_state = "tube"
 	item_state = "c_tube"
-	starting_materials = list(MAT_GLASS = 100)
+	starting_materials = list(MAT_GLASS = 100, MAT_IRON = 60)
 	w_type = RECYK_GLASS
 	brightness_range = 8
 	brightness_power = 3
@@ -599,6 +599,7 @@ var/global/list/obj/machinery/light/alllights = list()
 	name = "high efficiency light tube"
 	desc = "An efficient light used to reduce strain on the station's power grid."
 	base_state = "hetube"
+	starting_materials = list(MAT_GLASS = 300, MAT_IRON = 60)
 	cost = 2
 
 /obj/item/weapon/light/tube/large
@@ -606,6 +607,7 @@ var/global/list/obj/machinery/light/alllights = list()
 	name = "large light tube"
 	brightness_range = 15
 	brightness_power = 4
+	starting_materials = list(MAT_GLASS = 200, MAT_IRON = 100)
 	cost = 15
 
 /obj/item/weapon/light/bulb
@@ -618,7 +620,7 @@ var/global/list/obj/machinery/light/alllights = list()
 	brightness_range = 5
 	brightness_power = 2
 	brightness_color = LIGHT_COLOR_TUNGSTEN
-	starting_materials = list(MAT_GLASS = 100)
+	starting_materials = list(MAT_GLASS = 50, MAT_IRON = 30)
 	cost = 5
 	w_type = RECYK_GLASS
 
@@ -627,6 +629,7 @@ var/global/list/obj/machinery/light/alllights = list()
 	desc = "An efficient light used to reduce strain on the station's power grid."
 	base_state = "hebulb"
 	cost = 1
+	starting_materials = list(MAT_GLASS = 150, MAT_IRON = 30)
 	brightness_color = null//These should be white
 
 /obj/item/weapon/light/throw_impact(atom/hit_atom)
@@ -641,7 +644,7 @@ var/global/list/obj/machinery/light/alllights = list()
 	item_state = "egg4"
 	brightness_range = 5
 	brightness_power = 2
-	starting_materials = list(MAT_GLASS = 100)
+	starting_materials = list(MAT_GLASS = 300, MAT_IRON = 60)
 
 // update the icon state and description of the light
 

--- a/html/changelogs/Exxion.yml
+++ b/html/changelogs/Exxion.yml
@@ -1,0 +1,5 @@
+author: Exxion
+delete-after: True
+changes:
+  - rscadd: Light replacer has been completely overhauled. It now actually contains storage for lights and storage for waste lights, which it automatically picks up. It can be loaded the same way as before or by removing its box and replacing that. It ONLY accepts light bulb/tube boxes. The rest should be self-explanatory from its menu (accessed by clicking it in your hand).
+  - tweak: The material costs of most types of lights have been changed slightly. Standard tubes are the same, bulbs are half as much, and the HE variants require three times more glass (but not iron) than their standard counterparts. Also, the large tube and fire bulb were adjusted, but you almost never see them anyway. Even the most expensive light is still a small fraction of a sheet of each, though.


### PR DESCRIPTION
It didn't actually take me four months of work. I just didn't work on it for four months because I was busy and/or lazy.
Redo of #4800
Fixes #6807, fixes #4988, fixes #4972.
The light replacer has been completely overhauled. I'm copying and slightly editing the change list from the old PR because it's basically the same. 
- Light replacer now holds two boxes
  - Only accepts /obj/item/weapon/storage/box/lights and its subtypes for these boxes
  - One box is its light supply
    - Lights inserted into fixtures are drawn from this supply
    - Chooses the "best" light in its supply box that is compatible with the fixture it is used on
      - At the moment, it just prioritizes HE lights over regular ones
    - If it has a light that is "better" than the current one in the fixture, it will replace the one in the fixture, regardless of whether or not the one in the fixture works
      - If it does work, it is placed into the supply box
      - To prevent clogging of the box in the event one is attempting to upgrade all the lights, there are buttons in the menu to dump a number of lights of a given type from the supply box into the waste box
    - Interface popup (accessed by clicking the light replacer in your active hand) says how many of each type of light the supply box has
  - The other box is its waste container
    - Broken or burnt-out lights inserted into the light replacer go in here
    - Interface readout says how full this is, but not what types of lights it contains, as they should all be broken or obsolete
    - The borg light replacer (but NOT the standard one) can recycle the lights in its waste container back into glass, though for significantly less glass than it takes to make them
  - Interface popup allows either box to be ejected on the standard (but NOT borg) light replacer
  - Boxes can, of course, be inserted
    - If you attempt to insert a box, it first tries to use it as the supply, then tries to use it as the waste container if it already has a supply container. Obviously fails if it has both.
  - Lights can be inserted the same way as before, too, though it's generally much slower than just replacing the supply/waste box
    - Working ones inserted this way go into the supply box, broken/burnt-out ones go into the waste box

Webm demo (New, not old): https://a.uguu.se/vheiyj_2015-12-01_17-37-52.webm

EDIT: I forgot to mention
Both the standard and the borg light replacers can produce lights from glass, but ones produced by the standard (NOT borg) light replacer burn out more quickly and are much more expensive than lights produced otherwise. The borg light replacer holds twice as much glass, uses half as much to produce lights, and produces perfect ones that don't burn out any more quickly than others. It's still more expensive than lights from an autolathe, but by much less. It is also filled by recharge stations at a rate of 500 glass per Charge().

This also tweaks the material costs of different types of lights. HE lights use three times as much glass and iron as their non-HE counterparts, but the glass cost of non-HE bulbs (not tubes) was halved. Overall, the most expensive light still takes only a small fraction of a sheet of glass when made with an autolathe.
