### PR TITLE
chameleon jumpsuits no longer allow you to choose jumpsuit parent

### DIFF
--- a/code/modules/clothing/under/chameleon.dm
+++ b/code/modules/clothing/under/chameleon.dm
@@ -75,7 +75,7 @@
 
 /obj/item/clothing/under/chameleon/all/New()
 	..()
-	var/blocked = list(/obj/item/clothing/under/chameleon, /obj/item/clothing/under/chameleon/all)
+	var/blocked = list(/obj/item/clothing/under/chameleon, /obj/item/clothing/under/chameleon/all, /obj/item/clothing/under)
 	//to prevent an infinite loop
 	for(var/U in typesof(/obj/item/clothing/under)-blocked)
 		var/obj/item/clothing/under/V = new U


### PR DESCRIPTION
/obj/item/clothing/under, which has a broken icon_state since it's the parent

fixes #7339

tested
