### PR TITLE
[Hotfix] soulstone update stuff

### DIFF
--- a/code/game/gamemodes/wizard/soulstone.dm
+++ b/code/game/gamemodes/wizard/soulstone.dm
@@ -360,7 +360,7 @@
 					T.canmove = 0
 					T.health = T.maxHealth
 					C.icon_state = "soulstone2"
-					C.item_state = "shard-soulstone"
+					C.item_state = "shard-soulstone2"
 					U.update_inv_l_hand()
 					U.update_inv_r_hand()
 					C.name = "Soul Stone: [T.real_name]"

--- a/code/game/gamemodes/wizard/soulstone.dm
+++ b/code/game/gamemodes/wizard/soulstone.dm
@@ -328,7 +328,7 @@
 		qdel(add_target)
 
 
-/obj/item/proc/transfer_soul(var/choice as text, var/target, var/mob/U as mob)
+/obj/item/proc/transfer_soul(var/choice as text, var/target, var/mob/living/carbon/U as mob)
 	var/deleteafter = 0
 	switch(choice)
 		if("VICTIM")
@@ -360,6 +360,9 @@
 					T.canmove = 0
 					T.health = T.maxHealth
 					C.icon_state = "soulstone2"
+					C.item_state = "shard-soulstone"
+					U.update_inv_l_hand()
+					U.update_inv_r_hand()
 					C.name = "Soul Stone: [T.real_name]"
 					to_chat(T, "Your soul has been recaptured by the soul stone, its arcane energies are reknitting your ethereal form")
 					to_chat(U, "<span class='notice'><b>Capture successful!</b>: </span>[T.name]'s has been recaptured and stored within the soul stone.")

--- a/code/game/gamemodes/wizard/soulstone.dm
+++ b/code/game/gamemodes/wizard/soulstone.dm
@@ -53,7 +53,7 @@
 
 
 /obj/item/device/soulstone/Topic(href, href_list)
-	var/mob/U = usr
+	var/mob/living/carbon/U = usr
 	if (!in_range(src, U)||U.machine!=src)
 		U << browse(null, "window=aicard")
 		U.unset_machine()
@@ -72,6 +72,9 @@
 			for(var/mob/living/simple_animal/shade/A in src)
 				eject_shade(U)
 				src.icon_state = "soulstone"
+				src.item_state = "shard-soulstone"
+				U.update_inv_l_hand()
+				U.update_inv_r_hand()
 				src.name = "Soul Stone Shard"
 
 	attack_self(U)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1179,14 +1179,16 @@
 			updatehealth()
 			UpdateDamageIcon()
 
-			B.loc = src
-			affected.organ_item = B //this stores the organ for continuity
+			if(B.brainmob.mind)
+				B.brainmob.mind.transfer_to(src)
 
 			if(B.borer)
 				B.borer.perform_infestation(src)
 				B.borer=null
 
 			decapitated = null
+
+			qdel(B)
 
 	for(var/datum/organ/internal/I in internal_organs)
 		I.damage = 0

--- a/code/modules/surgery/headreattach.dm
+++ b/code/modules/surgery/headreattach.dm
@@ -230,8 +230,7 @@
 	affected.internal_organs += copied
 
 	user.u_equip(B,1)
-	B.loc = target
-	affected.organ_item = B //this stores the organ for continuity
+	qdel(B)
 
 
 /datum/surgery_step/head/attach/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)


### PR DESCRIPTION
- Fixed summoning/recapturing shades not updating the soulstone's item_state.
- Re-attaching a head/rejuvinating a decapitated player now deletes the head item after all the data has been copied. There's no real continuity that warrants the item still existing, however it causes further bug when trying to soulstone someone who had their head re-attached.
- Rejuvinating a player that had been decapitated puts them back in control of their body.
