### PR TITLE
More Blob stuff

### DIFF
--- a/code/game/gamemodes/blob/blobs/core.dm
+++ b/code/game/gamemodes/blob/blobs/core.dm
@@ -40,9 +40,9 @@
 
 	for(var/mob/camera/blob/O in blob_overminds)
 		if(overmind && (O != overmind))
-			to_chat(O,"<span class='danger'>A blob core has been destroyed! [overmind] lost his life!</span>")
+			to_chat(O,"<span class='danger'>A blob core has been destroyed! [overmind] lost his life!</span> <b><a href='?src=\ref[O];blobjump=\ref[loc]'>(JUMP)</a></b>")
 		else
-			to_chat(O,"<span class='warning'>A blob core has been destroyed. It had no overmind in control.</span>")
+			to_chat(O,"<span class='warning'>A blob core has been destroyed. It had no overmind in control.</span> <b><a href='?src=\ref[O];blobjump=\ref[loc]'>(JUMP)</a></b>")
 
 	if(overmind)
 		for(var/obj/effect/blob/resource/R in blob_resources)
@@ -62,7 +62,7 @@
 		overmind.update_health()
 		if((health < previous_health) && (core_warning_delay <= world.time))
 			resource_delay = world.time + (3 SECONDS)
-			to_chat(overmind,"<span class='danger'>YOUR CORE IS UNDER ATTACK!</span>")
+			to_chat(overmind,"<span class='danger'>YOUR CORE IS UNDER ATTACK!</span> <b><a href='?src=\ref[overmind];blobjump=\ref[loc]'>(JUMP)</a></b>")
 
 	previous_health = health
 
@@ -141,6 +141,13 @@
 		B.blob_core = src
 		src.overmind = B
 		if(!B.blob_core.creator)//If this core is the first of its lineage (created by game mode/event/admins, instead of another overmind) it gets to choose its looks.
+			var/new_name = "Blob Overmind ([rand(1, 999)])"
+			B.name = new_name
+			B.real_name = new_name
+			for(var/mob/camera/blob/O in blob_overminds)
+				if(O != B)
+					to_chat(O,"<span class='notice'>[B] has appeared and just started a new blob! <a href='?src=\ref[O];blobjump=\ref[loc]'>(JUMP)</a></span>")
+
 			B.verbs += /mob/camera/blob/proc/create_core
 			spawn()
 				var/chosen = input(B,"Select a blob looks", "Blob Looks", blob_looks[1]) as null|anything in blob_looks
@@ -148,6 +155,13 @@
 					for(var/obj/effect/blob/nearby_blob in range(src,5))
 						nearby_blob.looks = chosen
 						nearby_blob.update_looks(1)
+		else
+			var/new_name = "Blob Cerebrate ([rand(1, 999)])"
+			B.name = new_name
+			B.real_name = new_name
+			for(var/mob/camera/blob/O in blob_overminds)
+				if(O != B)
+					to_chat(O,"<span class='notice'>A new blob cerebrate has started thinking inside a blob core! [B] joins the blob! <a href='?src=\ref[O];blobjump=\ref[loc]'>(JUMP)</a></span>")
 
 		if(istype(ticker.mode, /datum/game_mode/blob))
 			var/datum/game_mode/blob/mode = ticker.mode

--- a/code/game/gamemodes/blob/blobs/factory.dm
+++ b/code/game/gamemodes/blob/blobs/factory.dm
@@ -51,7 +51,7 @@
 		for(var/mob/living/simple_animal/hostile/blobspore/S in spores)
 			S.Die()
 	if(!manual_remove && overmind)
-		to_chat(overmind,"<span class='warning'>A factory blob that you had created has been destroyed.</span>")
+		to_chat(overmind,"<span class='warning'>A factory blob that you had created has been destroyed.</span> <b><a href='?src=\ref[overmind];blobjump=\ref[loc]'>(JUMP)</a></b>")
 	..()
 
 /obj/effect/blob/factory/update_icon(var/spawnend = 0)

--- a/code/game/gamemodes/blob/blobs/node.dm
+++ b/code/game/gamemodes/blob/blobs/node.dm
@@ -27,7 +27,7 @@
 /obj/effect/blob/node/Destroy()
 	blob_nodes -= src
 	if(!manual_remove && overmind)
-		to_chat(overmind,"<span class='warning'>A node blob that you had created has been destroyed.</span>")
+		to_chat(overmind,"<span class='warning'>A node blob that you had created has been destroyed.</span> <b><a href='?src=\ref[overmind];blobjump=\ref[loc]'>(JUMP)</a></b>")
 	processing_objects.Remove(src)
 	..()
 

--- a/code/game/gamemodes/blob/blobs/resource.dm
+++ b/code/game/gamemodes/blob/blobs/resource.dm
@@ -23,7 +23,7 @@
 /obj/effect/blob/resource/Destroy()
 	blob_resources -= src
 	if(!manual_remove && overmind)
-		to_chat(overmind,"<span class='warning'>You lost a resource blob.</span>")
+		to_chat(overmind,"<span class='warning'>You lost a resource blob.</span> <b><a href='?src=\ref[overmind];blobjump=\ref[loc]'>(JUMP)</a></b>")
 	..()
 
 /obj/effect/blob/resource/update_health()

--- a/code/game/gamemodes/blob/overmind.dm
+++ b/code/game/gamemodes/blob/overmind.dm
@@ -21,9 +21,6 @@
 	var/blob_warning = 0
 
 /mob/camera/blob/New()
-	var/new_name = "[initial(name)] ([rand(1, 999)])"
-	name = new_name
-	real_name = new_name
 	blob_overminds += src
 	..()
 	spawn(10)
@@ -51,9 +48,48 @@
 	to_chat(src, "<b>Shortcuts:</b> CTRL Click = Expand Blob, Middle Mouse Click = Rally Spores, Alt Click = Create Shield, Double Click: Teleport to Blob")
 	update_health()
 
+/mob/camera/blob/Topic(href, href_list)
+	if(usr != src)
+		return
+	..()
+	if (href_list["blobjump"])//We only let blobs jump to where there are blobs.
+		var/turf/dest = locate(href_list["blobjump"])
+		if(dest)
+			var/turf/closest_turf = null
+			for(var/turf/T in spiral_block(dest,7))
+				var/obj/effect/blob/B = locate() in T
+				if(B)
+					closest_turf = T
+					break
+			if(closest_turf)
+				if(closest_turf != dest)
+					to_chat(src, "<span class='notice'>Jumping to closest blob from the target.</span>")
+				loc = closest_turf
+			else
+				to_chat(src, "<span class='warning'>Unable to make the jump. Looks like all the blobs in a large radius around the target have been destroyed.</span>")
+
+
 /mob/camera/blob/proc/update_health()
 	if(blob_core)
 		hud_used.blobhealthdisplay.maptext = "<div align='center' valign='middle' style='position:relative; top:0px; left:6px'> <font color='#e36600'>[blob_core.health]</font></div>"
+		var/severity = 0
+		switch(round(blob_core.health))
+			if(167 to 199)
+				severity = 1
+			if(134 to 166)
+				severity = 2
+			if(100 to 133)
+				severity = 3
+			if(67 to 99)
+				severity = 4
+			if(34 to 66)
+				severity = 5
+			if(-INFINITY to 33)
+				severity = 6
+		if(severity > 0)
+			overlay_fullscreen("damage", /obj/screen/fullscreen/brute, severity)
+		else
+			clear_fullscreen("damage")
 
 /mob/camera/blob/proc/add_points(var/points)
 	if(points != 0)

--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -221,6 +221,30 @@
 	B.Delete()
 	return
 
+/mob/camera/blob/verb/callblobs()
+	set category = "Blob"
+	set name = "Call Overminds"
+	set desc = "Prompts your fellow overminds to come at your location."
+
+	var/turf/T = get_turf(src)
+	if(!T)
+		return
+
+	to_chat(src,"<span class='notice'>You sent a call to the other overminds...</span>")
+
+	var/they_exist = 0
+	for(var/mob/camera/blob/O in blob_overminds)
+		if(O != src)
+			they_exist++
+			to_chat(O,"<span class='notice'>[src] is calling for your attention!</span> <b><a href='?src=\ref[O];blobjump=\ref[loc]'>(JUMP)</a></b>")
+
+	if(they_exist)
+		to_chat(src,"<span class='notice'>...[they_exist] overmind\s heard your call!</span>")
+	else
+		to_chat(src,"<span class='notice'>...but no one heard you!</span>")
+
+	return
+
 
 /mob/camera/blob/verb/expand_blob_power()
 	set category = "Blob"

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -120,7 +120,7 @@ var/list/blob_looks
 		for(var/obj/effect/blob/core/C in range(loc,4))
 			if((C != src) && C.overmind && (C.overmind.blob_warning <= world.time))
 				C.overmind.blob_warning = world.time + (10 SECONDS)
-				to_chat(C.overmind,"<span class='danger'>A blob died near your core!</span>")
+				to_chat(C.overmind,"<span class='danger'>A blob died near your core!</span> <b><a href='?src=\ref[C.overmind];blobjump=\ref[loc]'>(JUMP)</a></b>")
 
 	overmind = null
 	..()

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -7,7 +7,7 @@
 	desc = "It's a g-g-g-g-ghooooost!" //jinkies!
 	icon = 'icons/mob/mob.dmi'
 	icon_state = "ghost1"
-	layer = 4
+	layer = 8
 	stat = DEAD
 	density = 0
 	lockflags = 0 //Neither dense when locking or dense when locked to something

--- a/code/setup.dm
+++ b/code/setup.dm
@@ -663,22 +663,34 @@ var/list/liftable_structures = list(\
 
 #define SEE_INVISIBLE_MINIMUM 5
 
-#define SEE_INVISIBLE_OBSERVER_NOLIGHTING 15
+#define SEE_INVISIBLE_OBSERVER_NOLIGHTING 15	//Used by Ghosts when they click "Toggle Darkness".
 
-#define INVISIBILITY_LIGHTING 20
+#define INVISIBILITY_LIGHTING 20	//Used by the lighting_overlay. Any value bellow that one will let you see in the dark.
 
-#define SEE_INVISIBLE_LIVING 25
+#define SEE_INVISIBLE_LIVING 25		//This what players have by default.
 
-#define SEE_INVISIBLE_LEVEL_ONE 35	//Used by some stuff in code. It's really poorly organized.
-#define INVISIBILITY_LEVEL_ONE 35	//Used by some stuff in code. It's really poorly organized.
+#define SEE_INVISIBLE_LEVEL_ONE 35	//Used by mobs under certain conditions.
+#define INVISIBILITY_LEVEL_ONE 35	//Unused.
 
-#define SEE_INVISIBLE_LEVEL_TWO 45	//Used by some other stuff in code. It's really poorly organized.
-#define INVISIBILITY_LEVEL_TWO 45	//Used by some other stuff in code. It's really poorly organized.
+#define SEE_INVISIBLE_LEVEL_TWO 45	//Used by mobs under certain conditions.
+#define INVISIBILITY_LEVEL_TWO 45	//Used by turrets inside their covers.
 
-#define INVISIBILITY_OBSERVER 60
-#define SEE_INVISIBLE_OBSERVER 60
+#define INVISIBILITY_OBSERVER 60	//Used by Ghosts.
+#define SEE_INVISIBLE_OBSERVER 60	//Used by Ghosts.
 
 #define INVISIBILITY_MAXIMUM 100
+
+/*
+FOR IN-GAME TESTING PURPOSES (var/sight bitflags)
+
+BLIND		1
+SEE_MOBS	4
+SEE_OBJS	8
+SEE_TURFS	16
+SEE_SELF	32
+SEE_INFRA	64
+SEE_PIXELS	256
+*/
 
 // Object specific defines.
 #define CANDLE_LUM 2 //For how bright candles are.

--- a/html/changelogs/DeityLink_9924.yml
+++ b/html/changelogs/DeityLink_9924.yml
@@ -1,0 +1,9 @@
+author: Deity Link
+delete-after: true
+changes:
+  - tweak: Ghosts now appear above the blob layer.
+  - rscadd: Blob Overminds now get notified when a new overmind appears in a blob core.
+  - rscadd: Blob Overminds now have a "damage overlay" that updates as their core takes damage. Similar to the one humans have when they take damage (screen borders become dark/reddish).
+  - rscadd: Most of the Blob Overmind notifications added in the last update now have a (JUMP) button, so for example you can immediately find which of your blob nodes just got destroyed.
+  - rscadd: Blob Overminds have a new verb called "Call Overminds", which sends a notification to all the other overminds, along with a button allowing them to jump to you.
+  - rscadd: Blob Overminds that spawn in a blob core created by an Overmind are now called Blob Cerebrate. So they can easily tell which one of them was the original one (and the only one who can place new cores)


### PR DESCRIPTION
- Ghosts now appear above the blob layer.
- Blob Overminds now get notified when a new overmind appears in a blob core.
- Blob Overminds now have a "damage overlay" that updates as their core takes damage. Similar to the one humans have when they take damage (screen borders become dark/reddish).
- Most of the Blob Overmind notifications added in the last update now have a (JUMP) button, so for example you can immediately find which of your blob nodes just got destroyed.
- Blob Overminds have a new verb called "Call Overminds", which sends a notification to all the other overminds, along with a button allowing them to jump to you.
- Blob Overminds that spawn in a blob core created by an Overmind are now called Blob Cerebrate. So they can easily tell which one of them was the original one (and the only one who can place new cores)

![bleabl](https://cloud.githubusercontent.com/assets/7573912/15062376/b67e6152-133f-11e6-82cf-d4a7cb508759.png)
