### PR TITLE
(should) Fix jump link for adminlog on matter eater

### DIFF
--- a/code/game/dna/genes/goon_powers.dm
+++ b/code/game/dna/genes/goon_powers.dm
@@ -398,14 +398,14 @@
 			user.visible_message("<span class='danger'>[user] eats [the_item]'s [limb.display_name].</span>", \
 			"<span class='danger'>You eat [the_item]'s [limb.display_name].</span>")
 			playsound(get_turf(user), 'sound/items/eatfood.ogg', 50, 0)
-			message_admins("[user] ate [the_item]'s [limb]: (<A href='?src=\ref[src];jumpto=\ref[user]'><b>Jump to</b></A>)")
+			message_admins("[user] ate [the_item]'s [limb]: (<A href='?_src_=holder;jumpto=\ref[user]'><b>Jump to</b></A>)")
 			log_game("[user] ate \the [the_item]'s [limb] at [user.x], [user.y], [user.z]")
 			limb.droplimb("override" = 1, "spawn_limb" = 0)
 			doHeal(user)
 	else
 		user.visible_message("<span class='warning'>[usr] eats \the [the_item].")
 		playsound(get_turf(user), 'sound/items/eatfood.ogg', 50, 0)
-		message_admins("[user] ate \the [the_item]: (<A href='?src=\ref[src];jumpto=\ref[user]'><b>Jump to</b></A>)")
+		message_admins("[user] ate \the [the_item]: (<A href='?_src_=holder;jumpto=\ref[user]'><b>Jump to</b></A>)")
 		log_game("[user] ate \the [the_item] at [user.x], [user.y], [user.z]")
 		qdel(the_item)
 		doHeal(usr)


### PR DESCRIPTION
Matches syntax for other jumptos such as singulo, at least. So it **SHOULD** work
I thought I tested this but I'm not so sure anymore
