### PR TITLE
Teleporter code cleanup / test fire tweak

### DIFF
--- a/html/changelogs/Intigracyteleporter.yml
+++ b/html/changelogs/Intigracyteleporter.yml
@@ -1,0 +1,4 @@
+author: Intigracy
+delete-after: True
+changes: 
+- tweak: "Test firing a teleporter will now remove the 5% chance of spacing you for 3 seconds."


### PR DESCRIPTION
~~Removes a bunch of unused code (like the var that only existed for the clown planet card which got removed)~~

Removes an unused "active" var, moves "engaged" var define to the parent of the station/hub.

Test firing a teleporter will now remove the 5% chance of spacing you for 3 seconds. (a bunch of people believed that this was already true, myself included)

Tested extensively.
