### PR TITLE
allows Diona Nymphs to sample while held

### DIFF
--- a/code/modules/mob/living/carbon/monkey/diona.dm
+++ b/code/modules/mob/living/carbon/monkey/diona.dm
@@ -149,7 +149,7 @@
 
 	if(!M || !src)
 		return
-	if(!Adjacent(M))
+	if(!Adjacent(M) || is_holder_of(M, src))
 		return
 	if(donors.Find(M.real_name))
 		to_chat(src, "<span class='warning'>That donor offers you nothing new.</span>")

--- a/html/changelogs/coldcola.yml
+++ b/html/changelogs/coldcola.yml
@@ -1,4 +1,4 @@
 author: coldcola
 delete-after: True
 changes:
-- tweak: Vampire Rejuvenate skill actually does what it says it does now
+- tweak: Diona Nymphs should now be able to sample blood while held


### PR DESCRIPTION
adds an `is_holder_of()` check to allow diona to sample blood from adjacent mobs while held.
