### PR TITLE
Adds Add Reagent to SPAWN flag. Doesn't remove from DEBUG flag.

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -124,7 +124,8 @@ var/list/admin_verbs_spawn = list(
 	/datum/admins/proc/spawn_atom, // Allows us to spawn instances
 	/client/proc/spawn_datum, //Allows us to spawn datums to the marked datum buffer
 	/client/proc/cmd_admin_dress, //Allows us to spawn clothing and dress a mob with it in one click
-	/client/proc/respawn_character //Allows us to re-spawn someone
+	/client/proc/respawn_character, //Allows us to re-spawn someone
+	/client/proc/debug_reagents //Allows us to spawn reagents in mobs/containers
 	)
 var/list/admin_verbs_server = list(
 	/client/proc/Set_Holiday,


### PR DESCRIPTION
```
4:46 PM - Intigracy: I want to make the right click > add reagant part of spawn
4:46 PM - Intigracy: instead of debug or whatever it's under
4:46 PM - Intigracy: whatchu think
4:47 PM - Probe1: yea sure
```

It's literally just inserting reagents into whatever you're right clicking, and fails on incorrect reagents.
