### PR TITLE
improves check_body_part_coverage(), makes it easier to splash grays

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -76,10 +76,14 @@ emp_act
 /mob/living/carbon/human/proc/check_body_part_coverage(var/body_part_flags=0)
 	if(!body_part_flags)
 		return 0
+	var/parts_to_check = body_part_flags
 	for(var/obj/item/clothing/C in get_clothing_items())
 		if(!C)
 			continue
-		if(C.body_parts_covered & body_part_flags)
+		if((C.body_parts_covered & body_part_flags) == body_part_flags)
+			return 1
+		parts_to_check &= ~(C.body_parts_covered)
+		if(!parts_to_check)
 			return 1
 	return 0
 

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -376,15 +376,11 @@
 	//Greys treat water like acid
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
-		if(H.species.name == "Grey")
+		if(isgrey(H))
 			if(method == TOUCH)
 
-				if(H.wear_mask)
-					to_chat(H, "<span class='warning'>Your mask protects you from the water!</span>")
-					return
-
-				if(H.head)
-					to_chat(H, "<span class='warning'>Your helmet protects you from the water!</span>")
+				if(H.check_body_part_coverage(EYES|MOUTH))
+					to_chat(H, "<span class='warning'>Your face is protected from a splash of water!</span>")
 					return
 
 				if(M.acidable())


### PR DESCRIPTION
check_body_part_coverage() doesn't need all the flags given to it to be blocked by a single piece of clothing anymore.

Greys need to have their eyes and mouth covered to avoid being melted by splashed water, instead of having anything in their hat or mask slot.

Fixes  #13280