### PR TITLE
area turrets no longer rely on an area's type to work

### DIFF
--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -2098,6 +2098,7 @@ proc/process_adminbus_teleport_locs()
 		if(Obj:client)
 			mysound.status = SOUND_PAUSED | SOUND_UPDATE
 			Obj << mysound
+	..()
 
 /area/awaymission/beach/proc/process()
 	//set background = 1

--- a/code/game/area/ai_monitored.dm
+++ b/code/game/area/ai_monitored.dm
@@ -22,5 +22,5 @@
 /area/ai_monitored/Exited(atom/movable/O)
 	if (ismob(O) && motioncamera)
 		motioncamera.lostTarget(O)
-
+	..()
 

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -7,6 +7,8 @@
 	var/uid
 	var/obj/machinery/power/apc/areaapc = null
 	var/list/area_turfs
+	var/turret_protected = 0
+	var/list/turretTargets = list()
 
 /area/New()
 	area_turfs = list()
@@ -417,6 +419,30 @@
 			spawn(600) // Ewww - this is very very bad.
 				if(M && M.client)
 					M.client.ambience_playing = 0
+
+	if(turret_protected)
+		if(isliving(Obj))
+			turretTargets |= Obj
+		else if(istype(Obj, /obj/mecha))
+			var/obj/mecha/Mech = Obj
+			if(Mech.occupant)
+				turretTargets |= Mech
+		// /vg/ vehicles
+		else if(istype(Obj, /obj/structure/bed/chair/vehicle))
+			turretTargets |= Obj
+		return 1
+
+/area/Exited(atom/movable/Obj)
+	if(turret_protected)
+		if(Obj in turretTargets)
+			turretTargets -= Obj
+	..()
+
+/area/proc/subjectDied(target)
+	if(isliving(target))
+		var/mob/living/L = target
+		if(L.stat)
+			src.Exited(L)
 
 /area/proc/gravitychange(var/gravitystate = 0, var/area/A)
 

--- a/html/changelogs/Inturrets.yml
+++ b/html/changelogs/Inturrets.yml
@@ -1,0 +1,5 @@
+author: Intigracy
+delete-after: True
+changes: 
+- tweak: "Turrets that protect areas (AI turrets basically) can now be set to shoot at silicons (except AIs), or to have a faction (which all mobs also have, default is neutral) that it won't shoot other members of."
+- tweak: "Turrets set to stun now shoot mobs it would only shoot at when set to lasers before. It still doesn't stun them, it's just to show the turrets are working."


### PR DESCRIPTION
1. Area turrets now check if the area it's in has turret_protected set. If it doesn't, the turret deletes itself and yells at admins.
2. area/turret_protected/ is now simply for the var to be set, rather than having a bunch of procs unique to it. The procs are now on area/
3. Area turrets now have a faction var. Self explanatory, it won't shoot things that have the same faction var, just like simple mobs. The faction var check is before all other checks, so in no instance will a turret shoot something that's the same faction as it.
4. Area turrets now have a shootsilicon var, this is mostly for vault usage. I'm willing to add this as a toggle to all turret controls if the want is great enough.
5. Turrets set to stun now shoot mobs it would before only shoot while set to lethal. The exception is for mobs that are knocked down from being stunned (or are dead), the turrets set to stun stop shooting them just as before.
6. Added a /destroy() proc for turrets since it has a cover var.
7. A bunch of partial pathing fixing.

Tested as best I can.
