### PR TITLE
Blob cores/nodes/strong blobs are no longer immune to fire/flamethrowers

### DIFF
--- a/code/game/gamemodes/blob/blobs/core.dm
+++ b/code/game/gamemodes/blob/blobs/core.dm
@@ -56,9 +56,6 @@
 	processing_objects.Remove(src)
 	..()
 
-/obj/effect/blob/core/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
-	return
-
 /obj/effect/blob/core/update_health()
 	if(overmind)
 		overmind.update_health()

--- a/code/game/gamemodes/blob/blobs/node.dm
+++ b/code/game/gamemodes/blob/blobs/node.dm
@@ -21,9 +21,6 @@
 	if((blob_looks[looks] == 64) && !no_morph)
 		flick("morph_node",src)
 
-/obj/effect/blob/node/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
-	return
-
 /obj/effect/blob/node/Destroy()
 	blob_nodes -= src
 	if(!manual_remove && overmind)

--- a/code/game/gamemodes/blob/blobs/shield.dm
+++ b/code/game/gamemodes/blob/blobs/shield.dm
@@ -24,9 +24,6 @@
 		return
 	return
 
-/obj/effect/blob/shield/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
-	return
-
 /obj/effect/blob/shield/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(istype(mover) && mover.checkpass(PASSBLOB))	return 1
 	if(mover)


### PR DESCRIPTION
Blob cores/nodes/strong blobs are no longer immune to fire/flamethrowers.

They take half damage that regular blobs do due to the fire_resist var.
