### PR TITLE
Fixes lockbox items getting stuck with mouse_opacity 2 under specific but still pretty common circumstances

### DIFF
--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -71,14 +71,14 @@
 	..()
 	if(health <= 0)
 		for(var/atom/movable/A as mob|obj in src)
-			A.loc = src.loc
+			remove_from_storage(A, loc)
 		qdel(src)
 	return
 
 /obj/item/weapon/storage/lockbox/ex_act(severity)
 	var/newsev = max(3,severity+1)
 	for(var/atom/movable/A as mob|obj in src)//pulls everything out of the locker and hits it with an explosion
-		A.loc = src.loc
+		remove_from_storage(A, loc)
 		A.ex_act(newsev)
 	newsev=4-severity
 	if(prob(newsev*25)+25) // 1=100, 2=75, 3=50


### PR DESCRIPTION
There is absolutely no way this was never noticed before, but it was only reported two hours ago

If a lockbox was ever picked up then blown or shot open, the contents would be stuck with `mouse_opacity` 2 until they were placed into and removed from another storage item
I'm honestly amazed there haven't been more bugs of this nature found yet

Fixes #11035
