### PR TITLE
Quick equip prioritizes putting objects into belts

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -17,6 +17,12 @@
 	else
 		return 0
 
+/obj/item/weapon/storage/belt/can_quick_store(var/obj/item/I)
+	return can_be_inserted(I,1)
+	
+/obj/item/weapon/storage/belt/quick_store(var/obj/item/I)
+	return handle_item_insertion(I,0)
+
 /obj/item/weapon/storage/belt/utility
 	name = "tool-belt" //Carn: utility belt is nicer, but it bamboozles the text parsing.
 	desc = "It has a tag that rates it for compatibility with standard tools, device analyzers, flashlights, cables, engineering tape, small fire extinguishers, compressed matter cartridges, light replacers, and fuel cans."

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -350,6 +350,12 @@ a {
 
 /obj/proc/verb_pickup(mob/living/user)
 	return 0
+	
+/obj/proc/can_quick_store(var/obj/item/I) //proc used to check that the current object can store another through quick equip
+	return 0
+	
+/obj/proc/quick_store(var/obj/item/I) //proc used to handle quick storing
+	return 0
 
 /**
  * If a mob logouts/logins in side of an object you can use this proc.

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -578,11 +578,17 @@ var/list/slot_equipment_priority = list( \
 //puts the item "W" into an appropriate slot in a human's inventory
 //returns 0 if it cannot, 1 if successful
 /mob/proc/equip_to_appropriate_slot(obj/item/W)
-	if(!istype(W)) return 0
+	if(!istype(W))
+		return 0
 
 	for(var/slot in slot_equipment_priority)
+		
 		if(equip_to_slot_if_possible(W, slot, 0, 1, 1, 1)) //act_on_fail = 0; disable_warning = 0; redraw_mob = 1
 			return 1
+		if(get_item_by_slot(slot))
+			var/obj/item/S = get_item_by_slot(slot)
+			if(S.can_quick_store(W)) //check if the current object can be quick stored
+				return (S.quick_store(W))
 
 	return 0
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -582,13 +582,13 @@ var/list/slot_equipment_priority = list( \
 		return 0
 
 	for(var/slot in slot_equipment_priority)
-		
-		if(equip_to_slot_if_possible(W, slot, 0, 1, 1, 1)) //act_on_fail = 0; disable_warning = 0; redraw_mob = 1
-			return 1
 		if(get_item_by_slot(slot))
 			var/obj/item/S = get_item_by_slot(slot)
 			if(S.can_quick_store(W)) //check if the current object can be quick stored
 				return (S.quick_store(W))
+
+		if(equip_to_slot_if_possible(W, slot, 0, 1, 1, 1)) //act_on_fail = 0; disable_warning = 0; redraw_mob = 1
+			return 1
 
 	return 0
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -584,7 +584,7 @@ var/list/slot_equipment_priority = list( \
 	for(var/slot in slot_equipment_priority)
 		var/obj/item/S = get_item_by_slot(slot)
 		if(S && S.can_quick_store(W))
-			return (S.quick_store(W))
+			return S.quick_store(W)
 		if(equip_to_slot_if_possible(W, slot, 0, 1, 1, 1)) //act_on_fail = 0; disable_warning = 0; redraw_mob = 1
 			return 1
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -582,11 +582,9 @@ var/list/slot_equipment_priority = list( \
 		return 0
 
 	for(var/slot in slot_equipment_priority)
-		if(get_item_by_slot(slot))
-			var/obj/item/S = get_item_by_slot(slot)
-			if(S.can_quick_store(W)) //check if the current object can be quick stored
-				return (S.quick_store(W))
-
+		var/obj/item/S = get_item_by_slot(slot)
+		if(S && S.can_quick_store(W))
+			return (S.quick_store(W))
 		if(equip_to_slot_if_possible(W, slot, 0, 1, 1, 1)) //act_on_fail = 0; disable_warning = 0; redraw_mob = 1
 			return 1
 

--- a/html/changelogs/JustSumBody.yml
+++ b/html/changelogs/JustSumBody.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general deleting of nice things)
+#   rscadd (general adding of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.
+author: JustSumBody
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# There needs to be a space after the - and before the prefix. Don't use tabs anywhere in this file.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# If you're using characters such as # ' : - or the like in your changelog, surround the entire change with quotes as shown in the second example. These quotes don't show up on the changelog once it's merged and prevent errors.
+# SCREW ANY OF THIS UP AND IT WON'T WORK.
+changes: 
+- rscadd: Quick equip will now prioritize placing items into equipped belts over pockets and suit storage.


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.
-->

Closes #10556 
Quick equip will now prioritize placing an item in an equipped belt rather than in the suit storage or pockets. Functionality for other items to have this property is in place through quick_store and can_quick_store. 
Now with 90% less hardcode
I never realized how much I really wanted this until I went from borg to carbon and kept dropping things.
