### PR TITLE
Adds debug verb for pooling

### DIFF
--- a/code/__HELPERS/datumpool.dm
+++ b/code/__HELPERS/datumpool.dm
@@ -132,7 +132,7 @@
 	return 0
 
 /client/proc/debug_pooling()
-	set name = "Debug Pooling Type1"
+	set name = "Debug Pooling Type"
 	set category = "Debug"
 
 	var/type = input("What is the typepath for the pooled object variables you wish to view?", "Pooled Variables") in pooledvariables|null
@@ -140,14 +140,10 @@
 	if(!type)
 		return
 
-	if(!pooledvariables[type])
-		to_chat(src, "The type [type] inexplicably doesn't have a generated list holding variables for pooled objects")
-		return
-
 	var/list/L = list()
 	L += "<b>Stored Variables for Pooling for this type</b><br>"
 	for(var/key in pooledvariables[type])
-		if(L)
+		if(pooledvariables[type][key])
 			L += "<br>[key] = [pooledvariables[type][key]]"
 		else
 			L += "<br>[key] = null"

--- a/code/__HELPERS/datumpool.dm
+++ b/code/__HELPERS/datumpool.dm
@@ -132,20 +132,23 @@
 	return 0
 
 /client/proc/debug_pooling()
-	set name = "Debug Pooling Type"
+	set name = "Debug Pooling Type1"
 	set category = "Debug"
 
-	var/type = input("What is the typepath for the pooled object variables you wish to view?", "Pooled Variables") as text|null
+	var/type = input("What is the typepath for the pooled object variables you wish to view?", "Pooled Variables") in pooledvariables|null
 
 	if(!type)
 		return
 
 	if(!pooledvariables[type])
-		to_chat(src, "The type [type] doesn't have a generated list holding variables for pooled objects")
+		to_chat(src, "The type [type] inexplicably doesn't have a generated list holding variables for pooled objects")
 		return
 
 	var/list/L = list()
 	L += "<b>Stored Variables for Pooling for this type</b><br>"
 	for(var/key in pooledvariables[type])
-		L += "<br>[key] = [pooledvariables[type][key]]"
+		if(L)
+			L += "<br>[key] = [pooledvariables[type][key]]"
+		else
+			L += "<br>[key] = null"
 	usr << browse(jointext(L,""),"window=poolingvariablelogs")

--- a/code/__HELPERS/datumpool.dm
+++ b/code/__HELPERS/datumpool.dm
@@ -130,3 +130,22 @@
 			return 1
 
 	return 0
+
+/client/proc/debug_pooling()
+	set name = "Debug Pooling Type"
+	set category = "Debug"
+
+	var/type = input("What is the typepath for the pooled object variables you wish to view?", "Pooled Variables") as text|null
+
+	if(!type)
+		return
+
+	if(!pooledvariables[type])
+		to_chat(src, "The type [type] doesn't have a generated list holding variables for pooled objects")
+		return
+
+	var/list/L = list()
+	L += "<b>Stored Variables for Pooling for this type</b><br>"
+	for(var/key in pooledvariables[type])
+		L += "<br>[key] = [pooledvariables[type][key]]"
+	usr << browse(jointext(L,""),"window=poolingvariablelogs")

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -151,6 +151,7 @@ var/list/admin_verbs_server = list(
 	)
 var/list/admin_verbs_debug = list(
 	/client/proc/gc_dump_hdl,
+	/client/proc/debug_pooling,
 	/client/proc/getSchedulerContext,
 	/client/proc/cmd_admin_list_open_jobs,
 	/proc/getbrokeninhands,
@@ -280,7 +281,8 @@ var/list/admin_verbs_hideable = list(
 	/client/proc/mob_list,
 	/proc/possess,
 	/proc/release,
-	/client/proc/gc_dump_hdl
+	/client/proc/gc_dump_hdl,
+	/client/proc/debug_pooling
 	)
 var/list/admin_verbs_mod = list(
 	/client/proc/cmd_admin_pm_context,	/*right-click adminPM interface*/


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.
-->


I think pooling is a thing that has very few bugs due to the way I've simplified it to the extreme and thus this debug verb in an ideal world shouldn't be needed.

But we don't live in an ideal world as you can clearly see
http://www.byond.com/forum/?post=2080853

This lets you view all the stored variables for a pooled variable type (assuming it has already been pooled at least once)