### PR TITLE
Fixing Up Subspace Tunneler

### DIFF
--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -200,7 +200,8 @@ steam.start() -- spawns the effect
 /datum/effect/effect/system/spark_spread/start()
 	if (holder)
 		location = get_turf(holder)
-
+	if(!location)
+		return
 	var/list/directions
 	if (cardinals)
 		directions = cardinal.Copy()

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -591,7 +591,6 @@
 		. = 1 //returns 1 if any mobs actually got a close(M) call
 
 /obj/item/weapon/storage/Destroy()
-	..()
 	close_all()
 	returnToPool(boxes)
 	returnToPool(closer)
@@ -600,6 +599,7 @@
 	for(var/atom/movable/AM in contents)
 		qdel(AM)
 	contents = null
+	..()
 
 /obj/item/weapon/storage/preattack(atom/target, mob/user, adjacent, params)
 	if(!adjacent)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -778,36 +778,20 @@ Thanks.
 	var/mob/living/L = usr
 
 	//Escaping from within a subspace tunneler.
-	var/atom/topAtom = get_holder_at_turf_level(L)
-	var/list/tunnelercheck = topAtom.search_contents_for(/obj/item/weapon/subspacetunneler)
-	if(istype(topAtom,/obj/item/weapon/subspacetunneler))
-		tunnelercheck.Add(topAtom)
-	if(!isemptylist(tunnelercheck))
-		for(var/obj/item/weapon/subspacetunneler/T in tunnelercheck)
-			var/list/mobcheck = T.search_contents_for(/mob/living)
-			if(!isemptylist(mobcheck))
-				for(var/mob/living/M in mobcheck)
-					if(M == L)
-						var/breakout_time = 0.5 //30 seconds by default
-						var/obj/item/weapon/subspacetunneler/containing_tunneler = T
-						L.delayNext(DELAY_ALL,100)
-						L.visible_message("<span class='danger'>\The [containing_tunneler]'s storage bin shudders.</span>","<span class='warning'>You wander through subspace, looking for a way out (this will take about [breakout_time * 60] seconds).</span>")
-						spawn(0)
-							if(do_after(usr,src,breakout_time * 60 * 10)) //minutes * 60seconds * 10deciseconds
-								var/still_in = 0
-								var/list/mobcheck2 = containing_tunneler.search_contents_for(/mob/living)
-								for(var/mob/living/M2 in mobcheck2)
-									if(M2 == L)
-										still_in = 1
-								if(!containing_tunneler || !L || L.stat != CONSCIOUS || !still_in) //tunneler/user destroyed OR user dead/unconcious OR user no longer in tunneler
-									return
+	var/obj/item/weapon/subspacetunneler/inside_tunneler = get_holder_of_type(L, /obj/item/weapon/subspacetunneler)
+	if(inside_tunneler)
+		var/breakout_time = 0.5 //30 seconds by default
+		L.delayNext(DELAY_ALL,100)
+		L.visible_message("<span class='danger'>\The [inside_tunneler]'s storage bin shudders.</span>","<span class='warning'>You wander through subspace, looking for a way out (this will take about [breakout_time * 60] seconds).</span>")
+		spawn(0)
+			if(do_after(usr,src,breakout_time * 60 * 10)) //minutes * 60seconds * 10deciseconds
+				var/obj/item/weapon/subspacetunneler/still_in = get_holder_of_type(L, /obj/item/weapon/subspacetunneler)
+				if(!inside_tunneler || !L || L.stat != CONSCIOUS || !still_in) //tunneler/user destroyed OR user dead/unconcious OR user no longer in tunneler
+					return
 
-								//Well then break it!
-								containing_tunneler.break_out(L)
-						return
-
-
-
+				//Well then break it!
+				inside_tunneler.break_out(L)
+		return
 
 	//Getting out of someone's inventory.
 	if(istype(src.loc,/obj/item/weapon/holder))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -777,6 +777,38 @@ Thanks.
 
 	var/mob/living/L = usr
 
+	//Escaping from within a subspace tunneler.
+	var/atom/topAtom = get_holder_at_turf_level(L)
+	var/list/tunnelercheck = topAtom.search_contents_for(/obj/item/weapon/subspacetunneler)
+	if(istype(topAtom,/obj/item/weapon/subspacetunneler))
+		tunnelercheck.Add(topAtom)
+	if(!isemptylist(tunnelercheck))
+		for(var/obj/item/weapon/subspacetunneler/T in tunnelercheck)
+			var/list/mobcheck = T.search_contents_for(/mob/living)
+			if(!isemptylist(mobcheck))
+				for(var/mob/living/M in mobcheck)
+					if(M == L)
+						var/breakout_time = 0.5 //30 seconds by default
+						var/obj/item/weapon/subspacetunneler/containing_tunneler = T
+						L.delayNext(DELAY_ALL,100)
+						L.visible_message("<span class='danger'>\The [containing_tunneler]'s storage bin shudders.</span>","<span class='warning'>You wander through subspace, looking for a way out (this will take about [breakout_time * 60] seconds).</span>")
+						spawn(0)
+							if(do_after(usr,src,breakout_time * 60 * 10)) //minutes * 60seconds * 10deciseconds
+								var/still_in = 0
+								var/list/mobcheck2 = containing_tunneler.search_contents_for(/mob/living)
+								for(var/mob/living/M2 in mobcheck2)
+									if(M2 == L)
+										still_in = 1
+								if(!containing_tunneler || !L || L.stat != CONSCIOUS || !still_in) //tunneler/user destroyed OR user dead/unconcious OR user no longer in tunneler
+									return
+
+								//Well then break it!
+								containing_tunneler.break_out(L)
+						return
+
+
+
+
 	//Getting out of someone's inventory.
 	if(istype(src.loc,/obj/item/weapon/holder))
 		var/obj/item/weapon/holder/H = src.loc

--- a/code/modules/projectiles/guns/projectile/constructable/subspacetunneler.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/subspacetunneler.dm
@@ -191,7 +191,7 @@
 
 	if(!loaded_crystal)
 		user.visible_message("*click click*", "<span class='danger'>*click*</span>")
-//		playsound(user, 'sound/weapons/empty.ogg', 100, 1)
+		playsound(user, 'sound/weapons/empty.ogg', 100, 1)
 		return 0
 	else
 		if(istype(target, /obj))
@@ -220,7 +220,7 @@
 		stored_items -= O
 		if(user)
 			user.visible_message("<span class='warning'>[user] ejects \the [O] from \his [src.name] through a subspace rift!</span>","You eject \the [O] from your [src.name] through a subspace rift.")
-//		playsound(O, 'sound/effects/phasein.ogg', 50, 1)
+		playsound(O, 'sound/effects/phasein.ogg', 50, 1)
 		anim(location = T,a_icon = 'icons/obj/weaponsmithing.dmi',flick_anim = "subspace_rift",name = "subspace rift")
 
 /obj/item/weapon/subspacetunneler/proc/get_random_nearby_turf()

--- a/code/modules/projectiles/guns/projectile/constructable/subspacetunneler.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/subspacetunneler.dm
@@ -66,7 +66,7 @@
 		)
 
 /obj/item/weapon/subspacetunneler/Destroy()
-	var/turf/currturf = get_turf(src.loc) //This doesn't work because the container gets qdel()'d first, nullspacing the tunneler
+	var/turf/currturf = get_turf(src)
 	if(loaded_crystal)
 		qdel(loaded_crystal)
 		loaded_crystal = null
@@ -74,13 +74,14 @@
 		qdel(loaded_matter_bin)
 		loaded_matter_bin = null
 	if(stored_items.len)
-		src.visible_message("<span class='warning'>\The [src]'s stored [stored_items.len > 1 ? "items are" : "item is"] forcibly ejected as \the [src] is destroyed!</span>")
-		for(var/I in stored_items)
-			var/offset_x = rand(-3,3)
-			var/offset_y = rand(-3,3)
-			var/turf/T = locate(currturf.x+offset_x, currturf.y+offset_y, z)
-			send(T)
-			sleep(1)
+		spawn(0)
+			src.visible_message("<span class='warning'>\The [src]'s stored [stored_items.len > 1 ? "items are" : "item is"] forcibly ejected as \the [src] is destroyed!</span>")
+			for(var/I in stored_items)
+				var/offset_x = rand(-3,3)
+				var/offset_y = rand(-3,3)
+				var/turf/T = locate(currturf.x+offset_x, currturf.y+offset_y, currturf.z)
+				send(T)
+				sleep(1)
 	..()
 
 /obj/item/weapon/subspacetunneler/attack_self(mob/user as mob)
@@ -173,7 +174,7 @@
 			var/obj/item/weapon/stock_parts/matter_bin/M = loaded_matter_bin
 			to_chat(user, "<span class='info'>The gauge on \the [src]'s [M.name] indicates that there [stored_items.len > 1 ? "are [stored_items.len] objects" : "is [stored_items.len] object"] stored inside it.</span>")
 
-/obj/item/weapon/subspacetunneler/afterattack(atom/target as mob|obj|turf|area, mob/living/user as mob|obj, flag, params)
+/obj/item/weapon/subspacetunneler/afterattack(atom/target as mob|obj|turf|area, mob/living/user as mob|obj)
 	if (target.loc == user)
 		return
 
@@ -185,19 +186,23 @@
 		return
 
 	if(istype(target, /turf) && !istype(target, /turf/simulated/wall))
-		send(target,user,params)
+		send(target,user)
 		return
 
 	if(!loaded_crystal)
 		user.visible_message("*click click*", "<span class='danger'>*click*</span>")
-		playsound(user, 'sound/weapons/empty.ogg', 100, 1)
+//		playsound(user, 'sound/weapons/empty.ogg', 100, 1)
 		return 0
 	else
 		if(istype(target, /obj))
-			receive(target,user,params)
+			receive(target,user)
 			return
 
-/obj/item/weapon/subspacetunneler/proc/send(turf/T as turf, mob/living/user as mob|obj, params, reflex = 0)
+/obj/item/weapon/subspacetunneler/proc/send(turf/T as turf, mob/living/user as mob|obj)
+	if(!T)
+		T = get_random_nearby_turf()
+	if(!T)
+		return
 	if(stored_items.len)
 		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
 		s.set_up(3, 1, src)
@@ -215,8 +220,31 @@
 		stored_items -= O
 		if(user)
 			user.visible_message("<span class='warning'>[user] ejects \the [O] from \his [src.name] through a subspace rift!</span>","You eject \the [O] from your [src.name] through a subspace rift.")
-		playsound(O, 'sound/effects/phasein.ogg', 50, 1)
+//		playsound(O, 'sound/effects/phasein.ogg', 50, 1)
 		anim(location = T,a_icon = 'icons/obj/weaponsmithing.dmi',flick_anim = "subspace_rift",name = "subspace rift")
+
+/obj/item/weapon/subspacetunneler/proc/get_random_nearby_turf()
+	var/turf/currturf = get_turf(src)
+	var/offset_x = rand(-3,3)
+	var/offset_y = rand(-3,3)
+	return locate(currturf.x+offset_x, currturf.y+offset_y, currturf.z)
+
+/obj/item/weapon/subspacetunneler/proc/break_out(mob/living/captive)
+	if(!captive)
+		return
+	var/turf/T = get_random_nearby_turf()
+	if(!T)
+		return
+	var/list/mobcheck = search_contents_for(/mob/living)
+	for(var/mob/living/M in mobcheck)
+		if(M == captive)
+			var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
+			s.set_up(3, 1, src)
+			s.start()
+			captive.forceMove(T)
+			src.visible_message("<span class='warning'>\The [captive] breaks free from the storage bin of \the [src]!</span>")
+			playsound(captive, 'sound/effects/phasein.ogg', 50, 1)
+			anim(location = T,a_icon = 'icons/obj/weaponsmithing.dmi',flick_anim = "subspace_rift",name = "subspace rift")
 
 /obj/item/weapon/subspacetunneler/proc/receive(obj/O as obj, mob/living/user as mob|obj, params, reflex = 0)
 	if(!loaded_crystal)
@@ -314,5 +342,11 @@
 			loaded_crystal = null
 	if(!loaded_crystal)
 		to_chat(user, "<span class='notice'>\The [B] is consumed by the eruption of bluespace energy.</span>")
+
+/obj/item/weapon/subspacetunneler/complete/New() //Comes with a flawless bluespace crystal and supermatter bin by default
+	..()
+	loaded_crystal = new /obj/item/bluespace_crystal/flawless(src)
+	loaded_matter_bin = new /obj/item/weapon/stock_parts/matter_bin/adv/super(src)
+	update_icon()
 
 #undef MAX_BIN_MASS

--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -89,7 +89,7 @@ Note: Must be placed within 3 tiles of the R&D Console
 			spawn(10)
 				icon_state = "d_analyzer_l"
 				busy = 0
-	return
+	return 1
 
 /obj/machinery/r_n_d/destructive_analyzer/attack_hand(mob/user as mob)
 	if (..(user))


### PR DESCRIPTION
Putting the nuke disk in a container no longer allows the subspace tunneler to hold it.
SMESs, PAs, AME parts, and the gateway are now on the prohibited list.
Fixed issue where contents are not ejected if the tunneler's `loc` is not a turf.
The destructive analyzer's attackby() now returns 1 so afterattack() isn't called on items inserted into it.
Mobs can now use the resist verb to escape from a tunneler if they're inside one.
Sparks will no longer be created if their loc would be null.
