### PR TITLE
Drops diamond cost of posi brains.  Doubles gold, silver, and plasma cost.  

### DIFF
--- a/code/modules/research/designs/robotics.dm
+++ b/code/modules/research/designs/robotics.dm
@@ -6,7 +6,7 @@
 	id = "posibrain"
 	req_tech = list("engineering" = 4, "materials" = 6, "bluespace" = 2, "programming" = 4)
 	build_type = PROTOLATHE
-	materials = list(MAT_IRON = 2000, MAT_GLASS = 1000, MAT_SILVER = 1000, MAT_GOLD = 500, MAT_PLASMA = 500, MAT_DIAMOND = 100)
+	materials = list(MAT_IRON = 2000, MAT_GLASS = 1000, MAT_SILVER = 1000, MAT_GOLD = 1000, MAT_PLASMA = 1000)
 	category = "Robotics"
 	build_path = /obj/item/device/mmi/posibrain
 


### PR DESCRIPTION
Positronic brains are _very rarely made_ , rarer than their item value justifies.  This change still below 1 sheet per posibrain of each material but the diamond req is gone.

Custom vote started by Probe1.
Are posibrains too expensive to make?

Vote Result: They should be cheaper with 7 votes
    They should be more expensive had 1 vote
    Their price is ok had 1 vote
