### PR TITLE
Thoroughly fix SCP-173 + Fix Celthermia warning

### DIFF
--- a/code/modules/mob/thermoregulation.dm
+++ b/code/modules/mob/thermoregulation.dm
@@ -26,13 +26,13 @@
 /mob/living/proc/sweat(var/amount,var/forcesweat = 0)
 	if((status_flags & GODMODE) || (flags & INVULNERABLE))
 		return 1
+	/* buggy as fug
 	if(istype(src,/mob/living/carbon/human))
 		var/mob/living/carbon/human/H = src
-		/* buggy as fug
 		if(!H.species.has_sweat_glands)
 			return 1
-			
-		*/
+
+	*/
 	if(forcesweat && ticker && ticker.hardcore_mode)
 		forcesweat = 0
 	var/sustenance = amount / 50


### PR DESCRIPTION
SCP-173 wasn't functioning correctly for a while, notably its sight code. After a bit of digging and formatting, I realized that SCP-173 was considering itself in full darkness 100 % of the time due to deprecated code (turf luminosity var)

I changed it to check if any lights affect the turf. Logically, if no lights affect the turf, it is in full darkness
- Fix SCP-173 sightcode not working properly, SCP-173 should no longer ignore mob's sight on him

Other fixes and changes : 
- Removed grabbing and convoluted attack code from the mob. SCP-173 now instantly deals critical head damage (neck snap) once it is on a mob's tile and no-one else is looking at it. Hopefully you can't cheese it again by just running, if that happens I guess I'll throw in a Paralyze again
- Changed all of SCP-173's actions to consider if a mob is now looking at it before proceeding. This means SCP-173 will now stop breaking its way into places or sliding into a vent if a mob looks at it
- Vent crawl now takes five full seconds and will be interrupted if a mob starts looking at it
- Fix warning in thermoregulation file. The commented out part wasn't big enough

This was tested and seems to work swell. Only oddity is that SCP-173 does not consider full darkness tiles for wandering/targeting unless they are adjacent to it. Won't fix because looks flavorful and you will still get snapped if you decide to turn on any light in SCP-173's real visual range
