### PR TITLE
SPS tweaks/fixes

### DIFF
--- a/code/modules/telesci/gps.dm
+++ b/code/modules/telesci/gps.dm
@@ -140,7 +140,7 @@ var/global/secure_GPS_count = 0
 
 	for(var/E in SPS_list)
 		var/obj/item/device/gps/secure/S  = E //No idea why casting it like this makes it work better instead of just defining it in the for each
-		S.announce(wearer, src, "died")
+		S.announce(wearer, src, "has detected the death of their wearer")
 
 /obj/item/device/gps/secure/stripped(mob/wearer as mob)
 	if(emped) return
@@ -148,11 +148,12 @@ var/global/secure_GPS_count = 0
 
 	for(var/E in SPS_list)
 		var/obj/item/device/gps/secure/S  = E
-		S.announce(wearer, src, "been stripped of [wearer.gender == FEMALE ? "her" : "his"] SPS")
+		S.announce(wearer, src, "has been stripped from their wearer")
 
 /obj/item/device/gps/secure/proc/announce(var/mob/wearer, var/obj/item/device/gps/secure/SPS, var/reason)
-	if(istype(src.loc, /mob/living))
-		var/mob/living/L = src.loc
-		L.show_message("[gpstag] beeps: <span class='warning'>Warning! [wearer] has [reason] at [get_area(SPS)].</span>",MESSAGE_HEAR)
+	var/turf/pos = get_turf(SPS)
+	if(istype(find_holder(src), /mob/living))
+		var/mob/living/L = find_holder(src)
+		L.show_message("\icon[src] [gpstag] beeps: <span class='danger'>Warning! SPS '[SPS.gpstag]' [reason] at [get_area(SPS)] ([pos.x-WORLD_X_OFFSET[pos.z]], [pos.y-WORLD_Y_OFFSET[pos.z]], [pos.z]).</span>", MESSAGE_HEAR)
 	else if(isturf(src.loc))
-		src.visible_message("[gpstag] beeps: <span class='warning'>Warning! [wearer] has [reason] at [get_area(SPS)].</span>")
+		src.visible_message("\icon[src] [gpstag] beeps: <span class='danger'>Warning! SPS '[SPS.gpstag]' [reason] at [get_area(SPS)] ([pos.x-WORLD_X_OFFSET[pos.z]], [pos.y-WORLD_Y_OFFSET[pos.z]], [pos.z]).</span>")

--- a/html/changelogs/9600bauds_sps.yml
+++ b/html/changelogs/9600bauds_sps.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general deleting of nice things)
+#   rscadd (general adding of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.
+author: 9600bauds
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# There needs to be a space after the - and before the prefix. Don't use tabs anywhere in this file.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# If you're using characters such as # ' : - or the like in your changelog, surround the entire change with quotes as shown in the second example. These quotes don't show up on the changelog once it's merged and prevent errors.
+# SCREW ANY OF THIS UP AND IT WON'T WORK.
+changes: 
+- bugfix: "SPS will now work correctly while inside a backpack or container."
+- tweak: "SPS will no longer magically detect the name of their wearer (and will no longer report their wearer as 'unknown' if their face melts off), instead now broadcast their GPS tag. They also now broadcast precise coordinates as well as the general area."


### PR DESCRIPTION
- bugfix: "SPS will now work correctly while inside a backpack or container."
- tweak: "SPS will no longer magically detect the name of their wearer (and will no longer report their wearer as 'unknown' if their face melts off), instead now broadcast their GPS tag. They also now broadcast precise coordinates as well as the general area."

Fixes #8956
Fixes #8955
Tentatively tagging the tiny name change as balance even though it's pretty much the same thing or someone will bitch

![dreamseeker_2016-04-06_15-16-37](https://cloud.githubusercontent.com/assets/6526157/14327855/9588dfe6-fc0a-11e5-90e1-12ce8df72af3.png)
