### PR TITLE
Gotta Go Fast

### DIFF
--- a/code/modules/mob/delays.dm
+++ b/code/modules/mob/delays.dm
@@ -5,7 +5,7 @@
 // Reduces duplicated code by quite a bit.
 /datum/delay_controller
 	// Delay clamps (for adminbus, effects)
-	var/min_delay = 1
+	var/min_delay = 0.001
 	var/max_delay = ARBITRARILY_LARGE_NUMBER //See setup.dm, 12
 
 	var/next_allowed = 0
@@ -34,7 +34,7 @@
 // Constructor args are currently all the same, but placed here for ease of tuning.
 /client // Yep, clients are snowflakes.
 	// Walking speed is 7, as is grab speed.
-	var/datum/delay_controller/move_delayer    = new (1,ARBITRARILY_LARGE_NUMBER) // /mob/delayNextMove()
+	var/datum/delay_controller/move_delayer    = new (0.001,ARBITRARILY_LARGE_NUMBER) // /mob/delayNextMove()
 /mob
 	var/datum/delay_controller/click_delayer   = new (1,ARBITRARILY_LARGE_NUMBER) // (Handled in Click())
 	var/datum/delay_controller/attack_delayer  = new (1,ARBITRARILY_LARGE_NUMBER) // delayNextAttack() See setup.dm, 12

--- a/code/modules/mob/delays.dm
+++ b/code/modules/mob/delays.dm
@@ -5,7 +5,7 @@
 // Reduces duplicated code by quite a bit.
 /datum/delay_controller
 	// Delay clamps (for adminbus, effects)
-	var/min_delay = 0.001
+	var/min_delay = 0.3
 	var/max_delay = ARBITRARILY_LARGE_NUMBER //See setup.dm, 12
 
 	var/next_allowed = 0
@@ -34,7 +34,7 @@
 // Constructor args are currently all the same, but placed here for ease of tuning.
 /client // Yep, clients are snowflakes.
 	// Walking speed is 7, as is grab speed.
-	var/datum/delay_controller/move_delayer    = new (0.001,ARBITRARILY_LARGE_NUMBER) // /mob/delayNextMove()
+	var/datum/delay_controller/move_delayer    = new (0.3,ARBITRARILY_LARGE_NUMBER) // /mob/delayNextMove()
 /mob
 	var/datum/delay_controller/click_delayer   = new (1,ARBITRARILY_LARGE_NUMBER) // (Handled in Click())
 	var/datum/delay_controller/attack_delayer  = new (1,ARBITRARILY_LARGE_NUMBER) // delayNextAttack() See setup.dm, 12

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -193,6 +193,8 @@
 	var/move_on_shuttle = 1 // Can move on the shuttle.
 	var/captured = 0 //Functionally, should give the same effect as being buckled into a chair when true.
 
+	var/movement_speed_modifier = 0
+
 //Generic list for proc holders. Only way I can see to enable certain verbs/procs. Should be modified if needed.
 	var/proc_holder_list[] = list()//Right now unused.
 	//Also unlike the spell list, this would only store the object in contents, not an object in itself.

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -302,6 +302,8 @@
 
 		//We are now going to move
 		move_delay = max(move_delay,1)
+		if(mob.movement_speed_modifier)
+			move_delay *= (1/mob.movement_speed_modifier)
 		mob.delayNextMove(move_delay)
 		//Something with pulling things
 		if(Findgrab)


### PR DESCRIPTION
Adds a movement_speed_modifier var to mobs, which affects their overall move speed.
http://puu.sh/nEFwf/a62031d4ee.webm

The var is now a proper multiplier instead of an additive like it is in the WebM, but the basic functionality is the same.
The point at which speed increases become negligible seems to be roughly 5x for well-fed humans.

This works for all mobs.
