### PR TITLE
Removes a security camera from the vox hydroponics outpost on boxstation

### DIFF
--- a/html/changelogs/JustSumbirb.yml
+++ b/html/changelogs/JustSumbirb.yml
@@ -1,0 +1,7 @@
+
+author: JustSumGuy
+
+delete-after: True
+
+changes: 
+- rscdel: "Removed the security camera from Boxstation's Vox Hydroponics area."


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.
-->

Why was this even there none of the other portions of it have a camera
![image](https://cloud.githubusercontent.com/assets/19365096/18043494/2cd13996-6d96-11e6-9cff-0aab368e663c.png)

also closes #10891 since the two cameras had the same c_tag so the vox outpost one was being used in sec computers.
