### PR TITLE
Adds a noir genetics block which the detective starts roundstart with if he has selected the "Gumshoe" alternate title. This block turns vision black and white except for blood, which stands out as red.

### DIFF
--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -32,7 +32,7 @@
 #define DNA_UI_HAIR_STYLE  13
 #define DNA_UI_LENGTH      13 // Update this when you add something, or you WILL break shit.
 
-#define DNA_SE_LENGTH 54 // Was STRUCDNASIZE, size 27. 15 new blocks added = 42, plus room to grow.
+#define DNA_SE_LENGTH 55 // Was STRUCDNASIZE, size 27. 15 new blocks added = 42, plus room to grow.
 
 // Defines which values mean "on" or "off".
 //  This is to make some of the more OP superpowers a larger PITA to activate,

--- a/code/game/dna/genes/vg_powers.dm
+++ b/code/game/dna/genes/vg_powers.dm
@@ -120,3 +120,30 @@ Obviously, requires DNA2.
 	if((M.sdisabilities & BLIND) || (M.disabilities & NEARSIGHTED))
 		return 0
 	return ..(M,flags)
+
+var/list/NOIRLIST = list(0.3,0.3,0.3,0,\
+			 			 0.3,0.3,0.3,0,\
+						 0.3,0.3,0.3,0,\
+						 0.0,0.0,0.0,1,)
+
+/datum/dna/gene/basic/noir
+	name="Noir"
+	desc = "In recent years, there's been a real push towards 'Detective Noir' movies, but since the last black and white camera was lost many centuries ago, Scientists had to develop a way to turn any movie noir."
+	activation_messages=list("The Station's bright coloured light hits your eyes for the last time, and fades into a more appropriate tone, something's different about this place, but you can't put your finger on it. You feel a need to check out the bar, maybe get to the bottom of what's going on in this godforsaken place.")
+	deactivation_messages = list("You now feel soft boiled.")
+
+	mutation=M_NOIR
+
+/datum/dna/gene/basic/noir/New()
+	block=NOIRBLOCK
+	..()
+
+/datum/dna/gene/basic/noir/OnMobLife(var/mob/M)
+	..()
+	if(M.client)
+		M.client.color = NOIRLIST
+
+/datum/dna/gene/basic/noir/deactivate(var/mob/M,var/connected,var/flags)
+	if(..())
+		if(M.client && M.client.color == NOIRLIST)
+			M.client.color = null

--- a/code/game/gamemodes/setupgame.dm
+++ b/code/game/gamemodes/setupgame.dm
@@ -102,6 +102,7 @@
 	WHISPERBLOCK   = getAssignedBlock("WHISPER",    numsToAssign)
 	DIZZYBLOCK     = getAssignedBlock("DIZZY",      numsToAssign)
 	SANSBLOCK      = getAssignedBlock("SANS",       numsToAssign)
+	NOIRBLOCK      = getAssignedBlock("NOIR",       numsToAssign, good=1)
 
 
 	//

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -113,7 +113,7 @@
 
 	access = list(access_weapons, access_security, access_sec_doors, access_forensics_lockers, access_morgue, access_maint_tunnels, access_court, access_eva)
 	minimal_access = list(access_weapons, access_security, access_sec_doors, access_forensics_lockers, access_morgue, access_maint_tunnels, access_court)
-	alt_titles = list("Forensic Technician")
+	alt_titles = list("Forensic Technician","Gumshoe")
 
 	minimal_player_age = 7
 
@@ -157,6 +157,9 @@
 		affected.implants += L
 		L.part = affected
 		H.dna.SetSEState(SOBERBLOCK,1)
+		if(H.mind.role_alt_title == "Gumshoe")
+			H.mutations += M_NOIR
+			H.dna.SetSEState(NOIRBLOCK,1)
 		H.mutations += M_SOBER
 		H.check_mutations = 1
 		return 1

--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -13,7 +13,7 @@ var/global/list/blood_list = list()
 	icon = 'icons/effects/blood.dmi'
 	icon_state = "mfloor1"
 	random_icon_states = list("mfloor1", "mfloor2", "mfloor3", "mfloor4", "mfloor5", "mfloor6", "mfloor7")
-
+	appearance_flags = NO_CLIENT_COLOR
 	var/base_icon = 'icons/effects/blood.dmi'
 
 	basecolor="#A10808" // Color when wet.

--- a/code/global.dm
+++ b/code/global.dm
@@ -109,6 +109,7 @@ var/LOUDBLOCK = 0
 var/WHISPERBLOCK = 0
 var/DIZZYBLOCK = 0
 var/SANSBLOCK = 0
+var/NOIRBLOCK = 0
 
 
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -95,7 +95,6 @@
 					name = capitalize(pick(first_names_female)) + " " + capitalize(pick(last_names))
 
 		mind = body.mind	//we don't transfer the mind but we keep a reference to it.
-
 	if(!T)	T = pick(latejoin)			//Safety in case we cannot find the body's position
 	loc = T
 
@@ -105,6 +104,7 @@
 
 	start_poltergeist_cooldown() //FUCK OFF GHOSTS
 	..()
+
 
 /mob/dead/observer/Destroy()
 	..()

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -37,6 +37,7 @@
 			client.screen -= spell_master
 
 	client.reset_screen()				//remove hud items just in case
+	client.color = null
 	hud_used = new /datum/hud(src)
 	gui_icons = new /datum/ui_icons(src)
 	client.screen += catcher //Catcher of clicks

--- a/code/setup.dm
+++ b/code/setup.dm
@@ -468,6 +468,7 @@ var/global/list/BODY_THERMAL_VALUE_LIST=list("[HEAD]" = THERMAL_PROTECTION_HEAD,
 #define M_DIZZY		210		// Trippy.
 #define M_SANS		211		// IF YOU SEE THIS WHILST BROWSING CODE, YOU HAVE BEEN VISITED BY: THE FONT OF SHITPOSTING. GREAT LUCK AND WEALTH WILL COME TO YOU, BUT ONLY IF YOU SAY 'fuck comic sans' IN YOUR PR.
 #define M_FARSIGHT	212		// Increases mob's view range by 2
+#define M_NOIR		213		// aww yis detective noir
 
 // Bustanuts
 #define M_HARDCORE      300

--- a/html/changelogs/DrCelt.yml
+++ b/html/changelogs/DrCelt.yml
@@ -1,2 +1,3 @@
 author: DrCelt
-changes: []
+changes:
+- rscadd: Adds a noir genetics block which the detective starts roundstart with if he has selected the "Gumshoe" alternate title. This block turns the client black and white except for blood.


### PR DESCRIPTION
Adds a noir genetics block which the detective starts roundstart with if he has selected the "Gumshoe" alternate title. This block turns vision black and white except for blood, which stands out as red.

Yes this is a feature, but @gbasood told me to do something other than complain in the IRC

obviously don't merge until nofreeze

![detectivenoir](https://cloud.githubusercontent.com/assets/7193289/12770783/584f6152-ca1b-11e5-9990-e14919cb1ac5.png)
