### PR TITLE
Fix being able to bin stuff that doesn't belong in a bin

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -451,13 +451,16 @@
 	if(user.restrained() || !user.canmove)
 		return
 
-	if(istype(dropping, /obj/item))
+	if(!ismob(dropping)) //Not a mob, so we can expect it to be an item
+		if(istype(dropping, /obj/item))
 
-		if(dropping.locked_to) //Items can very specifically be locked to something, check that here
+			if(dropping.locked_to) //Items can very specifically be locked to something, check that here
+				return
+
+			attackby(dropping, user)
 			return
 
-		attackby(dropping, user)
-		return
+	//From there, we are working on a mob (as our target, user is supposed to be a mob)
 
 	var/locHolder = dropping.loc
 	var/mob/target = dropping

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -458,7 +458,7 @@
 				return
 
 			attackby(dropping, user)
-			return
+		return
 
 	//From there, we are working on a mob (as our target, user is supposed to be a mob)
 


### PR DESCRIPTION
Need to make sure we are working on a mob, else any movable atom can go, and there's lots of movable atoms that aren't items

Fixes #9522
