### PR TITLE
Allows Alt+click turf contents listing to be used on any tile you can see

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -246,7 +246,7 @@
 		src:give_item(user)
 		return
 	var/turf/T = get_turf(src)
-	if(T && T.Adjacent(user))
+	if(T) //Even if shenanigans are used to Alt+click on something you can't see (which is difficult, though not impossible), the check in Stat() will immediately close the Alt+click statpanel anyway
 		if(user.listed_turf == T)
 			user.listed_turf = null
 		else

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -235,7 +235,6 @@
 
 /*
 	Alt click
-	Unused except for AI
 */
 /mob/proc/AltClickOn(var/atom/A)
 	A.AltClick(src)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1432,7 +1432,7 @@ var/list/slot_equipment_priority = list( \
 					stat(null, "processScheduler is not running.")
 	if(client && client.inactivity < (1200))
 		if(listed_turf)
-			if(get_dist(listed_turf,src) > 1)
+			if(!(listed_turf in view(client.view, src)))
 				listed_turf = null
 			else if(statpanel(listed_turf.name))
 				statpanel(listed_turf.name, null, listed_turf)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1432,7 +1432,7 @@ var/list/slot_equipment_priority = list( \
 					stat(null, "processScheduler is not running.")
 	if(client && client.inactivity < (1200))
 		if(listed_turf)
-			if(!(listed_turf in view(client.view, src)))
+			if(!(listed_turf in view(client.view, client.eye)))
 				listed_turf = null
 			else if(statpanel(listed_turf.name))
 				statpanel(listed_turf.name, null, listed_turf)

--- a/html/changelogs/rangedlisting.yml
+++ b/html/changelogs/rangedlisting.yml
@@ -3,4 +3,4 @@ author: Exxion
 delete-after: True
 
 changes: 
-- tweak: Alt+clicking to list everything on a tile now works on any tile you can see. You still can't actually interact with things unless they're adjacent to you, of course.
+- tweak: "Alt+clicking to list everything on a tile now works on any tile you can see. You still can't actually interact with things unless they're adjacent to you, of course."

--- a/html/changelogs/rangedlisting.yml
+++ b/html/changelogs/rangedlisting.yml
@@ -1,0 +1,6 @@
+author: Exxion
+
+delete-after: True
+
+changes: 
+- tweak: Alt+clicking to list everything on a tile now works on any tile you can see. You still can't actually interact with things unless they're adjacent to you, of course.


### PR DESCRIPTION
Someone clearly intended this to only work on adjacent tiles, but I can't figure out why. It doesn't let you do anything right clicking doesn't already let you do anyway, but it doesn't have the lag problem associated with right clicking.

Now it still only works on tiles you can see. If the inspected tile leaves your vision due to distance, darkness, or obstruction (or anything else I didn't think of), the list of stuff disappears, like already happens if you move away from the inspected tile.
