### PR TITLE
Remove fake recall from rev and revsquad

### DIFF
--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -110,7 +110,7 @@
 		greet_revolutionary(rev_mind)
 	modePlayer += head_revolutionaries
 	if(emergency_shuttle)
-		emergency_shuttle.always_fake_recall = 1
+		emergency_shuttle.always_fake_recall = 0
 	spawn (rand(waittime_l, waittime_h))
 		if(!mixed)
 			send_intercept()

--- a/code/game/gamemodes/revolution/revsquad.dm
+++ b/code/game/gamemodes/revolution/revsquad.dm
@@ -95,7 +95,7 @@
 	modePlayer += head_revolutionaries
 
 	if(emergency_shuttle)
-		emergency_shuttle.always_fake_recall = 1
+		emergency_shuttle.always_fake_recall = 0
 
 	spawn (rand(waittime_l, waittime_h))
 		if(!mixed)


### PR DESCRIPTION
I explicitly remember changing these but apparently I didn't
Closes #13042, #12534
Revsquad change is bugfix and rev is there too because WHY NOT
🆑 
 - bugfix: Revsquad no longer auto recalls.
 - experiment: Revolution also no longer auto recalls.