### PR TITLE
Fixes #9470

### DIFF
--- a/code/modules/food/cooking_machines.dm
+++ b/code/modules/food/cooking_machines.dm
@@ -136,14 +136,14 @@ var/global/ingredientLimit = 10
 	else . = ..()
 
 /obj/machinery/cooking/attackby(obj/item/I,mob/user)
-	if(stat & (NOPOWER | BROKEN))
-		to_chat(user, "<span class='warning'> The power's off, it's no good. </span>")
-		return
 	if(src.active)
 		to_chat(user, "<span class='warning'>[src.name] is currently busy.</span>")
 		return
 	else if(..())
 		return 1
+	else if(stat & (NOPOWER | BROKEN))
+		to_chat(user, "<span class='warning'> The power's off, it's no good. </span>")
+		return
 	else if(istype(user,/mob/living/silicon))
 		to_chat(user, "<span class='warning'>That's a terrible idea.</span>")
 		return


### PR DESCRIPTION
A fix for my previous bug fix which really showcases my skill level.  I'm frankly embarrassed I didn't see this.

The original bug was obj/oven and children of oven could work without power.  The if broken check was placed haphazardly before other checks which had strange and buggy consequences, including being unable to unwrench oven/subtypes when power was off.

This will fix it and I have tested every situation I can think up.  

_Fixes [8825] but this time for realsies and I tested it_
Nice one Probe.
