### PR TITLE
Reduces default release pressure of Emergency Nitrogen Tanks

### DIFF
--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -123,6 +123,7 @@
 	slot_flags = SLOT_BELT
 	w_class = W_CLASS_SMALL
 	volume = 2
+	distribute_pressure = ONE_ATMOSPHERE*O2STANDARD
 
 /obj/item/weapon/tank/emergency_nitrogen/New()
 	. = ..()


### PR DESCRIPTION
Seems like an odd inconsistency that they start at 101 rather than 24 like most other tanks.

I heard from a bird that they see a ton of vox waste Emergency Nitrogen Tanks by not adjusting the pressure.

tested on my local server
