### PR TITLE
Blood color instead of blend for everything but gibs

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -16,7 +16,7 @@ var/global/list/blood_list = list()
 	appearance_flags = NO_CLIENT_COLOR
 	var/base_icon = 'icons/effects/blood.dmi'
 
-	basecolor="#A10808" // Color when wet.
+	color="#A10808" // Color when wet.
 	amount = 5
 	counts_as_blood = 1
 	transfers_dna = 1
@@ -33,11 +33,6 @@ var/global/list/blood_list = list()
 /obj/effect/decal/cleanable/blood/update_icon()
 	if(basecolor == "rainbow") basecolor = "#[pick(list("FF0000","FF7F00","FFFF00","00FF00","0000FF","4B0082","8F00FF"))]"
 	color = basecolor
-
-	var/icon/blood = icon(base_icon,icon_state,dir)
-	blood.Blend(basecolor,ICON_MULTIPLY)
-
-	icon = blood
 
 /obj/effect/decal/cleanable/blood/splatter
 	random_icon_states = list("mgibbl1", "mgibbl2", "mgibbl3", "mgibbl4", "mgibbl5")

--- a/code/game/objects/effects/decals/Cleanable/tracks.dm
+++ b/code/game/objects/effects/decals/Cleanable/tracks.dm
@@ -17,6 +17,7 @@ var/global/list/image/fluidtrack_cache=list()
 /datum/fluidtrack
 	var/direction=0
 	var/basecolor="#A10808"
+	var/color="#A10808"
 	var/wet=0
 	var/fresh=1
 	var/crusty=0
@@ -25,6 +26,7 @@ var/global/list/image/fluidtrack_cache=list()
 /datum/fluidtrack/New(_direction,_color,_wet)
 	src.direction=_direction
 	src.basecolor=_color
+	src.color=_color
 	src.wet=_wet
 
 // Footprints, tire trails...
@@ -199,7 +201,8 @@ var/global/list/image/fluidtrack_cache=list()
 			state=going_state
 			truedir=truedir>>4
 		var/icon/add = icon('icons/effects/fluidtracks.dmi', state, truedir)
-		add.SwapColor("#FFFFFF",track.basecolor)
+		// add.color = track.color
+		// color var is per obj so overlays dont need a color
 		overlays += add
 
 		track.fresh=0
@@ -228,4 +231,3 @@ var/global/list/image/fluidtrack_cache=list()
 	gender = PLURAL
 	random_icon_states = null
 	amount = 0
-


### PR DESCRIPTION
Left basecolor var in because it's used in some places right now.
This will mostly mean that tracking blood will lag a lot less, as will people bleeding in general. Gibs will still lag a bit.
The reason I can't just use color on gibs is because the base icons for gibs are colored and it doesn't multiply properly without Blend() for some reason?
