### PR TITLE
Makes atoms not call Crossed() on themselves

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -279,7 +279,8 @@
 			A.Entered(src)
 
 		for(var/atom/movable/AM in loc)
-			AM.Crossed(src,no_tp)
+			if(AM != src && AM.locked_to != src)
+				AM.Crossed(src,no_tp)
 
 
 		for(var/atom/movable/AM in locked_atoms)


### PR DESCRIPTION
Okay, this is a weird one.
Apparently every time an atom moves, it also calls Crossed() on itself. Same for items that have locked atoms.
I'm not sure if this could be a performance issue, or if there are any items that rely on this, but it really seems like a bug and it's biting my ass.
