### PR TITLE
[Merge-ready once more] Statistics Gathering

### DIFF
--- a/code/datums/statistics/documentation/statfile_1.0.md
+++ b/code/datums/statistics/documentation/statfile_1.0.md
@@ -1,0 +1,127 @@
+# STATFILE FORMAT DOCUMENTATION
+Because let's be honest, reading the statfiles themselves tells you nothing, and reading the code isn't the most convenient thing to see exactly what was intended.
+## Iteration 1.0
+This is what statfiles look like in the first iteration of this format. There should be a new documentation file for every iteration, even if it's just "only X has changed since the last version".
+
+### STATLOG_START
+Always shows up in every log file. If it isn't there, __PANIC__
+
+#### Format:
+`STATLOG_START|statistics format revision number|map's long name|round start time|round end time`
+
+#### Example:
+`STATLOG_START|1.0|Box Station|5033469952|5033470976`
+
+### WRITE_COMPLETE
+A single line at the end of every stat file. This is written in case the server crashes, closes, or writing is interrupted, so that we know a stat file is incomplete and should not be parsed because it's fucked.
+
+Format and example:
+`WRITE_COMPLETE`
+
+### MASTERMODE
+The master game mode that's running. Could be `secret`, could be `mixed`, could be an actual gamemode like `extended`. Taken from global variable `master_mode`
+
+#### Format:
+`MASTERMODE|master_mode`
+
+#### Example:
+`MASTERMODE|sandbox`
+
+### GAMEMODE
+This is the value taken from `ticker.mode`, parsed in case it's `mixed` so that it actually outputs all gamemodes.
+
+#### Format:
+`GAMEMODE|ticker.mode` or `GAMEMODE|mixedmode1|mixedmode2|etc`
+
+#### Examples:
+
+`GAMEMODE|extended`
+
+`GAMEMODE|traitor|wizard|changeling`
+
+
+### TECH_TOTAL
+This value is equal to all the levels of standard techs (non-illegal) added together, gathered from the R&D server. For more information, see `get_research_score()` in `statcollection.dm`
+
+#### Format:
+`TECH_TOTAL|techlevelssum`
+
+#### Example:
+`TECH_TOTAL|9`
+
+
+### BLOOD_SPILLED
+The sum of the volume of all blood lost via `/mob/living/carbon/human/proc/drip()`. As such this only cares about human blood, although there's not a whole lot of other things that bleed as far as I'm aware. Value is in centiliters.
+
+#### Example and format:
+`BLOOD_SPILLED|0`
+
+### CRATES_ORDERED
+Sum of all crates ordered by Supply.
+
+#### Example and format:
+`CRATES_ORDERED|0`
+
+### ARTIFACTS_DISCOVERED
+Sum of all artifacts uncovered.
+
+#### Example and format:
+`ARTIFACTS_DISCOVERED|0`
+
+
+### CREWSCORE
+This is the value calculated and shown at the in-game end of round scoreboard.
+
+#### Example and format:
+`CREWSCORE|2488`
+
+### ESCAPEES
+Sum of people who got off on the shuttle alive.
+
+#### Example and format:
+`ESCAPEES|0`
+
+### NUKED
+Whether or not the station was nuked. `0` is false, `1` is true.
+
+#### Example and format:
+`NUKED|1`
+
+### MOB_DEATH
+A big old log of a mob's death.
+
+#### Format:
+`MOB_DEATH|typepath|special role|timeofdeath|lAssailant|death location x|death locaton y|death location z|mind key|mind name`
+
+#### Example:
+`MOB_DEATH|/mob/living/carbon/monkey|null|782.3|Lorenzo Gibson|102|160|1|null|monkey (735)`
+
+#### Notes:
+ - At time of writing, LAssailant isn't as good as it could be, and is an unreliable indicator of who killed who.
+ - timeofdeath is time since server start (not round start, or world time.)
+
+
+### EXPLOSION
+A log file of an explosion, including all its parameters.
+
+#### Format:
+`EXPLOSION|epicenter_x|epicenter_y|epicenter_z|devastation_range|heavy_impact_range|light_impact_range|max_range`
+
+### CULTSTATS
+A whole conglomeration of cultist-related stats.
+
+#### Format:
+`CULTSTATS|runes written|runes fumbled|runes nulled|num people converted to cult|tomes created|narsie summoned|narsie corpses fed|surviving cultists|deconverted cult members`
+
+#### Example:
+`CULTSTATS|120|5002|3|15|3|1|30|10|2`
+
+
+### XENOSTATS
+A conglomeration of stats related to xenos.
+
+#### Format:
+`XENOSTATS|eggs laid|successful facehugger impregnations|number of facehuggers rebuffed by proper face protection`
+
+#### Example:
+`XENOSTATS|20|5|10`

--- a/code/datums/statistics/stat_blob.dm
+++ b/code/datums/statistics/stat_blob.dm
@@ -17,9 +17,8 @@
 	var/deconverted = 0
 
 /datum/stat_blob/cult/doPostRoundChecks()
-	narsie_summoned = ticker.mode.eldergod ? 1 : 0 // redundant as fuck
 	for(var/datum/mind/M in ticker.minds)
-		if(M.active && istype(M.current, /mob/living/carbon))
+		if(M.active && istype(M.current, /mob/living/carbon) && M.special_role == "Cultist")
 			surviving_cultists++
 
 /datum/stat_blob/cult/writeStats(file)

--- a/code/datums/statistics/stat_blob.dm
+++ b/code/datums/statistics/stat_blob.dm
@@ -1,0 +1,34 @@
+// Because why bloat the main file when I can do this?
+/datum/stat_blob/
+
+/datum/stat_blob/proc/doPostRoundChecks()
+
+/datum/stat_blob/proc/writeStats(file)
+
+/datum/stat_blob/cult
+	var/runes_written = 0
+	var/runes_fumbled = 0
+	var/runes_nulled = 0
+	var/tomes_created = 0
+	var/converted = 0
+	var/narsie_summoned = 0
+	var/narsie_corpses_fed = 0
+	var/surviving_cultists = 0
+	var/deconverted = 0
+
+/datum/stat_blob/cult/doPostRoundChecks()
+	narsie_summoned = ticker.mode.eldergod ? 1 : 0 // redundant as fuck
+	for(var/datum/mind/M in ticker.minds)
+		if(M.active && istype(M.current, /mob/living/carbon))
+			surviving_cultists++
+
+/datum/stat_blob/cult/writeStats(file)
+	file << "CULTSTATS|[runes_written]|[runes_fumbled]|[runes_nulled]|[converted]|[tomes_created]|[narsie_summoned]|[narsie_corpses_fed]|[surviving_cultists]|[deconverted]"
+
+/datum/stat_blob/xeno/
+	var/eggs_laid = 0
+	var/faces_hugged = 0 //this actually should only count people impregnated, I just like the name
+	var/proper_head_protection = 0 //whenever a facehugger fails to impregnate someone
+
+/datum/stat_blob/xeno/writeStats(file)
+	file << "XENOSTATS|[eggs_laid]|[faces_hugged]|[proper_head_protection]"

--- a/code/datums/statistics/statcollection.dm
+++ b/code/datums/statistics/statcollection.dm
@@ -21,7 +21,8 @@
 #define STAT_OUTPUT_DIR "data/statfiles/"
 
 /datum/stat_collector
-	var/enabled = 1 // unused
+	// UNUSED
+	// var/enabled = 1
 	var/human_death_stats = list()
 	var/death_stats = list()
 	var/explosion_stats = list()
@@ -112,6 +113,7 @@
 
 /datum/stat_collector/proc/add_death_stat(var/mob/M)
 	//if(istype(M, /mob/living/carbon/human)) return 0
+	if(ticker.current_state != GAME_STATE_PLAYING) return 0 // We don't care about pre-round or post-round deaths.
 	var/datum/stat/death_stat/d = new
 	d.time_of_death = M.timeofdeath
 	d.last_attacked_by = M.LAssailant
@@ -179,7 +181,7 @@
 
 // This guy writes the first line(s) of the stat file! Woo!
 /datum/stat_collector/proc/Write_Header(statfile)
-	statfile << "STATLOG_START|[STAT_OUTPUT_VERSION]|[map.nameLong]|[round_start_time]"
+	statfile << "STATLOG_START|[STAT_OUTPUT_VERSION]|[map.nameLong]|[num2text(round_start_time, 30)]|[num2text(world.realtime, 30)]"
 	statfile << "MASTERMODE|[master_mode]" // sekrit, or whatever else was decided as the 'actual' mode on round start.
 	if(istype(ticker.mode, /datum/game_mode/mixed))
 		var/datum/game_mode/mixed/mixy = ticker.mode
@@ -213,7 +215,7 @@
 	statfile << "NUKED|[nuked]"
 
 	for(var/datum/stat/death_stat/D in death_stats)
-		statfile << "MOB_DEATH|[D.mob_typepath]|[D.special_role]|[D.time_of_death]|[D.last_attacked_by]|[D.death_x]|[D.death_y]|[D.death_z]|[D.key]|[D.realname]"
+		statfile << "MOB_DEATH|[D.mob_typepath]|[D.special_role]|[num2text(D.time_of_death, 30)]|[D.last_attacked_by]|[D.death_x]|[D.death_y]|[D.death_z]|[D.key]|[D.realname]"
 	for(var/datum/stat/explosion_stat/E in explosion_stats)
 		statfile << "EXPLOSION|[E.epicenter_x]|[E.epicenter_y]|[E.epicenter_z]|[E.devastation_range]|[E.heavy_impact_range]|[E.light_impact_range]|[E.max_range]"
 	for(var/datum/stat/uplink_purchase_stat/U in uplink_purchases)

--- a/code/datums/statistics/statcollection.dm
+++ b/code/datums/statistics/statcollection.dm
@@ -1,0 +1,239 @@
+/* THE GREAT BIG STATISTICS COLLECTION project
+	The objective of all this shitcode is to collect important/interesting events in a round
+	and write it to a really dumb text file, which will then be processed by an external server,
+	whichi will generate a pretty, web-viewable version (if I get my shit together)
+	by the public.
+
+	Gamemode-specific stat collection is separated off into its own files because why not
+
+
+	stat_collector is the nerve center, everything else is just there to store data until
+	round end.
+*/
+
+// Important things to store stats on that aren't located here:
+// ticker.mode, actual gamemode
+// master_mode, i.e. secret, mixed
+
+// To ensure that if output file syntax is changed, we will still be able to process
+// new and old files
+#define STAT_OUTPUT_VERSION "1.0"
+#define STAT_OUTPUT_DIR "data/statfiles/"
+
+/datum/stat_collector
+	var/enabled = 1 // unused
+	var/human_death_stats = list()
+	var/death_stats = list()
+	var/explosion_stats = list()
+	var/uplink_purchases = list()
+	var/badass_bundles = list()
+	// Blood spilled in c.liters
+	var/blood_spilled = 0
+	var/crates_ordered = 0
+	var/artifacts_discovered = 0
+	var/narsie_corpses_fed = 0
+	var/escapees = 0
+	var/crewscore = 0
+	var/nuked = 0
+
+	// Stat blobs
+	var/datum/stat_blob/cult/cult = new
+	var/datum/stat_blob/xeno/xeno = new
+
+	var/gamemode = "UNSET"
+	var/mixed_gamemodes = null
+	var/round_start_time = null
+
+/datum/stat/death_stat
+	var/mob_typepath = "null"
+	var/death_x = 0
+	var/death_y = 0
+	var/death_z = 0
+	var/special_role = "null"
+	var/key = "null"
+	var/time_of_death = 0
+	var/last_attacked_by = "null"
+	var/realname = "null"
+
+/datum/stat/uplink_purchase_stat
+	var/itemtype = "null"
+	var/bundle = "null"
+	var/purchaser_key = "null"
+	var/purchaser_name = "null"
+	var/purchaser_is_traitor = 1
+
+/datum/stat/uplink_badass_bundle_stat
+	var/obj/contains = list()
+	var/purchaser_key = "null"
+	var/purchaser_name = "null"
+	var/purchaser_is_traitor = 1
+
+/datum/stat_collector/proc/uplink_purchase(var/datum/uplink_item/bundle, var/obj/resulting_item, var/mob/user )
+	var/was_traitor = 1
+	if(user.mind && user.mind.special_role != "traitor")
+		was_traitor = 0
+
+	if(istype(bundle, /datum/uplink_item/badass/bundle))
+		var/datum/stat/uplink_badass_bundle_stat/BAD = new
+		var/obj/item/weapon/storage/box/B = resulting_item
+		for(var/obj/O in B.contents)
+			BAD.contains += O.type
+		BAD.purchaser_key = user.mind.key
+		BAD.purchaser_name = user.mind.name
+		BAD.purchaser_is_traitor = was_traitor
+		badass_bundles += BAD
+	else
+		var/datum/stat/uplink_purchase_stat/UP = new
+		if(istype(bundle, /datum/uplink_item/badass/random))
+			UP.itemtype = resulting_item.type
+		else
+			UP.itemtype = bundle.item
+		UP.bundle = bundle.type
+		UP.purchaser_key = user.mind.key
+		UP.purchaser_name = user.mind.name
+		UP.purchaser_is_traitor = was_traitor
+		uplink_purchases += UP
+
+// /datum/stat_collector/proc/add_human_death(var/mob/living/carbon/human/M, var/datum/mind/B, timeofdeath)
+// 	var/datum/stat/death_stat/d = new
+// 	d.time_of_death = timeofdeath // We don't have a mob time of death yet since that's done after this proc call and I can't change that.
+// 	d.last_attacked_by = M.LAssailant
+// 	d.death_x = M.x
+// 	d.death_y = M.y
+// 	d.death_z = M.z
+// 	d.mob_typepath = M.type
+// 	if(B)
+// 		d.special_role = B.special_role
+// 		if(B.key)
+// 			d.key = B.key
+// 		if(B.name)
+// 			d.realname = B.name
+// 	stat_collection.human_death_stats += d
+
+/datum/stat_collector/proc/add_death_stat(var/mob/M)
+	//if(istype(M, /mob/living/carbon/human)) return 0
+	var/datum/stat/death_stat/d = new
+	d.time_of_death = M.timeofdeath
+	d.last_attacked_by = M.LAssailant
+	d.death_x = M.x
+	d.death_y = M.y
+	d.death_z = M.z
+	d.mob_typepath = M.type
+	d.realname = M.name
+	if(M.mind)
+		if(M.mind.special_role && M.mind.special_role != "") d.special_role = M.mind.special_role
+		if(M.mind.key) d.key = M.mind.key
+		if(M.mind.name) d.realname = M.mind.name
+	stat_collection.death_stats += d
+
+/datum/stat/explosion_stat
+	var/epicenter_x = 0
+	var/epicenter_y = 0
+	var/epicenter_z = 0
+	var/devastation_range = 0
+	var/heavy_impact_range = 0
+	var/light_impact_range = 0
+	var/max_range = 0
+
+/datum/stat_collector/proc/add_explosion_stat(turf/epicenter, const/dev_range, const/hi_range, const/li_range, mx_range)
+	var/datum/stat/explosion_stat/e = new
+	e.epicenter_x = epicenter.x
+	e.epicenter_y = epicenter.y
+	e.epicenter_z = epicenter.z
+	e.devastation_range = dev_range
+	e.heavy_impact_range = hi_range
+	e.light_impact_range = li_range
+	e.max_range = mx_range
+	stat_collection.explosion_stats += e
+
+/* Maybe not necessary, actually, since all survivors will be accessible on round end
+/datum/stat/survivor
+*/
+
+/datum/stat_collector/proc/get_research_score()
+	var/obj/machinery/r_n_d/server/server = null
+	var/tech_level_total
+	for(var/obj/machinery/r_n_d/server/serber in machines)
+		if(serber.name == "Core R&D Server")
+			server=serber
+			break
+	if(!server)
+		return
+	for(var/datum/tech/T in tech_list)
+		if(T.goal_level==0) // Ignore illegal tech, etc
+			continue
+		var/datum/tech/KT  = locate(T.type, server.files.known_tech)
+		tech_level_total += KT.level
+	return tech_level_total
+
+/datum/stat_collector/proc/antagCheck(statfile)
+	for(var/datum/mind/Mind in ticker.minds)
+		for(var/datum/objective/objective in Mind.objectives)
+			if(objective.explanation_text == "Free Objective")
+				statfile << "ANTAG_OBJ|[Mind.name]|[Mind.key]|[Mind.special_role]|FREE_OBJ"
+			else if (objective.target)
+				statfile << "ANTAG_OBJ|[Mind.name]|[Mind.key]|[Mind.special_role]|[objective.type]|[objective.target]|[objective.target.assigned_role]|[objective.target.name]|[objective.check_completion()]|[objective.explanation_text]"
+			else
+				statfile << "ANTAG_OBJ|[Mind.name]|[Mind.key]|[Mind.special_role]|[objective.type]|[objective.check_completion()]|[objective.explanation_text]"
+
+
+// This guy writes the first line(s) of the stat file! Woo!
+/datum/stat_collector/proc/Write_Header(statfile)
+	statfile << "STATLOG_START|[STAT_OUTPUT_VERSION]|[map.nameLong]|[round_start_time]"
+	statfile << "MASTERMODE|[master_mode]" // sekrit, or whatever else was decided as the 'actual' mode on round start.
+	if(istype(ticker.mode, /datum/game_mode/mixed))
+		var/datum/game_mode/mixed/mixy = ticker.mode
+		var/T = "GAMEMODE"
+		for(var/datum/game_mode/GM in mixy.modes)
+			T += "|[GM.name]"
+		statfile << T
+	else statfile << "GAMEMODE|[ticker.mode.name]"
+
+/datum/stat_collector/proc/Write_Footer(statfile)
+	statfile << "WRITE_COMPLETE" // because I'd like to know if a write was interrupted and therefore invalid
+
+/datum/stat_collector/proc/Process()
+	var/filename_date = time2text(round_start_time, "YYYY.DD.MM")
+	var/roundnum = 1
+	// Iterate until we have an unused file.
+	while(fexists(file(("[STAT_OUTPUT_DIR]statistics_[filename_date].[roundnum].txt"))))
+		roundnum++
+	var/statfile = file("[STAT_OUTPUT_DIR]statistics_[filename_date].[roundnum].txt")
+
+	world << "Writing statistics to file"
+
+	var/start_time = world.realtime
+	Write_Header(statfile)
+	statfile << "TECH_TOTAL|[get_research_score()]"
+	statfile << "BLOOD_SPILLED|[blood_spilled]"
+	statfile << "CRATES_ORDERED|[crates_ordered]"
+	statfile << "ARTIFACTS_DISCOVERED|[artifacts_discovered]"
+	statfile << "CREWSCORE|[crewscore]"
+	statfile << "ESCAPEES|[escapees]"
+	statfile << "NUKED|[nuked]"
+
+	for(var/datum/stat/death_stat/D in death_stats)
+		statfile << "MOB_DEATH|[D.mob_typepath]|[D.special_role]|[D.time_of_death]|[D.last_attacked_by]|[D.death_x]|[D.death_y]|[D.death_z]|[D.key]|[D.realname]"
+	for(var/datum/stat/explosion_stat/E in explosion_stats)
+		statfile << "EXPLOSION|[E.epicenter_x]|[E.epicenter_y]|[E.epicenter_z]|[E.devastation_range]|[E.heavy_impact_range]|[E.light_impact_range]|[E.max_range]"
+	for(var/datum/stat/uplink_purchase_stat/U in uplink_purchases)
+		statfile << "UPLINK_ITEM|[U.purchaser_key]|[U.purchaser_name]|[U.purchaser_is_traitor]|[U.bundle]|[U.itemtype]"
+	for(var/datum/stat/uplink_badass_bundle_stat/B in badass_bundles)
+		var/o 	= 		"BADASS_BUNDLE|[B.purchaser_key]|[B.purchaser_name]|[B.purchaser_is_traitor]"
+		for(var/S in B.contains)
+			o += "|[S]"
+		statfile << "[o]"
+
+	cult.doPostRoundChecks()
+	cult.writeStats(statfile)
+
+	xeno.doPostRoundChecks()
+	xeno.writeStats(statfile)
+
+	antagCheck(statfile)
+
+	Write_Footer(statfile)
+	world << "Statistics written to file in [(start_time - world.realtime)/10] seconds." // I think that's right?
+
+
+// TODO write all living mobs to DB

--- a/code/datums/statistics/statcollection.dm
+++ b/code/datums/statistics/statcollection.dm
@@ -113,7 +113,7 @@
 
 /datum/stat_collector/proc/add_death_stat(var/mob/M)
 	//if(istype(M, /mob/living/carbon/human)) return 0
-	if(ticker.current_state != GAME_STATE_PLAYING) return 0 // We don't care about pre-round or post-round deaths.
+	if(ticker.current_state != 3) return 0 // We don't care about pre-round or post-round deaths. 3 is GAME_STATE_PLAYING which is undefined I guess
 	var/datum/stat/death_stat/d = new
 	d.time_of_death = M.timeofdeath
 	d.last_attacked_by = M.LAssailant

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -88,6 +88,7 @@ var/list/uplink_items = list()
 			var/mob/living/carbon/human/A = user
 			A.put_in_any_hand_if_possible(I)
 			U.purchase_log += {"[user] ([user.ckey]) bought <img src="logo_[tempstate].png"> [name] for [cost]."}
+			stat_collection.uplink_purchase(src, I, user)
 			if(user.mind)
 				user.mind.uplink_items_bought += {"<img src="logo_[tempstate].png"> [bundlename]"}
 				user.mind.spent_TC += cost

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -447,6 +447,7 @@
 				to_chat(M, "<FONT size = 3>[cult_mind.current] looks like they just reverted to their old faith!</FONT>")
 		if(log)
 			log_admin("[cult_mind.current] ([ckey(cult_mind.current.key)] has been deconverted from the cult")
+			stat_collection.cult.deconverted++
 
 /datum/game_mode/proc/update_all_cult_icons()
 	spawn(0)

--- a/code/game/gamemodes/cult/narsie.dm
+++ b/code/game/gamemodes/cult/narsie.dm
@@ -188,6 +188,7 @@ var/global/list/narsie_list = list()
 				return 0
 
 			M.cultify()
+			stat_collection.cult.narsie_corpses_fed++
 
 	//ITEM PROCESSING
 		else if (istype(A, /obj/))

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -82,6 +82,7 @@ var/global/list/rune_list = list() // HOLY FUCK WHY ARE WE LOOPING THROUGH THE W
 		if(AI.client)
 			AI.client.images += blood_image
 	rune_list.Add(src)
+	stat_collection.cult.runes_written++
 
 /obj/effect/rune/Destroy()
 	if(istype(ajourn))
@@ -110,6 +111,7 @@ var/global/list/rune_list = list() // HOLY FUCK WHY ARE WE LOOPING THROUGH THE W
 	else if(istype(I, /obj/item/weapon/nullrod))
 		to_chat(user, "<span class='notice'>You disrupt the vile magic with the deadening field of the null rod!</span>")
 		qdel(src)
+		stat_collection.cult.runes_nulled++
 		return
 	return
 
@@ -185,6 +187,7 @@ var/global/list/rune_list = list() // HOLY FUCK WHY ARE WE LOOPING THROUGH THE W
 
 
 /obj/effect/rune/proc/fizzle()
+	stat_collection.cult.runes_fumbled++
 	if(istype(src,/obj/effect/rune))
 		usr.say(pick("B'ADMINES SP'WNIN SH'T","IC'IN O'OC","RO'SHA'M I'SA GRI'FF'N ME'AI","TOX'IN'S O'NM FI'RAH","IA BL'AME TOX'IN'S","FIR'A NON'AN RE'SONA","A'OI I'RS ROUA'GE","LE'OAN JU'STA SP'A'C Z'EE SH'EF","IA PT'WOBEA'RD, IA A'DMI'NEH'LP"))
 	else

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -156,6 +156,7 @@
 	else
 		new /obj/item/weapon/tome(usr.loc)
 	qdel(src)
+	stat_collection.cult.tomes_created++
 	return
 
 /////////////////////////////////////////THIRD RUNE
@@ -197,6 +198,7 @@
 			to_chat(M, "<span class='sinister'>You can now speak and understand the forgotten tongue of the occult.</span>")
 			M.add_language("Cult")
 			log_admin("[usr]([ckey(usr.key)]) has converted [M] ([ckey(M.key)]) to the cult at <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[M.loc.x];Y=[M.loc.y];Z=[M.loc.z]'>([M.loc.x], [M.loc.y], [M.loc.z])</a>")
+			stat_collection.cult.converted++
 			if(M.client)
 				spawn(600)
 					if(M && !M.client)

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -314,6 +314,7 @@
 			summonturfs = list()
 			summoning = 0
 			new /obj/machinery/singularity/narsie/large(src.loc)
+			stat_collection.cult.narsie_summoned = 1
 		return
 
 	currentCountdown--

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -223,6 +223,8 @@ var/global/datum/controller/gameticker/ticker
 		spawn(3000)
 		statistic_cycle() // Polls population totals regularly and stores them in an SQL DB -- TLE
 
+	stat_collection.round_start_time = world.realtime
+
 	return 1
 
 /datum/controller/gameticker

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -186,6 +186,7 @@ var/global/datum/controller/gameticker/ticker
 		for(var/obj in L)
 			if(istype(obj, /obj/effect/landmark/spacepod/random))
 				qdel(obj)
+		stat_collection.death_stats = list() // Get rid of the corpses that spawn on startup.
 		to_chat(world, "<FONT color='blue'><B>Enjoy the game!</B></FONT>")
 //		to_chat(world, sound('sound/AI/welcome.ogg'))// Skie //Out with the old, in with the new. - N3X15
 

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -309,6 +309,7 @@ var/bomb_set
 
 			ticker.mode.station_was_nuked = (off_station<2)	//offstation==1 is a draw. the station becomes irradiated and needs to be evacuated.
 															//kinda shit but I couldn't  get permission to do what I wanted to do.
+			stat_collection.nuked++
 
 			if(!ticker.mode.check_finished())//If the mode does not deal with the nuke going off so just reboot because everyone is stuck as is
 				to_chat(world, "<B>Resetting in 30 seconds!</B>")

--- a/code/game/gamemodes/scoreboard.dm
+++ b/code/game/gamemodes/scoreboard.dm
@@ -468,5 +468,9 @@
 		round_end_info = dat
 		log_game(dat)
 
+		stat_collection.escapees = score["escapees"]
+		stat_collection.crewscore = score["crewscore"]
+		stat_collection.Process()
+
 	src << browse(dat, "window=roundstats;size=1000x600")
 	return

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -42,6 +42,7 @@
 		score["explosions"]++ //For the scoreboard
 
 		var/max_range = max(devastation_range, heavy_impact_range, light_impact_range)
+		stat_collection.add_explosion_stat(epicenter, devastation_range, heavy_impact_range, light_impact_range, max_range)
 //		playsound(epicenter, 'sound/effects/explosionfar.ogg', 100, 1, round(devastation_range*2,1) )
 //		playsound(epicenter, "explosion", 100, 1, round(devastation_range,1) )
 

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -522,6 +522,7 @@ var/list/mechtoys = list(
 		O.orderedby = idname
 		O.account = account
 		supply_shuttle.requestlist += O
+		stat_collection.crates_ordered++
 
 
 		// AUTOFIXED BY fix_string_idiocy.py

--- a/code/global.dm
+++ b/code/global.dm
@@ -388,6 +388,8 @@ var/nanocoins_lastchange = 0
 
 var/minimapinit = 0
 
+var/datum/stat_collector/stat_collection = new
+
 //Hardcore mode
 //When enabled, starvation kills
 var/global/hardcore_mode = 0

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -38,6 +38,7 @@
 
 	living_mob_list -= src
 	dead_mob_list += src
+	stat_collection.add_death_stat(src)
 	for(var/obj/item/I in src)
 		I.OnMobDeath(src)
 	return ..(gibbed)

--- a/code/modules/mob/living/carbon/alien/humanoid/queen.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/queen.dm
@@ -74,6 +74,7 @@
 	if(powerc(75, 1))//Can't plant eggs on spess tiles. That's silly.
 		adjustToxLoss(-75)
 		visible_message("<span class='alien'>[src] has laid an egg!</span>")
+		stat_collection.xeno.eggs_laid++
 		new /obj/effect/alien/egg(loc)
 	return
 

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -140,6 +140,7 @@ var/const/MAX_ACTIVE_TIME = 400
 		var/obj/item/mouth_protection = H.get_body_part_coverage(MOUTH)
 		if(mouth_protection && mouth_protection != H.wear_mask) //can't be protected with your own mask, has to be a hat
 			H.visible_message("<span class='danger'>\The [src] smashes against [H]'s [mouth_protection] !</span>")
+			stat_collection.xeno.proper_head_protection++
 			Die()
 			return 0
 
@@ -182,6 +183,7 @@ var/const/MAX_ACTIVE_TIME = 400
 		target.status_flags |= XENO_HOST
 
 		target.visible_message("<span class='danger'>\The [src] falls limp after violating [target]'s face !</span>")
+		stat_collection.xeno.faces_hugged++
 
 		Die()
 		icon_state = "[initial(icon_state)]_impregnated"

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -162,6 +162,7 @@ var/const/BLOOD_VOLUME_SURVIVE = 122
 
 	vessel.remove_reagent("blood",amt)
 	blood_splatter(src,src)
+	stat_collection.blood_spilled += amt
 
 /****************************************************
 				BLOOD TRANSFERS

--- a/code/modules/research/xenoarchaeology/artifact/artifact.dm
+++ b/code/modules/research/xenoarchaeology/artifact/artifact.dm
@@ -10,6 +10,8 @@
 /datum/artifact_find/New()
 	artifact_detect_range = rand(5,300)
 
+	stat_collection.artifacts_discovered++
+
 	artifact_id = "[pick("kappa","sigma","antaeres","beta","omicron","iota","epsilon","omega","gamma","delta","tau","alpha")]-[rand(100,999)]"
 
 	artifact_find_type = pick(\

--- a/code/world.dm
+++ b/code/world.dm
@@ -141,6 +141,9 @@ var/savefile/panicfile
 		setup_species()
 		setup_shuttles()
 
+		stat_collection.artifacts_discovered = 0 // Because artifacts during generation get counted otherwise!
+		stat_collection.death_stats = list() // Get rid of the corpses that spawn on startup.
+
 	for(var/plugin_type in typesof(/plugin))
 		var/plugin/P = new plugin_type()
 		plugins[P.name] = P

--- a/code/world.dm
+++ b/code/world.dm
@@ -142,7 +142,6 @@ var/savefile/panicfile
 		setup_shuttles()
 
 		stat_collection.artifacts_discovered = 0 // Because artifacts during generation get counted otherwise!
-		stat_collection.death_stats = list() // Get rid of the corpses that spawn on startup.
 
 	for(var/plugin_type in typesof(/plugin))
 		var/plugin/P = new plugin_type()

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -210,6 +210,8 @@
 #include "code\datums\research\research_tree.dm"
 #include "code\datums\research\unlockable.dm"
 #include "code\datums\saycode\speech.dm"
+#include "code\datums\statistics\stat_blob.dm"
+#include "code\datums\statistics\statcollection.dm"
 #include "code\datums\wires\airlock.dm"
 #include "code\datums\wires\alarm.dm"
 #include "code\datums\wires\apc.dm"


### PR DESCRIPTION
## Statistics gathering (and later viewing!)

The goal of this PR is to add in gathering of interesting round statistics for public perusal (via a web interface I'd have to write up after I get all this sorted out) And also because I want to see how many cult victories there actually are instead of just hearing "cult rounds are shit because cult sucks" or "good cult always wins, bad players are to blame" etc.
## Features
- [x] General round statistics
  - [x] Gamemode (even though gamemode means nothing anymore because mixed and adminbus)
  - [x] Map name
    ~~\- [] Total chloral injected into players (maybe)~~
  - [x] Antag 'wins' (traitors succeeded over traitors total, for instance, will be handled frontend-side)
  - [x] Liters of blood spilled (maybe)
  - [x] Scoreboard score
  - [x] Surviving crew member count
- [x] Collects info on mob death, including location and type path of dead mob
- [x] Event and Gamemode-specific code:
  - [x] Cult (runes written, nar-sie summoned y/n, num. of cultists, num. of cultist converts)
  - [x] Traitor things (uplink bundle purchased, actual item recieved in the case of random)
  - [x] Nukeops things (currently only nuke activated y/n because what else should I even track here)
  - [x] Xenos (faces hugged, faces protected, eggs laid)
- [x] Writes everything to a text file because we have no good SQL setup (sockets are dumb, DLLs are dumb)
# MERGE READY, FIRE AWAY

Also, please note that anyone who adds/changes how statfiles are generated should make sure that:
- Their new output matches the current documentation
  **OR**
- Their new output is documented and they increment `STAT_OUTPUT_VERSION` 

This is to prevent whatever parser(s) from incorrectly interpreting data, throwing errors, or whatever the fuck.
