### PR TITLE
Fixes Hydroponics2 Icons

### DIFF
--- a/code/modules/hydroponics/seed_datums.dm
+++ b/code/modules/hydroponics/seed_datums.dm
@@ -694,6 +694,7 @@ var/global/list/gene_tag_masks = list()   // Gene obfuscation for delicious tria
 	new_seed.biolum =               biolum
 	new_seed.biolum_colour =        biolum_colour
 	new_seed.alter_temp = 			alter_temp
+	new_seed.plant_dmi =			plant_dmi
 
 	ASSERT(istype(new_seed)) //something happened... oh no...
 	return new_seed

--- a/html/changelogs/Kurfurst.yml
+++ b/html/changelogs/Kurfurst.yml
@@ -1,0 +1,5 @@
+author: Kurfurst
+delete-after: True
+
+changes: 
+- bugfix: Fixed a bug where any plant with images in hydroponics2.dmi would disappear when modified. These included diona nodes, Vox plants, cinnamonum.


### PR DESCRIPTION
Following @Deitylink 's example, I started adding new plants to hydroponics2.dmi - but in testing I noticed these plants disappeared when modified (e.g.: with Robust Harvest). This was because diverge() did not copy over plant_dmi, as I discovered with the aid of @9600bauds 

This fixes it so that those plants will not vanish leaving seemingly empty trays. Fully tested and includes changelog.
