### PR TITLE
Fixes (adds) stringed coin functionality with gashapons and candy machines

### DIFF
--- a/code/game/machinery/candymachine.dm
+++ b/code/game/machinery/candymachine.dm
@@ -23,7 +23,6 @@
 				sleep(rand(10,15))
 				src.visible_message("<span class='notice'>[src] dispenses a strange sweet!</span>")
 				new /obj/item/weapon/reagent_containers/food/snacks/sweet/strange(src.loc)
-				qdel(O)
 		else
 			if(user.drop_item(O, src))
 				user.visible_message("<span class='notice'>[user] puts a coin into [src] and turns the knob.", "<span class='notice'>You put a coin into [src] and turn the knob.</span>")
@@ -31,7 +30,18 @@
 				sleep(rand(10,15))
 				src.visible_message("<span class='notice'>[src] dispenses a sweet!</span>")
 				new /obj/item/weapon/reagent_containers/food/snacks/sweet(src.loc)
-				qdel(O)
+
+		if(istype(O, /obj/item/weapon/coin/))
+			var/obj/item/weapon/coin/real_coin = O
+			if(real_coin.string_attached)
+				if(prob(30))
+					to_chat(user, "<SPAN CLASS='notice'>You were able to force the knob around and successfully pulled the coin out before [src] could swallow it.</SPAN>")
+					user.put_in_hands(O)
+				else
+					to_chat(user, "<SPAN CLASS='notice'>You weren't able to pull the coin out fast enough, the machine ate it, string and all.</SPAN>")
+					qdel(O)
+		else
+			qdel(O)
 	else if(istype(O, /obj/item/weapon/reagent_containers/food/snacks/customizable/candy/coin))
 		to_chat(user, "<span class='rose'>That coin is smudgy and oddly soft, you don't think that would work.</span>")
 		return

--- a/code/game/machinery/gashapon.dm
+++ b/code/game/machinery/gashapon.dm
@@ -2,7 +2,7 @@
 
 
 /obj/machinery/gashapon
-	name = "Gashapon Machine"
+	name = "\improper Gashapon Machine"
 	desc = "Insert coin, recieve capsule!"
 	icon = 'icons/obj/gashapon.dmi'
 	icon_state = "gashapon"
@@ -19,8 +19,18 @@
 			src.visible_message("<span class='notice'>[src] dispenses a capsule!</span>")
 			var/obj/item/weapon/capsule/b = new(src.loc)
 			b.icon_state = "capsule[rand(1,12)]"
-			qdel(O)
-			O = null
+
+			if(istype(O, /obj/item/weapon/coin/))
+				var/obj/item/weapon/coin/real_coin = O
+				if(real_coin.string_attached)
+					if(prob(30))
+						to_chat(user, "<SPAN CLASS='notice'>You were able to force the knob around and successfully pulled the coin out before [src] could swallow it.</SPAN>")
+						user.put_in_hands(O)
+					else
+						to_chat(user, "<SPAN CLASS='notice'>You weren't able to pull the coin out fast enough, the machine ate it, string and all.</SPAN>")
+						qdel(O)
+			else
+				qdel(O)
 	else if(istype(O, /obj/item/weapon/reagent_containers/food/snacks/customizable/candy/coin))
 		to_chat(user, "<span class='rose'>That coin is smudgy and oddly soft, you don't think that would work.</span>")
 		return

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -724,7 +724,7 @@
 
 /obj/item/toy/gasha/jani
 	name = "toy janitor"
-	desc = "cleanliness is next to godliness!"
+	desc = "Cleanliness is next to godliness!"
 	icon_state = "jani"
 
 /obj/item/toy/gasha/miner


### PR DESCRIPTION
Fixes #7536 and #7381

To keep it balanced, made it so that you're more likely to lose your coin on them than with a regular vending machine, because of the possibility for ultra antag fun by emagging a candy machine, or ohshitwhyaretheresomanytoys with gashapons.

Also scanned through reported issues with these two machines and its products, and fixed a typo.
