### PR TITLE
Fixes #7104

### DIFF
--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -246,9 +246,9 @@ var/paperwork_library
 		return
 	to_chat(user, "<span class='warning'>You stab [M] with the pen.</span>")
 	to_chat(M, "<span class='warning'>You feel a tiny prick!</span>")
-	M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been stabbed with [name]  by [user.name] ([user.ckey])</font>")
-	user.attack_log += text("\[[time_stamp()]\] <font color='red'>Used the [name] to stab [M.name] ([M.ckey])</font>")
-	msg_admin_attack("[user.name] ([user.ckey]) Used the [name] to stab [M.name] ([M.ckey]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
+	M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been stabbed with [type]  by [user.name] ([user.ckey])</font>")
+	user.attack_log += text("\[[time_stamp()]\] <font color='red'>Used the [type] to stab [M.name] ([M.ckey])</font>")
+	msg_admin_attack("[user.name] ([user.ckey]) Used the [type] to stab [M.name] ([M.ckey]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
 	if(!iscarbon(user))
 		M.LAssailant = null
 	else


### PR DESCRIPTION
Replaces [name] with [type]

Adds explicit type logging to identify when someone was stabbed with a parapen/sleepypen/whatnot since they all share the same [name].  I wanted to do this a better way but could not figure out how and am open to advice.

Fixes https://github.com/d3athrow/vgstation13/issues/7104
