### PR TITLE
lazarus capsules now display the name of the contained mob.

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -309,6 +309,7 @@
 		NM.faction = "lazarus \ref[user]"
 		NM.friends += user
 		MC.contained_mob = NM
+		MC.name = "lazarus capsule - [NM.name]"
 	..()
 
 /obj/item/weapon/storage/belt/thunderdome

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -721,10 +721,11 @@ proc/move_mining_shuttle()
 			to_chat(user, "<span class='warning'>\The [src] briefly flashes an error.</span>")
 			return 0
 		spawn()
-			var/name = sanitize(input("Choose a name for your friend.", "Name your friend", contained_mob.name) as text|null)
-			if(name)
-				contained_mob.name = name
+			var/mname = sanitize(input("Choose a name for your friend.", "Name your friend", contained_mob.name) as text|null)
+			if(mname)
+				contained_mob.name = mname
 				to_chat(user, "<span class='notice'>Renaming successful, say hello to [contained_mob]</span>")
+				name = "lazarus capsule - [mname]"
 	..()
 
 /obj/item/device/mobcapsule/throw_impact(atom/A, mob/user)
@@ -756,6 +757,7 @@ proc/move_mining_shuttle()
 		return 0
 	AM.loc = src
 	contained_mob = AM
+	name = "lazarus capsule - [AM.name]"
 	return 1
 
 /obj/item/device/mobcapsule/pickup(mob/user)
@@ -783,6 +785,7 @@ proc/move_mining_shuttle()
 			contained_mob.client.eye = contained_mob.client.mob
 			contained_mob.client.perspective = MOB_PERSPECTIVE
 		contained_mob = null
+		name = "lazarus capsule"
 
 /obj/item/device/mobcapsule/attack_self(mob/user)
 	colorindex += 1


### PR DESCRIPTION
Basically just renames the capsule using the contained mobs name so you know what the hells inside the ball.
![1](https://cloud.githubusercontent.com/assets/14299601/16230454/6991e1c2-37b9-11e6-8609-a08a554aceee.jpg)
-Will update when you custom name the mob.

![2](https://cloud.githubusercontent.com/assets/14299601/16230453/699178e0-37b9-11e6-8a53-146c59c78606.jpg)
-This is how it looks when empty + the contained mob released.

![3](https://cloud.githubusercontent.com/assets/14299601/16230452/6990c4f4-37b9-11e6-8eb4-8ed396a4b4cb.jpg)
-This is how it looks when the mob has it's generic name.

Antag belt was also updated since it does a bespoke bonding process to make it work.
