### PR TITLE
Inventory QoL Changes.

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -145,6 +145,7 @@
 
 	if(display_contents_with_number)
 		for(var/datum/numbered_display/ND in display_contents)
+			ND.sample_object.mouse_opacity = 2
 			ND.sample_object.screen_loc = "[cx]:16,[cy]:16"
 			ND.sample_object.maptext = "<font color='white'>[(ND.number > 1)? "[ND.number]" : ""]</font>"
 			ND.sample_object.layer = 20
@@ -154,6 +155,7 @@
 				cy--
 	else
 		for(var/obj/O in contents)
+			O.mouse_opacity = 2 //This is here so storage items that spawn with contents correctly have the "click around item to equip"
 			O.screen_loc = "[cx]:16,[cy]:16"
 			O.maptext = ""
 			O.layer = 20
@@ -327,6 +329,7 @@
 		src.orient2hud(usr)
 		if(usr.s_active)
 			usr.s_active.show_to(usr)
+	W.mouse_opacity = 2 //So you can click on the area around the item to equip it, instead of having to pixel hunt
 	update_icon()
 	return 1
 
@@ -375,6 +378,7 @@
 	W.layer = initial(W.layer)
 	W.on_exit_storage(src)
 	update_icon()
+	W.mouse_opacity = initial(W.mouse_opacity)
 	return 1
 
 //This proc is called when you want to place an item into the storage item.

--- a/code/modules/mob/living/silicon/mommi/mommi_modules.dm
+++ b/code/modules/mob/living/silicon/mommi/mommi_modules.dm
@@ -33,7 +33,7 @@
 	W.amount = 50
 	W.max_amount = 50 // Override MAXCOIL
 	src.modules += W
-	return
+	fix_modules()
 
 /obj/item/weapon/robot_module/mommi/respawn_consumable(var/mob/living/silicon/robot/R)
 	var/list/what = list (

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -18,7 +18,7 @@
 /mob/living/silicon/robot/proc/uneq_module(const/obj/item/module)
 	if(!istype(module))
 		return 0
-
+	module.mouse_opacity = 2
 	if(client)
 		client.screen -= module
 
@@ -71,16 +71,19 @@
 		to_chat(src, "<span class='notice'>Already activated</span>")
 		return
 	if(!module_state_1)
+		O.mouse_opacity = initial(O.mouse_opacity)
 		module_state_1 = O
 		O.layer = 20
 		O.screen_loc = inv1.screen_loc
 		O.forceMove(src)
 	else if(!module_state_2)
+		O.mouse_opacity = initial(O.mouse_opacity)
 		module_state_2 = O
 		O.layer = 20
 		O.screen_loc = inv2.screen_loc
 		O.forceMove(src)
 	else if(!module_state_3)
+		O.mouse_opacity = initial(O.mouse_opacity)
 		module_state_3 = O
 		O.layer = 20
 		O.screen_loc = inv3.screen_loc

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -357,7 +357,7 @@ obj/item/weapon/robot_module/proc/fix_modules() //call this proc to enable click
 	R.my_atom = src.emag
 	R.add_reagent("beer2", 50)
 	src.emag.name = "Mickey Finn's Special Brew"
-	return
+	fix_modules()
 
 
 

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -52,6 +52,11 @@
 //		src.jetpack.name = "Placeholder Upgrade Item"
 	return
 
+obj/item/weapon/robot_module/proc/fix_modules() //call this proc to enable clicking the slot of a module to equip it.
+	for(var/obj/item/I in modules)
+		I.mouse_opacity = 2
+	if(emag)
+		emag.mouse_opacity = 2
 
 /obj/item/weapon/robot_module/proc/respawn_consumable(var/mob/living/silicon/robot/R)
 	return
@@ -90,7 +95,7 @@
 	O.amount = 15
 	src.modules += O
 
-	return
+	fix_modules()
 
 /obj/item/weapon/robot_module/standard/respawn_consumable(var/mob/living/silicon/robot/R)
 	// Recharge baton battery
@@ -159,7 +164,7 @@
 	S.amount = 10
 	src.modules += S
 
-	return
+	fix_modules()
 
 /obj/item/weapon/robot_module/medical/respawn_consumable(var/mob/living/silicon/robot/R)
 	var/list/what = list (
@@ -210,7 +215,7 @@
 	W.max_amount = 50
 	src.modules += W
 
-	return
+	fix_modules()
 
 
 /obj/item/weapon/robot_module/engineering/respawn_consumable(var/mob/living/silicon/robot/R)
@@ -262,7 +267,7 @@
 	src.modules += new /obj/item/weapon/crowbar(src)
 	src.emag = new /obj/item/weapon/gun/energy/laser/cyborg(src)
 	sensor_augs = list("Security", "Medical", "Disable")
-	return
+	fix_modules()
 
 /obj/item/weapon/robot_module/security/respawn_consumable(var/mob/living/silicon/robot/R)
 	// Recharge baton battery
@@ -288,7 +293,7 @@
 
 	src.emag.reagents.add_reagent("lube", 250)
 	src.emag.name = "Lube spray"
-	return
+	fix_modules()
 
 
 
@@ -371,7 +376,7 @@
 	src.modules += new /obj/item/weapon/crowbar(src)
 	sensor_augs = list("Mesons", "Disable")
 //		src.modules += new /obj/item/weapon/pickaxe/shovel(src) Uneeded due to buffed drill
-	return
+	fix_modules()
 
 
 /obj/item/weapon/robot_module/syndicate
@@ -384,7 +389,7 @@
 	src.modules += new /obj/item/weapon/card/emag(src)
 	src.modules += new /obj/item/weapon/crowbar(src)
 	sensor_augs = list("Security", "Medical", "Mesons", "Thermal", "Light Amplification", "Disable")
-	return
+	fix_modules()
 
 /obj/item/weapon/robot_module/combat
 	name = "combat robot module"
@@ -399,7 +404,7 @@
 	src.emag = new /obj/item/weapon/gun/energy/lasercannon/cyborg(src)
 	sensor_augs = list("Security", "Medical", "Mesons", "Thermal", "Light Amplification", "Disable")
 
-	return
+	fix_modules()
 
 /obj/item/weapon/robot_module/proc/add_languages(var/mob/living/silicon/robot/R)
 	for(var/language in languages)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -493,6 +493,10 @@ var/global/obj/screen/fuckstat/FUCK = new
 			equip_to_slot_if_possible(W, slot)
 		else if(hand_index)
 			put_in_hand(hand_index, W)
+		else
+			W = get_item_by_slot(slot)
+			if(W)
+				W.attack_hand(src)
 
 	if(ishuman(src) && W == src:head)
 		src:update_hair()

--- a/html/changelogs/letstrythisagain.yml
+++ b/html/changelogs/letstrythisagain.yml
@@ -1,0 +1,5 @@
+author: Albinobigfoot
+delete-after: True
+changes:
+- tweak: You can now grab an item from your inventory by clicking on its storage slot, as if you had selected the item's pixel itself.
+- tweak: "This works for items in storage (e.g. backpacks, boxes, bags, etc.), items on your person (e.g. pockets, suit storage, belt slot, etc.), as well as borg and mommi modules." 


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.
-->
- No more pixel hunting for obnoxiously small sprites. Now you can just click anywhere in an item's  inventory slot and equip/open it.
- Works for storage containers, inventory, and borg/mommi modules.

Don't thank me; most of this was ported, line for line.
Brought to you by: RemieRichards of TG and Tastyfish of Paradise.

Remake of https://github.com/d3athrow/vgstation13/pull/10356

Let's try this again.
