### PR TITLE
Wizard Statues now have hit delays

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/statue.dm
+++ b/code/game/objects/structures/crates_lockers/closets/statue.dm
@@ -115,6 +115,7 @@
 /obj/structure/closet/statue/attackby(obj/item/I as obj, mob/user as mob)
 	health -= I.force
 	visible_message("<span class='warning'>[user] strikes [src] with [I].</span>")
+	user.delayNextAttack(10)
 	if(health <= 0)
 		for(var/mob/M in src)
 			shatter(M)


### PR DESCRIPTION
Ten fucking seconds in Dreammaker. It's just like people don't report actual issues and spend months resenting about issues we don't even know about
- Added standard 1 second attack delay when Wizard statue is attacked to prevent instant toolbox rape
