### PR TITLE
Mulebots

### DIFF
--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -93,6 +93,7 @@ var/global/mulebot_count = 0
 		/obj/structure/vendomatpack,
 		/obj/structure/stackopacks,
 		/obj/item/weapon/gift,
+		/obj/item/delivery
 		)
 
 /obj/machinery/bot/mulebot/Destroy()
@@ -390,23 +391,19 @@ var/global/mulebot_count = 0
 	else
 		to_chat(user, "<span class='warning'>Access denied.</span>")
 		return 0
-
-// mousedrop a crate to load the bot
 // can load anything if emagged
 
-/obj/machinery/bot/mulebot/MouseDrop_T(var/atom/movable/C, mob/user)
 
+// Mousedrop a crate to load the bot
+
+/obj/machinery/bot/mulebot/MouseDrop_T(atom/dropping, mob/user)
 	if(user.stat)
-		return
+		load(dropping)
 
-	if (!on || !istype(C)|| C.anchored || get_dist(user, src) > 1 || get_dist(src,C) > 1 )
-		return
 
-	if(load)
-		return
-
-	load(C)
-
+/obj/machinery/bot/mulebot/MouseDrop(over_object, src_location, var/turf/over_location, src_control, over_control, params)
+	if(usr.stat)
+		unload(over_object)
 
 // called to load a crate
 /obj/machinery/bot/mulebot/proc/load(var/atom/movable/C)

--- a/code/game/objects/items/stacks/packagewrap.dm
+++ b/code/game/objects/items/stacks/packagewrap.dm
@@ -174,6 +174,7 @@
 
 /obj/item/delivery/large/attack_hand(mob/user as mob)
 	if(wrapped)
+		playsound(get_turf(src), 'sound/items/poster_ripped.ogg', 100, 1)
 		wrapped.forceMove(get_turf(src.loc))
 	qdel(src)
 

--- a/html/changelogs/Zth mules.yml
+++ b/html/changelogs/Zth mules.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general deleting of nice things)
+#   rscadd (general adding of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: Zth
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+changes: 
+- rscadd: Mulebots can now be unloaded by mousedropping.
+- rscadd: Mulebots can now carry wrapped stuff.
+- soundadd: Added sound for opening wrapped crates.


### PR DESCRIPTION
Mousedragging crates to mulebots works again (maybe years have passed since last time it worked).
I think this also counts as a QoL.
- Mulebots can now be unloaded by mousedropping.
- Mulebots can now carry wrapped stuff.
- Added sound for opening wrapped crates.
