### PR TITLE
Sol/Galactic Common visual tweaks.

### DIFF
--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -118,18 +118,19 @@
 
 /datum/language/common
 	name = "Galactic Common"
-	desc = "A bastardized hybrid of informal English and elements of Mandarin Chinese; the common language of the Sol system."
+	desc = "The language no one would ever use is now the language every race uses."
 	key = "1"
-	flags = RESTRICTED
-
-/datum/language/human
-	name = "Sol Common"
-	desc = "The language no one would ever use is now the language every human uses."
-	key = "7"
 	flags = RESTRICTED
 	syllables = list("sa","lu","to","n","bo","na","ve","spe","ro","no","non","ki","el","vi","far","tas",
 	"ne","da","dan","ko","kon","ka","kaj","kin","de","ami","ko","kio","vin","nen","ne","nio","mi","gi","gis","per",
 	"po","vas","va","he","min","mi","cu","dig","di","gi","gis","nu","ven","as","kie","re","ven","dau")
+
+/datum/language/human
+	name = "Sol Common"
+	desc = "A bastardized hybrid of informal English and elements of Mandarin Chinese; the common language of the Sol system."
+	key = "7"
+	colour = "solcom"
+	flags = RESTRICTED
 
 /datum/language/human/monkey
 	name = "Monkey"
@@ -319,7 +320,7 @@
 	else
 		return ..()
 
-/datum/language/common/syllables = list(
+/datum/language/human/syllables = list(
 "a", "ai", "an", "ang", "ao", "ba", "bai", "ban", "bang", "bao", "bei", "ben", "beng", "bi", "bian", "biao",
 "bie", "bin", "bing", "bo", "bu", "ca", "cai", "can", "cang", "cao", "ce", "cei", "cen", "ceng", "cha", "chai",
 "chan", "chang", "chao", "che", "chen", "cheng", "chi", "chong", "chou", "chu", "chua", "chuai", "chuan", "chuang", "chui", "chun",

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -270,7 +270,10 @@
 /mob/living/remove_language(rem_language)
 	var/datum/language/L = all_languages[rem_language]
 	if(default_language == L)
-		default_language = null
+		if(all_languages.len)
+			default_language = all_languages[1]
+		else
+			default_language = null
 	return ..()
 
 // Can we speak this language, as opposed to just understanding it?

--- a/html/changelogs/Sood1.yml
+++ b/html/changelogs/Sood1.yml
@@ -1,0 +1,5 @@
+author: Sood
+delete-after: true
+changes:
+  - tweak: Sol Common is now blue, and uses its old syllables (Mandarin+English)
+  - tweak: Galactic Common is still the same color and font, but uses the Esperanto-esque syllables Sol originally used.


### PR DESCRIPTION
- Sol Common is now blue, and uses its old syllables (Mandarin+English)
  ![](http://i.imgur.com/Drwop4B.png)
- Galactic Common is still the same color and font, but uses the Esperanto-esque syllables Sol originally used.
- Hotfix for removal of default language.

> But for instance, a vox whose default language (Galactic) is removed and never set to a new default (pidgin) can speak the old default over comms until their default is changed.

![](http://i.imgur.com/Q46jCI3.png)

Resolves #8050 
Side note, the color used was taken from the stylesheet. It was just an unused value.
