### PR TITLE
Changes "Nanotransen" to "Nanotrasen" and fixes typos

### DIFF
--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -383,7 +383,7 @@
 	idtype = /obj/item/weapon/card/id/centcom
 	total_positions = 2
 	spawn_positions = 2
-	supervisors = "Nanotrasen Law, CentComm Officals, and the stations captain."
+	supervisors = "Nanotrasen Law, CentComm Officals, and the station's captain."
 	selection_color = "#dddddd"
 	access = list(access_lawyer, access_court, access_sec_doors, access_maint_tunnels, access_cargo, access_medical,  access_bar, access_kitchen, access_hydroponics)
 	minimal_access = list(access_lawyer, access_court, access_sec_doors, access_cargo,  access_bar, access_kitchen)

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -383,7 +383,7 @@
 	idtype = /obj/item/weapon/card/id/centcom
 	total_positions = 2
 	spawn_positions = 2
-	supervisors = "NanoTransen Law, CentComm Officals, and the stations captain."
+	supervisors = "Nanotrasen Law, CentComm Officals, and the stations captain."
 	selection_color = "#dddddd"
 	access = list(access_lawyer, access_court, access_sec_doors, access_maint_tunnels, access_cargo, access_medical,  access_bar, access_kitchen, access_hydroponics)
 	minimal_access = list(access_lawyer, access_court, access_sec_doors, access_cargo,  access_bar, access_kitchen)

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -243,7 +243,7 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 			if(NEWSCASTER_MENU)
 
 				dat += {"Welcome to Newscasting Unit #[src.unit_no].<BR> Interface & News networks Operational.
-					<BR><FONT SIZE=1>property of Nanotransen Inc</FONT>"}
+					<BR><FONT SIZE=1>property of Nanotrasen Inc</FONT>"}
 				if(news_network.wanted_issue)
 					dat+= "<HR><A href='?src=\ref[src];view_wanted=1'>Read Wanted Issue</A>"
 
@@ -1042,7 +1042,7 @@ obj/item/weapon/newspaper/attack_self(mob/user as mob)
 			if(NEWSPAPER_TITLE_PAGE) //Cover
 
 				dat += {"<DIV ALIGN='center'><B><FONT SIZE=6>The Griffon</FONT></B></div>
-					<DIV ALIGN='center'><FONT SIZE=2>Nanotrasen-standard newspaper, for use on Nanotrasen� Space Facilities</FONT></div><HR>"}
+					<DIV ALIGN='center'><FONT SIZE=2>Nanotrasen-standard newspaper, for use on Nanotrasen Space Facilities</FONT></div><HR>"}
 				if(isemptylist(src.news_content))
 					if(src.important_message)
 						dat+="Contents:<BR><ul><B><FONT COLOR='red'>**</FONT>Important Security Announcement<FONT COLOR='red'>**</FONT></B> <FONT SIZE=2>\[page [src.pages+2]\]</FONT><BR></ul>"

--- a/code/game/objects/items/mountable_frames/paintings.dm
+++ b/code/game/objects/items/mountable_frames/paintings.dm
@@ -120,13 +120,13 @@ var/global/list/available_paintings = list(
 			desc = "A painfully standard painting, used to decorate dining rooms and bathrooms alike."
 		if("Blu")
 			name = "\improper Wai-Blu"
-			desc = "Faithfully Serving NanoTransen during her shift, gladly serving YOU after."
+			desc = "Faithfully Serving Nanotrasen during her shift, gladly serving YOU after."
 		if("Kate")
 			name = "\improper Cindy Kate"
 			desc = "Through the carnage and bloodshed she's gunning for you, champ."
 		if("daddy")
 			name = "\improper I <3 Daddy!"
-			desc = "'NanoTransen respects the right for all associates and their families to be able to express their indivuality though many media. However, soliciting NanoTransen related merchandise without proper warrant is strickly prohibited. Luckly for you, you can now own your very own contraband NanoTransen merch without the threat of *REDACTED*!'"
+			desc = "'Nanotrasen respects the right for all associates and their families to be able to express their indivuality though many media. However, soliciting Nanotrasen related merchandise without proper warrant is strickly prohibited. Luckly for you, you can now own your very own contraband Nanotrasen merch without the threat of *REDACTED*!'"
 		if("carp")
 			name = "\improper 'Singing' Mounted Carp"
 			desc = "Too unrobust to beat a carp to death with your bare hands and mount it on a plank of wood? Then this professionally taxidermied trophy is just for you! Note: Does not actually sing."
@@ -256,13 +256,13 @@ var/global/list/available_paintings = list(
 			desc = "A painfully standard painting, used to decorate dining rooms and bathrooms alike."
 		if("Blu")
 			name = "\improper Wai-Blu"
-			desc = "Faithfully Serving NanoTransen during her shift, gladly serving YOU after."
+			desc = "Faithfully Serving Nanotrasen during her shift, gladly serving YOU after."
 		if("Kate")
 			name = "\improper Cindy Kate"
 			desc = "Through the carnage and bloodshed she's gunning for you, champ."
 		if("daddy")
 			name = "\improper I <3 Daddy!"
-			desc = "'NanoTransen respects the right for all associates and their families to be able to express their indivuality though many media. However, soliciting NanoTransen related merchandise without proper warrant is strickly prohibited. Luckly for you, you can now own your very own contraband NanoTransen merch without the threat of *REDACTED*!'"
+			desc = "'Nanotrasen respects the right for all associates and their families to be able to express their indivuality though many media. However, soliciting Nanotrasen related merchandise without proper warrant is strickly prohibited. Luckly for you, you can now own your very own contraband Nanotrasen merch without the threat of *REDACTED*!'"
 		if("carp")
 			name = "\improper 'Singing' Mounted Carp"
 			desc = "Too unrobust to beat a carp to death with your bare hands and mount it on a plank of wood? Then this professionally taxidermied trophy is just for you! Note: Does not actually sing."

--- a/code/game/objects/items/mountable_frames/paintings.dm
+++ b/code/game/objects/items/mountable_frames/paintings.dm
@@ -126,7 +126,7 @@ var/global/list/available_paintings = list(
 			desc = "Through the carnage and bloodshed she's gunning for you, champ."
 		if("daddy")
 			name = "\improper I <3 Daddy!"
-			desc = "'Nanotrasen respects the right for all associates and their families to be able to express their indivuality though many media. However, soliciting Nanotrasen related merchandise without proper warrant is strickly prohibited. Luckly for you, you can now own your very own contraband Nanotrasen merch without the threat of *REDACTED*!'"
+			desc = "'Nanotrasen respects the right for all associates and their families to be able to express their indivuality though many media. However, soliciting Nanotrasen related merchandise without proper warrant is strictly prohibited. Luckly for you, you can now own your very own contraband Nanotrasen merch without the threat of *REDACTED*!'"
 		if("carp")
 			name = "\improper 'Singing' Mounted Carp"
 			desc = "Too unrobust to beat a carp to death with your bare hands and mount it on a plank of wood? Then this professionally taxidermied trophy is just for you! Note: Does not actually sing."
@@ -262,7 +262,7 @@ var/global/list/available_paintings = list(
 			desc = "Through the carnage and bloodshed she's gunning for you, champ."
 		if("daddy")
 			name = "\improper I <3 Daddy!"
-			desc = "'Nanotrasen respects the right for all associates and their families to be able to express their indivuality though many media. However, soliciting Nanotrasen related merchandise without proper warrant is strickly prohibited. Luckly for you, you can now own your very own contraband Nanotrasen merch without the threat of *REDACTED*!'"
+			desc = "'Nanotrasen respects the right for all associates and their families to be able to express their indivuality though many media. However, soliciting Nanotrasen related merchandise without proper warrant is strictly prohibited. Luckly for you, you can now own your very own contraband Nanotrasen merch without the threat of *REDACTED*!'"
 		if("carp")
 			name = "\improper 'Singing' Mounted Carp"
 			desc = "Too unrobust to beat a carp to death with your bare hands and mount it on a plank of wood? Then this professionally taxidermied trophy is just for you! Note: Does not actually sing."

--- a/code/modules/events/money_spam.dm
+++ b/code/modules/events/money_spam.dm
@@ -55,7 +55,7 @@
 					"You have (1) new message!", \
 					"You have (2) new profile views!")
 				if(3)
-					sender = pick("Galactic Payments Association", "Better Business Bureau", "Tau Ceti E-Payments", "Nanotrasen Finance Deparmtent", "Luxury Replicas")
+					sender = pick("Galactic Payments Association", "Better Business Bureau", "Tau Ceti E-Payments", "Nanotrasen Finance Department", "Luxury Replicas")
 					message = pick("Luxury watches for Blowout sale prices!", \
 					"Watches, Jewelry & Accessories, Bags & Wallets !", \
 					"Deposit 100$ and get 300$ totally free!", \

--- a/code/modules/events/money_spam.dm
+++ b/code/modules/events/money_spam.dm
@@ -55,7 +55,7 @@
 					"You have (1) new message!", \
 					"You have (2) new profile views!")
 				if(3)
-					sender = pick("Galactic Payments Association", "Better Business Bureau", "Tau Ceti E-Payments", "NAnoTransen Finance Deparmtent", "Luxury Replicas")
+					sender = pick("Galactic Payments Association", "Better Business Bureau", "Tau Ceti E-Payments", "Nanotrasen Finance Deparmtent", "Luxury Replicas")
 					message = pick("Luxury watches for Blowout sale prices!", \
 					"Watches, Jewelry & Accessories, Bags & Wallets !", \
 					"Deposit 100$ and get 300$ totally free!", \


### PR DESCRIPTION
There are 444 instances of "Nanotrasen" in the code and 11 instances of "Nanotransen" so clearly "Nanotrasen" is the correct spelling.
Also fixes a few typos.
