### PR TITLE
Fixed default language being broken for babel virus

### DIFF
--- a/code/modules/virus2/effect.dm
+++ b/code/modules/virus2/effect.dm
@@ -917,6 +917,7 @@ var/list/compatible_mobs = list(/mob/living/carbon/human, /mob/living/carbon/mon
 
 	var/picked_lang = pick(new_languages)
 	mob.add_language(picked_lang)
+	mob.default_language = mob.languages[1]
 
 	to_chat(mob, "You can't seem to remember any language but [picked_lang]. Odd.")
 


### PR DESCRIPTION
Turns out removing all languages sets the default language to a language you don't have
And adding languages to a mob with none doesn't change the default

Yes I tested this one all the way
I talked and it outputted my randomly picked language
