### PR TITLE
Syndie speedloader kit modified

### DIFF
--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -201,8 +201,7 @@
 
 /obj/item/weapon/storage/box/syndie_kit/ammo/New()
 	..()
-	new /obj/item/ammo_storage/speedloader/a357/empty(src)
-	new /obj/item/ammo_storage/box/a357(src)
+	new /obj/item/ammo_storage/speedloader/a357(src)
 	return
 
 /obj/item/weapon/storage/box/syndie_kit/flaregun

--- a/html/changelogs/Dylanstrategie.yml
+++ b/html/changelogs/Dylanstrategie.yml
@@ -1,2 +1,3 @@
 author: Dylanstrategie
-changes: []
+#delete-after: True
+changes:

--- a/html/changelogs/Dylanstrategie.yml
+++ b/html/changelogs/Dylanstrategie.yml
@@ -1,3 +1,3 @@
 author: Dylanstrategie
 #delete-after: True
-changes:
+changes: []

--- a/html/changelogs/Dylanstrategie_Speedload.yml
+++ b/html/changelogs/Dylanstrategie_Speedload.yml
@@ -1,0 +1,4 @@
+author: Dylanstrategie
+delete-after: True
+changes:
+- tweak: Change Syndicate ammo box to contain a loaded speedloader, instead of an empty speedloader and an ammo box (with as many bullets)

--- a/html/changelogs/Dylanstrategie_Speedload.yml
+++ b/html/changelogs/Dylanstrategie_Speedload.yml
@@ -1,4 +1,4 @@
 author: Dylanstrategie
 delete-after: True
-changes:
+changes: []
 - tweak: Change Syndicate ammo box to contain a loaded speedloader, instead of an empty speedloader and an ammo box (with as many bullets)

--- a/html/changelogs/Dylanstrategie_Speedload.yml
+++ b/html/changelogs/Dylanstrategie_Speedload.yml
@@ -1,4 +1,4 @@
 author: Dylanstrategie
 delete-after: True
-changes: []
+changes:
 - tweak: Change Syndicate ammo box to contain a loaded speedloader, instead of an empty speedloader and an ammo box (with as many bullets)


### PR DESCRIPTION
The syndie ammo kit now gives a filled a357 speedloader instead of an empty one and an ammo box, to save the syndie some time

Honestly, for the cost, that kit seems pretty fucking shit, but I'm not going to balance anything

Fixes #6875
