### PR TITLE
Makes the Rapid Cable Layer use on_moved events

### DIFF
--- a/code/game/objects/items/weapons/RCL.dm
+++ b/code/game/objects/items/weapons/RCL.dm
@@ -62,7 +62,7 @@
 	loaded = null
 	last = null
 	active = 0
-	set_move_hook()
+	set_move_event()
 	..()
 
 /obj/item/weapon/rcl/update_icon()
@@ -97,9 +97,9 @@
 /obj/item/weapon/rcl/dropped(mob/wearer as mob)
 	..()
 	active = 0
-	set_move_hook(wearer)
+	set_move_event(wearer)
 
-/obj/item/weapon/rcl/proc/set_move_hook(mob/user)
+/obj/item/weapon/rcl/proc/set_move_event(mob/user)
 	if(active && user)
 		trigger(user)
 		targetMoveKey = user.on_moved.Add(src, "holder_moved")
@@ -110,7 +110,7 @@
 /obj/item/weapon/rcl/attack_self(mob/user as mob)
 	active = !active
 	to_chat(user, "<span class='notice'>You turn \the [src] [active ? "on" : "off"].<span>")
-	set_move_hook(user)
+	set_move_event(user)
 
 /obj/item/weapon/rcl/proc/holder_moved(var/list/args)
 	to_chat(world, "holder_moved called")

--- a/code/game/objects/items/weapons/RCL.dm
+++ b/code/game/objects/items/weapons/RCL.dm
@@ -113,7 +113,6 @@
 	set_move_event(user)
 
 /obj/item/weapon/rcl/proc/holder_moved(var/list/args)
-	to_chat(world, "holder_moved called")
 	var/event/E = args["event"]
 	if(!targetMoveKey)
 		E.handlers.Remove("\ref[src]:holder_moved")

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -148,10 +148,6 @@
 			if(dispenser.spam_bomb)
 				dispenser.attack_self(src)
 
-		var/obj/item/weapon/rcl/R = get_active_hand()
-		if(R && istype(R) && R.active)
-			R.trigger(src)
-
 /mob/living/carbon/human/CheckSlip()
 	. = ..()
 	if(. && shoes && shoes.flags & NOSLIP)

--- a/html/changelogs/BarneyGumball1.yml
+++ b/html/changelogs/BarneyGumball1.yml
@@ -1,0 +1,4 @@
+author: BarneyGumball
+delete-after: True
+changes: 
+- tweak: MoMMIs can now use the Rapid Cable Layer


### PR DESCRIPTION
Fixes #6786
Fixes #10704

RCL now works with MoMMIs.  Probably works with some other mobs, too.  If a xeno using an RCL is a problem though, I can add a dexterity check.
