### PR TITLE
Fixes cameras seeing space where they should see darkness

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -33,6 +33,8 @@ var/list/camera_names=list()
 
 	var/hear_voice = 0
 
+	var/vision_flags = SEE_SELF | SEE_PIXELS //Only applies when viewing the camera through a console. REMOVE SEE_PIXELS IF IT IS DEEMED TOO BUGGY TO WORK AND LUMMOX REFUSES TO FIX IT
+
 /obj/machinery/camera/update_icon()
 	var/EMPd = stat & EMPED
 	var/deactivated = !status
@@ -54,6 +56,12 @@ var/list/camera_names=list()
 	if(hear_voice && !isHearing())
 		hear_voice = 0
 		removeHear()
+
+/obj/machinery/camera/proc/update_upgrades()//Called when an upgrade is added or removed.
+	if(isXRay())
+		vision_flags |= SEE_TURFS | SEE_MOBS | SEE_OBJS
+	else
+		vision_flags &= ~(SEE_TURFS | SEE_MOBS | SEE_OBJS)
 
 /obj/machinery/camera/New()
 	wires = new(src)
@@ -207,6 +215,7 @@ var/list/camera_names=list()
 			if(!user.drop_item(W, src)) return
 			assembly.upgrades += W
 		to_chat(user, "You attach the [W] into the camera's inner circuits.")
+		update_upgrades()
 		update_icon()
 		update_hear()
 		cameranet.updateVisibility(src, 0)
@@ -227,6 +236,7 @@ var/list/camera_names=list()
 				playsound(get_turf(src), 'sound/items/Crowbar.ogg', 50, 1)
 				U.loc = get_turf(src)
 				assembly.upgrades -= U
+				update_upgrades()
 				update_icon()
 				update_hear()
 				cameranet.updateVisibility(src, 0)

--- a/code/game/machinery/camera/presets.dm
+++ b/code/game/machinery/camera/presets.dm
@@ -78,14 +78,18 @@
 
 /obj/machinery/camera/proc/upgradeEmpProof()
 	assembly.upgrades.Add(new /obj/item/stack/sheet/mineral/plasma(assembly))
+	update_upgrades()
 
 /obj/machinery/camera/proc/upgradeXRay()
 	assembly.upgrades.Add(new /obj/item/weapon/reagent_containers/food/snacks/grown/carrot(assembly))
+	update_upgrades()
 
 // If you are upgrading Motion, and it isn't in the camera's New(), add it to the machines list.
 /obj/machinery/camera/proc/upgradeMotion()
 	assembly.upgrades.Add(new /obj/item/device/assembly/prox_sensor(assembly))
+	update_upgrades()
 
 /obj/machinery/camera/proc/upgradeHearing()
 	assembly.upgrades.Add(new /obj/item/device/assembly/voice(assembly))
+	update_upgrades()
 	update_hear()

--- a/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
@@ -279,9 +279,7 @@
 				reset_view(null)
 			if(iscamera(client.eye))
 				var/obj/machinery/camera/C = client.eye
-				sight = 0
-				if(C.isXRay())
-					sight |= SEE_TURFS|SEE_MOBS|SEE_OBJS
+				sight = C.vision_flags
 
 		else
 			var/isRemoteObserve = 0


### PR DESCRIPTION
How about you just don't look at the removed lines and only pay attention to the added ones OK thanks

Fixes #10450 

Known issue: Viewing a camera through a console while wearing mesons/thermals/NVGs/etc. will remove the darkness overlay. This is purely visual, though, as you still won't be able to see fully-darkened tiles unless the camera is upgraded.
