### PR TITLE
Fix AIs not being able to touch any canisters

### DIFF
--- a/maps/randomvaults/objects.dm
+++ b/maps/randomvaults/objects.dm
@@ -342,7 +342,7 @@
 	..()
 	can_label = 0
 
-/obj/machinery/portable_atmospherics/canister/attack_ai()
+/obj/machinery/portable_atmospherics/canister/old/attack_ai()
 	return
 
 /obj/machinery/portable_atmospherics/canister/old/plasma


### PR DESCRIPTION
I only intended the new/old canisters from the vault to be untouchable remotely, my bad.
