### PR TITLE
Adds an optional SHUT_UP_AUTOMATIC_DIAGNOSTIC_AND_ANNOUNCEMENT_SYSTEM config.

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -169,6 +169,7 @@
 
 	var/skip_minimap_generation = 0 //If 1, don't generate minimaps
 	var/skip_vault_generation = 0 //If 1, don't generate vaults
+	var/shut_up_automatic_diagnostic_and_announcement_system = 0 //If 1, don't play the vox sounds at the start of every shift.
 
 /datum/configuration/New()
 	. = ..()
@@ -531,6 +532,8 @@
 					skip_minimap_generation = 1
 				if("skip_vault_generation")
 					skip_vault_generation = 1
+				if("shut_up_automatic_diagnostic_and_announcement_system")
+					shut_up_automatic_diagnostic_and_announcement_system = 1
 				else
 					diary << "Unknown setting in configuration: '[name]'"
 

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -190,19 +190,20 @@ var/global/datum/controller/gameticker/ticker
 		to_chat(world, "<FONT color='blue'><B>Enjoy the game!</B></FONT>")
 //		to_chat(world, sound('sound/AI/welcome.ogg'))// Skie //Out with the old, in with the new. - N3X15
 
-		var/welcome_sentence=list('sound/AI/vox_login.ogg')
-		welcome_sentence += pick(
-			'sound/AI/vox_reminder1.ogg',
-			'sound/AI/vox_reminder2.ogg',
-			'sound/AI/vox_reminder3.ogg',
-			'sound/AI/vox_reminder4.ogg',
-			'sound/AI/vox_reminder5.ogg',
-			'sound/AI/vox_reminder6.ogg',
-			'sound/AI/vox_reminder7.ogg',
-			'sound/AI/vox_reminder8.ogg',
-			'sound/AI/vox_reminder9.ogg')
-		for(var/sound in welcome_sentence)
-			play_vox_sound(sound,STATION_Z,null)
+		if(!config.shut_up_automatic_diagnostic_and_announcement_system)
+			var/welcome_sentence=list('sound/AI/vox_login.ogg')
+			welcome_sentence += pick(
+				'sound/AI/vox_reminder1.ogg',
+				'sound/AI/vox_reminder2.ogg',
+				'sound/AI/vox_reminder3.ogg',
+				'sound/AI/vox_reminder4.ogg',
+				'sound/AI/vox_reminder5.ogg',
+				'sound/AI/vox_reminder6.ogg',
+				'sound/AI/vox_reminder7.ogg',
+				'sound/AI/vox_reminder8.ogg',
+				'sound/AI/vox_reminder9.ogg')
+			for(var/sound in welcome_sentence)
+				play_vox_sound(sound,STATION_Z,null)
 		//Holiday Round-start stuff	~Carn
 		Holiday_Game_Start()
 		mode.Clean_Antags()

--- a/config-example/config.txt
+++ b/config-example/config.txt
@@ -280,3 +280,8 @@ RENDERS_URL http://ss13.pomf.se/img/map-renders
 ## SKIP_MINIMAP_GENERATION
 ## Uncomment to disable generation of minimaps (makes the server start faster!)
 SKIP_MINIMAP_GENERATION
+
+## SHUT_UP_AUTOMATIC_DIAGNOSTIC_AND_ANNOUNCEMENT_SYSTEM
+## Uncomment to disable the lovely robotic voice that tells you the time at the start of every shift.
+## Recommended for your sanity if you start the server a lot for testing things.
+#SHUT_UP_AUTOMATIC_DIAGNOSTIC_AND_ANNOUNCEMENT_SYSTEM


### PR DESCRIPTION
It shuts up the automatic diagnostic and announcement system.
I start up the serbian a lot while coding so I need this for my sanity.
