### PR TITLE
containment fields no longer shock through windows/border objects

### DIFF
--- a/code/modules/power/singularity/containment_field.dm
+++ b/code/modules/power/singularity/containment_field.dm
@@ -40,12 +40,13 @@
 	return 0
 
 /obj/machinery/containment_field/HasProximity(atom/movable/AM as mob|obj)
-	if(istype(AM,/mob/living/silicon) && prob(40))
-		shock(AM)
-		return 1
-	if(istype(AM,/mob/living/carbon) && prob(50))
-		shock(AM)
-		return 1
+	if(Adjacent(AM)) //checking for windows and shit
+		if(istype(AM,/mob/living/silicon) && prob(40))
+			shock(AM)
+			return 1
+		if(istype(AM,/mob/living/carbon) && prob(50))
+			shock(AM)
+			return 1
 	return 0
 
 

--- a/html/changelogs/Intishocking.yml
+++ b/html/changelogs/Intishocking.yml
@@ -1,0 +1,4 @@
+author: Intigracy
+delete-after: True
+changes: 
+- bugfix: "Containment Fields now won't shock you through windows. For an example of what this means, see http://tinyurl.com/noshockpls"


### PR DESCRIPTION
fixes #6537

![](http://tinyurl.com/noshockpls)
