### PR TITLE
Readds secways and makes them orderable from cargo for 500 credits

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -559,7 +559,16 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	containername = "Special Ops crate"
 	group = "Security"
 	hidden = 1
-
+	
+/datum/supply_packs/secway
+	name = "Secway crate"
+	contains = list(/obj/structure/bed/chair/vehicle/secway)
+	cost = 1000
+	containertype = /obj/structure/closet/crate/secure/large
+	containername = "Secway crate"
+	access = access_security
+	group = "Security"
+	
 /datum/supply_packs/beanbagammo
 	name = "Beanbag shells"
 	contains = list(/obj/item/ammo_casing/shotgun/beanbag,

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -563,7 +563,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 /datum/supply_packs/secway
 	name = "Secway crate"
 	contains = list(/obj/structure/bed/chair/vehicle/secway)
-	cost = 1000
+	cost = 500
 	containertype = /obj/structure/closet/crate/secure/large
 	containername = "Secway crate"
 	access = access_security

--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -166,7 +166,6 @@
 	new /obj/item/key/security(src)
 	new /obj/item/key/security(src)
 	new /obj/item/key/security(src)
-	new /obj/item/key/security(src)
 	
 /obj/item/weapon/storage/lockbox/unlockable
 	name = "semi-secure lockbox"

--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -155,6 +155,19 @@
 	..()
 	new /obj/item/weapon/grenade/flashbang/clusterbang(src)
 
+/obj/item/weapon/storage/lockbox/secway
+	name = "lockbox (secway keys)"
+	desc = "Nobody knows this mall better than I do."
+	req_access = list(access_security)
+	
+/obj/item/weapon/storage/lockbox/secway/New()
+	..()
+	new /obj/item/key/security(src)
+	new /obj/item/key/security(src)
+	new /obj/item/key/security(src)
+	new /obj/item/key/security(src)
+	new /obj/item/key/security(src)
+	
 /obj/item/weapon/storage/lockbox/unlockable
 	name = "semi-secure lockbox"
 	desc = "A securable locked box. Can't lock anything, but can track whoever used it."

--- a/code/game/objects/structures/vehicles/secway.dm
+++ b/code/game/objects/structures/vehicles/secway.dm
@@ -9,7 +9,11 @@
 	name = "secway key"
 	desc = "A keyring with a small steel key, and a rubber stun baton accessory."
 	icon_state = "keysec"
+	
+/obj/structure/bed/chair/vehicle/secway/check_key(var/mob/user)
+	return user.find_held_item_by_type(keytype) //any secway key works with any other secway
 
+/obj/structure/bed/chair/vehicle/secway/set_keys() //doesn't spawn with keys, mapped in
 
 /obj/structure/bed/chair/vehicle/secway/update_mob()
 	if(!occupant)

--- a/code/game/objects/structures/vehicles/vehicle.dm
+++ b/code/game/objects/structures/vehicles/vehicle.dm
@@ -59,6 +59,9 @@
 
 	if(!nick)
 		nick=name
+	set_keys()
+		
+/obj/structure/bed/chair/vehicle/proc/set_keys()
 	if(keytype && !vin)
 		mykey = new keytype(src.loc)
 		mykey.paired_to=src

--- a/html/changelogs/JustSumSecway.yml
+++ b/html/changelogs/JustSumSecway.yml
@@ -4,4 +4,4 @@ author: JustSumGuy
 delete-after: True
 
 changes: 
-- rscadd: "Re-adds secways to the game, orderable through cargo for 1000 credits."
+- rscadd: "Re-adds secways to the game, orderable through cargo for 1000 credits with keys obtainable from a lockbox in the Warden's office."

--- a/html/changelogs/JustSumSecway.yml
+++ b/html/changelogs/JustSumSecway.yml
@@ -1,0 +1,7 @@
+
+author: JustSumGuy
+
+delete-after: True
+
+changes: 
+- rscadd: "Re-adds secways to the game, orderable through cargo for 1000 credits."

--- a/html/changelogs/JustSumSecway.yml
+++ b/html/changelogs/JustSumSecway.yml
@@ -4,4 +4,4 @@ author: JustSumGuy
 delete-after: True
 
 changes: 
-- rscadd: "Re-adds secways to the game, orderable through cargo for 1000 credits with keys obtainable from a lockbox in the Warden's office."
+- rscadd: "Re-adds secways to the game, orderable through cargo for 500 credits with keys obtainable from a lockbox in the Warden's office."

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -859,6 +859,7 @@
 #include "code\game\objects\structures\vehicles\adminbus_powers.dm"
 #include "code\game\objects\structures\vehicles\clowncart.dm"
 #include "code\game\objects\structures\vehicles\gokart.dm"
+#include "code\game\objects\structures\vehicles\secway.dm"
 #include "code\game\objects\structures\vehicles\vehicle.dm"
 #include "code\game\objects\structures\vehicles\wheelchair.dm"
 #include "code\game\objects\structures\vehicles\wizmobile.dm"


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.
-->

beep
Alright, so the secway keys are locked in a box with the warden, they'll no longer spawn with them. There are 4 keys at the start of the round. Any secway key works with any secway.
