### PR TITLE
Fixes certain antagonists getting the wrong names when cloned

### DIFF
--- a/code/game/gamemodes/antag_spawner.dm
+++ b/code/game/gamemodes/antag_spawner.dm
@@ -122,6 +122,7 @@
 	M.mind.name = newname
 	M.real_name = newname
 	M.name = newname
+	M.dna.real_name = newname
 	var/datum/objective/protect/new_objective = new /datum/objective/protect
 	new_objective.owner = M:mind
 	new_objective:target = usr:mind

--- a/code/game/gamemodes/antag_spawner.dm
+++ b/code/game/gamemodes/antag_spawner.dm
@@ -119,10 +119,7 @@
 	var/newname = copytext(sanitize(input(M, "You are the wizard's apprentice. Would you like to change your name to something else?", "Name change", randomname) as null|text),1,MAX_NAME_LEN)
 	if (!newname)
 		newname = randomname
-	M.mind.name = newname
-	M.real_name = newname
-	M.name = newname
-	M.dna.real_name = newname
+	M.fully_replace_character_name(M.real_name, newname)
 	var/datum/objective/protect/new_objective = new /datum/objective/protect
 	new_objective.owner = M:mind
 	new_objective:target = usr:mind

--- a/code/game/gamemodes/heist/heist.dm
+++ b/code/game/gamemodes/heist/heist.dm
@@ -97,6 +97,7 @@
 		vox.dna.mutantrace = "vox"
 		vox.set_species("Vox")
 		vox.generate_name()
+		vox.dna.real_name = vox.real_name
 		//vox.languages = HUMAN // Removing language from chargen.
 		vox.default_language = all_languages[LANGUAGE_VOX]
 		vox.species.default_language = LANGUAGE_VOX

--- a/code/game/gamemodes/heist/heist.dm
+++ b/code/game/gamemodes/heist/heist.dm
@@ -96,8 +96,7 @@
 		vox.s_tone = random_skin_tone("Vox")
 		vox.dna.mutantrace = "vox"
 		vox.set_species("Vox")
-		vox.generate_name()
-		vox.dna.real_name = vox.real_name
+		vox.fully_replace_character_name(vox.real_name, vox.generate_name())
 		//vox.languages = HUMAN // Removing language from chargen.
 		vox.default_language = all_languages[LANGUAGE_VOX]
 		vox.species.default_language = LANGUAGE_VOX

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -443,9 +443,7 @@
 	for(var/datum/mind/synd_mind in syndicates)
 		switch(synd_mind.current.gender)
 			if(MALE)
-				synd_mind.name = "[pick(first_names_male)] [lastname]"
+				synd_mind.current.fully_replace_character_name(synd_mind.current.real_name, "[pick(first_names_male)] [lastname]")
 			if(FEMALE)
-				synd_mind.name = "[pick(first_names_female)] [lastname]"
-		synd_mind.current.real_name = synd_mind.name
-		synd_mind.current.dna.real_name = synd_mind.name
+				synd_mind.current.fully_replace_character_name(synd_mind.current.real_name, "[pick(first_names_female)] [lastname]")
 	return

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -447,4 +447,5 @@
 			if(FEMALE)
 				synd_mind.name = "[pick(first_names_female)] [lastname]"
 		synd_mind.current.real_name = synd_mind.name
+		synd_mind.current.dna.real_name = synd_mind.name
 	return

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -149,6 +149,7 @@
 
 		wizard_mob.real_name = newname
 		wizard_mob.name = newname
+		wizard_mob.dna.real_name = newname
 		if(wizard_mob.mind)
 			wizard_mob.mind.name = newname
 	return

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -147,11 +147,7 @@
 		if (!newname)
 			newname = randomname
 
-		wizard_mob.real_name = newname
-		wizard_mob.name = newname
-		wizard_mob.dna.real_name = newname
-		if(wizard_mob.mind)
-			wizard_mob.mind.name = newname
+		wizard_mob.fully_replace_character_name(wizard_mob.real_name, newname)
 	return
 
 

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -284,6 +284,7 @@
 					H.equip_or_collect(new /obj/item/clothing/under/rank/clown(H), slot_w_uniform)
 					H.equip_or_collect(new /obj/item/clothing/shoes/clown_shoes(H), slot_shoes)
 		H.real_name = pick(clown_names)
+		H.dna.real_name = H.real_name
 		H.rename_self("clown")
 		return 1
 

--- a/code/modules/events/heist.dm
+++ b/code/modules/events/heist.dm
@@ -86,6 +86,7 @@ var/global/list/datum/mind/raiders = list()  //Antags.
 		vox.dna.mutantrace = "vox"
 		vox.set_species("Vox")
 		vox.generate_name()
+		vox.dna.real_name = vox.real_name
 		//vox.languages = HUMAN // Removing language from chargen.
 		vox.add_language(LANGUAGE_VOX)
 		vox.remove_language(LANGUAGE_GALACTIC_COMMON)

--- a/code/modules/events/heist.dm
+++ b/code/modules/events/heist.dm
@@ -85,8 +85,7 @@ var/global/list/datum/mind/raiders = list()  //Antags.
 		vox.s_tone = random_skin_tone("Vox")
 		vox.dna.mutantrace = "vox"
 		vox.set_species("Vox")
-		vox.generate_name()
-		vox.dna.real_name = vox.real_name
+		vox.fully_replace_character_name(vox.real_name, vox.generate_name())
 		//vox.languages = HUMAN // Removing language from chargen.
 		vox.add_language(LANGUAGE_VOX)
 		vox.remove_language(LANGUAGE_GALACTIC_COMMON)


### PR DESCRIPTION
Antag types that change the selected character's name wouldn't set the new name in the DNA, making them revert to their old name when cloned. This was mostly visible with raiders, but also happened with wizzes and theoretically ops.
