### PR TITLE
Fixes broken bottles being either totally harmless or incredibly powerful

### DIFF
--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -1052,7 +1052,7 @@
 	user.drop_item(force_drop = 1)
 	var/obj/item/weapon/broken_bottle/B = new /obj/item/weapon/broken_bottle(user.loc)
 	B.icon_state = src.icon_state
-	B.force = src.force
+	//B.force = src.force //Who the fuck thought this was a good idea? It makes broken bottles smashed by throwing deal no damage and broken bottles smashed over someone's head deal way too much.
 	B.name = src.smashname
 
 	if(istype(src, /obj/item/weapon/reagent_containers/food/drinks/drinkingglass))  //for drinking glasses


### PR DESCRIPTION
What happened to the line endings, anyway? Both files I've edited in the past couple days say every line is changed and refuse to let me discard the changes. I had to manually select only this line to commit.

Fixes #7707

All broken bottles now have force 9, which is much more reasonable than either 0 (thrown bottles) or 15 (bottles smashed over someone's head).
(Smashing a bottle over someone's head is still force 15, just the broken bottle left after you do so isn't.)
