### PR TITLE
unfucking secbots part 1

### DIFF
--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -187,6 +187,12 @@
 		return 0
 	return 1
 
+/proc/wpermit(var/mob/M) //weapons permit checking
+	var/list/L = M.GetAccess()
+	if(access_weapons in L)
+		return 1
+	return 0
+
 /proc/get_centcom_access(job)
 	switch(job)
 		if("VIP Guest")

--- a/code/game/machinery/bots/ed209bot.dm
+++ b/code/game/machinery/bots/ed209bot.dm
@@ -62,12 +62,15 @@
 	var/declare_arrests = 1 //When making an arrest, should it notify everyone wearing sechuds?
 	var/idcheck = 1 //If true, arrest people with no IDs
 	var/weaponscheck = 1 //If true, arrest people for weapons if they don't have access
-	//List of weapons that secbots will not arrest for
+
+	//List of weapons that secbots will not arrest for, also copypasted in secbot.dm and metaldetector.dm
 	var/safe_weapons = list(
 		/obj/item/weapon/gun/energy/laser/bluetag,
 		/obj/item/weapon/gun/energy/laser/redtag,
 		/obj/item/weapon/gun/energy/laser/practice,
 		/obj/item/weapon/gun/hookshot,
+		/obj/item/weapon/gun/energy/floragun,
+		/obj/item/weapon/melee/defibrillator
 		)
 
 
@@ -713,57 +716,59 @@ Auto Patrol: []"},
 
 //If the security records say to arrest them, arrest them
 //Or if they have weapons and aren't security, arrest them.
+//THIS CODE IS COPYPASTED IN secbot.dm AND metaldetector.dm, with slight variations
 /obj/machinery/bot/ed209/proc/assess_perp(mob/living/carbon/human/perp as mob)
-	var/threatcount = 0
+	var/threatcount = 0 //If threat >= 4 at the end, they get arrested
 
 	if(src.emagged == 2) return 10 //Everyone is a criminal!
 
-	if((src.idcheck) || (isnull(perp:wear_id)) || (istype(perp:wear_id.GetID(), /obj/item/weapon/card/id/syndicate)))
+	if(!src.allowed(perp)) //cops can do no wrong, unless set to arrest.
 
-		if((istype(perp.l_hand, /obj/item/weapon/gun) && !istype(perp.l_hand, /obj/item/weapon/gun/projectile/shotgun)) || istype(perp.l_hand, /obj/item/weapon/melee/baton))
-			if(!istype(perp.l_hand, /obj/item/weapon/gun/energy/laser/bluetag) \
-			&& !istype(perp.l_hand, /obj/item/weapon/gun/energy/laser/redtag) \
-			&& !istype(perp.l_hand, /obj/item/weapon/gun/energy/laser/practice))
-				threatcount += 4
+		if(weaponscheck && !wpermit(perp))
+			if(istype(perp.l_hand, /obj/item/weapon/gun) || istype(perp.l_hand, /obj/item/weapon/melee))
+				if(!(perp.l_hand.type in safe_weapons))
+					threatcount += 4
 
-		if(istype(perp.r_hand, /obj/item/weapon/gun) || istype(perp.r_hand, /obj/item/weapon/melee))
-			if(!istype(perp.r_hand, /obj/item/weapon/gun/energy/laser/bluetag) \
-			&& !istype(perp.r_hand, /obj/item/weapon/gun/energy/laser/redtag) \
-			&& !istype(perp.r_hand, /obj/item/weapon/gun/energy/laser/practice))
-				threatcount += 4
+			if(istype(perp.r_hand, /obj/item/weapon/gun) || istype(perp.r_hand, /obj/item/weapon/melee))
+				if(!(perp.r_hand.type in safe_weapons))
+					threatcount += 4
 
-		if(istype(perp:belt, /obj/item/weapon/gun) || istype(perp:belt, /obj/item/weapon/melee))
-			if(!istype(perp:belt, /obj/item/weapon/gun/energy/laser/bluetag) \
-			&& !istype(perp:belt, /obj/item/weapon/gun/energy/laser/redtag) \
-			&& !istype(perp:belt, /obj/item/weapon/gun/energy/laser/practice))
-				threatcount += 2
+			if(istype(perp.belt, /obj/item/weapon/gun) || istype(perp.belt, /obj/item/weapon/melee))
+				if(!(perp.belt.type in safe_weapons))
+					threatcount += 2
 
-		if(istype(perp:wear_suit, /obj/item/clothing/suit/wizrobe))
+		if(istype(perp.wear_suit, /obj/item/clothing/suit/wizrobe))
 			threatcount += 2
 
 		if(perp.dna && perp.dna.mutantrace && perp.dna.mutantrace != "none")
 			threatcount += 2
 
-//Agent cards lower threatlevel when normal idchecking is off.
-		if((perp.wear_id && istype(perp:wear_id.GetID(), /obj/item/weapon/card/id/syndicate)) && src.idcheck)
+		if(!perp.wear_id)
+			if(idcheck)
+				threatcount += 4
+			else
+				threatcount += 2
+
+		//Agent cards lower threatlevel.
+		if(perp.wear_id && istype(perp.wear_id.GetID(), /obj/item/weapon/card/id/syndicate))
 			threatcount -= 2
 
 	if(src.lasercolor == "b")//Lasertag turrets target the opposing team, how great is that? -Sieve
 		threatcount = 0//They will not, however shoot at people who have guns, because it gets really fucking annoying
 		if(istype(perp.wear_suit, /obj/item/clothing/suit/redtag))
 			threatcount += 4
-		if((istype(perp:r_hand,/obj/item/weapon/gun/energy/laser/redtag)) || (istype(perp:l_hand,/obj/item/weapon/gun/energy/laser/redtag)))
+		if((istype(perp.r_hand,/obj/item/weapon/gun/energy/laser/redtag)) || (istype(perp.l_hand,/obj/item/weapon/gun/energy/laser/redtag)))
 			threatcount += 4
-		if(istype(perp:belt, /obj/item/weapon/gun/energy/laser/redtag))
+		if(istype(perp.belt, /obj/item/weapon/gun/energy/laser/redtag))
 			threatcount += 2
 
 	if(src.lasercolor == "r")
 		threatcount = 0
 		if(istype(perp.wear_suit, /obj/item/clothing/suit/bluetag))
 			threatcount += 4
-		if((istype(perp:r_hand,/obj/item/weapon/gun/energy/laser/bluetag)) || (istype(perp:l_hand,/obj/item/weapon/gun/energy/laser/bluetag)))
+		if((istype(perp.r_hand,/obj/item/weapon/gun/energy/laser/bluetag)) || (istype(perp.l_hand,/obj/item/weapon/gun/energy/laser/bluetag)))
 			threatcount += 4
-		if(istype(perp:belt, /obj/item/weapon/gun/energy/laser/bluetag))
+		if(istype(perp.belt, /obj/item/weapon/gun/energy/laser/bluetag))
 			threatcount += 2
 
 	if(src.check_records)
@@ -779,9 +784,6 @@ Auto Patrol: []"},
 					if((R.fields["id"] == E.fields["id"]) && (R.fields["criminal"] == "*Arrest*"))
 						threatcount = 4
 						break
-
-	if((src.idcheck) && (src.allowed(perp)) && !(src.lasercolor))
-		threatcount = 0//Corrupt cops cannot exist beep boop
 
 	return threatcount
 
@@ -1106,7 +1108,7 @@ Auto Patrol: []"},
 	new /obj/machinery/bot/ed209(get_turf(src),null,"r")
 	qdel(src)
 
-/obj/machinery/bot/ed209/proc/check_for_weapons(var/obj/item/slot_item)
+/obj/machinery/bot/ed209/proc/check_for_weapons(var/obj/item/slot_item) //Unused anywhere, copypasted in secbot.dm
 	if(istype(slot_item, /obj/item/weapon/gun) || istype(slot_item, /obj/item/weapon/melee))
 		if(!(slot_item.type in safe_weapons))
 			return 1

--- a/code/game/machinery/metaldetector.dm
+++ b/code/game/machinery/metaldetector.dm
@@ -24,79 +24,70 @@
 	flags = FPRINT | PROXMOVE
 	machine_flags = WRENCHMOVE | FIXED2WORK
 
+	//List of weapons that metaldetector will not flash for, also copypasted in secbot.dm and ed209bot.dm
+	var/safe_weapons = list(
+		/obj/item/weapon/gun/energy/laser/bluetag,
+		/obj/item/weapon/gun/energy/laser/redtag,
+		/obj/item/weapon/gun/energy/laser/practice,
+		/obj/item/weapon/gun/hookshot,
+		/obj/item/weapon/gun/energy/floragun,
+		/obj/item/weapon/melee/defibrillator
+		)
+
+//THIS CODE IS COPYPASTED IN ed209bot.dm AND secbot.dm, with slight variations
 /obj/machinery/detector/proc/assess_perp(mob/living/carbon/human/perp as mob)
-	var/threatcount = 0
+	var/threatcount = 0 //If threat >= 4 at the end, they get arrested
 	if(!(istype(perp, /mob/living/carbon)) || isalien(perp) || isbrain(perp))
 		return -1
 
-	if(!src.allowed(perp))
+	if(!src.allowed(perp)) //cops can do no wrong, unless set to arrest
 
-		if(istype(perp.l_hand, /obj/item/weapon/gun) || istype(perp.l_hand, /obj/item/weapon/melee))
-			if(!istype(perp.l_hand, /obj/item/weapon/gun/energy/laser/bluetag) \
-			&& !istype(perp.l_hand, /obj/item/weapon/gun/energy/laser/redtag) \
-			&& !istype(perp.l_hand, /obj/item/weapon/gun/energy/laser/practice))
-				threatcount += 4
+		if(!wpermit(perp))
+			if(istype(perp.l_hand, /obj/item/weapon/gun) || istype(perp.l_hand, /obj/item/weapon/melee))
+				if(!(perp.l_hand.type in safe_weapons))
+					threatcount += 4
 
-		if(istype(perp.r_hand, /obj/item/weapon/gun) || istype(perp.r_hand, /obj/item/weapon/melee))
-			if(!istype(perp.r_hand, /obj/item/weapon/gun/energy/laser/bluetag) \
-			&& !istype(perp.r_hand, /obj/item/weapon/gun/energy/laser/redtag) \
-			&& !istype(perp.r_hand, /obj/item/weapon/gun/energy/laser/practice))
-				threatcount += 4
+			if(istype(perp.r_hand, /obj/item/weapon/gun) || istype(perp.r_hand, /obj/item/weapon/melee))
+				if(!(perp.r_hand.type in safe_weapons))
+					threatcount += 4
 
-		if(istype(perp.back, /obj/item/weapon/gun) || istype(perp.back, /obj/item/weapon/melee))
-			if(!istype(perp.back, /obj/item/weapon/gun/energy/laser/bluetag) \
-			&& !istype(perp.back, /obj/item/weapon/gun/energy/laser/redtag) \
-			&& !istype(perp.back, /obj/item/weapon/gun/energy/laser/practice))
-				threatcount += 2
-
-		if(ishuman(perp))
-			if(istype(perp.belt, /obj/item/weapon/gun) || istype(perp.belt, /obj/item/weapon/melee))
-				if(!istype(perp.belt, /obj/item/weapon/gun/energy/laser/bluetag) \
-				&& !istype(perp.belt, /obj/item/weapon/gun/energy/laser/redtag) \
-				&& !istype(perp.belt, /obj/item/weapon/gun/energy/laser/practice))
-					threatcount += 2
-			if(istype(perp.s_store, /obj/item/weapon/gun) || istype(perp.s_store, /obj/item/weapon/melee))
-				if(!istype(perp.s_store, /obj/item/weapon/gun/energy/laser/bluetag) \
-				&& !istype(perp.s_store, /obj/item/weapon/gun/energy/laser/redtag) \
-				&& !istype(perp.s_store, /obj/item/weapon/gun/energy/laser/practice))
+			if(istype(perp.back, /obj/item/weapon/gun) || istype(perp.back, /obj/item/weapon/melee))
+				if(!(perp.back.type in safe_weapons))
 					threatcount += 2
 
-		if(scanmode)
-			//
-			if(istype(perp.l_store, /obj/item/weapon/gun) || istype(perp.l_store, /obj/item/weapon/melee))
-				if(!istype(perp.l_store, /obj/item/weapon/gun/energy/laser/bluetag) \
-				&& !istype(perp.l_store, /obj/item/weapon/gun/energy/laser/redtag) \
-				&& !istype(perp.l_store, /obj/item/weapon/gun/energy/laser/practice))
-					threatcount += 2
+			if(ishuman(perp))
+				if(istype(perp.belt, /obj/item/weapon/gun) || istype(perp.belt, /obj/item/weapon/melee))
+					if(!(perp.belt.type in safe_weapons))
+						threatcount += 2
+
+				if(istype(perp.s_store, /obj/item/weapon/gun) || istype(perp.s_store, /obj/item/weapon/melee))
+					if(!(perp.s_store.type in safe_weapons))
+						threatcount += 2
+
+			if(scanmode)
+				if(istype(perp.l_store, /obj/item/weapon/gun) || istype(perp.l_store, /obj/item/weapon/melee))
+					if(!(perp.l_store.type in safe_weapons))
+						threatcount += 2
 
 
-			if(istype(perp.r_store, /obj/item/weapon/gun) || istype(perp.r_store, /obj/item/weapon/melee))
-				if(!istype(perp.r_store, /obj/item/weapon/gun/energy/laser/bluetag) \
-				&& !istype(perp.r_store, /obj/item/weapon/gun/energy/laser/redtag) \
-				&& !istype(perp.r_store, /obj/item/weapon/gun/energy/laser/practice))
-					threatcount += 2
+				if(istype(perp.r_store, /obj/item/weapon/gun) || istype(perp.r_store, /obj/item/weapon/melee))
+					if(!(perp.r_store.type in safe_weapons))
+						threatcount += 2
 
 
 
-			if (perp.back && istype(perp.back, /obj/item/weapon/storage/backpack))
-				//
-				var/obj/item/weapon/storage/backpack/B = perp.back
-							//
-				for(var/things in B.contents)
-					//
-					if(istype(things, /obj/item/weapon/gun) || istype(things, /obj/item/weapon/melee))
-						if(!istype(things, /obj/item/weapon/gun/energy/laser/bluetag) \
-						&& !istype(things, /obj/item/weapon/gun/energy/laser/redtag) \
-						&& !istype(things, /obj/item/weapon/gun/energy/laser/practice))
-							threatcount += 2
+				if (perp.back && istype(perp.back, /obj/item/weapon/storage/backpack))
+					var/obj/item/weapon/storage/backpack/B = perp.back
+					for(var/obj/item/weapon/thing in B.contents)
+						if(istype(thing, /obj/item/weapon/gun) || istype(thing, /obj/item/weapon/melee))
+							if(!(thing.type in safe_weapons))
+								threatcount += 2
 
 		if(idmode)
-			//
 			if(!perp.wear_id)
 				threatcount += 4
 
 		else
-
 			if(!perp.wear_id)
 				threatcount += 2
 
@@ -108,8 +99,8 @@
 			threatcount += 2
 
 		//Agent cards lower threatlevel.
-		//if(perp.wear_id && istype(perp:wear_id.GetID(), /obj/item/weapon/card/id/syndicate)) ///////////////nah, i dont think so
-		//	threatcount -= 2
+		if(perp.wear_id && istype(perp.wear_id.GetID(), /obj/item/weapon/card/id/syndicate))
+			threatcount -= 2
 
 	var/passperpname = ""
 	for (var/datum/data/record/E in data_core.general)
@@ -242,7 +233,7 @@
 
 			src.last_read = world.time
 			use_power(1000)
-			src.visible_message("<span class = 'warning'>Theat Detected! Subject: [dudesname]</span>")////
+			src.visible_message("<span class = 'warning'>Threat Detected! Subject: [dudesname]</span>")////
 
 
 		else if(dudesthreat <= 3 && dudesthreat != 0 && senset)

--- a/html/changelogs/Intigracybeepskyshit.yml
+++ b/html/changelogs/Intigracybeepskyshit.yml
@@ -1,0 +1,8 @@
+author: Intigracy
+delete-after: True
+changes: 
+- tweak: "ED-209s, beepsky/security bots, and V.A.L.I.D.S. no longer consider you a threat for holding floral somatories, hookshots, or defibs."
+- bugfix: "Secbot options now properly work. Before, you had to have ID checking on for it to check for anything, and it would always check for weapons with ID checking on."
+- bugfix: "Weapon Permits (the access available from the HoP) now properly function. The abovenamed will no longer consider you a threat for having weapons if you have the access."
+- tweak: "Note: Agent Cards lower your threat level by 2 for bots/VALIDs. It takes a minimum of 4 for them to arrest/flash you."
+- tweak: "Note: Bartenders have always started with a weapons permit."


### PR DESCRIPTION
Changes secbots (beepsky), ED-209's, and metal detectors (V.A.L.I.D.S.)

fixes #8419
fixes #8426
fixes #8774
fixes #8363

Things that I remember I changed or standardized:

Added floral somatories, defibs, and hookshots to the safe weapons list.

Standardized: Agent cards will lower your threat by 2 when being assessed. This was in on 2/3, I re-enabled it on metal detectors.
Standardized: If you have access to change settings on the bots, they won't bother checking if you have a weapons permit / won't threat assess you. You WILL still be arrested if set to arrest.

idcheck and weaponscheck settings now function correctly on bots. As it is currently, you have to have ID checking enabled to check everything, and weaponscheck doesn't work at all.

Fixed weapon permits not even doing anything via adding a proc to access.dm. The bartender starts with one, this isn't a change I made.

Removed a SHIT TON of colons. 
Removed a SHIT TON of copypasted code, but there's still more.

Todo at some other point in time: make this shit into one proc instead of 3 copypasted ones, use the proc sitting at the bottom of the code files.

As an added bonus, I even tested my code.
