### PR TITLE
Allows AIs to examine things through cameras

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -98,7 +98,7 @@
 
 /atom/proc/AIShiftClick(var/mob/user)
 	if(user.client)
-		examine(user)
+		user.examination(src)
 	return
 
 /obj/machinery/door/airlock/AIShiftClick()  // Opens and closes doors!

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -96,7 +96,9 @@
 	I have no idea why it was in atoms.dm instead of respective files.
 */
 
-/atom/proc/AIShiftClick()
+/atom/proc/AIShiftClick(var/mob/user)
+	if(user.client)
+		examine(user)
 	return
 
 /obj/machinery/door/airlock/AIShiftClick()  // Opens and closes doors!

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -97,13 +97,8 @@
 		return ..()
 	return ..()
 
-/turf/Click()
-	if(!isAI(usr))
-		..()
-
 /turf/ex_act(severity)
 	return 0
-
 
 /turf/bullet_act(var/obj/item/projectile/Proj)
 	if(Proj.destroy)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -614,7 +614,12 @@ var/list/ai_list = list()
 /mob/living/silicon/ai/cancel_camera()
 	src.view_core()
 
-
+/mob/living/silicon/ai/examination(atom/A as obj|mob|turf) //proc for AIs to examine things
+	if(!(cameranet.checkCameraVis(A) || client.eye == src )) //under static or out core's sight range
+		to_chat(src, "That isn't in range of your cameras.")
+	else
+		A.examine(src)
+	
 //Replaces /mob/living/silicon/ai/verb/change_network() in ai.dm & camera.dm
 //Adds in /mob/living/silicon/ai/proc/ai_network_change() instead
 //Addition by Mord_Sith to define AI's network change ability

--- a/code/modules/mob/living/silicon/ai/freelook/cameranet.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/cameranet.dm
@@ -127,7 +127,7 @@ var/datum/cameranet/cameranet = new()
 
 // Will check if a mob is on a viewable turf. Returns 1 if it is, otherwise returns 0.
 
-/datum/cameranet/proc/checkCameraVis(mob/living/target as mob)
+/datum/cameranet/proc/checkCameraVis(atom/target as obj|mob|turf)
 
 
 	// 0xf = 15

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -87,13 +87,6 @@
 			if (isturf(src.loc) || isturf(src))
 				AI.eyeobj.forceMove(src)
 
-/mob/living/Click()
-	if(isAI(usr)) //IDK why this is needed
-		var/mob/living/silicon/ai/A = usr
-		if(!A.aicamera.in_camera_mode) //Fix for taking photos of mobs
-			return
-	..()
-
 /mob/living/DblClick()
 	if(isAI(usr) && usr != src)
 		var/mob/living/silicon/ai/A = usr


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.
-->

AIs can examine things if they're in sight of a camera by shiftclicking it
Currently it works fine  ~~on examining objects but doesn't do anything on mobs or turfs for some reason.but now it lets you examine things under static so I'm going to look at that in a bit.~~

We'll use this as a discussion since I've seen arguments against it from a balance perspective. Should AIs be allowed to examine things through their cameras?
