### PR TITLE
Making explosive implants gib you for sure

### DIFF
--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -146,6 +146,7 @@ Implant Specifics:<BR>"}
 
 		var/turf/T = get_turf(M)
 
+		M.gib()
 		explosion(T, 1, 3, 4, 6)
 		T.hotspot_expose(3500, 125, surfaces = 1)
 

--- a/html/changelogs/JMWTurner-ImplantGib.yml
+++ b/html/changelogs/JMWTurner-ImplantGib.yml
@@ -1,0 +1,4 @@
+author: JMWTurner
+delete-after: true
+changes:
+  - tweak: Explosive Implants now gib their holder right before the explosion


### PR DESCRIPTION
It makes sense to me that deathsquad agents are fitted with explosive implants to prevent anyone from looting their valuable equipment. But their armor is so good that the body generally survives the explosion unscathed (which makes no sense considering the explosion comes from inside).

![boom](https://cloud.githubusercontent.com/assets/21122521/17839173/ac35e440-67e0-11e6-91d4-56c33bb0e4e6.png)
