### PR TITLE
[box] Expanded maint and goonecode containment. Some bugfixes too

### DIFF
--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -204,6 +204,8 @@
 
 		if(damage > explosion_point)
 			for(var/mob/living/mob in living_mob_list)
+				if(mob.z != src.z)//only make it effect mobs on the current Z level.
+					continue
 				if(istype(mob, /mob/living/carbon/human))
 					//Hilariously enough, running into a closet should make you get hit the hardest.
 					mob:hallucination += max(50, min(300, DETONATION_HALLUCINATION * sqrt(1 / (get_dist(mob, src) + 1)) ) )

--- a/html/changelogs/CptWad.yml
+++ b/html/changelogs/CptWad.yml
@@ -13,7 +13,10 @@ changes:
 - rscadd: New Holopads in CMO and HoS offices.
 - rscadd: Pen and paper in Chemistry
 - rscadd: Added all but one of Nigglys pets to their respective homes.
+- rscadd: Viro expanded a tad, new newscaster.
+- rscadd: Added 1 pill collector and 2 more antibody scanners.
 - bugfix: Turned that one vent at arrivals on that should have been on in the first place.
 - bugfix: Repaired the pipes at cryo.
+- bugfix: The lightswitch in atmospherics is now reachable.
 - tweak: Moved the Phalanximine out of the CMO's office. You can still find it however.
   

--- a/html/changelogs/CptWad.yml
+++ b/html/changelogs/CptWad.yml
@@ -1,0 +1,19 @@
+author: CptWad
+
+delete-after: True
+
+changes: 
+- rscadd: PBJ's code that makes it so now supermatters not on your z-level exploding will have no effect on your z-level.
+- tweak: The following apply to Boxstation
+- rscadd: Enlarged maint in the south east and north east quarters of the map.
+- experiment: Moved Toxins Test Site/Zoo back a few tiles for dylan
+- rscadd: New toys scattered around the station, collect them all!
+- rscadd: More loot at goonecode sat, just bring a weapon or two.
+- rscadd: New SME shard at derelict. Blessed be the crab
+- rscadd: New Holopads in CMO and HoS offices.
+- rscadd: Pen and paper in Chemistry
+- rscadd: Added all but one of Nigglys pets to their respective homes.
+- bugfix: Turned that one vent at arrivals on that should have been on in the first place.
+- bugfix: Repaired the pipes at cryo.
+- tweak: Moved the Phalanximine out of the CMO's office. You can still find it however.
+  


### PR DESCRIPTION
![gooone](https://cloud.githubusercontent.com/assets/3959840/13036411/a17ad34e-d31b-11e5-951a-b44039de56a1.png)
![skub](https://cloud.githubusercontent.com/assets/3959840/13036412/a17dd9f4-d31b-11e5-8cb7-7ee54450c3df.png)
![monkey trouble](https://cloud.githubusercontent.com/assets/3959840/13036413/a17df51a-d31b-11e5-8e69-a62a4b6f9a7f.png)
Other notes
1. Toxins test site moved back per request
2. New toys scattered around the map, collect them all!
3. Thing in space was scrapped _for now_
4. Fixes #2287 #3420 #7745 #7853 #8124 #8174 and #8178
5. Monkey room was remade, check below
5. Supermatter now does not broadcast shit off z-level, thanks @PJB3005 
6. put in all of @NigglyWiggly 's pets, besides the spider. Thanks dylan
7. Moved atmos's lightswitch somewhere it can be reached
8. Increased the size of virology, added a newscaster.
9. Another pill collector and some antibody scanners