### PR TITLE
Restricts weighted map voting with configurable filters

### DIFF
--- a/code/modules/html_interface/voting/vote_filter.dm
+++ b/code/modules/html_interface/voting/vote_filter.dm
@@ -1,0 +1,44 @@
+/datum/vote_filter/proc/filter_vote_list(list/votes)
+
+/datum/vote_filter/rank_filter
+	//A value of 0 is no filtering
+	var/minimum_ranking = 2
+
+/datum/vote_filter/rank_filter/New(var/min_rank)
+	if(isnum(min_rank))
+		minimum_ranking = min_rank
+
+/datum/vote_filter/rank_filter/filter_vote_list(list/votes)
+	//Removes the least-weighted choice from picking so long as the list is too large
+	if(minimum_ranking > 0)
+		while(votes.len > minimum_ranking)
+			var/smallest = null
+			for (var/choice in votes)
+				if(!smallest || votes[choice] < votes[smallest])
+					smallest = choice
+
+			votes -= smallest
+
+/datum/vote_filter/share_filter
+	var/minimum_share = 0.2
+
+/datum/vote_filter/share_filter/New(var/min_share)
+	if(isnum(min_share))
+		//Can't have less than no votes or more than all the votes
+		minimum_share = Clamp(min_share, 0, 1)
+
+/datum/vote_filter/share_filter/filter_vote_list(list/votes)
+	var/total = 0
+
+	for(var/choice in votes)
+		total += votes[choice]
+
+	//We use a list to avoid modifying votes while we for over it
+	var/list/bad_choices = new /list()
+
+	for(var/choice in votes)
+		//We got too few votes to be a choice
+		if(votes[choice]/total < minimum_share)
+			bad_choices += choice
+
+	votes -= bad_choices

--- a/code/modules/html_interface/voting/voting.dm
+++ b/code/modules/html_interface/voting/voting.dm
@@ -4,7 +4,6 @@ var/global/datum/controller/vote/vote = new()
 #define VOTE_SCREEN_WIDTH 400
 #define VOTE_SCREEN_HEIGHT 400
 
-
 /datum/html_interface/nanotrasen/vote/registerResources()
 	. = ..()
 
@@ -48,6 +47,7 @@ var/global/datum/controller/vote/vote = new()
 	var/lastupdate     = 0
 	var/total_votes    = 0
 	var/weighted        = FALSE // Whether to use weighted voting.
+	var/datum/vote_filter/vote_filter = new /datum/vote_filter/share_filter(0.1)
 
 /datum/controller/vote/New()
 	. = ..()
@@ -147,6 +147,10 @@ var/global/datum/controller/vote/vote = new()
 		for(var/a in filteredchoices)
 			if(!filteredchoices[a])
 				filteredchoices -= a //Remove choices with 0 votes, as pickweight gives them 1 vote
+
+		//Filters out choices based on the filter
+		vote_filter.filter_vote_list(filteredchoices)
+
 		if(filteredchoices.len)
 			. += pickweight(filteredchoices.Copy())
 	else

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -1131,6 +1131,7 @@
 #include "code\modules\html_interface\map\crew\crew.dm"
 #include "code\modules\html_interface\nanotrasen\nanotrasen.dm"
 #include "code\modules\html_interface\RCD\RCD.dm"
+#include "code\modules\html_interface\voting\vote_filter.dm"
 #include "code\modules\html_interface\voting\voting.dm"
 #include "code\modules\hydroponics\_hydro_setup.dm"
 #include "code\modules\hydroponics\eggincubator.dm"


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.
-->

There is an option to disable this filtering.
This stops players putting down a vote for a single map and that winning when there are multiple choices.
Filters include a minimum share of total vote filter, and a minimum vote rank filter.

The code is currently set to remove options with less than 10% of the vote.
