### PR TITLE
Removes "+" --> "plus" wordfilter on smartfridge

### DIFF
--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -229,7 +229,7 @@
 			if(!user.drop_item(O, src))
 				return 1
 
-			var/sanitized_name = sanitize(O.name, list("\"" = "", "'" = "", ";" = "", "^" = "", "&" = "", "<" = "", ">" = ""))
+			var/sanitized_name = sanitize(O.name)
 			O.name = sanitized_name
 			if(item_quants[sanitized_name])
 				item_quants[sanitized_name]++
@@ -248,7 +248,7 @@
 					return 1
 				else
 					bag.remove_from_storage(G,src)
-					var/sanitized_name = sanitize(G.name, list("\"" = "", "'" = "", ";" = "", "^" = "", "&" = "", "<" = "", ">" = ""))
+					var/sanitized_name = sanitize(G.name)
 					G.name = sanitized_name
 					if(item_quants[sanitized_name])
 						item_quants[sanitized_name]++

--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -229,7 +229,7 @@
 			if(!user.drop_item(O, src))
 				return 1
 
-			var/sanitized_name = sanitize(O.name, list("\"" = "", "'" = "", "+" = "plus", ";" = "", "^" = "", "&" = "", "<" = "", ">" = ""))
+			var/sanitized_name = sanitize(O.name, list("\"" = "", "'" = "", ";" = "", "^" = "", "&" = "", "<" = "", ">" = ""))
 			O.name = sanitized_name
 			if(item_quants[sanitized_name])
 				item_quants[sanitized_name]++
@@ -248,7 +248,7 @@
 					return 1
 				else
 					bag.remove_from_storage(G,src)
-					var/sanitized_name = sanitize(G.name, list("\"" = "", "'" = "", "+" = "plus", ";" = "", "^" = "", "&" = "", "<" = "", ">" = ""))
+					var/sanitized_name = sanitize(G.name, list("\"" = "", "'" = "", ";" = "", "^" = "", "&" = "", "<" = "", ">" = ""))
 					G.name = sanitized_name
 					if(item_quants[sanitized_name])
 						item_quants[sanitized_name]++

--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -229,12 +229,10 @@
 			if(!user.drop_item(O, src))
 				return 1
 
-			var/sanitized_name = sanitize(O.name)
-			O.name = sanitized_name
-			if(item_quants[sanitized_name])
-				item_quants[sanitized_name]++
+			if(item_quants[O.name])
+				item_quants[O.name]++
 			else
-				item_quants[sanitized_name] = 1
+				item_quants[O.name] = 1
 			user.visible_message("<span class='notice'>[user] has added \the [O] to \the [src].", \
 								 "<span class='notice'>You add \the [O] to \the [src].")
 
@@ -248,12 +246,10 @@
 					return 1
 				else
 					bag.remove_from_storage(G,src)
-					var/sanitized_name = sanitize(G.name)
-					G.name = sanitized_name
-					if(item_quants[sanitized_name])
-						item_quants[sanitized_name]++
+					if(item_quants[G.name])
+						item_quants[G.name]++
 					else
-						item_quants[sanitized_name] = 1
+						item_quants[G.name] = 1
 					objects_loaded++
 		if(objects_loaded)
 


### PR DESCRIPTION
I'll name my pills "Arith+Antitox" if I want to, goddamit
This seems to have been some sort of sanitization to prevent HTML from popping up on VV but the + sign alone can't do anything I don't think, tested using VV on a pill with + in it's name, it's all good
