### PR TITLE
Shrapnel for improvised explosives: the unfuck

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -53,6 +53,11 @@
 	var/vending_cat = null// subcategory for vending machines.
 	var/list/dynamic_overlay[0] //For items which need to slightly alter their on-mob appearance while being worn.
 
+	var/shrapnel_amount = 0 // How many pieces of shrapnel it disintegrates into.
+	var/shrapnel_type = null
+	var/shrapnel_size = 1
+
+
 /obj/item/proc/return_thermal_protection()
 	return return_cover_protection(body_parts_covered) * (1 - src.heat_conductivity)
 
@@ -1066,3 +1071,9 @@ var/global/list/image/blood_overlays = list()
 
 /obj/item/animationBolt(var/mob/firer)
 	new /mob/living/simple_animal/hostile/mimic/copy(loc, src, firer, duration=SPELL_ANIMATION_TTL)
+
+/obj/item/proc/get_shrapnel_projectile()
+	if(shrapnel_type)
+		return new shrapnel_type(src)
+	else
+		return 0

--- a/code/game/objects/items/weapons/grenades/ghettobomb.dm
+++ b/code/game/objects/items/weapons/grenades/ghettobomb.dm
@@ -30,7 +30,9 @@
 	var/assembled = 0
 	active = 1
 	det_time = 50
-
+	var/list/shrapnel_list = new()
+	var/max_shrapnel = 8
+	var/current_shrapnel = 0
 
 
 /obj/item/weapon/grenade/iedcasing/afterattack(atom/target, mob/user , flag) //Filling up the can
@@ -61,6 +63,27 @@
 			name = "improvised explosive"
 			active = 0
 			det_time = rand(30,80)
+	else
+
+		AddShrapnel(I,user)
+
+
+
+/obj/item/weapon/grenade/iedcasing/verb/remove_shrapnel()
+
+	set name = "Remove shrapnel"
+	set category = "Object"
+
+	if(assembled == 2 && shrapnel_list.len > 0)
+
+
+		to_chat(usr, "<span  class='notice'>You remove all the shrapnel from the improvised explosive.</span>")
+		current_shrapnel = 0
+		for(var/obj/item/shrapnel in shrapnel_list)
+
+			shrapnel.forceMove(get_turf(src))
+			shrapnel_list.Remove(shrapnel)
+		current_shrapnel = 0
 
 /obj/item/weapon/grenade/iedcasing/attack_self(mob/user as mob) //Activating the IED
 	if(!active)
@@ -82,9 +105,29 @@
 			spawn(det_time)
 				prime()
 
+
+/obj/item/weapon/grenade/iedcasing/proc/AddShrapnel(var/obj/item/I, mob/user as mob)
+
+	if(assembled == 2)
+		if((current_shrapnel + I.shrapnel_size)<= max_shrapnel )
+			if(I.shrapnel_amount > 0|| I.w_class == W_CLASS_TINY)
+				shrapnel_list.Add(I)
+				current_shrapnel += I.shrapnel_size
+				if(user && user.drop_item(I, src))
+					to_chat(user, "<span  class='notice'>You add \the [I] to the improvised explosive.</span>")
+					playsound(get_turf(src), 'sound/items/Deconstruct.ogg', 25, 1)
+				else
+					I.forceMove(src)
+
+	else
+		if(user)
+			to_chat(user, "<span  class='notice'>There is no room for \the [I] in the improvised explosive!.</span>")
+
+
 /obj/item/weapon/grenade/iedcasing/prime() //Blowing that can up
 	update_mob()
 	explosion(get_turf(src.loc),-1,0,2)
+	process_shrapnel()
 
 	if(istype(loc, /obj/item/weapon/legcuffs/beartrap))
 		var/obj/item/weapon/legcuffs/beartrap/boomtrap = loc
@@ -99,6 +142,29 @@
 				H.legcuffed = null
 	qdel(src)
 
+
+/obj/item/weapon/grenade/iedcasing/proc/process_shrapnel()
+
+	if(shrapnel_list.len > 0)
+		var/atom/target
+		var/atom/curloc = get_turf(src)
+		var/list/possible_targets= trange(7, curloc)
+		var/list/bodyparts = list("head","chest","groin","l_arm","r_arm","l_hand","r_hand","l_leg","r_leg","l_foot","r_foot")
+		for(var/obj/item/shrapnel in shrapnel_list)
+			var/amount = shrapnel.shrapnel_amount
+			if(amount)
+				while(amount > 0)
+					amount--
+					var/obj/item/projectile/shrapnel_projectile = shrapnel.get_shrapnel_projectile()
+					target=pick(possible_targets)
+					shrapnel_projectile.forceMove(curloc)
+					shrapnel_projectile.launch_at(target,bodyparts[rand(1,bodyparts.len)],curloc,src)
+				qdel(shrapnel)
+			else
+				target =pick(possible_targets)
+				shrapnel.forceMove(curloc)
+				shrapnel.throw_at(target,9,10)
+
 /obj/item/weapon/grenade/iedcasing/examine(mob/user)
 	..()
 	if(assembled == 3)
@@ -109,6 +175,15 @@
     desc = "A weak, improvised explosive."
     assembled = 2
     active = 0
+
+/obj/item/weapon/grenade/iedcasing/preassembled/withshrapnel
+	name = "shrapnel loaded improvised explosive"
+
+/obj/item/weapon/grenade/iedcasing/preassembled/withshrapnel/New()
+	..()
+	for(var/i = 1, i<=4,i++)
+		AddShrapnel(new /obj/item/weapon/shard(src), null)
+
 
 /obj/item/weapon/grenade/iedcasing/preassembled/New()
     ..()

--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -26,6 +26,9 @@
 	siemens_coefficient = 1
 	origin_tech = Tc_MATERIALS + "=1"
 	attack_verb = list("attacks", "stabs", "pokes")
+	shrapnel_amount = 1
+	shrapnel_size = 2
+	shrapnel_type = "/obj/item/projectile/bullet/shrapnel"
 
 /obj/item/weapon/kitchen/utensil/New()
 	. = ..()
@@ -202,6 +205,7 @@
 	melt_temperature = MELTPOINT_STEEL
 	origin_tech = Tc_MATERIALS + "=1"
 	attack_verb = list("slashes", "stabs", "slices", "tears", "rips", "dices", "cuts")
+	shrapnel_amount = 0
 
 /obj/item/weapon/kitchen/utensil/knife/large/attackby(obj/item/weapon/W, mob/user)
 	..()

--- a/code/game/objects/items/weapons/shard.dm
+++ b/code/game/objects/items/weapons/shard.dm
@@ -19,6 +19,9 @@
 	siemens_coefficient = 0 //no conduct
 	attack_verb = list("stabs", "slashes", "slices", "cuts")
 	var/glass = /obj/item/stack/sheet/glass/glass
+	shrapnel_amount = 3
+	shrapnel_type = "/obj/item/projectile/bullet/shrapnel/small"
+	shrapnel_size = 2
 
 /obj/item/weapon/shard/New()
 
@@ -45,6 +48,7 @@
 	icon_state = "plasmalarge"
 	item_state = "shard-plasglass"
 	glass = /obj/item/stack/sheet/glass/plasmaglass
+	shrapnel_type = "/obj/item/projectile/bullet/shrapnel/small/plasma"
 
 /obj/item/weapon/shard/plasma/New()
 	..()

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -11,6 +11,9 @@
 	var/caliber = ""							//Which kind of guns it can be loaded into
 	var/projectile_type = ""//The bullet type to create when New() is called
 	var/obj/item/projectile/BB = null 			//The loaded bullet
+	shrapnel_amount = 1
+	shrapnel_type = "/obj/item/projectile/bullet/shrapnel/small"
+	shrapnel_size = 1
 
 
 /obj/item/ammo_casing/New()
@@ -26,6 +29,14 @@
 	name = "[BB ? "" : "spent "][initial(name)]"
 	icon_state = "[initial(icon_state)][BB ? "-live" : ""]"
 	desc = "[initial(desc)][BB ? "" : " This one is spent."]"
+
+/obj/item/ammo_casing/get_shrapnel_projectile()
+	if(BB)
+
+		var/obj/item/projectile/bullet_bill = BB
+		BB = null
+		return bullet_bill
+	..()
 
 
 //Boxes of ammo

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -710,3 +710,15 @@ var/list/impact_master = list()
 
 /obj/item/projectile/acidable()
 	return 0
+
+/obj/item/projectile/proc/launch_at(var/atom/target,var/tar_zone = "chest",var/atom/curloc = get_turf(src),var/from = null) // doot doot shitcode alert
+	original = target
+	starting = curloc
+	shot_from = from
+	current = curloc
+	OnFired()
+	yo = target.loc.y - curloc.y
+	xo = target.loc.x - curloc.x
+	def_zone = tar_zone
+	spawn()
+		process()

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -23,6 +23,33 @@
 	damage_type = TOX
 	weaken = 5
 
+/obj/item/projectile/bullet/shrapnel
+
+	name = "shrapnel"
+	damage = 45
+	damage_type = BRUTE
+	weaken = 1
+	stun = 3
+
+/obj/item/projectile/bullet/shrapnel/New()
+	..()
+	kill_count = rand(6,10)
+
+
+
+/obj/item/projectile/bullet/shrapnel/small
+
+	name = "small shrapnel"
+	damage = 25
+
+/obj/item/projectile/bullet/shrapnel/small/plasma
+
+	name = "small plasma shrapnel"
+	damage_type = TOX
+	color = "#BF5FFF"
+	damage = 35
+
+
 /obj/item/projectile/bullet/weakbullet
 	name = "weak bullet"
 	icon_state = "bbshell"


### PR DESCRIPTION
New pr because of conflicts + git + problems on my machine.

@9600bauds , @Exxion and @PJB3005 still had open reviews in the previous pr at the time of closing.

Copy pasted from old pr:

In reponse to #12398

Allows players to add any w_class_tiny item to an improvised explosive. The items will then launch out in random directions when it explodes. Some items, not necessarily tiny, will disintegrate into shrapnel which deals spicy damage. The code makes it semi simple to add custom types of shrapnel for certain items in the future.

The numbers for those who do not want to read through the code:

8 item slots in each explosive. (Previously 10) Shards take up 2 slots (Previously 1)

Shards disintegrate into 3 pieces of small shrapnel (Previously 5 normal sized)

Standard shrapnel deals 45 damage and small shrapnel 25. Shrapnel is child of projectile/bullet (Previously 55 damage for standard shrapnel)

Shrapnel targets a random bodypart

Plasma shards produce purple TOX damage (35) shrapnel

Kitchen utensils produce 1 standard shrapnel and take up 2 slots each

Individual pieces of shrapnel have a random range limit of 6 to 10 squares

Bullet casings fire their projectile if its not already spent.

All spent bullet casings are small shrapnel.

As it is now this is fairly balanced tbh. Its a buff to the IED for sure but it was trash earlier.

Clip of some crayons and 5 shards: https://puu.sh/sVJ5o.mp4

🆑

rscadd: Shrapnel, in the form of tiny items and shards, can be added to improvised explosives.