### PR TITLE
Allows the ERT to send their shuttle to the station, some other ERT tweaks

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -38,6 +38,7 @@
 
 	var/list/datum/mind/deathsquad = list()
 	var/list/datum/mind/ert = list()
+	var/ert_reason
 	var/rage = 0
 	var/can_be_mixed = FALSE
 

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -204,7 +204,10 @@ var/shuttle_call/shuttle_calls[0]
 			if(response != "Yes")
 				return
 			var/ert_reason = stripped_input(usr, "Please input the reason for calling an Emergency Response Team. This may be all the information they get before arriving at the station.", "Response Team Justification")
-			if(!ert_reason || !Adjacent(usr) || usr.incapacitated())
+			if(!ert_reason)
+				to_chat(usr, "<span class='warning'>You are required to give a reason to call an ERT.</span>")
+				return
+			if(!Adjacent(usr) || usr.incapacitated())
 				return
 			trigger_armed_response_team(1,ert_reason)
 			log_game("[key_name(usr)] has called an ERT with reason: [ert_reason]")

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -203,7 +203,12 @@ var/shuttle_call/shuttle_calls[0]
 			var/response = alert(usr,"Are you sure you want to request a response team?", "ERT Request", "Yes", "No")
 			if(response != "Yes")
 				return
-			trigger_armed_response_team(1)
+			var/ert_reason = stripped_input(usr, "Please input the reason for calling an Emergency Response Team. This may be all the information they get before arriving at the station.", "Response Team Justification")
+			if(!ert_reason || !Adjacent(usr) || usr.restrained() || usr.isUnconscious())
+				return
+			trigger_armed_response_team(1,ert_reason)
+			log_game("[key_name(usr)] has called an ERT with reason: [ert_reason]")
+			message_admins("[key_name_admin(usr)] has called an ERT with reason: [ert_reason]")
 			setMenuState(usr,COMM_SCREEN_MAIN)
 			return
 

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -204,7 +204,7 @@ var/shuttle_call/shuttle_calls[0]
 			if(response != "Yes")
 				return
 			var/ert_reason = stripped_input(usr, "Please input the reason for calling an Emergency Response Team. This may be all the information they get before arriving at the station.", "Response Team Justification")
-			if(!ert_reason || !Adjacent(usr) || usr.restrained() || usr.isUnconscious())
+			if(!ert_reason || !Adjacent(usr) || usr.incapacitated())
 				return
 			trigger_armed_response_team(1,ert_reason)
 			log_game("[key_name(usr)] has called an ERT with reason: [ert_reason]")

--- a/code/game/machinery/computer/shuttle_computers.dm
+++ b/code/game/machinery/computer/shuttle_computers.dm
@@ -465,9 +465,8 @@
 				to_chat(usr, "<span class='info'>You insert \the [P] into \the [src].</span>")
 				qdel(P)
 				return
-		else
-			to_chat(usr, "<span class='info'>You insert \the [P] into \the [src], but it is rejected.</span>")
-			user.put_in_hands(P)
+		to_chat(usr, "<span class='info'>You insert \the [P] into \the [src], but it is rejected.</span>")
+		user.put_in_hands(P)
 
 /obj/machinery/computer/shuttle_control/bullet_act(var/obj/item/projectile/Proj)
 	visible_message("[Proj] ricochets off [src]!")

--- a/code/game/machinery/computer/shuttle_computers.dm
+++ b/code/game/machinery/computer/shuttle_computers.dm
@@ -462,10 +462,10 @@
 	if(user.drop_item(P, src))
 		if(shuttle && shuttle.type == P.allowed_shuttle)
 			if(shuttle.travel_to(P.destination, src, user))
-				to_chat(usr, "<span class='info'>You insert \the [P] into \the [src].</span>")
+				to_chat(user, "<span class='info'>You insert \the [P] into \the [src].</span>")
 				qdel(P)
 				return
-		to_chat(usr, "<span class='info'>You insert \the [P] into \the [src], but it is rejected.</span>")
+		to_chat(user, "<span class='info'>You insert \the [P] into \the [src], but it is rejected.</span>")
 		user.put_in_hands(P)
 
 /obj/machinery/computer/shuttle_control/bullet_act(var/obj/item/projectile/Proj)

--- a/code/game/machinery/computer/shuttle_computers.dm
+++ b/code/game/machinery/computer/shuttle_computers.dm
@@ -56,6 +56,32 @@
 	destination = null
 	header = "ERROR"
 
+/obj/item/weapon/card/shuttle_pass
+	name = "shuttle pass"
+	desc = "A one-use shuttle activation pass, for limited access to high-security transportation."
+	icon_state = "data"
+	item_state = "card-id"
+	var/obj/docking_port/destination/destination
+	var/allowed_shuttle
+
+/obj/item/weapon/card/shuttle_pass/New()
+	..()
+	if(ticker)
+		initialize()
+
+/obj/item/weapon/card/shuttle_pass/initialize()
+	if(ispath(destination))
+		spawn()
+			destination = locate(destination) in all_docking_ports
+
+/obj/item/weapon/card/shuttle_pass/Destroy()
+	destination = null
+
+/obj/item/weapon/card/shuttle_pass/ERT
+	name = "\improper ERT shuttle pass"
+	destination = /obj/docking_port/destination/transport/station
+	allowed_shuttle = /datum/shuttle/transport
+
 #define MAX_SHUTTLE_NAME_LEN
 
 /obj/machinery/computer/shuttle_control
@@ -120,9 +146,12 @@
 
 	return "[span_s][name][span_e]"
 
-/obj/machinery/computer/shuttle_control/attackby(obj/item/weapon/disk/shuttle_coords/SC, mob/user)
-	if(istype(SC))
-		insert_disk(SC, user)
+/obj/machinery/computer/shuttle_control/attackby(obj/item/O, mob/user)
+	if(istype(O, /obj/item/weapon/disk/shuttle_coords))
+		insert_disk(O, user)
+
+	if(istype(O, /obj/item/weapon/card/shuttle_pass))
+		use_pass(O, user)
 
 	return ..()
 
@@ -425,6 +454,19 @@
 		disk = SC
 		to_chat(usr, "<span class='info'>You insert \the [SC] into \the [src].</span>")
 		src.updateUsrDialog()
+
+/obj/machinery/computer/shuttle_control/proc/use_pass(obj/item/weapon/card/shuttle_pass/P, mob/user)
+	if(!istype(P))
+		return
+
+	if(shuttle && shuttle.type == P.allowed_shuttle)
+		if(user.drop_item(P, src))
+			if(shuttle.travel_to(P.destination, src, user))
+				to_chat(usr, "<span class='info'>You insert \the [P] into \the [src].</span>")
+				qdel(P)
+			else
+				to_chat(usr, "<span class='info'>You insert \the [P] into \the [src], but it is rejected.</span>")
+				user.put_in_hands(P)
 
 /obj/machinery/computer/shuttle_control/bullet_act(var/obj/item/projectile/Proj)
 	visible_message("[Proj] ricochets off [src]!")

--- a/code/game/machinery/computer/shuttle_computers.dm
+++ b/code/game/machinery/computer/shuttle_computers.dm
@@ -459,14 +459,15 @@
 	if(!istype(P))
 		return
 
-	if(shuttle && shuttle.type == P.allowed_shuttle)
-		if(user.drop_item(P, src))
+	if(user.drop_item(P, src))
+		if(shuttle && shuttle.type == P.allowed_shuttle)
 			if(shuttle.travel_to(P.destination, src, user))
 				to_chat(usr, "<span class='info'>You insert \the [P] into \the [src].</span>")
 				qdel(P)
-			else
-				to_chat(usr, "<span class='info'>You insert \the [P] into \the [src], but it is rejected.</span>")
-				user.put_in_hands(P)
+				return
+		else
+			to_chat(usr, "<span class='info'>You insert \the [P] into \the [src], but it is rejected.</span>")
+			user.put_in_hands(P)
 
 /obj/machinery/computer/shuttle_control/bullet_act(var/obj/item/projectile/Proj)
 	visible_message("[Proj] ricochets off [src]!")

--- a/code/game/response_team.dm
+++ b/code/game/response_team.dm
@@ -160,8 +160,8 @@ proc/trigger_armed_response_team(var/force = 0, var/reason)
 	can_call_ert = 0 // Only one call per round, gentleman.
 	send_emergency_team = 1
 
-	sleep(600 * 5)
-	send_emergency_team = 0 // Can no longer join the ERT.
+	spawn(600 * 5)
+		send_emergency_team = 0 // Can no longer join the ERT.
 
 	var/nuke_code
 	for(var/obj/machinery/nuclearbomb/nuke in machines)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1278,6 +1278,10 @@ var/list/slot_equipment_priority = list( \
 		var/t1 = text("window=[href_list["mach_close"]]")
 		unset_machine()
 		src << browse(null, t1)
+	if (href_list["joinresponseteam"])
+		if(usr.client)
+			var/client/C = usr.client
+			C.JoinResponseTeam()
 
 /mob/proc/pull_damage()
 	if(ishuman(src))

--- a/code/modules/security levels/keycard authentication.dm
+++ b/code/modules/security levels/keycard authentication.dm
@@ -111,7 +111,10 @@ var/global/list/obj/machinery/keycard_auth/authenticators = list()
 	if(href_list["triggerevent"])
 		if(href_list["triggerevent"] == "Emergency Response Team")
 			ert_reason = stripped_input(usr, "Please input the reason for calling an Emergency Response Team. This may be all the briefing they get before arriving at the station.", "Response Team Justification", ert_reason)
-			if(!ert_reason || !Adjacent(usr) || usr.incapacitated())
+			if(!ert_reason)
+				to_chat(usr, "<span class='warning'>You are required to give a reason to call an ERT.</span>")
+				return
+			if(!Adjacent(usr) || usr.incapacitated())
 				return
 		event = href_list["triggerevent"]
 		screen = 2
@@ -145,8 +148,8 @@ var/global/list/obj/machinery/keycard_auth/authenticators = list()
 	if(confirmed)
 		confirmed = 0
 		trigger_event(event)
-		log_game("[key_name(event_triggered_by)] triggered and [key_name(event_confirmed_by)] confirmed event [event]")
-		message_admins("[key_name(event_triggered_by)] triggered and [key_name(event_confirmed_by)] confirmed event [event]", 1)
+		log_game("[key_name(event_triggered_by)] triggered and [key_name(event_confirmed_by)] confirmed event [event][event=="Emergency Response Team"?". ERT reason given was '[ert_reason]'":""]")
+		message_admins("[key_name(event_triggered_by)] triggered and [key_name(event_confirmed_by)] confirmed event [event][event=="Emergency Response Team"?". ERT reason given was '[ert_reason]'":""]", 1)
 	reset()
 
 /obj/machinery/keycard_auth/proc/receive_request(var/obj/machinery/keycard_auth/source)


### PR DESCRIPTION
Calling an ERT allows a reason to be input which is later shown to joining ERT members, for when an admin can't be there to give a proper briefing. This is to give the ERT members an idea of what gear they should bring, because they have a huge selection of stuff.
When an ERT is called a message is shown to all ghosts with a link to join up, to hopefully increase participation.
The JoinResponseTeam verb is moved from the IC tab to the OOC tab.
Adds shuttle passes, which are one-use items that can move a shuttle to a destination. One is given to the ERT leader to send their shuttle to the station. They are unable to return after the shuttle is sent without admin intervention.
An ERT can be called by using the keycard authenticators, still only during code red or above.