### PR TITLE
Adds a proc to create a shuttle transit area at runtime

### DIFF
--- a/code/datums/map_elements.dm
+++ b/code/datums/map_elements.dm
@@ -24,7 +24,6 @@ var/list/datum/map_element/map_elements = list()
 		location = locate(/turf) in objects
 
 /datum/map_element/proc/load(x, y, z)
-	to_chat(world, "Loading at [x],[y],[z]")
 	pre_load()
 
 	if(file_path)

--- a/code/datums/map_elements.dm
+++ b/code/datums/map_elements.dm
@@ -9,7 +9,7 @@ var/list/datum/map_element/map_elements = list()
 
 	var/file_path = "maps/randomvaults/new.dmm"
 
-	var/turf/location //A random turf from the map element. Used for jumping to
+	var/turf/location //Lower left turf of the map element
 
 	var/width //Width of the map element, in turfs
 	var/height //Height of the map element, in turfs
@@ -24,11 +24,19 @@ var/list/datum/map_element/map_elements = list()
 		location = locate(/turf) in objects
 
 /datum/map_element/proc/load(x, y, z)
-	var/file = file(file_path)
-	if(isfile(file))
-		pre_load()
-		var/list/L = maploader.load_map(file, z, x, y, src)
-		initialize(L)
+	to_chat(world, "Loading at [x],[y],[z]")
+	pre_load()
+
+	if(file_path)
+		var/file = file(file_path)
+		if(isfile(file))
+			var/list/L = maploader.load_map(file, z, x, y, src)
+			initialize(L)
+			return 1
+	else //No file specified - empty map element
+		//These variables are usually set by the map loader. Here we have to set them manually
+		location = locate(x+1, y+1, z) //Location is always lower left corner
+		initialize(list()) //Initialize with an empty list
 		return 1
 
 	return 0

--- a/code/datums/map_elements.dm
+++ b/code/datums/map_elements.dm
@@ -29,7 +29,6 @@ var/list/datum/map_element/map_elements = list()
 		pre_load()
 		var/list/L = maploader.load_map(file, z, x, y, src)
 		initialize(L)
-		to_chat(world, "Loaded a vault with the dimensions [width]x[height]")
 		return 1
 
 	return 0

--- a/code/datums/map_elements.dm
+++ b/code/datums/map_elements.dm
@@ -29,6 +29,7 @@ var/list/datum/map_element/map_elements = list()
 		pre_load()
 		var/list/L = maploader.load_map(file, z, x, y, src)
 		initialize(L)
+		to_chat(world, "Loaded a vault with the dimensions [width]x[height]")
 		return 1
 
 	return 0

--- a/code/game/objects/effects/step_triggers.dm
+++ b/code/game/objects/effects/step_triggers.dm
@@ -118,3 +118,15 @@
 				A.y = rand(teleport_y, teleport_y_offset)
 				A.z = rand(teleport_z, teleport_z_offset)
 
+/obj/effect/step_trigger/teleporter/random/shuttle_transit
+	teleport_x = 25
+	teleport_y = 25
+	teleport_z = 6
+
+	//x and y offsets depend on the map size
+
+	teleport_z_offset = 6
+
+/obj/effect/step_trigger/teleporter/random/shuttle_transit/New()
+	teleport_x_offset = world.maxx - 25
+	teleport_y_offset = world.maxy - 25

--- a/code/game/objects/effects/step_triggers.dm
+++ b/code/game/objects/effects/step_triggers.dm
@@ -128,5 +128,6 @@
 	teleport_z_offset = 6
 
 /obj/effect/step_trigger/teleporter/random/shuttle_transit/New()
+	..()
 	teleport_x_offset = world.maxx - 25
 	teleport_y_offset = world.maxy - 25

--- a/code/game/turfs/space/transit.dm
+++ b/code/game/turfs/space/transit.dm
@@ -6,6 +6,12 @@
 	if(loc)
 		var/area/A = loc
 		A.area_turfs += src
+
+	update_icon()
+
+/turf/space/transit/update_icon()
+	icon_state = ""
+
 	var/dira=""
 	var/i=0
 	switch(pushdirection)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -861,6 +861,7 @@ var/global/floorIsLava = 0
 		<a href='?src=\ref[src];shuttle_create_destination=1'>Create a destination docking port</a><br>
 		<a href='?src=\ref[src];shuttle_modify_destination=1'>Add a destination docking port</a><br>
 		<a href='?src=\ref[src];shuttle_set_transit=1'>Modify transit area</a><br>
+		<a href='?src=\ref[src];shuttle_generate_transit=1'>Generate new transit area</a><br>
 		<a href='?src=\ref[src];shuttle_get_console=1'>Get control console</a><br>
 		<a href='?src=\ref[src];shuttle_edit=1'>Modify parameters[selected_shuttle.is_special() ? " and pre-defined areas" : ""]</a>
 		<hr>

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -4285,6 +4285,25 @@
 
 		S.show_outline(usr)
 
+	if(href_list["shuttle_generate_transit"])
+		feedback_inc("admin_shuttle_magic_used",1)
+		feedback_add_details("admin_shuttle_magic_used","SO")
+
+		var/datum/shuttle/S = selected_shuttle
+		if(!istype(S))
+			return
+
+		var/obj/docking_port/destination/D = generate_transit_area(S, NORTH)
+		if(!istype(D))
+			to_chat(usr, "<span class='notice'>Transit area generation failed!</span>")
+			return
+
+		S.transit_port = D
+		to_chat(usr, "<span class='info'>Transit area generated successfully.</span>")
+		if(S.use_transit = NO_TRANSIT)
+			S.use_transit = TRANSIT_ACROSS_Z_LEVELS
+			to_chat(usr, "<span class='info'>The [S.name] will now use the transit area when traveling across z-levels. Set its use_transit to 2 to make it always use transit, or 0 to disable transit.</span>")
+
 
 	//------------------------------------------------------------------Shuttle stuff end---------------------------------
 

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -4300,7 +4300,7 @@
 
 		S.transit_port = D
 		to_chat(usr, "<span class='info'>Transit area generated successfully.</span>")
-		if(S.use_transit = NO_TRANSIT)
+		if(S.use_transit == NO_TRANSIT)
 			S.use_transit = TRANSIT_ACROSS_Z_LEVELS
 			to_chat(usr, "<span class='info'>The [S.name] will now use the transit area when traveling across z-levels. Set its use_transit to 2 to make it always use transit, or 0 to disable transit.</span>")
 

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -4293,7 +4293,16 @@
 		if(!istype(S))
 			return
 
-		var/obj/docking_port/destination/D = generate_transit_area(S, NORTH)
+		var/transit_dir = NORTH
+		var/list/dirs = list("north"=NORTH, "west"=WEST, "east"=EAST, "south"=SOUTH)
+		var/choice = input(usr, "Select a direction for the transit area (this should be the direction in which the shuttle is currently facing)", "Transit") as null|anything in dirs
+
+		if(!choice)
+			return
+
+		transit_dir = dirs[choice]
+
+		var/obj/docking_port/destination/D = generate_transit_area(S, transit_dir)
 		if(!istype(D))
 			to_chat(usr, "<span class='notice'>Transit area generation failed!</span>")
 			return

--- a/code/modules/admin/verbs/adminjump.dm
+++ b/code/modules/admin/verbs/adminjump.dm
@@ -131,7 +131,7 @@
 
 		var/datum/map_element/V = vaults[selection]
 		if(!V.location)
-			to_chat(src, "[V.file_path] doesn't have a location! Report this")
+			to_chat(src, "[V.file_path || V.name] doesn't have a location! Report this")
 			return
 
 		usr.forceMove(V.location)

--- a/code/modules/randomMaps/transit.dm
+++ b/code/modules/randomMaps/transit.dm
@@ -1,11 +1,3 @@
-#define DEBUG_TRANSIT_GENERATION //Comment out if not needed
-
-#ifdef DEBUG_TRANSIT_GENERATION
-#define DEBUG_T(x) to_chat(world, x)
-#else
-#define DEBUG_T(x) to_chat(null, x)
-#endif
-
 //Dynamically generated transit areas - welcome to the future
 
 //Object used for the dungeons system (see dungeons.dm)
@@ -43,8 +35,6 @@
 	var/shuttle_width = abs(top_x - low_x)
 	var/shuttle_height= abs(top_y - low_y)
 
-	DEBUG_T("Width: [shuttle_width], height: [shuttle_height]. x1,y1;x2,y2: [low_x],[low_y];[top_x],[top_y]")
-
 	//Extra space in every direction. WIthout this, you'd be able to see z2 out of your shuttle's window
 	var/buffer_space = world.view
 
@@ -52,7 +42,6 @@
 	new_transit.name = "[shuttle.name] - transit area"
 	new_transit.width = shuttle_width + 2*buffer_space
 	new_transit.height = shuttle_height + 2*buffer_space
-	DEBUG_T("Transit map element created. Width: [new_transit.width],[new_transit.height]")
 
 	//Find a suitable location for the map_element object (done automatically)
 	load_dungeon(new_transit)

--- a/code/modules/randomMaps/transit.dm
+++ b/code/modules/randomMaps/transit.dm
@@ -1,0 +1,92 @@
+#define DEBUG_TRANSIT_GENERATION //Comment out if not needed
+
+#ifdef DEBUG_TRANSIT_GENERATION
+#define DEBUG_T(x) to_chat(world, x)
+#else
+#define DEBUG_T(x) to_chat(null, x)
+#endif
+
+//Dynamically generated transit areas - welcome to the future
+
+//Object used for the dungeons system (see dungeons.dm)
+/datum/map_element/transit
+	type_abbreviation = "TR"
+
+	file_path = null //No map file is loaded
+
+	width = 0
+	height = 0
+
+
+//generate_transit_area proc
+//Arguments: shuttle (/datum/shuttle object), direction (of the transit turfs), create_borders = 1 (if 0, people are not teleported when stepping out)
+//Returns: docking port
+/proc/generate_transit_area(datum/shuttle/shuttle, direction, create_borders = 1)
+	//To do this, we need to find the shuttle's width and height
+	//Go through each turf in the shuttle, find the lowest x;y and the highest x;y, subtract them to get the size
+	var/low_x = 0
+	var/low_y = 0
+	var/top_x = world.maxx
+	var/top_y = world.maxy
+
+	for(var/turf/T in shuttle.linked_area)
+		if(T.x > low_x)
+			low_x = T.x
+		if(T.x < top_x)
+			top_x = T.x
+
+		if(T.y > low_y)
+			low_y = T.y
+		if(T.y < top_y)
+			top_y = T.y
+
+	var/shuttle_width = abs(top_x - low_x)
+	var/shuttle_height= abs(top_y - low_y)
+
+	DEBUG_T("Width: [shuttle_width], height: [shuttle_height]. x1,y1;x2,y2: [low_x],[low_y];[top_x],[top_y]")
+
+	//Extra space in every direction. WIthout this, you'd be able to see z2 out of your shuttle's window
+	var/buffer_space = world.view
+
+	var/datum/map_element/transit/new_transit = new()
+	new_transit.name = "[shuttle.name] - transit area"
+	new_transit.width = shuttle_width + 2*buffer_space
+	new_transit.height = shuttle_height + 2*buffer_space
+	DEBUG_T("Transit map element created. Width: [new_transit.width],[new_transit.height]")
+
+	//Find a suitable location for the map_element object (done automatically)
+	load_dungeon(new_transit)
+
+	//Start filling out the area
+	var/turf/t_loc = new_transit.location
+
+	if(!istype(t_loc))
+		message_admins("<span class='warning'>ERROR: Unable to generate transit area (area placement failed).</span>")
+		return
+
+	for(var/turf/T in block(locate(t_loc.x, t_loc.y, t_loc.z), locate(t_loc.x+new_transit.width, t_loc.y+new_transit.height, t_loc.z)))
+		T.ChangeTurf(/turf/space/transit)
+		var/turf/space/transit/t_turf = T
+		t_turf.pushdirection = direction
+		t_turf.update_icon()
+
+	//Transit turfs placed - place the docking port!
+	//First, find the shuttle docking port's location relative to the shuttle's lower left corner
+	var/port_x = shuttle.linked_port.x - top_x
+	var/port_y = shuttle.linked_port.y - top_y
+
+	//Now calculate the location of the destination docking port
+	//Docking ports dock like this: [  ][->][<-][  ], so the resulting coordinates will have to be shifted 1 turf in the direction of the shuttle docking port
+	//Otherwise both arrows will be on the same turf
+	var/dest_x = t_loc.x + buffer_space + port_x
+	var/dest_y = t_loc.y + buffer_space + port_y
+	var/turf/destination_turf = get_step(locate(dest_x, dest_y, t_loc.z), shuttle.linked_port.dir)
+
+	var/obj/docking_port/destination/transit/result = new(destination_turf)
+	result.dir = turn(shuttle.linked_port.dir, 180)
+
+	if(create_borders)
+		result.generate_borders = TRUE
+		//Border generation is done by the docking port
+
+	return result

--- a/code/modules/randomMaps/vault_definitions.dm
+++ b/code/modules/randomMaps/vault_definitions.dm
@@ -60,6 +60,7 @@ var/list/existing_vaults = list()
 	file_path = "maps/randomvaults/oldarmory.dmm"
 
 /datum/map_element/vault/spacepond
+	require_dungeons = 1
 	file_path = "maps/randomvaults/spacepond.dmm"
 
 /datum/map_element/vault/spacepond/initialize(list/objects)

--- a/code/modules/randomMaps/vault_definitions.dm
+++ b/code/modules/randomMaps/vault_definitions.dm
@@ -60,7 +60,6 @@ var/list/existing_vaults = list()
 	file_path = "maps/randomvaults/oldarmory.dmm"
 
 /datum/map_element/vault/spacepond
-	require_dungeons = 1
 	file_path = "maps/randomvaults/spacepond.dmm"
 
 /datum/map_element/vault/spacepond/initialize(list/objects)

--- a/html/changelogs/unid-atr.yml
+++ b/html/changelogs/unid-atr.yml
@@ -1,0 +1,6 @@
+author: Unid
+
+delete-after: True
+
+changes: 
+- experiment: Added a new admin button to shuttle magic - it generates a transit area for the selected shuttle.

--- a/html/changelogs/unid-stu.yml
+++ b/html/changelogs/unid-stu.yml
@@ -3,4 +3,5 @@ author: Unid
 delete-after: True
 
 changes: 
-- rscadd: The space pond vault now contains a wine cellar.
+- experiment: Added a way for vaults to spawn additional, normally unreachable locations on the map.
+- rscadd: The space pond vault now contains an underground wine cellar, only accessible by a ladder.

--- a/html/changelogs/unid-stu.yml
+++ b/html/changelogs/unid-stu.yml
@@ -1,0 +1,6 @@
+author: Unid
+
+delete-after: True
+
+changes: 
+- rscadd: The space pond vault now contains a wine cellar.

--- a/html/changelogs/unid-stu.yml
+++ b/html/changelogs/unid-stu.yml
@@ -1,7 +1,0 @@
-author: Unid
-
-delete-after: True
-
-changes: 
-- experiment: Added a way for vaults to spawn additional, normally unreachable locations on the map.
-- rscadd: The space pond vault now contains an underground wine cellar, only accessible by a ladder.

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -1667,6 +1667,7 @@
 #include "code\modules\projectiles\projectile\rocket.dm"
 #include "code\modules\projectiles\projectile\special.dm"
 #include "code\modules\randomMaps\dungeons.dm"
+#include "code\modules\randomMaps\transit.dm"
 #include "code\modules\randomMaps\vault_definitions.dm"
 #include "code\modules\randomMaps\vaults.dm"
 #include "code\modules\RCD\engie.dm"


### PR DESCRIPTION
**Requires #11282**

Adds the following proc: **generate_transit_area(datum/shuttle/shuttle, direction, create_borders = 1)**. It uses #11282's dungeon system to generate a transit area for any shuttle you want, complete with teleporters on the borders
The generated transit areas are just as good as the pre-mapped ones with one exception - stepping out of the shuttle teleports you straight away, instead of tossing you around a bit

Added admin button to Shuttle Magic that does exactly that

![Welcome to the future](https://cloud.githubusercontent.com/assets/9512290/17737495/a5b5a0e8-648d-11e6-94c7-4380ea81818f.gif)
