### PR TITLE
Makes forks not feed if the do_after fails, fixes reagent multiplication

### DIFF
--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -81,6 +81,8 @@
 		reagents.update_total()
 		if(M == user)
 			user.visible_message("<span class='notice'>[user] eats a delicious forkful of [loaded_food_name]!</span>")
+			feed_to(user, user)
+			return
 		else
 			user.visible_message("<span class='notice'>[user] attempts to feed [M] a delicious forkful of [loaded_food_name].</span>")
 			if(do_mob(user, M))
@@ -88,12 +90,8 @@
 					return
 
 				user.visible_message("<span class='notice'>[user] feeds [M] a delicious forkful of [loaded_food_name]!</span>")
-		reagents.reaction(M, INGEST)
-		reagents.trans_to(M.reagents, reagents.total_volume, reagents.total_volume, log_transfer = TRUE, whodunnit = user)
-		overlays -= loaded_food
-		del(loaded_food)
-		loaded_food_name = null
-		return
+				feed_to(user, M)
+				return
 	else
 		if((M_CLUMSY in user.mutations) && prob(50))
 			return eyestab(user,user)
@@ -132,6 +130,13 @@
 			snack.bitecount++
 			snack.after_consume(user)
 	return 1
+
+/obj/item/weapon/kitchen/utensil/fork/proc/feed_to(mob/living/carbon/user, mob/living/carbon/target)
+	reagents.reaction(target, INGEST)
+	reagents.trans_to(target.reagents, reagents.total_volume, reagents.total_volume, log_transfer = TRUE, whodunnit = user)
+	overlays -= loaded_food
+	del(loaded_food)
+	loaded_food_name = null
 
 /obj/item/weapon/kitchen/utensil/fork/plastic
 	name = "plastic fork"

--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -133,7 +133,7 @@
 
 /obj/item/weapon/kitchen/utensil/fork/proc/feed_to(mob/living/carbon/user, mob/living/carbon/target)
 	reagents.reaction(target, INGEST)
-	reagents.trans_to(target.reagents, reagents.total_volume, reagents.total_volume, log_transfer = TRUE, whodunnit = user)
+	reagents.trans_to(target.reagents, reagents.total_volume, log_transfer = TRUE, whodunnit = user)
 	overlays -= loaded_food
 	del(loaded_food)
 	loaded_food_name = null

--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -135,7 +135,8 @@
 	reagents.reaction(target, INGEST)
 	reagents.trans_to(target.reagents, reagents.total_volume, log_transfer = TRUE, whodunnit = user)
 	overlays -= loaded_food
-	del(loaded_food)
+	qdel(loaded_food)
+	loaded_food = null
 	loaded_food_name = null
 
 /obj/item/weapon/kitchen/utensil/fork/plastic


### PR DESCRIPTION
When a delay was added to feeding from forks, it didn't actually check to see if the delay worked or not before feeding the food.

Also fixes an issue where feeding someone with a fork would square the reagents added to the victim.

Fixes #12255
