### PR TITLE
Double Tomato Plant outputs

### DIFF
--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -539,7 +539,7 @@
 	lifespan = 25
 	maturation = 8
 	production = 6
-	yield = 2
+	yield = 4
 	potency = 10
 	water_consumption = 6
 	nutrient_consumption = 0.25
@@ -557,7 +557,7 @@
 	packet_icon = "seed-bloodtomato"
 	plant_icon = "bloodtomato"
 	chems = list("nutriment" = list(1,10), "blood" = list(10,2))
-	yield = 1
+	yield = 2
 	splat_type = /obj/effect/decal/cleanable/blood/splatter
 
 /datum/seed/tomato/killer
@@ -583,6 +583,8 @@
 	plant_icon = "bluetomato"
 	chems = list("nutriment" = list(1,20), "lube" = list(1,5))
 	splat_type = /obj/effect/decal/cleanable/blood/oil
+
+	yield = 2
 
 /datum/seed/tomato/blue/teleport
 	name = "bluespacetomato"

--- a/html/changelogs/Dylanstrategie_Tomato.yml
+++ b/html/changelogs/Dylanstrategie_Tomato.yml
@@ -1,0 +1,4 @@
+author: Dylanstrategie
+delete-after: True
+changes:
+- tweak: Tomatoes now output twice as many crops as a baseline (2 -> 4). All special types output half of that (2)


### PR DESCRIPTION
Tomatoes are essential in most basic Chef recipes. Despite this, the base tomato yield is 2, and 2/1 for special tomato types

This has been doubled. Four tomatoes per tomato stalk is perfectly realistic, if the tomatoes are maintained properly. Special tomato stalks still get halved output from the normal stalk as previously, but bluespace tomatoes no longer get quarter output, now it's half

Balance only, no real code tweaks, so ready to go if change is fine

Changelog included
