### PR TITLE
Unsnowflakes phazon turfs

### DIFF
--- a/code/game/objects/items/stacks/tiles/mineral.dm
+++ b/code/game/objects/items/stacks/tiles/mineral.dm
@@ -138,3 +138,6 @@
 	origin_tech = "materials=9"
 
 	material = "phazon"
+
+/obj/item/stack/tile/mineral/phazon/adjust_slowdown(mob/living/L, current_slowdown)
+	return -1

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -8,6 +8,9 @@
 /obj/item/stack/tile
 	var/material
 
+/obj/item/stack/tile/proc/adjust_slowdown(mob/living/L, current_slowdown)
+	return current_slowdown
+
 /obj/item/stack/tile/ex_act(severity)
 	switch(severity)
 		if(1.0)

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -651,7 +651,7 @@ turf/simulated/floor/update_icon()
 
 /turf/simulated/floor/adjust_slowdown(mob/living/L, current_slowdown)
 	//Phazon floors make movement instant
-	if(material == "phazon")
-		return -1
+	if(floor_tile)
+		return floor_tile.adjust_slowdown(L, current_slowdown)
 
 	return ..()

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -648,3 +648,10 @@ turf/simulated/floor/update_icon()
 		icon_state = "cult"
 		turf_animation('icons/effects/effects.dmi',"cultfloor",0,0,MOB_LAYER-1,anim_plane = PLANE_OBJ)
 	return
+
+/turf/simulated/floor/adjust_slowdown(mob/living/L, current_slowdown)
+	//Phazon floors make movement instant
+	if(material == "phazon")
+		return -1
+
+	return ..()

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -690,3 +690,8 @@
 /turf/proc/soft_add_holomap(var/atom/movable/AM)
 	if (!ticker || ticker.current_state != GAME_STATE_PLAYING)
 		add_holomap(AM)
+
+// Return -1 to make movement instant for the mob
+// Return high values to make movement slower
+/turf/proc/adjust_slowdown(mob/living/L, base_slowdown)
+	return base_slowdown

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/drone.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/drone.dm
@@ -7,7 +7,13 @@
 	plasma_rate = 15
 
 /mob/living/carbon/alien/humanoid/drone/movement_delay()
-	return (2 + move_delay_add + config.alien_delay) //Drones are slow
+	var/tally = 2 + move_delay_add + config.alien_delay //Drones are slow
+
+	var/turf/T = loc
+	if(istype(T))
+		tally = T.adjust_slowdown(src, tally)
+
+	return tally
 
 /mob/living/carbon/alien/humanoid/drone/New()
 	var/datum/reagents/R = new/datum/reagents(100)

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
@@ -9,7 +9,13 @@
 	plasma_rate = 5
 
 /mob/living/carbon/alien/humanoid/hunter/movement_delay()
-	return (-2 + move_delay_add + config.alien_delay) //Hunters are fast
+	var/tally = -2 + move_delay_add + config.alien_delay //Hunters are fast
+
+	var/turf/T = loc
+	if(istype(T))
+		tally = T.adjust_slowdown(src, tally)
+
+	return tally
 
 /mob/living/carbon/alien/humanoid/hunter/New()
 	var/datum/reagents/R = new/datum/reagents(100)

--- a/code/modules/mob/living/carbon/alien/humanoid/queen.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/queen.dm
@@ -9,12 +9,16 @@
 	plasma_rate = 20
 
 /mob/living/carbon/alien/humanoid/queen/movement_delay()
-	return (5 + move_delay_add + config.alien_delay) //Queens are slow as fuck
+	var/tally = 5 + move_delay_add + config.alien_delay //Queens are slow as fuck
+
+	var/turf/T = loc
+	if(istype(T))
+		tally = T.adjust_slowdown(src, tally)
+
+	return tally
 
 /mob/living/carbon/alien/humanoid/queen/New()
-	var/datum/reagents/R = new/datum/reagents(100)
-	reagents = R
-	R.my_atom = src
+	create_reagents(100)
 
 	//there should only be one queen
 	for(var/mob/living/carbon/alien/humanoid/queen/Q in living_mob_list)

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -3,12 +3,15 @@
 
 	if(flying) return -1
 
-	if(istype(loc,/turf/simulated/floor))
-		var/turf/simulated/floor/T = loc
-		if(T.material=="phazon")
-			return -1 // Phazon floors make us go fast
-
 	var/tally = 0
+
+	var/turf/T = loc
+	if(istype(T))
+		tally = T.adjust_slowdown(src, tally)
+
+		if(tally == -1)
+			return tally
+
 	if(species && species.move_speed_mod)
 		tally += species.move_speed_mod
 

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -145,10 +145,13 @@
 
 /mob/living/carbon/monkey/movement_delay()
 	var/tally = 0
-	if(reagents)
-		if(reagents.has_reagent(HYPERZINE)) return -1
 
-		if(reagents.has_reagent(NUKA_COLA)) return -1
+	if(reagents)
+		if(reagents.has_reagent(HYPERZINE))
+			return -1
+
+		if(reagents.has_reagent(NUKA_COLA))
+			return -1
 
 	var/health_deficiency = (100 - health)
 	if(health_deficiency >= 45) tally += (health_deficiency / 25)
@@ -156,11 +159,12 @@
 	if (bodytemperature < 283.222)
 		tally += (283.222 - bodytemperature) / 10 * 1.75
 
-	if(istype(loc,/turf/simulated/floor))
-		var/turf/simulated/floor/T = loc
+	var/turf/T = loc
+	if(istype(T))
+		tally = T.adjust_slowdown(src, tally)
 
-		if(T.material=="phazon")
-			return -1 // Phazon floors make us go fast
+		if(tally == -1)
+			return tally
 
 	return tally+config.monkey_delay
 

--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -104,6 +104,13 @@
 /mob/living/carbon/slime/movement_delay()
 	var/tally = 0
 
+	var/turf/T = loc
+	if(istype(T))
+		tally = T.adjust_slowdown(src, tally)
+
+		if(tally == -1)
+			return tally
+
 	var/health_deficiency = (100 - health)
 	if(health_deficiency >= 45) tally += (health_deficiency / 25)
 

--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -15,11 +15,12 @@
 	if(module_active && istype(module_active,/obj/item/borg/combat/mobility))
 		tally-=3 // JESUS FUCKING CHRIST WHY
 
-	if(istype(loc,/turf/simulated/floor))
-		var/turf/simulated/floor/T = loc
+	var/turf/T = loc
+	if(istype(T))
+		tally = T.adjust_slowdown(src, tally)
 
-		if(T.material=="phazon")
-			return -1 // Phazon floors make us go fast
+		if(tally == -1)
+			return tally
 
 	return tally+config.robot_delay
 

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -618,7 +618,7 @@
 /mob/living/simple_animal/parrot/movement_delay()
 	if(client && stat == CONSCIOUS && parrot_state != "parrot_fly")
 		icon_state = "parrot_fly"
-	..()
+	return ..()
 
 /mob/living/simple_animal/parrot/proc/isStuck()
 	//Check to see if the parrot is stuck due to things like windows or doors or windowdoors

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -544,11 +544,12 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 			tally = 1
 		tally *= purge
 
-	if(istype(loc,/turf/simulated/floor))
-		var/turf/simulated/floor/T = loc
+	var/turf/T = loc
+	if(istype(T))
+		tally = T.adjust_slowdown(src, tally)
 
-		if(T.material=="phazon")
-			return -1 // Phazon floors make us go fast
+		if(tally == -1)
+			return tally
 
 	return tally+config.animal_delay
 

--- a/html/changelogs/unid-fast.yml
+++ b/html/changelogs/unid-fast.yml
@@ -1,0 +1,6 @@
+author: Unid
+
+delete-after: True
+
+changes: 
+- bugfix: Phazon floors now affect all types of mobs, not only a few of them


### PR DESCRIPTION
- Added turf proc adjust_slowdown(mob, current_delay) and made phazon floors use it
- Added the adjust_slowdown proc to all mobs, now all mobs are affected by phazon floors (aliens too)
- AI controlled simple_animals aren't affected because of the way they're coded, sadly. Player controlled ones are fine though
