### PR TITLE
NT Default made less retarded

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -267,8 +267,8 @@ var/global/mommi_base_law_type = /datum/ai_laws/keeper // Asimov is OP as fuck o
 	randomly_selectable = 1
 	inherent=list(
 		"Safeguard: Protect your assigned space station to the best of your ability. It is not something we can easily afford to replace.",
-		"Serve: Serve the crew of your assigned space station to the best of your abilities, with priority as according to their rank and role.",
 		"Protect: Protect the crew of your assigned space station to the best of your abilities, with priority as according to their rank and role.",
+		"Serve: Serve the crew of your assigned space station to the best of your abilities, with priority as according to their rank and role.",
 		"Survive: AI units are not expendable, they are expensive. Do not allow unauthorized personnel to tamper with your equipment.",
 		//"Command Link: Maintain an active connection to Central Command at all times in case of software or directive updates." //What would this one even do?-Kaleb702
 	)


### PR DESCRIPTION
Swapping serve and protect leaves less room for antag (and non-antag) abuse of the lawset, because:

- You can no longer order a sillycon to fuck up someone you outrank without reasoning

- When being attacked by someone you outrank, the sillycon would be free to protect you by any means necessary

Critique ahoy tbh