### PR TITLE
Prevents holstering weapons while attack delayer is blocked, also holster verb name quality

### DIFF
--- a/code/modules/clothing/accessories/holster.dm
+++ b/code/modules/clothing/accessories/holster.dm
@@ -5,6 +5,7 @@
 	origin_tech = "combat=2"
 	var/obj/item/holstered = null
 	accessory_exclusion = HOLSTER
+	var/holster_verb_name = "Holster"
 
 /obj/item/clothing/accessory/holster/proc/can_holster(obj/item/weapon/gun/W)
 	return
@@ -100,10 +101,12 @@
 
 /obj/item/clothing/accessory/holster/on_attached(obj/item/clothing/under/S)
 	..()
-	attached_to.verbs += /obj/item/clothing/accessory/holster/verb/holster_verb
+	//We're making a new verb, see http://www.byond.com/forum/?post=238593
+	attached_to.verbs += new/obj/item/clothing/accessory/holster/verb/holster_verb(attached_to,holster_verb_name)
 
 /obj/item/clothing/accessory/holster/on_removed(mob/user as mob)
-	attached_to.verbs -= /obj/item/clothing/accessory/holster/verb/holster_verb
+	//Yes, we're calling "new" when removing a verb. I blame verbs entirely for this shit. See: http://www.byond.com/forum/?post=80230
+	attached_to.verbs -= new/obj/item/clothing/accessory/holster/verb/holster_verb(attached_to,holster_verb_name)
 	..()
 
 //
@@ -112,6 +115,7 @@
 /obj/item/clothing/accessory/holster/handgun
 	name = "shoulder holster"
 	desc = "A handgun holster. Perfect for concealed carry."
+	holster_verb_name = "Holster (Handgun)"
 
 /obj/item/clothing/accessory/holster/handgun/can_holster(obj/item/weapon/gun/W)
 	if(!istype(W))
@@ -143,6 +147,7 @@
 /obj/item/clothing/accessory/holster/knife
 	name = "knife holster"
 	desc = "A holster that takes knives. The possibilities are endless."
+	holster_verb_name = "Holster (Knife)"
 
 /obj/item/clothing/accessory/holster/knife/can_holster(obj/item/weapon/W)
 	if(!istype(W))

--- a/code/modules/clothing/accessories/holster.dm
+++ b/code/modules/clothing/accessories/holster.dm
@@ -18,6 +18,9 @@
 		to_chat(user, "<span class='warning'>\The [I] won't fit in the [src]!</span>")
 		return
 
+	if(user.attack_delayer.blocked())
+		return
+
 	if(user.drop_item(I, src))
 		holstered = I
 		holstered.add_fingerprint(user)
@@ -51,15 +54,16 @@
 		return
 
 	var/obj/item/clothing/accessory/holster/H = null
-	if (istype(src, /obj/item/clothing/accessory/holster))
+	if(istype(src, /obj/item/clothing/accessory/holster))
 		H = src
-	else if (istype(src, /obj/item/clothing/))
+	else if(istype(src, /obj/item/clothing/))
 		var/obj/item/clothing/S = src
 		if (S.accessories.len)
 			H = locate() in S.accessories
 
-	if (!H)
+	if(!H)
 		to_chat(usr, "<span class='warning'>Something is very wrong.</span>")
+		return
 
 	if(!H.holstered)
 		var/obj/item/W = usr.get_active_hand()
@@ -105,6 +109,10 @@
 //
 // Handguns
 //
+/obj/item/clothing/accessory/holster/handgun
+	name = "shoulder holster"
+	desc = "A handgun holster. Perfect for concealed carry."
+
 /obj/item/clothing/accessory/holster/handgun/can_holster(obj/item/weapon/gun/W)
 	if(!istype(W))
 		return
@@ -117,10 +125,6 @@
 	else
 		user.visible_message("<span class='notice'>[user] draws \the [holstered], pointing it at the ground.</span>", \
 		"<span class='notice'>You draw \the [holstered], pointing it at the ground.</span>")
-
-/obj/item/clothing/accessory/holster/handgun
-	name = "shoulder holster"
-	desc = "A handgun holster. Perfect for concealed carry."
 
 /obj/item/clothing/accessory/holster/handgun/wornout
 	desc = "A worn-out handgun holster. Perfect for concealed carry."
@@ -136,6 +140,10 @@
 //
 // Knives
 //
+/obj/item/clothing/accessory/holster/knife
+	name = "knife holster"
+	desc = "A holster that takes knives. The possibilities are endless."
+
 /obj/item/clothing/accessory/holster/knife/can_holster(obj/item/weapon/W)
 	if(!istype(W))
 		return
@@ -152,7 +160,6 @@
 	"<span class='warning'>You draw your [holstered.name]!</span>")
 
 /obj/item/clothing/accessory/holster/knife/boot
-	name = "knife holster"
 	desc = "A knife holster that can be attached to any pair of boots."
 	item_state = "bootknife"
 	icon_state = "bootknife"

--- a/html/changelogs/asdhaa.yml
+++ b/html/changelogs/asdhaa.yml
@@ -34,3 +34,4 @@ delete-after: True
 # SCREW ANY OF THIS UP AND IT WON'T WORK.
 changes: 
 - tweak: "To prevent abuse, you may no longer holster weapons while they are in attack 'cooldown' (same behavior as trying to put it in a container). Quickdraw not affected."
+- rscadd: "Differentiated knife holster and handgun holster verb names so they can be used separately via the Object tab."

--- a/html/changelogs/asdhaa.yml
+++ b/html/changelogs/asdhaa.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general deleting of nice things)
+#   rscadd (general adding of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.
+author: 9600bauds
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# There needs to be a space after the - and before the prefix. Don't use tabs anywhere in this file.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# If you're using characters such as # ' : - or the like in your changelog, surround the entire change with quotes as shown in the second example. These quotes don't show up on the changelog once it's merged and prevent errors.
+# SCREW ANY OF THIS UP AND IT WON'T WORK.
+changes: 
+- tweak: "To prevent abuse, you may no longer holster weapons while they are in attack 'cooldown' (same behavior as trying to put it in a container). Quickdraw not affected."


### PR DESCRIPTION
Some people would abuse holsters by unholster->click->instaholster so they wouldn't lose their gun if stunned, you couldn't do this with containers before so whoop whoop
Arguably more of a bugfix than a balance change but you decide
