### PR TITLE
Reduces T3 part cost by 12% for evenness and to reduce the burden of plastic during early game.

### DIFF
--- a/code/modules/research/designs/stock_parts.dm
+++ b/code/modules/research/designs/stock_parts.dm
@@ -107,7 +107,7 @@
 	req_tech = list("powerstorage" = 5, "materials" = 4)
 	build_type = PROTOLATHE
 	reliability_base = 71
-	materials = list(MAT_PLASTIC = 300)
+	materials = list(MAT_PLASTIC = 266.6)
 	category = "Stock Parts"
 	build_path = /obj/item/weapon/stock_parts/capacitor/adv/super
 
@@ -118,7 +118,7 @@
 	id = "phasic_sensor"
 	req_tech = list("magnets" = 5, "materials" = 3)
 	build_type = PROTOLATHE
-	materials = list(MAT_PLASTIC = 300)
+	materials = list(MAT_PLASTIC = 266.6)
 	reliability_base = 72
 	category = "Stock Parts"
 	build_path = /obj/item/weapon/stock_parts/scanning_module/adv/phasic
@@ -129,7 +129,7 @@
 	id = "pico_mani"
 	req_tech = list("materials" = 5, "programming" = 2)
 	build_type = PROTOLATHE
-	materials = list(MAT_PLASTIC = 300)
+	materials = list(MAT_PLASTIC = 266.6)
 	reliability_base = 73
 	category = "Stock Parts"
 	build_path = /obj/item/weapon/stock_parts/manipulator/nano/pico
@@ -140,7 +140,7 @@
 	id = "ultra_micro_laser"
 	req_tech = list("magnets" = 5, "materials" = 5)
 	build_type = PROTOLATHE
-	materials = list(MAT_PLASTIC = 300)
+	materials = list(MAT_PLASTIC = 266.6)
 	reliability_base = 70
 	category = "Stock Parts"
 	build_path = /obj/item/weapon/stock_parts/micro_laser/high/ultra
@@ -151,7 +151,7 @@
 	id = "super_matter_bin"
 	req_tech = list("materials" = 5)
 	build_type = PROTOLATHE
-	materials = list(MAT_PLASTIC = 300)
+	materials = list(MAT_PLASTIC = 266.6)
 	reliability_base = 75
 	category = "Stock Parts"
 	build_path = /obj/item/weapon/stock_parts/matter_bin/adv/super

--- a/html/changelogs/Probe1.yml
+++ b/html/changelogs/Probe1.yml
@@ -1,0 +1,6 @@
+author: Probe1
+
+delete-after: False
+
+changes: 
+- tweak: Plastic cost of T3 parts reduced by 12% from 450 to 400.  


### PR DESCRIPTION
Plastic is shitty and this will make it mildly less shitty.  
1.  The part cost will divide evenly into a sheet (2000 / 400).  
2.  Plastic is a pain in the ass to get but once the 5-10 minute setup is done becomes completely irrelevant.  The cost for tier 3 parts from the switch to plastic went from 0.05 of a sheet to 0.233333t.  This will even out the usage of plastic, making it less retarded early game.  People will be less dependent on deconstructing plastic flaps for plastic and will be held over until the mid game plastic botany setup is a viable source.
