### PR TITLE
Makes flash powder affect silicons

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -456,7 +456,7 @@
 
 		var/eye_safety = 0
 
-		for(var/mob/living/carbon/M in viewers(get_turf(holder.my_atom), null))
+		for(var/mob/living/M in viewers(get_turf(holder.my_atom), null))
 			if(iscarbon(M))
 				eye_safety = M.eyecheck()
 

--- a/html/changelogs/JustSomeFlash.yml
+++ b/html/changelogs/JustSomeFlash.yml
@@ -1,0 +1,7 @@
+
+author: JustSumGuy
+
+delete-after: True
+
+changes: 
+- tweak: "Flash powder reactions now stun silicons."


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.
-->

With the change to flashbangs affecting silicons a while back, it makes sense that flash powder(which does basically the same thing) should also affect silicons.
Discuss I guess
