### PR TITLE
Increases the amount of stock parts in exosuit fabricators

### DIFF
--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -84,6 +84,8 @@
 		/obj/item/weapon/stock_parts/matter_bin,
 		/obj/item/weapon/stock_parts/matter_bin,
 		/obj/item/weapon/stock_parts/manipulator,
+		/obj/item/weapon/stock_parts/manipulator,
+		/obj/item/weapon/stock_parts/micro_laser,
 		/obj/item/weapon/stock_parts/micro_laser,
 		/obj/item/weapon/stock_parts/console_screen
 	)


### PR DESCRIPTION
Does what the title says. Before the parts in the exosuit fab were as follows

2 matter bin
1 manipulator
1 micro laser
1 console screen

This increases the manipulator and micro laser amount to 2 each

This change is designed to work with https://github.com/d3athrow/vgstation13/pull/12689 since the math behind how machine upgrades are intended for machines to have 2 lasers in them as oppose to 1 laser.