### PR TITLE
Cargo is now seperate on the crew manifest and the jobban menu

### DIFF
--- a/code/defines/obj.dm
+++ b/code/defines/obj.dm
@@ -54,6 +54,7 @@
 	var/list/eng = new()
 	var/list/med = new()
 	var/list/sci = new()
+	var/list/cgo = new()
 	var/list/civ = new()
 	var/list/bot = new()
 	var/list/misc = new()
@@ -108,6 +109,9 @@
 		if(real_rank in science_positions)
 			sci[name] = rank
 			department = 1
+		if(real_rank in cargo_positions)
+			cgo[name] = rank
+			department = 1
 		if(real_rank in civilian_positions)
 			civ[name] = rank
 			department = 1
@@ -121,37 +125,50 @@
 		for(name in heads)
 			dat += "<tr[even ? " class='alt'" : ""]><td>[name]</td><td>[heads[name]]</td><td>[isactive[name]]</td></tr>"
 			even = !even
+
 	if(sec.len > 0)
 		dat += "<tr><th colspan=3>Security</th></tr>"
 		for(name in sec)
 			dat += "<tr[even ? " class='alt'" : ""]><td>[name]</td><td>[sec[name]]</td><td>[isactive[name]]</td></tr>"
 			even = !even
+
 	if(eng.len > 0)
 		dat += "<tr><th colspan=3>Engineering</th></tr>"
 		for(name in eng)
 			dat += "<tr[even ? " class='alt'" : ""]><td>[name]</td><td>[eng[name]]</td><td>[isactive[name]]</td></tr>"
 			even = !even
+
 	if(med.len > 0)
 		dat += "<tr><th colspan=3>Medical</th></tr>"
 		for(name in med)
 			dat += "<tr[even ? " class='alt'" : ""]><td>[name]</td><td>[med[name]]</td><td>[isactive[name]]</td></tr>"
 			even = !even
+
 	if(sci.len > 0)
 		dat += "<tr><th colspan=3>Science</th></tr>"
 		for(name in sci)
 			dat += "<tr[even ? " class='alt'" : ""]><td>[name]</td><td>[sci[name]]</td><td>[isactive[name]]</td></tr>"
 			even = !even
+
+	if(cgo.len > 0)
+		dat += "<tr><th colspan=3>Cargo</th></tr>"
+		for(name in cgo)
+			dat += "<tr[even ? " class='alt'" : ""]><td>[name]</td><td>[cgo[name]]</td><td>[isactive[name]]</td></tr>"
+			even = !even
+
 	if(civ.len > 0)
 		dat += "<tr><th colspan=3>Civilian</th></tr>"
 		for(name in civ)
 			dat += "<tr[even ? " class='alt'" : ""]><td>[name]</td><td>[civ[name]]</td><td>[isactive[name]]</td></tr>"
 			even = !even
+
 	// in case somebody is insane and added them to the manifest, why not
 	if(bot.len > 0)
 		dat += "<tr><th colspan=3>Silicon</th></tr>"
 		for(name in bot)
 			dat += "<tr[even ? " class='alt'" : ""]><td>[name]</td><td>[bot[name]]</td><td>[isactive[name]]</td></tr>"
 			even = !even
+
 	// misc guys
 	if(misc.len > 0)
 		dat += "<tr><th colspan=3>Miscellaneous</th></tr>"
@@ -182,6 +199,7 @@ var/global/list/PDA_Manifest = list()
 	var/eng[0]
 	var/med[0]
 	var/sci[0]
+	var/cgo[0]
 	var/civ[0]
 	var/bot[0]
 	var/misc[0]
@@ -191,7 +209,7 @@ var/global/list/PDA_Manifest = list()
 		var/real_rank = t.fields["real_rank"]
 		var/isactive = t.fields["p_stat"]
 		var/department = 0
-		var/depthead = 0 			// Department Heads will be placed at the top of their lists.
+		var/depthead = 0 			// Department Heads will be placed at the top of their lists. Too bad all the procs that get the manifest call get_manifest(), which can't do this without a rewrite.
 		if(real_rank in command_positions)
 			heads[++heads.len] = list("name" = name, "rank" = rank, "active" = isactive)
 			department = 1
@@ -223,6 +241,12 @@ var/global/list/PDA_Manifest = list()
 			if(depthead && sci.len != 1)
 				sci.Swap(1,sci.len)
 
+		if(real_rank in cargo_positions)
+			cgo[++cgo.len] = list("name" = name, "rank" = rank, "active" = isactive)
+			department = 1
+			if(depthead && cgo.len != 1)
+				cgo.Swap(1,cgo.len)
+
 		if(real_rank in civilian_positions)
 			civ[++civ.len] = list("name" = name, "rank" = rank, "active" = isactive)
 			department = 1
@@ -243,6 +267,7 @@ var/global/list/PDA_Manifest = list()
 		"eng" = eng,\
 		"med" = med,\
 		"sci" = sci,\
+		"cgo" = cgo,\
 		"civ" = civ,\
 		"bot" = bot,\
 		"misc" = misc\

--- a/code/game/jobs/jobs.dm
+++ b/code/game/jobs/jobs.dm
@@ -94,14 +94,19 @@ var/list/civilian_positions = list(
 	"Chef",
 	"Janitor",
 	"Librarian",
-	"Quartermaster",
-	"Cargo Technician",
-	"Shaft Miner",
 	"Internal Affairs Agent",
 	"Chaplain",
+	"Clown",
+	"Mime",
 	"Assistant"
 )
 
+var/list/cargo_positions = list(
+	"Head of Personnel",
+	"Quartermaster",
+	"Cargo Technician",
+	"Shaft Miner"
+)
 
 var/list/security_positions = list(
 	"Head of Security",
@@ -109,7 +114,6 @@ var/list/security_positions = list(
 	"Detective",
 	"Security Officer"
 )
-
 
 var/list/nonhuman_positions = list(
 	"AI",

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -148,10 +148,12 @@
 	data["all_centcom_access"] = null
 	data["regions"] = null
 
+	data["head_jobs"] = format_jobs(command_positions)
 	data["engineering_jobs"] = format_jobs(engineering_positions)
 	data["medical_jobs"] = format_jobs(medical_positions)
 	data["science_jobs"] = format_jobs(science_positions)
 	data["security_jobs"] = format_jobs(security_positions)
+	data["cargo_jobs"] = format_jobs(cargo_positions)
 	data["civilian_jobs"] = format_jobs(civilian_positions)
 	data["centcom_jobs"] = format_jobs(get_all_centcom_jobs())
 	data["card_skins"] = format_card_skins(card_skins)

--- a/code/modules/Economy/Job_Departments.dm
+++ b/code/modules/Economy/Job_Departments.dm
@@ -20,8 +20,6 @@ var/list/station_departments = list("Command", "Medical", "Engineering", "Scienc
 
 /datum/job/hydro/department = "Civilian"
 
-/datum/job/mining/department = "Civilian"
-
 /datum/job/janitor/department = "Civilian"
 
 /datum/job/librarian/department = "Civilian"
@@ -30,10 +28,16 @@ var/list/station_departments = list("Command", "Medical", "Engineering", "Scienc
 
 /datum/job/chaplain/department = "Civilian"
 
+/datum/job/clown/department = "Civilian"
+
+/datum/job/mime/department = "Civilian"
+
 /datum/job/qm/department = "Cargo"
 /datum/job/qm/head_position = 1
 
 /datum/job/cargo_tech/department = "Cargo"
+
+/datum/job/mining/department = "Cargo"
 
 /datum/job/chief_engineer/department = "Engineering"
 /datum/job/chief_engineer/head_position = 1

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -735,10 +735,27 @@
 				jobs += "</tr><tr align='center'>"
 				counter = 0
 
-		if(jobban_isbanned(M, "Internal Affairs Agent"))
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=Internal Affairs Agent;jobban4=\ref[M]'><font color=red>Internal Affairs Agent</font></a></td>"
-		else
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=Internal Affairs Agent;jobban4=\ref[M]'>Internal Affairs Agent</a></td>"
+		jobs += "</tr></table>"
+
+	//Cargo (Brown)
+		counter = 0
+		jobs += "<table cellpadding='1' cellspacing='0' width='100%'>"
+		jobs += "<tr bgcolor='b3a292'><th colspan='[length(cargo_positions)]'><a href='?src=\ref[src];jobban3=cargodept;jobban4=\ref[M]'>Cargo Positions</a></th></tr><tr align='center'>"
+		for(var/jobPos in cargo_positions)
+			if(!jobPos)	continue
+			var/datum/job/job = job_master.GetJob(jobPos)
+			if(!job) continue
+
+			if(jobban_isbanned(M, job.title))
+				jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=[job.title];jobban4=\ref[M]'><font color=red>[replacetext(job.title, " ", "&nbsp")]</font></a></td>"
+				counter++
+			else
+				jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=[job.title];jobban4=\ref[M]'>[replacetext(job.title, " ", "&nbsp")]</a></td>"
+				counter++
+
+			if(counter >= 5) //So things dont get squiiiiished!
+				jobs += "</tr><tr align='center'>"
+				counter = 0
 
 		jobs += "</tr></table>"
 
@@ -921,6 +938,12 @@
 					joblist += temp.title
 			if("civiliandept")
 				for(var/jobPos in civilian_positions)
+					if(!jobPos)	continue
+					var/datum/job/temp = job_master.GetJob(jobPos)
+					if(!temp) continue
+					joblist += temp.title
+			if("cargodept")
+				for(var/jobPos in cargo_positions)
 					if(!jobPos)	continue
 					var/datum/job/temp = job_master.GetJob(jobPos)
 					if(!temp) continue

--- a/html/changelogs/Intimanifest.yml
+++ b/html/changelogs/Intimanifest.yml
@@ -1,0 +1,6 @@
+author: Intigracy
+delete-after: True
+changes: 
+- tweak: "Cargo is now seperately listed on the crew manifest and jobban menu."
+- bugfix: "You can now once again get jobbanned from mime and clown. Mime and clown are once again listed on the ID computer's list of jobs."
+- bugfix: "There's no longer a floating 'Command' text on the ID computer, it's now properly filled with the command roles."

--- a/nano/templates/identification_computer.tmpl
+++ b/nano/templates/identification_computer.tmpl
@@ -134,13 +134,25 @@
           <div id="all-value.jobs" style='display: none;'>
             <table>
               <tr>
-                <th></th><th>Command</th>
-              </tr>
-              <tr>
                 <th>Special</th>
                 <td>
-                  {{:helper.link("Captain", '', {'choice' : 'assign', 'assign_target' : 'Captain'}, data.target_rank == 'Captain' ? 'disabled' : null)}}
                   {{:helper.link("Custom", '', {'choice' : 'assign', 'assign_target' : 'Custom'})}}
+                </td>
+              </tr>             
+			  <tr>
+                <th>Command</th>
+				<td>
+				  {{for data.head_jobs}}
+				    {{:helper.link(value.display_name, '', {'choice' : 'assign', 'assign_target' : value.job}, data.target_rank == value.job ? 'disabled' : null)}}
+				  {{/for}}
+				</td>
+              </tr>
+              <tr>
+                <th style="color: '#B3A292';">Cargo</th>
+                <td>
+                  {{for data.cargo_jobs}}
+                    {{:helper.link(value.display_name, '', {'choice' : 'assign', 'assign_target' : value.job}, data.target_rank == value.job ? 'disabled' : null)}}
+                  {{/for}}
                 </td>
               </tr>
               <tr>


### PR DESCRIPTION
- tweak: "Cargo is now seperately listed on the crew manifest and jobban menu."
- bugfix: "You can now once again get jobbanned from mime and clown. Mime and clown are once again listed on the ID computer's list of jobs."
- bugfix: "There's no longer a floating 'Command' text on the ID computer, it's now properly filled with the command roles."

Jobban menu. Note: Image was before I removed the duplicate IAA entry:
![2016-03-27_18-01-02](https://cloud.githubusercontent.com/assets/4043940/14070096/026df238-f457-11e5-8793-0613cc608dd6.png)

ID computer:
![2016-03-27_18-57-24](https://cloud.githubusercontent.com/assets/4043940/14070106/1755c892-f457-11e5-933e-298ac5834893.png)

I don't have an image for the crew manifest, but I've tested it with a few people.

fixes #2376
fixes #5514
