### PR TITLE
Buffs/Reworks Medical Nanobots to be more consistent

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -2453,7 +2453,7 @@
 	color = "#3E3959" //rgb: 62, 57, 89
 
 
-//Great healing powers. Metabolizes quickly and rapidly heals all damage types.
+//Great healing powers. Metabolizes extremely slowly, but gets used up when it heals damage.
 //Dangerous in amounts over 5 units, healing that occurs while over 5 units adds to a counter. That counter affects gib chance. Guaranteed gib over 20 units.
 /datum/reagent/mednanobots
 	name = "Medical Nanobots"
@@ -2461,7 +2461,7 @@
 	description = "Microscopic robots intended for use in humans. Configured for rapid healing upon infiltration into the body."
 	reagent_state = LIQUID
 	color = "#593948" //rgb: 89, 57, 72
-	custom_metabolism = 0.5
+	custom_metabolism = 0.005
 	var/spawning_horror = 0
 	var/percent_machine = 0
 
@@ -2471,25 +2471,18 @@
 		return 1
 
 	switch(volume)
-		if(0.5 to 5)
+		if(0.1 to 5)
 			if(ishuman(M))
 				var/mob/living/carbon/human/H = M
 				if(H.species.name != "Diona")
-					if(H.getOxyLoss()>0 && prob(100))
+					if(H.getOxyLoss()>0 || H.getBruteLoss()>0 || H.getToxLoss()>0 || H.getFireLoss()>0 || H.getCloneLoss()>0)
 						if(holder.has_reagent("mednanobots"))
-							H.adjustOxyLoss(-7)
-					if(H.getBruteLoss()>0 && prob(100))
-						if(holder.has_reagent("mednanobots"))
-							H.heal_organ_damage(7, 0)
-					if(H.getFireLoss()>0 && prob(100))
-						if(holder.has_reagent("mednanobots"))
-							H.heal_organ_damage(0, 7)
-					if(H.getToxLoss()>0 && prob(100))
-						if(holder.has_reagent("mednanobots"))
-							H.adjustToxLoss(-7)
-					if(H.getCloneLoss()>0 && prob(100))
-						if(holder.has_reagent("mednanobots"))
-							H.adjustCloneLoss(-7)
+							H.adjustOxyLoss(-5)
+							H.heal_organ_damage(5, 5)
+							H.adjustToxLoss(-5)
+							H.adjustCloneLoss(-5)
+							holder.remove_reagent("mednanobots", 10/40)  //The number/40 means that every time it heals, it uses up number/40ths of a unit, meaning each unit heals 40 damage
+					if(percent_machine>5)
 						if(holder.has_reagent("mednanobots"))
 							percent_machine-=1
 							if(prob(20))
@@ -2507,37 +2500,13 @@
 			if(ishuman(M))
 				var/mob/living/carbon/human/H = M
 				if(H.species.name != "Diona")
-					if(H.getOxyLoss()>0 && prob(100))
+					if(H.getOxyLoss()>0 || H.getBruteLoss()>0 || H.getToxLoss()>0 || H.getFireLoss()>0 || H.getCloneLoss()>0)
 						if(holder.has_reagent("mednanobots"))
-							H.adjustOxyLoss(-7)
-							percent_machine +=1/2
-							if(prob(20))
-								to_chat(H, pick("<span class='warning'>Something shifts inside you...</span>", "<span class='warning'>You feel different, somehow...</span>"))
-							else
-					if(H.getBruteLoss()>0 && prob(100))
-						if(holder.has_reagent("mednanobots"))
-							H.heal_organ_damage(7, 0)
-							percent_machine +=1/2
-							if(prob(20))
-								to_chat(H, pick("<span class='warning'>Something shifts inside you...</span>", "<span class='warning'>You feel different, somehow...</span>"))
-							else
-					if(H.getFireLoss()>0 && prob(100))
-						if(holder.has_reagent("mednanobots"))
-							H.heal_organ_damage(0, 7)
-							percent_machine +=1/2
-							if(prob(20))
-								to_chat(H, pick("<span class='warning'>Something shifts inside you...</span>", "<span class='warning'>You feel different, somehow...</span>"))
-							else
-					if(H.getToxLoss()>0 && prob(100))
-						if(holder.has_reagent("mednanobots"))
-							H.adjustToxLoss(-7)
-							percent_machine +=1/2
-							if(prob(20))
-								to_chat(H, pick("<span class='warning'>Something shifts inside you...</span>", "<span class='warning'>You feel different, somehow...</span>"))
-							else
-					if(H.getCloneLoss()>0 && prob(100))
-						if(holder.has_reagent("mednanobots"))
-							H.adjustCloneLoss(-7)
+							H.adjustOxyLoss(-5)
+							H.heal_organ_damage(5, 5)
+							H.adjustToxLoss(-5)
+							H.adjustCloneLoss(-5)
+							holder.remove_reagent("mednanobots", 10/40)  //The number/40 means that every time it heals, it uses up number/40ths of a unit, meaning each unit heals 40 damage
 							percent_machine +=1/2
 							if(prob(20))
 								to_chat(H, pick("<span class='warning'>Something shifts inside you...</span>", "<span class='warning'>You feel different, somehow...</span>"))

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -2453,7 +2453,7 @@
 	color = "#3E3959" //rgb: 62, 57, 89
 
 
-//Great healing powers. Metabolizes extremely slowly, but gets used up when it heals damage.
+//Great healing powers. Metabolizes quickly and rapidly heals all damage types.
 //Dangerous in amounts over 5 units, healing that occurs while over 5 units adds to a counter. That counter affects gib chance. Guaranteed gib over 20 units.
 /datum/reagent/mednanobots
 	name = "Medical Nanobots"
@@ -2461,7 +2461,7 @@
 	description = "Microscopic robots intended for use in humans. Configured for rapid healing upon infiltration into the body."
 	reagent_state = LIQUID
 	color = "#593948" //rgb: 89, 57, 72
-	custom_metabolism = 0.005
+	custom_metabolism = 0.5
 	var/spawning_horror = 0
 	var/percent_machine = 0
 
@@ -2471,40 +2471,25 @@
 		return 1
 
 	switch(volume)
-		if(1 to 5)
+		if(0.5 to 5)
 			if(ishuman(M))
 				var/mob/living/carbon/human/H = M
 				if(H.species.name != "Diona")
-					var/datum/organ/external/affecting = H.get_organ()
-					for(var/datum/wound/W in affecting.wounds)
-						spawn(1)
-							affecting.wounds -= W
-							H.visible_message("<span class='warning'>[H]'s wounds close up in the blink of an eye!</span>")
-					if(H.getOxyLoss()>0 && prob(90))
+					if(H.getOxyLoss()>0 && prob(100))
 						if(holder.has_reagent("mednanobots"))
-							H.adjustOxyLoss(-4)
-							holder.remove_reagent("mednanobots", 4/40)  //The number/40 means that every time it heals, it uses up number/40ths of a unit, meaning each unit heals 40 damage
-						else
-					if(H.getBruteLoss()>0 && prob(90))
+							H.adjustOxyLoss(-7)
+					if(H.getBruteLoss()>0 && prob(100))
 						if(holder.has_reagent("mednanobots"))
-							H.heal_organ_damage(5, 0)
-							holder.remove_reagent("mednanobots", 5/40)
-						else
-					if(H.getFireLoss()>0 && prob(90))
+							H.heal_organ_damage(7, 0)
+					if(H.getFireLoss()>0 && prob(100))
 						if(holder.has_reagent("mednanobots"))
-							H.heal_organ_damage(0, 5)
-							holder.remove_reagent("mednanobots", 5/40)
-						else
-					if(H.getToxLoss()>0 && prob(50))
+							H.heal_organ_damage(0, 7)
+					if(H.getToxLoss()>0 && prob(100))
 						if(holder.has_reagent("mednanobots"))
-							H.adjustToxLoss(-2)
-							holder.remove_reagent("mednanobots", 2/40)
-						else
-					if(H.getCloneLoss()>0 && prob(60))
+							H.adjustToxLoss(-7)
+					if(H.getCloneLoss()>0 && prob(100))
 						if(holder.has_reagent("mednanobots"))
-							H.adjustCloneLoss(-2)
-							holder.remove_reagent("mednanobots", 2/40)
-					if(percent_machine>5)
+							H.adjustCloneLoss(-7)
 						if(holder.has_reagent("mednanobots"))
 							percent_machine-=1
 							if(prob(20))
@@ -2522,56 +2507,41 @@
 			if(ishuman(M))
 				var/mob/living/carbon/human/H = M
 				if(H.species.name != "Diona")
-					var/datum/organ/external/affecting = H.get_organ()
-					for(var/datum/wound/W in affecting.wounds)
-						spawn(1)
-							affecting.wounds -= W
-							H.visible_message("<span class='warning'>[H]'s wounds close up in the blink of an eye!</span>")
-					if(H.getOxyLoss()>0 && prob(90))
+					if(H.getOxyLoss()>0 && prob(100))
 						if(holder.has_reagent("mednanobots"))
-							H.adjustOxyLoss(-4)
-							holder.remove_reagent("mednanobots", 4/40)  //The number/40 means that every time it heals, it uses up number/40ths of a unit, meaning each unit heals 40 damage
+							H.adjustOxyLoss(-7)
 							percent_machine +=1/2
 							if(prob(20))
 								to_chat(H, pick("<span class='warning'>Something shifts inside you...</span>", "<span class='warning'>You feel different, somehow...</span>"))
 							else
-						else
-					if(H.getBruteLoss()>0 && prob(90))
+					if(H.getBruteLoss()>0 && prob(100))
 						if(holder.has_reagent("mednanobots"))
-							H.heal_organ_damage(5, 0)
-							holder.remove_reagent("mednanobots", 5/40)
+							H.heal_organ_damage(7, 0)
 							percent_machine +=1/2
 							if(prob(20))
 								to_chat(H, pick("<span class='warning'>Something shifts inside you...</span>", "<span class='warning'>You feel different, somehow...</span>"))
 							else
-						else
-					if(H.getFireLoss()>0 && prob(90))
+					if(H.getFireLoss()>0 && prob(100))
 						if(holder.has_reagent("mednanobots"))
-							H.heal_organ_damage(0, 5)
-							holder.remove_reagent("mednanobots", 5/40)
+							H.heal_organ_damage(0, 7)
 							percent_machine +=1/2
 							if(prob(20))
 								to_chat(H, pick("<span class='warning'>Something shifts inside you...</span>", "<span class='warning'>You feel different, somehow...</span>"))
 							else
-						else
-					if(H.getToxLoss()>0 && prob(50))
+					if(H.getToxLoss()>0 && prob(100))
 						if(holder.has_reagent("mednanobots"))
-							H.adjustToxLoss(-2)
-							holder.remove_reagent("mednanobots", 2/40)
+							H.adjustToxLoss(-7)
 							percent_machine +=1/2
 							if(prob(20))
 								to_chat(H, pick("<span class='warning'>Something shifts inside you...</span>", "<span class='warning'>You feel different, somehow...</span>"))
 							else
-						else
-					if(H.getCloneLoss()>0 && prob(60))
+					if(H.getCloneLoss()>0 && prob(100))
 						if(holder.has_reagent("mednanobots"))
-							H.adjustCloneLoss(-2)
-							holder.remove_reagent("mednanobots", 2/40)
+							H.adjustCloneLoss(-7)
 							percent_machine +=1/2
 							if(prob(20))
 								to_chat(H, pick("<span class='warning'>Something shifts inside you...</span>", "<span class='warning'>You feel different, somehow...</span>"))
 							else
-						else
 					if(H.dizziness != 0)
 						H.dizziness = max(0, H.dizziness - 15)
 					if(H.confused != 0)


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl: (as the emoji)
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
**Reasons for my PR**

Medical Nanobots are horribly inconsistent and downright awful against anything that isn't brute or burn. It heals one damage type every tick and with an added RNG system makes it so that other damage types(Namely toxin and oxy) have a lower chance of being selected compared to brute/burn, and when they are selected they get healed a measly 2 for toxin and 4 for oxygen.

Another issue was that medical nanobots would instantly and fully heal the chest area without any extra reagent consumed and only the chest area, other limbs would tick on at the standard pace.
I would assume that this was a bug rather than intended, but if this was fixed to apply to all areas then mednanos would make you effectively immortal against anything that isn't a pulse rifle.

---

It has now been changed to heal all damage types simultaneously for 5 every tick. For balance reasons it has been made so that it uses up slightly more with each tick.
There are no changes to the overdose limits or how they work. You still run a high risk of gibbing should you go over 5u.

**All in all, I want people to give their opinion on this and if it is unpopular I will trash it. Not a lot of people use mednanos as it is and they are ironically not that good unless the chest is wounded.
The number might need changing if deemed to overpowered etc**

Closes #12782

:cl:
* Medical Nanobots have been reworked to be more consistent and to heal all damage types simultaneously