### PR TITLE
Fixes bizarre blood type chimera-like bug, forces random blood types. [NEEDS REVIEW, TOUCHES CLIENT PREFF SAVEFILES]

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -167,3 +167,16 @@ proc/add_ghostlogs(var/mob/user, var/obj/target, var/what_done, var/admin=1, var
 
 /mob/proc/isVentCrawling()
 	return (istype(loc, /obj/machinery/atmospherics)) // Crude but no other situation would put them inside of this
+
+/proc/random_blood_type()
+	return pick(4;"O-", 36;"O+", 3;"A-", 28;"A+", 1;"B-", 20;"B+", 1;"AB-", 5;"AB+")
+	//https://en.wikipedia.org/wiki/Blood_type_distribution_by_country
+	/*return pick(\
+		41.9; "O+",\
+		31.2; "A+",\
+		15.4; "B+",\
+		4.8; "AB+",\
+		2.9; "O-",\
+		2.7; "A-",\
+		0.8; "B-",\
+		0.3; "AB-")*/

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -72,7 +72,7 @@
 		var/datum/data/record/M = new()
 		M.fields["id"]			= id
 		M.fields["name"]		= H.real_name
-		M.fields["b_type"]		= H.b_type
+		M.fields["b_type"]		= H.dna.b_type
 		M.fields["b_dna"]		= H.dna.unique_enzymes
 		M.fields["mi_dis"]		= "None"
 		M.fields["mi_dis_d"]	= "No minor disabilities have been declared."
@@ -111,7 +111,7 @@
 		L.fields["rank"] 		= H.mind.assigned_role
 		L.fields["age"]			= H.age
 		L.fields["sex"]			= H.gender
-		L.fields["b_type"]		= H.b_type
+		L.fields["b_type"]		= H.dna.b_type
 		L.fields["b_dna"]		= H.dna.unique_enzymes
 		L.fields["enzymes"]		= H.dna.SE // Used in respawning
 		L.fields["identity"]	= H.dna.UI // "

--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -62,7 +62,7 @@
 <BR>
 <B>Name:</B> [src.victim.real_name]<BR>
 <B>Age:</B> [src.victim.age]<BR>
-<B>Blood Type:</B> [src.victim.b_type]<BR>
+<B>Blood Type:</B> [src.victim.dna.b_type]<BR>
 <BR>
 <B>Health:</B> [src.victim.health]<BR>
 <B>Brute Damage:</B> [src.victim.getBruteLoss()]<BR>

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -3118,7 +3118,7 @@
 				dat += "<table cellspacing=5><tr><th>Name</th><th>DNA</th><th>Blood Type</th></tr>"
 				for(var/mob/living/carbon/human/H in mob_list)
 					if(H.dna && H.ckey)
-						dat += "<tr><td>[H]</td><td>[H.dna.unique_enzymes]</td><td>[H.b_type]</td></tr>"
+						dat += "<tr><td>[H]</td><td>[H.dna.unique_enzymes]</td><td>[H.dna.b_type]</td></tr>"
 				dat += "</table>"
 				usr << browse(dat, "window=DNA;size=440x410")
 			if("fingerprints")

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -445,7 +445,6 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		new_character.real_name = record_found.fields["name"]
 		new_character.setGender(record_found.fields["sex"])
 		new_character.age = record_found.fields["age"]
-		new_character.b_type = record_found.fields["b_type"]
 	else
 		new_character.setGender(pick(MALE,FEMALE))
 		var/datum/preferences/A = new()
@@ -467,6 +466,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(record_found)//Pull up their name from database records if they did have a mind.
 		new_character.dna = new()//Let's first give them a new DNA.
 		new_character.dna.unique_enzymes = record_found.fields["b_dna"]//Enzymes are based on real name but we'll use the record for conformity.
+		new_character.dna.b_type = record_found.fields["b_type"]
 
 		// I HATE BYOND.  HATE.  HATE. - N3X
 		var/list/newSE= record_found.fields["enzymes"]

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -63,7 +63,6 @@ var/const/MAX_SAVE_SLOTS = 8
 	var/be_random_body = 0				//whether we'll have a random body every round
 	var/gender = MALE					//gender of character (well duh)
 	var/age = 30						//age of character
-	var/b_type = "A+"					//blood type (not-chooseable)
 	var/underwear = 1					//underwear type
 	var/backbag = 2						//backpack type
 	var/h_style = "Bald"				//Hair type
@@ -142,7 +141,6 @@ var/const/MAX_SAVE_SLOTS = 8
 	var/client/client
 
 /datum/preferences/New(client/C)
-	b_type = pick(4;"O-", 36;"O+", 3;"A-", 28;"A+", 1;"B-", 20;"B+", 1;"AB-", 5;"AB+")
 	client=C
 	if(istype(C))
 		if(!IsGuestKey(C.key))
@@ -175,7 +173,6 @@ var/const/MAX_SAVE_SLOTS = 8
 	<table width='100%'><tr><td width='24%' valign='top'>
 	<b>Species:</b> <a href='?_src_=prefs;preference=species;task=input'>[species]</a><BR>
 	<b>Secondary Language:</b> <a href='byond://?src=\ref[user];preference=language;task=input'>[language]</a><br>
-	<b>Blood Type:</b> <a href='byond://?src=\ref[user];preference=b_type;task=input'>[b_type]</a><BR>
 	<b>Skin Tone:</b> <a href='?_src_=prefs;preference=s_tone;task=input'>[-s_tone + 35]/220<br></a><BR>
 	<b>Handicaps:</b> <a href='byond://?src=\ref[user];task=input;preference=disabilities'><b>Set</a></b><br>
 	<b>Limbs:</b> <a href='byond://?src=\ref[user];preference=limbs;task=input'>Set</a><br>
@@ -939,11 +936,6 @@ NOTE:  The change will take effect AFTER any current recruiting periods."}
 					if(new_metadata)
 						metadata = sanitize(copytext(new_metadata,1,MAX_MESSAGE_LEN))
 
-				if("b_type")
-					var/new_b_type = input(user, "Choose your character's blood-type:", "Character Preference") as null|anything in list( "A+", "A-", "B+", "B-", "AB+", "AB-", "O+", "O-" )
-					if(new_b_type)
-						b_type = new_b_type
-
 				if("hair")
 					if(species == "Human" || species == "Unathi")
 						var/new_hair = input(user, "Choose your character's hair colour:", "Character Preference") as color|null
@@ -1258,7 +1250,6 @@ NOTE:  The change will take effect AFTER any current recruiting periods."}
 	character.name = character.real_name
 	if(character.dna)
 		character.dna.real_name = character.real_name
-		character.dna.b_type = b_type
 
 	character.flavor_text = flavor_text
 	character.med_record = med_record

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1258,6 +1258,7 @@ NOTE:  The change will take effect AFTER any current recruiting periods."}
 	character.name = character.real_name
 	if(character.dna)
 		character.dna.real_name = character.real_name
+		character.dna.b_type = b_type
 
 	character.flavor_text = flavor_text
 	character.med_record = med_record
@@ -1266,7 +1267,6 @@ NOTE:  The change will take effect AFTER any current recruiting periods."}
 
 	character.setGender(gender)
 	character.age = age
-	character.b_type = b_type
 
 	character.r_eyes = r_eyes
 	character.g_eyes = g_eyes

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -292,7 +292,7 @@ SELECT
     body.eyes_green,
     body.eyes_blue,
     body.underwear,
-    body.backbag,
+    body.backbag
 FROM
     players
 INNER JOIN
@@ -660,7 +660,7 @@ AND players.player_slot = ? ;"}, ckey, slot)
 	if(check.Execute(db))
 		if(!check.NextRow())
 			q.Add("INSERT INTO body (player_ckey,player_slot,hair_red,hair_green,hair_blue,facial_red,facial_green,facial_blue,skin_tone,hair_style_name,facial_style_name,eyes_red,eyes_green,eyes_blue,underwear,backbag) \
-					VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)", ckey, slot, r_hair, g_hair, b_hair, r_facial, g_facial, b_facial, s_tone, h_style, f_style, r_eyes, g_eyes, b_eyes, underwear, backbag)
+					VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)", ckey, slot, r_hair, g_hair, b_hair, r_facial, g_facial, b_facial, s_tone, h_style, f_style, r_eyes, g_eyes, b_eyes, underwear, backbag)
 			if(!q.Execute(db))
 				message_admins("Error #:[q.Error()] - [q.ErrorMsg()]")
 				warning("Error #:[q.Error()] - [q.ErrorMsg()]")

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -293,7 +293,6 @@ SELECT
     body.eyes_blue,
     body.underwear,
     body.backbag,
-    body.b_type
 FROM
     players
 INNER JOIN
@@ -374,7 +373,6 @@ AND players.player_slot = ? ;"}, ckey, slot)
 
 	underwear			= text2num(preference_list["underwear"])
 	backbag				= text2num(preference_list["backbag"])
-	b_type				= preference_list["b_type"]
 
 	organ_data["l_arm"] = preference_list["l_arm"]
 	organ_data["r_arm"] = preference_list["r_arm"]
@@ -431,7 +429,6 @@ AND players.player_slot = ? ;"}, ckey, slot)
 
 	underwear		= sanitize_integer(underwear, 1, underwear_m.len, initial(underwear))
 	backbag			= sanitize_integer(backbag, 1, backbaglist.len, initial(backbag))
-	b_type			= sanitize_text(b_type, initial(b_type))
 	//be_special      = sanitize_integer(be_special, 0, 65535, initial(be_special))
 
 	alternate_option = sanitize_integer(alternate_option, 0, 2, initial(alternate_option))
@@ -496,7 +493,6 @@ AND players.player_slot = ? ;"}, ckey, slot)
 	S["eyes_blue"]			>> b_eyes
 	S["underwear"]			>> underwear
 	S["backbag"]			>> backbag
-	S["b_type"]				>> b_type
 
 	//Jobs
 	S["alternate_option"]	>> alternate_option
@@ -550,7 +546,6 @@ AND players.player_slot = ? ;"}, ckey, slot)
 	b_eyes			= sanitize_integer(b_eyes, 0, 255, initial(b_eyes))
 	underwear		= sanitize_integer(underwear, 1, underwear_m.len, initial(underwear))
 	backbag			= sanitize_integer(backbag, 1, backbaglist.len, initial(backbag))
-	b_type			= sanitize_text(b_type, initial(b_type))
 
 	alternate_option = sanitize_integer(alternate_option, 0, 2, initial(alternate_option))
 	job_civilian_high = sanitize_integer(job_civilian_high, 0, 65535, initial(job_civilian_high))
@@ -664,16 +659,16 @@ AND players.player_slot = ? ;"}, ckey, slot)
 	check.Add("SELECT player_ckey FROM body WHERE player_ckey = ? AND player_slot = ?", ckey, slot)
 	if(check.Execute(db))
 		if(!check.NextRow())
-			q.Add("INSERT INTO body (player_ckey,player_slot,hair_red,hair_green,hair_blue,facial_red,facial_green,facial_blue,skin_tone,hair_style_name,facial_style_name,eyes_red,eyes_green,eyes_blue,underwear,backbag,b_type) \
-					VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)", ckey, slot, r_hair, g_hair, b_hair, r_facial, g_facial, b_facial, s_tone, h_style, f_style, r_eyes, g_eyes, b_eyes, underwear, backbag, b_type)
+			q.Add("INSERT INTO body (player_ckey,player_slot,hair_red,hair_green,hair_blue,facial_red,facial_green,facial_blue,skin_tone,hair_style_name,facial_style_name,eyes_red,eyes_green,eyes_blue,underwear,backbag) \
+					VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)", ckey, slot, r_hair, g_hair, b_hair, r_facial, g_facial, b_facial, s_tone, h_style, f_style, r_eyes, g_eyes, b_eyes, underwear, backbag)
 			if(!q.Execute(db))
 				message_admins("Error #:[q.Error()] - [q.ErrorMsg()]")
 				warning("Error #:[q.Error()] - [q.ErrorMsg()]")
 				return 0
 			to_chat(user, "Created Body")
 		else
-			q.Add("UPDATE body SET hair_red=?,hair_green=?,hair_blue=?,facial_red=?,facial_green=?,facial_blue=?,skin_tone=?,hair_style_name=?,facial_style_name=?,eyes_red=?,eyes_green=?,eyes_blue=?,underwear=?,backbag=?,b_type=? WHERE player_ckey = ? AND player_slot = ?",\
-									r_hair, g_hair, b_hair, r_facial, g_facial, b_facial, s_tone, h_style, f_style, r_eyes, g_eyes, b_eyes, underwear, backbag, b_type, ckey, slot)
+			q.Add("UPDATE body SET hair_red=?,hair_green=?,hair_blue=?,facial_red=?,facial_green=?,facial_blue=?,skin_tone=?,hair_style_name=?,facial_style_name=?,eyes_red=?,eyes_green=?,eyes_blue=?,underwear=?,backbag=? WHERE player_ckey = ? AND player_slot = ?",\
+									r_hair, g_hair, b_hair, r_facial, g_facial, b_facial, s_tone, h_style, f_style, r_eyes, g_eyes, b_eyes, underwear, backbag, ckey, slot)
 			if(!q.Execute(db))
 				message_admins("Error #:[q.Error()] - [q.ErrorMsg()]")
 				warning("Error #:[q.Error()] - [q.ErrorMsg()]")
@@ -798,7 +793,6 @@ AND players.player_slot = ? ;"}, ckey, slot)
 	S["eyes_blue"]             << b_eyes
 	S["underwear"]             << underwear
 	S["backbag"]               << backbag
-	S["b_type"]                << b_type
 
 	//Jobs
 	S["alternate_option"]      << alternate_option

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -83,6 +83,7 @@
 	if(!dna)
 		dna = new /datum/dna(null)
 		dna.species=species.name
+		dna.b_type = random_blood_type()
 
 	hud_list[HEALTH_HUD]      = image('icons/mob/hud.dmi', src, "hudhealth100")
 	hud_list[STATUS_HUD]      = image('icons/mob/hud.dmi', src, "hudhealthy")

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -25,7 +25,7 @@
 	mob_swap_flags = ALLMOBS
 
 	var/age = 30		//Player's age (pure fluff)
-	var/b_type = "A+"	//Player's bloodtype
+	//var/b_type = "A+"	//Player's bloodtype //NOW HANDLED IN THEIR DNA
 
 	var/underwear = 1	//Which underwear the player wants
 	var/backbag = 2		//Which backpack type the player has chosen. Nothing, Satchel or Backpack.

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -81,14 +81,14 @@
 			setGender(pick(MALE, FEMALE))
 		dna = new /datum/dna( null )
 		dna.real_name = real_name
-		dna.b_type = pick("A+","A-","AB+","AB-","O+","O-")
+		dna.b_type = random_blood_type()
 		dna.ResetSE()
 		dna.ResetUI()
 		//dna.uni_identity = "00600200A00E0110148FC01300B009"
 		//dna.SetUI(list(0x006,0x002,0x00A,0x00E,0x011,0x014,0x8FC,0x013,0x00B,0x009))
 		//dna.struc_enzymes = "43359156756131E13763334D1C369012032164D4FE4CD61544B6C03F251B6C60A42821D26BA3B0FD6"
 		//dna.SetSE(list(0x433,0x591,0x567,0x561,0x31E,0x137,0x633,0x34D,0x1C3,0x690,0x120,0x321,0x64D,0x4FE,0x4CD,0x615,0x44B,0x6C0,0x3F2,0x51B,0x6C6,0x0A4,0x282,0x1D2,0x6BA,0x3B0,0xFD6))
-		dna.unique_enzymes = md5(name)
+		dna.unique_enzymes = md5(name) //Possibly not working?
 
 		// We're a monkey
 		dna.SetSEState(MONKEYBLOCK,   1)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -458,7 +458,6 @@ Round Duration: [round(hours)]h [round(mins)]m<br>"}
 
 	new_character.name = real_name
 	new_character.dna.ready_dna(new_character)
-	new_character.dna.b_type = client.prefs.b_type
 
 	if(client.prefs.disabilities & DISABILITY_FLAG_NEARSIGHTED)
 		new_character.dna.SetSEState(GLASSESBLOCK,1,1)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -459,6 +459,9 @@ Round Duration: [round(hours)]h [round(mins)]m<br>"}
 	new_character.name = real_name
 	new_character.dna.ready_dna(new_character)
 
+	if(new_character.mind)
+		new_character.mind.store_memory("<b>Your blood type is:</b> [new_character.dna.b_type]<br>")
+
 	if(client.prefs.disabilities & DISABILITY_FLAG_NEARSIGHTED)
 		new_character.dna.SetSEState(GLASSESBLOCK,1,1)
 		new_character.disabilities |= NEARSIGHTED

--- a/html/changelogs/9600bauds_someonehadtodoit.yml
+++ b/html/changelogs/9600bauds_someonehadtodoit.yml
@@ -32,8 +32,8 @@ delete-after: True
 # SCREW THIS UP AND IT WON'T WORK.
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 changes: 
-- bugfix: Fixed a very bizzare bug that could result in humans (especially monkeymen and head transplanted players) having TWO different blood types, each one of them only used for certain things.
+- bugfix: Fixed a very bizzare bug that could result in humans (especially lings, monkeymen, and head transplanted players) having TWO different blood types, each one of them only used for certain things.
 - bugfix: Monkeymen will now properly have randomized blood types.
 - rscdel: Players will now have randomized blood types as well. Random blood types follow a weighted distribution. Hopefully this will save Medbay from a lot of headaches.
 - experiment: "The blood type distribution is as follows: 36% O+, 28% A+, 20% B+, 5% AB+, 4% O-, 3% A-, 1% B-, 1% AB-. This is the same distribution Monkeymen were supposed to have, although a bug prevented it from working properly."
-- experiment: Remind yourself that you can check your blood type by examining your ID. Same goes for checking other people's blood type.
+- rscadd: Your blood type is now added to your character notes when you spawn, in case you lose your ID (use the 'notes' verb, IC tab). You can check on other people's blood type by examining their ID or using the Medical Records database.

--- a/html/changelogs/9600bauds_someonehadtodoit.yml
+++ b/html/changelogs/9600bauds_someonehadtodoit.yml
@@ -1,0 +1,39 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general deleting of nice things)
+#   rscadd (general adding of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: 9600bauds
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+changes: 
+- bugfix: Fixed a very bizzare bug that could result in humans (especially monkeymen and head transplanted players) having TWO different blood types, each one of them only used for certain things.
+- bugfix: Monkeymen will now properly have randomized blood types.
+- rscdel: Players will now have randomized blood types as well. Random blood types follow a weighted distribution. Hopefully this will save Medbay from a lot of headaches.
+- experiment: "The blood type distribution is as follows: 36% O+, 28% A+, 20% B+, 5% AB+, 4% O-, 3% A-, 1% B-, 1% AB-. This is the same distribution Monkeymen were supposed to have, although a bug prevented it from working properly."
+- experiment: Remind yourself that you can check your blood type by examining your ID. Same goes for checking other people's blood type.


### PR DESCRIPTION
Someone was going to do it at some point.

Fixes some weird shit where players had two different b_type variables, and nearly everything arbitrarily used either. This was especially bad because monkeymen and head transplants would always have A+ in one of those blood types.

Forces random blood types. The blood type distribution is as follows: 36% O+, 28% A+, 20% B+, 5% AB+, 4% O-, 3% A-, 1% B-, 1% AB-.

~~This needs some serious review in terms of triple-checking that I have removed blood type from client preferences in a proper way. I really don't want this to fuck up client savefiles and I have no way of checking, since I don't have a sqlite database set up.
Paging Doctor @ririchiyo~~

Fixes #4029
