### PR TITLE
Fixes #12339

### DIFF
--- a/code/modules/html_interface/map/station_map.dm
+++ b/code/modules/html_interface/map/station_map.dm
@@ -141,7 +141,11 @@
 		if(A.holomap_marker && (A.holomap_filter & HOLOMAP_EXTRA_STATIONMAP))
 			var/turf/T = A.getAreaCenter(StationZLevel)
 			if(T)
-				big_map.Blend(icon('icons/holomap_markers.dmi',A.holomap_marker), ICON_OVERLAY, T.x-8+map.holomap_offset_x[T.z]	, T.y-8+map.holomap_offset_y[T.z])
+				if(map.holomap_offset_x.len >= StationZLevel)
+					big_map.Blend(icon('icons/holomap_markers.dmi',A.holomap_marker), ICON_OVERLAY, T.x-8+map.holomap_offset_x[T.z]	, T.y-8+map.holomap_offset_y[T.z])
+				else
+					big_map.Blend(icon('icons/holomap_markers.dmi',A.holomap_marker), ICON_OVERLAY, T.x-8, T.y-8)
+
 
 	extraMiniMaps |= HOLOMAP_EXTRA_STATIONMAP+"_[StationZLevel]"
 	extraMiniMaps[HOLOMAP_EXTRA_STATIONMAP+"_[StationZLevel]"] = big_map

--- a/html/changelogs/JMWTurner-holochip.yml
+++ b/html/changelogs/JMWTurner-holochip.yml
@@ -1,3 +1,0 @@
-author: JMWTurner
-changes: []
-delete-after: false

--- a/html/changelogs/JMWTurner-holofix.yml
+++ b/html/changelogs/JMWTurner-holofix.yml
@@ -1,0 +1,4 @@
+author: JMWTurner
+delete-after: true
+changes:
+  - bugfix: Fixed station holomaps not working on the station Z levels of Meta and Deff.


### PR DESCRIPTION
This is what I get for following advices blindly.
Fixes #12339

:cl:
- bugfix: Station Holomaps now properly work on Defficiency and Metaclub's station ZLevels.
