### PR TITLE
Ghettochem and Soldering Tool polish

### DIFF
--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -278,6 +278,8 @@
 		var/obj/item/weapon/weldingtool/WT = I
 		if(WT.remove_fuel(1,user))
 			var/obj/item/weapon/circuitboard/blank/B = new /obj/item/weapon/circuitboard/blank(src.loc)
+			to_chat(user, "<span class='notice'>You melt away the circuitry, leaving behind a blank.</span>")
+			playsound(B.loc, 'sound/items/Welder.ogg', 30, 1)
 			if(user.get_inactive_hand() == src)
 				user.before_take_item(src)
 				user.put_in_hands(B)

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -262,12 +262,12 @@ to destroy them and players will be able to make replacements.
 		if(!t) return
 		var/obj/item/weapon/solder/S = O
 		if(!S.remove_fuel(4,user)) return
-		playsound(loc, 'sound/items/Welder.ogg', 100, 1)
+		playsound(loc, 'sound/items/Welder.ogg', 50, 1)
 		soldering = 1
 		if(do_after(user, src,40))
-			playsound(loc, 'sound/items/Welder.ogg', 100, 1)
 			var/boardType = allowed_boards[t]
 			var/obj/item/I = new boardType(get_turf(user))
+			to_chat(user, "<span class='notice'>You fashion a crude [I] from the blank circuitboard.</span>")
 			qdel(src)
 			user.put_in_hands(I)
 		soldering = 0

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -29,6 +29,8 @@
 	if(issolder(W))
 		src.use(1)
 		new /obj/item/weapon/circuitboard/blank(user.loc)
+		to_chat(user, "<span class='notice'>You fashion a blank circuitboard out of the glass.</span>")
+		playsound(src.loc, 'sound/items/Welder.ogg', 35, 1)
 	if(istype(W, /obj/item/stack/rods) && !reinforced)
 		var/obj/item/stack/rods/V  = W
 		var/obj/item/stack/sheet/glass/RG = new rglass(user.loc)
@@ -214,7 +216,7 @@
 		CC.use(2)
 		src.use(1)
 
-		to_chat(user, "<span class='notice'>You attach some wires to the [name].</span></span>")
+		to_chat(user, "<span class='notice'>You attach some wires to the [name].</span>")//the dreaded dubblespan
 
 		drop_stack(/obj/item/stack/light_w, get_turf(user), 1, user)
 	else

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -72,6 +72,8 @@
 		if(coil.amount < 2) return
 		coil.use(2)
 		var/obj/item/weapon/electrolyzer/E = new /obj/item/weapon/electrolyzer
+		to_chat(user, "<span class='notice'>You tightly coil the wire around the metal casing.</span>")
+		playsound(get_turf(src), 'sound/weapons/cablecuff.ogg', 30, 1, -2)
 		user.before_take_item(src)
 		user.put_in_hands(E)
 		qdel(src)

--- a/code/modules/food/customizables.dm
+++ b/code/modules/food/customizables.dm
@@ -73,8 +73,10 @@
 	if(istype(I,/obj/item/stack/sheet/metal))
 		var/obj/item/stack/sheet/metal/S = I
 		S.use(1)
-		new/obj/item/weapon/reagent_containers/mortar(get_turf(src))
+		var/obj/item/weapon/reagent_containers/glass/mortar/mortimer = new(get_turf(src))
+		to_chat(user, "<span class='notice'>You fashion a crude mortar out of the wooden bowl and a metal sheet.</span>")
 		qdel(src)
+		user.put_in_hands(mortimer)
 	if(istype(I,/obj/item/weapon/reagent_containers/food/snacks))
 		if(!recursiveFood && istype(I, /obj/item/weapon/reagent_containers/food/snacks/customizable))
 			to_chat(user, "<span class='warning'>Sorry, no recursive food.</span>")


### PR DESCRIPTION
Adds sounds and messages to many actions that were previously mute (basic shit such as "You do the thing *pssffwwwww*")
Electrolyzer now creates sparks when electrolyzing
Fixed infinite wooden bowl and metal sheet exploit caused by mortar deconstruction not deleting the mortar
Changed mortar to be a child of reagent_containers/glass, so it stops splashing everything everywhere when put in a locker or a table or anything. Possibly allows you to use it in unintended ways, such as using it as a grinder recipient, but I can't imagine any real problem.
