### PR TITLE
Nuke ops, deathsquad implants can be surgeried out

### DIFF
--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -295,7 +295,7 @@
 	var/obj/item/weapon/implant/explosive/E = new/obj/item/weapon/implant/explosive/nuclear(synd_mob)
 	E.imp_in = synd_mob
 	E.implanted = 1
-	var/datum/organ/external/affected = synd_mob.get_organ(LIMB_CHEST)
+	var/datum/organ/external/affected = synd_mob.get_organ(LIMB_HEAD)
 	affected.implants += E
 	E.part = affected
 	synd_mob.update_icons()

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -295,6 +295,9 @@
 	var/obj/item/weapon/implant/explosive/E = new/obj/item/weapon/implant/explosive/nuclear(synd_mob)
 	E.imp_in = synd_mob
 	E.implanted = 1
+	var/datum/organ/external/affected = synd_mob.get_organ(LIMB_CHEST)
+	affected.implants += E
+	E.part = affected
 	synd_mob.update_icons()
 	return 1
 

--- a/code/game/response_team.dm
+++ b/code/game/response_team.dm
@@ -335,6 +335,9 @@ proc/trigger_armed_response_team(var/force = 0)
 	var/obj/item/weapon/implant/loyalty/L = new/obj/item/weapon/implant/loyalty(src)
 	L.imp_in = src
 	L.implanted = 1
+	var/datum/organ/external/affected = get_organ(LIMB_HEAD)
+	affected.implants += L
+	L.part = affected
 
 	return 1
 

--- a/code/modules/admin/verbs/striketeam.dm
+++ b/code/modules/admin/verbs/striketeam.dm
@@ -162,15 +162,14 @@ var/global/sent_strike_team = 0
 	var/obj/item/weapon/implant/loyalty/L = new/obj/item/weapon/implant/loyalty(src)//Here you go Deuryn
 	L.imp_in = src
 	L.implanted = 1
-	var/datum/organ/external/affectedL = get_organ(LIMB_HEAD)
-	affectedL.implants += L
-	L.part = affectedL
 	var/obj/item/weapon/implant/explosive/E = new/obj/item/weapon/implant/explosive/nuclear(src)
 	E.imp_in = src
 	E.implanted = 1
-	var/datum/organ/external/affectedE = get_organ(LIMB_CHEST)
-	affectedE.implants += E
-	E.part = affectedE
+	var/datum/organ/external/affected = get_organ(LIMB_HEAD)
+	affected.implants += L
+	L.part = affected
+	affected.implants += E
+	E.part = affected
 	src.update_icons()
 
 

--- a/code/modules/admin/verbs/striketeam.dm
+++ b/code/modules/admin/verbs/striketeam.dm
@@ -162,9 +162,15 @@ var/global/sent_strike_team = 0
 	var/obj/item/weapon/implant/loyalty/L = new/obj/item/weapon/implant/loyalty(src)//Here you go Deuryn
 	L.imp_in = src
 	L.implanted = 1
-	var/obj/item/weapon/implant/explosive/E = new/obj/item/weapon/implant/explosive(src)
+	var/datum/organ/external/affectedL = get_organ(LIMB_HEAD)
+	affectedL.implants += L
+	L.part = affectedL
+	var/obj/item/weapon/implant/explosive/E = new/obj/item/weapon/implant/explosive/nuclear(src)
 	E.imp_in = src
 	E.implanted = 1
+	var/datum/organ/external/affectedE = get_organ(LIMB_CHEST)
+	affectedE.implants += E
+	E.part = affectedE
 	src.update_icons()
 
 

--- a/code/modules/admin/verbs/striketeam_syndicate.dm
+++ b/code/modules/admin/verbs/striketeam_syndicate.dm
@@ -181,7 +181,7 @@ var/global/sent_syndicate_strike_team = 0
 	var/obj/item/weapon/implant/explosive/E = new/obj/item/weapon/implant/explosive/nuclear(src) //no loyalty implant because you're already syndicate scum
 	E.imp_in = src
 	E.implanted = 1
-	var/datum/organ/external/affected = get_organ(LIMB_CHEST)
+	var/datum/organ/external/affected = get_organ(LIMB_HEAD)
 	affected.implants += E
 	E.part = affected
 	src.update_icons()

--- a/code/modules/admin/verbs/striketeam_syndicate.dm
+++ b/code/modules/admin/verbs/striketeam_syndicate.dm
@@ -178,9 +178,12 @@ var/global/sent_syndicate_strike_team = 0
 	W.registered_name = real_name
 	equip_to_slot_or_del(W, slot_wear_id)
 
-	var/obj/item/weapon/implant/explosive/E = new/obj/item/weapon/implant/explosive(src) //no loyalty implant because you're already syndicate scum
+	var/obj/item/weapon/implant/explosive/E = new/obj/item/weapon/implant/explosive/nuclear(src) //no loyalty implant because you're already syndicate scum
 	E.imp_in = src
 	E.implanted = 1
+	var/datum/organ/external/affected = get_organ(LIMB_CHEST)
+	affected.implants += E
+	E.part = affected
 	src.update_icons()
 
 	return 1


### PR DESCRIPTION
Nuke ops, deathsquad, syndicate deathsquad, and ERT implants now have bodyparts set so they can be removed surgically.
Deathsquad and syndicate deathsquad explosive implants are now the EMP-proof nuke op versions.
