### PR TITLE
Combat mechs now start with a tracking beacon too

### DIFF
--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -21,6 +21,7 @@
 	internal_damage_threshold = 25
 	force = 45
 	max_equip = 4
+	starts_with_tracking_beacon = FALSE
 
 /obj/mecha/combat/marauder/seraph
 	desc = "Heavy-duty, command-type exosuit. This is a custom model, utilized only by high-ranking military personnel."

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -53,6 +53,7 @@
 	var/obj/item/device/radio/radio = null
 	var/obj/item/device/radio/electropack/electropack = null
 	var/obj/item/mecha_parts/mecha_tracking/tracking = null
+	var/starts_with_tracking_beacon = TRUE
 
 	var/max_temperature = 25000
 	var/internal_damage_threshold = 50 //health percentage below which internal damage is possible
@@ -95,6 +96,8 @@
 	spark_system.set_up(2, 0, src)
 	spark_system.attach(src)
 	add_cell()
+	if(starts_with_tracking_beacon)
+		add_tracking_beacon()
 	add_iterators()
 	removeVerb(/obj/mecha/verb/disconnect_from_port)
 	log_message("[src.name] created.")
@@ -145,6 +148,10 @@
 	radio.icon = icon
 	radio.icon_state = icon_state
 	radio.subspace_transmission = 1
+
+/obj/mecha/proc/add_tracking_beacon()
+	tracking = new(src)
+	return tracking
 
 /obj/mecha/proc/add_iterators()
 	pr_int_temp_processor = new /datum/global_iterator/mecha_preserve_temp(list(src))

--- a/code/game/mecha/medical/medical.dm
+++ b/code/game/mecha/medical/medical.dm
@@ -1,9 +1,3 @@
-/obj/mecha/medical/New()
-	..()
-	tracking = new /obj/item/mecha_parts/mecha_tracking(src)
-	return
-
-
 /obj/mecha/medical/mechturn(direction)
 	dir = direction
 	playsound(src,'sound/mecha/mechmove01.ogg',40,1)

--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -46,6 +46,7 @@
 /obj/mecha/working/ripley/mining
 	desc = "An old, dusty mining ripley."
 	name = "APLU \"Miner\""
+	starts_with_tracking_beacon = FALSE //So it can't be easily found
 
 /obj/mecha/working/ripley/mining/New()
 	..()
@@ -61,12 +62,6 @@
 	var/obj/item/mecha_parts/mecha_equipment/tool/hydraulic_clamp/HC = new /obj/item/mecha_parts/mecha_equipment/tool/hydraulic_clamp
 	HC.attach(src)
 	src.hydraulic_clamp = HC
-
-	//Deletes the beacon so it can't be found easily
-	for(var/obj/item/mecha_parts/mecha_tracking/B in src.contents)
-		qdel (B)
-		B = null
-		src.tracking = null
 
 /obj/mecha/working/ripley/Exit(atom/movable/O)
 	if(O in cargo)

--- a/code/game/mecha/working/working.dm
+++ b/code/game/mecha/working/working.dm
@@ -1,11 +1,6 @@
 /obj/mecha/working
 	internal_damage_threshold = 60
 
-/obj/mecha/working/New()
-	..()
-	tracking = new /obj/item/mecha_parts/mecha_tracking(src)
-	return
-
 /*
 /obj/mecha/working/melee_action(atom/target as obj|mob|turf)
 	if(internal_damage&MECHA_INT_CONTROL_LOST)

--- a/html/changelogs/9600bauds_tre.yml
+++ b/html/changelogs/9600bauds_tre.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general deleting of nice things)
+#   rscadd (general adding of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.
+author: 9600bauds
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# There needs to be a space after the - and before the prefix. Don't use tabs anywhere in this file.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# If you're using characters such as # ' : - or the like in your changelog, surround the entire change with quotes as shown in the second example. These quotes don't show up on the changelog once it's merged and prevent errors.
+# SCREW ANY OF THIS UP AND IT WON'T WORK.
+changes: 
+- bugfix: "Combat mechs now start with a tracking beacon, like medical and mining mechs. As always, the beacon can be removed the same way you remove the power cell."


### PR DESCRIPTION
Adminbus/Deffsquid mechs do NOT start with one.
I've never ever seen tracking beacons actually used because the things you WANT to track don't start with one, and nobody even knows they exist
Hopefully this will remedy the situation

+- bugfix: "Combat mechs now start with a tracking beacon, like medical and mining mechs. As always, the beacon can be removed the same way you remove the power cell."

juan hunderd persent tested
