### PR TITLE
Arcane golem movespeed buff and melee attack

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/arcane_golem.dm
+++ b/code/modules/mob/living/simple_animal/friendly/arcane_golem.dm
@@ -1,4 +1,4 @@
-/mob/living/simple_animal/arcane_golem
+/mob/living/simple_animal/hostile/arcane_golem
 	name = "arcane golem"
 	desc = "A soulless construct forged by a wizard. It's linked to its master's magic powers, and it casts spells simultaneously with them. If one of them dies, the other's spellcasting abilities will be affected."
 
@@ -15,6 +15,15 @@
 	speak_emote = list("vocalizes")
 
 	speak_chance = 0.25
+	move_to_delay = 14
+
+	melee_damage_lower = 15
+	melee_damage_upper = 25
+	attacktext = "smashes its gauntlet into"
+	attack_sound = 'sound/weapons/heavysmash.ogg'
+
+	aggro_vision_range = 2
+	idle_vision_range = 2
 
 	var/spell/aoe_turf/conjure/arcane_golem/master_spell
 
@@ -28,16 +37,33 @@
 	max_n2 = 0
 	heat_damage_per_tick = 0
 	cold_damage_per_tick = 0
+	stop_automated_movement = 1
 
 
-/mob/living/simple_animal/arcane_golem/Destroy()
+/mob/living/simple_animal/hostile/arcane_golem/Destroy()
 	..()
 
 	if(master_spell)
 		master_spell.golems.Remove(src)
 		master_spell = null
 
-/mob/living/simple_animal/arcane_golem/Life()
+/mob/living/simple_animal/hostile/arcane_golem/MoveToTarget()
+	//This proc has been slightly modified to prevent the golem from chasing its targets
+	//It will follow the master, and attack enemies when the opportunity arises
+	stop_automated_movement = 1
+	if(!target || !CanAttack(target))
+		LoseTarget()
+		return
+
+	if(isturf(loc))
+		var/target_distance = get_dist(src,target)
+		if(ranged)//We ranged? Shoot at em
+			if(target_distance >= 2 && ranged_cooldown <= 0)//But make sure they're a tile away at least, and our range attack is off cooldown
+				OpenFire(target)
+		if(target.Adjacent(src))	//If they're next to us, attack
+			AttackingTarget()
+
+/mob/living/simple_animal/hostile/arcane_golem/Life()
 	..()
 
 	if(!master_spell)
@@ -56,13 +82,10 @@
 
 		//Alive - follow the master
 		if(!isDead())
-			//Don't wander around if wizard is nearby - follow him instead
-			if(step_to(src, master, 2))
-				wander = FALSE
-			else
-				wander = TRUE
+			if(canmove)
+				Goto(master, move_to_delay)
 
-/mob/living/simple_animal/arcane_golem/Die()
+/mob/living/simple_animal/hostile/arcane_golem/Die()
 	..()
 
 	//Punish the master by putting all of his spells on cooldown
@@ -79,4 +102,5 @@
 						S.charge_counter = 0
 
 	visible_message("<span class='warning'>\The <b>[src]</b> shatters into pieces!</span>")
+	new /obj/item/weapon/ectoplasm (src.loc)
 	qdel(src)

--- a/code/modules/mob/living/simple_animal/friendly/arcane_golem.dm
+++ b/code/modules/mob/living/simple_animal/friendly/arcane_golem.dm
@@ -15,7 +15,7 @@
 	speak_emote = list("vocalizes")
 
 	speak_chance = 0.25
-	move_to_delay = 14
+	move_to_delay = 20
 
 	melee_damage_lower = 15
 	melee_damage_upper = 25

--- a/code/modules/spells/aoe_turf/conjure/arcane_golem.dm
+++ b/code/modules/spells/aoe_turf/conjure/arcane_golem.dm
@@ -13,7 +13,7 @@
 	invocation_type = SpI_SHOUT
 	range = 0
 
-	summon_type = list(/mob/living/simple_animal/arcane_golem)
+	summon_type = list(/mob/living/simple_animal/hostile/arcane_golem)
 	duration = 0
 
 	hud_state = "wiz_summon_golem"
@@ -42,7 +42,7 @@
 			L.forceMove(get_step(user, pick(alldirs)))
 
 /spell/aoe_turf/conjure/arcane_golem/proc/check_golems()
-	for(var/mob/living/simple_animal/arcane_golem/AG in golems)
+	for(var/mob/living/simple_animal/hostile/arcane_golem/AG in golems)
 		if(!AG.master_spell)
 			continue
 
@@ -51,7 +51,7 @@
 			AG.master_spell = null
 			golems.Remove(AG)
 
-/spell/aoe_turf/conjure/arcane_golem/on_creation(mob/living/simple_animal/arcane_golem/AG, mob/user)
+/spell/aoe_turf/conjure/arcane_golem/on_creation(mob/living/simple_animal/hostile/arcane_golem/AG, mob/user)
 	for(var/spell/S in user.spell_list)
 		if(is_type_in_list(S, forbidden_spells))
 			continue
@@ -62,6 +62,7 @@
 
 		AG.add_spell(copy)
 
+	AG.faction = "\ref[user]"
 	to_chat(user, "<span class='sinister'>You infuse \the [AG] with your mana and knowledge. If it dies, your arcane abilities will be affected.</span>")
 	src.golems.Add(AG)
 
@@ -86,7 +87,7 @@
 	else if(!isnull(target))
 		targets = list(target)
 
-	for(var/mob/living/simple_animal/arcane_golem/AG in golems)
+	for(var/mob/living/simple_animal/hostile/arcane_golem/AG in golems)
 		var/spell/cast_spell = locate(spell_to_copy.type) in AG.spell_list
 		if(!istype(cast_spell))
 			continue

--- a/html/changelogs/unid-buf.yml
+++ b/html/changelogs/unid-buf.yml
@@ -3,5 +3,5 @@ author: Unid
 delete-after: True
 
 changes: 
-- tweak: Increased movement speed of arcane golems (now they move as fast as hivelords)
+- tweak: Increased movement speed of arcane golems (now they move as fast as basilisks)
 - tweak: Arcane golems now have a melee attack that they will use against any enemies that come close to them, dealing 15-25 damage. Arcane golems are still forced to follow their master, which means they will never chase anybody.

--- a/html/changelogs/unid-buf.yml
+++ b/html/changelogs/unid-buf.yml
@@ -1,0 +1,7 @@
+author: Unid
+
+delete-after: True
+
+changes: 
+- tweak: Increased movement speed of arcane golems (now they move as fast as hivelords)
+- tweak: Arcane golems now have a melee attack that they will use against any enemies that come close to them, dealing 15-25 damage. Arcane golems are still forced to follow their master, which means they will never chase anybody.


### PR DESCRIPTION
* Changed typepath to /mob/living/simple_animal/hostile/arcane_golem (used to be /mob/living/simple_animal/arcane_golem) - this allows for more complex behavior

* Arcane golems now have a 15-25 melee attack that they will occasionally use on any enemy who comes close to them. They are still forced to follow their master, and they will never chase anybody. They will not punch their master, other golems or any other animals slaved to the master.

* Arcane golems now move as fast as basilisks (slightly faster than before)

* Arcane golems now spawn ectoplasm on death

new movespeed
![](https://cloud.githubusercontent.com/assets/9512290/20450311/c32e310c-adef-11e6-993c-7afe62671118.gif)

3 golems hitting a cat
![punches](https://cloud.githubusercontent.com/assets/9512290/20450329/e26fa136-adef-11e6-87ca-69b387387bd8.gif)
