### PR TITLE
Hotfix to Cancer and amputed limbs

### DIFF
--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -242,7 +242,5 @@
 	cancerous_growth -= min(1, hardcores + holywater + ryetalyn - mutagen) + phalanximine + medbots //Simple enough, mut helps cancer growth, hardcores and holywater stall it, phalanx and medbots cure it
 	cancer_stage += cancerous_growth
 
-	//Cancer has a single universal sign. Coughing. Has a chance to happen every tick
-	//Most likely not medically accurate, but whocares.ru
-	if(prob(1))
-		owner.emote("cough")
+	if(cancerous_growth <= 0) //No cancerous growth this tick, no effects
+		return 0

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -222,10 +222,10 @@
 /datum/organ/proc/handle_cancer()
 
 	if(!cancer_stage) //This limb isn't cancerous, nothing to do in here
-		return 0
+		return 1
 
 	if(cancer_stage < CANCER_STAGE_BENIGN) //Abort immediately if the cancer has been suppresed
-		return 0
+		return 1
 
 	//List of reagents which will affect cancerous growth
 	//Phalanximine and Medical Nanobots are the only reagent which can reverse cancerous growth in high doses, the others can stall it, some can even accelerate it
@@ -243,4 +243,4 @@
 	cancer_stage += cancerous_growth
 
 	if(cancerous_growth <= 0) //No cancerous growth this tick, no effects
-		return 0
+		return 1

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -332,11 +332,12 @@
 //Limb cancer is relatively benign until it grows large, then it cripples you and metastases
 /datum/organ/external/handle_cancer()
 
-	..()
+	if(..())
+		return 1
 
 	if(!is_existing()) //Limb has been destroyed or amputated, cancer's over as far as we are concerned since there is no limb to grow on anymore
 		cancer_stage = 0
-		return 0
+		return 1
 
 	switch(cancer_stage)
 		if(CANCER_STAGE_SMALL_TUMOR to CANCER_STAGE_LARGE_TUMOR) //Small tumors will not damage your limb, but might flash pain

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -334,6 +334,10 @@
 
 	..()
 
+	if(!is_existing()) //Limb has been destroyed or amputated, cancer's over as far as we are concerned since there is no limb to grow on anymore
+		cancer_stage = 0
+		return 0
+
 	switch(cancer_stage)
 		if(CANCER_STAGE_SMALL_TUMOR to CANCER_STAGE_LARGE_TUMOR) //Small tumors will not damage your limb, but might flash pain
 			if(prob(1))
@@ -351,6 +355,11 @@
 				owner.apply_damage(0.5, CLONE, src)
 			if(prob(1))
 				owner.add_cancer() //Add a new cancerous growth
+
+	//Cancer has a single universal sign. Coughing. Has a chance to happen every tick
+	//Most likely not medically accurate, but whocares.ru
+	if(prob(1))
+		owner.emote("cough")
 
 //Updating germ levels. Handles organ germ levels and necrosis.
 /*
@@ -643,6 +652,12 @@ Note that amputating the affected organ does in fact remove the infection from t
 			owner.visible_message("<span class='danger'>[owner.name]'s [display_name] flies off in an arc.</span>", \
 			"<span class='danger'>Your [display_name] goes flying off!</span>", \
 			"<span class='danger'>You hear a terrible sound of ripping tendons and flesh.</span>")
+
+			//Here, we assign the organ health facts from its old position on the body
+			//Type check to avoid to rewrite everything else, for now
+			if(istype(organ, /obj/item/weapon/organ))
+				var/obj/item/weapon/organ/O = organ
+				O.cancer_stage = cancer_stage
 
 			//Throw organs around
 			var/randomdir = pick(cardinal)
@@ -1160,6 +1175,9 @@ obj/item/weapon/organ
 	//They are transferred from the mob from which the organ was removed.
 	//Currently the only "butchering drops" which are going to be stored here are teeth
 	var/list/butchering_drops = list()
+
+	//Store health facts. Right now limited exclusively to cancer, but should likely include all limb stats eventually
+	var/cancer_stage = 0
 
 obj/item/weapon/organ/New(loc, mob/living/carbon/human/H)
 	..(loc)

--- a/code/modules/surgery/headreattach.dm
+++ b/code/modules/surgery/headreattach.dm
@@ -215,6 +215,8 @@
 			target.butchering_drops += BP //Transfer
 			B.butchering_drops -= BP
 
+	affected.cancer_stage = B.cancer_stage
+
 	var/datum/organ/internal/brain/copied
 	if(B.organ_data)
 		var/datum/organ/internal/I = B.organ_data


### PR DESCRIPTION
- If cancer does not grow, or regresses during a process tick, it has no effect that tick like damaging or making the mob cough
- Cancer is immediately removed if the linked limb no longer exists during a process tick (aka amputated or destroyed)
- Organ items can now carry the cancer status of their parent on removal. Currently only useful for heads, since those are the only organic heads that can be reattached. Might be useful if normal limb reattachment is added later on

Linked to #9033
