### PR TITLE
Fixes a runtime on null mybag when removing bags from janicart

### DIFF
--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -72,7 +72,7 @@
 	set category = "Object"
 	set src in oview(1)
 
-	if(!usr.incapacitated() && Adjacent(usr) && usr.dexterity_check())
+	if(mybag && !usr.incapacitated() && Adjacent(usr) && usr.dexterity_check())
 		mybag.forceMove(get_turf(usr))
 		usr.put_in_hands(mybag)
 		mybag = null


### PR DESCRIPTION
``` DM
runtime error: Cannot execute null.forceMove().
proc name: Remove Trash Bag (/obj/structure/bed/chair/vehicle/janicart/verb/remove_trashbag)
  source file: janicart.dm,76
  usr: Mavis Reed (/mob/living/carbon/human)
  src: the upgraded janicart (/obj/structure/bed/chair/vehicle/janicart)
  usr.loc: the floor (265,242,1) (/turf/simulated/floor)
  src.loc: the floor (265,241,1) (/turf/simulated/floor)
  call stack:
the upgraded janicart (/obj/structure/bed/chair/vehicle/janicart): Remove Trash Bag()
```
