### PR TITLE
Rework asteroid_temple vault

### DIFF
--- a/code/game/objects/structures/cage.dm
+++ b/code/game/objects/structures/cage.dm
@@ -29,6 +29,19 @@
 
 	update_icon()
 
+/obj/structure/cage/autoclose/New() //Close when created - catching any creatures on the same turf
+	..()
+
+	spawn()
+		toggle_door() //Open it
+		toggle_door() //Close it again!
+
+/obj/structure/cage/autoclose/cover/New()
+	..()
+
+	spawn()
+		toggle_cover()
+
 /obj/structure/cage/Destroy()
 	for(var/atom/movable/M in contents)
 		M.forceMove(src.loc)

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -406,8 +406,9 @@ var/global/list/item_mimic_disguises = list(
 
 /mob/living/simple_animal/hostile/mimic/crate/item/examine(mob/user) //Total override to make the mimics look EXACTLY like items!
 	var/s_size = "normal-sized"
-	if(copied_object)
-		switch(initial(copied_object.w_class))
+	if(ispath(copied_object, /obj/item))
+		var/obj/item/I = copied_object
+		switch(initial(I.w_class))
 			if(1.0)
 				s_size = "tiny"
 			if(2.0)

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -405,20 +405,20 @@ var/global/list/item_mimic_disguises = list(
 	return //Don't take any items!
 
 /mob/living/simple_animal/hostile/mimic/crate/item/examine(mob/user) //Total override to make the mimics look EXACTLY like items!
-	var/s_size
-	switch(src.size)
-		if(1.0)
-			s_size = "tiny"
-		if(2.0)
-			s_size = "small"
-		if(3.0)
-			s_size = "normal-sized"
-		if(4.0)
-			s_size = "bulky"
-		if(5.0)
-			s_size = "huge"
-		else
-	//if ((M_CLUMSY in usr.mutations) && prob(50)) t = "funny-looking"
+	var/s_size = "normal-sized"
+	if(copied_object)
+		switch(initial(copied_object.w_class))
+			if(1.0)
+				s_size = "tiny"
+			if(2.0)
+				s_size = "small"
+			if(3.0)
+				s_size = "normal-sized"
+			if(4.0)
+				s_size = "bulky"
+			if(5.0)
+				s_size = "huge"
+
 	var/pronoun
 	if (src.gender == PLURAL)
 		pronoun = "They are"

--- a/maps/randomvaults/asteroid_temple.dmm
+++ b/maps/randomvaults/asteroid_temple.dmm
@@ -7,94 +7,95 @@
 "ag" = (/turf/simulated/floor/plating/airless{broken = 1; icon_state = "platingdmg1"},/area/vault/asteroid)
 "ah" = (/turf/simulated/floor/plating/airless,/area/vault/asteroid)
 "ai" = (/obj/structure/lattice,/turf/space,/area/vault/asteroid)
-"aj" = (/turf/simulated/floor/plating/airless{broken = 1; icon_state = "panelscorched"},/area/vault/asteroid)
-"ak" = (/obj/structure/catwalk,/turf/space,/area/vault/asteroid)
-"al" = (/obj/item/stack/tile/plasteel,/turf/simulated/floor/plating/airless{broken = 1; icon_state = "platingdmg1"},/area/vault/asteroid)
-"am" = (/obj/machinery/door/mineral/wood,/turf/simulated/floor/plating,/area/vault/asteroid)
-"an" = (/obj/structure/lattice,/turf/space,/area)
-"ao" = (/turf/simulated/wall/r_wall,/area/vault/asteroid)
-"ap" = (/obj/structure/reagent_dispensers/bloodkeg,/obj/structure/table/woodentable,/turf/simulated/floor/wood,/area/vault/asteroid)
-"aq" = (/obj/structure/table/woodentable,/obj/item/weapon/reagent_containers/food/drinks/drinkingglass,/obj/item/weapon/reagent_containers/food/drinks/drinkingglass,/obj/item/weapon/reagent_containers/food/drinks/drinkingglass,/obj/item/weapon/reagent_containers/food/drinks/ice{pixel_x = 12; pixel_y = 2},/turf/simulated/floor/wood,/area/vault/asteroid)
-"ar" = (/obj/structure/table/woodentable,/turf/simulated/floor/wood,/area/vault/asteroid)
-"as" = (/obj/item/weapon/stool,/turf/simulated/floor/wood,/area/vault/asteroid)
-"at" = (/turf/simulated/floor/wood,/area/vault/asteroid)
-"au" = (/obj/structure/bookcase,/turf/simulated/floor/wood,/area/vault/asteroid)
-"av" = (/obj/structure/bookcase,/mob/living/simple_animal/hostile/scarybat/book/woody,/turf/simulated/floor/wood,/area/vault/asteroid)
-"aw" = (/obj/effect/decal/cleanable/cockroach_remains,/obj/structure/cult/pylon,/obj/effect/decal/cleanable/cobweb,/turf/simulated/floor/plating,/area/vault/asteroid)
-"ax" = (/obj/item/weapon/cigbutt,/obj/effect/decal/cleanable/blood/drip,/turf/simulated/floor/plating,/area/vault/asteroid)
-"ay" = (/obj/structure/window/reinforced{dir = 8},/obj/effect/decal/cleanable/cockroach_remains,/turf/simulated/floor/plating,/area/vault/asteroid)
-"az" = (/obj/structure/window/reinforced/plasma{dir = 4},/turf/simulated/floor/plating,/area/vault/asteroid)
-"aA" = (/obj/item/weapon/shard{icon_state = "small"},/obj/effect/decal/cleanable/blood/drip,/obj/effect/decal/cleanable/blood,/turf/simulated/floor/wood,/area/vault/asteroid)
-"aB" = (/obj/item/weapon/stool,/turf/simulated/floor/carpet,/area/vault/asteroid)
-"aC" = (/turf/simulated/floor/carpet,/area/vault/asteroid)
-"aD" = (/turf/simulated/floor/wood{broken = 1; icon_state = "wood-broken6"},/area/vault/asteroid)
-"aE" = (/obj/effect/decal/cleanable/spiderling_remains,/obj/structure/table/woodentable,/obj/item/candle,/turf/simulated/floor/plating,/area/vault/asteroid)
-"aF" = (/obj/effect/decal/cleanable/blood,/turf/simulated/floor/plating,/area/vault/asteroid)
-"aG" = (/obj/machinery/door/window/brigdoor{dir = 8; id_tag = ""; name = "Cell 1"; req_access_txt = "2"},/turf/simulated/floor/plating,/area/vault/asteroid)
-"aH" = (/obj/structure/window/reinforced/plasma{dir = 4},/obj/item/weapon/reagent_containers/food/snacks/meat/spiderleg,/turf/simulated/floor/plating,/area/vault/asteroid)
-"aI" = (/obj/effect/decal/cleanable/blood/drip,/turf/simulated/floor/wood,/area/vault/asteroid)
-"aJ" = (/obj/item/weapon/reagent_containers/food/snacks/meat/roach,/obj/item/weapon/stool,/obj/effect/decal/remains/xeno{desc = "They look like the remains of something... unholy. They have a strange aura about them."},/turf/simulated/floor/plating,/area/vault/asteroid)
-"aK" = (/obj/item/weapon/storage/fancy/cigarettes,/turf/simulated/floor/plating,/area/vault/asteroid)
-"aL" = (/obj/structure/window/reinforced{dir = 8},/turf/simulated/floor/plating,/area/vault/asteroid)
-"aM" = (/obj/item/weapon/shard/plasma,/turf/simulated/floor/plating,/area/vault/asteroid)
-"aN" = (/obj/item/stack/rods,/turf/space,/area)
-"aO" = (/obj/structure/catwalk,/turf/space,/area)
-"aP" = (/turf/simulated/floor/plating,/area/vault/asteroid)
-"aQ" = (/obj/effect/decal/cleanable/spiderling_remains,/obj/item/weapon/storage/fancy/matchbox/empty,/obj/effect/decal/cleanable/blood/drip,/turf/simulated/floor/plating,/area/vault/asteroid)
-"aR" = (/obj/effect/decal/cleanable/blood/drip,/obj/effect/decal/cleanable/vomit,/turf/simulated/floor/wood,/area/vault/asteroid)
-"aS" = (/obj/structure/cult/pylon,/turf/simulated/floor/wood{broken = 1; icon_state = "wood-broken"},/area/vault/asteroid)
-"aT" = (/obj/structure/cult/pylon,/turf/simulated/floor/wood,/area/vault/asteroid)
-"aU" = (/obj/effect/decal/cleanable/spiderling_remains,/obj/effect/decal/cleanable/blood/drip,/turf/simulated/floor/plating,/area/vault/asteroid)
-"aV" = (/obj/structure/window/reinforced{dir = 8},/obj/effect/decal/remains/human,/obj/item/weapon/handcuffs,/obj/effect/decal/cleanable/cobweb,/turf/simulated/floor/plating,/area/vault/asteroid)
-"aW" = (/obj/structure/window/reinforced/plasma{dir = 4},/obj/effect/decal/cleanable/blood/writing{desc = "It looks like a writing in blood. The blood seems to have dried a long time ago."; message = "veniam petimus"; pixel_y = 32},/obj/effect/spider/stickyweb,/turf/simulated/floor/plating,/area/vault/asteroid)
-"aX" = (/obj/item/stack/medical/bruise_pack/tajaran,/obj/item/stack/medical/ointment/tajaran,/turf/simulated/floor/wood,/area/vault/asteroid)
-"aY" = (/obj/structure/cage/autoclose,/obj/item/weapon/cigbutt,/mob/living/simple_animal/hostile/giant_spider/hunter,/turf/simulated/floor/plating,/area/vault/asteroid)
-"aZ" = (/obj/machinery/door/window/brigdoor{dir = 8; id_tag = ""; name = "Cell 2"; req_access_txt = "2"},/obj/effect/spider/stickyweb,/turf/simulated/floor/plating,/area/vault/asteroid)
-"ba" = (/obj/structure/window/reinforced/plasma{dir = 4},/obj/effect/decal/cleanable/spiderling_remains,/obj/effect/spider/stickyweb,/turf/simulated/floor/plating,/area/vault/asteroid)
-"bb" = (/obj/structure/window/reinforced/plasma{dir = 4},/turf/simulated/wall,/area/vault/asteroid)
-"bc" = (/obj/structure/window/reinforced/plasma{dir = 8},/turf/simulated/wall,/area/vault/asteroid)
-"bd" = (/obj/effect/landmark/corpse/mime,/obj/effect/decal/cleanable/cockroach_remains,/mob/living/simple_animal/cockroach,/mob/living/simple_animal/cockroach,/mob/living/simple_animal/cockroach,/mob/living/simple_animal/cockroach,/turf/simulated/floor/plating,/area/vault/asteroid)
-"be" = (/obj/structure/window/barricade{dir = 8},/turf/simulated/floor/plating,/area/vault/asteroid)
-"bf" = (/obj/effect/decal/cleanable/spiderling_remains,/obj/item/weapon/cigbutt,/turf/simulated/floor/plating,/area/vault/asteroid)
-"bg" = (/obj/structure/window/reinforced{dir = 8},/obj/effect/decal/cleanable/spiderling_remains,/obj/effect/spider/stickyweb,/turf/simulated/floor/plating,/area/vault/asteroid)
-"bh" = (/obj/structure/window/reinforced/plasma{dir = 4},/obj/effect/spider/stickyweb,/obj/item/weapon/reagent_containers/food/snacks/meat/spiderleg,/obj/effect/decal/cleanable/cockroach_remains,/turf/simulated/floor/plating,/area/vault/asteroid)
-"bi" = (/obj/structure/lattice,/obj/structure/window/reinforced/plasma{dir = 4},/turf/space,/area)
-"bj" = (/turf/simulated/floor{dir = 5; icon_state = "stage_stairs"; tag = "icon-whitegreen (NORTHEAST)"},/area/vault/asteroid)
-"bk" = (/obj/structure/lattice,/obj/structure/window/reinforced/plasma{dir = 8},/turf/space,/area)
-"bl" = (/obj/structure/window/reinforced/plasma,/obj/structure/cage,/turf/simulated/floor/plating,/area/vault/asteroid)
-"bm" = (/obj/structure/window/reinforced/plasma{dir = 4},/turf/simulated/wall/r_wall,/area/vault/asteroid)
-"bn" = (/obj/structure/window/reinforced/plasma{dir = 8},/turf/simulated/wall/r_wall,/area/vault/asteroid)
-"bo" = (/obj/structure/cult/pylon,/obj/structure/window/reinforced/plasma,/turf/simulated/floor/plating,/area/vault/asteroid)
-"bp" = (/obj/structure/window/reinforced/plasma,/obj/item/weapon/paper/crumpled/bloody{info = "Only one artifact is real, all the others are fake. Don't make the same mistake that I did..."},/obj/effect/decal/remains/human,/turf/simulated/floor/plating,/area/vault/asteroid)
-"bq" = (/turf/simulated/floor{icon_state = "dark"},/area/vault/asteroid)
-"br" = (/obj/structure/cult/talisman,/obj/effect/landmark/catechizer_spawn,/turf/simulated/floor{icon_state = "dark"},/area/vault/asteroid)
-"bs" = (/obj/effect/decal/remains/human,/turf/simulated/floor/carpet,/area/vault/asteroid)
-"bt" = (/obj/structure/constructshell/cult,/turf/simulated/floor/carpet,/area/vault/asteroid)
-"bu" = (/mob/living/simple_animal/hostile/faithless{faction = "mimic"; name = "The Guardian"},/turf/simulated/floor/carpet,/area/vault/asteroid)
+"aj" = (/obj/structure/cult/forge,/turf/simulated/floor/plating/airless{broken = 1; icon_state = "panelscorched"},/area/vault/asteroid)
+"ak" = (/turf/simulated/floor/plating/airless{broken = 1; icon_state = "panelscorched"},/area/vault/asteroid)
+"al" = (/obj/structure/catwalk,/turf/space,/area/vault/asteroid)
+"am" = (/obj/item/stack/tile/plasteel,/turf/simulated/floor/plating/airless{broken = 1; icon_state = "platingdmg1"},/area/vault/asteroid)
+"an" = (/obj/machinery/door/mineral/wood,/turf/simulated/floor/plating,/area/vault/asteroid)
+"ao" = (/obj/structure/lattice,/turf/space,/area)
+"ap" = (/turf/simulated/wall/r_wall,/area/vault/asteroid)
+"aq" = (/obj/structure/reagent_dispensers/bloodkeg,/obj/structure/table/woodentable,/turf/simulated/floor/wood,/area/vault/asteroid)
+"ar" = (/obj/structure/table/woodentable,/obj/item/weapon/reagent_containers/food/drinks/drinkingglass,/obj/item/weapon/reagent_containers/food/drinks/drinkingglass,/obj/item/weapon/reagent_containers/food/drinks/drinkingglass,/obj/item/weapon/reagent_containers/food/drinks/ice{pixel_x = 12; pixel_y = 2},/turf/simulated/floor/wood,/area/vault/asteroid)
+"as" = (/obj/structure/table/woodentable,/turf/simulated/floor/wood,/area/vault/asteroid)
+"at" = (/obj/item/weapon/stool,/turf/simulated/floor/wood,/area/vault/asteroid)
+"au" = (/turf/simulated/floor/wood,/area/vault/asteroid)
+"av" = (/obj/structure/bookcase,/turf/simulated/floor/wood,/area/vault/asteroid)
+"aw" = (/obj/structure/bookcase,/mob/living/simple_animal/hostile/scarybat/book/woody,/turf/simulated/floor/wood,/area/vault/asteroid)
+"ax" = (/obj/effect/decal/cleanable/cockroach_remains,/obj/structure/cult/pylon,/obj/effect/decal/cleanable/cobweb,/turf/simulated/floor/plating,/area/vault/asteroid)
+"ay" = (/obj/item/weapon/cigbutt,/obj/effect/decal/cleanable/blood/drip,/turf/simulated/floor/plating,/area/vault/asteroid)
+"az" = (/obj/structure/window/reinforced{dir = 8},/obj/effect/decal/cleanable/cockroach_remains,/turf/simulated/floor/plating,/area/vault/asteroid)
+"aA" = (/obj/structure/window/reinforced/plasma{dir = 4},/turf/simulated/floor/plating,/area/vault/asteroid)
+"aB" = (/obj/item/weapon/shard{icon_state = "small"},/obj/effect/decal/cleanable/blood/drip,/obj/effect/decal/cleanable/blood,/turf/simulated/floor/wood,/area/vault/asteroid)
+"aC" = (/obj/item/weapon/stool,/turf/simulated/floor/carpet,/area/vault/asteroid)
+"aD" = (/turf/simulated/floor/carpet,/area/vault/asteroid)
+"aE" = (/turf/simulated/floor/wood{broken = 1; icon_state = "wood-broken6"},/area/vault/asteroid)
+"aF" = (/obj/effect/decal/cleanable/spiderling_remains,/obj/structure/table/woodentable,/obj/item/candle,/turf/simulated/floor/plating,/area/vault/asteroid)
+"aG" = (/obj/effect/decal/cleanable/blood,/turf/simulated/floor/plating,/area/vault/asteroid)
+"aH" = (/obj/machinery/door/window/brigdoor{dir = 8; id_tag = ""; name = "Cell 1"; req_access_txt = "2"},/turf/simulated/floor/plating,/area/vault/asteroid)
+"aI" = (/obj/structure/window/reinforced/plasma{dir = 4},/obj/item/weapon/reagent_containers/food/snacks/meat/spiderleg,/turf/simulated/floor/plating,/area/vault/asteroid)
+"aJ" = (/obj/effect/decal/cleanable/blood/drip,/turf/simulated/floor/wood,/area/vault/asteroid)
+"aK" = (/obj/item/weapon/reagent_containers/food/snacks/meat/roach,/obj/item/weapon/stool,/obj/effect/decal/remains/xeno{desc = "They look like the remains of something... unholy. They have a strange aura about them."},/turf/simulated/floor/plating,/area/vault/asteroid)
+"aL" = (/obj/item/weapon/storage/fancy/cigarettes,/turf/simulated/floor/plating,/area/vault/asteroid)
+"aM" = (/obj/structure/window/reinforced{dir = 8},/turf/simulated/floor/plating,/area/vault/asteroid)
+"aN" = (/obj/item/weapon/shard/plasma,/turf/simulated/floor/plating,/area/vault/asteroid)
+"aO" = (/obj/item/stack/rods,/turf/space,/area)
+"aP" = (/obj/structure/catwalk,/turf/space,/area)
+"aQ" = (/turf/simulated/floor/plating,/area/vault/asteroid)
+"aR" = (/obj/effect/decal/cleanable/spiderling_remains,/obj/item/weapon/storage/fancy/matchbox/empty,/obj/effect/decal/cleanable/blood/drip,/turf/simulated/floor/plating,/area/vault/asteroid)
+"aS" = (/obj/effect/decal/cleanable/blood/drip,/obj/effect/decal/cleanable/vomit,/turf/simulated/floor/wood,/area/vault/asteroid)
+"aT" = (/obj/structure/cult/pylon,/turf/simulated/floor/wood{broken = 1; icon_state = "wood-broken"},/area/vault/asteroid)
+"aU" = (/obj/structure/cult/pylon,/turf/simulated/floor/wood,/area/vault/asteroid)
+"aV" = (/obj/effect/decal/cleanable/spiderling_remains,/obj/effect/decal/cleanable/blood/drip,/turf/simulated/floor/plating,/area/vault/asteroid)
+"aW" = (/obj/structure/window/reinforced{dir = 8},/obj/effect/decal/remains/human,/obj/item/weapon/handcuffs,/obj/effect/decal/cleanable/cobweb,/turf/simulated/floor/plating,/area/vault/asteroid)
+"aX" = (/obj/structure/window/reinforced/plasma{dir = 4},/obj/effect/decal/cleanable/blood/writing{desc = "It looks like a writing in blood. The blood seems to have dried a long time ago."; message = "veniam petimus"; pixel_y = 32},/obj/effect/spider/stickyweb,/turf/simulated/floor/plating,/area/vault/asteroid)
+"aY" = (/obj/item/stack/medical/bruise_pack/tajaran,/obj/item/stack/medical/ointment/tajaran,/turf/simulated/floor/wood,/area/vault/asteroid)
+"aZ" = (/obj/structure/cage/autoclose,/obj/item/weapon/cigbutt,/mob/living/simple_animal/hostile/giant_spider/hunter,/turf/simulated/floor/plating,/area/vault/asteroid)
+"ba" = (/obj/machinery/door/window/brigdoor{dir = 8; id_tag = ""; name = "Cell 2"; req_access_txt = "2"},/obj/effect/spider/stickyweb,/turf/simulated/floor/plating,/area/vault/asteroid)
+"bb" = (/obj/structure/window/reinforced/plasma{dir = 4},/obj/effect/decal/cleanable/spiderling_remains,/obj/effect/spider/stickyweb,/turf/simulated/floor/plating,/area/vault/asteroid)
+"bc" = (/obj/structure/window/reinforced/plasma{dir = 4},/turf/simulated/wall,/area/vault/asteroid)
+"bd" = (/obj/structure/window/reinforced/plasma{dir = 8},/turf/simulated/wall,/area/vault/asteroid)
+"be" = (/obj/effect/decal/cleanable/cockroach_remains,/obj/effect/landmark/corpse/civilian,/mob/living/simple_animal/cockroach,/mob/living/simple_animal/cockroach,/mob/living/simple_animal/cockroach,/mob/living/simple_animal/cockroach,/turf/simulated/floor/plating,/area/vault/asteroid)
+"bf" = (/obj/structure/window/barricade{dir = 8},/turf/simulated/floor/plating,/area/vault/asteroid)
+"bg" = (/obj/effect/decal/cleanable/spiderling_remains,/obj/item/weapon/cigbutt,/turf/simulated/floor/plating,/area/vault/asteroid)
+"bh" = (/obj/structure/window/reinforced{dir = 8},/obj/effect/decal/cleanable/spiderling_remains,/obj/effect/spider/stickyweb,/turf/simulated/floor/plating,/area/vault/asteroid)
+"bi" = (/obj/structure/window/reinforced/plasma{dir = 4},/obj/effect/spider/stickyweb,/obj/item/weapon/reagent_containers/food/snacks/meat/spiderleg,/obj/effect/decal/cleanable/cockroach_remains,/turf/simulated/floor/plating,/area/vault/asteroid)
+"bj" = (/obj/structure/lattice,/obj/structure/window/reinforced/plasma{dir = 4},/turf/space,/area)
+"bk" = (/turf/simulated/floor{dir = 5; icon_state = "stage_stairs"; tag = "icon-whitegreen (NORTHEAST)"},/area/vault/asteroid)
+"bl" = (/obj/structure/lattice,/obj/structure/window/reinforced/plasma{dir = 8},/turf/space,/area)
+"bm" = (/obj/structure/window/reinforced/plasma,/obj/structure/cage,/turf/simulated/floor/plating,/area/vault/asteroid)
+"bn" = (/obj/structure/window/reinforced/plasma{dir = 4},/turf/simulated/wall/r_wall,/area/vault/asteroid)
+"bo" = (/obj/structure/window/reinforced/plasma{dir = 8},/turf/simulated/wall/r_wall,/area/vault/asteroid)
+"bp" = (/obj/structure/cult/pylon,/obj/structure/window/reinforced/plasma,/turf/simulated/floor/plating,/area/vault/asteroid)
+"bq" = (/obj/structure/window/reinforced/plasma,/obj/item/weapon/paper/crumpled/bloody{info = "Only one artifact is real, all the others are fake. Don't make the same mistake that I did..."},/obj/effect/decal/remains/human,/turf/simulated/floor/plating,/area/vault/asteroid)
+"br" = (/turf/simulated/floor{icon_state = "dark"},/area/vault/asteroid)
+"bs" = (/obj/structure/cult/talisman,/obj/effect/landmark/catechizer_spawn,/turf/simulated/floor{icon_state = "dark"},/area/vault/asteroid)
+"bt" = (/obj/effect/decal/remains/human,/turf/simulated/floor/carpet,/area/vault/asteroid)
+"bu" = (/obj/structure/constructshell/cult,/turf/simulated/floor/carpet,/area/vault/asteroid)
+"bv" = (/mob/living/simple_animal/hostile/faithless{faction = "mimic"; name = "The Guardian"},/turf/simulated/floor/carpet,/area/vault/asteroid)
 
 (1,1,1) = {"
 aaaaaaaaaaaaabaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaacacacacacadadaeadacacacacacacaa
 aaaaaaacafagahahaiaeadaiahafajafagacaa
-aaaaaaacahajahahakaiaiakalahagajahacaa
-aaaaaaacacamacacadadadadacacacamacacaa
-aaaaaaaaanakanaaaaaaaaaaaaaaanakanaaaa
-acacacacacamacacacacacaaaaaoaoamaoaoaa
-acapaqarasatatauavauacaaaaaoawaxayazaa
-acataAaBaCaCaCaCaDatacaaaaaoaEaFaGaHaa
-acaIataCaCaCaCaCatatacaaanaoaJaKaLaMaN
-acaIataCaCaCaCaCataIamaOaOamaPaQaoaoaa
-acaRaSaCaCaCaCaCaTatacaaanaoaUaPaVaWaa
-acaXatatatatatatatatacaoaoaoaYaPaZbaaa
-acacacacbbambcacacacacaobdambebfbgbhaa
-aaaaaaaabibjbkaaaaaaaaaoaoaoblblaoaoaa
-aaaaaaaabibjbkaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaabibjbkaaaaaaaaaaaaaaaaaaaaaaaa
-aoaoaoaobmbjbnaoaoaoaoaaaaaaaaaaaaaaaa
-aoboaoboaoamaoboaobpaoaaaaaaaaaaaaaaaa
-aobqbqbqbqbqbqbqbqbqaoaaaaaaaaaaaaaaaa
-aobrbqaCaCbsaCaCbqbraoaaaaaaaaaaaaaaaa
-aobqbqbtbsbubsbtbqbqaoaaaaaaaaaaaaaaaa
-aobrbqaCaCbsaCaCbqbraoaaaaaaaaaaaaaaaa
-aoaoaoaoaoaoaoaoaoaoaoaaaaaaaaaaaaaaaa
+aaaaaaacahakahahalaiaialamahagakahacaa
+aaaaaaacacanacacadadadadacacacanacacaa
+aaaaaaaaaoalaoaaaaaaaaaaaaaaaoalaoaaaa
+acacacacacanacacacacacaaaaapapanapapaa
+acaqarasatauauavawavacaaaaapaxayazaAaa
+acauaBaCaDaDaDaDaEauacaaaaapaFaGaHaIaa
+acaJauaDaDaDaDaDauauacaaaoapaKaLaMaNaO
+acaJauaDaDaDaDaDauaJanaPaPanaQaRapapaa
+acaSaTaDaDaDaDaDaUauacaaaoapaVaQaWaXaa
+acaYauauauauauauauauacapapapaZaQbabbaa
+acacacacbcanbdacacacacapbeanbfbgbhbiaa
+aaaaaaaabjbkblaaaaaaaaapapapbmbmapapaa
+aaaaaaaabjbkblaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaabjbkblaaaaaaaaaaaaaaaaaaaaaaaa
+apapapapbnbkboapapapapaaaaaaaaaaaaaaaa
+apbpapbpapanapbpapbqapaaaaaaaaaaaaaaaa
+apbrbrbrbrbrbrbrbrbrapaaaaaaaaaaaaaaaa
+apbsbraDaDbtaDaDbrbsapaaaaaaaaaaaaaaaa
+apbrbrbubtbvbtbubrbrapaaaaaaaaaaaaaaaa
+apbsbraDaDbtaDaDbrbsapaaaaaaaaaaaaaaaa
+apapapapapapapapapapapaaaaaaaaaaaaaaaa
 "}

--- a/maps/randomvaults/asteroid_temple.dmm
+++ b/maps/randomvaults/asteroid_temple.dmm
@@ -1,35 +1,100 @@
-"a" = (/turf/space,/area)
-"b" = (/turf/unsimulated/floor/asteroid,/area/vault/asteroid)
-"c" = (/turf/unsimulated/mineral,/area/vault/asteroid)
-"d" = (/obj/structure/toilet,/obj/item/toy/gasha/minibutt,/turf/unsimulated/floor/airless,/area/vault/asteroid)
-"e" = (/obj/structure/window/reinforced/tinted{dir = 8},/obj/structure/window/reinforced/tinted{dir = 4},/obj/structure/grille,/turf/unsimulated/floor/airless,/area/vault/asteroid)
-"f" = (/obj/structure/closet/crate/chest/potential_mimic,/obj/item/weapon/spacecash/c1000,/obj/item/clothing/head/batman,/obj/item/weapon/reagent_containers/food/snacks/baguette,/turf/unsimulated/floor/airless,/area/vault/asteroid)
-"g" = (/obj/structure/closet/crate/chest/potential_mimic,/obj/item/weapon/spacecash/c1000,/obj/item/clothing/head/wizard/necro,/turf/unsimulated/floor/airless,/area/vault/asteroid)
-"h" = (/obj/structure/closet/crate/chest/potential_mimic,/obj/item/weapon/spacecash/c1000,/obj/item/clothing/head/wizard/magus,/turf/unsimulated/floor/airless,/area/vault/asteroid)
-"i" = (/obj/structure/closet/crate/chest/potential_mimic,/obj/item/weapon/spacecash/c1000,/obj/item/clothing/head/tinfoil,/obj/item/toy/syndicateballoon,/turf/unsimulated/floor/airless,/area/vault/asteroid)
-"j" = (/turf/unsimulated/floor/airless,/area/vault/asteroid)
-"k" = (/obj/structure/window/reinforced/tinted{dir = 4},/obj/structure/window/reinforced/tinted{dir = 8},/obj/structure/window/reinforced/tinted,/obj/structure/grille,/turf/unsimulated/floor/airless,/area/vault/asteroid)
-"l" = (/obj/structure/table,/obj/item/toy/gun,/turf/unsimulated/floor/airless,/area/vault/asteroid)
-"m" = (/obj/item/target/alien,/turf/unsimulated/floor/airless,/area/vault/asteroid)
-"n" = (/obj/machinery/door/mineral/wood,/turf/unsimulated/floor/airless,/area/vault/asteroid)
-"o" = (/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"; dir = 9},/area/vault/asteroid)
-"p" = (/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"; dir = 5},/area/vault/asteroid)
-"q" = (/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"; dir = 8},/area/vault/asteroid)
-"r" = (/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"; dir = 4},/area/vault/asteroid)
-"s" = (/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"; dir = 10},/area/vault/asteroid)
-"t" = (/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"; dir = 6},/area/vault/asteroid)
+"aa" = (/turf/space,/area)
+"ab" = (/obj/item/stack/sheet/metal,/turf/space,/area)
+"ac" = (/turf/simulated/wall,/area/vault/asteroid)
+"ad" = (/turf/space,/area/vault/asteroid)
+"ae" = (/obj/item/stack/sheet/metal,/turf/space,/area/vault/asteroid)
+"af" = (/obj/item/stack/tile/plasteel,/turf/simulated/floor/plating/airless,/area/vault/asteroid)
+"ag" = (/turf/simulated/floor/plating/airless{broken = 1; icon_state = "platingdmg1"},/area/vault/asteroid)
+"ah" = (/turf/simulated/floor/plating/airless,/area/vault/asteroid)
+"ai" = (/obj/structure/lattice,/turf/space,/area/vault/asteroid)
+"aj" = (/turf/simulated/floor/plating/airless{broken = 1; icon_state = "panelscorched"},/area/vault/asteroid)
+"ak" = (/obj/structure/catwalk,/turf/space,/area/vault/asteroid)
+"al" = (/obj/item/stack/tile/plasteel,/turf/simulated/floor/plating/airless{broken = 1; icon_state = "platingdmg1"},/area/vault/asteroid)
+"am" = (/obj/machinery/door/mineral/wood,/turf/simulated/floor/plating,/area/vault/asteroid)
+"an" = (/obj/structure/lattice,/turf/space,/area)
+"ao" = (/turf/simulated/wall/r_wall,/area/vault/asteroid)
+"ap" = (/obj/structure/reagent_dispensers/bloodkeg,/obj/structure/table/woodentable,/turf/simulated/floor/wood,/area/vault/asteroid)
+"aq" = (/obj/structure/table/woodentable,/obj/item/weapon/reagent_containers/food/drinks/drinkingglass,/obj/item/weapon/reagent_containers/food/drinks/drinkingglass,/obj/item/weapon/reagent_containers/food/drinks/drinkingglass,/obj/item/weapon/reagent_containers/food/drinks/ice{pixel_x = 12; pixel_y = 2},/turf/simulated/floor/wood,/area/vault/asteroid)
+"ar" = (/obj/structure/table/woodentable,/turf/simulated/floor/wood,/area/vault/asteroid)
+"as" = (/obj/item/weapon/stool,/turf/simulated/floor/wood,/area/vault/asteroid)
+"at" = (/turf/simulated/floor/wood,/area/vault/asteroid)
+"au" = (/obj/structure/bookcase,/turf/simulated/floor/wood,/area/vault/asteroid)
+"av" = (/obj/structure/bookcase,/mob/living/simple_animal/hostile/scarybat/book/woody,/turf/simulated/floor/wood,/area/vault/asteroid)
+"aw" = (/obj/effect/decal/cleanable/cockroach_remains,/obj/structure/cult/pylon,/obj/effect/decal/cleanable/cobweb,/turf/simulated/floor/plating,/area/vault/asteroid)
+"ax" = (/obj/item/weapon/cigbutt,/obj/effect/decal/cleanable/blood/drip,/turf/simulated/floor/plating,/area/vault/asteroid)
+"ay" = (/obj/structure/window/reinforced{dir = 8},/obj/effect/decal/cleanable/cockroach_remains,/turf/simulated/floor/plating,/area/vault/asteroid)
+"az" = (/obj/structure/window/reinforced/plasma{dir = 4},/turf/simulated/floor/plating,/area/vault/asteroid)
+"aA" = (/obj/item/weapon/shard{icon_state = "small"},/obj/effect/decal/cleanable/blood/drip,/obj/effect/decal/cleanable/blood,/turf/simulated/floor/wood,/area/vault/asteroid)
+"aB" = (/obj/item/weapon/stool,/turf/simulated/floor/carpet,/area/vault/asteroid)
+"aC" = (/turf/simulated/floor/carpet,/area/vault/asteroid)
+"aD" = (/turf/simulated/floor/wood{broken = 1; icon_state = "wood-broken6"},/area/vault/asteroid)
+"aE" = (/obj/effect/decal/cleanable/spiderling_remains,/obj/structure/table/woodentable,/obj/item/candle,/turf/simulated/floor/plating,/area/vault/asteroid)
+"aF" = (/obj/effect/decal/cleanable/blood,/turf/simulated/floor/plating,/area/vault/asteroid)
+"aG" = (/obj/machinery/door/window/brigdoor{dir = 8; id_tag = ""; name = "Cell 1"; req_access_txt = "2"},/turf/simulated/floor/plating,/area/vault/asteroid)
+"aH" = (/obj/structure/window/reinforced/plasma{dir = 4},/obj/item/weapon/reagent_containers/food/snacks/meat/spiderleg,/turf/simulated/floor/plating,/area/vault/asteroid)
+"aI" = (/obj/effect/decal/cleanable/blood/drip,/turf/simulated/floor/wood,/area/vault/asteroid)
+"aJ" = (/obj/item/weapon/reagent_containers/food/snacks/meat/roach,/obj/item/weapon/stool,/obj/effect/decal/remains/xeno{desc = "They look like the remains of something... unholy. They have a strange aura about them."},/turf/simulated/floor/plating,/area/vault/asteroid)
+"aK" = (/obj/item/weapon/storage/fancy/cigarettes,/turf/simulated/floor/plating,/area/vault/asteroid)
+"aL" = (/obj/structure/window/reinforced{dir = 8},/turf/simulated/floor/plating,/area/vault/asteroid)
+"aM" = (/obj/item/weapon/shard/plasma,/turf/simulated/floor/plating,/area/vault/asteroid)
+"aN" = (/obj/item/stack/rods,/turf/space,/area)
+"aO" = (/obj/structure/catwalk,/turf/space,/area)
+"aP" = (/turf/simulated/floor/plating,/area/vault/asteroid)
+"aQ" = (/obj/effect/decal/cleanable/spiderling_remains,/obj/item/weapon/storage/fancy/matchbox/empty,/obj/effect/decal/cleanable/blood/drip,/turf/simulated/floor/plating,/area/vault/asteroid)
+"aR" = (/obj/effect/decal/cleanable/blood/drip,/obj/effect/decal/cleanable/vomit,/turf/simulated/floor/wood,/area/vault/asteroid)
+"aS" = (/obj/structure/cult/pylon,/turf/simulated/floor/wood{broken = 1; icon_state = "wood-broken"},/area/vault/asteroid)
+"aT" = (/obj/structure/cult/pylon,/turf/simulated/floor/wood,/area/vault/asteroid)
+"aU" = (/obj/effect/decal/cleanable/spiderling_remains,/obj/effect/decal/cleanable/blood/drip,/turf/simulated/floor/plating,/area/vault/asteroid)
+"aV" = (/obj/structure/window/reinforced{dir = 8},/obj/effect/decal/remains/human,/obj/item/weapon/handcuffs,/obj/effect/decal/cleanable/cobweb,/turf/simulated/floor/plating,/area/vault/asteroid)
+"aW" = (/obj/structure/window/reinforced/plasma{dir = 4},/obj/effect/decal/cleanable/blood/writing{desc = "It looks like a writing in blood. The blood seems to have dried a long time ago."; message = "veniam petimus"; pixel_y = 32},/obj/effect/spider/stickyweb,/turf/simulated/floor/plating,/area/vault/asteroid)
+"aX" = (/obj/item/stack/medical/bruise_pack/tajaran,/obj/item/stack/medical/ointment/tajaran,/turf/simulated/floor/wood,/area/vault/asteroid)
+"aY" = (/obj/structure/cage/autoclose,/obj/item/weapon/cigbutt,/mob/living/simple_animal/hostile/giant_spider/hunter,/turf/simulated/floor/plating,/area/vault/asteroid)
+"aZ" = (/obj/machinery/door/window/brigdoor{dir = 8; id_tag = ""; name = "Cell 2"; req_access_txt = "2"},/obj/effect/spider/stickyweb,/turf/simulated/floor/plating,/area/vault/asteroid)
+"ba" = (/obj/structure/window/reinforced/plasma{dir = 4},/obj/effect/decal/cleanable/spiderling_remains,/obj/effect/spider/stickyweb,/turf/simulated/floor/plating,/area/vault/asteroid)
+"bb" = (/obj/structure/window/reinforced/plasma{dir = 4},/turf/simulated/wall,/area/vault/asteroid)
+"bc" = (/obj/structure/window/reinforced/plasma{dir = 8},/turf/simulated/wall,/area/vault/asteroid)
+"bd" = (/obj/effect/landmark/corpse/mime,/obj/effect/decal/cleanable/cockroach_remains,/mob/living/simple_animal/cockroach,/mob/living/simple_animal/cockroach,/mob/living/simple_animal/cockroach,/mob/living/simple_animal/cockroach,/turf/simulated/floor/plating,/area/vault/asteroid)
+"be" = (/obj/structure/window/barricade{dir = 8},/turf/simulated/floor/plating,/area/vault/asteroid)
+"bf" = (/obj/effect/decal/cleanable/spiderling_remains,/obj/item/weapon/cigbutt,/turf/simulated/floor/plating,/area/vault/asteroid)
+"bg" = (/obj/structure/window/reinforced{dir = 8},/obj/effect/decal/cleanable/spiderling_remains,/obj/effect/spider/stickyweb,/turf/simulated/floor/plating,/area/vault/asteroid)
+"bh" = (/obj/structure/window/reinforced/plasma{dir = 4},/obj/effect/spider/stickyweb,/obj/item/weapon/reagent_containers/food/snacks/meat/spiderleg,/obj/effect/decal/cleanable/cockroach_remains,/turf/simulated/floor/plating,/area/vault/asteroid)
+"bi" = (/obj/structure/lattice,/obj/structure/window/reinforced/plasma{dir = 4},/turf/space,/area)
+"bj" = (/turf/simulated/floor{dir = 5; icon_state = "stage_stairs"; tag = "icon-whitegreen (NORTHEAST)"},/area/vault/asteroid)
+"bk" = (/obj/structure/lattice,/obj/structure/window/reinforced/plasma{dir = 8},/turf/space,/area)
+"bl" = (/obj/structure/window/reinforced/plasma,/obj/structure/cage,/turf/simulated/floor/plating,/area/vault/asteroid)
+"bm" = (/obj/structure/window/reinforced/plasma{dir = 4},/turf/simulated/wall/r_wall,/area/vault/asteroid)
+"bn" = (/obj/structure/window/reinforced/plasma{dir = 8},/turf/simulated/wall/r_wall,/area/vault/asteroid)
+"bo" = (/obj/structure/cult/pylon,/obj/structure/window/reinforced/plasma,/turf/simulated/floor/plating,/area/vault/asteroid)
+"bp" = (/obj/structure/window/reinforced/plasma,/obj/item/weapon/paper/crumpled/bloody{info = "Only one artifact is real, all the others are fake. Don't make the same mistake that I did..."},/obj/effect/decal/remains/human,/turf/simulated/floor/plating,/area/vault/asteroid)
+"bq" = (/turf/simulated/floor{icon_state = "dark"},/area/vault/asteroid)
+"br" = (/obj/structure/cult/talisman,/obj/effect/landmark/catechizer_spawn,/turf/simulated/floor{icon_state = "dark"},/area/vault/asteroid)
+"bs" = (/obj/effect/decal/remains/human,/turf/simulated/floor/carpet,/area/vault/asteroid)
+"bt" = (/obj/structure/constructshell/cult,/turf/simulated/floor/carpet,/area/vault/asteroid)
+"bu" = (/mob/living/simple_animal/hostile/faithless{faction = "mimic"; name = "The Guardian"},/turf/simulated/floor/carpet,/area/vault/asteroid)
 
 (1,1,1) = {"
-aaabccaaaaaa
-acccccccccaa
-bccdefghiccc
-bccjkjjjjccc
-accjjjljmcca
-abcjjjljmcbb
-abccnnccccca
-acccopccccca
-acccqrccccaa
-acccqrccccaa
-aaacstbcaaaa
-aaaabbbaaaaa
+aaaaaaaaaaaaabaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaacacacacacadadaeadacacacacacacaa
+aaaaaaacafagahahaiaeadaiahafajafagacaa
+aaaaaaacahajahahakaiaiakalahagajahacaa
+aaaaaaacacamacacadadadadacacacamacacaa
+aaaaaaaaanakanaaaaaaaaaaaaaaanakanaaaa
+acacacacacamacacacacacaaaaaoaoamaoaoaa
+acapaqarasatatauavauacaaaaaoawaxayazaa
+acataAaBaCaCaCaCaDatacaaaaaoaEaFaGaHaa
+acaIataCaCaCaCaCatatacaaanaoaJaKaLaMaN
+acaIataCaCaCaCaCataIamaOaOamaPaQaoaoaa
+acaRaSaCaCaCaCaCaTatacaaanaoaUaPaVaWaa
+acaXatatatatatatatatacaoaoaoaYaPaZbaaa
+acacacacbbambcacacacacaobdambebfbgbhaa
+aaaaaaaabibjbkaaaaaaaaaoaoaoblblaoaoaa
+aaaaaaaabibjbkaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaabibjbkaaaaaaaaaaaaaaaaaaaaaaaa
+aoaoaoaobmbjbnaoaoaoaoaaaaaaaaaaaaaaaa
+aoboaoboaoamaoboaobpaoaaaaaaaaaaaaaaaa
+aobqbqbqbqbqbqbqbqbqaoaaaaaaaaaaaaaaaa
+aobrbqaCaCbsaCaCbqbraoaaaaaaaaaaaaaaaa
+aobqbqbtbsbubsbtbqbqaoaaaaaaaaaaaaaaaa
+aobrbqaCaCbsaCaCbqbraoaaaaaaaaaaaaaaaa
+aoaoaoaoaoaoaoaoaoaoaoaaaaaaaaaaaaaaaa
 "}

--- a/maps/randomvaults/objects.dm
+++ b/maps/randomvaults/objects.dm
@@ -32,6 +32,36 @@
 
 	slip_power = 10
 
+/obj/item/weapon/melee/morningstar/catechizer
+	name = "The Catechizer"
+	desc = "An unholy weapon forged eons ago by a servant of Nar-Sie."
+
+	force = 37
+	throwforce = 30
+	throw_speed = 3
+	throw_range = 5
+
+/obj/effect/landmark/catechizer_spawn //Multiple of these are put in a single area. One of these landmark will contain a true catachizer, others only mimics
+	name = "catechizer spawn"
+
+/obj/effect/landmark/catechizer_spawn/New()
+	spawn()
+		if(!isturf(loc)) return
+
+		var/list/all_spawns = list()
+		for(var/obj/effect/landmark/catechizer_spawn/S in get_area(src))
+			all_spawns.Add(S)
+
+		var/obj/effect/true_spawn = pick(all_spawns)
+		all_spawns.Remove(true_spawn)
+
+		var/obj/item/weapon/melee/morningstar/catechizer/original = new(get_turf(true_spawn))
+
+		for(var/obj/effect/S in all_spawns)
+			new /mob/living/simple_animal/hostile/mimic/crate/item(get_turf(S), original) //Make copies
+			qdel(S)
+
+		qdel(src)
 
 /obj/machinery/door/poddoor/vault_rust
 	id_tag = "tokamak_yadro_ventilyatsionnyy" // Russian for "tokamak_core_vent"


### PR DESCRIPTION
Let's be honest flying through space for 30 minutes and finding this ![](http://puu.sh/nwZbx/0bff8a9aa9.png) sucks balls

Now this is a real cult temple with a torture chamber / prison and an artifact morningstar, "The Catechizer". The artifact has 37 force (up from morningstar's 20) and can be thrown up to 5 tiles away dealing ~18 damage. It's stored in a room with four altars and a faithless. Only one altar (chosen at random every round) will have the true Catechizer, the rest will have item mimics disguised as it.

http://puu.sh/nHPD4/88ff226040.png (map editor)
http://puu.sh/nHQ0H/0ed0d711a0.png (game)

Loot: 1 cage with a giant spider hunter, The Catechizer, Woody the flying book, tajaran versions of ointment and gauze

Also fixes item mimics not showing correct size
