### PR TITLE
Byond fucked up

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -252,7 +252,7 @@ var/global/num_vending_terminals = 1
 			if(prob(25)) malfunction()
 
 /obj/machinery/vending/proc/build_inventory(var/list/productlist,hidden=0,req_coin=0)
-	for(var/obj/item/typepath in productlist)
+	for(var/typepath in productlist)
 		var/amount = productlist[typepath]
 		var/price = prices[typepath]
 
@@ -276,8 +276,9 @@ var/global/num_vending_terminals = 1
 			R.category = CAT_NORMAL
 			product_records.Add(R)
 
-		R.product_name = initial(typepath.name)
-		R.subcategory = initial(typepath.vending_cat)
+		var/obj/item/initializer = typepath
+		R.product_name = initial(initializer.name)
+		R.subcategory = initial(initializer.vending_cat)
 
 /obj/machinery/vending/proc/get_item_by_type(var/this_type)
 	var/list/datum_products = list()


### PR DESCRIPTION
Typecasting a variable as an /obj didn't allow it to access the associative list index where a typepath was the index. This is literally the first I've ever heard of this, it's almost worthy of a bug report.