### PR TITLE
Optimizes PDA stationmap asset sending to hopefully cut PDA opening time delay

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -958,6 +958,10 @@ var/global/list/obj/item/device/pda/PDAs = list()
 								"}
 
 			if (PDA_APP_STATIONMAP)
+				if(user.client)
+					var/datum/asset/simple/C = new/datum/asset/simple/pda_stationmap()
+					send_asset_list(user.client, C.assets)
+
 				var/datum/pda_app/station_map/app = locate(/datum/pda_app/station_map) in applications
 				dat += {"<h4>Station Map Application</h4>"}
 				if(app)

--- a/code/modules/client/global cache.dm
+++ b/code/modules/client/global cache.dm
@@ -180,7 +180,11 @@
 		"pda_clock.png"			= 'icons/pda_icons/pda_clock.png',
 		"pda_game.png"		= 'icons/pda_icons/pda_game.png',
 		"pda_egg.png"			= 'icons/pda_icons/pda_egg.png',
-		"pda_money.png"				= 'icons/pda_icons/pda_money.png',
+		"pda_money.png"				= 'icons/pda_icons/pda_money.png'
+	)
+
+/datum/asset/simple/pda_stationmap
+	assets = list(
 		"pda_minimap_box.png"	= 'icons/pda_icons/pda_minimap_box.png',
 		"pda_minimap_bg_notfound.png"	= 'icons/pda_icons/pda_minimap_bg_notfound.png',
 		"pda_minimap_deff.png"					= 'icons/pda_icons/pda_minimap_deff.png',


### PR DESCRIPTION
You know when you try to open your PDA for the first time and it takes like 15 seconds to open?
What this SHOULD do is cut off some of those seconds, which you will then only experience when (if) you ever try opening the station app map for the first time