### PR TITLE
Re-adds chemmasters default multiple pill number as 10

### DIFF
--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -413,6 +413,7 @@ USE THIS CHEMISTRY DISPENSER FOR MAPS SO THEY START AT 100 ENERGY
 	var/condi = 0
 	var/windowtype = "chem_master" //For the browser windows
 	var/useramount = 30 // Last used amount
+	var/pillamount = 10
 	//var/bottlesprite = "1" //yes, strings
 	var/pillsprite = "1"
 
@@ -649,7 +650,7 @@ USE THIS CHEMISTRY DISPENSER FOR MAPS SO THEY START AT 100 ENERGY
 
 		else if(href_list["createpill"] || href_list["createpill_multiple"])
 			var/count = 1
-			if(href_list["createpill_multiple"]) count = isgoodnumber(input("Select the number of pills to make.", 10, max_pill_count) as num)
+			if(href_list["createpill_multiple"]) count = isgoodnumber(input("Select the number of pills to make.", 10, pillamount) as num)
 			count = min(max_pill_count, count)
 			if(!count)
 				return

--- a/html/changelogs/Probe3.yml
+++ b/html/changelogs/Probe3.yml
@@ -1,0 +1,6 @@
+author: Probe1
+
+delete-after: True
+
+changes: 
+- tweak: Chemmasters once again use 10 pills as the default input when making multiple pills.


### PR DESCRIPTION
Re-adds variable to make chemmasters use 10 pills by default when selecting multiple pills.  Does not alter the way upgrades work.

Closes https://github.com/d3athrow/vgstation13/issues/6102
