### PR TITLE
Courtroom is no longer affected by Radiation Storms

### DIFF
--- a/code/modules/events/radiation_storm.dm
+++ b/code/modules/events/radiation_storm.dm
@@ -3,6 +3,7 @@
 	var/safe_zones = list(
 		/area/maintenance,
 		/area/crew_quarters/sleep,
+		/area/crew_quarters/courtroom,
 		/area/security/prison,
 		/area/security/perma,
 		/area/security/gas_chamber,


### PR DESCRIPTION
Now that trials last more than two whole minutes before an antagonist decides to bomb the whole thing, the Courtroom needs to be radiation storm proof

Having to interrupt a trial because lel green lights is boring
