### PR TITLE
Adds primitive data types to use.

### DIFF
--- a/code/__HELPERS/primitives.dm
+++ b/code/__HELPERS/primitives.dm
@@ -2,3 +2,4 @@
 /int
 /float
 /string
+/appearance

--- a/code/__HELPERS/primitives.dm
+++ b/code/__HELPERS/primitives.dm
@@ -1,0 +1,4 @@
+/bool
+/int
+/float
+/string

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -36,6 +36,7 @@
 #include "code\__HELPERS\maths.dm"
 #include "code\__HELPERS\mobs.dm"
 #include "code\__HELPERS\names.dm"
+#include "code\__HELPERS\primitives.dm"
 #include "code\__HELPERS\sanitize_values.dm"
 #include "code\__HELPERS\text.dm"
 #include "code\__HELPERS\time.dm"


### PR DESCRIPTION
This is for code readability. After this is merged you should all begin doing `var/int/x = 10` instead of `var/x = 10`
