### PR TITLE
Inventory-within-inventory won't close on move if you are holding the storage item.

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -655,7 +655,7 @@ Thanks.
 		stop_pulling()
 		. = ..()
 
-	if ((s_active && !( s_active in contents ) ))
+	if ((s_active && ( find_holder(s_active) != src ) ))
 		s_active.close(src)
 
 	if(update_slimes)

--- a/html/changelogs/9600bauds_thewizard.yml
+++ b/html/changelogs/9600bauds_thewizard.yml
@@ -1,0 +1,35 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general deleting of nice things)
+#   rscadd (general adding of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: 9600bauds
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+changes: 
+- bugfix: Fixed nested storage items (e.g. a box inside a backpack) closing their inventory when you move, even if you were holding the parent storage item.


### PR DESCRIPTION
Fixes #7702
it baffles me that this was checking contents rather than the item's loc, I think this might actually be faster

```
[20:53] <Clusterfack> find_holder is likely faster than
[20:53] <Clusterfack> an in contents loop
[20:53] <bauds> excellent
[20:53] <Clusterfack> so don't worry about it
```
