### PR TITLE
Ports automatic material stacking from TG

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -274,8 +274,8 @@ to destroy them and players will be able to make replacements.
 	else if(iswelder(O))
 		var/obj/item/weapon/weldingtool/WT = O
 		if(WT.remove_fuel(1,user))
-			var/obj/item/stack/sheet/glass/glass/new_item = new /obj/item/stack/sheet/glass/glass(src.loc)
-			new_item.add_to_stacks(user)
+			var/obj/item/stack/sheet/glass/glass/new_item = new()
+			new_item.forceMove(src.loc) //This is because new() doesn't call forceMove, so we're forcemoving the new sheet to make it stack with other sheets on the ground.
 			returnToPool(src)
 			return
 	else

--- a/code/game/objects/items/stacks/cable.dm
+++ b/code/game/objects/items/stacks/cable.dm
@@ -82,6 +82,10 @@ var/global/list/datum/stack_recipe/cable_recipes = list ( \
 	. = ..()
 	update_icon()
 
+/obj/item/stack/cable_coil/add(var/amount)
+	. = ..()
+	update_icon()
+
 /obj/item/stack/cable_coil/can_stack_with(obj/item/other_stack)
 	return istype(other_stack, /obj/item/stack/cable_coil) && !istype(other_stack, /obj/item/stack/cable_coil/heavyduty) //It can be any cable, except the fat stuff
 

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -62,11 +62,11 @@
 			return
 
 		if(WT.remove_fuel(0,user))
-			var/obj/item/stack/sheet/metal/M = getFromPool(/obj/item/stack/sheet/metal, get_turf(src))
+			var/obj/item/stack/sheet/metal/M = getFromPool(/obj/item/stack/sheet/metal)
 			M.amount = 1
-			M.add_to_stacks(usr)
-			user.visible_message("<span class='warning'>[src] is shaped into metal by [user.name] with the weldingtool.</span>", \
-			"<span class='warning'>You shape the [src] into metal with the weldingtool.</span>", \
+			M.forceMove(get_turf(usr)) //This is because new() doesn't call forceMove, so we're forcemoving the new sheet to make it stack with other sheets on the ground.
+			user.visible_message("<span class='warning'>[src] is shaped into metal by [user.name] with the welding tool.</span>", \
+			"<span class='warning'>You shape the [src] into metal with the welding tool.</span>", \
 			"<span class='warning'>You hear welding.</span>")
 			var/obj/item/stack/rods/R = src
 			src = null

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -33,9 +33,9 @@
 		playsound(src.loc, 'sound/items/Welder.ogg', 35, 1)
 	if(istype(W, /obj/item/stack/rods) && !reinforced)
 		var/obj/item/stack/rods/V  = W
-		var/obj/item/stack/sheet/glass/RG = new rglass(user.loc)
+		var/obj/item/stack/sheet/glass/RG = new rglass()
+		RG.forceMove(user.loc) //This is because new() doesn't call forceMove, so we're forcemoving the new sheet to make it stack with other sheets on the ground.
 		RG.add_fingerprint(user)
-		RG.add_to_stacks(user)
 		V.use(1)
 		var/obj/item/stack/sheet/glass/G = src
 		src = null

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -225,16 +225,21 @@
 			usr.before_take_item(src)
 		spawn returnToPool(src)
 
-/obj/item/stack/proc/add_to_stacks(mob/usr as mob)
-	for (var/obj/item/stack/item in usr.loc)
-		if (src == item)
-			continue
-		if(!can_stack_with(item))
-			continue
-		if (item.amount>=item.max_amount)
-			continue
-		src.preattack(item, usr,1)
-		break
+/obj/item/stack/proc/add(var/amount)
+	src.amount += amount
+	update_materials()
+
+/obj/item/stack/proc/merge(obj/item/stack/S) //Merge src into S, as much as possible
+	if(src == S) //We need to check this because items can cross themselves for some fucked up reason
+		return
+	var/transfer = min(amount, S.max_amount - S.amount)
+	if(transfer <= 0)
+		return
+	if(pulledby)
+		pulledby.start_pulling(S)
+	S.copy_evidences(src)
+	use(transfer)
+	S.add(transfer)
 
 /obj/item/stack/proc/update_materials()
 	if(amount && starting_materials)
@@ -278,8 +283,7 @@
 			to_transfer = 1
 		else
 			to_transfer = min(S.amount, max_amount-amount)
-		amount+=to_transfer
-		update_materials()
+		add(to_transfer)
 		to_chat(user, "You add [to_transfer] [((to_transfer > 1) && S.irregular_plural) ? S.irregular_plural : "[S.singular_name]\s"] to \the [src]. It now contains [amount] [CORRECT_STACK_NAME(src)].")
 		if (S && user.machine==S)
 			spawn(0) interact(user)
@@ -289,6 +293,17 @@
 		update_icon()
 		S.update_icon()
 		return 1
+	return ..()
+
+//Ported from -tg-station/#10973, credit to MrPerson
+/obj/item/stack/Crossed(obj/o)
+	if(src != o && istype(o, src.type) && !o.throwing)
+		merge(o)
+	return ..()
+
+/obj/item/stack/hitby(atom/movable/AM) //Doesn't seem to ever be called since stacks are not dense but whatever
+	if(src != AM && istype(AM, src.type))
+		merge(AM)
 	return ..()
 
 /obj/item/stack/proc/copy_evidences(obj/item/stack/from as obj)
@@ -319,8 +334,7 @@
 	for(var/obj/item/stack/S in loc)
 		if(S.can_stack_with(new_stack_type))
 			if(S.max_amount >= S.amount + add_amount)
-				S.amount += add_amount
-				S.update_materials()
+				S.add(add_amount)
 
 				to_chat(user, "<span class='info'>You add [add_amount] item\s to the stack. It now contains [S.amount] [CORRECT_STACK_NAME(S)].</span>")
 				return S

--- a/code/game/objects/items/stacks/tiles/plasteel.dm
+++ b/code/game/objects/items/stacks/tiles/plasteel.dm
@@ -1,7 +1,7 @@
 /obj/item/stack/tile/plasteel
 	name = "floor tile"
 	singular_name = "floor tile"
-	desc = "Those could work as a pretty decent throwing weapon"
+	desc = "Those could work as a pretty decent throwing weapon."
 	icon_state = "tile"
 	w_class = 3.0
 	force = 6.0
@@ -56,11 +56,11 @@
 			return
 
 		if(WT.remove_fuel(0,user))
-			var/obj/item/stack/sheet/metal/M = getFromPool(/obj/item/stack/sheet/metal, get_turf(usr))
+			var/obj/item/stack/sheet/metal/M = getFromPool(/obj/item/stack/sheet/metal)
 			M.amount = 1
-			M.add_to_stacks(usr)
-			user.visible_message("<span class='warning'>[src] is shaped into metal by [user.name] with the weldingtool.</span>", \
-			"<span class='warning'>You shape the [src] into metal with the weldingtool.</span>", \
+			M.forceMove(get_turf(usr)) //This is because new() doesn't call forceMove, so we're forcemoving the new sheet to make it stack with other sheets on the ground.
+			user.visible_message("<span class='warning'>[src] is shaped into metal by [user.name] with the welding tool.</span>", \
+			"<span class='warning'>You shape the [src] into metal with the welding tool.</span>", \
 			"<span class='warning'>You hear welding.</span>")
 			var/obj/item/stack/tile/plasteel/R = src
 			src = null

--- a/code/game/objects/items/weapons/shard.dm
+++ b/code/game/objects/items/weapons/shard.dm
@@ -92,8 +92,8 @@
 	if (iswelder(W))
 		var/obj/item/weapon/weldingtool/WT = W
 		if(WT.remove_fuel(0, user))
-			var/obj/item/stack/sheet/glass/new_item = new glass(user.loc)
-			new_item.add_to_stacks(usr)
+			var/obj/item/stack/sheet/glass/new_item = new glass()
+			new_item.forceMove(user.loc) //This is because new() doesn't call forceMove, so we're forcemoving the new sheet to make it stack with other sheets on the ground.
 			returnToPool(src)
 			return
 	return ..()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -247,8 +247,8 @@
 			M.visible_message( \
 				"<span class='notice'>[M] shakes [src] trying to wake [t_him] up!</span>", \
 				"<span class='notice'>You shake [src] trying to wake [t_him] up!</span>", \
-				drugged_message = "<span class='notice'>[M] starts massaging [t_him]'s back.</span>", \
-				self_drugged_message = "<span class='notice'>You start massaging [t_him]'s back.</span>"
+				drugged_message = "<span class='notice'>[M] starts massaging [src]'s back.</span>", \
+				self_drugged_message = "<span class='notice'>You start massaging [src]'s back.</span>"
 				)
 		// BEGIN HUGCODE - N3X
 		else

--- a/html/changelogs/9600baudstilefetis.yml
+++ b/html/changelogs/9600baudstilefetis.yml
@@ -1,0 +1,35 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general deleting of nice things)
+#   rscadd (general adding of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: 9600bauds
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+changes: 
+- tgs: "Ported automatic material stacking from TG, full credits to MrPerson. This means that some stackable items (such as floortiles, cable coils, metal sheets etc) will now try to stack with eachother when they're in the same tile. This allows you to, for example, drag a floortile behind yourself to scoop up all the loose tiles in a hallway."


### PR DESCRIPTION
Ports https://github.com/tgstation/-tg-station/pull/10973, full credit to MrPerson.
What this PR does is make some stackable items (such as floortiles, cable coils, metal sheets etc) try to stack with eachother when they're in the same tile. This allows you to, for example, drag a floortile behind yourself to scoop up all the loose tiles in a hallway.

Fixes #7649

Webm:
http://a.pomf.cat/wsvmwc.webm
In this .webm you can see:
- How pleb I am by forgetting most hotkeys
- How dumb I am by throwing the full stack back into the pile
- My shit taste in music
