### PR TITLE
Magic Missile stuns instead of sleeps

### DIFF
--- a/code/modules/spells/targeted/projectile/magic_missile.dm
+++ b/code/modules/spells/targeted/projectile/magic_missile.dm
@@ -18,7 +18,7 @@
 
 	hud_state = "wiz_mm"
 
-	amt_paralysis = 3
+	amt_weakened = 3
 	amt_stunned = 3
 
 	amt_dam_fire = 10


### PR DESCRIPTION
Sleep had a delay before it made someone fall so all the projectiles hit the same guy who was able to get a few shots off before falling down. Tested this in a crowd and it seemed to do the trick. Now it's just mind swap and blink that need fixing
