### PR TITLE
Ghosts no longer get the "Boo!" spell and their poltergeist abilities.

### DIFF
--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -89,6 +89,10 @@
 	src.attack_hand(user)
 
 /obj/machinery/light_switch/attack_ghost(var/mob/dead/observer/G)
+	return
+
+/*
+/obj/machinery/light_switch/attack_ghost(var/mob/dead/observer/G)
 	if(blessed)
 		to_chat(G, "Your hand goes right through the switch...Is that some holy water dripping from it?")
 		return 0
@@ -96,6 +100,7 @@
 		to_chat(G, "Your poltergeist abilities are still cooling down.")
 		return 0
 	return ..()
+*/
 
 /obj/machinery/light_switch/attack_hand(mob/user)
 	if(buildstage != 2) return

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -26,7 +26,7 @@
 	var/can_reenter_corpse
 	var/datum/hud/living/carbon/hud = null // hud
 	var/bootime = 0
-	var/next_poltergeist = 0
+//	var/next_poltergeist = 0
 	var/started_as_observer //This variable is set to 1 when you enter the game as an observer.
 							//If you died in the game and are a ghsot - this will remain as null.
 							//Note that this is not a reliable way to determine if admins started as observers, since they change mobs a lot.
@@ -44,8 +44,8 @@
 	see_in_dark = 100
 	verbs += /mob/dead/observer/proc/dead_tele
 
-	// Our new boo spell.
-	add_spell(new /spell/aoe_turf/boo, "grey_spell_ready")
+	// Our new boo spell. NOT ANYMORE!
+	//add_spell(new /spell/aoe_turf/boo, "grey_spell_ready")
 
 	can_reenter_corpse = flags & GHOST_CAN_REENTER
 	started_as_observer = flags & GHOST_IS_OBSERVER
@@ -104,7 +104,7 @@
 		name = capitalize(pick(first_names_male)) + " " + capitalize(pick(last_names))
 	real_name = name
 
-	start_poltergeist_cooldown() //FUCK OFF GHOSTS
+//	start_poltergeist_cooldown() //FUCK OFF GHOSTS
 	..()
 
 /mob/dead/observer/Destroy()
@@ -312,7 +312,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			if(ghost.client)
 				ghost.client.time_died_as_mouse = world.time //We don't want people spawning infinite mice on the station
 	return
-
+/*
 // Check for last poltergeist activity.
 /mob/dead/observer/proc/can_poltergeist(var/start_cooldown=1)
 	if(world.time >= next_poltergeist)
@@ -326,7 +326,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 /mob/dead/observer/proc/reset_poltergeist_cooldown()
 	next_poltergeist=0
-
+*/
 /* WHY
 /mob/dead/observer/Move(NewLoc, direct)
 	dir = direct

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -419,10 +419,14 @@ var/global/list/obj/machinery/light/alllights = list()
 		update(0)
 
 /obj/machinery/light/attack_ghost(mob/user)
+	return
+/*
+/obj/machinery/light/attack_ghost(mob/user)
 	if(blessed) return
 	src.add_hiddenprint(user)
 	src.flicker(1)
 	return
+*/
 
 // ai attack - make lights flicker, because why not
 /obj/machinery/light/attack_ai(mob/user)


### PR DESCRIPTION
The actual "Boo!" spell is uncommented. In fact, `modules\mob\dead\observer\spells.dm` is completely unchanged,  leaving all references to it intact. The same also applies to `spook()`.

Fixes #11239 
Discussion is up there. Please only talk about the code in this PR.
