### PR TITLE
Venom Sword Buff

### DIFF
--- a/code/modules/projectiles/guns/projectile/constructable/swords.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/swords.dm
@@ -92,12 +92,10 @@
 		return
 	var/N = input("Injection amount:","[src]") as null|num
 	if (N)
-		if(N < min_inject_amount)
-			N = min_inject_amount
-		if(N > max_inject_amount)
-			N = max_inject_amount
-		inject_amount = N
-		to_chat(usr, "<span class='notice'>\The [src] will now inject [N] units each hit.</span>")
+		if(usr.incapacitated() || !(usr in range(src,0)))
+			return
+		inject_amount = Clamp(N, min_inject_amount, max_inject_amount)
+		to_chat(usr, "<span class='notice'>\The [src] will now inject [inject_amount] units each hit.</span>")
 
 /obj/item/weapon/sword/venom/examine(mob/user)
 	..()

--- a/code/modules/projectiles/guns/projectile/constructable/swords.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/swords.dm
@@ -79,8 +79,25 @@
 	icon_state = "venom_sword"
 	var/beaker = null
 	var/obj/item/weapon/reagent_containers/hypospray/HY = null
-	var/max_beaker_volume = 50 //The maximum volume a beaker can have and still be placed into the sword
-	var/inject_amount = 5 //The amount of reagents injected from the beaker each hit
+	var/max_beaker_volume = 500 //The maximum volume a beaker can have and still be placed into the sword
+	var/min_inject_amount = 5
+	var/max_inject_amount = 20
+	var/inject_amount = 20 //The amount of reagents injected from the beaker each hit
+
+/obj/item/weapon/sword/venom/verb/set_inject_amount()
+	set name = "Set injection amount"
+	set category = "Object"
+	set src in range(0)
+	if(usr.incapacitated())
+		return
+	var/N = input("Injection amount:","[src]") as null|num
+	if (N)
+		if(N < min_inject_amount)
+			N = min_inject_amount
+		if(N > max_inject_amount)
+			N = max_inject_amount
+		inject_amount = N
+		to_chat(usr, "<span class='notice'>\The [src] will now inject [N] units each hit.</span>")
 
 /obj/item/weapon/sword/venom/examine(mob/user)
 	..()
@@ -88,6 +105,7 @@
 		to_chat(user, "[bicon(beaker)] There is \a [beaker] in \the [src]'s beaker port.")
 		var/obj/item/weapon/reagent_containers/glass/beaker/B = beaker
 		B.show_list_of_reagents(user)
+	to_chat(user, "<span class='info'>\The [src] is set to inject [inject_amount] units each hit.</span>")
 
 /obj/item/weapon/sword/venom/Destroy()
 	if(beaker)


### PR DESCRIPTION
In an effort to make the venom sword an upgrade to the hypospray in return for becoming larger and more conspicuous, the venom sword is now capable of holding any existing beaker, and capable of injecting up to 20u from the beaker each hit.

The venom sword now also has a verb for setting the injection amount, between 5u and 20u inclusive.

:cl:
 * tweak: The venom sword is now capable of holding any beaker, and can now inject a maximum of 20u each hit.