### PR TITLE
Fixes shadowstep cooldown being 2 seconds, not 20

### DIFF
--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -510,7 +510,7 @@
 			T.turf_animation('icons/effects/effects.dmi',"shadowstep")
 			usr.loc = picked
 		M.current.verbs -= /client/proc/vampire_shadowstep
-		sleep(20)
+		sleep(20 SECONDS)
 		M.current.verbs += /client/proc/vampire_shadowstep
 
 /client/proc/vampire_shadowmenace()


### PR DESCRIPTION
whoops I made an issue only to make a PR on it a few minutes later
this may seem extremely vain but I wasn't even planning on making this PR because I had another branch checked out in git with uncommited changes

Fixes #9483
