### PR TITLE
Radiation collector tweak/experiment

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -378,7 +378,7 @@ proc/checkhtml(var/t)
 var/global/list/watt_suffixes = list("W", "KW", "MW", "GW", "TW", "PW", "EW", "ZW", "YW")
 /proc/format_watts(var/number)
 	if(number<0)
-		return "-[format_watts(number)]"
+		return "-[format_watts(abs(number))]"
 	if(number==0)
 		return "0 W"
 

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -1,3 +1,5 @@
+#define COLLECTOR_RAD_COEFFICIENT 25 // don't ask me how I got this number anymore
+
 //This file was auto-corrected by findeclaration.exe on 25.5.2012 20:42:33
 var/global/list/rad_collectors = list()
 
@@ -128,7 +130,11 @@ var/global/list/rad_collectors = list()
 
 /obj/machinery/power/rad_collector/proc/receive_pulse(const/pulse_strength)
 	if (P && active)
-		var/power_produced = P.air_contents.toxins * pulse_strength * 3.5 // original was 20, nerfed to 2 now 3.5 should get you about 500kw
+		// pre-logarithmic curve
+		// var/power_produced = P.air_contents.toxins * pulse_strength * 3.5 // original was 20, nerfed to 2 now 3.5 should get you about 500kw
+		var/power_produced = COLLECTOR_RAD_COEFFICIENT * sqrt(pulse_strength * P.air_contents.toxins * log(pulse_strength ^ P.air_contents.toxins))
+		// For anyone interested: this was the result of the square root of a log curve and the old linear equation.
+		// Log curve was y=log (x^z)* 175
 		add_avail(power_produced)
 		last_power = power_produced
 
@@ -153,4 +159,3 @@ var/global/list/rad_collectors = list()
 		last_power = 0
 
 	update_icons()
-

--- a/html/changelogs/Sood.yml
+++ b/html/changelogs/Sood.yml
@@ -1,3 +1,3 @@
 author: Sood
 changes:
- - experiment: Power output from radiation collectors now follows a combination of a logarithmic curve and the old linear equation. This means that you will get diminishing returns from radiation sources as pulse strength exceeds 100. In other words, SME gets nerfed, low level singulos get buffed, and max singulo output remains exactly the same. Values may be tweaked as needed, and revert may follow if this turns out to be an awful idea or something.
+ - experiment: Power output from radiation collectors now follows a combination of a logarithmic curve and the old linear equation. This means that you will get diminishing returns from radiation sources as pulse strength exceeds 100. In other words, SME and singulo both get a nerf. Values may be tweaked as needed, and revert may follow if this turns out to be an awful idea or something.

--- a/html/changelogs/Sood.yml
+++ b/html/changelogs/Sood.yml
@@ -1,3 +1,3 @@
 author: Sood
 changes:
- - experiment: Power output from radiation collectors now follows a combination of a logarithmic curve and the old linear equation. This means that you will get diminishing returns from radiation sources as pulse strength exceeds 100. In other words, SME and singulo both get a nerf. Values may be tweaked as needed, and revert may follow if this turns out to be an awful idea or something.
+ - experiment: Power output from radiation collectors now follows a combination of a logarithmic curve and the old linear equation. This means that you will get diminishing returns from radiation sources as pulse strength exceeds around 2000. In other words, this nerfs energy collection from singulos and SMEs both when working very large bursts of radiation, but lower values get a significant bump. Values may be tweaked as needed, and revert may follow if this turns out to be an awful idea or something.

--- a/html/changelogs/Sood.yml
+++ b/html/changelogs/Sood.yml
@@ -1,2 +1,3 @@
 author: Sood
-changes: []
+changes:
+ - experiment: Power output from radiation collectors now follows a combination of a logarithmic curve and the old linear equation. This means that you will get diminishing returns from radiation sources as pulse strength exceeds 100. In other words, SME gets nerfed, low level singulos get buffed, and max singulo output remains exactly the same. Values may be tweaked as needed, and revert may follow if this turns out to be an awful idea or something.


### PR DESCRIPTION
The change to format_text.dm just fixes an infinite loop if the formatted value is negative.
# I updated this to reflect some misunderstandings on my part of what this would affect.

The rest of this PR changes radiation collectors.
Power output from radiation collectors now follows a combination of a logarithmic curve and the old linear equation. This means that you will get diminishing returns from radiation sources as pulse strength exceeds 2000, although the point at which those returns become unviable is probably much higher.

In other words, this nerfs energy collection from singulos and SMEs both when working very large bursts of radiation, but lower values get a significant bump.

So autists will have a harder time getting miniature suns worth of energy, and casual engineers will have a somewhat easier time of it. But it isn't a plateau like the logarithmic curve I was going to use. Good outputs will still output more than bad by a VERY large margin.

![](http://i.imgur.com/e8joG0H.png)
Red is the old method, green is the method I _was_ going to use initially, and purple is the new method (which was the sqrt of the product of both curves)
`p` is just the value of an tank's worth of uncooled plasma.
https://www.desmos.com/calculator/skca9ntrwj this is the graph so you  can mess with values if  you'd like.

For my own reference, the coefficient was 24.7487 before I messed with it.
Also big thanks to Rhaplanca for the math help.
