### PR TITLE
Adds drinking functionality to chemical bottles.

### DIFF
--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -71,7 +71,7 @@
 	..()
 	toggle_open()
 
-/obj/item/weapon/reagent_containers/glass/verb/toggle_open() //set amount_per_transfer_from_this
+/obj/item/weapon/reagent_containers/glass/verb/toggle_open()
 	set name = "Toggle seal"
 	set category = "Object"
 	set src in range(0)

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -69,6 +69,13 @@
 
 /obj/item/weapon/reagent_containers/glass/attack_self()
 	..()
+	toggle_open()
+
+/obj/item/weapon/reagent_containers/glass/verb/toggle_open() //set amount_per_transfer_from_this
+	set name = "Toggle seal"
+	set category = "Object"
+	set src in range(0)
+
 	if(is_open_container())
 		to_chat(usr, "<span class = 'notice'>You put the lid on \the [src].")
 		flags ^= OPENCONTAINER

--- a/code/modules/reagents/reagent_containers/glass/bottle.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle.dm
@@ -54,6 +54,44 @@
 	..()
 	update_icon()
 
+/obj/item/weapon/reagent_containers/glass/bottle/attack_self(mob/user as mob)
+	if(!is_open_container())
+		to_chat(user, "<span class='warning'>You can't, \the [src] is closed.</span>")//Added this here and elsewhere to prevent drinking, etc. from closed drink containers. - Hinaichigo
+
+		return 0
+
+	else if(!src.reagents.total_volume || !src)
+		to_chat(user, "<span class='warning'>\The [src] is empty.<span>")
+		return 0
+
+	else
+		imbibe(user)
+		return 0
+
+/obj/item/weapon/reagent_containers/glass/bottle/proc/imbibe(mob/user) //Drink the liquid within
+
+
+	to_chat(user, "<span  class='notice'>You swallow a gulp of \the [src].</span>")
+	playsound(user.loc,'sound/items/drink.ogg', rand(10,50), 1)
+
+	if(isrobot(user))
+		reagents.remove_any(amount_per_transfer_from_this)
+		return 1
+	if(reagents.total_volume)
+		if (ishuman(user))
+			var/mob/living/carbon/human/H = user
+			if(H.species.chem_flags & NO_DRINK)
+				reagents.reaction(get_turf(H), TOUCH)
+				H.visible_message("<span class='warning'>The contents in [src] fall through and splash onto the ground, what a mess!</span>")
+				return 0
+
+		reagents.reaction(user, INGEST)
+		spawn(5)
+			reagents.trans_to(user, amount_per_transfer_from_this)
+
+	return 1
+
+
 /obj/item/weapon/reagent_containers/glass/bottle/attack_hand()
 	..()
 	update_icon()
@@ -294,7 +332,7 @@
 		var/datum/disease/F = new /datum/disease/fake_gbs(0)
 		var/list/data = list("viruses"= list(F))
 		reagents.add_reagent("blood", 20, data)
-		
+
 /obj/item/weapon/reagent_containers/glass/bottle/chickenpox
 	name = "Chickenpox culture bottle"
 	desc = "A small bottle. Contains activated chickenpox in a vox-blood medium."
@@ -305,7 +343,7 @@
 		var/datum/disease/F = new /datum/disease2/effect/chickenpox(0)
 		var/list/data = list("viruses"= list(F))
 		reagents.add_reagent("blood", 20, data)
-		
+
 /*
 /obj/item/weapon/reagent_containers/glass/bottle/rhumba_beat
 	name = "Rhumba Beat culture bottle"

--- a/html/changelogs/Skullyton.yml
+++ b/html/changelogs/Skullyton.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general deleting of nice things)
+#   rscadd (general adding of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.
+author: Skullyton
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# There needs to be a space after the - and before the prefix. Don't use tabs anywhere in this file.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# If you're using characters such as # ' : - or the like in your changelog, surround the entire change with quotes as shown in the second example. These quotes don't show up on the changelog once it's merged and prevent errors.
+# SCREW ANY OF THIS UP AND IT WON'T WORK.
+changes: 
+- rscadd: Adds drinking functionality to chemical bottles, so you can get your potions.
+- tweak: Changes putting the cap on things such as beakers to a verb, you can still click on most of them to toggle the cap, it's just you can right click them now as well


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.
-->

Fixes #10614 

As mentioned above, this basically copypastes the drinking mechanic from beer glasses and such, and applies it to those chemical bottles you can get from chem-masters.

However, this kinda sacrificed being able to cap the bottle, so I've also converted capping to a general verb that beakers and such use, so you can just right click the bottle and press 'toggle seal' from the verb list.

Additionally, the amount you consume from a chem bottle is dependent on its transfer amount, so you can potentially just down it all in one. However, attempting to apply it to another person simply splashes them like before, so you can't just run around force feeding people 30u hyperzine/chloral bottles.
