### PR TITLE
Lowers max_chance, replaces magic number with it in virus2

### DIFF
--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -28,7 +28,7 @@ var/global/list/disease2_list = list()
 		if(f.stage == stage && f.badness <= badness)
 			list += f
 	var/datum/disease2/effect/e = pick(list)
-	e.chance = rand(1,6)
+	e.chance = rand(1, e.max_chance)
 	return e
 
 /datum/disease2/disease/proc/makerandom(var/greater=0)

--- a/code/modules/virus2/effect.dm
+++ b/code/modules/virus2/effect.dm
@@ -14,7 +14,7 @@
 
 	var/chance = 3
 		// Under normal conditions, the percentage chance per tick to activate. 
-	var/max_chance = 50	
+	var/max_chance = 6	
 		// Maximum percentage chance per tick.
 
 	var/multiplier = 1


### PR DESCRIPTION
see changes. max_chance being at 6 means the chance for new viruses being created remains the same while minor mutate is now a much more minor change (but who ever minor mutated anyway?)
probably gonna have to go through the effects and set their max_chance manually if they need it

necessary now that we're actually using max_chance for something (vitreous resonance)

:cl:
 * tweak: The maximum chance for effects on minor mutation has been lowered to 6% per tick from 50%. This should NOT result in any significant changes to virology balance due to how rare minor mutations are in gameplay.