### PR TITLE
Light re-balancing to telepathy

### DIFF
--- a/code/game/dna/genes/powers.dm
+++ b/code/game/dna/genes/powers.dm
@@ -139,7 +139,7 @@
 			target.show_message("<span class='notice'>You hear [user.real_name]'s voice: [say]</span>")
 		else
 			target.show_message("<span class='notice'>You hear a voice that seems to echo around the room: [say]</span>")
-		user.show_message("<span class='notice'>You project your mind into [target.real_name]: [say]</span>")
+		user.show_message("<span class='notice'>You project your mind into [target.name]: [say]</span>")//A really shitty fix but targeted.dm is a bit too dense
 		for(var/mob/dead/observer/G in dead_mob_list)
 			G.show_message("<i>Telepathic message from <b>[user]</b> to <b>[target]</b>: [say]</i>")
 

--- a/code/game/dna/genes/powers.dm
+++ b/code/game/dna/genes/powers.dm
@@ -142,6 +142,7 @@
 		user.show_message("<span class='notice'>You project your mind into [target.name]: [say]</span>")//A really shitty fix but targeted.dm is a bit too dense
 		for(var/mob/dead/observer/G in dead_mob_list)
 			G.show_message("<i>Telepathic message from <b>[user]</b> to <b>[target]</b>: [say]</i>")
+		log_game("Telepathic message from [user] to [target]: [say]") //Logs what was said to game logs.
 
 /datum/dna/gene/basic/morph
 	name="Morph"

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -233,6 +233,11 @@
 	var/radio_freq = SYND_FREQ
 	var/tank_slot = slot_r_hand
 
+	synd_mob.mutations.Add(M_PSY_RESIST) //Boy I sure hope this works!
+	synd_mob.update_mutantrace(0)
+	synd_mob.update_mutations(0)
+//  synd_mob.default_block_names=list("PSYRESISTBLOCK") //Prevent project mind from detecting them too early
+
 	if(synd_mob.overeatduration) //We need to do this here and now, otherwise a lot of gear will fail to spawn
 		to_chat(synd_mob, "<span class='notice'>Your intensive physical training to become a Nuclear Operative has paid off and made you fit again!</span>")
 		synd_mob.overeatduration = 0 //Fat-B-Gone
@@ -286,8 +291,6 @@
 	var/obj/item/weapon/implant/explosive/E = new/obj/item/weapon/implant/explosive(synd_mob)
 	E.imp_in = synd_mob
 	E.implanted = 1
-	synd_mob.mutuations.Add(M_PSY_RESIST)       //Boy I sure hope this works!
-	//synd_mob.default_block_names=list("PSYRESISTBLOCK") //Prevent project mind from detecting them too early
 	synd_mob.update_icons()
 	return 1
 

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -286,6 +286,8 @@
 	var/obj/item/weapon/implant/explosive/E = new/obj/item/weapon/implant/explosive(synd_mob)
 	E.imp_in = synd_mob
 	E.implanted = 1
+	synd_mob.mutuations.Add(M_PSY_RESIST)       //Boy I sure hope this works!
+	//synd_mob.default_block_names=list("PSYRESISTBLOCK") //Prevent project mind from detecting them too early
 	synd_mob.update_icons()
 	return 1
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1140,6 +1140,7 @@
 	check_dna()
 
 	visible_message("<span class='notice'>\The [src] morphs and changes [get_visible_gender() == MALE ? "his" : get_visible_gender() == FEMALE ? "her" : "their"] appearance!</span>", "<span class='notice'>You change your appearance!</span>", "<span class='warning'>Oh, god!  What the hell was that?  It sounded like flesh getting squished and bone ground into a different shape!</span>")
+
 /mob/living/carbon/human/proc/can_mind_interact(var/mob/M)
 //	to_chat(world, "Starting can interact on [M]")
 	if(!ishuman(M)) return 0 //Can't see non humans with your fancy human mind.
@@ -1152,13 +1153,13 @@
 	if((temp_turf.z != our_turf.z) || M.stat!=CONSCIOUS) //Not on the same zlevel as us or they're dead.
 //		to_chat(world, "[(temp_turf.z != our_turf.z) ? "not on the same zlevel as [M]" : "[M] is not concious"]")
 		if(temp_turf.z != 2)
-			to_chat(src, "The mind of [M] is too faint...")//Prevent "The mind of Admin is too faint..."
-
-
+			if(prob(5))//Can't tell who is missing as easily as before. I feel like this is a fun alternative to removing it altogether
+				to_chat(src, "The mind of [M] is too faint...")//Prevent "The mind of Admin is too faint..."
 		return 0
 	if(M_PSY_RESIST in M.mutations)
 //		to_chat(world, "[M] has psy resist")
-		to_chat(src, "The mind of [M] is resisting!")
+		if(prob(2))
+			to_chat(src, pick("Hmmmn...","Something is out there is resisting.", "Your mind says, 'Hi!'.", "You feel less smart.", "The mind of [M] is resisting!", "<span class='warning'>[src] screams really loudly in your ear!</span>")) //Reduced in probability because they're supposed to be hiding themselves.
 		return 0
 	var/mob/living/carbon/human/H = M
 	if(H.head && istype(H.head,/obj/item/clothing/head/tinfoil))

--- a/html/changelogs/191.yml
+++ b/html/changelogs/191.yml
@@ -1,0 +1,38 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general deleting of nice things)
+#   rscadd (general adding of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.
+author: Angelite Entyshak
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# There needs to be a space after the - and before the prefix. Don't use tabs anywhere in this file.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# If you're using characters such as # ' : - or the like in your changelog, surround the entire change with quotes as shown in the second example. These quotes don't show up on the changelog once it's merged and prevent errors.
+# SCREW ANY OF THIS UP AND IT WON'T WORK.
+changes: 
+- tweak: Project mind no longer tells the mob's real name on projection
+- tweak: Nuclear Operatives now start with psy resist to prevent mind projection
+- tweak: When using mind targeting spells, a full list of mobs that are resisting, off z-level, or unconscious is no longer a guarantee 

--- a/html/changelogs/191.yml
+++ b/html/changelogs/191.yml
@@ -35,4 +35,5 @@ delete-after: True
 changes: 
 - tweak: Project mind no longer tells the mob's real name on projection
 - tweak: Nuclear Operatives now start with psy resist to prevent mind projection
-- tweak: When using mind targeting spells, a full list of mobs that are resisting, off z-level, or unconscious is no longer a guarantee 
+- tweak: When using mind targeting spells, a full list of mobs that are resisting, off z-level, or unconscious is no longer a guarantee
+- rscadd: Adds logging for telepathic speech 


### PR DESCRIPTION
- Telepathy no longer gives a full list of missing, incapacitated, or resistant mobs; It's a small chance to pick up distant or dying mobs
- Nuclear Operatives start with psy-resist
- Telepathically speaking to someone no longer reveals their real name
-  Added game logging to telepathic messages

fixes #10005  .

As with all of my PRs, please take the time to look at it and call me a dummy for every error I've made.
