### PR TITLE
More tweaks and fixes to SCP-173. Neuter the crematorium in wait for rewrite

### DIFF
--- a/code/WorkInProgress/Cael_Aislinn/sculpture.dm
+++ b/code/WorkInProgress/Cael_Aislinn/sculpture.dm
@@ -13,6 +13,7 @@
 	response_disarm = "pushes the"
 	response_harm   = "hits the"
 	meat_type = null
+	see_in_dark = 8 //Needs to see in darkness to snap in darkness
 	var/response_snap = "snapped the neck of" //Past tense because it "happened before you could see it"
 	var/response_snap_target = "In the blink of an eye, something grabs you and snaps your neck!"
 	var/snap_sound = list('sound/scp/firstpersonsnap.ogg','sound/scp/firstpersonsnap2.ogg','sound/scp/firstpersonsnap3.ogg')
@@ -128,6 +129,9 @@
 			for(var/obj/structure/table/O in next_turf)
 				O.ex_act(1)
 				sleep(5)
+			for(var/obj/structure/closet/C in next_turf)
+				C.ex_act(1)
+				sleep(5)
 			for(var/obj/structure/grille/G in next_turf)
 				G.ex_act(1)
 				sleep(5)
@@ -141,7 +145,7 @@
 				sleep(5)
 			if(!next_turf.CanPass(src, next_turf)) //Once we cleared everything we could, check one last time if we can pass
 				break
-			loc = next_turf
+			forceMove(next_turf)
 			dir = get_dir(src, target)
 			next_turf = get_step(src, get_dir(next_turf,target))
 			num_turfs--
@@ -176,6 +180,9 @@
 				for(var/obj/structure/table/O in next_turf)
 					O.ex_act(1)
 					sleep(5)
+				for(var/obj/structure/closet/C in next_turf)
+					C.ex_act(1)
+					sleep(5)
 				for(var/obj/structure/grille/G in next_turf)
 					G.ex_act(1)
 					sleep(5)
@@ -189,7 +196,7 @@
 					sleep(5)
 				if(!next_turf.CanPass(src, next_turf)) //Once we cleared everything we could, check one last time if we can pass
 					break
-				loc = next_turf
+				forceMove(next_turf)
 				dir = get_dir(src, target_turf)
 				next_turf = get_step(src, get_dir(next_turf,target_turf))
 				num_turfs--
@@ -198,8 +205,8 @@
 
 	//Do we have a vent ? Good, let's take a look
 	for(entry_vent in view(1, src))
-		if(prob(50))
-			return //Ignore that vent for this tick
+		if(prob(90)) //10 % chance to consider a vent, to try and avoid constant vent switching
+			return
 		visible_message("<span class='danger'>\The [src] starts trying to slide itself into the vent!</span>")
 		sleep(50) //Let's stop SCP-173 for five seconds to do his parking job
 		..()
@@ -219,17 +226,14 @@
 				var/travel_time = round(get_dist(loc, exit_vent.loc)/2)
 				spawn(travel_time)
 					if(!exit_vent || exit_vent.welded)
-						loc = entry_vent
+						forceMove(get_turf(entry_vent))
 						entry_vent = null
 						visible_message("<span class='danger'>\The [src] suddenly appears from the vent!</span>")
 						return
 
-					loc = exit_vent.loc
+					forceMove(get_turf(exit_vent))
 					entry_vent = null
 					visible_message("<span class='danger'>\The [src] suddenly appears from the vent!</span>")
-					var/area/new_area = get_area(loc)
-					if(new_area)
-						new_area.Entered(src)
 		else
 			entry_vent = null
 

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -343,7 +343,7 @@
 			return
 		if(locate(/mob/living/simple_animal/sculpture) in inside)
 			to_chat(user, "<span class='warning'>You try to toggle the crematorium on, but all you hear is scrapping stone.</span>")
-
+			return
 		for (var/mob/M in viewers(src))
 			if(!M.hallucinating())
 				M.show_message("<span class='warning'>You hear a roar as the crematorium activates.</span>", 1)

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -70,6 +70,8 @@
 /obj/structure/morgue/attack_hand(mob/user as mob)
 	if (src.connected)
 		for(var/atom/movable/A as mob|obj in src.connected.loc)
+			if(istype(A, /mob/living/simple_animal/sculpture)) //I have no shame. Until someone rewrites this shitcode extroadinaire, I'll just snowflake over it
+				continue
 			if (!( A.anchored ))
 				A.loc = src
 		playsound(get_turf(src), 'sound/items/Deconstruct.ogg', 50, 1)
@@ -170,6 +172,8 @@
 /obj/structure/m_tray/attack_hand(mob/user as mob)
 	if (src.connected)
 		for(var/atom/movable/A as mob|obj in src.loc)
+			if(istype(A, /mob/living/simple_animal/sculpture)) //I have no shame. Until someone rewrites this shitcode extroadinaire, I'll just snowflake over it
+				continue
 			if (!( A.anchored ))
 				A.loc = src.connected
 			//Foreach goto(26)
@@ -337,6 +341,8 @@
 		if (locate(/obj/item/weapon/disk/nuclear) in inside)
 			to_chat(user, "<SPAN CLASS='warning'>You get the feeling that you shouldn't cremate one of the items in the cremator.</SPAN>")
 			return
+		if(locate(/mob/living/simple_animal/sculpture) in inside)
+			to_chat(user, "<span class='warning'>You try to toggle the crematorium on, but all you hear is scrapping stone.</span>")
 
 		for (var/mob/M in viewers(src))
 			if(!M.hallucinating())


### PR DESCRIPTION
- SCP-173 can now see in darkness perfectly. This means you are no longer safe at all in darkness. This is to make sure SCP-173 doesn't get lost inching around in Maintenance, especially since there's no vents here
- SCP-173 can now break closets in its way, since those are somewhat common on station and crewmen could use them to abuse SCP's pathing
- All of SCP-173's movement is now done via forceMove. This ensures all procs related to movement and observer follow work as intended
- Prob of using a vent is now 10 %, down from 50 %. This means SCP will no longer spend 90 % of its idle time in the station's ventilation
- Added a few exceptions to the crematorium and morgue trays to mimick closet exceptions. Yes, cremating SCP-173 is totally a thing you could do. Now you can't. Hopefully I can rewrite this soon to make the code less shit, because it hurts just to look at it

Should all be hotfixes to unintended SCP-173 behavior. It just werks currently, but it can werk better
