### PR TITLE
Adds pre-commit Git hook to run `optipng` on staged images

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,15 @@
 CONTRIBUTING TO VGSTATION
 =========================
 
-1. **Only submit PRs that are ready to be pulled.**  PRs that are not ready will be closed.
-2. **Pull requests must be atomic.**  Change one set of related things at a time.  Bundling sucks for everyone.
-3. **Test your changes.**  PRs that do not compile will not be accepted.
-4. **Large changes require discussion.**  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  **MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.**
+# General rules
+
+* **Only submit PRs that are ready to be pulled.**  PRs that are not ready will be closed.
+* **Pull requests must be atomic.**  Change one set of related things at a time.  Bundling sucks for everyone.
+* **Test your changes.**  PRs that do not compile will not be accepted.
+* **Large changes require discussion.**  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  **MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.**
 
 It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.
+
+# Other considerations
+
+* If you're working with PNG and/or DMI files, you might want to check out and install the `pre-commit` git hook found [here](tools/git-hooks). This will automatically run `optipng` (if you have it) on your added/modified files, shaving off some bytes here and there.

--- a/tools/git-hooks/install-hooks.sh
+++ b/tools/git-hooks/install-hooks.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# List of client-sided Git hooks
+GIT_HOOKS="applypatch-msg pre-applypatch post-applypatch pre-commit prepare-commit-msg commit-msg
+post-commit pre-rebase post-checkout post-merge pre-auto-gc post-rewrite
+pre-push"
+
+BASEDIR=`dirname "$0"`
+REPO_ROOT=`git rev-parse --show-toplevel`
+REPO_GIT_DIR=`git rev-parse --git-dir`
+
+for hook in $GIT_HOOKS; do
+	if [ ! -f "$BASEDIR/$hook" ]; then
+		continue;
+	fi
+
+	if [ ! -e "$REPO_GIT_DIR/hooks/$hook" ]; then
+		ln -s `readlink -f "$BASEDIR/$hook"` "$REPO_GIT_DIR/hooks/$hook"
+		echo -e "\033[32m$hook: installed correctly\033[0m"
+	else
+		echo -e "\033[31m$hook: existing hook found, skipping...\033[0m"
+	fi
+done

--- a/tools/git-hooks/pre-commit
+++ b/tools/git-hooks/pre-commit
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+# This git hook runs optipng on any staged PNG (and DMI, obviously) before committing, and
+# updates the staged one with its optimized version automatically. optipng preserves PNG comments
+# by default, avoiding breaking DMI files.
+#
+# The script should be POSIX standard enough that you shouldn't encounter any problem using it,
+# provided your shell can find optipng.
+#
+# To install, just use the install-hooks.sh file provided in this directory, or copy this
+# file manually to .git/hooks. Remember that it needs execution permissions in order to work.
+#
+# If something breaks, bark at wwjnc.
+
+TAG="[optipng-hook]"
+OPTIPNG_NOT_FOUND_MSG="$TAG \033[31mCouldn't find optipng, aborting PNG optimization...\033[0m
+$TAG \033[31mPlease consider installing optipng before committing PNG/DMI files to the repo!\033[0m"
+
+# Retrieve added or changed PNG files on the commit (if any)
+PNG_FILES=`git diff --cached --diff-filter=AM --name-only | grep -i -e ".png\$" -e ".dmi\$"`
+[ -z "$PNG_FILES" ] && exit 0
+
+# Check if optipng is available
+command -v optipng > /dev/null 2>&1 || { echo -e "$OPTIPNG_NOT_FOUND_MSG"; exit 0; }
+
+# Process files
+echo "$TAG Optimizing staged image files..."
+for file in $PNG_FILES; do
+	if [ -f "$file" ]; then
+		before_size_str=`du -h --apparent-size "$file" | cut -f1`
+		before_size_bytes=`du -b "$file" | cut -f1`
+		optipng -quiet -clobber -keep -- "$file"
+		git add "$file"
+		after_size_str=`du -h --apparent-size "$file" | cut -f1`
+		after_size_bytes=`du -b "$file" | cut -f1`
+
+		if [ "$before_size_bytes" -eq "$after_size_bytes" ]; then
+			echo -e "$TAG \033[34m$file is already optimized.\033[0m"
+		else
+			percent=`echo "scale=2; 100 - 100*$after_size_bytes/$before_size_bytes" | bc`
+			echo -e "$TAG \033[32m$file was optimized from $before_size_str to $after_size_str ($percent% reduction)\033[0m"
+		fi
+	else
+		echo -e "$TAG \033[31mCouldn't find file $file, skipping...\033[0m"
+	fi
+done


### PR DESCRIPTION
>  I could not help but notice your PNGs were not optimized, vgstation13.

People with `optipng` installed (or in their PATH, whatever) can use this hook to run it automatically on every PNG/DMI staged before committing stuff, so the commits always have almost minimal size.

This needs to be enabled per-user, so you can choose not to ~~opt into the botnet~~ be a coolkid. Moving the `pre-commit` file to `.git/hooks` should be enough. I've also included a shell script to automatically install it—and maybe future hooks.

`optipng` preserves PNG comments so no DMI files ~~should~~will be exploding around.
