### PR TITLE
Shuttle bugfixes and logging

### DIFF
--- a/code/datums/shuttle.dm
+++ b/code/datums/shuttle.dm
@@ -286,6 +286,8 @@
 	last_moved = world.time
 	moving = 1
 
+	log_game("[usr ? key_name(usr) : "Something"] sent [name] ([type]) to [D.areaname]")
+
 	spawn(get_pre_flight_delay())
 		if(transit_port && get_transit_delay())
 			if(broadcast)
@@ -382,6 +384,8 @@
 
 				moved_shuttles |= S
 				S.move_to_dock(our_moved_dock, ignore_innacuracy = 1)
+
+		log_game("[name] ([type]) moved to [D.areaname]")
 
 		return 1
 
@@ -589,7 +593,7 @@
 		space.contents.Add(old_turf)
 		old_turf.change_area(linked_area,space)
 
-		//All objects which aren't going to be moved by the shuttle have their area changed to space!
+		//All objects which can't be moved by the shuttle have their area changed to space!
 		for(var/atom/movable/AM in old_turf.contents)
 			if(!AM.can_shuttle_move(src))
 				AM.change_area(linked_area,space)
@@ -646,7 +650,15 @@
 			if(!AM.can_shuttle_move(src))
 				continue
 
-			AM.forceMove(new_turf)
+			if(AM.bound_width > world.icon_size || AM.bound_height > world.icon_size) //If the moved object's bounding box is more than the default, move it after everything else (using spawn())
+				AM.loc = null //Without this, ALL neighbouring turfs attempt to move this object too, resulting in the object getting shifted to north/east
+
+				spawn()
+					AM.forceMove(new_turf)
+
+				//TODO: Make this compactible with bound_x and bound_y.
+			else
+				AM.forceMove(new_turf)
 
 			if(rotate)
 				AM.shuttle_rotate(rotate)

--- a/code/game/machinery/doors/multi_tile.dm
+++ b/code/game/machinery/doors/multi_tile.dm
@@ -2,10 +2,6 @@
 /obj/machinery/door/airlock/multi_tile
 	width = 2
 
-/obj/machinery/door/airlock/multi_tile/shuttle_act(datum/shuttle/S)
-	//Not destroyed to prevent shuttles from destroying their own multi_tile doors (most notable case is the salvage shuttle)
-	return
-
 /obj/machinery/door/airlock/multi_tile/glass
 	name = "Glass Airlock"
 	icon = 'icons/obj/doors/Door2x1glass.dmi'

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -178,21 +178,21 @@ Class Procs:
 		to_chat(user, "<span class='info'>Its maintenance panel is open.</span>")
 
 /obj/machinery/Destroy()
-	if(src in machines)
-		machines.Remove(src)
-	if(src in power_machines)
-		power_machines.Remove(src)
-	if(src in atmos_machines)
-		atmos_machines.Remove(src)
-	if(src in fast_machines)
-		fast_machines.Remove(src)
+
+	machines.Remove(src)
+
+	power_machines.Remove(src)
+
+	atmos_machines.Remove(src)
+
+	fast_machines.Remove(src)
 /*
 	if(component_parts)
 		for(var/atom/movable/AM in component_parts)
 			AM.loc = loc
 			component_parts -= AM
 */
-		component_parts = null
+	component_parts = null
 
 	..()
 

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -336,11 +336,11 @@
 			qdel(E)
 	..()
 
-/turf/simulated/wall/ChangeTurf(var/newtype)
+/turf/simulated/wall/ChangeTurf()
 	for(var/obj/effect/E in src)
 		if(E.name == "Wallrot")
 			qdel(E)
-	..(newtype)
+	..()
 
 /turf/simulated/wall/cultify()
 	ChangeTurf(/turf/simulated/wall/cult)


### PR DESCRIPTION
- Multi-tile objects like spacepods and big airlocks can now be properly moved (or destroyed) by shuttles - Fixes #7251
- Shuttle movement is logged to log_game (controlling a shuttle via console is also logged) - Fixes #7016
- Removed a redundant piece of code in obj/machinery/Destroy() (list.Remove(A) doesn't runtime if A isn't in list)
- **Shit is no longer fucked up when a shuttle lands on a wall ( http://puu.sh/m99uP/dcf39ba2fc.png )**
