### PR TITLE
shrapnel for improvised explosives: 3rd times the charm

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -49,6 +49,9 @@
 
 	var/list/attack_verb // used in attack() to say how something was attacked "[x] [z.attack_verb] [y] with [z]". Present tense.
 
+	var/shrapnel_amount = 0 // How many pieces of shrapnel it disintegrates into.
+	var/shrapnel_type = null
+	var/shrapnel_size = 1
 
 
 	var/vending_cat = null// subcategory for vending machines.
@@ -1080,3 +1083,8 @@ var/global/list/image/blood_overlays = list()
 		if(bit & slot_flags)
 			if(M.get_item_by_flag(bit) == src)
 				return TRUE
+/obj/item/proc/get_shrapnel_projectile()
+	if(shrapnel_type)
+		return new shrapnel_type(src)
+	else
+		return 0

--- a/code/game/objects/items/weapons/grenades/ghettobomb.dm
+++ b/code/game/objects/items/weapons/grenades/ghettobomb.dm
@@ -65,7 +65,7 @@
 			det_time = rand(30,80)
 	else
 
-		AddShrapnel(I,user)
+		add_shrapnel(I,user)
 
 
 
@@ -106,7 +106,7 @@
 				prime()
 
 
-/obj/item/weapon/grenade/iedcasing/proc/AddShrapnel(var/obj/item/I, mob/user as mob)
+/obj/item/weapon/grenade/iedcasing/proc/add_shrapnel(var/obj/item/I, mob/user as mob)
 
 	if(assembled == 2)
 		if((current_shrapnel + I.shrapnel_size)<= max_shrapnel )
@@ -181,7 +181,7 @@
 /obj/item/weapon/grenade/iedcasing/preassembled/withshrapnel/New()
 	..()
 	for(var/i = 1, i<=4,i++)
-		AddShrapnel(new /obj/item/weapon/shard(src), null)
+		add_shrapnel(new /obj/item/weapon/shard(src), null)
 
 
 /obj/item/weapon/grenade/iedcasing/preassembled/New()

--- a/code/game/objects/items/weapons/grenades/ghettobomb.dm
+++ b/code/game/objects/items/weapons/grenades/ghettobomb.dm
@@ -78,7 +78,6 @@
 
 
 		to_chat(usr, "<span  class='notice'>You remove all the shrapnel from the improvised explosive.</span>")
-		current_shrapnel = 0
 		for(var/obj/item/shrapnel in shrapnel_list)
 
 			shrapnel.forceMove(get_turf(src))

--- a/code/game/objects/items/weapons/grenades/ghettobomb.dm
+++ b/code/game/objects/items/weapons/grenades/ghettobomb.dm
@@ -119,8 +119,7 @@
 				else
 					I.forceMove(src)
 
-	else
-		if(user)
+		else if(user)
 			to_chat(user, "<span  class='notice'>There is no room for \the [I] in the improvised explosive!.</span>")
 
 

--- a/code/game/objects/items/weapons/grenades/ghettobomb.dm
+++ b/code/game/objects/items/weapons/grenades/ghettobomb.dm
@@ -30,7 +30,9 @@
 	var/assembled = 0
 	active = 1
 	det_time = 50
-
+	var/list/shrapnel_list = new()
+	var/max_shrapnel = 8
+	var/current_shrapnel = 0
 
 
 /obj/item/weapon/grenade/iedcasing/afterattack(atom/target, mob/user , flag) //Filling up the can
@@ -61,6 +63,27 @@
 			name = "improvised explosive"
 			active = 0
 			det_time = rand(30,80)
+	else
+
+		AddShrapnel(I,user)
+
+
+
+/obj/item/weapon/grenade/iedcasing/verb/remove_shrapnel()
+
+	set name = "Remove shrapnel"
+	set category = "Object"
+
+	if(assembled == 2 && shrapnel_list.len > 0)
+
+
+		to_chat(usr, "<span  class='notice'>You remove all the shrapnel from the improvised explosive.</span>")
+		current_shrapnel = 0
+		for(var/obj/item/shrapnel in shrapnel_list)
+
+			shrapnel.forceMove(get_turf(src))
+			shrapnel_list.Remove(shrapnel)
+		current_shrapnel = 0
 
 /obj/item/weapon/grenade/iedcasing/attack_self(mob/user as mob) //Activating the IED
 	if(!active)
@@ -82,9 +105,29 @@
 			spawn(det_time)
 				prime()
 
+
+/obj/item/weapon/grenade/iedcasing/proc/AddShrapnel(var/obj/item/I, mob/user as mob)
+
+	if(assembled == 2)
+		if((current_shrapnel + I.shrapnel_size)<= max_shrapnel )
+			if(I.shrapnel_amount > 0|| I.w_class == W_CLASS_TINY)
+				shrapnel_list.Add(I)
+				current_shrapnel += I.shrapnel_size
+				if(user && user.drop_item(I, src))
+					to_chat(user, "<span  class='notice'>You add \the [I] to the improvised explosive.</span>")
+					playsound(get_turf(src), 'sound/items/Deconstruct.ogg', 25, 1)
+				else
+					I.forceMove(src)
+
+	else
+		if(user)
+			to_chat(user, "<span  class='notice'>There is no room for \the [I] in the improvised explosive!.</span>")
+
+
 /obj/item/weapon/grenade/iedcasing/prime() //Blowing that can up
 	update_mob()
 	explosion(get_turf(src.loc),-1,0,2)
+	process_shrapnel()
 
 	if(istype(loc, /obj/item/weapon/legcuffs/beartrap))
 		var/obj/item/weapon/legcuffs/beartrap/boomtrap = loc
@@ -99,6 +142,29 @@
 				H.legcuffed = null
 	qdel(src)
 
+
+/obj/item/weapon/grenade/iedcasing/proc/process_shrapnel()
+
+	if(shrapnel_list.len > 0)
+		var/atom/target
+		var/atom/curloc = get_turf(src)
+		var/list/possible_targets= trange(7, curloc)
+		var/list/bodyparts = list("head","chest","groin","l_arm","r_arm","l_hand","r_hand","l_leg","r_leg","l_foot","r_foot")
+		for(var/obj/item/shrapnel in shrapnel_list)
+			var/amount = shrapnel.shrapnel_amount
+			if(amount)
+				while(amount > 0)
+					amount--
+					var/obj/item/projectile/shrapnel_projectile = shrapnel.get_shrapnel_projectile()
+					target=pick(possible_targets)
+					shrapnel_projectile.forceMove(curloc)
+					shrapnel_projectile.launch_at(target,bodyparts[rand(1,bodyparts.len)],curloc,src)
+				qdel(shrapnel)
+			else
+				target =pick(possible_targets)
+				shrapnel.forceMove(curloc)
+				shrapnel.throw_at(target,9,10)
+
 /obj/item/weapon/grenade/iedcasing/examine(mob/user)
 	..()
 	if(assembled == 3)
@@ -109,6 +175,15 @@
     desc = "A weak, improvised explosive."
     assembled = 2
     active = 0
+
+/obj/item/weapon/grenade/iedcasing/preassembled/withshrapnel
+	name = "shrapnel loaded improvised explosive"
+
+/obj/item/weapon/grenade/iedcasing/preassembled/withshrapnel/New()
+	..()
+	for(var/i = 1, i<=4,i++)
+		AddShrapnel(new /obj/item/weapon/shard(src), null)
+
 
 /obj/item/weapon/grenade/iedcasing/preassembled/New()
     ..()

--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -59,6 +59,7 @@
 	name = "fork"
 	desc = "Pointy."
 	icon_state = "fork"
+	sharpness_flags = SHARP_TIP
 	sharpness = 0.6
 	var/loaded_food_name
 	var/image/loaded_food
@@ -159,6 +160,7 @@
 	force = 10.0
 	throwforce = 10.0
 	sharpness = 1.2
+	sharpness_flags = SHARP_TIP | SHARP_BLADE
 	melt_temperature = MELTPOINT_STEEL
 
 /obj/item/weapon/kitchen/utensil/knife/suicide_act(mob/user)
@@ -250,6 +252,7 @@
 	flags = FPRINT
 	siemens_coefficient = 1
 	sharpness = 1.2
+	sharpness_flags = SHARP_BLADE
 	force = 15.0
 	w_class = W_CLASS_SMALL
 	throwforce = 8.0

--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -26,6 +26,9 @@
 	siemens_coefficient = 1
 	origin_tech = Tc_MATERIALS + "=1"
 	attack_verb = list("attacks", "stabs", "pokes")
+	shrapnel_amount = 1
+	shrapnel_size = 2
+	shrapnel_type = "/obj/item/projectile/bullet/shrapnel"
 
 /obj/item/weapon/kitchen/utensil/New()
 	. = ..()
@@ -57,7 +60,6 @@
 	desc = "Pointy."
 	icon_state = "fork"
 	sharpness = 0.6
-	sharpness_flags = SHARP_TIP
 	var/loaded_food_name
 	var/image/loaded_food
 	melt_temperature = MELTPOINT_STEEL
@@ -157,7 +159,6 @@
 	force = 10.0
 	throwforce = 10.0
 	sharpness = 1.2
-	sharpness_flags = SHARP_TIP | SHARP_BLADE
 	melt_temperature = MELTPOINT_STEEL
 
 /obj/item/weapon/kitchen/utensil/knife/suicide_act(mob/user)
@@ -204,6 +205,7 @@
 	melt_temperature = MELTPOINT_STEEL
 	origin_tech = Tc_MATERIALS + "=1"
 	attack_verb = list("slashes", "stabs", "slices", "tears", "rips", "dices", "cuts")
+	shrapnel_amount = 0
 
 /obj/item/weapon/kitchen/utensil/knife/large/attackby(obj/item/weapon/W, mob/user)
 	..()
@@ -248,7 +250,6 @@
 	flags = FPRINT
 	siemens_coefficient = 1
 	sharpness = 1.2
-	sharpness_flags = SHARP_BLADE
 	force = 15.0
 	w_class = W_CLASS_SMALL
 	throwforce = 8.0

--- a/code/game/objects/items/weapons/shard.dm
+++ b/code/game/objects/items/weapons/shard.dm
@@ -7,11 +7,13 @@
 	icon = 'icons/obj/shards.dmi'
 	icon_state = "large"
 	sharpness = 0.8
+	sharpness_flags = SHARP_TIP | SHARP_BLADE
 	desc = "Could probably be used as ... a throwing weapon?"
 	w_class = W_CLASS_TINY
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	force = 5.0
 	throwforce = 15.0
+	
 	item_state = "shard-glassnew"
 	starting_materials = list(MAT_GLASS = 3750)
 	w_type = RECYK_GLASS
@@ -107,7 +109,7 @@
 		if(AM.locked_to) //Mob is locked to something, so it's not actually stepping on the glass
 			playsound(get_turf(src), 'sound/effects/glass_step.ogg', 50, 1) //Make noise
 			return //Stop here
-		if(AM.flying) //We don't check for lying because it's intended to hurt
+		if(AM.flying) //We don't check for lying yet because it's intended to hurt
 			return
 		else //Stepping on the glass
 			playsound(get_turf(src), 'sound/effects/glass_step.ogg', 50, 1)
@@ -120,7 +122,7 @@
 					if(affecting.is_organic())
 						danger = TRUE
 
-						if(H.feels_pain())
+						if(!H.lying && H.feels_pain())
 							H.Knockdown(3)
 						if(affecting.take_damage(5, 0))
 							H.UpdateDamageIcon()

--- a/code/game/objects/items/weapons/shard.dm
+++ b/code/game/objects/items/weapons/shard.dm
@@ -7,7 +7,6 @@
 	icon = 'icons/obj/shards.dmi'
 	icon_state = "large"
 	sharpness = 0.8
-	sharpness_flags = SHARP_TIP | SHARP_BLADE
 	desc = "Could probably be used as ... a throwing weapon?"
 	w_class = W_CLASS_TINY
 	hitsound = 'sound/weapons/bladeslice.ogg'
@@ -20,6 +19,9 @@
 	siemens_coefficient = 0 //no conduct
 	attack_verb = list("stabs", "slashes", "slices", "cuts")
 	var/glass = /obj/item/stack/sheet/glass/glass
+	shrapnel_amount = 3
+	shrapnel_type = "/obj/item/projectile/bullet/shrapnel/small"
+	shrapnel_size = 2
 
 /obj/item/weapon/shard/New()
 
@@ -46,6 +48,7 @@
 	icon_state = "plasmalarge"
 	item_state = "shard-plasglass"
 	glass = /obj/item/stack/sheet/glass/plasmaglass
+	shrapnel_type = "/obj/item/projectile/bullet/shrapnel/small/plasma"
 
 /obj/item/weapon/shard/plasma/New()
 	..()
@@ -104,7 +107,7 @@
 		if(AM.locked_to) //Mob is locked to something, so it's not actually stepping on the glass
 			playsound(get_turf(src), 'sound/effects/glass_step.ogg', 50, 1) //Make noise
 			return //Stop here
-		if(AM.flying) //We don't check for lying yet because it's intended to hurt
+		if(AM.flying) //We don't check for lying because it's intended to hurt
 			return
 		else //Stepping on the glass
 			playsound(get_turf(src), 'sound/effects/glass_step.ogg', 50, 1)
@@ -117,7 +120,7 @@
 					if(affecting.is_organic())
 						danger = TRUE
 
-						if(!H.lying && H.feels_pain())
+						if(H.feels_pain())
 							H.Knockdown(3)
 						if(affecting.take_damage(5, 0))
 							H.UpdateDamageIcon()

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -36,7 +36,8 @@
 		var/obj/item/projectile/bullet_bill = BB
 		BB = null
 		return bullet_bill
-	..()
+	else
+		return new shrapnel_type(src)
 
 
 //Boxes of ammo

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -11,6 +11,9 @@
 	var/caliber = ""							//Which kind of guns it can be loaded into
 	var/projectile_type = ""//The bullet type to create when New() is called
 	var/obj/item/projectile/BB = null 			//The loaded bullet
+	shrapnel_amount = 1
+	shrapnel_type = "/obj/item/projectile/bullet/shrapnel/small"
+	shrapnel_size = 1
 
 
 /obj/item/ammo_casing/New()
@@ -26,6 +29,14 @@
 	name = "[BB ? "" : "spent "][initial(name)]"
 	icon_state = "[initial(icon_state)][BB ? "-live" : ""]"
 	desc = "[initial(desc)][BB ? "" : " This one is spent."]"
+
+/obj/item/ammo_casing/get_shrapnel_projectile()
+	if(BB)
+
+		var/obj/item/projectile/bullet_bill = BB
+		BB = null
+		return bullet_bill
+	..()
 
 
 //Boxes of ammo

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -710,3 +710,15 @@ var/list/impact_master = list()
 
 /obj/item/projectile/acidable()
 	return 0
+
+/obj/item/projectile/proc/launch_at(var/atom/target,var/tar_zone = "chest",var/atom/curloc = get_turf(src),var/from = null) // doot doot shitcode alert
+	original = target
+	starting = curloc
+	shot_from = from
+	current = curloc
+	OnFired()
+	yo = target.loc.y - curloc.y
+	xo = target.loc.x - curloc.x
+	def_zone = tar_zone
+	spawn()
+		process()

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -23,6 +23,33 @@
 	damage_type = TOX
 	weaken = 5
 
+/obj/item/projectile/bullet/shrapnel
+
+	name = "shrapnel"
+	damage = 45
+	damage_type = BRUTE
+	weaken = 1
+	stun = 3
+
+/obj/item/projectile/bullet/shrapnel/New()
+	..()
+	kill_count = rand(6,10)
+
+
+
+/obj/item/projectile/bullet/shrapnel/small
+
+	name = "small shrapnel"
+	damage = 25
+
+/obj/item/projectile/bullet/shrapnel/small/plasma
+
+	name = "small plasma shrapnel"
+	damage_type = TOX
+	color = "#BF5FFF"
+	damage = 35
+
+
 /obj/item/projectile/bullet/weakbullet
 	name = "weak bullet"
 	icon_state = "bbshell"


### PR DESCRIPTION
The 3rd PR for this, this time it seems to work. I literally could not unfuck my last 2 PRs. 1st pr : #12961

@9600bauds @PJB3005 and @Exxion had open reviews on the first PR.

I accidentaly some sharpness flags but I manually readded them, should be fine.

Copy paste:
In reponse to #12398

Allows players to add any w_class_tiny item to an improvised explosive. The items will then launch out in random directions when it explodes. Some items, not necessarily tiny, will disintegrate into shrapnel which deals spicy damage. The code makes it semi simple to add custom types of shrapnel for certain items in the future.

The numbers for those who do not want to read through the code:

 * 8 item slots in each explosive. (Previously 10) Shards take up 2 slots (Previously 1)

 * Shards disintegrate into 3 pieces of small shrapnel (Previously 5 normal sized)

 * Standard shrapnel deals 45 damage and small shrapnel 25. Shrapnel is child of projectile/bullet (Previously 55 damage for standard shrapnel)

 * Shrapnel targets a random bodypart

 * Plasma shards produce purple TOX damage (35) shrapnel

 * Kitchen utensils produce 1 standard shrapnel and take up 2 slots each

 * Individual pieces of shrapnel have a random range limit of 6 to 10 squares

 * Bullet casings fire their projectile if its not already spent.

 * All spent bullet casings are small shrapnel.

As it is now this is fairly balanced tbh. Its a buff to the IED for sure but it was trash earlier.

Clip of some crayons and 5 shards: https://puu.sh/sVJ5o.mp4

:cl:

 * rscadd: Shrapnel, in the form of tiny items and shards, can be added to improvised explosives.