### PR TITLE
Reverts Pico manipluator costing materials

### DIFF
--- a/code/modules/research/designs/engineering.dm
+++ b/code/modules/research/designs/engineering.dm
@@ -99,7 +99,7 @@
 	id = "rped"
 	req_tech = list(Tc_ENGINEERING = 4, Tc_MATERIALS = 4, Tc_PROGRAMMING = 2)
 	build_type = PROTOLATHE
-	materials = list(MAT_IRON = 60000, MAT_GLASS = 30000)
+	materials = list(MAT_IRON = 20000, MAT_GLASS = 10000)
 	build_path = /obj/item/weapon/storage/bag/gadgets/part_replacer
 	category = "Engineering"
 

--- a/code/modules/research/designs/stock_parts.dm
+++ b/code/modules/research/designs/stock_parts.dm
@@ -129,7 +129,7 @@
 	id = "pico_mani"
 	req_tech = list(Tc_MATERIALS = 5, Tc_PROGRAMMING = 2)
 	build_type = PROTOLATHE
-	materials = list(MAT_IRON = 30, MAT_URANIUM = 10, MAT_SILVER = 20)
+	materials = list(MAT_IRON = 30)
 	reliability_base = 73
 	category = "Stock Parts"
 	build_path = /obj/item/weapon/stock_parts/manipulator/nano/pico


### PR DESCRIPTION
I had originally made this to compliment a buff to fabricators but as it turns out community was against this so i am undoing it. The pico manip just costs metal now. Also i reduced the price of the RPED since it would take well up to 2 minutes to build one with the old price to where it now takes only 40 seconds to build.