### PR TITLE
Buffs Plasma weapon damage in general, modifies other Goofball weapons

### DIFF
--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -22,7 +22,8 @@
 	desc = "A laser pistol issued to high ranking members of a certain shadow corporation."
 	icon_state = "xcomlaserpistol"
 	item_state = null
-	projectile_type = /obj/item/projectile/beam
+	w_class = 1.0
+	projectile_type = /obj/item/projectile/beam/lightlaser
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/guninhands_left.dmi', "right_hand" = 'icons/mob/in-hand/right/guninhands_right.dmi')
 	charge_cost = 100 // holds less "ammo" then the rifle variant.
 
@@ -193,9 +194,9 @@ obj/item/weapon/gun/energy/laser/retro
 	desc = "A state of the art pistol utilizing plasma in a uranium-235 lined core to output searing bolts of energy."
 	icon_state = "alienpistol"
 	item_state = null
-	w_class = 2.0
+	w_class = 1.0
 	projectile_type = /obj/item/projectile/energy/plasma/pistol
-	charge_cost = 50
+	charge_cost = 100
 
 /obj/item/weapon/gun/energy/plasma/light
 	name = "plasma rifle"
@@ -203,7 +204,7 @@ obj/item/weapon/gun/energy/laser/retro
 	icon_state = "lightalienrifle"
 	item_state = null
 	projectile_type = /obj/item/projectile/energy/plasma/light
-	charge_cost = 100
+	charge_cost = 50
 
 /obj/item/weapon/gun/energy/plasma/rifle
 	name = "plasma cannon"

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -537,6 +537,12 @@ var/list/beam_master = list()
 		var/message = pick("\the [src] narrowly whizzes past [L]!","\the [src] almost hits [L]!","\the [src] straight up misses its target.","[L]'s hair is singed off by \the [src]!","\the [src] misses [L] by a millimetre!","\the [src] doesn't hit","\the [src] misses its intended target.","[L] has a lucky escape from \the [src]!")
 		target.loc.visible_message("<span class='danger'>[message]</span>")
 
+/obj/item/projectile/beam/lightlaser
+	name = "light laser"
+	icon_state = "light laser"
+	damage = 25
+
+
 /obj/item/projectile/beam/heavylaser
 	name = "heavy laser"
 	icon_state = "heavylaser"

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -63,17 +63,18 @@
 	return 0
 
 /obj/item/projectile/energy/plasma/pistol
-	damage = 12
+	damage = 25
 	icon_state = "plasma1"
 	irradiate = 12
 
 /obj/item/projectile/energy/plasma/light
-	damage = 25
+	damage = 35
 	icon_state = "plasma2"
+	irradiate = 20
 	knockdown_chance = 30
 
 /obj/item/projectile/energy/plasma/rifle
-	damage = 40
+	damage = 50
 	icon_state = "plasma3"
 	irradiate = 35
 	knockdown_chance = 50

--- a/html/changelogs/icantthinkofanameritenow.yml
+++ b/html/changelogs/icantthinkofanameritenow.yml
@@ -1,0 +1,5 @@
+author: Icantthinkofanameritenow
+delete-after: True
+changes: 
+- tweak: Laser and plasma pistols now fit in pockets, but deal less damage.
+- rscadd: Plasma pistols, plasma rifles, and plasma cannons now deal more damage.


### PR DESCRIPTION
Makes some much-needed tweaks to the Goofball/XCOM energy weapons.

-All plasma weapons deal extra damage.
-Laser and plasma pistols now fit in pockets. To compensate for the possibilities of having a pocket-sized laser gun usable, the laser pistol now deals slightly less damage compared to a laser gun. 
-Plasma rifle shots should irradiate targets hit by them like they're supposed to. 
