### PR TITLE
Adds 'dump contents' verb to open reagent containers, adds 'empty container into' verb to sinks and toilets and urinals

### DIFF
--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -20,6 +20,26 @@
 	open = round(rand(0, 1))
 	update_icon()
 
+/obj/structure/toilet/verb/empty_container_into()
+	set name = "Empty container into"
+	set category = "Object"
+	set src in oview(1)
+
+	if(!usr || !isturf(usr.loc))
+		return
+	if(!open)
+		to_chat(usr, "<span class='warning'>\The [src] is closed!</span>")
+		return
+	var/obj/item/weapon/reagent_containers/container = usr.get_active_hand()
+	if(!istype(container))
+		to_chat(usr, "<span class='warning'>You need a reagent container in your active hand to do that.</span>")
+		return
+	return container.drain_into(usr, src)
+
+/obj/structure/toilet/AltClick()
+	if(Adjacent(usr))
+		return empty_container_into()
+	return ..()
 /obj/structure/toilet/attack_hand(mob/living/user as mob)
 	if(swirlie)
 		usr.visible_message("<span class='danger'>[user] slams the toilet seat onto [swirlie.name]'s head!</span>", "<span class='notice'>You slam the toilet seat onto [swirlie.name]'s head!</span>", "You hear reverberating porcelain.")
@@ -121,6 +141,24 @@
 	icon_state = "urinal"
 	density = 0
 	anchored = 1
+
+/obj/structure/urinal/verb/empty_container_into()
+	set name = "Empty container into"
+	set category = "Object"
+	set src in oview(1)
+
+	if(!usr || !isturf(usr.loc))
+		return
+	var/obj/item/weapon/reagent_containers/container = usr.get_active_hand()
+	if(!istype(container))
+		to_chat(usr, "<span class='warning'>You need a reagent container in your active hand to do that.</span>")
+		return
+	return container.drain_into(usr, src)
+
+/obj/structure/urinal/AltClick()
+	if(Adjacent(usr))
+		return empty_container_into()
+	return ..()
 
 /obj/structure/urinal/attackby(obj/item/I as obj, mob/user as mob)
 	if(istype(I, /obj/item/weapon/grab))
@@ -395,6 +433,24 @@
 	desc = "A sink used for washing one's hands and face."
 	anchored = 1
 	var/busy = 0 	//Something's being washed at the moment
+
+/obj/structure/sink/verb/empty_container_into()
+	set name = "Empty container into"
+	set category = "Object"
+	set src in oview(1)
+
+	if(!usr || !isturf(usr.loc))
+		return
+	var/obj/item/weapon/reagent_containers/container = usr.get_active_hand()
+	if(!istype(container))
+		to_chat(usr, "<span class='warning'>You need a reagent container in your active hand to do that.</span>")
+		return
+	return container.drain_into(usr, src)
+
+/obj/structure/sink/AltClick()
+	if(Adjacent(usr))
+		return empty_container_into()
+	return ..()
 
 /obj/structure/sink/attack_hand(mob/M as mob)
 	if(isrobot(M) || isAI(M))

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -21,7 +21,7 @@ var/list/LOGGED_SPLASH_REAGENTS = list("fuel", "thermite")
 	if (N)
 		amount_per_transfer_from_this = N
 
-/obj/item/weapon/reagent_containers/verb/empty_contents()
+/obj/item/weapon/reagent_containers/verb/empty_contents() //Just dump it out on the floor
 	set name = "Dump contents"
 	set category = "Object"
 	set src in usr
@@ -36,10 +36,28 @@ var/list/LOGGED_SPLASH_REAGENTS = list("fuel", "thermite")
 		to_chat(usr, "<span class='warning'>\The [src] is empty.</span>")
 		return
 	if(isturf(usr.loc))
-		to_chat(usr, "<span class='notice'>You empty the [src] onto the floor.</span>")
+		if(reagents.total_volume > 10) //Beakersplashing only likes to do this sound when over 10 units
+			playsound(get_turf(src), 'sound/effects/slosh.ogg', 25, 1)
 		reagents.reaction(usr.loc)
-		playsound(get_turf(src), 'sound/effects/slosh.ogg', 25, 1)
 		spawn() src.reagents.clear_reagents()
+		usr.visible_message("<span class='warning'>[usr] splashes something onto the floor!</span>",
+						 "<span class='notice'>You empty \the [src] onto the floor.</span>")
+
+/obj/item/weapon/reagent_containers/proc/drain_into(mob/user, var/atom/where) //We're flushing our contents down the drain!
+	if(usr.incapacitated())
+		to_chat(usr, "<span class='warning'>You can't do that while incapacitated.</span>")
+		return
+	if(!is_open_container(src))
+		to_chat(usr, "<span class='warning'>You can't, \the [src] is closed.</span>")
+		return
+	if(src.is_empty())
+		to_chat(usr, "<span class='warning'>\The [src] is empty.</span>")
+		return
+	playsound(get_turf(src), 'sound/effects/slosh.ogg', 25, 1)
+	reagents.reaction(where, TOUCH) //I don't think this will ever do anything but I guess maybe polyacid could melt a toilet
+	spawn() src.reagents.clear_reagents()
+	to_chat(user, "<span class='notice'>You flush \the [src] down \the [where].</span>")
+
 
 /obj/item/weapon/reagent_containers/AltClick()
 	if(find_holder_of_type(src, /mob) == usr && possible_transfer_amounts)

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -21,6 +21,26 @@ var/list/LOGGED_SPLASH_REAGENTS = list("fuel", "thermite")
 	if (N)
 		amount_per_transfer_from_this = N
 
+/obj/item/weapon/reagent_containers/verb/empty_contents()
+	set name = "Dump contents"
+	set category = "Object"
+	set src in usr
+
+	if(usr.incapacitated())
+		to_chat(usr, "<span class='warning'>You can't do that while incapacitated.</span>")
+		return
+	if(!is_open_container(src))
+		to_chat(usr, "<span class='warning'>You can't, \the [src] is closed.</span>")
+		return
+	if(src.is_empty())
+		to_chat(usr, "<span class='warning'>\The [src] is empty.</span>")
+		return
+	if(isturf(usr.loc))
+		to_chat(usr, "<span class='notice'>You empty the [src] onto the floor.</span>")
+		reagents.reaction(usr.loc)
+		playsound(get_turf(src), 'sound/effects/slosh.ogg', 25, 1)
+		spawn() src.reagents.clear_reagents()
+
 /obj/item/weapon/reagent_containers/AltClick()
 	if(find_holder_of_type(src, /mob) == usr && possible_transfer_amounts)
 		set_APTFT()
@@ -31,7 +51,9 @@ var/list/LOGGED_SPLASH_REAGENTS = list("fuel", "thermite")
 	..()
 	create_reagents(volume)
 
-	if (!possible_transfer_amounts)
+	if(!is_open_container(src))
+		src.verbs -= /obj/item/weapon/reagent_containers/verb/empty_contents
+	if(!possible_transfer_amounts)
 		src.verbs -= /obj/item/weapon/reagent_containers/verb/set_APTFT
 
 /obj/item/weapon/reagent_containers/attack_self(mob/user as mob)

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -617,17 +617,15 @@
 
 /obj/item/weapon/reagent_containers/food/drinks/soda_cans
 	vending_cat = "carbonated drinks"
+	flags = FPRINT //Starts sealed until you pull the tab! Lacks OPENCONTAINER for this purpose
 	//because playsound(user, 'sound/effects/can_open[rand(1,3)].ogg', 50, 1) just wouldn't work. also so badmins can varedit these
 	var/list/open_sounds = list('sound/effects/can_open1.ogg', 'sound/effects/can_open2.ogg', 'sound/effects/can_open3.ogg')
-
-/obj/item/weapon/reagent_containers/food/drinks/soda_cans/New()
-	..()
-	flags &= ~OPENCONTAINER //Starts sealed until you pull the tab!
 
 /obj/item/weapon/reagent_containers/food/drinks/soda_cans/attack_self(mob/user as mob)
 	if(!is_open_container())
 		to_chat(user, "You pull back the tab of \the [src] with a satisfying pop.")
 		flags |= OPENCONTAINER
+		src.verbs |= /obj/item/weapon/reagent_containers/verb/empty_contents
 		playsound(user, pick(open_sounds), 50, 1)
 		return
 	return ..()

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -116,18 +116,6 @@ var/global/list/logged_sprayed_reagents = list("sacid", "pacid", "lube", "fuel")
 
 	playsound(get_turf(src), 'sound/effects/spray2.ogg', 50, 1, -6)
 
-/obj/item/weapon/reagent_containers/spray/verb/empty()
-
-
-	set name = "Empty Spray Bottle"
-	set category = "Object"
-	set src in usr
-
-	if(isturf(usr.loc))
-		to_chat(usr, "<span class='notice'>You empty the [src] onto the floor.</span>")
-		reagents.reaction(usr.loc)
-		spawn(5) src.reagents.clear_reagents()
-
 //space cleaner
 /obj/item/weapon/reagent_containers/spray/cleaner
 	name = "space cleaner"
@@ -219,4 +207,3 @@ var/global/list/logged_sprayed_reagents = list("sacid", "pacid", "lube", "fuel")
 			returnToPool(D)
 
 	playsound(get_turf(src), 'sound/effects/spray2.ogg', 50, 1, -6)
-

--- a/html/changelogs/9600bauds_slosh.yml
+++ b/html/changelogs/9600bauds_slosh.yml
@@ -33,4 +33,5 @@ delete-after: True
 # If you're using characters such as # ' : - or the like in your changelog, surround the entire change with quotes as shown in the second example. These quotes don't show up on the changelog once it's merged and prevent errors.
 # SCREW ANY OF THIS UP AND IT WON'T WORK.
 changes: 
-- rscadd: "Added a 'dump contents' verb to most reagent containers that lets you empty the contents of the container onto the floor, like splashing a beaker. Useful for emptying bottles or drink glasses without having to drink whatever's inside."
+- rscadd: "Added a 'dump contents' verb to most reagent containers that lets you empty the contents of the container onto the floor, just like splashing a beaker."
+- rscadd: "Added a 'empty container into' verb to sinks, urinals, and toilets. This lets you empty the contents of a container without making a mess on the floor. You can also alt-click to use this verb quickly."

--- a/html/changelogs/9600bauds_slosh.yml
+++ b/html/changelogs/9600bauds_slosh.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general deleting of nice things)
+#   rscadd (general adding of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.
+author: 9600bauds
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# There needs to be a space after the - and before the prefix. Don't use tabs anywhere in this file.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# If you're using characters such as # ' : - or the like in your changelog, surround the entire change with quotes as shown in the second example. These quotes don't show up on the changelog once it's merged and prevent errors.
+# SCREW ANY OF THIS UP AND IT WON'T WORK.
+changes: 
+- rscadd: "Added a 'dump contents' verb to most reagent containers that lets you empty the contents of the container onto the floor, like splashing a beaker. Useful for emptying bottles or drink glasses without having to drink whatever's inside."


### PR DESCRIPTION
'dump contents': It's the exact same verb spraybottles have, but for everything
'empty container into': Like beakersplashing but doesn't make a stain if you're using one of the like five reagents in the whole game that do anything when splashed into the floor
97% tested

Adresses 2. of #8402
