### PR TITLE
No more Firebird ghostspin

### DIFF
--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -15,6 +15,7 @@
 	nick = "pimpin' ride"
 	keytype = /obj/item/key/janicart
 	flags = OPENCONTAINER
+	overrideghostspin = 0
 	var/amount_per_transfer_from_this = 5 //shit I dunno, adding this so syringes stop runtime erroring. --NeoFite
 	var/obj/item/weapon/storage/bag/trash/mybag	= null
 

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -6,6 +6,8 @@
 
 	sheet_amt = 1
 
+	var/overrideghostspin = 0 //Set it to 1 if ghosts should NEVER be able to spin this
+
 /obj/structure/bed/chair/New()
 	..()
 	spawn(3)
@@ -57,7 +59,7 @@
 	if(!usr || !isturf(usr.loc))
 		return
 
-	if(!config.ghost_interaction && !blessed)
+	if((!config.ghost_interaction && !blessed) || overrideghostspin)
 		if(usr.isUnconscious() || usr.restrained())
 			return
 

--- a/code/game/objects/structures/vehicles/clowncart.dm
+++ b/code/game/objects/structures/vehicles/clowncart.dm
@@ -22,6 +22,7 @@
 	density = 1
 	nick = "honkin' ride" //For fucks sake, well then
 	flags = OPENCONTAINER
+	overrideghostspin = 0
 
 	max_health = 100 //Bananium sheets increases maximum health by 20
 	var/activated = 0 //Honk to activate, it stays active while you sit in it, and will deactivate when you unbuckle
@@ -36,6 +37,7 @@
 	var/colour2 = "#3D3D3D" //Default is boring black
 	var/emagged = 0			//Does something maybe
 	var/honk				//Timer to prevent spamming honk
+
 /obj/structure/bed/chair/vehicle/clowncart/process()
 	icon_state = "clowncart0"
 	if(empstun > 0)

--- a/code/game/objects/structures/vehicles/gokart.dm
+++ b/code/game/objects/structures/vehicles/gokart.dm
@@ -9,6 +9,7 @@
 	icon_state = "gokart0"
 	//nick = "TRUE POWER"
 	keytype = /obj/item/key/gokart
+	overrideghostspin = 0
 
 /obj/structure/bed/chair/vehicle/gokart/unlock_atom(var/atom/movable/AM)
 	. = ..()

--- a/code/game/objects/structures/vehicles/vehicle.dm
+++ b/code/game/objects/structures/vehicles/vehicle.dm
@@ -21,6 +21,7 @@
 	icon = 'icons/obj/vehicles.dmi'
 	anchored = 1
 	density = 1
+	overrideghostspin = 1 //You guys are no fun
 	var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread
 
 	var/empstun = 0

--- a/code/game/objects/structures/vehicles/wizmobile.dm
+++ b/code/game/objects/structures/vehicles/wizmobile.dm
@@ -21,6 +21,7 @@
 	icon_state = "wizmobile"
 	//nick = "TRUE POWER"
 	keytype = /obj/item/key/wizmobile
+	overrideghostspin = 1
 	can_spacemove=1
 	//ethereal=1 // NERF
 	var/can_move=1

--- a/code/game/objects/structures/vehicles/wizmobile.dm
+++ b/code/game/objects/structures/vehicles/wizmobile.dm
@@ -21,7 +21,6 @@
 	icon_state = "wizmobile"
 	//nick = "TRUE POWER"
 	keytype = /obj/item/key/wizmobile
-	overrideghostspin = 1
 	can_spacemove=1
 	//ethereal=1 // NERF
 	var/can_move=1


### PR DESCRIPTION
Specifically makes the Firebird unspinnable by ghosts
It's basically #8224 except specifically applied to ghosts (and unconscious/restrained players because that's how the code worked)
This does mean that the driver or anyone beside the Firebird can still spin it, but honestly if a wizard is trying to fireball from a Firebird and they let someone get right beside them they deserve whatever is coming to them
