### PR TITLE
Fix spacepod weapons

### DIFF
--- a/code/WorkInProgress/pomf/spacepods/equipment.dm
+++ b/code/WorkInProgress/pomf/spacepods/equipment.dm
@@ -46,6 +46,7 @@
 		spawn(0)
 			playsound(my_atom, fire_sound, 50, 1)
 			projone.dumbfire(dir)
+		spawn(0)
 			projtwo.dumbfire(dir)
 		sleep(1)
 	my_atom.next_firetime = world.time + fire_delay


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.
-->


Spacepods would fire two shots from both sides facing the direction you are firing, however the second projectile would wait for the first projectile to finish before firing. So the second projectile would fire from the original location a second later, thus if you had moved forward in the second it took for the first projectile to finish firing the second projectile would collide with your spacepod and damage you.