### PR TITLE
Trans-species limb/head reattachment surgery improvements

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -192,3 +192,39 @@ proc/add_ghostlogs(var/mob/user, var/obj/target, var/what_done, var/admin=1, var
 		2.7; "A-",\
 		0.8; "B-",\
 		0.3; "AB-")*/
+
+//Returns list of organs that are affected by items worn in the slot. For example, calling get_organ_by_slot(slot_belt) will return list(groin)
+//If H is null, a list of organ names is returned: list("l_arm", "l_hand")
+//If H isn't null, a list of organ objects from H is returned: list(H.get_organ("l_arm"), H.get_organ("l_hand"))
+
+/proc/get_organs_by_slot(input_slot, mob/living/carbon/human/H = null)
+	var/list/L
+
+	switch(input_slot)
+		if(slot_wear_suit) //Exosuit
+			L = list("chest", "groin", "l_arm", "l_hand", "r_arm", "r_hand", "l_leg", "l_foot", "r_leg", "r_foot")
+		if(slot_w_uniform) //Uniform
+			L = list("chest", "groin", "l_arm", "r_arm", "l_leg", "r_leg")
+		if(slot_gloves, slot_handcuffed) //Gloves
+			L = list("l_hand", "r_hand")
+		if(slot_l_hand)
+			L = list("l_hand")
+		if(slot_r_hand)
+			L = list("r_hand")
+		if(slot_wear_mask, slot_ears, slot_glasses, slot_head)
+			L = list("head")
+		if(slot_shoes)
+			L = list("l_foot", "r_foot")
+		if(slot_belt)
+			L = list("groin")
+		if(slot_back, slot_wear_id)
+			L = list("chest")
+		if(slot_legs, slot_legcuffed)
+			L = list("l_leg", "r_leg")
+
+	if(H)
+		for(var/organ in L)
+			L |= (H.get_organ(organ))
+			L.Remove(organ)
+
+	return L

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -305,10 +305,18 @@
 					if(!disable_warning)
 						to_chat(H, "<span class='warning'>You're too fat to wear the [name].</span>")
 					return 0
-			if(H.species.flags & IS_BULKY && !(flags & ONESIZEFITSALL))
-				if(!disable_warning)
-					to_chat(H, "<span class='warning'>You can't get \the [src] to fit over your bulky exterior!</span>")
-				return 0
+
+			for(var/datum/organ/external/OE in get_organs_by_slot(slot, H))
+				if(!OE.species) //Organ has same species as body
+					if(H.species.flags & IS_BULKY && !(flags & ONESIZEFITSALL)) //Use the body's base species
+						if(!disable_warning)
+							to_chat(H, "<span class='warning'>You can't get \the [src] to fit over your bulky exterior!</span>")
+						return 0
+				else //Organ's species is different from body
+					if(OE.species.flags & IS_BULKY && !(flags & ONESIZEFITSALL))
+						if(!disable_warning)
+							to_chat(H, "<span class='warning'>You can't get \the [src] to fit over your bulky exterior!</span>")
+						return 0
 
 		switch(slot)
 			if(slot_l_hand)
@@ -322,10 +330,19 @@
 			if(slot_wear_mask)
 				if( !(slot_flags & SLOT_MASK) )
 					return 0
-				if(H.species.flags & IS_BULKY && !(flags & ONESIZEFITSALL))
-					if(!disable_warning)
-						to_chat(H, "<span class='warning'>You can't get \the [src] to fasten around your thick head!</span>")
-					return 0
+
+				for(var/datum/organ/external/OE in get_organs_by_slot(slot, H))
+					if(!OE.species) //Organ has same species as body
+						if(H.species.flags & IS_BULKY && !(flags & ONESIZEFITSALL)) //Use the body's base species
+							if(!disable_warning)
+								to_chat(H, "<span class='warning'>You can't get \the [src] to fasten around your thick head!</span>")
+							return 0
+					else //Organ's species is different from body
+						if(OE.species.flags & IS_BULKY && !(flags & ONESIZEFITSALL))
+							if(!disable_warning)
+								to_chat(H, "<span class='warning'>You can't get \the [src] to fasten around your thick head!</span>")
+							return 0
+
 				if(H.wear_mask)
 					if(automatic)
 						if(H.check_for_open_slot(src))
@@ -350,10 +367,19 @@
 			if(slot_wear_suit)
 				if( !(slot_flags & SLOT_OCLOTHING) )
 					return 0
-				if(H.species.flags & IS_BULKY && !(flags & ONESIZEFITSALL))
-					if(!disable_warning)
-						to_chat(H, "<span class='warning'>You can't get \the [src] to fit over your bulky exterior!</span>")
-					return 0
+
+				for(var/datum/organ/external/OE in get_organs_by_slot(slot, H))
+					if(!OE.species) //Organ has same species as body
+						if(H.species.flags & IS_BULKY && !(flags & ONESIZEFITSALL)) //Use the body's base species
+							if(!disable_warning)
+								to_chat(H, "<span class='warning'>You can't get \the [src] to fasten around your bulky exterior!</span>")
+							return 0
+					else //Organ's species is different from body
+						if(OE.species.flags & IS_BULKY && !(flags & ONESIZEFITSALL))
+							if(!disable_warning)
+								to_chat(H, "<span class='warning'>You can't get \the [src] to fasten around your bulky exterior!</span>")
+							return 0
+
 				if(H.wear_suit)
 					if(automatic)
 						if(H.check_for_open_slot(src))
@@ -366,10 +392,19 @@
 			if(slot_gloves)
 				if( !(slot_flags & SLOT_GLOVES) )
 					return 0
-				if(H.species.flags & IS_BULKY && !(flags & ONESIZEFITSALL))
-					if(!disable_warning)
-						to_chat(H, "<span class='warning'>You can't get \the [src] to fit over your bulky fingers!</span>")
-					return 0
+
+				for(var/datum/organ/external/OE in get_organs_by_slot(slot, H))
+					if(!OE.species) //Organ has same species as body
+						if(H.species.flags & IS_BULKY && !(flags & ONESIZEFITSALL)) //Use the body's base species
+							if(!disable_warning)
+								to_chat(H, "<span class='warning'>You can't get \the [src] to fasten around your bulky fingers!</span>")
+							return 0
+					else //Organ's species is different from body
+						if(OE.species.flags & IS_BULKY && !(flags & ONESIZEFITSALL))
+							if(!disable_warning)
+								to_chat(H, "<span class='warning'>You can't get \the [src] to fasten around your bulky fingers!</span>")
+							return 0
+
 				if(H.gloves)
 					if(automatic)
 						if(H.check_for_open_slot(src))
@@ -382,10 +417,19 @@
 			if(slot_shoes)
 				if( !(slot_flags & SLOT_FEET) )
 					return 0
-				if(H.species.flags & IS_BULKY && !(flags & ONESIZEFITSALL))
-					if(!disable_warning)
-						to_chat(H, "<span class='warning'>You can't get \the [src] to fit over your bulky feet!</span>")
-					return 0
+
+				for(var/datum/organ/external/OE in get_organs_by_slot(slot, H))
+					if(!OE.species) //Organ has same species as body
+						if(H.species.flags & IS_BULKY && !(flags & ONESIZEFITSALL)) //Use the body's base species
+							if(!disable_warning)
+								to_chat(H, "<span class='warning'>You can't get \the [src] to fasten around your bulky feet!</span>")
+							return 0
+					else //Organ's species is different from body
+						if(OE.species.flags & IS_BULKY && !(flags & ONESIZEFITSALL))
+							if(!disable_warning)
+								to_chat(H, "<span class='warning'>You can't get \the [src] to fasten around your bulky feet!</span>")
+							return 0
+
 				if(H.shoes)
 					if(automatic)
 						if(H.check_for_open_slot(src))

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -16,7 +16,7 @@
 	. = ..(M, slot, 1) //Default return value. If 1, item can be equipped. If 0, it can't be.
 	if(!.) return //Default return value is 0 - don't check for species
 
-	if(species_restricted && istype(M,/mob/living/carbon/human) && (slot != 15 && slot != 16))
+	if(species_restricted && istype(M,/mob/living/carbon/human) && (slot != slot_l_store && slot != slot_r_store))
 
 		var/wearable = null
 		var/exclusive = null

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -11,11 +11,12 @@
 	var/cold_speed_protection = 300 //that cloth allows its wearer to keep walking at normal speed at lower temperatures
 
 //BS12: Species-restricted clothing check.
-/obj/item/clothing/mob_can_equip(M as mob, slot)
+/obj/item/clothing/mob_can_equip(mob/M, slot)
 
 	. = ..(M, slot, 1) //Default return value. If 1, item can be equipped. If 0, it can't be.
+	if(!.) return //Default return value is 0 - don't check for species
 
-	if(species_restricted && istype(M,/mob/living/carbon/human))
+	if(species_restricted && istype(M,/mob/living/carbon/human) && (slot != 15 && slot != 16))
 
 		var/wearable = null
 		var/exclusive = null
@@ -24,21 +25,49 @@
 		if("exclude" in species_restricted)
 			exclusive = 1
 
-		if(H.species)
-			if(exclusive)
-				if(!(H.species.name in species_restricted))
-					wearable = 1
+		var/datum/species/base_species = H.species
+		if(!base_species) return
+
+		var/base_species_can_wear = 1 //If the body's main species can wear this
+
+		if(exclusive)
+			if(!species_restricted.Find(base_species.name))
+				wearable = 1
 			else
-				if(H.species.name in species_restricted)
+				base_species_can_wear = 0
+		else
+			if(species_restricted.Find(base_species.name))
+				wearable = 1
+			else
+				base_species_can_wear = 0
+
+		//Check ALL organs covered by the slot. If any of the organ's species can't wear this, return 0
+
+		for(var/datum/organ/external/OE in get_organs_by_slot(slot, H)) //Go through all organs covered by the item
+			if(!OE.species) //Species same as of the body
+				if(!base_species_can_wear) //And the body's species can't wear
+					wearable = 0
+					break
+				continue
+
+			if(exclusive)
+				if(!species_restricted.Find(OE.species.name))
 					wearable = 1
-
-			if(.) //If normally we CAN equip this item,
-				if(!wearable && (slot != 15 && slot != 16)) //But we are a species that CAN'T wear it (sidenote: slots 15 and 16 are pockets)
-					to_chat(M, "<span class='warning'>Your species cannot wear [src].</span>")//Let us know
-
+				else
+					to_chat(M, "<span class='warning'>Your misshapen [OE.display_name] prevents you from wearing \the [src].</span>")
+					return 0
+			else
+				if(species_restricted.Find(OE.species.name))
+					wearable = 1
+				else
+					to_chat(M, "<span class='warning'>Your misshapen [OE.display_name] prevents you from wearing \the [src].</span>")
 					return 0
 
-	return ..()
+		if(!wearable) //But we are a species that CAN'T wear it (sidenote: slots 15 and 16 are pockets)
+			to_chat(M, "<span class='warning'>Your species cannot wear [src].</span>")//Let us know
+			return 0
+
+	//return ..()
 
 //Ears: headsets, earmuffs and tiny objects
 /obj/item/clothing/ears

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -68,13 +68,15 @@
 	f_style = pick(facial_hair_styles_list)
 	h_style = pick(hair_styles_list)
 
-	var/datum/species/new_species = all_species[pick(all_species)]
+	var/list/valid_species = (all_species - list("Krampus", "Horror"))
+
+	var/datum/species/new_species = all_species[pick(valid_species)]
 	..(new_loc, new_species.name)
 	gender = pick(MALE, FEMALE, NEUTER, PLURAL)
 	meat_type = pick(typesof(/obj/item/weapon/reagent_containers/food/snacks/meat))
 
 	for(var/datum/organ/external/E in organs)
-		E.species = all_species[pick(all_species)]
+		E.species = all_species[pick(valid_species)]
 
 	update_body()
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -68,13 +68,13 @@
 	f_style = pick(facial_hair_styles_list)
 	h_style = pick(hair_styles_list)
 
-	var/datum/species/new_species = pick(all_species)
+	var/datum/species/new_species = all_species[pick(all_species)]
 	..(new_loc, new_species.name)
 	gender = pick(MALE, FEMALE, NEUTER, PLURAL)
 	meat_type = pick(typesof(/obj/item/weapon/reagent_containers/food/snacks/meat))
 
 	for(var/datum/organ/external/E in organs)
-		E.species = pick(all_species)
+		E.species = all_species[pick(all_species)]
 
 	update_body()
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -64,6 +64,20 @@
 	gender = NEUTER
 	meat_type = /obj/item/weapon/ore/diamond
 
+/mob/living/carbon/human/frankenstein/New(var/new_loc, delay_ready_dna = 0) //Just fuck my shit up: the mob
+	f_style = pick(facial_hair_styles_list)
+	h_style = pick(hair_styles_list)
+
+	var/datum/species/new_species = pick(all_species)
+	..(new_loc, new_species.name)
+	gender = pick(MALE, FEMALE, NEUTER, PLURAL)
+	meat_type = pick(typesof(/obj/item/weapon/reagent_containers/food/snacks/meat))
+
+	for(var/datum/organ/external/E in organs)
+		E.species = pick(all_species)
+
+	update_body()
+
 /mob/living/carbon/human/generate_static_overlay()
 	if(!istype(static_overlays,/list))
 		static_overlays = list()

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -522,6 +522,7 @@ var/global/list/damage_icon_parts = list()
 			standing.icon	= 'icons/mob/uniform.dmi'
 
 		var/obj/item/clothing/under/under_uniform = w_uniform
+
 		if(species.name in under_uniform.species_fit) //Allows clothes to display differently for multiple species
 			if(species.uniform_icons)
 				standing.icon = species.uniform_icons
@@ -608,9 +609,18 @@ var/global/list/damage_icon_parts = list()
 		var/image/standing	= image("icon" = ((gloves.icon_override) ? gloves.icon_override : 'icons/mob/hands.dmi'), "icon_state" = "[t_state]")
 
 		var/obj/item/I = gloves
-		if(species.name in I.species_fit) //Allows clothes to display differently for multiple species
-			if(species.gloves_icons)
-				standing.icon = species.gloves_icons
+
+		var/datum/species/S = species
+		for(var/datum/organ/external/OE in get_organs_by_slot(slot_gloves, src)) //Display species-exclusive species correctly on attached limbs
+			if(OE.species)
+				S = OE.species
+				break
+
+		if(S.name in I.species_fit) //Allows clothes to display differently for multiple species
+			if(S.gloves_icons)
+				standing.icon = S.gloves_icons
+
+
 		if(gloves.dynamic_overlay)
 			if(gloves.dynamic_overlay["[GLOVES_LAYER]"])
 				var/image/dyn_overlay = gloves.dynamic_overlay["[GLOVES_LAYER]"]
@@ -650,9 +660,16 @@ var/global/list/damage_icon_parts = list()
 		var/image/standing = image("icon" = ((glasses.icon_override) ? glasses.icon_override : 'icons/mob/eyes.dmi'), "icon_state" = "[glasses.icon_state]")
 
 		var/obj/item/I = glasses
-		if(species.name in I.species_fit) //Allows clothes to display differently for multiple species
-			if(species.glasses_icons)
-				standing.icon = species.glasses_icons
+
+		var/datum/species/S = species
+		for(var/datum/organ/external/OE in get_organs_by_slot(slot_head, src)) //Display species-exclusive species correctly on attached limbs
+			if(OE.species)
+				S = OE.species
+				break
+
+		if(S.name in I.species_fit) //Allows clothes to display differently for multiple species
+			if(S.glasses_icons)
+				standing.icon = S.glasses_icons
 
 		if(glasses.cover_hair)
 			var/obj/Overlays/O = obj_overlays[GLASSES_OVER_HAIR_LAYER]
@@ -692,9 +709,16 @@ var/global/list/damage_icon_parts = list()
 		var/image/standing = image("icon" = ((ears.icon_override) ? ears.icon_override : 'icons/mob/ears.dmi'), "icon_state" = "[ears.icon_state]")
 
 		var/obj/item/I = ears
-		if(species.name in I.species_fit) //Allows clothes to display differently for multiple species
-			if(species.ears_icons)
-				standing.icon = species.ears_icons
+
+		var/datum/species/S = species
+		for(var/datum/organ/external/OE in get_organs_by_slot(slot_head, src)) //Display species-exclusive species correctly on attached limbs
+			if(OE.species)
+				S = OE.species
+				break
+
+		if(S.name in I.species_fit) //Allows clothes to display differently for multiple species
+			if(S.ears_icons)
+				standing.icon = S.ears_icons
 
 		var/obj/Overlays/O = obj_overlays[EARS_LAYER]
 		O.icon = standing
@@ -720,10 +744,16 @@ var/global/list/damage_icon_parts = list()
 		//var/image/standing	= image("icon" = ((shoes.icon_override) ? shoes.icon_override : 'icons/mob/feet.dmi'), "icon_state" = "[shoes.icon_state]")
 
 		var/obj/item/I = shoes
-		if(species.name in I.species_fit) //Allows clothes to display differently for multiple species
-			if(species.shoes_icons)
-				O.icon = species.shoes_icons
-				//standing.icon = species.shoes_icons
+
+		var/datum/species/S = species
+		for(var/datum/organ/external/OE in get_organs_by_slot(slot_shoes, src)) //Display species-exclusive species correctly on attached limbs
+			if(OE.species)
+				S = OE.species
+				break
+
+		if(S.name in I.species_fit) //Allows clothes to display differently for multiple species
+			if(S.gloves_icons)
+				O.icon = S.shoes_icons
 
 		O.overlays.len = 0
 		if(shoes.dynamic_overlay)
@@ -777,9 +807,16 @@ var/global/list/damage_icon_parts = list()
 			standing	= image("icon" = ((head.icon_override) ? head.icon_override : 'icons/mob/head.dmi'), "icon_state" = "[head.icon_state]")
 
 		var/obj/item/I = head
-		if(species.name in I.species_fit) //Allows clothes to display differently for multiple species
-			if(species.head_icons)
-				standing.icon = species.head_icons
+
+		var/datum/species/S = species
+		for(var/datum/organ/external/OE in get_organs_by_slot(slot_head, src)) //Display species-exclusive species correctly on attached limbs
+			if(OE.species)
+				S = OE.species
+				break
+
+		if(S.name in I.species_fit) //Allows clothes to display differently for multiple species
+			if(S.head_icons)
+				standing.icon = S.head_icons
 
 		if(head.dynamic_overlay)
 			if(head.dynamic_overlay["[HEAD_LAYER]"])
@@ -810,9 +847,17 @@ var/global/list/damage_icon_parts = list()
 		var/image/standing = image("icon" = ((belt.icon_override) ? belt.icon_override : 'icons/mob/belt.dmi'), "icon_state" = "[t_state]")
 
 		var/obj/item/I = belt
-		if(species.name in I.species_fit) //Allows clothes to display differently for multiple species
-			if(species.belt_icons)
-				standing.icon = species.belt_icons
+
+		var/datum/species/S = species
+		for(var/datum/organ/external/OE in get_organs_by_slot(slot_belt, src)) //Display species-exclusive species correctly on attached limbs
+			if(OE.species)
+				S = OE.species
+				break
+
+		if(S.name in I.species_fit) //Allows clothes to display differently for multiple species
+			if(S.belt_icons)
+				standing.icon = S.belt_icons
+
 		var/obj/Overlays/O = obj_overlays[BELT_LAYER]
 		O.icon = standing
 		O.icon_state = standing.icon_state
@@ -842,9 +887,16 @@ var/global/list/damage_icon_parts = list()
 			drop_hands()
 
 		var/obj/item/I = wear_suit
-		if(species.name in I.species_fit) //Allows clothes to display differently for multiple species
-			if(species.wear_suit_icons)
-				standing.icon = species.wear_suit_icons
+
+		var/datum/species/SP = species
+		for(var/datum/organ/external/OE in get_organs_by_slot(slot_wear_suit, src)) //Display species-exclusive species correctly on attached limbs
+			if(OE.species)
+				SP = OE.species
+				break
+
+		if(SP.name in I.species_fit) //Allows clothes to display differently for multiple species
+			if(SP.wear_suit_icons)
+				standing.icon = SP.wear_suit_icons
 
 		if(wear_suit.dynamic_overlay)
 			if(wear_suit.dynamic_overlay["[SUIT_LAYER]"])
@@ -886,9 +938,16 @@ var/global/list/damage_icon_parts = list()
 		var/image/standing	= image("icon" = ((wear_mask.icon_override) ? wear_mask.icon_override : 'icons/mob/mask.dmi'), "icon_state" = "[wear_mask.icon_state]")
 
 		var/obj/item/I = wear_mask
-		if(species.name in I.species_fit) //Allows clothes to display differently for multiple species
-			if(species.wear_mask_icons)   //This REQUIRES the species to be listed in species_fit and also to have an appropriate dmi allocated in their species datum
-				standing.icon = species.wear_mask_icons
+
+		var/datum/species/S = species
+		for(var/datum/organ/external/OE in get_organs_by_slot(slot_wear_mask, src)) //Display species-exclusive species correctly on attached limbs
+			if(OE.species)
+				S = OE.species
+				break
+
+		if(S.name in I.species_fit) //Allows clothes to display differently for multiple species
+			if(S.wear_mask_icons)
+				standing.icon = S.wear_mask_icons
 
 		if(wear_mask.dynamic_overlay)
 			if(wear_mask.dynamic_overlay["[FACEMASK_LAYER]"])
@@ -918,9 +977,16 @@ var/global/list/damage_icon_parts = list()
 		var/image/standing	= image("icon" = ((back.icon_override) ? back.icon_override : 'icons/mob/back.dmi'), "icon_state" = "[back.icon_state]")
 
 		var/obj/item/I = back
-		if(species.name in I.species_fit) //Allows clothes to display differently for multiple species
-			if(species.back_icons)
-				standing.icon = species.back_icons
+
+		var/datum/species/S = species
+		for(var/datum/organ/external/OE in get_organs_by_slot(slot_back, src)) //Display species-exclusive species correctly on attached limbs
+			if(OE.species)
+				S = OE.species
+				break
+
+		if(S.name in I.species_fit) //Allows clothes to display differently for multiple species
+			if(S.back_icons)
+				standing.icon = S.back_icons
 
 		var/obj/Overlays/O = obj_overlays[BACK_LAYER]
 		O.icon = standing

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -9,10 +9,11 @@
 	..()
 
 /mob/living/proc/init_butchering_list()
+	butchering_drops = list()
+
 	if(species_type && (!src.butchering_drops || !src.butchering_drops.len))
 		if(animal_butchering_products[species_type])
 			var/list/L = animal_butchering_products[species_type]
-			src.butchering_drops = list()
 
 			for(var/butchering_type in L)
 				src.butchering_drops += new butchering_type

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -619,6 +619,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 		src.status &= ~ORGAN_BLEEDING
 		src.status &= ~ORGAN_SPLINTED
 		src.status &= ~ORGAN_DEAD
+		src.species = null
+		
 		for(var/implant in implants)
 			qdel(implant)
 

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -768,6 +768,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	src.status &= ~ORGAN_DESTROYED
 	src.status &= ~ORGAN_PEG
 	src.status |= ORGAN_ROBOT
+	src.species = null
 	src.destspawn = 0
 	for (var/datum/organ/external/T in children)
 		if(T)
@@ -782,6 +783,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	src.status &= ~ORGAN_DESTROYED
 	src.status &= ~ORGAN_ROBOT
 	src.status |= ORGAN_PEG
+	src.species = null
 	src.wounds.len = 0
 	for (var/datum/organ/external/T in children)
 		if(T)

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -631,7 +631,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 			organ = generate_dropped_organ(organ_item)
 			if(species)
 				organ.species = src.species
-				organ.update_icon(owner)
+				organ.update_icon()
 
 		if(body_part == LOWER_TORSO)
 			to_chat(owner, "<span class='danger'>You are now sterile.</span>")
@@ -1251,11 +1251,12 @@ obj/item/weapon/organ/New(loc, mob/living/carbon/human/H)
 
 	if(base)
 		//Changing limb's skin tone to match owner
-		if(!H.species || H.species.flags & HAS_SKIN_TONE)
-			if(H.s_tone >= 0)
-				base.Blend(rgb(H.s_tone, H.s_tone, H.s_tone), ICON_ADD)
-			else
-				base.Blend(rgb(-H.s_tone,  -H.s_tone,  -H.s_tone), ICON_SUBTRACT)
+		if(H)
+			if(!H.species || H.species.flags & HAS_SKIN_TONE)
+				if(H.s_tone >= 0)
+					base.Blend(rgb(H.s_tone, H.s_tone, H.s_tone), ICON_ADD)
+				else
+					base.Blend(rgb(-H.s_tone,  -H.s_tone,  -H.s_tone), ICON_SUBTRACT)
 
 		icon = base
 		dir = SOUTH

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -3,6 +3,8 @@
 ****************************************************/
 /datum/organ/external
 	name = "external"
+
+	var/datum/species/species
 	var/icon_name = null
 	var/body_part = null
 	var/icon_position = 0
@@ -624,7 +626,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		for(var/datum/organ/external/O in children)
 			O.droplimb(1)
 
-		var/obj/organ //Dropped limb object
+		var/obj/item/weapon/organ/organ //Dropped limb object
 		if(spawn_limb)
 			organ = generate_dropped_organ(organ_item)
 		if(body_part == LOWER_TORSO)
@@ -828,9 +830,9 @@ Note that amputating the affected organ does in fact remove the infection from t
 	if(isFat && has_fat)
 		fat = "_fat"
 	var/icon_state = "[icon_name][gender][fat]"
-	var/baseicon = owner.race_icon
+	var/baseicon = (species ? species.icobase : owner.race_icon)
 	if(status & ORGAN_MUTATED)
-		baseicon = owner.deform_icon
+		baseicon = (species ? species.deform : owner.deform_icon)
 	else if(is_peg())
 		baseicon = 'icons/mob/human_races/o_peg.dmi'
 	else if(is_robotic())
@@ -1123,9 +1125,11 @@ Note that amputating the affected organ does in fact remove the infection from t
 	var/g = "m"
 	if(owner.gender == FEMALE)
 		g = "f"
-	var/baseicon = owner.race_icon
+
+	var/baseicon = (species ? species.icobase : owner.race_icon)
 	if(status & ORGAN_MUTATED)
-		baseicon = owner.deform_icon
+		baseicon = (species ? species.deform : owner.deform_icon)
+
 	if(is_peg())
 		baseicon = 'icons/mob/human_races/o_peg.dmi'
 	if(is_robotic())
@@ -1178,6 +1182,8 @@ obj/item/weapon/organ
 	//Currently the only "butchering drops" which are going to be stored here are teeth
 	var/list/butchering_drops = list()
 
+	var/datum/species/species
+
 	//Store health facts. Right now limited exclusively to cancer, but should likely include all limb stats eventually
 	var/cancer_stage = 0
 
@@ -1195,7 +1201,10 @@ obj/item/weapon/organ/New(loc, mob/living/carbon/human/H)
 	//Setting base icon for this mob's race
 	var/icon/base
 	if(H.species && H.species.icobase)
-		base = icon(H.species.icobase)
+		src.species = H.species //Also store the mob's species for later use
+
+		if(H.species.icobase)
+			base = icon(H.species.icobase)
 	else
 		base = icon('icons/mob/human_races/r_human.dmi')
 

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -629,6 +629,10 @@ Note that amputating the affected organ does in fact remove the infection from t
 		var/obj/item/weapon/organ/organ //Dropped limb object
 		if(spawn_limb)
 			organ = generate_dropped_organ(organ_item)
+			if(species)
+				organ.species = src.species
+				organ.update_icon(owner)
+
 		if(body_part == LOWER_TORSO)
 			to_chat(owner, "<span class='danger'>You are now sterile.</span>")
 
@@ -1197,33 +1201,11 @@ obj/item/weapon/organ/New(loc, mob/living/carbon/human/H)
 			blood_DNA = list()
 		blood_DNA[H.dna.unique_enzymes] = H.dna.b_type
 
+	src.species = H.species
+
 	//Forming icon for the limb
 	//Setting base icon for this mob's race
-	var/icon/base
-	if(H.species && H.species.icobase)
-		src.species = H.species //Also store the mob's species for later use
-
-		if(H.species.icobase)
-			base = icon(H.species.icobase)
-	else
-		base = icon('icons/mob/human_races/r_human.dmi')
-
-	if(base)
-		//Changing limb's skin tone to match owner
-		if(!H.species || H.species.flags & HAS_SKIN_TONE)
-			if(H.s_tone >= 0)
-				base.Blend(rgb(H.s_tone, H.s_tone, H.s_tone), ICON_ADD)
-			else
-				base.Blend(rgb(-H.s_tone,  -H.s_tone,  -H.s_tone), ICON_SUBTRACT)
-
-/*	if(base)
-		//Changing limb's skin color to match owner
-		if(!H.species || H.species.flags & HAS_SKIN_COLOR)
-			base.Blend(rgb(H.r_skin, H.g_skin, H.b_skin), ICON_ADD)*/
-
-	icon = base
-	dir = SOUTH
-	src.transform = turn(src.transform, rand(70, 130))
+	update_icon(H)
 
 	for(var/datum/butchering_product/B in H.butchering_drops) //Go through all butchering products (like teeth) in the parent
 		if(B.stored_in_organ == src.part) //If they're stored in our organ,
@@ -1248,6 +1230,36 @@ obj/item/weapon/organ/New(loc, mob/living/carbon/human/H)
 			butchery = "[butchery][B.desc_modifier(src, user)]"
 	if(butchery)
 		to_chat(user, "<span class='warning'>[butchery]</span>")
+
+/obj/item/weapon/organ/update_icon(mob/living/carbon/human/H)
+	..()
+
+	if(!H && !species) return
+
+	var/icon/base
+	if(H)
+		if(H.species)
+			if(!src.species)
+				src.species = H.species //Also store the mob's species for later use
+
+			if(H.species.icobase)
+				base = icon(H.species.icobase)
+		else
+			base = icon('icons/mob/human_races/r_human.dmi')
+	else if(species)
+		base = icon(species.icobase)
+
+	if(base)
+		//Changing limb's skin tone to match owner
+		if(!H.species || H.species.flags & HAS_SKIN_TONE)
+			if(H.s_tone >= 0)
+				base.Blend(rgb(H.s_tone, H.s_tone, H.s_tone), ICON_ADD)
+			else
+				base.Blend(rgb(-H.s_tone,  -H.s_tone,  -H.s_tone), ICON_SUBTRACT)
+
+		icon = base
+		dir = SOUTH
+		src.transform = turn(src.transform, rand(70, 130))
 
 /****************************************************
 			   EXTERNAL ORGAN ITEMS DEFINES

--- a/code/modules/surgery/headreattach.dm
+++ b/code/modules/surgery/headreattach.dm
@@ -197,6 +197,11 @@
 	affected.status = 0
 	affected.amputated = 0
 	affected.destspawn = 0
+
+	var/obj/item/weapon/organ/O = tool
+	if(istype(O))
+		affected.species = O.species
+
 	target.update_body()
 	target.updatehealth()
 	target.UpdateDamageIcon()

--- a/code/modules/surgery/headreattach.dm
+++ b/code/modules/surgery/headreattach.dm
@@ -217,8 +217,8 @@
 				target.butchering_drops -= match //Remove it!
 				qdel(match)
 
-			target.butchering_drops += BP //Transfer
-			B.butchering_drops -= BP
+			target.butchering_drops.Add(BP) //Transfer
+			B.butchering_drops.Remove(BP)
 
 	affected.cancer_stage = B.cancer_stage
 

--- a/code/modules/surgery/robolimbs.dm
+++ b/code/modules/surgery/robolimbs.dm
@@ -263,6 +263,11 @@
 	var/datum/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'>[user] has attached [tool] where [target]'s [affected.display_name] used to be.</span>",	\
 	"<span class='notice'>You have attached [tool] where [target]'s [affected.display_name] used to be.</span>")
+
+	var/obj/item/weapon/organ/O = tool
+	if(istype(O))
+		affected.species = O.species
+
 	affected.fleshify()
 	target.update_body()
 	target.updatehealth()

--- a/html/changelogs/unid-you_just_lost_the_game.yml
+++ b/html/changelogs/unid-you_just_lost_the_game.yml
@@ -3,4 +3,5 @@ author: Unid
 delete-after: True
 
 changes: 
-- imageadd: "Surgically attached limbs no longer magically transform when you attach them to another species' body (this means you can create a human with vox head, tajaran arms and muton legs). This is purely a visual effect"
+- rscadd: "Surgically attached limbs no longer magically transform when you attach them to another species' body (this means you can create a human with vox head, tajaran arms and muton legs)."
+- tweak: "Slightly changed how species restricted clothing works in respect to the above change. Now it's possible to, for example, wear vox magboots as a human - but only if both of the human's feet are vox talons."

--- a/html/changelogs/unid-you_just_lost_the_game.yml
+++ b/html/changelogs/unid-you_just_lost_the_game.yml
@@ -1,0 +1,6 @@
+author: Unid
+
+delete-after: True
+
+changes: 
+- imageadd: "Surgically attached limbs no longer magically transform when you attach them to another species' body (this means you can create a human with vox head, tajaran arms and muton legs). This is purely a visual effect"


### PR DESCRIPTION
A small update that makes surgery a lot more fun
- Limbs and heads now show up properly when attached to other species

![](http://puu.sh/owIgb/64af095b7c.png)

![](http://puu.sh/owGLt/55f0d69c78.png)
- Species-exclusive clothing can be worn if ALL organs covered by it belong to the species. For example, a human can wear vox magboots if both of their feet are vox. And a vox can't wear vox magboots if at least one of their feet isn't vox.

![](http://puu.sh/oyV6E/20c854077e.png) - unathi with vox limbs wearing vox gloves and magboots
- Added a spawnable frankenstein's monster (mob/living/carbon/human/frankenstein). All of its organs are randomized, as well as xe gender and meat type

![](http://puu.sh/owPKN/2620bb4cae.png)

Notes:
- The organ code is still a mess
- These are purely visual effects. Attaching a tajaran hand won't make you able to claw (mob code rewrite when)
- Also fixes an examine() runtime that happens after you attach a human head to a vox body

Tested!
