### PR TITLE
assburgers have no spiritbreaker, mindbreaker instead

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -1168,7 +1168,7 @@
 		reagents.add_reagent("nutriment", 6)
 		reagents.add_reagent("bustanut", 6)
 		reagents.add_reagent("sodiumchloride", 6)
-		
+
 /obj/item/weapon/reagent_containers/food/snacks/oldempirebar
 	name = "Old Empire Bar"
 	icon_state = "old_empire_bar"
@@ -3076,7 +3076,7 @@
 	New()
 		..()
 		reagents.add_reagent("nutriment", 6)
-		reagents.add_reagent("spiritbreaker", 10) // Screaming
+		reagents.add_reagent("mindbreaker", 10) // Screaming
 		reagents.add_reagent("mercury",       10) // Idiot
 		bitesize = 2
 
@@ -3975,7 +3975,7 @@
 /obj/item/weapon/reagent_containers/food/snacks/eucharist/New()
 	..()
 	reagents.add_reagent("holywater", 5)
-	
+
 /obj/item/weapon/reagent_containers/food/snacks/eclair
 	name = "\improper eclair"
 	desc = "Plus doux que ses lèvres."

--- a/html/changelogs/Intiassburgers.yml
+++ b/html/changelogs/Intiassburgers.yml
@@ -1,0 +1,4 @@
+author: Intigracy
+delete-after: True
+changes: 
+- tweak: "Assburgers now give 10u mindbreaker, not 10u spiritbreaker."


### PR DESCRIPTION
Because 10 spiritbreaker from an item you can produce easily using monkeys is pretty bad.

I'm not gonna remove getting it from the no-fruit though, that at least requires skill/luck to get one of the cruciatus plant.
