### PR TITLE
Lockboxes actually check the used ID

### DIFF
--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -95,9 +95,9 @@
 /var/const/access_paramedic = 500
 /var/const/access_mechanic = 501
 
-/obj/var/list/req_access = null
+/obj/var/list/req_access = list()
 /obj/var/req_access_txt = "0"			// A user must have ALL of these accesses to use the object
-/obj/var/list/req_one_access = null
+/obj/var/list/req_one_access = list()
 /obj/var/req_one_access_txt = "0"		// If this list is populated, a user must have at least ONE of these accesses to use the object
 
 //returns 1 if this mob has sufficient access to use this object

--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -25,7 +25,7 @@
 		if(src.broken)
 			to_chat(user, "<span class='rose'>It appears to be broken.</span>")
 			return
-		if(src.allowed(user))
+		if(can_access(ID.GetAccess(), req_access, req_one_access))
 			src.locked = !( src.locked )
 			if(src.locked)
 				src.icon_state = src.icon_locked


### PR DESCRIPTION
fixes #12149

makes unset req_access and req_one_access an empty list rather than just a null so can_access() will work on things without req_access

Unrelated, but both this and the vanishing when opened in-hand bugs existed before my recent lockbox change
