### PR TITLE
GC stuff

### DIFF
--- a/code/ATMOSPHERICS/pipes.dm
+++ b/code/ATMOSPHERICS/pipes.dm
@@ -94,6 +94,7 @@
 			qdel(M)
 	if(air_temporary && loc)
 		loc.assume_air(air_temporary)
+		air_temporary = null
 
 	..()
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -144,8 +144,12 @@ var/global/list/ghdel_profiling = list()
 	// Idea by ChuckTheSheep to make the object even more unreferencable.
 	invisibility = 101
 	INVOKE_EVENT(on_destroyed, list()) // No args.
-	if(on_moved) on_moved.holder = null
-	if(on_destroyed) on_destroyed.holder = null
+	if(on_moved)
+		on_moved.holder = null
+		on_moved = null
+	if(on_destroyed)
+		on_destroyed.holder = null
+		on_destroyed = null
 	if(istype(beams, /list) && beams.len) beams.len = 0
 	/*if(istype(beams) && beams.len)
 		for(var/obj/effect/beam/B in beams)

--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -22,6 +22,11 @@ var/global/list/blood_list = list()
 	transfers_dna = 1
 	absorbs_types=list(/obj/effect/decal/cleanable/blood,/obj/effect/decal/cleanable/blood/drip,/obj/effect/decal/cleanable/blood/writing)
 
+/obj/effect/decal/cleanable/blood/Destroy()
+	..()
+	blood_DNA = null
+	virus2 = null
+
 /obj/effect/decal/cleanable/blood/cultify()
 	return
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -22,7 +22,7 @@ var/global/obj/screen/fuckstat/FUCK = new
 	if(on_uattack) on_uattack.holder = null
 	unset_machine()
 	if(mind && mind.current == src)
-		spellremove(src)
+		mind.current = null
 	if(client)
 		for(var/obj/screen/movable/spell_master/spell_master in spell_masters)
 			returnToPool(spell_master)
@@ -47,8 +47,13 @@ var/global/obj/screen/fuckstat/FUCK = new
 	special_delayer = null
 	gui_icons = null
 	qdel(hud_used)
+	hud_used = null
 	for(var/obj/leftovers in src)
 		qdel(leftovers)
+	spellremove(src)
+	if(on_uattack)
+		on_uattack.holder = null
+		on_uattack = null
 	..()
 
 /mob/projectile_check()


### PR DESCRIPTION
May help the soft deletion of /obj/effect/decal/cleanable/blood and atmospherics/pipe subtypes

Makes it so spells are removed regardless of mind because obviously the fucking mob is getting destroyed so do it. Also nulls out on_uattack for mobs and hud_used.
