### PR TITLE
Updating Canmove

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1453,7 +1453,7 @@ var/list/slot_equipment_priority = list( \
 		lying = (locked_to.lockflags & LOCKED_SHOULD_LIE) ? TRUE : FALSE //A lying value that !=1 will break this
 
 
-	else if(isUnconscious() || weakened || paralysis || resting)
+	else if(isUnconscious() || weakened || paralysis || resting || !can_stand)
 		stop_pulling()
 		lying = 1
 		canmove = 0
@@ -1465,7 +1465,7 @@ var/list/slot_equipment_priority = list( \
 		canmove = 0
 		lying = 0
 	else
-		lying = !can_stand
+		lying = 0
 		canmove = has_limbs
 
 	if(lying)


### PR DESCRIPTION
If you can no longer stand, it stands to reason that you should be lying, since lying is the state in which you are not standing, and thusly if you are lying you are not moving, since that is how the game works.

Fixes #8671
Fixes #6029
Fixes #7021