### PR TITLE
Reagent stuff

### DIFF
--- a/code/modules/mob/living/carbon/human/life/handle_chemicals_in_body.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_chemicals_in_body.dm
@@ -11,8 +11,7 @@
 				if(/datum/species/diona)	alien = IS_DIONA
 				if(/datum/species/vox)	alien = IS_VOX
 				if(/datum/species/plasmaman)	alien = IS_PLASMA
-		spawn()
-			reagents.metabolize(src,alien)
+		reagents.metabolize(src,alien)
 
 	var/total_plasmaloss = 0
 	for(var/obj/item/I in src)

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -444,40 +444,24 @@ datum
 						for(var/datum/reagent/R in reagent_list)
 							if(ismob(A))
 								if(isanimal(A))
-									spawn(0)
-										if(!R) return
-										else R.reaction_animal(A, TOUCH, R.volume+volume_modifier)
+									R.reaction_animal(A, TOUCH, R.volume+volume_modifier)
 								else
-									spawn(0)
-										if(!R) return
-										else R.reaction_mob(A, TOUCH, R.volume+volume_modifier)
+									R.reaction_mob(A, TOUCH, R.volume+volume_modifier)
 							if(isturf(A))
-								spawn(0)
-									if(!R) return
-									else R.reaction_turf(A, R.volume+volume_modifier)
+								R.reaction_turf(A, R.volume+volume_modifier)
 							if(isobj(A))
-								spawn(0)
-									if(!R) return
-									else R.reaction_obj(A, R.volume+volume_modifier)
+								R.reaction_obj(A, R.volume+volume_modifier)
 					if(INGEST)
 						for(var/datum/reagent/R in reagent_list)
 							if(ismob(A))
 								if(isanimal(A))
-									spawn(0)
-										if(!R) return
-										else R.reaction_animal(A, INGEST, R.volume+volume_modifier)
+									R.reaction_animal(A, INGEST, R.volume+volume_modifier)
 								else
-									spawn(0)
-										if(!R) return
-										else R.reaction_mob(A, INGEST, R.volume+volume_modifier)
+									R.reaction_mob(A, INGEST, R.volume+volume_modifier)
 							if(isturf(A) && R)
-								spawn(0)
-									if(!R) return
-									else R.reaction_turf(A, R.volume+volume_modifier)
+								R.reaction_turf(A, R.volume+volume_modifier)
 							if(isobj(A) && R)
-								spawn(0)
-									if(!R) return
-									else R.reaction_obj(A, R.volume+volume_modifier)
+								R.reaction_obj(A, R.volume+volume_modifier)
 				return
 
 			add_reagent(var/reagent, var/amount, var/list/data=null)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -30,6 +30,7 @@
 	var/alpha = 255
 
 /datum/reagent/proc/reaction_mob(var/mob/living/M, var/method = TOUCH, var/volume)
+	set waitfor = 0
 
 	if(!holder)
 		return 1
@@ -66,6 +67,7 @@
 					M.reagents.add_reagent(self.id, self.volume/2) //Hardcoded, transfer half of volume
 
 /datum/reagent/proc/reaction_animal(var/mob/living/simple_animal/M, var/method=TOUCH, var/volume)
+	set waitfor = 0
 
 	if(!holder)
 		return 1
@@ -78,6 +80,7 @@
 	M.reagent_act(self.id, method, volume)
 
 /datum/reagent/proc/reaction_obj(var/obj/O, var/volume)
+	set waitfor = 0
 
 	if(!holder)
 		return 1
@@ -87,6 +90,7 @@
 	src = null
 
 /datum/reagent/proc/reaction_turf(var/turf/simulated/T, var/volume)
+	set waitfor = 0
 
 	if(!holder)
 		return 1
@@ -96,6 +100,7 @@
 	src = null
 
 /datum/reagent/proc/on_mob_life(var/mob/living/M, var/alien)
+	set waitfor = 0
 
 	if(!holder)
 		return 1


### PR DESCRIPTION
Fix #7482 I expect
fixes #7479

Since these reaction procs were spawned off reagents clear was being called BEFORE the reagents were reacting. 

This sets waitfor = 0 for these procs so that they will automatically spawn off instead of delaying the reaction if sleep() is used in them, but still let's them react before clear_reagents is called.