### PR TITLE
Lets dead monkeys donate.

### DIFF
--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -239,11 +239,6 @@ var/const/BLOOD_VOLUME_SURVIVE = 122
 	. = ..()
 	vessel.remove_reagent(BLOOD,amount) // Removes blood if human
 
-/mob/living/carbon/monkey/take_blood(obj/item/weapon/reagent_containers/container, var/amount)
-	if(!isDead())
-		adjustOxyLoss(amount)
-		. = ..()
-
 //Transfers blood from container ot vessels
 /mob/living/carbon/proc/inject_blood(obj/item/weapon/reagent_containers/container, var/amount)
 	var/datum/reagent/blood/injected = get_blood(container.reagents)

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -239,6 +239,11 @@ var/const/BLOOD_VOLUME_SURVIVE = 122
 	. = ..()
 	vessel.remove_reagent(BLOOD,amount) // Removes blood if human
 
+/mob/living/carbon/monkey/take_blood(obj/item/weapon/reagent_containers/container, var/amount)
+	if(!isDead())
+		adjustOxyLoss(amount)
+	. = ..()
+
 //Transfers blood from container ot vessels
 /mob/living/carbon/proc/inject_blood(obj/item/weapon/reagent_containers/container, var/amount)
 	var/datum/reagent/blood/injected = get_blood(container.reagents)


### PR DESCRIPTION
Fixes #12068

The monkey blood change was easily circumvented by feeding the buggers dexplus, which was easily acquired by the type of people that did this "exploit", scientists and medical. The change broke virology and unbreaking it while leaving the monkey oxyloss in would either entail giving all carbons a blood vessel (even carbons that do not use blood) or making monkey a child of human (spooky), both of which make code more complex for insufficient gain.

And 'infinite' blood has no practical use anyway so there you go. No need to break virology over a nonissue.
