### PR TITLE
Snack Hotfix

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -4229,7 +4229,7 @@
 /obj/item/weapon/reagent_containers/food/snacks/porktenderloin
 	name = "pork tenderloin"
 	desc = "Delicious, gravy-covered meat that will melt-in-your-beak. Or mouth."
-	icon_state = "zhulongcaofan"
+	icon_state = "porktenderloin"
 	bitesize = 4
 	New()
 		..()

--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -792,7 +792,7 @@
 	plantname = "woodapple"
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/pitcher
-	name = "slipping pitcher"
+	name = "pitcher plant" //results in "slippery pitcher plant"
 	desc = "A fragile, but slippery exotic plant from tropical climates. Powerful digestive acid contained within dissolves prey."
 	icon_state = "pitcher"
 	filling_color = "7E8507"


### PR DESCRIPTION
- Pork Tenderloin now uses the proper sprite
- Slipping Pitcher renamed Pitcher Plant so that it results in "Slippery Pitcher Plant" instead of "Slippery Slipping Pitcher" which was redundant.

fixes #11050
