### PR TITLE
Fixes portable flashes (and wall mounted flashes) flashing through eye protection

### DIFF
--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -93,7 +93,10 @@ var/list/obj/machinery/flasher/flashers = list()
 		if(istype(O, /mob/living))
 			var/mob/living/L = O
 			L.flash_eyes(affect_silicon = 1)
-		O.Weaken(strength)
+		if(isype(O, /mob/living/carbon))
+			var/mob/living/carbon/C = O
+			if(O.eyecheck() <= 0) // Identical to handheld flash safety check
+				O.Weaken(strength)
 
 
 /obj/machinery/flasher/emp_act(severity)

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -93,10 +93,10 @@ var/list/obj/machinery/flasher/flashers = list()
 		if(istype(O, /mob/living))
 			var/mob/living/L = O
 			L.flash_eyes(affect_silicon = 1)
-		if(isype(O, /mob/living/carbon))
+		if(istype(O, /mob/living/carbon))
 			var/mob/living/carbon/C = O
-			if(O.eyecheck() <= 0) // Identical to handheld flash safety check
-				O.Weaken(strength)
+			if(C.eyecheck() <= 0) // Identical to handheld flash safety check
+				C.Weaken(strength)
 
 
 /obj/machinery/flasher/emp_act(severity)

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -97,6 +97,8 @@ var/list/obj/machinery/flasher/flashers = list()
 			var/mob/living/carbon/C = O
 			if(C.eyecheck() <= 0) // Identical to handheld flash safety check
 				C.Weaken(strength)
+		else
+			O.Weaken(strength)
 
 
 /obj/machinery/flasher/emp_act(severity)


### PR DESCRIPTION
I think I accidentally removed the eyeprot check here because I was going to move flashes stunning to flash_eyes
But I gave up on that and forgot to re-add it here?
WHO KNOWS
Fixes #9687
