### PR TITLE
Fixes #7552

### DIFF
--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -208,6 +208,7 @@
 	icon_type = "match"
 	plural_type = "es"
 	storage_slots = 21 //3 rows of 7 items
+	max_combined_w_class = 21
 	w_class = 1
 	flags = 0
 	var/matchtype = /obj/item/weapon/match


### PR DESCRIPTION
Matchboxes can hold 21 items (matchboxes) but inherit a max weight class (the combined weight of all items inside) of 14.  Adds a quick max_combined_w_class = 21 to fix that.  

Fixes #7552
