### PR TITLE
Mommis/Engiborgs have magboots again

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1,6 +1,3 @@
-/mob/proc/CheckSlip()
-	return 0
-
 /mob/living/New()
 	. = ..()
 	generate_static_overlay()
@@ -1377,3 +1374,6 @@ default behaviour is:
 /mob/living/nuke_act() //Called when caught in a nuclear blast
 	health = 0
 	stat = DEAD
+
+/mob/proc/CheckSlip()
+	return 0

--- a/code/modules/mob/living/silicon/mommi/mommi.dm
+++ b/code/modules/mob/living/silicon/mommi/mommi.dm
@@ -457,6 +457,9 @@ They can only use one tool at a time, they can't choose modules, and they have 1
 /mob/living/silicon/robot/mommi/Move(a, b, flag)
 	..()
 
+/mob/living/silicon/robot/mommi/CheckSlip()
+	return -1
+
 /*
 /mob/living/silicon/robot/mommi/proc/ActivateKeeper()
 	set category = "Robot Commands"

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1535,3 +1535,6 @@
 
 /mob/living/silicon/robot/proc/help_shake_act(mob/user)
 	user.visible_message("<span class='notice'>[user.name] pats [src.name] on the head.</span>")
+
+/mob/living/silicon/robot/CheckSlip()
+	return (istype(module,/obj/item/weapon/robot_module/engineering)? -1 : 0)


### PR DESCRIPTION
All borgs were considered to have noslip shoes under the new checkslip system, but airflow is one step higher than noslip requiring magboots. So, mommis and magboots have that level of non-slippage now.
Fixes #7580