### PR TITLE
Fixes pai examine

### DIFF
--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -12,7 +12,7 @@
 
 /obj/item/device/paicard/New()
 	..()
-	overlays += "pai-off"
+	overlays += image(icon=icon, icon_state = "pai-off")
 
 #ifdef DEBUG_ROLESELECT
 /obj/item/device/paicard/test/New()
@@ -118,12 +118,12 @@
 
 /obj/item/device/paicard/proc/setPersonality(mob/living/silicon/pai/personality)
 	src.pai = personality
-	src.overlays += "pai-happy"
+	src.overlays += image(icon=icon, icon_state = "pai-happy")
 
 /obj/item/device/paicard/proc/removePersonality()
 	src.pai = null
 	src.overlays.len = 0
-	src.overlays += "pai-off"
+	src.overlays += image(icon=icon, icon_state = "pai-off")
 
 /obj/item/device/paicard/proc/setEmotion(var/emotion)
 	if(pai)
@@ -149,8 +149,8 @@
 			if(16) face = "pai-nose"
 			if(17) face = "pai-kawaii"
 			if(18) face = "pai-cry"
-		src.overlays += "[face]"
-		pai.overlays += "[face]"//we also update the mob's overlay so it appears properly on the scoreboard.
+		src.overlays += image(icon=icon, icon_state = "[face]")
+		pai.overlays += image(icon=icon, icon_state = "[face]")//we also update the mob's overlay so it appears properly on the scoreboard.
 
 /obj/item/device/paicard/proc/alertUpdate()
 	var/turf/T = get_turf(src.loc)


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.
-->


I fixed this literally in a dream, woke up, applied the fix, and didn't even remember what bug I fixed originally until I looked at it.

This fixes the eamine bug where if you examine a pai you would get a sheet of icon states, apparently in byond when you add a string icon state to an overlay it stores the entire dmi in the icon. I don't know why this happens, and I don't know how I fixed it while asleep.