### PR TITLE
Minor solar panel changes

### DIFF
--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -49,7 +49,6 @@ var/list/solars_list = list()
 	if(!anchored && isturf(loc))
 		if(iswrench(W))
 			anchored = 1
-			density = 1
 			user.visible_message("<span class='notice'>[user] wrenches [src] down.</span>", \
 			"<span class='notice'>You wrench [src] down.</span>")
 			playsound(get_turf(src), 'sound/items/Ratchet.ogg', 75, 1)
@@ -57,7 +56,6 @@ var/list/solars_list = list()
 	else
 		if(iswrench(W))
 			anchored = 0
-			density = 0
 			user.visible_message("<span class='notice'>[user] unwrenches [src] from the ground.</span>", \
 			"<span class='notice'>You unwrench [src] from the ground.</span>")
 			playsound(get_turf(src), 'sound/items/Ratchet.ogg', 75, 1)

--- a/code/modules/power/solars/panel.dm
+++ b/code/modules/power/solars/panel.dm
@@ -48,6 +48,7 @@
 			qdel(src)
 	else if(W)
 		add_fingerprint(user)
+		user.delayNextAttack(10)
 		health -= W.force
 		healthcheck()
 	..()

--- a/code/modules/power/solars/panel.dm
+++ b/code/modules/power/solars/panel.dm
@@ -1,5 +1,6 @@
 /obj/machinery/power/solar/panel
 	icon_state = "sp_base"
+	density = 1
 	var/id_tag = 0
 	var/health = 15 //Fragile shit, even with state-of-the-art reinforced glass
 	var/maxhealth = 15 //If ANYONE ever makes it so that solars can be directly repaired without glass, also used for fancy calculations
@@ -22,7 +23,6 @@
 		solar_assembly = new /obj/machinery/power/solar_assembly()
 		solar_assembly.glass_type = /obj/item/stack/sheet/glass/rglass
 		solar_assembly.anchored = 1
-		solar_assembly.density = 1
 		solar_assembly.tracker = tracker
 	else
 		solar_assembly = S
@@ -61,9 +61,15 @@
 
 	healthcheck()
 
+/obj/machinery/power/solar/panel/bullet_act(var/obj/item/projectile/Proj)
+	if(Proj.damage)
+		health -= Proj.damage
+		healthcheck()
+	..()
+
 /obj/machinery/power/solar/panel/proc/healthcheck()
 	if(health <= 0)
-		if(!(stat & BROKEN))
+		if(!(stat & BROKEN) && health > -maxhealth)
 			broken()
 		else
 			var/obj/item/stack/sheet/glass/G = solar_assembly.glass_type

--- a/code/modules/power/solars/panel.dm
+++ b/code/modules/power/solars/panel.dm
@@ -1,6 +1,5 @@
 /obj/machinery/power/solar/panel
 	icon_state = "sp_base"
-	density = 1
 	var/id_tag = 0
 	var/health = 15 //Fragile shit, even with state-of-the-art reinforced glass
 	var/maxhealth = 15 //If ANYONE ever makes it so that solars can be directly repaired without glass, also used for fancy calculations


### PR DESCRIPTION
Solar panels can now take damage from projectiles.
Solar assemblies now don't become dense when wrenched to the ground, only when the glass is added.
If a solar panel takes enough damage it can go straight to being destroyed, rather than always going through the broken state.
