### PR TITLE
[Really Fucking Ready 4 Merge This Time] Fixes Comic's material datums being broken with stackable items

### DIFF
--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -16,10 +16,6 @@
 	w_type=RECYK_METAL
 	melt_temperature = MELTPOINT_STEEL
 
-/obj/item/stack/rods/recycle(var/datum/materials/rec)
-	rec.addAmount("iron",amount/2)
-	return RECYK_METAL
-
 /obj/item/stack/rods/afterattack(atom/Target, mob/user, adjacent, params)
 	var/busy = 0
 	if(adjacent)

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -203,10 +203,6 @@
 /obj/item/stack/sheet/glass/glass/cyborg
 	starting_materials = null
 
-/obj/item/stack/sheet/glass/glass/recycle(var/datum/materials/rec)
-	rec.addAmount(MAT_GLASS, amount)
-	return 1
-
 /obj/item/stack/sheet/glass/glass/attackby(obj/item/W, mob/user)
 	if(istype(W,/obj/item/stack/cable_coil))
 		var/obj/item/stack/cable_coil/CC = W
@@ -245,11 +241,6 @@
 /obj/item/stack/sheet/glass/rglass/cyborg
 	starting_materials = null
 
-/obj/item/stack/sheet/glass/rglass/recycle(var/datum/materials/rec)
-	rec.addAmount(MAT_GLASS, amount)
-	rec.addAmount(MAT_IRON,  0.5 * amount)
-	return 1
-
 /*
  * Plasma Glass sheets
  */
@@ -260,7 +251,7 @@
 	singular_name = "glass sheet"
 	icon_state = "sheet-plasmaglass"
 	sname = "plasma"
-	starting_materials = list(MAT_GLASS = CC_PER_SHEET_GLASS)
+	starting_materials = list(MAT_GLASS = CC_PER_SHEET_GLASS, MAT_PLASMA = CC_PER_SHEET_MISC)
 	origin_tech = "materials=3;plasmatech=2"
 	created_window = /obj/structure/window/plasma
 	full_window = /obj/structure/window/full/plasma
@@ -271,11 +262,6 @@
 	shealth = 20
 	shard_type = /obj/item/weapon/shard/plasma
 
-/obj/item/stack/sheet/glass/plasmaglass/recycle(var/datum/materials/rec)
-	rec.addAmount(MAT_PLASMA, amount)
-	rec.addAmount(MAT_GLASS, amount)
-	return RECYK_GLASS
-
 /*
  * Reinforced plasma glass sheets
  */
@@ -285,7 +271,7 @@
 	singular_name = "reinforced plasma glass sheet"
 	icon_state = "sheet-plasmarglass"
 	sname = "plasma_ref"
-	starting_materials = list(MAT_IRON = 1875, MAT_GLASS = CC_PER_SHEET_GLASS)
+	starting_materials = list(MAT_IRON = 1875, MAT_GLASS = CC_PER_SHEET_GLASS, MAT_PLASMA = CC_PER_SHEET_MISC)
 	melt_temperature = MELTPOINT_STEEL+500 // I guess...?
 	origin_tech = "materials=4;plasmatech=2"
 	created_window = /obj/structure/window/reinforced/plasma
@@ -296,9 +282,3 @@
 	glass_quality = 1.3
 	shealth = 30
 	shard_type = /obj/item/weapon/shard/plasma
-
-/obj/item/stack/sheet/glass/plasmarglass/recycle(var/datum/materials/rec)
-	rec.addAmount(MAT_PLASMA, amount)
-	rec.addAmount(MAT_GLASS, amount)
-	rec.addAmount(MAT_IRON,  0.5 * amount)
-	return 1

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -88,7 +88,7 @@ var/global/list/datum/stack_recipe/metal_recipes = list (
 	desc = "Sheets made out of metal. It has been dubbed Metal Sheets."
 	singular_name = "metal sheet"
 	icon_state = "sheet-metal"
-	starting_materials = list(MAT_IRON = 3750)
+	starting_materials = list(MAT_IRON = CC_PER_SHEET_METAL)
 	w_type = RECYK_METAL
 	throwforce = 14.0
 	flags = FPRINT
@@ -122,10 +122,6 @@ var/global/list/datum/stack_recipe/metal_recipes = list (
 	returnToPool(src)
 	return 2
 
-/obj/item/stack/sheet/metal/recycle(var/datum/materials/rec)
-	rec.addAmount(MAT_IRON, amount)
-	return 1
-
 // Diet metal.
 /obj/item/stack/sheet/metal/cyborg
 	starting_materials = null
@@ -156,7 +152,7 @@ var/global/list/datum/stack_recipe/plasteel_recipes = list (
 	desc = "This sheet is an alloy of iron and plasma."
 	icon_state = "sheet-plasteel"
 	item_state = "sheet-plasteel"
-	starting_materials = list(MAT_IRON = 3750) // Was 7500, which doesn't make any fucking sense
+	starting_materials = list(MAT_IRON = CC_PER_SHEET_METAL, MAT_PLASMA = CC_PER_SHEET_MISC) // Was 7500, which doesn't make any fucking sense
 	perunit = 2875 //average of plasma and metal
 	throwforce = 15.0
 	flags = FPRINT
@@ -168,11 +164,6 @@ var/global/list/datum/stack_recipe/plasteel_recipes = list (
 /obj/item/stack/sheet/plasteel/New(var/loc, var/amount=null)
 		recipes = plasteel_recipes
 		return ..()
-
-/obj/item/stack/sheet/plasteel/recycle(var/datum/materials/rec)
-	rec.addAmount(MAT_PLASMA, amount)
-	rec.addAmount(MAT_IRON, amount)
-	return 1
 
 /*
  * Wood

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -24,6 +24,7 @@
 	..()
 	if (amount)
 		src.amount=amount
+	update_materials()
 	return
 
 /obj/item/stack/Destroy()
@@ -154,6 +155,8 @@
 		var/atom/O
 		if(ispath(R.result_type, /obj/item/stack))
 			O = drop_stack(R.result_type, usr.loc, (R.max_res_amount>1 ? R.res_amount*multiplier : 1), usr)
+			var/obj/item/stack/S = O
+			S.update_materials()
 		else
 			O = new R.result_type( usr.loc )
 
@@ -196,6 +199,7 @@
 
 	if(src.amount>=amount)
 		src.amount-=amount
+		update_materials()
 	else
 		return 0
 	. = 1
@@ -232,6 +236,11 @@
 		src.preattack(item, usr,1)
 		break
 
+/obj/item/stack/proc/update_materials()
+	if(amount && starting_materials)
+		for(var/matID in starting_materials)
+			materials.storage[matID] = max(0, starting_materials[matID]*amount)
+
 /obj/item/stack/proc/can_stack_with(obj/item/other_stack)
 	if(ispath(other_stack)) return (src.type == other_stack)
 
@@ -266,6 +275,7 @@
 		else
 			to_transfer = min(S.amount, max_amount-amount)
 		amount+=to_transfer
+		update_materials()
 		to_chat(user, "You add [to_transfer] [((to_transfer > 1) && S.irregular_plural) ? S.irregular_plural : "[S.singular_name]\s"] to \the [src]. It now contains [amount] [CORRECT_STACK_NAME(src)].")
 		if (S && user.machine==S)
 			spawn(0) interact(user)
@@ -306,6 +316,7 @@
 		if(S.can_stack_with(new_stack_type))
 			if(S.max_amount >= S.amount + add_amount)
 				S.amount += add_amount
+				S.update_materials()
 
 				to_chat(user, "<span class='info'>You add [add_amount] item\s to the stack. It now contains [S.amount] [CORRECT_STACK_NAME(S)].</span>")
 				return S

--- a/code/game/objects/items/stacks/tiles/plasteel.dm
+++ b/code/game/objects/items/stacks/tiles/plasteel.dm
@@ -22,10 +22,6 @@
 	pixel_x = rand(1, 14)
 	pixel_y = rand(1, 14)
 
-/obj/item/stack/tile/plasteel/recycle(var/datum/materials/rec)
-	rec.addAmount("iron",amount/4)
-	return 1
-
 /*
 /obj/item/stack/tile/plasteel/attack_self(mob/user as mob)
 	if (usr.stat)

--- a/html/changelogs/9600bauds_HOLYSHITFUCKYOUGIT.yml
+++ b/html/changelogs/9600bauds_HOLYSHITFUCKYOUGIT.yml
@@ -1,0 +1,35 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general deleting of nice things)
+#   rscadd (general adding of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: 9600bauds
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+changes: 
+- bugfix: Fixed stackable items (metal rods, floortiles etc) only giving one item's worth of materials when recycled at an Autolathe, regardless of how many items there were in the stack. Also fixes metal rods and possibly more items having the same bug or not working at all in the Recycler. Given that this had been broken for over half a year with seemingly no reports, I'm obliged to say once again that if you notice anything weird with this fix, you should make an in-game bug report.


### PR DESCRIPTION
It's honestly rather concerning just how unfinished and (presumably) completely untested everything Comic-related that I've touched so far has BEEN.

This makes it so that /obj/item/stack update their materials to account for the amount of items in stack. I did not make the Autolathe use recycle() because then it could smelt ore.

~~There is one bug I haven't been able to fix: Roundstart material stacks don't update their material count when the game starts. That means that, until you do something that updates the 50 rod stacks from Engineering (like take one rod out and put it back), they will still only give one rod's worth of metal if recycled. I tried a spawn() in /obj/item/stack's New(), but that didn't work. Listening to suggestions.~~

Fixes #7099
