### PR TITLE
Move Boxstation to 500x500 following start-up improvements

### DIFF
--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -17,6 +17,10 @@
 		var/area/A = loc
 		A.area_turfs += src
 
+	if(ticker)
+		initialize()
+
+/turf/space/initialize()
 	if(!istype(src, /turf/space/transit))
 		icon_state = "[((x + y) ^ ~(x * y) + z) % 25]"
 

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -17,10 +17,6 @@
 		var/area/A = loc
 		A.area_turfs += src
 
-	if(ticker)
-		initialize()
-
-/turf/space/initialize()
 	if(!istype(src, /turf/space/transit))
 		icon_state = "[((x + y) ^ ~(x * y) + z) % 25]"
 

--- a/maps/tgstation.dm
+++ b/maps/tgstation.dm
@@ -7,8 +7,8 @@
 	nameShort = "box"
 	nameLong = "Box Station"
 	map_dir = "boxstation"
-	tDomeX = 128
-	tDomeY = 69
+	tDomeX = 250
+	tDomeY = 99
 	tDomeZ = 2
 	zLevels = list(
 		/datum/zLevel/station,


### PR DESCRIPTION
This is a small cut-off from 512 because I guess 500x500 sounds neater and if we ever have to expand against it'll be in 10s or 50s, not all the way to 1024

The Thunderdome locs were updated as needed, no functional changes were made to the map beyond making it have a ton more space (literally)

Statistics : 
- Startup on 255x255 took 43 seconds
- Startup on 500x500 took 1 minute and 50 seconds. That's 2.55 times more, but  its hard to do better when you increase the map size
- Nothing seems to have unnaturally increased setup time, the minimap tries to set up 250k tiles but finishes at 22k because the rest is space
- After initial setup and before startup, there were 1.61 million instances on the map

This concerns only Boxstation as other maps might warrant fixes before being expanded, and I want to see how it behaves live before committing all the maps and a lot more time to it

The main reason why I'm bothering to push on feature freeze time is because the problem that caused me to try it before is still here. The map is too small, preventing effective changes and area expansions without cannibalizing the rest of the station (for example, Boxstation R&D needs expansion but right now there's a literal two tiles of clearance on the eastern side)
