### PR TITLE
Revsquad, a revolution variant

### DIFF
--- a/code/datums/statistics/stat_blob.dm
+++ b/code/datums/statistics/stat_blob.dm
@@ -59,3 +59,20 @@
 		for(var/module in bought_modules)
 			modulestring += "|[module]"
 		file << modulestring
+
+/datum/stat_blob/revsquad
+	var/revsquad_won = 0
+	var/list/revsquad_items = list()
+	var/headcount = 0
+
+/datum/stat_blob/revsquad/doPostRoundChecks()
+	var/list/heads = ticker.mode.get_all_heads()
+	headcount = heads.len
+
+/datum/stat_blob/revsquad/writeStats(file)
+	file << "REVSQUADSTATS|[revsquad_won]|[headcount]"
+	if(revsquad_items.len)
+		var/itemsline = "REVSQUADITEMS"
+		for(var/i in revsquad_items)
+			itemsline += "|[i]"
+		file << itemsline

--- a/code/datums/statistics/statcollection.dm
+++ b/code/datums/statistics/statcollection.dm
@@ -42,6 +42,7 @@
 	var/datum/stat_blob/xeno/xeno = new
 	var/datum/stat_blob/blobmode/blobblob = new
 	var/datum/stat_blob/malf/malf = new
+	var/datum/stat_blob/revsquad/revsquad = new
 
 	var/gamemode = "UNSET"
 	var/mixed_gamemodes = null

--- a/code/game/gamemodes/revolution/rev_squad.dm
+++ b/code/game/gamemodes/revolution/rev_squad.dm
@@ -1,0 +1,143 @@
+/datum/game_mode/rev_squad
+  name = "Revolution Squad"
+  config_tag = "revsquad"
+  restricted_jobs = list("Security Officer", "Warden", "Detective", "AI", "Cyborg","Mobile MMI","Captain", "Head of Personnel", "Head of Security", "Chief Engineer", "Research Director", "Chief Medical Officer", "Internal Affairs Agent")
+  desc = "A variant of revolution, with an emphasis on a small group with co-ordinated efforts instead of greytiding"
+
+  required_players = 4
+  required_players_secret = 25
+  required_enemies = 3
+  recommended_enemies = 3
+  var/finished = 0
+  var/checkwin_counter = 0
+  var/max_headrevs = 3
+  var/const/waittime_l = 600 //lower bound on time before intercept arrives (in tenths of seconds)
+  var/const/waittime_h = 1800 //upper bound on time before intercept arrives (in tenths of seconds)
+
+  var/possible_items = list(/obj/item/weapon/card/emag,
+                            /obj/item/clothing/gloves/yellow,
+                            /obj/item/weapon/gun/projectile/automatic,
+                            /obj/item/device/flash/revsquad,
+                            /obj/item/weapon/gun/projectile/shotgun/doublebarrel/sawnoff
+                            )
+  var/flash_uses = 1 // Number of times a specially spawned flash can convert normal crew members.
+
+
+/datum/game_mode/rev_squad/announce()
+	to_chat(world, "<B>The current game mode is - Revolution Squad!</B>")
+	to_chat(world, "<B>Some crewmembers are members of an organized group attempting to assassinate the heads of this station!<BR>\nRevolutionaries - Kill the Captain, HoP, HoS, CE, RD and CMO. \nPersonnel - Protect the heads of staff. Kill the revolutionaries.</B>")
+
+
+/datum/game_mode/revsquad/pre_setup()
+
+	if(config.protect_roles_from_antagonist)
+		restricted_jobs += protected_jobs
+
+	var/list/datum/mind/possible_revs = get_players_for_role(ROLE_REV)
+
+	var/head_check = 0
+	for(var/mob/new_player/player in player_list)
+		if(player.mind.assigned_role in command_positions)
+			head_check++
+
+	for(var/datum/mind/player in possible_revs)
+		for(var/job in restricted_jobs)//Removing heads and such from the list
+			if(player.assigned_role == job)
+				possible_revs -= player
+
+	for (var/i=1 to max_headrevs)
+		if (possible_revs.len==0)
+			break
+		var/datum/mind/lenin = pick(possible_revs)
+		possible_revs -= lenin
+		head_revolutionaries += lenin
+
+	if((revolutionaries.len==0)||(!head_check))
+		log_admin("Failed to set-up a round of revsquad. Couldn't find any heads of staffs or any volunteers to be revolutionaries.")
+		message_admins("Failed to set-up a round of revsquad. Couldn't find any heads of staffs or any volunteers to be revolutionaries.")
+		return 0
+
+	log_admin("Starting a round of revsquad with [head_revolutionaries.len] revolutionaries and [head_check] heads of staff.")
+	message_admins("Starting a round of revsquad with [head_revolutionaries.len] revolutionaries and [head_check] heads of staff.")
+	return 1
+
+/datum/game_mode/revolution/post_setup()
+	var/list/heads = get_living_heads()
+
+	for(var/datum/mind/rev_mind in head_revolutionaries)
+		for(var/datum/mind/head_mind in heads)
+			var/datum/objective/mutiny/rev_obj = new
+			rev_obj.owner = rev_mind
+			rev_obj.target = head_mind
+			rev_obj.explanation_text = "Assassinate [head_mind.name], the [head_mind.assigned_role]."
+			rev_mind.objectives += rev_obj
+
+		equip_revsquad(rev_mind.current)
+		update_rev_icons_added(rev_mind)
+
+	for(var/datum/mind/rev_mind in head_revolutionaries)
+		greet_revsquad(rev_mind)
+	modePlayer += head_revolutionaries
+	if(emergency_shuttle)
+		emergency_shuttle.always_fake_recall = 1
+	spawn (rand(waittime_l, waittime_h))
+		if(!mixed) send_intercept()
+	..()
+
+/datum/game_mode/revsquad/process()
+	checkwin_counter++
+	if(checkwin_counter >= 5)
+		if(!finished)
+			ticker.mode.check_win()
+		checkwin_counter = 0
+	return 0
+
+/datum/game_mode/proc/greet_revsquad(var/datum/mind/rev_mind, var/you_are=1)
+	var/obj_count = 1
+	if (you_are)
+		to_chat(rev_mind.current, "<span class='notice'>You are a member of the organized revolutionary organization that has infiltrated this station!</span>")
+	for(var/datum/objective/objective in rev_mind.objectives)
+		to_chat(rev_mind.current, "<B>Objective #[obj_count]</B>: [objective.explanation_text]")
+		rev_mind.special_role = "Revolutionary Squad Member"
+		obj_count++
+
+  to_chat(rev_mind.current, "<br/><b>Your fellow revolutionaries are:</b>")
+  rev_mind.store_memory("<br/><b>Your fellow revolutionaries are:</b>")
+  for(var/datum/mind/M in head_revolutionaries)
+    rev_mind.store_memory("[M.assigned_role] the [assigned_job.title]")
+    to_chat(rev_mind.current, "[M.assigned_role] the [assigned_job.title]")
+
+/datum/game_mode/revsquad/proc/get_squaddie_item(/mob/living/carbon/human/mob)
+  var/obj/item/requisitioned = pick(possible_items)
+  if(istype(requisitioned, /obj/item/device/flash/revsquad))
+    requsitioned = new requsitioned(mob, uses = flash_uses)
+  else
+    requisitioned = new requisitioned(mob)
+  return requisitioned
+
+/datum/game_mode/proc/equip_revsquad(mob/living/carbon/human/mob)
+	if(!istype(mob))
+		return
+
+	if (mob.mind)
+		if (mob.mind.assigned_role == "Clown")
+			to_chat(mob, "Your training has allowed you to overcome your clownish nature, allowing you to wield weapons without harming yourself.")
+			mob.mutations.Remove(M_CLUMSY)
+
+  var/obj/item/T = get_squaddie_item(mob)
+
+	var/list/slots = list (
+		"backpack" = slot_in_backpack,
+		"left pocket" = slot_l_store,
+		"right pocket" = slot_r_store,
+	)
+	var/where = mob.equip_in_one_of_slots(T, slots, put_in_hand_if_fail = 0)
+
+	if (!where)
+		to_chat(mob, "The Syndicate were unfortunately unable to get you any special equipment.")
+	else
+		to_chat(mob, "The [T] in your [where] will help you to persuade the crew to join your cause.")
+    if(istype(T, /obj/item/weapon/flash/revsquad))
+      to_chat(mob, "<span class = 'warning'>Your [T] has [T.limited_conversions] uses for conversions, and not all of your comrades have one like it. Use it wisely.</span>")
+		mob.update_icons()
+		return 1

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -33,6 +33,7 @@
 	var/finished = 0
 	var/checkwin_counter = 0
 	var/max_headrevs = 3
+	var/minimum_heads = 3
 	var/const/waittime_l = 600 //lower bound on time before intercept arrives (in tenths of seconds)
 	var/const/waittime_h = 1800 //upper bound on time before intercept arrives (in tenths of seconds)
 ///////////////////////////
@@ -70,9 +71,9 @@
 		possible_headrevs -= lenin
 		head_revolutionaries += lenin
 
-	if((head_revolutionaries.len==0)||(!head_check))
-		log_admin("Failed to set-up a round of revolution. Couldn't find any heads of staffs or any volunteers to be head revolutionaries.")
-		message_admins("Failed to set-up a round of revolution. Couldn't find any heads of staffs or any volunteers to be head revolutionaries.")
+	if(head_revolutionaries.len==0|| head_check < minimum_heads)
+		log_admin("Failed to set-up a round of revolution. Couldn't find enough heads of staffs or any volunteers to be head revolutionaries.")
+		message_admins("Failed to set-up a round of revolution. Couldn't find enough heads of staffs or any volunteers to be head revolutionaries.")
 		return 0
 
 	log_admin("Starting a round of revolution with [head_revolutionaries.len] head revolutionaries and [head_check] heads of staff.")

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -7,6 +7,12 @@
 // If the rev icons start going wrong for some reason, ticker.mode:update_all_rev_icons() can be called to correct them.
 // If the game somtimes isn't registering a win properly, then ticker.mode.check_win() isn't being called somewhere.
 
+#define ADD_REVOLUTIONARY_FAIL_IS_COMMAND -1
+#define ADD_REVOLUTIONARY_FAIL_IS_JOBBANNED -2
+#define ADD_REVOLUTIONARY_FAIL_IS_IMPLANTED -3
+#define ADD_REVOLUTIONARY_FAIL_IS_REV -4
+
+
 /datum/game_mode
 	var/list/datum/mind/head_revolutionaries = list()
 	var/list/datum/mind/revolutionaries = list()
@@ -185,19 +191,19 @@
 ///////////////////////////////////////////////////
 /datum/game_mode/proc/add_revolutionary(datum/mind/rev_mind)
 	if(rev_mind.assigned_role in command_positions)
-		return -1
+		return ADD_REVOLUTIONARY_FAIL_IS_COMMAND
 
 	var/mob/living/carbon/human/H = rev_mind.current
 
 	if(jobban_isbanned(H, "revolutionary"))
-		return -2
+		return ADD_REVOLUTIONARY_FAIL_IS_JOBBANNED
 
 	for(var/obj/item/weapon/implant/loyalty/L in H) // check loyalty implant in the contents
 		if(L.imp_in == H) // a check if it's actually implanted
-			return -3
+			return ADD_REVOLUTIONARY_FAIL_IS_IMPLANTED
 
 	if((rev_mind in revolutionaries) || (rev_mind in head_revolutionaries))
-		return -4
+		return ADD_REVOLUTIONARY_FAIL_IS_REV
 
 	revolutionaries += rev_mind
 	to_chat(rev_mind.current, "<span class='warning'><FONT size = 3> You are now a revolutionary! Help your cause. Do not harm your fellow freedom fighters. You can identify your comrades by the red \"R\" icons, and your leaders by the blue \"R\" icons. Help them kill the heads to win the revolution!</FONT></span>")

--- a/code/game/gamemodes/revolution/revsquad.dm
+++ b/code/game/gamemodes/revolution/revsquad.dm
@@ -29,8 +29,8 @@
 								  )
 
 /datum/game_mode/revsquad/announce()
-	to_chat(world, "<B>The current game mode is - Revolution Squad!</B>")
-	to_chat(world, "<B>Some crewmembers are members of an organized group attempting to assassinate the heads of this station!<BR>\nRevolutionaries - Kill the Captain, HoP, HoS, CE, RD and CMO. \nPersonnel - Protect the heads of staff. Kill the revolutionaries.</B>")
+	to_chat(world, "<b>The current game mode is - Revolution Squad!</B>")
+	to_chat(world, "<b>Some crewmembers are members of an organized group attempting to assassinate the heads of this station!<BR>\nRevolutionaries - Kill the Captain, HoP, HoS, CE, RD and CMO. \nPersonnel - Protect the heads of staff. Kill the revolutionaries.</B>")
 
 
 /datum/game_mode/revsquad/pre_setup()
@@ -57,7 +57,7 @@
 		possible_revs -= lenin
 		head_revolutionaries += lenin
 
-	if((revolutionaries.len==0)||(!head_check))
+	if(revolutionaries.len==0 || !head_check)
 		log_admin("Failed to set-up a round of revsquad. Couldn't find any heads of staffs or any volunteers to be revolutionaries.")
 		message_admins("Failed to set-up a round of revsquad. Couldn't find any heads of staffs or any volunteers to be revolutionaries.")
 		return 0
@@ -82,11 +82,15 @@
 
 	for(var/datum/mind/rev_mind in head_revolutionaries)
 		greet_revsquad(rev_mind)
+
 	modePlayer += head_revolutionaries
+
 	if(emergency_shuttle)
 		emergency_shuttle.always_fake_recall = 1
+
 	spawn (rand(waittime_l, waittime_h))
-		if(!mixed) send_intercept()
+		if(!mixed)
+			send_intercept()
 	..()
 
 /datum/game_mode/revsquad/process()
@@ -102,7 +106,7 @@
 	if (you_are)
 		to_chat(rev_mind.current, "<span class='notice'>You are a member of the organized revolutionary organization that has infiltrated this station!</span>")
 	for(var/datum/objective/objective in rev_mind.objectives)
-		to_chat(rev_mind.current, "<B>Objective #[obj_count]</B>: [objective.explanation_text]")
+		to_chat(rev_mind.current, "<b>Objective #[obj_count]</B>: [objective.explanation_text]")
 		rev_mind.special_role = "Revolutionary Squad Member"
 		obj_count++
 
@@ -154,7 +158,7 @@
 /datum/game_mode/revsquad/proc/check_rev_victory()
 	for(var/datum/mind/rev_mind in head_revolutionaries)
 		for(var/datum/objective/objective in rev_mind.objectives)
-			if(!(objective.check_completion()))
+			if(!objective.check_completion())
 				return 0
 
 		return 1
@@ -162,7 +166,7 @@
 /datum/game_mode/revsquad/proc/check_heads_victory()
 	for(var/datum/mind/rev_mind in head_revolutionaries)
 		var/turf/T = get_turf(rev_mind.current)
-		if((rev_mind) && (rev_mind.current) && (rev_mind.current.isDead()) && T && (T.z == map.zMainStation))
+		if(rev_mind && rev_mind.current && rev_mind.current.isDead() && T && T.z == map.zMainStation)
 			if(ishuman(rev_mind.current))
 				return 0
 	return 1
@@ -173,7 +177,6 @@
 		finished = REVSQUAD_VICTORY_REVS
 	else if(check_heads_victory())
 		finished = REVSQUAD_VICTORY_HEADS
-	return
 
 ///////////////////////////////
 //Checks if the round is over//
@@ -184,10 +187,7 @@
 			if(emergency_shuttle)
 				emergency_shuttle.always_fake_recall = 0
 		return ..()
-	if(finished != 0)
-		return 1
-	else
-		return 0
+	return finished != 0
 
 /datum/game_mode/revsquad/declare_completion()
 	if(finished == REVSQUAD_VICTORY_REVS)
@@ -196,7 +196,7 @@
 		stat_collection.revsquad.revsquad_won = 1
 	else if(finished == REVSQUAD_VICTORY_HEADS)
 		feedback_set_details("round_end_result","loss - rev heads killed")
-		completion_text = "<br><span class='danger'><FONT size = 3> The heads of staff managed to stop the revolution!</FONT></span>"
+		completion_text = "<br><span class='danger'>The heads of staff managed to stop the revolution!</FONT></span>"
 	..()
 	return 1
 
@@ -207,19 +207,19 @@
 		var/icon/logo1 = icon('icons/mob/mob.dmi', "rev_head-logo")
 		end_icons += logo1
 		var/tempstate = end_icons.len
-		text += {"<img src="logo_[tempstate].png"> <FONT size = 2><B>The revolutionary squad members were:</B></FONT> <img src="logo_[tempstate].png">"}
+		text += "<img src='logo_[tempstate].png'><span class = 'big bold'The revolutionary squad members were:</span> <img src='logo_[tempstate].png'>"
 
 		for(var/datum/mind/headrev in head_revolutionaries)
 			if(headrev.current)
 				var/icon/flat = getFlatIcon(headrev.current, SOUTH, 1, 1)
 				end_icons += flat
 				tempstate = end_icons.len
-				text += {"<br><img src="logo_[tempstate].png"> <b>[headrev.key]</b> was <b>[headrev.name]</b> ("}
+				text += "<br><img src='logo_[tempstate].png'> <b>[headrev.key]</b> was <b>[headrev.name]</b> ("
 				if(headrev.current.isDead())
 					text += "died"
 					flat.Turn(90)
 					end_icons[tempstate] = flat
-				else if(headrev.current.z != 1)
+				else if(headrev.current.z != map.zMainStation)
 					text += "fled the station"
 				else
 					text += "survived the revolution"
@@ -229,7 +229,7 @@
 				var/icon/sprotch = icon('icons/effects/blood.dmi', "floor1-old")
 				end_icons += sprotch
 				tempstate = end_icons.len
-				text += {"<br><img src="logo_[tempstate].png"> <b>[headrev.key]</b> was <b>[headrev.name]</b> ("}
+				text += "<br><img src='logo_[tempstate].png'> <b>[headrev.key]</b> was <b>[headrev.name]</b> ("
 				text += "body destroyed"
 			text += ")"
 
@@ -241,19 +241,19 @@
 		var/icon/logo2 = icon('icons/mob/mob.dmi', "rev-logo")
 		end_icons += logo2
 		var/tempstate = end_icons.len
-		text += {"<br><img src="logo_[tempstate].png"> <FONT size = 2><B>The recruited revolutionaries were:</B></FONT> <img src="logo_[tempstate].png">"}
+		text += "<br><img src='logo_[tempstate].png'> <FONT size = 2><b>The recruited revolutionaries were:</B></FONT> <img src='logo_[tempstate].png'>"
 
 		for(var/datum/mind/rev in revolutionaries)
 			if(rev.current)
 				var/icon/flat = getFlatIcon(rev.current, SOUTH, 1, 1)
 				end_icons += flat
 				tempstate = end_icons.len
-				text += {"<br><img src="logo_[tempstate].png"> <b>[rev.key]</b> was <b>[rev.name]</b> ("}
+				text += "<br><img src='logo_[tempstate].png'> <b>[rev.key]</b> was <b>[rev.name]</b> ("
 				if(rev.current.isDead())
 					text += "died"
 					flat.Turn(90)
 					end_icons[tempstate] = flat
-				else if(rev.current.z != 1)
+				else if(rev.current.z != map.zMainStation)
 					text += "fled the station"
 				else
 					text += "survived the revolution"
@@ -263,33 +263,33 @@
 				var/icon/sprotch = icon('icons/effects/blood.dmi', "floor1-old")
 				end_icons += sprotch
 				tempstate = end_icons.len
-				text += {"<br><img src="logo_[tempstate].png"> <b>[rev.key]</b> was <b>[rev.name]</b> ("}
+				text += "<br><img src='logo_[tempstate].png'> <b>[rev.key]</b> was <b>[rev.name]</b> ("
 				text += "body destroyed"
 			text += ")"
 
 
 
-	if( head_revolutionaries.len || revolutionaries.len || istype(ticker.mode,/datum/game_mode/revolution) )
+	if( head_revolutionaries.len || revolutionaries.len )
 		var/icon/logo3 = icon('icons/mob/mob.dmi', "nano-logo")
 		end_icons += logo3
 		var/tempstate = end_icons.len
-		text += {"<br><img src="logo_[tempstate].png"> <FONT size = 2><B>The heads of staff were:</B></FONT> <img src="logo_[tempstate].png">"}
+		text += "<br><img src='logo_[tempstate].png'> <span class = 'big bold'>The heads of staff were:</span> <img src='logo_[tempstate].png'>"
 
 		var/list/heads = get_all_heads()
 		for(var/datum/mind/head in heads)
 			var/target = (head in targets)
 			if(target)
-				text += "<font color='red'>"
+				text += "<span class='red'>"
 			if(head.current)
 				var/icon/flat = getFlatIcon(head.current, SOUTH, 1, 1)
 				end_icons += flat
 				tempstate = end_icons.len
-				text += {"<br><img src="logo_[tempstate].png"> <b>[head.key]</b> was <b>[head.name]</b> ("}
+				text += "<br><img src='logo_[tempstate].png'> <b>[head.key]</b> was <b>[head.name]</b> ("
 				if(head.current.isDead())
 					text += "died"
 					flat.Turn(90)
 					end_icons[tempstate] = flat
-				else if(head.current.z != 1)
+				else if(head.current.z != map.zMainStation)
 					text += "fled the station"
 				else
 					text += "survived the revolution"
@@ -299,7 +299,7 @@
 				var/icon/sprotch = icon('icons/effects/blood.dmi', "floor1-old")
 				end_icons += sprotch
 				tempstate = end_icons.len
-				text += {"<br><img src="logo_[tempstate].png"> <b>[head.key]</b> was <b>[head.name]</b> ("}
+				text += "<br><img src='logo_[tempstate].png'> <b>[head.key]</b> was <b>[head.name]</b> ("
 				text += "body destroyed"
 			text += ")"
 			if(target)

--- a/code/game/gamemodes/revolution/revsquad.dm
+++ b/code/game/gamemodes/revolution/revsquad.dm
@@ -17,6 +17,16 @@
 	var/checkwin_counter = 0
 	var/const/waittime_l = 600 //lower bound on time before intercept arrives (in tenths of seconds)
 	var/const/waittime_h = 1800 //upper bound on time before intercept arrives (in tenths of seconds)
+	var/list/possible_items = list(/obj/item/weapon/card/emag,
+								   /obj/item/clothing/gloves/yellow,
+								   /obj/item/weapon/gun/projectile/automatic,
+								   /obj/item/device/flash/revsquad,
+								   /obj/item/weapon/gun/projectile/shotgun/doublebarrel/sawnoff,
+								   /obj/item/weapon/grenade/iedcasing/preassembled,
+								   /obj/item/weapon/gun/projectile/pistol,
+								   /obj/item/gun_part/silencer,
+								   /obj/item/clothing/suit/armor/vest
+								  )
 
 /datum/game_mode/revsquad/announce()
 	to_chat(world, "<B>The current game mode is - Revolution Squad!</B>")
@@ -87,7 +97,7 @@
 		checkwin_counter = 0
 	return 0
 
-/datum/game_mode/proc/greet_revsquad(var/datum/mind/rev_mind, var/you_are=1)
+/datum/game_mode/revsquad/proc/greet_revsquad(var/datum/mind/rev_mind, var/you_are=1)
 	var/obj_count = 1
 	if (you_are)
 		to_chat(rev_mind.current, "<span class='notice'>You are a member of the organized revolutionary organization that has infiltrated this station!</span>")
@@ -102,15 +112,7 @@
 		rev_mind.store_memory("[M.assigned_role] the [M.assigned_job.title]")
 		to_chat(rev_mind.current, "[M.assigned_role] the [M.assigned_job.title]")
 
-/datum/game_mode/proc/get_revsquad_item(var/mob/living/carbon/human/M)
-	var/possible_items = list(/obj/item/weapon/card/emag,
-														/obj/item/clothing/gloves/yellow,
-														/obj/item/weapon/gun/projectile/automatic,
-														/obj/item/device/flash/revsquad,
-														/obj/item/weapon/gun/projectile/shotgun/doublebarrel/sawnoff,
-														/obj/item/weapon/grenade/iedcasing/preassembled
-														)
-
+/datum/game_mode/revsquad/proc/get_revsquad_item(var/mob/living/carbon/human/M)
 	var/obj/item/requisitioned = pick(possible_items)
 	if(istype(requisitioned, /obj/item/device/flash/revsquad))
 		var/obj/item/device/flash/revsquad/FR = new(M, uses = REVSQUAD_FLASH_USES)
@@ -119,7 +121,8 @@
 		requisitioned = new requisitioned(M)
 	return requisitioned
 
-/datum/game_mode/proc/equip_revsquad(mob/living/carbon/human/mob)
+// Since it's part of the revsquad type, this will not currently work with make antags. Which is fine because this is a variant on rev.
+/datum/game_mode/revsquad/proc/equip_revsquad(mob/living/carbon/human/mob)
 	if(!istype(mob))
 		return
 
@@ -227,14 +230,6 @@
 				text += {"<br><img src="logo_[tempstate].png"> <b>[headrev.key]</b> was <b>[headrev.name]</b> ("}
 				text += "body destroyed"
 			text += ")"
-			if(headrev.total_TC)
-				if(headrev.spent_TC)
-					text += "<br><span class='sinister'>TC Remaining: [headrev.total_TC - headrev.spent_TC]/[headrev.total_TC] - The tools used by the Head Revolutionary were:"
-					for(var/entry in headrev.uplink_items_bought)
-						text += "<br>[entry]"
-					text += "</span>"
-				else
-					text += "<br><span class='sinister'>The Head Revolutionary was a smooth operator this round (did not purchase any uplink items)</span>"
 
 			for(var/datum/objective/mutiny/objective in headrev.objectives)
 				targets |= objective.target

--- a/code/game/gamemodes/revolution/revsquad.dm
+++ b/code/game/gamemodes/revolution/revsquad.dm
@@ -1,6 +1,9 @@
 //A variant of revolution, with an emphasis on a small group with co-ordinated efforts instead of greytiding
 
 #define REVSQUAD_FLASH_USES 1 // Number of times a specially spawned flash can convert normal crew members.
+
+#define REVSQUAD_VICTORY_REVS 1
+#define REVSQUAD_VICTORY_HEADS 2
 /datum/game_mode/revsquad
 	name = "Revolution Squad"
 	config_tag = "revsquad"
@@ -12,7 +15,6 @@
 	recommended_enemies = 3
 	var/finished = 0
 	var/checkwin_counter = 0
-	var/max_squaddies = 3
 	var/const/waittime_l = 600 //lower bound on time before intercept arrives (in tenths of seconds)
 	var/const/waittime_h = 1800 //upper bound on time before intercept arrives (in tenths of seconds)
 
@@ -37,8 +39,8 @@
 		for(var/job in restricted_jobs)//Removing heads and such from the list
 			if(player.assigned_role == job)
 				possible_revs -= player
-
-	for (var/i=1 to max_squaddies)
+	// Depending how this mode performs, might need to change this to have a minimum number of revs as required and a maximum as recommended.
+	for (var/i=1 to required_enemies)
 		if (possible_revs.len==0)
 			break
 		var/datum/mind/lenin = pick(possible_revs)
@@ -105,7 +107,8 @@
 														/obj/item/clothing/gloves/yellow,
 														/obj/item/weapon/gun/projectile/automatic,
 														/obj/item/device/flash/revsquad,
-														/obj/item/weapon/gun/projectile/shotgun/doublebarrel/sawnoff
+														/obj/item/weapon/gun/projectile/shotgun/doublebarrel/sawnoff,
+														/obj/item/weapon/grenade/iedcasing/preassembled
 														)
 
 	var/obj/item/requisitioned = pick(possible_items)
@@ -155,7 +158,7 @@
 /datum/game_mode/revsquad/proc/check_heads_victory()
 	for(var/datum/mind/rev_mind in head_revolutionaries)
 		var/turf/T = get_turf(rev_mind.current)
-		if((rev_mind) && (rev_mind.current) && (rev_mind.current.stat != 2) && T && (T.z == 1))
+		if((rev_mind) && (rev_mind.current) && (rev_mind.current.isDead()) && T && (T.z == map.zMainStation))
 			if(ishuman(rev_mind.current))
 				return 0
 	return 1
@@ -163,9 +166,9 @@
 
 /datum/game_mode/revsquad/check_win()
 	if(check_rev_victory())
-		finished = 1
+		finished = REVSQUAD_VICTORY_REVS
 	else if(check_heads_victory())
-		finished = 2
+		finished = REVSQUAD_VICTORY_HEADS
 	return
 
 ///////////////////////////////
@@ -183,10 +186,10 @@
 		return 0
 
 /datum/game_mode/revsquad/declare_completion()
-	if(finished == 1)
+	if(finished == REVSQUAD_VICTORY_REVS)
 		feedback_set_details("round_end_result","win - heads killed")
 		completion_text = "<br><span class='danger'><FONT size = 3> The heads of staff were killed or abandoned the station! The revolutionaries win!</FONT></span>"
-	else if(finished == 2)
+	else if(finished == REVSQUAD_VICTORY_HEADS)
 		feedback_set_details("round_end_result","loss - rev heads killed")
 		completion_text = "<br><span class='danger'><FONT size = 3> The heads of staff managed to stop the revolution!</FONT></span>"
 	..()
@@ -207,7 +210,7 @@
 				end_icons += flat
 				tempstate = end_icons.len
 				text += {"<br><img src="logo_[tempstate].png"> <b>[headrev.key]</b> was <b>[headrev.name]</b> ("}
-				if(headrev.current.stat == DEAD)
+				if(headrev.current.isDead())
 					text += "died"
 					flat.Turn(90)
 					end_icons[tempstate] = flat
@@ -249,7 +252,7 @@
 				end_icons += flat
 				tempstate = end_icons.len
 				text += {"<br><img src="logo_[tempstate].png"> <b>[rev.key]</b> was <b>[rev.name]</b> ("}
-				if(rev.current.stat == DEAD)
+				if(rev.current.isDead())
 					text += "died"
 					flat.Turn(90)
 					end_icons[tempstate] = flat
@@ -285,7 +288,7 @@
 				end_icons += flat
 				tempstate = end_icons.len
 				text += {"<br><img src="logo_[tempstate].png"> <b>[head.key]</b> was <b>[head.name]</b> ("}
-				if(head.current.stat == DEAD)
+				if(head.current.isDead())
 					text += "died"
 					flat.Turn(90)
 					end_icons[tempstate] = flat

--- a/code/game/gamemodes/revolution/revsquad.dm
+++ b/code/game/gamemodes/revolution/revsquad.dm
@@ -148,6 +148,7 @@
 			var/obj/item/device/flash/revsquad/FR = T
 			to_chat(mob, "<span class = 'warning'>Your [FR] has [FR.limited_conversions] uses for conversions, and not all of your comrades have one like it. Use it wisely.</span>")
 		mob.update_icons()
+		stat_collection.revsquad.revsquad_items += T.name
 		return 1
 
 /datum/game_mode/revsquad/proc/check_rev_victory()
@@ -192,6 +193,7 @@
 	if(finished == REVSQUAD_VICTORY_REVS)
 		feedback_set_details("round_end_result","win - heads killed")
 		completion_text = "<br><span class='danger'><FONT size = 3> The heads of staff were killed or abandoned the station! The revolutionaries win!</FONT></span>"
+		stat_collection.revsquad.revsquad_won = 1
 	else if(finished == REVSQUAD_VICTORY_HEADS)
 		feedback_set_details("round_end_result","loss - rev heads killed")
 		completion_text = "<br><span class='danger'><FONT size = 3> The heads of staff managed to stop the revolution!</FONT></span>"

--- a/code/game/gamemodes/revolution/revsquad.dm
+++ b/code/game/gamemodes/revolution/revsquad.dm
@@ -17,6 +17,7 @@
 	var/checkwin_counter = 0
 	var/const/waittime_l = 600 //lower bound on time before intercept arrives (in tenths of seconds)
 	var/const/waittime_h = 1800 //upper bound on time before intercept arrives (in tenths of seconds)
+	var/minimum_heads = 3
 	var/list/possible_items = list(/obj/item/weapon/card/emag,
 								   /obj/item/clothing/gloves/yellow,
 								   /obj/item/weapon/gun/projectile/automatic,
@@ -57,7 +58,7 @@
 		possible_revs -= lenin
 		head_revolutionaries += lenin
 
-	if(revolutionaries.len==0 || !head_check)
+	if(revolutionaries.len==0 || head_check < minimum_heads)
 		log_admin("Failed to set-up a round of revsquad. Couldn't find any heads of staffs or any volunteers to be revolutionaries.")
 		message_admins("Failed to set-up a round of revsquad. Couldn't find any heads of staffs or any volunteers to be revolutionaries.")
 		return 0

--- a/code/game/gamemodes/revolution/revsquad.dm
+++ b/code/game/gamemodes/revolution/revsquad.dm
@@ -303,7 +303,7 @@
 				text += "body destroyed"
 			text += ")"
 			if(target)
-				text += "</font>"
+				text += "</span>"
 
-		text += "<BR><HR>"
+		text += "<br /><hr>"
 	return text

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -102,16 +102,16 @@
 									limited_conversions--
 									if(limited_conversions <= 0)
 										to_chat(user, "<span class='warning'>The bulb has burnt out!</span>")
-										src.broken = 1
+										broken = 1
 										icon_state = "flashburnt"
-							else if(result == -1 || Subject.mind.has_been_rev) // command positions or has been rev before (according to old code you cannot attempt to rev people that has been deconverted, can be remove)
-								to_chat(user, "<span class=\"warning\">This mind seems resistant to the flash!</span>")
-							else if(result == -2) // rev jobbanned
-								to_chat(user, "<span class=\"warning\">This mind seems resistant to the flash! (OOC INFO: REVOLUTIONARY JOBBANNED)</span>")
-							else if(result == -3) // loyalty implanted
-								to_chat(user, "<span class=\"warning\">Something seems to be blocking the flash!</span>")
+							else if(result == ADD_REVOLUTIONARY_FAIL_IS_COMMAND || Subject.mind.has_been_rev) // command positions or has been rev before (according to old code you cannot attempt to rev people that has been deconverted, can be remove)
+								to_chat(user, "<span class='warning'>This mind seems resistant to the flash!</span>")
+							else if(result == ADD_REVOLUTIONARY_FAIL_IS_JOBBANNED) // rev jobbanned
+								to_chat(user, "<span class='warning'>This mind seems resistant to the flash! (OOC INFO: REVOLUTIONARY JOBBANNED)</span>")
+							else if(result == ADD_REVOLUTIONARY_FAIL_IS_IMPLANTED) // loyalty implanted
+								to_chat(user, "<span class='warning'>Something seems to be blocking the flash!</span>")
 					else
-						to_chat(user, "<span class=\"warning\">This mind is so vacant that it is not susceptible to influence!</span>")
+						to_chat(user, "<span class='warning'>This mind is so vacant that it is not susceptible to influence!</span>")
 		else
 			flashfail = TRUE
 	else if(issilicon(M))
@@ -134,11 +134,11 @@
 		M.flash_eyes(affect_silicon = 1)
 
 		if(!issilicon(M))
-			user.visible_message("<span class=\"disarm\">[user] blinds [M] with the flash!</span>")
+			user.visible_message("<span class='disarm'>[user] blinds [M] with the flash!</span>")
 		else
-			user.visible_message("<span class=\"warning\">[user] overloads [M]'s sensors with the flash!</span>")
+			user.visible_message("<span class='warning'>[user] overloads [M]'s sensors with the flash!</span>")
 	else
-		user.visible_message("<span class=\"notice\">[user] fails to blind [M] with the flash!</span>")
+		user.visible_message("<span class='notice'>[user] fails to blind [M] with the flash!</span>")
 
 /obj/item/device/flash/attack_self(mob/living/carbon/user as mob, flag = 0, emp = 0)
 	if(!user || !clown_check(user)) 	return
@@ -241,8 +241,6 @@
 		broken = 1
 		to_chat(user, "<span class='warning'>The bulb has burnt out!</span>")
 		icon_state = "flashburnt"
-
-/obj/item/device/flash/revsquad
 
 /obj/item/device/flash/revsquad/New(var/uses = 1)
 	..()

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -110,8 +110,8 @@
 								to_chat(user, "<span class=\"warning\">This mind seems resistant to the flash! (OOC INFO: REVOLUTIONARY JOBBANNED)</span>")
 							else if(result == -3) // loyalty implanted
 								to_chat(user, "<span class=\"warning\">Something seems to be blocking the flash!</span>")
-						else
-							to_chat(user, "<span class=\"warning\">This mind is so vacant that it is not susceptible to influence!</span>")
+					else
+						to_chat(user, "<span class=\"warning\">This mind is so vacant that it is not susceptible to influence!</span>")
 		else
 			flashfail = TRUE
 	else if(issilicon(M))

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -91,7 +91,7 @@
 					if(Subject.stat != DEAD)
 						Subject.mind_initialize() // give them a mind datum if they don't have one
 
-						var/is_revsquad = istype(ticker.mode, /datum/game_mode/rev_squad)
+						var/is_revsquad = istype(ticker.mode, /datum/game_mode/revsquad)
 						if(!is_revsquad || (is_revsquad && limited_conversions))
 							var/result = ticker.mode.add_revolutionary(Subject.mind)
 
@@ -103,7 +103,7 @@
 									if(limited_conversions <= 0)
 										to_chat(user, "<span class='warning'>The bulb has burnt out!</span>")
 										src.broken = 1
-										icon_state = flashburnt
+										icon_state = "flashburnt"
 							else if(result == -1 || Subject.mind.has_been_rev) // command positions or has been rev before (according to old code you cannot attempt to rev people that has been deconverted, can be remove)
 								to_chat(user, "<span class=\"warning\">This mind seems resistant to the flash!</span>")
 							else if(result == -2) // rev jobbanned
@@ -241,6 +241,8 @@
 		broken = 1
 		to_chat(user, "<span class='warning'>The bulb has burnt out!</span>")
 		icon_state = "flashburnt"
+
+/obj/item/device/flash/revsquad
 
 /obj/item/device/flash/revsquad/New(var/uses = 1)
 	..()

--- a/code/game/objects/items/weapons/grenades/ghettobomb.dm
+++ b/code/game/objects/items/weapons/grenades/ghettobomb.dm
@@ -103,3 +103,15 @@
 	..()
 	if(assembled == 3)
 		to_chat(user, "<span class='info'>You can't tell when it will explode!</span>")//Stops you from checking the time to detonation unlike regular grenades
+
+/obj/item/weapon/grenade/iedcasing/preassembled
+    name = "improvised explosive"
+    desc = "A weak, improvised explosive."
+    assembled = 2
+    active = 0
+
+/obj/item/weapon/grenade/iedcasing/preassembled/New()
+    ..()
+    det_time = rand(30,80)
+    overlays += image('icons/obj/grenade.dmi', icon_state = "improvised_grenade_filled")
+    overlays += image('icons/obj/grenade.dmi', icon_state = "improvised_grenade_wired")

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -138,3 +138,11 @@
 			if(istype(user, /mob/living/carbon/human) && src.loc == user)
 				var/mob/living/carbon/human/H = user
 				H.update_inv_hands()
+
+/obj/item/weapon/gun/projectile/shotgun/doublebarrel/sawnoff
+	name = "sawn-off shotgun"
+	desc = "Omar's coming!"
+	icon_state = "sawnshotgun"
+	item_state = "sawnshotgun"
+	w_class = W_CLASS_MEDIUM
+	slot_flags = SLOT_BELT

--- a/html/changelogs/Sood.yml
+++ b/html/changelogs/Sood.yml
@@ -1,2 +1,5 @@
 author: Sood
-changes: []
+changes:
+  - rscadd: "Adds a new gamemode, Revolutionary Squad, which is a variant on revolution with an emphasis on a small, organized group of underequipped revolutionaries trying to kill the heads instead of a large group of gretiders."
+  - tweak:  "Revsquad members only sometimes spawn with a flash capable of converting crew members, and it always has limited uses. They cannot use a standard flash to convert."
+  - tweak: "Adds the sawn-off shotgun as a defined type, which means it might get picked as random loot in places where guns are picked."

--- a/html/changelogs/Sood.yml
+++ b/html/changelogs/Sood.yml
@@ -3,3 +3,4 @@ changes:
   - rscadd: "Adds a new gamemode, Revolutionary Squad, which is a variant on revolution with an emphasis on a small, organized group of underequipped revolutionaries trying to kill the heads instead of a large group of gretiders."
   - tweak:  "Revsquad members only sometimes spawn with a flash capable of converting crew members, and it always has limited uses. They cannot use a standard flash to convert."
   - tweak: "Adds the sawn-off shotgun as a defined type, which means it might get picked as random loot in places where guns are picked."
+  - tweak: "Adds pre-assembled IED as a defined type, similar to above."

--- a/html/changelogs/Sood.yml
+++ b/html/changelogs/Sood.yml
@@ -4,3 +4,4 @@ changes:
   - tweak:  "Revsquad members only sometimes spawn with a flash capable of converting crew members, and it always has limited uses. They cannot use a standard flash to convert."
   - tweak: "Adds the sawn-off shotgun as a defined type, which means it might get picked as random loot in places where guns are picked."
   - tweak: "Adds pre-assembled IED as a defined type, similar to above."
+  - tweak: "Both revolution and revsquad requires at least 3 heads of staff to start."

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -344,7 +344,7 @@
 #include "code\game\gamemodes\nuclear\nuclear.dm"
 #include "code\game\gamemodes\nuclear\nuclearbomb.dm"
 #include "code\game\gamemodes\nuclear\pinpointer.dm"
-#include "code\game\gamemodes\revolution\rev_squad.dm"
+#include "code\game\gamemodes\revolution\revsquad.dm"
 #include "code\game\gamemodes\revolution\revolution.dm"
 #include "code\game\gamemodes\sandbox\h_sandbox.dm"
 #include "code\game\gamemodes\sandbox\sandbox.dm"

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -344,6 +344,7 @@
 #include "code\game\gamemodes\nuclear\nuclear.dm"
 #include "code\game\gamemodes\nuclear\nuclearbomb.dm"
 #include "code\game\gamemodes\nuclear\pinpointer.dm"
+#include "code\game\gamemodes\revolution\rev_squad.dm"
 #include "code\game\gamemodes\revolution\revolution.dm"
 #include "code\game\gamemodes\sandbox\h_sandbox.dm"
 #include "code\game\gamemodes\sandbox\sandbox.dm"


### PR DESCRIPTION
This is a variant on revolutoin with an emphasis on a small group of organized revolutionaries instead of a greytiding swarm. Otherwise, most of the code is (currently) identical to revolution.
They are given a random item from a list instead of a flash (or a specialized limited-use flash, if it's randomly chosen by the game).

This contains some other minor changes:
- Sawn-off shotgun as a defined subtype of double barrel shotgun, so that revsquaddies can spawn with a sawn-off in their backpack.
- Special flash subtype with limited uses specifically intended for revsquad
- 8/8: Preassembled IED added, similar to pre-sawnoff shotgun

TODO:
- [x] Stat collection
- [x] More items for the random item selection (possibly, it's pretty limited right now, please give feedback on this)
