### PR TITLE
You can now catch thrown items by having your throw intent on and an empty active hand

### DIFF
--- a/__DEFINES/game.dm
+++ b/__DEFINES/game.dm
@@ -1,0 +1,1 @@
+#define EMBED_THROWING_SPEED 20

--- a/code/modules/mob/living/carbon/combat.dm
+++ b/code/modules/mob/living/carbon/combat.dm
@@ -5,10 +5,21 @@
 	return ..()
 
 /mob/living/carbon/hitby(var/obj/item/I, var/speed, var/dir)
-	if(istype(I) && isturf(I.loc))
-		if(!restrained() && in_throw_mode && !get_active_hand()) //We're an able-bodied person with an empty hand and intent to catch
-			if(speed < EMBED_THROWING_SPEED && put_in_hands(I)) //Can't catch things going too fast
-				visible_message("<span class='warning'>\The [src] catches \the [I]!</span>")
-				throw_mode_off()
-				return 1
+	if(istype(I) && isturf(I.loc) && in_throw_mode) //Only try to catch things while we have throwing mode active (also only items please)
+		if(can_catch(I, speed) && put_in_hands(I))
+			visible_message("<span class='warning'>\The [src] catches \the [I][speed > EMBED_THROWING_SPEED ? ". Wow!" : "!"]</span>")
+			throw_mode_off()
+			return 1
+		else
+			to_chat(src, "<span class='warning'>You fail to catch \the [I]!")
 	return ..()
+
+/mob/living/carbon/proc/can_catch(var/item/I, var/speed)
+	if(restrained() || get_active_hand())
+		return FALSE
+	if(speed > EMBED_THROWING_SPEED) //Can't catch things going too fast unless you're a special boy
+		if((M_RUN in mutations) || (reagents && reagents.has_reagent(METHYLIN)))
+			return TRUE
+		else
+			return FALSE
+	return TRUE

--- a/code/modules/mob/living/carbon/combat.dm
+++ b/code/modules/mob/living/carbon/combat.dm
@@ -3,3 +3,12 @@
 		share_contact_diseases(C)
 
 	return ..()
+
+/mob/living/carbon/hitby(var/obj/item/I, var/speed, var/dir)
+	if(istype(I) && isturf(I.loc))
+		if(!restrained() && in_throw_mode && !get_active_hand()) //We're an able-bodied person with an empty hand and intent to catch
+			if(speed < EMBED_THROWING_SPEED && put_in_hands(I)) //Can't catch things going too fast
+				visible_message("<span class='warning'>[src] catches \the [I]!</span>")
+				throw_mode_off()
+				return 1
+	..()

--- a/code/modules/mob/living/carbon/combat.dm
+++ b/code/modules/mob/living/carbon/combat.dm
@@ -11,4 +11,4 @@
 				visible_message("<span class='warning'>\The [src] catches \the [I]!</span>")
 				throw_mode_off()
 				return 1
-	..()
+	return ..()

--- a/code/modules/mob/living/carbon/combat.dm
+++ b/code/modules/mob/living/carbon/combat.dm
@@ -8,7 +8,7 @@
 	if(istype(I) && isturf(I.loc))
 		if(!restrained() && in_throw_mode && !get_active_hand()) //We're an able-bodied person with an empty hand and intent to catch
 			if(speed < EMBED_THROWING_SPEED && put_in_hands(I)) //Can't catch things going too fast
-				visible_message("<span class='warning'>[src] catches \the [I]!</span>")
+				visible_message("<span class='warning'>\The [src] catches \the [I]!</span>")
 				throw_mode_off()
 				return 1
 	..()

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -102,7 +102,7 @@
 		if(assailant && assailant.mob && istype(assailant.mob,/mob))
 			M = assailant.mob
 
-		if(speed >= 20)
+		if(speed >= EMBED_THROWING_SPEED)
 			var/obj/item/weapon/W = O
 			var/momentum = speed/2
 

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -14,6 +14,7 @@
 #include "__DEFINES\atom_locking.dm"
 #include "__DEFINES\atoms.dm"
 #include "__DEFINES\error_hander.dm"
+#include "__DEFINES\game.dm"
 #include "__DEFINES\global.dm"
 #include "__DEFINES\lighting.dm"
 #include "__DEFINES\limb_defines.dm"


### PR DESCRIPTION
technikally a port from TG

Hilariously shitty demonstration:
![2016-12-30_16-58-16](https://cloud.githubusercontent.com/assets/6526157/21571794/70a00464-ceb1-11e6-9add-f8a36f6441bb.gif)
You cannot catch items unless you have throw intent on. You must have your ACTIVE hand selected to catch something (you can't have your esword in your active hand and keep throw intent on with your other hand empty). Since your throwing intent gets reset when you catch something you need to free your hand and then re-enable it after every catch.

Will conflict with #13146 since I'm using the same new define file that he created there, but it would be trivial for either of us to fix that conflict I think. His PR should be merged before mine anyways.

:cl:
 * rscadd: You can now catch items that were thrown at you by having throw intent enabled and having your active hand empty.