### PR TITLE
fixes multiple people entering popout cakes

### DIFF
--- a/code/game/objects/structures/popout_cake.dm
+++ b/code/game/objects/structures/popout_cake.dm
@@ -63,6 +63,9 @@
 
 	user.visible_message("<span class='notice'>[user] starts climbing into \the [src]!</span>")
 	if(do_after(user, src, 60))
+		if(locate(/mob/living) in contents)
+			to_chat(user, "<span class='info'>There appears to be something inside of \the [src]!</span>")
+			return
 		user.forceMove(src)
 		to_chat(user, "<span class='info'>You are now inside the cake! When you're ready to emerge from the cake in a blaze of confetti and party horns, pull on the string by clicking on \the [src] (<b>this can only be done once</b>). If you wish to leave without setting off the confetti, just attempt to move out of the cake!</span>")
 

--- a/html/changelogs/JustSumCake.yml
+++ b/html/changelogs/JustSumCake.yml
@@ -1,0 +1,8 @@
+
+author: JustSumGuy
+
+delete-after: True
+
+changes: 
+- bugfix: "Fixed a bug that allowed multiple people to enter the popout cake at once." 
+


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.
-->

fixes #11498 
