### PR TITLE
Fixes runtimes on mommi gibbing

### DIFF
--- a/code/modules/mob/living/silicon/mommi/death.dm
+++ b/code/modules/mob/living/silicon/mommi/death.dm
@@ -14,7 +14,7 @@
 		var/obj/item/found = locate(tool_state) in src.module.modules
 		if(!found && tool_state != src.module.emag)
 			var/obj/item/TS = tool_state
-			drop_item(TS, force_drop = 1)
+			drop_item(TS)
 	qdel(src)
 
 /mob/living/silicon/robot/mommi/dust()


### PR DESCRIPTION
Fixes #7451
`drop_item(TS, force_drop = 1)`

That's not how MoMMI drop proc works
