### PR TITLE
Fix Cursed Dice Define Issue

### DIFF
--- a/code/modules/research/xenoarchaeology/finds/finds_defines.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds_defines.dm
@@ -123,7 +123,7 @@
 			return "carbon"
 		if(ARCHAEO_MASK)
 			return "mercury"
-		if(ARCHAEO_MASK)
+		if(ARCHAEO_DICE)
 			return "mercury"
 	return "plasma"
 


### PR DESCRIPTION
Previously this meant that cursed dice would show up as 'anomalous materials' when scanned because they weren't being defined properly.
