### PR TITLE
Cult sword xenoarch find tweak

### DIFF
--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/melee/cultblade
 	name = "Cult Blade"
-	desc = "An arcane weapon wielded by the followers of Nar-Sie"
+	desc = "An arcane weapon wielded by the followers of Nar-Sie."
 	icon_state = "cultblade"
 	item_state = "cultblade"
 	flags = FPRINT
@@ -9,12 +9,17 @@
 	throwforce = 10
 	sharpness = 1.35
 	attack_verb = list("attacks", "slashes", "stabs", "slices", "tears", "rips", "dices", "cuts")
+	var/checkcult = 1
+
+/obj/item/weapon/melee/cultblade/nocult
+	checkcult = 0
+	force = 15
 
 /obj/item/weapon/melee/cultblade/cultify()
 	return
 
 /obj/item/weapon/melee/cultblade/attack(mob/living/target as mob, mob/living/carbon/human/user as mob)
-	if(iscultist(user))
+	if(!checkcult || iscultist(user))
 		playsound(loc, 'sound/weapons/bladeslice.ogg', 50, 1, -1)
 		return ..()
 	else
@@ -23,10 +28,10 @@
 		var/datum/organ/external/affecting = user.get_active_hand_organ()
 		if(affecting && affecting.take_damage(rand(force/2, force))) //random amount of damage between half of the blade's force and the full force of the blade.
 			user.UpdateDamageIcon()
-	return
+
 
 /obj/item/weapon/melee/cultblade/pickup(mob/living/user as mob)
-	if(!iscultist(user))
+	if(checkcult && !iscultist(user))
 		to_chat(user, "<span class='warning'>An overwhelming feeling of dread comes over you as you pick up the cultist's sword. It would be wise to be rid of this blade quickly.</span>")
 		user.Dizzy(120)
 

--- a/code/modules/research/xenoarchaeology/finds/finds.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds.dm
@@ -274,7 +274,7 @@
 		if(17)
 			//cultblade
 			apply_prefix = 0
-			new_item = new /obj/item/weapon/melee/cultblade(src.loc)
+			new_item = new /obj/item/weapon/melee/cultblade/nocult(src.loc)
 			apply_material_decorations = 0
 			apply_image_decorations = 0
 		if(18)

--- a/html/changelogs/Inticultblade.yml
+++ b/html/changelogs/Inticultblade.yml
@@ -1,0 +1,4 @@
+author: Intigracy
+delete-after: True
+changes: 
+- tweak: "Cult blades found through Xenoarchaeology no longer require you to be a cultist to use them. As a result, they also have only 15 force as opposed to 30."


### PR DESCRIPTION
+- tweak: "Cult blades found through Xenoarchaeology no longer require you to be a cultist to use them. As a result, they also have only 15 force as opposed to 30."
