### PR TITLE
PROBABLY fixes items getting stuck dense after being fucked with by ZAS

### DIFF
--- a/code/ZAS/Airflow.dm
+++ b/code/ZAS/Airflow.dm
@@ -350,9 +350,9 @@ proc/AirflowSpace(zone/A)
 			if ((!( src.airflow_dest ) || src.loc == src.airflow_dest))
 				airflow_dest = locate(Clamp(x + xo, 1, world.maxx), Clamp(y + yo, 1, world.maxy), z)
 			if ((src.x == 1 || src.x == world.maxx || src.y == 1 || src.y == world.maxy))
-				return
+				break
 			if (!isturf(loc))
-				return
+				break
 			step_towards(src, src.airflow_dest)
 			if(ismob(src) && src:client)
 				var/mob/M = src


### PR DESCRIPTION
At the very least, fixes one cause of it. It's the only one I could find, but maybe there are still others.
(Technically it fixes two causes, but one is such an unlikely case it probably never happened ever)

> tfw an almost-identical proc we DON'T use was already fixed but not the one we DO use

Fixes #8252 and fixes #10727, unless shown otherwise.
