### PR TITLE
Revsquad changes

### DIFF
--- a/code/game/gamemodes/revolution/revsquad.dm
+++ b/code/game/gamemodes/revolution/revsquad.dm
@@ -199,9 +199,9 @@
 ///////////////////////////////
 /datum/game_mode/revsquad/check_finished()
 	if(config.continous_rounds)
-		if(finished != 0)
-			if(emergency_shuttle)
-				emergency_shuttle.always_fake_recall = 0
+		// if(finished != 0)
+		// 	if(emergency_shuttle)
+		// 		emergency_shuttle.always_fake_recall = 0
 		return ..()
 	return finished != 0
 

--- a/code/game/gamemodes/revolution/revsquad.dm
+++ b/code/game/gamemodes/revolution/revsquad.dm
@@ -114,7 +114,7 @@
 	var/obj_count = 1
 	if (you_are)
 		to_chat(rev_mind.current, "<span class='big bold center red'>You are a member of the organized revolutionary organization that has infiltrated this station!</span>")
-		to_chat(character, "<span class='info'><a HREF='?src=\ref[character];getwiki=["Revolutionary Squad"]'>(Wiki Guide)</a></span>") // Hacky but revsquad doesn't have a pref define or anything
+		to_chat(rev_mind.current, "<span class='info'><a HREF='?src=\ref[rev_mind.current];getwiki=["Revolutionary Squad"]'>(Wiki Guide)</a></span>") // Hacky but revsquad doesn't have a pref define or anything
 	for(var/datum/objective/objective in rev_mind.objectives)
 		to_chat(rev_mind.current, "<b>Objective #[obj_count]</B>: [objective.explanation_text]")
 		rev_mind.special_role = "Revolutionary Squad Member"
@@ -219,7 +219,7 @@
 /datum/game_mode/proc/auto_declare_completion_revsquad()
 	var/list/targets = list()
 	var/text = ""
-	if(head_revolutionaries.len || istype(ticker.mode,/datum/game_mode/revolution/revsquad))
+	if(head_revolutionaries.len || istype(ticker.mode,/datum/game_mode/revsquad))
 		var/icon/logo1 = icon('icons/mob/mob.dmi', "rev_head-logo")
 		end_icons += logo1
 		var/tempstate = end_icons.len

--- a/code/game/gamemodes/revolution/revsquad.dm
+++ b/code/game/gamemodes/revolution/revsquad.dm
@@ -25,7 +25,7 @@
 								   /obj/item/weapon/gun/projectile/shotgun/doublebarrel/sawnoff,
 								   /obj/item/weapon/grenade/iedcasing/preassembled,
 								   /obj/item/weapon/gun/projectile/pistol,
-								   /obj/item/clothing/suit/armor/vest
+								   /obj/item/weapon/aiModule/freeform/syndicate
 								  )
 
 /datum/game_mode/revsquad/announce()

--- a/code/game/gamemodes/revolution/revsquad.dm
+++ b/code/game/gamemodes/revolution/revsquad.dm
@@ -23,7 +23,7 @@
 								   /obj/item/weapon/gun/projectile/automatic,
 								   /obj/item/device/flash/revsquad,
 								   /obj/item/weapon/gun/projectile/shotgun/doublebarrel/sawnoff,
-								   /obj/item/weapon/grenade/iedcasing/preassembled,
+								   /obj/item/weapon/plastique,
 								   /obj/item/weapon/gun/projectile/pistol,
 								   /obj/item/weapon/aiModule/freeform/syndicate
 								  )
@@ -132,6 +132,7 @@
 
 /datum/game_mode/revsquad/proc/get_revsquad_item(var/mob/living/carbon/human/M)
 	var/obj/item/requisitioned = pick(possible_items)
+	possible_items.Remove(requisitioned) // No 3 pairs of insulated gloves
 	if(istype(requisitioned, /obj/item/device/flash/revsquad))
 		var/obj/item/device/flash/revsquad/FR = new(M)
 		requisitioned = FR

--- a/code/game/gamemodes/revolution/revsquad.dm
+++ b/code/game/gamemodes/revolution/revsquad.dm
@@ -113,7 +113,8 @@
 /datum/game_mode/revsquad/proc/greet_revsquad(var/datum/mind/rev_mind, var/you_are=1)
 	var/obj_count = 1
 	if (you_are)
-		to_chat(rev_mind.current, "<span class='notice'>You are a member of the organized revolutionary organization that has infiltrated this station!</span>")
+		to_chat(rev_mind.current, "<span class='big bold center red'>You are a member of the organized revolutionary organization that has infiltrated this station!</span>")
+		to_chat(character, "<span class='info'><a HREF='?src=\ref[character];getwiki=["Revolutionary Squad"]'>(Wiki Guide)</a></span>") // Hacky but revsquad doesn't have a pref define or anything
 	for(var/datum/objective/objective in rev_mind.objectives)
 		to_chat(rev_mind.current, "<b>Objective #[obj_count]</B>: [objective.explanation_text]")
 		rev_mind.special_role = "Revolutionary Squad Member"
@@ -218,7 +219,7 @@
 /datum/game_mode/proc/auto_declare_completion_revsquad()
 	var/list/targets = list()
 	var/text = ""
-	if(head_revolutionaries.len || istype(ticker.mode,/datum/game_mode/revolution))
+	if(head_revolutionaries.len || istype(ticker.mode,/datum/game_mode/revolution/revsquad))
 		var/icon/logo1 = icon('icons/mob/mob.dmi', "rev_head-logo")
 		end_icons += logo1
 		var/tempstate = end_icons.len

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -151,3 +151,4 @@
 	item_state = "sawnshotgun"
 	w_class = W_CLASS_MEDIUM
 	slot_flags = SLOT_BELT
+	ammo_type = "/obj/item/ammo_casing/shotgun/buckshot"


### PR DESCRIPTION
The armor vest was almost always thrown away, so I've replaced it with a traitor freeform AI module.
Also the sawnoff shotgun spawned in with beanbags because I'm dumb, so now it uses buckshot.
This should be left open for awhile for suggestions.
Should fix #11614, if for some reason this PR doesn't go through I'll move it to a new PR. Don't want to hold bugfixes hostage.
🆑 
 * tweak: Revsquad's sawnoff shotgun now starts with buckshot instead of beanbag ammo. Whoops.
 * rscadd: Revsquad members will no longer get duplicate items.
 * rscadd: Revsquad IED replaced with plastique.
 * rscadd: Revsquad's random chance for an armor vest is now replaced with a random chance for syndi freeform AI module.
 * rscadd: Revsquad members get a link to the wiki article for the mode now.
 * tweak: Revsquad will no longer prevent shuttle calls.