### PR TITLE
Mapping-ready AME

### DIFF
--- a/code/modules/power/antimatter/control.dm
+++ b/code/modules/power/antimatter/control.dm
@@ -177,6 +177,7 @@
 				"You hear a ratchet")
 			src.anchored = 1
 			update_shield_icons = 2
+			check_shield_icons()
 			connect_to_network()
 		else if(!linked_shielding.len > 0)
 			playsound(get_turf(src), 'sound/items/Ratchet.ogg', 75, 1)

--- a/code/modules/power/antimatter/control.dm
+++ b/code/modules/power/antimatter/control.dm
@@ -270,6 +270,7 @@
 			AMS.control_unit = null
 			spawn(10)
 				AMS.controllerscan()
+				AMS.assimilate()
 		linked_shielding = list()
 
 	else

--- a/code/modules/power/antimatter/control.dm
+++ b/code/modules/power/antimatter/control.dm
@@ -176,6 +176,7 @@
 				"You secure the anchor bolts to the floor.", \
 				"You hear a ratchet")
 			src.anchored = 1
+			update_shield_icons = 2
 			connect_to_network()
 		else if(!linked_shielding.len > 0)
 			playsound(get_turf(src), 'sound/items/Ratchet.ogg', 75, 1)
@@ -265,6 +266,9 @@
 		return
 	shield_icon_delay = 1
 	if(update_shield_icons == 2)//2 means to clear everything and rebuild
+		for(var/obj/machinery/am_shielding/neighbor in cardinalrange(loc))
+			if(!neighbor.control_unit)
+				linked_shielding += neighbor
 		for(var/obj/machinery/am_shielding/AMS in linked_shielding)
 			if(AMS.processing)
 				AMS.shutdown_core()

--- a/code/modules/power/antimatter/control.dm
+++ b/code/modules/power/antimatter/control.dm
@@ -224,7 +224,8 @@
 		return 0
 	if(!AMS_linking && !AMS.link_control(src))
 		return 0
-	linked_shielding.Add(AMS)
+	if(!(AMS in linked_shielding))
+		linked_shielding.Add(AMS)
 	update_shield_icons = 1
 	return 1
 

--- a/code/modules/power/antimatter/shielding.dm
+++ b/code/modules/power/antimatter/shielding.dm
@@ -77,15 +77,16 @@ proc/cardinalrange(var/center)
 		if(AMS && AMS.control_unit && link_control(AMS.control_unit))
 			break
 
-	if(!control_unit && !mapped)//No other guys nearby, look for a control unit
+	if(!control_unit)//No other guys nearby, look for a control unit
 		for(var/obj/machinery/power/am_control_unit/AMC in cardinalrange(src))
 			if(AMC.add_shielding(src))
 				break
-		if(!priorscan)
-			sleep(20)
-			controllerscan(1)//Last chance
-			return
-		qdel(src)
+		if(!mapped) // Prevent rescanning and suicide if it's part of the map
+			if(!priorscan)
+				sleep(20)
+				controllerscan(1)//Last chance
+				return
+			qdel(src)
 
 /obj/machinery/am_shielding/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(air_group || (height==0))

--- a/code/modules/power/antimatter/shielding.dm
+++ b/code/modules/power/antimatter/shielding.dm
@@ -29,12 +29,14 @@ proc/cardinalrange(var/center)
 	var/efficiency = 1//How many cores this core counts for when doing power processing, plasma in the air and stability could affect this
 	var/coredirs = 0
 	var/dirs=0
+	var/mapped=0 //Set to 1 to ignore usual suicide if it doesn't immediately find a control_unit
 
 
 /obj/machinery/am_shielding/New(loc, var/obj/machinery/power/am_control_unit/AMC)
 	..()
 	if(!AMC)
-		WARNING("AME sector somehow created without a parent control unit!")
+		if (!mapped)
+			WARNING("AME sector somehow created without a parent control unit!")
 		controllerscan()
 		return
 	link_control(AMC)
@@ -75,7 +77,7 @@ proc/cardinalrange(var/center)
 		if(AMS && AMS.control_unit && link_control(AMS.control_unit))
 			break
 
-	if(!control_unit)//No other guys nearby, look for a control unit
+	if(!control_unit && !mapped)//No other guys nearby, look for a control unit
 		for(var/obj/machinery/power/am_control_unit/AMC in cardinalrange(src))
 			if(AMC.add_shielding(src))
 				break

--- a/code/modules/power/antimatter/shielding.dm
+++ b/code/modules/power/antimatter/shielding.dm
@@ -28,8 +28,8 @@ proc/cardinalrange(var/center)
 	var/stability = 100//If this gets low bad things tend to happen
 	var/efficiency = 1//How many cores this core counts for when doing power processing, plasma in the air and stability could affect this
 	var/coredirs = 0
-	var/dirs=0
-	var/mapped=0 //Set to 1 to ignore usual suicide if it doesn't immediately find a control_unit
+	var/dirs = 0
+	var/mapped = 0 //Set to 1 to ignore usual suicide if it doesn't immediately find a control_unit
 
 // Stupidly easy way to use it in maps
 /obj/machinery/am_shielding/map

--- a/code/modules/power/antimatter/shielding.dm
+++ b/code/modules/power/antimatter/shielding.dm
@@ -31,6 +31,9 @@ proc/cardinalrange(var/center)
 	var/dirs=0
 	var/mapped=0 //Set to 1 to ignore usual suicide if it doesn't immediately find a control_unit
 
+// Stupidly easy way to use it in maps
+/obj/machinery/am_shielding/map
+	mapped = 1
 
 /obj/machinery/am_shielding/New(loc, var/obj/machinery/power/am_control_unit/AMC)
 	..()

--- a/code/modules/power/antimatter/shielding.dm
+++ b/code/modules/power/antimatter/shielding.dm
@@ -88,6 +88,15 @@ proc/cardinalrange(var/center)
 				return
 			qdel(src)
 
+// Find surrounding unconnected shielding and add them to our controller
+/obj/machinery/am_shielding/proc/assimilate()
+	if(!control_unit)
+		return // nothing to share :'^(
+	for(var/obj/machinery/am_shielding/neighbor in cardinalrange(src))
+		if(neighbor && !neighbor.control_unit)
+			neighbor.link_control(control_unit)
+			neighbor.assimilate() // recursion is fun, right?
+
 /obj/machinery/am_shielding/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(air_group || (height==0))
 		return 1


### PR DESCRIPTION
 * Adds a new subtype `/obj/machinery/am_shielding/map` which prevents the shielding units from generating warnings and deleting themselves if they fail to find other AME parts.
 * Makes all AME shielding recursively seek out adjacent parts without a controller when spawned/constructed.
 * Changes the "Refresh Parts" button on the controller to engage that seeking functionality, rather than just update the icons.