### PR TITLE
Fixes beam runtimes

### DIFF
--- a/code/__HELPERS/_macros.dm
+++ b/code/__HELPERS/_macros.dm
@@ -133,6 +133,8 @@
 
 #define isatom(A) (istype(A, /atom))
 
+#define isatommovable(A) (istype(A, /atom/movable))
+
 #define ismatrix(A) (istype(A, /matrix))
 
 //Macros for antags

--- a/code/game/gamemodes/blob/blobs/core.dm
+++ b/code/game/gamemodes/blob/blobs/core.dm
@@ -6,6 +6,7 @@
 	maxhealth = 200
 	fire_resist = 2
 	custom_process=1
+	destroy_sound = "sound/effects/blobkill.ogg"
 	var/overmind_get_delay = 0 // we don't want to constantly try to find an overmind, do it every 30 seconds
 	var/resource_delay = 0
 	var/last_resource_collection
@@ -66,13 +67,7 @@
 			to_chat(overmind,"<span class='danger'>YOUR CORE IS UNDER ATTACK!</span> <b><a href='?src=\ref[overmind];blobjump=\ref[loc]'>(JUMP)</a></b>")
 
 	previous_health = health
-
-	if(health <= 0)
-		dying = 1
-		playsound(get_turf(src), 'sound/effects/blobkill.ogg', 50, 1)
-		Delete()
-		return
-	return
+	..()
 
 /obj/effect/blob/core/Life()
 	if(timestopped)

--- a/code/game/gamemodes/blob/blobs/factory.dm
+++ b/code/game/gamemodes/blob/blobs/factory.dm
@@ -10,6 +10,7 @@
 	var/spore_delay = 50
 	spawning = 0
 	layer = BLOB_FACTORY_LAYER
+	destroy_sound = "sound/effects/blobsplatspecial.ogg"
 
 	icon_new = "factory"
 	icon_classic = "blob_factory"
@@ -19,14 +20,6 @@
 	if(blob_looks[looks] == 64)
 		flick("morph_factory",src)
 		spore_delay = world.time + (2 SECONDS)
-
-/obj/effect/blob/factory/update_health()
-	if(health <= 0)
-		dying = 1
-		playsound(get_turf(src), 'sound/effects/blobsplatspecial.ogg', 50, 1)
-		qdel(src)
-		return
-	return
 
 /obj/effect/blob/factory/run_action()
 	if(spores.len >= max_spores)

--- a/code/game/gamemodes/blob/blobs/node.dm
+++ b/code/game/gamemodes/blob/blobs/node.dm
@@ -8,6 +8,7 @@
 	custom_process=1
 	layer = BLOB_NODE_LAYER
 	spawning = 0
+	destroy_sound = "sound/effects/blobsplatspecial.ogg"
 
 	icon_new = "node"
 	icon_classic = "blob_node"
@@ -48,14 +49,6 @@
 		health = min(maxhealth, health + 1)
 		update_icon()
 
-/obj/effect/blob/node/update_health()
-	if(health <= 0)
-		dying = 1
-		playsound(get_turf(src), 'sound/effects/blobsplatspecial.ogg', 50, 1)
-		Delete()
-		return
-	return
-
 /obj/effect/blob/node/run_action()
 	return 0
 
@@ -76,4 +69,3 @@
 
 
 			..()
-

--- a/code/game/gamemodes/blob/blobs/resource.dm
+++ b/code/game/gamemodes/blob/blobs/resource.dm
@@ -8,6 +8,7 @@
 	var/resource_delay = 0
 	spawning = 0
 	layer = BLOB_RESOURCE_LAYER
+	destroy_sound = "sound/effects/blobsplatspecial.ogg"
 
 	icon_new = "resource"
 	icon_classic = "blob_resource"
@@ -26,14 +27,6 @@
 		overmind.special_blobs -= src
 		overmind.update_specialblobs()
 	..()
-
-/obj/effect/blob/resource/update_health()
-	if(health <= 0)
-		dying = 1
-		playsound(get_turf(src), 'sound/effects/blobsplatspecial.ogg', 50, 1)
-		qdel(src)
-		return
-	return
 
 /obj/effect/blob/resource/Pulse(var/pulse = 0, var/origin_dir = 0)
 	if(!overmind)

--- a/code/game/gamemodes/blob/blobs/shield.dm
+++ b/code/game/gamemodes/blob/blobs/shield.dm
@@ -7,6 +7,7 @@
 	fire_resist = 2
 	layer = BLOB_SHIELD_LAYER
 	spawning = 0
+	destroy_sound = "sound/effects/blobsplat.ogg"
 
 	icon_new = "strong"
 	icon_classic = "blob_idle"
@@ -14,14 +15,6 @@
 /obj/effect/blob/shield/New(loc,newlook = "new")
 	..()
 	flick("morph_strong",src)
-
-/obj/effect/blob/shield/update_health()
-	if(health <= 0)
-		dying = 1
-		playsound(get_turf(src), 'sound/effects/blobsplat.ogg', 50, 1)
-		qdel(src)
-		return
-	return
 
 /obj/effect/blob/shield/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	return

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -148,9 +148,7 @@ var/list/blob_looks
 
 /obj/effect/blob/beam_disconnect(var/obj/effect/beam/B)
 	..()
-	apply_beam_damage(B)
 	last_beamchecks.Remove("\ref[B]") // RIP
-	update_health()
 	update_icon()
 	if(beams.len == 0)
 		if(!custom_process && src in processing_objects)
@@ -174,10 +172,10 @@ var/list/blob_looks
 		apply_beam_damage(B)
 	update_health()
 	update_icon()
-	
+
 /obj/effect/blob/can_mech_drill()
 	return TRUE
-	
+
 /obj/effect/blob/process()
 	handle_beams()
 	Life()

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -57,6 +57,7 @@ var/list/blob_looks
 	var/spawning = 2
 	var/dying = 0
 	var/mob/camera/blob/overmind = null
+	var/destroy_sound = "sound/effects/blobsplat.ogg"
 
 	var/looks = "new"
 
@@ -148,7 +149,9 @@ var/list/blob_looks
 
 /obj/effect/blob/beam_disconnect(var/obj/effect/beam/B)
 	..()
+	apply_beam_damage(B)
 	last_beamchecks.Remove("\ref[B]") // RIP
+	update_health()
 	update_icon()
 	if(beams.len == 0)
 		if(!custom_process && src in processing_objects)
@@ -397,12 +400,11 @@ var/list/blob_looks = list(
 	qdel(src)
 
 /obj/effect/blob/proc/update_health()
-	if(health <= 0)
+	if(!dying && (health <= 0))
 		dying = 1
-		playsound(get_turf(src), 'sound/effects/blobsplat.ogg', 50, 1)
-
+		if(get_turf(src))
+			playsound(src, destroy_sound, 50, 1)
 		Delete()
-		return
 
 //////////////////NORMAL BLOBS/////////////////////////////////
 /obj/effect/blob/normal

--- a/code/game/objects/effects/beam.dm
+++ b/code/game/objects/effects/beam.dm
@@ -151,7 +151,8 @@
 		beam_testing("\ref[BM] - Disconnecting [BM.target]: target changed.")
 		BM.disconnect(0)
 	BM.target=AM
-	BM.targetMoveKey    = AM.on_moved.Add(BM,    "target_moved")
+	if(istype(AM))
+		BM.targetMoveKey    = AM.on_moved.Add(BM,    "target_moved")
 	BM.targetDestroyKey = AM.on_destroyed.Add(BM,"target_destroyed")
 	BM.targetContactLoc = AM.loc
 	beam_testing("\ref[BM] - Connected to [AM]")
@@ -179,7 +180,8 @@
 /obj/effect/beam/proc/disconnect(var/re_emit=1)
 	var/obj/effect/beam/_master=get_master()
 	if(_master.target)
-		_master.target.on_moved.Remove(_master.targetMoveKey)
+		if(isatommovable(_master.target) && _master.target.on_moved)
+			_master.target.on_moved.Remove(_master.targetMoveKey)
 		_master.target.on_destroyed.Remove(_master.targetDestroyKey)
 		_master.target.beam_disconnect(_master)
 		_master.target=null


### PR DESCRIPTION
Sanity checks and removing the unnecessary damage application on beam disconnect for blobs.  The blob piece would try to delete itself twice resulting in runtimes if it was destroyed with a beam attached.

Fixes #12336

:cl:
- bugfix: Fixed emitters bugging out on blobs.
