### PR TITLE
Disallow nonhumans from taking HOP HOS Captain.

### DIFF
--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -13,6 +13,8 @@
 	minimal_access = list() 	//See get_access()
 	minimal_player_age = 14
 
+	species_whitelist = list("Human")
+
 	pdaslot=slot_l_store
 	pdatype=/obj/item/device/pda/captain
 
@@ -67,6 +69,9 @@
 	idtype = /obj/item/weapon/card/id/silver
 	req_admin_notify = 1
 	minimal_player_age = 10
+
+	species_whitelist = list("Human")
+
 	access = list(access_security, access_sec_doors, access_brig, access_court, access_weapons, access_forensics_lockers,
 			            access_medical, access_engine, access_change_ids, access_ai_upload, access_eva, access_heads,
 			            access_all_personal_lockers, access_maint_tunnels, access_bar, access_janitor, access_construction, access_morgue,

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -19,6 +19,8 @@
 			            access_heads, access_hos, access_RC_announce, access_keycard_auth, access_gateway)
 	minimal_player_age = 14
 
+	species_whitelist = list("Human")
+
 	pdaslot=slot_belt
 	pdatype=/obj/item/device/pda/heads/hos
 

--- a/html/changelogs/Wamp.yml
+++ b/html/changelogs/Wamp.yml
@@ -1,0 +1,7 @@
+
+author: Kavlax
+
+delete-after: True
+
+changes:
+        - rscadd: "Disallow nonhumans from taking HOP HOS Captain."


### PR DESCRIPTION
Can't have no shit birds leading our glorious NanoTrasen stations, nosirree.

I was considering restricting all heads of staff from nonhumans. But only restricting implanted heads seems like an okay compromise.