### PR TITLE
Makes reactive teleport armor code better

### DIFF
--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -1,5 +1,5 @@
 /obj/machinery/washing_machine
-	name = "Washing Machine"
+	name = "washing machine"
 	icon = 'icons/obj/machines/washing_machine.dmi'
 	icon_state = "wm_10"
 	density = 1

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -691,6 +691,15 @@
 /obj/item/proc/IsShield()
 	return 0
 
+//Called when the item blocks an attack. Return 1 to stop the hit, return 0 to let the hit go through
+/obj/item/proc/on_block(damage, attack_text = "the attack")
+	if(ismob(loc))
+		if(prob(50 - round(damage / 3)))
+			visible_message("<span class='danger'>[loc] blocks [attack_text] with \the [src]!</span>")
+			return 1
+
+	return 0
+
 /obj/item/proc/eyestab(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
 
 

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -174,6 +174,34 @@
 		src.add_fingerprint(user)
 	return
 
+/obj/item/clothing/suit/armor/reactive/on_block(damage, attack_text)
+	if(!prob(35)) return 0 //35% chance
+
+	var/mob/living/carbon/human/L = loc
+	if(!istype(L)) return 0 //Not living mob
+	if(L.wear_suit != src) //Not worn
+		return 0 //Don't do anything
+
+	var/list/turfs = new/list()
+
+	for(var/turf/T in orange(6, loc))
+		if(istype(T,/turf/space)) continue
+		if(T.density) continue
+		if(T.x>world.maxx-6 || T.x<6)	continue
+		if(T.y>world.maxy-6 || T.y<6)	continue
+		turfs += T
+	if(!turfs.len) turfs += pick(/turf in orange(6))
+	var/turf/picked = pick(turfs)
+	if(!isturf(picked)) return
+
+	L.visible_message("<span class='danger'>The reactive teleport system flings [L] clear of [attack_text]!</span>", "<span class='notice'>The reactive teleport system flings you clear of [attack_text].</span>")
+
+	playsound(get_turf(L), 'sound/effects/teleport.ogg', 30, 1)
+
+	L.forceMove(picked)
+
+	return 1
+
 /obj/item/clothing/suit/armor/reactive/emp_act(severity)
 	active = 0
 	src.icon_state = "reactiveoff"

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -99,32 +99,21 @@ emp_act
 
 
 /mob/living/carbon/human/proc/check_shields(var/damage = 0, var/attack_text = "the attack")
-	if(l_hand && istype(l_hand, /obj/item/weapon))//Current base is the prob(50-d/3)
+	if(l_hand && istype(l_hand, /obj/item/weapon))
 		var/obj/item/weapon/I = l_hand
-		if(I.IsShield() && (prob(50 - round(damage / 3))))
-			visible_message("<span class='danger'>[src] blocks [attack_text] with the [l_hand.name]!</span>")
+		if(I.IsShield() && I.on_block(damage, attack_text))
 			return 1
+
 	if(r_hand && istype(r_hand, /obj/item/weapon))
 		var/obj/item/weapon/I = r_hand
-		if(I.IsShield() && (prob(50 - round(damage / 3))))
-			visible_message("<span class='danger'>[src] blocks [attack_text] with the [r_hand.name]!</span>")
+		if(I.IsShield() && I.on_block(damage, attack_text))
 			return 1
+
 	if(wear_suit && istype(wear_suit, /obj/item/))
 		var/obj/item/I = wear_suit
-		if(I.IsShield() && (prob(35)))
-			visible_message("<span class='danger'>The reactive teleport system flings [src] clear of [attack_text]!</span>")
-			var/list/turfs = new/list()
-			for(var/turf/T in orange(6))
-				if(istype(T,/turf/space)) continue
-				if(T.density) continue
-				if(T.x>world.maxx-6 || T.x<6)	continue
-				if(T.y>world.maxy-6 || T.y<6)	continue
-				turfs += T
-			if(!turfs.len) turfs += pick(/turf in orange(6))
-			var/turf/picked = pick(turfs)
-			if(!isturf(picked)) return
-			src.loc = picked
+		if(I.IsShield() && I.on_block(damage, attack_text))
 			return 1
+
 	return 0
 
 /mob/living/carbon/human/emp_act(severity)


### PR DESCRIPTION
because this is just awful:

```
    if(wear_suit && istype(wear_suit, /obj/item/))
        var/obj/item/I = wear_suit
        if(I.IsShield() && (prob(35)))
            visible_message("<span class='danger'>The reactive teleport system flings [src] clear of [attack_text]!</span>")
            var/list/turfs = new/list()
            for(var/turf/T in orange(6))
                if(istype(T,/turf/space)) continue
                if(T.density) continue
                if(T.x>world.maxx-6 || T.x<6)   continue
                if(T.y>world.maxy-6 || T.y<6)   continue
                turfs += T
            if(!turfs.len) turfs += pick(/turf in orange(6))
            var/turf/picked = pick(turfs)
            if(!isturf(picked)) return
            src.loc = picked
```

In addition to isShield() proc for items, there's now "on_block(damage, attack_text)" proc that is called when an item can block a hit. If it returns 1, the hit is successfully blocked.

Also plays a sound when the reactive teleport armor activates

Also the washing machine's name is now lowercase 
