### PR TITLE
Make hide sprite make ghosts not get in the mouse's way.

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -792,9 +792,11 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	// Toggle alpha
 	if(alpha == 127)
 		alpha = 0
+		mouse_opacity = 0
 		to_chat(src, "<span class='warning'>Sprite hidden.</span>")
 	else
 		alpha = 127
+		mouse_opacity = 1
 		to_chat(src, "<span class='info'>Sprite shown.</span>")
 
 


### PR DESCRIPTION
Don't see any reason they still need to be clickable when their sprite is hidden
Currently they just take up extra space in right-click menus and get in the way of clicking on mobs they might be haunting as well
