### PR TITLE
Fixes Utility Borer Attack Spam and Other Things

### DIFF
--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -220,7 +220,7 @@
 	flags = FPRINT
 	siemens_coefficient = 0
 	slot_flags = null
-	force = 20
+	force = 18
 	throwforce = 0
 	w_class = 5
 	sharpness = 1.5

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -205,7 +205,7 @@ obj/item/weapon/banhammer/admin
 	flags = FPRINT
 	siemens_coefficient = 0
 	slot_flags = null
-	force = 35
+	force = 25
 	throwforce = 0
 	w_class = 5
 	sharpness = 0

--- a/code/modules/mob/living/simple_animal/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer.dm
@@ -1123,8 +1123,7 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 							else
 								A.attackby(host.get_held_item_by_index(GRASP_RIGHT_HAND), host, 1, src)
 								attack_cooldown = 1
-								spawn(10)
-									attack_cooldown = 0
+								reset_attack_cooldown()
 								return
 						else if(istype(A, /obj/item))
 							var/obj/item/I = A
@@ -1138,8 +1137,7 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 							else
 								A.attackby(host.get_held_item_by_index(GRASP_LEFT_HAND), host, 1, src)
 								attack_cooldown = 1
-								spawn(10)
-									attack_cooldown = 0
+								reset_attack_cooldown()
 								return
 						else if(istype(A, /obj/item))
 							var/obj/item/I = A
@@ -1155,3 +1153,7 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 					if(host.get_held_item_by_index(GRASP_LEFT_HAND) && istype(host.get_held_item_by_index(GRASP_LEFT_HAND), /obj/item/weapon/gun/hookshot))
 						return
 				extend_o_arm.afterattack(A, host)
+
+/mob/living/simple_animal/borer/proc/reset_attack_cooldown()
+	spawn(10)
+		attack_cooldown = 0

--- a/code/modules/mob/living/simple_animal/borer/chems.dm
+++ b/code/modules/mob/living/simple_animal/borer/chems.dm
@@ -149,10 +149,6 @@
 	name = "cafe_latte"
 	cost = 1
 
-/datum/borer_chem/arm/unlockable/hamserum
-	name = "hamserum"
-	cost = 100
-
 /datum/borer_chem/arm/unlockable/iron
 	name = "iron"
 	cost = 1

--- a/code/modules/mob/living/simple_animal/borer/fleshshot.dm
+++ b/code/modules/mob/living/simple_animal/borer/fleshshot.dm
@@ -350,12 +350,18 @@
 					var/mob/living/carbon/human/L = parent_borer.host
 					if(parent_borer.hostlimb == "r_arm")
 						if(L.get_held_item_by_index(GRASP_RIGHT_HAND))
-							A.attackby(L.get_held_item_by_index(GRASP_RIGHT_HAND), L, 1, parent_borer)
+							if(!parent_borer.attack_cooldown)
+								A.attackby(L.get_held_item_by_index(GRASP_RIGHT_HAND), L, 1, parent_borer)
+								parent_borer.attack_cooldown = 1
+								parent_borer.reset_attack_cooldown()
 							bullet_die()
 							return
 					else
 						if(L.get_held_item_by_index(GRASP_LEFT_HAND))
-							A.attackby(L.get_held_item_by_index(GRASP_LEFT_HAND), L, 1, parent_borer)
+							if(!parent_borer.attack_cooldown)
+								A.attackby(L.get_held_item_by_index(GRASP_LEFT_HAND), L, 1, parent_borer)
+								parent_borer.attack_cooldown = 1
+								parent_borer.reset_attack_cooldown()
 							bullet_die()
 							return
 		if(isturf(A))					//if we hit a wall or an anchored atom, we pull ourselves to it

--- a/code/modules/mob/living/simple_animal/borer/unlocks.dm
+++ b/code/modules/mob/living/simple_animal/borer/unlocks.dm
@@ -207,15 +207,6 @@
 	chem_type = /datum/borer_chem/arm/unlockable/cafe_latte
 	prerequisites=list("bone_sword")
 
-/datum/unlockable/borer/arm/chem_unlock/hamserum
-	id = "hamserum"
-	name = "Ham Serum Secretion"
-	desc = "Learn how to synthesize electromagnetic ham serum."
-	cost = 150
-	time = 60 SECONDS
-	chem_type = /datum/borer_chem/arm/unlockable/hamserum
-	prerequisites=list("bone_shield")
-
 /datum/unlockable/borer/arm/chem_unlock/iron
 	id = "iron"
 	name = "Iron Secretion"
@@ -642,6 +633,16 @@
 	cost=200
 	time=1 MINUTES
 	verb_type = /obj/item/verbs/borer/attached_arm/bone_cocoon
+	give_when_attached=1
+	prerequisites=list("bone_shield")
+
+/datum/unlockable/borer/arm/verb_unlock/em_pulse
+	id="em_pulse"
+	name = "Electromagnetic Pulse"
+	desc = "Learn how to expend a great deal of chemicals to produce a small electromagnetic pulse."
+	cost=150
+	time=60 SECONDS
+	verb_type = /obj/item/verbs/borer/attached_arm/em_pulse
 	give_when_attached=1
 	prerequisites=list("bone_shield")
 

--- a/code/modules/mob/living/simple_animal/borer/verbs_attached_arm.dm
+++ b/code/modules/mob/living/simple_animal/borer/verbs_attached_arm.dm
@@ -282,6 +282,30 @@
 				showmessage = 1
 			passout(time_spent_channeling, showmessage)
 
+/obj/item/verbs/borer/attached_arm/em_pulse/verb/em_pulse()
+	set category = "Alien"
+	set name = "Electromagnetic Pulse"
+	set desc = "Expend a great deal of chemicals to produce a small electromagnetic pulse."
+
+	var/mob/living/simple_animal/borer/B=loc
+	if(!istype(B)) return
+	B.em_pulse()
+
+/mob/living/simple_animal/borer/proc/em_pulse()
+	set category = "Alien"
+	set name = "Electromagnetic Pulse"
+	set desc = "Expend a great deal of chemicals to produce a small electromagnetic pulse."
+
+	if(!check_can_do())
+		return
+
+	if(chemicals < 100)
+		to_chat(src, "<span class='warning'>You need at least 100 chemicals to do this.</span>")
+		return
+	else
+		chemicals -= 100
+		empulse(get_turf(src), 1, 2, 0)
+
 //////////UTILITY TREE/////////////////////
 /obj/item/verbs/borer/attached_arm/repair_bone/verb/repair_bone()
 	set category = "Alien"

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -4799,8 +4799,9 @@
 	description = "Concentrated legal discussions"
 	reagent_state = LIQUID
 	color = "#00FF21" //rgb: 0, 255, 33
+	custom_metabolism = 1
 
-/datum/reagent/hamserum/reaction_mob(var/mob/living/M, var/method = TOUCH, var/volume)
+/datum/reagent/hamserum/on_mob_life(var/mob/living/M)
 
 	if(..()) return 1
 

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -4799,9 +4799,8 @@
 	description = "Concentrated legal discussions"
 	reagent_state = LIQUID
 	color = "#00FF21" //rgb: 0, 255, 33
-	custom_metabolism = 1
 
-/datum/reagent/hamserum/on_mob_life(var/mob/living/M)
+/datum/reagent/hamserum/reaction_mob(var/mob/living/M, var/method = TOUCH, var/volume)
 
 	if(..()) return 1
 


### PR DESCRIPTION
Fixes the fleshshot's attack delay so borers can't go fist-of-the-north-star on opponents. They are now able to land an attack with the fleshshot only once per second, though it can still be fired as fast as the borer is able to fire it.

Reduces the bone sword's force from 20 to 18, reduces the bone hammer's force from 35 to 25.

Defense-spec borers now get a verb to produce an EMP instead of doing it via a chem. The cost is still 100 chems per EMP.
