### PR TITLE
Removes Jaunt invocation, speech bubbles don't follow invisible casters

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -425,15 +425,14 @@ var/list/department_radio_keys = list(
 				tracking_speech_bubble_recipients.Add(M.client)
 	spawn(0)
 		if(static_speech_bubble_recipients.len)
-			var/image/speech_bubble = image('icons/mob/talk.dmi', get_turf(src), "h[bubble_type][say_test(message)]",MOB_LAYER+1)
-			speech_bubble.plane = BASE_PLANE
-			speech_bubble.appearance_flags = RESET_COLOR
-			flick_overlay(speech_bubble, static_speech_bubble_recipients, 30)
+			display_bubble_to_clientlist(image('icons/mob/talk.dmi', get_turf(src), "h[bubble_type][say_test(message)]",MOB_LAYER+1), static_speech_bubble_recipients)
 		if(tracking_speech_bubble_recipients.len)
-			var/image/speech_bubble = image('icons/mob/talk.dmi', get_holder_at_turf_level(src), "h[bubble_type][say_test(message)]",MOB_LAYER+1)
-			speech_bubble.plane = BASE_PLANE
-			speech_bubble.appearance_flags = RESET_COLOR
-			flick_overlay(speech_bubble, tracking_speech_bubble_recipients, 30)
+			display_bubble_to_clientlist(image('icons/mob/talk.dmi', get_holder_at_turf_level(src), "h[bubble_type][say_test(message)]",MOB_LAYER+1), tracking_speech_bubble_recipients)
+
+/proc/display_bubble_to_clientlist(var/image/speech_bubble, var/clientlist)
+	speech_bubble.plane = BASE_PLANE
+	speech_bubble.appearance_flags = RESET_COLOR
+	flick_overlay(speech_bubble, clientlist, 30)
 
 /mob/proc/addSpeechBubble(image/speech_bubble)
 	if(client)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -414,16 +414,26 @@ var/list/department_radio_keys = list(
 
 /mob/living/proc/send_speech_bubble(var/message,var/bubble_type, var/list/hearers)
 	//speech bubble
-	var/list/speech_bubble_recipients = list()
+	var/list/tracking_speech_bubble_recipients = list()
+	var/list/static_speech_bubble_recipients = list()
 	for(var/mob/M in hearers)
 		M.heard(src)
 		if(M.client)
-			speech_bubble_recipients.Add(M.client)
+			if(src.invisibility > M.see_invisible) //You cannot see who's talking, so you only get a vague sense of where the sound originated from. This is mostly for Jaunt invocation.
+				static_speech_bubble_recipients.Add(M.client)
+			else
+				tracking_speech_bubble_recipients.Add(M.client)
 	spawn(0)
-		var/image/speech_bubble = image('icons/mob/talk.dmi', get_holder_at_turf_level(src), "h[bubble_type][say_test(message)]",MOB_LAYER+1)
-		speech_bubble.plane = BASE_PLANE
-		speech_bubble.appearance_flags = RESET_COLOR
-		flick_overlay(speech_bubble, speech_bubble_recipients, 30)
+		if(static_speech_bubble_recipients.len)
+			var/image/speech_bubble = image('icons/mob/talk.dmi', get_turf(src), "h[bubble_type][say_test(message)]",MOB_LAYER+1)
+			speech_bubble.plane = BASE_PLANE
+			speech_bubble.appearance_flags = RESET_COLOR
+			flick_overlay(speech_bubble, static_speech_bubble_recipients, 30)
+		if(tracking_speech_bubble_recipients.len)
+			var/image/speech_bubble = image('icons/mob/talk.dmi', get_holder_at_turf_level(src), "h[bubble_type][say_test(message)]",MOB_LAYER+1)
+			speech_bubble.plane = BASE_PLANE
+			speech_bubble.appearance_flags = RESET_COLOR
+			flick_overlay(speech_bubble, tracking_speech_bubble_recipients, 30)
 
 /mob/proc/addSpeechBubble(image/speech_bubble)
 	if(client)

--- a/code/modules/spells/targeted/ethereal_jaunt.dm
+++ b/code/modules/spells/targeted/ethereal_jaunt.dm
@@ -6,8 +6,7 @@
 	school = "transmutation"
 	charge_max = 300
 	spell_flags = Z2NOCAST | NEEDSCLOTHES | INCLUDEUSER
-	invocation = "Rah'dee K'Alari"
-	invocation_type = SpI_SHOUT
+	invocation_type = SpI_NONE
 	range = SELFCAST
 	max_targets = 1
 	cooldown_min = 100 //50 deciseconds reduction per rank


### PR DESCRIPTION
Jaunt was having problems in that the invocation caused a speech bubble, which followed the invisible wizard while they jaunted
I thought that by making invisible mobs have speech bubbles not follow them, the problem would be solved
Sadly the actual jaunt invocation happens before the jaunt, so I just made jaunt not have an invocation again
Left the whole "speech bubbles don't follow invisible casters" thing in in case a brain damage wizard speaks while jaunted or something
:cl: 
 * bugfix: Removed the verbal invocation from Ethereal Jaunt, because it was following the invisible wizard and giving away where they jaunted to.