### PR TITLE
power cells are now smol

### DIFF
--- a/code/game/objects/items/weapons/power_cells.dm
+++ b/code/game/objects/items/weapons/power_cells.dm
@@ -10,7 +10,7 @@
 	throwforce = 5.0
 	throw_speed = 3
 	throw_range = 5
-	w_class = W_CLASS_MEDIUM
+	w_class = W_CLASS_SMALL
 	var/charge = 0	// note %age conveted to actual charge in New
 	var/maxcharge = 1000
 	starting_materials = list(MAT_IRON = 700, MAT_GLASS = 50)


### PR DESCRIPTION
Power Cells are now SMALL items, so they fit in pockets. Because you could put them on gloves and they'd fit in your pocket, but they wouldn't fit in your pocket by themselves. ???

:cl:
- tweak: Made power cells small items, now they fit in your pockets.