### PR TITLE
Rebalance RPGs for new explosions

### DIFF
--- a/code/modules/projectiles/projectile/rocket.dm
+++ b/code/modules/projectiles/projectile/rocket.dm
@@ -25,9 +25,10 @@
 			pixel_y = PixelY
 		sleep(picked_up_speed)
 
-/obj/item/projectile/rocket/Bump(var/atom/rocket)
-	explosion(rocket, -1, 1, 4, 8)
-	qdel(src)
+/obj/item/projectile/rocket/Bump(var/atom/A)
+	explosion(A, 1, 4, 6, 8) //RPGs pack a serious punch and will cause massive structural damage in your average room, but won't punch through reinforced walls
+	if(src)
+		qdel(src)
 
 /obj/item/projectile/nikita
 	name = "\improper Nikita missile"
@@ -98,7 +99,7 @@
 /obj/item/projectile/nikita/Bumped(var/atom/A)
 	if(emagged && (A == mob))
 		return
-	detonate()
+	detonate(A)
 
 /obj/item/projectile/nikita/process_step()
 	if(!emagged && !check_user())//if the original user dropped the Nikita and the missile is still in the air, we check if someone picked it up.
@@ -153,8 +154,8 @@
 		return 0
 	return 1
 
-/obj/item/projectile/nikita/proc/detonate(var/explosion = loc)
-	explosion(explosion, -1, 1, 4, 8)
+/obj/item/projectile/nikita/proc/detonate(var/atom/A)
+	explosion(A, 1, 4, 6, 8) //Nikita rockets pack a serious punch and will cause massive structural damage in your average room, but won't punch through reinforced walls
 	if(src)
 		qdel(src)
 

--- a/code/modules/projectiles/projectile/rocket.dm
+++ b/code/modules/projectiles/projectile/rocket.dm
@@ -27,7 +27,7 @@
 
 /obj/item/projectile/rocket/Bump(var/atom/A)
 	explosion(A, 1, 4, 6, 8) //RPGs pack a serious punch and will cause massive structural damage in your average room, but won't punch through reinforced walls
-	if(src)
+	if(!gcDestroyed)
 		qdel(src)
 
 /obj/item/projectile/nikita
@@ -156,7 +156,7 @@
 
 /obj/item/projectile/nikita/proc/detonate(var/atom/A)
 	explosion(A, 1, 4, 6, 8) //Nikita rockets pack a serious punch and will cause massive structural damage in your average room, but won't punch through reinforced walls
-	if(src)
+	if(!gcDestroyed)
 		qdel(src)
 
 /obj/item/projectile/nikita/proc/reset_view()

--- a/code/modules/projectiles/projectile/rocket.dm
+++ b/code/modules/projectiles/projectile/rocket.dm
@@ -26,7 +26,7 @@
 		sleep(picked_up_speed)
 
 /obj/item/projectile/rocket/Bump(var/atom/A)
-	explosion(A, 1, 4, 6, 8) //RPGs pack a serious punch and will cause massive structural damage in your average room, but won't punch through reinforced walls
+	explosion(A, 1, 3, 5, 8) //RPGs pack a serious punch and will cause massive structural damage in your average room, but won't punch through reinforced walls
 	if(!gcDestroyed)
 		qdel(src)
 
@@ -155,7 +155,7 @@
 	return 1
 
 /obj/item/projectile/nikita/proc/detonate(var/atom/A)
-	explosion(A, 1, 4, 6, 8) //Nikita rockets pack a serious punch and will cause massive structural damage in your average room, but won't punch through reinforced walls
+	explosion(A, 1, 3, 5, 8) //Nikita rockets pack a serious punch and will cause massive structural damage in your average room, but won't punch through reinforced walls
 	if(!gcDestroyed)
 		qdel(src)
 


### PR DESCRIPTION
Rocket propelled grenades are explosive, very explosive. There's no fancy armor penetration patterns, they just blow up really hard when they hit something
- Changed explosion radii of RPGs from -1, 1, 4 to 1, 3, 5

This should make RPGs much more worthwhile for destruction and "crowd control", although they are still subpar for breaking into places, compared to a brick of C4 which can punch through a wall instead of exploding against it

Fixes #10294
