### PR TITLE
Adds Hyperthermia

### DIFF
--- a/html/changelogs/DrCelt.yml
+++ b/html/changelogs/DrCelt.yml
@@ -1,2 +1,11 @@
 author: DrCelt
-changes: []
+changes:
+- rscadd: Added hyperthermia or heat stroke, which occurs when the body absorbs too much heat.
+- rscadd: An early stage of hyperthermia symptoms include heavy sweating, rapid breathing and a fast, weak pulse. 
+- rscadd: Other signs and symptoms vary. Accompanying dehydration can produce nausea, vomiting, headaches, and low blood pressure leading to fainting or dizziness.
+- rscadd: In severe heat stroke, there may be confused, hostile, or seemingly intoxicated behavior, directional movement may be different and will have a chance to not be able to use machinery.
+- rscadd: Eventually, Organ failure, unconciousness, and death will result.
+- tweak: Tweaked plasmafloods slightly in order to allow for this to not be imbalanced
+- rscadd: You will now sweat to cool your body down.
+- experimental: Added system of dehydration that occurs after too much sweating.
+- experimental: Added new machine, like the mancrowave, but named the coolman, in order to cool down your body temperature to 37C incase you overheat too much and cannot sweat it off.


### PR DESCRIPTION
- Added hyperthermia or heat stroke, which occurs when the body absorbs too much heat.
- An early stage of hyperthermia symptoms include heavy sweating, rapid breathing and a fast, weak pulse. 
- Other signs and symptoms vary. Accompanying dehydration can produce nausea, vomiting, headaches, and low blood pressure leading to fainting or dizziness.
- In severe heat stroke, there may be confused, hostile, or seemingly intoxicated behavior, directional movement may be different and will have a chance to not be able to use machinery.
- Eventually, Organ failure, unconciousness, and death will result.
- Tweaked plasmafloods slightly in order to allow for this to not be imbalanced
- You will now sweat to cool your body down.
- Added system of dehydration that occurs after too much sweating.
- Added new machine, like the mancrowave, but named the coolman, in order to cool down your body temperature to 37C incase you overheat too much and cannot sweat it off.
  ![bf0ob4i 1](https://cloud.githubusercontent.com/assets/7193289/14194551/96094f44-f7a7-11e5-8a6a-79e669d48672.png)

addresses #9176
