### PR TITLE
Limits blob cores by population

### DIFF
--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -24,7 +24,7 @@ var/list/blob_overminds = list()
 	var/nuclear = 0
 
 	var/cores_to_spawn = 15
-	var/players_per_core = 30
+	var/players_per_core = BLOB_CORE_PROPORTION
 	var/blob_point_rate = 3
 
 	var/blobwincount = 750 // WAS: 500

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -29,6 +29,7 @@
 			spawn_meteor(chosen_dir, meteor_type)
 		sleep(50) //Five seconds for the chat to scroll
 		meteor_wave_active = 0
+	return chosen_dir
 
 //A bunch of information to be used by the bhangmeter (doubles as a meteor monitoring computer), and sent to the admins otherwise
 /proc/output_information(var/meteor_delay, var/wave_dir, var/meteor_size, var/wave_size, var/wave_name)

--- a/code/modules/events/event_dynamic.dm
+++ b/code/modules/events/event_dynamic.dm
@@ -64,9 +64,9 @@ var/list/event_last_fired = list()
 		possibleEvents[/datum/event/meteor_wave] = 15
 		possibleEvents[/datum/event/meteor_shower] = 40
 		possibleEvents[/datum/event/immovable_rod] = 15
-		possibleEvents[/datum/event/thing_storm/blob_shower] = 25//Blob Cluster
+		possibleEvents[/datum/event/thing_storm/blob_shower] = 15//Blob Cluster
 
-	if((active_with_role["Engineer"] > 1) && (active_with_role["Security"] > 1) && (living >= 25))
+	if((active_with_role["Engineer"] > 1) && (active_with_role["Security"] > 1) && (living >= BLOB_CORE_PROPORTION))
 		possibleEvents[/datum/event/thing_storm/blob_storm] = 10//Blob Conglomerate
 
 	possibleEvents[/datum/event/radiation_storm] = 50

--- a/code/modules/events/meteors.dm
+++ b/code/modules/events/meteors.dm
@@ -107,7 +107,6 @@ var/global/list/thing_storm_types = list(
 		/obj/item/projectile/meteor/blob/node,
 		/obj/item/projectile/meteor/blob/node,
 		/obj/item/projectile/meteor/blob/node,
-		/obj/item/projectile/meteor/blob/core,
 	),
 )
 
@@ -166,13 +165,22 @@ var/global/list/thing_storm_types = list(
 	command_alert("The station has cleared the Blob cluster. Eradicate the blob from hit areas.", "Blob Cluster")
 
 /datum/event/thing_storm/blob_storm
+	var/cores_spawned = 0
 
 /datum/event/thing_storm/blob_storm/setup()
 	endWhen = rand(60, 90) + 10
 	storm_name="blob storm"
 
 /datum/event/thing_storm/blob_storm/tick()
-	meteor_wave(rand(20, 40), types = thing_storm_types[storm_name])
+	var/chosen_dir = meteor_wave(rand(20, 40), types = thing_storm_types[storm_name])
+	if(!cores_spawned)
+		var/living = 0
+		for(var/mob/living/M in player_list)
+			if(M.stat == CONSCIOUS)
+				living++
+		cores_spawned = round(living/BLOB_CORE_PROPORTION) //Cores spawned depends on living players
+		for(var/i = 0 to cores_spawned)
+			spawn_meteor(chosen_dir, /obj/item/projectile/meteor/blob/core)
 
 /datum/event/thing_storm/blob_storm/announce()
 	command_alert("The station is about to pass through a Blob conglomerate. Overmind brainwaves possibly detected.", "Blob Conglomerate")

--- a/code/setup.dm
+++ b/code/setup.dm
@@ -1804,3 +1804,5 @@ var/proccalls = 1
 //Grasp indexes
 #define GRASP_RIGHT_HAND 1
 #define GRASP_LEFT_HAND 2
+
+#define BLOB_CORE_PROPORTION 20


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.
-->


Sets blobs to a standard proportion of how many players need to be ingame per blob spawned. 

Lowered that quantity from 30 people required to blob to 20 per blob, applied that same proportion to the event dynamic (which previously did not check the number of people per blob spawned).