### PR TITLE
Converting meteors into projectiles

### DIFF
--- a/code/WorkInProgress/Ported/policetape.dm
+++ b/code/WorkInProgress/Ported/policetape.dm
@@ -148,7 +148,7 @@
 	if(!density) return 1
 	if(air_group || (height==0)) return 1
 
-	if ((mover.flags & 2 || istype(mover, /obj/effect/meteor) || mover.throwing == 1) )
+	if ((mover.flags & 2 || istype(mover, /obj/item/projectile/meteor) || mover.throwing == 1) )
 		return 1
 	else
 		return 0

--- a/code/WorkInProgress/Ported/policetape.dm
+++ b/code/WorkInProgress/Ported/policetape.dm
@@ -144,11 +144,12 @@
 				return
 		M:loc = T
 
-/obj/item/tape/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
-	if(!density) return 1
-	if(air_group || (height==0)) return 1
-
-	if ((mover.flags & 2 || istype(mover, /obj/item/projectile/meteor) || mover.throwing == 1) )
+/obj/item/tape/Cross(atom/movable/mover, turf/target, height = 1.5, air_group = 0)
+	if(!density)
+		return 1
+	if(air_group || (height == 0))
+		return 1
+	if((mover.checkpass(PASSGLASS) || istype(mover, /obj/item/projectile/meteor) || mover.throwing == 1))
 		return 1
 	else
 		return 0

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -159,7 +159,7 @@
 
 //We don't want meteors to bump into eachother and explode, so they pass through eachother
 //Reflection on bumping would be better, but I would reckon I'm not sure on how to achieve it
-/obj/item/projectile/meteor/CanPass(atom/movable/mover, turf/target, height = 1.5, air_group = 0)
+/obj/item/projectile/meteor/Cross(atom/movable/mover, turf/target, height = 1.5, air_group = 0)
 
 	if(istype(mover, /obj/item/projectile/meteor))
 		return 1 //Just move through it, no questions asked

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -169,6 +169,7 @@
 		return ..() //Refer to atom/proc/Cross
 
 /obj/item/projectile/meteor/Bump(atom/A)
+
 	if(loc == null)
 		return
 
@@ -186,6 +187,9 @@
 
 /obj/item/projectile/meteor/radioactive/Bump(atom/a)
 
+	if(loc == null)
+		return
+
 	for(var/mob/living/M in viewers(src, null))
 		M.radiation += rand(5, 10)
 
@@ -198,6 +202,8 @@
 	pass_flags = PASSTABLE
 
 /obj/item/projectile/meteor/small/Bump(atom/A)
+	if(loc == null)
+		return
 
 	explosion(get_turf(src), -1, 1, 3, 4, 0, 1, 0) //Tiny meteor doesn't cause too much damage
 	qdel(src)
@@ -208,6 +214,9 @@
 	icon_state = "small_flash"
 
 /obj/item/projectile/meteor/small/flash/Bump(atom/A)
+
+	if(loc == null)
+		return
 
 	//Adjusted from flashbangs, should be its own global proc
 	visible_message("<span class='danger'>BANG</span>")
@@ -256,7 +265,8 @@
 				to_chat(M, "<span class='warning'>You can't hear anything!</span>")
 				M.sdisabilities |= DEAF
 
-	..()
+	explosion(get_turf(src), -1, 1, 3, 4, 0, 1, 0) //Tiny meteor doesn't cause too much damage
+	qdel(src)
 
 /obj/item/projectile/meteor/piercing
 	name = "piercing meteor"
@@ -265,6 +275,9 @@
 	var/pierce_health = 1 //When 0, piercing meteor explodes like normal
 
 /obj/item/projectile/meteor/piercing/Bump(atom/A)
+
+	if(loc == null)
+		return
 
 	if(pierce_health)
 		explosion(get_turf(A), 1, 0, 0, 0, 0, 1, 0) //Blow up the resisting object
@@ -280,6 +293,9 @@
 
 /obj/item/projectile/meteor/big/Bump(atom/A)
 
+	if(loc == null)
+		return
+
 	explosion(get_turf(src), 4, 6, 8, 8, 0, 1, 0) //You have been visited by the nuclear meteor
 	qdel(src)
 
@@ -289,6 +305,9 @@
 	icon_state = "big_cluster"
 
 /obj/item/projectile/meteor/big/cluster/Bump(atom/A)
+
+	if(loc == null)
+		return
 
 	explosion(get_turf(A), 1, 0, 0, 0, 0, 1, 0) //Enough to destroy whatever was in the way
 	for(var/i = 0, i < 3, i++)
@@ -319,5 +338,9 @@
 	icon_state = "human"
 
 /obj/effect/meteor/gib/Bump(atom/A)
+
+	if(loc == null)
+		return
+
 	new /obj/effect/gibspawner/human(src.loc)
 	qdel(src)

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -169,6 +169,8 @@
 		return ..() //Refer to atom/proc/Cross
 
 /obj/item/projectile/meteor/Bump(atom/A)
+	if(loc == null)
+		return
 
 	explosion(get_turf(src), 2, 4, 6, 8, 0, 1, 0) //Medium meteor, medium boom
 	qdel(src)

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -241,7 +241,7 @@
 
 		//Flashing everyone
 		if(eye_safety < 2)
-			flick("e_flash", M.flash)
+			M.flash_eyes(visual = 1)
 			switch(eye_safety)
 				if(1)
 					M.Stun(2)
@@ -330,7 +330,6 @@
 	..()
 
 /obj/item/projectile/meteor/Destroy()
-	walk(src, 0) //This cancels the walk_towards() proc
 	..()
 
 /obj/effect/meteor/gib    //non explosive meteor, appears to be a corpse spinning in space before impacting something and spraying gibs everywhere

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -176,7 +176,8 @@
 	explosion(get_turf(src), 2, 4, 6, 8, 0, 1, 0) //Medium meteor, medium boom
 	qdel(src)
 
-/obj/item/projectile/immovablerod/forceMove(atom/destination, var/no_tp = 0)
+/obj/item/projectile/meteor/forceMove(atom/destination, var/no_tp = 0)
+	..()
 	if(z != starting.z)
 		qdel(src)
 		return

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -176,11 +176,11 @@
 	explosion(get_turf(src), 2, 4, 6, 8, 0, 1, 0) //Medium meteor, medium boom
 	qdel(src)
 
-/obj/item/projectile/meteor/forceMove(atom/destination, var/no_tp = 0)
-	..()
+/obj/item/projectile/meteor/process()
 	if(z != starting.z)
 		qdel(src)
 		return
+	..()
 
 /obj/item/projectile/meteor/radioactive
 	name = "radioactive meteor"

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -176,9 +176,10 @@
 	explosion(get_turf(src), 2, 4, 6, 8, 0, 1, 0) //Medium meteor, medium boom
 	qdel(src)
 
-/obj/item/projectile/meteor/Move()
-	..()
-	return
+/obj/item/projectile/immovablerod/forceMove(atom/destination, var/no_tp = 0)
+	if(z != starting.z)
+		qdel(src)
+		return
 
 /obj/item/projectile/meteor/radioactive
 	name = "radioactive meteor"

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -108,96 +108,105 @@
 
 	while(!istype(pickedstart, /turf/space))
 
-	var/atom/movable/M
 	if(meteorpath)
-		M = new meteorpath(pickedstart)
+		new meteorpath(pickedstart, pickedgoal)
 	else
 		var/list/possible_meteors = list()
 		if(!max_meteor_size || max_meteor_size >= 1) //Small waves
-			possible_meteors[/obj/effect/meteor/small] = 40
-			possible_meteors[/obj/effect/meteor/small/flash] = 5
+			possible_meteors[/obj/item/projectile/meteor/small] = 80
+			possible_meteors[/obj/item/projectile/meteor/small/flash] = 8
 		if(!max_meteor_size || max_meteor_size >= 2) //Medium waves
-			possible_meteors[/obj/effect/meteor] = 55
-			possible_meteors[/obj/effect/meteor/radioactive] = 5
+			possible_meteors[/obj/item/projectile/meteor] = 100
+			possible_meteors[/obj/item/projectile/meteor/radioactive] = 10
 		if(!max_meteor_size || max_meteor_size >= 3) //Big waves
-			possible_meteors[/obj/effect/meteor/big] = 5
-			possible_meteors[/obj/effect/meteor/big/cluster] = 5
+			possible_meteors[/obj/item/projectile/meteor/big] = 10
+			possible_meteors[/obj/item/projectile/meteor/big/cluster] = 1
 		var/chosen = pick(possible_meteors)
-		M = new chosen(pickedstart)
-	if(M)
-		walk_towards(M, pickedgoal, 1)
-	return
+		new chosen(pickedstart, pickedgoal)
 
 /*
  * Below are all meteor types
  */
 
-/obj/effect/meteor
+/obj/item/projectile/meteor
 	name = "meteor"
 	icon = 'icons/obj/meteor.dmi'
 	icon_state = "medium"
 	density = 1
 	anchored = 1 //You can't push or pull it to prevent exploiting
-	pass_flags = PASSTABLE
+	grillepasschance = 0
+	mouse_opacity = 1
+
+/obj/item/projectile/meteor/New(atom/start, atom/end)
+	..()
+	if(end)
+		throw_at(end)
+
+/obj/item/projectile/meteor/throw_at(atom/end)
+	original = end
+	starting = loc
+	current = loc
+	OnFired()
+	yo = target.y - y
+	xo = target.x - x
+	process()
 
 //Since meteors explode on impact, we won't allow chain reactions like this
 //Maybe one day I wil code explosive recoil, but in the meantime who bombs meteor waves anyways ?
-/obj/effect/meteor/ex_act()
+/obj/item/projectile/meteor/ex_act()
 
 	return
 
 //We don't want meteors to bump into eachother and explode, so they pass through eachother
 //Reflection on bumping would be better, but I would reckon I'm not sure on how to achieve it
-/obj/effect/meteor/Cross(atom/movable/mover, turf/target, height = 1.5, air_group = 0)
+/obj/item/projectile/meteor/CanPass(atom/movable/mover, turf/target, height = 1.5, air_group = 0)
 
-	if(istype(mover, /obj/effect/meteor))
+	if(istype(mover, /obj/item/projectile/meteor))
 		return 1 //Just move through it, no questions asked
+	if(isliving(mover))
+		return 0 //Collision
 	else
 		return ..() //Refer to atom/proc/Cross
 
-/obj/effect/meteor/Bump(atom/A)
-	if(loc == null)
-		return
+/obj/item/projectile/meteor/Bump(atom/A)
+
 	explosion(get_turf(src), 2, 4, 6, 8, 0, 1, 0) //Medium meteor, medium boom
 	qdel(src)
 
-/obj/effect/meteor/Move()
+/obj/item/projectile/meteor/Move()
 	..()
 	return
 
-/obj/effect/meteor/radioactive
+/obj/item/projectile/meteor/radioactive
 	name = "radioactive meteor"
 	desc = "The Engineer's bane"
 	icon_state = "medium_radioactive"
 
-/obj/effect/meteor/radioactive/Bump(atom/a)
-	if(loc == null)
-		return
+/obj/item/projectile/meteor/radioactive/Bump(atom/a)
+
 	for(var/mob/living/M in viewers(src, null))
 		M.radiation += rand(5, 10)
 
 	..()
 
-/obj/effect/meteor/small
+/obj/item/projectile/meteor/small
 	name = "small meteor"
 	desc = "The mineral version of armed C4, coming right for your walls."
 	icon_state = "small"
 	pass_flags = PASSTABLE
 
-/obj/effect/meteor/small/Bump(atom/A)
-	if(loc == null)
-		return
+/obj/item/projectile/meteor/small/Bump(atom/A)
+
 	explosion(get_turf(src), -1, 1, 3, 4, 0, 1, 0) //Tiny meteor doesn't cause too much damage
 	qdel(src)
 
-/obj/effect/meteor/small/flash
+/obj/item/projectile/meteor/small/flash
 	name = "flash meteor"
 	desc = "A absolutely stunning rock specimen of blinding beauty."
 	icon_state = "small_flash"
 
-/obj/effect/meteor/small/flash/Bump(atom/A)
-	if(loc == null)
-		return
+/obj/item/projectile/meteor/small/flash/Bump(atom/A)
+
 	//Adjusted from flashbangs, should be its own global proc
 	visible_message("<span class='danger'>BANG</span>")
 	playsound(get_turf(src), 'sound/effects/bang.ogg', 25, 1)
@@ -221,7 +230,7 @@
 
 		//Flashing everyone
 		if(eye_safety < 2)
-			M.flash_eyes(visual = 1)
+			flick("e_flash", M.flash)
 			switch(eye_safety)
 				if(1)
 					M.Stun(2)
@@ -247,15 +256,14 @@
 
 	..()
 
-/obj/effect/meteor/piercing
+/obj/item/projectile/meteor/piercing
 	name = "piercing meteor"
 	desc = "Takes a page out of armor-piercing rounds, blowing its way through cover once, and then blowing up normally."
 	icon_state = "medium_piercing"
 	var/pierce_health = 1 //When 0, piercing meteor explodes like normal
 
-/obj/effect/meteor/piercing/Bump(atom/A)
-	if(loc == null)
-		return
+/obj/item/projectile/meteor/piercing/Bump(atom/A)
+
 	if(pierce_health)
 		explosion(get_turf(A), 1, 0, 0, 0, 0, 1, 0) //Blow up the resisting object
 		pierce_health--
@@ -263,54 +271,44 @@
 		explosion(get_turf(src), 2, 4, 6, 8, 0, 1, 0) //Blow ourselves up, in glory
 		qdel(src)
 
-/obj/effect/meteor/big
+/obj/item/projectile/meteor/big
 	name = "large meteor"
 	desc = "It might look large, but it is only a small splinter of a much bigger thing."
 	icon_state = "big"
-	pass_flags = 0 //Nope, you're not dodging that table
 
-/obj/effect/meteor/big/Bump(atom/A)
-	if(loc == null)
-		return
+/obj/item/projectile/meteor/big/Bump(atom/A)
+
 	explosion(get_turf(src), 4, 6, 8, 8, 0, 1, 0) //You have been visited by the nuclear meteor
 	qdel(src)
 
-/obj/effect/meteor/big/cluster
+/obj/item/projectile/meteor/big/cluster
 	name = "cluster meteor"
 	desc = "Makes up for its lack of explosiveness by splitting into multiple, fairly explosive meteors."
 	icon_state = "big_cluster"
 
-/obj/effect/meteor/big/cluster/Bump(atom/A)
-	if(loc == null)
-		return
+/obj/item/projectile/meteor/big/cluster/Bump(atom/A)
 
 	explosion(get_turf(A), 1, 0, 0, 0, 0, 1, 0) //Enough to destroy whatever was in the way
-	var/failcount = 0
 	for(var/i = 0, i < 3, i++)
-		if(failcount >= 5)
-			break
-		var/obj/effect/meteor/M = new /obj/effect/meteor(get_turf(src))
-		var/c_endy = rand(TRANSITIONEDGE, world.maxy - TRANSITIONEDGE)
 		var/c_endx = rand(TRANSITIONEDGE, world.maxx - TRANSITIONEDGE)
+		var/c_endy = rand(TRANSITIONEDGE, world.maxy - TRANSITIONEDGE)
 		var/c_pickedgoal = locate(c_endx, c_endy, 1)
-		if(!c_pickedgoal)
-			qdel(M)
-			i-- //Try again
-			failcount++ //Keep a track of failures
-		walk_towards(M, c_pickedgoal, 1)
+		if(c_pickedgoal)
+			new /obj/item/projectile/meteor(get_turf(src), c_pickedgoal)
 	qdel(src)
 
 //Placeholder for actual meteors of this kind, will be included SOON
-/obj/effect/meteor/boss
+/obj/item/projectile/meteor/boss
 	name = "apocalytic meteor"
 	desc = "And behold, a white meteor. And on that meteor..."
 
-/obj/effect/meteor/attackby(obj/item/weapon/W as obj, mob/user as mob)
+/obj/item/projectile/meteor/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(istype(W, /obj/item/weapon/pickaxe)) //Yeah, you can totally do that
 		qdel(src)
+		return
 	..()
 
-/obj/effect/meteor/Destroy()
+/obj/item/projectile/meteor/Destroy()
 	walk(src, 0) //This cancels the walk_towards() proc
 	..()
 
@@ -319,7 +317,5 @@
 	icon_state = "human"
 
 /obj/effect/meteor/gib/Bump(atom/A)
-	if(loc == null)
-		return
 	new /obj/effect/gibspawner/human(src.loc)
 	qdel(src)

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -61,10 +61,6 @@
 	var/list/y_arr
 
 	if(src.x <= 1)
-		if(istype(A, /obj/effect/meteor)||istype(A, /obj/effect/space_dust))
-			qdel(A)
-			A = null
-			return
 
 		var/list/cur_pos = src.get_global_map_pos()
 		if(!cur_pos) return
@@ -87,7 +83,7 @@
 				if ((A && A.loc))
 					A.loc.Entered(A)
 	else if (src.x >= world.maxx)
-		if(istype(A, /obj/effect/meteor))
+		if(istype(A, /obj/item/projectile/meteor))
 			qdel(A)
 			A = null
 			return
@@ -113,7 +109,7 @@
 				if ((A && A.loc))
 					A.loc.Entered(A)
 	else if (src.y <= 1)
-		if(istype(A, /obj/effect/meteor))
+		if(istype(A, /obj/item/projectile/meteor))
 			qdel(A)
 			A = null
 			return
@@ -139,7 +135,7 @@
 					A.loc.Entered(A)
 
 	else if (src.y >= world.maxy)
-		if(istype(A, /obj/effect/meteor)||istype(A, /obj/effect/space_dust))
+		if(istype(A, /obj/item/projectile/meteor)||istype(A, /obj/effect/space_dust))
 			qdel(A)
 			A = null
 			return

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -161,9 +161,6 @@
 		// if(ticker.mode.name == "nuclear emergency")	return
 		if(A.z > 6) return
 		if (A.x <= TRANSITIONEDGE || A.x >= (world.maxx - TRANSITIONEDGE - 1) || A.y <= TRANSITIONEDGE || A.y >= (world.maxy - TRANSITIONEDGE - 1))
-			if(istype(A, /obj/effect/meteor)||istype(A, /obj/effect/space_dust))
-				qdel(A)
-				return
 
 			var/list/contents_brought = list()
 			contents_brought += recursive_type_check(A)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -42,7 +42,7 @@ var/list/impact_master = list()
 	var/nodamage = 0 //Determines if the projectile will skip any damage inflictions
 	var/flag = "bullet" //Defines what armor to use when it hits things.  Must be set to bullet, laser, energy,or bomb	//Cael - bio and rad are also valid
 	var/projectile_type = "/obj/item/projectile"
-	var/kill_count = 50 //This will de-increment every process(). When 0, it will delete the projectile.
+	var/kill_count = INFINITY //This will de-increment every process(). When 0, it will delete the projectile.
 	var/total_steps = 0
 		//Effects
 	var/stun = 0

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -92,27 +92,6 @@
 			playsound(M.loc, 'sound/effects/bamf.ogg', 50, 0)
 	return 1
 
-//This shouldn't fucking exist, just spawn a meteor damnit
-/obj/item/projectile/meteor
-	name = "meteor"
-	icon = 'icons/obj/meteor.dmi'
-	icon_state = "smallf"
-	damage = 0
-	damage_type = BRUTE
-	nodamage = 1
-	flag = "bullet"
-
-/obj/item/projectile/meteor/Bump(atom/A as mob|obj|turf|area)
-	if(A == firer)
-		loc = A.loc
-		return
-
-	//Copied straight from small meteor code
-	spawn(0)
-		playsound(get_turf(src), 'sound/effects/meteorimpact.ogg', 10, 1)
-		explosion(src.loc, -1, 1, 3, 4, 0) //Tiny meteor doesn't cause too much damage
-		qdel(src)
-
 //Simple fireball
 /obj/item/projectile/simple_fireball
 	name = "fireball"


### PR DESCRIPTION
Redux of #8281
- Meteors are now projectiles and use projectile code to move around instead of walk_towards. This should make good use of the projectile move procs and allow us to target meteors and still have them keep moving, which will be useful later on
- Change probability weight. 100 is normal meteor weight, small meteors are 80, large meteors are 10. All special meteor types are ten times less likely than their parent
- Meteors that cross over a mob (same code as syndicate wheelchair and hacked MULEbot) will now fire Bump(), aka explosion. This prevents players from cheesing meteor waves by simply laying down in space, now they have to actually dodge the rocks
- A bunch of path updates, and old meteor projectile that was used for that weird meteor launcher bus weapon has been removed. I haven't tested that weapon, but it might just werk
- Attempt to fix cluster meteors, for some reason they sometimes don't get a destination
- Meteors are no longer deleted when hitting transition zones but still can't cross into other Z-levels

New changes : 
- Projectiles now have INFINITY as a kill_count. This means that most projectiles won't delete themselves fifty tiles in for no reason. And indeed, there's no reason, from optimization to gameplay, to have this for things like bullets or rockets

Tested, no runtimes
