### PR TITLE
Fixes syndicate wheelchair not having a cooldown between crushings

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -362,7 +362,7 @@
 		MB.RunOverCreature(src,species.blood_color)
 	else
 		var/obj/structure/bed/chair/vehicle/wheelchair/motorized/syndicate/WC = AM
-		if(istype(WC))
+		if(istype(WC) && !WC.attack_cooldown)
 			WC.crush(src,species.blood_color)
 		else
 			return //Don't make blood


### PR DESCRIPTION
#11249 didn't actually apply the cooldown to the chair, as seen in recent escape shuttle massacres
