### PR TITLE
Fix supermatter tiles

### DIFF
--- a/code/game/gamemodes/endgame/supermatter_cascade/blob.dm
+++ b/code/game/gamemodes/endgame/supermatter_cascade/blob.dm
@@ -43,8 +43,8 @@
 
 	// EXPAND DONG
 	if(isturf(T))
-		// Do pretty fadeout animation for 1s.
-		new /obj/effect/overlay/bluespacify(T)
+		// This is normally where a growth animation would occur
+//		new /obj/effect/overlay/bluespacify(T)
 		spawn(10)
 			// Nom.
 			for(var/atom/movable/A in T)
@@ -118,3 +118,6 @@
 		return
 
 	qdel(user)
+
+/turf/unsimulated/wall/supermatter/singularity_act()
+	return

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -880,6 +880,8 @@ var/global/list/image/blood_overlays = list()
 
 //handling the pulling of the item for singularity
 /obj/item/singularity_pull(S, current_size)
+	if(flags & INVULNERABLE)
+		return
 	spawn(0) //this is needed or multiple items will be thrown sequentially and not simultaneously
 		if(current_size >= STAGE_FOUR)
 			//throw_at(S, 14, 3)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -157,6 +157,8 @@ var/global/list/reagents_to_log = list("fuel"  =  "welder fuel", "plasma"=  "pla
 	return
 
 /obj/singularity_act()
+	if(flags & INVULNERABLE)
+		return
 	ex_act(1)
 	if(src)
 		qdel(src)


### PR DESCRIPTION
It no longer bluespacifies when growing
A supermatter trying to eat them no longer does anything fixes #9714
Singularities also check invulnerability before pulling/eating objects