### PR TITLE
I keep my IDE open and grep for every spelling, punctuation, or grammar error I can find: Part 2

### DIFF
--- a/code/ATMOSPHERICS/components/binary_devices/valve.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/valve.dm
@@ -3,7 +3,7 @@
 	icon_state = "hvalve0"
 
 	name = "manual valve"
-	desc = "A pipe valve"
+	desc = "A pipe valve."
 	var/open = 0
 	var/openDuringInit = 0
 

--- a/code/ATMOSPHERICS/components/trinary_devices/t_valve.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/t_valve.dm
@@ -3,7 +3,7 @@
 	icon_state = "tvalve0"
 
 	name = "manual switching valve"
-	desc = "A pipe valve"
+	desc = "A pipe valve."
 
 	dir = SOUTH
 	initialize_directions = SOUTH|NORTH|WEST

--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -587,7 +587,7 @@
 
 /obj/item/weapon/SWF_uplink
 	name = "station-bounced radio"
-	desc = "used to comunicate it appears."
+	desc = "Used for communication, it appears."
 	icon = 'icons/obj/radio.dmi'
 	icon_state = "radio"
 	var/temp = null
@@ -779,7 +779,7 @@
 
 /obj/item/weapon/syntiflesh
 	name = "syntiflesh"
-	desc = "Meat that appears...strange..."
+	desc = "Meat that appears... strange..."
 	icon = 'icons/obj/food.dmi'
 	icon_state = "meat"
 	flags = FPRINT

--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -214,9 +214,9 @@
 				continue
 			return
 	if(occupant == usr)
-		visible_message("[usr] climbs out of \the [src].", 3)
+		visible_message("[usr] climbs out of \the [src].", 2) //spooky
 	else
-		visible_message("[usr] removes [occupant.name] from \the [src].", 3)
+		visible_message("[usr] removes [occupant.name] from \the [src].", 2) //spooky
 	eject_occupant(over_location)
 
 /obj/machinery/dna_scannernew/attackby(var/obj/item/weapon/item as obj, var/mob/user as mob)

--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -42,7 +42,7 @@
 			for(var/mob/M in viewers(src))
 				if(M == user)
 					continue
-				M.show_message("[user.name] smashed the pylon!", 3, "You hear a tinkle of crystal shards.", 2)
+				M.show_message("[user.name] smashed the pylon!", 1, "You hear a tinkle of crystal shards.", 2)
 			playsound(get_turf(src), 'sound/effects/Glassbr3.ogg', 75, 1)
 			isbroken = 1
 			density = 0

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -193,7 +193,7 @@ var/global/list/rune_list = list() // HOLY FUCK WHY ARE WE LOOPING THROUGH THE W
 	else
 		usr.whisper(pick("B'ADMINES SP'WNIN SH'T","IC'IN O'OC","RO'SHA'M I'SA GRI'FF'N ME'AI","TOX'IN'S O'NM FI'RAH","IA BL'AME TOX'IN'S","FIR'A NON'AN RE'SONA","A'OI I'RS ROUA'GE","LE'OAN JU'STA SP'A'C Z'EE SH'EF","IA PT'WOBEA'RD, IA A'DMI'NEH'LP"))
 	for (var/mob/V in viewers(src))
-		V.show_message("<span class='warning'>The markings pulse with a small burst of light, then fall dark.</span>", 3, "<span class='warning'>You hear a faint fizzle.</span>", 2)
+		V.show_message("<span class='warning'>The markings pulse with a small burst of light, then fall dark.</span>", 1, "<span class='warning'>You hear a faint fizzle.</span>", 2)
 	return
 
 /obj/effect/rune/proc/check_icon()
@@ -462,7 +462,7 @@ var/global/list/rune_list = list() // HOLY FUCK WHY ARE WE LOOPING THROUGH THE W
 		if(usr.get_active_hand() != src)
 			return
 		for (var/mob/V in viewers(src))
-			V.show_message("<span class='warning'>[user] slices open a finger and begins to chant and paint symbols on the floor.</span>", 3, "<span class='warning'>You hear chanting.</span>", 2)
+			V.show_message("<span class='warning'>[user] slices open a finger and begins to chant and paint symbols on the floor.</span>", 1, "<span class='warning'>You hear chanting.</span>", 2)
 		to_chat(user, "<span class='warning'>You slice open one of your fingers and begin drawing a rune on the floor whilst chanting the ritual that binds your life essence with the dark arcane energies flowing through the surrounding world.</span>")
 		user.take_overall_damage((rand(9)+1)/10) // 0.1 to 1.0 damage
 		if(do_after(user, user.loc, 50))

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -219,7 +219,7 @@
 			return 0
 
 	usr.say("Mah[pick("'","`")]weyh pleggh at e'ntrath!")
-	usr.show_message("<span class='warning'>The markings pulse with a small burst of light, then fall dark.</span>", 3, "<span class='warning'>You hear a faint fizzle.</span>", 2)
+	usr.show_message("<span class='warning'>The markings pulse with a small burst of light, then fall dark.</span>", 1, "<span class='warning'>You hear a faint fizzle.</span>", 2)
 	to_chat(usr, "<span class='notice'>You remembered the words correctly, but the rune isn't working. Maybe your ritual is missing something important.</span>")
 
 /////////////////////////////////////////FOURTH RUNE
@@ -433,7 +433,7 @@
 			usr.seer = 1
 		return
 	usr.say("Rash'tla sektath mal[pick("'","`")]zua. Zasan therium vivira. Itonis al'ra matum!")
-	usr.show_message("\<span class='warning'>The markings pulse with a small burst of light, then fall dark.</span>", 3, "<span class='warning'>You hear a faint fizzle.</span>", 2)
+	usr.show_message("\<span class='warning'>The markings pulse with a small burst of light, then fall dark.</span>", 1, "<span class='warning'>You hear a faint fizzle.</span>", 2)
 	to_chat(usr, "<span class='notice'>You remembered the words correctly, but the rune isn't reacting. Maybe you should position yourself differently.</span>")
 
 /////////////////////////////////////////EIGHTH RUNE
@@ -532,14 +532,14 @@
 		if(istype(src,/obj/effect/rune))
 			usr.say("Kla[pick("'","`")]atu barada nikt'o!")
 			for (var/mob/V in viewers(src))
-				V.show_message("<span class='warning'>The rune turns into gray dust, veiling the surrounding runes.</span>", 3)
+				V.show_message("<span class='warning'>The rune turns into gray dust, veiling the surrounding runes.</span>")
 			qdel(src)
 		else
 			usr.whisper("Kla[pick("'","`")]atu barada nikt'o!")
 			to_chat(usr, "<span class='warning'>Your talisman turns into gray dust, veiling the surrounding runes.</span>")
 			for (var/mob/V in orange(1,src))
 				if(V!=usr)
-					V.show_message("<span class='warning'>Dust emanates from [usr]'s hands for a moment.</span>", 3)
+					V.show_message("<span class='warning'>Dust emanates from [usr]'s hands for a moment.</span>")
 
 		return
 	if(istype(src,/obj/effect/rune))
@@ -728,14 +728,14 @@
 			break
 	if (imbued_from)
 		for (var/mob/V in viewers(src))
-			V.show_message("<span class='warning'>The runes turn into dust, which then forms into an arcane image on the paper.</span>", 3)
+			V.show_message("<span class='warning'>The runes turn into dust, which then forms into an arcane image on the paper.</span>", 1)
 		usr.say("H'drak v[pick("'","`")]loso, mir'kanas verbot!")
 		qdel(imbued_from)
 		qdel(newtalisman)
 		invocation("rune_imbue")
 	else
 		usr.say("H'drak v[pick("'","`")]loso, mir'kanas verbot!")
-		usr.show_message("\<span class='warning'>The markings pulse with a small burst of light, then fall dark.</span>", 3, "<span class='warning'>You hear a faint fizzle.</span>", 2)
+		usr.show_message("\<span class='warning'>The markings pulse with a small burst of light, then fall dark.</span>", 1, "<span class='warning'>You hear a faint fizzle.</span>", 2)
 		to_chat(usr, "<span class='notice'>You remembered the words correctly, but the rune isn't working properly. Maybe you're missing something in the ritual.</span>")
 
 /////////////////////////////////////////THIRTEENTH RUNE
@@ -976,7 +976,7 @@
 		if(istype(W,/obj/effect/rune))
 			usr.say("Nikt[pick("'","`")]o barada kla'atu!")
 			for (var/mob/V in viewers(src))
-				V.show_message("<span class='warning'>The rune turns into red dust, reveaing the surrounding runes.</span>", 3)
+				V.show_message("<span class='warning'>The rune turns into red dust, revealing the surrounding runes.</span>", 1)
 			qdel(src)
 			return
 		if(istype(W,/obj/item/weapon/paper/talisman))
@@ -984,7 +984,7 @@
 			to_chat(usr, "<span class='warning'>Your talisman turns into red dust, revealing the surrounding runes.</span>")
 			for (var/mob/V in orange(1,usr.loc))
 				if(V!=usr)
-					V.show_message("<span class='warning'>Red dust emanates from [usr]'s hands for a moment.</span>", 3)
+					V.show_message("<span class='warning'>Red dust emanates from [usr]'s hands for a moment.</span>", 1)
 			return
 		return
 	if(istype(W,/obj/effect/rune))
@@ -1161,7 +1161,7 @@
 		if(nullblock)
 			continue
 		C.ear_deaf += 50
-		C.show_message("<span class='warning'>The world around you suddenly becomes quiet.</span>", 3)
+		C.show_message("<span class='warning'>The world around you suddenly becomes quiet.</span>")
 		affected++
 		if(prob(1))
 			C.sdisabilities |= DEAF

--- a/code/game/gamemodes/cult/talisman.dm
+++ b/code/game/gamemodes/cult/talisman.dm
@@ -230,11 +230,11 @@
 			continue
 		C.ear_deaf += 30
 		//talismans is weaker.
-		C.show_message("\<span class='warning'>The world around you suddenly becomes quiet.</span>", 3)
+		C.show_message("\<span class='warning'>The world around you suddenly becomes quiet.</span>")
 		affected++
 	if(affected)
 		usr.whisper("Sti[pick("'","`")] kaliedir!")
 		to_chat(usr, "<span class='warning'>Your talisman turns into gray dust, deafening everyone around.</span>")
 		for (var/mob/V in orange(1,src))
 			if(!(iscultist(V)))
-				V.show_message("<span class='warning'>Dust flows from [usr]'s hands for a moment, and the world suddenly becomes quiet..</span>", 3)
+				V.show_message("<span class='warning'>Dust flows from [usr]'s hands for a moment, and the world suddenly becomes quiet..</span>")

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -145,7 +145,7 @@
 	if (C == user)
 		user.visible_message("[user] climbs on the operating table.","You climb on the operating table.")
 	else
-		visible_message("<span class='warning'>[C] has been laid on the operating table by [user].</span>", 3)
+		visible_message("<span class='warning'>[C] has been laid on the operating table by [user].</span>", 2) //spooky
 
 	add_fingerprint(user)
 

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -269,9 +269,9 @@
 			return
 
 	if(L == user)
-		visible_message("[user] climbs into \the [src].", 3)
+		visible_message("[user] climbs into \the [src].", 2) //spooky
 	else
-		visible_message("[user] places [L.name] into \the [src].", 3)
+		visible_message("[user] places [L.name] into \the [src].", 2) //spooky
 
 	L.forceMove(src)
 	L.reset_view()
@@ -317,9 +317,9 @@
 				continue
 			return
 	if(occupant == usr)
-		visible_message("[usr] climbs out of \the [src].", 3)
+		visible_message("[usr] climbs out of \the [src].", 2) //spooky
 	else
-		visible_message("[usr] removes [occupant.name] from \the [src].", 3)
+		visible_message("[usr] removes [occupant.name] from \the [src].", 2) //spooky
 	go_out(over_location)
 
 /obj/machinery/sleeper/allow_drop()
@@ -376,7 +376,7 @@
 			to_chat(usr, "[G.affecting.name] will not fit into the sleeper because they have a slime latched onto their head.")
 			return
 
-	visible_message("[user] places [G.affecting.name] into the sleeper.", 3)
+	visible_message("[user] places [G.affecting.name] into the sleeper.", 2) //spooky
 
 	var/mob/M = G.affecting
 	if(!isliving(M) || M.locked_to)
@@ -532,7 +532,7 @@
 			return
 	if(usr.locked_to)
 		return
-	visible_message("[usr] starts climbing into the sleeper.", 3)
+	visible_message("[usr] starts climbing into the sleeper.", 2) //spooky
 	if(do_after(usr, src, 20))
 		if(src.occupant)
 			to_chat(usr, "<span class='notice'><B>The sleeper is already occupied!</B></span>")

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -162,9 +162,9 @@
 				continue
 			return
 	if(occupant == usr)
-		visible_message("[usr] climbs out of \the [src].", 3)
+		visible_message("[usr] climbs out of \the [src].", 2) //spooky
 	else
-		visible_message("[usr] removes [occupant.name] from \the [src].", 3)
+		visible_message("[usr] removes [occupant.name] from \the [src].", 2) //spooky
 	go_out(over_location)
 
 /obj/machinery/bodyscanner/relaymove(mob/user as mob)

--- a/code/game/machinery/airlock_control.dm
+++ b/code/game/machinery/airlock_control.dm
@@ -309,7 +309,7 @@ obj/machinery/access_button/update_icon()
 obj/machinery/access_button/attack_hand(mob/user)
 	add_fingerprint(usr)
 	if(!allowed(user))
-		to_chat(user, "<span class='warning'>Access Denied</span>")
+		to_chat(user, "<span class='warning'>Access Denied.</span>")
 
 	else if(radio_connection)
 		var/datum/signal/signal = getFromPool(/datum/signal)

--- a/code/game/machinery/computer/HolodeckControl.dm
+++ b/code/game/machinery/computer/HolodeckControl.dm
@@ -512,12 +512,12 @@
 			return
 		G.affecting.loc = src.loc
 		G.affecting.Weaken(5)
-		visible_message("<span class='warning'>[G.assailant] dunks [G.affecting] into the [src]!</span>", 3)
+		visible_message("<span class='warning'>[G.assailant] dunks [G.affecting] into the [src]!</span>", 2) //spooky
 		qdel(W)
 		return
 	else if (istype(W, /obj/item) && get_dist(src,user)<2)
 		if(user.drop_item(W, src.loc))
-			visible_message("<span class='notice'>[user] dunks [W] into the [src]!</span>", 3)
+			visible_message("<span class='notice'>[user] dunks [W] into the [src]!</span>", 2) //spooky
 			return
 
 /obj/structure/holohoop/CanPass(atom/movable/mover, turf/target, height=1.5, air_group = 0)
@@ -527,9 +527,9 @@
 			return
 		if(prob(50))
 			I.loc = src.loc
-			visible_message("<span class='notice'>Swish! \the [I] lands in \the [src].</span>", 3)
+			visible_message("<span class='notice'>Swish! \the [I] lands in \the [src].</span>", 2) //spooky
 		else
-			visible_message("<span class='warning'>\the [I] bounces off of \the [src]'s rim!</span>", 3)
+			visible_message("<span class='warning'>\the [I] bounces off of \the [src]'s rim!</span>", 2) //spooky
 		return 0
 	else
 		return ..(mover, target, height, air_group)

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -101,9 +101,9 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 			return
 	if(put_mob(L))
 		if(L == user)
-			visible_message("[user] climbs into \the [src].", 3)
+			visible_message("[user] climbs into \the [src].", 2) //spooky
 		else
-			visible_message("[user] puts [L.name] into \the [src].", 3)
+			visible_message("[user] puts [L.name] into \the [src].", 2) //spooky
 			if(user.pulling == L)
 				user.pulling = null
 
@@ -127,7 +127,7 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 			if((A == src) || istype(A, /mob))
 				continue
 			return
-	visible_message("[usr] removes [occupant.name] from \the [src].", 3)
+	visible_message("[usr] removes [occupant.name] from \the [src].", 2) //spooky
 	go_out(over_location)
 
 /obj/machinery/atmospherics/unary/cryo_cell/process()

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -445,7 +445,7 @@
 					src.MASK = null
 				if(src.BOOTS)
 					src.BOOTS = null
-				visible_message("<font color='red'>With a loud whining noise, the Suit Storage Unit's door grinds open. Puffs of ashen smoke come out of its chamber.</font>", 3)
+				visible_message("<font color='red'>With a loud whining noise, the Suit Storage Unit's door grinds open. Puffs of ashen smoke come out of its chamber.</font>", 2) //spooky
 				stat |= BROKEN
 				src.isopen = 1
 				src.islocked = 0
@@ -509,7 +509,7 @@
 	if ( (src.OCCUPANT) || (src.HELMET) || (src.SUIT) || BOOTS )
 		to_chat(usr, "<font color='red'>It's too cluttered inside for you to fit in!</font>")
 		return
-	visible_message("[usr] starts squeezing into the suit storage unit!", 3)
+	visible_message("[usr] starts squeezing into the suit storage unit!", 2) //spooky
 	if(do_after(usr, src, 10))
 		usr.stop_pulling()
 		usr.client.perspective = EYE_PERSPECTIVE
@@ -567,7 +567,7 @@
 		if ( (src.OCCUPANT) || (src.HELMET) || (src.SUIT) || BOOTS) //Unit needs to be absolutely empty
 			to_chat(user, "<font color='red'>The unit's storage area is too cluttered.</font>")
 			return
-		visible_message("[user] starts putting [G.affecting.name] into the Suit Storage Unit.", 3)
+		visible_message("[user] starts putting [G.affecting.name] into the Suit Storage Unit.", 2) //spooky
 		if(do_after(user, src, 20))
 			if(!G || !G.affecting) return //derpcheck
 			var/mob/M = G.affecting

--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -95,7 +95,7 @@
 	set_ready_state(1)
 
 	chassis.empty_bad_contents()
-	
+
 	return
 
 /obj/item/mecha_parts/mecha_equipment/tool/sleeper/detach()
@@ -386,7 +386,7 @@
 	return 1
 
 /obj/item/mecha_parts/mecha_equipment/tool/syringe_gun
-	name = "Syringe Gun"
+	name = "Exosuit-Mounted Syringe Gun"
 	desc = "Exosuit-mounted chem synthesizer with syringe gun. Reagents inside are held in stasis, so no reactions will occur. (Can be attached to: Medical Exosuits)"
 	icon = 'icons/obj/gun.dmi'
 	icon_state = "syringegun"

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -130,9 +130,8 @@
 			size = "normal-sized"
 		if(4.0)
 			size = "bulky"
-		if(5.0)
+		if(5.0 to INFINITY)
 			size = "huge"
-		else
 	//if ((M_CLUMSY in usr.mutations) && prob(50)) t = "funny-looking"
 	var/pronoun
 	if (src.gender == PLURAL)

--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -155,11 +155,10 @@
 /obj/item/device/paicard/proc/alertUpdate()
 	var/turf/T = get_turf(src.loc)
 	for (var/mob/M in viewers(T))
-		M.show_message("<span class='notice'>[src] flashes a message across its screen, \"Additional personalities available for download.\"</span>", 3, "<span class='notice'>[src] bleeps electronically.</span>", 2)
+		M.show_message("<span class='notice'>[src] flashes a message across its screen, \"Additional personalities available for download.\"</span>", 1, "<span class='notice'>[src] bleeps electronically.</span>", 2)
 		playsound(loc, 'sound/machines/paistartup.ogg', 50, 1)
 
 /obj/item/device/paicard/emp_act(severity)
 	for(var/mob/M in src)
 		M.emp_act(severity)
 	..()
-

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -294,7 +294,7 @@
 
 		for(var/mob/O in viewers(M, null))
 			if(O.client)
-				O.show_message(text("<span class = 'danger'><B>[] casually lines up a shot with []'s head and pulls the trigger!</B></span>", user, M), 1, "<span class = 'danger'>You hear the sound of foam against skull</span>", 2)
+				O.show_message(text("<span class = 'danger'><B>[] casually lines up a shot with []'s head and pulls the trigger!</B></span>", user, M), 1, "<span class = 'danger'>You hear the sound of foam against skull.</span>", 2)
 				O.show_message(text("<span class = 'danger'>[] was hit in the head by the foam dart!</span>", M), 1)
 
 		playsound(user.loc, 'sound/items/syringeproj.ogg', 50, 1)

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -387,7 +387,7 @@
 
 /obj/item/weapon/storage/box/mousetraps
 	name = "box of Pest-B-Gon Mousetraps"
-	desc = "<B><FONT=red>WARNING:</FONT></B> <I>Keep out of reach of children</I>."
+	desc = "<span class='danger'>WARNING:</span> <I>Keep out of reach of children</I>."
 	icon_state = "mousetraps"
 
 	New()

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -149,6 +149,6 @@ obj/item/weapon/wirerod/attackby(var/obj/item/I, mob/user as mob)
 
 
 obj/item/weapon/banhammer/admin
-	desc = "A banhammer specifically reserved for admins. Legends tell of a weapon that destroys the target to the utmost capacity"
+	desc = "A banhammer specifically reserved for admins. Legends tell of a weapon that destroys the target to the utmost capacity."
 	throwforce = 999
 	force = 999

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -281,7 +281,7 @@
 			var/obj/item/stack/sheet/metal/Met = getFromPool(/obj/item/stack/sheet/metal, get_turf(src))
 			Met.amount = 2
 			for(var/mob/M in viewers(src))
-				M.show_message("<span class='notice'>\The [src] has been cut apart by [user] with \the [WT].</span>", 3, "You hear welding.", 2)
+				M.show_message("<span class='notice'>\The [src] has been cut apart by [user] with \the [WT].</span>", 1, "You hear welding.", 2)
 			qdel(src)
 			return
 
@@ -297,7 +297,7 @@
 		src.welded =! src.welded
 		src.update_icon()
 		for(var/mob/M in viewers(src))
-			M.show_message("<span class='warning'>[src] has been [welded?"welded shut":"unwelded"] by [user.name].</span>", 3, "You hear welding.", 2)
+			M.show_message("<span class='warning'>[src] has been [welded?"welded shut":"unwelded"] by [user.name].</span>", 1, "You hear welding.", 2)
 	else if(!place(user, W))
 		src.attack_hand(user)
 	return

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -91,7 +91,7 @@
 			src.welded =! src.welded
 			src.update_icon()
 			for(var/mob/M in viewers(src))
-				M.show_message("<span class='warning'>[src] has been [welded?"welded shut":"unwelded"] by [user.name].</span>", 3, "You hear welding.", 2)
+				M.show_message("<span class='warning'>[src] has been [welded?"welded shut":"unwelded"] by [user.name].</span>", 1, "You hear welding.", 2)
 		else
 			togglelock(user)
 

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -24,11 +24,11 @@
 		if(state == 0) //Normal girder or wooden girder
 			if(anchored && !istype(src, /obj/structure/girder/displaced)) //Anchored, destroy it
 				playsound(get_turf(src), 'sound/items/Ratchet.ogg', 100, 1)
-				user.visible_message("<span class='notice'>[user] starts disassembling \the [src]</span>", \
-				"<span class='notice'>You start disassembling \the [src]</span>")
+				user.visible_message("<span class='notice'>[user] starts disassembling \the [src].</span>", \
+				"<span class='notice'>You start disassembling \the [src].</span>")
 				if(do_after(user, src, 40))
-					user.visible_message("<span class='warning'>[user] dissasembles \the [src]</span>", \
-					"<span class='notice'>You dissasemble \the [src]</span>")
+					user.visible_message("<span class='warning'>[user] dissasembles \the [src].</span>", \
+					"<span class='notice'>You dissasemble \the [src].</span>")
 					getFromPool(material, get_turf(src))
 					qdel(src)
 			else if(!anchored) //Unanchored, anchor it
@@ -37,23 +37,23 @@
 					return
 
 				playsound(get_turf(src), 'sound/items/Ratchet.ogg', 100, 1)
-				user.visible_message("<span class='notice'>[user] starts securing \the [src]</span>", \
-				"<span class='notice'>You start securing \the [src]</span>")
+				user.visible_message("<span class='notice'>[user] starts securing \the [src].</span>", \
+				"<span class='notice'>You start securing \the [src].</span>")
 				if(do_after(user, src, 40))
-					user.visible_message("<span class='notice'>[user] secures \the [src]</span>", \
-					"<span class='notice'>You secure \the [src]</span>")
+					user.visible_message("<span class='notice'>[user] secures \the [src].</span>", \
+					"<span class='notice'>You secure \the [src].</span>")
 					add_hiddenprint(user)
 					add_fingerprint(user)
 					anchored = 1
 					update_icon()
 		else if(state == 1 || state == 2) //Clearly a reinforced girder
 			playsound(get_turf(src), 'sound/items/Ratchet.ogg', 100, 1)
-			user.visible_message("<span class='notice'>[user] starts [anchored ? "un" : ""]securing \the [src]</span>", \
-			"<span class='notice'>You start [anchored ? "un" : ""]securing \the [src]</span>")
+			user.visible_message("<span class='notice'>[user] starts [anchored ? "un" : ""]securing \the [src].</span>", \
+			"<span class='notice'>You start [anchored ? "un" : ""]securing \the [src].</span>")
 			if(do_after(user, src, 40))
 				anchored = !anchored //Unachor it if anchored, or opposite
-				user.visible_message("<span class='notice'>[user] [anchored ? "" : "un"]secures \the [src]</span>", \
-				"<span class='notice'>You [anchored ? "" : "un"]secure \the [src]</span>")
+				user.visible_message("<span class='notice'>[user] [anchored ? "" : "un"]secures \the [src].</span>", \
+				"<span class='notice'>You [anchored ? "" : "un"]secure \the [src].</span>")
 				add_hiddenprint(user)
 				add_fingerprint(user)
 				update_icon()
@@ -111,18 +111,18 @@
 	else if(istype(W, /obj/item/stack/rods) && state == 0 && material == /obj/item/stack/sheet/metal) //Inserting support struts, stage 0 to 1 (reinforced girder, replaces plasteel step)
 		var/obj/item/stack/rods/R = W
 		if(R.amount < 2) //Do a first check BEFORE the user begins, in case he's using a single rod
-			to_chat(user, "<span class='warning'>You need more rods to finish the support struts</span>")
+			to_chat(user, "<span class='warning'>You need more rods to finish the support struts.</span>")
 			return
-		user.visible_message("<span class='notice'>[user] starts inserting internal support struts into \the [src]</span>", \
-		"<span class='notice'>You start inserting internal support struts into \the [src]</span>")
+		user.visible_message("<span class='notice'>[user] starts inserting internal support struts into \the [src.]</span>", \
+		"<span class='notice'>You start inserting internal support struts into \the [src].</span>")
 		if(do_after(user, src,40))
 			var/obj/item/stack/rods/O = W
 			if(O.amount < 2) //In case our user is trying to be tricky
-				to_chat(user, "<span class='warning'>You need more rods to finish the support struts</span>")
+				to_chat(user, "<span class='warning'>You need more rods to finish the support struts.</span>")
 				return
 			O.use(2)
-			user.visible_message("<span class='notice'>[user] inserts internal support struts into \the [src]</span>", \
-			"<span class='notice'>You insert internal support struts into \the [src]</span>")
+			user.visible_message("<span class='notice'>[user] inserts internal support struts into \the [src].</span>", \
+			"<span class='notice'>You insert internal support struts into \the [src].</span>")
 			add_hiddenprint(user)
 			add_fingerprint(user)
 			state = 1
@@ -166,14 +166,14 @@
 				else
 					if(S.amount < 2)
 						return ..() // ?
-					user.visible_message("<span class='notice'>[user] starts installing plating to \the [src]</span>", \
-					"<span class='notice'>You start installing plating to \the [src]</span>")
+					user.visible_message("<span class='notice'>[user] starts installing plating to \the [src].</span>", \
+					"<span class='notice'>You start installing plating to \the [src].</span>")
 					if(do_after(user, src, 40))
 						if(S.amount < 2) //User being tricky
 							return
 						S.use(2)
-						user.visible_message("<span class='notice'>[user] finishes installing plating to \the [src]</span>", \
-						"<span class='notice'>You finish installing plating to \the [src]</span>")
+						user.visible_message("<span class='notice'>[user] finishes installing plating to \the [src].</span>", \
+						"<span class='notice'>You finish installing plating to \the [src].</span>")
 						var/turf/Tsrc = get_turf(src)
 						if(!istype(Tsrc)) return 0
 						var/turf/simulated/wall/X = Tsrc.ChangeTurf(/turf/simulated/wall)
@@ -253,14 +253,14 @@
 				var/wallpath = text2path("/turf/simulated/wall/mineral/[M]")
 				if(!ispath(wallpath))
 					return ..()
-				user.visible_message("<span class='notice'>[user] starts installing plating to \the [src]</span>", \
-				"<span class='notice'>You start installing plating to \the [src]</span>")
+				user.visible_message("<span class='notice'>[user] starts installing plating to \the [src].</span>", \
+				"<span class='notice'>You start installing plating to \the [src].</span>")
 				if(do_after(user, src,40))
 					if(S.amount < 2) //Don't be tricky now
 						return
 					S.use(2)
-					user.visible_message("<span class='notice'>[user] finishes installing plating to \the [src]</span>", \
-					"<span class='notice'>You finish installing plating to \the [src]</span>")
+					user.visible_message("<span class='notice'>[user] finishes installing plating to \the [src].</span>", \
+					"<span class='notice'>You finish installing plating to \the [src].</span>")
 					var/turf/Tsrc = get_turf(src)
 					var/turf/simulated/wall/mineral/X = Tsrc.ChangeTurf(wallpath)
 					if(X)
@@ -375,11 +375,11 @@
 /obj/structure/cultgirder/attackby(obj/item/W as obj, mob/user as mob)
 	if(istype(W, /obj/item/weapon/wrench))
 		playsound(get_turf(src), 'sound/items/Ratchet.ogg', 100, 1)
-		user.visible_message("<span class='notice'>[user] starts disassembling \the [src]</span>", \
-		"<span class='notice'>You start disassembling \the [src]</span>")
+		user.visible_message("<span class='notice'>[user] starts disassembling \the [src].</span>", \
+		"<span class='notice'>You start disassembling \the [src].</span>")
 		if(do_after(user, src,40))
-			user.visible_message("<span class='warning'>[src] dissasembles \the [src]</span>", \
-			"<span class='notice'>You dissasemble \the [src]</span>")
+			user.visible_message("<span class='warning'>[src] dissasembles \the [src].</span>", \
+			"<span class='notice'>You dissasemble \the [src].</span>")
 			//new /obj/effect/decal/remains/human(get_turf(src))	//Commented out until remains are cleanable
 			qdel(src)
 
@@ -388,8 +388,8 @@
 		if(!(PK.diggables & DIG_WALLS))
 			return
 
-		user.visible_message("<span class='warning'>[user] starts [PK.drill_verb] \the [src] with \the [PK]</span>",
-							"<span class='notice'>You start [PK.drill_verb] \the [src] with \the [PK]</span>")
+		user.visible_message("<span class='warning'>[user] starts [PK.drill_verb] \the [src] with \the [PK].</span>",
+							"<span class='notice'>You start [PK.drill_verb] \the [src] with \the [PK].</span>")
 		if(do_after(user, src,30))
 			user.visible_message("<span class='warning'>[user] destroys \the [src]!</span>",
 								"<span class='notice'>Your [PK] tears through the last of \the [src]!</span>")

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -167,7 +167,7 @@
 
 	if(!holder)
 		for(var/mob/O in hearers(1, src.loc))
-			O.show_message(text("\icon[] *beep* *beep*", src), 3, "*beep* *beep*", 2)
+			O.show_message(text("\icon[] *beep* *beep*", src), 1, "*beep* *beep*", 2)
 	return
 
 

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -435,7 +435,7 @@
 	_color = "jester"
 
 /obj/item/clothing/under/stilsuit
-	name = "dtilsuit"
+	name = "stillsuit"
 	desc = "Designed to preserve bodymoisture."
 	icon_state = "stilsuit"
 	item_state = "stilsuit"

--- a/code/modules/hydroponics/grown_inedible.dm
+++ b/code/modules/hydroponics/grown_inedible.dm
@@ -173,7 +173,7 @@
 
 /obj/item/weapon/grown/deathnettle // -- Skie
 	plantname = "deathnettle"
-	desc = "The <span class='danger'>glowingnettle incites <span class='warning'>rage\black in you just from looking at it!</span></span>"
+	desc = "A glowing red nettle that incites rage in you just from looking at it."
 	icon = 'icons/obj/weapons.dmi'
 	name = "deathnettle"
 	icon_state = "deathnettle"
@@ -187,14 +187,14 @@
 	origin_tech = "combat=3"
 	attack_verb = list("stung")
 
-	New()
-		..()
-		spawn(5)
-			force = round((5+potency/2.5), 1)
+/obj/item/weapon/grown/deathnettle/New()
+	..()
+	spawn(5)
+		force = round((5+potency/2.5), 1)
 
-	suicide_act(mob/user)
-		to_chat(viewers(user), "<span class='danger'>[user] is eating some of the [src.name]! It looks like \he's trying to commit suicide.</span>")
-		return (BRUTELOSS|TOXLOSS)
+/obj/item/weapon/grown/deathnettle/suicide_act(mob/user)
+	to_chat(viewers(user), "<span class='danger'>[user] is eating some of the [src.name]! It looks like \he's trying to commit suicide.</span>")
+	return (BRUTELOSS|TOXLOSS)
 
 /obj/item/weapon/grown/deathnettle/pickup(mob/living/carbon/human/user as mob)
 	if(!user.gloves)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -417,7 +417,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		return
 	var/mob/dead/observer/M = src
 	if(jobban_isbanned(M, "AntagHUD"))
-		to_chat(src, "<span class='danger'>You have been banned from using this feature</span>")
+		to_chat(src, "<span class='danger'>You have been banned from using this feature.</span>")
 		return
 	if(config.antag_hud_restricted && !M.has_enabled_antagHUD &&!client.holder)
 		var/response = alert(src, "If you turn this on, you will not be able to take any part in the round.","Are you sure you want to turn this feature on?","Yes","No")

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -239,7 +239,7 @@
 
 	if(has_brain() && stat != DEAD)
 		if(!key)
-			msg += "<span class='deadsay'>[t_He] [t_is] totally catatonic. The stresses of life in deep space must have been too much for [t_him]. Any recovery is unlikely</span>\n"
+			msg += "<span class='deadsay'>[t_He] [t_is] totally catatonic. The stresses of life in deep space must have been too much for [t_him]. Any recovery is unlikely.</span>\n"
 		else if(!client)
 			msg += "[t_He] [t_has] a vacant, braindead stare...\n"
 

--- a/code/modules/mob/living/silicon/mommi/mommi.dm
+++ b/code/modules/mob/living/silicon/mommi/mommi.dm
@@ -274,7 +274,7 @@ They can only use one tool at a time, they can't choose modules, and they have 1
 
 	else if(istype(W, /obj/item/weapon/screwdriver) && opened && !cell)	// haxing
 		wiresexposed = !wiresexposed
-		to_chat(user, "The wires have been [wiresexposed ? "exposed" : "unexposed"]")
+		to_chat(user, "The wires have been [wiresexposed ? "exposed" : "unexposed"].")
 		updateicon()
 
 	else if(istype(W, /obj/item/weapon/screwdriver) && opened && cell)	// radio

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -167,7 +167,7 @@
 	if(prob(20) && !software.Find("redundant threading"))
 		var/turf/T = get_turf(src.loc)
 		for (var/mob/M in viewers(T))
-			M.show_message("<span class='warning'>A shower of sparks spray from [src]'s inner workings.</span>", 3, "<span class='warning'>You hear and smell the ozone hiss of electrical sparks being expelled violently.</span>", 2)
+			M.show_message("<span class='warning'>A shower of sparks spray from [src]'s inner workings.</span>", 1, "<span class='warning'>You hear and smell the ozone hiss of electrical sparks being expelled violently.</span>", 2)
 		return src.death(0)
 
 	switch(pick(1,2,3))

--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -38,7 +38,7 @@
 	if(temp)
 		left_part = temp
 	else if(src.stat == 2)						// Show some flavor text if the pAI is dead
-		left_part = "<b><font color=red>ÈRrÖR Ğa†Ä ÇÖRrÚş†Ìoñ</font></b>"
+		left_part = "<b><font color=red>ÃˆRrÃ–R Ãaâ€ Ã„ Ã‡Ã–RrÃšÃ¾â€ ÃŒoÃ±</font></b>"
 		right_part = "<pre>Program index hash not found</pre>"
 
 	else
@@ -202,7 +202,7 @@
 
 				sradio.send_signal("ACTIVATE")
 				for(var/mob/O in hearers(1, src.loc))
-					O.show_message(text("\icon[] *beep* *beep*", src), 3, "*beep* *beep*", 2)
+					O.show_message(text("\icon[] *beep* *beep*", src), 1, "*beep* *beep*", 2)
 
 			if(href_list["freq"])
 
@@ -362,7 +362,7 @@
 		if(s == SOFT_WJ)
 			dat += "<a href='byond://?src=\ref[src];software=wirejack;sub=0'>Wire Jack</a> <br>"
 		if(s == SOFT_UT)
-			dat += "<a href='byond://?src=\ref[src];software=translator;sub=0'>Universal Translator</a>[(universal_understand) ? "<font color=#55FF55>•</font>" : "<font color=#FF5555>•</font>"] <br>"
+			dat += "<a href='byond://?src=\ref[src];software=translator;sub=0'>Universal Translator</a>[(universal_understand) ? "<font color=#55FF55>ï¿½</font>" : "<font color=#FF5555>ï¿½</font>"] <br>"
 		if(s == SOFT_CS)
 			dat += "<a href='byond://?src=\ref[src];software=chemsynth;sub=0'>Chemical Synthesizer</a> <br>"
 		if(s == SOFT_FS)
@@ -426,7 +426,7 @@
 	if(answer == "Yes")
 		var/turf/T = get_turf(P.loc)
 		for (var/mob/v in viewers(T))
-			v.show_message("<span class='notice'>[M] presses \his thumb against [P].</span>", 3, "<span class='notice'>[P] makes a sharp clicking sound as it extracts DNA material from [M].</span>", 2)
+			v.show_message("<span class='notice'>[M] presses \his thumb against [P].</span>", 1, "<span class='notice'>[P] makes a sharp clicking sound as it extracts DNA material from [M].</span>", 2)
 		var/datum/dna/dna = M.dna
 		to_chat(P, "<font color = red><h3>[M]'s UE string : [dna.unique_enzymes]</h3></font>")
 		if(dna.unique_enzymes == P.master_dna)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -882,7 +882,7 @@
 
 	else if(istype(W, /obj/item/weapon/screwdriver) && opened && !cell)	// haxing
 		wiresexposed = !wiresexposed
-		to_chat(user, "The wires have been [wiresexposed ? "exposed" : "unexposed"]")
+		to_chat(user, "The wires have been [wiresexposed ? "exposed" : "unexposed"].")
 		updateicon()
 
 	else if(istype(W, /obj/item/weapon/screwdriver) && opened && cell)	// radio

--- a/code/modules/paperwork/nano_paper_bin.dm
+++ b/code/modules/paperwork/nano_paper_bin.dm
@@ -36,7 +36,7 @@
 		p = new /obj/item/weapon/paper/nano
 		p.loc = user.loc
 		user.put_in_hands(p)
-		to_chat(user, "<span class='notice'>the [src] spits out a [p]</span>")
+		to_chat(user, "<span class='notice'>\The [src] spits out a piece of nano paper.</span>")
 		if(ressources == 0)
 			to_chat(user, "<span class=notice> The dispenser is now empty!")
 	else

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -441,7 +441,7 @@
 			to_chat(user, "The interface is broken.")
 		else if(has_electronics == 2)
 			wiresexposed = !wiresexposed
-			to_chat(user, "The wires have been [wiresexposed ? "exposed" : "unexposed"]")
+			to_chat(user, "The wires have been [wiresexposed ? "exposed" : "unexposed"].")
 			update_icon()
 		else
 			to_chat(user, "<span class='warning'>You open the panel and find nothing inside.</span>")
@@ -995,7 +995,7 @@
 				s.set_up(3, 1, src)
 				s.start()
 				for(var/mob/M in viewers(src))
-					M.show_message("<span class='warning'>The [src.name] suddenly lets out a blast of smoke and some sparks!</span>", 3, "<span class='warning'>You hear sizzling electronics.</span>", 2)
+					M.show_message("<span class='warning'>The [src.name] suddenly lets out a blast of smoke and some sparks!</span>", 1, "<span class='warning'>You hear sizzling electronics.</span>", 2)
 
 /obj/machinery/power/apc/can_attach_terminal(mob/user)
 	return user.loc == src.loc && has_electronics != 2 && !terminal

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -335,7 +335,7 @@ var/global/list/obj/machinery/light/alllights = list()
 			for(var/mob/M in viewers(src))
 				if(M == user)
 					continue
-				M.show_message("[user.name] smashed the light!", 3, "You hear a tinkle of breaking glass", 2)
+				M.show_message("[user.name] smashed the light!", 1, "You hear a tinkle of breaking glass", 2)
 			if(on && (W.is_conductor()))
 				//if(!user.mutations & M_RESIST_COLD)
 				if (prob(12))
@@ -430,7 +430,7 @@ var/global/list/obj/machinery/light/alllights = list()
 		return
 	else if (status == LIGHT_OK||status == LIGHT_BURNED)
 		for(var/mob/M in viewers(src))
-			M.show_message("<span class='attack'>[user.name] smashed the light!</span>", 3, "You hear a tinkle of breaking glass", 2)
+			M.show_message("<span class='attack'>[user.name] smashed the light!</span>", 1, "You hear a tinkle of breaking glass", 2)
 		broken()
 	return
 
@@ -441,7 +441,7 @@ var/global/list/obj/machinery/light/alllights = list()
 		return
 	else if (status == LIGHT_OK||status == LIGHT_BURNED)
 		for(var/mob/O in viewers(src))
-			O.show_message("<span class='attack'>[M.name] smashed the light!</span>", 3, "You hear a tinkle of breaking glass", 2)
+			O.show_message("<span class='attack'>[M.name] smashed the light!</span>", 1, "You hear a tinkle of breaking glass", 2)
 		broken()
 	return
 // attack with hand - remove tube/bulb

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -142,10 +142,10 @@
 				M.apply_effect((rand(30,80)),IRRADIATE)
 				M.Weaken(5)
 				for (var/mob/V in viewers(src))
-					V.show_message("<span class='warning'>[M] writhes in pain as \his vacuoles boil.</span>", 3, "<span class='warning'>You hear the crunching of leaves.</span>", 2)
+					V.show_message("<span class='warning'>[M] writhes in pain as \his vacuoles boil.</span>", 1, "<span class='warning'>You hear the crunching of leaves.</span>", 2)
 			if(prob(mutstrength*3))
 			//	for (var/mob/V in viewers(src)) //Public messages commented out to prevent possible metaish genetics experimentation and stuff. - Cheridan
-			//		V.show_message("<span class='warning'>[M] is mutated by the radiation beam.</span>", 3, "<span class='warning'>You hear the snapping of twigs.</span>", 2)
+			//		V.show_message("<span class='warning'>[M] is mutated by the radiation beam.</span>", 1, "<span class='warning'>You hear the snapping of twigs.</span>", 2)
 				if(prob(80))
 					randmutb(M)
 					domutcheck(M,null)
@@ -156,12 +156,12 @@
 				M.adjustFireLoss(rand(mutstrength/3, mutstrength))
 				M.show_message("<span class='warning'>The radiation beam singes you!</span>")
 			//	for (var/mob/V in viewers(src))
-			//		V.show_message("<span class='warning'>[M] is singed by the radiation beam.</span>", 3, "<span class='warning'>You hear the crackle of burning leaves.</span>", 2)
+			//		V.show_message("<span class='warning'>[M] is singed by the radiation beam.</span>", 1, "<span class='warning'>You hear the crackle of burning leaves.</span>", 2)
 		else
 			M.show_message("<span class='notice'>The radiation beam dissipates harmlessly through your body.</span>")
 	else if(istype(target, /mob/living/carbon/))
 	//	for (var/mob/V in viewers(src))
-	//		V.show_message("The radiation beam dissipates harmlessly through [M]", 3)
+	//		V.show_message("The radiation beam dissipates harmlessly through [M]", 2) //spooky
 		M.show_message("<span class='notice'>The radiation beam dissipates harmlessly through your body.</span>")
 	else
 		return 1

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -431,10 +431,10 @@
 		if(prob(75))
 			I.loc = src
 			for(var/mob/M in viewers(src))
-				M.show_message("\the [I] lands in \the [src].", 3)
+				M.show_message("\the [I] lands in \the [src].", 1)
 		else
 			for(var/mob/M in viewers(src))
-				M.show_message("\the [I] bounces off of \the [src]'s rim!.", 3)
+				M.show_message("\the [I] bounces off of \the [src]'s rim!.", 1)
 		return 0
 	else
 		return ..(mover, target, height, air_group)

--- a/code/modules/research/xenoarchaeology/machinery/artifact_analyser_old.dm
+++ b/code/modules/research/xenoarchaeology/machinery/artifact_analyser_old.dm
@@ -289,7 +289,7 @@
 		P.name = "Artifact Analysis Report #[scan_num]"
 		P.info = r
 		for(var/mob/O in hearers(src, null))
-			O.show_message("\icon[src] <span class='notice'>The [src.name] prints a sheet of paper</span>", 3)
+			O.show_message("\icon[src] <span class='notice'>The [src.name] prints a sheet of paper.</span>")
 		use_power(10)
 
 	if(href_list["close"])

--- a/code/modules/virus2/analyser.dm
+++ b/code/modules/virus2/analyser.dm
@@ -50,7 +50,7 @@
 			else
 				toscan += D
 
-		visible_message("<span class='notice'>[user.name] inserts the [D.name] in the [src.name].</span>", 3)
+		visible_message("<span class='notice'>[user.name] inserts the [D.name] in the [src.name].</span>", 2) //spooky
 		src.updateUsrDialog()
 
 /obj/machinery/disease2/diseaseanalyser/proc/PrintPaper(var/obj/item/weapon/virusdish/D)

--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -47,12 +47,12 @@ var/global/list/disease2_list = list()
 		return // return if isn't proper mob type
 	var/datum/disease2/disease/D = new /datum/disease2/disease("custom_disease") //set base name
 	for(var/i = 1; i <= D.max_stage; i++)  // run through this loop until everything is set
-		var/datum/disease2/effect/sympton = input(C, "Choose a sympton to add ([5-i] remaining)", "Choose a Sympton") in ((typesof(/datum/disease2/effect) - /datum/disease2/effect)) // choose a sympton from the list of them
+		var/datum/disease2/effect/symptom = input(C, "Choose a symptom to add ([5-i] remaining)", "Choose a Symptom") in ((typesof(/datum/disease2/effect) - /datum/disease2/effect)) // choose a symptom from the list of them
 		var/datum/disease2/effectholder/holder = new /datum/disease2/effectholder(infectedMob) // create the infectedMob as a holder for it.
 		holder.stage = i // set the stage of this holder equal to i.
-		var/datum/disease2/effect/f = new sympton // initalize the new sympton
-		holder.effect = f // assign the new sympton to the holder
-		holder.chance = input(C, "Choose chance", "Chance") as num // set the chance of the sympton that can occur
+		var/datum/disease2/effect/f = new symptom // initalize the new symptom
+		holder.effect = f // assign the new symptom to the holder
+		holder.chance = input(C, "Choose chance", "Chance") as num // set the chance of the symptom that can occur
 		if(holder.chance > 100 || holder.chance < 0)
 			return 0
 		D.log += "[f.name] [holder.chance]%<br>"

--- a/code/unused/disease2/analyser.dm
+++ b/code/unused/disease2/analyser.dm
@@ -20,7 +20,7 @@
 			I.loc = src
 			for(var/mob/M in viewers(src))
 				if(M == user)	continue
-				M.show_message("<span class='notice'>[user.name] inserts the [dish.name] in the [src.name]</span>", 3)
+				M.show_message("<span class='notice'>[user.name] inserts the [dish.name] in the [src.name].</span>", 1)
 
 
 		else
@@ -55,7 +55,7 @@
 			icon_state = "analyser"
 
 			for(var/mob/O in hearers(src, null))
-				O.show_message("\icon[src] <span class='notice'>The [src.name] prints a sheet of paper</span>", 3)
+				O.show_message("\icon[src] <span class='notice'>The [src.name] prints a sheet of paper.</span>", 1)
 	else if(dish && !scanning && !pause)
 		if(dish.virus2 && dish.growth > 50)
 			dish.growth -= 10


### PR DESCRIPTION
Fixes some large items, such as mech parts, showing "it is a  item" in their description
Fixes #6909
Fixes HTML in mousetrap box description
Fixes arguments in many messages that were intended to not be visible to blind people
Renames mech "Syringe Gun" to "Exosuit-Mounted Syringe Gun", to differentiate it a little better, since they have the same icon and almost the same name as the non-mech deal.
