### PR TITLE
modifies storage vars again

### DIFF
--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -16,6 +16,7 @@
 	name = "body bag kit"
 	desc = "A kit specifically designed to fit bodybags."
 	icon_state = "bodybags" //Consider respriting this to a kit some day
+	fits_max_w_class = 3
 	max_combined_w_class = 21
 	can_only_hold = list("/obj/item/bodybag") //Needed due to the last two variables, figures
 

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -102,6 +102,7 @@
 	slot_flags = SLOT_BELT | SLOT_POCKET
 	w_class = W_CLASS_MEDIUM
 	storage_slots = 50
+	fits_max_w_class = 3
 	max_combined_w_class = 200 //Doesn't matter what this is, so long as it's more or equal to storage_slots * ore.w_class
 	can_only_hold = list("/obj/item/weapon/ore")
 
@@ -115,6 +116,7 @@
 	icon_state = "plantbag"
 	name = "Plant Bag"
 	storage_slots = 50; //the number of plant pieces it can carry.
+	fits_max_w_class = 3
 	max_combined_w_class = 200 //Doesn't matter what this is, so long as it's more or equal to storage_slots * plants.w_class
 	w_class = W_CLASS_TINY
 	can_only_hold = list("/obj/item/weapon/reagent_containers/food/snacks/grown","/obj/item/seeds","/obj/item/weapon/grown", "/obj/item/weapon/reagent_containers/food/snacks/meat", "/obj/item/weapon/reagent_containers/food/snacks/egg", "/obj/item/weapon/reagent_containers/food/snacks/honeycomb")
@@ -129,6 +131,7 @@
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/backpacks_n_bags.dmi', "right_hand" = 'icons/mob/in-hand/right/backpacks_n_bags.dmi')
 	name = "Food Delivery Bag"
 	storage_slots = 14; //the number of food items it can carry.
+	fits_max_w_class = 3
 	max_combined_w_class = 28 //Doesn't matter what this is, so long as it's more or equal to storage_slots * plants.w_class
 	w_class = W_CLASS_MEDIUM
 	can_only_hold = list("/obj/item/weapon/reagent_containers/food/snacks")
@@ -171,6 +174,7 @@
 	item_state = "pcollector"
 	origin_tech = Tc_BIOTECH + "=2;" + Tc_MATERIALS + "=1"
 	storage_slots = 50; //the number of plant pieces it can carry.
+	fits_max_w_class = 3
 	max_combined_w_class = 200 //Doesn't matter what this is, so long as it's more or equal to storage_slots * plants.w_class
 	w_class = W_CLASS_TINY
 	can_only_hold = list("/obj/item/weapon/reagent_containers/glass/bottle","/obj/item/weapon/reagent_containers/pill","/obj/item/weapon/reagent_containers/syringe")

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -88,8 +88,7 @@
 	desc = "The ancestral belt of Many-APCs-Charging, the original chief engineer from Space Native America. It's made out of the skins of the ancient enemy of engineers, giant spiders."
 	icon_state = "utilitychief"
 	item_state = "utilitychief"
-	w_class = W_CLASS_LARGE
-	storage_slots = 14
+	fits_max_w_class = 3
 	can_only_hold = list(
 		"/obj/item/weapon/crowbar",
 		"/obj/item/weapon/screwdriver",
@@ -171,6 +170,7 @@
 	icon_state = "securitybelt"
 	item_state = "security"//Could likely use a better one.
 	storage_slots = 7
+	fits_max_w_class = 3
 	max_combined_w_class = 21
 	can_only_hold = list(
 		"/obj/item/weapon/grenade",
@@ -244,6 +244,7 @@
 	desc = "Excellent for holding the heads of your fallen foes."
 	icon_state = "utilitybelt"
 	item_state = "utility"
+	fits_max_w_class = 4
 	max_combined_w_class = 28
 	can_only_hold = list(
  		"/obj/item/weapon/organ/head"
@@ -256,6 +257,7 @@
 	icon_state = "miningbelt"
 	item_state = "mining"
 	w_class = W_CLASS_LARGE
+	fits_max_w_class = 4
 	max_combined_w_class = 28
 	can_only_hold = list(
 		"/obj/item/weapon/storage/bag/ore",
@@ -289,6 +291,7 @@
 	icon_state = "lazarusbelt_0"
 	item_state = "lazbelt"
 	w_class = W_CLASS_LARGE
+	fits_max_w_class = 4
 	max_combined_w_class = 28
 	storage_slots = 6
 	can_only_hold = list(

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -357,6 +357,7 @@
 	icon_state = "vialbox0"
 	item_state = "syringe_kit"
 	can_only_hold = list("/obj/item/weapon/reagent_containers/glass/beaker/vial")
+	fits_max_w_class = 3
 	max_combined_w_class = 14 //The sum of the w_classes of all the items in this storage item.
 	storage_slots = 6
 	req_access = list(access_virology)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -13,10 +13,10 @@
 	// These two accept a string containing the type path and the following optional prefixes:
 	//  = - Strict type matching.  Will NOT check for subtypes.
 	var/list/can_only_hold = new/list() //List of objects which this item can store (if set, it can't store anything else)
-	var/list/cant_hold = new/list() //List of objects which this item can't store (in effect only if can_only_hold isn't set)
-	var/list/fits_ignoring_w_class = new/list() //List of objects which will fit in this item, regardless of size. Doesn't restrict to ONLY items of these types, and doesn't ignore max_combined_w_class. (in effect only if can_only_hold isn't set)
+	var/list/cant_hold = new/list() //List of objects which this item can't store (in effect even if can_only_hold is set)
+	var/list/fits_ignoring_w_class = new/list() //List of objects which will fit in this item, regardless of size. Doesn't restrict to ONLY items of these types, and doesn't ignore max_combined_w_class. (in effect even if can_only_hold isn set)
 	var/list/is_seeing = new/list() //List of mobs which are currently seeing the contents of this item's storage
-	var/fits_max_w_class = W_CLASS_SMALL //Max size of objects that this object can store (in effect only if can_only_hold isn't set)
+	var/fits_max_w_class = W_CLASS_SMALL //Max size of objects that this object can store (in effect even if can_only_hold is set)
 	var/max_combined_w_class = 14 //The sum of the w_classes of all the items in this storage item.
 	var/storage_slots = 7 //The number of storage slots in this container.
 	var/obj/screen/storage/boxes = null
@@ -244,6 +244,18 @@
 			else if(istype(W, text2path(A) ))
 				ok = 1
 				break
+			else if(fits_ignoring_w_class.len)
+				for(var/B in fits_ignoring_w_class)
+					if(dd_hasprefix(B,"="))
+						// Force strict matching of type.
+						// No subtypes allowed.
+						if("[W.type]"==copytext(B,2))
+							ok = 1
+							break
+					else if(istype(W, text2path(B) ))
+						ok = 1
+						break
+
 		if(!ok)
 			if(!stop_messages)
 				if (istype(W, /obj/item/weapon/hand_labeler))
@@ -267,7 +279,7 @@
 				to_chat(usr, "<span class='notice'>\The [src] cannot hold \the [W].</span>")
 			return 0
 
-	if ((W.w_class > fits_max_w_class) && !can_only_hold.len) //fits_max_w_class doesn't matter if there's only a specific list of items you can put in
+	if (W.w_class > fits_max_w_class)
 		var/yeh = 0
 		if(fits_ignoring_w_class.len)
 			for(var/A in fits_ignoring_w_class)

--- a/code/game/objects/storage/coat.dm
+++ b/code/game/objects/storage/coat.dm
@@ -1,7 +1,7 @@
 /obj/item/clothing/suit/storage
 	var/list/can_only_hold = new/list() //List of objects which this item can store (if set, it can't store anything else)
-	var/list/cant_hold = new/list() //List of objects which this item can't store (in effect only if can_only_hold isn't set)
-	var/fits_max_w_class = W_CLASS_SMALL //Max size of objects that this object can store (in effect only if can_only_hold isn't set)
+	var/list/cant_hold = new/list() //List of objects which this item can't store (even if it's in the can_only_hold list)
+	var/fits_max_w_class = W_CLASS_SMALL //Max size of objects that this object can store (in effect even if can_only_hold is set)
 	var/max_combined_w_class = 4 //The sum of the w_classes of all the items in this storage item.
 	var/storage_slots = 2 //The number of storage slots in this container.
 	var/obj/screen/storage/boxes = null
@@ -130,7 +130,7 @@
 			to_chat(user, "<span class='warning'>The [src] cannot hold \the [W].</span>")
 			return
 
-	if (W.w_class > fits_max_w_class && !can_only_hold.len) //fits_max_w_class doesn't matter if there's only a specific list of items you can put in
+	if (W.w_class > fits_max_w_class)
 		to_chat(user, "<span class='warning'>The [W] is too big for \the [src].</span>")
 		return
 

--- a/code/modules/games/cards/wizard_cards.dm
+++ b/code/modules/games/cards/wizard_cards.dm
@@ -252,6 +252,7 @@ var/global/list/wizard_cards_normal = list(
 	icon_state = "cardpack"
 	name = "Wizard Card Pack"
 	storage_slots = 50
+	fits_max_w_class = 3
 	max_combined_w_class = 200
 	w_class = W_CLASS_TINY
 	can_only_hold = list("/obj/item/toy/wizard_card","/obj/item/weapon/reagent_containers/food/snacks/chocofrog")

--- a/code/modules/research/xenoarchaeology/tools/gearbelt.dm
+++ b/code/modules/research/xenoarchaeology/tools/gearbelt.dm
@@ -5,6 +5,7 @@
 	icon_state = "gearbelt"
 	item_state = "utility"
 	w_class = W_CLASS_LARGE //Lets it hold mining satchels.
+	fits_max_w_class = 4
 	max_combined_w_class = 28
 	can_only_hold = list(
 		"/obj/item/weapon/storage/box/samplebags",

--- a/code/modules/research/xenoarchaeology/tools/tools_pickaxe.dm
+++ b/code/modules/research/xenoarchaeology/tools/tools_pickaxe.dm
@@ -118,6 +118,7 @@
 	"/obj/item/weapon/pickaxe/five_pick",\
 	"/obj/item/weapon/pickaxe/six_pick")
 	max_combined_w_class = 17
+	fits_max_w_class = 4
 	use_to_pickup = 1 // for picking up broken bulbs, not that most people will try
 
 /obj/item/weapon/storage/box/excavation/New()

--- a/html/changelogs/Intistorage.yml
+++ b/html/changelogs/Intistorage.yml
@@ -1,0 +1,4 @@
+author: Intigracy
+delete-after: True
+changes: 
+- tweak: "Socket wrenches and large extinguishers no longer fit in ordinary toolbelts. CE toolbelt remains unchanged."


### PR DESCRIPTION
changes #9354's modifications to it due to an issue brought up in #11721 by kurfurst

can_only_hold no longer ignores fits_max_w_class, meaning you need to put the item you want to fit in there into fits_ignoring_w_class if you want it to fit.

This will affect, to my present knowledge, just the following:

Fire extinguishers
Socket wrenches

They'll no longer fit in regular toolbelts.

fixes #11721 obviously
