### PR TITLE
Station Holomap hotfix

### DIFF
--- a/code/game/machinery/station_map.dm
+++ b/code/game/machinery/station_map.dm
@@ -117,8 +117,14 @@ var/list/station_holomaps = list()
 /obj/machinery/station_map/attack_animal(var/mob/user)
 	src.attack_hand(user)
 
-/obj/machinery/station_map/attack_ai(var/mob/user)
-	return//TODO: Give AIs their own holomap
+/obj/machinery/station_map/attack_ghost(var/mob/user)
+	if(blessed)
+		return
+	add_hiddenprint(user)
+	flick("station_map_activate", src)
+
+/obj/machinery/station_map/attack_ai(var/mob/living/silicon/robot/user)
+	user.station_holomap.toggleHolomap(src)
 
 /obj/machinery/station_map/process()
 	if((stat & (NOPOWER|BROKEN)) || !anchored)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -843,7 +843,7 @@ var/list/ai_list = list()
 	set name = "Toggle Station Holomap"
 	set desc = "Toggle station holomap on your screen"
 	set category = "AI Commands"
-	if(!isUnconscious())
+	if(isUnconscious())
 		return
 
 	station_holomap.toggleHolomap(src,1)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -536,7 +536,7 @@
 	set name = "Toggle Station Holomap"
 	set desc = "Toggle station holomap on your screen"
 	set category = "Robot Commands"
-	if(!isUnconscious())
+	if(isUnconscious())
 		return
 
 	station_holomap.toggleHolomap(src)

--- a/html/changelogs/JMWTurner-StationMapFix.yml
+++ b/html/changelogs/JMWTurner-StationMapFix.yml
@@ -1,0 +1,4 @@
+author: JMWTurner
+delete-after: true
+changes:
+  - bugfix: Fixed silicon integrated station maps not working


### PR DESCRIPTION
- Fixed borgs and AI being unable to activate their holomaps
- Ghosts can flicker holomaps by touching them
