### PR TITLE
Fix for Using Detective Scanner on Blunderbuss and Cannon, and Damage Buff for the Cannon

### DIFF
--- a/code/modules/projectiles/guns/projectile/constructable/blunderbuss.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/blunderbuss.dm
@@ -25,6 +25,7 @@
 		/obj/item/weapon/gun,
 		/obj/item/weapon/blunderbuss,
 		/obj/item/weapon/storage/pneumatic,
+		/obj/item/device/detective_scanner,
 		)
 	var/flawless = 0
 	var/dont_shoot = 0 //I couldn't get attack() to play nice with afterattack() for some reason, so I'm jury-rigging the melee stuff.

--- a/code/modules/projectiles/guns/projectile/constructable/cannon.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/cannon.dm
@@ -7,6 +7,7 @@
 	var/fuel_level = 0
 	var/max_fuel = 10
 	var/loaded_item = null
+	var/damage_multiplier = 2
 	var/list/prohibited_items = list( //Certain common items that, due to a combination of their throwforce and w_class, are too powerful to be allowed as ammunition.
 		/obj/item/weapon/shard,
 		/obj/item/weapon/batteringram,
@@ -195,6 +196,8 @@
 		speed = (((fire_force*(4/object.w_class))/5)*2) //projectile speed.
 	else
 		speed = (((fire_force*2)/5)*2)
+		
+	speed = speed * damage_multiplier
 
 	var/distance = round(((20/object.w_class)*(fuel_level/10))*1.5)
 

--- a/code/modules/projectiles/guns/projectile/constructable/cannon.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/cannon.dm
@@ -12,6 +12,7 @@
 		/obj/item/weapon/batteringram,
 		/obj/item/weapon/hatchet,
 		/obj/item/weapon/storage/pneumatic,
+		/obj/item/device/detective_scanner,
 		)
 
 /obj/structure/bed/chair/vehicle/wheelchair/wheelchair_assembly/cannon/Destroy()


### PR DESCRIPTION
Previously the scanner would be inserted into both of these.

The cannon's damage output has been doubled.
In the original PR I doubled the blunderbuss's original damage, but forgot to do the same to the cannon.
