### PR TITLE
Bandolier holding more than shotgun shells

### DIFF
--- a/code/modules/clothing/accessories/storage.dm
+++ b/code/modules/clothing/accessories/storage.dm
@@ -84,11 +84,11 @@
 
 /obj/item/clothing/accessory/storage/bandolier
 	name = "bandolier"
-	desc = "A bandolier designed to hold up to eight shotgun shells."
+	desc = "A bandolier designed with eight pouches for diffrent ammunition types."
 	icon_state = "bandolier"
 	_color = "bandolier"
 	slots = 8
-	can_only_hold = list("/obj/item/ammo_casing/shotgun")
+	can_only_hold = list("/obj/item/ammo_casing", "/obj/item/projectile/bullet", "/obj/item/ammo_storage/magazine", "/obj/item/ammo_storage/speedloader", "/obj/item/weapon/rcd_ammo", "/obj/item/weapon/grenade")
 
 /obj/item/clothing/accessory/storage/knifeharness
 	name = "decorated harness"

--- a/html/changelogs/FudgePucker-patch-10.yml
+++ b/html/changelogs/FudgePucker-patch-10.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general deleting of nice things)
+#   rscadd (general adding of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.
+author: FudgePucker
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# There needs to be a space after the - and before the prefix. Don't use tabs anywhere in this file.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# If you're using characters such as # ' : - or the like in your changelog, surround the entire change with quotes as shown in the second example. These quotes don't show up on the changelog once it's merged and prevent errors.
+# SCREW ANY OF THIS UP AND IT WON'T WORK.
+changes: 
+- rscadd: Adds the ability for Bandoliers to hold more ammo types


### PR DESCRIPTION
Sometimes you want to just be covered with ammo, but don't want to use a shotgun.

Now if you can put it into any gun (That one pressure based cannon excluded), you can put it in your bandolier.

Also matter carts because why not.

Also totally going to make a cowboy traitor bundle with a revolver, a hat, a coat, and a bandolier filled with speed loaders once this gets merged (if it does).

Also don't know how to edit the change log, we will cross that hurdle sometime later... not right now though. :^)

Edit: Closes #10909 
