### PR TITLE
Changes to Syndicate Beacon

### DIFF
--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -102,119 +102,165 @@
 		selfdestructing = 1
 		spawn() explosion(src.loc, 1, rand(1,3), rand(3,8), 10)
 
-
-
-#define SCREWED 32
-
-/obj/machinery/singularity_beacon //not the best place for it but it's a hack job anyway -- Urist
-	name = "ominous beacon"
-	desc = "This looks suspicious..."
+//Not the best place for it but it's a hack job anyway -- Urist
+/obj/machinery/singularity_beacon
+	name = "singularity beacon"
+	desc = "A suspicious-looking beacon. It looks like one of those snazzy state-of-the-art bluespace devices."
 	icon = 'icons/obj/singularity.dmi'
 	icon_state = "beacon"
-
 	anchored = 0
 	density = 1
-	layer = MOB_LAYER - 0.1 //so people can't hide it and it's REALLY OBVIOUS
-	stat = 0
+	machine_flags = WRENCHMOVE | FIXED2WORK
+	layer = MOB_LAYER
 
-	var/active = 0 //It doesn't use up power, so use_power wouldn't really suit it
+	light_color = LIGHT_COLOR_RED
+	light_range_on = 2
+	light_power_on = 2
+
+	var/obj/item/weapon/cell/cell
+	var/power_load = 1000 //A bit ugly. How much power this machine needs per tick. Equivalent to one minute on 30k W battery, two second ticks
+	var/power_draw = 0 //If there's spare power on the grid, cannibalize it to charge the beacon's battery
+	var/active = 0 //It doesn't use APCs, so use_power wouldn't really suit it
 	var/icontype = "beacon"
 	var/obj/structure/cable/attached = null
 
+/obj/machinery/singularity_beacon/New()
 
-	proc/Activate(mob/user = null)
-		if(!checkWirePower())
-			if(user) to_chat(user, "<span class='notice'>The connected wire doesn't have enough current.</span>")
-			return
-		for(var/obj/machinery/singularity/singulo in power_machines)
-			if(singulo.z == z)
-				singulo.target = src
-		icon_state = "[icontype]1"
-		active = 1
-		if(user) to_chat(user, "<span class='notice'>You activate the beacon.</span>")
+	..()
 
+	cell = new /obj/item/weapon/cell/hyper(src) //Singularity beacons are wasteful as fuck, that state-of-the-art cell will last a single minute
 
-	proc/Deactivate(mob/user = null)
-		for(var/obj/machinery/singularity/singulo in power_machines)
-			if(singulo.target == src)
-				singulo.target = null
-		icon_state = "[icontype]0"
-		active = 0
-		if(user) to_chat(user, "<span class='notice'>You deactivate the beacon.</span>")
+/obj/machinery/singularity_beacon/examine(mob/user)
 
+	..()
 
-	attack_ai(mob/user as mob)
+	if(anchored)
+		to_chat(user, "<span class='info'>It appears firmly secured to the floor. Nothing a wrench can't undo.</span>")
+	to_chat(user, "<span class='info'>It features a power port. [attached ? "A power cable is running through it":"It looks like a power cable can be ran straight through it to power it"].</span>")
+	if(active)
+		to_chat(user, "<span class='info'>It is slowly pulsing red and emitting a deep humming sound.</span>")
+
+/obj/machinery/singularity_beacon/proc/activate(mob/user = null)
+	if(!anchored) //Sanity
 		return
-
-
-	attack_hand(var/mob/user as mob)
-		if(stat & SCREWED)
-			return active ? Deactivate(user) : Activate(user)
+	if(!check_power())
+		if(user)
+			user.visible_message("<span class='warning'>[user] tries to start \the [src], but it shuts down halfway.</span>", \
+			"<span class='warning'>You try to start \the [src], but it shuts down halfway. Looks like a power issue.</span>")
 		else
-			to_chat(user, "<span class='warning'>You need to screw the beacon to the floor first!</span>")
-			return
+			visible_message("<span class='warning'>\The [src] suddenly springs to life, only to shut down halfway through startup.</span>")
+		return
+	for(var/obj/machinery/singularity/singulo in power_machines)
+		if(singulo.z == z)
+			singulo.target = src
+	icon_state = "[icontype]1"
+	active = 1
+	set_light(light_range_on, light_power_on, light_color)
+	if(user)
+		user.visible_message("<span class='warning'>[user] starts up \the [src].</span>", \
+		"<span class='notice'>You start up \the [src].</span>")
+	else
+		visible_message("<span class='warning'>\The [src] suddenly springs to life.</span>")
 
+/obj/machinery/singularity_beacon/proc/deactivate(mob/user = null)
+	for(var/obj/machinery/singularity/singulo in power_machines)
+		if(singulo.target == src)
+			singulo.target = null
+	icon_state = "[icontype]0"
+	active = 0
+	set_light(0)
+	if(user)
+		user.visible_message("<span class='warning'>[user] shuts down \the [src].</span>", \
+		"<span class='notice'>You shut down \the [src].</span>")
+	else
+		visible_message("<span class='warning'>\The [src] suddenly shuts down.</span>")
 
-	attackby(obj/item/weapon/W as obj, mob/user as mob)
-		if(istype(W,/obj/item/weapon/screwdriver))
-			if(active)
-				to_chat(user, "<span class='warning'>You need to deactivate the beacon first!</span>")
-				return
+/obj/machinery/singularity_beacon/attack_ai(mob/user as mob)
+	to_chat(user, "<span class='warning'>You try to interface with \the [src], but it throws a strange encrypted error message.</span>")
+	return
 
-			if(stat & SCREWED)
-				stat &= ~SCREWED
-				anchored = 0
-				to_chat(user, "<span class='notice'>You unscrew the beacon from the floor.</span>")
-				attached = null
-				return
-			else
-				var/turf/T = loc
-				if(isturf(T) && !T.intact)
-					attached = locate() in T
-				if(!attached)
-					to_chat(user, "This device must be placed over an exposed cable.")
-					return
-				stat |= SCREWED
-				anchored = 1
-				to_chat(user, "<span class='notice'>You screw the beacon to the floor and attach the cable.</span>")
-				return
-		..()
+/obj/machinery/singularity_beacon/attack_hand(var/mob/user as mob)
+	user.delayNextAttack(10) //Prevent spam toggling, otherwise you can brick the cell very quickly
+	if(anchored)
+		if(!attached)
+			var/turf/T = get_turf(src)
+			if(isturf(T) && !T.intact)
+				attached = locate() in T
+			if(attached)
+				user.visible_message("<span class='notice'>[user] reaches for the exposed cabling and carefully runs it through \the [src]'s power port.</span>", \
+				"<span class='notice'>You reach for the exposed cabling and carefully run it through \the [src]'s power port.</span>")
+				return //Need to attack again to actually start
+		return active ? deactivate(user) : activate(user)
+	else
+		to_chat(user, "<span class='warning'>\The [src] doesn't work on the fly, wrench it down first.</span>")
 		return
 
+/obj/machinery/singularity_beacon/wrenchAnchor(mob/user)
 
-	Destroy()
-		if(active) Deactivate()
-		..()
+	if(active)
+		to_chat(user, "<span class='warning'>Turn off \the [src] first.</span>")
+		return
+	..()
+	if(attached)
+		attached = null //Reset attached cable
 
-	/*
-	* Added for a simple way to check power. Verifies that the beacon
-	* is connected to a wire, the wire is part of a powernet (that part's
-	* sort of redundant, since all wires either join or create one when placed)
-	* and that the powernet has at least 1500 power units available for use.
-	* Doesn't use them, though, just makes sure they're there.
-	* - QualityVan, Aug 11 2012
-	*/
-	proc/checkWirePower()
-		if(!attached)
-			return 0
-		var/datum/powernet/PN = attached.get_powernet()
-		if(!PN)
-			return 0
-		if(PN.avail < 1500)
-			return 0
+/obj/machinery/singularity_beacon/Destroy()
+	if(active)
+		deactivate()
+	if(cell)
+		qdel(cell)
+		cell = null
+	..()
+
+/*
+* Added for a simple way to check power. Verifies that the beacon
+* is connected to a wire, the wire is part of a powernet (that part's
+* sort of redundant, since all wires either join or create one when placed)
+* and that the powernet has at least 1500 power units available for use.
+* Doesn't use them, though, just makes sure they're there.
+* - QualityVan, Aug 11 2012
+*/
+
+//Simplified check for power. If we can charge straight out of the grid, do it
+/obj/machinery/singularity_beacon/proc/check_wire_power()
+	if(!attached) //No wire, move straight to battery power
+		return 0
+	var/datum/powernet/PN = attached.get_powernet()
+	if(!PN) //Powernet is dead
+		return 0
+	if(PN.avail < power_load) //Cannot drain enough power, needs 1500 per tick, move to battery
+		return 0
+	else
+		PN.load += power_load
+		if(cell && cell.charge < cell.maxcharge && cell.charge > 0 && PN.netexcess)
+			power_draw = min(cell.maxcharge - cell.charge, PN.netexcess) //Draw power directly from excess power
+			PN.load += power_draw
+			cell.give(power_draw) //We drew power from the grid, charge the cell
 		return 1
 
-	process()
-		if(!active)
-			return
-		else
-			if(!checkWirePower())
-				Deactivate()
-		return
+//Use up the battery if powernet check fails
+/obj/machinery/singularity_beacon/proc/check_battery_power()
 
+	if(cell && cell.charge > power_load)
+		cell.use(power_load)
+		return 1
+	else //Nothing here either
+		return 0
+
+//Composite of the two, called at every process
+/obj/machinery/singularity_beacon/proc/check_power()
+
+	return check_wire_power() || check_battery_power()
+
+/obj/machinery/singularity_beacon/process()
+	if(!active)
+		return
+	if(!anchored) //If it got unanchored "inexplicably"
+		deactivate()
+	else
+		if(!check_power()) //No power
+			deactivate()
 
 /obj/machinery/singularity_beacon/syndicate
 	icontype = "beaconsynd"
 	icon_state = "beaconsynd0"
-
-#undef SCREWED

--- a/html/changelogs/Dylanstrategie_SingBeacon.yml
+++ b/html/changelogs/Dylanstrategie_SingBeacon.yml
@@ -1,0 +1,7 @@
+author: Dylanstrategie
+delete-after: True
+changes:
+  - rscadd: Singularity Beacons now have an internal battery. It will last one minute, which allows you to either set up a quick beacon without wires, or continue dragging when the Singularity knocks out the powernet
+  - rscadd: The Singularity Beacon now glows red when on. This means it will be far less concealable in darkness, and shouldn't be adjacent to a wall (due to the way lighting works)
+  - tweak: Singularity Beacons now needs to be wrenched down instead of screwed down. Cable is connected on hand interaction (interact again to turn on and off) and disconnected by wrenching or unwrenching
+  - tweak: Singularity Beacons now need 500 W/s to run, and actually drain that amount from the grid


### PR DESCRIPTION
- Singularity beacon is now named singularity beacon. We're not Bay, everyone knows what that beacon does
- When activated, the singularity beacon now glows red. This means the singularity beacon will be obvious even in dark places or in a 1x1 wall-in (Protip : Try any fire closet and put it in the middle)
- The Singularity Beacon now has a battery. It is a hyper battery with 30k W charge that is intended to last one minute. The Singularity Beacon will fall back to this battery if it has no cable to drain power from. The battery can charge from the powernet if there's excess power (much like APCs, except that it will drain all the excess power it needs in one go)
- The Singularity Beacon uses 1000 watts (down from 1500 and no longer hardcoded). It also now uses said power, physically
- The Singularity Beacon now uses a wrench for anchoring and no longer requires a cable. If there is an exposed cable under the beacon, you will run it through the device on first interaction (all further interactions will toggle the device)
- Snazzy examine proc, visible messages

Discussions go below. This has seen testing to make sure everything works properly, scrutiny is welcome
