### PR TITLE
Vampire glare now stuns silicons 

### DIFF
--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -243,11 +243,13 @@
 		var/list/close_mobs = list()
 		var/list/dist_mobs = list()
 		for(var/mob/living/L in view(1))
-			if(!L.vampire_affected(M)) continue
+			if(!L.vampire_affected(M))
+				continue
 			//if(!M.current.vampire_can_reach(C, 1)) continue
 			if(istype(L)) close_mobs |= L // using |= prevents adding 'large bounded' mobs twice with how the loop works
 		for(var/mob/living/L in view(3))
-			if(!L.vampire_affected(M)) continue
+			if(!L.vampire_affected(M))
+				continue
 			if(istype(L)) dist_mobs |= L
 		dist_mobs -= close_mobs //So they don't get double affected.
 		for(var/mob/living/L in close_mobs)
@@ -256,7 +258,8 @@
 				L.Stun(8)
 				L.Weaken(8)
 				L.stuttering += 20
-				if(!L.blinded) L.blinded = 1
+				if(!L.blinded)
+					L.blinded = 1
 				L.blinded += 5
 			else
 				var/mob/living/silicon/robot/R = L
@@ -267,7 +270,8 @@
 			if(!isrobot(L))
 				L.Stun(distance_value)
 				L.stuttering += 5+distance_value * ((VAMP_CHARISMA in M.vampire.powers) ? 2 : 1) //double stutter time with Charisma
-				if(!L.blinded) L.blinded = 1
+				if(!L.blinded)
+					L.blinded = 1
 				L.blinded += max(1, distance_value)
 				if(distance_value > 1)
 					L.flash_eyes(visual = 1, forced = 1)

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -242,30 +242,46 @@
 				M.current.verbs += /client/proc/vampire_glare
 		var/list/close_mobs = list()
 		var/list/dist_mobs = list()
-		for(var/mob/living/carbon/C in view(1))
-			if(!C.vampire_affected(M)) continue
+		for(var/mob/living/L in view(1))
+			if(!L.vampire_affected(M)) continue
 			//if(!M.current.vampire_can_reach(C, 1)) continue
-			if(istype(C)) close_mobs |= C // using |= prevents adding 'large bounded' mobs twice with how the loop works
-		for(var/mob/living/carbon/C in view(3))
-			if(!C.vampire_affected(M)) continue
-			if(istype(C)) dist_mobs |= C
+			if(istype(L)) close_mobs |= L // using |= prevents adding 'large bounded' mobs twice with how the loop works
+		for(var/mob/living/L in view(3))
+			if(!L.vampire_affected(M)) continue
+			if(istype(L)) dist_mobs |= L
 		dist_mobs -= close_mobs //So they don't get double affected.
-		for(var/mob/living/carbon/C in close_mobs)
-			C.Stun(8)
-			C.Weaken(8)
-			C.stuttering += 20
-			if(!C.blinded) C.blinded = 1
-			C.blinded += 5
-		for(var/mob/living/carbon/C in dist_mobs)
-			var/distance_value = max(0, abs((get_dist(C, M.current)-3)) + 1)
-			C.Stun(distance_value)
-			if(distance_value > 1)
-				C.Weaken(distance_value)
-			C.stuttering += 5+distance_value * ((VAMP_CHARISMA in M.vampire.powers) ? 2 : 1) //double stutter time with Charisma
-			if(!C.blinded) C.blinded = 1
-			C.blinded += max(1, distance_value)
-		to_chat((dist_mobs + close_mobs), "<span class='warning'>You are blinded by [M.current.name]'s glare</span>")
-
+		for(var/mob/living/L in close_mobs)
+			L.flash_eyes(affect_silicon = 1, visual = 1, forced = 1)
+			if(!isrobot(L))
+				L.Stun(8)
+				L.Weaken(8)
+				L.stuttering += 20
+				if(!L.blinded) L.blinded = 1
+				L.blinded += 5
+			else
+				var/mob/living/silicon/robot/R = L
+				R.spark_system.start()
+				R.Weaken(rand(5,10)) // same as getting flashed
+		for(var/mob/living/L in dist_mobs)
+			var/distance_value = max(0, abs((get_dist(L, M.current)-3)) + 1)
+			if(!isrobot(L))
+				L.Stun(distance_value)
+				L.stuttering += 5+distance_value * ((VAMP_CHARISMA in M.vampire.powers) ? 2 : 1) //double stutter time with Charisma
+				if(!L.blinded) L.blinded = 1
+				L.blinded += max(1, distance_value)
+				if(distance_value > 1)
+					L.flash_eyes(visual = 1, forced = 1)
+					L.Weaken(distance_value)
+			else
+				var/mob/living/silicon/robot/R = L
+				R.flash_eyes(affect_silicon = 1, visual = 1)
+				R.spark_system.start()
+				R.Weaken(distance_value + 1)
+		for(var/mob/L in (close_mobs + dist_mobs))
+			if(isrobot(L))
+				to_chat(L, "<span class='warning'>Your circuits have been overloaded by [M.current.name]'s glare!</span>")
+			else
+				to_chat(L, "<span class='warning'>You are blinded by [M.current.name]'s glare!</span>")
 
 /client/proc/vampire_shapeshift()
 	set category = "Vampire"

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -636,6 +636,6 @@
 			src.stomach_contents.Remove(O)
 			O.forceMove(target)
 
-/mob/living/carbon/flash_eyes(intensity = 1, override_blindness_check = 0, affect_silicon = 0, visual = 0)
-	if(eyecheck() < intensity)
+/mob/living/carbon/flash_eyes(intensity = 1, override_blindness_check = 0, affect_silicon = 0, visual = 0, forced = 0)
+	if(eyecheck() < intensity || forced)
 		..()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1638,7 +1638,7 @@
 	var/obj/item/clothing/shoes/S = shoes //Why isn't shoes just typecast in the first place?
 	return ((istype(S) && S.footprint_type) || (species && species.footprint_type) || /obj/effect/decal/cleanable/blood/tracks/footprints) //The shoes' footprint type overrides the mob's, for obvious reasons. Shoes with a falsy footprint_type will let the mob's footprint take over, though.
 
-/mob/living/carbon/human/flash_eyes(intensity = 1, override_blindness_check = 0, affect_silicon = 0, visual = 0)
+/mob/living/carbon/human/flash_eyes(intensity = 1, override_blindness_check = 0, affect_silicon = 0, visual = 0, forced = 0)
 	if(..()) // we've been flashed
 		var/datum/organ/internal/eyes/eyes = internal_organs_by_name["eyes"]
 		var/damage = intensity - eyecheck()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1392,7 +1392,6 @@ default behaviour is:
 	affect_silicon = 0 means that the flash won't affect silicons at all.
 
 */
-/mob/living/proc/flash_eyes(intensity = 1, override_blindness_check = 0, affect_silicon = 0, visual = 0, type = /obj/screen/fullscreen/flash)
 	if(override_blindness_check || !(disabilities & BLIND))
 		// flick("e_flash", flash)
 		overlay_fullscreen("flash", type)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1390,8 +1390,10 @@ default behaviour is:
 	visual determines whether the proc damages eyes (in the living/carbon/human proc). 1 for no damage
 	override_blindness_check = 1 means that it'll display a flash even if the mob is blind
 	affect_silicon = 0 means that the flash won't affect silicons at all.
+	forced = 1 means that it'll override the eyecheck proc in carbon.dm and show the flashing overlay anyway
 
 */
+/mob/living/proc/flash_eyes(intensity = 1, override_blindness_check = 0, affect_silicon = 0, visual = 0, forced = 0, type = /obj/screen/fullscreen/flash)
 	if(override_blindness_check || !(disabilities & BLIND))
 		// flick("e_flash", flash)
 		overlay_fullscreen("flash", type)

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -317,7 +317,7 @@
 	else
 		to_chat(H, "<span class='info'>Your self-preservation instinct prevents you from breaking your teeth on \the [src].</span>")
 
-/mob/living/silicon/flash_eyes(intensity = 1, override_blindness_check = 0, affect_silicon = 0, visual = 0, type = /obj/screen/fullscreen/flash/noise)
+/mob/living/silicon/flash_eyes(intensity = 1, override_blindness_check = 0, affect_silicon = 0, visual = 0, forced = 0, type = /obj/screen/fullscreen/flash/noise)
 	if(affect_silicon)
 		return ..()
 

--- a/html/changelogs/mph55.yml
+++ b/html/changelogs/mph55.yml
@@ -1,0 +1,3 @@
+author: mph55
+delete-after: True
+changes: 

--- a/html/changelogs/mph55.yml
+++ b/html/changelogs/mph55.yml
@@ -1,5 +1,5 @@
 author: mph55
 delete-after: True
 changes: 
-- rscadd: "The vampire glare hability now stuns all living mobs instead of carbons only, that includes the powergaming secborg faggot."
-- rscadd: "The same hability now shows the flashing animation overlay for the affected by it."
+- rscadd: "The vampire glare ability now stuns all living mobs instead of carbons only, that includes the powergaming secborg faggot."
+- rscadd: "The same ability now shows the flashing animation overlay for the affected by it."

--- a/html/changelogs/mph55.yml
+++ b/html/changelogs/mph55.yml
@@ -1,3 +1,5 @@
 author: mph55
 delete-after: True
 changes: 
+- rscadd: "The vampire glare hability now stuns all living mobs instead of carbons only, that includes the powergaming secborg faggot."
+- rscadd: "The same hability now shows the flashing animation overlay for the affected by it."


### PR DESCRIPTION
- rscadd: "The vampire glare ability now stuns all living mobs instead of carbons only, that includes the powergaming secborg faggot."
- rscadd: "The same ability now shows the flashing animation overlay for the affected by it."
