### PR TITLE
Temporarily removes mindswap from the spellbook

### DIFF
--- a/code/game/gamemodes/antag_spawner.dm
+++ b/code/game/gamemodes/antag_spawner.dm
@@ -42,7 +42,7 @@
 		//dat += "<I>Your apprentice is training to cast spells that will aid your survival. They know Forcewall and Charge and come with a Staff of Healing.</I><BR>"
 		dat += "<I>The school of healing has been closed for renovations, so you cannot find an apprentice specializing in this school. (Bug #99 on Redmine for more info)</I><BR>"
 		dat += "<A href='byond://?src=\ref[src];school=robeless'>Robeless</A><BR>"
-		dat += "<I>Your apprentice is training to cast spells without their robes. They know Knock and Mindswap.</I><BR>"
+		dat += "<I>Your apprentice is training to cast spells without their robes. They know Knock and Forcewall.</I><BR>"
 	user << browse(dat, "window=radio")
 	onclose(user, "radio")
 	return
@@ -93,8 +93,8 @@
 		*/
 		if("robeless")
 			M.add_spell(new /spell/aoe_turf/knock)
-			M.add_spell(new /spell/targeted/mind_transfer)
-			to_chat(M, "<B>Your service has not gone unrewarded, however. Studying under [usr.real_name], you have learned stealthy, robeless spells. You are able to cast knock and mindswap.")
+			M.add_spell(new /spell/aoe_turf/conjure/forcewall)
+			to_chat(M, "<B>Your service has not gone unrewarded, however. Studying under [usr.real_name], you have learned stealthy, robeless spells. You are able to cast knock and forcewall.")
 		if("clown")
 			M.add_spell(new /spell/targeted/equip_item/clowncurse)
 			M.add_spell(new /spell/targeted/shoesnatch)

--- a/code/game/gamemodes/wizard/rightandwrong.dm
+++ b/code/game/gamemodes/wizard/rightandwrong.dm
@@ -20,7 +20,7 @@
 				to_chat(H, "<B>Objective #[obj_count]</B>: [OBJ.explanation_text]")
 				obj_count++
 		var/randomizeguns = pick("taser","egun","laser","revolver","detective","smg","nuclear","deagle","gyrojet","pulse","silenced","cannon","doublebarrel","shotgun","combatshotgun","mateba","smg","uzi","crossbow","saw","hecate","osipr","gatling","bison","ricochet","spur","nagant","beegun")
-		var/randomizemagic = pick("fireball","smoke","blind","mindswap","forcewall","knock","horsemask","charge","wandnothing", "wanddeath", "wandresurrection", "wandpolymorph", "wandteleport", "wanddoor", "wandfireball", "staffchange", "staffhealing", "armor", "scrying")
+		var/randomizemagic = pick("fireball","smoke","blind","forcewall","knock","horsemask","charge","wandnothing", "wanddeath", "wandresurrection", "wandpolymorph", "wandteleport", "wanddoor", "wandfireball", "staffchange", "staffhealing", "armor", "scrying")
 		if(!summon_type)
 			switch (randomizeguns)
 				if("taser")
@@ -92,8 +92,10 @@
 					new /obj/item/weapon/spellbook/oneuse/smoke(get_turf(H))
 				if("blind")
 					new /obj/item/weapon/spellbook/oneuse/blind(get_turf(H))
+				/*TEMP MINDSWAP REMOVAL
 				if("mindswap")
 					new /obj/item/weapon/spellbook/oneuse/mindswap(get_turf(H))
+				*/
 				if("forcewall")
 					new /obj/item/weapon/spellbook/oneuse/forcewall(get_turf(H))
 				if("knock")

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -53,8 +53,6 @@
 			<I>This spell temporarly blinds a single person and does not require wizard garb.</I><BR>
 			<A href='byond://?src=\ref[src];spell_choice=subjugation'>Subjugation</A> (30)<BR>
 			<I>This spell temporarily subjugates a target's mind and does not require wizard garb.</I><BR>
-			<A href='byond://?src=\ref[src];spell_choice=mindswap'>Mind Transfer</A> (60)<BR>
-			<I>This spell allows the user to switch bodies with a target. Careful to not lose your memory in the process.</I><BR>
 			<A href='byond://?src=\ref[src];spell_choice=forcewall'>Forcewall</A> (10)<BR>
 			<I>This spell creates an unbreakable wall that lasts for 30 seconds and does not need wizard garb.</I><BR>
 			<A href='byond://?src=\ref[src];spell_choice=blink'>Blink</A> (2)<BR>
@@ -160,7 +158,7 @@
 				uses--
 
 				var/list/available_spells = list(magicmissile = "Magic Missile", fireball = "Fireball", lightning = "Lightning", disintegrate = "Disintegrate", disabletech = "Disable Tech",
-				smoke = "Smoke", blind = "Blind", subjugation = "Subjugation", mindswap = "Mind Transfer", forcewall = "Forcewall", blink = "Blink", teleport = "Teleport", mutate = "Mutate",
+				smoke = "Smoke", blind = "Blind", subjugation = "Subjugation", forcewall = "Forcewall", blink = "Blink", teleport = "Teleport", mutate = "Mutate",
 				etherealjaunt = "Ethereal Jaunt", knock = "Knock", horseman = "Curse of the Horseman", frenchcurse = "The French Curse", summonguns = "Summon Guns", staffchange = "Staff of Change",
 				mentalfocus = "Mental Focus", soulstone = "Six Soul Stone Shards and the spell Artificer", armor = "Mastercrafted Armor Set", staffanimate = "Staff of Animation", noclothes = "No Clothes",
 				fleshtostone = "Flesh to Stone", arsenath = "Butt-Bot's Revenge", timestop = "Time Stop", bundle = "Spellbook Bundle")
@@ -239,7 +237,8 @@
 							feedback_add_details("wizard_spell_learned","MS")
 							add_spell(new/spell/aoe_turf/fall,H)
 							temp = "You have learned time stop."
-						/*if("disintegrate")
+						/*
+						if("disintegrate")
 							if(!ticker.mode.rage)
 								feedback_add_details("wizard_spell_learned","DG") //please do not change the abbreviation to keep data processing consistent. Add a unique id to any new spells
 								add_spell(new/spell/targeted/disintegrate,H)
@@ -261,10 +260,12 @@
 							feedback_add_details("wizard_spell_learned","SJ") //please do not change the abbreviation to keep data processing consistent. Add a unique id to any new spells
 							add_spell(new/spell/targeted/subjugation,H)
 							temp = "You have learned subjugate."
+						/*TEMP MINDSWAP REMOVAL
 						if("mindswap")
 							feedback_add_details("wizard_spell_learned","MT") //please do not change the abbreviation to keep data processing consistent. Add a unique id to any new spells
 							add_spell(new/spell/targeted/mind_transfer,H)
 							temp = "You have learned mindswap."
+						*/
 						if("forcewall")
 							feedback_add_details("wizard_spell_learned","FW") //please do not change the abbreviation to keep data processing consistent. Add a unique id to any new spells
 							add_spell(new/spell/aoe_turf/conjure/forcewall,H)
@@ -806,6 +807,8 @@
 	var/list/possible_books = typesof(/obj/item/weapon/spellbook/oneuse)
 	possible_books -= /obj/item/weapon/spellbook/oneuse
 	possible_books -= /obj/item/weapon/spellbook/oneuse/charge
+	/*TEMP MINDSWAP REMOVAL*/
+	possible_books -= /obj/item/weapon/spellbook/oneuse/mindswap
 	for(var/i =1; i <= 7; i++)
 		var/randombook = pick(possible_books)
 		var/book = new randombook(src)

--- a/html/changelogs/Intiswapmeupfam.yml
+++ b/html/changelogs/Intiswapmeupfam.yml
@@ -1,0 +1,5 @@
+author: Intigracy
+delete-after: True
+changes: 
+- rscdel: "Removed Mindswap from the spellbook until the multitude of issues it has is fixed."
+- tweak: "The robeless spell set that apprentices can pick now has forcewall instead of mindswap for the time being."


### PR DESCRIPTION
- rscdel: "Removed Mindswap from the spellbook until the multitude of issues it has is fixed."
- tweak: "The robeless spell set that apprentices can pick now has forcewall instead of mindswap for the time being."

Single most buggy spell we currently have, extremely exploitable too.
