### PR TITLE
Fixes vault shuttle engine dirs

### DIFF
--- a/maps/randomvaults/brokeufo.dmm
+++ b/maps/randomvaults/brokeufo.dmm
@@ -1,8 +1,8 @@
 "aa" = (/turf/space,/area)
 "ab" = (/turf/simulated/shuttle/wall,/area/vault/brokeufo)
-"ac" = (/obj/structure/shuttle/engine/propulsion{icon_state = "propulsion_r"; dir = 1},/turf/space,/area/vault/brokeufo)
-"ad" = (/obj/structure/shuttle/engine/propulsion,/turf/space,/area/vault/brokeufo)
-"ae" = (/obj/structure/shuttle/engine/propulsion{icon_state = "propulsion_l"; dir = 1},/turf/space,/area/vault/brokeufo)
+"ac" = (/obj/machinery/light,/obj/structure/table/flipped{dir = 8},/turf/simulated/floor{tag = "icon-white"; icon_state = "white"},/area/vault/brokeufo)
+"ad" = (/obj/structure/shuttle/engine/propulsion{dir = 1},/turf/space,/area/vault/brokeufo)
+"ae" = (/obj/structure/shuttle/engine/propulsion/right{dir = 1},/turf/space,/area/vault/brokeufo)
 "af" = (/turf/simulated/shuttle/wall{tag = "icon-swall_s6"; icon_state = "swall_s6"},/area/vault/brokeufo)
 "ag" = (/turf/simulated/shuttle/wall{icon_state = "swall12"},/area/vault/brokeufo)
 "ah" = (/turf/simulated/shuttle/wall{icon_state = "swall11"},/area/vault/brokeufo)
@@ -17,7 +17,7 @@
 "aq" = (/obj/item/weapon/soap/deluxe,/turf/simulated/floor{tag = "icon-whitebluefull"; icon_state = "whitebluefull"},/area/vault/brokeufo)
 "ar" = (/obj/structure/bed,/obj/effect/landmark/corpse/tajaran,/turf/simulated/floor{tag = "icon-whitebluefull"; icon_state = "whitebluefull"},/area/vault/brokeufo)
 "as" = (/obj/machinery/door/unpowered/shuttle,/turf/simulated/floor{tag = "icon-white"; icon_state = "white"},/area/vault/brokeufo)
-"at" = (/obj/machinery/light,/turf/simulated/floor{tag = "icon-white"; icon_state = "white"},/area/vault/brokeufo)
+"at" = (/obj/structure/shuttle/engine/propulsion/left{dir = 1},/turf/space,/area/vault/brokeufo)
 "au" = (/turf/simulated/floor{dir = 9; icon_state = "yellowfull"},/area/vault/brokeufo)
 "av" = (/mob/living/simple_animal/hostile/humanoid/grey/space{name = "Klaatu"},/turf/simulated/floor{dir = 9; icon_state = "yellowfull"},/area/vault/brokeufo)
 "aw" = (/obj/item/clothing/gloves/yellow,/turf/simulated/floor{dir = 9; icon_state = "yellowfull"},/area/vault/brokeufo)
@@ -62,10 +62,10 @@
 "bj" = (/obj/item/toy/gasha/wizard,/turf/space,/area)
 
 (1,1,1) = {"
-aaaaaaaaabacadaeabaaaaaaaaaaaa
+aaaaaaaaabaeadatabaaaaaaaaaaaa
 aaaaafagahaiaiaiajagagakaaaaaa
 aaaaalamalanaoapalaqaralaaaaaa
-aaaaasatasauavawalaxayalaaaaaa
+aaaaasacasauavawalaxayalaaaaaa
 aaafazagaAagasagahaBaCalaaaaaa
 aaalaDaEalaFaGaHalaCaIalaaaaaa
 aaaJaKaGasaGaGaGasaLaCalaaaaaa
@@ -78,3 +78,4 @@ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaabjaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 "}
+

--- a/maps/randomvaults/droneship.dmm
+++ b/maps/randomvaults/droneship.dmm
@@ -1,12 +1,12 @@
 "a" = (/turf/space,/area)
-"b" = (/obj/structure/shuttle/engine/propulsion/burst{dir = 4; pixel_x = -24},/turf/simulated/shuttle/wall{icon_state = "wall3"},/area/vault/droneship)
+"b" = (/obj/structure/shuttle/engine/propulsion{dir = 8},/turf/space,/area)
 "c" = (/turf/simulated/shuttle/wall{icon_state = "wall3"},/area/vault/droneship)
 "d" = (/turf/simulated/shuttle/wall{dir = 1; icon_state = "diagonalWall3"},/area/vault/droneship)
 "e" = (/turf/simulated/shuttle/wall{dir = 8; icon_state = "diagonalWall3"},/area/vault/droneship)
 "f" = (/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 8},/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced{dir = 4},/obj/structure/grille,/obj/structure/window/full/reinforced,/turf/simulated/shuttle/plating/airless,/area/vault/droneship)
 "g" = (/obj/item/robot_parts/l_arm,/turf/space,/area)
 "h" = (/obj/item/stack/rods,/turf/space,/area)
-"i" = (/obj/structure/shuttle/engine/propulsion{dir = 4},/turf/space,/area)
+"i" = (/obj/structure/shuttle/engine/propulsion/burst{dir = 8; pixel_x = -24},/turf/simulated/shuttle/wall{icon_state = "wall3"},/area/vault/droneship)
 "j" = (/obj/structure/shuttle/engine/heater{dir = 8},/obj/item/weapon/shard,/obj/effect/decal/cleanable/soot,/turf/simulated/shuttle/plating/airless,/area/vault/droneship)
 "k" = (/obj/effect/decal/cleanable/soot,/obj/effect/decal/cleanable/molten_item,/obj/machinery/computer/pod{id_tags = list("Cyber"); name = "Pod Door Control"},/turf/simulated/shuttle/floor{icon_state = "floor2"},/area/vault/droneship)
 "l" = (/turf/simulated/shuttle/floor{icon_state = "floor2"},/area/vault/droneship)
@@ -36,11 +36,12 @@
 "J" = (/turf/simulated/shuttle/wall{icon_state = "diagonalWall3"},/area/vault/droneship)
 
 (1,1,1) = {"
-aaaaaaaaaaabccdaaa
+aaaaaaaaaaaiccdaaa
 aaaaeccfcccccccdaa
-gahaijklmcnopqrccd
+gahabjklmcnopqrccd
 asaatuvwxyxxxxxzAc
-aaBaiCDlEcnFGHnccI
+aaBabCDlEcnFGHnccI
 aaaaJccfcccccccIaa
-aaaaaaaaaaabccIaaa
+aaaaaaaaaaaiccIaaa
 "}
+

--- a/maps/randomvaults/hivebot_crash.dmm
+++ b/maps/randomvaults/hivebot_crash.dmm
@@ -15,14 +15,14 @@
 "ao" = (/obj/structure/closet/wardrobe/grey,/turf/simulated/shuttle/floor/airless,/area/vault/hive_shuttle)
 "ap" = (/obj/machinery/light_construct{dir = 1},/turf/simulated/shuttle/floor/airless,/area/vault/hive_shuttle)
 "aq" = (/turf/simulated/shuttle/wall{icon_state = "swall7"},/area/vault/hive_shuttle)
-"ar" = (/obj/structure/shuttle/engine/propulsion{icon_state = "burst_r"; dir = 8},/turf/space,/area/vault/hive_shuttle)
+"ar" = (/obj/structure/shuttle/engine/propulsion{dir = 4},/turf/space,/area/vault/hive_shuttle)
 "as" = (/turf/simulated/shuttle/wall{icon_state = "swall3"},/area/vault/hive_shuttle)
 "at" = (/obj/structure/computerframe,/turf/simulated/shuttle/floor/airless,/area/vault/hive_shuttle)
 "au" = (/obj/structure/bed/chair{dir = 8},/obj/machinery/light_construct{dir = 4},/obj/effect/landmark/corpse/engineer,/turf/simulated/shuttle/floor/airless,/area/vault/hive_shuttle)
 "av" = (/obj/structure/bed/chair{dir = 8},/obj/effect/landmark/corpse/civilian,/turf/simulated/shuttle/floor/airless,/area/vault/hive_shuttle)
 "aw" = (/obj/effect/decal/cleanable/blood/drip,/turf/simulated/shuttle/floor/airless,/area/vault/hive_shuttle)
 "ax" = (/obj/structure/shuttle/engine/heater{dir = 4},/obj/structure/window/reinforced{dir = 8},/turf/simulated/shuttle/plating/airless,/area/vault/hive_shuttle)
-"ay" = (/obj/structure/shuttle/engine/propulsion{dir = 8},/turf/space,/area/vault/hive_shuttle)
+"ay" = (/obj/structure/shuttle/engine/propulsion/right{dir = 4},/turf/space,/area/vault/hive_shuttle)
 "az" = (/obj/structure/grille,/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 4},/obj/structure/window/reinforced{dir = 8},/turf/simulated/shuttle/plating,/area/vault/hive_shuttle)
 "aA" = (/obj/structure/bed/chair{dir = 8},/obj/effect/landmark/corpse/civilian,/turf/simulated/shuttle/plating/airless,/area/vault/hive_shuttle)
 "aB" = (/mob/living/simple_animal/hostile/hivebot,/turf/simulated/shuttle/plating/airless,/area/vault/hive_shuttle)
@@ -34,7 +34,7 @@
 "aH" = (/obj/machinery/light_construct,/mob/living/simple_animal/hostile/hivebot,/turf/simulated/shuttle/plating/airless,/area/vault/hive_shuttle)
 "aI" = (/obj/item/stack/rods,/obj/effect/decal/cleanable/blood/gibs/robot,/turf/simulated/shuttle/plating/airless,/area/vault/hive_shuttle)
 "aJ" = (/obj/machinery/light_construct,/turf/simulated/shuttle/plating/airless,/area/vault/hive_shuttle)
-"aK" = (/obj/structure/shuttle/engine/propulsion{icon_state = "burst_l"; dir = 8},/turf/space,/area/vault/hive_shuttle)
+"aK" = (/obj/structure/shuttle/engine/propulsion/left{dir = 4},/turf/space,/area/vault/hive_shuttle)
 "aL" = (/obj/item/stack/tile/plasteel,/obj/structure/grille/broken,/obj/effect/decal/cleanable/blood/gibs/robot,/turf/simulated/shuttle/plating/airless,/area/vault/hive_shuttle)
 "aM" = (/obj/item/stack/rods,/turf/simulated/shuttle/plating/airless,/area/vault/hive_shuttle)
 "aN" = (/turf/simulated/shuttle/wall{icon_state = "swall13"},/area/vault/hive_shuttle)
@@ -78,17 +78,17 @@
 "bz" = (/obj/machinery/computer/aifixer,/turf/simulated/floor/engine/airless,/area/vault/hive_shuttle)
 "bA" = (/obj/structure/shuttle/engine/heater,/obj/structure/window/reinforced/plasma{dir = 1},/turf/simulated/shuttle/plating/airless,/area/vault/hive_shuttle)
 "bB" = (/turf/space,/turf/simulated/shuttle/wall{icon_state = "diagonalWall3"},/area/vault/hive_shuttle)
-"bC" = (/obj/structure/shuttle/engine/propulsion{dir = 1; icon_state = "burst_l"},/turf/space,/area/vault/hive_shuttle)
-"bD" = (/obj/structure/shuttle/engine/propulsion{dir = 1},/turf/space,/area/vault/hive_shuttle)
-"bE" = (/obj/structure/shuttle/engine/propulsion{dir = 1; icon_state = "burst_r"},/turf/space,/area/vault/hive_shuttle)
+"bC" = (/obj/structure/shuttle/engine/propulsion/left,/turf/space,/area/vault/hive_shuttle)
+"bD" = (/obj/structure/shuttle/engine/propulsion,/turf/space,/area/vault/hive_shuttle)
+"bE" = (/obj/structure/shuttle/engine/propulsion/right,/turf/space,/area/vault/hive_shuttle)
 "bF" = (/turf/space,/turf/simulated/shuttle/wall{dir = 4; icon_state = "diagonalWall3"},/area/vault/hive_shuttle)
 
 (1,1,1) = {"
 aaaaaaabacadacacaeafacacadagah
-abacacaiajajakalamanaoapajaqar
-asatauasajavawavajavajavajaxay
-azatajajajaAajavaBavawavajaCay
-asatauasajavaDaAaEaFaDavajaCay
+abacacaiajajakalamanaoapajaqay
+asatauasajavawavajavajavajaxar
+azatajajajaAajavaBavawavajaCar
+asatauasajavaDaAaEaFaDavajaCar
 aGacacaiajajaHaIaEaEaIaJaEaqaK
 aaaaaaaGacadacaEaLaMaEacadaNaO
 aaaaaaaaaaaaaPaQaRaSaTaPaaaaaa
@@ -102,3 +102,4 @@ aaaaaaaaaaaPbwbebxbybtbzaPaaaa
 aaaaaaaaaaaPaPbAbAbAbAaPaPaaaa
 aaaaaaaaaabBbCbDbDbDbDbEbFaaaa
 "}
+

--- a/maps/randomvaults/prison_ship.dmm
+++ b/maps/randomvaults/prison_ship.dmm
@@ -6,7 +6,7 @@
 "f" = (/obj/item/stack/rods,/turf/simulated/shuttle/plating,/area/vault/prison_ship)
 "g" = (/obj/item/stack/rods,/turf/unsimulated/mineral,/area/vault/prison_ship)
 "h" = (/obj/item/stack/rods,/obj/effect/landmark/corpse/mutilated,/turf/simulated/shuttle/plating,/area/vault/prison_ship)
-"i" = (/obj/structure/shuttle/engine/heater{dir = 4},/obj/structure/shuttle/engine/propulsion/burst{dir = 4; pixel_x = -24},/turf/simulated/shuttle/floor4,/area/vault/prison_ship)
+"i" = (/obj/structure/shuttle/engine/heater{dir = 8; pixel_x = 8},/obj/structure/shuttle/engine/propulsion/burst{dir = 8; pixel_x = -24},/turf/simulated/shuttle/floor4,/area/vault/prison_ship)
 "j" = (/turf/simulated/shuttle/wall{icon_state = "swall11"},/area/vault/prison_ship)
 "k" = (/obj/item/weapon/reagent_containers/glass/bucket,/obj/effect/landmark/corpse/civilian,/turf/simulated/shuttle/floor4,/area/vault/prison_ship)
 "l" = (/obj/item/stack/sheet/cardboard,/obj/effect/landmark/corpse/civilian,/turf/simulated/shuttle/floor4,/area/vault/prison_ship)
@@ -39,3 +39,4 @@ aaijtttotwxbaa
 aaijtotytzxaaa
 aaABeCCeeeDaaa
 "}
+


### PR DESCRIPTION
Forgot vaults when I did #12494, this fixes those.
Also adds a flipped table to keep the greys from spacing themselves.
![greydoor](https://cloud.githubusercontent.com/assets/19806447/20243192/47d417fc-a91b-11e6-80c3-097321442965.png)

Fixes #12532
