### PR TITLE
no more removing reagents (from living mobs) with droppers

### DIFF
--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -83,7 +83,7 @@
 		if(!target.is_open_container() && !istype(target,/obj/structure/reagent_dispensers))
 			to_chat(user, "<span class='warning'>You cannot directly remove reagents from [target].</span>")
 			return
-		if(target.is_open_container() && istype(target,/mob/living/carbon))
+		if(target.is_open_container() && ismob(target))
 			to_chat(user, "<span class='warning'>That doesn't make much sense.</span>")
 			return
 		if(!target.reagents.total_volume)

--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -83,7 +83,9 @@
 		if(!target.is_open_container() && !istype(target,/obj/structure/reagent_dispensers))
 			to_chat(user, "<span class='warning'>You cannot directly remove reagents from [target].</span>")
 			return
-
+		if(target.is_open_container() && istype(target,/mob/living/carbon))
+			to_chat(user, "<span class='warning'>That doesn't make much sense.</span>")
+			return
 		if(!target.reagents.total_volume)
 			to_chat(user, "<span class='warning'>[target] is empty.</span>")
 			return

--- a/html/changelogs/coldcola.yml
+++ b/html/changelogs/coldcola.yml
@@ -1,0 +1,4 @@
+author: coldcola
+delete-after: True
+changes:
+- bugfix: droppers and basters can no longer remove reagents from living mobs


### PR DESCRIPTION
fixes #11086
![dropper](https://cloud.githubusercontent.com/assets/17585284/19500654/3a57bb90-956d-11e6-879c-9aa22681bdee.png)
