### PR TITLE
Fixes Autopsy Scanners Not Detecting Melee Weapon Damage

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -236,7 +236,7 @@ emp_act
 				if(prob(chance))
 					knock_out_teeth(user)
 
-	apply_damage(I.force, I.damtype, affecting, armor , I.is_sharp(), I.edge, I)
+	apply_damage(I.force, I.damtype, affecting, armor , I.is_sharp(), I.edge, used_weapon = I)
 
 	var/bloody = 0
 	if(((I.damtype == BRUTE) || (I.damtype == HALLOSS)) && prob(25 + (I.force * 2)))

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -236,7 +236,7 @@ emp_act
 				if(prob(chance))
 					knock_out_teeth(user)
 
-	apply_damage(I.force, I.damtype, affecting, armor , I.is_sharp(), I)
+	apply_damage(I.force, I.damtype, affecting, armor , I.is_sharp(), I.edge, I)
 
 	var/bloody = 0
 	if(((I.damtype == BRUTE) || (I.damtype == HALLOSS)) && prob(25 + (I.force * 2)))

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -236,7 +236,7 @@ emp_act
 				if(prob(chance))
 					knock_out_teeth(user)
 
-	apply_damage(I.force, I.damtype, affecting, armor , I.is_sharp(), I.edge, used_weapon = I)
+	apply_damage(I.force, I.damtype, affecting, armor , I.is_sharp(), used_weapon = I)
 
 	var/bloody = 0
 	if(((I.damtype == BRUTE) || (I.damtype == HALLOSS)) && prob(25 + (I.force * 2)))


### PR DESCRIPTION
Autopsy scanners are supposed to give a readout of all the things that caused damage to the corpse, but were only doing so for projectiles.
The autopsy scanner will now properly give a report on what melee weapons a corpse was damaged with as well.

:cl:
 * bugfix: Autopsy scanners will now report what melee weapons a corpse has been damaged with in addition to projectiles.
