### PR TITLE
Rebalancing of cost/attack power of protolathe-printed bullet-firing guns.

### DIFF
--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -49,9 +49,6 @@
 	ammo_type = "/obj/item/ammo_casing/a12mm"
 	max_ammo = 30
 
-/obj/item/ammo_storage/box/c12mm/assault
-	ammo_type = "/obj/item/ammo_casing/a12mm/assault"
-
 /obj/item/ammo_storage/box/c45
 	name = "ammo box (.45)"
 	icon_state = "9mm"

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -49,6 +49,9 @@
 	ammo_type = "/obj/item/ammo_casing/a12mm"
 	max_ammo = 30
 
+/obj/item/ammo_storage/box/c12mm/assault
+	ammo_type = "/obj/item/ammo_casing/a12mm/assault"
+
 /obj/item/ammo_storage/box/c45
 	name = "ammo box (.45)"
 	icon_state = "9mm"

--- a/code/modules/projectiles/ammunition/bullets.dm
+++ b/code/modules/projectiles/ammunition/bullets.dm
@@ -65,9 +65,6 @@
 	projectile_type = "/obj/item/projectile/bullet/midbullet"
 	w_type = RECYK_METAL
 
-/obj/item/ammo_casing/a12mm/assault
-	projectile_type = "/obj/item/projectile/bullet/midbullet2"
-
 /obj/item/ammo_casing/a12mm/bounce
 	desc = "A rubber-titanium 12mm bullet casing."
 	projectile_type = "/obj/item/projectile/bullet/midbullet/bouncebullet"

--- a/code/modules/projectiles/ammunition/bullets.dm
+++ b/code/modules/projectiles/ammunition/bullets.dm
@@ -65,6 +65,9 @@
 	projectile_type = "/obj/item/projectile/bullet/midbullet"
 	w_type = RECYK_METAL
 
+/obj/item/ammo_casing/a12mm/assault
+	projectile_type = "/obj/item/projectile/bullet/midbullet/assault"
+
 /obj/item/ammo_casing/a12mm/bounce
 	desc = "A rubber-titanium 12mm bullet casing."
 	projectile_type = "/obj/item/projectile/bullet/midbullet/bouncebullet"

--- a/code/modules/projectiles/ammunition/bullets.dm
+++ b/code/modules/projectiles/ammunition/bullets.dm
@@ -65,6 +65,9 @@
 	projectile_type = "/obj/item/projectile/bullet/midbullet"
 	w_type = RECYK_METAL
 
+/obj/item/ammo_casing/a12mm/assault
+	projectile_type = "/obj/item/projectile/bullet/midbullet2"
+
 /obj/item/ammo_casing/a12mm/bounce
 	desc = "A rubber-titanium 12mm bullet casing."
 	projectile_type = "/obj/item/projectile/bullet/midbullet/bouncebullet"

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -49,9 +49,6 @@
 	else
 		..()
 
-/obj/item/weapon/gun/projectile/automatic/lockbox
-	mag_type = "/obj/item/ammo_storage/magazine/smg9mm/empty"
-
 /obj/item/weapon/gun/projectile/automatic/mini_uzi
 	name = "Uzi"
 	desc = "A lightweight, fast firing gun, for when you want someone dead. Uses .45 rounds."
@@ -106,13 +103,10 @@
 	max_shells = 20
 	burst_count = 4
 	caliber = list("12mm" = 1)
-	ammo_type = "/obj/item/ammo_casing/a12mm/assault"
+	ammo_type = "/obj/item/ammo_casing/a12mm"
 	mag_type = "/obj/item/ammo_storage/magazine/a12mm"
 	fire_sound = 'sound/weapons/Gunshot_c20.ogg'
 	load_method = 2
-
-/obj/item/weapon/gun/projectile/automatic/xcom/lockbox
-	mag_type = "/obj/item/ammo_storage/magazine/a12mm/empty"
 
 	gun_flags = AUTOMAGDROP | EMPTYCASINGS
 

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -49,6 +49,9 @@
 	else
 		..()
 
+/obj/item/weapon/gun/projectile/automatic/lockbox
+	mag_type = "/obj/item/ammo_storage/magazine/smg9mm/empty"
+
 /obj/item/weapon/gun/projectile/automatic/mini_uzi
 	name = "Uzi"
 	desc = "A lightweight, fast firing gun, for when you want someone dead. Uses .45 rounds."
@@ -103,12 +106,15 @@
 	max_shells = 20
 	burst_count = 4
 	caliber = list("12mm" = 1)
-	ammo_type = "/obj/item/ammo_casing/a12mm"
+	ammo_type = "/obj/item/ammo_casing/a12mm/assault"
 	mag_type = "/obj/item/ammo_storage/magazine/a12mm"
 	fire_sound = 'sound/weapons/Gunshot_c20.ogg'
 	load_method = 2
-
 	gun_flags = AUTOMAGDROP | EMPTYCASINGS
+
+/obj/item/weapon/gun/projectile/automatic/xcom/lockbox
+	mag_type = "/obj/item/ammo_storage/magazine/a12mm/empty"
+
 
 /obj/item/weapon/gun/projectile/automatic/l6_saw
 	name = "\improper L6 SAW"

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -49,6 +49,9 @@
 	else
 		..()
 
+/obj/item/weapon/gun/projectile/automatic/lockbox
+	mag_type = "/obj/item/ammo_storage/magazine/smg9mm/empty"
+
 /obj/item/weapon/gun/projectile/automatic/mini_uzi
 	name = "Uzi"
 	desc = "A lightweight, fast firing gun, for when you want someone dead. Uses .45 rounds."
@@ -103,10 +106,13 @@
 	max_shells = 20
 	burst_count = 4
 	caliber = list("12mm" = 1)
-	ammo_type = "/obj/item/ammo_casing/a12mm"
+	ammo_type = "/obj/item/ammo_casing/a12mm/assault"
 	mag_type = "/obj/item/ammo_storage/magazine/a12mm"
 	fire_sound = 'sound/weapons/Gunshot_c20.ogg'
 	load_method = 2
+
+/obj/item/weapon/gun/projectile/automatic/xcom/lockbox
+	mag_type = "/obj/item/ammo_storage/magazine/a12mm/empty"
 
 	gun_flags = AUTOMAGDROP | EMPTYCASINGS
 

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -69,8 +69,6 @@
 
 /obj/item/projectile/bullet/midbullet2
 	damage = 25
-	stun = 0
-	weaken = 0
 
 /obj/item/projectile/bullet/midbullet/bouncebullet
 	bounce_type = PROJREACT_WALLS|PROJREACT_WINDOWS

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -67,8 +67,15 @@
 	weaken = 0
 	superspeed = 1
 
+/obj/item/projectile/bullet/midbullet/assault
+	damage = 20
+	stun = 0
+	weaken = 0
+
 /obj/item/projectile/bullet/midbullet2
 	damage = 25
+	stun = 0
+	weaken = 0
 
 /obj/item/projectile/bullet/midbullet/bouncebullet
 	bounce_type = PROJREACT_WALLS|PROJREACT_WINDOWS

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -69,6 +69,8 @@
 
 /obj/item/projectile/bullet/midbullet2
 	damage = 25
+	stun = 0
+	weaken = 0
 
 /obj/item/projectile/bullet/midbullet/bouncebullet
 	bounce_type = PROJREACT_WALLS|PROJREACT_WINDOWS

--- a/code/modules/research/designs/weapons.dm
+++ b/code/modules/research/designs/weapons.dm
@@ -8,7 +8,7 @@
 	reliability_base = 76
 	category = "Weapons"
 	build_path = /obj/item/device/modkit/aeg_parts
-	
+
 
 /datum/design/stunrevolver
 	name = "Stun Revolver"
@@ -100,9 +100,9 @@
 	id = "xcomar"
 	req_tech = list("combat" = 4, "materials" = 3)
 	build_type = PROTOLATHE
-	materials = list(MAT_IRON = 10000, MAT_GLASS = 1000)
+	materials = list(MAT_IRON = 12500, MAT_GLASS = 12500)
 	category = "Weapons"
-	build_path = /obj/item/weapon/gun/projectile/automatic/xcom
+	build_path = /obj/item/weapon/gun/projectile/automatic/xcom/lockbox
 	locked = 1
 	req_lock_access = list(access_armory)
 
@@ -112,9 +112,9 @@
 	id = "ammo_12mm"
 	req_tech = list("combat" = 3, "materials" = 2)
 	build_type = PROTOLATHE
-	materials = list(MAT_IRON = 2000, MAT_GLASS = 200)
+	materials = list(MAT_IRON = 4250, MAT_SILVER = 250)
 	category = "Weapons"
-	build_path = /obj/item/ammo_storage/box/c12mm
+	build_path = /obj/item/ammo_storage/box/c12mm/assault
 
 /datum/design/magazine_12mm
 	name = "Magazine (12mm)"
@@ -122,7 +122,7 @@
 	id = "magazine_12mm"
 	req_tech = list("combat" = 2)
 	build_type = PROTOLATHE
-	materials = list(MAT_IRON = 300)
+	materials = list(MAT_IRON = 400)
 	category = "Weapons"
 	build_path = /obj/item/ammo_storage/magazine/a12mm/empty
 
@@ -212,9 +212,9 @@
 	id = "smg"
 	req_tech = list("combat" = 4, "materials" = 3)
 	build_type = PROTOLATHE
-	materials = list(MAT_IRON = 8000, MAT_SILVER = 2000, MAT_DIAMOND = 1000)
+	materials = list(MAT_IRON = 10000, MAT_GLASS = 10000)
 	category = "Weapons"
-	build_path = /obj/item/weapon/gun/projectile/automatic
+	build_path = /obj/item/weapon/gun/projectile/automatic/lockbox
 	locked = 1
 	req_lock_access = list(access_armory)
 

--- a/code/modules/research/designs/weapons.dm
+++ b/code/modules/research/designs/weapons.dm
@@ -8,7 +8,7 @@
 	reliability_base = 76
 	category = "Weapons"
 	build_path = /obj/item/device/modkit/aeg_parts
-
+	
 
 /datum/design/stunrevolver
 	name = "Stun Revolver"
@@ -100,9 +100,9 @@
 	id = "xcomar"
 	req_tech = list("combat" = 4, "materials" = 3)
 	build_type = PROTOLATHE
-	materials = list(MAT_IRON = 10000, MAT_GLASS = 10000, MAT_SILVER = 5000)
+	materials = list(MAT_IRON = 10000, MAT_GLASS = 1000)
 	category = "Weapons"
-	build_path = /obj/item/weapon/gun/projectile/automatic/xcom/lockbox
+	build_path = /obj/item/weapon/gun/projectile/automatic/xcom
 	locked = 1
 	req_lock_access = list(access_armory)
 
@@ -112,9 +112,9 @@
 	id = "ammo_12mm"
 	req_tech = list("combat" = 3, "materials" = 2)
 	build_type = PROTOLATHE
-	materials = list(MAT_IRON = 4250, MAT_SILVER = 250)
+	materials = list(MAT_IRON = 2000, MAT_GLASS = 200)
 	category = "Weapons"
-	build_path = /obj/item/ammo_storage/box/c12mm/assault
+	build_path = /obj/item/ammo_storage/box/c12mm
 
 /datum/design/magazine_12mm
 	name = "Magazine (12mm)"
@@ -122,7 +122,7 @@
 	id = "magazine_12mm"
 	req_tech = list("combat" = 2)
 	build_type = PROTOLATHE
-	materials = list(MAT_IRON = 400)
+	materials = list(MAT_IRON = 300)
 	category = "Weapons"
 	build_path = /obj/item/ammo_storage/magazine/a12mm/empty
 
@@ -212,9 +212,9 @@
 	id = "smg"
 	req_tech = list("combat" = 4, "materials" = 3)
 	build_type = PROTOLATHE
-	materials = list(MAT_IRON = 10000, MAT_GLASS = 5000)
+	materials = list(MAT_IRON = 8000, MAT_SILVER = 2000, MAT_DIAMOND = 1000)
 	category = "Weapons"
-	build_path = /obj/item/weapon/gun/projectile/automatic/lockbox
+	build_path = /obj/item/weapon/gun/projectile/automatic
 	locked = 1
 	req_lock_access = list(access_armory)
 

--- a/code/modules/research/designs/weapons.dm
+++ b/code/modules/research/designs/weapons.dm
@@ -8,7 +8,7 @@
 	reliability_base = 76
 	category = "Weapons"
 	build_path = /obj/item/device/modkit/aeg_parts
-	
+
 
 /datum/design/stunrevolver
 	name = "Stun Revolver"
@@ -100,9 +100,9 @@
 	id = "xcomar"
 	req_tech = list("combat" = 4, "materials" = 3)
 	build_type = PROTOLATHE
-	materials = list(MAT_IRON = 10000, MAT_GLASS = 1000)
+	materials = list(MAT_IRON = 10000, MAT_GLASS = 10000, MAT_SILVER = 5000)
 	category = "Weapons"
-	build_path = /obj/item/weapon/gun/projectile/automatic/xcom
+	build_path = /obj/item/weapon/gun/projectile/automatic/xcom/lockbox
 	locked = 1
 	req_lock_access = list(access_armory)
 
@@ -112,9 +112,9 @@
 	id = "ammo_12mm"
 	req_tech = list("combat" = 3, "materials" = 2)
 	build_type = PROTOLATHE
-	materials = list(MAT_IRON = 2000, MAT_GLASS = 200)
+	materials = list(MAT_IRON = 4250, MAT_SILVER = 250)
 	category = "Weapons"
-	build_path = /obj/item/ammo_storage/box/c12mm
+	build_path = /obj/item/ammo_storage/box/c12mm/assault
 
 /datum/design/magazine_12mm
 	name = "Magazine (12mm)"
@@ -122,7 +122,7 @@
 	id = "magazine_12mm"
 	req_tech = list("combat" = 2)
 	build_type = PROTOLATHE
-	materials = list(MAT_IRON = 300)
+	materials = list(MAT_IRON = 400)
 	category = "Weapons"
 	build_path = /obj/item/ammo_storage/magazine/a12mm/empty
 
@@ -212,9 +212,9 @@
 	id = "smg"
 	req_tech = list("combat" = 4, "materials" = 3)
 	build_type = PROTOLATHE
-	materials = list(MAT_IRON = 8000, MAT_SILVER = 2000, MAT_DIAMOND = 1000)
+	materials = list(MAT_IRON = 10000, MAT_GLASS = 5000)
 	category = "Weapons"
-	build_path = /obj/item/weapon/gun/projectile/automatic
+	build_path = /obj/item/weapon/gun/projectile/automatic/lockbox
 	locked = 1
 	req_lock_access = list(access_armory)
 

--- a/html/changelogs/icantthinkofanameritenow.yml
+++ b/html/changelogs/icantthinkofanameritenow.yml
@@ -1,8 +1,0 @@
-
-author: Icantthinkofanameritenow
-
-delete-after: True
-
-changes: 
-- rscadd: Assault Rifle does slightly more damage.
-- rscdel: "Price of Assault Rifle and ammunition increased, and Assault Rifle and SMG start with empty magazines. Assault Rifle shots no longer stun people." 

--- a/html/changelogs/icantthinkofanameritenow.yml
+++ b/html/changelogs/icantthinkofanameritenow.yml
@@ -1,0 +1,8 @@
+
+author: Icantthinkofanameritenow
+
+delete-after: True
+
+changes: 
+- rscadd: Assault Rifle does slightly more damage.
+- rscdel: "Price of Assault Rifle and ammunition increased, and Assault Rifle and SMG start with empty magazines. Assault Rifle shots no longer stun people." 


### PR DESCRIPTION
To address the ubiquity of the AR to the point of it being spammed, it now spawns in the lockbox with no ammo and has half its current stun time; the ammo itself is a bit more expensive as well, though not to the point it will be prohibitive unless you have a ton of trouble finding silver. To compensate, it deals slightly more damage. 

Specifically: 
-AR bullets deal 25 damage each, but no stun or weaken effect. 
-AR price is now 12500 metal and 12500 glass.
-12mm rounds cost 4250 metal and 250 silver per box.

SMG is also tweaked a little, and now only costs iron and glass to build. Ammo still needs silver however, and it too begins with an empty magazine.

Specifically:
-SMG now costs 10000 metal and 10000 glass. 

Fixes #8628. Depending on what people want, I may end up increasing the size of the AR to bulky as part of potential changes proposed in #11487  
