### PR TITLE
Fixes spacepod weapons again

### DIFF
--- a/code/WorkInProgress/pomf/spacepods/spacepods.dm
+++ b/code/WorkInProgress/pomf/spacepods/spacepods.dm
@@ -143,7 +143,7 @@
 				to_chat(user, "<span class='notice'>The pod already has a weapon system, remove it first.</span>")
 				return
 			else
-				if(user.drop_item(W, equipment_system))
+				if(user.drop_item(W, src))
 					to_chat(user, "<span class='notice'>You insert \the [W] into the equipment system.</span>")
 					equipment_system.weapon_system = W
 					equipment_system.weapon_system.my_atom = src


### PR DESCRIPTION
Spacepod weapons are now inserted into the spacepod rather than nullspaced and inserting them actually makes the spacepod know they're there now

The spacepod equipment system code makes me uncomfortable, but it does work (with this fix) and I don't really want to rewrite it all right now

This is tested, by the way
