### PR TITLE
Modifications to the cryptographic sequencer

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -424,7 +424,7 @@ var/list/uplink_items = list()
 	name = "Cryptographic Sequencer"
 	desc = "The emag is a small card that unlocks hidden functions in electronic devices, subverts intended functions and characteristically breaks security mechanisms."
 	item = /obj/item/weapon/card/emag
-	cost = 3
+	cost = 5
 
 /datum/uplink_item/device_tools/toolbox
 	name = "Fully Loaded Toolbox"

--- a/html/changelogs/icantthinkofanameritenow.yml
+++ b/html/changelogs/icantthinkofanameritenow.yml
@@ -1,0 +1,7 @@
+
+author: Icantthinkofanameritenow
+
+delete-after: True
+
+changes: 
+- tweak Changed the price of the emag to 5 TC (from 3 TC)

--- a/html/changelogs/icantthinkofanameritenow.yml
+++ b/html/changelogs/icantthinkofanameritenow.yml
@@ -3,4 +3,4 @@ author: Icantthinkofanameritenow
 delete-after: True
 
 changes: 
-- tweak Changed the price of the emag to 5 TC (from 3 TC)
+ - tweak: Changed the price of the emag to 5 TC (from 3 TC)

--- a/html/changelogs/icantthinkofanameritenow.yml
+++ b/html/changelogs/icantthinkofanameritenow.yml
@@ -1,6 +1,5 @@
 
 author: Icantthinkofanameritenow
-
 delete-after: True
 
 changes: 


### PR DESCRIPTION
To answer the complaints that the e-mag is too versatile and too powerful for its cost to the point where it invalidates all other traitor items, I'm considering one of two approaches:
1. Raise its price. This is what I have already coded, and if needed can be performed in conjunction with the second approach.
2. Re-enable one of its older features which was removed in 2014, in which it expended energy to function but could regain said energy over a period of time. This would make it impossible to just emag open every door on the station. (Some features also expended more than one unit of energy at a time, which could again force players to use it carefully- subverting a borg should take more energy than just breaking a door.)
