### PR TITLE
Gives more endurance to Diona pods.

### DIFF
--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -37,7 +37,7 @@
 		to_chat(user, "It's tagged as variety <span class='info'>#[seed.uid].</span>")
 	else
 		to_chat(user, "Plant Yield: <span class='info'>[(seed.yield != -1) ? seed.yield : "<span class='warning'> ERROR</span>"]</span>")
-		to_chat(user, "Plant Potency: <span class='info'>[(seed.potency != -1) ? seed.potency : "<span class='warning> ERROR</span>"]</span>")
+		to_chat(user, "Plant Potency: <span class='info'>[(seed.potency != -1) ? seed.potency : "<span class='warning'> ERROR</span>"]</span>")
 
 /obj/item/seeds/cutting
 	name = "cuttings"
@@ -1382,7 +1382,7 @@
 	immutable = 1
 
 	lifespan = 50
-	endurance = 8
+	endurance = 35
 	maturation = 5
 	production = 10
 	yield = 1

--- a/html/changelogs/9600bauds_diona.yml
+++ b/html/changelogs/9600bauds_diona.yml
@@ -1,0 +1,35 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general deleting of nice things)
+#   rscadd (general adding of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: 9600bauds
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+changes: 
+  - tweak: Diona pods now start with 35 durability. This means that they won't immediately die as soon as the lights are turned off or the tray gets weeds or something similar. This also means that, due to popular vote, Diona seeds are easily attainable by using plant clippers.


### PR DESCRIPTION
This means that they won't immediately die as soon as the lights are turned off or the tray gets weeds or something similar. This also means that, due to popular vote, Diona seeds are easily attainable by using plant clippers. 
![2016-01-04_18-45-44](https://cloud.githubusercontent.com/assets/6526157/12101417/6b42a748-b313-11e5-86f9-11639c6eb197.png)

Fixes #7120
