### PR TITLE
cuban pete rewards modification

### DIFF
--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -201,14 +201,14 @@
 
 			if(emagged)
 				feedback_inc("arcade_win_emagged")
-				new /obj/effect/spawner/newbomb/timer/syndicate(src.loc)
 				new /obj/item/clothing/head/collectable/petehat(src.loc)
-				new /obj/item/device/maracas(src.loc)
-				new /obj/item/device/maracas(src.loc)
-				message_admins("[key_name_admin(usr)] has outbombed Cuban Pete and been awarded a bomb.")
-				log_game("[key_name_admin(usr)] has outbombed Cuban Pete and been awarded a bomb.")
+				new /obj/item/device/maracas/cubanpete(src.loc)
+				new /obj/item/device/maracas/cubanpete(src.loc)
+				message_admins("[key_name_admin(usr)] has outbombed Cuban Pete and been awarded explosive maracas.")
+				log_game("[key_name_admin(usr)] has outbombed Cuban Pete and been awarded explosive maracas.")
 				src.New()
 				emagged = 0
+
 			else if(!contents.len)
 				feedback_inc("arcade_win_normal")
 				var/prizeselect = pickweight(prizes)
@@ -220,10 +220,10 @@
 				else if(istype(prizeselect, /obj/item/clothing/suit/syndicatefake)) //Helmet is part of the suit
 					new	/obj/item/clothing/head/syndicatefake(src.loc)
 
-			else
+			else //admins can varedit arcades to have special prizes via contents, but it removes the prize rather than spawn a new one
 				feedback_inc("arcade_win_normal")
 				var/atom/movable/prize = pick(contents)
-				prize.loc = src.loc
+				prize.forceMove(src.loc)
 
 	else if (emagged && (turtle >= 4))
 		var/boomamt = rand(5,10)

--- a/code/game/objects/items/devices/maracas.dm
+++ b/code/game/objects/items/devices/maracas.dm
@@ -11,6 +11,10 @@
 
 	var/emagged = 0//our maracas are different - Deity Link
 
+/obj/item/device/maracas/cubanpete
+	name = "Cuban Pete's maracas"
+	emagged = 1
+
 /obj/item/device/maracas/New()
 	..()
 	src.pixel_x = rand(-5.0, 5)
@@ -23,19 +27,27 @@
 
 /obj/item/device/maracas/throw_impact(atom/hit_atom)
 	if(emagged)
-		explosion(get_turf(src), -1 ,-1, 1)
-		emagged = 0
+		explosion(get_turf(src), -1 ,1, 3)
+		qdel(src)
 
 /obj/item/device/maracas/dropped(mob/user)
 	user.callOnFace -= "\ref[src]"
 	spawn(3)
 		chickchicky()
 
+/obj/item/device/maracas/examine(mob/user)
+	..()
+	if(emagged)
+		to_chat(user, "<span class='warning'>You're not sure why, but you swear that you can hear the maracas ticking.</span>")
+
 /obj/item/device/maracas/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/weapon/card/emag) && !emagged)
-		to_chat(user, "<span class='warning'>You're not sure why, but you could swear that you can hear the maracas ticking.</span>")
+		to_chat(user, "<span class='warning'>You're not sure why, but you swear that you can hear the maracas ticking.</span>")
 		emagged = 1
 	return
+
+/obj/item/device/maracas/afterattack()
+	chickchicky()
 
 /obj/item/device/maracas/attack_self(mob/user as mob)
 	chickchicky()

--- a/html/changelogs/Intipete.yml
+++ b/html/changelogs/Intipete.yml
@@ -1,0 +1,6 @@
+author: Intigracy
+delete-after: True
+changes: 
+- rscdel: "Cuban pete no longer gives you a free bomb when you beat him via emagged arcade."
+- tweak: "The maracas Pete gives you for beating him are now by default emagged, meaning when you throw them at something they explode."
+- tweak: "Buffed the emagged maraca explosion. It will now cause a hull breach if thrown at a floor, and will gib dead bodies. It deals about 100 damage when thrown at mobs."


### PR DESCRIPTION
http://dl.dropboxusercontent.com/s/o3x6yxfwq5m9dgw/mexicanpeter.mp4?dl=0
- rscdel: "Cuban pete no longer gives you a free bomb when you beat him via emagged arcade."
- tweak: "The maracas Pete gives you for beating him are now by default emagged, meaning when you throw them at something they explode."
- tweak: "Buffed the emagged maraca explosion. It will now cause a hull breach if thrown at a floor, and will gib dead bodies. It deals about 100 damage when thrown at mobs."

closes #9766
