### PR TITLE
Fix #4230

### DIFF
--- a/code/game/mecha/equipment/tools/tools.dm
+++ b/code/game/mecha/equipment/tools/tools.dm
@@ -33,6 +33,11 @@
 	if(!istype(chassis, /obj/mecha/working/ripley)) return
 	var/obj/mecha/working/ripley/R = chassis
 
+	if(istype(target,/obj/machinery/power/supermatter))
+		var/obj/machinery/power/supermatter/supermatter = target
+		if(supermatter.damage) //is it overheating
+			occupant_message("<span class='danger'>The supermatter is fluctuating too wildly to safely lift!</span>")
+			return
 	if(istype(target, /obj/structure/bed))
 		occupant_message("<span class='warning'>Safety features prevent this action.</span>")
 		return //no picking up rollerbeds
@@ -68,6 +73,9 @@
 				O.anchored = 1 //Why
 				var/T = chassis.loc
 				if(do_after_cooldown(target))
+					var/list/oh_shit_new_living_in_target = target.search_contents_for(/mob/living)
+					if(oh_shit_new_living_in_target.len)
+						return
 					if(T == chassis.loc && src == chassis.selected)
 						R.cargo += O
 						O.loc = chassis

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -99,16 +99,17 @@
 	. = ..()
 
 /obj/machinery/power/supermatter/proc/explode()
-		explosion(get_turf(src), explosion_power, explosion_power * 2, explosion_power * 3, explosion_power * 4, 1)
-		new /turf/unsimulated/wall/supermatter(get_turf(src))
-		SetUniversalState(/datum/universal_state/supermatter_cascade)
-		qdel(src)
+	explosion(get_turf(src), explosion_power, explosion_power * 2, explosion_power * 3, explosion_power * 4, 1)
+	new /turf/unsimulated/wall/supermatter(get_turf(src))
+	SetUniversalState(/datum/universal_state/supermatter_cascade)
+	empulse(get_turf(src), 100, 200, 1)
+	qdel(src)
 
 /obj/machinery/power/supermatter/shard/explode()
-		explosion(get_turf(src), explosion_power, explosion_power * 2, explosion_power * 3, explosion_power * 4, 1)
-		empulse(get_turf(src), 100, 200, 1)
-		qdel(src)
-		return
+	explosion(get_turf(src), explosion_power, explosion_power * 2, explosion_power * 3, explosion_power * 4, 1)
+	empulse(get_turf(src), 100, 200, 1)
+	qdel(src)
+	return
 
 /obj/machinery/power/supermatter/ex_act(severity)
 	switch(severity)


### PR DESCRIPTION
Mech clamps cant pick up supermatters - ones that are currently melting down that is, they can still pick up regular ones.

Mech clamps cant pick up objects that a mob snuck its way inside between the do_after time.