### PR TITLE
Facehuggers should no longer remove masks through helmets or hug faces through helmets all in one step.

### DIFF
--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -245,9 +245,11 @@ var/const/MAX_ACTIVE_TIME = 400
 				H.visible_message("<span class='danger'>\The [src] bounces off of the [mouth_protection]!</span>")
 				if(prob(75) && sterile == 0)
 					Die()
+					return
 				else
 					GoIdle(15)
 					return
+			return
 
 	if(iscarbon(M))
 		var/mob/living/carbon/target = L


### PR DESCRIPTION
However they will still remove masks and jump on your face all in one step because a breath mask does not protect against facehuggers.

I really don't know that there was an issue before because all I have to go off of is text logs and I can't reproduce it so
And according to #8756 it isnt actually a problem anymore

Fixes #8633
