### PR TITLE
May help virtualhearers somewhat

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -47,7 +47,7 @@
 /atom/movable/New()
 	. = ..()
 	areaMaster = get_area_master(src)
-	if(flags & HEAR && !ismob(src))
+	if((flags & HEAR) && !ismob(src))
 		getFromPool(/mob/virtualhearer, src)
 
 	locked_atoms            = list()
@@ -55,14 +55,6 @@
 	locking_categories_name = list()
 
 /atom/movable/Destroy()
-	if(flags & HEAR && !ismob(src))
-		var/found = 0
-		for(var/mob/virtualhearer/VH in virtualhearers)
-			if(VH.attached == src)
-				returnToPool(VH)
-				found = 1
-		if(!found)
-			world.log << "Atom Movable virtualhearer for [type] could not be found for /ref[src]"
 	gcDestroyed = "Bye, world!"
 	tag = null
 
@@ -109,6 +101,15 @@
 		soft_dels += 1
 
 /atom/movable/Del()
+	if((flags & HEAR) && !ismob(src))
+		var/found = 0
+		for(var/mob/virtualhearer/VH in virtualhearers)
+			if(VH.attached == src)
+				returnToPool(VH)
+				found = 1
+		if(!found)
+			world.log << "Atom Movable virtualhearer for [type] could not be found for /ref[src]"
+
 	if (gcDestroyed)
 
 		if (hard_deleted)

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -55,7 +55,7 @@
 
 	reset_view()
 
-	if(flags & HEAR && !(flags & HEAR_ALWAYS)) //Mobs with HEAR_ALWAYS will already have a virtualhearer
+	if((flags & HEAR) && !(flags & HEAR_ALWAYS)) //Mobs with HEAR_ALWAYS will already have a virtualhearer
 		getFromPool(/mob/virtualhearer, src)
 
 	//Clear ability list and update from mob.

--- a/code/modules/mob/logout.dm
+++ b/code/modules/mob/logout.dm
@@ -3,7 +3,7 @@
 		var/obj/location = loc
 		location.on_logout(src)
 
-	if(!(flags & HEAR_ALWAYS))
+	if((flags & HEAR) && !(flags & HEAR_ALWAYS))
 		var/found = 0
 		for(var/mob/virtualhearer/VH in virtualhearers)
 			if(VH.attached == src)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -255,6 +255,17 @@ var/global/obj/screen/fuckstat/FUCK = new
 	if(flags & HEAR_ALWAYS)
 		getFromPool(/mob/virtualhearer, src)
 
+/mob/Del()
+	if(flags & HEAR_ALWAYS)
+		var/found = 0
+		for(var/mob/virtualhearer/VH in virtualhearers)
+			if(VH.attached == src)
+				returnToPool(VH)
+				found = 1
+		if(!found)
+			world.log << "Mob virtualhearer for [type] could not be found for /ref[src]"
+	..()
+
 /mob/proc/is_muzzled()
 	return 0
 


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.
-->


Moved virtualhearer removal from destroy() to del(), but to be honest I'm not sure why this would resolve any problems since we SHOULD be using qdel() for everything, and nothing is going be garbage collected while a virtualhearer is holding a reference to them anyway.

There may have been an issue with HEAR_ALWAYS since I cant find anywhere where HEAR_ALWAYS mobs were getting a virtualhearer removed, which would only affect AI eye and poly.