### PR TITLE
Allows condiments to be stored in the kitchen/botany smartfridge

### DIFF
--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -23,7 +23,8 @@
 									/obj/item/weapon/grown,
 									/obj/item/seeds/,
 									/obj/item/weapon/reagent_containers/food/snacks/meat,
-									/obj/item/weapon/reagent_containers/food/snacks/egg)
+									/obj/item/weapon/reagent_containers/food/snacks/egg,
+									/obj/item/weapon/reagent_containers/food/condiment)
 
 	machine_flags = SCREWTOGGLE | CROWDESTROY | EJECTNOTDEL
 


### PR DESCRIPTION
First pull request.

Just means chef can add condiments (such as flour, sugar, salt, ketchup, gravy) to his smart fridge. It was already possible to add condiments to the drinks smart fridge, but I don't think anyone uses that machine, AND I don't think any bartender really needs gravy in his non existent fridge. That said, didn't change anything about drinks fridge, just added the ability to put condies in chef fridge.

ONE HUNDRED PERCENT TESTED (misc condiment bottles don't differentiate within the fridge even if they have different reagents inside. In pic one bottle had water, the other had ice, dunno if this is an issue for anyone.)
http://imgur.com/a/Q04dZ

(was thinking of making a non-powered wooden condiment/spice rack, but that is far beyond my coding abilities, so here is a much easier fix to something that doesn't really matter)
