### PR TITLE
Fixes gibbed mob stomach contents message

### DIFF
--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -70,8 +70,9 @@
 				our_mob.forceMove(src)
 				if(iscarbon(our_mob))
 					var/mob/living/carbon/C = our_mob
-					C.drop_stomach_contents()
-					user.visible_message("<span class='warning'>\The [C]'s stomach contents drop to the ground!</span>")
+					if(C.stomach_contents && C.stomach_contents.len)
+						C.drop_stomach_contents()
+						user.visible_message("<span class='warning'>\The [C]'s stomach contents drop to the ground!</span>")
 
 				returnToPool(G)
 				return

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -81,8 +81,9 @@
 
 /mob/living/carbon/gib()
 	dropBorers(1)
-	drop_stomach_contents()
-	src.visible_message("<span class='warning'>Something bursts from \the [src]'s stomach!</span>")
+	if(stomach_contents && stomach_contents.len)
+		drop_stomach_contents()
+		visible_message("<span class='warning'>Something bursts from \the [src]'s stomach!</span>")
 	. = ..()
 
 /mob/living/carbon/proc/share_contact_diseases(var/mob/M)


### PR DESCRIPTION
Adds a check to see if there actually is anything in their stomach before displaying the message.

This was mostly visible when slimes were gibbed by a singularity.