### PR TITLE
Projectile-related fixes

### DIFF
--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -42,7 +42,7 @@ var/list/blob_looks
 	icon_state = "center"
 	luminosity = 2
 	desc = "Some blob creature thingy"
-	density = 0
+	density = 1
 	opacity = 0
 	anchored = 1
 	penetration_dampening = 17
@@ -131,7 +131,7 @@ var/list/blob_looks
 /obj/effect/blob/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(air_group || (height==0))	return 1
 	if(istype(mover) && mover.checkpass(PASSBLOB))	return 1
-	return 0
+	return !density
 
 /obj/effect/blob/beam_connect(var/obj/effect/beam/B)
 	..()

--- a/code/game/machinery/computer/HolodeckControl.dm
+++ b/code/game/machinery/computer/HolodeckControl.dm
@@ -428,7 +428,7 @@
 			if(get_dir(loc, target) == dir)
 				return !density
 		else if(mover.dir == dir) //Or are we using move code
-			if(density)	Bumped(mover)
+			if(density)	mover.Bump(src)
 			return !density
 	return 1
 

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -477,7 +477,7 @@ var/global/list/alert_overlays_global = list()
 			if(get_dir(loc, target) == dir)
 				return !density
 		else if(mover.dir == dir) //Or are we using move code
-			if(density)	Bumped(mover)
+			if(density)	mover.Bump(src)
 			return !density
 	return 1
 

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -90,7 +90,7 @@
 			if(get_dir(loc, target) == dir)
 				return !density
 		else if(mover.dir == dir) //Or are we using move code
-			if(density)	Bumped(mover)
+			if(density)	mover.Bump(src)
 			return !density
 	return 1
 

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -351,7 +351,7 @@
 			if(get_dir(loc, target) == dir)
 				return !density
 		else if(mover.dir == dir) //Or are we using move code
-			if(density)	Bumped(mover)
+			if(density)	mover.Bump(src)
 			return !density
 	return 1
 

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -62,7 +62,7 @@ obj/structure/windoor_assembly/Destroy()
 			if(get_dir(loc, target) == dir)
 				return !density
 		else if(mover.dir == dir) //Or are we using move code
-			if(density)	Bumped(mover)
+			if(density)	mover.Bump(src)
 			return !density
 	return 1
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -152,7 +152,7 @@
 			if(get_dir(loc, target) == dir)
 				return !density
 		else if(mover.dir == dir) //Or are we using move code
-			if(density)	Bumped(mover)
+			if(density)	mover.Bump(src)
 			return !density
 	return 1
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -628,3 +628,7 @@ var/list/impact_master = list()
 
 /obj/item/projectile/kick_act() //Can't be kicked around
 	return
+
+/obj/item/projectile/attack_hand(mob/user)
+	if(timestopped)
+		..()


### PR DESCRIPTION
Projectiles can now only be picked up while timestopped.
Projectiles no longer get stuck on windows or blobs.
You can push windows in the direction they're facing again.

Fixes #9888, fixes #9885, addresses #9882

Now also probably fixes #9871 even though it's already closed
