### PR TITLE
Shuttle flames don't reach so far into the shuttle

### DIFF
--- a/code/controllers/shuttle_controller.dm
+++ b/code/controllers/shuttle_controller.dm
@@ -195,7 +195,7 @@ datum/shuttle_controller/emergency_shuttle/process()
 			if(direction == 2)
 				for(var/obj/structure/shuttle/engine/propulsion/P in shuttle.linked_area)
 					spawn()
-						P.shoot_exhaust()
+						P.shoot_exhaust(backward = 3)
 				if(timeleft>0)
 					return 0
 
@@ -274,7 +274,7 @@ datum/shuttle_controller/emergency_shuttle/process()
 						D.locked = 1
 				for(var/obj/structure/shuttle/engine/propulsion/P in shuttle.linked_area)
 					spawn()
-						P.shoot_exhaust()
+						P.shoot_exhaust(backward = 3)
 
 			if(timeleft>0)
 				return 0
@@ -306,7 +306,7 @@ datum/shuttle_controller/emergency_shuttle/process()
 
 					for(var/obj/structure/shuttle/engine/propulsion/P in E.linked_area)
 						spawn()
-							P.shoot_exhaust()
+							P.shoot_exhaust(backward = 3)
 
 					if(!E.move_to_dock(E.transit_port, 0, turn(E.dir,180))) //Throw everything backwards
 						message_admins("WARNING: THE EMERGENCY SHUTTLE FAILED TO FIND TRANSIT! PANIC PANIC PANIC")

--- a/code/game/shuttle_engines.dm
+++ b/code/game/shuttle_engines.dm
@@ -41,11 +41,12 @@
 	icon_state = "propulsion"
 	opacity = 1
 
-/obj/structure/shuttle/engine/propulsion/proc/shoot_exhaust()
+/obj/structure/shuttle/engine/propulsion/proc/shoot_exhaust(forward=9, backward=9)
 
 	var/turf/target = get_edge_target_turf(src,dir)
 	var/turf/T = get_turf(src)
-	var/obj/item/projectile/A = new /obj/item/projectile/fire_breath/shuttle_exhaust(T)
+	var/obj/item/projectile/fire_breath/A = new /obj/item/projectile/fire_breath/shuttle_exhaust(T)
+	A.max_range = forward
 
 	for(var/i=0, i<2, i++)
 		A.original = target
@@ -61,6 +62,7 @@
 		target = get_edge_target_turf(src,reverse_direction(dir))
 		sleep(6)
 		A = new /obj/item/projectile/fire_breath/shuttle_exhaust(T)
+		A.max_range = backward
 
 /obj/structure/shuttle/engine/propulsion/left
 	icon_state = "propulsion_l"


### PR DESCRIPTION
The escape shuttle exhaust has been cut in length, and should only burn people in the cargo/medical rooms or just outside of them.

Hopefully somewhat addresses #12568, because after watching a few rounds of it being loosed I agree it was a bit too excessive.