### PR TITLE
Rods do_after change

### DIFF
--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -104,7 +104,7 @@
 
 		to_chat(user, "<span class='notice'>Assembling grille...</span>")
 
-		if(!do_after(user, src, 10))
+		if(!do_after(user, get_turf(src), 10))
 			return
 
 		var/obj/structure/grille/Grille = getFromPool(/obj/structure/grille, user.loc)


### PR DESCRIPTION
Makes assembling a grille show the progress bar in the correct location