### PR TITLE
Maybe if I go ahead and open this I'll actually finish it

### DIFF
--- a/goon/code/datums/browserOutput.dm
+++ b/goon/code/datums/browserOutput.dm
@@ -203,10 +203,10 @@ For the main html chat area
 
 	// Either an atom or somebody fucked up and is gonna get a runtime, which I'm fine with.
 	var/atom/A = obj
-	var/key = "[istype(A.icon, /icon) ? "\ref[A.icon]" : A.icon]:[A.icon_state]"
+	var/key = "\ref[A.appearance]"
 	if (!bicon_cache[key]) // Doesn't exist, make it.
-		var/icon/I = icon(A.icon, A.icon_state, SOUTH, 1)
-		if (ishuman(obj)) // Shitty workaround for a BYOND issue.
+		var/icon/I = getFlatIcon(A, SOUTH)
+		if (!"[A.icon]") // Shitty workaround for a BYOND issue. Just... don't even question it.
 			var/icon/temp = I
 			I = icon()
 			I.Insert(temp, dir = SOUTH)


### PR DESCRIPTION
This works, but probably needs some optimization before it's ready to merge.

Fixes human mobs appearing all fucked up on examine. Also fixes other things appearing fucked up on examine but humans were really the only one that was obvious.

Issues:
* `getFlatIcon()` is slow as shit. It would be great to not use it, but that may or may not be possible.
* Caching with `"\ref[appearance]"` is pretty awful, but the current caching system won't work for obvious reasons. I could use the same caching scheme as `getFlatIcon()`, ~~but if I do that and don't find an alternative to `getFlatIcon()`, I might as well entirely remove `bicon_cache` and just use `getFlatIcon()`'s cache instead.~~ I'm actually an idiot and that's not true.