### PR TITLE
hotfix lighting runtime related to shuttle code

### DIFF
--- a/code/modules/lighting/light_source.dm
+++ b/code/modules/lighting/light_source.dm
@@ -271,7 +271,7 @@
 // Assumes the turf is visible and such.
 // For the love of god don't call this proc when it's not needed! Lighting artifacts WILL happen!
 /datum/light_source/proc/calc_turf(var/turf/T)
-	if(T.lighting_overlay)
+	if(T && T.lighting_overlay)
 		LUM_FALLOFF(., T, source_turf)
 		. *= light_power
 


### PR DESCRIPTION
```
runtime error: Cannot read null.x
proc name: calc turf (/datum/light_source/proc/calc_turf)
  source file: light_source.dm,275
  usr: Kiera Howe (/mob/living/carbon/human)
  src: /datum/light_source (/datum/light_source)
  call stack:
/datum/light_source (/datum/light_source): calc turf(the floor (161,66,5) (/turf/simulated/shuttle/floor))
the floor (161,66,5) (/turf/simulated/shuttle/floor): lighting build overlays()
the floor (161,66,5) (/turf/simulated/shuttle/floor): ChangeTurf(/turf/simulated/shuttle/floor (/turf/simulated/shuttle/floor), 1, 1, 1)
the floor (161,66,5) (/turf/simulated/shuttle/floor): ChangeTurf(/turf/simulated/shuttle/floor (/turf/simulated/shuttle/floor), 1, 0, 1)
mining shuttle (/datum/shuttle/mining): move area to(the floor (80,108,1) (/turf/simulated/shuttle/floor), space (162,68,5) (/turf/space), 0)
mining shuttle (/datum/shuttle/mining): move to dock(the docking port (/obj/structure/docking_port/destination/mining/outpost), 0)
mining shuttle (/datum/shuttle/mining): pre flight()
mining shuttle (/datum/shuttle/mining): travel to(the docking port (/obj/structure/docking_port/destination/mining/outpost), the mining shuttle console (/obj/machinery/computer/shuttle_control/mining), Kiera Howe (/mob/living/carbon/human))
```

checks if T is null before continuing

do I know why the changes to shuttle code caused this? NOPE
