### PR TITLE
Fixes two tiny runtimes

### DIFF
--- a/code/modules/hydroponics/grown_inedible.dm
+++ b/code/modules/hydroponics/grown_inedible.dm
@@ -162,7 +162,7 @@
 		to_chat(user, "<span class='warning'>The nettle burns your bare hand!</span>")
 
 /obj/item/weapon/grown/nettle/afterattack(atom/A as mob|obj, mob/user as mob, proximity)
-	if(!proximity) return
+	if(!proximity || destroyed) return
 	user.delayNextAttack(8)
 	if(force > 0)
 		force -= rand(1,(force/3)+1) // When you whack someone with it, leaves fall off

--- a/code/modules/media/broadcast/receiver.dm
+++ b/code/modules/media/broadcast/receiver.dm
@@ -30,10 +30,11 @@ var/global/media_receivers=list()
 
 	// Check if there's a broadcast to tune into.
 	if(freq in media_transmitters)
-		// Pick a random broadcast in that frequency.
-		var/obj/machinery/media/transmitter/B = pick(media_transmitters[freq])
-		if(B.media_crypto == media_crypto) // Crypto-key check, if needed.
-			receive_broadcast(B.media_url,B.media_start_time)
+		// Pick a random broadcast in that frequency, if there is one.
+		if(media_transmitters.len)
+			var/obj/machinery/media/transmitter/B = pick(media_transmitters[freq])
+			if(B.media_crypto == media_crypto) // Crypto-key check, if needed.
+				receive_broadcast(B.media_url,B.media_start_time)
 
 /obj/machinery/media/receiver/proc/disconnect_frequency()
 	var/list/receivers=list()


### PR DESCRIPTION
Fixed runtimes on:
- receiver connect_frequency proc
- Nettle playsound assert fail when attacking a seed extractor
