### PR TITLE
Fixes a disease runtime

### DIFF
--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -126,6 +126,7 @@ var/global/list/disease2_list = list()
 			src.cure(mob)
 			mob.antibodies |= src.antigen
 			log += "<br />[timestamp()] STAGEMAX ([stage])"
+			return
 		else
 			stage++
 			log += "<br />[timestamp()] NEXT STAGE ([stage])"


### PR DESCRIPTION
Up until now, viruses still applied effects and tried to spread themselves even after being cured by waiting them out, only for the duration of the tick that they got cured. This resulted in a division by zero runtime because a snippet below relied on the host actually having said virus in its body, which apparently wasn't guaranteed since said virus cured itself.