### PR TITLE
Map element stuff

### DIFF
--- a/code/datums/map_elements.dm
+++ b/code/datums/map_elements.dm
@@ -24,11 +24,8 @@ var/list/datum/map_element/map_elements = list()
 		location = locate(/turf) in objects
 
 	//Build powernets
-	for(var/obj/structure/cable/C in objects)
-		if(C.powernet)
-			continue
-		
-		C.rebuild_from()
+	for(var/atom/A in objects)
+		A.spawned_by_map_element(src, objects)
 
 /datum/map_element/proc/load(x, y, z)
 	pre_load()

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -800,3 +800,7 @@ its easier to just keep the beam vertical.
 
 /atom/proc/animationBolt(var/mob/firer)
 	return
+
+//Called when loaded by the map loader
+/atom/proc/spawned_by_map_element(datum/map_element/ME, list/objects)
+	return

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -60,7 +60,8 @@
 	// This is the placed to store data for the holomap.
 	var/list/image/holomap_data
 
-
+	// Map element which spawned this turf
+	var/datum/map_element/map_element
 
 /turf/examine(mob/user)
 	..()
@@ -687,3 +688,8 @@
 		return A.has_gravity
 
 	return 1
+
+/turf/spawned_by_map_element(datum/map_element/ME, list/objects)
+	.=..()
+
+	src.map_element = ME

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -194,6 +194,7 @@ var/global/dmm_suite/preloader/_preloader = null
 
 	if(!isspace(instance)) //Space is the default area and contains every loaded turf by default
 		instance.contents.Add(locate(xcrd,ycrd,zcrd))
+		spawned_atoms |= instance
 
 	if(_preloader && instance)
 		_preloader.load(instance)

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -485,3 +485,11 @@ By design, d1 is the smallest direction and d2 is the highest
 
 		if(PN.is_empty()) // can happen with machines made nodeless when smoothing cables
 			returnToPool(PN) //powernets do not get qdelled
+
+/obj/structure/cable/spawned_by_map_element(datum/map_element/ME, list/objects)
+	.=..()
+
+	if(powernet)
+		return
+
+	rebuild_from()

--- a/maps/randomvaults/objects.dm
+++ b/maps/randomvaults/objects.dm
@@ -1,5 +1,10 @@
 //Object and area definitions go here
-/area/vault //Please make all areas used in vaults a subtype of this!
+//Please make all areas used in vaults one of these:
+//  * subtype of /area/vault
+//  * /area/vault/automap (preferred option)
+//  * subtype of /area/vault/automap
+
+/area/vault
 	name = "mysterious structure"
 	requires_power = 0
 	icon_state = "firingrange"
@@ -7,6 +12,27 @@
 
 /area/vault/holomapAlwaysDraw()
 	return 0
+
+//Special area that can be used in map elements. When loaded, it creates a new area object and transfers all of its contents into it.
+//This means that this area can be put into multiple map elements without any issues
+/area/vault/automap
+
+/area/vault/automap/spawned_by_map_element(datum/map_element/ME, list/objects)
+	var/area/vault/automap/new_area = new src.type
+
+	for(var/turf/T in src.contents)
+		new_area.contents.Add(T)
+
+		T.change_area(src, new_area)
+		for(var/atom/allthings in T.contents)
+			allthings.change_area(src, new_area)
+
+	new_area.tag = "[new_area.type]/\ref[ME]"
+	new_area.addSorted()
+
+/area/vault/automap/no_light
+	icon_state = "ME_vault_lit"
+	dynamic_lighting = FALSE
 
 /area/vault/icetruck
 


### PR DESCRIPTION
#12495 but only useful parts are included and no secret repo conflicts (that one is still wip)

* spawned_by_map_element proc

* Turfs remember which map element they belong to

* /area/vault/automap area that removes the need of creating a subtype of /area/vault for every vault