### PR TITLE
[Goonchat] Pause button

### DIFF
--- a/goon/browserassets/css/browserOutput.css
+++ b/goon/browserassets/css/browserOutput.css
@@ -79,6 +79,12 @@ a.popt {text-decoration: none;}
 	height: 30px;
 	padding: 8px 0 2px 0;
 }
+#pause {
+	position: fixed;
+	top: 0;
+	right: 80px;
+}
+
 #ping i {display: block; text-align: center;}
 #ping .ms {
 	display: block;
@@ -91,23 +97,31 @@ a.popt {text-decoration: none;}
 	top: 0;
 	right: 0;
 }
-#options a {
-	background: #ddd;
-    height: 30px;
-	padding: 5px 0;
-	display: block;
-	color: #333;
-	text-decoration: none;
-    line-height: 28px;
-    border-top: 1px solid #b4b4b4;
+#options a,
+#pause a
+{
+  background: #ddd;
+  height: 30px;
+  padding: 5px 0;
+  display: block;
+  color: #333;
+  text-decoration: none;
+  line-height: 28px;
+  border-top: 1px solid #b4b4b4;
 }
-#options a:hover {background: #ccc;}
-#options .toggle {
-	width: 40px;
-    background: #ccc;
-    border-top: 0;
-    float: right;
-    text-align: center;
+#options a:hover,
+#pause a:hover
+{
+  background: #ccc;
+}
+#options .toggle,
+#pause .toggle
+{
+  width: 40px;
+  background: #ccc;
+  border-top: 0;
+  float: right;
+  text-align: center;
 }
 #options .sub {clear: both; display: none; width: 160px;}
 #options .sub.scroll {overflow-y: scroll;}

--- a/goon/browserassets/html/browserOutput.html
+++ b/goon/browserassets/html/browserOutput.html
@@ -26,6 +26,9 @@
 			<i class="icon-circle" id="pingDot"></i>
 			<span class="ms" id="pingMs">--ms</span>
 		</div>
+		<div id="pause">
+			<a href="#" class="toggle" id="togglePause" title="Click to pause chat"><i class="icon-play"></i></a>
+		</div>
 		<div id="options">
 			<a href="#" class="toggle" id="toggleOptions" title="Options"><i class="icon-cog"></i></a>
 			<div class="sub" id="subOptions">

--- a/goon/code/datums/browserOutput.dm
+++ b/goon/code/datums/browserOutput.dm
@@ -272,4 +272,4 @@ For the main html chat area
 		message = replacetext(message, "\n", "<br>")
 
 		// url_encode it TWICE, this way any UTF-8 characters are able to be decoded by the Javascript.
-		target << output(url_encode(url_encode(message)), "browseroutput:output")
+		target << output(url_encode(url_encode(message)), "browseroutput:externalOutput")


### PR DESCRIPTION
# Executive Summary

Goonchat can be completely paused by clicking on a pause button, which redirects incoming chat to a background queue.  When resumed by clicking the play button, the queue is dumped to the chat window and it resumes.  All of this is done in Javascript on the client.

Also adds a highly half-assed debugging flag for running goonchat outside of BYOND.

# Screenshot
![dreamseeker_2017-01-10_20-08-19](https://cloud.githubusercontent.com/assets/110073/21835455/fc92b4bc-d771-11e6-90a8-0ad0586f5316.png)
(Button state was reversed in this image.)

# Changelog
:cl:
 * rscadd: You can now pause goonchat by clicking on a pause button.
