### PR TITLE
Adds minerals to the price of the pico manipulator

### DIFF
--- a/code/modules/research/designs/stock_parts.dm
+++ b/code/modules/research/designs/stock_parts.dm
@@ -129,7 +129,7 @@
 	id = "pico_mani"
 	req_tech = list(Tc_MATERIALS = 5, Tc_PROGRAMMING = 2)
 	build_type = PROTOLATHE
-	materials = list(MAT_IRON = 30)
+	materials = list(MAT_IRON = 30, MAT_URANIUM = 10, MAT_SILVER = 20)
 	reliability_base = 73
 	category = "Stock Parts"
 	build_path = /obj/item/weapon/stock_parts/manipulator/nano/pico


### PR DESCRIPTION
Does what the title says. Adds a tiny amount of silver and uranium (similar amounts as other stock parts) to the pico manipulator in the protolathe. The super matter bin is still mineral free so r&d can be completed with ease as normal. This change is designed to work with my other PRs that will be pushed shortly