### PR TITLE
Trying to cheat Cuban Pete now has consequences.

### DIFF
--- a/html/changelogs/Intipete.yml
+++ b/html/changelogs/Intipete.yml
@@ -1,0 +1,4 @@
+author: Intigracy
+delete-after: True
+changes: 
+- experiment: Trying to cheat Cuban Pete now has consequences.


### PR DESCRIPTION
- experiment: Trying to cheat Cuban Pete now has consequences.

https://dl.dropboxusercontent.com/s/cje592mky7yqfbh/2016-04-09_02-38-11.mp4?dl=0
https://dl.dropboxusercontent.com/s/wt6tedymqr7kgpu/2016-04-09_14-55-06.mp4?dl=0
added screwdriving to cheating

fixes #8819 
fixes #8682 

Kicking the CP arcade (normally kicking arcades randomizes all health and magic values, makes it really easy to cheese), screwdrivering it, or emagging it again now warns you that you're trying to cheat. Trying to cheat again gibs you and explodes the arcade.

Cheating doesn't trigger if the arcade is broken or unpowered.
