### PR TITLE
Inaprov OD fix

### DIFF
--- a/code/modules/medical/cloning.dm
+++ b/code/modules/medical/cloning.dm
@@ -298,7 +298,7 @@
 
 			//So clones don't die of oxyloss in a running pod.
 			if (src.occupant.reagents.get_reagent_amount("inaprovaline") < 30)
-				src.occupant.reagents.add_reagent("inaprovaline", 60)
+				src.occupant.reagents.add_reagent("inaprovaline", 30)
 
 			var/mob/living/carbon/human/H = src.occupant
 


### PR DESCRIPTION
Inaprovaline was killing unattended cloning patients, this fixes that.
Previously it had been ODing the patient with 89 units of Inaprovaline after the initial dose of 60. This works similarly to how it did originally, but never goes over 60.
