### PR TITLE
Species Damage Modifiers Affect Targeted External Organ Damage

### DIFF
--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -85,6 +85,12 @@
 	if(!is_organic())
 		brute *= 0.66 //~2/3 damage for ROBOLIMBS
 		burn *= (status & (ORGAN_PEG) ? 2 : 0.66) //~2/3 damage for ROBOLIMBS 2x for peg
+	else
+		if(owner.species)
+			if(owner.species.brute_mod)
+				brute *= owner.species.brute_mod
+			if(owner.species.burn_mod)
+				burn *= owner.species.burn_mod
 
 	//If limb took enough damage, try to cut or tear it off
 	if(body_part != UPPER_TORSO && body_part != LOWER_TORSO) //As hilarious as it is, getting hit on the chest too much shouldn't effectively gib you.

--- a/html/changelogs/Shadowmech88.yml
+++ b/html/changelogs/Shadowmech88.yml
@@ -1,4 +1,4 @@
 author: Shadowmech88
 delete-after: True
 changes: 
-- tweak: Species damage modifiers are now applied when individual external organs take damage.
+- tweak: Diona now properly take increased burn damage from electrical shocks, and golems now properly take decreased burn damage from electrical shocks.

--- a/html/changelogs/Shadowmech88.yml
+++ b/html/changelogs/Shadowmech88.yml
@@ -1,0 +1,4 @@
+author: Shadowmech88
+delete-after: True
+changes: 
+- tweak: Species damage modifiers are now applied when individual external organs take damage.


### PR DESCRIPTION
`/datum/organ/external/proc/take_damage()` now takes the burn_mod and brute_mod of the organ's owner's species into account when applying damage.
The most obvious effect of this is that now diona will take increased burn damage from electrical shocks according to their burn_mod, and golems will take decreased burn damage from electrical shocks according to their burn_mod.

Fixes #9533.
