### PR TITLE
Makes Silicate recipe return 9 units instead of 3

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -103,7 +103,7 @@ datum
 			id = "silicate"
 			result = "silicate"
 			required_reagents = list("aluminum" = 1, "silicon" = 1, "oxygen" = 1)
-			result_amount = 3
+			result_amount = 9
 
 		phalanximine
 			name = "Phalanximine"

--- a/html/changelogs/9600bauds_slip.yml
+++ b/html/changelogs/9600bauds_slip.yml
@@ -1,0 +1,35 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general deleting of nice things)
+#   rscadd (general adding of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: 9600bauds
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+changes: 
+- tweak: Silicate formula now results in 9 units instead of 3.


### PR DESCRIPTION
Silicate kind of fucked up the ghettochem meta because it makes two previously hard-to-obtain chemicals:
- Aluminum: Lets you make flash powder and napalm, previously NOT ghettochemable
- Silicon: Lets you make LUBE, previously required you to get your hands on anti-tox

What this means is that people can just electrolyze Silicate and add water to make lube with zero access and no effort. This won't prevent them from doing so, but it will make it give smaller amounts of lube (ghettochem originally wasn't meant to be so ez)
