### PR TITLE
Make Phalanximine production a ton easier

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -109,8 +109,8 @@ datum
 			name = "Phalanximine"
 			id = "phalanximine"
 			result = "phalanximine"
-			required_reagents = list("arithrazine" = 1, "diethylamine" = 1, "mutagen" = 1)
-			result_amount = 1
+			required_reagents = list("hyronalin" = 1, "ethanol" = 1, "mutagen" = 1)
+			result_amount = 3
 
 		stoxin
 			name = "Sleep Toxin"

--- a/html/changelogs/Dylanstrategie_Cancer.yml
+++ b/html/changelogs/Dylanstrategie_Cancer.yml
@@ -1,0 +1,4 @@
+author: Dylanstrategie
+delete-after: True
+changes:
+  - tweak: Phalanximine recipe has been simplified and now yields three times more


### PR DESCRIPTION
- Old recipe was Arithrazine, Diethylamine, Mutagen, which easily was one of the most complex recipes in the game
- New recipe is Hyronalin, Ethanol (Wikipedia mentioned it so here we go) and Mutagen. This completely gets rid of the fertilizer route and replaces it with a simple button mash, and means you only need about five button presses (with two of those shared between Hyronalin and Mutagen) instead of a fuckload
- New recipe for Phalanximine yields 3 units instead of 1 (Read : 100 % yield instead of 33 %)

Since Phalanximine is going to be guzzled down like water when needed, might as well make it a lot easier to make
