### PR TITLE
Minor MMI fix

### DIFF
--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -283,5 +283,6 @@ obj/item/device/mmi/Destroy()
 	to_chat(user, "<span class='info'>*---------*</span>")
 
 /obj/item/device/mmi/OnMobDeath(var/mob/living/carbon/brain/B)
-	icon_state = "mmi_dead"
-	visible_message(message = "<span class='danger'>[B]'s MMI flatlines!</span>", blind_message = "<span class='warning'>You hear something flatline.</span>")
+	if(istype(B))
+		icon_state = "mmi_dead"
+		visible_message(message = "<span class='danger'>[B]'s MMI flatlines!</span>", blind_message = "<span class='warning'>You hear something flatline.</span>")

--- a/code/modules/mob/living/carbon/brain/posibrain.dm
+++ b/code/modules/mob/living/carbon/brain/posibrain.dm
@@ -181,6 +181,7 @@
 			to_chat(O, "[src] is recharging. Try again in a few moments.")
 
 /obj/item/device/mmi/posibrain/OnMobDeath(var/mob/living/carbon/brain/B)
-	visible_message(message = "<span class='danger'>[B] begins to go dark, having seemingly thought himself to death</span>", blind_message = "<span class='danger'>You hear the wistful sigh of a hopeful machine powering off with a tone of finality.</span>")
-	icon_state = "posibrain"
-	searching = 0
+	if(istype(B))
+		visible_message(message = "<span class='danger'>[B] begins to go dark, having seemingly thought itself to death</span>", blind_message = "<span class='danger'>You hear the wistful sigh of a hopeful machine powering off with a tone of finality.</span>")
+		icon_state = "posibrain"
+		searching = 0


### PR DESCRIPTION
Currently whenever a mob dies, every MMI in their contents gives the flatlines message, when it was only intended to happen when the brain inside died. This is also why MMIs removed from dead borgs have the dead sprite while still being alive.