### PR TITLE
Fixes players being double-traitored, double-agent'd and otherwise.

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -265,9 +265,10 @@
 	if(candidates.len < recommended_enemies)
 		for(var/mob/new_player/player in players)
 			if(player.client && player.ready)
-				if(player.client.desires_role(role, display_to_user=poll)) // We don't have enough people who want to be antagonist, make a seperate list of people who don't want to be one
-					if(!jobban_isbanned(player, "Syndicate") && !jobban_isbanned(player, role)) //Nodrak/Carn: Antag Job-bans
-						drafted += player.mind
+				if(!player.mind in drafted || !player.mind in candidates) // Players were getting placed in candidates AND drafted lists.
+					if(player.client.desires_role(role, display_to_user=poll)) // We don't have enough people who want to be antagonist, make a seperate list of people who don't want to be one
+						if(!jobban_isbanned(player, "Syndicate") && !jobban_isbanned(player, role)) //Nodrak/Carn: Antag Job-bans
+							drafted += player.mind
 
 	if(restricted_jobs)
 		for(var/datum/mind/player in drafted)				// Remove people who can't be an antagonist


### PR DESCRIPTION
Fixes #7042, #3701
Possibly other issues I couldn't find easily related to this.

``` DM
[08:11:47]DEBUG: Small_Boss had traitor enabled, so drafting them.
[08:11:47]DEBUG: StealthMelon had traitor enabled, so drafting them.
[08:11:47]DEBUG: DarkSnack had traitor enabled, so drafting them.
[08:11:47]DEBUG: JeanVoerman had traitor enabled, so drafting them. (X)
[08:11:47]DEBUG: Lorkhatosh had traitor enabled, so drafting them.
[08:11:47]DEBUG: DonGilardoni had traitor enabled, so drafting them.
[08:11:47]DEBUG: JeanVoerman was force-drafted as traitor, because there aren't enough candidates. (X)
[08:11:47]DEBUG: Small_Boss was force-drafted as traitor, because there aren't enough candidates.
[08:11:47]DEBUG: DarkSnack was force-drafted as traitor, because there aren't enough candidates.
[08:11:47]ADMIN: Starting a round of double agents with 2 starting traitors.
```

You ever spend a whole day trying to find a bug, give up, ignore it for months, then come back later and find the problem instantly?
Best feeling

@Intigracy should decide whether or not this should wait until after antag datums I guess
Or @clusterfack 
