### PR TITLE
Minor Nar-Sie/Hell Rising changes

### DIFF
--- a/code/game/gamemodes/cult/hell_universe.dm
+++ b/code/game/gamemodes/cult/hell_universe.dm
@@ -112,7 +112,7 @@ In short:
 		if(istype(T, /turf/space))
 			T.overlays += image(icon = T.icon, icon_state = "hell01")
 		else
-			if(!T.holy && prob(1))
+			if(!T.holy && prob(1) && T.z != CENTCOMM_Z)
 				new /obj/effect/gateway/active/cult(T)
 			T.underlays += "hell01"
 		tcheck(85,1)
@@ -146,5 +146,5 @@ In short:
 /datum/universal_state/hell/proc/KillMobs()
 	for(var/mob/living/simple_animal/M in mob_list)
 		if(M && !M.client)
-			M.stat = DEAD
+			M.Die()
 		tcheck(80,1)

--- a/code/game/gamemodes/cult/narsie.dm
+++ b/code/game/gamemodes/cult/narsie.dm
@@ -57,7 +57,6 @@ var/global/list/narsie_list = list()
 		if (emergency_shuttle)
 			emergency_shuttle.incall()
 			emergency_shuttle.can_recall = 0
-			emergency_shuttle.settimeleft(600)
 
 		if(narnar)
 			SetUniversalState(/datum/universal_state/hell)

--- a/code/game/gamemodes/cult/narsie.dm
+++ b/code/game/gamemodes/cult/narsie.dm
@@ -57,6 +57,8 @@ var/global/list/narsie_list = list()
 		if (emergency_shuttle)
 			emergency_shuttle.incall()
 			emergency_shuttle.can_recall = 0
+			if(emergency_shuttle.endtime > world.timeofday + 1800 && emergency_shuttle.location != 1 && !emergency_shuttle.departed)
+				emergency_shuttle.settimeleft(180)
 
 		if(narnar)
 			SetUniversalState(/datum/universal_state/hell)


### PR DESCRIPTION
Summoning Nar-Sie sets the escape shuttle timer to three minutes.
The cult monster portals don't spawn on the centcomm z-level.
All simple animals now properly die when Hell Rising begins.
