### PR TITLE
Eggbox Hotfix

### DIFF
--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -83,7 +83,7 @@
  */
 
 /obj/item/weapon/storage/fancy/egg_box
-	icon = 'icons/obj/food.dmi'
+	icon = 'icons/obj/food_container.dmi'
 	icon_state = "eggbox"
 	icon_type = "egg"
 	name = "egg box"


### PR DESCRIPTION
fixes #12680 

In an effort to make food.dmi faster, some stuff was split off into new files (in this case, food_container.dmi) but eggbox didn't get its icon variable updated. 