### PR TITLE
Mobs that eat other mobs, changes to this already existing system

### DIFF
--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -67,6 +67,10 @@
 				our_mob.ghostize()
 
 				our_mob.forceMove(src)
+				if(iscarbon(our_mob))
+					var/mob/living/carbon/C = our_mob
+					C.drop_stomach_contents()
+					user.visible_message("<span class='warning'>\The [C]'s stomach contents drop to the ground!</span>")
 
 				returnToPool(G)
 				return

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -163,6 +163,11 @@
 		return 0
 
 	to_drop.forceMove(Target) //calls the Entered procs
+	if(ismob(Target))
+		var/mob/M = Target
+		if(iscarbon(M))
+			var/mob/living/carbon/C = M
+			C.stomach_contents.Add(to_drop)
 
 	to_drop.dropped(src)
 

--- a/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
@@ -179,11 +179,6 @@ Doesn't work on other aliens/AI.*/
 	set category = "Alien"
 
 	if(powerc())
-		if(stomach_contents.len)
-			for(var/mob/M in src)
-				if(M in stomach_contents)
-					stomach_contents.Remove(M)
-					M.loc = loc
-					//Paralyse(10)
-			src.visible_message("<span class='alien'>\The [src] hurls out the contents of their stomach!</span>")
+		drop_stomach_contents()
+		src.visible_message("<span class='alien'>\The [src] hurls out the contents of their stomach!</span>")
 	return

--- a/code/modules/mob/living/carbon/alien/humanoid/life.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/life.dm
@@ -452,14 +452,25 @@
 				if(M.loc != src)
 					stomach_contents.Remove(M)
 					continue
-				if(istype(M, /mob/living/carbon) && stat != 2)
+				if(istype(M, /mob/living/carbon) && stat & stat != 2)
+					var/digest = 0
 					if(M.stat == 2)
-						M.death(1)
-						stomach_contents.Remove(M)
-						qdel(M)
-						M = null
+						if(prob(5))
+							switch(digest)
+								if(0)
+									to_chat(src, "<span class='warning'>\The [M] shifts around in your stomach cavity as digestion begins.</span>")
+								if(1)
+									to_chat(src, "<span class='warning'>\The [M] feels a little bit lighter in your stomach cavity.</span>")
+								if(2)
+									to_chat(src, "<span class='danger'>You barely feel the weight of [M] in your stomach cavity anymore.</span>")
+								if(3 to INFINITY)
+									to_chat(src, "<span class='warning'>The weight of [M] is no longer there. Digestion has completed.</span>")
+									M.ghostize(1)
+									drop_stomach_contents()
+									qdel(M)
+							digest++
 						continue
 					if(air_master.current_cycle%3==1)
-						if(!(status_flags & GODMODE))
+						if(!(M.status_flags & GODMODE))
 							M.adjustBruteLoss(5)
 						nutrition += 10

--- a/code/modules/mob/living/carbon/alien/larva/life.dm
+++ b/code/modules/mob/living/carbon/alien/larva/life.dm
@@ -370,22 +370,3 @@
 
 	proc/handle_random_events()
 		return
-
-
-	proc/handle_stomach()
-		spawn(0)
-			for(var/mob/living/M in stomach_contents)
-				if(M.loc != src)
-					stomach_contents.Remove(M)
-					continue
-				if(istype(M, /mob/living/carbon) && stat != 2)
-					if(M.stat == 2)
-						M.death(1)
-						stomach_contents.Remove(M)
-						qdel(M)
-						M = null
-						continue
-					if(air_master.current_cycle%3==1)
-						if(!(M.status_flags & GODMODE))
-							M.adjustBruteLoss(5)
-						nutrition += 10

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -75,22 +75,12 @@
 					if(M.client)
 						M.show_message(text("<span class='warning'><B>[user] attacks [src]'s stomach wall with the [I.name]!</span>"), 2)
 				playsound(user.loc, 'sound/effects/attackblob.ogg', 50, 1)
-
-				if(prob(src.getBruteLoss() - 50))
-					for(var/atom/movable/A in stomach_contents)
-						A.loc = loc
-						stomach_contents.Remove(A)
-					src.gib()
+				src.delayNextMove(10) //no just holding the key for an instant gib
 
 /mob/living/carbon/gib()
 	dropBorers(1)
-	for(var/mob/M in src)
-		if(M in src.stomach_contents)
-			src.stomach_contents.Remove(M)
-		M.loc = src.loc
-		for(var/mob/N in viewers(src, null))
-			if(N.client)
-				N.show_message(text("<span class='danger'>[M] bursts out of [src]!</span>"), 2)
+	drop_stomach_contents()
+	src.visible_message("<span class='warning'>Something bursts from \the [src]'s stomach!</span>")
 	. = ..()
 
 /mob/living/carbon/proc/share_contact_diseases(var/mob/M)
@@ -659,3 +649,20 @@
 			B.perform_infestation(C)
 		else
 			to_chat(B, "<span class='notice'>You're forcefully popped out of your host!</span>")
+
+/mob/living/carbon/proc/drop_stomach_contents(var/target)
+	if(!target)
+		target = get_turf(src)
+
+	var/mob/living/simple_animal/borer/B = src.has_brain_worms()
+	for(var/mob/M in src)//mobs, all of them
+		if(M == B)
+			continue
+		if(M in src.stomach_contents)
+			src.stomach_contents.Remove(M)
+		M.forceMove(target)
+
+	for(var/obj/O in src)//objects, only the ones in the stomach
+		if(O in src.stomach_contents)
+			src.stomach_contents.Remove(O)
+			O.forceMove(target)

--- a/code/modules/mob/living/carbon/human/life/handle_stomach.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_stomach.dm
@@ -6,12 +6,30 @@
 			if(M.loc != src)
 				stomach_contents.Remove(M)
 				continue
-			if(istype(M, /mob/living/carbon) && stat != DEAD)
-				if(M.stat == DEAD) //We just checked if the mob ISN'T dead, but what the fuck ever oldcoders
-					M.death(1)
-					stomach_contents.Remove(M)
-					qdel(M)
-					M = null
+			if(istype(M, /mob/living/carbon) && stat & stat != DEAD)//Only digest carbons and only when not dead
+				var/digest = 0
+				if(M.stat == DEAD)//Only digest if mob inside is dead
+					M.death(0)
+					if(prob(10))
+						switch(digest)
+							if(0)
+								to_chat(src, "<span class='warning'>Your stomach starts rumbling as /the [M] is shifted around.</span>")
+							if(1)
+								visible_message(src, "<span class='warning'>\The [src] lets out a small toot.</span>", "<span class='warning'>You let out a small toot, your stomach gurgling.</span>")
+								playsound(get_turf(src), 'sound/misc/fart.ogg', 50, 1)
+							if(2)
+								visible_message(src, "<span class='warning'>\The [src] lets out an extremely long fart.</span>", "<span class='warning'>You let out an extremely long and loud fart, to the point that it starts hurting your ass.</span>")
+								playsound(get_turf(src), 'sound/effects/superfart.ogg', 50, 1)
+								if(!(status_flags & GODMODE))
+									adjustBruteLoss(5)
+							if(3 to INFINITY)
+								visible_message(src, "<span class='warning'>\The [src] vomits.</span>", "<span class='warning'>You vomit up what little remains of \the [M].</span>")
+								vomit()
+								new /obj/effect/decal/remains/human(src.loc)
+								M.ghostize(1)
+								drop_stomach_contents()
+								qdel(M)
+						digest++
 					continue
 				if(air_master.current_cycle % 3 == 1)
 					if(!(M.status_flags & GODMODE))

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -83,9 +83,6 @@
 			if(G.affecting != affecting)
 				allow_upgrade = 0
 		if(state == GRAB_AGGRESSIVE)
-			var/h = affecting.hand
-			affecting.drop_hands()
-			affecting.hand = h
 			for(var/obj/item/weapon/grab/G in affecting.grabbed_by)
 				if(G == src) continue
 				if(G.state == GRAB_AGGRESSIVE)
@@ -229,6 +226,9 @@
 	if(M == assailant && state >= GRAB_AGGRESSIVE)
 		if( (ishuman(user) && (M_FAT in user.mutations) && ismonkey(affecting) ) || ( isalien(user) && iscarbon(affecting) ) )
 			var/mob/living/carbon/attacker = user
+			if(locate(/mob) in attacker.stomach_contents)
+				to_chat(attacker, "<span class='warning'>You already have something in your stomach.</span>")
+				return
 			user.visible_message("<span class='danger'>[user] is attempting to devour [affecting]!</span>", \
 				drugged_message="<span class='danger'>[user] is attempting to kiss [affecting]! Ew!</span>")
 			if(istype(user, /mob/living/carbon/alien/humanoid/hunter))

--- a/html/changelogs/Intialienstuff.yml
+++ b/html/changelogs/Intialienstuff.yml
@@ -1,0 +1,8 @@
+author: Intigracy
+delete-after: True
+changes: 
+- rscadd: "An alien who dies via meat spike will have their stomachs emptied out on the ground."
+- rscadd: "Mobs (such as aliens or fatass humans) can now only eat one mob at a time."
+- tweak: "Mobs eaten by other mobs are digested (unchanged). The person who ate the other mob will recieve 4 notifications over time after the mob as died as to the status of the mob being digested, with the 4th finishing them off."
+- tweak: "Grabbing someone to the point that it says '(now hands)' no longer causes them to drop what they're holding every second or so. This was done so that mobs who are grabbed while holding something can once again chestburst out of the thing that ate them."
+- bugfix: "Holding an arrow key while inside of a mob's stomach no longer causes it to pretty much instantly gib."


### PR DESCRIPTION
- rscadd: "An alien who dies via meat spike will have their stomachs emptied out on the ground."
- rscadd: "Mobs (such as aliens or fatass humans) can now only eat one mob at a time."
- tweak: "Mobs eaten by other mobs are digested (unchanged). The person who ate the other mob will recieve 4 notifications over time after the mob as died as to the status of the mob being digested, with the 4th finishing them off."
- tweak: "Grabbing someone to the point that it says '(now hands)' no longer causes them to drop what they're holding every second or so. This was done so that mobs who are grabbed while holding something can once again chestburst out of the thing that ate them."
- bugfix: "Holding an arrow key while inside of a mob's stomach no longer causes it to pretty much instantly gib."

fixes #6566
fixes #3333
