### PR TITLE
Fixes Lighting For Dim Atoms

### DIFF
--- a/code/modules/lighting/lighting_atom.dm
+++ b/code/modules/lighting/lighting_atom.dm
@@ -1,3 +1,5 @@
+#define MINIMUM_USEFUL_LIGHT_RANGE 1.4
+
 /atom
 	var/light_power = 1 // Intensity of the light.
 	var/light_range = 0 // Range in tiles of the light.
@@ -10,6 +12,8 @@
 // Nonesensical value for l_color default, so we can detect if it gets set to null.
 #define NONSENSICAL_VALUE -99999
 /atom/proc/set_light(var/l_range, var/l_power, var/l_color = NONSENSICAL_VALUE)
+	if(l_range > 0 && l_range < MINIMUM_USEFUL_LIGHT_RANGE)
+		l_range = MINIMUM_USEFUL_LIGHT_RANGE	//Brings the range up to 1.4, which is just barely brighter than the soft lighting that surrounds players.
 	if (l_power != null)
 		light_power = l_power
 


### PR DESCRIPTION
Sufficiently small nonzero range arguments given to set_light() will now automatically be brought up to 1.4, the smallest light range at which color is detectable, and just a bit brighter than the soft lighting that surrounds players.

The most immediately observable effect of this is that lit cigarettes once again give off a small amount of light.

Fixes #7759

:cl:
 * bugfix: Fixed lighting for dimly-lit items, such as cigarettes.