### PR TITLE
Adds dedicated chemistry investigation file

### DIFF
--- a/code/__HELPERS/logging.dm
+++ b/code/__HELPERS/logging.dm
@@ -110,37 +110,6 @@
 		message_admins(msg)
 
 /**
- * Helper function to log reagent transfers, usually 'bad' ones.
- *
- * @param user The user that performed the transfer
- * @param source The item from which the reagents are transferred.
- * @param target The destination of the transfer
- * @param amount The amount of units transferred
- * @param reagent_names List of reagent names to log
- */
-/proc/log_reagent_transfer(var/mob/user, var/atom/source, var/atom/target, var/amount_desired)
-	if(amount_desired == 0)
-		return
-	if(isobj(target)) //Wouldn't it be nice to just use : sometimes?
-		var/obj/O = target
-		if(!O.log_reagents)
-			return
-
-	var/list/bad_reagents = source.reagents.get_bad_reagent_names()
-	var/all_reagents = source.reagents.get_reagent_ids()
-	var/success = source.reagents.trans_to(target, amount_desired)
-
-	if(success)
-		if(bad_reagents.len > 0)
-			message_admins("<span class='notice'>[user] ([user.ckey]) (<A HREF='?_src_=holder;adminplayeropts=\ref[user]'>PP</A>) (<A HREF='?_src_=holder;adminmoreinfo=\ref[user]'>?</A>) \
-				has transferred [success]u of chemicals (including <span class='warning'>[english_list(bad_reagents)]</span>) \
-				from \a [source] (<A HREF='?_src_=vars;Vars=\ref[source]'>VV</A>) to \a [target] (<A HREF='?_src_=vars;Vars=\ref[target]'>VV</A>).</span>")
-		user.investigation_log(I_CHEMS, "[user.ckey] transferred [success]u of [all_reagents] from \a [source] \ref[source] to \a [target] \ref[target].")
-
-	return success
-
-
-/**
  * Standardized method for tracking startup times.
  */
 /proc/log_startup_progress(var/message)

--- a/code/game/machinery/bots/medbot.dm
+++ b/code/game/machinery/bots/medbot.dm
@@ -226,6 +226,7 @@
 		if(user.drop_item(W, src))
 			src.reagent_glass = W
 			to_chat(user, "<span class='notice'>You insert [W].</span>")
+			investigation_log(I_CHEMS, "was loaded with \a [W] by [user] ([user.ckey]), containing [W.reagents.get_reagent_ids(1)]")
 			src.updateUsrDialog()
 			return
 

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -328,6 +328,7 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 		if(user.drop_item(G, src))
 			beaker =  G
 			user.visible_message("[user] adds \a [G] to \the [src]!", "You add \a [G] to \the [src]!")
+			investigation_log(I_CHEMS, "was loaded with \a [G] by [user] ([user.ckey]), containing [G.reagents.get_reagent_ids(1)]")
 	if(iswrench(G))//FUCK YOU PARENT, YOU AREN'T MY REAL DAD
 		return
 	if(..())

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -78,6 +78,7 @@
 		if(user.drop_item(W, src))
 			src.beaker = W
 			to_chat(user, "You attach \the [W] to \the [src].")
+			investigation_log(I_CHEMS, "was loaded with \a [W] by [user] ([user.ckey]), containing [W.reagents.get_reagent_ids(1)]")
 			src.update_icon()
 			return
 	else

--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -630,7 +630,7 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 	diary << msg
 	diary << rawcode
 
-	investigation_log("ntsl", "[msg]<br /><pre>[rawcode]</pre>")
+	investigation_log(I_NTSL, "[msg]<br /><pre>[rawcode]</pre>")
 
 	if (length(rawcode)) // Let's not bother the admins for empty code.
 		message_admins("[msg] ([formatJumpTo(mob)])", 0, 1)
@@ -668,10 +668,3 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 	var/name = "data packet (#)"
 	var/garbage_collector = 1 // if set to 0, will not be garbage collected
 	var/input_type = "Speech File"
-
-
-
-
-
-
-

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -444,27 +444,6 @@ steam.start() -- spawns the effect
 		if(direct)
 			direction = direct
 
-		var/contained = ""
-		for(var/reagent in carry.reagent_list)
-			contained += " [reagent] "
-		if(contained)
-			contained = "\[[contained]\]"
-		var/area/A = get_area(location)
-
-		var/where = "[A.name] | [location.x], [location.y]"
-		var/whereLink = "<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[location.x];Y=[location.y];Z=[location.z]'>[where]</a>"
-
-		if(carry.my_atom.fingerprintslast)
-			var/mob/M = get_mob_by_key(carry.my_atom.fingerprintslast)
-			var/more = ""
-			if(M)
-				more = "(<A HREF='?_src_=holder;adminmoreinfo=\ref[M]'>?</a>)"
-			message_admins("A chemical smoke reaction has taken place in ([whereLink])[contained]. Last associated key is [carry.my_atom.fingerprintslast][more].", 0, 1)
-			log_game("A chemical smoke reaction has taken place in ([where])[contained]. Last associated key is [carry.my_atom.fingerprintslast].")
-		else
-			message_admins("A chemical smoke reaction has taken place in ([whereLink]). No associated key.", 0, 1)
-			log_game("A chemical smoke reaction has taken place in ([where])[contained]. No associated key.")
-
 	start()
 		var/i = 0
 

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -116,16 +116,7 @@
 /obj/item/weapon/extinguisher/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	if(proximity_flag)
 		if((istype(target, /obj/structure/reagent_dispensers)))
-			var/obj/o = target
-			var/list/badshit=list()
-			for(var/bad_reagent in reagents_to_log)
-				if(o.reagents.has_reagent(bad_reagent))
-					badshit += reagents_to_log[bad_reagent]
-			if(badshit.len)
-				var/hl="<span class='danger'>([english_list(badshit)])"
-				// message_admins("[user.name] ([user.ckey]) filled \a [src] with [o.reagents.get_reagent_ids()] [hl]. (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
-				log_game("[user.name] ([user.ckey]) filled \a [src] with [o.reagents.get_reagent_ids()] [hl]. (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
-			o.reagents.trans_to(src, 50)
+			target.reagents.trans_to(src, 50, log_transfer = TRUE, whodunnit = user)
 			to_chat(user, "<span class='notice'>\The [src] is now refilled</span>")
 			playsound(get_turf(src), 'sound/effects/refill.ogg', 50, 1, -6)
 			return
@@ -151,14 +142,10 @@
 		if (world.time < src.last_use + 20)
 			return
 		user.delayNextAttack(5, 1)
-		var/list/badshit=list()
-		for(var/bad_reagent in reagents_to_log)
-			if(reagents.has_reagent(bad_reagent))
-				badshit += reagents_to_log[bad_reagent]
-		if(badshit.len)
-			var/hl="<span class='danger'>([english_list(badshit)])</span>"
-			message_admins("[user.name] ([user.ckey]) used \a [src] filled with [reagents.get_reagent_ids(1)] [hl]. (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
-			log_game("[user.name] ([user.ckey]) used \a [src] filled with [reagents.get_reagent_ids(1)] [hl]. (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
+		var/badshit = reagents.write_logged_reagents()
+		if(badshit)
+			message_admins("[user.name] ([user.ckey]) used \a [src] that contained (<span class='warning'>[badshit]</span>). (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
+			log_game("[user.name] ([user.ckey]) used \a [src] that contained [badshit] at [user.x], [user.y], [user.z]")
 
 		src.last_use = world.time
 

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -132,6 +132,7 @@
 
 		if(is_open_container() && reagents.total_volume)
 			to_chat(user, "<span class='notice'>You empty \the [src] onto [target].</span>")
+			user.investigation_log(I_CHEMS, "has splashed [reagents.get_reagent_ids(1)] from \a [src] \ref[src] onto \the [target].")
 			if(reagents.has_reagent(FUEL))
 				message_admins("[user.name] ([user.ckey]) poured Welder Fuel onto [target]. (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
 				log_game("[user.name] ([user.ckey]) poured Welder Fuel onto [target]. (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -17,6 +17,7 @@
 	var/obj/item/slime_extract/C = null	//for Ex grenades
 	var/obj/item/weapon/reagent_containers/glass/beaker/noreactgrenade/reservoir = null
 	var/extract_uses = 0
+	var/mob/primed_by //For logging purposes mostly
 
 /obj/item/weapon/grenade/chem_grenade/attack_self(mob/user as mob)
 	if(!stage || stage==1)
@@ -42,6 +43,7 @@
 		log_attack("<font color='red'>[user.name] ([user.ckey]) primed \a [src].</font>")
 		log_admin("ATTACK: [user] ([user.ckey]) primed \a [src].")
 		message_admins("ATTACK: [user] ([user.ckey]) primed \a [src].")
+		primed_by = user
 
 		activate()
 		add_fingerprint(user)
@@ -172,6 +174,7 @@
 			log_attack("<font color='red'>[user.name] ([user.ckey]) primed \a [src]</font>")
 			log_admin("ATTACK: [user] ([user.ckey]) primed \a [src]")
 			message_admins("ATTACK: [user] ([user.ckey]) primed \a [src]")
+			primed_by = user
 
 	return
 
@@ -231,6 +234,8 @@
 				C.reagents.trans_to(reservoir, C.reagents.total_volume)
 
 		reservoir.reagents.update_total()
+
+	investigation_log(I_CHEMS, "has detonated, containing [reservoir.reagents.get_reagent_ids(1)][primed_by ? " - Primed by: [primed_by] ([primed_by.ckey])" : ""]")
 
 	reservoir.reagents.trans_to(src, reservoir.reagents.total_volume)
 

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -17,7 +17,7 @@
 	var/obj/item/slime_extract/C = null	//for Ex grenades
 	var/obj/item/weapon/reagent_containers/glass/beaker/noreactgrenade/reservoir = null
 	var/extract_uses = 0
-	var/mob/primed_by //For logging purposes mostly
+	var/mob/primed_by = "N/A" //"name (ckey)". For logging purposes
 
 /obj/item/weapon/grenade/chem_grenade/attack_self(mob/user as mob)
 	if(!stage || stage==1)
@@ -43,7 +43,7 @@
 		log_attack("<font color='red'>[user.name] ([user.ckey]) primed \a [src].</font>")
 		log_admin("ATTACK: [user] ([user.ckey]) primed \a [src].")
 		message_admins("ATTACK: [user] ([user.ckey]) primed \a [src].")
-		primed_by = user
+		primed_by = "[user] ([user.ckey])"
 
 		activate()
 		add_fingerprint(user)
@@ -174,7 +174,7 @@
 			log_attack("<font color='red'>[user.name] ([user.ckey]) primed \a [src]</font>")
 			log_admin("ATTACK: [user] ([user.ckey]) primed \a [src]")
 			message_admins("ATTACK: [user] ([user.ckey]) primed \a [src]")
-			primed_by = user
+			primed_by = "[user] ([user.ckey])"
 
 	return
 
@@ -235,7 +235,7 @@
 
 		reservoir.reagents.update_total()
 
-	investigation_log(I_CHEMS, "has detonated, containing [reservoir.reagents.get_reagent_ids(1)][primed_by ? " - Primed by: [primed_by] ([primed_by.ckey])" : ""]")
+	investigation_log(I_CHEMS, "has detonated, containing [reservoir.reagents.get_reagent_ids(1)] - Primed by: [primed_by]")
 
 	reservoir.reagents.trans_to(src, reservoir.reagents.total_volume)
 

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -1,4 +1,4 @@
-var/global/list/reagents_to_log = list(FUEL = "welder fuel", PLASMA = "plasma", PACID =  "polytrinic acid", SACID = "sulphuric acid", AMUTATIONTOXIN = "slime mutation toxin", MINDBREAKER = "mindbreaker toxin", CYANIDE = "cyanide", IMPEDREZENE = "impedrezene")
+var/global/list/reagents_to_log = list(FUEL, PLASMA, PACID, SACID, AMUTATIONTOXIN, MINDBREAKER, SPIRITBREAKER, CYANIDE, IMPEDREZENE)
 /obj
 	var/origin_tech = null	//Used by R&D to determine what research bonuses it grants.
 	var/reliability = 100	//Used by SOME devices to determine how reliable they are.

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -1,4 +1,4 @@
-var/global/list/reagents_to_log = list(FUEL  =  "welder fuel", PLASMA=  PLASMA, PACID =  "polytrinic acid", SACID =  "sulphuric acid", AMUTATIONTOXIN = "slime mutation toxin")
+var/global/list/reagents_to_log = list(FUEL = "welder fuel", PLASMA = "plasma", PACID =  "polytrinic acid", SACID = "sulphuric acid", AMUTATIONTOXIN = "slime mutation toxin", MINDBREAKER = "mindbreaker toxin", CYANIDE = "cyanide", IMPEDREZENE = "impedrezene")
 /obj
 	var/origin_tech = null	//Used by R&D to determine what research bonuses it grants.
 	var/reliability = 100	//Used by SOME devices to determine how reliable they are.
@@ -15,7 +15,7 @@ var/global/list/reagents_to_log = list(FUEL  =  "welder fuel", PLASMA=  PLASMA, 
 
 	var/damtype = "brute"
 	var/force = 0
-	
+
 	//Should we alert about reagents that should be logged?
 	var/log_reagents = 1
 
@@ -65,13 +65,13 @@ var/global/list/reagents_to_log = list(FUEL  =  "welder fuel", PLASMA=  PLASMA, 
 
 /obj/proc/cultify()
 	qdel(src)
-	
+
 /obj/proc/wrenchable()
 	return 0
-	
+
 /obj/proc/can_wrench_shuttle()
 	return 0
-	
+
 /obj/proc/is_sharp()
 	return sharpness
 
@@ -350,10 +350,10 @@ a {
 
 /obj/proc/verb_pickup(mob/living/user)
 	return 0
-	
+
 /obj/proc/can_quick_store(var/obj/item/I) //proc used to check that the current object can store another through quick equip
 	return 0
-	
+
 /obj/proc/quick_store(var/obj/item/I) //proc used to handle quick storing
 	return 0
 

--- a/code/modules/admin/admin_investigate.dm
+++ b/code/modules/admin/admin_investigate.dm
@@ -67,7 +67,7 @@ var/global/list/investigations=list(
 
 // Permits special snowflake formatting.
 /atom/proc/format_investigation_text(var/message)
-	return "<small>[time2text(world.timeofday,"hh:mm")] \ref[src] ([x],[y],[z])</small> || [src] [message]<br />"
+	return "<small>[time2text(world.timeofday,"hh:mm:ss")] \ref[src] ([x],[y],[z])</small> || [src] [message]<br />"
 
 //ADMINVERBS
 /client/proc/investigate_show(var/subject in AVAILABLE_INVESTIGATIONS)

--- a/code/modules/admin/admin_investigate.dm
+++ b/code/modules/admin/admin_investigate.dm
@@ -12,7 +12,7 @@
 #define INVESTIGATE_DIR "data/investigate/"
 
 // Just in case
-#define AVAILABLE_INVESTIGATIONS list("hrefs","notes","ntsl","singulo","atmos")
+#define AVAILABLE_INVESTIGATIONS list("hrefs","notes","ntsl","singulo","atmos","chems")
 
 // Actual list of global controllers.
 var/global/list/investigations=list(
@@ -21,6 +21,7 @@ var/global/list/investigations=list(
 	"ntsl"    = new /datum/log_controller("ntsl"),
 	"singulo" = new /datum/log_controller("singulo"),
 	"atmos"   = null, //new /datum/log_controller("atmos",filename="data/logs/[date_string] atmos.htm", persist=TRUE),
+	"chems" = null // Set on world.New() with hrefs and atmos
 )
 
 // Handles appending shit to log.

--- a/code/modules/admin/admin_investigate.dm
+++ b/code/modules/admin/admin_investigate.dm
@@ -12,16 +12,16 @@
 #define INVESTIGATE_DIR "data/investigate/"
 
 // Just in case
-#define AVAILABLE_INVESTIGATIONS list("hrefs","notes","ntsl","singulo","atmos","chems")
+#define AVAILABLE_INVESTIGATIONS list(I_HREFS,I_NOTES,I_NTSL,I_SINGULO,I_ATMOS,I_CHEMS)
 
 // Actual list of global controllers.
 var/global/list/investigations=list(
-	"hrefs"   = null, // Set on world.New()
-	"notes"   = new /datum/log_controller("notes"),
-	"ntsl"    = new /datum/log_controller("ntsl"),
-	"singulo" = new /datum/log_controller("singulo"),
-	"atmos"   = null, //new /datum/log_controller("atmos",filename="data/logs/[date_string] atmos.htm", persist=TRUE),
-	"chems" = null // Set on world.New() with hrefs and atmos
+	I_HREFS   = null, // Set on world.New()
+	I_NOTES   = new /datum/log_controller(I_NOTES),
+	I_NTSL    = new /datum/log_controller(I_NTSL),
+	I_SINGULO = new /datum/log_controller(I_SINGULO),
+	I_ATMOS   = null, //new /datum/log_controller("atmos",filename="data/logs/[date_string] atmos.htm", persist=TRUE),
+	I_CHEMS = null // Set on world.New() with hrefs and atmos
 )
 
 // Handles appending shit to log.

--- a/code/modules/admin/admin_investigate.dm
+++ b/code/modules/admin/admin_investigate.dm
@@ -69,6 +69,14 @@ var/global/list/investigations=list(
 /atom/proc/format_investigation_text(var/message)
 	return "<small>[time2text(world.timeofday,"hh:mm:ss")] \ref[src] ([x],[y],[z])</small> || [src] [message]<br />"
 
+// For non-atoms or very specific messages.
+/proc/minimal_investigation_log(var/subject, var/message, var/prefix)
+	var/datum/log_controller/I = investigations[subject]
+	if(!I)
+		warning("SOME ASSHAT USED INVALID INVESTIGATION ID [subject]")
+		return
+	I.write("<small>[time2text(world.timeofday,"hh:mm:ss")][prefix]</small> || [message]<br />")
+
 //ADMINVERBS
 /client/proc/investigate_show(var/subject in AVAILABLE_INVESTIGATIONS)
 	set name = "Investigate"

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -70,7 +70,7 @@
 	//Logs all hrefs
 	if(config && config.log_hrefs && investigations[I_HREFS])
 		var/datum/log_controller/I = investigations[I_HREFS]
-		I.write("<small>[time2text(world.timeofday,"hh:mm")] [src] (usr:[usr])</small> || [hsrc ? "[hsrc] " : ""][href]<br />")
+		I.write("<small>[time2text(world.timeofday,"hh:mm:ss")] [src] (usr:[usr])</small> || [hsrc ? "[hsrc] " : ""][href]<br />")
 
 	switch(href_list["_src_"])
 		if("holder")	hsrc = holder

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -354,9 +354,9 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 
 					var/created_volume = C.result_amount*multiplier
 					if(C.result)
-						feedback_add_details("chemical_reaction","[C.result]|[C.result_amount*multiplier]")
+						feedback_add_details("chemical_reaction","[created_volume][C.result]")
 						multiplier = max(multiplier, 1) //this shouldnt happen ...
-						add_reagent(C.result, C.result_amount*multiplier)
+						add_reagent(C.result, created_volume)
 						set_data(C.result, preserved_data)
 
 						//add secondary products
@@ -365,10 +365,13 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 
 					if	(istype(my_atom, /obj/item/weapon/grenade/chem_grenade))
 						my_atom.visible_message("<span class='caution'>[bicon(my_atom)] Something comes out of \the [my_atom].</span>")
+						//Logging inside chem_grenade.dm, prime()
 					else if	(istype(my_atom, /mob/living/carbon/human))
 						my_atom.visible_message("<span class='notice'>[my_atom] shudders a little.</span>","<span class='notice'>You shudder a little.</span>")
+						//Since the are no fingerprints to be had here, we'll trust the attack logs to log this
 					else
 						my_atom.visible_message("<span class='notice'>[bicon(my_atom)] The solution begins to bubble.</span>")
+						C.log_reaction(src, created_volume)
 
 					if(istype(my_atom, /obj/item/slime_extract))
 						var/obj/item/slime_extract/ME2 = my_atom
@@ -590,10 +593,10 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 	var/list/stuff = list()
 	for(var/datum/reagent/A in reagent_list)
 		if(and_amount)
-			stuff += "[get_reagent_amount(A.id)]U of [A.id]"
+			stuff += "[get_reagent_amount(A.id)]u of [A.id]"
 		else
 			stuff += A.id
-	return english_list(stuff)
+	return english_list(stuff, "no reagents")
 
 /datum/reagents/proc/remove_all_type(var/reagent_type, var/amount, var/strict = 0, var/safety = 1) // Removes all reagent of X type. @strict set to 1 determines whether the childs of the type are included.
 	if(!isnum(amount)) return 1

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -91,9 +91,18 @@ var/const/INGEST = 2
 
 	return the_id
 
-/datum/reagents/proc/trans_to(var/target, var/amount=1, var/multiplier=1, var/preserve_data=1)//if preserve_data=0, the reagents data will be lost. Usefull if you use data for some strange stuff and don't want it to be transferred.
+/* Transfers reagents from one reagents datum to another.
+ * target: Can be either a specific reagents datum, or an atom (in which case the atom's respective reagent datum will be used)
+ * amount: Desired amount to transfer. If the target doesn't have enough space, it will only transfer as much as possible rather than the full amount.
+ * multiplier: Magically multiplies the amount of reagents that the target will receive (does not affect how much is removed from the source)
+ * preserve_data: If false, the reagents data will be lost. Useful if you use data for some strange stuff and don't want it to be transferred.
+ * log_transfer: If true, will log the transfer of these reagents to the chemistry investigation file. If the reagents transferred contain a logged reagent, it will also alert admins.
+ * whodunnit: If available, the mob that directly caused this transfer. Used for logging.
+ */
+/datum/reagents/proc/trans_to(var/target, var/amount=1, var/multiplier=1, var/preserve_data=1, var/log_transfer = FALSE, var/mob/whodunnit)
 	if (!target)
 		return
+
 	var/datum/reagents/R
 	if (istype(target, /datum/reagents))
 		R = target
@@ -103,9 +112,18 @@ var/const/INGEST = 2
 			return
 		else
 			R = AM.reagents
+
 	amount = min(min(amount, src.total_volume), R.maximum_volume-R.total_volume)
 	var/part = amount / src.total_volume
 	var/trans_data = null
+
+	if(istype(R.my_atom, /obj))
+		var/obj/O = R.my_atom
+		if(!O.log_reagents)
+			log_transfer = FALSE
+	var/list/logged_message = list()
+	var/list/adminwarn_message = list()
+
 	for (var/datum/reagent/current_reagent in src.reagent_list)
 		if (!current_reagent)
 			continue
@@ -116,6 +134,10 @@ var/const/INGEST = 2
 		var/current_reagent_transfer = current_reagent.volume * part
 		if(preserve_data)
 			trans_data = current_reagent.data
+		if(log_transfer)
+			logged_message += "[current_reagent_transfer]u of [current_reagent.name]"
+			if(current_reagent.id in reagents_to_log)
+				adminwarn_message += "[current_reagent_transfer]u of <span class='warning'>[current_reagent.name]</span>"
 
 		R.add_reagent(current_reagent.id, (current_reagent_transfer * multiplier), trans_data)
 		src.remove_reagent(current_reagent.id, current_reagent_transfer)
@@ -125,7 +147,19 @@ var/const/INGEST = 2
 	//R.update_total()
 	R.handle_reactions()
 	src.handle_reactions()
+
+	if(log_transfer && logged_message.len)
+		var/turf/T = get_turf(my_atom)
+		minimal_investigation_log(I_CHEMS, "[whodunnit ? "[whodunnit] ([whodunnit.ckey])" : "(unknown whodunnit, last whodunnit processed: [usr.ckey])"] \
+		transferred [english_list(logged_message)] from \a [my_atom] \ref[my_atom] to \a [R.my_atom] \ref[R.my_atom].", prefix=" ([T.x],[T.y],[T.z])")
+		if(adminwarn_message.len)
+			message_admins("[whodunnit ? "[whodunnit] ([whodunnit.ckey]) (<A HREF='?_src_=holder;adminplayeropts=\ref[whodunnit]'>PP</A>) (<A HREF='?_src_=holder;adminmoreinfo=\ref[whodunnit]'>?</A>)" : "(unknown whodunnit, last whodunnit processed: [usr.ckey])"]\
+			has transferred [english_list(adminwarn_message)] from \a [my_atom] (<A HREF='?_src_=vars;Vars=\ref[my_atom]'>VV</A>) to \a [R.my_atom] (<A HREF='?_src_=vars;Vars=\ref[R.my_atom]'>VV</A>).\
+			[whodunnit ? " (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[whodunnit.x];Y=[whodunnit.y];Z=[whodunnit.z]'>JMP</a>)" : ""]")
+
 	return amount
+
+//I totally cannot tell why this proc exists
 /datum/reagents/proc/trans_to_holder(var/datum/reagents/target, var/amount=1, var/multiplier=1, var/preserve_data=1)//if preserve_data=0, the reagents data will be lost. Usefull if you use data for some strange stuff and don't want it to be transferred.
 	if (!target || src.is_empty())
 		return
@@ -643,17 +677,16 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 
 /**
  * Helper proc to retrieve the 'bad' reagents in the holder. Used for logging.
+ * Example of result: "5u of Polytrinic Acid, 5u of Cyanide, and 15u of Mindbreaker Toxin"
  */
-/datum/reagents/proc/get_bad_reagent_names()
-	if (!istype(reagents_to_log) || reagents_to_log.len == 0)
-		return null
+/datum/reagents/proc/write_logged_reagents()
+	. = list()
 
-	var/list/bad_reagents = list()
-	for (var/reagent_id in reagents_to_log)
-		if (src.has_reagent(reagent_id))
-			bad_reagents += reagents_to_log[reagent_id]
+	for(var/datum/reagent/R in reagent_list)
+		if(R.id in reagents_to_log) //reagents_to_log being a global list in objs.dm
+			. += "[R.volume]u of [R.name]"
 
-	return bad_reagents
+	return english_list(., nothing_text = "")
 
 /datum/reagents/proc/is_empty()
 	return total_volume <= 0

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -354,7 +354,7 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 
 					var/created_volume = C.result_amount*multiplier
 					if(C.result)
-						feedback_add_details("chemical_reaction","[created_volume][C.result]")
+						feedback_add_details("chemical_reaction","[C.result][created_volume]")
 						multiplier = max(multiplier, 1) //this shouldnt happen ...
 						add_reagent(C.result, created_volume)
 						set_data(C.result, preserved_data)

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -665,6 +665,8 @@ USE THIS CHEMISTRY DISPENSER FOR MAPS SO THEY START AT 100 ENERGY
 			if(!name)
 				return
 
+			var/logged_message = " - [usr] ([usr.ckey]) has made [count] pill[count > 1 ? "s, each" : ""] named '[name]' and containing "
+
 			while(count--)
 				if((amount_per_pill == 0 || reagents.total_volume == 0) && !href_list["createempty"]) //Don't create empty pills unless "createempty" is 1!
 					break
@@ -680,6 +682,10 @@ USE THIS CHEMISTRY DISPENSER FOR MAPS SO THEY START AT 100 ENERGY
 				if(src.loaded_pill_bottle)
 					if(loaded_pill_bottle.contents.len < loaded_pill_bottle.storage_slots)
 						P.loc = loaded_pill_bottle
+				if(count == 0) //only do this ONCE
+					logged_message += "[P.reagents.get_reagent_ids(1)]"
+
+			investigation_log(I_CHEMS, logged_message)
 
 			src.updateUsrDialog()
 			return 1

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -32,11 +32,36 @@
 			log_game("[message_prefix] in [my_area.name] ([T.x],[T.y],[T.z]) - Carried by [M.real_name] ([M.key])")
 		else
 			message += " - Last Fingerprint: [(A.fingerprintslast ? A.fingerprintslast : "N/A")]"
-			log_game("[message_prefix] in [my_area.name] ([T.x],[T.y],[T.z]) - last fingerprint  [(A.fingerprintslast ? A.fingerprintslast : "N/A")]")
+			log_game("[message_prefix] in [my_area.name] ([T.x],[T.y],[T.z]) - last fingerprint  [(A.fingerprintslast ? A.fingerprintslast : "N/A (Last user processed: [usr.ckey])")]")
 	else
 		message += "."
 
 	message_admins(message, 0, 1)
+
+/datum/chemical_reaction/proc/log_reaction(var/datum/reagents/holder, var/amt)
+	var/datum/log_controller/I = investigations[I_CHEMS]
+	var/atom/A = holder.my_atom
+	var/turf/T = get_turf(holder.my_atom)
+	to_chat(world, "holder being [A]")
+
+	var/formatted = "<small>[time2text(world.timeofday,"hh:mm:ss")] \ref[A] ([T.x],[T.y],[T.z])</small> || "
+
+	formatted += format_investigation_text(amt)
+
+	var/obj/machinery/M = get_holder_of_type(A, /obj/machinery)
+	if(istype(M))
+		formatted += " in \a [M], last touched by [(M.fingerprintslast ? M.fingerprintslast : "N/A (Last user processed: [usr.ckey])")] (Container: \a [A])"
+	else
+		formatted += " in \a [A], last touched by [(A.fingerprintslast ? A.fingerprintslast : "N/A (Last user processed: [usr.ckey])")]"
+
+	formatted += "<br />"
+
+	I.write(formatted)
+	return formatted
+
+// Permits special snowflake formatting.
+/datum/chemical_reaction/proc/format_investigation_text(var/amt)
+	return "[amt]u of [result] have been created"
 
 /datum/chemical_reaction/proc/on_reaction(var/datum/reagents/holder, var/created_volume)
 	return

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -1,3 +1,6 @@
+#define ALERT_AMOUNT_ONLY 1
+#define ALERT_ALL_REAGENTS 2
+
 ///////////////////////////////////////////////////////////////////////////////////
 /datum/chemical_reaction
 	var/name = null
@@ -59,7 +62,7 @@
 	result = null
 	required_reagents = list(WATER = 1, POTASSIUM = 1)
 	result_amount = 2
-	alert_admins = 1
+	alert_admins = ALERT_AMOUNT_ONLY
 
 /datum/chemical_reaction/explosion_potassium/on_reaction(var/datum/reagents/holder, var/created_volume)
 	var/datum/effect/effect/system/reagents_explosion/e = new()
@@ -414,7 +417,7 @@
 	result = NITROGLYCERIN
 	required_reagents = list(GLYCEROL = 1, PACID = 1, SACID = 1)
 	result_amount = 2
-	alert_admins = 1
+	alert_admins = ALERT_AMOUNT_ONLY
 
 /datum/chemical_reaction/nitroglycerin/on_reaction(var/datum/reagents/holder, var/created_volume)
 	var/datum/effect/effect/system/reagents_explosion/e = new()
@@ -497,7 +500,7 @@
 	required_reagents = list(POTASSIUM = 1, SUGAR = 1, PHOSPHORUS = 1)
 	result_amount = null
 	secondary = 1
-	alert_admins = 2
+	alert_admins = ALERT_ALL_REAGENTS
 
 /datum/chemical_reaction/chemsmoke/on_reaction(var/datum/reagents/holder, var/created_volume)
 	if(!is_in_airtight_object(holder.my_atom)) //Don't pop while ventcrawling.
@@ -810,7 +813,7 @@
 	result_amount = 1
 	required_container = /obj/item/slime_extract/grey
 	required_other = 1
-	alert_admins = 2
+	alert_admins = ALERT_ALL_REAGENTS
 
 /datum/chemical_reaction/slimespawn/on_reaction(var/datum/reagents/holder)
 	if(!is_in_airtight_object(holder.my_atom)) //Don't pop while ventcrawling.
@@ -1011,7 +1014,7 @@
 	result_amount = 1
 	required_container = /obj/item/slime_extract/gold
 	required_other = 1
-	alert_admins = 2
+	alert_admins = ALERT_ALL_REAGENTS
 
 /datum/chemical_reaction/slimecrit/on_reaction(var/datum/reagents/holder)
 	feedback_add_details("slime_cores_used", "[replacetext(name, " ", "_")]")
@@ -1067,7 +1070,7 @@
 	result_amount = 1
 	required_container = /obj/item/slime_extract/gold
 	required_other = 1
-	alert_admins = 2
+	alert_admins = ALERT_ALL_REAGENTS
 
 /datum/chemical_reaction/slimecritlesser/on_reaction(var/datum/reagents/holder)
 	feedback_add_details("slime_cores_used", "[replacetext(name, " ", "_")]")
@@ -1115,7 +1118,7 @@
 	result_amount = 1
 	required_container = /obj/item/slime_extract/gold
 	required_other = 1
-	alert_admins = 2
+	alert_admins = ALERT_ALL_REAGENTS
 
 /datum/chemical_reaction/slimecritweak/on_reaction(var/datum/reagents/holder)
 	feedback_add_details("slime_cores_used", "[replacetext(name, " ", "_")]")
@@ -1310,7 +1313,7 @@
 	result_amount = 1
 	required_container = /obj/item/slime_extract/darkblue
 	required_other = 1
-	alert_admins = 2
+	alert_admins = ALERT_ALL_REAGENTS
 
 /datum/chemical_reaction/slimefreeze/on_reaction(var/datum/reagents/holder)
 	feedback_add_details("slime_cores_used", "[replacetext(name, " ", "_")]")
@@ -1359,7 +1362,7 @@
 	result_amount = 1
 	required_container = /obj/item/slime_extract/orange
 	required_other = 1
-	alert_admins = 2
+	alert_admins = ALERT_ALL_REAGENTS
 
 /datum/chemical_reaction/slimefire/on_reaction(var/datum/reagents/holder)
 	feedback_add_details("slime_cores_used", "[replacetext(name, " ", "_")]")
@@ -1386,7 +1389,7 @@
 	result_amount = 1
 	required_container = /obj/item/slime_extract/yellow
 	required_other = 1
-	alert_admins = 2
+	alert_admins = ALERT_ALL_REAGENTS
 
 /datum/chemical_reaction/slimeoverload/on_reaction(var/datum/reagents/holder, var/created_volume)
 	feedback_add_details("slime_cores_used", "[replacetext(name, " ", "_")]")
@@ -1446,7 +1449,7 @@
 	result_amount = 10
 	required_container = /obj/item/slime_extract/purple
 	required_other = 1
-	alert_admins = 2
+	alert_admins = ALERT_ALL_REAGENTS
 
 /datum/chemical_reaction/slimejam/on_reaction(var/datum/reagents/holder)
 	feedback_add_details("slime_cores_used","[replacetext(name, " ", "_")]")
@@ -1476,7 +1479,7 @@
 	result_amount = 8
 	required_container = /obj/item/slime_extract/red
 	required_other = 1
-	alert_admins = 2
+	alert_admins = ALERT_ALL_REAGENTS
 
 /datum/chemical_reaction/slimeglycerol/on_reaction(var/datum/reagents/holder)
 	feedback_add_details("slime_cores_used", "[replacetext(name, " ", "_")]")
@@ -1503,7 +1506,7 @@
 	result_amount = 1
 	required_container = /obj/item/slime_extract/red
 	required_other = 1
-	alert_admins = 2
+	alert_admins = ALERT_ALL_REAGENTS
 
 /datum/chemical_reaction/slimebloodlust/on_reaction(var/datum/reagents/holder)
 	feedback_add_details("slime_cores_used", "[replacetext(name, " ", "_")]")
@@ -1539,7 +1542,7 @@
 	result_amount = 1
 	required_other = 1
 	required_container = /obj/item/slime_extract/black
-	alert_admins = 2
+	alert_admins = ALERT_ALL_REAGENTS
 
 /datum/chemical_reaction/slimemutate2/on_reaction(var/datum/reagents/holder)
 	feedback_add_details("slime_cores_used", "[replacetext(name, " ", "_")]")
@@ -1552,7 +1555,7 @@
 	result_amount = 1
 	required_other = 1
 	required_container = /obj/item/slime_extract/black
-	alert_admins = 2
+	alert_admins = ALERT_ALL_REAGENTS
 
 /datum/chemical_reaction/slimemednanobots/on_reaction(var/datum/reagents/holder)
 	feedback_add_details("slime_cores_used", "[replacetext(name, " ", "_")]")
@@ -1565,7 +1568,7 @@
 	result_amount = 1
 	required_other = 1
 	required_container = /obj/item/slime_extract/black
-	alert_admins = 2
+	alert_admins = ALERT_ALL_REAGENTS
 
 /datum/chemical_reaction/slimecomnanobots/on_reaction(var/datum/reagents/holder)
 	feedback_add_details("slime_cores_used", "[replacetext(name, " ", "_")]")
@@ -1579,7 +1582,7 @@
 	result_amount = 1
 	required_container = /obj/item/slime_extract/oil
 	required_other = 1
-	alert_admins = 2
+	alert_admins = ALERT_ALL_REAGENTS
 
 /datum/chemical_reaction/slimeexplosion/on_reaction(var/datum/reagents/holder)
 	feedback_add_details("slime_cores_used", "[replacetext(name, " ", "_")]")
@@ -1596,7 +1599,7 @@
 	result_amount = 1
 	required_container = /obj/item/slime_extract/oil
 	required_other = 1
-	alert_admins = 2
+	alert_admins = ALERT_ALL_REAGENTS
 
 /datum/chemical_reaction/slimegenocide/on_reaction(var/datum/reagents/holder)
 	feedback_add_details("slime_cores_used", "[replacetext(name, " ", "_")]")
@@ -1703,7 +1706,7 @@
 	result_amount = 1
 	required_container = /obj/item/slime_extract/bluespace
 	required_other = 1
-	alert_admins = 2
+	alert_admins = ALERT_ALL_REAGENTS
 
 /datum/chemical_reaction/slimeteleport/on_reaction(var/datum/reagents/holder, var/created_volume)
 	feedback_add_details("slime_cores_used", "[replacetext(name, " ", "_")]")
@@ -2693,3 +2696,7 @@
 	result = PAROXETINE
 	required_reagents = list(MINDBREAKER = 1, OXYGEN = 1, INAPROVALINE = 1)
 	result_amount = 3
+
+
+#undef ALERT_AMOUNT_ONLY
+#undef ALERT_ALL_REAGENTS

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -14,70 +14,54 @@
 	var/secondary = 0 //Set to nonzero if secondary reaction
 	var/list/secondary_results = list() //Additional reagents produced by the reaction
 	var/requires_heating = 0
-
-///vg/: Send admin alerts with standardized code.
-/datum/chemical_reaction/proc/send_admin_alert(var/datum/reagents/holder, var/reaction_name = src.name)
-	var/message_prefix = "\A [reaction_name] reaction has occured"
-	var/message = "[message_prefix]"
-	var/atom/A = holder.my_atom
-
-	if(A)
-		var/turf/T = get_turf(A)
-		var/area/my_area = get_area(T)
-
-		message += " in [formatJumpTo(T)]. (<A HREF='?_src_=vars;Vars=\ref[A]'>VV</A>)"
-		var/mob/M = get_holder_of_type(A, /mob)
-		if(M)
-			message += " - Carried By: [M.real_name] ([M.key]) (<A HREF='?_src_=holder;adminplayeropts=\ref[M]'>PP</A>) (<A HREF='?_src_=holder;adminmoreinfo=\ref[M]'>?</A>)"
-			log_game("[message_prefix] in [my_area.name] ([T.x],[T.y],[T.z]) - Carried by [M.real_name] ([M.key])")
-		else
-			message += " - Last Fingerprint: [(A.fingerprintslast ? A.fingerprintslast : "N/A")]"
-			log_game("[message_prefix] in [my_area.name] ([T.x],[T.y],[T.z]) - last fingerprint  [(A.fingerprintslast ? A.fingerprintslast : "N/A (Last user processed: [usr.ckey])")]")
-	else
-		message += "."
-
-	message_admins(message, 0, 1)
+	var/alert_admins = 0 //1 to alert admins with name and amount, 2 to alert with name and amount of all reagents
 
 /datum/chemical_reaction/proc/log_reaction(var/datum/reagents/holder, var/amt)
 	var/datum/log_controller/I = investigations[I_CHEMS]
 	var/atom/A = holder.my_atom
 	var/turf/T = get_turf(holder.my_atom)
-	to_chat(world, "holder being [A]")
+	var/mob/M = get_holder_of_type(A, /mob) //if held by a mob (not necessarily true)
 
-	var/formatted = "<small>[time2text(world.timeofday,"hh:mm:ss")] \ref[A] ([T.x],[T.y],[T.z])</small> || "
+	var/obj/machinery/O = get_holder_of_type(A, /obj/machinery) //rather than showing "in a large beaker" let's show the name of the machine if it's inside one
+	if(istype(O))
+		A = O
 
-	formatted += format_investigation_text(amt)
+	var/investigate_text = "<small>[time2text(world.timeofday,"hh:mm:ss")] \ref[A] ([T.x],[T.y],[T.z])</small> || "
 
-	var/obj/machinery/M = get_holder_of_type(A, /obj/machinery)
-	if(istype(M))
-		formatted += " in \a [M], last touched by [(M.fingerprintslast ? M.fingerprintslast : "N/A (Last user processed: [usr.ckey])")] (Container: \a [A])"
+	if(result)
+		investigate_text += "[amt]u of [result] have been created"
 	else
-		formatted += " in \a [A], last touched by [(A.fingerprintslast ? A.fingerprintslast : "N/A (Last user processed: [usr.ckey])")]"
+		investigate_text += "\A [name] reaction ([amt]u total combined) has taken place"
 
-	formatted += "<br />"
+	if(M)
+		investigate_text += " in \a [A] \ref[A], carried by [M.real_name] ([M.key])<br />"
+	else
+		investigate_text += " in \a [A] \ref[A], last touched by [(A.fingerprintslast ? A.fingerprintslast : "N/A (Last user processed: [usr.ckey])")]<br />"
 
-	I.write(formatted)
-	return formatted
+	I.write(investigate_text)
 
-// Permits special snowflake formatting.
-/datum/chemical_reaction/proc/format_investigation_text(var/amt)
-	return "[amt]u of [result] have been created"
+	if(alert_admins)
+		var/admin_text = "[name] reaction [alert_admins == 2 ? "([holder.get_reagent_ids(1)])" : "([amt]u total combined)"] at [formatJumpTo(T)]"
+		if(M)
+			admin_text += " in \a [A] (<A HREF='?_src_=vars;Vars=\ref[A]'>VV</A>), carried by [M.real_name] ([M.key]) (<A HREF='?_src_=holder;adminplayeropts=\ref[M]'>PP</A>) (<A HREF='?_src_=holder;adminmoreinfo=\ref[M]'>?</A>)"
+		else
+			admin_text += " in \a [A] (<A HREF='?_src_=vars;Vars=\ref[A]'>VV</A>), last touched by [(A.fingerprintslast ? A.fingerprintslast : "N/A (Last user processed: [usr.ckey])")]"
+		message_admins(admin_text, 0, 1)
+	return investigate_text
 
 /datum/chemical_reaction/proc/on_reaction(var/datum/reagents/holder, var/created_volume)
 	return
 
 //I recommend you set the result amount to the total volume of all components.
 /datum/chemical_reaction/explosion_potassium
-	name = "Explosion"
+	name = "Water Potassium Explosion"
 	id = "explosion_potassium"
 	result = null
 	required_reagents = list(WATER = 1, POTASSIUM = 1)
 	result_amount = 2
+	alert_admins = 1
 
 /datum/chemical_reaction/explosion_potassium/on_reaction(var/datum/reagents/holder, var/created_volume)
-
-	send_admin_alert(holder, reaction_name = "water/potassium explosion")
-
 	var/datum/effect/effect/system/reagents_explosion/e = new()
 	e.set_up(round (created_volume/10, 1), holder.my_atom, 0, 0)
 	e.holder_damage(holder.my_atom)
@@ -425,16 +409,14 @@
 	result_amount = 1
 
 /datum/chemical_reaction/nitroglycerin
-	name = "Nitroglycerin"
+	name = "Nitroglycerin Explosion"
 	id = NITROGLYCERIN
 	result = NITROGLYCERIN
 	required_reagents = list(GLYCEROL = 1, PACID = 1, SACID = 1)
 	result_amount = 2
+	alert_admins = 1
 
 /datum/chemical_reaction/nitroglycerin/on_reaction(var/datum/reagents/holder, var/created_volume)
-
-	send_admin_alert(holder, reaction_name = "nitroglycerin explosion")
-
 	var/datum/effect/effect/system/reagents_explosion/e = new()
 	e.set_up(round (created_volume/2, 1), holder.my_atom, 0, 0)
 	e.holder_damage(holder.my_atom)
@@ -515,6 +497,7 @@
 	required_reagents = list(POTASSIUM = 1, SUGAR = 1, PHOSPHORUS = 1)
 	result_amount = null
 	secondary = 1
+	alert_admins = 2
 
 /datum/chemical_reaction/chemsmoke/on_reaction(var/datum/reagents/holder, var/created_volume)
 	if(!is_in_airtight_object(holder.my_atom)) //Don't pop while ventcrawling.
@@ -827,14 +810,10 @@
 	result_amount = 1
 	required_container = /obj/item/slime_extract/grey
 	required_other = 1
+	alert_admins = 2
 
 /datum/chemical_reaction/slimespawn/on_reaction(var/datum/reagents/holder)
 	if(!is_in_airtight_object(holder.my_atom)) //Don't pop while ventcrawling.
-		if(istype(holder.my_atom.loc,/obj/item/weapon/grenade/chem_grenade))
-			send_admin_alert(holder, reaction_name = "grey slime in a grenade")
-		else
-			send_admin_alert(holder, reaction_name = "grey slime")
-
 		feedback_add_details("slime_cores_used", "[replacetext(name, " ", "_")]")
 
 		if(istype(holder.my_atom.loc,/obj/item/weapon/grenade/chem_grenade))
@@ -1025,22 +1004,20 @@
 
 //Gold
 /datum/chemical_reaction/slimecrit
-	name = "Slime Crit"
+	name = "Slime Crit (Summon Monsters)"
 	id = "m_tele"
 	result = null
 	required_reagents = list(PLASMA = 5)
 	result_amount = 1
 	required_container = /obj/item/slime_extract/gold
 	required_other = 1
+	alert_admins = 2
 
 /datum/chemical_reaction/slimecrit/on_reaction(var/datum/reagents/holder)
 	feedback_add_details("slime_cores_used", "[replacetext(name, " ", "_")]")
 	if(!istype(holder.my_atom.loc, /obj/item/weapon/grenade/chem_grenade))
 		holder.my_atom.visible_message("<span class='warning'>The slime extract begins to vibrate violently!</span>")
-		send_admin_alert(holder, reaction_name = "gold slime + plasma")
 		sleep(50)
-	else
-		send_admin_alert(holder, reaction_name = "gold slime + plasma in a grenade!!") //Expect to this this one spammed in the times to come
 
 	var/blocked = list(
 		/mob/living/simple_animal/hostile/alien/queen/large,
@@ -1083,22 +1060,20 @@
 				step(C, pick(NORTH,SOUTH,EAST,WEST))
 
 /datum/chemical_reaction/slimecritlesser
-	name = "Slime Crit Lesser"
+	name = "Slime Crit Lesser (Summon Monsters)"
 	id = "m_tele3"
 	result = null
 	required_reagents = list(BLOOD = 5)
 	result_amount = 1
 	required_container = /obj/item/slime_extract/gold
 	required_other = 1
+	alert_admins = 2
 
 /datum/chemical_reaction/slimecritlesser/on_reaction(var/datum/reagents/holder)
 	feedback_add_details("slime_cores_used", "[replacetext(name, " ", "_")]")
 	if(!istype(holder.my_atom.loc, /obj/item/weapon/grenade/chem_grenade))
 		holder.my_atom.visible_message("<span class='warning'>The slime extract begins to vibrate violently !</span>")
-		send_admin_alert(holder, reaction_name = "gold slime + blood")
 		sleep(50)
-	else
-		send_admin_alert(holder, reaction_name = "gold slime + blood in a grenade")
 
 	var/blocked = list(
 		/mob/living/simple_animal/hostile/alien/queen/large,
@@ -1113,8 +1088,6 @@
 		/mob/living/simple_animal/hostile/mining_drone,
 		) + typesof(/mob/living/simple_animal/hostile/humanoid) + typesof(/mob/living/simple_animal/hostile/asteroid) //Exclusion list for things you don't want the reaction to create.
 	var/list/critters = existing_typesof(/mob/living/simple_animal/hostile) - blocked //List of possible hostile mobs
-
-	send_admin_alert(holder, reaction_name = "gold slime + blood")
 
 	playsound(get_turf(holder.my_atom), 'sound/effects/phasein.ogg', 100, 1)
 
@@ -1142,14 +1115,12 @@
 	result_amount = 1
 	required_container = /obj/item/slime_extract/gold
 	required_other = 1
+	alert_admins = 2
 
 /datum/chemical_reaction/slimecritweak/on_reaction(var/datum/reagents/holder)
 	feedback_add_details("slime_cores_used", "[replacetext(name, " ", "_")]")
 	if(!istype(holder.my_atom.loc, /obj/item/weapon/grenade/chem_grenade))
 		holder.my_atom.visible_message("<span class='warning'>The slime extract begins to slowly vibrate!</span>")
-		send_admin_alert(holder, reaction_name = "gold slime + water")
-	else
-		send_admin_alert(holder, reaction_name = "gold slime + water in a grenade")
 
 	spawn(50)
 		var/atom/location = holder.my_atom.loc
@@ -1339,15 +1310,13 @@
 	result_amount = 1
 	required_container = /obj/item/slime_extract/darkblue
 	required_other = 1
+	alert_admins = 2
 
 /datum/chemical_reaction/slimefreeze/on_reaction(var/datum/reagents/holder)
 	feedback_add_details("slime_cores_used", "[replacetext(name, " ", "_")]")
 	if(!istype(holder.my_atom.loc,/obj/item/weapon/grenade/chem_grenade))
 		holder.my_atom.visible_message("<span class='warning'>The slime extract begins to vibrate violently!</span>")
-		send_admin_alert(holder, reaction_name = "dark blue slime + plasma (Freeze)")
 		sleep(50)
-	else
-		send_admin_alert(holder, reaction_name = "dark blue slime + plasma (Freeze) in a grenade")
 
 	playsound(get_turf(holder.my_atom), 'sound/effects/phasein.ogg', 100, 1)
 
@@ -1383,22 +1352,21 @@
 	feedback_add_details("slime_cores_used", "[replacetext(name, " ", "_")]")
 
 /datum/chemical_reaction/slimefire
-	name = "Slime fire"
+	name = "Slime Napalm"
 	id = "m_fire"
 	result = null
 	required_reagents = list(PLASMA = 5)
 	result_amount = 1
 	required_container = /obj/item/slime_extract/orange
 	required_other = 1
+	alert_admins = 2
 
 /datum/chemical_reaction/slimefire/on_reaction(var/datum/reagents/holder)
 	feedback_add_details("slime_cores_used", "[replacetext(name, " ", "_")]")
 	if(!istype(holder.my_atom.loc,/obj/item/weapon/grenade/chem_grenade))
 		holder.my_atom.visible_message("<span class='warning'>The slime extract begins to vibrate violently!</span>")
-		send_admin_alert(holder, reaction_name = "orange slime + plasma (Napalm)")
 		sleep(50)
-	else
-		send_admin_alert(holder, reaction_name = "orange slime + plasma (Napalm) in a grenade")
+
 	var/turf/location = get_turf(holder.my_atom.loc)
 	for(var/turf/simulated/floor/target_tile in range(0, location))
 
@@ -1418,13 +1386,10 @@
 	result_amount = 1
 	required_container = /obj/item/slime_extract/yellow
 	required_other = 1
+	alert_admins = 2
 
 /datum/chemical_reaction/slimeoverload/on_reaction(var/datum/reagents/holder, var/created_volume)
 	feedback_add_details("slime_cores_used", "[replacetext(name, " ", "_")]")
-	if(!istype(holder.my_atom.loc, /obj/item/weapon/grenade/chem_grenade))
-		send_admin_alert(holder, reaction_name = "yellow slime + blood (EMP)")
-	else
-		send_admin_alert(holder, reaction_name = "yellow slime + blood (EMP) in a grenade")
 	empulse(get_turf(holder.my_atom), 3, 7)
 
 /datum/chemical_reaction/slimecell
@@ -1481,11 +1446,10 @@
 	result_amount = 10
 	required_container = /obj/item/slime_extract/purple
 	required_other = 1
+	alert_admins = 2
 
 /datum/chemical_reaction/slimejam/on_reaction(var/datum/reagents/holder)
 	feedback_add_details("slime_cores_used","[replacetext(name, " ", "_")]")
-	if(istype(holder.my_atom.loc, /obj/item/weapon/grenade/chem_grenade))
-		send_admin_alert(holder, reaction_name="purple slime + sugar (Slime Jelly) in a grenade")
 
 //Dark Purple
 /datum/chemical_reaction/slimeplasma
@@ -1512,11 +1476,10 @@
 	result_amount = 8
 	required_container = /obj/item/slime_extract/red
 	required_other = 1
+	alert_admins = 2
 
 /datum/chemical_reaction/slimeglycerol/on_reaction(var/datum/reagents/holder)
 	feedback_add_details("slime_cores_used", "[replacetext(name, " ", "_")]")
-	if(istype(holder.my_atom.loc, /obj/item/weapon/grenade/chem_grenade))
-		send_admin_alert(holder, reaction_name = "red slime + plasma (Glycerol) in a grenade")
 
 /datum/chemical_reaction/slimeres
 	name = "Slime Res"
@@ -1540,14 +1503,10 @@
 	result_amount = 1
 	required_container = /obj/item/slime_extract/red
 	required_other = 1
+	alert_admins = 2
 
 /datum/chemical_reaction/slimebloodlust/on_reaction(var/datum/reagents/holder)
 	feedback_add_details("slime_cores_used", "[replacetext(name, " ", "_")]")
-
-	if(!istype(holder.my_atom.loc, /obj/item/weapon/grenade/chem_grenade))
-		send_admin_alert(holder, reaction_name = "red slime + blood (Slime Frenzy)")
-	else
-		send_admin_alert(holder, reaction_name = "red slime + blood (Slime Frenzy) in a grenade")
 
 	for(var/mob/living/carbon/slime/slime in viewers(get_turf(holder.my_atom), null))
 		slime.rabid()
@@ -1580,11 +1539,10 @@
 	result_amount = 1
 	required_other = 1
 	required_container = /obj/item/slime_extract/black
+	alert_admins = 2
 
 /datum/chemical_reaction/slimemutate2/on_reaction(var/datum/reagents/holder)
 	feedback_add_details("slime_cores_used", "[replacetext(name, " ", "_")]")
-	if(istype(holder.my_atom.loc, /obj/item/weapon/grenade/chem_grenade))
-		send_admin_alert(holder, reaction_name = "black slime + plasma (Mutates to Slime) in a grenade")
 
 /datum/chemical_reaction/slimemednanobots
 	name = "Slime Medical Nanobots"
@@ -1594,10 +1552,10 @@
 	result_amount = 1
 	required_other = 1
 	required_container = /obj/item/slime_extract/black
+	alert_admins = 2
 
 /datum/chemical_reaction/slimemednanobots/on_reaction(var/datum/reagents/holder)
 	feedback_add_details("slime_cores_used", "[replacetext(name, " ", "_")]")
-	send_admin_alert(holder, reaction_name = "black slime + gold (Medical Nanobots) in a grenade")
 
 /datum/chemical_reaction/slimecomnanobots
 	name  = "Slime Combat Nanobots"
@@ -1607,10 +1565,10 @@
 	result_amount = 1
 	required_other = 1
 	required_container = /obj/item/slime_extract/black
+	alert_admins = 2
 
 /datum/chemical_reaction/slimecomnanobots/on_reaction(var/datum/reagents/holder)
 	feedback_add_details("slime_cores_used", "[replacetext(name, " ", "_")]")
-	send_admin_alert(holder, reaction_name = "black slime + uranium (Combat Nanobots) in a grenade")
 
 //Oil
 /datum/chemical_reaction/slimeexplosion
@@ -1621,15 +1579,13 @@
 	result_amount = 1
 	required_container = /obj/item/slime_extract/oil
 	required_other = 1
+	alert_admins = 2
 
 /datum/chemical_reaction/slimeexplosion/on_reaction(var/datum/reagents/holder)
 	feedback_add_details("slime_cores_used", "[replacetext(name, " ", "_")]")
 	if(!istype(holder.my_atom.loc,/obj/item/weapon/grenade/chem_grenade))
 		holder.my_atom.visible_message("<span class='warning'>The slime extract begins to vibrate violently!</span>")
-		send_admin_alert(holder, reaction_name = "oil slime + plasma (Explosion)")
 		sleep(50)
-	else
-		send_admin_alert(holder, reaction_name = "oil slime + plasma (Explosion) in a grenade")
 	explosion(get_turf(holder.my_atom), 1 ,3, 6)
 
 /datum/chemical_reaction/slimegenocide
@@ -1640,15 +1596,10 @@
 	result_amount = 1
 	required_container = /obj/item/slime_extract/oil
 	required_other = 1
+	alert_admins = 2
 
 /datum/chemical_reaction/slimegenocide/on_reaction(var/datum/reagents/holder)
 	feedback_add_details("slime_cores_used", "[replacetext(name, " ", "_")]")
-
-	if(!istype(holder.my_atom.loc, /obj/item/weapon/grenade/chem_grenade))
-		send_admin_alert(holder, reaction_name="oil slime + blood (Slime Genocide)")
-	else
-		send_admin_alert(holder, reaction_name="oil slime + blood (Slime Genocide) in a grenade")
-
 	for(var/mob/living/carbon/slime/S in viewers(get_turf(holder.my_atom), null)) //Kills slimes
 		S.death(0)
 	for(var/mob/living/simple_animal/slime/S in viewers(get_turf(holder.my_atom), null)) //Kills pet slimes too
@@ -1752,14 +1703,10 @@
 	result_amount = 1
 	required_container = /obj/item/slime_extract/bluespace
 	required_other = 1
+	alert_admins = 2
 
 /datum/chemical_reaction/slimeteleport/on_reaction(var/datum/reagents/holder, var/created_volume)
 	feedback_add_details("slime_cores_used", "[replacetext(name, " ", "_")]")
-
-	if(!istype(holder.my_atom.loc,/obj/item/weapon/grenade/chem_grenade))
-		send_admin_alert(holder, reaction_name = "bluespace slime + plasma (Mass Teleport)")
-	else
-		send_admin_alert(holder, reaction_name = "bluespace slime + plasma (Mass Teleport) in a grenade")
 
 	//Calculate new position (searches through beacons in world)
 	var/obj/item/beacon/chosen

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -106,7 +106,7 @@ var/list/LOGGED_SPLASH_REAGENTS = list(FUEL, THERMITE)
 /**
  * Transfer reagents between reagent_containers/reagent_dispensers.
  */
-/proc/transfer_sub(var/atom/source, var/atom/target, var/amount, var/mob/user)
+/proc/transfer_sub(var/atom/source, var/atom/target, var/amount, var/mob/user, var/log_transfer = FALSE)
 	// Typecheck shenanigans
 	var/source_empty
 	var/target_full
@@ -148,7 +148,7 @@ var/list/LOGGED_SPLASH_REAGENTS = list(FUEL, THERMITE)
 		to_chat(user, "<span class='warning'>\The [target] is full.</span>")
 		return -1
 
-	return source.reagents.trans_to(target, amount)
+	return source.reagents.trans_to(target, amount, log_transfer = log_transfer, whodunnit = user)
 
 /**
  * Helper proc to handle reagent splashes. A negative `amount` will splash all the reagents.
@@ -210,14 +210,13 @@ var/list/LOGGED_SPLASH_REAGENTS = list(FUEL, THERMITE)
 		if (!container.is_open_container() && istype(container,/obj/item/weapon/reagent_containers))
 			return -1
 
-		var/tx_amount = log_reagent_transfer(user, src, target, amount_per_transfer_from_this)
+		success = transfer_sub(src, target, amount_per_transfer_from_this, user, log_transfer = TRUE)
 
-		success = tx_amount
 		if(success)
-			if (tx_amount > 0)
-				to_chat(user, "<span class='notice'>You transfer [tx_amount] units of the solution to \the [target].</span>")
+			if (success > 0)
+				to_chat(user, "<span class='notice'>You transfer [success] units of the solution to \the [target].</span>")
 
-			return (tx_amount)
+			return (success)
 
 	if(!success)
 		// Mob splashing

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -38,6 +38,7 @@ var/list/LOGGED_SPLASH_REAGENTS = list(FUEL, THERMITE)
 	if(isturf(usr.loc))
 		if(reagents.total_volume > 10) //Beakersplashing only likes to do this sound when over 10 units
 			playsound(get_turf(src), 'sound/effects/slosh.ogg', 25, 1)
+		usr.investigation_log(I_CHEMS, "has emptied \a [src] \ref[src] containing [reagents.get_reagent_ids(1)] onto \the [usr.loc].")
 		reagents.reaction(usr.loc)
 		spawn() src.reagents.clear_reagents()
 		usr.visible_message("<span class='warning'>[usr] splashes something onto the floor!</span>",
@@ -161,12 +162,16 @@ var/list/LOGGED_SPLASH_REAGENTS = list(FUEL, THERMITE)
 	reagents.reaction(target, TOUCH)
 
 	if (amount > 0)
+		if(user)
+			user.investigation_log(I_CHEMS, "has splashed [amount]u of [reagents.get_reagent_ids()] from \a [reagents.my_atom] \ref[reagents.my_atom] onto \the [target].")
 		reagents.remove_any(amount)
 		if(user)
 			if(user.Adjacent(target))
 				user.visible_message("<span class='warning'>\The [target] has been splashed with something by [user]!</span>",
 			                     "<span class='notice'>You splash some of the solution onto \the [target].</span>")
 	else
+		if(user)
+			user.investigation_log(I_CHEMS, "has splashed [reagents.get_reagent_ids(1)] from \a [reagents.my_atom] \ref[reagents.my_atom] onto \the [target].")
 		reagents.clear_reagents()
 		if(user)
 			if(user.Adjacent(target))
@@ -205,16 +210,12 @@ var/list/LOGGED_SPLASH_REAGENTS = list(FUEL, THERMITE)
 		if (!container.is_open_container() && istype(container,/obj/item/weapon/reagent_containers))
 			return -1
 
-		var/list/bad_reagents = reagents.get_bad_reagent_names() // Used for logging
-		var/tx_amount = transfer_sub(src, target, amount_per_transfer_from_this, user)
+		var/tx_amount = log_reagent_transfer(user, src, target, amount_per_transfer_from_this)
+
 		success = tx_amount
 		if(success)
 			if (tx_amount > 0)
 				to_chat(user, "<span class='notice'>You transfer [tx_amount] units of the solution to \the [target].</span>")
-
-			// Log transfers of 'bad things' (/vg/)
-			if (tx_amount > 0 && container.log_reagents && bad_reagents && bad_reagents.len > 0)
-				log_reagents(user, src, target, tx_amount, bad_reagents)
 
 			return (tx_amount)
 

--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -73,7 +73,7 @@
 			else
 				M.LAssailant = user
 
-		trans = log_reagent_transfer(user, src, target, amount_per_transfer_from_this)
+		trans = src.reagents.trans_to(target, amount_per_transfer_from_this, log_transfer = TRUE, whodunnit = user)
 		to_chat(user, "<span class='notice'>You transfer [trans] units of the solution.</span>")
 		update_icon()
 
@@ -87,7 +87,7 @@
 			to_chat(user, "<span class='warning'>[target] is empty.</span>")
 			return
 
-		var/trans = log_reagent_transfer(user, target, src, amount_per_transfer_from_this)
+		var/trans = target.reagents.trans_to(src, amount_per_transfer_from_this, log_transfer = TRUE, whodunnit = user)
 
 		to_chat(user, "<span class='notice'>You fill [src] with [trans] units of the solution.</span>")
 

--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -31,7 +31,6 @@
 				to_chat(user, "<span class='notice'>You squirt the solution onto the [target]!</span>")
 				update_icon()
 		return
-	var/list/bad_reagents = reagents.get_bad_reagent_names() // Used for logging
 	if(reagents.total_volume)
 
 		if(target.reagents.total_volume >= target.reagents.maximum_volume)
@@ -66,26 +65,18 @@
 
 			var/mob/living/M = target
 
-			var/list/injected = list()
-			for(var/datum/reagent/R in src.reagents.reagent_list)
-				injected += R.name
-			var/contained = english_list(injected)
-			M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been squirted with [src.name] by [user.name] ([user.ckey]). Reagents: [contained]</font>")
-			user.attack_log += text("\[[time_stamp()]\] <font color='red'>Used the [src.name] to squirt [M.name] ([M.key]). Reagents: [contained]</font>")
-			msg_admin_attack("[user.name] ([user.ckey]) squirted [M.name] ([M.key]) with [src.name]. Reagents: [contained] (INTENT: [uppertext(user.a_intent)]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
+			M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been squirted with [src.name] by [user.name] ([user.ckey]). Reagents: [reagents.get_reagent_ids(1)]</font>")
+			user.attack_log += text("\[[time_stamp()]\] <font color='red'>Used the [src.name] to squirt [M.name] ([M.key]). Reagents: [reagents.get_reagent_ids(1)]</font>")
+			msg_admin_attack("[user.name] ([user.ckey]) squirted [M.name] ([M.key]) with [src.name]. Reagents: [reagents.get_reagent_ids(1)] (INTENT: [uppertext(user.a_intent)]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
 			if(!iscarbon(user))
 				M.LAssailant = null
 			else
 				M.LAssailant = user
 
-		trans = src.reagents.trans_to(target, amount_per_transfer_from_this)
+		trans = log_reagent_transfer(user, src, target, amount_per_transfer_from_this)
 		to_chat(user, "<span class='notice'>You transfer [trans] units of the solution.</span>")
 		update_icon()
 
-		// /vg/: Logging transfers of bad things
-		if(istype(target))
-			if(istype(reagents_to_log) && reagents_to_log.len && target.log_reagents)
-				log_reagents(user, src, target, trans, bad_reagents)
 	else
 
 		if(!target.is_open_container() && !istype(target,/obj/structure/reagent_dispensers))
@@ -96,9 +87,7 @@
 			to_chat(user, "<span class='warning'>[target] is empty.</span>")
 			return
 
-		var/trans = target.reagents.trans_to(src, amount_per_transfer_from_this)
-		if(istype(reagents_to_log) && reagents_to_log.len && target.log_reagents)
-			log_reagents(user, src, target, trans, bad_reagents)
+		var/trans = log_reagent_transfer(user, target, src, amount_per_transfer_from_this)
 
 		to_chat(user, "<span class='notice'>You fill [src] with [trans] units of the solution.</span>")
 

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -53,12 +53,7 @@
 		return
 
 	var/target_was_empty = (target.reagents.total_volume == 0)
-	var/list/bad_reagents = reagents.get_bad_reagent_names()
-	var/tx_amount = reagents.trans_to(target, reagents.total_volume)
-
-	// Log transfers of 'bad 'things' (/vg/)
-	if (tx_amount > 0 && target.log_reagents && bad_reagents && bad_reagents.len > 0)
-		log_reagents(user, src, target, tx_amount, bad_reagents)
+	var/tx_amount = log_reagent_transfer(user, src, target, reagents.total_volume)
 
 	// Show messages
 	if (tx_amount > 0)

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -53,7 +53,7 @@
 		return
 
 	var/target_was_empty = (target.reagents.total_volume == 0)
-	var/tx_amount = log_reagent_transfer(user, src, target, reagents.total_volume)
+	var/tx_amount = reagents.trans_to(target, reagents.total_volume, log_transfer = TRUE, whodunnit = user)
 
 	// Show messages
 	if (tx_amount > 0)

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -83,6 +83,8 @@ var/global/list/logged_sprayed_reagents = list(SACID, PACID, LUBE, FUEL)
 	if (log_reagent_list.len > 0)
 		add_gamelogs(user, "sprayed {[english_list(log_reagent_list, and_text = ", ")]} with \the [src]", admin = TRUE, tp_link = TRUE)
 
+	user.investigation_log(I_CHEMS, "[user.ckey] sprayed [amount_per_transfer_from_this]u from \a [src] \ref[src] containing [reagents.get_reagent_ids(1)] towards [A] ([A.x], [A.y], [A.z]).")
+
 	// Override for your custom puff behaviour
 	make_puff(A, user)
 

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -232,7 +232,7 @@
 		// TODO which is pretty irrelevant now but should be fixed
 		reagents.reaction(target, INGEST)
 
-	tx_amount = log_reagent_transfer(user, src, target, tx_amount)
+	tx_amount = reagents.trans_to(target, tx_amount, log_transfer = TRUE, whodunnit = user)
 	to_chat(user, "<span class='notice'>You inject [tx_amount] units of the solution. The syringe now contains [reagents.total_volume] units.</span>")
 
 	if (src.is_empty())

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -226,19 +226,14 @@
 			add_attacklogs(user, target, "injected", object = src, addition = "Reagents: [reagent_names]", admin_warn = TRUE)
 
 	// Handle transfers and mob reactions
-	var/list/bad_reagents = reagents.get_bad_reagent_names() // Used for logging
 	var/tx_amount = min(amount_per_transfer_from_this, reagents.total_volume)
 	if (ismob(target))
 		// TODO Every reagent reacts with the full volume instead of being scaled accordingly
 		// TODO which is pretty irrelevant now but should be fixed
 		reagents.reaction(target, INGEST)
 
-	tx_amount = reagents.trans_to(target, tx_amount)
+	tx_amount = log_reagent_transfer(user, src, target, tx_amount)
 	to_chat(user, "<span class='notice'>You inject [tx_amount] units of the solution. The syringe now contains [reagents.total_volume] units.</span>")
-
-	// Log transfers of 'bad things' (/vg/)
-	if (tx_amount > 0 && isobj(target) && target:log_reagents && bad_reagents && bad_reagents.len > 0)
-		log_reagents(user, src, target, tx_amount, bad_reagents)
 
 	if (src.is_empty())
 		mode = SYRINGE_DRAW

--- a/code/setup.dm
+++ b/code/setup.dm
@@ -1470,6 +1470,7 @@ var/default_colour_matrix = list(1,0,0,0,\
 #define I_NTSL     "ntsl"
 #define I_SINGULO  "singulo"
 #define I_ATMOS    "atmos"
+#define I_CHEMS	   "chems"
 
 // delayNext() flags.
 #define DELAY_MOVE    1

--- a/code/world.dm
+++ b/code/world.dm
@@ -34,6 +34,7 @@ var/savefile/panicfile
 
 	investigations["hrefs"] = new /datum/log_controller("hrefs", filename="data/logs/[date_string] hrefs.htm", persist=TRUE)
 	investigations["atmos"] = new /datum/log_controller("atmos", filename="data/logs/[date_string] atmos.htm", persist=TRUE)
+	investigations["chems"] = new /datum/log_controller("chems", filename="data/logs/[date_string] chemistry.htm", persist=TRUE)
 
 	diary = file("data/logs/[date_string].log")
 	panicfile = new/savefile("data/logs/profiling/proclogs/[date_string].sav")

--- a/code/world.dm
+++ b/code/world.dm
@@ -32,9 +32,9 @@ var/savefile/panicfile
 	// logs
 	var/date_string = time2text(world.realtime, "YYYY/MM-Month/DD-Day")
 
-	investigations["hrefs"] = new /datum/log_controller("hrefs", filename="data/logs/[date_string] hrefs.htm", persist=TRUE)
-	investigations["atmos"] = new /datum/log_controller("atmos", filename="data/logs/[date_string] atmos.htm", persist=TRUE)
-	investigations["chems"] = new /datum/log_controller("chems", filename="data/logs/[date_string] chemistry.htm", persist=TRUE)
+	investigations[I_HREFS] = new /datum/log_controller(I_HREFS, filename="data/logs/[date_string] hrefs.htm", persist=TRUE)
+	investigations[I_ATMOS] = new /datum/log_controller(I_ATMOS, filename="data/logs/[date_string] atmos.htm", persist=TRUE)
+	investigations[I_CHEMS] = new /datum/log_controller(I_CHEMS, filename="data/logs/[date_string] chemistry.htm", persist=TRUE)
 
 	diary = file("data/logs/[date_string].log")
 	panicfile = new/savefile("data/logs/profiling/proclogs/[date_string].sav")


### PR DESCRIPTION
No more playing the guessing game when someone puts polyacid in Cryo!
This adds a whole new file to the logs, i.e. "18-Monday chemistry.htm", which can be seen in-game by admins with the Investigate verb.
A few new things are logged in this file and some logging messages that would go to general logs now go into this file instead.
Mindbreaker, Cyanide and Impedrezene are now considered "logged reagents" and will alert admins like polyacid and such already do.

Things that are now logged in this file:
- Every transfer of chemicals from one container to the other, including injecting chemicals into food and such
- Every chemical reaction, including whodunnit and where
- Contents of splashed beakers
- Exactly what did chemgrenades have when exploding
- Making pills, with the name of the pills and what they contained precisely
- Loading beakers into Cryo, Medibots, and IV drips

Fixes #7337
Fixes #9490
