### PR TITLE
[Hotfix] Blob Update counter-attacks

### DIFF
--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -5,6 +5,7 @@ var/list/blobs = list()
 var/list/blob_cores = list()
 var/list/blob_nodes = list()
 var/list/blob_resources = list()
+var/list/blob_overminds = list()
 
 
 /datum/game_mode/blob

--- a/code/game/gamemodes/blob/blobs/core.dm
+++ b/code/game/gamemodes/blob/blobs/core.dm
@@ -6,7 +6,6 @@
 	maxhealth = 200
 	fire_resist = 2
 	custom_process=1
-	var/mob/camera/blob/overmind = null // the blob core's overmind
 	var/overmind_get_delay = 0 // we don't want to constantly try to find an overmind, do it every 30 seconds
 	var/resource_delay = 0
 	var/point_rate = 2

--- a/code/game/gamemodes/blob/blobs/core.dm
+++ b/code/game/gamemodes/blob/blobs/core.dm
@@ -1,6 +1,7 @@
 /obj/effect/blob/core
 	name = "blob core"
 	icon_state = "core"
+	desc = "Some big pulsating blob creature thingy"
 	health = 200
 	maxhealth = 200
 	fire_resist = 2
@@ -11,6 +12,8 @@
 	var/point_rate = 2
 	var/mob/camera/blob/creator = null
 	layer = 7
+	var/core_warning_delay = 0
+	var/previous_health = 200
 
 	layer_new = 7
 	icon_new = "core"
@@ -35,6 +38,13 @@
 
 /obj/effect/blob/core/Destroy()
 	blob_cores -= src
+
+	for(var/mob/camera/blob/O in blob_overminds)
+		if(overmind && (O != overmind))
+			to_chat(O,"<span class='danger'>A blob core has been destroyed! [overmind] lost his life!</span>")
+		else
+			to_chat(O,"<span class='warning'>A blob core has been destroyed. It had no overmind in control.</span>")
+
 	if(overmind)
 		for(var/obj/effect/blob/resource/R in blob_resources)
 			if(R.overmind == overmind)
@@ -49,6 +59,14 @@
 	return
 
 /obj/effect/blob/core/update_health()
+	if(overmind)
+		overmind.update_health()
+		if((health < previous_health) && (core_warning_delay <= world.time))
+			resource_delay = world.time + (3 SECONDS)
+			to_chat(overmind,"<span class='danger'>YOUR CORE IS UNDER ATTACK!</span>")
+
+	previous_health = health
+
 	if(health <= 0)
 		dying = 1
 		playsound(get_turf(src), 'sound/effects/blobkill.ogg', 50, 1)

--- a/code/game/gamemodes/blob/blobs/factory.dm
+++ b/code/game/gamemodes/blob/blobs/factory.dm
@@ -5,7 +5,6 @@
 	health = 100
 	maxhealth = 100
 	fire_resist = 2
-	var/mob/camera/blob/overmind = null
 	var/list/spores = list()
 	var/max_spores = 2
 	var/spore_delay = 50

--- a/code/game/gamemodes/blob/blobs/factory.dm
+++ b/code/game/gamemodes/blob/blobs/factory.dm
@@ -1,9 +1,11 @@
 /obj/effect/blob/factory
 	name = "factory blob"
 	icon_state = "factory"
+	desc = "Some antibodies-producing blob creature thingy"
 	health = 100
 	maxhealth = 100
 	fire_resist = 2
+	var/mob/camera/blob/overmind = null
 	var/list/spores = list()
 	var/max_spores = 2
 	var/spore_delay = 50
@@ -49,6 +51,8 @@
 	if(spores.len)
 		for(var/mob/living/simple_animal/hostile/blobspore/S in spores)
 			S.Die()
+	if(!manual_remove && overmind)
+		to_chat(overmind,"<span class='warning'>A factory blob that you had created has been destroyed.</span>")
 	..()
 
 /obj/effect/blob/factory/update_icon(var/spawnend = 0)

--- a/code/game/gamemodes/blob/blobs/node.dm
+++ b/code/game/gamemodes/blob/blobs/node.dm
@@ -5,7 +5,6 @@
 	health = 100
 	maxhealth = 100
 	fire_resist = 2
-	var/mob/camera/blob/overmind = null
 	custom_process=1
 	layer = 6.8
 	spawning = 0

--- a/code/game/gamemodes/blob/blobs/node.dm
+++ b/code/game/gamemodes/blob/blobs/node.dm
@@ -1,9 +1,11 @@
 /obj/effect/blob/node
 	name = "blob node"
 	icon_state = "node"
+	desc = "Some pulsating blob creature thingy"
 	health = 100
 	maxhealth = 100
 	fire_resist = 2
+	var/mob/camera/blob/overmind = null
 	custom_process=1
 	layer = 6.8
 	spawning = 0
@@ -25,6 +27,8 @@
 
 /obj/effect/blob/node/Destroy()
 	blob_nodes -= src
+	if(!manual_remove && overmind)
+		to_chat(overmind,"<span class='warning'>A node blob that you had created has been destroyed.</span>")
 	processing_objects.Remove(src)
 	..()
 

--- a/code/game/gamemodes/blob/blobs/resource.dm
+++ b/code/game/gamemodes/blob/blobs/resource.dm
@@ -5,7 +5,6 @@
 	health = 30
 	maxhealth = 30
 	fire_resist = 2
-	var/mob/camera/blob/overmind = null
 	var/resource_delay = 0
 	spawning = 0
 	layer = 6.4

--- a/code/game/gamemodes/blob/blobs/resource.dm
+++ b/code/game/gamemodes/blob/blobs/resource.dm
@@ -1,6 +1,7 @@
 /obj/effect/blob/resource
 	name = "resource blob"
 	icon_state = "resource"
+	desc = "Some smoke-producing blob creature thingy"
 	health = 30
 	maxhealth = 30
 	fire_resist = 2
@@ -22,6 +23,8 @@
 
 /obj/effect/blob/resource/Destroy()
 	blob_resources -= src
+	if(!manual_remove && overmind)
+		to_chat(overmind,"<span class='warning'>You lost a resource blob.</span>")
 	..()
 
 /obj/effect/blob/resource/update_health()
@@ -36,6 +39,7 @@
 	if(!overmind)
 		var/mob/camera/blob/B = (locate() in range(src,1))
 		if(B)
+			to_chat(B,"<span class='notice'>You take control of the resource blob.</span>")
 			overmind = B
 			update_icon()
 	..()

--- a/code/game/gamemodes/blob/blobs/shield.dm
+++ b/code/game/gamemodes/blob/blobs/shield.dm
@@ -1,7 +1,7 @@
 /obj/effect/blob/shield
 	name = "strong blob"
 	icon_state = "strong"
-	desc = "Some blob creature thingy"
+	desc = "Some very dense blob creature thingy"
 	health = 75
 	maxhealth = 75
 	fire_resist = 2

--- a/code/game/gamemodes/blob/overmind.dm
+++ b/code/game/gamemodes/blob/overmind.dm
@@ -18,14 +18,21 @@
 	var/max_blob_points = 100
 	var/maxjumprange = 20 //how far you can go in terms of non-blob tiles in a jump attempt
 
+	var/blob_warning = 0
+
 /mob/camera/blob/New()
 	var/new_name = "[initial(name)] ([rand(1, 999)])"
 	name = new_name
 	real_name = new_name
+	blob_overminds += src
 	..()
 	spawn(10)
 		if(src.mind)
 			src.mind.special_role = "Blob"
+
+/mob/camera/blob/Destroy()
+	blob_overminds -= src
+	..()
 
 /mob/camera/blob/Login()
 	..()

--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -159,6 +159,9 @@
 
 
 	B.change_to(/obj/effect/blob/node)
+	var/obj/effect/blob/node/N = locate() in T
+	if(N)
+		N.overmind = src
 	return
 
 
@@ -190,6 +193,9 @@
 		return
 
 	B.change_to(/obj/effect/blob/factory)
+	var/obj/effect/blob/factory/F = locate() in T
+	if(F)
+		F.overmind = src
 	return
 
 
@@ -211,6 +217,7 @@
 		to_chat(src, "Unable to remove this blob.")
 		return
 
+	B.manual_remove = 1
 	B.Delete()
 	return
 

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -56,6 +56,7 @@ var/list/blob_looks
 	layer = 6
 	var/spawning = 2
 	var/dying = 0
+	var/mob/camera/blob/overmind = null
 
 	var/looks = "new"
 
@@ -117,9 +118,11 @@ var/list/blob_looks
 
 	if(!manual_remove)
 		for(var/obj/effect/blob/core/C in range(loc,4))
-			if(C.overmind && (C.overmind.blob_warning <= world.time))
+			if((C != src) && C.overmind && (C.overmind.blob_warning <= world.time))
 				C.overmind.blob_warning = world.time + (10 SECONDS)
 				to_chat(C.overmind,"<span class='danger'>A blob died near your core!</span>")
+
+	overmind = null
 	..()
 
 /obj/effect/blob/projectile_check()

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -68,6 +68,8 @@ var/list/blob_looks
 	var/icon_new = "center"
 	var/icon_classic = "blob"
 
+	var/manual_remove = 0
+
 /obj/effect/blob/blob_act()
 	return
 
@@ -113,6 +115,11 @@ var/list/blob_looks
 			if(!spawning)
 				anim(target = B.loc, a_icon = icon, flick_anim = "connect_die", sleeptime = 50, direction = get_dir(B,src), lay = layer+0.3, offX = -16, offY = -16, col = "red")
 
+	if(!manual_remove)
+		for(var/obj/effect/blob/core/C in range(loc,4))
+			if(C.overmind && (C.overmind.blob_warning <= world.time))
+				C.overmind.blob_warning = world.time + (10 SECONDS)
+				to_chat(C.overmind,"<span class='danger'>A blob died near your core!</span>")
 	..()
 
 /obj/effect/blob/projectile_check()
@@ -270,6 +277,7 @@ var/list/blob_looks = list(
 /obj/effect/blob/proc/aftermove()
 	for(var/obj/effect/blob/B in loc)
 		if(B != src)
+			manual_remove = 1
 			qdel(src)
 			return
 	update_icon()
@@ -349,6 +357,7 @@ var/list/blob_looks = list(
 			B.forceMove(T)
 	else
 		T.blob_act()//If we cant move in hit the turf
+		B.manual_remove = 1
 		B.Delete()
 
 	for(var/atom/A in T)//Hit everything in the turf
@@ -364,6 +373,7 @@ var/list/blob_looks = list(
 	else
 		new type(src.loc, newlook = looks)
 	spawning = 1//so we don't show red severed connections
+	manual_remove = 1
 	Delete()
 	return
 

--- a/code/game/objects/structures/docking_port.dm
+++ b/code/game/objects/structures/docking_port.dm
@@ -42,6 +42,9 @@ var/global/list/all_docking_ports = list()
 /obj/structure/docking_port/ex_act()
 	return //we are eternal
 
+/obj/structure/docking_port/blob_act()
+	return //we are eternal
+
 /obj/structure/docking_port/cultify()
 	return //we are eternal
 

--- a/code/game/objects/structures/docking_port.dm
+++ b/code/game/objects/structures/docking_port.dm
@@ -42,9 +42,6 @@ var/global/list/all_docking_ports = list()
 /obj/structure/docking_port/ex_act()
 	return //we are eternal
 
-/obj/structure/docking_port/blob_act()
-	return //we are eternal
-
 /obj/structure/docking_port/cultify()
 	return //we are eternal
 

--- a/html/changelogs/DeityLink_9765.yml
+++ b/html/changelogs/DeityLink_9765.yml
@@ -1,0 +1,7 @@
+author: Deity Link
+delete-after: true
+changes:
+  - bugfix: Blobs cannot destroy docking ports anymore.
+  - bugfix: The Blob Overmind's HUD now properly indicates how much health his core has.
+  - rscadd: Added a lot of messages to Blob Overminds that trigger under a variety of conditions. Such as blobs near their core dying, a special blob that they've placed having been destroyed, or their core getting damaged.
+  - rscadd: If there are multiple Blob Overminds in the world, they get instantly notified by the death of one of them. They also get notified by the death of any blob core, whether it had an overmind or not.


### PR DESCRIPTION
Half were bugs we found when we forced a blob event earlier today.

The other half were ideas that came to me since incidentally I got to actually play blob for the first time.
- Blobs cannot destroy docking ports anymore.
- The Blob Overmind's HUD now properly indicates how much health his core has.
- Added a lot of messages to Blob Overminds that trigger under a variety of conditions. Such as blobs near their core dying (10 seconds cooldown), a special blob that they've placed having been destroyed, or their core getting damaged (3 seconds cooldown).
- If there are multiple Blob Overminds in the world, they get instantly notified by the death of one of them. They also get notified by the death of any blob core, whether it had an overmind or not.
