### PR TITLE
Makes access names less confusing, gives roboticist back rnd access

### DIFF
--- a/code/WorkInProgress/Cael_Aislinn/Supermatter/ZeroPointLaser.dm
+++ b/code/WorkInProgress/Cael_Aislinn/Supermatter/ZeroPointLaser.dm
@@ -7,7 +7,7 @@
 	icon_state = "laser"
 	anchored = 0
 	density = 1
-	req_access = list(access_research)
+	req_access = list(access_science)
 
 	use_power = 1
 	idle_power_usage = 10

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1472,7 +1472,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure/scisec
 	containername = "RnD Stock Parts Crate"
-	access = access_research
+	access = access_science
 	group = "Science"
 
 /datum/supply_packs/research_nanotrasen
@@ -1484,7 +1484,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 80
 	containertype = /obj/structure/closet/crate/secure/scisec
 	containername = "RnD Experimental Crate"
-	access = access_research
+	access = access_science
 	group = "Science"
 
 /datum/supply_packs/robotics
@@ -1511,7 +1511,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 50
 	containertype = /obj/structure/largecrate
 	containername = "suspension field generator crate"
-	access = access_research
+	access = access_science
 	group = "Science"
 
 /datum/supply_packs/excavation_gear
@@ -1530,7 +1530,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure/scisec
 	containername = "excavation equipment"
-	access = access_research
+	access = access_science
 	group = "Science"
 
 /datum/supply_packs/plasma

--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -6,7 +6,7 @@
 /var/const/access_forensics_lockers= 4
 /var/const/access_medical = 5
 /var/const/access_morgue = 6
-/var/const/access_tox = 7			// Research and Development
+/var/const/access_rnd = 7			// Research and Development
 /var/const/access_tox_storage = 8	// Toxins mixing and storage
 /var/const/access_genetics = 9
 /var/const/access_engine = 10		// Power Engines
@@ -46,7 +46,7 @@
 /var/const/access_mime = 44
 /var/const/access_surgery = 45
 /var/const/access_theatre = 46
-/var/const/access_research = 47		// Research Division hallway
+/var/const/access_science = 47		// Research Division hallway
 /var/const/access_mining = 48
 /var/const/access_mining_office = 49 //not in use
 /var/const/access_mailsorting = 50	// Cargo Office
@@ -227,13 +227,13 @@
 /proc/get_all_accesses()
 	return list(access_shop, access_security, access_sec_doors, access_brig, access_armory, access_forensics_lockers, access_court,
 	            access_medical, access_genetics, access_morgue, access_rd,
-	            access_tox, access_tox_storage, access_chemistry, access_engine, access_engine_equip, access_maint_tunnels,
+	            access_rnd, access_tox_storage, access_chemistry, access_engine, access_engine_equip, access_maint_tunnels,
 	            access_external_airlocks, access_change_ids, access_ai_upload,
 	            access_teleporter, access_eva, access_heads, access_captain, access_all_personal_lockers,
 	            access_tech_storage, access_chapel_office, access_atmospherics, access_kitchen,
 	            access_bar, access_janitor, access_crematorium, access_robotics, access_cargo, access_construction,
 	            access_hydroponics, access_library, access_lawyer, access_virology, access_psychiatrist, access_cmo, access_qm, access_clown, access_mime, access_surgery,
-	            access_theatre, access_research, access_mining, access_mailsorting,access_weapons,
+	            access_theatre, access_science, access_mining, access_mailsorting,access_weapons,
 	            access_heads_vault, access_mining_station, access_xenobiology, access_ce, access_hop, access_hos, access_RC_announce,
 	            access_keycard_auth, access_tcomsat, access_gateway, /*vg paramedic*/, access_paramedic, access_mechanic, access_taxi)
 
@@ -251,7 +251,7 @@
 		access_security, access_sec_doors, access_brig, access_armory,		//sec
 		access_medical, access_genetics, access_surgery, access_paramedic,	//med
 		access_atmospherics, access_engine,	access_tech_storage,			//engi
-		access_robotics, access_research,									//sci
+		access_robotics, access_science,									//sci
 		access_external_airlocks, access_teleporter, access_eva,			//entering/leaving the station
 		access_maint_tunnels,
 		access_tcomsat, access_gateway,										//why not
@@ -266,7 +266,7 @@
 		if(2) //medbay
 			return list(access_medical, access_genetics, access_morgue, access_chemistry, access_paramedic, access_virology, access_surgery, access_cmo)
 		if(3) //research
-			return list(access_research, access_tox, access_tox_storage, access_robotics, access_mechanic, access_xenobiology, access_rd)
+			return list(access_science, access_rnd, access_tox_storage, access_robotics, access_mechanic, access_xenobiology, access_rd)
 		if(4) //engineering and maintenance
 			return list(access_construction, access_maint_tunnels, access_engine, access_engine_equip, access_external_airlocks, access_tech_storage, access_mechanic, access_atmospherics, access_ce)
 		if(5) //command
@@ -318,7 +318,7 @@
 			return "Genetics Lab"
 		if(access_morgue)
 			return "Morgue"
-		if(access_tox)
+		if(access_rnd)
 			return "R&D Lab"
 		if(access_tox_storage)
 			return "Toxins Lab"
@@ -394,7 +394,7 @@
 			return "Theatre"
 		if(access_manufacturing)
 			return "Manufacturing"
-		if(access_research)
+		if(access_science)
 			return "Science"
 		if(access_mining)
 			return "Mining"

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -76,13 +76,13 @@
 			            access_medical, access_engine, access_change_ids, access_ai_upload, access_eva, access_heads,
 			            access_all_personal_lockers, access_maint_tunnels, access_bar, access_janitor, access_construction, access_morgue,
 			            access_crematorium, access_kitchen, access_cargo, access_cargo_bot, access_mailsorting, access_qm, access_hydroponics, access_lawyer,
-			            access_theatre, access_chapel_office, access_library, access_research, access_mining, access_heads_vault, access_mining_station,
+			            access_theatre, access_chapel_office, access_library, access_science, access_mining, access_heads_vault, access_mining_station,
 			            access_clown, access_mime, access_hop, access_RC_announce, access_keycard_auth, access_gateway, access_taxi)
 	minimal_access = list(access_security, access_sec_doors, access_brig, access_court, access_weapons, access_forensics_lockers,
 			            access_medical, access_engine, access_change_ids, access_ai_upload, access_eva, access_heads,
 			            access_all_personal_lockers, access_maint_tunnels, access_bar, access_janitor, access_construction, access_morgue,
 			            access_crematorium, access_kitchen, access_cargo, access_cargo_bot, access_mailsorting, access_qm, access_hydroponics, access_lawyer,
-			            access_theatre, access_chapel_office, access_library, access_research, access_mining, access_heads_vault, access_mining_station,
+			            access_theatre, access_chapel_office, access_library, access_science, access_mining, access_heads_vault, access_mining_station,
 			            access_clown, access_mime, access_hop, access_RC_announce, access_keycard_auth, access_gateway, access_taxi)
 
 	pdaslot=slot_l_store

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -147,8 +147,8 @@
 	supervisors = "the research director and the chief engineer"
 	selection_color = "#fff5cc"
 	idtype = /obj/item/weapon/card/id/engineering
-	access = list(access_eva, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction, access_mechanic, access_tcomsat, access_research)
-	minimal_access = list(access_maint_tunnels, access_emergency_storage, access_construction, access_engine_equip, access_external_airlocks, access_mechanic, access_research)
+	access = list(access_eva, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction, access_mechanic, access_tcomsat, access_science)
+	minimal_access = list(access_maint_tunnels, access_emergency_storage, access_construction, access_engine_equip, access_external_airlocks, access_mechanic, access_science)
 	alt_titles = list("Telecommunications Technician", "Spacepod Mechanic", "Greasemonkey")
 
 	pdaslot=slot_l_store

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -164,8 +164,8 @@
 	supervisors = "the chief medical officer and research director"
 	selection_color = "#ffeef0"
 	idtype = /obj/item/weapon/card/id/medical
-	access = list(access_medical, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics, access_research, access_eva)
-	minimal_access = list(access_medical, access_morgue, access_genetics, access_research)
+	access = list(access_medical, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics, access_science, access_eva)
+	minimal_access = list(access_medical, access_morgue, access_genetics, access_science)
 
 	pdaslot=slot_belt
 	pdatype=/obj/item/device/pda/geneticist

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -97,7 +97,7 @@
 	supervisors = "research director"
 	selection_color = "#ffeeff"
 	idtype = /obj/item/weapon/card/id/research
-	access = list(access_robotics, access_tech_storage, access_morgue, access_science) //As a job that handles so many corpses, it makes sense for them to have morgue access.
+	access = list(access_robotics, access_tech_storage, access_morgue, access_science, access_rnd) //As a job that handles so many corpses, it makes sense for them to have morgue access.
 	minimal_access = list(access_robotics, access_tech_storage, access_morgue, access_science) //As a job that handles so many corpses, it makes sense for them to have morgue access.
 	alt_titles = list("Biomechanical Engineer","Mechatronic Engineer")
 

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -9,13 +9,13 @@
 	selection_color = "#ffddff"
 	idtype = /obj/item/weapon/card/id/rd
 	req_admin_notify = 1
-	access = list(access_rd, access_heads, access_tox, access_genetics, access_morgue,
+	access = list(access_rd, access_heads, access_rnd, access_genetics, access_morgue,
 			            access_tox_storage, access_teleporter, access_sec_doors,
-			            access_research, access_robotics, access_xenobiology, access_ai_upload,
+			            access_science, access_robotics, access_xenobiology, access_ai_upload,
 			            access_RC_announce, access_keycard_auth, access_tcomsat, access_gateway, access_mechanic)
-	minimal_access = list(access_rd, access_heads, access_tox, access_genetics, access_morgue,
+	minimal_access = list(access_rd, access_heads, access_rnd, access_genetics, access_morgue,
 			            access_tox_storage, access_teleporter, access_sec_doors,
-			            access_research, access_robotics, access_xenobiology, access_ai_upload,
+			            access_science, access_robotics, access_xenobiology, access_ai_upload,
 			            access_RC_announce, access_keycard_auth, access_tcomsat, access_gateway, access_mechanic)
 	minimal_player_age = 7
 
@@ -46,8 +46,8 @@
 	supervisors = "the research director"
 	selection_color = "#ffeeff"
 	idtype = /obj/item/weapon/card/id/research
-	access = list(access_robotics, access_tox, access_tox_storage, access_research, access_xenobiology)
-	minimal_access = list(access_tox, access_tox_storage, access_research, access_xenobiology)
+	access = list(access_robotics, access_rnd, access_tox_storage, access_science, access_xenobiology)
+	minimal_access = list(access_rnd, access_tox_storage, access_science, access_xenobiology)
 	alt_titles = list("Xenoarcheologist", "Anomalist", "Plasma Researcher", "Xenobiologist", "Research Botanist")
 
 	pdaslot=slot_belt
@@ -97,8 +97,8 @@
 	supervisors = "research director"
 	selection_color = "#ffeeff"
 	idtype = /obj/item/weapon/card/id/research
-	access = list(access_robotics, access_tech_storage, access_morgue, access_research) //As a job that handles so many corpses, it makes sense for them to have morgue access.
-	minimal_access = list(access_robotics, access_tech_storage, access_morgue, access_research) //As a job that handles so many corpses, it makes sense for them to have morgue access.
+	access = list(access_robotics, access_tech_storage, access_morgue, access_science) //As a job that handles so many corpses, it makes sense for them to have morgue access.
+	minimal_access = list(access_robotics, access_tech_storage, access_morgue, access_science) //As a job that handles so many corpses, it makes sense for them to have morgue access.
 	alt_titles = list("Biomechanical Engineer","Mechatronic Engineer")
 
 	pdaslot=slot_belt

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -11,11 +11,11 @@
 	req_admin_notify = 1
 	access = list(access_weapons, access_security, access_sec_doors, access_brig, access_armory, access_court,
 			            access_forensics_lockers, access_morgue, access_maint_tunnels, access_all_personal_lockers,
-			            access_research, access_engine, access_mining, access_medical, access_construction, access_mailsorting,
+			            access_science, access_engine, access_mining, access_medical, access_construction, access_mailsorting,
 			            access_heads, access_hos, access_RC_announce, access_keycard_auth, access_gateway, access_eva)
 	minimal_access = list(access_weapons, access_security, access_sec_doors, access_brig, access_armory, access_court,
 			            access_forensics_lockers, access_morgue, access_maint_tunnels, access_all_personal_lockers,
-			            access_research, access_engine, access_mining, access_medical, access_construction, access_mailsorting,
+			            access_science, access_engine, access_mining, access_medical, access_construction, access_mailsorting,
 			            access_heads, access_hos, access_RC_announce, access_keycard_auth, access_gateway)
 	minimal_player_age = 14
 

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -12,7 +12,7 @@ for reference:
 	access_forensics_lockers= 4
 	access_medical = 5
 	access_morgue = 6
-	access_tox = 7
+	access_rnd = 7
 	access_tox_storage = 8
 	access_genetics = 9
 	access_engine = 10

--- a/code/game/objects/closets/secure/research.dm
+++ b/code/game/objects/closets/secure/research.dm
@@ -1,6 +1,6 @@
 /obj/structure/closet/secure_closet/scientist
 	name = "Scientist's Locker"
-	req_access = list(ACCESS_RESEARCH)
+	req_access = list(ACCESS_SCIENCE)
 	icon_state = "secureres1"
 	icon_closed = "secureres"
 	icon_locked = "secureres1"

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -538,7 +538,7 @@
 	registered_name = "Scientist"
 	icon_state = "research"
 	desc = "Pinnacle of name technology."
-	access = list(access_research, access_tox, access_tox_storage, access_robotics, access_xenobiology, access_rd)
+	access = list(access_science, access_rnd, access_tox_storage, access_robotics, access_xenobiology, access_rd)
 
 /obj/item/weapon/card/id/supply
 	name = "Supply ID"
@@ -559,7 +559,7 @@
 	registered_name = "HoS"
 	icon_state = "HoS"
 	desc = "An ID awarded to only the most robust shits in the buisness."
-	access = list(access_security, access_sec_doors, access_brig, access_armory, access_court, access_forensics_lockers, access_morgue, access_maint_tunnels, access_all_personal_lockers, access_research, access_engine, access_mining, access_medical, access_construction, access_mailsorting, access_heads, access_hos, access_RC_announce, access_keycard_auth, access_gateway)
+	access = list(access_security, access_sec_doors, access_brig, access_armory, access_court, access_forensics_lockers, access_morgue, access_maint_tunnels, access_all_personal_lockers, access_science, access_engine, access_mining, access_medical, access_construction, access_mailsorting, access_heads, access_hos, access_RC_announce, access_keycard_auth, access_gateway)
 
 /obj/item/weapon/card/id/cmo
 	name = "Chief Medical Officer ID"
@@ -573,7 +573,7 @@
 	registered_name = "RD"
 	icon_state = "RD"
 	desc = "If you put your ear to the card, you can faintly hear screaming, glomping, and mechs. What the fuck."
-	access = list(access_rd, access_heads, access_tox, access_genetics, access_morgue, access_tox_storage, access_teleporter, access_sec_doors, access_research, access_robotics, access_xenobiology, access_ai_upload, access_RC_announce, access_keycard_auth, access_tcomsat, access_gateway)
+	access = list(access_rd, access_heads, access_rnd, access_genetics, access_morgue, access_tox_storage, access_teleporter, access_sec_doors, access_science, access_robotics, access_xenobiology, access_ai_upload, access_RC_announce, access_keycard_auth, access_tcomsat, access_gateway)
 
 /obj/item/weapon/card/id/ce
 	name = "Chief Engineer ID"

--- a/code/game/shuttles/research.dm
+++ b/code/game/shuttles/research.dm
@@ -3,7 +3,7 @@ var/global/datum/shuttle/research/research_shuttle = new(starting_area = /area/s
 /datum/shuttle/research
 	name = "research shuttle"
 	can_link_to_computer = LINK_FREE
-	req_access = list(access_research)
+	req_access = list(access_science)
 
 /datum/shuttle/research/initialize()
 	.=..()

--- a/code/modules/mining/ore_redemption.dm
+++ b/code/modules/mining/ore_redemption.dm
@@ -14,7 +14,7 @@
 		access_mining_station,
 		access_chemistry,
 		access_bar,
-		access_research,
+		access_science,
 		access_ce,
 		access_virology
 	)

--- a/code/modules/research/designs/boards/computer_command.dm
+++ b/code/modules/research/designs/boards/computer_command.dm
@@ -10,7 +10,7 @@
 	category = "Console Boards"
 	build_path = /obj/item/weapon/circuitboard/aiupload
 	locked = 1
-	req_lock_access = list(access_tox, access_robotics, access_rd)
+	req_lock_access = list(access_rnd, access_robotics, access_rd)
 
 /datum/design/borgupload
 	name = "Circuit Design (Cyborg Upload)"
@@ -22,7 +22,7 @@
 	category = "Console Boards"
 	build_path = /obj/item/weapon/circuitboard/borgupload
 	locked = 1
-	req_lock_access = list(access_tox, access_robotics, access_rd)
+	req_lock_access = list(access_rnd, access_robotics, access_rd)
 
 /datum/design/comconsole
 	name = "Circuit Design (Communications)"

--- a/code/modules/research/designs/boards/machine_command.dm
+++ b/code/modules/research/designs/boards/machine_command.dm
@@ -10,7 +10,7 @@
 	category = "Machine Boards"
 	build_path = /obj/item/weapon/circuitboard/aicore
 	locked = 1
-	req_lock_access = list(access_tox, access_robotics, access_rd)
+	req_lock_access = list(access_rnd, access_robotics, access_rd)
 
 /datum/design/pdapainter
 	name = "PDA Painter Board"

--- a/code/modules/research/designs/weapons.dm
+++ b/code/modules/research/designs/weapons.dm
@@ -182,7 +182,7 @@
 	category = "Weapons"
 	build_path = /obj/item/weapon/gun/energy/temperature
 	locked = 1
-	req_lock_access = list(access_tox, access_robotics, access_rd)
+	req_lock_access = list(access_rnd, access_robotics, access_rd)
 
 /datum/design/large_grenade
 	name = "Large Grenade"

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -65,7 +65,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	)
 	var/autorefresh = 1 //Prevents the window from being updated while queueing items
 
-	req_access = list(access_tox)	//Data and setting manipulation requires scientist access.
+	req_access = list(access_rnd)	//Data and setting manipulation requires scientist access.
 
 	starting_materials = list()
 
@@ -1003,7 +1003,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 /obj/machinery/computer/rdconsole/mommi
 	name = "MoMMI R&D Console"
 	id = 3
-	req_access = list(access_tox)
+	req_access = list(access_rnd)
 	circuit = "/obj/item/weapon/circuitboard/rdconsole/mommi"
 
 /obj/machinery/computer/rdconsole/robotics
@@ -1023,7 +1023,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 /obj/machinery/computer/rdconsole/core
 	name = "Core R&D Console"
 	id = 1
-	req_access = list(access_tox)
+	req_access = list(access_rnd)
 	circuit = "/obj/item/weapon/circuitboard/rdconsole"
 
 /obj/machinery/computer/rdconsole/pod

--- a/code/modules/research/research_shuttle.dm
+++ b/code/modules/research/research_shuttle.dm
@@ -78,7 +78,7 @@ proc/move_research_shuttle()
 	name = "Research Shuttle Console"
 	icon = 'icons/obj/computer.dmi'
 	icon_state = "shuttle"
-	req_access = list(access_research)
+	req_access = list(access_science)
 	circuit = "/obj/item/weapon/circuitboard/research_shuttle"
 	var/location = 0 //0 = station, 1 = research base
 	machine_flags = EMAGGABLE | SCREWTOGGLE

--- a/code/modules/research/xenoarchaeology/misc.dm
+++ b/code/modules/research/xenoarchaeology/misc.dm
@@ -171,4 +171,4 @@ proc/SetupXenoarch()
 
 /obj/machinery/alarm/isolation
 	name = "Isolation room air control"
-	req_access = list(access_research)
+	req_access = list(access_science)

--- a/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
+++ b/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/xenoarchaeology.dmi'
 	icon_state = "suspension2-b"
 	density = 1
-	req_access = list(access_research)
+	req_access = list(access_science)
 	var/obj/item/weapon/cell/cell
 	var/obj/item/weapon/card/id/auth_card
 	var/locked = 1

--- a/maps/ministation/job/jobs.dm
+++ b/maps/ministation/job/jobs.dm
@@ -64,8 +64,8 @@
 	..()
 	total_positions = 4
 	spawn_positions = 4
-	access = list(access_robotics, access_tox, access_tox_storage, access_research, access_xenobiology)
-	minimal_access = list(access_tox, access_tox_storage, access_research, access_xenobiology, access_robotics)
+	access = list(access_robotics, access_rnd, access_tox_storage, access_science, access_xenobiology)
+	minimal_access = list(access_rnd, access_tox_storage, access_science, access_xenobiology, access_robotics)
 
 // Security
 


### PR DESCRIPTION
fixes #12607

Removal of R&D from Roboticist wasn't an intention of that PR, if you think it should happen anyway you can make a different PR for it.