### PR TITLE
Aliens can now alt-click on mobs to spit neurotoxin at them.

### DIFF
--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -18,6 +18,7 @@
 
 	var/storedPlasma = 250
 	var/max_plasma = 500
+	var/neurotoxin_cooldown = 0
 
 	var/obj/item/weapon/card/id/wear_id = null // Fix for station bounced radios -- Skie
 	var/has_fine_manipulation = 0

--- a/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
@@ -116,7 +116,9 @@ Doesn't work on other aliens/AI.*/
 	set name = "Spit Neurotoxin (50)"
 	set desc = "Spits neurotoxin at someone, paralyzing them for a short time if they are not wearing protective gear."
 	set category = "Alien"
-
+	if(neurotoxin_cooldown)
+		to_chat(src, "<span class='alien'>You aren't ready to spit more neurotoxin yet.")
+		return
 	if(powerc(50))
 		if(isalien(target))
 			to_chat(src, "<span class='alien'>Your allies are not valid targets.</span>")
@@ -150,6 +152,10 @@ Doesn't work on other aliens/AI.*/
 		spawn()
 			A.OnFired()
 			A.process()
+		neurotoxin_cooldown = 1
+		spawn(50)
+			neurotoxin_cooldown = 0
+
 	return
 
 /mob/living/carbon/alien/humanoid/proc/resin() // -- TLE
@@ -182,3 +188,16 @@ Doesn't work on other aliens/AI.*/
 		drop_stomach_contents()
 		src.visible_message("<span class='alien'>\The [src] hurls out the contents of their stomach!</span>")
 	return
+
+
+/mob/living/carbon/alien/humanoid/AltClickOn(var/atom/A)
+	if(ismob(A))
+		neurotoxin(A)
+		return
+	. = ..()
+
+/mob/living/carbon/alien/humanoid/CtrlClickOn(var/atom/A)
+	if(isalien(A))
+		transfer_plasma(A)
+		return
+	. = ..()

--- a/html/changelogs/Sood.yml
+++ b/html/changelogs/Sood.yml
@@ -1,2 +1,5 @@
 author: Sood
-changes: []
+changes:
+  - rscadd: Aliens can now alt-click on mobs to spit neurotoxin at them.
+  - rscadd: Aliens can now ctrl-click on other aliens to transfer plasma to them.
+  - tweak: Spit neurotoxin now has a cooldown. Yes, it didn't before. That's how clunky that menu was.


### PR DESCRIPTION
Aliens can now alt-click on mobs to spit neurotoxin at them.
Aliens can now ctrl-click on other aliens to transfer plasma to them.
Spit neurotoxin now has a cooldown. Yes, it didn't before. That's how clunky that menu was.
Resolves #8164, #5074
