### PR TITLE
More chat fixes.

### DIFF
--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -76,6 +76,10 @@
 		if("vars")		return view_var_Topic(href,href_list,hsrc)
 		if("chat")		return chatOutput.Topic(href, href_list)
 
+	switch(href_list["action"])
+		if ("openLink")
+			src << link(href_list["link"])
+
 	..()	//redirect to hsrc.Topic()
 	//testing("[usr] topic call took [(world.timeofday - timestart)/10] seconds")
 

--- a/goon/browserassets/css/browserOutput.css
+++ b/goon/browserassets/css/browserOutput.css
@@ -11,9 +11,9 @@ html, body {
 }
 body {
 	background: #fff;
-    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-family: Verdana, "Helvetica Neue", Helvetica, Arial, sans-serif;
     font-size: 9pt;
-    line-height: 1.4;
+    line-height: 1.2;
 	overflow-x: hidden;
 	overflow-y: scroll;
 	word-wrap: break-word;

--- a/goon/browserassets/js/browserOutput.js
+++ b/goon/browserassets/js/browserOutput.js
@@ -771,12 +771,14 @@ $(function() {
 		if ($('.popup .changeFont').is(':visible')) {return;}
 		var popupContent = '<div class="head">Change Font</div>' +
 			'<div id="changeFont" class="changeFont">'+
-				'<a href="#" data-font="\'Helvetica Neue\', Helvetica, Arial" style="font-family: \'Helvetica Neue\', Helvetica, Arial;">Arial / Helvetica (Default)</a>'+
+				'<a href="#" data-font="Verdana" style="font-family: Verdana;">Verdana (Default)</a>'+
+				'<a href="#" data-font="\'Helvetica Neue\', Helvetica, Arial" style="font-family: \'Helvetica Neue\', Helvetica, Arial;">Arial / Helvetica</a>'+
 				'<a href="#" data-font="Times New Roman" style="font-family: Times New Roman;">Times New Roman</a>'+
 				'<a href="#" data-font="Georgia" style="font-family: Georgia;">Georgia</a>'+
-				'<a href="#" data-font="Verdana" style="font-family: Verdana;">Verdana</a>'+
 				'<a href="#" data-font="Courier New" style="font-family: Courier New;">Courier New</a>'+
 				'<a href="#" data-font="Lucida Console" style="font-family: Lucida Console;">Lucida Console</a>'+
+				'<a href="#" data-font="Wingdings" style="font-family: Wingdings;">Wingdings</a>'+
+				'<a href="#" data-font="Comic Sans MS" style="font-family: Comic Sans MS;">Comic Sans MS</a>'+
 			'</div>';
 		createPopup(popupContent, 200);
 	});

--- a/goon/code/datums/browserOutput.dm
+++ b/goon/code/datums/browserOutput.dm
@@ -179,7 +179,7 @@ For the main html chat area
 	iconCache[iconKey] << icon
 	var/iconData = iconCache.ExportText(iconKey)
 	var/list/partial = text2list(iconData, "{")
-	return copytext(partial[2], 3, -5)
+	return replacetext(copytext(partial[2], 3, -5), "\n", "")
 
 
 /proc/bicon(obj)


### PR DESCRIPTION
Fixes icons in chat, whoops.
Fixes links.
Sets default font to Verdana, changes line height to 1.2 (previously 1.4 which was a bit much)

Adds Wingdings and Comic Sans.
