### PR TITLE
Permit carding malf AIs before code delta.

### DIFF
--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -214,7 +214,7 @@ That prevents a few funky behaviors.
 							if (ticker.mode.name == "AI malfunction")
 								var/datum/game_mode/malfunction/malf = ticker.mode
 								for (var/datum/mind/malfai in malf.malf_ai)
-									if (T.mind == malfai)
+									if (T.mind == malfai && ticker.mode:malf_mode_declared)
 										to_chat(U, "<span class='danger'>ERROR:</span> Remote transfer interface disabled.")//Do ho ho ho~
 
 										return

--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -214,7 +214,7 @@ That prevents a few funky behaviors.
 							if (ticker.mode.name == "AI malfunction")
 								var/datum/game_mode/malfunction/malf = ticker.mode
 								for (var/datum/mind/malfai in malf.malf_ai)
-									if (T.mind == malfai && ticker.mode:malf_mode_declared)
+									if (T.mind == malfai && malf.malf_mode_declared)
 										to_chat(U, "<span class='danger'>ERROR:</span> Remote transfer interface disabled.")//Do ho ho ho~
 
 										return

--- a/html/changelogs/Wamples.yml
+++ b/html/changelogs/Wamples.yml
@@ -1,0 +1,7 @@
+
+author: Kavlax
+
+delete-after: True
+
+changes:
+        - rscadd: "Permit carding malf AIs before code delta."


### PR DESCRIPTION
Can card traitor AIs, law 0 does not show there. Bit odd for an antag check to exist for that reason.