### PR TITLE
Hivelord cores can be preserved with frost oil

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -301,6 +301,10 @@ obj/item/asteroid/basilisk_hide/New()
 	create_reagents(5)
 	processing_objects.Add(src)
 
+/obj/item/asteroid/hivelord_core/Destroy()
+	processing_objects.Remove(src)
+	..()
+
 /obj/item/asteroid/hivelord_core/process()
 	if(reagents && reagents.has_reagent(FROSTOIL, 5))
 		playsound(get_turf(src), 'sound/effects/glass_step.ogg', 50, 1)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -294,16 +294,30 @@ obj/item/asteroid/basilisk_hide/New()
 	icon = 'icons/obj/food.dmi'
 	icon_state = "boiledrorocore"
 	var/inert = 0
+	var/timer = 60
 
 /obj/item/asteroid/hivelord_core/New()
 	..()
 	create_reagents(5)
-	spawn(1200)
-		if(reagents && reagents.has_reagent("frostoil", 5))
-			desc = "All that remains of a hivelord, it seems to be what allows it to break pieces of itself off without being hurt. It is covered in a thin coat of frost."
-		else
-			inert = 1
-			desc = "The remains of a hivelord that have become useless, having been left alone too long after being harvested."
+	processing_objects.Add(src)
+
+/obj/item/asteroid/hivelord_core/process()
+	if(reagents && reagents.has_reagent(FROSTOIL, 5))
+		playsound(get_turf(src), 'sound/effects/glass_step.ogg', 50, 1)
+		desc = "All that remains of a hivelord, it seems to be what allows it to break pieces of itself off without being hurt. It is covered in a thin coat of frost."
+		processing_objects.Remove(src)
+		return
+
+	if(timer <= 0)
+		inert = 1
+		desc = "The remains of a hivelord that have become useless, having been left alone too long after being harvested."
+		processing_objects.Remove(src)
+		return
+
+	if(loc && (istype(loc, /obj/structure/closet/crate/freezer) || istype(loc, /obj/structure/closet/secure_closet/freezer)))
+		return
+
+	timer--
 
 /obj/item/asteroid/hivelord_core/attack(mob/living/M as mob, mob/living/user as mob)
 	if (iscarbon(M) && user.a_intent != I_HURT)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -297,9 +297,13 @@ obj/item/asteroid/basilisk_hide/New()
 
 /obj/item/asteroid/hivelord_core/New()
 	..()
+	create_reagents(5)
 	spawn(1200)
-		inert = 1
-		desc = "The remains of a hivelord that have become useless, having been left alone too long after being harvested."
+		if(reagents && reagents.has_reagent("frostoil", 5))
+			desc = "All that remains of a hivelord, it seems to be what allows it to break pieces of itself off without being hurt. It is covered in a thin coat of frost."
+		else
+			inert = 1
+			desc = "The remains of a hivelord that have become useless, having been left alone too long after being harvested."
 
 /obj/item/asteroid/hivelord_core/attack(mob/living/M as mob, mob/living/user as mob)
 	if (iscarbon(M) && user.a_intent != I_HURT)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -294,11 +294,13 @@ obj/item/asteroid/basilisk_hide/New()
 	icon = 'icons/obj/food.dmi'
 	icon_state = "boiledrorocore"
 	var/inert = 0
-	var/timer = 60
+	var/time_left = 1200 //deciseconds
+	var/last_process
 
 /obj/item/asteroid/hivelord_core/New()
 	..()
 	create_reagents(5)
+	last_process = world.time
 	processing_objects.Add(src)
 
 /obj/item/asteroid/hivelord_core/Destroy()
@@ -312,16 +314,18 @@ obj/item/asteroid/basilisk_hide/New()
 		processing_objects.Remove(src)
 		return
 
-	if(timer <= 0)
+	if(time_left <= 0)
 		inert = 1
 		desc = "The remains of a hivelord that have become useless, having been left alone too long after being harvested."
 		processing_objects.Remove(src)
 		return
 
 	if(loc && (istype(loc, /obj/structure/closet/crate/freezer) || istype(loc, /obj/structure/closet/secure_closet/freezer)))
+		last_process = world.time
 		return
 
-	timer--
+	time_left -= world.time - last_process
+	last_process = world.time
 
 /obj/item/asteroid/hivelord_core/attack(mob/living/M as mob, mob/living/user as mob)
 	if (iscarbon(M) && user.a_intent != I_HURT)

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -33,7 +33,8 @@
 	                            /obj/item/weapon/storage/fancy/cigarettes,
 	                            /obj/item/weapon/implantcase/chem,
 	                            /obj/item/weapon/reagent_containers/pill/time_release,
-	                            /obj/item/clothing/mask/facehugger/lamarr)
+	                            /obj/item/clothing/mask/facehugger/lamarr,
+	                            /obj/item/asteroid/hivelord_core)
 
 /obj/item/weapon/reagent_containers/syringe/suicide_act(mob/user)
 	to_chat(viewers(user), "<span class='danger'>[user] appears to be injecting an air bubble using a [src.name]! It looks like \he's trying to commit suicide.</span>")


### PR DESCRIPTION
Injecting a fresh hivelord core with 5u frost oil will prevent it from becoming inert.

Someone suggested this in deadchat and now it's real, this is for whoever that was.

:cl:
- tweak: Hivelord cores can be preserved by injecting them with 5 units of frost oil.
