### PR TITLE
Reduces minimum number of heads required for rev/revsquad to 2

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -361,6 +361,13 @@
 			heads += player.mind
 	return heads
 
+/datum/game_mode/proc/get_assigned_head_roles()
+	var/list/roles = list()
+	for(var/mob/player in mob_list)
+		if(player.mind && (player.mind.assigned_role in command_positions))
+			roles += player.mind.assigned_role
+	return roles
+
 /*/datum/game_mode/New()
 	newscaster_announcements = pick(newscaster_standard_feeds)*/
 

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -71,11 +71,19 @@
 		possible_headrevs -= lenin
 		head_revolutionaries += lenin
 
-	if(head_revolutionaries.len==0|| head_check < minimum_heads)
+	if(master_mode=="secret" && force_secret_mode != "secret")
+		minimum_heads = 1
+
+	// If an admin forces this mode, we set the minimum head count to 1, otherwise check minimum heads
+	if((head_revolutionaries.len==0 || head_check < minimum_heads) && (master_mode=="secret" && force_secret_mode == "secret"))
 		log_admin("Failed to set-up a round of revolution. Couldn't find enough heads of staffs or any volunteers to be head revolutionaries.")
 		log_admin("Number of headrevs: [head_revolutionaries.len] Number of heads: [head_check]")
 		message_admins("Failed to set-up a round of revolution. Couldn't find enough heads of staffs or any volunteers to be head revolutionaries.")
 		message_admins("Number of headrevs: [head_revolutionaries.len] Number of heads: [head_check]")
+		return 0
+	else if (head_revolutionaries.len==0 || head_check < 1)
+		log_admin("Failed to setup a round of revolution while secret forced mode: there was not at least one head. Headcount: [head_check]")
+		message_admins("Failed to setup a round of revolution while secret forced mode: there was not at least one head. Headcount: [head_check]")
 		return 0
 
 	log_admin("Starting a round of revolution with [head_revolutionaries.len] head revolutionaries and [head_check] heads of staff.")

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -76,7 +76,7 @@
 		log_admin("Failed to set-up a round of revolution. Couldn't find enough heads of staffs or any volunteers to be head revolutionaries.")
 		log_admin("Number of headrevs: [head_revolutionaries.len] Number of heads: [head_check]")
 		message_admins("Failed to set-up a round of revolution. Couldn't find enough heads of staffs or any volunteers to be head revolutionaries.")
-		message_admins("Number of headrevs: [head_revolutionaries.len] Heads of Staff: [get_all_heads]")
+		message_admins("Number of headrevs: [head_revolutionaries.len] Heads of Staff: [get_assigned_head_roles()]")
 		return 0
 	else if (head_revolutionaries.len==0 || head_check < 1)
 		log_admin("Failed to setup a round of revolution while secret forced mode: there was not at least one head. Headcount: [head_check]")

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -33,7 +33,7 @@
 	var/finished = 0
 	var/checkwin_counter = 0
 	var/max_headrevs = 3
-	var/minimum_heads = 3
+	var/minimum_heads = 2
 	var/const/waittime_l = 600 //lower bound on time before intercept arrives (in tenths of seconds)
 	var/const/waittime_h = 1800 //upper bound on time before intercept arrives (in tenths of seconds)
 ///////////////////////////

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -72,12 +72,14 @@
 		head_revolutionaries += lenin
 
 	// If an admin forces this mode, we set the minimum head count to 1, otherwise check minimum heads
-	if((head_revolutionaries.len==0 || head_check < minimum_heads) && (master_mode=="secret" && secret_force_mode == "secret"))
-		log_admin("Failed to set-up a round of revolution. Couldn't find enough heads of staffs or any volunteers to be head revolutionaries.")
-		log_admin("Number of headrevs: [head_revolutionaries.len] Number of heads: [head_check]")
-		message_admins("Failed to set-up a round of revolution. Couldn't find enough heads of staffs or any volunteers to be head revolutionaries.")
-		message_admins("Number of headrevs: [head_revolutionaries.len] Heads of Staff: [get_assigned_head_roles()]")
-		return 0
+	if(master_mode=="secret" && secret_force_mode=="secret")
+		if(head_revolutionaries.len==0 || head_check < minimum_heads)
+			log_admin("Failed to set-up a round of revolution. Couldn't find enough heads of staffs or any volunteers to be head revolutionaries.")
+			log_admin("Number of headrevs: [head_revolutionaries.len] Number of heads: [head_check]")
+			message_admins("Failed to set-up a round of revolution. Couldn't find enough heads of staffs or any volunteers to be head revolutionaries.")
+			message_admins("Number of headrevs: [head_revolutionaries.len] Heads of Staff: [get_assigned_head_roles()]")
+			return 0
+			
 	else if (head_revolutionaries.len==0 || head_check < 1)
 		log_admin("Failed to setup a round of revolution while secret forced mode: there was not at least one head. Headcount: [head_check]")
 		message_admins("Failed to setup a round of revolution while secret forced mode: there was not at least one head. Headcount: [head_check]")

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -71,15 +71,12 @@
 		possible_headrevs -= lenin
 		head_revolutionaries += lenin
 
-	if(master_mode=="secret" && force_secret_mode != "secret")
-		minimum_heads = 1
-
 	// If an admin forces this mode, we set the minimum head count to 1, otherwise check minimum heads
-	if((head_revolutionaries.len==0 || head_check < minimum_heads) && (master_mode=="secret" && force_secret_mode == "secret"))
+	if((head_revolutionaries.len==0 || head_check < minimum_heads) && (master_mode=="secret" && secret_force_mode == "secret"))
 		log_admin("Failed to set-up a round of revolution. Couldn't find enough heads of staffs or any volunteers to be head revolutionaries.")
 		log_admin("Number of headrevs: [head_revolutionaries.len] Number of heads: [head_check]")
 		message_admins("Failed to set-up a round of revolution. Couldn't find enough heads of staffs or any volunteers to be head revolutionaries.")
-		message_admins("Number of headrevs: [head_revolutionaries.len] Number of heads: [head_check]")
+		message_admins("Number of headrevs: [head_revolutionaries.len] Heads of Staff: [get_all_heads]")
 		return 0
 	else if (head_revolutionaries.len==0 || head_check < 1)
 		log_admin("Failed to setup a round of revolution while secret forced mode: there was not at least one head. Headcount: [head_check]")

--- a/code/game/gamemodes/revolution/revsquad.dm
+++ b/code/game/gamemodes/revolution/revsquad.dm
@@ -17,7 +17,7 @@
 	var/checkwin_counter = 0
 	var/const/waittime_l = 600 //lower bound on time before intercept arrives (in tenths of seconds)
 	var/const/waittime_h = 1800 //upper bound on time before intercept arrives (in tenths of seconds)
-	var/minimum_heads = 3
+	var/minimum_heads = 2
 	var/list/possible_items = list(/obj/item/weapon/card/emag,
 								   /obj/item/clothing/gloves/yellow,
 								   /obj/item/weapon/gun/projectile/automatic,

--- a/code/game/gamemodes/revolution/revsquad.dm
+++ b/code/game/gamemodes/revolution/revsquad.dm
@@ -59,11 +59,11 @@
 		head_revolutionaries += lenin
 
 	// If an admin forces this mode, we set the minimum head count to 1, otherwise check minimum heads
-	if((head_revolutionaries.len==0 || head_check < minimum_heads) && (master_mode=="secret" && force_secret_mode == "secret"))
+	if((head_revolutionaries.len==0 || head_check < minimum_heads) && (master_mode=="secret" && secret_force_mode == "secret"))
 		log_admin("Failed to set-up a round of revsquad. Couldn't find any heads of staffs or any volunteers to be revolutionaries.")
 		log_admin("Number of headrevs: [head_revolutionaries.len] Number of heads: [head_check]")
 		message_admins("Failed to set-up a round of revsquad. Couldn't find any heads of staffs or any volunteers to be revolutionaries.")
-		message_admins("Number of headrevs: [head_revolutionaries.len] Number of heads: [head_check]")
+		message_admins("Number of headrevs: [head_revolutionaries.len] Heads of Staff: [get_all_heads]")
 		return 0
 	else if (head_revolutionaries.len==0 || head_check < 1)
 		log_admin("Failed to set-up a secret-forced round of revsquad. Couldn't find any heads of staffs or any volunteers to be revolutionaries.")

--- a/code/game/gamemodes/revolution/revsquad.dm
+++ b/code/game/gamemodes/revolution/revsquad.dm
@@ -59,12 +59,14 @@
 		head_revolutionaries += lenin
 
 	// If an admin forces this mode, we set the minimum head count to 1, otherwise check minimum heads
-	if((head_revolutionaries.len==0 || head_check < minimum_heads) && (master_mode=="secret" && secret_force_mode == "secret"))
-		log_admin("Failed to set-up a round of revsquad. Couldn't find any heads of staffs or any volunteers to be revolutionaries.")
-		log_admin("Number of headrevs: [head_revolutionaries.len] Number of heads: [head_check]")
-		message_admins("Failed to set-up a round of revsquad. Couldn't find any heads of staffs or any volunteers to be revolutionaries.")
-		message_admins("Number of headrevs: [head_revolutionaries.len] Heads of Staff: [get_assigned_head_roles()]")
-		return 0
+	if(master_mode=="secret" && secret_force_mode=="secret")
+		if(head_revolutionaries.len==0 || head_check < minimum_heads)
+			log_admin("Failed to set-up a round of revsquad. Couldn't find any heads of staffs or any volunteers to be revolutionaries.")
+			log_admin("Number of headrevs: [head_revolutionaries.len] Number of heads: [head_check]")
+			message_admins("Failed to set-up a round of revsquad. Couldn't find any heads of staffs or any volunteers to be revolutionaries.")
+			message_admins("Number of headrevs: [head_revolutionaries.len] Heads of Staff: [get_assigned_head_roles()]")
+			return 0
+
 	else if (head_revolutionaries.len==0 || head_check < 1)
 		log_admin("Failed to set-up a secret-forced round of revsquad. Couldn't find any heads of staffs or any volunteers to be revolutionaries.")
 		message_admins("Failed to set-up a secret-forced round of revsquad. Couldn't find any heads of staffs or any volunteers to be revolutionaries.")

--- a/code/game/gamemodes/revolution/revsquad.dm
+++ b/code/game/gamemodes/revolution/revsquad.dm
@@ -58,11 +58,16 @@
 		possible_revs -= lenin
 		head_revolutionaries += lenin
 
-	if(revolutionaries.len==0 || head_check < minimum_heads)
+	// If an admin forces this mode, we set the minimum head count to 1, otherwise check minimum heads
+	if((head_revolutionaries.len==0 || head_check < minimum_heads) && (master_mode=="secret" && force_secret_mode == "secret"))
 		log_admin("Failed to set-up a round of revsquad. Couldn't find any heads of staffs or any volunteers to be revolutionaries.")
 		log_admin("Number of headrevs: [head_revolutionaries.len] Number of heads: [head_check]")
 		message_admins("Failed to set-up a round of revsquad. Couldn't find any heads of staffs or any volunteers to be revolutionaries.")
 		message_admins("Number of headrevs: [head_revolutionaries.len] Number of heads: [head_check]")
+		return 0
+	else if (head_revolutionaries.len==0 || head_check < 1)
+		log_admin("Failed to set-up a secret-forced round of revsquad. Couldn't find any heads of staffs or any volunteers to be revolutionaries.")
+		message_admins("Failed to set-up a secret-forced round of revsquad. Couldn't find any heads of staffs or any volunteers to be revolutionaries.")
 		return 0
 
 	log_admin("Starting a round of revsquad with [head_revolutionaries.len] revolutionaries and [head_check] heads of staff.")

--- a/code/game/gamemodes/revolution/revsquad.dm
+++ b/code/game/gamemodes/revolution/revsquad.dm
@@ -63,7 +63,7 @@
 		log_admin("Failed to set-up a round of revsquad. Couldn't find any heads of staffs or any volunteers to be revolutionaries.")
 		log_admin("Number of headrevs: [head_revolutionaries.len] Number of heads: [head_check]")
 		message_admins("Failed to set-up a round of revsquad. Couldn't find any heads of staffs or any volunteers to be revolutionaries.")
-		message_admins("Number of headrevs: [head_revolutionaries.len] Heads of Staff: [get_all_heads]")
+		message_admins("Number of headrevs: [head_revolutionaries.len] Heads of Staff: [get_assigned_head_roles()]")
 		return 0
 	else if (head_revolutionaries.len==0 || head_check < 1)
 		log_admin("Failed to set-up a secret-forced round of revsquad. Couldn't find any heads of staffs or any volunteers to be revolutionaries.")


### PR DESCRIPTION
## IT USED TO BE 1 A FEW DAYS AGO BUT I TURNED IT UP TO 3 AND IT BECAME UNSTARTABLE

Because either something's fucked or we will never get over 2 heads in a lobby even during highpop

Can be increased later if we really need it to be.

Also, if the mode is forced (either through forced secret mode or changing from secret to rev/revsquad), then it only requires one head of staff.
