### PR TITLE
Allows pathogenic incubator to remain on when it doesn't have a dish loaded, fixes lack of UI response, fixes overwriting blood viruses

### DIFF
--- a/code/modules/virus2/dishincubator.dm
+++ b/code/modules/virus2/dishincubator.dm
@@ -175,16 +175,16 @@
 		if(!powered(EQUIP))
 			on = 0
 			icon_state = "incubator"
-		if(dish.growth >= INCUBATOR_MAX_SIZE)
+		if(dish && dish.growth >= INCUBATOR_MAX_SIZE)
 			if(icon_state != "incubator_fed")
 				icon_state = "incubator_fed"
 			if(last_notice + FED_PING_DELAY < world.time)
 				last_notice = world.time
 				alert_noise("ping")
-		if(foodsupply && dish && dish.virus2)
+		if(dish && dish.virus2 && foodsupply)
 			foodsupply -= 1
 			dish.growth = min(growthrate + dish.growth, INCUBATOR_MAX_SIZE)
-		if(radiation && dish && dish.virus2)
+		if(dish && dish.virus2 && radiation
 			if(radiation > 50 & prob(mutatechance))
 				dish.virus2.log += "<br />[timestamp()] MAJORMUTATE (incubator rads)"
 				dish.virus2.majormutate()
@@ -197,9 +197,9 @@
 			else if(prob(mutatechance))
 				dish.virus2.minormutate()
 			radiation -= 1
-		if(toxins && prob(5) && dish && dish.virus2)
+		if(dish && dish.virus2 && toxins && prob(5))
 			dish.virus2.infectionchance -= 1
-		if(toxins > 50 && dish && dish.virus2)
+		if(dish && dish.virus2 && toxins > 50)
 			dish.virus2 = null
 	else
 		icon_state = "incubator"

--- a/code/modules/virus2/dishincubator.dm
+++ b/code/modules/virus2/dishincubator.dm
@@ -175,15 +175,15 @@
 		if(!powered(EQUIP))
 			on = 0
 			icon_state = "incubator"
+		if(dish.growth >= INCUBATOR_MAX_SIZE)
+			if(icon_state != "incubator_fed")
+				icon_state = "incubator_fed"
+			if(last_notice + FED_PING_DELAY < world.time)
+				last_notice = world.time
+				alert_noise("ping")
 		if(foodsupply && dish && dish.virus2)
 			foodsupply -= 1
 			dish.growth = min(growthrate + dish.growth, INCUBATOR_MAX_SIZE)
-			if(dish.growth >= INCUBATOR_MAX_SIZE)
-				if(icon_state != "incubator_fed")
-					icon_state = "incubator_fed"
-				if(last_notice + FED_PING_DELAY < world.time)
-					last_notice = world.time
-					alert_noise("ping")
 		if(radiation && dish && dish.virus2)
 			if(radiation > 50 & prob(mutatechance))
 				dish.virus2.log += "<br />[timestamp()] MAJORMUTATE (incubator rads)"

--- a/code/modules/virus2/dishincubator.dm
+++ b/code/modules/virus2/dishincubator.dm
@@ -170,12 +170,12 @@
 	onclose(user, "dish_incubator")
 
 /obj/machinery/disease2/incubator/process()
-	if(dish && on && dish.virus2)
+	if(on)
 		use_power(50,EQUIP)
 		if(!powered(EQUIP))
 			on = 0
 			icon_state = "incubator"
-		if(foodsupply)
+		if(foodsupply && dish && dish.virus2)
 			foodsupply -= 1
 			dish.growth = min(growthrate + dish.growth, INCUBATOR_MAX_SIZE)
 			if(dish.growth >= INCUBATOR_MAX_SIZE)
@@ -184,7 +184,7 @@
 				if(last_notice + FED_PING_DELAY < world.time)
 					last_notice = world.time
 					alert_noise("ping")
-		if(radiation)
+		if(radiation && dish && dish.virus2)
 			if(radiation > 50 & prob(mutatechance))
 				dish.virus2.log += "<br />[timestamp()] MAJORMUTATE (incubator rads)"
 				dish.virus2.majormutate()
@@ -197,12 +197,11 @@
 			else if(prob(mutatechance))
 				dish.virus2.minormutate()
 			radiation -= 1
-		if(toxins && prob(5))
+		if(toxins && prob(5) && dish && dish.virus2)
 			dish.virus2.infectionchance -= 1
-		if(toxins > 50)
+		if(toxins > 50 && dish && dish.virus2)
 			dish.virus2 = null
-	else if(!dish)
-		on = 0
+	else
 		icon_state = "incubator"
 
 	if(beaker)

--- a/code/modules/virus2/dishincubator.dm
+++ b/code/modules/virus2/dishincubator.dm
@@ -95,8 +95,6 @@
 		if(beaker)
 			beaker.forceMove(src.loc)
 			beaker = null
-	if(!dish)
-		return
 	if (href_list["power"])
 		on = !on
 		if(on)
@@ -129,8 +127,7 @@
 				var/datum/disease2/disease/D = dish.virus2.getcopy()
 				D.log += "<br />[timestamp()] Injected into blood via [src] by [key_name(usr)]"
 				var/list/virus = list("[dish.virus2.uniqueID]" = D)
-				B.data["virus2"] = virus
-
+				B.data["virus2"] += virus
 				say("Injection complete.")
 	src.add_fingerprint(usr)
 	src.updateUsrDialog()

--- a/code/modules/virus2/dishincubator.dm
+++ b/code/modules/virus2/dishincubator.dm
@@ -175,32 +175,33 @@
 		if(!powered(EQUIP))
 			on = 0
 			icon_state = "incubator"
-		if(dish && dish.growth >= INCUBATOR_MAX_SIZE)
-			if(icon_state != "incubator_fed")
-				icon_state = "incubator_fed"
-			if(last_notice + FED_PING_DELAY < world.time)
-				last_notice = world.time
-				alert_noise("ping")
-		if(dish && dish.virus2 && foodsupply)
-			foodsupply -= 1
-			dish.growth = min(growthrate + dish.growth, INCUBATOR_MAX_SIZE)
-		if(dish && dish.virus2 && radiation
-			if(radiation > 50 & prob(mutatechance))
-				dish.virus2.log += "<br />[timestamp()] MAJORMUTATE (incubator rads)"
-				dish.virus2.majormutate()
-				if(dish.info)
-					dish.info = "OUTDATED : [dish.info]"
-					dish.analysed = 0
-				alert_noise("beep")
-				flick("incubator_mut", src)
+		if (dish && dish.virus2)
+			if(dish.growth >= INCUBATOR_MAX_SIZE)
+				if(icon_state != "incubator_fed")
+					icon_state = "incubator_fed"
+				if(last_notice + FED_PING_DELAY < world.time)
+					last_notice = world.time
+					alert_noise("ping")
+			if(foodsupply)
+				foodsupply -= 1
+				dish.growth = min(growthrate + dish.growth, INCUBATOR_MAX_SIZE)
+			if(radiation)
+				if(radiation > 50 & prob(mutatechance))
+					dish.virus2.log += "<br />[timestamp()] MAJORMUTATE (incubator rads)"
+					dish.virus2.majormutate()
+					if(dish.info)
+						dish.info = "OUTDATED : [dish.info]"
+						dish.analysed = 0
+					alert_noise("beep")
+					flick("incubator_mut", src)
 
-			else if(prob(mutatechance))
-				dish.virus2.minormutate()
-			radiation -= 1
-		if(dish && dish.virus2 && toxins && prob(5))
-			dish.virus2.infectionchance -= 1
-		if(dish && dish.virus2 && toxins > 50)
-			dish.virus2 = null
+				else if(prob(mutatechance))
+					dish.virus2.minormutate()
+				radiation -= 1
+			if(toxins && prob(5))
+				dish.virus2.infectionchance -= 1
+			if(toxins > 50)
+				dish.virus2 = null
 	else
 		icon_state = "incubator"
 


### PR DESCRIPTION
Closes #11934

Tested in-game, everything works fine.

:cl:
 * tweak: Pathogenic Incubator can now remain on even when a virus dish isn't loaded.
 * bugfix: Pathogenic Incubator now always lets you radiate and flush even when a virus dish isn't loaded.
 * bugfix: Pathogenic Incubator now adds (rather than overwrites) its virus to its blood container.