### PR TITLE
Repair is type in list

### DIFF
--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -58,16 +58,24 @@
 
 //Checks for specific types in a list
 /proc/is_type_in_list(datum/A, list/L)
-	if (!L.len || !A)
+	if(!L.len || !A)
 		return 0
-	if (!isnum(L[L[1]])) //Has this not been converted to an associative list?
-		generate_type_list_cache(L) //Convert it to an associative list
+
+	if(L[L[1]] != MAX_VALUE) //Is this already a generated typecache
+		if(isnull(L[L[1]])) //It's not a typecache, so now we'll check if its an associative list or not
+			generate_type_list_cache(L) //Convert it to an associative list format for speed in access
+		else //Else this is meant to be an associative list, we can't reformat it
+			for(var/type in L)
+				if(istype(A, type))
+					return 1
+			return 0
+
 	return L[A.type]
 
 /proc/generate_type_list_cache(L)
 	for(var/type in L)
 		for(var/T in typesof(type)) //Gather all possible typepaths into an associative list
-			L[T] = 1 //Set them equal to one
+			L[T] = MAX_VALUE //Set them equal to the max value which is unlikely to collide with any other pregenerated value
 
 //Empties the list by setting the length to 0. Hopefully the elements get garbage collected
 /proc/clearlist(list/list)

--- a/code/setup.dm
+++ b/code/setup.dm
@@ -13,6 +13,7 @@
 #define PROFILE_MACHINES // Disable when not debugging.
 
 #define ARBITRARILY_LARGE_NUMBER 10000 //Used in delays.dm and vehicle.dm. Upper limit on delays
+#define MAX_VALUE 65535
 
 #ifdef PROFILE_MACHINES
 #define CHECK_DISABLED(TYPE) if(disable_##TYPE) return


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.
-->


Using isnum is unreliable for detecting nonstandard formats of already associative lists. Causing them to be overriden with the type cache.

Checking isnull instead will allow us to detect strings, numbers, lists, typepaths, basically everything that we want to check to make sure this isn't already an associative list.

Fixes #10225
Fixes #10224