### PR TITLE
Removes tile painter paint delay

### DIFF
--- a/code/modules/RCD/schematics/tile.dm
+++ b/code/modules/RCD/schematics/tile.dm
@@ -18,10 +18,6 @@
 /datum/rcd_schematic/clear_decals/attack(var/turf/A, var/mob/user)
 	to_chat(user, "Clearing decals...")
 	playsound(get_turf(master), 'sound/effects/spray3.ogg', 15, 1)
-	if (!do_after(user, A, 20))
-		return 1
-
-	playsound(get_turf(master), 'sound/machines/click.ogg', 50, 1)
 
 	A.ClearDecals()
 
@@ -118,10 +114,6 @@
 	to_chat(user, "Painting floor...")
 	//playsound(get_turf(master), 'sound/AI/animes.ogg', 50, 1)
 	playsound(get_turf(master), 'sound/effects/spray3.ogg', 15, 1)
-	if (!do_after(user, A, 20))
-		return 1
-
-	playsound(get_turf(master), 'sound/machines/click.ogg', 50, 1)
 
 	selection.apply(A, nname, ndesc, thisdir)
 


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.
-->


Since you cant change the painting type while you are currently painting easily, and they're simply no balance reason that 'painting' would ever need a delay.