### PR TITLE
Chemmaster quality

### DIFF
--- a/html/changelogs/9600bauds_example2_doesanyonelookhereanyways_mentionbananasifso.yml
+++ b/html/changelogs/9600bauds_example2_doesanyonelookhereanyways_mentionbananasifso.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general deleting of nice things)
+#   rscadd (general adding of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: 9600bauds
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+changes: 
+- tweak: When making bottles at a Chemmaster, you will now be prompted to input how many bottles you want to make before being prompted to name the bottles. This is to keep consistency with making pills (prevent bottles named '3'), and also allows the bottles to be automatically named after many units of chemicals they contain.
+- rscadd: You can now alt-click Chemmasters and All-in-One Grinders to eject their beaker, if they have one loaded.


### PR DESCRIPTION
Fixes #7905 
changes: 
- tweak: When making bottles at a Chemmaster, you will now be prompted to input how many bottles you want to make before being prompted to name the bottles. This is to keep consistency with making pills (prevent bottles named '3'), and also allows the bottles to be automatically named after many units of chemicals they contain.
- rscadd: You can now alt-click Chemmasters and All-in-One Grinders to eject their beaker, if they have one loaded.

Also fixes improper sanity with centrifuge
