### PR TITLE
I totally have no idea how can silicons attack_hand their location again, but as long as they do...

### DIFF
--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -126,6 +126,9 @@
 	attack_hand(user)
 
 /obj/machinery/recharge_station/attack_hand(var/mob/user)
+	if(occupant == user)
+		apply_cell_upgrade()
+		return
 	if(upgrade_holder.len && !upgrading)
 		var/obj/removed = input(user, "Choose an item to remove.",upgrade_holder[1]) as null|anything in upgrade_holder
 		if(!removed || upgrading)


### PR DESCRIPTION
Fixes #10781

Fortunately, silicons still can't attack their location with items, for some reason, somehow, I don't know
