### PR TITLE
Possible fix for fullscreen.dm runtime

### DIFF
--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -47,9 +47,14 @@
 		clear_fullscreen(category)
 
 /datum/hud/proc/reload_fullscreen()
-	var/list/screens = mymob.screens
-	for(var/category in screens)
-		mymob.client.screen |= screens[category]
+	if(mymob && mymob.client && mymob.stat != DEAD)
+		var/list/screens = mymob.screens
+		for(var/category in screens)
+			var/obj/A = screens[category]
+			if(!istype(A, /obj/screen))
+				log_debug("Wrong type of object in screens, type [A.type]")
+				continue
+			mymob.client.screen |= A
 
 /obj/screen/fullscreen
 	icon = 'icons/mob/screen1_full.dmi'

--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -51,7 +51,7 @@
 		var/list/screens = mymob.screens
 		for(var/category in screens)
 			var/obj/A = screens[category]
-			if(!istype(A, /obj/screen))
+			if(istype(A, /atom) && !istype(A, /obj/screen))
 				log_debug("Wrong type of object in screens, type [A.type]")
 				continue
 			mymob.client.screen |= A


### PR DESCRIPTION
Adds some debug logging and a possible fix
The runtime that this was causing didn't provide any HUGELY descriptive info anyways, so this should help

The fix might work if only because this runtime occurs solely on human/New() shortly after Login(), so it's possible that for **SOME ARCANE REASON** the mob isn't ready to get shit thrown on its screen yet
It's also possible that this runtime is caused by that mysterious /obj that @clusterfack keeps nagging about that shows up on people's screen.
