### PR TITLE
Revert "Disallow nonhumans from taking HOP HOS Captain."

### DIFF
--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -13,8 +13,6 @@
 	minimal_access = list() 	//See get_access()
 	minimal_player_age = 14
 
-	species_whitelist = list("Human")
-
 	pdaslot=slot_l_store
 	pdatype=/obj/item/device/pda/captain
 
@@ -69,9 +67,6 @@
 	idtype = /obj/item/weapon/card/id/silver
 	req_admin_notify = 1
 	minimal_player_age = 10
-
-	species_whitelist = list("Human")
-
 	access = list(access_security, access_sec_doors, access_brig, access_court, access_weapons, access_forensics_lockers,
 			            access_medical, access_engine, access_change_ids, access_ai_upload, access_eva, access_heads,
 			            access_all_personal_lockers, access_maint_tunnels, access_bar, access_janitor, access_construction, access_morgue,

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -19,8 +19,6 @@
 			            access_heads, access_hos, access_RC_announce, access_keycard_auth, access_gateway)
 	minimal_player_age = 14
 
-	species_whitelist = list("Human")
-
 	pdaslot=slot_belt
 	pdatype=/obj/item/device/pda/heads/hos
 


### PR DESCRIPTION
Reverts d3athrow/vgstation13#12219



1. It doesn't work. You can still latejoin as a nonhuman HOP/HOS/Captain.
2. I don't see ANY feasible reason other than MUH LAWS for not allowing nonhumans to be roundstart heads. A human can order any nonhuman dead, but nonhumans are still playable.
3. Sweet plasma man suits

Basically I think this was a shit change and the poll doesn't matter. If polls mattered, then we would have attack animations and skeletons would be valid.

