### PR TITLE
Removes the declared icon state for subtyped flipped tables

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -522,7 +522,6 @@
 	return 1
 
 /obj/structure/table/flipped
-	icon_state = "tableflip0"
 	flipped = 1
 
 /*


### PR DESCRIPTION
Removes the declared icon state for subtyped flipped tables which overrrides default flipping behavior.  This will make flipped tables look like normal tables in mapping but fixes the issue in game.

Attempts to create an elegant solution didn't work and I ran out of fucks to give.

Fixes https://github.com/d3athrow/vgstation13/issues/9812
