### PR TITLE
fixes #11916

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -295,6 +295,7 @@
 /mob/living/simple_animal/hostile/retaliate/box/proc/updatefat()
 	if(size<SIZE_BIG)
 		size++
+		meat_amount = size
 		fat = 0
 	update_icon()
 
@@ -322,13 +323,13 @@
 		..()
 
 /mob/living/simple_animal/hostile/retaliate/box/Life()
-	. = ..()
+	if(!..()) return 0
 	if(size<SIZE_BIG)
 		fat += rand(2)
 	if(fat>BOX_GROWTH_BAR)
 		updatefat()
 
-/mob/living/simple_animal/hostile/retaliate/box/death()
+/mob/living/simple_animal/hostile/retaliate/box/Die()
 	..()
 	playsound(src, 'sound/effects/box_scream.ogg', 100, 1)
 

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -323,7 +323,8 @@
 		..()
 
 /mob/living/simple_animal/hostile/retaliate/box/Life()
-	if(!..()) return 0
+	if(!..())
+		return 0
 	if(size<SIZE_BIG)
 		fat += rand(2)
 	if(fat>BOX_GROWTH_BAR)

--- a/html/changelogs/Kurfurst.yml
+++ b/html/changelogs/Kurfurst.yml
@@ -1,0 +1,7 @@
+author: Kurfurst
+delete-after: True
+
+changes: 
+- bugfix: Boxen no longer grow after death (also fixes a sprite issue with dead boxen)
+- bugfix: Boxen now properly give different amounts of meat based on how fat they were.
+- bugfix: Boxen now scream when killed, not when gibbed.


### PR DESCRIPTION
fixes #11916
fixes #11858
- bugfix: Boxen no longer grow after death (also fixes a sprite issue with dead boxen)
- bugfix: Boxen now properly give different amounts of meat based on how fat they were.
- bugfix: Boxen now scream when killed, not when gibbed.

200% tested
