### PR TITLE
Fix missing check that allowed to create regular walls from reinforced girders

### DIFF
--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -131,6 +131,8 @@
 		var/obj/item/stack/sheet/S = W
 		switch(S.type)
 			if(/obj/item/stack/sheet/metal, /obj/item/stack/sheet/metal/cyborg)
+				if(state) //We are trying to finish a reinforced girder with regular metal
+					return
 				if(!anchored)
 					if(S.amount < 2)
 						return


### PR DESCRIPTION
I guess that has been broken for this long. Certainly this is not the first time someone accidentally tries to finish a reinforced girder with metal ?

Fixes #7032
