### PR TITLE
costly_bicon()

### DIFF
--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -262,7 +262,7 @@
 			if(istype(thisPile))
 				thisPile.addAmount(1)
 			else
-				piles[O.name] = getFromPool(/datum/fridge_pile, O.name, src, 1, bicon(O))
+				piles[O.name] = getFromPool(/datum/fridge_pile, O.name, src, 1, costly_bicon(O))
 			user.visible_message("<span class='notice'>[user] has added \the [O] to \the [src].", \
 								 "<span class='notice'>You add \the [O] to \the [src].")
 
@@ -280,7 +280,7 @@
 					if(istype(thisPile))
 						thisPile.addAmount(1)
 					else
-						piles[G.name] = new/datum/fridge_pile(G.name, src, 1, bicon(G))
+						piles[G.name] = new/datum/fridge_pile(G.name, src, 1, costly_bicon(G))
 					objects_loaded++
 		if(objects_loaded)
 

--- a/goon/code/datums/browserOutput.dm
+++ b/goon/code/datums/browserOutput.dm
@@ -196,10 +196,11 @@ For the main html chat area
 		return
 
 	if (isicon(obj))
-		if (!bicon_cache["\ref[obj]"]) // Doesn't exist yet, make it.
+		//Icons get pooled constantly, references are no good here.
+		/*if (!bicon_cache["\ref[obj]"]) // Doesn't exist yet, make it.
 			bicon_cache["\ref[obj]"] = icon2base64(obj)
-
-		return "<img class='icon misc' src='data:image/png;base64,[bicon_cache["\ref[obj]"]]'>"
+		return "<img class='icon misc' src='data:image/png;base64,[bicon_cache["\ref[obj]"]]'>"*/
+		return "<img class='icon misc' src='data:image/png;base64,[icon2base64(obj)]'>"
 
 	// Either an atom or somebody fucked up and is gonna get a runtime, which I'm fine with.
 	var/atom/A = obj
@@ -217,6 +218,17 @@ For the main html chat area
 //Aliases for bicon
 /proc/bi(obj)
 	bicon(obj)
+
+//Costlier version of bicon() that uses getFlatIcon() to account for overlays, underlays, etc. Use with extreme moderation, ESPECIALLY on mobs.
+/proc/costly_bicon(var/obj)
+	if (!obj)
+		return
+
+	if (isicon(obj))
+		return bicon(obj)
+
+	var/icon/I = getFlatIcon(obj)
+	return bicon(I)
 
 /proc/to_chat(target, message)
 	//Ok so I did my best but I accept that some calls to this will be for shit like sound and images


### PR DESCRIPTION
Removes the bicon() icon caching which, at best, didn't work (fixes #11179)
Adds costly_bicon(). This is like bicon(), except it uses getFlatIcon(). Those who know anything about getFlatIcon() know that this means it should be used VERY SPARINGLY.
I checked with PJB and he seemed to think it was OK to use this in the chemfridge, since the icon generation only happens once per pile and none of the things that go inside fridges will have many overlays and especially not overlays inside massive massive DMI files (the main thing that turns getFlatIcon() into performance hell).

Before:
![2016-12-24_17-40-54](https://cloud.githubusercontent.com/assets/6526157/21468916/e7770492-ca0c-11e6-8f9e-543809bbc103.png)
After:
![2016-12-24_19-12-45](https://cloud.githubusercontent.com/assets/6526157/21468920/f7a73fc6-ca0c-11e6-83ee-2eb3edadeef6.png)
