### PR TITLE
fixes self surgery / surgery on flipped tables

### DIFF
--- a/code/WorkInProgress/autopsy.dm
+++ b/code/WorkInProgress/autopsy.dm
@@ -172,7 +172,7 @@
 	if(!istype(M))
 		return
 
-	if(!can_operate(M))
+	if(!can_operate(M, user))
 		return
 
 	if(target_name != M.name)

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1183,11 +1183,18 @@ var/global/list/common_tools = list(
 	)
 
 //check if mob is lying down on something we can operate him on.
-/proc/can_operate(mob/living/carbon/M)
-	return (ishuman(M) && M.lying && \
-	locate(/obj/machinery/optable, M.loc) || \
-	(locate(/obj/structure/bed/roller, M.loc) && prob(75)) || \
-	(locate(/obj/structure/table/, M.loc) && prob(66)))
+/proc/can_operate(mob/living/carbon/M, mob/U)
+	if(U == M)
+		return 0
+	if(ishuman(M) && M.lying)
+		if(locate(/obj/machinery/optable,M.loc))
+			return 1
+		if(locate(/obj/structure/bed/roller, M.loc) && prob(75))
+			return 1
+		var/obj/structure/table/T = locate(/obj/structure/table/, M.loc)
+		if(T && !T.flipped && prob(66))
+			return 1
+	return 0
 
 /*
 Checks if that loc and dir has a item on the wall

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -55,7 +55,7 @@ obj/item/proc/get_clamped_volume()
 	if (!istype(M)) // not sure if this is the right thing...
 		return 0
 	//var/messagesource = M
-	if (can_operate(M))        //Checks if mob is lying down on table for surgery
+	if (can_operate(M, user))        //Checks if mob is lying down on table for surgery
 		if (do_surgery(M,user,I))
 			return 1
 	//if (istype(M,/mob/living/carbon/brain))

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -96,7 +96,7 @@
 										"<span class='notice'>You place a bandaid over \the [W.desc] on [M]'s [affecting.display_name].</span>")
 				use(1)
 		else
-			if(can_operate(H))        //Checks if mob is lying down on table for surgery
+			if(can_operate(H, user))        //Checks if mob is lying down on table for surgery
 				if(do_surgery(H,user,src))
 					return
 			else
@@ -127,7 +127,7 @@
 										"<span class='notice'>You salve the wounds on [M]'s [affecting.display_name].</span>" )
 				use(1)
 		else
-			if(can_operate(H))        //Checks if mob is lying down on table for surgery
+			if(can_operate(H, user))        //Checks if mob is lying down on table for surgery
 				if(do_surgery(H,user,src))
 					return
 			else
@@ -187,7 +187,7 @@
 				affecting.heal_damage(rand(heal_brute, heal_brute + 5), 0)
 				use(1)
 		else
-			if(can_operate(H))        //Checks if mob is lying down on table for surgery
+			if(can_operate(H, user))        //Checks if mob is lying down on table for surgery
 				if(do_surgery(H,user,src))
 					return
 			else
@@ -220,7 +220,7 @@
 				affecting.heal_damage(0, rand(heal_burn, heal_burn + 5))
 				use(1)
 		else
-			if(can_operate(H))        //Checks if mob is lying down on table for surgery
+			if(can_operate(H, user))        //Checks if mob is lying down on table for surgery
 				if(do_surgery(H,user,src))
 					return
 			else

--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -37,7 +37,7 @@
 				else
 					to_chat(user, "<span class='notice'>Nothing to fix here.</span>")
 		else
-			if(can_operate(H))
+			if(can_operate(H, user))
 				if(do_surgery(H,user,src))
 					return
 			else

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -130,7 +130,7 @@
 /obj/item/weapon/screwdriver/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
 	if(!istype(M))
 		return ..()
-	if(can_operate(M))
+	if(can_operate(M, user))
 		return ..()
 	if(user.zone_sel.selecting != "eyes" && user.zone_sel.selecting != LIMB_HEAD)
 		return ..()
@@ -577,7 +577,7 @@
 
 /obj/item/weapon/weldingtool/attack(mob/M as mob, mob/user as mob)
 	if(hasorgans(M))
-		if(can_operate(M))
+		if(can_operate(M, user))
 			if(do_surgery(M, user, src))
 				return
 		var/datum/organ/external/S = M:organs_by_name[user.zone_sel.selecting]

--- a/code/modules/surgery/bones.dm
+++ b/code/modules/surgery/bones.dm
@@ -20,13 +20,6 @@
 	var/datum/organ/external/affected = target.get_organ(target_zone)
 	return (affected.open >= 2 || (target.species.flags & NO_SKIN)) && affected.stage == 0
 
-/*/datum/surgery_step/glue_bone/can_operate(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	var/datum/organ/external/affected = target.get_organ(target_zone)
-	if(affected.brute_dam >= affected.min_broken_damage * config.organ_health_multiplier)
-		to_chat(user, "<span class='warning'>The [affected.display_name] is far too damaged to operate on the fracture. Fix some of the damage first.</span>")
-		return 0
-	return ..()*/
-
 /datum/surgery_step/glue_bone/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/datum/organ/external/affected = target.get_organ(target_zone)
 	if (affected.stage == 0)
@@ -61,13 +54,6 @@
 /datum/surgery_step/set_bone/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/datum/organ/external/affected = target.get_organ(target_zone)
 	return affected.name != LIMB_HEAD && (affected.open >= 2 || (target.species.flags & NO_SKIN)) && affected.stage == 1
-
-/*/datum/surgery_step/set_bone/can_operate(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	var/datum/organ/external/affected = target.get_organ(target_zone)
-	if(affected.brute_dam >= affected.min_broken_damage * config.organ_health_multiplier)
-		to_chat(user, "<span class='warning'>The [affected.display_name] is far too damaged to operate on the fracture. Fix some of the damage first.</span>")
-		return 0
-	return ..()*/
 
 /datum/surgery_step/set_bone/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/datum/organ/external/affected = target.get_organ(target_zone)
@@ -109,13 +95,6 @@
 	var/datum/organ/external/affected = target.get_organ(target_zone)
 	return affected.name == LIMB_HEAD && (affected.open >= 2 || (target.species.flags & NO_SKIN))&& affected.stage == 1
 
-/*/datum/surgery_step/mend_skull/can_operate(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	var/datum/organ/external/affected = target.get_organ(target_zone)
-	if(affected.brute_dam >= affected.min_broken_damage * config.organ_health_multiplier)
-		to_chat(user, "<span class='warning'>The [affected.display_name] is far too damaged to operate on the fracture. Fix some of the damage first.</span>")
-		return 0
-	return ..()*/
-
 /datum/surgery_step/mend_skull/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	user.visible_message("[user] is beginning piece together [target]'s skull with \the [tool]."  , \
 		"You are beginning piece together [target]'s skull with \the [tool].")
@@ -153,13 +132,6 @@
 /datum/surgery_step/finish_bone/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/datum/organ/external/affected = target.get_organ(target_zone)
 	return (affected.open >= 2 || (target.species.flags & NO_SKIN)) && affected.stage == 2
-
-/*/datum/surgery_step/finish_bone/can_operate(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	var/datum/organ/external/affected = target.get_organ(target_zone)
-	if(affected.brute_dam >= affected.min_broken_damage * config.organ_health_multiplier)
-		to_chat(user, "<span class='warning'>The [affected.display_name] is far too damaged to operate on the fracture. Fix some of the damage first.</span>")
-		return 0
-	return ..()*/
 
 /datum/surgery_step/finish_bone/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/datum/organ/external/affected = target.get_organ(target_zone)

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -55,10 +55,6 @@
 /datum/surgery_step/proc/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	return 0
 
-	// once a surgery is selected, let's check if we can actually accomplish it
-/datum/surgery_step/proc/can_operate(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	return 1
-
 	// does stuff to begin the step, usually just printing messages. Moved germs transfering and bloodying here too
 /datum/surgery_step/proc/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/datum/organ/external/affected = target.get_organ(target_zone)
@@ -116,7 +112,7 @@ proc/do_surgery(mob/living/M, mob/living/user, obj/item/tool)
 			if(canuse == -1)
 				sleep_fail = 1
 			if(canuse && S.is_valid_mutantrace(M) && !(M in S.doing_surgery))
-				if(!S.can_operate(user, M, user.zone_sel.selecting, tool)) //ruh oh, we picked this step, but we can't actually do it for some special raisin
+				if(!can_operate(M, user))
 					return 1
 				M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has had surgery [S.type] with \the [tool] started by [user.name] ([user.ckey])</font>")
 				user.attack_log += text("\[[time_stamp()]\] <font color='red'>Started surgery [S.type] with \the [tool] on [M.name] ([M.ckey])</font>")


### PR DESCRIPTION
fixes #12397
removes /datum/surgery_step/proc/can_operate() since it's unused and just returns 1

🆑 
- bugfix: You can no longer perform self surgery, nor can you perform surgery when the person being operated on is on a flipped table.
