### PR TITLE
fixes #8237

### DIFF
--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -46,8 +46,7 @@
 
 	if(stat & (NOPOWER | BROKEN) && id) //Power out/this thing is broken, but at least allow the guy to take his ID out if it's still in there.
 		id.forceMove(get_turf(src))
-		if(!user.get_active_hand()) //User's hand is empty.
-			user.put_in_hands(id)
+		user.put_in_hands(id)
 
 		to_chat(user, "<span class='notify'>You pry the ID card out of \the [src]</span>")
 		id = null
@@ -172,9 +171,8 @@
 			return
 
 		id.forceMove(get_turf(src))
-		if(!usr.get_active_hand()) //Nothing in the user's hand.
+		if(usr.Adjacent(src))
 			usr.put_in_hands(id)
-
 		id = null
 		updateUsrDialog()
 		return 1

--- a/code/modules/mining/ore_redemption.dm
+++ b/code/modules/mining/ore_redemption.dm
@@ -129,8 +129,7 @@
 	if(href_list["choice"])
 		if(istype(inserted_id))
 			if(href_list["choice"] == "eject")
-				inserted_id.loc = loc
-				inserted_id.verb_pickup()
+				inserted_id.forceMove(loc)
 				inserted_id = null
 			if(href_list["choice"] == "claim")
 				var/datum/money_account/acct = get_card_account(inserted_id)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -390,6 +390,8 @@ var/list/ai_list = list()
 
 	updatehealth()
 
+/mob/living/silicon/ai/put_in_hands(var/obj/item/W)
+	return 0
 
 /mob/living/silicon/ai/Topic(href, href_list)
 	if(usr != src)


### PR DESCRIPTION
fixes #8237

because of where this is in the code there's no mob to reference for adjacency checks, so the best bet is to just leave it on the same tile as the machine
