### PR TITLE
You know I probably shouldn't complain about how long this took because I also didn't do it but come on I said how to fix it two weeks ago

### DIFF
--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -27,7 +27,7 @@
 		var/obj/item/clothing/under/U = new /obj/item/clothing/under/rank/captain(H)
 		var/obj/item/clothing/accessory/medal/gold/captain/medal = new
 		U.accessories += medal
-		medal.on_attached(null, U)
+		medal.on_attached(U, null)
 		H.equip_or_collect(U, slot_w_uniform)
 		//H.equip_or_collect(new /obj/item/device/pda/captain(H), slot_belt)
 		H.equip_or_collect(new /obj/item/clothing/shoes/brown(H), slot_shoes)


### PR DESCRIPTION
The roundstart Medal of Captaincy is no longer (accidentally) permanently fused to the jumpsuit, thus rendering the jumpsuit irremovable

And by the way I have justification for not fixing it when I found the problem, just not for not fixing it the next day

Fixes #10121

This is, by the way, tested, even though that probably wasn't necessary
