### PR TITLE
Fixes a bug where Command Staff other than Captain can't change Security Code

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -110,7 +110,7 @@ var/shuttle_call/shuttle_calls[0]
 				var/obj/item/device/pda/pda = I
 				I = pda.id
 			if (I && istype(I))
-				if(access_captain in I.access || access_heads in I.access) //Let heads change the alert level.
+				if(access_heads in I.access) //Let heads change the alert level.
 					var/old_level = security_level
 					if(!tmp_alertlevel)
 						tmp_alertlevel = SEC_LEVEL_GREEN

--- a/html/changelogs/coldcola.yml
+++ b/html/changelogs/coldcola.yml
@@ -1,0 +1,4 @@
+author: coldcola
+delete-after: True
+changes:
+- tweak: Allows all Command Staff to change the Security Code.


### PR DESCRIPTION
pretty clear, for some reason the (access_captain in I.access || ) was causing the second part to not apply.

as a side note, IAA has access_heads and as such is able to do the things.
separate PR required as I have no idea why IAA has it in the first place.

PARTIALLY addresses #9999 
