### PR TITLE
possibly fixes getting the same antagonist type twice

### DIFF
--- a/code/game/gamemodes/autotraitor/autotraitor.dm
+++ b/code/game/gamemodes/autotraitor/autotraitor.dm
@@ -57,11 +57,10 @@
 
 	for(var/i = 0, i < num_traitors, i++)
 		var/datum/mind/traitor = pick(possible_traitors)
+		possible_traitors -= traitor
 		if(traitor.special_role)
-			possible_traitors.Remove(traitor)
 			continue
 		traitors += traitor
-		possible_traitors.Remove(traitor)
 
 	for(var/datum/mind/traitor in traitors)
 		if(!traitor || !istype(traitor))

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -69,10 +69,9 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 		for(var/i = 0, i < changeling_amount, i++)
 			if(!possible_changelings.len) break
 			var/datum/mind/changeling = pick(possible_changelings)
-			if(changeling.special_role)
-				possible_changelings.Remove(changeling)
-				continue
 			possible_changelings -= changeling
+			if(changeling.special_role)
+				continue
 			changelings += changeling
 			modePlayer += changelings
 		log_admin("Starting a round of changeling with [changelings.len] changelings.")

--- a/code/game/gamemodes/changeling/traitor_chan.dm
+++ b/code/game/gamemodes/changeling/traitor_chan.dm
@@ -31,7 +31,8 @@
 
 	if(possible_changelings.len>0)
 		var/datum/mind/changeling = pick(possible_changelings)
-		//possible_changelings-=changeling
+		possible_changelings -= changeling
+		changeling.special_role = "Changeling"
 		changelings += changeling
 		modePlayer += changelings
 		if(mixed)
@@ -52,7 +53,6 @@
 /datum/game_mode/traitor/changeling/post_setup()
 	for(var/datum/mind/changeling in changelings)
 		grant_changeling_powers(changeling.current)
-		changeling.special_role = "Changeling"
 		forge_changeling_objectives(changeling)
 		greet_changeling(changeling)
 	..()

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -59,9 +59,11 @@
 		if (!possible_traitors.len)
 			break
 		var/datum/mind/traitor = pick(possible_traitors)
+		possible_traitors -= traitor
+		if(traitor.special_role == "traitor")
+			continue
 		traitors += traitor
 		traitor.special_role = "traitor"
-		possible_traitors.Remove(traitor)
 
 	if(!traitors.len)
 		return 0


### PR DESCRIPTION
I suspect that byond's remove() proc is slower than just doing list -= var.

This for sure won't fix getting both traitor and changeling, but I believe it will fix getting traitor 2-3 times at once.

All I've done here is taken the two antagonists this is known to happen with (traitor and changeling) and made the code match all the other game mode pre-setups when assigning antags.

maybe fixes #10948
