### PR TITLE
Removes alcohol overdose

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -3687,6 +3687,7 @@
 	description = "A superb and well-aged single-malt whiskey. Damn."
 	color = "#664300" //rgb: 102, 67, 0
 	dizzy_adj = 4
+	pass_out = 225
 
 /datum/reagent/ethanol/specialwhiskey
 	name = "Special Blend Whiskey"
@@ -3694,6 +3695,7 @@
 	description = "Just when you thought regular station whiskey was good... This silky, amber goodness has to come along and ruin everything."
 	color = "#664300" //rgb: 102, 67, 0
 	slur_start = 30
+	pass_out = 225
 
 /datum/reagent/ethanol/gin
 	name = "Gin"
@@ -3701,6 +3703,7 @@
 	description = "It's gin. In space. I say, good sir."
 	color = "#664300" //rgb: 102, 67, 0
 	dizzy_adj = 3
+	pass_out = 260
 
 /datum/reagent/ethanol/absinthe
 	name = "Absinthe"
@@ -3710,7 +3713,7 @@
 	dizzy_adj = 5
 	slur_start = 25
 	confused_start = 100
-	pass_out = 350
+	pass_out = 175
 
 //Copy paste from LSD... shoot me
 /datum/reagent/ethanol/absinthe/on_mob_life(var/mob/living/M)
@@ -3725,6 +3728,7 @@
 	id = "rum"
 	description = "Yohoho and all that."
 	color = "#664300" //rgb: 102, 67, 0
+	pass_out = 250
 
 /datum/reagent/ethanol/tequila
 	name = "Tequila"
@@ -3841,7 +3845,7 @@
 	id = "rum"
 	description = "Popular with the sailors. Not very popular with everyone else."
 	color = "#664300" //rgb: 102, 67, 0
-	pass_out = 350
+	pass_out = 325
 
 /datum/reagent/ethanol/deadrum/on_mob_life(var/mob/living/M)
 
@@ -3899,6 +3903,7 @@
 	slurr_adj = 5
 	slur_start = 35
 	confused_start = 90
+	pass_out = 250
 
 /datum/reagent/ethanol/deadrum/ale
 	name = "Ale"

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -3650,7 +3650,7 @@
 				H.adjustToxLoss(5)
 			else if(istype(L))
 				L.take_damage(0.05, 0.5)
-			H.adjustToxLoss(0.1)
+			H.adjustToxLoss(0.5)
 
 /datum/reagent/ethanol/reaction_obj(var/obj/O, var/volume)
 
@@ -3710,6 +3710,7 @@
 	dizzy_adj = 5
 	slur_start = 25
 	confused_start = 100
+	pass_out = 350
 
 //Copy paste from LSD... shoot me
 /datum/reagent/ethanol/absinthe/on_mob_life(var/mob/living/M)
@@ -3718,8 +3719,6 @@
 
 	data++
 	M.hallucination += 5
-	if(volume > REAGENTS_OVERDOSE)
-		M.adjustToxLoss(1)
 
 /datum/reagent/ethanol/rum
 	name = "Rum"
@@ -3842,15 +3841,13 @@
 	id = "rum"
 	description = "Popular with the sailors. Not very popular with everyone else."
 	color = "#664300" //rgb: 102, 67, 0
+	pass_out = 350
 
 /datum/reagent/ethanol/deadrum/on_mob_life(var/mob/living/M)
 
 	if(..()) return 1
 
 	M.dizziness += 5
-
-	if(volume > REAGENTS_OVERDOSE)
-		M.adjustToxLoss(1)
 
 /datum/reagent/ethanol/deadrum/vodka
 	name = "Vodka"


### PR DESCRIPTION
This is distinct from removing alcohol's toxicity. Alcohol poisons you in 4 stages each with varying effects of slurring speech up to damaging your liver and you with toxins. However deadrum/absinthe (which covers almost all alcohols) will begin toxing you above 30u, the reagents_overdose point, whereas normal alcohol shouldn't be damaging you until 450u.

This PR instead removes >30u toxins damage, and to compensate lowers the pass_out (normal toxins damage level) to 350u for variants of deadrum/absinthe instead while increasing the tox damage at that level.

Closes #7129
Fixes #7115

Arthur wasn't making my suggested changes quickly enough/at all