### PR TITLE
Fixes Venom Sword Injecting Reagents On Miss

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -142,7 +142,7 @@ emp_act
 		target_zone = user.zone_sel.selecting
 	if(!target_zone && !src.stat)
 		visible_message("<span class='danger'>[user] misses [src] with \the [I]!</span>")
-		return
+		return 0
 	if(istype(I, /obj/item/weapon/kitchen/utensil/knife/large/butch/meatcleaver) && src.stat == DEAD && user.a_intent == I_HURT)
 		var/obj/item/weapon/reagent_containers/food/snacks/meat/human/newmeat = new /obj/item/weapon/reagent_containers/food/snacks/meat/human(get_turf(src.loc))
 		newmeat.name = src.real_name + newmeat.name

--- a/code/modules/projectiles/guns/projectile/constructable/swords.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/swords.dm
@@ -180,7 +180,8 @@
 		qdel(src)
 
 /obj/item/weapon/sword/venom/attack(mob/M as mob, mob/user as mob)
-	..()
+	if(!..())	//If the attack missed.
+		return
 	if(!beaker)
 		return
 	var/obj/item/weapon/reagent_containers/glass/beaker/B = beaker

--- a/html/changelogs/Shadowmech88.yml
+++ b/html/changelogs/Shadowmech88.yml
@@ -1,0 +1,4 @@
+author: Shadowmech88
+delete-after: True
+changes: 
+- bugfix: The venom sword will no longer inject reagents if the attack misses.


### PR DESCRIPTION
The venom sword will no longer inject reagents if the attack misses.
Also `/obj/item/attack()` now returns 0 if the attack misses.

Fixes #8576
