### PR TITLE
Faster Startup take 2

### DIFF
--- a/code/controllers/master_controller.dm
+++ b/code/controllers/master_controller.dm
@@ -89,6 +89,7 @@ datum/controller/game_controller/proc/setup()
 		global.garbageCollector = new
 		garbageCollector = global.garbageCollector
 */
+
 	setup_objects() // Most log_startup spam happens here
 	setupgenetics()
 	setupfactions()

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -79,11 +79,13 @@
 		spawn( 0 )
 			src.Entered(AM)
 			return
-	turfs |= src
 
 	var/area/A = loc
 	if(!dynamic_lighting || !A.lighting_use_dynamic)
 		luminosity = 1
+
+/turf/proc/initialize()
+	return
 
 /turf/DblClick()
 	if(istype(usr, /mob/living/silicon/ai))

--- a/code/modules/awaymissions/zlevel.dm
+++ b/code/modules/awaymissions/zlevel.dm
@@ -52,6 +52,10 @@
 			if(isfile(file))
 				maploader.load_map(file)
 
+				for(var/x = 1 to world.maxx)
+					for(var/y = 1 to world.maxy)
+						turfs += locate(x,y,world.maxz)
+
 				for(var/obj/effect/landmark/L in landmarks_list)
 					if (L.name != "awaystart")
 						continue

--- a/code/modules/lighting/lighting_system.dm
+++ b/code/modules/lighting/lighting_system.dm
@@ -1,5 +1,5 @@
 /var/list/lighting_update_lights	= list()	// List of light sources queued for update.
-/var/list/lighting_update_overlays	= list()	// List of ligting overlays queued for update. 
+/var/list/lighting_update_overlays	= list()	// List of ligting overlays queued for update.
 /var/list/all_lighting_overlays		= list()	// Global list of lighting overlays.
 
 /area/var/lighting_use_dynamic		= 1			// Disabling this variable on an area disables dynamic lighting.
@@ -11,7 +11,7 @@
 		for(var/turf/T in turfs)
 			if(T.dynamic_lighting)
 				A = T.loc // Get the area.
-				if(A.lighting_use_dynamic)
+				if(A.lighting_use_dynamic && !T.lighting_overlay)
 					var/atom/movable/lighting_overlay/O = getFromPool(/atom/movable/lighting_overlay, T)
 					all_lighting_overlays |= O
 					T.lighting_overlay = O
@@ -22,7 +22,7 @@
 				var/turf/T = locate(x, y, zlevel)
 				if(T.dynamic_lighting)
 					A = T.loc // Get the area.
-					if(A.lighting_use_dynamic)
+					if(A.lighting_use_dynamic && !T.lighting_overlay)
 						var/atom/movable/lighting_overlay/O = getFromPool(/atom/movable/lighting_overlay, T)
 						all_lighting_overlays |= O
 						T.lighting_overlay = O

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -33,7 +33,10 @@
 /turf/unsimulated/mineral/New()
 	. = ..()
 	MineralSpread()
+	if(ticker)
+		initialize()
 
+/turf/unsimulated/mineral/initialize()
 	spawn(1)
 		var/turf/T
 		if((istype(get_step(src, NORTH), /turf/simulated/floor)) || (istype(get_step(src, NORTH), /turf/space)) || (istype(get_step(src, NORTH), /turf/simulated/shuttle/floor)))
@@ -499,6 +502,10 @@
 
 	if(prob(20))
 		icon_state = "asteroid[rand(0,12)]"
+	if(ticker)
+		initialize()
+
+/turf/unsimulated/floor/asteroid/initialize()
 	updateMineralOverlays()
 
 /turf/unsimulated/floor/asteroid/ex_act(severity)
@@ -557,15 +564,18 @@
 
 /turf/unsimulated/floor/asteroid/proc/updateMineralOverlays()
 	src.overlays.len = 0
-
-	if(istype(get_step(src, NORTH), /turf/unsimulated/mineral))
-		src.overlays += image('icons/turf/walls.dmi', "rock_side_n")
-	if(istype(get_step(src, SOUTH), /turf/unsimulated/mineral))
-		src.overlays += image('icons/turf/walls.dmi', "rock_side_s", layer=6)
-	if(istype(get_step(src, EAST), /turf/unsimulated/mineral))
-		src.overlays += image('icons/turf/walls.dmi', "rock_side_e", layer=6)
-	if(istype(get_step(src, WEST), /turf/unsimulated/mineral))
-		src.overlays += image('icons/turf/walls.dmi', "rock_side_w", layer=6)
+	spawn(1)
+		for(var/dir in cardinal)
+			if(istype(get_step(src,dir), /turf/unsimulated/mineral))
+				switch(dir)
+					if(NORTH)
+						src.overlays += image('icons/turf/walls.dmi', "rock_side_n")
+					if(SOUTH)
+						src.overlays += image('icons/turf/walls.dmi', "rock_side_s", layer=6)
+					if(EAST)
+						src.overlays += image('icons/turf/walls.dmi', "rock_side_e", layer=6)
+					if(WEST)
+						src.overlays += image('icons/turf/walls.dmi', "rock_side_w", layer=6)
 
 /turf/unsimulated/floor/asteroid/proc/fullUpdateMineralOverlays()
 	var/turf/unsimulated/floor/asteroid/A
@@ -998,6 +1008,7 @@
 			// We can't go a full loop though
 			next_angle = -next_angle
 			dir = angle2dir(dir2angle(dir) + next_angle)
+
 /turf/unsimulated/floor/asteroid/cave/proc/SpawnFloor(var/turf/T)
 	for(var/turf/S in range(2,T))
 		if(istype(S, /turf/space) || istype(S.loc, /area/mine/explored))

--- a/code/world.dm
+++ b/code/world.dm
@@ -135,6 +135,10 @@ var/savefile/panicfile
 	master_controller = new /datum/controller/game_controller()
 
 	spawn(1)
+		for(var/turf/T in world)
+			T.initialize()
+			turfs += T
+
 		processScheduler.deferSetupFor(/datum/controller/process/ticker)
 		processScheduler.setup()
 
@@ -155,7 +159,7 @@ var/savefile/panicfile
 	process_adminbus_teleport_locs()	//Sets up adminbus teleport locations.
 	SortAreas()							//Build the list of all existing areas and sort it alphabetically
 
-	spawn(3000)		//so we aren't adding to the round-start lag
+	spawn(2000)		//so we aren't adding to the round-start lag
 		if(config.ToRban)
 			ToRban_autoupdate()
 		/*if(config.kick_inactive)


### PR DESCRIPTION
Moves turfs list creation to initialize
Moves some mine turfs work to initialize

Fixes bugs from last try:
Initializes turfs before the process scheduler begins so it will probably set up it's processes