### PR TITLE
Fixes my mess-up with plants exuding gasses

### DIFF
--- a/code/modules/hydroponics/hydro_tray.dm
+++ b/code/modules/hydroponics/hydro_tray.dm
@@ -206,6 +206,8 @@
 				if(2)
 					var/turf/T = get_turf(src)
 					msg_admin_attack("[key_name(user)] has planted a spreading vine packet. <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>(JMP)</a>")
+			if(S.seed.exude_gasses && S.seed.exude_gasses.len)
+				add_gamelogs(user, "planted a packet exuding [english_list(S.seed.exude_gasses)]", tp_link = TRUE)
 
 			seed = S.seed //Grab the seed datum.
 			dead = 0


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.
-->

I'm not good at this
I changed it to check for both if the list exists and if the list has a length (because not checking for the latter makes it trigger even when the list is empty and I think not checking for both returns a runtime in the unlikely event there IS no `exude_gasses` var?). I don't know why it says "2 additions and 0 deletions" because those two lines exist already. Shouldn't it say "1 addition and 1 deletion"?
This'll fix plants going "**ADMIN LOG: Admin (kammerjunk) has planted a packet exuding nothing. (JMP)**" and keep them going "**ADMIN LOG: Admin (kammerjunk) has planted a packet exuding plasma and oxygen. (JMP)**"
![newest message](https://cloud.githubusercontent.com/assets/5942183/19434490/02391e3c-9466-11e6-952b-d27f825bb4f7.PNG)
