### PR TITLE
Fixed a very old Field Generator bug

### DIFF
--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -37,18 +37,17 @@ var/global/list/obj/machinery/field_generator/field_gen_list = list()
 
 /obj/machinery/field_generator/update_icon()
 	overlays.len = 0
-	if(!active)
-		if(warming_up)
-			overlays += image(icon = icon, icon_state = "+a[warming_up]")
+	if(warming_up)
+		overlays += image(icon = icon, icon_state = "+a[warming_up]")
 	if(fields.len)
 		overlays += image(icon = icon, icon_state = "+on")
 	// Power level indicator
 	// Scale % power to % num_power_levels and truncate value
-	var/level = round(num_power_levels * power / field_generator_max_power)
+	var/p_level = round(num_power_levels * power / field_generator_max_power, 1)
 	// Clamp between 0 and num_power_levels for out of range power values
-	level = Clamp(level, 0, num_power_levels)
-	if(level)
-		overlays += image(icon = icon, icon_state = "+p[level]")
+	p_level = Clamp(p_level, 0, num_power_levels)
+	if(p_level)
+		overlays += image(icon = icon, icon_state = "+p[p_level]")
 
 	return
 
@@ -61,9 +60,10 @@ var/global/list/obj/machinery/field_generator/field_gen_list = list()
 	return
 
 /obj/machinery/field_generator/process()
-
+	var/beams_hit = 0
 	for(var/obj/effect/beam/B in beams)
 		power += B.get_damage()
+		beams_hit = 1
 
 	if(Varedit_start == 1)
 		if(active == 0)
@@ -76,7 +76,7 @@ var/global/list/obj/machinery/field_generator/field_gen_list = list()
 			update_icon()
 		Varedit_start = 0
 
-	if(src.active == 2)
+	if((src.active == 2) || beams_hit)
 		calc_power()
 		update_icon()
 	return

--- a/html/changelogs/JMWTurner-ContainmentField.yml
+++ b/html/changelogs/JMWTurner-ContainmentField.yml
@@ -1,0 +1,4 @@
+author: JMWTurner
+delete-after: true
+changes:
+  - bugfix: Fixed a very old bug with Field Generators. The warm up gauge finally shows up once more. The power gauge is now also visible while the Generator is off.


### PR DESCRIPTION
The warm up gauge finally shows up once more, it appears in blue after you turn on the generator. A generator can link with another generator once its warm up gauge is fully charged (which takes about 12-15 seconds after being turned on).

The power gauge is now also visible while the Generator is off, such as if it gets hit by an emitter beam.
![fields](https://cloud.githubusercontent.com/assets/21122521/17831938/3b9f382e-66f7-11e6-8718-06d4ff8da9e5.png)
