### PR TITLE
Fix reentering destroyed mobs

### DIFF
--- a/code/modules/mob/living/carbon/brain/posibrain.dm
+++ b/code/modules/mob/living/carbon/brain/posibrain.dm
@@ -175,4 +175,3 @@
 	visible_message(message = "<span class='danger'>[B] begins to go dark, having seemingly thought himself to death</span>", blind_message = "<span class='danger'>You hear the wistful sigh of a hopeful machine powering off with a tone of finality.<span>")
 	icon_state = "posibrain"
 	searching = 0
-	B.ghostize(0)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -41,7 +41,7 @@ var/global/obj/screen/fuckstat/FUCK = new
 	mob_list.Remove(src)
 	dead_mob_list.Remove(src)
 	living_mob_list.Remove(src)
-	ghostize()
+	ghostize(0)
 	//Fuck datums amirite
 	click_delayer = null
 	attack_delayer = null


### PR DESCRIPTION
Ghostize(0) is a form that doesn't let you reenter your corpse as a ghost
Fix #7234, posibrains wont permanently force ghost you when the mob dies