### PR TITLE
Re-enable Virologist as a job position

### DIFF
--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -54,7 +54,7 @@
 	idtype = /obj/item/weapon/card/id/medical
 	access = list(access_medical, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics, access_eva)
 	minimal_access = list(access_medical, access_morgue, access_surgery, access_virology)
-	alt_titles = list("Surgeon","Emergency Physician","Nurse","Virologist")
+	alt_titles = list("Surgeon", "Emergency Physician", "Nurse")
 
 	pdaslot=slot_belt
 	pdatype=/obj/item/device/pda/medical
@@ -65,10 +65,7 @@
 		switch(H.backbag)
 			if(2) H.equip_or_collect(new /obj/item/weapon/storage/backpack/medic(H), slot_back)
 			if(3)
-				if(H.mind.role_alt_title=="Virologist")
-					H.equip_or_collect(new /obj/item/weapon/storage/backpack/satchel_vir, slot_back)
-				else
-					H.equip_or_collect(new /obj/item/weapon/storage/backpack/satchel_med(H), slot_back)
+				H.equip_or_collect(new /obj/item/weapon/storage/backpack/satchel_med(H), slot_back)
 			if(4) H.equip_or_collect(new /obj/item/weapon/storage/backpack/satchel(H), slot_back)
 		if (H.mind.role_alt_title)
 			switch(H.mind.role_alt_title)
@@ -79,10 +76,6 @@
 					H.equip_or_collect(new /obj/item/clothing/under/rank/medical/blue(H), slot_w_uniform)
 					H.equip_or_collect(new /obj/item/clothing/suit/storage/labcoat(H), slot_wear_suit)
 					H.equip_or_collect(new /obj/item/clothing/head/surgery/blue(H), slot_head)
-				if("Virologist")
-					H.equip_or_collect(new /obj/item/clothing/suit/storage/labcoat/virologist(H), slot_wear_suit)
-					H.equip_or_collect(new /obj/item/clothing/under/rank/virologist(H), slot_w_uniform)
-					H.equip_or_collect(new /obj/item/clothing/mask/surgical(H), slot_wear_mask)
 				if("Medical Doctor")
 					H.equip_or_collect(new /obj/item/clothing/under/rank/medical(H), slot_w_uniform)
 					H.equip_or_collect(new /obj/item/clothing/suit/storage/labcoat(H), slot_wear_suit)
@@ -184,7 +177,7 @@
 			H.equip_or_collect(new H.species.survival_gear(H.back), slot_in_backpack)
 		return 1
 
-/*/datum/job/virologist
+/datum/job/virologist
 	title = "Virologist"
 	flag = VIROLOGIST
 	department_flag = MEDSCI
@@ -193,17 +186,16 @@
 	spawn_positions = 1
 	supervisors = "the chief medical officer"
 	selection_color = "#ffeef0"
-	access = list(access_medical, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics)
+	access = list(access_medical, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics, access_eva)
 	minimal_access = list(access_medical, access_virology)
-	alt_titles = list("Pathologist","Microbiologist")
-
+	alt_titles = list("Pathologist", "Microbiologist")
 
 	equip(var/mob/living/carbon/human/H)
 		if(!H)	return 0
 		H.equip_or_collect(new /obj/item/device/radio/headset/headset_med(H), slot_ears)
 		switch(H.backbag)
 			if(2) H.equip_or_collect(new /obj/item/weapon/storage/backpack/medic(H), slot_back)
-			if(3) H.equip_or_collect(new /obj/item/weapon/storage/backpack/satchel_med(H), slot_back)
+			if(3) H.equip_or_collect(new /obj/item/weapon/storage/backpack/satchel_vir, slot_back)
 			if(4) H.equip_or_collect(new /obj/item/weapon/storage/backpack/satchel(H), slot_back)
 		H.equip_or_collect(new /obj/item/clothing/under/rank/virologist(H), slot_w_uniform)
 		H.equip_or_collect(new /obj/item/device/pda/viro(H), slot_belt)
@@ -217,6 +209,7 @@
 			H.equip_or_collect(new H.species.survival_gear(H.back), slot_in_backpack)
 		return 1
 
+/*
 /datum/job/psychiatrist
 	title = "Psychiatrist"
 	flag = PSYCHIATRIST

--- a/html/changelogs/Dylanstrategie_Virologist.yml
+++ b/html/changelogs/Dylanstrategie_Virologist.yml
@@ -1,0 +1,4 @@
+author: Dylanstrategie
+delete-after: True
+changes:
+- rscadd: Virologist is once again its own job instead of a Medical Doctor title. For better or for worse.


### PR DESCRIPTION
Virologist was removed a while ago when we compressed all departmental accesses. At this point we made the judgement that a separate Virology job wasn't needed since, after all, any Medical Doctor could do it and it was usually antagonist bait.

I want to come back on that because I feel Medical Doctor Virology is actually worse than having a Virologist slot. First of all, multiple Virologists can sign up for a laboratory intended for one. Second of all, Virologists who sign up to use Virology will, 95 % of the time, never assume their role as a Doctor ever again because splicing viruses is a huge time sink. Third of all, the Chief Medical Officer or indeed any Medical Doctor can already and will still cure viruses if the Virologist is outskie. And last but not least, we nuked two really fancy job titles doing this.

All medical personnel will still have access to Virology, and Virologist access was updated. He also gets the new fancy Virologist satchel if you're not a fuccboi and actually use satchels. Obviously, the Virologist alt title was removed from Medical Doctors

Tested and ready to go.
