### PR TITLE
Shooting A Pie From A Cannon

### DIFF
--- a/code/modules/projectiles/guns/projectile/constructable/blunderbuss.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/blunderbuss.dm
@@ -97,7 +97,7 @@
 	for(var/i=1, i<=prohibited_items.len, i++)
 		if(istype(W,prohibited_items[i]))
 			item_prohibited = 1
-	if(!loaded_item && istype(W,/obj/item) && !istype(W,/obj/item/weapon/reagent_containers) && !item_prohibited)
+	if(!loaded_item && istype(W,/obj/item) && !W.is_open_container() && !item_prohibited)
 		if(istype(W, /obj/item/stack))
 			var/obj/item/stack/S = W
 			S.use(1)
@@ -113,10 +113,10 @@
 	else if(!loaded_item && item_prohibited)
 		to_chat(user, "<span class='warning'>That won't fit into the muzzle!</span>")
 		return 1
-	else if(loaded_item && istype(W,/obj/item/weapon/reagent_containers))
+	else if(loaded_item && W.is_open_container())
 		to_chat(user, "<span class='warning'>You can't reach the fuel chamber when there's something stuck in the barrel!</span>")
 		return 1
-	else if(!loaded_item && istype(W,/obj/item/weapon/reagent_containers))
+	else if(!loaded_item && W.is_open_container())
 		transfer_fuel(W, user)
 		return 1
 	else if(loaded_item && istype(W,/obj/item))
@@ -127,6 +127,8 @@
 
 /obj/item/weapon/blunderbuss/proc/transfer_fuel(obj/item/weapon/reagent_containers/S, mob/user as mob)
 	if(!S.is_open_container())
+		return
+	if(!istype(S))
 		return
 	if(S.is_empty())
 		to_chat(user, "<span class='warning'>\The [S] is empty.</span>")

--- a/code/modules/projectiles/guns/projectile/constructable/cannon.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/cannon.dm
@@ -91,7 +91,7 @@
 	for(var/i=1, i<=prohibited_items.len, i++)
 		if(istype(W,prohibited_items[i]))
 			item_prohibited = 1
-	if(!loaded_item && istype(W,/obj/item) && !istype(W,/obj/item/weapon/reagent_containers) && !item_prohibited)
+	if(!loaded_item && istype(W,/obj/item) && !W.is_open_container() && !item_prohibited)
 		if(!user.drop_item(W, src))
 			to_chat(user, "<span class='warning'>You can't let go of \the [W]!</span>")
 			return 1
@@ -101,10 +101,10 @@
 	else if(!loaded_item && item_prohibited)
 		to_chat(user, "<span class='warning'>That won't fit into the barrel!</span>")
 		return 1
-	else if(loaded_item && istype(W,/obj/item/weapon/reagent_containers))
+	else if(loaded_item && W.is_open_container())
 		to_chat(user, "<span class='warning'>The fuel needs to be put in before the ammunition!</span>")
 		return 1
-	else if(!loaded_item && istype(W,/obj/item/weapon/reagent_containers))
+	else if(!loaded_item && W.is_open_container())
 		transfer_fuel(W, user)
 		return 1
 	else if(loaded_item && istype(W,/obj/item))
@@ -115,6 +115,8 @@
 
 /obj/structure/bed/chair/vehicle/wheelchair/wheelchair_assembly/cannon/proc/transfer_fuel(obj/item/weapon/reagent_containers/S, mob/user as mob)
 	if(!S.is_open_container())
+		return
+	if(!istype(S))
 		return
 	if(S.is_empty())
 		to_chat(user, "<span class='warning'>\The [S] is empty.</span>")

--- a/html/changelogs/Shadowmech88.yml
+++ b/html/changelogs/Shadowmech88.yml
@@ -1,0 +1,4 @@
+author: Shadowmech88
+delete-after: True
+changes: 
+- tweak: Food items can now be loaded into the blunderbuss and the cannon. Drinks can as well, as long as the container isn't open.


### PR DESCRIPTION
Blunderbusses and cannons now only disallow open containers instead of all reagent_containers. This means that food items can now be loaded and fired, as well as drinks if the container isn't open.
