### PR TITLE
Removes the autofix messages.

### DIFF
--- a/code/ATMOSPHERICS/hvac/chiller.dm
+++ b/code/ATMOSPHERICS/hvac/chiller.dm
@@ -34,8 +34,6 @@
 			dat += "<A href='byond://?src=\ref[src];op=cellinstall'>Removed</A><BR>"
 
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\ATMOSPHERICS\chiller.dm:95: dat += "Power Level: [cell ? round(cell.percent(),1) : 0]%<BR><BR>"
 		dat += {"Power Level: [cell ? round(cell.percent(),1) : 0]%<BR><BR>
 			Set Temperature:
 			<A href='?src=\ref[src];op=temp;val=-5'>-</A>
@@ -43,7 +41,6 @@
 			[temp]&deg;C
 			<A href='?src=\ref[src];op=temp;val=1'>+</A>
 			<A href='?src=\ref[src];op=temp;val=5'>+</A><BR>"}
-		// END AUTOFIX
 		user.set_machine(src)
 		user << browse("<HEAD><TITLE>Air Conditioner Control Panel</TITLE></HEAD><TT>[dat]</TT>", "window=aircond")
 		onclose(user, "aircond")

--- a/code/ATMOSPHERICS/hvac/spaceheater.dm
+++ b/code/ATMOSPHERICS/hvac/spaceheater.dm
@@ -194,14 +194,11 @@
 			dat += "<A href='byond://?src=\ref[src];op=cellinstall'>Removed</A><BR>"
 
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\spaceheater.dm:99: dat += "Power Level: [cell ? round(cell.percent(),1) : 0]%<BR><BR>"
 		dat += {"Power Level: [cell ? round(cell.percent(),1) : 0]%<BR><BR>
 			Set Temperature:
 			<A href='?src=\ref[src];op=temp;val=-5'>-</A>
 			[set_temperature]&deg;C
 			<A href='?src=\ref[src];op=temp;val=5'>+</A><BR>"}
-		// END AUTOFIX
 		user.set_machine(src)
 		user << browse("<HEAD><TITLE>Space Heater Control Panel</TITLE></HEAD><TT>[dat]</TT>", "window=spaceheater")
 		onclose(user, "spaceheater")

--- a/code/WorkInProgress/Cael_Aislinn/Rust/fuel_compressor.dm
+++ b/code/WorkInProgress/Cael_Aislinn/Rust/fuel_compressor.dm
@@ -37,30 +37,21 @@ var/const/max_assembly_amount = 300
 			return
 
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\WorkInProgress\Cael_Aislinn\Rust\fuel_compressor.dm:39: var/t = "<B>Reactor Fuel Rod Compressor / Assembler</B><BR>"
 	var/t = {"<B>Reactor Fuel Rod Compressor / Assembler</B><BR>
 <A href='?src=\ref[src];close=1'>Close</A><BR>"}
-	// END AUTOFIX
 	if(locked)
 		t += "Swipe your ID to unlock this console."
 	else
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\WorkInProgress\Cael_Aislinn\Rust\fuel_compressor.dm:44: t += "Compressed matter in storage: [compressed_matter] <A href='?src=\ref[src];eject_matter=1'>\[Eject all\]</a><br>"
 		t += {"Compressed matter in storage: [compressed_matter] <A href='?src=\ref[src];eject_matter=1'>\[Eject all\]</a><br>
 			<A href='?src=\ref[src];activate=1'><b>Activate Fuel Synthesis</b></A><BR> (fuel assemblies require no more than [max_assembly_amount] rods).<br>
 			<hr>
 			- New fuel assembly constituents:- <br>"}
-		// END AUTOFIX
 		for(var/reagent in new_assembly_quantities)
 			t += "	[reagent] rods: [new_assembly_quantities[reagent]] \[<A href='?src=\ref[src];change_reagent=[reagent]'>Modify</A>\]<br>"
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\WorkInProgress\Cael_Aislinn\Rust\fuel_compressor.dm:50: t += "<hr>"
 	t += {"<hr>
 		<A href='?src=\ref[src];close=1'>Close</A><BR>"}
-	// END AUTOFIX
 	user << browse(t, "window=fuelcomp;size=500x300")
 	user.set_machine(src)
 

--- a/code/WorkInProgress/Cael_Aislinn/Rust/fuel_control.dm
+++ b/code/WorkInProgress/Cael_Aislinn/Rust/fuel_control.dm
@@ -65,7 +65,6 @@
 	/*dat += "<b>Fuel depletion announcement:</b> "
 
 	// NOT-AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\WorkInProgress\Cael_Aislinn\Rust\fuel_control.dm:66: dat += "[announce_fueldepletion == 0 ? 	"Disabled"		: "<a href='?src=\ref[src];announce_fueldepletion=0'>\[Disable\]</a>"] "
 	dat += {"[announce_fueldepletion == 0 ? 	"Disabled"		: "<a href='?src=\ref[src];announce_fueldepletion=0'>\[Disable\]</a>"]
 		[announce_fueldepletion == 1 ? 	"Announcing"	: "<a href='?src=\ref[src];announce_fueldepletion=1'>\[Announce\]</a>"]
 		[announce_fueldepletion == 2 ? 	"Broadcasting"	: "<a href='?src=\ref[src];announce_fueldepletion=2'>\[Broadcast\]</a>"]<br>
@@ -87,14 +86,10 @@
 		<td></td>
 		<td></td>
 		</tr>"}
-	// END AUTOFIX
 	for(var/obj/machinery/power/rust_fuel_injector/I in connected_injectors)
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\WorkInProgress\Cael_Aislinn\Rust\fuel_control.dm:89: dat += "<tr>"
 		dat += {"<tr>
 			<td>[I.id_tag]</td>"}
-		// END AUTOFIX
 		if(I.cur_assembly)
 			dat += "<td><a href='?src=\ref[I];toggle_injecting=1;update_extern=\ref[src]'>\[[I.injecting ? "Halt injecting" : "Begin injecting"]\]</a></td>"
 		else
@@ -113,19 +108,13 @@
 		else
 			dat += "<td>None <a href='?src=\ref[src];set_next_stage=[I.id_tag]'>\[modify\]</a></td>"
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\WorkInProgress\Cael_Aislinn\Rust\fuel_control.dm:108: dat += "<td><a href='?src=\ref[src];toggle_stage=[I.id_tag]'>\[[active_stages.Find(I.id_tag) ? "Deactivate stage" : "Activate stage "] \]</a></td>"
 		dat += {"<td><a href='?src=\ref[src];toggle_stage=[I.id_tag]'>\[[active_stages.Find(I.id_tag) ? "Deactivate stage" : "Activate stage "] \]</a></td>
 			</tr>"}
-		// END AUTOFIX
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\WorkInProgress\Cael_Aislinn\Rust\fuel_control.dm:110: dat += "</table>"
 	dat += {"</table>
 		<hr>
 		<A href='?src=\ref[src];refresh=1'>Refresh</A>
 		<A href='?src=\ref[src];close=1'>Close</A><BR>"}
-	// END AUTOFIX
 	user << browse(dat, "window=fuel_control;size=800x400")
 	user.set_machine(src)
 

--- a/code/WorkInProgress/Cael_Aislinn/Rust/fuel_injector.dm
+++ b/code/WorkInProgress/Cael_Aislinn/Rust/fuel_injector.dm
@@ -104,15 +104,12 @@
 		dat += "<i>The console is dark and nonresponsive.</i>"
 	else
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\WorkInProgress\Cael_Aislinn\Rust\fuel_injector.dm:149: dat += "<B>Reactor Core Fuel Injector</B><hr>"
 		dat += {"<B>Reactor Core Fuel Injector</B><hr>
 			<b>Device ID tag:</b> [id_tag] <a href='?src=\ref[src];modify_tag=1'>\[Modify\]</a><br>
 			<b>Status:</b> [injecting ? "<font color=green>Active</font> <a href='?src=\ref[src];toggle_injecting=1'>\[Disable\]</a>" : "<font color=blue>Standby</font> <a href='?src=\ref[src];toggle_injecting=1'>\[Enable\]</a>"]<br>
 			<b>Fuel usage:</b> [fuel_usage*100]% <a href='?src=\ref[src];fuel_usage=1'>\[Modify\]</a><br>
 			<b>Fuel assembly port:</b>
 			<a href='?src=\ref[src];fuel_assembly=1'>\[[cur_assembly ? "Eject assembly to port" : "Draw assembly from port"]\]</a> "}
-		// END AUTOFIX
 		if(cur_assembly)
 			dat += "<a href='?src=\ref[src];emergency_fuel_assembly=1'>\[Emergency eject\]</a><br>"
 		else
@@ -123,14 +120,11 @@
 		else if(cached_power_avail < active_power_usage * 2)
 			font_colour = "orange"
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\WorkInProgress\Cael_Aislinn\Rust\fuel_injector.dm:164: dat += "<b>Power status:</b> <font color=[font_colour]>[active_power_usage]/[cached_power_avail] W</font><br>"
 		dat += {"<b>Power status:</b> <font color=[font_colour]>[active_power_usage]/[cached_power_avail] W</font><br>
 			<a href='?src=\ref[src];toggle_remote=1'>\[[remote_access_enabled ? "Disable remote access" : "Enable remote access"]\]</a><br>
 			<hr>
 			<A href='?src=\ref[src];refresh=1'>Refresh</A>
 			<A href='?src=\ref[src];close=1'>Close</A><BR>"}
-		// END AUTOFIX
 	user << browse(dat, "window=fuel_injector;size=500x300")
 	onclose(user, "fuel_injector")
 	user.set_machine(src)

--- a/code/WorkInProgress/Cael_Aislinn/ShieldGen/shield_capacitor.dm
+++ b/code/WorkInProgress/Cael_Aislinn/ShieldGen/shield_capacitor.dm
@@ -97,8 +97,6 @@
 	if(locked)
 		t += "<i>Swipe your ID card to begin.</i>"
 	else
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\WorkInProgress\Cael_Aislinn\ShieldGen\shield_capacitor.dm:94: t += "This capacitor is: [active ? "<font color=green>Online</font>" : "<font color=red>Offline</font>" ] <a href='?src=\ref[src];toggle=1'>[active ? "\[Deactivate\]" : "\[Activate\]"]</a><br>"
 		t += {"This capacitor is: [active ? "<font color=green>Online</font>" : "<font color=red>Offline</font>" ] <a href='?src=\ref[src];toggle=1'>[active ? "\[Deactivate\]" : "\[Activate\]"]</a><br>
 			[time_since_fail > 2 ? "<font color=green>Charging stable.</font>" : "<font color=red>Warning, low charge!</font>"]<br>
 			Charge: [stored_charge] Watts ([100 * stored_charge/max_charge]%)<br>
@@ -110,12 +108,9 @@
 		<a href='?src=\ref[src];charge_rate=1000'>\[++\]</a>
 		<a href='?src=\ref[src];charge_rate=[max_charge_rate]'>\[max\]</a><br>"}
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\WorkInProgress\Cael_Aislinn\ShieldGen\shield_capacitor.dm:104: t += "<hr>"
 	t += {"<hr>
 		<A href='?src=\ref[src]'>Refresh</A>
 		<A href='?src=\ref[src];close=1'>Close</A><BR>"}
-	// END AUTOFIX
 	user << browse(t, "window=shield_capacitor;size=500x800")
 	user.set_machine(src)
 

--- a/code/WorkInProgress/Cael_Aislinn/ShieldGen/shield_gen.dm
+++ b/code/WorkInProgress/Cael_Aislinn/ShieldGen/shield_gen.dm
@@ -111,8 +111,6 @@
 		t += "<i>Swipe your ID card to begin.</i>"
 	else
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\WorkInProgress\Cael_Aislinn\ShieldGen\shield_gen.dm:102: t += "[owned_capacitor ? "<font color=green>Charge capacitor connected.</font>" : "<font color=red>Unable to locate charge capacitor!</font>"]<br>"
 		t += {"[owned_capacitor ? "<font color=green>Charge capacitor connected.</font>" : "<font color=red>Unable to locate charge capacitor!</font>"]<br>
 			This generator is: [active ? "<font color=green>Online</font>" : "<font color=red>Offline</font>" ] <a href='?src=\ref[src];toggle=1'>[active ? "\[Deactivate\]" : "\[Activate\]"]</a><br>
 			[time_since_fail > 2 ? "<font color=green>Field is stable.</font>" : "<font color=red>Warning, field is unstable!</font>"]<br>
@@ -140,12 +138,9 @@
 		<a href='?src=\ref[src];max_field_strength=100'>\[max\]</a><br>"}
 		// END NOT-AUTOFIX
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\WorkInProgress\Cael_Aislinn\ShieldGen\shield_gen.dm:127: t += "<hr>"
 	t += {"<hr>
 		<A href='?src=\ref[src]'>Refresh</A>
 		<A href='?src=\ref[src];close=1'>Close</A><BR>"}
-	// END AUTOFIX
 	user << browse(t, "window=shield_generator;size=500x800")
 	user.set_machine(src)
 

--- a/code/ZAS/NewSettings.dm
+++ b/code/ZAS/NewSettings.dm
@@ -391,11 +391,8 @@ a { color: white; }
 	for(var/id in src.settings)
 		var/datum/ZAS_Setting/s = src.settings[id]
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\ZAS\NewSettings.dm:393: dat += "<dt><b>[s.name]</b> = <i>[s.value]</i> <A href='?src=\ref[src];changevar=[id]'>\[Change\]</A></dt>"
 		dat += {"<dt><b>[s.name]</b> = <i>[s.value]</i> <A href='?src=\ref[src];changevar=[id]'>\[Change\]</A></dt>
 			<dd>[s.desc]</i></dd>"}
-		// END AUTOFIX
 	dat += "</dl></body></html>"
 	user << browse(dat,"window=settings")
 

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -177,11 +177,8 @@
 			</script> "}
 
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\\datums\\datumvars.dm:162: body += "<body onload='selectTextField(); updateSearch()' onkeyup='updateSearch()'>"
 	body += {"<body onload='selectTextField(); updateSearch()' onkeyup='updateSearch()'>
 		<div align='center'><table width='100%'><tr><td width='50%'>"}
-	// END AUTOFIX
 	if(sprite)
 		body += "<table align='center' width='100%'><tr><td><img src='view_vars_sprite.png'></td><td>"
 	else
@@ -217,11 +214,8 @@
 		body += "<b>[D]</b>"
 
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\\datums\\datumvars.dm:200: body += "</div>"
 	body += {"</div>
 		</tr></td></table>"}
-	// END AUTOFIX
 	var/formatted_type = text("[D.type]")
 	if(length(formatted_type) > 25)
 		var/middle_point = length(formatted_type) / 2
@@ -237,12 +231,9 @@
 		body += "<br><font size='1' color='red'><b>Marked Object</b></font>"
 
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\\datums\\datumvars.dm:218: body += "</div>"
 	body += {"</div>
 		</div></td>
 		<td width='50%'><div align='center'><a href='?_src_=vars;datumrefresh=\ref[D]'>Refresh</a>"}
-	// END AUTOFIX
 	//if(ismob(D))
 	//	body += "<br><a href='?_src_=vars;mob_player_panel=\ref[D]'>Show player panel</a></div></td></tr></table></div><hr>"
 
@@ -275,8 +266,6 @@
 
 	if(ismob(D))
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\\datums\\datumvars.dm:247: body += "<option value='?_src_=vars;give_spell=\ref[D]'>Give Spell</option>"
 		body += {"<option value='?_src_=vars;give_spell=\ref[D]'>Give Spell</option>
 			<option value='?_src_=vars;give_disease=\ref[D]'>Give Disease</option>
 			<option value='?_src_=vars;godmode=\ref[D]'>Toggle Godmode</option>
@@ -287,11 +276,8 @@
 			<option value='?_src_=vars;regenerateicons=\ref[D]'>Regenerate Icons</option>
 			<option value='?_src_=vars;addlanguage=\ref[D]'>Add Language</option>
 			<option value='?_src_=vars;remlanguage=\ref[D]'>Remove Language</option>"}
-		// END AUTOFIX
 		if(ishuman(D))
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\\datums\\datumvars.dm:262: body += "<option value>---</option>"
 			body += {"<option value>---</option>
 				<option value='?_src_=vars;setmutantrace=\ref[D]'>Set Mutantrace</option>
 				<option value='?_src_=vars;setspecies=\ref[D]'>Set Species</option>
@@ -301,27 +287,18 @@
 				<option value='?_src_=vars;makealien=\ref[D]'>Make alien</option>
 				<option value='?_src_=vars;makeslime=\ref[D]'>Make slime</option>
 				<option value='?_src_=vars;makecluwne=\ref[D]'>Make cluwne</option>"}
-		// END AUTOFIX
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\\datums\\datumvars.dm:270: body += "<option value>---</option>"
 		body += {"<option value>---</option>
 			<option value='?_src_=vars;gib=\ref[D]'>Gib</option>"}
-		// END AUTOFIX
 	if(istype(D,/atom))
 		body += "<option value='?_src_=vars;delete=\ref[D]'>Delete</option>"
 	if(isobj(D))
 		body += "<option value='?_src_=vars;delall=\ref[D]'>Delete all of type</option>"
 	if(isobj(D) || ismob(D) || isturf(D))
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\\datums\\datumvars.dm:275: body += "<option value='?_src_=vars;explode=\ref[D]'>Trigger explosion</option>"
 		body += {"<option value='?_src_=vars;explode=\ref[D]'>Trigger explosion</option>
 			<option value='?_src_=vars;emp=\ref[D]'>Trigger EM pulse</option>"}
-		// END AUTOFIX
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\\datums\\datumvars.dm:278: body += "</select></form>"
 	body += {"</select></form>
 		</div></td></tr></table></div><hr>
 		<font size='1'><b>E</b> - Edit, tries to determine the variable type by itself.<br>
@@ -329,7 +306,6 @@
 		<b>M</b> - Mass modify: changes this variable for all objects of this type.</font><br>
 		<hr><table width='100%'><tr><td width='20%'><div align='center'><b>Search:</b></div></td><td width='80%'><input type='text' id='filter' name='filter_text' value='' style='width:100%;'></td></tr></table><hr>
 		<ol id='vars'>"}
-	// END AUTOFIX
 	var/list/names = list()
 	for (var/V in D.vars)
 		names += V
@@ -428,11 +404,8 @@ body
 			// not sure if this is completely right...
 			if(0)   //(L.vars.len > 0)
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\\datums\\datumvars.dm:386: html += "<ol>"
 				html += {"<ol>
 					</ol>"}
-				// END AUTOFIX
 			else
 				html += "<ul>"
 				var/index = 1

--- a/code/datums/helper_datums/getrev.dm
+++ b/code/datums/helper_datums/getrev.dm
@@ -100,10 +100,7 @@ var/global/datum/getrev/revdata = new("config/svndir.txt")
 	if(!output || output == "")
 		output = "Unable to load revision info from HEAD"
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\\datums\helper_datums\getrev.dm:93: output += "Current Infomational Settings: <br>"
 	output += {"Current Infomational Settings: <br>
 		Protect Authority Roles From Tratior: [config.protect_roles_from_antagonist]<br>"}
-	// END AUTOFIX
 	usr << browse(output,"window=revdata");
 	return

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -124,12 +124,9 @@
 
 	var/out = "<B>[name]</B>[(current&&(current.real_name!=name))?" (as [current.real_name])":""]<br>"
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\\datums\\mind.dm:110: out += "Mind currently owned by key: [key] [active?"(synced)":"(not synced)"]<br>"
 	out += {"Mind currently owned by key: [key] [active?"(synced)":"(not synced)"]<br>
 		Assigned role: [assigned_role]. <a href='?src=\ref[src];role_edit=1'>Edit</a><br>
 		Factions and special roles:<br>"}
-	// END AUTOFIX
 	var/list/sections = list(
 		"revolution",
 		"cult",
@@ -157,11 +154,8 @@
 			text += "head|<b>OFFICER</b>|employee|headre|rev"
 		else if (src in ticker.mode.head_revolutionaries)
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\\datums\\mind.dm:137: text = "head|officer|<a href='?src=\ref[src];revolution=clear'>employee</a>|<b>HEADREV</b>|<a href='?src=\ref[src];revolution=rev'>rev</a>"
 			text = {"head|officer|<a href='?src=\ref[src];revolution=clear'>employee</a>|<b>HEADREV</b>|<a href='?src=\ref[src];revolution=rev'>rev</a>
 				<br>Flash: <a href='?src=\ref[src];revolution=flash'>give</a>"}
-			// END AUTOFIX
 			var/list/L = current.get_contents()
 			var/obj/item/device/flash/flash = locate() in L
 			if (flash)
@@ -192,11 +186,8 @@
 			text += "head|<b>OFFICER</b>|employee|cultist"
 		else if (src in ticker.mode.cult)
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\\datums\\mind.dm:169: text += "head|officer|<a href='?src=\ref[src];cult=clear'>employee</a>|<b>CULTIST</b>"
 			text += {"head|officer|<a href='?src=\ref[src];cult=clear'>employee</a>|<b>CULTIST</b>
 				<br>Give <a href='?src=\ref[src];cult=tome'>tome</a>|<a href='?src=\ref[src];cult=amulet'>amulet</a>."}
-			// END AUTOFIX
 /*
 			if (objectives.len==0)
 				text += "<br>Objectives are empty! Set to sacrifice and <a href='?src=\ref[src];cult=escape'>escape</a> or <a href='?src=\ref[src];cult=summon'>summon</a>."
@@ -212,11 +203,8 @@
 		text = "<i><b>[text]</b></i>: "
 		if (src in ticker.mode.wizards)
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\\datums\\mind.dm:185: text += "<b>YES</b>|<a href='?src=\ref[src];wizard=clear'>no</a>"
 			text += {"<b>YES</b>|<a href='?src=\ref[src];wizard=clear'>no</a>
 				<br><a href='?src=\ref[src];wizard=lair'>To lair</a>, <a href='?src=\ref[src];common=undress'>undress</a>, <a href='?src=\ref[src];wizard=dressup'>dress up</a>, <a href='?src=\ref[src];wizard=name'>let choose name</a>."}
-			// END AUTOFIX
 			if (objectives.len==0)
 				text += "<br>Objectives are empty! <a href='?src=\ref[src];wizard=autoobjectives'>Randomize!</a>"
 		else
@@ -269,11 +257,8 @@
 		text = "<i><b>[text]</b></i>: "
 		if (src in ticker.mode.syndicates)
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\\datums\\mind.dm:217: text += "<b>OPERATIVE</b>|<a href='?src=\ref[src];nuclear=clear'>nanotrasen</a>"
 			text += {"<b>OPERATIVE</b>|<a href='?src=\ref[src];nuclear=clear'>nanotrasen</a>
 				<br><a href='?src=\ref[src];nuclear=lair'>To shuttle</a>, <a href='?src=\ref[src];common=undress'>undress</a>, <a href='?src=\ref[src];nuclear=dressup'>dress up</a>."}
-			// END AUTOFIX
 			var/code
 			for (var/obj/machinery/nuclearbomb/bombue in machines)
 				if (length(bombue.r_code) <= 5 && bombue.r_code != "LOLNO" && bombue.r_code != "ADMIN")
@@ -420,11 +405,8 @@
 			out += "<B>[obj_count]</B>: [objective.explanation_text] <a href='?src=\ref[src];obj_edit=\ref[objective]'>Edit</a> <a href='?src=\ref[src];obj_delete=\ref[objective]'>Delete</a> <a href='?src=\ref[src];obj_completed=\ref[objective]'><font color=[objective.completed ? "green" : "red"]>Toggle Completion</font></a><br>"
 			obj_count++
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\\datums\\mind.dm:338: out += "<a href='?src=\ref[src];obj_add=1'>Add objective</a><br><br>"
 	out += {"<a href='?src=\ref[src];obj_add=1'>Add objective</a><br><br>
 		<a href='?src=\ref[src];obj_announce=1'>Announce objectives</a><br><br>"}
-	// END AUTOFIX
 	usr << browse(out, "window=edit_memory[src]")
 
 /datum/mind/Topic(href, href_list)

--- a/code/defines/procs/command_alert.dm
+++ b/code/defines/procs/command_alert.dm
@@ -5,11 +5,8 @@
 		command += "<br><h2 class='alert'>[html_encode(title)]</h2>"
 
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\\defines\\\procs\command_alert.dm:7: command += "<br><span class='alert'>[html_encode(text)]</span><br>"
 	command += {"<br><span class='alert'>[html_encode(text)]</span><br>
 		<br>"}
-	// END AUTOFIX
 	for(var/mob/M in player_list)
 		if(!istype(M,/mob/new_player) && M.client)
 			to_chat(M, command)

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -217,11 +217,8 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 
 			//Removed sanity if(changeling) because we -want- a runtime to inform us that the changelings list is incorrect and needs to be fixed.
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\gamemodes\changeling\changeling.dm:182: text += "<br><b>Changeling ID:</b> [changeling.changeling.changelingID]."
 			text += {"<br><b>Changeling ID:</b> [changeling.changeling.changelingID].
 <b>Genomes Absorbed:</b> [changeling.changeling.absorbedcount]"}
-			// END AUTOFIX
 			if(changeling.objectives.len)
 				var/count = 1
 				for(var/datum/objective/objective in changeling.objectives)

--- a/code/game/gamemodes/cult/talisman.dm
+++ b/code/game/gamemodes/cult/talisman.dm
@@ -128,7 +128,6 @@
 <A href='?src=\ref[src];rune=soulstone'>Kal om neth</A> - Summons a soul stone<BR>
 <A href='?src=\ref[src];rune=construct'>Da A'ig Osk</A> - Summons a construct shell for use with captured souls. It is too large to carry on your person.<BR>"}
 //<A href='?src=\ref[src];rune=armor'>Sa tatha najin</A> - Allows you to summon armoured robes and an unholy blade<BR> //Kept for reference
-	// END AUTOFIX
 	usr << browse(dat, "window=id_com;size=350x200")
 	return
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -175,11 +175,8 @@
 /datum/game_mode/proc/send_intercept()
 
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\gamemodes\game_mode.dm:230: var/intercepttext = "<FONT size = 3><B>[command_name()] Update</B> Requested status information:</FONT><HR>"
 	var/intercepttext = {"<FONT size = 3><B>[command_name()] Update</B> Requested status information:</FONT><HR>
 <B> In case you have misplaced your copy, attached is a list of personnel whom reliable sources&trade; suspect may be affiliated with the Syndicate:</B><br> <I>Reminder: Acting upon this information without solid evidence will result in termination of your working contract with Nanotrasen.</I></br>"}
-	// END AUTOFIX
 	var/list/suspects = list()
 	for(var/mob/living/carbon/human/man in player_list) if(man.client && man.mind)
 		// NT relation option

--- a/code/game/gamemodes/intercept_report.dm
+++ b/code/game/gamemodes/intercept_report.dm
@@ -131,26 +131,17 @@
 	var/prob_right_dude = rand(1, 100)
 
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\gamemodes\intercept_report.dm:133: src.text += "<BR><BR>The <B>[name_1] [name_2]</B> implied an undercover operative was acting on their behalf on the station currently."
 	src.text += {"<BR><BR>The <B>[name_1] [name_2]</B> implied an undercover operative was acting on their behalf on the station currently.
 		It would be in your best interests to suspect everybody, as these undercover operatives could have implants which trigger them to have their memories removed until they are needed. He, or she, could even be a high ranking officer.
 		After some investigation, we "}
-	// END AUTOFIX
 	if(prob(50))
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\gamemodes\intercept_report.dm:138: src.text += "are [prob_right_dude]% sure that [traitor_name] may have been involved, and should be closely observed."
 		src.text += {"are [prob_right_dude]% sure that [traitor_name] may have been involved, and should be closely observed.
 			<BR>Note: This group are known to be untrustworthy, so do not act on this information without proper discourse."}
-		// END AUTOFIX
 	else
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\gamemodes\intercept_report.dm:141: src.text += "discovered the following set of fingerprints ([fingerprints]) on sensitive materials, and their owner should be closely observed."
 		src.text += {"discovered the following set of fingerprints ([fingerprints]) on sensitive materials, and their owner should be closely observed.
 			However, these could also belong to a current Cent. Com employee, so do not act on this without reason."}
-		// END AUTOFIX
 /datum/intercept_text/proc/build_cult(datum/mind/correct_person)
 	var/name_1 = pick(src.org_names_1)
 	var/name_2 = pick(src.org_names_2)
@@ -161,14 +152,11 @@
 	var/traitor_job = H.mind.assigned_role
 
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\gamemodes\intercept_report.dm:155: src.text += "<BR><BR>It has been brought to our attention that the [name_1] [name_2] have stumbled upon some dark secrets. They apparently want to spread the dangerous knowledge onto as many stations as they can."
 	src.text += {"<BR><BR>It has been brought to our attention that the [name_1] [name_2] have stumbled upon some dark secrets. They apparently want to spread the dangerous knowledge onto as many stations as they can.
 		Watch out for the following: praying to an unfamilar god, preaching the word of \[REDACTED\], sacrifices, magical dark power, living constructs of evil and a portal to the dimension of the underworld.
 		Based on our intelligence, we are [prob_right_dude]% sure that if true, someone doing the job of [traitor_job] on your station may have been converted 
 		and instilled with the idea of the flimsiness of the real world, seeking to destroy it. 
 		<BR>However, if this information is acted on without substantial evidence, those responsible will face severe repercussions."}
-	// END AUTOFIX
 /datum/intercept_text/proc/build_rev(datum/mind/correct_person)
 	var/name_1 = pick(src.org_names_1)
 	var/name_2 = pick(src.org_names_2)
@@ -179,44 +167,32 @@
 	var/traitor_job = H.mind.assigned_role
 
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\gamemodes\intercept_report.dm:174: src.text += "<BR><BR>It has been brought to our attention that the [name_1] [name_2] are attempting to stir unrest on one of our stations in your sector."
 	src.text += {"<BR><BR>It has been brought to our attention that the [name_1] [name_2] are attempting to stir unrest on one of our stations in your sector.
 		Watch out for suspicious activity among the crew and make sure that all heads of staff report in periodically.
 		Based on our intelligence, we are [prob_right_dude]% sure that if true, someone doing the job of [traitor_job] on your station may have been brainwashed 
 		at a recent conference, and their department should be closely monitored for signs of mutiny. 
 		<BR>However, if this information is acted on without substantial evidence, those responsible will face severe repercussions."}
-	// END AUTOFIX
 /datum/intercept_text/proc/build_wizard(datum/mind/correct_person)
 	var/SWF_desc = pick(SWF_names)
 
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\gamemodes\intercept_report.dm:187: src.text += "<BR><BR>The evil Space Wizards Federation have recently broke their most feared wizard, known only as \"[SWF_desc]\" out of space jail. "
 	src.text += {"<BR><BR>The evil Space Wizards Federation have recently broke their most feared wizard, known only as \"[SWF_desc]\" out of space jail. 
 		He is on the run, last spotted in a system near your present location. If anybody suspicious is located aboard, please 
 		approach with EXTREME caution. Cent. Com also recommends that it would be wise to not inform the crew of this, due to their fearful nature.
 		Known attributes include: Brown sandals, a large blue hat, a voluptous white beard, and an inclination to cast spells."}
-	// END AUTOFIX
 /datum/intercept_text/proc/build_nuke(datum/mind/correct_person)
 
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\gamemodes\intercept_report.dm:193: src.text += "<BR><BR>Cent. Com recently recieved a report of a plot to destroy one of our stations in your area. We believe the Nuclear Authentication Disc "
 	src.text += {"<BR><BR>Cent. Com recently recieved a report of a plot to destroy one of our stations in your area. We believe the Nuclear Authentication Disc 
 		that is standard issue aboard your vessel may be a target. We recommend removal of this object, and it's storage in a safe 
 		environment. As this may cause panic among the crew, all efforts should be made to keep this information a secret from all but 
 		the most trusted crew-members."}
-	// END AUTOFIX
 /datum/intercept_text/proc/build_malf(datum/mind/correct_person)
 	var/a_name = pick(src.anomalies)
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\gamemodes\intercept_report.dm:200: src.text += "<BR><BR>A [a_name] was recently picked up by a nearby stations sensors in your sector. If it came into contact with your ship or "
 	src.text += {"<BR><BR>A [a_name] was recently picked up by a nearby stations sensors in your sector. If it came into contact with your ship or 
 		electrical equipment, it may have had hazardarous and unpredictable effect. Closely observe any non carbon based life forms 
 		for signs of unusual behaviour, but keep this information discreet at all times due to this possibly dangerous scenario."}
-	// END AUTOFIX
 /datum/intercept_text/proc/build_changeling(datum/mind/correct_person)
 	var/cname = pick(src.changeling_names)
 	var/orgname1 = pick(src.org_names_1)
@@ -246,15 +222,9 @@
 	src.text += "<BR><BR>We have received a report that a dangerous alien lifeform known only as \"[cname]\" may have infiltrated your crew.  "
 	/*
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\gamemodes\intercept_report.dm:232: src.text += "Our intelligence suggests a [prob_right_job]% chance that a [changeling_job] on board your station has been replaced by the alien.  "
 	src.text += {"Our intelligence suggests a [prob_right_job]% chance that a [changeling_job] on board your station has been replaced by the alien.  
 		Additionally, the report indicates a [prob_right_dude]% chance that [changeling_name] may have been in contact with the lifeform at a recent social gathering.  "}
-	// END AUTOFIX
 	*/
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\gamemodes\intercept_report.dm:235: src.text += "These lifeforms are assosciated with the [orgname1] [orgname2] and may be attempting to acquire sensitive materials on their behalf.  "
 	src.text += {"These lifeforms are assosciated with the [orgname1] [orgname2] and may be attempting to acquire sensitive materials on their behalf.  
 		Please take care not to alarm the crew, as [cname] may take advantage of a panic situation. Remember, they can be anybody, suspect everybody!"}
-	// END AUTOFIX

--- a/code/game/gamemodes/sandbox/h_sandbox.dm
+++ b/code/game/gamemodes/sandbox/h_sandbox.dm
@@ -98,11 +98,8 @@ datum/hSB
 			var/hsbpanel = "<center><b>h_Sandbox Panel</b></center><hr>"
 			if(admin)
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\gamemodes\sandbox\h_sandbox.dm:39: hsbpanel += "<b>Administration Tools:</b><br>"
 				hsbpanel += {"<b>Administration Tools:</b><br>
 					- <a href=\"?\ref[src];hsb=hsbtobj\">Toggle Object Spawning</a><br><br>"}
-			// END AUTOFIX
 			hsbpanel += "<b>Regular Tools:</b><br>"
 			for(var/T in hrefs)
 				hsbpanel += "- <a href=\"?\ref[src];hsb=[T]\">[hrefs[T]]</a><br>"

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -33,8 +33,6 @@
 		dat = "[temp]<BR><BR><A href='byond://?src=\ref[src];temp=1'>Clear</A>"
 	else
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\gamemodes\wizard\spellbook.dm:22: dat = "<B>The Book of Spells:</B><BR>"
 		dat = {"<B>The Book of Spells:</B><BR>
 			Spells left to memorize: [uses]<BR>
 			<HR>
@@ -118,7 +116,6 @@
 			<A href='byond://?src=\ref[src];spell_choice=scrying'>Scrying Orb</A><BR>
 			<I>An incandescent orb of crackling energy, using it will allow you to ghost while alive, allowing you to spy upon the station with ease. In addition, buying it will permanently grant you x-ray vision.</I><BR>
 			<HR>"}
-		// END AUTOFIX
 		if(op)
 			dat += "<A href='byond://?src=\ref[src];spell_choice=rememorize'>Re-memorize Spells</A><BR>"
 	user << browse(dat, "window=radio")

--- a/code/game/machinery/atmo_control.dm
+++ b/code/game/machinery/atmo_control.dm
@@ -613,23 +613,17 @@ font-weight:bold;
 
 		if(automation)
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\atmo_control.dm:372: output += "Automated Fuel Injection: <A href='?src=\ref[src];toggle_automation=1'>Engaged</A><BR>"
 			output += {"
 			<tr>
 				<td colspan="2">Injector Controls Locked Out</td>
 			</tr>"}
-			// END AUTOFIX
 		else
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\atmo_control.dm:375: output += "Automated Fuel Injection: <A href='?src=\ref[src];toggle_automation=1'>Disengaged</A><BR>"
 			output += {"
 			<tr>
 				<th>Injector:</th>
 				<td><A href='?src=\ref[src];toggle_injector=1'>Toggle Power</A> <A href='?src=\ref[src];injection=1'>Inject (1 Cycle)</A></td>
 			</td>"}
-			// END AUTOFIX
 		output += "</table>"
 	else
 		output += {"<p style="color:red"><b>ERROR:</b> Can not find device. <A href='?src=\ref[src];refresh_status=1'>Search</A></p>"}

--- a/code/game/machinery/biogenerator.dm
+++ b/code/game/machinery/biogenerator.dm
@@ -379,8 +379,6 @@
 			if("menu")
 				if (beaker)
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\biogenerator.dm:89: dat += "<A href='?src=\ref[src];action=activate'>Activate Biogenerator!</A><BR>"
 					dat += {"<A href='?src=\ref[src];action=activate'>Activate Biogenerator!</A><BR>
 						<A href='?src=\ref[src];action=detach'>Detach Container</A><BR><BR>"}
 
@@ -395,25 +393,16 @@
 					dat += "<BR><FONT COLOR=red>No beaker inside. Please insert a beaker.</FONT><BR>"
 			if("nopoints")
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\biogenerator.dm:108: dat += "You do not have biomass to create products.<BR>Please, put growns into reactor and activate it.<BR>"
 				dat += {"You do not have biomass to create products.<BR>Please, put growns into reactor and activate it.<BR>
 					<A href='?src=\ref[src];action=menu'>Return to menu</A>"}
-				// END AUTOFIX
 			if("complete")
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\biogenerator.dm:111: dat += "Operation complete.<BR>"
 				dat += {"Operation complete.<BR>
 					<A href='?src=\ref[src];action=menu'>Return to menu</A>"}
-				// END AUTOFIX
 			if("void")
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\biogenerator.dm:114: dat += "<FONT COLOR=red>Error: No growns inside.</FONT><BR>Please, put growns into reactor.<BR>"
 				dat += {"<FONT COLOR=red>Error: No growns inside.</FONT><BR>Please, put growns into reactor.<BR>
 					<A href='?src=\ref[src];action=menu'>Return to menu</A>"}
-				// END AUTOFIX
 	user << browse(dat, "window=biogenerator")
 	onclose(user, "biogenerator")
 	return

--- a/code/game/machinery/computer/HolodeckControl.dm
+++ b/code/game/machinery/computer/HolodeckControl.dm
@@ -25,8 +25,6 @@
 	user.set_machine(src)
 	var/dat
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\computer\HolodeckControl.dm:28: dat += "<B>Holodeck Control System</B><BR>"
 	dat += {"<B>Holodeck Control System</B><BR>
 		<HR>Current Loaded Programs:<BR>
 		<A href='?src=\ref[src];emptycourt=1'>((Empty Court)</font>)</A><BR>
@@ -40,20 +38,16 @@
 		<A href='?src=\ref[src];snowfield=1'>((Snow Field)</font>)</A><BR>
 		<A href='?src=\ref[src];theatre=1'>((Theatre)</font>)</A><BR>
 		<A href='?src=\ref[src];meetinghall=1'>((Meeting Hall)</font>)</A><BR>"}
-	// END AUTOFIX
 //	dat += "<A href='?src=\ref[src];turnoff=1'>((Shutdown System)</font>)</A><BR>"
 	dat += "Please ensure that only holographic weapons are used in the holodeck if a combat simulation has been loaded.<BR>"
 
 	if(emagged)
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\computer\HolodeckControl.dm:47: dat += "<A href='?src=\ref[src];burntest=1'>(<font color=red>Begin Atmospheric Burn Simulation</font>)</A><BR>"
 		dat += {"<A href='?src=\ref[src];burntest=1'>(<font color=red>Begin Atmospheric Burn Simulation</font>)</A><BR>
 			Ensure the holodeck is empty before testing.<BR>
 			<BR>
 			<A href='?src=\ref[src];wildlifecarp=1'>(<font color=red>Begin Wildlife Simulation</font>)</A><BR>
 			Ensure the holodeck is empty before testing.<BR>
 			<BR>"}
-		// END AUTOFIX
 		if(issilicon(user))
 			dat += "<A href='?src=\ref[src];AIoverride=1'>(<font color=green>Re-Enable Safety Protocols?</font>)</A><BR>"
 		dat += "Safety Protocols are <font color=red> DISABLED </font><BR>"
@@ -61,11 +55,8 @@
 		if(issilicon(user))
 			dat += "<A href='?src=\ref[src];AIoverride=1'>(<font color=red>Override Safety Protocols?</font>)</A><BR>"
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\computer\HolodeckControl.dm:59: dat += "<BR>"
 		dat += {"<BR>
 			Safety Protocols are <font color=green> ENABLED </font><BR>"}
-		// END AUTOFIX
 	user << browse(dat, "window=computer;size=400x500")
 	onclose(user, "computer")
 	return

--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -54,10 +54,7 @@
 
 	updatemodules()
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\computer\Operating.dm:41: var/dat = "<HEAD><TITLE>Operating Computer</TITLE><META HTTP-EQUIV='Refresh' CONTENT='10'></HEAD><BODY>\n"
 	var/dat = {"<HEAD><TITLE>Operating Computer</TITLE><META HTTP-EQUIV='Refresh' CONTENT='10'></HEAD><BODY>"}
-	// END AUTOFIX
 	if(!isnull(src.optable) && (src.optable.check_victim()))
 		src.victim = src.optable.victim
 		dat += {"

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -107,22 +107,16 @@
 	user.set_machine(src)
 	var/dat = "<a href='byond://?src=\ref[src];close=1'>Close</a>"
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\computer\arcade.dm:67: dat += "<center><h4>[src.enemy_name]</h4></center>"
 	dat += {"<center><h4>[src.enemy_name]</h4></center>
 		<br><center><h3>[src.temp]</h3></center>
 		<br><center>Health: [src.player_hp] | Magic: [src.player_mp] | Enemy Health: [src.enemy_hp]</center>"}
-	// END AUTOFIX
 	if (src.gameover)
 		dat += "<center><b><a href='byond://?src=\ref[src];newgame=1'>New Game</a>"
 	else
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\computer\arcade.dm:75: dat += "<center><b><a href='byond://?src=\ref[src];attack=1'>Attack</a> | "
 		dat += {"<center><b><a href='byond://?src=\ref[src];attack=1'>Attack</a> |
 			<a href='byond://?src=\ref[src];heal=1'>Heal</a> |
 			<a href='byond://?src=\ref[src];charge=1'>Recharge Power</a>"}
-	// END AUTOFIX
 
 	dat += "</b></center>"
 

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -102,12 +102,9 @@
 					dat += "<br><a href='?src=\ref[src];screen=1'>Back</a>"
 				if(6.0)
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\computer\\medical.dm:96: dat += "<center><b>Medical Robot Monitor</b></center>"
 					dat += {"<center><b>Medical Robot Monitor</b></center>
 						<a href='?src=\ref[src];screen=1'>Back</a>
 						<br><b>Medical Robots:</b>"}
-					// END AUTOFIX
 					var/bdat = null
 					for(var/obj/machinery/bot/medbot/M in machines)
 

--- a/code/game/machinery/computer/message.dm
+++ b/code/game/machinery/computer/message.dm
@@ -90,25 +90,16 @@
 		message = rebootmsg
 	var/dat = "<head><title>Message Monitor Console</title></head><body>"
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\computer\\message.dm:93: dat += "<center><h2>Message Monitor Console</h2></center><hr>"
 	dat += {"<center><h2>Message Monitor Console</h2></center><hr>
 		<center><h4><font color='blue'[message]</h5></center>"}
-	// END AUTOFIX
 	if(auth)
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\computer\\message.dm:97: dat += "<h4><dd><A href='?src=\ref[src];auth=1'>&#09;<font color='green'>\[Authenticated\]</font></a>&#09;/"
 		dat += {"<h4><dd><A href='?src=\ref[src];auth=1'>&#09;<font color='green'>\[Authenticated\]</font></a>&#09;/
 			Server Power: <A href='?src=\ref[src];active=1'>[src.linkedServer && src.linkedServer.active ? "<font color='green'>\[On\]</font>":"<font color='red'>\[Off\]</font>"]</a></h4>"}
-		// END AUTOFIX
 	else
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\computer\\message.dm:100: dat += "<h4><dd><A href='?src=\ref[src];auth=1'>&#09;<font color='red'>\[Unauthenticated\]</font></a>&#09;/"
 		dat += {"<h4><dd><A href='?src=\ref[src];auth=1'>&#09;<font color='red'>\[Unauthenticated\]</font></a>&#09;/
 			Server Power: <u>[src.linkedServer && src.linkedServer.active ? "<font color='green'>\[On\]</font>":"<font color='red'>\[Off\]</font>"]</u></h4>"}
-		// END AUTOFIX
 	if(hacking || emagged)
 		screen = 2
 	else if(!auth || !linkedServer || (linkedServer.stat & (NOPOWER|BROKEN)))
@@ -126,15 +117,12 @@
 					dat += "<dd><A>&#09;ERROR: Server not found!</A><br></dd>"
 				else
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\computer\\message.dm:119: dat += "<dd><A href='?src=\ref[src];view=1'>&#09;[++i]. View Message Logs </a><br></dd>"
 					dat += {"<dd><A href='?src=\ref[src];view=1'>&#09;[++i]. View Message Logs </a><br></dd>
 						<dd><A href='?src=\ref[src];viewr=1'>&#09;[++i]. View Request Console Logs </a></br></dd>
 						<dd><A href='?src=\ref[src];clear=1'>&#09;[++i]. Clear Message Logs</a><br></dd>
 						<dd><A href='?src=\ref[src];clearr=1'>&#09;[++i]. Clear Request Console Logs</a><br></dd>
 						<dd><A href='?src=\ref[src];pass=1'>&#09;[++i]. Set Custom Key</a><br></dd>
 						<dd><A href='?src=\ref[src];msg=1'>&#09;[++i]. Send Admin Message</a><br></dd>"}
-					// END AUTOFIX
 			else
 				for(var/n = ++i; n <= optioncount; n++)
 					dat += "<dd><font color='blue'>&#09;[n]. ---------------</font><br></dd>"
@@ -157,11 +145,8 @@
 			//var/sender = "Unspecified" //name of the sender
 			//var/message = "Blank" //transferred message
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\computer\\message.dm:146: dat += "<center><A href='?src=\ref[src];back=1'>Back</a> - <A href='?src=\ref[src];refresh=1'>Refresh</center><hr>"
 			dat += {"<center><A href='?src=\ref[src];back=1'>Back</a> - <A href='?src=\ref[src];refresh=1'>Refresh</center><hr>
 				<table border='1' width='100%'><tr><th width = '5%'>X</th><th width='15%'>Sender</th><th width='15%'>Recipient</th><th width='300px' word-wrap: break-word>Message</th></tr>"}
-			// END AUTOFIX
 			for(var/datum/data_pda_msg/pda in src.linkedServer.pda_msgs)
 				index++
 				if(index > 3000)
@@ -174,11 +159,8 @@
 		if(2)
 			if(istype(user, /mob/living/silicon/ai) || istype(user, /mob/living/silicon/robot))
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\computer\\message.dm:159: dat += "Brute-forcing for server key.<br> It will take 20 seconds for every character that the password has."
 				dat += {"Brute-forcing for server key.<br> It will take 20 seconds for every character that the password has.
 					In the meantime, this console can reveal your true intentions if you let someone access it. Make sure no humans enter the room during that time."}
-				// END AUTOFIX
 			else
 				//It's the same message as the one above but in binary. Because robots understand binary and humans don't... well I thought it was clever.
 				dat += {"01000010011100100111010101110100011001010010110<br>

--- a/code/game/machinery/computer/prisoner.dm
+++ b/code/game/machinery/computer/prisoner.dm
@@ -39,14 +39,11 @@
 				if((Tr) && (Tr.z != src.z))	continue//Out of range
 				if(!C.implanted) continue
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\computer\\\prisoner.dm:41: dat += "[C.imp_in.name] | Remaining Units: [C.reagents.total_volume] | Inject: "
 				dat += {"[C.imp_in.name] | Remaining Units: [C.reagents.total_volume] | Inject:
 					<A href='?src=\ref[src];inject1=\ref[C]'>(<font color=red>(1)</font>)</A>
 					<A href='?src=\ref[src];inject5=\ref[C]'>(<font color=red>(5)</font>)</A>
 					<A href='?src=\ref[src];inject10=\ref[C]'>(<font color=red>(10)</font>)</A><BR>
 					********************************<BR>"}
-				// END AUTOFIX
 			dat += "<HR>Tracking Implants<BR>"
 			for(var/obj/item/weapon/implant/tracking/T in world)
 				Tr = get_turf(T)
@@ -61,12 +58,9 @@
 				if(T.malfunction)
 					loc_display = pick(teleportlocs)
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\computer\\\prisoner.dm:58: dat += "ID: [T.id] | Location: [loc_display]<BR>"
 				dat += {"ID: [T.id] | Location: [loc_display]<BR>
 					<A href='?src=\ref[src];warn=\ref[T]'>(<font color=red><i>Message Holder</i></font>)</A> |<BR>
 					********************************<BR>"}
-				// END AUTOFIX
 			dat += "<HR><A href='?src=\ref[src];lock=1'>Lock Console</A>"
 		dat = list2text(dat)
 		var/datum/browser/popup = new(user, "prisoner_implants", "Prisoner Implant Manager System", 400, 500, src)

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -41,12 +41,9 @@
 	else
 		if(screen == 0)
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\computer\robot.dm:41: dat += "<h3>Cyborg Control Console</h3><BR>"
 			dat += {"<h3>Cyborg Control Console</h3><BR>
 				<A href='?src=\ref[src];screen=1'>1. Cyborg Status</A><BR>
 				<A href='?src=\ref[src];screen=2'>2. Emergency Full Destruct</A><BR>"}
-			// END AUTOFIX
 		if(screen == 1)
 			for(var/mob/living/silicon/robot/R in mob_list)
 				if(istype(user, /mob/living/silicon/ai))
@@ -82,12 +79,9 @@
 					if((user.mind.special_role && user.mind.original == user) && !R.emagged)
 						dat += "<A href='?src=\ref[src];magbot=\ref[R]'>(<font color=blue><i>Hack</i></font>)</A> "
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\computer\robot.dm:78: dat += "<A href='?src=\ref[src];stopbot=\ref[R]'>(<font color=green><i>[R.canmove ? "Lockdown" : "Release"]</i></font>)</A> "
 				dat += {"<A href='?src=\ref[src];stopbot=\ref[R]'>(<font color=green><i>[R.canmove ? "Lockdown" : "Release"]</i></font>)</A>
 					<A href='?src=\ref[src];killbot=\ref[R]'>(<font color=red><i>Destroy</i></font>)</A>
 					<BR>"}
-				// END AUTOFIX
 			dat += "<A href='?src=\ref[src];screen=0'>(Return to Main Menu)</A><BR>"
 		if(screen == 2)
 			if(!src.status)

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -104,11 +104,8 @@
 					dat += text("<A href='?src=\ref[];choice=Log Out'>{Log Out}</A>",src)
 				if(2.0)
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\computer\security.dm:106: dat += "<B>Records Maintenance</B><HR>"
 					dat += {"<B>Records Maintenance</B><HR>
 						<BR><A href='?src=\ref[src];choice=Delete All Records'>Delete All Records</A><BR><BR><A href='?src=\ref[src];choice=Return'>Back</A>"}
-					// END AUTOFIX
 				if(3.0)
 					dat += "<CENTER><B>Security Record</B></CENTER><BR>"
 					if ((istype(active1, /datum/data/record) && data_core.general.Find(active1)))
@@ -347,13 +344,10 @@ What a mess.*/
 //RECORD DELETE
 			if ("Delete All Records")
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\computer\security.dm:346: temp = ""
 				temp = {"
 					Are you sure you wish to delete all Security records?<br>
 					<a href='?src=\ref[src];choice=Purge All Records'>Yes</a><br>
 					<a href='?src=\ref[src];choice=Clear Screen'>No</a>"}
-				// END AUTOFIX
 			if ("Purge All Records")
 				for(var/datum/data/record/R in data_core.security)
 					qdel(R)
@@ -375,21 +369,15 @@ What a mess.*/
 			if ("Delete Record (ALL)")
 				if (active1)
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\computer\security.dm:370: temp = "<h5>Are you sure you wish to delete the record (ALL)?</h5>"
 					temp = {"<h5>Are you sure you wish to delete the record (ALL)?</h5>
 						<a href='?src=\ref[src];choice=Delete Record (ALL) Execute'>Yes</a><br>
 						<a href='?src=\ref[src];choice=Clear Screen'>No</a>"}
-					// END AUTOFIX
 			if ("Delete Record (Security)")
 				if (active2)
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\computer\security.dm:376: temp = "<h5>Are you sure you wish to delete the record (Security Portion Only)?</h5>"
 					temp = {"<h5>Are you sure you wish to delete the record (Security Portion Only)?</h5>
 						<a href='?src=\ref[src];choice=Delete Record (Security) Execute'>Yes</a><br>
 						<a href='?src=\ref[src];choice=Clear Screen'>No</a>"}
-					// END AUTOFIX
 			if ("Delete Entry")
 				if ((istype(active2, /datum/data/record) && active2.fields[text("com_[]", href_list["del_c"])]))
 					active2.fields[text("com_[]", href_list["del_c"])] = "<B>Deleted</B>"
@@ -494,8 +482,6 @@ What a mess.*/
 					if("criminal")
 						if (istype(active2, /datum/data/record))
 
-							// AUTOFIXED BY fix_string_idiocy.py
-							// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\computer\security.dm:483: temp = "<h5>Criminal Status:</h5>"
 							temp = {"<h5>Criminal Status:</h5>
 								<ul>
 								<li><a href='?src=\ref[src];choice=Change Criminal Status;criminal2=none'>None</a></li>
@@ -504,17 +490,13 @@ What a mess.*/
 								<li><a href='?src=\ref[src];choice=Change Criminal Status;criminal2=parolled'>Parolled</a></li>
 								<li><a href='?src=\ref[src];choice=Change Criminal Status;criminal2=released'>Released</a></li>
 								</ul>"}
-							// END AUTOFIX
 					if("rank")
 						var/list/L = list( "Head of Personnel", "Captain", "AI" )
 						//This was so silly before the change. Now it actually works without beating your head against the keyboard. /N
 						if ((istype(active1, /datum/data/record) && L.Find(rank)))
 
-							// AUTOFIXED BY fix_string_idiocy.py
-							// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\computer\security.dm:495: temp = "<h5>Rank:</h5>"
 							temp = {"<h5>Rank:</h5>
 								<ul>"}
-							// END AUTOFIX
 							for(var/rank in get_all_jobs())
 								temp += "<li><a href='?src=\ref[src];choice=Change Rank;rank=[rank]'>[rank]</a></li>"
 							temp += "</ul>"

--- a/code/game/machinery/computer/station_alert.dm
+++ b/code/game/machinery/computer/station_alert.dm
@@ -60,11 +60,8 @@
 /obj/machinery/computer/station_alert/interact(mob/user)
 	usr.set_machine(src)
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\computer\station_alert.dm:29: var/dat = "<HEAD><TITLE>Current Station Alerts</TITLE><META HTTP-EQUIV='Refresh' CONTENT='10'></HEAD><BODY>\n"
 	var/dat = {"<HEAD><TITLE>Current [general_area_name] Alerts</TITLE><META HTTP-EQUIV='Refresh' CONTENT='10'></HEAD><BODY>\n
 	<A HREF='?src=\ref[user];mach_close=alerts'>Close</A><br><br>"}
-	// END AUTOFIX
 	for (var/cat in src.alarms)
 		dat += text("<B>[]</B><BR>\n", cat)
 		var/list/L = src.alarms[cat]
@@ -74,12 +71,9 @@
 				var/area/A = alm[1]
 				var/list/sources = alm[3]
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\computer\station_alert.dm:39: dat += "<NOBR>"
 				dat += {"<NOBR>
 					&bull;
 					[A.name]"}
-				// END AUTOFIX
 				if (sources.len > 1)
 					dat += text(" - [] sources", sources.len)
 				dat += "</NOBR><BR>\n"

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -136,22 +136,16 @@
 		user.set_machine(src)
 		var/dat = "<HTML><BODY><TT>"
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\\doors\brigdoors.dm:138: dat += "<HR>Timer System:</hr>"
 		dat += {"<HR>Timer System:</hr>
 			<b>Door [src.id_tag] controls</b><br/>"}
-		// END AUTOFIX
 		if (src.timing)
 			dat += "<a href='?src=\ref[src];timing=0'>Stop Timer and open door</a><br/>"
 		else
 			dat += "<a href='?src=\ref[src];timing=1'>Activate Timer and close door</a><br/>"
 
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\\doors\brigdoors.dm:145: dat += "Time Left: [(minute ? text("[minute]:") : null)][second] <br/>"
 		dat += {"Time Left: [(minute ? text("[minute]:") : null)][second] <br/>
 			<a href='?src=\ref[src];tp=-60'>-</a> <a href='?src=\ref[src];tp=-1'>-</a> <a href='?src=\ref[src];tp=1'>+</a> <A href='?src=\ref[src];tp=60'>+</a><br/>"}
-		// END AUTOFIX
 		for(var/obj/machinery/flasher/F in targets)
 			if(F.last_flash && (F.last_flash + 150) > world.time)
 				dat += "<br/><A href='?src=\ref[src];fc=1'>Flash Charging</A>"
@@ -159,11 +153,8 @@
 				dat += "<br/><A href='?src=\ref[src];fc=1'>Activate Flash</A>"
 
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\\doors\brigdoors.dm:154: dat += "<br/><br/><a href='?src=\ref[user];mach_close=computer'>Close</a>"
 		dat += {"<br/><br/><a href='?src=\ref[user];mach_close=computer'>Close</a>
 			</TT></BODY></HTML>"}
-		// END AUTOFIX
 		user << browse(dat, "window=computer;size=400x500")
 		onclose(user, "computer")
 		return

--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -304,12 +304,9 @@
 			if(item_quants[O] > 0)
 				var/N = item_quants[O]
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\kitchen\smartfridge.dm:140: dat += "<FONT color = 'blue'><B>[capitalize(O)]</B>:"
 				dat += {"<FONT color = 'blue'><B>[capitalize(O)]</B>:
 					[N] </font>
 					<a href='byond://?src=\ref[src];vend=[O];amount=1'>Vend</A> "}
-				// END AUTOFIX
 				if(N > 5)
 					dat += "(<a href='byond://?src=\ref[src];vend=[O];amount=5'>x5</A>)"
 					if(N > 10)

--- a/code/game/machinery/magnet.dm
+++ b/code/game/machinery/magnet.dm
@@ -269,12 +269,9 @@
 				dat += "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;< \[[i]\] (<a href='?src=\ref[src];radio-op=togglepower'>[M.on ? "On":"Off"]</a>) | Electricity level: <a href='?src=\ref[src];radio-op=minuselec'>-</a> [M.electricity_level] <a href='?src=\ref[src];radio-op=pluselec'>+</a>; Magnetic field: <a href='?src=\ref[src];radio-op=minusmag'>-</a> [M.magnetic_field] <a href='?src=\ref[src];radio-op=plusmag'>+</a><br>"
 
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\\magnet.dm:270: dat += "<br>Speed: <a href='?src=\ref[src];operation=minusspeed'>-</a> [speed] <a href='?src=\ref[src];operation=plusspeed'>+</a><br>"
 		dat += {"<br>Speed: <a href='?src=\ref[src];operation=minusspeed'>-</a> [speed] <a href='?src=\ref[src];operation=plusspeed'>+</a><br>
 			Path: {<a href='?src=\ref[src];operation=setpath'>[path]</a>}<br>
 			Moving: <a href='?src=\ref[src];operation=togglemoving'>[moving ? "Enabled":"Disabled"]</a>"}
-		// END AUTOFIX
 		user << browse(dat, "window=magnet;size=400x500")
 		onclose(user, "magnet")
 

--- a/code/game/machinery/navbeacon.dm
+++ b/code/game/machinery/navbeacon.dm
@@ -170,19 +170,13 @@ Transponder Codes:<UL>"}
 
 			for(var/key in codes)
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\navbeacon.dm:174: t += "<LI>[key] ... [codes[key]]"
 				t += {"<LI>[key] ... [codes[key]]
 					<small><A href='byond://?src=\ref[src];edit=1;code=[key]'>(edit)</A>
 					<A href='byond://?src=\ref[src];delete=1;code=[key]'>(delete)</A></small><BR>"}
-			// END AUTOFIX
 				t += "<LI>[key] ... [codes[key]]"
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\navbeacon.dm:177: t += "<small><A href='byond://?src=\ref[src];add=1;'>(add new)</A></small><BR>"
 			t += {"<small><A href='byond://?src=\ref[src];add=1;'>(add new)</A></small><BR>
 				<UL></TT>"}
-			// END AUTOFIX
 		user << browse(t, "window=navbeacon")
 		onclose(user, "navbeacon")
 		return

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -242,36 +242,27 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 		switch(screen)
 			if(NEWSCASTER_MENU)
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\newscaster.dm:187: dat += "Welcome to Newscasting Unit #[src.unit_no].<BR> Interface & News networks Operational."
 				dat += {"Welcome to Newscasting Unit #[src.unit_no].<BR> Interface & News networks Operational.
 					<BR><FONT SIZE=1>property of Nanotransen Inc</FONT>"}
-				// END AUTOFIX
 				if(news_network.wanted_issue)
 					dat+= "<HR><A href='?src=\ref[src];view_wanted=1'>Read Wanted Issue</A>"
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\newscaster.dm:191: dat+= "<HR><BR><A href='?src=\ref[src];create_channel=1'>Create Feed Channel</A>"
 				dat += {"<HR><BR><A href='?src=\ref[src];create_channel=1'>Create Feed Channel</A>
 					<BR><A href='?src=\ref[src];view=1'>View Feed Channels</A>
 					<BR><A href='?src=\ref[src];create_feed_story=1'>Submit new Feed story</A>
 					<BR><A href='?src=\ref[src];menu_paper=1'>Print newspaper</A>
 					<BR><A href='?src=\ref[src];refresh=1'>Re-scan User</A>
 					<BR><BR><A href='?src=\ref[M];mach_close=newscaster_main'>Exit</A>"}
-				// END AUTOFIX
 				if(src.securityCaster)
 					var/wanted_already = 0
 					if(news_network.wanted_issue)
 						wanted_already = 1
 
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\newscaster.dm:202: dat+="<HR><B>Feed Security functions:</B><BR>"
 					dat += {"<HR><B>Feed Security functions:</B><BR>
 						<BR><A href='?src=\ref[src];menu_wanted=1'>[(wanted_already) ? ("Manage") : ("Publish")] \"Wanted\" Issue</A>
 						<BR><A href='?src=\ref[src];menu_censor_story=1'>Censor Feed Stories</A>
 						<BR><A href='?src=\ref[src];menu_censor_channel=1'>Mark Feed Channel with Nanotrasen D-Notice</A>"}
-				// END AUTOFIX
 				dat+="<BR><HR>The newscaster recognises you as: <FONT COLOR='green'>[src.scanned_user]</FONT>"
 			if(NEWSCASTER_CHANNEL_LIST)
 				dat+= "Station Feed Channels<HR>"
@@ -292,25 +283,17 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 								dat+="-[MESSAGE.body] <BR><FONT SIZE=1>\[Story by <FONT COLOR='maroon'>[MESSAGE.author]</FONT>\]</FONT><BR>"*/
 
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\newscaster.dm:225: dat+="<BR><HR><A href='?src=\ref[src];refresh=1'>Refresh</A>"
 				dat += {"<BR><HR><A href='?src=\ref[src];refresh=1'>Refresh</A>
 					<BR><A href='?src=\ref[src];setScreen=[NEWSCASTER_MENU]'>Back</A>"}
-				// END AUTOFIX
 			if(NEWSCASTER_NEW_CHANNEL)
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\newscaster.dm:228: dat+="Creating new Feed Channel..."
 				dat += {"Creating new Feed Channel...
 					<HR><B><A href='?src=\ref[src];set_channel_name=1'>Channel Name</A>:</B> [src.channel_name]<BR>
 					<B>Channel Author:</B> <FONT COLOR='green'>[src.scanned_user]</FONT><BR>
 					<B><A href='?src=\ref[src];set_channel_lock=1'>Will Accept Public Feeds</A>:</B> [(src.c_locked) ? ("NO") : ("YES")]<BR><BR>
 					<BR><A href='?src=\ref[src];submit_new_channel=1'>Submit</A><BR><BR><A href='?src=\ref[src];setScreen=[NEWSCASTER_MENU]'>Cancel</A><BR>"}
-				// END AUTOFIX
 			if(NEWSCASTER_NEW_MESSAGE)
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\newscaster.dm:234: dat+="Creating new Feed Message..."
 				dat += {"Creating new Feed Message...
 					<HR><B><A href='?src=\ref[src];set_channel_receiving=1'>Receiving Channel</A>:</B> [src.channel_name]<BR>
 					<B>Message Author:</B> <FONT COLOR='green'>[src.scanned_user]</FONT><BR>
@@ -324,21 +307,14 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 				dat += AttachPhotoButton(user)
 
 				dat += "<BR><A href='?src=\ref[src];submit_new_message=1'>Submit</A><BR><BR><A href='?src=\ref[src];setScreen=[NEWSCASTER_MENU]'>Cancel</A><BR>"
-				// END AUTOFIX
 			if(NEWSCASTER_NEW_MESSAGE_SUCCESS)
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\newscaster.dm:241: dat+="Feed story successfully submitted to [src.channel_name].<BR><BR>"
 				dat += {"Feed story successfully submitted to [src.channel_name].<BR><BR>
 					<BR><A href='?src=\ref[src];setScreen=[NEWSCASTER_MENU]'>Return</A><BR>"}
-				// END AUTOFIX
 			if(NEWSCASTER_NEW_CHANNEL_SUCCESS)
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\newscaster.dm:244: dat+="Feed Channel [src.channel_name] created successfully.<BR><BR>"
 				dat += {"Feed Channel [src.channel_name] created successfully.<BR><BR>
 					<BR><A href='?src=\ref[src];setScreen=[NEWSCASTER_MENU]'>Return</A><BR>"}
-				// END AUTOFIX
 			if(NEWSCASTER_NEW_MESSAGE_ERROR)
 				dat+="<B><FONT COLOR='maroon'>ERROR: Could not submit Feed story to Network.</B></FONT><HR><BR>"
 				if(src.channel_name=="")
@@ -383,22 +359,16 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 					else
 						active_num--
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\newscaster.dm:289: dat+="Network currently serves a total of [total_num] Feed channels, [active_num] of which are active, and a total of [message_num] Feed Stories." //TODO: CONTINUE
 				dat += {"Network currently serves a total of [total_num] Feed channels, [active_num] of which are active, and a total of [message_num] Feed Stories." //TODO: CONTINU
 					<BR><BR><B>Liquid Paper remaining:</B> [(src.paper_remaining) *100 ] cm^3
 					<BR><BR><A href='?src=\ref[src];print_paper=[0]'>Print Paper</A>
 					<BR><A href='?src=\ref[src];setScreen=[NEWSCASTER_MENU]'>Cancel</A>"}
-				// END AUTOFIX
 			if(NEWSCASTER_VIEW_CHANNEL)
 				dat+="<B>[src.viewing_channel.channel_name]: </B><FONT SIZE=1>\[created by: <FONT COLOR='maroon'>[src.viewing_channel.author]</FONT>\]</FONT><HR>"
 				if(src.viewing_channel.censored)
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\newscaster.dm:296: dat+="<FONT COLOR='red'><B>ATTENTION: </B></FONT>This channel has been deemed as threatening to the welfare of the station, and marked with a Nanotrasen D-Notice.<BR>"
 					dat += {"<FONT COLOR='red'><B>ATTENTION: </B></FONT>This channel has been deemed as threatening to the welfare of the station, and marked with a Nanotrasen D-Notice.<BR>
 						No further feed story additions are allowed while the D-Notice is in effect.</FONT><BR><BR>"}
-					// END AUTOFIX
 				else
 					if( isemptylist(src.viewing_channel.messages) )
 						dat+="<I>No feed messages found in channel...</I><BR>"
@@ -412,20 +382,14 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 								dat+="<a href='?src=\ref[src];show_photo_info=\ref[MESSAGE]'><img src='tmp_photo[i].png' width = '180'></a><BR><BR>"
 							dat+="<FONT SIZE=1>\[Story by <FONT COLOR='maroon'>[MESSAGE.author]</FONT>\]</FONT><BR>"
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\newscaster.dm:310: dat+="<BR><HR><A href='?src=\ref[src];refresh=1'>Refresh</A>"
 				dat += {"<BR><HR><A href='?src=\ref[src];refresh=1'>Refresh</A>
 					<BR><A href='?src=\ref[src];setScreen=[NEWSCASTER_CHANNEL_LIST]'>Back</A>"}
-				// END AUTOFIX
 			if(NEWSCASTER_CENSORSHIP_MENU)
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\newscaster.dm:313: dat+="<B>Nanotrasen Feed Censorship Tool</B><BR>"
 				dat += {"<B>Nanotrasen Feed Censorship Tool</B><BR>
 					<FONT SIZE=1>NOTE: Due to the nature of news Feeds, total deletion of a Feed Story is not possible.<BR>
 					Keep in mind that users attempting to view a censored feed will instead see the \[REDACTED\] tag above it.</FONT>
 					<HR>Select Feed channel to get Stories from:<BR>"}
-				// END AUTOFIX
 				if(isemptylist(news_network.network_channels))
 					dat+="<I>No feed channels found active...</I><BR>"
 				else
@@ -434,13 +398,10 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 				dat+="<BR><A href='?src=\ref[src];setScreen=[NEWSCASTER_MENU]'>Cancel</A>"
 			if(NEWSCASTER_D_NOTICE_MENU)
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\newscaster.dm:324: dat+="<B>Nanotrasen D-Notice Handler</B><HR>"
 				dat += {"<B>Nanotrasen D-Notice Handler</B><HR>
 					<FONT SIZE=1>A D-Notice is to be bestowed upon the channel if the handling Authority deems it as harmful for the station's
 					morale, integrity or disciplinary behaviour. A D-Notice will render a channel unable to be updated by anyone, without deleting any feed
 					stories it might contain at the time. You can lift a D-Notice if you have the required access at any time.</FONT><HR>"}
-				// END AUTOFIX
 				if(isemptylist(news_network.network_channels))
 					dat+="<I>No feed channels found active...</I><BR>"
 				else
@@ -450,36 +411,24 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 				dat+="<BR><A href='?src=\ref[src];setScreen=[NEWSCASTER_MENU]'>Back</A>"
 			if(NEWSCASTER_CENSORSHIP_CHANNEL)
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\newscaster.dm:336: dat+="<B>[src.viewing_channel.channel_name]: </B><FONT SIZE=1>\[ created by: <FONT COLOR='maroon'>[src.viewing_channel.author]</FONT> \]</FONT><BR>"
 				dat += {"<B>[src.viewing_channel.channel_name]: </B><FONT SIZE=1>\[ created by: <FONT COLOR='maroon'>[src.viewing_channel.author]</FONT> \]</FONT><BR>
 					<FONT SIZE=2><A href='?src=\ref[src];censor_channel_author=\ref[src.viewing_channel]'>[(src.viewing_channel.author=="\[REDACTED\]") ? ("Undo Author censorship") : ("Censor channel Author")]</A></FONT><HR>"}
-				// END AUTOFIX
 				if( isemptylist(src.viewing_channel.messages) )
 					dat+="<I>No feed messages found in channel...</I><BR>"
 				else
 					for(var/datum/feed_message/MESSAGE in src.viewing_channel.messages)
 
-						// AUTOFIXED BY fix_string_idiocy.py
-						// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\newscaster.dm:344: dat+="-[MESSAGE.body] <BR><FONT SIZE=1>\[Story by <FONT COLOR='maroon'>[MESSAGE.author]</FONT>\]</FONT><BR>"
 						dat += {"-[MESSAGE.body] <BR><FONT SIZE=1>\[Story by <FONT COLOR='maroon'>[MESSAGE.author]</FONT>\]</FONT><BR>
 							<FONT SIZE=2><A href='?src=\ref[src];censor_channel_story_body=\ref[MESSAGE]'>[(MESSAGE.body == "\[REDACTED\]") ? ("Undo story censorship") : ("Censor story")]</A>  -  <A href='?src=\ref[src];censor_channel_story_author=\ref[MESSAGE]'>[(MESSAGE.author == "\[REDACTED\]") ? ("Undo Author Censorship") : ("Censor message Author")]</A></FONT><BR>"}
-						// END AUTOFIX
 				dat+="<BR><A href='?src=\ref[src];setScreen=[NEWSCASTER_CENSORSHIP_MENU]'>Back</A>"
 			if(NEWSCASTER_D_NOTICE_CHANNEL)
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\newscaster.dm:348: dat+="<B>[src.viewing_channel.channel_name]: </B><FONT SIZE=1>\[ created by: <FONT COLOR='maroon'>[src.viewing_channel.author]</FONT> \]</FONT><BR>"
 				dat += {"<B>[src.viewing_channel.channel_name]: </B><FONT SIZE=1>\[ created by: <FONT COLOR='maroon'>[src.viewing_channel.author]</FONT> \]</FONT><BR>
 					Channel messages listed below. If you deem them dangerous to the station, you can <A href='?src=\ref[src];toggle_d_notice=\ref[src.viewing_channel]'>Bestow a D-Notice upon the channel</A>.<HR>"}
-				// END AUTOFIX
 				if(src.viewing_channel.censored)
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\newscaster.dm:351: dat+="<FONT COLOR='red'><B>ATTENTION: </B></FONT>This channel has been deemed as threatening to the welfare of the station, and marked with a Nanotrasen D-Notice.<BR>"
 					dat += {"<FONT COLOR='red'><B>ATTENTION: </B></FONT>This channel has been deemed as threatening to the welfare of the station, and marked with a Nanotrasen D-Notice.<BR>
 						No further feed story additions are allowed while the D-Notice is in effect.</FONT><BR><BR>"}
-					// END AUTOFIX
 				else
 					if( isemptylist(src.viewing_channel.messages) )
 						dat+="<I>No feed messages found in channel...</I><BR>"
@@ -499,13 +448,10 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 				if(wanted_already)
 					dat+="<FONT SIZE=2><BR><I>A wanted issue is already in Feed Circulation. You can edit or cancel it below.</FONT></I>"
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\newscaster.dm:371: dat+="<HR>"
 				dat += {"<HR>
 					<A href='?src=\ref[src];set_wanted_name=1'>Criminal Name</A>: [src.channel_name] <BR>
 					<A href='?src=\ref[src];set_wanted_desc=1'>Description</A>: [src.msg] <BR>"}
 				dat += AttachPhotoButton(user)
-				// END AUTOFIX
 				if(wanted_already)
 					dat+="<B>Wanted Issue created by:</B><FONT COLOR='green'> [news_network.wanted_issue.backup_author]</FONT><BR>"
 				else
@@ -516,11 +462,8 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 				dat+="<BR><A href='?src=\ref[src];setScreen=[NEWSCASTER_MENU]'>Cancel</A>"
 			if(NEWSCASTER_WANTED_SUCCESS)
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\newscaster.dm:384: dat+="<FONT COLOR='green'>Wanted issue for [src.channel_name] is now in Network Circulation.</FONT><BR><BR>"
 				dat += {"<FONT COLOR='green'>Wanted issue for [src.channel_name] is now in Network Circulation.</FONT><BR><BR>
 					<BR><A href='?src=\ref[src];setScreen=[NEWSCASTER_MENU]'>Return</A><BR>"}
-				// END AUTOFIX
 			if(NEWSCASTER_WANTED_ERROR)
 				dat+="<B><FONT COLOR='maroon'>ERROR: Wanted Issue rejected by Network.</B></FONT><HR><BR>"
 				if(src.channel_name=="" || src.channel_name == "\[REDACTED\]")
@@ -532,20 +475,14 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 				dat+="<BR><A href='?src=\ref[src];setScreen=[NEWSCASTER_MENU]'>Return</A><BR>"
 			if(NEWSCASTER_WANTED_DELETED)
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\newscaster.dm:396: dat+="<B>Wanted Issue successfully deleted from Circulation</B><BR>"
 				dat += {"<B>Wanted Issue successfully deleted from Circulation</B><BR>
 					<BR><A href='?src=\ref[src];setScreen=[NEWSCASTER_MENU]'>Return</A><BR>"}
-				// END AUTOFIX
 			if(NEWSCASTER_WANTED_SHOW)
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\newscaster.dm:399: dat+="<B><FONT COLOR ='maroon'>-- STATIONWIDE WANTED ISSUE --</B></FONT><BR><FONT SIZE=2>\[Submitted by: <FONT COLOR='green'>[news_network.wanted_issue.backup_author]</FONT>\]</FONT><HR>"
 				dat += {"<B><FONT COLOR ='maroon'>-- STATIONWIDE WANTED ISSUE --</B></FONT><BR><FONT SIZE=2>\[Submitted by: <FONT COLOR='green'>[news_network.wanted_issue.backup_author]</FONT>\]</FONT><HR>
 					<B>Criminal</B>: [news_network.wanted_issue.author]<BR>
 					<B>Description</B>: [news_network.wanted_issue.body]<BR>
 					<B>Photo:</B>: "}
-				// END AUTOFIX
 				if(news_network.wanted_issue.img)
 					usr << browse_rsc(news_network.wanted_issue.img, "tmp_photow.png")
 					dat+="<BR><img src='tmp_photow.png' width = '180'>"
@@ -554,25 +491,16 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 				dat+="<BR><BR><A href='?src=\ref[src];setScreen=[NEWSCASTER_MENU]'>Back</A><BR>"
 			if(NEWSCASTER_WANTED_EDIT)
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\newscaster.dm:410: dat+="<FONT COLOR='green'>Wanted issue for [src.channel_name] successfully edited.</FONT><BR><BR>"
 				dat += {"<FONT COLOR='green'>Wanted issue for [src.channel_name] successfully edited.</FONT><BR><BR>
 					<BR><A href='?src=\ref[src];setScreen=[NEWSCASTER_MENU]'>Return</A><BR>"}
-				// END AUTOFIX
 			if(NEWSCASTER_PRINT_NEWSPAPER_SUCCESS)
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\newscaster.dm:413: dat+="<FONT COLOR='green'>Printing successfull. Please receive your newspaper from the bottom of the machine.</FONT><BR><BR>"
 				dat += {"<FONT COLOR='green'>Printing successfull. Please receive your newspaper from the bottom of the machine.</FONT><BR><BR>
 					<A href='?src=\ref[src];setScreen=[NEWSCASTER_MENU]'>Return</A>"}
-				// END AUTOFIX
 			if(NEWSCASTER_PRINT_NEWSPAPER_ERROR)
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\newscaster.dm:416: dat+="<FONT COLOR='maroon'>Unable to print newspaper. Insufficient paper. Please notify maintenance personnell to refill machine storage.</FONT><BR><BR>"
 				dat += {"<FONT COLOR='maroon'>Unable to print newspaper. Insufficient paper. Please notify maintenance personnell to refill machine storage.</FONT><BR><BR>
 					<A href='?src=\ref[src];setScreen=[NEWSCASTER_MENU]'>Return</A>"}
-				// END AUTOFIX
 			else
 				dat+="I'm sorry to break your immersion. This shit's bugged. Report this bug to Agouri, polyxenitopalidou@gmail.com"
 
@@ -1113,11 +1041,8 @@ obj/item/weapon/newspaper/attack_self(mob/user as mob)
 		switch(screen)
 			if(NEWSPAPER_TITLE_PAGE) //Cover
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\newscaster.dm:806: dat+="<DIV ALIGN='center'><B><FONT SIZE=6>The Griffon</FONT></B></div>"
 				dat += {"<DIV ALIGN='center'><B><FONT SIZE=6>The Griffon</FONT></B></div>
 					<DIV ALIGN='center'><FONT SIZE=2>Nanotrasen-standard newspaper, for use on Nanotrasen� Space Facilities</FONT></div><HR>"}
-				// END AUTOFIX
 				if(isemptylist(src.news_content))
 					if(src.important_message)
 						dat+="Contents:<BR><ul><B><FONT COLOR='red'>**</FONT>Important Security Announcement<FONT COLOR='red'>**</FONT></B> <FONT SIZE=2>\[page [src.pages+2]\]</FONT><BR></ul>"
@@ -1166,13 +1091,10 @@ obj/item/weapon/newspaper/attack_self(mob/user as mob)
 					src.pages++
 				if(src.important_message!=null)
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\newscaster.dm:855: dat+="<DIV STYLE='float:center;'><FONT SIZE=4><B>Wanted Issue:</B></FONT SIZE></DIV><BR><BR>"
 					dat += {"<DIV STYLE='float:center;'><FONT SIZE=4><B>Wanted Issue:</B></FONT SIZE></DIV><BR><BR>
 						<B>Criminal name</B>: <FONT COLOR='maroon'>[important_message.author]</FONT><BR>
 						<B>Description</B>: [important_message.body]<BR>
 						<B>Photo:</B>: "}
-					// END AUTOFIX
 					if(important_message.img)
 						user << browse_rsc(important_message.img, "tmp_photow.png")
 						dat+="<BR><img src='tmp_photow.png' width = '180'>"

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -143,12 +143,9 @@
 		return
 	if(src.panel_open) //The maintenance panel is open. Time for some shady stuff
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\suit_storage_unit.dm:100: dat+= "<HEAD><TITLE>Suit storage unit: Maintenance panel</TITLE></HEAD>"
 		dat += {"<HEAD><TITLE>Suit storage unit: Maintenance panel</TITLE></HEAD>
 			<Font color ='black'><B>Maintenance panel controls</B></font><HR>
 			<font color ='grey'>The panel is ridden with controls, button and meters, labeled in strange signs and symbols that <BR>you cannot understand. Probably the manufactoring world's language.<BR> Among other things, a few controls catch your eye.<BR><BR>"}
-		// END AUTOFIX
 		dat+= text("<font color ='black'>A small dial with a \"ë\" symbol embroidded on it. It's pointing towards a gauge that reads []</font>.<BR> <font color='blue'><A href='?src=\ref[];toggleUV=1'> Turn towards []</A><BR>",(src.issuperUV ? "15nm" : "185nm"),src,(src.issuperUV ? "185nm" : "15nm") )
 		dat+= text("<font color ='black'>A thick old-style button, with 2 grimy LED lights next to it. The [] LED is on.</font><BR><font color ='blue'><A href='?src=\ref[];togglesafeties=1'>Press button</a></font>",(src.safetieson? "<font color='green'><B>GREEN</B></font>" : "<font color='red'><B>RED</B></font>"),src)
 		dat+= text("<HR><BR><A href='?src=\ref[];mach_close=suit_storage_unit'>Close panel</A>", user)
@@ -156,11 +153,8 @@
 		//onclose(user, "ssu_m_panel")
 	else if(src.isUV) //The thing is running its cauterisation cycle. You have to wait.
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\suit_storage_unit.dm:109: dat += "<HEAD><TITLE>Suit storage unit</TITLE></HEAD>"
 		dat += {"<HEAD><TITLE>Suit storage unit</TITLE></HEAD>
 			<font color ='red'><B>Unit is cauterising contents with selected UV ray intensity. Please wait.</font></B><BR>"}
-		// END AUTOFIX
 		//dat+= "<font colr='black'><B>Cycle end in: [src.cycletimeleft()] seconds. </font></B>"
 		//user << browse(dat, "window=ssu_cycling_panel;size=400x500")
 		//onclose(user, "ssu_cycling_panel")
@@ -168,12 +162,9 @@
 	else
 		if(!(stat & BROKEN))
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\suit_storage_unit.dm:117: dat+= "<HEAD><TITLE>Suit storage unit</TITLE></HEAD>"
 			dat += {"<HEAD><TITLE>Suit storage unit</TITLE></HEAD>
 				<font color='blue'><font size = 4><B>U-Stor-It Suit Storage Unit, model DS1900</B></FONT><BR>
 				<B>Welcome to the Unit control panel.</B><HR>"}
-			// END AUTOFIX
 			dat+= text("<font color='black'>Helmet storage compartment: <B>[]</B></font><BR>",(src.HELMET ? HELMET.name : "</font><font color ='grey'>No helmet detected.") )
 			if(HELMET && src.isopen)
 				dat+=text("<A href='?src=\ref[];dispense_helmet=1'>Dispense helmet</A><BR>",src)
@@ -188,11 +179,8 @@
 				dat+=text("<A href='?src=\ref[];dispense_boots=1'>Dispense boots</A><BR>",src)
 			if(src.OCCUPANT)
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\suit_storage_unit.dm:130: dat+= "<HR><B><font color ='red'>WARNING: Biological entity detected inside the Unit's storage. Please remove.</B></font><BR>"
 				dat += {"<HR><B><font color ='red'>WARNING: Biological entity detected inside the Unit's storage. Please remove.</B></font><BR>
 					<A href='?src=\ref[src];eject_guy=1'>Eject extra load</A>"}
-				// END AUTOFIX
 			dat+= text("<HR><font color='black'>Unit is: [] - <A href='?src=\ref[];toggle_open=1'>[] Unit</A></font> ",(src.isopen ? "Open" : "Closed"),src,(src.isopen ? "Close" : "Open"))
 			if(src.isopen)
 				dat+="<HR>"
@@ -205,11 +193,8 @@
 			//onclose(user, "Suit Storage Unit")
 		else //Ohhhh shit it's dirty or broken! Let's inform the guy.
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\suit_storage_unit.dm:143: dat+= "<HEAD><TITLE>Suit storage unit</TITLE></HEAD>"
 			dat += {"<HEAD><TITLE>Suit storage unit</TITLE></HEAD>
 				<font color='maroon'><B>Unit chamber is too contaminated to continue usage. Please call for a qualified individual to perform maintenance.</font></B><BR><BR>"}
-			// END AUTOFIX
 			dat+= text("<HR><A href='?src=\ref[];mach_close=suit_storage_unit'>Close control panel</A>", user)
 			//user << browse(dat, "window=suit_storage_unit;size=400x500")
 			//onclose(user, "suit_storage_unit")

--- a/code/game/machinery/telecomms/logbrowser.dm
+++ b/code/game/machinery/telecomms/logbrowser.dm
@@ -35,21 +35,15 @@
 
 		if(0)
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\telecomms\logbrowser.dm:30: dat += "<br>[temp]<br>"
 			dat += {"<br>[temp]<br>
 				<br>Current Network: <a href='?src=\ref[src];network=1'>[network]</a><br>"}
-			// END AUTOFIX
 			if(servers.len)
 				dat += "<br>Detected Telecommunication Servers:<ul>"
 				for(var/obj/machinery/telecomms/T in servers)
 					dat += "<li><a href='?src=\ref[src];viewserver=[T.id]'>\ref[T] [T.name]</a> ([T.id])</li>"
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\telecomms\logbrowser.dm:36: dat += "</ul>"
 				dat += {"</ul>
 					<br><a href='?src=\ref[src];operation=release'>\[Flush Buffer\]</a>"}
-				// END AUTOFIX
 			else
 				dat += "<br>No servers detected. Scan for servers: <a href='?src=\ref[src];operation=scan'>\[Scan\]</a>"
 
@@ -58,13 +52,10 @@
 
 		if(1)
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\telecomms\logbrowser.dm:46: dat += "<br>[temp]<br>"
 			dat += {"<br>[temp]<br>
 				<center><a href='?src=\ref[src];operation=mainmenu'>\[Main Menu\]</a>     <a href='?src=\ref[src];operation=refresh'>\[Refresh\]</a></center>
 				<br>Current Network: [network]
 				<br>Selected Server: [SelectedServer.id]"}
-			// END AUTOFIX
 			if(SelectedServer.totaltraffic >= 1024)
 				dat += "<br>Total recorded traffic: [round(SelectedServer.totaltraffic / 1024)] Terrabytes<br><br>"
 			else
@@ -125,36 +116,27 @@
 
 					if(language == "Human" || universal_translate || C.parameters["uspeech"])
 
-						// AUTOFIXED BY fix_string_idiocy.py
-						// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\telecomms\logbrowser.dm:102: dat += "<u><font color = #18743E>Data type</font color></u>: [C.input_type]<br>"
 						dat += {"<u><font color = #18743E>Data type</font color></u>: [C.input_type]<br>
 							<u><font color = #18743E>Source</font color></u>: [C.parameters["name"]] (Job: [C.parameters["job"]])<br>
 							<u><font color = #18743E>Class</font color></u>: [race]<br>
 							<u><font color = #18743E>Contents</font color></u>: \"[C.parameters["message"]]\"<br>"}
-						// END AUTOFIX
 					// -- Orator is not human and universal translate not active --
 
 					else
 
-						// AUTOFIXED BY fix_string_idiocy.py
-						// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\telecomms\logbrowser.dm:111: dat += "<u><font color = #18743E>Data type</font color></u>: Audio File<br>"
 						dat += {"<u><font color = #18743E>Data type</font color></u>: Audio File<br>
 							<u><font color = #18743E>Source</font color></u>: <i>Unidentifiable</i><br>
 							<u><font color = #18743E>Class</font color></u>: [race]<br>
 							<u><font color = #18743E>Contents</font color></u>: <i>Unintelligble</i><br>"}
-					// END AUTOFIX
 
 					dat += "</li><br>"
 
 				else if(C.input_type == "Execution Error")
 
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\telecomms\logbrowser.dm:120: dat += "<li><font color = #990000>[C.name]</font color>  <font color = #FF0000><a href='?src=\ref[src];delete=[i]'>\[X\]</a></font color><br>"
 					dat += {"<li><font color = #990000>[C.name]</font color>  <font color = #FF0000><a href='?src=\ref[src];delete=[i]'>\[X\]</a></font color><br>
 						<u><font color = #787700>Output</font color></u>: \"[C.parameters["message"]]\"<br>
 						</li><br>"}
-					// END AUTOFIX
 
 
 			dat += "</ol>"

--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -143,11 +143,8 @@
 				continue
 			dat += "<li>\ref[T] [T.name] ([T.id])  <a href='?src=\ref[src];unlink=[i]'>\[X\]</a></li>"
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\telecomms\\machine_interactions.dm:140: dat += "</ol>"
 		dat += {"</ol>
 			<h2>Filtering Frequencies:</h2>"}
-		// END AUTOFIX
 		i = 0
 		if(length(freq_listening))
 			dat += "<ul>"
@@ -158,11 +155,8 @@
 			dat += "<li>NONE</li>"
 
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\telecomms\\machine_interactions.dm:155: dat += "<br>  <a href='?src=\ref[src];input=freq'>\[Add Filter\]</a>"
 		dat += {"<p><a href='?src=\ref[src];input=freq'>\[Add Filter\]</a></p>
 			<hr />"}
-		// END AUTOFIX
 
 	return dat
 
@@ -227,11 +221,8 @@
 	if(src.z == TELECOMM_Z)
 		dat += "<br>Signal Locked to Station: <A href='?src=\ref[src];change_listening=1'>[listening_level == STATION_Z ? "TRUE" : "FALSE"]</a>"
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\telecomms\\machine_interactions.dm:236: dat += "<br>Broadcasting: <A href='?src=\ref[src];broadcast=1'>[broadcasting ? "YES" : "NO"]</a>"
 	dat += {"<br>Broadcasting: <A href='?src=\ref[src];broadcast=1'>[broadcasting ? "YES" : "NO"]</a>
 		<br>Receiving:    <A href='?src=\ref[src];receive=1'>[receiving ? "YES" : "NO"]</a>"}
-	// END AUTOFIX
 	return dat
 
 /obj/machinery/telecomms/relay/Options_Topic(href, href_list)

--- a/code/game/machinery/telecomms/telemonitor.dm
+++ b/code/game/machinery/telecomms/telemonitor.dm
@@ -35,21 +35,15 @@
 
 		if(0)
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\telecomms\telemonitor.dm:34: dat += "<br>[temp]<br><br>"
 			dat += {"<br>[temp]<br><br>
 				<br>Current Network: <a href='?src=\ref[src];network=1'>[network]</a><br>"}
-			// END AUTOFIX
 			if(machinelist.len)
 				dat += "<br>Detected Network Entities:<ul>"
 				for(var/obj/machinery/telecomms/T in machinelist)
 					dat += "<li><a href='?src=\ref[src];viewmachine=[T.id]'>\ref[T] [T.name]</a> ([T.id])</li>"
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\telecomms\telemonitor.dm:40: dat += "</ul>"
 				dat += {"</ul>
 					<br><a href='?src=\ref[src];operation=release'>\[Flush Buffer\]</a>"}
-				// END AUTOFIX
 			else
 				dat += "<a href='?src=\ref[src];operation=probe'>\[Probe Network\]</a>"
 
@@ -58,14 +52,11 @@
 
 		if(1)
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\telecomms\telemonitor.dm:49: dat += "<br>[temp]<br>"
 			dat += {"<br>[temp]<br>
 				<center><a href='?src=\ref[src];operation=mainmenu'>\[Main Menu\]</a></center>
 				<br>Current Network: [network]<br>
 				Selected Network Entity: [SelectedMachine.name] ([SelectedMachine.id])<br>
 				Linked Entities: <ol>"}
-			// END AUTOFIX
 			for(var/obj/machinery/telecomms/T in SelectedMachine.links)
 				if(!T.hide)
 					dat += "<li><a href='?src=\ref[src];viewmachine=[T.id]'>\ref[T.id] [T.name]</a> ([T.id])</li>"

--- a/code/game/machinery/telecomms/traffic_control.dm
+++ b/code/game/machinery/telecomms/traffic_control.dm
@@ -90,11 +90,8 @@
 	user.set_machine(src)
 	var/dat = "<TITLE>Telecommunication Traffic Control</TITLE><center><b>Telecommunications Traffic Control</b></center>"
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\telecomms\traffic_control.dm:93: dat += "<br><b><font color='[(auth ? "green" : "red")]'>[(auth ? "AUTHED" : "NOT AUTHED")]:</font></b> <A href='?src=\ref[src];auth=1'>[(!auth ? "Insert ID" : auth.registered_name)]</A><BR>"
 	dat += {"<br><b><font color='[(auth ? "green" : "red")]'>[(auth ? "AUTHED" : "NOT AUTHED")]:</font></b> <A href='?src=\ref[src];auth=1'>[(!auth ? "Insert ID" : auth.registered_name)]</A><BR>
 		<A href='?src=\ref[src];print=1'>View System Log</A><HR>"}
-	// END AUTOFIX
 	if(issilicon(user) || auth)
 
 		switch(screen)
@@ -104,21 +101,15 @@
 
 			if(0)
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\telecomms\traffic_control.dm:104: dat += "<br>[temp]<br>"
 				dat += {"<br>[temp]<br>
 					<br>Current Network: <a href='?src=\ref[src];network=1'>[network]</a><br>"}
-				// END AUTOFIX
 				if(servers.len)
 					dat += "<br>Detected Telecommunication Servers:<ul>"
 					for(var/obj/machinery/telecomms/T in servers)
 						dat += "<li><a href='?src=\ref[src];viewserver=[T.id]'>\ref[T] [T.name]</a> ([T.id])</li>"
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\telecomms\traffic_control.dm:110: dat += "</ul>"
 					dat += {"</ul>
 						<br><a href='?src=\ref[src];operation=release'>\[Flush Buffer\]</a>"}
-					// END AUTOFIX
 				else
 					dat += "<br>No servers detected. Scan for servers: <a href='?src=\ref[src];operation=scan'>\[Scan\]</a>"
 
@@ -128,15 +119,12 @@
 			if(1)
 				if(SelectedServer)
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\telecomms\traffic_control.dm:121: dat += "<br>[temp]<br>"
 					dat += {"<br>[temp]<br>
 						<center><a href='?src=\ref[src];operation=mainmenu'>\[Main Menu\]</a>     <a href='?src=\ref[src];operation=refresh'>\[Refresh\]</a></center>
 						<br>Current Network: [network]
 						<br>Selected Server: [SelectedServer.id]<br><br>
 						<br><a href='?src=\ref[src];operation=editcode'>\[Edit Code\]</a>
 						<br>Signal Execution: "}
-					// END AUTOFIX
 					if(SelectedServer.autoruncode)
 						dat += "<a href='?src=\ref[src];operation=togglerun'>ALWAYS</a>"
 					else

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -597,12 +597,9 @@ var/global/num_vending_terminals = 1
 	if(src.currently_vending)
 		var/dat = "<TT><center><b>[vendorname]</b></center><hr /><br>" //display the name, and added a horizontal rule
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\vending.dm:260: dat += "<b>You have selected [currently_vending.product_name].<br>Please ensure your ID is in your ID holder or hand.</b><br>"
 		dat += {"<b>You have selected [currently_vending.product_name].<br>Please ensure your ID is in your ID holder or hand.</b><br>
 			<a href='byond://?src=\ref[src];buy=1'>Pay</a> |
 			<a href='byond://?src=\ref[src];cancel_buying=1'>Cancel</a>"}
-		// END AUTOFIX
 		user << browse(dat, "window=vending")
 		onclose(user, "")
 		return

--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -564,12 +564,9 @@
 	var/inputs
 	if(r_list)
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\mecha\equipment\tools\\medical_tools.dm:567: inputs += "<input type=\"hidden\" name=\"src\" value=\"\ref[src]\">"
 		inputs += {"<input type=\"hidden\" name=\"src\" value=\"\ref[src]\">
 			<input type=\"hidden\" name=\"select_reagents\" value=\"1\">
 			<input id=\"submit\" type=\"submit\" value=\"Apply settings\">"}
-		// END AUTOFIX
 	var/output = {"<form action="byond://" method="get">
 						[r_list || "No known reagents"]
 						[inputs]

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1482,11 +1482,8 @@
 		for(var/obj/item/mecha_parts/mecha_equipment/W in equipment)
 			output += "[W.name] <a href='?src=\ref[W];detach=1'>Detach</a><br>"
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\mecha\\mecha.dm:1333: output += "<b>Available equipment slots:</b> [max_equip-equipment.len]"
 		output += {"<b>Available equipment slots:</b> [max_equip-equipment.len]
 			</div></div>"}
-		// END AUTOFIX
 	return output
 
 /obj/mecha/proc/get_equipment_list() //outputs mecha equipment list in html
@@ -1529,11 +1526,8 @@
 		if(!a_name) continue //there's some strange access without a name
 		output += "[a_name] - <a href='?src=\ref[src];add_req_access=[a];user=\ref[user];id_card=\ref[id_card]'>Add</a><br>"
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\mecha\\mecha.dm:1376: output += "<hr><a href='?src=\ref[src];finish_req_access=1;user=\ref[user]'>Finish</a> <font color='red'>(Warning! The ID upload panel will be locked. It can be unlocked only through Exosuit Interface.)</font>"
 	output += {"<hr><a href='?src=\ref[src];finish_req_access=1;user=\ref[user]'>Finish</a> <font color='red'>(Warning! The ID upload panel will be locked. It can be unlocked only through Exosuit Interface.)</font>
 		</body></html>"}
-	// END AUTOFIX
 	user << browse(output, "window=exosuit_add_access")
 	onclose(user, "exosuit_add_access")
 	return

--- a/code/game/mecha/mecha_control_console.dm
+++ b/code/game/mecha/mecha_control_console.dm
@@ -35,19 +35,13 @@
 
 	if(screen==1)
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\mecha\\mecha_control_console.dm:33: dat += "<h3>Log contents</h3>"
 		dat += {"<h3>Log contents</h3>
 			<a href='?src=\ref[src];return=1'>Return</a><hr>
 			[stored_data]"}
-		// END AUTOFIX
 
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\mecha\\mecha_control_console.dm:37: dat += "<A href='?src=\ref[src];refresh=1'>(Refresh)</A><BR>"
 	dat += {"<A href='?src=\ref[src];refresh=1'>(Refresh)</A><BR>
 		</body></html>"}
-	// END AUTOFIX
 	user << browse(dat, "window=computer;size=400x500")
 	onclose(user, "computer")
 	return

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -605,28 +605,19 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	if(active_uplink_check(user))
 		return
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\objects\items\\devices\\\pDA\\\pDA.dm:313: var/dat = "<html><head><title>Personal Data Assistant</title></head><body bgcolor=\"#808000\"><style>a, a:link, a:visited, a:active, a:hover { color: #000000; }img {border-style:none;}</style>"
 	var/dat = {"<html><head><title>Personal Data Assistant</title></head><body bgcolor=\"#808000\"><style>a, a:link, a:visited, a:active, a:hover { color: #000000; }img {border-style:none;}</style>
 <a href='byond://?src=\ref[src];choice=Close'><img src=pda_exit.png> Close</a>"}
-	// END AUTOFIX
 	if ((!isnull(cartridge)) && (mode == 0))
 		dat += " | <a href='byond://?src=\ref[src];choice=Eject'><img src=pda_eject.png> Eject [cartridge]</a>"
 	if (mode)
 		dat += " | <a href='byond://?src=\ref[src];choice=Return'><img src=pda_menu.png> Return</a>"
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\objects\items\\devices\\\pDA\\\pDA.dm:321: dat += " | <a href='byond://?src=\ref[src];choice=Refresh'><img src=pda_refresh.png> Refresh</a>"
 	dat += {"| <a href='byond://?src=\ref[src];choice=Refresh'><img src=pda_refresh.png> Refresh</a>
 		<br>"}
-	// END AUTOFIX
 	if (!owner)
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\objects\items\\devices\\\pDA\\\pDA.dm:326: dat += "Warning: No owner information entered.  Please swipe card.<br><br>"
 		dat += {"Warning: No owner information entered.  Please swipe card.<br><br>
 			<a href='byond://?src=\ref[src];choice=Refresh'><img src=pda_refresh.png> Retry</a>"}
-		// END AUTOFIX
 	else
 		switch (mode)
 			if (0)
@@ -635,17 +626,12 @@ var/global/list/obj/item/device/pda/PDAs = list()
 					var/datum/asset/simple/C = new/datum/asset/simple/pda()
 					send_asset_list(user.client, C.assets)
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\objects\items\\devices\\\pDA\\\pDA.dm:331: dat += "<h2>PERSONAL DATA ASSISTANT v.1.3</h2>"
 				dat += {"<h2>PERSONAL DATA ASSISTANT v.1.3</h2>
 					Owner: [owner], [ownjob]<br>"}
-				// END AUTOFIX
 				dat += text("ID: <A href='?src=\ref[src];choice=Authenticate'>[id ? "[id.registered_name], [id.assignment]" : "----------"]")
 				dat += text("<br><A href='?src=\ref[src];choice=UpdateInfo'>[id ? "Update PDA Info" : ""]</A><br><br>")
 
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\objects\items\\devices\\\pDA\\\pDA.dm:336: dat += "Station Time: [worldtime2text()]"//:[world.time / 100 % 6][world.time / 100 % 10]"
 				dat += {"Station Time: [worldtime2text()]
 					<br><br>
 					<h4>General Functions</h4>
@@ -653,7 +639,6 @@ var/global/list/obj/item/device/pda/PDAs = list()
 					<li><a href='byond://?src=\ref[src];choice=1'><img src=pda_notes.png> Notekeeper</a></li>
 					<li><a href='byond://?src=\ref[src];choice=2'><img src=pda_mail.png> Messenger</a></li>
 					<li><a href='byond://?src=\ref[src];choice=50'><img src=pda_clock.png> Current Events</a></li>"}
-				// END AUTOFIX
 				//dat += "<li><a href='byond://?src=[src];choice=chatroom'><img src=pda_chatroom.png> Nanotrasen Relay Chat</a></li>"
 
 				dat += "<li><a href='byond://?src=\ref[src];choice=41'><img src=pda_notes.png> View Crew Manifest</a></li>"
@@ -694,47 +679,32 @@ var/global/list/obj/item/device/pda/PDAs = list()
 
 					if (cartridge.access_medical)
 
-						// AUTOFIXED BY fix_string_idiocy.py
-						// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\objects\items\\devices\\\pDA\\\pDA.dm:360: dat += "<h4>Medical Functions</h4>"
 						dat += {"<h4>Medical Functions</h4>
 							<ul>
 							<li><a href='byond://?src=\ref[src];choice=44'><img src=pda_medical.png> Medical Records</a></li>
 							<li><a href='byond://?src=\ref[src];choice=Medical Scan'><img src=pda_scanner.png> [scanmode == 1 ? "Disable" : "Enable"] Medical Scanner</a></li>
 							</ul>"}
-						// END AUTOFIX
 					if (cartridge.access_security)
 
-						// AUTOFIXED BY fix_string_idiocy.py
-						// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\objects\items\\devices\\\pDA\\\pDA.dm:366: dat += "<h4>Security Functions</h4>"
 						dat += {"<h4>Security Functions</h4>
 							<ul>
 							<li><a href='byond://?src=\ref[src];choice=45'><img src=pda_cuffs.png> Security Records</A></li>"}
-						// END AUTOFIX
 					if(istype(cartridge.radio, /obj/item/radio/integrated/beepsky))
 
-						// AUTOFIXED BY fix_string_idiocy.py
-						// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\objects\items\\devices\\\pDA\\\pDA.dm:370: dat += "<li><a href='byond://?src=\ref[src];choice=46'><img src=pda_cuffs.png> Security Bot Access</a></li>"
 						dat += {"<li><a href='byond://?src=\ref[src];choice=46'><img src=pda_cuffs.png> Security Bot Access</a></li>
 							</ul>"}
-						// END AUTOFIX
 					else	dat += "</ul>"
 					if(cartridge.access_quartermaster)
 
-						// AUTOFIXED BY fix_string_idiocy.py
-						// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\objects\items\\devices\\\pDA\\\pDA.dm:374: dat += "<h4>Quartermaster Functions:</h4>"
 						dat += {"<h4>Quartermaster Functions:</h4>
 							<ul>
 							<li><a href='byond://?src=\ref[src];choice=47'><img src=pda_crate.png> Supply Records</A></li>
 							<li><a href='byond://?src=\ref[src];choice=48'><img src=pda_mule.png> Delivery Bot Control</A></li>
 							</ul>"}
-				// END AUTOFIX
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\objects\items\\devices\\\pDA\\\pDA.dm:379: dat += "</ul>"
 				dat += {"</ul>
 					<h4>Utilities</h4>
 					<ul>"}
-				// END AUTOFIX
 				if (cartridge)
 					if (cartridge.access_janitor)
 						dat += "<li><a href='byond://?src=\ref[src];choice=49'><img src=pda_bucket.png> Custodial Locator</a></li>"
@@ -749,42 +719,30 @@ var/global/list/obj/item/device/pda/PDAs = list()
 					if (cartridge.access_remote_door)
 						dat += "<li><a href='byond://?src=\ref[src];choice=Toggle Door'><img src=pda_rdoor.png> Toggle Remote Door</a></li>"
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\objects\items\\devices\\\pDA\\\pDA.dm:396: dat += "<li><a href='byond://?src=\ref[src];choice=3'><img src=pda_atmos.png> Atmospheric Scan</a></li>"
 				dat += {"<li><a href='byond://?src=\ref[src];choice=3'><img src=pda_atmos.png> Atmospheric Scan</a></li>
 					<li><a href='byond://?src=\ref[src];choice=Light'><img src=pda_flashlight.png> [fon ? "Disable" : "Enable"] Flashlight</a></li>"}
-				// END AUTOFIX
 				if (pai)
 					if(pai.loc != src)
 						pai = null
 					else
 
-						// AUTOFIXED BY fix_string_idiocy.py
-						// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\objects\items\\devices\\\pDA\\\pDA.dm:402: dat += "<li><a href='byond://?src=\ref[src];choice=pai;option=1'>pAI Device Configuration</a></li>"
 						dat += {"<li><a href='byond://?src=\ref[src];choice=pai;option=1'>pAI Device Configuration</a></li>
 							<li><a href='byond://?src=\ref[src];choice=pai;option=2'>Eject pAI Device</a></li>"}
-						// END AUTOFIX
 				dat += "</ul>"
 
 			if (1)
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\objects\items\\devices\\\pDA\\\pDA.dm:407: dat += "<h4><img src=pda_notes.png> Notekeeper V2.1</h4>"
 				dat += {"<h4><img src=pda_notes.png> Notekeeper V2.1</h4>
 					<a href='byond://?src=\ref[src];choice=Edit'> Edit</a><br>"}
-				// END AUTOFIX
 				dat += note
 
 			if (2)
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\objects\items\\devices\\\pDA\\\pDA.dm:412: dat += "<h4><img src=pda_mail.png> SpaceMessenger V3.9.4</h4>"
 				dat += {"<h4><img src=pda_mail.png> SpaceMessenger V3.9.4</h4>
 					<a href='byond://?src=\ref[src];choice=Toggle Ringer'><img src=pda_bell.png> Ringer: [silent == 1 ? "Off" : "On"]</a> |
 					<a href='byond://?src=\ref[src];choice=Toggle Messenger'><img src=pda_mail.png> Send / Receive: [toff == 1 ? "Off" : "On"]</a> |
 					<a href='byond://?src=\ref[src];choice=Ringtone'><img src=pda_bell.png> Set Ringtone</a> |
 					<a href='byond://?src=\ref[src];choice=21'><img src=pda_mail.png> Messages</a><br>"}
-				// END AUTOFIX
 				if (istype(cartridge, /obj/item/weapon/cartridge/syndicate))
 					dat += "<b>[cartridge:shock_charges] detonation charges left.</b><HR>"
 				if (istype(cartridge, /obj/item/weapon/cartridge/clown))
@@ -793,11 +751,8 @@ var/global/list/obj/item/device/pda/PDAs = list()
 					dat += "<b>[cartridge:mime_charges] viral files left.</b><HR>"
 
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\objects\items\\devices\\\pDA\\\pDA.dm:425: dat += "<h4><img src=pda_menu.png> Detected PDAs</h4>"
 				dat += {"<h4><img src=pda_menu.png> Detected PDAs</h4>
 					<ul>"}
-				// END AUTOFIX
 				var/count = 0
 
 				if (!toff)
@@ -821,12 +776,9 @@ var/global/list/obj/item/device/pda/PDAs = list()
 
 			if(21)
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\objects\items\\devices\\\pDA\\\pDA.dm:448: dat += "<h4><img src=pda_mail.png> SpaceMessenger V3.9.4</h4>"
 				dat += {"<h4><img src=pda_mail.png> SpaceMessenger V3.9.4</h4>
 					<a href='byond://?src=\ref[src];choice=Clear'><img src=pda_blank.png> Clear Messages</a>
 					<h4><img src=pda_mail.png> Messages</h4>"}
-				// END AUTOFIX
 				dat += tnote
 				dat += "<br>"
 
@@ -851,13 +803,10 @@ var/global/list/obj/item/device/pda/PDAs = list()
 						var/plasma_level = environment.toxins/total_moles
 						var/unknown_level =  1-(o2_level+n2_level+co2_level+plasma_level)
 
-						// AUTOFIXED BY fix_string_idiocy.py
-						// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\objects\items\\devices\\\pDA\\\pDA.dm:476: dat += "Nitrogen: [round(n2_level*100)]%<br>"
 						dat += {"Nitrogen: [round(n2_level*100)]%<br>
 							Oxygen: [round(o2_level*100)]%<br>
 							Carbon Dioxide: [round(co2_level*100)]%<br>
 							Plasma: [round(plasma_level*100)]%<br>"}
-						// END AUTOFIX
 						if(unknown_level > 0.01)
 							dat += "OTHER: [round(unknown_level)]%<br>"
 					dat += "Temperature: [round(environment.temperature-T0C)]&deg;C<br>"
@@ -865,11 +814,8 @@ var/global/list/obj/item/device/pda/PDAs = list()
 
 			if (5)
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\objects\items\\devices\\\pDA\\\pDA.dm:486: dat += "<h4><img src=pda_chatroom.png> Nanotrasen Relay Chat</h4>"
 				dat += {"<h4><img src=pda_chatroom.png> Nanotrasen Relay Chat</h4>
 					<h4><img src=pda_menu.png> Detected Channels</h4>: <li>"}
-				// END AUTOFIX
 				for(var/datum/chatroom/C in chatrooms)
 					dat += "<a href='byond://?src=\ref[src];pdachannel=[C.name]'>#[html_encode(lowertext(C.name))]"
 					if(C.password != "")
@@ -878,11 +824,8 @@ var/global/list/obj/item/device/pda/PDAs = list()
 
 			if (41) //Allows everyone to access crew
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\objects\items\\devices\\\pDA\cart.dm:281: menu = "<h4><img src=pda_notes.png> Crew Manifest</h4>"
 				dat += {"<h4><img src=pda_notes.png> Crew Manifest</h4>
 					Entries cannot be modified from this terminal.<br><br>"}
-				// END AUTOFIX
 				if(data_core)
 					dat += data_core.get_manifest(1) // make it monochrome
 				dat += "<br>"

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -300,11 +300,8 @@ Code:
 		/*if (41) //crew manifest
 
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\objects\items\\devices\\\pDA\cart.dm:281: menu = "<h4><img src=pda_notes.png> Crew Manifest</h4>"
 			menu = {"<h4><img src=pda_notes.png> Crew Manifest</h4>
 				Entries cannot be modified from this terminal.<br><br>"}
-			// END AUTOFIX
 			if(data_core)
 				menu += data_core.get_manifest(1) // make it monochrome
 			menu += "<br>"*/
@@ -312,8 +309,6 @@ Code:
 
 		if (42) //status displays
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\objects\items\\devices\\\pDA\cart.dm:289: menu = "<h4><img src=pda_status.png> Station Status Display Interlink</h4>"
 			menu = {"<h4><img src=pda_status.png> Station Status Display Interlink</h4>
 				\[ <A HREF='?src=\ref[src];choice=Status;statdisp=blank'>Clear</A> \]<BR>
 				\[ <A HREF='?src=\ref[src];choice=Status;statdisp=shuttle'>Shuttle ETA</A> \]<BR>
@@ -324,7 +319,6 @@ Code:
 				<A HREF='?src=\ref[src];choice=Status;statdisp=alert;alert=redalert'>Red Alert</A> |
 				<A HREF='?src=\ref[src];choice=Status;statdisp=alert;alert=lockdown'>Lockdown</A> |
 				<A HREF='?src=\ref[src];choice=Status;statdisp=alert;alert=biohazard'>Biohazard</A> \]<BR>"}
-			// END AUTOFIX
 		if (43) //Muskets' and Rockdtben's power monitor :D
 			menu = "<h4><img src=pda_power.png> Please select a Power Monitoring Computer</h4><BR>No Power Monitoring Computer detected in the vicinity.<BR>"
 			var/powercount = 0
@@ -357,11 +351,8 @@ Code:
 						L += A
 
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\objects\items\\devices\\\pDA\cart.dm:338: menu += "<PRE>Total power: [powmonitor.powernet.avail] W<BR>Total load:  [num2text(powmonitor.powernet.viewload,10)] W<BR>"
 				menu += {"<PRE>Total power: [powmonitor.powernet.avail] W<BR>Total load:  [num2text(powmonitor.powernet.viewload,10)] W<BR>
 					<FONT SIZE=-1>"}
-				// END AUTOFIX
 				if(L.len > 0)
 					menu += "Area                           Eqp./Lgt./Env.  Load   Cell<HR>"
 
@@ -435,8 +426,6 @@ Code:
 
 			if (istype(active1, /datum/data/record) && (active1 in data_core.general))
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\objects\items\\devices\\\pDA\cart.dm:364: menu += "Name: [active1.fields["name"]] ID: [active1.fields["id"]]<br>"
 				menu += {"Name: [active1.fields["name"]] ID: [active1.fields["id"]]<br>
 					Sex: [active1.fields["sex"]]<br>
 					Age: [active1.fields["age"]]<br>
@@ -444,20 +433,14 @@ Code:
 					Fingerprint: [active1.fields["fingerprint"]]<br>
 					Physical Status: [active1.fields["p_stat"]]<br>
 					Mental Status: [active1.fields["m_stat"]]<br>"}
-				// END AUTOFIX
 			else
 				menu += "<b>Record Lost!</b><br>"
 
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\objects\items\\devices\\\pDA\cart.dm:374: menu += "<br>"
 			menu += {"<br>
 				<h4><img src=pda_medical.png> Medical Data</h4>"}
-			// END AUTOFIX
 			if (istype(active2, /datum/data/record) && (active2 in data_core.medical))
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\objects\items\\devices\\\pDA\cart.dm:378: menu += "Blood Type: [active2.fields["b_type"]]<br><br>"
 				menu += {"Blood Type: [active2.fields["b_type"]]<br><br>
 					Minor Disabilities: [active2.fields["mi_dis"]]<br>
 					Details: [active2.fields["mi_dis_d"]]<br><br>
@@ -468,7 +451,6 @@ Code:
 					Current Diseases: [active2.fields["cdi"]]<br>
 					Details: [active2.fields["cdi_d"]]<br><br>
 					Important Notes: [active2.fields["notes"]]<br>"}
-				// END AUTOFIX
 			else
 				menu += "<b>Record Lost!</b><br>"
 
@@ -485,8 +467,6 @@ Code:
 
 			if (istype(active1, /datum/data/record) && (active1 in data_core.general))
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\objects\items\\devices\\\pDA\cart.dm:408: menu += "Name: [active1.fields["name"]] ID: [active1.fields["id"]]<br>"
 				menu += {"Name: [active1.fields["name"]] ID: [active1.fields["id"]]<br>
 					Sex: [active1.fields["sex"]]<br>
 					Age: [active1.fields["age"]]<br>
@@ -494,20 +474,14 @@ Code:
 					Fingerprint: [active1.fields["fingerprint"]]<br>
 					Physical Status: [active1.fields["p_stat"]]<br>
 					Mental Status: [active1.fields["m_stat"]]<br>"}
-				// END AUTOFIX
 			else
 				menu += "<b>Record Lost!</b><br>"
 
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\objects\items\\devices\\\pDA\cart.dm:418: menu += "<br>"
 			menu += {"<br>
 				<h4><img src=pda_cuffs.png> Security Data</h4>"}
-			// END AUTOFIX
 			if (istype(active3, /datum/data/record) && (active3 in data_core.security))
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\objects\items\\devices\\\pDA\cart.dm:422: menu += "Criminal Status: [active3.fields["criminal"]]<br>"
 				menu += {"Criminal Status: [active3.fields["criminal"]]<br>
 					Minor Crimes: [active3.fields["mi_crim"]]<br>
 					Details: [active3.fields["mi_crim"]]<br><br>
@@ -515,7 +489,6 @@ Code:
 					Details: [active3.fields["ma_crim_d"]]<br><br>
 					Important Notes:<br>
 					[active3.fields["notes"]]"}
-				// END AUTOFIX
 			else
 				menu += "<b>Record Lost!</b><br>"
 
@@ -549,11 +522,8 @@ Code:
 				else
 
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\objects\items\\devices\\\pDA\cart.dm:464: menu += "Location: [SC.botstatus["loca"] ]<BR>"
 					menu += {"Location: [SC.botstatus["loca"] ]<BR>
 						Mode: "}
-					// END AUTOFIX
 					switch(SC.botstatus["mode"])
 						if(0)
 							menu += "Ready"
@@ -569,31 +539,22 @@ Code:
 							menu += "Responding to summons"
 
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\objects\items\\devices\\\pDA\cart.dm:481: menu += "<BR>\[<A href='byond://?src=\ref[SC];op=stop'>Stop Patrol</A>\] "
 					menu += {"<BR>\[<A href='byond://?src=\ref[SC];op=stop'>Stop Patrol</A>\]
 						\[<A href='byond://?src=\ref[SC];op=go'>Start Patrol</A>\]
 						\[<A href='byond://?src=\ref[SC];op=summon'>Summon Bot</A>\]<BR>
 						<HR><A href='byond://?src=\ref[SC];op=botlist'><img src=pda_back.png>Return to bot list</A>"}
-					// END AUTOFIX
 		if (47) //quartermaster order records
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\objects\items\\devices\\\pDA\cart.dm:487: menu = "<h4><img src=pda_crate.png> Supply Record Interlink</h4>"
 			menu = {"<h4><img src=pda_crate.png> Supply Record Interlink</h4>
 				<BR><B>Supply shuttle</B><BR>
 				Location: [supply_shuttle.moving ? "Moving to station ([supply_shuttle.eta] Mins.)":supply_shuttle.at_station ? "Station":"Dock"]<BR>
 				Current approved orders: <BR><ol>"}
-			// END AUTOFIX
 			for(var/S in supply_shuttle.shoppinglist)
 				var/datum/supply_order/SO = S
 				menu += "<li>#[SO.ordernum] - [SO.object.name] approved by [SO.orderedby] [SO.comment ? "([SO.comment])":""]</li>"
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\objects\items\\devices\\\pDA\cart.dm:495: menu += "</ol>"
 			menu += {"</ol>
 				Current requests: <BR><ol>"}
-			// END AUTOFIX
 			for(var/S in supply_shuttle.requestlist)
 				var/datum/supply_order/SO = S
 				menu += "<li>#[SO.ordernum] - [SO.object.name] requested by [SO.orderedby]</li>"
@@ -626,11 +587,8 @@ Code:
 				else
 
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\objects\items\\devices\\\pDA\cart.dm:529: menu += "Location: [QC.botstatus["loca"] ]<BR>"
 					menu += {"Location: [QC.botstatus["loca"] ]<BR>
 						Mode: "}
-					// END AUTOFIX
 					switch(QC.botstatus["mode"])
 						if(0)
 							menu += "Ready"
@@ -648,8 +606,6 @@ Code:
 							menu += "Unable to locate destination"
 					var/obj/structure/closet/crate/C = QC.botstatus["load"]
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\objects\items\\devices\\\pDA\cart.dm:548: menu += "<BR>Current Load: [ !C ? "<i>none</i>" : "[C.name] (<A href='byond://?src=\ref[QC];op=unload'><i>unload</i></A>)" ]<BR>"
 					menu += {"<BR>Current Load: [ !C ? "<i>none</i>" : "[C.name] (<A href='byond://?src=\ref[QC];op=unload'><i>unload</i></A>)" ]<BR>
 						Destination: [!QC.botstatus["dest"] ? "<i>none</i>" : QC.botstatus["dest"] ] (<A href='byond://?src=\ref[QC];op=setdest'><i>set</i></A>)<BR>
 						Power: [QC.botstatus["powr"]]%<BR>
@@ -660,18 +616,14 @@ Code:
 						\[<A href='byond://?src=\ref[QC];op=go'>Proceed</A>\]
 						\[<A href='byond://?src=\ref[QC];op=home'>Return Home</A>\]<BR>
 						<HR><A href='byond://?src=\ref[QC];op=botlist'><img src=pda_back.png>Return to bot list</A>"}
-					// END AUTOFIX
 		if (49) //janitorial locator
 			menu = "<h4><img src=pda_bucket.png> Persistent Custodial Object Locator</h4>"
 
 			var/turf/cl = get_turf(src)
 			if (cl)
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\objects\items\\devices\\\pDA\cart.dm:565: menu += "Current Orbital Location: <b>\[[cl.x],[cl.y]\]</b>"
 				menu += {"Current Orbital Location: <b>\[[cl.x-WORLD_X_OFFSET[cl.z]],[cl.y-WORLD_Y_OFFSET[cl.z]]\]</b>
 					<h4>Located Mops:</h4>"}
-				// END AUTOFIX
 				var/ldat
 				for (var/obj/item/weapon/mop/M in world)
 					var/turf/ml = get_turf(M)

--- a/code/game/objects/items/devices/uplinks.dm
+++ b/code/game/objects/items/devices/uplinks.dm
@@ -26,13 +26,10 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 		job = user.mind.assigned_role
 	var/dat = "<B>[src.welcome]</B><BR>"
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\objects\items\\devices\uplinks.dm:26: dat += "Tele-Crystals left: [src.uses]<BR>"
 	dat += {"Tele-Crystals left: [src.uses]<BR>
 		<HR>
 		<B>Request item:</B><BR>
 		<I>Each item costs a number of tele-crystals as indicated by the number following their name.</I><br><BR>"}
-	// END AUTOFIX
 	var/list/buyable_items = get_uplink_items()
 
 	// Loop through categories
@@ -82,11 +79,8 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 	var/dat = "<body link='yellow' alink='white' bgcolor='#601414'><font color='white'>"
 	dat += src.generate_menu(user)
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\objects\items\\devices\uplinks.dm:72: dat += "<A href='byond://?src=\ref[src];lock=1'>Lock</a>"
 	dat += {"<A href='byond://?src=\ref[src];lock=1'>Lock</a>
 		</font></body>"}
-	// END AUTOFIX
 	user << browse(dat, "window=hidden")
 	onclose(user, "hidden")
 	return

--- a/code/game/objects/items/devices/violin.dm
+++ b/code/game/objects/items/devices/violin.dm
@@ -244,28 +244,19 @@
 	if(song)
 		if(song.lines.len > 0 && !(playing))
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\objects\items\\devices\violin.dm:246: dat += "<A href='?src=\ref[src];play=1'>Play Song</A><BR><BR>"
 			dat += {"<A href='?src=\ref[src];play=1'>Play Song</A><BR><BR>
 				<A href='?src=\ref[src];repeat=1'>Repeat Song: [repeat] times.</A><BR><BR>"}
-			// END AUTOFIX
 		if(playing)
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\objects\items\\devices\violin.dm:249: dat += "<A href='?src=\ref[src];stop=1'>Stop Playing</A><BR>"
 			dat += {"<A href='?src=\ref[src];stop=1'>Stop Playing</A><BR>
 				Repeats left: [repeat].<BR><BR>"}
-			// END AUTOFIX
 	if(!edit)
 		dat += "<A href='?src=\ref[src];edit=2'>Show Editor</A><BR><BR>"
 	else
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\objects\items\\devices\violin.dm:254: dat += "<A href='?src=\ref[src];edit=1'>Hide Editor</A><BR>"
 		dat += {"<A href='?src=\ref[src];edit=1'>Hide Editor</A><BR>
 			<A href='?src=\ref[src];newsong=1'>Start a New Song</A><BR>
 			<A href='?src=\ref[src];import=1'>Import a Song</A><BR><BR>"}
-		// END AUTOFIX
 		if(song)
 			var/calctempo = (10/song.tempo)*60
 			dat += "Tempo : <A href='?src=\ref[src];tempo=10'>-</A><A href='?src=\ref[src];tempo=1'>-</A> [calctempo] BPM <A href='?src=\ref[src];tempo=-1'>+</A><A href='?src=\ref[src];tempo=-10'>+</A><BR><BR>"

--- a/code/game/objects/items/weapons/hydroponics.dm
+++ b/code/game/objects/items/weapons/hydroponics.dm
@@ -80,19 +80,13 @@
 			if(item_quants[O] > 0)
 				var/N = item_quants[O]
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\objects\items\weapons\hydroponics.dm:82: dat += "<FONT color = 'blue'><B>[capitalize(O)]</B>:"
 				dat += {"<FONT color = 'blue'><B>[capitalize(O)]</B>:
 					[N] </font>
 					<a href='byond://?src=\ref[src];vend=[O]'>Vend</A>
 					<br>"}
-				// END AUTOFIX
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\objects\items\weapons\hydroponics.dm:87: dat += "<br><a href='byond://?src=\ref[src];unload=1'>Unload All</A>"
 		dat += {"<br><a href='byond://?src=\ref[src];unload=1'>Unload All</A>
 			</TT>"}
-		// END AUTOFIX
 	user << browse("<HEAD><TITLE>Seedbag Supplies</TITLE></HEAD><TT>[dat]</TT>", "window=seedbag")
 	onclose(user, "seedbag")
 	return

--- a/code/game/objects/items/weapons/implants/implantchair.dm
+++ b/code/game/objects/items/weapons/implants/implantchair.dm
@@ -45,11 +45,8 @@
 		var/dat ="<B>Implanter Status</B><BR>"
 
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\objects\items\weapons\implants\implantchair.dm:47: dat +="<B>Current occupant:</B> [src.occupant ? "<BR>Name: [src.occupant]<BR>Health: [health_text]<BR>" : "<FONT color=red>None</FONT>"]<BR>"
 		dat += {"<B>Current occupant:</B> [src.occupant ? "<BR>Name: [src.occupant]<BR>Health: [health_text]<BR>" : "<FONT color=red>None</FONT>"]<BR>
 			<B>Implants:</B> [src.implant_list.len ? "[implant_list.len]" : "<A href='?src=\ref[src];replenish=1'>Replenish</A>"]<BR>"}
-		// END AUTOFIX
 		if(src.occupant)
 			dat += "[src.ready ? "<A href='?src=\ref[src];implant=1'>Implant</A>" : "Recharging"]<BR>"
 		user.set_machine(src)

--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -271,28 +271,19 @@
 	if(song)
 		if(song.lines.len > 0 && !(playing))
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\objects\structures\\musician.dm:262: dat += "<A href='?src=\ref[src];play=1'>Play Song</A><BR><BR>"
 			dat += {"<A href='?src=\ref[src];play=1'>Play Song</A><BR><BR>
 				<A href='?src=\ref[src];repeat=1'>Repeat Song: [repeat] times.</A><BR><BR>"}
-			// END AUTOFIX
 		if(playing)
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\objects\structures\\musician.dm:265: dat += "<A href='?src=\ref[src];stop=1'>Stop Playing</A><BR>"
 			dat += {"<A href='?src=\ref[src];stop=1'>Stop Playing</A><BR>
 				Repeats left: [repeat].<BR><BR>"}
-			// END AUTOFIX
 	if(!edit)
 		dat += "<A href='?src=\ref[src];edit=2'>Show Editor</A><BR><BR>"
 	else
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\objects\structures\\musician.dm:270: dat += "<A href='?src=\ref[src];edit=1'>Hide Editor</A><BR>"
 		dat += {"<A href='?src=\ref[src];edit=1'>Hide Editor</A><BR>
 			<A href='?src=\ref[src];newsong=1'>Start a New Song</A><BR>
 			<A href='?src=\ref[src];import=1'>Import a Song</A><BR><BR>"}
-		// END AUTOFIX
 		if(song)
 			var/calctempo = (10/song.tempo)*60
 			dat += "Tempo : <A href='?src=\ref[src];tempo=10'>-</A><A href='?src=\ref[src];tempo=1'>-</A> [calctempo] BPM <A href='?src=\ref[src];tempo=-1'>+</A><A href='?src=\ref[src];tempo=-10'>+</A><BR><BR>"

--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -75,11 +75,8 @@ FLOOR SAFES
 /obj/structure/safe/attack_hand(mob/user as mob)
 	user.set_machine(src)
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\objects\structures\safe.dm:77: var/dat = "<center>"
 	var/dat = {"<center>
 <a href='?src=\ref[src];open=1'>[open ? "Close" : "Open"] [src]</a> | <a href='?src=\ref[src];decrement=1'>-</a> [dial * 5] <a href='?src=\ref[src];increment=1'>+</a>"}
-	// END AUTOFIX
 	if(open)
 		dat += "<table>"
 		for(var/i = contents.len, i>=1, i--)

--- a/code/game/objects/structures/tank_dispenser.dm
+++ b/code/game/objects/structures/tank_dispenser.dm
@@ -46,11 +46,8 @@
 	user.set_machine(src)
 	var/dat = "[src]<br><br>"
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\objects\structures\tank_dispenser.dm:38: dat += "Oxygen tanks: [oxygentanks] - [oxygentanks ? "<A href='?src=\ref[src];oxygen=1'>Dispense</A>" : "empty"]<br>"
 	dat += {"Oxygen tanks: [oxygentanks] - [oxygentanks ? "<A href='?src=\ref[src];oxygen=1'>Dispense</A>" : "empty"]<br>
 		Plasma tanks: [plasmatanks] - [plasmatanks ? "<A href='?src=\ref[src];plasma=1'>Dispense</A>" : "empty"]"}
-	// END AUTOFIX
 	user << browse(dat, "window=dispenser")
 	onclose(user, "dispenser")
 	return

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -326,15 +326,12 @@ var/list/mechtoys = list(
 
 		var/obj/item/weapon/paper/manifest/slip = new /obj/item/weapon/paper/manifest(A)
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\supplyshuttle.dm:298: slip.info = "<h3>[command_name()] Shipping Manifest</h3><hr><br>"
 		slip.name = "Shipping Manifest for [SO.orderedby]'s Order"
 		slip.info = {"<h3>[command_name()] Shipping Manifest for [SO.orderedby]'s Order</h3><hr><br>
 			Order #[SO.ordernum]<br>
 			Destination: [station_name]<br>
 			[supply_shuttle.shoppinglist.len] PACKAGES IN THIS SHIPMENT<br>
 			CONTENTS:<br><ul>"}
-		// END AUTOFIX
 		//spawn the stuff, finish generating the manifest while you're at it
 		if(SP.access)
 			A:req_access = list()
@@ -358,11 +355,8 @@ var/list/mechtoys = list(
 
 		//manifest finalisation
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\supplyshuttle.dm:326: slip.info += "</ul><br>"
 		slip.info += {"</ul><br>
 			CHECK CONTENTS AND STAMP BELOW THE LINE TO CONFIRM RECEIPT OF GOODS<hr>"}
-		// END AUTOFIX
 		if (SP.contraband) slip.loc = null	//we are out of blanks for Form #44-D Ordering Illicit Drugs.
 
 	supply_shuttle.shoppinglist.len = 0
@@ -436,23 +430,17 @@ var/list/mechtoys = list(
 			//Request what?
 			last_viewed_group = "categories"
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\supplyshuttle.dm:383: temp = "<b>Supply points: [supply_shuttle.points]</b><BR>"
 			temp = {"<b>Bank account credits: [current_acct ? current_acct.fmtBalance() : "PANIC"]</b><BR>
 				<A href='?src=\ref[src];mainmenu=1'>Main Menu</A><HR><BR><BR>
 				<b>Select a category</b><BR><BR>"}
-			// END AUTOFIX
 			for(var/supply_group_name in all_supply_groups )
 				temp += "<A href='?src=\ref[src];order=[supply_group_name]'>[supply_group_name]</A><BR>"
 		else
 			last_viewed_group = href_list["order"]
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\supplyshuttle.dm:390: temp = "<b>Supply points: [supply_shuttle.points]</b><BR>"
 			temp = {"<b>Bank account credits: [current_acct ? current_acct.fmtBalance() : "PANIC"]</b><BR>
 				<A href='?src=\ref[src];order=categories'>Back to all categories</A><HR><BR><BR>
 				<b>Request from: [last_viewed_group]</b><BR><BR>"}
-			// END AUTOFIX
 			for(var/supply_name in supply_shuttle.supply_packs )
 				var/datum/supply_packs/N = supply_shuttle.supply_packs[supply_name]
 				if(N.hidden || N.contraband || N.group != last_viewed_group) continue								//Have to send the type instead of a reference to
@@ -496,8 +484,6 @@ var/list/mechtoys = list(
 		var/obj/item/weapon/paper/reqform = new /obj/item/weapon/paper(loc)
 		reqform.name = "[P.name] Requisition Form - [idname], [idrank]"
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\supplyshuttle.dm:425: reqform.info += "<h3>[station_name] Supply Requisition Form</h3><hr>"
 		reqform.info += {"<h3>[station_name] Supply Requisition Form</h3><hr>
 			INDEX: #[supply_shuttle.ordernum]<br>
 			REQUESTED BY: [idname]<br>
@@ -506,14 +492,10 @@ var/list/mechtoys = list(
 			SUPPLY CRATE TYPE: [P.name]<br>
 			ACCESS RESTRICTION: [replacetext(get_access_desc(P.access))]<br>
 			CONTENTS:<br>"}
-		// END AUTOFIX
 		reqform.info += P.manifest
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\supplyshuttle.dm:434: reqform.info += "<hr>"
 		reqform.info += {"<hr>
 			STAMP BELOW TO APPROVE THIS REQUISITION:<br>"}
-		// END AUTOFIX
 		reqform.update_icon()	//Fix for appearing blank when printed.
 		reqtime = (world.time + 5) % 1e5
 
@@ -527,11 +509,8 @@ var/list/mechtoys = list(
 		stat_collection.crates_ordered++
 
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\supplyshuttle.dm:447: temp = "Thanks for your request. The cargo team will process it as soon as possible.<BR>"
 		temp = {"Thanks for your request. The cargo team will process it as soon as possible.<BR>
 			<BR><A href='?src=\ref[src];order=[last_viewed_group]'>Back</A> <A href='?src=\ref[src];mainmenu=1'>Main Menu</A>"}
-		// END AUTOFIX
 	else if (href_list["vieworders"])
 		temp = "Current approved orders: <BR><BR>"
 		for(var/S in supply_shuttle.shoppinglist)
@@ -647,22 +626,16 @@ var/list/mechtoys = list(
 			//all_supply_groups
 			//Request what?
 			last_viewed_group = "categories"
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\supplyshuttle.dm:567: temp = "<b>Supply points: [supply_shuttle.points]</b><BR>"
 			temp = {"<b>Available credits: [current_acct ? current_acct.fmtBalance() : "PANIC"]</b><BR>
 				<A href='?src=\ref[src];mainmenu=1'>Main Menu</A><HR><BR><BR>
 				<b>Select a category</b><BR><BR>"}
-			// END AUTOFIX
 			for(var/supply_group_name in all_supply_groups )
 				temp += "<A href='?src=\ref[src];order=[supply_group_name]'>[supply_group_name]</A><BR>"
 		else
 			last_viewed_group = href_list["order"]
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\supplyshuttle.dm:574: temp = "<b>Supply points: [supply_shuttle.points]</b><BR>"
 			temp = {"<b>Available credits: [current_acct ? current_acct.fmtBalance() : "PANIC"]</b><BR>
 				<A href='?src=\ref[src];order=categories'>Back to all categories</A><HR><BR><BR>
 				<b>Request from: [last_viewed_group]</b><BR><BR>"}
-			// END AUTOFIX
 			for(var/supply_name in supply_shuttle.supply_packs )
 				var/datum/supply_packs/N = supply_shuttle.supply_packs[supply_name]
 				if((N.hidden && !hacked) || (N.contraband && !can_order_contraband) || N.group != last_viewed_group) continue								//Have to send the type instead of a reference to
@@ -707,8 +680,6 @@ var/list/mechtoys = list(
 		supply_shuttle.ordernum++
 		var/obj/item/weapon/paper/reqform = new /obj/item/weapon/paper(loc)
 		reqform.name = "[P.name] Requisition Form - [idname], [idrank]"
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\supplyshuttle.dm:618: reqform.info += "<h3>[station_name] Supply Requisition Form</h3><hr>"
 		reqform.info += {"<h3>[station_name] Supply Requisition Form</h3><hr>
 			INDEX: #[supply_shuttle.ordernum]<br>
 			REQUESTED BY: [idname]<br>
@@ -717,13 +688,9 @@ var/list/mechtoys = list(
 			SUPPLY CRATE TYPE: [P.name]<br>
 			ACCESS RESTRICTION: [replacetext(get_access_desc(P.access))]<br>
 			CONTENTS:<br>"}
-		// END AUTOFIX
 		reqform.info += P.manifest
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\supplyshuttle.dm:627: reqform.info += "<hr>"
 		reqform.info += {"<hr>
 			STAMP BELOW TO APPROVE THIS REQUISITION:<br>"}
-		// END AUTOFIX
 		reqform.update_icon()	//Fix for appearing blank when printed.
 		reqtime = (world.time + 5) % 1e5
 		//make our supply_order datum
@@ -733,11 +700,8 @@ var/list/mechtoys = list(
 		O.orderedby = idname
 		O.account = account
 		supply_shuttle.requestlist += O
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\supplyshuttle.dm:640: temp = "Order request placed.<BR>"
 		temp = {"Order request placed.<BR>
 			<BR><A href='?src=\ref[src];order=[last_viewed_group]'>Back</A> | <A href='?src=\ref[src];mainmenu=1'>Main Menu</A> | <A href='?src=\ref[src];confirmorder=[O.ordernum]'>Authorize Order</A>"}
-		// END AUTOFIX
 	else if(href_list["confirmorder"])
 		//Find the correct supply_order datum
 		var/ordernum = text2num(href_list["confirmorder"])
@@ -759,17 +723,11 @@ var/list/mechtoys = list(
 					A.charge(centcom_share,null,"Supply Order #[SO.ordernum] ([P.name])",src.name,dest_name = "CentComm")
 					A.charge(cargo_share,cargo_acct,"Order Tax",src.name)
 					supply_shuttle.shoppinglist += O
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\supplyshuttle.dm:658: temp = "Thanks for your order.<BR>"
 					temp = {"Thanks for your order.<BR>
 						<BR><A href='?src=\ref[src];viewrequests=1'>Back</A> <A href='?src=\ref[src];mainmenu=1'>Main Menu</A>"}
-					// END AUTOFIX
 				else
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\supplyshuttle.dm:661: temp = "Not enough supply points.<BR>"
 					temp = {"Not enough credit.<BR>
 						<BR><A href='?src=\ref[src];viewrequests=1'>Back</A> <A href='?src=\ref[src];mainmenu=1'>Main Menu</A>"}
-					// END AUTOFIX
 				break
 	else if (href_list["vieworders"])
 		temp = "Current approved orders: <BR><BR>"
@@ -795,11 +753,8 @@ var/list/mechtoys = list(
 			temp += "#[SO.ordernum] - [SO.object.name] requested by [SO.orderedby]  [supply_shuttle.moving ? "":supply_shuttle.at_station ? "":"<A href='?src=\ref[src];confirmorder=[SO.ordernum]'>Approve</A> <A href='?src=\ref[src];rreq=[SO.ordernum]'>Remove</A>"]<BR>"
 
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\supplyshuttle.dm:689: temp += "<BR><A href='?src=\ref[src];clearreq=1'>Clear list</A>"
 		temp += {"<BR><A href='?src=\ref[src];clearreq=1'>Clear list</A>
 			<BR><A href='?src=\ref[src];mainmenu=1'>OK</A>"}
-		// END AUTOFIX
 	else if (href_list["rreq"])
 		var/ordernum = text2num(href_list["rreq"])
 		temp = "Invalid Request.<BR>"
@@ -814,11 +769,8 @@ var/list/mechtoys = list(
 	else if (href_list["clearreq"])
 		supply_shuttle.requestlist.len = 0
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\supplyshuttle.dm:705: temp = "List cleared.<BR>"
 		temp = {"List cleared.<BR>
 			<BR><A href='?src=\ref[src];mainmenu=1'>OK</A>"}
-		// END AUTOFIX
 	else if (href_list["mainmenu"])
 		temp = null
 

--- a/code/modules/Economy/Accounts.dm
+++ b/code/modules/Economy/Accounts.dm
@@ -97,8 +97,6 @@ var/global/list/all_money_accounts = list()
 		P.wrapped = R
 		R.name = "Account information: [M.owner_name]"
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\WorkInProgress\Cael_Aislinn\Economy\Accounts.dm:94: R.info = "<b>Account details (confidential)</b><br><hr><br>"
 		R.info = {"<b>Account details (confidential)</b><br><hr><br>
 			<i>Account holder:</i> [M.owner_name]<br>
 			<i>Account number:</i> [M.account_number]<br>
@@ -107,7 +105,6 @@ var/global/list/all_money_accounts = list()
 			<i>Date and time:</i> [worldtime2text()], [current_date_string]<br><br>
 			<i>Creation terminal ID:</i> [source_db.machine_id]<br>
 			<i>Authorised NT officer overseeing creation:</i> [source_db.held_card.registered_name]<br>"}
-		// END AUTOFIX
 		//stamp the paper
 		var/image/stampoverlay = image('icons/obj/bureaucracy.dmi')
 		stampoverlay.icon_state = "paper_stamp-cent"
@@ -200,22 +197,14 @@ var/global/list/all_money_accounts = list()
 	if(ishuman(user) && !user.stat && get_dist(src,user) <= 1)
 		var/dat = "<b>Accounts Database</b><br>"
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\WorkInProgress\Cael_Aislinn\Economy\Accounts.dm:171: dat += "<i>[machine_id]</i><br>"
 		dat += {"<i>[machine_id]</i><br>
 			Confirm identity: <a href='?src=\ref[src];choice=insert_card'>[held_card ? held_card : "-----"]</a><br>"}
-		// END AUTOFIX
 		if(access_level > 0)
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\WorkInProgress\Cael_Aislinn\Economy\Accounts.dm:175: dat += "<a href='?src=\ref[src];toggle_activated=1'>[activated ? "Disable" : "Enable"] remote access</a><br>"
 			dat += {"<a href='?src=\ref[src];toggle_activated=1'>[activated ? "Disable" : "Enable"] remote access</a><br>
 				You may not edit accounts at this terminal, only create and view them.<br>"}
-			// END AUTOFIX
 			if(creating_new_account)
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\WorkInProgress\Cael_Aislinn\Economy\Accounts.dm:178: dat += "<br>"
 				dat += {"<br>
 					<a href='?src=\ref[src];choice=view_accounts_list;'>Return to accounts list</a>
 					<form name='create_account' action='?src=\ref[src]' method='get'>
@@ -227,12 +216,9 @@ var/global/list/all_money_accounts = list()
 					<b>Ensure that the station account has enough money to create the account, or it will not be created</b>
 					<input type='submit' value='Create'><br>
 					</form>"}
-				// END AUTOFIX
 			else
 				if(detailed_account_view)
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\WorkInProgress\Cael_Aislinn\Economy\Accounts.dm:190: dat += "<br>"
 					dat += {"<br>
 						<a href='?src=\ref[src];choice=view_accounts_list;'>Return to accounts list</a><hr>
 						<b>Account number:</b> #[detailed_account_view.account_number]<br>
@@ -247,11 +233,8 @@ var/global/list/all_money_accounts = list()
 						<td><b>Value</b></td>
 						<td><b>Source terminal ID</b></td>
 						</tr>"}
-					// END AUTOFIX
 					for(var/datum/transaction/T in detailed_account_view.transaction_log)
 
-						// AUTOFIXED BY fix_string_idiocy.py
-						// C:\Users\Rob\\documents\\\projects\vgstation13\code\WorkInProgress\Cael_Aislinn\Economy\Accounts.dm:205: dat += "<tr>"
 						dat += {"<tr>
 							<td>[T.date]</td>
 							<td>[T.time]</td>
@@ -260,26 +243,19 @@ var/global/list/all_money_accounts = list()
 							<td>$[T.amount]</td>
 							<td>[T.source_terminal]</td>
 							</tr>"}
-						// END AUTOFIX
 					dat += "</table>"
 				else
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\WorkInProgress\Cael_Aislinn\Economy\Accounts.dm:215: dat += "<a href='?src=\ref[src];choice=create_account;'>Create new account</a><br><br>"
 					dat += {"<a href='?src=\ref[src];choice=create_account;'>Create new account</a><br><br>
 						<table border=1 style='width:100%'>"}
-					// END AUTOFIX
 					for(var/i=1, i<=all_money_accounts.len, i++)
 						var/datum/money_account/D = all_money_accounts[i]
 
-						// AUTOFIXED BY fix_string_idiocy.py
-						// C:\Users\Rob\\documents\\\projects\vgstation13\code\WorkInProgress\Cael_Aislinn\Economy\Accounts.dm:219: dat += "<tr>"
 						dat += {"<tr>
 							<td>#[D.account_number]</td>
 							<td>[D.owner_name]</td>
 							<td><a href='?src=\ref[src];choice=view_account_detail;account_index=[i]'>View in detail</a></td>
 							</tr>"}
-						// END AUTOFIX
 					dat += "</table>"
 		user << browse(dat,"window=account_db;size=700x650")
 	else

--- a/code/modules/Economy/EFTPOS.dm
+++ b/code/modules/Economy/EFTPOS.dm
@@ -29,12 +29,9 @@
 	var/obj/item/weapon/paper/R = new(src.loc)
 	R.name = "Reference: [eftpos_name]"
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\WorkInProgress\Cael_Aislinn\Economy\EFTPOS.dm:31: R.info = "<b>[eftpos_name] reference</b><br><br>"
 	R.info = {"<b>[eftpos_name] reference</b><br><br>
 		Access code: [access_code]<br><br>
 		<b>Do not lose or misplace this code.</b><br>"}
-	// END AUTOFIX
 	//stamp the paper
 	var/image/stampoverlay = image('icons/obj/bureaucracy.dmi')
 	stampoverlay.icon_state = "paper_stamp-cent"
@@ -63,33 +60,22 @@
 /obj/item/device/eftpos/attack_self(mob/user as mob)
 	if(get_dist(src,user) <= 1)
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\WorkInProgress\Cael_Aislinn\Economy\EFTPOS.dm:59: var/dat = "<b>[eftpos_name]</b><br>"
 		var/dat = {"<b>[eftpos_name]</b><br>
 <i>This terminal is</i> [machine_id]. <i>Report this code when contacting NanoTrasen IT Support</i><br>"}
-		// END AUTOFIX
 		if(transaction_locked)
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\WorkInProgress\Cael_Aislinn\Economy\EFTPOS.dm:59: dat += "<a href='?src=\ref[src];choice=toggle_lock'>Reset[transaction_paid ? "" : " (authentication required)"]</a><br><br>"
 			dat += {"<a href='?src=\ref[src];choice=toggle_lock'>Reset[transaction_paid ? "" : " (authentication required)"]</a><br><br>
 				Transaction purpose: <b>[transaction_purpose]</b><br>
 				Value: <b>$[transaction_amount]</b><br>
 				Linked account: <b>[linked_account ? linked_account.owner_name : "None"]</b><hr>"}
-			// END AUTOFIX
 			if(transaction_paid)
 				dat += "<i>This transaction has been processed successfully.</i><hr>"
 			else
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\WorkInProgress\Cael_Aislinn\Economy\EFTPOS.dm:67: dat += "<i>Swipe your card below the line to finish this transaction.</i><hr>"
 				dat += {"<i>Swipe your card below the line to finish this transaction.</i><hr>
 					<a href='?src=\ref[src];choice=scan_card'>\[------\]</a>"}
-				// END AUTOFIX
 		else
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\WorkInProgress\Cael_Aislinn\Economy\EFTPOS.dm:70: dat += "<a href='?src=\ref[src];choice=toggle_lock'>Lock in new transaction</a><br><br>"
 			dat += {"<a href='?src=\ref[src];choice=toggle_lock'>Lock in new transaction</a><br><br>
 				Transaction purpose: <a href='?src=\ref[src];choice=trans_purpose'>[transaction_purpose]</a><br>
 				Value: <a href='?src=\ref[src];choice=trans_value'>$[transaction_amount]</a><br>
@@ -97,7 +83,6 @@
 				<a href='?src=\ref[src];choice=change_code'>Change access code</a><br>
 				<a href='?src=\ref[src];choice=change_id'>Change EFTPOS ID</a><br>
 				Scan card to reset access code <a href='?src=\ref[src];choice=reset'>\[------\]</a>"}
-			// END AUTOFIX
 		user << browse(dat,"window=eftpos")
 	else
 		user << browse(null,"window=eftpos")

--- a/code/modules/Economy/Economy_Events_Mundane.dm
+++ b/code/modules/Economy/Economy_Events_Mundane.dm
@@ -119,11 +119,8 @@
 					[random_name(pick(MALE,FEMALE))] at [pick("a society ball","a new opening","a launch","a club")] on [affected_dest.name] yesterday, pundits are shocked."
 				else
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\WorkInProgress\Cael_Aislinn\Economy\Economy_Events_Mundane.dm:119: newMsg.body += "is recovering from plastic surgery in a clinic on [affected_dest.name] for the [pick("second","third","fourth")] time, reportedly having made the decision in response to "
 					newMsg.body += {"is recovering from plastic surgery in a clinic on [affected_dest.name] for the [pick("second","third","fourth")] time, reportedly having made the decision in response to
 						[pick("unkind comments by an ex","rumours started by jealous friends","the decision to be dropped by a major sponsor","a disasterous interview on Tau Ceti Tonight")]."}
-					// END AUTOFIX
 			if(TOURISM)
 				newMsg.body += "Tourists are flocking to [affected_dest.name] after the surprise announcement of [pick("major shopping bargains by a wily retailer",\
 				"a huge new ARG by a popular entertainment company","a secret tour by popular artiste [random_name(pick(MALE,FEMALE))]")]. \

--- a/code/modules/Economy/POS.dm
+++ b/code/modules/Economy/POS.dm
@@ -395,7 +395,6 @@ var/const/POS_HEADER = {"<html>
 		if(POS_SCREEN_SETTINGS) dat += SettingsScreen()
 
 	dat += "</body></html>"
-	// END AUTOFIX
 	user << browse(dat, "window=pos")
 	onclose(user, "pos")
 	return

--- a/code/modules/admin/DB ban/functions.dm
+++ b/code/modules/admin/DB ban/functions.dm
@@ -307,8 +307,6 @@ datum/admins/proc/DB_ban_unban_by_id(var/id)
 	var/output = "<div align='center'><table width='90%'><tr>"
 
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\admin\\dB ban\functions.dm:282: output += "<td width='35%' align='center'>"
 	output += {"<td width='35%' align='center'>
 		<h1>Banning panel</h1>
 		</td>
@@ -330,7 +328,6 @@ datum/admins/proc/DB_ban_unban_by_id(var/id)
 		<tr><td><b>Duration:</b> <input type='text' name='dbbaddduration'></td>
 		<td><b>Job:</b><select name='dbbanaddjob'>
 		<option value=''>--</option>"}
-	// END AUTOFIX
 	for(var/j in get_all_jobs())
 		output += "<option value='[j]'>[j]</option>"
 	for(var/j in nonhuman_positions)
@@ -338,8 +335,6 @@ datum/admins/proc/DB_ban_unban_by_id(var/id)
 	for(var/j in list("traitor","changeling","operative","revolutionary","cultist","wizard"))
 		output += "<option value='[j]'>[j]</option>"
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\admin\\dB ban\functions.dm:309: output += "</select></td></tr></table>"
 	output += {"</select></td></tr></table>
 		<b>Reason:<br></b><textarea name='dbbanreason' cols='50'></textarea><br>
 		<input type='submit' value='Add ban'>
@@ -354,7 +349,6 @@ datum/admins/proc/DB_ban_unban_by_id(var/id)
 		<input type='submit' value='search'>
 		</form>
 		Please note that all jobban bans or unbans are in-effect the following round."}
-	// END AUTOFIX
 	if(adminckey || playerckey)
 
 		var/blcolor = "#ffeeee" //banned light
@@ -363,8 +357,6 @@ datum/admins/proc/DB_ban_unban_by_id(var/id)
 		var/udcolor = "#ddffdd" //unbanned dark
 
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\admin\\dB ban\functions.dm:333: output += "<table width='90%' bgcolor='#e3e3e3' cellpadding='5' cellspacing='0' align='center'>"
 		output += {"<table width='90%' bgcolor='#e3e3e3' cellpadding='5' cellspacing='0' align='center'>
 			<tr>
 			<th width='25%'><b>TYPE</b></th>
@@ -373,7 +365,6 @@ datum/admins/proc/DB_ban_unban_by_id(var/id)
 			<th width='20%'><b>ADMIN</b></th>
 			<th width='15%'><b>OPTIONS</b></th>
 			</tr>"}
-		// END AUTOFIX
 		adminckey = ckey(adminckey)
 		playerckey = ckey(playerckey)
 		var/adminsearch = ""
@@ -425,8 +416,6 @@ datum/admins/proc/DB_ban_unban_by_id(var/id)
 					typedesc = "<b>TEMP OOCBAN</b>"
 
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\admin\\dB ban\functions.dm:388: output += "<tr bgcolor='[dcolor]'>"
 			output += {"<tr bgcolor='[dcolor]'>
 				<td align='center'>[typedesc]</td>
 				<td align='center'><b>[ckey]</b></td>
@@ -437,32 +426,22 @@ datum/admins/proc/DB_ban_unban_by_id(var/id)
 				<tr bgcolor='[lcolor]'>
 				<td align='center' colspan='5'><b>Reason: [(unbanned) ? "" : "(<a href=\"byond://?src=\ref[src];dbbanedit=reason;dbbanid=[banid]\">Edit</a>)"]</b> <cite>\"[reason]\"</cite></td>
 				</tr>"}
-			// END AUTOFIX
 			if(edits)
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\admin\\dB ban\functions.dm:399: output += "<tr bgcolor='[dcolor]'>"
 				output += {"<tr bgcolor='[dcolor]'>
 					<td align='center' colspan='5'><b>EDITS</b></td>
 					</tr>
 					<tr bgcolor='[lcolor]'>
 					<td align='center' colspan='5'><font size='2'>[edits]</font></td>
 					</tr>"}
-				// END AUTOFIX
 			if(unbanned)
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\admin\\dB ban\functions.dm:406: output += "<tr bgcolor='[dcolor]'>"
 				output += {"<tr bgcolor='[dcolor]'>
 					<td align='center' colspan='5' bgcolor=''><b>UNBANNED by admin [unbanckey] on [unbantime]</b></td>
 					</tr>"}
-				// END AUTOFIX
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\admin\\dB ban\functions.dm:409: output += "<tr>"
 			output += {"<tr>
 				<td colspan='5' bgcolor='white'>&nbsp</td>
 				</tr>"}
-			// END AUTOFIX
 
 		output += "</table></div>"
 

--- a/code/modules/admin/NewBan.dm
+++ b/code/modules/admin/NewBan.dm
@@ -187,11 +187,8 @@ var/savefile/Banlist
 		dat += text("<tr><td><A href='?src=[ref];unbanf=[key][id]'>(U)</A><A href='?src=[ref];unbane=[key][id]'>(E)</A> Key: <B>[key]</B></td><td>ComputerID: <B>[id]</B></td><td>IP: <B>[ip]</B></td><td> [expiry]</td><td>(By: [by])</td><td>(Reason: [reason])</td></tr>")
 
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\admin\NewBan.dm:187: dat += "</table>"
 	dat += {"</table>
 		<HR><B>Bans:</B> <FONT COLOR=blue>(U) = Unban , (E) = Edit Ban</FONT> - <FONT COLOR=green>([count] Bans)</FONT><HR><table border=1 rules=all frame=void cellspacing=0 cellpadding=3 >[dat]"}
-	// END AUTOFIX
 	usr << browse(dat, "window=unbanp;size=875x400")
 
 //////////////////////////////////// DEBUG ////////////////////////////////////

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -42,19 +42,13 @@ var/global/floorIsLava = 0
 		return
 
 	checkSessionKey()
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\admin\admin.dm:40: var/body = "<html><head><title>Options for [M.key]</title></head>"
 	var/body = {"<html><head><title>Options for [M.key]</title></head>
 <body>Options panel for <b>[M]</b>"}
-	// END AUTOFIX
 	var/species_description
 	if(M.client)
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\admin\admin.dm:43: body += " played by <b>[M.client]</b> "
 		body += {"played by <b>[M.client]</b>
 			\[<A href='?src=\ref[src];editrights=show'>[M.client.holder ? M.client.holder.rank : "Player"]</A>\]"}
-		// END AUTOFIX
 	if(istype(M, /mob/new_player))
 		body += " <B>Hasn't Entered Game</B> "
 	else
@@ -109,12 +103,9 @@ var/global/floorIsLava = 0
 	if (M.client)
 		if(!istype(M, /mob/new_player))
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\admin\admin.dm:90: body += "<br><br>"
 			body += {"<br><br>
 				<b>Transformation:</b>
 				<br>"}
-			// END AUTOFIX
 			//Monkey
 			if(ismonkey(M))
 				body += "<B>Monkeyized</B> | "

--- a/code/modules/admin/newbanjob.dm
+++ b/code/modules/admin/newbanjob.dm
@@ -215,11 +215,8 @@ var/savefile/Banlistjob
 		dat += text("<tr><td><A href='?src=\ref[src];unjobbanf=[Banlistjob["key"]][Banlistjob["id"]][Banlistjob["rank"]]'>(U)</A> Key: <B>[Banlistjob["key"]] </B>Rank: <B>[Banlistjob["rank"]]</B></td><td> ([Banlistjob["temp"] ? "[GetBanExpjob(Banlistjob["minutes"]) ? GetBanExpjob(Banlistjob["minutes"]) : "Removal pending" ]" : "Permaban"])</td><td>(By: [Banlistjob["bannedby"]])</td><td>(Reason: [Banlistjob["reason"]])</td></tr>")
 
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\admin\newbanjob.dm:216: dat += "</table>"
 	dat += {"</table>
 		<HR><B>Bans:</B> <FONT COLOR=blue>(U) = Unban , </FONT> - <FONT COLOR=green>([count] Bans)</FONT><HR><table border=1 rules=all frame=void cellspacing=0 cellpadding=3 >[dat]"}
-	// END AUTOFIX
 	usr << browse(dat, "window=unbanp;size=875x400")
 
 /*/datum/admins/proc/permjobban(ckey, computerid, reason, bannedby, temp, minutes, rank)

--- a/code/modules/admin/permissionverbs/permissionedit.dm
+++ b/code/modules/admin/permissionverbs/permissionedit.dm
@@ -37,12 +37,9 @@
 
 		/*output += "<tr>"
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\admin\\\permissionverbs\\\permissionedit.dm:39: output += "<td style='text-align:right;'>[adm_ckey] <a class='small' href='?src=\ref[src];editrights=remove;ckey=[adm_ckey]'>\[-\]</a></td>"
 		output += {"<td style='text-align:right;'>[adm_ckey] <a class='small' href='?src=\ref[src];editrights=remove;ckey=[adm_ckey]'>\[-\]</a></td>
 <td><a href='?src=\ref[src];editrights=rank;ckey=[adm_ckey]'>[rank]</a></td>
 <td><a class='small' href='?src=\ref[src];editrights=permissions;ckey=[adm_ckey]'>[rights]</a></font></td>"}
-		// END AUTOFIX
 		output += "</tr>"*/
 
 	output += {"

--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -327,11 +327,8 @@
 	if (!usr.client.holder)
 		return
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\admin\\\player_panel.dm:327: var/dat = "<html><head><title>Player Menu</title></head>"
 	var/dat = {"<html><head><title>Player Menu</title></head>
 <body><table border=1 cellspacing=5><B><tr><th>Name</th><th>Real Name</th><th>Assigned Job</th><th>Key</th><th>Options</th><th>PM</th><th>Traitor?</th></tr></B>"}
-	// END AUTOFIX
 	//add <th>IP:</th> to this if wanting to add back in IP checking
 	//add <td>(IP: [M.lastKnownIP])</td> if you want to know their ip to the lists below
 	var/list/mobs = sortmobs()
@@ -392,12 +389,9 @@
 	if (ticker && ticker.current_state >= GAME_STATE_PLAYING)
 		var/dat = "<html><head><title>Round Status</title></head><body><h1><B>Round Status</B></h1>"
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\admin\\\player_panel.dm:386: dat += "Current Game Mode: <B>[ticker.mode.name]</B><BR>"
 		dat += {"Current Game Mode: <B>[ticker.mode.name]</B><BR>
 			Round Duration: <B>[round(world.time / 36000)]:[add_zero(world.time / 600 % 60, 2)]:[world.time / 100 % 6][world.time / 100 % 10]</B><BR>
 			<B>Emergency shuttle</B><BR>"}
-		// END AUTOFIX
 		if (!emergency_shuttle.online)
 			dat += "<a href='?src=\ref[src];call_shuttle=1'>Call Shuttle</a><br>"
 		else
@@ -405,11 +399,8 @@
 			switch(emergency_shuttle.location)
 				if(0)
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\admin\\\player_panel.dm:395: dat += "ETA: <a href='?src=\ref[src];edit_shuttle_time=1'>[(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]</a><BR>"
 					dat += {"ETA: <a href='?src=\ref[src];edit_shuttle_time=1'>[(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]</a><BR>
 						<a href='?src=\ref[src];call_shuttle=2'>Send Back</a><br>"}
-					// END AUTOFIX
 				if(1)
 					dat += "ETA: <a href='?src=\ref[src];edit_shuttle_time=1'>[(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]</a><BR>"
 		dat += "<a href='?src=\ref[src];delay_round_end=1'>[ticker.delay_end ? "End Round Normally" : "Delay Round End"]</a><br>"
@@ -419,11 +410,8 @@
 				var/mob/M = N.current
 				if(M)
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\admin\\\player_panel.dm:405: dat += "<tr><td><a href='?src=\ref[src];adminplayeropts=\ref[M]'>[M.real_name]</a>[M.client ? "" : " <i>(logged out)</i>"][M.stat == 2 ? " <b><font color=red>(DEAD)</font></b>" : ""]</td>"
 					dat += {"<tr><td><a href='?src=\ref[src];adminplayeropts=\ref[M]'>[M.real_name]</a>[M.client ? "" : " <i>(logged out)</i>"][M.stat == 2 ? " <b><font color=red>(DEAD)</font></b>" : ""]</td>
 						<td><A href='?src=\ref[usr];priv_msg=\ref[M]'>PM</A></td></tr>"}
-					// END AUTOFIX
 				else
 					dat += "<tr><td><i>Nuclear Operative not found!</i></td></tr>"
 			dat += "</table><br><table><tr><td><B>Nuclear Disk(s)</B></td></tr>"
@@ -450,30 +438,21 @@
 					dat += "<tr><td><i>Head Revolutionary not found!</i></td></tr>"
 				else
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\admin\\\player_panel.dm:431: dat += "<tr><td><a href='?src=\ref[src];adminplayeropts=\ref[M]'>[M.real_name]</a> <b>(Leader)</b>[M.client ? "" : " <i>(logged out)</i>"][M.stat == 2 ? " <b><font color=red>(DEAD)</font></b>" : ""]</td>"
 					dat += {"<tr><td><a href='?src=\ref[src];adminplayeropts=\ref[M]'>[M.real_name]</a> <b>(Leader)</b>[M.client ? "" : " <i>(logged out)</i>"][M.stat == 2 ? " <b><font color=red>(DEAD)</font></b>" : ""]</td>
 						<td><A href='?src=\ref[usr];priv_msg=\ref[M]'>PM</A></td></tr>"}
-					// END AUTOFIX
 			for(var/datum/mind/N in ticker.mode.revolutionaries)
 				var/mob/M = N.current
 				if(M)
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\admin\\\player_panel.dm:436: dat += "<tr><td><a href='?src=\ref[src];adminplayeropts=\ref[M]'>[M.real_name]</a>[M.client ? "" : " <i>(logged out)</i>"][M.stat == 2 ? " <b><font color=red>(DEAD)</font></b>" : ""]</td>"
 					dat += {"<tr><td><a href='?src=\ref[src];adminplayeropts=\ref[M]'>[M.real_name]</a>[M.client ? "" : " <i>(logged out)</i>"][M.stat == 2 ? " <b><font color=red>(DEAD)</font></b>" : ""]</td>
 						<td><A href='?src=\ref[usr];priv_msg=\ref[M]'>PM</A></td></tr>"}
-					// END AUTOFIX
 			dat += "</table><table cellspacing=5><tr><td><B>Target(s)</B></td><td></td><td><B>Location</B></td></tr>"
 			for(var/datum/mind/N in ticker.mode.get_living_heads())
 				var/mob/M = N.current
 				if(M)
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\admin\\\player_panel.dm:442: dat += "<tr><td><a href='?src=\ref[src];adminplayeropts=\ref[M]'>[M.real_name]</a>[M.client ? "" : " <i>(logged out)</i>"][M.stat == 2 ? " <b><font color=red>(DEAD)</font></b>" : ""]</td>"
 					dat += {"<tr><td><a href='?src=\ref[src];adminplayeropts=\ref[M]'>[M.real_name]</a>[M.client ? "" : " <i>(logged out)</i>"][M.stat == 2 ? " <b><font color=red>(DEAD)</font></b>" : ""]</td>
 						<td><A href='?src=\ref[usr];priv_msg=\ref[M]'>PM</A></td>"}
-					// END AUTOFIX
 					var/turf/mob_loc = get_turf(M)
 					dat += "<td>[mob_loc.loc]</td></tr>"
 				else
@@ -486,12 +465,9 @@
 				var/mob/M = changeling.current
 				if(M)
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\admin\\\player_panel.dm:455: dat += "<tr><td><a href='?src=\ref[src];adminplayeropts=\ref[M]'>[M.real_name]</a>[M.client ? "" : " <i>(logged out)</i>"][M.stat == 2 ? " <b><font color=red>(DEAD)</font></b>" : ""]</td>"
 					dat += {"<tr><td><a href='?src=\ref[src];adminplayeropts=\ref[M]'>[M.real_name]</a>[M.client ? "" : " <i>(logged out)</i>"][M.stat == 2 ? " <b><font color=red>(DEAD)</font></b>" : ""]</td>
 						<td><A href='?src=\ref[usr];priv_msg=\ref[M]'>PM</A></td>
 						<td><A HREF='?src=\ref[src];traitor=\ref[M]'>Show Objective</A></td></tr>"}
-					// END AUTOFIX
 				else
 					dat += "<tr><td><i>Changeling not found!</i></td></tr>"
 			dat += "</table>"
@@ -502,12 +478,9 @@
 				var/mob/M = wizard.current
 				if(M)
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\admin\\\player_panel.dm:467: dat += "<tr><td><a href='?src=\ref[src];adminplayeropts=\ref[M]'>[M.real_name]</a>[M.client ? "" : " <i>(logged out)</i>"][M.stat == 2 ? " <b><font color=red>(DEAD)</font></b>" : ""]</td>"
 					dat += {"<tr><td><a href='?src=\ref[src];adminplayeropts=\ref[M]'>[M.real_name]</a>[M.client ? "" : " <i>(logged out)</i>"][M.stat == 2 ? " <b><font color=red>(DEAD)</font></b>" : ""]</td>
 						<td><A href='?src=\ref[usr];priv_msg=\ref[M]'>PM</A></td>
 						<td><A HREF='?src=\ref[src];traitor=\ref[M]'>Show Objective</A></td></tr>"}
-					// END AUTOFIX
 				else
 					dat += "<tr><td><i>Wizard not found!</i></td></tr>"
 			dat += "</table>"
@@ -519,12 +492,9 @@
 				var/mob/M = raider.current
 				if(M)
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\admin\\\player_panel.dm:479: dat += "<tr><td><a href='?src=\ref[src];adminplayeropts=\ref[M]'>[M.real_name]</a>[M.client ? "" : " <i>(logged out)</i>"][M.stat == 2 ? " <b><font color=red>(DEAD)</font></b>" : ""]</td>"
 					dat += {"<tr><td><a href='?src=\ref[src];adminplayeropts=\ref[M]'>[M.real_name]</a>[M.client ? "" : " <i>(logged out)</i>"][M.stat == 2 ? " <b><font color=red>(DEAD)</font></b>" : ""]</td>
 						<td><A href='?src=\ref[usr];priv_msg=\ref[M]'>PM</A></td>
 						<td><A HREF='?src=\ref[src];traitor=\ref[M]'>Show Objective</A></td></tr>"}
-					// END AUTOFIX
 			dat += "</table>"
 		*/
 
@@ -535,12 +505,9 @@
 				var/mob/M = ninja.current
 				if(M)
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\admin\\\player_panel.dm:490: dat += "<tr><td><a href='?src=\ref[src];adminplayeropts=\ref[M]'>[M.real_name]</a>[M.client ? "" : " <i>(logged out)</i>"][M.stat == 2 ? " <b><font color=red>(DEAD)</font></b>" : ""]</td>"
 					dat += {"<tr><td><a href='?src=\ref[src];adminplayeropts=\ref[M]'>[M.real_name]</a>[M.client ? "" : " <i>(logged out)</i>"][M.stat == 2 ? " <b><font color=red>(DEAD)</font></b>" : ""]</td>
 						<td><A href='?src=\ref[usr];priv_msg=\ref[M]'>PM</A></td>
 						<td><A HREF='?src=\ref[src];traitor=\ref[M]'>Show Objective</A></td></tr>"}
-					// END AUTOFIX
 				else
 					dat += "<tr><td><i>Ninja not found!</i></td></tr>"
 			dat += "</table>"
@@ -552,12 +519,9 @@
 				var/mob/M = N.current
 				if(M)
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\admin\\\player_panel.dm:503: dat += "<tr><td><a href='?src=\ref[src];adminplayeropts=\ref[M]'>[M.real_name]</a>[M.client ? "" : " <i>(logged out)</i>"][M.stat == 2 ? " <b><font color=red>(DEAD)</font></b>" : ""]</td>"
 					dat += {"<tr><td><a href='?src=\ref[src];adminplayeropts=\ref[M]'>[M.real_name]</a>[M.client ? "" : " <i>(logged out)</i>"][M.stat == 2 ? " <b><font color=red>(DEAD)</font></b>" : ""]</td>
 						<td><A href='?src=\ref[usr];priv_msg=\ref[M]'>PM</A></td>
 						<td><A href='?src=\ref[src];cult_privatespeak=\ref[M]'>Nar-Speak</A></td></tr>"}
-					// END AUTOFIX
 			dat += "</table>"
 
 			var/living_crew = 0
@@ -607,11 +571,8 @@
 				var/mob/M = N.current
 				if(M)
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\admin\\\player_panel.dm:512: dat += "<tr><td><a href='?src=\ref[src];adminplayeropts=\ref[M]'>[M.real_name]</a>[M.client ? "" : " <i>(logged out)</i>"][M.stat == 2 ? " <b><font color=red>(DEAD)</font></b>" : ""]</td>"
 					dat += {"<tr><td><a href='?src=\ref[src];adminplayeropts=\ref[M]'>[M.real_name]</a>[M.client ? "" : " <i>(logged out)</i>"][M.stat == 2 ? " <b><font color=red>(DEAD)</font></b>" : ""]</td>
 						<td><A href='?src=\ref[usr];priv_msg=\ref[M]'>PM</A></td></tr>"}
-					// END AUTOFIX
 			dat += "</table>"
 */
 
@@ -621,12 +582,9 @@
 				var/mob/M = vampire.current
 				if(M)
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\admin\\\player_panel.dm:521: dat += "<tr><td><a href='?src=\ref[src];adminplayeropts=\ref[M]'>[M.real_name]</a>[M.client ? "" : " <i>(logged out)</i>"][M.stat == 2 ? " <b><font color=red>(DEAD)</font></b>" : ""]</td>"
 					dat += {"<tr><td><a href='?src=\ref[src];adminplayeropts=\ref[M]'>[M.real_name]</a>[M.client ? "" : " <i>(logged out)</i>"][M.stat == 2 ? " <b><font color=red>(DEAD)</font></b>" : ""]</td>
 						<td><A href='?src=\ref[usr];priv_msg=\ref[M]'>PM</A></td>
 						<td><A HREF='?src=\ref[src];traitor=\ref[M]'>Show Objective</A></td></tr>"}
-					// END AUTOFIX
 				else
 					dat += "<tr><td><i>Vampire not found!</i></td></tr>"
 
@@ -636,12 +594,9 @@
 				var/mob/M = Mind.current
 				if(M)
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\admin\\\player_panel.dm:521: dat += "<tr><td><a href='?src=\ref[src];adminplayeropts=\ref[M]'>[M.real_name]</a>[M.client ? "" : " <i>(logged out)</i>"][M.stat == 2 ? " <b><font color=red>(DEAD)</font></b>" : ""]</td>"
 					dat += {"<tr><td><a href='?src=\ref[src];adminplayeropts=\ref[M]'>[M.real_name]</a>[M.client ? "" : " <i>(logged out)</i>"][M.stat == 2 ? " <b><font color=red>(DEAD)</font></b>" : ""]</td>
 						<td><A href='?src=\ref[usr];priv_msg=\ref[M]'>PM</A></td>
 						<td><A HREF='?src=\ref[src];traitor=\ref[M]'>Show Objective</A></td></tr>"}
-					// END AUTOFIX
 				else
 					dat += "<tr><td><i>Enthralled not found!</i></td></tr>"
 
@@ -651,12 +606,9 @@
 				var/mob/M = traitor.current
 				if(M)
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\admin\\\player_panel.dm:521: dat += "<tr><td><a href='?src=\ref[src];adminplayeropts=\ref[M]'>[M.real_name]</a>[M.client ? "" : " <i>(logged out)</i>"][M.stat == 2 ? " <b><font color=red>(DEAD)</font></b>" : ""]</td>"
 					dat += {"<tr><td><a href='?src=\ref[src];adminplayeropts=\ref[M]'>[M.real_name]</a>[M.client ? "" : " <i>(logged out)</i>"][M.stat == 2 ? " <b><font color=red>(DEAD)</font></b>" : ""]</td>
 						<td><A href='?src=\ref[usr];priv_msg=\ref[M]'>PM</A></td>
 						<td><A HREF='?src=\ref[src];traitor=\ref[M]'>Show Objective</A></td></tr>"}
-					// END AUTOFIX
 				else
 					dat += "<tr><td><i>Traitor not found!</i></td></tr>"
 			dat += "</table>"
@@ -664,20 +616,14 @@
 		if(istype(ticker.mode, /datum/game_mode/blob))
 			var/datum/game_mode/blob/mode = ticker.mode
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\admin\\\player_panel.dm:530: dat += "<br><table cellspacing=5><tr><td><B>Blob</B></td><td></td><td></td></tr>"
 			dat += {"<br><table cellspacing=5><tr><td><B>Blob</B></td><td></td><td></td></tr>
 				<tr><td><i>Progress: [blobs.len]/[mode.blobwincount]</i></td></tr>"}
-			// END AUTOFIX
 			for(var/datum/mind/blob in mode.infected_crew)
 				var/mob/M = blob.current
 				if(M)
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\admin\\\player_panel.dm:536: dat += "<tr><td><a href='?_src_=holder;adminplayeropts=\ref[M]'>[M.real_name]</a>[M.client ? "" : " <i>(logged out)</i>"][M.stat == 2 ? " <b><font color=red>(DEAD)</font></b>" : ""]</td>"
 					dat += {"<tr><td><a href='?_src_=holder;adminplayeropts=\ref[M]'>[M.real_name]</a>[M.client ? "" : " <i>(logged out)</i>"][M.stat == 2 ? " <b><font color=red>(DEAD)</font></b>" : ""]</td>
 						<td><A href='?priv_msg=\ref[M]'>PM</A></td>"}
-					// END AUTOFIX
 				else
 					dat += "<tr><td><i>Blob not found!</i></td></tr>"
 			dat += "</table>"
@@ -686,11 +632,8 @@
 			for(var/mob/M in mob_list)
 				if(istype(M, /mob/camera/blob))
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\admin\\\player_panel.dm:545: dat += "<tr><td><a href='?_src_=holder;adminplayeropts=\ref[M]'>[M.real_name]</a>[M.client ? "" : " <i>(logged out)</i>"][M.stat == 2 ? " <b><font color=red>(DEAD)</font></b>" : ""]</td>"
 					dat += {"<tr><td><a href='?_src_=holder;adminplayeropts=\ref[M]'>[M.real_name]</a>[M.client ? "" : " <i>(logged out)</i>"][M.stat == 2 ? " <b><font color=red>(DEAD)</font></b>" : ""]</td>
 						<td><A href='?priv_msg=\ref[M]'>PM</A></td>"}
-					// END AUTOFIX
 			dat += "</table>"
 		if(ticker.mode.raiders.len)
 			dat += "<br><table cellspacing=5><tr><td><B>Thralls</B></td><td></td><td></td></tr>"

--- a/code/modules/admin/verbs/check_customitem_activity.dm
+++ b/code/modules/admin/verbs/check_customitem_activity.dm
@@ -7,29 +7,20 @@ var/inactive_keys = "None<br>"
 
 	var/dat = "<b>Inactive players with custom items</b><br>"
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\admin\verbs\check_customitem_activity.dm:9: dat += "<br>"
 	dat += {"<br>
 		The list below contains players with custom items that have not logged
 		in for the past two months, or have not logged in since this system was implemented.
 		This system requires the feedback SQL database to be properly setup and linked.<br>"}
-	// END AUTOFIX
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\admin\verbs\check_customitem_activity.dm:13: dat += "<br>"
 	dat += {"<br>
 		Populating this list is done automatically, but must be manually triggered on a per
 	 round basis. Populating the list may cause a lag spike, so use it sparingly.<br>"}
-	// END AUTOFIX
 	dat += "<hr>"
 	if(checked_for_inactives)
 		dat += inactive_keys
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\admin\verbs\check_customitem_activity.dm:19: dat += "<hr>"
 		dat += {"<hr>
 			This system was implemented on March 1 2013, and the database a few days before that. Root server access is required to add or disable access to specific custom items.<br>"}
-		// END AUTOFIX
 	else
 		dat += "<a href='?src=\ref[src];_src_=holder;populate_inactive_customitems=1'>Populate list (requires an active database connection)</a><br>"
 

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -232,14 +232,11 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 
 	var/t = ""
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\admin\verbs\\debug.dm:145: t+= "Nitrogen : [env.nitrogen]\n"
 	t += {"Nitrogen : [env.nitrogen]
 Oxygen : [env.oxygen]
 Plasma : [env.toxins]
 CO2: [env.carbon_dioxide]
 Pressure: [env.return_pressure()]"}
-	// END AUTOFIX
 	usr.show_message(t, 1)
 	feedback_add_details("admin_verb","ASL") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -123,11 +123,8 @@
 	user.set_machine(src)
 	var/dat = text("<TT><B>Infrared Laser</B>\n<B>Status</B>: []<BR>\n<B>Visibility</B>: []<BR>\n</TT>", (on ? text("<A href='?src=\ref[];state=0'>On</A>", src) : text("<A href='?src=\ref[];state=1'>Off</A>", src)), (src.visible ? text("<A href='?src=\ref[];visible=0'>Visible</A>", src) : text("<A href='?src=\ref[];visible=1'>Invisible</A>", src)))
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\assembly\infrared.dm:117: dat += "<BR><BR><A href='?src=\ref[src];refresh=1'>Refresh</A>"
 	dat += {"<BR><BR><A href='?src=\ref[src];refresh=1'>Refresh</A>
 		<BR><BR><A href='?src=\ref[src];close=1'>Close</A>"}
-	// END AUTOFIX
 	user << browse(dat, "window=infra")
 	onclose(user, "infra")
 	return

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -130,13 +130,10 @@
 	var/dat = text("<TT><B>Proximity Sensor</B>\n[] []:[]\n<A href='?src=\ref[];tp=-30'>-</A> <A href='?src=\ref[];tp=-1'>-</A> <A href='?src=\ref[];tp=1'>+</A> <A href='?src=\ref[];tp=30'>+</A>\n</TT>", (timing ? text("<A href='?src=\ref[];time=0'>Arming</A>", src) : text("<A href='?src=\ref[];time=1'>Not Arming</A>", src)), minute, second, src, src, src, src)
 	dat += text("<BR>Range: <A href='?src=\ref[];range=-1'>-</A> [] <A href='?src=\ref[];range=1'>+</A>", src, range, src)
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\assembly\\\proximity.dm:125: dat += "<BR><A href='?src=\ref[src];scanning=1'>[scanning?"Armed":"Unarmed"]</A> (Movement sensor active when armed!)"
 	dat += {"<BR><A href='?src=\ref[src];scanning=1'>[scanning?"Armed":"Unarmed"]</A> (Movement sensor active when armed!)
 		<BR><BR><A href='?src=\ref[src];set_default_time=1'>After countdown, reset time to [(default_time - default_time%60)/60]:[(default_time % 60)]</A>
 		<BR><BR><A href='?src=\ref[src];refresh=1'>Refresh</A>
 		<BR><BR><A href='?src=\ref[src];close=1'>Close</A>"}
-	// END AUTOFIX
 	user << browse(dat, "window=prox")
 	onclose(user, "prox")
 	return

--- a/code/modules/assembly/timer.dm
+++ b/code/modules/assembly/timer.dm
@@ -76,12 +76,9 @@
 	var/minute = (time - second) / 60
 	var/dat = text("<TT><B>Timing Unit</B>\n[] []:[]\n<A href='?src=\ref[];tp=-30'>-</A> <A href='?src=\ref[];tp=-1'>-</A> <A href='?src=\ref[];tp=1'>+</A> <A href='?src=\ref[];tp=30'>+</A>\n</TT>", (timing ? text("<A href='?src=\ref[];time=0'>Timing</A>", src) : text("<A href='?src=\ref[];time=1'>Not Timing</A>", src)), minute, second, src, src, src, src)
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\assembly\timer.dm:80: dat += "<BR><BR><A href='?src=\ref[src];refresh=1'>Refresh</A>"
 	dat += "<BR><BR><A href='?src=\ref[src];set_default_time=1'>After countdown, reset time to [(default_time - default_time%60)/60]:[(default_time % 60)]</A>"
 	dat += {"<BR><BR><A href='?src=\ref[src];refresh=1'>Refresh</A>
 		<BR><BR><A href='?src=\ref[src];close=1'>Close</A>"}
-	// END AUTOFIX
 	user << browse(dat, "window=timer")
 	onclose(user, "timer")
 	return

--- a/code/modules/awaymissions/bluespaceartillery.dm
+++ b/code/modules/awaymissions/bluespaceartillery.dm
@@ -24,13 +24,10 @@
 	user.set_machine(src)
 	var/dat = "<B>Bluespace Artillery Control:</B><BR>"
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\awaymissions<span class='warning'>spaceartillery.dm:26: dat += </span>"Locked on<BR>"
 	dat += {"Locked on<BR>
 		<B>Charge progress: [reload]/180:</B><BR>
 		<A href='byond://?src=\ref[src];fire=1'>Open Fire</A><BR>
 		Deployment of weapon authorized by <br>Nanotrasen Naval Command<br><br>Remember, friendly fire is grounds for termination of your contract and life.<HR>"}
-	// END AUTOFIX
 	user << browse(dat, "window=scroll")
 	onclose(user, "scroll")
 	return

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -265,8 +265,6 @@ var/const/MAX_SAVE_SLOTS = 8
 	HTML += "<script type='text/javascript'>function setJobPrefRedirect(level, rank) { window.location.href='?_src_=prefs;preference=job;task=input;level=' + level + ';text=' + encodeURIComponent(rank); return false; }</script>"
 
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\client\\\preferences.dm:386: HTML += "<tt><center>"
 	HTML += {"<center>
 		<b>Choose occupation chances</b><br>
 		<div align='center'>Left-click to raise an occupation preference, right-click to lower it.<br><div>
@@ -275,7 +273,6 @@ var/const/MAX_SAVE_SLOTS = 8
 		<table width='100%' cellpadding='1' cellspacing='0'>"}
 
 
-	// END AUTOFIX
 	var/index = -1
 
 	//The job before the current job. I only use this to get the previous jobs color when I'm filling in blank rows.
@@ -318,8 +315,6 @@ var/const/MAX_SAVE_SLOTS = 8
 				HTML += "<span class='dark'>[rank]</span>"
 
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\client\\\preferences.dm:426: HTML += "</td><td width='40%'>"
 		HTML += "</td><td width='40%'>"
 
 
@@ -368,11 +363,8 @@ var/const/MAX_SAVE_SLOTS = 8
 
 	for(var/i = 1, i < (limit - index), i += 1)
 		HTML += "<tr bgcolor='[lastJob.selection_color]'><td width='60%' align='right'>&nbsp</td><td>&nbsp</td></tr>"
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\client\\\preferences.dm:450: HTML += "</td'></tr></table>"
 	HTML += {"</td'></tr></table>
 		</center></table>"}
-	// END AUTOFIX
 	switch(alternate_option)
 		if(GET_RANDOM_JOB)
 			HTML += "<center><br><a href='?_src_=prefs;preference=job;task=random'>Get random job if preferences unavailable</a></center><br>"
@@ -382,11 +374,8 @@ var/const/MAX_SAVE_SLOTS = 8
 			HTML += "<center><br><a href='?_src_=prefs;preference=job;task=random'>Return to lobby if preference unavailable</a></center><br>"
 
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\client\\\preferences.dm:462: HTML += "<center><a href='?_src_=prefs;preference=job;task=reset'>\[Reset\]</a></center>"
 	HTML += {"<center><a href='?_src_=prefs;preference=job;task=reset'>Reset</a></center>
 		</tt>"}
-	// END AUTOFIX
 	user << browse(null, "window=preferences")
 	//user << browse(HTML, "window=mob_occupation;size=[width]x[height]")
 	var/datum/browser/popup = new(user, "mob_occupation", "<div align='center'>Occupation Preferences</div>", width, height)
@@ -451,11 +440,8 @@ var/const/MAX_SAVE_SLOTS = 8
 /datum/preferences/proc/SetDisabilities(mob/user)
 	var/HTML = "<body>"
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\client\\\preferences.dm:474: HTML += "<tt><center>"
 	HTML += {"<tt><center>
 		<b>Choose disabilities</b><ul>"}
-	// END AUTOFIX
 	HTML += ShowDisabilityState(user,DISABILITY_FLAG_NEARSIGHTED,"Needs Glasses")
 	HTML += ShowDisabilityState(user,DISABILITY_FLAG_FAT,        "Obese")
 	HTML += ShowDisabilityState(user,DISABILITY_FLAG_EPILEPTIC,  "Seizures")
@@ -464,13 +450,10 @@ var/const/MAX_SAVE_SLOTS = 8
 	HTML += ShowDisabilityState(user,DISABILITY_FLAG_TOURETTES,   "Tourettes") Still working on it! -Angelite*/
 
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\client\\\preferences.dm:481: HTML += "</ul>"
 	HTML += {"</ul>
 		<a href=\"?_src_=prefs;task=close;preference=disabilities\">\[Done\]</a>
 		<a href=\"?_src_=prefs;task=reset;preference=disabilities\">\[Reset\]</a>
 		</center></tt>"}
-	// END AUTOFIX
 	user << browse(null, "window=preferences")
 	user << browse(HTML, "window=disabil;size=350x300")
 	return
@@ -478,12 +461,9 @@ var/const/MAX_SAVE_SLOTS = 8
 /datum/preferences/proc/SetRecords(mob/user)
 	var/HTML = "<body>"
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\client\\\preferences.dm:492: HTML += "<tt><center>"
 	HTML += {"<tt><center>
 		<b>Set Character Records</b><br>
 		<a href=\"byond://?src=\ref[user];preference=records;task=med_record\">Medical Records</a><br>"}
-	// END AUTOFIX
 	if(length(med_record) <= 40)
 		HTML += "[med_record]"
 	else
@@ -504,12 +484,9 @@ var/const/MAX_SAVE_SLOTS = 8
 		HTML += "[copytext(sec_record, 1, 37)]...<br>"
 
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\client\\\preferences.dm:516: HTML += "<br>"
 	HTML += {"<br>
 		<a href=\"byond://?src=\ref[user];preference=records;records=-1\">\[Done\]</a>
 		</center></tt>"}
-	// END AUTOFIX
 	user << browse(null, "window=preferences")
 	user << browse(HTML, "window=records;size=350x300")
 	return
@@ -1378,10 +1355,7 @@ NOTE:  The change will take effect AFTER any current recruiting periods."}
 		message_admins("Error #: [q.Error()] - [q.ErrorMsg()]")
 		warning("Error #:[q.Error()] - [q.ErrorMsg()]")
 		return 0
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\client\\\preferences.dm:1283: var/dat = "<body>"
 	var/dat = {"<body><tt><center>"}
-	// END AUTOFIX
 	dat += "<b>Select a character slot to load</b><hr>"
 	var/counter = 1
 	while(counter <= MAX_SAVE_SLOTS)
@@ -1394,12 +1368,9 @@ NOTE:  The change will take effect AFTER any current recruiting periods."}
 				dat += "<a href='?_src_=prefs;preference=changeslot;num=[counter];'>[name_list[counter]]</a><br>"
 		counter++
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\client\\\preferences.dm:1228: dat += "<hr>"
 	dat += {"<hr>
 		<a href='byond://?src=\ref[user];preference=close_load_dialog'>Close</a><br>
 		</center></tt>"}
-	// END AUTOFIX
 	user << browse(dat, "window=saves;size=300x390")
 
 /datum/preferences/proc/close_load_dialog(mob/user)

--- a/code/modules/detectivework/detective_work.dm
+++ b/code/modules/detectivework/detective_work.dm
@@ -111,11 +111,8 @@ var/const/FINGERPRINT_COMPLETE = 6	//This is the output of the stringpercent(pri
 			if(scanning)
 				if(scan_process)
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\detectiveWork\\detective_work.dm:111: dat += "Scan Object: {[scanning.name]}<br>"
 					dat += {"Scan Object: {[scanning.name]}<br>
 						<a href='?src=\ref[src];operation=cancel'>{Cancel Scan}</a> {Print}<br>"}
-					// END AUTOFIX
 				else
 					if(isai) dat += "Scan Object: {[scanning.name]}<br>"
 					else dat += "Scan Object: <a href='?src=\ref[src];operation=eject'>{[scanning.name]}</a><br>"
@@ -125,11 +122,8 @@ var/const/FINGERPRINT_COMPLETE = 6	//This is the output of the stringpercent(pri
 				else dat += "<a href='?src=\ref[src];operation=insert'>{No Object Inserted}</a><br>"
 				dat += "{Scan} <a href='?src=\ref[src];operation=print'>{Print}</a><br>"
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\detectiveWork\\detective_work.dm:121: dat += "<a href='?src=\ref[src];operation=database'>{Access Database}</a><br><br>"
 			dat += {"<a href='?src=\ref[src];operation=database'>{Access Database}</a><br><br>
 				<tt>[scan_data]</tt>"}
-			// END AUTOFIX
 			if(scan_data && !scan_process)
 				dat += "<br><a href='?src=\ref[src];operation=erase'>{Erase Data}</a>"
 	user << browse(dat,"window=scanner")
@@ -204,11 +198,8 @@ var/const/FINGERPRINT_COMPLETE = 6	//This is the output of the stringpercent(pri
 			else
 				if(files && files.len)
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\detectiveWork\\detective_work.dm:195: temp = "<b>Criminal Evidence Database</b><br><br>"
 					temp = {"<b>Criminal Evidence Database</b><br><br>
 						Consolidated data points:<br>"}
-					// END AUTOFIX
 					for(var/print in files)
 						var/list/file = files[print]
 						temp += "<a href='?src=\ref[src];operation=record;identifier=[print]'>{[file[2]]}</a><br>"
@@ -217,11 +208,8 @@ var/const/FINGERPRINT_COMPLETE = 6	//This is the output of the stringpercent(pri
 					temp = ""
 				if(misc && misc.len)
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\detectiveWork\\detective_work.dm:204: temp += "<b>Auxiliary Evidence Database</b><br><br>"
 					temp += {"<b>Auxiliary Evidence Database</b><br><br>
 						This is where anything without fingerprints goes.<br><br>"}
-					// END AUTOFIX
 					for(var/atom in misc)
 						var/list/data_entry = misc[atom]
 						temp += "<a href='?src=\ref[src];operation=auxiliary;identifier=[atom]'>{[data_entry[3]]}</a><br>"
@@ -236,11 +224,8 @@ var/const/FINGERPRINT_COMPLETE = 6	//This is the output of the stringpercent(pri
 					else
 						to_chat(usr, "Illegal or blank name.")
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\detectiveWork\\detective_work.dm:219: temp = "<b>Criminal Evidence Database</b><br><br>"
 				temp = {"<b>Criminal Evidence Database</b><br><br>
 					Consolidated data points: [dossier[2]]<br>"}
-				// END AUTOFIX
 				var/print_string = "Fingerprints: Print not complete!<br>"
 				if(stringpercent(dossier[1]) <= FINGERPRINT_COMPLETE)
 					print_string = "Fingerprints: (80% or higher completion reached)<br>[dossier[1]]<br>"
@@ -252,12 +237,9 @@ var/const/FINGERPRINT_COMPLETE = 6	//This is the output of the stringpercent(pri
 					var/list/outputs = dossier[object]
 					var/list/prints = outputs[1]
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\detectiveWork\\detective_work.dm:231: temp += "<big><b>Object:</b> [outputs[4]]</big><br>"
 					temp += {"<big><b>Object:</b> [outputs[4]]</big><br>
 						&nbsp<b>Fingerprints:</b><br>
 						&nbsp;&nbsp;&nbsp;&nbsp;[prints.len] Unique fingerprints found.<br>"}
-					// END AUTOFIX
 					var/complete_prints = 0
 					for(var/print in prints)
 						if(stringpercent(prints[print]) <= FINGERPRINT_COMPLETE)
@@ -278,12 +260,9 @@ var/const/FINGERPRINT_COMPLETE = 6	//This is the output of the stringpercent(pri
 						for(var/named in blood)
 							temp += "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Type: [blood[named]], DNA: [named]<br>"
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\detectiveWork\\detective_work.dm:253: temp += "<br><a href='?src=\ref[src];operation=record;identifier=[href_list["identifier"]];ren=true'>{Rename this Dossier}</a>"
 				temp += {"<br><a href='?src=\ref[src];operation=record;identifier=[href_list["identifier"]];ren=true'>{Rename this Dossier}</a>
 					<br><a href='?src=\ref[src];operation=database;delete_record=[href_list["identifier"]]'>{Delete this Dossier}</a>
 					<br><a href='?src=\ref[src];operation=databaseprint;identifier=[href_list["identifier"]]'>{Print}</a>"}
-				// END AUTOFIX
 			else
 				temp = "ERROR.  Database not found!<br>"
 			temp += "<br><a href='?src=\ref[src];operation=database'>{Return}</a>"
@@ -294,11 +273,8 @@ var/const/FINGERPRINT_COMPLETE = 6	//This is the output of the stringpercent(pri
 				P.name = "\improper Database File ([dossier[2]])"
 				P.overlays += "paper_words"
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\detectiveWork\\detective_work.dm:265: P.info = "<b>Criminal Evidence Database</b><br><br>"
 				P.info = {"<b>Criminal Evidence Database</b><br><br>
 					Consolidated data points: [dossier[2]]<br>"}
-				// END AUTOFIX
 				var/print_string = "Fingerprints: Print not complete!<br>"
 				if(stringpercent(dossier[1]) <= FINGERPRINT_COMPLETE)
 					print_string = "Fingerprints: (80% or higher completion reached)<br>[dossier[1]]<br>"
@@ -310,12 +286,9 @@ var/const/FINGERPRINT_COMPLETE = 6	//This is the output of the stringpercent(pri
 					var/list/outputs = dossier[object]
 					var/list/prints = outputs[1]
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\detectiveWork\\detective_work.dm:277: P.info += "<big><b>Object:</b> [outputs[4]]</big><br>"
 					P.info += {"<big><b>Object:</b> [outputs[4]]</big><br>
 						&nbsp<b>Fingerprints:</b><br>
 						&nbsp;&nbsp;&nbsp;&nbsp;[prints.len] Unique fingerprints found.<br>"}
-					// END AUTOFIX
 					var/complete_prints = 0
 					for(var/print in prints)
 						if(stringpercent(prints[print]) <= FINGERPRINT_COMPLETE)
@@ -346,11 +319,8 @@ var/const/FINGERPRINT_COMPLETE = 6	//This is the output of the stringpercent(pri
 				var/list/prints = outputs[4]
 				if(prints)
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\detectiveWork\\detective_work.dm:309: temp += "&nbsp<b>Fingerprints:</b><br>"
 					temp += {"&nbsp<b>Fingerprints:</b><br>
 						&nbsp;&nbsp;&nbsp;&nbsp;[prints.len] Unique fingerprints found.<br>"}
-					// END AUTOFIX
 					var/complete_prints = 0
 					for(var/print in prints)
 						if(stringpercent(prints[print]) <= FINGERPRINT_COMPLETE)
@@ -371,11 +341,8 @@ var/const/FINGERPRINT_COMPLETE = 6	//This is the output of the stringpercent(pri
 					for(var/named in blood)
 						temp += "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Type: [blood[named]], DNA: [named]<br>"
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\detectiveWork\\detective_work.dm:330: temp += "<br><a href='?src=\ref[src];operation=database;delete_aux=[href_list["identifier"]]'>{Delete This Record}</a>"
 				temp += {"<br><a href='?src=\ref[src];operation=database;delete_aux=[href_list["identifier"]]'>{Delete This Record}</a>
 					<br><a href='?src=\ref[src];operation=auxiliaryprint;identifier=[href_list["identifier"]]'>{Print}</a>"}
-				// END AUTOFIX
 			else
 				temp = "ERROR.  Database not found!<br>"
 			temp += "<br><a href='?src=\ref[src];operation=database'>{Return}</a>"
@@ -386,19 +353,13 @@ var/const/FINGERPRINT_COMPLETE = 6	//This is the output of the stringpercent(pri
 				P.name = "\improper Auxiliary Database File ([outputs[3]])"
 				P.overlays += "paper_words"
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\detectiveWork\\detective_work.dm:341: P.info = "<b>Auxiliary Evidence Database</b><br><br>"
 				P.info = {"<b>Auxiliary Evidence Database</b><br><br>
 					<big><b>Consolidated data points:</b> [outputs[3]]</big><br>"}
-				// END AUTOFIX
 				var/list/prints = outputs[4]
 				if(prints)
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\detectiveWork\\detective_work.dm:345: P.info += "&nbsp<b>Fingerprints:</b><br>"
 					P.info += {"&nbsp<b>Fingerprints:</b><br>
 						&nbsp;&nbsp;&nbsp;&nbsp;[prints.len] Unique fingerprints found.<br>"}
-					// END AUTOFIX
 					var/complete_prints = 0
 					for(var/print in prints)
 						if(stringpercent(prints[print]) <= FINGERPRINT_COMPLETE)

--- a/code/modules/events/money_spam.dm
+++ b/code/modules/events/money_spam.dm
@@ -70,10 +70,7 @@
 					"Men of all species report AMAZING increases in length, width and stamina.")
 				if(5)
 					sender = pick("Dr", "Crown prince", "King Regent", "Professor", "Captain")
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\events\\money_spam.dm:69: sender += " " + pick("Robert","Alfred","Josephat","Kingsley","Sehi","Zbahi")
 					sender += " [pick("Robert", "Alfred", "Josephat", "Kingsley", "Sehi", "Zbahi")] [pick("Mugawe", "Nkem", "Gbatokwia", "Nchekwube", "Ndim", "Ndubisi")]"
-					// END AUTOFIX
 					message = pick("YOUR FUND HAS BEEN MOVED TO [pick("Salusa", "Segunda", "Cepheus", "Andromeda", "Gruis", "Corona", "Aquila", "Asellus")] DEVELOPMENTARY BANK FOR ONWARD REMITTANCE.", \
 					"We are happy to inform you that due to the delay, we have been instructed to IMMEDIATELY deposit all funds into your account", \
 					"Dear fund beneficiary, We have please to inform you that overdue funds payment has finally been approved and released for payment", \

--- a/code/modules/library/computers/checkout.dm
+++ b/code/modules/library/computers/checkout.dm
@@ -35,8 +35,6 @@
 		if(0)
 			// Main Menu
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\library\lib_machines.dm:141: dat += "<A href='?src=\ref[src];switchscreen=1'>1. View General Inventory</A><BR>"
 			dat += {"<ol>
 				<li><A href='?src=\ref[src];switchscreen=1'>View General Inventory</A></li>
 				<li><A href='?src=\ref[src];switchscreen=2'>View Checked Out Inventory</A></li>
@@ -45,7 +43,6 @@
 				<li><A href='?src=\ref[src];switchscreen=5'>Upload New Title to Archive</A></li>
 				<li><A href='?src=\ref[src];switchscreen=6'>Print a Bible</A></li>
 				<li><A href='?src=\ref[src];switchscreen=7'>Print a Manual</A></li>"}
-			// END AUTOFIX
 			if(src.emagged)
 				dat += "<li><A href='?src=\ref[src];switchscreen=8'>Access the Forbidden Lore Vault</A></li>"
 			dat += "</ol>"
@@ -77,17 +74,12 @@
 				else
 					timedue = round(timedue)
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\library\lib_machines.dm:175: dat += "\"[b.bookname]\", Checked out to: [b.mobname]<BR>--- Taken: [timetaken] minutes ago, Due: in [timedue] minutes<BR>"
 				dat += {"\"[b.bookname]\", Checked out to: [b.mobname]<BR>--- Taken: [timetaken] minutes ago, Due: in [timedue] minutes<BR>
 					<A href='?src=\ref[src];checkin=\ref[b]'>(Check In)</A><BR><BR>"}
-				// END AUTOFIX
 			dat += "<A href='?src=\ref[src];switchscreen=0'>(Return to main menu)</A><BR>"
 		if(3)
 			// Check Out a Book
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\library\lib_machines.dm:180: dat += "<h3>Check Out a Book</h3><BR>"
 			dat += {"<h3>Check Out a Book</h3><BR>
 				Book: [src.buffer_book]
 				<A href='?src=\ref[src];editbook=1'>\[Edit\]</A><BR>
@@ -98,7 +90,6 @@
 				(Checkout Period: [checkoutperiod] minutes) (<A href='?src=\ref[src];increasetime=1'>+</A>/<A href='?src=\ref[src];decreasetime=1'>-</A>)
 				<A href='?src=\ref[src];checkout=1'>(Commit Entry)</A><BR>
 				<A href='?src=\ref[src];switchscreen=0'>(Return to main menu)</A><BR>"}
-			// END AUTOFIX
 		if(4)
 			dat += "<h3>External Archive</h3>"
 			if(!dbcon_old.IsConnected())
@@ -106,8 +97,6 @@
 			else
 				num_results = src.get_num_results()
 				num_pages = Ceiling(num_results/LIBRARY_BOOKS_PER_PAGE)
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\library\lib_machines.dm:196: dat += "<A href='?src=\ref[src];orderbyid=1'>(Order book by SS<sup>13</sup>BN)</A><BR><BR>"
 				dat += {"<ul>
 					<li><A href='?src=\ref[src];id=-1'>(Order book by SS<sup>13</sup>BN)</A></li>
 				</ul>"}
@@ -164,20 +153,14 @@
 				dat += "<FONT color=red>No data found in scanner memory.</FONT><BR>"
 			else
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\library\lib_machines.dm:222: dat += "<TT>Data marked for upload...</TT><BR>"
 				dat += {"<TT>Data marked for upload...</TT><BR>
 					<TT>Title: </TT>[scanner.cache.name]<BR>"}
-				// END AUTOFIX
 				if(!scanner.cache.author)
 					scanner.cache.author = "Anonymous"
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\library\lib_machines.dm:226: dat += "<TT>Author: </TT><A href='?src=\ref[src];setauthor=1'>[scanner.cache.author]</A><BR>"
 				dat += {"<TT>Author: </TT><A href='?src=\ref[src];setauthor=1'>[scanner.cache.author]</A><BR>
 					<TT>Category: </TT><A href='?src=\ref[src];setcategory=1'>[upload_category]</A><BR>
 					<A href='?src=\ref[src];upload=1'>\[Upload\]</A><BR>"}
-				// END AUTOFIX
 			dat += "<A href='?src=\ref[src];switchscreen=0'>(Return to main menu)</A><BR>"
 		if(7)
 			dat += "<H3>Print a Manual</H3>"
@@ -204,8 +187,6 @@
 
 		if(8)
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\library\lib_machines.dm:231: dat += "<h3>Accessing Forbidden Lore Vault v 1.3</h3>"
 			dat += {"<h3>Accessing Forbidden Lore Vault v 1.3</h3>
 				Are you absolutely sure you want to proceed? EldritchTomes Inc. takes no responsibilities for loss of sanity resulting from this action.<p>
 				<A href='?src=\ref[src];arccheckout=1'>Yes.</A><BR>

--- a/code/modules/library/computers/public.dm
+++ b/code/modules/library/computers/public.dm
@@ -13,14 +13,11 @@
 	switch(screenstate)
 		if(0)
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\library\lib_machines.dm:40: dat += "<h2>Search Settings</h2><br />"
 			dat += {"<h2>Search Settings</h2><br />
 				<A href='?src=\ref[src];settitle=1'>Filter by Title: [query.title]</A><br />
 				<A href='?src=\ref[src];setcategory=1'>Filter by Category: [query.category]</A><br />
 				<A href='?src=\ref[src];setauthor=1'>Filter by Author: [query.author]</A><br />
 				<A href='?src=\ref[src];search=1'>\[Start Search\]</A><br />"}
-			// END AUTOFIX
 		if(1)
 			establish_old_db_connection()
 			if(!dbcon_old.IsConnected())
@@ -36,8 +33,6 @@
 										<input type='text' name='pagenum' value='[page_num]' maxlength="5" size="5">
 										<input type='submit' value='Jump To Page'>
 							</form>"}
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\library\lib_machines.dm:52: dat += "<table>"
 				dat += {"<table border=\"0\">
 					<tr>
 						<td>Author</td>
@@ -45,7 +40,6 @@
 						<td>Category</td>
 						<td>SS<sup>13</sup>BN</td>
 					</tr>"}
-				// END AUTOFIX
 				for(var/datum/cachedbook/CB in get_page(page_num))
 					dat += {"<tr>
 						<td>[CB.author]</td>

--- a/code/modules/medical/computer/cloning.dm
+++ b/code/modules/medical/computer/cloning.dm
@@ -112,11 +112,8 @@
 
 	var/dat = "<h3>Cloning System Control</h3>"
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\computer\cloning.dm:168: dat += "<font size=-1><a href='byond://?src=\ref[src];refresh=1'>Refresh</a></font>"
 	dat += {"<font size=-1><a href='byond://?src=\ref[src];refresh=1'>Refresh</a></font>
 		<br><tt>[temp]</tt><br>"}
-	// END AUTOFIX
 	switch(src.menu)
 		if(1)
 			// Modules
@@ -156,40 +153,28 @@
 
 			// Database
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\computer\cloning.dm:210: dat += "<h4>Database Functions</h4>"
 			dat += {"<h4>Database Functions</h4>
 				<a href='byond://?src=\ref[src];menu=2'>View Records</a><br>"}
-			// END AUTOFIX
 			if (src.diskette)
 				dat += "<a href='byond://?src=\ref[src];disk=eject'>Eject Disk</a>"
 
 
 		if(2)
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\computer\cloning.dm:217: dat += "<h4>Current records</h4>"
 			dat += {"<h4>Current records</h4>
 				<a href='byond://?src=\ref[src];menu=1'>Back</a><br><ul>"}
-			// END AUTOFIX
 			for(var/datum/dna2/record/R in src.records)
 				dat += "<li><a href='byond://?src=\ref[src];view_rec=\ref[R]'>[R.dna.real_name && R.dna.real_name != "" ? R.dna.real_name : "Unknown"]</a></li>"
 
 		if(3)
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\computer\cloning.dm:223: dat += "<h4>Selected Record</h4>"
 			dat += {"<h4>Selected Record</h4>
 				<a href='byond://?src=\ref[src];menu=2'>Back</a><br>"}
-			// END AUTOFIX
 			if (!src.active_record)
 				dat += "<font color=red>ERROR: Record not found.</font>"
 			else
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\computer\cloning.dm:229: dat += "<br><font size=1><a href='byond://?src=\ref[src];del_rec=1'>Delete Record</a></font><br>"
 				dat += {"<br><font size=1><a href='byond://?src=\ref[src];del_rec=1'>Delete Record</a></font><br>
 					<b>Name:</b> [src.active_record.dna.real_name && src.active_record.dna.real_name != "" ? src.active_record.dna.real_name : "Unknown"]<br>"}
-				// END AUTOFIX
 				var/obj/item/weapon/implant/health/H = null
 				if(src.active_record.implant)
 					H=locate(src.active_record.implant)
@@ -201,14 +186,11 @@
 
 				if (!isnull(src.diskette))
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\computer\cloning.dm:240: dat += "<a href='byond://?src=\ref[src];disk=load'>Load from disk.</a>"
 					dat += {"<a href='byond://?src=\ref[src];disk=load'>Load from disk.</a>
 						| Save: <a href='byond://?src=\ref[src];save_disk=ue'>UI + UE</a>
 						| Save: <a href='byond://?src=\ref[src];save_disk=ui'>UI</a>
 						| Save: <a href='byond://?src=\ref[src];save_disk=se'>SE</a>
 						<br>"}
-					// END AUTOFIX
 				else
 					dat += "<br>" //Keeping a line empty for appearances I guess.
 
@@ -224,13 +206,10 @@
 			if (!src.active_record)
 				src.menu = 2
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\game\\machinery\computer\cloning.dm:258: dat = "[src.temp]<br>"
 			dat = {"[src.temp]<br>
 				<h4>Confirm Record Deletion</h4>
 				<b><a href='byond://?src=\ref[src];del_rec=1'>Scan card to confirm.</a></b><br>
 				<b><a href='byond://?src=\ref[src];menu=3'>No</a></b>"}
-			// END AUTOFIX
 	user << browse(dat, "window=cloning")
 	onclose(user, "cloning")
 	return

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -442,11 +442,8 @@
 							criminal = R.fields["criminal"]
 
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\mob\living\carbon\human\examine.dm:411: msg += "<span class = 'deptradio'>Criminal status:</span> <a href='?src=\ref[src];criminal=1'>\[[criminal]\]</a>\n"
 			msg += {"<span class = 'deptradio'>Criminal status:</span> <a href='?src=\ref[src];criminal=1'>\[[criminal]\]</a>
 <span class = 'deptradio'>Security records:</span> <a href='?src=\ref[src];secrecord=`'>\[View\]</a>  <a href='?src=\ref[src];secrecordadd=`'>\[Add comment\]</a>\n"}
-			// END AUTOFIX
 	if(hasHUD(user,"medical"))
 		var/perpname = "wot"
 		var/medical = "None"
@@ -467,11 +464,8 @@
 						medical = R.fields["p_stat"]
 
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\mob\living\carbon\human\examine.dm:433: msg += "<span class = 'deptradio'>Physical status:</span> <a href='?src=\ref[src];medical=1'>\[[medical]\]</a>\n"
 		msg += {"<span class = 'deptradio'>Physical status:</span> <a href='?src=\ref[src];medical=1'>\[[medical]\]</a>\n
 			<span class = 'deptradio'>Medical records:</span> <a href='?src=\ref[src];medrecord=`'>\[View\]</a> <a href='?src=\ref[src];medrecordadd=`'>\[Add comment\]</a>\n"}
-		// END AUTOFIX
 	if(print_flavor_text()) msg += "[print_flavor_text()]\n"
 
 	msg += "*---------*</span>"

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -262,11 +262,8 @@ var/list/ai_list = list()
 /mob/living/silicon/ai/proc/ai_alerts()
 
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\mob\living\silicon\ai\ai.dm:195: var/dat = "<HEAD><TITLE>Current Station Alerts</TITLE><META HTTP-EQUIV='Refresh' CONTENT='10'></HEAD><BODY>\n"
 	var/dat = {"<HEAD><TITLE>Current Station Alerts</TITLE><META HTTP-EQUIV='Refresh' CONTENT='10'></HEAD><BODY>\n
 <A HREF='?src=\ref[src];mach_close=aialerts'>Close</A><BR><BR>"}
-	// END AUTOFIX
 	for (var/cat in alarms)
 		dat += text("<B>[]</B><BR>\n", cat)
 		var/list/L = alarms[cat]

--- a/code/modules/mob/living/silicon/mommi/examine.dm
+++ b/code/modules/mob/living/silicon/mommi/examine.dm
@@ -2,10 +2,7 @@
 
 	var/msg = "<span class='info'>*---------*\nThis is \icon[src] \a <EM>[src]</EM>!\n"
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\mob\living\silicon\\mommi\examine.dm:10: msg += "<p>It's like a crab, but it has a utility tool on one arm and a crude metal claw on the other.  That, and you doubt it'd survive in an ocean for very long.</p>"
 	msg += {"<p>It's like a crab, but it has a utility tool on one arm and a crude metal claw on the other.  That, and you doubt it'd survive in an ocean for very long.</p><span class='warning'>"}
-	// END AUTOFIX
 	if (src.getBruteLoss())
 		if (src.getBruteLoss() < 75)
 			msg += "It looks slightly dented.\n"

--- a/code/modules/mob/living/silicon/pai/recruit.dm
+++ b/code/modules/mob/living/silicon/pai/recruit.dm
@@ -125,8 +125,6 @@ var/datum/paiController/paiController			// Global handler for pAI candidates
 				"}
 
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\mob\living\silicon\\\pai\recruit.dm:123: dat += "<p class=\"top\">Please configure your pAI personality's options. Remember, what you enter here could determine whether or not the user requesting a personality chooses you!</p>"
 		dat += {"<p class=\"top\">Please configure your pAI personality's options. Remember, what you enter here could determine whether or not the user requesting a personality chooses you!</p>
 			<table>
 			<tr class=\"d0\"><td>Name:</td><td>[candidate.name]</td></tr>
@@ -142,7 +140,6 @@ var/datum/paiController/paiController			// Global handler for pAI candidates
 			<h3><a href='byond://?src=\ref[src];option=submit;new=1;candidate=\ref[candidate]'>Submit Personality</a></h3><br>
 			<a href='byond://?src=\ref[src];option=save;new=1;candidate=\ref[candidate]'>Save Personality</a><br>
 			<a href='byond://?src=\ref[src];option=load;new=1;candidate=\ref[candidate]'>Load Personality</a><br>"}
-		// END AUTOFIX
 		M << browse(dat, "window=paiRecruit")
 
 	proc/findPAI(var/obj/item/device/paicard/p, var/mob/user)
@@ -177,21 +174,15 @@ var/datum/paiController/paiController			// Global handler for pAI candidates
 				</style>
 				"}
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\mob\living\silicon\\\pai\recruit.dm:177: dat += "<p class=\"top\">Requesting AI personalities from central database... If there are no entries, or if a suitable entry is not listed, check again later as more personalities may be added.</p>"
 		dat += {"<p class=\"top\">Requesting AI personalities from central database... If there are no entries, or if a suitable entry is not listed, check again later as more personalities may be added.</p>
 			<table>"}
-		// END AUTOFIX
 		for(var/datum/paiCandidate/c in available)
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\mob\living\silicon\\\pai\recruit.dm:182: dat += "<tr class=\"d0\"><td>Name:</td><td>[c.name]</td></tr>"
 			dat += {"<tr class=\"d0\"><td>Name:</td><td>[c.name]</td></tr>
 				<tr class=\"d1\"><td>Description:</td><td>[c.description]</td></tr>
 				<tr class=\"d0\"><td>Preferred Role:</td><td>[c.role]</td></tr>
 				<tr class=\"d1\"><td>OOC Comments:</td><td>[c.comments]</td></tr>
 				<tr class=\"d2\"><td><a href='byond://?src=\ref[src];download=1;candidate=\ref[c];device=\ref[p]'>\[Download [c.name]\]</a></td><td></td></tr>"}
-			// END AUTOFIX
 
 		dat += "</table>"
 

--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -326,12 +326,9 @@
 	dat += "<A href='byond://?src=\ref[src];software=refresh'>Refresh</A><br>"
 	// Built-in
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\mob\living\silicon\\\pai\software.dm:283: dat += "<A href='byond://?src=\ref[src];software=directives'>Directives</A><br>"
 	dat += {"<A href='byond://?src=\ref[src];software=directives'>Directives</A><br>
 		<A href='byond://?src=\ref[src];software=radio;sub=0'>Radio Configuration</A><br>
 		<A href='byond://?src=\ref[src];software=image'>Screen Display</A><br>"}
-	// END AUTOFIX
 	//dat += "Text Messaging <br>"
 	dat += "<br>"
 
@@ -583,22 +580,16 @@
 			var/plasma_level = environment.toxins/total_moles
 			var/unknown_level =  1-(o2_level+n2_level+co2_level+plasma_level)
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\mob\living\silicon\\\pai\software.dm:547: dat += "Nitrogen: [round(n2_level*100)]%<br>"
 			dat += {"Nitrogen: [round(n2_level*100)]%<br>
 				Oxygen: [round(o2_level*100)]%<br>
 				Carbon Dioxide: [round(co2_level*100)]%<br>
 				Plasma: [round(plasma_level*100)]%<br>"}
-			// END AUTOFIX
 			if(unknown_level > 0.01)
 				dat += "OTHER: [round(unknown_level)]%<br>"
 		dat += "Temperature: [round(environment.temperature-T0C)]&deg;C<br>"
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\mob\living\silicon\\\pai\software.dm:554: dat += "<a href='byond://?src=\ref[src];software=atmosensor;sub=0'>Refresh Reading</a> <br>"
 	dat += {"<a href='byond://?src=\ref[src];software=atmosensor;sub=0'>Refresh Reading</a> <br>
 		<br>"}
-	// END AUTOFIX
 	return dat
 
 /mob/living/silicon/pai/proc/softwareDoor()
@@ -713,15 +704,9 @@ Target Machine: "}
 		for (var/obj/item/device/pda/P in sortNames(PDAs))
 			if (!P.owner||P.toff||P == src.pda||P.hidden)	continue
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\mob\living\silicon\\\pai\software.dm:642: dat += "<li><a href='byond://?src=\ref[src];software=pdamessage;target=\ref[P]'>[P]</a>"
 			dat += {"<li><a href='byond://?src=\ref[src];software=pdamessage;target=\ref[P]'>[P]</a>
 				</li>"}
-			// END AUTOFIX
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\mob\living\silicon\\\pai\software.dm:644: dat += "</ul>"
 	dat += {"</ul>
 		<br><br>
 		Messages: <hr> [pda.tnote]"}
-	// END AUTOFIX
 	return dat

--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -1,9 +1,6 @@
 /mob/living/silicon/robot/examine(mob/user)
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\mob\living\silicon\robot\examine.dm:9: var/msg = "<span class='info'>*---------*\nThis is \icon[src] \a <EM>[src]</EM>[custom_name ? ", [modtype] [braintype]" : ""]!\n"
 	var/msg = {"<span class='info'>*---------*\nThis is \icon[src] \a <EM>[src]</EM>[custom_name ? ", [modtype] [braintype]" : ""]!\n
 <span class='warning'>"}
-	// END AUTOFIX
 	if (src.getBruteLoss())
 		if (src.getBruteLoss() < 75)
 			msg += "It looks slightly dented.\n"

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -446,11 +446,8 @@
 /mob/living/silicon/robot/proc/robot_alerts()
 
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\mob\living\silicon\robot\robot.dm:322: var/dat = "<HEAD><TITLE>Current Station Alerts</TITLE><META HTTP-EQUIV='Refresh' CONTENT='10'></HEAD><BODY>\n"
 	var/dat = {"<HEAD><TITLE>Current Station Alerts</TITLE><META HTTP-EQUIV='Refresh' CONTENT='10'></HEAD><BODY>\n
 <A HREF='?src=\ref[src];mach_close=robotalerts'>Close</A><BR><BR>"}
-	// END AUTOFIX
 	for (var/cat in alarms)
 		dat += text("<B>[cat]</B><BR>\n")
 		var/list/L = alarms[cat]

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -243,14 +243,11 @@ var/global/obj/screen/fuckstat/FUCK = new
 
 	var/t = "<span class='notice'> Coordinates: [x],[y] \n</span>"
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\mob\\mob.dm:25: t+= "<span class='warning'> Temperature: [environment.temperature] \n"
 	t += {"<span class='warning'> Temperature: [environment.temperature] \n</span>
 <span class='notice'> Nitrogen: [environment.nitrogen] \n</span>
 <span class='notice'> Oxygen: [environment.oxygen] \n</span>
 <span class='notice'> Plasma : [environment.toxins] \n</span>
 <span class='notice'> Carbon Dioxide: [environment.carbon_dioxide] \n</span>"}
-	// END AUTOFIX
 	for(var/datum/gas/trace_gas in environment.trace_gases)
 		to_chat(usr, "<span class='notice'> [trace_gas.type]: [trace_gas.moles] \n</span>")
 

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -24,22 +24,16 @@
 /mob/new_player/proc/new_player_panel_proc()
 	var/output = "<div align='center'><B>New Player Options</B>"
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\mob\new_player\new_player.dm:28: output +="<hr>"
 	output += {"<hr>
 		<p><a href='byond://?src=\ref[src];show_preferences=1'>Setup Character</A></p>"}
-	// END AUTOFIX
 	if(!ticker || ticker.current_state <= GAME_STATE_PREGAME)
 		if(!ready)	output += "<p><a href='byond://?src=\ref[src];ready=1'>Declare Ready</A></p>"
 		else	output += "<p><b>You are ready</b> (<a href='byond://?src=\ref[src];ready=2'>Cancel</A>)</p>"
 
 	else
 		ready = 0 // prevent setup character issues
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\mob\new_player\new_player.dm:36: output += "<a href='byond://?src=\ref[src];manifest=1'>View the Crew Manifest</A><br><br>"
 		output += {"<a href='byond://?src=\ref[src];manifest=1'>View the Crew Manifest</A><br><br>
 			<p><a href='byond://?src=\ref[src];late_join=1'>Join Game!</A></p>"}
-		// END AUTOFIX
 
 	output += "<p><a href='byond://?src=\ref[src];observe=1'>Observe</A></p>"
 
@@ -402,11 +396,8 @@
 	var/hours = mills / 36000
 
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\mob\new_player\new_player.dm:322: var/dat = "<html><body><center>"
 	var/dat = {"<html><body><center>
 Round Duration: [round(hours)]h [round(mins)]m<br>"}
-	// END AUTOFIX
 	if(emergency_shuttle) //In case Nanotrasen decides reposess CentComm's shuttles.
 		if(emergency_shuttle.direction == 2) //Shuttle is going to centcomm, not recalled
 			dat += "<font color='red'><b>The station has been evacuated.</b></font><br>"
@@ -496,11 +487,8 @@ Round Duration: [round(hours)]h [round(mins)]m<br>"}
 /mob/new_player/proc/ViewManifest()
 
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\mob\new_player\new_player.dm:410: var/dat = "<html><body>"
 	var/dat = {"<html><body>
 <h4>Crew Manifest</h4>"}
-	// END AUTOFIX
 	dat += data_core.get_manifest(OOC = 1)
 
 	src << browse(dat, "window=manifest;size=370x420;can_close=1")

--- a/code/modules/mob/new_player/poll.dm
+++ b/code/modules/mob/new_player/poll.dm
@@ -17,8 +17,6 @@
 /mob/new_player/proc/privacy_poll()
 	var/output = "<div align='center'><B>Player poll</B>"
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\mob\new_player\\\poll.dm:19: output +="<hr>"
 	output += {"<hr>
 		<b>We would like to expand our stats gathering.</b>
 		<br>This however involves gathering data about player behavior, play styles, unique player numbers, play times, etc. Data like that cannot be gathered fully anonymously, which is why we're asking you how you'd feel if player-specific data was gathered. Prior to any of this actually happening, a privacy policy will be discussed, but before that can begin, we'd preliminarily like to know how you feel about the concept.
@@ -35,7 +33,6 @@
 		<p><a href='byond://?src=\ref[src];privacy_poll=abstain'>Don't ask again</A>
 		<br>Only pick this if you are fine with whatever option wins.
 		</div>"}
-	// END AUTOFIX
 	src << browse(output,"window=privacypoll;size=600x500")
 	return
 
@@ -54,11 +51,8 @@
 		select_query.Execute()
 
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\mob\new_player\\\poll.dm:56: var/output = "<div align='center'><B>Player polls</B>"
 		var/output = {"<div align='center'><B>Player polls</B>
 <hr>"}
-		// END AUTOFIX
 		var/pollid
 		var/pollquestion
 
@@ -131,21 +125,15 @@
 
 				var/output = "<div align='center'><B>Player poll</B>"
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\mob\new_player\\\poll.dm:133: output +="<hr>"
 				output += {"<hr>
 					<b>Question: [pollquestion]</b><br>
 					<font size='2'>Poll runs from <b>[pollstarttime]</b> until <b>[pollendtime]</b></font><p>"}
-				// END AUTOFIX
 				if(!voted)	//Only make this a form if we have not voted yet
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\mob\new_player\\\poll.dm:138: output += "<form name='cardcomp' action='?src=\ref[src]' method='get'>"
 					output += {"<form name='cardcomp' action='?src=\ref[src]' method='get'>
 						<input type='hidden' name='src' value='\ref[src]'>
 						<input type='hidden' name='votepollid' value='[pollid]'>
 						<input type='hidden' name='votetype' value='OPTION'>"}
-					// END AUTOFIX
 
 				output += "<table><tr><td>"
 				for(var/datum/polloption/O in options)
@@ -161,11 +149,8 @@
 
 				if(!voted)	//Only make this a form if we have not voted yet
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\mob\new_player\\\poll.dm:156: output += "<p><input type='submit' value='Vote'>"
 					output += {"<p><input type='submit' value='Vote'>
 						</form>"}
-					// END AUTOFIX
 
 				output += "</div>"
 
@@ -186,16 +171,11 @@
 
 				var/output = "<div align='center'><B>Player poll</B>"
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\mob\new_player\\\poll.dm:177: output +="<hr>"
 				output += {"<hr>
 					<b>Question: [pollquestion]</b><br>
 					<font size='2'>Feedback gathering runs from <b>[pollstarttime]</b> until <b>[pollendtime]</b></font><p>"}
-				// END AUTOFIX
 				if(!voted)	//Only make this a form if we have not voted yet
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\mob\new_player\\\poll.dm:182: output += "<form name='cardcomp' action='?src=\ref[src]' method='get'>"
 					output += {"<form name='cardcomp' action='?src=\ref[src]' method='get'>
 						<input type='hidden' name='src' value='\ref[src]'>
 						<input type='hidden' name='votepollid' value='[pollid]'>
@@ -211,7 +191,6 @@
 						<input type='hidden' name='replytext' value='ABSTAIN'>
 						<input type='submit' value='Abstain'>
 						</form>"}
-					// END AUTOFIX
 				else
 					output += "[vote_text]"
 
@@ -224,12 +203,9 @@
 
 				var/output = "<div align='center'><B>Player poll</B>"
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\mob\new_player\\\poll.dm:211: output +="<hr>"
 				output += {"<hr>
 					<b>Question: [pollquestion]</b><br>
 					<font size='2'>Poll runs from <b>[pollstarttime]</b> until <b>[pollendtime]</b></font><p>"}
-				// END AUTOFIX
 				var/voted = 0
 				while(voted_query.NextRow())
 					voted = 1
@@ -241,13 +217,10 @@
 
 				if(!voted)	//Only make this a form if we have not voted yet
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\mob\new_player\\\poll.dm:225: output += "<form name='cardcomp' action='?src=\ref[src]' method='get'>"
 					output += {"<form name='cardcomp' action='?src=\ref[src]' method='get'>
 						<input type='hidden' name='src' value='\ref[src]'>
 						<input type='hidden' name='votepollid' value='[pollid]'>
 						<input type='hidden' name='votetype' value='NUMVAL'>"}
-					// END AUTOFIX
 					var/minid = 999999
 					var/maxid = 0
 
@@ -273,11 +246,8 @@
 							continue
 
 
-						// AUTOFIXED BY fix_string_idiocy.py
-						// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\mob\new_player\\\poll.dm:254: output += "<br>[optiontext]: <select name='o[optionid]'>"
 						output += {"<br>[optiontext]: <select name='o[optionid]'>
 							<option value='abstain'>abstain</option>"}
-						// END AUTOFIX
 						for (var/j = minvalue; j <= maxvalue; j++)
 							if(j == minvalue && descmin)
 								output += "<option value='[j]'>[j] ([descmin])</option>"
@@ -291,13 +261,10 @@
 						output += "</select>"
 
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\mob\new_player\\\poll.dm:268: output += "<input type='hidden' name='minid' value='[minid]'>"
 					output += {"<input type='hidden' name='minid' value='[minid]'>
 						<input type='hidden' name='maxid' value='[maxid]'>
 						<p><input type='submit' value='Submit'>
 						</form>"}
-					// END AUTOFIX
 				src << browse(output,"window=playerpoll;size=500x500")
 			if("MULTICHOICE")
 				var/DBQuery/voted_query = dbcon.NewQuery("SELECT optionid FROM erro_poll_vote WHERE pollid = [pollid] AND ckey = '[usr.ckey]'")
@@ -331,23 +298,17 @@
 
 				var/output = "<div align='center'><B>Player poll</B>"
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\mob\new_player\\\poll.dm:306: output +="<hr>"
 				output += {"<hr>
 					<b>Question: [pollquestion]</b><br>You can select up to [multiplechoiceoptions] options. If you select more, the first [multiplechoiceoptions] will be saved.<br>
 					<font size='2'>Poll runs from <b>[pollstarttime]</b> until <b>[pollendtime]</b></font><p>"}
-				// END AUTOFIX
 				if(!voted)	//Only make this a form if we have not voted yet
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\mob\new_player\\\poll.dm:311: output += "<form name='cardcomp' action='?src=\ref[src]' method='get'>"
 					output += {"<form name='cardcomp' action='?src=\ref[src]' method='get'>
 						<input type='hidden' name='src' value='\ref[src]'>
 						<input type='hidden' name='votepollid' value='[pollid]'>
 						<input type='hidden' name='votetype' value='MULTICHOICE'>
 						<input type='hidden' name='maxoptionid' value='[maxoptionid]'>
 						<input type='hidden' name='minoptionid' value='[minoptionid]'>"}
-					// END AUTOFIX
 
 				output += "<table><tr><td>"
 				for(var/datum/polloption/O in options)
@@ -363,11 +324,8 @@
 
 				if(!voted)	//Only make this a form if we have not voted yet
 
-					// AUTOFIXED BY fix_string_idiocy.py
-					// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\mob\new_player\\\poll.dm:331: output += "<p><input type='submit' value='Vote'>"
 					output += {"<p><input type='submit' value='Vote'>
 						</form>"}
-					// END AUTOFIX
 
 				output += "</div>"
 

--- a/code/modules/paperwork/filingcabinet.dm
+++ b/code/modules/paperwork/filingcabinet.dm
@@ -97,12 +97,9 @@
 					break
 			var/obj/item/weapon/paper/P = new /obj/item/weapon/paper(src)
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\\paperwork\filingcabinet.dm:100: P.info = "<CENTER><B>Security Record</B></CENTER><BR>"
 			P.info = {"<CENTER><B>Security Record</B></CENTER><BR>
 				Name: [G.fields["name"]] ID: [G.fields["id"]]<BR>\nSex: [G.fields["sex"]]<BR>\nAge: [G.fields["age"]]<BR>\nFingerprint: [G.fields["fingerprint"]]<BR>\nPhysical Status: [G.fields["p_stat"]]<BR>\nMental Status: [G.fields["m_stat"]]<BR>
 				<BR>\n<CENTER><B>Security Data</B></CENTER><BR>\nCriminal Status: [S.fields["criminal"]]<BR>\n<BR>\nMinor Crimes: [S.fields["mi_crim"]]<BR>\nDetails: [S.fields["mi_crim_d"]]<BR>\n<BR>\nMajor Crimes: [S.fields["ma_crim"]]<BR>\nDetails: [S.fields["ma_crim_d"]]<BR>\n<BR>\nImportant Notes:<BR>\n\t[S.fields["notes"]]<BR>\n<BR>\n<CENTER><B>Comments/Log</B></CENTER><BR>"}
-			// END AUTOFIX
 			var/counter = 1
 			while(S.fields["com_[counter]"])
 				P.info += "[S.fields["com_[counter]"]]<BR>"
@@ -130,12 +127,9 @@
 					break
 			var/obj/item/weapon/paper/P = new /obj/item/weapon/paper(src)
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\\paperwork\filingcabinet.dm:129: P.info = "<CENTER><B>Medical Record</B></CENTER><BR>"
 			P.info = {"<CENTER><B>Medical Record</B></CENTER><BR>
 				Name: [G.fields["name"]] ID: [G.fields["id"]]<BR>\nSex: [G.fields["sex"]]<BR>\nAge: [G.fields["age"]]<BR>\nFingerprint: [G.fields["fingerprint"]]<BR>\nPhysical Status: [G.fields["p_stat"]]<BR>\nMental Status: [G.fields["m_stat"]]<BR>
 				<BR>\n<CENTER><B>Medical Data</B></CENTER><BR>\nBlood Type: [M.fields["b_type"]]<BR>\nDNA: [M.fields["b_dna"]]<BR>\n<BR>\nMinor Disabilities: [M.fields["mi_dis"]]<BR>\nDetails: [M.fields["mi_dis_d"]]<BR>\n<BR>\nMajor Disabilities: [M.fields["ma_dis"]]<BR>\nDetails: [M.fields["ma_dis_d"]]<BR>\n<BR>\nAllergies: [M.fields["alg"]]<BR>\nDetails: [M.fields["alg_d"]]<BR>\n<BR>\nCurrent Diseases: [M.fields["cdi"]] (per disease info placed in log/comment section)<BR>\nDetails: [M.fields["cdi_d"]]<BR>\n<BR>\nImportant Notes:<BR>\n\t[M.fields["notes"]]<BR>\n<BR>\n<CENTER><B>Comments/Log</B></CENTER><BR>"}
-			// END AUTOFIX
 			var/counter = 1
 			while(M.fields["com_[counter]"])
 				P.info += "[M.fields["com_[counter]"]]<BR>"

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -182,10 +182,7 @@ By design, d1 is the smallest direction and d2 is the highest
 			var/turf/Z = get_turf(A)
 			var/area/my_area = get_area(Z)
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\\power\cable.dm:104: message += " in [my_area.name]. (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>JMP</A>)"
 			message += {"in [my_area.name]. (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>JMP</A>) (<A HREF='?_src_=vars;Vars=\ref[A]'>VV</A>)"}
-			// END AUTOFIX
 
 			var/mob/M = get(A, /mob)
 

--- a/code/modules/power/generator_type2.dm
+++ b/code/modules/power/generator_type2.dm
@@ -107,14 +107,11 @@
 	var/t = "<h2>Thermo-Electric Generator Mk. 2</h2>"
 
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\\power\generator_type2.dm:113: t += "Output : [round(lastgen)] W<BR><BR>"
 	t += {"Output : [round(lastgen)] W<BR><BR>
 [get_loop_state("Cold",input1_dir,input1)]
 [get_loop_state("Hot",input2_dir,input2)]
 <BR><HR><A href='?src=\ref[src];close=1'>Close</A>
 | <A href='?src=\ref[src];reconnect=1'>Refresh Inputs</A>"}
-	// END AUTOFIX
 	user << browse(t, "window=teg;size=460x300")
 	onclose(user, "teg")
 	return 1

--- a/code/modules/power/solars/control.dm
+++ b/code/modules/power/solars/control.dm
@@ -129,8 +129,6 @@
 	user.set_machine(src)
 
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\\power\solar.dm:407: var/t = "<TT><B>Solar Generator Control</B><HR><PRE>"
 	var/t = {"<TT><B>Solar Generator Control</B><HR><PRE>
 <B>Generated power</B> : [round(lastgen)] W<BR>
 Station Orbital Period : [60/abs(sun.rotationRate)] minutes<BR>
@@ -139,7 +137,6 @@ Star Orientation : [sun.angle]&deg ([angle2text(sun.angle)])<BR>
 Array Orientation : [rate_control(src,"cdir","[cdir]&deg",1,10,60)] ([angle2text(cdir)])<BR>
 <BR><HR><BR>
 Tracking :"}
-	// END AUTOFIX
 	switch(track)
 		if(0)
 			t += "<B>Off</B> <A href='?src=\ref[src];track=1'>Manual</A> <A href='?src=\ref[src];track=2'>Automatic</A><BR>"
@@ -149,11 +146,8 @@ Tracking :"}
 			t += "<A href='?src=\ref[src];track=0'>Off</A> <A href='?src=\ref[src];track=1'>Manual</A> <B>Automatic</B><BR>"
 
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\\power\solar.dm:423: t += "Manual Tracking Rate: [rate_control(src,"tdir","[trackrate/10]&deg/min ([trackdir<0 ? "CCW" : "CW"])",1,10)]<BR>"
 	t += {"Manual Tracking Rate: [rate_control(src,"tdir","[trackrate/10]&deg/min ([trackdir<0 ? "CCW" : "CW"])",1,10)]<BR>
 Manual Tracking Direction:"}
-	// END AUTOFIX
 	switch(trackdir)
 		if(-1)
 			t += "<A href='?src=\ref[src];trackdir=1'>CW</A> <B>CCW</B><BR>"

--- a/code/modules/power/turbine.dm
+++ b/code/modules/power/turbine.dm
@@ -155,14 +155,11 @@
 	var/t = "<TT><B>Gas Turbine Generator</B><HR><PRE>"
 
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\\\power\turbine.dm:156: t += "Generated power : [round(lastgen)] W<BR><BR>"
 	t += {"Generated power : [round(lastgen)] W<BR><BR>
 		Turbine: [round(compressor.rpm)] RPM<BR>
 		Starter: [ compressor.starter ? "<A href='?src=\ref[src];str=1'>Off</A> <B>On</B>" : "<B>Off</B> <A href='?src=\ref[src];str=1'>On</A>"]
 		</PRE><HR><A href='?src=\ref[src];close=1'>Close</A>
 		</TT>"}
-	// END AUTOFIX
 	user << browse(t, "window=turbine")
 	onclose(user, "turbine")
 

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -822,8 +822,6 @@ USE THIS CHEMISTRY DISPENSER FOR MAPS SO THEY START AT 100 ENERGY
 			dat += "Add to buffer:<BR>"
 			for(var/datum/reagent/G in R.reagent_list)
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\reagents\Chemistry-Machinery.dm:518: dat += "[G.name] , [G.volume] Units - "
 				dat += {"[G.name] , [G.volume] Units -
 					<A href='?src=\ref[src];analyze=1;desc=[G.description];name=[G.name]'>(Analyze)</A>
 					<A href='?src=\ref[src];add=[G.id];amount=1'>(1)</A>
@@ -831,14 +829,11 @@ USE THIS CHEMISTRY DISPENSER FOR MAPS SO THEY START AT 100 ENERGY
 					<A href='?src=\ref[src];add=[G.id];amount=10'>(10)</A>
 					<A href='?src=\ref[src];add=[G.id];amount=[G.volume]'>(All)</A>
 					<A href='?src=\ref[src];addcustom=[G.id]'>(Custom)</A><BR>"}
-				// END AUTOFIX
 
 		dat += "<HR>Transfer to <A href='?src=\ref[src];toggle=1'>[(!mode ? "disposal" : "beaker")]:</A><BR>"
 		if(reagents.total_volume)
 			for(var/datum/reagent/N in reagents.reagent_list)
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\reagents\Chemistry-Machinery.dm:529: dat += "[N.name] , [N.volume] Units - "
 				dat += {"[N.name] , [N.volume] Units -
 					<A href='?src=\ref[src];analyze=1;desc=[N.description];name=[N.name]'>(Analyze)</A>
 					<A href='?src=\ref[src];remove=[N.id];amount=1'>(1)</A>
@@ -846,13 +841,10 @@ USE THIS CHEMISTRY DISPENSER FOR MAPS SO THEY START AT 100 ENERGY
 					<A href='?src=\ref[src];remove=[N.id];amount=10'>(10)</A>
 					<A href='?src=\ref[src];remove=[N.id];amount=[N.volume]'>(All)</A>
 					<A href='?src=\ref[src];removecustom=[N.id]'>(Custom)</A><BR>"}
-				// END AUTOFIX
 		else
 			dat += "Buffer is empty.<BR>"
 		if(!condi)
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\reagents\Chemistry-Machinery.dm:539: dat += "<HR><BR><A href='?src=\ref[src];createpill=1'>Create pill (50 units max)</A><a href=\"?src=\ref[src]&change_pill=1\"><img src=\"pill[pillsprite].png\" /></a><BR>"
 			//dat += {"<a href=\"?src=\ref[src]&change_pill=1\"><img src=\"pill[pillsprite].png\" /></a><a href=\"?src=\ref[src]&change_bottle=1\"><img src=\"bottle[bottlesprite].png\" /></a><BR>"}
 			dat += {"<a href=\"?src=\ref[src]&change_pill=1\"><img src=\"pill[pillsprite].png\" /></a><BR>"}
 			dat += {"<HR><BR><A href='?src=\ref[src];createpill=1'>Create single pill (50 units max)</A><BR>
@@ -860,7 +852,6 @@ USE THIS CHEMISTRY DISPENSER FOR MAPS SO THEY START AT 100 ENERGY
 					<A href='?src=\ref[src];createpill_multiple=1;createempty=1'>Create empty pills</A><BR>
 					<A href='?src=\ref[src];createbottle=1'>Create bottle ([max_bottle_size] units max)</A><BR>
 					<A href='?src=\ref[src];createbottle_multiple=1'>Create multiple bottles ([max_bottle_size] units max each; 4 max)</A><BR>"}
-			// END AUTOFIX
 		else
 			dat += "<A href='?src=\ref[src];createbottle=1'>Create bottle (50 units max)</A>"
 	dat = list2text(dat)
@@ -1101,11 +1092,8 @@ USE THIS CHEMISTRY DISPENSER FOR MAPS SO THEY START AT 100 ENERGY
 		dat = "[src.temphtml]<BR><BR><A href='?src=\ref[src];clear=1'>Main Menu</A>"
 	else if(!beaker)
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\reagents\Chemistry-Machinery.dm:722: dat += "Please insert beaker.<BR>"
 		dat += {"Please insert beaker.<BR>
 			<A href='?src=\ref[user];mach_close=pandemic'>Close</A>"}
-		// END AUTOFIX
 	else
 		var/datum/reagents/R = beaker.reagents
 		var/datum/reagent/blood/Blood = null
@@ -1121,12 +1109,9 @@ USE THIS CHEMISTRY DISPENSER FOR MAPS SO THEY START AT 100 ENERGY
 			dat += "No blood data found in beaker."
 		else
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\reagents\Chemistry-Machinery.dm:738: dat += "<h3>Blood sample data:</h3>"
 			dat += {"<h3>Blood sample data:</h3>
 				<b>Blood DNA:</b> [(Blood.data["blood_DNA"]||"none")]<BR>
 				<b>Blood Type:</b> [(Blood.data["blood_type"]||"none")]<BR>"}
-			// END AUTOFIX
 			if(Blood.data["viruses"])
 				var/list/vir = Blood.data["viruses"]
 				if(vir.len)
@@ -1147,14 +1132,11 @@ USE THIS CHEMISTRY DISPENSER FOR MAPS SO THEY START AT 100 ENERGY
 								CRASH("We weren't able to get the advance disease from the archive.")
 
 
-							// AUTOFIXED BY fix_string_idiocy.py
-							// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\reagents\Chemistry-Machinery.dm:762: dat += "<b>Disease Agent:</b> [D?"[D.agent] - <A href='?src=\ref[src];create_virus_culture=[disease_creation]'>Create virus culture bottle</A>":"none"]<BR>"
 							dat += {"<b>Disease Agent:</b> [D?"[D.agent] - <A href='?src=\ref[src];create_virus_culture=[disease_creation]'>Create virus culture bottle</A>":"none"]<BR>
 								<b>Common name:</b> [(D.name||"none")]<BR>
 								<b>Description: </b> [(D.desc||"none")]<BR>
 								<b>Spread:</b> [(D.spread||"none")]<BR>
 								<b>Possible cure:</b> [(D.cure||"none")]<BR><BR>"}
-							// END AUTOFIX
 							if(istype(D, /datum/disease/advance))
 								var/datum/disease/advance/A = D
 								dat += "<b>Symptoms:</b> "
@@ -1187,11 +1169,8 @@ USE THIS CHEMISTRY DISPENSER FOR MAPS SO THEY START AT 100 ENERGY
 			else
 				dat += "nothing<BR>"
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\reagents\Chemistry-Machinery.dm:799: dat += "<BR><A href='?src=\ref[src];eject=1'>Eject beaker</A>[((R.total_volume&&R.reagent_list.len) ? "-- <A href='?src=\ref[src];empty_beaker=1'>Empty beaker</A>":"")]<BR>"
 		dat += {"<BR><A href='?src=\ref[src];eject=1'>Eject beaker</A>[((R.total_volume&&R.reagent_list.len) ? "-- <A href='?src=\ref[src];empty_beaker=1'>Empty beaker</A>":"")]<BR>
 			<A href='?src=\ref[user];mach_close=pandemic'>Close</A>"}
-		// END AUTOFIX
 	user << browse("<TITLE>[src.name]</TITLE><BR>[dat]", "window=pandemic;size=575x400")
 	onclose(user, "pandemic")
 	return
@@ -1465,11 +1444,8 @@ USE THIS CHEMISTRY DISPENSER FOR MAPS SO THEY START AT 100 ENERGY
 	"}
 		if (is_beaker_ready && !is_chamber_empty && !(stat & (NOPOWER|BROKEN)))
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\reagents\Chemistry-Machinery.dm:1016: dat += "<A href='?src=\ref[src];action=grind'>Grind the reagents</a><BR>"
 			dat += {"<A href='?src=\ref[src];action=grind'>Grind the reagents</a><BR>
 				<A href='?src=\ref[src];action=juice'>Juice the reagents</a><BR><BR>"}
-			// END AUTOFIX
 		if(holdingitems && holdingitems.len > 0)
 			dat += "<A href='?src=\ref[src];action=eject'>Eject the reagents</a><BR>"
 		if (beaker)

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -667,11 +667,8 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 
 		if(0.2)
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\research\rdconsole.dm:584: dat += "SYSTEM LOCKED<BR><BR>"
 			dat += {"SYSTEM LOCKED<BR><BR>
 				<A href='?src=\ref[src];lock=1.6'>Unlock</A>"}
-			// END AUTOFIX
 		if(0.3)
 			dat += "Constructing Prototypes. Please Wait..."
 
@@ -680,11 +677,8 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 
 		if(1.0) //Main Menu
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\research\rdconsole.dm:594: dat += "Main Menu:<BR><BR>"
 			dat += {"Main Menu:<BR><BR>
 				<A href='?src=\ref[src];menu=1.1'>Current Research Levels</A><BR>"}
-			// END AUTOFIX
 			if(t_disk) dat += "<A href='?src=\ref[src];menu=1.2'>Disk Operations</A><BR>"
 			else if(d_disk) dat += "<A href='?src=\ref[src];menu=1.4'>Disk Operations</A><BR>"
 			else dat += "(Please Insert Disk)<BR>"
@@ -698,75 +692,51 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			dat += "Current Research Levels:<BR><BR>"
 			for(var/datum/tech/T in files.known_tech)
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\research\rdconsole.dm:607: dat += "[T.name]<BR>"
 				dat += {"[T.name]<BR>
 					* Level: [T.level]<BR>
 					* Summary: [T.desc]<HR>"}
-				// END AUTOFIX
 			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A>"
 
 		if(1.2) //Technology Disk Menu
 
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\research\rdconsole.dm:614: dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A><HR>"
 			dat += {"<A href='?src=\ref[src];menu=1.0'>Main Menu</A><HR>
 				Disk Contents: (Technology Data Disk)<BR><BR>"}
-			// END AUTOFIX
 			if(t_disk.stored == null)
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\research\rdconsole.dm:617: dat += "The disk has no data stored on it.<HR>"
 				dat += {"The disk has no data stored on it.<HR>
 					Operations:
 					<A href='?src=\ref[src];menu=1.3'>Load Tech to Disk</A> || "}
-				// END AUTOFIX
 			else
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\research\rdconsole.dm:621: dat += "Name: [t_disk.stored.name]<BR>"
 				dat += {"Name: [t_disk.stored.name]<BR>
 					Level: [t_disk.stored.level]<BR>
 					Description: [t_disk.stored.desc]<HR>
 					Operations:
 					<A href='?src=\ref[src];updt_tech=1'>Upload to Database</A> ||
 					<A href='?src=\ref[src];clear_tech=1'>Clear Disk</A> || "}
-				// END AUTOFIX
 			dat += "<A href='?src=\ref[src];eject_tech=1'>Eject Disk</A>"
 
 		if(1.3) //Technology Disk submenu
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\research\rdconsole.dm:630: dat += "<BR><A href='?src=\ref[src];menu=1.0'>Main Menu</A> || "
 			dat += {"<BR><A href='?src=\ref[src];menu=1.0'>Main Menu</A> ||
 				<A href='?src=\ref[src];menu=1.2'>Return to Disk Operations</A><HR>
 				Load Technology to Disk:<BR><BR>"}
-			// END AUTOFIX
 			for(var/datum/tech/T in files.known_tech)
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\research\rdconsole.dm:634: dat += "[T.name] "
 				dat += {"[T.name]
 					<A href='?src=\ref[src];copy_tech=1;copy_tech_ID=[T.id]'>(Copy to Disk)</A><BR>"}
-				// END AUTOFIX
 		if(1.4) //Design Disk menu.
 			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A><HR>"
 			if(d_disk.blueprint == null)
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\research\rdconsole.dm:640: dat += "The disk has no data stored on it.<HR>"
 				dat += {"The disk has no data stored on it.<HR>
 					Operations:
 					<A href='?src=\ref[src];menu=1.5'>Load Design to Disk</A> || "}
-				// END AUTOFIX
 			else
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\research\rdconsole.dm:644: dat += "Name: [d_disk.blueprint.name]<BR>"
 				dat += {"Name: [d_disk.blueprint.name]<BR>
 					Level: [Clamp(d_disk.blueprint.reliability + rand(-15,15), 0, 100)]<BR>"}
-				// END AUTOFIX
 				switch(d_disk.blueprint.build_type)
 					if(IMPRINTER) dat += "Lathe Type: Circuit Imprinter<BR>"
 					if(PROTOLATHE) dat += "Lathe Type: Proto-lathe<BR>"
@@ -776,62 +746,41 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 					if(copytext(M, 1, 2) == "$") dat += "* [copytext(M, 2)] x [d_disk.blueprint.materials[M]]<BR>"
 					else dat += "* [M] x [d_disk.blueprint.materials[M]]<BR>"
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\research\rdconsole.dm:654: dat += "<HR>Operations: "
 				dat += {"<HR>Operations:
 					<A href='?src=\ref[src];updt_design=1'>Upload to Database</A> ||
 					<A href='?src=\ref[src];clear_design=1'>Clear Disk</A> || "}
-				// END AUTOFIX
 			dat += "<A href='?src=\ref[src];eject_design=1'>Eject Disk</A>"
 
 		if(1.5) //Technology disk submenu
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\research\rdconsole.dm:660: dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A> || "
 			dat += {"<A href='?src=\ref[src];menu=1.0'>Main Menu</A> ||
 				<A href='?src=\ref[src];menu=1.4'>Return to Disk Operations</A><HR>
 				Load Design to Disk:<BR><BR>"}
-			// END AUTOFIX
 			for(var/datum/design/D in files.known_designs)
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\research\rdconsole.dm:664: dat += "[D.name] "
 				dat += {"[D.name]
 					<A href='?src=\ref[src];copy_design=1;copy_design_ID=[D.id]'>(Copy to Disk)</A><BR>"}
-				// END AUTOFIX
 		if(1.6) //R&D console settings
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\research\rdconsole.dm:668: dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A><HR>"
 			dat += {"<A href='?src=\ref[src];menu=1.0'>Main Menu</A><HR>
 				R&D Console Setting:<BR><BR>"}
-			// END AUTOFIX
 			if(sync)
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\research\rdconsole.dm:671: dat += "<A href='?src=\ref[src];sync=1'>Sync Database with Network</A><BR>"
 				dat += {"<A href='?src=\ref[src];sync=1'>Sync Database with Network</A><BR>
 					<A href='?src=\ref[src];togglesync=1'>Disconnect from Research Network</A><BR>"}
-				// END AUTOFIX
 			else
 				dat += "<A href='?src=\ref[src];togglesync=1'>Connect to Research Network</A><BR>"
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\research\rdconsole.dm:675: dat += "<A href='?src=\ref[src];menu=1.7'>Device Linkage Menu</A><BR>"
 			dat += {"<A href='?src=\ref[src];menu=1.7'>Device Linkage Menu</A><BR>
 				<A href='?src=\ref[src];lock=0.2'>Lock Console</A><BR>
 				<A href='?src=\ref[src];reset=1'>Reset R&D Database.</A><BR>"}
-			// END AUTOFIX
 		if(1.7) //R&D device linkage
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\research\rdconsole.dm:680: dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A> || "
 			dat += {"<A href='?src=\ref[src];menu=1.0'>Main Menu</A> ||
 				<A href='?src=\ref[src];menu=1.6'>Settings Menu</A><HR>
 				R&D Console Device Linkage Menu:<BR><BR>
 				<A href='?src=\ref[src];find_device=1'>Re-sync with Nearby Devices</A><BR>
 				Linked Devices:<BR>"}
-			// END AUTOFIX
 			var/remain_link = linked_machines
 			if(linked_destroy)
 				dat += "* Destructive Analyzer <A href='?src=\ref[src];disconnect=destroy'>(Disconnect)</A><BR>"
@@ -855,50 +804,32 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 		////////////////////DESTRUCTIVE ANALYZER SCREENS////////////////////////////
 		if(2.0)
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\research\rdconsole.dm:700: dat += "NO DESTRUCTIVE ANALYZER LINKED TO CONSOLE<BR><BR>"
 			dat += {"NO DESTRUCTIVE ANALYZER LINKED TO CONSOLE<BR><BR>
 				<A href='?src=\ref[src];menu=1.0'>Main Menu</A>"}
-			// END AUTOFIX
 		if(2.1)
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\research\rdconsole.dm:704: dat += "No Item Loaded. Standing-by...<BR><HR>"
 			dat += {"No Item Loaded. Standing-by...<BR><HR>
 				<A href='?src=\ref[src];menu=1.0'>Main Menu</A>"}
-			// END AUTOFIX
 		if(2.2)
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\research\rdconsole.dm:708: dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A><HR>"
 			dat += {"<A href='?src=\ref[src];menu=1.0'>Main Menu</A><HR>
 				Deconstruction Menu<HR>
 				Name: [linked_destroy.loaded_item.name]<BR>
 				Origin Tech:<BR>"}
-			// END AUTOFIX
 			var/list/temp_tech = linked_destroy.ConvertReqString2List(linked_destroy.loaded_item.origin_tech)
 			for(var/T in temp_tech)
 				dat += "* [CallTechName(T)] [temp_tech[T]]<BR>"
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\research\rdconsole.dm:715: dat += "<HR><A href='?src=\ref[src];deconstruct=1'>Deconstruct Item</A> || "
 			dat += {"<HR><A href='?src=\ref[src];deconstruct=1'>Deconstruct Item</A> ||
 				<A href='?src=\ref[src];eject_item=1'>Eject Item</A> || "}
-			// END AUTOFIX
 		/////////////////////PROTOLATHE SCREENS/////////////////////////
 		if(3.0)
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\research\rdconsole.dm:720: dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A><HR>"
 			dat += {"<A href='?src=\ref[src];menu=1.0'>Main Menu</A><HR>
 				NO PROTOLATHE LINKED TO CONSOLE<BR><BR>"}
-			// END AUTOFIX
 		if(3.1)
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\research\rdconsole.dm:724: dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A> || "
 			dat += protolathe_header()+{"Protolathe Construction Menu \[<A href='?src=\ref[src];toggleAutoRefresh=1'>Auto-Refresh: [autorefresh ? "ON" : "OFF"]</A>\]<HR>"}
-			// END AUTOFIX
 			dat += "Filter: "
 			for(var/name_set in linked_lathe.part_sets)
 				if (name_set in filtered["protolathe"])
@@ -937,10 +868,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 
 		if(3.2) //Protolathe Material Storage Sub-menu
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\research\rdconsole.dm:763: dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A> || "
 			dat += protolathe_header()+{"Material Storage<ul>"}
-			// END AUTOFIX
 
 
 			for(var/matID in linked_lathe.materials.storage)
@@ -958,18 +886,12 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 
 		if(3.3) //Protolathe Chemical Storage Submenu
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\research\rdconsole.dm:823: dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A> || "
 			dat += protolathe_header()+{"Chemical Storage<BR><HR>"}
-			// END AUTOFIX
 			for(var/datum/reagent/R in linked_lathe.reagents.reagent_list)
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\research\rdconsole.dm:827: dat += "Name: [R.name] | Units: [R.volume] "
 				dat += {"Name: [R.name] | Units: [R.volume]
 					<A href='?src=\ref[src];disposep=[R.id]'>(Purge)</A><BR>
 					<A href='?src=\ref[src];disposeallP=1'><U>Disposal All Chemicals in Storage</U></A><BR>"}
-				// END AUTOFIX
 
 		if(3.4) //Protolathe Queue Management
 			dat += protolathe_header()+"Production Queue<BR><HR><ul>"
@@ -987,20 +909,14 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 		///////////////////CIRCUIT IMPRINTER SCREENS////////////////////
 		if(4.0)
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\research\rdconsole.dm:833: dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A><HR>"
 			dat += {"<A href='?src=\ref[src];menu=1.0'>Main Menu</A><HR>
 				NO CIRCUIT IMPRINTER LINKED TO CONSOLE<BR><BR>"}
-			// END AUTOFIX
 		if(4.1)
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\research\rdconsole.dm:837: dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A> || "
 			dat += {"[CircuitImprinterHeader()]
 				Circuit Imprinter Menu \[<A href='?src=\ref[src];toggleAutoRefresh=1'>Auto-Refresh: [autorefresh ? "ON" : "OFF"]</A>\]<BR>
 				<b>Material Amount:</b> [linked_imprinter.TotalMaterials()] cm<sup>3</sup><BR>
 				<b>Chemical Volume:</b> [linked_imprinter.reagents.total_volume]<HR>"}
-			// END AUTOFIX
 			dat += "Filter: "
 			for(var/name_set in linked_imprinter.part_sets)
 				if (name_set in filtered["imprinter"])
@@ -1038,23 +954,15 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 
 		if(4.2)
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\research\rdconsole.dm:869: dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A> || "
 			dat += {"[CircuitImprinterHeader()]
 				Chemical Storage<HR>"}
-			// END AUTOFIX
 			for(var/datum/reagent/R in linked_imprinter.reagents.reagent_list)
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\research\rdconsole.dm:873: dat += "Name: [R.name] | Units: [R.volume] "
 				dat += {"Name: [R.name] | Units: [R.volume]
 					<A href='?src=\ref[src];disposeI=[R.id]'>(Purge)</A><BR>
 					<A href='?src=\ref[src];disposeallI=1'><U>Disposal All Chemicals in Storage</U></A><BR>"}
-				// END AUTOFIX
 		if(4.3)
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\research\rdconsole.dm:878: dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A> || "
 			dat += {"[CircuitImprinterHeader()]
 				Material Storage<HR><ul>"}
 

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -254,22 +254,16 @@
 				if(istype(S, /obj/machinery/r_n_d/server/centcom) && !badmin)
 					continue
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\research\server.dm:289: dat += "[S.name] || "
 				dat += {"[S.name] ||
 					<A href='?src=\ref[src];access=[S.server_id]'> Access Rights</A> |
 					<A href='?src=\ref[src];data=[S.server_id]'>Data Management</A>"}
-				// END AUTOFIX
 				if(badmin) dat += " | <A href='?src=\ref[src];transfer=[S.server_id]'>Server-to-Server Transfer</A>"
 				dat += "<BR>"
 
 		if(1) //Access rights menu
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\research\server.dm:296: dat += "[temp_server.name] Access Rights<BR><BR>"
 			dat += {"[temp_server.name] Access Rights<BR><BR>
 				Consoles with Upload Access<BR>"}
-			// END AUTOFIX
 			for(var/obj/machinery/computer/rdconsole/C in consoles)
 				var/turf/console_turf = get_turf(C)
 				dat += "* <A href='?src=\ref[src];upload_toggle=[C.id]'>[console_turf.loc]" //FYI, these are all numeric ids, eventually.
@@ -289,35 +283,23 @@
 
 		if(2) //Data Management menu
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\research\server.dm:316: dat += "[temp_server.name] Data ManagementP<BR><BR>"
 			dat += {"[temp_server.name] Data Management<BR><BR>
 				Known Technologies<BR>"}
-			// END AUTOFIX
 			for(var/datum/tech/T in temp_server.files.known_tech)
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\research\server.dm:319: dat += "* [T.name] "
 				dat += {"* [T.name]
 					<A href='?src=\ref[src];reset_tech=[T.id]'>(Reset)</A><BR>"} //FYI, these are all strings
-				// END AUTOFIX
 			dat += "Known Designs<BR>"
 			for(var/datum/design/D in temp_server.files.known_designs)
 
-				// AUTOFIXED BY fix_string_idiocy.py
-				// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\research\server.dm:323: dat += "* [D.name] "
 				dat += {"* [D.name]
 					<A href='?src=\ref[src];reset_design=[D.id]'>(Delete)</A><BR>"}
-				// END AUTOFIX
 			dat += "<HR><A href='?src=\ref[src];main=1'>Main Menu</A>"
 
 		if(3) //Server Data Transfer
 
-			// AUTOFIXED BY fix_string_idiocy.py
-			// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\research\server.dm:328: dat += "[temp_server.name] Server to Server Transfer<BR><BR>"
 			dat += {"[temp_server.name] Server to Server Transfer<BR><BR>
 				Send Data to what server?<BR>"}
-			// END AUTOFIX
 			for(var/obj/machinery/r_n_d/server/S in servers)
 				dat += "[S.name] <A href='?src=\ref[src];send_to=[S.server_id]'> (Transfer)</A><BR>"
 			dat += "<HR><A href='?src=\ref[src];main=1'>Main Menu</A>"

--- a/code/modules/research/xenoarchaeology/machinery/analysis_base.dm
+++ b/code/modules/research/xenoarchaeology/machinery/analysis_base.dm
@@ -120,12 +120,9 @@
 	user.machine = src
 	var/dat = "<B>[src.name]</B><BR>"
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\research\xenoarchaeology\\machinery\analysis_base.dm:111: dat += "Module heat level: [temperature] kelvin<br>"
 	dat += {"Module heat level: [temperature] kelvin<br>
 		Safeties set at 350k, shielding failure at 400k. Failure to maintain safe heat levels may result in equipment damage.<br>
 		<hr>"}
-	// END AUTOFIX
 	if(scan_process)
 		dat += "Scan in progress<br><br><br>"
 	else
@@ -133,12 +130,9 @@
 		//dat += "[fuel_container ? "<A href='?src=\ref[src];eject_fuel=1'>Eject fuel tank</a>" : "No fuel tank inserted."]<br>"
 		dat += "[held_container ? "<A href='?src=\ref[src];begin=1'>Begin scanning</a>" : ""]"
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\research\xenoarchaeology\\machinery\analysis_base.dm:120: dat += "<hr>"
 	dat += {"<hr>
 		<A href='?src=\ref[src];refresh=1'>Refresh</a><BR>
 		<A href='?src=\ref[src];close=1'>Close</a><BR>"}
-	// END AUTOFIX
 	user << browse(dat, "window=anomaly;size=450x500")
 	onclose(user, "anomaly")
 

--- a/code/modules/security levels/keycard authentication.dm
+++ b/code/modules/security levels/keycard authentication.dm
@@ -74,34 +74,22 @@ var/global/list/obj/machinery/keycard_auth/authenticators = list()
 	var/dat = "<h1>Keycard Authentication Device</h1>"
 
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\security levels\keycard authentication.dm:66: dat += "This device is used to trigger some high security events. It requires the simultaneous swipe of two high-level ID cards."
 	dat += {"This device is used to trigger some high security events. It requires the simultaneous swipe of two high-level ID cards.
 		<br><hr><br>"}
-	// END AUTOFIX
 	if(screen == 1)
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\security levels\keycard authentication.dm:70: dat += "Select an event to trigger:<ul>"
 		dat += {"Select an event to trigger:<ul>
 			<li><A href='?src=\ref[src];triggerevent=Red alert'>Red alert</A></li>"}
-		// END AUTOFIX
 		//dat += "<li><A href='?src=\ref[src];triggerevent=Emergency Response Team'>Emergency Response Team</A></li>" Not yet
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\security levels\keycard authentication.dm:73: dat += "<li><A href='?src=\ref[src];triggerevent=Grant Emergency Maintenance Access'>Grant Emergency Maintenance Access</A></li>"
 		dat += {"<li><A href='?src=\ref[src];triggerevent=Grant Emergency Maintenance Access'>Grant Emergency Maintenance Access</A></li>
 			<li><A href='?src=\ref[src];triggerevent=Revoke Emergency Maintenance Access'>Revoke Emergency Maintenance Access</A></li>
 			</ul>"}
-		// END AUTOFIX
 		user << browse(dat, "window=keycard_auth;size=500x250")
 	if(screen == 2)
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\security levels\keycard authentication.dm:78: dat += "Please swipe your card to authorize the following event: <b>[event]</b>"
 		dat += {"Please swipe your card to authorize the following event: <b>[event]</b>
 			<p><A href='?src=\ref[src];reset=1'>Back</A>"}
-		// END AUTOFIX
 		user << browse(dat, "window=keycard_auth;size=500x250")
 	return
 

--- a/code/modules/virus2/isolator.dm
+++ b/code/modules/virus2/isolator.dm
@@ -70,11 +70,8 @@
 	var/dat = ""
 	if(!beaker)
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\\documents\\\projects\vgstation13\code\\modules\virus2\isolator.dm:68: dat = "Please insert sample into the isolator.<BR>"
 		dat = {"Please insert sample into the isolator.<BR>
 <A href='?src=\ref[src];close=1'>Close</A>"}
-		// END AUTOFIX
 	else if(isolating)
 		dat = "Isolating"
 	else

--- a/code/world.dm
+++ b/code/world.dm
@@ -335,15 +335,12 @@ var/savefile/panicfile
 		s += "<b>[config.server_name]</b> &#8212; "
 
 
-	// AUTOFIXED BY fix_string_idiocy.py
-	// C:\Users\Rob\\documents\\\projects\vgstation13\code\world.dm:235: s += "<b>[station_name()]</b>";
 	s += {"<b>[station_name()]</b>"
 		(
 		<a href=\"http://\">" //Change this to wherever you want the hub to link to
 		Default"  //Replace this with something else. Or ever better, delete it and uncomment the game version
 		</a>
 		)"}
-	// END AUTOFIX
 	var/list/features = list()
 
 	if(ticker)


### PR DESCRIPTION
``` Python
import sys
import re
import os

autofixre  = re.compile("(// AUTOFIXED BY fix_string_idiocy\.py|// C:\\\\Users\\\\Rob\\\\\\\\documents\\\\\\\\\\\\projects\\\\vgstation13\\\\|// END AUTOFIX)")

if len(sys.argv) < 2:
    print "Not enough argument supplied."
    quit()

print sys.argv[1]
for root, dirs, files in os.walk(sys.argv[1]):
    print(root)
    for filename in files:
        if filename.find(".dm") == -1 or not (filename.find(".dmi") == -1 and filename.find(".dmb")) == -1:
            continue

        absolute = os.path.join(root, filename)

        print(absolute)

        f = open(absolute, "r")
        lines = f.readlines()
        f.close()

        f = open(absolute, "w")

        for line in lines:
            if autofixre.search(line) == None:
                f.write(line)

        f.close()
```
