### PR TITLE
Small Change to movement_speed_modifer

### DIFF
--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -193,7 +193,7 @@
 	var/move_on_shuttle = 1 // Can move on the shuttle.
 	var/captured = 0 //Functionally, should give the same effect as being buckled into a chair when true.
 
-	var/movement_speed_modifier = 0
+	var/movement_speed_modifier = 1
 
 //Generic list for proc holders. Only way I can see to enable certain verbs/procs. Should be modified if needed.
 	var/proc_holder_list[] = list()//Right now unused.


### PR DESCRIPTION
I didn't realize until just now that it would make more sense for the modifier to be 1 by default instead of 0.
