### PR TITLE
Removed automatic paper printout from virus analyzer.

### DIFF
--- a/code/modules/virus2/analyser.dm
+++ b/code/modules/virus2/analyser.dm
@@ -67,7 +67,6 @@
 	dish.analysed = 1
 	if (D.virus2.addToDB())
 		say("Added new pathogen to database.")
-	PrintPaper(dish)
 	dish.forceMove(src.loc)
 	dish = null
 	icon_state = "analyser"


### PR DESCRIPTION
No one cares about virology so I might as well be honest and say I'm doing this for my own convenience. Why?

- Printout information is redundant. You can just examine the virus dish directly and it provides the same information.
- There's a manual "print" button in the machine anyway. Use that if you really like paper.
- The printouts get spit out all over the tile and clutter up the top of the machine if you let them pile up. Makes it hard to stuff the next dish in if you work fast.
- It's inconvenient to constantly have to flush them down disposals, especially on non-Box maps that have disposals far away from the analyzer. Virology is _really_ cluttered as it is; a single person has to deal with monkeys, beakers, vials, syringes, radium, antitoxin, virus food, blood, infected blood, virus dishes, four machines, two scanners, etc., and getting rid of paper would make the virologists' job just a touch less intimidating.

Fixes https://github.com/d3athrow/vgstation13/issues/11673, which had no comments and a single upvote (that means the gods assent to merging this ASAP). While this doesn't add a toggle, the option to manually print has always been there, so it's essentially the same thing.

<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl: (as the emoji)
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
