### PR TITLE
Adds a "bwoink-me-bro" to putting ghosted brains in MMIs

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1396,10 +1396,15 @@ proc/clear_memory(var/silent = 1)
 	mind.assigned_role = "Armalis"
 	mind.special_role = "Vox Raider"
 
+/proc/get_ghost_from_mind(var/datum/mind/mind)
+	if(!mind)
+		return
+	for(var/mob/dead/observer/G in player_list)
+		if(G.mind == mind)
+			return G
 
 /proc/mind_can_reenter(var/datum/mind/mind)
-	if(mind)
-		for(var/mob/dead/observer/G in player_list)
-			if(G.can_reenter_corpse && G.mind == mind)
-				return TRUE
+	var/mob/dead/observer/G = get_ghost_from_mind(mind)
+	if(G && G.client && G.can_reenter_corpse)
+		return TRUE
 	return FALSE

--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -258,15 +258,15 @@
 		if(C)
 			C.update_icon()
 			if(!M.client && M.mind)
-				for(var/mob/dead/observer/ghost in player_list)
-					if(ghost.mind == M.mind)
-						if(ghost.client && ghost.can_reenter_corpse)
-							ghost << 'sound/effects/adminhelp.ogg'
-							to_chat(ghost, "<span class='interface'><b><font size = 3>Your corpse has been placed into a cloning scanner. Return to your body if you want to be resurrected/cloned!</b> \
-								(Verbs -> Ghost -> Re-enter corpse, or <a href='?src=\ref[ghost];reentercorpse=1'>click here!</a>)</font></span>")
-						else
-							ghost.canclone = M
-						break
+				var/mob/dead/observer/ghost = get_ghost_from_mind(M.mind)
+				if(ghost)
+					if(ghost.client && ghost.can_reenter_corpse)
+						ghost << 'sound/effects/adminhelp.ogg'
+						to_chat(ghost, "<span class='interface'><b><font size = 3>Your corpse has been placed into a cloning scanner. Return to your body if you want to be resurrected/cloned!</b> \
+							(Verbs -> Ghost -> Re-enter corpse, or <a href='?src=\ref[ghost];reentercorpse=1'>click here!</a>)</font></span>")
+					else
+						ghost.canclone = M
+				break
 			break
 	return
 

--- a/code/game/machinery/podmen.dm
+++ b/code/game/machinery/podmen.dm
@@ -45,11 +45,11 @@ var/global/list/hasbeendiona = list() // Stores ckeys and a timestamp for ghost 
 			source = B.data["donor"]
 			to_chat(user, "The strange, sluglike seeds quiver gently and swell with blood.")
 			if(!source.client && source.mind)
-				for(var/mob/dead/observer/O in player_list)
-					if(O.mind == source.mind && config.revival_pod_plants)
-						to_chat(O, "<span class='interface'><b><font size = 3>Your blood has been placed into a replica pod seed. Return to your body if you want to be returned to life as a pod person!</b> \)
-							(Verbs -> Ghost -> Re-enter corpse, or <a href='?src=\ref[O];reentercorpse=1'>click here!</a>)</font></span>"
-						break
+				var/mob/dead/observer/O = get_ghost_from_mind(source.mind)
+				if(O && O.client && config.revival_pod_plants)
+					to_chat(O, "<span class='interface'><b><font size = 3>Your blood has been placed into a replica pod seed. Return to your body if you want to be returned to life as a pod person!</b> \)
+						(Verbs -> Ghost -> Re-enter corpse, or <a href='?src=\ref[O];reentercorpse=1'>click here!</a>)</font></span>"
+					break
 		else
 			to_chat(user, "Nothing happens.")
 			return

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -148,13 +148,13 @@
 			target.apply_damage(rand(1,5),BURN,LIMB_CHEST)
 			return
 		if(target.mind && !target.client) //Let's call up the ghost! Also, bodies with clients only, thank you.
-			for(var/mob/dead/observer/ghost in player_list)
-				if(ghost.mind == target.mind  && ghost.client && ghost.can_reenter_corpse)
-					ghost << 'sound/effects/adminhelp.ogg'
-					to_chat(ghost, "<span class='interface'><b><font size = 3>Someone is trying to revive your body. Return to it if you want to be resurrected!</b> \
-						(Verbs -> Ghost -> Re-enter corpse, or <a href='?src=\ref[ghost];reentercorpse=1'>click here!</a>)</font></span>")
-					to_chat(user, "<span class='warning'>[src] buzzes: Defibrillation failed. Vital signs are too weak, please try again in five seconds.</span>")
-					return
+			var/mob/dead/observer/ghost = get_ghost_from_mind(target.mind)
+			if(ghost && ghost.client && ghost.can_reenter_corpse)
+				ghost << 'sound/effects/adminhelp.ogg'
+				to_chat(ghost, "<span class='interface'><b><font size = 3>Someone is trying to revive your body. Return to it if you want to be resurrected!</b> \
+					(Verbs -> Ghost -> Re-enter corpse, or <a href='?src=\ref[ghost];reentercorpse=1'>click here!</a>)</font></span>")
+				to_chat(user, "<span class='warning'>[src] buzzes: Defibrillation failed. Vital signs are too weak, please try again in five seconds.</span>")
+				return
 			//we couldn't find a suitable ghost.
 			target.visible_message("<span class='warning'>[src] buzzes: Defibrillation failed. Patient's condition does not allow reviving.</span>")
 			return

--- a/code/modules/medical/computer/cloning.dm
+++ b/code/modules/medical/computer/cloning.dm
@@ -395,14 +395,14 @@
 	if ((M_NOCLONE in subject.mutations) || (subject.suiciding == 1))
 		scantemp = "Error: Mental interface failure." //uncloneable, this guy is done for
 		return
-	if (!subject.client && subject.mind) //this guy ghosted from his corpse, but he can still come back!
-		for(var/mob/dead/observer/ghost in player_list)
-			if(ghost.mind == subject.mind && ghost.client && ghost.can_reenter_corpse)
-				ghost << 'sound/effects/adminhelp.ogg'
-				to_chat(ghost, "<span class='interface'><b><font size = 3>Someone is trying to clone your corpse. Return to your body if you want to be cloned!</b> \
-					(Verbs -> Ghost -> Re-enter corpse, or <a href='?src=\ref[ghost];reentercorpse=1'>click here!</a>)</font></span>")
-				scantemp = "Error: Subject's brain is not responding to scanning stimuli, subject may be brain dead. Please try again in five seconds."
-				return
+	if (!subject.client && subject.mind) //this guy ghosted from his corpse, but he could still come back!
+		var/mob/dead/observer/ghost = get_ghost_from_mind(subject.mind)
+		if(ghost && ghost.client && ghost.can_reenter_corpse)
+			ghost << 'sound/effects/adminhelp.ogg'
+			to_chat(ghost, "<span class='interface'><b><font size = 3>Someone is trying to clone your corpse. Return to your body if you want to be cloned!</b> \
+				(Verbs -> Ghost -> Re-enter corpse, or <a href='?src=\ref[ghost];reentercorpse=1'>click here!</a>)</font></span>")
+			scantemp = "Error: Subject's brain is not responding to scanning stimuli, subject may be brain dead. Please try again in five seconds."
+			return
 		//we couldn't find a suitable ghost.
 		scantemp = "Error: Mental interface failure."
 		return

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -109,20 +109,27 @@ obj/item/device/mmi/Destroy()
 		// MaMIs inherit from brain, but they shouldn't be insertable into a MMI
 		if (istype(O, /obj/item/organ/brain/mami))
 			to_chat(user, "<span class='warning'>You are only able to fit organic brains on a MMI. [src] won't work.</span>")
-			return
+			return TRUE
 
 		var/obj/item/organ/brain/BO = O
 		if(!BO.brainmob)
 			to_chat(user, "<span class='warning'>You aren't sure where this brain came from, but you're pretty sure it's a useless brain.</span>")
-			return
+			return TRUE
 		// Checking to see if the ghost has been moused/borer'd/etc since death.
 		var/mob/living/carbon/brain/BM = BO.brainmob
 		if(!BM.client)
-			to_chat(user, "<span class='notice'>\The [src] indicates that their mind is completely unresponsive; there's no point.</span>")
-			return
+			var/mob/dead/observer/ghost = get_ghost_from_mind(BM.mind)
+			if(ghost && ghost.client && ghost.can_reenter_corpse)
+				to_chat(user, "<span class='warning'>\The [src] indicates that \the [O] seems slow to respond. Try again in a few seconds.</span>")
+				ghost << 'sound/effects/adminhelp.ogg'
+				to_chat(ghost, "<span class='interface'><b><font size = 3>Someone is trying to put your brain in a MMI. Return to your body if you want to be resurrected!</b> \
+					(Verbs -> Ghost -> Re-enter corpse, or <a href='?src=\ref[ghost];reentercorpse=1'>click here!</a>)</font></span>")
+				return TRUE
+			to_chat(user, "<span class='warning'>\The [src] indicates that \the [O] is completely unresponsive; there's no point.</span>")
+			return TRUE
 		if(!user.drop_item(O))
 			to_chat(user, "<span class='warning'>You can't let go of \the [O]!</span>")
-			return
+			return TRUE
 
 		src.visible_message("<span class='notice'>[user] sticks \a [O] into \the [src].</span>")
 
@@ -143,7 +150,7 @@ obj/item/device/mmi/Destroy()
 
 		feedback_inc("cyborg_mmis_filled",1)
 
-		return
+		return TRUE
 
 	if((istype(O,/obj/item/weapon/card/id)||istype(O,/obj/item/device/pda)) && brainmob)
 		if(allowed(user))
@@ -151,7 +158,7 @@ obj/item/device/mmi/Destroy()
 			to_chat(user, "<span class='notice'>You [locked ? "lock" : "unlock"] \the [src].</span>")
 		else
 			to_chat(user, "<span class='warning'>Access denied.</span>")
-		return
+		return TRUE
 
 	if(istype(O, /obj/item/weapon/implanter))
 		return//toplel

--- a/code/modules/mob/living/carbon/brain/brain_item.dm
+++ b/code/modules/mob/living/carbon/brain/brain_item.dm
@@ -40,15 +40,16 @@
 
 /obj/item/organ/brain/examine(mob/user)
 	..()
-	if(brainmob && brainmob.client)//if thar be a brain inside... the brain.
-		if(mind_can_reenter(brainmob.mind))// This checks if the ghost can re-enter (ghost.can_reenter_corpse)
-			to_chat(user, "<span class='deadsay'>This one seems unresponsive.</span>")// Should probably make this more realistic,
-
-			                                                                    //  but this message ties it in with MMI errors.
-		else
+	if(brainmob)
+		if(brainmob.client)
 			to_chat(user, "<span class='notice'>You can feel the small spark of life still left in this one.</span>")
-	else
-		to_chat(user, "<span class='deadsay'>This one seems particularly lifeless. Perhaps it will regain some of its luster later..</span>")
+			return
+		var/mob/dead/observer/ghost = get_ghost_from_mind(brainmob.mind)
+		if(ghost && ghost.client && ghost.can_reenter_corpse)
+			to_chat(user, "<span class='deadsay'>It seems particularly lifeless, but not yet gone. Perhaps it will regain some of its luster later...</span>")
+			return
+		to_chat(user, "<span class='deadsay'>This one seems unresponsive.</span>")// Should probably make this more realistic, but this message ties it in with MMI errors.
+		return
 
 /obj/item/organ/brain/removed(var/mob/living/target,var/mob/living/user)
 

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -801,11 +801,11 @@ var/global/list/whitelisted_species = list("Human")
 			else
 				if(!client)
 					to_chat(user, "<span class='notice'>As you press \the [A] into \the [src], it shudders briefly, but falls still.</span>")
-					for(var/mob/dead/observer/ghost in player_list)
-						if(ghost.mind == mind && ghost.client && ghost.can_reenter_corpse)
-							ghost << 'sound/effects/adminhelp.ogg'
-							to_chat(ghost, "<span class='interface'><b><font size = 3>Someone is trying to resurrect you. Return to your body if you want to live again!</b> \
-								(Verbs -> Ghost -> Re-enter corpse, or <a href='?src=\ref[ghost];reentercorpse=1'>click here!</a>)</font></span>")
+					var/mob/dead/observer/ghost = get_ghost_from_mind(mind)
+					if(ghost && ghost.client && ghost.can_reenter_corpse)
+						ghost << 'sound/effects/adminhelp.ogg'
+						to_chat(ghost, "<span class='interface'><b><font size = 3>Someone is trying to resurrect you. Return to your body if you want to live again!</b> \
+							(Verbs -> Ghost -> Re-enter corpse, or <a href='?src=\ref[ghost];reentercorpse=1'>click here!</a>)</font></span>")
 				else
 					anim(target = src, a_icon = 'icons/mob/mob.dmi', flick_anim = "reverse-dust-g", sleeptime = 15)
 					var/mob/living/carbon/human/golem/G = new /mob/living/carbon/human/golem

--- a/html/changelogs/whoevenreadsthese.yml
+++ b/html/changelogs/whoevenreadsthese.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general deleting of nice things)
+#   rscadd (general adding of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.
+author: 9600bauds
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# There needs to be a space after the - and before the prefix. Don't use tabs anywhere in this file.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# If you're using characters such as # ' : - or the like in your changelog, surround the entire change with quotes as shown in the second example. These quotes don't show up on the changelog once it's merged and prevent errors.
+# SCREW ANY OF THIS UP AND IT WON'T WORK.
+changes: 
+- rscadd: "Trying to put a brain in a MMI now produces a special message telling you to try again if the brain has ghosted but can still rejoin their body, much like how cloners work with corpses. When this happens, the ghosted player will get bwoinked and told to rejoin their corpse."
+- bugfix: "Fixed the message you get when examining a brain, which was supposed to differentiate brains with a player still inside and brains belonging to a ghosted player."


### PR DESCRIPTION
- rscadd: "Trying to put a brain in a MMI now produces a special message telling you to try again if the brain has ghosted but can still rejoin their body, much like how cloners work with corpses. When this happens, the ghosted player will get bwoinked and told to rejoin their corpse."
- bugfix: "Fixed the message you get when examining a brain, which was supposed to differentiate brains with a player still inside and brains belonging to a ghosted player."
