### PR TITLE
Make Select Equipment a +SPAWN verb instead of +FUN

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -94,7 +94,6 @@ var/list/admin_verbs_sounds = list(
 var/list/admin_verbs_fun = list(
 	/datum/admins/proc/media_stop_all,
 	/client/proc/object_talk,
-	/client/proc/cmd_admin_dress,
 	/client/proc/cmd_admin_gib_self,
 	/client/proc/drop_bomb,
 	/client/proc/drop_emp,
@@ -121,9 +120,10 @@ var/list/admin_verbs_fun = list(
 	/client/proc/makepAI
 	)
 var/list/admin_verbs_spawn = list(
-	/datum/admins/proc/spawn_atom,		/*	Allows us to spawn instances.							*/
-	/client/proc/spawn_datum,		/*	Allows us to spawn datums to the marked datum buffer.	*/
-	/client/proc/respawn_character
+	/datum/admins/proc/spawn_atom, // Allows us to spawn instances
+	/client/proc/spawn_datum, //Allows us to spawn datums to the marked datum buffer
+	/client/proc/cmd_admin_dress, //Allows us to spawn clothing and dress a mob with it in one click
+	/client/proc/respawn_character //Allows us to re-spawn someone
 	)
 var/list/admin_verbs_server = list(
 	/client/proc/Set_Holiday,

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -621,10 +621,13 @@ Pressure: [env.return_pressure()]"}
 	set category = "Fun"
 	set name = "Select equipment"
 
+	if(!check_rights(R_SPAWN))
+		return
+
 	if(!ishuman(M))
 		alert("Invalid mob")
 		return
-	//log_admin("[key_name(src)] has alienized [M.key].")
+
 	var/list/dresspacks = list(
 		"strip",
 		"Engineer RIG",
@@ -659,6 +662,7 @@ Pressure: [env.return_pressure()]"}
 		"Bomberman",
 		"Bomberman(arena)",
 		)
+
 	var/dostrip = input("Do you want to strip [M] before equipping them? (0=no, 1=yes)", "STRIPTEASE") as null|anything in list(0,1)
 	if(isnull(dostrip))
 		return


### PR DESCRIPTION
The first streak in my newfound crusade against the obvious lack of balance in the distribution of admin verbs relative to flags

Since Select Equipment spawns clothing on a mob, it makes sense for it to be locked behind +SPAWN. And not locked behind +FUN for some reason
- Moved Select Equipment from +FUN to +SPAWN
- Tweaked a few comments
