### PR TITLE
Adds Explosive Handcuffs as a Security-only Traitor item

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -154,6 +154,14 @@ var/list/uplink_items = list()
 	cost = 3
 	job = list("Clown", "Mime")
 
+//Security
+/datum/uplink_item/jobspecific/syndicuffs
+	name = "Syndicate Cuffs"
+	desc = "A pair of cuffs rigged with electronics and laced with a C4 charge. Can be toggled between explosion on application and explosion on removal."
+	item = /obj/item/weapon/handcuffs/syndicate
+	cost = 2
+	job = list("Security Officer", "Warden", "Head of Security")
+
 //Detective
 /datum/uplink_item/jobspecific/evidenceforger
 	name = "Evidence Forger"

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -1058,8 +1058,7 @@
 		cultist.unlock_from()
 		if (cultist.handcuffed)
 			cultist.handcuffed.loc = cultist.loc
-			cultist.handcuffed = null
-			cultist.update_inv_handcuffed()
+			cultist.handcuffed.handcuffs_remove(cultist)
 		if (cultist.legcuffed)
 			cultist.legcuffed.loc = cultist.loc
 			cultist.legcuffed = null

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -37,7 +37,7 @@
 			var/turf/p_loc_m = C.loc
 			playsound(get_turf(src), cuffing_sound, 30, 1, -2)
 			user.visible_message("<span class='danger'>[user] is trying to handcuff \the [C]!</span>", \
-								 "<span class='danger'>You try to handcuff on \the [C]!</span>")
+								 "<span class='danger'>You try to handcuff \the [C]!</span>")
 			if(do_after(user, C, 30))
 				if(!C)
 					return
@@ -140,10 +140,10 @@
 	switch(mode)
 		if(SYNDICUFFS_ON_REMOVE)
 			mode = SYNDICUFFS_ON_APPLY
-			user << "<span class='notice'>You pull the rotating arm back until you hear two clicks. \The [src] will detonate a few seconds after being applied.</span>"
+			to_chat(user, "<span class='notice'>You pull the rotating arm back until you hear two clicks. \The [src] will detonate a few seconds after being applied.</span>")
 		if(SYNDICUFFS_ON_APPLY)
 			mode = SYNDICUFFS_ON_REMOVE
-			user << "<span class='notice'>You pull the rotating arm back until you hear one click. \The [src] will detonate when removed.</span>"
+			to_chat(user, "<span class='notice'>You pull the rotating arm back until you hear one click. \The [src] will detonate when removed.</span>")
 
 //C4 and EMPs don't mix, will always explode at severity 1, and likely to explode at severity 2
 /obj/item/weapon/handcuffs/syndicate/emp_act(severity)

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -1,3 +1,7 @@
+#define NOT_SYNDICUFFS 0
+#define SYNDICUFFS_ON_APPLY 1
+#define SYNDICUFFS_ON_REMOVE 2
+
 /obj/item/weapon/handcuffs
 	name = "handcuffs"
 	desc = "Use this to keep prisoners in line."
@@ -15,45 +19,44 @@
 	w_type = RECYK_METAL
 	melt_temperature = MELTPOINT_STEEL
 	origin_tech = "materials=1"
+	var/cuffing_sound = 'sound/weapons/handcuffs.ogg'
 	var/dispenser = 0
 	var/breakouttime = 1200 //Deciseconds = 120s = 2 minutes
+	var/mode = NOT_SYNDICUFFS //Handled at this level, Syndicate Cuffs code
+	var/charge_detonated = 0
 
 /obj/item/weapon/handcuffs/attack(mob/living/carbon/C as mob, mob/user as mob)
-	if(!istype(C)) return
+
+	if(!istype(C))
+		return
+
+	//This one is not handled by the general code because Cyborgs in charge of not making shitcode worse
 	if(istype(src, /obj/item/weapon/handcuffs/cyborg) && isrobot(user))
 		if(!C.handcuffed)
 			var/turf/p_loc = user.loc
 			var/turf/p_loc_m = C.loc
-			playsound(get_turf(src), 'sound/weapons/handcuffs.ogg', 30, 1, -2)
-			for(var/mob/O in viewers(user, null))
-				O.show_message("<span class='danger'>[user] is trying to put handcuffs on [C]!</span>", 1)
+			playsound(get_turf(src), cuffing_sound, 30, 1, -2)
+			user.visible_message("<span class='danger'>[user] is trying to handcuff \the [C]!</span>", \
+								 "<span class='danger'>You try to handcuff on \the [C]!</span>")
 			if(do_after(user, C, 30))
-				if(!C)	return
+				if(!C)
+					return
 				if(p_loc == user.loc && p_loc_m == C.loc)
 					C.handcuffed = new /obj/item/weapon/handcuffs(C)
 					C.update_inv_handcuffed()
 
 	else
-		if ((M_CLUMSY in usr.mutations) && prob(50))
-			to_chat(usr, "<span class='warning'>Uh ... how do those things work?!</span>")
-			if (istype(C, /mob/living/carbon/human))
-				if(!C.handcuffed)
-					var/obj/effect/equip_e/human/O = new /obj/effect/equip_e/human(  )
-					O.source = user
-					O.target = user
-					O.item = user.get_active_hand()
-					O.s_loc = user.loc
-					O.t_loc = user.loc
-					O.place = "handcuff"
-					C.requests += O
-					spawn( 0 )
-						O.process()
+		if((M_CLUMSY in user.mutations) && prob(50))
+			if(ishuman(C))
+				handcuffs_apply(C, user)
 				return
 			return
-		if (!usr.dexterity_check())
+
+		if(!user.dexterity_check())
 			to_chat(usr, "<span class='warning'>You don't have the dexterity to do this!</span>")
 			return
-		if (istype(C, /mob/living/carbon/human))
+
+		if(ishuman(C))
 			if(!C.handcuffed)
 				C.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been handcuffed (attempt) by [user.name] ([user.ckey])</font>")
 				user.attack_log += text("\[[time_stamp()]\] <font color='red'>Attempted to handcuff [C.name] ([C.ckey])</font>")
@@ -64,41 +67,137 @@
 
 				log_attack("<font color='red'>[user.name] ([user.ckey]) Attempted to handcuff [C.name] ([C.ckey])</font>")
 
-				var/obj/effect/equip_e/human/O = new /obj/effect/equip_e/human(  )
-				O.source = user
-				O.target = C
-				O.item = user.get_active_hand()
-				O.s_loc = user.loc
-				O.t_loc = C.loc
-				O.place = "handcuff"
-				C.requests += O
-				spawn( 0 )
-					if(istype(src, /obj/item/weapon/handcuffs/cable))
-						feedback_add_details("handcuffs","C")
-						playsound(get_turf(src), 'sound/weapons/cablecuff.ogg', 30, 1, -2)
-					else
-						feedback_add_details("handcuffs","H")
-						playsound(get_turf(src), 'sound/weapons/handcuffs.ogg', 30, 1, -2)
-					O.process()
+				handcuffs_apply(C, user)
 			return
 		else
 			if(!C.handcuffed)
-				var/obj/effect/equip_e/monkey/O = new /obj/effect/equip_e/monkey(  )
-				O.source = user
-				O.target = C
-				O.item = user.get_active_hand()
-				O.s_loc = user.loc
-				O.t_loc = C.loc
-				O.place = "handcuff"
-				C.requests += O
-				spawn( 0 )
-					if(istype(src, /obj/item/weapon/handcuffs/cable))
-						playsound(get_turf(src), 'sound/weapons/cablecuff.ogg', 30, 1, -2)
-					else
-						playsound(get_turf(src), 'sound/weapons/handcuffs.ogg', 30, 1, -2)
-					O.process()
+				handcuffs_apply(C, user)
 			return
+
+/obj/item/weapon/handcuffs/proc/detonate(var/countdown = 1)
+
 	return
+
+//Our inventory procs should be able to handle the following, but our inventory code is hot spaghetti bologni, so here we go
+/obj/item/weapon/handcuffs/proc/handcuffs_apply(mob/living/carbon/C as mob, mob/user as mob)
+
+	if(!istype(C)) //Sanity doesn't hurt, right ?
+		return
+
+	if(ishuman(C))
+		var/obj/effect/equip_e/human/O = new /obj/effect/equip_e/human()
+		O.source = user
+		if(M_CLUMSY in user.mutations)
+			O.target = user
+			O.t_loc = user.loc
+		else
+			O.target = C
+			O.t_loc = C.loc
+		O.item = user.get_active_hand()
+		O.s_loc = user.loc
+		O.place = "handcuff"
+		C.requests += O
+		spawn()
+			if(istype(src, /obj/item/weapon/handcuffs/cable))
+				feedback_add_details("handcuffs", "C")
+			else
+				feedback_add_details("handcuffs", "H")
+			playsound(get_turf(src), cuffing_sound, 30, 1, -2)
+			O.process()
+			if(mode == SYNDICUFFS_ON_APPLY && !charge_detonated)
+				detonate(1)
+	else
+		var/obj/effect/equip_e/monkey/O = new /obj/effect/equip_e/monkey()
+		O.source = user
+		O.target = C
+		O.item = user.get_active_hand()
+		O.s_loc = user.loc
+		O.t_loc = C.loc
+		O.place = "handcuff"
+		C.requests += O
+		spawn()
+			playsound(get_turf(src), cuffing_sound, 30, 1, -2)
+			O.process()
+			if(mode == SYNDICUFFS_ON_APPLY && !charge_detonated)
+				detonate(1)
+
+/obj/item/weapon/handcuffs/proc/handcuffs_remove(var/mob/living/carbon/C)
+
+	if(mode == SYNDICUFFS_ON_REMOVE && !charge_detonated)
+		detonate(0) //This handles cleaning up the inventory already
+	else
+		C.handcuffed = null
+		C.update_inv_handcuffed()
+
+//Syndicate Cuffs. Disguised as regular cuffs, they are pretty explosive
+/obj/item/weapon/handcuffs/syndicate
+
+	mode = SYNDICUFFS_ON_APPLY
+	var/countdown_time = 30
+
+/obj/item/weapon/handcuffs/syndicate/attack_self(mob/user)
+
+	switch(mode)
+		if(SYNDICUFFS_ON_REMOVE)
+			mode = SYNDICUFFS_ON_APPLY
+			user << "<span class='notice'>You pull the rotating arm back until you hear two clicks. \The [src] will detonate a few seconds after being applied.</span>"
+		if(SYNDICUFFS_ON_APPLY)
+			mode = SYNDICUFFS_ON_REMOVE
+			user << "<span class='notice'>You pull the rotating arm back until you hear one click. \The [src] will detonate when removed.</span>"
+
+//C4 and EMPs don't mix, will always explode at severity 1, and likely to explode at severity 2
+/obj/item/weapon/handcuffs/syndicate/emp_act(severity)
+
+	switch(severity)
+		if(1)
+			if(prob(80))
+				detonate(1)
+			else
+				detonate(0)
+		if(2)
+			if(prob(50))
+				detonate(1)
+
+/obj/item/weapon/handcuffs/syndicate/ex_act(severity)
+
+	switch(severity)
+		if(1)
+			if(!charge_detonated)
+				detonate(0)
+		if(2)
+			if(!charge_detonated)
+				detonate(0)
+		if(3)
+			if(!charge_detonated && prob(50))
+				detonate(1)
+		else
+			return
+
+	qdel(src)
+
+/obj/item/weapon/handcuffs/syndicate/detonate(countdown)
+
+	if(charge_detonated)
+		return
+	charge_detonated = 1 //Do it before countdown to prevent spam fuckery
+	if(countdown)
+		//Cannot use a sleep() instruction here since we do NOT want to delay inventory handling
+		spawn(countdown_time)
+			explosion(get_turf(src), 0, 1, 3, 0)
+			qdel(src)
+	else
+		explosion(get_turf(src), 0, 1, 3, 0)
+		qdel(src)
+
+/obj/item/weapon/handcuffs/Destroy()
+
+	if(iscarbon(loc)) //Inventory shit
+		var/mob/living/carbon/C = loc
+		if(C.handcuffed)
+			C.handcuffed.loc = C.loc //Standby while we delete this shit
+			C.drop_from_inventory(src)
+
+	..()
 
 /obj/item/weapon/handcuffs/cable
 	name = "cable restraints"
@@ -106,6 +205,7 @@
 	icon_state = "cuff_red"
 	_color = "red"
 	breakouttime = 300 //Deciseconds = 30s
+	cuffing_sound = 'sound/weapons/cablecuff.ogg'
 
 /obj/item/weapon/handcuffs/cable/red
 	icon_state = "cuff_red"
@@ -158,20 +258,3 @@
 		to_chat(user, "<span class='notice'>You wrap the cable restraint around the top of the rod.</span>")
 
 		qdel(src)
-
-/* mite b cool - N3X
-/obj/item/weapon/handcuffs/cyborg/attack(mob/living/carbon/C, mob/user)
-	if(isrobot(user))
-		if(!C.handcuffed)
-			var/turf/user_loc = user.loc
-			var/turf/C_loc = C.loc
-			playsound(loc, 'sound/weapons/handcuffs.ogg', 30, 1, -2)
-			C.visible_message("<span class='danger'>[user] is trying to put handcuffs on [C]!</span>", \
-								"<span class='userdanger'>[user] is trying to put handcuffs on [C]!</span>")
-			if(do_after(user, C, 30))
-				if(!C || C.handcuffed)
-					return
-				if(user_loc == user.loc && C_loc == C.loc)
-					C.handcuffed = new /obj/item/weapon/handcuffs(C)
-					C.update_inv_handcuffed(0)
-*/

--- a/code/game/objects/items/weapons/implants/implantfreedom.dm
+++ b/code/game/objects/items/weapons/implants/implantfreedom.dm
@@ -22,8 +22,7 @@
 			to_chat(source, "You feel a faint click.")
 			if (source.handcuffed)
 				var/obj/item/weapon/W = source.handcuffed
-				source.handcuffed = null
-				source.update_inv_handcuffed()
+				source.handcuffed.handcuffs_remove(source)
 				if (source.client)
 					source.client.screen -= W
 				if (W)

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -188,12 +188,10 @@
 
 /obj/item/weapon/wirecutters/attack(mob/living/carbon/C as mob, mob/user as mob)
 	if((iscarbon(C)) && (C.handcuffed) && (istype(C.handcuffed, /obj/item/weapon/handcuffs/cable)))
-		usr.visible_message("\The [usr] cuts \the [C]'s restraints with \the [src]!",\
-		"You cut \the [C]'s restraints with \the [src]!",\
+		usr.visible_message("\The [user] cuts \the [C]'s [C.handcuffed.name] with \the [src]!",\
+		"You cut \the [C]'s [C.handcuffed.name] with \the [src]!",\
 		"You hear cable being cut.")
-		C.handcuffed.loc = null	//garbage collector awaaaaay
-		C.handcuffed = null
-		C.update_inv_handcuffed()
+		qdel(C.handcuffed)
 		return
 	else
 		..()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -421,9 +421,8 @@
 	var/success = 0
 	if(!W)	return 0
 	else if (W == handcuffed)
-		handcuffed = null
+		handcuffed.handcuffs_remove(src)
 		success = 1
-		update_inv_handcuffed()
 
 	else if (W == legcuffed)
 		legcuffed = null

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -11,7 +11,7 @@
 					  // life should decrease this by 1 every tick
 	// total amount of wounds on mob, used to spread out healing and the like over all wounds
 	var/number_wounds = 0
-	var/obj/item/handcuffed = null //Whether or not the mob is handcuffed
+	var/obj/item/weapon/handcuffs/handcuffed = null //Whether or not the mob is handcuffed.
 	var/obj/item/legcuffed = null  //Same as handcuffs but for legs. Bear traps use this.
 	//Surgery info
 	var/datum/surgery_status/op_stage = new/datum/surgery_status

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -535,7 +535,7 @@
 		if(isrobot(source) && place != "handcuff")
 			qdel(src)
 		for(var/mob/O in viewers(target, null))
-			O.show_message("<span class='danger'>[source] is trying to put [item.gender == PLURAL ? "[item]" : "\a [item]"] on [target]</span>", 1)
+			O.show_message("<span class='danger'>[source] is trying to put [item.gender == PLURAL ? "\the [item]" : "\a [item]"] on [target]</span>", 1)
 	else
 		var/message=null
 		switch(place)

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -177,9 +177,9 @@
 	return null
 
 /mob/living/carbon/human/proc/has_organ(name)
-	var/datum/organ/external/O = organs_by_name[name]
 
-	return (O && !(O.status & ORGAN_DESTROYED) )
+	var/datum/organ/external/O = organs_by_name[name]
+	return O.is_existing()
 
 /mob/living/carbon/human/proc/has_organ_for_slot(slot)
 	switch(slot)
@@ -299,9 +299,8 @@
 		success = 1
 		update_inv_back()
 	else if (W == handcuffed)
-		handcuffed = null
+		handcuffed.handcuffs_remove(src)
 		success = 1
-		update_inv_handcuffed()
 	else if (W == legcuffed)
 		legcuffed = null
 		success = 1
@@ -536,7 +535,7 @@
 		if(isrobot(source) && place != "handcuff")
 			qdel(src)
 		for(var/mob/O in viewers(target, null))
-			O.show_message("<span class='danger'>[source] is trying to put \a [item] on [target]</span>", 1)
+			O.show_message("<span class='danger'>[source] is trying to put [item.gender == PLURAL ? "[item]" : "\a [item]"] on [target]</span>", 1)
 	else
 		var/message=null
 		switch(place)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -954,9 +954,6 @@ var/global/list/damage_icon_parts = list()
 		O.icon_state = "handcuff1"
 		overlays += O
 		obj_overlays[HANDCUFF_LAYER] = O
-		//overlays_standing[HANDCUFF_LAYER]	= image("icon" = 'icons/mob/mob.dmi', "icon_state" = "handcuff1")
-	//else
-		//overlays_standing[HANDCUFF_LAYER]	= null
 
 	if(update_icons)   update_icons()
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -961,8 +961,7 @@ Thanks.
 										   "<span class='notice'>You successfuly break your handcuffs.</span>")
 						CM.say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" ))
 						qdel(CM.handcuffed)
-						CM.handcuffed = null
-						CM.update_inv_handcuffed()
+						CM.handcuffed.handcuffs_remove(CM)
 					else
 						to_chat(CM, "<span class='warning'>Your cuff breaking attempt was interrupted.</span>")
 
@@ -983,8 +982,7 @@ Thanks.
 										   "<span class='notice'>You successfuly remove [HC].</span>",
 										   self_drugged_message="<span class='notice'>You successfully regain control of your hands.</span>")
 						CM.handcuffed.loc = usr.loc
-						CM.handcuffed = null
-						CM.update_inv_handcuffed()
+						CM.handcuffed.handcuffs_remove(CM)
 					else
 						CM.simple_message("<span class='warning'>Your uncuffing attempt was interrupted.</span>",
 							"<span class='warning'>Your attempt to regain control of your hands was interrupted. Damn it!</span>")


### PR DESCRIPTION
This is one of the two Security-only Traitor items I have planned, took long enough and caused enough modifications to get a first PR
- Adds Syndicate Handcuffs (Stylized Syndicuffs). Those look like handcuffs on every aspect, but they contain a C4 charge and are filled with electronics. They cost 2 TC for every unit
- The handcuffs have two modes, they either explode three seconds after being engaged (someone is handcuffed) or immediately when disengaged (handcuffs are removed for any reason). Modes are toggled by pulling the rotating arm all the way back (using the handcuffs)
- Explosion is a (0, 1, 3). This will crit the target and might breach the hull, and will "lightly" (will generally lead to internal bleeding and fractures) damage anyone close by
- Handcuffs can be triggered prematurely by explosions or EMP blasts (might not work when in a mob's inventory due to spaghetti code as far as explosions go, EMPs should be fine as demonstrated by headsets and such)
- Added new procs to handle handcuffs application, removal and deletion. This was done to have the required procs actually work without shitcoding in the inventory file, but could be of use later
- Added a sound var to remove a few lines of shitcode, also allows custom sounds for your top-tier adminbus cuffs
- Fixed handcuffing message (used to be 'User is trying to put a handcuffs on Shitler'), used a plural check so that at least this one is fixed
- Updated a bunch of things related to those changes

Explosive Handcuffs cost as much as C4 (2 TC). The balance reasoning is that Explosive Handcuffs can be easily sneaked in on a -somewhat- innocent Security Officer, are not obvious to onlookers until it blows up, can be applied without causing alarm and can cause slightly more serious damage around the target, BUT it does not gib the target, meaning he can easily be dragged off to be cloned unlike the block of C4 which will literally remove the target outside of its head, which can be picked up and binned, or cut open and used for a braincake.
