### PR TITLE
Fix for grab move logic

### DIFF
--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -343,7 +343,7 @@
 					if(M)
 						if ((mob.Adjacent(M) || M.loc == mob.loc))
 							var/turf/T = mob.loc
-							. = ..()
+							step(mob, dir)
 							if (isturf(M.loc))
 								var/diag = get_dir(mob, M)
 								if ((diag - 1) & diag)
@@ -365,7 +365,7 @@
 							M.animate_movement = 2
 							return
 
-		else if(mob.confused)
+		if(mob.confused)
 			step_rand(mob)
 			mob.last_movement=world.time
 		else

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -365,7 +365,7 @@
 							M.animate_movement = 2
 							return
 
-		if(mob.confused)
+		else if(mob.confused)
 			step_rand(mob)
 			mob.last_movement=world.time
 		else


### PR DESCRIPTION
The . = ..() call was removed in #12287 and replaced with a step for the standard case, so I infer it no longer worked to do the step call.

I assume this call in the grab code was meant to also be replaced but was overlooked.

This probably fixes #12516 but I didn't test it yet