### PR TITLE
Makes webbings have a tech value of materials 2

### DIFF
--- a/code/modules/clothing/accessories/storage.dm
+++ b/code/modules/clothing/accessories/storage.dm
@@ -67,6 +67,7 @@
 	desc = "Sturdy mess of synthcotton belts and buckles, ready to share your burden."
 	icon_state = "webbing"
 	_color = "webbing"
+	origin_tech = Tc_MATERIALS + "=2"
 
 /obj/item/clothing/accessory/storage/webbing/paramed
 	name = "paramedic webbing"


### PR DESCRIPTION
This allows you to decontruct the webbings for research in a Destructive Analyzer and allows mechanics to scan and reproduce

:cl:
 * tweak: Webbings can now be deconstructed with a research value of materials 2
 * tweak: Mechanics can now scan and reproduce webbings
