### PR TITLE
Giving easier admin punishment

### DIFF
--- a/code/WorkInProgress/kilakk/fax.dm
+++ b/code/WorkInProgress/kilakk/fax.dm
@@ -207,7 +207,7 @@ var/list/alldepartments = list("Central Command")
 /proc/Centcomm_fax(var/obj/item/weapon/paper/sent, var/sentname, var/mob/Sender)
 
 //why the fuck doesnt the thing show as orange
-	var/msg = "<span class='notice'><b><font color='orange'>CENTCOMM FAX: </font>[key_name(Sender, 1)] (<A HREF='?_src_=holder;adminplayeropts=\ref[Sender]'>PP</A>) (<A HREF='?_src_=vars;Vars=\ref[Sender]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=\ref[Sender]'>SM</A>) (<A HREF='?_src_=holder;adminplayerobservejump=\ref[Sender]'>JMP</A>) (<A HREF='?_src_=holder;secretsadmin=check_antagonist'>CA</A>) (<a href='?_src_=holder;CentcommFaxReply=\ref[Sender]'>RPLY</a>)</b>: Receiving '[sentname]' via secure connection ... <a href='?_src_=holder;CentcommFaxView=\ref[sent]'>view message</a></span>"
+	var/msg = "<span class='notice'><b><font color='orange'>CENTCOMM FAX: </font>[key_name(Sender, 1)] (<A HREF='?_src_=holder;adminplayeropts=\ref[Sender]'>PP</A>) (<A HREF='?_src_=vars;Vars=\ref[Sender]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=\ref[Sender]'>SM</A>) (<A HREF='?_src_=holder;adminplayerobservejump=\ref[Sender]'>JMP</A>) (<A HREF='?_src_=holder;secretsadmin=check_antagonist'>CA</A>) (<A HREF='?_src_=holder;BlueSpaceArtillery=\ref[Sender]'>BSA</A>) (<a href='?_src_=holder;CentcommFaxReply=\ref[Sender]'>RPLY</a>)</b>: Receiving '[sentname]' via secure connection ... <a href='?_src_=holder;CentcommFaxView=\ref[sent]'>view message</a></span>"
 	for (var/client/C in admins)
 		if(C.prefs.special_popup)
 			C << output(msg, "window1.msay_output")//if i get told to make this a proc imma be fuckin mad

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -97,6 +97,17 @@ var/global/floorIsLava = 0
 		<A href='?src=\ref[src];subtlemessage=\ref[M]'>Subtle message</A>
 	"}
 
+	if(istype(M, /mob/living/carbon/human))
+		body += {"<br><br>
+			<b>Punishments:</b>
+			<br>"}
+		body += {"
+			<A href='?src=\ref[src];BlueSpaceArtillery=\ref[M]'>BSA</A> |
+			<A href='?src=\ref[src];addcancer=\ref[M]'>Inflict Cancer</A> |
+			<A href='?src=\ref[src];makecatbeast=\ref[M]'>Make Catbeast</A> |
+			<A href='?src=\ref[src];makecluwne=\ref[M]'>Make Cluwne</A> |
+		"}
+
 	// Mob-specific controls.
 	body += M.player_panel_controls(usr)
 
@@ -127,7 +138,6 @@ var/global/floorIsLava = 0
 					<A href='?src=\ref[src];makemommi=\ref[M]'>Make MoMMI</A> |
 					<A href='?src=\ref[src];makealien=\ref[M]'>Make Alien</A> |
 					<A href='?src=\ref[src];makeslime=\ref[M]'>Make slime</A> |
-					<A href='?src=\ref[src];makecluwne=\ref[M]'>Make Cluwne</A> |
 				"}
 
 			//Simple Animals
@@ -206,7 +216,6 @@ var/global/floorIsLava = 0
 			<A href='?src=\ref[src];tdome2=\ref[M]'>Thunderdome Red</A> |
 			<A href='?src=\ref[src];tdomeadmin=\ref[M]'>Thunderdome Admin</A> |
 			<A href='?src=\ref[src];tdomeobserve=\ref[M]'>Thunderdome Observer</A> |
-			<A href='?src=\ref[src];addcancer=\ref[M]'>Inflict Cancer</A> |
 		"}
 
 	// language toggles

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1811,6 +1811,25 @@
 				usr = M //We probably transformed ourselves
 			show_player_panel(M)
 
+	else if(href_list["makecatbeast"])
+		if(!check_rights(R_SPAWN))
+			return
+
+		var/mob/living/carbon/human/H = locate(href_list["makecatbeast"])
+		if(!istype(H))
+			to_chat(usr, "This can only be used on instances of type /mob/living/carbon/human")
+			return
+
+		if(alert(src.owner, "Are you sure you wish to catbeast [key_name(H)]?",  "Catbeast?" , "Yes" , "No") != "Yes")
+			return
+
+		if(H)
+			H.set_species("Tajaran", force_organs=1)
+			H.regenerate_icons()
+			add_gamelogs(usr, "turned [key_name(H)] into a catbeast", tp_link = FALSE)
+		else
+			to_chat(usr, "Failed! Something went wrong.")
+
 	else if(href_list["makerobot"])
 		if(!check_rights(R_SPAWN))
 			return

--- a/code/modules/admin/verbs/pray.dm
+++ b/code/modules/admin/verbs/pray.dm
@@ -20,7 +20,7 @@
 
 	var/orig_message = msg
 	var/image/cross = image('icons/obj/storage.dmi',"bible")
-	msg = "<span class='notice'>[bicon(cross)] <b><font color='purple'>PRAY (DEITY:[ticker.Bible_deity_name]): </font>[key_name(src, 1)] (<A HREF='?_src_=holder;adminmoreinfo=\ref[src]'>?</A>) (<A HREF='?_src_=holder;adminplayeropts=\ref[src]'>PP</A>) (<A HREF='?_src_=vars;Vars=\ref[src]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=\ref[src]'>SM</A>) (<A HREF='?_src_=holder;adminplayerobservejump=\ref[src]'>JMP</A>) (<A HREF='?_src_=holder;secretsadmin=check_antagonist'>CA</A>) (<A HREF='?_src_=holder;adminspawncookie=\ref[src]'>SC</a>) (<A HREF='?_src_=holder;secretsadmin=check_antagonist'>CA</A>):</b> [msg]</span>"
+	msg = "<span class='notice'>[bicon(cross)] <b><font color='purple'>PRAY (DEITY:[ticker.Bible_deity_name]): </font>[key_name(src, 1)] (<A HREF='?_src_=holder;adminmoreinfo=\ref[src]'>?</A>) (<A HREF='?_src_=holder;adminplayeropts=\ref[src]'>PP</A>) (<A HREF='?_src_=vars;Vars=\ref[src]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=\ref[src]'>SM</A>) (<A HREF='?_src_=holder;adminplayerobservejump=\ref[src]'>JMP</A>) (<A HREF='?_src_=holder;secretsadmin=check_antagonist'>CA</A>) (<A HREF='?_src_=holder;adminspawncookie=\ref[src]'>SC</a>) (<A HREF='?_src_=holder;BlueSpaceArtillery=\ref[src]'>BSA</A>):</b> [msg]</span>"
 
 	send_prayer_to_admins(msg, 'sound/effects/prayer.ogg')
 


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.
-->

Adds bluespace artillery buttons (with confirmation prompts) to prayers and faxes in-line the same way CentComm/Syndicate communications have it.
![bsa fax](https://cloud.githubusercontent.com/assets/5942183/19419794/8d815298-93df-11e6-81e5-f6635362f1dd.PNG)
![bsa pray](https://cloud.githubusercontent.com/assets/5942183/19419797/900b2124-93df-11e6-8483-b6e2aef9f3bd.PNG)

"Punishments" will also be grouped in a category in the PP for ease of admin abuse.
![bsa pp](https://cloud.githubusercontent.com/assets/5942183/19419839/0b9a3bcc-93e0-11e6-953a-0b355f758ed0.PNG)
This (currently) only shows up on human mobs because these are all only applicable to human mobs. The new Make Catbeast button gives a confirmation prompt when you press it. The Make Cluwne already existed and the button was just moved up from Transformations - it doesn't have a confirmation prompt.
I couldn't think of anything else to add to it. There's brain damage and stuff, but I think VV is much better suited for applying it than this.
