### PR TITLE
Change Meteors to use Universal State code

### DIFF
--- a/code/game/gamemodes/endgame/endgame.dm
+++ b/code/game/gamemodes/endgame/endgame.dm
@@ -49,6 +49,10 @@
 	if(decay_rate && prob(decay_rate))
 		DecayTurf(T)
 
+// In the event you just need something called every tick, here it is
+/datum/universal_state/proc/process()
+	return 0
+
 // Apply changes when exiting state
 /datum/universal_state/proc/OnExit()
  	// Does nothing by default

--- a/code/game/gamemodes/meteor/meteor.dm
+++ b/code/game/gamemodes/meteor/meteor.dm
@@ -33,7 +33,8 @@
 		message_admins("Meteor storm confirmed by Space Weather Incorporated. Announcement arrives in approximately [round((meteor_announce_delay-200)/600)] minutes, further information will be given then.")
 
 	spawn(rand(waittime_l, waittime_h))
-		if(!mixed) send_intercept()
+		if(!mixed)
+			send_intercept()
 
 	spawn(meteor_announce_delay)
 

--- a/code/game/gamemodes/meteor/meteor.dm
+++ b/code/game/gamemodes/meteor/meteor.dm
@@ -2,18 +2,13 @@
 	name = "meteor"
 	config_tag = "meteor"
 
-	var/const/waittime_l = 600 //Lower bound on time before intercept arrives (in tenths of seconds)
-	var/const/waittime_h = 1800 //Upper bound on time before intercept arrives (in tenths of seconds)
+	var/const/waittime_l = 600 //Lower interval on time before intercept arrives (in tenths of seconds)
+	var/const/waittime_h = 1800 //Upper interval on time before intercept arrives (in tenths of seconds)
 
-	var/const/meteorannouncedelay_l = 2100 //Lower bound on announcement, here 3 minutes and 30 seconds
-	var/const/meteorannouncedelay_h = 3000 //Upper bound on announcement, here 5 minutes
-	var/meteorannouncedelay = 2400 //Default final announcement delay
-	var/const/supplydelay = 100 //Delay before meteor supplies are spawned in tenth of seconds
-	var/const/meteordelay_l = 4500 //Lower bound to meteor wave arrival, here 7.5 minutes
-	var/const/meteordelay_h = 6000 //Higher bound to meteor wave arrival, here 10 minutes
-	var/const/meteorshuttlemultiplier = 3 //How much more will we need to hold out ? Here 30 minutes until the shuttle arrives. Multiplies by 10
-	var/meteordelay = 7500 //Default final meteor delay
-	var/meteors_allowed = 0 //Can we send the meteors ?
+	var/const/meteor_announce_delay_l = 2100 //Lower interval on announcement, here 3 minutes and 30 seconds
+	var/const/meteor_announce_delay_h = 3000 //Upper interval on announcement, here 5 minutes
+	var/meteor_announce_delay = 2400 //Default final announcement delay
+
 	required_players = 0
 	required_players_secret = 20
 
@@ -29,62 +24,110 @@
 	message_admins("Starting a round of meteor.")
 	return 1
 
-/datum/universal_state/meteor_storm
- 	name = "Meteor Storm"
- 	desc = "A meteor storm is currently wrecking havoc around this sector. Duck and cover."
+/datum/game_mode/meteor/post_setup()
 
- 	decay_rate = 0 //Just to make sure
+	//Let's set up the announcement and meteor delay immediatly to send to the admins and use later
+	meteor_announce_delay = rand((meteor_announce_delay_l/600), (meteor_announce_delay_h/600)) * 600 //Minute interval for simplicity
+
+	spawn(300) //Give everything 30 seconds to initialize, this does not delay the rest of post_setup() nor the game and ensures deadmins aren't aware in advance and the admins are
+		message_admins("Meteor storm confirmed by Space Weather Incorporated. Announcement arrives in approximately [round((meteor_announce_delay-200)/600)] minutes, further information will be given then.")
+
+	spawn(rand(waittime_l, waittime_h))
+		if(!mixed) send_intercept()
+
+	spawn(meteor_announce_delay)
+
+		meteor_universal_state()
+
+/datum/universal_state/meteor_storm
+	name = "Meteor Storm"
+	desc = "A meteor storm is currently wrecking havoc around this sector. Duck and cover."
+
+	decay_rate = 0 //Just to make sure
+
+	var/meteor_extra_announce_delay = 0 //Independent from the gamemode delay. Delay from firing universal state before stuff happens
+
+	var/supply_delay = 100 //Delay before meteor supplies are spawned in tenth of seconds
+
+	var/meteor_shuttle_multiplier = 3 //How much more will we need to hold out ? Here 30 minutes until the shuttle arrives. Multiplies by 10
+
+	var/const/meteor_delay_l = 4500 //Lower interval to meteor wave arrival, here 7.5 minutes
+	var/const/meteor_delay_h = 6000 //Higher interval to meteor wave arrival, here 10 minutes
+	var/meteor_delay = 0 //Final meteor delay, must be defined as 0 to automatically generate
+
+	var/meteors_allowed = 0 //Can we send the meteors ?
+
+	var/meteor_wave_size_l = 150 //Lower interval to meteor wave size
+	var/meteor_wave_size_h = 200 //Higher interval to meteor wave size
+
+//We want a ton of extra variables to allow us to do fancy things with it
+//We can't inherit directly because of a host of reasons, all good I assure you
+/proc/meteor_universal_state(var/on_exit = 1, var/extra_delay = 100, var/supply_delay = 100, var/shuttle_mult = 3, var/delay = 0, var/size_l = 150, var/size_h = 200)
+
+	if(on_exit)
+		universe.OnExit()
+
+	var/datum/universal_state/meteor_storm/meteor_storm = new /datum/universal_state/meteor_storm
+
+	meteor_storm.meteor_extra_announce_delay = extra_delay
+	meteor_storm.supply_delay = supply_delay
+	meteor_storm.meteor_shuttle_multiplier = shuttle_mult
+	meteor_storm.meteor_delay = delay
+	meteor_storm.meteor_wave_size_l = size_l
+	meteor_storm.meteor_wave_size_h = size_h
+
+	meteor_storm.OnEnter()
 
 /datum/universal_state/meteor_storm/OnShuttleCall(var/mob/user)
 	if(user)
 		to_chat(user, "<span class='sinister'>You hear an automatic dispatch from Nanotrasen. It states that Centcomm is being shielded due to an incoming meteor storm and that regular shuttle service has been interrupted.</span>")
 	return 0
 
-/datum/game_mode/meteor/post_setup()
+/datum/universal_state/meteor_storm/OnEnter()
 
-	//Let's set up the announcement and meteor delay immediatly to send to the admins and use later
-	meteorannouncedelay = rand((meteorannouncedelay_l/600), (meteorannouncedelay_h/600))*600 //Minute interval for simplicity
-	meteordelay = rand((meteordelay_l/600), (meteordelay_h/600))*600 //Ditto above
+	sleep(meteor_extra_announce_delay) //Pause everything as according to the extra delay
 
-	spawn(450) //Give everything 45 seconds to initialize, this does not delay the rest of post_setup() nor the game and ensures deadmins aren't aware in advance and the admins are
-		message_admins("Meteor storm confirmed by Space Weather Incorporated. Announcement arrives in [round((meteorannouncedelay-450)/600)] minutes, actual meteors in [round((meteordelay+meteorannouncedelay-450)/600)] minutes. Shuttle will take [10*meteorshuttlemultiplier] minutes to arrive and supplies will be dispatched in the Bar.")
+	world << sound('sound/machines/warning.ogg') //The same chime as the Delta countdown, just twice
 
-	spawn(rand(waittime_l, waittime_h))
-		if(!mixed) send_intercept()
+	if(!meteor_delay)
+		meteor_delay = rand((meteor_delay_l/600), (meteor_delay_h/600))*600 //Let's set up the meteor delay in here
 
-	spawn(meteorannouncedelay)
-		if(prob(70)) //Slighty off-scale
-			command_alert("A meteor storm has been detected in proximity of [station_name()] and is expected to strike within [round((rand(meteordelay - 600, meteordelay + 600))/600)] minutes. A backup emergency shuttle is being dispatched and emergency gear should be teleported into your station's Bar area in [supplydelay/10] seconds.", \
-			"Space Weather Automated Announcements",alert='sound/AI/meteorround.ogg')
-		else //Oh boy
-			command_alert("A meteor storm has been detected in proximity of [station_name()] and is expected to strike within [round((rand(meteordelay - 1800, meteordelay + 1800))/600)] minutes. A backup emergency shuttle is being dispatched and emergency gear should be teleported into your station's Bar area in [supplydelay/10] seconds.", \
-			"Space Weather Automated Announcements",alert='sound/AI/meteorround.ogg')
-		/*
-		for(var/obj/item/mecha_parts/mecha_equipment/tool/rcd/rcd in world) //Borg RCDs are fairly cheap, so disabling those
-			rcd.disabled = 1
-		*/
+	sleep(20) //Two seconds for warning to play
 
-		spawn(100) //Panic interval
-			emergency_shuttle.incall(meteorshuttlemultiplier)
-			captain_announce("A backup emergency shuttle has been called. It will arrive in [round((emergency_shuttle.timeleft())/60)] minutes. Justification : 'Major meteor storm inbound. Evacuation procedures deferred to Space Weather Inc. THIS IS NOT A DRILL'")
-			world << sound('sound/AI/shuttlecalled.ogg')
-			SetUniversalState(/datum/universal_state/meteor_storm)
+	if(prob(70)) //Slighty off-scale
+		command_alert("A meteor storm has been detected in proximity of [station_name()] and is expected to strike within [round((rand(meteor_delay - 600, meteor_delay + 600))/600)] minutes. A backup emergency shuttle is being dispatched and emergency gear should be teleported into your station's Bar area in [supply_delay/10] seconds.", \
+		"Space Weather Automated Announcements", alert = 'sound/AI/meteorround.ogg')
+	else //Oh boy
+		command_alert("A meteor storm has been detected in proximity of [station_name()] and is expected to strike within [round((rand(meteor_delay - 1800, meteor_delay + 1800))/600)] minutes. A backup emergency shuttle is being dispatched and emergency gear should be teleported into your station's Bar area in [supply_delay/10] seconds.", \
+		"Space Weather Automated Announcements", alert = 'sound/AI/meteorround.ogg')
 
-		spawn(supplydelay)
+	message_admins("Meteor Storm announcement given. Meteors will arrive in approximately [round(meteor_delay/600)] minutes. Shuttle will take [10*meteor_shuttle_multiplier] minutes to arrive and supplies are about to be dispatched in the Bar.")
 
-			meteor_initial_supply() //Handled in meteor_supply.dm
+	spawn(100) //Time for the announcement to spell out)
 
-		spawn(meteordelay)
+		emergency_shuttle.incall(meteor_shuttle_multiplier)
+		captain_announce("A backup emergency shuttle has been called. It will arrive in [round((emergency_shuttle.timeleft())/60)] minutes. Justification : 'Major meteor storm inbound. Evacuation procedures deferred to Space Weather Inc. THIS IS NOT A DRILL'")
+		world << sound('sound/AI/shuttlecalled.ogg')
+
+	spawn(supply_delay) //Panic inverval
+
+		meteor_initial_supply() //Handled in meteor_supply.dm
+
+		ticker.StartThematic("endgame") //We can start building up now and then. If someone feels like this gamemode deserves a unique music playlist, they can go ahead and do that
+
+		spawn(meteor_delay)
 			meteors_allowed = 1
 
-/datum/game_mode/meteor/process()
+/datum/universal_state/meteor_storm/process()
 	if(meteors_allowed)
-		var/meteors_in_wave = rand(150, 200) //Between 150 and 200 meteors per wave
+		var/meteors_in_wave = rand(meteor_wave_size_l, meteor_wave_size_h)
 		meteor_wave(meteors_in_wave, 3)
 	return
 
+//Important note : This will only fire if the Meteors gamemode was fired
 /datum/game_mode/meteor/declare_completion()
 	var/text
+	var/escapees = 0
 	var/survivors = 0
 	for(var/mob/living/player in player_list)
 		if(player.stat != DEAD)
@@ -94,16 +137,22 @@
 			switch(location.loc.type)
 				if(/area/shuttle/escape/centcom)
 					text += "<br><b><font size=2>[player.real_name] escaped on the emergency shuttle</font></b>"
+					escapees++
+					survivors++
 				if(/area/shuttle/escape_pod1/centcom, /area/shuttle/escape_pod2/centcom, /area/shuttle/escape_pod3/centcom, /area/shuttle/escape_pod5/centcom)
 					text += "<br><font size=2>[player.real_name] escaped in a life pod.</font>"
+					escapees++
+					survivors++
 				else
-					text += "<br><font size=1>[player.real_name] survived but is stranded without any hope of rescue.</font>"
-			survivors++
+					text += "<br><font size=1>[player.real_name] is stranded in outer space without any hope of rescue.</font>"
+					survivors++
 
-	if(survivors)
-		to_chat(world, "<span class='info'><B>The following survived the meteor storm</B>:[text]</span>")
+	if(escapees)
+		to_chat(world, "<span class='info'><B>The following escaped from the meteor storm</B>:[text]</span>")
+	else if(survivors)
+		to_chat(world, "<span class='info'><B>No-one escaped the meteor storm. The following are still alive for now</B>:[text]</span>")
 	else
-		to_chat(world, "<span class='info'><B>The meteors crashed this station with no survivors!</B></span>")
+		to_chat(world, "<span class='info'><B>The meteor storm crashed this station with no survivors!</B></span>")
 
 	feedback_set_details("round_end_result", "end - evacuation")
 	feedback_set("round_end_result", survivors)

--- a/code/game/gamemodes/meteor/meteor_supply.dm
+++ b/code/game/gamemodes/meteor/meteor_supply.dm
@@ -1,4 +1,4 @@
-/datum/game_mode/meteor/proc/meteor_initial_supply()
+/datum/universal_state/meteor_storm/proc/meteor_initial_supply()
 
 	var/list/meteor_initial_drop = list(/obj/structure/closet/crate/engi/meteor_materials, \
 	/obj/structure/closet/crate/meteor_assorted_protection, \

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -798,6 +798,7 @@ var/global/floorIsLava = 0
 			<BR>
 			<A href='?src=\ref[src];secretsfun=hellonearth'>Summon Nar-Sie</A><BR>
 			<A href='?src=\ref[src];secretsfun=supermattercascade'>Start a Supermatter Cascade</A><BR>
+			<A href='?src=\ref[src];secretsfun=meteorstorm'>Trigger an undending Meteor Storm</A><BR>
 			"}
 
 	if(check_rights(R_SERVER,0))

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2914,19 +2914,35 @@
 			if("hellonearth")
 				feedback_inc("admin_secrets_fun_used",1)
 				feedback_add_details("admin_secrets_fun_used","NS")
-				var/choice = input("You sure you want to end the round and summon narsie at your location? Misuse of this could result in removal of flags or halarity.") in list("PRAISE SATAN", "Cancel")
+				var/choice = input("You sure you want to end the round and summon narsie at your location? Misuse of this could result in removal of flags or hilarity.") in list("PRAISE SATAN", "Cancel")
 				if(choice == "PRAISE SATAN")
 					new /obj/machinery/singularity/narsie/large(get_turf(usr))
 					message_admins("[key_name_admin(usr)] has summoned narsie and brought about a new realm of suffering.")
 			if("supermattercascade")
 				feedback_inc("admin_secrets_fun_used",1)
 				feedback_add_details("admin_secrets_fun_used","SC")
-				var/choice = input("You sure you want to destroy the universe and create a large explosion at your location? Misuse of this could result in removal of flags or halarity.") in list("NO TIME TO EXPLAIN", "Cancel")
+				var/choice = input("You sure you want to destroy the universe and create a large explosion at your location? Misuse of this could result in removal of flags or hilarity.") in list("NO TIME TO EXPLAIN", "Cancel")
 				if(choice == "NO TIME TO EXPLAIN")
 					explosion(get_turf(usr), 8, 16, 24, 32, 1)
 					new /turf/unsimulated/wall/supermatter(get_turf(usr))
 					SetUniversalState(/datum/universal_state/supermatter_cascade)
 					message_admins("[key_name_admin(usr)] has managed to destroy the universe with a supermatter cascade. Good job, [key_name_admin(usr)]")
+			if("meteorstorm")
+				feedback_inc("admin_secrets_fun_used",1)
+				feedback_add_details("admin_secrets_fun_used","MS")
+				var/choice = input("Are you sure you want to summon an unending hail of meteors and force station evacuation? This will only work properly if the shuttle is not in use. Misuse of this could result in removal of flags or hilarity.") in list("BRING ME MY FRIDGE", "Cancel")
+				if(choice == "BRING ME MY FRIDGE")
+					//We go through a boring amount of variable prompts first
+					var/extra_delay = input("Input an extra delay before warning and announcement, in tenths of seconds. Default is 100", 100) as num|null
+					var/supply_delay = input("Input an extra delay before supply, in tenths of seconds; Default is 100", 100) as num|null
+					var/shuttle_delay = input("Input a shuttle delay multiplier, times ten minutes. Default is 3", 3) as num|null
+					var/meteor_delay = input("Input the delay before meteors start striking, in tenths of seconds. Keep null to generate between 7.5 to 10 minutes. Default is null", 0) as num|null
+					var/meteor_size_l = input("Input a lower interval on the amount of meteors per wave. Default is 150", 150) as num|null
+					var/meteor_size_h = input("Input an upper interval on the amount of meteors per wave. Default is 200", 200) as num|null
+					var/choice_second = input("Are you still sure you want to summon a meteor storm? Misuse of this could result in removal of flags or hilarity.") in list("WORKED FOR INDIANA JONES", "Cancel")
+					if(choice_second == "WORKED FOR INDIANA JONES")
+						meteor_universal_state(1, extra_delay, supply_delay, shuttle_delay, meteor_delay, meteor_size_l, meteor_size_h)
+						message_admins("[key_name_admin(usr)] has summoned an unending meteor storm upon the station. Go ahead and ask him for the details, don't forget to scream at him.")
 			if("mobswarm")
 				feedback_inc("admin_secrets_fun_used",1)
 				feedback_add_details("admin_secrets_fun_used","MS")


### PR DESCRIPTION
There shouldn't have been any gameplay change, this is solely a refactor
- Meteor Storm Universal State now handles all the meteor storm stuff, like calling the shuttle, spawning supplies and spawning meteor waves
- Meteor gamemode is still around but has been trimmed to only handle delay to announcement, at which point it passes the task to the universal state handler
- Added a proc that handles passing variables to the meteor's universal state specifically
- Added a buzzer sound (warning.ogg, file already existed but wasn't used) just before announcement for ambiance and what not
- Added a new verb under Secrets that triggers the Meteor Storm universal state (just like Nar'Sie and Supermatter)
- Tweaked the end game results

Due to the shuttle controller (the one that handles shuttle calls, not the brand new shuttle controller we added a few months ago) being complete spaghetti, the meteor storm event does not handle the shuttle well. AKA, warning was given to not fire this if the shuttle has been called. Otherwise, it doesn't apply the proper time or does other very weird stuff. Up to the admins to not fuck up, I have given proper written warning in the actual verb

Should not affect meteor gamemode since the shuttle is called before shuttle calls are allowed
