### PR TITLE
Shuttle destination disks

### DIFF
--- a/code/game/machinery/computer/shuttle_computers.dm
+++ b/code/game/machinery/computer/shuttle_computers.dm
@@ -29,7 +29,8 @@
 	if(ispath(destination))
 		spawn()
 			destination = locate(destination) in all_docking_ports
-			destination.disk_references.Add(src)
+			if(destination)
+				destination.disk_references.Add(src)
 	else
 		header = "ERROR"
 

--- a/code/game/machinery/computer/shuttle_computers.dm
+++ b/code/game/machinery/computer/shuttle_computers.dm
@@ -27,6 +27,10 @@
 /obj/item/weapon/disk/shuttle_coords/New()
 	..()
 
+	if(ticker)
+		initialize()
+
+/obj/item/weapon/disk/shuttle_coords/initialize()
 	if(ispath(destination))
 		spawn()
 			destination = locate(destination) in all_docking_ports

--- a/code/game/machinery/computer/shuttle_computers.dm
+++ b/code/game/machinery/computer/shuttle_computers.dm
@@ -1,4 +1,5 @@
 //Docking port disks
+//Insert into a shuttle computer to unlock a new destination
 /obj/item/weapon/disk/shuttle_coords
 	name = "shuttle destination disk"
 	desc = "A small disk containing encrypted coordinates and tracking data."

--- a/code/game/machinery/computer/shuttle_computers.dm
+++ b/code/game/machinery/computer/shuttle_computers.dm
@@ -37,7 +37,7 @@
 
 /obj/item/weapon/disk/shuttle_coords/Destroy()
 	if(destination)
-		destination.dick_references.Remove(src)
+		destination.disk_references.Remove(src)
 		destination = null
 
 	..()

--- a/code/game/objects/structures/docking_port.dm
+++ b/code/game/objects/structures/docking_port.dm
@@ -116,6 +116,8 @@ var/global/list/all_docking_ports = list()
 /obj/docking_port/destination //this guy is installed on stations and connects to shuttles
 	icon_state = "docking_station"
 
+	var/list/disk_references = list() //List of shuttle destination disks that know about this docking port
+
 	var/base_turf_type			= /turf/space
 	var/base_turf_icon			= null
 	var/base_turf_icon_state	= null
@@ -138,6 +140,13 @@ var/global/list/all_docking_ports = list()
 				base_turf_type			= T.type
 				base_turf_icon			= T.icon
 				base_turf_icon_state	= T.icon_state
+
+/obj/docking_port/destination/Destroy()
+	..()
+
+	for(var/obj/item/weapon/disk/shuttle_coords/C in disk_references)
+		C.reset()
+	disk_references = list()
 
 /obj/docking_port/destination/link_to_shuttle(var/datum/shuttle/S)
 	..()

--- a/html/changelogs/unid-sh.yml
+++ b/html/changelogs/unid-sh.yml
@@ -1,36 +1,6 @@
-################################
-# Example Changelog File
-#
-# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
-#
-# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
-# When it is, any changes listed below will disappear.
-#
-# Valid Prefixes: 
-#   bugfix
-#   wip (For works in progress)
-#   tweak
-#   soundadd
-#   sounddel
-#   rscdel (general deleting of nice things)
-#   rscadd (general adding of nice things)
-#   imageadd
-#   imagedel
-#   spellcheck (typo fixes)
-#   experiment
-#   tgs (TG-ported fixes?)
-#################################
+author: Unid
 
-# Your name.
-author: N3X15
-
-# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True
 
-# Any changes you've made.  See valid prefix list above.
-# There needs to be a space after the - and before the prefix. Don't use tabs anywhere in this file.
-# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
-# If you're using characters such as # ' : - or the like in your changelog, surround the entire change with quotes as shown in the second example. These quotes don't show up on the changelog once it's merged and prevent errors.
-# SCREW ANY OF THIS UP AND IT WON'T WORK.
 changes: 
 - rscadd: "Added shuttle destination disks - disks that can be inserted into shuttle control consoles to unlock additional destinations. Currently they can't be obtained."

--- a/html/changelogs/unid-sh.yml
+++ b/html/changelogs/unid-sh.yml
@@ -3,4 +3,5 @@ author: Unid
 delete-after: True
 
 changes: 
-- rscadd: "Added shuttle destination disks - disks that can be inserted into shuttle control consoles to unlock additional destinations. Currently they can't be obtained."
+- rscadd: "Added shuttle destination disks. They can be inserted into shuttle computers to unlock additional destinations."
+- rscadd: "The biodome and listening outpost vaults now contain these disks. They allow mining/science shuttles to travel to the biodome and the listening outpost, respectively."

--- a/html/changelogs/unid-sh.yml
+++ b/html/changelogs/unid-sh.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general deleting of nice things)
+#   rscadd (general adding of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.
+author: N3X15
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# There needs to be a space after the - and before the prefix. Don't use tabs anywhere in this file.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# If you're using characters such as # ' : - or the like in your changelog, surround the entire change with quotes as shown in the second example. These quotes don't show up on the changelog once it's merged and prevent errors.
+# SCREW ANY OF THIS UP AND IT WON'T WORK.
+changes: 
+- rscadd: "Added shuttle destination disks - disks that can be inserted into shuttle control consoles to unlock additional destinations. Currently they can't be obtained."

--- a/maps/randomvaults/biodome.dmm
+++ b/maps/randomvaults/biodome.dmm
@@ -3,7 +3,7 @@
 "ac" = (/turf/simulated/floor/airless,/area/vault/biodome)
 "ad" = (/turf/simulated/floor/plating,/area/vault/biodome)
 "ae" = (/obj/structure/window/reinforced{dir = 4},/turf/simulated/floor/plating,/area/vault/biodome)
-"af" = (/obj/machinery/door/airlock/external,/turf/simulated/floor/plating,/area/vault/biodome)
+"af" = (/obj/machinery/door/airlock/external,/obj/docking_port/destination/vault/biodome,/turf/simulated/floor/plating,/area/vault/biodome)
 "ag" = (/obj/structure/window/reinforced{dir = 8},/turf/simulated/floor/plating,/area/vault/biodome)
 "ah" = (/obj/structure/window/full/reinforced,/turf/simulated/floor/plating,/area/vault/biodome)
 "ai" = (/turf/simulated/wall,/area/vault/biodome)
@@ -11,114 +11,116 @@
 "ak" = (/turf/simulated/floor/grass,/area/vault/biodome)
 "al" = (/obj/structure/flora/ausbushes/genericbush,/turf/simulated/floor/grass,/area/vault/biodome)
 "am" = (/turf/simulated/floor,/area/vault/biodome)
-"an" = (/obj/structure/cable{d1 = 2; d2 = 4; icon_state = "2-4"},/turf/simulated/floor/plating/airless,/area/vault/biodome)
-"ao" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/plating/airless,/area/vault/biodome)
-"ap" = (/obj/structure/cable{d1 = 1; d2 = 8; icon_state = "1-8"},/turf/simulated/floor/plating/airless,/area/vault/biodome)
-"aq" = (/obj/machinery/power/solar/panel,/obj/structure/cable{icon_state = "0-2"; d2 = 2},/turf/simulated/floor/plating/airless,/area/vault/biodome)
-"ar" = (/obj/structure/flora/ausbushes/stalkybush,/turf/simulated/floor/grass,/area/vault/biodome)
-"as" = (/obj/machinery/power/solar/panel,/obj/structure/cable{icon_state = "0-4"; d2 = 4},/turf/simulated/floor/plating/airless,/area/vault/biodome)
-"at" = (/obj/structure/cable{d1 = 2; d2 = 8; icon_state = "2-8"},/obj/structure/cable{d1 = 1; d2 = 8; icon_state = "1-8"},/turf/simulated/floor/plating/airless,/area/vault/biodome)
-"au" = (/obj/machinery/power/solar/panel,/obj/structure/cable{d1 = 2; d2 = 4; icon_state = "2-4"},/obj/structure/cable{icon_state = "0-2"; d2 = 2},/turf/simulated/floor/plating/airless,/area/vault/biodome)
-"av" = (/obj/structure/cable{d1 = 1; d2 = 8; icon_state = "1-8"},/turf/simulated/floor/airless,/area/vault/biodome)
-"aw" = (/obj/structure/flora/ausbushes/ywflowers,/turf/simulated/floor/grass,/area/vault/biodome)
-"ax" = (/obj/structure/flora/ausbushes/reedbush,/turf/simulated/floor/grass,/area/vault/biodome)
-"ay" = (/obj/structure/reagent_dispensers/watertank,/turf/simulated/floor/grass,/area/vault/biodome)
-"az" = (/obj/machinery/power/solar/panel,/obj/structure/cable,/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"; tag = ""},/turf/simulated/floor/plating/airless,/area/vault/biodome)
-"aA" = (/obj/machinery/portable_atmospherics/hydroponics/soil,/turf/simulated/floor/grass,/area/vault/biodome)
-"aB" = (/obj/structure/flora/ausbushes/ppflowers,/turf/simulated/floor/grass,/area/vault/biodome)
-"aC" = (/obj/structure/cable{d1 = 1; d2 = 4; icon_state = "1-4"},/turf/simulated/floor/airless,/area/vault/biodome)
-"aD" = (/obj/structure/cable{d1 = 2; d2 = 8; icon_state = "2-8"},/turf/simulated/floor/plating/airless,/area/vault/biodome)
-"aE" = (/obj/machinery/floodlight/on,/turf/simulated/floor/grass,/area/vault/biodome)
-"aF" = (/obj/structure/flora/ausbushes/leafybush,/turf/simulated/floor/grass,/area/vault/biodome)
-"aG" = (/obj/structure/flora/ausbushes/sparsegrass,/turf/simulated/floor/grass,/area/vault/biodome)
-"aH" = (/obj/structure/flora/ausbushes/stalkybush,/obj/structure/window/reinforced,/turf/simulated/floor/grass,/area/vault/biodome)
-"aI" = (/obj/structure/window/reinforced,/turf/simulated/floor/grass,/area/vault/biodome)
-"aJ" = (/obj/structure/flora/ausbushes/ywflowers,/obj/structure/window/reinforced,/turf/simulated/floor/grass,/area/vault/biodome)
-"aK" = (/obj/structure/flora/ausbushes/sparsegrass,/obj/structure/window/reinforced,/turf/simulated/floor/grass,/area/vault/biodome)
-"aL" = (/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/airless,/area/vault/biodome)
-"aM" = (/obj/structure/cable{d1 = 2; d2 = 4; icon_state = "2-4"},/turf/simulated/floor,/area/vault/biodome)
-"aN" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor,/area/vault/biodome)
-"aO" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/wood,/area/vault/biodome)
-"aP" = (/obj/structure/cable{d1 = 2; d2 = 4; icon_state = "2-4"},/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/wood,/area/vault/biodome)
-"aQ" = (/obj/structure/cable{d1 = 2; d2 = 8; icon_state = "2-8"},/turf/simulated/floor/wood,/area/vault/biodome)
-"aR" = (/obj/structure/window/reinforced{dir = 8},/turf/simulated/floor/grass,/area/vault/biodome)
-"aS" = (/turf/simulated/floor/wood,/area/vault/biodome)
-"aT" = (/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor,/area/vault/biodome)
-"aU" = (/obj/structure/flora/ausbushes/ppflowers,/obj/structure/window/reinforced{dir = 1},/turf/simulated/floor/grass,/area/vault/biodome)
-"aV" = (/obj/structure/window/reinforced{dir = 4},/obj/structure/window/reinforced{dir = 1},/turf/simulated/floor/grass,/area/vault/biodome)
-"aW" = (/obj/machinery/power/battery/smes,/obj/structure/cable{icon_state = "0-2"; d2 = 2},/turf/simulated/floor/wood,/area/vault/biodome)
-"aX" = (/obj/machinery/power/terminal{dir = 8},/obj/structure/cable,/turf/simulated/floor/wood,/area/vault/biodome)
-"aY" = (/obj/machinery/floodlight/on,/turf/simulated/floor/wood,/area/vault/biodome)
-"aZ" = (/obj/machinery/power/solar/control,/obj/structure/cable,/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/wood,/area/vault/biodome)
-"ba" = (/obj/structure/closet/crate/hydroponics,/obj/item/weapon/pickaxe/shovel/spade,/obj/item/weapon/hatchet,/turf/simulated/floor/wood,/area/vault/biodome)
-"bb" = (/obj/structure/table/woodentable,/obj/item/weapon/fossil/plant,/turf/simulated/floor/grass,/area/vault/biodome)
-"bc" = (/obj/structure/window/reinforced{dir = 4},/turf/simulated/floor/grass,/area/vault/biodome)
-"bd" = (/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/wood,/area/vault/biodome)
-"be" = (/obj/structure/window/reinforced{dir = 1},/turf/simulated/floor/grass,/area/vault/biodome)
-"bf" = (/obj/structure/flora/ausbushes/sparsegrass,/obj/structure/window/reinforced{dir = 4},/turf/simulated/floor/grass,/area/vault/biodome)
-"bg" = (/obj/structure/window/reinforced{dir = 8},/obj/structure/window/reinforced{dir = 1},/turf/simulated/floor/grass,/area/vault/biodome)
-"bh" = (/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/plating,/area/vault/biodome)
-"bi" = (/obj/structure/cable{d1 = 1; d2 = 8; icon_state = "1-8"},/turf/simulated/floor,/area/vault/biodome)
-"bj" = (/obj/structure/window/reinforced,/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/plating,/area/vault/biodome)
-"bk" = (/obj/machinery/seed_extractor,/turf/simulated/floor,/area/vault/biodome)
-"bl" = (/obj/machinery/door/airlock/external,/obj/structure/cable{d1 = 2; d2 = 4; icon_state = "2-4"},/obj/structure/cable{d1 = 1; d2 = 4; icon_state = "1-4"},/turf/simulated/floor/plating,/area/vault/biodome)
-"bm" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/plating,/area/vault/biodome)
-"bn" = (/obj/machinery/door/airlock/external,/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/plating,/area/vault/biodome)
-"bo" = (/obj/machinery/vending/hydroseeds,/turf/simulated/floor,/area/vault/biodome)
-"bp" = (/obj/machinery/biogenerator,/turf/simulated/floor,/area/vault/biodome)
-"bq" = (/obj/structure/cable{d1 = 1; d2 = 8; icon_state = "1-8"},/obj/machinery/bot/farmbot/duey,/turf/simulated/floor,/area/vault/biodome)
-"br" = (/obj/structure/cable{d1 = 1; d2 = 4; icon_state = "1-4"},/turf/simulated/floor,/area/vault/biodome)
-"bs" = (/obj/machinery/door/airlock/external,/obj/structure/cable{d1 = 1; d2 = 8; icon_state = "1-8"},/obj/structure/cable{d1 = 2; d2 = 8; icon_state = "2-8"},/turf/simulated/floor/plating,/area/vault/biodome)
-"bt" = (/obj/structure/window/reinforced{dir = 1},/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/plating,/area/vault/biodome)
-"bu" = (/obj/machinery/vending/hydronutrients,/turf/simulated/floor,/area/vault/biodome)
-"bv" = (/obj/machinery/floodlight/on,/turf/simulated/floor,/area/vault/biodome)
-"bw" = (/obj/structure/cable{icon_state = "0-4"; d2 = 4},/obj/machinery/power/apc{dir = 1; pixel_y = 24; pixel_x = 0},/turf/simulated/floor,/area/vault/biodome)
-"bx" = (/obj/structure/flora/ausbushes/grassybush,/turf/simulated/floor/grass,/area/vault/biodome)
-"by" = (/obj/structure/flora/ausbushes/palebush,/turf/simulated/floor/grass,/area/vault/biodome)
-"bz" = (/obj/structure/window/reinforced{dir = 2},/turf/simulated/floor/grass,/area/vault/biodome)
-"bA" = (/obj/structure/reagent_dispensers/watertank,/turf/simulated/floor/wood,/area/vault/biodome)
-"bB" = (/obj/structure/closet/crate/hydroponics,/obj/item/weapon/reagent_containers/glass/bucket,/obj/item/weapon/minihoe,/turf/simulated/floor/wood,/area/vault/biodome)
-"bC" = (/obj/structure/flora/ausbushes/ywflowers,/obj/structure/window/reinforced{dir = 4},/turf/simulated/floor/grass,/area/vault/biodome)
-"bD" = (/obj/structure/closet/crate/hydroponics,/obj/item/weapon/wirecutters/clippers,/obj/item/weapon/storage/bag/plants,/turf/simulated/floor/wood,/area/vault/biodome)
-"bE" = (/obj/machinery/chem_dispenser,/turf/simulated/floor/wood,/area/vault/biodome)
-"bF" = (/obj/structure/table/woodentable,/obj/item/weapon/reagent_containers/glass/mortar,/turf/simulated/floor/wood,/area/vault/biodome)
-"bG" = (/obj/structure/cable{d1 = 1; d2 = 4; icon_state = "1-4"},/turf/simulated/floor/plating/airless,/area/vault/biodome)
-"bH" = (/obj/structure/cable{d1 = 2; d2 = 8; icon_state = "2-8"},/turf/simulated/floor/airless,/area/vault/biodome)
-"bI" = (/obj/structure/flora/ausbushes/pointybush,/turf/simulated/floor/grass,/area/vault/biodome)
-"bJ" = (/obj/structure/cable{d1 = 2; d2 = 4; icon_state = "2-4"},/turf/simulated/floor/airless,/area/vault/biodome)
-"bK" = (/obj/machinery/power/solar/panel,/obj/structure/cable{d1 = 1; d2 = 4; icon_state = "1-4"},/obj/structure/cable,/turf/simulated/floor/plating/airless,/area/vault/biodome)
-"bL" = (/obj/machinery/power/solar/panel,/obj/structure/cable{d1 = 1; d2 = 8; icon_state = "1-8"},/obj/structure/cable{d2 = 8; icon_state = "0-8"},/turf/simulated/floor/plating/airless,/area/vault/biodome)
-"bM" = (/obj/machinery/power/solar/panel,/obj/structure/cable,/turf/simulated/floor/plating/airless,/area/vault/biodome)
+"an" = (/obj/machinery/door/airlock/external,/turf/simulated/floor/plating,/area/vault/biodome)
+"ao" = (/obj/structure/cable{d1 = 2; d2 = 4; icon_state = "2-4"},/turf/simulated/floor/plating/airless,/area/vault/biodome)
+"ap" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/plating/airless,/area/vault/biodome)
+"aq" = (/obj/structure/cable{d1 = 1; d2 = 8; icon_state = "1-8"},/turf/simulated/floor/plating/airless,/area/vault/biodome)
+"ar" = (/obj/machinery/power/solar/panel,/obj/structure/cable{icon_state = "0-2"; d2 = 2},/turf/simulated/floor/plating/airless,/area/vault/biodome)
+"as" = (/obj/structure/flora/ausbushes/stalkybush,/turf/simulated/floor/grass,/area/vault/biodome)
+"at" = (/obj/machinery/power/solar/panel,/obj/structure/cable{icon_state = "0-4"; d2 = 4},/turf/simulated/floor/plating/airless,/area/vault/biodome)
+"au" = (/obj/structure/cable{d1 = 2; d2 = 8; icon_state = "2-8"},/obj/structure/cable{d1 = 1; d2 = 8; icon_state = "1-8"},/turf/simulated/floor/plating/airless,/area/vault/biodome)
+"av" = (/obj/machinery/power/solar/panel,/obj/structure/cable{d1 = 2; d2 = 4; icon_state = "2-4"},/obj/structure/cable{icon_state = "0-2"; d2 = 2},/turf/simulated/floor/plating/airless,/area/vault/biodome)
+"aw" = (/obj/structure/cable{d1 = 1; d2 = 8; icon_state = "1-8"},/turf/simulated/floor/airless,/area/vault/biodome)
+"ax" = (/obj/structure/flora/ausbushes/ywflowers,/turf/simulated/floor/grass,/area/vault/biodome)
+"ay" = (/obj/structure/flora/ausbushes/reedbush,/turf/simulated/floor/grass,/area/vault/biodome)
+"az" = (/obj/structure/reagent_dispensers/watertank,/turf/simulated/floor/grass,/area/vault/biodome)
+"aA" = (/obj/machinery/power/solar/panel,/obj/structure/cable,/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"; tag = ""},/turf/simulated/floor/plating/airless,/area/vault/biodome)
+"aB" = (/obj/machinery/portable_atmospherics/hydroponics/soil,/turf/simulated/floor/grass,/area/vault/biodome)
+"aC" = (/obj/structure/flora/ausbushes/ppflowers,/turf/simulated/floor/grass,/area/vault/biodome)
+"aD" = (/obj/structure/cable{d1 = 1; d2 = 4; icon_state = "1-4"},/turf/simulated/floor/airless,/area/vault/biodome)
+"aE" = (/obj/structure/cable{d1 = 2; d2 = 8; icon_state = "2-8"},/turf/simulated/floor/plating/airless,/area/vault/biodome)
+"aF" = (/obj/machinery/floodlight/on,/turf/simulated/floor/grass,/area/vault/biodome)
+"aG" = (/obj/structure/flora/ausbushes/leafybush,/turf/simulated/floor/grass,/area/vault/biodome)
+"aH" = (/obj/structure/flora/ausbushes/sparsegrass,/turf/simulated/floor/grass,/area/vault/biodome)
+"aI" = (/obj/structure/flora/ausbushes/stalkybush,/obj/structure/window/reinforced,/turf/simulated/floor/grass,/area/vault/biodome)
+"aJ" = (/obj/structure/window/reinforced,/turf/simulated/floor/grass,/area/vault/biodome)
+"aK" = (/obj/structure/flora/ausbushes/ywflowers,/obj/structure/window/reinforced,/turf/simulated/floor/grass,/area/vault/biodome)
+"aL" = (/obj/structure/flora/ausbushes/sparsegrass,/obj/structure/window/reinforced,/turf/simulated/floor/grass,/area/vault/biodome)
+"aM" = (/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/airless,/area/vault/biodome)
+"aN" = (/obj/structure/cable{d1 = 2; d2 = 4; icon_state = "2-4"},/turf/simulated/floor,/area/vault/biodome)
+"aO" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor,/area/vault/biodome)
+"aP" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/wood,/area/vault/biodome)
+"aQ" = (/obj/structure/cable{d1 = 2; d2 = 4; icon_state = "2-4"},/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/wood,/area/vault/biodome)
+"aR" = (/obj/structure/cable{d1 = 2; d2 = 8; icon_state = "2-8"},/turf/simulated/floor/wood,/area/vault/biodome)
+"aS" = (/obj/structure/window/reinforced{dir = 8},/turf/simulated/floor/grass,/area/vault/biodome)
+"aT" = (/turf/simulated/floor/wood,/area/vault/biodome)
+"aU" = (/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor,/area/vault/biodome)
+"aV" = (/obj/structure/flora/ausbushes/ppflowers,/obj/structure/window/reinforced{dir = 1},/turf/simulated/floor/grass,/area/vault/biodome)
+"aW" = (/obj/structure/window/reinforced{dir = 4},/obj/structure/window/reinforced{dir = 1},/turf/simulated/floor/grass,/area/vault/biodome)
+"aX" = (/obj/machinery/power/battery/smes,/obj/structure/cable{icon_state = "0-2"; d2 = 2},/turf/simulated/floor/wood,/area/vault/biodome)
+"aY" = (/obj/machinery/power/terminal{dir = 8},/obj/structure/cable,/turf/simulated/floor/wood,/area/vault/biodome)
+"aZ" = (/obj/machinery/floodlight/on,/turf/simulated/floor/wood,/area/vault/biodome)
+"ba" = (/obj/machinery/power/solar/control,/obj/structure/cable,/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/wood,/area/vault/biodome)
+"bb" = (/obj/structure/closet/crate/hydroponics,/obj/item/weapon/pickaxe/shovel/spade,/obj/item/weapon/hatchet,/turf/simulated/floor/wood,/area/vault/biodome)
+"bc" = (/obj/structure/table/woodentable,/obj/item/weapon/fossil/plant,/obj/item/weapon/disk/shuttle_coords/vault/biodome,/turf/simulated/floor/grass,/area/vault/biodome)
+"bd" = (/obj/structure/window/reinforced{dir = 4},/turf/simulated/floor/grass,/area/vault/biodome)
+"be" = (/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/wood,/area/vault/biodome)
+"bf" = (/obj/structure/window/reinforced{dir = 1},/turf/simulated/floor/grass,/area/vault/biodome)
+"bg" = (/obj/structure/table/woodentable,/obj/item/weapon/fossil/plant,/turf/simulated/floor/grass,/area/vault/biodome)
+"bh" = (/obj/structure/flora/ausbushes/sparsegrass,/obj/structure/window/reinforced{dir = 4},/turf/simulated/floor/grass,/area/vault/biodome)
+"bi" = (/obj/structure/window/reinforced{dir = 8},/obj/structure/window/reinforced{dir = 1},/turf/simulated/floor/grass,/area/vault/biodome)
+"bj" = (/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/plating,/area/vault/biodome)
+"bk" = (/obj/structure/cable{d1 = 1; d2 = 8; icon_state = "1-8"},/turf/simulated/floor,/area/vault/biodome)
+"bl" = (/obj/structure/window/reinforced,/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/plating,/area/vault/biodome)
+"bm" = (/obj/machinery/seed_extractor,/turf/simulated/floor,/area/vault/biodome)
+"bn" = (/obj/machinery/door/airlock/external,/obj/structure/cable{d1 = 2; d2 = 4; icon_state = "2-4"},/obj/structure/cable{d1 = 1; d2 = 4; icon_state = "1-4"},/turf/simulated/floor/plating,/area/vault/biodome)
+"bo" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/plating,/area/vault/biodome)
+"bp" = (/obj/machinery/door/airlock/external,/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/plating,/area/vault/biodome)
+"bq" = (/obj/machinery/vending/hydroseeds,/turf/simulated/floor,/area/vault/biodome)
+"br" = (/obj/machinery/biogenerator,/turf/simulated/floor,/area/vault/biodome)
+"bs" = (/obj/structure/cable{d1 = 1; d2 = 8; icon_state = "1-8"},/obj/machinery/bot/farmbot/duey,/turf/simulated/floor,/area/vault/biodome)
+"bt" = (/obj/structure/cable{d1 = 1; d2 = 4; icon_state = "1-4"},/turf/simulated/floor,/area/vault/biodome)
+"bu" = (/obj/machinery/door/airlock/external,/obj/structure/cable{d1 = 1; d2 = 8; icon_state = "1-8"},/obj/structure/cable{d1 = 2; d2 = 8; icon_state = "2-8"},/turf/simulated/floor/plating,/area/vault/biodome)
+"bv" = (/obj/structure/window/reinforced{dir = 1},/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/plating,/area/vault/biodome)
+"bw" = (/obj/machinery/vending/hydronutrients,/turf/simulated/floor,/area/vault/biodome)
+"bx" = (/obj/machinery/floodlight/on,/turf/simulated/floor,/area/vault/biodome)
+"by" = (/obj/structure/cable{icon_state = "0-4"; d2 = 4},/obj/machinery/power/apc{dir = 1; pixel_y = 24; pixel_x = 0},/turf/simulated/floor,/area/vault/biodome)
+"bz" = (/obj/structure/flora/ausbushes/grassybush,/turf/simulated/floor/grass,/area/vault/biodome)
+"bA" = (/obj/structure/flora/ausbushes/palebush,/turf/simulated/floor/grass,/area/vault/biodome)
+"bB" = (/obj/structure/window/reinforced{dir = 2},/turf/simulated/floor/grass,/area/vault/biodome)
+"bC" = (/obj/structure/reagent_dispensers/watertank,/turf/simulated/floor/wood,/area/vault/biodome)
+"bD" = (/obj/structure/closet/crate/hydroponics,/obj/item/weapon/reagent_containers/glass/bucket,/obj/item/weapon/minihoe,/turf/simulated/floor/wood,/area/vault/biodome)
+"bE" = (/obj/structure/flora/ausbushes/ywflowers,/obj/structure/window/reinforced{dir = 4},/turf/simulated/floor/grass,/area/vault/biodome)
+"bF" = (/obj/structure/closet/crate/hydroponics,/obj/item/weapon/wirecutters/clippers,/obj/item/weapon/storage/bag/plants,/turf/simulated/floor/wood,/area/vault/biodome)
+"bG" = (/obj/machinery/chem_dispenser,/turf/simulated/floor/wood,/area/vault/biodome)
+"bH" = (/obj/structure/table/woodentable,/obj/item/weapon/reagent_containers/glass/mortar,/turf/simulated/floor/wood,/area/vault/biodome)
+"bI" = (/obj/structure/cable{d1 = 1; d2 = 4; icon_state = "1-4"},/turf/simulated/floor/plating/airless,/area/vault/biodome)
+"bJ" = (/obj/structure/cable{d1 = 2; d2 = 8; icon_state = "2-8"},/turf/simulated/floor/airless,/area/vault/biodome)
+"bK" = (/obj/structure/flora/ausbushes/pointybush,/turf/simulated/floor/grass,/area/vault/biodome)
+"bL" = (/obj/structure/cable{d1 = 2; d2 = 4; icon_state = "2-4"},/turf/simulated/floor/airless,/area/vault/biodome)
+"bM" = (/obj/machinery/power/solar/panel,/obj/structure/cable{d1 = 1; d2 = 4; icon_state = "1-4"},/obj/structure/cable,/turf/simulated/floor/plating/airless,/area/vault/biodome)
+"bN" = (/obj/machinery/power/solar/panel,/obj/structure/cable{d1 = 1; d2 = 8; icon_state = "1-8"},/obj/structure/cable{d2 = 8; icon_state = "0-8"},/turf/simulated/floor/plating/airless,/area/vault/biodome)
+"bO" = (/obj/machinery/power/solar/panel,/obj/structure/cable,/turf/simulated/floor/plating/airless,/area/vault/biodome)
 
 (1,1,1) = {"
 aaaaaaaaaaaaaaabacacacacadaeafagadacacacacabaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaabacahahahahahaiadaiahahahahahacabaaaaaaabajaaaa
-aaaaaaaaaaabacahahakalakamaiafaiamakakakahahacabaaanaoapaaaa
-aaaaaaaaaqacahahakakakakamamamamamakakarakahahacasatabaaaaaa
-aaaaaaauavahahakakawaxakamamamamamaxakayakakahahacazaaaaaaaa
-aaaaanavahahakaAaAaAaAakamamamamamakakaBakawakahahaCaDaaaaaa
-aaanavahahakaEaFakakaGakamamamamamakakakakalakakahahaCaDaaaa
-anavahahakaAaAaAaAaAakawamamamamamaHaIaJaIaIaKaIakahahaCaDaa
-aLahahakakakarakaBaFakakamamaMaNaNaOaOaOaPaOaOaQaRakahahaLaa
-aLahakaAaAaAaAaAaAakaSaRamamaTamamaUaVaWaXaSaYaZaRakakahaLaa
-aLahakakaGakaEakakaSbaaRamamaTamambbbcbdaSaSaSbdaRakakahaLaa
-aLahakakakaFawayakbebeaEamamaTamambbbfbdbgbeaVbdaRakakahaLaa
-bhahamamamamamaMaNaNaNaNaNaNbiamamamamaTamamamaTamamamahbhaa
-bjaiaiamamamamaTamamamamamaibkaiamamamaTamamamaTamamaiaibjaa
-blbmbnaNaNaNaNbiamamamamamboaibpaMaNaNbqamamambraNaNbnbmbsaa
-btaiaiamamamamamamamamamamaibuaiaTamamamamamamamamamaiaibtaa
-bhahamamamamamamamamamambvamambwbiamamamamamamamamamamahbhaa
-aLahakakbxakakbyakaIbzaFamamamamamakaJaIakakaFakakakakahaLaa
-aLahakakakaAawakakbAbBaRamamamamambCbDbEakaGakaAakaxakahaLaa
-aLahakbxaGaAakaAawakbFaRamamamamambcaSaEaBaAakaAakayakahaLaa
-aLahahakakaAaEaAaBaAakakamamamamamakakaAawaAaFaAaBakahahaLaa
-bGbHahahakaAbIaAakaAakakamamamamamakakaAakaAakaAakahahbJapaa
-aabGbHahahakawaAakaAaGakamamamamamawakaAaGaAaEakahahbJapaaaa
-aaaabGbHahahakaAakaAakawamamamamamakbyaAakaAakahahbJapaaaaaa
-aaaaaabKbHahahakaGaAaEaFamamamamamakakaAakaBahahbJbLaaaaaaaa
-aaaaaaaabMacahahakaAakakamamamamamakakaAakahahacbMaaaaaaaaaa
-aaaaaaaaaaabacahahakakakamaiafaiamakakakahahacabaaaaaaaaaaaa
+aaaaaaaaaaabacahahakalakamaianaiamakakakahahacabaaaoapaqaaaa
+aaaaaaaaaracahahakakakakamamamamamakakasakahahacatauabaaaaaa
+aaaaaaavawahahakakaxayakamamamamamayakazakakahahacaAaaaaaaaa
+aaaaaoawahahakaBaBaBaBakamamamamamakakaCakaxakahahaDaEaaaaaa
+aaaoawahahakaFaGakakaHakamamamamamakakakakalakakahahaDaEaaaa
+aoawahahakaBaBaBaBaBakaxamamamamamaIaJaKaJaJaLaJakahahaDaEaa
+aMahahakakakasakaCaGakakamamaNaOaOaPaPaPaQaPaPaRaSakahahaMaa
+aMahakaBaBaBaBaBaBakaTaSamamaUamamaVaWaXaYaTaZbaaSakakahaMaa
+aMahakakaHakaFakakaTbbaSamamaUamambcbdbeaTaTaTbeaSakakahaMaa
+aMahakakakaGaxazakbfbfaFamamaUamambgbhbebibfaWbeaSakakahaMaa
+bjahamamamamamaNaOaOaOaOaOaObkamamamamaUamamamaUamamamahbjaa
+blaiaiamamamamaUamamamamamaibmaiamamamaUamamamaUamamaiaiblaa
+bnbobpaOaOaOaObkamamamamambqaibraNaOaObsamamambtaOaObpbobuaa
+bvaiaiamamamamamamamamamamaibwaiaUamamamamamamamamamaiaibvaa
+bjahamamamamamamamamamambxamambybkamamamamamamamamamamahbjaa
+aMahakakbzakakbAakaJbBaGamamamamamakaKaJakakaGakakakakahaMaa
+aMahakakakaBaxakakbCbDaSamamamamambEbFbGakaHakaBakayakahaMaa
+aMahakbzaHaBakaBaxakbHaSamamamamambdaTaFaCaBakaBakazakahaMaa
+aMahahakakaBaFaBaCaBakakamamamamamakakaBaxaBaGaBaCakahahaMaa
+bIbJahahakaBbKaBakaBakakamamamamamakakaBakaBakaBakahahbLaqaa
+aabIbJahahakaxaBakaBaHakamamamamamaxakaBaHaBaFakahahbLaqaaaa
+aaaabIbJahahakaBakaBakaxamamamamamakbAaBakaBakahahbLaqaaaaaa
+aaaaaabMbJahahakaHaBaFaGamamamamamakakaBakaCahahbLbNaaaaaaaa
+aaaaaaaabOacahahakaBakakamamamamamakakaBakahahacbOaaaaaaaaaa
+aaaaaaaaaaabacahahakakakamaianaiamakakakahahacabaaaaaaaaaaaa
 aaaaaaaaaaaaabacahahahahahaiadaiahahahahahacabaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaabacacacacadaeafagadacacacacabaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaabacacacacadaeanagadacacacacabaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 "}

--- a/maps/randomvaults/listening.dmm
+++ b/maps/randomvaults/listening.dmm
@@ -55,7 +55,7 @@
 "bc" = (/obj/machinery/computer/communications,/turf/simulated/floor,/area/vault/listening)
 "bd" = (/obj/machinery/computer/crew,/obj/machinery/light{dir = 1},/turf/simulated/floor,/area/vault/listening)
 "be" = (/obj/structure/rack,/obj/item/device/encryptionkey/syndicate/hacked/full,/obj/item/device/encryptionkey/syndicate/hacked/full,/obj/item/device/encryptionkey/syndicate/hacked/full,/turf/simulated/floor,/area/vault/listening)
-"bf" = (/obj/structure/table,/obj/item/ammo_storage/box/c9mm,/obj/item/ammo_storage/box/c9mm,/turf/simulated/floor,/area/vault/listening)
+"bf" = (/obj/structure/table,/obj/item/ammo_storage/box/c9mm,/obj/item/ammo_storage/box/c9mm,/obj/item/weapon/disk/shuttle_coords/vault/listening,/turf/simulated/floor,/area/vault/listening)
 "bg" = (/obj/structure/grille,/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced{dir = 4},/obj/structure/window/reinforced{dir = 8},/turf/simulated/floor/plating,/area/vault/listening)
 "bh" = (/obj/item/weapon/stool,/turf/simulated/floor/carpet,/area/vault/listening)
 "bi" = (/turf/simulated/floor/carpet,/area/vault/listening)
@@ -91,6 +91,7 @@
 "bM" = (/obj/structure/rack,/obj/item/ammo_storage/magazine/mc9mm,/obj/item/ammo_storage/magazine/mc9mm,/obj/item/ammo_storage/magazine/mc9mm,/obj/item/ammo_storage/magazine/mc9mm,/turf/simulated/floor,/area/vault/listening)
 "bN" = (/obj/structure/table,/obj/machinery/recharger,/turf/simulated/floor,/area/vault/listening)
 "bO" = (/obj/machinery/door/airlock/external,/turf/simulated/floor/plating,/area/vault/listening)
+"bP" = (/obj/machinery/door/airlock/external,/obj/docking_port/destination/vault/listening{dir = 2},/turf/simulated/floor/plating,/area/vault/listening)
 
 (1,1,1) = {"
 aaaaaaaaaaaaaaaaaaaaaaaaabaaaaaaaaaaaaaaaaaaaaaaaa
@@ -117,5 +118,5 @@ aaaabybzbababaadbAbAadbBbbbCadbAbAadbbbbbmbnbyaaaa
 aaaaadbDbEbFbGadaaaaadbHbIbJadaaaaadbKbLbMbNadaaaa
 aaaaadadadadadadafafadadbOadadafafadadadadadadaaaa
 aaaaaaaaaaaaaaaaaaaaaaadauadaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaadbOadaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaadbPadaaaaaaaaaaaaaaaaaaaaaa
 "}

--- a/maps/randomvaults/objects.dm
+++ b/maps/randomvaults/objects.dm
@@ -39,8 +39,20 @@
 /area/vault/listening
 	requires_power = 1
 
+/obj/item/weapon/disk/shuttle_coords/vault/listening
+	destination = /obj/docking_port/destination/vault/listening
+
+/obj/docking_port/destination/vault/listening
+	areaname = "outpost V-24"
+
 /area/vault/biodome
 	requires_power = 1
+
+/obj/item/weapon/disk/shuttle_coords/vault/biodome
+	destination = /obj/docking_port/destination/vault/biodome
+
+/obj/docking_port/destination/vault/biodome
+	areaname = "biodome"
 
 /area/vault/brokeufo
 	requires_power = 1


### PR DESCRIPTION
- Added shuttle destination disks. They can be inserted into shuttle computers to unlock additional travel destinations. They're intended to be hidden in vaults, away missions and such

![revert 64x64](https://cloud.githubusercontent.com/assets/9512290/17515015/33e82100-5e36-11e6-9305-a69af86590aa.gif)
- Syndicate listening outpost and the biodome now have these disks. They allow mining and science shuttles to travel there (salvage shuttle not allowed yet because it might get stuck in hyperspace if another shuttle occupies its destination - see #10303 . Shuttles without transit handle sharing just fine)

This also brings us one step closer to custom shuttle destinations
