### PR TITLE
Cloning pod biomass is now proportional to quantity of nutriment in meat given to it

### DIFF
--- a/code/modules/medical/cloning.dm
+++ b/code/modules/medical/cloning.dm
@@ -384,9 +384,13 @@
 			src.locked = 0
 			to_chat(user, "System unlocked.")
 	if (istype(W, /obj/item/weapon/reagent_containers/food/snacks/meat))
-		if(user.drop_item(W))
-			to_chat(user, "<span class='notice'>\The [src] processes \the [W].</span>")
-			biomass += 50
+		var/obj/item/weapon/reagent_containers/food/snacks/meat/M = W
+		if (!M.reagents.has_reagent(NUTRIMENT))
+			to_chat(user, "<span class='notice'>\The [src] rejects \the [M] as it lacks sufficient nutriment.")
+			return
+		if(user.drop_item(M))
+			to_chat(user, "<span class='notice'>\The [src] processes \the [M].</span>")
+			biomass += M.reagents.get_reagent_amount(NUTRIMENT) * 3
 			qdel(W)
 			return
 


### PR DESCRIPTION
No more stuffing loads of clonex-monkeyman synthmeat into the cloner that defies all physics.

This will still lead to powergaming in the form of injecting nutriment into meat but that's better than what we have now so whatever. I'm not quite certain on how much nutriment is gained from a monkey on average so recommend better values for the multiplier if you can think of any.

:cl:
 * tweak: Cloning pods now add biomass proportional to the quantity of nutriment in the meat fed to it. This means that synthmeat is now much less useful.