### PR TITLE
Hotfix for recruiter runtiming on empty currently_querying

### DIFF
--- a/code/datums/recruiter.dm
+++ b/code/datums/recruiter.dm
@@ -56,6 +56,7 @@
 	spawn(recruitment_timeout)
 		if(!currently_querying || currently_querying.len==0)
 			INVOKE_EVENT(recruited, list("player"=null))
+			return
 
 		var/mob/dead/observer/O
 


### PR DESCRIPTION
I believe this was intended behavior, anyways. If someone wants to tell me why this is a bad idea I'll change it.
