### PR TITLE
Smart Laser Gun

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -686,7 +686,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/gun/energy/laser/smart)
 	cost = 60
 	containertype = /obj/structure/closet/crate/secure/weapon
-	containername = "Smart laser gun crate"
+	containername = "smart laser gun crate"
 	access = access_armory
 	group = "Security"
 

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -678,6 +678,18 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	access = access_security
 	group = "Security"
 
+/datum/supply_packs/smartlaser
+	name = "Smart laser gun crate"
+	contains = list(/obj/item/weapon/gun/energy/laser/smart,
+					/obj/item/weapon/gun/energy/laser/smart,
+					/obj/item/weapon/gun/energy/laser/smart,
+					/obj/item/weapon/gun/energy/laser/smart)
+	cost = 60
+	containertype = /obj/structure/closet/crate/secure/weapon
+	containername = "Smart laser gun crate"
+	access = access_armory
+	group = "Security"
+
 /datum/supply_packs/eweapons
 	name = "Incendiary weapons crate"
 	contains = list(/obj/item/weapon/gun/projectile/flamethrower/full,

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -348,8 +348,8 @@
 	else
 		to_chat(user, "<span class='warning'>You can't aim the gun properly from this location!</span>")
 
-/obj/item/weapon/gun/check_pai_can_fire(mob/living/silicon/pai/user)	//for various restrictions on when pAIs can fire a gun into which they're integrated
-	if(get_holder_of_type(user, /obj/structure/disposalpipe) || get_holder_of_type(user, /obj/machinery/atmospherics/pipe)	//can't fire the gun from inside pipes or disposal pipes
+/obj/item/weapon/gun/proc/check_pai_can_fire(mob/living/silicon/pai/user)	//for various restrictions on when pAIs can fire a gun into which they're integrated
+	if(get_holder_of_type(user, /obj/structure/disposalpipe) || get_holder_of_type(user, /obj/machinery/atmospherics/pipe))	//can't fire the gun from inside pipes or disposal pipes
 		return TRUE
 	else
 		return FALSE

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -125,7 +125,7 @@
 			return 0
 	return 1
 
-/obj/item/weapon/gun/proc/Fire(atom/target as mob|obj|turf|area, mob/living/user as mob|obj, params, reflex = 0, struggle = 0)//TODO: go over this
+/obj/item/weapon/gun/proc/Fire(atom/target as mob|obj|turf|area, mob/living/user as mob|obj, params, reflex = 0, struggle = 0, var/use_shooter_turf = FALSE)//TODO: go over this
 	//Exclude lasertag guns from the M_CLUMSY check.
 	if(clumsy_check)
 		if(istype(user, /mob/living))
@@ -144,6 +144,8 @@
 	var/atom/originaltarget = target
 
 	var/turf/curloc = user.loc
+	if(use_shooter_turf)
+		curloc = get_turf(user)
 	var/turf/targloc = get_turf(target)
 	if (!istype(targloc) || !istype(curloc))
 		return
@@ -339,3 +341,6 @@
 			return ..() //Allows a player to choose to melee instead of shoot, by being on help intent.
 	else
 		return ..() //Pistolwhippin'
+
+/obj/item/weapon/gun/on_integrated_pai_click(mob/living/silicon/pai/user, var/atom/A)	//to allow any gun to be pAI-compatible, on a basic level, just by varediting
+	Fire(A,user,use_shooter_turf = TRUE)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -343,4 +343,13 @@
 		return ..() //Pistolwhippin'
 
 /obj/item/weapon/gun/on_integrated_pai_click(mob/living/silicon/pai/user, var/atom/A)	//to allow any gun to be pAI-compatible, on a basic level, just by varediting
-	Fire(A,user,use_shooter_turf = TRUE)
+	if(check_pai_can_fire(user))
+		Fire(A,user,use_shooter_turf = TRUE)
+	else
+		to_chat(user, "<span class='warning'>You can't aim the gun properly from this location!</span>")
+
+/obj/item/weapon/gun/check_pai_can_fire(mob/living/silicon/pai/user)	//for various restrictions on when pAIs can fire a gun into which they're integrated
+	if(get_holder_of_type(user, /obj/structure/disposalpipe) || get_holder_of_type(user, /obj/machinery/atmospherics/pipe)	//can't fire the gun from inside pipes or disposal pipes
+		return TRUE
+	else
+		return FALSE

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -456,3 +456,9 @@
 	charge_cost = 25
 	fire_sound = 'sound/weapons/mmlbuster.ogg'
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/megabusters.dmi', "right_hand" = 'icons/mob/in-hand/right/megabusters.dmi')
+
+/obj/item/weapon/gun/energy/laser/smart
+	name = "smart laser gun"
+	desc = "An upgraded model of the basic laser gun. There seems to be some sort of slot in the handle."
+	can_take_pai = TRUE
+	origin_tech = Tc_COMBAT + "=3;" + Tc_MAGNETS + "=2;" + Tc_ENGINEERING + "=2;" + Tc_PROGRAMMING + "=4"


### PR DESCRIPTION
Adds smart laser gun, which can take pAIs by default.
Adds smart laser gun crate to Cargo, for twice the price of a standard weapons crate. It contains four smart laser guns.

Also adds framework for any gun to be usable, on a basic level, by pAI if the can_take_pAI var is changed to TRUE, opening up adminbus options.

:cl:
 * rscadd: Added smart laser guns, which can hold pAIs and be operated by them. Smart laser guns are orderable from Cargo.
