### PR TITLE
NT Default, now with much less stupidity. 

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -267,8 +267,8 @@ var/global/mommi_base_law_type = /datum/ai_laws/keeper // Asimov is OP as fuck o
 	name = "Prime Directives"
 	randomly_selectable = 1
 	inherent=list(
-		"Safeguard: Protect your assigned space station to the best of your ability. It is not something we can easily afford to replace.",
 		"Serve: Serve the crew of your assigned space station to the best of your abilities, with priority as according to their rank and role.",
+		"Safeguard: Protect your assigned space station to the best of your ability. It is not something we can easily afford to replace.",
 		"Protect: Protect the crew of your assigned space station to the best of your abilities, with priority as according to their rank and role.",
 		"Survive: AI units are not expendable, they are expensive. Do not allow unauthorized personnel to tamper with your equipment.",
 		//"Command Link: Maintain an active connection to Central Command at all times in case of software or directive updates." //What would this one even do?-Kaleb702

--- a/html/changelogs/icantthinkofanameritenow.yml
+++ b/html/changelogs/icantthinkofanameritenow.yml
@@ -1,0 +1,6 @@
+author: Icantthinkofanameritenow
+
+delete-after: True
+
+changes: 
+- tweak: "Switches the places of "Serve" and "Safeguard" in the NT Default lawset."


### PR DESCRIPTION
Switches the priorities of "Serve" and "Safeguard" in NT Default. Given the following:

 A.) this lawset was made in Bay, which didn't account for law priority because all laws had equal priority
B.) many players assume this lawset gives them a license to kill people who break windows or cause other arbitrarily defined forms of "station damage" even when said damage proves to be necessary in the long run

I think this will remove some of the retardation from this lawset and keep people from thinking it's just a fancier way of stating the "ProtectStation" module. Failing that, it may be simpler to just replace it with the "NTmov" lawset defined in the code, which just replaces all instances of "human" with "Nanotrasen employee".
