### PR TITLE
Fixes diona being able to use creatine and nanobots

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -2479,7 +2479,7 @@
 		if(1 to 5)
 			if(ishuman(M))
 				var/mob/living/carbon/human/H = M
-				if(H.species.name != "Dionae")
+				if(H.species.name != "Diona")
 					var/datum/organ/external/affecting = H.get_organ()
 					for(var/datum/wound/W in affecting.wounds)
 						spawn(1)
@@ -2526,7 +2526,7 @@
 		if(5 to 20)		//Danger zone healing. Adds to a human mob's "percent machine" var, which is directly translated into the chance that it will turn horror each tick that the reagent is above 5u.
 			if(ishuman(M))
 				var/mob/living/carbon/human/H = M
-				if(H.species.name != "Dionae")
+				if(H.species.name != "Diona")
 					var/datum/organ/external/affecting = H.get_organ()
 					for(var/datum/wound/W in affecting.wounds)
 						spawn(1)
@@ -2649,7 +2649,7 @@
 		if(4.5 to 15)
 			if(ishuman(M)) //Does nothing to non-humans.
 				var/mob/living/carbon/human/H = M
-				if(H.species.name != "Dionae") //Dionae are broken as fuck
+				if(H.species.name != "Diona") //Dionae are broken as fuck
 					if(H.hulk_time<world.time && !has_been_armstrong)
 						H.hulk_time = world.time + (45 SECONDS)
 						armstronged_at = H.hulk_time
@@ -3035,7 +3035,7 @@
 		if(25 to INFINITY)
 			if(ishuman(M)) //Does nothing to non-humans.
 				var/mob/living/carbon/human/H = M
-				if(H.species.name != "Dionae") //Dionae are broken as fuck
+				if(H.species.name != "Diona") //Dionae are broken as fuck
 					if(H.hulk_time<world.time && !has_been_hulk)
 						H.hulk_time = world.time + (30 SECONDS)
 						hulked_at = H.hulk_time


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.
-->

Fixes #8948
Due to a one-letter typo, diona/dionae/dionas have been able to use creatine, mednanobots, and comnanobots, even though they're not supposed to be able to. I was told to just give all races defines and turn all instances of species checks into defines but then I realised how many there were so have fun with that. I don't know if xe/xem/xir being able to use these reagents is a real issue we're having or if they even **should** be disallowed from those reagents and I don't really care to be honest, this is just to fix a bug I posted.
If you feel strongly one way or the other, don't sit in silence - share
