### PR TITLE
Flesh to stone now lasts for 2.5 minutes rather than 8.5 minutes.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/statue.dm
+++ b/code/game/objects/structures/crates_lockers/closets/statue.dm
@@ -10,7 +10,7 @@
 	var/intialFire = 0	//it's a little sloppy I know but it was this or the GODMODE flag. Lesser of two evils.
 	var/intialBrute = 0
 	var/intialOxy = 0
-	var/timer = 240 //eventually the person will be freed
+	var/timer = 80 // time in seconds = 2.5(timer) - 50, this makes 150 seconds = 2.5m
 
 /obj/structure/closet/statue/New(loc, var/mob/living/L)
 

--- a/html/changelogs/Intimathisez.yml
+++ b/html/changelogs/Intimathisez.yml
@@ -1,0 +1,4 @@
+author: Intigracy
+delete-after: True
+changes: 
+- tweak: "Flesh to stone now lasts for 2.5 minutes rather than 8.5 minutes."


### PR DESCRIPTION
I came to this wonderful math formula by timing how long it took for someone to get unstatued using a stopwatch.

It took 8m 20s almost exactly.

From there I assumed half of the timer would result in 4m 10s and did simple math to make the equation. (m = (y2-y1)/(x2-x1), plug in to y = mx + b and solve for b)
