### PR TITLE
Adds an adminverb to write map files.

### DIFF
--- a/code/__HELPERS/files.dm
+++ b/code/__HELPERS/files.dm
@@ -66,7 +66,7 @@
 	for(var/file in args)
 		src << browse_rsc(file)
 
-/client/proc/browse_files(root="data/logs/", max_iterations=10, list/valid_extensions=list(".txt",".log",".htm", ".csv"))
+/client/proc/browse_files(root="data/logs/", max_iterations=10, list/valid_extensions=list(".txt",".log",".htm", ".csv", ".dmm"))
 	var/path = root
 
 	for(var/i=0, i<max_iterations, i++)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -144,6 +144,7 @@ var/list/admin_verbs_server = list(
 	/client/proc/toggle_random_events,
 	/client/proc/check_customitem_activity,
 	/client/proc/dump_chemreactions,
+	/client/proc/save_coordinates
 	)
 var/list/admin_verbs_debug = list(
 	/client/proc/gc_dump_hdl,

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -974,8 +974,47 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		config.allow_random_events = 1
 		to_chat(usr, "Random events enabled")
 		message_admins("Admin [key_name_admin(usr)] has enabled random events.", 1)
+
 	else
 		config.allow_random_events = 0
 		to_chat(usr, "Random events disabled")
 		message_admins("Admin [key_name_admin(usr)] has disabled random events.", 1)
+
 	feedback_add_details("admin_verb","TRE") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
+/client/proc/save_coordinates(var/x1 as num, var/y1 as num, var/z1 as num, var/x2 as num, var/y2 as num, var/z2 as num, var/mapname as text)
+	set name     = "Save map by coordinates"
+	set category = "Fun"
+	set desc     = "(x1, y1, z1, x2, y2, z2, mapname) Saves the map beetween (x1, y1, z1) and (x2, y2, z2), and it will be sent to your client, it will also be stored in data/logs/saved_maps."
+
+	if(!check_rights(R_SERVER))
+		return
+
+	if(!(x1 && x2 && y1 && y2 && z1 && z2))
+		usr << "Not all coordinates supplied."
+		return
+
+	if(ckeyEx(mapname) != mapname || !mapname)
+		usr << "Map name contains invalid characters or is empty."
+		return
+
+	var/confirm = alert("Are you sure you want to save the map between coordinates ([x1], [y1], [z1]) and ([x2], [y2], [z2])? This can cause quite a bit of lag!", "Save map", "Yes, do it!", "No")
+	if(confirm == "No")
+		return
+
+	var/dmm_suite/DMM = new
+
+	var/turf/T1 = locate(x1, y1, z1)
+	var/turf/T2 = locate(x2, y2, z2)
+
+	var/output = DMM.write_map(T1, T2, DMM_IGNORE_MOBS)
+
+	if(fexists("data/logs/saved_maps/[mapname].dmm"))
+		fdel("data/logs/saved_maps/[mapname].dmm")
+
+	var/F = file("data/logs/saved_maps/[mapname].dmm")
+	F   << output
+	usr << ftp(F)
+
+	feedback_add_details("admin_verb", "SCO") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+

--- a/code/modules/awaymissions/maploader/writer.dm
+++ b/code/modules/awaymissions/maploader/writer.dm
@@ -1,9 +1,3 @@
-#define DMM_IGNORE_AREAS 1
-#define DMM_IGNORE_TURFS 2
-#define DMM_IGNORE_OBJS 4
-#define DMM_IGNORE_NPCS 8
-#define DMM_IGNORE_PLAYERS 16
-#define DMM_IGNORE_MOBS 24
 /dmm_suite
 	var/quote = "\""
 	var/list/letter_digits = list(
@@ -22,8 +16,10 @@
 	)
 	var/list/blacklist = list(
 			/atom/movable/lighting_overlay,
-			/obj/effect/beam,
-			/obj/item/projectile
+			/obj/effect,
+			/obj/item/projectile,
+			/mob/dview,
+			/mob/virtualhearer
 	)
 /dmm_suite/save_map(var/turf/t1 as turf, var/turf/t2 as turf, var/map_name as text, var/flags as num)
 	//Check for illegal characters in file name... in a cheap way.
@@ -168,7 +164,7 @@
 			attributes_text += "[V] = [A.vars[V]]"
 
 		else if(isicon(A.vars[V]) || isfile(A.vars[V]))
-			if(!fexists(A.vars[V]))	//The file doesn't actually exist and would cause DM to be unable to read the map.
+			if(!fexists(A.vars[V]))	//The file doesn't actually exist and would cause DM to be unable to read the map (this can happen by admin-uploaded files and icon datums created at runtime).
 				continue
 
 			attributes_text += "[V] = '[A.vars[V]]'"

--- a/code/setup.dm
+++ b/code/setup.dm
@@ -1464,3 +1464,11 @@ var/proccalls = 1
 #define NORMAL_ATTACK 0
 #define ATTACK_BITE 1
 #define ATTACK_KICK 2
+
+// Defines for the map writer, moved here for reasons.
+#define DMM_IGNORE_AREAS 1
+#define DMM_IGNORE_TURFS 2
+#define DMM_IGNORE_OBJS 4
+#define DMM_IGNORE_NPCS 8
+#define DMM_IGNORE_PLAYERS 16
+#define DMM_IGNORE_MOBS 24


### PR DESCRIPTION
Map files are stored in `data/logs/saved_maps`, as such they can be retried with `.getserverlog`, however the admin that started a write will also get the file sent to him with the `ftp()` proc.

**Note:** map files exported still need a _lot_ of cleaning afterwards (literally every turf has redundant variables that might even break things written to them).
