### PR TITLE
Local coder makes get_turf() 50+% faster with this one weird trick!

### DIFF
--- a/code/__HELPERS/_macros.dm
+++ b/code/__HELPERS/_macros.dm
@@ -185,6 +185,9 @@
 	dview_mob.see_invisible = invis_flags; \
 	for(type in view(range, dview_mob))
 
+//get_turf(): Returns the turf that contains the atom.
+//Example: A fork inside a box inside a locker will return the turf the locker is standing on.
+//Yes, this is the fastest known way to do it.
 #define get_turf(A) (get_step(A, 0))
 
 //HARDCORE MODE STUFF (mainly hunger)

--- a/code/__HELPERS/_macros.dm
+++ b/code/__HELPERS/_macros.dm
@@ -185,6 +185,8 @@
 	dview_mob.see_invisible = invis_flags; \
 	for(type in view(range, dview_mob))
 
+#define get_turf(A) (get_step(A, 0))
+
 //HARDCORE MODE STUFF (mainly hunger)
 
 #define hardcore_mode_on (hardcore_mode)//((ticker) && (ticker.hardcore_mode))

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1091,6 +1091,20 @@ proc/get_mob_with_client_list()
 			return zone
 
 /*
+	get_turf(): Returns the turf that contains the atom.
+	Example: A fork inside a box inside a locker will return the turf the locker is standing on.
+	The weird for loop with an empty statement is apparently the fastest way possible to do this.
+
+	This is now a macro, over in _macros.dm. It's functionally the same, but the code is different and much faster.
+*/
+///proc/get_turf(const/atom/O)
+//	if(!istype(O) || isarea(O))
+//		return
+//	var/atom/A
+//	for(A=O, A && !isturf(A), A=A.loc);  // semicolon is for the empty statement
+//	return A
+
+/*
 	get_holder_at_turf_level(): Similar to get_turf(), will return the "highest up" holder of this atom, excluding the turf.
 	Example: A fork inside a box inside a locker will return the locker. Essentially, get_just_before_turf().
 */

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1091,20 +1091,6 @@ proc/get_mob_with_client_list()
 			return zone
 
 /*
-	get_turf(): Returns the turf that contains the atom.
-	Example: A fork inside a box inside a locker will return the turf the locker is standing on.
-	The weird for loop with an empty statement is apparently the fastest way possible to do this.
-
-	This is now a macro, over in _macros.dm. It's functionally the same, but the code is different and much faster.
-*/
-///proc/get_turf(const/atom/O)
-//	if(!istype(O) || isarea(O))
-//		return
-//	var/atom/A
-//	for(A=O, A && !isturf(A), A=A.loc);  // semicolon is for the empty statement
-//	return A
-
-/*
 	get_holder_at_turf_level(): Similar to get_turf(), will return the "highest up" holder of this atom, excluding the turf.
 	Example: A fork inside a box inside a locker will return the locker. Essentially, get_just_before_turf().
 */

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -653,72 +653,6 @@ proc/GaussRandRound(var/sigma,var/roundto)
 
 	return 1
 
-//A prototype implementation of can_see() that doesn't suck massive ass. Ignores darkness.
-//The functional part of this is probably completely inscrutable unless you understand BYOND occlusion very well.
-/proc/accurate_can_see(var/atom/source, var/atom/target, var/length=world.view)
-	if(source.z != target.z) //Can't see things on other Z-levels.
-		return 0
-
-	var/dx = target.x - source.x
-	var/dy = target.y - source.y
-	if(dx > length || dy > length) //Too far away
-		return 0
-
-	var/Xdir = 0 //Whether the target is to the east or west of the source.
-	if(dx)
-		if(dx > 0)
-			Xdir = EAST
-		else
-			Xdir = WEST
-
-	var/Ydir = 0 //Whether the target is to he north or south of the source.
-	if(dy)
-		if(dy > 0)
-			Ydir = NORTH
-		else
-			Ydir = SOUTH
-
-	var/Gdir = Xdir | Ydir //The GENERAL direction the target is from the source.
-
-	if(!Gdir) //If it's on your own tile, you can see it.
-		return 1
-
-	var/adx = abs(dx)
-	if(adx <= 1 && !dy) //You can always see cardinally-adjacent tiles.
-		return 1
-
-	var/ady = abs(dy)
-	if(ady <= 1 && !dx) //You can always see cardinally-adjacent tiles.
-		return 1
-
-	var/turf/target_turf = get_turf(target)
-	if(target_turf.opacity)
-		if(adx <= 1 && ady <= 1) //You can always see diagonally-adjacent tiles IF their TURFS are opaque. It's true, but don't ask me why.
-			return 1
-
-	//if(!dx || !dy) //source and target are aligned horizontally or vertically.
-	//	if(!target_turf.opacity) //The turf target is on is not opaque, so things behave as one would normally expect.
-	//		var/turf/current = get_step(source, Gdir)
-	//		while(current != target_turf)
-	//			if(current.check_opacity())
-	//				return 0
-	//			current = get_step(current, Gdir)
-	//		return 1
-	//	else //So target is on an opaque turf. Fuck.
-	//		var/list/checkdirs = list(Xdir << 2 | Ydir >> 2, ((Xdir << 1 | Xdir >> 1) & 12) | ((Ydir << 1 | Ydir >> 1) & 3)) //Gets both directions perpendicular to Gdir through bitwise magic.
-	//		for(var/checkdir in checkdirs)
-	//			var/turf/current = get_step(source, Gdir | checkdir)
-	//			var/turf/pseudo_target_turf = get_step(target_turf, checkdir)
-	//			while(current != pseudo_target_turf)
-	//				if(current.check_opacity())
-	//					//Nothing!
-
-	var/Pdir = 0 //Primary direction: Which of the horizontal distance and vertical distance is greater, if either. 0 if they are equal.
-	if(adx > ady)
-		Pdir = Xdir
-	else if(ady > adx)
-		Pdir = Ydir
-
 /proc/is_blocked_turf(var/turf/T)
 	var/cant_pass = 0
 	if(T.density) cant_pass = 1
@@ -1155,20 +1089,6 @@ proc/get_mob_with_client_list()
 			return "right foot"
 		else
 			return zone
-
-/*
-	get_turf(): Returns the turf that contains the atom.
-	Example: A fork inside a box inside a locker will return the turf the locker is standing on.
-	The weird for loop with an empty statement is apparently the fastest way possible to do this.
-
-	This is now a macro, over in _macros.dm. It's functionally the same, but the code is different and much faster.
-*/
-///proc/get_turf(const/atom/O)
-//	if(!istype(O) || isarea(O))
-//		return
-//	var/atom/A
-//	for(A=O, A && !isturf(A), A=A.loc);  // semicolon is for the empty statement
-//	return A
 
 /*
 	get_holder_at_turf_level(): Similar to get_turf(), will return the "highest up" holder of this atom, excluding the turf.

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1093,14 +1093,12 @@ proc/get_mob_with_client_list()
 /*
 	get_turf(): Returns the turf that contains the atom.
 	Example: A fork inside a box inside a locker will return the turf the locker is standing on.
-	The weird for loop with an empty statement is apparently the fastest way possible to do this.
+	Considering how poorly stock BYOND procs often run, it's surprising this is the fastest way to do this, but it is. By a lot.
+	The sanity that used to be here too is apparently handled by get_step() anyway.
+	It's actually (comparatively) substantially faster to directly call get_step(whatever, 0) than to call this proc, so maybe do that when you really need the best possible performance.
 */
 /proc/get_turf(const/atom/O)
-	if(!istype(O) || isarea(O))
-		return
-	var/atom/A
-	for(A=O, A && !isturf(A), A=A.loc);  // semicolon is for the empty statement
-	return A
+	return get_step(O, 0)
 
 /*
 	get_holder_at_turf_level(): Similar to get_turf(), will return the "highest up" holder of this atom, excluding the turf.

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1091,16 +1091,6 @@ proc/get_mob_with_client_list()
 			return zone
 
 /*
-	get_turf(): Returns the turf that contains the atom.
-	Example: A fork inside a box inside a locker will return the turf the locker is standing on.
-	Considering how poorly stock BYOND procs often run, it's surprising this is the fastest way to do this, but it is. By a lot.
-	The sanity that used to be here too is apparently handled by get_step() anyway.
-	It's actually (comparatively) substantially faster to directly call get_step(whatever, 0) than to call this proc, so maybe do that when you really need the best possible performance.
-*/
-/proc/get_turf(const/atom/O)
-	return get_step(O, 0)
-
-/*
 	get_holder_at_turf_level(): Similar to get_turf(), will return the "highest up" holder of this atom, excluding the turf.
 	Example: A fork inside a box inside a locker will return the locker. Essentially, get_just_before_turf().
 */

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -653,6 +653,72 @@ proc/GaussRandRound(var/sigma,var/roundto)
 
 	return 1
 
+//A prototype implementation of can_see() that doesn't suck massive ass. Ignores darkness.
+//The functional part of this is probably completely inscrutable unless you understand BYOND occlusion very well.
+/proc/accurate_can_see(var/atom/source, var/atom/target, var/length=world.view)
+	if(source.z != target.z) //Can't see things on other Z-levels.
+		return 0
+
+	var/dx = target.x - source.x
+	var/dy = target.y - source.y
+	if(dx > length || dy > length) //Too far away
+		return 0
+
+	var/Xdir = 0 //Whether the target is to the east or west of the source.
+	if(dx)
+		if(dx > 0)
+			Xdir = EAST
+		else
+			Xdir = WEST
+
+	var/Ydir = 0 //Whether the target is to he north or south of the source.
+	if(dy)
+		if(dy > 0)
+			Ydir = NORTH
+		else
+			Ydir = SOUTH
+
+	var/Gdir = Xdir | Ydir //The GENERAL direction the target is from the source.
+
+	if(!Gdir) //If it's on your own tile, you can see it.
+		return 1
+
+	var/adx = abs(dx)
+	if(adx <= 1 && !dy) //You can always see cardinally-adjacent tiles.
+		return 1
+
+	var/ady = abs(dy)
+	if(ady <= 1 && !dx) //You can always see cardinally-adjacent tiles.
+		return 1
+
+	var/turf/target_turf = get_turf(target)
+	if(target_turf.opacity)
+		if(adx <= 1 && ady <= 1) //You can always see diagonally-adjacent tiles IF their TURFS are opaque. It's true, but don't ask me why.
+			return 1
+
+	//if(!dx || !dy) //source and target are aligned horizontally or vertically.
+	//	if(!target_turf.opacity) //The turf target is on is not opaque, so things behave as one would normally expect.
+	//		var/turf/current = get_step(source, Gdir)
+	//		while(current != target_turf)
+	//			if(current.check_opacity())
+	//				return 0
+	//			current = get_step(current, Gdir)
+	//		return 1
+	//	else //So target is on an opaque turf. Fuck.
+	//		var/list/checkdirs = list(Xdir << 2 | Ydir >> 2, ((Xdir << 1 | Xdir >> 1) & 12) | ((Ydir << 1 | Ydir >> 1) & 3)) //Gets both directions perpendicular to Gdir through bitwise magic.
+	//		for(var/checkdir in checkdirs)
+	//			var/turf/current = get_step(source, Gdir | checkdir)
+	//			var/turf/pseudo_target_turf = get_step(target_turf, checkdir)
+	//			while(current != pseudo_target_turf)
+	//				if(current.check_opacity())
+	//					//Nothing!
+
+	var/Pdir = 0 //Primary direction: Which of the horizontal distance and vertical distance is greater, if either. 0 if they are equal.
+	if(adx > ady)
+		Pdir = Xdir
+	else if(ady > adx)
+		Pdir = Ydir
+
 /proc/is_blocked_turf(var/turf/T)
 	var/cant_pass = 0
 	if(T.density) cant_pass = 1
@@ -1089,6 +1155,20 @@ proc/get_mob_with_client_list()
 			return "right foot"
 		else
 			return zone
+
+/*
+	get_turf(): Returns the turf that contains the atom.
+	Example: A fork inside a box inside a locker will return the turf the locker is standing on.
+	The weird for loop with an empty statement is apparently the fastest way possible to do this.
+
+	This is now a macro, over in _macros.dm. It's functionally the same, but the code is different and much faster.
+*/
+///proc/get_turf(const/atom/O)
+//	if(!istype(O) || isarea(O))
+//		return
+//	var/atom/A
+//	for(A=O, A && !isturf(A), A=A.loc);  // semicolon is for the empty statement
+//	return A
 
 /*
 	get_holder_at_turf_level(): Similar to get_turf(), will return the "highest up" holder of this atom, excluding the turf.


### PR DESCRIPTION
I'm kind of surprised this worked at all, let alone this well.

`get_turf()` was already extremely fast, so the actual savings here are admittedly not that great, but it can't hurt

I tested calling this on an area and a datum and it just returned null and didn't runtime, so apparently `get_step()` has that sanity built in

Item sitting directly in the turf:
![image](https://cloud.githubusercontent.com/assets/9827785/16543085/b6bda4b8-4092-11e6-99ad-979af63ba1e5.png)

Item in a box in a bag on a mob in a locker on the turf:
![image](https://cloud.githubusercontent.com/assets/9827785/16543086/c9870f12-4092-11e6-97be-5dfe4d37422b.png)

~~Note that just calling `get_step(whatever, 0)` is actually measurably faster than calling this proc, so maybe do that in cases where every single ounce of performance matters~~ Never mind, I'm making this into a macro when I get the go-ahead from Lummox

Tested a lot.
