### PR TITLE
Fix switchtool undeploy runtime

### DIFF
--- a/code/game/objects/items/weapons/switchtool.dm
+++ b/code/game/objects/items/weapons/switchtool.dm
@@ -116,7 +116,6 @@
 	playsound(get_turf(src), "sound/weapons/switchblade.ogg", 10, 1)
 	deployed = null
 	overlays.len = 0
-	deployed.cant_drop = 0
 	w_class = initial(w_class)
 
 /obj/item/weapon/switchtool/proc/deploy(var/module)

--- a/code/game/objects/items/weapons/switchtool.dm
+++ b/code/game/objects/items/weapons/switchtool.dm
@@ -114,6 +114,7 @@
 
 /obj/item/weapon/switchtool/proc/undeploy()
 	playsound(get_turf(src), "sound/weapons/switchblade.ogg", 10, 1)
+	deployed.cant_drop = 0
 	deployed = null
 	overlays.len = 0
 	w_class = initial(w_class)


### PR DESCRIPTION
[05:29:15] Runtime in switchtool.dm,119: Cannot modify null.cant_drop.
  proc name: undeploy (/obj/item/weapon/switchtool/proc/undeploy)
  usr: Igor Slovenich (h0l3m4k3r) (/mob/living/carbon/human)
  usr.loc: The floor (295, 200, 1) (/turf/simulated/floor)
  src: the surgeon\'s switchtool (/obj/item/weapon/switchtool/surgery)
  src.loc: Igor Slovenich (/mob/living/carbon/human)
  call stack:
  the surgeon\'s switchtool (/obj/item/weapon/switchtool/surgery): undeploy()
  the surgeon\'s switchtool (/obj/item/weapon/switchtool/surgery): attack self(Igor Slovenich (/mob/living/carbon/human))
  Igor Slovenich (/mob/living/carbon/human): Activate Held Object()
