### PR TITLE
Fix #6913

### DIFF
--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -328,6 +328,7 @@ var/global/datum/controller/occupations/job_master
 	//For ones returning to lobby
 	for(var/mob/new_player/player in unassigned)
 		if(player.client.prefs.alternate_option == RETURN_TO_LOBBY)
+			to_chat(player, "<span class='danger'>You have not been placed in the game due to job related restrictions.")
 			player.ready = 0
 			unassigned -= player
 	return 1


### PR DESCRIPTION
Puts in a message sent to players who get unreadied and not put into the game due to job restrictions. If you get put back into the lobby and DON'T get this message only then should you be saying the system is 'broken'.