### PR TITLE
Fix #7313, formatting

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -444,8 +444,8 @@
 	if(isAI(user))
 		return
 
-	//We are restrained, can't move or locked to something, this will compromise taking out the trash
-	if(user.restrained() || !user.canmove || user.locked_to)
+	//We are restrained or can't move, this will compromise taking out the trash
+	if(user.restrained() || !user.canmove)
 		return
 
 	if(istype(dropping, /obj/item))
@@ -476,7 +476,7 @@
 	if(!do_after(user, src, 20))
 		return
 
-	if(user.restrained() || !user.canmove || user.locked_to)
+	if(user.restrained() || !user.canmove)
 		return
 
 	if(target.locked_to)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -459,8 +459,8 @@
 	var/locHolder = dropping.loc
 	var/mob/target = dropping
 
-	//Our target, now confirmed to be a mob, can't move or is locked to something, same thing
-	if(!target.canmove || target.locked_to)
+	//Our target, now confirmed to be a mob, is locked to something, same thing
+	if(target.locked_to)
 		return
 
 	if(target == user)
@@ -479,7 +479,7 @@
 	if(user.restrained() || !user.canmove || user.locked_to)
 		return
 
-	if(!target.canmove || target.locked_to)
+	if(target.locked_to)
 		return
 
 	if(locHolder != target.loc)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -440,14 +440,12 @@
 		return ..(mover, target, height, air_group)
 
 /obj/machinery/disposal/MouseDrop_T(atom/dropping, mob/user)
-	if(istype(user, /mob/living/silicon/ai))
+	if(isAI(user))
 		return
 
-	if(!ismob(dropping))
-		if(istype(dropping, /obj/item))
-			if(!user.restrained() && user.canmove)
-				attackby(dropping, user)
-
+	if(istype(dropping, /obj/item))
+		if(!user.restrained() && user.canmove)
+			attackby(dropping, user)
 		return
 
 	var/locHolder = dropping.loc
@@ -455,20 +453,16 @@
 
 	if(target == user)
 		if(!user.restrained() && user.canmove && !user.locked_to)
-			target.visible_message("[target] starts climbing into the [src].", "You start climbing into the [src].")
-		else
-			return
+			target.visible_message("[target] starts climbing into \the [src].", "You start climbing into \the [src].")
 	else
 		if(isanimal(user))
-			return // animals cannot put mobs other than themselves into disposal
+			return //Animals cannot put mobs other than themselves into disposal
 
 		if(!user.restrained() && user.canmove)
 			if(target.locked_to)
 				return
 
-			user.visible_message("[user] starts stuffing [target] into the [src].", "You start stuffing [target] into the [src].")
-		else
-			return
+			user.visible_message("[user] starts stuffing \the [target] into \the [src].", "You start stuffing \the [target] into \the [src].")
 
 	if(!do_after(user, src, 20))
 		return
@@ -478,27 +472,17 @@
 
 	if(target == user)
 		if(!user.restrained() && user.canmove)
-			target.visible_message("[target] climbed into the [src].", "You climbed into the [src].")
-		else
-			return
+			target.visible_message("[target] climbs into \the [src].", "You climb into \the [src].")
 	else
 		if(!user.restrained() && user.canmove)
 			if(target.locked_to)
 				return
 
-			user.visible_message("[user] stuffed [target] into the [src]!", "You stuffed [target] into the [src]!")
-			log_attack("<SPAN CLASS='warning'>[key_name(user)] placed [key_name(target)] in a disposals unit/([src]).</SPAN>")
-		else
-			return
+			user.visible_message("[user] stuffed \the [target] into \the [src]!", "You stuffed \the [target] into \the [src]!")
+			log_attack("<span class='warning'>[key_name(user)] stuffed [key_name(target)] into a disposal unit/([src]).</span>")
 
 	add_fingerprint(user)
-
-	if(target.client)
-		target.client.perspective = EYE_PERSPECTIVE
-		target.client.eye = src
-
-	target.loc = src
-
+	target.forceMove(src)
 	update_icon()
 
 // virtual disposal object


### PR DESCRIPTION
- Use forceMove() instead of manually adjusting loc, fixes #7313
- A mob eye adjustment was removed along the way, since it's also handled by forceMove()

Other changes : 
- Tons of formatting, removing a bunch of useless "else return" segments (implicit in DM language, if not in all major coding languages), macros, \the, bit of comment formatting
- Squash item check slightly. No need to check that it isn't a mob before checking if it's an item, since it's an exception before the rest of the code
