### PR TITLE
[Hotfix] Fixes feeding anyone anything at any time causing your hand to be sticky with the residue of a qdel'd item that had null reagents, thus cursing you with the ire of a thousand runtimes and the garbage collector system

### DIFF
--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -119,11 +119,7 @@
 		u_equip(W,1)
 		if(!W) return 1 // self destroying objects (tk, grabs)
 		W.layer = initial(W.layer)
-		W.loc = loc
-
-		var/turf/T = get_turf(loc)
-		if(isturf(T))
-			T.Entered(W)
+		W.forceMove(loc)
 
 		//W.dropped(src)
 		//update_icons() // Redundant as u_equip will handle updating the specific overlay

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -35,7 +35,13 @@
 		user.visible_message("<span class='notice'>[user] finishes eating \the [src].</span>", \
 		"<span class='notice'>You finish eating \the [src].</span>")
 		score["foodeaten"]++ //For post-round score
-		user.drop_from_inventory(src) //Drop our item before we delete it
+
+		//Drop our item before we delete it, to clear any references of ourselves in people's hands or whatever.
+		if(loc == user)
+			user.drop_from_inventory(src)
+		else if(ismob(loc))
+			var/mob/holder = loc
+			holder.drop_from_inventory(src)
 
 		if(trash) //Do we have somehing defined as trash for our snack item ?
 			//Note : This makes sense in some way, or at least this works, just don't mess with it
@@ -139,7 +145,7 @@
 			playsound(target.loc,'sound/items/eatfood.ogg', rand(10,50), 1)
 			if(reagents.total_volume)
 				reagents.reaction(target, INGEST)
-				spawn(5)
+				spawn(5) //WHY IS THIS SPAWN() HERE
 					if(reagents.total_volume > bitesize)
 						/*
 						 * I totally cannot understand what this code supposed to do.
@@ -153,6 +159,7 @@
 					bitecount++
 					On_Consume(target)
 			return 1
+
 	return 0
 
 /obj/item/weapon/reagent_containers/food/snacks/examine(mob/user)

--- a/html/changelogs/9600bauds_infiniruntimes.yml
+++ b/html/changelogs/9600bauds_infiniruntimes.yml
@@ -1,0 +1,35 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general deleting of nice things)
+#   rscadd (general adding of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: 9600bauds
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+changes: 
+  - bugfix: Probably fixes a critical bug related to force-feeding people that resulted in invisible food sticking to your hand, as well as allowing for the potential of infinite slipping and infinite runtimes.


### PR DESCRIPTION
![disaster](https://cloud.githubusercontent.com/assets/6526157/11910101/b8bb8802-a5ce-11e5-87fe-e9640fc77a37.jpg)

I wonder how fucking old this bug IS. Everything points towards it being as old as force-feeding people ITSELF, just that nobody noticed because the invisible null reagents item used not to have the ability to slip.
Fixes #7132
SHOULD fix  #7052, I think it was likely caused by this
Probably fixes  #7048
