### PR TITLE
Makes cables not shock you for clicking on them with things that don't interact with cables

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -220,7 +220,7 @@ By design, d1 is the smallest direction and d2 is the highest
 
 		shock(user, 5, 0.2)
 	else
-		if(W.is_conductor())
+		if(src.d1 && W.is_conductor()) // d1 determines if this is a cable end
 			shock(user, 50, 0.7)
 
 	src.add_fingerprint(user)
@@ -232,16 +232,15 @@ By design, d1 is the smallest direction and d2 is the highest
 
 // shock the user with probability prb
 /obj/structure/cable/proc/shock(mob/user, prb, siemens_coeff = 1.0)
-	if(src.d1 == 0) // Same as get_cable_node except that we're checking the cable clicked, not the turf.
-		if((get_powernet()) && (powernet.avail > 1000))
-			if(!prob(prb))
-				return 0
+	if((get_powernet()) && (powernet.avail > 1000))
+		if(!prob(prb))
+			return 0
 
-			if(electrocute_mob(user, powernet, src, siemens_coeff))
-				var/datum/effect/effect/system/spark_spread/s = new
-				s.set_up(5,1,src)
-				s.start()
-				return 1
+		if(electrocute_mob(user, powernet, src, siemens_coeff))
+			var/datum/effect/effect/system/spark_spread/s = new
+			s.set_up(5,1,src)
+			s.start()
+			return 1
 
 	return 0
 

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -232,15 +232,16 @@ By design, d1 is the smallest direction and d2 is the highest
 
 // shock the user with probability prb
 /obj/structure/cable/proc/shock(mob/user, prb, siemens_coeff = 1.0)
-	if((get_powernet()) && (powernet.avail > 1000))
-		if(!prob(prb))
-			return 0
+	if(src.d1 == 0) // Same as get_cable_node except that we're checking the cable clicked, not the turf.
+		if((get_powernet()) && (powernet.avail > 1000))
+			if(!prob(prb))
+				return 0
 
-		if(electrocute_mob(user, powernet, src, siemens_coeff))
-			var/datum/effect/effect/system/spark_spread/s = new
-			s.set_up(5,1,src)
-			s.start()
-			return 1
+			if(electrocute_mob(user, powernet, src, siemens_coeff))
+				var/datum/effect/effect/system/spark_spread/s = new
+				s.set_up(5,1,src)
+				s.start()
+				return 1
 
 	return 0
 

--- a/html/changelogs/Sood.yml
+++ b/html/changelogs/Sood.yml
@@ -1,2 +1,5 @@
 author: Sood
-changes: []
+changes:
+ - tweak: Power cables will no longer shock you unless you click on a cable end or are using tools on them.
+ - tweak: This means that wirecutters on cables still might shock you but bruise packs will not.
+ - tweak: UNLESS IT IS A CABLE END.


### PR DESCRIPTION
Resolves #9625 
Resolves #8461
Because **NOTHING HAS DEFINED SIEMENS COEFFICIENTS** that are not inherited
So we could either change the siemens values of a bunch of different things, virtually every item we have in code
OR
we could just fucking remove this block, because why would clicking on a power cable with things that do not break the insulation matter

Cable ends will shock you the same as cables currently do.
Normal pieces of cable will not shock you unless you are using tools on them.
