### PR TITLE
Nerfs viruloose

### DIFF
--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -128,7 +128,7 @@ var/global/list/disease2_list = list()
 			clicks = 0
 
 	// This makes it so that <mob> only ever gets affected by the equivalent of one virus so antags don't just stack a bunch
-	if(prob(100 - (100 / mob.virus2.len))
+	if(prob(100 - (100 / mob.virus2.len)))
 		return
 
 	//Do nasty effects

--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -106,10 +106,6 @@ var/global/list/disease2_list = list()
 	if(mob.reagents.has_reagent(SPACEACILLIN))
 		return
 
-	// Prevents virus stacks of doom - if you have many viruses, they "take turns" / progress slower / eat each other
-	if(prob(100 - (100 / mob.virus2.len))
-		return
-
 	//Virus food speeds up disease progress
 	if(mob.reagents.has_reagent(VIRUSFOOD))
 		mob.reagents.remove_reagent(VIRUSFOOD,0.1)
@@ -130,6 +126,11 @@ var/global/list/disease2_list = list()
 			stage++
 			log += "<br />[timestamp()] NEXT STAGE ([stage])"
 			clicks = 0
+
+	// This makes it so that <mob> only ever gets affected by the equivalent of one virus so antags don't just stack a bunch
+	if(prob(100 - (100 / mob.virus2.len))
+		return
+
 
 	//Do nasty effects
 	for(var/datum/disease2/effect/e in effects)

--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -131,7 +131,6 @@ var/global/list/disease2_list = list()
 	if(prob(100 - (100 / mob.virus2.len))
 		return
 
-
 	//Do nasty effects
 	for(var/datum/disease2/effect/e in effects)
 		if (e.can_run_effect(stage))

--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -61,7 +61,7 @@ var/global/list/disease2_list = list()
 		var/datum/disease2/effect/symptom = input(C, "Choose a symptom to add ([5-i] remaining)", "Choose a Symptom") in (typesof(/datum/disease2/effect))
 			// choose a symptom from the list of them
 		var/datum/disease2/effect/e = new symptom(D)
-		e.chance = input(C, "Choose chance", "Chance") as num 
+		e.chance = input(C, "Choose chance", "Chance") as num
 			// set the chance of the symptom that can occur
 		if(e.chance > 100 || e.chance < 0)
 			return 0
@@ -104,6 +104,10 @@ var/global/list/disease2_list = list()
 
 	//Space antibiotics stop disease completely (temporary)
 	if(mob.reagents.has_reagent(SPACEACILLIN))
+		return
+
+	// Prevents virus stacks of doom - if you have many viruses, they "take turns" / progress slower / eat each other
+	if(prob(100 - (100 / mob.virus2.len))
 		return
 
 	//Virus food speeds up disease progress


### PR DESCRIPTION
So with the recent changes to the pathogenic incubator, it's become easier than ever to order a bunch of virus crates and inject dozens of viruses into a single syringe then stick someone with 'em, stacking the effects into what I call a viruloose.

This simple-to-understand change makes it so that a `mob` essentially only ever has one virus's worth of effects acting on them: 

- if you have one virus in your system, it has a 100% chance per tick of activating
- if you have two viruses, they _each_ have a 50% chance per tick to activate. put another way, it's like you have one virus that activates has two effects per stage, choosing to run one of the effects at random each tick
- three viruses, 33% each
and so on

What would the IC explanation for this trait of viruses be?

- They're space viruses and fun > immulsions, I don't have to explain any more than that
- They fight each other for blood/space in the human body
- They literally attack each other? """"""""""""virus"""""""""""" already behaves like bacteria, might as well make it behave like parasites too
- Despite having different antigens, the body reacting to one virus affects its reaction to other viruses
- https://www.youtube.com/watch?v=gmBj8r1-fDo


This has subtler balance implications for "one-time-only" activation effects like Gibbington's or the voice affecting changes, but otherwise serves its purpose well for the other 90% of effects.

Antag virologists will now want to:

- Actually study viruses and splice the most potent effects together instead of just viruloosing every virus they have without second thought. In fact, viroloosing is now a really ineffective strategy: it's (usually) easier to survive 10 of every damage type than 100 of one damage type
- Release combinations of viruses whose effects work well together like... gaben and glasgow syndrome? get both drunk and fat? nothing really jumps out but I'm sure they'll find entertaining combinations

Non-antag virologists will now want to:

- Generate a bunch of neutral viruses to stick into people who are infected with harmful viruses to lessen the chance that they activate the harmful virus's effect
- Similarly, they might even want to have neutral viruses infect the station on a regular basis so that bad viruses have a lower chance of activating
- They might, if future updates remove antigens or rework them considerably, want to find neutral viruses that "cancel out" the effects of a bad virus - right now most effects are very polarized and either super good or super bad, but if you take https://github.com/d3athrow/vgstation13/pull/13202 as an example, it cures brain damage when around other people - so it might be a good idea to use this effect to "counter" Lazy Mind syndrome. 

:cl:
 * tweak: Viruses effectively no longer "stack"; you can still have many viruses in one person and they still progress at the same speed, but they no longer add to each other such that being injected with a hundred of them pretty much instakills you. Instead, they now act as if they combined into one virus: one virus has a 100% chance of activating per tick, two viruses each have a 50% chance of activating per tick, three viruses each have 33% chance, etc. Get creative with your viruses instead of just viruloosing!