### PR TITLE
Removed the blob conglomerate event from being able to randomly happen, made the blob storm event less likely to happen.

### DIFF
--- a/code/modules/events/event_dynamic.dm
+++ b/code/modules/events/event_dynamic.dm
@@ -64,10 +64,9 @@ var/list/event_last_fired = list()
 		possibleEvents[/datum/event/meteor_wave] = 15
 		possibleEvents[/datum/event/meteor_shower] = 40
 		possibleEvents[/datum/event/immovable_rod] = 15
-		possibleEvents[/datum/event/thing_storm/blob_shower] = 15//Blob Cluster
 
 	if((active_with_role["Engineer"] > 1) && (active_with_role["Security"] > 1) && (living >= BLOB_CORE_PROPORTION))
-		possibleEvents[/datum/event/thing_storm/blob_storm] = 10//Blob Conglomerate
+		possibleEvents[/datum/event/thing_storm/blob_shower] = 10//Blob Cluster
 
 	possibleEvents[/datum/event/radiation_storm] = 50
 	if(active_with_role["Medical"] > 1)

--- a/html/changelogs/blobsucksremoveblob.yml
+++ b/html/changelogs/blobsucksremoveblob.yml
@@ -1,0 +1,4 @@
+author: Intigracy
+delete-after: True
+changes: 
+- tweak: "Removed the blob conglomerate event from being able to randomly happen, made the blob storm event less likely to happen."


### PR DESCRIPTION
Let's go over why blob is bullshit in its current form:

Blob conglomerate will end the round. Regardless of what you do, you're going to get fucked when there's multiple blobs spawning at once.

Every blob type that isn't the standard blob is immune to fire. Even the standard blob type dies so slow that blobs can just continually replace them, or can just bump them up to strong blobs.

Blobs are almost entirely immune to bombs.

You don't even need to be connected to a blob piece to put new pieces down next to it. In some cases, you can just keep spam clicking on a tile and replacing a piece that is THE ONLY PIECE AROUND.

You can put blob pieces down next to pieces that aren't even yours, resulting in blobs ganging up on the crew.

Blobs have fast enough resource gain that you cannot kill them without almost the entire crew dropping everything they're doing and focusing on the blob. In the case of one spawning mid round, you're already going to have dead crew making this not possible. Then there's MULTIPLE you have to deal with.

BLOBS CAN SPAWN MORE BLOB PLAYERS WITH THEIR OWN RESOURCE POOL

10 blobs ended up spawned within 10 minutes as a result of this event, completely overrunning the station in that time.

You now need 20 players to get a blob storm, and blob conglomerate is removed from randomly firing.
