### PR TITLE
Makes airlock eletronics more intuitive

### DIFF
--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -60,9 +60,9 @@
 		if(isrobot(user))
 			t1 += "<a href='?src=\ref[src];login=1'>Log In</a><hr>"
 		else
-			t1 += "<a href='?src=\ref[src];login=1'>Swipe ID</a><hr>"
+			t1 += "<a href='?src=\ref[src];login=1'>Set access</a><hr>"
 	else
-		t1 += "<a href='?src=\ref[src];logout=1'>Block</a><hr>"
+		t1 += "<a href='?src=\ref[src];logout=1'>Finish</a><hr>"
 
 		t1 += "Access requirement is set to "
 		t1 += one_access ? "<a style='color: green' href='?src=\ref[src];one_access=1'>ONE</a><hr>" : "<a style='color: red' href='?src=\ref[src];one_access=1'>ALL</a><hr>"
@@ -107,6 +107,7 @@
 			src.last_configurator = usr.name
 
 	if(locked)
+		to_chat(usr, "<span class='warning'>Access denied.</span>")
 		return
 
 	if(href_list["logout"])


### PR DESCRIPTION
Changes the cursed non-silicon login 'Swipe ID' to 'Set access', the logout 'Block' to 'Finish' and now you get a nice 'Access Denied' if you try to change it's settings without proper access.

Closes #11834

:cl:
* tweak: Changes airlock eletronics non-silicon login text from 'Swipe ID' to 'Set access'
* tweak: Changes airlock eletronics logout text from 'Block' to 'Finish'
* rscadd: Now you get a nice 'Access Denied' if you try to change airlock eletronics settings without proper access.