### PR TITLE
Added existing_typesof() proc

### DIFF
--- a/code/__HELPERS/typeof.dm
+++ b/code/__HELPERS/typeof.dm
@@ -1,0 +1,32 @@
+var/global/list/existing_typesof_cache = list()
+
+//existing_typesof functions like typesof, with some differences
+//1) it only works with pathes derived from /atom
+//2) the returned list contains NO items without an icon state or an icon
+//
+//Intended to be used, for example, when you want to spawn a random monster or an item.
+//picking a type from typesof(/mob/living/simple_animal/hostile) can output an abstract type like /mob/living/simple_animal/hostile/asteroid,
+//resulting in an invisible monster.
+
+//Values are cached, so when doing existing_typesof(/atom), all paths derived from /atom will only be checked on the first call
+//All calls afterwards will return a copy of a list from the cache
+
+/proc/existing_typesof(var/path)
+	if(!ispath(path, /atom))
+		return typesof(path)
+
+	if(existing_typesof_cache[path])
+		var/list/L = existing_typesof_cache[path]
+		return L.Copy()
+
+	var/list/L = typesof(path)
+
+	for(var/checked_type in L) //Go through all types
+		var/atom/A = checked_type
+
+		if(!initial(A.icon_state) || !initial(A.icon)) //No icon or icon_state -> into the trash it goes
+			L.Remove(checked_type)
+
+	existing_typesof_cache[path] = L.Copy()
+
+	return L

--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -744,7 +744,7 @@
 
 /obj/item/weapon/module
 	icon = 'icons/obj/module.dmi'
-	icon_state = "std_module"
+	//icon_state = "std_module"
 	w_class = 2.0
 	item_state = "electronic"
 	flags = FPRINT

--- a/code/game/objects/items/devices/mat_synth.dm
+++ b/code/game/objects/items/devices/mat_synth.dm
@@ -174,7 +174,7 @@
 			emagged = 1
 			var/matter_rng = rand(5, 25)
 			if(matter >= matter_rng)
-				var/obj/item/device/spawn_item = pick(typesof(/obj/item/device) - /obj/item/device) //we make any kind of device. It's a surprise!
+				var/obj/item/device/spawn_item = pick(existing_typesof(/obj/item/device)) //we make any kind of device. It's a surprise!
 				user.visible_message("<span class='warning'>\The [src] in [user]'s hands appears to be trying to synthesize... \a [initial(spawn_item.name)]?</span>", \
 									 "<span class='warning'>\The [src] pops and fizzles in your hands, before creating... \a [initial(spawn_item.name)]?</span>", \
 									 "<span class='warning'>You hear a loud popping noise.</span>")

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -2,7 +2,7 @@
 	name = "robot parts"
 	icon = 'icons/obj/robot_parts.dmi'
 	item_state = "buildpipe"
-	icon_state = "blank"
+	icon_state = ""
 	flags = FPRINT
 	siemens_coefficient = 1
 	slot_flags = SLOT_BELT

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -926,7 +926,7 @@
 /obj/item/toy/gasha/bomberman
 	name = "toy bomberman"
 	desc = "The explosive hero of the Bomberman series!"
-	icon_state = "bomberman"
+	icon_state = "bomberman1"
 
 /obj/item/toy/gasha/bomberman/white
 	icon_state = "bomberman1"

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -266,7 +266,7 @@
 /obj/item/weapon/storage/belt/lazarus
 	name = "trainer's belt"
 	desc = "For the pokemo- mining master, holds your lazarus capsules."
-	icon_state = "lazarusbelt"
+	icon_state = "lazarusbelt_0"
 	item_state = "lazbelt"
 	w_class = 4
 	max_w_class = 4
@@ -281,7 +281,7 @@
 
 /obj/item/weapon/storage/belt/lazarus/update_icon()
 	..()
-	icon_state = "[initial(icon_state)]_[contents.len]"
+	icon_state = "lazarusbelt_[contents.len]"
 
 /obj/item/weapon/storage/belt/lazarus/attackby(obj/item/W, mob/user)
 	var/amount = contents.len
@@ -305,12 +305,10 @@
 	can_hold = list("/obj/item/device/mobcapsule")
 
 /obj/item/weapon/storage/belt/lazarus/antag/New(loc, mob/user)
-	var/blocked = list(/mob/living/simple_animal/hostile,
+	var/blocked = list(
 	/mob/living/simple_animal/hostile/hivebot/tele,
-	/mob/living/simple_animal/hostile/necro/copy,
-	/mob/living/simple_animal/hostile/humanoid,
 	)
-	var/list/critters = typesof(/mob/living/simple_animal/hostile) - blocked // list of possible hostile mobs
+	var/list/critters = existing_typesof(/mob/living/simple_animal/hostile) - blocked // list of possible hostile mobs
 	critters = shuffle(critters)
 	while(contents.len < 6)
 		var/obj/item/device/mobcapsule/MC = new /obj/item/device/mobcapsule(src)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -1,7 +1,7 @@
 /obj/item/weapon/robot_module
 	name = "robot module"
 	icon = 'icons/obj/module.dmi'
-	icon_state = "std_module"
+	//icon_state = "std_module"
 	w_class = 100.0
 	item_state = "electronic"
 	flags = FPRINT

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -367,7 +367,7 @@ var/global/list/item_mimic_disguises = list(
 				/obj/item/weapon/gun/energy/mindflayer, /obj/item/weapon/gun/energy/lasercannon, /obj/item/weapon/gun/energy/pulse_rifle, /obj/item/weapon/katana/hfrequency,\
 				/obj/item/weapon/melee/cultblade, /obj/item/weapon/pickaxe/jackhammer, /obj/item/weapon/tank/plasma, /obj/item/weapon/gibtonite), //Security items and weapons
 
-	"bar" = (typesof(/obj/item/weapon/reagent_containers/food/drinks) - typesof(/obj/item/weapon/reagent_containers/food/drinks/bottle/customizable) - /obj/item/weapon/reagent_containers/food/drinks/bottle - /obj/item/weapon/reagent_containers/food/drinks/soda_cans),  //All drinks (except for abstract types)
+	"bar" = (existing_typesof(/obj/item/weapon/reagent_containers/food/drinks) - typesof(/obj/item/weapon/reagent_containers/food/drinks/bottle/customizable)),  //All drinks (except for customizable stuff)
 
 	"emergency" = list(/obj/item/clothing/mask/breath, /obj/item/weapon/tank/jetpack/oxygen, /obj/item/weapon/tank/emergency_oxygen, /obj/item/weapon/tank/air, /obj/item/weapon/crowbar,\
 					/obj/item/weapon/storage/firstaid, /obj/item/weapon/storage/backpack/holding, /obj/item/weapon/storage/backpack/security, /obj/item/device/maracas, /obj/item/device/multitool,\
@@ -375,12 +375,12 @@ var/global/list/item_mimic_disguises = list(
 
 	"lowhealth" = list(/obj/item/weapon/cigbutt, /obj/item/weapon/shard, /obj/item/toy/blink, /obj/item/toy/ammo/crossbow, /obj/item/ammo_casing/a666), //Small, hard-to-notice items to turn into when at low health
 
-	//All foods EXCEPT for those with no icons (plenty of them)
-	"kitchen" = (typesof(/obj/item/weapon/reagent_containers/food/snacks) - /obj/item/weapon/reagent_containers/food/snacks - typesof(/obj/item/weapon/reagent_containers/food/snacks/chip) - typesof(/obj/item/weapon/reagent_containers/food/snacks/customizable) - typesof(/obj/item/weapon/reagent_containers/food/snacks/sliceable) - /obj/item/weapon/reagent_containers/food/snacks/slimesoup - typesof(/obj/item/weapon/reagent_containers/food/snacks/sweet)),
+	//All foods except for customizable stuff
+	"kitchen" = (existing_typesof(/obj/item/weapon/reagent_containers/food/snacks) - typesof(/obj/item/weapon/reagent_containers/food/snacks/customizable) - typesof(/obj/item/weapon/reagent_containers/food/snacks/sliceable) - /obj/item/weapon/reagent_containers/food/snacks/slimesoup - typesof(/obj/item/weapon/reagent_containers/food/snacks/sweet)),
 
 	"library" = typesof(/obj/item/weapon/book), //All default books
 
-	"botany" = (typesof(/obj/item/weapon/reagent_containers/food/snacks/grown) - /obj/item/weapon/reagent_containers/food/snacks/grown), //All grown items
+	"botany" = existing_typesof(/obj/item/weapon/reagent_containers/food/snacks/grown), //All grown items
 
 	//Nuke, nuke disk, all coins, all minerals (except for those with no icons)
 	"vault" = list(/obj/machinery/nuclearbomb, /obj/item/weapon/disk/nuclear) + typesof(/obj/item/weapon/coin) + typesof(/obj/item/stack/sheet/mineral) - /obj/item/stack/sheet/mineral - /obj/item/stack/sheet/mineral/enruranium,
@@ -489,6 +489,8 @@ var/global/list/protected_objects = list(
 
 	health = 100
 	maxHealth = 100
+
+	icon_state = "" //So that existing_typesof() doesn't return this type
 
 	copied_object = null
 	var/mob/living/creator = null // the creator

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -1158,44 +1158,24 @@ datum
 				else
 					send_admin_alert(holder, reaction_name="gold slime + plasma in a grenade!!")//expect to this this one spammed in the times to come
 
-				var/blocked = list(/mob/living/simple_animal/hostile,
-					/mob/living/simple_animal/hostile/humanoid/,
-					/mob/living/simple_animal/hostile/humanoid/pirate,
-					/mob/living/simple_animal/hostile/humanoid/pirate/ranged,
-					/mob/living/simple_animal/hostile/humanoid/russian,
-					/mob/living/simple_animal/hostile/humanoid/russian/ranged,
-					/mob/living/simple_animal/hostile/humanoid/syndicate,
-					/mob/living/simple_animal/hostile/humanoid/syndicate/melee,
-					/mob/living/simple_animal/hostile/humanoid/syndicate/melee/space,
-					/mob/living/simple_animal/hostile/humanoid/syndicate/ranged,
-					/mob/living/simple_animal/hostile/humanoid/syndicate/ranged/space,
+				var/blocked = list(
 					/mob/living/simple_animal/hostile/alien/queen/large,
 					/mob/living/simple_animal/hostile/faithless,
 					/mob/living/simple_animal/hostile/faithless/cult,
 					/mob/living/simple_animal/hostile/scarybat/cult,
 					/mob/living/simple_animal/hostile/creature/cult,
-					// /mob/living/simple_animal/hostile/panther,
-					// /mob/living/simple_animal/hostile/snake,
-					/mob/living/simple_animal/hostile/retaliate,
 					/mob/living/simple_animal/hostile/retaliate/clown,
 					/mob/living/simple_animal/hostile/mushroom,
-					/mob/living/simple_animal/hostile/asteroid,
-					/mob/living/simple_animal/hostile/asteroid/basilisk,
-					/mob/living/simple_animal/hostile/asteroid/goldgrub,
-					/mob/living/simple_animal/hostile/asteroid/goliath,
-					/mob/living/simple_animal/hostile/asteroid/hivelord,
-					/mob/living/simple_animal/hostile/asteroid/hivelordbrood,
 					/mob/living/simple_animal/hostile/carp/holocarp,
 					/mob/living/simple_animal/hostile/slime,
 					/mob/living/simple_animal/hostile/slime/adult,
 					/mob/living/simple_animal/hostile/mining_drone,
 					/mob/living/simple_animal/hostile/mimic,
-					/mob/living/simple_animal/hostile/mimic/copy,
 					/mob/living/simple_animal/hostile/mimic/crate,
 					/mob/living/simple_animal/hostile/mimic/crate/chest,
 					/mob/living/simple_animal/hostile/mimic/crate/item,
-					)//exclusion list for things you don't want the reaction to create.
-				var/list/critters = typesof(/mob/living/simple_animal/hostile) - blocked // list of possible hostile mobs
+					) + typesof(/mob/living/simple_animal/hostile/humanoid) + typesof(/mob/living/simple_animal/hostile/asteroid)//exclusion list for things you don't want the reaction to create.
+				var/list/critters = existing_typesof(/mob/living/simple_animal/hostile) - blocked // list of possible hostile mobs
 
 
 				playsound(get_turf(holder.my_atom), 'sound/effects/phasein.ogg', 100, 1)
@@ -1237,27 +1217,10 @@ datum
 				else
 					send_admin_alert(holder, reaction_name="gold slime + blood in a grenade")
 
-				var/blocked = list(/mob/living/simple_animal/hostile,
-					/mob/living/simple_animal/hostile/humanoid,
-					/mob/living/simple_animal/hostile/humanoid/pirate,
-					/mob/living/simple_animal/hostile/humanoid/pirate/ranged,
-					/mob/living/simple_animal/hostile/humanoid/russian,
-					/mob/living/simple_animal/hostile/humanoid/russian/ranged,
-					/mob/living/simple_animal/hostile/humanoid/syndicate,
-					/mob/living/simple_animal/hostile/humanoid/syndicate/melee,
-					/mob/living/simple_animal/hostile/humanoid/syndicate/melee/space,
-					/mob/living/simple_animal/hostile/humanoid/syndicate/ranged,
-					/mob/living/simple_animal/hostile/humanoid/syndicate/ranged/space,
+				var/blocked = list(
 					/mob/living/simple_animal/hostile/alien/queen/large,
-					/mob/living/simple_animal/hostile/retaliate,
 					/mob/living/simple_animal/hostile/retaliate/clown,
 					/mob/living/simple_animal/hostile/mushroom,
-					/mob/living/simple_animal/hostile/asteroid,
-					/mob/living/simple_animal/hostile/asteroid/basilisk,
-					/mob/living/simple_animal/hostile/asteroid/goldgrub,
-					/mob/living/simple_animal/hostile/asteroid/goliath,
-					/mob/living/simple_animal/hostile/asteroid/hivelord,
-					/mob/living/simple_animal/hostile/asteroid/hivelordbrood,
 					/mob/living/simple_animal/hostile/carp/holocarp,
 					/mob/living/simple_animal/hostile/faithless/cult,
 					/mob/living/simple_animal/hostile/scarybat/cult,
@@ -1266,8 +1229,8 @@ datum
 					/mob/living/simple_animal/hostile/slime/adult,
 					/mob/living/simple_animal/hostile/hivebot/tele,//this thing spawns hostile mobs
 					/mob/living/simple_animal/hostile/mining_drone,
-					)//exclusion list for things you don't want the reaction to create.
-				var/list/critters = typesof(/mob/living/simple_animal/hostile) - blocked // list of possible hostile mobs
+					) + typesof(/mob/living/simple_animal/hostile/humanoid) + typesof(/mob/living/simple_animal/hostile/asteroid)//exclusion list for things you don't want the reaction to create.
+				var/list/critters = existing_typesof(/mob/living/simple_animal/hostile) - blocked // list of possible hostile mobs
 
 				send_admin_alert(holder, reaction_name="gold slime + blood")
 
@@ -1360,7 +1323,7 @@ datum
 					)
 				blocked += typesof(/obj/item/weapon/reagent_containers/food/snacks/customizable)	//silver-slime spawned customizable food is borked
 
-				var/list/borks = typesof(/obj/item/weapon/reagent_containers/food/snacks) - blocked
+				var/list/borks = existing_typesof(/obj/item/weapon/reagent_containers/food/snacks) - blocked
 				// BORK BORK BORK
 
 				playsound(get_turf(holder.my_atom), 'sound/effects/phasein.ogg', 100, 1)
@@ -1413,7 +1376,7 @@ datum
 				blocked += typesof(/obj/item/weapon/reagent_containers/food/drinks/bottle/customizable)	//silver-slime spawned customizable food is borked
 				blocked += typesof(/obj/item/weapon/reagent_containers/food/drinks/golden_cup)		//was probably never intended to spawn outside admin events
 
-				var/list/borks = typesof(/obj/item/weapon/reagent_containers/food/drinks) - blocked
+				var/list/borks = existing_typesof(/obj/item/weapon/reagent_containers/food/drinks) - blocked
 				// BORK BORK BORK
 
 				playsound(get_turf(holder.my_atom), 'sound/effects/phasein.ogg', 100, 1)

--- a/code/modules/reagents/reagent_containers/food/snacks/meat.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/meat.dm
@@ -140,7 +140,7 @@
 	visible_message("<span class='info'>\The [src] transforms into a pile of bones!</span>")
 	shapeshift(/obj/effect/decal/remains/human) //Turn into human remains
 
-var/global/list/valid_random_food_types = typesof(/obj/item/weapon/reagent_containers/food/snacks) - typesof(/obj/item/weapon/reagent_containers/food/snacks/customizable) - /obj/item/weapon/reagent_containers/food/snacks
+var/global/list/valid_random_food_types = existing_typesof(/obj/item/weapon/reagent_containers/food/snacks) - typesof(/obj/item/weapon/reagent_containers/food/snacks/customizable)
 
 /obj/item/weapon/reagent_containers/food/snacks/meat/mimic/proc/shapeshift(atom/atom_to_copy = null)
 	if(!atom_to_copy)

--- a/code/modules/research/xenoarchaeology/finds/finds.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds.dm
@@ -319,9 +319,7 @@
 			apply_image_decorations = 0
 			apply_material_decorations = 0
 		if(24)
-			var/list/possible_spawns = typesof(/obj/item/weapon/stock_parts)
-			possible_spawns -= /obj/item/weapon/stock_parts
-			possible_spawns -= /obj/item/weapon/stock_parts/subspace
+			var/list/possible_spawns = existing_typesof(/obj/item/weapon/stock_parts)
 
 			var/new_type = pick(possible_spawns)
 			new_item = new new_type(src.loc)

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -36,6 +36,7 @@
 #include "code\__HELPERS\time.dm"
 #include "code\__HELPERS\timed_alerts.dm"
 #include "code\__HELPERS\type2type.dm"
+#include "code\__HELPERS\typeof.dm"
 #include "code\__HELPERS\unsorted.dm"
 #include "code\__HELPERS\sorts\_Main.dm"
 #include "code\__HELPERS\sorts\InsertSort.dm"


### PR DESCRIPTION
existing_typesof(/obj) works almost like typesof(/obj), but **most** of the "abstract" paths like /obj or /obj/item are weeded out.

It works by going through each path in typesof(/obj) and checking if its _icon_ or _icon_state_ are equal to null. If they are, the path is removed from the result

Results are cached

Fixes #7608 

Fixes #7350 

Also changed / commented out some of the items' icon_states which were previously invalid (so that this proc can work better). Some instances of typesof(/atom) were replaced with existing_typesof(/atom)
