### PR TITLE
Robot components bugfixes

### DIFF
--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -134,6 +134,8 @@
 /obj/item/robot_parts/robot_component
 	icon = 'icons/robot_component.dmi'
 	icon_state = "working"
+	var/brute_damage = 0
+	var/electronics_damage = 0
 
 /obj/item/robot_parts/robot_component/binary_communication_device
 	name = "binary communication device"

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -791,8 +791,11 @@
 		for(var/V in components)
 			var/datum/robot_component/C = components[V]
 			if(!C.installed && istype(W, C.external_type))
+				var/obj/item/robot_parts/robot_component/I = W
 				C.installed = 1
 				C.wrapped = W
+				C.electronics_damage = I.electronics_damage
+				C.brute_damage = I.brute_damage
 				C.install()
 				user.drop_item(W)
 				W.forceMove(null)
@@ -863,7 +866,12 @@
 				if(!remove)
 					return
 				var/datum/robot_component/C = components[remove]
-				var/obj/item/I = C.wrapped
+				if(istype(C.wrapped, /obj/item/broken_device)
+					var/obj/item/broken_device/I = C.wrapped
+				else
+					var/obj/item/robot_parts/robot_component/I = C.wrapped
+					I.brute_damage = C.brute_damage
+					I.electronics_damage = C.electronics_damage
 				to_chat(user, "You remove \the [I].")
 				I.forceMove(src.loc)
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -866,14 +866,16 @@
 				if(!remove)
 					return
 				var/datum/robot_component/C = components[remove]
-				if(istype(C.wrapped, /obj/item/broken_device)
+				if(istype(C.wrapped, /obj/item/broken_device))
 					var/obj/item/broken_device/I = C.wrapped
+					to_chat(user, "You remove \the [I].")
+					I.forceMove(src.loc)
 				else
 					var/obj/item/robot_parts/robot_component/I = C.wrapped
 					I.brute_damage = C.brute_damage
 					I.electronics_damage = C.electronics_damage
-				to_chat(user, "You remove \the [I].")
-				I.forceMove(src.loc)
+					to_chat(user, "You remove \the [I].")
+					I.forceMove(src.loc)
 
 				if(C.installed == 1)
 					C.uninstall()


### PR DESCRIPTION
70% tested. I'll do a bit more testing tomorrow

:cl:
- bugfix: Robots components. When replacing a damaged component, the new one remembered the old damage values, so you had to apply nanopaste to fix it. Now you don't
- bugfix: This also fixes a bug where power cell damage can't be fixed (because of a stupid loop). You still have to place a new power cell though.
