### PR TITLE
PDA alt-click and ctrl-click swapped

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -2113,7 +2113,7 @@ obj/item/device/pda/CtrlClick()
 
 obj/item/device/pda/AltClick()
 	if ( can_use(usr) ) // Checks that the PDA is in our inventory. This will be checked by the proc anyways, but we don't want to generate an error message if not.
-		verb_remove_pen(usr)
+		verb_remove_id(usr)
 		return
 	return ..()
 

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -2084,7 +2084,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 
 obj/item/device/pda/CtrlClick()
 	if ( can_use(usr) ) // Checks that the PDA is in our inventory. This will be checked by the proc anyways, but we don't want to generate an error message if not.
-		verb_remove_id(usr)
+		verb_remove_pen(usr)
 		return
 	return ..()
 


### PR DESCRIPTION
Far more people will be convenienced by this change than inconvenienced.

:cl:
 * tweak: "Alt-clicking and control-clicking a PDA have now been swapped. Alt-click to eject ID card and control-click to eject pen."