### PR TITLE
Can't pry floor tiles while on harm intent using a crowbar

### DIFF
--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -502,6 +502,7 @@ turf/simulated/floor/update_icon()
 
 	if(iscrowbar(C) && (!(is_plating())))
 		if (user.a_intent != I_HELP) //We assume the user is fighting
+			to_chat(user, "<span class='notice'>You swing the crowbar in front of you.</span>")
 			return
 		if(broken || burnt)
 			to_chat(user, "<span class='warning'>You remove the broken plating.</span>")

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -501,6 +501,8 @@ turf/simulated/floor/update_icon()
 		return 0
 
 	if(iscrowbar(C) && (!(is_plating())))
+		if (user.a_intent != I_HELP) //We assume the user is fighting
+			return
 		if(broken || burnt)
 			to_chat(user, "<span class='warning'>You remove the broken plating.</span>")
 		else


### PR DESCRIPTION
I got tired of seeing people prying floors while trying to use crowbars as weapons, it really hurts my eyes. ~~The only problem I see with this is people going "wtf my crowbar doesn't work"~~ solved

:cl:
- rscadd: Now crowbars only pry tiles on help intent, so it's possible to use them as weapons now without fucking with the station and your attack delay