### PR TITLE
Fix crash caused by byond bug

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -7,8 +7,14 @@
 	cache_lifespan = 0	//stops player uploaded stuff from being kept in the rsc past the current session
 	//loop_checks = 0
 	icon_size = WORLD_ICON_SIZE
-#define RECOMMENDED_VERSION 510
+#define RECOMMENDED_VERSION 511
 
+#if DM_VERSION < 511
+//fix a byond bug by creating a sound and icon at world init. (byond bug ID:2024361)
+//	This is here because this has to run before any save files are loaded in order to work.
+var/sound/fixcleanbotbug_sound = sound()
+var/icon/fixcleanbotbug_icon = icon()
+#endif
 
 var/savefile/panicfile
 /world/New()


### PR DESCRIPTION
You can remove once you update to 511 or leave it in for coders who are still on 510.

I don't actually remember if these procs work in compile time, i know some do and some don't, we did it differently (put the same code in like 5 different places along world int) because we were more focused on testing for the bug rather than fixing it because we didn't know testing for it would fix it.

So if this doesn't compile i'll fix that.
