### PR TITLE
Letting you move in space around blobs

### DIFF
--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -487,6 +487,8 @@
 		dense_object++
 	if(!dense_object && (locate(/obj/structure/catwalk) in oview(1, src)))
 		dense_object++
+	if(!dense_object && (locate(/obj/effect/blob) in oview(1, src)))
+		dense_object++
 
 	//Lastly attempt to locate any dense objects we could push off of
 	//TODO: If we implement objects drifing in space this needs to really push them

--- a/html/changelogs/DeityLink_9981.yml
+++ b/html/changelogs/DeityLink_9981.yml
@@ -1,0 +1,4 @@
+author: Deity Link
+delete-after: true
+changes:
+  - bugfix: You can now move in space if there is a blob adjacent to you.


### PR DESCRIPTION
Since blobs had to be made not dense, and that harmless blobs from blob clusters are now a relatively common thing, this should help people move around the blob as they remove it.
