### PR TITLE
Service QoL Shortcuts

### DIFF
--- a/code/game/machinery/biogenerator.dm
+++ b/code/game/machinery/biogenerator.dm
@@ -329,6 +329,18 @@
 	speed_coefficient = 2/manipcount
 	biomass_coefficient = 3*lasercount
 
+/obj/machinery/biogenerator/AltClick(mob/user)
+	if(!user.incapacitated() && Adjacent(user) && user.dexterity_check())
+		eject_produce()
+		return
+	return ..()
+
+/obj/machinery/biogenerator/CtrlClick(mob/user)
+	if(!user.incapacitated() && Adjacent(user) && beaker && user.dexterity_check())
+		activate() //This proc already internally checks if the machine is in use, broken, out of power
+		return
+	return ..()
+
 /obj/machinery/biogenerator/attackby(var/obj/item/O as obj, var/mob/user as mob)
 	if(..())
 		return 1

--- a/code/game/machinery/biogenerator.dm
+++ b/code/game/machinery/biogenerator.dm
@@ -336,7 +336,7 @@
 	return ..()
 
 /obj/machinery/biogenerator/CtrlClick(mob/user)
-	if(!user.incapacitated() && Adjacent(user) && beaker && user.dexterity_check())
+	if(!user.incapacitated() && Adjacent(user) && beaker && user.dexterity_check() && anchored)
 		activate() //This proc already internally checks if the machine is in use, broken, out of power
 		return
 	return ..()

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -17,6 +17,7 @@
 	var/opened = 0.0
 	var/dirty = 0 // = {0..100} Does it need cleaning?
 	var/broken = 0 // ={0,1,2} How broken is it???
+	var/reagent_disposal = 1 //Does it empty out reagents when you eject? Default yes.
 	var/global/list/datum/recipe/available_recipes // List of the recipes you can use
 	var/global/list/acceptable_items // List of the items you can put in
 	var/global/list/acceptable_reagents // List of the reagents you can put in
@@ -276,7 +277,8 @@
 					dat += {"<b>Expected result: </b>[display_name]<br>"}
 		dat += {"\
 <A href='?src=\ref[src];action=cook'>Turn on!<BR>\
-<A href='?src=\ref[src];action=dispose'>Eject ingredients!<BR>\
+<A href='?src=\ref[src];action=dispose'>Eject ingredients!<BR><BR><BR>\
+<A href='?src=\ref[src];action=reagenttoggle'>[reagent_disposal ? "Disable reagent disposal" : "Enable reagent disposal"]<BR>\
 "}
 
 	user << browse("<HEAD><TITLE>Microwave Controls</TITLE></HEAD><TT>[dat]</TT>", "window=microwave")
@@ -387,7 +389,8 @@
 		O.forceMove(src.loc)
 	if (src.reagents.total_volume)
 		src.dirty++
-	src.reagents.clear_reagents()
+	if(reagent_disposal)
+		reagents.clear_reagents()
 	to_chat(usr, "<span class='notice'>You dispose of the microwave contents.</span>")
 	src.updateUsrDialog()
 
@@ -431,11 +434,17 @@
 	ffuu.reagents.add_reagent(TOXIN, amount/10)
 	return ffuu
 
-/obj/machinery/microwave/AltClick(mob/user)
+/obj/machinery/microwave/CtrlClick(mob/user)
     if(!user.incapacitated() && Adjacent(user) && user.dexterity_check())
         cook() //Cook checks for power, brokenness, and contents internally
         return
     return ..()
+
+/obj/machinery/microwave/AltClick(mob/user)
+	if(!user.incapacitated() && Adjacent(user) && user.dexterity_check())
+		dispose()
+		return
+	return ..()
 
 /obj/machinery/microwave/Topic(href, href_list)
 	if(..())
@@ -443,7 +452,7 @@
 
 	usr.set_machine(src)
 	if(src.operating)
-		src.updateUsrDialog()
+		updateUsrDialog()
 		return
 
 	switch(href_list["action"])
@@ -452,4 +461,8 @@
 
 		if ("dispose")
 			dispose()
+
+		if ("reagenttoggle")
+			reagent_disposal = !reagent_disposal
+			updateUsrDialog()
 	return

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -435,7 +435,7 @@
 	return ffuu
 
 /obj/machinery/microwave/CtrlClick(mob/user)
-    if(!user.incapacitated() && Adjacent(user) && user.dexterity_check())
+    if(!user.incapacitated() && Adjacent(user) && user.dexterity_check() && anchored)
         cook() //Cook checks for power, brokenness, and contents internally
         return
     return ..()

--- a/code/modules/reagents/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/machinery/reagentgrinder.dm
@@ -289,10 +289,13 @@
 
 /obj/machinery/reagentgrinder/AltClick()
 	if(!usr.incapacitated() && Adjacent(usr) && beaker && !(stat & (NOPOWER|BROKEN) && usr.dexterity_check()) && !inuse)
-		if(holdingitems.len)
-			grind()
-		else
-			detach()
+		detach()
+		return
+	return ..()
+
+/obj/machinery/reagentgrinder/CtrlClick()
+	if(!usr.incapacitated() && Adjacent(usr) && usr.dexterity_check() && !inuse && holdingitems.len)
+		grind() //Checks for beaker and power/broken internally
 		return
 	return ..()
 

--- a/code/modules/reagents/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/machinery/reagentgrinder.dm
@@ -287,14 +287,14 @@
 	beaker = null
 	update_icon()
 
-/obj/machinery/reagentgrinder/AltClick()
-	if(!usr.incapacitated() && Adjacent(usr) && beaker && !(stat & (NOPOWER|BROKEN) && usr.dexterity_check()) && !inuse)
+/obj/machinery/reagentgrinder/AltClick(mob/user)
+	if(!user.incapacitated() && Adjacent(user) && beaker && !(stat & (NOPOWER|BROKEN) && user.dexterity_check()) && !inuse)
 		detach()
 		return
 	return ..()
 
-/obj/machinery/reagentgrinder/CtrlClick()
-	if(!usr.incapacitated() && Adjacent(usr) && usr.dexterity_check() && !inuse && holdingitems.len)
+/obj/machinery/reagentgrinder/CtrlClick(mob/user)
+	if(!user.incapacitated() && Adjacent(user) && user.dexterity_check() && !inuse && holdingitems.len && anchored)
 		grind() //Checks for beaker and power/broken internally
 		return
 	return ..()

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -16,6 +16,12 @@
 	var/amount_per_transfer_from_this = 10
 	var/possible_transfer_amounts = list(10,25,50,100)
 
+/obj/structure/reagent_dispensers/AltClick(mob/user)
+	if(user.Adjacent(get_turf(src)) && possible_transfer_amounts)
+		set_APTFT()
+		return
+	return ..()
+
 /obj/structure/reagent_dispensers/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(iswrench(W) && wrenchable())
 		return wrenchAnchor(user)
@@ -219,7 +225,7 @@
 	amount_per_transfer_from_this = 5
 	icon = 'icons/obj/vending.dmi'
 	icon_state = "water_cooler"
-	possible_transfer_amounts = null
+	possible_transfer_amounts = list(5,10,30)
 	anchored = 0
 	var/addedliquid = 500
 	var/paper_cups = 10

--- a/html/changelogs/Kurfurst.yml
+++ b/html/changelogs/Kurfurst.yml
@@ -1,0 +1,11 @@
+author: Kurfurst
+delete-after: True
+
+changes: 
+- tweak: Changed the shortcut to make the grinder grind from alt+click to ctrl+click. Eject remains alt+click.
+- rscadd: You can now alt+click to change transfer amounts on any reagent dispenser (welding tank, water tank, pepper spray, etc.) that has alterante transfer amounts.
+- rscadd: Granted the water cooler alternate transfer amounts.
+- rscadd: Alt+click on the biogenerator to eject the contained produce. Ctrl+click to grind.
+- tweak: Alt+click on microwave changed to eject ingredients.
+- rscadd: Ctrl+click on microwave to cook.
+- rscadd: The microwave can now have reagent disposal disabled, so that ejecting will not waste any resources. As a general reminder, you can safely remove reagents from the microwave with a baster.


### PR DESCRIPTION
* Changed the shortcut to make the grinder grind from alt+click to ctrl+click. Eject remains alt+click. Fixes #13021
* You can now alt+click to change transfer amounts on any reagent dispenser (welding tank, water tank, pepper spray, etc.) that has alterante transfer amounts.
* Granted the water cooler alternate transfer amounts as per a thread request.
* Alt+click on the biogenerator to eject the contained produce. Ctrl+click to grind.
* Alt+click on microwave changed to eject ingredients.
* Ctrl+click on microwave to cook.
* The microwave can now have reagent disposal disabled, so that ejecting will not waste any resources

Reminder: you can safely remove reagents from a microwave with a baster or dropper.