### PR TITLE
Adds snap-pop smoke bombs as Syndie uplink item for 3 TC

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -477,6 +477,12 @@ var/list/uplink_items = list()
 	item = /obj/item/device/chameleon
 	cost = 6
 
+/datum/uplink_item/stealthy_tools/chameleon_proj
+	name = "Instant Smoke Bombs"
+	desc = "A package of eight instant-action smoke bombs, cleverly disguised as harmless snap-pops. The cover of smoke they create is large enough to cover most of a room. Pair well with thermal imaging glasses."
+	item = /obj/item/weapon/storage/box/syndie_kit/smokebombs
+	cost = 3
+
 
 // DEVICE AND TOOLS
 

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -447,39 +447,6 @@
 	user.visible_message("<span class = 'danger'><b>[user] is jamming \the [src.name] up \his nose and into \his brain. It looks like \he's trying to commit suicide.</b></span>")
 	return (BRUTELOSS|OXYLOSS)
 
-
-
-
-/*
- * Snap pops viral shit
- */
-/obj/item/toy/snappop/virus
-	name = "unstable goo"
-	desc = "Your palm is oozing this stuff!"
-	icon = 'icons/mob/slimes.dmi'
-	icon_state = "red slime extract"
-	throwforce = 30.0
-	throw_speed = 10
-	throw_range = 30
-	w_class = W_CLASS_TINY
-
-
-/obj/item/toy/snappop/virus/throw_impact(atom/hit_atom)
-	..()
-	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-	s.set_up(3, 1, src)
-	s.start()
-	new /obj/effect/decal/cleanable/ash(src.loc)
-	src.visible_message("<span class = 'danger'>\The [src.name] explodes!</span>","</span class = 'danger'>You hear a bang!</span>")
-
-
-	playsound(src, 'sound/effects/snap.ogg', 50, 1)
-	qdel(src)
-
-
-
-
-
 /*
  * Snap pops
  */
@@ -492,27 +459,64 @@
 
 /obj/item/toy/snappop/throw_impact(atom/hit_atom)
 	..()
-	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-	s.set_up(3, 1, src)
-	s.start()
-	new /obj/effect/decal/cleanable/ash(src.loc)
-	src.visible_message("<span class = 'danger'>\The [src.name] explodes!</span>","<span class = 'danger'>You hear a snap!</span>")
-	playsound(src, 'sound/effects/snap.ogg', 50, 1)
-	qdel(src)
+	pop()
 
 /obj/item/toy/snappop/Crossed(H as mob|obj)
 	if((ishuman(H))) //i guess carp and shit shouldn't set them off
 		var/mob/living/carbon/M = H
 		if(M.m_intent == "run")
 			to_chat(M, "<span class = 'warning'>You step on \the [src.name]!</span>")
+			pop()
 
-			var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-			s.set_up(2, 0, src)
-			s.start()
-			new /obj/effect/decal/cleanable/ash(src.loc)
-			src.visible_message("<span class = 'danger'>\The [src.name] explodes!</span>","<span class = 'danger'>You hear a snap!</span>")
-			playsound(src, 'sound/effects/snap.ogg', 50, 1)
-			qdel(src)
+/obj/item/toy/snappop/proc/pop()
+	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
+	s.set_up(2, 0, src)
+	s.start()
+	new /obj/effect/decal/cleanable/ash(src.loc)
+	src.visible_message("<span class = 'danger'>\The [src.name] explodes!</span>","<span class = 'danger'>You hear a snap!</span>")
+	playsound(src, 'sound/effects/snap.ogg', 50, 1)
+	qdel(src)
+
+/*
+ * From the virus symptom
+ */
+/obj/item/toy/snappop/virus
+	name = "unstable goo"
+	desc = "Your palm is oozing this stuff!"
+	icon = 'icons/mob/slimes.dmi'
+	icon_state = "red slime extract"
+	throwforce = 30.0
+	throw_speed = 10
+	throw_range = 30
+	w_class = W_CLASS_TINY
+
+/obj/item/toy/snappop/virus/pop()
+	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
+	s.set_up(3, 1, src)
+	s.start()
+	new /obj/effect/decal/cleanable/ash(src.loc)
+	src.visible_message("<span class = 'danger'>\The [src.name] explodes!</span>","</span class = 'danger'>You hear a bang!</span>")
+	playsound(src, 'sound/effects/snap.ogg', 50, 1)
+	qdel(src)
+
+/*
+ * Syndie stealthy smokebombs!
+ */
+ /obj/item/toy/snappop/smokebomb
+ 	origin_tech = Tc_COMBAT + "=1;" + Tc_SYNDICATE + "=1"
+
+/obj/item/toy/snappop/smokebomb/pop()
+	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
+	s.set_up(2, 0, src)
+	s.start()
+	playsound(src, 'sound/effects/snap.ogg', 50, 1)
+	for(var/turf/T in trange(1, get_turf(src))) //Cause smoke in all 9 turfs around us, like the wizard smoke spell
+		if(T.density) //no wallsmoke pls
+			continue
+		var/datum/effect/effect/system/smoke_spread/bad/smoke = new /datum/effect/effect/system/smoke_spread/bad()
+		smoke.set_up(5, 0, T)
+		smoke.start()
+	qdel(src)
 
 /*
  * Water flower

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -461,10 +461,9 @@
 	..()
 	pop()
 
-/obj/item/toy/snappop/Crossed(H as mob|obj)
-	if((ishuman(H))) //i guess carp and shit shouldn't set them off
-		var/mob/living/carbon/M = H
-		if(M.m_intent == "run")
+/obj/item/toy/snappop/Crossed(var/mob/living/M)
+	if(istype(M) && M.size > SIZE_SMALL) //i guess carp and shit shouldn't set them off
+		if(M.m_intent == "run" && M.on_foot())
 			to_chat(M, "<span class = 'warning'>You step on \the [src.name]!</span>")
 			pop()
 

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -234,3 +234,16 @@
 	new /obj/item/weapon/reagent_containers/glass/bottle/antisocial(src)
 	new /obj/item/weapon/reagent_containers/syringe(src)
 	return
+
+/obj/item/weapon/storage/box/syndie_kit/smokebombs
+	name = "snap pop box"
+	desc = "Eight wrappers of fun! Ages 8 and up. Not suitable for children."
+	icon = 'icons/obj/toy.dmi'
+	icon_state = "spbox"
+	storage_slots = 8
+	can_only_hold = list("/obj/item/toy/snappop")
+
+/obj/item/weapon/storage/box/syndie_kit/smokebombs/New()
+	..()
+	for(var/i=1; i <= storage_slots; i++)
+		new /obj/item/toy/snappop/smokebomb(src)


### PR DESCRIPTION
Instant smoke bombs are essentially one-use Smoke wizard spells. Note that the smoke from this effect is a little faster and lasts longer than the smoke from chemistry/Sec smoke bombs.

The 3TC package includes 8 smoke bombs. They are disguised as snap-pops, to make them a little less obvious.
I plan to eventually give them the NO_THROW_MSG flag from  #12720, so that if you throw them in a crowded room nobody gets a message saying who did it.

I imagine these could be useful for getaways or as a one-way smoke screen if you have thermal vision, but not terribly good so the price is kept at a low 3TC.

Size of the smoke cloud
![dreamseeker_2016-12-10_14-01-04](https://cloud.githubusercontent.com/assets/6526157/21074831/68c6b8c6-bee1-11e6-8583-3430203687ae.png)

Demonstration webm
https://a.uguu.se/lBeNfbnIqFO4_Desktop12.10.2016-13.59.28.04.webm

:cl:
 * rscadd: Added a package of 8 Instant Smoke Bombs to Syndie uplinks, available for 3TC.
