### PR TITLE
Adds Github issue template to the repo

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,47 @@
+<!--
+	If a specific field doesn't apply, remove it!
+	Anything inside tags like these is a comment and will not be displayed in the final issue.
+	Be careful not to write inside them!
+-->
+
+#### Description of issue
+
+
+
+#### Difference between expected and actual behavior
+
+
+
+#### Steps to reproduce 
+
+
+
+#### Specific information for locating
+<!-- e.g. an object name, paste specific message outputs... -->
+
+
+
+#### Length of time in which bug has been known to occur
+<!--
+	Be specific if you approximately know the time its been occurring
+	for—this can speed up finding the source. If you're not sure
+	about it, tell us too!
+-->
+
+
+
+#### Server revision
+<!-- Found with the "Show server revision" verb in the OOC tab in game. -->
+
+
+
+#### Issue bingo
+
+Please check whatever applies. More checkboxes checked increase your chances of not being yelled at by every contributor.
+
+<!-- Check these by writing an x inside the [ ] -->
+- [ ] Issue could be reproduced at least once
+- [ ] Issue could be reproduced by different players
+- [ ] Issue could be reproduced in multiple rounds
+- [ ] Issue happened in a recent (less than 7 days ago) round
+- [ ] [Couldn't find an existing issue about this](https://github.com/d3athrow/vgstation13/issues)


### PR DESCRIPTION
We made a Piratepad to write one for convenience, and this is the final result but with the memes removed from it. Github couldn't deal with them well enough.

The raw version of the file should show up in the text area automatically when someone tries to open a new issue. Hopefully they won't ignore it.

@PJB3005 @clusterfack 
