### PR TITLE
Give Neo Robotics Mech Bay another chance

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -246,6 +246,9 @@
 		target = safepick(view(3,target))
 		if(!target)
 			return
+	if(istype(target, /obj/machinery/door_control))
+		var/obj/machinery/door_control/button = target
+		return button.attack_hand(user)
 	if(get_dist(src, target)>1)
 		if(selected && selected.is_ranged())
 			selected.action(target)


### PR DESCRIPTION
A year since #3683
- Changed Mechs to be able to remotely press buttons, to allow them to maneuver around blast doors more easily

Map changes : 
- Mech Bay Entrance has been changed. Instead of a wall with a door and two shutters, it's now three shutters surrounded by two window tiles
- To enter or leave, you have buttons on both sides you can operate

This was and still is mostly a stylistic change, although usability was preserved as much as possible. You can enter Robotics fairly easily still, just need to press the button, get in, press another button to close. AI and Cyborgs can very easily toggle the shutters too

Only change is that there no longer is an airlock directly leading into Robotics. Eventually the shutters with buttons are as handy. However, they can't be hacked. Which actually makes illicit access a bit harder without blasting through the window bay

The windows also improve visibility, you can now see if there's people outside the Mech Bay wanting to get in, like mechs or Cyborgs

![robotics_redo](https://cloud.githubusercontent.com/assets/6137403/14517337/9294baf0-020c-11e6-974d-1a23905ea79c.png)
