### PR TITLE
Fixes pAI HUD override when using both med and sec supplements

### DIFF
--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -249,6 +249,7 @@
 
 		// Accessing medical records
 		if("medicalsupplement")
+			src.secHUD = 0 // Can't have both of them at the same time
 			src.medHUD = 1
 			if(src.subscreen == 1)
 				var/datum/data/record/record = locate(href_list["med_rec"])
@@ -264,6 +265,7 @@
 						src.medicalActive1 = R
 						src.medicalActive2 = M
 		if("securitysupplement")
+			src.medHUD = 0 // Can't have both of them at the same time
 			src.secHUD = 1
 			if(src.subscreen == 1)
 				var/datum/data/record/record = locate(href_list["sec_rec"])


### PR DESCRIPTION
Turns off sec HUD when you access the medical supplement and turns off medhud when you access security suppement. Hacky but at least works :100:%

https://webmshare.com/eWway

Closes #13092

:cl: 
* bugfix: You can now switch between pAI's sec/med HUD by accessing their respective supplement