### PR TITLE
Makes fireball better at breaking things

### DIFF
--- a/code/modules/spells/targeted/projectile/fireball.dm
+++ b/code/modules/spells/targeted/projectile/fireball.dm
@@ -39,7 +39,7 @@
 /spell/targeted/projectile/dumbfire/fireball/choose_prox_targets(mob/user = usr, var/atom/movable/spell_holder)
 	var/list/targets = ..()
 	for(var/mob/living/M in targets)
-		if(M.isUnconscious())
+		if(M.lying)
 			targets -= M
 	return targets
 

--- a/code/modules/spells/targeted/projectile/fireball.dm
+++ b/code/modules/spells/targeted/projectile/fireball.dm
@@ -1,7 +1,7 @@
 /spell/targeted/projectile/dumbfire/fireball
 	name = "Fireball"
 	abbreviation = "FB"
-	desc = "This spell conjures a fireball that will fly in the direction you're facing and explode on collision with anything."
+	desc = "This spell conjures a fireball that will fly in the direction you're facing and explode on collision with anything, or when it gets close to anyone else."
 
 	proj_type = /obj/item/projectile/spell_projectile/fireball
 
@@ -34,6 +34,13 @@
 	for(var/mob/living/M in targets)
 		apply_spell_damage(M)
 	explosion(get_turf(spell_holder), ex_severe, ex_heavy, ex_light, ex_flash)
+	return targets
+
+/spell/targeted/projectile/dumbfire/fireball/choose_prox_targets(mob/user = usr, var/atom/movable/spell_holder)
+	var/list/targets = ..()
+	for(var/mob/living/M in targets)
+		if(M.isUnconscious())
+			targets -= M
 	return targets
 
 /spell/targeted/projectile/dumbfire/fireball/empower_spell()
@@ -74,3 +81,8 @@
 	icon_state = "fireball"
 	animate_movement = 2
 	linear_movement = 0
+
+/obj/item/projectile/spell_projectile/fireball/Bump(var/atom/A)
+	if(!isliving(A))
+		forceMove(get_turf(A))
+	return ..()

--- a/html/changelogs/sprok.yml
+++ b/html/changelogs/sprok.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general deleting of nice things)
+#   rscadd (general adding of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.
+author: Sprok
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# There needs to be a space after the - and before the prefix. Don't use tabs anywhere in this file.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# If you're using characters such as # ' : - or the like in your changelog, surround the entire change with quotes as shown in the second example. These quotes don't show up on the changelog once it's merged and prevent errors.
+# SCREW ANY OF THIS UP AND IT WON'T WORK.
+changes: 
+- tweak: "Fireball now explodes on top of non-mob things that it hits, rather than next to them."


### PR DESCRIPTION
When a fireball hits something that isn't a mob, it will now move onto whatever it hits before exploding to increase its effectiveness at breaking things that aren't the floor. No longer will a window take like ten fireballs to break!

Adds a bit to the fireball description to make clearer that it will explode if it gets within a tile of any mobs.
Makes fireball not get stopped by people lying on the ground.