### PR TITLE
fixes an exploit with picking up projectiles outside of timestop

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -676,6 +676,10 @@ var/list/impact_master = list()
 	if(timestopped)
 		..()
 
+/obj/item/projectile/verb_pickup(mob/user)
+	if(timestopped)
+		..()
+
 /obj/item/projectile/friendlyCheck
 	invisibility = 101
 	rotate = 0


### PR DESCRIPTION
Same check as for attack_hand.
