### PR TITLE
ZAS slam damage protection rework

### DIFF
--- a/code/ZAS/Airflow.dm
+++ b/code/ZAS/Airflow.dm
@@ -405,6 +405,9 @@ mob/living/carbon/human/airflow_hit(atom/A)
 //	for(var/mob/M in hearers(src))
 //		M.show_message("<span class='danger'>[src] slams into [A]!</span>",1,"<span class='warning'>You hear a loud slam!</span>",2)
 	//playsound(get_turf(src), "punch", 25, 1, -1)
+
+
+	/*See this? This is how you DON'T handle armor values for protection
 	if(prob(33))
 		loc:add_blood(src)
 		bloody_body(src)
@@ -426,6 +429,18 @@ mob/living/carbon/human/airflow_hit(atom/A)
 			stunned = max(stunned,paralysis + 3)
 		else
 			stunned += round(airflow_speed * zas_settings.Get(/datum/ZAS_Setting/airflow_stun)/2)
+	*/
+
+	var/b_loss = airflow_speed * zas_settings.Get(/datum/ZAS_Setting/airflow_damage)
+
+	var/head_damage = ((b_loss/3)/100) * getarmor("head","melee")
+	apply_damage(head_damage, BRUTE, "head", 0, 0, used_weapon = "Airflow")
+
+	var/chest_damage = ((b_loss/3)/100) * getarmor("chest","melee")
+	apply_damage(chest_damage, BRUTE, "head", 0, 0, used_weapon = "Airflow")
+
+	var/groin_damage = ((b_loss/3)/100) * getarmor("groin","melee")
+	apply_damage(groin_damage, BRUTE, "head", 0, 0, used_weapon = "Airflow")
 
 	. = ..()
 

--- a/code/ZAS/Airflow.dm
+++ b/code/ZAS/Airflow.dm
@@ -433,14 +433,19 @@ mob/living/carbon/human/airflow_hit(atom/A)
 
 	var/b_loss = airflow_speed * zas_settings.Get(/datum/ZAS_Setting/airflow_damage)
 
-	var/head_damage = ((b_loss/3)/100) * getarmor("head","melee")
+	var/head_damage = ((b_loss/3)/100) * (100 - getarmor("head","melee"))
 	apply_damage(head_damage, BRUTE, "head", 0, 0, used_weapon = "Airflow")
 
-	var/chest_damage = ((b_loss/3)/100) * getarmor("chest","melee")
+	var/chest_damage = ((b_loss/3)/100) * (100 - getarmor("chest","melee"))
 	apply_damage(chest_damage, BRUTE, "head", 0, 0, used_weapon = "Airflow")
 
-	var/groin_damage = ((b_loss/3)/100) * getarmor("groin","melee")
+	var/groin_damage = ((b_loss/3)/100) * (100 - getarmor("groin","melee"))
 	apply_damage(groin_damage, BRUTE, "head", 0, 0, used_weapon = "Airflow")
+
+	if((head_damage + chest_damage + groin_damage) > 15)
+		var/turf/T = get_turf(src)
+		T.add_blood(src)
+		bloody_body(src)
 
 	. = ..()
 

--- a/code/ZAS/Airflow.dm
+++ b/code/ZAS/Airflow.dm
@@ -422,13 +422,6 @@ mob/living/carbon/human/airflow_hit(atom/A)
 
 	blocked = run_armor_check("groin","melee")
 	apply_damage(b_loss/3, BRUTE, "groin", blocked, 0, used_weapon = "Airflow")
-
-	if(zas_settings.Get(/datum/ZAS_Setting/airflow_push) || AirflowCanPush())
-		if(airflow_speed > 10)
-			paralysis += round(airflow_speed * zas_settings.Get(/datum/ZAS_Setting/airflow_stun))
-			stunned = max(stunned,paralysis + 3)
-		else
-			stunned += round(airflow_speed * zas_settings.Get(/datum/ZAS_Setting/airflow_stun)/2)
 	*/
 
 	var/b_loss = airflow_speed * zas_settings.Get(/datum/ZAS_Setting/airflow_damage)
@@ -446,6 +439,13 @@ mob/living/carbon/human/airflow_hit(atom/A)
 		var/turf/T = get_turf(src)
 		T.add_blood(src)
 		bloody_body(src)
+
+	if(zas_settings.Get(/datum/ZAS_Setting/airflow_push) || AirflowCanPush())
+		if(airflow_speed > 10)
+			paralysis += round(airflow_speed * zas_settings.Get(/datum/ZAS_Setting/airflow_stun))
+			stunned = max(stunned,paralysis + 3)
+		else
+			stunned += round(airflow_speed * zas_settings.Get(/datum/ZAS_Setting/airflow_stun)/2)
 
 	. = ..()
 


### PR DESCRIPTION
![zas](https://cloud.githubusercontent.com/assets/7573912/14672914/1d61617c-06fb-11e6-90b7-3efc5715ccc3.jpg)
it says "head_damage" 3 times but in fact it's head, chest, and groin

Previously airflow would roll a dice based on your armor protection and deal you either full damage or no damage at all based on some bullshit probability check. I'm not saying that percentage damage is the solution for everything, but at the very least in this case, it is.

I ran a few tests to compare and make sure the rework is working. The above pic was made on dangerous ZAS settings.

Nuke Ops shouldn't anymore get wrecked too bad because of ZAS.
