### PR TITLE
Low charge =/= unconscious

### DIFF
--- a/code/modules/mob/living/silicon/mommi/life.dm
+++ b/code/modules/mob/living/silicon/mommi/life.dm
@@ -42,7 +42,6 @@
 	if(cell)
 		if(cell.charge <= 0)
 			uneq_all()
-			stat = 1
 		else if (src.cell.charge <= MOMMI_LOW_POWER)
 			uneq_all()
 			cell.use(1)

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -42,7 +42,6 @@
 	if (is_component_functioning("power cell") && cell)
 		if(src.cell.charge <= 0)
 			uneq_all()
-			src.stat = 1
 		else
 			if(src.module_state_1)
 				src.cell.use(3)


### PR DESCRIPTION
For robots makes the state of being 'unconscious' only applicable to lacking a cell, which puts you in a state of being almost totally nonfunctional similar to the 'unconscious' (critical) state of humans.

Low power mode does disable some functionality such as module use, but does nothing to your vision and overall movement. This fixes #7215, whereby it was assuming a low power mode borg was in crit and thus ejected it.