### PR TITLE
Fixes virtualhearers sight flags

### DIFF
--- a/code/game/gamemodes/vampire/vampire.dm
+++ b/code/game/gamemodes/vampire/vampire.dm
@@ -362,12 +362,12 @@ You are weak to holy things and starlight. Don't go into space and avoid the Cha
 		owner.see_invisible = SEE_INVISIBLE_LEVEL_TWO
 
 	if(VAMP_MATURE in powers)
-		owner.sight |= SEE_TURFS|SEE_MOBS|SEE_OBJS
+		owner.change_sight(adding = SEE_TURFS|SEE_MOBS|SEE_OBJS)
 		owner.see_in_dark = 8
 		owner.see_invisible = SEE_INVISIBLE_MINIMUM
 
 	else if(VAMP_VISION in powers)
-		owner.sight |= SEE_MOBS
+		owner.change_sight(adding = SEE_MOBS)
 
 /mob/proc/handle_bloodsucking(mob/living/carbon/human/H)
 	src.mind.vampire.draining = H

--- a/code/game/gamemodes/wizard/rightandwrong.dm
+++ b/code/game/gamemodes/wizard/rightandwrong.dm
@@ -129,7 +129,7 @@
 					new /obj/item/weapon/scrying(get_turf(H))
 					if (!(M_XRAY in H.mutations))
 						H.mutations.Add(M_XRAY)
-						H.sight |= (SEE_MOBS|SEE_OBJS|SEE_TURFS)
+						H.change_sight(adding = SEE_MOBS|SEE_OBJS|SEE_TURFS)
 						H.see_in_dark = 8
 						H.see_invisible = SEE_INVISIBLE_LEVEL_TWO
 						to_chat(H, "<span class='notice'>The walls suddenly disappear.</span>")

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -377,7 +377,7 @@
 							new /obj/item/weapon/scrying(get_turf(H))
 							if (!(M_XRAY in H.mutations))
 								H.mutations.Add(M_XRAY)
-								H.sight |= (SEE_MOBS|SEE_OBJS|SEE_TURFS)
+								H.change_sight(adding = SEE_MOBS|SEE_OBJS|SEE_TURFS)
 								H.see_in_dark = 8
 								H.see_invisible = SEE_INVISIBLE_LEVEL_TWO
 								to_chat(H, "<span class='notice'>The walls suddenly disappear.</span>")

--- a/code/game/machinery/wishgranter.dm
+++ b/code/game/machinery/wishgranter.dm
@@ -46,7 +46,7 @@
 
 			if (!(M_XRAY in user.mutations))
 				user.mutations.Add(M_XRAY)
-				user.sight |= (SEE_MOBS|SEE_OBJS|SEE_TURFS)
+				user.change_sight(adding = SEE_MOBS|SEE_OBJS|SEE_TURFS)
 				user.see_in_dark = 8
 				user.see_invisible = SEE_INVISIBLE_LEVEL_TWO
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -39,7 +39,7 @@
 	var/lastchairspin
 
 /mob/dead/observer/New(var/mob/body=null, var/flags=1)
-	sight |= SEE_TURFS | SEE_MOBS | SEE_OBJS | SEE_SELF
+	change_sight(adding = SEE_TURFS | SEE_MOBS | SEE_OBJS | SEE_SELF)
 	see_invisible = SEE_INVISIBLE_OBSERVER
 	see_in_dark = 100
 	verbs += /mob/dead/observer/proc/dead_tele

--- a/code/modules/mob/hearing/virtualhearer.dm
+++ b/code/modules/mob/hearing/virtualhearer.dm
@@ -29,6 +29,11 @@ var/list/stationary_hearers = list(	/obj/item/device/radio/intercom,
 	virtualhearers += src
 	loc = get_turf(attachedto)
 	attached = attachedto
+
+	var/mob/M = attachedto
+	if(istype(M))
+		sight = M.sight
+
 	attached_type = attachedto.type //record the attached's typepath in case something goes wrong
 	attached_ref = "/ref[attachedto]" //record attached's text ref to see what is happening
 	if(is_type_in_list(attachedto,stationary_hearers))
@@ -61,3 +66,16 @@ var/list/stationary_hearers = list(	/obj/item/device/radio/intercom,
 
 /mob/virtualhearer/blob_act()
 	return
+
+/mob/proc/change_sight(adding, removing, copying)
+	var/oldsight = sight
+	if(copying)
+		sight = copying
+	if(adding)
+		sight |= adding
+	if(removing)
+		sight &= ~removing
+	if(sight != oldsight)
+		for(var/mob/virtualhearer/VH in virtualhearers)
+			if(VH.attached == src)
+				VH.sight = sight

--- a/code/modules/mob/living/carbon/alien/humanoid/life.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/life.dm
@@ -385,15 +385,11 @@
 
 
 		if (stat == 2 || (M_XRAY in mutations))
-			sight |= SEE_TURFS
-			sight |= SEE_MOBS
-			sight |= SEE_OBJS
+			change_sight(adding = SEE_TURFS|SEE_MOBS|SEE_OBJS)
 			see_in_dark = 8
 			see_invisible = SEE_INVISIBLE_MINIMUM
 		else if (stat != 2)
-			sight |= SEE_MOBS
-			sight &= ~SEE_TURFS
-			sight &= ~SEE_OBJS
+			change_sight(adding = SEE_MOBS, removing = SEE_TURFS|SEE_OBJS)
 			see_in_dark = 4
 			see_invisible = SEE_INVISIBLE_MINIMUM
 

--- a/code/modules/mob/living/carbon/alien/larva/life.dm
+++ b/code/modules/mob/living/carbon/alien/larva/life.dm
@@ -306,15 +306,11 @@
 
 
 		if (stat == 2 || (M_XRAY in mutations))
-			sight |= SEE_TURFS
-			sight |= SEE_MOBS
-			sight |= SEE_OBJS
+			change_sight(adding = SEE_TURFS|SEE_MOBS|SEE_OBJS)
 			see_in_dark = 8
 			see_invisible = SEE_INVISIBLE_MINIMUM
 		else if (stat != 2)
-			sight |= SEE_MOBS
-			sight &= ~SEE_TURFS
-			sight &= ~SEE_OBJS
+			change_sight(adding = SEE_MOBS, removing = SEE_TURFS|SEE_OBJS)
 			see_in_dark = 4
 			see_invisible = SEE_INVISIBLE_MINIMUM
 

--- a/code/modules/mob/living/carbon/brain/death.dm
+++ b/code/modules/mob/living/carbon/brain/death.dm
@@ -6,7 +6,7 @@
 
 	stat = DEAD
 
-	sight |= SEE_TURFS|SEE_MOBS|SEE_OBJS
+	change_sight(adding = SEE_TURFS|SEE_MOBS|SEE_OBJS)
 	see_in_dark = 8
 	see_invisible = SEE_INVISIBLE_LEVEL_TWO
 

--- a/code/modules/mob/living/carbon/brain/life.dm
+++ b/code/modules/mob/living/carbon/brain/life.dm
@@ -215,15 +215,11 @@
 
 
 		if (stat == 2 || (M_XRAY in src.mutations))
-			sight |= SEE_TURFS
-			sight |= SEE_MOBS
-			sight |= SEE_OBJS
+			change_sight(adding = SEE_TURFS|SEE_MOBS|SEE_OBJS)
 			see_in_dark = 8
 			see_invisible = SEE_INVISIBLE_LEVEL_TWO
 		else if (stat != 2)
-			sight &= ~SEE_TURFS
-			sight &= ~SEE_MOBS
-			sight &= ~SEE_OBJS
+			change_sight(removing = SEE_TURFS|SEE_MOBS|SEE_OBJS)
 			see_in_dark = 2
 			see_invisible = SEE_INVISIBLE_LIVING
 

--- a/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
@@ -4,7 +4,7 @@
 	if(!client)
 		return 0
 
-	sight &= ~BLIND
+	change_sight(removing = BLIND)
 
 	regular_hud_updates()
 
@@ -79,7 +79,7 @@
 			clear_fullscreen("brute")
 			//damageoverlay.overlays += I
 	if(stat == DEAD)
-		sight |= (SEE_TURFS|SEE_MOBS|SEE_OBJS)
+		change_sight(adding = SEE_TURFS|SEE_MOBS|SEE_OBJS)
 		see_in_dark = 8
 		if(!druggy)
 			see_invisible = SEE_INVISIBLE_LEVEL_TWO
@@ -87,7 +87,7 @@
 			healths.icon_state = "health7" //DEAD healthmeter
 		return
 	else
-		sight &= ~(SEE_TURFS|SEE_MOBS|SEE_OBJS)
+		change_sight(removing = SEE_TURFS|SEE_MOBS|SEE_OBJS)
 
 		var/datum/organ/internal/eyes/E = src.internal_organs_by_name["eyes"]
 		if(E)
@@ -106,7 +106,7 @@
 					see_in_dark = 8
 					see_invisible = SEE_INVISIBLE_LEVEL_ONE
 		if(M_XRAY in mutations)
-			sight |= SEE_TURFS|SEE_MOBS|SEE_OBJS
+			change_sight(adding = SEE_TURFS|SEE_MOBS|SEE_OBJS)
 			see_in_dark = 8
 			if(!druggy)
 				see_invisible = SEE_INVISIBLE_LEVEL_TWO
@@ -127,7 +127,7 @@
 					see_in_dark = max(see_in_dark, G.see_in_dark)
 				see_in_dark += G.darkness_view
 				if(G.vision_flags) //MESONS
-					sight |= G.vision_flags
+					change_sight(adding = G.vision_flags)
 					if(!druggy)
 						see_invisible = SEE_INVISIBLE_MINIMUM
 				if(G.see_invisible)
@@ -327,7 +327,7 @@
 				reset_view(null)
 			if(iscamera(client.eye))
 				var/obj/machinery/camera/C = client.eye
-				sight = C.vision_flags
+				change_sight(copying = C.vision_flags)
 
 		else
 			var/isRemoteObserve = 0

--- a/code/modules/mob/living/carbon/monkey/life.dm
+++ b/code/modules/mob/living/carbon/monkey/life.dm
@@ -642,15 +642,11 @@
 
 /mob/living/carbon/monkey/proc/handle_regular_hud_updates()
 	if (stat == 2 || (M_XRAY in mutations))
-		sight |= SEE_TURFS
-		sight |= SEE_MOBS
-		sight |= SEE_OBJS
+		change_sight(adding = SEE_TURFS|SEE_MOBS|SEE_OBJS)
 		see_in_dark = 8
 		see_invisible = SEE_INVISIBLE_LEVEL_TWO
 	else if (stat != 2)
-		sight &= ~SEE_TURFS
-		sight &= ~SEE_MOBS
-		sight &= ~SEE_OBJS
+		change_sight(removing = SEE_TURFS|SEE_MOBS|SEE_OBJS)
 		see_in_dark = 2
 		see_invisible = SEE_INVISIBLE_LIVING
 

--- a/code/modules/mob/living/silicon/ai/death.dm
+++ b/code/modules/mob/living/silicon/ai/death.dm
@@ -10,7 +10,7 @@
 		src.eyeobj.forceMove(get_turf(src))
 	if(blind)
 		blind.layer = 0
-	sight |= SEE_TURFS|SEE_MOBS|SEE_OBJS
+	change_sight(adding = SEE_TURFS|SEE_MOBS|SEE_OBJS)
 	see_in_dark = 8
 	see_invisible = SEE_INVISIBLE_LEVEL_TWO
 

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -26,9 +26,7 @@
 		cameranet.visibility(src)
 		if(ai.client && ai.client.eye != src) // Set the eye to us and give the AI the sight & visibility flags it needs.
 			ai.client.eye = src
-			ai.sight |= SEE_TURFS
-			ai.sight |= SEE_MOBS
-			ai.sight |= SEE_OBJS
+			ai.change_sight(adding = SEE_TURFS|SEE_MOBS|SEE_OBJS)
 			ai.see_in_dark = 8
 			ai.see_invisible = SEE_INVISIBLE_LEVEL_TWO
 
@@ -39,13 +37,13 @@
 
 /mob/camera/aiEye/Move()
 	return 0
-	
+
 /mob/camera/aiEye/on_see(var/message, var/blind_message, var/drugged_message, var/blind_drugged_message, atom/A) //proc for eye seeing visible messages from atom A, only possible with the high_res camera module
 	if(!high_res)
 		return
 	if(ai && cameranet.checkCameraVis(A)) //check it's actually in view of a camera
 		ai.show_message( message, 1, blind_message, 2)
-			
+
 //An AI eyeobj mob cant hear unless it updates high_res with a Malf Module
 /mob/camera/aiEye/Hear(var/datum/speech/speech, var/rendered_speech="")
 	if(!high_res)
@@ -159,7 +157,7 @@
 
 	if(client && client.eye) // Reset these things so the AI can't view through walls and stuff.
 		client.eye = src
-		sight &= ~(SEE_TURFS | SEE_MOBS | SEE_OBJS)
+		change_sight(removing = SEE_TURFS | SEE_MOBS | SEE_OBJS)
 		see_in_dark = 0
 		see_invisible = SEE_INVISIBLE_LIVING
 

--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -59,9 +59,7 @@
 					//I'll get back to this when I find out  how this is -supposed- to work ~Carn //removed this shit since it was confusing as all hell --39kk9t
 			//stage = 4.5
 			if(client && client.eye == eyeobj) // We are viewing the world through our "eye" mob.
-				src.sight |= SEE_TURFS
-				src.sight |= SEE_MOBS
-				src.sight |= SEE_OBJS
+				change_sight(adding = SEE_TURFS|SEE_MOBS|SEE_OBJS)
 				src.see_in_dark = 8
 				src.see_invisible = SEE_INVISIBLE_LEVEL_TWO
 
@@ -97,9 +95,7 @@
 					src.blind.screen_loc = "1,1 to 15,15"
 					if (src.blind.layer != 18)
 						src.blind.layer = UNDER_HUD_LAYER
-				src.sight = src.sight&~SEE_TURFS
-				src.sight = src.sight&~SEE_MOBS
-				src.sight = src.sight&~SEE_OBJS
+				change_sight(removing = SEE_TURFS|SEE_MOBS|SEE_OBJS)
 				src.see_in_dark = 0
 			src.see_invisible = SEE_INVISIBLE_LIVING
 

--- a/code/modules/mob/living/silicon/mommi/death.dm
+++ b/code/modules/mob/living/silicon/mommi/death.dm
@@ -51,7 +51,7 @@
 
 	if(blind)
 		blind.layer = 0
-	sight |= SEE_TURFS|SEE_MOBS|SEE_OBJS
+	change_sight(adding = SEE_TURFS|SEE_MOBS|SEE_OBJS)
 	see_in_dark = 8
 	see_invisible = SEE_INVISIBLE_LEVEL_TWO
 	updateicon()

--- a/code/modules/mob/living/silicon/pai/death.dm
+++ b/code/modules/mob/living/silicon/pai/death.dm
@@ -5,7 +5,7 @@
 	canmove = 0
 	if(blind)
 		blind.layer = 0
-	sight |= SEE_TURFS|SEE_MOBS|SEE_OBJS
+	change_sight(adding = SEE_TURFS|SEE_MOBS|SEE_OBJS)
 	see_in_dark = 8
 	see_invisible = SEE_INVISIBLE_LEVEL_TWO
 

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -63,7 +63,7 @@
 	var/obj/item/radio/integrated/signal/sradio // AI's signaller
 
 /mob/living/silicon/pai/New(var/obj/item/device/paicard)
-	sight &= ~BLIND
+	change_sight(removing = BLIND)
 	canmove = 0
 	src.loc = paicard
 	card = paicard

--- a/code/modules/mob/living/silicon/robot/death.dm
+++ b/code/modules/mob/living/silicon/robot/death.dm
@@ -51,7 +51,7 @@
 
 	if(blind)
 		blind.layer = 0
-	sight |= SEE_TURFS|SEE_MOBS|SEE_OBJS
+	change_sight(adding = SEE_TURFS|SEE_MOBS|SEE_OBJS)
 	see_in_dark = 8
 	see_invisible = SEE_INVISIBLE_LEVEL_TWO
 	updateicon()

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -147,61 +147,33 @@
 	return 1
 
 /mob/living/silicon/robot/proc/handle_sensor_modes()
-	src.sight &= ~SEE_MOBS
-	src.sight &= ~SEE_TURFS
-	src.sight &= ~SEE_OBJS
-	src.sight &= ~BLIND
+	change_sight(removing = SEE_TURFS|SEE_MOBS|SEE_OBJS|BLIND)
 	src.see_in_dark = 8
 	src.see_invisible = SEE_INVISIBLE_LEVEL_TWO
 	if (src.stat == DEAD)
-		sight |= (SEE_TURFS|SEE_MOBS|SEE_OBJS)
+		change_sight(adding = SEE_TURFS|SEE_MOBS|SEE_OBJS)
 		src.see_in_dark = 8
 		src.see_invisible = SEE_INVISIBLE_LEVEL_TWO
 	else
 		if (M_XRAY in mutations || src.sight_mode & BORGXRAY)
-			sight |= (SEE_TURFS|SEE_MOBS|SEE_OBJS)
+			change_sight(adding = SEE_TURFS|SEE_MOBS|SEE_OBJS)
 			src.see_in_dark = 8
 			src.see_invisible = SEE_INVISIBLE_LEVEL_TWO
 		if ((src.sight_mode & BORGTHERM) || sensor_mode == THERMAL_VISION)
-			src.sight |= SEE_MOBS
+			change_sight(adding = SEE_MOBS)
 			src.see_in_dark = 4
 			src.see_invisible = SEE_INVISIBLE_MINIMUM
 		if (sensor_mode == NIGHT)
 			see_invisible = SEE_INVISIBLE_MINIMUM
 			see_in_dark = 8
 		if ((src.sight_mode & BORGMESON) || (sensor_mode == MESON_VISION))
-			src.sight |= SEE_TURFS
+			change_sight(adding = SEE_TURFS)
 			src.see_in_dark = 8
 			see_invisible = SEE_INVISIBLE_MINIMUM
 
 
 /mob/living/silicon/robot/proc/handle_regular_hud_updates()
 	handle_sensor_modes()
-	/*if (src.stat == 2 || M_XRAY in mutations || src.sight_mode & BORGXRAY)
-		src.sight |= SEE_TURFS
-		src.sight |= SEE_MOBS
-		src.sight |= SEE_OBJS
-		src.see_in_dark = 8
-		src.see_invisible = SEE_INVISIBLE_MINIMUM
-	else if ((src.sight_mode & BORGMESON  || sensor_mode == MESON_VISION) && src.sight_mode & BORGTHERM)
-		src.sight |= SEE_TURFS
-		src.sight |= SEE_MOBS
-		src.see_in_dark = 8
-		see_invisible = SEE_INVISIBLE_MINIMUM
-	else if (src.sight_mode & BORGMESON  || sensor_mode == MESON_VISION)
-		src.sight |= SEE_TURFS
-		src.see_in_dark = 8
-		see_invisible = SEE_INVISIBLE_MINIMUM
-	else if (src.sight_mode & BORGTHERM)
-		src.sight |= SEE_MOBS
-		src.see_in_dark = 8
-		src.see_invisible = SEE_INVISIBLE_LEVEL_TWO
-	else if (src.stat != 2)
-		src.sight &= ~SEE_MOBS
-		src.sight &= ~SEE_TURFS
-		src.sight &= ~SEE_OBJS
-		src.see_in_dark = 8
-		src.see_invisible = SEE_INVISIBLE_LEVEL_TWO*/
 
 	regular_hud_updates() //Handles MED/SEC HUDs for borgs.
 	switch(sensor_mode)
@@ -209,12 +181,6 @@
 			process_sec_hud(src, 1)
 		if (MED_HUD)
 			process_med_hud(src)
-
-	/*switch(sensor_mode)
-		if (SEC_HUD)
-			process_sec_hud(src, 1)
-		if (MED_HUD)
-			process_med_hud(src)*/
 
 	if (src.healths)
 		if (src.stat != 2)

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -334,7 +334,7 @@
 
 /mob/living/simple_animal/construct/harvester/New()
 	..()
-	sight |= SEE_MOBS
+	change_sight(adding = SEE_MOBS)
 
 ////////////////Glow//////////////////
 /mob/living/simple_animal/construct/proc/updateicon()

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -49,7 +49,7 @@
 
 	delayNextMove(0)
 
-	sight |= SEE_SELF
+	change_sight(adding = SEE_SELF)
 
 	..()
 

--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -13,7 +13,7 @@
 	else
 		loc = locate(1,1,1)
 
-	sight |= SEE_TURFS
+	change_sight(adding = SEE_TURFS)
 	player_list |= src
 
 /*

--- a/maps/RandomZLevels/wildwest.dm
+++ b/maps/RandomZLevels/wildwest.dm
@@ -57,7 +57,7 @@
 					to_chat(user, "\blue Your skin feels icy to the touch.")
 				if (!(M_XRAY in user.mutations))
 					user.mutations.Add(M_XRAY)
-					user.sight |= (SEE_MOBS|SEE_OBJS|SEE_TURFS)
+					user.change_sight(adding = SEE_TURFS|SEE_MOBS|SEE_OBJS)
 					user.see_in_dark = 8
 					user.see_invisible = SEE_INVISIBLE_LEVEL_TWO
 					to_chat(user, "\blue The walls suddenly disappear.")


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.
-->


Adds a wrapper proc for changing sight flags

When sight flags are changed, it checks if the sight flags have actually been changed and then if so modifies the virtualhearer's sight flags.