### PR TITLE
effect.dm cleanup and slight tweak to babel syndrome

### DIFF
--- a/code/modules/virus2/effect.dm
+++ b/code/modules/virus2/effect.dm
@@ -1,8 +1,6 @@
-////////////////////////////////////////////////////////////////
-////////////////////////EFFECTS/////////////////////////////////
-////////////////////////////////////////////////////////////////
-// Use two newlines between each effect, and one newline between each effect's methods.
-
+// Make sure to use two newlines between each effect and one newline between each method.
+// Fully read through the example effect below to get an idea of what attributes and procs are available.
+// Babel Syndrome provides a good example of the usage of affect_voice, affect_mob_voice, etc. 
 
 /datum/disease2/effect
 	var/name = "Example syndrome"
@@ -75,413 +73,308 @@
 	return new_e
 
 
-////////////////////////SPECIAL/////////////////////////////////
+////////////////////////STAGE 1/////////////////////////////////
 
 
-/*/datum/disease2/effect/alien
-	name = "Unidentified Foreign Body"
-	stage = 4
-	activate(var/mob/living/carbon/mob)
-		to_chat(mob, "<span class='warning'>You feel something tearing its way out of your stomach...</span>")
-		mob.adjustToxLoss(10)
-		mob.updatehealth()
-		if(prob(40))
-			if(mob.client)
-				mob.client.mob = new/mob/living/carbon/alien/larva(mob.loc)
-			else
-				new/mob/living/carbon/alien/larva(mob.loc)
-			var/datum/disease2/disease/D = mob:virus2
-			mob:gib()
-			del D*/
+/datum/disease2/effect/invisible
+	name = "Waiting Syndrome"
+	stage = 1
 
-
-/datum/disease2/effect/spaceadapt
-	name = "Space Adaptation Effect"
-	stage = 5
-
-/datum/disease2/effect/spaceadapt/activate(var/mob/living/carbon/mob)
-	var/mob/living/carbon/human/H = mob
-	if (mob.reagents.get_reagent_amount(DEXALINP) < 10)
-		mob.reagents.add_reagent(DEXALINP, 4)
-	if (mob.reagents.get_reagent_amount(LEPORAZINE) < 10)
-		mob.reagents.add_reagent(LEPORAZINE, 4)
-	if (mob.reagents.get_reagent_amount(BICARIDINE) < 10)
-		mob.reagents.add_reagent(BICARIDINE, 4)
-	if (mob.reagents.get_reagent_amount(DERMALINE) < 10)
-		mob.reagents.add_reagent(DERMALINE, 4)
-	mob.emote("me",1,"exhales slowly.")
-
-	if(ishuman(H))
-		var/datum/organ/external/chest/chest = H.get_organ(LIMB_CHEST)
-		for(var/datum/organ/internal/I in chest.internal_organs)
-			I.damage = 0
-
-
-////////////////////////STAGE 4/////////////////////////////////
-
-
-/datum/disease2/effect/minttoxin
-	name = "Creosote Syndrome"
-	stage = 4
-
-/datum/disease2/effect/minttoxin/activate(var/mob/living/carbon/mob)
-	if(istype(mob) && mob.reagents.get_reagent_amount(MINTTOXIN) < 5)
-		to_chat(mob, "<span class='notice'>You feel a minty freshness</span>")
-		mob.reagents.add_reagent(MINTTOXIN, 5)
-
-
-/datum/disease2/effect/gibbingtons
-	name = "Gibbingtons Syndrome"
-	stage = 4
-	badness = 2
-
-/datum/disease2/effect/gibbingtons/activate(var/mob/living/carbon/mob)
-	mob.gib()
-
-
-/datum/disease2/effect/radian
-	name = "Radian's Syndrome"
-	stage = 4
-	max_multiplier = 3
-
-/datum/disease2/effect/radian/activate(var/mob/living/carbon/mob)
-	mob.radiation += (2*multiplier)
-
-
-/datum/disease2/effect/deaf
-	name = "Dead Ear Syndrome"
-	stage = 4
-
-/datum/disease2/effect/deaf/activate(var/mob/living/carbon/mob)
-	mob.ear_deaf += 20
-
-
-/datum/disease2/effect/monkey
-	name = "Monkism Syndrome"
-	stage = 4
-	badness = 2
-
-/datum/disease2/effect/monkey/activate(var/mob/living/carbon/mob)
-	if(istype(mob,/mob/living/carbon/human))
-		var/mob/living/carbon/human/h = mob
-		h.monkeyize()
-
-
-/datum/disease2/effect/catbeast
-	name = "Kingston Syndrome"
-	stage = 4
-	badness = 2
-
-/datum/disease2/effect/catbeast/activate(var/mob/living/carbon/mob)
-	if(istype(mob,/mob/living/carbon/human))
-		var/mob/living/carbon/human/h = mob
-		if(h.species.name != "Tajaran")
-			if(h.set_species("Tajaran"))
-				h.regenerate_icons()
-
-
-/datum/disease2/effect/voxpox
-	name = "Vox Pox"
-	stage = 4
-	badness = 2
-
-/datum/disease2/effect/voxpox/activate(var/mob/living/carbon/mob)
-	if(istype(mob,/mob/living/carbon/human))
-		var/mob/living/carbon/human/h = mob
-		if(h.species.name != "Vox")
-			if(h.set_species("Vox"))
-				h.regenerate_icons()
-
-
-/datum/disease2/effect/suicide
-	name = "Suicidal Syndrome"
-	stage = 4
-	badness = 2
-
-/datum/disease2/effect/suicide/activate(var/mob/living/carbon/mob)
-	mob.suiciding = 1
-	//instead of killing them instantly, just put them at -175 health and let 'em gasp for a while
-	to_chat(viewers(mob), "<span class='danger'>[mob.name] is holding \his breath. It looks like \he's trying to commit suicide.</span>")
-	mob.adjustOxyLoss(175 - mob.getToxLoss() - mob.getFireLoss() - mob.getBruteLoss() - mob.getOxyLoss())
-	mob.updatehealth()
-	spawn(200) //in case they get revived by cryo chamber or something stupid like that, let them suicide again in 20 seconds
-		mob.suiciding = 0
-
-
-/datum/disease2/effect/killertoxins
-	name = "Toxification Syndrome"
-	stage = 4
-
-/datum/disease2/effect/killertoxins/activate(var/mob/living/carbon/mob)
-	mob.adjustToxLoss(15*multiplier)
-
-
-/datum/disease2/effect/dna
-	name = "Reverse Pattern Syndrome"
-	stage = 4
-
-/datum/disease2/effect/dna/activate(var/mob/living/carbon/mob)
-	mob.bodytemperature = max(mob.bodytemperature, 350)
-	scramble(0,mob,10)
-	mob.apply_damage(10, CLONE)
-
-
-/datum/disease2/effect/organs
-	name = "Shutdown Syndrome"
-	stage = 4
-
-/datum/disease2/effect/organs/activate(var/mob/living/carbon/mob)
-	if(istype(mob, /mob/living/carbon/human))
-		var/mob/living/carbon/human/H = mob
-		var/organ = pick(list(LIMB_RIGHT_ARM,LIMB_LEFT_ARM,LIMB_RIGHT_LEG,LIMB_RIGHT_LEG))
-		var/datum/organ/external/E = H.organs_by_name[organ]
-		if (!(E.status & ORGAN_DEAD))
-			E.status |= ORGAN_DEAD
-			to_chat(H, "<span class='notice'>You can't feel your [E.display_name] anymore...</span>")
-			for (var/datum/organ/external/C in E.children)
-				C.status |= ORGAN_DEAD
-		H.update_body(1)
-		if(multiplier < 1)
-			multiplier = 1
-		H.adjustToxLoss(15*multiplier)
-
-/datum/disease2/effect/organs/vampire
-	stage = 3 //For use with vampires?
-
-/datum/disease2/effect/organs/deactivate(var/mob/living/carbon/mob)
-	if(istype(mob, /mob/living/carbon/human))
-		var/mob/living/carbon/human/H = mob
-		for (var/datum/organ/external/E in H.organs)
-			E.status &= ~ORGAN_DEAD
-			for (var/datum/organ/external/C in E.children)
-				C.status &= ~ORGAN_DEAD
-		H.update_body(1)
-
-
-/datum/disease2/effect/immortal
-	name = "Longevity Syndrome"
-	stage = 4
-
-/datum/disease2/effect/immortal/activate(var/mob/living/carbon/mob)
-	if(istype(mob, /mob/living/carbon/human))
-		var/mob/living/carbon/human/H = mob
-		for (var/datum/organ/external/E in H.organs)
-			if (E.status & ORGAN_BROKEN && prob(30))
-				E.status ^= ORGAN_BROKEN
-	var/heal_amt = -5*multiplier
-	mob.apply_damages(heal_amt,heal_amt,heal_amt,heal_amt)
-
-/datum/disease2/effect/immortal/deactivate(var/mob/living/carbon/mob)
-	if(istype(mob, /mob/living/carbon/human))
-		var/mob/living/carbon/human/H = mob
-		to_chat(H, "<span class='notice'>You suddenly feel hurt and old...</span>")
-		H.age += 8
-	var/backlash_amt = 5*multiplier
-	mob.apply_damages(backlash_amt,backlash_amt,backlash_amt,backlash_amt)
-
-
-/datum/disease2/effect/bones
-	name = "Fragile Bones Syndrome"
-	stage = 4
-
-/datum/disease2/effect/bones/activate(var/mob/living/carbon/mob)
-	if(istype(mob, /mob/living/carbon/human))
-		var/mob/living/carbon/human/H = mob
-		for (var/datum/organ/external/E in H.organs)
-			E.min_broken_damage = max(5, E.min_broken_damage - 30)
-
-/datum/disease2/effect/bones/deactivate(var/mob/living/carbon/mob)
-	if(istype(mob, /mob/living/carbon/human))
-		var/mob/living/carbon/human/H = mob
-		for (var/datum/organ/external/E in H.organs)
-			E.min_broken_damage = initial(E.min_broken_damage)
-
-
-/datum/disease2/effect/scc
-	name = "Spontaneous Cellular Collapse"
-	stage = 4
-
-/datum/disease2/effect/scc/activate(var/mob/living/carbon/mob)
-	//
-	if(!ishuman(mob))
-		return 0
-	var/mob/living/carbon/human/H = mob
-	mob.reagents.add_reagent(PACID, 10)
-	to_chat(mob, "<span class = 'warning'>Your body burns as your cells break down.</span>")
-	shake_camera(mob,5*multiplier)
-
-	for (var/datum/organ/external/E in H.organs)
-		if(pick(1,0))
-			//
-			E.createwound(CUT, pick(2,4,6,8,10))
-			E.fracture()
-
-
-/datum/disease2/effect/necrosis
-	name = "Necrosis"
-	stage = 4
-
-/datum/disease2/effect/necrosis/activate(var/mob/living/carbon/mob)
-
-	if(ishuman(mob)) //Only works on humans properly since it needs to do organ work
-		var/mob/living/carbon/human/H = mob
-		var/inst = pick(1, 2, 3)
-
-		switch(inst)
-
-			if(1)
-				to_chat(H, "<span class='warning'>A chunk of meat falls off of you!</span>")
-				var/totalslabs = 1
-				var/obj/item/weapon/reagent_containers/food/snacks/meat/allmeat[totalslabs]
-				var/sourcename = H.real_name
-				var/sourcejob = H.job
-				var/sourcenutriment = H.nutrition / 15
-				//var/sourcetotalreagents = mob.reagents.total_volume
-
-				for(var/i = 1 to totalslabs)
-					var/obj/item/weapon/reagent_containers/food/snacks/meat/human/newmeat = new
-					newmeat.name = sourcename + newmeat.name
-					newmeat.subjectname = sourcename
-					newmeat.subjectjob = sourcejob
-					newmeat.reagents.add_reagent(NUTRIMENT, sourcenutriment / totalslabs) //Thehehe. Fat guys go first
-					//src.occupant.reagents.trans_to(newmeat, round (sourcetotalreagents / totalslabs, 1)) // Transfer all the reagents from the
-					allmeat[i] = newmeat
-
-					var/obj/item/meatslab = allmeat[i]
-					var/turf/Tx = locate(mob.x, mob.y, mob.z)
-					meatslab.forceMove(get_turf(H))
-					meatslab.throw_at(Tx, i, 3)
-
-					if(!Tx.density)
-						var/obj/effect/decal/cleanable/blood/gibs/D = getFromPool(/obj/effect/decal/cleanable/blood/gibs, Tx)
-						D.New(Tx,i)
-
-			if(2)
-				for(var/datum/organ/external/E in H.organs)
-					if(pick(1, 0))
-						E.droplimb(1)
-
-			if(3)
-				if(H.species.name != "Skellington")
-					to_chat(H, "<span class='warning'>Your necrotic skin ruptures!</span>")
-
-					for(var/datum/organ/external/E in H.organs)
-						if(pick(1,0))
-							E.createwound(CUT, pick(2, 4, 6, 8, 10))
-
-					if(prob(30))
-						if(H.species.name != "Skellington")
-							if(H.set_species("Skellington"))
-								to_chat(mob, "<span class='warning'>A massive amount of flesh sloughs off your bones!</span>")
-								H.regenerate_icons()
-				else
-					return
-
-
-/datum/disease2/effect/fizzle
-	name = "Fizzle Effect"
-	stage = 4
-
-/datum/disease2/effect/fizzle/activate(var/mob/living/carbon/mob)
-	mob.emote("me",1,pick("sniffles...", "clears their throat..."))
-
-
-/datum/disease2/effect/delightful
-	name = "Delightful Effect"
-	stage = 4
-
-/datum/disease2/effect/delightful/activate(var/mob/living/carbon/mob)
-	to_chat(mob, "<span class = 'notice'>You feel delightful!</span>")
-	if (mob.reagents.get_reagent_amount(DOCTORSDELIGHT) < 1)
-		mob.reagents.add_reagent(DOCTORSDELIGHT, 1)
-
-
-/datum/disease2/effect/spawn
-	name = "Arachnogenesis Effect"
-	stage = 4
-	var/spawn_type=/mob/living/simple_animal/hostile/giant_spider/spiderling
-	var/spawn_name="spiderling"
-
-/datum/disease2/effect/spawn/activate(var/mob/living/carbon/mob)
-	//var/mob/living/carbon/human/H = mob
-	var/placemob = locate(mob.x + pick(1,-1), mob.y, mob.z)
-	playsound(mob.loc, 'sound/effects/splat.ogg', 50, 1)
-
-	new spawn_type(placemob)
-	mob.emote("me",1,"vomits up a live [spawn_name]!")
-
-/datum/disease2/effect/spawn/roach
-	name = "Blattogenesis Effect"
-	stage = 4
-	spawn_type=/mob/living/simple_animal/cockroach
-	spawn_name="cockroach"
-
-
-/datum/disease2/effect/orbweapon
-	name = "Biolobulin Effect"
-	stage = 4
-/datum/disease2/effect/orbweapon/activate(var/mob/living/carbon/mob)
-	var/obj/item/toy/snappop/virus/virus = new /obj/item/toy/snappop/virus
-	mob.put_in_hands(virus)
-
-
-/datum/disease2/effect/plasma
-	name = "Toxin Sublimation"
-	stage = 4
-
-/datum/disease2/effect/plasma/activate(var/mob/living/carbon/mob)
-	//var/src = mob
-	var/hack = mob.loc
-	var/turf/simulated/T = get_turf(hack)
-	if(!T)
+/datum/disease2/effect/invisible/activate(var/mob/living/carbon/mob)
 		return
-	var/datum/gas_mixture/GM = new
-	if(prob(10))
-		GM.toxins += 100
-		//GM.temperature = 1500+T0C //should be enough to start a fire
-		to_chat(mob, "<span class='warning'>You exhale a large plume of toxic gas!</span>")
+
+
+/datum/disease2/effect/sneeze
+	name = "Coldingtons Effect"
+	stage = 1
+
+/datum/disease2/effect/sneeze/activate(var/mob/living/carbon/mob)
+	mob.say("*sneeze")
+	if (prob(50))
+		var/obj/effect/decal/cleanable/mucus/M= locate(/obj/effect/decal/cleanable/mucus) in get_turf(mob)
+		if(M==null)
+			M = new(get_turf(mob))
+		else
+			if(M.dry)
+				M.dry=0
+		M.virus2 |= virus_copylist(mob.virus2)
+
+
+/datum/disease2/effect/gunck
+	name = "Flemmingtons"
+	stage = 1
+
+/datum/disease2/effect/gunck/activate(var/mob/living/carbon/mob)
+	to_chat(mob, "<span class = 'notice'> Mucous runs down the back of your throat.</span>")
+
+
+/datum/disease2/effect/drool
+	name = "Saliva Effect"
+	stage = 1
+
+/datum/disease2/effect/drool/activate(var/mob/living/carbon/mob)
+	mob.say("*drool")
+
+
+/datum/disease2/effect/twitch
+	name = "Twitcher"
+	stage = 1
+
+/datum/disease2/effect/twitch/activate(var/mob/living/carbon/mob)
+	mob.say("*twitch")
+
+
+/datum/disease2/effect/headache
+	name = "Headache"
+	stage = 1
+
+/datum/disease2/effect/headache/activate(var/mob/living/carbon/mob)
+	to_chat(mob, "<span class = 'notice'>Your head hurts a bit</span>")
+
+
+/datum/disease2/effect/itching
+	name = "Itching"
+	stage = 1
+
+/datum/disease2/effect/itching/activate(var/mob/living/carbon/mob)
+	var/mob/living/carbon/human/H = mob
+	if (istype(H) && H.species && H.species.flags & NO_SKIN)
+		to_chat(mob, "<span class='warning'>Your bones itch!</span>")
 	else
-		GM.toxins += 10
-		GM.temperature = istype(T) ? T.air.temperature : T20C
-		to_chat(mob, "<span class = 'warning'> A toxic gas emanates from your pores!</span>")
-	T.assume_air(GM)
-	return
+		to_chat(mob, "<span class='warning'>Your skin itches!</span>")
 
 
-/datum/disease2/effect/babel
-	name = "Babel Syndrome"
-	stage = 4
-	max_count = 1
+/datum/disease2/effect/drained
+	name = "Drained Feeling"
+	stage = 1
 
-	var/list/original_languages = list()
+/datum/disease2/effect/drained/activate(var/mob/living/carbon/mob)
+	to_chat(mob, "<span class='warning'>You feel drained.</span>")
 
-/datum/disease2/effect/babel/activate(var/mob/living/carbon/mob)
-	if(mob.languages.len <= 1)
-		to_chat(mob, "You realize your knowledge of language is just fine, and that you were panicking over nothing.")
-		return
 
-	for(var/datum/language/L in mob.languages)
-		original_languages += L.name
-		mob.remove_language(L.name)
+/datum/disease2/effect/eyewater
+	name = "Watery Eyes"
+	stage = 1
 
-	var/list/new_languages = list()
-	for(var/L in all_languages)
-		var/datum/language/lang = all_languages[L]
-		if(!(lang.flags & RESTRICTED))
-			new_languages += lang.name
+/datum/disease2/effect/eyewater/activate(var/mob/living/carbon/mob)
+	to_chat(mob, "<SPAN CLASS='warning'>Your eyes sting and water!</SPAN>")
 
-	var/picked_lang = pick(new_languages)
-	mob.add_language(picked_lang)
-	mob.default_language = mob.languages[1]
 
-	to_chat(mob, "You can't seem to remember any language but [picked_lang]. Odd.")
+/datum/disease2/effect/wheeze
+	name = "Wheezing"
+	stage = 1
 
-/datum/disease2/effect/babel/deactivate(var/mob/living/carbon/mob)
-	if(original_languages.len)
-		for(var/forgotten in original_languages)
-			mob.add_language(forgotten)
+/datum/disease2/effect/wheeze/activate(var/mob/living/carbon/mob)
+	mob.emote("me",1,"wheezes.")
 
-		to_chat(mob, "Suddenly, your knowledge of languages comes back to you.")
+
+/datum/disease2/effect/optimistic
+	name = "Full Glass Syndrome"
+	stage = 1
+
+/datum/disease2/effect/optimistic/activate(var/mob/living/carbon/mob)
+	to_chat(mob, "<span class = 'notice'>You feel optimistic!</span>")
+	if (mob.reagents.get_reagent_amount(TRICORDRAZINE) < 1)
+		mob.reagents.add_reagent(TRICORDRAZINE, 1)
+
+
+/datum/disease2/effect/spyndrome
+	name = "Gyroscopic Manipulation Syndrome"
+	stage = 1
+
+/datum/disease2/effect/spyndrome/activate(var/mob/living/carbon/mob)
+	if (mob.reagents.get_reagent_amount(GYRO) < 1)
+		mob.reagents.add_reagent(GYRO, 1)
+
+
+////////////////////////STAGE 2/////////////////////////////////
+
+
+/datum/disease2/effect/scream
+	name = "Loudness Syndrome"
+	stage = 2
+	
+/datum/disease2/effect/scream/activate(var/mob/living/carbon/mob)
+	mob.emote("scream",,, 1)
+
+
+/datum/disease2/effect/drowsness
+	name = "Automated Sleeping Syndrome"
+	stage = 2
+	
+/datum/disease2/effect/drowsness/activate(var/mob/living/carbon/mob)
+	mob.drowsyness += 10
+
+
+/datum/disease2/effect/sleepy
+	name = "Resting Syndrome"
+	stage = 2
+
+/datum/disease2/effect/sleepy/activate(var/mob/living/carbon/mob)
+	mob.say("*collapse")
+
+
+/datum/disease2/effect/blind
+	name = "Blackout Syndrome"
+	stage = 2
+
+/datum/disease2/effect/blind/activate(var/mob/living/carbon/mob)
+	mob.eye_blind = max(mob.eye_blind, 4)
+
+
+/datum/disease2/effect/cough
+	name = "Anima Syndrome"
+	stage = 2
+
+/datum/disease2/effect/cough/activate(var/mob/living/carbon/mob)
+	mob.say("*cough")
+	for(var/mob/living/carbon/M in oview(2,mob))
+		mob.spread_disease_to(M)
+
+
+/datum/disease2/effect/hungry
+	name = "Appetiser Effect"
+	stage = 2
+
+/datum/disease2/effect/hungry/activate(var/mob/living/carbon/mob)
+	mob.nutrition = max(0, mob.nutrition - 200)
+
+
+/datum/disease2/effect/fridge
+	name = "Refridgerator Syndrome"
+	stage = 2
+
+/datum/disease2/effect/fridge/activate(var/mob/living/carbon/mob)
+	mob.say("*shiver")
+
+
+/datum/disease2/effect/hair
+	name = "Hair Loss"
+	stage = 2
+
+/datum/disease2/effect/hair/activate(var/mob/living/carbon/mob)
+	if(istype(mob, /mob/living/carbon/human))
+		var/mob/living/carbon/human/H = mob
+		if(H.species.name == "Human" && !(H.h_style == "Bald") && !(H.h_style == "Balding Hair"))
+			to_chat(H, "<span class='danger'>Your hair starts to fall out in clumps...</span>")
+			spawn(50)
+				H.h_style = "Balding Hair"
+				H.update_hair()
+
+
+/datum/disease2/effect/stimulant
+	name = "Adrenaline Extra"
+	stage = 2
+
+/datum/disease2/effect/stimulant/activate(var/mob/living/carbon/mob)
+	to_chat(mob, "<span class='notice'>You feel a rush of energy inside you!</span>")
+	if (mob.reagents.get_reagent_amount(HYPERZINE) < 10)
+		mob.reagents.add_reagent(HYPERZINE, 4)
+	if (prob(30))
+		mob.jitteriness += 10
+
+
+/datum/disease2/effect/drunk
+	name = "Glasgow Syndrome"
+	stage = 2
+
+/datum/disease2/effect/drunk/activate(var/mob/living/carbon/mob)
+	to_chat(mob, "<span class='notice'>You feel like you had one hell of a party!</span>")
+	if (mob.reagents.get_reagent_amount(ETHANOL) < 325)
+		mob.reagents.add_reagent(ETHANOL, 5*multiplier)
+
+
+/datum/disease2/effect/gaben
+	name = "Gaben Syndrome"
+	stage = 2
+
+/datum/disease2/effect/gaben/activate(var/mob/living/carbon/mob)
+	to_chat(mob, "<span class='notice'>Your clothing fits a little tighter!!</span>")
+	if (prob(10))
+		mob.reagents.add_reagent(NUTRIMENT, 1000)
+		mob.overeatduration = 1000
+
+
+/datum/disease2/effect/beard
+	name = "Bearding"
+	stage = 2
+
+/datum/disease2/effect/beard/activate(var/mob/living/carbon/mob)
+	if(istype(mob, /mob/living/carbon/human))
+		var/mob/living/carbon/human/H = mob
+		if(H.species.name == "Human" && !(H.f_style == "Full Beard"))
+			to_chat(H, "<span class='warning'>Your chin and neck itch!.</span>")
+			spawn(50)
+				H.f_style = "Full Beard"
+				H.update_hair()
+
+
+/datum/disease2/effect/bloodynose
+	name = "Intranasal Hemorrhage"
+	stage = 2
+
+/datum/disease2/effect/bloodynose/activate(var/mob/living/carbon/mob)
+	if (prob(30))
+		var/obj/effect/decal/cleanable/blood/D= locate(/obj/effect/decal/cleanable/blood) in get_turf(mob)
+		if(D==null)
+			D = getFromPool(/obj/effect/decal/cleanable/blood, get_turf(mob))
+			D.New(D.loc)
+
+		D.virus2 |= virus_copylist(mob.virus2)
+
+
+/datum/disease2/effect/viralsputum
+	name = "Respiratory Putrification"
+	stage = 2
+
+/datum/disease2/effect/viralsputum/activate(var/mob/living/carbon/mob)
+
+	if (prob(30))
+		mob.say("*cough")
+		var/obj/effect/decal/cleanable/blood/viralsputum/D= locate(/obj/effect/decal/cleanable/blood/viralsputum) in get_turf(mob)
+		if(!D)
+			D = getFromPool(/obj/effect/decal/cleanable/blood/viralsputum, get_turf(mob))
+			D.New(D.loc)
+
+		D.virus2 |= virus_copylist(mob.virus2)
+
+
+/datum/disease2/effect/lantern
+	name = "Lantern Syndrome"
+	stage = 2
+
+/datum/disease2/effect/lantern/activate(var/mob/living/carbon/mob)
+	mob.set_light(4)
+	to_chat(mob, "<span class = 'notice'>You are glowing!</span>")
+
+
+/datum/disease2/effect/hangman
+	name = "Hanging Man's Syndrome"
+	stage = 2
+	var/triggered = 0
+	affect_voice = 1
+
+/datum/disease2/effect/hangman/activate(var/mob/living/carbon/mob)
+//Add filters to change a,A,e,E,i,I,o,O,u,U to _
+	if(!triggered)
+		to_chat(mob, "<span class='warning'>Y__ f__l _ b_t str_ng _p.</span>")
+		affect_voice_active = 1
+		triggered = 1
+
+/datum/disease2/effect/hangman/affect_mob_voice(var/datum/speech/speech)
+	var/message=speech.message
+	message = replacetext(message, "a", "_")
+	message = replacetext(message, "A", "_")
+	message = replacetext(message, "e", "_")
+	message = replacetext(message, "E", "_")
+	message = replacetext(message, "i", "_")
+	message = replacetext(message, "I", "_")
+	message = replacetext(message, "o", "_")
+	message = replacetext(message, "O", "_")
+	message = replacetext(message, "u", "_")
+	message = replacetext(message, "U", "_")
+
+	speech.message = message
 
 
 ////////////////////////STAGE 3/////////////////////////////////
@@ -830,305 +723,410 @@ datum/disease2/effect/lubefoot/deactivate(var/mob/living/carbon/mob)
 			honkers.canremove = 1
 
 
-////////////////////////STAGE 2/////////////////////////////////
+////////////////////////STAGE 4/////////////////////////////////
 
 
-/datum/disease2/effect/scream
-	name = "Loudness Syndrome"
-	stage = 2
-	
-/datum/disease2/effect/scream/activate(var/mob/living/carbon/mob)
-	mob.emote("scream",,, 1)
+/datum/disease2/effect/minttoxin
+	name = "Creosote Syndrome"
+	stage = 4
+
+/datum/disease2/effect/minttoxin/activate(var/mob/living/carbon/mob)
+	if(istype(mob) && mob.reagents.get_reagent_amount(MINTTOXIN) < 5)
+		to_chat(mob, "<span class='notice'>You feel a minty freshness</span>")
+		mob.reagents.add_reagent(MINTTOXIN, 5)
 
 
-/datum/disease2/effect/drowsness
-	name = "Automated Sleeping Syndrome"
-	stage = 2
-	
-/datum/disease2/effect/drowsness/activate(var/mob/living/carbon/mob)
-	mob.drowsyness += 10
+/datum/disease2/effect/gibbingtons
+	name = "Gibbingtons Syndrome"
+	stage = 4
+	badness = 2
+
+/datum/disease2/effect/gibbingtons/activate(var/mob/living/carbon/mob)
+	mob.gib()
 
 
-/datum/disease2/effect/sleepy
-	name = "Resting Syndrome"
-	stage = 2
+/datum/disease2/effect/radian
+	name = "Radian's Syndrome"
+	stage = 4
+	max_multiplier = 3
 
-/datum/disease2/effect/sleepy/activate(var/mob/living/carbon/mob)
-	mob.say("*collapse")
-
-
-/datum/disease2/effect/blind
-	name = "Blackout Syndrome"
-	stage = 2
-
-/datum/disease2/effect/blind/activate(var/mob/living/carbon/mob)
-	mob.eye_blind = max(mob.eye_blind, 4)
+/datum/disease2/effect/radian/activate(var/mob/living/carbon/mob)
+	mob.radiation += (2*multiplier)
 
 
-/datum/disease2/effect/cough
-	name = "Anima Syndrome"
-	stage = 2
+/datum/disease2/effect/deaf
+	name = "Dead Ear Syndrome"
+	stage = 4
 
-/datum/disease2/effect/cough/activate(var/mob/living/carbon/mob)
-	mob.say("*cough")
-	for(var/mob/living/carbon/M in oview(2,mob))
-		mob.spread_disease_to(M)
+/datum/disease2/effect/deaf/activate(var/mob/living/carbon/mob)
+	mob.ear_deaf += 20
 
 
-/datum/disease2/effect/hungry
-	name = "Appetiser Effect"
-	stage = 2
+/datum/disease2/effect/monkey
+	name = "Monkism Syndrome"
+	stage = 4
+	badness = 2
 
-/datum/disease2/effect/hungry/activate(var/mob/living/carbon/mob)
-	mob.nutrition = max(0, mob.nutrition - 200)
-
-
-/datum/disease2/effect/fridge
-	name = "Refridgerator Syndrome"
-	stage = 2
-
-/datum/disease2/effect/fridge/activate(var/mob/living/carbon/mob)
-	mob.say("*shiver")
+/datum/disease2/effect/monkey/activate(var/mob/living/carbon/mob)
+	if(istype(mob,/mob/living/carbon/human))
+		var/mob/living/carbon/human/h = mob
+		h.monkeyize()
 
 
-/datum/disease2/effect/hair
-	name = "Hair Loss"
-	stage = 2
+/datum/disease2/effect/catbeast
+	name = "Kingston Syndrome"
+	stage = 4
+	badness = 2
 
-/datum/disease2/effect/hair/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/catbeast/activate(var/mob/living/carbon/mob)
+	if(istype(mob,/mob/living/carbon/human))
+		var/mob/living/carbon/human/h = mob
+		if(h.species.name != "Tajaran")
+			if(h.set_species("Tajaran"))
+				h.regenerate_icons()
+
+
+/datum/disease2/effect/voxpox
+	name = "Vox Pox"
+	stage = 4
+	badness = 2
+
+/datum/disease2/effect/voxpox/activate(var/mob/living/carbon/mob)
+	if(istype(mob,/mob/living/carbon/human))
+		var/mob/living/carbon/human/h = mob
+		if(h.species.name != "Vox")
+			if(h.set_species("Vox"))
+				h.regenerate_icons()
+
+
+/datum/disease2/effect/suicide
+	name = "Suicidal Syndrome"
+	stage = 4
+	badness = 2
+
+/datum/disease2/effect/suicide/activate(var/mob/living/carbon/mob)
+	mob.suiciding = 1
+	//instead of killing them instantly, just put them at -175 health and let 'em gasp for a while
+	to_chat(viewers(mob), "<span class='danger'>[mob.name] is holding \his breath. It looks like \he's trying to commit suicide.</span>")
+	mob.adjustOxyLoss(175 - mob.getToxLoss() - mob.getFireLoss() - mob.getBruteLoss() - mob.getOxyLoss())
+	mob.updatehealth()
+	spawn(200) //in case they get revived by cryo chamber or something stupid like that, let them suicide again in 20 seconds
+		mob.suiciding = 0
+
+
+/datum/disease2/effect/killertoxins
+	name = "Toxification Syndrome"
+	stage = 4
+
+/datum/disease2/effect/killertoxins/activate(var/mob/living/carbon/mob)
+	mob.adjustToxLoss(15*multiplier)
+
+
+/datum/disease2/effect/dna
+	name = "Reverse Pattern Syndrome"
+	stage = 4
+
+/datum/disease2/effect/dna/activate(var/mob/living/carbon/mob)
+	mob.bodytemperature = max(mob.bodytemperature, 350)
+	scramble(0,mob,10)
+	mob.apply_damage(10, CLONE)
+
+
+/datum/disease2/effect/organs
+	name = "Shutdown Syndrome"
+	stage = 4
+
+/datum/disease2/effect/organs/activate(var/mob/living/carbon/mob)
 	if(istype(mob, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = mob
-		if(H.species.name == "Human" && !(H.h_style == "Bald") && !(H.h_style == "Balding Hair"))
-			to_chat(H, "<span class='danger'>Your hair starts to fall out in clumps...</span>")
-			spawn(50)
-				H.h_style = "Balding Hair"
-				H.update_hair()
+		var/organ = pick(list(LIMB_RIGHT_ARM,LIMB_LEFT_ARM,LIMB_RIGHT_LEG,LIMB_RIGHT_LEG))
+		var/datum/organ/external/E = H.organs_by_name[organ]
+		if (!(E.status & ORGAN_DEAD))
+			E.status |= ORGAN_DEAD
+			to_chat(H, "<span class='notice'>You can't feel your [E.display_name] anymore...</span>")
+			for (var/datum/organ/external/C in E.children)
+				C.status |= ORGAN_DEAD
+		H.update_body(1)
+		if(multiplier < 1)
+			multiplier = 1
+		H.adjustToxLoss(15*multiplier)
 
+/datum/disease2/effect/organs/vampire
+	stage = 3 //For use with vampires?
 
-/datum/disease2/effect/stimulant
-	name = "Adrenaline Extra"
-	stage = 2
-
-/datum/disease2/effect/stimulant/activate(var/mob/living/carbon/mob)
-	to_chat(mob, "<span class='notice'>You feel a rush of energy inside you!</span>")
-	if (mob.reagents.get_reagent_amount(HYPERZINE) < 10)
-		mob.reagents.add_reagent(HYPERZINE, 4)
-	if (prob(30))
-		mob.jitteriness += 10
-
-
-/datum/disease2/effect/drunk
-	name = "Glasgow Syndrome"
-	stage = 2
-
-/datum/disease2/effect/drunk/activate(var/mob/living/carbon/mob)
-	to_chat(mob, "<span class='notice'>You feel like you had one hell of a party!</span>")
-	if (mob.reagents.get_reagent_amount(ETHANOL) < 325)
-		mob.reagents.add_reagent(ETHANOL, 5*multiplier)
-
-
-/datum/disease2/effect/gaben
-	name = "Gaben Syndrome"
-	stage = 2
-
-/datum/disease2/effect/gaben/activate(var/mob/living/carbon/mob)
-	to_chat(mob, "<span class='notice'>Your clothing fits a little tighter!!</span>")
-	if (prob(10))
-		mob.reagents.add_reagent(NUTRIMENT, 1000)
-		mob.overeatduration = 1000
-
-
-/datum/disease2/effect/beard
-	name = "Bearding"
-	stage = 2
-
-/datum/disease2/effect/beard/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/organs/deactivate(var/mob/living/carbon/mob)
 	if(istype(mob, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = mob
-		if(H.species.name == "Human" && !(H.f_style == "Full Beard"))
-			to_chat(H, "<span class='warning'>Your chin and neck itch!.</span>")
-			spawn(50)
-				H.f_style = "Full Beard"
-				H.update_hair()
+		for (var/datum/organ/external/E in H.organs)
+			E.status &= ~ORGAN_DEAD
+			for (var/datum/organ/external/C in E.children)
+				C.status &= ~ORGAN_DEAD
+		H.update_body(1)
 
 
-/datum/disease2/effect/bloodynose
-	name = "Intranasal Hemorrhage"
-	stage = 2
+/datum/disease2/effect/immortal
+	name = "Longevity Syndrome"
+	stage = 4
 
-/datum/disease2/effect/bloodynose/activate(var/mob/living/carbon/mob)
-	if (prob(30))
-		var/obj/effect/decal/cleanable/blood/D= locate(/obj/effect/decal/cleanable/blood) in get_turf(mob)
-		if(D==null)
-			D = getFromPool(/obj/effect/decal/cleanable/blood, get_turf(mob))
-			D.New(D.loc)
+/datum/disease2/effect/immortal/activate(var/mob/living/carbon/mob)
+	if(istype(mob, /mob/living/carbon/human))
+		var/mob/living/carbon/human/H = mob
+		for (var/datum/organ/external/E in H.organs)
+			if (E.status & ORGAN_BROKEN && prob(30))
+				E.status ^= ORGAN_BROKEN
+	var/heal_amt = -5*multiplier
+	mob.apply_damages(heal_amt,heal_amt,heal_amt,heal_amt)
 
-		D.virus2 |= virus_copylist(mob.virus2)
-
-
-/datum/disease2/effect/viralsputum
-	name = "Respiratory Putrification"
-	stage = 2
-
-/datum/disease2/effect/viralsputum/activate(var/mob/living/carbon/mob)
-
-	if (prob(30))
-		mob.say("*cough")
-		var/obj/effect/decal/cleanable/blood/viralsputum/D= locate(/obj/effect/decal/cleanable/blood/viralsputum) in get_turf(mob)
-		if(!D)
-			D = getFromPool(/obj/effect/decal/cleanable/blood/viralsputum, get_turf(mob))
-			D.New(D.loc)
-
-		D.virus2 |= virus_copylist(mob.virus2)
+/datum/disease2/effect/immortal/deactivate(var/mob/living/carbon/mob)
+	if(istype(mob, /mob/living/carbon/human))
+		var/mob/living/carbon/human/H = mob
+		to_chat(H, "<span class='notice'>You suddenly feel hurt and old...</span>")
+		H.age += 8
+	var/backlash_amt = 5*multiplier
+	mob.apply_damages(backlash_amt,backlash_amt,backlash_amt,backlash_amt)
 
 
-/datum/disease2/effect/lantern
-	name = "Lantern Syndrome"
-	stage = 2
+/datum/disease2/effect/bones
+	name = "Fragile Bones Syndrome"
+	stage = 4
 
-/datum/disease2/effect/lantern/activate(var/mob/living/carbon/mob)
-	mob.set_light(4)
-	to_chat(mob, "<span class = 'notice'>You are glowing!</span>")
+/datum/disease2/effect/bones/activate(var/mob/living/carbon/mob)
+	if(istype(mob, /mob/living/carbon/human))
+		var/mob/living/carbon/human/H = mob
+		for (var/datum/organ/external/E in H.organs)
+			E.min_broken_damage = max(5, E.min_broken_damage - 30)
 
-
-/datum/disease2/effect/hangman
-	name = "Hanging Man's Syndrome"
-	stage = 2
-	var/triggered = 0
-	affect_voice = 1
-
-/datum/disease2/effect/hangman/activate(var/mob/living/carbon/mob)
-//Add filters to change a,A,e,E,i,I,o,O,u,U to _
-	if(!triggered)
-		to_chat(mob, "<span class='warning'>Y__ f__l _ b_t str_ng _p.</span>")
-		affect_voice_active = 1
-		triggered = 1
-
-/datum/disease2/effect/hangman/affect_mob_voice(var/datum/speech/speech)
-	var/message=speech.message
-	message = replacetext(message, "a", "_")
-	message = replacetext(message, "A", "_")
-	message = replacetext(message, "e", "_")
-	message = replacetext(message, "E", "_")
-	message = replacetext(message, "i", "_")
-	message = replacetext(message, "I", "_")
-	message = replacetext(message, "o", "_")
-	message = replacetext(message, "O", "_")
-	message = replacetext(message, "u", "_")
-	message = replacetext(message, "U", "_")
-
-	speech.message = message
+/datum/disease2/effect/bones/deactivate(var/mob/living/carbon/mob)
+	if(istype(mob, /mob/living/carbon/human))
+		var/mob/living/carbon/human/H = mob
+		for (var/datum/organ/external/E in H.organs)
+			E.min_broken_damage = initial(E.min_broken_damage)
 
 
-////////////////////////STAGE 1/////////////////////////////////
+/datum/disease2/effect/scc
+	name = "Spontaneous Cellular Collapse"
+	stage = 4
+
+/datum/disease2/effect/scc/activate(var/mob/living/carbon/mob)
+	//
+	if(!ishuman(mob))
+		return 0
+	var/mob/living/carbon/human/H = mob
+	mob.reagents.add_reagent(PACID, 10)
+	to_chat(mob, "<span class = 'warning'>Your body burns as your cells break down.</span>")
+	shake_camera(mob,5*multiplier)
+
+	for (var/datum/organ/external/E in H.organs)
+		if(pick(1,0))
+			//
+			E.createwound(CUT, pick(2,4,6,8,10))
+			E.fracture()
 
 
-/datum/disease2/effect/invisible
-	name = "Waiting Syndrome"
-	stage = 1
+/datum/disease2/effect/necrosis
+	name = "Necrosis"
+	stage = 4
 
-/datum/disease2/effect/invisible/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/necrosis/activate(var/mob/living/carbon/mob)
+
+	if(ishuman(mob)) //Only works on humans properly since it needs to do organ work
+		var/mob/living/carbon/human/H = mob
+		var/inst = pick(1, 2, 3)
+
+		switch(inst)
+
+			if(1)
+				to_chat(H, "<span class='warning'>A chunk of meat falls off of you!</span>")
+				var/totalslabs = 1
+				var/obj/item/weapon/reagent_containers/food/snacks/meat/allmeat[totalslabs]
+				var/sourcename = H.real_name
+				var/sourcejob = H.job
+				var/sourcenutriment = H.nutrition / 15
+				//var/sourcetotalreagents = mob.reagents.total_volume
+
+				for(var/i = 1 to totalslabs)
+					var/obj/item/weapon/reagent_containers/food/snacks/meat/human/newmeat = new
+					newmeat.name = sourcename + newmeat.name
+					newmeat.subjectname = sourcename
+					newmeat.subjectjob = sourcejob
+					newmeat.reagents.add_reagent(NUTRIMENT, sourcenutriment / totalslabs) //Thehehe. Fat guys go first
+					//src.occupant.reagents.trans_to(newmeat, round (sourcetotalreagents / totalslabs, 1)) // Transfer all the reagents from the
+					allmeat[i] = newmeat
+
+					var/obj/item/meatslab = allmeat[i]
+					var/turf/Tx = locate(mob.x, mob.y, mob.z)
+					meatslab.forceMove(get_turf(H))
+					meatslab.throw_at(Tx, i, 3)
+
+					if(!Tx.density)
+						var/obj/effect/decal/cleanable/blood/gibs/D = getFromPool(/obj/effect/decal/cleanable/blood/gibs, Tx)
+						D.New(Tx,i)
+
+			if(2)
+				for(var/datum/organ/external/E in H.organs)
+					if(pick(1, 0))
+						E.droplimb(1)
+
+			if(3)
+				if(H.species.name != "Skellington")
+					to_chat(H, "<span class='warning'>Your necrotic skin ruptures!</span>")
+
+					for(var/datum/organ/external/E in H.organs)
+						if(pick(1,0))
+							E.createwound(CUT, pick(2, 4, 6, 8, 10))
+
+					if(prob(30))
+						if(H.species.name != "Skellington")
+							if(H.set_species("Skellington"))
+								to_chat(mob, "<span class='warning'>A massive amount of flesh sloughs off your bones!</span>")
+								H.regenerate_icons()
+				else
+					return
+
+
+/datum/disease2/effect/fizzle
+	name = "Fizzle Effect"
+	stage = 4
+
+/datum/disease2/effect/fizzle/activate(var/mob/living/carbon/mob)
+	mob.emote("me",1,pick("sniffles...", "clears their throat..."))
+
+
+/datum/disease2/effect/delightful
+	name = "Delightful Effect"
+	stage = 4
+
+/datum/disease2/effect/delightful/activate(var/mob/living/carbon/mob)
+	to_chat(mob, "<span class = 'notice'>You feel delightful!</span>")
+	if (mob.reagents.get_reagent_amount(DOCTORSDELIGHT) < 1)
+		mob.reagents.add_reagent(DOCTORSDELIGHT, 1)
+
+
+/datum/disease2/effect/spawn
+	name = "Arachnogenesis Effect"
+	stage = 4
+	var/spawn_type=/mob/living/simple_animal/hostile/giant_spider/spiderling
+	var/spawn_name="spiderling"
+
+/datum/disease2/effect/spawn/activate(var/mob/living/carbon/mob)
+	//var/mob/living/carbon/human/H = mob
+	var/placemob = locate(mob.x + pick(1,-1), mob.y, mob.z)
+	playsound(mob.loc, 'sound/effects/splat.ogg', 50, 1)
+
+	new spawn_type(placemob)
+	mob.emote("me",1,"vomits up a live [spawn_name]!")
+
+/datum/disease2/effect/spawn/roach
+	name = "Blattogenesis Effect"
+	stage = 4
+	spawn_type=/mob/living/simple_animal/cockroach
+	spawn_name="cockroach"
+
+
+/datum/disease2/effect/orbweapon
+	name = "Biolobulin Effect"
+	stage = 4
+/datum/disease2/effect/orbweapon/activate(var/mob/living/carbon/mob)
+	var/obj/item/toy/snappop/virus/virus = new /obj/item/toy/snappop/virus
+	mob.put_in_hands(virus)
+
+
+/datum/disease2/effect/plasma
+	name = "Toxin Sublimation"
+	stage = 4
+
+/datum/disease2/effect/plasma/activate(var/mob/living/carbon/mob)
+	//var/src = mob
+	var/hack = mob.loc
+	var/turf/simulated/T = get_turf(hack)
+	if(!T)
+		return
+	var/datum/gas_mixture/GM = new
+	if(prob(10))
+		GM.toxins += 100
+		//GM.temperature = 1500+T0C //should be enough to start a fire
+		to_chat(mob, "<span class='warning'>You exhale a large plume of toxic gas!</span>")
+	else
+		GM.toxins += 10
+		GM.temperature = istype(T) ? T.air.temperature : T20C
+		to_chat(mob, "<span class = 'warning'> A toxic gas emanates from your pores!</span>")
+	T.assume_air(GM)
+	return
+
+
+/datum/disease2/effect/babel
+	name = "Babel Syndrome"
+	stage = 4
+	max_count = 1
+
+	var/list/original_languages = list()
+
+/datum/disease2/effect/babel/activate(var/mob/living/carbon/mob)
+	if(mob.languages.len <= 1)
+		to_chat(mob, "Your knowledge of language is just fine.")
 		return
 
+	for(var/datum/language/L in mob.languages)
+		original_languages += L.name
+		mob.remove_language(L.name)
 
-/datum/disease2/effect/sneeze
-	name = "Coldingtons Effect"
-	stage = 1
+	var/list/new_languages = list()
+	for(var/L in all_languages)
+		var/datum/language/lang = all_languages[L]
+		if(!(lang.flags & RESTRICTED))
+			new_languages += lang.name
 
-/datum/disease2/effect/sneeze/activate(var/mob/living/carbon/mob)
-	mob.say("*sneeze")
-	if (prob(50))
-		var/obj/effect/decal/cleanable/mucus/M= locate(/obj/effect/decal/cleanable/mucus) in get_turf(mob)
-		if(M==null)
-			M = new(get_turf(mob))
-		else
-			if(M.dry)
-				M.dry=0
-		M.virus2 |= virus_copylist(mob.virus2)
+	var/picked_lang = pick(new_languages)
+	mob.add_language(picked_lang)
+	mob.default_language = mob.languages[1]
 
+	to_chat(mob, "You can't seem to remember any language but [picked_lang]. Odd.")
 
-/datum/disease2/effect/gunck
-	name = "Flemmingtons"
-	stage = 1
+/datum/disease2/effect/babel/deactivate(var/mob/living/carbon/mob)
+	if(original_languages.len)
+		for(var/forgotten in original_languages)
+			mob.add_language(forgotten)
 
-/datum/disease2/effect/gunck/activate(var/mob/living/carbon/mob)
-	to_chat(mob, "<span class = 'notice'> Mucous runs down the back of your throat.</span>")
-
-
-/datum/disease2/effect/drool
-	name = "Saliva Effect"
-	stage = 1
-
-/datum/disease2/effect/drool/activate(var/mob/living/carbon/mob)
-	mob.say("*drool")
+		to_chat(mob, "Suddenly, your knowledge of languages comes back to you.")
 
 
-/datum/disease2/effect/twitch
-	name = "Twitcher"
-	stage = 1
-
-/datum/disease2/effect/twitch/activate(var/mob/living/carbon/mob)
-	mob.say("*twitch")
+////////////////////////SPECIAL/////////////////////////////////
 
 
-/datum/disease2/effect/headache
-	name = "Headache"
-	stage = 1
+/*/datum/disease2/effect/alien
+	name = "Unidentified Foreign Body"
+	stage = 4
+	activate(var/mob/living/carbon/mob)
+		to_chat(mob, "<span class='warning'>You feel something tearing its way out of your stomach...</span>")
+		mob.adjustToxLoss(10)
+		mob.updatehealth()
+		if(prob(40))
+			if(mob.client)
+				mob.client.mob = new/mob/living/carbon/alien/larva(mob.loc)
+			else
+				new/mob/living/carbon/alien/larva(mob.loc)
+			var/datum/disease2/disease/D = mob:virus2
+			mob:gib()
+			del D*/
 
-/datum/disease2/effect/headache/activate(var/mob/living/carbon/mob)
-	to_chat(mob, "<span class = 'notice'>Your head hurts a bit</span>")
 
+/datum/disease2/effect/spaceadapt
+	name = "Space Adaptation Effect"
+	stage = 5
 
-/datum/disease2/effect/itching
-	name = "Itching"
-	stage = 1
-
-/datum/disease2/effect/itching/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/spaceadapt/activate(var/mob/living/carbon/mob)
 	var/mob/living/carbon/human/H = mob
-	if (istype(H) && H.species && H.species.flags & NO_SKIN)
-		to_chat(mob, "<span class='warning'>Your bones itch!</span>")
-	else
-		to_chat(mob, "<span class='warning'>Your skin itches!</span>")
+	if (mob.reagents.get_reagent_amount(DEXALINP) < 10)
+		mob.reagents.add_reagent(DEXALINP, 4)
+	if (mob.reagents.get_reagent_amount(LEPORAZINE) < 10)
+		mob.reagents.add_reagent(LEPORAZINE, 4)
+	if (mob.reagents.get_reagent_amount(BICARIDINE) < 10)
+		mob.reagents.add_reagent(BICARIDINE, 4)
+	if (mob.reagents.get_reagent_amount(DERMALINE) < 10)
+		mob.reagents.add_reagent(DERMALINE, 4)
+	mob.emote("me",1,"exhales slowly.")
 
-
-/datum/disease2/effect/drained
-	name = "Drained Feeling"
-	stage = 1
-
-/datum/disease2/effect/drained/activate(var/mob/living/carbon/mob)
-	to_chat(mob, "<span class='warning'>You feel drained.</span>")
-
-
-/datum/disease2/effect/eyewater
-	name = "Watery Eyes"
-	stage = 1
-
-/datum/disease2/effect/eyewater/activate(var/mob/living/carbon/mob)
-	to_chat(mob, "<SPAN CLASS='warning'>Your eyes sting and water!</SPAN>")
-
-
-/datum/disease2/effect/wheeze
-	name = "Wheezing"
-	stage = 1
-
-/datum/disease2/effect/wheeze/activate(var/mob/living/carbon/mob)
-	mob.emote("me",1,"wheezes.")
-
-
-/datum/disease2/effect/optimistic
-	name = "Full Glass Syndrome"
-	stage = 1
-
-/datum/disease2/effect/optimistic/activate(var/mob/living/carbon/mob)
-	to_chat(mob, "<span class = 'notice'>You feel optimistic!</span>")
-	if (mob.reagents.get_reagent_amount(TRICORDRAZINE) < 1)
-		mob.reagents.add_reagent(TRICORDRAZINE, 1)
-
-
-/datum/disease2/effect/spyndrome
-	name = "Gyroscopic Manipulation Syndrome"
-	stage = 1
-
-/datum/disease2/effect/spyndrome/activate(var/mob/living/carbon/mob)
-	if (mob.reagents.get_reagent_amount(GYRO) < 1)
-		mob.reagents.add_reagent(GYRO, 1)
+	if(ishuman(H))
+		var/datum/organ/external/chest/chest = H.get_organ(LIMB_CHEST)
+		for(var/datum/organ/internal/I in chest.internal_organs)
+			I.damage = 0

--- a/code/modules/virus2/effect.dm
+++ b/code/modules/virus2/effect.dm
@@ -451,14 +451,11 @@
 /datum/disease2/effect/babel
 	name = "Babel Syndrome"
 	stage = 4
+	max_count = 1
 
 	var/list/original_languages = list()
-	var/has_been_triggered = 0
 
 /datum/disease2/effect/babel/activate(var/mob/living/carbon/mob)
-	if(has_been_triggered)
-		return
-	has_been_triggered = 1
 	if(mob.languages.len <= 1)
 		to_chat(mob, "You realize your knowledge of language is just fine, and that you were panicking over nothing.")
 		return
@@ -485,7 +482,6 @@
 			mob.add_language(forgotten)
 
 		to_chat(mob, "Suddenly, your knowledge of languages comes back to you.")
-	..()
 
 
 ////////////////////////STAGE 3/////////////////////////////////


### PR DESCRIPTION
- Reorders the effects to start at stage 1 and end at special
- Makes Babel use max_count instead of hackish vars and conditionals 
- Babel's activation message for when the user only knows one language now makes more sense