### PR TITLE
fixes #10719

### DIFF
--- a/code/modules/mob/living/carbon/monkey/life.dm
+++ b/code/modules/mob/living/carbon/monkey/life.dm
@@ -7,6 +7,7 @@
 	var/pressure_alert = 0
 	base_insulation = 0.5
 	var/temperature_alert = 0
+	var/safe_oxygen_min = 16 // Minimum safe partial pressure of O2, in kPa
 
 
 /mob/living/carbon/monkey/Life()
@@ -311,7 +312,7 @@
 
 		return 0
 
-	var/safe_oxygen_min = 16 // Minimum safe partial pressure of O2, in kPa
+
 	//var/safe_oxygen_max = 140 // Maximum safe partial pressure of O2, in kPa (Not used for now)
 	var/safe_co2_max = 10 // Yes it's an arbitrary value who cares?
 	var/safe_toxins_max = 0.5

--- a/code/modules/mob/living/carbon/monkey/vox.dm
+++ b/code/modules/mob/living/carbon/monkey/vox.dm
@@ -10,6 +10,7 @@
 	meat_type = /obj/item/weapon/reagent_containers/food/snacks/meat/rawchicken
 	canWearClothes = 0
 	canWearGlasses = 0
+	safe_oxygen_min = 0
 	var/eggsleft
 	var/eggcost = 250
 	languagetoadd = "Vox-pidgin"


### PR DESCRIPTION
Just a small fix to make it so that Vox chickens don't suffocate in oxygenless environs. They still can't survive if there is no nitrogen, though.

fixes #10719 

It's a matter of debate whether they should be poisoned by oxygen, but since they aren't allowed to pick things up or wear suits, it seemed a little unfair to expect them to hold an N2 tank.
