### PR TITLE
Morgue tray messages

### DIFF
--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -264,8 +264,6 @@
 						ghost << 'sound/effects/adminhelp.ogg'
 						to_chat(ghost, "<span class='interface'><b><font size = 3>Your corpse has been placed into a cloning scanner. Return to your body if you want to be resurrected/cloned!</b> \
 							(Verbs -> Ghost -> Re-enter corpse, or <a href='?src=\ref[ghost];reentercorpse=1'>click here!</a>)</font></span>")
-					else
-						ghost.canclone = M
 				break
 			break
 	return
@@ -292,6 +290,14 @@
 			C.update_icon()
 
 	return 1
+
+/obj/machinery/dna_scannernew/on_login(var/mob/M)
+	if(M.mind && !M.client && locate(/obj/machinery/computer/cloning) in range(src, 1)) //!M.client = mob has ghosted out of their body
+		var/mob/dead/observer/ghost = get_ghost_from_mind(M.mind)
+		if(ghost && ghost.client)
+			ghost << 'sound/effects/adminhelp.ogg'
+			to_chat(ghost, "<span class='interface'><b><font size = 3>Your corpse has been placed into a cloning scanner. Return to your body if you want to be resurrected/cloned!</b> \
+				(Verbs -> Ghost -> Re-enter corpse, or <a href='?src=\ref[src];reentercorpse=1'>click here!</a>)</font></span>")
 
 /obj/machinery/dna_scannernew/ex_act(severity)
 	//This is by far the oldest code I have ever seen, please appreciate how it's preserved in comments for distant posterity. Have some perspective of where we came from.
@@ -320,7 +326,7 @@
 		if(3.0)
 			if (prob(25))
 				for(var/atom/movable/A as mob|obj in src)
-					A.loc = src.loc
+					A.forceMove(src.loc)
 					ex_act(severity)
 					//Foreach goto(181)
 				//SN src = null

--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -262,8 +262,8 @@
 				if(ghost)
 					if(ghost.client && ghost.can_reenter_corpse)
 						ghost << 'sound/effects/adminhelp.ogg'
-						to_chat(ghost, "<span class='interface'><b><font size = 3>Your corpse has been placed into a cloning scanner. Return to your body if you want to be resurrected/cloned!</b> \
-							(Verbs -> Ghost -> Re-enter corpse, or <a href='?src=\ref[ghost];reentercorpse=1'>click here!</a>)</font></span>")
+						to_chat(ghost, "<span class='interface big'><span class='bold'>Your corpse has been placed into a cloning scanner. Return to your body if you want to be resurrected/cloned!</span> \
+							(Verbs -> Ghost -> Re-enter corpse, or <a href='?src=\ref[ghost];reentercorpse=1'>click here!</a>)</span>")
 				break
 			break
 	return
@@ -296,8 +296,8 @@
 		var/mob/dead/observer/ghost = get_ghost_from_mind(M.mind)
 		if(ghost && ghost.client)
 			ghost << 'sound/effects/adminhelp.ogg'
-			to_chat(ghost, "<span class='interface'><b><font size = 3>Your corpse has been placed into a cloning scanner. Return to your body if you want to be resurrected/cloned!</b> \
-				(Verbs -> Ghost -> Re-enter corpse, or <a href='?src=\ref[src];reentercorpse=1'>click here!</a>)</font></span>")
+			to_chat(ghost, "<span class='interface big'><span class='bold'>Your corpse has been placed into a cloning scanner. Return to your body if you want to be resurrected/cloned!</span> \
+				(Verbs -> Ghost -> Re-enter corpse, or <a href='?src=\ref[src];reentercorpse=1'>click here!</a>)</span>")
 
 /obj/machinery/dna_scannernew/ex_act(severity)
 	//This is by far the oldest code I have ever seen, please appreciate how it's preserved in comments for distant posterity. Have some perspective of where we came from.

--- a/code/game/machinery/podmen.dm
+++ b/code/game/machinery/podmen.dm
@@ -47,8 +47,8 @@ var/global/list/hasbeendiona = list() // Stores ckeys and a timestamp for ghost 
 			if(!source.client && source.mind)
 				var/mob/dead/observer/O = get_ghost_from_mind(source.mind)
 				if(O && O.client && config.revival_pod_plants)
-					to_chat(O, "<span class='interface'><b><font size = 3>Your blood has been placed into a replica pod seed. Return to your body if you want to be returned to life as a pod person!</b> \)
-						(Verbs -> Ghost -> Re-enter corpse, or <a href='?src=\ref[O];reentercorpse=1'>click here!</a>)</font></span>"
+					to_chat(O, "<span class='interface big'><span class='bold'>Your blood has been placed into a replica pod seed. Return to your body if you want to be returned to life as a pod person!</span> \)
+						(Verbs -> Ghost -> Re-enter corpse, or <a href='?src=\ref[O];reentercorpse=1'>click here!</a>)</span>"
 					break
 		else
 			to_chat(user, "Nothing happens.")

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -151,8 +151,8 @@
 			var/mob/dead/observer/ghost = get_ghost_from_mind(target.mind)
 			if(ghost && ghost.client && ghost.can_reenter_corpse)
 				ghost << 'sound/effects/adminhelp.ogg'
-				to_chat(ghost, "<span class='interface'><b><font size = 3>Someone is trying to revive your body. Return to it if you want to be resurrected!</b> \
-					(Verbs -> Ghost -> Re-enter corpse, or <a href='?src=\ref[ghost];reentercorpse=1'>click here!</a>)</font></span>")
+				to_chat(ghost, "<span class='interface big'><span class='bold'>Someone is trying to revive your body. Return to it if you want to be resurrected!</span> \
+					(Verbs -> Ghost -> Re-enter corpse, or <a href='?src=\ref[ghost];reentercorpse=1'>click here!</a>)</span>")
 				to_chat(user, "<span class='warning'>[src] buzzes: Defibrillation failed. Vital signs are too weak, please try again in five seconds.</span>")
 				return
 			//we couldn't find a suitable ghost.

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -358,12 +358,20 @@ a {
 	return 0
 
 /**
- * If a mob logouts/logins in side of an object you can use this proc.
+ * Called when a mob inside this obj's contents logs out.
  */
-/obj/proc/on_log()
-	if (isobj(loc))
+/obj/proc/on_logout(var/mob/M)
+	if(isobj(loc))
 		var/obj/location = loc
-		location.on_log()
+		location.on_logout(M)
+
+/**
+ * Called when a mob inside this obj's contents logs in.
+ */
+/obj/proc/on_login(var/mob/M)
+	if(isobj(loc))
+		var/obj/location = loc
+		location.on_login(M)
 
 // Dummy to give items special techlist for the purposes of the Device Analyser, in case you'd ever need them to give them different tech levels depending on special checks.
 /obj/proc/give_tech_list()

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -37,65 +37,87 @@
 		else
 			icon_state = "morgue1"
 
+/obj/structure/morgue/examine(mob/user)
+	..()
+	switch(icon_state)
+		if("morgue2")
+			to_chat(user, "<span class='info'>\The [src]'s light display indicates there is a catatonic corpse inside.</span>")
+		if("morgue3")
+			to_chat(user, "<span class='info'>\The [src]'s light display indicates there are items inside.</span>")
+		if("morgue4")
+			to_chat(user, "<span class='info'>\The [src]'s light display indicates there is an active corpse inside.</span>")
+
 /obj/structure/morgue/ex_act(severity)
 	switch(severity)
 		if(1.0)
-			for(var/atom/movable/A as mob|obj in src)
-				A.loc = src.loc
-				ex_act(severity)
+			for(var/atom/movable/A in src)
+				A.forceMove(src.loc)
+				A.ex_act(severity)
 			qdel(src)
 			return
 		if(2.0)
-			if (prob(50))
-				for(var/atom/movable/A as mob|obj in src)
-					A.loc = src.loc
-					ex_act(severity)
+			if(prob(50))
+				for(var/atom/movable/A in src)
+					A.forceMove(src.loc)
+					A.ex_act(severity)
 				qdel(src)
 				return
 		if(3.0)
-			if (prob(5))
-				for(var/atom/movable/A as mob|obj in src)
-					A.loc = src.loc
-					ex_act(severity)
+			if(prob(5))
+				for(var/atom/movable/A in src)
+					A.forceMove(src.loc)
+					A.ex_act(severity)
 				qdel(src)
 				return
-	return
 
-/obj/structure/morgue/alter_health()
+/obj/structure/morgue/alter_health() //???????????????
 	return src.loc
 
 /obj/structure/morgue/attack_paw(mob/user as mob)
 	return src.attack_hand(user)
 
 /obj/structure/morgue/attack_hand(mob/user as mob)
-	if (src.connected)
-		for(var/atom/movable/A as mob|obj in src.connected.loc)
-			if(istype(A, /mob/living/simple_animal/sculpture)) //I have no shame. Until someone rewrites this shitcode extroadinaire, I'll just snowflake over it
-				continue
-			if (!( A.anchored ))
-				A.loc = src
-		playsound(get_turf(src), 'sound/items/Deconstruct.ogg', 50, 1)
-		//src.connected = null
-		qdel(src.connected)
-		src.connected = null
+	if (connected)
+		close_up()
 	else
-		playsound(get_turf(src), 'sound/items/Deconstruct.ogg', 50, 1)
-		src.connected = new /obj/structure/m_tray( src.loc )
-		step(src.connected, src.dir)
-		src.connected.layer = OBJ_LAYER
-		var/turf/T = get_step(src, src.dir)
-		if (T.contents.Find(src.connected))
-			src.connected.connected = src
-			src.icon_state = "morgue0"
-			for(var/atom/movable/A as mob|obj in src)
-				A.loc = src.connected.loc
-			src.connected.icon_state = "morguet"
-			src.connected.dir = src.dir
-		else
-			qdel(src.connected)
-			src.connected = null
+		open_up()
 	src.add_fingerprint(user)
 	update()
+	return
+
+/obj/structure/morgue/proc/open_up()
+	playsound(get_turf(src), 'sound/items/Deconstruct.ogg', 50, 1)
+	connected = new /obj/structure/m_tray(loc)
+	connected.layer = OBJ_LAYER
+	step(connected, src.dir)
+	var/turf/T = get_step(src, src.dir)
+	if(T.contents.Find(connected))
+		src.connected.connected = src //like a dog chasing it's own tail
+		src.icon_state = "morgue0"
+		for(var/atom/movable/A as mob|obj in src)
+			A.forceMove(src.connected.loc)
+		connected.icon_state = "morguet"
+		connected.dir = src.dir
+	else
+		qdel(connected)
+		connected = null
+
+/obj/structure/morgue/proc/close_up()
+	if(!connected)
+		return
+	for(var/atom/movable/A as mob|obj in connected.loc)
+		if(istype(A, /mob/living/simple_animal/sculpture)) //I have no shame. Until someone rewrites this shitcode extroadinaire, I'll just snowflake over it
+			continue
+		if(!A.anchored)
+			A.forceMove(src)
+			if(ismob(A))
+				var/mob/M = A
+				if(M.mind && !M.client) //!M.client = mob has ghosted out of their body
+					var/mob/dead/observer/ghost = get_ghost_from_mind(M.mind)
+					if(ghost && ghost.client)
+						to_chat(ghost, "<span class='interface'><b><font size = 3>Your corpse has been placed into a morgue tray.</b></font> \
+							Re-entering your corpse will cause the tray's lights to turn green, which will let people know you're still there, and just maybe improve your chances of being revived. No promises.")
+	qdel(connected)
 
 /obj/structure/morgue/attackby(P as obj, mob/user as mob)
 	if(iscrowbar(P)&&!contents.len)
@@ -111,37 +133,38 @@
 		else
 			dir=4
 	if (istype(P, /obj/item/weapon/pen))
-		var/t = input(user, "What would you like the label to be?", text("[]", src.name), null)  as text
+		var/t = input(user, "What would you like the label to be?", text("[]", src.name), null) as text
 		if (user.get_active_hand() != P)
 			return
-		if (!Adjacent(user) || user.stat)
+		if (!Adjacent(user) || user.incapacitated())
 			return
 		t = copytext(sanitize(t),1,MAX_MESSAGE_LEN)
 		if (t)
-			src.name = text("Morgue- '[]'", t)
+			src.name = "morgue- '[t]'"
 		else
-			src.name = "Morgue"
+			src.name = initial(src.name)
 	src.add_fingerprint(user)
 
 /obj/structure/morgue/relaymove(mob/user as mob)
-	if (user.stat)
+	if (user.isUnconscious())
 		return
-	src.connected = new /obj/structure/m_tray( src.loc )
-	step(src.connected, EAST)
-	var/turf/T = get_step(src, EAST)
-	if (T.contents.Find(src.connected))
-		src.connected.connected = src
-		src.icon_state = "morgue0"
-		for(var/atom/movable/A as mob|obj in src)
-			A.loc = src.connected.loc
-			//Foreach goto(106)
-		src.connected.icon_state = "morguet"
-	else
-		//src.connected = null
-		qdel(src.connected)
+	open_up()
 
-/obj/structure/morgue/on_log()
+/obj/structure/morgue/on_login(var/mob/M)
 	update()
+	if(M.mind && !M.client) //!M.client = mob has ghosted out of their body
+		var/mob/dead/observer/ghost = get_ghost_from_mind(M.mind)
+		if(ghost && ghost.client)
+			to_chat(ghost, "<span class='interface'><b><font size = 3>Your corpse has been placed into a morgue tray.</b></font> \
+				Re-entering your corpse will cause the tray's lights to turn green, which will let people know you're still there, and just maybe improve your chances of being revived. No promises.")
+
+/obj/structure/morgue/on_logout(var/mob/M)
+	update()
+
+/obj/structure/morgue/Destroy()
+	. = ..()
+	if(connected)
+		qdel(connected) //references get cleared in the tray's Destroy()
 
 /*
  * Morgue tray
@@ -165,32 +188,26 @@
 	return src.attack_hand(user)
 
 /obj/structure/m_tray/attack_hand(mob/user as mob)
-	if (src.connected)
-		for(var/atom/movable/A as mob|obj in src.loc)
-			if(istype(A, /mob/living/simple_animal/sculpture)) //I have no shame. Until someone rewrites this shitcode extroadinaire, I'll just snowflake over it
-				continue
-			if (!( A.anchored ))
-				A.loc = src.connected
-			//Foreach goto(26)
-		src.connected.connected = null
-		src.connected.update()
-		add_fingerprint(user)
-		//SN src = null
-		qdel(src)
-		return
-	return
+	if(connected)
+		connected.close_up()
+	else
+		qdel(src) //this should not happen but if it does happen we should not be here
 
 /obj/structure/m_tray/MouseDrop_T(atom/movable/O as mob|obj, mob/user as mob)
-	if ((!( istype(O, /atom/movable) ) || O.anchored || get_dist(user, src) > 1 || get_dist(user, O) > 1 || user.contents.Find(src) || user.contents.Find(O)))
+	if (O.anchored || !Adjacent(user) || !Adjacent(O) || user.contents.Find(O))
 		return
 	if (!ismob(O) && !istype(O, /obj/structure/closet/body_bag))
 		return
-	O.loc = src.loc
+	O.forceMove(src.loc)
 	if (user != O)
-		for(var/mob/B in viewers(user, 3))
-			if ((B.client && !( B.blinded )))
-				to_chat(B, text("<span class='warning'>[] stuffs [] into []!</span>", user, O, src))
+		visible_message("<span class='warning'>[user] stuffs [O] into [src]!</span>")
 
+/obj/structure/m_tray/Destroy()
+	. = ..()
+	if(connected)
+		connected.connected = null
+		connected.update()
+		connected = null
 
 /*
  * Crematorium

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -41,11 +41,11 @@
 	..()
 	switch(icon_state)
 		if("morgue2")
-			to_chat(user, "<span class='info'>\The [src]'s light display indicates there is a catatonic corpse inside.</span>")
+			to_chat(user, "<span class='info'>\The [src]'s light display indicates there is an unrecoverable corpse inside.</span>")
 		if("morgue3")
 			to_chat(user, "<span class='info'>\The [src]'s light display indicates there are items inside.</span>")
 		if("morgue4")
-			to_chat(user, "<span class='info'>\The [src]'s light display indicates there is an active corpse inside.</span>")
+			to_chat(user, "<span class='info'>\The [src]'s light display indicates there is a potential clone candidate inside.</span>")
 
 /obj/structure/morgue/ex_act(severity)
 	switch(severity)
@@ -115,8 +115,8 @@
 				if(M.mind && !M.client) //!M.client = mob has ghosted out of their body
 					var/mob/dead/observer/ghost = get_ghost_from_mind(M.mind)
 					if(ghost && ghost.client)
-						to_chat(ghost, "<span class='interface'><b><font size = 3>Your corpse has been placed into a morgue tray.</b></font> \
-							Re-entering your corpse will cause the tray's lights to turn green, which will let people know you're still there, and just maybe improve your chances of being revived. No promises.")
+						to_chat(ghost, "<span class='interface'><span class='big bold'>Your corpse has been placed into a morgue tray.</span> \
+							Re-entering your corpse will cause the tray's lights to turn green, which will let people know you're still there, and just maybe improve your chances of being revived. No promises.</span>")
 	qdel(connected)
 
 /obj/structure/morgue/attackby(P as obj, mob/user as mob)
@@ -155,8 +155,8 @@
 	if(M.mind && !M.client) //!M.client = mob has ghosted out of their body
 		var/mob/dead/observer/ghost = get_ghost_from_mind(M.mind)
 		if(ghost && ghost.client)
-			to_chat(ghost, "<span class='interface'><b><font size = 3>Your corpse has been placed into a morgue tray.</b></font> \
-				Re-entering your corpse will cause the tray's lights to turn green, which will let people know you're still there, and just maybe improve your chances of being revived. No promises.")
+			to_chat(ghost, "<span class='interface'><span class='big bold'>Your corpse has been placed into a morgue tray.</span> \
+				Re-entering your corpse will cause the tray's lights to turn green, which will let people know you're still there, and just maybe improve your chances of being revived. No promises.</span>")
 
 /obj/structure/morgue/on_logout(var/mob/M)
 	update()
@@ -194,7 +194,7 @@
 		qdel(src) //this should not happen but if it does happen we should not be here
 
 /obj/structure/m_tray/MouseDrop_T(atom/movable/O as mob|obj, mob/user as mob)
-	if (O.anchored || !Adjacent(user) || !Adjacent(O) || user.contents.Find(O))
+	if (!istype(O) || O.anchored || !Adjacent(user) || !Adjacent(O) || user.contents.Find(O))
 		return
 	if (!ismob(O) && !istype(O, /obj/structure/closet/body_bag))
 		return

--- a/code/modules/medical/computer/cloning.dm
+++ b/code/modules/medical/computer/cloning.dm
@@ -409,7 +409,7 @@
 	if(M_NOCLONE in subject.mutations) //We cannot clone this guy because he's a husk, but maybe we can give a more informative message.
 		if(subject.client)
 			scantemp = "Error: Unable to locate valid genetic data. However, mental interface initialized successfully."
-			to_chat(subject, "<span class='interface'><b><font size = 3>Someone is trying to clone your corpse.</b></font> \
+			to_chat(subject, "<span class='interface'><span class='big bold'>Someone is trying to clone your corpse.</span> \
 				You cannot be cloned as your body has been husked. However, your brain may still be used. Your ghost has been displayed as active and inside your body.</span>")
 			return
 		else
@@ -417,8 +417,8 @@
 			if(ghost && ghost.client && ghost.can_reenter_corpse)
 				scantemp = "Error: Unable to locate valid genetic data. Additionally, subject's brain is not responding to scanning stimuli."
 				ghost << 'sound/effects/adminhelp.ogg'
-				to_chat(ghost, "<span class='interface'><b><font size = 3>Someone is trying to clone your corpse.</b></font> \
-					You cannot be cloned as your body has been husked. However, your brain may still be used. To show you're still active, return to your body! (Verbs -> Ghost -> Re-enter corpse, or <a href='?src=\ref[ghost];reentercorpse=1'>click here!</a>)</font></span>")
+				to_chat(ghost, "<span class='interface'><span class='big bold'>Someone is trying to clone your corpse.</span> \
+					You cannot be cloned as your body has been husked. However, your brain may still be used. To show you're still active, return to your body! (Verbs -> Ghost -> Re-enter corpse, or <a href='?src=\ref[ghost];reentercorpse=1'>click here!</a>)</span>")
 				return
 			else
 				scantemp = "Error: Unable to locate valid genetic data. Additionally, mental interface failed to initialize."
@@ -430,8 +430,8 @@
 		if(ghost && ghost.client && ghost.can_reenter_corpse) //Found this guy's ghost, and it still belongs to this corpse. There's nothing preventing this guy from being cloned, except them being ghosted
 			scantemp = "Error: Subject's brain is not responding to scanning stimuli, subject may be brain dead. Please try again in five seconds."
 			ghost << 'sound/effects/adminhelp.ogg'
-			to_chat(ghost, "<span class='interface'><b><font size = 3>Someone is trying to clone your corpse. Return to your body if you want to be cloned!</b> \
-				(Verbs -> Ghost -> Re-enter corpse, or <a href='?src=\ref[ghost];reentercorpse=1'>click here!</a>)</font></span>")
+			to_chat(ghost, "<span class='interface big'><span class='bold'>Someone is trying to clone your corpse. Return to your body if you want to be cloned!</span> \
+				(Verbs -> Ghost -> Re-enter corpse, or <a href='?src=\ref[ghost];reentercorpse=1'>click here!</a>)</span>")
 			return
 		else //No ghost matching this corpse. Guy probably either logged out or was revived by out-of-body means.
 			scantemp = "Error: Mental interface failure."

--- a/code/modules/mob/dead/observer/login.dm
+++ b/code/modules/mob/dead/observer/login.dm
@@ -3,14 +3,6 @@
 
 	if(src.check_rights(R_ADMIN|R_FUN))
 		to_chat(src, "<span class='warning'>You are now an admin ghost.  Think of yourself as an AI that doesn't show up anywhere and cannot speak.  You can access any console or machine by standing next to it and clicking on it.  Abuse of this privilege may result in hilarity or removal of your flags, so caution is recommended.</span>")
-	if(istype(canclone) && canclone.mind == mind)
-		if(can_reenter_corpse && istype(canclone.loc, /obj/machinery/dna_scannernew))
-			for(dir in list(NORTH, EAST, SOUTH, WEST))
-				if(locate(/obj/machinery/computer/cloning, get_step(canclone.loc, dir)))
-					src << 'sound/effects/adminhelp.ogg'
-					to_chat(src, "<span class='interface'><b><font size = 3>Your corpse has been placed into a cloning scanner. Return to your body if you want to be resurrected/cloned!</b> \
-						(Verbs -> Ghost -> Re-enter corpse, or <a href='?src=\ref[src];reentercorpse=1'>click here!</a>)</font></span>")
-	canclone = null
 
 /mob/dead/observer/MouseDrop(atom/over)
 	if(!usr || !over)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -34,7 +34,6 @@
 	var/medHUD = 0
 	var/antagHUD = 0
 	var/atom/movable/following = null
-	var/mob/canclone = null
 	incorporeal_move = INCORPOREAL_GHOST
 	var/movespeed = 0.75
 
@@ -111,7 +110,6 @@
 	..()
 	following = null
 	ghostMulti = null
-	canclone = null
 	observers.Remove(src)
 
 /mob/dead/observer/hasFullAccess()

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -122,8 +122,8 @@ obj/item/device/mmi/Destroy()
 			if(ghost && ghost.client && ghost.can_reenter_corpse)
 				to_chat(user, "<span class='warning'>\The [src] indicates that \the [O] seems slow to respond. Try again in a few seconds.</span>")
 				ghost << 'sound/effects/adminhelp.ogg'
-				to_chat(ghost, "<span class='interface'><b><font size = 3>Someone is trying to put your brain in a MMI. Return to your body if you want to be resurrected!</b> \
-					(Verbs -> Ghost -> Re-enter corpse, or <a href='?src=\ref[ghost];reentercorpse=1'>click here!</a>)</font></span>")
+				to_chat(ghost, "<span class='interface big'><span class='bold'>Someone is trying to put your brain in a MMI. Return to your body if you want to be resurrected!</span> \
+					(Verbs -> Ghost -> Re-enter corpse, or <a href='?src=\ref[ghost];reentercorpse=1'>click here!</a>)</span>")
 				return TRUE
 			to_chat(user, "<span class='warning'>\The [src] indicates that \the [O] is completely unresponsive; there's no point.</span>")
 			return TRUE

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -826,8 +826,8 @@ var/global/list/whitelisted_species = list("Human")
 					var/mob/dead/observer/ghost = get_ghost_from_mind(mind)
 					if(ghost && ghost.client && ghost.can_reenter_corpse)
 						ghost << 'sound/effects/adminhelp.ogg'
-						to_chat(ghost, "<span class='interface'><b><font size = 3>Someone is trying to resurrect you. Return to your body if you want to live again!</b> \
-							(Verbs -> Ghost -> Re-enter corpse, or <a href='?src=\ref[ghost];reentercorpse=1'>click here!</a>)</font></span>")
+						to_chat(ghost, "<span class='interface big'><span class='bold'>Someone is trying to resurrect you. Return to your body if you want to live again!</span> \
+							(Verbs -> Ghost -> Re-enter corpse, or <a href='?src=\ref[ghost];reentercorpse=1'>click here!</a>)</span>")
 				else
 					anim(target = src, a_icon = 'icons/mob/mob.dmi', flick_anim = "reverse-dust-g", sleeptime = 15)
 					var/mob/living/carbon/human/golem/G = new /mob/living/carbon/human/golem

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -81,7 +81,7 @@
 
 	if (isobj(loc))
 		var/obj/location = loc
-		location.on_log()
+		location.on_login(src)
 
 	if(client && client.haszoomed && !client.holder)
 		client.view = world.view

--- a/code/modules/mob/logout.dm
+++ b/code/modules/mob/logout.dm
@@ -1,7 +1,7 @@
 /mob/Logout()
 	if (isobj(loc))
 		var/obj/location = loc
-		location.on_log()
+		location.on_logout(src)
 
 	if(!(flags & HEAR_ALWAYS))
 		for(var/mob/virtualhearer/VH in virtualhearers)

--- a/html/changelogs/example_2.yml
+++ b/html/changelogs/example_2.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general deleting of nice things)
+#   rscadd (general adding of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.
+author: 9600bauds
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# There needs to be a space after the - and before the prefix. Don't use tabs anywhere in this file.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# If you're using characters such as # ' : - or the like in your changelog, surround the entire change with quotes as shown in the second example. These quotes don't show up on the changelog once it's merged and prevent errors.
+# SCREW ANY OF THIS UP AND IT WON'T WORK.
+changes: 
+- rscadd: "Added a message that is displayed to ghosts when their corpse gets placed in a morgue tray, which explains what the morgue lights do."
+- bugfix: "Fixed a dumb bug that prevented (live) mobs from being able to exit morgue trays on their own."


### PR DESCRIPTION
Alt title: "i try to do something small and end up doing code housekeeping"

Adds this message for ghosted players when their corpse gets put into a morgue tray
![dreamseeker_2016-07-30_01-49-52](https://cloud.githubusercontent.com/assets/6526157/17268161/f67e37fa-55f7-11e6-8a92-f04127eb8262.png)
Fixes live mobs not being able to exit morgue trays

Unfucks morgue code
Removes snowflake, removing mystery "canclone" var in the process
