### PR TITLE
Makes a group jaunt spell

### DIFF
--- a/code/_hooks/events.dm
+++ b/code/_hooks/events.dm
@@ -21,6 +21,10 @@
 	..()
 	holder = owner
 
+/event/Destroy()
+	holder = null
+	handlers = null
+
 /event/proc/Add(var/objectRef,var/procName)
 	var/key="\ref[objectRef]:[procName]"
 	handlers[key]=list(EVENT_OBJECT_INDEX=objectRef,EVENT_PROC_INDEX=procName)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -61,11 +61,12 @@ var/global/obj/screen/fuckstat/FUCK = new
 	hud_used = null
 	for(var/atom/movable/leftovers in src)
 		qdel(leftovers)
-	if(on_uattack)
-		on_uattack.holder = null
-		on_uattack = null
 	qdel(on_logout)
 	on_logout = null
+	qdel(on_moved)
+	on_moved = null
+	qdel(on_uattack)
+	on_uattack = null
 
 	..()
 

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -489,6 +489,7 @@
 				mob.dir = direct
 			else
 				to_chat(mob, "<span class='warning'>Some strange aura is blocking the way!</span>")
+			INVOKE_EVENT(mob.on_moved,list("dir"=direct))
 			mob.delayNextMove(2)
 			return 1
 	// Crossed is always a bit iffy

--- a/code/modules/spells/targeted/ethereal_jaunt.dm
+++ b/code/modules/spells/targeted/ethereal_jaunt.dm
@@ -5,8 +5,8 @@
 	school = "transmutation"
 	charge_max = 300
 	spell_flags = Z2NOCAST | NEEDSCLOTHES | INCLUDEUSER
-	invocation = "none"
-	invocation_type = SpI_NONE
+	invocation = "Rah'dee K'Alari"
+	invocation_type = SpI_SHOUT
 	range = -1
 	max_targets = 1
 	cooldown_min = 100 //50 deciseconds reduction per rank
@@ -18,11 +18,25 @@
 	var/exitanim = "reappear"
 	var/mist = 1
 
-/spell/targeted/ethereal_jaunt/cast(list/targets) //magnets, so mostly hardcoded
+/spell/targeted/ethereal_jaunt/cast(list/targets)
 	if(targets.len > 1)
+		var/list/jaunts = list()
+		for(var/mob/living/target in targets)
+			var/image/I = image(icon = target.icon, loc = target, icon_state = target.icon_state)
+			I.appearance = target.appearance
+			I.alpha = 125
+			jaunts += I
 		for(var/mob/living/target in targets)
 			spawn(0)
-				ethereal_jaunt(target, duration, enteranim, exitanim, mist)
+				if(!target.incorporeal_move == INCORPOREAL_ETHEREAL) //To avoid the potential for infinite jaunt
+					if(target.client)
+						target.client.images += jaunts
+					ethereal_jaunt(target, duration, enteranim, exitanim, mist)
+					if(target.client)
+						target.client.images -= jaunts
+		sleep(duration + 60 SECONDS)
+		for(var/image/I in jaunts) //Garbage collection of images
+			I.loc = null
 	else
 		ethereal_jaunt(targets[1], duration, enteranim, exitanim, mist)
 
@@ -75,6 +89,18 @@
 	target.incorporeal_move = previncorp
 	target.alphas -= "etheral_jaunt"
 	target.handle_alpha()
+
+/spell/targeted/ethereal_jaunt/jauntgroup
+	name = "Group Jaunt"
+	desc = "This spell allows all people within range to be jaunted along with the user"
+	spell_flags = Z2NOCAST | INCLUDEUSER //Adminbus spell, so we'll exclude robe requirement for ease of use
+
+	invocation = "Tc'ln Oc'lip"
+	max_targets = 0
+	range = 3
+
+	charge_max = 600 //Double cooldown, makes it less spammable
+	duration = 100 //Double jaunt time, makes it easier to cooperate
 
 /spell/targeted/ethereal_jaunt/shift
 	name = "Phase Shift"

--- a/code/modules/spells/targeted/ethereal_jaunt.dm
+++ b/code/modules/spells/targeted/ethereal_jaunt.dm
@@ -28,15 +28,12 @@
 			jaunts += I
 		for(var/mob/living/target in targets)
 			spawn(0)
-				if(!target.incorporeal_move == INCORPOREAL_ETHEREAL) //To avoid the potential for infinite jaunt
+				if(target.incorporeal_move != INCORPOREAL_ETHEREAL) //To avoid the potential for infinite jaunt
 					if(target.client)
 						target.client.images += jaunts
 					ethereal_jaunt(target, duration, enteranim, exitanim, mist)
 					if(target.client)
 						target.client.images -= jaunts
-		sleep(duration + 60 SECONDS)
-		for(var/image/I in jaunts) //Garbage collection of images
-			I.loc = null
 	else
 		ethereal_jaunt(targets[1], duration, enteranim, exitanim, mist)
 
@@ -93,6 +90,8 @@
 /spell/targeted/ethereal_jaunt/jauntgroup
 	name = "Group Jaunt"
 	desc = "This spell allows all people within range to be jaunted along with the user"
+	hud_state = "group_jaunt"
+
 	spell_flags = Z2NOCAST | INCLUDEUSER //Adminbus spell, so we'll exclude robe requirement for ease of use
 
 	invocation = "Tc'ln Oc'lip"

--- a/code/modules/spells/targeted/ethereal_jaunt.dm
+++ b/code/modules/spells/targeted/ethereal_jaunt.dm
@@ -18,29 +18,21 @@
 	var/exitanim = "reappear"
 	var/mist = 1
 
+/image/jaunter
+
+/image/jaunter/proc/update_dir(params)
+	dir = params["dir"]
+
 /spell/targeted/ethereal_jaunt/cast(list/targets)
 	if(targets.len > 1)
-		var/list/jaunts = list()
-		for(var/mob/living/target in targets)
-			var/image/I = image(icon = target.icon, loc = target, icon_state = target.icon_state)
-			I.appearance = target.appearance
-			I.alpha = 125
-			jaunts += I
-		for(var/mob/living/target in targets)
-			spawn(0)
-				if(target.incorporeal_move != INCORPOREAL_ETHEREAL) //To avoid the potential for infinite jaunt
-					if(target.client)
-						target.client.images += jaunts
-					ethereal_jaunt(target, duration, enteranim, exitanim, mist)
-					if(target.client)
-						target.client.images -= jaunts
+		mass_jaunt(targets, duration, enteranim, exitanim, mist)
 	else
 		ethereal_jaunt(targets[1], duration, enteranim, exitanim, mist)
 
 /proc/ethereal_jaunt(var/mob/living/target, duration, enteranim = "liquify", exitanim = "reappear", mist = 1)
 	var/mobloc = get_turf(target)
 	var/previncorp = target.incorporeal_move //This shouldn't ever matter under usual circumstances
-	if(target.incorporeal_move == INCORPOREAL_ETHEREAL) //they're already jaunting, we have another fix for this but this is sane)
+	if(target.incorporeal_move == INCORPOREAL_ETHEREAL) //they're already jaunting, we have another fix for this but this is sane
 		return
 	target.unlock_from()
 	//Begin jaunting with an animation
@@ -50,6 +42,7 @@
 		var/datum/effect/effect/system/steam_spread/steam = new /datum/effect/effect/system/steam_spread()
 		steam.set_up(10, 0, mobloc)
 		steam.start()
+
 	//Turn on jaunt incorporeal movement, make him invincible and invisible
 	target.incorporeal_move = INCORPOREAL_ETHEREAL
 	target.invisibility = INVISIBILITY_MAXIMUM
@@ -63,7 +56,9 @@
 		SM.silence_spells(duration+25)
 	target.delayNextAttack(duration+25)
 	target.click_delayer.setDelay(duration+25)
+
 	sleep(duration)
+
 	//Begin unjaunting
 	mobloc = get_turf(target)
 	if(mist)
@@ -75,6 +70,7 @@
 	sleep(20)
 	anim(location = mobloc, target = target, a_icon = 'icons/mob/mob.dmi', flick_anim = exitanim, direction = target.dir, name = "water")
 	sleep(5)
+
 	//Forcemove him onto the tile and make him visible and vulnerable
 	target.forceMove(mobloc)
 	target.invisibility = 0
@@ -86,6 +82,29 @@
 	target.incorporeal_move = previncorp
 	target.alphas -= "etheral_jaunt"
 	target.handle_alpha()
+
+/proc/mass_jaunt(targets, duration, enteranim, exitanim, mist)
+	var/list/jaunts = list()
+	for(var/mob/living/target in targets)
+		var/image/jaunter/I = new(icon = target.icon, loc = target, icon_state = target.icon_state)
+		I.appearance = target.appearance
+		I.alpha = 125
+		jaunts[target] = I
+	for(var/mob/living/target in targets)
+		spawn(0)
+			if(target.incorporeal_move != INCORPOREAL_ETHEREAL) //To avoid the potential for infinite jaunt
+				if(target.client)
+					for(var/A in jaunts)
+						target.client.images += jaunts[A]
+				var/on_moved_holder = target.on_moved
+				target.on_moved = new("owner"=src)
+				target.on_moved.Add(jaunts[target],"update_dir")
+				ethereal_jaunt(target, duration, enteranim, exitanim, mist)
+				qdel(target.on_moved)
+				target.on_moved = on_moved_holder
+				if(target.client)
+					for(var/A in jaunts)
+						target.client.images -= jaunts[A]
 
 /spell/targeted/ethereal_jaunt/jauntgroup
 	name = "Group Jaunt"


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.
-->


1. Adds invocation to jaunt and group jaunt
2. Creates an adminbus group jaunt spell, gives everyone jaunting for double the time of regular jaunt with a double cooldown as well in a 3 tile range
3. Group jaunting makes an image so all jaunters can see each other
4. Group jaunt adminbus only and maybe will be placed on a secret map or away mission or vault some day so it requires no robes