### PR TITLE
Reverts every change -I- have made to preferences.dm

### DIFF
--- a/code/game/gamemodes/setupgame.dm
+++ b/code/game/gamemodes/setupgame.dm
@@ -155,7 +155,6 @@
 			if(species.default_blocks.len)
 				all_species[name]=species
 
-	speciesinit = 1
 
 
 /proc/setupfactions()

--- a/code/global.dm
+++ b/code/global.dm
@@ -392,7 +392,6 @@ var/global/list/minesweeper_best_players = list()
 var/nanocoins_rates = 1
 var/nanocoins_lastchange = 0
 
-var/speciesinit = 0
 var/minimapinit = 0
 
 var/datum/stat_collector/stat_collection = new

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -185,24 +185,15 @@ var/const/MAX_SAVE_SLOTS = 8
 	if(istype(C))
 		var/theckey = C.ckey
 		var/thekey = C.key
-		spawn()
-			while(!speciesinit)
-				sleep(1)
-			if(!IsGuestKey(thekey))
-				var/load_pref = load_preferences_sqlite(theckey)
-				if(load_pref)
-					if(load_save_sqlite(theckey, C, default_slot) && C)
-						saveloaded = 1
-						return
-					else
-						world.log << "[theckey] failed loading save slot."
-				else
-					world.log << "[theckey] failed loading preferences."
+		if(!IsGuestKey(thekey))
+			var/load_pref = load_preferences_sqlite(theckey)
+			if(load_pref)
+				if(load_save_sqlite(theckey, C, default_slot) && C)
+					return
 
-			randomize_appearance_for()
-			real_name = random_name(gender)
-			save_character_sqlite(theckey, C, default_slot)
-			saveloaded = 1
+		randomize_appearance_for()
+		real_name = random_name(gender)
+		save_character_sqlite(theckey, C, default_slot)
 
 /datum/preferences/proc/setup_character_options(var/dat, var/user)
 

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -100,16 +100,10 @@
 	if(!client)	return 0
 
 	if(href_list["show_preferences"])
-		if(!client.prefs.saveloaded)
-			to_chat(usr, "<span class='warning'>Your character preferences have not yet loaded.</span>")
-			return
 		client.prefs.ShowChoices(src)
 		return 1
 
 	if(href_list["ready"])
-		if(!client.prefs.saveloaded)
-			to_chat(usr, "<span class='warning'>Your character preferences have not yet loaded.</span>")
-			return
 		switch(text2num(href_list["ready"]))
 			if(1)
 				ready = 1
@@ -125,9 +119,6 @@
 		new_player_panel_proc()
 
 	if(href_list["observe"])
-		if(!client.prefs.saveloaded)
-			to_chat(usr, "<span class='warning'>Your character preferences have not yet loaded.</span>")
-			return
 		if(alert(src,"Are you sure you wish to observe? You will not be able to play this round!","Player Setup","Yes","No") == "Yes")
 			if(!client)	return 1
 			sleep(1)


### PR DESCRIPTION
#9360
#9599
#9450
#9360

open #9358

closes #9661
closes #9678 

![2016-04-27_10-12-16](https://cloud.githubusercontent.com/assets/4043940/14861074/8ef1f95e-0c60-11e6-8890-5f9fb8d18ddf.png)
/datum/preferences (/datum/preferences): load save sqlite("mrpain666", null, 1)
/datum/preferences (/datum/preferences): New(null)

Client continuing to return null (for absolutely everyone trying to load save that's failing) is the cause, but I'm done trying to fix this.
