### PR TITLE
Fixes cybernetic eyeballs not actually protecting from welders

### DIFF
--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -454,18 +454,18 @@
 		if(!E)
 			return
 		if(E.welding_proof)
-			usr.simple_message("<span class='notice'>Your eyelenses darken to accomodate for the welder's glow</span>")
+			user.simple_message("<span class='notice'>Your eyelenses darken to accommodate for the welder's glow.</span>")
 			return
 		if(safety < 2)
 			switch(safety)
 				if(1)
-					usr.simple_message("<span class='warning'>Your eyes sting a little.</span>",\
+					user.simple_message("<span class='warning'>Your eyes sting a little.</span>",\
 						"<span class='warning'>You shed a tear.</span>")
 					E.damage += rand(1, 2)
 					if(E.damage > 12)
 						user.eye_blurry += rand(3,6)
 				if(0)
-					usr.simple_message("<span class='warning'>Your eyes burn.</span>",\
+					user.simple_message("<span class='warning'>Your eyes burn.</span>",\
 						"<span class='warning'>Some tears fall down from your eyes.</span>")
 					E.damage += rand(2, 4)
 					if(E.damage > 10)
@@ -474,7 +474,7 @@
 					var/obj/item/clothing/to_blame = H.head //blame the hat
 					if(!to_blame || (istype(to_blame) && H.glasses && H.glasses.eyeprot < to_blame.eyeprot)) //if we don't have a hat, the issue is the glasses. Otherwise, if the glasses are worse, blame the glasses
 						to_blame = H.glasses
-					usr.simple_message("<span class='warning'>Your [to_blame] intensifies the welder's glow. Your eyes itch and burn severely.</span>",\
+					user.simple_message("<span class='warning'>Your [to_blame] intensifies the welder's glow. Your eyes itch and burn severely.</span>",\
 						"<span class='warning'>Somebody's cutting onions.</span>")
 					user.eye_blurry += rand(12,20)
 					E.damage += rand(12, 16)

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -453,6 +453,9 @@
 		var/datum/organ/internal/eyes/E = H.internal_organs_by_name["eyes"]
 		if(!E)
 			return
+		if(E.welding_proof)
+			usr.simple_message("<span class='notice'>Your eyelenses darken to accomodate for the welder's glow</span>")
+			return
 		if(safety < 2)
 			switch(safety)
 				if(1)


### PR DESCRIPTION
There's a variable called welding_proof in eyes, that was never used in anything. By assumption it's only used for welder protection rather than protecting against flashes (Whichshould be eyeprot, considering what it's used in.)

Guess now you don't need goggles or helmets to weld.
