### PR TITLE
Fixed Viscerator spawned by nuke ops attacking everyone indiscriminatly

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/viscerator.dm
+++ b/code/modules/mob/living/simple_animal/hostile/viscerator.dm
@@ -38,6 +38,11 @@
 	qdel (src)
 	return
 
+/mob/living/simple_animal/hostile/viscerator/CanAttack(var/atom/the_target)
+	if(isnukeop(the_target) && faction == "syndicate")
+		return 0
+	return ..(the_target)
+
 /mob/living/simple_animal/hostile/viscerator/Cross(atom/movable/mover, turf/target, height = 1.5, air_group = 0)
 	if(air_group || (height == 0))
 		return 1

--- a/code/modules/mob/living/simple_animal/hostile/viscerator.dm
+++ b/code/modules/mob/living/simple_animal/hostile/viscerator.dm
@@ -41,7 +41,7 @@
 /mob/living/simple_animal/hostile/viscerator/CanAttack(var/atom/the_target)
 	if(ismob(the_target))
 		var/mob/mob_target = the_target
-		if(isnukeop(mob_target.mind) && faction == "syndicate")
+		if(isnukeop(mob_target) && faction == "syndicate")
 			return 0
 	return ..(the_target)
 

--- a/code/modules/mob/living/simple_animal/hostile/viscerator.dm
+++ b/code/modules/mob/living/simple_animal/hostile/viscerator.dm
@@ -39,8 +39,10 @@
 	return
 
 /mob/living/simple_animal/hostile/viscerator/CanAttack(var/atom/the_target)
-	if(isnukeop(the_target) && faction == "syndicate")
-		return 0
+	if(ismob(the_target))
+		var/mob/mob_target = the_target
+		if(isnukeop(mob_target.mind) && faction == "syndicate")
+			return 0
 	return ..(the_target)
 
 /mob/living/simple_animal/hostile/viscerator/Cross(atom/movable/mover, turf/target, height = 1.5, air_group = 0)


### PR DESCRIPTION
Fixes #9808

:cl:
- bugfix: Viscerator spawned by grenades thrown by nuke ops now properly ignore their owner and other nuke ops.
