### PR TITLE
Woodcutting

### DIFF
--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -797,6 +797,7 @@
 	throwforce = 15.0
 	throw_speed = 4
 	throw_range = 4
+	sharpness = 1.2
 	starting_materials = list(MAT_IRON = 15000)
 	w_type = RECYK_METAL
 	melt_temperature=MELTPOINT_STEEL
@@ -813,6 +814,7 @@
 	icon = 'icons/obj/weapons.dmi'
 	icon_state = "unathiknife"
 	attack_verb = list("ripped", "torn", "cut")
+	sharpness = 1.35
 
 /obj/item/weapon/scythe
 	icon_state = "scythe0"
@@ -823,6 +825,7 @@
 	throw_speed = 1
 	throw_range = 3
 	w_class = 4.0
+	sharpness = 1.0
 	starting_materials = list(MAT_IRON = 15000)
 	w_type = RECYK_METAL
 	flags = FPRINT

--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -7,6 +7,7 @@
 	w_class = 4
 	force = 30
 	throwforce = 10
+	sharpness = 1.35
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 
 /obj/item/weapon/melee/cultblade/cultify()

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -38,7 +38,6 @@
 		return (BRUTELOSS|FIRELOSS)
 
 /obj/item/weapon/melee/energy/sword
-	color
 	name = "energy sword"
 	desc = "May the force be within you."
 	icon_state = "sword0"
@@ -86,12 +85,14 @@
 	if (active)
 		force = 30
 		w_class = 4
+		sharpness = 1.5
 		hitsound = "sound/weapons/blade1.ogg"
 		playsound(user, 'sound/weapons/saberon.ogg', 50, 1)
 		to_chat(user, "<span class='notice'> [src] is now active.</span>")
 	else
 		force = 3
 		w_class = 2
+		sharpness = 0
 		playsound(user, 'sound/weapons/saberoff.ogg', 50, 1)
 		hitsound = "sound/weapons/empty.ogg"
 		to_chat(user, "<span class='notice'> [src] can now be concealed.</span>")

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -197,11 +197,13 @@
 		src.force = 150
 		src.icon_state = "axe1"
 		src.w_class = 5
+		src.sharpness = 1.5
 	else
 		to_chat(user, "<span class='notice'>The axe can now be concealed.</span>")
 		src.force = 40
 		src.icon_state = "axe0"
 		src.w_class = 5
+		src.sharpness = 1.0
 	src.add_fingerprint(user)
 	return
 

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -50,6 +50,7 @@
 	force = 40
 	throwforce = 10
 	w_class = 3
+	sharpness = 1.2
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 
 

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -9,7 +9,6 @@
 	icon_state = "tree_1"
 
 	pixel_x = -16
-	pixel_y = 21
 
 	var/health = 100
 	var/maxHealth = 100
@@ -30,11 +29,6 @@
 		maxHealth = health
 
 		height = rand(3, 8)
-
-		if(prob(5)) //5% chance to make a tree 4 times as resilent, yield 6-15 logs and have an "ancient" prefix
-			height = rand(6, 15)
-			health *= 4
-			name = "ancient [name]"
 
 		icon_state = pick(
 		"tree_1",
@@ -72,14 +66,7 @@
 		else
 			to_chat(user, "<span class='info'>\The [W] doesn't appear to be sharp enough to cut into \the [src]. Try something sharper.</span>")
 
-	if(health < 40 && !falling_dir)
-		falling_dir = pick(cardinal)
-		visible_message("<span class='danger'>\The [src] starts leaning to the [dir2text(falling_dir)]!</span>",
-			drugged_message = "<span class='sinister'>[pick("Treebeard", "The ent")] cries in agony as \the [W] tears into his bark, sap oozing from the wound.</span>")
-
-	if(health <= 0)
-		fall_down()
-		qdel(src)
+	update_health()
 
 	return 1
 
@@ -90,17 +77,40 @@
 	var/turf/our_turf = get_turf(src) //Turf at which this tree is located
 	var/turf/current_turf = get_turf(src) //Turf in which to spawn a log. Updated in the loop
 
-	while(height > 0)
-		if(!current_turf) break //If the turf in which to spawn a log doesn't exist, stop the thing
+	qdel(src)
 
-		var/obj/item/I = new log_type(our_turf) //Spawn a log and throw it at the "current_turf"
-		I.throw_at(current_turf, 10, 10)
+	spawn()
+		while(height > 0)
+			if(!current_turf) break //If the turf in which to spawn a log doesn't exist, stop the thing
 
-		current_turf = get_step(current_turf, falling_dir)
+			var/obj/item/I = new log_type(our_turf) //Spawn a log and throw it at the "current_turf"
+			I.throw_at(current_turf, 10, 10)
 
-		height--
+			current_turf = get_step(current_turf, falling_dir)
 
-		sleep(1)
+			height--
+
+			sleep(1)
+
+/obj/structure/flora/tree/proc/update_health()
+	if(health < 40 && !falling_dir)
+		falling_dir = pick(cardinal)
+		visible_message("<span class='danger'>\The [src] starts leaning to the [dir2text(falling_dir)]!</span>",
+			drugged_message = "<span class='sinister'>\The [src] is coming to life, man.</span>")
+
+	if(health <= 0)
+		fall_down()
+
+/obj/structure/flora/tree/ex_act(severity)
+	switch(severity)
+		if(1) //Epicentre
+			return qdel(src)
+		if(2) //Major devastation
+			height -= rand(1,4) //Some logs are lost
+			fall_down()
+		if(3) //Minor devastation (IED)
+			health -= rand(10,30)
+			update_health()
 
 /obj/structure/flora/tree/pine
 	name = "pine tree"

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -3,8 +3,104 @@
 	name = "tree"
 	anchored = 1
 	density = 1
+
+	layer = FLY_LAYER
+	icon = 'icons/obj/flora/deadtrees.dmi'
+	icon_state = "tree_1"
+
 	pixel_x = -16
-	layer = 9
+	pixel_y = 21
+
+	var/health = 100
+	var/maxHealth = 100
+
+	var/height = 6 //How many logs are spawned
+
+
+	var/falling_dir = 0 //Direction in which spawned logs are thrown.
+
+	var/const/randomize_on_creation = 1
+	var/const/log_type = /obj/item/weapon/grown/log/tree
+
+/obj/structure/flora/tree/New()
+	..()
+
+	if(randomize_on_creation)
+		health = rand(60, 200)
+		maxHealth = health
+
+		height = rand(3, 8)
+
+		if(prob(5)) //5% chance to make a tree 4 times as resilent, yield 6-15 logs and have an "ancient" prefix
+			height = rand(6, 15)
+			health *= 4
+			name = "ancient [name]"
+
+		icon_state = pick(
+		"tree_1",
+		"tree_2",
+		"tree_3",
+		"tree_4",
+		"tree_5",
+		"tree_6",
+		)
+
+/obj/structure/flora/tree/examine(mob/user)
+	.=..()
+
+	//Tell user about the height. Note that normally height ranges from 3 to 8 (with a 5% chance of having 6 to 15 instead)
+	to_chat(user, "<span class='info'>It appears to be about [height*3] feet tall.</span>")
+	switch(health / maxHealth)
+		if(1.0)
+			//It's healthy
+		if(0.9 to 0.6)
+			to_chat(user, "<span class='info'>It's been partially cut down.</span>")
+		if(0.6 to 0.2)
+			to_chat(user, "<span class='notice'>It's almost cut down, [falling_dir ? "and it's leaning towards the [dir2text(falling_dir)]." : "but it still stands upright."]</span>")
+		if(0.2 to 0)
+			to_chat(user, "<span class='danger'>It's going to fall down any minute now!</span>")
+
+/obj/structure/flora/tree/attackby(obj/item/W, mob/living/user)
+	..()
+
+	if(istype(W, /obj/item/weapon))
+		if(W.is_sharp() >= 1.2) //As sharp as a knife
+			if(W.w_class >= 2) //Big enough to use to cut down trees
+				health -= (user.get_strength() * W.force)
+			else
+				to_chat(user, "<span class='info'>\The [W] doesn't appear to be big enough to cut into \the [src]. Try something bigger.</span>")
+		else
+			to_chat(user, "<span class='info'>\The [W] doesn't appear to be sharp enough to cut into \the [src]. Try something sharper.</span>")
+
+	if(health < 40 && !falling_dir)
+		falling_dir = pick(cardinal)
+		visible_message("<span class='danger'>\The [src] starts leaning to the [dir2text(falling_dir)]!</span>",
+			drugged_message = "<span class='sinister'>[pick("Treebeard", "The ent")] cries in agony as \the [W] tears into his bark, sap oozing from the wound.</span>")
+
+	if(health <= 0)
+		fall_down()
+		qdel(src)
+
+	return 1
+
+/obj/structure/flora/tree/proc/fall_down()
+	if(!falling_dir)
+		falling_dir = pick(cardinal)
+
+	var/turf/our_turf = get_turf(src) //Turf at which this tree is located
+	var/turf/current_turf = get_turf(src) //Turf in which to spawn a log. Updated in the loop
+
+	while(height > 0)
+		if(!current_turf) break //If the turf in which to spawn a log doesn't exist, stop the thing
+
+		var/obj/item/I = new log_type(our_turf) //Spawn a log and throw it at the "current_turf"
+		I.throw_at(current_turf, 10, 10)
+
+		current_turf = get_step(current_turf, falling_dir)
+
+		height--
+
+		sleep(1)
 
 /obj/structure/flora/tree/pine
 	name = "pine tree"
@@ -25,6 +121,7 @@
 	icon_state = "pine_c"
 
 /obj/structure/flora/tree/dead
+	name = "dead tree"
 	icon = 'icons/obj/flora/deadtrees.dmi'
 	icon_state = "tree_1"
 

--- a/code/modules/hydroponics/grown_inedible.dm
+++ b/code/modules/hydroponics/grown_inedible.dm
@@ -37,7 +37,6 @@
 	potency = newValue
 
 /obj/item/weapon/grown/log
-	name = "towercap"
 	name = "tower-cap log"
 	desc = "It's better than bad, it's good!"
 	icon = 'icons/obj/harvest.dmi'
@@ -65,6 +64,12 @@
 			to_chat(user, "You add the newly-formed wood to the stack. It now contains [NG.amount] planks.")
 		qdel(src)
 		return
+
+/obj/item/weapon/grown/log/tree
+	name = "log"
+	desc = "A very heavy log, a main product of woodcutting. Much heavier than tower-cap logs."
+	force = 10
+	w_class = 4.0
 
 /obj/item/weapon/grown/sunflower // FLOWER POWER!
 	plantname = "sunflowers"

--- a/code/modules/hydroponics/grown_inedible.dm
+++ b/code/modules/hydroponics/grown_inedible.dm
@@ -67,6 +67,7 @@
 
 /obj/item/weapon/grown/log/tree
 	name = "log"
+	plantname = "tree"
 	desc = "A very heavy log, a main product of woodcutting. Much heavier than tower-cap logs."
 	force = 10
 	w_class = 4.0

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1292,6 +1292,14 @@ default behaviour is:
 	if(istype(src, /mob/living/simple_animal)) //Animals can be butchered completely, humans - not so
 		gib(meat = 0) //"meat" argument only exists for mob/living/simple_animal/gib()
 
+/mob/living/proc/get_strength() //Returns a mob's strength. Isn't used in damage calculations, but rather in things like cutting down trees etc.
+	var/strength = 1.0
+
+	strength += (M_HULK in src.mutations)
+	strength += (M_STRONG in src.mutations)
+
+	. = strength
+
 /mob/living/proc/scoop_up(mob/M) //M = mob who scoops us up!
 	if(!holder_type) return
 

--- a/html/changelogs/unid-just.yml
+++ b/html/changelogs/unid-just.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general deleting of nice things)
+#   rscadd (general adding of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: Unid
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+changes: 
+  - rscadd: Trees may be cut down with sharp and big enough objects, yielding 3 to 8 big logs (they are too big to be held by small plant bags).
+  - rscadd: Trees fall in a random direction when chopped down. Standing in a large tree's way is a great way to get yourself killed (you can see the direction in which it's going to fall).

--- a/html/changelogs/unid-just.yml
+++ b/html/changelogs/unid-just.yml
@@ -32,5 +32,5 @@ delete-after: True
 # SCREW THIS UP AND IT WON'T WORK.
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 changes: 
-  - rscadd: Trees may be cut down with sharp and big enough objects, yielding 3 to 8 big logs (they are too big to be held by small plant bags).
-  - rscadd: Trees fall in a random direction when chopped down. Standing in a large tree's way is a great way to get yourself killed (you can see the direction in which it's going to fall).
+  - rscadd: Trees may be cut down with sharp and big enough objects, yielding from 3 to 8 big logs.
+  - rscadd: Trees fall in a random direction when chopped down. Standing in a large tree's way is a sure way to get some broken bones, and you can see the direction in which the tree is going to fall before it's cut down.


### PR DESCRIPTION
- Trees of type /obj/structure/flora/tree have been updated:
- They now have a random amount of health and height (height affects the amount of logs produced by the tree). Health is 60-200, height is 3-8m.
- They can be cut down by repeatedly hitting them with big sharp objects (sharpness >= 1.2 and w_class > 1, so eswords, hatchets, fireaxes, energy axes). Having big muscles helps cut the trees faster (STRONG and HULK mutations multiply the damage dealt to the tree). Bombs work too
- When cut down, trees fall in a random direction. It's possible to see the direction the tree is going to fall when cutting it down, and it'll never fall in a diagonal direction so it's fairly easy to avoid. Mobs that are standing in the falling tree's way will get a fair share of bruises and broken bones.
- Eswords, energy axes, hatchets, claymores and cult blades are now sharp

![y tho](http://puu.sh/lK5Yy/c084a4ce62.gif) ---- ignore the trees not disappearing before the logs are spawned, it's fixed

---
- Logs from trees are much bigger than logs from mushrooms, so their w_class is 4.0 (up from 3.0) and their force is 10 (up from 5). They don't fit in plant bags!
- Added mob/living/proc/get_strength(). It returns 3 if the mob has both M_STRONG and M_HULK mutations, returns 2 if it has only one of those, returns 1 if it doesn't have any.
