### PR TITLE
Fixes powernet random event magically refilling SMES and setting their output to M A X I M U M P O W E R

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -568,6 +568,7 @@ var/global/list/bad_changing_colour_ckeys = list()
 #define POWEROFF	4		// tbd
 #define MAINT		8			// under maintaince
 #define EMPED		16		// temporary broken by EMP pulse
+#define FORCEDISABLE 32 //forced to be off, such as by a random event
 
 //bitflags for door switches.
 #define OPEN	1

--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -35,8 +35,11 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	var/always_unpowered = 0	//this gets overriden to 1 for space in area/New()
 
 	var/power_equip = 1
+	var/old_power_equip = 1
 	var/power_light = 1
+	var/old_power_light = 1
 	var/power_environ = 1
+	var/old_power_environ = 1
 	var/music = null
 	var/used_equip = 0
 	var/used_light = 0

--- a/code/game/gamemodes/events/power_failure.dm
+++ b/code/game/gamemodes/events/power_failure.dm
@@ -55,7 +55,7 @@
 		command_alert(/datum/command_alert/power_restored)
 	for(var/obj/machinery/power/apc/C in power_machines)
 		if(C.cell && C.z == map.zMainStation)
-			C.cell.charge = min(C.cell.maxcharge, max(C.old_charge, C.cell.charge))
+			C.cell.charge = Clamp(C.cell.charge, C.old_charge, C.cell.maxcharge)
 			C.chargemode = 1
 	for(var/obj/machinery/power/battery/smes/S in power_machines)
 		if(S.z != map.zMainStation)

--- a/code/game/gamemodes/events/power_failure.dm
+++ b/code/game/gamemodes/events/power_failure.dm
@@ -6,11 +6,8 @@
 	for(var/obj/machinery/power/battery/smes/S in power_machines)
 		if(istype(get_area(S), /area/turret_protected) || S.z != map.zMainStation)
 			continue
-		S.charge = 0
-		S.output = 0
-		S.online = 0
+		S.stat |= FORCEDISABLE
 		S.update_icon()
-		S.power_change()
 
 	var/list/skipped_areas = list(/area/engineering/engine, /area/turret_protected/ai)
 
@@ -30,8 +27,11 @@
 				break
 		if(skip)
 			continue
+		A.old_power_light = A.power_light
 		A.power_light = 0
+		A.old_power_equip = A.power_equip
 		A.power_equip = 0
+		A.old_power_environ = A.power_environ
 		A.power_environ = 0
 
 	for(var/obj/machinery/power/apc/C in power_machines)
@@ -45,6 +45,7 @@
 			if(skip)
 				continue
 			C.chargemode = 0
+			C.old_charge = C.cell.charge
 			C.cell.charge = 0
 
 /proc/power_restore(var/announce = 1)
@@ -54,21 +55,19 @@
 		command_alert(/datum/command_alert/power_restored)
 	for(var/obj/machinery/power/apc/C in power_machines)
 		if(C.cell && C.z == map.zMainStation)
-			C.cell.charge = C.cell.maxcharge
+			C.cell.charge = min(C.cell.maxcharge, max(C.old_charge, C.cell.charge))
 			C.chargemode = 1
 	for(var/obj/machinery/power/battery/smes/S in power_machines)
 		if(S.z != map.zMainStation)
 			continue
-		S.charge = S.capacity
-		S.output = 200000
-		S.online = 1
+		S.stat &= ~FORCEDISABLE
 		S.update_icon()
-		S.power_change()
+
 	for(var/area/A in areas)
 		if(A.name != "Space" && A.name != "Engine Walls" && A.name != "Chemical Lab Test Chamber" && A.name != "space" && A.name != "Escape Shuttle" && A.name != "Arrival Area" && A.name != "Arrival Shuttle" && A.name != "start area" && A.name != "Engine Combustion Chamber")
-			A.power_light = 1
-			A.power_equip = 1
-			A.power_environ = 1
+			A.power_light = max(A.power_light, A.old_power_light)
+			A.power_equip = max(A.power_equip, A.old_power_equip)
+			A.power_environ = max(A.power_environ, A.old_power_environ)
 	suspend_alert = 0
 
 /proc/power_restore_quick(var/announce = 1)

--- a/code/modules/events/grid_check.dm
+++ b/code/modules/events/grid_check.dm
@@ -1,15 +1,11 @@
 /datum/event/grid_check	//NOTE: Times are measured in master controller ticks!
 	announceWhen		= 5
-	var/list/settings = list()
 
 /datum/event/grid_check/setup()
 	endWhen = rand(30,120)
 
 /datum/event/grid_check/start()
 	power_failure(0)
-
-	for(var/obj/machinery/power/battery/smes/S in power_machines)
-		settings[S] = list(S.charge, S.output, S.online)
 
 /datum/event/grid_check/announce()
 	command_alert(/datum/command_alert/power_disabled)
@@ -19,11 +15,3 @@
 		message_admins("Universe isn't normal, aborting power_restore().")//we don't want the power to come back up during Nar-Sie or a Supermatter Cascade, do we?
 		return
 	power_restore()
-
-	for(var/obj/machinery/power/battery/smes/S in settings)
-		var/list/oursettings = settings[S]
-		if(oursettings)
-			S.charge = oursettings[1]
-			S.output = oursettings[2]
-			S.online = oursettings[3]
-	settings = null

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -52,6 +52,7 @@
 	var/spooky=0
 	var/obj/item/weapon/cell/cell
 	var/start_charge = 90				// initial cell charge %
+	var/old_charge = 0					// how much charge did this thing have before a random event knocked it out
 	var/cell_type = 2500				// 0=no cell, 1=regular, 2=high-cap (x5) <- old, now it's just 0=no cell, otherwise dictate cellcapacity by changing this value. 1 used to be 1000, 2 was 2500
 	var/opened = 0                      //0=closed, 1=opened, 2=cover removed
 	var/shorted = 0
@@ -1043,7 +1044,7 @@
 
 /obj/machinery/power/apc/process()
 
-	if(stat & (BROKEN|MAINT))
+	if(stat & (BROKEN|MAINT|FORCEDISABLE))
 		return
 	if(!areaMaster.requires_power)
 		return

--- a/code/modules/power/battery.dm
+++ b/code/modules/power/battery.dm
@@ -24,7 +24,7 @@ var/global/list/battery_online =	list(
 
 /obj/machinery/power/battery/update_icon()
 	overlays.len = 0
-	if(stat & BROKEN)
+	if(stat & (BROKEN | FORCEDISABLE))
 		return
 
 	overlays += battery_online[online + 1]
@@ -86,7 +86,8 @@ var/global/list/battery_online =	list(
 	smes_output_max = initial(smes_output_max) + lasercount*25000
 
 /obj/machinery/power/battery/process()
-	if (stat & BROKEN)
+	if(stat & (BROKEN | FORCEDISABLE))
+		last_charge = 0
 		return
 
 	if(infinite_power) //Only used for magical machines - BEWARE
@@ -297,23 +298,10 @@ var/global/list/battery_online =	list(
 
 
 /obj/machinery/power/battery/emp_act(severity)
-
-	var/old_online = online
-	var/old_charging = charging
-	var/old_output = output
-
-	online = 0
-	charging = 0
-	output = 0
 	charge = max(0, charge - 1e6/severity)
-
+	stat |= FORCEDISABLE
 	spawn(100)
-		if(output == 0)
-			output = old_output
-		if(online == 0)
-			online = old_online
-		if(charging == 0)
-			charging = old_charging
+		stat &= ~FORCEDISABLE
 	..()
 
 /proc/rate_control(var/S, var/V, var/C, var/Min=1, var/Max=5, var/Limit=null)

--- a/code/modules/power/battery.dm
+++ b/code/modules/power/battery.dm
@@ -24,7 +24,7 @@ var/global/list/battery_online =	list(
 
 /obj/machinery/power/battery/update_icon()
 	overlays.len = 0
-	if(stat & (BROKEN | FORCEDISABLE))
+	if(stat & (BROKEN | FORCEDISABLE | EMPED))
 		return
 
 	overlays += battery_online[online + 1]
@@ -86,7 +86,7 @@ var/global/list/battery_online =	list(
 	smes_output_max = initial(smes_output_max) + lasercount*25000
 
 /obj/machinery/power/battery/process()
-	if(stat & (BROKEN | FORCEDISABLE))
+	if(stat & (BROKEN | FORCEDISABLE | EMPED))
 		last_charge = 0
 		return
 
@@ -299,9 +299,9 @@ var/global/list/battery_online =	list(
 
 /obj/machinery/power/battery/emp_act(severity)
 	charge = max(0, charge - 1e6/severity)
-	stat |= FORCEDISABLE
+	stat |= EMPED
 	spawn(100)
-		stat &= ~FORCEDISABLE
+		stat &= ~EMPED
 	..()
 
 /proc/rate_control(var/S, var/V, var/C, var/Min=1, var/Max=5, var/Limit=null)


### PR DESCRIPTION
Before:
* APCs magically go poof losing all their charge and setting all settings to "off", you can jam a new cell in tho
* SMES magically go poof losing all their charge and set all settings to "off", you can still just turn them back on though but it won't really help since
* when power is restored all APCs magically get FULL charge back and have all settings turned to ON even if they were set to off before the event
* when power is restored all SMES magically get !!FULL FUCKING CHARGE!! and are set to !!200K FUCKING OUTPUT!!

Now:
* APCs still magically go poof and lose their charge, you can still take the cell out and jam a new cell in (the old one will never regain power if you do so), when regaining power they go back to their old settings and go to their old charge % (or stay at their current if you swapped the cell, whichever is higher). I left it like this because I prefer this functioning over not being able to swap out the cell, which would make the event really shitty.
* SMES do NOT lose charge, do NOT have their settings fucked with, they just BSOD for as long as the event continues, not charging and not providing power

Fixes #11704
:cl:
 * bugfix: The 'temporary powernet disable' random event no longer magically refills all SMES or sets their output to M A X I M U M after power is restored. It will also not restore lighting/environment/equipment in APCs if they were disabled before the event.
