### PR TITLE
Moves attack self delayer to centralized proc

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1432,6 +1432,8 @@
 	set category = "IC"
 	set src = usr
 
+	if(attack_delayer.blocked()) return
+
 	if(stat == DEAD) return
 	var/obj/item/W = get_active_hand()
 	if (W)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -973,6 +973,7 @@ var/list/slot_equipment_priority = list( \
 	set category = "IC"
 	set src = usr
 
+	if(attack_delayer.blocked()) return
 
 	if(istype(loc,/obj/mecha)) return
 

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -154,7 +154,7 @@
 
 /client/verb/attack_self()
 	set hidden = 1
-	if(mob && !mob.attack_delayer.blocked())
+	if(mob)
 		mob.mode()
 	return
 


### PR DESCRIPTION
While attack self is called by some of the standard hotkeys, a few of the macros manually call this proc instead. Instead of changing every macro (and potentially letting new macros break it as well), this is a better place to place the attack delayer.

Fixes #8069