### PR TITLE
Fixes chute nullspacing

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -503,6 +503,14 @@
 	target.forceMove(src)
 	update_icon()
 
+/obj/machinery/disposal/cultify()
+	eject()
+	..()
+
+/obj/machinery/disposal/blob_act(destroy = 0)
+	eject()
+	..()
+
 // virtual disposal object
 // travels through pipes in lieu of actual items
 // contents will be items flushed by the disposal

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -73,7 +73,6 @@
 				if(severity==2)
 					qdel(src)
 		if(1)
-			eject()
 			qdel(src)
 
 
@@ -503,11 +502,7 @@
 	target.forceMove(src)
 	update_icon()
 
-/obj/machinery/disposal/cultify()
-	eject()
-	..()
-
-/obj/machinery/disposal/blob_act(destroy = 0)
+/obj/machinery/disposal/Destroy()
 	eject()
 	..()
 


### PR DESCRIPTION
Fixes chutes nullspacing their contents when cultified or eaten by a blob.

Fixes #7751
Fixes #10092
