### PR TITLE
AI cameras can no longer track invisible mobs

### DIFF
--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -48,7 +48,7 @@
 	track.humans.len = 0
 	track.others.len = 0
 
-	if(usr.stat == 2)
+	if(stat == 2)
 		return list()
 
 	for(var/mob/living/M in mob_list)
@@ -63,9 +63,9 @@
 			continue
 		if(M == usr)
 			continue
-		if(M.invisibility)//cloaked
+		if(see_invisible < M.invisibility) //cloaked
 			continue
-		if(M.alpha <= 1)//fully transparent
+		if(M.alpha <= 1) //fully transparent
 			continue
 		if(M.digitalcamo)
 			continue
@@ -170,7 +170,7 @@
 			if (U.cameraFollow == null)
 				return
 
-			if(target.digitalcamo || target.invisibility || target.alpha <= 1)
+			if(target.digitalcamo || (see_invisible < target.invisibility) || target.alpha <= 1)
 				to_chat(U, "Follow camera mode terminated.")
 				U.cameraFollow = null
 				return

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -65,6 +65,8 @@
 			continue
 		if(M.invisibility)//cloaked
 			continue
+		if(M.alpha < 1)//fully transparent
+			continue
 		if(M.digitalcamo)
 			continue
 
@@ -167,19 +169,21 @@
 		while (U.cameraFollow == target)
 			if (U.cameraFollow == null)
 				return
-			if (istype(target, /mob/living/carbon/human))
+
+			if(target.digitalcamo || target.invisibility || target.alpha < 1)
+				to_chat(U, "Follow camera mode terminated.")
+				U.cameraFollow = null
+				return
+
+			if(istype(target, /mob/living/carbon/human))
 				var/mob/living/carbon/human/H = target
 				if(H.wear_id && istype(H.wear_id.GetID(), /obj/item/weapon/card/id/syndicate))
 					to_chat(U, "Follow camera mode terminated.")
 					U.cameraFollow = null
 					return
-				if(H.digitalcamo)
-					to_chat(U, "Follow camera mode terminated.")
-					U.cameraFollow = null
-					return
 
 			if(istype(target.loc,/obj/effect/dummy))
-				to_chat(U, "Follow camera mode ended.")
+				to_chat(U, "Follow camera mode terminated.")
 				U.cameraFollow = null
 				return
 

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -65,7 +65,7 @@
 			continue
 		if(M.invisibility)//cloaked
 			continue
-		if(M.alpha < 1)//fully transparent
+		if(M.alpha <= 1)//fully transparent
 			continue
 		if(M.digitalcamo)
 			continue
@@ -170,7 +170,7 @@
 			if (U.cameraFollow == null)
 				return
 
-			if(target.digitalcamo || target.invisibility || target.alpha < 1)
+			if(target.digitalcamo || target.invisibility || target.alpha <= 1)
 				to_chat(U, "Follow camera mode terminated.")
 				U.cameraFollow = null
 				return


### PR DESCRIPTION
Before anyone can say "this guy is just butthurt because an AI tracked his shit!!!" I have literally all antag preferences turned off :^)

Invisible mobs don't show up in the AI's tracking options and tracking mode ends if the mob becomes invisible. This will affect the following:
* Humans with the Chameleon gene that remained still long enough to be transparent
* Wizards/Vampires using Jaunt
* The invisibility cape

This will NOT affect:
* Vampire cloak of darkness

I partly consider this a bugfix but tagging it balance anyways

:cl: 
 * tweak: AI camera can no longer track invisible mobs.