### PR TITLE
Breaking double shotguns doesn't make shells appear right on top of each other

### DIFF
--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -110,8 +110,8 @@
 	var/i = 0
 	for(var/obj/item/ammo_casing/shotgun/loaded_shell in src) //This feels like a hack. don't code at 3:30am kids!!
 		loaded_shell.forceMove(get_turf(src))
-		loaded_shell.pixel_x = -3 + (i*4)
-		loaded_shell.pixel_y =  3 - (i*4)
+		loaded_shell.pixel_x = min(-3 + (i*4),15) * PIXEL_MULTIPLIER
+		loaded_shell.pixel_y = min( 3 - (i*4),15) * PIXEL_MULTIPLIER
 		if(loaded_shell in loaded)
 			loaded -= loaded_shell
 		i++

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -107,10 +107,14 @@
 		to_chat(user, "<span class='notice'>\The [src] is empty.</span>")
 		return
 
+	var/i = 0
 	for(var/obj/item/ammo_casing/shotgun/loaded_shell in src) //This feels like a hack. don't code at 3:30am kids!!
 		loaded_shell.forceMove(get_turf(src))
+		loaded_shell.pixel_x = -3 + (i*4)
+		loaded_shell.pixel_y =  3 - (i*4)
 		if(loaded_shell in loaded)
 			loaded -= loaded_shell
+		i++
 
 	to_chat(user, "<span class='notice'>You break \the [src].</span>")
 	update_icon()


### PR DESCRIPTION
Often confuses me about whether I dropped either one or two shells.
before
![before](https://cloud.githubusercontent.com/assets/21122521/18475903/736c519a-79c8-11e6-8dc6-fa11e2977bdf.png)

after
![after](https://cloud.githubusercontent.com/assets/21122521/18475904/7417d916-79c8-11e6-8a98-1390088ddc21.png)
