### PR TITLE
Fixes Diona light calculations

### DIFF
--- a/code/modules/mob/living/carbon/human/life/handle_chemicals_in_body.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_chemicals_in_body.dm
@@ -32,7 +32,7 @@
 		var/light_amount = 0 //How much light there is in the place, affects receiving nutrition and healing
 		if(isturf(loc)) //Else, there's considered to be no light
 			var/turf/T = loc
-			light_amount = T.get_lumcount(0.5) * 10
+			light_amount = T.get_lumcount() * 10
 
 		nutrition += light_amount
 		traumatic_shock -= light_amount

--- a/code/modules/mob/living/carbon/monkey/life.dm
+++ b/code/modules/mob/living/carbon/monkey/life.dm
@@ -509,7 +509,7 @@
 		if(isturf(loc)) //else, there's considered to be no light
 			var/turf/T = loc
 			if(T.dynamic_lighting)
-				light_amount = T.get_lumcount(0.5)
+				light_amount = T.get_lumcount() * 10
 			else
 				light_amount = 5
 		nutrition += light_amount

--- a/html/changelogs/example_2.yml
+++ b/html/changelogs/example_2.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general deleting of nice things)
+#   rscadd (general adding of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.
+author: 9600bauds
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# There needs to be a space after the - and before the prefix. Don't use tabs anywhere in this file.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# If you're using characters such as # ' : - or the like in your changelog, surround the entire change with quotes as shown in the second example. These quotes don't show up on the changelog once it's merged and prevent errors.
+# SCREW ANY OF THIS UP AND IT WON'T WORK.
+changes: 
+- bugfix: "Fixed Diona nymphs not regenerating health from bright lights. Note that their health regen is much much slower than grown Diona. Did not 'fix' the way they take damage from darkness, meaning they still pretty much just don't."


### PR DESCRIPTION
Elaborating on how Diona light calculations work
If the tile is at least 30% lit, Diona will regen from brute, toxin, and oxygen damage. Nymphs regen these at a rate of 1 per tick (basically like tricord), grown Diona regen the tile's lit% divided by 10. That is 10 fucking brute every tick if they carry a flashlight. And that's heinous.
What about darkness?
They don't take any damage from darkness. 
They just start to die if their hunger goes below red, except being on light quickly puts it back into grey. So basically to die from darkness you have to stay in a COMPLETELY dark place for, I don't know, 30 fucking minutes until you get hungry, without ever seeing light.
Darkness doesn't even make them starve faster.

Part of #11015
Fixes #7812
