### PR TITLE
Add cancel buttons or instructions for a bunch of admin procs

### DIFF
--- a/code/game/gamemodes/endgame/xmas/xmas.dm
+++ b/code/game/gamemodes/endgame/xmas/xmas.dm
@@ -29,5 +29,9 @@
 /client/proc/smissmas()
 	set category = "Fun"
 	set name = "Execute Smissmas"
-	if(!holder)	return
+	if(!holder)
+		return
+	var/confirm = alert(src, "Are you sure? This will tamper with the universal state of all things!", "Confirm", "Yes", "No")
+	if(confirm != "Yes")
+		return
 	SetUniversalState(/datum/universal_state/christmas)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -905,15 +905,19 @@ var/global/floorIsLava = 0
 	set name = "Announce"
 	set desc="Announce your desires to the world"
 
-	if(!check_rights(0))	return
+	if(!check_rights(0))
+		return
 
-	var/message = input("Global message to send:", "Admin Announce", null, null)  as message
-	if(message)
-		if(!check_rights(R_SERVER,0))
-			message = adminscrub(message,500)
-		to_chat(world, "<span class='notice'><b>[usr.client.holder.fakekey ? "Administrator" : usr.key] Announces:</b>\n \t [message]</span>")
-		log_admin("Announce: [key_name(usr)] : [message]")
-	feedback_add_details("admin_verb","A") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+	var/message = input("Global message to send, input nothing to cancel.", "Admin Announce", null, null) as message
+
+	if(!message)
+		return
+
+	if(!check_rights(R_SERVER, 0))
+		message = adminscrub(message, 500)
+	to_chat(world, "<span class='notice'><b>[usr.client.holder.fakekey ? "Administrator" : usr.key] Announces:</b>\n \t [message]</span>")
+	log_admin("Announce: [key_name(usr)] : [message]")
+	feedback_add_details("admin_verb", "A") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /datum/admins/proc/toggleooc()
 	set category = "Server"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -609,8 +609,8 @@ var/list/admin_verbs_mod = list(
 	set desc = "Cause an explosion of varying strength at your location."
 
 	var/turf/epicenter = mob.loc
-	var/list/choices = list("Small Bomb (1,2,3)", "Medium Bomb (2,3,4)", "Big Bomb (3,5,7)", "Custom Bomb", "Cancel")
-	var/choice = input("What size explosion would you like to produce?") in choices|null
+	var/list/choices = list("Small Bomb (1,2,3)", "Medium Bomb (2,3,4)", "Big Bomb (3,5,7)", "Custom Bomb")
+	var/choice = input("What size explosion would you like to produce?") in choices | null
 	switch(choice)
 		if(null)
 			return 0
@@ -626,8 +626,7 @@ var/list/admin_verbs_mod = list(
 			var/light_impact_range = input("Light impact range (in tiles):") as num
 			var/flash_range = input("Flash range (in tiles):") as num
 			explosion(epicenter, devastation_range, heavy_impact_range, light_impact_range, flash_range)
-		if("Cancel")
-			return 0
+
 	log_admin("[key_name(usr)] creating an admin explosion at [epicenter.loc] ([epicenter.x],[epicenter.y],[epicenter.z]).")
 	message_admins("<span class='notice'>[key_name_admin(src)] creating an admin explosion at [epicenter.loc] ([epicenter.x],[epicenter.y],[epicenter.z]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[epicenter.x];Y=[epicenter.y];Z=[epicenter.z]'>JMP</A>).</span>")
 	feedback_add_details("admin_verb","DB") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
@@ -638,8 +637,8 @@ var/list/admin_verbs_mod = list(
 	set desc = "Cause an EMP of varying strength at your location."
 
 	var/turf/epicenter = mob.loc
-	var/list/choices = list("Small EMP (1,2)", "Medium EMP (2,4)", "Big EMP (4,8)", "Custom EMP", "Cancel")
-	var/choice = input("What size EMP would you like to produce?") in choices|null
+	var/list/choices = list("Small EMP (1,2)", "Medium EMP (2,4)", "Big EMP (4,8)", "Custom EMP")
+	var/choice = input("What size EMP would you like to produce?") in choices | null
 	switch(choice)
 		if(null)
 			return 0
@@ -653,8 +652,7 @@ var/list/admin_verbs_mod = list(
 			var/heavy_impact_range = input("Heavy impact range (in tiles):") as num
 			var/light_impact_range = input("Light impact range (in tiles):") as num
 			empulse(epicenter, heavy_impact_range, light_impact_range)
-		if("Cancel")
-			return 0
+
 	log_admin("[key_name(usr)] creating an admin EMP at [epicenter.loc] ([epicenter.x],[epicenter.y],[epicenter.z]).")
 	message_admins("<span class='notice'>[key_name_admin(src)] creating an admin EMP at [epicenter.loc] ([epicenter.x],[epicenter.y],[epicenter.z]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[epicenter.x];Y=[epicenter.y];Z=[epicenter.z]'>JMP</A>).</span>")
 	feedback_add_details("admin_verb","DE") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -610,7 +610,7 @@ var/list/admin_verbs_mod = list(
 
 	var/turf/epicenter = mob.loc
 	var/list/choices = list("Small Bomb (1,2,3)", "Medium Bomb (2,3,4)", "Big Bomb (3,5,7)", "Custom Bomb", "Cancel")
-	var/choice = input("What size explosion would you like to produce?") in choices
+	var/choice = input("What size explosion would you like to produce?") in choices|null
 	switch(choice)
 		if(null)
 			return 0
@@ -639,7 +639,7 @@ var/list/admin_verbs_mod = list(
 
 	var/turf/epicenter = mob.loc
 	var/list/choices = list("Small EMP (1,2)", "Medium EMP (2,4)", "Big EMP (4,8)", "Custom EMP", "Cancel")
-	var/choice = input("What size EMP would you like to produce?") in choices
+	var/choice = input("What size EMP would you like to produce?") in choices|null
 	switch(choice)
 		if(null)
 			return 0

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -609,7 +609,7 @@ var/list/admin_verbs_mod = list(
 	set desc = "Cause an explosion of varying strength at your location."
 
 	var/turf/epicenter = mob.loc
-	var/list/choices = list("Small Bomb (1,2,3)", "Medium Bomb (2,3,4)", "Big Bomb (3,5,7)", "Custom Bomb")
+	var/list/choices = list("Small Bomb (1,2,3)", "Medium Bomb (2,3,4)", "Big Bomb (3,5,7)", "Custom Bomb", "Cancel")
 	var/choice = input("What size explosion would you like to produce?") in choices
 	switch(choice)
 		if(null)
@@ -626,6 +626,8 @@ var/list/admin_verbs_mod = list(
 			var/light_impact_range = input("Light impact range (in tiles):") as num
 			var/flash_range = input("Flash range (in tiles):") as num
 			explosion(epicenter, devastation_range, heavy_impact_range, light_impact_range, flash_range)
+		if("Cancel")
+			return 0
 	log_admin("[key_name(usr)] creating an admin explosion at [epicenter.loc] ([epicenter.x],[epicenter.y],[epicenter.z]).")
 	message_admins("<span class='notice'>[key_name_admin(src)] creating an admin explosion at [epicenter.loc] ([epicenter.x],[epicenter.y],[epicenter.z]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[epicenter.x];Y=[epicenter.y];Z=[epicenter.z]'>JMP</A>).</span>")
 	feedback_add_details("admin_verb","DB") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
@@ -636,7 +638,7 @@ var/list/admin_verbs_mod = list(
 	set desc = "Cause an EMP of varying strength at your location."
 
 	var/turf/epicenter = mob.loc
-	var/list/choices = list("Small EMP (1,2)", "Medium EMP (2,4)", "Big EMP (4,8)", "Custom EMP")
+	var/list/choices = list("Small EMP (1,2)", "Medium EMP (2,4)", "Big EMP (4,8)", "Custom EMP", "Cancel")
 	var/choice = input("What size EMP would you like to produce?") in choices
 	switch(choice)
 		if(null)
@@ -651,6 +653,8 @@ var/list/admin_verbs_mod = list(
 			var/heavy_impact_range = input("Heavy impact range (in tiles):") as num
 			var/light_impact_range = input("Light impact range (in tiles):") as num
 			empulse(epicenter, heavy_impact_range, light_impact_range)
+		if("Cancel")
+			return 0
 	log_admin("[key_name(usr)] creating an admin EMP at [epicenter.loc] ([epicenter.x],[epicenter.y],[epicenter.z]).")
 	message_admins("<span class='notice'>[key_name_admin(src)] creating an admin EMP at [epicenter.loc] ([epicenter.x],[epicenter.y],[epicenter.z]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[epicenter.x];Y=[epicenter.y];Z=[epicenter.z]'>JMP</A>).</span>")
 	feedback_add_details("admin_verb","DE") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -1515,10 +1515,15 @@ client/proc/create_bomberman_arena()
 		"15x13 (2 players)",
 		"15x15 (4 players)",
 		"39x23 (10 players)",
+		"Cancel",
 		)
 	var/arena_type = input("What size for the arena?", "Arena Construction") in arena_sizes
+
+	if(arena_type == "Cancel")
+		return
+
 	var/turf/T = get_turf(src.mob)
-	var/datum/bomberman_arena/A = new /datum/bomberman_arena(T,arena_type,src.mob)
+	var/datum/bomberman_arena/A = new /datum/bomberman_arena(T, arena_type, src.mob)
 	arenas += A
 
 client/proc/control_bomberman_arena()

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -1515,11 +1515,10 @@ client/proc/create_bomberman_arena()
 		"15x13 (2 players)",
 		"15x15 (4 players)",
 		"39x23 (10 players)",
-		"Cancel",
 		)
-	var/arena_type = input("What size for the arena?", "Arena Construction") in arena_sizes
+	var/arena_type = input("What size for the arena?", "Arena Construction") in arena_sizes | null
 
-	if(arena_type == "Cancel")
+	if(!arena_type)
 		return
 
 	var/turf/T = get_turf(src.mob)

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -117,7 +117,7 @@
 
 	var/msg = input("Message:", text("Enter the text you wish to appear to your target, input nothing to cancel.")) as text
 
-	if(!msg
+	if(!msg)
 		return
 
 	for(var/mob/M in view())

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -69,14 +69,15 @@
 	set category = "Special Verbs"
 	set name = "Global Narrate"
 
-	if (!holder)
+	if(!holder)
 		to_chat(src, "Only administrators may use this command.")
 		return
 
-	var/msg = input("Message:", text("Enter the text you wish to appear to everyone:")) as text
+	var/msg = input("Message:", text("Enter the text you wish to appear to everyone, input nothing to cancel.")) as text
 
-	if (!msg)
+	if(!msg)
 		return
+
 	to_chat(world, "[msg]")
 	log_admin("GlobalNarrate: [key_name(usr)] : [msg]")
 	message_admins("<span class='notice'><B>GlobalNarrate: [key_name_admin(usr)] : [msg]<BR></B></span>", 1)
@@ -96,9 +97,9 @@
 	if(!M)
 		return
 
-	var/msg = input("Message:", text("Enter the text you wish to appear to your target:")) as text
+	var/msg = input("Message:", text("Enter the text you wish to appear to your target, input nothing to cancel.")) as text
 
-	if( !msg )
+	if(!msg)
 		return
 
 	to_chat(M, msg)
@@ -114,9 +115,9 @@
 		to_chat(src, "Only administrators may use this command.")
 		return
 
-	var/msg = input("Message:", text("Enter the text you wish to appear to your target:")) as text
+	var/msg = input("Message:", text("Enter the text you wish to appear to your target, input nothing to cancel.")) as text
 
-	if( !msg )
+	if(!msg
 		return
 
 	for(var/mob/M in view())
@@ -380,7 +381,8 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(!holder)
 		to_chat(src, "Only administrators may use this command.")
 		return
-	var/input = ckey(input(src, "Please specify which key will be respawned.", "Key", ""))
+
+	var/input = ckey(input(src, "Please specify which key will be respawned. Input nothing to cancel.", "Key", ""))
 	if(!input)
 		return
 


### PR DESCRIPTION
Added cancel buttons or clear instructions for : 
- Drop EMP
- Drop Bomb
- Local Narrate
- Global Narrate
- Announce
- Respawn Character
- Create a Bomberman Arena
- Execute Smissmas

Fixes #9830
