### PR TITLE
[DNM] Fixes all that Bump() nonsense

### DIFF
--- a/code/WorkInProgress/Cael_Aislinn/ShieldGen/energy_field.dm
+++ b/code/WorkInProgress/Cael_Aislinn/ShieldGen/energy_field.dm
@@ -40,5 +40,5 @@
 		invisibility = 101
 		density = 0
 
-/obj/effect/energy_field/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+/obj/effect/energy_field/CrossCheck(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	return !density

--- a/code/WorkInProgress/Cael_Aislinn/sculpture.dm
+++ b/code/WorkInProgress/Cael_Aislinn/sculpture.dm
@@ -125,7 +125,7 @@
 		while(get_turf(src) != target_turf && num_turfs > 0)
 			if(!check_los()) //Something is looking at us now
 				break
-			if(!next_turf.Cross(src, next_turf)) //We can't pass through our planned path
+			if(!next_turf.CrossCheck(src, next_turf)) //We can't pass through our planned path
 				break
 			for(var/obj/structure/window/W in next_turf)
 				W.Destroy(brokenup = 1)
@@ -147,7 +147,7 @@
 			for(var/obj/machinery/door/D in next_turf)
 				D.open()
 				sleep(5)
-			if(!next_turf.Cross(src, next_turf)) //Once we cleared everything we could, check one last time if we can pass
+			if(!next_turf.CrossCheck(src, next_turf)) //Once we cleared everything we could, check one last time if we can pass
 				break
 			forceMove(next_turf)
 			dir = get_dir(src, target)
@@ -176,7 +176,7 @@
 			while(get_turf(src) != target_turf && num_turfs > 0)
 				if(!check_los()) //Something is looking at us now
 					break
-				if(!next_turf.Cross(src, next_turf)) //We can't pass through our planned path
+				if(!next_turf.CrossCheck(src, next_turf)) //We can't pass through our planned path
 					break
 				for(var/obj/structure/window/W in next_turf)
 					W.Destroy(brokenup = 1)
@@ -198,7 +198,7 @@
 				for(var/obj/machinery/door/D in next_turf)
 					D.open()
 					sleep(5)
-				if(!next_turf.Cross(src, next_turf)) //Once we cleared everything we could, check one last time if we can pass
+				if(!next_turf.CrossCheck(src, next_turf)) //Once we cleared everything we could, check one last time if we can pass
 					break
 				forceMove(next_turf)
 				dir = get_dir(src, target_turf)

--- a/code/WorkInProgress/Ported/policetape.dm
+++ b/code/WorkInProgress/Ported/policetape.dm
@@ -144,7 +144,7 @@
 				return
 		M:loc = T
 
-/obj/item/tape/Cross(atom/movable/mover, turf/target, height = 1.5, air_group = 0)
+/obj/item/tape/CrossCheck(atom/movable/mover, turf/target, height = 1.5, air_group = 0)
 	if(!density)
 		return 1
 	if(air_group || (height == 0))

--- a/code/ZAS/Atom.dm
+++ b/code/ZAS/Atom.dm
@@ -1,7 +1,7 @@
-/atom/movable/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+/atom/movable/proc/CrossCheck(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	return (!density || !height || air_group)
 
-/turf/proc/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+/turf/proc/CrossCheck(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(!target) return 0
 
 	if(istype(mover)) // turf/Enter(...) will perform more advanced checks
@@ -12,16 +12,16 @@
 			return 0
 
 		for(var/obj/obstacle in src)
-			if(!obstacle.Cross(mover, target, height, air_group))
+			if(!obstacle.CrossCheck(mover, target, height, air_group))
 				return 0
 		if(target != src)
 			for(var/obj/obstacle in target)
-				if(!obstacle.Cross(mover, src, height, air_group))
+				if(!obstacle.CrossCheck(mover, src, height, air_group))
 					return 0
 
 		return 1
 
-//Basically another way of calling Cross(null, other, 0, 0) and Cross(null, other, 1.5, 1).
+//Basically another way of calling CrossCheck(null, other, 0, 0) and CrossCheck(null, other, 1.5, 1).
 //Returns:
 // 0 - Not blocked
 // AIR_BLOCKED - Blocked
@@ -33,7 +33,7 @@
 	#ifdef ZASDBG
 	ASSERT(isturf(other))
 	#endif
-	return !Cross(null, other, 0, 0) + 2*!Cross(null, other, 1.5, 1)
+	return !CrossCheck(null, other, 0, 0) + 2*!CrossCheck(null, other, 1.5, 1)
 
 /turf/c_airblock(turf/other)
 	#ifdef ZASDBG

--- a/code/ZAS/Diagnostic.dm
+++ b/code/ZAS/Diagnostic.dm
@@ -175,7 +175,7 @@ client/proc/Test_ZAS_Connection(var/turf/simulated/T as turf)
 
 		for(var/direction in cardinal)
 			var/turf/simulated/adjacent = get_step(current, direction)
-			if(!current.ZCross(adjacent))
+			if(!current.ZCrossCheck(adjacent))
 				continue
 			if(turfs.Find(adjacent))
 				current_adjacents += adjacent

--- a/code/ZAS/Diagnostic.dm
+++ b/code/ZAS/Diagnostic.dm
@@ -175,7 +175,7 @@ client/proc/Test_ZAS_Connection(var/turf/simulated/T as turf)
 
 		for(var/direction in cardinal)
 			var/turf/simulated/adjacent = get_step(current, direction)
-			if(!current.ZCrossCheck(adjacent))
+			if(!current.ZCross(adjacent))
 				continue
 			if(turfs.Find(adjacent))
 				current_adjacents += adjacent

--- a/code/ZAS/Fire.dm
+++ b/code/ZAS/Fire.dm
@@ -224,7 +224,7 @@ Attach to transfer valve and open. BOOM.
 
 				//Spread the fire.
 				if(!(locate(/obj/fire) in enemy_tile))
-					if( prob( 50 + 50 * (firelevel/zas_settings.Get(/datum/ZAS_Setting/fire_firelevel_multiplier)) ) && S.Cross(null, enemy_tile, 0,0) && enemy_tile.Cross(null, S, 0,0))
+					if( prob( 50 + 50 * (firelevel/zas_settings.Get(/datum/ZAS_Setting/fire_firelevel_multiplier)) ) && S.CrossCheck(null, enemy_tile, 0,0) && enemy_tile.CrossCheck(null, S, 0,0))
 						new/obj/fire(enemy_tile)
 
 	//seperate part of the present gas

--- a/code/ZAS/_docs.dm
+++ b/code/ZAS/_docs.dm
@@ -17,7 +17,7 @@ Important Functions:
 
 air_master.mark_for_update(turf)
 	When stuff happens, call this. It works on everything. You basically don't need to worry about any other
-	functions besides Cross().
+	functions besides CrossCheck().
 
 Notes for people who used ZAS before:
 	There is no connected_zones anymore.

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -271,7 +271,7 @@ var/list/DummyCache = list()
 	//Now, check objects to block exit that are on the border
 	for(var/obj/border_obstacle in srcturf)
 		if(border_obstacle.flags & ON_BORDER)
-			if(!border_obstacle.Uncross(D, targetturf))
+			if(!border_obstacle.UncrossCheck(D, targetturf))
 				D.loc = null
 				DummyCache.Add(D)
 				return 0
@@ -279,7 +279,7 @@ var/list/DummyCache = list()
 	//Next, check objects to block entry that are on the border
 	for(var/obj/border_obstacle in targetturf)
 		if((border_obstacle.flags & ON_BORDER) && (target != border_obstacle))
-			if(!border_obstacle.Cross(D, srcturf, 1, 0))
+			if(!border_obstacle.CrossCheck(D, srcturf, 1, 0))
 				D.loc = null
 				DummyCache.Add(D)
 				return 0

--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -1,4 +1,4 @@
-Cross/*
+/*
  * Holds procs to help with list operations
  * Contains groups:
  *			Misc

--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -1,4 +1,4 @@
-/*
+Cross/*
  * Holds procs to help with list operations
  * Contains groups:
  *			Misc

--- a/code/_onclick/adjacent.dm
+++ b/code/_onclick/adjacent.dm
@@ -45,7 +45,7 @@
 			// Window snowflake code
 			if(neighbor.flags & ON_BORDER && neighbor.dir == get_dir(T0, src)) return 1
 			// Check for border blockages
-			if(T0.ClickCrossCheck(get_dir(T0,src), border_only = 1) && src.ClickCrossCheck(get_dir(src,T0), border_only = 1, target_atom = target))
+			if(T0.ClickCross(get_dir(T0,src), border_only = 1) && src.ClickCross(get_dir(src,T0), border_only = 1, target_atom = target))
 				return 1
 			continue
 
@@ -55,14 +55,14 @@
 		var/d2 = in_dir&12			 // eg. west	  (1+8)&12 (0000 1100) = 8 (0000 1000)
 
 		for(var/d in list(d1,d2))
-			if(!T0.ClickCrossCheck(d, border_only = 1) && !(neighbor.flags & ON_BORDER && neighbor.dir == d))
+			if(!T0.ClickCross(d, border_only = 1) && !(neighbor.flags & ON_BORDER && neighbor.dir == d))
 				continue // could not leave T0 in that direction
 
 			var/turf/T1 = get_step(T0,d)
-			if(!T1 || T1.density || !T1.ClickCrossCheck(get_dir(T1,T0) | get_dir(T1,src), border_only = 0)) //let's check both directions at once
+			if(!T1 || T1.density || !T1.ClickCross(get_dir(T1,T0) | get_dir(T1,src), border_only = 0)) //let's check both directions at once
 				continue // couldn't enter or couldn't leave T1
 
-			if(!src.ClickCrossCheck(get_dir(src,T1), border_only = 1, target_atom = target))
+			if(!src.ClickCross(get_dir(src,T1), border_only = 1, target_atom = target))
 				continue // could not enter src
 
 			return 1 // we don't care about our own density
@@ -119,7 +119,7 @@
 	This is defined as any dense ON_BORDER object, or any dense object without throwpass.
 	The border_only flag allows you to not objects (for source and destination squares)
 */
-/turf/proc/ClickCrossCheck(var/target_dir, var/border_only, var/atom/target_atom = null)
+/turf/proc/ClickCross(var/target_dir, var/border_only, var/atom/target_atom = null)
 	for(var/obj/O in src)
 		if( !O.density || O == target_atom || O.throwpass) continue // throwpass is used for anything you can click through
 

--- a/code/_onclick/adjacent.dm
+++ b/code/_onclick/adjacent.dm
@@ -45,7 +45,7 @@
 			// Window snowflake code
 			if(neighbor.flags & ON_BORDER && neighbor.dir == get_dir(T0, src)) return 1
 			// Check for border blockages
-			if(T0.ClickCross(get_dir(T0,src), border_only = 1) && src.ClickCross(get_dir(src,T0), border_only = 1, target_atom = target))
+			if(T0.ClickCrossCheck(get_dir(T0,src), border_only = 1) && src.ClickCrossCheck(get_dir(src,T0), border_only = 1, target_atom = target))
 				return 1
 			continue
 
@@ -55,14 +55,14 @@
 		var/d2 = in_dir&12			 // eg. west	  (1+8)&12 (0000 1100) = 8 (0000 1000)
 
 		for(var/d in list(d1,d2))
-			if(!T0.ClickCross(d, border_only = 1) && !(neighbor.flags & ON_BORDER && neighbor.dir == d))
+			if(!T0.ClickCrossCheck(d, border_only = 1) && !(neighbor.flags & ON_BORDER && neighbor.dir == d))
 				continue // could not leave T0 in that direction
 
 			var/turf/T1 = get_step(T0,d)
-			if(!T1 || T1.density || !T1.ClickCross(get_dir(T1,T0) | get_dir(T1,src), border_only = 0)) //let's check both directions at once
+			if(!T1 || T1.density || !T1.ClickCrossCheck(get_dir(T1,T0) | get_dir(T1,src), border_only = 0)) //let's check both directions at once
 				continue // couldn't enter or couldn't leave T1
 
-			if(!src.ClickCross(get_dir(src,T1), border_only = 1, target_atom = target))
+			if(!src.ClickCrossCheck(get_dir(src,T1), border_only = 1, target_atom = target))
 				continue // could not enter src
 
 			return 1 // we don't care about our own density
@@ -119,7 +119,7 @@
 	This is defined as any dense ON_BORDER object, or any dense object without throwpass.
 	The border_only flag allows you to not objects (for source and destination squares)
 */
-/turf/proc/ClickCross(var/target_dir, var/border_only, var/atom/target_atom = null)
+/turf/proc/ClickCrossCheck(var/target_dir, var/border_only, var/atom/target_atom = null)
 	for(var/obj/O in src)
 		if( !O.density || O == target_atom || O.throwpass) continue // throwpass is used for anything you can click through
 

--- a/code/defines/obj.dm
+++ b/code/defines/obj.dm
@@ -341,7 +341,7 @@ var/global/list/PDA_Manifest = list()
 	desc = "You can't resist."
 	// name = ""
 
-/obj/effect/stop/Uncross(atom/movable/mover)
+/obj/effect/stop/UncrossCheck(atom/movable/mover)
 	if(victim == mover)
 		return 0
 	return 1

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -358,7 +358,7 @@ its easier to just keep the beam vertical.
 				qdel(X)
 				break
 			for(var/obj/O in TT)
-				if(!O.Cross(light))
+				if(!O.CrossCheck(light))
 					broken = 1
 					break
 				else if(O.density)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -288,6 +288,31 @@
 		return 1
 	return 0
 
+/atom/movable/Cross(atom/movable/mover, turf/target, var/ignoreborder = 1)
+	if(flags & ON_BORDER && ignoreborder)
+		return 1
+	if(CrossCheck(mover, target))
+		return 1
+	if(!density || loc.contents[1] == src || !isturf(loc))
+		return 0
+	if(ismob(src))
+		to_chat(world, "[src]")
+	var/contentsholder = loc.contents - src
+	loc.contents = contentsholder
+
+
+/atom/movable/Uncross(atom/movable/mover, turf/target)
+	if(UncrossCheck(mover, target))
+		return 1
+	if(!density || loc.contents[1] == src || !isturf(loc))
+		return 0
+	var/turf/locholder = loc
+	loc = null
+	locholder.contents = list(src) + locholder.contents
+
+/atom/movable/proc/UncrossCheck(atom/movable/mover, turf/target) //CrossCheck base definition is in ZAS/Atom.dm
+	return 1
+
 // Previously known as HasEntered()
 // This is automatically called when something enters your square
 /atom/movable/Crossed(atom/movable/AM)

--- a/code/game/gamemodes/blob/blobs/factory.dm
+++ b/code/game/gamemodes/blob/blobs/factory.dm
@@ -112,7 +112,7 @@
 /mob/living/simple_animal/hostile/blobspore/blob_act()
 	return
 
-/mob/living/simple_animal/hostile/blobspore/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+/mob/living/simple_animal/hostile/blobspore/CrossCheck(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(istype(mover, /obj/effect/blob))
 		return 1
 	return ..()

--- a/code/game/gamemodes/blob/blobs/shield.dm
+++ b/code/game/gamemodes/blob/blobs/shield.dm
@@ -27,7 +27,7 @@
 /obj/effect/blob/shield/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	return
 
-/obj/effect/blob/shield/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+/obj/effect/blob/shield/CrossCheck(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(istype(mover) && mover.checkpass(PASSBLOB))	return 1
 	if(mover)
 		mover.Bump(src) //Only automatic for dense objects

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -131,7 +131,7 @@ var/list/blob_looks
 /obj/effect/blob/projectile_check()
 	return PROJREACT_BLOB
 
-/obj/effect/blob/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+/obj/effect/blob/CrossCheck(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(air_group || (height==0))	return 1
 	if(istype(mover) && mover.checkpass(PASSBLOB))	return 1
 	mover.Bump(src) //Only automatic for dense objects

--- a/code/game/gamemodes/endgame/xmas/snow.dm
+++ b/code/game/gamemodes/endgame/xmas/snow.dm
@@ -365,7 +365,7 @@ var/global/list/datum/stack_recipe/snow_recipes = list (
 		qdel(src)
 	return
 
-/obj/structure/window/barricade/snow/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)//So bullets will fly over and stuff.
+/obj/structure/window/barricade/snow/CrossCheck(atom/movable/mover, turf/target, height=1.5, air_group = 0)//So bullets will fly over and stuff.
 	if(air_group || (height==0))
 		return 1
 	if(istype(mover) && mover.checkpass(PASSTABLE))

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -160,7 +160,7 @@
 
 //We don't want meteors to bump into eachother and explode, so they pass through eachother
 //Reflection on bumping would be better, but I would reckon I'm not sure on how to achieve it
-/obj/item/projectile/meteor/Cross(atom/movable/mover, turf/target, height = 1.5, air_group = 0)
+/obj/item/projectile/meteor/CrossCheck(atom/movable/mover, turf/target, height = 1.5, air_group = 0)
 
 	if(istype(mover, /obj/item/projectile/meteor))
 		return 1 //Just move through it, no questions asked

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -56,7 +56,7 @@
 		src.density = 0
 		qdel(src)
 
-/obj/machinery/optable/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+/obj/machinery/optable/CrossCheck(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(air_group || (height==0)) return 1
 
 	if(istype(mover) && mover.checkpass(PASSTABLE))

--- a/code/game/machinery/bees_apiary.dm
+++ b/code/game/machinery/bees_apiary.dm
@@ -127,7 +127,7 @@
 		user.visible_message("<span class='warning'>\the [user] hits \the [src] with \the [O]!</span>","<span class='warning'>You hit \the [src] with \the [O]!</span>")
 		angry_swarm(user)
 
-/obj/machinery/apiary/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+/obj/machinery/apiary/CrossCheck(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(air_group || (height==0)) return 1
 
 	if(istype(mover) && mover.checkpass(PASSTABLE))

--- a/code/game/machinery/bots/ed209bot.dm
+++ b/code/game/machinery/bots/ed209bot.dm
@@ -118,7 +118,7 @@
 			if((lasercolor == "r") && (name == "ED-209 Security Robot"))
 				name = pick("RED RAMPAGE","RED ROVER","RED KILLDEATH MURDERBOT")
 
-/obj/machinery/bot/ed209/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+/obj/machinery/bot/ed209/CrossCheck(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(istype(mover,/obj/machinery/bot/ed209))
 		return 1
 	else

--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -427,7 +427,7 @@ var/global/mulebot_count = 0
 	if(get_dist(C, src) > 1 || load || !on)
 		return
 	for(var/obj/structure/plasticflaps/P in src.loc)//Takes flaps into account
-		if(!Cross(C,P))
+		if(!CrossCheck(C,P))
 			return
 	mode = 1
 
@@ -480,7 +480,7 @@ var/global/mulebot_count = 0
 	if(dirn)
 		var/turf/T = src.loc
 		T = get_step(T,dirn)
-		if(Cross(load,T))//Can't get off onto anything that wouldn't let you pass normally
+		if(CrossCheck(load,T))//Can't get off onto anything that wouldn't let you pass normally
 			step(load, dirn)
 		else
 			load.loc = src.loc//Drops you right there, so you shouldn't be able to get yourself stuck

--- a/code/game/machinery/computer/HolodeckControl.dm
+++ b/code/game/machinery/computer/HolodeckControl.dm
@@ -420,7 +420,7 @@
 	anchored = 1.0
 	flags = ON_BORDER
 
-/obj/structure/holowindow/Uncross(var/atom/movable/mover, var/turf/target)
+/obj/structure/holowindow/UncrossCheck(var/atom/movable/mover, var/turf/target)
 	if(istype(mover) && mover.checkpass(PASSGLASS))
 		return 1
 	if(flags & ON_BORDER)
@@ -432,7 +432,7 @@
 			return !density
 	return 1
 
-/obj/structure/holowindow/Cross(atom/movable/mover, turf/target, height = 0)
+/obj/structure/holowindow/CrossCheck(atom/movable/mover, turf/target, height = 0)
 	if(istype(mover) && mover.checkpass(PASSGLASS))
 		return 1
 	if(get_dir(loc, target) == dir || get_dir(loc, mover) == dir)
@@ -528,7 +528,7 @@
 			visible_message("<span class='notice'>[user] dunks [W] into the [src]!</span>")
 			return
 
-/obj/structure/holohoop/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+/obj/structure/holohoop/CrossCheck(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(istype(mover,/obj/item) && mover.throwing)
 		var/obj/item/I = mover
 		if(istype(I, /obj/item/weapon/dummy) || istype(I, /obj/item/projectile))

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -23,7 +23,7 @@
 	if(ticker)
 		initialize()
 
-/obj/machinery/computer/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+/obj/machinery/computer/CrossCheck(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(istype(mover) && mover.checkpass(PASSMACHINE))
 		return 1
 	return ..()

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -141,7 +141,7 @@ for reference:
 		src.explode()
 	return
 
-/obj/machinery/deployable/barrier/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)//So bullets will fly over and stuff.
+/obj/machinery/deployable/barrier/CrossCheck(atom/movable/mover, turf/target, height=1.5, air_group = 0)//So bullets will fly over and stuff.
 	if(air_group || (height==0))
 		return 1
 	if(istype(mover) && mover.checkpass(PASSTABLE))

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -668,7 +668,7 @@ About the new airlock wires panel:
 			if (user)
 				src.attack_ai(user)
 
-/obj/machinery/door/airlock/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+/obj/machinery/door/airlock/CrossCheck(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if (isElectrified())
 		if (istype(mover, /obj/item))
 			var/obj/item/i = mover

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -334,7 +334,7 @@ var/list/all_doors = list()
 	all_doors -= src
 	..()
 
-/obj/machinery/door/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+/obj/machinery/door/CrossCheck(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(air_group) return 0
 	if(istype(mover) && mover.checkpass(PASSGLASS))
 		return !opacity

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -472,7 +472,7 @@ var/global/list/alert_overlays_global = list()
 	air_properties_vary_with_direction = 1
 	flags = ON_BORDER
 
-/obj/machinery/door/firedoor/border_only/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+/obj/machinery/door/firedoor/border_only/CrossCheck(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(istype(mover) && mover.checkpass(PASSGLASS))
 		return 1
 	if(get_dir(loc, target) == dir || get_dir(loc, mover) == dir)
@@ -484,7 +484,7 @@ var/global/list/alert_overlays_global = list()
 	return !density
 
 
-/obj/machinery/door/firedoor/border_only/Uncross(atom/movable/mover as mob|obj, turf/target as turf)
+/obj/machinery/door/firedoor/border_only/UncrossCheck(atom/movable/mover as mob|obj, turf/target as turf)
 	if(istype(mover) && mover.checkpass(PASSGLASS))
 		return 1
 	if(flags & ON_BORDER)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -68,7 +68,7 @@
 		close()
 	return
 
-/obj/machinery/door/window/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+/obj/machinery/door/window/CrossCheck(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(istype(mover) && mover.checkpass(PASSGLASS))
 		return 1
 	if(get_dir(loc, target) == dir || get_dir(loc, mover) == dir)
@@ -82,7 +82,7 @@
 	return !density || (dir != to_dir) || check_access(ID)
 
 
-/obj/machinery/door/window/Uncross(atom/movable/mover as mob|obj, turf/target as turf)
+/obj/machinery/door/window/UncrossCheck(atom/movable/mover as mob|obj, turf/target as turf)
 	if(istype(mover) && mover.checkpass(PASSGLASS))
 		return 1
 	if(flags & ON_BORDER)

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -23,7 +23,7 @@
 	update_nearby_tiles()
 	..()
 
-/obj/machinery/shield/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+/obj/machinery/shield/CrossCheck(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(!height || air_group) return 0
 	else return ..()
 
@@ -597,7 +597,7 @@
 					G = gen_secondary
 				G.storedpower -= 20
 
-/obj/machinery/shieldwall/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+/obj/machinery/shieldwall/CrossCheck(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(air_group || (height==0)) return 1
 
 	if(!mover)

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -152,7 +152,7 @@ var/global/num_vending_terminals = 1
 		coinbox.forceMove(get_turf(src))
 	..()
 
-/obj/machinery/vending/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+/obj/machinery/vending/CrossCheck(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(istype(mover) && mover.checkpass(PASSMACHINE))
 		return 1
 	return ..()

--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -597,11 +597,11 @@
 			occupant_message("The syringe is too far away.")
 			return 0
 		for(var/obj/structure/D in S.loc)//Basic level check for structures in the way (Like grilles and windows)
-			if(!(D.Cross(S,src.loc)))
+			if(!(D.CrossCheck(S,src.loc)))
 				occupant_message("Unable to load syringe.")
 				return 0
 		for(var/obj/machinery/door/D in S.loc)//Checks for doors
-			if(!(D.Cross(S,src.loc)))
+			if(!(D.CrossCheck(S,src.loc)))
 				occupant_message("Unable to load syringe.")
 				return 0
 		S.reagents.trans_to(src, S.reagents.total_volume)

--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -154,7 +154,7 @@
 	healthcheck()
 	..()
 
-/obj/effect/alien/resin/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+/obj/effect/alien/resin/CrossCheck(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(air_group) return 0
 	if(istype(mover) && mover.checkpass(PASSGLASS))
 		return !opacity

--- a/code/game/objects/effects/decals/Cleanable/fuel.dm
+++ b/code/game/objects/effects/decals/Cleanable/fuel.dm
@@ -44,7 +44,7 @@
 			if (!istype(target)) // Avoid spreading to unsimulated/space/etc. turfs
 				continue
 
-			if(origin.Cross(null, target, 0, 0) && target.Cross(null, origin, 0, 0))
+			if(origin.CrossCheck(null, target, 0, 0) && target.CrossCheck(null, origin, 0, 0))
 				if(!locate(/obj/effect/decal/cleanable/liquid_fuel) in target)
 					getFromPool(/obj/effect/decal/cleanable/liquid_fuel, target, amount*0.25)
 					amount *= 0.75
@@ -71,7 +71,7 @@
 		var/turf/simulated/O = get_step(S,d)
 		if(locate(/obj/effect/decal/cleanable/liquid_fuel/flamethrower_fuel) in O)
 			continue
-		if(O.Cross(null, S, 0, 0) && S.Cross(null, O, 0, 0))
+		if(O.CrossCheck(null, S, 0, 0) && S.CrossCheck(null, O, 0, 0))
 			var/obj/effect/decal/cleanable/liquid_fuel/flamethrower_fuel/FF = getFromPool(/obj/effect/decal/cleanable/liquid_fuel/flamethrower_fuel, O, amount*0.25, d)
 
 			if(amount + FF.amount > 0.4) //if we make a patch with not enough fuel, we balance it out properly to ensure even burn

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -278,7 +278,7 @@ steam.start() -- spawns the effect
 		spawn ( 20 )
 			M.coughedtime = 0
 
-/obj/effect/effect/smoke/bad/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+/obj/effect/effect/smoke/bad/CrossCheck(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(air_group || (height==0)) return 1
 	if(istype(mover, /obj/item/projectile/beam))
 		var/obj/item/projectile/beam/B = mover
@@ -931,7 +931,7 @@ steam.start() -- spawns the effect
 	else
 		to_chat(user, "<span class='notice'>You hit \the [src] to no effect.</span>")
 
-/obj/structure/foamedmetal/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+/obj/structure/foamedmetal/CrossCheck(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(air_group) return 0
 	return !density
 

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -39,7 +39,7 @@
 	spawn()
 		teleport(AM)
 
-/obj/effect/portal/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+/obj/effect/portal/CrossCheck(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(istype(mover,/obj/effect/beam))
 		return 0
 	else

--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -94,7 +94,7 @@
 	else
 		..() //Weapon checks for weapons without brute or burn damage type and grab check
 
-/obj/structure/window/barricade/Cross(atom/movable/mover, turf/target, height = 1.5, air_group = 0)
+/obj/structure/window/barricade/CrossCheck(atom/movable/mover, turf/target, height = 1.5, air_group = 0)
 
 	if(air_group || !height) //The mover is an airgroup
 		return 1 //We aren't airtight, only exception to PASSGLASS
@@ -138,11 +138,11 @@
 	..(loc)
 	flags &= ~ON_BORDER
 
-/obj/structure/window/barricade/full/Uncross(atom/movable/O as mob|obj, target as turf)
+/obj/structure/window/barricade/full/UncrossCheck(atom/movable/O as mob|obj, target as turf)
 
 	return 1
 
-/obj/structure/window/barricade/full/Cross(atom/movable/mover, turf/target, height = 1.5, air_group = 0)
+/obj/structure/window/barricade/full/CrossCheck(atom/movable/mover, turf/target, height = 1.5, air_group = 0)
 
 	if(air_group || !height) //The mover is an airgroup
 		return 1 //We aren't airtight, only exception to PASSGLASS

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -40,7 +40,7 @@
 /obj/structure/closet/alter_health()
 	return get_turf(src)
 
-/obj/structure/closet/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+/obj/structure/closet/CrossCheck(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(air_group || (height==0 || wall_mounted)) return 1
 	return (!density)
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -212,7 +212,7 @@
 		sleep(2)
 		new /obj/machinery/power/supermatter/shard(src)
 
-/obj/structure/closet/crate/secure/large/reinforced/shard/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+/obj/structure/closet/crate/secure/large/reinforced/shard/CrossCheck(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(istype(mover,/obj/machinery/power/supermatter))
 		return 1
 	. = ..()

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -361,7 +361,7 @@
 	new /obj/item/clothing/suit/radiation(src)
 	new /obj/item/clothing/head/radiation(src)
 
-/obj/structure/closet/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+/obj/structure/closet/CrossCheck(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(air_group || (height==0 || wall_mounted)) return 1
 	if(istype(mover, /obj/structure/closet/crate)) return 0
 	return (!density)

--- a/code/game/objects/structures/fullwindow.dm
+++ b/code/game/objects/structures/fullwindow.dm
@@ -22,11 +22,11 @@
 	..(loc)
 	flags |= ON_BORDER
 
-/obj/structure/window/full/Uncross(atom/movable/O as mob|obj, target as turf)
+/obj/structure/window/full/UncrossCheck(atom/movable/O as mob|obj, target as turf)
 
 	return 1
 
-/obj/structure/window/full/Cross(atom/movable/mover, turf/target, height = 1.5, air_group = 0)
+/obj/structure/window/full/CrossCheck(atom/movable/mover, turf/target, height = 1.5, air_group = 0)
 
 	if(istype(mover) && mover.checkpass(PASSGLASS))
 		return 1

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -115,7 +115,7 @@
 	return
 
 
-/obj/structure/grille/Cross(atom/movable/mover, turf/target, height = 1.5, air_group = 0)
+/obj/structure/grille/CrossCheck(atom/movable/mover, turf/target, height = 1.5, air_group = 0)
 	if(air_group || (height == 0))
 		return 1
 	if(istype(mover) && mover.checkpass(PASSGRILLE))
@@ -265,7 +265,7 @@
 	icon_state = "grillecult"
 	health = 40 //Make it strong enough to avoid people breaking in too easily
 
-/obj/structure/grille/cult/Cross(atom/movable/mover, turf/target, height = 1.5, air_group = 0)
+/obj/structure/grille/cult/CrossCheck(atom/movable/mover, turf/target, height = 1.5, air_group = 0)
 	if(air_group || !broken)
 		return 0 //Make sure air doesn't drain
 	..()

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -160,7 +160,7 @@
 	var/obj/structure/morgue/connected = null
 	anchored = 1.0
 
-/obj/structure/m_tray/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+/obj/structure/m_tray/CrossCheck(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if (istype(mover, /obj/item/weapon/dummy))
 		return 1
 	else
@@ -394,7 +394,7 @@
 	var/obj/structure/crematorium/connected = null
 	anchored = 1.0
 
-/obj/structure/c_tray/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+/obj/structure/c_tray/CrossCheck(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if (istype(mover, /obj/item/weapon/dummy))
 		return 1
 	else

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -294,7 +294,7 @@
 /obj/structure/table/attack_tk() // no telehulk sorry
 	return
 
-/obj/structure/table/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+/obj/structure/table/CrossCheck(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(air_group || (height==0)) return 1
 	if(istype(mover,/obj/item/projectile))
 		return (check_cover(mover,target))
@@ -343,7 +343,7 @@
 				return 1
 	return 1
 
-/obj/structure/table/Uncross(atom/movable/mover as mob|obj, target as turf)
+/obj/structure/table/UncrossCheck(atom/movable/mover as mob|obj, target as turf)
 	if(istype(mover) && mover.checkpass(PASSTABLE))
 		return 1
 	if(flags & ON_BORDER)
@@ -711,7 +711,7 @@
 		del(src)
 		return
 
-/obj/structure/rack/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+/obj/structure/rack/CrossCheck(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(air_group || (height==0)) return 1
 	if(istype(mover) && mover.checkpass(PASSTABLE))
 		return 1

--- a/code/game/objects/structures/transit_tubes.dm
+++ b/code/game/objects/structures/transit_tubes.dm
@@ -99,18 +99,18 @@ obj/structure/ex_act(severity)
 		var/list/large_dense = list()
 		for(var/atom/movable/border_obstacle in T)
 			if(border_obstacle.flags&ON_BORDER)
-				if(!border_obstacle.Cross(AM, AM.loc) && AM != border_obstacle)
+				if(!border_obstacle.CrossCheck(AM, AM.loc) && AM != border_obstacle)
 					return ..()
 			else if(border_obstacle != src)
 				large_dense += border_obstacle
 
 		//Then, check the turf itself
-		if (!T.Cross(AM, T))
+		if (!T.CrossCheck(AM, T))
 			return ..()
 
 		//Finally, check objects/mobs to block entry that are not on the border
 		for(var/atom/movable/obstacle in large_dense)
-			if(!obstacle.Cross(AM, AM.loc) && AM != obstacle)
+			if(!obstacle.CrossCheck(AM, AM.loc) && AM != obstacle)
 				return ..()
 		AM.loc = src.loc
 		to_chat(AM, "<span class='info'>You slip under the tube.</span>")

--- a/code/game/objects/structures/vehicles/wizmobile.dm
+++ b/code/game/objects/structures/vehicles/wizmobile.dm
@@ -38,7 +38,7 @@
 
 /* Server vote on 16-12-2014 to disable wallmoving (10-7 Y)
 // Shit be ethereal.
-/obj/structure/bed/chair/vehicle/wizmobile/Cross(atom/movable/mover, turf/target height=1.5, air_group = 0)
+/obj/structure/bed/chair/vehicle/wizmobile/CrossCheck(atom/movable/mover, turf/target height=1.5, air_group = 0)
 	return 1
 */
 

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -45,7 +45,7 @@ obj/structure/windoor_assembly/Destroy()
 /obj/structure/windoor_assembly/update_icon()
 	icon_state = "[facing]_[secure]windoor_assembly[state]"
 
-/obj/structure/windoor_assembly/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+/obj/structure/windoor_assembly/CrossCheck(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(istype(mover) && mover.checkpass(PASSGLASS))
 		return 1
 	if(get_dir(target, mover) == dir) //Make sure looking at appropriate border
@@ -54,7 +54,7 @@ obj/structure/windoor_assembly/Destroy()
 	else
 		return 1
 
-/obj/structure/windoor_assembly/Uncross(atom/movable/mover as mob|obj, turf/target as turf)
+/obj/structure/windoor_assembly/UncrossCheck(atom/movable/mover as mob|obj, turf/target as turf)
 	if(istype(mover) && mover.checkpass(PASSGLASS))
 		return 1
 	if(flags & ON_BORDER)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -145,7 +145,7 @@
 		health -= damage
 		healthcheck()
 
-/obj/structure/window/Uncross(var/atom/movable/mover, var/turf/target)
+/obj/structure/window/UncrossCheck(var/atom/movable/mover, var/turf/target)
 	if(istype(mover) && mover.checkpass(PASSGLASS))
 		return 1
 	if(flags & ON_BORDER)
@@ -157,7 +157,7 @@
 			return !density
 	return 1
 
-/obj/structure/window/Cross(atom/movable/mover, turf/target, height = 0)
+/obj/structure/window/CrossCheck(atom/movable/mover, turf/target, height = 0)
 	if(istype(mover) && mover.checkpass(PASSGLASS))
 		return 1
 	if(get_dir(loc, target) == dir || get_dir(loc, mover) == dir)
@@ -404,7 +404,7 @@
 	if(!is_fulltile())
 		if(get_dir(user, src) & dir)
 			for(var/obj/O in loc)
-				if(!O.Cross(user, user.loc, 1, 0))
+				if(!O.CrossCheck(user, user.loc, 1, 0))
 					return 0
 	return 1
 

--- a/code/game/shuttle_engines.dm
+++ b/code/game/shuttle_engines.dm
@@ -13,7 +13,7 @@
 /obj/structure/shuttle/window/shuttle_rotate(angle) //WOW
 	src.transform = turn(src.transform, angle)
 
-/obj/structure/shuttle/window/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+/obj/structure/shuttle/window/CrossCheck(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(!height || air_group)
 		return 0
 	else

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -62,7 +62,7 @@ var/list/mechtoys = list(
 	..()
 	to_chat(user, "It appears to be [anchored? "anchored to" : "unachored from"] the floor, [airtight? "and it seems to be airtight as well." : "but it does not seem to be airtight."]")
 
-/obj/structure/plasticflaps/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+/obj/structure/plasticflaps/CrossCheck(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(istype(mover) && mover.checkpass(PASSGLASS))
 		return prob(60)
 

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -56,7 +56,7 @@ var/image/list/w_overlays = list("wet" = image('icons/effects/water.dmi',icon_st
 /turf/simulated/floor/melt() // Melting is different.
 	burn_tile()
 
-//turf/simulated/floor/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+//turf/simulated/floor/CrossCheck(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 //	if ((istype(mover, /obj/machinery/vehicle) && !(src.burnt)))
 //		if (!( locate(/obj/machinery/mass_driver, src) ))
 //			return 0

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -120,6 +120,10 @@
 /turf/Enter(atom/movable/mover as mob|obj, atom/forget as mob|obj|turf|area)
 	if(!mover)
 		return 1
+	for(var/atom/movable/AM in src)
+		if(AM.flags & ON_BORDER)
+			if(!AM.Cross(mover, src, 0))
+				return 0
 	. = ..()
 	if(.)
 		return !density //Nothing found to block so return success!

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -425,7 +425,7 @@
 	var/turf/in_T = get_step(src, in_dir)
 	var/turf/out_T = get_step(src, out_dir)
 
-	if(!in_T.Cross(mover, in_T) || !in_T.Enter(mover) || !out_T.Cross(mover, out_T) || !out_T.Enter(mover))
+	if(!in_T.CrossCheck(mover, in_T) || !in_T.Enter(mover) || !out_T.CrossCheck(mover, out_T) || !out_T.Enter(mover))
 		return
 
 	grab_ores() //Grab some more ore to process this tick.

--- a/code/modules/mining/machine_stacking.dm
+++ b/code/modules/mining/machine_stacking.dm
@@ -189,7 +189,7 @@
 	var/turf/in_T = get_step(src, in_dir)
 	var/turf/out_T = get_step(src, out_dir)
 
-	if(!in_T.Cross(mover, in_T) || !in_T.Enter(mover) || !out_T.Cross(mover, out_T) || !out_T.Enter(mover))
+	if(!in_T.CrossCheck(mover, in_T) || !in_T.Enter(mover) || !out_T.CrossCheck(mover, out_T) || !out_T.Enter(mover))
 		return
 
 	var/obj/item/stack/stack

--- a/code/modules/mining/ore_redemption.dm
+++ b/code/modules/mining/ore_redemption.dm
@@ -166,7 +166,7 @@
 /obj/machinery/mineral/ore_redemption/ex_act()
 	return //So some chucklefuck doesn't ruin miners reward with an explosion
 
-/obj/machinery/mineral/ore_redemption/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+/obj/machinery/mineral/ore_redemption/CrossCheck(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(air_group)
 		return 0
 	if(istype(mover) && mover.checkpass(PASSGLASS))

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -148,7 +148,7 @@
 	return ghostMulti
 
 
-/mob/dead/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+/mob/dead/CrossCheck(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	return 1
 /*
 Transfer_mind is there to check if mob is being deleted/not going to have a body.

--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -679,11 +679,11 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 				check_1 = 1
 				for(var/obj/border_obstacle in Step_1)
 					if(border_obstacle.flags & ON_BORDER)
-						if(!border_obstacle.Uncross(D, A))
+						if(!border_obstacle.UncrossCheck(D, A))
 							check_1 = 0
 				for(var/obj/border_obstacle in get_turf(A))
 					if((border_obstacle.flags & ON_BORDER) && (src != border_obstacle))
-						if(!border_obstacle.Cross(D, D.loc, 1, 0))
+						if(!border_obstacle.CrossCheck(D, D.loc, 1, 0))
 							check_1 = 0
 
 			D.loc = src.loc
@@ -692,11 +692,11 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 
 				for(var/obj/border_obstacle in Step_2)
 					if(border_obstacle.flags & ON_BORDER)
-						if(!border_obstacle.Uncross(D, A))
+						if(!border_obstacle.UncrossCheck(D, A))
 							check_2 = 0
 				for(var/obj/border_obstacle in get_turf(A))
 					if((border_obstacle.flags & ON_BORDER) && (src != border_obstacle))
-						if(!border_obstacle.Cross(D, D.loc, 1, 0))
+						if(!border_obstacle.CrossCheck(D, D.loc, 1, 0))
 							check_2 = 0
 			if(check_1 || check_2)
 				ok = 1
@@ -709,13 +709,13 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 			//Now, check objects to block exit that are on the border
 			for(var/obj/border_obstacle in src.loc)
 				if(border_obstacle.flags & ON_BORDER)
-					if(!border_obstacle.Uncross(D, A))
+					if(!border_obstacle.UncrossCheck(D, A))
 						ok = 0
 
 			//Next, check objects to block entry that are on the border
 			for(var/obj/border_obstacle in get_turf(A))
 				if((border_obstacle.flags & ON_BORDER) && (A != border_obstacle))
-					if(!border_obstacle.Cross(D, D.loc, 1, 0))
+					if(!border_obstacle.CrossCheck(D, D.loc, 1, 0))
 						ok = 0
 
 	//del(D)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1157,7 +1157,7 @@ default behaviour is:
 					continue
 				if(A.density)
 					if(A.flags&ON_BORDER)
-						dense = !A.Cross(src, src.loc)
+						dense = !A.CrossCheck(src, src.loc)
 					else
 						dense = 1
 				if(dense) break

--- a/code/modules/mob/living/simple_animal/bees.dm
+++ b/code/modules/mob/living/simple_animal/bees.dm
@@ -61,7 +61,7 @@
 
 	qdel(src)
 
-/mob/living/simple_animal/bee/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+/mob/living/simple_animal/bee/CrossCheck(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	return 1
 
 /mob/living/simple_animal/bee/attackby(var/obj/item/O as obj, var/mob/user as mob)

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -120,7 +120,7 @@
 	var/turf/target_turf = get_step(src,dir)
 	//CanReachThrough(src.loc, target_turf, src)
 	var/can_fit_under = 0
-	if(target_turf.ZCrossCheck(get_turf(src),1))
+	if(target_turf.ZCross(get_turf(src),1))
 		can_fit_under = 1
 
 	..(dir)
@@ -129,7 +129,7 @@
 	for(var/d in cardinal)
 		var/turf/O = get_step(T,d)
 		//Simple pass check.
-		if(O.ZCrossCheck(T, 1) && !(O in open) && !(O in closed) && O in possibles)
+		if(O.ZCross(T, 1) && !(O in open) && !(O in closed) && O in possibles)
 			open += O
 			*/
 

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -120,7 +120,7 @@
 	var/turf/target_turf = get_step(src,dir)
 	//CanReachThrough(src.loc, target_turf, src)
 	var/can_fit_under = 0
-	if(target_turf.ZCross(get_turf(src),1))
+	if(target_turf.ZCrossCheck(get_turf(src),1))
 		can_fit_under = 1
 
 	..(dir)
@@ -129,7 +129,7 @@
 	for(var/d in cardinal)
 		var/turf/O = get_step(T,d)
 		//Simple pass check.
-		if(O.ZCross(T, 1) && !(O in open) && !(O in closed) && O in possibles)
+		if(O.ZCrossCheck(T, 1) && !(O in open) && !(O in closed) && O in possibles)
 			open += O
 			*/
 

--- a/code/modules/mob/living/simple_animal/hostile/frog.dm
+++ b/code/modules/mob/living/simple_animal/hostile/frog.dm
@@ -80,7 +80,7 @@
 	update_spear()
 	..()
 
-/mob/living/simple_animal/hostile/frog/Cross(obj/item/weapon/spear/S)
+/mob/living/simple_animal/hostile/frog/CrossCheck(obj/item/weapon/spear/S)
 	.=..()
 
 	if(!locked_to && !throwing && !isDead() && istype(S) && S.throwing && isturf(S.loc))

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/effects.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/effects.dm
@@ -67,7 +67,7 @@
 	if (prob(50))
 		icon_state = "stickyweb2"
 
-/obj/effect/spider/stickyweb/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+/obj/effect/spider/stickyweb/CrossCheck(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(air_group || (height==0)) return 1
 	if(istype(mover, /mob/living/simple_animal/hostile/giant_spider))
 		return 1

--- a/code/modules/mob/living/simple_animal/hostile/viscerator.dm
+++ b/code/modules/mob/living/simple_animal/hostile/viscerator.dm
@@ -38,7 +38,7 @@
 	qdel (src)
 	return
 
-/mob/living/simple_animal/hostile/viscerator/Cross(atom/movable/mover, turf/target, height = 1.5, air_group = 0)
+/mob/living/simple_animal/hostile/viscerator/CrossCheck(atom/movable/mover, turf/target, height = 1.5, air_group = 0)
 	if(air_group || (height == 0))
 		return 1
 	if(istype(mover, /mob/living/simple_animal/hostile/viscerator))

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -1,4 +1,4 @@
-/mob/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+/mob/CrossCheck(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(air_group || (height==0)) return 1
 
 	if(ismob(mover))

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -435,13 +435,13 @@
 			continue
 		if(AM.density)
 			if(AM.flags&ON_BORDER)
-				if(!AM.Cross(user, src.loc))
+				if(!AM.CrossCheck(user, src.loc))
 					return 1
 			else
 				return 1
 	return 0
 
-/obj/machinery/photocopier/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+/obj/machinery/photocopier/CrossCheck(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(air_group || (height==0)) return 1
 
 	return (!mover.density || !density || mover.pass_flags)

--- a/code/modules/power/antimatter/shielding.dm
+++ b/code/modules/power/antimatter/shielding.dm
@@ -73,7 +73,7 @@ proc/cardinalrange(var/center)
 	return
 
 
-/obj/machinery/am_shielding/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+/obj/machinery/am_shielding/CrossCheck(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(air_group || (height==0))	return 1
 	return 0
 

--- a/code/modules/power/treadmill.dm
+++ b/code/modules/power/treadmill.dm
@@ -77,7 +77,7 @@
 				runner.bodytemperature = max(T0C + 100,cached_temp)
 	else to_chat(runner,"<span class='warning'>You're exhausted! You can't run anymore!</span>")
 
-/obj/machinery/power/treadmill/Uncross(var/atom/movable/mover, var/turf/target)
+/obj/machinery/power/treadmill/UncrossCheck(var/atom/movable/mover, var/turf/target)
 	if(istype(mover) && mover.checkpass(PASSGLASS))
 		return 1
 	if(flags & ON_BORDER)
@@ -89,7 +89,7 @@
 			return !density
 	return 1
 
-/obj/machinery/power/treadmill/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+/obj/machinery/power/treadmill/CrossCheck(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(istype(mover) && mover.checkpass(PASSGLASS))
 		return 1
 	if(get_dir(loc, target) == dir || get_dir(loc, mover) == dir)

--- a/code/modules/projectiles/guns/hookshot.dm
+++ b/code/modules/projectiles/guns/hookshot.dm
@@ -318,7 +318,7 @@
 	var/datum/chain/chain_datum = null
 	var/rewinding = 0
 
-/obj/effect/overlay/chain/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+/obj/effect/overlay/chain/CrossCheck(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	return 1
 
 /obj/effect/overlay/chain/update_icon()

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -351,7 +351,7 @@ var/list/impact_master = list()
 	bullet_die()
 	return 1
 
-/obj/item/projectile/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+/obj/item/projectile/CrossCheck(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(air_group || (height==0)) return 1
 
 	if(istype(mover, /obj/item/projectile))

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -409,7 +409,7 @@ var/list/beam_master = list()
 			X = null
 			break
 		for(var/atom/movable/O in TT)
-			if(!O.Cross(src))
+			if(!O.CrossCheck(src))
 				qdel(X)
 				broke = 1
 				break

--- a/code/modules/projectiles/projectile/rocket.dm
+++ b/code/modules/projectiles/projectile/rocket.dm
@@ -143,7 +143,7 @@
 
 	sleep(sleeptime)
 
-/obj/item/projectile/nikita/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+/obj/item/projectile/nikita/CrossCheck(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	return (!density || !height || air_group)
 
 /obj/item/projectile/nikita/proc/check_user()

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -426,7 +426,7 @@
 		H.vent_gas(loc)
 		qdel(H)
 
-/obj/machinery/disposal/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+/obj/machinery/disposal/CrossCheck(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if (istype(mover,/obj/item) && mover.throwing)
 		var/obj/item/I = mover
 		if(istype(I, /obj/item/weapon/dummy) || istype(I, /obj/item/projectile))

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -273,7 +273,7 @@
 	var/turf/out_T = get_step(src, output_dir)
 	var/turf/filter_T = get_step(src, filter_dir)
 
-	if(!out_T.Cross(mover, out_T) || !out_T.Enter(mover) || !filter_T.Cross(mover, filter_T) || !filter_T.Enter(mover))
+	if(!out_T.CrossCheck(mover, out_T) || !out_T.Enter(mover) || !filter_T.CrossCheck(mover, filter_T) || !filter_T.Enter(mover))
 		return
 
 	var/affecting = in_T.contents

--- a/code/modules/research/rdmachines.dm
+++ b/code/modules/research/rdmachines.dm
@@ -65,7 +65,7 @@ var/global/list/rnd_machines = list()
 	if(shocked>0)
 		shocked--
 
-/obj/machinery/r_n_d/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+/obj/machinery/r_n_d/CrossCheck(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(istype(mover) && mover.checkpass(PASSMACHINE))
 		return 1
 	return ..()

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -141,7 +141,7 @@
 	qdel(src)
 	return 20000
 
-/obj/machinery/power/supermatter/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+/obj/machinery/power/supermatter/CrossCheck(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(istype(mover,/obj/structure/closet/crate/secure/large/reinforced))
 		return 1
 	. = ..()


### PR DESCRIPTION
How it works:
Every instance of `Cross()` in the codebase was changed to `CrossCheck()`. This applies to both definitions and calls.
On the `/atom/movable` level, `Cross()` is defined to call `CrossCheck()` and, if that returns false (and the object being crossed is dense and on a turf), the object being crossed moves itself to the beginning of its `loc`'s `contents`. This causes it to be the object that gets bumped.
Also, border objects are checked before anything else, to prevent that causing nonsense.

Problems:
1. I don't like the way I made it check border objects first. It works, but it's not exactly great code. I'll try to figure out a better way to do it.
2. Mobs are fucky. Apparently, they are handled differently from all other `/atom/movable`s and cannot be manually inserted into `contents`, so they still don't work. I can't think of a way around this other than moving all OTHER dense objects to the END of contents when a mob should be bumped. That sounds like an awful solution and I'd rather not use it, but I will if nothing better comes up.
