### PR TITLE
Clicking on a photo in newscaster shows its description + Fixes #7383

### DIFF
--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -32,8 +32,10 @@
 	var/backup_body =""
 	var/backup_author =""
 	var/is_admin_message = 0
+
 	var/icon/img = null
 	var/icon/backup_img
+	var/img_info = "" //Stuff like "You can see Honkers on the photo. Honkins looks hurt..."
 
 /datum/feed_channel
 	var/channel_name=""
@@ -407,7 +409,7 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 							dat+="-[MESSAGE.body] <BR>"
 							if(MESSAGE.img)
 								usr << browse_rsc(MESSAGE.img, "tmp_photo[i].png")
-								dat+="<img src='tmp_photo[i].png' width = '180'><BR><BR>"
+								dat+="<a href='?src=\ref[src];show_photo_info=\ref[MESSAGE]'><img src='tmp_photo[i].png' width = '180'></a><BR><BR>"
 							dat+="<FONT SIZE=1>\[Story by <FONT COLOR='maroon'>[MESSAGE.author]</FONT>\]</FONT><BR>"
 
 				// AUTOFIXED BY fix_string_idiocy.py
@@ -714,9 +716,11 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 					if(istype(photo,/obj/item/weapon/photo))
 						var/obj/item/weapon/photo/P = photo
 						newMsg.img = P.img
+						newMsg.img_info = P.info
 					else if(istype(photo,/datum/picture))
 						var/datum/picture/P = photo
 						newMsg.img = P.fields["img"]
+						newMsg.img_info = P.fields["info"]
 				feedback_inc("newscaster_stories",1)
 				for(var/datum/feed_channel/FC in news_network.network_channels)
 					if(FC.channel_name == src.channel_name)
@@ -959,6 +963,14 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 			var/datum/feed_channel/FC = locate(href_list["pick_censor_channel"])
 			src.viewing_channel = FC
 			src.screen = NEWSCASTER_CENSORSHIP_CHANNEL
+			src.updateUsrDialog()
+
+		else if(href_list["show_photo_info"])
+			var/datum/feed_message/FM = locate(href_list["show_photo_info"])
+
+			if(istype(FM) && FM.img_info)
+				usr.show_message("<span class='info'>[FM.img_info]</span>", MESSAGE_SEE)
+
 			src.updateUsrDialog()
 
 		else if(href_list["refresh"])

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -132,6 +132,7 @@
 						p.pixel_x = rand(-10, 10)
 						p.pixel_y = rand(-10, 10)
 						p.blueprints = photocopy.blueprints //a copy of a picture is still good enough for the syndicate
+						p.info = photocopy.info
 
 						sleep(15)
 					else

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -76,7 +76,7 @@
 
 	var/n_name = copytext(sanitize(input(usr, "What would you like to label the photo?", "Photo Labelling", null)  as text), 1, MAX_NAME_LEN)
 	//loc.loc check is for making possible renaming photos in clipboards
-	if((loc == usr || loc.loc && loc.loc == usr) && !usr.isUnconscious())
+	if(!usr.isUnconscious() && Adjacent(usr))
 		name = "photo[(n_name ? text("- '[n_name]'") : null)]"
 	add_fingerprint(usr)
 

--- a/html/changelogs/unid-photo.yml
+++ b/html/changelogs/unid-photo.yml
@@ -1,0 +1,35 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general deleting of nice things)
+#   rscadd (general adding of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: Unid
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+changes: 
+- tweak: When reading a newscaster, clicking on a photo will show you its description


### PR DESCRIPTION
Fixes #7383

Clicking on a photo in a newscaster feed will show you its description

![](http://puu.sh/mdAmW/30745e703f.png)
