### PR TITLE
Fixed marauder boards appearing on the R&D console

### DIFF
--- a/code/modules/research/designs/mecha/boards.dm
+++ b/code/modules/research/designs/mecha/boards.dm
@@ -134,7 +134,7 @@
 	name = "Circuit Design (\"Marauder\" Central Control module)"
 	desc = "Allows for the construction of a \"Marauder\" Central Control module."
 	id = "marauder_main"
-	req_tech = list(Tc_PROGRAMMING = 4)
+	req_tech = list(Tc_PROGRAMMING = 4, NANOTRASEN = 5)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 2000, SACID = 20)
 	category = "Mecha Boards"
@@ -144,7 +144,7 @@
 	name = "Circuit Design (\"Marauder\" Peripherals Control module)"
 	desc = "Allows for the construction of a \"Marauder\" Peripheral Control module."
 	id = "marauder_peri"
-	req_tech = list(Tc_PROGRAMMING = 4)
+	req_tech = list(Tc_PROGRAMMING = 4, NANOTRASEN = 5)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 2000, SACID = 20)
 	category = "Mecha Boards"
@@ -154,7 +154,7 @@
 	name = "Circuit Design (\"Marauder\" Weapons & Targeting Control module)"
 	desc = "Allows for the construction of a \"Marauder\" Weapons & Targeting Control module."
 	id = "marauder_targ"
-	req_tech = list(Tc_PROGRAMMING = 4, Tc_COMBAT = 2)
+	req_tech = list(Tc_PROGRAMMING = 4, Tc_COMBAT = 2, NANOTRASEN = 5)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 2000, SACID = 20)
 	category = "Mecha Boards"

--- a/code/modules/research/designs/mecha/boards.dm
+++ b/code/modules/research/designs/mecha/boards.dm
@@ -134,7 +134,7 @@
 	name = "Circuit Design (\"Marauder\" Central Control module)"
 	desc = "Allows for the construction of a \"Marauder\" Central Control module."
 	id = "marauder_main"
-	req_tech = list(Tc_PROGRAMMING = 4, NANOTRASEN = 5)
+	req_tech = list(Tc_PROGRAMMING = 4, Tc_NANOTRASEN = 5)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 2000, SACID = 20)
 	category = "Mecha Boards"
@@ -144,7 +144,7 @@
 	name = "Circuit Design (\"Marauder\" Peripherals Control module)"
 	desc = "Allows for the construction of a \"Marauder\" Peripheral Control module."
 	id = "marauder_peri"
-	req_tech = list(Tc_PROGRAMMING = 4, NANOTRASEN = 5)
+	req_tech = list(Tc_PROGRAMMING = 4, Tc_NANOTRASEN = 5)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 2000, SACID = 20)
 	category = "Mecha Boards"
@@ -154,7 +154,7 @@
 	name = "Circuit Design (\"Marauder\" Weapons & Targeting Control module)"
 	desc = "Allows for the construction of a \"Marauder\" Weapons & Targeting Control module."
 	id = "marauder_targ"
-	req_tech = list(Tc_PROGRAMMING = 4, Tc_COMBAT = 2, NANOTRASEN = 5)
+	req_tech = list(Tc_PROGRAMMING = 4, Tc_COMBAT = 2, Tc_NANOTRASEN = 5)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 2000, SACID = 20)
 	category = "Mecha Boards"

--- a/code/modules/research/designs/mecha/marauder.dm
+++ b/code/modules/research/designs/mecha/marauder.dm
@@ -1,0 +1,79 @@
+/datum/design/marauder/chassis
+	name = "Exosuit Structure (Marauder chassis)"
+	desc = "Used to build a Marauder chassis."
+	id = "durand_chassis"
+	req_tech = list(Tc_COMBAT = 2, NANOTRASEN = 5)
+	build_type = MECHFAB
+	build_path = /obj/item/mecha_parts/chassis/durand
+	category = "Durand"
+	materials = list(MAT_IRON=25000)
+
+/datum/design/marauder/torso
+	name = "Exosuit Structure (Marauder torso)"
+	desc = "Used to build a Marauder torso."
+	id = "durand_torso"
+	req_tech = list(Tc_COMBAT = 2, NANOTRASEN = 5)
+	build_type = MECHFAB
+	build_path = /obj/item/mecha_parts/part/marauder_torso
+	category = "Durand"
+	materials = list(MAT_IRON=55000,MAT_GLASS=20000,MAT_SILVER=10000)
+
+/datum/design/marauder/l_arm
+	name = "Exosuit Structure (Marauder left arm)"
+	desc = "Used to build a Marauder left arm."
+	id = "durand_larm"
+	req_tech = list(Tc_COMBAT = 5, NANOTRASEN = 5)
+	build_type = MECHFAB
+	build_path = /obj/item/mecha_parts/part/marauder_left_arm
+	category = "Durand"
+	materials = list(MAT_IRON=35000,MAT_SILVER=3000)
+
+/datum/design/marauder/r_arm
+	name = "Exosuit Structure (Marauder right arm)"
+	desc = "Used to build a Marauder right arm."
+	id = "durand_rarm"
+	req_tech = list(Tc_COMBAT = 4, NANOTRASEN = 5)
+	build_type = MECHFAB
+	build_path = /obj/item/mecha_parts/part/marauder_right_arm
+	category = "Durand"
+	materials = list(MAT_IRON=35000,MAT_SILVER=3000)
+
+/datum/design/marauder/l_leg
+	name = "Exosuit Structure (Marauder left leg)"
+	desc = "Used to build a Marauder left leg."
+	id = "durand_lleg"
+	req_tech = list(Tc_COMBAT = 2, NANOTRASEN = 5)
+	build_type = MECHFAB
+	build_path = /obj/item/mecha_parts/part/marauder_left_leg
+	category = "Durand"
+	materials = list(MAT_IRON=40000,MAT_SILVER=3000)
+
+/datum/design/marauder/r_leg
+	name = "Exosuit Structure (Marauder right leg)"
+	desc = "Used to build a Marauder right leg."
+	id = "durand_rleg"
+	req_tech = list(Tc_COMBAT = 2, NANOTRASEN = 5)
+	build_type = MECHFAB
+	build_path = /obj/item/mecha_parts/part/marauder_right_leg
+	category = "Durand"
+	materials = list(MAT_IRON=40000,MAT_SILVER=3000)
+
+/datum/design/marauder/head
+	name = "Exosuit Structure (Marauder head)"
+	desc = "Used to build a Marauder head."
+	id = "durand_head"
+	req_tech = list(Tc_COMBAT = 2, NANOTRASEN = 5)
+	build_type = MECHFAB
+	build_path = /obj/item/mecha_parts/part/marauder_head
+	category = "Durand"
+	materials = list(MAT_IRON=25000,MAT_GLASS=10000,MAT_SILVER=3000)
+
+/datum/design/marauder/armor
+	name = "Exosuit Structure (Marauder plates)"
+	desc = "Used to build Marauder armor plates."
+	id = "durand_armor"
+	req_tech = list(Tc_COMBAT = 4, Tc_MAGNETS = 5, NANOTRASEN = 5)
+	build_type = MECHFAB
+	build_path = /obj/item/mecha_parts/part/marauder_armour
+	category = "Durand"
+	materials = list(MAT_IRON=50000,MAT_URANIUM=10000)

--- a/code/modules/research/designs/mecha/marauder.dm
+++ b/code/modules/research/designs/mecha/marauder.dm
@@ -2,7 +2,7 @@
 	name = "Exosuit Structure (Marauder chassis)"
 	desc = "Used to build a Marauder chassis."
 	id = "durand_chassis"
-	req_tech = list(Tc_COMBAT = 2, NANOTRASEN = 5)
+	req_tech = list(Tc_COMBAT = 2, Tc_NANOTRASEN = 5)
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/chassis/durand
 	category = "Durand"
@@ -12,7 +12,7 @@
 	name = "Exosuit Structure (Marauder torso)"
 	desc = "Used to build a Marauder torso."
 	id = "durand_torso"
-	req_tech = list(Tc_COMBAT = 2, NANOTRASEN = 5)
+	req_tech = list(Tc_COMBAT = 2, Tc_NANOTRASEN = 5)
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/marauder_torso
 	category = "Durand"
@@ -22,7 +22,7 @@
 	name = "Exosuit Structure (Marauder left arm)"
 	desc = "Used to build a Marauder left arm."
 	id = "durand_larm"
-	req_tech = list(Tc_COMBAT = 5, NANOTRASEN = 5)
+	req_tech = list(Tc_COMBAT = 5, Tc_NANOTRASEN = 5)
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/marauder_left_arm
 	category = "Durand"
@@ -32,7 +32,7 @@
 	name = "Exosuit Structure (Marauder right arm)"
 	desc = "Used to build a Marauder right arm."
 	id = "durand_rarm"
-	req_tech = list(Tc_COMBAT = 4, NANOTRASEN = 5)
+	req_tech = list(Tc_COMBAT = 4, Tc_NANOTRASEN = 5)
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/marauder_right_arm
 	category = "Durand"
@@ -42,7 +42,7 @@
 	name = "Exosuit Structure (Marauder left leg)"
 	desc = "Used to build a Marauder left leg."
 	id = "durand_lleg"
-	req_tech = list(Tc_COMBAT = 2, NANOTRASEN = 5)
+	req_tech = list(Tc_COMBAT = 2, Tc_NANOTRASEN = 5)
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/marauder_left_leg
 	category = "Durand"
@@ -52,7 +52,7 @@
 	name = "Exosuit Structure (Marauder right leg)"
 	desc = "Used to build a Marauder right leg."
 	id = "durand_rleg"
-	req_tech = list(Tc_COMBAT = 2, NANOTRASEN = 5)
+	req_tech = list(Tc_COMBAT = 2, Tc_NANOTRASEN = 5)
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/marauder_right_leg
 	category = "Durand"
@@ -62,7 +62,7 @@
 	name = "Exosuit Structure (Marauder head)"
 	desc = "Used to build a Marauder head."
 	id = "durand_head"
-	req_tech = list(Tc_COMBAT = 2, NANOTRASEN = 5)
+	req_tech = list(Tc_COMBAT = 2, Tc_NANOTRASEN = 5)
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/marauder_head
 	category = "Durand"
@@ -72,7 +72,7 @@
 	name = "Exosuit Structure (Marauder plates)"
 	desc = "Used to build Marauder armor plates."
 	id = "durand_armor"
-	req_tech = list(Tc_COMBAT = 4, Tc_MAGNETS = 5, NANOTRASEN = 5)
+	req_tech = list(Tc_COMBAT = 4, Tc_MAGNETS = 5, Tc_NANOTRASEN = 5)
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/marauder_armour
 	category = "Durand"

--- a/html/changelogs/JMWTurner-MarauderBoards.yml
+++ b/html/changelogs/JMWTurner-MarauderBoards.yml
@@ -1,0 +1,5 @@
+author: JMWTurner
+delete-after: true
+changes:
+  - rscadd: Added design datums for Marauder parts.
+  - tweak: Marauder parts and boards now require Nanotrasen tech FIVE. Which only admins can grant. So they won't appear on the R&D computers by default anymore.

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -1774,6 +1774,7 @@
 #include "code\modules\research\designs\mecha\durand.dm"
 #include "code\modules\research\designs\mecha\gygax.dm"
 #include "code\modules\research\designs\mecha\honker.dm"
+#include "code\modules\research\designs\mecha\marauder.dm"
 #include "code\modules\research\designs\mecha\misc.dm"
 #include "code\modules\research\designs\mecha\odysseus.dm"
 #include "code\modules\research\designs\mecha\phazon.dm"


### PR DESCRIPTION
They now require Nanotrasen tech 5. Along with Marauder parts. Admins can spawn nanotrasen tech disks and varedit their value to 5 if they wish to grant players the tech to build them IC, or during an event.

Closes #11594
