### PR TITLE
THANKS NOT DUNY

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -1007,7 +1007,10 @@
 /obj/structure/disposalpipe/sortjunction/New()
 	. = ..()
 	if(sortType && !sort_tag)
-		sort_tag = uppertext(DEFAULT_TAGGER_LOCATIONS[sortType])
+		sort_tag = uppertext(map.default_tagger_locations[sortType])
+
+	else if(sort_tag)
+		sort_tag = uppertext(sort_tag)
 
 	updatedir()
 	updatedesc()
@@ -1062,84 +1065,162 @@
 	return P
 
 ////////////////// SortJunctionSubtypes//////////////////
-//Box
+
 /obj/structure/disposalpipe/sortjunction/Disposals
-	sortType = 1
+	sort_tag = DISP_DISPOSALS
+
+/obj/structure/disposalpipe/sortjunction/Disposals/mirrored
+	icon_state = "pipe-j2s"
 
 /obj/structure/disposalpipe/sortjunction/Cargo
-	sortType = 2
+	sort_tag = DISP_CARGO_BAY
+
+/obj/structure/disposalpipe/sortjunction/Cargo/mirrored
+	icon_state = "pipe-j2s"
 
 /obj/structure/disposalpipe/sortjunction/QM
-	sortType = 3
+	sort_tag = DISP_QM_OFFICE
+
+/obj/structure/disposalpipe/sortjunction/QM/mirrored
+	icon_state = "pipe-j2s"
 
 /obj/structure/disposalpipe/sortjunction/Engineering
-	sortType = 4
+	sort_tag = DISP_ENGINEERING
+
+/obj/structure/disposalpipe/sortjunction/Engineering/mirrored
+	icon_state = "pipe-j2s"
 
 /obj/structure/disposalpipe/sortjunction/CE
-	sortType = 5
+	sort_tag = DISP_CE_OFFICE
+
+/obj/structure/disposalpipe/sortjunction/CE/mirrored
+	icon_state = "pipe-j2s"
 
 /obj/structure/disposalpipe/sortjunction/Atmos
-	sortType = 6
+	sort_tag = DISP_ATMOSPHERICS
+
+/obj/structure/disposalpipe/sortjunction/Atmos/mirrored
+	icon_state = "pipe-j2s"
 
 /obj/structure/disposalpipe/sortjunction/Security
-	sortType = 7
+	sort_tag = DISP_SECURITY
+
+/obj/structure/disposalpipe/sortjunction/Security/mirrored
+	icon_state = "pipe-j2s"
 
 /obj/structure/disposalpipe/sortjunction/HoS
-	sortType = 8
+	sort_tag = DISP_HOS_OFFICE
+
+/obj/structure/disposalpipe/sortjunction/HoS/mirrored
+	icon_state = "pipe-j2s"
 
 /obj/structure/disposalpipe/sortjunction/Medbay
-	sortType = 9
+	sort_tag = DISP_MEDBAY
+
+/obj/structure/disposalpipe/sortjunction/Medbay/mirrored
+	icon_state = "pipe-j2s"
 
 /obj/structure/disposalpipe/sortjunction/CMO
-	sortType = 10
+	sort_tag = DISP_CMO_OFFICE
+
+/obj/structure/disposalpipe/sortjunction/CMO/mirrored
+	icon_state = "pipe-j2s"
 
 /obj/structure/disposalpipe/sortjunction/Chemistry
-	sortType = 11
+	sort_tag = DISP_CHEMISTRY
+
+/obj/structure/disposalpipe/sortjunction/Chemistry/mirrored
+	icon_state = "pipe-j2s"
 
 /obj/structure/disposalpipe/sortjunction/Research
-	sortType = 12
+		sort_tag = DISP_RESEARCH
+
+/obj/structure/disposalpipe/sortjunction/Research/mirrored
+	icon_state = "pipe-j2s"
 
 /obj/structure/disposalpipe/sortjunction/RD
-	sortType = 13
+		sort_tag = DISP_RD_OFFICE
+
+/obj/structure/disposalpipe/sortjunction/RD/mirrored
+	icon_state = "pipe-j2s"
 
 /obj/structure/disposalpipe/sortjunction/Robotics
-	sortType = 14
+		sort_tag = DISP_ROBOTICS
+
+/obj/structure/disposalpipe/sortjunction/Robotics/mirrored
+	icon_state = "pipe-j2s"
 
 /obj/structure/disposalpipe/sortjunction/HoP
-	sortType = 15
+		sort_tag = DISP_HOP_OFFICE
+
+/obj/structure/disposalpipe/sortjunction/HoP/mirrored
+	icon_state = "pipe-j2s"
 
 /obj/structure/disposalpipe/sortjunction/Library
-	sortType = 16
+		sort_tag = DISP_LIBRARY
+
+/obj/structure/disposalpipe/sortjunction/Library/mirrored
+	icon_state = "pipe-j2s"
 
 /obj/structure/disposalpipe/sortjunction/Chapel
-	sortType = 17
+		sort_tag = DISP_CHAPEL
+
+/obj/structure/disposalpipe/sortjunction/Chapel/mirrored
+	icon_state = "pipe-j2s"
 
 /obj/structure/disposalpipe/sortjunction/Theatre
-	sortType = 18
+		sort_tag = DISP_THEATRE
+
+/obj/structure/disposalpipe/sortjunction/Theatre/mirrored
+	icon_state = "pipe-j2s"
 
 /obj/structure/disposalpipe/sortjunction/Bar
-	sortType = 19
+		sort_tag = DISP_BAR
+
+/obj/structure/disposalpipe/sortjunction/Bar/mirrored
+	icon_state = "pipe-j2s"
 
 /obj/structure/disposalpipe/sortjunction/Kitchen
-	sortType = 20
+		sort_tag = DISP_KITCHEN
+
+/obj/structure/disposalpipe/sortjunction/Kitchen/mirrored
+	icon_state = "pipe-j2s"
 
 /obj/structure/disposalpipe/sortjunction/Hydroponics
-	sortType = 21
+		sort_tag = DISP_HYDROPONICS
+
+/obj/structure/disposalpipe/sortjunction/Hydroponics/mirrored
+	icon_state = "pipe-j2s"
 
 /obj/structure/disposalpipe/sortjunction/Janitor
-	sortType = 22
+		sort_tag = DISP_JANITOR_CLOSET
+
+/obj/structure/disposalpipe/sortjunction/Janitor/mirrored
+	icon_state = "pipe-j2s"
 
 /obj/structure/disposalpipe/sortjunction/Genetics
-	sortType = 23
+		sort_tag = DISP_GENETICS
+
+/obj/structure/disposalpipe/sortjunction/Genetics/mirrored
+	icon_state = "pipe-j2s"
 
 /obj/structure/disposalpipe/sortjunction/Telecomms
-	sortType = 24
+		sort_tag = DISP_TELECOMMS
+
+/obj/structure/disposalpipe/sortjunction/Telecomms/mirrored
+	icon_state = "pipe-j2s"
 
 /obj/structure/disposalpipe/sortjunction/Mechanics
-	sortType = 25
+		sort_tag = DISP_MECHANICS
+
+/obj/structure/disposalpipe/sortjunction/Mechanics/mirrored
+	icon_state = "pipe-j2s"
 
 /obj/structure/disposalpipe/sortjunction/Telescience
-	sortType = 26
+		sort_tag = DISP_TELESCIENCE
+
+/obj/structure/disposalpipe/sortjunction/Telescience/mirrored
+	icon_state = "pipe-j2s"
 
 //////////////////
 //a three-way junction that sorts objects destined for the mail office mail table (tomail = 1)
@@ -1150,6 +1231,9 @@
 	var/posdir = 0
 	var/negdir = 0
 	var/sortdir = 0
+
+/obj/structure/disposalpipe/wrapsortjunction/mirrored
+	icon_state = "pipe-j2s"
 
 /obj/structure/disposalpipe/wrapsortjunction/New()
 	. = ..()

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -1,34 +1,5 @@
 //Default list destination taggers and such can use.
 
-var/list/DEFAULT_TAGGER_LOCATIONS = list(
-	"Disposals",
-	"Cargo Bay",
-	"QM Office",
-	"Engineering",
-	"CE Office",
-	"Atmospherics",
-	"Security",
-	"HoS Office",
-	"Medbay",
-	"CMO Office",
-	"Chemistry",
-	"Research",
-	"RD Office",
-	"Robotics",
-	"HoP Office",
-	"Library",
-	"Chapel",
-	"Theatre",
-	"Bar",
-	"Kitchen",
-	"Hydroponics",
-	"Janitor Closet",
-	"Genetics",
-	"Telecomms",
-	"Mechanics",
-	"Telescience"
-	)
-
 /obj/item/device/destTagger
 	name = "destination tagger"
 	desc = "Used to set the destination of properly wrapped packages."
@@ -38,7 +9,7 @@ var/list/DEFAULT_TAGGER_LOCATIONS = list(
 	var/mode  = 0 //If the tagger is "hacked" so you can add extra tags.
 
 	var/currTag = 0
-	var/list/destinations
+	var/list/destinations  = list()
 
 	w_class = 1
 	item_state = "electronic"
@@ -55,7 +26,11 @@ var/list/DEFAULT_TAGGER_LOCATIONS = list(
 
 /obj/item/device/destTagger/New()
 	. = ..()
-	destinations = DEFAULT_TAGGER_LOCATIONS.Copy() //T-thanks BYOND.
+
+	// Make sure to not copy any null ones, null is for map overrides to remove.
+	for(var/dest in map.default_tagger_locations)
+		if(dest)
+			destinations += dest
 
 /obj/item/device/destTagger/interact(mob/user as mob)
 
@@ -464,7 +439,7 @@ var/list/DEFAULT_TAGGER_LOCATIONS = list(
 /obj/machinery/sorting_machine/destination/New()
 	. = ..()
 
-	destinations = DEFAULT_TAGGER_LOCATIONS.Copy() //Here because BYOND.
+	destinations = map.default_tagger_locations.Copy() //Here because BYOND.
 
 	for(var/i = 1, i <= destinations.len, i++)
 		destinations[i] = uppertext(destinations[i])

--- a/code/setup.dm
+++ b/code/setup.dm
@@ -1416,3 +1416,32 @@ var/proccalls = 1
 #define LOCKED_SHOULD_LIE 1
 #define DENSE_WHEN_LOCKING 2
 #define DENSE_WHEN_LOCKED 4
+
+// Disposals destinations.
+
+#define DISP_DISPOSALS      "Disposals"
+#define DISP_CARGO_BAY      "Cargo Bay"
+#define DISP_QM_OFFICE      "QM Office"
+#define DISP_ENGINEERING    "Engineering"
+#define DISP_CE_OFFICE      "CE Office"
+#define DISP_ATMOSPHERICS   "Atmospherics"
+#define DISP_SECURITY       "Security"
+#define DISP_HOS_OFFICE     "HoS Office"
+#define DISP_MEDBAY         "Medbay"
+#define DISP_CMO_OFFICE     "CMO Office"
+#define DISP_CHEMISTRY      "Chemistry"
+#define DISP_RESEARCH       "Research"
+#define DISP_RD_OFFICE      "RD Office"
+#define DISP_ROBOTICS       "Robotics"
+#define DISP_HOP_OFFICE     "HoP Office"
+#define DISP_LIBRARY        "Library"
+#define DISP_CHAPEL         "Chapel"
+#define DISP_THEATRE        "Theatre"
+#define DISP_BAR            "Bar"
+#define DISP_KITCHEN        "Kitchen"
+#define DISP_HYDROPONICS    "Hydroponics"
+#define DISP_JANITOR_CLOSET "Janitor Closet"
+#define DISP_GENETICS       "Genetics"
+#define DISP_TELECOMMS      "Telecomms"
+#define DISP_MECHANICS      "Mechanics"
+#define DISP_TELESCIENCE    "Telescience"

--- a/maps/_map.dm
+++ b/maps/_map.dm
@@ -43,6 +43,36 @@
 	//Fuck the preprocessor
 	var/dorf = 0
 
+	// List of package tagger locations. Due to legacy shitcode you can only append or replace ones with null, or you'll break stuff.
+	var/list/default_tagger_locations = list(
+		DISP_DISPOSALS,
+		DISP_CARGO_BAY,
+		DISP_QM_OFFICE,
+		DISP_ENGINEERING,
+		DISP_CE_OFFICE,
+		DISP_ATMOSPHERICS,
+		DISP_SECURITY,
+		DISP_HOS_OFFICE,
+		DISP_MEDBAY,
+		DISP_CMO_OFFICE,
+		DISP_CHEMISTRY,
+		DISP_RESEARCH,
+		DISP_RD_OFFICE,
+		DISP_ROBOTICS,
+		DISP_HOP_OFFICE,
+		DISP_LIBRARY,
+		DISP_CHAPEL,
+		DISP_THEATRE,
+		DISP_BAR,
+		DISP_KITCHEN,
+		DISP_HYDROPONICS,
+		DISP_JANITOR_CLOSET,
+		DISP_GENETICS,
+		DISP_TELECOMMS,
+		DISP_MECHANICS,
+		DISP_TELESCIENCE
+	)
+
 /datum/map/New()
 
 	. = ..()

--- a/maps/defficiency.dm
+++ b/maps/defficiency.dm
@@ -25,10 +25,38 @@
 			},
 		)
 
+	default_tagger_locations = list(
+		DISP_DISPOSALS,
+		DISP_CARGO_BAY,
+		DISP_QM_OFFICE,
+		DISP_ENGINEERING,
+		DISP_CE_OFFICE,
+		DISP_ATMOSPHERICS,
+		DISP_SECURITY,
+		DISP_HOS_OFFICE,
+		DISP_MEDBAY,
+		DISP_CMO_OFFICE,
+		DISP_CHEMISTRY,
+		DISP_RESEARCH,
+		DISP_RD_OFFICE,
+		DISP_ROBOTICS,
+		DISP_HOP_OFFICE,
+		DISP_LIBRARY,
+		DISP_CHAPEL,
+		DISP_THEATRE,
+		DISP_BAR,
+		DISP_KITCHEN,
+		DISP_HYDROPONICS,
+		DISP_JANITOR_CLOSET,
+		DISP_GENETICS,
+		null,
+		DISP_MECHANICS,
+		null
+	)
 
 //The central shuttle leads to both outposts
 /datum/map/active/New()
-	.=..()
+	. = ..()
 
 	mining_shuttle.name = "Asteroid Shuttle" //There is only one shuttle on defficiency now - the asteroid shuttle
 	mining_shuttle.req_access = list() //It's shared by miners and researchers, so remove access requirements


### PR DESCRIPTION
Fixes #8146 - Moved default tagger locations to map datums and used this to make telecommunications and telescience not show up in the tagger, because they were too cramped.
FIxes #8406 
Fixes #8405 
