### PR TITLE
[Hotfix] Borer Ventcrawling and Host Abandoning Fix

### DIFF
--- a/code/_onclick/ventcrawl.dm
+++ b/code/_onclick/ventcrawl.dm
@@ -71,6 +71,9 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 /mob/living/simple_animal/borer/can_ventcrawl()
 	return 1
 
+/mob/living/simple_animal/borer/ventcrawl_carry()
+	return 1
+
 /mob/living/simple_animal/mouse/can_ventcrawl()
 	return 1
 

--- a/code/modules/mob/living/simple_animal/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer.dm
@@ -528,7 +528,12 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 			to_chat(src, "<span class='warning'>You cannot abandon [host] while your focus is directed elsewhere.</span>")
 			return
 
-		if(!check_can_do())
+		if(controlling)
+			to_chat(src, "<span class='warning'>You're too busy controlling your host.</span>")
+			return
+
+		if(research.unlocking)
+			to_chat(src, "<span class='warning'>You are busy evolving.</span>")
 			return
 
 		if(severed)

--- a/html/changelogs/Shadowmech88.yml
+++ b/html/changelogs/Shadowmech88.yml
@@ -1,0 +1,4 @@
+author: Shadowmech88
+delete-after: True
+changes: 
+- rscadd: Borers can now inhabit a human's left arm, right arm, left leg, right leg, and chest in addition to their head. A human may have one borer in each of these limbs. The borer's available evolutions are influenced by the limb it is currently inhabiting.


### PR DESCRIPTION
Fixes borers being unable to ventcrawl and unable to disconnect from a dead host.

Also adds changelog because I forgot to do that in the main PR.
