### PR TITLE
NPC Ranged Hostile mobs no longer shoot at their target if there's a friendly in the way

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -121,7 +121,11 @@ var/list/nest_locations = list()
 					D.attackby(CB,src)
 					qdel(CB)
 
-/mob/living/simple_animal/hostile/alien/CanAttack(var/atom/the_target)//they don't kill mindless monkeys so they can drag them to nests with a higher chance of a successful impregnation.
+/mob/living/simple_animal/hostile/alien/CanAttack(var/atom/the_target)
+	if(isalien(the_target))
+		return 0
+
+	//they don't harm mindless monkeys so they can drag them to nests with a higher chance of a successful impregnation.
 	if(istype(the_target,/mob/living/carbon/monkey))
 		var/mob/living/carbon/monkey/M = the_target
 		if(!M.client)
@@ -359,11 +363,6 @@ var/list/nest_locations = list()
 	dead_mob_list -= src
 
 	qdel(src)
-
-/mob/living/simple_animal/hostile/alien/CanAttack(var/atom/the_target)
-	if(isalien(the_target))
-		return 0
-	return ..(the_target)
 
 /mob/living/simple_animal/hostile/alien/adjustBruteLoss(amount,var/damage_type) // Weak to Fire
 	if(damage_type == BURN)

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -275,40 +275,26 @@
 	if(istype(H))
 		src.friends |= H.friends
 
-/mob/living/simple_animal/hostile/proc/OpenFire(var/target)
-	var/tturf = get_turf(target)
+/mob/living/simple_animal/hostile/proc/OpenFire(var/atom/ttarget)
+	var/target_turf = get_turf(ttarget)
 	if(rapid)
 		spawn(1)
-			if(Shoot(tturf, src.loc, src))
-				ranged_cooldown = ranged_cooldown_cap
-				if(ranged_message)
-					visible_message("<span class='warning'><b>[src]</b> [ranged_message] at [target]!</span>", 1)
-				if(casingtype)
-					new casingtype(get_turf(src))
+			TryToShoot(target_turf)
 		spawn(4)
-			if(Shoot(tturf, src.loc, src))
-				ranged_cooldown = ranged_cooldown_cap
-				if(ranged_message)
-					visible_message("<span class='warning'><b>[src]</b> [ranged_message] at [target]!</span>", 1)
-				if(casingtype)
-					new casingtype(get_turf(src))
+			TryToShoot(target_turf)
 		spawn(6)
-			if(Shoot(tturf, src.loc, src))
-				ranged_cooldown = ranged_cooldown_cap
-				if(ranged_message)
-					visible_message("<span class='warning'><b>[src]</b> [ranged_message] at [target]!</span>", 1)
-				if(casingtype)
-					new casingtype(get_turf(src))
+			TryToShoot(target_turf)
 	else
-		if(Shoot(tturf, src.loc, src))
-			ranged_cooldown = ranged_cooldown_cap
-			if(ranged_message)
-				visible_message("<span class='warning'><b>[src]</b> [ranged_message] at [target]!</span>", 1)
-			if(casingtype)
-				new casingtype(get_turf(src))
-
-
+		TryToShoot(target_turf)
 	return
+
+/mob/living/simple_animal/hostile/proc/TryToShoot(var/atom/target_turf)
+	if(Shoot(target_turf, src.loc, src))
+		ranged_cooldown = ranged_cooldown_cap
+		if(ranged_message)
+			visible_message("<span class='warning'><b>[src]</b> [ranged_message] at [target]!</span>", 1)
+		if(casingtype)
+			new casingtype(get_turf(src))
 
 /mob/living/simple_animal/hostile/proc/Shoot(var/atom/target, var/atom/start, var/mob/user, var/bullet = 0)
 	if(target == start)

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -329,7 +329,8 @@
 		fC.yo = target.y - start.y
 		fC.xo = target.x - start.x
 
-		if(!CanAttack(fC.process()))
+		var/atom/potentialImpact = fC.process()
+		if(potentialImpact && !CanAttack(potentialImpact))
 			returnToPool(fC)
 			return 0
 		returnToPool(fC)

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -27,6 +27,7 @@
 	var/stat_attack = 0 //Mobs with stat_attack to 1 will attempt to attack things that are unconscious, Mobs with stat_attack set to 2 will attempt to attack the dead.
 	var/stat_exclusive = 0 //Mobs with this set to 1 will exclusively attack things defined by stat_attack, stat_attack 2 means they will only attack corpses
 	var/attack_faction = null //Put a faction string here to have a mob only ever attack a specific faction
+	var/friendly_fire = 0 //If set to 1, they won't hesitate to shoot their target even if a friendly is in the way.
 
 /mob/living/simple_animal/hostile/resetVariables()
 	..("wanted_objects", "friends", args)
@@ -275,42 +276,71 @@
 		src.friends |= H.friends
 
 /mob/living/simple_animal/hostile/proc/OpenFire(var/target)
-
-
 	var/tturf = get_turf(target)
 	if(rapid)
 		spawn(1)
-			Shoot(tturf, src.loc, src)
-			if(ranged_message) visible_message("<span class='warning'><b>[src]</b> [ranged_message] at [target]!</span>", 1)
-			if(casingtype)
-				new casingtype(get_turf(src))
+			if(Shoot(tturf, src.loc, src))
+				ranged_cooldown = ranged_cooldown_cap
+				if(ranged_message)
+					visible_message("<span class='warning'><b>[src]</b> [ranged_message] at [target]!</span>", 1)
+				if(casingtype)
+					new casingtype(get_turf(src))
 		spawn(4)
-			Shoot(tturf, src.loc, src)
-			if(ranged_message) visible_message("<span class='warning'><b>[src]</b> [ranged_message] at [target]!</span>", 1)
-			if(casingtype)
-				new casingtype(get_turf(src))
+			if(Shoot(tturf, src.loc, src))
+				ranged_cooldown = ranged_cooldown_cap
+				if(ranged_message)
+					visible_message("<span class='warning'><b>[src]</b> [ranged_message] at [target]!</span>", 1)
+				if(casingtype)
+					new casingtype(get_turf(src))
 		spawn(6)
-			Shoot(tturf, src.loc, src)
-			if(ranged_message) visible_message("<span class='warning'><b>[src]</b> [ranged_message] at [target]!</span>", 1)
+			if(Shoot(tturf, src.loc, src))
+				ranged_cooldown = ranged_cooldown_cap
+				if(ranged_message)
+					visible_message("<span class='warning'><b>[src]</b> [ranged_message] at [target]!</span>", 1)
+				if(casingtype)
+					new casingtype(get_turf(src))
+	else
+		if(Shoot(tturf, src.loc, src))
+			ranged_cooldown = ranged_cooldown_cap
+			if(ranged_message)
+				visible_message("<span class='warning'><b>[src]</b> [ranged_message] at [target]!</span>", 1)
 			if(casingtype)
 				new casingtype(get_turf(src))
-	else
-		Shoot(tturf, src.loc, src)
-		if(ranged_message) visible_message("<span class='warning'><b>[src]</b> [ranged_message] at [target]!</span>", 1)
-		if(casingtype)
-			new casingtype
-	ranged_cooldown = ranged_cooldown_cap
+
+
 	return
 
-/mob/living/simple_animal/hostile/proc/Shoot(var/target, var/start, var/user, var/bullet = 0)
+/mob/living/simple_animal/hostile/proc/Shoot(var/atom/target, var/atom/start, var/mob/user, var/bullet = 0)
 	if(target == start)
-		return
+		return 0
 	if(!istype(target, /turf))
-		return
+		return 0
 
-	var/obj/item/projectile/A = new projectiletype(user:loc)
+	//Friendly Fire check
+	if(!friendly_fire)
+		var/obj/item/projectile/friendlyCheck/fC = getFromPool(/obj/item/projectile/friendlyCheck,user.loc)
+		fC.current = target
+		var/turf/T = get_turf(user)
+		var/turf/U = get_turf(target)
+		fC.original = target
+		fC.target = U
+		fC.current = T
+		fC.starting = T
+		fC.yo = target.y - start.y
+		fC.xo = target.x - start.x
+
+		if(!CanAttack(fC.process()))
+			returnToPool(fC)
+			return 0
+		returnToPool(fC)
+	//Friendly Fire check - End
+
+	var/obj/item/projectile/A = new projectiletype(user.loc)
+
+	if(!A)
+		return 0
+
 	playsound(user, projectilesound, 100, 1)
-	if(!A)	return
 
 	A.current = target
 
@@ -320,12 +350,13 @@
 	A.target = U
 	A.current = T
 	A.starting = T
-	A.yo = target:y - start:y
-	A.xo = target:x - start:x
+	A.yo = target.y - start.y
+	A.xo = target.x - start.x
 	spawn()
 		A.OnFired()
 		A.process()
-	return
+
+	return 1
 
 /mob/living/simple_animal/hostile/proc/DestroySurroundings()
 	if(environment_smash)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -649,19 +649,17 @@ var/list/impact_master = list()
 			bresenham_step(dist_y,dist_x,dy,dx)
 	return impact
 
-/obj/item/projectile/friendlyCheck/Bump(var/atom/A)
-	if(bumped)	return 0
-
-	bumped = 1
-
+/obj/item/projectile/proc/get_hit_atom(var/atom/A)
 	if(istype(A, /obj/structure/bed/chair/vehicle))
 		var/obj/structure/bed/chair/vehicle/JC = A
 		if(JC.occupant)
-			impact = JC.occupant
-			return
+			return JC.occupant
+	return A
+
+/obj/item/projectile/friendlyCheck/Bump(var/atom/A)
+	if(bumped)
+		return 0
+	bumped = 1
 
 	if(ismob(A) || isturf(A) || isobj(A))
-		impact = A
-		return
-
-	return
+		impact = get_hit_atom(A)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -649,27 +649,6 @@ var/list/impact_master = list()
 			bresenham_step(dist_y,dist_x,dy,dx)
 	return impact
 
-/obj/item/projectile/friendlyCheck/bresenham_step(var/distA, var/distB, var/dA, var/dB)
-	kill_count--
-	total_steps++
-	if(error < 0)
-		var/atom/step = get_step(src, dB)
-		if(!step)
-			bullet_die()
-		src.Move(step)
-		error += distA
-		bump_original_check()
-	else
-		var/atom/step = get_step(src, dA)
-		if(!step)
-			bullet_die()
-		src.Move(step)
-		error -= distB
-		dir = dA
-		if(error < 0)
-			dir = dA + dB
-		bump_original_check()
-
 /obj/item/projectile/friendlyCheck/Bump(var/atom/A)
 	if(bumped)	return 0
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -670,7 +670,7 @@ var/list/impact_master = list()
 			dir = dA + dB
 		bump_original_check()
 
-/obj/item/projectile/friendlyCheck/Bump(atom/A as mob|obj|turf|area)
+/obj/item/projectile/friendlyCheck/Bump(var/atom/A)
 	if(bumped)	return 0
 
 	bumped = 1
@@ -679,12 +679,6 @@ var/list/impact_master = list()
 		var/obj/structure/bed/chair/vehicle/JC = A
 		if(JC.occupant)
 			impact = JC.occupant
-			return
-
-	if(istype(A, /obj/mecha))
-		var/obj/mecha/M = A
-		if(M.occupant)
-			impact = M.occupant
 			return
 
 	if(ismob(A) || isturf(A) || isobj(A))

--- a/html/changelogs/DeityLink_9897.yml
+++ b/html/changelogs/DeityLink_9897.yml
@@ -1,0 +1,4 @@
+author: Deity Link
+delete-after: true
+changes:
+  - tweak: NPC hostile mobs with ranged weapons will no longer fire if there's a friendly unity between them and their target. Hivebots, aliens, syndicate agents, russians, etc, should stop killing each others now.


### PR DESCRIPTION
Well they can still accidentally hurt them if the friendly moves in the way after they fire.

Affects mobs such as hivebots, syndicates, xenomorphs, and any other ranged simple_animal.

Oh, and they now have a friendly_fire variable, so you can set it to 1 if you want your mobs to fire anyway.
