### PR TITLE
Removes more duplicate Bump()s and also fixes mining

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -120,32 +120,36 @@
 	..()
 	return 0
 
-/*
- * IF YOU HAVE BYOND VERSION BELOW 507.1248 OR ARE ABLE TO WALK THROUGH WINDOORS/BORDER WINDOWS COMMENT OUT
- * #define BORDER_USE_TURF_EXIT
- * FOR MORE INFORMATION SEE: http://www.byond.com/forum/?post=1666940
- *
-#ifdef BORDER_USE_TURF_EXIT
-/turf/Exit(atom/movable/mover, atom/target)
-	if(!mover)
-		return 1
-	// First, make sure it can leave its square
-	if(mover.loc == src)
-		// Nothing but border objects stop you from leaving a tile, only one loop is needed
-		for(var/obj/obstacle in src)
-			/*if(ismob(mover) && mover:client)
-				to_chat(world, "<span class='danger'>EXIT</span>origin: checking exit of mob [obstacle]"*/)
-			if(obstacle != mover && obstacle != target && !obstacle.CheckExit(mover, target))
-				/*if(ismob(mover) && mover:client)
-					to_chat(world, "<span class='danger'>EXIT</span>Origin: We are bumping into [obstacle]"*/)
-				mover.Bump(obstacle, 1)
-				return 0
-	return 1
-#if DM_VERSION < 507
-	#warn This compiler is too far out of date! You will experience issues with windows and windoors unles you update to atleast 507.1248 or comment out BORDER_USE_TURF_EXIT in global.dm!
+///*
+// * IF YOU HAVE BYOND VERSION BELOW 507.1248 OR ARE ABLE TO WALK THROUGH WINDOORS/BORDER WINDOWS COMMENT OUT
+// * #define BORDER_USE_TURF_EXIT
+// * FOR MORE INFORMATION SEE: http://www.byond.com/forum/?post=1666940
+// *
+//#ifdef BORDER_USE_TURF_EXIT
+///turf/Exit(atom/movable/mover, atom/target)
+//	if(!mover)
+//		return 1
+//	// First, make sure it can leave its square
+//	if(mover.loc == src)
+//		// Nothing but border objects stop you from leaving a tile, only one loop is needed
+//		for(var/obj/obstacle in src)
+//			/*if(ismob(mover) && mover:client)
+//				to_chat(world, "<span class='danger'>EXIT</span>origin: checking exit of mob [obstacle]"*/)
+//			if(obstacle != mover && obstacle != target && !obstacle.CheckExit(mover, target))
+//				/*if(ismob(mover) && mover:client)
+//					to_chat(world, "<span class='danger'>EXIT</span>Origin: We are bumping into [obstacle]"*/)
+//				mover.Bump(obstacle, 1)
+//				return 0
+//	return 1
+//
+//#if DM_VERSION < 507
+//	#warn This compiler is too far out of date! You will experience issues with windows and windoors unles you update to atleast 507.1248 or comment out BORDER_USE_TURF_EXIT in global.dm!
+//
+//#endif
+//*/
 
-#endif
-*/
+//Fuck your block comments. This wasn't even entirely commented out properly.
+
 /turf/Enter(atom/movable/mover as mob|obj, atom/forget as mob|obj|turf|area)
 	if (!mover)
 		return 1
@@ -157,7 +161,7 @@
 		// Nothing but border objects stop you from leaving a tile, only one loop is needed
 		for(var/obj/obstacle in mover.loc)
 			if(obstacle != mover && obstacle != forget && !obstacle.CheckExit(mover, src) )
-				mover.Bump(obstacle, 1)
+				mover.Bump(obstacle, 1) //Necessary in specifically this case
 				return 0
 //#endif
 	var/list/large_dense = list()
@@ -169,7 +173,6 @@
 			if(!border_obstacle.CanPass(mover, mover.loc) && (forget != border_obstacle) && mover != border_obstacle)
 				/*if(ismob(mover) && mover:client)
 					to_chat(world, "<span class='danger'>ENTER</span>Target(border): We are bumping into [border_obstacle]")*/
-				mover.Bump(border_obstacle, 1)
 				return 0
 		else
 			large_dense += border_obstacle
@@ -185,7 +188,6 @@
 		if(!obstacle.CanPass(mover, mover.loc) && (forget != obstacle) && mover != obstacle)
 			/*if(ismob(mover) && mover:client)
 				to_chat(world, "<span class='danger'>ENTER</span>target(large_dense): checking: We are bumping into [obstacle]")*/
-			mover.Bump(obstacle, 1)
 			return 0
 	return 1 //Nothing found to block so return success!
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -3,7 +3,7 @@
 	update_hud()
 	return
 
-/mob/living/carbon/Bump(var/atom/movable/AM, yes)
+/mob/living/carbon/Bump(var/atom/movable/AM, yes = 1)
 	if(now_pushing || !yes)
 		return
 	..()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1118,7 +1118,7 @@ default behaviour is:
 			return 1
 		return 0
 
-/mob/living/Bump(atom/movable/AM as mob|obj, yes)
+/mob/living/Bump(atom/movable/AM as mob|obj, yes = 1)
 	spawn(0)
 		if ((!( yes ) || now_pushing) || !loc)
 			return


### PR DESCRIPTION
Also fully comments out a block of code that someone tried to comment out but partially failed because apparently they weren't using syntax highlighting and didn't notice their block comments ending prematurely

Fixes #9684

Tested for all unique cases I could think of, so I can say with confidence that it is probably at least 40% tested

Also 90% guaranteed to not break anything significant and 70% guaranteed to not break anything at all
