### PR TITLE
Fleshshot Changes and Borer Poison

### DIFF
--- a/code/modules/mob/living/simple_animal/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer.dm
@@ -1171,16 +1171,24 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 				if(get_turf(A) == get_turf(host) && !istype(A, /obj/item))
 					return
 				if(hostlimb == "r_arm")
-					if(host.get_held_item_by_index(GRASP_RIGHT_HAND) && istype(host.get_held_item_by_index(GRASP_RIGHT_HAND), /obj/item/weapon/gun/hookshot)) //I don't want to deal with the fleshshot interacting with hookshots
-						return
+					if(host.get_held_item_by_index(GRASP_RIGHT_HAND))
+						if(istype(host.get_held_item_by_index(GRASP_RIGHT_HAND), /obj/item/weapon/gun/hookshot)) //I don't want to deal with the fleshshot interacting with hookshots
+							return
+						if(chemicals < 10)
+							to_chat(src, "<span class='warning'>You don't have enough chemicals stored to swing an item with this arm!</span>")
+							return
+						else
+							chemicals -= 10		//It costs 20 chems to fire the fleshshot while holding an item.
 				else if(hostlimb == "l_arm")
-					if(host.get_held_item_by_index(GRASP_LEFT_HAND) && istype(host.get_held_item_by_index(GRASP_LEFT_HAND), /obj/item/weapon/gun/hookshot))
-						return
-				if(chemicals >= 10)
-					chemicals -= 10
-					extend_o_arm.afterattack(A, host)
-				else
-					to_chat(src, "<span class='warning'>You don't have enough chemicals stored to do this.</span>")
+					if(host.get_held_item_by_index(GRASP_LEFT_HAND))
+						if(istype(host.get_held_item_by_index(GRASP_LEFT_HAND), /obj/item/weapon/gun/hookshot))
+							return
+						if(chemicals < 10)
+							to_chat(src, "<span class='warning'>You don't have enough chemicals stored to swing an item with this arm!</span>")
+							return
+						else
+							chemicals -= 10
+				extend_o_arm.afterattack(A, host)
 
 /mob/living/simple_animal/borer/proc/reset_attack_cooldown()
 	spawn(10)

--- a/code/modules/mob/living/simple_animal/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer.dm
@@ -1135,10 +1135,10 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 					to_chat(src, "<span class='warning'>Your host's muscles are tightened. You can't extend your arm!</span>")
 					return
 				var/datum/reagents/R = host.reagents
-					if(R)
-						if(R.has_reagent("silicate"))
-							to_chat(src, "<span class='warning'>Something in your host's bloodstream tightening their muscles. You can't extend your arm!</span>")
-							return
+				if(R)
+					if(R.has_reagent("silicate"))
+						to_chat(src, "<span class='warning'>Something in your host's bloodstream is tightening their muscles. You can't extend your arm!</span>")
+						return
 				if(host.Adjacent(A))
 					if(hostlimb == "r_arm")
 						if(host.get_held_item_by_index(GRASP_RIGHT_HAND))

--- a/code/modules/mob/living/simple_animal/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer.dm
@@ -302,6 +302,7 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 				if (timeleft)
 					stat(null, "ETA-[(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]")
 
+		stat("Health", health)
 		stat("Chemicals", chemicals)
 
 /mob/living/simple_animal/borer/earprot()
@@ -1178,7 +1179,8 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 							to_chat(src, "<span class='warning'>You don't have enough chemicals stored to swing an item with this arm!</span>")
 							return
 						else
-							chemicals -= 10		//It costs 10 chems to fire the fleshshot while holding an item.
+							if(!(extend_o_arm.hook || extend_o_arm.chain_datum || extend_o_arm.rewinding))	//If the arm is not currently extended.
+								chemicals -= 10		//It costs 10 chems to fire the fleshshot while holding an item.
 				else if(hostlimb == "l_arm")
 					if(host.get_held_item_by_index(GRASP_LEFT_HAND))
 						if(istype(host.get_held_item_by_index(GRASP_LEFT_HAND), /obj/item/weapon/gun/hookshot))
@@ -1187,7 +1189,8 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 							to_chat(src, "<span class='warning'>You don't have enough chemicals stored to swing an item with this arm!</span>")
 							return
 						else
-							chemicals -= 10
+							if(!(extend_o_arm.hook || extend_o_arm.chain_datum || extend_o_arm.rewinding))
+								chemicals -= 10
 				extend_o_arm.afterattack(A, host)
 
 /mob/living/simple_animal/borer/proc/reset_attack_cooldown()

--- a/code/modules/mob/living/simple_animal/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer.dm
@@ -1178,7 +1178,7 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 							to_chat(src, "<span class='warning'>You don't have enough chemicals stored to swing an item with this arm!</span>")
 							return
 						else
-							chemicals -= 10		//It costs 20 chems to fire the fleshshot while holding an item.
+							chemicals -= 10		//It costs 10 chems to fire the fleshshot while holding an item.
 				else if(hostlimb == "l_arm")
 					if(host.get_held_item_by_index(GRASP_LEFT_HAND))
 						if(istype(host.get_held_item_by_index(GRASP_LEFT_HAND), /obj/item/weapon/gun/hookshot))

--- a/code/modules/mob/living/simple_animal/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer.dm
@@ -134,6 +134,8 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 	..()
 	if(host)
 		if(!stat && !host.stat)
+			if(health < 20)
+				health += 0.5
 			if(chemicals < 250 && !channeling)
 				chemicals++
 			if(controlling)
@@ -1129,6 +1131,14 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 				if(istype(host.get_held_item_by_index(GRASP_RIGHT_HAND), /obj/item/offhand) || istype(host.get_held_item_by_index(GRASP_LEFT_HAND), /obj/item/offhand)) //If the host is two-handing something.
 					to_chat(src, "<span class='warning'>You cannot swing this item while your host holds it with both hands!</span>")
 					return
+				if(host.stunned)
+					to_chat(src, "<span class='warning'>Your host's muscles are tightened. You can't extend your arm!</span>")
+					return
+				var/datum/reagents/R = host.reagents
+					if(R)
+						if(R.has_reagent("silicate"))
+							to_chat(src, "<span class='warning'>Something in your host's bloodstream tightening their muscles. You can't extend your arm!</span>")
+							return
 				if(host.Adjacent(A))
 					if(hostlimb == "r_arm")
 						if(host.get_held_item_by_index(GRASP_RIGHT_HAND))
@@ -1166,7 +1176,11 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 				else if(hostlimb == "l_arm")
 					if(host.get_held_item_by_index(GRASP_LEFT_HAND) && istype(host.get_held_item_by_index(GRASP_LEFT_HAND), /obj/item/weapon/gun/hookshot))
 						return
-				extend_o_arm.afterattack(A, host)
+				if(chemicals >= 10)
+					chemicals -= 10
+					extend_o_arm.afterattack(A, host)
+				else
+					to_chat(src, "<span class='warning'>You don't have enough chemicals stored to do this.</span>")
 
 /mob/living/simple_animal/borer/proc/reset_attack_cooldown()
 	spawn(10)

--- a/code/modules/mob/living/simple_animal/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer.dm
@@ -1137,7 +1137,7 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 					return
 				var/datum/reagents/R = host.reagents
 				if(R)
-					if(R.has_reagent("silicate"))
+					if(R.has_reagent(SILICATE))
 						to_chat(src, "<span class='warning'>Something in your host's bloodstream is tightening their muscles. You can't extend your arm!</span>")
 						return
 				if(host.Adjacent(A))

--- a/code/modules/mob/living/simple_animal/borer/fleshshot.dm
+++ b/code/modules/mob/living/simple_animal/borer/fleshshot.dm
@@ -9,6 +9,11 @@
 	silenced = 1
 	fire_volume = 250
 	maxlength = 10
+	clumsy_check = 0
+	advanced_tool_user_check = 0
+	nymph_check = 0
+	hulk_check = 0
+	golem_check = 0
 	var/mob/living/simple_animal/borer/parent_borer = null
 	var/image/item_overlay = null
 	var/obj/item/to_be_dropped = null //to allow items to be dropped at range

--- a/code/modules/mob/living/simple_animal/borer/fleshshot.dm
+++ b/code/modules/mob/living/simple_animal/borer/fleshshot.dm
@@ -357,6 +357,9 @@
 						if(L.get_held_item_by_index(GRASP_RIGHT_HAND))
 							if(!parent_borer.attack_cooldown)
 								A.attackby(L.get_held_item_by_index(GRASP_RIGHT_HAND), L, 1, parent_borer)
+								if(!parent_borer)	//There's already a check for this above, but for some reason when it hits an airlock it gets qdel()'d before it gets to this point.
+									bullet_die()
+									return
 								parent_borer.attack_cooldown = 1
 								parent_borer.reset_attack_cooldown()
 							bullet_die()
@@ -365,6 +368,9 @@
 						if(L.get_held_item_by_index(GRASP_LEFT_HAND))
 							if(!parent_borer.attack_cooldown)
 								A.attackby(L.get_held_item_by_index(GRASP_LEFT_HAND), L, 1, parent_borer)
+								if(!parent_borer)
+									bullet_die()
+									return
 								parent_borer.attack_cooldown = 1
 								parent_borer.reset_attack_cooldown()
 							bullet_die()

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -2861,6 +2861,16 @@
 	reagent_state = SOLID
 	color = "#FFFFFF" //rgb: 255, 255, 255
 
+/datum/reagent/sodiumchloride/on_mob_life(var/mob/living/M)
+
+	if(..()) return 1
+
+	var/list/borers = M.get_brain_worms()
+	if(borers)
+		for(var/mob/living/simple_animal/borer/B in borers)
+			B.health -= 1
+			to_chat(B, "<span class='warning'>Something in your host's bloodstream burns you!</span>")
+
 /datum/reagent/creatine
 	name = "Creatine"
 	id = CREATINE

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -870,7 +870,7 @@
 	description = "A compound that can be used to repair and reinforce glass."
 	reagent_state = LIQUID
 	color = "#C7FFFF" //rgb: 199, 255, 255
-	overdose = REAGENTS_OVERDOSE
+	overdose = 0
 
 /datum/reagent/oxygen
 	name = "Oxygen"

--- a/html/changelogs/Shadowmech88.yml
+++ b/html/changelogs/Shadowmech88.yml
@@ -1,7 +1,7 @@
 author: Shadowmech88
 delete-after: True
 changes: 
-- tweak: The utility borer's fleshshot now requires 10 chems per shot to use.
+- tweak: The utility borer's fleshshot now requires 10 chems to fire if the borer is using it to swing an item. It costs nothing if the host's hand is empty.
 - tweak: Utility borers are now incapable of using their fleshshot while their host is stunned, or has silicate in their system.
 - rscadd: Borers will now take damage while their host has sodium chloride in their system, and will die from it after roughly 40 seconds.
 - rscadd: Borers now slowly regenerate health while inside a host.

--- a/html/changelogs/Shadowmech88.yml
+++ b/html/changelogs/Shadowmech88.yml
@@ -1,0 +1,7 @@
+author: Shadowmech88
+delete-after: True
+changes: 
+- tweak: The utility borer's fleshshot now requires 10 chems per shot to use.
+- tweak: Utility borers are now incapable of using their fleshshot while their host is stunned, or has silicate in their system.
+- rscadd: Borers will now take damage while their host has sodium chloride in their system, and will die from it after roughly 20 seconds.
+- rscadd: Borers now slowly regenerate health while inside a host.

--- a/html/changelogs/Shadowmech88.yml
+++ b/html/changelogs/Shadowmech88.yml
@@ -5,3 +5,4 @@ changes:
 - tweak: Utility borers are now incapable of using their fleshshot while their host is stunned, or has silicate in their system.
 - rscadd: Borers will now take damage while their host has sodium chloride in their system, and will die from it after roughly 40 seconds.
 - rscadd: Borers now slowly regenerate health while inside a host.
+- rscadd: Borers can now see their health in the status tab.

--- a/html/changelogs/Shadowmech88.yml
+++ b/html/changelogs/Shadowmech88.yml
@@ -3,5 +3,5 @@ delete-after: True
 changes: 
 - tweak: The utility borer's fleshshot now requires 10 chems per shot to use.
 - tweak: Utility borers are now incapable of using their fleshshot while their host is stunned, or has silicate in their system.
-- rscadd: Borers will now take damage while their host has sodium chloride in their system, and will die from it after roughly 20 seconds.
+- rscadd: Borers will now take damage while their host has sodium chloride in their system, and will die from it after roughly 40 seconds.
 - rscadd: Borers now slowly regenerate health while inside a host.


### PR DESCRIPTION
A utility borer must now expend 10 chems <strike>each time</strike> only when it uses the fleshshot to swing a weapon. It costs nothing if the host's hand is empty.
Utility borers are now unable to fire their fleshshot while their host is stunned, or has silicate in their system.
Standard gun checks have been removed from the fleshshot, meaning clowns and hulks and the like are no longer prevented from using it.
Sodium chloride will now damage borers while in their host's bloodstream, taking roughly 40 seconds to kill them.
Borers now slowly regenerate health while inside a host.
Borers can now see their health in the status tab.

I chose silicate for the inhibitor chemical because it had no other special effect on mobs and is literally everywhere in the form of silicate tanks.

Fixes #10638
Fixes #10628
