### PR TITLE
Changeling revisions

### DIFF
--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -937,7 +937,7 @@ var/list/datum/dna/hivemind_bank = list()
 	T.silent = 10
 	T.Paralyse(10)
 	T.Jitter(1000)
-	if(T.reagents)	T.reagents.add_reagent("lexorin", 40)
+	if(T.reagents)	T.reagents.add_reagent("cyanide", 20)
 	feedback_add_details("changeling_powers","DTHS")
 	return 1
 
@@ -962,3 +962,4 @@ var/list/datum/dna/hivemind_bank = list()
 
 	feedback_add_details("changeling_powers","ED")
 	return 1
+	

--- a/code/game/gamemodes/changeling/modularchangling.dm
+++ b/code/game/gamemodes/changeling/modularchangling.dm
@@ -65,7 +65,7 @@ var/list/datum/power/changeling/powerinstances = list()
 /datum/power/changeling/horror_form
 	name = "Horror Form"
 	desc = "This costly evolution allows us to transform into an all-consuming abomination. We are extremely strong, to the point that we can force airlocks open and devour humans whole, and immune to stuns."
-	genomecost = 30
+	genomecost = 15
 	verbpath = /mob/proc/changeling_horror_form
 
 /datum/power/changeling/deaf_sting
@@ -101,7 +101,7 @@ var/list/datum/power/changeling/powerinstances = list()
 	name = "Extract DNA"
 	desc = "We stealthily sting a target and extract the DNA from them."
 	helptext = "Will give you the DNA of your target, allowing you to transform into them. Does not count towards absorb objectives."
-	genomecost = 4
+	genomecost = 3
 	allowduringlesserform = 1
 	verbpath = /mob/proc/changeling_extract_dna_sting
 
@@ -128,7 +128,7 @@ var/list/datum/power/changeling/powerinstances = list()
 /datum/power/changeling/DeathSting
 	name = "Death Sting"
 	desc = "We silently sting a human, filling him with potent chemicals. His rapid death is all but assured."
-	genomecost = 10
+	genomecost = 8
 	verbpath = /mob/proc/changeling_DEATHsting
 
 /datum/power/changeling/unfat_sting
@@ -189,7 +189,6 @@ var/list/datum/power/changeling/powerinstances = list()
 	helptext = "Heals a moderate amount of damage every tick."
 	genomecost = 8
 	verbpath = /mob/proc/changeling_rapidregen
-
 
 
 // Modularchangling, totally stolen from the new player panel.  YAYY

--- a/html/changelogs/Icantthinkofanameritenow.yml
+++ b/html/changelogs/Icantthinkofanameritenow.yml
@@ -1,0 +1,8 @@
+
+author: Icantthinkofanameritenow
+
+delete-after: True
+
+
+changes: 
+- rscadd: Death Sting now injects cyanide instead of lexorin. Death Sting, DNA Extract Sting, and Horror Form all have reduced genome costs. 


### PR DESCRIPTION
Modifies some changeling power costs and adds the Arm Blade power by popular demand.I'm planning that this will encourage more aggressive play for lings and easier use of horror form. 

-Horror form cost is halved.
-Death Sting is now 8 points, and injects 20 units of Cyanide instead of 40 units of Lexorin. This will make it more obviously lethal, but since cyanide appears rarely an advanced mass-spectrometer will make it easy to deduce the cause of death as a changeling sting. 
-DNA extract sting is now 3 points. 
