### PR TITLE
Medbots treat brute with tricord again to stop overdoses

### DIFF
--- a/code/game/machinery/bots/medbot.dm
+++ b/code/game/machinery/bots/medbot.dm
@@ -82,7 +82,7 @@
 				if("o2")
 					treatment_oxy = DEXALIN
 		else
-			treatment_brute = BICARIDINE
+			treatment_brute = TRICORDRAZINE
 		src.botcard = new /obj/item/weapon/card/id(src)
 		if(isnull(src.botcard_access) || (src.botcard_access.len < 1))
 			var/datum/job/doctor/J = new/datum/job/doctor

--- a/html/changelogs/SarahJohnson-FixMedbots.yml
+++ b/html/changelogs/SarahJohnson-FixMedbots.yml
@@ -33,4 +33,4 @@ delete-after: True
 # If you're using characters such as # ' : - or the like in your changelog, surround the entire change with quotes as shown in the second example. These quotes don't show up on the changelog once it's merged and prevent errors.
 # SCREW ANY OF THIS UP AND IT WON'T WORK.
 changes: 
-- tweak: Medbots treat brute with tricord again to avoid lethal poisonings.
+- tweak: Medbots treat brute with tricord again to avoid accidental overdoses.

--- a/html/changelogs/SarahJohnson-FixMedbots.yml
+++ b/html/changelogs/SarahJohnson-FixMedbots.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general deleting of nice things)
+#   rscadd (general adding of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.
+author: SarahJohnson
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# There needs to be a space after the - and before the prefix. Don't use tabs anywhere in this file.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# If you're using characters such as # ' : - or the like in your changelog, surround the entire change with quotes as shown in the second example. These quotes don't show up on the changelog once it's merged and prevent errors.
+# SCREW ANY OF THIS UP AND IT WON'T WORK.
+changes: 
+- tweak: Medbots treat brute with tricord again to avoid lethal poisonings.


### PR DESCRIPTION
Back in https://github.com/d3athrow/vgstation13/pull/9275 medbots gained the ability to dispense a specialized chem based on the medkit it was made out of. So an O2 kit medbot would treat oxyloss with Dexalin instead of Tricord. Tox with Antitox. Fire with kelotane. Regular with bicard. The problem with that being that Bicard OD's at 30u and medbots inject with 15u at default making it easy to OD yourself if all 3 of the robotics medbots or a cluster of medbots from other sources get made and are close enough to inject someone all at once for brute damage. PR changes that back to Tricord.

Tested locally. Sandbox spawned medbots worked fine. Built 3 in robotics and they injected tricord for brute successfully as well.
