### PR TITLE
Fix drop item runtimes

### DIFF
--- a/code/modules/mob/living/silicon/mommi/inventory.dm
+++ b/code/modules/mob/living/silicon/mommi/inventory.dm
@@ -101,7 +101,7 @@
 		return drop_item()
 	return 0
 
-/mob/living/silicon/robot/mommi/drop_item(var/obj/item/to_drop, var/atom/Target)
+/mob/living/silicon/robot/mommi/drop_item(var/obj/item/to_drop, var/atom/Target, force_drop = 0)
 	if(tool_state)
 		//var/obj/item/found = locate(tool_state) in src.module.modules
 		if(is_in_modules(tool_state))

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -111,7 +111,7 @@
 			for(var/i = 1; i < alarm_types_clear.len; i++)
 				alarm_types_clear[i] = 0
 
-/mob/living/silicon/drop_item()
+/mob/living/silicon/drop_item(var/obj/item/to_drop, var/atom/Target, force_drop = 0)
 	return 1
 
 /mob/living/silicon/generate_static_overlay()


### PR DESCRIPTION
Using named args for procs without defining them for all versions of the proc runs into problems because byond doesn't see them as defined for those children procs or some shit I can't explain it.