### PR TITLE
New AI names added/previous names alphabetized

### DIFF
--- a/config/names/ai.txt
+++ b/config/names/ai.txt
@@ -93,6 +93,7 @@ OMM 0910
 Orange v 3.5
 PTO
 Project 2501
+Puppet Master
 R.I.C. 2.0
 R2-D2
 R4-P17


### PR DESCRIPTION
I just added some names of AI from Cyberpunk fiction. They are as follows (brackets just their source material, not part of name):

Daedalus (Deus Ex)
Helios (Deus Ex)
Icarus (Deus Ex)
Neuromancer (Neuromancer)
Puppet Master (Ghost in the Shell)
Samaritan (Person of Internets)
Wintermute (Neuromancer)

I also alphabetized some that were at the end in no particular order. I also deleted the the second instance of "Terminus." It was repeated.
