### PR TITLE
Fixes a particularly silly runtime that has occurred multiple times each time anyone has gotten shocked by a vending machine or certain other things in the past four days (come on now, guys)

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -125,7 +125,7 @@
 	if(damage <= 0)
 		damage = 0
 
-	if(take_overall_damage(0, damage, "[source]") == 0) // godmode
+	if(take_overall_damage(0, damage, used_weapon = "[source]") == 0) // godmode
 		return 0
 
 	//src.burn_skin(shock_damage)


### PR DESCRIPTION
`runtime error: type mismatch: cannot compare "Groans Soda" to 2`

You don't really need the rest of the runtime info because this fixes it
Yes, I tested it

I looked at the runtime logs to see if there was anything to fix and this one was so common it washed out everything else
