### PR TITLE
Changes trays to function more like tables

### DIFF
--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -330,7 +330,6 @@
 	var/max_carry = 10 // w_class = W_CLASS_TINY -- takes up 1
 					   // w_class = W_CLASS_SMALL -- takes up 3
 					   // w_class = W_CLASS_MEDIUM -- takes up 5
-	var/currentweight = 0
 	var/cooldown = 0	//shield bash cooldown. based on world.time
 
 /obj/item/weapon/tray/Destroy()
@@ -479,14 +478,13 @@
 	if(!weight)
 		to_chat(user, "<span class='warning'>\The [W] is too heavy!</span>")
 		return
-	if(weight + currentweight > max_carry)
+	if(weight + calc_carry() > max_carry)
 		to_chat(user, "<span class='warning'>The tray is carrying too much!</span>")
 		return
 	if( W == src || W.anchored || is_type_in_list(W, list(/obj/item/clothing/under, /obj/item/clothing/suit, /obj/item/projectile, /obj/item/weapon/tray)) )
 		to_chat(user, "<span class='warning'>This doesn't seem like a good idea.</span>")
 		return
 	if(user.drop_item(W, user.loc))
-		currentweight += weight
 		W.loc = src
 		carrying.Add(W)
 		var/list/params_list = params2list(params)
@@ -509,11 +507,11 @@
 	var/val = 0 // value to return
 
 	for(var/obj/item/I in carrying)
-		if(I.w_class > W_CLASS_TINY)
-			val ++
+		if(I.w_class == W_CLASS_TINY)
+			val += 1
 		else if(I.w_class == W_CLASS_SMALL)
 			val += 3
-		else if(I.w_class > W_CLASS_MEDIUM)
+		else if(I.w_class == W_CLASS_MEDIUM)
 			val += 5
 		else //Shouldn't happen
 			val += INFINITY
@@ -576,7 +574,6 @@
 	overlays.len = 0
 	for(var/obj/item/I in carrying)
 		I.forceMove(get_turf(src))
-		currentweight -= I.get_trayweight()
 		carrying.Remove(I)
 
 /obj/item/weapon/tray/proc/send_items_flying()
@@ -584,7 +581,6 @@
 	for(var/obj/item/I in carrying)
 		I.forceMove(get_turf(src))
 		carrying.Remove(I)
-		currentweight -= I.get_trayweight()
 		spawn(rand(1,3))
 			if(I && prob(75))
 				step(I, pick(alldirs))

--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -481,7 +481,7 @@
 	if(weight + calc_carry() > max_carry)
 		to_chat(user, "<span class='warning'>The tray is carrying too much!</span>")
 		return
-	if( W == src || W.anchored || is_type_in_list(W, list(/obj/item/clothing/under, /obj/item/clothing/suit, /obj/item/projectile, /obj/item/weapon/tray)) )
+	if( W == src || W.anchored || is_type_in_list(W, list(/obj/item/clothing/under, /obj/item/clothing/suit, /obj/item/projectile, /obj/item/weapon/tray, /obj/item/weapon/holder/) ) )
 		to_chat(user, "<span class='warning'>This doesn't seem like a good idea.</span>")
 		return
 	if(user.drop_item(W, user.loc))
@@ -504,15 +504,10 @@
 		..()
 /obj/item/weapon/tray/proc/calc_carry() 
 	// calculate the weight of the items on the tray
-	var/val = 0 // value to return
+	. = 0 // value to return
 
 	for(var/obj/item/I in carrying)
-		if(I.get_trayweight())
-			val += I.get_trayweight()
-		else
-			return INFINITY
-
-	return val
+		. += I.get_trayweight() || INFINITY
 /* previous functionality of trays, 
 /obj/item/weapon/tray/prepickup(mob/user)
 	..()

--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -507,14 +507,10 @@
 	var/val = 0 // value to return
 
 	for(var/obj/item/I in carrying)
-		if(I.w_class == W_CLASS_TINY)
-			val += 1
-		else if(I.w_class == W_CLASS_SMALL)
-			val += 3
-		else if(I.w_class == W_CLASS_MEDIUM)
-			val += 5
-		else //Shouldn't happen
-			val += INFINITY
+		if(I.get_trayweight())
+			val += I.get_trayweight()
+		else
+			return INFINITY
 
 	return val
 /* previous functionality of trays, 

--- a/html/changelogs/JustSumGuy.yml
+++ b/html/changelogs/JustSumGuy.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general deleting of nice things)
+#   rscadd (general adding of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.
+author: JustSumGuy
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# There needs to be a space after the - and before the prefix. Don't use tabs anywhere in this file.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# If you're using characters such as # ' : - or the like in your changelog, surround the entire change with quotes as shown in the second example. These quotes don't show up on the changelog once it's merged and prevent errors.
+# SCREW ANY OF THIS UP AND IT WON'T WORK.
+changes: 
+- bugfix: Made the food tray more like a table, add items to trays by clicking on the tray with the item in hand. Trays drop all their items upon being placed on a table,thrown, or dropped. 


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.
-->

closes #10603 
Click on the tray with an item and it gets placed on it like a portable table.(even works in your hand!) Putting down the tray removes all the items. I commented out the previous functionality because it was inconsistent, not sure if it's worth revisiting to have trays do both but this way is cleaner I think.

I'm not going to lie I know jack shit about what I did I just copy pasted a bunch of shit from tables and it worked out.
Tested moderately
Also this doesn't affect robotrays because honestly how are those supposed to work
