### PR TITLE
Vampire rebalancing

### DIFF
--- a/html/changelogs/Intienthrall2.yml
+++ b/html/changelogs/Intienthrall2.yml
@@ -1,0 +1,6 @@
+author: Intigracy
+delete-after: True
+changes: 
+- bugfix: "Vampire spells that have a blood cost listed now actually take that blood from you, some weren't."
+- tweak: "Enthrall now costs 150 blood to use, up from free."
+- bugfix: "You no longer appear in your own list of targets when you cast a spell as a vampire."


### PR DESCRIPTION
- bugfix: "Vampire spells that have a blood cost listed now actually take that blood from you, some weren't."
- tweak: "Enthrall now costs 150 blood to use, up from free."
- bugfix: "You no longer appear in your own list of targets when you cast a spell as a vampire." 

This is one of the most complained about things about vampire.
