### PR TITLE
Fixes energy axes being unconcealable after activation

### DIFF
--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -111,10 +111,10 @@
 		"<span class='warning'>You collapse the fishing rod.</span>",\
 		"You hear a balloon exploding.")
 
-		icon_state = "telebaton_0"
-		item_state = "telebaton_0"
-		w_class = 2
-		force = 3//not so robust now
+		icon_state = initial(icon_state)
+		item_state = initial(item_state)
+		w_class = initial(w_class)
+		force = initial(force) //not so robust now
 		attack_verb = list("hit", "punched")
 	playsound(get_turf(src), 'sound/weapons/empty.ogg', 50, 1)
 	add_fingerprint(user)
@@ -203,9 +203,9 @@
 		src.sharpness = 1.5
 	else
 		to_chat(user, "<span class='notice'>The axe can now be concealed.</span>")
-		src.force = 40
-		src.icon_state = "axe0"
-		src.w_class = 5
-		src.sharpness = 1.0
+		src.force = initial(src.force)
+		src.icon_state = initial(src.icon_state)
+		src.w_class = initial(src.w_class)
+		src.sharpness = initial(src.sharpness)
 	src.add_fingerprint(user)
 	return


### PR DESCRIPTION
Sets energy axes and energy swords to use initial proc to return to their starting state after de-activation
