### PR TITLE
drop_stack() for hydroponics, crafting and biogenerator

### DIFF
--- a/code/game/machinery/biogenerator.dm
+++ b/code/game/machinery/biogenerator.dm
@@ -469,9 +469,8 @@
 	if(recipe.reagent)
 		beaker.reagents.add_reagent(recipe.reagent,recipe.amount_per_unit*num)
 	else
-		if(istype(recipe.result,/obj/item/stack))
-			var/obj/item/stack/stack=new recipe.result(src.loc)
-			stack.amount=num*recipe.amount_per_unit
+		if(ispath(recipe.result,/obj/item/stack))
+			drop_stack(recipe.result, src.loc, num*recipe.amount_per_unit, 1, null)
 		else
 			for(var/i=0;i<num;i++)
 				new recipe.result(src.loc)

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -150,15 +150,23 @@
 				return
 		if (src.amount < R.req_amount*multiplier)
 			return
-		var/atom/O = new R.result_type( usr.loc )
+
+		var/atom/O
+		if(ispath(R.result_type, /obj/item/stack))
+			O = drop_stack(R.result_type, usr.loc, (R.max_res_amount>1 ? R.res_amount*multiplier : 1), usr)
+		else
+			O = new R.result_type( usr.loc )
+
 		O.dir = usr.dir
 		if(R.start_unanchored)
 			var/obj/A = O
 			A.anchored = 0
-		if (R.max_res_amount>1)
-			var/obj/item/stack/new_item = O
-			new_item.amount = R.res_amount*multiplier
-			//new_item.add_to_stacks(usr)
+
+		//if (R.max_res_amount>1)
+		//	var/obj/item/stack/new_item = O
+		//	new_item.amount = R.res_amount*multiplier
+		//	//new_item.add_to_stacks(usr)
+
 		src.use(R.req_amount*multiplier)
 		if (src.amount<=0)
 			var/oldsrc = src
@@ -289,6 +297,8 @@
  add *amount items to them and return.
  If unable to add to any already existing stack, create a new instance of *new_stack_type
 
+ Returns stack
+
  */
 
 /proc/drop_stack(new_stack_type = /obj/item/stack, turf/loc, add_amount = 1, mob/user)
@@ -298,10 +308,11 @@
 				S.amount += add_amount
 
 				to_chat(user, "<span class='info'>You add [add_amount] item\s to the stack. It now contains [S.amount] [CORRECT_STACK_NAME(S)].</span>")
-				return 1
+				return S
 
 	var/obj/item/stack/S = getFromPool(new_stack_type, loc)
 	S.amount = add_amount
+	return S
 
 /*
  * Recipe datum

--- a/code/game/objects/items/weapons/table_rack_parts.dm
+++ b/code/game/objects/items/weapons/table_rack_parts.dm
@@ -61,10 +61,9 @@
 
 	if (istype(W, /obj/item/stack/tile/grass))
 		var/obj/item/stack/tile/grass/Grass = W
-		if(Grass.amount > 1)
-			Grass.amount -= 1
-		else
-			qdel(Grass)
+
+		if(!Grass.use(1)) return
+
 		new /obj/item/weapon/table_parts/wood/poker( get_turf(src) )
 		visible_message("<span class='notice'>[user] adds grass to the wooden table parts.</span>")
 		qdel(src)

--- a/code/modules/hydroponics/grown_inedible.dm
+++ b/code/modules/hydroponics/grown_inedible.dm
@@ -52,16 +52,10 @@
 
 /obj/item/weapon/grown/log/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(istype(W, /obj/item/weapon/circular_saw) || istype(W, /obj/item/weapon/hatchet) || (istype(W, /obj/item/weapon/fireaxe) && W:wielded) || istype(W, /obj/item/weapon/melee/energy))
-		user.show_message("<span class='notice'>You make planks out of \the [src]!</span>", 1)
-		for(var/i=0,i<2,i++)
-			var/obj/item/stack/sheet/wood/NG = new (user.loc)
-			for (var/obj/item/stack/sheet/wood/G in user.loc)
-				if(G==NG)
-					continue
-				if(G.amount>=G.max_amount)
-					continue
-				G.attackby(NG, user)
-			to_chat(user, "You add the newly-formed wood to the stack. It now contains [NG.amount] planks.")
+		user.show_message("<span class='notice'>You make two planks out of \the [src].</span>", MESSAGE_SEE)
+
+		drop_stack(/obj/item/stack/sheet/wood, get_turf(user), 2, user)
+
 		qdel(src)
 		return
 

--- a/code/modules/hydroponics/seed_datums.dm
+++ b/code/modules/hydroponics/seed_datums.dm
@@ -547,7 +547,13 @@ var/global/list/gene_tag_masks = list()   // Gene obfuscation for delicious tria
 		currently_querying = list()
 		for(var/i = 0;i<total_yield;i++)
 			var/product_type = pick(products)
-			var/obj/item/product = new product_type(get_turf(user))
+
+			var/obj/item/product
+
+			if(ispath(product_type, /obj/item/stack))
+				product = drop_stack(product_type, get_turf(user), 1, user)
+			else
+				product = new product_type(get_turf(user))
 
 			score["stuffharvested"] += 1 //One point per product unit
 

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -57,9 +57,10 @@
 /obj/item/weapon/ore/glass/attack_self(mob/living/user as mob) //It's magic I ain't gonna explain how instant conversion with no tool works. -- Urist
 	var/location = get_turf(user)
 	for(var/obj/item/weapon/ore/glass/sandToConvert in location)
-		new /obj/item/stack/sheet/mineral/sandstone(location)
+		drop_stack(/obj/item/stack/sheet/mineral/sandstone, location, 1, user)
 		qdel(sandToConvert)
-	new /obj/item/stack/sheet/mineral/sandstone(location)
+
+	drop_stack(/obj/item/stack/sheet/mineral/sandstone, location, 1, user)
 	qdel(src)
 
 /obj/item/weapon/ore/plasma

--- a/html/changelogs/unid_gudshit.yml
+++ b/html/changelogs/unid_gudshit.yml
@@ -1,0 +1,6 @@
+author: Unid
+
+delete-after: True
+
+changes: 
+  - tweak: Grass, planks, stacks produced from crafting or from the biogenerator will now automatically stack with each other (so harvesting from a tray with glass yields one stack with 5 grass tiles)


### PR DESCRIPTION
- Stacks created from woodcutting, hydroponics, crafting and the biogenerator now use drop_stack()
- What this means: harvesting from a tray with grass now yields one stack with 5 grass tiles, instead of 5 grass tiles. Planks created by cutting logs will now immediately stack together, and so will metal rods / floor tiles crafted by hand or in the biogenerator
- Tested
- Fixes #7626 
- Will conflict with #7620
