### PR TITLE
Regular mommis on derelict again

### DIFF
--- a/code/game/machinery/mommi_spawner.dm
+++ b/code/game/machinery/mommi_spawner.dm
@@ -140,7 +140,7 @@
 	if(!user.client) return // Player has already been made into another mob before this one spawned, so don't make a new one
 	var/turf/T = get_turf(src)
 
-	var/mob/living/silicon/robot/mommi/M = new /mob/living/silicon/robot/mommi/soviet(T)
+	var/mob/living/silicon/robot/mommi/M = new /mob/living/silicon/robot/mommi(T)
 	if(!M)	return
 
 	M.invisibility = 0
@@ -163,7 +163,7 @@
 
 	M.mmi = new /obj/item/device/mmi(M)
 	M.mmi.transfer_identity(user)
-	//M.Namepick()
+	M.Namepick()
 	M.updatename()
 
 	qdel(user)


### PR DESCRIPTION
I don't know precisely the full plans that N3X15 had for derelict mommis to be more Russian-ized, but they were incomplete and we have no way of knowing if they will ever be completed at this point. 

Therefore, unless N3X15 comes back to finish whatever rework he had planned I am changing the type of mommi spawned on the derelict back to the standard type (with namepicking)
Fixes #6848