### PR TITLE
succumb tweak

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -297,7 +297,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	set name = "Ghost"
 	set desc = "Relinquish your life and enter the land of the dead."
 
-	if(src.health < 0 && src.health > -95.0) //crit people
+	if(src.health < 0 && stat != DEAD) //crit people
 		succumb()
 		ghostize(1)
 	else if(stat == DEAD)
@@ -923,5 +923,5 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		return
 	speed = text2num(copytext(speed,1,4))/100
 	movespeed = 1/speed
-	
+
 /datum/locking_category/observer

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -175,10 +175,10 @@
 
 /mob/living/verb/succumb()
 	set hidden = 1
-	if ((src.health < 0 && src.health > -95.0))
+	if (src.health < 0 && stat != DEAD)
 		src.attack_log += "[src] has succumbed to death with [health] points of health!"
-		src.apply_damage(maxHealth + 5 + src.health, OXY) // This will ensure people die when using the command, but don't go into overkill. 15 oxy points over the limit for safety since brute and burn regenerates
-		src.health = 100 - src.getOxyLoss() - src.getToxLoss() - src.getFireLoss() - src.getBruteLoss()
+		src.apply_damage(maxHealth + src.health, OXY)
+		death(0)
 		to_chat(src, "<span class='info'>You have given up life and succumbed to death.</span>")
 
 

--- a/html/changelogs/Intisuccumbedit.yml
+++ b/html/changelogs/Intisuccumbedit.yml
@@ -1,0 +1,4 @@
+author: Intigracy
+delete-after: True
+changes: 
+- bugfix: Dionae succumbing to death will actually die now.


### PR DESCRIPTION
Succumbing now kills you. I retained the oxygen damage being applied because it's a nice touch.

I also changed the check for succumbing to check if you're dead rather than to check if you have more than -95 health.

fixes #9480

Tested.
