### PR TITLE
Sleeper buff

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -260,12 +260,11 @@
 		T += SP.rating
 	switch(T)
 		if(0 to 5)
-			available_options = list(INAPROVALINE = "Inaprovaline", STOXIN = "Soporific", DERMALINE = "Dermaline", BICARIDINE = "Bicaridine", DEXALIN = "Dexalin")
+			available_options = list(INAPROVALINE = "Inaprovaline", STOXIN = "Soporific", KELOTANE = "kelotane", BICARIDINE = "Bicaridine", DEXALIN = "Dexalin")
 		if(6 to 8)
-			available_options = list(INAPROVALINE = "Inaprovaline", STOXIN = "Soporific", DERMALINE = "Dermaline", BICARIDINE = "Bicaridine", DEXALIN = "Dexalin", PHALANXIMINE = "Phalanximine")
+			available_options = list(INAPROVALINE = "Inaprovaline", STOXIN = "Soporific", DERMALINE = "Dermaline", BICARIDINE = "Bicaridine", DEXALIN = "Dexalin", IMIDAZOLINE = "Imidazoline" , INACUSIATE = "Inacusiate" ,  TRICORDRAZINE = "Tricordrazine")
 		else
-			available_options = list(INAPROVALINE = "Inaprovaline", STOXIN = "Soporific", DERMALINE = "Dermaline", BICARIDINE = "Bicaridine", DEXALIN = "Dexalin", PHALANXIMINE = "Phalanximine", SPACEACILLIN = "Spaceacillin")
-
+			available_options = list(INAPROVALINE = "Inaprovaline", STOXIN = "Soporific", DERMALINE = "Dermaline", BICARIDINE = "Bicaridine", DEXALIN = "Dexalin", IMIDAZOLINE = "Imidazoline" , INACUSIATE = "Inacusiate" ,  TRICORDRAZINE = "Tricordrazine" , ALKYSINE = "Alkysine" , TRAMADOL = "Tramadol" , CHARCOAL = "Activated Charcoal")
 
 /obj/machinery/sleeper/MouseDrop_T(atom/movable/O as mob|obj, mob/user as mob)
 	if(!ismob(O)) //mobs only


### PR DESCRIPTION
This piece of shitty code that i made a few months ago changes how upgraded sleepers chems without changing their base functionality. Mechanics like the anti OD chem limits, only invapro in crit and basic sleeper functionallity are untouched by this. Instead it changes the chems that are in the upgrades. T1 parts (roundstart) have had dremaline removed and replaced with kelotane for balance. T2 parts (nano manipulators and advanced scanners) remove the kelotane and put dremaline back in its place and adds in Imidazoline, Inacusiate, and tricordrazine. T3 (pico manipulators and phasic scanners) adds in all of the previously mentioned chems in T2 parts aswell as alkysine, tramadol, and activated charcoal. I had picked these random and marginally usefull chems as their are miscellaneous and usually not made by the wild ride but could still be usefull at that exact moment. I could not add anti tox otherwise you would be able to synthesize 700u of tricord by spamming invapro and anti tox so i went with activated charcoal instead.
