### PR TITLE
adjusts spirit breaker and doc's delight

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -168,7 +168,7 @@
 			to_chat(M, "<span class='notice'>[pick("You feel quite hardcore", "Coderbased is your god", "Fucking kickscammers Bustration will be the best")].")
 		else
 			M.say(pick("Muh hardcores.", "Falling down is a feature.", "Gorrillionaires and Booty Borgs when?"))
-			
+
 /datum/reagent/rogan
 	name = "Rogan"
 	id = "rogan"
@@ -2213,8 +2213,8 @@
 	if(data >= 165)
 		M.adjustToxLoss(0.2)
 		M.adjustBrainLoss(5)
-		M.hallucination += 100
-		M.dizziness += 100
+		M.hallucination += 50
+		M.dizziness += 50
 		M.confused += 2
 	data++
 
@@ -2640,10 +2640,8 @@
 
 	if(..()) return 1
 
-	M.nutrition -= nutriment_factor
+	M.nutrition = max(0, M.nutrition -= nutriment_factor)
 	M.overeatduration = 0
-	if(M.nutrition < 0) //Prevent from going into negatives
-		M.nutrition = 0
 
 /datum/reagent/soysauce
 	name = "Soysauce"
@@ -4367,6 +4365,8 @@
 			H.dizziness = max(0, H.dizziness - 15)
 		if(H.confused != 0)
 			H.confused = max(0, H.confused - 5)
+		if(H.hallucination != 0)
+			H.hallucination = max(0, H.hallucination - 25)
 
 /datum/reagent/ethanol/deadrum/changelingsting
 	name = "Changeling Sting"

--- a/html/changelogs/Intichem.yml
+++ b/html/changelogs/Intichem.yml
@@ -1,0 +1,5 @@
+author: Intigracy
+delete-after: True
+changes: 
+- rscadd: "Doctor's Delight now removes 25 units of hallucination per mob life tick."
+- tweak: "Spiritbreaker now applies 50 units of dizziness and hallucination per mob life tick, down from 100 each."


### PR DESCRIPTION
- rscadd: "Doctor's Delight now removes 25 units of hallucination per mob life tick."
- tweak: "Spiritbreaker now applies 50 units of dizziness and hallucination per mob life tick, down from 100 each."

This arose from a conversation in the thread about how OP spiritbreaker is, to the point that even once you get it out of your system (which there's no chemical for, so you have to water/potass or smoke reagent them) it's still going to take forever to reverse the effects.

This is still 5x the values of mindbreaker, so it's still a huge upgrade from it.
