### PR TITLE
Stops Move() being called three times on diagonal moves

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -158,9 +158,8 @@
 				if(Dir & direction)
 					if(is_blocked_turf(get_step(src, direction)))
 						blocked++
-			if(blocked >= 2) // both cardinals blocked, can't move on this diagonal
-				return
-			. = ..()
+			if(blocked < 2) // path is open to the diagonal
+				. = ..()
 
 	if(. && locked_atoms && locked_atoms.len)	//The move was succesful, update locked atoms.
 		spawn(0)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -152,30 +152,15 @@
 	if(loc != newLoc)
 		if (!(Dir & (Dir - 1))) //Cardinal move
 			. = ..()
-		else //Diagonal move, split it into cardinal moves
-			if (Dir & NORTH)
-				if (Dir & EAST) //Northeast
-					if (step(src, NORTH))
-						. = step(src, EAST)
-					else if (step(src, EAST))
-						. = step(src, NORTH)
-				else if (Dir & WEST) //Northwest
-					if (step(src, NORTH))
-						. = step(src, WEST)
-					else if (step(src, WEST))
-						. = step(src, NORTH)
-			else if (Dir & SOUTH)
-				if (Dir & EAST) //Southeast
-					if (step(src, SOUTH))
-						. = step(src, EAST)
-					else if (step(src, EAST))
-						. = step(src, SOUTH)
-				else if (Dir & WEST) //Southwest
-					if (step(src, SOUTH))
-						. = step(src, WEST)
-					else if (step(src, WEST))
-						. = step(src, SOUTH)
-
+		else //Diagonal move, check cardinal directions for dense objects
+			var/blocked = 0
+			for(var/direction in cardinal)
+				if(Dir & direction)
+					if(is_blocked_turf(get_step(src, direction)))
+						blocked++
+			if(blocked >= 2) // both cardinals blocked, can't move on this diagonal
+				return
+			. = ..()
 
 	if(. && locked_atoms && locked_atoms.len)	//The move was succesful, update locked atoms.
 		spawn(0)


### PR DESCRIPTION
`atom/movable/Move()` now checks if the diagonal path is blocked before moving rather than calling `step()` over and over again to see if the path is blocked.
