### PR TITLE
Grende prime logging

### DIFF
--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -41,8 +41,8 @@
 		to_chat(user, "<span class='attack'>You prime \the [name]!</span>")
 
 		log_attack("<font color='red'>[user.name] ([user.ckey]) primed \a [src].</font>")
-		log_admin("ATTACK: [user] ([user.ckey]) primed \a [src].")
-		message_admins("ATTACK: [user] ([user.ckey]) primed \a [src].")
+		log_admin("ATTACK: [user] ([user.ckey]) primed \a [src] at ([user.x],[user.y],[user.z]).")
+		message_admins("ATTACK: [user] ([user.ckey]) primed \a [src] at [formatJumpTo(user.loc)].")
 		primed_by = "[user] ([user.ckey])"
 
 		activate()

--- a/code/modules/medical/cloning.dm
+++ b/code/modules/medical/cloning.dm
@@ -361,9 +361,10 @@
 	return..()
 
 /obj/machinery/cloning/clonepod/Destroy()
-	if(connected.pod1 == src)
-		connected.pod1 = null
-	connected = null
+	if(connected)
+		if(connected.pod1 == src)
+			connected.pod1 = null
+		connected = null
 	go_out() //Eject everything
 
 	. = ..()


### PR DESCRIPTION
Will log priming grenades with co-ordinates instead of without. This is what it looks like in the logs:
```
[15:15:23]ADMIN: ATTACK: Admin (kammerjunk) primed a grenade at (109,102,1).
[15:15:23]ADMINWARN: <span class="admin"><span class="prefix">ADMIN LOG:</span> <span class="message">ATTACK: Admin (kammerjunk) primed a grenade at <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=109;Y=102;Z=1'>Bar - 109,102,1</a>.</span></span>
[15:15:26]ACCESS: Logout: *no key*/(Admin) (Bar - 109,102,1)
```
This is what it looks like in-game:
![image](https://cloud.githubusercontent.com/assets/5942183/21566449/6e80c8de-cea3-11e6-96ac-7115637b0f90.png)

If anything else needs similar logging, I might as well do that in this PR, so give a shout.
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl: (as the emoji)
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
