### PR TITLE
Fixes #6950

### DIFF
--- a/code/datums/shuttle.dm
+++ b/code/datums/shuttle.dm
@@ -582,7 +582,7 @@
 
 		linked_area.contents.Add(new_turf)
 		new_turf.change_area(old_area,linked_area)
-		new_turf.ChangeTurf(old_turf.type)
+		new_turf.ChangeTurf(old_turf.type, allow = 1)
 		new_turfs[C] = new_turf
 
 		//***Remove old turf from shuttle's area****
@@ -667,7 +667,7 @@
 
 		if(D && istype(D)) replacing_turf_type = D.base_turf_type
 
-		old_turf.ChangeTurf(replacing_turf_type)
+		old_turf.ChangeTurf(replacing_turf_type, allow = 1)
 
 		if(D && istype(D))
 			if(D.base_turf_icon)

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -245,5 +245,5 @@
 /turf/space/singularity_act()
 	return
 
-/turf/space/ChangeTurf(var/turf/N, var/tell_universe=1, var/force_lighting_update = 0)
-	return ..(N, tell_universe, 1)
+/turf/space/ChangeTurf(var/turf/N, var/tell_universe=1, var/force_lighting_update = 0, var/allow = 1)
+	return ..(N, tell_universe, 1, allow)

--- a/code/game/turfs/space/transit.dm
+++ b/code/game/turfs/space/transit.dm
@@ -28,6 +28,8 @@
 	if(icon_state != "black")
 		icon_state = "speedspace_[dira]_[i]"
 
+/turf/space/transit/ChangeTurf(var/turf/N, var/tell_universe=1, var/force_lighting_update = 0, var/allow = 0)
+	. = ..()
 
 //Overwrite because we dont want people building rods in space.
 /turf/space/transit/attackby(obj/O as obj, mob/user as mob)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -286,8 +286,8 @@
 		L = null
 
 //Creates a new turf
-/turf/proc/ChangeTurf(var/turf/N, var/tell_universe=1, var/force_lighting_update = 0)
-	if (!N)
+/turf/proc/ChangeTurf(var/turf/N, var/tell_universe=1, var/force_lighting_update = 0, var/allow = 1)
+	if (!N || !allow)
 		return
 
 #ifdef ENABLE_TRI_LEVEL


### PR DESCRIPTION
By adding another argument to changeturf to specially allow changeturf to be called on hyperspace transit turfs, we prevent anything but shuttles changing the turf of these hyperspace transit turfs. Fixing the issue by preventing this kind of thing from being changed.