### PR TITLE
Adds spell power upgrades for fireball, shoe snatching charm and summon robes. Spell channeling for wizard spells

### DIFF
--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -163,7 +163,8 @@
 				smoke = "Smoke", blind = "Blind", subjugation = "Subjugation", mindswap = "Mind Transfer", forcewall = "Forcewall", blink = "Blink", teleport = "Teleport", mutate = "Mutate",
 				etherealjaunt = "Ethereal Jaunt", knock = "Knock", horseman = "Curse of the Horseman", frenchcurse = "The French Curse", summonguns = "Summon Guns", staffchange = "Staff of Change",
 				mentalfocus = "Mental Focus", soulstone = "Six Soul Stone Shards and the spell Artificer", armor = "Mastercrafted Armor Set", staffanimate = "Staff of Animation", noclothes = "No Clothes",
-				fleshtostone = "Flesh to Stone", arsenath = "Butt-Bot's Revenge", timestop = "Time Stop", bundle = "Spellbook Bundle")
+				fleshtostone = "Flesh to Stone", arsenath = "Butt-Bot's Revenge", timestop = "Time Stop", bundle = "Spellbook Bundle", shoesnatch = "Shoe Snatching Charm", robesummon = "Summon Robes",\
+				)
 				var/already_knows = 0
 				for(var/spell/aspell in H.spell_list)
 					if(available_spells[href_list["spell_choice"]] == initial(aspell.name))

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -76,7 +76,7 @@
 			<A href='byond://?src=\ref[src];spell_choice=clowncurse'>The Clown Curse</A> (30)<BR>
 			<I>This spell turns an adjacent target into a miserable clown. This spell does not require robes to cast.</I><BR>
 			<A href='byond://?src=\ref[src];spell_choice=shoesnatch'>Shoe Snatching Charm</A> (15)<BR>
-			<I>This spell will remove your victim's shoes and materialize them in your hands. This spell does not require robes to cast. Upgrading spell power causes the spell to summon glass shards around the victim.</I><BR>
+			<I>This spell will remove your victim's shoes and materialize them in your hands. This spell does not require robes to cast. Upgrading spell power causes the spell to summon glass shards around the victim, if they were wearing shoes.</I><BR>
 			<A href='byond://?src=\ref[src];spell_choice=robesummon'>Summon Robes</A> (50)<BR>
 			<I>This spell will allow you to summon a new set of robes. Useful for stealthy wizards. This spell (quite obviously) does not require robes to cast. Upgrading spell power lets you summon a gem-encrusted hardsuit with an oxygen tank and a breath mask.</I><BR>
 			<A href='byond://?src=\ref[src];spell_choice=fleshtostone'>Flesh to Stone</A> (60)<BR>

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -42,7 +42,7 @@
 			<A href='byond://?src=\ref[src];spell_choice=magicmissile'>Magic Missile</A> (10)<BR>
 			<I>This spell fires several, slow moving, magic projectiles at nearby targets. If they hit a target, it is paralyzed and takes minor damage.</I><BR>
 			<A href='byond://?src=\ref[src];spell_choice=fireball'>Fireball</A> (10)<BR>
-			<I>This spell fires a fireball in the direction you're facing and does not require wizard garb. Be careful not to fire it at people that are standing next to you.</I><BR>
+			<I>This spell fires a fireball in the direction you're facing and does not require wizard garb. Be careful not to fire it at people that are standing next to you. Upgrading spell power makes Fireball targetable.</I><BR>
 			<A href='byond://?src=\ref[src];spell_choice=lightning'>Lightning</A> (20)<BR>
 			<I>Become Zeus and throw lightning at your foes, once you've charged the spell focus it upon any being to unleash electric fury. Upgrading this will cause your lightning to arc.</I><BR>
 			<A href='byond://?src=\ref[src];spell_choice=disabletech'>Disable Technology</A> (60)<BR>
@@ -76,9 +76,9 @@
 			<A href='byond://?src=\ref[src];spell_choice=clowncurse'>The Clown Curse</A> (30)<BR>
 			<I>This spell turns an adjacent target into a miserable clown. This spell does not require robes to cast.</I><BR>
 			<A href='byond://?src=\ref[src];spell_choice=shoesnatch'>Shoe Snatching Charm</A> (15)<BR>
-			<I>This spell will remove your victim's shoes and materialize them in your hands. This spell does not require robes to cast.</I><BR>
+			<I>This spell will remove your victim's shoes and materialize them in your hands. This spell does not require robes to cast. Upgrading spell power causes the spell to summon glass shards around the victim.</I><BR>
 			<A href='byond://?src=\ref[src];spell_choice=robesummon'>Summon Robes</A> (50)<BR>
-			<I>This spell will allow you to summon a new set of robes. Useful for stealthy wizards. This spell (quite obviously) does not require robes to cast.</I><BR>
+			<I>This spell will allow you to summon a new set of robes. Useful for stealthy wizards. This spell (quite obviously) does not require robes to cast. Upgrading spell power lets you summon a gem-encrusted hardsuit with an oxygen tank and a breath mask.</I><BR>
 			<A href='byond://?src=\ref[src];spell_choice=fleshtostone'>Flesh to Stone</A> (60)<BR>
 			<I>This spell will curse a person to immediately turn into an unmoving statue. The effect will eventually wear off if the statue is not destroyed.</I><BR>
 			<A href='byond://?src=\ref[src];spell_choice=arsenath'>Butt-Bot's Revenge</A> (50)<BR>

--- a/code/modules/spells/spell_projectile.dm
+++ b/code/modules/spells/spell_projectile.dm
@@ -21,7 +21,7 @@
 	if(!isnull(src.loc))
 		if(carried)
 			var/list/targets = choose_prox_targets(user = carried.holder, spell_holder = src)
-			if(targets.len)
+			if(targets && targets.len)
 				src.prox_cast(targets)
 		if(proj_trail && src && src.loc) //pretty trails
 			var/obj/effect/overlay/trail = getFromPool(/obj/effect/overlay, src.loc)
@@ -49,7 +49,10 @@
 	return
 
 /obj/item/projectile/spell_projectile/proc/choose_prox_targets(user = carried.holder, spell_holder = src)
-	return carried.choose_prox_targets(args)
+	if(!carried)
+		return
+
+	return carried.choose_prox_targets(arglist(args))
 
 /obj/item/projectile/spell_projectile/seeking
 	name = "seeking spell"

--- a/code/modules/spells/targeted/buttbots_revenge.dm
+++ b/code/modules/spells/targeted/buttbots_revenge.dm
@@ -4,7 +4,7 @@
 
 	school = "evocation"
 	charge_max = 500
-	spell_flags = NEEDSCLOTHES | SELECTABLE
+	spell_flags = NEEDSCLOTHES | WAIT_FOR_CLICK
 	invocation = "ARSE NATH"
 	invocation_type = SpI_SHOUT
 	range = 1

--- a/code/modules/spells/targeted/equip/clowncurse.dm
+++ b/code/modules/spells/targeted/equip/clowncurse.dm
@@ -7,7 +7,7 @@
 	invocation = "L' C'MMEDIA E F'NITA!"
 	invocation_type = SpI_SHOUT
 	range = 1
-	spell_flags = 0 //SELECTABLE hinders you here, since the spell has a range of 1 and only works on adjacent guys. Having the TARGETTED flag here makes it easy for your target to run away from you!
+	spell_flags = WAIT_FOR_CLICK //SELECTABLE hinders you here, since the spell has a range of 1 and only works on adjacent guys. Having the TARGETTED flag here makes it easy for your target to run away from you!
 
 	cooldown_min = 50
 

--- a/code/modules/spells/targeted/equip/frenchcurse.dm
+++ b/code/modules/spells/targeted/equip/frenchcurse.dm
@@ -7,7 +7,7 @@
 	invocation = "FU'K Y'U D'NY"
 	invocation_type = SpI_SHOUT
 	range = 1
-	spell_flags = 0 //SELECTABLE hinders you here, since the spell has a range of 1 and only works on adjacent guys. Having the TARGETTED flag here makes it easy for your target to run away from you!
+	spell_flags = WAIT_FOR_CLICK //SELECTABLE hinders you here, since the spell has a range of 1 and only works on adjacent guys. Having the TARGETTED flag here makes it easy for your target to run away from you!
 	cooldown_min = 50
 
 	sparks_spread = 1

--- a/code/modules/spells/targeted/equip/horsemask.dm
+++ b/code/modules/spells/targeted/equip/horsemask.dm
@@ -11,6 +11,7 @@
 	max_targets = 1
 	cooldown_min = 30 //30 deciseconds reduction per rank
 	selection_type = "range"
+	spell_flags = WAIT_FOR_CLICK
 
 	compatible_mobs = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 

--- a/code/modules/spells/targeted/equip/robesummon.dm
+++ b/code/modules/spells/targeted/equip/robesummon.dm
@@ -1,13 +1,15 @@
 /spell/targeted/equip_item/robesummon
-	name = "Summon Robes	"
+	name = "Summon Robes"
 	desc = "A spell which will summon you a new set of robes."
 
 	school = "evocation"
 	charge_max = 300
+
+	level_max = list(Sp_TOTAL = 5, Sp_SPEED = 4, Sp_POWER = 1)
 	invocation = "I PUT ON MY ROBE AND WIZARD HAT!"
 	invocation_type = SpI_SHOUT
 	range = -1
-	spell_flags = INCLUDEUSER //SELECTABLE hinders you here, since the spell has a range of 1 and only works on adjacent guys. Having the TARGETTED flag here makes it easy for your target to run away from you!
+	spell_flags = INCLUDEUSER | Z2NOCAST //z2nocast to prevent wizards from summoning the spacesuit and getting a refund
 
 	delete_old = 0 //Players shouldn't lose their hardsuits because they decided to summon some robes.
 
@@ -17,9 +19,11 @@
 
 	hud_state = "wiz_robesummon"
 
+	var/list/valid_outfits = list("blue", "red", "marisa")
+
 
 /spell/targeted/equip_item/robesummon/cast(list/targets, mob/user = usr)
-	switch(pick("blue","red","marisa"))
+	switch(pick(valid_outfits))
 
 		if ("blue")
 			equipped_summons = list("[slot_head]" = /obj/item/clothing/head/wizard,
@@ -36,7 +40,24 @@
 									"[slot_wear_suit]" = /obj/item/clothing/suit/wizrobe/marisa,
 									"[slot_shoes]" = /obj/item/clothing/shoes/sandal/marisa)
 
-	usr.visible_message("<span class='danger'>[usr] puts on his robe and wizard hat!</span>", \
+		if("suit")
+			equipped_summons = list("[slot_head]" = /obj/item/clothing/head/helmet/space/rig/wizard,
+									"[slot_wear_suit]" = /obj/item/clothing/suit/space/rig/wizard,
+									"[slot_shoes]" = /obj/item/clothing/shoes/sandal,
+									"[slot_wear_mask]" = /obj/item/clothing/mask/breath,
+									"[slot_s_store]" = /obj/item/weapon/tank/oxygen/yellow)
+
+	usr.visible_message("<span class='danger'>[user] puts on \his robe and wizard hat!</span>", \
 						"<span class='danger'>You put on your robe and wizard hat!</span>")
 
 	..()
+
+/spell/targeted/equip_item/robesummon/empower_spell()
+	if(!valid_outfits.Find("suit"))
+		valid_outfits = list("suit")
+		spell_levels[Sp_POWER]++
+
+	name = "Summon Hardsuit"
+	desc = "A spell which will summon you a wizard hardsuit."
+	delete_old = 1
+	return "You have improved Summon Robes into [name]. It will now summon a gem-encrusted hardsuit with internals."

--- a/code/modules/spells/targeted/equip/robesummon.dm
+++ b/code/modules/spells/targeted/equip/robesummon.dm
@@ -1,3 +1,8 @@
+#define ROBES_BLUE "blue"
+#define ROBES_RED "red"
+#define ROBES_MARISA "marisa"
+#define ROBES_SUIT "suit"
+
 /spell/targeted/equip_item/robesummon
 	name = "Summon Robes"
 	desc = "A spell which will summon you a new set of robes."
@@ -19,28 +24,28 @@
 
 	hud_state = "wiz_robesummon"
 
-	var/list/valid_outfits = list("blue", "red", "marisa")
+	var/list/valid_outfits = list(ROBES_BLUE, ROBES_RED, ROBES_MARISA)
 
 
 /spell/targeted/equip_item/robesummon/cast(list/targets, mob/user = usr)
 	switch(pick(valid_outfits))
 
-		if ("blue")
+		if (ROBES_BLUE)
 			equipped_summons = list("[slot_head]" = /obj/item/clothing/head/wizard,
 									"[slot_wear_suit]" = /obj/item/clothing/suit/wizrobe,
 									"[slot_shoes]" = /obj/item/clothing/shoes/sandal)
 
-		if ("red")
+		if (ROBES_RED)
 			equipped_summons = list("[slot_head]" = /obj/item/clothing/head/wizard/red,
 									"[slot_wear_suit]" = /obj/item/clothing/suit/wizrobe/red,
 									"[slot_shoes]" = /obj/item/clothing/shoes/sandal)
 
-		if("marisa")
+		if(ROBES_MARISA)
 			equipped_summons = list("[slot_head]" = /obj/item/clothing/head/wizard/marisa,
 									"[slot_wear_suit]" = /obj/item/clothing/suit/wizrobe/marisa,
 									"[slot_shoes]" = /obj/item/clothing/shoes/sandal/marisa)
 
-		if("suit")
+		if(ROBES_SUIT)
 			equipped_summons = list("[slot_head]" = /obj/item/clothing/head/helmet/space/rig/wizard,
 									"[slot_wear_suit]" = /obj/item/clothing/suit/space/rig/wizard,
 									"[slot_shoes]" = /obj/item/clothing/shoes/sandal,
@@ -53,11 +58,16 @@
 	..()
 
 /spell/targeted/equip_item/robesummon/empower_spell()
-	if(!valid_outfits.Find("suit"))
-		valid_outfits = list("suit")
+	if(!valid_outfits.Find(ROBES_SUIT))
+		valid_outfits = list(ROBES_SUIT)
 		spell_levels[Sp_POWER]++
 
 	name = "Summon Hardsuit"
 	desc = "A spell which will summon you a wizard hardsuit."
 	delete_old = 1
 	return "You have improved Summon Robes into [name]. It will now summon a gem-encrusted hardsuit with internals."
+
+#undef ROBES_BLUE
+#undef ROBES_RED
+#undef ROBES_MARISA
+#undef ROBES_SUIT

--- a/code/modules/spells/targeted/genetic.dm
+++ b/code/modules/spells/targeted/genetic.dm
@@ -34,14 +34,14 @@ code\game\\dna\genes\goon_powers.dm
 
 	charge_max = 300
 
-	spell_flags = 0
+	spell_flags = WAIT_FOR_CLICK
 	invocation = "STI KALY"
 	invocation_type = SpI_WHISPER
 	message = "<span class='danger'>Your eyes cry out in pain!</span>"
 	cooldown_min = 50
 
 	range = 7
-	max_targets = 0
+	max_targets = 1
 
 	amt_eye_blind = 10
 	amt_eye_blurry = 20

--- a/code/modules/spells/targeted/projectile/dumbfire.dm
+++ b/code/modules/spells/targeted/projectile/dumbfire.dm
@@ -1,13 +1,18 @@
 /spell/targeted/projectile/dumbfire
 	name = "dumbfire spell"
 
-/spell/targeted/projectile/dumbfire/choose_targets(mob/user = usr)
-	var/list/targets = list()
+	var/dumbfire = 1
 
-	var/starting_dir = user.dir //where are we facing at the time of casting?
-	var/turf/starting_turf = get_turf(user)
-	var/current_turf = starting_turf
-	for(var/i = 1; i <= src.range; i++)
-		current_turf = get_step(current_turf, starting_dir)
-	targets += current_turf
-	return targets
+/spell/targeted/projectile/dumbfire/choose_targets(mob/user = usr)
+	if(dumbfire)
+		var/list/targets = list()
+
+		var/starting_dir = user.dir //where are we facing at the time of casting?
+		var/turf/starting_turf = get_turf(user)
+		var/current_turf = starting_turf
+		for(var/i = 1; i <= src.range; i++)
+			current_turf = get_step(current_turf, starting_dir)
+		targets += current_turf
+		return targets
+	else
+		return ..()

--- a/code/modules/spells/targeted/projectile/fireball.dm
+++ b/code/modules/spells/targeted/projectile/fireball.dm
@@ -25,11 +25,7 @@
 	var/ex_light = 2
 	var/ex_flash = 5
 
-	level_max = list(Sp_TOTAL = 7, Sp_SPEED = 4, Sp_POWER = 1)
-
-	var/list/explosion_by_power = list( //Explosion stats corresponding to the spell's power level. Level 1 explosion is the first list (-1,1,2), level 2 is the second, ...
-		list(-1, 1, 2, 5)
-	)
+	level_max = list(Sp_TOTAL = 5, Sp_SPEED = 4, Sp_POWER = 1)
 
 	hud_state = "wiz_fireball"
 
@@ -41,16 +37,9 @@
 
 /spell/targeted/projectile/dumbfire/fireball/empower_spell()
 	spell_levels[Sp_POWER]++
-	var/power_level = min(spell_levels[Sp_POWER], 3)
-	var/list/new_explosion_stats = explosion_by_power[power_level]
-
-	ex_severe = new_explosion_stats[1]
-	ex_heavy = new_explosion_stats[2]
-	ex_light = new_explosion_stats[3]
-	ex_flash = new_explosion_stats[4]
 
 	var/explosion_description = ""
-	switch(power_level)
+	switch(spell_levels[Sp_POWER])
 		if(0)
 			name = "Fireball"
 			explosion_description = "It will now create a small explosion."
@@ -59,6 +48,8 @@
 			explosion_description = "The fireball will no longer only fly in the direction you're facing. Now you're able to shoot it wherever you want."
 			spell_flags |= WAIT_FOR_CLICK
 			dumbfire = 0
+		else
+			return
 
 	return "You have improved Fireball into [name]. [explosion_description]"
 

--- a/code/modules/spells/targeted/projectile/fireball.dm
+++ b/code/modules/spells/targeted/projectile/fireball.dm
@@ -25,12 +25,50 @@
 	var/ex_light = 2
 	var/ex_flash = 5
 
+	level_max = list(Sp_TOTAL = 7, Sp_SPEED = 4, Sp_POWER = 1)
+
+	var/list/explosion_by_power = list( //Explosion stats corresponding to the spell's power level. Level 1 explosion is the first list (-1,1,2), level 2 is the second, ...
+		list(-1, 1, 2, 5)
+	)
+
 	hud_state = "wiz_fireball"
 
 /spell/targeted/projectile/dumbfire/fireball/prox_cast(var/list/targets, spell_holder)
 	for(var/mob/living/M in targets)
 		apply_spell_damage(M)
 	explosion(get_turf(spell_holder), ex_severe, ex_heavy, ex_light, ex_flash)
+	return targets
+
+/spell/targeted/projectile/dumbfire/fireball/empower_spell()
+	spell_levels[Sp_POWER]++
+	var/power_level = min(spell_levels[Sp_POWER], 3)
+	var/list/new_explosion_stats = explosion_by_power[power_level]
+
+	ex_severe = new_explosion_stats[1]
+	ex_heavy = new_explosion_stats[2]
+	ex_light = new_explosion_stats[3]
+	ex_flash = new_explosion_stats[4]
+
+	var/explosion_description = ""
+	switch(power_level)
+		if(0)
+			name = "Fireball"
+			explosion_description = "It will now create a small explosion."
+		if(1)
+			name = "Controlled Fireball"
+			explosion_description = "The fireball will no longer only fly in the direction you're facing. Now you're able to shoot it wherever you want."
+			spell_flags |= WAIT_FOR_CLICK
+			dumbfire = 0
+
+	return "You have improved Fireball into [name]. [explosion_description]"
+
+/spell/targeted/projectile/dumbfire/fireball/is_valid_target(var/atom/target)
+	if(!istype(target))
+		return 0
+	if(target == holder)
+		return 0
+
+	return (isturf(target) || isturf(target.loc))
 
 //PROJECTILE
 

--- a/code/modules/spells/targeted/shoesnatch.dm
+++ b/code/modules/spells/targeted/shoesnatch.dm
@@ -32,8 +32,10 @@
 									"<span class='danger'>Your shoes suddenly vanish!</span>")
 			user.put_in_active_hand(old_shoes)
 
-			if(spawn_shards)
-				summon_shards(get_turf(target), cardinal)
+		else if(spawn_shards) //Spawn shards if the target isn't wearing shoes
+			to_chat("<span class='danger'>You conjure several glass shards around \the [target].</span>")
+			target.show_message("<span class='danger'>You are surrounded by glass shards!</span>", MESSAGE_SEE)
+			summon_shards(get_turf(target), cardinal)
 
 /spell/targeted/shoesnatch/proc/summon_shards(turf/T, list/dirlist)
 	for(var/D in dirlist)
@@ -44,10 +46,10 @@
 
 /spell/targeted/shoesnatch/empower_spell()
 	spell_levels[Sp_POWER]++
-	spawn_shards++
+	spawn_shards = 1
 
-	var/upgrade_desc = "You have upgraded [name] into Shoe Snatching Scourge. Whenever it successfully removes shoes from the victim, it will also surround them with 4 glass shards."
+	var/upgrade_desc = "You have upgraded [name] into Shoe Snatching Scourge. When cast on somebody who isn't wearing any shoes, it will summon 4 glass shards around them."
 	name = "Shoe Snatching Scourge"
-	desc = "This spell allows you to steal somebody's shoes right off of their feet. If you successfully steal the shoes, 4 glass shards will surround the victim."
+	desc = "This spell allows you to steal somebody's shoes right off of their feet. If they aren't wearing any shoes, 4 glass shards will be conjured around them."
 
 	return upgrade_desc

--- a/code/modules/spells/targeted/shoesnatch.dm
+++ b/code/modules/spells/targeted/shoesnatch.dm
@@ -1,7 +1,3 @@
-#define SPAWN_SHARDS_DISABLED 0
-#define SPAWN_SHARDS_WEAK 1
-#define SPAWN_SHARDS_STRONG 2
-
 /spell/targeted/shoesnatch
 
 	name = "Shoe Snatching Charm"
@@ -17,12 +13,12 @@
 	cooldown_min = 30
 	selection_type = "range"
 
-	level_max = list(Sp_TOTAL = 6, Sp_SPEED = 4, Sp_POWER = 2)
+	level_max = list(Sp_TOTAL = 5, Sp_SPEED = 4, Sp_POWER = 1)
 	compatible_mobs = list(/mob/living/carbon/human)
 
 	hud_state = "wiz_shoes"
 
-	var/spawn_shards = SPAWN_SHARDS_DISABLED
+	var/spawn_shards = 0
 
 /spell/targeted/shoesnatch/cast(list/targets, mob/user = user)
 	..()
@@ -36,12 +32,8 @@
 									"<span class='danger'>Your shoes suddenly vanish!</span>")
 			user.put_in_active_hand(old_shoes)
 
-		switch(spawn_shards)
-			if(SPAWN_SHARDS_WEAK) //Spawn 4 shards if shoes were stolen
-				if(old_shoes)
-					summon_shards(get_turf(target), cardinal)
-			if(SPAWN_SHARDS_STRONG) //Spawn 8 shards always
-				summon_shards(get_turf(target), alldirs)
+			if(spawn_shards)
+				summon_shards(get_turf(target), cardinal)
 
 /spell/targeted/shoesnatch/proc/summon_shards(turf/T, list/dirlist)
 	for(var/D in dirlist)
@@ -54,19 +46,8 @@
 	spell_levels[Sp_POWER]++
 	spawn_shards++
 
-	var/upgrade_desc = "You have upgraded [name]."
-	switch(spawn_shards)
-		if(SPAWN_SHARDS_WEAK)
-			upgrade_desc = "You have upgraded [name] into Shoe Snatching Scourge. Whenever it successfully removes shoes from the victim, it will also surround them with 4 glass shards."
-			name = "Shoe Snatching Scourge"
-			desc = "This spell allows you to steal somebody's shoes right off of their feet. If you successfully steal the shoes, 4 glass shards will surround the victim."
-		if(SPAWN_SHARDS_STRONG)
-			upgrade_desc = "You have upgraded [name] into Super Shoe Snatching Scourge. The amount of summoned glass shards has been increased to 8, and they will always appear - even if the victim wasn't wearing any shoes."
-			name = "Super Shoe Snatching Scourge"
-			desc = "This spell allows you to steal somebody's shoes right off of their feet. In addition, 8 glass shards will surround the victim - even if they weren't wearing any shoes."
+	var/upgrade_desc = "You have upgraded [name] into Shoe Snatching Scourge. Whenever it successfully removes shoes from the victim, it will also surround them with 4 glass shards."
+	name = "Shoe Snatching Scourge"
+	desc = "This spell allows you to steal somebody's shoes right off of their feet. If you successfully steal the shoes, 4 glass shards will surround the victim."
 
 	return upgrade_desc
-
-#undef SPAWN_SHARDS_DISABLED
-#undef SPAWN_SHARDS_WEAK
-#undef SPAWN_SHARDS_STRONG

--- a/code/modules/spells/targeted/shoesnatch.dm
+++ b/code/modules/spells/targeted/shoesnatch.dm
@@ -1,3 +1,7 @@
+#define SPAWN_SHARDS_DISABLED 0
+#define SPAWN_SHARDS_WEAK 1
+#define SPAWN_SHARDS_STRONG 2
+
 /spell/targeted/shoesnatch
 
 	name = "Shoe Snatching Charm"
@@ -13,12 +17,12 @@
 	cooldown_min = 30
 	selection_type = "range"
 
-	level_max = list(Sp_TOTAL = 5, Sp_SPEED = 4, Sp_POWER = 1)
+	level_max = list(Sp_TOTAL = 6, Sp_SPEED = 4, Sp_POWER = 2)
 	compatible_mobs = list(/mob/living/carbon/human)
 
 	hud_state = "wiz_shoes"
 
-	var/spawn_shards = 0
+	var/spawn_shards = SPAWN_SHARDS_DISABLED
 
 /spell/targeted/shoesnatch/cast(list/targets, mob/user = user)
 	..()
@@ -32,17 +36,37 @@
 									"<span class='danger'>Your shoes suddenly vanish!</span>")
 			user.put_in_active_hand(old_shoes)
 
-		if(spawn_shards)
-			for(var/D in alldirs)
-				var/obj/item/weapon/shard/S = new(get_turf(target))
-				step(S, D)
-				S.alpha = 0
-				animate(S, alpha = 255, time = 10)
+		switch(spawn_shards)
+			if(SPAWN_SHARDS_WEAK) //Spawn 4 shards if shoes were stolen
+				if(old_shoes)
+					summon_shards(get_turf(target), cardinal)
+			if(SPAWN_SHARDS_STRONG) //Spawn 8 shards always
+				summon_shards(get_turf(target), alldirs)
+
+/spell/targeted/shoesnatch/proc/summon_shards(turf/T, list/dirlist)
+	for(var/D in dirlist)
+		var/obj/item/weapon/shard/S = new(T)
+		step(S, D)
+		S.alpha = 0
+		animate(S, alpha = 255, time = 10)
 
 /spell/targeted/shoesnatch/empower_spell()
 	spell_levels[Sp_POWER]++
-	spawn_shards = 1
+	spawn_shards++
 
-	name = "Shoe Snatching Scourge"
-	desc = "This spell allows you to steal somebody's shoes right off of their feet and surround them with glass shards."
-	return "You have improved Shoe Snatching Charm into [name]. It will now summon 8 glass shards around the victim in addition to stealing their shoes."
+	var/upgrade_desc = "You have upgraded [name]."
+	switch(spawn_shards)
+		if(SPAWN_SHARDS_WEAK)
+			upgrade_desc = "You have upgraded [name] into Shoe Snatching Scourge. Whenever it successfully removes shoes from the victim, it will also surround them with 4 glass shards."
+			name = "Shoe Snatching Scourge"
+			desc = "This spell allows you to steal somebody's shoes right off of their feet. If you successfully steal the shoes, 4 glass shards will surround the victim."
+		if(SPAWN_SHARDS_STRONG)
+			upgrade_desc = "You have upgraded [name] into Super Shoe Snatching Scourge. The amount of summoned glass shards has been increased to 8, and they will always appear - even if the victim wasn't wearing any shoes."
+			name = "Super Shoe Snatching Scourge"
+			desc = "This spell allows you to steal somebody's shoes right off of their feet. In addition, 8 glass shards will surround the victim - even if they weren't wearing any shoes."
+
+	return upgrade_desc
+
+#undef SPAWN_SHARDS_DISABLED
+#undef SPAWN_SHARDS_WEAK
+#undef SPAWN_SHARDS_STRONG

--- a/code/modules/spells/targeted/shoesnatch.dm
+++ b/code/modules/spells/targeted/shoesnatch.dm
@@ -1,7 +1,7 @@
 /spell/targeted/shoesnatch
 
 	name = "Shoe Snatching Charm"
-	desc = "This spell will allow you to steal somebodies shoes right off of their feet!"
+	desc = "This spell allows you to steal somebody's shoes right off of their feet!"
 	school = "evocation"
 	charge_type = Sp_RECHARGE
 	charge_max = 150
@@ -9,13 +9,16 @@
 	invocation_type = SpI_SHOUT
 	range = 7
 	max_targets = 1
+	spell_flags = WAIT_FOR_CLICK
 	cooldown_min = 30
 	selection_type = "range"
 
+	level_max = list(Sp_TOTAL = 5, Sp_SPEED = 4, Sp_POWER = 1)
 	compatible_mobs = list(/mob/living/carbon/human)
 
 	hud_state = "wiz_shoes"
 
+	var/spawn_shards = 0
 
 /spell/targeted/shoesnatch/cast(list/targets, mob/user = user)
 	..()
@@ -28,3 +31,18 @@
 			target.visible_message(	"<span class='danger'>[target]'s shoes suddenly vanish!</span>", \
 									"<span class='danger'>Your shoes suddenly vanish!</span>")
 			user.put_in_active_hand(old_shoes)
+
+		if(spawn_shards)
+			for(var/D in alldirs)
+				var/obj/item/weapon/shard/S = new(get_turf(target))
+				step(S, D)
+				S.alpha = 0
+				animate(S, alpha = 255, time = 10)
+
+/spell/targeted/shoesnatch/empower_spell()
+	spell_levels[Sp_POWER]++
+	spawn_shards = 1
+
+	name = "Shoe Snatching Scourge"
+	desc = "This spell allows you to steal somebody's shoes right off of their feet and surround them with glass shards."
+	return "You have improved Shoe Snatching Charm into [name]. It will now summon 8 glass shards around the victim in addition to stealing their shoes."

--- a/code/modules/spells/targeted/subjugate.dm
+++ b/code/modules/spells/targeted/subjugate.dm
@@ -15,5 +15,6 @@
 	amt_stuttering = 86
 
 	compatible_mobs = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
+	spell_flags = WAIT_FOR_CLICK
 
 	hud_state = "wiz_subj"

--- a/html/changelogs/unid-magik.yml
+++ b/html/changelogs/unid-magik.yml
@@ -3,7 +3,7 @@ author: Unid
 delete-after: True
 
 changes: 
-- rscadd: You can now upgrade spell power of Summon Robes. Upgrading it makes the spell summon a gem encrusted hardsuit.
-- rscadd: You can now upgrade spell power of Shoe Snatching Charm. Upgrading it makes the spell summon 4 glass shards around the victim whenever it successfully removes shoes (meaning no glass is summoned if the victim had no shoes).
+- rscadd: You can now upgrade spell power of Summon Robes. Upgrading it makes the spell summon a gem encrusted hardsuit with internals.
+- rscadd: You can now upgrade spell power of Shoe Snatching Charm. Upgrading it makes the spell summon 4 glass shards when cast on somebody who isn't wearing shoes (glass won't be spawned if the victim is wearing shoes).
 - rscadd: You can now upgrade spell power of Fireball. Upgrading it makes fireball targettable, shooting it wherever you click.
 - tweak: Several spells are now controlled by clicking on the spell and then on the target, instead of choosing a target randomly or bringing up a menu. Among these spells are Arse Nath, Clown/Mime/Horse curses, Blind, Shoe Snatching Charm, Subjugate and Controlled Fireball.

--- a/html/changelogs/unid-magik.yml
+++ b/html/changelogs/unid-magik.yml
@@ -1,0 +1,9 @@
+author: Unid
+
+delete-after: True
+
+changes: 
+- rscadd: You can now upgrade spell power of Summon Robes. Upgrading it makes the spell summon a gem encrusted hardsuit.
+- rscadd: You can now upgrade spell power of Shoe Snatching Charm. Upgrading it makes the spell summon 8 glass shards around the target, in addition to removing shoes.
+- rscadd: You can now upgrade spell power of Fireball. Upgrading it makes fireball targettable, shooting it wherever you click.
+- tweak: Several spells are now controlled by clicking on the spell and then on the target, instead of choosing a target randomly or bringing up a menu. Among these spells are Arse Nath, Clown/Mime/Horse curses, Blind, Shoe Snatching Charm, Subjugate and Controlled Fireball.

--- a/html/changelogs/unid-magik.yml
+++ b/html/changelogs/unid-magik.yml
@@ -4,6 +4,6 @@ delete-after: True
 
 changes: 
 - rscadd: You can now upgrade spell power of Summon Robes. Upgrading it makes the spell summon a gem encrusted hardsuit.
-- rscadd: You can now upgrade spell power of Shoe Snatching Charm. Upgrading it makes the spell summon 8 glass shards around the target, in addition to removing shoes.
+- rscadd: You can now upgrade spell power of Shoe Snatching Charm. Upgrading it makes the spell summon 4 glass shards around the victim whenever it successfully removes shoes (meaning no glass is summoned if the victim had no shoes).
 - rscadd: You can now upgrade spell power of Fireball. Upgrading it makes fireball targettable, shooting it wherever you click.
 - tweak: Several spells are now controlled by clicking on the spell and then on the target, instead of choosing a target randomly or bringing up a menu. Among these spells are Arse Nath, Clown/Mime/Horse curses, Blind, Shoe Snatching Charm, Subjugate and Controlled Fireball.


### PR DESCRIPTION
- Upgrading fireball's power turns it into Controlled Fireball. Controlled Fireball flies at whatever you click, instead of whatever's in front of you.

Also fixed a horrible fireball runtime

![faerbol](https://cloud.githubusercontent.com/assets/9512290/17261345/8c5a1032-55d5-11e6-87b3-9f233f79fbe8.gif)
- Upgrading shoe snatching's charm power turns it into Shoe Snatching Scourge. When cast on somebody who isn't wearing shoes, it will summon 4 glass shards around them.

![shoes](https://cloud.githubusercontent.com/assets/9512290/17273442/0549d722-56b5-11e6-894e-6adbf53024ea.gif) (gif is outdated, shards only summon if victim isn't wearing shoes)
- Upgrading summon robes' power turns it into Summon Hardsuit. It summons a gem-encrusted hardsuit, breath mask and an oxygen tank.

(to prevent exploits, summon robes is no longer castable in the wizard's den)

![robes](https://cloud.githubusercontent.com/assets/9512290/17261421/eac46dd4-55d5-11e6-9d5f-2d9b72ef48fe.gif)

Many spells now use channeling (you have to click on the spell and then on your target) - Fixes #11096
