### PR TITLE
Alt-click for jumpsuits and radios

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -74,6 +74,10 @@
 	for (var/channel_name in channels)
 		secure_radio_connections[channel_name] = add_radio(src, radiochannels[channel_name])
 
+/obj/item/device/radio/AltClick()
+	if(!usr.incapacitated() && find_holder_of_type(src, /mob/living) == usr)
+		attack_self(usr)
+
 /obj/item/device/radio/attack_self(mob/user as mob)
 	user.set_machine(src)
 	interact(user)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -418,7 +418,7 @@
 /obj/item/weapon/storage/MouseDrop(over_object, src_location, over_location)
 	..()
 	orient2hud(usr)
-	if (over_object == usr && (in_range(src, usr) || find_holder(src) == usr))
+	if (over_object == usr && (in_range(src, usr) || find_holder_of_type(src, /mob) == usr))
 		if (usr.s_active)
 			usr.s_active.close(usr)
 		src.show_to(usr)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -403,7 +403,7 @@ BLIND     // can't see anything
 /obj/item/clothing/under/proc/set_sensors(mob/usr as mob)
 	var/mob/M = usr
 	if (istype(M, /mob/dead/)) return
-	if (usr.stat || usr.restrained()) return
+	if (usr.incapacitated()) return
 	if(has_sensor >= 2)
 		to_chat(usr, "<span class='warning'>The controls are locked.</span>")
 		return 0
@@ -434,6 +434,10 @@ BLIND     // can't see anything
 	set src in usr
 	set_sensors(usr)
 	..()
+
+/obj/item/clothing/under/AltClick()
+	if(find_holder_of_type(src, /mob) == usr)
+		set_sensors(usr)
 
 /obj/item/clothing/under/verb/removetie()
 	set name = "Remove Accessory"

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -15,12 +15,14 @@ var/list/LOGGED_SPLASH_REAGENTS = list("fuel", "thermite")
 	set name = "Set transfer amount"
 	set category = "Object"
 	set src in range(0)
+	if(usr.incapacitated())
+		return
 	var/N = input("Amount per transfer from this:","[src]") as null|anything in possible_transfer_amounts
 	if (N)
 		amount_per_transfer_from_this = N
 
 /obj/item/weapon/reagent_containers/AltClick()
-	if(loc == usr && possible_transfer_amounts)
+	if(find_holder_of_type(src, /mob) == usr && possible_transfer_amounts)
 		set_APTFT()
 		return
 	return ..()

--- a/code/modules/telesci/gps.dm
+++ b/code/modules/telesci/gps.dm
@@ -152,8 +152,8 @@ var/global/secure_GPS_count = 0
 
 /obj/item/device/gps/secure/proc/announce(var/mob/wearer, var/obj/item/device/gps/secure/SPS, var/reason)
 	var/turf/pos = get_turf(SPS)
-	if(istype(find_holder(src), /mob/living))
-		var/mob/living/L = find_holder(src)
+	var/mob/living/L = find_holder_of_type(src, /mob/living/)
+	if(L)
 		L.show_message("\icon[src] [gpstag] beeps: <span class='danger'>Warning! SPS '[SPS.gpstag]' [reason] at [get_area(SPS)] ([pos.x-WORLD_X_OFFSET[pos.z]], [pos.y-WORLD_Y_OFFSET[pos.z]], [pos.z]).</span>", MESSAGE_HEAR)
 	else if(isturf(src.loc))
 		src.visible_message("\icon[src] [gpstag] beeps: <span class='danger'>Warning! SPS '[SPS.gpstag]' [reason] at [get_area(SPS)] ([pos.x-WORLD_X_OFFSET[pos.z]], [pos.y-WORLD_Y_OFFSET[pos.z]], [pos.z]).</span>")

--- a/html/changelogs/9600bauds_anditssoverylonguntilthesungoesdownagain.yml
+++ b/html/changelogs/9600bauds_anditssoverylonguntilthesungoesdownagain.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general deleting of nice things)
+#   rscadd (general adding of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.
+author: 9600bauds
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# There needs to be a space after the - and before the prefix. Don't use tabs anywhere in this file.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# If you're using characters such as # ' : - or the like in your changelog, surround the entire change with quotes as shown in the second example. These quotes don't show up on the changelog once it's merged and prevent errors.
+# SCREW ANY OF THIS UP AND IT WON'T WORK.
+changes: 
+- rscadd: "You can now alt-click a jumpsuit (while worn or in your inventory) to bring up the suit sensors menu."
+- rscadd: "Alt-clicking a radio or headset (while worn or in your inventory) will now work the same as using it in your hand, bringing up the frequency/channel settings."


### PR DESCRIPTION
Addresses 1. and 3. of #8402
Fak u I copypaste this here
+changes: 
+- rscadd: "You can now alt-click a jumpsuit (while worn or in your inventory) to bring up the suit sensors menu."
+- rscadd: "Alt-clicking a radio or headset (while worn or in your inventory) will now work the same as using it in your hand, bringing up the frequency/channel settings."

Also fixes some wrong sanity that wouldn't work if you were in a locker or something
