### PR TITLE
Fix #7873 I guess

### DIFF
--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -137,6 +137,11 @@
 	qdel(src)
 	return 20000
 
+/obj/machinery/power/supermatter/CanPass(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+	if(istype(mover,/obj/structure/closet/crate/secure/large/reinforced))
+		return 1
+	. = ..()
+
 /obj/machinery/power/supermatter/process()
 
 	var/turf/L = loc


### PR DESCRIPTION
You can already close the crate on the supermatter, you can also already move the supermatter onto the crate's tile and close the crate on the supermatter.

The only problem I can think of is that the crate collides with the supermatter when moved onto the supermatter's tile, now it wont and you can move it onto the supermatter's tile.