### PR TITLE
Changes Assassinate to use special_role if needed

### DIFF
--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -149,7 +149,7 @@
 			spilltarget = 100 + rand(0,player_list.len * 3)
 			explanation = "We must prepare this place for the Geometer of Blood's coming. Spill blood and gibs over [spilltarget] floor tiles."
 		if("sacrifice")
-			explanation = "We need to sacrifice [sacrifice_target.name], the [sacrifice_target.assigned_role], for his blood is the key that will lead our master to this realm. You will need 3 cultists around a Sacrifice rune (Hell Blood Join) to perform the ritual."
+			explanation = "We need to sacrifice [sacrifice_target.name], the [sacrifice_target.assigned_role=="MODE" ? (sacrifice_target.special_role) : (sacrifice_target.assigned_role)], for his blood is the key that will lead our master to this realm. You will need 3 cultists around a Sacrifice rune (Hell Blood Join) to perform the ritual."
 
 	for(var/datum/mind/cult_mind in cult)
 		equip_cultist(cult_mind.current)
@@ -216,7 +216,7 @@
 				spilltarget = 100 + rand(0,player_list.len * 3)
 				explanation = "We must prepare this place for the Geometer of Blood's coming. Spread blood and gibs over [spilltarget] of the Station's floor tiles."
 			if("sacrifice")
-				explanation = "We need to sacrifice [sacrifice_target.name], the [sacrifice_target.assigned_role], for his blood is the key that will lead our master to this realm. You will need 3 cultists around a Sacrifice rune (Hell Blood Join) to perform the ritual."
+				explanation = "We need to sacrifice [sacrifice_target.name], the [sacrifice_target.assigned_role=="MODE" ? (sacrifice_target.special_role) : (sacrifice_target.assigned_role)], for his blood is the key that will lead our master to this realm. You will need 3 cultists around a Sacrifice rune (Hell Blood Join) to perform the ritual."
 
 		for(var/datum/mind/cult_mind in cult)
 			to_chat(cult_mind.current, "<span class='sinister'>You and your acolytes have completed your task, but this place requires yet more preparation!</span>")
@@ -296,6 +296,8 @@
 			for(var/mob/living/carbon/human/player in player_list)
 				if(player.z == map.zCentcomm) //We can't sacrifice people that are on the centcom z-level
 					continue
+				if(player.mind.assigned_role == "MODE") //Excludes wizards, ERT members, deathsquads, and the like
+					continue
 				if(player.mind && !(player.mind in cult))
 					possible_targets += player.mind
 
@@ -369,7 +371,7 @@
 		if("bloodspill")
 			explanation = "We must prepare this place for the Geometer of Blood's coming. Spill blood and gibs over [spilltarget] floor tiles."
 		if("sacrifice")
-			explanation = "We need to sacrifice [sacrifice_target.name], the [sacrifice_target.assigned_role], for his blood is the key that will lead our master to this realm. You will need 3 cultists around a Sacrifice rune (Hell Blood Join) to perform the ritual."
+			explanation = "We need to sacrifice [sacrifice_target.name], the [sacrifice_target.assigned_role=="MODE" ? (sacrifice_target.special_role) : (sacrifice_target.assigned_role)], for his blood is the key that will lead our master to this realm. You will need 3 cultists around a Sacrifice rune (Hell Blood Join) to perform the ritual."
 		if("eldergod")
 			explanation = "Summon Nar-Sie via the use of the Tear Reality rune (Hell Join Self). You will need 9 cultists standing on and around the rune to summon Him."
 	to_chat(cult_mind.current, "<B>Objective #[current_objective]</B>: [explanation]")
@@ -607,13 +609,13 @@
 				if("sacrifice")//sacrifice a high value target
 					if(sacrifice_target)
 						if(sacrifice_target in sacrificed)
-							explanation = "Sacrifice [sacrifice_target.name], the [sacrifice_target.assigned_role]. <font color='green'><B>Success!</B></font>"
+							explanation = "Sacrifice [sacrifice_target.name], the [sacrifice_target.assigned_role=="MODE" ? (sacrifice_target.special_role) : (sacrifice_target.assigned_role)]. <font color='green'><B>Success!</B></font>"
 							feedback_add_details("cult_objective","cult_sacrifice|SUCCESS")
 						else if(sacrifice_target && sacrifice_target.current)
-							explanation = "Sacrifice [sacrifice_target.name], the [sacrifice_target.assigned_role]. <font color='red'>Fail.</font>"
+							explanation = "Sacrifice [sacrifice_target.name], the [sacrifice_target.assigned_role=="MODE" ? (sacrifice_target.special_role) : (sacrifice_target.assigned_role)]. <font color='red'>Fail.</font>"
 							feedback_add_details("cult_objective","cult_sacrifice|FAIL")
 						else
-							explanation = "Sacrifice [sacrifice_target.name], the [sacrifice_target.assigned_role]. <font color='red'>Fail (Gibbed).</font>"
+							explanation = "Sacrifice [sacrifice_target.name], the [sacrifice_target.assigned_role=="MODE" ? (sacrifice_target.special_role) : (sacrifice_target.assigned_role)]. <font color='red'>Fail (Gibbed).</font>"
 							feedback_add_details("cult_objective","cult_sacrifice|FAIL|GIBBED")
 
 				if("eldergod")//summon narsie

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -296,8 +296,6 @@
 			for(var/mob/living/carbon/human/player in player_list)
 				if(player.z == map.zCentcomm) //We can't sacrifice people that are on the centcom z-level
 					continue
-				if(player.mind.assigned_role == "MODE") //Excludes wizards, ERT members, deathsquads, and the like
-					continue
 				if(player.mind && !(player.mind in cult))
 					possible_targets += player.mind
 

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -44,7 +44,7 @@ var/list/potential_theft_objectives=list(
 /datum/objective/assassinate/find_target()
 	..()
 	if(target && target.current)
-		explanation_text = "Assassinate [target.current.real_name], the [target.assigned_role]."
+		explanation_text = "Assassinate [target.current.real_name], the [target.assigned_role=="MODE" ? (target.special_role) : (target.assigned_role)]."
 	else
 		explanation_text = "Free Objective"
 	return target


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.
-->

Fixes #12233 
Currently, assasinate/cult sacrifice objectives go solely off of `target.assigned_role` and `sacrifice_target.assigned_role` respectively which, if special roles like ERT members or wizards are in play, will make the objective read "Sacrifice/Assassinate Big McLargehuge, the MODE."
This changes it to use the target's special_role (which seems to be designed specifically for this) if the assigned_role is MODE by ripping off someone else's work in code\datums\mind.dm
I'm at a loss regarding how to test the cult part of it, so if anyone can assist there, that'd be super. I can't seem to select the game mode datum using SDQL (I guess you can't select datums?) and there's no link to it in the cultists' minds.
