### PR TITLE
ERT and Deathsquad implants

### DIFF
--- a/code/game/response_team.dm
+++ b/code/game/response_team.dm
@@ -324,6 +324,9 @@ proc/trigger_armed_response_team(var/force = 0)
 		W.access = get_centcom_access("Emergency Responders Leader")
 		W.icon_state = "ERT_leader"
 	equip_to_slot_or_del(W, slot_wear_id)
+	var/obj/item/weapon/implant/loyalty/L = new/obj/item/weapon/implant/loyalty(src)
+	L.imp_in = src
+	L.implanted = 1
 
 	return 1
 

--- a/code/modules/admin/verbs/striketeam.dm
+++ b/code/modules/admin/verbs/striketeam.dm
@@ -161,6 +161,10 @@ var/global/sent_strike_team = 0
 	var/obj/item/weapon/implant/loyalty/L = new/obj/item/weapon/implant/loyalty(src)//Here you go Deuryn
 	L.imp_in = src
 	L.implanted = 1
+	var/obj/item/weapon/implant/explosive/E = new/obj/item/weapon/implant/explosive(src)
+	E.imp_in = src
+	E.implanted = 1
+	src.update_icons()
 
 
 

--- a/code/modules/admin/verbs/striketeam_syndicate.dm
+++ b/code/modules/admin/verbs/striketeam_syndicate.dm
@@ -177,4 +177,9 @@ var/global/sent_syndicate_strike_team = 0
 	W.registered_name = real_name
 	equip_to_slot_or_del(W, slot_wear_id)
 
+	var/obj/item/weapon/implant/explosive/E = new/obj/item/weapon/implant/explosive(src) //no loyalty implant because you're already syndicate scum
+	E.imp_in = src
+	E.implanted = 1
+	src.update_icons()
+
 	return 1

--- a/html/changelogs/IntiERT.yml
+++ b/html/changelogs/IntiERT.yml
@@ -1,0 +1,4 @@
+author: Intigracy
+delete-after: True
+changes: 
+- tweak: "ERTs and Deathsquads are now implanted with loyalty implants. Deathsquads also have explosive implants."


### PR DESCRIPTION
- tweak: "ERTs and Deathsquads are now implanted with loyalty implants. Deathsquads also have explosive implants."

fixes #8723
