### PR TITLE
I think that this is generic enough.

### DIFF
--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -381,9 +381,9 @@
 /mob/living/silicon/pai/proc/downloadSoftware()
 	var/dat = ""
 
-	dat += {"<h2>CentComm pAI Module Subversion Network</h2><br>
+	dat += {"<h2>CentComm pAI Module Source Control Network</h2><br>
 		<pre>Remaining Available Memory: [src.ram]</pre><br>
-		<p style=\"text-align:center\"><b>Trunks available for checkout</b><br>"}
+		<p style=\"text-align:center\"><b>Branches available for checkout</b><br>"}
 	for(var/s in available_software)
 		if(!software.Find(s))
 			var/cost = src.available_software[s]


### PR DESCRIPTION
So, I was playing pAI and noticed that Nanotrasen's pAI software is hosted on a Subversion network.
Why would they use Subversion many years in the future? So I changed it.

Here is the generic pull request, where I made the text neutral.
There is another pull request upcoming where I changed "Subversion" to "Git" and "Trunks" to "Branches", probably a minute after creating this PR.

If you want to talk about which one you want to accept (or deny both), please talk about it in THIS PR to prevent making things more difficult.

Git PR: https://github.com/d3athrow/vgstation13/pull/8632
