### PR TITLE
Importing/exporting of assembly frames from/to text

### DIFF
--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -1,6 +1,8 @@
 #define VALUE_VARIABLE_NAME 1 //See var/list/accessible_values below!
 #define VALUE_VARIABLE_TYPE 2
 
+var/global/list/assembly_short_name_to_type = list() //Please, I beg you, don't give two different types of assembly the same short_name
+
 /obj/item/device/assembly
 	name = "assembly"
 	var/short_name //Short name of the assembly. If the name is "remote signalling device", short_name must be something like "signaler"


### PR DESCRIPTION
Please fucking kill me this was awful

Sorry here's what I actually did:
Assembly frames now have seven new procs. (Wait calm down keep reading.) One just handles insertion of assemblies into the frame. It's basically the same as before except it doesn't assume a mob is holding the assembly and it's handled outside of attackby(), which now calls this proc to insert assemblies.
Two of the remaining six are for debug purposes; I'll explain them at the end, but they're pretty simple.
Two of the others are mainly meant to be used by one of the others. You can read the code to see exactly what they do.

The remaining two are the real part of this PR.
The first is to_text(). It simply returns a somewhat human-readable string containing the information about the assemblies inside (well, all the information that can be accessed by the assembly frame, at least).
The other is from_text(). This is the COOL part of this PR.
from_text() accepts three args. The first is the text that to_text() outputs, or at least a string of that form. Given no other args, the assembly frame assembles itself from the text given, just creating assemblies as needed.
If the second arg is true, the third arg must be given. The third arg is a list of assemblies available to the assembly frame to set itself up as the text data dictates. If the list contains the assemblies the frame requires, it will take and configure them, preserving the order of individual assemblies of a type (not types of assemblies, which are in the order dictated by the text data) in the list from which they were taken. The preservation of the order is important for things that have variables not in accessible_values, such as light tile controllers. (If the list does not contain the required assemblies, nothing really happens.)

I left in the two debug procs because they're the only real way to use this for now. I'm too tired and done with this fucking shit to code a proper in-game way to use this feature at the moment. For the time being, admins can fuck around with debug_to_text() and debug_from_text().

debug_to_text() spawns a piece of paper containing the output of to_text() on the assembly frame's turf.
debug_from_text() accepts one arg. It defaults to false. If left false, it just calls from_text() with the data off the first piece of paper it finds in the same loc as the assembly frame. If that arg is set to true, it calls from_text() with the data of the first paper it finds in the loc and uses the first cardboard box (of any kind) it finds in that loc as the list of assemblies to draw from.

Anyone who wants to is ~~invited~~ encouraged to code a machine or something that gives players an actual way to use this feature.

Fully tested for normal use, at least. It might be possible to break it if you try to do so, but I _think_ I did a pretty good job on the validation.
