### PR TITLE
Adds Borer Egg Crates

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1201,6 +1201,15 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	access = access_tox_storage
 	group = "Science"
 
+/datum/supply_packs/borer
+	name = "Borer Egg Crate"
+	contains = list (/obj/item/weapon/reagent_containers/food/snacks/borer_egg)
+	cost = 100
+	containertype = /obj/structure/closet/crate/secure/scisec
+	containername = "Borer egg crate"
+	access = access_xenobiology
+	group = "Science"
+
 //////HYDROPONICS//////
 
 /datum/supply_packs/monkey

--- a/html/changelogs/ArthurDentist.yml
+++ b/html/changelogs/ArthurDentist.yml
@@ -1,2 +1,3 @@
 author: ArthurDentist
-changes: []
+changes:
+ - rscadd: Borer eggs can now be ordered from Cargo. Each egg crate contains 1 egg, costs 100 credits and requires Xenobiology access to open. 


### PR DESCRIPTION
Borer eggs can now be ordered from cargo.
- Each crate costs 100 credits.
- Each crate contains a single egg
- Xenobiology access is required to open the crate

Because each crate contains a single egg you cannot use this to quickly and easily get lots of borers. It does mean however that if a dipshit xenobiologist eats the only available egg and then suicide succumbs, another xenobiologist can bring borers into existence without having to bother the admins. 

This also addresses #7177 to some extent as it allows you to get a new egg on stations which don't start with one, though it'd still be preferable if eggs were eventually added to each of these stations. 
