### PR TITLE
put_in_hand now calls pickup()

### DIFF
--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -40,6 +40,7 @@
 		if(client)	client.screen |= W
 		if(pulling == W) stop_pulling()
 		update_inv_l_hand()
+		W.pickup(src)
 		return 1
 	return 0
 
@@ -59,6 +60,7 @@
 		if(client)	client.screen |= W
 		if(pulling == W) stop_pulling()
 		update_inv_r_hand()
+		W.pickup(src)
 		return 1
 	return 0
 


### PR DESCRIPTION
Apparently this wasn't limited to the give verb.
Fixes #7241
