### PR TITLE
Fixes borg leg no go

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -369,11 +369,11 @@
 	if(modtype == "Medical" || modtype == "Security" || modtype == "Combat")
 		status_flags &= ~CANPUSH
 
+	var/picked  = pick(module_sprites)
+	icon_state = module_sprites[picked]
+		
 	if(!forced_module)
 		choose_icon(6, module_sprites)
-	else
-		var/picked  = pick(module_sprites)
-		icon_state = module_sprites[picked]
 
 	base_icon = icon_state
 	SetEmagged(emagged) // Update emag status and give/take emag modules away
@@ -1483,13 +1483,10 @@
 	else
 		triesleft--
 
-	lockcharge = 1  //Locks borg until it select an icon to avoid secborgs running around with a standard sprite
-
 	var/icontype = input("Select an icon! [triesleft>0 ? "You have [triesleft] more chances." : "This is your last try."]", "Robot", null, null) as null|anything in module_sprites
 
 	if(icontype)
 		icon_state = module_sprites[icontype]
-		lockcharge = null
 	else
 		triesleft++
 		return

--- a/html/changelogs/sjeggd.yml
+++ b/html/changelogs/sjeggd.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general deleting of nice things)
+#   rscadd (general adding of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.
+author: 9600bauds
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# There needs to be a space after the - and before the prefix. Don't use tabs anywhere in this file.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# If you're using characters such as # ' : - or the like in your changelog, surround the entire change with quotes as shown in the second example. These quotes don't show up on the changelog once it's merged and prevent errors.
+# SCREW ANY OF THIS UP AND IT WON'T WORK.
+changes: 
+- bugfix: "Fixed borgs becoming unable to move if they pressed Cancel when prompted to choose their appearance."


### PR DESCRIPTION
fixes #7555
fixes #7001
Apparently this was a badly implemented "feature" that was there to prevent borgs from not selecting an appearance and just doing their shit with the default sprite, so part of this fix involved giving the borg a random appearance immediately upon selecting the module (they can still change it obviously)
