### PR TITLE
fixes defib recharger deconstruction

### DIFF
--- a/code/game/machinery/defibcharger.dm
+++ b/code/game/machinery/defibcharger.dm
@@ -82,7 +82,8 @@ obj/machinery/recharger/defibcharger/wallcharger/process()
 /obj/machinery/recharger/defibcharger/wallcharger/crowbarDestroy()
 	if(..() == 1)
 		if(charging)
-			charging.loc = src.loc
+			charging.forceMove(src.loc)
+			charging = null
 		return 1
 	return -1
 
@@ -98,5 +99,7 @@ obj/machinery/recharger/defibcharger/wallcharger/attackby(obj/item/weapon/G as o
 			charging = G
 			use_power = 2
 			update_icon()
+	else if (isscrewdriver(G) || iscrowbar(G))
+		..()
 	else
 		to_chat(user, "<span class='warning'>\The [G] isn't a defibrillator, it won't fit!</span>")


### PR DESCRIPTION
oops

It still has the old behavior though, it's going to create a machine assembly on the tile the defib recharger is on (not the wall), and you can't put them on walls since they're machine assemblies obviously.

Should be made to be like the other wall assemblies tbh, with an item you slap on the wall and then you can apply the rest of the shit (circuitboard) after that. Same should be done with the rechargers in mining.
