### PR TITLE
Removes unused mob var definitions

### DIFF
--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -172,14 +172,7 @@
 
 	var/inertia_dir = 0
 
-	var/music_lastplayed = "null"
-
 	var/job = null//Living
-
-	var/const/blindness = 1//Carbon
-	var/const/deafness = 2//Carbon
-	var/const/muteness = 4//Carbon
-
 
 	var/datum/dna/dna = null//Carbon
 	var/radiation = 0.0//Carbon


### PR DESCRIPTION
Currently travis fails this build because #9746 needs to be merged
But yeah these seem to be oldcode vars that arent used anymore now that we have GENETICS
