### PR TITLE
Champion of Ghosts

### DIFF
--- a/__DEFINES/reagents.dm
+++ b/__DEFINES/reagents.dm
@@ -296,6 +296,7 @@
 #define HELL_RAMEN		"hell_ramen"
 #define CLOTTING_AGENT	"clotting_agent"
 #define BIOFOAM			"biofoam"
+#define ECTOPLASM		"ectoplasm"
 #define SOY_LATTE		"soy_latte"
 #define CAFE_LATTE		"cafe_latte"
 #define NUKA_COLA		"nuka_cola"

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -46,6 +46,8 @@
 	// Our new boo spell.
 	add_spell(new /spell/aoe_turf/boo, "grey_spell_ready")
 
+	add_spell(new /spell/aoe_turf/haunt, "grey_spell_ready")
+
 	can_reenter_corpse = flags & GHOST_CAN_REENTER
 	started_as_observer = flags & GHOST_IS_OBSERVER
 

--- a/code/modules/mob/dead/observer/spells.dm
+++ b/code/modules/mob/dead/observer/spells.dm
@@ -57,3 +57,35 @@ var/global/list/boo_phrases_silicon=list(
 		for(var/atom/A in T.contents)
 			if(A.can_spook())
 				A.spook(holder)
+
+/spell/aoe_turf/haunt
+	name = "Haunt"
+	desc = "Give the living a little help."
+
+	spell_flags = STATALLOWED | GHOSTCAST
+
+	school = "transmutation"
+	charge_max = 6000
+	invocation = ""
+	invocation_type = SpI_NONE
+	range = 0
+
+	override_base = "grey"
+	hud_state = "boo"
+
+/spell/aoe_turf/haunt/before_cast(list/targets, user)
+	. = ..()
+	for(var/turf/T in targets)
+		for(var/atom/A in T.contents)
+			if(isliving(A))
+				return
+	to_chat(user, "There is nothing living here.")
+	return list()
+
+/spell/aoe_turf/haunt/cast(list/targets)
+	for(var/turf/T in targets)
+		for(var/atom/A in T.contents)
+			if(isliving(A))
+				var/mob/living/L = A
+				L.reagents.add_reagent(ECTOPLASM, 1)
+				return

--- a/code/modules/mob/dead/observer/spells.dm
+++ b/code/modules/mob/dead/observer/spells.dm
@@ -58,6 +58,8 @@ var/global/list/boo_phrases_silicon=list(
 			if(A.can_spook())
 				A.spook(holder)
 
+var/list/has_haunted = list()
+
 /spell/aoe_turf/haunt
 	name = "Haunt"
 	desc = "Give the living a little help."
@@ -75,6 +77,11 @@ var/global/list/boo_phrases_silicon=list(
 
 /spell/aoe_turf/haunt/before_cast(list/targets, user)
 	. = ..()
+	var/mob/M = user
+	if(istype(M))
+		if(has_haunted[M.key] && (world.time - has_haunted[M.key]) < charge_max)
+			to_chat(user, "You don't yet have enough power to do that again.")
+			return list()
 	for(var/turf/T in targets)
 		for(var/atom/A in T.contents)
 			if(isliving(A))
@@ -89,4 +96,7 @@ var/global/list/boo_phrases_silicon=list(
 				var/mob/living/L = A
 				L.reagents.add_reagent(ECTOPLASM, 1)
 				L.investigation_log(I_GHOST, "|| was given the hot ectoplasm dose by [key_name(holder)][holder.locked_to ? ", who was haunting [holder.locked_to]" : ""]")
+				var/mob/M = holder
+				if(istype(M))
+					has_haunted[M.key] = world.time
 				return

--- a/code/modules/mob/dead/observer/spells.dm
+++ b/code/modules/mob/dead/observer/spells.dm
@@ -88,4 +88,5 @@ var/global/list/boo_phrases_silicon=list(
 			if(isliving(A))
 				var/mob/living/L = A
 				L.reagents.add_reagent(ECTOPLASM, 1)
+				L.investigation_log(I_GHOST, "|| was given the hot ectoplasm dose by [key_name(holder)][holder.locked_to ? ", who was haunting [holder.locked_to]" : ""]")
 				return

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1508,6 +1508,7 @@
 		to_chat(src, "<i>[pick(boo_phrases)]</i>")
 	else
 		to_chat(src, "<b><font color='[pick("red","orange","yellow","green","blue")]'>[pick(boo_phrases_drugs)]</font></b>")
+	reagents.add_reagent(ECTOPLASM, 1)
 
 // Makes all robotic limbs organic.
 /mob/living/carbon/human/proc/make_robot_limbs_organic()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1508,7 +1508,6 @@
 		to_chat(src, "<i>[pick(boo_phrases)]</i>")
 	else
 		to_chat(src, "<b><font color='[pick("red","orange","yellow","green","blue")]'>[pick(boo_phrases_drugs)]</font></b>")
-	reagents.add_reagent(ECTOPLASM, 1)
 
 // Makes all robotic limbs organic.
 /mob/living/carbon/human/proc/make_robot_limbs_organic()

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -165,6 +165,8 @@ var/const/BLOOD_VOLUME_SURVIVE = 122
 				blood_max = blood_max * 0.7
 			/*if(reagents.has_reagent(INAPROVALINE))
 				blood_max = blood_max * 0.7*/
+			if(reagents.has_reagent(ECTOPLASM))
+				blood_max *= 0.7
 		drip(blood_max)
 
 //Makes a blood drop, leaking amt units of blood from the mob

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -495,7 +495,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	for(var/datum/wound/W in wounds)
 		//Internal wounds get worse over time. Low temperatures (cryo) stop them.
 		if(W.internal && !W.is_treated() && owner.bodytemperature >= 170 && !(owner.species && owner.species.anatomy_flags & NO_BLOOD))
-			if(!owner.reagents.has_reagent(BICARIDINE) && !owner.reagents.has_reagent(INAPROVALINE) && !owner.reagents.has_reagent(CLOTTING_AGENT) && !owner.reagents.has_reagent(BIOFOAM))	//Bicard, inaprovaline, clotting agent, and biofoam stop internal wounds from growing bigger with time, and also slow bleeding
+			if(!owner.reagents.has_reagent(BICARIDINE) && !owner.reagents.has_reagent(INAPROVALINE) && !owner.reagents.has_reagent(CLOTTING_AGENT) && !owner.reagents.has_reagent(BIOFOAM) && !owner.reagents.has_reagent(ECTOPLASM))	//Bicard, inaprovaline, clotting agent, biofoam, and ectoplasm stop internal wounds from growing bigger with time, and also slow bleeding
 				W.open_wound(0.1 * wound_update_accuracy)
 				owner.vessel.remove_reagent(BLOOD, 0.05 * W.damage * wound_update_accuracy)
 

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -495,7 +495,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	for(var/datum/wound/W in wounds)
 		//Internal wounds get worse over time. Low temperatures (cryo) stop them.
 		if(W.internal && !W.is_treated() && owner.bodytemperature >= 170 && !(owner.species && owner.species.anatomy_flags & NO_BLOOD))
-			if(!owner.reagents.has_reagent(BICARIDINE) && !owner.reagents.has_reagent(INAPROVALINE) && !owner.reagents.has_reagent(CLOTTING_AGENT) && !owner.reagents.has_reagent(BIOFOAM) && !owner.reagents.has_reagent(ECTOPLASM))	//Bicard, inaprovaline, clotting agent, biofoam, and ectoplasm stop internal wounds from growing bigger with time, and also slow bleeding
+			if(!owner.reagents.has_any_reagents(list(BICARIDINE,INAPROVALINE,CLOTTING_AGENT,BIOFOAM,ECTOPLASM)))	//Bicard, inaprovaline, clotting agent, biofoam, and ectoplasm stop internal wounds from growing bigger with time, and also slow bleeding
 				W.open_wound(0.1 * wound_update_accuracy)
 				owner.vessel.remove_reagent(BLOOD, 0.05 * W.damage * wound_update_accuracy)
 

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -608,6 +608,19 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 		return amount_cache[reagent] >= max(0,amount)
 	return 0
 
+/datum/reagents/proc/has_any_reagents(var/list/input_reagents, var/amount = -1)		//returns true if any of the input reagents are found
+	var/has = FALSE
+	for(var/i in input_reagents)
+		if(has_reagent(i, amount))
+			has = TRUE
+	return has
+
+/datum/reagents/proc/has_all_reagents(var/list/input_reagents, var/amount = -1)		//returns true if all of the input reagents are found
+	for(var/i in input_reagents)
+		if(!has_reagent(i, amount))
+			return FALSE
+	return TRUE
+
 /datum/reagents/proc/get_reagent(var/reagent, var/amount = -1)
 	// SLOWWWWWWW
 	for(var/A in reagent_list)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -3647,7 +3647,6 @@
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		H.shock_stage--
-		H.traumatic_shock--
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////DRINKS BELOW, Beer is up there though, along with cola. Cap'n Pete's Cuban Spiced Rum//////////

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -3629,6 +3629,26 @@
 	color = "#D9C0E7" //rgb: 217, 192, 231
 	custom_metabolism = 0.1
 
+/datum/reagent/ectoplasm	//This chem also slows external bleeding by 30% and internal bleeding by 70%
+	name = "Ectoplasm"
+	id = ECTOPLASM
+	description = "Concentrated ghostly essence."
+	reagent_state = LIQUID
+	color = "#02E816" //rgb: 2, 232, 22 (does not support alpha channels - yet!)
+	alpha = 140
+
+/datum/reagent/ectoplasm/on_mob_life(var/mob/living/M)
+
+	if(..())
+		return 1
+
+	M.adjustOxyLoss(-2 * REM)
+
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		H.shock_stage--
+		H.traumatic_shock--
+
 /////////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////DRINKS BELOW, Beer is up there though, along with cola. Cap'n Pete's Cuban Spiced Rum//////////
 /////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -3636,6 +3636,7 @@
 	reagent_state = LIQUID
 	color = "#02E816" //rgb: 2, 232, 22 (does not support alpha channels - yet!)
 	alpha = 140
+	pain_resistance = 60
 
 /datum/reagent/ectoplasm/on_mob_life(var/mob/living/M)
 
@@ -3643,10 +3644,6 @@
 		return 1
 
 	M.adjustOxyLoss(-2 * REM)
-
-	if(ishuman(M))
-		var/mob/living/carbon/human/H = M
-		H.shock_stage--
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////DRINKS BELOW, Beer is up there though, along with cola. Cap'n Pete's Cuban Spiced Rum//////////


### PR DESCRIPTION
Adds ectoplasm, a reagent that slows bleeding and has the effects of dexalin and paracetamol.
Adds a new spell for ghosts, Haunt. Can be cast once every ten minutes.
When Haunt is cast, a living mob on the same tile as the ghost is injected with 1u ectoplasm.

A single ghost would not be able do very much, since ghosts can only spook once per minute. But a large amount of ghosts would be able to focus their efforts on a single player, giving that player an extra bit of survivability.

Closes #8376

:cl:
 * rscadd: Added ectoplasm, a reagent that slows down bleeding and has the effects of dexalin and paracetamol.
 * rscadd: When a human is spooked by a ghost, 1u of ectoplasm is added to them.
