### PR TITLE
Remove vox trader ID prompt, give trader access to raiders

### DIFF
--- a/code/game/jobs/job/whitelisted.dm
+++ b/code/game/jobs/job/whitelisted.dm
@@ -21,7 +21,6 @@
 	no_starting_money = 1
 	no_pda = 1
 
-	no_id = 1 //Starting with an ID is optional!
 	idtype = /obj/item/weapon/card/id/vox
 
 	no_headset = 1
@@ -45,23 +44,6 @@
 
 	H.equip_or_collect(new /obj/item/device/radio(H), slot_belt)
 
-	//Ask if the player wants to start with an ID.
-	spawn(10)
-		to_chat(H, "<span class='notice'>Oh no! I can't seem to find my ID.</span>")
-		var/current_time = world.time
-		var/choice = alert(H, "Would you like to start with a traveler's ID? Traveling in human-controlled territories without one is illegal.  You won't be able to pilot the trade ship without an ID  either. If you choose \"No\", it's up to you to think of a reason why you're traveling without an ID.", "Scenario Picker (30 seconds to choose)", "Yes", "No")
-
-		if(choice == "Yes")
-			if(!job_master)
-				to_chat(H, "Job controller doesn't exist. Something is wrong!")
-				return
-			if((current_time + 30 SECONDS) <= world.time)
-				to_chat(H, "<span class='danger'>Too slow, sorry.</span>")
-				return
-
-			no_id = 0
-			job_master.spawnId(H, "Trader", "Traveler")
-			to_chat(H, "<span class='info'>Ah, there's my ID. I was almost worried for a second that I had lost it.</span>")
 	return 1
 
 /datum/job/trader/introduce(mob/M, job_title)

--- a/code/modules/admin/verbs/vox_raiders.dm
+++ b/code/modules/admin/verbs/vox_raiders.dm
@@ -59,11 +59,14 @@ var/global/vox_tick = 1
 	equip_to_slot_or_del(new /obj/item/device/flashlight(src), slot_r_store)
 
 	var/obj/item/weapon/card/id/syndicate/C = new(src)
-	C.name = "[real_name]'s Legitimate Human ID Card"
-	C.icon_state = "id"
-	C.access = list(access_syndicate)
-	C.assignment = "Trader"
+	//C.name = "[real_name]'s Legitimate Human ID Card"
 	C.registered_name = real_name
+	C.assignment = "Trader"
+	C.UpdateName()
+	C.SetOwnerInfo(src)
+
+	C.icon_state = "traveler"
+	C.access = list(access_syndicate, access_trade)
 	//C.registered_user = src
 	var/obj/item/weapon/storage/wallet/W = new(src)
 	W.handle_item_insertion(C)

--- a/code/modules/admin/verbs/vox_raiders.dm
+++ b/code/modules/admin/verbs/vox_raiders.dm
@@ -65,7 +65,7 @@ var/global/vox_tick = 1
 	C.UpdateName()
 	C.SetOwnerInfo(src)
 
-	C.icon_state = "traveler"
+	C.icon_state = "trader"
 	C.access = list(access_syndicate, access_trade)
 	//C.registered_user = src
 	var/obj/item/weapon/storage/wallet/W = new(src)


### PR DESCRIPTION
- Traders now always spawn with an ID
- Raiders now spawn with vox access
- Fixes #11222
