### PR TITLE
Vapor Salts Dry Floors

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1487,9 +1487,21 @@
 /datum/reagent/vaporsalt
 	name = "Vapor Salts"
 	id = VAPORSALT
-	description = "A strange mineral found in alien plantlife that behaves strangely in the presence of certain gasses in liquid form."
+	description = "A strange mineral found in alien plantlife that has been observed to vaporize some liquids."
 	reagent_state = LIQUID
 	color = "#BDE5F2"
+
+
+/datum/reagent/vaporsalt/reaction_turf(var/turf/simulated/T, var/volume)
+
+	if(..())
+		return 1
+
+	if(T.wet)
+		T.dry(TURF_WET_LUBE) //Cleans water or lube
+		var/obj/effect/effect/smoke/S = new /obj/effect/effect/smoke(T)
+		S.time_to_live = 10 //unusually short smoke
+		//We don't need to start up the system because we only want to smoke one tile.
 
 /datum/reagent/iron
 	name = "Iron"

--- a/html/changelogs/Kurfurst.yml
+++ b/html/changelogs/Kurfurst.yml
@@ -1,0 +1,5 @@
+author: Kurfurst
+delete-after: True
+
+changes: 
+- rscadd: Vapor salts will now dry wet floors and cause a very brief smoke effect.


### PR DESCRIPTION
For a long time I've wanted a way to dispense with lube other than waiting it out, and also to encourage more vapor salts to be sold onto the station.  Vapor salts now dry lubed and wet floors, and cause a very brief (10% of normal length) smoke effect on **the cleaned tile only**.

I think good trade is rare enough that lube remains a significant threat, but vapor salts can provide some relief in the most miserable of "all floors coated" situations.