### PR TITLE
Add SKIP_MINIMAP_GENERATION to config

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -167,6 +167,8 @@
 
 	var/mommi_static = 0 //Scrambling mobs for mommis or not
 
+	var/skip_minimap_generation = 0 //If 1, don't generate minimaps
+
 /datum/configuration/New()
 	. = ..()
 	var/list/L = typesof(/datum/game_mode) - /datum/game_mode
@@ -524,6 +526,8 @@
 					renders_url = value
 				if("mommi_static")
 					mommi_static = 1
+				if("skip_minimap_generation")
+					skip_minimap_generation = 1
 				else
 					diary << "Unknown setting in configuration: '[name]'"
 

--- a/code/controllers/master_controller.dm
+++ b/code/controllers/master_controller.dm
@@ -216,11 +216,14 @@ datum/controller/game_controller/proc/cachedamageicons()
 			count++
 	log_startup_progress("  Initialized [count] atmos devices in [stop_watch(watch)]s.")
 
-	spawn()
-		watch = start_watch()
-		log_startup_progress("Generating in-game minimaps...")
-		generateMiniMaps()
-		log_startup_progress("  Finished minimaps in [stop_watch(watch)]s.")
+	if(!config.skip_minimap_generation)
+		spawn()
+			watch = start_watch()
+			log_startup_progress("Generating in-game minimaps...")
+			generateMiniMaps()
+			log_startup_progress("  Finished minimaps in [stop_watch(watch)]s.")
+	else
+		log_startup_progress("Not generating minimaps - SKIP_MINIMAP_GENERATION found in config/config.txt")
 
 	log_startup_progress("Finished initializations in [stop_watch(overwatch)]s.")
 

--- a/config-example/config.txt
+++ b/config-example/config.txt
@@ -276,3 +276,7 @@ RENDERS_URL http://ss13.pomf.se/img/map-renders
 ## MOMMI_STATIC
 ## Uncomment to enable scrambling the image of mobs for MoMMIs
 #MOMMI_STATIC
+
+## SKIP_MINIMAP_GENERATION
+## Uncomment to disable generation of minimaps (makes the server start faster!)
+SKIP_MINIMAP_GENERATION


### PR DESCRIPTION
Enabled by default in config-example

Makes local servers start near instantly
