### PR TITLE
Beepsky will no longer target monkeys unless they have jungle fever

### DIFF
--- a/code/game/machinery/bots/secbot.dm
+++ b/code/game/machinery/bots/secbot.dm
@@ -646,10 +646,10 @@ Auto Patrol: []"},
 			if((C.name == src.oldtarget_name) && (world.time < src.last_found + 100))
 				continue
 
-			if(istype(C, /mob/living/carbon/human))
+			if(ishuman(C))
 				src.threatlevel = src.assess_perp(C)
-			else if((src.idcheck) && (istype(C, /mob/living/carbon/monkey)))
-				src.threatlevel = 4
+			else if(ismonkey(C) && isbadmonkey(C)) //Beepsky can detect jungle fever monkeys
+				src.threatlevel = 666
 			else
 				continue
 		else


### PR DESCRIPTION
Currently, monkeys will be targeted if ID check is on, which is stupid (monkeys can't wear IDs) and causes Beepsky to get permanently stuck trying to arrest the Genetics monkeys on some maps like Meta or if manually dragged there

Beepsky will now go after "bad monkeys" (jungle fever) specifically. Also threat level 666 because Monkeys gamemode is fucking hell and whoever forces it is worse than Hitler

Also the runtime operators in assess_perp trigger me deeply, but if I fix that I completely overhaul Beepsky including balance and formatting changes for please don't mention it again unless you want me to do that

Fixes #7505
