### PR TITLE
Toolboxes can hold normal-size items

### DIFF
--- a/code/game/machinery/bots/floorbot.dm
+++ b/code/game/machinery/bots/floorbot.dm
@@ -1,6 +1,6 @@
 //Floorbot assemblies
 /obj/item/weapon/toolbox_tiles
-	desc = "It's a toolbox with tiles sticking out the top"
+	desc = "It's a toolbox with tiles sticking out the top."
 	name = "tiles and toolbox"
 	icon = 'icons/obj/aibots.dmi'
 	icon_state = "toolbox_tiles"
@@ -13,7 +13,7 @@
 	var/created_name = "Floorbot"
 
 /obj/item/weapon/toolbox_tiles_sensor
-	desc = "It's a toolbox with tiles sticking out the top and a sensor attached"
+	desc = "It's a toolbox with tiles sticking out the top and a sensor attached."
 	name = "tiles, toolbox and sensor arrangement"
 	icon = 'icons/obj/aibots.dmi'
 	icon_state = "toolbox_tiles_sensor"
@@ -706,14 +706,11 @@ var/global/list/floorbot_targets=list()
 
 
 /obj/item/weapon/storage/toolbox/mechanical/attackby(var/obj/item/stack/tile/plasteel/T, mob/user as mob)
-	if(!istype(T, /obj/item/stack/tile/plasteel))
-		. = ..()
-		return
-	if(src.contents.len >= 1)
-		to_chat(user, "<span class='notice'>They wont fit in as there is already stuff inside.</span>")
-		return
-	if(user.s_active)
-		user.s_active.close(user)
+	if(!istype(T, /obj/item/stack/tile/plasteel) || src.contents.len >= 1) //Only do this if the thing is empty
+		return ..()
+	/*if(user.s_active)
+		user.s_active.close(user)*/
+	user.remove_from_mob(T)
 	qdel(T)
 	T = null
 	var/obj/item/weapon/toolbox_tiles/B = new /obj/item/weapon/toolbox_tiles

--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -17,9 +17,10 @@
 	melt_temperature = MELTPOINT_STEEL
 	origin_tech = "combat=1"
 	attack_verb = list("robusts", "batters", "staves in")
+	fits_max_w_class = W_CLASS_MEDIUM
 	storage_slots = 14
 	max_combined_w_class = 28
-	fits_ignoring_w_class = list(
+	/*fits_ignoring_w_class = list(
 		"/obj/item/weapon/weldingtool/hugetank",
 		"/obj/item/device/rcd/matter/engineering",
 		"/obj/item/device/rcd/rpd",
@@ -34,7 +35,10 @@
 		"/obj/item/stack/sheet/glass",
 		"/obj/item/stack/sheet/mineral",
 		"/obj/item/stack/sheet/wood"
-		)
+		)*/
+
+
+//see /obj/item/weapon/storage/toolbox/mechanical/attackby(var/obj/item/stack/tile/plasteel/T, mob/user as mob) override in floorbot.dm
 
 /obj/item/weapon/storage/toolbox/suicide_act(mob/user)
 	to_chat(viewers(user), "<span class='danger'>[user] is [pick("staving","robusting")] \his head in with the [src.name]! It looks like \he's  trying to commit suicide!</span>")

--- a/html/changelogs/asaffasfasfasfasasdasdasfasdgfasdfsasfd.yml
+++ b/html/changelogs/asaffasfasfasfasasdasdasfasdgfasdfsasfd.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general deleting of nice things)
+#   rscadd (general adding of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.
+author: 9600bauds
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# There needs to be a space after the - and before the prefix. Don't use tabs anywhere in this file.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# If you're using characters such as # ' : - or the like in your changelog, surround the entire change with quotes as shown in the second example. These quotes don't show up on the changelog once it's merged and prevent errors.
+# SCREW ANY OF THIS UP AND IT WON'T WORK.
+changes: 
+- tweak: "Toolboxes can now hold normal-size items, just like backpacks."


### PR DESCRIPTION
Some people think toolboxes are still useless even after they were buffed, so there should be no problem with this buff :^)
After all, right now you could just find a backpack easily and carry that around instead of the toolbox
