### PR TITLE
Fix alien humanoids going blind and back repeatedly

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/life.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/life.dm
@@ -421,7 +421,7 @@
 		if (client)
 			clear_fullscreens()
 
-			if(src.eye_blind || src.blindness)
+			if(src.eye_blind)
 				overlay_fullscreen("blind", /obj/screen/fullscreen/blind)
 			if (src.disabilities & NEARSIGHTED)
 				overlay_fullscreen("impaired", /obj/screen/fullscreen/impaired)


### PR DESCRIPTION
Fixes #9738

Do we even use the blindness var anymore actually? I can only find it assigned in two places in the repo
