### PR TITLE
Fix #4968

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -990,7 +990,8 @@ About the new airlock wires panel:
 			// TODO: analyze the called proc
 			if (shock(user, 100))
 				return
-	if (!panel_open)
+	//Basically no open panel, not opening already, door has power, area has power, door isn't bolted
+	if (!panel_open && !operating && arePowerSystemsOn() && !(stat & NOPOWER|BROKEN) && !locked)
 		..(user)
 	//else
 	//	// TODO: logic for adding fingerprints when interacting with wires

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -190,8 +190,8 @@ var/list/all_doors = list()
 			return open()
 
 	playsound(src.loc, 'sound/machines/denied.ogg', 50, 1)
-	door_animate("deny")
-	return
+	if(density) //Why are we playing a denied animation on an OPEN DOOR
+		door_animate("deny")
 
 /obj/machinery/door/blob_act()
 	if(prob(BLOB_PROBABILITY))


### PR DESCRIPTION
Door denying animations won't play when doors are open

They also will no longer play when a door lacks power, the area lacks power, the door is bolted shut or when its already opening