### PR TITLE
Allows Projectile Sharpness to Matter

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -59,7 +59,7 @@
 		P.on_hit(src,2)
 		return 2
 	if(!P.nodamage)
-		apply_damage((P.damage/(absorb+1)), P.damage_type, def_zone, absorb, P.is_sharp(), P.edge, used_weapon = P)
+		apply_damage((P.damage/(absorb+1)), P.damage_type, def_zone, absorb, P.is_sharp(), used_weapon = P)
 		regenerate_icons()
 	P.on_hit(src, absorb)
 	if(istype(P, /obj/item/projectile/beam/lightning))

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -59,7 +59,7 @@
 		P.on_hit(src,2)
 		return 2
 	if(!P.nodamage)
-		apply_damage((P.damage/(absorb+1)), P.damage_type, def_zone, absorb, 0, used_weapon = P)
+		apply_damage((P.damage/(absorb+1)), P.damage_type, def_zone, absorb, P.is_sharp(), P.edge, used_weapon = P)
 		regenerate_icons()
 	P.on_hit(src, absorb)
 	if(istype(P, /obj/item/projectile/beam/lightning))


### PR DESCRIPTION
This alters `/mob/living/bullet_act()` so that it passes the `sharpness`  var of the projectile to `apply_damage()` meaning that giving a projectile sharpness will actually change the way the projectile affects targets in the same way that giving a melee weapon sharpness does, such as increased chance of bleeding and limb severing.

Tested with a 100 sharpness bullet, seems to work properly out of the box.