### PR TITLE
Adds the "trader" appearance to the list of available agent ID appearances

### DIFF
--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -351,7 +351,7 @@
 						UpdateName()
 						to_chat(user, "Name changed to [new_name].")
 
-					if("Appearance") //what a snowflake fuck you
+					if("Appearance")
 						var/list/appearances = list(
 							"data",
 							"id",

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -351,7 +351,7 @@
 						UpdateName()
 						to_chat(user, "Name changed to [new_name].")
 
-					if("Appearance")
+					if("Appearance") //what a snowflake fuck you
 						var/list/appearances = list(
 							"data",
 							"id",
@@ -369,6 +369,7 @@
 							"CE",
 							"clown",
 							"mime",
+							"trader",
 							"syndie",
 							"deathsquad",
 							"creed",

--- a/html/changelogs/Wizardcrying.yml
+++ b/html/changelogs/Wizardcrying.yml
@@ -1,0 +1,3 @@
+author: Wizardcrying
+changes: 
+- bugfix: Added the Traveler ID to the list of Agent ID appearances.


### PR DESCRIPTION
:100:% tested.
Fuck that list why doesn't it pull from existing ones
Fixes #11134 
