### PR TITLE
Fix missing Adjacency check on PDA reagent scan

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -2276,6 +2276,8 @@ obj/item/device/pda/AltClick()
 /obj/item/device/pda/preattack(atom/A as mob|obj|turf|area, mob/user as mob)
 	switch(scanmode)
 		if(3)
+			if(!A.Adjacent(user))
+				return
 			if(!isnull(A.reagents))
 				if(A.reagents.reagent_list.len > 0)
 					var/reagents_length = A.reagents.reagent_list.len


### PR DESCRIPTION
The PDA was able to scan reagents at any range, this is no longer the case

Fixes #7007
