### PR TITLE
Vox and Plasmaman helmets no longer protect from flashes

### DIFF
--- a/code/modules/clothing/spacesuits/alien.dm
+++ b/code/modules/clothing/spacesuits/alien.dm
@@ -160,6 +160,7 @@
 	flags = FPRINT //Flags need updating from inheritance above
 	armor = list(melee = 5, bullet = 5, laser = 5, energy = 5, bomb = 0, bio = 100, rad = 25)
 	pressure_resistance = 5 * ONE_ATMOSPHERE
+	eyeprot = 0
 
 /obj/item/clothing/suit/space/vox/civ/bartender
 	name = "vox bartender pressure suit"
@@ -254,6 +255,7 @@
 	item_state = "vox-pressure-science"
 	desc = "A very alien-looking helmet for vox crewmembers. This one is for SCIENCE!"
 	armor = list(melee = 5, bullet = 5, laser = 5, energy = 5, bomb = 10, bio = 100, rad = 25)
+	eyeprot = 0
 
 /obj/item/clothing/suit/space/vox/civ/science/rd
 	name = "vox research director pressure suit"
@@ -283,6 +285,7 @@
 	item_state = "vox-pressure-medical"
 	desc = "A very alien-looking helmet for Nanotrasen-hired Vox. This one is for medical personnel."
 	pressure_resistance = 40 * ONE_ATMOSPHERE
+	eyeprot = 0
 
 /obj/item/clothing/suit/space/vox/civ/medical/virologist
 	name = "vox virologist pressure suit"

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -41,6 +41,7 @@
 	flags = FPRINT | PLASMAGUARD
 	pressure_resistance = 40 * ONE_ATMOSPHERE
 	species_restricted = list("Plasmaman")
+	eyeprot = 0
 
 	icon_state = "plasmaman_helmet0"
 	item_state = "plasmaman_helmet0"
@@ -96,6 +97,7 @@
 	base_state = "plasmamanEngineer_helmet"
 	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 35, bio = 100, rad = 80)
 	pressure_resistance = 200 * ONE_ATMOSPHERE
+	eyeprot = 1
 
 /obj/item/clothing/suit/space/plasmaman/engineer/ce
 	name = "plasmaman chief engineer suit"
@@ -259,6 +261,7 @@
 	icon_state = "plasmamanSecurity_helmet0"
 	base_state = "plasmamanSecurity_helmet"
 	armor = list(melee = 40, bullet = 15, laser = 35,energy = 5, bomb = 35, bio = 100, rad = 20)
+	eyeprot = 1
 
 /obj/item/clothing/suit/space/plasmaman/security/hos
 	name = "plasmaman head of security suit"

--- a/html/changelogs/icantthinkofanameritenow.yml
+++ b/html/changelogs/icantthinkofanameritenow.yml
@@ -1,0 +1,6 @@
+ 
+author: Icantthinkofanameritenow
+delete-after: True
+
+changes: 
+- rscdel: Most vox and plasmaman helmets no longer protect from flashes.


### PR DESCRIPTION
Removes EYEPROT from civilian Vox and Plasmaman helmets (e.g. all but engineering and security). This will make them vulnerable to flashing despite being space helmets. Please note that this also removes their welder protection too, so please remember to wear welding goggles if you need to weld something and aren't one of those jobs at roundstart.

Addresses #6093 
