### PR TITLE
Fix MoMMI spawner not spawning MoMMIs

### DIFF
--- a/code/game/machinery/mommi_spawner.dm
+++ b/code/game/machinery/mommi_spawner.dm
@@ -130,13 +130,13 @@
 /obj/machinery/mommi_spawner/proc/makeMoMMI(var/mob/user)
 	building = TRUE
 	update_icon()
-	if(!user || istype(user) || !user.client)
+	if(!user || !istype(user) || !user.client)
 		// Player has already been made into another mob before this one spawned, so let's reset the spawner
 		building = FALSE
 		update_icon()
 		return FALSE
 	spawn(50)
-		if(!user || istype(user) || !user.client)
+		if(!user || !istype(user) || !user.client)
 			// Player disappeared between clicking on the spawner and now, so we have no one to give a MoMMI to!
 			building = FALSE
 			update_icon()


### PR DESCRIPTION
fixes #12410 
peer review has failed to catch this simple mistake
there is no hope left
🆑 
 * bugfix: Fixes MoMMI spawners not spawning MoMMIs because I messed up my last fix for them.