### PR TITLE
Fixes artificers not building in space

### DIFF
--- a/code/modules/spells/aoe_turf/conjure/construct.dm
+++ b/code/modules/spells/aoe_turf/conjure/construct.dm
@@ -36,7 +36,7 @@
 	cast_sound = 'sound/items/welder.ogg'
 
 /spell/aoe_turf/conjure/floor/choose_targets(mob/user = usr)
-	return get_turf(user)
+	return list(get_turf(user))
 
 /spell/aoe_turf/conjure/floor/conjure_animation(var/atom/movable/overlay/animation, var/turf/target)
 	animation.icon_state = "cultfloor"
@@ -60,7 +60,7 @@
 	cast_sound = 'sound/items/welder.ogg'
 
 /spell/aoe_turf/conjure/wall/choose_targets(mob/user = usr)
-	return get_turf(user)
+	return list(get_turf(user))
 
 /spell/aoe_turf/conjure/wall/conjure_animation(var/atom/movable/overlay/animation, var/turf/target)
 	animation.icon_state = "cultwall"

--- a/html/changelogs/JustSumConstruct.yml
+++ b/html/changelogs/JustSumConstruct.yml
@@ -1,0 +1,7 @@
+
+author: JustSumGuy
+
+delete-after: True
+
+changes: 
+- bugfix: "Fixed an issue preventing artificers from building in space."


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.
-->

fixes part of #12069 
The spells were throwing runtimes because the perform proc for spellcasting expects a list of targets, the cult spells were just returning turfs as targets.
