### PR TITLE
Gives plasmamen suits unlimited extinguishes

### DIFF
--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -18,22 +18,15 @@
 
 	var/next_extinguish=0
 	var/extinguish_cooldown=10 SECONDS
-	var/extinguishes_left=10 // Yeah yeah, reagents, blah blah blah.  This should be simple.
-
-/obj/item/clothing/suit/space/plasmaman/examine(mob/user)
-	..()
-	to_chat(user, "<span class='info'>There are [extinguishes_left] extinguisher canisters left in this suit.</span>")
 
 /obj/item/clothing/suit/space/plasmaman/proc/Extinguish(var/mob/user)
 	var/mob/living/carbon/human/H=user
-	if(extinguishes_left)
-		if(next_extinguish > world.time)
-			return
+	if(next_extinguish > world.time)
+		return
 
-		next_extinguish = world.time + extinguish_cooldown
-		extinguishes_left--
-		to_chat(H, "<span class='warning'>Your suit automatically extinguishes the fire.</span>")
-		H.ExtinguishMob()
+	next_extinguish = world.time + extinguish_cooldown
+	to_chat(H, "<span class='warning'>Your suit automatically extinguishes the fire.</span>")
+	H.ExtinguishMob()
 
 /obj/item/clothing/head/helmet/space/plasmaman
 	name = "plasmaman helmet"

--- a/html/changelogs/9600bauds_fgiufdhiushdfisdfiaasdfh.yml
+++ b/html/changelogs/9600bauds_fgiufdhiushdfisdfiaasdfh.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general deleting of nice things)
+#   rscadd (general adding of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.
+author: 9600bauds
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# There needs to be a space after the - and before the prefix. Don't use tabs anywhere in this file.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# If you're using characters such as # ' : - or the like in your changelog, surround the entire change with quotes as shown in the second example. These quotes don't show up on the changelog once it's merged and prevent errors.
+# SCREW ANY OF THIS UP AND IT WON'T WORK.
+changes: 
+- tweak: Plasmamen suits now have unlimited extinguishing charges, up from 10.


### PR DESCRIPTION
There was a 10 extinguish limit for plasmamen suits and I really can't think of what the point of that limit was. It's enough to deter someone from removing their hardsuit and putting it back on quickly (i.e. for a search) but then again I've never heard of a plasmaman running out of charge on this thing anyways

It's extremely pointless, but still gets in the way. So I think it warrants a removal
