### PR TITLE
Reworked how reagents cool/heat you.

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -78,7 +78,7 @@ var/global/disable_vents     = 0
 #define WARNING_LOW_PRESSURE 50 	//This is when the gray low pressure icon is displayed. (it is 2.5 * HAZARD_LOW_PRESSURE)
 #define HAZARD_LOW_PRESSURE 20		//This is when the black ultra-low pressure icon is displayed. (This one is set as a constant)
 
-#define TEMPERATURE_DAMAGE_COEFFICIENT 1.5	//This is used in handle_temperature_damage() for humans, and in reagents that affect body temperature. Temperature damage is multiplied by this amount.
+#define TEMPERATURE_DAMAGE_COEFFICIENT 0.0001	//This is used in reagents that affect body temperature. Temperature damage is multiplied by this amount.
 #define BODYTEMP_AUTORECOVERY_DIVISOR 0.5 //This is the divisor which handles how much of the temperature difference between the current body temperature and 310.15K (optimal temperature) humans auto-regenerate each tick. The higher the number, the slower the recovery. This is applied each tick, so long as the mob is alive.
 #define BODYTEMP_AUTORECOVERY_MAXIMUM 2.0 //Maximum amount of kelvin moved toward 310.15K per tick. So long as abs(310.15 - bodytemp) is more than 0.5 .
 
@@ -189,6 +189,7 @@ var/global/disable_vents     = 0
 
 #define T0C  273.15					// 0degC
 #define T20C 293.15					// 20degC
+#define T37C 310.15					// 37degC
 #define TCMB 2.73					// -270.42degC
 
 var/turf/space/Space_Tile = locate(/turf/space) // A space tile to reference when atmos wants to remove excess heat.

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -373,7 +373,7 @@
 	name = "packet of cinnamomum seeds"
 	seed_type = "cinnamomum"
 	vending_cat = "trees"
-	
+
 /obj/item/seeds/test
 	name = "packet of testing data seed"
 	seed_type = "test"
@@ -1678,7 +1678,7 @@
 	yield = 4
 	potency = 20
 	growth_stages = 3
-	ideal_heat = 310
+	ideal_heat = T37C
 	thorny = 1
 
 /datum/seed/vaporsac

--- a/code/modules/mob/living/carbon/slime/life.dm
+++ b/code/modules/mob/living/carbon/slime/life.dm
@@ -211,7 +211,7 @@
 		Tempstun = 0
 
 	/*moved after the temperature damage code so freeze beams can instantly kill slimes -Deity Link*/
-	if(loc_temp < 310.15) // a cold place
+	if(loc_temp < T37C) // a cold place
 		bodytemperature += adjust_body_temperature(bodytemperature, loc_temp, 1)
 	else // a hot place
 		bodytemperature += adjust_body_temperature(bodytemperature, loc_temp, 1)

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -79,7 +79,7 @@ var/global/list/whitelisted_species = list("Human")
 	var/brute_mod 		// brute multiplier
 	var/burn_mod		// burn multiplier
 
-	var/body_temperature = 310.15
+	var/body_temperature = T37C
 
 	var/footprint_type = /obj/effect/decal/cleanable/blood/tracks/footprints //The type of footprint the species leaves if they are not wearing shoes. If we ever get any other than human and vox, maybe this should be explicitly defined for each species.
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -530,7 +530,7 @@ Thanks.
 	traumatic_shock = 0
 	radiation = 0
 	nutrition = 400
-	bodytemperature = 310
+	bodytemperature = T37C
 	sdisabilities = 0
 	disabilities = 0
 	blinded = 0

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -123,7 +123,7 @@
 	var/cpr_time = 1.0//Carbon
 
 
-	var/bodytemperature = 310.055	//98.7 F
+	var/bodytemperature = T37C	//98.7 F
 	var/drowsyness = 0.0//Carbon
 	var/dizziness = 0//Carbon
 	var/jitteriness = 0//Carbon

--- a/code/modules/mob/thermoregulation.dm
+++ b/code/modules/mob/thermoregulation.dm
@@ -1,10 +1,10 @@
 /mob/living/proc/handle_body_temperature()
-	var/body_temperature_difference = abs(310.15 - bodytemperature)
+	var/body_temperature_difference = abs(T37C - bodytemperature)
 	if(body_temperature_difference < 0.5)
 		return //fuck this precision
 	if(undergoing_hypothermia())
 		handle_hypothermia()
-	if(bodytemperature > 310.15)
+	if(bodytemperature > T37C)
 		var/recovery_amt = min((body_temperature_difference / BODYTEMP_AUTORECOVERY_DIVISOR),BODYTEMP_AUTORECOVERY_MAXIMUM)
 		sweat(recovery_amt,1)
 

--- a/code/modules/organs/internal/lungs/lung.dm
+++ b/code/modules/organs/internal/lungs/lung.dm
@@ -39,7 +39,7 @@
 		G.set_context(src,breath,H)
 		G.handle_exhale()
 
-	if( (abs(310.15 - breath.temperature) > 50) && !(M_RESIST_HEAT in H.mutations)) // Hot air hurts :(
+	if( (abs(T37C - breath.temperature) > 50) && !(M_RESIST_HEAT in H.mutations)) // Hot air hurts :(
 		if(H.status_flags & GODMODE)
 			return 1	//godmode
 		if(breath.temperature < H.species.cold_level_1)

--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -128,7 +128,7 @@ var/global/list/disease2_list = list()
 				infect_virus2(M,src, notes="(Airborne from [key_name(mob)])")
 
 	//fever
-	mob.bodytemperature = max(mob.bodytemperature, min(310+5*stage ,mob.bodytemperature+5*stage))
+	mob.bodytemperature = max(mob.bodytemperature, min(T37C+5*stage ,mob.bodytemperature+5*stage))
 	clicks+=speed
 
 /datum/disease2/disease/proc/cure(var/mob/living/carbon/mob)


### PR DESCRIPTION
Or rather, made them cool/heat you at all.
You see, in the past, A glass of ice would be equally good at warming you up as coffee. (That's not how ice works)
Reagents also had no behaviour for cooling and heating, only snowflaked in stuff.
Made T37C a define.
Capsaicin and Frost Oil should not change your temperature to lethal amounts anymore, but instead will cause you minor burn damage to the head and still give you the alert for feeling hot or cold

How it works now: All drinks/reagents move you towards their temperature. By default, all reagents are 37C. - They do so at a rate of:
Their volume times the difference in temperature between that of the person times their heat conductivity times the coefficient (currently: 0.0001)

This means that if you drank 50 units of coffee (60C), you would gain 0.115c extra a tick (0.0001 x 50 x 23)
Alternatively if you drank 50 units of ice (0C), you would lose 0.185c extra a tick. 
This *should* never be lethal (on its own), as hypothermia will kick in and start you shivering and heating up first, and the "hyperthermia" system should be able to prevent all but the most hot of food from killing you

Pending :100: % testing