### PR TITLE
Makes rotate chair less ass

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -52,7 +52,7 @@
 
 /obj/structure/bed/chair/verb/rotate()
 	set name = "Rotate Chair"
-	set category = "Object"
+	set category = null //So it's only accessible from the right click menu
 	set src in oview(1)
 
 	if(!usr || !isturf(usr.loc))

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -211,6 +211,8 @@ var/global/obj/screen/fuckstat/FUCK = new
 	if(flags & HEAR_ALWAYS)
 		getFromPool(/mob/virtualhearer, src)
 
+	src.on_moved.Add(src, "update_verbs_onmove")
+
 /mob/proc/is_muzzled()
 	return 0
 
@@ -1286,6 +1288,38 @@ var/list/slot_equipment_priority = list( \
 		if(istype(src, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = M
 			H.handle_regular_hud_updates()
+
+/mob/verb/rotate_chair() //To allow for actually sensible chair selection.
+	set name = "Rotate Chair"
+	set popup_menu = 0 //You know, I'm not actually sure if this is necessary for mob verbs with src = usr but better safe than sorry
+	set category = "Object" //Takes the place of the chair's rotate chair verb in the verbs panel
+	if(src.locked_to)
+		if(istype(src.locked_to, /obj/structure/bed/chair)) //If you're buckled to a chair, rotate that one
+			var/obj/structure/bed/chair/C = src.locked_to
+			C.rotate()
+			return
+	for(var/obj/structure/bed/chair/C in get_turf(src)) //Rotate the first chair found on your tile, if there is one
+		C.rotate()
+		return
+	for(var/checkdir in list(NORTH, SOUTH, EAST, WEST, NORTHEAST, NORTHWEST, SOUTHEAST, SOUTHWEST)) //Arbitrary, really. May change this order later or even scrap a hardcoded order for something a bit smarter.
+		var/turf/checkturf = get_step(src, checkdir)
+		for(var/obj/structure/bed/chair/C in checkturf)
+			C.rotate()
+			return
+
+/mob/proc/update_verbs_onmove() //Should probably be given more functionality later (mob verbs are faster than object verbs and all that jazz) but right now I'm writing this for one god damn feature
+	//Update rotate_chair
+	if(client) //This check could be a bit slow, but since only playermobs can actually rotate chairs there's no need to perform it for all mobs.
+		chair_check: //BREAKING NEWS: BYOND has shit label syntax. I would just make it return except that would obviously break things badly if someone put something after this in this proc.
+			for(var/checkdir in list(NORTH, SOUTH, EAST, WEST, NORTHEAST, NORTHWEST, SOUTHEAST, SOUTHWEST)) //Still arbitrary.
+				var/turf/checkturf = get_step(src, checkdir)
+				for(var/obj/structure/bed/chair/C in checkturf)
+					verbs |= /mob/verb/rotate_chair
+					break chair_check
+			for(var/obj/structure/bed/chair/C in get_turf(src))
+				verbs |= /mob/verb/rotate_chair
+				break chair_check
+			verbs -= /mob/verb/rotate_chair
 
 /mob/Topic(href,href_list[])
 	if(href_list["mach_close"])


### PR DESCRIPTION
This pretty much just makes the rotate chair verb less awful and unpredictable at choosing which chair to rotate when there are multiple chairs adjacent to you. Other than looking at tiles for chairs in a predictable order, there is one change to the verb visible in-game: If there are chairs around you with different names, rotate chair will now just pick one to rotate like it would if all the adjacent chairs had the same name. This means that you no longer have to worry about accidentally opening a fuckload of windows if you try to rapidly spin a chair when there's another one with a different name nearby. I _could_ change this back but I think it's better this way.

When used from the right click menu, it behaves exactly like it did before.

This is a pretty hacky fix, to be honest, but there's not a better way to do it within BYOND's verbs system, at least that I could think of. There are now actually two different rotate chair verbs. One is exactly what it was before except it doesn't show up in the verbs panel. This is what you access by right clicking and what the other one calls. The other is a mob verb that does show up in the Object panel but not in the right-click menu. This one handles the selection of a chair to rotate.

It rotates the first chair it finds, searching in this order:
1. A chair you are buckled to
2. Any chair on your tile
3. Any chair on the tile to your north
4. Any chair on the tile to your south
5. Any chair on the tile to your east
6. Any chair on the tile to your west
7. Any chair on the tile to your northeast
8. Any chair on the tile to your northwest
9. Any chair on the tile to your southeast
10. Any chair on the tile to your southwest

The order of the directional search is arbitrary and can be easily changed. It's just what I thought would be a good order, but if anyone else has a suggestion, go ahead. It could also be made to do the directional search in a smarter way than a hardcoded order if anyone has any suggestions.

Fixes #7662
