### PR TITLE
fixes some stupid flag requirements

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -805,7 +805,7 @@ var/global/floorIsLava = 0
 
 	dat += "<BR>"
 
-	if(check_rights(R_DEBUG,0))
+	if(check_rights(R_FUN,0))
 		dat += {"
 			<B>Security Level Elevated</B><BR>
 			<BR>
@@ -814,12 +814,15 @@ var/global/floorIsLava = 0
 			<A href='?src=\ref[src];secretscoder=infinite_sec'>Remove cap on security officers</A><BR>
 			<a href='?src=\ref[src];secretscoder=virus_custom'>Custom Virus Outbreak</a><BR>
 			<BR>
-			<B>Coder Secrets</B><BR>
-			<BR>
-			<A href='?src=\ref[src];secretsadmin=list_job_debug'>Show Job Debug</A><BR>
-			<A href='?src=\ref[src];secretscoder=spawn_objects'>Admin Log</A><BR>
-			<BR>
 			"}
+	dat +=	{"
+		<B>Coder Secrets</B><BR>
+		<BR>
+		<A href='?src=\ref[src];secretsadmin=list_job_debug'>Show Job Debug</A><BR>
+		<A href='?src=\ref[src];secretscoder=spawn_objects'>Admin Log</A><BR>
+		<BR>
+		"}
+
 
 	usr << browse(dat, "window=secrets")
 	return

--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -137,7 +137,7 @@ var/list/forbidden_varedit_object_types = list(
 		else
 			L = list()
 
-	var/list/locked = list("vars", "client", "firemut", "ishulk", "telekinesis", "xray", "virus", "viruses", "cuffed", "ka", "last_eaten", "urine", "poo", "icon", "icon_state")
+	var/list/locked = list("vars", "client")
 	var/list/names = sortList(L)
 
 	var/variable = input("Which var?","Var") as null|anything in names + "(ADD VAR)"


### PR DESCRIPTION
Admins can now edit icon/icon_state without needing DEBUG. You needed varedit even if you had debug anyway, and this list is so ancient that it references poo and urine.

Every admin can now use the admin log in the secrets menu.

Changing door accesses/remove sec cap(if this still even works) is now under FUN instead of DEBUG.

This isn't just so I can use more things, some of these requirements are legitimately stupid.
