### PR TITLE
Surgeon switchtools now fit in pockets when not activated

### DIFF
--- a/code/game/objects/items/weapons/switchtool.dm
+++ b/code/game/objects/items/weapons/switchtool.dm
@@ -164,7 +164,6 @@
 	icon_state = "surg_switchtool"
 	desc = "A switchtool containing most of the necessary items for impromptu surgery. For the surgeon on the go."
 
-	w_class = 3.0
 	origin_tech = "materials=4;bluespace=3;biotech=3"
 	stored_modules = list("/obj/item/weapon/scalpel:scalpel" = null,
 						"/obj/item/weapon/circular_saw:circular saw" = null,

--- a/html/changelogs/Intiswitchtool.yml
+++ b/html/changelogs/Intiswitchtool.yml
@@ -1,0 +1,4 @@
+author: Intigracy
+delete-after: True
+changes: 
+- tweak: "Surgeon switchtools now fit in pockets when not activated."


### PR DESCRIPTION
Because this isn't a bugfix, unlike my belts change
A T O M I C  P R

![2016-04-09_16-44-10](https://cloud.githubusercontent.com/assets/4043940/14407123/59240a3e-fe72-11e5-8fb5-f145968b52e8.png)

closes #9352
