### PR TITLE
Fixes killer tomatoes not actually speciating from blood tomatoes

### DIFF
--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -598,7 +598,7 @@
 	seed_name = "blood tomato"
 	display_name = "blood tomato plant"
 	products = list(/obj/item/weapon/reagent_containers/food/snacks/grown/bloodtomato)
-	mutants = list("killer")
+	mutants = list("killertomato")
 	packet_icon = "seed-bloodtomato"
 	plant_icon = "bloodtomato"
 	chems = list(NUTRIMENT = list(1,10), BLOOD = list(10,2))


### PR DESCRIPTION
tested **before** compiling that force mutating species of a blood tomato didn't do anything while all other mutable plants did. didn't test after but it's obvious that it should work.

:cl:
 * bugfix: Fixed killer tomatoes never mutating from blood tomatoes.