### PR TITLE
Fixes people going bald every round

### DIFF
--- a/code/game/gamemodes/setupgame.dm
+++ b/code/game/gamemodes/setupgame.dm
@@ -155,6 +155,8 @@
 			if(species.default_blocks.len)
 				all_species[name]=species
 
+	speciesinit = 1
+
 
 /proc/setupfactions()
 

--- a/code/global.dm
+++ b/code/global.dm
@@ -389,6 +389,7 @@ var/global/list/minesweeper_best_players = list()
 var/nanocoins_rates = 1
 var/nanocoins_lastchange = 0
 
+var/speciesinit = 0
 var/minimapinit = 0
 
 var/datum/stat_collector/stat_collection = new

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -182,14 +182,17 @@ var/const/MAX_SAVE_SLOTS = 8
 /datum/preferences/New(client/C)
 	client=C
 	if(istype(C))
-		if(!IsGuestKey(C.key))
-			var/load_pref = load_preferences_sqlite(C.ckey)
-			if(load_pref)
-				if(load_save_sqlite(C.ckey, C, default_slot))
-					return
-		randomize_appearance_for()
-		real_name = random_name(gender)
-		save_character_sqlite(src, C.ckey, default_slot)
+		spawn()
+			while(!speciesinit)
+				sleep(10)
+			if(!IsGuestKey(C.key))
+				var/load_pref = load_preferences_sqlite(C.ckey)
+				if(load_pref)
+					if(load_save_sqlite(C.ckey, C, default_slot))
+						return
+			randomize_appearance_for()
+			real_name = random_name(gender)
+			save_character_sqlite(src, C.ckey, default_slot)
 
 /datum/preferences/proc/setup_character_options(var/dat, var/user)
 
@@ -1334,7 +1337,7 @@ NOTE:  The change will take effect AFTER any current recruiting periods."}
 					//random_character_sqlite(user, user.ckey)
 
 				if("reload")
-					load_preferences_sqlite(user, user.ckey)
+					load_preferences_sqlite(user.ckey)
 					load_save_sqlite(user.ckey, user, default_slot)
 
 				if("open_load_dialog")

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -100,56 +100,58 @@
 	if(!client)	return 0
 
 	if(href_list["show_preferences"])
-		client.prefs.ShowChoices(src)
-		return 1
+		if(speciesinit)
+			client.prefs.ShowChoices(src)
+			return 1
 
 	if(href_list["ready"])
-		switch(text2num(href_list["ready"]))
-			if(1)
-				ready = 1
-			if(2)
-				ready = 0
-		to_chat(usr, "<span class='recruit'>You [ready ? "have declared ready" : "have unreadied"].</span>")
-		new_player_panel_proc()
-		//testing("[usr] topic call took [(world.timeofday - timestart)/10] seconds")
-		return 1
+		if(speciesinit)
+			switch(text2num(href_list["ready"]))
+				if(1)
+					ready = 1
+				if(2)
+					ready = 0
+			to_chat(usr, "<span class='recruit'>You [ready ? "have declared ready" : "have unreadied"].</span>")
+			new_player_panel_proc()
+			//testing("[usr] topic call took [(world.timeofday - timestart)/10] seconds")
+			return 1
 
 	if(href_list["refresh"])
 		src << browse(null, "window=playersetup") //closes the player setup window
 		new_player_panel_proc()
 
 	if(href_list["observe"])
+		if(speciesinit)
+			if(alert(src,"Are you sure you wish to observe? You will not be able to play this round!","Player Setup","Yes","No") == "Yes")
+				if(!client)	return 1
+				var/mob/dead/observer/observer = new()
 
-		if(alert(src,"Are you sure you wish to observe? You will not be able to play this round!","Player Setup","Yes","No") == "Yes")
-			if(!client)	return 1
-			var/mob/dead/observer/observer = new()
-
-			spawning = 1
-			src << sound(null, repeat = 0, wait = 0, volume = 85, channel = 1) // MAD JAMS cant last forever yo
+				spawning = 1
+				src << sound(null, repeat = 0, wait = 0, volume = 85, channel = 1) // MAD JAMS cant last forever yo
 
 
-			observer.started_as_observer = 1
-			close_spawn_windows()
-			var/obj/O = locate("landmark*Observer-Start")
-			to_chat(src, "<span class='notice'>Now teleporting.</span>")
-			observer.loc = O.loc
-			observer.timeofdeath = world.time // Set the time of death so that the respawn timer works correctly.
+				observer.started_as_observer = 1
+				close_spawn_windows()
+				var/obj/O = locate("landmark*Observer-Start")
+				to_chat(src, "<span class='notice'>Now teleporting.</span>")
+				observer.loc = O.loc
+				observer.timeofdeath = world.time // Set the time of death so that the respawn timer works correctly.
 
-			client.prefs.update_preview_icon(1)
-			observer.icon = client.prefs.preview_icon
-			observer.alpha = 127
+				client.prefs.update_preview_icon(1)
+				observer.icon = client.prefs.preview_icon
+				observer.alpha = 127
 
-			if(client.prefs.be_random_name)
-				client.prefs.real_name = random_name(client.prefs.gender,client.prefs.species)
-			observer.real_name = client.prefs.real_name
-			observer.name = observer.real_name
-			if(!client.holder && !config.antag_hud_allowed)           // For new ghosts we remove the verb from even showing up if it's not allowed.
-				observer.verbs -= /mob/dead/observer/verb/toggle_antagHUD        // Poor guys, don't know what they are missing!
-			observer.key = key
-			mob_list -= src
-			qdel(src)
+				if(client.prefs.be_random_name)
+					client.prefs.real_name = random_name(client.prefs.gender,client.prefs.species)
+				observer.real_name = client.prefs.real_name
+				observer.name = observer.real_name
+				if(!client.holder && !config.antag_hud_allowed)           // For new ghosts we remove the verb from even showing up if it's not allowed.
+					observer.verbs -= /mob/dead/observer/verb/toggle_antagHUD        // Poor guys, don't know what they are missing!
+				observer.key = key
+				mob_list -= src
+				qdel(src)
 
-			return 1
+				return 1
 
 	if(href_list["late_join"])
 		if(!ticker || ticker.current_state != GAME_STATE_PLAYING)

--- a/html/changelogs/Intibaldymcbaldbald.yml
+++ b/html/changelogs/Intibaldymcbaldbald.yml
@@ -1,0 +1,5 @@
+author: Intigracy
+delete-after: True
+changes: 
+- bugfix: "Fixes people going bald when they join before the game initializes."
+- tweak: "You can't use the three buttons on the popup on joining the game until the game has initialized."


### PR DESCRIPTION
Species datums weren't being generated before preferences to be able to reference the species allowed hair, so it was making everyone bald.

This makes it so you can't click on the three buttons you get when joining until your preferences are loaded, and your preferences actually load correctly now.

fixes #6463
fixes #9358
