### PR TITLE
Adds tech levels to many items, so that they can be scanned. Makes borer eggs non-scannable

### DIFF
--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -112,6 +112,7 @@
 	name = "cane"
 	desc = "A cane used by a true gentlemen. Or a clown."
 	icon = 'icons/obj/weapons.dmi'
+	origin_tech = "materials=1"
 	icon_state = "cane"
 	item_state = "stick"
 	flags = FPRINT

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/obj/pda.dmi'
 	icon_state = "cart"
 	item_state = "electronic"
+	origin_tech = "programming=2"
 	w_class = 1
 
 	var/obj/item/radio/integrated/radio = null
@@ -221,6 +222,8 @@
 	icon_state = "cart"
 	access_remote_door = 1
 	remote_door_id = "smindicate" //Make sure this matches the syndicate shuttle's shield/door id!!	//don't ask about the name, testing.
+	origin_tech = "programming=2;syndicate=2"
+	mech_flags = MECH_SCAN_ILLEGAL
 	var/shock_charges = 4
 
 /obj/item/weapon/cartridge/proc/unlock()

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/obj/lighting.dmi'
 	icon_state = "flashlight"
 	item_state = "flashlight"
+	origin_tech = "engineering=1"
 	w_class = 2
 	flags = FPRINT
 	siemens_coefficient = 1
@@ -210,6 +211,7 @@
 	desc = "A lamp powered by a slime core. You can adjust its brightness by touching it."
 	icon_state = "slimelamp"
 	item_state = ""
+	origin_tech = "biotech=3"
 	light_color = LIGHT_COLOR_SLIME_LAMP
 	on = 0
 	luminosity = 2

--- a/code/game/objects/items/devices/modkit.dm
+++ b/code/game/objects/items/devices/modkit.dm
@@ -3,6 +3,7 @@
 	name = "modification kit"
 	desc = "A kit containing all the needed tools and parts to modify an item into another one."
 	icon_state = "modkit"
+	origin_tech = "materials=2;engineering=2"
 	var/list/parts = list()		//how many times can this kit perform a given modification
 	var/list/original = list()	//the starting parts
 	var/list/finished = list()	//the finished products

--- a/code/game/objects/items/devices/radio/electropack.dm
+++ b/code/game/objects/items/devices/radio/electropack.dm
@@ -3,6 +3,7 @@
 	desc = "Dance my monkeys! DANCE!!!"
 	icon_state = "electropack0"
 	item_state = "electropack"
+	origin_tech = "materials=1;powerstorage=2"
 	frequency = 1449
 	flags = FPRINT
 	siemens_coefficient = 1

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -3,6 +3,7 @@
 	name = "universal recorder"
 	icon_state = "taperecorderidle"
 	item_state = "analyzer"
+	origin_tech = "magnets=1;programming=1"
 	w_class = 1.0
 	starting_materials = list(MAT_IRON = 60, MAT_GLASS = 30)
 	w_type = RECYK_ELECTRONIC

--- a/code/game/objects/items/devices/whistle.dm
+++ b/code/game/objects/items/devices/whistle.dm
@@ -3,6 +3,7 @@
 	desc = "Used by obese officers to save their breath for running."
 	icon_state = "voice0"
 	item_state = "flashbang"	//looks exactly like a flash (and nothing like a flashbang)
+	origin_tech = "magnets=1;combat=1"
 	w_class = 1.0
 	flags = FPRINT
 	siemens_coefficient = 1

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -169,6 +169,7 @@
 	icon_state = "pcollector"
 	name = "Pill Collector"
 	item_state = "pcollector"
+	origin_tech = "biotech=2;materials=1"
 	storage_slots = 50; //the number of plant pieces it can carry.
 	max_combined_w_class = 200 //Doesn't matter what this is, so long as it's more or equal to storage_slots * plants.w_class
 	max_w_class = 3

--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -137,6 +137,7 @@
 	icon_state = "secure"
 	item_state = "sec-case"
 	desc = "A large briefcase with a digital locking system."
+	origin_tech = "materials=2;magnets=2;programming=1"
 	flags = FPRINT
 	force = 8.0
 	throw_speed = 1

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -25,6 +25,8 @@
 	icon_state = "baton"
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/misc_tools.dmi', "right_hand" = 'icons/mob/in-hand/right/misc_tools.dmi')
 	item_state = "classic_baton"
+	origin_tech = "combat=3"
+	mech_flags = MECH_SCAN_FAIL
 	flags = FPRINT
 	slot_flags = SLOT_BELT
 	force = 10
@@ -78,6 +80,7 @@
 	icon = 'icons/obj/weapons.dmi'
 	icon_state = "telebaton_0"
 	item_state = "telebaton_0"
+	origin_tech = "combat=2"
 	flags = FPRINT
 	slot_flags = SLOT_BELT
 	w_class = 2
@@ -206,5 +209,3 @@
 		src.sharpness = 1.0
 	src.add_fingerprint(user)
 	return
-
-

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -316,3 +316,7 @@ a {
 	if (isobj(loc))
 		var/obj/location = loc
 		location.on_log()
+
+// Dummy to give items special techlist for the purposes of the Device Analyser, in case you'd ever need them to give them different tech levels depending on special checks.
+/obj/proc/give_tech_list()
+	return null

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -59,6 +59,7 @@
 	desc = "nothing"
 	icon_state = "purple"
 	item_state = "glasses"
+	origin_tech = "materials=1"
 
 /obj/item/clothing/glasses/night
 	name = "Night Vision Goggles"
@@ -123,6 +124,7 @@
 	name = "sunglasses"
 	icon_state = "sun"
 	item_state = "sunglasses"
+	origin_tech = "combat=2"
 	darkness_view = -1
 	eyeprot = 1
 	species_fit = list("Vox")
@@ -132,6 +134,7 @@
 	name = "sunglasses"
 	icon_state = "sun"
 	item_state = "sunglasses"
+	origin_tech = "combat=2"
 	darkness_view = -1
 	species_fit = list("Vox")
 
@@ -140,6 +143,7 @@
 	desc = "Protects the eyes from welders, approved by the mad scientist association."
 	icon_state = "welding-g"
 	item_state = "welding-g"
+	origin_tech = "engineering=1;materials=2"
 	action_button_name = "Toggle Welding Goggles"
 	var/up = 0
 	eyeprot = 3
@@ -182,6 +186,7 @@
 	desc = "Welding goggles made from more expensive materials, strangely smells like potatoes. Allows for better vision than normal goggles.."
 	icon_state = "rwelding-g"
 	item_state = "rwelding-g"
+	origin_tech = "engineering=3;materials=3"
 
 /obj/item/clothing/glasses/welding/superior/getMask()
 	return null

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -7,6 +7,7 @@
 	w_class = 2
 	gas_transfer_coefficient = 0.90
 	species_fit = list("Vox")
+	origin_tech = "biotech=2"
 
 //Monkeys can not take the muzzle off of themself! Call PETA!
 /obj/item/clothing/mask/muzzle/attack_paw(mob/user as mob)

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -14,6 +14,7 @@
 	icon_state = "bluetag"
 	item_state = "bluetag"
 	blood_overlay_type = "armor"
+	origin_tech = "materials=1;magnets=2"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
 	allowed = list (/obj/item/weapon/gun/energy/laser/bluetag)
 	siemens_coefficient = 3.0
@@ -24,6 +25,7 @@
 	icon_state = "redtag"
 	item_state = "redtag"
 	blood_overlay_type = "armor"
+	origin_tech = "materials=1;magnets=2"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
 	allowed = list (/obj/item/weapon/gun/energy/laser/redtag)
 	siemens_coefficient = 3.0
@@ -191,6 +193,7 @@
 	desc = "A suit that completely restrains the wearer."
 	icon_state = "straight_jacket"
 	item_state = "straight_jacket"
+	origin_tech = "biotech=2"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|HANDS
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 

--- a/code/modules/clothing/suits/utility.dm
+++ b/code/modules/clothing/suits/utility.dm
@@ -14,6 +14,7 @@
 	desc = "A suit that protects against fire and heat."
 	icon_state = "fire"
 	item_state = "fire_suit"
+	origin_tech = "materials=2;engineering=1"
 	w_class = 4//bulky item
 	gas_transfer_coefficient = 0.90
 	permeability_coefficient = 0.50

--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -77,6 +77,7 @@
 	desc = "An outdated medical apparatus for listening to the sounds of the human body. It also makes you look like you know what you're doing."
 	icon_state = "stethoscope"
 	_color = "stethoscope"
+	origin_tech = "biotech=1"
 
 /obj/item/clothing/accessory/stethoscope/attack(mob/living/carbon/human/M, mob/living/user)
 	if(ishuman(M) && isliving(user))

--- a/code/modules/clothing/under/accessories/holster.dm
+++ b/code/modules/clothing/under/accessories/holster.dm
@@ -3,6 +3,7 @@
 	desc = "A handgun holster."
 	icon_state = "holster"
 	_color = "holster"
+	origin_tech = "combat=2"
 	var/obj/item/weapon/gun/holstered = null
 	accessory_exclusion = HOLSTER
 
@@ -13,7 +14,7 @@
 
 /obj/item/clothing/accessory/holster/armpit
 	name = "shoulder holster"
-	desc = "A worn-out handgun holster. Perfect for concealed carry"
+	desc = "A worn-out handgun holster. Perfect for concealed carry."
 	icon_state = "holster"
 	_color = "holster"
 

--- a/code/modules/mob/living/simple_animal/borer/egg.dm
+++ b/code/modules/mob/living/simple_animal/borer/egg.dm
@@ -5,6 +5,7 @@
 	icon_state = "borer egg-growing"
 	bitesize = 12
 	origin_tech = "biotech=4"
+	mech_flags = MECH_SCAN_FAIL
 	var/grown = 0
 	var/hatching = 0 // So we don't spam ghosts.
 	var/datum/recruiter/recruiter = null

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -3,6 +3,7 @@
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "labeler0"
 	item_state = "labeler0"
+	origin_tech = "materials=1"
 	var/label = null
 	var/chars_left = 250 //Like in an actual label maker, uses an amount per character rather than per label.
 	var/mode = 0	//off or on.

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -190,6 +190,7 @@ var/paperwork_library
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "pen"
 	item_state = "pen"
+	origin_tech = "materials=1"
 	sharpness = 0.5
 	flags = FPRINT
 	slot_flags = SLOT_BELT | slot_ears

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -16,6 +16,7 @@
 	icon_state = "film"
 	item_state = "electropack"
 	w_class = 1.0
+	origin_tech = "materials=1;programming=1"
 
 
 /*
@@ -105,6 +106,7 @@
 	flags = FPRINT
 	siemens_coefficient = 1
 	slot_flags = SLOT_BELT
+	origin_tech = "materials=1;programming=1"
 	starting_materials = list(MAT_IRON = 2000)
 	w_type = RECYK_ELECTRONIC
 	min_harm_label = 3
@@ -124,6 +126,7 @@
 	item_state = "sepia-polaroid"
 	icon_on = "sepia-camera"
 	icon_off = "sepia-camera_off"
+	mech_flags = MECH_SCAN_FAIL
 
 /obj/item/device/camera/examine(mob/user)
 	..()

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -30,7 +30,7 @@ var/list/solars_list = list()
 //Solar Assembly - For construction of solar arrays
 /obj/machinery/power/solar_assembly
 	name = "solar panel assembly"
-	desc = "A solar panel assembly kit, allows constructions of a solar panel, or with a tracking circuit board, a solar tracker"
+	desc = "A solar panel assembly kit, allows constructions of a solar panel, or with a tracking circuit board, a solar tracker."
 	icon = 'icons/obj/power.dmi'
 	icon_state = "sp_base"
 	anchored = 0
@@ -95,3 +95,6 @@ var/list/solars_list = list()
 			"<span class='notice'>You take the electronics out of [src].</span>")
 			return 1
 	..()
+
+/obj/machinery/power/solar_assembly/give_tech_list()
+	return "power=3"

--- a/code/modules/power/solars/tracker.dm
+++ b/code/modules/power/solars/tracker.dm
@@ -38,4 +38,5 @@
 	name = "tracker electronics"
 	icon = 'icons/obj/doors/door_assembly.dmi'
 	icon_state = "door_electronics"
+	origin_tech = "power=3;engineering=2"
 	w_class = 2.0

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -15,6 +15,7 @@
 	desc = "A modified version of the basic laser gun, this one fires less concentrated energy bolts designed for target practice."
 	projectile_type = "/obj/item/projectile/beam/practice"
 	clumsy_check = 0
+	mech_flags = null // So it can be scanned by the Device Analyser
 
 /obj/item/weapon/gun/energy/laser/pistol
 	name = "laser pistol"
@@ -78,24 +79,24 @@ obj/item/weapon/gun/energy/laser/retro
 	projectile_type = "/obj/item/projectile/beam/captain"
 
 
-	New()
-		..()
-		processing_objects.Add(src)
+/obj/item/weapon/gun/energy/laser/captain/New()
+	..()
+	processing_objects.Add(src)
 
 
-	Destroy()
-		processing_objects.Remove(src)
-		..()
+/obj/item/weapon/gun/energy/laser/captain/Destroy()
+	processing_objects.Remove(src)
+	..()
 
 
-	process()
-		charge_tick++
-		if(charge_tick < 4) return 0
-		charge_tick = 0
-		if(!power_supply) return 0
-		power_supply.give(100)
-		update_icon()
-		return 1
+/obj/item/weapon/gun/energy/laser/captain/process()
+	charge_tick++
+	if(charge_tick < 4) return 0
+	charge_tick = 0
+	if(!power_supply) return 0
+	power_supply.give(100)
+	update_icon()
+	return 1
 
 
 
@@ -238,37 +239,38 @@ obj/item/weapon/gun/energy/laser/retro
 	icon_state = "bluetag"
 	item_state = null
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/guninhands_left.dmi', "right_hand" = 'icons/mob/in-hand/right/guninhands_right.dmi')
-	desc = "Standard issue weapon of the Imperial Guard"
+	desc = "Standard issue weapon of the Imperial Guard."
 	projectile_type = "/obj/item/projectile/beam/lastertag/blue"
-	origin_tech = "combat=1;magnets=2"
+	origin_tech = "magnets=2"
+	mech_flags = null // So it can be scanned by the Device Analyser
 	clumsy_check = 0
 	var/charge_tick = 0
 
-	special_check(var/mob/living/carbon/human/M)
-		if(ishuman(M))
-			if(istype(M.wear_suit, /obj/item/clothing/suit/bluetag))
-				return 1
-			to_chat(M, "<span class='warning'>You need to be wearing your laser tag vest!</span>")
-		return 0
+/obj/item/weapon/gun/energy/laser/bluetag/special_check(var/mob/living/carbon/human/M)
+	if(ishuman(M))
+		if(istype(M.wear_suit, /obj/item/clothing/suit/bluetag))
+			return 1
+		to_chat(M, "<span class='warning'>You need to be wearing your laser tag vest!</span>")
+	return 0
 
-	New()
-		..()
-		processing_objects.Add(src)
-
-
-	Destroy()
-		processing_objects.Remove(src)
-		..()
+/obj/item/weapon/gun/energy/laser/bluetag/New()
+	..()
+	processing_objects.Add(src)
 
 
-	process()
-		charge_tick++
-		if(charge_tick < 4) return 0
-		charge_tick = 0
-		if(!power_supply) return 0
-		power_supply.give(100)
-		update_icon()
-		return 1
+/obj/item/weapon/gun/energy/laser/bluetag/Destroy()
+	processing_objects.Remove(src)
+	..()
+
+
+/obj/item/weapon/gun/energy/laser/bluetag/process()
+	charge_tick++
+	if(charge_tick < 4) return 0
+	charge_tick = 0
+	if(!power_supply) return 0
+	power_supply.give(100)
+	update_icon()
+	return 1
 
 
 
@@ -277,37 +279,38 @@ obj/item/weapon/gun/energy/laser/retro
 	icon_state = "redtag"
 	item_state = null
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/guninhands_left.dmi', "right_hand" = 'icons/mob/in-hand/right/guninhands_right.dmi')
-	desc = "Standard issue weapon of the Imperial Guard"
+	desc = "Standard issue weapon of the Imperial Guard."
 	projectile_type = "/obj/item/projectile/beam/lastertag/red"
-	origin_tech = "combat=1;magnets=2"
+	origin_tech = "magnets=2"
+	mech_flags = null // So it can be scanned by the Device Analyser
 	clumsy_check = 0
 	var/charge_tick = 0
 
-	special_check(var/mob/living/carbon/human/M)
-		if(ishuman(M))
-			if(istype(M.wear_suit, /obj/item/clothing/suit/redtag))
-				return 1
-			to_chat(M, "<span class='warning'>You need to be wearing your laser tag vest!</span>")
-		return 0
+/obj/item/weapon/gun/energy/laser/bluetag/special_check(var/mob/living/carbon/human/M)
+	if(ishuman(M))
+		if(istype(M.wear_suit, /obj/item/clothing/suit/redtag))
+			return 1
+		to_chat(M, "<span class='warning'>You need to be wearing your laser tag vest!</span>")
+	return 0
 
-	New()
-		..()
-		processing_objects.Add(src)
-
-
-	Destroy()
-		processing_objects.Remove(src)
-		..()
+/obj/item/weapon/gun/energy/laser/bluetag/New()
+	..()
+	processing_objects.Add(src)
 
 
-	process()
-		charge_tick++
-		if(charge_tick < 4) return 0
-		charge_tick = 0
-		if(!power_supply) return 0
-		power_supply.give(100)
-		update_icon()
-		return 1
+/obj/item/weapon/gun/energy/laser/bluetag/Destroy()
+	processing_objects.Remove(src)
+	..()
+
+
+/obj/item/weapon/gun/energy/laser/bluetag/process()
+	charge_tick++
+	if(charge_tick < 4) return 0
+	charge_tick = 0
+	if(!power_supply) return 0
+	power_supply.give(100)
+	update_icon()
+	return 1
 
 
 /obj/item/weapon/gun/energy/megabuster

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -118,6 +118,7 @@ var/available_staff_transforms=list("monkey","robot","slime","xeno","human","fur
 	charge_cost = 100
 	projectile_type = "/obj/item/projectile/energy/floramut"
 	origin_tech = "materials=2;biotech=3;powerstorage=3"
+	mech_flags = null // So it can be scanned by the Device Analyser
 	modifystate = "floramut"
 	var/charge_tick = 0
 	var/mode = 0 //0 = mutate, 1 = yield boost, 2 = emag-mutate

--- a/code/modules/projectiles/guns/hookshot.dm
+++ b/code/modules/projectiles/guns/hookshot.dm
@@ -6,6 +6,7 @@
 	item_state = "hookshot"
 	slot_flags = SLOT_BELT
 	origin_tech = "materials=2;engineering=3;magnets=2"
+	mech_flags = null // So it can be scanned by the Device Analyser
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/guns_experimental.dmi', "right_hand" = 'icons/mob/in-hand/right/guns_experimental.dmi')
 	recoil = 0
 	flags = FPRINT

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -767,13 +767,15 @@
 	name = "Shaker"
 	desc = "A metal shaker to mix drinks in."
 	icon_state = "shaker"
+	origin_tech = "materials=1"
 	amount_per_transfer_from_this = 10
 	volume = 100
 
 /obj/item/weapon/reagent_containers/food/drinks/flask
 	name = "Captain's Flask"
-	desc = "A metal flask belonging to the captain"
+	desc = "A metal flask belonging to the captain."
 	icon_state = "flask"
+	origin_tech = "materials=1"
 	volume = 60
 
 /obj/item/weapon/reagent_containers/food/drinks/flask/detflask

--- a/code/modules/research/designs/engineering.dm
+++ b/code/modules/research/designs/engineering.dm
@@ -52,7 +52,7 @@
 
 /datum/design/superior_welding_goggles
 	name = "Superior Welding Goggles"
-	desc = "Welding goggles made from more expensive materials, strangely smells like potatoes. Allows for better vision than normal goggles.."
+	desc = "Welding goggles made from more expensive materials, strangely smells like potatoes. Allows for better vision than normal goggles."
 	id = "superior_welding_goggles"
 	req_tech = list("materials" = 3, "engineering" = 3)
 	build_type = PROTOLATHE

--- a/code/modules/research/mechanic/device_analyser.dm
+++ b/code/modules/research/mechanic/device_analyser.dm
@@ -81,16 +81,22 @@
 	if((O.mech_flags & MECH_SCAN_FAIL)==MECH_SCAN_FAIL)
 		return 0
 
-	var/list/techlist
+	var/list/techlist = O.give_tech_list() //Some items may have a specific techlist. Currently only used for solar assemblies, since they don't hold a circuitboard.
+	if(techlist)
+		return 1
+
 	if(istype(O, /obj/machinery))
 		var/obj/machinery/M = O
+
 		if(user && (!M.allowed(user) && M.mech_flags & MECH_SCAN_ACCESS) && !src.access_avoidance) //if we require access, and don't have it, and the scanner can't bypass it
 			return -2
+
 		if(M.component_parts)
 			for(var/obj/item/weapon/circuitboard/CB in M.component_parts) //fetching the circuit by looking in the parts
 				if(istype(CB))
 					techlist = ConvertReqString2List(CB.origin_tech)
 					break
+
 		else if(istype(M, /obj/machinery/computer))
 			var/obj/machinery/computer/C = M
 			if(C.circuit)

--- a/html/changelogs/9600baudsanalyzer.yml
+++ b/html/changelogs/9600baudsanalyzer.yml
@@ -1,0 +1,35 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general deleting of nice things)
+#   rscadd (general adding of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: 9600bauds
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+changes: 
+  - tweak: Added tech levels to many common items, so that they can be scanned with the Device Analyser. Notorious additions are PDA cartridges, Laser Tag equipment, Hookshots, Straightjacket/Muzzle/Blindfold, Pill collectors, Hailers, Modkits, and Shoulder holsters.


### PR DESCRIPTION
Also slays relative pathing.

List of things that can now be scanned by the Device Analyser (and thus mass-produced, if anyone gives enough of a fuck):
Laser Tag guns and vests
Practice Laser gun
Hookshot
Floral Somatoray
Telescopic Baton (given that stunbatons are scannable)
PDA Cartridges (Det-o-Matix cartridge only scannable with antag Mechanic scanner, we'll see if this ends up too abusable)
Shoulder Holster
All modkits currently available (Atmos goldsuit, Stormtrooper hardsuit, Spur parts)
Pill Collector
Welding Goggles, Superior Welding Goggles
Cameras, Camera Film (not sepia cameras)
Flashlights as well as children (desk lamps, lanterns, etc.)
Secure Briefcase
Hand Labeler
Pens
Hailer
Sunglasses
Science Goggles
Firesuits
Staightjacket, muzzle, blindfold, cane
Electropack
Universal Recorder
Shaker, Flask
