### PR TITLE
Shrunk APC power alert on/off threshold gap. (#3417)

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1145,7 +1145,7 @@
 			equipment = autoset(equipment, 1)
 			lighting = autoset(lighting, 1)
 			environ = autoset(environ, 1)
-			if(cell.percent() > 75 && !areaMaster.poweralm && make_alerts)
+			if(cell.percent() > 35 && !areaMaster.poweralm && make_alerts) // 35% to prevent spamming alerts if it fluctuates
 				areaMaster.poweralert(1, src)
 
 		// now trickle-charge the cell


### PR DESCRIPTION

:cl:
 * tweak: Power alerts now issued and dismissed at 30% and 35%, rather than 30% and 75%.