### PR TITLE
Fixes unreported MoMMI exploit

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -591,8 +591,18 @@
 					return 0
 				return 1
 		return 0 //Unsupported slot
-
 		//END MONKEY
+
+	else if(isMoMMI(M))
+		//START MOMMI ALSO THIS SO FUCKING SILLY
+		var/mob/living/silicon/robot/mommi/MoM = M
+		switch(slot)
+			if(slot_head)
+				if(MoM.head_state)
+					return 0
+				return 1
+		return 0 //Unsupported slot
+		//END MOMMI
 
 /obj/item/can_pickup(mob/living/user)
 	if(!(user) || !isliving(user)) //BS12 EDIT

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -80,6 +80,10 @@
 		var/mob/living/carbon/human/H = loc
 		if(H.head == src) //If worn
 			return 0
+	else if(isMoMMI(loc))
+		var/mob/living/silicon/robot/mommi/MoM = loc
+		if(MoM.head_state == src) //If worn
+			return 0
 	return ..()
 
 /obj/item/weapon/storage/bag/plasticbag/suicide_act(mob/user)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -414,7 +414,11 @@
 
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
-		if((H.l_store == src || H.r_store == src) && !H.get_active_hand())	//Prevents opening if it's in a pocket.
+		if((H.l_store == src || H.r_store == src || H.head == src) && !H.get_active_hand())	//Prevents opening if it's in a pocket or head slot. Terrible kludge, I'm sorry.
+			return ..()
+	else if(isMoMMI(user))
+		var/mob/living/silicon/robot/mommi/MoM = user
+		if(MoM.head_state == src) //I'm so sorry. We have exactly one storage item that goes on head, and it can't hold any items while equipped. This is so you can actually take it off.
 			return ..()
 
 	src.orient2hud(user)

--- a/code/modules/mob/living/silicon/mommi/inventory.dm
+++ b/code/modules/mob/living/silicon/mommi/inventory.dm
@@ -323,10 +323,8 @@
 /mob/living/silicon/robot/mommi/attack_ui(slot)
 	var/obj/item/W = tool_state
 	if(istype(W))
-		if(equip_to_slot(W, slot))
+		if(equip_to_slot_if_possible(W, slot))
 			update_items()
-		else
-			to_chat(src, "<span class='warning'>You are unable to equip that.</span>")
 
 // Quickly equip a hat by pressing "e"
 /mob/living/silicon/robot/mommi/verb/quick_equip()
@@ -351,4 +349,3 @@
 			update_items()
 		else
 			to_chat(M, "<span class='warning'>You are unable to equip that.</span>")
-


### PR DESCRIPTION
What do you know, it turns out that MoMMIs were able to place plastic bags on their heads, and due to the quality inventory code we have currently, the plastic bag didn't realize it was equipped so it would still allow you to use it as a container.
In this way, a MoMMI could theoretically have a backpack and fill it with shit like polyacid smoke grenades or beakers full of reagents for polyacid smoke or replacement polyacid smoke stasis beakers for a polyacid-smoke-creating venom sword! I say "theoretically" because I'm sure that since this bug was unreported for a very long time, it must mean nobody discovered it before so nobody abused it or anything.

Also fixes MoMMIs being unable to take off their plastic bag hat after equipping it, showing it was clearly a bug.
