### PR TITLE
Traitor steal objective tweaks

### DIFF
--- a/code/game/gamemodes/steal_items.dm
+++ b/code/game/gamemodes/steal_items.dm
@@ -212,16 +212,18 @@
 		var/found_amount = 0
 		for(var/obj/I in all_items) //Check for items
 			if(istype(I, typepath))
+			
 				//Stealing the cheap autoinjector doesn't count
 				if(istype(I, /obj/item/weapon/reagent_containers/hypospray/autoinjector))
 					continue
+
 				if(istype(I,/obj/item/device/aicard))
 					var/obj/item/device/aicard/C = I
 					if(!C.contents.len)
 						continue //Stealing a card with no contents doesn't count
 					var/is_at_least_one_alive = 0
 					for(var/mob/living/silicon/ai/A in C)
-						if(A.stat != DEAD)
+						if(A.stat != 2)
 							is_at_least_one_alive++
 					if(!is_at_least_one_alive)
 						continue

--- a/code/game/gamemodes/steal_items.dm
+++ b/code/game/gamemodes/steal_items.dm
@@ -72,7 +72,7 @@
 /datum/theft_objective/traitor/rcd
 	name = "an RCD"
 	typepath = /obj/item/device/rcd/matter/engineering
-	protected_jobs = list("Chief Engineer")
+	protected_jobs = list("Chief Engineer", "Atmospherics Technician", "Station Engineer")
 
 /datum/theft_objective/traitor/rpd
 	name = "an RPD"
@@ -87,14 +87,12 @@
 /datum/theft_objective/traitor/cap_jumpsuit
 	name = "the captain's jumpsuit"
 	typepath = /obj/item/clothing/under/rank/captain
-	protected_jobs = list("Captain")
+	protected_jobs = list("Captain", "Head of Personnel")
 
-/*
 /datum/theft_objective/traitor/ai
 	name = "a functional AI"
 	typepath = /obj/item/device/aicard
-*/
-
+	protected_jobs = list("Captain", "Research Director", "Head of Personnel")
 
 /datum/theft_objective/traitor/magboots
 	name = "a pair of advanced magboots"
@@ -124,22 +122,22 @@
 /datum/theft_objective/traitor/rd_jumpsuit
 	name = "the research director's jumpsuit"
 	typepath = /obj/item/clothing/under/rank/research_director
-	protected_jobs = list("Captain", "Research Director")
+	protected_jobs = list("Captain", "Research Director", "Head of Personnel")
 
 /datum/theft_objective/traitor/ce_jumpsuit
 	name = "the chief engineer's jumpsuit"
 	typepath = /obj/item/clothing/under/rank/chief_engineer
-	protected_jobs = list("Captain", "Chief Engineer")
+	protected_jobs = list("Captain", "Chief Engineer", "Head of Personnel")
 
 /datum/theft_objective/traitor/cmo_jumpsuit
 	name = "the chief medical officer's jumpsuit"
 	typepath = /obj/item/clothing/under/rank/chief_medical_officer
-	protected_jobs = list("Captain", "Chief Medical Officer")
+	protected_jobs = list("Captain", "Chief Medical Officer", "Head of Personnel")
 
 /datum/theft_objective/traitor/hos_jumpsuit
 	name = "the head of security's jumpsuit"
 	typepath = /obj/item/clothing/under/rank/head_of_security
-	protected_jobs = list("Captain", "Head of Security")
+	protected_jobs = list("Captain", "Head of Security", "Head of Personnel")
 
 /datum/theft_objective/traitor/hop_jumpsuit
 	name = "the head of personnel's jumpsuit"
@@ -169,17 +167,12 @@
 /datum/theft_objective/traitor/planningframe
 	name = "the law planning frame"
 	typepath = /obj/item/weapon/planning_frame
-	protected_jobs = list("Captain", "Research Director", "Chief Engineer")
+	protected_jobs = list("Captain", "Research Director", "Chief Engineer", "Head of Personnel")
 
 /datum/theft_objective/traitor/belt
 	name = "the chief engineers advanced toolbelt"
 	typepath = /obj/item/weapon/storage/belt/utility/chief
 	protected_jobs = list("Captain", "Chief Engineer")
-
-/datum/theft_objective/traitor/antibody
-	name = "an antibody scanner"
-	typepath = /obj/item/device/antibody_scanner
-	protected_jobs = list("Chief Medical Officer", "Medical Doctor")
 
 /datum/theft_objective/traitor/ttv
 	name = "a tank transfer valve"

--- a/code/game/gamemodes/steal_items.dm
+++ b/code/game/gamemodes/steal_items.dm
@@ -77,20 +77,23 @@
 /datum/theft_objective/traitor/rpd
 	name = "an RPD"
 	typepath = /obj/item/device/rcd/rpd
-	protected_jobs = list("Chief Engineer", "Atmospherics Technician")
+	protected_jobs = list("Chief Engineer", "Atmospherics Technician", "Station Engineer")//engineers have atmos access.
 
 /datum/theft_objective/traitor/jetpack
 	name = "a jetpack"
 	typepath = /obj/item/weapon/tank/jetpack
+	protected_jobs = list("Chief Engineer", "Captain", "Trader", "Atmospherics Technician", "Station Engineer", "Shaft Miner")
 
 /datum/theft_objective/traitor/cap_jumpsuit
 	name = "the captain's jumpsuit"
 	typepath = /obj/item/clothing/under/rank/captain
 	protected_jobs = list("Captain")
 
+/*
 /datum/theft_objective/traitor/ai
 	name = "a functional AI"
 	typepath = /obj/item/device/aicard
+*/
 
 
 /datum/theft_objective/traitor/magboots
@@ -116,31 +119,32 @@
 /datum/theft_objective/traitor/corgi
 	name = "a piece of corgi meat"
 	typepath = /obj/item/weapon/reagent_containers/food/snacks/meat/animal/corgi
+	protected_jobs = list("Head of Personnel") //Really HoP? Your own dog?
 
 /datum/theft_objective/traitor/rd_jumpsuit
 	name = "the research director's jumpsuit"
 	typepath = /obj/item/clothing/under/rank/research_director
-	protected_jobs = list("Research Director")
+	protected_jobs = list("Captain", "Research Director")
 
 /datum/theft_objective/traitor/ce_jumpsuit
 	name = "the chief engineer's jumpsuit"
 	typepath = /obj/item/clothing/under/rank/chief_engineer
-	protected_jobs = list("Chief Engineer")
+	protected_jobs = list("Captain", "Chief Engineer")
 
 /datum/theft_objective/traitor/cmo_jumpsuit
 	name = "the chief medical officer's jumpsuit"
 	typepath = /obj/item/clothing/under/rank/chief_medical_officer
-	protected_jobs = list("Chief Medical Officer")
+	protected_jobs = list("Captain", "Chief Medical Officer")
 
 /datum/theft_objective/traitor/hos_jumpsuit
 	name = "the head of security's jumpsuit"
 	typepath = /obj/item/clothing/under/rank/head_of_security
-	protected_jobs = list("Head of Security")
+	protected_jobs = list("Captain", "Head of Security")
 
 /datum/theft_objective/traitor/hop_jumpsuit
 	name = "the head of personnel's jumpsuit"
 	typepath = /obj/item/clothing/under/rank/head_of_personnel
-	protected_jobs = list("Head of Personnel")
+	protected_jobs = list("Captain", "Head of Personnel")
 
 /datum/theft_objective/traitor/hypospray
 	name = "a hypospray"
@@ -155,7 +159,33 @@
 /datum/theft_objective/traitor/ablative
 	name = "an ablative armor vest"
 	typepath = /obj/item/clothing/suit/armor/laserproof
-	protected_jobs = list("Head of Security", "Warden")
+	protected_jobs = list("Captain", "Head of Security", "Warden")
+
+/datum/theft_objective/traitor/telebaton
+	name = "a telescopic baton"
+	typepath = /obj/item/weapon/melee/telebaton
+	protected_jobs = list("Captain", "Head of Security")
+
+/datum/theft_objective/traitor/planningframe
+	name = "the law planning frame"
+	typepath = /obj/item/weapon/planning_frame
+	protected_jobs = list("Captain", "Research Director")
+
+/datum/theft_objective/traitor/belt
+	name = "the advanced toolbelt"
+	typepath = /obj/item/weapon/storage/belt/utility/chief
+	protected_jobs = list("Captain", "Chief Engineer")
+
+/datum/theft_objective/traitor/antibody
+	name = "an antibody scanner"
+	typepath = /obj/item/device/antibody_scanner
+	protected_jobs = list("Chief Medical Officer", "Medical Doctor")
+
+/datum/theft_objective/traitor/ttv
+	name = "a tank transfer valve"
+	typepath = /obj/item/device/transfer_valve
+	protected_jobs = list("Research Director", "Scientist")
+
 
 /datum/theft_objective/number
 	var/min=0

--- a/code/game/gamemodes/steal_items.dm
+++ b/code/game/gamemodes/steal_items.dm
@@ -67,7 +67,7 @@
 /datum/theft_objective/traitor/hand_tele
 	name = "a hand teleporter"
 	typepath = /obj/item/weapon/hand_tele
-	protected_jobs = list("Captain")
+	protected_jobs = list("Captain", "Research Director")
 
 /datum/theft_objective/traitor/rcd
 	name = "an RCD"
@@ -169,10 +169,10 @@
 /datum/theft_objective/traitor/planningframe
 	name = "the law planning frame"
 	typepath = /obj/item/weapon/planning_frame
-	protected_jobs = list("Captain", "Research Director")
+	protected_jobs = list("Captain", "Research Director", "Chief Engineer")
 
 /datum/theft_objective/traitor/belt
-	name = "the advanced toolbelt"
+	name = "the chief engineers advanced toolbelt"
 	typepath = /obj/item/weapon/storage/belt/utility/chief
 	protected_jobs = list("Captain", "Chief Engineer")
 

--- a/code/game/gamemodes/steal_items.dm
+++ b/code/game/gamemodes/steal_items.dm
@@ -67,7 +67,7 @@
 /datum/theft_objective/traitor/hand_tele
 	name = "a hand teleporter"
 	typepath = /obj/item/weapon/hand_tele
-	protected_jobs = list("Captain", "Research Director")
+	protected_jobs = list("Captain", "Research Director", "Head of Personnel")
 
 /datum/theft_objective/traitor/rcd
 	name = "an RCD"
@@ -92,7 +92,7 @@
 /datum/theft_objective/traitor/ai
 	name = "a functional AI"
 	typepath = /obj/item/device/aicard
-	protected_jobs = list("Captain", "Research Director", "Head of Personnel")
+	protected_jobs = list("Captain", "Research Director", "Head of Personnel", "Chief Engineer")
 
 /datum/theft_objective/traitor/magboots
 	name = "a pair of advanced magboots"
@@ -117,7 +117,7 @@
 /datum/theft_objective/traitor/corgi
 	name = "a piece of corgi meat"
 	typepath = /obj/item/weapon/reagent_containers/food/snacks/meat/animal/corgi
-	protected_jobs = list("Head of Personnel") //Really HoP? Your own dog?
+	protected_jobs = list("Captain", "Head of Personnel") //Really HoP? Your own dog?
 
 /datum/theft_objective/traitor/rd_jumpsuit
 	name = "the research director's jumpsuit"
@@ -170,7 +170,7 @@
 	protected_jobs = list("Captain", "Research Director", "Chief Engineer", "Head of Personnel")
 
 /datum/theft_objective/traitor/belt
-	name = "the chief engineers advanced toolbelt"
+	name = "the chief engineer's advanced toolbelt"
 	typepath = /obj/item/weapon/storage/belt/utility/chief
 	protected_jobs = list("Captain", "Chief Engineer")
 
@@ -223,7 +223,7 @@
 						continue //Stealing a card with no contents doesn't count
 					var/is_at_least_one_alive = 0
 					for(var/mob/living/silicon/ai/A in C)
-						if(A.stat != 2)
+						if(A.stat != DEAD)
 							is_at_least_one_alive++
 					if(!is_at_least_one_alive)
 						continue
@@ -243,6 +243,7 @@
 	typepath = /obj/item/weapon/tank
 	min=28
 	max=28
+	protected_jobs = list("Research Director", "Scientist")
 
 /datum/theft_objective/number/traitor/plasma_gas/getAmountStolen(var/obj/item/I)
 	return I:air_contents:toxins

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -46,7 +46,7 @@
 	supervisors = "the research director"
 	selection_color = "#ffeeff"
 	idtype = /obj/item/weapon/card/id/research
-	access = list(access_robotics, access_tox, access_tox_storage, access_research, access_xenobiology)
+	access = list(/*access_robotics, */access_tox, access_tox_storage, access_research, access_xenobiology)
 	minimal_access = list(access_tox, access_tox_storage, access_research, access_xenobiology)
 	alt_titles = list("Xenoarcheologist", "Anomalist", "Plasma Researcher", "Xenobiologist", "Research Botanist")
 
@@ -97,7 +97,7 @@
 	supervisors = "research director"
 	selection_color = "#ffeeff"
 	idtype = /obj/item/weapon/card/id/research
-	access = list(access_robotics, access_tox, access_tox_storage, access_tech_storage, access_morgue, access_research) //As a job that handles so many corpses, it makes sense for them to have morgue access.
+	access = list(access_robotics, access_tech_storage, access_morgue, access_research) //As a job that handles so many corpses, it makes sense for them to have morgue access.
 	minimal_access = list(access_robotics, access_tech_storage, access_morgue, access_research) //As a job that handles so many corpses, it makes sense for them to have morgue access.
 	alt_titles = list("Biomechanical Engineer","Mechatronic Engineer")
 

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -46,7 +46,7 @@
 	supervisors = "the research director"
 	selection_color = "#ffeeff"
 	idtype = /obj/item/weapon/card/id/research
-	access = list(/*access_robotics, */access_tox, access_tox_storage, access_research, access_xenobiology)
+	access = list(access_robotics, access_tox, access_tox_storage, access_research, access_xenobiology)
 	minimal_access = list(access_tox, access_tox_storage, access_research, access_xenobiology)
 	alt_titles = list("Xenoarcheologist", "Anomalist", "Plasma Researcher", "Xenobiologist", "Research Botanist")
 

--- a/html/changelogs/cptwad.yml
+++ b/html/changelogs/cptwad.yml
@@ -3,4 +3,5 @@ changes:
 - rscadd: "Added new antagonist steal objectives: A TTV, the CE's fancy belt, the telebaton, the planning frame and the antibody scanner."
 - tweak: "Some jobs with easy access to old objectives have been removed from being able to take these items (mostly the captain taking jumpsuits)."
 - rscdel: "Removes the AI steal objective as you never actually needed to steal an AI, just the AI card."
+- tweak: "Roboticists no longer have Toxins access, and scientists no longer have robotics access."
 delete-after: false

--- a/html/changelogs/cptwad.yml
+++ b/html/changelogs/cptwad.yml
@@ -1,7 +1,6 @@
 author: CptWad
 changes: 
-- rscadd: "Added new antagonist steal objectives: A TTV, the CE's fancy belt, the telebaton, the planning frame and the antibody scanner."
-- tweak: "Some jobs with easy access to old objectives have been removed from being able to take these items (mostly the captain taking jumpsuits)."
-- rscdel: "Removes the AI steal objective as you never actually needed to steal an AI, just the AI card."
+- rscadd: "Added new antagonist steal objectives: A TTV, the CE's fancy belt, the telebaton and the planning frame"
+- tweak: "Some jobs with easy access to old objectives have been removed from being able to take these items (mostly the captain/HoP taking jumpsuits)."
 - tweak: "Roboticists no longer have Toxins access."
 delete-after: false

--- a/html/changelogs/cptwad.yml
+++ b/html/changelogs/cptwad.yml
@@ -3,5 +3,5 @@ changes:
 - rscadd: "Added new antagonist steal objectives: A TTV, the CE's fancy belt, the telebaton, the planning frame and the antibody scanner."
 - tweak: "Some jobs with easy access to old objectives have been removed from being able to take these items (mostly the captain taking jumpsuits)."
 - rscdel: "Removes the AI steal objective as you never actually needed to steal an AI, just the AI card."
-- tweak: "Roboticists no longer have Toxins access, and scientists no longer have robotics access."
+- tweak: "Roboticists no longer have Toxins access."
 delete-after: false

--- a/html/changelogs/cptwad.yml
+++ b/html/changelogs/cptwad.yml
@@ -1,3 +1,6 @@
 author: CptWad
-changes: []
+changes: 
+- rscadd: "Added new antagonist steal objectives: A TTV, the CE's fancy belt, the telebaton, the planning frame and the antibody scanner."
+- tweak: "Some jobs with easy access to old objectives have been removed from being able to take these items (mostly the captain taking jumpsuits)."
+- rscdel: "Removes the AI steal objective as you never actually needed to steal an AI, just the AI card."
 delete-after: false


### PR DESCRIPTION
1. adds four new items to steal, all of which hard to find or get. This includes: The Telebaton, the planning frame, the CE's fancy belt and a TTV.
2. Tweaks which jobs can or cant get certain steal objectives. Captain can no longer wander into a head of staffs office to snag a jumpsuit and vox traders don't get the steal a jetpack objective, etc. The changes are easy to read off the code if you want to know specifics but its mostly against the captain and jobs that have direct access to the item(s).
3. Roboticists no longer have toxins access
