### PR TITLE
Stun revolver lockboxes can now be opened by all security staff.

### DIFF
--- a/code/modules/research/designs/weapons.dm
+++ b/code/modules/research/designs/weapons.dm
@@ -8,7 +8,7 @@
 	reliability_base = 76
 	category = "Weapons"
 	build_path = /obj/item/device/modkit/aeg_parts
-	
+
 
 /datum/design/stunrevolver
 	name = "Stun Revolver"
@@ -20,7 +20,7 @@
 	category = "Weapons"
 	build_path = /obj/item/weapon/gun/energy/stunrevolver
 	locked = 1
-	req_lock_access = list(access_armory)
+	req_lock_access = list(access_security)
 
 /datum/design/lasercannon
 	name = "Laser Cannon"

--- a/html/changelogs/icantthinkofanameritenow.yml
+++ b/html/changelogs/icantthinkofanameritenow.yml
@@ -1,0 +1,9 @@
+
+author: Icantthinkofanameritenow
+
+delete-after: True
+
+
+changes: 
+- rscadd: Stun revolver lockboxes can now be opened by all Security staff. 
+


### PR DESCRIPTION
The name says it all. It's basically a taser with 3 more shots anyway, so why this ever required revolver access in the first place is beyond me.
