### PR TITLE
Fixes two runtimes (and fixes some relative pathing)

### DIFF
--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -402,66 +402,67 @@ Alien plants should do something if theres a lot of poison
 
 	flags = PROXMOVE
 
-	New()
-		if(aliens_allowed)
-			..()
-			spawn(rand(MIN_GROWTH_TIME,MAX_GROWTH_TIME))
-				Grow()
-		else
-			qdel(src)
+/obj/effect/alien/egg/New()
+	if(aliens_allowed)
+		..()
+		spawn(rand(MIN_GROWTH_TIME,MAX_GROWTH_TIME))
+			Grow()
+	else
+		qdel(src)
 
-	attack_paw(user as mob)
-		if(isalien(user))
-			switch(status)
-				if(BURST)
-					to_chat(user, "<span class='warning'>You clear the hatched egg.</span>")
-					qdel(src)
-					return
-				if(GROWING)
-					to_chat(user, "<span class='warning'>The child is not developed yet.</span>")
-					return
-				if(GROWN)
-					to_chat(user, "<span class='warning'>You retrieve the child.</span>")
-					Burst(0)
-					return
-		else
-			return attack_hand(user)
+/obj/effect/alien/egg/attack_paw(user as mob)
+	if(isalien(user))
+		switch(status)
+			if(BURST)
+				to_chat(user, "<span class='warning'>You clear the hatched egg.</span>")
+				qdel(src)
+				return
+			if(GROWING)
+				to_chat(user, "<span class='warning'>The child is not developed yet.</span>")
+				return
+			if(GROWN)
+				to_chat(user, "<span class='warning'>You retrieve the child.</span>")
+				Burst(0)
+				return
+	else
+		return attack_hand(user)
 
-	attack_hand(user as mob)
-		to_chat(user, "It feels slimy.")
-		return
+/obj/effect/alien/egg/attack_hand(user as mob)
+	to_chat(user, "It feels slimy.")
+	return
 
-	proc/GetFacehugger()
-		return locate(/obj/item/clothing/mask/facehugger) in contents
+/obj/effect/alien/egg/proc/GetFacehugger()
+	return locate(/obj/item/clothing/mask/facehugger) in contents
 
-	proc/Grow()
-		icon_state = "egg"
-		status = GROWN
-		new /obj/item/clothing/mask/facehugger(src)
-		return
+/obj/effect/alien/egg/proc/Grow()
+	icon_state = "egg"
+	status = GROWN
+	new /obj/item/clothing/mask/facehugger(src)
+	return
 
-	proc/Burst(var/kill = 1) //drops and kills the hugger if any is remaining
-		if(status == GROWN || status == GROWING)
-			var/obj/item/clothing/mask/facehugger/child = GetFacehugger()
-			icon_state = "egg_hatched"
-			flick("egg_opening", src)
-			status = BURSTING
-			spawn(15)
-				status = BURST
-				if(!child)
-					src.visible_message("<span class='warning'>The egg bursts apart revealing nothing</span>")
-					status = "GROWN"
-					new /obj/effect/decal/cleanable/blood/xeno(src)
-					var/obj/effect/decal/cleanable/blood/xeno/O = getFromPool(/obj/effect/decal/cleanable/blood/xeno, src)
-					O.New(src)
-				child.loc = loc
-				if(kill && istype(child))
-					child.Die()
-				else
-					for(var/mob/M in range(1,src))
-						if(CanHug(M))
-							child.Attach(M)
-							break
+/obj/effect/alien/egg/proc/Burst(var/kill = 1) //drops and kills the hugger if any is remaining
+	if(status == GROWN || status == GROWING)
+		var/obj/item/clothing/mask/facehugger/child = GetFacehugger()
+		icon_state = "egg_hatched"
+		flick("egg_opening", src)
+		status = BURSTING
+		spawn(15)
+			status = BURST
+			if(!child)
+				src.visible_message("<span class='warning'>The egg bursts apart, revealing nothing!</span>")
+				status = "GROWN"
+				new /obj/effect/decal/cleanable/blood/xeno(src)
+				var/obj/effect/decal/cleanable/blood/xeno/O = getFromPool(/obj/effect/decal/cleanable/blood/xeno, src)
+				O.New(src)
+				return
+			child.forceMove(loc)
+			if(kill && istype(child))
+				child.Die()
+			else
+				for(var/mob/M in range(1,src))
+					if(CanHug(M))
+						child.Attach(M)
+						break
 
 
 /obj/effect/alien/egg/bullet_act(var/obj/item/projectile/Proj)

--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -451,9 +451,7 @@ Alien plants should do something if theres a lot of poison
 			if(!child)
 				src.visible_message("<span class='warning'>The egg bursts apart, revealing nothing!</span>")
 				status = "GROWN"
-				new /obj/effect/decal/cleanable/blood/xeno(src)
-				var/obj/effect/decal/cleanable/blood/xeno/O = getFromPool(/obj/effect/decal/cleanable/blood/xeno, src)
-				O.New(src)
+				getFromPool(/obj/effect/decal/cleanable/blood/xeno, src)
 				return
 			child.forceMove(loc)
 			if(kill && istype(child))

--- a/code/modules/RCD/schematics/engi.dm
+++ b/code/modules/RCD/schematics/engi.dm
@@ -80,7 +80,7 @@
 
 	var/turf/simulated/floor/T = A
 	to_chat(user, "Building wall")
-	playsound(get_turf(src), 'sound/machines/click.ogg', 50, 1)
+	playsound(get_turf(master), 'sound/machines/click.ogg', 50, 1)
 	if(do_after(user, A, 20))
 		if(master.get_energy(user) < energy_cost)
 			return 1


### PR DESCRIPTION
Fixes a sound runtime on building walls with the RCD
Fixes a runtime that would occur whenever an empty facehugger egg bursts

I was going to fix more runtimes on this branch but then I didn't

We have _FUCKLOADS_ of sound runtimes and this only fixes one kind
