### PR TITLE
Improves the spawn command

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -388,6 +388,15 @@ var/global/list/watt_suffixes = list("W", "KW", "MW", "GW", "TW", "PW", "EW", "Z
 		i++
 	return "[format_num(number)] [watt_suffixes[i]]"
 
+//Returns 1 if [text] ends with [suffix]
+//Example: text_ends_with("Woody got wood", "dy got wood") returns 1
+//         text_ends_with("Woody got wood", "d") returns 1
+//         text_ends_with("Woody got wood", "Wood") returns 0
+proc/text_ends_with(text, suffix)
+	if(length(suffix) > length(text))
+		return FALSE
+
+	return (copytext(text, length(text) - length(suffix) + 1) == suffix)
 
 // Custom algorithm since stackoverflow is full of complete garbage and even the MS algorithm sucks.
 // Uses recursion, in places.

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1248,9 +1248,17 @@ var/global/floorIsLava = 0
 
 	var/list/matches = new()
 
-	for(var/path in typesof(/atom))
-		if(findtext("[path]", object))
-			matches += path
+	if(text_ends_with(object, ".")) //Path ends with a dot - DO NOT include subtypes
+		object = copytext(object, 1, length(object)) //Remove the dot
+
+		for(var/path in typesof(/atom))
+			if(text_ends_with("[path]", object))
+				matches += path
+	else //Include subtypes
+		for(var/path in typesof(/atom))
+			if(findtext("[path]", object))
+				matches += path
+
 
 	if(matches.len==0)
 		return

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1240,7 +1240,7 @@ var/global/floorIsLava = 0
 */
 /datum/admins/proc/spawn_atom(var/object as text)
 	set category = "Debug"
-	set desc = "(atom path) Spawn an atom"
+	set desc = "(atom path) Spawn an atom. Finish path with a period to hide subtypes"
 	set name = "Spawn"
 
 	if(!check_rights(R_SPAWN))

--- a/html/changelogs/unid-ta.yml
+++ b/html/changelogs/unid-ta.yml
@@ -1,0 +1,6 @@
+author: Unid
+
+delete-after: True
+
+changes: 
+- tweak: "When using the 'spawn' admin command, you can place a period at the end of the path to prevent subtypes of the path from being listed. For example: 'spawn /mob/living/carbon/human.' spawns a human without bringing up any lists."


### PR DESCRIPTION
Placing a period at the end of the path prevents subtypes from being listed

spawn "carbon/human" -> brings up a list with 9999 subtypes of /mob/living/carbon/human

spawn "carbon/human." -> spawns a human

![fa](https://cloud.githubusercontent.com/assets/9512290/21472807/4a37fe46-caea-11e6-9922-4d1cccf7b19b.gif)
