### PR TITLE
Adds one and changes one Emagged cargo console supply packs ala @isaac in discord

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -574,11 +574,33 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/grenade/smokebomb,
 					/obj/item/weapon/grenade/smokebomb,
 					/obj/item/weapon/grenade/smokebomb,
-					/obj/item/weapon/pen/paralysis,
-					/obj/item/weapon/grenade/chem_grenade/incendiary)
+					/obj/item/weapon/gun/projectile/silenced,
+					/obj/item/ammo_storage/magazine/c45)
 	cost = 20
 	containertype = /obj/structure/closet/crate
 	containername = "Special Ops crate"
+	group = "Security"
+	hidden = 1
+
+/datum/supply_packs/randomised/russianguns
+	name = "Russian weapons"
+	num_contained = 3 //number of items picked to be contained in a randomised
+	contains = list(/obj/item/weapon/gun/projectile/nagant,
+					/obj/item/ammo_storage/speedloader/a762x55,
+					/obj/item/ammo_storage/speedloader/a762x55,
+					/obj/item/ammo_storage/speedloader/a762x55,
+					/obj/item/ammo_storage/speedloader/a762x55/empty,
+					/obj/item/ammo_storage/speedloader/a762x55/empty,
+					/obj/item/ammo_storage/speedloader/a762x55/empty,
+					/obj/item/ammo_storage/box/b762x55,
+					/obj/item/ammo_storage/box/b762x55,
+					/obj/item/ammo_storage/box/b762x55,
+					/obj/item/weapon/gun/energy/laser/LaserAK,
+					/obj/item/weapon/gun/energy/laser/LaserAK)
+	name = "Rusian Weapons"
+	cost = 150
+	containertype = /obj/structure/closet/crate
+	containername = "Russian Weapons"
 	group = "Security"
 	hidden = 1
 

--- a/html/changelogs/Isaac.yml
+++ b/html/changelogs/Isaac.yml
@@ -1,0 +1,7 @@
+author: Isaac
+
+delete-after: true
+
+changes: 
+- tweak: "The Special ops crate (emagged console) has its para-pen and incindeary grenade removed and replaced with a silenced pistol and ammo for said pistol."
+- rscadd: "Added a new crate for the emagged console, a russian weapons crate. It has a random three items chosen from the following pools, 1/12 a mosin nagant, 2/12 a laserAK, 3/12 a full 7.62 stripper clip, 3/12 an empty 7.62 stripper clip, 3/12 a 7.62 ammo box.

--- a/html/changelogs/Isaac.yml
+++ b/html/changelogs/Isaac.yml
@@ -4,4 +4,4 @@ delete-after: true
 
 changes: 
 - tweak: "The Special ops crate (emagged console) has its para-pen and incindeary grenade removed and replaced with a silenced pistol and ammo for said pistol."
-- rscadd: "Added a new crate for the emagged console, a russian weapons crate. It has a random three items chosen from the following pools, 1/12 a mosin nagant, 2/12 a laserAK, 3/12 a full 7.62 stripper clip, 3/12 an empty 7.62 stripper clip, 3/12 a 7.62 ammo box.
+- rscadd: "Added a new crate for the emagged console, a russian weapons crate. It has a random three items chosen from the following pools, 1/12 a mosin nagant, 2/12 a laserAK, 3/12 a full 7.62 stripper clip, 3/12 an empty 7.62 stripper clip, 3/12 a 7.62 ammo box."


### PR DESCRIPTION
Changes the spec-ops bundle to contain no parapen and no box of incendiary grenades, replaces it with silenced pistol and ammo for said pistol.

Adds a new bundle, Russian weapons crate, which costs 150 credits and gives you three random items, which can be a mosin nagant, ammo for this mosin nagant, empty ammo for the gun and laser aks.

@isaac cant into github so he asked me to PR it
