### PR TITLE
Makes subjugate less insanely long

### DIFF
--- a/code/modules/spells/targeted/subjugate.dm
+++ b/code/modules/spells/targeted/subjugate.dm
@@ -10,9 +10,9 @@
 
 	max_targets = 1
 
-	amt_dizziness = 300
-	amt_confused = 300
-	amt_stuttering = 300
+	amt_dizziness = 86
+	amt_confused = 86 // 2.1 seconds per = 180.6s
+	amt_stuttering = 86
 
 	compatible_mobs = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 

--- a/html/changelogs/Intigracysubjugate.yml
+++ b/html/changelogs/Intigracysubjugate.yml
@@ -1,0 +1,4 @@
+author: Intigracy
+delete-after: True
+changes:
+  - tweak: Subjugation no longer lasts for upwards of 10 minutes. It now lasts 3 minutes per cast.


### PR DESCRIPTION
Before: 10.5 minutes per cast
Now: 180.6 seconds (3m) per cast

Partial fix for #7204 but I'm pretty sure it only works through walls when you have XRAY, needs testing.
