### PR TITLE
Making pianos spawn facing west

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -926,7 +926,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/device/instrument/recorder,
 					/obj/item/device/instrument/harmonica,
 					/obj/structure/piano/xylophone,
-					/obj/structure/piano)
+					/obj/structure/piano/random)
 	name = "Random instrument"
 	cost = 50
 	containertype = /obj/structure/closet/crate
@@ -943,6 +943,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/device/instrument/recorder,
 					/obj/item/device/instrument/harmonica,
 					/obj/structure/piano/xylophone,
+					/obj/structure/piano/minimoog,
 					/obj/structure/piano)
 	name = "Big band instrument collection"
 	cost = 500

--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -275,15 +275,21 @@
 		return 1
 //////////////////////////////////////////////////////////////////////////
 /obj/structure/piano
-	name = "space minimoog"
+	name = "space piano"
+	desc = "This is a space piano, like a regular piano, but always in tune! Even if the musician isn't."
 	icon = 'icons/obj/musician.dmi'
-	icon_state = "minimoog"
+	icon_state = "piano"
 	anchored = 1
 	density = 1
 	var/broken = 0
 	var/datum/song/song
-/obj/structure/piano/New()
-	dir = WEST
+
+/obj/structure/piano/minimoog
+	name = "space minimoog"
+	icon_state = "minimoog"
+	desc = "This is a minimoog, like a space piano, but more spacey!"
+
+/obj/structure/piano/random/New()
 	song = new("piano", src)
 	if(prob(50))
 		name = "space minimoog"
@@ -293,10 +299,12 @@
 		name = "space piano"
 		desc = "This is a space piano, like a regular piano, but always in tune! Even if the musician isn't."
 		icon_state = "piano"
+
 /obj/structure/piano/Destroy()
 	qdel(song)
 	song = null
 	..()
+
 /obj/structure/piano/initialize()
 	song.tempo = song.sanitize_tempo(song.tempo) // tick_lag isn't set when the map is loaded
 	..()

--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -283,6 +283,7 @@
 	var/broken = 0
 	var/datum/song/song
 /obj/structure/piano/New()
+	dir = WEST
 	song = new("piano", src)
 	if(prob(50))
 		name = "space minimoog"
@@ -370,5 +371,6 @@
 	icon_state = "xylophone"
 
 /obj/structure/piano/xylophone/New()
+	..()
 	song = new("xylophone", src)
 	song.instrumentExt = "mid"


### PR DESCRIPTION
which means their keyboard will be east, just like it used to look like.
