### PR TITLE
Changes the way deaf hear sounds

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -423,7 +423,7 @@
 				else
 					sound = pick('sound/ambience/ambigen1.ogg', 'sound/ambience/ambigen3.ogg', 'sound/ambience/ambigen4.ogg', 'sound/ambience/ambigen5.ogg', 'sound/ambience/ambigen6.ogg', 'sound/ambience/ambigen7.ogg', 'sound/ambience/ambigen8.ogg', 'sound/ambience/ambigen9.ogg', 'sound/ambience/ambigen10.ogg', 'sound/ambience/ambigen11.ogg', 'sound/ambience/ambigen12.ogg', 'sound/ambience/ambigen14.ogg')
 
-			M << sound(sound, 0, 0, SOUND_AMBIANCE, 25)
+			M << sound(sound, 0, 0, CHANNEL_AMBIENCE, 25)
 
 			spawn(600) // Ewww - this is very very bad.
 				if(M && M.client)

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -66,6 +66,9 @@ var/list/soulstone_sound = list('sound/hallucinations/far_noise.ogg', 'sound/hal
 		if(!player || !player.client)
 			continue
 
+		if(player.is_deaf() && !(channel == CHANNEL_ADMINMUSIC || channel == CHANNEL_AMBIENCE)) //check their hearing for obvious reasons
+			continue
+
 		var/turf/player_turf = get_turf(player)
 
 		if (player_turf && turf_source && player_turf.z == turf_source.z)

--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -4,7 +4,7 @@
 	if(!check_rights(R_SOUNDS))
 		return
 
-	var/sound/uploaded_sound = sound(S, repeat = 0, wait = 1, channel = 777)
+	var/sound/uploaded_sound = sound(S, repeat = 0, wait = 1, channel = CHANNEL_ADMINMUSIC)
 	uploaded_sound.status = SOUND_STREAM | SOUND_UPDATE
 	uploaded_sound.priority = 250
 
@@ -38,7 +38,7 @@
 	log_admin("[key_name(src)] played a local sound [S]")
 	message_admins("[key_name_admin(src)] played a local sound [S]", 1)
 	S.status = SOUND_STREAM | SOUND_UPDATE
-	playsound(get_turf(src.mob), S, 50, 0, 0)
+	playsound(source = get_turf(src.mob), soundin = S, vol = 50, vary = 0, falloff = 0, channel = CHANNEL_ADMINMUSIC)
 	feedback_add_details("admin_verb","PLS") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 

--- a/code/setup.dm
+++ b/code/setup.dm
@@ -1319,7 +1319,9 @@ var/proccalls = 1
 #define ORE_PROCESSING_GENERAL 1
 #define ORE_PROCESSING_ALLOY 2
 
-#define SOUND_AMBIANCE			485	//Literally arbitrary.
+//SOUND CHANNELS
+#define CHANNEL_AMBIENCE			1023
+#define CHANNEL_ADMINMUSIC			1024
 
 //incorporeal_move values
 #define INCORPOREAL_DEACTIVATE	0


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.
-->


Dear shouldn't hear any sound coming directly from play sound, which should be the wrapper proc for most every sound.
Put defines on the ambience channel and the admin played music channel.

Deaf people can no longer hear any regular sound, but they'll still be able to hear ambience, admin music, and jukeboxes.

Fixes #11632
Fixes #11631