### PR TITLE
Plasmen now exhale co2 instead of oxygen which made them ignite thems…

### DIFF
--- a/code/modules/organs/internal/lungs/lung.dm
+++ b/code/modules/organs/internal/lungs/lung.dm
@@ -115,6 +115,6 @@
 
 	gasses = list(
 		new /datum/lung_gas/metabolizable("toxins", min_pp=16, max_pp=140),
-		new /datum/lung_gas/waste("oxygen",         max_pp=0),
+		new /datum/lung_gas/waste("carbon_dioxide",         max_pp=10),
 		new /datum/lung_gas/sleep_agent("/datum/gas/sleeping_agent", trace_gas=1, min_giggle_pp=0.15, min_para_pp=1, min_sleep_pp=5),
 	)


### PR DESCRIPTION
I consider this a bug, although it was the baldman's code originally.
Plasmen exhaled oxygen. Plasmen would ignite when in contact with oxygen. Therefore, even if they took off their suit in a room that was originally atmosphere-less, they'd ignite themselves shortly after taking their suit off.
Closes #10440
So now they'll just exhale co2 like everyone else because why would plasmen exhale a thing that ignites them
🆑 
 * bugfix: Plasmen now exhale co2 so they can survive in a plasma-based atmosphere without a suit again.