### PR TITLE
Ghosts can read books

### DIFF
--- a/html/changelogs/9600bauds_R-E-A-D-A-B-O-O-KAY.yml
+++ b/html/changelogs/9600bauds_R-E-A-D-A-B-O-O-KAY.yml
@@ -1,0 +1,35 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general deleting of nice things)
+#   rscadd (general adding of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: 9600bauds
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+changes: 
+- rscadd: Ghosts can now read books by examining them when close enough. Ghosts can now also click a bookcase to read the books that are inside (without removing them from the bookcase).


### PR DESCRIPTION
Ghosts can now read books by examining them when close enough. Ghosts can now also click a bookcase to read the books that are inside (without removing them from the bookcase). 

Pros:
- Gives dead people something in-game to pass time
- Makes librarian a little bit less useless
- Players voted for it: http://i.imgur.com/IGTnF5h.png
- Will probably greatly increase the amount of books read

Cons:
- Will probably greatly increase the amount of books read
- Supposedly rewards players for being dead, though most players wouldn't consider being able to read a book as a reward for being alive

Fixes #7444 
Also, adds a message when someone uses a screwdriver on a bookcase, fixes #6678
