### PR TITLE
Changes shake_camera

### DIFF
--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -254,19 +254,19 @@ proc/Gibberish(t, p)//t is the inputted message, and any value higher than 70 fo
 		if(!M || !M.client || M.shakecamera)
 			return
 
-		var/oldeye=M.client.eye
-
 		M.shakecamera = 1
 
 		for (var/x = 1 to duration)
 			if(!M || !M.client)
 				M.shakecamera = 0
 				return //somebody disconnected while being shaken
-			M.client.eye = locate(Clamp(M.loc.x + rand(-strength, strength), 1, world.maxx), Clamp(M.loc.y + rand(-strength, strength), 1, world.maxy), M.loc.z)
+			M.client.pixel_x = 32*rand(-strength, strength)
+			M.client.pixel_y = 32*rand(-strength, strength)
 			sleep(1)
 
 		M.shakecamera = 0
-		M.client.eye=oldeye
+		M.client.pixel_x = 0
+		M.client.pixel_y = 0
 
 
 /proc/findname(msg)

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -102,10 +102,6 @@
 
 	//Copied straight from small meteor code
 	spawn(0)
-		for(var/mob/M in range(8, src))
-			if(!M.stat && !istype(M, /mob/living/silicon/ai)) //bad idea to shake an ai's view
-				shake_camera(M, 2, 1) //Poof
-
 		playsound(get_turf(src), 'sound/effects/meteorimpact.ogg', 10, 1)
 		explosion(src.loc, -1, 1, 3, 4, 0) //Tiny meteor doesn't cause too much damage
 		qdel(src)


### PR DESCRIPTION
Fixes #7468
This changes the shake camera function to use client.pixel x/y instead of manually modifying the client eye. The reason it never used this before is simply that client.pixel x/y didn't exist until recently, but this should give functionally identical code.

Someone should still probably check it out and check that it is the same before/after though.