### PR TITLE
Removes guns and viruses from maint loot spawners

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -227,7 +227,7 @@
 
 /obj/item/device/radio/headset/headset_earmuffs
 	name = "headset earmuffs"
-	desc = "Protective earmuffs for sound technicians that allow one to speak on radio channels. To access service, use :d. For engineering, use :e."
+	desc = "Protective earmuffs for sound technicians that allow one to speak on radio channels."
 	icon = 'icons/obj/items.dmi'
 	icon_state = "headset_earmuffs"
 	item_state = "earmuffs"

--- a/code/modules/maps/spawners/spawners.dm
+++ b/code/modules/maps/spawners/spawners.dm
@@ -312,17 +312,12 @@
 		/obj/item/device/camera,
 		/obj/item/device/camera_film,
 		/obj/item/device/encryptionkey,
-		/obj/item/device/encryptionkey,
-		/obj/item/device/encryptionkey,
-		/obj/item/device/encryptionkey/syndicate,
 		/obj/item/device/encryptionkey/binary,
-		/obj/item/device/encryptionkey/syndicate/hacked,
 		/obj/item/device/hailer,
 		/obj/item/device/healthanalyzer,
 		/obj/item/device/mass_spectrometer,
 		/obj/item/device/megaphone,
 		/obj/item/device/mmi/radio_enabled,
-		/obj/item/device/powersink,
 		/obj/item/device/reagent_scanner,
 		/obj/item/device/soundsynth,
 		/obj/item/latexballon,
@@ -525,9 +520,6 @@
 		/obj/item/weapon/coin/silver,
 		/obj/item/weapon/coin/uranium,
 		/obj/item/weapon/dice,
-		/obj/item/weapon/gun/projectile/flamethrower/full,
-		/obj/item/weapon/gun/projectile/deagle/gold,
-		/obj/item/weapon/gun/projectile/russian,
 		/obj/item/weapon/handcuffs,
 		/obj/item/weapon/handcuffs/cable,
 		/obj/item/weapon/hatchet,
@@ -541,17 +533,10 @@
 		/obj/item/weapon/scalpel,
 		/obj/item/weapon/shard,
 		/obj/item/weapon/stool,
-		/obj/item/device/powersink,
 		/obj/item/weapon/reagent_containers/blood/OMinus,
 		/obj/item/weapon/reagent_containers/glass/bottle/ammonia,
 		/obj/item/weapon/reagent_containers/glass/bottle/capsaicin,
-		/obj/item/weapon/reagent_containers/glass/bottle/chloralhydrate,
-		/obj/item/weapon/reagent_containers/glass/bottle/cold,
 		/obj/item/weapon/reagent_containers/glass/bottle/diethylamine,
-		/obj/item/weapon/reagent_containers/glass/bottle/epiglottis_virion,
-		/obj/item/weapon/reagent_containers/glass/bottle/flu_virion,
-		/obj/item/weapon/reagent_containers/glass/bottle/magnitis,
-		/obj/item/weapon/reagent_containers/glass/bottle/pierrot_throat,
 		/obj/item/weapon/reagent_containers/food/drinks/beer,
 		/obj/item/weapon/reagent_containers/food/drinks/bottle/absinthe,
 		/obj/item/weapon/reagent_containers/food/drinks/bottle/cream,
@@ -586,7 +571,36 @@
 		/obj/item/weapon/reagent_containers/food/snacks/soylenviridians,
 		/obj/item/weapon/reagent_containers/food/snacks/syndicake,
 		/obj/item/weapon/reagent_containers/food/snacks/tofurkey,
+		/obj/item/device/radio/headset/headset_earmuffs,
+		/obj/item/weapon/solder/pre_fueled,
+		/obj/item/weapon/storage/box/smokebombs,
+		/obj/item/weapon/storage/box/wind,
+		/obj/item/weapon/storage/box/foam,
+		/obj/item/weapon/reagent_containers/food/snacks/grown/peanut,
+		/obj/structure/popout_cake,
+		/obj/structure/bed/chair/vehicle/wheelchair/multi_people,
+		/obj/item/stack/package_wrap/syndie,
+		/obj/item/weapon/storage/toolbox/syndicate,
+		/obj/item/weapon/switchtool/swiss_army_knife
 		)
+
+/obj/map/spawner/highrisk
+	name = "high risk spawner"
+	icon_state = "maint"
+	chance = 20
+	to_spawn = list(
+		/obj/item/weapon/reagent_containers/glass/bottle/epiglottis_virion,
+		/obj/item/weapon/reagent_containers/glass/bottle/flu_virion,
+		/obj/item/weapon/reagent_containers/glass/bottle/magnitis,
+		/obj/item/weapon/reagent_containers/glass/bottle/pierrot_throat,
+		/obj/item/weapon/reagent_containers/glass/bottle/chloralhydrate,
+		/obj/item/weapon/reagent_containers/glass/bottle/cold,
+		/obj/item/device/powersink,
+		/obj/item/device/powersink,
+		/obj/item/weapon/gun/projectile/flamethrower/full,
+		/obj/item/weapon/gun/projectile/deagle/gold,
+		/obj/item/weapon/gun/projectile/russian,
+	)
 
 // Space ///////////////////////////////////////////////////////
 

--- a/html/changelogs/Kurfurst.yml
+++ b/html/changelogs/Kurfurst.yml
@@ -1,0 +1,6 @@
+author: Kurfurst
+delete-after: True
+
+changes: 
+- rscdel: The maint loot spawner has had several items moved to a separate high risk spawner, including guns and viruses. They will no longer appear in Defficiency maintenance.
+- rscadd: The maint loot spawner now spawns several new items including (normally unobtainable) multi-person wheelchair, peanuts, headset earmuffs, box of wind grenades, and swiss army knife among other things.


### PR DESCRIPTION
Removes some highly dangerous stuff from maint loot spawner and moved it to its own spawner, including:
- Guns
- Powersink
- Viruses

However, to not be anti-fun, some new entertaining stuff has been added to make up for it. _Italicized if normally unobtainable._
- Syndicate wrapping paper
- Suspicious toolbox
- Pop out cake
- _Multi-person wheelchair_
- _Headset earmuffs_
- _Peanut_
- _Box of wind grenades_
- Box of smoke grenades
- Box of metal foam grenades
- Pre-loaded soldering tool
- _Swiss army knife_

I think this is a fair tradeoff to make Deff a little less crazy without sacrificing the fun of a great discovery in maintenance. Did you know Powersink was listed twice on the spawner? That explains why we saw so many.
