### PR TITLE
Slime Paralysis Potion

### DIFF
--- a/code/game/dna/genes/goon_powers.dm
+++ b/code/game/dna/genes/goon_powers.dm
@@ -230,7 +230,6 @@
 		/mob/living/carbon/slime,
 		/mob/living/carbon/alien/larva,
 		/mob/living/simple_animal/slime,
-		/mob/living/simple_animal/adultslime,
 		/mob/living/simple_animal/tomato,
 		/mob/living/simple_animal/chick,
 		/mob/living/simple_animal/chicken,

--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -925,7 +925,7 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 		if(M.stat)
 			to_chat(user, "<span class='warning'>The slime is dead!</span>")
 			return..()
-		var/mob/living/simple_animal/adultslime/pet = new /mob/living/simple_animal/adultslime(M.loc)
+		var/mob/living/simple_animal/slime/adult/pet = new /mob/living/simple_animal/slime/adult(M.loc)
 		pet.icon_state = "[M.colour] adult slime"
 		pet.icon_living = "[M.colour] adult slime"
 		pet.icon_dead = "[M.colour] baby slime dead"
@@ -946,44 +946,6 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 		pet.name = newname
 		pet.real_name = newname
 		qdel (src)
-
-/obj/item/weapon/slimeparapotion
-	name = "slime paralyzing solution"
-	desc = "An exotic chemical which paralyzes a slime, allowing it to be safely picked up and transported."
-	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bottle9"
-
-/obj/item/weapon/slimeparapotion/attack(mob/living/carbon/slime/M as mob, mob/user as mob)
-	if(!istype(M))//If target is not a slime.
-		to_chat(user, "<span class='warning'>The potion only works on slimes!</span>")
-		return ..()
-	var/obj/item/weapon/paraslime/F = new /obj/item/weapon/paraslime(get_turf(M))
-	F.icon_state = "[M.colour] [istype(M,/mob/living/carbon/slime/adult) ? "adult" : "baby"] slime dead"
-	F.name = "frozen [M.colour] slime"
-	F.stored = M
-	M.forceMove(F)
-	qdel(src)
-
-/obj/item/weapon/paraslime
-	name = "paralyzed slime"
-	desc = "A paralyzed slime that can be revived by throwing or use in hand."
-	icon = 'icons/mob/slimes.dmi'
-	icon_state = "grey baby slime"
-	var/mob/living/carbon/slime/stored
-
-/obj/item/weapon/paraslime/throw_impact(atom/hit_atom)
-	..()
-	unfreeze()
-
-/obj/item/weapon/paraslime/attack_hand(mob/living/user as mob)
-	if(user.get_active_hand() == src)
-		unfreeze()
-	else return ..()
-
-/obj/item/weapon/paraslime/proc/unfreeze()
-	if(!stored) return
-	stored.forceMove(get_turf(src))
-	qdel(src)
 
 /obj/item/weapon/slimesteroid
 	name = "slime steroid"

--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -947,6 +947,43 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 		pet.real_name = newname
 		qdel (src)
 
+/obj/item/weapon/slimeparapotion
+	name = "slime paralyzing solution"
+	desc = "An exotic chemical which paralyzes a slime, allowing it to be safely picked up and transported."
+	icon = 'icons/obj/chemical.dmi'
+	icon_state = "bottle9"
+
+/obj/item/weapon/slimeparapotion/attack(mob/living/carbon/slime/M as mob, mob/user as mob)
+	if(!istype(M))//If target is not a slime.
+		to_chat(user, "<span class='warning'>The potion only works on slimes!</span>")
+		return ..()
+	var/obj/item/weapon/paraslime/F = new /obj/item/weapon/paraslime(get_turf(M))
+	F.icon_state = "[M.colour] [istype(M,/mob/living/carbon/slime/adult) ? "adult" : "baby"] slime dead"
+	F.name = "frozen [M.colour] slime"
+	F.stored = M
+	M.forceMove(F)
+	qdel(src)
+
+/obj/item/weapon/paraslime
+	name = "paralyzed slime"
+	desc = "A paralyzed slime that can be revived by throwing or use in hand."
+	icon = 'icons/mob/slimes.dmi'
+	icon_state = "grey baby slime"
+	var/mob/living/carbon/slime/stored
+
+/obj/item/weapon/paraslime/throw_impact(atom/hit_atom)
+	..()
+	unfreeze()
+
+/obj/item/weapon/paraslime/attack_hand(mob/living/user as mob)
+	if(user.get_active_hand() == src)
+		unfreeze()
+	else return ..()
+
+/obj/item/weapon/paraslime/proc/unfreeze()
+	if(!stored) return
+	stored.forceMove(get_turf(src))
+	qdel(src)
 
 /obj/item/weapon/slimesteroid
 	name = "slime steroid"

--- a/code/modules/mob/living/holders.dm
+++ b/code/modules/mob/living/holders.dm
@@ -140,3 +140,25 @@
 	item_state = "cat1"
 
 	update_itemstate_on_twohand = 1
+
+//SLIMES
+/obj/item/weapon/holder/animal/slime
+	name = "slime holder"
+	desc = "It seeps through your fingers"
+
+/obj/item/weapon/holder/animal/slime/New(loc, mob/M)
+	..()
+	var/mob/living/simple_animal/slime/S = stored_mob
+	icon_state = S.icon_state
+
+/obj/item/weapon/holder/animal/slime/proc/unfreeze()
+	stored_mob.canmove = 1
+	Destroy()
+
+/obj/item/weapon/holder/animal/slime/throw_impact(atom/hit_atom)
+	..()
+	unfreeze()
+
+/obj/item/weapon/holder/animal/slime/attack_hand(mob/user)
+	if(user.get_active_hand() == src) unfreeze()
+	else ..()

--- a/code/modules/mob/living/holders.dm
+++ b/code/modules/mob/living/holders.dm
@@ -150,7 +150,7 @@
 	var/mob/living/simple_animal/slime/S = stored_mob
 	S.canmove = 1
 	S.icon_state = "[S.colour] [istype(S,/mob/living/simple_animal/slime/adult) ? "adult" : "baby"] slime"
-	Destroy()
+	returnToPool(src)
 
 /obj/item/weapon/holder/animal/slime/throw_impact(atom/hit_atom)
 	..()

--- a/code/modules/mob/living/holders.dm
+++ b/code/modules/mob/living/holders.dm
@@ -146,19 +146,16 @@
 	name = "slime holder"
 	desc = "It seeps through your fingers"
 
-/obj/item/weapon/holder/animal/slime/New(loc, mob/M)
-	..()
-	var/mob/living/simple_animal/slime/S = stored_mob
-	icon_state = S.icon_state
-
 /obj/item/weapon/holder/animal/slime/proc/unfreeze()
-	stored_mob.canmove = 1
+	var/mob/living/simple_animal/slime/S = stored_mob
+	S.canmove = 1
+	S.icon_state = "[S.colour] [istype(S,/mob/living/simple_animal/slime/adult) ? "adult" : "baby"] slime"
 	Destroy()
 
 /obj/item/weapon/holder/animal/slime/throw_impact(atom/hit_atom)
 	..()
 	unfreeze()
 
-/obj/item/weapon/holder/animal/slime/attack_hand(mob/user)
-	if(user.get_active_hand() == src) unfreeze()
-	else ..()
+/obj/item/weapon/holder/animal/slime/attack_self(mob/user)
+	..()
+	unfreeze()

--- a/code/modules/mob/living/simple_animal/friendly/slime.dm
+++ b/code/modules/mob/living/simple_animal/friendly/slime.dm
@@ -24,7 +24,8 @@
 /mob/living/simple_animal/slime/attackby(var/obj/item/weapon/slimeparapotion/O as obj, var/mob/user as mob)
 	if(istype(O))
 		canmove = 0
-		icon_state = "[src.colour] baby slime dead"
+		icon_state = "[colour] baby slime dead"
+		to_chat(user, "<span class='info'>The [src] stops moving and coalesces.</span>")
 		qdel(O)
 	else
 		..()
@@ -72,7 +73,7 @@
 /mob/living/simple_animal/slime/attack_hand(mob/living/carbon/human/M as mob)
 
 	//Shamelessly stolen from Dionacode
-	if(!canmove && !(locked_to) && (isturf(src.loc)) && (M.get_active_hand() == null)) //Unless their location isn't a turf!
+	if(!canmove && !(locked_to) && (isturf(src.loc)) && (M.get_active_hand() == null))
 		scoop_up(M)
 	..()
 

--- a/code/modules/mob/living/simple_animal/friendly/slime.dm
+++ b/code/modules/mob/living/simple_animal/friendly/slime.dm
@@ -14,6 +14,7 @@
 	emote_see = list("jiggles", "bounces in place")
 	holder_type = /obj/item/weapon/holder/animal/slime
 	var/colour = "grey"
+	var/paralyzed = 0
 	can_butcher = 0
 	meat_type = null
 
@@ -25,7 +26,7 @@
 	if(istype(O))
 		canmove = 0
 		icon_state = "[colour] baby slime dead"
-		to_chat(user, "<span class='info'>The [src] stops moving and coalesces.</span>")
+		to_chat(user, "<span class='info'>\The [src] stops moving and coalesces.</span>")
 		qdel(O)
 	else
 		..()
@@ -73,7 +74,7 @@
 /mob/living/simple_animal/slime/attack_hand(mob/living/carbon/human/M as mob)
 
 	//Shamelessly stolen from Dionacode
-	if(!canmove && !(locked_to) && (isturf(src.loc)) && (M.get_active_hand() == null))
+	if(!canmove && !locked_to && isturf(loc) && !M.get_active_hand())
 		scoop_up(M)
 	..()
 

--- a/code/modules/mob/living/simple_animal/friendly/slime.dm
+++ b/code/modules/mob/living/simple_animal/friendly/slime.dm
@@ -29,7 +29,7 @@
 		to_chat(user, "<span class='info'>\The [src] stops moving and coalesces.</span>")
 		qdel(O)
 	else
-		..()
+		return ..()
 
 /mob/living/simple_animal/slime/adult
 	health = 200
@@ -76,7 +76,7 @@
 	//Shamelessly stolen from Dionacode
 	if(!canmove && !locked_to && isturf(loc) && !M.get_active_hand())
 		scoop_up(M)
-	..()
+	return ..()
 
 /obj/item/weapon/slimeparapotion
 	name = "slime paralyzing solution"

--- a/code/modules/mob/living/simple_animal/friendly/slime.dm
+++ b/code/modules/mob/living/simple_animal/friendly/slime.dm
@@ -12,8 +12,8 @@
 	response_disarm = "shoos"
 	response_harm   = "stomps on"
 	emote_see = list("jiggles", "bounces in place")
+	holder_type = /obj/item/weapon/holder/animal/slime
 	var/colour = "grey"
-
 	can_butcher = 0
 	meat_type = null
 
@@ -23,11 +23,8 @@
 
 /mob/living/simple_animal/slime/attackby(var/obj/item/weapon/slimeparapotion/O as obj, var/mob/user as mob)
 	if(istype(O))
-		var/obj/item/weapon/paraslime/F = new /obj/item/weapon/paraslime(get_turf(src))
-		F.icon_state = icon_dead
-		F.name = "paralyzed [colour] slime"
-		F.stored = src
-		forceMove(F)
+		canmove = 0
+		icon_state = "[src.colour] baby slime dead"
 		qdel(O)
 	else
 		..()
@@ -72,30 +69,15 @@
 	pet.colour = "[colour]"
 	qdel (src)
 
+/mob/living/simple_animal/slime/attack_hand(mob/living/carbon/human/M as mob)
+
+	//Shamelessly stolen from Dionacode
+	if(!canmove && !(locked_to) && (isturf(src.loc)) && (M.get_active_hand() == null)) //Unless their location isn't a turf!
+		scoop_up(M)
+	..()
 
 /obj/item/weapon/slimeparapotion
 	name = "slime paralyzing solution"
 	desc = "An exotic chemical which paralyzes a slime, allowing it to be safely picked up and transported."
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "bottle9"
-
-/obj/item/weapon/paraslime
-	name = "paralyzed slime"
-	desc = "A paralyzed slime that can be revived by throwing or use in hand."
-	icon = 'icons/mob/slimes.dmi'
-	icon_state = "grey baby slime"
-	var/mob/living/carbon/slime/stored
-
-/obj/item/weapon/paraslime/throw_impact(atom/hit_atom)
-	..()
-	unfreeze()
-
-/obj/item/weapon/paraslime/attack_hand(mob/living/user as mob)
-	if(user.get_active_hand() == src)
-		unfreeze()
-	else return ..()
-
-/obj/item/weapon/paraslime/proc/unfreeze()
-	if(!stored) return
-	stored.forceMove(get_turf(src))
-	qdel(src)

--- a/code/modules/mob/living/simple_animal/friendly/slime.dm
+++ b/code/modules/mob/living/simple_animal/friendly/slime.dm
@@ -21,33 +21,32 @@
 	mob_swap_flags = MONKEY|SLIME|SIMPLE_ANIMAL
 	mob_push_flags = MONKEY|SLIME|SIMPLE_ANIMAL
 
+/mob/living/simple_animal/slime/attackby(var/obj/item/weapon/slimeparapotion/O as obj, var/mob/user as mob)
+	if(istype(O))
+		var/obj/item/weapon/paraslime/F = new /obj/item/weapon/paraslime(get_turf(src))
+		F.icon_state = icon_dead
+		F.name = "paralyzed [colour] slime"
+		F.stored = src
+		forceMove(F)
+		qdel(O)
+	else
+		..()
 
-/mob/living/simple_animal/adultslime
-	name = "pet slime"
-	desc = "A lovable, domesticated slime."
-	icon = 'icons/mob/slimes.dmi'
+/mob/living/simple_animal/slime/adult
 	health = 200
 	maxHealth = 200
 	icon_state = "grey adult slime"
 	icon_living = "grey adult slime"
 	icon_dead = "grey baby slime dead"
-	response_help  = "pets"
-	response_disarm = "shoos"
-	response_harm   = "stomps on"
-	emote_see = list("jiggles", "bounces in place")
 
 	size = SIZE_BIG
-	can_butcher = 0
-	meat_type = null
 
-	var/colour = "grey"
-
-/mob/living/simple_animal/adultslime/New()
+/mob/living/simple_animal/slime/adult/New()
 	..()
 	overlays += "aslime-:33"
 
 
-/mob/living/simple_animal/adultslime/Die()
+/mob/living/simple_animal/slime/adult/Die()
 	var/mob/living/simple_animal/slime/S1 = new /mob/living/simple_animal/slime (src.loc)
 	S1.icon_state = "[src.colour] baby slime"
 	S1.icon_living = "[src.colour] baby slime"
@@ -73,14 +72,30 @@
 	pet.colour = "[colour]"
 	qdel (src)
 
-/mob/living/simple_animal/adultslime/proc/rabid()
-	if(stat)
-		return
-	if(client)
-		return
-	var/mob/living/simple_animal/hostile/slime/adult/pet = new /mob/living/simple_animal/hostile/slime/adult(loc)
-	pet.icon_state = "[colour] baby adult eat"
-	pet.icon_living = "[colour] baby adult eat"
-	pet.icon_dead = "[colour] baby slime dead"
-	pet.colour = "[colour]"
-	qdel (src)
+
+/obj/item/weapon/slimeparapotion
+	name = "slime paralyzing solution"
+	desc = "An exotic chemical which paralyzes a slime, allowing it to be safely picked up and transported."
+	icon = 'icons/obj/chemical.dmi'
+	icon_state = "bottle9"
+
+/obj/item/weapon/paraslime
+	name = "paralyzed slime"
+	desc = "A paralyzed slime that can be revived by throwing or use in hand."
+	icon = 'icons/mob/slimes.dmi'
+	icon_state = "grey baby slime"
+	var/mob/living/carbon/slime/stored
+
+/obj/item/weapon/paraslime/throw_impact(atom/hit_atom)
+	..()
+	unfreeze()
+
+/obj/item/weapon/paraslime/attack_hand(mob/living/user as mob)
+	if(user.get_active_hand() == src)
+		unfreeze()
+	else return ..()
+
+/obj/item/weapon/paraslime/proc/unfreeze()
+	if(!stored) return
+	stored.forceMove(get_turf(src))
+	qdel(src)

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -982,7 +982,6 @@
 		/mob/living/simple_animal/hostile/mushroom,
 		/mob/living/simple_animal/hostile/carp/holocarp,
 		/mob/living/simple_animal/hostile/slime,
-		/mob/living/simple_animal/hostile/slime/adult,
 		/mob/living/simple_animal/hostile/mining_drone,
 		/mob/living/simple_animal/hostile/mimic,
 		/mob/living/simple_animal/hostile/mimic/crate,
@@ -1040,7 +1039,6 @@
 		/mob/living/simple_animal/hostile/scarybat/cult,
 		/mob/living/simple_animal/hostile/creature/cult,
 		/mob/living/simple_animal/hostile/slime,
-		/mob/living/simple_animal/hostile/slime/adult,
 		/mob/living/simple_animal/hostile/hivebot/tele, //This thing spawns hostile mobs
 		/mob/living/simple_animal/hostile/mining_drone,
 		) + typesof(/mob/living/simple_animal/hostile/humanoid) + typesof(/mob/living/simple_animal/hostile/asteroid) //Exclusion list for things you don't want the reaction to create.
@@ -1487,9 +1485,6 @@
 	for(var/mob/living/simple_animal/slime/slime in viewers(get_turf(holder.my_atom), null))
 		slime.rabid()
 		holder.my_atom.visible_message("<span class='warning'>\The [slime] is driven into a frenzy!</span>")
-	for(var/mob/living/simple_animal/adultslime/slime in viewers(get_turf(holder.my_atom), null))
-		slime.rabid()
-		holder.my_atom.visible_message("<span class='warning'>\The [slime] is driven into a frenzy!</span>")
 
 //Pink
 /datum/chemical_reaction/slimeppotion
@@ -1587,8 +1582,6 @@
 	for(var/mob/living/carbon/slime/S in viewers(get_turf(holder.my_atom), null)) //Kills slimes
 		S.death(0)
 	for(var/mob/living/simple_animal/slime/S in viewers(get_turf(holder.my_atom), null)) //Kills pet slimes too
-		S.death(0)
-	for(var/mob/living/simple_animal/adultslime/S in viewers(get_turf(holder.my_atom), null)) //No survivors
 		S.death(0)
 
 //Light Pink

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -1606,6 +1606,19 @@
 	var/obj/item/weapon/slimepotion2/P = new /obj/item/weapon/slimepotion2
 	P.loc = get_turf(holder.my_atom)
 
+/datum/chemical_reaction/slimeparalyze
+	name = "Slime Paralyzer"
+	id = "slimepara"
+	result = null
+	result_amount = 1
+	required_container = /obj/item/slime_extract/lightpink
+	required_reagents = list("blood" = 5)
+	required_other = 1
+
+/datum/chemical_reaction/slimeparalyze/on_reaction(var/datum/reagents/holder)
+	feedback_add_details("slime_cores_used", "[replacetext(name, " ", "_")]")
+	new /obj/item/weapon/slimeparapotion(get_turf(holder.my_atom))
+
 //Adamantine
 /datum/chemical_reaction/slimegolem
 	name = "Slime Golem"

--- a/html/changelogs/Kurfurst.yml
+++ b/html/changelogs/Kurfurst.yml
@@ -2,4 +2,4 @@ author: Kurfurst
 delete-after: True
 
 changes: 
-- rscadd: Inject light pink slimes to get a paralysis potion that works on baby and adult domesticated slimes. This makes them able to be picked up for easy transport.
+- rscadd: Inject light pink slimes with blood to get a paralysis potion that works on baby and adult domesticated slimes. This makes them able to be picked up for easy transport.

--- a/html/changelogs/Kurfurst.yml
+++ b/html/changelogs/Kurfurst.yml
@@ -1,0 +1,5 @@
+author: Kurfurst
+delete-after: True
+
+changes: 
+- rscadd: Inject light pink slimes to get a paralysis potion that works on baby and adult domesticated slimes. This makes them able to be picked up for easy transport.


### PR DESCRIPTION
Injecting a light pink slime with blood now creates a paralysis potion. Applying the potion to any _domesticated slime_ will paralyze it, converting it into an easily-transported-item. It retains its previous color. You can convert a paralyzed slime back to an active one by using the slime in your hand or throwing it.

In the course of this PR I had to unfuck adultslime, so it is now a child of slime. Some of the worst copypaste I've ever seen.

Filled as a bounty PR. Payment was received.

**Tested** 
