### PR TITLE
Fix insanity

### DIFF
--- a/code/WorkInProgress/Cael_Aislinn/Rust/fuel_assembly_port.dm
+++ b/code/WorkInProgress/Cael_Aislinn/Rust/fuel_assembly_port.dm
@@ -98,5 +98,5 @@
 	set name = "Eject assembly from port"
 	set category = "Object"
 	set src in oview(1)
-	if(!usr.isUnconscious())
+	if(!usr.incapacitated())
 		eject_assembly()

--- a/code/WorkInProgress/Cael_Aislinn/Rust/fuel_assembly_port.dm
+++ b/code/WorkInProgress/Cael_Aislinn/Rust/fuel_assembly_port.dm
@@ -8,6 +8,7 @@
 	var/obj/item/weapon/fuel_assembly/cur_assembly
 	var/busy = 0
 	anchored = 1
+	ghost_read = 0
 
 	var/opened = 1 //0=closed, 1=opened
 	var/has_electronics = 0 // 0 - none, bit 1 - circuitboard, bit 2 - wires
@@ -23,8 +24,9 @@
 				to_chat(user, "<span class='notice'>You insert [I] into [src]. Touch the panel again to insert [I] into the injector.</span>")
 
 /obj/machinery/rust_fuel_assembly_port/attack_hand(mob/user)
-	add_fingerprint(user)
-	if(stat & (BROKEN|NOPOWER) || opened)
+	if(..())
+		return
+	if(opened)
 		return
 
 	if(cur_assembly)
@@ -96,6 +98,5 @@
 	set name = "Eject assembly from port"
 	set category = "Object"
 	set src in oview(1)
-
-	eject_assembly()
-
+	if(!usr.isUnconscious())
+		eject_assembly()

--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -40,6 +40,8 @@ var/const/AIRLOCK_WIRE_LIGHT = 2048
 		..()
 
 /datum/wires/airlock/CanUse(var/mob/living/L)
+	if(!..())
+		return 0
 	var/obj/machinery/door/airlock/A = holder
 	if(!istype(L, /mob/living/silicon))
 		if(A.isElectrified())

--- a/code/datums/wires/alarm.dm
+++ b/code/datums/wires/alarm.dm
@@ -21,6 +21,8 @@ var/const/AALARM_WIRE_AALARM = 16
 
 
 /datum/wires/alarm/CanUse(var/mob/living/L)
+	if(!..())
+		return 0
 	var/obj/machinery/alarm/A = holder
 	if(A.wiresexposed)
 		return 1

--- a/code/datums/wires/apc.dm
+++ b/code/datums/wires/apc.dm
@@ -23,6 +23,8 @@ var/const/APC_WIRE_AI_CONTROL = 8
 
 
 /datum/wires/apc/CanUse(var/mob/living/L)
+	if(!..())
+		return 0
 	var/obj/machinery/power/apc/A = holder
 	if(A.wiresexposed)
 		return 1

--- a/code/datums/wires/camera.dm
+++ b/code/datums/wires/camera.dm
@@ -27,6 +27,8 @@
 	return .
 
 /datum/wires/camera/CanUse(var/mob/living/L)
+	if(!..())
+		return 0
 	var/obj/machinery/camera/C = holder
 	if(!C.panel_open)
 		return 0

--- a/code/datums/wires/explosive.dm
+++ b/code/datums/wires/explosive.dm
@@ -21,6 +21,8 @@ var/const/WIRE_EXPLODE = 1
 	holder_type = /obj/item/weapon/plastique
 
 /datum/wires/explosive/plastic/CanUse(var/mob/living/L)
+	if(!..())
+		return 0
 	var/obj/item/weapon/plastique/P = holder
 	if(P.open_panel)
 		return 1
@@ -29,4 +31,3 @@ var/const/WIRE_EXPLODE = 1
 /datum/wires/explosive/plastic/explode()
 	var/obj/item/weapon/plastique/P = holder
 	P.explode(get_turf(P))
-

--- a/code/datums/wires/jukebox.dm
+++ b/code/datums/wires/jukebox.dm
@@ -35,6 +35,8 @@ var/const/JUKE_CONFIG = 64 //Cut emags. Pulse plays IAMERROR.ogg
 var/const/JUKE_SETTING = 128 //Cut shocks. Pulse toggles settings menu.
 
 /datum/wires/jukebox/CanUse(var/mob/living/L)
+	if(!..())
+		return 0
 	var/obj/machinery/media/jukebox/J = holder
 	if(J.panel_open)
 		return 1

--- a/code/datums/wires/mommi.dm
+++ b/code/datums/wires/mommi.dm
@@ -52,6 +52,8 @@
 			R.SetLockdown(!R.lockcharge) // Toggle
 
 /datum/wires/robot/mommi/CanUse(var/mob/living/L)
+	if(!..())
+		return 0
 	var/mob/living/silicon/robot/mommi/R = holder
 	if(R.wiresexposed)
 		return 1

--- a/code/datums/wires/mulebot.dm
+++ b/code/datums/wires/mulebot.dm
@@ -28,6 +28,8 @@ var/const/WIRE_REMOTE_TX = 128	// remote trans status
 var/const/WIRE_BEACON_RX = 256	// beacon ping recv
 
 /datum/wires/mulebot/CanUse(var/mob/living/L)
+	if(!..())
+		return 0
 	var/obj/machinery/bot/mulebot/M = holder
 	if(M.open)
 		return 1

--- a/code/datums/wires/particle_accelerator.dm
+++ b/code/datums/wires/particle_accelerator.dm
@@ -18,6 +18,8 @@ var/const/PARTICLE_LIMIT_POWER_WIRE = 8 // Determines how strong the PA can be.
 //var/const/PARTICLE_NOTHING_WIRE = 16 // Blank wire
 
 /datum/wires/particle_acc/control_box/CanUse(var/mob/living/L)
+	if(!..())
+		return 0
 	var/obj/machinery/particle_accelerator/control_box/C = holder
 	if(C.construction_state == 2)
 		return 1

--- a/code/datums/wires/radio.dm
+++ b/code/datums/wires/radio.dm
@@ -15,6 +15,8 @@ var/const/WIRE_RECEIVE = 2
 var/const/WIRE_TRANSMIT = 4
 
 /datum/wires/radio/CanUse(var/mob/living/L)
+	if(!..())
+		return 0
 	var/obj/item/device/radio/R = holder
 	if(R.b_stat)
 		return 1

--- a/code/datums/wires/rnd_wires.dm
+++ b/code/datums/wires/rnd_wires.dm
@@ -15,6 +15,8 @@ var/const/RND_WIRE_SHOCK = 2
 var/const/RND_WIRE_HACK = 4
 
 /datum/wires/rnd/CanUse(var/mob/living/L)
+	if(!..())
+		return 0
 	var/obj/machinery/r_n_d/rnd = holder
 	if(rnd.panel_open)
 		return 1

--- a/code/datums/wires/robot.dm
+++ b/code/datums/wires/robot.dm
@@ -88,6 +88,8 @@ var/const/BORG_WIRE_LAWCHECK    = 16 // Not used on MoMMIs
 			R.SetLockdown(!R.lockcharge) // Toggle
 
 /datum/wires/robot/CanUse(var/mob/living/L)
+	if(!..())
+		return 0
 	var/mob/living/silicon/robot/R = holder
 	if(R.wiresexposed)
 		return 1

--- a/code/datums/wires/taperecorder.dm
+++ b/code/datums/wires/taperecorder.dm
@@ -14,6 +14,8 @@ var/const/WIRE_RECORD = 2
 			record()
 
 /datum/wires/taperecorder/CanUse(var/mob/living/L)
+	if(!..())
+		return 0
 	var/obj/item/device/taperecorder/T = holder
 	if(T.open_panel)
 		return 1

--- a/code/datums/wires/transmitter.dm
+++ b/code/datums/wires/transmitter.dm
@@ -20,6 +20,8 @@ var/const/TRANS_LINK = 8 //Cut shocks. Pulse clears links.
 var/const/TRANS_SETTINGS = 16 //Pulse shows percentage given by environment temperature over safe operating temperature.
 
 /datum/wires/transmitter/CanUse(var/mob/living/L)
+	if(!..())
+		return 0
 	var/obj/machinery/media/transmitter/broadcast/T = holder
 	if(T.panel_open)
 		return 1

--- a/code/datums/wires/vending.dm
+++ b/code/datums/wires/vending.dm
@@ -17,9 +17,9 @@ var/const/VENDING_WIRE_ELECTRIFY = 4
 var/const/VENDING_WIRE_IDSCAN = 8
 
 /datum/wires/vending/CanUse(var/mob/living/L)
-	var/obj/machinery/vending/V = holder
-	if(L.lying || L.incapacitated())
+	if(!..())
 		return 0
+	var/obj/machinery/vending/V = holder
 	if(!istype(L, /mob/living/silicon))
 		if(V.seconds_electrified)
 			if(V.shock(L, 100))

--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -70,11 +70,11 @@ var/list/wireColours = list("red", "blue", "green", "black", "orange", "brown", 
 		src.wires[colour] = index
 		//wires = shuffle(wires)
 
-/datum/wires/proc/Interact(var/mob/living/user)
-	if(!istype(user))
+/datum/wires/proc/Interact(var/mob/user)
+	if(!user || !CanUse(user))
 		return 0
 	var/html = null
-	if(holder && CanUse(user))
+	if(holder)
 		html = GetInteractWindow()
 	if(html)
 		user.set_machine(holder)

--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -176,10 +176,10 @@ var/list/wireColours = list("red", "blue", "green", "black", "orange", "brown", 
 /datum/wires/proc/UpdatePulsed(var/index)
 	return
 
-/datum/wires/proc/CanUse(var/mob/living/L)
+/datum/wires/proc/CanUse(var/mob/L)
 	if(!L.dexterity_check())
 		return 0
-	if(L.incapacitated() || L.lying)
+	if((L.incapacitated() && !isAdminGhost(L)) || L.lying)
 		return 0
 	return 1
 

--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -114,7 +114,10 @@ var/list/wireColours = list("red", "blue", "green", "black", "orange", "brown", 
 	if(in_range(holder, usr) && isliving(usr))
 
 		var/mob/living/L = usr
-		if(CanUse(L) && href_list["action"])
+		if(!CanUse(L))
+			to_chat(usr, "<span class='notice'>You are incapable of this right now.</span>")
+			return
+		if(href_list["action"])
 			var/obj/item/I = L.get_active_hand()
 			holder.add_hiddenprint(L)
 			if(href_list["cut"]) // Toggles the cut/mend status
@@ -174,6 +177,10 @@ var/list/wireColours = list("red", "blue", "green", "black", "orange", "brown", 
 	return
 
 /datum/wires/proc/CanUse(var/mob/living/L)
+	if(!L.dexterity_check())
+		return 0
+	if(L.incapacitated() || L.lying)
+		return 0
 	return 1
 
 // Example of use:

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -908,6 +908,11 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 /mob/dead/observer/dexterity_check()
 	return 1
 
+/mob/dead/observer/incapacitated()
+	if(isAdminGhost(src))
+		return 0
+	return 1
+
 //this is a mob verb instead of atom for performance reasons
 //see /mob/verb/examinate() in mob.dm for more info
 //overriden here and in /mob/living for different point span classes and sanity checks

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -908,11 +908,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 /mob/dead/observer/dexterity_check()
 	return 1
 
-/mob/dead/observer/incapacitated()
-	if(isAdminGhost(src))
-		return 0
-	return 1
-
 //this is a mob verb instead of atom for performance reasons
 //see /mob/verb/examinate() in mob.dm for more info
 //overriden here and in /mob/living for different point span classes and sanity checks

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -19,6 +19,7 @@
 	mech_flags = MECH_SCAN_ILLEGAL
 	min_harm_label = 20
 	harm_label_examine = list("<span class='info'>A label is stuck to the trigger, but it is too small to get in the way.</span>", "<span class='warning'>A label firmly sticks the trigger to the guard!</span>")
+	ghost_read = 0
 
 	var/fire_sound = 'sound/weapons/Gunshot.ogg'
 	var/empty_sound = 'sound/weapons/empty.ogg'

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -89,7 +89,7 @@
 	set name = "Remove Ammo / Magazine"
 	set category = "Object"
 	set src in range(0)
-	if(usr.isUnconscious())
+	if(usr.incapacitated())
 		to_chat(usr, "<span class='rose'>You can't do this!</span>")
 		return
 	if(stored_magazine)

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -89,8 +89,11 @@
 	set name = "Remove Ammo / Magazine"
 	set category = "Object"
 	set src in range(0)
+	if(usr.isUnconscious())
+		to_chat(usr, "<span class='rose'>You can't do this!</span>")
+		return
 	if(stored_magazine)
-		RemoveMag()
+		RemoveMag(usr)
 	else
 		to_chat(usr, "<span class='rose'>There is no magazine to remove!</span>")
 

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -197,13 +197,10 @@
 		..()
 
 /obj/item/weapon/gun/projectile/automatic/l6_saw/force_removeMag() //special because of its cover
-	if(cover_open && stored_magazine)
-		RemoveMag(usr)
-		to_chat(usr, "<span class='notice'>You remove the magazine from [src].</span>")
-	else if(stored_magazine)
+	if(!cover_open)
 		to_chat(usr, "<span class='rose'>The [src]'s cover has to be open to do that!</span>")
-	else
-		to_chat(usr, "<span class='rose'>There is no magazine to remove!</span>")
+		return
+	..()
 
 
 /* The thing I found with guns in ss13 is that they don't seem to simulate the rounds in the magazine in the gun.

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -221,12 +221,14 @@
 	AC.forceMove(src) //get back in there you
 
 /obj/item/weapon/gun/projectile/russian/force_removeMag()
+	if(usr.isUnconscious())
+		return
 	if(getAmmo() > 0)
 		for(var/obj/item/ammo_casing/AC in loaded)
 			AC.forceMove(get_turf(src))
 			loaded -= AC
 			loaded += null
-	src.loc.visible_message("<span class='warning'>[src] empties onto the ground!</span>")
+	visible_message("<span class='warning'>[src] empties onto the ground!</span>")
 
 
 /obj/item/weapon/gun/projectile/russian/empty/New()

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -221,7 +221,7 @@
 	AC.forceMove(src) //get back in there you
 
 /obj/item/weapon/gun/projectile/russian/force_removeMag()
-	if(usr.isUnconscious())
+	if(usr.incapacitated())
 		return
 	if(getAmmo() > 0)
 		for(var/obj/item/ammo_casing/AC in loaded)


### PR DESCRIPTION
Fixes #8115
Fixes #8300
Fixes #8369
Fixes #11016

:cl:
- bugfix: Ghosts can no longer pull magazines out of guns or mess with R-UST fuel ports.
- bugfix: You can no longer avoid the dexterity/consciousness checks when cutting or pulsing wires on machinery.
