### PR TITLE
Multiplies spell prices and spellbook points by 5

### DIFF
--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -1,4 +1,4 @@
-#define STARTING_USES 5
+#define STARTING_USES 5 * Sp_BASE_PRICE
 
 /obj/item/weapon/spellbook
 	name = "spell book"
@@ -44,6 +44,10 @@
 	var/max_uses = STARTING_USES
 
 	var/op = 1
+
+/obj/item/weapon/spellbook/admin
+	uses = 30 * Sp_BASE_PRICE
+	op = 0
 
 /obj/item/weapon/spellbook/New()
 	..()
@@ -130,7 +134,7 @@
 				if(!max)
 					continue
 
-				upgrade_data += "<a href='?src=\ref[src];spell=\ref[spell];upgrade_type=[upgrade];upgrade_info=1'>[upgrade]</a>: [lvl]/[max] (<a href='?src=\ref[src];spell=\ref[spell];upgrade_type=[upgrade];upgrade=1'>upgrade</a>)  "
+				upgrade_data += "<a href='?src=\ref[src];spell=\ref[spell];upgrade_type=[upgrade];upgrade_info=1'>[upgrade]</a>: [lvl]/[max] (<a href='?src=\ref[src];spell=\ref[spell];upgrade_type=[upgrade];upgrade=1'>upgrade ([spell.get_upgrade_price(upgrade)] points)</a>)  "
 
 			if(upgrade_data)
 				dat += "[upgrade_data]<br><br>"
@@ -292,8 +296,9 @@
 		var/spell/spell = locate(href_list["spell"])
 
 		if(istype(spell) && spell.can_improve(upgrade_type))
-			if(use(Sp_UPGRADE_PRICE))
-				spell.refund_price += Sp_UPGRADE_PRICE
+			var/price = spell.get_upgrade_price(upgrade_type)
+			if(use(price))
+				spell.refund_price += price
 				var/temp = spell.apply_upgrade(upgrade_type)
 
 				if(temp)

--- a/code/modules/admin/verbs/antag_madness.dm
+++ b/code/modules/admin/verbs/antag_madness.dm
@@ -543,9 +543,7 @@ client/proc/antag_madness(var/mob/M in mob_list)
 			M.equip_to_slot_or_del(new/obj/item/device/radio/headset, slot_ears)
 			M.equip_to_slot_or_del(new/obj/item/clothing/under/lightpurple, slot_w_uniform)
 			M.equip_to_slot_or_del(new/obj/item/weapon/storage/backpack/satchel, slot_back)
-			var/obj/item/weapon/spellbook/S = new/obj/item/weapon/spellbook(M)
-			S.uses = 30
-			S.op = 0
+			var/obj/item/weapon/spellbook/S = new/obj/item/weapon/spellbook/admin(M)
 			M.put_in_hands(S)
 
 			var/obj/item/weapon/teleportation_scroll/T = new/obj/item/weapon/teleportation_scroll(M)

--- a/code/modules/spells/spell_code.dm
+++ b/code/modules/spells/spell_code.dm
@@ -477,6 +477,9 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 		if(Sp_POWER)
 			return empower_spell()
 
+/spell/proc/get_upgrade_price(upgrade_type)
+	return src.price
+
 ///INFO
 
 /spell/proc/get_upgrade_info(upgrade_type)

--- a/code/setup.dm
+++ b/code/setup.dm
@@ -1261,8 +1261,7 @@ var/default_colour_matrix = list(1,0,0,0,\
 #define GLOBALCAST -2
 
 //buying costs
-#define Sp_BASE_PRICE 1
-#define Sp_UPGRADE_PRICE 1
+#define Sp_BASE_PRICE 5
 
 ///////WIZ END/////////
 

--- a/html/changelogs/unid-cantrip.yml
+++ b/html/changelogs/unid-cantrip.yml
@@ -3,4 +3,4 @@ author: Unid
 delete-after: True
 
 changes: 
-- tweak: "The wizard's spellbook now starts with 25 points. Multiplied all spellbook prices by 5 (ordinary spells now cost 5 points, no clothes costs 10, spellbook bundle costs 25)."
+- tweak: "The wizard's spellbook now starts with 25 points. Multiplied all spellbook prices by 5 (ordinary spells now cost 5 points, no clothes costs 10, spellbook bundle costs 25). Effectively, all prices are still the same."

--- a/html/changelogs/unid-cantrip.yml
+++ b/html/changelogs/unid-cantrip.yml
@@ -1,0 +1,6 @@
+author: Unid
+
+delete-after: True
+
+changes: 
+- tweak: "The wizard's spellbook now starts with 25 points. Multiplied all spellbook prices by 5 (ordinary spells now cost 5 points, no clothes costs 10, spellbook bundle costs 25)."


### PR DESCRIPTION
Spellbook now has 25 points. Most spells now cost 5 points, no clothes costs 10, santa bundle costs 15, spellbook bundle costs 25.

Now we can have cheap spells and expensive spells. Like 2 point knock and 6 point jaunt.
I'll adjust prices and add some cheap cantrips soon
