### PR TITLE
Observers lose PROXMOVE flag

### DIFF
--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -1,7 +1,6 @@
 /var/global/list/prox_sensor_ignored_types = list \
 (
-	/obj/effect/beam,
-	/mob/dead/observer
+	/obj/effect/beam
 )
 
 /obj/item/device/assembly/prox_sensor

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -13,6 +13,7 @@
 	canmove = 0
 	blinded = 0
 	anchored = 1	//  don't get pushed around
+	flags = HEAR
 	invisibility = INVISIBILITY_OBSERVER
 	universal_understand = 1
 	universal_speak = 1


### PR DESCRIPTION
Nothing that I can see that uses PROXMOVE flag necessitates observers to have this flag, and in fact, most of the things using it had to make an exception for observers as a result.