### PR TITLE
pAI medbots

### DIFF
--- a/code/game/machinery/bots/medbot.dm
+++ b/code/game/machinery/bots/medbot.dm
@@ -669,17 +669,17 @@
 	patient = A //Needed because medicate_patient doesn't set up one.
 
 	if(pai_analyze_mode)
-		medicate_patient(A)
-	else
 		if(istype(A, /mob/living/carbon))
 			healthanalyze(A, user, 1)
+	else
+		medicate_patient(A)
 
 /obj/machinery/bot/medbot/dropkey_integrated_pai(mob/living/silicon/pai/user)	//called when integrated pAI uses the drop hotkey
 	declare()
 
 /obj/machinery/bot/medbot/swapkey_integrated_pai(mob/living/silicon/pai/user)	//called when integrated pAI uses the swap_hand() hotkey
-	pai_analyze_mode = !pai_analyze_mode
 	pai_analyze_mode ? to_chat(user, "<span class='info'>You switch to inject mode.</span>") : to_chat(user, "<span class='info'>You switch to analyze mode.</span>")
+	pai_analyze_mode = !pai_analyze_mode
 
 /obj/machinery/bot/medbot/state_controls_pai(obj/item/device/paicard/P)
 	to_chat(P.pai, "<span class='info'><b>Welcome to your new body. Remember: you're a pAI inside a medbot, not a medbot.</b></span>")

--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -91,7 +91,7 @@
 			var/datum/dna/dna = usr.dna
 			pai.master = M.real_name
 			pai.master_dna = dna.unique_enzymes
-			to_chat(pai, "<font color = red><h3>You have been bound to a new master.</h3></font>")
+			to_chat(pai, "<font color = red><h3>You have been bound to a new master: [pai.master].</h3></font>")
 	if(href_list["request"])
 		src.looking_for_personality = 1
 		paiController.findPAI(src, usr)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -52,6 +52,7 @@ var/global/list/reagents_to_log = list(FUEL, PLASMA, PACID, SACID, AMUTATIONTOXI
 
 /obj/item/proc/is_used_on(obj/O, mob/user)
 
+
 /obj/proc/install_pai(obj/item/device/paicard/P)
 	if(!P || !istype(P))
 		return 0
@@ -59,12 +60,17 @@ var/global/list/reagents_to_log = list(FUEL, PLASMA, PACID, SACID, AMUTATIONTOXI
 	integratedpai = P
 	verbs += /obj/verb/remove_pai
 
+
 /obj/attackby(obj/item/weapon/W, mob/user)
 	if(can_take_pai && istype(W, /obj/item/device/paicard))
 		if(user.drop_item(W))
 			to_chat(user, "You insert \the [W] into a slot in \the [src].")
 			install_pai(W)
+			state_controls_pai(W)
 			playsound(src, 'sound/misc/cartridge_in.ogg', 25)
+
+/obj/proc/state_controls_pai(obj/item/device/paicard/P) //text the pAI receives when is inserted into something. EXAMPLE: to_chat(P.pai, "Welcome to your new body")
+	return
 
 /obj/proc/attack_integrated_pai(mob/living/silicon/pai/user)	//called when integrated pAI clicks on the object, or uses the attack_self() hotkey
 	return


### PR DESCRIPTION
_**pAI medbots**_

Just like mulebots. 

With Q (or drop hotkey) you state there's a critical patient in the room.
With X (or swap hands) you switch mode. There are 2 modes, analyze mode and injection mode.
With clic you inject or analyze depending on your mode.

The pAI can't modify the medbot's settings, so what the medbot injects depends on humans and if there's a beaker loaded it or not.

Also adds a proc called state_controls_pai that prints text when a pAI enters an object. It is used here to print the controls and some extra info.

:cl:
 * rscadd: pAIs can be inserted into medbots. Instructions are printed when you enter one.
