### PR TITLE
Better controllable simple animals

### DIFF
--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -303,7 +303,7 @@
 	for(var/mob/living/simple_animal/hostile/blobspore/BS in living_mob_list)
 		if(isturf(BS.loc) && get_dist(BS, T) <= 35)
 			BS.LoseTarget()
-			BS.Goto(pick(surrounding_turfs), BS.move_to_delay)
+			BS.Goto(pick(surrounding_turfs), BS.speed)
 	return
 
 /mob/camera/blob/verb/telepathy(message as text)

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -536,7 +536,7 @@ proc/move_mining_shuttle()
 	minbodytemp = 0
 	wander = 0
 	idle_vision_range = 5
-	move_to_delay = 10
+	speed = 10
 	retreat_distance = 1
 	minimum_distance = 2
 	health = 100

--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -202,7 +202,7 @@ var/list/nest_locations = list()
 				if(last_loc && (last_loc == loc))
 					DestroySurroundings()
 				last_loc = loc
-				Goto(dragging,move_to_delay,1)
+				Goto(dragging, speed, 1)
 		else//if another alien is dragging them, just leave them alone
 			dragging = null
 			walk(src, 0)
@@ -229,7 +229,7 @@ var/list/nest_locations = list()
 			if(last_loc && (last_loc == loc))
 				DestroySurroundings()
 			last_loc = loc
-			Goto(dest,move_to_delay,0)
+			Goto(dest, speed, 0)
 
 
 /mob/living/simple_animal/hostile/alien/proc/CanOpenDoor(var/obj/machinery/door/D)
@@ -284,7 +284,7 @@ var/list/nest_locations = list()
 	melee_damage_lower = 15
 	melee_damage_upper = 15
 	ranged = 1
-	move_to_delay = 3
+	speed = 3
 	projectiletype = /obj/item/projectile/neurotox
 	projectilesound = 'sound/weapons/pierce.ogg'
 	rapid = 1
@@ -337,7 +337,7 @@ var/list/nest_locations = list()
 	icon_state = "queen_s"
 	icon_living = "queen_s"
 	icon_dead = "queen_dead"
-	move_to_delay = 4
+	speed = 4
 	maxHealth = 400
 	health = 400
 	pixel_x = -16

--- a/code/modules/mob/living/simple_animal/hostile/frog.dm
+++ b/code/modules/mob/living/simple_animal/hostile/frog.dm
@@ -31,8 +31,7 @@
 	ranged_cooldown_cap = 8
 	ranged_message = "leaps"
 
-	move_to_delay = 6
-	speed = 2
+	speed = 6
 
 	harm_intent_damage = 6
 	melee_damage_lower = 1

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/base_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/base_spider.dm
@@ -33,8 +33,7 @@ var/global/list/spider_types = typesof(/mob/living/simple_animal/hostile/giant_s
 	cold_damage_per_tick = 20
 	faction = "spiders"
 	pass_flags = PASSTABLE
-	move_to_delay = 6
-	speed = 3
+	speed = 6
 	attack_sound = 'sound/weapons/spiderlunge.ogg'
 
 	species_type = /mob/living/simple_animal/hostile/giant_spider
@@ -186,7 +185,7 @@ var/global/list/spider_types = typesof(/mob/living/simple_animal/hostile/giant_s
 				for(var/turf/T in orange(20, src))
 					move_targets.Add(T)*/
 				stop_automated_movement = 1
-				Goto(pick(orange(20, src)), move_to_delay)
+				Goto(pick(orange(20, src)), speed)
 				spawn(50)
 					stop_automated_movement = 0
 					walk(src,0)

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/nurse.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/nurse.dm
@@ -38,7 +38,7 @@
 					if(C.stat && !istype(C,/mob/living/simple_animal/hostile/giant_spider))
 						cocoon_target = C
 						busy = MOVING_TO_TARGET
-						Goto(C, move_to_delay)
+						Goto(C, speed)
 						//give up if we can't reach them after 10 seconds
 						GiveUp(C)
 						return
@@ -104,7 +104,7 @@
 						cocoon_target = O
 						busy = MOVING_TO_TARGET
 						stop_automated_movement = 1
-						Goto(O, move_to_delay)
+						Goto(O, speed)
 						//give up if we can't reach them after 10 seconds
 						GiveUp(O)
 

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/spiderling.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/spiderling.dm
@@ -23,7 +23,7 @@
 	vision_range = 3
 	aggro_vision_range = 9
 	idle_vision_range = 3
-	move_to_delay = 3
+	speed = 3
 	friendly = "harmlessly skitters into"
 	maxHealth = 12
 	health = 12
@@ -140,7 +140,7 @@
 	//ventcrawl!
 	if(!v.welded)
 		entry_vent = v
-		Goto(get_turf(v),move_to_delay)
+		Goto(get_turf(v), speed)
 
 //Virologist's little friend!
 /mob/living/simple_animal/hostile/giant_spider/spiderling/salk

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -37,6 +37,10 @@
 /mob/living/simple_animal/hostile/Life()
 	if(timestopped) return 0 //under effects of time magick
 	. = ..()
+	//Cooldowns
+	if(ranged)
+		ranged_cooldown--
+
 	if(istype(loc, /obj/item/device/mobcapsule))
 		return 0
 	if(!.)
@@ -68,9 +72,6 @@
 				if(!(flags & INVULNERABLE))
 					AttackTarget()
 					DestroySurroundings()
-
-		if(ranged)
-			ranged_cooldown--
 
 //////////////HOSTILE MOB TARGETTING AND AGGRESSION////////////
 
@@ -281,16 +282,19 @@
 	var/target_turf = get_turf(ttarget)
 	if(rapid)
 		sleep(1)
-		TryToShoot(target_turf)
+		TryToShoot(target_turf, ttarget)
 		sleep(4)
-		TryToShoot(target_turf)
+		TryToShoot(target_turf, ttarget)
 		sleep(6)
-		TryToShoot(target_turf)
+		TryToShoot(target_turf, ttarget)
 	else
-		TryToShoot(target_turf)
+		TryToShoot(target_turf, ttarget)
 	return
 
-/mob/living/simple_animal/hostile/proc/TryToShoot(var/atom/target_turf)
+/mob/living/simple_animal/hostile/proc/TryToShoot(var/atom/target_turf, atom/target)
+	if(!target)
+		target = src.target
+
 	if(Shoot(target_turf, src.loc, src))
 		ranged_cooldown = ranged_cooldown_cap
 		if(ranged_message)
@@ -374,6 +378,12 @@
 		return 0
 
 //Let players use mobs' ranged attacks
+/mob/living/simple_animal/hostile/Stat()
+	..()
+
+	if(ranged && statpanel("Status"))
+		stat(null, "Ranged Attack: [ranged_cooldown <= 0 ? "READY" : "[100 - round((ranged_cooldown / ranged_cooldown_cap) * 100)]%"]")
+
 /mob/living/simple_animal/hostile/RangedAttack(atom/A, params)
 	if(ranged && ranged_cooldown <= 0)
 		OpenFire(A)

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -2,6 +2,7 @@
 	faction = "hostile"
 	stop_automated_movement_when_pulled = 0
 	environment_smash = 1 //Set to 1 to break closets,tables,racks, etc; 2 for walls; 3 for rwalls
+	speed = 2
 
 	var/stance = HOSTILE_STANCE_IDLE	//Used to determine behavior
 	var/atom/target // /vg/ edit:  Removed type specification so spiders can target doors.
@@ -11,7 +12,6 @@
 	var/projectiletype
 	var/projectilesound
 	var/casingtype
-	var/move_to_delay = 2 //delay for the automated movement.
 	var/list/friends = list()
 	var/vision_range = 9 //How big of an area to search for targets in, a vision of 9 attempts to find targets as soon as they walk into screen view
 
@@ -189,16 +189,16 @@
 				AttackingTarget()
 			if(canmove)
 				if(retreat_distance != null && target_distance <= retreat_distance) //If we have a retreat distance, check if we need to run from our target
-					walk_away(src,target,retreat_distance,move_to_delay)
+					walk_away(src, target, retreat_distance, speed)
 				else
-					Goto(target,move_to_delay,minimum_distance)//Otherwise, get to our minimum distance so we chase them
+					Goto(target, speed, minimum_distance)//Otherwise, get to our minimum distance so we chase them
 			return
 
 	if(target.loc != null && get_dist(src, target.loc) <= vision_range)//We can't see our target, but he's in our vision range still
 		if(FindHidden(target) && environment_smash)//Check if he tried to hide in something to lose us
 			var/atom/A = target.loc
 			if(canmove)
-				Goto(A,move_to_delay,minimum_distance)
+				Goto(A, speed, minimum_distance)
 			if(A.Adjacent(src))
 				A.attack_animal(src)
 			return
@@ -276,14 +276,16 @@
 		src.friends |= H.friends
 
 /mob/living/simple_animal/hostile/proc/OpenFire(var/atom/ttarget)
+	set waitfor = 0
+
 	var/target_turf = get_turf(ttarget)
 	if(rapid)
-		spawn(1)
-			TryToShoot(target_turf)
-		spawn(4)
-			TryToShoot(target_turf)
-		spawn(6)
-			TryToShoot(target_turf)
+		sleep(1)
+		TryToShoot(target_turf)
+		sleep(4)
+		TryToShoot(target_turf)
+		sleep(6)
+		TryToShoot(target_turf)
 	else
 		TryToShoot(target_turf)
 	return
@@ -302,8 +304,8 @@
 	if(!istype(target, /turf))
 		return 0
 
-	//Friendly Fire check
-	if(!friendly_fire)
+	//Friendly Fire check (don't bother if the mob is controlled by a player)
+	if(!friendly_fire && !ckey)
 		var/obj/item/projectile/friendlyCheck/fC = getFromPool(/obj/item/projectile/friendlyCheck,user.loc)
 		fC.current = target
 		var/turf/T = get_turf(user)
@@ -370,3 +372,10 @@
 		return 1
 	else
 		return 0
+
+//Let players use mobs' ranged attacks
+/mob/living/simple_animal/hostile/RangedAttack(atom/A, params)
+	if(ranged && ranged_cooldown <= 0)
+		OpenFire(A)
+
+	return ..()

--- a/code/modules/mob/living/simple_animal/hostile/human/diona.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/diona.dm
@@ -11,8 +11,7 @@
 	health = 140
 	maxHealth = 140
 
-	move_to_delay = 30
-	speed = 5
+	speed = 30
 
 	min_oxy = 0
 	max_oxy = 0
@@ -56,8 +55,7 @@
 	health = 180
 	maxHealth = 180
 
-	move_to_delay = 2
-	speed = -1
+	speed = 2
 
 	attacktext = "chops"
 	attack_sound = 'sound/weapons/bladeslice.ogg'

--- a/code/modules/mob/living/simple_animal/hostile/human/jackal.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/jackal.dm
@@ -18,8 +18,7 @@
 	health = 100
 	maxHealth = 100
 
-	move_to_delay = 4
-	speed = 1
+	speed = 4
 
 	melee_damage_lower = 5
 	melee_damage_upper = 7

--- a/code/modules/mob/living/simple_animal/hostile/human/mummy.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/mummy.dm
@@ -22,8 +22,7 @@
 	health = 70
 	maxHealth = 70
 
-	move_to_delay = 20
-	speed = 4
+	speed = 20
 
 	melee_damage_lower = 3
 	melee_damage_upper = 6
@@ -171,8 +170,7 @@
 
 	ranged = 1
 
-	move_to_delay = 15 //Faster than normal mummies
-	speed = 2
+	speed = 15 //Faster than normal mummies
 
 	ranged_message = "invokes a powerful curse"
 	stat_attack = 0 //Only attack living dudes

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -15,7 +15,6 @@
 	response_help = "touches"
 	response_disarm = "pushes"
 	response_harm = "hits"
-	speed = -1
 	maxHealth = 250
 	health = 250
 
@@ -36,7 +35,7 @@
 	minbodytemp = 0
 
 	faction = "mimic"
-	move_to_delay = 8
+	speed = 8
 
 	var/atom/copied_object = /obj/structure/closet/crate
 	var/angry = 0
@@ -215,7 +214,7 @@ var/global/list/crate_mimic_disguises = list(\
 		angry = 2 //Can't calm down
 		melee_damage_lower = initial(melee_damage_lower) + 4
 		melee_damage_upper = initial(melee_damage_upper) + 4 //Increase damage
-		move_to_delay = 0 //Remove delay for automated movement
+		speed = 0 //Remove delay for automated movement
 		name = "[initial(name)] mimic"
 
 /mob/living/simple_animal/hostile/mimic/crate/proc/calm_down(change_icon = 1)
@@ -390,7 +389,7 @@ var/global/list/item_mimic_disguises = list(
 	name = "item mimic"
 	density = 0
 
-	move_to_delay = 2 //Faster than crate mimics
+	speed = 2 //Faster than crate mimics
 	maxHealth = 60
 	health = 60 //Slightly less robust
 
@@ -596,7 +595,7 @@ var/global/list/protected_objects = list(
 			health = 15 * I.w_class
 			melee_damage_lower = 2 + I.force
 			melee_damage_upper = 2 + I.force
-			move_to_delay = 2 * I.w_class
+			speed = 2 * I.w_class
 
 		maxHealth = health
 

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -56,7 +56,7 @@
 	icon_aggro = "Basilisk_alert"
 	icon_dead = "Basilisk_dead"
 	icon_gib = "syndicate_gib"
-	move_to_delay = 20
+	speed = 20
 	projectiletype = /obj/item/projectile/temp/basilisk
 	projectilesound = 'sound/weapons/pierce.ogg'
 	ranged = 1
@@ -64,7 +64,6 @@
 	ranged_cooldown_cap = 20
 	throw_message = "does nothing against the hard shell of"
 	vision_range = 2
-	speed = 3
 	maxHealth = 200
 	health = 200
 	harm_intent_damage = 5
@@ -129,7 +128,7 @@
 	vision_range = 3
 	aggro_vision_range = 9
 	idle_vision_range = 3
-	move_to_delay = 3
+	speed = 3
 	friendly = "harmlessly rolls into"
 	maxHealth = 60
 	health = 60
@@ -222,12 +221,11 @@
 	icon_dead = "Hivelord_dead"
 	icon_gib = "syndicate_gib"
 	mouse_opacity = 2
-	move_to_delay = 14
+	speed = 14
 	ranged = 1
 	vision_range = 5
 	aggro_vision_range = 9
 	idle_vision_range = 5
-	speed = 3
 	maxHealth = 75
 	health = 75
 	harm_intent_damage = 5
@@ -326,10 +324,9 @@
 	icon_dead = "Hivelordbrood"
 	icon_gib = "syndicate_gib"
 	mouse_opacity = 2
-	move_to_delay = 0
+	speed = 0
 	friendly = "buzzes near"
 	vision_range = 10
-	speed = 3
 	maxHealth = 1
 	health = 1
 	harm_intent_damage = 5
@@ -358,12 +355,11 @@
 	icon_dead = "Goliath_dead"
 	icon_gib = "syndicate_gib"
 	attack_sound = 'sound/weapons/heavysmash.ogg'
-	move_to_delay = 40
+	speed = 40
 	ranged = 1
 	ranged_cooldown_cap = 8
 	friendly = "wails at"
 	vision_range = 5
-	speed = 3
 	maxHealth = 300
 	health = 300
 	harm_intent_damage = 0

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -234,7 +234,7 @@
 	attacktext = "lashes out at"
 	throw_message = "falls right through the strange body of the"
 	ranged_cooldown = 0
-	ranged_cooldown_cap = 0
+	ranged_cooldown_cap = 1
 	environment_smash = 0
 	retreat_distance = 3
 	minimum_distance = 3
@@ -372,10 +372,12 @@
 
 	size = SIZE_BIG
 
-/mob/living/simple_animal/hostile/asteroid/goliath/OpenFire()
-	visible_message("<span class='warning'>The [src.name] digs its tentacles under [target.name]!</span>")
+/mob/living/simple_animal/hostile/asteroid/goliath/OpenFire(atom/ttarget)
+	if(istype(ttarget))
+		visible_message("<span class='warning'>\The [src] digs its tentacles under \the [ttarget]!</span>")
+
 	playsound(loc, 'sound/weapons/whip.ogg', 50, 1, -1)
-	var/tturf = get_turf(target)
+	var/tturf = get_turf(ttarget)
 	new /obj/effect/goliath_tentacle/original(tturf)
 	ranged_cooldown = ranged_cooldown_cap
 	return

--- a/code/modules/mob/living/simple_animal/hostile/monster.dm
+++ b/code/modules/mob/living/simple_animal/hostile/monster.dm
@@ -15,9 +15,8 @@
 	attacktext = "slashes"
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	faction = "creature"
-	speed = 4
 	size = SIZE_BIG
-	move_to_delay = 4
+	speed = 4
 	canRegenerate = 1
 	minRegenTime = 300
 	maxRegenTime = 1200
@@ -57,7 +56,7 @@
 	projectiletype = /obj/item/projectile/energy/neurotox
 	projectilesound = 'sound/weapons/pierce.ogg'
 	ranged = 1
-	move_to_delay = 7
+	speed = 7
 
 /obj/item/projectile/energy/neurotox
 	damage = 10
@@ -80,7 +79,7 @@
 	melee_damage_lower = 5
 	melee_damage_upper = 15
 	attacktext = "flails around and hits"
-	move_to_delay = 5
+	speed = 5
 	can_butcher = 0
 	attack_sound = 'sound/weapons/hivehand_empty.ogg'
 

--- a/code/modules/mob/living/simple_animal/hostile/mushroom.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mushroom.dm
@@ -48,7 +48,7 @@
 	melee_damage_lower += rand(3, 5)
 	melee_damage_upper += rand(10,20)
 	maxHealth += rand(40,60)
-	move_to_delay = rand(2,10)
+	speed = rand(2,10)
 	var/cap_color = rgb(rand(0, 255), rand(0, 255), rand(0, 255))
 	cap_living = image('icons/mob/animal.dmi',icon_state = "mushroom_cap")
 	cap_dead = image('icons/mob/animal.dmi',icon_state = "mushroom_cap_dead")

--- a/code/modules/mob/living/simple_animal/hostile/necro.dm
+++ b/code/modules/mob/living/simple_animal/hostile/necro.dm
@@ -13,8 +13,7 @@
 	response_help = "pets the"
 	response_disarm = "gently pushes aside the"
 	response_harm = "hits the"
-	speed = 8
-	move_to_delay = 3
+	speed = 3
 	maxHealth = 50
 	health = 50
 
@@ -52,8 +51,7 @@
 	response_help = "pets the"
 	response_disarm = "gently pushes aside the"
 	response_harm = "hits the"
-	speed = 2
-	move_to_delay = 6
+	speed = 6
 	maxHealth = 100
 	health = 100
 	canRegenerate = 1

--- a/html/changelogs/unid-mom.yml
+++ b/html/changelogs/unid-mom.yml
@@ -1,0 +1,7 @@
+author: Unid
+
+delete-after: True
+
+changes: 
+- tweak: "Player-controlled simple animals now move at the same speed as NPC simple animals."
+- tweak: "Ranged attacks of simple animals (such as goliath tentacles, hivelord summons and spider queen web) can now be used by players."


### PR DESCRIPTION
- Removed the _move_to_delay_ var, replaced the instances with _speed_ - this makes player controlled animals and NPCs move at the same speed (player goliaths and mummies are painfully slow now)
- You can now use mobs' ranged attacks by clicking

![heaaa](https://cloud.githubusercontent.com/assets/9512290/17184331/ee540b9a-542b-11e6-8347-2c0f45c9aec4.gif)
