### PR TITLE
[Hotfix] A Lot of Borer Fixes

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1124,6 +1124,8 @@ proc/get_mob_with_client_list()
 	This is essentially the same as calling (locate(B) in A), but a little clearer as to what you're doing, and locate() has been known to bug out or be extremely slow in the past.
 */
 /proc/is_holder_of(const/atom/movable/A, const/atom/movable/B)
+	if(istype(A, /turf) || istype(B, /turf)) //Clicking on turfs is a common thing and turfs are also not /atom/movable, so it was causing the assertion to fail.
+		return 0
 	ASSERT(istype(A) && istype(B))
 	var/atom/O = B
 	while(O && !isturf(O))

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -224,7 +224,7 @@
 	throwforce = 0
 	w_class = 5
 	sharpness = 1.5
-	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	attack_verb = list("attacks", "slashes", "stabs", "slices", "tears", "rips", "dices", "cuts")
 	mech_flags = MECH_SCAN_ILLEGAL
 	cant_drop = 1
 	var/mob/living/simple_animal/borer/parent_borer = null

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -209,7 +209,7 @@ obj/item/weapon/banhammer/admin
 	throwforce = 0
 	w_class = 5
 	sharpness = 0
-	attack_verb = list("bludgeoned", "smashed", "pummeled", "crushed", "slammed")
+	attack_verb = list("bludgeons", "smashes", "pummels", "crushes", "slams")
 	mech_flags = MECH_SCAN_ILLEGAL
 	cant_drop = 1
 	var/mob/living/simple_animal/borer/parent_borer = null

--- a/code/modules/mob/living/simple_animal/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer.dm
@@ -465,9 +465,18 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 	if(!host || controlling || !src || stat) //Sanity check.
 		return
 
+	if(chem.name == "blood")
+		if(istype(host, /mob/living/carbon/human) && !(host.species.flags & NO_BLOOD))
+			host.vessel.add_reagent(chem.name, units)
+		else
+			to_chat(src, "<span class='notice'>Your host seems to be a species that doesn't use blood.<span>")
+			return
+	else
+		host.reagents.add_reagent(chem.name, units)
+
 	to_chat(src, "<span class='info'>You squirt a measure of [chem.name] from your reservoirs into [host]'s bloodstream.</span>")
 	add_gamelogs(src, "secreted [units]U of '[chemID]' into \the [host]", admin = TRUE, tp_link = TRUE, span_class = "message")
-	host.reagents.add_reagent(chem.name, units)
+
 	chemicals -= chem.cost*units
 
 // We've been moved to someone's head.

--- a/code/modules/mob/living/simple_animal/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer.dm
@@ -1118,8 +1118,10 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 									attack_cooldown = 0
 								return
 						else if(istype(A, /obj/item))
-							host.put_in_r_hand(A)
-							return
+							var/obj/item/I = A
+							if(!I.anchored)
+								host.put_in_r_hand(A)
+								return
 					else
 						if(host.get_held_item_by_index(GRASP_LEFT_HAND))
 							if(attack_cooldown)
@@ -1131,8 +1133,10 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 									attack_cooldown = 0
 								return
 						else if(istype(A, /obj/item))
-							host.put_in_l_hand(A)
-							return
+							var/obj/item/I = A
+							if(!I.anchored)
+								host.put_in_l_hand(A)
+								return
 				if(get_turf(A) == get_turf(host) && !istype(A, /obj/item))
 					return
 				if(hostlimb == "r_arm")

--- a/code/modules/mob/living/simple_animal/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer.dm
@@ -1103,6 +1103,9 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 				if(!extend_o_arm)
 					extend_o_arm = new /obj/item/weapon/gun/hookshot/flesh(src, src)
 					extend_o_arm.forceMove(host)
+				if(istype(host.get_held_item_by_index(GRASP_RIGHT_HAND), /obj/item/offhand) || istype(host.get_held_item_by_index(GRASP_LEFT_HAND), /obj/item/offhand)) //If the host is two-handing something.
+					to_chat(src, "<span class='warning'>You cannot swing this item while your host holds it with both hands!</span>")
+					return
 				if(host.Adjacent(A))
 					if(hostlimb == "r_arm")
 						if(host.get_held_item_by_index(GRASP_RIGHT_HAND))

--- a/code/modules/mob/living/simple_animal/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer.dm
@@ -798,6 +798,10 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 		to_chat(src, "That is not an appropriate target.")
 		return
 
+	if(M.has_brain_worms(region))
+		to_chat(src, "This host's [limb_to_name(region)] is already infested!")
+		return
+
 	if(M in view(1, src))
 		to_chat(src, "[region == "head" ? "You wiggle into [M]'s ear." : "You burrow under [M]'s skin."]")
 		src.perform_infestation(M, region)

--- a/code/modules/mob/living/simple_animal/borer/fleshshot.dm
+++ b/code/modules/mob/living/simple_animal/borer/fleshshot.dm
@@ -6,6 +6,8 @@
 	w_class = 5
 	fire_sound = 'sound/effects/flesh_squelch.ogg'
 	empty_sound = null
+	silenced = 1
+	fire_volume = 250
 	maxlength = 10
 	var/mob/living/simple_animal/borer/parent_borer = null
 	var/image/item_overlay = null


### PR DESCRIPTION
A bone sword and a fleshshot on the same arm was never meant to happen.
Nor was being able to attack with a _wielded_ fireaxe at range.

Fixes runtime.
Fixes multiple borers being able to inhabit the same limb.
Fixes being able to use the extend-o-arm to attack with a two-handed weapon that the host is currently wielding.
Updates attack verbs of bone weapons.
Removes the visible_message that appears when the fleshshot is fired.
Fixes borers being able to pick up anchored items.
Fixes #10599
(Fixes the blood secretion, at least. I'm confident that the lipozine issue is not specifically related to borers.)
