### PR TITLE
Makes onedir conveyor switches actually onedir

### DIFF
--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -301,7 +301,11 @@
 
 	anchored = 1
 
-/obj/machinery/conveyor_switch/oneway  // Kept in for mapping legacy because I am too lazy to actually fix the maps.
+/obj/machinery/conveyor_switch/oneway //Use these instances for mapping
+	convdir = 1
+
+/obj/machinery/conveyor_switch/oneway/reverse
+	convdir = -1
 
 /obj/machinery/conveyor_switch/receive_signal(datum/signal/signal)
 	if(!signal || signal.encryption) return


### PR DESCRIPTION
Fixes #6923
Fixes #7777, both Meta and Box
Does NOT fix  #7747, that lever still needs to be /onedir

This seemed like a good idea at the time for reasons I can't recall anymore
