### PR TITLE
changing-references-of-subversion-in-the-pai-software-downloader-to-cvs-because-nt-uses-outdated-technology

### DIFF
--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -381,7 +381,7 @@
 /mob/living/silicon/pai/proc/downloadSoftware()
 	var/dat = ""
 
-	dat += {"<h2>CentComm pAI Module Subversion Network</h2><br>
+	dat += {"<h2>CentComm pAI Module CVS Network</h2><br>
 		<pre>Remaining Available Memory: [src.ram]</pre><br>
 		<p style=\"text-align:center\"><b>Trunks available for checkout</b><br>"}
 	for(var/s in available_software)


### PR DESCRIPTION
I hope that I got the terminology correct.
https://github.com/d3athrow/vgstation13/pull/8631#issuecomment-192399370
https://github.com/d3athrow/vgstation13/pull/8631#issuecomment-192400665
