### PR TITLE
Fixes orders getting deleted if the supply shuttle was full

### DIFF
--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -278,6 +278,7 @@ var/list/mechtoys = list(
 					if(slip.stamped && slip.stamped.len) //yes, the clown stamp will work. clown is the highest authority on the station, it makes sense
 						cargo_acct.money += credits_per_slip
 						find_slip = 0
+					qdel(A)
 					continue
 
 				SellObjToOrders(A,0)
@@ -371,9 +372,7 @@ var/list/mechtoys = list(
 			CHECK CONTENTS AND STAMP BELOW THE LINE TO CONFIRM RECEIPT OF GOODS<hr>"}
 		if (SP.contraband)
 			slip.forceMove(null)	//we are out of blanks for Form #44-D Ordering Illicit Drugs.
-
-	supply_shuttle.shoppinglist.len = 0
-	return
+		shoppinglist.Remove(S)
 
 /datum/controller/supply_shuttle/proc/forbidden_atoms_check(atom/A)
 	var/contents = get_contents_in_object(A)

--- a/html/changelogs/BarneyGumball.yml
+++ b/html/changelogs/BarneyGumball.yml
@@ -1,2 +1,3 @@
 author: BarneyGumball
-changes: []
+changes: 
+- bugfix: Orders no longer get deleted if they didn't fit on the supply shuttle


### PR DESCRIPTION
Also deletes the supply manifest papers after you send the shuttle back to centcomm, instead of just leaving them on the shuttle floor.
