### PR TITLE
Long Overdue Feature Loss

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1576,9 +1576,6 @@ var/global/num_vending_terminals = 1
 		/obj/item/toy/waterflower = 1,
 		)
 
-	allowed_inputs = list(
-		/obj/item/seeds,
-		)
 	pack = /obj/structure/vendomatpack/hydroseeds
 
 /obj/machinery/vending/voxseeds
@@ -1604,10 +1601,6 @@ var/global/num_vending_terminals = 1
 		)
 	premium = list(
 		/obj/item/weapon/storage/box/boxen = 1
-		)
-
-	allowed_inputs = list(
-		/obj/item/seeds,
 		)
 
 /obj/machinery/vending/magivend


### PR DESCRIPTION
Fixes #6551
Fixes #7684
Fixes #8475
Fixes #8541
Fixes #8932

Seed packets work with datums, so trying to sort them by types in vending machines was stupid in the first place. I'm fixing an old mistake.

:cl:
- rscdel: You can no longer place seed packets back into the MegaSeed Servitor. Nobody will miss that feature. Incidentally you cannot re-roll exotic seeds that way anymore. Worth noting that the Seed Extractor can still store seed perfectly fine.
