### PR TITLE
Removes abiotic check for sleepers, cryo, body scanner, and DNA scanner.

### DIFF
--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -111,15 +111,10 @@
 
 /obj/machinery/dna_scannernew/proc/eject_occupant(var/exit = loc)
 	src.go_out(exit)
-	for(var/obj/O in src)
-		if(!istype(O,/obj/item/weapon/circuitboard/clonescanner) && \
-		   !istype(O,/obj/item/weapon/stock_parts) && \
-		   !istype(O,/obj/item/stack/cable_coil) && \
-		   O != beaker)
-			O.loc = get_turf(src)//Ejects items that manage to get in there (exluding the components and beaker)
+
 	if(!occupant)
 		for(var/mob/M in src)//Failsafe so you can get mobs out
-			M.loc = get_turf(src)
+			M.forceMove(get_turf(src))
 
 /obj/machinery/dna_scannernew/verb/move_inside()
 	set src in oview(1)
@@ -138,9 +133,9 @@
 	if (src.occupant)
 		to_chat(usr, "<span class='notice'> <B>The scanner is already occupied!</B></span>")
 		return
-	if (usr.abiotic())
+	/*if (usr.abiotic())
 		to_chat(usr, "<span class='notice'> <B>Subject cannot have abiotic items on.</B></span>")
-		return
+		return*/
 	usr.stop_pulling()
 	usr.loc = src
 	usr.reset_view()
@@ -179,9 +174,9 @@
 	var/mob/living/L = O
 	if(!istype(L) || L.locked_to)
 		return
-	if(L.abiotic())
+	/*if(L.abiotic())
 		to_chat(user, "<span class='danger'>Subject cannot have abiotic items on.</span>")
-		return
+		return*/
 	for(var/mob/living/carbon/slime/M in range(1,L))
 		if(M.Victim == L)
 			to_chat(usr, "[L.name] will not fit into the DNA Scanner because they have a slime latched onto their head.")
@@ -241,9 +236,9 @@
 		if (src.occupant)
 			to_chat(user, "<span class='notice'><B>The scanner is already occupied!</B></span>")
 			return
-		if (G.affecting.abiotic())
+		/*if (G.affecting.abiotic())
 			to_chat(user, "<span class='notice'><B>Subject cannot have abiotic items on.</B></span>")
-			return
+			return*/
 		if(G.affecting.locked_to)
 			return
 		put_in(G.affecting)
@@ -283,6 +278,11 @@
 	occupant.reset_view()
 	occupant = null
 	icon_state = "scanner_0"
+
+	for (var/atom/movable/x in src.contents)//Ejects items that manage to get in there (exluding the components and beaker)
+		if((x in component_parts) || (x == src.beaker))
+			continue
+		x.forceMove(src.loc)
 
 	for(dir in cardinal)
 		var/obj/machinery/computer/cloning/C = locate(/obj/machinery/computer/cloning) in get_step(src, dir)
@@ -325,8 +325,6 @@
 
 /obj/machinery/dna_scannernew/blob_act()
 	if(prob(75))
-		for(var/atom/movable/A as mob|obj in src)
-			A.loc = src.loc
 		qdel(src)
 
 /obj/machinery/computer/scan_consolenew

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -260,9 +260,9 @@
 	var/mob/living/L = O
 	if(!istype(L) || L.locked_to)
 		return
-	if(L.abiotic())
+	/*if(L.abiotic())
 		to_chat(user, "<span class='notice'><B>Subject cannot have abiotic items on.</B></span>")
-		return
+		return*/
 	for(var/mob/living/carbon/slime/M in range(1,L))
 		if(M.Victim == L)
 			to_chat(usr, "[L.name] will not fit into the sleeper because they have a slime latched onto their head.")
@@ -449,8 +449,10 @@
 /obj/machinery/sleeper/proc/go_out(var/exit = src.loc)
 	if(!occupant)
 		return 0
-	for(var/obj/O in src)
-		O.loc = src.loc
+	for (var/atom/movable/x in src.contents)
+		if(x in component_parts)
+			continue
+		x.forceMove(src.loc)
 	occupant.forceMove(exit)
 	occupant.reset_view()
 	occupant = null

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -115,9 +115,9 @@
 	var/mob/living/L = O
 	if(!istype(L) || L.locked_to)
 		return
-	if(L.abiotic())
+	/*if(L.abiotic())
 		to_chat(user, "<span class='notice'>Subject cannot have abiotic items on.</span>")
-		return
+		return*/
 	for(var/mob/living/carbon/slime/M in range(1, L))
 		if(M.Victim == L)
 			to_chat(usr, "<span class='notice'>[L] will not fit into \the [src] because they have a slime latched onto their head.</span>")
@@ -194,9 +194,9 @@
 	if(src.occupant)
 		to_chat(usr, "<span class='notice'>\The [src] is already occupied!</span>")
 		return
-	if(usr.abiotic())
+	/*if(usr.abiotic())
 		to_chat(usr, "<span class='notice'>Subject cannot have abiotic items on.</span>")
-		return
+		return*/
 	if(usr.locked_to)
 		return
 	usr.pulling = null
@@ -214,8 +214,10 @@
 /obj/machinery/bodyscanner/proc/go_out(var/exit = loc)
 	if(!src.occupant)
 		return
-	for(var/obj/O in src)
-		O.loc = src.loc
+	for (var/atom/movable/x in src.contents)
+		if(x in component_parts)
+			continue
+		x.forceMove(src.loc)
 
 	src.occupant.forceMove(exit)
 	src.occupant.reset_view()
@@ -261,16 +263,14 @@
 
 	G.affecting.unlock_from()
 
-	if(G.affecting.abiotic())
+	/*if(G.affecting.abiotic())
 		to_chat(user, "<span class='notice'>Subject cannot have abiotic items on.</span>")
-		return
+		return*/
 	var/mob/M = G.affecting
 	M.loc = src
 	M.reset_view()
 	src.occupant = M
 	update_icon()
-	for(var/obj/O in src)
-		O.forceMove(loc)
 	src.add_fingerprint(user)
 	qdel(G)
 	if(!(stat & (BROKEN|NOPOWER)))

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -92,9 +92,9 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 	var/mob/living/L = O
 	if(!istype(L) || L.locked_to)
 		return
-	if(L.abiotic())
+	/*if(L.abiotic())
 		to_chat(user, "<span class='danger'>Subject cannot have abiotic items on.</span>")
-		return
+		return*/
 	for(var/mob/living/carbon/slime/M in range(1,L))
 		if(M.Victim == L)
 			to_chat(usr, "[L.name] will not fit into the cryo cell because they have a slime latched onto their head.")
@@ -422,8 +422,10 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 /obj/machinery/atmospherics/unary/cryo_cell/proc/go_out(var/exit = src.loc)
 	if(!(occupant))
 		return 0
-	//for(var/obj/O in src)
-	//	O.loc = loc
+	for (var/atom/movable/x in src.contents)
+		if((x in component_parts) || (x == src.beaker))
+			continue
+		x.forceMove(src.loc)
 	if(exit == loc)
 		occupant.forceMove(get_step(loc, SOUTH))	//this doesn't account for walls or anything, but i don't forsee that being a problem.
 	else
@@ -442,9 +444,9 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 	if (occupant)
 		to_chat(usr, "<span class='danger'>The cryo cell is already occupied!</span>")
 		return
-	if (M.abiotic())
+	/*if (M.abiotic())
 		to_chat(usr, "<span class='warning'>Subject may not have abiotic items on.</span>")
-		return
+		return*/
 	if(M.locked_to)
 		M.locked_to.unlock_atom(M)
 	if(!node)

--- a/code/game/machinery/kitchen/gibber.dm
+++ b/code/game/machinery/kitchen/gibber.dm
@@ -215,8 +215,10 @@ obj/machinery/gibber/New()
 /obj/machinery/gibber/proc/go_out()
 	if (!src.occupant)
 		return
-	for(var/obj/O in src)
-		O.loc = src.loc
+	for (var/atom/movable/x in src.contents)
+		if(x in component_parts)
+			continue
+		x.forceMove(src.loc)
 	if (src.occupant.client)
 		src.occupant.client.eye = src.occupant.client.mob
 		src.occupant.client.perspective = MOB_PERSPECTIVE
@@ -361,4 +363,3 @@ obj/machinery/gibber/New()
 				O.New(Tx,i)
 		src.operating = 0
 		update_icon()
-

--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -42,7 +42,7 @@
 	if(!istype(target))
 		return
 	if(target.abiotic())
-		occupant_message("<span class='notice'><B>Subject cannot have abiotic items on.</B></span>")
+		occupant_message("<span class='notice'><B>Subject cannot have abiotic items on.</B></span>") //Leaving this one in for balance concerns
 	if(target.locked_to)
 		occupant_message("[target] will not fit into the sleeper because they are buckled to [target.locked_to].")
 		return
@@ -93,6 +93,9 @@
 	occupant = null
 	pr_mech_sleeper.stop()
 	set_ready_state(1)
+
+	chassis.empty_bad_contents()
+	
 	return
 
 /obj/item/mecha_parts/mecha_equipment/tool/sleeper/detach()

--- a/html/changelogs/9600bauds_abiotic.yml
+++ b/html/changelogs/9600bauds_abiotic.yml
@@ -1,0 +1,35 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general adding of nice things)
+#   rscadd (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: 9600bauds
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+changes: 
+  - tweak: "Sleepers, DNA scanners, Body scanners, and Cryo pods now allow patients to have \"abiotic\" items in their hands. Items that get trapped inside the machine (dropped by the patient while inside) will just get ejected together with the patient."


### PR DESCRIPTION
Apparently the only reason why we even had this was that long, long, LONG ago, people could drop things inside sleepers and those things would get stuck inside the sleeper's contents, and no coder was smart enough to write a for check to spit out the bad contents.

Anyone that has played Medical can attest to the abiotic check being a pain when you're trying to scan the miner who broke his hand and you have to disarm his other hand just to put him inside the body scanner.

<Ririchiyo> if you guys actually want people to work on that kind of stuff people need to stop mucking around with files related to it
