### PR TITLE
Fixes solar control computers going invisible when broken.

### DIFF
--- a/code/modules/power/solars/control.dm
+++ b/code/modules/power/solars/control.dm
@@ -37,11 +37,11 @@
 	overlays.len = 0
 
 	if(stat & BROKEN)
-		icon_state = "broken"
+		icon_state = "solarb"
 		return
 
 	if(stat & NOPOWER)
-		icon_state = "c_unpowered"
+		icon_state = "solar0"
 		return
 
 	icon_state = "solar"


### PR DESCRIPTION
![](http://i.imgur.com/Huh53w3.png)
I didn't add these, just making use of them since for some reason someone thought "broken" exists.
