### PR TITLE
Fixes #11342

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/effects.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/effects.dm
@@ -26,9 +26,9 @@
 
 /obj/effect/spider/attackby(var/obj/item/weapon/W, var/mob/user)
 	user.delayNextAttack(8)
-	if(W.attack_verb && W.attack_verb.len)
+	if(W.attack_verb && W.attack_verb.len  && !(W.flags&NOBLUDGEON))
 		visible_message("<span class='warning'><B>[user] [pick(W.attack_verb)] \the [src] with \the [W].</span>")
-	else
+	else if(!(W.flags&NOBLUDGEON))
 		visible_message("<span class='warning'><B>[user] attacks \the [src] with \the [W]</span>")
 
 	var/damage = (W.is_hot() || W.is_sharp()) ? (W.force) : (W.force / SPIDERWEB_BRUTE_DIVISOR)
@@ -43,6 +43,22 @@
 
 	health -= damage
 	healthcheck()
+
+/obj/effect/spider/attack_hand(var/mob/living/carbon/human/user)
+	if(user.a_intent == I_HURT)
+		user.delayNextAttack(8)
+		user.visible_message("<span class='danger'>[user.name] claws at \the [src]!</span>", \
+			"<span class='danger'>You claw at \the [src]!</span>", \
+			"You hear something tear.")
+		health -= 2
+		healthcheck()
+	else
+		var/atom/movable/I = pick(contents)
+		var/some_suffix = "thing"
+		if(I && istype(I,/mob/living/carbon/human))
+			some_suffix = "one"
+		user.visible_message("<span class='notice'>[user] rubs their hands all over \the [src]!</span>", \
+			"<span class='notice'>You rub your hands over \the [src] [I ? ", you think you can feel some[some_suffix] in there!": ""]</span>")
 
 /obj/effect/spider/bullet_act(var/obj/item/projectile/Proj)
 	..()


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl: (as the emoji)
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->

Fixes #11342
Adds feedback for hitting a spider cocoon
also fixes bug where items with nobludgeon would still bludgeon on a spider cocoon