### PR TITLE
Quick tweaks to Meteors gamemode

### DIFF
--- a/code/game/gamemodes/meteor/meteor.dm
+++ b/code/game/gamemodes/meteor/meteor.dm
@@ -9,8 +9,8 @@
 	var/const/meteorannouncedelay_h = 3000 //Upper bound on announcement, here 5 minutes
 	var/meteorannouncedelay = 2400 //Default final announcement delay
 	var/const/supplydelay = 100 //Delay before meteor supplies are spawned in tenth of seconds
-	var/const/meteordelay_l = 3000 //Lower bound to meteor wave arrival, here 5 minutes
-	var/const/meteordelay_h = 4500 //Higher bound to meteor wave arrival, here 7 and a half minutes
+	var/const/meteordelay_l = 4500 //Lower bound to meteor wave arrival, here 7.5 minutes
+	var/const/meteordelay_h = 6000 //Higher bound to meteor wave arrival, here 10 minutes
 	var/const/meteorshuttlemultiplier = 3 //How much more will we need to hold out ? Here 30 minutes until the shuttle arrives. Multiplies by 10
 	var/meteordelay = 7500 //Default final meteor delay
 	var/meteors_allowed = 0 //Can we send the meteors ?
@@ -80,7 +80,7 @@
 
 /datum/game_mode/meteor/process()
 	if(meteors_allowed)
-		var/meteors_in_wave = rand(60, 125) //Between 60 and 125 meteors per wave
+		var/meteors_in_wave = rand(150, 200) //Between 150 and 200 meteors per wave
 		meteor_wave(meteors_in_wave, 3)
 	return
 

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -276,7 +276,7 @@
 
 /obj/effect/meteor/big/cluster/Bump(atom/A)
 
-	explosion(get_turf(src), 1, 0, 0, 0, 0, 1, 0) //Enough to destroy whatever was in the way
+	explosion(get_turf(A), 1, 0, 0, 0, 0, 1, 0) //Enough to destroy whatever was in the way
 	var/failcount = 0
 	for(var/i = 0, i < 3, i++)
 		if(failcount >= 5)

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -6,7 +6,9 @@
 /var/max_meteor_size = 0 //One for small waves, two for big waves, three for massive waves, four for boss waves
 /var/chosen_dir = 1
 
-/proc/meteor_wave(var/number = meteors_in_wave, var/max_size = 0, var/list/types = null) //Call above constants to change
+//Call above constants to change
+/proc/meteor_wave(var/number = meteors_in_wave, var/max_size = 0, var/list/types = null)
+
 	if(!ticker || meteor_wave_active)
 		return
 	meteor_wave_active = 1
@@ -62,7 +64,6 @@
 			bhangmeter.say("Detected: [wave_name], containing [wave_size] objects up to [meteor_l_size] size and incoming from the [wave_l_dir], will strike in [meteor_delay/10] seconds.")
 
 /proc/spawn_meteor(var/chosen_dir, var/meteorpath = null)
-
 
 	var/startx
 	var/starty
@@ -276,11 +277,18 @@
 /obj/effect/meteor/big/cluster/Bump(atom/A)
 
 	explosion(get_turf(src), 1, 0, 0, 0, 0, 1, 0) //Enough to destroy whatever was in the way
+	var/failcount = 0
 	for(var/i = 0, i < 3, i++)
+		if(failcount >= 5)
+			break
 		var/obj/effect/meteor/M = new /obj/effect/meteor(get_turf(src))
 		var/c_endy = rand(TRANSITIONEDGE, world.maxy - TRANSITIONEDGE)
 		var/c_endx = rand(TRANSITIONEDGE, world.maxx - TRANSITIONEDGE)
 		var/c_pickedgoal = locate(c_endx, c_endy, 1)
+		if(!c_pickedgoal)
+			qdel(M)
+			i-- //Try again
+			failcount++ //Keep a track of failures
 		walk_towards(M, c_pickedgoal, 1)
 	qdel(src)
 


### PR DESCRIPTION
Based on observations or requests. Those are the ones I can do immediately, the rest will have to wait until I work on the next stage of this
- Increased "build time" (time from announcement to meteors arriving) to 7.5-10 from 5-7.5
- To make up for that, the notable lack of lag, and an observation that meteors could easily be held-off and leave about half of the station mostly intact, increased meteor numbers from 60-125 to 150-200. This will give a challenge to the crew for sure, although competent Engineers can set up well-protected shielding to save entire wings of the station
- Allow the big cluster meteor to fail a total of five times with picking a destination for all clusters. If it does, break, this should hopefully prevent the static meteors that were observed here and there
- Big cluster meteors now devastate the turf they hit, instead of their own, as originally intended

<s>Currently, with wave spacing of 30-45 seconds, that brings us to 35-40 waves of 150-200 meteors, which is 5250 to 8000 meteors total to shuttle arrival.</s> Not including misses later in the round, shuttle wall hits and meteor types, that means the station will be gone without shielding efforts, and might survive if shielded properly
