### PR TITLE
Fixes 2 spell channeling bugs

### DIFF
--- a/code/_hooks/events.dm
+++ b/code/_hooks/events.dm
@@ -6,7 +6,9 @@
  */
 
 // Buggy bullshit requires shitty workarounds
-#define INVOKE_EVENT(event,args) if(istype(event)) event.Invoke(args)
+/proc/INVOKE_EVENT(event/event,args)
+	if(istype(event))
+		. = event.Invoke(args)
 
 /**
  * Event dispatcher
@@ -42,4 +44,5 @@
 			handlers.Remove(handler)
 			continue
 		args["event"] = src
-		call(objRef,procName)(args, holder)
+		if(call(objRef,procName)(args, holder)) //An intercept value so whatever code section knows we mean business
+			. = 1

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -83,7 +83,7 @@
 
 	var/obj/item/W = get_active_hand()
 	var/item_attack_delay = 0
-	
+
 	if(W == A)
 		/*next_move = world.time + 6
 		if(W.flags&USEDELAY)
@@ -115,7 +115,8 @@
 		else
 			if(ismob(A) || istype(W, /obj/item/weapon/grab))
 				delayNextAttack(10)
-			INVOKE_EVENT(on_uattack,list("atom"=A))
+			if(INVOKE_EVENT(on_uattack,list("atom"=A))) //This returns 1 when doing an action intercept
+				return
 			UnarmedAttack(A, 1, params)
 		return
 	else // non-adjacent click
@@ -127,8 +128,9 @@
 		else
 			if(ismob(A))
 				delayNextAttack(10)
+			if(INVOKE_EVENT(on_uattack,list("atom"=A))) //This returns 1 when doing an action intercept
+				return
 			RangedAttack(A, params)
-			INVOKE_EVENT(on_uattack,list("atom"=A))
 	return
 
 // Default behavior: ignore double clicks, consider them normal clicks instead

--- a/code/modules/spells/spell_code.dm
+++ b/code/modules/spells/spell_code.dm
@@ -135,6 +135,7 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 	if(!user.spell_channeling && !force_remove)
 		if(!cast_check(skipcharge, user))
 			return 0
+		user.remove_spell_channeling() //In case we're swapping from an older spell to this new one
 		user.spell_channeling = user.on_uattack.Add(src, "channeled_spell")
 		connected_button.name = "(Ready) [name]"
 		currently_channeled = 1
@@ -153,13 +154,13 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 	var/event/E = args["event"]
 	if(!currently_channeled)
 		E.handlers.Remove("\ref[src]:channeled_spell")
-		return
+		return 0
 
 	var/atom/A = args["atom"]
 
 	if(E.holder != holder)
 		E.handlers.Remove("\ref[src]:channeled_spell")
-		return
+		return 0
 	var/list/target = list(A)
 	var/mob/user = holder
 	user.attack_delayer.delayNext(0)
@@ -173,6 +174,8 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 		if(!.) //Returning 1 will prevent us from removing the channeling and taking charge
 			channel_spell(force_remove = 1)
 			take_charge(holder, 0)
+		return 1
+	return 0
 
 /spell/proc/cast(list/targets, mob/user) //the actual meat of the spell
 	return


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.
-->


If you had multiple spells that could be channeled you could freak the system out by some convoluted combination of using each one.

While it was previously thought to be sane, not intercepting attacks after spells were cast were causing some insane behaviors, (such as picking up food after using matter eater on it), so now a spell being cast successfully will intercept attacks.