### PR TITLE
Fixes clone pod runtime

### DIFF
--- a/code/modules/medical/cloning.dm
+++ b/code/modules/medical/cloning.dm
@@ -361,9 +361,10 @@
 	return..()
 
 /obj/machinery/cloning/clonepod/Destroy()
-	if(connected.pod1 == src)
-		connected.pod1 = null
-	connected = null
+	if(connected)
+		if(connected.pod1 == src)
+			connected.pod1 = null
+		connected = null
 	go_out() //Eject everything
 
 	. = ..()


### PR DESCRIPTION
Fixes this when the clone pod has a connected of `null`:
```
[05:19:21] Runtime in cloning.dm,364: Cannot read null.pod1
  proc name: Destroy (/obj/machinery/cloning/clonepod/Destroy)
  usr: Test Dummy (kammerjunk) (/mob/dead/observer)
  usr.loc: The floor (133, 64, 2) (/turf/simulated/floor)
  src: the cloning pod (/obj/machinery/cloning/clonepod/full)
  src.loc: the floor (132,66,2) (/turf/simulated/floor)
  call stack:
  the cloning pod (/obj/machinery/cloning/clonepod/full): Destroy()
  qdel(the cloning pod (/obj/machinery/cloning/clonepod/full), 0, 0)
  Kammerjunk (/client): Delete(the cloning pod (/obj/machinery/cloning/clonepod/full))
```
Instead of deleting the clone pod and making a machine frame instead, it'll create the machine frame and leave the clone pod (which will be indestructable to everything, even admin deletion)
Not sure exactly why it happens to begin with. I _suspect_ it'll happen whenever mechanics makes their own clone pod, but it seems to not be the only time it'll happen.

<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl: (as the emoji)
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
