### PR TITLE
Hotfix for statfile names causing parser to discard them.

### DIFF
--- a/code/datums/statistics/statcollection.dm
+++ b/code/datums/statistics/statcollection.dm
@@ -209,7 +209,7 @@
 	var/uniquefilename = time2text(round_start_time, "HHMMSS")
 	// Iterate until we have an unused file.
 	while(fexists(file(("[STAT_OUTPUT_DIR]statistics_[filename_date].[uniquefilename].txt"))))
-		uniquefilename = uniquefilename += "1"
+		uniquefilename = "[uniquefilename].dupe"
 	var/statfile = file("[STAT_OUTPUT_DIR]statistics_[filename_date].[uniquefilename].txt")
 
 	world << "Writing statistics to file"

--- a/code/datums/statistics/statcollection.dm
+++ b/code/datums/statistics/statcollection.dm
@@ -206,11 +206,11 @@
 
 /datum/stat_collector/proc/Process()
 	var/filename_date = time2text(round_start_time, "YYYY.DD.MM")
-	var/roundnum = 1
+	var/uniquefilename = time2text(round_start_time, "HHMMSS")
 	// Iterate until we have an unused file.
-	while(fexists(file(("[STAT_OUTPUT_DIR]statistics_[filename_date].[roundnum].txt"))))
-		roundnum++
-	var/statfile = file("[STAT_OUTPUT_DIR]statistics_[filename_date].[roundnum].txt")
+	while(fexists(file(("[STAT_OUTPUT_DIR]statistics_[filename_date].[uniquefilename].txt"))))
+		uniquefilename = uniquefilename += "1"
+	var/statfile = file("[STAT_OUTPUT_DIR]statistics_[filename_date].[uniquefilename].txt")
 
 	world << "Writing statistics to file"
 


### PR DESCRIPTION
Titty Chicken - Today at 2:47 PM
2016-10-05 03:48:41,690  ~ ~ Duplicate parse entry detected.)
                            ~ ~ Request filename: statistics_2016.05.10.1.txt
Sood - Today at 2:47 PM
oh god damnit
Sood - Today at 2:47 PM
i know exactly what's going on with that
the naming convention works based off of what files are in the dir
statistics_2016.05.10.1.txt gets made, then statistics_2016.05.10.2.txt, but because 1 got parsed the next one will be 1 again
