### PR TITLE
Added feedback to bar sign error

### DIFF
--- a/code/game/objects/structures/barsign.dm
+++ b/code/game/objects/structures/barsign.dm
@@ -48,6 +48,7 @@
 		return
 
 	if (!(get_dir(src, usr) in list(SOUTHWEST, SOUTH, SOUTHEAST)))
+		to_chat(user, "<span class='warning'>You must stand south of the bar sign to change its design.</span>")
 		return
 
 	barsigns.len = 0
@@ -71,9 +72,7 @@
 		desc = "It displays \"[name]\"."
 
 /obj/structure/sign/double/barsign/cultify()
-	if(cult)
-		return
-	else
+	if(!cult)
 		icon_state = "narsiebistro"
 		name = "Narsie Bistro"
 		desc = "The last pub before the World's End."

--- a/code/game/objects/structures/barsign.dm
+++ b/code/game/objects/structures/barsign.dm
@@ -47,10 +47,6 @@
 		to_chat(user, "<span class='warning'>Access denied.</span>")
 		return
 
-	if (!(get_dir(src, usr) in list(SOUTHWEST, SOUTH, SOUTHEAST)))
-		to_chat(user, "<span class='warning'>You must stand south of the bar sign to change its design.</span>")
-		return
-
 	barsigns.len = 0
 	for(var/bartype in typesof(/datum/barsign))
 		var/datum/barsign/signinfo = new bartype


### PR DESCRIPTION
I mistook a case of missing feedback for a bug. Turns out that someone decided that you need to stand south of a bar sign to edit it. However there are no error messages when you try to do it from the north, leaving you to believe that you ran into a runtime error.
