### PR TITLE
Fix revive animations appearing on simple mobs for no reason

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -688,7 +688,7 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 		maxHealth = initial(maxHealth)
 		maxHealth -= (initial(maxHealth) / meat_amount) * meat_taken
 	health = maxHealth
-	..()
+	..(0)
 
 /mob/living/simple_animal/proc/make_babies() // <3 <3 <3
 	if(gender != FEMALE || stat || !scan_ready || !childtype || !species_type)


### PR DESCRIPTION
Hotfix for a dumb problem made by someone who didn't think to check the parent procs  I guess
Not that I actually know this is the problem but fuck if I know what else could be causing it