### PR TITLE
Changing anything referencing Svn to Git.

### DIFF
--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -381,9 +381,9 @@
 /mob/living/silicon/pai/proc/downloadSoftware()
 	var/dat = ""
 
-	dat += {"<h2>CentComm pAI Module Subversion Network</h2><br>
+	dat += {"<h2>CentComm pAI Module Git Network</h2><br>
 		<pre>Remaining Available Memory: [src.ram]</pre><br>
-		<p style=\"text-align:center\"><b>Trunks available for checkout</b><br>"}
+		<p style=\"text-align:center\"><b>Branches available for checkout</b><br>"}
 	for(var/s in available_software)
 		if(!software.Find(s))
 			var/cost = src.available_software[s]


### PR DESCRIPTION
[So, I was playing pAI and noticed that Nanotrasen's pAI software is hosted on a Subversion network.
Why would they use Subversion many years in the future? So I changed it.

Here is the Git pull request, where I changed any reference of Subversion to Git.

If you want to talk about which one you want to accept (or deny both), please talk about it in https://github.com/d3athrow/vgstation13/pull/8631 to prevent making things more difficult.
