### PR TITLE
Bone repair surgery will now directly heal the limb if it's beyond instabreak point, rather than not let you repair the bone in the first place.

### DIFF
--- a/code/modules/surgery/bones.dm
+++ b/code/modules/surgery/bones.dm
@@ -20,12 +20,12 @@
 	var/datum/organ/external/affected = target.get_organ(target_zone)
 	return (affected.open >= 2 || (target.species.flags & NO_SKIN)) && affected.stage == 0
 
-/datum/surgery_step/glue_bone/can_operate(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/*/datum/surgery_step/glue_bone/can_operate(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/datum/organ/external/affected = target.get_organ(target_zone)
 	if(affected.brute_dam >= affected.min_broken_damage * config.organ_health_multiplier)
 		to_chat(user, "<span class='warning'>The [affected.display_name] is far too damaged to operate on the fracture. Fix some of the damage first.</span>")
 		return 0
-	return ..()
+	return ..()*/
 
 /datum/surgery_step/glue_bone/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/datum/organ/external/affected = target.get_organ(target_zone)
@@ -62,12 +62,12 @@
 	var/datum/organ/external/affected = target.get_organ(target_zone)
 	return affected.name != "head" && (affected.open >= 2 || (target.species.flags & NO_SKIN)) && affected.stage == 1
 
-/datum/surgery_step/set_bone/can_operate(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/*/datum/surgery_step/set_bone/can_operate(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/datum/organ/external/affected = target.get_organ(target_zone)
 	if(affected.brute_dam >= affected.min_broken_damage * config.organ_health_multiplier)
 		to_chat(user, "<span class='warning'>The [affected.display_name] is far too damaged to operate on the fracture. Fix some of the damage first.</span>")
 		return 0
-	return ..()
+	return ..()*/
 
 /datum/surgery_step/set_bone/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/datum/organ/external/affected = target.get_organ(target_zone)
@@ -83,8 +83,8 @@
 			"<span class='notice'>You set the bone in [target]'s [affected.display_name] in place with \the [tool].</span>")
 		affected.stage = 2
 	else
-		user.visible_message("<span class='notice'>[user] sets the bone in [target]'s [affected.display_name]<span class='warning'>in the WRONG place with \the [tool].</span>", \
-			"<span class='notice'>You set the bone in [target]'s [affected.display_name]<span class='warning'>in the WRONG place with \the [tool].</span>")
+		user.visible_message("<span class='notice'>[user] sets the bone in [target]'s [affected.display_name] <span class='warning'>in the WRONG place with \the [tool].</span>", \
+			"<span class='notice'>You set the bone in [target]'s [affected.display_name] <span class='warning'>in the WRONG place with \the [tool].</span>")
 		affected.fracture()
 
 /datum/surgery_step/set_bone/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -109,12 +109,12 @@
 	var/datum/organ/external/affected = target.get_organ(target_zone)
 	return affected.name == "head" && (affected.open >= 2 || (target.species.flags & NO_SKIN))&& affected.stage == 1
 
-/datum/surgery_step/mend_skull/can_operate(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/*/datum/surgery_step/mend_skull/can_operate(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/datum/organ/external/affected = target.get_organ(target_zone)
 	if(affected.brute_dam >= affected.min_broken_damage * config.organ_health_multiplier)
 		to_chat(user, "<span class='warning'>The [affected.display_name] is far too damaged to operate on the fracture. Fix some of the damage first.</span>")
 		return 0
-	return ..()
+	return ..()*/
 
 /datum/surgery_step/mend_skull/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	user.visible_message("[user] is beginning piece together [target]'s skull with \the [tool]."  , \
@@ -154,12 +154,12 @@
 	var/datum/organ/external/affected = target.get_organ(target_zone)
 	return (affected.open >= 2 || (target.species.flags & NO_SKIN)) && affected.stage == 2
 
-/datum/surgery_step/finish_bone/can_operate(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/*/datum/surgery_step/finish_bone/can_operate(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/datum/organ/external/affected = target.get_organ(target_zone)
 	if(affected.brute_dam >= affected.min_broken_damage * config.organ_health_multiplier)
 		to_chat(user, "<span class='warning'>The [affected.display_name] is far too damaged to operate on the fracture. Fix some of the damage first.</span>")
 		return 0
-	return ..()
+	return ..()*/
 
 /datum/surgery_step/finish_bone/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/datum/organ/external/affected = target.get_organ(target_zone)
@@ -175,11 +175,8 @@
 	affected.status &= ~ORGAN_SPLINTED
 	affected.stage = 0
 	affected.perma_injury = 0
-	/*
-	if(target.stat != DEAD && affected.brute_dam >= affected.min_broken_damage * config.organ_health_multiplier)
+	if(affected.brute_dam >= affected.min_broken_damage * config.organ_health_multiplier)
 		affected.heal_damage(affected.brute_dam - (affected.min_broken_damage - rand(3,5)) * config.organ_health_multiplier) //Put the limb's brute damage just under the bone breaking threshold, to prevent it from instabreaking again.
-		//This was actually bad because it would either not work on dead people, or allow people that died from >200 brute damage to be defibbed.
-	*/
 
 /datum/surgery_step/finish_bone/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/datum/organ/external/affected = target.get_organ(target_zone)

--- a/html/changelogs/9600bauds_bonezone.yml
+++ b/html/changelogs/9600bauds_bonezone.yml
@@ -1,0 +1,35 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general deleting of nice things)
+#   rscadd (general adding of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: 9600bauds
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+changes: 
+- tweak: Better solution to the 'bone explodes immediately after being mended' syndrome. You will now once again be able to fix bones no matter the damage level of the limb. If the limb is so damaged that it would immediately break again after setting the bone, it will now heal to just under bone fracture levels. Note that this effectively lets you heal brute damage on dead people.


### PR DESCRIPTION
Take for example a doctor trying to fix a bone in an arm that has 40 brute damage. Arm bones instabreak if the arm ever has 30 brute damage or more.

How this used to work before my first fix: The surgery would work as normal, but when the doctor sets the bone, it immediately shatters again, at which point the doctor would try to set it again and it would break over and over.

How it worked after my first fix: It would simply not let you start the surgery at all, to prevent confusion. While this worked in stopping the perpetually shattering bone syndrome, some people didn't like that.

How it will work now: After fixing the bone, the arm will heal to ~27 brute damage or so. A lot more intuitive.

Essentially reverts #7796
