### PR TITLE
Fixes station name and world.name

### DIFF
--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -58,9 +58,7 @@ var/religion_name = null
 
 	return capitalize(name)
 
-/proc/station_name()
-	if(station_name)
-		return station_name
+/proc/new_station_name()
 	var/random = rand(1,5)
 	var/name = ""
 
@@ -115,8 +113,12 @@ var/religion_name = null
 
 	return station_name
 
-/proc/world_name(var/name)
+/proc/station_name()
+	if(!station_name)
+		station_name = new_station_name()
+	return station_name
 
+/proc/set_world_name(var/name)
 
 	station_name = name
 
@@ -124,8 +126,6 @@ var/religion_name = null
 		world.name = "[config.server_name]: [name]"
 	else
 		world.name = name
-
-	return name
 
 var/syndicate_name = null
 /proc/syndicate_name()

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1092,7 +1092,7 @@ window "mainwindow"
 		right-click = false
 		saved-params = "pos;size;is-minimized;is-maximized"
 		on-size = ""
-		title = "Space Station 13"
+		/*title = "Space Station 13"*/
 		titlebar = true
 		statusbar = true
 		can-close = true


### PR DESCRIPTION
Fixes station name not showing up in window name
Fixes station name changing when referenced in several places

Lots of code used station_name to get the station's name, which would **GENERATE A NEW STATION NAME EVERY TIME**

I did test this by the way.
![](http://i.imgur.com/iNcbcLO.png)
