### PR TITLE
Finally fucking fixes robot/peg limbs having their damage count against your total health.

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -235,7 +235,7 @@
 	var/list/is_bleeding = list()
 	for(var/datum/organ/external/temp in organs)
 		if(temp)
-			if(temp.status & ORGAN_DESTROYED)
+			if(!temp.is_existing())
 				is_destroyed["[temp.display_name]"] = 1
 				wound_flavor_text["[temp.display_name]"] = "<span class='danger'>[t_He] is missing [t_his] [temp.display_name].</span>\n"
 				continue

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -7,8 +7,9 @@
 	var/total_burn	= 0
 	var/total_brute	= 0
 	for(var/datum/organ/external/O in organs)	//hardcoded to streamline things a bit
-		total_brute	+= O.brute_dam
-		total_burn	+= O.burn_dam
+		if(O.is_organic() && O.is_existing())
+			total_brute	+= O.brute_dam
+			total_burn	+= O.burn_dam
 	health = maxHealth - getOxyLoss() - getToxLoss() - getCloneLoss() - total_burn - total_brute
 	//TODO: fix husking
 	if( ((maxHealth - total_burn) < config.health_threshold_dead) && stat == DEAD) //100 only being used as the magic human max health number, feel free to change it if you add a var for it -- Urist
@@ -169,6 +170,8 @@
 /mob/living/carbon/human/proc/get_damageable_organs()
 	var/list/datum/organ/external/parts = list()
 	for(var/datum/organ/external/O in organs)
+		if(!O.is_existing())
+			continue
 		if(O.brute_dam + O.burn_dam < O.max_damage)
 			parts += O
 	return parts

--- a/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
@@ -168,8 +168,8 @@
 							if(ruptured)
 								healths.overlays.Add(organ_damage_overlays["[e.name]_max"])
 								continue
-						var/total_damage = e.brute_dam + e.burn_dam
-						if(e.status & ORGAN_BROKEN)
+						var/total_damage = e.get_damage()
+						if(!e.is_existing())
 							healths.overlays.Add(organ_damage_overlays["[e.name]_gone"])
 						else
 							switch(total_damage)

--- a/code/modules/organs/pain.dm
+++ b/code/modules/organs/pain.dm
@@ -92,9 +92,9 @@ mob/living/carbon/human/proc/handle_pain()
 	var/datum/organ/external/damaged_organ = null
 	for(var/datum/organ/external/E in organs)
 		// amputated limbs don't cause pain
-		if(E.amputated)
+		if(!E.is_existing() || E.amputated)
 			continue
-		if(E.status & ORGAN_DEAD)
+		if(E.status & ORGAN_DEAD || E.status & ORGAN_PEG)
 			continue
 		var/dam = E.get_damage()
 		// make the choice of the organ depend on damage,


### PR DESCRIPTION
Also:
Peg limbs don't hurt
Missing limbs are shown missing in your paperdoll
Broken limbs are shown as always badly damaged rather than always missing

:cl:
 * bugfix: Prosthetics (robot/peg limbs) no longer count their damage against your total health.
 * bugfix: Damaged peg limbs no longer hurt. Robot limbs still do, however.
 * bugfix: Missing limbs now actually show up as missing in your paperdoll.
 * tweak: Broken limbs are now shown as badly damaged in your paperdoll, rather than missing.