### PR TITLE
pAI MULEbots

### DIFF
--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -18,6 +18,7 @@ var/global/mulebot_count = 0
 	maxhealth = 150
 	fire_dam_coeff = 0.7
 	brute_dam_coeff = 0.5
+	can_take_pai = TRUE
 	var/atom/movable/load = null		// the loaded crate (usually)
 	var/beacon_freq = 1400
 	var/control_freq = 1447
@@ -491,7 +492,7 @@ var/global/mulebot_count = 0
 	// with items dropping as mobs are loaded
 
 	for(var/atom/movable/AM in src)
-		if(AM == cell || AM == botcard)
+		if(AM == cell || AM == botcard || AM == integratedpai)
 			continue
 
 		AM.forceMove(src.loc)
@@ -922,3 +923,32 @@ var/global/mulebot_count = 0
 	O.New(O.loc)
 	unload(0)
 	qdel(src)
+
+/obj/machinery/bot/mulebot/getpAIMovementDelay()
+	return ((wires.Motor1() ? 1 : 0) + (wires.Motor2() ? 2 : 0) - 1) * 2
+
+/obj/machinery/bot/mulebot/pAImove(mob/living/silicon/pai/user, dir)
+	if(getpAIMovementDelay() < 0)
+		to_chat(user, "There seems to be something wrong with the motor. Have a technician check the wires.")
+		return
+	if(!..())
+		return
+	if(!on)
+		to_chat(user, "You can't move \the [src] while it's turned off.")
+		return
+	var/turf/T = loc
+	if(!T.has_gravity())
+		return
+	step(src, dir)
+
+/obj/machinery/bot/mulebot/on_integrated_pai_click(mob/living/silicon/pai/user, var/atom/movable/A)
+	if(!istype(A) || !Adjacent(A) || A.anchored)
+		return
+	load(A)
+	if(load)
+		to_chat(user, "You load \the [A] onto \the [src].")
+
+/obj/machinery/bot/mulebot/attack_integrated_pai(mob/living/silicon/pai/user)
+	if(load)
+		to_chat(user, "You unload \the [load].")
+		unload()

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -550,6 +550,7 @@ Class Procs:
 	return emag_cost
 
 /obj/machinery/attackby(var/obj/O, var/mob/user)
+	..()
 	if(istype(O, /obj/item/weapon/card/emag) && machine_flags & EMAGGABLE)
 		var/obj/item/weapon/card/emag/E = O
 		if(E.canUse(user,src))
@@ -605,10 +606,10 @@ Class Procs:
 	if(!P.hackloop(src))
 		return 0
 	return 1
-	
+
 /obj/machinery/proc/can_overload(mob/user) //used for AI machine overload
 	return(src in machines)
-	
+
 /obj/machinery/proc/shock(mob/user, prb, var/siemenspassed = -1)
 	if(stat & (BROKEN|NOPOWER))		// unpowered, no shock
 		return 0

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -31,6 +31,8 @@ var/global/list/reagents_to_log = list(FUEL, PLASMA, PACID, SACID, AMUTATIONTOXI
 
 	var/can_take_pai = FALSE
 	var/obj/item/device/paicard/integratedpai = null
+	var/datum/delay_controller/pAImove_delayer = new(1, ARBITRARILY_LARGE_NUMBER)
+	var/pAImovement_delay = 0
 
 /obj/New()
 	..()
@@ -96,6 +98,19 @@ var/global/list/reagents_to_log = list(FUEL, PLASMA, PACID, SACID, AMUTATIONTOXI
 
 /obj/proc/intenthurt_integrated_pai(mob/living/silicon/pai/user)	//called when integrated pAI uses the hurt intent hotkey
 	return
+
+/obj/proc/pAImove(mob/living/silicon/pai/user, dir)					//called when integrated pAI attempts to move
+	if(pAImove_delayer.blocked())
+		return 0
+	else
+		delayNextpAIMove(getpAIMovementDelay())
+		return 1
+
+/obj/proc/getpAIMovementDelay()
+	return pAImovement_delay
+
+/obj/proc/delayNextpAIMove(var/delay, var/additive=0)
+	pAImove_delayer.delayNext(delay,additive)
 
 /obj/proc/on_integrated_pai_click(mob/living/silicon/pai/user, var/atom/A)
 	if(istype(A,/obj/machinery)||(istype(A,/mob)&&user.secHUD))

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -314,6 +314,13 @@
 					if("left")
 						O.intentleft_integrated_pai(P)
 
+/mob/living/silicon/pai/relaymove(dir)
+	if(incapacitated())
+		return
+	if(istype(card.loc, /obj))
+		var/obj/O = card.loc
+		if(O.integratedpai == card)
+			O.pAImove(src, dir)
 
 /atom/proc/attack_pai(mob/user as mob)
 	return

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -270,6 +270,11 @@
 	if(isAI(mob))
 		return AIMove(loc,dir,mob)
 
+	if(ispAI(mob))
+		var/mob/living/silicon/pai/P = mob
+		P.relaymove(dir)
+		return
+
 	if(mob.monkeyizing)
 		return//This is sota the goto stop mobs from moving var
 


### PR DESCRIPTION
Adds a framework to allow pAI movements to be passed to the object into which it's integrated.

Allows pAIs to be inserted into MULEbots. While inside a MULEbot, the pAI can load objects by clicking on them and unload by clicking the MULEbot or pressing the "use" hotkey.
The MULEbot can only be moved while it is turned on, and factors like movement speed, what can be loaded, and knocking over mobs are governed by the MULEbot's wires same as they are for the MULEbot itself.

:cl:
 * rscadd: pAIs can now be inserted into MULEbots. They can move the MULEbot, as well as click objects to load them. The pAI can unload the MULEbot by clicking it, or pressing the "use" hotkey.
