### PR TITLE
Plasmaman speech no longer stutters the s's it's replacing.

### DIFF
--- a/code/modules/mob/living/carbon/human/plasmaman/species.dm
+++ b/code/modules/mob/living/carbon/human/plasmaman/species.dm
@@ -30,8 +30,8 @@
 	)
 
 /datum/species/plasmaman/handle_speech(var/datum/speech/speech, mob/living/carbon/human/H)
-	speech.message = replacetext(speech.message, "s", stutter("ss"))
-	return ..(speech,H)
+	speech.message = replacetext(speech.message, "s", "s-s") //not using stutter("s") because it likes adding more s's.
+	speech.message = replacetext(speech.message, "s-ss-s", "ss-ss") //asshole shows up as ass-sshole
 
 /datum/species/plasmaman/equip(var/mob/living/carbon/human/H)
 	H.fire_sprite = "Plasmaman"

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -279,8 +279,8 @@ var/global/list/whitelisted_species = list("Human")
 	flesh_color = "#34AF10"
 
 /datum/species/unathi/handle_speech(var/datum/speech/speech, mob/living/carbon/human/H)
-	speech.message = replacetext(speech.message, "s", stutter("ss"))
-	return ..(speech, H)
+	speech.message = replacetext(speech.message, "s", "s-s") //not using stutter("s") because it likes adding more s's.
+	speech.message = replacetext(speech.message, "s-ss-s", "ss-ss") //asshole shows up as ass-sshole
 
 /datum/species/skellington // /vg/
 	name = "Skellington"

--- a/html/changelogs/Intiplasmaspeech.yml
+++ b/html/changelogs/Intiplasmaspeech.yml
@@ -1,0 +1,4 @@
+author: Intigracy
+delete-after: True
+changes: 
+- rscadd: "Plasmamen are now slightly less annoying when using the letter 's'. 's' becomes 's-s' and 'ss' becomes 'ss-ss' every time, no more long 's-s-s-s-s' messages."


### PR DESCRIPTION
Also removed it from happening on Unathi in case at some point they get added.

Closes #5111 

Before:
"You're an asshole" = "You're an as-s-s-s-shole" (probably has more s's than this since stutter likes adding more letters)
After:
"You're an asshole" = "You're an ass-sshole"
