### PR TITLE
Makes emagging the robotics control console work

### DIFF
--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -233,7 +233,7 @@
 
 	return
 
-/obj/machinery/computer/robotics/emag(mob/user as mob)
+/obj/machinery/computer/robotics/emag(mob/user)
 	..()
 	req_access = list()
-	to_chat(usr, "You disable the console's access requirement.")
+	to_chat(user, "You disable the console's access requirement.")

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -232,3 +232,8 @@
 			R.self_destruct()
 
 	return
+
+/obj/machinery/computer/robotics/emag(mob/user as mob)
+	..()
+	req_access = list()
+	to_chat(usr, "You disable the console's access requirement.")


### PR DESCRIPTION
Considering getting around access requirements is the intended purpose of the emag, not letting it work on the robo console seems like an oversight.
