### PR TITLE
Fixes a few issues with playing cards

### DIFF
--- a/code/modules/games/cards/playing_cards.dm
+++ b/code/modules/games/cards/playing_cards.dm
@@ -277,7 +277,7 @@
 		if(card)
 			card.layer = FLOAT_LAYER
 			card.plane = HUD_PLANE
-			card.pixel_x = (i * (CARD_DISPLACE - currenthand.len) - CARD_DISPLACE) * PIXEL_MULTIPLIER
+			card.pixel_x = i * (CARD_DISPLACE - currenthand.len) - CARD_DISPLACE
 			overlays += card
 
 /*

--- a/code/modules/games/cards/playing_cards.dm
+++ b/code/modules/games/cards/playing_cards.dm
@@ -276,7 +276,7 @@
 		var/obj/item/toy/singlecard/card = currenthand[i]
 		if(card)
 			card.layer = FLOAT_LAYER
-			card.plane = HUD_PLANE
+			card.plane = FLOAT_PLANE
 			card.pixel_x = i * (CARD_DISPLACE - currenthand.len) - CARD_DISPLACE
 			overlays += card
 

--- a/code/modules/games/cards/playing_cards.dm
+++ b/code/modules/games/cards/playing_cards.dm
@@ -276,7 +276,8 @@
 		var/obj/item/toy/singlecard/card = currenthand[i]
 		if(card)
 			card.layer = FLOAT_LAYER
-			card.pixel_x = i * (CARD_DISPLACE - currenthand.len) - CARD_DISPLACE
+			card.plane = HUD_PLANE
+			card.pixel_x = (i * (CARD_DISPLACE - currenthand.len) - CARD_DISPLACE) * PIXEL_MULTIPLIER
 			overlays += card
 
 /*
@@ -344,17 +345,15 @@
 		if(!(C.parentdeck || src.parentdeck) || C.parentdeck == src.parentdeck)
 			var/obj/item/toy/cardhand/H = new/obj/item/toy/cardhand(user.loc)
 			H.parentdeck = C.parentdeck
-			user.drop_item(C, H, force_drop = 1)
-			user.put_in_active_hand(H)
-			to_chat(user, "<span class = 'notice'>You combine \the [C] and \the [src] into a hand.</span>")
-			user.drop_item(C, H, force_drop = 1)
-
+			user.drop_item(C, src, force_drop = 1)
 			user.remove_from_mob(src) //we could be anywhere!
 			src.forceMove(H)
+			user.put_in_active_hand(H)
+			to_chat(user, "<span class = 'notice'>You combine \the [C] and \the [src] into a hand.</span>")
+			
 			H.currenthand += C
 			H.currenthand += src
 			H.update_icon()
-			user.put_in_hands(H)
 		else
 			to_chat(user, "<span class = 'notice'>You can't mix cards from other decks.</span>")
 	else if(istype(I, /obj/item/toy/cardhand))
@@ -363,9 +362,12 @@
 		for(var/obj/item/toy/singlecard/card in H.currenthand)
 			if(!(!(card.parentdeck || src.parentdeck) || card.parentdeck == src.parentdeck))
 				compatible = 0
+		if(H.currenthand.len >= H.max_hand_size)
+			to_chat(user, "<span class = 'warning'>You can't add any more cards to this hand.</span>")
+			return
 		if(compatible)
 			user << "<span class = 'notice'>You add \the [src] to your hand.</span>"
-			user.drop_item(src, H)
+			user.drop_item(src)
 			user.remove_from_mob(src) //we could be anywhere!
 			src.forceMove(H)
 			H.currenthand += src

--- a/html/changelogs/JustSumCard.yml
+++ b/html/changelogs/JustSumCard.yml
@@ -1,0 +1,7 @@
+
+author: JustSumGuy
+
+delete-after: True
+
+changes: 
+- bugfix: "Fixed some issues with playing cards not showing up or combining properly."


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.
-->

fixes #10855 and an unreported issue that would let you bypass the hand's max through using single cards on hands. Also fixes some really funky shit where making a hand places the hand in both your hand slots, so drawing from the deck becomes impossible without dropping the whole thing or placing it back in the deck.
Maybe fixes #7338 ? I can't reproduce it at any rate.

~~My understanding of planes and layers is limited though, so this has the unintended result of making the cards layer above mobs when they're outside of your hand. I was told this usually resets upon being dropped, but I'm not seeing that happen.~~
![image](https://cloud.githubusercontent.com/assets/19365096/17835799/aed43d3c-674a-11e6-89e1-801e18b753ae.png) 

Ayy it's fixed now
