### PR TITLE
Buckets hold 150u, don't fit in machinery

### DIFF
--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -221,6 +221,9 @@
 
 /obj/machinery/dna_scannernew/attackby(var/obj/item/weapon/item as obj, var/mob/user as mob)
 	if(istype(item, /obj/item/weapon/reagent_containers/glass))
+		if(item.w_class > W_CLASS_SMALL)
+			to_chat(user, "<span class='warning'>\The [item] is too big to fit.</span>")
+			return
 		if(beaker)
 			to_chat(user, "<span class='warning'>A beaker is already loaded into the machine.</span>")
 			return

--- a/code/game/machinery/biogenerator.dm
+++ b/code/game/machinery/biogenerator.dm
@@ -328,7 +328,7 @@
 		return 1
 	else if(istype(O, /obj/item/weapon/reagent_containers/glass))
 		if(beaker)
-			to_chat(user, "<span class='warning'>The biogenerator is already occuped.</span>")
+			to_chat(user, "<span class='warning'>The biogenerator is already occupied.</span>")
 		else if(panel_open)
 			to_chat(user, "<span class='rose'>The biogenerator's maintenance panel must be closed first.</span>")
 		else if(O.w_class > W_CLASS_SMALL)

--- a/code/game/machinery/biogenerator.dm
+++ b/code/game/machinery/biogenerator.dm
@@ -328,9 +328,11 @@
 		return 1
 	else if(istype(O, /obj/item/weapon/reagent_containers/glass))
 		if(beaker)
-			to_chat(user, "<span class='warning'>The biogenerator already occuped.</span>")
+			to_chat(user, "<span class='warning'>The biogenerator is already occuped.</span>")
 		else if(panel_open)
 			to_chat(user, "<span class='rose'>The biogenerator's maintenance panel must be closed first.</span>")
+		else if(O.w_class > W_CLASS_SMALL)
+			to_chat(user, "<span class='warning'>\The [O] is too big to fit.</span>")
 		else
 			if(user.drop_item(O, src))
 				beaker = O

--- a/code/game/machinery/bots/medbot.dm
+++ b/code/game/machinery/bots/medbot.dm
@@ -221,6 +221,9 @@
 		if(!isnull(src.reagent_glass))
 			to_chat(user, "<span class='notice'>There is already a beaker loaded.</span>")
 			return
+		if(W.w_class > W_CLASS_SMALL)
+			to_chat(user, "<span class='warning'>\The [W] is too big to fit.</span>")
+			return
 
 		if(user.drop_item(W, src))
 			src.reagent_glass = W

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -335,6 +335,9 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 		if(beaker)
 			to_chat(user, "<span class='warning'>A beaker is already loaded into the machine.</span>")
 			return
+		if(G.w_class > W_CLASS_SMALL)
+			to_chat(user, "<span class='warning'>\The [G] is too big to fit.</span>")
+			return
 		if(user.drop_item(G, src))
 			beaker =  G
 			user.visible_message("[user] adds \a [G] to \the [src]!", "You add \a [G] to \the [src]!")

--- a/code/game/objects/items/weapons/paint.dm
+++ b/code/game/objects/items/weapons/paint.dm
@@ -13,8 +13,8 @@ var/global/list/cached_icons = list()
 	w_class = W_CLASS_MEDIUM
 	melt_temperature = MELTPOINT_STEEL
 	amount_per_transfer_from_this = 10
-	possible_transfer_amounts = list(10,20,30,50,70)
-	volume = 70
+	possible_transfer_amounts = list(10,20,25,30,50,100,150)
+	volume = 150
 	flags = FPRINT | OPENCONTAINER
 	var/paint_type = ""
 

--- a/code/modules/food/icecreamvat.dm
+++ b/code/modules/food/icecreamvat.dm
@@ -33,14 +33,20 @@
 
 /obj/machinery/cooking/icemachine/takeIngredient(var/obj/item/I,mob/user)
 	if(istype(I,/obj/item/weapon/reagent_containers/glass))
-		if(!src.beaker)
-			if(user.drop_item(I, src))
-				src.beaker = I
-				. = 1
-				to_chat(user, "<span class='notice'>You add the [I.name] to the [src.name].</span>")
-				src.updateUsrDialog()
-		else
+		if(src.beaker)
 			to_chat(user, "<span class='warning'>The [src.name] already has a beaker.</span>")
+			return
+
+		if(I.w_class > W_CLASS_SMALL)
+			to_chat(user, "<span class='warning'>\The [I] is too big to fit.</span>")
+			return
+
+		if(user.drop_item(I, src))
+			src.beaker = I
+			. = 1
+			to_chat(user, "<span class='notice'>You add the [I.name] to the [src.name].</span>")
+			src.updateUsrDialog()
+
 	else if(istype(I,/obj/item/weapon/reagent_containers/food/snacks/icecream))
 		if(!I.reagents.has_reagent(SPRINKLES))
 			I.reagents.add_reagent(SPRINKLES,1)

--- a/code/modules/reagents/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/machinery/chem_dispenser.dm
@@ -276,6 +276,9 @@ USE THIS CHEMISTRY DISPENSER FOR MAPS SO THEY START AT 100 ENERGY
 		if(src.container)
 			to_chat(user, "\A [src.container] is already loaded into the machine.")
 			return
+		if(D.w_class > W_CLASS_SMALL)
+			to_chat(user, "<span class='warning'>\The [D] is too big to fit.</span>")
+			return
 		else if(!panel_open)
 			if(!user.drop_item(D, src))
 				to_chat(user, "<span class='warning'>You can't let go of \the [D]!</span>")

--- a/code/modules/reagents/machinery/chem_master.dm
+++ b/code/modules/reagents/machinery/chem_master.dm
@@ -116,9 +116,11 @@
 		return 1
 
 	else if(istype(B, /obj/item/weapon/reagent_containers/glass))
-
 		if(src.beaker)
 			to_chat(user, "<span class='warning'>There already is a beaker loaded in the machine.</span>")
+			return
+		if(B.w_class > W_CLASS_SMALL)
+			to_chat(user, "<span class='warning'>\The [B] is too big to fit.</span>")
 			return
 		if(!user.drop_item(B, src))
 			to_chat(user, "<span class='warning'>You can't let go of \the [B]!</span>")

--- a/code/modules/reagents/machinery/electrolyzer.dm
+++ b/code/modules/reagents/machinery/electrolyzer.dm
@@ -43,6 +43,9 @@
 			return
 	else if(is_type_in_list(W, allowed_containers))
 		var/obj/item/weapon/reagent_containers/glass/G = W
+		if(G.w_class > W_CLASS_SMALL)
+			to_chat(user, "<span class='warning'>\The [G] is too big to fit.</span>")
+			return
 		if(G.reagents.reagent_list.len > 1)
 			to_chat(user, "<span class='warning'>That mixture is too complex!</span>")
 			return

--- a/code/modules/reagents/machinery/pandemic.dm
+++ b/code/modules/reagents/machinery/pandemic.dm
@@ -281,7 +281,7 @@
 	return
 
 
-/obj/machinery/computer/pandemic/attackby(var/obj/I as obj, var/mob/user as mob)
+/obj/machinery/computer/pandemic/attackby(var/obj/item/I as obj, var/mob/user as mob)
 	if(..())
 		return 1
 	else if(istype(I, /obj/item/weapon/reagent_containers/glass))
@@ -289,6 +289,9 @@
 			return
 		if(src.beaker)
 			to_chat(user, "A beaker is already loaded into the machine.")
+			return
+		if(I.w_class > W_CLASS_SMALL)
+			to_chat(user, "<span class='warning'>\The [I] is too big to fit.</span>")
 			return
 		if(!user.drop_item(I, src))
 			to_chat(user, "<span class='warning'>You can't let go of \the [I]!</span>")

--- a/code/modules/reagents/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/machinery/reagentgrinder.dm
@@ -145,6 +145,9 @@
 		if (panel_open)
 			to_chat(user, "You can't load a beaker while the maintenance panel is open.")
 			return 0
+		if (O.w_class > W_CLASS_SMALL)
+			to_chat(user, "<span class='warning'>\The [O] is too big to fit.</span>")
+			return 0
 		else
 			if(!user.drop_item(O, src))
 				to_chat(user, "<span class='warning'>You can't let go of \the [O]!</span>")

--- a/code/modules/reagents/reagent_containers/chempack.dm
+++ b/code/modules/reagents/reagent_containers/chempack.dm
@@ -171,13 +171,16 @@ obj/item/weapon/reagent_containers/chempack/verb/set_fill()
 /obj/item/weapon/reagent_containers/chempack/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/weapon/reagent_containers/glass))
 		if(src.safety && auxiliary)
-			if (stage)
+			if(stage)
 				to_chat(user, "<span class='warning'>You need to secure the maintenance panel before you can insert a beaker!</span>")
 				return
 			if(user.type == /mob/living/silicon/robot) //Can't have silicons putting their beakers inside this.
 				return
 			if(src.beaker)
 				to_chat(user, "There is already a beaker loaded into \the [src].")
+				return
+			if(W.w_class > W_CLASS_SMALL)
+				to_chat(user, "<span class='warning'>\The [W] is too big to fit.</span>")
 				return
 			else
 				if(user.drop_item(W, src))

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -305,8 +305,8 @@
 	w_type = RECYK_METAL
 	w_class = W_CLASS_MEDIUM
 	amount_per_transfer_from_this = 20
-	possible_transfer_amounts = list(10,20,30,50,70)
-	volume = 70
+	possible_transfer_amounts = list(10,20,25,30,50,100,150)
+	volume = 150
 	flags = FPRINT | OPENCONTAINER
 	slot_flags = SLOT_HEAD
 


### PR DESCRIPTION
To make buckets a little more useful, they now hold 150 units, so it can hold more than twice as much mutagen as before.

However, they now don't fit in machinery such as chemmasters or chemdispensers, to prevent them from becoming the beaker meta.

:cl:
 * tweak: Buckets can now hold 150 units, up from 70. However, they won't fit in machinery, such as chemdispensers.