### PR TITLE
Fix a switchtool bug

### DIFF
--- a/code/game/objects/items/weapons/switchtool.dm
+++ b/code/game/objects/items/weapons/switchtool.dm
@@ -102,6 +102,7 @@
 					return 1
 
 /obj/item/weapon/switchtool/proc/remove_module(mob/user)
+	deployed.cant_drop = 0
 	deployed.loc = get_turf(user)
 	for(var/module in stored_modules)
 		if(stored_modules[module] == deployed)

--- a/html/changelogs/mph55.yml
+++ b/html/changelogs/mph55.yml
@@ -1,0 +1,4 @@
+author: mph55
+delete-after: True
+changes: 
+- bugfix: "Fixed an unreported bug which items removed from the switchtool were stuck on your hands after being picked up."


### PR DESCRIPTION
- bugfix: "Fixed an unreported bug which items removed from the switchtool were stuck on your hands after being picked up."
