### PR TITLE
Comment added to sleepy pen define

### DIFF
--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -259,7 +259,7 @@ var/paperwork_library
 /*
  * Sleepy Pens
  */
-/obj/item/weapon/pen/sleepypen
+/obj/item/weapon/pen/sleepypen //this is not given to antagonists in the uplinks
 	desc = "It's a black ink pen with a sharp point and a carefully engraved \"Waffle Co.\""
 	flags = FPRINT  | OPENCONTAINER
 	slot_flags = SLOT_BELT


### PR DESCRIPTION
Sleepy pens might or might not be refillable, I haven't looked at syringe or beaker attack code, but there's no attackby code for it so.

Parapens never were.

Fixes #7118
