### PR TITLE
removes the invisible enruranium again

### DIFF
--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -298,21 +298,6 @@ var/global/list/datum/stack_recipe/clown_recipes = list ( \
 	..()
 
 /****************************** Others ****************************/
-
-/*
- * Enriched Uranium
- */
-/obj/item/stack/sheet/mineral/enruranium
-	name = "enriched uranium"
-	icon_state = "sheet-enruranium"
-	force = 5.0
-	throwforce = 5
-	w_class = W_CLASS_MEDIUM
-	throw_speed = 3
-	throw_range = 3
-	origin_tech = "materials=5"
-	perunit = 1000
-
 /*
  * Adamantine
  */

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -169,7 +169,7 @@ var/global/list/crate_mimic_disguises = list(\
 		//Drop all loot!
 		for(var/atom/movable/AM in src)
 			AM.forceMove(C)
-	
+
 	..()
 
 /mob/living/simple_animal/hostile/mimic/crate/initialize()
@@ -380,7 +380,7 @@ var/global/list/item_mimic_disguises = list(
 	"botany" = existing_typesof(/obj/item/weapon/reagent_containers/food/snacks/grown), //All grown items
 
 	//Nuke, nuke disk, all coins, all minerals (except for those with no icons)
-	"vault" = list(/obj/machinery/nuclearbomb, /obj/item/weapon/disk/nuclear) + typesof(/obj/item/weapon/coin) + typesof(/obj/item/stack/sheet/mineral) - /obj/item/stack/sheet/mineral - /obj/item/stack/sheet/mineral/enruranium,
+	"vault" = list(/obj/machinery/nuclearbomb, /obj/item/weapon/disk/nuclear) + typesof(/obj/item/weapon/coin) + typesof(/obj/item/stack/sheet/mineral) - /obj/item/stack/sheet/mineral,
 
 	"chapel" = list(/obj/item/weapon/storage/bible, /obj/item/clothing/head/chaplain_hood, /obj/item/clothing/head/helmet/space/plasmaman/chaplain, /obj/item/clothing/suit/chaplain_hoodie, /obj/item/clothing/suit/space/plasmaman/chaplain,\
 				/obj/item/device/pda/chaplain, /obj/item/weapon/nullrod, /obj/item/weapon/reagent_containers/food/drinks/bottle/holywater, /obj/item/weapon/staff), //Chaplain garb, null rod, bible, holy water

--- a/code/modules/research/xenoarchaeology/finds/finds.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds.dm
@@ -236,7 +236,7 @@
 			possible_spawns += /obj/item/stack/sheet/mineral/mythril
 			possible_spawns += /obj/item/stack/sheet/mineral/gold
 			possible_spawns += /obj/item/stack/sheet/mineral/silver
-			possible_spawns += /obj/item/stack/sheet/mineral/enruranium
+			possible_spawns += /obj/item/stack/sheet/mineral/uranium
 			possible_spawns += /obj/item/stack/sheet/mineral/sandstone
 			possible_spawns += /obj/item/stack/sheet/mineral/silver
 


### PR DESCRIPTION
It has never had an icon or a use, and as such is a waste of xenoarch finds.

I say again because I tried almost a year ago. #5509
