### PR TITLE
Shrapnel for improvised explosives

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -53,8 +53,8 @@
 	var/vending_cat = null// subcategory for vending machines.
 	var/list/dynamic_overlay[0] //For items which need to slightly alter their on-mob appearance while being worn.
 
-	var/shrapnel_amount = 0 // How many pieces of shrapnel it disintegrates into. This variable also decides it the item disintegrates or not!
-	var/shrapnel_type = ""
+	var/shrapnel_amount = 0 // How many pieces of shrapnel it disintegrates into.
+	var/shrapnel_type = null
 	var/shrapnel_size = 1
 
 /obj/item/proc/return_thermal_protection()
@@ -1071,15 +1071,8 @@ var/global/list/image/blood_overlays = list()
 /obj/item/animationBolt(var/mob/firer)
 	new /mob/living/simple_animal/hostile/mimic/copy(loc, src, firer, duration=SPELL_ANIMATION_TTL)
 
-/obj/item/proc/is_worn(mob/user)
-	var/mob/living/carbon/monkey/Mo = user
-	var/mob/living/carbon/human/H = user
-
-	if(!istype(H) && !istype(Mo))
-		return FALSE
-	var/mob/M = user
-	for(var/bit = 0 to 15)
-		bit = 1 << bit
-		if(bit & slot_flags)
-			if(M.get_item_by_flag(bit) == src)
-				return TRUE
+/obj/item/proc/get_shrapnel_projectile()
+	if(shrapnel_type)
+		return new shrapnel_type(src)
+	else
+		return 0

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -53,9 +53,9 @@
 	var/vending_cat = null// subcategory for vending machines.
 	var/list/dynamic_overlay[0] //For items which need to slightly alter their on-mob appearance while being worn.
 
-	var/is_shrapnel = 0
-	var/shrapnel_amount = 0
+	var/shrapnel_amount = 0 // How many pieces of shrapnel it disintegrates into. This variable also decides it the item disintegrates or not!
 	var/shrapnel_type = ""
+	var/shrapnel_size = 1
 
 /obj/item/proc/return_thermal_protection()
 	return return_cover_protection(body_parts_covered) * (1 - src.heat_conductivity)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -8,7 +8,6 @@
 	var/r_speed = 1.0
 	var/health = null
 	var/hitsound = null
-
 	var/w_class = W_CLASS_MEDIUM
 	var/attack_delay = 10 //Delay between attacking with this item, in 1/10s of a second (default = 1 second)
 
@@ -53,6 +52,10 @@
 
 	var/vending_cat = null// subcategory for vending machines.
 	var/list/dynamic_overlay[0] //For items which need to slightly alter their on-mob appearance while being worn.
+
+	var/is_shrapnel = 0
+	var/shrapnel_amount = 0
+	var/shrapnel_type = ""
 
 /obj/item/proc/return_thermal_protection()
 	return return_cover_protection(body_parts_covered) * (1 - src.heat_conductivity)

--- a/code/game/objects/items/weapons/grenades/ghettobomb.dm
+++ b/code/game/objects/items/weapons/grenades/ghettobomb.dm
@@ -30,7 +30,10 @@
 	var/assembled = 0
 	active = 1
 	det_time = 50
-
+	var/ammo_type = "/obj/item/ammo_casing/c38"
+	var/list/shrapnel_list = new()
+	var/max_shrapnel = 10
+	var/current_shrapnel = 0
 
 
 /obj/item/weapon/grenade/iedcasing/afterattack(atom/target, mob/user , flag) //Filling up the can
@@ -61,7 +64,34 @@
 			name = "improvised explosive"
 			active = 0
 			det_time = rand(30,80)
+	else
+		if(assembled == 2 && current_shrapnel < max_shrapnel )
+			if(I.is_shrapnel && I.w_class == W_CLASS_TINY || I.w_class == W_CLASS_TINY || I.is_shrapnel)
+				if(user.drop_item(I, src))
+					shrapnel_list.Add(I)
+					I.forceMove(src)
+					to_chat(user, "<span  class='notice'>You add the [I] to the improvised explosive.</span>")
+					playsound(get_turf(src), 'sound/items/Deconstruct.ogg', 25, 1)
+					current_shrapnel++
 
+/*
+/obj/item/weapon/grenade/iedcasing/verb/remove_shrapnel()
+
+	set name = "Remove shrapnel"
+	set category = "Object"
+
+	if(assembled == 2 && shrapnel_list.len > 0)
+
+		var/i
+		to_chat(usr, "<span  class='notice'>You remove all the shrapnel from the improvised explosive.</span>")
+		current_shrapnel = 0
+		for(i=1, i<=shrapnel_list.len, i++)
+
+			var/obj/item/shrapnel = shrapnel_list[i]
+			shrapnel.forceMove(getTurf(src))
+			shrapnel_list.Remove(shrapnel_list[i])
+
+*/
 /obj/item/weapon/grenade/iedcasing/attack_self(mob/user as mob) //Activating the IED
 	if(!active)
 		if(clown_check(user))
@@ -85,6 +115,38 @@
 /obj/item/weapon/grenade/iedcasing/prime() //Blowing that can up
 	update_mob()
 	explosion(get_turf(src.loc),-1,0,2)
+	if(shrapnel_list.len > 0)
+		var/i
+		var/atom/target
+		var/list/bodyparts = list("head","chest","groin","l_arm","r_arm","l_hand","r_hand","l_leg","r_leg","l_foot","r_foot")
+		for(i=1, i<=shrapnel_list.len, i++)
+			var/obj/item/shrapnel = shrapnel_list[i]
+			if(shrapnel.is_shrapnel)
+
+				var/amount = shrapnel.shrapnel_amount
+
+				while(amount > 0)
+					amount = amount - 1
+					target =pick(trange(6, src.loc))
+					var/obj/item/projectile/bullet/shrapnel_projectile = new shrapnel.shrapnel_type(src) //obj/item/projectile/bullet/shrapnel
+					shrapnel_projectile.forceMove(src.loc)
+					shrapnel_projectile.original = target
+					shrapnel_projectile.starting = src.loc
+					shrapnel_projectile.shot_from = src
+					shrapnel_projectile.current = src.loc
+					shrapnel_projectile.OnFired()
+					shrapnel_projectile.yo = target.loc.y - src.loc.y
+					shrapnel_projectile.xo = target.loc.x - src.loc.x
+					shrapnel_projectile.def_zone = bodyparts[rand(1,bodyparts.len)]
+					qdel(shrapnel)
+
+					if(shrapnel_projectile)
+
+						shrapnel_projectile.process()
+
+			else
+				shrapnel.forceMove(src.loc)
+				shrapnel.throw_at(target,100,10)
 
 	if(istype(loc, /obj/item/weapon/legcuffs/beartrap))
 		var/obj/item/weapon/legcuffs/beartrap/boomtrap = loc
@@ -109,6 +171,18 @@
     desc = "A weak, improvised explosive."
     assembled = 2
     active = 0
+
+/obj/item/weapon/grenade/iedcasing/preassembled/withshrapnel
+//	var/list/shrapnel_list = new()
+	var/please_work = "obj/item/toy/crayon/red"
+
+/obj/item/weapon/grenade/iedcasing/preassembled/withshrapnel/New()
+	..()
+	shrapnel_list.Add(new /obj/item/weapon/shard(src))
+	shrapnel_list.Add(new /obj/item/weapon/shard(src))
+	shrapnel_list.Add(new /obj/item/weapon/shard(src))
+	shrapnel_list.Add(new /obj/item/weapon/shard(src))
+	shrapnel_list.Add(new /obj/item/weapon/shard(src))
 
 /obj/item/weapon/grenade/iedcasing/preassembled/New()
     ..()

--- a/code/game/objects/items/weapons/grenades/ghettobomb.dm
+++ b/code/game/objects/items/weapons/grenades/ghettobomb.dm
@@ -68,7 +68,6 @@
 			if(I.is_shrapnel && I.w_class == W_CLASS_TINY || I.w_class == W_CLASS_TINY || I.is_shrapnel)
 				if(user.drop_item(I, src))
 					shrapnel_list.Add(I)
-					I.forceMove(src)
 					to_chat(user, "<span  class='notice'>You add the [I] to the improvised explosive.</span>")
 					playsound(get_turf(src), 'sound/items/Deconstruct.ogg', 25, 1)
 					current_shrapnel++
@@ -125,7 +124,7 @@
 				var/amount = shrapnel.shrapnel_amount
 
 				while(amount > 0)
-					amount = amount - 1
+					amount--
 					target =pick(trange(6, src.loc))
 					var/obj/item/projectile/bullet/shrapnel_projectile = new shrapnel.shrapnel_type(src) //obj/item/projectile/bullet/shrapnel
 					shrapnel_projectile.forceMove(src.loc)
@@ -173,8 +172,7 @@
     active = 0
 
 /obj/item/weapon/grenade/iedcasing/preassembled/withshrapnel
-//	var/list/shrapnel_list = new()
-	var/please_work = "obj/item/toy/crayon/red"
+	name = "shrapnel loaded improvised explosive"
 
 /obj/item/weapon/grenade/iedcasing/preassembled/withshrapnel/New()
 	..()

--- a/code/game/objects/items/weapons/grenades/ghettobomb.dm
+++ b/code/game/objects/items/weapons/grenades/ghettobomb.dm
@@ -130,32 +130,21 @@
 	if(shrapnel_list.len > 0)
 		var/atom/target
 		var/atom/curloc = get_turf(src)
-		var/list/possbile_targets= trange(6, curloc)
+		var/list/possbile_targets= trange(8, curloc)
 
 		var/list/bodyparts = list("head","chest","groin","l_arm","r_arm","l_hand","r_hand","l_leg","r_leg","l_foot","r_foot")
 		for(var/obj/item/shrapnel in shrapnel_list)
 			if(shrapnel.shrapnel_amount >0)
-
 				var/amount = shrapnel.shrapnel_amount
-
 				while(amount > 0)
 					amount--
 					target =pick(possbile_targets)
 					var/obj/item/projectile/bullet/shrapnel_projectile = new shrapnel.shrapnel_type(src) //obj/item/projectile/bullet/shrapnel
 					shrapnel_projectile.forceMove(curloc)
-					shrapnel_projectile.original = target
-					shrapnel_projectile.starting = curloc
-					shrapnel_projectile.shot_from = src
-					shrapnel_projectile.current = curloc
-					shrapnel_projectile.OnFired()
-					shrapnel_projectile.yo = target.loc.y - curloc.y
-					shrapnel_projectile.xo = target.loc.x - curloc.x
-					shrapnel_projectile.def_zone = bodyparts[rand(1,bodyparts.len)]
+					shrapnel_projectile.launch_at(target,bodyparts[rand(1,bodyparts.len)],curloc,src)
 					qdel(shrapnel)
 
-					if(shrapnel_projectile)
 
-						shrapnel_projectile.process()
 
 			else
 				target =pick(possbile_targets)

--- a/code/game/objects/items/weapons/grenades/ghettobomb.dm
+++ b/code/game/objects/items/weapons/grenades/ghettobomb.dm
@@ -71,7 +71,7 @@
 						shrapnel_list.Add(I)
 						to_chat(user, "<span  class='notice'>You add the [I] to the improvised explosive.</span>")
 						playsound(get_turf(src), 'sound/items/Deconstruct.ogg', 25, 1)
-						current_shrapnel = current_shrapnel + I.shrapnel_size
+						current_shrapnel =+ I.shrapnel_size
 			else
 				to_chat(user, "<span  class='notice'>There is no room for the [I] in the improvised explosive!.</span>")
 
@@ -92,7 +92,7 @@
 
 			shrapnel.forceMove(get_turf(src))
 			shrapnel_list.Remove(shrapnel)
-			current_shrapnel = current_shrapnel - shrapnel.shrapnel_size
+		current_shrapnel = 0
 
 /obj/item/weapon/grenade/iedcasing/attack_self(mob/user as mob) //Activating the IED
 	if(!active)

--- a/code/game/objects/items/weapons/grenades/ghettobomb.dm
+++ b/code/game/objects/items/weapons/grenades/ghettobomb.dm
@@ -130,24 +130,25 @@
 	if(shrapnel_list.len > 0)
 		var/atom/target
 		var/atom/curloc = get_turf(src)
-		var/list/possbile_targets= trange(8, curloc)
+		var/list/possible_targets= new()
 
 		var/list/bodyparts = list("head","chest","groin","l_arm","r_arm","l_hand","r_hand","l_leg","r_leg","l_foot","r_foot")
 		for(var/obj/item/shrapnel in shrapnel_list)
 			if(shrapnel.shrapnel_amount >0)
 				var/amount = shrapnel.shrapnel_amount
+				possible_targets = trange(6, curloc)
 				while(amount > 0)
 					amount--
-					target =pick(possbile_targets)
-					var/obj/item/projectile/bullet/shrapnel_projectile = new shrapnel.shrapnel_type(src) //obj/item/projectile/bullet/shrapnel
+					target =pick(possible_targets)
+					var/obj/item/projectile/bullet/shrapnel_projectile = new shrapnel.shrapnel_type(src)
 					shrapnel_projectile.forceMove(curloc)
+					shrapnel_projectile.kill_count = rand(6,10)//killcount=max squares traveled before the projectile is deleted. Limits shrapnel range
 					shrapnel_projectile.launch_at(target,bodyparts[rand(1,bodyparts.len)],curloc,src)
 					qdel(shrapnel)
 
-
-
 			else
-				target =pick(possbile_targets)
+				possible_targets = trange(9, curloc)
+				target =pick(possible_targets)
 				shrapnel.forceMove(curloc)
 				shrapnel.throw_at(target,100,10)
 

--- a/code/game/objects/items/weapons/grenades/ghettobomb.dm
+++ b/code/game/objects/items/weapons/grenades/ghettobomb.dm
@@ -30,7 +30,6 @@
 	var/assembled = 0
 	active = 1
 	det_time = 50
-	var/ammo_type = "/obj/item/ammo_casing/c38"
 	var/list/shrapnel_list = new()
 	var/max_shrapnel = 8
 	var/current_shrapnel = 0

--- a/code/game/objects/items/weapons/grenades/ghettobomb.dm
+++ b/code/game/objects/items/weapons/grenades/ghettobomb.dm
@@ -32,7 +32,7 @@
 	det_time = 50
 	var/ammo_type = "/obj/item/ammo_casing/c38"
 	var/list/shrapnel_list = new()
-	var/max_shrapnel = 10
+	var/max_shrapnel = 8
 	var/current_shrapnel = 0
 
 
@@ -145,6 +145,7 @@
 						shrapnel_projectile.process()
 
 			else
+				target =pick(trange(6, src.loc))
 				shrapnel.forceMove(src.loc)
 				shrapnel.throw_at(target,100,10)
 

--- a/code/game/objects/items/weapons/grenades/ghettobomb.dm
+++ b/code/game/objects/items/weapons/grenades/ghettobomb.dm
@@ -148,26 +148,35 @@
 	if(shrapnel_list.len > 0)
 		var/atom/target
 		var/atom/curloc = get_turf(src)
-		var/list/possible_targets= new()
+		var/list/possible_targets= trange(7, curloc)
 		var/list/bodyparts = list("head","chest","groin","l_arm","r_arm","l_hand","r_hand","l_leg","r_leg","l_foot","r_foot")
 		for(var/obj/item/shrapnel in shrapnel_list)
-			if(shrapnel.shrapnel_amount >0)
-				var/amount = shrapnel.shrapnel_amount
-				possible_targets = trange(6, curloc)
-				while(amount > 0)
-					amount--
-					target =pick(possible_targets)
-					var/obj/item/projectile/bullet/shrapnel_projectile = new shrapnel.shrapnel_type(src)
-					shrapnel_projectile.forceMove(curloc)
-					shrapnel_projectile.kill_count = rand(6,10)//killcount=max squares traveled before the projectile is deleted. Limits shrapnel range
-					shrapnel_projectile.launch_at(target,bodyparts[rand(1,bodyparts.len)],curloc,src)
-					qdel(shrapnel)
-
-			else
-				possible_targets = trange(9, curloc)
+			if(istype(shrapnel, /obj/item/ammo_casing))// If the shrapnel is a bullet casing it will be fired
+				var/obj/item/ammo_casing/shrapnel_bullet = shrapnel //shitcode but otherwise BB is undefined var
+				var/obj/item/projectile/shrapnel_projectile = null
 				target =pick(possible_targets)
-				shrapnel.forceMove(curloc)
-				shrapnel.throw_at(target,9,10)
+				if(shrapnel_bullet.BB)
+					shrapnel_projectile = shrapnel_bullet.BB
+				else
+					shrapnel_projectile = new /obj/item/projectile/bullet/shrapnel/small
+				shrapnel_projectile.forceMove(curloc)
+				shrapnel_projectile.launch_at(target,bodyparts[rand(1,bodyparts.len)],curloc,src)
+				qdel(shrapnel) // the casing is disintegrated in the explosion
+			else // elif doesnt work even though its in the dm ref
+				if(shrapnel.shrapnel_amount >0)
+					var/amount = shrapnel.shrapnel_amount
+					while(amount > 0)
+						amount--
+						target =pick(possible_targets)
+						var/obj/item/projectile/bullet/shrapnel_projectile = new shrapnel.shrapnel_type(src)
+						shrapnel_projectile.forceMove(curloc)
+						shrapnel_projectile.kill_count = rand(6,10)//killcount=max squares traveled before the projectile is deleted. Limits shrapnel range
+						shrapnel_projectile.launch_at(target,bodyparts[rand(1,bodyparts.len)],curloc,src)
+						qdel(shrapnel)
+				else
+					target =pick(possible_targets)
+					shrapnel.forceMove(curloc)
+					shrapnel.throw_at(target,9,10)
 
 /obj/item/weapon/grenade/iedcasing/examine(mob/user)
 	..()

--- a/code/game/objects/items/weapons/grenades/ghettobomb.dm
+++ b/code/game/objects/items/weapons/grenades/ghettobomb.dm
@@ -64,17 +64,8 @@
 			active = 0
 			det_time = rand(30,80)
 	else
-		if(assembled == 2)
-			if((current_shrapnel + I.shrapnel_size)<= max_shrapnel )
-				if(I.shrapnel_amount > 0|| I.w_class == W_CLASS_TINY)
-					if(user.drop_item(I, src))
-						shrapnel_list.Add(I)
-						to_chat(user, "<span  class='notice'>You add the [I] to the improvised explosive.</span>")
-						playsound(get_turf(src), 'sound/items/Deconstruct.ogg', 25, 1)
-						current_shrapnel += I.shrapnel_size
-			else
-				to_chat(user, "<span  class='notice'>There is no room for the [I] in the improvised explosive!.</span>")
 
+		AddShrapnel(I,user)
 
 
 
@@ -114,12 +105,33 @@
 			spawn(det_time)
 				prime()
 
+
+/obj/item/weapon/grenade/iedcasing/proc/AddShrapnel(var/obj/item/I, mob/user as mob)
+
+	if(assembled == 2)
+		if((current_shrapnel + I.shrapnel_size)<= max_shrapnel )
+			if(I.shrapnel_amount > 0|| I.w_class == W_CLASS_TINY)
+				shrapnel_list.Add(I)
+				current_shrapnel += I.shrapnel_size
+				if(user.drop_item(I, src))
+					to_chat(user, "<span  class='notice'>You add \the [I] to the improvised explosive.</span>")
+					playsound(get_turf(src), 'sound/items/Deconstruct.ogg', 25, 1)
+				else
+					I.forceMove(src)
+
+	else
+		if(user)
+			to_chat(user, "<span  class='notice'>There is no room for \the [I] in the improvised explosive!.</span>")
+
+
 /obj/item/weapon/grenade/iedcasing/prime() //Blowing that can up
 	update_mob()
 	explosion(get_turf(src.loc),-1,0,2)
 	if(shrapnel_list.len > 0)
 		var/atom/target
 		var/atom/curloc = get_turf(src)
+		var/list/possbile_targets= trange(6, curloc)
+
 		var/list/bodyparts = list("head","chest","groin","l_arm","r_arm","l_hand","r_hand","l_leg","r_leg","l_foot","r_foot")
 		for(var/obj/item/shrapnel in shrapnel_list)
 			if(shrapnel.shrapnel_amount >0)
@@ -128,7 +140,7 @@
 
 				while(amount > 0)
 					amount--
-					target =pick(trange(6, curloc))
+					target =pick(possbile_targets)
 					var/obj/item/projectile/bullet/shrapnel_projectile = new shrapnel.shrapnel_type(src) //obj/item/projectile/bullet/shrapnel
 					shrapnel_projectile.forceMove(curloc)
 					shrapnel_projectile.original = target
@@ -146,7 +158,7 @@
 						shrapnel_projectile.process()
 
 			else
-				target =pick(trange(6, curloc))
+				target =pick(possbile_targets)
 				shrapnel.forceMove(curloc)
 				shrapnel.throw_at(target,100,10)
 
@@ -179,11 +191,9 @@
 
 /obj/item/weapon/grenade/iedcasing/preassembled/withshrapnel/New()
 	..()
-	shrapnel_list.Add(new /obj/item/weapon/shard(src))
-	shrapnel_list.Add(new /obj/item/weapon/shard(src))
-	shrapnel_list.Add(new /obj/item/weapon/shard(src))
-	shrapnel_list.Add(new /obj/item/weapon/shard(src))
-	current_shrapnel = 8
+	for(var/i = 1, i<=4,i++)
+		AddShrapnel(new /obj/item/weapon/shard(src), null)
+
 
 /obj/item/weapon/grenade/iedcasing/preassembled/New()
     ..()

--- a/code/game/objects/items/weapons/grenades/ghettobomb.dm
+++ b/code/game/objects/items/weapons/grenades/ghettobomb.dm
@@ -127,11 +127,28 @@
 /obj/item/weapon/grenade/iedcasing/prime() //Blowing that can up
 	update_mob()
 	explosion(get_turf(src.loc),-1,0,2)
+	process_shrapnel()
+
+	if(istype(loc, /obj/item/weapon/legcuffs/beartrap))
+		var/obj/item/weapon/legcuffs/beartrap/boomtrap = loc
+		if(istype(boomtrap.loc, /mob/living/carbon/human))
+			var/mob/living/carbon/human/H = loc.loc
+			if(H.legcuffed == boomtrap)
+				var/datum/organ/external/leg = H.get_organ("[pick("l","r")]_leg") //Either left or right leg
+				if(leg && !(leg.status & ORGAN_DESTROYED))
+					leg.droplimb(1,0)
+
+				qdel(H.legcuffed)
+				H.legcuffed = null
+	qdel(src)
+
+
+/obj/item/weapon/grenade/iedcasing/proc/process_shrapnel()
+
 	if(shrapnel_list.len > 0)
 		var/atom/target
 		var/atom/curloc = get_turf(src)
 		var/list/possible_targets= new()
-
 		var/list/bodyparts = list("head","chest","groin","l_arm","r_arm","l_hand","r_hand","l_leg","r_leg","l_foot","r_foot")
 		for(var/obj/item/shrapnel in shrapnel_list)
 			if(shrapnel.shrapnel_amount >0)
@@ -150,20 +167,7 @@
 				possible_targets = trange(9, curloc)
 				target =pick(possible_targets)
 				shrapnel.forceMove(curloc)
-				shrapnel.throw_at(target,100,10)
-
-	if(istype(loc, /obj/item/weapon/legcuffs/beartrap))
-		var/obj/item/weapon/legcuffs/beartrap/boomtrap = loc
-		if(istype(boomtrap.loc, /mob/living/carbon/human))
-			var/mob/living/carbon/human/H = loc.loc
-			if(H.legcuffed == boomtrap)
-				var/datum/organ/external/leg = H.get_organ("[pick("l","r")]_leg") //Either left or right leg
-				if(leg && !(leg.status & ORGAN_DESTROYED))
-					leg.droplimb(1,0)
-
-				qdel(H.legcuffed)
-				H.legcuffed = null
-	qdel(src)
+				shrapnel.throw_at(target,9,10)
 
 /obj/item/weapon/grenade/iedcasing/examine(mob/user)
 	..()

--- a/code/game/objects/items/weapons/grenades/ghettobomb.dm
+++ b/code/game/objects/items/weapons/grenades/ghettobomb.dm
@@ -119,9 +119,9 @@
 				else
 					I.forceMove(src)
 
-	else
-		if(user)
-			to_chat(user, "<span  class='notice'>There is no room for \the [I] in the improvised explosive!.</span>")
+		else
+			if(user)
+				to_chat(user, "<span  class='notice'>There is no room for \the [I] in the improvised explosive!.</span>")
 
 
 /obj/item/weapon/grenade/iedcasing/prime() //Blowing that can up

--- a/code/game/objects/items/weapons/grenades/ghettobomb.dm
+++ b/code/game/objects/items/weapons/grenades/ghettobomb.dm
@@ -154,11 +154,11 @@
 			if(istype(shrapnel, /obj/item/ammo_casing))// If the shrapnel is a bullet casing it will be fired
 				var/obj/item/ammo_casing/shrapnel_bullet = shrapnel //shitcode but otherwise BB is undefined var
 				var/obj/item/projectile/shrapnel_projectile = null
-				target =pick(possible_targets)
+				target=pick(possible_targets)
 				if(shrapnel_bullet.BB)
 					shrapnel_projectile = shrapnel_bullet.BB
 				else
-					shrapnel_projectile = new /obj/item/projectile/bullet/shrapnel/small
+					shrapnel_projectile = new /obj/item/projectile/bullet/shrapnel/small(src)
 				shrapnel_projectile.forceMove(curloc)
 				shrapnel_projectile.launch_at(target,bodyparts[rand(1,bodyparts.len)],curloc,src)
 				qdel(shrapnel) // the casing is disintegrated in the explosion

--- a/code/game/objects/items/weapons/grenades/ghettobomb.dm
+++ b/code/game/objects/items/weapons/grenades/ghettobomb.dm
@@ -160,27 +160,6 @@
 					shrapnel_projectile.forceMove(curloc)
 					shrapnel_projectile.launch_at(target,bodyparts[rand(1,bodyparts.len)],curloc,src)
 				qdel(shrapnel)
-			/*if(istype(shrapnel, /obj/item/ammo_casing))// If the shrapnel is a bullet casing it will be fired
-				var/obj/item/ammo_casing/shrapnel_bullet = shrapnel //shitcode but otherwise BB is undefined var
-				var/obj/item/projectile/shrapnel_projectile = null
-				target=pick(possible_targets)
-				if(shrapnel_bullet.BB)
-					shrapnel_projectile = shrapnel_bullet.BB
-				else
-					shrapnel_projectile = new /obj/item/projectile/bullet/shrapnel/small(src)
-				shrapnel_projectile.forceMove(curloc)
-				shrapnel_projectile.launch_at(target,bodyparts[rand(1,bodyparts.len)],curloc,src)
-				qdel(shrapnel) // the casing is disintegrated in the explosion
-			else if(shrapnel.shrapnel_amount >0)
-				var/amount = shrapnel.shrapnel_amount
-				while(amount > 0)
-					amount--
-					target =pick(possible_targets)
-					var/obj/item/projectile/bullet/shrapnel_projectile = new shrapnel.shrapnel_type(src)
-					shrapnel_projectile.forceMove(curloc)
-					shrapnel_projectile.kill_count = rand(6,10)//killcount=max squares traveled before the projectile is deleted. Limits shrapnel range
-					shrapnel_projectile.launch_at(target,bodyparts[rand(1,bodyparts.len)],curloc,src)
-					qdel(shrapnel)*/
 			else
 				target =pick(possible_targets)
 				shrapnel.forceMove(curloc)

--- a/code/game/objects/items/weapons/grenades/ghettobomb.dm
+++ b/code/game/objects/items/weapons/grenades/ghettobomb.dm
@@ -113,7 +113,7 @@
 			if(I.shrapnel_amount > 0|| I.w_class == W_CLASS_TINY)
 				shrapnel_list.Add(I)
 				current_shrapnel += I.shrapnel_size
-				if(user.drop_item(I, src))
+				if(user && user.drop_item(I, src))
 					to_chat(user, "<span  class='notice'>You add \the [I] to the improvised explosive.</span>")
 					playsound(get_turf(src), 'sound/items/Deconstruct.ogg', 25, 1)
 				else
@@ -162,21 +162,20 @@
 				shrapnel_projectile.forceMove(curloc)
 				shrapnel_projectile.launch_at(target,bodyparts[rand(1,bodyparts.len)],curloc,src)
 				qdel(shrapnel) // the casing is disintegrated in the explosion
-			else // elif doesnt work even though its in the dm ref
-				if(shrapnel.shrapnel_amount >0)
-					var/amount = shrapnel.shrapnel_amount
-					while(amount > 0)
-						amount--
-						target =pick(possible_targets)
-						var/obj/item/projectile/bullet/shrapnel_projectile = new shrapnel.shrapnel_type(src)
-						shrapnel_projectile.forceMove(curloc)
-						shrapnel_projectile.kill_count = rand(6,10)//killcount=max squares traveled before the projectile is deleted. Limits shrapnel range
-						shrapnel_projectile.launch_at(target,bodyparts[rand(1,bodyparts.len)],curloc,src)
-						qdel(shrapnel)
-				else
+			else if(shrapnel.shrapnel_amount >0)
+				var/amount = shrapnel.shrapnel_amount
+				while(amount > 0)
+					amount--
 					target =pick(possible_targets)
-					shrapnel.forceMove(curloc)
-					shrapnel.throw_at(target,9,10)
+					var/obj/item/projectile/bullet/shrapnel_projectile = new shrapnel.shrapnel_type(src)
+					shrapnel_projectile.forceMove(curloc)
+					shrapnel_projectile.kill_count = rand(6,10)//killcount=max squares traveled before the projectile is deleted. Limits shrapnel range
+					shrapnel_projectile.launch_at(target,bodyparts[rand(1,bodyparts.len)],curloc,src)
+					qdel(shrapnel)
+			else
+				target =pick(possible_targets)
+				shrapnel.forceMove(curloc)
+				shrapnel.throw_at(target,9,10)
 
 /obj/item/weapon/grenade/iedcasing/examine(mob/user)
 	..()

--- a/code/game/objects/items/weapons/grenades/ghettobomb.dm
+++ b/code/game/objects/items/weapons/grenades/ghettobomb.dm
@@ -183,7 +183,7 @@
 	shrapnel_list.Add(new /obj/item/weapon/shard(src))
 	shrapnel_list.Add(new /obj/item/weapon/shard(src))
 	shrapnel_list.Add(new /obj/item/weapon/shard(src))
-	shrapnel_list.Add(new /obj/item/weapon/shard(src))
+	current_shrapnel = 8
 
 /obj/item/weapon/grenade/iedcasing/preassembled/New()
     ..()

--- a/code/game/objects/items/weapons/grenades/ghettobomb.dm
+++ b/code/game/objects/items/weapons/grenades/ghettobomb.dm
@@ -151,7 +151,16 @@
 		var/list/possible_targets= trange(7, curloc)
 		var/list/bodyparts = list("head","chest","groin","l_arm","r_arm","l_hand","r_hand","l_leg","r_leg","l_foot","r_foot")
 		for(var/obj/item/shrapnel in shrapnel_list)
-			if(istype(shrapnel, /obj/item/ammo_casing))// If the shrapnel is a bullet casing it will be fired
+			var/amount = shrapnel.shrapnel_amount
+			if(amount)
+				while(amount > 0)
+					amount--
+					var/obj/item/projectile/shrapnel_projectile = shrapnel.get_shrapnel_projectile()
+					target=pick(possible_targets)
+					shrapnel_projectile.forceMove(curloc)
+					shrapnel_projectile.launch_at(target,bodyparts[rand(1,bodyparts.len)],curloc,src)
+				qdel(shrapnel)
+			/*if(istype(shrapnel, /obj/item/ammo_casing))// If the shrapnel is a bullet casing it will be fired
 				var/obj/item/ammo_casing/shrapnel_bullet = shrapnel //shitcode but otherwise BB is undefined var
 				var/obj/item/projectile/shrapnel_projectile = null
 				target=pick(possible_targets)
@@ -171,7 +180,7 @@
 					shrapnel_projectile.forceMove(curloc)
 					shrapnel_projectile.kill_count = rand(6,10)//killcount=max squares traveled before the projectile is deleted. Limits shrapnel range
 					shrapnel_projectile.launch_at(target,bodyparts[rand(1,bodyparts.len)],curloc,src)
-					qdel(shrapnel)
+					qdel(shrapnel)*/
 			else
 				target =pick(possible_targets)
 				shrapnel.forceMove(curloc)

--- a/code/game/objects/items/weapons/grenades/ghettobomb.dm
+++ b/code/game/objects/items/weapons/grenades/ghettobomb.dm
@@ -71,7 +71,7 @@
 						shrapnel_list.Add(I)
 						to_chat(user, "<span  class='notice'>You add the [I] to the improvised explosive.</span>")
 						playsound(get_turf(src), 'sound/items/Deconstruct.ogg', 25, 1)
-						current_shrapnel =+ I.shrapnel_size
+						current_shrapnel += I.shrapnel_size
 			else
 				to_chat(user, "<span  class='notice'>There is no room for the [I] in the improvised explosive!.</span>")
 

--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -26,6 +26,9 @@
 	siemens_coefficient = 1
 	origin_tech = Tc_MATERIALS + "=1"
 	attack_verb = list("attacks", "stabs", "pokes")
+	shrapnel_amount = 1
+	shrapnel_size = 2
+	shrapnel_type = "/obj/item/projectile/bullet/shrapnel"
 
 /obj/item/weapon/kitchen/utensil/New()
 	. = ..()

--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -207,6 +207,7 @@
 	melt_temperature = MELTPOINT_STEEL
 	origin_tech = Tc_MATERIALS + "=1"
 	attack_verb = list("slashes", "stabs", "slices", "tears", "rips", "dices", "cuts")
+	shrapnel_amount = 0
 
 /obj/item/weapon/kitchen/utensil/knife/large/attackby(obj/item/weapon/W, mob/user)
 	..()

--- a/code/game/objects/items/weapons/shard.dm
+++ b/code/game/objects/items/weapons/shard.dm
@@ -21,7 +21,7 @@
 	attack_verb = list("stabs", "slashes", "slices", "cuts")
 	var/glass = /obj/item/stack/sheet/glass/glass
 	shrapnel_amount = 3
-	shrapnel_type = "/obj/item/projectile/bullet/shrapnel"
+	shrapnel_type = "/obj/item/projectile/bullet/shrapnel/small"
 	shrapnel_size = 2
 
 /obj/item/weapon/shard/New()
@@ -49,6 +49,7 @@
 	icon_state = "plasmalarge"
 	item_state = "shard-plasglass"
 	glass = /obj/item/stack/sheet/glass/plasmaglass
+	shrapnel_type = "/obj/item/projectile/bullet/shrapnel/small/plasma"
 
 /obj/item/weapon/shard/plasma/New()
 	..()

--- a/code/game/objects/items/weapons/shard.dm
+++ b/code/game/objects/items/weapons/shard.dm
@@ -20,6 +20,9 @@
 	siemens_coefficient = 0 //no conduct
 	attack_verb = list("stabs", "slashes", "slices", "cuts")
 	var/glass = /obj/item/stack/sheet/glass/glass
+	is_shrapnel = 1
+	shrapnel_amount = 5
+	shrapnel_type = "/obj/item/projectile/bullet/shrapnel"
 
 /obj/item/weapon/shard/New()
 

--- a/code/game/objects/items/weapons/shard.dm
+++ b/code/game/objects/items/weapons/shard.dm
@@ -21,7 +21,7 @@
 	attack_verb = list("stabs", "slashes", "slices", "cuts")
 	var/glass = /obj/item/stack/sheet/glass/glass
 	is_shrapnel = 1
-	shrapnel_amount = 5
+	shrapnel_amount = 3
 	shrapnel_type = "/obj/item/projectile/bullet/shrapnel"
 
 /obj/item/weapon/shard/New()

--- a/code/game/objects/items/weapons/shard.dm
+++ b/code/game/objects/items/weapons/shard.dm
@@ -20,9 +20,9 @@
 	siemens_coefficient = 0 //no conduct
 	attack_verb = list("stabs", "slashes", "slices", "cuts")
 	var/glass = /obj/item/stack/sheet/glass/glass
-	is_shrapnel = 1
 	shrapnel_amount = 3
 	shrapnel_type = "/obj/item/projectile/bullet/shrapnel"
+	shrapnel_size = 2
 
 /obj/item/weapon/shard/New()
 

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -22,6 +22,7 @@
 		BB = new projectile_type(src)
 	update_icon()
 
+
 /obj/item/ammo_casing/update_icon()
 	pixel_x = rand(-10, 10) * PIXEL_MULTIPLIER
 	pixel_y = rand(-10, 10) * PIXEL_MULTIPLIER

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -32,7 +32,10 @@
 
 /obj/item/ammo_casing/get_shrapnel_projectile()
 	if(BB)
-		return BB
+
+		var/obj/item/projectile/bullet_bill = BB
+		BB = null
+		return bullet_bill
 	..()
 
 

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -11,6 +11,9 @@
 	var/caliber = ""							//Which kind of guns it can be loaded into
 	var/projectile_type = ""//The bullet type to create when New() is called
 	var/obj/item/projectile/BB = null 			//The loaded bullet
+	shrapnel_amount = 1
+	shrapnel_type = "/obj/item/projectile/bullet/shrapnel/small"
+	shrapnel_size = 1
 
 
 /obj/item/ammo_casing/New()
@@ -26,6 +29,11 @@
 	name = "[BB ? "" : "spent "][initial(name)]"
 	icon_state = "[initial(icon_state)][BB ? "-live" : ""]"
 	desc = "[initial(desc)][BB ? "" : " This one is spent."]"
+
+/obj/item/ammo_casing/get_shrapnel_projectile()
+	if(BB)
+		return BB
+	..()
 
 
 //Boxes of ammo

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -710,3 +710,15 @@ var/list/impact_master = list()
 
 /obj/item/projectile/acidable()
 	return 0
+
+/obj/item/projectile/proc/launch_at(var/atom/target,var/tar_zone = "chest",var/atom/curloc = get_turf(src),var/shot_from = null) // doot doot shitcode alert
+	original = target
+	starting = curloc
+	shot_from = src
+	current = curloc
+	OnFired()
+	yo = target.loc.y - curloc.y
+	xo = target.loc.x - curloc.x
+	def_zone = tar_zone
+	spawn()
+		process()

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -711,10 +711,10 @@ var/list/impact_master = list()
 /obj/item/projectile/acidable()
 	return 0
 
-/obj/item/projectile/proc/launch_at(var/atom/target,var/tar_zone = "chest",var/atom/curloc = get_turf(src),var/shot_from = null) // doot doot shitcode alert
+/obj/item/projectile/proc/launch_at(var/atom/target,var/tar_zone = "chest",var/atom/curloc = get_turf(src),var/from = null) // doot doot shitcode alert
 	original = target
 	starting = curloc
-	shot_from = src
+	shot_from = from
 	current = curloc
 	OnFired()
 	yo = target.loc.y - curloc.y

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -31,6 +31,7 @@
 	weaken = 1
 	stun = 5
 
+
 /obj/item/projectile/bullet/shrapnel/small
 
 	name = "small shrapnel"

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -23,6 +23,19 @@
 	damage_type = TOX
 	weaken = 5
 
+/obj/item/projectile/bullet/shrapnel
+
+	name = "shrapnel"
+	damage = 55
+	damage_type = BRUTE
+	weaken = 1
+	stun = 1
+
+/obj/item/projectile/bullet/shrapnel/small
+
+	name = "small shrapnel"
+	damage = 35
+
 /obj/item/projectile/bullet/weakbullet
 	name = "weak bullet"
 	icon_state = "bbshell"

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -26,15 +26,23 @@
 /obj/item/projectile/bullet/shrapnel
 
 	name = "shrapnel"
-	damage = 35
+	damage = 45
 	damage_type = BRUTE
 	weaken = 1
-	stun = 1
+	stun = 5
 
 /obj/item/projectile/bullet/shrapnel/small
 
 	name = "small shrapnel"
-	damage = 20
+	damage = 25
+
+/obj/item/projectile/bullet/shrapnel/small/plasma
+
+	name = "small plasma shrapnel"
+	damage_type = TOX
+	color = "#BF5FFF"¨
+	damage = 35
+
 
 /obj/item/projectile/bullet/weakbullet
 	name = "weak bullet"

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -26,7 +26,7 @@
 /obj/item/projectile/bullet/shrapnel
 
 	name = "shrapnel"
-	damage = 55
+	damage = 35
 	damage_type = BRUTE
 	weaken = 1
 	stun = 1
@@ -34,7 +34,7 @@
 /obj/item/projectile/bullet/shrapnel/small
 
 	name = "small shrapnel"
-	damage = 35
+	damage = 20
 
 /obj/item/projectile/bullet/weakbullet
 	name = "weak bullet"

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -40,7 +40,7 @@
 
 	name = "small plasma shrapnel"
 	damage_type = TOX
-	color = "#BF5FFF"¨
+	color = "#BF5FFF"
 	damage = 35
 
 

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -31,6 +31,11 @@
 	weaken = 1
 	stun = 3
 
+/obj/item/projectile/bullet/shrapnel/New()
+	..()
+	kill_count = rand(6,10)
+
+
 
 /obj/item/projectile/bullet/shrapnel/small
 

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -29,7 +29,7 @@
 	damage = 45
 	damage_type = BRUTE
 	weaken = 1
-	stun = 5
+	stun = 3
 
 
 /obj/item/projectile/bullet/shrapnel/small


### PR DESCRIPTION
In reponse to #12398

Allows players to add any w_class_tiny item to an improvised explosive. The items will then launch out in random directions when it explodes. Some items, not necessarily tiny, will disintegrate into shrapnel which deals spicy damage. The code makes it semi simple to add custom types of shrapnel for certain items in the future.

The numbers for those who do not want to read through the code:

 * 8 item slots in each explosive. (Previously 10) Shards take up 2 slots (Previously 1)

 * Shards disintegrate into 3 pieces of **small** shrapnel (Previously 5 normal sized)

 * Standard shrapnel deals 45 damage and small shrapnel 25. Shrapnel is child of projectile/bullet (Previously 55 damage for standard shrapnel)

 * Shrapnel targets a random bodypart

 * Plasma shards produce purple TOX damage (35) shrapnel
 
 * Kitchen utensils produce 1 standard shrapnel and take up 2 slots each

 * Individual pieces of shrapnel have a random range limit of 6 to 10 squares

 * Bullet casings fire their projectile if its not already spent.

* All spent bullet casings are small shrapnel.

As it is now this is fairly balanced tbh. Its a buff to the IED for sure but it was trash earlier.

Clip of some crayons and 5 shards: https://puu.sh/sVJ5o.mp4

:cl:

 * rscadd: Shrapnel, in the form of tiny items and shards, can be added to improvised explosives.