### PR TITLE
Fixes disposal bins/outlets breaking the floor tiles when things come out of them, other minor fixes

### DIFF
--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -20,132 +20,132 @@
 	var/base_state = "pipe-s"
 
 	// update iconstate and dpdir due to dir and type
-	proc/update()
-		var/flip = turn(dir, 180)
-		var/left = turn(dir, 90)
-		var/right = turn(dir, -90)
+/obj/structure/disposalconstruct/proc/update()
+	var/flip = turn(dir, 180)
+	var/left = turn(dir, 90)
+	var/right = turn(dir, -90)
 
-		switch(ptype)
-			if(0)
-				base_state = "pipe-s"
-				dpdir = dir | flip
-			if(1)
-				base_state = "pipe-c"
-				dpdir = dir | right
-			if(2)
-				base_state = "pipe-j1"
-				dpdir = dir | right | flip
-			if(3)
-				base_state = "pipe-j2"
-				dpdir = dir | left | flip
-			if(4)
-				base_state = "pipe-y"
-				dpdir = dir | left | right
-			if(5)
-				base_state = "pipe-t"
-				dpdir = dir
-			 // disposal bin has only one dir, thus we don't need to care about setting it
-			if(6)
-				if(anchored)
-					base_state = "disposal"
-				else
-					base_state = "condisposal"
+	switch(ptype)
+		if(0)
+			base_state = "pipe-s"
+			dpdir = dir | flip
+		if(1)
+			base_state = "pipe-c"
+			dpdir = dir | right
+		if(2)
+			base_state = "pipe-j1"
+			dpdir = dir | right | flip
+		if(3)
+			base_state = "pipe-j2"
+			dpdir = dir | left | flip
+		if(4)
+			base_state = "pipe-y"
+			dpdir = dir | left | right
+		if(5)
+			base_state = "pipe-t"
+			dpdir = dir
+		 // disposal bin has only one dir, thus we don't need to care about setting it
+		if(6)
+			if(anchored)
+				base_state = "disposal"
+			else
+				base_state = "condisposal"
 
-			if(7)
-				base_state = "outlet"
-				dpdir = dir
+		if(7)
+			base_state = "outlet"
+			dpdir = dir
 
-			if(8)
-				base_state = "intake"
-				dpdir = dir
+		if(8)
+			base_state = "intake"
+			dpdir = dir
 
-			if(9, 11)
-				base_state = "pipe-j1s"
-				dpdir = dir | right | flip
+		if(9, 11)
+			base_state = "pipe-j1s"
+			dpdir = dir | right | flip
 
-			if(10, 12)
-				base_state = "pipe-j2s"
-				dpdir = dir | left | flip
+		if(10, 12)
+			base_state = "pipe-j2s"
+			dpdir = dir | left | flip
 
-		if(ptype<6 || ptype>8)
-			icon_state = "con[base_state]"
-		else
-			icon_state = base_state
+	if(ptype<6 || ptype>8)
+		icon_state = "con[base_state]"
+	else
+		icon_state = base_state
 
-		if(invisibility)				// if invisible, fade icon
-			icon -= rgb(0,0,0,128)
+	if(invisibility)				// if invisible, fade icon
+		icon -= rgb(0,0,0,128)
 
 	// hide called by levelupdate if turf intact status changes
 	// change visibility status and force update of icon
-	hide(var/intact)
-		invisibility = (intact && level==1) ? 101: 0	// hide if floor is intact
-		update()
+/obj/structure/disposalconstruct/hide(var/intact)
+	invisibility = (intact && level==1) ? 101: 0	// hide if floor is intact
+	update()
 
 
 	// flip and rotate verbs
-	verb/rotate()
-		set name = "Rotate Pipe"
-		set category = "Object"
-		set src in view(1)
+/obj/structure/disposalconstruct/verb/rotate()
+	set name = "Rotate Pipe"
+	set category = "Object"
+	set src in view(1)
 
-		if(usr.isUnconscious())
-			return
+	if(usr.isUnconscious())
+		return
 
-		if(anchored)
-			to_chat(usr, "You must unfasten the pipe before rotating it.")
-			return
+	if(anchored)
+		to_chat(usr, "You must unfasten the pipe before rotating it.")
+		return
 
-		dir = turn(dir, -90)
-		update()
+	dir = turn(dir, -90)
+	update()
 
-	verb/flip()
-		set name = "Flip Pipe"
-		set category = "Object"
-		set src in view(1)
-		if(usr.isUnconscious())
-			return
+/obj/structure/disposalconstruct/verb/flip()
+	set name = "Flip Pipe"
+	set category = "Object"
+	set src in view(1)
+	if(usr.isUnconscious())
+		return
 
-		if(anchored)
-			to_chat(usr, "You must unfasten the pipe before flipping it.")
-			return
+	if(anchored)
+		to_chat(usr, "You must unfasten the pipe before flipping it.")
+		return
 
-		dir = turn(dir, 180)
-		switch(ptype)
-			if(2)
-				ptype = 3
-			if(3)
-				ptype = 2
-			if(9)
-				ptype = 10
-			if(10)
-				ptype = 9
-			if(11)
-				ptype = 12
-			if(12)
-				ptype = 11
+	dir = turn(dir, 180)
+	switch(ptype)
+		if(2)
+			ptype = 3
+		if(3)
+			ptype = 2
+		if(9)
+			ptype = 10
+		if(10)
+			ptype = 9
+		if(11)
+			ptype = 12
+		if(12)
+			ptype = 11
 
-		update()
+	update()
 
 	// returns the type path of disposalpipe corresponding to this item dtype
-	proc/dpipetype()
-		switch(ptype)
-			if(0,1)
-				return /obj/structure/disposalpipe/segment
-			if(2,3,4)
-				return /obj/structure/disposalpipe/junction
-			if(5)
-				return /obj/structure/disposalpipe/trunk
-			if(6)
-				return /obj/machinery/disposal
-			if(7)
-				return /obj/structure/disposaloutlet
-			if(8)
-				return /obj/machinery/disposal/deliveryChute
-			if(9,10)
-				return /obj/structure/disposalpipe/sortjunction
-			if(11, 12)
-				return /obj/structure/disposalpipe/wrapsortjunction
-		return
+/obj/structure/disposalconstruct/proc/dpipetype()
+	switch(ptype)
+		if(0,1)
+			return /obj/structure/disposalpipe/segment
+		if(2,3,4)
+			return /obj/structure/disposalpipe/junction
+		if(5)
+			return /obj/structure/disposalpipe/trunk
+		if(6)
+			return /obj/machinery/disposal
+		if(7)
+			return /obj/structure/disposaloutlet
+		if(8)
+			return /obj/machinery/disposal/deliveryChute
+		if(9,10)
+			return /obj/structure/disposalpipe/sortjunction
+		if(11, 12)
+			return /obj/structure/disposalpipe/wrapsortjunction
+	return
 
 
 
@@ -153,127 +153,127 @@
 	// wrench: (un)anchor
 	// weldingtool: convert to real pipe
 
-	attackby(var/obj/item/I, var/mob/user)
-		var/nicetype = "pipe"
-		var/ispipe = 0 // Indicates if we should change the level of this pipe
-		src.add_fingerprint(user)
-		switch(ptype)
-			if(6)
-				nicetype = "disposal bin"
-			if(7)
-				nicetype = "disposal outlet"
-			if(8)
-				nicetype = "delivery chute"
-			if(9, 10)
-				nicetype = "sorting pipe"
-				ispipe = 1
-			if(11, 12)
-				nicetype = "wrap sorting pipe"
-				ispipe = 1
-			else
-				nicetype = "pipe"
-				ispipe = 1
-
-		var/turf/T = src.loc
-		if(T.intact)
-			to_chat(user, "You can only attach the [nicetype] if the floor plating is removed.")
-			return
-
-		var/obj/structure/disposalpipe/CP = locate() in T
-		if(ptype>=6 && ptype <= 8) // Disposal or outlet
-			if(CP) // There's something there
-				if(!istype(CP,/obj/structure/disposalpipe/trunk) && !anchored)
-					to_chat(user, "The [nicetype] requires a trunk underneath it in order to work.")
-					return
-			else // Nothing under, fuck.
-				if(!anchored)
-					to_chat(user, "The [nicetype] requires a trunk underneath it in order to work.")
-					return
+/obj/structure/disposalconstruct/attackby(var/obj/item/I, var/mob/user)
+	var/nicetype = "pipe"
+	var/ispipe = 0 // Indicates if we should change the level of this pipe
+	src.add_fingerprint(user)
+	switch(ptype)
+		if(6)
+			nicetype = "disposal bin"
+		if(7)
+			nicetype = "disposal outlet"
+		if(8)
+			nicetype = "delivery chute"
+		if(9, 10)
+			nicetype = "sorting pipe"
+			ispipe = 1
+		if(11, 12)
+			nicetype = "wrap sorting pipe"
+			ispipe = 1
 		else
-			if(CP)
-				update()
-				var/pdir = CP.dpdir
-				if(istype(CP, /obj/structure/disposalpipe/broken))
-					pdir = CP.dir
-				if(pdir & dpdir)
-					to_chat(user, "There is already a [nicetype] at that location.")
-					return
+			nicetype = "pipe"
+			ispipe = 1
 
+	var/turf/T = src.loc
+	if(T.intact)
+		to_chat(user, "You can only attach the [nicetype] if the floor plating is removed.")
+		return
 
-		if(iswrench(I))
-			if(anchored)
-				anchored = 0
-				if(ispipe)
-					level = 2
-					density = 0
-				else
-					density = 1
-				to_chat(user, "You detach the [nicetype] from the underfloor.")
-			else
-				anchored = 1
-				if(ispipe)
-					level = 1 // We don't want disposal bins to disappear under the floors
-					density = 0
-				else
-					density = 1 // We don't want disposal bins or outlets to go density 0
-				to_chat(user, "You attach the [nicetype] to the underfloor.")
-			playsound(get_turf(src), 'sound/items/Ratchet.ogg', 100, 1)
-			update()
-
-		else if(iswelder(I))
-			if(anchored)
-				var/obj/item/weapon/weldingtool/W = I
-				if(W.remove_fuel(0,user))
-					playsound(get_turf(src), 'sound/items/Welder2.ogg', 100, 1)
-					to_chat(user, "Welding the [nicetype] in place.")
-					if(do_after(user, src, 20))
-						if(!src || !W.isOn())
-							return
-						to_chat(user, "The [nicetype] has been welded in place!")
-						update() // TODO: Make this neat
-						if(ispipe) // Pipe
-
-							var/pipetype = dpipetype()
-							var/obj/structure/disposalpipe/P = new pipetype(src.loc)
-							src.transfer_fingerprints_to(P)
-							P.base_icon_state = base_state
-							P.dir = dir
-							P.dpdir = dpdir
-							P.updateicon()
-
-							//Needs some special treatment ;)
-							switch(ptype)
-								if(9, 10)
-									var/obj/structure/disposalpipe/sortjunction/SortP = P
-									SortP.updatedir()
-								if(11, 12)
-									var/obj/structure/disposalpipe/wrapsortjunction/sort_P = P
-									sort_P.update_dir()
-
-						else if(ptype==6) // Disposal bin
-							var/obj/machinery/disposal/P = new /obj/machinery/disposal(src.loc)
-							src.transfer_fingerprints_to(P)
-							P.mode = 0 // start with pump off
-
-						else if(ptype==7) // Disposal outlet
-
-							var/obj/structure/disposaloutlet/P = new /obj/structure/disposaloutlet(src.loc)
-							src.transfer_fingerprints_to(P)
-							P.dir = dir
-							var/obj/structure/disposalpipe/trunk/Trunk = CP
-							Trunk.linked = P
-
-						else if(ptype==8) // Disposal outlet
-
-							var/obj/machinery/disposal/deliveryChute/P = new /obj/machinery/disposal/deliveryChute(src.loc)
-							src.transfer_fingerprints_to(P)
-							P.dir = dir
-
-						qdel(src)
-						return
-				else
-					to_chat(user, "You need more welding fuel to complete this task.")
-					return
-			else
-				to_chat(user, "You need to attach it to the plating first!")
+	var/obj/structure/disposalpipe/CP = locate() in T
+	if(ptype>=6 && ptype <= 8) // Disposal or outlet
+		if(CP) // There's something there
+			if(!istype(CP,/obj/structure/disposalpipe/trunk) && !anchored)
+				to_chat(user, "The [nicetype] requires a trunk underneath it in order to work.")
 				return
+		else // Nothing under, fuck.
+			if(!anchored)
+				to_chat(user, "The [nicetype] requires a trunk underneath it in order to work.")
+				return
+	else
+		if(CP)
+			update()
+			var/pdir = CP.dpdir
+			if(istype(CP, /obj/structure/disposalpipe/broken))
+				pdir = CP.dir
+			if(pdir & dpdir)
+				to_chat(user, "There is already a [nicetype] at that location.")
+				return
+
+
+	if(iswrench(I))
+		if(anchored)
+			anchored = 0
+			if(ispipe)
+				level = 2
+				density = 0
+			else
+				density = 1
+			to_chat(user, "You detach the [nicetype] from the underfloor.")
+		else
+			anchored = 1
+			if(ispipe)
+				level = 1 // We don't want disposal bins to disappear under the floors
+				density = 0
+			else
+				density = 1 // We don't want disposal bins or outlets to go density 0
+			to_chat(user, "You attach the [nicetype] to the underfloor.")
+		playsound(get_turf(src), 'sound/items/Ratchet.ogg', 100, 1)
+		update()
+
+	else if(iswelder(I))
+		if(anchored)
+			var/obj/item/weapon/weldingtool/W = I
+			if(W.remove_fuel(0,user))
+				playsound(get_turf(src), 'sound/items/Welder2.ogg', 100, 1)
+				to_chat(user, "Welding the [nicetype] in place.")
+				if(do_after(user, src, 20))
+					if(!src || !W.isOn())
+						return
+					to_chat(user, "The [nicetype] has been welded in place!")
+					update() // TODO: Make this neat
+					if(ispipe) // Pipe
+
+						var/pipetype = dpipetype()
+						var/obj/structure/disposalpipe/P = new pipetype(src.loc)
+						src.transfer_fingerprints_to(P)
+						P.base_icon_state = base_state
+						P.dir = dir
+						P.dpdir = dpdir
+						P.updateicon()
+
+						//Needs some special treatment ;)
+						switch(ptype)
+							if(9, 10)
+								var/obj/structure/disposalpipe/sortjunction/SortP = P
+								SortP.updatedir()
+							if(11, 12)
+								var/obj/structure/disposalpipe/wrapsortjunction/sort_P = P
+								sort_P.update_dir()
+
+					else if(ptype==6) // Disposal bin
+						var/obj/machinery/disposal/P = new /obj/machinery/disposal(src.loc)
+						src.transfer_fingerprints_to(P)
+						P.mode = 0 // start with pump off
+
+					else if(ptype==7) // Disposal outlet
+
+						var/obj/structure/disposaloutlet/P = new /obj/structure/disposaloutlet(src.loc)
+						src.transfer_fingerprints_to(P)
+						P.dir = dir
+						var/obj/structure/disposalpipe/trunk/Trunk = CP
+						Trunk.linked = P
+
+					else if(ptype==8) // Disposal outlet
+
+						var/obj/machinery/disposal/deliveryChute/P = new /obj/machinery/disposal/deliveryChute(src.loc)
+						src.transfer_fingerprints_to(P)
+						P.dir = dir
+
+					qdel(src)
+					return
+			else
+				to_chat(user, "You need more welding fuel to complete this task.")
+				return
+		else
+			to_chat(user, "You need to attach it to the plating first!")
+			return

--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -145,7 +145,6 @@
 			return /obj/structure/disposalpipe/sortjunction
 		if(11, 12)
 			return /obj/structure/disposalpipe/wrapsortjunction
-	return
 
 
 

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -115,7 +115,7 @@
 					C.ptype = 6 // 6 = disposal unit
 					C.anchored = 1
 					C.density = 1
-					C.update_icon()
+					C.update()
 					qdel(src)
 				return
 			else
@@ -1156,91 +1156,91 @@
 	icon_state = "pipe-j2s"
 
 /obj/structure/disposalpipe/sortjunction/Research
-		sort_tag = DISP_RESEARCH
+	sort_tag = DISP_RESEARCH
 
 /obj/structure/disposalpipe/sortjunction/Research/mirrored
 	icon_state = "pipe-j2s"
 
 /obj/structure/disposalpipe/sortjunction/RD
-		sort_tag = DISP_RD_OFFICE
+	sort_tag = DISP_RD_OFFICE
 
 /obj/structure/disposalpipe/sortjunction/RD/mirrored
 	icon_state = "pipe-j2s"
 
 /obj/structure/disposalpipe/sortjunction/Robotics
-		sort_tag = DISP_ROBOTICS
+	sort_tag = DISP_ROBOTICS
 
 /obj/structure/disposalpipe/sortjunction/Robotics/mirrored
 	icon_state = "pipe-j2s"
 
 /obj/structure/disposalpipe/sortjunction/HoP
-		sort_tag = DISP_HOP_OFFICE
+	sort_tag = DISP_HOP_OFFICE
 
 /obj/structure/disposalpipe/sortjunction/HoP/mirrored
 	icon_state = "pipe-j2s"
 
 /obj/structure/disposalpipe/sortjunction/Library
-		sort_tag = DISP_LIBRARY
+	sort_tag = DISP_LIBRARY
 
 /obj/structure/disposalpipe/sortjunction/Library/mirrored
 	icon_state = "pipe-j2s"
 
 /obj/structure/disposalpipe/sortjunction/Chapel
-		sort_tag = DISP_CHAPEL
+	sort_tag = DISP_CHAPEL
 
 /obj/structure/disposalpipe/sortjunction/Chapel/mirrored
 	icon_state = "pipe-j2s"
 
 /obj/structure/disposalpipe/sortjunction/Theatre
-		sort_tag = DISP_THEATRE
+	sort_tag = DISP_THEATRE
 
 /obj/structure/disposalpipe/sortjunction/Theatre/mirrored
 	icon_state = "pipe-j2s"
 
 /obj/structure/disposalpipe/sortjunction/Bar
-		sort_tag = DISP_BAR
+	sort_tag = DISP_BAR
 
 /obj/structure/disposalpipe/sortjunction/Bar/mirrored
 	icon_state = "pipe-j2s"
 
 /obj/structure/disposalpipe/sortjunction/Kitchen
-		sort_tag = DISP_KITCHEN
+	sort_tag = DISP_KITCHEN
 
 /obj/structure/disposalpipe/sortjunction/Kitchen/mirrored
 	icon_state = "pipe-j2s"
 
 /obj/structure/disposalpipe/sortjunction/Hydroponics
-		sort_tag = DISP_HYDROPONICS
+	sort_tag = DISP_HYDROPONICS
 
 /obj/structure/disposalpipe/sortjunction/Hydroponics/mirrored
 	icon_state = "pipe-j2s"
 
 /obj/structure/disposalpipe/sortjunction/Janitor
-		sort_tag = DISP_JANITOR_CLOSET
+	sort_tag = DISP_JANITOR_CLOSET
 
 /obj/structure/disposalpipe/sortjunction/Janitor/mirrored
 	icon_state = "pipe-j2s"
 
 /obj/structure/disposalpipe/sortjunction/Genetics
-		sort_tag = DISP_GENETICS
+	sort_tag = DISP_GENETICS
 
 /obj/structure/disposalpipe/sortjunction/Genetics/mirrored
 	icon_state = "pipe-j2s"
 
 /obj/structure/disposalpipe/sortjunction/Telecomms
-		sort_tag = DISP_TELECOMMS
+	sort_tag = DISP_TELECOMMS
 
 /obj/structure/disposalpipe/sortjunction/Telecomms/mirrored
 	icon_state = "pipe-j2s"
 
 /obj/structure/disposalpipe/sortjunction/Mechanics
-		sort_tag = DISP_MECHANICS
+	sort_tag = DISP_MECHANICS
 
 /obj/structure/disposalpipe/sortjunction/Mechanics/mirrored
 	icon_state = "pipe-j2s"
 
 /obj/structure/disposalpipe/sortjunction/Telescience
-		sort_tag = DISP_TELESCIENCE
+	sort_tag = DISP_TELESCIENCE
 
 /obj/structure/disposalpipe/sortjunction/Telescience/mirrored
 	icon_state = "pipe-j2s"
@@ -1422,10 +1422,12 @@
 		var/obj/structure/disposaloutlet/O = linked
 		if(istype(O) && (H))
 			O.expel(H)	// expel at outlet
+			return H
 		else
 			var/obj/machinery/disposal/D = linked
 			if(H)
 				D.expel(H)	// expel at disposal
+				return H
 	else
 		if(H)
 			src.expel(H, src.loc, 0)	// expel at turf
@@ -1446,18 +1448,18 @@
 					// i.e. will be treated as an empty turf
 	desc = "A broken piece of disposal pipe."
 
-	New()
-		..()
-		update()
-		return
+/obj/structure/disposalpipe/broken/New()
+	..()
+	update()
+	return
 
 	// called when welded
 	// for broken pipe, remove and turn into scrap
 
-	welded()
-//		var/obj/item/scrap/S = new(src.loc)
-//		S.set_components(200,0,0)
-		qdel(src)
+/obj/structure/disposalpipe/broken/welded()
+//	var/obj/item/scrap/S = new(src.loc)
+//	S.set_components(200,0,0)
+	qdel(src)
 
 // the disposal outlet machine
 
@@ -1476,90 +1478,91 @@
 	holomap = TRUE
 	auto_holomap = TRUE
 
-	New()
-		. = ..()
+/obj/structure/disposaloutlet/New()
+	. = ..()
 
-		spawn(1)
-			target = get_ranged_target_turf(src, dir, 10)
+	spawn(1)
+		target = get_ranged_target_turf(src, dir, 10)
 
-			trunk = locate() in loc
+		trunk = locate() in loc
 
-			if(trunk)
-				if(trunk.disposaloutlet != src)
-					trunk.disposaloutlet = src
-
-				if(trunk.linked != trunk.disposaloutlet)
-					trunk.linked = trunk.disposaloutlet
-
-	Destroy()
 		if(trunk)
-			if(trunk.disposaloutlet)
-				trunk.disposaloutlet = null
+			if(trunk.disposaloutlet != src)
+				trunk.disposaloutlet = src
 
-			if(trunk.linked)
-				trunk.linked = null
+			if(trunk.linked != trunk.disposaloutlet)
+				trunk.linked = trunk.disposaloutlet
 
-			trunk = null
+/obj/structure/disposaloutlet/Destroy()
+	if(trunk)
+		if(trunk.disposaloutlet)
+			trunk.disposaloutlet = null
 
-		..()
+		if(trunk.linked)
+			trunk.linked = null
+
+		trunk = null
+
+	..()
 
 	// expel the contents of the holder object, then delete it
 	// called when the holder exits the outlet
-	proc/expel(var/obj/structure/disposalholder/H)
+/obj/structure/disposaloutlet/proc/expel(var/obj/structure/disposalholder/H)
 
+	if(H)
+		H.active = 0
+	flick("outlet-open", src)
+	playsound(src, 'sound/machines/warning-buzzer.ogg', 50, 0, 0)
+	sleep(20)	//wait until correct animation frame
+	playsound(src, 'sound/machines/hiss.ogg', 50, 0, 0)
 
-		flick("outlet-open", src)
-		playsound(src, 'sound/machines/warning-buzzer.ogg', 50, 0, 0)
-		sleep(20)	//wait until correct animation frame
-		playsound(src, 'sound/machines/hiss.ogg', 50, 0, 0)
+	if(H)
+		for(var/atom/movable/AM in H)
+			AM.forceMove(src.loc)
+			AM.pipe_eject(dir)
+			spawn(5)
+				if(AM)
+					AM.throw_at(target, 3, 1)
+		H.vent_gas(src.loc)
+		qdel(H)
 
-		if(H)
-			for(var/atom/movable/AM in H)
-				AM.forceMove(src.loc)
-				AM.pipe_eject(dir)
-				spawn(5)
-					if(AM)
-						AM.throw_at(target, 3, 1)
-			H.vent_gas(src.loc)
-			qdel(H)
+	return
 
+/obj/structure/disposaloutlet/attackby(var/obj/item/I, var/mob/user)
+	if(!I || !user)
 		return
-
-	attackby(var/obj/item/I, var/mob/user)
-		if(!I || !user)
+	src.add_fingerprint(user)
+	if(isscrewdriver(I))
+		if(mode==0)
+			mode=1
+			playsound(get_turf(src), 'sound/items/Screwdriver.ogg', 50, 1)
+			to_chat(user, "You remove the screws around the power connection.")
 			return
-		src.add_fingerprint(user)
-		if(isscrewdriver(I))
-			if(mode==0)
-				mode=1
-				playsound(get_turf(src), 'sound/items/Screwdriver.ogg', 50, 1)
-				to_chat(user, "You remove the screws around the power connection.")
-				return
-			else if(mode==1)
-				mode=0
-				playsound(get_turf(src), 'sound/items/Screwdriver.ogg', 50, 1)
-				to_chat(user, "You attach the screws around the power connection.")
-				return
-		else if(istype(I,/obj/item/weapon/weldingtool) && mode==1)
-			var/obj/item/weapon/weldingtool/W = I
-			if(W.remove_fuel(0,user))
-				playsound(get_turf(src), 'sound/items/Welder2.ogg', 100, 1)
-				to_chat(user, "You start slicing the floorweld off the disposal outlet.")
-				if(do_after(user, src,20))
-					if(!src || !W.isOn())
-						return
-					to_chat(user, "You sliced the floorweld off the disposal outlet.")
-					var/obj/structure/disposalconstruct/C = new (src.loc)
-					src.transfer_fingerprints_to(C)
-					C.ptype = 7 // 7 =  outlet
-					C.update()
-					C.anchored = 1
-					C.density = 1
-					qdel(src)
-				return
-			else
-				to_chat(user, "You need more welding fuel to complete this task.")
-				return
+		else if(mode==1)
+			mode=0
+			playsound(get_turf(src), 'sound/items/Screwdriver.ogg', 50, 1)
+			to_chat(user, "You attach the screws around the power connection.")
+			return
+	else if(istype(I,/obj/item/weapon/weldingtool) && mode==1)
+		var/obj/item/weapon/weldingtool/W = I
+		if(W.remove_fuel(0,user))
+			playsound(get_turf(src), 'sound/items/Welder2.ogg', 100, 1)
+			to_chat(user, "You start slicing the floorweld off the disposal outlet.")
+			if(do_after(user, src,20))
+				if(!src || !W.isOn())
+					return
+				to_chat(user, "You sliced the floorweld off the disposal outlet.")
+				var/obj/structure/disposalconstruct/C = new (src.loc)
+				src.transfer_fingerprints_to(C)
+				C.ptype = 7 // 7 =  outlet
+				C.update()
+				C.anchored = 1
+				C.density = 1
+				qdel(src)
+			return
+		else
+			to_chat(user, "You need more welding fuel to complete this task.")
+			return
 
 
 

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -1451,7 +1451,6 @@
 /obj/structure/disposalpipe/broken/New()
 	..()
 	update()
-	return
 
 	// called when welded
 	// for broken pipe, remove and turn into scrap
@@ -1525,8 +1524,6 @@
 					AM.throw_at(target, 3, 1)
 		H.vent_gas(src.loc)
 		qdel(H)
-
-	return
 
 /obj/structure/disposaloutlet/attackby(var/obj/item/I, var/mob/user)
 	if(!I || !user)

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -121,7 +121,7 @@
 		if(trunk)
 			trunk.linked = src	// link the pipe trunk to self
 
-/obj/machinery/disposal/deliveryChute/interact()
+/obj/machinery/disposal/deliveryChute/ui_interact()
 	return
 
 /obj/machinery/disposal/deliveryChute/update_icon()


### PR DESCRIPTION
Mail deliveries using the disposal system won't break the floor tiles anymore.
You can't open the nonfunctional disposal bin menu on disposal chutes.
Fixes disposal bins appearing as a normal disposal pipe for part of their deconstruction.
Removes a bunch of relative pathing.

Fixes  #7440