### PR TITLE
Removes Z2NOCAST from blink and mutate

### DIFF
--- a/code/modules/spells/aoe_turf/blink.dm
+++ b/code/modules/spells/aoe_turf/blink.dm
@@ -5,7 +5,7 @@
 
 	school = "abjuration"
 	charge_max = 20
-	spell_flags = Z2NOCAST | IGNOREDENSE | IGNORESPACE
+	spell_flags = IGNOREDENSE | IGNORESPACE
 	invocation = "none"
 	invocation_type = SpI_NONE
 	range = 7

--- a/code/modules/spells/targeted/genetic.dm
+++ b/code/modules/spells/targeted/genetic.dm
@@ -57,7 +57,7 @@ code\game\\dna\genes\goon_powers.dm
 
 	school = "transmutation"
 	charge_max = 400
-	spell_flags = Z2NOCAST | NEEDSCLOTHES | INCLUDEUSER
+	spell_flags = NEEDSCLOTHES | INCLUDEUSER
 	invocation = "BIRUZ BENNAR"
 	invocation_type = SpI_SHOUT
 	message = "<span class='notice'>You feel strong! You feel a pressure building behind your eyes!</span>"


### PR DESCRIPTION
I don't know why mutate was blocked from being cast on z2, was the wiz shuttle made of punchable walls at any point?

I checked and the wiz outpost, and any shuttles are too far from anything else for blink to put the wizard somewhere they shouldn't be. The only exception is after the escape shuttle docks, but the round is over at that point.
