### PR TITLE
Let's find out which one is causing it before trying to fix it again.

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -193,6 +193,10 @@ var/const/MAX_SAVE_SLOTS = 8
 					if(load_save_sqlite(theckey, C, default_slot) && C)
 						saveloaded = 1
 						return
+					else
+						world.log << "[C.ckey] failed loading save slot."
+				else
+					world.log << "[C.ckey] failed loading preferences."
 
 			randomize_appearance_for()
 			real_name = random_name(gender)


### PR DESCRIPTION
Adds debug messages to failed preferences/save loading, so we can find out for sure which one it is.

It blurts out the ckey so we can double check they aren't just a new player failing because they have nothing to load.
