### PR TITLE
Fixes Borer Unlock Prerequisites

### DIFF
--- a/code/modules/mob/living/simple_animal/borer/unlocks.dm
+++ b/code/modules/mob/living/simple_animal/borer/unlocks.dm
@@ -26,6 +26,7 @@
 
 /datum/unlockable/borer/end_unlock()
 //	to_chat(Redundant borer, "<span class='info'>You finally finish your task.</span>")
+	tree.unlocked.Add(src.id)
 	borer.chemicals -= cost
 
 // additional checks to perform when unlocking things.
@@ -174,12 +175,12 @@
 	gene_name = "FARSIGHT"
 
 /datum/unlockable/borer/gene_unlock/xray
-	id = "run"
+	id = "xray"
 	name = "High-Energy Vision"
 	desc = "Adjusts your host's eyes to see in the X-Ray spectrum."
 	cost = 200
 	time = 2 MINUTES
-	gene_name = "XRAYBLOCK"
+	gene_name = "XRAY"
 	prerequisites=list("farsight")
 
 

--- a/html/changelogs/Shadowmech88.yml
+++ b/html/changelogs/Shadowmech88.yml
@@ -1,4 +1,4 @@
 author: Shadowmech88
 delete-after: True
 changes: 
-- bugfix: Fixed borer unlock prerequisites. Borers are now able to unlock the X-ray vision and fast running mutations for their hosts, as was always intended.
+- bugfix: Fixed borer unlock prerequisites. Borers are now able to unlock dexalin plus secretion as well as the X-ray vision and fast running mutations for their hosts, as was always intended.

--- a/html/changelogs/Shadowmech88.yml
+++ b/html/changelogs/Shadowmech88.yml
@@ -1,0 +1,4 @@
+author: Shadowmech88
+delete-after: True
+changes: 
+- bugfix: Fixed borer unlock prerequisites. Borers are now able to unlock the X-ray vision and fast running mutations for their hosts, as was always intended.


### PR DESCRIPTION
Borers are now able to unlock the X-ray and fast running genes for their hosts after unlocking the farsight and soberness genes, respectively.
They are also able to unlock dexalin plus secretion after unlocking dexalin secretion.

Fixes #6976
Fixes #10136
