### PR TITLE
Fixes sleep gas not working (type comparisons a shit)

### DIFF
--- a/code/modules/organs/internal/lungs/lung_gasses.dm
+++ b/code/modules/organs/internal/lungs/lung_gasses.dm
@@ -55,7 +55,7 @@
 		// Find the trace gas we need to mess with
 		if(breath.trace_gases.len)	// If there's some other shit in the air lets deal with it here.
 			for(var/datum/gas/G in breath.trace_gases)
-				if(G.type != id)
+				if("[G.type]" != id)
 					continue
 				gas = G
 


### PR DESCRIPTION
thing.type == /literal/type/path/ref would always be false
I actually made a test project for this, even.

https://gist.github.com/gbasood/5b97c01847caee1415384c7154a5e33b
