### PR TITLE
Map element datums

### DIFF
--- a/code/datums/map_elements.dm
+++ b/code/datums/map_elements.dm
@@ -1,0 +1,30 @@
+//map elements: areas loaded into the game during runtime
+//see: vaults, away missions
+var/list/datum/map_element/map_elements = list()
+
+/datum/map_element
+	var/name //Name of the map element. Optional
+	var/desc //Short description. Optional
+
+	var/file_path = "maps/randomvaults/new.dmm"
+
+	var/turf/location //A random turf from the map element. Used for jumping to
+
+/datum/map_element/proc/pre_load() //Called before loading the element
+	return
+
+/datum/map_element/proc/initialize(list/objects) //Called after loading the element. The "objects" list contains all spawned atoms
+	map_elements.Add(src)
+
+	if(objects.len)
+		location = locate(/turf) in objects
+
+/datum/map_element/proc/load(x, y, z)
+	var/file = file(file_path)
+	if(isfile(file))
+		pre_load()
+		var/list/L = maploader.load_map(file, z, x, y)
+		initialize(L)
+		return 1
+
+	return 0

--- a/code/datums/map_elements.dm
+++ b/code/datums/map_elements.dm
@@ -5,6 +5,7 @@ var/list/datum/map_element/map_elements = list()
 /datum/map_element
 	var/name //Name of the map element. Optional
 	var/desc //Short description. Optional
+	var/type_abbreviation //Very short string that determines the map element's type (whether it's an away mission, a small vault, or something else)
 
 	var/file_path = "maps/randomvaults/new.dmm"
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -1124,6 +1124,7 @@ var/list/admin_verbs_mod = list(
 			log_admin("[key_name(src)] is trying to load [ME.file_path].")
 
 		if("Load external .dmm file")
+			to_chat(src, "<span class='danger'>Do not load very large maps or files that aren't BYOND maps. If you want to be sure that your map won't hang up the game, try loading it on a local server first.</span>")
 			ME = new /datum/map_element
 			log_admin("[key_name(src)] is trying to load an external map file.")
 			var/new_file_path = input(usr, "Select a .dmm file.    WARNING: Very large map files WILL crash the server. Loading them is punishable by death.", "Map element loading") as null|file
@@ -1134,39 +1135,37 @@ var/list/admin_verbs_mod = list(
 		else
 			return
 
-	var/turf/new_location
+	var/x_coord
+	var/y_coord
+	var/z_coord
 
 	switch(alert(usr, "Select a location for the new map element", "Map element loading", "Use my current location", "Input coordinates", "Cancel"))
 		if("Use my current location")
-			new_location = get_turf(usr)
+			var/turf/new_location = get_turf(usr)
 			if(!new_location)
 				return
+
+			x_coord = new_location.x
+			y_coord = new_location.y
+			z_coord = new_location.z
 
 		if("Input coordinates")
-			var/x_coord = input(usr, "Input the X coordinate: ", "Map element loading") as null|num
+			x_coord = input(usr, "Input the X coordinate: ", "Map element loading") as null|num
 			if(x_coord == null) return
 
-			var/y_coord = input(usr, "Input the Y coordinate (X = [x_coord]): ", "Map element loading") as null|num
+			y_coord = input(usr, "Input the Y coordinate (X = [x_coord]): ", "Map element loading") as null|num
 			if(y_coord == null) return
 
-			var/z_coord = input(usr, "Input the Z coordinate. If it's higher than [world.maxz], a new Z-level will be created (X = [x_coord], Y = [y_coord]): ", "Map element loading") as null|num
+			z_coord = input(usr, "Input the Z coordinate. If it's higher than [world.maxz], a new Z-level will be created (X = [x_coord], Y = [y_coord]): ", "Map element loading") as null|num
 			if(z_coord == null) return
-
-			if(z_coord > world.maxz)
-				world.maxz++
-				z_coord = world.maxz //So that some lardass can't create 60 empty zlevels after his fat fingers type in "66" instead of "6"
-
-			new_location = locate(x_coord, y_coord, z_coord)
-			if(!new_location)
-				to_chat(usr, "Unable to find the turf at [x_coord], [y_coord], [z_coord]!")
-				return
 
 		if("Cancel")
 			return
 
-	log_admin("[key_name(src)] is loading [ME.file_path] at [formatJumpTo(new_location)]")
-	message_admins("[key_name_admin(src)] is loading [ME.file_path] at [formatJumpTo(new_location)]")
-	ME.load(new_location.x, new_location.y, new_location.z)
+	log_admin("[key_name(src)] is loading [ME.file_path] at [x_coord], [y_coord], [z_coord]")
+	message_admins("[key_name_admin(src)] is loading [ME.file_path] at [x_coord], [y_coord], [z_coord]")
+	ME.load(x_coord, y_coord, z_coord)
+	message_admins("[ME.file_path] loaded at [ME.location ? formatJumpTo(ME.location) : "[x_coord], [y_coord], [z_coord]"]")
 
 /client/proc/create_awaymission()
 	set category = "Admin"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -1149,8 +1149,12 @@ var/list/admin_verbs_mod = list(
 			var/y_coord = input(usr, "Input the Y coordinate (X = [x_coord]): ", "Map element loading") as null|num
 			if(y_coord == null) return
 
-			var/z_coord = input(usr, "Input the Z coordinate (X = [x_coord], Y = [y_coord]): ", "Map element loading") as null|num
+			var/z_coord = input(usr, "Input the Z coordinate. If it's higher than [world.maxz], a new Z-level will be created (X = [x_coord], Y = [y_coord]): ", "Map element loading") as null|num
 			if(z_coord == null) return
+
+			if(z_coord > world.maxz)
+				world.maxz++
+				z_coord = world.maxz //So that some lardass can't create 60 empty zlevels after his fat fingers type in "66" instead of "6"
 
 			new_location = locate(x_coord, y_coord, z_coord)
 			if(!new_location)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -1114,20 +1114,22 @@ var/list/admin_verbs_mod = list(
 		return
 
 	var/datum/map_element/ME
-	var/mission_to_load = alert(usr, "How do you want to select the map element?", "Map element loading", "Choose a /datum/map_element object", "Input a file path", "Cancel")
+	var/mission_to_load = alert(usr, "How do you want to select the map element?", "Map element loading", "Choose a /datum/map_element object", "Load external .dmm file", "Cancel")
 	switch(mission_to_load)
 		if("Choose a /datum/map_element object")
 			var/new_map_element = input(usr, "Please select the map element object.", "Map element loading") as null|anything in typesof(/datum/map_element) - /datum/map_element
 			if(!new_map_element) return
 
 			ME = new new_map_element
+			log_admin("[key_name(src)] is trying to load [ME.file_path].")
 
-		if("Input a file path")
+		if("Load external .dmm file")
 			ME = new /datum/map_element
-			var/new_file_path = input(usr, "Please type in the file path (for example: maps/randomvaults/clown_base.dmm ):", "Map element loading") as null|text
+			log_admin("[key_name(src)] is trying to load an external map file.")
+			var/new_file_path = input(usr, "Select a .dmm file.    WARNING: Very large map files WILL crash the server. Loading them is punishable by death.", "Map element loading") as null|file
 			if(!new_file_path) return
-			if(!file(new_file_path)) return
 
+			log_admin("[key_name(src)] has selected [new_file_path] for loading.")
 			ME.file_path = new_file_path
 		else
 			return
@@ -1158,6 +1160,8 @@ var/list/admin_verbs_mod = list(
 		if("Cancel")
 			return
 
+	log_admin("[key_name(src)] is loading [ME.file_path] at [formatJumpTo(new_location)]")
+	message_admins("[key_name_admin(src)] is loading [ME.file_path] at [formatJumpTo(new_location)]")
 	ME.load(new_location.x, new_location.y, new_location.z)
 
 /client/proc/create_awaymission()

--- a/code/modules/admin/verbs/adminjump.dm
+++ b/code/modules/admin/verbs/adminjump.dm
@@ -121,15 +121,11 @@
 		var/list/vaults = list()
 
 		for(var/datum/map_element/V in map_elements)
-			var/name = "[V.name ? V.name : V.file_path] at [V.location ? "[V.location.x], [V.location.y], [V.location.z]" : "UNKNOWN"]"
-			if(istype(V, /datum/map_element/vault))
-				name = "VAULT [name]"
-			else if(istype(V, /datum/map_element/away_mission))
-				name = "AWAY MISSION [name]"
+			var/name = "[V.type_abbreviation] [V.name ? V.name : V.file_path] @ [V.location ? "[V.location.x],[V.location.y],[V.location.z]" : "UNKNOWN"]"
 
 			vaults[name] = V
 
-		var/selection = input("Select a map element to teleport to.", "Admin Jumping", null, null) as null|anything in sortList(vaults)
+		var/selection = input("Select a map element to teleport to. AM = Away Mission, V = Vault.", "Admin Jumping", null, null) as null|anything in sortList(vaults)
 		if(!selection)
 			return
 

--- a/code/modules/admin/verbs/adminjump.dm
+++ b/code/modules/admin/verbs/adminjump.dm
@@ -110,9 +110,9 @@
 	else
 		alert("Admin jumping disabled")
 
-/client/proc/jumptovault()
+/client/proc/jumptomapelement()
 	set category = "Admin"
-	set name = "Jump to Vault"
+	set name = "Jump to Map Element"
 
 	if(!check_rights())
 		return
@@ -120,49 +120,28 @@
 	if(config.allow_admin_jump)
 		var/list/vaults = list()
 
-		for(var/datum/vault/V in existing_vaults)
-			vaults["[V.map_name] at [V.location ? "[V.location.x], [V.location.y], [V.location.z]" : "UNKNOWN"]"] = V
+		for(var/datum/map_element/V in map_elements)
+			var/name = "[V.name ? V.name : V.file_path] at [V.location ? "[V.location.x], [V.location.y], [V.location.z]" : "UNKNOWN"]"
+			if(istype(V, /datum/map_element/vault))
+				name = "VAULT [name]"
+			else if(istype(V, /datum/map_element/away_mission))
+				name = "AWAY MISSION [name]"
 
-		var/selection = input("Select a vault to teleport to.", "Admin Jumping", null, null) as null|anything in sortList(vaults)
+			vaults[name] = V
+
+		var/selection = input("Select a map element to teleport to.", "Admin Jumping", null, null) as null|anything in sortList(vaults)
 		if(!selection)
 			return
 
-		var/datum/vault/V = vaults[selection]
+		var/datum/map_element/V = vaults[selection]
 		if(!V.location)
-			to_chat(src, "[V.map_name] doesn't have a location! Report this")
+			to_chat(src, "[V.file_path] doesn't have a location! Report this")
 			return
 
 		usr.forceMove(V.location)
 		feedback_add_details("admin_verb","JV")
 	else
 		alert("Admin jumping disabled")
-
-/client/proc/jumptoaway()
-	set category = "Admin"
-	set name = "Jump to Away Mission"
-
-	if(!check_rights())
-		return
-
-	if(!config.allow_admin_jump)
-		alert("Admin jumping disabled")
-		return
-
-	var/list/awaymissions = list()
-	for(var/datum/away_mission/AM in existing_away_missions)
-		awaymissions["[AM.name] ([AM.file_path][AM.location ? ", Z:[AM.location.z]" : ""])"] = AM
-
-	var/selection = input("Select a vault to teleport to.", "Admin Jumping", null, null) as null|anything in sortList(awaymissions)
-	if(!selection)
-		return
-
-	var/datum/away_mission/AM = awaymissions[selection]
-	if(!AM.location)
-		to_chat(src, "[AM.name] doesn't have a location! Panic")
-		return
-
-	usr.forceMove(AM.location)
-	feedback_add_details("admin_verb","JV")
 
 /client/proc/Getmob(var/mob/M in mob_list)
 	set category = "Admin"

--- a/code/modules/awaymissions/_awaymission.dm
+++ b/code/modules/awaymissions/_awaymission.dm
@@ -32,6 +32,7 @@ Example of the second method:
 */
 
 /datum/map_element/away_mission
+	type_abbreviation = "AM"
 	var/generate_randomly = 1 //If 0, don't generate this away mission randomly
 
 	var/datum/zLevel/zLevel

--- a/code/modules/awaymissions/_awaymission.dm
+++ b/code/modules/awaymissions/_awaymission.dm
@@ -1,6 +1,6 @@
 //#define DISABLE_AWAYMISSIONS_ON_ROUNDSTART
 
-var/list/datum/away_mission/existing_away_missions = list()
+var/list/datum/map_element/away_mission/existing_away_missions = list()
 
 var/list/awaydestinations = list() //List of landmarks
 /obj/effect/landmark/awaystart
@@ -9,7 +9,7 @@ var/list/awaydestinations = list() //List of landmarks
 There are two ways to add an away mission to the game
 
  A) Add the map file's location to maps/RandomZLevels/fileList.txt
- B) Create a subtype of /datum/away_mission and set its file_path to the map file's location (see below)
+ B) Create a subtype of /datum/map_element/away_mission and set its file_path to the map file's location (see below)
 
 First method sucks
 
@@ -18,7 +18,7 @@ It also lets you write a description for the away mission, as well as many other
 
 Example of the second method:
 
-/datum/away_mission/my_shit
+/datum/map_element/away_mission/my_shit
 	file_path = "maps/RandomZLevels/fresh_dump.dmm"
 	desc = "This stinks"
 
@@ -31,20 +31,17 @@ Example of the second method:
 
 */
 
-/datum/away_mission
-	var/name = "" //Name of the mission
-	var/file_path = "" //Path of the file. Example: "maps/RandomZLevels/test.dmm"
-	var/desc //Short description. It will be visible to admins when they attempt to create an away mission
+/datum/map_element/away_mission
 	var/generate_randomly = 1 //If 0, don't generate this away mission randomly
 
 	var/datum/zLevel/zLevel
-	var/turf/location
 
-/datum/away_mission/proc/pre_load() //Called before loading the map
-	return
+/datum/map_element/away_mission/initialize(list/objects) //objects: list of all atoms in the away mission. This proc is called after the away mission is loaded
+	..()
 
-/datum/away_mission/proc/initialize(list/objects) //objects: list of all atoms in the away mission. This proc is called after the away mission is loaded
-	var/z = world.maxz //z coordinate
+	existing_away_missions.Add(src)
+
+	var/z = location ? location.z : world.maxz //z coordinate
 
 	for(var/turf/T in block(locate(1,1,z), locate(world.maxx, world.maxy, z)))
 		turfs.Add(T)
@@ -63,67 +60,64 @@ Example of the second method:
 	for(var/obj/machinery/gateway/G in objects)
 		G.initialize()
 
-	if(objects.len && !location)
-		location = get_turf(pick(objects))
-
-/datum/away_mission/empty_space
+/datum/map_element/away_mission/empty_space
 	name = "empty space"
 	file_path = "maps/RandomZLevels/space.dmm" //1x1 space tile. It changes its size according to the map's dimensions
 	generate_randomly = 0
 
-/datum/away_mission/empty_space/New()
+/datum/map_element/away_mission/empty_space/New()
 	..()
 	desc = "[world.maxx]x[world.maxy] tiles of pure space. No structures, no humans, absolutely nothing. Not even a gateway - you'll have to spawn one yourself."
 
-/datum/away_mission/arcticwaste
+/datum/map_element/away_mission/arcticwaste
 	name = "arctic waste"
 	file_path = "maps/RandomZLevels/arcticwaste.dmm"
 	desc = "A frozen wasteland with an underground bunker. Features a gateway."
 
-/datum/away_mission/assistantchamber
+/datum/map_element/away_mission/assistantchamber
 	name = "assistant chamber"
 	file_path = "maps/RandomZLevels/assistantChamber.dmm"
 	desc = "A tiny unbreachable room full of angry turrets and loot."
 	generate_randomly = 0
 
-/datum/away_mission/challenge
+/datum/map_element/away_mission/challenge
 	name = "emitter hell"
 	file_path = "maps/RandomZLevels/unused/challenge.dmm"
 	desc = "A long hallway featuring emitters, turrets and syndicate agents. Features loot and a gateway."
 
-/datum/away_mission/spaceship
+/datum/map_element/away_mission/spaceship
 	name = "stranded spaceship"
 	file_path = "maps/RandomZLevels/unused/blackmarketpackers.dmm"
 	desc = "A mysteriously empty shuttle crashed into the asteroid."
 
-/datum/away_mission/academy
+/datum/map_element/away_mission/academy
 	name = "academy"
 	file_path = "maps/RandomZLevels/unused/Academy.dmm"
 
-/datum/away_mission/beach
+/datum/map_element/away_mission/beach
 	name = "beach"
 	file_path = "maps/RandomZLevels/unused/beach.dmm"
 	desc = "A small, comfy seaside area with a bar."
 	generate_randomly = 0
 
-/datum/away_mission/listeningpost
+/datum/map_element/away_mission/listeningpost
 	name = "listening post"
 	file_path = "maps/RandomZLevels/unused/listeningpost.dmm"
 	desc = "A large asteroid with a hidden syndicate listening post. Don't forget to bring pickaxes!"
 
-/datum/away_mission/stationcollision
+/datum/map_element/away_mission/stationcollision
 	name = "station collision"
 	file_path = "maps/RandomZLevels/unused/stationCollision.dmm"
 	desc = "A shuttlecraft crashed into a small space station, bringing aboard aliens and cultists. Features the Lord Nar-Sie himself."
 
-/datum/away_mission/wildwest
+/datum/map_element/away_mission/wildwest
 	name = "wild west"
 	file_path = "maps/RandomZLevels/unused/wildwest.dmm"
 	desc = "An exciting adventure for the toughest adventures your station can offer. Those who defeat all of the final area's guardians will find a wish granter."
 
-var/static/list/away_mission_subtypes = typesof(/datum/away_mission) - /datum/away_mission
+var/static/list/away_mission_subtypes = typesof(/datum/map_element/away_mission) - /datum/map_element/away_mission
 
-//Returns a list containing /datum/away_mission objects.
+//Returns a list containing /datum/map_element/away_mission objects.
 /proc/getRandomZlevels(include_unrandom = 0)
 	var/list/potentialRandomZlevels = away_mission_subtypes.Copy()
 	for(var/T in potentialRandomZlevels) //Fill the list with away mission datums (because currently it only contains paths)
@@ -161,18 +155,18 @@ var/static/list/away_mission_subtypes = typesof(/datum/away_mission) - /datum/aw
 			warning("fileList.txt contains a map that does not exist: [name]")
 			continue
 
-		var/datum/away_mission/AM = new /datum/away_mission
+		var/datum/map_element/away_mission/AM = new /datum/map_element/away_mission
 		AM.file_path = name
 
 		potentialRandomZlevels.Add(AM)
 
 	if(!include_unrandom)
-		for(var/datum/away_mission/AM in potentialRandomZlevels)
+		for(var/datum/map_element/away_mission/AM in potentialRandomZlevels)
 			if(!AM.generate_randomly) potentialRandomZlevels.Remove(AM)
 
 	return potentialRandomZlevels
 
-/proc/createRandomZlevel(override = 0, var/datum/away_mission/AM, var/messages = null)
+/proc/createRandomZlevel(override = 0, var/datum/map_element/away_mission/AM, var/messages = null)
 	if(!messages) messages = world
 
 	if(existing_away_missions.len && !override)	//crude, but it saves another var!
@@ -192,14 +186,8 @@ var/static/list/away_mission_subtypes = typesof(/datum/away_mission) - /datum/aw
 
 	log_game("Loading away mission [AM.file_path]")
 
-	var/file = file(AM.file_path)
-	if(isfile(file))
-		AM.pre_load()
-		var/list/L = maploader.load_map(file)
-		to_chat(messages, "<span class='danger'>Initializing away mission...</span>")
-		AM.initialize(L)
-
+	if(AM.load())
 		to_chat(messages, "<span class='danger'>Away mission loaded.</span>")
-		existing_away_missions.Add(AM)
 		return
+
 	to_chat(messages, "<span class='danger'>Failed to load away mission [AM.file_path] (file doesn't exist).</span>")

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -174,40 +174,44 @@ var/global/dmm_suite/preloader/_preloader = null
 
 	//The next part of the code assumes there's ALWAYS an /area AND a /turf on a given tile
 
-	//in case of multiples turfs on one tile,
-	//will contains the images of all underlying turfs, to simulate the DMM multiple tiles piling
-	var/list/turfs_underlays = list()
-
 	//first instance the /area and remove it from the members list
 	index = members.len
 	var/atom/instance
 	_preloader = new(members_attributes[index])//preloader for assigning  set variables on atom creation
 
+	//Locate the area object
 	instance = locate(members[index])
-	instance.contents.Add(locate(xcrd,ycrd,zcrd))
+
+	if(!isspace(instance)) //Space is the default area and contains every loaded turf by default
+		instance.contents.Add(locate(xcrd,ycrd,zcrd))
 
 	if(_preloader && instance)
 		_preloader.load(instance)
 
 	members.Remove(members[index])
 
-	//then instance the /turf and, if multiple tiles are presents, simulates the DMM underlays piling effect
+	//then instance the /turf and, if multiple tiles are presents, simulates the DMM underlays piling effect (only the last turf is spawned, other ones are drawn as underlays)
 
 	var/first_turf_index = 1
 	while(!ispath(members[first_turf_index],/turf)) //find first /turf object in members
 		first_turf_index++
 
-	//instanciate the first /turf
-	var/turf/T = instance_atom(members[first_turf_index],members_attributes[first_turf_index],xcrd,ycrd,zcrd)
+	var/last_turf_index = first_turf_index
+	while(last_turf_index+1 <= members.len && ispath(members[last_turf_index + 1], /turf))
+		last_turf_index++
 
-	//if others /turf are presents, simulates the underlays piling effect
-	index = first_turf_index + 1
-	while(index <= members.len)
-		turfs_underlays.Insert(1,image(T.icon,null,T.icon_state,T.layer,T.dir))//add the current turf image to the underlays list
-		var/turf/UT = instance_atom(members[index],members_attributes[index],xcrd,ycrd,zcrd)//instance new turf
-		add_underlying_turf(UT,T,turfs_underlays)//simulates the DMM piling effect
-		T = UT
-		index++
+	//instanciate the last /turf
+	var/turf/T = instance_atom(members[last_turf_index],members_attributes[last_turf_index],xcrd,ycrd,zcrd)
+
+	if(first_turf_index != last_turf_index) //More than one turf is present - go from the lowest turf to the turf before the last one
+		var/turf_index = first_turf_index
+		while(turf_index < last_turf_index)
+			var/turf/underlying_turf = members[turf_index]
+			var/image/new_underlay = image(icon = null) //Because just image() doesn't work, and neither does image(appearance=...)
+
+			new_underlay.appearance = initial(underlying_turf.appearance)
+			T.underlays.Add(new_underlay)
+			turf_index++
 
 	spawned_atoms.Add(T)
 

--- a/code/modules/randomMaps/vault_definitions.dm
+++ b/code/modules/randomMaps/vault_definitions.dm
@@ -1,22 +1,16 @@
 var/list/existing_vaults = list()
 
-/datum/vault
+/datum/map_element/vault
 	var/list/exclusive_to_maps = list() //Only spawn on these maps (accepts nameShort and nameLong, for more info see maps/_map.dm). No effect if empty
 	var/list/map_blacklist = list() //Don't spawn on these maps
 
-	var/map_directory = "maps/randomVaults/"
-	var/map_name = "" //Don't include the suffix or "maps/randomVaults/". If the vault is maps/randomVaults/hell.dmm, this should be "hell"
-
 	var/only_spawn_once = 1 //If 0, this vault can spawn multiple times on a single map
 
-	var/turf/location //The first turf from this vault
 	var/base_turf_type = /turf/space //The "default" turf type that surrounds this vault. If it differs from the z-level's base turf type (for example if this vault is loaded on a snow map), all turfs of this type will be replaced with turfs of the z-level's base turf type
 
-/datum/vault/proc/initialize(list/objects)
+/datum/map_element/vault/initialize(list/objects)
+	..(objects)
 	existing_vaults.Add(src)
-
-	location = locate(/turf) in objects
-	if(!location) return
 
 	var/zlevel_base_turf_type = get_base_turf(location.z)
 	if(!zlevel_base_turf_type) zlevel_base_turf_type = /turf/space
@@ -30,41 +24,41 @@ var/list/existing_vaults = list()
 
 //How to create a new vault:
 //1) create a map in maps/randomVaults/
-//2) create a new subtype of /datum/vault/ (look below for an example) and set its map_name to your map's filename (don't include the "dmm" part)
+//2) create a new subtype of /datum/map_element/vault/ (look below for an example) and set its file_path to your map's file path (including the file extension, which is most likely ".dmm")
 //3) if you're an advanced user, feel free to play around with other variables
 
-/datum/vault/icetruck_crash
-	map_name = "icetruck_crash"
+/datum/map_element/vault/icetruck_crash
+	file_path = "maps/randomvaults/icetruck_crash.dmm"
 
-/datum/vault/asteroid_temple
-	map_name = "asteroid_temple"
+/datum/map_element/vault/asteroid_temple
+	file_path = "maps/randomvaults/asteroid_temple.dmm"
 
-/datum/vault/tommyboyasteroid
-	map_name = "tommyboyasteroid"
+/datum/map_element/vault/tommyboyasteroid
+	file_path = "maps/randomvaults/tommyboyasteroid.dmm"
 
-/datum/vault/hivebot_factory
-	map_name = "hivebot_factory"
+/datum/map_element/vault/hivebot_factory
+	file_path = "maps/randomvaults/hivebot_factory.dmm"
 
-/datum/vault/clown_base
-	map_name = "clown_base"
+/datum/map_element/vault/clown_base
+	file_path = "maps/randomvaults/clown_base.dmm"
 
-/datum/vault/rust
-	map_name = "rust"
+/datum/map_element/vault/rust
+	file_path = "maps/randomvaults/rust.dmm"
 
-/datum/vault/dance_revolution
-	map_name = "dance_revolution"
+/datum/map_element/vault/dance_revolution
+	file_path = "maps/randomvaults/dance_revolution.dmm"
 
-/datum/vault/spacegym
-	map_name = "spacegym"
+/datum/map_element/vault/spacegym
+	file_path = "maps/randomvaults/spacegym.dmm"
 
-/datum/vault/oldarmory
-	map_name = "oldarmory"
+/datum/map_element/vault/oldarmory
+	file_path = "maps/randomvaults/oldarmory.dmm"
 
-/datum/vault/spacepond
-	map_name = "spacepond"
+/datum/map_element/vault/spacepond
+	file_path = "maps/randomvaults/spacepond.dmm"
 
-/datum/vault/iou_vault
-	map_name = "iou_fort"
+/datum/map_element/vault/iou_vault
+	file_path = "maps/randomvaults/iou_fort.dmm"
 
-/datum/vault/biodome
-	map_name = "biodome"
+/datum/map_element/vault/biodome
+	file_path = "maps/randomvaults/biodome.dmm"

--- a/code/modules/randomMaps/vault_definitions.dm
+++ b/code/modules/randomMaps/vault_definitions.dm
@@ -1,6 +1,8 @@
 var/list/existing_vaults = list()
 
 /datum/map_element/vault
+	type_abbreviation = "V"
+
 	var/list/exclusive_to_maps = list() //Only spawn on these maps (accepts nameShort and nameLong, for more info see maps/_map.dm). No effect if empty
 	var/list/map_blacklist = list() //Don't spawn on these maps
 

--- a/html/changelogs/unid-a4o4.yml
+++ b/html/changelogs/unid-a4o4.yml
@@ -1,0 +1,7 @@
+author: Unid
+
+delete-after: True
+
+changes: 
+- rscadd: "Added a 'Load Map Element' admin command that allows admins to spawn any vault, away mission or external map file into the game. Warning: loading large external map files may result in extreme lag."
+- tweak: "Merged 'Jump to Vault' and 'Jump to Away Mission' into one command - 'Jump to Map Element'"

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -154,6 +154,7 @@
 #include "code\datums\datumvars.dm"
 #include "code\datums\disease.dm"
 #include "code\datums\locking_category.dm"
+#include "code\datums\map_elements.dm"
 #include "code\datums\mind.dm"
 #include "code\datums\mixed.dm"
 #include "code\datums\modules.dm"


### PR DESCRIPTION
- Added /datum/map_element objects. Vaults and away missions are children of them (as /datum/map_element/vault and /datum/map_element/away_mission, respectively)
- Merged "Jump to Vault" and "Jump to Away Mission" procs into "Jump to Map Element"
- Added "Load Map Element" proc that lets admins load any vault, away mission or external map file into the game. Away missions loaded through this proc function just like normal away missions - you can use the gateways and so on.
- Fixed maploader not processing underlying turfs correctly. Before: http://puu.sh/oYRuJ/8fd01b5f52.png . After: http://puu.sh/oYRGK/e93f1737ee.png . This should also fix some nasty runtimes

Jump to Map Element looks like this:
![](http://puu.sh/oYTFj/b74990d59e.png)
