### PR TITLE
Special tab QOL for admins

### DIFF
--- a/code/WorkInProgress/kilakk/fax.dm
+++ b/code/WorkInProgress/kilakk/fax.dm
@@ -209,7 +209,7 @@ var/list/alldepartments = list("Central Command")
 /proc/Centcomm_fax(var/obj/item/weapon/paper/sent, var/sentname, var/mob/Sender)
 
 //why the fuck doesnt the thing show as orange
-	var/msg = "<span class='notice'><b><font color='orange'>CENTCOMM FAX: </font>[key_name(Sender, 1)] (<A HREF='?_src_=holder;adminplayeropts=\ref[Sender]'>PP</A>) (<A HREF='?_src_=vars;Vars=\ref[Sender]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=\ref[Sender]'>SM</A>) (<A HREF='?_src_=holder;adminplayerobservejump=\ref[Sender]'>JMP</A>) (<A HREF='?_src_=holder;secretsadmin=check_antagonist'>CA</A>) (<A HREF='?_src_=holder;BlueSpaceArtillery=\ref[Sender]'>BSA</A>) (<a href='?_src_=holder;CentcommFaxReply=\ref[Sender]'>RPLY</a>)</b>: Receiving '[sentname]' via secure connection ... <a href='?_src_=holder;CentcommFaxView=\ref[sent]'>view message</a></span>"
+	var/msg = "<span class='notice'><b>  CENTCOMM FAX: [key_name(Sender, 1)] (<A HREF='?_src_=holder;adminplayeropts=\ref[Sender]'>PP</A>) (<A HREF='?_src_=vars;Vars=\ref[Sender]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=\ref[Sender]'>SM</A>) (<A HREF='?_src_=holder;adminplayerobservejump=\ref[Sender]'>JMP</A>) (<A HREF='?_src_=holder;secretsadmin=check_antagonist'>CA</A>) (<A HREF='?_src_=holder;BlueSpaceArtillery=\ref[Sender]'>BSA</A>) (<a href='?_src_=holder;CentcommFaxReply=\ref[Sender]'>RPLY</a>)</b>: Receiving '[sentname]' via secure connection ... <a href='?_src_=holder;CentcommFaxView=\ref[sent]'>view message</a></span>"
 	for (var/client/C in admins)
 		if(C.prefs.special_popup)
 			C << output(msg, "window1.msay_output")//if i get told to make this a proc imma be fuckin mad
@@ -229,25 +229,28 @@ proc/SendFax(var/sent, var/sentname, var/mob/Sender, var/dpt, var/centcomm)
 
 				flick("faxreceive", F)
 
+				var/obj/item/weapon/paper/P = new /obj/item/weapon/paper(F)
+
+				if (centcomm)
+					P.name = "[command_name()] - [sentname]"
+				else//probably a
+					P.name = "[sentname]"
+				P.info = "[sent]"
+				P.update_icon()
+
+				playsound(F.loc, "sound/effects/fax.ogg", 50, 1)
+
+				if(centcomm)
+					var/image/stampoverlay = image('icons/obj/bureaucracy.dmi')
+					stampoverlay.icon_state = "paper_stamp-cent"
+					if(!P.stamped)
+						P.stamped = new
+					P.stamped += /obj/item/weapon/stamp
+					P.overlays += stampoverlay
+					P.stamps += "<HR><i>This paper has been stamped by the Central Command Quantum Relay.</i>"
+
 				// give the sprite some time to flick
 				spawn(20)
-					var/obj/item/weapon/paper/P = new /obj/item/weapon/paper( F.loc )
-					if (centcomm)
-						P.name = "[command_name()]- [sentname]"
-					else//probably a
-						P.name = "[sentname]"
-					P.info = "[sent]"
-					P.update_icon()
+					P.forceMove(F.loc)
 
-					playsound(F.loc, "sound/effects/fax.ogg", 50, 1)
-
-					if(centcomm)
-						var/image/stampoverlay = image('icons/obj/bureaucracy.dmi')
-						stampoverlay.icon_state = "paper_stamp-cent"
-						if(!P.stamped)
-							P.stamped = new
-						P.stamped += /obj/item/weapon/stamp
-						P.overlays += stampoverlay
-						P.stamps += "<HR><i>This paper has been stamped by the Central Command Quantum Relay.</i>"
-
-					return P
+				return P

--- a/code/WorkInProgress/kilakk/fax.dm
+++ b/code/WorkInProgress/kilakk/fax.dm
@@ -219,9 +219,7 @@ var/list/alldepartments = list("Central Command")
 
 proc/SendFax(var/sent, var/sentname, var/mob/Sender, var/dpt, var/centcomm)
 
-
-
-
+	var/faxed = null
 	for(var/obj/machinery/faxmachine/F in allfaxes)
 
 		if(centcomm || F.department == dpt )
@@ -253,4 +251,5 @@ proc/SendFax(var/sent, var/sentname, var/mob/Sender, var/dpt, var/centcomm)
 				spawn(20)
 					P.forceMove(F.loc)
 
-				return P
+				faxed = P //doesn't return here in case there's multiple faxes in the department
+	return faxed

--- a/code/WorkInProgress/kilakk/fax.dm
+++ b/code/WorkInProgress/kilakk/fax.dm
@@ -249,3 +249,5 @@ proc/SendFax(var/sent, var/sentname, var/mob/Sender, var/dpt, var/centcomm)
 						P.stamped += /obj/item/weapon/stamp
 						P.overlays += stampoverlay
 						P.stamps += "<HR><i>This paper has been stamped by the Central Command Quantum Relay.</i>"
+
+					return P

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1547,3 +1547,12 @@ Game Mode config tags:
 	for(var/mob/M in mobs)
 		if(M.client)
 			. += M.client
+
+
+// A standard proc for generic output to the msay window, Not useful for things that have their own prefs settings (prayers for instance)
+/proc/output_to_msay(msg)
+	for(var/client/C in admins)
+		if(C.prefs.special_popup)
+			C << output(msg, "window1.msay_output")
+		else
+			to_chat(C, msg)

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1553,6 +1553,6 @@ Game Mode config tags:
 /proc/output_to_msay(msg)
 	for(var/client/C in admins)
 		if(C.prefs.special_popup)
-			C << output(msg, "window1.msay_output")
+			C << output("\[[time_stamp()]] [msg]", "window1.msay_output")
 		else
 			to_chat(C, msg)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2257,11 +2257,13 @@
 
 		var/sentname = input(src.owner, "Pick a title for the report", "Title") as text|null
 
-		SendFax(sent, sentname, centcomm = 1)
-
-		to_chat(src.owner, "Message reply to transmitted successfully.")
+		var/replyfax = SendFax(sent, sentname, centcomm = 1)
+		if(!replyfax)
+			to_chat(src.owner, "Message reply to [key_name(H)] failed.")
+			
+		to_chat(src.owner, "Message reply to [key_name(H)] transmitted successfully.")
 		log_admin("[key_name(src.owner)] replied to a fax message from [key_name(H)]: [sent]")
-		output_to_msay("[key_name_admin(src.owner)] replied to a fax message from [key_name_admin(H)]: [sent]", 1)
+		output_to_msay("[key_name_admin(src.owner)] replied to a fax message from [key_name_admin(H)]: <a href='?_src_=holder;CentcommFaxView=\ref[replyfax]'>view message</a>", 1)
 
 
 	else if(href_list["jumpto"])

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2140,14 +2140,14 @@
 			return
 
 		if(BSACooldown)
-			to_chat(src.owner, "Standby!  Reload cycle in progress!  Gunnary crews ready in five seconds!")
+			to_chat(src.owner, "Standby!  Reload cycle in progress!  Gunnery crews ready in five seconds!")
 			return
 
 		BSACooldown = 1
 		spawn(50)
 			BSACooldown = 0
 
-		to_chat(M, "You've been hit by bluespace artillery!")
+		to_chat(M, "<span class='danger'>You've been hit by bluespace artillery!</span>")
 
 		log_admin("[key_name(M)] has been hit by Bluespace Artillery fired by [src.owner]")
 		message_admins("[key_name(M)] has been hit by Bluespace Artillery fired by [src.owner]")
@@ -2180,63 +2180,63 @@
 		if(!check_rights(R_ADMIN))
 			return
 		var/mob/M = locate(href_list["PrayerReply"])
-		output_to_msay("[key_name(src.owner)] is replying to a prayer from [key_name(M)]")
+		output_to_msay("<b>[key_name_admin(src.owner)] is replying to a prayer from [key_name_admin(M)]</b>.")
 
 		usr.client.cmd_admin_subtle_message(M)
 
 	else if(href_list["CentcommReply"])
 		var/mob/M = locate(href_list["CentcommReply"])
 
-		output_to_msay("[key_name(src.owner)] is replying to a Centcomm message from [key_name(M)]")
+		output_to_msay("<b>[key_name_admin(src.owner)] is replying to a Centcomm message from [key_name_admin(M)]</b>.")
 
 		var/receive_type
 		if(istype(M, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = M
 			if(!istype(H.ears, /obj/item/device/radio/headset))
-				to_chat(usr, "The person you are trying to contact is not wearing a headset")
+				to_chat(usr, "<span class='warning'>The person you are trying to contact is not wearing a headset.</span>")
 				return
 			receive_type = "headset"
 		else if(istype(M, /mob/living/silicon))
 			receive_type = "official communication channel"
 		if(!receive_type)
-			to_chat(usr, "This mob type cannot be replied to")
+			to_chat(usr, "<span class='warning'>This mob type cannot be replied to.</span>")
 			return
 
 		var/input = input(src.owner, "Please enter a message to reply to [key_name(M)] via their [receive_type].","Outgoing message from Central Command", "")
 		if(!input)
 			return
 
-		to_chat(src.owner, "You sent [input] to [M] via a secure channel.")
+		to_chat(src.owner, "You sent <b>\"[input]\"</b> to <b>[M]</b> via a secure channel.")
 		log_admin("[src.owner] replied to [key_name(M)]'s Centcomm message with the message [input].")
-		output_to_msay("[src.owner] replied to [key_name(M)]'s Centcom message with: \"[input]\"")
-		to_chat(M, "You hear something crackle from your [receive_type] for a moment before a voice speaks.  \"Please stand by for a message from Central Command.  Message as follows. <b>\"[input]\"</b>  Message ends.\"")
+		output_to_msay("<b>[key_name_admin(src.owner)] replied to [key_name_admin(M)]'s Centcom message with:</b> \"[input]\"")
+		to_chat(M, "<span class='notice'>You hear something crackle from your [receive_type] for a moment before a voice speaks:</span>\n\"Please stand by for a message from Central Command. Message as follows.\"\n<b>\"[input]\"</b>")
 
 	else if(href_list["SyndicateReply"])
 		var/mob/M = locate(href_list["SyndicateReply"])
 
-		output_to_msay("[key_name(src.owner)] is replying to a Syndicate message from [key_name(M)]")
+		output_to_msay("<b>[key_name_admin(src.owner)] is replying to a Syndicate message from [key_name_admin(M)]</b>.")
 
 		var/receive_type
 		if(istype(M, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = M
 			if(!istype(H.ears, /obj/item/device/radio/headset))
-				to_chat(usr, "The person you are trying to contact is not wearing a headset")
+				to_chat(usr, "<span class='warning'>The person you are trying to contact is not wearing a headset.</span>")
 				return
 			receive_type = "headset"
 		else if(istype(M, /mob/living/silicon))
 			receive_type = "undetectable communications channel"
 		if(!receive_type)
-			to_chat(usr, "This mob type cannot be replied to")
+			to_chat(usr, "<span class='warning'>This mob type cannot be replied to.</span>")
 			return
 
 		var/input = input(src.owner, "Please enter a message to reply to [key_name(M)] via their [receive_type].","Outgoing message from The Syndicate", "")
 		if(!input)
 			return
 
-		to_chat(src.owner, "You sent [input] to [M] via a secure channel.")
+		to_chat(src.owner, "You sent <b>\"[input]\"</b> to <b>[M]</b> via a secure channel.")
 		log_admin("[src.owner] replied to [key_name(M)]'s Syndicate message with the message [input].")
-		output_to_msay("[src.owner] replied to [key_name(M)]'s Syndicate message with: \"[input]\"")
-		to_chat(M, "You hear something crackle from your [receive_type] for a moment before a voice speaks.  \"Please stand by for a message from your benefactor.  Message as follows, agent. <b>\"[input]\"</b>  Message ends.\"")
+		output_to_msay("<b>[key_name_admin(src.owner)] replied to [key_name_admin(M)]'s Syndicate message with:</b> \"[input]\"")
+		to_chat(M, "<span class='notice'>You hear something crackle from your [receive_type] for a moment before a voice speaks:</span>\n\"Please stand by for a message from your benefactor, agent. Message as follows.\"\n<b>\"[input]\"</b>")
 
 	else if(href_list["CentcommFaxView"])
 		var/obj/item/weapon/paper/P = locate(href_list["CentcommFaxView"])
@@ -2249,7 +2249,7 @@
 	else if(href_list["CentcommFaxReply"])
 		var/mob/living/carbon/human/H = locate(href_list["CentcommFaxReply"])
 
-		output_to_msay("[key_name(src.owner)] is replying to a fax message from [key_name(H)]")
+		output_to_msay("<b>[key_name_admin(src.owner)] is replying to a fax message from [key_name_admin(H)].</b>")
 
 		var/sent = input(src.owner, "Please enter a message to reply to [key_name(H)] via secure connection. NOTE: BBCode does not work, but HTML tags do! Use <br> for line breaks.", "Outgoing message from Centcomm", "") as message|null
 		if(!sent)
@@ -2259,11 +2259,12 @@
 
 		var/obj/item/weapon/paper/replyfax = SendFax(sent, sentname, centcomm = 1)
 		if(!istype(replyfax))
-			to_chat(src.owner, "Message reply to [key_name(H)] failed.")
+			to_chat(src.owner, "<span class='warning'>Message reply to [key_name(H)] failed.</span>")
 			return
-		to_chat(src.owner, "Message reply to [key_name(H)] transmitted successfully.")
+
+		to_chat(src.owner, "<span class='notice'>Message reply to [key_name(H)] transmitted successfully.</span>")
 		log_admin("[key_name(src.owner)] replied to a fax message from [key_name(H)]: [sent]")
-		output_to_msay("[key_name_admin(src.owner)] replied to a fax message from [key_name_admin(H)]: <a href='?_src_=holder;CentcommFaxView=\ref[replyfax]'>view message</a>")
+		output_to_msay("<b>[key_name_admin(src.owner)] replied to a fax message from [key_name_admin(H)]:</b> <a href='?_src_=holder;CentcommFaxView=\ref[replyfax]'>View Message</a>")
 
 
 	else if(href_list["jumpto"])

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2176,8 +2176,19 @@
 			M.Weaken(20)
 			M.stuttering = 20
 
+	else if (href_list["PrayerReply"])
+		if(!check_rights(R_ADMIN))
+			return
+		var/mob/M = locate(href_list["subtlemessage"])
+		output_to_msay("[key_name(src.owner)] is replying to a prayer from [key_name(M)]")
+
+		usr.client.cmd_admin_subtle_message(M)
+
 	else if(href_list["CentcommReply"])
 		var/mob/M = locate(href_list["CentcommReply"])
+
+		output_to_msay("[key_name(src.owner)] is replying to a Centcomm message from [key_name(M)]")
+
 		var/receive_type
 		if(istype(M, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = M
@@ -2202,6 +2213,9 @@
 
 	else if(href_list["SyndicateReply"])
 		var/mob/M = locate(href_list["SyndicateReply"])
+
+		output_to_msay("[key_name(src.owner)] is replying to a Syndicate message from [key_name(M)]")
+
 		var/receive_type
 		if(istype(M, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = M
@@ -2235,6 +2249,7 @@
 	else if(href_list["CentcommFaxReply"])
 		var/mob/living/carbon/human/H = locate(href_list["CentcommFaxReply"])
 
+		output_to_msay("[key_name(src.owner)] is replying to a fax message from [key_name(H)]")
 
 		var/sent = input(src.owner, "Please enter a message to reply to [key_name(H)] via secure connection. NOTE: BBCode does not work, but HTML tags do! Use <br> for line breaks.", "Outgoing message from Centcomm", "") as message|null
 		if(!sent)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2260,7 +2260,7 @@
 		var/replyfax = SendFax(sent, sentname, centcomm = 1)
 		if(!replyfax)
 			to_chat(src.owner, "Message reply to [key_name(H)] failed.")
-			
+			return
 		to_chat(src.owner, "Message reply to [key_name(H)] transmitted successfully.")
 		log_admin("[key_name(src.owner)] replied to a fax message from [key_name(H)]: [sent]")
 		output_to_msay("[key_name_admin(src.owner)] replied to a fax message from [key_name_admin(H)]: <a href='?_src_=holder;CentcommFaxView=\ref[replyfax]'>view message</a>", 1)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2257,8 +2257,8 @@
 
 		var/sentname = input(src.owner, "Pick a title for the report", "Title") as text|null
 
-		var/replyfax = SendFax(sent, sentname, centcomm = 1)
-		if(!replyfax)
+		var/obj/item/weapon/paper/replyfax = SendFax(sent, sentname, centcomm = 1)
+		if(!istype(replyfax))
 			to_chat(src.owner, "Message reply to [key_name(H)] failed.")
 			return
 		to_chat(src.owner, "Message reply to [key_name(H)] transmitted successfully.")

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2208,7 +2208,7 @@
 
 		to_chat(src.owner, "You sent [input] to [M] via a secure channel.")
 		log_admin("[src.owner] replied to [key_name(M)]'s Centcomm message with the message [input].")
-		message_admins("[src.owner] replied to [key_name(M)]'s Centcom message with: \"[input]\"")
+		output_to_msay("[src.owner] replied to [key_name(M)]'s Centcom message with: \"[input]\"")
 		to_chat(M, "You hear something crackle from your [receive_type] for a moment before a voice speaks.  \"Please stand by for a message from Central Command.  Message as follows. <b>\"[input]\"</b>  Message ends.\"")
 
 	else if(href_list["SyndicateReply"])
@@ -2235,7 +2235,7 @@
 
 		to_chat(src.owner, "You sent [input] to [M] via a secure channel.")
 		log_admin("[src.owner] replied to [key_name(M)]'s Syndicate message with the message [input].")
-		message_admins("[src.owner] replied to [key_name(M)]'s Syndicate message with: \"[input]\"")
+		output_to_msay("[src.owner] replied to [key_name(M)]'s Syndicate message with: \"[input]\"")
 		to_chat(M, "You hear something crackle from your [receive_type] for a moment before a voice speaks.  \"Please stand by for a message from your benefactor.  Message as follows, agent. <b>\"[input]\"</b>  Message ends.\"")
 
 	else if(href_list["CentcommFaxView"])
@@ -2261,7 +2261,7 @@
 
 		to_chat(src.owner, "Message reply to transmitted successfully.")
 		log_admin("[key_name(src.owner)] replied to a fax message from [key_name(H)]: [sent]")
-		message_admins("[key_name_admin(src.owner)] replied to a fax message from [key_name_admin(H)]", 1)
+		output_to_msay("[key_name_admin(src.owner)] replied to a fax message from [key_name_admin(H)]: [sent]", 1)
 
 
 	else if(href_list["jumpto"])

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2180,14 +2180,14 @@
 		if(!check_rights(R_ADMIN))
 			return
 		var/mob/M = locate(href_list["PrayerReply"])
-		output_to_msay("<b>[key_name_admin(src.owner)] is replying to a prayer from [key_name_admin(M)]</b>.")
+		output_to_msay("<span class = 'bold'>[key_name_admin(src.owner)] is replying to a prayer from [key_name_admin(M)]</span>.")
 
 		usr.client.cmd_admin_subtle_message(M)
 
 	else if(href_list["CentcommReply"])
 		var/mob/M = locate(href_list["CentcommReply"])
 
-		output_to_msay("<b>[key_name_admin(src.owner)] is replying to a Centcomm message from [key_name_admin(M)]</b>.")
+		output_to_msay("<span class = 'bold'>[key_name_admin(src.owner)] is replying to a Centcomm message from [key_name_admin(M)]</span>.")
 
 		var/receive_type
 		if(istype(M, /mob/living/carbon/human))
@@ -2206,15 +2206,15 @@
 		if(!input)
 			return
 
-		to_chat(src.owner, "You sent <b>\"[input]\"</b> to <b>[M]</b> via a secure channel.")
+		to_chat(src.owner, "You sent <span class = 'bold'>\"[input]\"</span> to <span class = 'bold'>[M]</span> via a secure channel.")
 		log_admin("[src.owner] replied to [key_name(M)]'s Centcomm message with the message [input].")
-		output_to_msay("<b>[key_name_admin(src.owner)] replied to [key_name_admin(M)]'s Centcom message with:</b> \"[input]\"")
-		to_chat(M, "<span class='notice'>You hear something crackle from your [receive_type] for a moment before a voice speaks:</span>\n\"Please stand by for a message from Central Command. Message as follows.\"\n<b>\"[input]\"</b>")
+		output_to_msay("<span class = 'bold'>[key_name_admin(src.owner)] replied to [key_name_admin(M)]'s Centcom message with:</span> \"[input]\"")
+		to_chat(M, "<span class='notice'>You hear something crackle from your [receive_type] for a moment before a voice speaks:</span>\n\"Please stand by for a message from Central Command. Message as follows.\"\n<span class = 'bold'>\"[input]\"</span>")
 
 	else if(href_list["SyndicateReply"])
 		var/mob/M = locate(href_list["SyndicateReply"])
 
-		output_to_msay("<b>[key_name_admin(src.owner)] is replying to a Syndicate message from [key_name_admin(M)]</b>.")
+		output_to_msay("<span class = 'bold'>[key_name_admin(src.owner)] is replying to a Syndicate message from [key_name_admin(M)]</span>.")
 
 		var/receive_type
 		if(istype(M, /mob/living/carbon/human))
@@ -2233,10 +2233,10 @@
 		if(!input)
 			return
 
-		to_chat(src.owner, "You sent <b>\"[input]\"</b> to <b>[M]</b> via a secure channel.")
+		to_chat(src.owner, "You sent <span class = 'bold'>\"[input]\"</span> to <span class = 'bold'>[M]</span> via a secure channel.")
 		log_admin("[src.owner] replied to [key_name(M)]'s Syndicate message with the message [input].")
-		output_to_msay("<b>[key_name_admin(src.owner)] replied to [key_name_admin(M)]'s Syndicate message with:</b> \"[input]\"")
-		to_chat(M, "<span class='notice'>You hear something crackle from your [receive_type] for a moment before a voice speaks:</span>\n\"Please stand by for a message from your benefactor, agent. Message as follows.\"\n<b>\"[input]\"</b>")
+		output_to_msay("<span class = 'bold'>[key_name_admin(src.owner)] replied to [key_name_admin(M)]'s Syndicate message with:</span> \"[input]\"")
+		to_chat(M, "<span class='notice'>You hear something crackle from your [receive_type] for a moment before a voice speaks:</span>\n\"Please stand by for a message from your benefactor, agent. Message as follows.\"\n<span class = 'bold'>\"[input]\"</span>")
 
 	else if(href_list["CentcommFaxView"])
 		var/obj/item/weapon/paper/P = locate(href_list["CentcommFaxView"])
@@ -2249,7 +2249,7 @@
 	else if(href_list["CentcommFaxReply"])
 		var/mob/living/carbon/human/H = locate(href_list["CentcommFaxReply"])
 
-		output_to_msay("<b>[key_name_admin(src.owner)] is replying to a fax message from [key_name_admin(H)].</b>")
+		output_to_msay("<span class = 'bold'>[key_name_admin(src.owner)] is replying to a fax message from [key_name_admin(H)].</span>")
 
 		var/sent = input(src.owner, "Please enter a message to reply to [key_name(H)] via secure connection. NOTE: BBCode does not work, but HTML tags do! Use <br> for line breaks.", "Outgoing message from Centcomm", "") as message|null
 		if(!sent)
@@ -2264,7 +2264,7 @@
 
 		to_chat(src.owner, "<span class='notice'>Message reply to [key_name(H)] transmitted successfully.</span>")
 		log_admin("[key_name(src.owner)] replied to a fax message from [key_name(H)]: [sent]")
-		output_to_msay("<b>[key_name_admin(src.owner)] replied to a fax message from [key_name_admin(H)]:</b> <a href='?_src_=holder;CentcommFaxView=\ref[replyfax]'>View Message</a>")
+		output_to_msay("<span class = 'bold'>[key_name_admin(src.owner)] replied to a fax message from [key_name_admin(H)]:</span> <a href='?_src_=holder;CentcommFaxView=\ref[replyfax]'>View Message</a>")
 
 
 	else if(href_list["jumpto"])

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2263,7 +2263,7 @@
 			return
 		to_chat(src.owner, "Message reply to [key_name(H)] transmitted successfully.")
 		log_admin("[key_name(src.owner)] replied to a fax message from [key_name(H)]: [sent]")
-		output_to_msay("[key_name_admin(src.owner)] replied to a fax message from [key_name_admin(H)]: <a href='?_src_=holder;CentcommFaxView=\ref[replyfax]'>view message</a>", 1)
+		output_to_msay("[key_name_admin(src.owner)] replied to a fax message from [key_name_admin(H)]: <a href='?_src_=holder;CentcommFaxView=\ref[replyfax]'>view message</a>")
 
 
 	else if(href_list["jumpto"])

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2179,7 +2179,7 @@
 	else if (href_list["PrayerReply"])
 		if(!check_rights(R_ADMIN))
 			return
-		var/mob/M = locate(href_list["subtlemessage"])
+		var/mob/M = locate(href_list["PrayerReply"])
 		output_to_msay("[key_name(src.owner)] is replying to a prayer from [key_name(M)]")
 
 		usr.client.cmd_admin_subtle_message(M)

--- a/code/modules/admin/verbs/pray.dm
+++ b/code/modules/admin/verbs/pray.dm
@@ -20,7 +20,7 @@
 
 	var/orig_message = msg
 	var/image/cross = image('icons/obj/storage.dmi',"bible")
-	msg = "<span class='notice'>[bicon(cross)] <b><font color='purple'>PRAY (DEITY:[ticker.Bible_deity_name]): </font>[key_name(src, 1)] (<A HREF='?_src_=holder;adminmoreinfo=\ref[src]'>?</A>) (<A HREF='?_src_=holder;adminplayeropts=\ref[src]'>PP</A>) (<A HREF='?_src_=vars;Vars=\ref[src]'>VV</A>) (<A HREF='?_src_=holder;adminplayerobservejump=\ref[src]'>JMP</A>) (<A HREF='?_src_=holder;secretsadmin=check_antagonist'>CA</A>) (<A HREF='?_src_=holder;adminspawncookie=\ref[src]'>SC</a>) (<A HREF='?_src_=holder;BlueSpaceArtillery=\ref[src]'>BSA</A>) (<A HREF='?_src_=holder;PrayerReply=\ref[Sender]'>RPLY</A>):</b> [msg]</span>"
+	msg = "<span class='notice'>[bicon(cross)] <b><font color='purple'>PRAY (DEITY:[ticker.Bible_deity_name]): </font>[key_name(src, 1)] (<A HREF='?_src_=holder;adminmoreinfo=\ref[src]'>?</A>) (<A HREF='?_src_=holder;adminplayeropts=\ref[src]'>PP</A>) (<A HREF='?_src_=vars;Vars=\ref[src]'>VV</A>) (<A HREF='?_src_=holder;adminplayerobservejump=\ref[src]'>JMP</A>) (<A HREF='?_src_=holder;secretsadmin=check_antagonist'>CA</A>) (<A HREF='?_src_=holder;adminspawncookie=\ref[src]'>SC</a>) (<A HREF='?_src_=holder;BlueSpaceArtillery=\ref[src]'>BSA</A>) (<A HREF='?_src_=holder;PrayerReply=\ref[src]'>RPLY</A>):</b> [msg]</span>"
 
 	send_prayer_to_admins(msg, 'sound/effects/prayer.ogg')
 

--- a/code/modules/admin/verbs/pray.dm
+++ b/code/modules/admin/verbs/pray.dm
@@ -20,7 +20,7 @@
 
 	var/orig_message = msg
 	var/image/cross = image('icons/obj/storage.dmi',"bible")
-	msg = "<span class='notice'>[bicon(cross)] <b><font color='purple'>PRAY (DEITY:[ticker.Bible_deity_name]): </font>[key_name(src, 1)] (<A HREF='?_src_=holder;adminmoreinfo=\ref[src]'>?</A>) (<A HREF='?_src_=holder;adminplayeropts=\ref[src]'>PP</A>) (<A HREF='?_src_=vars;Vars=\ref[src]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=\ref[src]'>SM</A>) (<A HREF='?_src_=holder;adminplayerobservejump=\ref[src]'>JMP</A>) (<A HREF='?_src_=holder;secretsadmin=check_antagonist'>CA</A>) (<A HREF='?_src_=holder;adminspawncookie=\ref[src]'>SC</a>) (<A HREF='?_src_=holder;BlueSpaceArtillery=\ref[src]'>BSA</A>):</b> [msg]</span>"
+	msg = "<span class='notice'>[bicon(cross)] <b><font color='purple'>PRAY (DEITY:[ticker.Bible_deity_name]): </font>[key_name(src, 1)] (<A HREF='?_src_=holder;adminmoreinfo=\ref[src]'>?</A>) (<A HREF='?_src_=holder;adminplayeropts=\ref[src]'>PP</A>) (<A HREF='?_src_=vars;Vars=\ref[src]'>VV</A>) (<A HREF='?_src_=holder;adminplayerobservejump=\ref[src]'>JMP</A>) (<A HREF='?_src_=holder;secretsadmin=check_antagonist'>CA</A>) (<A HREF='?_src_=holder;adminspawncookie=\ref[src]'>SC</a>) (<A HREF='?_src_=holder;BlueSpaceArtillery=\ref[src]'>BSA</A>) (<A HREF='?_src_=holder;PrayerReply=\ref[Sender]'>RPLY</A>):</b> [msg]</span>"
 
 	send_prayer_to_admins(msg, 'sound/effects/prayer.ogg')
 

--- a/code/modules/admin/verbs/pray.dm
+++ b/code/modules/admin/verbs/pray.dm
@@ -33,12 +33,12 @@
 
 /proc/Centcomm_announce(var/text , var/mob/Sender)
 	var/msg = copytext(sanitize(text), 1, MAX_MESSAGE_LEN)
-	msg = "<span class='notice'><b><font color=orange>CENTCOMM:</font>[key_name(Sender, 1)] (<A HREF='?_src_=holder;adminplayeropts=\ref[Sender]'>PP</A>) (<A HREF='?_src_=vars;Vars=\ref[Sender]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=\ref[Sender]'>SM</A>) (<A HREF='?_src_=holder;adminplayerobservejump=\ref[Sender]'>JMP</A>) (<A HREF='?_src_=holder;secretsadmin=check_antagonist'>CA</A>) (<A HREF='?_src_=holder;BlueSpaceArtillery=\ref[Sender]'>BSA</A>) (<A HREF='?_src_=holder;CentcommReply=\ref[Sender]'>RPLY</A>):</b> [msg]</span>"
+	msg = "<span class='notice'><b>  CENTCOMM: [key_name(Sender, 1)] (<A HREF='?_src_=holder;adminplayeropts=\ref[Sender]'>PP</A>) (<A HREF='?_src_=vars;Vars=\ref[Sender]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=\ref[Sender]'>SM</A>) (<A HREF='?_src_=holder;adminplayerobservejump=\ref[Sender]'>JMP</A>) (<A HREF='?_src_=holder;secretsadmin=check_antagonist'>CA</A>) (<A HREF='?_src_=holder;BlueSpaceArtillery=\ref[Sender]'>BSA</A>) (<A HREF='?_src_=holder;CentcommReply=\ref[Sender]'>RPLY</A>):</b> [msg]</span>"
 	send_prayer_to_admins(msg, 'sound/effects/msn.ogg')
 
 /proc/Syndicate_announce(var/text , var/mob/Sender)
 	var/msg = copytext(sanitize(text), 1, MAX_MESSAGE_LEN)
-	msg = "<span class='notice'><b><font color=crimson>SYNDICATE:</font>[key_name(Sender, 1)] (<A HREF='?_src_=holder;adminplayeropts=\ref[Sender]'>PP</A>) (<A HREF='?_src_=vars;Vars=\ref[Sender]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=\ref[Sender]'>SM</A>) (<A HREF='?_src_=holder;adminplayerobservejump=\ref[Sender]'>JMP</A>) (<A HREF='?_src_=holder;secretsadmin=check_antagonist'>CA</A>) (<A HREF='?_src_=holder;BlueSpaceArtillery=\ref[Sender]'>BSA</A>) (<A HREF='?_src_=holder;SyndicateReply=\ref[Sender]'>RPLY</A>):</b> [msg]</span>"
+	msg = "<span class='notice'><b>  SYNDICATE: [key_name(Sender, 1)] (<A HREF='?_src_=holder;adminplayeropts=\ref[Sender]'>PP</A>) (<A HREF='?_src_=vars;Vars=\ref[Sender]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=\ref[Sender]'>SM</A>) (<A HREF='?_src_=holder;adminplayerobservejump=\ref[Sender]'>JMP</A>) (<A HREF='?_src_=holder;secretsadmin=check_antagonist'>CA</A>) (<A HREF='?_src_=holder;BlueSpaceArtillery=\ref[Sender]'>BSA</A>) (<A HREF='?_src_=holder;SyndicateReply=\ref[Sender]'>RPLY</A>):</b> [msg]</span>"
 	send_prayer_to_admins(msg, 'sound/effects/inception.ogg')
 
 /proc/send_prayer_to_admins(var/msg,var/sound)

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -62,8 +62,10 @@
 		if (usr.client)
 			if(usr.client.holder)
 				M.get_subtle_message(msg, deity)
+
+
 	log_admin("SubtlePM: [key_name(usr)] as [deity] -> [key_name(M)] : [msg]")
-	message_admins("<span class='notice'><B>SubtleMessage: [key_name_admin(usr)] as [deity] -> [key_name_admin(M)] : [msg]</B></span>", 1)
+	output_to_msay("<span class='notice'><B>SubtleMessage: [key_name_admin(usr)] as [deity] -> [key_name_admin(M)] : [msg]</B></span>")
 	feedback_add_details("admin_verb","SMS") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/cmd_admin_world_narrate() // Allows administrators to fluff events a little easier -- TLE
@@ -1073,4 +1075,3 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	usr << ftp(F)
 
 	feedback_add_details("admin_verb", "SCO") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-


### PR DESCRIPTION
Outputs a message to msay window AKA special tab when an admin starts to reply to:
 - Centcomm messages
 - Syndicate messages
 - Prayers
 - Faxes

This does of course check the admin's prefs to see if they want that message in the special tab or in chat, but it doesn't implement a new pref, so it uses the catch-all pref for having the special tab enabled at all or not.

I removed the Subtle Message HREF from prayers in favor a RPLY link that is basically just the same thing but with the message to admins on starting a reply.
🆑 
 * tweak: Admins will now see when another admin starts to reply to a fax, prayer, centcomm or syndicate message, in order to hopefully avoid duplicate replies from separate admins.
 * tweak: Admins will also see replies to prayers/faxes/centcom or syndie messages, thanks to Intigracy