### PR TITLE
Removes obj/structure/table/flipped from tables_racks.dm and metaclub.dmm

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -521,10 +521,6 @@
 
 	return 1
 
-/obj/structure/table/flipped
-	icon_state = "tableflip0"
-	flipped = 1
-
 /*
  * Wooden tables
  */


### PR DESCRIPTION
What it says on the tin. 

Closes https://github.com/d3athrow/vgstation13/pull/9976
Fixes https://github.com/d3athrow/vgstation13/issues/9812
