### PR TITLE
Command alerts datums, new malf AI module

### DIFF
--- a/code/datums/helper_datums/command_alerts.dm
+++ b/code/datums/helper_datums/command_alerts.dm
@@ -1,0 +1,457 @@
+/datum/command_alert
+	var/name //Descriptive name - it's not shown to anybody, so feel free to make it OOC
+
+	var/alert_title = "Central Command"
+	var/message
+
+	var/force_report = 0
+	var/alert = 'sound/AI/commandreport.ogg'//sound
+	var/noalert = 0
+
+/datum/command_alert/proc/announce()
+	command_alert(message, alert_title, force_report, alert, noalert)
+
+//////BIOHAZARD
+
+/datum/command_alert/biohazard_alert
+	name = "Biohazard Alert"
+	alert_title = "Biohazard Alert"
+	noalert = 1
+	force_report = 1
+
+	var/level = 1
+
+/datum/command_alert/biohazard_alert/announce()
+	level = rand(4,7)
+	message = "Confirmed outbreak of level [level] biohazard aboard [station_name()]. All personnel must contain the outbreak."
+
+	..()
+
+	var/list/vox_sentence=list(
+	'sound/AI/outbreak_before.ogg',
+	outbreak_level_words[level],
+	'sound/AI/outbreak_after.ogg',
+	)
+
+	for(var/word in vox_sentence)
+		play_vox_sound(word,STATION_Z,null)
+
+///////BIOHAZARD UPDATED
+
+/datum/command_alert/biohazard_station_lockdown
+	name = "Biohazard Level Updated - Station Locked Down"
+	alert_title = "Directive 7-10 Initiated"
+	alert = 'sound/AI/blob_confirmed.ogg'
+	force_report = 1
+
+/datum/command_alert/biohazard_station_lockdown/announce()
+	message = "Biohazard outbreak alert status upgraded to level 9.  [station_name()] is now locked down, under Directive 7-10, until further notice."
+
+	..()
+
+/datum/command_alert/biohazard_station_nuke
+	name = "Biohazard Level Updated - Nuclear Force Authorized"
+	alert_title = "Final Measure"
+	noalert = 1
+
+/datum/command_alert/biohazard_station_nuke/announce()
+	message = "Biohazard outbreak containment status reaching critical mass, total quarantine failure is now possibile. As such, Directive 7-12 has now been authorized for [station_name()]."
+
+	..()
+
+////////BLOB (mini)
+
+/datum/command_alert/biohazard_level_5
+	name = "Biohazard Alert (level 5)"
+	alert_title = "Biohazard Alert"
+	alert = 'sound/AI/outbreak5.ogg'
+	force_report = 1
+
+/datum/command_alert/biohazard_level_5/announce()
+	message = "Confirmed outbreak of level 5 biohazard aboard [station_name()]. All personnel must contain the outbreak."
+
+	..()
+
+/////////ERT
+
+/datum/command_alert/ert_fail
+	name = "ERT - Unable To Send"
+
+/datum/command_alert/ert_fail/announce()
+	message = "It would appear that an emergency response team was requested for [station_name()]. Unfortunately, we were unable to send one at this time."
+
+	..()
+
+/datum/command_alert/ert_success
+	name = "ERT - Team Sent"
+
+/datum/command_alert/ert_success/announce()
+	message = "It would appear that an emergency response team was requested for [station_name()]. We will prepare and send one as soon as possible."
+
+	..()
+
+////////AYY
+
+/datum/command_alert/xenomorphs
+	name = "Unidentified Lifesigns Alert"
+	alert_title = "Lifesign Alert"
+	alert = 'sound/AI/aliens.ogg'
+
+/datum/command_alert/xenomorphs/announce()
+	message = "Unidentified lifesigns detected coming aboard [station_name()]. Secure any exterior access, including ducting and ventilation."
+
+	..()
+
+///////RADIATION
+
+/datum/command_alert/radiation_storm
+	name = "Radiation Storm - Warning"
+	alert_title = "Anomaly Alert"
+	alert = 'sound/AI/radiation.ogg'
+	message = "High levels of radiation detected near the station, ETA in 30 seconds. Please evacuate into one of the shielded maintenance tunnels."
+
+/datum/command_alert/radiation_storm/start
+	name = "Radiation Storm - Start"
+	alert = null
+	message = "The station has entered the radiation belt. Please remain in a sheltered area until we have passed the radiation belt."
+
+/datum/command_alert/radiation_storm/end
+	name = "Radiation Storm - End"
+	alert = null
+	message = "The station has passed the radiation belt. Please report to medbay if you experience any unusual symptoms. Maintenance will lose all access again shortly."
+
+/datum/command_alert/radiation
+	name = "High Levels Of Radiation"
+	alert_title = "Anomaly Alert"
+	alert = 'sound/AI/radiation.ogg'
+
+	message = "High levels of radiation detected near the station. Please report to the Med-bay if you feel strange."
+
+
+///////GRAYTIDE VIRUS
+
+/datum/command_alert/graytide
+	name = "Gr3y.T1d3 virus"
+	alert_title = "Security Alert"
+
+/datum/command_alert/graytide/announce()
+	message = "[pick("Gr3y.T1d3 virus","Malignant trojan")] detected in [station_name()] imprisonment subroutines. Recommend station AI involvement."
+
+	..()
+
+//////CARP
+
+/datum/command_alert/carp
+	name = "Carp Migration"
+	alert_title = "Lifesign Alert"
+
+/datum/command_alert/carp/announce()
+	message = "Unknown biological entities have been detected near [station_name()], please stand-by."
+
+	..()
+
+////////ELECTRICAL STORM
+
+/datum/command_alert/electrical_storm
+	name = "Electrical Storm"
+	alert_title = "Electrical Storm Alert"
+	message = "An Electrical storm has been detected in your area, please repair potential electronic overloads."
+
+///////SUMMARY DOWNLOADED AND PRINTED AT COMMS
+
+/datum/command_alert/enemy_comms_interception
+	name = "Enemy Communications Intercepted"
+	alert_title = "Enemy communications intercept"
+	message = "Summary downloaded and printed out at all communications consoles."
+
+//////////SUPERMATTER CASCADE
+
+/datum/command_alert/supermatter_cascade
+	name = "Supermatter Cascade Start"
+	alert_title = "SUPERMATTER CASCADE DETECTED"
+
+/datum/command_alert/supermatter_cascade/announce()
+	message = {"
+There's been a galaxy-wide electromagnetic pulse.  All of our systems are heavily damaged and many personnel are dead or dying. We are seeing increasing indications of the universe itself beginning to unravel.
+
+[station_name()], you are the only facility nearby a bluespace rift, which is near your research outpost.  You are hereby directed to enter the rift using all means necessary, quite possibly as the last humans alive.
+
+You have five minutes before the universe collapses. Good l\[\[###!!!-
+
+AUTOMATED ALERT: Link to [command_name()] lost.
+
+The access requirements on the Asteroid Shuttles' consoles have now been revoked.
+"}
+
+	..()
+
+/////////////POWER OUTAGE
+
+/datum/command_alert/power_outage
+	name = "Power Outage - Start"
+	alert_title = "Critical Power Failure"
+	alert ='sound/AI/poweroff.ogg'
+
+/datum/command_alert/power_outage/announce()
+	message = "Abnormal activity detected in [station_name()]'s powernet. As a precautionary measure, the station's power will be shut off for an indeterminate duration."
+
+	..()
+
+/datum/command_alert/power_restored
+	name = "Power Outage - End"
+	alert_title = "Power Systems Nominal"
+	alert = 'sound/AI/poweron.ogg'
+
+/datum/command_alert/power_restored/announce()
+	message = "Power has been restored to [station_name()]. We apologize for the inconvenience."
+
+	..()
+
+/datum/command_alert/smes_charged
+	name = "SMES Recharged"
+	alert_title = "Power Systems Nominal"
+	alert = 'sound/AI/poweron.ogg'
+
+/datum/command_alert/smes_charged/announce()
+	message = "All SMESs on [station_name()] have been recharged. We apologize for the inconvenience."
+
+	..()
+
+////////////////WORMHOLES
+
+/datum/command_alert/wormholes
+	name = "Space-Time Anomalities Detected"
+	alert_title = "Anomaly Alert"
+	alert = 'sound/AI/spanomalies.ogg'
+	message = "Space-time anomalies detected on the station. There is no additional data."
+
+//////////////MALF ANNOUNCEMENT
+
+/datum/command_alert/malf_announce
+	name = "AI Malfunctioning Warning"
+	alert_title = "Anomaly Alert"
+	alert = 'sound/AI/aimalf.ogg'
+	message = "Hostile runtimes detected in all station systems, please deactivate your AI to prevent possible damage to its morality core."
+
+/////////////METEOR STORM
+
+/datum/command_alert/meteor_round
+	name = "Major Meteor Storm Warning"
+	alert_title = "Space Weather Automated Announcements"
+	alert = 'sound/AI/meteorround.ogg'
+
+	var/meteor_delay = 2000
+	var/supply_delay = 100
+
+/datum/command_alert/meteor_round/announce()
+	meteor_delay = rand(4500, 6000)
+	if(prob(70)) //slightly off-scale
+		message = "A meteor storm has been detected in proximity of [station_name()] and is expected to strike within [round((rand(meteor_delay - 600, meteor_delay + 600))/600)] minutes. A backup emergency shuttle is being dispatched and emergency gear should be teleported into your station's Bar area in [supply_delay/10] seconds."
+	else
+		message = "A meteor storm has been detected in proximity of [station_name()] and is expected to strike within [round((rand(meteor_delay - 1800, meteor_delay + 1800))/600)] minutes. A backup emergency shuttle is being dispatched and emergency gear should be teleported into your station's Bar area in [supply_delay/10] seconds."
+
+	..()
+
+////small meteor storm
+
+/datum/command_alert/meteor_wave
+	name = "Meteor Storm Warning"
+	alert_title = "Meteor Alert"
+	alert = 'sound/AI/meteors.ogg'
+	message = "A meteor storm has been detected on collision course with the station. Seek shelter within the core of the station immediately."
+
+
+/////meteor storm end
+/datum/command_alert/meteor_wave_end
+	name = "Meteor Storm Cleared"
+	alert_title = "Meteor Alert"
+	message = "The station has cleared the meteor storm."
+
+/datum/command_alert/meteor_storm
+	name = "Small-Intensity Meteor Storm Warning"
+	alert_title = "Meteor Alert"
+	message = "The station is about to be hit by a small-intensity meteor storm. Seek shelter within the core of the station immediately."
+
+//////blob storm
+/datum/command_alert/blob_storm
+	name = "Meteor Blob Cluster - No Overminds"
+	alert_title = "Blob Cluster"
+	message = "The station is about to pass through a Blob cluster. No overmind brainwaves detected."
+
+/datum/command_alert/blob_storm/end
+	name = "Meteor Blob Cluster Ended (No Overminds)"
+	message = "The station has cleared the Blob cluster. Eradicate the blob from hit areas."
+
+/datum/command_alert/blob_storm/overminds
+	name = "Meteor Blob Cluster - Overminds!"
+	alert_title = "Blob Conglomerate"
+	message = "The station is about to pass through a Blob conglomerate. Overmind brainwaves possibly detected."
+
+/datum/command_alert/blob_storm/overminds/end
+	name = "Meteor Blob Cluster Ended (Overminds!)"
+	message = "The station has cleared the Blob conglomerate. Investigate the hit areas at once and clear the blob. Beware for possible Overmind presence."
+
+/////////////GRAVITY
+
+/datum/command_alert/gravity_enabled
+	name = "Gravity - Enabled"
+	message = "Gravity generators are again functioning within normal parameters. Sorry for any inconvenience."
+
+/datum/command_alert/gravity_disabled
+	name = "Gravity - Disabled"
+	message = "Feedback surge detected in mass-distributions systems. Artifical gravity has been disabled whilst the system reinitializes. Further failures may result in a gravitational collapse and formation of blackholes. Have a nice day."
+
+//////////////////////////////ION STORM
+
+/datum/command_alert/ion_storm
+	name = "Ion Storm - AI affected"
+	alert_title = "Anomaly Alert"
+	alert = 'sound/AI/ionstorm.ogg'
+	message = "Ion storm detected near the station. Please check all AI-controlled equipment for errors."
+
+/datum/command_alert/ion_storm_large
+	name = "Ion Storm - All Affected"
+	alert_title = "Anomaly Alert"
+	message = "It has come to our attention that the station passed through an ion storm.  Please monitor all electronic equipment for malfunctions."
+
+///////////BLUESPACE ANOMALY
+
+/datum/command_alert/bluespace_anomaly
+	name = "Bluespace Anomaly"
+	alert_title = "Anomaly Alert"
+
+/datum/command_alert/bluespace_anomaly/New(impact_area_name)
+	message = "Bluespace anomaly detected in the vicinity of [station_name()]. [impact_area_name || "An unknown area"] has been affected."
+	..()
+
+//////////POWER DISABLED
+
+/datum/command_alert/power_disabled
+	name = "Station Power - Disabled"
+	alert_title = "Automated Grid Check"
+	alert = 'sound/AI/poweroff.ogg'
+
+/datum/command_alert/power_disabled/announce()
+	message = "Abnormal activity detected in [station_name()]'s powernet. As a precautionary measure, the station's power will be shut off for an indeterminate duration."
+	..()
+
+/datum/command_alert/power_restored
+	name = "Station Power - Restored"
+	alert_title = "Power Nominal"
+	alert = 'sound/AI/poweron.ogg'
+
+/datum/command_alert/power_restored/announce()
+	message = "Power has been restored to [station_name()]. We apologize for the inconvenience."
+	..()
+
+//////////////CENTCOM LINK
+
+/datum/command_alert/command_link_lost
+	name = "Centcom Link Lost"
+	alert_title = "Automated Announcement"
+	alert = 'sound/AI/loss.ogg'
+	message = "This is an automated announcement. The link with central command has been lost. Repeat: The link with central command has been lost. Attempting to re-establish communications in T-10."
+
+/datum/command_alert/command_link_restored
+	name = "Centcom Link Restored"
+	alert_title = "Link Established"
+
+/datum/command_alert/command_link_restored/announce()
+	message = "A link to Central Command has been established on [station_name()]."
+	..()
+
+/////////HOSTILE CREATURES
+
+/datum/command_alert/hostile_creatures
+	name = "Hostile Creatures Alert"
+	alert_title = "WARNING: Hostile Creature(s)"
+
+/datum/command_alert/hostile_creatures/New(localestring = "an unknown location", monsterstring = "malicious intent")
+	..()
+
+	message = "One or more hostile creatures have entered the station in [localestring]. External security cameras indicate that the creature has [monsterstring]."
+
+/datum/command_alert/vermin
+	name = "Vermin Alert"
+	alert_title = "Vermin infestation"
+
+/datum/command_alert/vermin/New(vermstring = "various vermin", locstring = "the station's maintenance tunnels")
+	..()
+
+	message = "Bioscans indicate that [vermstring] have been breeding in [locstring]. Clear them out, before this starts to affect productivity."
+
+/datum/command_alert/mob_swarm
+	name = "Mob Swarm"
+
+/datum/command_alert/mob_swarm/New(mob_name = "animals")
+	..()
+
+	message = "Due to timespace anomalies of unknown origin, [station_name] is now host to several [mob_name]\s more than there were a moment ago."
+
+////////MISC STUFF
+
+/datum/command_alert/eagles
+	name = "Airlock Access Removed"
+	message = "Centcomm airlock control override activated. Please take this time to get acquainted with your coworkers."
+
+/datum/command_alert/bluespace_artillery
+	name = "Bluespace Artillery Strike Detected"
+	message = "Bluespace artillery fire detected. Brace for impact."
+
+/datum/command_alert/vending_machines
+	name = "Rampant Brand Intelligence Detected"
+	alert_title = "Machine Learning Alert"
+
+/datum/command_alert/vending_machines/announce()
+	message = "Rampant brand intelligence has been detected aboard [station_name()], please stand-by."
+
+/datum/command_alert/comms_blackout
+	name = "Ionospheric Anomalies - Telecommunications Failure"
+	message = "Ionospheric anomalies detected. Temporary telecommunication failure imminent. Please contact you-BZZT"
+
+/datum/command_alert/comms_blackout/announce()
+	message = pick(	"Ionospheric anomalies detected. Temporary telecommunication failure imminent. Please contact you*%fj00)`5vc-BZZT", \
+						"Ionospheric anomalies detected. Temporary telecommunication failu*3mga;b4;'1v¬-BZZZT", \
+						"Ionospheric anomalies detected. Temporary telec#MCi46:5.;@63-BZZZZT", \
+						"Ionospheric anomalies dete'fZ\\kg5_0-BZZZZZT", \
+						"Ionospheri:%£ MCayj^j<.3-BZZZZZZT", \
+						"#4nd%;f4y6,>£%-BZZZZZZZT")
+	..()
+
+/datum/command_alert/electrical_storm
+	name = "Electrical Storm Alert"
+	alert_title = "Electrical Storm Alert"
+	message = "An electrical storm has been detected in your area, please repair potential electronic overloads."
+
+/datum/command_alert/immovable_rod
+	name = "Immovable Rod (\"What The Fuck Was That?\")"
+	alert_title = "General Alert"
+	message = "What the fuck was that?!"
+
+/datum/command_alert/rogue_drone
+	name = "Rogue Drones - Alert"
+	alert_title = "Rogue Drone Alert"
+
+/datum/command_alert/rogue_drone/New()
+	..()
+
+	if(prob(33))
+		message = "A combat drone wing operating out of the NMV Icarus has failed to return from a sweep of this sector, if any are sighted approach with caution."
+	else if(prob(50))
+		message = "Contact has been lost with a combat drone wing operating out of the NMV Icarus. If any are sighted in the area, approach with caution."
+	else
+		message = "Unidentified hackers have targeted a combat drone wing deployed from the NMV Icarus. If any are sighted in the area, approach with caution."
+
+/datum/command_alert/drones_recovered
+	name = "Rogue Drones - Recovered Successfully"
+	alert_title = "Rogue Drone Alert"
+	message = "Icarus drone control reports the malfunctioning wing has been recovered safely."
+
+/datum/command_alert/drones_recovered/failure
+	name = "Rogue Drones - Failed To Recover"
+	message = "Icarus drone control registers disappointment at the loss of the drones, but the survivors have been recovered."
+
+/datum/command_alert/wall_fungi
+	name = "Wall Fungi"
+	alert_title = "Biohazard Alert"
+	message = "Harmful fungi detected on station. Station structures may be contaminated."

--- a/code/datums/helper_datums/command_alerts.dm
+++ b/code/datums/helper_datums/command_alerts.dm
@@ -411,11 +411,11 @@ The access requirements on the Asteroid Shuttles' consoles have now been revoked
 
 /datum/command_alert/comms_blackout/announce()
 	message = pick(	"Ionospheric anomalies detected. Temporary telecommunication failure imminent. Please contact you*%fj00)`5vc-BZZT", \
-						"Ionospheric anomalies detected. Temporary telecommunication failu*3mga;b4;'1v¬-BZZZT", \
+						"Ionospheric anomalies detected. Temporary telecommunication failu*3mga;b4;'1vÂ¬-BZZZT", \
 						"Ionospheric anomalies detected. Temporary telec#MCi46:5.;@63-BZZZZT", \
 						"Ionospheric anomalies dete'fZ\\kg5_0-BZZZZZT", \
-						"Ionospheri:%£ MCayj^j<.3-BZZZZZZT", \
-						"#4nd%;f4y6,>£%-BZZZZZZZT")
+						"Ionospheri:%Â£ MCayj^j<.3-BZZZZZZT", \
+						"#4nd%;f4y6,>Â£%-BZZZZZZZT")
 	..()
 
 /datum/command_alert/electrical_storm
@@ -432,15 +432,15 @@ The access requirements on the Asteroid Shuttles' consoles have now been revoked
 	name = "Rogue Drones - Alert"
 	alert_title = "Rogue Drone Alert"
 
-/datum/command_alert/rogue_drone/New()
-	..()
-
+/datum/command_alert/rogue_drone/announce()
 	if(prob(33))
 		message = "A combat drone wing operating out of the NMV Icarus has failed to return from a sweep of this sector, if any are sighted approach with caution."
 	else if(prob(50))
 		message = "Contact has been lost with a combat drone wing operating out of the NMV Icarus. If any are sighted in the area, approach with caution."
 	else
 		message = "Unidentified hackers have targeted a combat drone wing deployed from the NMV Icarus. If any are sighted in the area, approach with caution."
+	
+	..()
 
 /datum/command_alert/drones_recovered
 	name = "Rogue Drones - Recovered Successfully"

--- a/code/defines/procs/biohazard_alert.dm
+++ b/code/defines/procs/biohazard_alert.dm
@@ -8,17 +8,7 @@ var/global/list/outbreak_level_words=list(
 	/* 7 */ 'sound/vox_fem/seven.ogg',
 )
 /proc/biohazard_alert(var/level=0)
-	if(!level)
-		level = rand(4,7)
-	command_alert("Confirmed outbreak of level [level] biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert",1,noalert = 1)
-
-	var/list/vox_sentence=list(
-		'sound/AI/outbreak_before.ogg',
-		outbreak_level_words[level],
-		'sound/AI/outbreak_after.ogg',
-	)
-	for(var/word in vox_sentence)
-		play_vox_sound(word,STATION_Z,null)
+	command_alert(/datum/command_alert/biohazard_alert)
 
 /*
 #warning TELL N3X15 TO COMMENT THIS SHIT OUT

--- a/code/defines/procs/command_alert.dm
+++ b/code/defines/procs/command_alert.dm
@@ -1,4 +1,13 @@
+//First argument can be a /datum/command_alert object or path. See "code/datums/helper_datums/command_alerts.dm" for more info
+
 /proc/command_alert(var/text, var/title = "",var/force_report = 0,var/alert,var/noalert = 0)
+	if(ispath(text, /datum/command_alert))
+		var/datum/command_alert/CA = new text
+		return CA.announce()
+	else if(istype(text, /datum/command_alert))
+		var/datum/command_alert/CA = text
+		return CA.announce()
+
 	if(!alert && !noalert)
 		alert = 'sound/AI/commandreport.ogg'
 	var/gibberish = map.linked_to_centcomm ? 0 : 1

--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -172,7 +172,7 @@ You must kill it all while minimizing the damage to the station."})
 			return
 
 		if (1)
-			command_alert("Biohazard outbreak alert status upgraded to level 9.  [station_name()] is now locked down, under Directive 7-10, until further notice.", "Directive 7-10 Initiated",1,alert='sound/AI/blob_confirmed.ogg')
+			command_alert(/datum/command_alert/biohazard_station_lockdown)
 			for(var/mob/M in player_list)
 				var/T = M.loc
 				if((istype(T, /turf/space)) || ((istype(T, /turf)) && (M.z!=1)))
@@ -183,7 +183,7 @@ You must kill it all while minimizing the damage to the station."})
 			research_shuttle.lockdown = "Under directive 7-10, [station_name()] is quarantined until further notice." //LOCKDOWN THESE SHUTTLES
 			mining_shuttle.lockdown = "Under directive 7-10, [station_name()] is quarantined until further notice."
 		if (2)
-			command_alert("Biohazard outbreak containment status reaching critical mass, total quarantine failure is now possibile. As such, Directive 7-12 has now been authorized for [station_name()].", "Final Measure",1)
+			command_alert(/datum/command_alert/biohazard_station_nuke)
 			for(var/mob/camera/blob/B in player_list)
 				to_chat(B, "<span class='blob'>The beings intend to eliminate you with a final suicidal attack, you must stop them quickly or consume the station before this occurs!</span>")
 			if(!mixed) send_intercept(2)

--- a/code/game/gamemodes/endgame/supermatter_cascade/universe.dm
+++ b/code/game/gamemodes/endgame/supermatter_cascade/universe.dm
@@ -75,18 +75,7 @@
 		message_admins("<span class='warning'><font size=7>SOMEBODY DIDNT PUT ENDGAME EXITS FOR THIS FUCKING MAP: [map.nameLong]</span></font>")
 	else new /obj/machinery/singularity/narsie/large/exit(pick(endgame_exits))
 	spawn(rand(30,60) SECONDS)
-		var/txt = {"
-There's been a galaxy-wide electromagnetic pulse.  All of our systems are heavily damaged and many personnel are dead or dying. We are seeing increasing indications of the universe itself beginning to unravel.
-
-[station_name()], you are the only facility nearby a bluespace rift, which is near your research outpost.  You are hereby directed to enter the rift using all means necessary, quite possibly as the last humans alive.
-
-You have five minutes before the universe collapses. Good l\[\[###!!!-
-
-AUTOMATED ALERT: Link to [command_name()] lost.
-
-The access requirements on the Asteroid Shuttles' consoles have now been revoked.
-"}
-		command_alert(txt,"SUPERMATTER CASCADE DETECTED")
+		command_alert(/datum/command_alert/supermatter_cascade)
 
 		for(var/obj/machinery/computer/shuttle_control/C in machines)
 			if(istype(C.shuttle,/datum/shuttle/mining) || istype(C.shuttle,/datum/shuttle/research))

--- a/code/game/gamemodes/events.dm
+++ b/code/game/gamemodes/events.dm
@@ -205,7 +205,7 @@
 		spawncount--
 
 	spawn(rand(5000, 6000)) //Delayed announcements to keep the crew on their toes.
-		command_alert("Unidentified lifesigns detected coming aboard [station_name()]. Secure any exterior access, including ducting and ventilation.", "Lifesign Alert",alert = 'sound/AI/aliens.ogg')
+		command_alert(/datum/command_alert/xenomorphs)
 
 
 /proc/high_radiation_event()
@@ -242,7 +242,7 @@
 			continue
 		M.apply_effect((rand(15,75)),IRRADIATE,0)
 	sleep(100)
-	command_alert("High levels of radiation detected near the station. Please report to the Med-bay if you feel strange.", "Anomaly Alert",alert='sound/AI/radiation.ogg')
+	command_alert(/datum/command_alert/radiation)
 
 
 //Changing this to affect the main station. Blame Urist. --Pete
@@ -282,7 +282,7 @@
 				temp_timer.releasetime = 1
 
 		sleep(150)
-		command_alert("Gr3y.T1d3 virus detected in [station_name()] imprisonment subroutines. Recommend station AI involvement.", "Security Alert")
+		command_alert(/datum/command_alert/graytide)
 	else
 		world.log << "ERROR: Could not initate grey-tide. Unable find prison or brig area."
 
@@ -292,11 +292,11 @@
 			new /mob/living/simple_animal/hostile/carp(C.loc)
 	//sleep(100)
 	spawn(rand(300, 600)) //Delayed announcements to keep the crew on their toes.
-		command_alert("Unknown biological entities have been detected near [station_name()], please stand-by.", "Lifesign Alert")
+		command_alert(/datum/command_alert/carp)
 
 /proc/lightsout(isEvent = 0, lightsoutAmount = 1,lightsoutRange = 25) //leave lightsoutAmount as 0 to break ALL lights
 	if(isEvent)
-		command_alert("An Electrical storm has been detected in your area, please repair potential electronic overloads.","Electrical Storm Alert")
+		command_alert(/datum/command_alert/electrical_storm)
 
 	if(lightsoutAmount)
 		var/list/epicentreList = list()

--- a/code/game/gamemodes/events/miniblob.dm
+++ b/code/game/gamemodes/events/miniblob.dm
@@ -13,7 +13,7 @@
 	spawn(3000)
 		blobevent = 0
 	spawn(rand(1000, 2000)) //Delayed announcements to keep the crew on their toes.
-		command_alert("Confirmed outbreak of level 5 biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert",1,alert='sound/AI/outbreak5.ogg')
+		command_alert(/datum/command_alert/biohazard_level_5)
 
 /proc/dotheblobbaby()
 	if (blobevent)

--- a/code/game/gamemodes/events/power_failure.dm
+++ b/code/game/gamemodes/events/power_failure.dm
@@ -2,7 +2,7 @@
 /proc/power_failure(var/announce = 1)
 	suspend_alert = 1
 	if(announce)
-		command_alert("Abnormal activity detected in [station_name()]'s powernet. As a precautionary measure, the station's power will be shut off for an indeterminate duration.", "Critical Power Failure",alert ='sound/AI/poweroff.ogg')
+		command_alert(/datum/command_alert/power_outage)
 	for(var/obj/machinery/power/battery/smes/S in power_machines)
 		if(istype(get_area(S), /area/turret_protected) || S.z != 1)
 			continue
@@ -49,7 +49,7 @@
 
 
 	if(announce)
-		command_alert("Power has been restored to [station_name()]. We apologize for the inconvenience.", "Power Systems Nominal",alert='sound/AI/poweron.ogg')
+		command_alert(/datum/command_alert/power_restored)
 	for(var/obj/machinery/power/apc/C in power_machines)
 		if(C.cell && C.z == 1)
 			C.cell.charge = C.cell.maxcharge
@@ -71,7 +71,7 @@
 
 /proc/power_restore_quick(var/announce = 1)
 	if(announce)
-		command_alert("All SMESs on [station_name()] have been recharged. We apologize for the inconvenience.", "Power Systems Nominal",alert='sound/AI/poweron.ogg')
+		command_alert(/datum/command_alert/smes_charged)
 	for(var/obj/machinery/power/battery/smes/S in power_machines)
 		if(S.z != 1)
 			continue

--- a/code/game/gamemodes/events/wormholes.dm
+++ b/code/game/gamemodes/events/wormholes.dm
@@ -7,7 +7,7 @@
 
 		if(pick_turfs.len)
 			//All ready. Announce that bad juju is afoot.
-			command_alert("Space-time anomalies detected on the station. There is no additional data.", "Anomaly Alert",alert='sound/AI/spanomalies.ogg')
+			command_alert(/datum/command_alert/wormholes)
 			//prob(20) can be approximated to 1 wormhole every 5 turfs!
 			//admittedly less random but totally worth it >_<
 			var/event_duration = 3000	//~5 minutes in ticks

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -226,7 +226,7 @@
 			comm.messagetitle.Add("[command_name()] Status Summary")
 			comm.messagetext.Add(intercepttext)
 
-	command_alert("Summary downloaded and printed out at all communications consoles.", "Enemy communication intercept.")
+	command_alert(/datum/command_alert/enemy_comms_interception)
 /*	for(var/mob/M in player_list)
 		if(!istype(M,/mob/new_player))
 			M << sound('sound/AI/intercept.ogg')

--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -181,7 +181,7 @@ You should now be able to use your Explode verb to interface with the nuclear fi
 	if (alert(usr, "Are you sure you wish to initiate the takeover? The station hostile runtime detection software is bound to alert everyone. You have hacked [ticker.mode:apcs] APCs.", "Takeover:", "Yes", "No") != "Yes")
 		return
 
-	command_alert("Hostile runtimes detected in all station systems, please deactivate your AI to prevent possible damage to its morality core.", "Anomaly Alert",alert='sound/AI/aimalf.ogg')
+	command_alert(/datum/command_alert/malf_announce)
 	set_security_level("delta")
 
 	ticker.mode:malf_mode_declared = 1

--- a/code/game/gamemodes/meteor/meteor.dm
+++ b/code/game/gamemodes/meteor/meteor.dm
@@ -95,12 +95,10 @@
 
 	sleep(20) //Two seconds for warning to play
 
-	if(prob(70)) //Slighty off-scale
-		command_alert("A meteor storm has been detected in proximity of [station_name()] and is expected to strike within [round((rand(meteor_delay - 600, meteor_delay + 600))/600)] minutes. A backup emergency shuttle is being dispatched and emergency gear should be teleported into your station's Bar area in [supply_delay/10] seconds.", \
-		"Space Weather Automated Announcements", alert = 'sound/AI/meteorround.ogg')
-	else //Oh boy
-		command_alert("A meteor storm has been detected in proximity of [station_name()] and is expected to strike within [round((rand(meteor_delay - 1800, meteor_delay + 1800))/600)] minutes. A backup emergency shuttle is being dispatched and emergency gear should be teleported into your station's Bar area in [supply_delay/10] seconds.", \
-		"Space Weather Automated Announcements", alert = 'sound/AI/meteorround.ogg')
+	var/datum/command_alert/meteor_round/CA = new()
+	CA.meteor_delay = meteor_delay
+	CA.supply_delay = supply_delay
+	command_alert(CA)
 
 	message_admins("Meteor Storm announcement given. Meteors will arrive in approximately [round(meteor_delay/600)] minutes. Shuttle will take [10*meteor_shuttle_multiplier] minutes to arrive and supplies are about to be dispatched in the Bar.")
 

--- a/code/game/response_team.dm
+++ b/code/game/response_team.dm
@@ -135,11 +135,11 @@ proc/trigger_armed_response_team(var/force = 0)
 
 	// there's only a certain chance a team will be sent
 	if(!prob(send_team_chance))
-		command_alert("It would appear that an emergency response team was requested for [station_name()]. Unfortunately, we were unable to send one at this time.", "Central Command")
+		command_alert(/datum/command_alert/ert_fail)
 		can_call_ert = 0 // Only one call per round, ladies.
 		return
 
-	command_alert("It would appear that an emergency response team was requested for [station_name()]. We will prepare and send one as soon as possible.", "Central Command")
+	command_alert(/datum/command_alert/ert_success)
 
 	can_call_ert = 0 // Only one call per round, gentleman.
 	send_emergency_team = 1

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2360,11 +2360,11 @@
 				if(gravity_is_on)
 					log_admin("[key_name(usr)] toggled gravity on.", 1)
 					message_admins("<span class='notice'>[key_name_admin(usr)] toggled gravity on.</span>", 1)
-					command_alert("Gravity generators are again functioning within normal parameters. Sorry for any inconvenience.")
+					command_alert(/datum/command_alert/gravity_enabled)
 				else
 					log_admin("[key_name(usr)] toggled gravity off.", 1)
 					message_admins("<span class='notice'>[key_name_admin(usr)] toggled gravity off.</span>", 1)
-					command_alert("Feedback surge detected in mass-distributions systems. Artifical gravity has been disabled whilst the system reinitializes. Further failures may result in a gravitational collapse and formation of blackholes. Have a nice day.")
+					command_alert(/datum/command_alert/gravity_disabled)
 			if("wave")
 				feedback_inc("admin_secrets_fun_used",1)
 				feedback_add_details("admin_secrets_fun_used","Meteor")
@@ -2660,8 +2660,7 @@
 			if("gravanomalies")
 				feedback_inc("admin_secrets_fun_used",1)
 				feedback_add_details("admin_secrets_fun_used","GA")
-				command_alert("Gravitational anomalies detected on the station. There is no additional data.", "Anomaly Alert")
-				world << sound('sound/AI/granomalies.ogg')
+				command_alert(/datum/command_alert/wormholes)
 				var/turf/T = pick(blobstart)
 				var/obj/effect/bhole/bh = new /obj/effect/bhole( T.loc, 30 )
 				spawn(rand(100, 600))
@@ -2888,7 +2887,7 @@
 					if(W.z == 1 && !istype(get_area(W), /area/bridge) && !istype(get_area(W), /area/crew_quarters) && !istype(get_area(W), /area/security/prison))
 						W.req_access = list()
 				message_admins("[key_name_admin(usr)] activated Egalitarian Station mode")
-				command_alert("Centcomm airlock control override activated. Please take this time to get acquainted with your coworkers.")
+				command_alert(/datum/command_alert/eagles)
 			if("dorf")
 				feedback_inc("admin_secrets_fun_used",1)
 				feedback_add_details("admin_secrets_fun_used","DF")
@@ -2903,7 +2902,7 @@
 				message_admins("[key_name_admin(usr)] triggered an ion storm")
 				var/show_log = alert(usr, "Show ion message?", "Message", "Yes", "No")
 				if(show_log == "Yes")
-					command_alert("Ion storm detected near the station. Please check all AI-controlled equipment for errors.", "Anomaly Alert",alert='sound/AI/ionstorm.ogg')
+					command_alert(/datum/command_alert/ion_storm)
 			if("spacevines")
 				feedback_inc("admin_secrets_fun_used",1)
 				feedback_add_details("admin_secrets_fun_used","K")
@@ -3017,14 +3016,14 @@
 					log_admin("[key_name_admin(usr)] triggered a FAKE Biohzard Alert.")
 					return
 				if(choice == "Lifesigns") //MUH ALIUMS
-					command_alert("Unidentified lifesigns detected coming aboard [station_name()]. Secure any exterior access, including ducting and ventilation.", "Lifesign Alert",alert='sound/AI/aliens.ogg')
+					command_alert(/datum/command_alert/xenomorphs)
 					message_admins("[key_name_admin(usr)] triggered a FAKE Lifesign Alert.")
 					log_admin("[key_name_admin(usr)] triggered a FAKE Lifesign Alert.")
 					return
 				if(choice == "Malfunction") //BLOW EVERYTHING
 					var/salertchoice = input("Do you wish to include the Hostile Runtimes warning to have an authentic Malfunction Takeover Alert ?", "Nanotrasen Alert Level Monitor") in list("Yes", "No")
 					if(salertchoice == "Yes")
-						command_alert("Hostile runtimes detected in all station systems, please deactivate your AI to prevent possible damage to its morality core.", "Anomaly Alert",alert='sound/AI/aimalf.ogg')
+						command_alert(/datum/command_alert/malf_announce)
 					to_chat(world, "<font size=4 color='red'>Attention! Delta security level reached!</font>")//Don't ACTUALLY set station alert to Delta to avoid fucking shit up for real
 
 					to_chat(world, "<font color='red'>[config.alert_desc_delta]</font>")
@@ -3033,17 +3032,17 @@
 					log_admin("[key_name_admin(usr)] triggered a FAKE Malfunction Takeover Alert (Hostile Runtimes alert [salertchoice == "Yes" ? "included":"excluded"])")
 					return
 				if(choice == "Ion")
-					command_alert("Ion storm detected near the station. Please check all AI-controlled equipment for errors.", "Anomaly Alert",alert='sound/AI/ionstorm.ogg')
+					command_alert(/datum/command_alert/ion_storm)
 					message_admins("[key_name_admin(usr)] triggered a FAKE Ion Alert.")
 					log_admin("[key_name_admin(usr)] triggered a FAKE Ion Alert.")
 					return
 				if(choice == "Meteor Wave")
-					command_alert("A meteor storm has been detected on collision course with the station. Seek shelter within the core of the station immediately.", "Meteor Alert",alert='sound/AI/meteors.ogg')
+					command_alert(/datum/command_alert/meteor_wave)
 					message_admins("[key_name_admin(usr)] triggered a FAKE Meteor Alert.")
 					log_admin("[key_name_admin(usr)] triggered a FAKE Meteor Alert.")
 					return
 				if(choice == "Carp Migration")
-					command_alert("Unknown biological entities have been detected near [station_name()], please stand-by.", "Lifesign Alert")
+					command_alert(/datum/command_alert/carp)
 					message_admins("[key_name_admin(usr)] triggered a FAKE Carp Migration Alert.")
 					log_admin("[key_name_admin(usr)] triggered a FAKE Carp Migration Alert.")
 					return

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -207,7 +207,7 @@ proc/cmd_admin_mute(mob/M as mob, mute_type, automute = 0)
 
 	var/show_log = alert(src, "Show ion message?", "Message", "Yes", "No")
 	if(show_log == "Yes")
-		command_alert("Ion storm detected near the station. Please check all AI-controlled equipment for errors.", "Anomaly Alert",alert='sound/AI/ionstorm.ogg')
+		command_alert(/datum/command_alert/ion_storm)
 
 	generate_ion_law()
 	feedback_add_details("admin_verb","ION") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
@@ -566,7 +566,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 
 	var/show_log = alert(src, "Show ion message?", "Message", "Yes", "No")
 	if(show_log == "Yes")
-		command_alert("Ion storm detected near the station. Please check all AI-controlled equipment for errors.", "Anomaly Alert",alert='sound/AI/ionstorm.ogg')
+		command_alert(/datum/command_alert/ion_storm)
 	feedback_add_details("admin_verb","IONC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/cmd_admin_rejuvenate(mob/living/M as mob in mob_list)

--- a/code/modules/awaymissions/bluespaceartillery.dm
+++ b/code/modules/awaymissions/bluespaceartillery.dm
@@ -41,7 +41,7 @@
 		if (usr.stat || usr.restrained()) return
 		if(src.reload < 180) return
 		if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (istype(usr, /mob/living/silicon)))
-			command_alert("Bluespace artillery fire detected. Brace for impact.")
+			command_alert(/datum/command_alert/bluespace_artillery)
 			message_admins("[key_name_admin(usr)] has launched an artillery strike.", 1)
 			var/list/L = list()
 			for(var/turf/T in get_area_turfs(thearea.type))

--- a/code/modules/events/alien_infestation.dm
+++ b/code/modules/events/alien_infestation.dm
@@ -16,7 +16,7 @@
 
 /datum/event/alien_infestation/announce()
 	if(successSpawn)
-		command_alert("Unidentified lifesigns detected coming aboard [station_name()]. Secure any exterior access, including ducting and ventilation.", "Lifesign Alert",alert='sound/AI/aliens.ogg')
+		command_alert(/datum/command_alert/xenomorphs)
 
 
 /datum/event/alien_infestation/start()

--- a/code/modules/events/bluespaceanomaly.dm
+++ b/code/modules/events/bluespaceanomaly.dm
@@ -34,7 +34,7 @@
 
 
 /datum/event/bluespace_anomaly/announce()
-	command_alert("Bluespace anomaly detected in the vicinity of [station_name()]. [impact_area.name] has been affected.", "Anomaly Alert")
+	command_alert(new /datum/command_alert/bluespace_anomaly(impact_area.name))
 
 
 /datum/event/bluespace_anomaly/start()

--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -9,7 +9,7 @@
 
 
 /datum/event/brand_intelligence/announce()
-	command_alert("Rampant brand intelligence has been detected aboard [station_name()], please stand-by.", "Machine Learning Alert")
+	command_alert(/datum/command_alert/vending_machines)
 
 
 /datum/event/brand_intelligence/start()

--- a/code/modules/events/carp_migration.dm
+++ b/code/modules/events/carp_migration.dm
@@ -8,7 +8,7 @@
 	endWhen = rand(600,1200)
 
 /datum/event/carp_migration/announce()
-	command_alert("Unknown biological entities have been detected near [station_name()], please stand-by.", "Lifesign Alert")
+	command_alert(/datum/command_alert/carp)
 
 /datum/event/carp_migration/start()
 	for(var/obj/effect/landmark/C in landmarks_list)

--- a/code/modules/events/comms_blackout.dm
+++ b/code/modules/events/comms_blackout.dm
@@ -3,7 +3,7 @@
 
 
 	if(!silent)
-		command_alert("Ionospheric anomalies detected. Temporary telecommunication failure imminent. Please contact you-BZZT")
+		command_alert(/datum/command_alert/comms_blackout)
 	else // AIs will always know if there's a comm blackout, rogue AIs could then lie about comm blackouts in the future while they shutdown comms
 		for(var/mob/living/silicon/ai/A in player_list)
 			to_chat(A, "<br>")

--- a/code/modules/events/communications_blackout.dm
+++ b/code/modules/events/communications_blackout.dm
@@ -12,7 +12,7 @@
 		to_chat(A, "<br>")
 
 	if(prob(30))	//most of the time, we don't want an announcement, so as to allow AIs to fake blackouts.
-		command_alert(alert)
+		command_alert(/datum/command_alert/comms_blackout)
 
 
 /datum/event/communications_blackout/start()

--- a/code/modules/events/electrical_storm.dm
+++ b/code/modules/events/electrical_storm.dm
@@ -4,7 +4,7 @@
 
 
 /datum/event/electrical_storm/announce()
-	command_alert("An electrical storm has been detected in your area, please repair potential electronic overloads.", "Electrical Storm Alert")
+	command_alert(/datum/command_alert/electrical_storm)
 
 
 /datum/event/electrical_storm/start()

--- a/code/modules/events/grid_check.dm
+++ b/code/modules/events/grid_check.dm
@@ -8,7 +8,7 @@
 	power_failure(0)
 
 /datum/event/grid_check/announce()
-	command_alert("Abnormal activity detected in [station_name()]'s powernet. As a precautionary measure, the station's power will be shut off for an indeterminate duration.", "Automated Grid Check",alert='sound/AI/poweroff.ogg')
+	command_alert(/datum/command_alert/power_disabled)
 
 /datum/event/grid_check/end()
 	if(universe.name != "Normal")

--- a/code/modules/events/hostile_infestation.dm
+++ b/code/modules/events/hostile_infestation.dm
@@ -115,7 +115,7 @@
 
 
 /datum/event/hostile_infestation/announce()
-	command_alert("One or more hostile creatures have entered the station in [localestring]. External security cameras indicate that the creature has [monsterstring].", "WARNING: Hostile Creature(s)")
+	command_alert(new /datum/command_alert/hostile_creatures(localestring, monsterstring))
 
 
 #undef LOC_KITCHEN

--- a/code/modules/events/immovablerod.dm
+++ b/code/modules/events/immovablerod.dm
@@ -8,7 +8,7 @@
 	announceWhen = 100
 
 /datum/event/immovable_rod/announce()
-	command_alert("What the fuck was that?!", "General Alert")
+	command_alert(/datum/command_alert/immovable_rod)
 
 /datum/event/immovable_rod/start()
 	immovablerod()

--- a/code/modules/events/infestation.dm
+++ b/code/modules/events/infestation.dm
@@ -108,7 +108,7 @@
 			new spawn_type(picked)
 
 /datum/event/infestation/announce()
-	command_alert("Bioscans indicate that [vermstring] have been breeding in [locstring]. Clear them out, before this starts to affect productivity.", "Vermin infestation")
+	command_alert(new /datum/command_alert/vermin(vermstring, locstring))
 
 #undef LOC_KITCHEN
 #undef LOC_ATMOS

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -174,7 +174,7 @@
 	active = 0
 	spawn(rand(5000,8000))
 		if(prob(50))
-			command_alert("It has come to our attention that the station passed through an ion storm.  Please monitor all electronic equipment for malfunctions.", "Anomaly Alert")
+			command_alert(/datum/command_alert/ion_storm_large)
 
 /*
 /proc/IonStorm(botEmagChance = 10)

--- a/code/modules/events/link_with_centcomm.dm
+++ b/code/modules/events/link_with_centcomm.dm
@@ -10,9 +10,9 @@
 proc/link_to_centcomm()
 	if(!map.linked_to_centcomm)
 		map.linked_to_centcomm = 1
-		command_alert("A link to Central Command has been established on [station_name()].","Link Established")
+		command_alert(/datum/command_alert/command_link_restored)
 
 proc/unlink_from_centcomm()
 	if(map.linked_to_centcomm)
-		command_alert("This is an automated announcement. The link with central command has been lost. Repeat: The link with central command has been lost. Attempting to re-establish communications in T-10.","Automated announcement",1,alert='sound/AI/loss.ogg')
+		command_alert(/datum/command_alert/command_link_lost)
 		map.linked_to_centcomm = 0

--- a/code/modules/events/meteors.dm
+++ b/code/modules/events/meteors.dm
@@ -12,14 +12,14 @@
 	endWhen = rand(45, 90) //More drawn out than the shower, but not too powerful. Supposed to be a devastating event
 
 /datum/event/meteor_wave/announce()
-	command_alert("A meteor storm has been detected on collision course with the station. Seek shelter within the core of the station immediately.", "Meteor Alert",alert='sound/AI/meteors.ogg')
+	command_alert(/datum/command_alert/meteor_wave)
 
 //Two to three waves. So 40 to 120
 /datum/event/meteor_wave/tick()
 	meteor_wave(rand(20, 40), max_size = 2) //Large waves, panic is mandatory
 
 /datum/event/meteor_wave/end()
-	command_alert("The station has cleared the meteor storm.", "Meteor Alert")
+	command_alert(/datum/command_alert/meteor_wave_end)
 
 //One to two vawes
 /datum/event/meteor_shower
@@ -30,7 +30,7 @@
 	endWhen	= rand(45, 60) //From thirty seconds to one minute
 
 /datum/event/meteor_shower/announce()
-	command_alert("The station is about to be hit by a small-intensity meteor storm. Seek shelter within the core of the station immediately.", "Meteor Alert")
+	command_alert(/datum/command_alert/meteor_storm)
 
 //Meteor showers are lighter and more common
 //Sometimes a single wave, most likely two, so anywhere from 10 to 30 small meteors
@@ -38,7 +38,7 @@
 	meteor_wave(rand(10, 15), max_size = 1) //Much more clement
 
 /datum/event/meteor_shower/end()
-	command_alert("The station has cleared the meteor shower.", "Meteor Alert")
+	command_alert(/datum/command_alert/meteor_wave_end)
 
 //Meteor wave that doesn't trigger an announcement. Perfect for adminbus involving extended meteor bombardments without spamming the crew with Meteor alerts.
 /datum/event/meteor_shower/meteor_quiet
@@ -124,7 +124,7 @@ var/global/list/thing_storm_types = list(
 	storm_name=pick(possible_names)
 
 /datum/event/thing_storm/announce()
-	command_alert("The station is about to be hit by a small-intensity meteor storm. Seek shelter within the core of the station immediately.", "Meteor Alert")
+	command_alert(/datum/command_alert/meteor_storm)
 
 //Meteor showers are lighter and more common
 //Since this isn't rocks of pure pain and explosion, we have more, anywhere from 10 to 40 items
@@ -159,10 +159,10 @@ var/global/list/thing_storm_types = list(
 	meteor_wave(rand(12, 24), types = thing_storm_types[storm_name])
 
 /datum/event/thing_storm/blob_shower/announce()
-	command_alert("The station is about to pass through a Blob cluster. No overmind brainwaves detected.", "Blob Cluster")
+	command_alert(/datum/command_alert/blob_storm)
 
 /datum/event/thing_storm/blob_shower/end()
-	command_alert("The station has cleared the Blob cluster. Eradicate the blob from hit areas.", "Blob Cluster")
+	command_alert(/datum/command_alert/blob_storm/end)
 
 /datum/event/thing_storm/blob_storm
 	var/cores_spawned = 0
@@ -183,7 +183,7 @@ var/global/list/thing_storm_types = list(
 			spawn_meteor(chosen_dir, /obj/item/projectile/meteor/blob/core)
 
 /datum/event/thing_storm/blob_storm/announce()
-	command_alert("The station is about to pass through a Blob conglomerate. Overmind brainwaves possibly detected.", "Blob Conglomerate")
+	command_alert(/datum/command_alert/blob_storm/overminds)
 
 /datum/event/thing_storm/blob_storm/end()
-	command_alert("The station has cleared the Blob conglomerate. Investigate the hit areas at once and clear the blob. Beware for possible Overmind presence.", "Blob Conglomerate")
+	command_alert(/datum/command_alert/blob_storm/overminds/end)

--- a/code/modules/events/mob_swarm.dm
+++ b/code/modules/events/mob_swarm.dm
@@ -51,4 +51,4 @@
 
 
 /datum/event/mob_swarm/announce()
-    command_alert("Due to timespace anomalies of unknown origin, [station_name] is now host to several [mob_name]\s more than there were a moment ago.")
+    command_alert(new /datum/command_alert/mob_swarm(mob_name))

--- a/code/modules/events/prison_break.dm
+++ b/code/modules/events/prison_break.dm
@@ -14,7 +14,7 @@
 
 /datum/event/prison_break/announce()
 	if(prisonAreas && prisonAreas.len > 0)
-		command_alert("[pick("Gr3y.T1d3 virus","Malignant trojan")] detected in [station_name()] imprisonment subroutines. Recommend station AI involvement.", "Security Alert")
+		command_alert(/datum/command_alert/graytide)
 	else
 		world.log << "ERROR: Could not initate grey-tide. Unable find prison or brig area."
 		kill()

--- a/code/modules/events/radiation_storm.dm
+++ b/code/modules/events/radiation_storm.dm
@@ -24,7 +24,7 @@
 
 /datum/event/radiation_storm/start()
 	spawn()
-		command_alert("High levels of radiation detected near the station, ETA in 30 seconds. Please evacuate into one of the shielded maintenance tunnels.", "Anomaly Alert",alert='sound/AI/radiation.ogg')
+		command_alert(/datum/command_alert/radiation_storm)
 
 		for(var/area/A in areas)
 			if(A.z != 1 || is_safe_zone(A))
@@ -38,7 +38,7 @@
 		sleep(30 SECONDS)
 
 
-		command_alert("The station has entered the radiation belt. Please remain in a sheltered area until we have passed the radiation belt.", "Anomaly Alert")
+		command_alert(/datum/command_alert/radiation_storm/start)
 
 		for(var/i = 0, i < 15, i++)
 			var/irradiationThisBurst = rand(15,25) //everybody gets the same rads this radiation burst
@@ -66,7 +66,7 @@
 			sleep(25)
 
 
-		command_alert("The station has passed the radiation belt. Please report to medbay if you experience any unusual symptoms. Maintenance will lose all access again shortly.", "Anomaly Alert")
+		command_alert(/datum/command_alert/radiation_storm/end)
 
 		for(var/area/A in areas)
 			if(A.z != 1 || is_safe_zone(A))

--- a/code/modules/events/rogue_drones.dm
+++ b/code/modules/events/rogue_drones.dm
@@ -24,14 +24,7 @@
 			D.disabled = rand(15, 60)
 
 /datum/event/rogue_drone/announce()
-	var/msg
-	if(prob(33))
-		msg = "A combat drone wing operating out of the NMV Icarus has failed to return from a sweep of this sector, if any are sighted approach with caution."
-	else if(prob(50))
-		msg = "Contact has been lost with a combat drone wing operating out of the NMV Icarus. If any are sighted in the area, approach with caution."
-	else
-		msg = "Unidentified hackers have targeted a combat drone wing deployed from the NMV Icarus. If any are sighted in the area, approach with caution."
-	command_alert(msg, "Rogue drone alert")
+	command_alert(/datum/command_alert/rogue_drone)
 
 /datum/event/rogue_drone/tick()
 	return
@@ -51,6 +44,6 @@
 		num_recovered++
 
 	if(num_recovered > drones_list.len * 0.75)
-		command_alert("Icarus drone control reports the malfunctioning wing has been recovered safely.", "Rogue drone alert")
+		command_alert(/datum/command_alert/drones_recovered)
 	else
-		command_alert("Icarus drone control registers disappointment at the loss of the drones, but the survivors have been recovered.", "Rogue drone alert")
+		command_alert(/datum/command_alert/drones_recovered/failure)

--- a/code/modules/events/spider_infestation.dm
+++ b/code/modules/events/spider_infestation.dm
@@ -12,7 +12,7 @@
 	sent_spiders_to_station = 0
 
 /datum/event/spider_infestation/announce()
-	command_alert("Unidentified lifesigns detected coming aboard [station_name()]. Secure any exterior access, including ducting and ventilation.", "Lifesign Alert",alert='sound/AI/aliens.ogg')
+	command_alert(/datum/command_alert/xenomorphs)
 
 
 /datum/event/spider_infestation/start()

--- a/code/modules/events/wallrot.dm
+++ b/code/modules/events/wallrot.dm
@@ -10,7 +10,7 @@ datum/event/wallrot/setup()
 	severity = rand(5, 10)
 
 datum/event/wallrot/announce()
-	command_alert("Harmful fungi detected on station. Station structures may be contaminated.", "Biohazard Alert")
+	command_alert(/datum/command_alert/wall_fungi)
 
 datum/event/wallrot/start()
 	spawn()

--- a/html/changelogs/unid-hak.yml
+++ b/html/changelogs/unid-hak.yml
@@ -1,0 +1,7 @@
+author: Unid
+
+delete-after: True
+
+changes: 
+- rscdel: "Changed Malf AI modules: Replaced Interhack (useless module) with Fake Centcom Announcement:"
+- rscadd: "Fake Centcom Announcement: Buying it lets you create up to 3 centcom announcements (such as meteor waves warning, unidentified lifesigns warning etc). Costs 15 units."

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -208,6 +208,7 @@
 #include "code\datums\diseases\advance\symptoms\vomit.dm"
 #include "code\datums\diseases\advance\symptoms\weight.dm"
 #include "code\datums\helper_datums\butchering.dm"
+#include "code\datums\helper_datums\command_alerts.dm"
 #include "code\datums\helper_datums\construction_datum.dm"
 #include "code\datums\helper_datums\events.dm"
 #include "code\datums\helper_datums\getrev.dm"


### PR DESCRIPTION
- Introduced command alert datums. Pass them to the command_alert proc like so:

_command_alert(/datum/command_alert/carp_alert)_
or like so:
_command_alert(new /datum/command_alert/carp_alert)_

You can still use the command_alert proc the old way, like so:
_command_alert("Bad things are happening", "Bad Thing Detector", 1, 'sound/AI/loss.ogg')_
- Replaced "Interhack" malf AI module (which did nothing) with a new module: "Fake Centcom Announcement". It lets you fake any command alert up to three times! The price remains the same: 15.

![](http://puu.sh/qe4mZ/62d81f621a.png)
