### PR TITLE
Chemistry runtimes fix

### DIFF
--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -263,6 +263,7 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 		var/datum/reagent/R = A
 		if(M && R)
 			R.on_mob_life(M, alien)
+			R.metabolize(M)
 	update_total()
 
 /datum/reagents/proc/update_aerosol(var/mob/M)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -120,8 +120,6 @@
 	if(overdose && volume >= overdose) //This is the current overdose system
 		M.adjustToxLoss(overdose_dam)
 
-	metabolize(M)
-
 /datum/reagent/proc/on_plant_life(var/obj/machinery/portable_atmospherics/hydroponics/T)
 	if(!holder)
 		return


### PR DESCRIPTION
Fixes #8721 
By moving metabolize to outside on_mob_life we can make sure that a reagent won't get qdel'd before its `on_mob_life` finishes, which means that we won't get null holder refs.
