### PR TITLE
Makes Busta-Nuts great again

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1058,7 +1058,7 @@ var/global/num_vending_terminals = 1
 /obj/machinery/vending/snack
 	name = "Getmore Chocolate Corp"
 	desc = "A snack machine courtesy of the Getmore Chocolate Corporation, based out of Mars"
-	product_slogans = "Try our new nougat bar!;Half the calories for double the price!;It's better then Dan's!"
+	product_slogans = "Try our new nougat bar!;Half the calories for double the price!;It's better than Dan's!"
 	product_ads = "The healthiest!;Award-winning chocolate bars!;Mmm! So good!;Oh my god it's so juicy!;Have a snack.;Snacks are good for you!;Have some more Getmore!;Best quality snacks straight from mars.;We love chocolate!;Try our new jerky!"
 	icon_state = "snack"
 	products = list(
@@ -1070,10 +1070,10 @@ var/global/num_vending_terminals = 1
 		/obj/item/weapon/reagent_containers/food/snacks/spacetwinkie = 6,
 		/obj/item/weapon/reagent_containers/food/snacks/cheesiehonkers = 6,
 		/obj/item/weapon/reagent_containers/food/snacks/chococoin/wrapped = 2,
-		/obj/item/weapon/reagent_containers/food/snacks/bustanuts = 10,
 		)
 	contraband = list(
-		/obj/item/weapon/reagent_containers/food/snacks/syndicake = 6,
+		/obj/item/weapon/reagent_containers/food/snacks/syndicake = 4,
+		/obj/item/weapon/reagent_containers/food/snacks/bustanuts = 4,
 		)
 	prices = list(
 		/obj/item/weapon/reagent_containers/food/snacks/candy = 13,
@@ -1084,7 +1084,6 @@ var/global/num_vending_terminals = 1
 		/obj/item/weapon/reagent_containers/food/snacks/spacetwinkie = 12,
 		/obj/item/weapon/reagent_containers/food/snacks/cheesiehonkers = 40,
 		/obj/item/weapon/reagent_containers/food/snacks/chococoin/wrapped = 75,
-		/obj/item/weapon/reagent_containers/food/snacks/bustanuts = 0,
 		)
 
 	pack = /obj/structure/vendomatpack/snack

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -1144,6 +1144,7 @@
 	trash = /obj/item/trash/bustanuts
 	New()
 		..()
+		reagents.add_reagent("nutriment", 6)
 		reagents.add_reagent("bustanut", 6)
 		reagents.add_reagent("sodiumchloride", 6)
 

--- a/html/changelogs/9600bauds_youregonnalovemynuts.yml
+++ b/html/changelogs/9600bauds_youregonnalovemynuts.yml
@@ -1,0 +1,35 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general deleting of nice things)
+#   rscadd (general adding of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: 9600bauds
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+changes: 
+- tweak: "Busta-Nuts now contain nutriment once again. However, to keep them free, they are now a contraband item, and they have a more limited stock."


### PR DESCRIPTION
Busta-nuts now have nutriment once again. As a compromise to keep them free, they're now a contraband item. To prevent hacked Getmore machines from having TOO MUCH free nutriment, lowered the stock of Busta-Nuts and Syndie-Cakes to 4 each.
I've never actually seen Syndie-Cakes out of stock, in fact I rarely see the machines hacked ever so I don't foresee anyone caring about the 2 missing cakes

Fixes #8707
