### PR TITLE
Broken components can now be fixed with nanopaste

### DIFF
--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -161,11 +161,12 @@
 
 /obj/item/broken_device/attackby(var/obj/item/weapon/W, var/mob/user)
 	if(istype(W, /obj/item/stack/nanopaste))
-		var/obj/item/stack/nanopaste/C = W
-		new src.component (src.loc)
-		to_chat(user, "<span class='notice'>You fix the broken component.</span>")
-		C.use(1)
-		qdel(src)
+		if(do_after(user,src,30))
+			var/obj/item/stack/nanopaste/C = W
+			new src.component (src.loc)
+			to_chat(user, "<span class='notice'>You fix the broken component.</span>")
+			C.use(1)
+			qdel(src)
 
 //
 //Robotic Component Analyser, basically a health analyser for robots

--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -23,12 +23,9 @@
 /datum/robot_component/proc/uninstall()
 
 /datum/robot_component/proc/destroy()
-	if(wrapped)
-		qdel (wrapped)
-		wrapped = null
-
-
-	wrapped = new/obj/item/broken_device
+	var/obj/item/broken_device/G = new/obj/item/broken_device
+	G.component = wrapped.type // the broken component now "remembers" the component it used to be, now it's scrap. This is used to fix the scrap into the component it was.
+	wrapped = G
 
 	// The thing itself isn't there anymore, but some fried remains are.
 	installed = -1
@@ -130,6 +127,7 @@
 	name = "broken component"
 	icon = 'icons/robot_component.dmi'
 	icon_state = "broken"
+	var/component = null //This remembers which component was it before breaking, so it can be fixed later (i.e nanopaste)
 
 /obj/item/robot_parts/robot_component
 	icon = 'icons/robot_component.dmi'
@@ -160,6 +158,14 @@
 /obj/item/robot_parts/robot_component/radio
 	name = "radio"
 	icon_state = "radio"
+
+/obj/item/broken_device/attackby(var/obj/item/weapon/W, var/mob/user)
+	if(istype(W, /obj/item/stack/nanopaste))
+		var/obj/item/stack/nanopaste/C = W
+		new src.component (src.loc)
+		to_chat(user, "<span class='notice'>You fix the broken component.</span>")
+		C.use(1)
+		qdel(src)
 
 //
 //Robotic Component Analyser, basically a health analyser for robots

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -2052,7 +2052,7 @@
 #include "interface\web\interface.dms"
 #include "maprendering\maprendering.dm"
 #include "maps\_map.dm"
-#include "maps\tgstation.dm"
+#include "maps\test_tiny.dm"
 #include "maps\defficiency\areas.dm"
 #include "maps\defficiency\pipes.dm"
 #include "maps\randomvaults\dance_revolution.dm"

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -2052,7 +2052,7 @@
 #include "interface\web\interface.dms"
 #include "maprendering\maprendering.dm"
 #include "maps\_map.dm"
-#include "maps\test_tiny.dm"
+#include "maps\tgstation.dm"
 #include "maps\defficiency\areas.dm"
 #include "maps\defficiency\pipes.dm"
 #include "maps\randomvaults\dance_revolution.dm"


### PR DESCRIPTION
What the tin says.

This opens a new discussion, how should it be balanced? How many uses of nanopaste should it use?
The thing here is, since you can now fix the broken components, there's no real point on printing new ones

:cl:
- rscadd: Broken robot components can now be fixed with nanopaste
