### PR TITLE
Allowing admins to specify which modes to play in Mixed

### DIFF
--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -5,7 +5,7 @@ var/list/directory = list()							//list of all ckeys with associated client
 //Since it didn't really belong in any other category, I'm putting this here
 //This is for procs to replace all the goddamn 'in world's that are chilling around the code
 
-var/global/list/mixed_modes = list()							//Set when admins wish to force specific modes to be mixed
+var/list/mixed_modes = list()							//Set when admins wish to force specific modes to be mixed
 
 var/global/list/player_list = list()				//List of all mobs **with clients attached**. Excludes /mob/new_player
 var/global/list/mob_list = list()					//List of all mobs, including clientless

--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -5,6 +5,8 @@ var/list/directory = list()							//list of all ckeys with associated client
 //Since it didn't really belong in any other category, I'm putting this here
 //This is for procs to replace all the goddamn 'in world's that are chilling around the code
 
+var/global/list/mixed_modes = list()							//Set when admins wish to force specific modes to be mixed
+
 var/global/list/player_list = list()				//List of all mobs **with clients attached**. Excludes /mob/new_player
 var/global/list/mob_list = list()					//List of all mobs, including clientless
 var/global/list/living_mob_list = list()			//List of all alive mobs, including clientless. Excludes /mob/new_player

--- a/code/game/gamemodes/mixed/mixed.dm
+++ b/code/game/gamemodes/mixed/mixed.dm
@@ -1,3 +1,12 @@
+
+var/global/list/mixed_allowed = list(
+	"autotraitor",
+	"changeling",
+	"cult",
+	"vampire",
+	"wizard",
+	)
+
 /datum/game_mode/mixed
 	name = "mixed"
 	config_tag = "mixed"
@@ -37,20 +46,43 @@
 	. = 1
 	modes = list()
 	picked_antags = list()
-	var/list/datum/game_mode/possible = typesof(/datum/game_mode) - list(/datum/game_mode, /datum/game_mode/mixed, /datum/game_mode/malfunction, /datum/game_mode/traitor, /datum/game_mode/traitor/double_agents, /datum/game_mode/sandbox, /datum/game_mode/revolution, /datum/game_mode/meteor, /datum/game_mode/extended, /datum/game_mode/heist, /datum/game_mode/nuclear, /datum/game_mode/traitor/changeling, /datum/game_mode/wizard/raginmages, /datum/game_mode/blob)
-	possible = shuffle(possible)//what's the point? we're using pick() to choose a random mode anyway
-	while(modes.len < 3)
-		if(!possible.len) break
-		var/ourmode = pick(possible)//see?
-		possible -= ourmode
-		var/datum/game_mode/M = new ourmode
-		M.mixed = 1
-		if(!M.pre_setup())
-			del(M)
-			continue
-		//modePlayer += M.modePlayer
-		modes += M
-		possible = shuffle(possible)//what's the point though?
+
+	if(mixed_modes.len)
+		for(var/M in mixed_modes)
+			var/datum/game_mode/GM = config.pick_mode(M)
+			GM.mixed = 1
+			if(GM.pre_setup())
+				modes += GM
+			else
+				qdel(GM)
+	else
+		var/list/datum/game_mode/possible = typesof(/datum/game_mode) - list(
+																			/datum/game_mode,
+																			/datum/game_mode/mixed,
+																			/datum/game_mode/malfunction,
+																			/datum/game_mode/traitor,
+																			/datum/game_mode/traitor/double_agents,
+																			/datum/game_mode/sandbox,
+																			/datum/game_mode/revolution,
+																			/datum/game_mode/meteor,
+																			/datum/game_mode/extended,
+																			/datum/game_mode/heist,
+																			/datum/game_mode/nuclear,
+																			/datum/game_mode/traitor/changeling,
+																			/datum/game_mode/wizard/raginmages,
+																			/datum/game_mode/blob,
+																			)
+		while(modes.len < 3)
+			if(!possible.len) break
+			var/ourmode = pick(possible)
+			possible -= ourmode
+			var/datum/game_mode/M = new ourmode
+			M.mixed = 1
+			if(!M.pre_setup())
+				qdel(M)
+				continue
+			//modePlayer += M.modePlayer
+			modes += M
 	if(!modes.len)
 		. = 0
 	else

--- a/code/game/gamemodes/vampire/vampire.dm
+++ b/code/game/gamemodes/vampire/vampire.dm
@@ -270,8 +270,6 @@
 You are weak to holy things and starlight. Don't go into space and avoid the Chaplain, the chapel, and especially Holy Water."}
 	to_chat(vampire.current, dat)
 	to_chat(vampire.current, "<B>You must complete the following tasks:</B>")
-	vampire.current << dat
-	vampire.current << "<B>You must complete the following tasks:</B>"
 	vampire.current << sound('sound/effects/vampire_intro.ogg')
 
 	if (vampire.current.mind)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1195,12 +1195,43 @@
 		if (ticker && ticker.mode)
 			return alert(usr, "The game has already started.", null, null, null, null)
 		master_mode = href_list["c_mode2"]
-		log_admin("[key_name(usr)] set the mode as [master_mode].")
-		message_admins("<span class='notice'>[key_name_admin(usr)] set the mode as [master_mode].</span>", 1)
-		to_chat(world, "<span class='notice'><b>The mode is now: [master_mode]</b></span>")
-		Game() // updates the main game menu
-		world.save_mode(master_mode)
-		.(href, list("c_mode"=1))
+		if((master_mode != "mixed") || alert("Do you wish to specify which game modes to be mixed?","Specify Mixed","Yes","No")=="No")
+			mixed_modes = list()
+			log_admin("[key_name(usr)] set the mode as [master_mode].")
+			message_admins("<span class='notice'>[key_name_admin(usr)] set the mode as [master_mode].</span>", 1)
+			to_chat(world, "<span class='notice'><b>The mode is now: [master_mode]</b></span>")
+			Game() // updates the main game menu
+			world.save_mode(master_mode)
+			.(href, list("c_mode"=1))
+		else
+			var/list/possible = list()
+			possible += mixed_allowed
+			possible += "DONE"
+			possible += "CANCEL"
+			if(possible.len < 3)
+				return alert(usr, "Not enough possible game modes.", null, null, null, null)
+			var/mixed_mode_added = null
+			while(possible.len >= 3)
+				var/mixed_mode_add = input("Pick game modes to add to the mix. ([mixed_mode_added])", "Specify Mixed") in possible
+				possible -= mixed_mode_add
+				if(mixed_mode_add == "CANCEL")
+					return
+				else if(mixed_mode_add == "DONE")
+					break
+				else
+					mixed_modes += mixed_mode_add
+					possible -= mixed_mode_add
+					if(!mixed_mode_added)
+						mixed_mode_added = mixed_mode_add
+					else
+						mixed_mode_added = "[mixed_mode_added], [mixed_mode_add]"
+
+			log_admin("[key_name(usr)] set the mode as [master_mode] with the following modes: [mixed_mode_added].")
+			message_admins("<span class='notice'>[key_name_admin(usr)] set the mode as [master_mode] with the following modes: [mixed_mode_added].</span>", 1)
+			to_chat(world, "<span class='notice'><b>The mode is now: [master_mode] ([mixed_mode_added])</b></span>")
+			Game() // updates the main game menu
+			world.save_mode(master_mode)
+			.(href, list("c_mode"=1))
 
 	else if(href_list["f_secret2"])
 		if(!check_rights(R_ADMIN|R_SERVER))	return
@@ -1210,10 +1241,40 @@
 		if(master_mode != "secret")
 			return alert(usr, "The game mode has to be secret!", null, null, null, null)
 		secret_force_mode = href_list["f_secret2"]
-		log_admin("[key_name(usr)] set the forced secret mode as [secret_force_mode].")
-		message_admins("<span class='notice'>[key_name_admin(usr)] set the forced secret mode as [secret_force_mode].</span>", 1)
-		Game() // updates the main game menu
-		.(href, list("f_secret"=1))
+
+		if((secret_force_mode != "mixed") || alert("Do you wish to specify which game modes to be mixed?","Specify Secret Mixed","Yes","No")=="No")
+			mixed_modes = list()
+			log_admin("[key_name(usr)] set the forced secret mode as [secret_force_mode].")
+			message_admins("<span class='notice'>[key_name_admin(usr)] set the forced secret mode as [secret_force_mode].</span>", 1)
+			Game() // updates the main game menu
+			.(href, list("f_secret"=1))
+		else
+			var/list/possible = list()
+			possible += mixed_allowed
+			possible += "DONE"
+			possible += "CANCEL"
+			if(possible.len < 3)
+				return alert(usr, "Not enough possible game modes.", null, null, null, null)
+			var/mixed_mode_added = null
+			while(possible.len >= 3)
+				var/mixed_mode_add = input("Pick game modes to add to the secret mix. ([mixed_mode_added])", "Specify Secret Mixed") in possible
+				possible -= mixed_mode_add
+				if(mixed_mode_add == "CANCEL")
+					return
+				else if(mixed_mode_add == "DONE")
+					break
+				else
+					mixed_modes += mixed_mode_add
+					possible -= mixed_mode_add
+					if(!mixed_mode_added)
+						mixed_mode_added = mixed_mode_add
+					else
+						mixed_mode_added = "[mixed_mode_added], [mixed_mode_add]"
+
+			log_admin("[key_name(usr)] set the mode as [secret_force_mode] with the following modes: [mixed_mode_added].")
+			message_admins("<span class='notice'>[key_name_admin(usr)] set the forced secret mode as [secret_force_mode] with the following modes: [mixed_mode_added].</span>", 1)
+			Game() // updates the main game menu
+			.(href, list("f_secret"=1))
 
 	else if(href_list["monkeyone"])
 		if(!check_rights(R_SPAWN))	return

--- a/html/changelogs/DeityLink_7815.yml
+++ b/html/changelogs/DeityLink_7815.yml
@@ -1,0 +1,4 @@
+author: Deity Link
+delete-after: true
+changes:
+  - rscadd: Admins can now specify which modes they want in Mixed (among the modes allowed in Mixed)


### PR DESCRIPTION
When setting the mode or forced secret mode as Mixed, admins are now asked whether they'd like to choose specific game modes to mix, among the allowed Mixed game modes (aka: Autotator, Changeling, Cult, Wizard, and Vampire). If they decline (or if the mode is chosen through Secret rotation) the game will pick 3 modes among those.

So that means that now admins can easily set up rounds mixing up 1 to 5 game modes!

I originally started working on that so I could check the fixes to Cult I did in #7813 but I think it'd be a great QoL change for admins.

Also fixed Vampires getting their greeting twice.
