### PR TITLE
Highlander Changes

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -394,9 +394,7 @@
 	spawn()
 		for(var/i = 0;i < 2;i++)
 			for(var/turf/T in drain_turflist)
-				var/obj/effect/tracker/drain/Tr = getFromPool(/obj/effect/tracker/drain, T)
-				Tr.target = user
-				Tr.icon_state = pick("soul1","soul2","soul3")
+				make_tracker_effects(T, user, 1, "soul", 3, /obj/effect/tracker/drain)
 				sleep(1)
 
 	if(user.bhunger)

--- a/code/game/gamemodes/wizard/soulstone.dm
+++ b/code/game/gamemodes/wizard/soulstone.dm
@@ -310,17 +310,9 @@
 	if(add_target && add_target.loc)
 		T2 = get_turf(add_target)
 
-	spawn()
-		for(var/i = 0;i < 10;i++)
-			var/obj/effect/tracker/soul/Tr = getFromPool(/obj/effect/tracker/soul, T1)
-			Tr.target = user
-			Tr.icon_state = pick("soul1","soul2","soul3")
-			if(T2)
-				var/obj/effect/tracker/soul/Tr2 = getFromPool(/obj/effect/tracker/soul, T2)
-				Tr2.target = user
-				Tr2.icon_state = pick("soul1","soul2","soul3")
-			sleep(1)
-
+	make_tracker_effects(T1, user)
+	if(T2)
+		make_tracker_effects(T2, user)
 
 	//Cleaning up the corpse
 	qdel(target)

--- a/code/game/objects/effects/trackers.dm
+++ b/code/game/objects/effects/trackers.dm
@@ -91,3 +91,16 @@
 
 /obj/effect/tracker/singularity_pull()
 	return
+
+/proc/make_tracker_effects(tr_source, tr_destination, var/tr_number = 10, var/custom_icon_state = "soul", var/number_of_icons = 3, var/tr_type = /obj/effect/tracker/soul)
+	spawn()
+		var/list/possible_icons = list()
+		if(custom_icon_state)
+			for(var/i = 1;i <= number_of_icons;i++)
+				possible_icons.Add("[custom_icon_state][i]")
+		for(var/i = 0;i < tr_number;i++)
+			var/obj/effect/tracker/Tr = getFromPool(tr_type, tr_source)
+			Tr.target = tr_destination
+			if(custom_icon_state)
+				Tr.icon_state = pick(possible_icons)
+			sleep(1)

--- a/code/game/objects/structures/vehicles/vehicle.dm
+++ b/code/game/objects/structures/vehicles/vehicle.dm
@@ -219,10 +219,10 @@
 		return 0
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
-		if(H.mind && H.mind.special_role == "highlander")
+		if(H.mind && H.mind.special_role == HIGHLANDER)
 			if(user == M)
 				to_chat(user, "<span class='warning'>A true highlander has no need for a mount!</span>")
-			return
+			return 0
 	return 1
 
 /obj/structure/bed/chair/vehicle/buckle_mob(mob/M, mob/user)

--- a/code/game/objects/structures/vehicles/vehicle.dm
+++ b/code/game/objects/structures/vehicles/vehicle.dm
@@ -64,11 +64,6 @@
 	if(empstun < 0)
 		empstun = 0
 
-/obj/structure/bed/chair/vehicle/buckle_mob(mob/M as mob, mob/user as mob)
-	if(isanimal(M)) return //Animals can't buckle
-
-	..()
-
 /obj/structure/bed/chair/vehicle/attackby(obj/item/W, mob/user)
 	if (istype(W, /obj/item/weapon/weldingtool))
 		var/obj/item/weapon/weldingtool/WT = W
@@ -222,6 +217,12 @@
 /obj/structure/bed/chair/vehicle/proc/can_buckle(mob/M, mob/user)
 	if(M != user || !ishuman(user) || !Adjacent(user) || user.restrained() || user.lying || user.stat || user.locked_to || destroyed || occupant)
 		return 0
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(H.mind && H.mind.special_role == "highlander")
+			if(user == M)
+				to_chat(user, "<span class='warning'>A true highlander has no need for a mount!</span>")
+			return
 	return 1
 
 /obj/structure/bed/chair/vehicle/buckle_mob(mob/M, mob/user)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -771,7 +771,7 @@ var/global/floorIsLava = 0
 			<A href='?src=\ref[src];secretsfun=prisonwarp'>Warp all Players to Prison</A><BR>
 			<A href='?src=\ref[src];secretsfun=tripleAI'>Triple AI mode (needs to be used in the lobby)</A><BR>
 			<A href='?src=\ref[src];secretsfun=traitor_all'>Everyone is the traitor</A><BR>
-			<A href='?src=\ref[src];secretsfun=onlyone'>There can only be one!</A><BR>
+			<A href='?src=\ref[src];secretsfun=onlyone'>There can be only one!</A><BR>
 			<A href='?src=\ref[src];secretsfun=flicklights'>Ghost Mode</A><BR>
 			<A href='?src=\ref[src];secretsfun=retardify'>Make all players retarded</A><BR>
 			<A href='?src=\ref[src];secretsfun=fakeguns'>Make all items look like guns</A><BR>

--- a/code/modules/admin/verbs/onlyone.dm
+++ b/code/modules/admin/verbs/onlyone.dm
@@ -4,7 +4,7 @@
 		return
 
 	for(var/mob/living/silicon/S in player_list) //All silicons get made into humans so they can be highlanders, too.
-		if(S.stat == 2 || !(S.client)) continue
+		if(S.isDead() || !S.client) continue
 		if(is_special_character(S)) continue
 
 		var/mob/living/carbon/human/new_human = new /mob/living/carbon/human(S.loc, delay_ready_dna=1)
@@ -21,7 +21,7 @@
 		qdel(S)
 
 	for(var/mob/living/carbon/human/H in player_list)
-		if(H.stat == 2 || !(H.client)) continue
+		if(H.isDead() || !H.client) continue
 		if(is_special_character(H)) continue
 
 		ticker.mode.traitors += H.mind

--- a/code/modules/admin/verbs/onlyone.dm
+++ b/code/modules/admin/verbs/onlyone.dm
@@ -25,7 +25,11 @@
 		if(is_special_character(H)) continue
 
 		ticker.mode.traitors += H.mind
-		H.mind.special_role = "highlander"
+		H.mind.special_role = HIGHLANDER
+
+		H.mutations.Add(M_HULK) //all highlanders are permahulks
+		H.update_mutations()
+		H.update_body()
 
 		/* This never worked.
 		var/datum/objective/steal/steal_objective = new

--- a/code/modules/admin/verbs/onlyone.dm
+++ b/code/modules/admin/verbs/onlyone.dm
@@ -3,12 +3,29 @@
 		alert("The game hasn't started yet!")
 		return
 
+	for(var/mob/living/silicon/S in player_list) //All silicons get made into humans so they can be highlanders, too.
+		if(S.stat == 2 || !(S.client)) continue
+		if(is_special_character(S)) continue
+
+		var/mob/living/carbon/human/new_human = new /mob/living/carbon/human(S.loc, delay_ready_dna=1)
+		new_human.setGender(pick(MALE, FEMALE)) //The new human's gender will be random
+		var/datum/preferences/A = new()	//Randomize appearance for the human
+		A.randomize_appearance_for(new_human)
+		new_human.generate_name()
+		new_human.languages |= S.languages
+		if(S.default_language) new_human.default_language = S.default_language
+		if(S.mind)
+			S.mind.transfer_to(new_human)
+		else
+			new_human.key = S.key
+		qdel(S)
+
 	for(var/mob/living/carbon/human/H in player_list)
 		if(H.stat == 2 || !(H.client)) continue
 		if(is_special_character(H)) continue
 
 		ticker.mode.traitors += H.mind
-		H.mind.special_role = "traitor"
+		H.mind.special_role = "highlander"
 
 		/* This never worked.
 		var/datum/objective/steal/steal_objective = new
@@ -21,7 +38,7 @@
 		hijack_objective.owner = H.mind
 		H.mind.objectives += hijack_objective
 
-		to_chat(H, "<B>You are the traitor.</B>")
+		to_chat(H, "<B>You are a highlander!</B>")
 		var/obj_count = 1
 		for(var/datum/objective/OBJ in H.mind.objectives)
 			to_chat(H, "<B>Objective #[obj_count]</B>: [OBJ.explanation_text]")

--- a/code/modules/admin/verbs/onlyone.dm
+++ b/code/modules/admin/verbs/onlyone.dm
@@ -51,11 +51,19 @@
 		for (var/obj/item/I in H)
 			if (istype(I, /obj/item/weapon/implant))
 				continue
-			del(I)
+			if(isplasmaman(H)) //Plasmamen don't lose their plasma gear since they need it to live.
+				if(!(istype(I, /obj/item/clothing/suit/space/plasmaman) || istype(I, /obj/item/clothing/head/helmet/space/plasmaman) || istype(I, /obj/item/weapon/tank/plasma/plasmaman) || istype(I, /obj/item/clothing/mask/breath)))
+					qdel(I)
+			else if(isvox(H)) //Vox don't lose their N2 gear since they need it to live.
+				if(!(istype(I, /obj/item/weapon/tank/nitrogen) || istype(I, /obj/item/clothing/mask/breath/vox)))
+					qdel(I)
+			else
+				qdel(I)
 
 		H.equip_to_slot_or_del(new /obj/item/clothing/under/kilt(H), slot_w_uniform)
 		H.equip_to_slot_or_del(new /obj/item/device/radio/headset/heads/captain(H), slot_ears)
-		H.equip_to_slot_or_del(new /obj/item/clothing/head/beret(H), slot_head)
+		if(!isplasmaman(H)) //Plasmamen don't get a beret since they need their helmet to not burn to death.
+			H.equip_to_slot_or_del(new /obj/item/clothing/head/beret(H), slot_head)
 		H.equip_to_slot_or_del(new /obj/item/weapon/claymore(H), slot_l_hand)
 		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/combat(H), slot_shoes)
 		H.equip_to_slot_or_del(new /obj/item/weapon/pinpointer(H.loc), slot_l_store)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -964,6 +964,8 @@
 
 
 /mob/living/carbon/human/IsAdvancedToolUser()
+	if(mind && mind.special_role == "highlander")
+		return 0 //Using a gun during highlander is poor form.
 	return 1//Humans can use guns and such
 
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -964,8 +964,6 @@
 
 
 /mob/living/carbon/human/IsAdvancedToolUser()
-	if(mind && mind.special_role == "highlander")
-		return 0 //Using a gun during highlander is poor form.
 	return 1//Humans can use guns and such
 
 

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -625,7 +625,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		src.status &= ~ORGAN_BLEEDING
 		src.status &= ~ORGAN_SPLINTED
 		src.status &= ~ORGAN_DEAD
-		
+
 		for(var/implant in implants)
 			qdel(implant)
 
@@ -1381,6 +1381,20 @@ obj/item/weapon/organ/head/New(loc, mob/living/carbon/human/H)
 
 	brainmob.stat = 2
 	brainmob.death()
+
+	if(brainmob.mind && brainmob.mind.special_role == "highlander")
+		if(H.lastattacker && istype(H.lastattacker, /mob/living/carbon/human))
+			var/mob/living/carbon/human/L = H.lastattacker
+			if(L.mind && L.mind.special_role == "highlander")
+				L.revive(0)
+				to_chat(L, "<span class='notice'>You absorb \the [brainmob]'s power!</span>")
+				var/turf/T1 = get_turf(H)
+				spawn()
+					for(var/i = 0;i < 10;i++)
+						var/obj/effect/tracker/soul/Tr = getFromPool(/obj/effect/tracker/soul, T1)
+						Tr.target = L
+						Tr.icon_state = pick("soul1","soul2","soul3")
+						sleep(1)
 
 obj/item/weapon/organ/head/proc/transfer_identity(var/mob/living/carbon/human/H)//Same deal as the regular brain proc. Used for human-->head
 	brainmob = new(src)

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -1382,19 +1382,14 @@ obj/item/weapon/organ/head/New(loc, mob/living/carbon/human/H)
 	brainmob.stat = 2
 	brainmob.death()
 
-	if(brainmob.mind && brainmob.mind.special_role == "highlander")
+	if(brainmob.mind && brainmob.mind.special_role == HIGHLANDER)
 		if(H.lastattacker && istype(H.lastattacker, /mob/living/carbon/human))
 			var/mob/living/carbon/human/L = H.lastattacker
-			if(L.mind && L.mind.special_role == "highlander")
+			if(L.mind && L.mind.special_role == HIGHLANDER)
 				L.revive(0)
 				to_chat(L, "<span class='notice'>You absorb \the [brainmob]'s power!</span>")
 				var/turf/T1 = get_turf(H)
-				spawn()
-					for(var/i = 0;i < 10;i++)
-						var/obj/effect/tracker/soul/Tr = getFromPool(/obj/effect/tracker/soul, T1)
-						Tr.target = L
-						Tr.icon_state = pick("soul1","soul2","soul3")
-						sleep(1)
+				make_tracker_effects(T1, L)
 
 obj/item/weapon/organ/head/proc/transfer_identity(var/mob/living/carbon/human/H)//Same deal as the regular brain proc. Used for human-->head
 	brainmob = new(src)

--- a/code/setup.dm
+++ b/code/setup.dm
@@ -1505,3 +1505,5 @@ var/proccalls = 1
 
 #define EVENT_OBJECT_INDEX "o"
 #define EVENT_PROC_INDEX "p"
+
+#define HIGHLANDER "highlander"

--- a/html/changelogs/Shadowmech88.yml
+++ b/html/changelogs/Shadowmech88.yml
@@ -2,6 +2,7 @@ author: Shadowmech88
 delete-after: True
 changes: 
 - rscadd: A highlander will be fully healed if he decapitates another highlander.
+- rscadd: Highlanders are now perma-hulked, making them immune to stuns.
 - tweak: Upon pressing the highlander button, all silicons will be made into humans so that they can also be highlanders.
-- rscdel: Highlanders can no longer use advanced tools like machinery or guns.
+- rscdel: Highlanders can no longer use guns as a result of their hulk power.
 - rscdel: Highlanders can no longer be buckled to vehicles.

--- a/html/changelogs/Shadowmech88.yml
+++ b/html/changelogs/Shadowmech88.yml
@@ -3,6 +3,7 @@ delete-after: True
 changes: 
 - rscadd: A highlander will be fully healed if he decapitates another highlander.
 - rscadd: Highlanders are now perma-hulked, making them immune to stuns.
+- tweak: Plasmamen and vox will now retain the gear that they require to survive when they're made into highlanders.
 - tweak: Upon pressing the highlander button, all silicons will be made into humans so that they can also be highlanders.
 - rscdel: Highlanders can no longer use guns as a result of their hulk power.
 - rscdel: Highlanders can no longer be buckled to vehicles.

--- a/html/changelogs/Shadowmech88.yml
+++ b/html/changelogs/Shadowmech88.yml
@@ -1,0 +1,7 @@
+author: Shadowmech88
+delete-after: True
+changes: 
+- rscadd: A highlander will be fully healed if he decapitates another highlander.
+- tweak: Upon pressing the highlander button, all silicons will be made into humans so that they can also be highlanders.
+- rscdel: Highlanders can no longer use advanced tools like machinery or guns.
+- rscdel: Highlanders can no longer be buckled to vehicles.


### PR DESCRIPTION
When someone is made into a highlander, their `mind.special_role` is set to "highlander" so you can now check whether someone is a highlander.
When a highlander decapitates another highlander, they will now receive a full heal, accompanied by the same particle effect that soulstones now use.
Highlanders are now permahulks, making them immune to stuns as well as incapable of using guns.
Highlanders can no longer be buckled to vehicles.
Upon use of the highlander button, all player-controlled silicons will be made into humans, so that they can then be made into highlanders. No more MoMMIs running around with claymores or engiborgs plasmaflooding while everyone else is fighting.
Plasmamen and vox no longer lose the gear that they need to survive when they're turned into highlanders.

Closes #9801.
