### PR TITLE
Fixes #11041

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -285,8 +285,7 @@
 			if(!WT.remove_fuel(0,user))
 				to_chat(user, "<span class='notice'>You need more welding fuel to complete this task.</span>")
 				return
-			var/obj/item/stack/sheet/metal/Met = getFromPool(/obj/item/stack/sheet/metal, get_turf(src))
-			Met.amount = 2
+			materials.makeSheets(src)
 			for(var/mob/M in viewers(src))
 				M.show_message("<span class='notice'>\The [src] has been cut apart by [user] with \the [WT].</span>", 1, "You hear welding.", 2)
 			qdel(src)

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -32,7 +32,7 @@
 	var/sound_effect_open = 'sound/machines/click.ogg'
 	var/sound_effect_close = 'sound/machines/click.ogg'
 
-	starting_materials = list(MAT_PLASTIC = 10*CC_PER_SHEET_METAL) // Recipe calls for 10 sheets.
+	starting_materials = list(MAT_PLASTIC = 10*CC_PER_SHEET_MISC) // Recipe calls for 10 sheets.
 
 /obj/structure/closet/crate/internals
 	desc = "A internals crate."

--- a/code/modules/mining/materials.dm
+++ b/code/modules/mining/materials.dm
@@ -105,6 +105,13 @@ var/global/list/initial_materials	//Stores all the matids = 0 in helping New
 
 	return material_list[mat_id]
 
+/datum/materials/proc/makeSheets(var/atom/loc)
+	for (var/id in storage)
+		var/amount = getAmount(id)
+		if(amount)
+			var/datum/material/mat = getMaterial(id)
+			getFromPool(mat.sheettype, loc, Floor(amount / mat.cc_per_sheet))
+
 //HOOKS//
 /atom/proc/onMaterialChange(matID, amount)
 	return

--- a/html/changelogs/Hikato.yml
+++ b/html/changelogs/Hikato.yml
@@ -33,5 +33,5 @@ delete-after: True
 # If you're using characters such as # ' : - or the like in your changelog, surround the entire change with quotes as shown in the second example. These quotes don't show up on the changelog once it's merged and prevent errors.
 # SCREW ANY OF THIS UP AND IT WON'T WORK.
 changes: 
-- rscadd: Plastic crates now store the proper materials for deconstruction.
-- rscdel: Deconstructing closets/crates give proper materials back. (Plastic crates will get 10 plastic back.)
+- bugfix: Plastic crates now store the proper materials for deconstruction.
+- bugfix: Deconstructing closets/crates give proper materials back. (Plastic crates will get 10 plastic back.)

--- a/html/changelogs/Hikato.yml
+++ b/html/changelogs/Hikato.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general deleting of nice things)
+#   rscadd (general adding of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.
+author: Hikato
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# There needs to be a space after the - and before the prefix. Don't use tabs anywhere in this file.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# If you're using characters such as # ' : - or the like in your changelog, surround the entire change with quotes as shown in the second example. These quotes don't show up on the changelog once it's merged and prevent errors.
+# SCREW ANY OF THIS UP AND IT WON'T WORK.
+changes: 
+- rscadd: Plastic crates now store the proper materials for deconstruction.
+- rscdel: Deconstructing closets/crates give proper materials back. (Plastic crates will get 10 plastic back.)


### PR DESCRIPTION
Fixes #11041

Adds makeSheets() to materials datum.  Pass it materials and it will spawn the appropriate sheets. (Thanks PJ.)
Used makeSheets() to handle producing the proper materials when deconstructing closets/crates.
Plastic crates use the proper sheet size for plastic.
