### PR TITLE
Fixes borgs putting modules on food trays

### DIFF
--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -466,6 +466,8 @@
 		return 5
 
 /obj/item/weapon/tray/attackby(obj/item/W as obj, mob/user as mob, params)
+	if(isrobot(user) && !isMoMMI(user))
+		return
 	if(istype(W, /obj/item/weapon/kitchen/rollingpin)) //shield bash
 		if(cooldown < world.time - 25)
 			user.visible_message("<span class='warning'>[user] bashes [src] with [W]!</span>")


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.
-->

Whoops
I didn't realize borgs could "drop" modules, I thought candrop would cover that but apparently not
~~actually wait this is still fucked hold on~~
actually it works out, MoMMIs have sanity on dropping modules but borgs don't because beakers so it should be fine
