### PR TITLE
changes cost of supermatter shard crate

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1094,7 +1094,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 /datum/supply_packs/supermatter_shard
 	contains = list(/obj/machinery/power/supermatter/shard)
 	name = "Supermatter Shard"
-	cost = 100 //So cargo thinks twice before killing themselves with it
+	cost = 500 //So cargo thinks thrice before killing themselves with it. You're going to need a department account most likely.
 	containertype = /obj/structure/closet/crate/secure/engisec
 	containername = "Supermatter Shard Crate"
 	group = "Engineering"

--- a/html/changelogs/Intilifematters.yml
+++ b/html/changelogs/Intilifematters.yml
@@ -1,0 +1,4 @@
+author: Intigracy
+delete-after: True
+changes: 
+- tweak: "Supermatter crates ordered from cargo now cost 500 credits, as opposed to 100."


### PR DESCRIPTION
- tweak: "Supermatter crates ordered from cargo now cost 500 credits, as opposed to 100." 

fixes #11001 

You're probably going to need department account access to order one.
