### PR TITLE
Updates the changelog to reflect the fact that viruses mutating through radiation has been removed for a few months now

### DIFF
--- a/html/changelogs/Wizardcrying_redbead.yml
+++ b/html/changelogs/Wizardcrying_redbead.yml
@@ -1,0 +1,35 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general deleting of nice things)
+#   rscadd (general adding of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: Wizardcrying
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+changes: 
+- tweak: Viruses no longer mutate their effects when their host catches some radiation. This change actually dates back to Nov. 10, 2015, but it was never added to the changelog until now.


### PR DESCRIPTION
Since #6495 was never added to changelogs, a lot of people never found out about it. Many people both in-game and in the thread still believe that "beneficial" viruses will turn into 40 variations of gibbingtons the moment a radstorm hits the station, as it used to be.
I think it's important that the changelog is updated for changes as big as these.
Properly credited to @Wizardcrying
Fixes #6492
