### PR TITLE
Fixes the particle accelerator being balanced around broken code

### DIFF
--- a/code/modules/power/singularity/particle_accelerator/particle.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle.dm
@@ -8,7 +8,7 @@
 	anchored = 1
 	density = 1
 	var/movement_range = 10
-	var/energy = 10		//energy in eV
+	var/energy = 20		//energy in eV
 	var/mega_energy = 0	//energy in MeV
 	var/frequency = 1
 	var/ionizing = 0
@@ -29,29 +29,29 @@
 
 /obj/effect/accelerated_particle/weak
 	movement_range = 8
-	energy = 5
+	energy = 10
 	icon_state="particle0"
 	resetVariables()
 		..("energy", "movement_range")
 		movement_range = 8
-		energy = 5
+		energy = 10
 
 /obj/effect/accelerated_particle/strong
 	movement_range = 15
-	energy = 15
+	energy = 30
 	icon_state="particle2"
 	resetVariables()
 		..("energy", "movement_range")
-		energy = 15
+		energy = 30
 		movement_range = 15
 
 /obj/effect/accelerated_particle/powerful
 	movement_range = 20
-	energy = 50
+	energy = 100
 	icon_state="particle3"
 	resetVariables()
 		..("energy", "movement_range")
-		energy = 50
+		energy = 100
 		movement_range = 20
 
 /obj/effect/accelerated_particle/New(loc, dir = 2, move = 0)
@@ -99,7 +99,7 @@
 	return
 
 /obj/effect/accelerated_particle/proc/toxmob(var/mob/living/M)
-	var/radiation = (energy*2)
+	var/radiation = (energy)
 /*			if(istype(M,/mob/living/carbon/human))
 		if(M:wear_suit) //TODO: check for radiation protection
 			radiation = round(radiation/2,1)

--- a/code/modules/power/singularity/particle_accelerator/particle.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle.dm
@@ -1,6 +1,14 @@
 //This file was auto-corrected by findeclaration.exe on 25.5.2012 20:42:33
 
-#define PARTICLE_ENERGY 20 //Of the base particle type.
+#define PARTICLE_ENERGY 20
+#define WEAK_PARTICLE_ENERGY (PARTICLE_ENERGY / 2)
+#define STRONG_PARTICLE_ENERGY (PARTICLE_ENERGY * 1.5)
+#define POWERFUL_PARTICLE_ENERGY (PARTICLE_ENERGY * 5)
+
+#define PARTICLE_RANGE 10
+#define WEAK_PARTICLE_RANGE 8
+#define STRONG_PARTICLE_RANGE 15
+#define POWERFUL_PARTICLE_RANGE 20
 
 /obj/effect/accelerated_particle
 	name = "Accelerated Particles"
@@ -9,7 +17,7 @@
 	icon_state = "particle1"//Need a new icon for this
 	anchored = 1
 	density = 1
-	var/movement_range = 10
+	var/movement_range = PARTICLE_RANGE
 	var/energy = PARTICLE_ENERGY		//energy in eV
 	var/mega_energy = 0	//energy in MeV
 	var/frequency = 1
@@ -22,7 +30,7 @@
 
 /obj/effect/accelerated_particle/resetVariables()
 	..("movement_range", "target", "ionizing", "particle_type", "source", "movetotarget", args)
-	movement_range = 10
+	movement_range = PARTICLE_RANGE
 	target = null
 	ionizing = 0
 	particle_type = null
@@ -31,37 +39,37 @@
 
 
 /obj/effect/accelerated_particle/weak
-	movement_range = 8
-	energy = PARTICLE_ENERGY / 2
+	movement_range = WEAK_PARTICLE_RANGE
+	energy = WEAK_PARTICLE_ENERGY
 	icon_state="particle0"
 
 /obj/effect/accelerated_particle/weak/resetVariables()
 	..("energy", "movement_range")
-	movement_range = 8
-	energy = PARTICLE_ENERGY / 2
+	movement_range = WEAK_PARTICLE_RANGE
+	energy = WEAK_PARTICLE_ENERGY
 
 
 /obj/effect/accelerated_particle/strong
-	movement_range = 15
-	energy = PARTICLE_ENERGY * 1.5
+	movement_range = STRONG_PARTICLE_RANGE
+	energy = STRONG_PARTICLE_ENERGY
 	icon_state="particle2"
 
 /obj/effect/accelerated_particle/strong/resetVariables()
 	..("energy", "movement_range")
-	energy = PARTICLE_ENERGY * 1.5
-	movement_range = 15
+	energy = STRONG_PARTICLE_ENERGY
+	movement_range = STRONG_PARTICLE_RANGE
 
 
 /obj/effect/accelerated_particle/powerful
-	movement_range = 20
-	energy = PARTICLE_ENERGY * 5
+	movement_range = POWERFUL_PARTICLE_RANGE
+	energy = POWERFUL_PARTICLE_ENERGY
 	icon_state="particle3"
 	
 /obj/effect/accelerated_particle/powerful/resetVariables()
 	..("energy", "movement_range")
-	energy = PARTICLE_ENERGY * 5
-	movement_range = 20
-	
+	energy = POWERFUL_PARTICLE_ENERGY
+	movement_range = POWERFUL_PARTICLE_RANGE
+
 
 /obj/effect/accelerated_particle/New(loc, dir = 2, move = 0)
 	. = ..()
@@ -145,3 +153,10 @@
 		move(lag)
 
 #undef PARTICLE_ENERGY
+#undef WEAK_PARTICLE_ENERGY
+#undef STRONG_PARTICLE_ENERGY
+#undef POWERFUL_PARTICLE_ENERGY
+#undef PARTICLE_RANGE
+#undef WEAK_PARTICLE_RANGE
+#undef STRONG_PARTICLE_RANGE
+#undef POWERFUL_PARTICLE_RANGE

--- a/code/modules/power/singularity/particle_accelerator/particle.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle.dm
@@ -1,5 +1,7 @@
 //This file was auto-corrected by findeclaration.exe on 25.5.2012 20:42:33
 
+#define PARTICLE_ENERGY 20 //Of the base particle type.
+
 /obj/effect/accelerated_particle
 	name = "Accelerated Particles"
 	desc = "Small things moving very fast."
@@ -8,7 +10,7 @@
 	anchored = 1
 	density = 1
 	var/movement_range = 10
-	var/energy = 20		//energy in eV
+	var/energy = PARTICLE_ENERGY		//energy in eV
 	var/mega_energy = 0	//energy in MeV
 	var/frequency = 1
 	var/ionizing = 0
@@ -27,32 +29,39 @@
 	source = null
 	movetotarget = 1
 
+
 /obj/effect/accelerated_particle/weak
 	movement_range = 8
-	energy = 10
+	energy = PARTICLE_ENERGY / 2
 	icon_state="particle0"
-	resetVariables()
-		..("energy", "movement_range")
-		movement_range = 8
-		energy = 10
+
+/obj/effect/accelerated_particle/weak/resetVariables()
+	..("energy", "movement_range")
+	movement_range = 8
+	energy = PARTICLE_ENERGY / 2
+
 
 /obj/effect/accelerated_particle/strong
 	movement_range = 15
-	energy = 30
+	energy = PARTICLE_ENERGY * 1.5
 	icon_state="particle2"
-	resetVariables()
-		..("energy", "movement_range")
-		energy = 30
-		movement_range = 15
+
+/obj/effect/accelerated_particle/strong/resetVariables()
+	..("energy", "movement_range")
+	energy = PARTICLE_ENERGY * 1.5
+	movement_range = 15
+
 
 /obj/effect/accelerated_particle/powerful
 	movement_range = 20
-	energy = 100
+	energy = PARTICLE_ENERGY * 5
 	icon_state="particle3"
-	resetVariables()
-		..("energy", "movement_range")
-		energy = 100
-		movement_range = 20
+	
+/obj/effect/accelerated_particle/powerful/resetVariables()
+	..("energy", "movement_range")
+	energy = PARTICLE_ENERGY * 5
+	movement_range = 20
+	
 
 /obj/effect/accelerated_particle/New(loc, dir = 2, move = 0)
 	. = ..()
@@ -134,3 +143,5 @@
 	else
 		sleep(lag)
 		move(lag)
+
+#undef PARTICLE_ENERGY


### PR DESCRIPTION
All forms of accelerated particle now contain exactly twice as much energy as before and mobs hit by them are now irradiated for as much energy as they have rather than double that

This should have no effect on mobs being hit by the PA and should return the PA-singularity interaction to how it used to work.
Probably also returns the R-UST to nearly how it worked before, but not quite. Not sure if the duplicate `Bump()` removal broke the R-UST or not because of the `loc = null` thing in there. If not, it's an easy fix.

Fixes #9987
