### PR TITLE
Absolute pathing for defines/obj/weapon.dm

### DIFF
--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -875,9 +875,9 @@
 	desc = "test lightning"
 	flags = 0
 
-	New()
-		icon = midicon
-		icon_state = "1"
+/obj/item/weapon/lightning/New()
+	icon = midicon
+	icon_state = "1"
 
 /obj/item/weapon/lightning/afterattack(atom/A as mob|obj|turf|area, mob/living/user as mob|obj, flag, params)
 	var/angle = get_angle(A, user)


### PR DESCRIPTION
``` 

//TODO: Figure out wtf this is and possibly remove it -Nodrak
/obj/item/weapon/dummy
	name = "dummy"
	invisibility = 101.0
	anchored = 1.0
	flags = 0

```

<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl: (as the emoji)
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
