### PR TITLE
Replaces Protolathe AEGs with an AEG Modkit, that turns normal energy guns into AEGs

### DIFF
--- a/code/game/objects/items/devices/modkit.dm
+++ b/code/game/objects/items/devices/modkit.dm
@@ -132,3 +132,18 @@
 	parts[1] =	1
 	original[1] = /obj/item/weapon/gun/energy/polarstar
 	finished[1] = /obj/item/weapon/gun/energy/polarstar/spur
+	
+	/obj/item/device/modkit/aeg_parts
+	name = "advanced energy gun modkit"
+	desc = "A kit containing all the needed tools and parts to modify an item into another one"
+	icon_state = "modkit"
+
+/obj/item/device/modkit/aeg_parts/New()
+	..()
+	parts = new/list(1)
+	original = new/list(1)
+	finished = new/list(1)
+
+	parts[1] =	1
+	original[1] = /obj/item/weapon/gun/energy/gun
+	finished[1] = /obj/item/weapon/gun/energy/gun/nuclear

--- a/code/game/objects/items/devices/modkit.dm
+++ b/code/game/objects/items/devices/modkit.dm
@@ -133,7 +133,7 @@
 	original[1] = /obj/item/weapon/gun/energy/polarstar
 	finished[1] = /obj/item/weapon/gun/energy/polarstar/spur
 	
-	/obj/item/device/modkit/aeg_parts
+/obj/item/device/modkit/aeg_parts
 	name = "advanced energy gun modkit"
 	desc = "A kit containing all the needed tools and parts to modify an item into another one"
 	icon_state = "modkit"

--- a/code/game/objects/items/devices/modkit.dm
+++ b/code/game/objects/items/devices/modkit.dm
@@ -135,7 +135,7 @@
 	
 /obj/item/device/modkit/aeg_parts
 	name = "advanced energy gun modkit"
-	desc = "A kit containing all the needed tools and parts to modify an item into another one"
+	desc = "A kit containing all the needed tools and parts to modify an energy gun into an advanced energy gun, granting it the ability to recharge itself."
 	icon_state = "modkit"
 
 /obj/item/device/modkit/aeg_parts/New()

--- a/code/modules/research/designs/weapons.dm
+++ b/code/modules/research/designs/weapons.dm
@@ -1,13 +1,13 @@
 /datum/design/nuclear_gun
-	name = "Advanced Energy Gun"
-	desc = "An energy gun with an experimental miniaturized reactor."
+	name = "Advanced Energy Gun Modkit"
+	desc = "Can be used on an energy gun to grant it an experimental miniaturized reactor."
 	id = "nuclear_gun"
 	req_tech = list("combat" = 3, "materials" = 5, "powerstorage" = 3)
 	build_type = PROTOLATHE
-	materials = list(MAT_IRON = 5000, MAT_GLASS = 1000, MAT_URANIUM = 500)
+	materials = list(MAT_IRON = 5000, MAT_GLASS = 1500, MAT_URANIUM = 750)
 	reliability_base = 76
 	category = "Weapons"
-	build_path = /obj/item/weapon/gun/energy/gun/nuclear
+	build_path = /obj/item/device/modkit/aeg_parts
 	locked = 1
 	req_lock_access = list(access_armory)
 

--- a/code/modules/research/designs/weapons.dm
+++ b/code/modules/research/designs/weapons.dm
@@ -1,6 +1,6 @@
 /datum/design/nuclear_gun
 	name = "Advanced Energy Gun Modkit"
-	desc = "Can be used on an energy gun to grant it an experimental miniaturized reactor."
+	desc = "Can be used on an energy gun to grant it the ability to recharge itself over time."
 	id = "nuclear_gun"
 	req_tech = list("combat" = 3, "materials" = 5, "powerstorage" = 3)
 	build_type = PROTOLATHE

--- a/code/modules/research/designs/weapons.dm
+++ b/code/modules/research/designs/weapons.dm
@@ -4,7 +4,7 @@
 	id = "nuclear_gun"
 	req_tech = list("combat" = 3, "materials" = 5, "powerstorage" = 3)
 	build_type = PROTOLATHE
-	materials = list(MAT_IRON = 5000, MAT_GLASS = 1500, MAT_URANIUM = 750)
+	materials = list(MAT_IRON = 5000, MAT_GLASS = 1000, MAT_URANIUM = 500)
 	reliability_base = 76
 	category = "Weapons"
 	build_path = /obj/item/device/modkit/aeg_parts

--- a/code/modules/research/designs/weapons.dm
+++ b/code/modules/research/designs/weapons.dm
@@ -8,8 +8,7 @@
 	reliability_base = 76
 	category = "Weapons"
 	build_path = /obj/item/device/modkit/aeg_parts
-	locked = 1
-	req_lock_access = list(access_armory)
+	
 
 /datum/design/stunrevolver
 	name = "Stun Revolver"


### PR DESCRIPTION
Removes the AEG from the protolathe, and adds a modkit that can be used on an energy gun to create an AEG in its place. Now RnD will have to actually get off its fat ass to make its overpowered guns!

Addresses #7680  if merged. 
