### PR TITLE
Wizard Den Floor Safe Loot

### DIFF
--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -206,7 +206,6 @@ obj/structure/safe/ex_act(severity)
 		/obj/item/weapon/gun/energy/staff,
 		/obj/item/weapon/gun/energy/staff/animate,
 		/obj/item/weapon/gun/energy/staff/focus,
-		/obj/item/weapon/scrying,
 		/obj/item/clothing/suit/space/rig/wizard/complete
 		)
 

--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -187,3 +187,30 @@ obj/structure/safe/ex_act(severity)
 
 /obj/structure/safe/floor/hide(var/intact)
 	invisibility = intact ? 101 : 0
+
+/obj/structure/safe/floor/wizard	//Given that these are so difficult to open, and only spawn in wizard dens, they should have some good loot.
+	var/list/loot_list = list(
+		/obj/item/weapon/spellbook/oneuse/fireball,
+		/obj/item/weapon/spellbook/oneuse/smoke,
+		/obj/item/weapon/spellbook/oneuse/blind,
+		/obj/item/weapon/spellbook/oneuse/subjugate,
+		/obj/item/weapon/spellbook/oneuse/mindswap,
+		/obj/item/weapon/spellbook/oneuse/forcewall,
+		/obj/item/weapon/spellbook/oneuse/teleport/blink,
+		/obj/item/weapon/spellbook/oneuse/knock,
+		/obj/item/weapon/spellbook/oneuse/horsemask,
+		/obj/item/weapon/spellbook/oneuse/clown,
+		/obj/item/weapon/spellbook/oneuse/mime,
+		/obj/item/weapon/spellbook/oneuse/shoesnatch,
+		/obj/item/weapon/spellbook/oneuse/bound_object,
+		/obj/item/weapon/gun/energy/staff,
+		/obj/item/weapon/gun/energy/staff/animate,
+		/obj/item/weapon/gun/energy/staff/focus,
+		/obj/item/weapon/scrying,
+		/obj/item/clothing/suit/space/rig/wizard/complete
+		)
+
+/obj/structure/safe/floor/wizard/New()
+	..()
+	var/I = pick(loot_list)
+	new I(src)

--- a/code/modules/clothing/spacesuits/rig.dm
+++ b/code/modules/clothing/spacesuits/rig.dm
@@ -233,6 +233,14 @@
 /obj/item/clothing/suit/space/rig/wizard/acidable()
 	return 0
 
+/obj/item/clothing/suit/space/rig/wizard/complete/New()	//Use to spawn a complete gemsuit set all at once
+	..()
+	new /obj/item/clothing/head/helmet/space/rig/wizard(loc)
+	new /obj/item/clothing/suit/space/rig/wizard(loc)
+	new /obj/item/clothing/gloves/purple(loc)
+	new /obj/item/clothing/shoes/sandal(loc)
+	qdel(src)
+
 //Medical Rig
 /obj/item/clothing/head/helmet/space/rig/medical
 	name = "medical hardsuit helmet"

--- a/code/modules/mining/surprises/tg.dm
+++ b/code/modules/mining/surprises/tg.dm
@@ -80,7 +80,7 @@
 		/obj/structure/bed/chair/vehicle/wizmobile=1
 	)
 	fluffitems = list(
-		/obj/structure/safe/floor=1,
+		/obj/structure/safe/floor/wizard=1,
 		// /obj/structure/wardrobe=1,
 		/obj/item/weapon/storage/belt/soulstone=1,
 		/obj/item/trash/candle=3,


### PR DESCRIPTION
The floor safes that can sometimes be found in the wizard dens that sometimes spawn on the asteroid now contain a random piece of magic loot, as opposed to literally nothing.

The pool of possible loot items includes: one of each single-use spellbook that doesn't require robes, a staff of change, a staff of mental focus, a staff of animation, and a full gem-encrusted hardsuit.

Resolves #7925

:cl:
 * rscadd: The floor safes inside wizard dens on the asteroid now contain a random magical loot item.