### PR TITLE
Gives the lockers on the outpost more suits

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/syndicate.dm
+++ b/code/game/objects/structures/crates_lockers/closets/syndicate.dm
@@ -162,9 +162,8 @@
 
 	New()
 		sleep(2)
-		new /obj/item/clothing/head/helmet/space/vox/civ/trader(src)
+		new /obj/map/spawner/space/vox/trader/spacesuit(src)
 		new /obj/item/clothing/mask/breath/vox(src)
 		new /obj/item/clothing/shoes/magboots/vox(src)
-		new /obj/item/clothing/suit/space/vox/civ/trader(src)
 		new /obj/item/clothing/under/vox/vox_casual(src)
 		new /obj/item/weapon/tank/jetpack/nitrogen(src)

--- a/code/modules/clothing/spacesuits/alien.dm
+++ b/code/modules/clothing/spacesuits/alien.dm
@@ -147,22 +147,59 @@
 		to_chat(usr, "You dig your claws deeply into the flooring, bracing yourself.")
 
 
-// Vox Trader -- Same stats as civ gear, but looks like raiders.
-/obj/item/clothing/suit/space/vox/civ/trader
+// Vox Trader -- Same stats as civ gear, but looks like raiders. ///////////////////////////////
+/obj/item/clothing/suit/space/vox/civ/trader // brownsuit
 	name = "alien pressure suit"
 	icon_state = "vox-pressure"
 	item_state = "vox-pressure"
 	desc = "A huge, pressurized suit, designed for distinctly nonhuman proportions. It looks unusually cheap, even for Vox."
 	goliath_reinforce = TRUE
 
-/obj/item/clothing/head/helmet/space/vox/civ/trader
+/obj/item/clothing/head/helmet/space/vox/civ/trader //brownhelmet
 	name = "alien helmet"
 	icon_state = "vox-pressure"
 	item_state = "vox-pressure"
 	desc = "Hey, wasn't this a prop in \'The Abyss\'?"
 	goliath_reinforce = TRUE
 
-// Vox Casual
+/obj/item/clothing/suit/space/vox/civ/trader/carapace //carapace
+	name = "alien carapace armor"
+	icon_state = "vox-carapace"
+	item_state = "vox-carapace"
+	desc = "An armored, segmented carapace with glowing purple lights. It looks like someone stripped most of the armor off."
+
+/obj/item/clothing/head/helmet/space/vox/civ/trader/carapace //carapace helmet
+	name = "alien visor"
+	icon_state = "vox-carapace"
+	item_state = "vox-carapace"
+	desc = "A glowing visor, perhaps stolen from a depressed Cylon."
+	eyeprot = 3
+
+/obj/item/clothing/suit/space/vox/civ/trader/medic // aquasuit
+	name = "alien armor"
+	icon_state = "vox-medic"
+	item_state = "vox-medic"
+	desc = "An almost organic looking nonhuman pressure suit."
+
+/obj/item/clothing/head/helmet/space/vox/civ/trader/medic //aquahelmet
+	name = "alien goggled helmet"
+	icon_state = "vox-medic"
+	item_state = "vox-medic"
+	desc = "An alien helmet with enormous goggled lenses."
+
+/obj/item/clothing/suit/space/vox/civ/trader/stealth // blacksuit
+	name = "alien stealth suit"
+	icon_state = "vox-stealth"
+	item_state = "vox-stealth"
+	desc = "A sleek black suit. It seems to have a tail, and is very heavy."
+
+obj/item/clothing/head/helmet/space/vox/civ/trader/stealth //blackhelmet
+	name = "alien stealth helmet"
+	icon_state = "vox-stealth"
+	item_state = "vox-stealth"
+	desc = "A smoothly contoured, matte-black alien helmet.?"
+
+// Vox Casual//////////////////////////////////////////////
 // Civvie
 /obj/item/clothing/suit/space/vox/civ
 	name = "vox assistant pressure suit"

--- a/code/modules/maps/spawners/spawners.dm
+++ b/code/modules/maps/spawners/spawners.dm
@@ -814,6 +814,27 @@
 	chance = 5
 	to_spawn = list(/mob/living/simple_animal/hostile/humanoid/russian/ranged)
 
+/obj/map/spawner/space/vox/trader/spacesuit // for the vox outpost trader closets to spawn a random hardsuit. Each hardsuit has the same stats which are ofcourse very poor armor.
+ 	name = "trader spacesuit spawner"
+ 	icon_state = "space_supply"
+
+/obj/map/spawner/space/vox/trader/spacesuit/perform_spawn()
+	var/i = rand(1, 4) // 1 in 4 chance of spawning a single of listed below
+	switch (i)
+		if (1)
+			new /obj/item/clothing/suit/space/vox/civ/trader(src.loc) // standard brownsuit and helmet
+			new /obj/item/clothing/head/helmet/space/vox/civ/trader(src.loc)
+
+		if (2)
+			new /obj/item/clothing/suit/space/vox/civ/trader/carapace(src.loc) // carapace
+			new /obj/item/clothing/head/helmet/space/vox/civ/trader/carapace(src.loc)
+		if (3)
+			new /obj/item/clothing/suit/space/vox/civ/trader/medic(src.loc) // aqua coloured hardsuit
+			new /obj/item/clothing/head/helmet/space/vox/civ/trader/medic(src.loc)
+		if (4)
+			new /obj/item/clothing/suit/space/vox/civ/trader/stealth(src.loc) // black hardsuit. Not capable of any form of stealth systems or shit like that
+			new /obj/item/clothing/head/helmet/space/vox/civ/trader/stealth(src.loc)
+
 // Mobs ////////////////////////////////////////////////////////
 
 /obj/map/spawner/mobs/carp
@@ -1179,3 +1200,5 @@
 	/obj/item/weapon/reagent_containers/food/snacks/bacon,
 	/obj/item/weapon/reagent_containers/food/snacks/bacon
 )
+
+


### PR DESCRIPTION
In this change the red locker on the vox outpost can now spawn 1 of the 4 sets of special vox hardsuits that were tucked away in the code. The hardsuits have had special version made with the same stats of the normal weak trader hardsuit so traders dont get near HOS trenchcoat levels of protection.