### PR TITLE
Rewrites the fax code and stuff

### DIFF
--- a/code/WorkInProgress/kilakk/fax.dm
+++ b/code/WorkInProgress/kilakk/fax.dm
@@ -203,19 +203,23 @@ var/list/alldepartments = list("Central Command")
 
 /proc/Centcomm_fax(var/obj/item/weapon/paper/sent, var/sentname, var/mob/Sender)
 
-
+//why the fuck doesnt the thing show as orange
 	var/msg = "<span class='notice'><b><font color='orange'>CENTCOMM FAX: </font>[key_name(Sender, 1)] (<A HREF='?_src_=holder;adminplayeropts=\ref[Sender]'>PP</A>) (<A HREF='?_src_=vars;Vars=\ref[Sender]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=\ref[Sender]'>SM</A>) (<A HREF='?_src_=holder;adminplayerobservejump=\ref[Sender]'>JMP</A>) (<A HREF='?_src_=holder;secretsadmin=check_antagonist'>CA</A>) (<a href='?_src_=holder;CentcommFaxReply=\ref[Sender]'>RPLY</a>)</b>: Receiving '[sentname]' via secure connection ... <a href='?_src_=holder;CentcommFaxView=\ref[sent]'>view message</a></span>"
-	to_chat(admins, msg)
-	to_chat(admins, 'sound/effects/fax.ogg')
+	for (var/client/C in admins)
+		if(C.prefs.special_popup)
+			C << output(msg, "window1.msay_output")//if i get told to make this a proc imma be fuckin mad
+		else
+			to_chat(C, msg)
+		to_chat(C, 'sound/effects/fax.ogg')
 
-proc/SendFax(var/sent, var/sentname, var/mob/Sender, var/dpt)
+proc/SendFax(var/sent, var/sentname, var/mob/Sender, var/dpt, var/centcomm)
 
 
 
 
 	for(var/obj/machinery/faxmachine/F in allfaxes)
 
-		if( F.department == dpt )
+		if(centcomm || F.department == dpt )
 			if(! (F.stat & (BROKEN|NOPOWER) ) )
 
 				flick("faxreceive", F)
@@ -223,8 +227,20 @@ proc/SendFax(var/sent, var/sentname, var/mob/Sender, var/dpt)
 				// give the sprite some time to flick
 				spawn(20)
 					var/obj/item/weapon/paper/P = new /obj/item/weapon/paper( F.loc )
-					P.name = "[sentname]"
+					if (centcomm)
+						P.name = "[command_name()]- [sentname]"
+					else//probably a 
+						P.name = "[sentname]"
 					P.info = "[sent]"
 					P.update_icon()
 
 					playsound(F.loc, "sound/effects/fax.ogg", 50, 1)
+
+					if(centcomm)
+						var/image/stampoverlay = image('icons/obj/bureaucracy.dmi')
+						stampoverlay.icon_state = "paper_stamp-cent"
+						if(!P.stamped)
+							P.stamped = new
+						P.stamped += /obj/item/weapon/stamp
+						P.overlays += stampoverlay
+						P.stamps += "<HR><i>This paper has been stamped by the Central Command Quantum Relay.</i>"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -14,6 +14,7 @@ var/list/admin_verbs_default = list(
 var/list/admin_verbs_admin = list(
 	/client/proc/set_base_turf,
 	/datum/admins/proc/delay,
+	/client/proc/SendCentcommFax,		/*sends a fax to all fax machines*/
 	/client/proc/player_panel,			/*shows an interface for all players, with links to various panels (old style)*/
 	/client/proc/player_panel_new,		/*shows an interface for all players, with links to various panels*/
 	/client/proc/invisimin,				/*allows our mob to go invisible/visible*/
@@ -1042,3 +1043,18 @@ var/list/admin_verbs_mod = list(
 	message_admins("[key_name_admin(usr)] has stopped all media.", 1)
 
 	stop_all_media()
+
+/client/proc/SendCentcommFax()
+	set	category = "Fun"
+	set name = "Send Fax"
+	set desc = "Sends a fax to all fax machines."
+
+	var/sent = input(src, "Please enter a message send via secure connection. NOTE: BBCode does not work, but HTML tags do! Use <br> for line breaks.", "Outgoing message from Centcomm", "") as message|null
+	if(!sent)	return
+
+	var/sentname = input(src, "Pick a title for the report", "Title") as text|null
+
+	SendFax(sent, sentname, centcomm = 1)
+
+	log_admin("[key_name(src)] sent a fax to all machines.: [sent]")
+	message_admins("[key_name_admin(src)] sent a fax to all machines.", 1)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1916,37 +1916,16 @@
 	else if(href_list["CentcommFaxReply"])
 		var/mob/living/carbon/human/H = locate(href_list["CentcommFaxReply"])
 
-		var/input = input(src.owner, "Please enter a message to reply to [key_name(H)] via secure connection. NOTE: BBCode does not work, but HTML tags do! Use <br> for line breaks.", "Outgoing message from Centcomm", "") as message|null
-		if(!input)	return
 
-		var/customname = input(src.owner, "Pick a title for the report", "Title") as text|null
+		var/sent = input(src.owner, "Please enter a message to reply to [key_name(H)] via secure connection. NOTE: BBCode does not work, but HTML tags do! Use <br> for line breaks.", "Outgoing message from Centcomm", "") as message|null
+		if(!sent)	return
 
-		for(var/obj/machinery/faxmachine/F in allfaxes)
-			if(! (F.stat & (BROKEN|NOPOWER) ) )
+		var/sentname = input(src.owner, "Pick a title for the report", "Title") as text|null
 
-				// animate! it's alive!
-				flick("faxreceive", F)
-
-				// give the sprite some time to flick
-				spawn(20)
-					var/obj/item/weapon/paper/P = new /obj/item/weapon/paper( F.loc )
-					P.name = "[command_name()]- [customname]"
-					P.info = input
-					P.update_icon()
-
-					playsound(F.loc, "sound/items/polaroid1.ogg", 50, 1)
-
-					// Stamps
-					var/image/stampoverlay = image('icons/obj/bureaucracy.dmi')
-					stampoverlay.icon_state = "paper_stamp-cent"
-					if(!P.stamped)
-						P.stamped = new
-					P.stamped += /obj/item/weapon/stamp
-					P.overlays += stampoverlay
-					P.stamps += "<HR><i>This paper has been stamped by the Central Command Quantum Relay.</i>"
+		SendFax(sent, sentname, centcomm = 1)
 
 		to_chat(src.owner, "Message reply to transmitted successfully.")
-		log_admin("[key_name(src.owner)] replied to a fax message from [key_name(H)]: [input]")
+		log_admin("[key_name(src.owner)] replied to a fax message from [key_name(H)]: [sent]")
 		message_admins("[key_name_admin(src.owner)] replied to a fax message from [key_name_admin(H)]", 1)
 
 

--- a/code/modules/admin/verbs/pray.dm
+++ b/code/modules/admin/verbs/pray.dm
@@ -24,7 +24,10 @@
 
 	for(var/client/C in admins)
 		if(C.prefs.toggles & CHAT_PRAYER)
-			to_chat(C, msg)
+			if(C.prefs.special_popup)
+				C << output(msg, "window1.msay_output")//if i get told to make this a proc imma be fuckin mad
+			else
+				to_chat(C, msg)
 			to_chat(C, 'sound/effects/prayer.ogg')
 
 	if(!stat)

--- a/html/changelogs/DeadPoolJ.yml
+++ b/html/changelogs/DeadPoolJ.yml
@@ -1,0 +1,5 @@
+author: DeadPoolJ
+changes: 
+  - rscadd: Made a new admin verb, Send Fax, which lets admins send a fax without having to reply to one first.
+  - rscadd: Made faxes and prayers show up in the special window if admins have it enabled.)
+delete-after: true


### PR DESCRIPTION
Makes a new admin verb, Send-Fax, which is like replying but without needing a fax to reply to.

Redoes the reply code to call SendFax() instead of hardcoding it.

Also makes faxes and prayers show up in the Special window if enabled.
