### PR TITLE
QoL for Snowmap: Wood walls constructed faster, but are far easier to break

### DIFF
--- a/code/game/objects/items/stacks/stack_recipes.dm
+++ b/code/game/objects/items/stacks/stack_recipes.dm
@@ -216,7 +216,7 @@ var/global/list/datum/stack_recipe/wood_recipes = list (
 	new/datum/stack_recipe("blank canvas",		/obj/item/mounted/frame/painting/blank,	2,		time = 15									),
 	new/datum/stack_recipe("campfire",			/obj/machinery/space_heater/campfire,	4,		time = 35,	one_per_turf = 1,	on_floor = 1),
 	new/datum/stack_recipe("spit",				/obj/machinery/cooking/grill/spit,		1,		time = 10,	one_per_turf = 1,	on_floor = 1),
-	new/datum/stack_recipe("wall girders",		/obj/structure/girder/wood,				2, 		time = 50, 	one_per_turf = 1, 	on_floor = 1),
+	new/datum/stack_recipe("wall girders",		/obj/structure/girder/wood,				2, 		time = 25, 	one_per_turf = 1, 	on_floor = 1),
 	new/datum/stack_recipe("boomerang",			/obj/item/weapon/boomerang,				6,		time = 50),
 	new/datum/stack_recipe("buckler",			/obj/item/weapon/shield/riot/buckler,	5,		time = 50),
 	)

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -4,11 +4,25 @@
 	density = 1
 	var/state = 0
 	var/material = /obj/item/stack/sheet/metal
+	var/construction_length = 40
 
 /obj/structure/girder/wood
 	icon_state = "girder_wood"
 	name = "wooden girder"
 	material = /obj/item/stack/sheet/wood
+	construction_length = 20
+
+/obj/structure/girder/wood/attackby(var/obj/item/W, var/mob/user)
+	if(W.sharpness_flags & CHOPWOOD)
+		playsound(get_turf(src), 'sound/effects/woodcuttingshort.ogg', 50, 1)
+		user.visible_message("<span class='warning'>[user] smashes through \the [src] with \the [W].</span>", \
+							"<span class='notice'>You smash through \the [src].</span>",\
+							"<span class='warning'>You hear the sound of wood being cut</span>"
+							)
+		qdel(src)
+		getFromPool(material, get_turf(src), 2)
+	else
+		..()
 
 /obj/structure/girder/wood/update_icon()
 	if(anchored)
@@ -25,7 +39,7 @@
 				playsound(get_turf(src), 'sound/items/Ratchet.ogg', 100, 1)
 				user.visible_message("<span class='notice'>[user] starts disassembling \the [src].</span>", \
 				"<span class='notice'>You start disassembling \the [src].</span>")
-				if(do_after(user, src, 40))
+				if(do_after(user, src, construction_length))
 					user.visible_message("<span class='warning'>[user] dissasembles \the [src].</span>", \
 					"<span class='notice'>You dissasemble \the [src].</span>")
 					getFromPool(material, get_turf(src))
@@ -38,7 +52,7 @@
 				playsound(get_turf(src), 'sound/items/Ratchet.ogg', 100, 1)
 				user.visible_message("<span class='notice'>[user] starts securing \the [src].</span>", \
 				"<span class='notice'>You start securing \the [src].</span>")
-				if(do_after(user, src, 40))
+				if(do_after(user, src, construction_length))
 					user.visible_message("<span class='notice'>[user] secures \the [src].</span>", \
 					"<span class='notice'>You secure \the [src].</span>")
 					add_hiddenprint(user)
@@ -49,7 +63,7 @@
 			playsound(get_turf(src), 'sound/items/Ratchet.ogg', 100, 1)
 			user.visible_message("<span class='notice'>[user] starts [anchored ? "un" : ""]securing \the [src].</span>", \
 			"<span class='notice'>You start [anchored ? "un" : ""]securing \the [src].</span>")
-			if(do_after(user, src, 40))
+			if(do_after(user, src, construction_length))
 				anchored = !anchored //Unachor it if anchored, or opposite
 				user.visible_message("<span class='notice'>[user] [anchored ? "" : "un"]secures \the [src].</span>", \
 				"<span class='notice'>You [anchored ? "" : "un"]secure \the [src].</span>")
@@ -74,7 +88,7 @@
 		playsound(get_turf(src), 'sound/items/Screwdriver.ogg', 100, 1)
 		user.visible_message("<span class='warning'>[user] starts unsecuring \the [src]'s internal support struts.</span>", \
 		"<span class='notice'>You start unsecuring \the [src]'s internal support struts.</span>")
-		if(do_after(user, src, 40))
+		if(do_after(user, src, construction_length))
 			user.visible_message("<span class='warning'>[user] unsecures \the [src]'s internal support struts.</span>", \
 			"<span class='notice'>You unsecure \the [src]'s internal support struts.</span>")
 			add_hiddenprint(user)
@@ -86,7 +100,7 @@
 		playsound(get_turf(src), 'sound/items/Screwdriver.ogg', 100, 1)
 		user.visible_message("<span class='notice'>[user] starts securing \the [src]'s internal support struts.</span>", \
 		"<span class='notice'>You start securing \the [src]'s internal support struts.</span>")
-		if(do_after(user, src, 40))
+		if(do_after(user, src, construction_length))
 			user.visible_message("<span class='notice'>[user] secures \the [src]'s internal support struts.</span>", \
 			"<span class='notice'>You secure \the [src]'s internal support struts.</span>")
 			add_hiddenprint(user)
@@ -98,7 +112,7 @@
 		playsound(get_turf(src), 'sound/items/Wirecutter.ogg', 100, 1)
 		user.visible_message("<span class='warning'>[user] starts removing \the [src]'s internal support struts.</span>", \
 		"<span class='notice'>You start removing \the [src]'s internal support struts.</span>")
-		if(do_after(user, src, 40))
+		if(do_after(user, src, construction_length))
 			user.visible_message("<span class='warning'>[user] removes \the [src]'s internal support struts.</span>", \
 			"<span class='notice'>You remove \the [src]'s internal support struts.</span>")
 			add_hiddenprint(user)
@@ -114,7 +128,7 @@
 			return
 		user.visible_message("<span class='notice'>[user] starts inserting internal support struts into \the [src.]</span>", \
 		"<span class='notice'>You start inserting internal support struts into \the [src].</span>")
-		if(do_after(user, src,40))
+		if(do_after(user, src,construction_length))
 			var/obj/item/stack/rods/O = W
 			if(O.amount < 2) //In case our user is trying to be tricky
 				to_chat(user, "<span class='warning'>You need more rods to finish the support struts.</span>")
@@ -131,7 +145,7 @@
 		playsound(get_turf(src), 'sound/items/Crowbar.ogg', 100, 1)
 		user.visible_message("<span class='warning'>[user] starts dislodging \the [src].</span>", \
 		"<span class='notice'>You start dislodging \the [src].</span>")
-		if(do_after(user, src, 40))
+		if(do_after(user, src, construction_length))
 			user.visible_message("<span class='warning'>[user] dislodges \the [src].</span>", \
 			"<span class='notice'>You dislodge \the [src].</span>")
 			add_hiddenprint(user)
@@ -167,7 +181,7 @@
 						return ..() // ?
 					user.visible_message("<span class='notice'>[user] starts installing plating to \the [src].</span>", \
 					"<span class='notice'>You start installing plating to \the [src].</span>")
-					if(do_after(user, src, 40))
+					if(do_after(user, src, construction_length))
 						if(S.amount < 2) //User being tricky
 							return
 						S.use(2)
@@ -255,7 +269,7 @@
 					return ..()
 				user.visible_message("<span class='notice'>[user] starts installing plating to \the [src].</span>", \
 				"<span class='notice'>You start installing plating to \the [src].</span>")
-				if(do_after(user, src,40))
+				if(do_after(user, src,construction_length))
 					if(S.amount < 2) //Don't be tricky now
 						return
 					S.use(2)

--- a/code/game/turfs/simulated/walls_mineral.dm
+++ b/code/game/turfs/simulated/walls_mineral.dm
@@ -13,6 +13,25 @@
 	walltype = "wood"
 	mineral = "wood"
 	girder_type = /obj/structure/girder/wood
+	hardness = 0 // a hulk can smash through wood easily
+
+/turf/simulated/wall/mineral/wood/attackby(var/obj/item/W, var/mob/user)
+	if(W.sharpness_flags & CHOPWOOD)
+		playsound(src, 'sound/effects/woodcuttingshort.ogg', 50, 1)
+		user.visible_message("<span class='warning'>[user] smashes through \the [src] with \the [W].</span>", \
+							"<span class='notice'>You smash through \the [src].</span>",\
+							"<span class='warning'>You hear the sound of wood being cut</span>"
+							)
+		dismantle_wall()
+	else
+		..()
+
+/turf/simulated/wall/mineral/wood/ex_act(var/severity)
+	if(severity < 3)
+		ChangeTurf(get_underlying_turf())
+		getFromPool(/obj/item/stack/sheet/wood, src, 2)
+	else
+		dismantle_wall()
 
 /turf/simulated/wall/mineral/brick
 	name = "brick wall"


### PR DESCRIPTION
One of the bonuses of snowmap is the greater ability of people to build little huts in the snow. I'd like to encourage that behaviour; so I have halved the construction time of wooden girders. To balance this, you can break through wooden walls with an axe with two swings - one to break the wall, the other to break the girder. This change is not for all girder behaviour as #13124 proved to be controversial

<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl: (as the emoji)
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
