### PR TITLE
Removes a space in xeno chips recipe causing the whole world to burn.

### DIFF
--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -1281,7 +1281,7 @@
 	result = /obj/item/weapon/reagent_containers/food/snacks/chips/cookable/communist
 
 /datum/recipe/xenochips
-	reagents = list ("sodiumchloride " = 2)
+	reagents = list ("sodiumchloride" = 2)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/grown/potato,
 		/obj/item/weapon/reagent_containers/food/snacks/meat/xenomeat,


### PR DESCRIPTION
Fixes https://github.com/d3athrow/vgstation13/issues/9763
