### PR TITLE
Fix mindswap the rest of the way

### DIFF
--- a/code/modules/mob/spells.dm
+++ b/code/modules/mob/spells.dm
@@ -2,6 +2,7 @@
 	if(!spell_masters)
 		spell_masters = list()
 
+	spell_to_add.holder = src
 	if(spell_masters.len)
 		for(var/obj/screen/movable/spell_master/spell_master in spell_masters)
 			if(spell_master.type == master_type)
@@ -13,7 +14,6 @@
 	if(client)
 		src.client.screen += new_spell_master
 	new_spell_master.spell_holder = src
-	spell_to_add.holder = src
 	new_spell_master.add_spell(spell_to_add)
 	if(spell_base)
 		new_spell_master.icon_state = spell_base


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.
-->


So all the spells were being added properly to the new mob just as intended. But as a quirk of add_spell() code, only spells that were added when there was no spell master were getting their holder var set to the new mob they were added to.
Fixes #11537