### PR TITLE
Add a Security GPS to all Security, Captain, HoP

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -29,6 +29,7 @@
 		new /obj/item/clothing/suit/armor/captain(src)
 		new /obj/item/weapon/melee/telebaton(src)
 		new /obj/item/clothing/under/dress/dress_cap(src)
+		new /obj/item/device/gps/secure(src)
 		return
 
 
@@ -52,9 +53,10 @@
 		new /obj/item/weapon/cartridge/hop(src)
 		new /obj/item/device/radio/headset/heads/hop(src)
 		new /obj/item/weapon/storage/box/ids(src)
-		new /obj/item/weapon/storage/box/ids( src )
+		new /obj/item/weapon/storage/box/ids(src)
 		new /obj/item/weapon/gun/energy/gun(src)
 		new /obj/item/device/flash(src)
+		new /obj/item/device/gps/secure(src)
 		return
 
 /obj/structure/closet/secure_closet/hop2
@@ -120,6 +122,7 @@
 		new /obj/item/weapon/gun/energy/gun(src)
 		new /obj/item/clothing/accessory/holster/waist(src)
 		new /obj/item/weapon/melee/telebaton(src)
+		new /obj/item/device/gps/secure(src)
 		return
 
 
@@ -156,6 +159,7 @@
 		new /obj/item/weapon/gun/energy/taser(src)
 		new /obj/item/weapon/storage/box/bolas(src)
 		new /obj/item/weapon/batteringram(src)
+		new /obj/item/device/gps/secure(src)
 		return
 
 
@@ -257,6 +261,7 @@
 		new /obj/item/ammo_storage/box/c38(src)
 		new /obj/item/weapon/gun/projectile/detective(src)
 		new /obj/item/clothing/accessory/holster/armpit(src)
+		new /obj/item/device/gps/secure(src)
 		return
 
 /obj/structure/closet/secure_closet/detective/update_icon()
@@ -293,8 +298,8 @@
 
 	New()
 		..()
-		new /obj/item/clothing/under/color/prisoner( src )
-		new /obj/item/clothing/shoes/orange( src )
+		new /obj/item/clothing/under/color/prisoner(src)
+		new /obj/item/clothing/shoes/orange(src)
 		return
 
 
@@ -307,12 +312,12 @@
 		..()
 		sleep(2)
 		new /obj/item/clothing/shoes/brown(src)
-		new /obj/item/weapon/paper/Court (src)
-		new /obj/item/weapon/paper/Court (src)
-		new /obj/item/weapon/paper/Court (src)
+		new /obj/item/weapon/paper/Court(src)
+		new /obj/item/weapon/paper/Court(src)
+		new /obj/item/weapon/paper/Court(src)
 		new /obj/item/weapon/pen (src)
-		new /obj/item/clothing/suit/judgerobe (src)
-		new /obj/item/clothing/head/powdered_wig (src)
+		new /obj/item/clothing/suit/judgerobe(src)
+		new /obj/item/clothing/head/powdered_wig(src)
 		new /obj/item/weapon/storage/briefcase(src)
 		return
 


### PR DESCRIPTION
Add a Security GPS to the following lockers :
- Warden
- Detective
- HoS
- Captain
- HoP

All of these crewmen need Security GPS because Security MUST know where they are at all times (all are obvious except HoP, which gets it because he becomes Captain if old Captain is dead or missing)

A tiny bit of formatting while I'm in here because jesus christ why are those spaces here

Fixes #7079
