### PR TITLE
Miner borgs now have a dest.tagger and package wrap.

### DIFF
--- a/code/game/objects/items/stacks/cable.dm
+++ b/code/game/objects/items/stacks/cable.dm
@@ -20,6 +20,7 @@ var/global/list/datum/stack_recipe/cable_recipes = list ( \
 	icon_state = "coil_red"
 	gender = NEUTER
 	amount = MAXCOIL
+	restock_amount = 2
 	singular_name = "cable piece"
 	max_amount = MAXCOIL
 	_color = "red"

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/obj/items.dmi'
 	amount = 5
 	max_amount = 5
+	restock_amount = 2
 	w_class = W_CLASS_TINY
 	throw_speed = 4
 	throw_range = 10

--- a/code/game/objects/items/stacks/packagewrap.dm
+++ b/code/game/objects/items/stacks/packagewrap.dm
@@ -7,6 +7,7 @@
 	w_class = W_CLASS_SMALL
 	amount = 24
 	max_amount = 24
+	restock_amount = 2
 	//If it's null, it can't wrap that type.
 	var/smallpath = /obj/item/delivery //We use this for items
 	var/bigpath = /obj/item/delivery/large //We use this for structures (crates, closets, recharge packs, etc.)

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -19,6 +19,7 @@
 	var/perunit = 3750
 	var/max_amount //also see stack recipes initialisation, param "max_res_amount" must be equal to this max_amount
 	var/redeemed = 0 // For selling minerals to central command via supply shuttle.
+	var/restock_amount = 0 //For borg chargers restocking.
 
 /obj/item/stack/New(var/loc, var/amount=null)
 	..()
@@ -339,10 +340,10 @@
 	return ..()
 
 /obj/item/stack/restock()
-	if(istype(src,/obj/item/stack/cable_coil) || istype(src,/obj/item/stack/medical))
-		if(amount < max_amount)
-			amount += 2
-		if(amount > max_amount)
-			amount = max_amount
+	if(!restock_amount) return //Do not restock this stack type
+	if(amount < max_amount)
+		amount += restock_amount
+	if(amount > max_amount)
+		amount = max_amount
 
 #undef CORRECT_STACK_NAME

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -223,7 +223,7 @@
 		sensor = null
 
 /proc/getAvailableRobotModules()
-	var/list/modules = list("Standard", "Engineering", "Medical", "Miner", "Janitor", "Service", "Security")
+	var/list/modules = list("Standard", "Engineering", "Medical", "Supply", "Janitor", "Service", "Security")
 	if(security_level == SEC_LEVEL_RED) //Add crisis to this check if you want to make it available at an admin's whim
 		modules+="Combat"
 	return modules
@@ -273,7 +273,7 @@
 			module_sprites["#27"] = "servbot-service"
 			speed = 0
 
-		if("Miner")
+		if("Supply")
 			module = new /obj/item/weapon/robot_module/miner(src)
 			radio.insert_key(new/obj/item/device/encryptionkey/headset_cargo(radio))
 			if(camera && "Robots" in camera.network)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -110,11 +110,11 @@ obj/item/weapon/robot_module/proc/fix_modules() //call this proc to enable click
 	for (var/T in what)
 		if (!(locate(T) in src.modules))
 			src.modules -= null
-			var/O = new T(src)
+			var/obj/item/stack/O = new T(src)
 			if(istype(O,/obj/item/stack/medical))
-				O:max_amount = 15
+				O.max_amount = 15
 			src.modules += O
-			O:amount = 1
+			O.amount = 1
 	return
 
 
@@ -175,11 +175,11 @@ obj/item/weapon/robot_module/proc/fix_modules() //call this proc to enable click
 	for (var/T in what)
 		if (!(locate(T) in src.modules))
 			src.modules -= null
-			var/O = new T(src)
+			var/obj/item/stack/O = new T(src)
 			if(istype(O,/obj/item/stack/medical))
-				O:max_amount = 15
+				O.max_amount = 15
 			src.modules += O
-			O:amount = 1
+			O.amount = 1
 	return
 
 
@@ -225,11 +225,11 @@ obj/item/weapon/robot_module/proc/fix_modules() //call this proc to enable click
 	for (var/T in what)
 		if (!(locate(T) in src.modules))
 			src.modules -= null
-			var/O = new T(src)
+			var/obj/item/stack/O = new T(src)
 			if(istype(O,/obj/item/stack/cable_coil))
-				O:max_amount = 50
+				O.max_amount = 50
 			src.modules += O
-			O:amount = 1
+			O.amount = 1
 	return
 
 /obj/item/weapon/robot_module/engineering/recharge_consumable(var/mob/living/silicon/robot/R)
@@ -244,14 +244,14 @@ obj/item/weapon/robot_module/proc/fix_modules() //call this proc to enable click
 		respawn_consumable(R)
 		var/list/um = R.contents|R.module.modules
 		// ^ makes sinle list of active (R.contents) and inactive modules (R.module.modules)
-		for(var/obj/O in um)
+		for(var/obj/item/stack/O in um)
 			// Engineering
 			if(istype(O,/obj/item/stack/cable_coil))
-				if(O:amount < 50)
-					O:amount += 1
+				if(O.amount < 50)
+					O.amount += 1
 					R.cell.use(50) 		//Take power from the borg...
-				if(O:amount > 50)
-					O:amount = 50
+				if(O.amount > 50)
+					O.amount = 50
 
 
 /obj/item/weapon/robot_module/security
@@ -348,8 +348,6 @@ obj/item/weapon/robot_module/proc/fix_modules() //call this proc to enable click
 
 	src.modules += new /obj/item/weapon/crowbar(src)
 
-
-
 	src.emag = new /obj/item/weapon/reagent_containers/food/drinks/beer(src)
 
 	var/datum/reagents/R = new/datum/reagents(50)
@@ -362,8 +360,7 @@ obj/item/weapon/robot_module/proc/fix_modules() //call this proc to enable click
 
 
 /obj/item/weapon/robot_module/miner
-	name = "miner robot module"
-
+	name = "supply robot module"
 
 /obj/item/weapon/robot_module/miner/New()
 	..()
@@ -376,8 +373,30 @@ obj/item/weapon/robot_module/proc/fix_modules() //call this proc to enable click
 	src.modules += new /obj/item/weapon/crowbar(src)
 	sensor_augs = list("Mesons", "Disable")
 //		src.modules += new /obj/item/weapon/pickaxe/shovel(src) Uneeded due to buffed drill
+
+	var/obj/item/device/destTagger/tag = new /obj/item/device/destTagger(src)
+	tag.mode = 1 //For editing the tag list
+	src.modules += tag
+
+	var/obj/item/stack/package_wrap/W = new /obj/item/stack/package_wrap(src)
+	W.amount = 24
+	W.max_amount = 24
+	src.modules += W
+
 	fix_modules()
 
+/obj/item/weapon/robot_module/miner/respawn_consumable(var/mob/living/silicon/robot/R)
+	var/list/what = list (
+		/obj/item/stack/package_wrap
+	)
+	for (var/T in what)
+		if (!(locate(T) in src.modules))
+			src.modules -= null
+			var/obj/item/stack/O = new T(src)
+			if(istype(O,/obj/item/stack/package_wrap))
+				O.max_amount = 24
+			src.modules += O
+			O.amount = 1
 
 /obj/item/weapon/robot_module/syndicate
 	name = "syndicate robot module"

--- a/html/changelogs/Faptastic.yml
+++ b/html/changelogs/Faptastic.yml
@@ -1,2 +1,4 @@
 author: Faptastic
-changes: []
+changes: 
+- rscadd: The miner borg module now has a destination tagger and package wrap.
+- tweak: The miner borg is now known as the supply borg, hail cargonia.


### PR DESCRIPTION
![cargodroid2](https://cloud.githubusercontent.com/assets/14299601/15962080/953c3d70-2f00-11e6-8aa8-28e9d6446f66.jpg)
I have also renamed the miner borg to supply since they can now fulfill all cargonia roles competently.

The destination tagger is in unlocked mode to let the borg edit it, they have no means to do so otherwise, it doesn't interfere with the existing tagger(s).
The package wrap can be recharged in a borg charger.
This lets them sub for cargo staff or much like the janiborg, render them obsolete.

Cargo droid sprite not included because I don't have one.
