### PR TITLE
Nerfs external blood loss, slays relative pathing

### DIFF
--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -1,9 +1,12 @@
 /****************************************************
 				BLOOD SYSTEM
 ****************************************************/
+#define BLOODLOSS_SPEED_MULTIPLIER 0.75
+
 //Blood levels
 var/const/BLOOD_VOLUME_MAX = 560
 var/const/BLOOD_VOLUME_SAFE = 501
+var/const/BLOOD_VOLUME_WARN = 392
 var/const/BLOOD_VOLUME_OKAY = 336
 var/const/BLOOD_VOLUME_BAD = 224
 var/const/BLOOD_VOLUME_SURVIVE = 122
@@ -89,32 +92,41 @@ var/const/BLOOD_VOLUME_SURVIVE = 122
 					//update_body()
 					var/word = pick("dizzy","woosey","faint")
 					to_chat(src, "<span class='danger'>You feel [word].</span>")
-				if(prob(1))
-					var/word = pick("dizzy","woosey","faint")
-					to_chat(src, "<span class='danger'>You feel [word].</span>")
+				if(blood_volume > BLOOD_VOLUME_WARN)
+					if(prob(1))
+						var/word = pick("dizzy","woosey","faint")
+						to_chat(src, "<span class='danger'>You feel [word].</span>")
+				else
+					if(prob(3))
+						var/word = pick("dizzy","woosey","faint")
+						to_chat(src, "<span class='danger'>You very [word].</span>")
 				if(oxyloss < 20)
 					oxyloss += 2
 			if(BLOOD_VOLUME_BAD to BLOOD_VOLUME_OKAY)
 				if(!pale)
 					pale = 1
 					//update_body()
-				eye_blurry += 6
-				if(oxyloss < 50)
-					oxyloss += 5
+				eye_blurry = max(eye_blurry,2)
+				if(oxyloss < 40)
+					oxyloss += 3
 				oxyloss += 3
 				if(prob(15))
-					Paralyse(rand(1,3))
+					Paralyse(1)
 					var/word = pick("dizzy","woosey","faint")
 					to_chat(src, "<span class='danger'>You feel extremely [word].</span>")
 			if(BLOOD_VOLUME_SURVIVE to BLOOD_VOLUME_BAD)
 				if(!pale)
 					pale = 1
 					//update_body()
+				eye_blurry = max(eye_blurry,4)
+				if(oxyloss < 60)
+					oxyloss += 5
 				oxyloss += 5
 				toxloss += 1
 				if(prob(15))
+					Paralyse(rand(1,3))
 					var/word = pick("dizzy","woosey","faint")
-					to_chat(src, "<span class='danger'>You feel extremely [word].</span>")
+					to_chat(src, "<span class='danger'>You feel deathly [word].</span>")
 			if(0 to BLOOD_VOLUME_SURVIVE)
 				// Kill then pretty fast, but don't overdo it
 				// I SAID DON'T OVERDO IT
@@ -147,7 +159,12 @@ var/const/BLOOD_VOLUME_SURVIVE = 122
 			if(temp.status & ORGAN_DESTROYED && !(temp.status & ORGAN_GAUZED) && !temp.amputated)
 				blood_max += 20 //Yer missing a fucking limb.
 			if (temp.open)
-				blood_max += 2  //Yer stomach is cut open
+				blood_max += 2 //Yer stomach is cut open
+			blood_max = blood_max * BLOODLOSS_SPEED_MULTIPLIER
+			if(lying)
+				blood_max = blood_max * 0.7
+			/*if(reagents.has_reagent("inaprovaline"))
+				blood_max = blood_max * 0.7*/
 		drip(blood_max)
 
 //Makes a blood drop, leaking amt units of blood from the mob

--- a/code/modules/organs/wound.dm
+++ b/code/modules/organs/wound.dm
@@ -50,130 +50,131 @@
 	// helper lists
 	var/tmp/list/desc_list = list()
 	var/tmp/list/damage_list = list()
-	New(var/damage)
 
-		created = world.time
+/datum/wound/New(var/damage)
 
-		// reading from a list("stage" = damage) is pretty difficult, so build two separate
-		// lists from them instead
-		for(var/V in stages)
-			desc_list += V
-			damage_list += stages[V]
+	created = world.time
 
-		src.damage = damage
+	// reading from a list("stage" = damage) is pretty difficult, so build two separate
+	// lists from them instead
+	for(var/V in stages)
+		desc_list += V
+		damage_list += stages[V]
 
-		// initialize with the first stage
-		next_stage()
+	src.damage = damage
 
-		// this will ensure the size of the wound matches the damage
-		src.heal_damage(0)
+	// initialize with the first stage
+	next_stage()
 
-		// make the max_bleeding_stage count from the end of the list rather than the start
-		// this is more robust to changes to the list
-		max_bleeding_stage = src.desc_list.len - max_bleeding_stage
+	// this will ensure the size of the wound matches the damage
+	src.heal_damage(0)
 
-		bleed_timer += damage
+	// make the max_bleeding_stage count from the end of the list rather than the start
+	// this is more robust to changes to the list
+	max_bleeding_stage = src.desc_list.len - max_bleeding_stage
 
-	// returns 1 if there's a next stage, 0 otherwise
-	proc/next_stage()
-		if(current_stage + 1 > src.desc_list.len)
-			return 0
+	bleed_timer += damage / BLOODLOSS_SPEED_MULTIPLIER
 
-		current_stage++
-
-		src.min_damage = damage_list[current_stage]
-		src.desc = desc_list[current_stage]
-		return 1
-
-	// returns 1 if the wound has started healing
-	proc/started_healing()
-		return (current_stage > 1)
-
-	// checks whether the wound has been appropriately treated
-	// always returns 1 for wounds that don't need to be treated
-	proc/is_treated()
-		if(!needs_treatment) return 1
-
-		if(damage_type == BRUISE || damage_type == CUT)
-			return bandaged
-		else if(damage_type == BURN)
-			return salved
-
-	// checks if wound is considered open for external infections
-	// untreated cuts (and bleeding bruises) and burns are possibly infectable, chance higher if wound is bigger
-	proc/can_infect()
-		if (is_treated() && damage < 10)
-			return 0
-		if (disinfected)
-			return 0
-		var/dam_coef = round(damage/10)
-		switch (damage_type)
-			if (BRUISE)
-				return prob(dam_coef*5) && bleeding() //bruises only infectable if bleeding
-			if (BURN)
-				return prob(dam_coef*10)
-			if (CUT)
-				return prob(dam_coef*20)
-
-		return 0
-	// heal the given amount of damage, and if the given amount of damage was more
-	// than what needed to be healed, return how much heal was left
-	// set @heals_internal to also heal internal organ damage
-
-	proc/infection_check()
-		if (damage < 10)
-			return 0
-		if (is_treated() && damage < 25)
-			return 0
-		if (disinfected)
-			germ_level = 0
-			return 0
-
-		if(damage_type == BRUISE && !bleeding())
-			return 0
-
-		var/dam_coef = round(damage/10)
-		switch (damage_type)
-			if (BRUISE)
-				return prob(dam_coef*5)
-			if (BURN)
-				return prob(dam_coef*10)
-			if (CUT)
-				return prob(dam_coef*20)
-
+// returns 1 if there's a next stage, 0 otherwise
+/datum/wound/proc/next_stage()
+	if(current_stage + 1 > src.desc_list.len)
 		return 0
 
-	proc/heal_damage(amount, heals_internal = 0)
-		if(src.internal && !heals_internal)
-			// heal nothing
-			return amount
+	current_stage++
 
-		var/healed_damage = min(src.damage, amount)
-		amount -= healed_damage
-		src.damage -= healed_damage
+	src.min_damage = damage_list[current_stage]
+	src.desc = desc_list[current_stage]
+	return 1
 
-		while(src.damage / src.amount < damage_list[current_stage] && current_stage < src.desc_list.len)
-			current_stage++
-		desc = desc_list[current_stage]
-		src.min_damage = damage_list[current_stage]
+// returns 1 if the wound has started healing
+/datum/wound/proc/started_healing()
+	return (current_stage > 1)
 
-		// return amount of healing still leftover, can be used for other wounds
+// checks whether the wound has been appropriately treated
+// always returns 1 for wounds that don't need to be treated
+/datum/wound/proc/is_treated()
+	if(!needs_treatment) return 1
+
+	if(damage_type == BRUISE || damage_type == CUT)
+		return bandaged
+	else if(damage_type == BURN)
+		return salved
+
+// checks if wound is considered open for external infections
+// untreated cuts (and bleeding bruises) and burns are possibly infectable, chance higher if wound is bigger
+/datum/wound/proc/can_infect()
+	if (is_treated() && damage < 10)
+		return 0
+	if (disinfected)
+		return 0
+	var/dam_coef = round(damage/10)
+	switch (damage_type)
+		if (BRUISE)
+			return prob(dam_coef*5) && bleeding() //bruises only infectable if bleeding
+		if (BURN)
+			return prob(dam_coef*10)
+		if (CUT)
+			return prob(dam_coef*20)
+
+	return 0
+// heal the given amount of damage, and if the given amount of damage was more
+// than what needed to be healed, return how much heal was left
+// set @heals_internal to also heal internal organ damage
+
+/datum/wound/proc/infection_check()
+	if (damage < 10)
+		return 0
+	if (is_treated() && damage < 25)
+		return 0
+	if (disinfected)
+		germ_level = 0
+		return 0
+
+	if(damage_type == BRUISE && !bleeding())
+		return 0
+
+	var/dam_coef = round(damage/10)
+	switch (damage_type)
+		if (BRUISE)
+			return prob(dam_coef*5)
+		if (BURN)
+			return prob(dam_coef*10)
+		if (CUT)
+			return prob(dam_coef*20)
+
+	return 0
+
+/datum/wound/proc/heal_damage(amount, heals_internal = 0)
+	if(src.internal && !heals_internal)
+		// heal nothing
 		return amount
 
-	// opens the wound again
-	proc/open_wound(damage)
-		src.damage += damage
-		bleed_timer += damage
+	var/healed_damage = min(src.damage, amount)
+	amount -= healed_damage
+	src.damage -= healed_damage
 
-		while(src.current_stage > 1 && src.damage_list[current_stage-1] <= src.damage)
-			src.current_stage--
+	while(src.damage / src.amount < damage_list[current_stage] && current_stage < src.desc_list.len)
+		current_stage++
+	desc = desc_list[current_stage]
+	src.min_damage = damage_list[current_stage]
 
-		src.desc = desc_list[current_stage]
-		src.min_damage = damage_list[current_stage]
+	// return amount of healing still leftover, can be used for other wounds
+	return amount
 
-	proc/bleeding()
-		// internal wounds don't bleed in the sense of this function
-		return ((damage > 30 || bleed_timer > 0) && !(bandaged||clamped) && (damage_type == BRUISE && damage >= 20 || damage_type == CUT && damage >= 5) && current_stage <= max_bleeding_stage && !src.internal)
+// opens the wound again
+/datum/wound/proc/open_wound(damage)
+	src.damage += damage
+	bleed_timer += damage / BLOODLOSS_SPEED_MULTIPLIER
+
+	while(src.current_stage > 1 && src.damage_list[current_stage-1] <= src.damage)
+		src.current_stage--
+
+	src.desc = desc_list[current_stage]
+	src.min_damage = damage_list[current_stage]
+
+/datum/wound/proc/bleeding()
+	// internal wounds don't bleed in the sense of this function
+	return ((damage > 30 || bleed_timer > 0) && !(bandaged||clamped) && (damage_type == BRUISE && damage >= 20 || damage_type == CUT && damage >= 5) && current_stage <= max_bleeding_stage && !src.internal)
 
 /** CUTS **/
 /datum/wound/cut/small
@@ -280,3 +281,5 @@ datum/wound/cut/massive
 	max_bleeding_stage = 0
 
 	needs_treatment = 1
+
+#undef BLOODLOSS_SPEED_MULTIPLIER

--- a/html/changelogs/9600bauds_blud.yml
+++ b/html/changelogs/9600bauds_blud.yml
@@ -1,0 +1,38 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general deleting of nice things)
+#   rscadd (general adding of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: 9600bauds
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+changes: 
+  - tweak: External blood loss has been slowed by 25%, though you'll still lose roughly the same amount of blood.
+  - rscadd: Lying down will reduce the amount of blood you lose from external bleeding by 30% (This goes a longer way than it sounds). If you can't stop the bleeding, your best bet is to lie down and call for help or have someone drag you.
+  - tweak: "Tweaked low blood level warnings to give a little of a warning transition between \"mostly fine\" and \"going into shock\"."
+  - tweak: Slightly tweaked the effect of low blood levels, previously medium blood loss would be deadlier than heavy blood loss. It will still kill you pretty dead.


### PR DESCRIPTION
External blood loss has been slowed by 25%, though you'll still lose roughly the same amount of blood.

Lying down will reduce the amount of blood you lose from external bleeding by 30% (This goes a longer way than it sounds). If you can't stop the bleeding, your best bet is to lie down and call for help or have someone drag you.

Tweaked low blood level warnings to give a little of a warning transition between "mostly fine" and "going into shock".

Slightly tweaked the effect of low blood levels, previously medium blood loss would be deadlier than heavy blood loss. It will still kill you pretty dead.

Github is shit at diffs, here are the 2 lines I changed in wounds.dm in a non-shit presentation: http://i.imgur.com/YCQ84tc.png http://i.imgur.com/qwCzHlQ.png
