### PR TITLE
Makes toolboxes more useful

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -14,6 +14,7 @@
 	//  = - Strict type matching.  Will NOT check for subtypes.
 	var/list/can_hold = new/list() //List of objects which this item can store (if set, it can't store anything else)
 	var/list/cant_hold = new/list() //List of objects which this item can't store (in effect only if can_hold isn't set)
+	var/list/ignore_w_class = new/list() //List of objects which will fit in this item, regardless of size. AKA can_hold_too.
 	var/list/is_seeing = new/list() //List of mobs which are currently seeing the contents of this item's storage
 	var/max_w_class = 2 //Max size of objects that this object can store (in effect only if can_hold isn't set)
 	var/max_combined_w_class = 14 //The sum of the w_classes of all the items in this storage item.
@@ -262,9 +263,22 @@
 			return 0
 
 	if (W.w_class > max_w_class)
-		if(!stop_messages)
-			to_chat(usr, "<span class='notice'>\The [W] is too big for \the [src].</span>")
-		return 0
+		var/yeh = 0
+		if(ignore_w_class.len)
+			for(var/A in ignore_w_class)
+				if(dd_hasprefix(A,"="))
+					// Force strict matching of type.
+					// No subtypes allowed.
+					if("[W.type]"==copytext(A,2))
+						yeh = 1
+						break
+				else if(istype(W, text2path(A) ))
+					yeh = 1
+					break
+		if(!yeh)
+			if(!stop_messages)
+				to_chat(usr, "<span class='notice'>\The [W] is too big for \the [src].</span>")
+			return 0
 
 	var/sum_w_class = W.w_class
 	for(var/obj/item/I in contents)

--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -17,7 +17,24 @@
 	melt_temperature = MELTPOINT_STEEL
 	origin_tech = "combat=1"
 	attack_verb = list("robusted", "battered", "staved in")
-
+	storage_slots = 14
+	max_combined_w_class = 28
+	ignore_w_class = list(
+		"/obj/item/weapon/weldingtool/hugetank",
+		"/obj/item/device/rcd/matter/engineering",
+		"/obj/item/device/rcd/rpd",
+		"/obj/item/device/rcd/tile_painter",
+		"/obj/item/blueprints",
+		"/obj/item/device/lightreplacer",
+		"/obj/item/weapon/rcl",
+		"/obj/item/weapon/cell",
+		"/obj/item/stack/rods",
+		"/obj/item/stack/tile",
+		"/obj/item/stack/sheet/metal",
+		"/obj/item/stack/sheet/glass",
+		"/obj/item/stack/sheet/mineral",
+		"/obj/item/stack/sheet/wood"
+		)
 
 /obj/item/weapon/storage/toolbox/suicide_act(mob/user)
 	to_chat(viewers(user), "<span class='danger'>[user] is [pick("staving","robusting")] \his head in with the [src.name]! It looks like \he's  trying to commit suicide!</span>")

--- a/html/changelogs/9600bauds_clong.yml
+++ b/html/changelogs/9600bauds_clong.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general deleting of nice things)
+#   rscadd (general adding of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: 9600bauds
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+changes: 
+- tweak: Toolboxes now have up to 14 item slots. Much like how plastic bags work, they may hold less than 14 items depending on their total combined size.
+- tweak: Toolboxes can now hold many general Engineering items they couldn't hold before. This includes material sheets, power cells, floor tiles, metal rods, RCD, RPD, tile painter, light replacer, improved welding tools, and the station blueprints.


### PR DESCRIPTION
It always bothered me that you never saw engineers carrying toolboxes, because they were worse than a backpack at carrying anything. After toolbelts were buffed, these fell even more behind the curve.
This is my attempt at making them more useful. I think these changes won't mess with the balance too much, seeing as toolboxes are w_class 4 items that must be carried by hand.
- Many tools and Engineering items which previously didn't fit in toolboxes will now fit. This includes material sheets, power cells, floor tiles, metal rods, RCD, RPD, tile painter, light replacer, improved welding tools, and the station blueprints.
- Toolboxes can now hold up to 14 items (much like plastic bags, less if big items are loaded).
