### PR TITLE
Adds the antibody scanner to the list of things that can be held in the medical belt.

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -139,7 +139,7 @@
 		"/obj/item/clothing/gloves/latex",
         "/obj/item/weapon/reagent_containers/hypospray/autoinjector",
 		"/obj/item/device/mass_spectrometer",
-		"/obj/item/device/gps/paramedic"
+		"/obj/item/device/gps/paramedic",
 		"/obj/item/device/antibody_scanner"
 	)
 

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -140,6 +140,7 @@
         "/obj/item/weapon/reagent_containers/hypospray/autoinjector",
 		"/obj/item/device/mass_spectrometer",
 		"/obj/item/device/gps/paramedic"
+		"/obj/item/device/antibody_scanner"
 	)
 
 


### PR DESCRIPTION
Title pretty much says it all.

Fixes #7298 
