### PR TITLE
Removes the Debug and Server tab for non-admins

### DIFF
--- a/code/controllers/garbage.dm
+++ b/code/controllers/garbage.dm
@@ -6,13 +6,20 @@
 var/list/gc_hard_del_types = new
 var/datum/garbage_collector/garbageCollector
 var/soft_dels = 0
-/client/verb/gc_dump_hdl()
+
+/client/proc/gc_dump_hdl()
 	set name = "(GC) Hard Del List"
-	set desc = "List types that are hard del()'d by the GC."
+	set desc = "List types that fail to soft del and are hard del()'d by the GC."
 	set category = "Debug"
 
-	for(var/A in gc_hard_del_types)
-		to_chat(usr, "[A] = [gc_hard_del_types[A]]")
+	var/list/L = list()
+	L += "<b>Garbage Collector Forced Deletions in this round</b><br>"
+	for(var/A in ghdel_profiling)
+		L += "<br>[A] = [gc_hard_del_types[A]]"
+	if(L.len == 1)
+		to_chat(usr, "No garbage collector deletions this round")
+		return
+	usr << browse(list2text(L),"window=harddellogs")
 
 /datum/garbage_collector
 	var/list/queue = new

--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -514,7 +514,7 @@
 //Fake our own death and fully heal. You will appear to be dead but regenerate fully after a short delay.
 /mob/verb/check_mob_list()
 	set name = "(Mobs) Check Mob List"
-	set category = "Debug"
+	set hidden = 1
 	var/yes = 0
 	if(src in mob_list)
 		yes = 1

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -12,6 +12,7 @@ var/list/admin_verbs_default = list(
 //	/client/proc/deadchat				/*toggles deadchat on/off*/
 	)
 var/list/admin_verbs_admin = list(
+	/client/proc/set_base_turf,
 	/client/proc/player_panel,			/*shows an interface for all players, with links to various panels (old style)*/
 	/client/proc/player_panel_new,		/*shows an interface for all players, with links to various panels*/
 	/client/proc/invisimin,				/*allows our mob to go invisible/visible*/
@@ -144,6 +145,7 @@ var/list/admin_verbs_server = list(
 	/client/proc/dump_chemreactions,
 	)
 var/list/admin_verbs_debug = list(
+	/client/proc/gc_dump_hdl,
 	/client/proc/getSchedulerContext,
 	/client/proc/cmd_admin_list_open_jobs,
 	/proc/getbrokeninhands,
@@ -271,7 +273,8 @@ var/list/admin_verbs_hideable = list(
 	/client/proc/enable_debug_verbs,
 	/client/proc/mob_list,
 	/proc/possess,
-	/proc/release
+	/proc/release,
+	/client/proc/gc_dump_hdl
 	)
 var/list/admin_verbs_mod = list(
 	/client/proc/cmd_admin_pm_context,	/*right-click adminPM interface*/
@@ -320,6 +323,7 @@ var/list/admin_verbs_mod = list(
 		admin_verbs_rejuv,
 		admin_verbs_sounds,
 		admin_verbs_spawn,
+		admin_verbs_mod,
 		/*Debug verbs added by "show debug verbs"*/
 		/client/proc/Cell,
 		/client/proc/pdiff,
@@ -343,6 +347,8 @@ var/list/admin_verbs_mod = list(
 		/client/proc/splash,
 		/client/proc/cmd_admin_areatest,
 		/client/proc/readmin,
+		/client/proc/nanomapgen_DumpImage,
+		/client/proc/nanomapgen_DumpImageAll
 		)
 
 /client/proc/hide_most_verbs()//Allows you to keep some functionality while hiding some verbs
@@ -959,17 +965,17 @@ var/list/admin_verbs_mod = list(
 
 	var/mob/winner = input("Who's a winner?", "Achievement Winner", null) as null|anything in player_list
 	if(!winner)	return
-	
+
 	var/name = input("What will you call your achievement?", "Achievement Winner", "New Achievement", null) as null|text
 	if(!name) return
-	
+
 	var/desc = input("What description will you give it?", "Achievement Description", "You Win", null) as null|text
 	if(!desc) return
-	
+
 	if(istype(winner, /mob/living))
 		achoice = alert("Give our winner his own trophy?","Achievement Trophy", "Confirm", "Cancel")
 		if(achoice == "Cancel") return
-		
+
 	var/glob = alert("Announce the achievement globally? (Beware! Ruins immersion!)", "Last Question", "No!","Yes!")
 
 	if(achoice == "Confirm")

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -165,6 +165,8 @@ var/intercom_range_display_status = 0
 	src.verbs += /client/proc/Test_ZAS_Connection
 	src.verbs += /client/proc/SDQL2_query
 	src.verbs += /client/proc/check_sim_unsim
+	src.verbs += /client/proc/nanomapgen_DumpImage
+	src.verbs += /client/proc/nanomapgen_DumpImageAll
 	//src.verbs += /client/proc/cmd_admin_rejuvenate
 
 	feedback_add_details("admin_verb","mDV") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/html_interface/map/adv_sec/adv_camera.dm
+++ b/code/modules/html_interface/map/adv_sec/adv_camera.dm
@@ -30,9 +30,11 @@
 	return 1
 
 var/global/datum/interactive_map/camera/adv_camera = new
+/*
 /client/verb/lookatdatum()
 	set category = "Debug"
 	debug_variables(adv_camera)
+*/
 
 /datum/interactive_map/camera
 	var/list/zlevel_data

--- a/code/modules/nano/nanomapgen.dm
+++ b/code/modules/nano/nanomapgen.dm
@@ -16,11 +16,11 @@
 //Call these procs to dump your world to a series of image files (!!)
 //NOTE: Does not explicitly support non 32x32 icons or stuff with large pixel_* values, so don't blame me if it doesn't work perfectly
 
-/mob/verb/nanomapgen_DumpImage()
-	set category = "Server"
+/client/proc/nanomapgen_DumpImage()
+	set category = "Mapping"
 	set name = "Generate NanoUI Map"
 
-	if(!src.client.holder)
+	if(!holder)
 		to_chat(src, "Only administrators may use this command.")
 		return
 	if(alert("Sure you want to do this? It will cause a lot of lag", "generate maps", "Yes", "No") == "No")
@@ -30,11 +30,11 @@
 	var/turf/T = get_turf(src)
 	nanomapgen_DumpTile(1,1, T.z)
 
-/mob/verb/nanomapgen_DumpImageAll()
-	set category = "Server"
+/client/proc/nanomapgen_DumpImageAll()
+	set category = "Mapping"
 	set name = "Generate all NanoUI Maps"
 
-	if(!src.client.holder)
+	if(!holder)
 		to_chat(src, "Only administrators may use this command.")
 		return
 	if(alert("Sure you want to do this? It will cause a lot of lag", "generate maps", "Yes", "No") == "No")
@@ -44,7 +44,7 @@
 	//var/turf/T = get_turf(src)
 	nanomapgen_DumpTile(allz = 1)
 
-/mob/proc/nanomapgen_DumpTile(var/startX = 1, var/startY = 1, var/currentZ = 1, var/endX = -1, var/endY = -1, var/allz = 0)
+/client/proc/nanomapgen_DumpTile(var/startX = 1, var/startY = 1, var/currentZ = 1, var/endX = -1, var/endY = -1, var/allz = 0)
 
 
 	if(currentZ == 2)

--- a/maps/_map.dm
+++ b/maps/_map.dm
@@ -146,7 +146,7 @@ proc/get_base_turf(var/z)
 	var/datum/zLevel/L = map.zLevels[z]
 	return L.base_turf
 
-/client/verb/set_base_turf()
+/client/proc/set_base_turf()
 
 
 	set category = "Debug"


### PR DESCRIPTION
Deals with the 6 or so verbs that show up when you aren't an admin

1. Both nano map generators have been moved to mapping (debug verbs) tab so that they aren't seen by everyone needlessly.

3. The hard del() checking proc was fixed (it did NOTHING for months), improved, and moved to debug verbs as well

4. The check mob list is now hidden, can still be accessed by typing the verb with . infront of it in case it is necessary

5. The debug verb for cameras, view datum, is commented out because it's debug code for testing a specific thing

6. Set base turf given to admins instead of being a verb for everyone because why wouldn't it be

7. Fixes a bug where admin verbs of mod level weren't being removed even when de-adminned.