### PR TITLE
Removes duplicate on_moved INVOKE_EVENT from mob/living

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -725,8 +725,6 @@ Thanks.
 				for(var/mob/living/M in G.target)
 					if(M && !(M in view(src)))
 						M.NotTargeted(G)
-	// Update on_moved listeners.
-	INVOKE_EVENT(on_moved,list("loc"=loc))
 
 /mob/living/proc/handle_hookchain(var/direct)
 	for(var/obj/item/weapon/gun/hookshot/hookshot in src)


### PR DESCRIPTION
The `on_moved` event is already invoked in `/atom/movable/Move()`, which is always called by `/mob/living/Move()`, meaning all `/mob/living` types invoke it twice when they move.  Tested every instance of `on_moved` and everything functions exactly the same.
