### PR TITLE
Brain damage makes you collapse rather than permanently set your lying var

### DIFF
--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -140,7 +140,8 @@
 
 	if (ishuman(C))
 		victim = C
-		C.resting = 1
+		C.resting = 1 //This probably shouldn't be using this variable
+		C.update_canmove() //but for as long as it does we're adding sanity to it
 
 	if (C == user)
 		user.visible_message("[user] climbs on the operating table.","You climb on the operating table.")

--- a/code/modules/mob/living/carbon/human/life/handle_disabilities.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_disabilities.dm
@@ -91,6 +91,6 @@
 				to_chat(src, "<span class='warning'>Your hand won't respond properly, you drop what you're holding.</span>")
 				drop_item()
 		if(getBrainLoss() >= 50)
-			if(10 <= rn && rn <= 12) if(!lying)
+			if(10 <= rn && rn <= 12) if(canmove)
 				to_chat(src, "<span class='warning'>Your legs won't respond properly, you fall down.</span>")
-				resting = 1
+				emote("collapse")


### PR DESCRIPTION
When you have brain damage, your legs can randomly fail, making you fall down.
The first time it happens, you'll probably just wait until you get back up.
Turns out that you will never get back up by yourself. Why? It actually sets your lying var, which is only modified by the LIE DOWN verb.
Which is stupid and unintuitive, so I'm making it do the collapse emote that radiation and hulk use.
Could POSSIBLY be a fix for #6029 but I don't think so
