### PR TITLE
Fixes an issue with advanced buildmode's middle mouse copy thing

### DIFF
--- a/code/WorkInProgress/buildmode.dm
+++ b/code/WorkInProgress/buildmode.dm
@@ -618,11 +618,11 @@ obj/effect/bmode/buildholder/New()
 					to_chat(usr, "<span class='notice'>You don't have sufficient rights to clone [object.type]</span>")
 				else
 					if(ismob(object))
-						holder.buildmode.objholder = object.type
-						to_chat(usr, "<span class='info'>You will now build [object.type] when clicking.</span>")
-					else
 						holder.buildmode.copycat = object
 						to_chat(usr, "<span class='info'>You will now build a lookalike of [object] when clicking.</span>")
+					else
+						holder.buildmode.objholder = object.type
+						to_chat(usr, "<span class='info'>You will now build [object.type] when clicking.</span>")
 
 		if(3)
 			if(pa.Find("left")) //I cant believe this shit actually compiles.


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.
-->

closes #11553
So now it actually lets you left click build/mass fill things you've copied with middle mouse, 
Tested it and didn't see any issues, but I don't understand a single thing happening in this file so it's entirely possible this breaks something
