### PR TITLE
Another move optimization

### DIFF
--- a/code/defines/obj.dm
+++ b/code/defines/obj.dm
@@ -332,10 +332,13 @@ var/global/list/PDA_Manifest = list()
 	owner = mind
 	ourspell = F
 	src.theworld = theworld
+
 /obj/effect/stop/sleeping/Crossed(atom/movable/A)
 	if(sleeptime > world.time)
 		if(ismob(A))
 			var/mob/living/L = A
+			if(L.client)
+				L.client.move_delayer.next_allowed = sleeptime //So we don't need to check timestopped in client/move
 			if(L.mind != owner)
 				if(!L.stat) L.playsound_local(src, theworld == 1 ? 'sound/effects/theworld2.ogg' : 'sound/effects/fall2.ogg', 100, 0, 0, 0, 0)
 				//L.Paralyse(round(((sleeptime - world.time)/10)/2, 1))

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -201,10 +201,6 @@
 		O.dir = direct
 
 /client/Move(loc,dir)
-	if(!mob)
-		return // Moved here to avoid nullrefs below. - N3X
-	if(mob.timestopped)
-		return 0
 	if(move_delayer.next_allowed > world.time)
 		return 0
 


### PR DESCRIPTION
Instead of mobs checking timestopped in client/move(), being timestopped sets your move delayer until the time when the timestop will end.

Also removes the mob check because seriously if a client doesn't have a mob it gets removed from the game and if that is still runtiming then its a serious byond bug.