### PR TITLE
Tweaks Service and Medical radio colors to make them more distinct from Common radio

### DIFF
--- a/__DEFINES/stylesheet.dm
+++ b/__DEFINES/stylesheet.dm
@@ -28,10 +28,10 @@ em						{font-style: normal;	font-weight: bold;}
 .centradio				{color: #5C5C8A;}
 .secradio				{color: #A30000;}
 .engradio				{color: #A66300;}
-.medradio				{color: #008160;}
+.medradio				{color: #3399CC;}
 .sciradio				{color: #993399;}
 .supradio				{color: #5F4519;}
-.serradio				{color: #3399CC;}
+.serradio				{color: #006666;}
 .djradio				{color: #663300;}
 .binaryradio			{color: #300050;	font-family: 'Courier New', Courier, monospace;}
 .mommiradio				{color: navy;}

--- a/__DEFINES/stylesheet.dm
+++ b/__DEFINES/stylesheet.dm
@@ -31,7 +31,7 @@ em						{font-style: normal;	font-weight: bold;}
 .medradio				{color: #3399CC;}
 .sciradio				{color: #993399;}
 .supradio				{color: #5F4519;}
-.serradio				{color: #006666;}
+.serradio				{color: #C0A17D;}
 .djradio				{color: #663300;}
 .binaryradio			{color: #300050;	font-family: 'Courier New', Courier, monospace;}
 .mommiradio				{color: navy;}

--- a/__DEFINES/stylesheet.dm
+++ b/__DEFINES/stylesheet.dm
@@ -31,7 +31,7 @@ em						{font-style: normal;	font-weight: bold;}
 .medradio				{color: #3399CC;}
 .sciradio				{color: #993399;}
 .supradio				{color: #5F4519;}
-.serradio				{color: #C0A17D;}
+.serradio				{color: #A17A4E;}
 .djradio				{color: #663300;}
 .binaryradio			{color: #300050;	font-family: 'Courier New', Courier, monospace;}
 .mommiradio				{color: navy;}

--- a/goon/browserassets/css/browserOutput.css
+++ b/goon/browserassets/css/browserOutput.css
@@ -250,7 +250,7 @@ em						{font-style: normal;	font-weight: bold;}
 .medradio				{color: #3399CC;}
 .sciradio				{color: #993399;}
 .supradio				{color: #5F4519;}
-.serradio				{color: #006666;}
+.serradio				{color: #C0A17D;}
 .djradio				{color: #663300;}
 .binaryradio			{color: #0B0050;	font-family: 'Courier New', Courier, monospace;}
 .mommiradio				{color: navy;}

--- a/goon/browserassets/css/browserOutput.css
+++ b/goon/browserassets/css/browserOutput.css
@@ -247,10 +247,10 @@ em						{font-style: normal;	font-weight: bold;}
 .centradio				{color: #5C5C8A;}
 .secradio				{color: #A30000;}
 .engradio				{color: #A66300;}
-.medradio				{color: #008160;}
+.medradio				{color: #3399CC;}
 .sciradio				{color: #993399;}
 .supradio				{color: #5F4519;}
-.serradio				{color: #3399CC;}
+.serradio				{color: #006666;}
 .djradio				{color: #663300;}
 .binaryradio			{color: #0B0050;	font-family: 'Courier New', Courier, monospace;}
 .mommiradio				{color: navy;}

--- a/goon/browserassets/css/browserOutput.css
+++ b/goon/browserassets/css/browserOutput.css
@@ -250,7 +250,7 @@ em						{font-style: normal;	font-weight: bold;}
 .medradio				{color: #3399CC;}
 .sciradio				{color: #993399;}
 .supradio				{color: #5F4519;}
-.serradio				{color: #C0A17D;}
+.serradio				{color: #A17A4E;}
 .djradio				{color: #663300;}
 .binaryradio			{color: #0B0050;	font-family: 'Courier New', Courier, monospace;}
 .mommiradio				{color: navy;}


### PR DESCRIPTION
**!! NOT FINAL - SUGGESTIONS/FEEDBACK MUCH APPRECIATED !!** - Fixes #11405

At some point, the chat color for Medical radio got somehow re-assigned to the Service radio. Meanwhile, the Medical radio got given an ugly color that looks very very close to the Common radio channel.
This is my solution that is guaranteed to leave everyone thoroughly dissatisfied:

Before
![photoshop_2016-12-29_23-08-58](https://cloud.githubusercontent.com/assets/6526157/21558621/cf3a9e9e-ce1b-11e6-91bc-bd6436427c8f.png)
![dreamseeker_2016-12-29_22-55-01](https://cloud.githubusercontent.com/assets/6526157/21558623/d54d76ee-ce1b-11e6-8442-f7b06848908f.png)

After
![asd](https://cloud.githubusercontent.com/assets/6526157/21571099/96a6e800-ceaa-11e6-81c5-1466d3e979d8.png)
![dreamseeker_2016-12-30_16-09-57](https://cloud.githubusercontent.com/assets/6526157/21571077/6ee6213c-ceaa-11e6-8cee-9e869691e1b2.png)



I am DEFINITELY listening out for better ideas on the colors here.
For reference this is the old one
![photoshop_2016-12-29_21-56-56](https://cloud.githubusercontent.com/assets/6526157/21559172/fe31392e-ce25-11e6-9878-433dfbce84a6.png)


:cl:
 * tweak: Tweaked the Medical and Service radio colors to make them more distinct from the Common radio color.