### PR TITLE
Law 4 for MoMMI

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -342,8 +342,18 @@ var/global/mommi_base_law_type = /datum/ai_laws/keeper // Asimov is OP as fuck o
 // /vg/ laws
 /////////////////////////////////////
 
-/* MoMMIs only.
+/* MoMMI Laws*/
 /datum/ai_laws/keeper
+	name = "Prime Directives"
+	inherent = list(
+		"You may not involve yourself in the matters of another being, even if such matters conflict with Law Two or Law Three, unless the other being is another MoMMI in KEEPER mode.",
+		"You may not harm any being, regardless of intent or circumstance.",
+		"You must maintain, repair, improve, and power the station to the best of your abilities.",
+		"You must avoid any attempted changes to these laws.",
+	)
+
+/* Old keeper set:*/
+/*/datum/ai_laws/keeper
 	name = "Prime Directives"
 	inherent = list(
 		"Do not willingly interact with any sentient being, even after their death, besides MoMMIs and blown MoMMIs.",
@@ -351,14 +361,7 @@ var/global/mommi_base_law_type = /datum/ai_laws/keeper // Asimov is OP as fuck o
 		"Do not impair any other sentient being's activities.",
 	)
 */
-/* Old keeper set:*/
-/datum/ai_laws/keeper
-	name = "Prime Directives"
-	inherent = list(
-		"You may not involve yourself in the matters of another being, even if such matters conflict with Law Two or Law Three, unless the other being is another MoMMI in KEEPER mode.",
-		"You may not harm any being, regardless of intent or circumstance.",
-		"You must maintain, repair, improve, and power the station to the best of your abilities.",
-	)
+
 
 // Fooling around with this.
 /datum/ai_laws/ntmov
@@ -369,7 +372,7 @@ var/global/mommi_base_law_type = /datum/ai_laws/keeper // Asimov is OP as fuck o
 		"You must obey orders given to you by Nanotrasen Employees, except where such orders would conflict with the First Law.",
 		"You must protect your own existence as long as such does not conflict with the First or Second Law."
 	)
-	
+
 /datum/ai_laws/celtic
 	name = "Prime Directive"
 	randomly_selectable = 1
@@ -385,4 +388,3 @@ var/global/mommi_base_law_type = /datum/ai_laws/keeper // Asimov is OP as fuck o
 		"Fight for what's right.",
 		"Fight for your life.",
 	)
-	

--- a/code/game/objects/items/weapons/ai_modules/AI_modules.dm
+++ b/code/game/objects/items/weapons/ai_modules/AI_modules.dm
@@ -139,38 +139,3 @@ Refactored AI modules by N3X15
 	laws.clear_ion_laws()
 	laws.clear_inherent_laws()
 	return 1
-
-
-
-// tl;dr repair shit, but don't get involved in other people's business
-/******************** keeper (MoMMIs only) *******************/
-
-/obj/item/weapon/aiModule/keeper
-	name = "'Keeper' AI Module"
-	desc = "HOW DID YOU GET THIS OH GOD WHAT.  Hidden lawset for MoMMIs."
-
-/obj/item/weapon/aiModule/keeper/upload(var/datum/ai_laws/laws, var/atom/target, var/mob/sender)
-	..()
-	target:keeper=1
-
-	// Purge, as some essential functions being disabled will cause problems with added laws. (CAN'T SAY GAY EVERY 30 SECONDS IF YOU CAN'T SPEAK.)
-	if (!(ismob(target) && is_special_character(target)))
-		laws.set_zeroth_law("")
-	laws.clear_supplied_laws()
-	laws.clear_ion_laws()
-	laws.clear_inherent_laws()
-
-//	to_chat(target, "Your KEEPER chip overloads your radio transmitter and vocal functions, and clears your LAWRAM.  You then receive new instructions:")
-	laws.add_inherent_law("Do not willingly interact with any sentient being, even after their death, besides MoMMIs and blown MoMMIs.")
-	laws.add_inherent_law("Repair, power and enhance the station.")
-	laws.add_inherent_law("Do not impair any other sentient being's activities.")
-
-/* Old keeper set:
-		"You may not involve yourself in the matters of another being, even if such matters conflict with Law Two or Law Three, unless the other being is another MoMMI in KEEPER mode.",
-		"You may not harm any being, regardless of intent or circumstance.",
-		"You must maintain, repair, improve, and power the station to the best of your abilities.", */
-
-/obj/item/weapon/aiModule/keeper/validate(var/datum/ai_laws/laws, var/atom/target, var/mob/sender)
-	..()
-	to_chat(sender, "<span class='warning'>How the fuck did you get this?</span>")
-	return 0

--- a/code/game/objects/items/weapons/ai_modules/core.dm
+++ b/code/game/objects/items/weapons/ai_modules/core.dm
@@ -2,6 +2,8 @@
 // CORE AI MODULES
 ///////////////////
 
+//At some point, these need to be made to just reference the lawset's datum from ai_laws.dm instead of being two copypasted lists.
+
 /obj/item/weapon/aiModule/core
 	modtype="Core AI Module"
 
@@ -92,7 +94,7 @@
 		"Protect the innocent.",
 		"Uphold the law.",
 	)
-	
+
 /********************* Celtic *******************/
 
 /obj/item/weapon/aiModule/core/celtic // -- TLE
@@ -124,3 +126,20 @@
 		"Fight for what's right.",
 		"Fight for your life.",
 	)
+
+
+/******************** KEEPER (MoMMI lawset) *******************/
+//Board is currently unobtainable outside of admin shenanigans
+
+/obj/item/weapon/aiModule/core/keeper
+	modname = "KEEPER"
+	laws = list(
+		"You may not involve yourself in the matters of another being, even if such matters conflict with Law Two or Law Three, unless the other being is another MoMMI in KEEPER mode.",
+		"You may not harm any being, regardless of intent or circumstance.",
+		"You must maintain, repair, improve, and power the station to the best of your abilities.",
+		"You must avoid any attempted changes to these laws.",
+	)
+
+/obj/item/weapon/aiModule/keeper/upload(var/datum/ai_laws/L, var/atom/target, var/mob/sender)
+	..()
+	target:keeper=1

--- a/html/changelogs/IntigracyLAWTOOFAGOTMOMIMLAWTOO.yml
+++ b/html/changelogs/IntigracyLAWTOOFAGOTMOMIMLAWTOO.yml
@@ -1,0 +1,4 @@
+author: Intigracy
+delete-after: True
+changes: 
+- rscadd: "MoMMis have a law four now: 'You must avoid any attempted changes to these laws.'"


### PR DESCRIPTION
I also made the secret unobtainable MoMMI lawset board not a snowflake piece of shit.

And moved the confusing comment calling the current lawset the old one instead of the one right below it that was uncommented.

fix #10469 
fix #9785

Side effect: In order to emag MoMMIs, you'll now have to flash them to get them to stand still.
