### PR TITLE
IAA demotion promotion text cleanup

### DIFF
--- a/code/WorkInProgress/Cutelilduck/human_resources.dm
+++ b/code/WorkInProgress/Cutelilduck/human_resources.dm
@@ -1,13 +1,13 @@
 /obj/item/weapon/paper/demotion_key
 	name = "Human Resources: Demotion Fax Key"
-	info = "<center><B>Fax Machine Demotion Key</B></center><BR><BR>This document is intended for use in the station fax machines.<br><ol><li>Insert into fax with your Internal Affairs ID.</li><li>Select NANOTRASEN HR to send to; Requires official Agent authorization.</li><li>Use the printed chip to carefully set a name.</li></ol> Remember to probably capitolize the employee name. Acquire Heads of Staff stamps to bar respective access, and once you have completed gathering authorizations you can apply the chip to the intended ID card.<br><br>In case of a mistake, acquire a new ID card as Identification Computers cannot bypass the chip."
+	info = "<center><B>Fax Machine Demotion Key</B></center><BR><BR>This document is intended for use in the station fax machines sent to NANOTRASEN HR.  Demotion keys sent to Centcomm will result in insults and allegations of incompetence.<br><ol><li>Insert into fax with your Internal Affairs ID.</li><li>Select NANOTRASEN HR to send to; Requires official Agent authorization.</li><li>Use the printed chip to carefully set a name.</li></ol> Remember to match capitalization of the employee name. Acquire Heads of Staff stamps to bar respective access, and once you have completed gathering authorizations you can apply the chip to the intended ID card.<br><br>In case of a mistake, acquire a new ID card as Identification Computers cannot bypass the chip."
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "paper"
 	stamps = "<br><br><i>This document has an intricate Nanontrasen logo in magnetic ink. It looks impossible to forge.</i>"
 
 /obj/item/weapon/paper/commendation_key
 	name = "Human Resources: Commendation Fax Key"
-	info = "<center><B>Fax Machine Commendation Key</B></center><BR><BR>This document is intended for use in the station fax machines.<br><ol><li>Insert into fax with your Internal Affairs ID.</li><li>Select NANOTRASEN HR to send to; Requires official Agent authorization.</li><li>Take the printed sticker and give cordially to valued employee.</li></ol> Commendations should only be given to outstanding crew members and those who exhibit positive, productive qualities."
+	info = "<center><B>Fax Machine Commendation Key</B></center><BR><BR>This document is intended for use in the station fax machines sent to NANOTRASEN HR.  Commendation keys sent to Centcomm will result in insults and allegations of incompetence.<br><ol><li>Insert into fax with your Internal Affairs ID.</li><li>Select NANOTRASEN HR to send to; Requires official Agent authorization.</li><li>Take the printed sticker and give cordially to valued employee.</li></ol> Commendations should only be given to outstanding crew members and those who exhibit positive, productive qualities."
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "paper"
 	stamps = "<br><br><i>This document has an intricate Nanontrasen logo in magnetic ink. It looks impossible to forge.</i>"

--- a/code/WorkInProgress/Cutelilduck/human_resources.dm
+++ b/code/WorkInProgress/Cutelilduck/human_resources.dm
@@ -7,7 +7,7 @@
 
 /obj/item/weapon/paper/commendation_key
 	name = "Human Resources: Commendation Fax Key"
-	info = "<center><B>Fax Machine Commendation Key</B></center><BR><BR>This document is intended for use in the station fax machines sent to NANOTRASEN HR.  Commendation keys sent to Centcomm will result in insults and allegations of incompetence.<br><ol><li>Insert into fax with your Internal Affairs ID.</li><li>Select NANOTRASEN HR to send to; Requires official Agent authorization.</li><li>Take the printed sticker and give cordially to valued employee.</li></ol> Commendations should only be given to outstanding crew members and those who exhibit positive, productive qualities."
+	info = "<center><B>Fax Machine Commendation Key</B></center><BR><BR>This document is intended for use in the station fax machines sent to NANOTRASEN HR.  Commendation keys sent to Centcomm will result in insults and allegations of incompetence.<br><ol><li>Insert into fax with your Internal Affairs ID.</li><li>Select NANOTRASEN HR to send to; Requires official Agent authorization.</li><li>Take the printed poster and give cordially to valued employee.</li></ol> Commendations should only be given to outstanding crew members and those who exhibit positive, productive qualities."
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "paper"
 	stamps = "<br><br><i>This document has an intricate Nanontrasen logo in magnetic ink. It looks impossible to forge.</i>"

--- a/code/game/objects/items/mountable_frames/posters/poster.dm
+++ b/code/game/objects/items/mountable_frames/posters/poster.dm
@@ -57,8 +57,8 @@ obj/structure/sign/poster/New(var/serial)
 	serial_number = serial
 
 	if(serial_number == -1)
-		name += "Award of Sufficiency"
-		desc += "The mere sight of it makes you very proud."
+		name = "Award of Sufficiency"
+		desc = "The mere sight of it makes you very proud."
 		icon_state = "goldstar"
 	else
 		if(serial_number == loc)


### PR DESCRIPTION
In other news, the demotion chips are SHIT and poorly thought out.  Commendations don't actually ask for the persons name and they're just shitty posters.  Demotion chips work like ass and you are infinitely better served taking their ID to the HoP to have the access removed.  This is a basket of bad ideas and it's no wonder I never see them used.

Closes https://github.com/d3athrow/vgstation13/issues/9377

but goddamn this stuff needs real work.  
