### PR TITLE
Fixes storing items in carved out books

### DIFF
--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -244,7 +244,7 @@
 /obj/item/weapon/book/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(carved)
 		if(!store)
-			if(W.w_class > W_CLASS_MEDIUM)
+			if(W.w_class < W_CLASS_MEDIUM)
 				if(user.drop_item(W, src))
 					store = W
 					to_chat(user, "<span class='notice'>You put [W] in [title].</span>")


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.
-->

closes #10305
Can no longer store large items in carved out books
Can now properly store small and tiny items in carved out books
