### PR TITLE
Derelict mommis self-destruct if they find their way off the zlevel

### DIFF
--- a/code/game/machinery/mommi_spawner.dm
+++ b/code/game/machinery/mommi_spawner.dm
@@ -122,12 +122,10 @@
 				return TRUE
 
 			if(user.drop_item(O, src))
-				mmi.icon = null
-				mmi.invisibility = 101
-				makeMoMMI(mmi.brainmob)
+				makeMoMMI(mmi.brainmob, mmi)
 				return TRUE
 
-/obj/machinery/mommi_spawner/proc/makeMoMMI(var/mob/user)
+/obj/machinery/mommi_spawner/proc/makeMoMMI(var/mob/user, var/obj/item/device/mmi/use_mmi)
 	building = TRUE
 	update_icon()
 	if(!user || !istype(user) || !user.client)
@@ -158,21 +156,21 @@
 			user.mind.transfer_to(M)
 			if(M.mind.assigned_role == "MoMMI")
 				M.mind.original = M
-			else if(user.mind.special_role)
+			else if(M.mind.special_role)
 				M.mind.store_memory("In case you look at this after being borged, the objectives are only here until I find a way to make them not show up for you, as I can't simply delete them without screwing up round-end reporting. --NeoFite")
-		M.key = user.key
-		M.job = "Mobile MMI"
+		M.job = "MoMMI"
 
 		//M.cell = locate(/obj/item/weapon/cell) in contents
 		//M.cell.loc = M
-		user.forceMove(M)//Should fix cybros run time erroring when blown up. It got deleted before, along with the frame.
 
-		M.mmi = new /obj/item/device/mmi(M)
-		M.mmi.transfer_identity(user)
+		if(use_mmi)
+			M.mmi = use_mmi
+			use_mmi.forceMove(M)
 		M.Namepick()
 		M.updatename()
 
-		qdel(user)
+		if(!use_mmi)
+			qdel(user)
 
 		metal=0
 		building=0

--- a/code/game/machinery/mommi_spawner.dm
+++ b/code/game/machinery/mommi_spawner.dm
@@ -170,6 +170,7 @@
 		M.updatename()
 
 		if(!use_mmi)
+			M.key = user.key
 			qdel(user)
 
 		metal=0

--- a/code/modules/mob/living/silicon/mommi/life.dm
+++ b/code/modules/mob/living/silicon/mommi/life.dm
@@ -23,6 +23,8 @@
 		process_locks()
 	update_canmove()
 	handle_beams()
+	if(locked_to_z)
+		check_locked_zlevel()
 
 
 
@@ -262,5 +264,19 @@
 /mob/living/silicon/robot/mommi/update_canmove()
 	canmove = !(paralysis || stunned || knockdown || locked_to || lockcharge || anchored)
 	return canmove
+
+/mob/living/silicon/robot/mommi/proc/check_locked_zlevel()
+	if(!locked_to_z)
+		return
+
+	var/datum/zLevel/current_zlevel = get_z_level(src)
+	if(!current_zlevel)
+		return
+	if(current_zlevel.z != locked_to_z)
+		to_chat(src, "<span class='userdanger'>Your hardware detects that you have left your intended location. Initiating self-destruct.</span>")
+		if(mmi) //no sneaking brains away
+			qdel(mmi)
+			mmi = null
+		gib()
 
 #undef MOMMI_LOW_POWER

--- a/code/modules/mob/living/silicon/mommi/life.dm
+++ b/code/modules/mob/living/silicon/mommi/life.dm
@@ -274,9 +274,11 @@
 		return
 	if(current_zlevel.z != locked_to_z)
 		to_chat(src, "<span class='userdanger'>Your hardware detects that you have left your intended location. Initiating self-destruct.</span>")
-		if(mmi) //no sneaking brains away
-			qdel(mmi)
-			mmi = null
-		gib()
+		locked_to_z = 0
+		spawn(rand(2,7) SECONDS)
+			if(mmi) //no sneaking brains away
+				qdel(mmi)
+				mmi = null
+			gib()
 
 #undef MOMMI_LOW_POWER

--- a/html/changelogs/Sprok.yml
+++ b/html/changelogs/Sprok.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general deleting of nice things)
+#   rscadd (general adding of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.
+author: Sprok
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# There needs to be a space after the - and before the prefix. Don't use tabs anywhere in this file.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# If you're using characters such as # ' : - or the like in your changelog, surround the entire change with quotes as shown in the second example. These quotes don't show up on the changelog once it's merged and prevent errors.
+# SCREW ANY OF THIS UP AND IT WON'T WORK.
+changes: 
+- bugfix: Derelict MoMMIs now explode if they leave their z-level by any means.


### PR DESCRIPTION
If someone manages to find a way around all the checks on z-locked mommis, they now gib after leaving their designated zlevel.

Fixes #13187
Fixes being able to take them off their level with shuttles
Fixes future ways around z-level locking(for mommis)