### PR TITLE
Double agents sometimes receive a third objective

### DIFF
--- a/code/game/gamemodes/traitor/doubleagent.dm
+++ b/code/game/gamemodes/traitor/doubleagent.dm
@@ -9,7 +9,6 @@
 	traitor_name = "double agent"
 
 	var/list/target_list = list()
-	var/list/required_protection = list() //Civilians chosen for assassinate targets. Other agents get objectives to protect them
 
 /datum/game_mode/traitor/double_agents/announce()
 	to_chat(world, "<B>The current game mode is - Double Agents!</B>")

--- a/code/game/gamemodes/traitor/doubleagent.dm
+++ b/code/game/gamemodes/traitor/doubleagent.dm
@@ -9,6 +9,7 @@
 	traitor_name = "double agent"
 
 	var/list/target_list = list()
+	var/list/required_protection = list() //Civilians chosen for assassinate targets. Other agents get objectives to protect them
 
 /datum/game_mode/traitor/double_agents/announce()
 	to_chat(world, "<B>The current game mode is - Double Agents!</B>")
@@ -87,6 +88,33 @@
 			kill_objective.find_target()
 		traitor.objectives += kill_objective
 
+	if(prob(20))
+		var/datum/mind/protector = pick(traitors - traitor)
+
+		if(protector)
+			var/datum/objective/assassinate/kill_objective = new
+			kill_objective.owner = traitor
+			kill_objective.find_target()
+
+			//Make sure that the target exists, and that we don't already have an objective to protect the target
+			var/block_objective_generation = 0
+			if(!kill_objective.target)
+				block_objective_generation = 1
+			else
+				for(var/datum/objective/protect/P in traitor.objectives)
+					if(P.target == kill_objective.target)
+						block_objective_generation = 1
+						break
+
+			if(!block_objective_generation)
+				kill_objective.explanation_text = "[kill_objective.explanation_text] Be wary, they may be under protection of another agent."
+				traitor.objectives += kill_objective
+
+				var/datum/objective/protect/protect_objective = new
+				protect_objective.owner = protector
+				protect_objective.target = kill_objective.target
+				protect_objective.explanation_text = "Protect [protect_objective.target.current.real_name], the [protect_objective.target.assigned_role] from another agent."
+				protector.objectives += protect_objective
 
 	// Escape
 	if(prob(15))

--- a/html/changelogs/unid-triple_agents.yml
+++ b/html/changelogs/unid-triple_agents.yml
@@ -1,0 +1,6 @@
+author: Unid
+
+delete-after: True
+
+changes: 
+- rscadd: Double agents now have a 20% chance to receive an objective to assassinate a civilian (non-antagonist). When such an objective is given, another double agent receives an objective to protect the civilian.


### PR DESCRIPTION
Double agents have a 20% chance to receive a second assassination objective - that can target both civilians and traitors.

When they receive such an objective, another double agent receives an objective to protect the target!

_0% tested because I have no idea how, but I tried to make the code unlikely to break_
