### PR TITLE
Jumping to things now stops your current Haunt

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1960,6 +1960,11 @@
 		if(!isobserver(usr))
 			C.admin_ghost()
 		sleep(2)
+		if(!isobserver(usr))
+			return
+		var/mob/dead/observer/O = usr
+		if(O.locked_to)
+			O.manual_stop_follow(O.locked_to)
 		if(C)
 			C.jumptomob(M)
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -33,7 +33,6 @@
 	var/has_enabled_antagHUD = 0
 	var/medHUD = 0
 	var/antagHUD = 0
-	var/atom/movable/following = null
 	incorporeal_move = INCORPOREAL_GHOST
 	var/movespeed = 0.75
 	var/lastchairspin
@@ -111,7 +110,6 @@
 
 /mob/dead/observer/Destroy()
 	..()
-	following = null
 	ghostMulti = null
 	observers.Remove(src)
 
@@ -886,15 +884,14 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 				if(!T)
 					to_chat(A, "<span class='warning'>Target not in a turf.</span>")
 					return
-				// Why.
-				//if(!client)
-				//	to_chat(A, "<span class='warning'>Target doesn't have a client.</span>")
-				//	return
+				if(locked_to)
+					manual_stop_follow(locked_to)
 				forceMove(T)
-			following = null
 
 	if(href_list["jumptoarenacood"])
 		var/datum/bomberman_arena/targetarena = locate(href_list["targetarena"])
+		if(locked_to)
+			manual_stop_follow(locked_to)
 		usr.forceMove(targetarena.center)
 		to_chat(usr, "Remember to enable darkness to be able to see the spawns. Click on a green spawn between rounds to register on it.")
 


### PR DESCRIPTION
Removed var/following that's a relic from the old system and unused.

Admin jumping, jumping to arenas, and ghosts teleporting places (posibrain links in chat, borer eggs, etc) now stops your current haunt.
