### PR TITLE
Cleans up pain messages

### DIFF
--- a/code/modules/mob/living/carbon/human/life/handle_shock.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_shock.dm
@@ -24,7 +24,8 @@
 
 	if(shock_stage >= 30)
 		if(shock_stage == 30)
-			emote("me", 1, "is having trouble keeping their eyes open.")
+			if(!isUnconscious())
+				visible_message("<B>[src]</B> is having trouble keeping their eyes open.")
 		eye_blurry = max(2, eye_blurry)
 		stuttering = max(stuttering, 5)
 
@@ -33,7 +34,8 @@
 
 	if(shock_stage >= 60)
 		if(shock_stage == 60)
-			emote("me",1,"'s body becomes limp.")
+			if(!isUnconscious())
+				visible_message("<B>[src]</B>'s body becomes limp.")
 		if(prob(2))
 			to_chat(src, "<span class='danger'>[pick("The pain is excrutiating!", "Please, just end the pain!", "Your whole body is going numb!")]</span>")
 			Weaken(20)
@@ -49,7 +51,8 @@
 			Paralyse(5)
 
 	if(shock_stage == 150)
-		emote("me", 1, "can no longer stand, collapsing!")
+		if(!isUnconscious())
+			visible_message("<B>[src]</b> can no longer stand, collapsing!")
 		Weaken(20)
 
 	if(shock_stage >= 150)


### PR DESCRIPTION
Removes the space between the name and the apostrophe when a person's body becomes limp. The message is now a visible message instead of a me emote.
