### PR TITLE
Improves A* pathfinding with One Weird Trick

### DIFF
--- a/code/defines/procs/AStar.dm
+++ b/code/defines/procs/AStar.dm
@@ -215,7 +215,7 @@ proc/AStar(start,end,adjacent,dist,maxnodes,maxnodedepth = 30,mintargetdist,minn
 			else //is already in open list, check if it's a better way from the current turf
 				if(newg < T.PNode.g)
 					T.PNode.prevNode = cur
-					T.PNode.g = newg
+					T.PNode.g = (newg * L.len / 9)
 					T.PNode.calc_f()
 					open.ReSort(T.PNode)//reorder the changed element in the list
 


### PR DESCRIPTION
Improves A* pathfinding performance, **bots lag less**

# old
![687474703a2f2f692e696d6775722e636f6d2f37636d363975442e706e67](https://cloud.githubusercontent.com/assets/4081722/21745599/5783bc4e-d4e4-11e6-97f3-33d65194c00a.png)
# new
![687474703a2f2f692e696d6775722e636f6d2f516245547448792e706e67](https://cloud.githubusercontent.com/assets/4081722/21745601/5f802c8e-d4e4-11e6-9006-c5162467cc18.png)

PS. this file is horrifying please port our A* from here please:

https://raw.githubusercontent.com/tgstation/tgstation/master/code/orphaned_procs/AStar.dm