### PR TITLE
Updated Potent Ham Recipe so it requires meat from the Vox pig

### DIFF
--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -1641,6 +1641,8 @@
 /datum/recipe/potentham
 	reagents = list(PLASMA = 10)
 	items = list(
+
+		/obj/item/weapon/reagent_containers/food/snacks/meat/box,
 		/obj/item/weapon/aiModule/core/asimov,
 		/obj/item/robot_parts/head,
 		/obj/item/weapon/handcuffs

--- a/html/changelogs/ArthurDentist.yml
+++ b/html/changelogs/ArthurDentist.yml
@@ -1,2 +1,3 @@
 author: ArthurDentist
-changes: []
+changes: 
+- tweak: Changed the potent ham recipe to require Vox Pig meat.


### PR DESCRIPTION
See Title ^

This is basically a bug fix because any ham food product should probably require pig meat. 
