### PR TITLE
Combat Mech Restrainment Module

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -747,14 +747,18 @@ proc/GaussRandRound(var/sigma,var/roundto)
 		progbar.loc = null
 	return 1
 
-/proc/do_after(var/mob/user as mob, var/atom/target, var/delay as num, var/numticks = 10, var/needhand = TRUE)
+/proc/do_after(var/mob/user as mob, var/atom/target, var/delay as num, var/numticks = 10, var/needhand = TRUE, var/use_user_turf = FALSE)
 	if(!user || isnull(user))
 		return 0
 	if(numticks == 0)
 		return 0
 
 	var/delayfraction = round(delay/numticks)
-	var/Location = user.loc
+	var/Location
+	if(use_user_turf)	//When this is true, do_after() will check whether the user's turf has changed, rather than the user's loc.
+		Location = get_turf(user)
+	else
+		Location = user.loc
 	var/holding = user.get_active_hand()
 	var/target_location = target.loc
 	var/image/progbar
@@ -784,7 +788,12 @@ proc/GaussRandRound(var/sigma,var/roundto)
 		sleep(delayfraction)
 		//if(user.client && progbar.icon_state != oldstate)
 			//user.client.images.Remove(progbar)
-		if(!user || user.isStunned() || !(user.loc == Location) || !(target.loc == target_location))
+		var/user_loc_to_check
+		if(use_user_turf)
+			user_loc_to_check = get_turf(user)
+		else
+			user_loc_to_check = user.loc
+		if(!user || user.isStunned() || !(user_loc_to_check == Location) || !(target.loc == target_location))
 			if(progbar)
 				progbar.icon_state = "prog_bar_stopped"
 				spawn(2)

--- a/code/game/mecha/equipment/mecha_equipment.dm
+++ b/code/game/mecha/equipment/mecha_equipment.dm
@@ -70,10 +70,10 @@
 	return "<span style=\"color:[equip_ready?"#0f0":"#f00"];\">*</span>&nbsp;[chassis.selected==src?"<b>":"<a href='?src=\ref[chassis];select_equip=\ref[src]'>"][src.name][chassis.selected==src?"</b>":"</a>"]"
 
 /obj/item/mecha_parts/mecha_equipment/proc/is_ranged()//add a distance restricted equipment. Why not?
-	return (range&RANGED || range&BOTH)
+	return (range&RANGED)
 
 /obj/item/mecha_parts/mecha_equipment/proc/is_melee()
-	return (range&MELEE || range&BOTH)
+	return (range&MELEE)
 
 
 /obj/item/mecha_parts/mecha_equipment/proc/action_checks(atom/target)

--- a/code/game/mecha/equipment/mecha_equipment.dm
+++ b/code/game/mecha/equipment/mecha_equipment.dm
@@ -70,10 +70,10 @@
 	return "<span style=\"color:[equip_ready?"#0f0":"#f00"];\">*</span>&nbsp;[chassis.selected==src?"<b>":"<a href='?src=\ref[chassis];select_equip=\ref[src]'>"][src.name][chassis.selected==src?"</b>":"</a>"]"
 
 /obj/item/mecha_parts/mecha_equipment/proc/is_ranged()//add a distance restricted equipment. Why not?
-	return range&RANGED
+	return (range&RANGED || range&BOTH)
 
 /obj/item/mecha_parts/mecha_equipment/proc/is_melee()
-	return range&MELEE
+	return (range&MELEE || range&BOTH)
 
 
 /obj/item/mecha_parts/mecha_equipment/proc/action_checks(atom/target)

--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -1,5 +1,5 @@
 /obj/item/mecha_parts/mecha_equipment/tool/sleeper
-	name = "Mounted Sleeper"
+	name = "\improper Mounted Sleeper"
 	desc = "Mounted Sleeper. (Can be attached to: Medical Exosuits)"
 	icon = 'icons/obj/Cryogenic2.dmi'
 	icon_state = "sleeper_0"
@@ -240,7 +240,7 @@
 
 
 /obj/item/mecha_parts/mecha_equipment/tool/cable_layer //why the fuck is this under medical_tools?
-	name = "Cable Layer"
+	name = "\improper Cable Layer"
 	icon_state = "mecha_wire"
 	var/datum/event/event
 	var/turf/old_turf
@@ -386,7 +386,7 @@
 	return 1
 
 /obj/item/mecha_parts/mecha_equipment/tool/syringe_gun
-	name = "Exosuit-Mounted Syringe Gun"
+	name = "\improper Exosuit-Mounted Syringe Gun"
 	desc = "Exosuit-mounted chem synthesizer with syringe gun. Reagents inside are held in stasis, so no reactions will occur. (Can be attached to: Medical Exosuits)"
 	icon = 'icons/obj/gun.dmi'
 	icon_state = "syringegun"

--- a/code/game/mecha/equipment/tools/sec_tools.dm
+++ b/code/game/mecha/equipment/tools/sec_tools.dm
@@ -1,7 +1,7 @@
 #define MECH_JAIL_TIME 10
 
 /obj/item/mecha_parts/mecha_equipment/tool/jail
-	name = "Mounted Jail Cell"
+	name = "\improper Mounted Jail Cell"
 	desc = "Mounted Jail Cell, capable of holding up to two prisoners for a limited time. (Can be attached to Gygax)"
 	icon_state = "mecha_jail"
 	origin_tech = Tc_BIOTECH + "=2;" + Tc_COMBAT + "=4"

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -515,7 +515,7 @@
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/bolas/restrainment
 	name = "\improper PCMK-7 Restrainment Module"
 	desc = "This upgraded version of the PCMK-6 is capable of applying handcuffs as well as launching bolas."
-	range = BOTH
+	range = MELEE | RANGED
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/bolas/restrainment/action(target)
 	if(!action_checks(target))

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -13,7 +13,7 @@
 	return 0
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy
-	name = "General Energy Weapon"
+	name = "\improper General Energy Weapon"
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/become_defective()
 	if(!defective)
@@ -55,7 +55,7 @@
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser
 	equip_cooldown = 8
-	name = "CH-PS \"Immolator\" Laser"
+	name = "\improper CH-PS \"Immolator\" Laser"
 	icon_state = "mecha_laser"
 	energy_drain = 30
 	projectile = /obj/item/projectile/beam
@@ -63,7 +63,7 @@
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser/heavy
 	equip_cooldown = 15
-	name = "CH-LC \"Solaris\" Laser Cannon"
+	name = "\improper CH-LC \"Solaris\" Laser Cannon"
 	icon_state = "mecha_laser"
 	energy_drain = 60
 	projectile = /obj/item/projectile/beam/heavylaser
@@ -159,7 +159,7 @@
 	return
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic
-	name = "General Ballisic Weapon"
+	name = "\improper General Ballistic Weapon"
 	var/max_projectiles
 	var/projectiles
 	var/projectile_energy_cost
@@ -205,7 +205,7 @@
 
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/scattershot
-	name = "LBX AC 10 \"Scattershot\""
+	name = "\improper LBX AC 10 \"Scattershot\""
 	icon_state = "mecha_scatter"
 	equip_cooldown = 20
 	projectile = /obj/item/projectile/bullet/midbullet
@@ -255,7 +255,7 @@
 
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/lmg
-	name = "Ultra AC 2"
+	name = "\improper Ultra AC 2"
 	icon_state = "mecha_uac2"
 	equip_cooldown = 10
 	projectile = /obj/item/projectile/bullet/weakbullet
@@ -307,7 +307,7 @@
 	return
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack
-	name = "SRM-8 Missile Rack"
+	name = "\improper SRM-8 Missile Rack"
 	icon_state = "mecha_missilerack"
 	projectile = /obj/item/missile
 	fire_sound = 'sound/weapons/rocket.ogg'
@@ -351,7 +351,7 @@
 	return
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/flashbang
-	name = "SGL-6 Grenade Launcher"
+	name = "\improper SGL-6 Grenade Launcher"
 	icon_state = "mecha_grenadelnchr"
 	projectile = /obj/item/weapon/grenade/flashbang
 	fire_sound = 'sound/weapons/grenadelauncher.ogg'
@@ -381,7 +381,7 @@
 	return
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/flashbang/clusterbang//Because I am a heartless bastard -Sieve
-	name = "SOP-6 Grenade Launcher"
+	name = "\improper SOP-6 Grenade Launcher"
 	projectile = /obj/item/weapon/grenade/flashbang/clusterbang
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/flashbang/clusterbang/limited/get_equip_info()//Limited version of the clusterbang launcher that can't reload
@@ -391,7 +391,7 @@
 	return//Extra bit of security
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/banana_mortar
-	name = "Banana Mortar"
+	name = "\improper Banana Mortar"
 	icon_state = "mecha_bananamrtr"
 	projectile = /obj/item/weapon/bananapeel
 	fire_sound = 'sound/items/bikehorn.ogg'
@@ -421,7 +421,7 @@
 	return
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/mousetrap_mortar
-	name = "Mousetrap Mortar"
+	name = "\improper Mousetrap Mortar"
 	icon_state = "mecha_mousetrapmrtr"
 	projectile = /obj/item/device/assembly/mousetrap
 	fire_sound = 'sound/items/bikehorn.ogg'
@@ -452,7 +452,7 @@
 	return
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/creampie_mortar //why waste perfectly good food synthetizing technology in solving world hunger when you can have clowntide instead?
-	name = "Rapid-Fire Cream Pie Mortar"
+	name = "\improper Rapid-Fire Cream Pie Mortar"
 	icon_state = "mecha_bananamrtr"
 	projectile = /obj/item/weapon/reagent_containers/food/snacks/pie/empty //because some chucklefuck will try to catch the pie somehow for free nutriment
 	fire_sound = 'sound/items/bikehorn.ogg'
@@ -483,7 +483,7 @@
 	return
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/bolas
-	name = "PCMK-6 Bolas Launcher"
+	name = "\improper PCMK-6 Bolas Launcher"
 	icon_state = "mecha_bolas"
 	projectile = /obj/item/weapon/legcuffs/bolas
 	fire_sound = 'sound/weapons/whip.ogg'
@@ -511,3 +511,44 @@
 	log_attack("[key_name(chassis.occupant)] fired \a [src] from [chassis] towards [originaltarget] ([formatLocation(chassis)])")
 	do_after_cooldown()
 	return
+
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/bolas/restrainment
+	name = "\improper PCMK-7 Restrainment Module"
+	desc = "This upgraded version of the PCMK-6 is capable of applying handcuffs as well as launching bolas."
+	range = BOTH
+
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/bolas/restrainment/action(target)
+	if(!action_checks(target))
+		return
+	if(loc.Adjacent(target) && istype(target, /mob/living/carbon))
+		var/obj/mecha/M = loc
+		if(!istype(M))
+			return ..()
+		var/mob/living/carbon/human/user = M.occupant
+		if(!istype(user))
+			return ..()
+
+		var/mob/living/carbon/C = target
+		if(ishuman(C))
+			var/mob/living/carbon/human/H = C
+			if (!H.has_organ_for_slot(slot_handcuffed))
+				to_chat(user, "<span class='danger'>\The [C] needs at least two wrists before you can cuff them together!</span>")
+				return
+
+		playsound(get_turf(src), 'sound/weapons/handcuffs.ogg', 30, 1, -2)
+		user.visible_message("<span class='danger'>\The [M] is trying to handcuff \the [C]!</span>",
+							 "<span class='danger'>You try to handcuff \the [C]!</span>")
+
+		if(do_after(user, C, 3 SECONDS, 10, FALSE, TRUE))
+			var/obj/item/weapon/handcuffs/cuffs = new(src)
+			feedback_add_details("handcuffs", "H")
+
+			user.visible_message("<span class='danger'>\The [M] has put \the [cuffs] on \the [C]!</span>")
+			user.attack_log += text("\[[time_stamp()]\] <font color='red'>Has put \the [cuffs] on [C.name] ([C.ckey])</font>")
+			C.attack_log += text("\[[time_stamp()]\] <font color='red'>Handcuffed with \the [cuffs] by [user.name] ([user.ckey])</font>")
+			log_attack("[user.name] ([user.ckey]) has cuffed [C.name] ([C.ckey]) with \the [cuffs] while piloting \the [M]")
+
+			C.equip_to_slot(cuffs, slot_handcuffed)
+			projectiles--
+	else
+		..()

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -6,6 +6,7 @@
 
 #define MELEE 1
 #define RANGED 2
+#define BOTH 4	//for mech equipment with effects depending on whether the target is adjacent
 
 #define STATE_BOLTSHIDDEN 0
 #define STATE_BOLTSEXPOSED 1

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -6,7 +6,6 @@
 
 #define MELEE 1
 #define RANGED 2
-#define BOTH 4	//for mech equipment with effects depending on whether the target is adjacent
 
 #define STATE_BOLTSHIDDEN 0
 #define STATE_BOLTSEXPOSED 1

--- a/code/modules/research/designs/mecha/weapons.dm
+++ b/code/modules/research/designs/mecha/weapons.dm
@@ -86,6 +86,18 @@
 	req_lock_access = list(access_armory)
 	materials = list(MAT_IRON=20000)
 
+/datum/design/mech_restrainment
+	name = "Weapon Design (PCMK-7 Restrainment Module)"
+	desc = "Allows for the construction of PCMK-7 Restrainment Module."
+	id = "mech_restrainment"
+	build_type = MECHFAB
+	req_tech = list(Tc_COMBAT = 4)
+	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/bolas/restrainment
+	category = "Exosuit_Weapons"
+	locked = 1
+	req_lock_access = list(access_armory)
+	materials = list(MAT_IRON=20000)
+
 /datum/design/mech_laser
 	name = "Weapon Design (CH-PS \"Immolator\" Laser)"
 	desc = "Allows for the construction of CH-PS Laser."


### PR DESCRIPTION
Adds a new mech module, the PCMK-7 Restrainment Module. It functions similarly to the PCMK-6 Bolas Launcher, but if used while adjacent to your target, it will attempt to handcuff them.

Being a child of the bolas launcher, it has the same restrictions as to what mechs it can be placed on as the bolas launcher does.

The restrainment module requires combat tech 4 to produce, one level higher than is required by the bolas launcher.

Closes #4020

:cl:
 * rscadd: Adds the restrainment module for combat mechs. Functions similarly to the bolas launcher, but is capable of applying handcuffs to adjacent targets. Requires combat tech 4 to produce.