### PR TITLE
Fix the many instances where haunting updates improperly

### DIFF
--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -34,6 +34,8 @@
 				to_chat(usr, "<span class='warning'>These are sacred grounds, you cannot go there!</span>")
 			else
 				forceEnter(targetloc)
+				if(locked_to)
+					manual_stop_follow(locked_to)
 
 /mob/dead/observer/ClickOn(var/atom/A, var/params)
 	if(client.buildmode)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -472,6 +472,8 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			to_chat(usr, "No area available.")
 
 	usr.loc = pick(L)
+	if(locked_to)
+		manual_stop_follow(locked_to)
 
 /mob/dead/observer/verb/follow()
 	set category = "Ghost"
@@ -550,6 +552,8 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 			if(T && isturf(T))	//Make sure the turf exists, then move the source to that destination.
 				A.loc = T
+				if(locked_to)
+					manual_stop_follow(locked_to)
 			else
 				to_chat(A, "This mob is not located in the game world.")
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1133,8 +1133,8 @@ default behaviour is:
 				if(dense) break
 			if((tmob.a_intent == I_HELP || tmob.restrained()) && (a_intent == I_HELP || src.restrained()) && tmob.canmove && canmove && !dense && can_move_mob(tmob, 1, 0)) // mutual brohugs all around!
 				var/turf/oldloc = loc
-				loc = tmob.loc
-				tmob.loc = oldloc
+				forceMove(tmob.loc)
+				tmob.forceMove(oldloc)
 				now_pushing = 0
 				for(var/mob/living/carbon/slime/slime in view(1,tmob))
 					if(slime.Victim == tmob)


### PR DESCRIPTION
- You will now stop following haunt targets if you double-click on a tile (jump)
- You will now stop following haunt targets if you use Observer Teleport
- You will now stop following haunt targets if you use Observer Jump To
- Updated mob swapping code to work properly with atom locking code

For some reason Github decided that I rewrote the entire observer.dm file. Normally only four lines were changed for fix 2 and 3

Fixes #7540
