### PR TITLE
Change observer following to use locked_to methods

### DIFF
--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -9,7 +9,7 @@
 
 	// Things you might plausibly want to follow
 	if((ismob(A) && A != src) || istype(A,/obj/machinery/bot) || istype(A,/obj/machinery/singularity))
-		ManualFollow(A)
+		manual_follow(A)
 
 	// Otherwise jump
 	else

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -475,43 +475,49 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 /mob/dead/observer/verb/follow()
 	set category = "Ghost"
-	set name = "Follow" // "Haunt"
-	set desc = "Follow and haunt a mob."
+	set name = "Haunt" //Flavor name for following mobs
+	set desc = "Haunt a mob, stalking them everywhere they go."
 
 	var/list/mobs = getmobs()
 	var/input = input("Please, select a mob!", "Haunt", null, null) as null|anything in mobs
 	var/mob/target = mobs[input]
-	ManualFollow(target)
+	manual_follow(target)
 
-// This is the ghost's follow verb with an argument
-/mob/dead/observer/proc/ManualFollow(var/atom/movable/target)
+/mob/dead/observer/verb/end_follow()
+	set category = "Ghost"
+	set name = "Stop Haunting"
+	set desc = "Stop haunting a mob. They weren't worth your eternal time anyways."
+
+	if(locked_to)
+		manual_stop_follow(locked_to)
+
+//This is the ghost's follow verb with an argument
+/mob/dead/observer/proc/manual_follow(var/atom/movable/target)
 	if(target)
 		var/turf/targetloc = get_turf(target)
 		var/area/targetarea = get_area(target)
 		if(targetarea && targetarea.anti_ethereal && !isAdminGhost(usr))
 			to_chat(usr, "<span class='sinister'>You can sense a sinister force surrounding that mob, your spooky body itself refuses to follow it.</span>")
 			return
-		if(targetloc.holy && ((src.invisibility == 0) || (src.mind in ticker.mode.cult)))
+		if(targetloc.holy && ((!invisibility) || (mind in ticker.mode.cult)))
 			to_chat(usr, "<span class='warning'>You cannot follow a mob standing on holy grounds!</span>")
 			return
 		if(target != src)
-			if(following && following == target)
-				return
-			following = target
-			to_chat(src, "<span class='notice'>Now following [target]</span>")
-			spawn(0)
-				var/turf/pos = get_turf(src)
-				while(loc == pos && target && following == target && client)
-					var/turf/T = get_turf(target)
-					if(!T)
-						break
-					// To stop the ghost flickering.
-					if(loc != T)
-						loc = T
-					pos = loc
-					sleep(15)
-				following = null
+			if(locked_to)
+				if(locked_to == target) //Trying to follow same target, don't do anything
+					return
+				manual_stop_follow(locked_to) //So you can switch follow target on a whim
+			target.lock_atom(src)
+			to_chat(src, "<span class='sinister'>You are now haunting \the [target]</span>")
 
+/mob/dead/observer/proc/manual_stop_follow(var/atom/movable/target)
+
+	if(!target)
+		to_chat(src, "<span class='warning'>You are not currently haunting anyone.</span>")
+		return
+	else
+		to_chat(src, "<span class='sinister'>You are no longer haunting \the [target].</span>")
+		target.unlock_atom(src)
 
 /mob/dead/observer/verb/jumptomob() //Moves the ghost instead of just changing the ghosts's eye -Nodrak
 	set category = "Ghost"

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -386,7 +386,11 @@
 	var/turf/mobloc = get_turf(mob)
 
 	switch(mob.incorporeal_move)
-		if(1)
+		if(INCORPOREAL_GHOST)
+			if(isobserver(mob)) //Typecast time
+				var/mob/dead/observer/observer = mob
+				if(observer.locked_to) //Ghosts can move at any time to unlock themselves (in theory from following a mob)
+					observer.manual_stop_follow(observer.locked_to)
 			var/turf/T = get_step(mob, direct)
 			var/area/A = get_area(T)
 			if(A && A.anti_ethereal && !isAdminGhost(mob))
@@ -397,7 +401,7 @@
 				else
 					mob.forceEnter(get_step(mob, direct))
 					mob.dir = direct
-		if(2)
+		if(INCORPOREAL_NINJA)
 			if(prob(50))
 				var/locx
 				var/locy
@@ -435,7 +439,7 @@
 				anim(mobloc,mob,'icons/mob/mob.dmi',,"shadow",,mob.dir)
 				mob.forceEnter(get_step(mob, direct))
 			mob.dir = direct
-		if(3) //Jaunting, without needing to be done through relaymove
+		if(INCORPOREAL_ETHEREAL) //Jaunting, without needing to be done through relaymove
 			var/turf/newLoc = get_step(mob,direct)
 			if(!(newLoc.flags & NOJAUNT))
 				mob.forceEnter(newLoc)


### PR DESCRIPTION
- Change Follow into Haunt, because flavor
- Add Stop Haunting verb (stop following), if you can't figure out how it works
- Following mobs now lock you to them, instead of the extremely convoluted method used before. This will make ghost following a ton more responsive, stop the massive wall of delayed movement observers, and possibly even reduce lag (one can hope) given a while loop was removed
- You can still move while locked to mobs. Doing so will have you stop following them, as it was handled before

This was tested and works properly on monkeys and singularities (although monkeys being switched doesn't seem to update your position). Since targets are limited to mobs, the nuclear disk and the singularity, this also shouldn't cause problems with any object that uses locked_to like vehicles
