### PR TITLE
Slime Core Reaction Expansion

### DIFF
--- a/code/game/objects/items/weapons/power_cells.dm
+++ b/code/game/objects/items/weapons/power_cells.dm
@@ -117,7 +117,7 @@
 	origin_tech = "powerstorage=2;biotech=4"
 	icon = 'icons/mob/slimes.dmi' //'icons/obj/harvest.dmi'
 	icon_state = "yellow slime extract" //"potato_battery"
-	maxcharge = 10000
+	maxcharge = 30000
 	starting_materials =  null
 	w_type = RECYK_BIOLOGICAL
 

--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -746,7 +746,6 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 			Uses = 3
 			enhanced = 1
 			qdel(O)
-			O = null
 
 		//slime res
 		if(istype(O, /obj/item/weapon/slimeres))
@@ -758,7 +757,6 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 			S.loc = get_turf(src)
 			Uses--
 			qdel(O)
-			O = null
 
 /obj/item/slime_extract/New()
 		..()
@@ -974,14 +972,14 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 
 
 /obj/item/weapon/slimenutrient
-	name = "Slime Nutrient"
+	name = "slime nutrient"
 	desc = "A potent chemical mix that is a great nutrient for slimes."
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "bottle12"
 	var/Uses = 2
 
 /obj/item/weapon/slimenutrient/attack(mob/living/carbon/slime/M as mob, mob/user as mob)
-	if(!istype(M, /mob/living/carbon/slime))//If target is not a slime.
+	if(!istype(M))//If target is not a slime.
 		to_chat(user, "<span class='warning'>The steroid only works on slimes!</span>")
 		return ..()
 	if(M.stat)
@@ -1043,7 +1041,7 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
         qdel(src)
 
 /obj/item/weapon/slimeres
-    name = "Slime Resurrection Serum"
+    name = "slime resurrection serum"
     desc = "A potent chemical mix that when used on a slime extact, will bring it to life!"
     icon = 'icons/obj/chemical.dmi'
     icon_state = "bottle14"

--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -753,8 +753,7 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 				to_chat(user, "<span class='warning'>The solution doesn't work on used extracts!</span>")
 				return ..()
 			to_chat(user, "You splash the Slime Resurrection Serum onto the extract causing it to quiver and come to life.")
-			var/mob/living/carbon/slime/S = new primarytype
-			S.loc = get_turf(src)
+			new primarytype(get_turf(src))
 			Uses--
 			qdel(O)
 
@@ -1017,34 +1016,34 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 			del (src)*/
 
 /obj/item/weapon/slimedupe
-    name = "slime duplicator"
-    desc = "A potent chemical mix that will force a child slime to split in two!"
-    icon = 'icons/obj/chemical.dmi'
-    icon_state = "bottle15"
+	name = "slime duplicator"
+	desc = "temp desc i'm not good at things"
+	icon = 'icons/obj/chemical.dmi'
+	icon_state = "bottle15"
 
-    attack(mob/living/carbon/slime/M as mob, mob/user as mob)
-        if(!istype(M, /mob/living/carbon/slime))//target is not a slime
-            to_chat(user, "<span class='warning'>The solution only works on slimes!</span>")
-            return ..()
-        if(istype(M, /mob/living/carbon/slime/adult))
-            to_chat(user, "<span class='warning'>Only baby slimes can be duplicated!</span>")
-            return ..()
-        if(M.stat)
-            to_chat(user, "<span class='warning'>That slime is dead!</span>")
-            return ..()
+/obj/item/weapon/slimedupe/attack(mob/living/carbon/slime/M as mob, mob/user as mob)
+	if(!istype(M, /mob/living/carbon/slime))//target is not a slime
+		to_chat(user, "<span class='warning'>The solution only works on slimes!</span>")
+		return ..()
+	if(istype(M, /mob/living/carbon/slime/adult))//don't allow adults because i'm lazy i don't wanna
+		to_chat(user, "<span class='warning'>Only baby slimes can be duplicated!</span>")
+		return ..()
+	if(M.stat)//dunno if this should be allowed but i think it's probably better this way
+		to_chat(user, "<span class='warning'>That slime is dead!</span>")
+		return ..()
 
-        to_chat(user, "You splash the cloning juice onto the slime.")
+	to_chat(user, "You splash the cloning juice onto the slime.")
 
-        var/mob/living/carbon/slime/S = new M.primarytype
-        S.tame = M.tame
-        S.loc = get_turf(M)
-        qdel(src)
+	var/mob/living/carbon/slime/S = new M.primarytype // don't let's start
+	S.tame = M.tame
+	S.loc = get_turf(M)
+	qdel(src)
 
 /obj/item/weapon/slimeres
-    name = "slime resurrection serum"
-    desc = "A potent chemical mix that when used on a slime extact, will bring it to life!"
-    icon = 'icons/obj/chemical.dmi'
-    icon_state = "bottle14"
+	name = "slime resurrection serum"
+	desc = "A potent chemical mix that when used on a slime extact, will bring it to life!"
+	icon = 'icons/obj/chemical.dmi'
+	icon_state = "bottle14"
 
 ////////Adamantine Golem stuff I dunno where else to put it
 

--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -732,6 +732,7 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 	origin_tech = "biotech=4"
 	var/Uses = 1 // uses before it goes inert
 	var/enhanced = 0 //has it been enhanced before?
+	var/primarytype = /mob/living/carbon/slime
 
 	attackby(obj/item/O as obj, mob/user as mob)
 		if(istype(O, /obj/item/weapon/slimesteroid2))
@@ -744,7 +745,19 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 			to_chat(user, "You apply the enhancer. It now has triple the amount of uses.")
 			Uses = 3
 			enhanced = 1
-			qdel (O)
+			qdel(O)
+			O = null
+
+		//slime res
+		if(istype(O, /obj/item/weapon/slimeres))
+			if(Uses == 0)
+				to_chat(user, "<span class='warning'>The solution doesn't work on used extracts!</span>")
+				return ..()
+			to_chat(user, "You splash the Slime Resurrection Serum onto the extract causing it to quiver and come to life.")
+			var/mob/living/carbon/slime/S = new primarytype
+			S.loc = get_turf(src)
+			Uses--
+			qdel(O)
 			O = null
 
 /obj/item/slime_extract/New()
@@ -756,86 +769,107 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 /obj/item/slime_extract/grey
 	name = "grey slime extract"
 	icon_state = "grey slime extract"
+	primarytype = /mob/living/carbon/slime/gold
 
 /obj/item/slime_extract/gold
 	name = "gold slime extract"
 	icon_state = "gold slime extract"
+	primarytype = /mob/living/carbon/slime/gold
 
 /obj/item/slime_extract/silver
 	name = "silver slime extract"
 	icon_state = "silver slime extract"
+	primarytype = /mob/living/carbon/slime/silver
 
 /obj/item/slime_extract/metal
 	name = "metal slime extract"
 	icon_state = "metal slime extract"
+	primarytype = /mob/living/carbon/slime/metal
 
 /obj/item/slime_extract/purple
 	name = "purple slime extract"
 	icon_state = "purple slime extract"
+	primarytype = /mob/living/carbon/slime/purple
 
 /obj/item/slime_extract/darkpurple
 	name = "dark purple slime extract"
 	icon_state = "dark purple slime extract"
+	primarytype = /mob/living/carbon/slime/darkpurple
 
 /obj/item/slime_extract/orange
 	name = "orange slime extract"
 	icon_state = "orange slime extract"
+	primarytype = /mob/living/carbon/slime/orange
 
 /obj/item/slime_extract/yellow
 	name = "yellow slime extract"
 	icon_state = "yellow slime extract"
+	primarytype = /mob/living/carbon/slime/yellow
 
 /obj/item/slime_extract/red
 	name = "red slime extract"
 	icon_state = "red slime extract"
+	primarytype = /mob/living/carbon/slime/red
 
 /obj/item/slime_extract/blue
 	name = "blue slime extract"
 	icon_state = "blue slime extract"
+	primarytype = /mob/living/carbon/slime/blue
 
 /obj/item/slime_extract/darkblue
 	name = "dark blue slime extract"
 	icon_state = "dark blue slime extract"
+	primarytype = /mob/living/carbon/slime/darkblue
 
 /obj/item/slime_extract/pink
 	name = "pink slime extract"
 	icon_state = "pink slime extract"
+	primarytype = /mob/living/carbon/slime/pink
 
 /obj/item/slime_extract/green
 	name = "green slime extract"
 	icon_state = "green slime extract"
+	primarytype = /mob/living/carbon/slime/green
 
 /obj/item/slime_extract/lightpink
 	name = "light pink slime extract"
 	icon_state = "light pink slime extract"
+	primarytype = /mob/living/carbon/slime/lightpink
 
 /obj/item/slime_extract/black
 	name = "black slime extract"
 	icon_state = "black slime extract"
+	primarytype = /mob/living/carbon/slime/black
 
 /obj/item/slime_extract/oil
 	name = "oil slime extract"
 	icon_state = "oil slime extract"
+	primarytype = /mob/living/carbon/slime/oil
 
 /obj/item/slime_extract/adamantine
 	name = "adamantine slime extract"
 	icon_state = "adamantine slime extract"
+	primarytype = /mob/living/carbon/slime/adamantine
 
 /obj/item/slime_extract/bluespace
 	name = "bluespace slime extract"
 	icon_state = "bluespace slime extract"
+	primarytype = /mob/living/carbon/slime/bluespace
 
 /obj/item/slime_extract/pyrite
 	name = "pyrite slime extract"
 	icon_state = "pyrite slime extract"
+	primarytype = /mob/living/carbon/slime/pyrite
 
 /obj/item/slime_extract/cerulean
 	name = "cerulean slime extract"
 	icon_state = "cerulean slime extract"
+	primarytype = /mob/living/carbon/slime/cerulean
 
 /obj/item/slime_extract/sepia
 	name = "sepia slime extract"
 	icon_state = "sepia slime extract"
+	primarytype = /mob/living/carbon/slime/sepia
 
 
 ////Pet Slime Creation///
@@ -938,6 +972,33 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 		M.cores = 3
 		qdel (src)
 
+
+/obj/item/weapon/slimenutrient
+	name = "Slime Nutrient"
+	desc = "A potent chemical mix that is a great nutrient for slimes."
+	icon = 'icons/obj/chemical.dmi'
+	icon_state = "bottle12"
+	var/Uses = 2
+
+/obj/item/weapon/slimenutrient/attack(mob/living/carbon/slime/M as mob, mob/user as mob)
+	if(!istype(M, /mob/living/carbon/slime))//If target is not a slime.
+		to_chat(user, "<span class='warning'>The steroid only works on slimes!</span>")
+		return ..()
+	if(M.stat)
+		to_chat(user, "<span class='warning'>The slime is dead!</span>")
+		return..()
+	if(M.amount_grown == 10)
+		to_chat(user, "<span class='warning'>The slime has already fed enough!</span>")
+		return..()
+
+	to_chat(user, "You feed the slime the nutrient. It now appears ready to grow.")
+	M.amount_grown = 10
+
+	if (Uses > 0)
+		Uses -= 1
+	if (Uses == 0)
+		qdel (src)
+
 /obj/item/weapon/slimesteroid2
 	name = "extract enhancer"
 	desc = "A potent chemical mix that will give a slime extract three uses."
@@ -956,6 +1017,36 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 			target.Uses = 3
 			target.enahnced = 1
 			del (src)*/
+
+/obj/item/weapon/slimedupe
+    name = "slime duplicator"
+    desc = "A potent chemical mix that will force a child slime to split in two!"
+    icon = 'icons/obj/chemical.dmi'
+    icon_state = "bottle15"
+
+    attack(mob/living/carbon/slime/M as mob, mob/user as mob)
+        if(!istype(M, /mob/living/carbon/slime))//target is not a slime
+            to_chat(user, "<span class='warning'>The solution only works on slimes!</span>")
+            return ..()
+        if(istype(M, /mob/living/carbon/slime/adult))
+            to_chat(user, "<span class='warning'>Only baby slimes can be duplicated!</span>")
+            return ..()
+        if(M.stat)
+            to_chat(user, "<span class='warning'>That slime is dead!</span>")
+            return ..()
+
+        to_chat(user, "You splash the cloning juice onto the slime.")
+
+        var/mob/living/carbon/slime/S = new M.primarytype
+        S.tame = M.tame
+        S.loc = get_turf(M)
+        qdel(src)
+
+/obj/item/weapon/slimeres
+    name = "Slime Resurrection Serum"
+    desc = "A potent chemical mix that when used on a slime extact, will bring it to life!"
+    icon = 'icons/obj/chemical.dmi'
+    icon_state = "bottle14"
 
 ////////Adamantine Golem stuff I dunno where else to put it
 

--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -1017,7 +1017,7 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 
 /obj/item/weapon/slimedupe
 	name = "slime duplicator"
-	desc = "temp desc i'm not good at things"
+	desc = "A potent chemical mix that will force a child slime to split in two!"
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "bottle15"
 

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -1569,22 +1569,15 @@ datum
 			required_container = /obj/item/slime_extract/silver
 			required_other = 1
 			on_reaction(var/datum/reagents/holder)
-				var/obj/item/stack/sheet/S1 = pick(new /obj/item/stack/sheet/plasteel,
-												new /obj/item/stack/sheet/metal,
-												new /obj/item/stack/sheet/mineral/plasma,
-												new /obj/item/stack/sheet/mineral/silver,
-												new /obj/item/stack/sheet/mineral/gold,
-												new /obj/item/stack/sheet/mineral/uranium)
-				S1.amount = 5
-				var/obj/item/stack/sheet/S2 = pick(new /obj/item/stack/sheet/plasteel,
-												new /obj/item/stack/sheet/metal,
-												new /obj/item/stack/sheet/mineral/plasma,
-												new /obj/item/stack/sheet/mineral/silver,
-												new /obj/item/stack/sheet/mineral/gold,
-												new /obj/item/stack/sheet/mineral/uranium)
-				S2.amount = 5
-				S1.loc = get_turf(holder.my_atom)
-				S2.loc = get_turf(holder.my_atom)
+				var/list/paths = list(/obj/item/stack/sheet/plasteel,
+						/obj/item/stack/sheet/metal,
+						/obj/item/stack/sheet/mineral/plasma,
+						/obj/item/stack/sheet/mineral/silver,
+						/obj/item/stack/sheet/mineral/gold,
+						/obj/item/stack/sheet/mineral/uranium)
+				getFromPool(pick(paths), get_turf(holder.my_atom), 5)
+				getFromPool(pick(paths), get_turf(holder.my_atom), 5)
+
 
 //Blue
 		slimefrost

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -1775,6 +1775,18 @@ datum
 				if (istype(holder.my_atom.loc,/obj/item/weapon/grenade/chem_grenade))
 					send_admin_alert(holder, reaction_name="red slime + plasma (Glycerol) in a grenade")
 
+		slimeres
+			name = "Slime Res"
+			id = "m_nutrient"
+			result = null
+			required_reagents = list("blood" = 5)
+			result_amount = 1
+			required_container = /obj/item/slime_extract/red
+			required_other = 1
+			on_reaction(var/datum/reagents/holder)
+				feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+				var/obj/item/weapon/slimeres/P = new /obj/item/weapon/slimeres
+				P.loc = get_turf(holder.my_atom)
 
 		slimebloodlust
 			name = "Bloodlust"

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -1772,7 +1772,7 @@ datum
 			name = "Slime Res"
 			id = "m_nutrient"
 			result = null
-			required_reagents = list("blood" = 5)
+			required_reagents = list("sugar" = 5)
 			result_amount = 1
 			required_container = /obj/item/slime_extract/red
 			required_other = 1

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -1895,9 +1895,9 @@ datum
 				for(var/mob/living/carbon/slime/S in viewers(get_turf(holder.my_atom), null)) // kills slimes
 					S.death(0)
 				for(var/mob/living/simple_animal/slime/S in viewers(get_turf(holder.my_atom), null)) // kills pet slimes too
-					S.health = 0
+					S.death(0)
 				for(var/mob/living/simple_animal/adultslime/S in viewers(get_turf(holder.my_atom), null)) // no survivors
-					S.health = 0
+					S.death(0)
 
 //Light Pink
 		slimepotion2

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -1143,6 +1143,81 @@ datum
 			required_other = 1
 			required_container = /obj/item/slime_extract/green
 
+		slimeperidaxon
+			name = "Slime Peridaxon"
+			id = "m_peridaxon"
+			result = null
+			required_reagents = list("water" = 5)
+			result_amount = 1
+			required_container = /obj/item/slime_extract/green
+			required_other = 1
+			on_reaction(var/datum/reagents/holder)
+				feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+				var/obj/item/weapon/reagent_containers/glass/bottle/B = new /obj/item/weapon/reagent_containers/glass/bottle
+				B.name = "peridaxon bottle"
+				B.reagents.add_reagent("peridaxon",5)
+				B.loc = get_turf(holder.my_atom)
+
+		slimedexplus
+			name = "Slime Dexalin Plus"
+			id = "m_dexplus"
+			result = null
+			required_reagents = list("oxygen" = 5)
+			result_amount = 1
+			required_container = /obj/item/slime_extract/green
+			required_other = 1
+			on_reaction(var/datum/reagents/holder)
+				feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+				var/obj/item/weapon/reagent_containers/glass/bottle/B = new /obj/item/weapon/reagent_containers/glass/bottle
+				B.name = "Dexalin Plus Bottle"
+				B.reagents.add_reagent("dexalinp",5)
+				B.loc = get_turf(holder.my_atom)
+
+		slimesdelight
+			name = "Slime Doctor's Delight"
+			id = "m_doctordelight"
+			result = null
+			required_reagents = list("sugar" = 5)
+			result_amount = 1
+			required_container = /obj/item/slime_extract/green
+			required_other = 1
+			on_reaction(var/datum/reagents/holder)
+				feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+				var/obj/item/weapon/reagent_containers/glass/bottle/B = new /obj/item/weapon/reagent_containers/glass/bottle
+				B.name = "Doctor's Delight bottle"
+				B.reagents.add_reagent("doctorsdelight",10)
+				B.loc = get_turf(holder.my_atom)
+
+		slimebicard
+			name = "Slime Bicaridine"
+			id = "m_bicaridine"
+			result = null
+			required_reagents = list("carbon" = 5)
+			result_amount = 1
+			required_container = /obj/item/slime_extract/green
+			required_other = 1
+			on_reaction(var/datum/reagents/holder)
+				feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+				var/obj/item/weapon/reagent_containers/glass/bottle/B = new /obj/item/weapon/reagent_containers/glass/bottle
+				B.name = "bicaridine bottle"
+				B.reagents.add_reagent("bicaridine",10)
+				B.loc = get_turf(holder.my_atom)
+
+		slimedermaline
+			name = "Slime Dermaline"
+			id = "m_dermaline"
+			result = null
+			required_reagents = list("phosphorus" = 5)
+			result_amount = 1
+			required_container = /obj/item/slime_extract/green
+			required_other = 1
+			on_reaction(var/datum/reagents/holder)
+				feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+				var/obj/item/weapon/reagent_containers/glass/bottle/B = new /obj/item/weapon/reagent_containers/glass/bottle
+				B.name = "Dermaline bottle"
+				B.reagents.add_reagent("dermaline",5)
+				B.loc = get_turf(holder.my_atom)
+
 //Metal
 		slimemetal
 			name = "Slime Metal"
@@ -1158,6 +1233,59 @@ datum
 				var/obj/item/stack/sheet/plasteel/P = new /obj/item/stack/sheet/plasteel
 				P.amount = 5
 				P.loc = get_turf(holder.my_atom)
+
+		slimegold
+			name = "Slime Gold"
+			id = "m_gold"
+			result = null
+			required_reagents = list("copper" = 5)
+			result_amount = 1
+			required_container = /obj/item/slime_extract/metal
+			required_other = 1
+			on_reaction(var/datum/reagents/holder)
+				var/obj/item/stack/sheet/mineral/gold/G = new /obj/item/stack/sheet/mineral/gold
+				G.amount = 5
+				G.loc = get_turf(holder.my_atom)
+
+		slimesilver
+			name = "Slime Silver"
+			id = "m_silver"
+			result = null
+			required_reagents = list("tungsten" = 5)
+			result_amount = 1
+			required_container = /obj/item/slime_extract/metal
+			required_other = 1
+			on_reaction(var/datum/reagents/holder)
+				var/obj/item/stack/sheet/mineral/silver/S = new /obj/item/stack/sheet/mineral/silver
+				S.amount = 5
+				S.loc = get_turf(holder.my_atom)
+
+		slimeuranium
+			name = "Slime Uranium"
+			id = "m_uranium"
+			result = null
+			required_reagents = list("radium" = 5)
+			result_amount = 1
+			required_container = /obj/item/slime_extract/metal
+			required_other = 1
+			on_reaction(var/datum/reagents/holder)
+				var/obj/item/stack/sheet/mineral/uranium/U = new /obj/item/stack/sheet/mineral/uranium
+				U.amount = 5
+				U.loc = get_turf(holder.my_atom)
+
+		slimediamond
+			name = "Slime diamond"
+			id = "m_diamond"
+			result = null
+			required_reagents = list("carbon" = 5)
+			result_amount = 1
+			required_container = /obj/item/slime_extract/metal
+			required_other = 1
+			on_reaction(var/datum/reagents/holder)
+				var/obj/item/stack/sheet/mineral/diamond/K = new /obj/item/stack/sheet/mineral/diamond
+				K.amount = 2
+				K.loc = get_turf(holder.my_atom)
+
 
 //Gold
 		slimecrit
@@ -1432,6 +1560,31 @@ datum
 							for(var/j = 1, j <= rand(1, 3), j++)
 								step(B, pick(NORTH,SOUTH,EAST,WEST))
 
+		slimematerials
+			name = "Slime Materials"
+			id = "m_mats"
+			result = null
+			required_reagents = list("carbon" = 5)
+			result_amount = 1
+			required_container = /obj/item/slime_extract/silver
+			required_other = 1
+			on_reaction(var/datum/reagents/holder)
+				var/obj/item/stack/sheet/S1 = pick(new /obj/item/stack/sheet/plasteel,
+												new /obj/item/stack/sheet/metal,
+												new /obj/item/stack/sheet/mineral/plasma,
+												new /obj/item/stack/sheet/mineral/silver,
+												new /obj/item/stack/sheet/mineral/gold,
+												new /obj/item/stack/sheet/mineral/uranium)
+				S1.amount = 5
+				var/obj/item/stack/sheet/S2 = pick(new /obj/item/stack/sheet/plasteel,
+												new /obj/item/stack/sheet/metal,
+												new /obj/item/stack/sheet/mineral/plasma,
+												new /obj/item/stack/sheet/mineral/silver,
+												new /obj/item/stack/sheet/mineral/gold,
+												new /obj/item/stack/sheet/mineral/uranium)
+				S2.amount = 5
+				S1.loc = get_turf(holder.my_atom)
+				S2.loc = get_turf(holder.my_atom)
 
 //Blue
 		slimefrost
@@ -1467,6 +1620,19 @@ datum
 				for(var/mob/living/M in range (get_turf(holder.my_atom), 7))
 					M.bodytemperature -= 6
 					to_chat(M, "<span class='notice'>You feel a chill!</span>")
+
+		slimenutrient
+			name = "Slime Nutrient"
+			id = "m_nutrient"
+			result = null
+			required_reagents = list("blood" = 5)
+			result_amount = 1
+			required_container = /obj/item/slime_extract/darkblue
+			required_other = 1
+			on_reaction(var/datum/reagents/holder)
+				feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+				var/obj/item/weapon/slimenutrient/P = new /obj/item/weapon/slimenutrient
+				P.loc = get_turf(holder.my_atom)
 
 //Orange
 		slimecasp
@@ -1551,6 +1717,7 @@ datum
 				var/obj/item/device/flashlight/lamp/slime/P = new /obj/item/device/flashlight/lamp/slime
 				P.loc = get_turf(holder.my_atom)
 
+
 //Purple
 
 		slimepsteroid
@@ -1578,7 +1745,6 @@ datum
 				feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
 				if (istype(holder.my_atom.loc,/obj/item/weapon/grenade/chem_grenade))
 					send_admin_alert(holder, reaction_name="purple slime + sugar (Slime Jelly) in a grenade")
-
 
 //Dark Purple
 		slimeplasma
@@ -1663,6 +1829,31 @@ datum
 				if (istype(holder.my_atom.loc,/obj/item/weapon/grenade/chem_grenade))
 					send_admin_alert(holder, reaction_name="black slime + plasma (Mutates to Slime) in a grenade")
 
+		slimemednanobots
+			name = "Slime Medical Nanobots"
+			id = "m_mednanobots"
+			result = "mednanobots"
+			required_reagents = list("gold" = 5)
+			result_amount = 1
+			required_other = 1
+			required_container = /obj/item/slime_extract/black
+			on_reaction(var/datum/reagents/holder)
+				feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+				send_admin_alert(holder, reaction_name="black slime + gold (Medical Nanobots) in a grenade")
+
+
+		slimecomnanobots
+			name  = "Slime Combat Nanobots"
+			id = "m_comnanobots"
+			result = "comnanobots"
+			required_reagents = list("uranium" = 5)
+			result_amount = 1
+			required_other = 1
+			required_container = /obj/item/slime_extract/black
+			on_reaction(var/datum/reagents/holder)
+				feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+				send_admin_alert(holder, reaction_name="black slime + uranium (Combat Nanobots) in a grenade")
+
 //Oil
 		slimeexplosion
 			name = "Slime Explosion"
@@ -1681,6 +1872,28 @@ datum
 				else
 					send_admin_alert(holder, reaction_name="oil slime + plasma (Explosion) in a grenade")
 				explosion(get_turf(holder.my_atom), 1 ,3, 6)
+
+		slimegenocide
+			name = "Slime Genocide" //oy vey
+			id = "m_genocide"
+			result = null
+			required_reagents = list("blood" = 5)
+			result_amount = 1
+			required_container = /obj/item/slime_extract/oil
+			required_other = 1
+			on_reaction(var/datum/reagents/holder)
+				feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+				if (!istype(holder.my_atom.loc,/obj/item/weapon/grenade/chem_grenade))
+					send_admin_alert(holder, reaction_name="oil slime + blood (Slime Genocide)")
+				else
+					send_admin_alert(holder, reaction_name="oil slime + blood (Slime Genocide) in a grenade")
+				for(var/mob/living/carbon/slime/S in viewers(get_turf(holder.my_atom), null)) // kills slimes
+					S.death(0)
+				for(var/mob/living/simple_animal/slime/S in viewers(get_turf(holder.my_atom), null)) // kills pet slimes too
+					S.health = 0
+				for(var/mob/living/simple_animal/adultslime/S in viewers(get_turf(holder.my_atom), null)) // no survivors
+					S.health = 0
+
 //Light Pink
 		slimepotion2
 			name = "Slime Potion 2"
@@ -1694,6 +1907,7 @@ datum
 				feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
 				var/obj/item/weapon/slimepotion2/P = new /obj/item/weapon/slimepotion2
 				P.loc = get_turf(holder.my_atom)
+
 //Adamantine
 		slimegolem
 			name = "Slime Golem"
@@ -1708,6 +1922,51 @@ datum
 				var/obj/effect/golem_rune/Z = new /obj/effect/golem_rune
 				Z.loc = get_turf(holder.my_atom)
 				Z.announce_to_ghosts()
+
+
+		slimediamond2
+			name = "Slime Diamond2"
+			id = "m_Diamond2"
+			result = null
+			result_amount = 1
+			required_container = /obj/item/slime_extract/adamantine
+			required_reagents = list("carbon" = 5)
+			required_other = 1
+			on_reaction(var/datum/reagents/holder)
+				feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+				var/obj/item/stack/sheet/mineral/diamond/D = new /obj/item/stack/sheet/mineral/diamond
+				D.amount = 5
+				D.loc = get_turf(holder.my_atom)
+
+
+		slimephazon
+			name = "Slime Phazon"
+			id = "m_Phazon"
+			result = null
+			result_amount = 1
+			required_container = /obj/item/slime_extract/adamantine
+			required_reagents = list("gold" = 5)
+			required_other = 1
+			on_reaction(var/datum/reagents/holder)
+				feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+				var/obj/item/stack/sheet/mineral/phazon/P = new /obj/item/stack/sheet/mineral/phazon
+				P.amount = 5
+				P.loc = get_turf(holder.my_atom)
+
+		slimeclown
+			name = "Slime Clown"
+			id = "m_Clown"
+			result = null
+			required_reagents = list("silver" = 5)
+			result_amount = 1
+			required_container = /obj/item/slime_extract/adamantine
+			required_other = 1
+			on_reaction(var/datum/reagents/holder)
+				feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+				var/obj/item/stack/sheet/mineral/clown/C = new /obj/item/stack/sheet/mineral/clown
+				C.amount = 5
+				C.loc = get_turf(holder.my_atom)
+
 
 
 //Bluespace
@@ -1788,6 +2047,7 @@ datum
 					var/obj/item/bluespace_crystal/BC = new(get_turf(holder.my_atom))
 					BC.visible_message("<span class='notice'>The [BC.name] appears out of thin air!</span>")
 
+
 //Cerulean
 
 		slimepsteroid2
@@ -1801,6 +2061,19 @@ datum
 			on_reaction(var/datum/reagents/holder)
 				feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
 				var/obj/item/weapon/slimesteroid2/P = new /obj/item/weapon/slimesteroid2
+				P.loc = get_turf(holder.my_atom)
+
+		slimedupe
+			name = "Slime Duplicator"
+			id = "m_dupe"
+			result = null
+			required_reagents = list("blood" = 5)
+			result_amount = 1
+			required_container = /obj/item/slime_extract/cerulean
+			required_other = 1
+			on_reaction(var/datum/reagents/holder)
+				feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+				var/obj/item/weapon/slimedupe/P = new /obj/item/weapon/slimedupe
 				P.loc = get_turf(holder.my_atom)
 
 //sepia
@@ -1848,6 +2121,20 @@ datum
 				var/obj/P = new chosen
 				if(P)
 					P.loc = get_turf(holder.my_atom)
+
+		slimecash
+			name = "Slime Cash"
+			id = "m_cash"
+			result = null
+			required_reagents = list("blood" = 5)
+			result_amount = 1
+			required_container = /obj/item/slime_extract/pyrite
+			required_other = 1
+			on_reaction(var/datum/reagents/holder)
+				var/obj/item/weapon/spacecash/c100/C = new /obj/item/weapon/spacecash/c100/
+				C.amount = 1
+				C.loc = get_turf(holder.my_atom)
+
 
 
 //////////////////////////////////////////FOOD MIXTURES////////////////////////////////////

--- a/html/changelogs/DenkouZ-Slime-Core-Reaction-Expansion.yml
+++ b/html/changelogs/DenkouZ-Slime-Core-Reaction-Expansion.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general deleting of nice things)
+#   rscadd (general adding of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: DenkouZ & Kammerjunk
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+changes: 
+- rscadd: New reactions for slime core reactions
+- tweak: Increased charged slime core charges to be the same as hyper cells


### PR DESCRIPTION
This is a slime feature request with the idea of trying to make xenobiology more useful for the station.
There is a mix of recipes in here. 

There is one small buff I have changed in all of this. That is changing Charged Slime Core Cells from 10000 charge to 30000 charge. This make the time spent gathering the core more useful as for before. The 30 or so minutes it might take to mutate a slime core that had the equivalent charge of a High Capacity Power Cell felt mostly useless as by that point the rest of science would be producing Super and Hyper cells. The rest of the changes are all expansions on the slime core reactions.

The intention behind these changes it to make the xenobiologist require more than just plasma to operate and provide for the station, also the ingredients chosen are to make the Xenobiologist leave the lab to acquire them or to collaborate with someone else in the science, chemistry or mining departments.
Although some slimes take longer than others to obtain, some of the earlier mutations have some more functionality. This is to make the xenobiologist make decisions about what slimes he is to keep and what ones to continue breeding.

_**There have been 3 new potions added to the slime reaction table.**_

**Slime Resurrection Serum**: This potion is to be used on unused slime cores to make them into child slimes. They are not loyal to anyone as they are new slimes but this offers a way of storing slimes in the smartfridge and also offers a way to bring back killed slimes if something does occur in the lab.
Also added while making this item was adding a primary type to all of the slime cores so that BYOND can read what kind of slimes they come from. Maybe someone with more imagination than I can come up with interesting ideas using this variable.

**Slime Duplicator**: This is a potion that can be used on a baby slime causing it to split in two giving you 2 child slimes. The intent behind this is to be able to make quick splits from your child mutations if you want an extract quickly but can also serve the purpose of giving you another slime to be able to try and mutate onto the next stage.

**Slime Nutrient**: This potion is a method of quickly growing slimes if you have the resources and the cores for it. It comes with two uses in the bottle. This is to increase the variety in what you can apply it in the lab. You can fully grow and split a baby slime for a chance at a quick mutation. You can grow two baby slimes into adults to save some time and extending from that you can use it to split off 2 adult slimes.

_**Next is all Slime core reactions and expanding on what they do**_. While reading over these I would like to keep in mind that slime cores are produced rather slowly and XenoBiology isn't turning out tens of cores in half an hour. Also that if some of these seem small or insignificant it is because the intent of some of these ideas it to be a crutch for science if other departments need the product or if science finds their stocks lacking.

**Green slime cores** 
Now have the ability to produce more chems.
+water = 5u bottle of Peridoxin
+oxygen = 5u bottle of Dexalin Plus
+sugar = 10u bottle of Doctor's Delight
+carbon = 10u bottle of Bicaridine
+phosphorus = 5u bottle of Dermaline 
These reactions have been set up to be able to drip feed some chems out of XenoBio if someone wants to produce them but the main feature of this is another way for people to acquire Peridoxin. It is a very round about method to get the chemical. But with this option on the table it means that it is available from more than just borers.

**Metal slime cores**
Can now make more materials
+Copper = 5 sheets of Gold
+Tungsten = 5 sheets of Silver
+Radium = 5 sheets of Uranium
+Carbon = 2 sheets of Diamond
The intention behind these reactions is to give RnD a slow feed of materials if they need it. These reactions are enough to get some items produced but not enough to be reliable on still keeping a strong cargo presence in Science. There are some shifts where things don't pan out for miners and they can't find diamond or uranium is scattered and hard to find. This is a way to help support both departments after a time of waiting on slimes to mutate and being processed. 

**Silver slime cores**
Have a new function.
+Carbon =  Creates 2 stacks of 5 sheets of a random material. (The pool for these is : Metal, Plasma, Gold, Uranium)
The idea behind this is just a small upgrade from metal slimes to be able to produce more materials from a single slime core while still keeping in theme of the silver slime's randomized reactions.

**Dark blue slime cores**
Have a reaction to create Slime Nutrient
+blood = One bottle with 2 uses of Slime Nutrient

 **Red slime cores**
Can create the Slime Resurrection Serum now
+blood = One bottle with 1 use of Slime Resurrection Serum

**Black slime cores**
Now hold a new reaction to be able to make NanoMachines from a recent addition.
+Gold = 1u Medical Nanomachines that can be drawn from the used extract
+Uranium = 1u Combat Nanomachines that can be drawn from the used extract.
The intent behind this is to give another method to acquire Nanomachines late into slime mutations. With this said it is a very small amount, that is so that people can not generate nanomachines quickly and suddenly start a cyber horror outbreak.

**Oil slime cores**
Can now use a new function
+blood = The slime genocide. Killing all slimes in view of the tile it is activated from. It will instantly kill regular slimes in their tracks and force adult slimes to split into 2 rabid slimes. 
This is made to have 2 functions in mind. Mass culling or starting a Rabid Slime outbreak. Or killing off an outbreak of slimes from a wild outbreak in the library or if wormholes suck all of the slimes out of containment

**Adamantine slime cores**
Have an advanced version of the metal slime reaction
+carbon = 5 sheets of diamond
+silver = 5 sheets of bananium
+gold = 5 sheets of phazon
These slimes are very late game and these reactions are to inspire more people to head towards these options. With telescience not being able to find the clown roid to get bananium or phazon and space travel becoming much more longer for miners because of the increase in zlevel size this reaction has been made to give an alternative to finding these materials so robotics can have some fun making other big stompy mechs.

**Cerulean slime cores**
Make Slime Duplicator potions now.
+blood = One bottle with 1 use of Slime Duplicator

**Pyrite slime cores**
Have one small added feature
+blood = 100 space cash chip
Seeing how silver slimes act as a service slime with food and drink and pyrite slimes go into more fun things like paint. I figured another way to get cash out of slimes would be fun. 
