### PR TITLE
Removes hardcoded 50 energy on some Box and Meta chemdispensers [needs telling me I didn't fuck up]

### DIFF
--- a/html/changelogs/9600bauds_power.yml
+++ b/html/changelogs/9600bauds_power.yml
@@ -1,0 +1,35 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general deleting of nice things)
+#   rscadd (general adding of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: 9600bauds
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+changes: 
+- tweak: All Chemdispensers in Boxstation and Metastation now start with 100 energy, like they were intended to.


### PR DESCRIPTION
What I did was simply open the map with notepad++ and remove the brackets. I tested it ingame and it compiles and it werks but for the love of GOD I have never touched anything map-related and I don't plan to anytime soon so I need to be reassured that this won't fuck anything up from whitespace or whatever have you

Why To This Change: Every chemdispenser in every map except these 3 all spawned with 100 energy, they're coded to start with 100 energy, and I'm of the belief that chemdispenser energy is a bad mechanic anyways

Fixes #7972
