### PR TITLE
Adds /obj/mecha to quick create menu

### DIFF
--- a/code/modules/admin/create_object.dm
+++ b/code/modules/admin/create_object.dm
@@ -16,7 +16,7 @@
 	var/quick_create_object_html = null
 	var/pathtext = null
 
-	pathtext = input("Select the path of the object you wish to create.", "Path", "/obj") in list("/obj","/obj/structure","/obj/item","/obj/item/weapon","/obj/machinery")
+	pathtext = input("Select the path of the object you wish to create.", "Path", "/obj") in list("/obj","/obj/structure","/obj/item","/obj/item/weapon","/obj/machinery","/obj/mecha")
 
 	var path = text2path(pathtext)
 


### PR DESCRIPTION
To spawn mechs for testing or something, you'd need to load all /obj which freezes the client for like a minute. This adds /obj/mecha to the quick create menu.
