### PR TITLE
Fixes #12922

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -340,6 +340,8 @@ var/global/list/alert_overlays_global = list()
 	return TRUE
 
 /obj/machinery/door/firedoor/horror_force(var/mob/living/carbon/human/H)
+	if(!ishorrorform(H))
+		return FALSE
 	return force_open(H)
 
 /obj/machinery/door/firedoor/close()


### PR DESCRIPTION
Whoops. I had tested this before when the horror form force open firelock had a delay and decided to just replace it with the crowbar action because it was unnecessarily slow, didn't realize I had replaced the sanity with it too.