### PR TITLE
Adds virologist to the list of medical jobs so crew manifests properly tag them as Medical instead of Miscellaneous

### DIFF
--- a/code/game/jobs/jobs.dm
+++ b/code/game/jobs/jobs.dm
@@ -73,6 +73,7 @@ var/list/medical_positions = list(
 	"Chief Medical Officer",
 	"Medical Doctor",
 	"Geneticist",
+	"Virologist",
 //	"Psychiatrist",
 	"Paramedic",
 	"Chemist"


### PR DESCRIPTION
explanatory

testes tested nightly :100:%
