### PR TITLE
Vault datums

### DIFF
--- a/code/modules/randomMaps/vault_definitions.dm
+++ b/code/modules/randomMaps/vault_definitions.dm
@@ -1,0 +1,35 @@
+/datum/vault
+	var/list/exclusive_to_maps = list() //Only spawn on these maps (accepts nameShort and nameLong, for more info see maps/_map.dm). No effect if empty
+	var/list/map_blacklist = list() //Don't spawn on these maps
+
+	var/map_directory = "maps/randomVaults/"
+	var/map_name = "" //Don't include the preffix or "maps/randomVaults/". If the vault is maps/randomVaults/hell.dmm, this should be "hell"
+
+	var/only_spawn_once = 1 //If 0, this vault can spawn multiple times on a single map
+
+/datum/vault/proc/initialize(list/objects)
+	for(var/turf/new_turf in objects)
+		new_turf.flags |= NO_MINIMAP //Makes the spawned turfs invisible on minimaps
+
+//How to create a new vault:
+//1) create a map in maps/randomVaults/
+//2) create a new subtype of /datum/vault/ (look below for an example) and set its map_name to your map's filename (don't include the "dmm" part)
+//3) if you're an advanced user, feel free to play around with other variables
+
+/datum/vault/icetruck_crash
+	map_name = "icetruck_crash"
+
+/datum/vault/asteroid_temple
+	map_name = "asteroid_temple"
+
+/datum/vault/hivebot_factory
+	map_name = "hivebot_factory"
+
+/datum/vault/clown_base
+	map_name = "clown_base"
+
+/datum/vault/rust
+	map_name = "rust"
+
+/datum/vault/spacegym
+	map_name = "spacegym"

--- a/code/modules/randomMaps/vaults.dm
+++ b/code/modules/randomMaps/vaults.dm
@@ -8,20 +8,9 @@
 
 #define MINIMUM_VAULT_AMOUNT 1 //Amount of guaranteed vault spawns
 
-//#define SPAWN_ALL_VAULTS //Uncomment to spawn all existing vaults (otherwise only some will spawn)!
+#define SPAWN_ALL_VAULTS //Uncomment to spawn all existing vaults (otherwise only some will spawn)!
 
-var/const/vault_map_directory = "maps/randomVaults/"
-
-
-var/list/vault_map_names = list( //Add your vaults' map names to this list. Don't include the .dmm prefix
-	"icetruck_crash",
-	"asteroid_temple",
-	//"doomed_satelite", WARNING: this map is possessed. Uncommenting will cause bugs and general spookiness. Don't uncomment
-	"hivebot_factory",
-	"clown_base",
-	"rust",
-	"spacegym"
-)
+//List of spawnable vaults is in code/modules/randomMaps/vault_definitions.dm
 
 /area/random_vault
 	name = "random vault area"
@@ -50,25 +39,52 @@ var/list/vault_map_names = list( //Add your vaults' map names to this list. Don'
 /proc/generate_vaults()
 	var/area/space = get_space_area
 
-	var/list/list_of_vaults = shuffle(typesof(/area/random_vault) - /area/random_vault)
+	var/list/list_of_vault_spawners = shuffle(typesof(/area/random_vault) - /area/random_vault)
+	var/list/list_of_vaults = typesof(/datum/vault) - /datum/vault
+
+	for(var/vault_path in list_of_vaults) //Turn a list of paths into a list of objects
+		list_of_vaults.Add(new vault_path)
+		list_of_vaults.Remove(vault_path)
+
+	//Start processing the list of vaults
+
+	if(map.only_spawn_map_exclusive_vaults) //If the map spawns only map-exclusive vaults - remove all vaults that aren't exclusive to this map
+		for(var/datum/vault/V in list_of_vaults)
+
+			if(V.exclusive_to_maps.Find(map.nameShort) || V.exclusive_to_maps.Find(map.nameLong))
+				continue
+
+			list_of_vaults.Remove(V)
+	else //Map spawns all vaults - remove all vaults that are exclusive to other maps
+		for(var/datum/vault/V in list_of_vaults)
+
+			if(V.exclusive_to_maps.len)
+				if(!V.exclusive_to_maps.Find(map.nameShort) && !V.exclusive_to_maps.Find(map.nameLong))
+					list_of_vaults.Remove(V)
+
+	for(var/datum/vault/V in list_of_vaults) //Remove all vaults that can't spawn on this map
+		if(V.map_blacklist.len)
+			if(V.map_blacklist.Find(map.nameShort) || V.map_blacklist.Find(map.nameLong))
+				list_of_vaults.Remove(V)
+
 	var/failures = 0
 	var/successes = 0
-	var/vault_number = rand(MINIMUM_VAULT_AMOUNT, min(vault_map_names.len, list_of_vaults.len))
+	var/vault_number = rand(MINIMUM_VAULT_AMOUNT, min(list_of_vaults.len, list_of_vault_spawners.len))
 
 	#ifdef SPAWN_ALL_VAULTS
 	#warning Spawning all vaults!
-	vault_number = min(vault_map_names.len, list_of_vaults.len)
+	vault_number = min(list_of_vaults.len, list_of_vault_spawners.len)
 	#endif
 
-	message_admins("<span class='info'>Spawning [vault_number] vaults (in [list_of_vaults.len] areas)...</span>")
+	message_admins("<span class='info'>Spawning [vault_number] vaults (in [list_of_vault_spawners.len] areas)...</span>")
 
-	for(var/T in list_of_vaults) //Go through all subtypes of /area/random_vault
+	for(var/T in list_of_vault_spawners) //Go through all subtypes of /area/random_vault
 		var/area/A = locate(T) //Find the area
 
 		if(!A || !A.contents.len) //Area is empty and doesn't exist - skip
 			continue
 
-		if(vault_map_names.len > 0 && vault_number>0)
+		if(list_of_vaults.len > 0 && vault_number>0)
 			vault_number--
 
 			var/vault_x
@@ -81,15 +97,16 @@ var/list/vault_map_names = list( //Add your vaults' map names to this list. Don'
 			vault_y = TURF.y
 			vault_z = TURF.z
 
-			var/map_name = pick(vault_map_names)
-			vault_map_names.Remove(map_name)
+			var/datum/vault/new_vault = pick(list_of_vaults) //Pick a random path from list_of_vaults (like /datum/vault/spacegym)
 
-			var/path_file = "[vault_map_directory][pick(map_name)].dmm"
+			if(!new_vault.only_spawn_once)
+				list_of_vaults.Remove(new_vault)
+
+			var/path_file = "[new_vault.map_directory][new_vault.map_name].dmm"
 
 			if(fexists(path_file))
 				var/list/L = maploader.load_map(file(path_file), vault_z, vault_x, vault_y)
-				for(var/turf/new_turf in L)
-					new_turf.flags |= NO_MINIMAP //f u c k minimaps
+				new_vault.initialize(L)
 
 				message_admins("<span class='info'>Loaded [path_file]: [formatJumpTo(locate(vault_x, vault_y, vault_z))].")
 				successes++

--- a/code/modules/randomMaps/vaults.dm
+++ b/code/modules/randomMaps/vaults.dm
@@ -8,7 +8,7 @@
 
 #define MINIMUM_VAULT_AMOUNT 1 //Amount of guaranteed vault spawns
 
-#define SPAWN_ALL_VAULTS //Uncomment to spawn all existing vaults (otherwise only some will spawn)!
+//#define SPAWN_ALL_VAULTS //Uncomment to spawn all existing vaults (otherwise only some will spawn)!
 
 //List of spawnable vaults is in code/modules/randomMaps/vault_definitions.dm
 

--- a/maps/_map.dm
+++ b/maps/_map.dm
@@ -44,6 +44,9 @@
 	var/dorf = 0
 	var/linked_to_centcomm = 1
 
+	//If 1, only spawn vaults that are exclusive to this map (other vaults aren't spawned). For more info, see code/modules/randomMaps/vault_definitions.dm
+	var/only_spawn_map_exclusive_vaults = 0
+
 	// List of package tagger locations. Due to legacy shitcode you can only append or replace ones with null, or you'll break stuff.
 	var/list/default_tagger_locations = list(
 		DISP_DISPOSALS,

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -1592,6 +1592,7 @@
 #include "code\modules\projectiles\projectile\ricochet.dm"
 #include "code\modules\projectiles\projectile\rocket.dm"
 #include "code\modules\projectiles\projectile\special.dm"
+#include "code\modules\randomMaps\vault_definitions.dm"
 #include "code\modules\randomMaps\vaults.dm"
 #include "code\modules\RCD\engie.dm"
 #include "code\modules\RCD\RCD.dm"


### PR DESCRIPTION
- Vaults are now defined by datums in code/modules/randomMaps/vault_definitions.dm
- Vaults can now be exclusive to maps (so they only spawn on specified maps)
- Vaults can be set to not spawn on some maps (so they only spawn on other maps)
- Maps can be set to only spawn vaults that are exclusive to them (so vaults that aren't exclusive to any map don't get spawned)
- Vaults can be set to spawn multiple times (instead of 1 time per map)

This allows creating random structures that only spawn on a snow map and nowhere else, for example. Also allows vaults with working shuttles (the shuttles have to be created in the vault's initialize() proc).

Adding vaults is just as easy as it was before, but instead of adding the map's name to a list, you now have to add something like this to vault_definitions.dm

```
/datum/vault/icetruck_crash
    map_name = "icetruck_crash"
```
