### PR TITLE
Potential virus2 hotfix that raises your hopes then almost immediately dashes them

### DIFF
--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -22,9 +22,11 @@ var/global/list/virusDB = list()
 	..()
 
 /datum/disease2/disease/proc/generate_uniqueID()
+	var/original_id = uniqueID
 	for (var/x = 1 to 5)
 		uniqueID = rand(1, 10000)
-		if (!disease2_list.Find("[uniqueID]")) // Not a dupe! We'll try five times and then just accept it.
+		if (!disease2_list.Find("[original_id]")) // Not a dupe! We'll try five times and then just accept it.
+			disease2_list.Remove("[uniqueID]") // just in case we call this proc a lot
 			disease2_list["[uniqueID]"] = src
 			return
 
@@ -67,7 +69,7 @@ var/global/list/virusDB = list()
 		var/datum/disease2/effect/symptom = input(C, "Choose a symptom to add ([5-i] remaining)", "Choose a Symptom") in (typesof(/datum/disease2/effect))
 			// choose a symptom from the list of them
 		var/datum/disease2/effect/e = new symptom(D)
-		e.chance = input(C, "Choose chance", "Chance") as num 
+		e.chance = input(C, "Choose chance", "Chance") as num
 			// set the chance of the symptom that can occur
 		if(e.chance > 100 || e.chance < 0)
 			return 0


### PR DESCRIPTION
This very likely doesn't do anything to prevent the crash that happened, it just changes `generate_uniqueID` so that it vacates the old uniqueID when a new one is assigned so we don't get any future problems from having the proc called a lot.

Fun fact: did you know that `disease2_list`, the global list of diseases, doesn't actually do anything? https://github.com/d3athrow/vgstation13/search?utf8=%E2%9C%93&q=disease2_list