### PR TITLE
fix fullscreen again, also cleans up AI's life.dm

### DIFF
--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -46,7 +46,7 @@
 		for(var/category in screens)
 			var/obj/A = screens[category]
 			if(!A)
-				log_debug("screens\[[category]\] is null")
+				log_debug("screens\[[category]\] is null on [mymob]")
 				continue
 			if(istype(A, /atom)
 			 	if(!istype(A, /obj/screen)))

--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -32,7 +32,6 @@
 		animate(screen, alpha = 0, time = animate)
 		sleep(animate)
 
-	screens -= screen
 	screens[category] = null
 	screens -= category
 	if(client)

--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -53,7 +53,7 @@
 					log_debug("Wrong type of object in screens, type [A.type] [mymob]")
 					continue
 			else // not even an atom, shouldnt go in list anyway
-				log_debug("screens[\[category]\] is a non-atom, WHY IS THIS IN SCREENS [mymob]")
+				log_debug("screens\[[category]\] is a non-atom, WHY IS THIS IN SCREENS [mymob]")
 				continue
 			mymob.client.screen |= A
 

--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -45,8 +45,15 @@
 		var/list/screens = mymob.screens
 		for(var/category in screens)
 			var/obj/A = screens[category]
-			if(istype(A, /atom) && !istype(A, /obj/screen))
-				log_debug("Wrong type of object in screens, type [A.type]")
+			if(!A)
+				log_debug("screens\[[category]\] is null")
+				continue
+			if(istype(A, /atom)
+			 	if(!istype(A, /obj/screen)))
+					log_debug("Wrong type of object in screens, type [A.type] [mymob]")
+					continue
+			else // not even an atom, shouldnt go in list anyway
+				log_debug("screens[\[category]\] is a non-atom, WHY IS THIS IN SCREENS [mymob]")
 				continue
 			mymob.client.screen |= A
 

--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -25,6 +25,7 @@
 	set waitfor = 0
 	var/obj/screen/fullscreen/screen = screens[category]
 	if(!screen)
+		screens -= category
 		return
 
 	if(animate)
@@ -32,6 +33,8 @@
 		sleep(animate)
 
 	screens -= screen
+	screens[category] = null
+	screens -= category
 	if(client)
 		client.screen -= screen
 	qdel(screen)

--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -48,8 +48,8 @@
 			if(!A)
 				log_debug("screens\[[category]\] is null on [mymob]")
 				continue
-			if(istype(A, /atom)
-			 	if(!istype(A, /obj/screen)))
+			if(istype(A, /atom))
+			 	if(!istype(A, /obj/screen))
 					log_debug("Wrong type of object in screens, type [A.type] [mymob]")
 					continue
 			else // not even an atom, shouldnt go in list anyway

--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -49,7 +49,7 @@
 				log_debug("screens\[[category]\] is null on [mymob]")
 				continue
 			if(istype(A, /atom))
-			 	if(!istype(A, /obj/screen))
+				if(!istype(A, /obj/screen))
 					log_debug("Wrong type of object in screens, type [A.type] [mymob]")
 					continue
 			else // not even an atom, shouldnt go in list anyway

--- a/code/_onclick/hud/other_mobs.dm
+++ b/code/_onclick/hud/other_mobs.dm
@@ -9,16 +9,9 @@
 	mymob.visible.name = "visible"
 	mymob.visible.screen_loc = ui_health
 
-	mymob.flash = getFromPool(/obj/screen)
-	mymob.flash.icon = 'icons/mob/screen1.dmi'
-	mymob.flash.icon_state = "blank"
-	mymob.flash.name = "flash"
-	mymob.flash.screen_loc = ui_entire_screen
-	mymob.flash.layer = UNDER_HUD_LAYER
-
 	mymob.client.reset_screen()
 
-	mymob.client.screen += list(mymob.visible, mymob.flash)
+	mymob.client.screen += list(mymob.visible)
 
 /datum/hud/proc/corgi_hud()
 	mymob.fire = getFromPool(/obj/screen)
@@ -51,16 +44,9 @@
 	mymob.toxin.name = "toxin"
 	mymob.toxin.screen_loc = ui_toxin
 
-	mymob.flash = getFromPool(/obj/screen)
-	mymob.flash.icon = 'icons/mob/screen1.dmi'
-	mymob.flash.icon_state = "blank"
-	mymob.flash.name = "flash"
-	mymob.flash.screen_loc = ui_entire_screen
-	mymob.flash.layer = UNDER_HUD_LAYER
-
 	mymob.client.reset_screen()
 
-	mymob.client.screen += list(mymob.fire, mymob.healths, mymob.pullin, mymob.oxygen, mymob.toxin, mymob.flash)
+	mymob.client.screen += list(mymob.fire, mymob.healths, mymob.pullin, mymob.oxygen, mymob.toxin)
 
 /datum/hud/proc/brain_hud(ui_style = 'icons/mob/screen1_Midnight.dmi')
 
@@ -84,16 +70,9 @@
 	mymob.zone_sel.overlays.len = 0
 	mymob.zone_sel.overlays += image('icons/mob/zone_sel.dmi', "[mymob.zone_sel.selecting]")
 
-	mymob.flash = getFromPool(/obj/screen)
-	mymob.flash.icon = 'icons/mob/screen1.dmi'
-	mymob.flash.icon_state = "blank"
-	mymob.flash.name = "flash"
-	mymob.flash.screen_loc = ui_entire_screen
-	mymob.flash.layer = UNDER_HUD_LAYER
-
 	mymob.client.reset_screen()
 
-	mymob.client.screen += list(mymob.healths, mymob.pullin, mymob.zone_sel, mymob.flash)
+	mymob.client.screen += list(mymob.healths, mymob.pullin, mymob.zone_sel)
 
 /datum/hud/proc/shade_hud()
 
@@ -121,16 +100,9 @@
 	mymob.zone_sel.overlays.len = 0
 	mymob.zone_sel.overlays += image('icons/mob/zone_sel.dmi', "[mymob.zone_sel.selecting]")
 
-	mymob.flash = getFromPool(/obj/screen)
-	mymob.flash.icon = 'icons/mob/screen1.dmi'
-	mymob.flash.icon_state = "blank"
-	mymob.flash.name = "flash"
-	mymob.flash.screen_loc = ui_entire_screen
-	mymob.flash.layer = UNDER_HUD_LAYER
-
 	mymob.client.reset_screen()
 
-	mymob.client.screen += list(mymob.healths, mymob.pullin, mymob.zone_sel, mymob.purged, mymob.flash)
+	mymob.client.screen += list(mymob.healths, mymob.pullin, mymob.zone_sel, mymob.purged)
 
 /datum/hud/proc/borer_hud()
 
@@ -160,13 +132,6 @@
 		constructtype = "wraith"
 	else if(istype(mymob,/mob/living/simple_animal/construct/harvester))
 		constructtype = "harvester"
-
-	mymob.flash = getFromPool(/obj/screen)
-	mymob.flash.icon = 'icons/mob/screen1.dmi'
-	mymob.flash.icon_state = "blank"
-	mymob.flash.name = "flash"
-	mymob.flash.screen_loc = ui_entire_screen
-	mymob.flash.layer = UNDER_HUD_LAYER
 
 	if(constructtype)
 		mymob.fire = getFromPool(/obj/screen)
@@ -200,7 +165,7 @@
 
 	mymob.client.reset_screen()
 
-	mymob.client.screen += list(mymob.fire, mymob.healths, mymob.pullin, mymob.zone_sel, mymob.purged, mymob.flash)
+	mymob.client.screen += list(mymob.fire, mymob.healths, mymob.pullin, mymob.zone_sel, mymob.purged)
 
 /datum/hud/proc/vampire_hud(ui_style = 'icons/mob/screen1_Midnight.dmi')
 

--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -233,7 +233,7 @@ That prevents a few funky behaviors.
 							//fix blindness from powerloss
 							if(T.aiRestorePowerRoutine)
 								T.aiRestorePowerRoutine = -1
-								T.blind.layer = 0
+								T.clear_fullscreen("blind")
 
 			if("INACTIVE")//Inactive AI object.
 				var/obj/structure/AIcore/deactivated/T = target

--- a/code/modules/mob/living/carbon/monkey/death.dm
+++ b/code/modules/mob/living/carbon/monkey/death.dm
@@ -37,8 +37,6 @@
 			O.show_message("<b>The [name]</b> lets out a faint chimper as it collapses and stops moving...", 1) //ded -- Urist
 
 	update_canmove()
-	if(blind)
-		blind.layer = 0
 
 	ticker.mode.check_win()
 

--- a/code/modules/mob/living/carbon/slime/death.dm
+++ b/code/modules/mob/living/carbon/slime/death.dm
@@ -23,8 +23,6 @@
 				O.show_message("<b>The [name]</b> seizes up and falls limp...", 1) //ded -- Urist
 
 	update_canmove()
-	if(blind)
-		blind.layer = 0
 
 	ticker.mode.check_win()
 

--- a/code/modules/mob/living/silicon/ai/death.dm
+++ b/code/modules/mob/living/silicon/ai/death.dm
@@ -8,8 +8,6 @@
 	update_canmove()
 	if(src.eyeobj)
 		src.eyeobj.forceMove(get_turf(src))
-	if(blind)
-		blind.layer = 0
 	change_sight(adding = SEE_TURFS|SEE_MOBS|SEE_OBJS)
 	see_in_dark = 8
 	see_invisible = SEE_INVISIBLE_LEVEL_TWO

--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -168,6 +168,8 @@
 									src.show_laws()
 							sleep(50)
 							theAPC = null
+			if(unblindme)
+				clear_fullscreen("blind")
 
 /mob/living/silicon/ai/updatehealth()
 	if(status_flags & GODMODE)

--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -2,39 +2,39 @@
 	if(timestopped)
 		return 0 //under effects of time magick
 
-	if (src.stat == DEAD)
+	if (stat == DEAD)
 		return
 	else
 		var/turf/T = get_turf(src)
 
-		if (src.stat!=CONSCIOUS)
-			src.cameraFollow = null
-			src.reset_view(null)
-			src.unset_machine()
+		if (stat!=CONSCIOUS)
+			cameraFollow = null
+			reset_view(null)
+			unset_machine()
 
-		src.updatehealth()
+		updatehealth()
 
-		if (src.malfhack)
-			if (src.malfhack.aidisabled)
+		if (malfhack)
+			if (malfhack.aidisabled)
 				to_chat(src, "<span class='warning'>ERROR: APC access disabled, hack attempt canceled.</span>")
-				src.malfhacking = 0
-				src.malfhack = null
+				malfhacking = 0
+				malfhack = null
 
 
-		if (src.health <= config.health_threshold_dead)
+		if (health <= config.health_threshold_dead)
 			death()
 			return
 
 		if(client)
-			if (src.machine)
-				if (!( src.machine.check_eye(src) ))
-					src.reset_view(null)
+			if (machine)
+				if (!( machine.check_eye(src) ))
+					reset_view(null)
 			else
 				if(!isTeleViewing(client.eye))
 					reset_view(null)
 
 		// Handle power damage (oxy)
-		if(src.aiRestorePowerRoutine != 0)
+		if(aiRestorePowerRoutine != 0)
 			// Lost power
 			adjustOxyLoss(1)
 		else
@@ -46,30 +46,30 @@
 		if (istype(T, /turf))
 			loc = T.loc
 			if (istype(loc, /area))
-				if (!loc.power_equip && !istype(src.loc,/obj/item))
+				if (!loc.power_equip && !istype(loc,/obj/item))
 					unpowered_core = 1
 		if (!unpowered_core)
 			var/unblindme = 0
 			if(client && client.eye == eyeobj) // We are viewing the world through our "eye" mob.
 				change_sight(adding = SEE_TURFS|SEE_MOBS|SEE_OBJS)
-				src.see_in_dark = 8
-				src.see_invisible = SEE_INVISIBLE_LEVEL_TWO
+				see_in_dark = 8
+				see_invisible = SEE_INVISIBLE_LEVEL_TWO
 
 			var/area/home = get_area(src)
 			if(home && home.powered(EQUIP))
 				home.use_power(1000, EQUIP)
 
-			if (src.aiRestorePowerRoutine==2)
+			if (aiRestorePowerRoutine==2)
 				to_chat(src, "Alert cancelled. Power has been restored without our assistance.")
-				src.aiRestorePowerRoutine = 0
+				aiRestorePowerRoutine = 0
 				unblindme = 1
-			else if (src.aiRestorePowerRoutine==3)
+			else if (aiRestorePowerRoutine==3)
 				to_chat(src, "Alert cancelled. Power has been restored.")
-				src.aiRestorePowerRoutine = 0
+				aiRestorePowerRoutine = 0
 				unblindme = 1
-			else if (src.aiRestorePowerRoutine == -1)
+			else if (aiRestorePowerRoutine == -1)
 				to_chat(src, "Alert cancelled. External power source detected.")
-				src.aiRestorePowerRoutine = 0
+				aiRestorePowerRoutine = 0
 				unblindme = 1
 			if(unblindme)
 				clear_fullscreen("blind")
@@ -81,48 +81,48 @@
 			overlay_fullscreen("blind", /obj/screen/fullscreen/blind)
 			if(client)
 				change_sight(removing = SEE_TURFS|SEE_MOBS|SEE_OBJS)
-				src.see_in_dark = 0
-			src.see_invisible = SEE_INVISIBLE_LIVING
+				see_in_dark = 0
+			see_invisible = SEE_INVISIBLE_LIVING
 
-			if (((!loc.power_equip) || istype(T, /turf/space)) && !istype(src.loc,/obj/item))
-				if (src.aiRestorePowerRoutine==0)
-					src.aiRestorePowerRoutine = 1
+			if (((!loc.power_equip) || istype(T, /turf/space)) && !istype(loc,/obj/item))
+				if (aiRestorePowerRoutine==0)
+					aiRestorePowerRoutine = 1
 
 					to_chat(src, "You've lost power!")
 					spawn(20)
-						if(!src.aiRestorePowerRoutine)
+						if(!aiRestorePowerRoutine)
 							return // Checking for premature changes.
 						to_chat(src, "Backup battery online. Scanners, camera, and radio interface offline. Beginning fault-detection.")
 						sleep(50)
-						if(!src.aiRestorePowerRoutine)
+						if(!aiRestorePowerRoutine)
 							return // Checking for premature changes.
 						if (loc.power_equip)
 							if (!istype(T, /turf/space))
 								to_chat(src, "Alert cancelled. Power has been restored without our assistance.")
-								src.aiRestorePowerRoutine = 0
+								aiRestorePowerRoutine = 0
 								unblindme = 1
 								return
 						to_chat(src, "Fault confirmed: missing external power. Shutting down main control system to save power.")
 						sleep(20)
-						if(!src.aiRestorePowerRoutine)
+						if(!aiRestorePowerRoutine)
 							return // Checking for premature changes.
 						to_chat(src, "Emergency control system online. Verifying connection to power network.")
 						sleep(50)
-						if(!src.aiRestorePowerRoutine)
+						if(!aiRestorePowerRoutine)
 							return // Checking for premature changes.
 						if (istype(T, /turf/space))
 							to_chat(src, "Unable to verify! No power connection detected!")
-							src.aiRestorePowerRoutine = 2
+							aiRestorePowerRoutine = 2
 							return
 						to_chat(src, "Connection verified. Searching for APC in power network.")
 						sleep(50)
-						if(!src.aiRestorePowerRoutine)
+						if(!aiRestorePowerRoutine)
 							return // Checking for premature changes.
 						var/obj/machinery/power/apc/theAPC = null
 
 						var/PRP //like ERP with the code, at least this stuff is no more 4x sametext
 						for (PRP=1, PRP<=4, PRP++)
-							if(!src.aiRestorePowerRoutine)
+							if(!aiRestorePowerRoutine)
 								return // Checking for premature changes.
 							var/area/AIarea = get_area(src)
 							for (var/obj/machinery/power/apc/APC in AIarea)
@@ -135,12 +135,12 @@
 										to_chat(src, "Unable to locate APC!")
 									else
 										to_chat(src, "Lost connection with the APC!")
-								src.aiRestorePowerRoutine = 2
+								aiRestorePowerRoutine = 2
 								return
 							if (loc.power_equip)
 								if (!istype(T, /turf/space))
 									to_chat(src, "Alert cancelled. Power has been restored without our assistance.")
-									src.aiRestorePowerRoutine = 0
+									aiRestorePowerRoutine = 0
 									unblindme = 1
 									return
 							switch(PRP)
@@ -153,19 +153,19 @@
 								if (4)
 									to_chat(src, "Transfer complete. Forcing APC to execute program.")
 									sleep(50)
-									if(!src.aiRestorePowerRoutine)
+									if(!aiRestorePowerRoutine)
 										theAPC = null
 										return // Checking for premature changes.
 									to_chat(src, "Receiving control information from APC.")
 									sleep(2)
-									if(!src.aiRestorePowerRoutine)
+									if(!aiRestorePowerRoutine)
 										theAPC = null
 										return // Checking for premature changes.
 									//bring up APC dialog
 									theAPC.attack_ai(src)
-									src.aiRestorePowerRoutine = 3
+									aiRestorePowerRoutine = 3
 									to_chat(src, "Here are your current laws:")
-									src.show_laws()
+									show_laws()
 							sleep(50)
 							theAPC = null
 			if(unblindme)

--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -42,29 +42,20 @@
 			// Gain Power
 			adjustOxyLoss(-1)
 
-		//stage = 1
-		//if (istype(src, /mob/living/silicon/ai)) // Are we not sure what we are?
-		var/blind = 0
-		//stage = 2
+		var/blindme = 0
 		var/area/loc = null
 		if (istype(T, /turf))
-			//stage = 3
 			loc = T.loc
 			if (istype(loc, /area))
-				//stage = 4
 				if (!loc.power_equip && !istype(src.loc,/obj/item))
-					//stage = 5
-					blind = 1
-		if (!blind)	//lol? if(!blind)	#if(src.blind.layer)    <--something here is clearly wrong :P
-					//I'll get back to this when I find out  how this is -supposed- to work ~Carn //removed this shit since it was confusing as all hell --39kk9t
-			//stage = 4.5
+					blindme = 1
+		if (!blindme)
 			if(client && client.eye == eyeobj) // We are viewing the world through our "eye" mob.
 				change_sight(adding = SEE_TURFS|SEE_MOBS|SEE_OBJS)
 				src.see_in_dark = 8
 				src.see_invisible = SEE_INVISIBLE_LEVEL_TWO
 
 			var/area/home = get_area(src)
-			//if(!home)	return//something to do with malf fucking things up I guess. <-- aisat is gone. is this still necessary? ~Carn
 			if(home && home.powered(EQUIP))
 				home.use_power(1000, EQUIP)
 
@@ -88,8 +79,6 @@
 				return
 
 		else
-
-			//stage = 6
 			if(client)
 				if(src.blind)
 					src.blind.screen_loc = "1,1 to 15,15"

--- a/code/modules/mob/living/silicon/mommi/death.dm
+++ b/code/modules/mob/living/silicon/mommi/death.dm
@@ -49,8 +49,6 @@
 			RC.upgrade_finished = -1
 		RC.go_out()
 
-	if(blind)
-		blind.layer = 0
 	change_sight(adding = SEE_TURFS|SEE_MOBS|SEE_OBJS)
 	see_in_dark = 8
 	see_invisible = SEE_INVISIBLE_LEVEL_TWO

--- a/code/modules/mob/living/silicon/pai/death.dm
+++ b/code/modules/mob/living/silicon/pai/death.dm
@@ -3,8 +3,6 @@
 		return
 	stat = DEAD
 	canmove = 0
-	if(blind)
-		blind.layer = 0
 	change_sight(adding = SEE_TURFS|SEE_MOBS|SEE_OBJS)
 	see_in_dark = 8
 	see_invisible = SEE_INVISIBLE_LEVEL_TWO

--- a/code/modules/mob/living/silicon/robot/death.dm
+++ b/code/modules/mob/living/silicon/robot/death.dm
@@ -49,8 +49,6 @@
 			RC.upgrade_finished = -1
 		RC.go_out()
 
-	if(blind)
-		blind.layer = 0
 	change_sight(adding = SEE_TURFS|SEE_MOBS|SEE_OBJS)
 	see_in_dark = 8
 	see_invisible = SEE_INVISIBLE_LEVEL_TWO

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -75,16 +75,6 @@ var/global/obj/screen/fuckstat/FUCK = new
 	return PROJREACT_MOBS
 
 /mob/proc/remove_screen_objs()
-	if(flash)
-		returnToPool(flash)
-		if(client)
-			client.screen -= flash
-		flash = null
-	if(blind)
-		returnToPool(blind)
-		if(client)
-			client.screen -= blind
-		blind = null
 	if(hands)
 		returnToPool(hands)
 		if(client)

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -12,8 +12,6 @@
 
 	var/stat = 0 //Whether a mob is alive or dead. TODO: Move this to living - Nodrak
 
-	var/obj/screen/flash = null
-	var/obj/screen/blind = null
 	var/obj/screen/hands = null
 	var/obj/screen/pullin = null
 	var/obj/screen/kick_icon = null

--- a/code/unused/hivebot/death.dm
+++ b/code/unused/hivebot/death.dm
@@ -4,8 +4,6 @@
 	src.stat = 2
 	src.canmove = 0
 
-	if(src.blind)
-		src.blind.layer = 0
 	src.sight |= SEE_TURFS
 	src.sight |= SEE_MOBS
 	src.sight |= SEE_OBJS

--- a/code/unused/hivebot/hud.dm
+++ b/code/unused/hivebot/hud.dm
@@ -204,28 +204,11 @@
 	mymob.fire.name = "fire"
 	mymob.fire.screen_loc = ui_fire
 
-
-
 	mymob.pullin = new /obj/screen( null )
 	mymob.pullin.icon = 'icons/mob/screen1_robot.dmi'
 	mymob.pullin.icon_state = "pull0"
 	mymob.pullin.name = "pull"
 	mymob.pullin.screen_loc = ui_pull
-
-	mymob.blind = new /obj/screen( null )
-	mymob.blind.icon = 'icons/mob/screen1_full.dmi''
-	mymob.blind.icon_state = "blackimageoverlay"
-	mymob.blind.name = " "
-	mymob.blind.screen_loc = "1,1"
-	mymob.blind.layer = 0
-	mymob.blind.mouse_opacity = 0
-
-	mymob.flash = new /obj/screen( null )
-	mymob.flash.icon = 'icons/mob/screen1_robot.dmi'
-	mymob.flash.icon_state = "blank"
-	mymob.flash.name = "flash"
-	mymob.flash.screen_loc = "1,1 to 15,15"
-	mymob.flash.layer = UNDER_HUD_LAYER
 
 	mymob.sleep = new /obj/screen( null )
 	mymob.sleep.icon = 'icons/mob/screen1_robot.dmi'
@@ -246,7 +229,7 @@
 
 	mymob.client.reset_screen()
 
-	mymob.client.screen += list(mymob.throw_icon, mymob.zone_sel, mymob.oxygen, mymob.fire, mymob.hands, mymob.healths, mymob:cells, mymob.pullin, mymob.blind, mymob.flash, mymob.rest, mymob.sleep) //, mymob.mach )
+	mymob.client.screen += list(mymob.throw_icon, mymob.zone_sel, mymob.oxygen, mymob.fire, mymob.hands, mymob.healths, mymob:cells, mymob.pullin, mymob.rest, mymob.sleep) //, mymob.mach )
 	mymob.client.screen += src.adding + src.other
 
 	return

--- a/code/unused/hivebot/life.dm
+++ b/code/unused/hivebot/life.dm
@@ -186,7 +186,7 @@
 			src.client.screen -= src.hud_used.druggy
 			src.client.screen -= src.hud_used.vimpaired
 
-			if ((src.stat != 2))
+			if ((src.stat != DEAD))
 				if ((src.blinded))
 					src.blind.layer = 18
 				else

--- a/code/unused/hivebot/life.dm
+++ b/code/unused/hivebot/life.dm
@@ -186,7 +186,7 @@
 			src.client.screen -= src.hud_used.druggy
 			src.client.screen -= src.hud_used.vimpaired
 
-			if ((src.blind && src.stat != 2))
+			if ((src.stat != 2))
 				if ((src.blinded))
 					src.blind.layer = 18
 				else

--- a/code/unused/hivebot/life.dm
+++ b/code/unused/hivebot/life.dm
@@ -188,10 +188,9 @@
 
 			if ((src.stat != DEAD))
 				if ((src.blinded))
-					src.blind.layer = 18
+					overlay_fullscreen("blind", /obj/screen/fullscreen/blind)
 				else
-					src.blind.layer = 0
-
+					clear_fullscreen("blind")
 					if (src.disabilities & 1)
 						src.client.screen += src.hud_used.vimpaired
 

--- a/code/unused/hivebot/mainframe.dm
+++ b/code/unused/hivebot/mainframe.dm
@@ -130,17 +130,6 @@
 	update_clothing()
 	for(var/S in src.client.screen)
 		del(S)
-	src.flash = new /obj/screen( null )
-	src.flash.icon_state = "blank"
-	src.flash.name = "flash"
-	src.flash.screen_loc = "1,1 to 15,15"
-	src.flash.layer = UNDER_HUD_LAYER
-	src.blind = new /obj/screen( null )
-	src.blind.icon_state = "black"
-	src.blind.name = " "
-	src.blind.screen_loc = "1,1 to 15,15"
-	src.blind.layer = 0
-	src.client.screen += list( src.blind, src.flash )
 	if(!isturf(src.loc))
 		src.client.eye = src.loc
 		src.client.perspective = EYE_PERSPECTIVE


### PR DESCRIPTION
Fixes a runtime in fullscreen.dm if a thing is null and adds debug output
I have no idea what'd be adding non-objs to screens so woo

Now includes:
- AI lifecode cleanup
- Removing blind and flash as vars because these should be handled by fullscreen.dm now
