### PR TITLE
Allows xenomorphs to force doors open

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1029,6 +1029,29 @@ About the new airlock wires panel:
 
 	return
 
+/obj/machinery/door/airlock/attack_alien(mob/living/carbon/alien/humanoid/user)
+	if(isElectrified())
+		shock(user, 100)
+
+	user.delayNextAttack(10)
+	if(operating)
+		return
+	if(locked || welded || jammed)
+		to_chat(user, "<span class='notice'>The airlock won't budge!</span>")
+	else if(arePowerSystemsOn() && !(stat & NOPOWER))
+		to_chat(user, "<span class='notice'>You start forcing the airlock [density ? "open" : "closed"].</span>")
+		visible_message("<span class='warning'>\The [src]'s motors whine as something begins trying to force it [density ? "open" : "closed"]!</span>",\
+						"<span class='notice'>You hear groaning metal and overworked motors.</span>")
+		if(do_after(user,src,100))
+			if(locked || welded || jammed) //if it got welded/bolted during the do_after
+				to_chat(user, "<span class='notice'>The airlock won't budge!</span>")
+				return
+			visible_message("<span class='warning'>\The [user] forces \the [src] [density ? "open" : "closed"]!</span>")
+			density ? open(1) : close(1)
+	else
+		visible_message("<span class='warning'>\The [user] forces \the [src] [density ? "open" : "closed"]!</span>")
+		density ? open(1) : close(1)
+
 //You can ALWAYS screwdriver a door. Period. Well, at least you can even if it's open
 /obj/machinery/door/airlock/togglePanelOpen(var/obj/toggleitem, mob/user)
 	if(!operating)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -216,6 +216,9 @@ var/global/list/alert_overlays_global = list()
 /obj/machinery/door/firedoor/attack_hand(mob/user as mob)
 	return attackby(null, user)
 
+/obj/machinery/door/firedoor/attack_alien(mob/living/carbon/alien/humanoid/user)
+	force_open(user)
+
 /obj/machinery/door/firedoor/attackby(obj/item/weapon/C as obj, mob/user as mob)
 	add_fingerprint(user)
 	if(operating)
@@ -329,14 +332,14 @@ var/global/list/alert_overlays_global = list()
 	var/alarmed = A.doors_down || A.fire
 
 	if( blocked )
-		user.visible_message("<span class='attack'>\The [istype(user.loc,/obj/mecha) ? "[user.loc.name]" : "[user]"] pries at \the [src] with \a [C], but \the [src] is welded in place!</span>",\
+		user.visible_message("<span class='attack'>\The [istype(user.loc,/obj/mecha) ? "[user.loc.name]" : "[user]"] pries at \the [src][istype(C) ? " with \a [C]" : ""], but \the [src] is welded in place!</span>",\
 		"You try to pry \the [src] [density ? "open" : "closed"], but it is welded in place!",\
 		"You hear someone struggle and metal straining.")
 		return
 
 	//thank you Tigercat2000
-	user.visible_message("<span class='attack'>\The [istype(user.loc,/obj/mecha) ? "[user.loc.name]" : "[user]"] forces \the [src] [density ? "open" : "closed"] with \a [C]!</span>",\
-		"You force \the [src] [density ? "open" : "closed"] with \the [C]!",\
+	user.visible_message("<span class='attack'>\The [istype(user.loc,/obj/mecha) ? "[user.loc.name]" : "[user]"] forces \the [src] [density ? "open" : "closed"][istype(C) ? " with \a [C]" : ""]!</span>",\
+		"You force \the [src] [density ? "open" : "closed"][istype(C) ? " with \the [C]" : ""]!",\
 		"You hear metal strain, and a door [density ? "open" : "close"].")
 
 	if(density)


### PR DESCRIPTION
Xenomorphs can now force open unpowered doors, and powered doors after a ten second delay. Bolted or welded doors can't be opened.
Also they can open firelocks, but not welded firelocks.
