### PR TITLE
Separates logging into per-round, rather than per-day

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -33,7 +33,7 @@ var/savefile/panicfile
 	*/
 
 	// logs
-	var/date_string = time2text(world.realtime, "YYYY/MM-Month/DD-Day")
+	var/date_string = time2text(world.realtime, "YYYY/MM-Month/DD-Day/hh.mm [station_name]")
 
 	investigations[I_HREFS] = new /datum/log_controller(I_HREFS, filename="data/logs/[date_string] hrefs.htm", persist=TRUE)
 	investigations[I_ATMOS] = new /datum/log_controller(I_ATMOS, filename="data/logs/[date_string] atmos.htm", persist=TRUE)


### PR DESCRIPTION
Before: The entire day's worth of logging is bundled inside `logs\2016\12-December\13-Tuesday.log`.
Now: Each round is separated into its own `logs\2016\12-December\13-Tuesday\[hour].[minute] [station name]`, for example `logs\2016\12-December\13-Tuesday\11.06 Death-World Center Alpha.log`

Is this a ton more convenient? Yes.
Will this cause the logging to shit itself and break instantly? Probably.
It worked in my machine, no idea if it will break for Pomf's. Concerns are that the filepaths become 2long for Pomf's machine, or that the station names generate with an invalid character for Windows filenames such as `:`.