### PR TITLE
Fixes and tweaks to surgery

### DIFF
--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -180,5 +180,5 @@
 			returnToPool(W)
 			return
 	if(isrobot(user)) return
-	user.drop_item(W, src.loc)
+	//user.drop_item(W, src.loc) why?
 	return

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -114,6 +114,8 @@
 
 /obj/item/weapon/screwdriver/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
 	if(!istype(M))	return ..()
+	if(can_operate(M))
+		return ..()
 	if(user.zone_sel.selecting != "eyes" && user.zone_sel.selecting != "head")
 		return ..()
 	if((M_CLUMSY in user.mutations) && prob(50))

--- a/code/modules/surgery/bones.dm
+++ b/code/modules/surgery/bones.dm
@@ -20,6 +20,13 @@
 	var/datum/organ/external/affected = target.get_organ(target_zone)
 	return (affected.open >= 2 || (target.species.flags & NO_SKIN)) && affected.stage == 0
 
+/datum/surgery_step/glue_bone/can_operate(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	var/datum/organ/external/affected = target.get_organ(target_zone)
+	if(affected.brute_dam >= affected.min_broken_damage * config.organ_health_multiplier)
+		to_chat(user, "<span class='warning'>The [affected.display_name] is far too damaged to operate on the fracture. Fix some of the damage first.</span>")
+		return 0
+	return ..()
+
 /datum/surgery_step/glue_bone/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/datum/organ/external/affected = target.get_organ(target_zone)
 	if (affected.stage == 0)
@@ -54,6 +61,13 @@
 /datum/surgery_step/set_bone/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/datum/organ/external/affected = target.get_organ(target_zone)
 	return affected.name != "head" && (affected.open >= 2 || (target.species.flags & NO_SKIN)) && affected.stage == 1
+
+/datum/surgery_step/set_bone/can_operate(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	var/datum/organ/external/affected = target.get_organ(target_zone)
+	if(affected.brute_dam >= affected.min_broken_damage * config.organ_health_multiplier)
+		to_chat(user, "<span class='warning'>The [affected.display_name] is far too damaged to operate on the fracture. Fix some of the damage first.</span>")
+		return 0
+	return ..()
 
 /datum/surgery_step/set_bone/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/datum/organ/external/affected = target.get_organ(target_zone)
@@ -95,6 +109,13 @@
 	var/datum/organ/external/affected = target.get_organ(target_zone)
 	return affected.name == "head" && (affected.open >= 2 || (target.species.flags & NO_SKIN))&& affected.stage == 1
 
+/datum/surgery_step/mend_skull/can_operate(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	var/datum/organ/external/affected = target.get_organ(target_zone)
+	if(affected.brute_dam >= affected.min_broken_damage * config.organ_health_multiplier)
+		to_chat(user, "<span class='warning'>The [affected.display_name] is far too damaged to operate on the fracture. Fix some of the damage first.</span>")
+		return 0
+	return ..()
+
 /datum/surgery_step/mend_skull/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	user.visible_message("[user] is beginning piece together [target]'s skull with \the [tool]."  , \
 		"You are beginning piece together [target]'s skull with \the [tool].")
@@ -133,6 +154,13 @@
 	var/datum/organ/external/affected = target.get_organ(target_zone)
 	return (affected.open >= 2 || (target.species.flags & NO_SKIN)) && affected.stage == 2
 
+/datum/surgery_step/finish_bone/can_operate(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	var/datum/organ/external/affected = target.get_organ(target_zone)
+	if(affected.brute_dam >= affected.min_broken_damage * config.organ_health_multiplier)
+		to_chat(user, "<span class='warning'>The [affected.display_name] is far too damaged to operate on the fracture. Fix some of the damage first.</span>")
+		return 0
+	return ..()
+
 /datum/surgery_step/finish_bone/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/datum/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] starts to finish mending the damaged bones in [target]'s [affected.display_name] with \the [tool].", \
@@ -147,6 +175,11 @@
 	affected.status &= ~ORGAN_SPLINTED
 	affected.stage = 0
 	affected.perma_injury = 0
+	/*
+	if(target.stat != DEAD && affected.brute_dam >= affected.min_broken_damage * config.organ_health_multiplier)
+		affected.heal_damage(affected.brute_dam - (affected.min_broken_damage - rand(3,5)) * config.organ_health_multiplier) //Put the limb's brute damage just under the bone breaking threshold, to prevent it from instabreaking again.
+		//This was actually bad because it would either not work on dead people, or allow people that died from >200 brute damage to be defibbed.
+	*/
 
 /datum/surgery_step/finish_bone/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/datum/organ/external/affected = target.get_organ(target_zone)

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -55,6 +55,10 @@
 /datum/surgery_step/proc/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	return 0
 
+	// once a surgery is selected, let's check if we can actually accomplish it
+/datum/surgery_step/proc/can_operate(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	return 1
+
 	// does stuff to begin the step, usually just printing messages. Moved germs transfering and bloodying here too
 /datum/surgery_step/proc/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/datum/organ/external/affected = target.get_organ(target_zone)
@@ -110,6 +114,8 @@ proc/do_surgery(mob/living/M, mob/living/user, obj/item/tool)
 			var/canuse = S.can_use(user, M, user.zone_sel.selecting, tool)
 			if(canuse == -1) sleep_fail = 1
 			if(canuse && S.is_valid_mutantrace(M) && !(M in S.doing_surgery))
+				if(!S.can_operate(user, M, user.zone_sel.selecting, tool)) //ruh oh, we picked this step, but we can't actually do it for some special raisin
+					return 1
 				M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has had surgery [S.type] with \the [tool] started by [user.name] ([user.ckey])</font>")
 				user.attack_log += text("\[[time_stamp()]\] <font color='red'>Started surgery [S.type] with \the [tool] on [M.name] ([M.ckey])</font>")
 				log_attack("<font color='red'>[user.name] ([user.ckey]) used \the [tool] to perform surgery type [S.type] on [M.name] ([M.ckey])</font>")

--- a/html/changelogs/9600bauds_assblast.yml
+++ b/html/changelogs/9600bauds_assblast.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general deleting of nice things)
+#   rscadd (general adding of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: 9600bauds
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+changes: 
+- bugfix: Fixed not being able to use screwdrivers as ghetto surgery tools.
+- tweak: Added an error message when trying to use surgery to fix a bone fracture in a very damaged limb. This is to prevent the \"bone explodes immediately after being mended\" syndrome.
+- tweak: Will no longer place items on operating tables, which was really annoying because it would end up in accidentally dropping your surgery tools under the patient. If you really want to place an item on top of the operating table for some reason, you can throw it on top instead.


### PR DESCRIPTION
Fixed not being able to use screwdrivers as ghetto surgery tools. (fixes #7612)
Added an error message when trying to use surgery to fix a bone fracture in a very damaged limb. This is to prevent the "bone explodes immediately after being mended" syndrome. (fixes #7615)
Will no longer place items on operating tables, which was really annoying because it would end up in accidentally dropping your surgery tools under the patient. If you really want to place an item on top of the operating table for some reason, you can throw it on top instead.
