### PR TITLE
Simplified virus2 stage definition

### DIFF
--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -216,7 +216,7 @@ var/global/list/virusDB = list()
 	r += "<BR>Spread form : [spreadtype]"
 	r += "<BR>Progress Speed : [stageprob]"
 	for(var/datum/disease2/effectholder/E in effects)
-		r += "<BR>Effect:[E.effect.name]. Strength : [E.multiplier]. Verosity : [E.chance]. Type : [5-E.stage]."
+		r += "<BR>Effect:[E.effect.name]. Strength : [E.multiplier]. Verosity : [E.chance]. Type : [E.stage]."
 
 	r += "<BR>Antigen pattern: [antigens2string(antigen)]"
 	return r

--- a/code/modules/virus2/diseasesplicer.dm
+++ b/code/modules/virus2/diseasesplicer.dm
@@ -59,9 +59,9 @@
 		if(memorybank)
 			dat += "<A href='?src=\ref[src];splice=1'>"
 			if(analysed)
-				dat += "[memorybank.effect.name] ([5-memorybank.effect.stage])"
+				dat += "[memorybank.effect.name] ([memorybank.effect.stage])"
 			else
-				dat += "Unknown DNA strand ([5-memorybank.effect.stage])"
+				dat += "Unknown DNA strand ([memorybank.effect.stage])"
 			dat += "</a>"
 
 			dat += "<BR><A href='?src=\ref[src];disk=1'>Burn DNA Sequence to data storage disk</a>"
@@ -77,7 +77,7 @@
 						dat += "<BR><A href='?src=\ref[src];grab=\ref[e]'> DNA strand"
 						if(dish.analysed)
 							dat += ": [e.effect.name]"
-						dat += " (5-[e.effect.stage])</a>"
+						dat += " ([e.effect.stage])</a>"
 				else
 					dat += "<BR>Insufficent cells to attempt gene splicing."
 			else
@@ -111,9 +111,9 @@
 		if(!burning)
 			var/obj/item/weapon/diseasedisk/d = new /obj/item/weapon/diseasedisk(src.loc)
 			if(analysed)
-				d.name = "[memorybank.effect.name] GNA disk (Stage: [5-memorybank.effect.stage])"
+				d.name = "[memorybank.effect.name] GNA disk (Stage: [memorybank.effect.stage])"
 			else
-				d.name = "Unknown GNA disk (Stage: [5-memorybank.effect.stage])"
+				d.name = "Unknown GNA disk (Stage: [memorybank.effect.stage])"
 			d.effect = memorybank
 			alert_noise("ping")
 

--- a/code/modules/virus2/items_devices.dm
+++ b/code/modules/virus2/items_devices.dm
@@ -78,7 +78,7 @@
 	var/stage = 1
 
 /obj/item/weapon/diseasedisk/premade/New()
-	name = "Blank GNA disk (stage: [5-stage])"
+	name = "Blank GNA disk (stage: [stage])"
 	effect = new /datum/disease2/effectholder
 	effect.effect = new /datum/disease2/effect/invisible
 	effect.stage = stage


### PR DESCRIPTION
- stage x effects are displayed to the user as "stage x" effect, instead of "stage 5-x" effect, which matches the disease stage code

Tested all four virology machines and shift-examine, injected into self with first stage correctly going first, no errors