### PR TITLE
Fireball's projectile_step_delay = 0

### DIFF
--- a/code/modules/spells/targeted/projectile/fireball.dm
+++ b/code/modules/spells/targeted/projectile/fireball.dm
@@ -15,7 +15,7 @@
 	spell_flags = 0
 
 	duration = 20
-	proj_step_delay = 1
+	proj_step_delay = 0
 
 	amt_dam_brute = 20
 	amt_dam_fire = 25

--- a/html/changelogs/Intigracyfireball.yml
+++ b/html/changelogs/Intigracyfireball.yml
@@ -1,0 +1,4 @@
+author: Intigracy
+delete-after: True
+changes: 
+- tweak: "Fireballs now move faster, so you're a bit less likely to run into it right after casting."


### PR DESCRIPTION
- tweak: Fireballs now move faster, so you're a bit less likely to run into it right after casting.
