### PR TITLE
Revert "NPC pathfinding through border-windows"

### DIFF
--- a/code/game/objects/structures/fullwindow.dm
+++ b/code/game/objects/structures/fullwindow.dm
@@ -11,7 +11,6 @@
 	sheetamount = 2
 	mouse_opacity = 2 // Complete opacity //What in the name of everything is this variable ?
 	layer = 3.21 // Windows are at 3.2.
-	density = 1
 
 	penetration_dampening = 1
 
@@ -53,7 +52,7 @@
 		var/junction = 0 //Will be used to determine from which side the window is connected to other windows
 		if(anchored)
 			for(var/obj/structure/window/full/W in orange(src, 1))
-				if(W.anchored) //Only counts anchored full-tile windows.
+				if(W.anchored && W.density) //Only counts anchored, not-destroyed full-tile windows.
 					if(abs(x-W.x)-abs(y-W.y)) 	//Doesn't count windows, placed diagonally to src
 						junction |= get_dir(src,W)
 		icon_state = "[base_state][junction]"

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -12,7 +12,7 @@
 	desc = "A silicate barrier, used to keep things out and in sight. Fragile."
 	icon = 'icons/obj/structures.dmi'
 	icon_state = "window"
-	density = 0 //Necessary for NPC mobs pathfinding
+	density = 1
 	layer = 3.2 //Just above airlocks //For some reason I guess
 	pressure_resistance = 4*ONE_ATMOSPHERE
 	anchored = 1
@@ -150,18 +150,17 @@
 	if(flags & ON_BORDER)
 		if(target) //Are we doing a manual check to see
 			if(get_dir(loc, target) == dir)
-				return 0
+				return !density
 		else if(mover.dir == dir) //Or are we using move code
-			mover.Bump(src)
-			return 0
+			if(density)	mover.Bump(src)
+			return !density
 	return 1
 
 /obj/structure/window/Cross(atom/movable/mover, turf/target, height = 0)
 	if(istype(mover) && mover.checkpass(PASSGLASS))
 		return 1
-	if(mover && (get_dir(loc, target) == dir || get_dir(loc, mover) == dir))
-		mover.Bump(src)
-		return 0
+	if(get_dir(loc, target) == dir || get_dir(loc, mover) == dir)
+		return !density
 	return 1
 
 //Someone threw something at us, please advise
@@ -458,7 +457,7 @@
 	dir = ini_dir
 	update_nearby_tiles()
 
-//This proc has to do with airgroups and atmos, it has nothing to do with smoothwindows, that's update_nearby_icons().
+//This proc has to do with airgroups and atmos, it has nothing to do with smoothwindows, that's update_nearby_tiles().
 /obj/structure/window/proc/update_nearby_tiles(var/turf/T)
 
 


### PR DESCRIPTION
Reverts d3athrow/vgstation13#9912
Caused air to leak through windows and grilles to shock through windows.
