### PR TITLE
ion rifles are now EMP proof

### DIFF
--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -14,11 +14,7 @@
 	projectile_type = "/obj/item/projectile/ion"
 
 /obj/item/weapon/gun/energy/ionrifle/emp_act(severity)
-	if(severity <= 2)
-		power_supply.use(round(power_supply.maxcharge / severity))
-		update_icon()
-	else
-		return
+	return
 
 /obj/item/weapon/gun/energy/decloner
 	name = "biological demolecularisor"


### PR DESCRIPTION
fixes #12551

:cl:
 * tweak: Ion Rifles are now EMP proof, so they cannot ion themselves.