### PR TITLE
Tier three parts now require only metal and glass

### DIFF
--- a/code/modules/research/designs/stock_parts.dm
+++ b/code/modules/research/designs/stock_parts.dm
@@ -107,7 +107,7 @@
 	req_tech = list("powerstorage" = 5, "materials" = 4)
 	build_type = PROTOLATHE
 	reliability_base = 71
-	materials = list(MAT_IRON = 50, MAT_GLASS = 50, MAT_GOLD = 20)
+	materials = list(MAT_IRON = 100, MAT_GLASS = 100)
 	category = "Stock Parts"
 	build_path = /obj/item/weapon/stock_parts/capacitor/adv/super
 
@@ -118,7 +118,7 @@
 	id = "phasic_sensor"
 	req_tech = list("magnets" = 5, "materials" = 3)
 	build_type = PROTOLATHE
-	materials = list(MAT_IRON = 50, MAT_GLASS = 20, MAT_SILVER = 10)
+	materials = list(MAT_IRON = 100, MAT_GLASS = 40)
 	reliability_base = 72
 	category = "Stock Parts"
 	build_path = /obj/item/weapon/stock_parts/scanning_module/adv/phasic
@@ -140,7 +140,7 @@
 	id = "ultra_micro_laser"
 	req_tech = list("magnets" = 5, "materials" = 5)
 	build_type = PROTOLATHE
-	materials = list(MAT_IRON = 10, MAT_GLASS = 20, MAT_URANIUM = 10)
+	materials = list(MAT_IRON = 20, MAT_GLASS = 40)
 	reliability_base = 70
 	category = "Stock Parts"
 	build_path = /obj/item/weapon/stock_parts/micro_laser/high/ultra


### PR DESCRIPTION
You see, if we use uranium gold and silver, then mechanics cry, if we use plastic then science has to loot the station of its plastic flaps.

What if we ask our selves, why the hell do we need mats for stock parts anyways?
Why?
Why can't we just require metal and glass?
Will the fucking station rip itself apart due to the minor 'muh meta' change?

Who gives a shit.

This way everyone is happy.

Or you know, we could have revert 'revert 'revert 'revert tier three parts requiring plastic'''

This is the second PR that effects the tier three stock parts,
Don't think of it as me not knowing how the fuck git works, think of it as me making atomic PRs, whatever that means.
