### PR TITLE
Tweak to boxing gloves

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -126,7 +126,7 @@ BLIND     // can't see anything
 	species_restricted = list("exclude","Unathi","Tajaran","Muton")
 	var/pickpocket = 0 //Master pickpocket?
 
-	var/bonus_knockout = 0 //Added to knockout chance. 5 or above is pretty much a 50% chance to weaken per hit
+	var/bonus_knockout = 0 //Knockout chance is multiplied by (1 + bonus_knockout) and is capped at 1/2. 0 = 1/12 chance, 1 = 1/6 chance, 2 = 1/4 chance, 3 = 1/3 chance, etc.
 	var/damage_added = 0 //Added to unarmed damage, doesn't affect knockout chance
 
 /obj/item/clothing/gloves/emp_act(severity)

--- a/code/modules/clothing/gloves/boxing.dm
+++ b/code/modules/clothing/gloves/boxing.dm
@@ -4,6 +4,10 @@
 	icon_state = "boxing"
 	item_state = "boxingred"
 	species_fit = list("Vox")
+	bonus_knockout = 1 //Increase knockout chance from 1/12 to 1/6
+
+/obj/item/clothing/gloves/boxing/dexterity_check()
+	return 0 //Wearing boxing gloves makes you less dexterious (so, for example, you can't use computers)
 
 /obj/item/clothing/gloves/boxing/green
 	icon_state = "boxinggreen"

--- a/html/changelogs/unid-boxboxbox.yml
+++ b/html/changelogs/unid-boxboxbox.yml
@@ -1,0 +1,7 @@
+author: Unid
+
+delete-after: True
+
+changes: 
+  - tweak: Boxing gloves now reduce dexterity, just like knuckledusters
+  - tweak: Boxing gloves now double the chance to stun your enemy in unarmed combat


### PR DESCRIPTION
Fixes #7622
- Wearing boxing gloves doubles the chance of stunning your enemy in unarmed combat (8% to 16%)
- Boxing gloves now make you less dexterous
