### PR TITLE
Makes Bolas Launcher work on more mechs not just Gygax.

### DIFF
--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -429,11 +429,6 @@
 	projectile_energy_cost = 50
 	equip_cooldown = 10
 
-/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/bolas/can_attach(obj/mecha/combat/gygax/M as obj)
-	if(..())
-		if(istype(M))
-			return 1
-	return 0
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/bolas/action(target)
 	if(!action_checks(target)) return

--- a/html/changelogs/coldcola.yml
+++ b/html/changelogs/coldcola.yml
@@ -1,0 +1,4 @@
+author: coldcola
+delete-after: True
+changes:
+- tweak: Removes Gygax-only Bolas Launcher restriction.


### PR DESCRIPTION
Seems this was left in and no one took it out, tested and ready if this is a warranted fix.
closes #8997.
