### PR TITLE
Tweaks and fixes to flashbangs

### DIFF
--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -65,6 +65,9 @@
 /mob/living/carbon/alien/eyecheck()
 	return 2
 
+/mob/living/carbon/alien/earprot()
+	return 1
+
 // MULEBOT SMASH
 /mob/living/carbon/alien/Crossed(var/atom/movable/AM)
 	var/obj/machinery/bot/mulebot/MB = AM

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -254,10 +254,6 @@
 
 			share_contact_diseases(M)
 
-
-/mob/living/carbon/proc/eyecheck()
-	return 0
-
 // ++++ROCKDTBEN++++ MOB PROCS -- Ask me before touching.
 // Stop! ... Hammertime! ~Carn
 

--- a/code/modules/mob/living/carbon/human/life/life_helpers.dm
+++ b/code/modules/mob/living/carbon/human/life/life_helpers.dm
@@ -174,11 +174,8 @@
 	//var/randorgan = pick("head","chest","groin")
 	return randorgan
 
-/mob/living/carbon/human/proc/earprot()
-	var/detect = 0
-	if(is_on_ears(/obj/item/clothing/ears/earmuffs)||is_on_ears(/obj/item/device/radio/headset/headset_earmuffs))
-		detect = 1
-	return detect
+/mob/living/carbon/human/earprot()
+	return is_on_ears(/obj/item/clothing/ears/earmuffs) || is_on_ears(/obj/item/device/radio/headset/headset_earmuffs)
 
 /mob/living/carbon/human/proc/has_reagent_in_blood(var/reagent_name,var/amount = -1)
 	if(!reagents || !ticker)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -132,14 +132,28 @@
 			throwByName = M.name
 			M.attack_log += text("\[[time_stamp()]\] <font color='red'>Hit [src.name] ([src.ckey]) with a thrown [O] (speed: [speed])</font>")
 		src.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been hit with a thrown [O], last touched by [throwByName] ([assailant.ckey]) (speed: [speed])</font>")
-		
+
 		if(!src.isDead() && src.ckey) //Message admins if the hit mob is alive and has a ckey
 			msg_admin_attack("[src.name] ([src.ckey]) was hit by a thrown [O], last touched by [throwByName] ([assailant.ckey]) (speed: [speed]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[src.x];Y=[src.y];Z=[src.z]'>JMP</a>)")
-		
+
 		if(!iscarbon(M))
 			src.LAssailant = null
 		else
 			src.LAssailant = M
+
+/*
+	Ear and eye protection
+
+	Some mobs have built-in ear or eye protection, mobs that can wear equipment may account their eye/ear wear into this proc
+*/
+
+//earprot(): retuns 0 for no protection, 1 for full protection (no ears, earmuffs, etc)
+/mob/living/proc/earprot()
+	return 0
+
+//eyecheck(): retuns 0 for no protection, 1 for partial protection, 2 for full protection
+/mob/living/proc/eyecheck()
+	return 0
 
 
 //BITES

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -320,3 +320,6 @@
 /mob/living/silicon/flash_eyes(intensity = 1, override_blindness_check = 0, affect_silicon = 0, visual = 0, type = /obj/screen/fullscreen/flash/noise)
 	if(affect_silicon)
 		return ..()
+
+/mob/living/silicon/earprot()
+	return 1

--- a/html/changelogs/9600bauds_bang.yml
+++ b/html/changelogs/9600bauds_bang.yml
@@ -1,0 +1,38 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general deleting of nice things)
+#   rscadd (general adding of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.
+author: 9600bauds
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# There needs to be a space after the - and before the prefix. Don't use tabs anywhere in this file.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# If you're using characters such as # ' : - or the like in your changelog, surround the entire change with quotes as shown in the second example. These quotes don't show up on the changelog once it's merged and prevent errors.
+# SCREW ANY OF THIS UP AND IT WON'T WORK.
+changes: 
+- bugfix: Fixed flashbangs not affecting mobs without a player controlling them.
+- bugfix: Fixed flashbang sound dropoff not working, always giving maximum stun time to players with no ear protection.
+- tweak: "As per server poll, flashbangs will now affect cyborgs and simple animals. See the poll here: ss13.moe/index.php/poll/38"


### PR DESCRIPTION
Fixes bug that made flashbangs not have sound dropoff (fixes #4585). Effectively this means that flashbangs will no longer stun people that have ear+flash protection, unless they're within 2 tiles. Also, if you have flash protection and run away from a flashbang you'll get a shorter stun time.

Fixes #9739

Resolves #8583 as per server vote: http://ss13.moe/index.php/poll/38
Flashbangs now stun borgs and simple animals.
