### PR TITLE
Trader fixes

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -15,7 +15,7 @@ var/list/potential_theft_objectives=list(
 	var/target_amount = 0				//If they are focused on a particular number. Steal objectives have their own counter.
 	var/completed = 0					//currently only used for custom objectives.
 	var/blocked = 0                     // Universe fucked, you lost.
-	var/list/bad_targets = list("AI","Cyborg","Mobile MMI","Trader")//For roundstart cases where they are still human at the time of objective assignment
+	var/list/bad_targets = list("AI","Cyborg","Mobile MMI")//For roundstart cases where they are still human at the time of objective assignment
 
 /datum/objective/New(var/text)
 	if(text)

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -15,7 +15,7 @@ var/list/potential_theft_objectives=list(
 	var/target_amount = 0				//If they are focused on a particular number. Steal objectives have their own counter.
 	var/completed = 0					//currently only used for custom objectives.
 	var/blocked = 0                     // Universe fucked, you lost.
-	var/list/bad_targets = list("AI","Cyborg","Mobile MMI")//For roundstart cases where they are still human at the time of objective assignment
+	var/list/bad_targets = list("AI","Cyborg","Mobile MMI","Trader")//For roundstart cases where they are still human at the time of objective assignment
 
 /datum/objective/New(var/text)
 	if(text)

--- a/code/game/gamemodes/traitor/doubleagent.dm
+++ b/code/game/gamemodes/traitor/doubleagent.dm
@@ -1,7 +1,7 @@
 /datum/game_mode/traitor/double_agents
 	name = "double agents"
 	config_tag = "double_agents"
-	restricted_jobs = list("Cyborg", "AI", "Captain", "Head of Personnel", "Chief Medical Officer", "Research Director", "Chief Engineer", "Head of Security", "Mobile MMI", "Trader") // Human / Minor roles only.
+	restricted_jobs = list("Cyborg", "AI", "Captain", "Head of Personnel", "Chief Medical Officer", "Research Director", "Chief Engineer", "Head of Security", "Mobile MMI") // Human / Minor roles only.
 	required_players = 15
 	required_enemies = 2 //we only need 2 - the agent, and the other agent
 	recommended_enemies = 6

--- a/code/game/gamemodes/traitor/doubleagent.dm
+++ b/code/game/gamemodes/traitor/doubleagent.dm
@@ -1,7 +1,7 @@
 /datum/game_mode/traitor/double_agents
 	name = "double agents"
 	config_tag = "double_agents"
-	restricted_jobs = list("Cyborg", "AI", "Captain", "Head of Personnel", "Chief Medical Officer", "Research Director", "Chief Engineer", "Head of Security", "Mobile MMI") // Human / Minor roles only.
+	restricted_jobs = list("Cyborg", "AI", "Captain", "Head of Personnel", "Chief Medical Officer", "Research Director", "Chief Engineer", "Head of Security", "Mobile MMI", "Trader") // Human / Minor roles only.
 	required_players = 15
 	required_enemies = 2 //we only need 2 - the agent, and the other agent
 	recommended_enemies = 6

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -252,6 +252,7 @@ var/shuttle_call/shuttle_calls[0]
 		// Status display stuff
 		if("setstat")
 			display_type=href_list["statdisp"]
+			to_chat(usr, "Set stat: [display_type]") //debug message
 			switch(display_type)
 				if("message")
 					post_status("message", stat_msg1, stat_msg2)

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -252,7 +252,6 @@ var/shuttle_call/shuttle_calls[0]
 		// Status display stuff
 		if("setstat")
 			display_type=href_list["statdisp"]
-			to_chat(usr, "Set stat: [display_type]") //debug message
 			switch(display_type)
 				if("message")
 					post_status("message", stat_msg1, stat_msg2)

--- a/html/changelogs/unid-ug.yml
+++ b/html/changelogs/unid-ug.yml
@@ -28,4 +28,4 @@ delete-after: True
 
 changes: 
 - bugfix: "Fixed missing trader spawn points"
-- tweak: "Traders have more metal and glass at roundstart (50/50 of each)"
+- tweak: "Traders have more metal and glass at roundstart (50 of each)"

--- a/html/changelogs/unid-ug.yml
+++ b/html/changelogs/unid-ug.yml
@@ -27,5 +27,5 @@ author: Unid
 delete-after: True
 
 changes: 
-- bugfix: "Traders can no longer become double agents. Fixed missing trader spawn points"
+- bugfix: "Fixed missing trader spawn points"
 - tweak: "Traders have more metal and glass at roundstart (50/50 of each)"

--- a/html/changelogs/unid-ug.yml
+++ b/html/changelogs/unid-ug.yml
@@ -27,5 +27,5 @@ author: Unid
 delete-after: True
 
 changes: 
-- bugfix: "Fixed some issues with traders. Traders are no longer valid assassination targets for antagonists, and can no longer become double agents."
+- bugfix: "Traders can no longer become double agents. Fixed missing trader spawn points"
 - tweak: "Traders have more metal and glass at roundstart (50/50 of each)"

--- a/html/changelogs/unid-ug.yml
+++ b/html/changelogs/unid-ug.yml
@@ -1,0 +1,31 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general deleting of nice things)
+#   rscadd (general adding of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.
+author: Unid
+
+delete-after: True
+
+changes: 
+- bugfix: "Fixed some issues with traders. Traders are no longer valid assassination targets for antagonists, and can no longer become double agents."
+- tweak: "Traders have more metal and glass at roundstart (50/50 of each)"


### PR DESCRIPTION
- Traders now have 50 metal and 50 glass, instead of something like 20/10 (why). Also moved third trader's spawn point so that they spawn in a N2-filled room and put some spawn points on deff (Fixes #9517)
