### PR TITLE
Emp grenade buff

### DIFF
--- a/code/game/objects/items/weapons/grenades/emgrenade.dm
+++ b/code/game/objects/items/weapons/grenades/emgrenade.dm
@@ -7,6 +7,10 @@
 /obj/item/weapon/grenade/empgrenade/prime()
 	..()
 	empulse(src, 4, 10)
-	spawn(5)
+	sleep(60)
+	empulse(src, 4, 10)
+	sleep(120)
+	empulse(src, 4, 10)
+	spawn(10)
 		qdel(src)
 


### PR DESCRIPTION
As it stands now the EMP grenade is not very good of a weapon. Even with the recent EMP buff these grenades still fall short in comparison to the EMP rifle. Even though they are intended to be a traitor item they are inferior to some ghetto weapons. Emp blasts themsevles cant be buffed without making emp rifles retartedly OP so instead in this change the EMP grenade were adjusted to be worth the price of TC needed to buy them. Instead of a single blast the emp grenade instead causes 3 successive emp blasts before despawning. The exact timings for the emp blasts as follow

Emp grenade primed at second 0
First blast at second 5
second blast at second 12
third blast at second 25
grenade despawns at second 26

I feel this would help make emp grenades not a complete joke in comparison to other weaponry.