### PR TITLE
set_light() via update() will now accept null values via maxed color

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -257,6 +257,8 @@ var/global/list/obj/machinery/light/alllights = list()
 					set_light(0)
 			else
 				use_power = 2
+				if((light_color != brightness_color) && !brightness_color)//set_light doesn't set to null values
+					brightness_color = "#FFFFFF"//so we'll use pure white as our value
 				set_light(brightness_range, brightness_power, brightness_color)
 	else
 		use_power = 1


### PR DESCRIPTION
see comments if the title is confusing

If you take a colored light bulb and put it in a socket, and then try putting in a bulb with a null color (aka almost every bulb ever), it will keep the color of the colored one.

this fixes that

There's no functional difference between #FFFFFF and a nulled var except maybe in some checks for updating color, it looks exactly the same otherwise
