### PR TITLE
"Fixes" #5616, Thermostat on Cold Room settings is broken

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -767,13 +767,13 @@
 
 	if(href_list["temperature"])
 		var/list/selected = TLV["temperature"]
-		var/max_temperature = min(selected[3] - T0C, MAX_TEMPERATURE)
-		var/min_temperature = max(selected[2] - T0C, MIN_TEMPERATURE)
-		var/input_temperature = input("What temperature would you like the system to maintain? (Capped between [min_temperature]C and [max_temperature]C)", "Thermostat Controls") as num|null
+		var/max_temperature = selected[3] - T0C
+		var/min_temperature = selected[2] - T0C
+		var/input_temperature = input("What temperature (in C) would you like the system to maintain? (Capped between [min_temperature]C and [max_temperature]C)", "Thermostat Controls") as num|null
 		if(input_temperature==null)
 			return
-		if(!input_temperature || input_temperature >= max_temperature || input_temperature <= min_temperature)
-			to_chat(usr, "Temperature must be between [min_temperature]C and [max_temperature]C")
+		if(!input_temperature || input_temperature > max_temperature || input_temperature < min_temperature)
+			to_chat(usr, "<span class='warning'>Temperature must be between [min_temperature]C and [max_temperature]C.</span>")
 		else
 			target_temperature = input_temperature + T0C
 		return 1


### PR DESCRIPTION
While this technically works, the "Cold Room" preset for some reason has extremely low temperature thresholds set, way below the thermostat's -40c limit, so no matter what you set it will get reset to -40 one tick afterwards. Not entirely sure what to do about this because I am not an atmos-smart man.