### PR TITLE
Package wrap tweaks/fixes

### DIFF
--- a/code/game/gamemodes/steal_items.dm
+++ b/code/game/gamemodes/steal_items.dm
@@ -14,7 +14,7 @@
 	var/list/areas = list()
 	var/flags=0
 
-/datum/theft_objective/proc/get_contents(var/obj/O)
+/datum/theft_objective/proc/get_contents(var/obj/O) //What a pile of shit. "What is this OOP you speak of?"
 	var/list/L = list()
 
 	if(istype(O,/obj/item/weapon/storage))
@@ -29,9 +29,10 @@
 
 	else if(istype(O,/obj/item/delivery))
 		var/obj/item/delivery/D = O
-		L += D.wrapped
-		if(istype(D.wrapped, /obj/item/weapon/storage)) //this should never happen
-			L += get_contents(D.wrapped)
+		for(var/atom/movable/wrapped in D) //Under normal circumstances, there will be only one thing in it, but not all circumstances are normal
+			L += wrapped
+			if(istype(wrapped, /obj/item/weapon/storage)) //this should never happen
+				L += get_contents(wrapped)
 	return L
 
 /datum/theft_objective/proc/check_completion(datum/mind/owner)

--- a/code/game/objects/items/stacks/packagewrap.dm
+++ b/code/game/objects/items/stacks/packagewrap.dm
@@ -124,26 +124,23 @@
 	icon = 'icons/obj/storage.dmi'
 	icon_state = "deliverycrateSmall"
 	var/sortTag
-	var/atom/movable/wrapped
 	flags = FPRINT
 
 /obj/item/delivery/New(turf/loc, var/obj/item/target = null, var/size = 2)
 	..()
 	w_class = size
-	wrapped = target
 	icon_state = "deliverycrate[min(size,5)]"
 
 /obj/item/delivery/Destroy()
-	if(wrapped)
-		wrapped.forceMove(get_turf(src.loc))
-	wrapped = null
+	for(var/atom/movable/AM in src)
+		AM.forceMove(loc)
 	..()
 
 /obj/item/delivery/attack_self(mob/user as mob)
-	if(wrapped)
+	user.drop_item(src, user.loc)
+	if(contents.len)
 		if(ishuman(user))
-			user.put_in_hands(wrapped)
-			wrapped = null
+			user.put_in_hands(contents[1])
 	qdel(src)
 
 /obj/item/delivery/attackby(obj/item/W as obj, mob/user as mob)
@@ -181,14 +178,13 @@
 /obj/item/delivery/large/New(turf/loc, atom/movable/target)
 	..()
 	w_class = W_CLASS_GIANT
-	wrapped = target
-	if(istype(wrapped,/obj/structure/closet/crate) || ishuman(target))
+	if(istype(target,/obj/structure/closet/crate) || ishuman(target))
 		icon_state = "deliverycrate"
-	else if(istype(wrapped,/obj/structure/vendomatpack))
+	else if(istype(target,/obj/structure/vendomatpack))
 		icon_state = "deliverypack"
-	else if(istype(wrapped,/obj/structure/stackopacks))
+	else if(istype(target,/obj/structure/stackopacks))
 		icon_state = "deliverystack"
-	else if(istype(wrapped,/obj/structure/closet))
+	else if(istype(target,/obj/structure/closet))
 		icon_state = "deliverycloset" //Only IF it isn't a crate-type
 
 /obj/item/delivery/large/attack_paw(mob/user as mob)

--- a/code/game/objects/items/stacks/packagewrap.dm
+++ b/code/game/objects/items/stacks/packagewrap.dm
@@ -32,7 +32,9 @@
 		)
 
 /obj/item/stack/package_wrap/afterattack(var/attacked, mob/user as mob, var/proximity_flag)
-	var/obj/target = attacked
+	var/atom/movable/target = attacked
+	if(!istype(target))
+		return
 	if(is_type_in_list(target, cannot_wrap))
 		return
 	if(target.anchored)

--- a/code/modules/Economy/Accounts.dm
+++ b/code/modules/Economy/Accounts.dm
@@ -98,7 +98,6 @@ var/global/list/all_money_accounts = list()
 		var/obj/item/delivery/P = new /obj/item/delivery(source_db.loc)
 
 		var/obj/item/weapon/paper/R = new /obj/item/weapon/paper(P)
-		P.wrapped = R
 		R.name = "Account information: [M.owner_name]"
 
 		R.info = {"<b>Account details (confidential)</b><br><hr><br>

--- a/code/modules/Economy/EFTPOS.dm
+++ b/code/modules/Economy/EFTPOS.dm
@@ -42,7 +42,6 @@
 	R.stamps += "<HR><i>This paper has been stamped by the EFTPOS device.</i>"
 	var/obj/item/delivery/D = new(R.loc)
 	R.forceMove(D)
-	D.wrapped = R
 	D.name = "small parcel - 'EFTPOS access code'"
 
 /obj/item/device/eftpos/proc/reconnect_database()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -365,9 +365,10 @@
 				L += get_contents(G.gift)
 
 		for(var/obj/item/delivery/D in Storage.return_inv()) //Check for package wrapped items
-			L += D.wrapped
-			if(istype(D.wrapped, /obj/item/weapon/storage)) //this should never happen
-				L += get_contents(D.wrapped)
+			for(var/atom/movable/wrapped in D) //Basically always only one thing, but could theoretically be more
+				L += wrapped
+				if(istype(wrapped, /obj/item/weapon/storage)) //this should never happen
+					L += get_contents(wrapped)
 		return L
 
 	else
@@ -385,9 +386,10 @@
 				L += get_contents(G.gift)
 
 		for(var/obj/item/delivery/D in src.contents) //Check for package wrapped items
-			L += D.wrapped
-			if(istype(D.wrapped, /obj/item/weapon/storage)) //this should never happen
-				L += get_contents(D.wrapped)
+			for(var/atom/movable/wrapped in D) //Basically always only one thing, but could theoretically be more
+				L += wrapped
+				if(istype(wrapped, /obj/item/weapon/storage)) //this should never happen
+					L += get_contents(wrapped)
 		return L
 
 /mob/living/proc/can_inject()

--- a/html/changelogs/Exxion.yml
+++ b/html/changelogs/Exxion.yml
@@ -1,0 +1,7 @@
+author: Exxion
+
+delete-after: True
+
+changes: 
+- bugfix: "Fixed package wrap nullspacing things. (Actually fixed this several days ago but I didn't realize how long the bug had been happening so I didn't changelog it. Whoops!)"
+- tweak: "Small wrapped packages now place the wrapped item in the same hand the package was in when opened."


### PR DESCRIPTION
1. (Only change with any gameplay significance in any scenario I'm aware is possible) Unwrapping a small package now places the contained item in the same hand the package was in. This is both way nicer to work with in-game and made part 4 easier to do. (The package is dropped to the user's `loc` before being unwrapped, which is relevant to both 3 and 4.)
2. Wrapped packages no longer have the capability to drag things back from `qdel`etion if they are somehow `qdel()`ed while wrapped
3. Similarly, wrapped packages now dump ALL contents when unwrapped rather than just the original wrapped object, meaning that if somehow a wrapped object drops other objects into the package, they will no longer be nullspaced. If the package is unwrapped in the hand, the first object in `contents` will attempt to be put in the user's hand, as long as they are a human. (Not sure why that restriction is there, but that's how it was when I found it.)
4. Wrapped packages now dump their `contents` to their `loc` rather than always onto the turf. I'm not aware of any scenarios in which this is relevant, but there probably are some, and that's how it should work anyway.
5. Wrapped packages no longer hold a reference to the originally-wrapped object because there's not really any need for them to. Just use `contents[1]` or iterate through instead.

P.S. I spotted lots of shitcode while working on this that I want to clean up at a later date

P.P.S. This also includes a changelog entry for the package wrap nullspacing fix because apparently people haven't all found out it got fixed yet because they aren't using it because they don't know it's fixed
