### PR TITLE
Cockroaches no longer spam useless, dead eggs + tiny nerf

### DIFF
--- a/code/__HELPERS/_macros.dm
+++ b/code/__HELPERS/_macros.dm
@@ -157,3 +157,6 @@
 
 #define hardcore_mode_on (hardcore_mode)//((ticker) && (ticker.hardcore_mode))
 #define eligible_for_hardcore_mode(M) (M.ckey && M.client)
+
+//Helper macro for eggs, called in process() of all fertilized eggs. If it returns 0, the egg will no longer be able to hatch
+#define is_in_valid_nest(egg) (isturf(egg.loc))

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -259,7 +259,7 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/egg/var/amount_grown = 0
 /obj/item/weapon/reagent_containers/food/snacks/egg/process()
-	if(isturf(loc))
+	if(is_in_valid_nest(src)) //_macros.dm
 		amount_grown += rand(1,2)
 		if(amount_grown >= 100)
 			hatch()

--- a/code/modules/reagents/reagent_containers/food/snacks/eggs/roach.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/eggs/roach.dm
@@ -1,3 +1,5 @@
+var/global/cockroach_egg_amount = 0
+
 /obj/item/weapon/reagent_containers/food/snacks/roach_eggs
 	name = "cockroach eggs"
 	desc = "A bunch of tiny, brown eggs, each of them housing a bunch of cockroach larvae."
@@ -16,20 +18,40 @@
 
 	icon_state = "roach_eggs[rand(1,3)]"
 
-/obj/item/weapon/reagent_containers/food/snacks/roach_eggs/process()
-	if(isturf(loc))
-		amount_grown += rand(1,3)
+	cockroach_egg_amount++
 
-		if(amount_grown >= 50)
+/obj/item/weapon/reagent_containers/food/snacks/roach_eggs/process()
+	if(is_in_valid_nest(src)) //_macros.dm
+		amount_grown += rand(1,2)
+
+		if(amount_grown >= 41)
 			if(animal_count[/mob/living/simple_animal/cockroach] < ANIMAL_CHILD_CAP)
 				hatch()
 			else
-				processing_objects.Remove(src)
+				die()
 	else
-		processing_objects.Remove(src)
+		die()
+
+/obj/item/weapon/reagent_containers/food/snacks/roach_eggs/Destroy()
+	if(amount_grown)
+		die()
+
+	cockroach_egg_amount--
+
+	return ..()
 
 /obj/item/weapon/reagent_containers/food/snacks/roach_eggs/proc/hatch()
 	new /mob/living/simple_animal/cockroach(get_turf(src))
 
 	processing_objects.Remove(src)
 	qdel(src)
+
+/obj/item/weapon/reagent_containers/food/snacks/roach_eggs/proc/fertilize()
+	processing_objects.Add(src)
+
+	amount_grown = 1 //So there's a way of checking if the egg is fertilized without doing processing_objects.Find(src)
+
+/obj/item/weapon/reagent_containers/food/snacks/roach_eggs/proc/die()
+	processing_objects.Remove(src)
+
+	amount_grown = 0


### PR DESCRIPTION
Roaches breed slightly slower, no longer create THOUSANDS of useless eggs
- Chance of roaches laying eggs when found a good place is 75% (previously 100%). Quarter of that if the place is trash.
- Chance of roach eggs being hatchable is 100% (previously 75%), unless there are more than 50 roaches
- **Roaches stop laying eggs after making 30 unhatchable eggs**. They'll start laying eggs again once they can make hatchable eggs (i.e. their population goes down)
- **Roach eggs hatch slightly slower** (from 10-30 ticks to 20-40 ticks)
- Added is_in_valid_nest(egg) macro used by cockroach and chicken eggs. It checks if egg's location is a turf. It's called in process() of fertilized eggs, if it returns 0 the eggs are no longer be able to hatch.
- Fixes #7286
