### PR TITLE
Fixes statistics time collection to be useful

### DIFF
--- a/code/datums/statistics/statcollection.dm
+++ b/code/datums/statistics/statcollection.dm
@@ -17,7 +17,7 @@
 
 // To ensure that if output file syntax is changed, we will still be able to process
 // new and old files
-#define STAT_OUTPUT_VERSION "1.0"
+#define STAT_OUTPUT_VERSION "1.1"
 #define STAT_OUTPUT_DIR "data/statfiles/"
 
 /datum/stat_collector
@@ -182,7 +182,9 @@
 
 // This guy writes the first line(s) of the stat file! Woo!
 /datum/stat_collector/proc/Write_Header(statfile)
-	statfile << "STATLOG_START|[STAT_OUTPUT_VERSION]|[map.nameLong]|[num2text(round_start_time, 30)]|[num2text(world.realtime, 30)]"
+	var/start_timestamp = time2text(round_start_time, "YYYY.MM.DD.hh.mm.ss")
+	var/end_timestamp = time2text(world.realtime, "YYYY.MM.DD.hh.mm.ss")
+	statfile << "STATLOG_START|[STAT_OUTPUT_VERSION]|[map.nameLong]|[start_timestamp]]|[end_timestamp]"
 	statfile << "MASTERMODE|[master_mode]" // sekrit, or whatever else was decided as the 'actual' mode on round start.
 	if(istype(ticker.mode, /datum/game_mode/mixed))
 		var/datum/game_mode/mixed/mixy = ticker.mode


### PR DESCRIPTION
Also increments statfile by .1 but who cares about that right
This basically means I can re-interpret the timestamp later in Python to prevent fuckups such as:
- Midnight clock rollover!
- DST time change!
- Leap year fuckery!
