### PR TITLE
Removes improper use cases of \improper in signs and added a warning at the top.

### DIFF
--- a/code/game/objects/structures/signs.dm
+++ b/code/game/objects/structures/signs.dm
@@ -1,3 +1,15 @@
+/*//////////////////////////////////////////
+//			WARNING! ACHTUNG!			  //
+//		WHEN YOU'RE MAKING A SIGN:		  //
+//		REMEMBER TO USE \improper		  //
+//	ONLY IF NAME IS CAPITALIZED AND 	  //
+//ACTUALLY NOT PROPER; FAILURE TO DO THIS //
+//	RESULT IN MESSAGES LIKE "The The 	  //
+//	Periodic Table has been hit..."		  //
+//	PLEASE REMEMBER THAT AND THANKS.	  //
+//			HAVE A NICE DAY!			  //
+*///////////////////////////////////////////
+
 /obj/structure/sign
 	icon = 'icons/obj/decals.dmi'
 	anchored = 1
@@ -94,62 +106,62 @@
 	icon_state = "map-right-MS"
 
 /obj/structure/sign/securearea
-	name = "\improper SECURE AREA"
+	name = "SECURE AREA"
 	desc = "A warning sign which reads 'SECURE AREA'."
 	icon_state = "securearea"
 
 /obj/structure/sign/biohazard
-	name = "\improper BIOHAZARD"
+	name = "BIOHAZARD"
 	desc = "A warning sign which reads 'BIOHAZARD'"
 	icon_state = "bio"
 
 /obj/structure/sign/electricshock
-	name = "\improper HIGH VOLTAGE"
+	name = "HIGH VOLTAGE"
 	desc = "A warning sign which reads 'HIGH VOLTAGE'"
 	icon_state = "shock"
 
 /obj/structure/sign/examroom
-	name = "\improper EXAM"
+	name = "EXAM"
 	desc = "A guidance sign which reads 'EXAM ROOM'"
 	icon_state = "examroom"
 
 /obj/structure/sign/vacuum
-	name = "\improper HARD VACUUM AHEAD"
+	name = "HARD VACUUM AHEAD"
 	desc = "A warning sign which reads 'HARD VACUUM AHEAD'"
 	icon_state = "space"
 
 /obj/structure/sign/deathsposal
-	name = "\improper DISPOSAL LEADS TO SPACE"
+	name = "DISPOSAL LEADS TO SPACE"
 	desc = "A warning sign which reads 'DISPOSAL LEADS TO SPACE'"
 	icon_state = "deathsposal"
 
 /obj/structure/sign/pods
-	name = "\improper ESCAPE PODS"
+	name = "ESCAPE PODS"
 	desc = "A warning sign which reads 'ESCAPE PODS'"
 	icon_state = "pods"
 
 /obj/structure/sign/fire
-	name = "\improper DANGER: FIRE"
+	name = "DANGER: FIRE"
 	desc = "A warning sign which reads 'DANGER: FIRE'"
 	icon_state = "fire"
 
 /obj/structure/sign/nosmoking_1
-	name = "\improper NO SMOKING"
+	name = "NO SMOKING"
 	desc = "A warning sign which reads 'NO SMOKING'"
 	icon_state = "nosmoking"
 
 /obj/structure/sign/nosmoking_2
-	name = "\improper NO SMOKING"
+	name = "NO SMOKING"
 	desc = "A warning sign which reads 'NO SMOKING'"
 	icon_state = "nosmoking2"
 
 /obj/structure/sign/redcross
-	name = "medbay"
+	name = "Medbay"
 	desc = "The Intergalactic symbol of Medical institutions. You'll probably get help here.'"
 	icon_state = "redcross"
 
 /obj/structure/sign/greencross
-	name = "medbay"
+	name = "Medbay"
 	desc = "The Intergalactic symbol of Medical institutions. You'll probably get help here.'"
 	icon_state = "greencross"
 
@@ -159,7 +171,7 @@
 	icon_state = "goldenplaque"
 
 /obj/structure/sign/kiddieplaque
-	name = "AI developer's plaque"
+	name = "\improper AI developer's plaque"
 	desc = "Next to the extremely long list of names and job titles, there is a drawing of a little child. The child appears to be retarded. Beneath the image, someone has scratched the word \"PACKETS\""
 	icon_state = "kiddieplaque"
 
@@ -169,46 +181,46 @@
 	icon_state = "atmosplaque"
 
 /obj/structure/sign/science			//These 3 have multiple types, just var-edit the icon_state to whatever one you want on the map
-	name = "\improper SCIENCE!"
+	name = "SCIENCE!"
 	desc = "A warning sign which reads 'SCIENCE!'"
 	icon_state = "science1"
 
 /obj/structure/sign/chemistry
-	name = "\improper CHEMISTRY"
+	name = "CHEMISTRY"
 	desc = "A warning sign which reads 'CHEMISTRY'"
 	icon_state = "chemistry1"
 
 /obj/structure/sign/chemtable
-	name = "\improper The Periodic Table"
+	name = "The Periodic Table"
 	desc = "A very colorful and detailed table of all the chemical elements you could blow up or burn down a chemistry laboratory with, titled 'The Space Periodic Table - To be continued'. Just the mere sight of it makes you feel smarter."
 	icon_state = "periodic"
 
 /obj/structure/sign/botany
-	name = "\improper HYDROPONICS"
+	name = "HYDROPONICS"
 	desc = "A warning sign which reads 'HYDROPONICS'"
 	icon_state = "hydro1"
 
 /obj/structure/sign/directions/science
-	name = "\improper Science department"
+	name = "Science department"
 	desc = "A direction sign, pointing out which way Science department is."
 	icon_state = "direction_sci"
 
 /obj/structure/sign/directions/engineering
-	name = "\improper Engineering department"
+	name = "Engineering department"
 	desc = "A direction sign, pointing out which way Engineering department is."
 	icon_state = "direction_eng"
 
 /obj/structure/sign/directions/security
-	name = "\improper Security department"
+	name = "Security department"
 	desc = "A direction sign, pointing out which way Security department is."
 	icon_state = "direction_sec"
 
 /obj/structure/sign/directions/medical
-	name = "\improper Medical Bay"
+	name = "Medical Bay"
 	desc = "A direction sign, pointing out which way Meducal Bay is."
 	icon_state = "direction_med"
 
 /obj/structure/sign/directions/evac
-	name = "\improper Escape Arm"
+	name = "Escape Arm"
 	desc = "A direction sign, pointing out which way escape shuttle dock is."
 	icon_state = "direction_evac"

--- a/code/game/objects/structures/signs.dm
+++ b/code/game/objects/structures/signs.dm
@@ -4,7 +4,7 @@
 //		REMEMBER TO USE \improper		  //
 //	ONLY IF NAME IS CAPITALIZED AND 	  //
 //ACTUALLY NOT PROPER; FAILURE TO DO THIS //
-//	RESULT IN MESSAGES LIKE "The The 	  //
+// WILL RESULT IN MESSAGES LIKE "The The  //
 //	Periodic Table has been hit..."		  //
 //	PLEASE REMEMBER THAT AND THANKS.	  //
 //			HAVE A NICE DAY!			  //


### PR DESCRIPTION
Thank you, and have a nice day!
Fixes #7188.
How the message looks in DM:
![achtung](https://my.mixtape.moe/znvjxh.png)
