### PR TITLE
Attempt to fix old area shitcode to slim load times

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -791,11 +791,16 @@ proc/GaussRandRound(var/sigma,var/roundto)
 		if(istype(N, areatype)) theareas += N
 	return theareas
 
+/*
+ * Severely broken, causes infinite loop runtimes on areas that are too big. Please don't do that
+
 //Takes: Area type as text string or as typepath OR an instance of the area.
 //Returns: A list of all turfs in areas of that type of that type in the world.
 /proc/get_area_turfs(var/areatype)
-	if(!areatype) return null
-	if(istext(areatype)) areatype = text2path(areatype)
+	if(!areatype)
+		return null
+	if(istext(areatype))
+		areatype = text2path(areatype)
 	if(isarea(areatype))
 		var/area/areatemp = areatype
 		areatype = areatemp.type
@@ -803,8 +808,11 @@ proc/GaussRandRound(var/sigma,var/roundto)
 	var/list/turfs = new/list()
 	for(var/area/N in areas)
 		if(istype(N, areatype))
-			for(var/turf/T in N) turfs += T
+			for(var/turf/T in N)
+				turfs += T
 	return turfs
+
+*/
 
 //Takes: Area type as text string or as typepath OR an instance of the area.
 //Returns: A list of all atoms	(objs, turfs, mobs) in areas of that type of that type in the world.

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -791,9 +791,6 @@ proc/GaussRandRound(var/sigma,var/roundto)
 		if(istype(N, areatype)) theareas += N
 	return theareas
 
-/*
- * Severely broken, causes infinite loop runtimes on areas that are too big. Please don't do that
-
 //Takes: Area type as text string or as typepath OR an instance of the area.
 //Returns: A list of all turfs in areas of that type of that type in the world.
 /proc/get_area_turfs(var/areatype)
@@ -811,8 +808,6 @@ proc/GaussRandRound(var/sigma,var/roundto)
 			for(var/turf/T in N)
 				turfs += T
 	return turfs
-
-*/
 
 //Takes: Area type as text string or as typepath OR an instance of the area.
 //Returns: A list of all atoms	(objs, turfs, mobs) in areas of that type of that type in the world.

--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -72,14 +72,9 @@ var/list/teleportlocs = list()
 //Wizards can teleport to any area on station
 proc/process_teleport_locs()
 	for(var/area/AR in areas)
-		//Cannot teleport on shuttles or antag outposts
-		//if(istype(AR, /area/shuttle) || istype(AR, /area/syndicate_station) || istype(AR, /area/wizard_station))
-			//continue
-		//if(teleportlocs.Find(AR.name))
-			//continue
 		var/turf/picked = safepick(get_area_turfs(AR.type))
 		if(picked && picked.z == map.zMainStation)
-			teleportlocs |= AR.name
+			teleportlocs += AR.name
 			teleportlocs[AR.name] = AR
 
 	sortTim(teleportlocs, /proc/cmp_text_asc)
@@ -89,11 +84,9 @@ var/list/ghostteleportlocs = list()
 //Ghosts can go wherever they want to go, they're free
 proc/process_ghost_teleport_locs()
 	for(var/area/AR in areas)
-		//if(ghostteleportlocs.Find(AR.name))
-			//continue
 		var/turf/picked = safepick(get_area_turfs(AR.type))
 		if(picked)
-			ghostteleportlocs |= AR.name
+			ghostteleportlocs += AR.name
 			ghostteleportlocs[AR.name] = AR
 
 	sortTim(ghostteleportlocs, /proc/cmp_text_asc)
@@ -103,11 +96,9 @@ var/global/list/adminbusteleportlocs = list()
 //Technically the same as ghost teleports for now
 proc/process_adminbus_teleport_locs()
 	for(var/area/AR in areas)
-		//if(adminbusteleportlocs.Find(AR.name))
-			//continue
 		var/turf/picked = safepick(get_area_turfs(AR.type))
 		if(picked)
-			adminbusteleportlocs |= AR.name
+			adminbusteleportlocs += AR.name
 			adminbusteleportlocs[AR.name] = AR
 
 	sortTim(adminbusteleportlocs, /proc/cmp_text_dsc)

--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -67,45 +67,47 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	var/general_area = /area/station	// the highest parent bellow /area,
 	var/general_area_name = "Station"
 
-
-/*Adding a wizard area teleport list because motherfucking lag -- Urist*/
-/*I am far too lazy to make it a proper list of areas so I'll just make it run the usual telepot routine at the start of the game*/
 var/list/teleportlocs = list()
 
+//Wizards can teleport to any area on station
 proc/process_teleport_locs()
 	for(var/area/AR in areas)
-		if(istype(AR, /area/shuttle) || istype(AR, /area/syndicate_station) || istype(AR, /area/wizard_station)) continue
-		if(teleportlocs.Find(AR.name)) continue
+		//Cannot teleport on shuttles or antag outposts
+		//if(istype(AR, /area/shuttle) || istype(AR, /area/syndicate_station) || istype(AR, /area/wizard_station))
+			//continue
+		//if(teleportlocs.Find(AR.name))
+			//continue
 		var/turf/picked = safepick(get_area_turfs(AR.type))
-		if (picked && picked.z == 1)
-			teleportlocs += AR.name
+		if(picked && picked.z == map.zMainStation)
+			teleportlocs |= AR.name
 			teleportlocs[AR.name] = AR
 
 	sortTim(teleportlocs, /proc/cmp_text_asc)
 
 var/list/ghostteleportlocs = list()
 
+//Ghosts can go wherever they want to go, they're free
 proc/process_ghost_teleport_locs()
 	for(var/area/AR in areas)
-		if(ghostteleportlocs.Find(AR.name)) continue
-		if(istype(AR, /area/turret_protected/aisat) || istype(AR, /area/derelict) || istype(AR, /area/tdome))
-			ghostteleportlocs += AR.name
-			ghostteleportlocs[AR.name] = AR
+		//if(ghostteleportlocs.Find(AR.name))
+			//continue
 		var/turf/picked = safepick(get_area_turfs(AR.type))
-		if (picked && (picked.z == 1 || picked.z == 5 || picked.z == 3))
-			ghostteleportlocs += AR.name
+		if(picked)
+			ghostteleportlocs |= AR.name
 			ghostteleportlocs[AR.name] = AR
 
 	sortTim(ghostteleportlocs, /proc/cmp_text_asc)
 
 var/global/list/adminbusteleportlocs = list()
 
+//Technically the same as ghost teleports for now
 proc/process_adminbus_teleport_locs()
 	for(var/area/AR in areas)
-		if(adminbusteleportlocs.Find(AR.name)) continue
+		//if(adminbusteleportlocs.Find(AR.name))
+			//continue
 		var/turf/picked = safepick(get_area_turfs(AR.type))
-		if (picked)
-			adminbusteleportlocs += AR.name
+		if(picked)
+			adminbusteleportlocs |= AR.name
 			adminbusteleportlocs[AR.name] = AR
 
 	sortTim(adminbusteleportlocs, /proc/cmp_text_dsc)


### PR DESCRIPTION
- Use |= method instead of whatever the fuck this oldcode shitcode was going for originally
- Wizards can teleport to any area on station, removing current exceptions. Only effective change is that Wizards can now teleport on the shuttles when they start docked on the station and are moved (Read : Mining and Research Shuttle)
- Ghosts can now teleport to any area. I do not see the logic in the current system at all, especially since ghosts can access Z2 via the thunderdome and there's nothing secret on the Derelict

Start-up time : Precisely one minute on Boxstation

This means a 500x500 map would load in roughly four minutes and something, under the breakpoint for server startup abort. So that's hopefully what I'll do next, I'd need the extra space to fix R&D
