### PR TITLE
Borer Bugfixes

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -532,7 +532,6 @@
 			var/mob/living/simple_animal/borer/B = I
 			if(B.hostlimb == host_region)
 				return B
-
 	return 0
 
 /mob/proc/get_brain_worms()
@@ -600,8 +599,8 @@
 				affected.implants += I
 
 /mob/living/carbon/proc/dropBorers(var/gibbed = null)
-	var/mob/living/simple_animal/borer/B = has_brain_worms()
-	if(B)
+	var/list/borer_list = get_brain_worms()
+	for(var/mob/living/simple_animal/borer/B in borer_list)
 		B.detach()
 		if(gibbed)
 			to_chat(B, "<span class='danger'>As your host is violently destroyed, so are you!</span>")
@@ -611,12 +610,17 @@
 			to_chat(B, "<span class='notice'>You're forcefully popped out of your host!</span>")
 
 /mob/living/carbon/proc/transferBorers(mob/living/target)
-	var/mob/living/simple_animal/borer/B = has_brain_worms()
-	if(B)
+	var/list/borer_list = get_brain_worms()
+	for(var/mob/living/simple_animal/borer/B in borer_list)
+		var/currenthostlimb = B.hostlimb
 		B.detach()
 		if(iscarbon(target))
+			if(!ishuman(target))
+				if(currenthostlimb != LIMB_HEAD)
+					to_chat(B, "<span class='notice'>You're forcefully popped out of your host!</span>")
+					return
 			var/mob/living/carbon/C = target
-			B.perform_infestation(C)
+			B.perform_infestation(C, currenthostlimb)
 		else
 			to_chat(B, "<span class='notice'>You're forcefully popped out of your host!</span>")
 
@@ -624,13 +628,15 @@
 	if(!target)
 		target = get_turf(src)
 
-	var/mob/living/simple_animal/borer/B = src.has_brain_worms()
-	for(var/mob/M in src)//mobs, all of them
-		if(M == B)
-			continue
-		if(M in src.stomach_contents)
-			src.stomach_contents.Remove(M)
-		M.forceMove(target)
+//	var/mob/living/simple_animal/borer/B = has_brain_worms()
+	var/list/borer_list = get_brain_worms()
+	for(var/mob/living/simple_animal/borer/B in borer_list)
+		for(var/mob/M in src)//mobs, all of them
+			if(M == B)
+				continue
+			if(M in src.stomach_contents)
+				src.stomach_contents.Remove(M)
+			M.forceMove(target)
 
 	for(var/obj/O in src)//objects, only the ones in the stomach
 		if(O in src.stomach_contents)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -628,15 +628,13 @@
 	if(!target)
 		target = get_turf(src)
 
-//	var/mob/living/simple_animal/borer/B = has_brain_worms()
 	var/list/borer_list = get_brain_worms()
-	for(var/mob/living/simple_animal/borer/B in borer_list)
-		for(var/mob/M in src)//mobs, all of them
-			if(M == B)
-				continue
-			if(M in src.stomach_contents)
-				src.stomach_contents.Remove(M)
-			M.forceMove(target)
+	for(var/mob/M in src)//mobs, all of them
+		if(M in borer_list)
+			continue
+		if(M in src.stomach_contents)
+			src.stomach_contents.Remove(M)
+		M.forceMove(target)
 
 	for(var/obj/O in src)//objects, only the ones in the stomach
 		if(O in src.stomach_contents)

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -12,7 +12,7 @@
 		if(prob(100 - E.get_damage()))
 			//Override the current limb status and don't cause an explosion
 			E.droplimb(1, 1)
-
+	dropBorers()
 	var/gib_radius = 0
 	if(reagents.has_reagent(LUBE))
 		gib_radius = 6 //Your insides are all lubed, so gibs travel much further

--- a/code/modules/mob/living/carbon/slime/life.dm
+++ b/code/modules/mob/living/carbon/slime/life.dm
@@ -391,6 +391,8 @@
 				A.powerlevel = max(0, powerlevel-1)
 				A.Friends = Friends
 				A.tame = tame
+				transferImplantsTo(A)
+				transferBorers(A)
 				qdel(src)
 
 

--- a/code/modules/mob/living/simple_animal/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer.dm
@@ -86,8 +86,6 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 	var/obj/item/weapon/gun/hookshot/flesh/extend_o_arm = null
 	var/extend_o_arm_unlocked = 0
 
-	var/attack_cooldown = 0 //to prevent spamming extend_o_arm attacks at close range
-
 	// Event handles
 	var/eh_emote
 
@@ -1197,12 +1195,11 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 				if(host.Adjacent(A))
 					if(hostlimb == LIMB_RIGHT_ARM)
 						if(host.get_held_item_by_index(GRASP_RIGHT_HAND))
-							if(attack_cooldown)
+							if(check_attack_cooldown())
 								return
 							else
 								A.attackby(host.get_held_item_by_index(GRASP_RIGHT_HAND), host, 1, src)
-								attack_cooldown = 1
-								reset_attack_cooldown()
+								set_attack_cooldown()
 								return
 						else if(istype(A, /obj/item))
 							var/obj/item/I = A
@@ -1211,12 +1208,11 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 								return
 					else
 						if(host.get_held_item_by_index(GRASP_LEFT_HAND))
-							if(attack_cooldown)
+							if(check_attack_cooldown())
 								return
 							else
 								A.attackby(host.get_held_item_by_index(GRASP_LEFT_HAND), host, 1, src)
-								attack_cooldown = 1
-								reset_attack_cooldown()
+								set_attack_cooldown()
 								return
 						else if(istype(A, /obj/item))
 							var/obj/item/I = A
@@ -1247,6 +1243,9 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 								chemicals -= 10
 				extend_o_arm.afterattack(A, host)
 
-/mob/living/simple_animal/borer/proc/reset_attack_cooldown()
-	spawn(10)
-		attack_cooldown = 0
+/mob/living/simple_animal/borer/proc/check_attack_cooldown()
+	var/datum/delay_controller/host_attack_delayer = host.attack_delayer
+	return host_attack_delayer.blocked()
+
+/mob/living/simple_animal/borer/proc/set_attack_cooldown()
+	host.delayNextAttack(10)

--- a/code/modules/mob/living/simple_animal/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer.dm
@@ -317,7 +317,7 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 	for(var/mob/M in player_list)
 		if(istype(M, /mob/new_player))
 			continue
-		if(istype(M,/mob/dead/observer)  && (M.client && M.client.prefs.toggles & CHAT_GHOSTEARS))
+		if(istype(M,/mob/dead/observer)  && (M.client && (M.client.prefs.toggles & CHAT_GHOSTEARS || get_turf(src) in view(M))))
 			var/controls = "<a href='byond://?src=\ref[M];follow2=\ref[M];follow=\ref[src]'>Follow</a>"
 			if(M.client.holder)
 				controls+= " | <A HREF='?_src_=holder;adminmoreinfo=\ref[src]'>?</A>"
@@ -535,7 +535,7 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 /mob/living/simple_animal/borer/proc/infest_limb(var/obj/item/weapon/organ/limb)
 	detach()
 	limb.borer=src
-	loc=limb
+	forceMove(limb)
 
 	update_verbs(BORER_MODE_SEVERED)
 
@@ -572,22 +572,32 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 	if(!src)
 		return
 
-	if(hostlimb == LIMB_HEAD)
-		to_chat(src, "<span class='info'>You begin disconnecting from [host]'s synapses and prodding at their internal ear canal.</span>")
+	if(severed)
+		if(istype(loc, /obj/item/weapon/organ/head))
+			to_chat(src, "<span class='info'>You begin disconnecting from \the [loc]'s synapses and prodding at its internal ear canal.</span>")
+		else
+			to_chat(src, "<span class='info'>You begin disconnecting from \the [loc]'s nerve endings and prodding at the surface of its skin.</span>")
 	else
-		to_chat(src, "<span class='info'>You begin disconnecting from [host]'s nerve endings and prodding at the surface of their skin.</span>")
+		if(hostlimb == LIMB_HEAD)
+			to_chat(src, "<span class='info'>You begin disconnecting from \the [host]'s synapses and prodding at their internal ear canal.</span>")
+		else
+			to_chat(src, "<span class='info'>You begin disconnecting from \the [host]'s nerve endings and prodding at the surface of their skin.</span>")
 
-	spawn(200)
+	var/leave_time = 200
+	if(severed)
+		leave_time = 20
+
+	spawn(leave_time)
 
 		if((!host && !severed) || !src)
 			return
 
 		if(src.stat)
-			to_chat(src, "<span class='warning'>You cannot abandon [host] in your current state.</span>")
+			to_chat(src, "<span class='warning'>You cannot abandon [host ? host : "\the [loc]"] in your current state.</span>")
 			return
 
 		if(channeling)
-			to_chat(src, "<span class='warning'>You cannot abandon [host] while your focus is directed elsewhere.</span>")
+			to_chat(src, "<span class='warning'>You cannot abandon [host ? host : "\the [loc]"] while your focus is directed elsewhere.</span>")
 			return
 
 		if(controlling)
@@ -599,15 +609,15 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 			return
 
 		if(severed)
-			if(hostlimb == LIMB_HEAD)
+			if(istype(loc, /obj/item/weapon/organ/head))
 				to_chat(src, "<span class='info'>You wiggle out of the ear of \the [loc] and plop to the ground.</span>")
 			else
-				to_chat(src, "<span class='info'>You wiggle out of \the [limb_to_name(hostlimb)] and plop to the ground.</span>")
+				to_chat(src, "<span class='info'>You wiggle out of \the [loc] and plop to the ground.</span>")
 		else
 			if(hostlimb == LIMB_HEAD)
-				to_chat(src, "<span class='info'>You wiggle out of [host]'s ear and plop to the ground.</span>")
+				to_chat(src, "<span class='info'>You wiggle out of \the [host]'s ear and plop to the ground.</span>")
 			else
-				to_chat(src, "<span class='info'>You wiggle out of [host]'s [limb_to_name(hostlimb)] and plop to the ground.</span>")
+				to_chat(src, "<span class='info'>You wiggle out of \the [host]'s [limb_to_name(hostlimb)] and plop to the ground.</span>")
 
 		detach()
 
@@ -1171,6 +1181,8 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 				if(!extend_o_arm)
 					extend_o_arm = new /obj/item/weapon/gun/hookshot/flesh(src, src)
 					extend_o_arm.forceMove(host)
+				if(!check_can_do())
+					return
 				if(istype(host.get_held_item_by_index(GRASP_RIGHT_HAND), /obj/item/offhand) || istype(host.get_held_item_by_index(GRASP_LEFT_HAND), /obj/item/offhand)) //If the host is two-handing something.
 					to_chat(src, "<span class='warning'>You cannot swing this item while your host holds it with both hands!</span>")
 					return

--- a/code/modules/mob/living/simple_animal/borer/fleshshot.dm
+++ b/code/modules/mob/living/simple_animal/borer/fleshshot.dm
@@ -25,6 +25,10 @@
 	if(!parent_borer)
 		qdel(src)
 
+/obj/item/weapon/gun/hookshot/flesh/dropped()
+	..()
+	qdel(src)
+
 /obj/item/weapon/gun/hookshot/flesh/Destroy()//if a single link of the chain is destroyed, the rest of the chain is instantly destroyed as well.
 	if(parent_borer)
 		if(parent_borer.extend_o_arm == src)

--- a/code/modules/mob/living/simple_animal/borer/fleshshot.dm
+++ b/code/modules/mob/living/simple_animal/borer/fleshshot.dm
@@ -362,14 +362,13 @@
 			if(OE.grasp_id) //If borer is in an arm
 				var/obj/item/held = L.get_held_item_by_index(OE.grasp_id)
 				if(held)
-					if(!parent_borer.attack_cooldown)
+					if(!parent_borer.check_attack_cooldown())
 						A.attackby(held, L, 1, parent_borer)
 						if(!parent_borer)	//There's already a check for this above, but for some reason when it hits an airlock it gets qdel()'d before it gets to this point.
 							bullet_die()
 							return
 
-						parent_borer.attack_cooldown = 1
-						parent_borer.reset_attack_cooldown()
+						parent_borer.set_attack_cooldown()
 					bullet_die()
 					return
 

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -7,7 +7,6 @@
 			continue
 		drop_from_inventory(W)
 	regenerate_icons()
-	dropBorers()
 	monkeyizing = 1
 	canmove = 0
 	delayNextAttack(50)
@@ -26,6 +25,8 @@
 	var/mob/living/carbon/monkey/O = null
 
 	O = new species.primitive(get_turf(src))
+
+	transferBorers(O)
 
 	O.dna = dna.Clone()
 	O.dna.SetSEState(MONKEYBLOCK,1)
@@ -306,7 +307,6 @@
 		return
 	for(var/obj/item/W in src)
 		drop_from_inventory(W)
-	dropBorers()
 	regenerate_icons()
 	monkeyizing = 1
 	canmove = 0
@@ -317,6 +317,7 @@
 		qdel(t)
 
 	var/mob/living/carbon/slime/new_slime
+	transferBorers(new_slime)
 	if(reproduce)
 		var/number = pick(14;2,3,4)	//reproduce (has a small chance of producing 3 or 4 offspring)
 		var/list/babies = list()

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -632,9 +632,6 @@ Note that amputating the affected organ does in fact remove the infection from t
 		src.status &= ~ORGAN_SPLINTED
 		src.status &= ~ORGAN_DEAD
 
-		for(var/implant in implants)
-			qdel(implant)
-
 		//If any organs are attached to this, destroy them
 		for(var/datum/organ/external/O in children)
 			O.droplimb(1)
@@ -645,6 +642,9 @@ Note that amputating the affected organ does in fact remove the infection from t
 			if(species) //Transfer species to the generated organ
 				organ.species = src.species
 				organ.update_icon()
+
+		for(var/implant in implants)
+			qdel(implant)
 
 		src.species = null
 

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -662,6 +662,7 @@
 				C.mind.transfer_to(new_mob)
 			else
 				new_mob.key = C.key
+			C.transferBorers(new_mob)
 			qdel(C)
 
 /datum/reagent/stoxin


### PR DESCRIPTION
Borers are now properly placed into severed limbs.
Fixes #6629
Fixes #11114

Being turned into a monkey no longer causes head borers to drop.

Fixes #10911
Fixes #11020
Fixes #11385

The fleshshot is no longer capable of being dropped through any means.

As far as _adjacent_ attacks go, arm borers' attack delays are now tied directly to their hosts (and, by extension, the other arm borer's).
Fixes #11897

What I did _should_ fix #10911 and #11897, but I can't really test these alone.
Every other fix has been tested.
