### PR TITLE
Trader vending machine (again)

### DIFF
--- a/code/__HELPERS/_macros.dm
+++ b/code/__HELPERS/_macros.dm
@@ -107,6 +107,8 @@
 
 #define iscoil(A) istype(A, /obj/item/stack/cable_coil)
 
+#define iscoin(A) is_type_in_list(A, list(/obj/item/weapon/coin, /obj/item/weapon/reagent_containers/food/snacks/chococoin))
+
 #define iswirecutter(A) istype(A, /obj/item/weapon/wirecutters)
 
 #define iswiretool(A) (iswirecutter(A) || ismultitool(A) || issignaler(A))

--- a/code/game/jobs/job/whitelisted.dm
+++ b/code/game/jobs/job/whitelisted.dm
@@ -45,6 +45,7 @@
 	H.equip_or_collect(new /obj/item/weapon/storage/box/donkpockets/random_amount(H.back), slot_in_backpack)
 	H.equip_or_collect(new /obj/item/weapon/reagent_containers/food/drinks/thermos/full(H.back), slot_in_backpack)
 	H.equip_or_collect(new /obj/item/weapon/storage/wallet/random(H.back), slot_in_backpack)
+	H.equip_or_collect(new /obj/item/weapon/coin/trader(H.back), slot_in_backpack)
 
 	H.equip_or_collect(new /obj/item/device/radio(H), slot_belt)
 

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -362,7 +362,7 @@ var/global/num_vending_terminals = 1
 		if(panel_open)
 			attack_hand(user)
 		return
-	else if(premium.len > 0 && iscoin(W)))
+	else if(premium.len > 0 && iscoin(W))
 		if (isnull(coin))
 			if(user.drop_item(W, src))
 				coin = W

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -43,6 +43,8 @@ var/global/num_vending_terminals = 1
 	var/shoot_chance = 2 //How often do we throw items?
 	var/datum/data/vending_product/currently_vending = null // A /datum/data/vending_product instance of what we're paying for right now.
 	// To be filled out at compile time
+	var/list/accepted_coins	= list()	// Accepted coins by the machine.
+
 	var/list/products	= list()	// For each, use the following pattern:
 	var/list/contraband	= list()	// list(/type/path = amount,/type/path2 = amount2)
 	var/list/premium 	= list()	// No specified amount = only one in stock
@@ -92,6 +94,11 @@ var/global/num_vending_terminals = 1
 	num_vending_machines++
 
 	overlays_vending[1] = "[icon_state]-panel"
+
+	accepted_coins = list(
+			/obj/item/weapon/coin,
+			/obj/item/weapon/reagent_containers/food/snacks/chococoin
+			) 
 
 	component_parts = newlist(\
 		/obj/item/weapon/circuitboard/vendomat,\
@@ -362,7 +369,7 @@ var/global/num_vending_terminals = 1
 		if(panel_open)
 			attack_hand(user)
 		return
-	else if(premium.len > 0 && iscoin(W))
+	else if(premium.len > 0 && is_type_in_list(W, accepted_coins))
 		if (isnull(coin))
 			if(user.drop_item(W, src))
 				coin = W
@@ -2393,6 +2400,9 @@ var/global/num_vending_terminals = 1
 
 /obj/machinery/vending/trader/New()
 	..()
+
+	accepted_coins = list(/obj/item/weapon/coin/trader)
+
 	premium = list(
 		/obj/item/weapon/storage/trader_marauder,
 		/obj/item/weapon/storage/backpack/holding,
@@ -2400,24 +2410,11 @@ var/global/num_vending_terminals = 1
 		/obj/item/weapon/storage/bluespace_crystal,
 		/obj/item/clothing/shoes/magboots/elite,
 		/obj/item/weapon/reagent_containers/food/snacks/borer_egg,
-		/obj/item/weapon/reagent_containers/glass/bottle/peridaxonsmall,
+		/obj/item/weapon/reagent_containers/glass/bottle/peridaxon,
 		/obj/item/weapon/reagent_containers/glass/bottle/rezadone,
 		/obj/item/weapon/reagent_containers/glass/bottle/nanitessmall,	
 		)
 
-	for(var/random_items = 1 to 5)
+	for(var/random_items = 1 to premium.len - 4)
 		premium.Remove(pick(premium))
 	src.initialize()
-
-/obj/machinery/vending/trader/attackby(var/obj/item/W, var/mob/user) //This shitcode is needed.
-	if (iscoin(W))
-		if (istype(W, /obj/item/weapon/coin/trader))
-			if (isnull(coin))
-				if(user.drop_item(W, src))
-					coin = W
-					to_chat(user, "<span class='notice'>You insert a coin into [src].</span>")
-					src.updateUsrDialog()
-		else
-			to_chat(user, "<span class='notice'>It doesn't fit.</span>")
-		return
-	..()

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -362,7 +362,7 @@ var/global/num_vending_terminals = 1
 		if(panel_open)
 			attack_hand(user)
 		return
-	else if(premium.len > 0 && is_type_in_list(W, list(/obj/item/weapon/coin/, /obj/item/weapon/reagent_containers/food/snacks/chococoin)))
+	else if(premium.len > 0 && iscoin(W)))
 		if (isnull(coin))
 			if(user.drop_item(W, src))
 				coin = W
@@ -2378,3 +2378,46 @@ var/global/num_vending_terminals = 1
  		/obj/item/clothing/suit/armor/knight/templar = 5,
 		)
 	pack = /obj/structure/vendomatpack/chapelvend
+
+
+/obj/machinery/vending/trader	// Boxes are defined in trader.dm
+	name = "Jewvend"
+	desc = "Its coin groove has been modified."
+	product_slogans = "Profits."
+	product_ads = "When you charge a customer $100, and he pays you by mistake $200, you have an ethical dilemma — should you tell your partner?"
+	vend_reply = "Money money money!"
+	icon_state = "voxseed"
+	products = list (
+		/obj/item/weapon/storage/fancy/donut_box = 2,
+		)
+
+/obj/machinery/vending/trader/New()
+	..()
+	premium = list(
+		/obj/item/weapon/storage/trader_marauder,
+		/obj/item/weapon/storage/backpack/holding,
+		/obj/item/weapon/reagent_containers/glass/beaker/bluespace,
+		/obj/item/weapon/storage/bluespace_crystal,
+		/obj/item/clothing/shoes/magboots/elite,
+		/obj/item/weapon/reagent_containers/food/snacks/borer_egg,
+		/obj/item/weapon/reagent_containers/glass/bottle/peridaxonsmall,
+		/obj/item/weapon/reagent_containers/glass/bottle/rezadone,
+		/obj/item/weapon/reagent_containers/glass/bottle/nanitessmall,	
+		)
+
+	for(var/random_items = 1 to 5)
+		premium.Remove(pick(premium))
+	src.initialize()
+
+/obj/machinery/vending/trader/attackby(var/obj/item/W, var/mob/user) //This shitcode is needed.
+	if (iscoin(W))
+		if (istype(W, /obj/item/weapon/coin/trader))
+			if (isnull(coin))
+				if(user.drop_item(W, src))
+					coin = W
+					to_chat(user, "<span class='notice'>You insert a coin into [src].</span>")
+					src.updateUsrDialog()
+		else
+			to_chat(user, "<span class='notice'>It doesn't fit.</span>")
+		return
+	..()

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -2408,7 +2408,7 @@ var/global/num_vending_terminals = 1
 		/obj/item/weapon/storage/backpack/holding,
 		/obj/item/weapon/reagent_containers/glass/beaker/bluespace,
 		/obj/item/weapon/storage/bluespace_crystal,
-		/obj/item/clothing/shoes/magboots/elite,
+		//obj/item/clothing/shoes/magboots/elite,
 		/obj/item/weapon/reagent_containers/food/snacks/borer_egg,
 		/obj/item/weapon/reagent_containers/glass/bottle/peridaxon,
 		/obj/item/weapon/reagent_containers/glass/bottle/rezadone,

--- a/code/game/objects/items/trader.dm
+++ b/code/game/objects/items/trader.dm
@@ -1,0 +1,43 @@
+/*
+ *	Here defined the boxes contained in the trader vending machine.
+ *	Feel free to add stuff. Don't forget to add them to the vmachine afterwards.
+*/
+
+/obj/item/weapon/coin/trader
+	material=MAT_GOLD
+	name = "Trader coin"
+	icon_state = "coin_mythril"
+
+/obj/item/weapon/storage/trader_marauder
+	name = "Box of Marauder circuits"
+	desc = "All in one box!"
+	icon_state = "box_of_doom"
+	item_state = "box_of_doom"
+
+/obj/item/weapon/storage/trader_marauder/New() //Because we're good jews, they won't be able to finish the marauder. The box is missing a circuit.
+	..()
+	new /obj/item/weapon/circuitboard/mecha/marauder(src)
+	new /obj/item/weapon/circuitboard/mecha/marauder/peripherals(src)
+	//new /obj/item/weapon/circuitboard/mecha/marauder/targeting(src)
+	new /obj/item/weapon/circuitboard/mecha/marauder/main(src)
+
+/obj/item/weapon/storage/bluespace_crystal
+	name = "Natural bluespace crystals box"
+	desc = "Hmmm... it smells like tomato"
+	icon_state = "box_of_doom"
+	item_state = "box_of_doom"
+
+/obj/item/weapon/storage/bluespace_crystal/New()
+	..()
+	for(var/amount = 1 to 6)
+		new /obj/item/bluespace_crystal(src)
+	new /obj/item/weapon/reagent_containers/food/snacks/grown/bluespacetomato(src)
+
+/*/obj/structure/cage/with_random_slime
+	..()
+	
+	add_mob
+
+/mob/living/carbon/slime/proc/randomSlime()
+*/	
+

--- a/code/modules/reagents/reagent_containers/glass/bottle.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle.dm
@@ -442,3 +442,21 @@
 /obj/item/weapon/reagent_containers/glass/bottle/alkysinesmall/New()
 	..()
 	reagents.add_reagent(ALKYSINE, 10)
+
+/obj/item/weapon/reagent_containers/glass/bottle/peridaxonsmall
+	name = "Peridaxon Bottle"
+	desc = "A small bottle. Contains peridaxon. Medicate cautiously."
+	icon = 'icons/obj/chemical.dmi'
+
+/obj/item/weapon/reagent_containers/glass/bottle/peridaxonsmall/New()
+		..()
+		reagents.add_reagent(PERIDAXON, 10)
+
+/obj/item/weapon/reagent_containers/glass/bottle/nanitessmall
+	name = "Nanobots Bottle"
+	desc = "A small bottle. You hear beeps and boops."
+	icon = 'icons/obj/chemical.dmi'
+
+/obj/item/weapon/reagent_containers/glass/bottle/nanitessmall/New()
+		..()
+		reagents.add_reagent(NANITES, 10)

--- a/code/modules/reagents/reagent_containers/glass/bottle.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle.dm
@@ -443,14 +443,14 @@
 	..()
 	reagents.add_reagent(ALKYSINE, 10)
 
-/obj/item/weapon/reagent_containers/glass/bottle/peridaxonsmall
+/obj/item/weapon/reagent_containers/glass/bottle/peridaxon
 	name = "Peridaxon Bottle"
 	desc = "A small bottle. Contains peridaxon. Medicate cautiously."
 	icon = 'icons/obj/chemical.dmi'
 
-/obj/item/weapon/reagent_containers/glass/bottle/peridaxonsmall/New()
-		..()
-		reagents.add_reagent(PERIDAXON, 10)
+/obj/item/weapon/reagent_containers/glass/bottle/peridaxon/New()
+	..()
+	reagents.add_reagent(PERIDAXON, 30)
 
 /obj/item/weapon/reagent_containers/glass/bottle/nanitessmall
 	name = "Nanobots Bottle"
@@ -458,5 +458,5 @@
 	icon = 'icons/obj/chemical.dmi'
 
 /obj/item/weapon/reagent_containers/glass/bottle/nanitessmall/New()
-		..()
-		reagents.add_reagent(NANITES, 10)
+	..()
+	reagents.add_reagent(NANITES, 10)

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -617,6 +617,7 @@
 #include "code\game\objects\items\ornaments.dm"
 #include "code\game\objects\items\shooting_range.dm"
 #include "code\game\objects\items\toys.dm"
+#include "code\game\objects\items\trader.dm"
 #include "code\game\objects\items\trash.dm"
 #include "code\game\objects\items\verb_holder.dm"
 #include "code\game\objects\items\vouchers.dm"


### PR DESCRIPTION
Revives #12395 as a request from @Probe1 

I know there are better ideas for traders. The difference is _this one is coded_. If you have a better implementation then code it.

The list so far is:
- Box of marauder circuits (one is missing, because vox are jews)
- Box of natural blue space crystals, with an extra blue tomato
- Bag of Holding
- Bluespace beaker
- Borer egg
- A bottle of peridaxon
- A small bottle of nanites
- A bottle of rezadone

## Have ideas? Post here ↓↓↓

:cl:
- rscadd: New vending machine for traders. It spawns with a few random items including stuff like marauder circuits, borer eggs, a small bottle of peridaxon. This doesn't add it to the map yet.
- rscadd: This machine can only be operated with special trader coins.
- rscadd: Every trader spawns with a single trader coin.
- rscadd: Since these are big changes, expect getting jobbanned or even permabanned if misused.
