### PR TITLE
The RPED now only needs metal and glass

### DIFF
--- a/code/modules/research/designs/engineering.dm
+++ b/code/modules/research/designs/engineering.dm
@@ -99,7 +99,7 @@
 	id = "rped"
 	req_tech = list("engineering" = 4, "materials" = 4, "programming" = 2)
 	build_type = PROTOLATHE
-	materials = list(MAT_IRON = 500, MAT_GLASS = 1000, MAT_GOLD = 200, MAT_SILVER = 200)
+	materials = list(MAT_IRON = 1000, MAT_GLASS = 1000)
 	build_path = /obj/item/weapon/storage/bag/gadgets/part_replacer
 	category = "Engineering"
 


### PR DESCRIPTION
You see, if we use uranium gold and silver, then mechanics cry, if we use plastic then science has to loot the station of its plastic flaps.

What if we ask our selves, why the hell do we need mats for stock parts anyways?
Why?
Why can't we just require metal and glass?
Will the fucking station rip itself apart due to the minor 'muh meta' change?

Who gives a shit.

This way everyone is happy.

Or you know, we could have revert 'revert 'revert 'revert tier three parts requiring plastic'''

This is the first PR that effects the RPED,
Don't think of it as me not knowing how the fuck git works, think of it as me making atomic PRs, whatever that means.
