### PR TITLE
Poking at door animation timers

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -123,6 +123,7 @@
 
 	explosion_block = 3//that's some high quality plasteel door
 	penetration_dampening = 20
+	animation_delay = 11
 
 /obj/machinery/door/airlock/freezer
 	name = "Freezer Airlock"
@@ -141,6 +142,7 @@
 	icon = 'icons/obj/doors/Doorhatchmaint2.dmi'
 	opacity = 1
 	assembly_type = /obj/structure/door_assembly/door_assembly_mhatch
+	animation_delay = 12
 
 /obj/machinery/door/airlock/glass_command
 	name = "Maintenance Hatch"
@@ -328,6 +330,7 @@
 	icon = 'icons/obj/doors/hightechsecurity.dmi'
 	assembly_type = /obj/structure/door_assembly/door_assembly_highsecurity
 	emag_cost = 2 // in MJ
+	animation_delay = 14
 
 /*
 About the new airlock wires panel:
@@ -499,8 +502,7 @@ About the new airlock wires panel:
 			if(overlays)
 				overlays.len = 0
 			if(panel_open)
-				spawn(2) // The only work around that works. Downside is that the door will be gone for a millisecond.
-					flick("o_door_opening", src)  //can not use flick due to BYOND bug updating overlays right before flicking
+				flick("o_door_opening", src)
 			else
 				flick("door_opening", src)
 		if("closing")

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -43,7 +43,7 @@ var/list/all_doors = list()
 	var/prefix = null
 
 	// TODO: refactor to best :(
-	var/animation_delay = 12
+	var/animation_delay = 10
 	var/animation_delay_2 = null
 
 	// turf animation
@@ -183,8 +183,6 @@ var/list/all_doors = list()
 		if ("closing")
 			flick("[prefix]door_closing", src)
 
-	sleep(animation_delay)
-
 /obj/machinery/door/update_icon()
 	if(!density)
 		icon_state = "[prefix]door_open"
@@ -204,9 +202,9 @@ var/list/all_doors = list()
 	if(!operating)
 		operating = 1
 
-	door_animate("opening")
 	set_opacity(0)
-	sleep(10)
+	door_animate("opening")
+	sleep(animation_delay)
 	layer = open_layer
 	density = 0
 	explosion_resistance = 0
@@ -230,11 +228,12 @@ var/list/all_doors = list()
 	if (density || operating || jammed)
 		return
 	operating = 1
-	door_animate("closing")
 
 	layer = closed_layer
 
 	density = 1
+	door_animate("closing")
+	sleep(animation_delay)
 	update_icon()
 
 	if (!glass)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -355,14 +355,6 @@ var/global/list/alert_overlays_global = list()
 	latetoggle()
 	layer = closed_layer
 
-/obj/machinery/door/firedoor/door_animate(animation)
-	switch(animation)
-		if("opening")
-			flick("door_opening", src)
-		if("closing")
-			flick("door_closing", src)
-
-
 /obj/machinery/door/firedoor/update_icon()
 	overlays.len = 0
 	if(density)

--- a/code/game/machinery/doors/multi_tile.dm
+++ b/code/game/machinery/doors/multi_tile.dm
@@ -9,6 +9,7 @@
 	opacity = 0
 	glass = 1
 	assembly_type = "obj/structure/door_assembly/multi_tile"
+	animation_delay = 16
 
 /obj/machinery/door/airlock/multi_tile/glass/bump_open(mob/user as mob)
 	if(istype(user,/mob/living/simple_animal/hostile/giant_spider))

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -15,8 +15,7 @@ var/list/poddoors = list()
 	var/id_tag = 1.0
 
 	prefix = "r_"
-	animation_delay = 18
-	animation_delay_2 = 5
+	animation_delay = 5
 
 	var/closedicon = "pdoor1"
 	var/openicon = "pdoor0"
@@ -69,7 +68,7 @@ var/list/poddoors = list()
 			flick(openingicon, src)
 			src.icon_state = openicon
 			src.set_opacity(0)
-			sleep(15)
+			sleep(animation_delay)
 			src.density = 0
 			src.operating = 0
 			return
@@ -85,7 +84,7 @@ var/list/poddoors = list()
 	flick(openingicon, src)
 	src.icon_state = openicon
 	src.set_opacity(0)
-	sleep(10)
+	sleep(animation_delay)
 	layer = open_layer
 	src.density = 0
 	update_nearby_tiles()
@@ -108,7 +107,7 @@ var/list/poddoors = list()
 	src.set_opacity(initial(opacity))
 	update_nearby_tiles()
 
-	sleep(10)
+	sleep(animation_delay)
 	src.operating = 0
 	return
 

--- a/code/game/machinery/doors/shutters.dm
+++ b/code/game/machinery/doors/shutters.dm
@@ -5,6 +5,7 @@
 	power_channel = ENVIRON
 	var/sound_open = 'sound/machines/shutter_open.ogg'
 	var/sound_close = 'sound/machines/shutter_close.ogg'
+	animation_delay = 7
 
 /obj/machinery/door/poddoor/shutters/New()
 	..()
@@ -24,7 +25,7 @@
 		spawn(-1)
 			flick("shutterc0", src)
 			icon_state = "shutter0"
-			sleep(15)
+			sleep(animation_delay)
 			density = 0
 			set_opacity(0)
 			operating = 0
@@ -39,7 +40,7 @@
 	flick("shutterc0", src)
 	icon_state = "shutter0"
 	playsound(src.loc, sound_open, 100, 1)
-	sleep(10)
+	sleep(animation_delay)
 	density = 0
 	set_opacity(0)
 	update_nearby_tiles()
@@ -64,5 +65,5 @@
 		set_opacity(1)
 	update_nearby_tiles()
 
-	sleep(10)
+	sleep(animation_delay)
 	operating = 0

--- a/code/game/machinery/doors/unpowered.dm
+++ b/code/game/machinery/doors/unpowered.dm
@@ -29,7 +29,7 @@
 /obj/machinery/door/unpowered/shuttle
 	icon = 'icons/obj/doors/shuttle.dmi'
 	icon_state = "door_closed"
-	animation_delay = 5
+	animation_delay = 14
 
 	explosion_block = 1
 

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -19,6 +19,7 @@
 	soundeffect = 'sound/machines/windowdoor.ogg'
 	var/shard = /obj/item/weapon/shard
 	penetration_dampening = 2
+	animation_delay = 7
 
 /obj/machinery/door/window/New()
 	..()
@@ -108,7 +109,7 @@
 	flick(text("[]opening", src.base_state), src)
 	playsound(get_turf(src), soundeffect, 100, 1)
 	src.icon_state = text("[]open", src.base_state)
-	sleep(10)
+	sleep(animation_delay)
 
 	explosion_resistance = 0
 	src.density = 0
@@ -133,7 +134,7 @@
 //		SetOpacity(1)	//TODO: why is this here? Opaque windoors? ~Carn
 	update_nearby_tiles()
 
-	sleep(10)
+	sleep(animation_delay)
 
 	src.operating = 0
 	return 1


### PR DESCRIPTION
Replaces the sleep(10)s strewn throughout door opening/closing with sleep(animation_delay), allowing for doors to finish opening sooner or later as needed. Gives doors with different animation lengths delays based on the number of frames before the final icon. Windoors let you pass about a quarter second sooner, certain fancy airlocks a bit later. Pod doors no longer hang open for like a full second before allowing passage.

Fixes #12324
Removes a workaround for a byond bug that doesn't seem to exist anymore.
Removes an effectively identical child proc from firedoors.