### PR TITLE
Adds Cuban Pete bombs as a rare prize from non-emagged arcade machines

### DIFF
--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -23,6 +23,7 @@
 							/obj/item/toy/blink								= 2,
 							/obj/item/clothing/under/syndicate/tacticool	= 2,
 							/obj/item/toy/sword								= 2,
+							/obj/item/toy/bomb								= 1,
 							/obj/item/toy/gun								= 2,
 							/obj/item/toy/crossbow							= 2,
 							/obj/item/clothing/suit/syndicatefake			= 2,
@@ -82,7 +83,7 @@
 	A.game_data.len = 0
 	A.game_data["name"] = name
 	A.game_data["emagged"] = emagged
-	A.game_data["enemy_name"] = enemy_name 
+	A.game_data["enemy_name"] = enemy_name
 	A.game_data["temp"] = temp
 	A.game_data["player_hp"] = player_hp
 	A.game_data["player_mp"] = player_mp

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -6,6 +6,7 @@
  *		Toy gun
  *		Toy crossbow
  *		Toy swords
+ *      Bomb clock
  *		Crayons
  *		Snap pops
  *		Water flower
@@ -363,6 +364,31 @@
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced")
 
 /*
+ * Clock bomb
+ */
+/obj/item/toy/bomb
+	name = "commemorative Toxins clock"
+	desc = "A bright-colored plastic clock, commemorating 20 years of Nanotrasen's Plasma division. Comes with permanent snooze button, just twist the valve!"
+	icon = 'icons/obj/assemblies.dmi'
+	icon_state = "valve"
+
+/obj/item/toy/bomb/New()
+	..()
+	overlays += "plasma"
+	var/icon/J = new(icon, icon_state = "oxygen")
+	J.Shift(WEST, 13)
+	underlays += J
+	overlays += "device"
+
+/obj/item/toy/bomb/examine(mob/user)
+	..()
+	to_chat(user, "<span class='info'>Station Time: [worldtime2text()]")
+
+/obj/item/toy/bomb/attack_self(mob/user)
+	var/turf/T = get_turf(src)
+	T.visible_message("\icon[src] *beep* *beep*", "*beep* *beep*")
+
+/*
  * Crayons
  */
 
@@ -605,20 +631,6 @@
 	name = "toy phazon"
 	desc = "Mini-Mecha action figure! Collect them all! 11/11."
 	icon_state = "phazonprize"
-
-/obj/item/toy/katana
-	name = "replica katana"
-	desc = "Woefully underpowered in D20."
-	icon = 'icons/obj/weapons.dmi'
-	icon_state = "katana"
-	item_state = "katana"
-	flags = FPRINT
-	siemens_coefficient = 1
-	slot_flags = SLOT_BELT | SLOT_BACK
-	force = 5
-	throwforce = 5
-	w_class = 3
-	attack_verb = list("attacked", "slashed", "stabbed", "sliced")
 
 /*
  * OMG THEIF

--- a/code/game/objects/items/weapons/gift_wrappaper.dm
+++ b/code/game/objects/items/weapons/gift_wrappaper.dm
@@ -127,6 +127,7 @@
 //		/obj/item/toy/blink,	//this one reaaally needs a revamp. there's a limit to how lame a toy can be.
 		/obj/item/toy/crossbow,
 		/obj/item/toy/gun,
+		/obj/item/toy/bomb,
 		/obj/item/toy/katana,
 		/obj/item/toy/prize/deathripley,
 		/obj/item/toy/prize/durand,

--- a/code/modules/maps/spawners/spawners.dm
+++ b/code/modules/maps/spawners/spawners.dm
@@ -486,6 +486,7 @@
 		/obj/item/toy/gun,
 		/obj/item/toy/snappop,
 		/obj/item/toy/sword,
+		/obj/item/toy/bomb,
 		/obj/item/clothing/mask/facehugger/toy,
 		/obj/item/trash/candle,
 		/obj/item/trash/candy,
@@ -928,5 +929,3 @@
 		/obj/item/seeds/whitebeetseed,
 		/obj/item/seeds/cinnamomum,
 		)
-
-

--- a/html/changelogs/9600bauds_thatchangelogisabomb.yml
+++ b/html/changelogs/9600bauds_thatchangelogisabomb.yml
@@ -1,0 +1,35 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general adding of nice things)
+#   rscadd (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: 9600bauds
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+changes: 
+  - rscadd: Added a new, rare, super special, un-limited edition prize to arcade machines! Hint: It's the bomb! Ages 8 and up.


### PR DESCRIPTION
There's been a few complaints about how emags have too many unique features, emags already do too many things, etc. so I thought I'd help this problem a little by adding alternate ways to get emag-exclusive items.
This makes it so that a patient antag can still get infinite bombs from arcade machines without HAVING to buy the emag, as well as be a little less suspicious. I think more bombs will help bring more action to the round.
This also technically gives bombs to non-antags but I'm not concerned with that because they can't use them anyways since it's against the rules, so I don't think anyone will really think too much of it when they get one so no-one will use them of course :^).

Also, the toy katana was defined twice
