### PR TITLE
Fix unexpected newlines in statfiles.

### DIFF
--- a/code/datums/statistics/statcollection.dm
+++ b/code/datums/statistics/statcollection.dm
@@ -17,6 +17,8 @@
 
 // To ensure that if output file syntax is changed, we will still be able to process
 // new and old files
+#define STRIP_NEWLINE(S) replacetextEx(S, "\n", null)
+
 #define STAT_OUTPUT_VERSION "1.1"
 #define STAT_OUTPUT_DIR "data/statfiles/"
 
@@ -83,7 +85,7 @@
 		for(var/obj/O in B.contents)
 			BAD.contains += O.type
 		BAD.purchaser_key = ckey(user.mind.key)
-		BAD.purchaser_name = user.mind.name
+		BAD.purchaser_name = STRIP_NEWLINE(user.mind.name)
 		BAD.purchaser_is_traitor = was_traitor
 		badass_bundles += BAD
 	else
@@ -181,9 +183,9 @@
 			if(objective.explanation_text == "Free Objective")
 				statfile << "ANTAG_OBJ|[Mind.name]|[Mind.key]|[Mind.special_role]|FREE_OBJ"
 			else if (objective.target)
-				statfile << "ANTAG_OBJ|[Mind.name]|[Mind.key]|[Mind.special_role]|[objective.type]|[objective.target]|[objective.target.assigned_role]|[objective.target.name]|[objective.check_completion()]|[objective.explanation_text]"
+				statfile << STRIP_NEWLINE("ANTAG_OBJ|[Mind.name]|[Mind.key]|[Mind.special_role]|[objective.type]|[objective.target]|[objective.target.assigned_role]|[objective.target.name]|[objective.check_completion()]|[objective.explanation_text]")
 			else
-				statfile << "ANTAG_OBJ|[Mind.name]|[Mind.key]|[Mind.special_role]|[objective.type]|[objective.check_completion()]|[objective.explanation_text]"
+				statfile << STRIP_NEWLINE("ANTAG_OBJ|[Mind.name]|[Mind.key]|[Mind.special_role]|[objective.type]|[objective.check_completion()]|[objective.explanation_text]")
 
 
 // This guy writes the first line(s) of the stat file! Woo!
@@ -225,13 +227,13 @@
 	statfile << "NUKED|[nuked]"
 
 	for(var/datum/stat/death_stat/D in death_stats)
-		statfile << "MOB_DEATH|[D.mob_typepath]|[D.special_role]|[num2text(D.time_of_death, 30)]|[D.last_attacked_by]|[D.death_x]|[D.death_y]|[D.death_z]|[D.key]|[D.realname]"
+		statfile << STRIP_NEWLINE("MOB_DEATH|[D.mob_typepath]|[D.special_role]|[num2text(D.time_of_death, 30)]|[D.last_attacked_by]|[D.death_x]|[D.death_y]|[D.death_z]|[D.key]|[D.realname]")
 	for(var/datum/stat/explosion_stat/E in explosion_stats)
 		statfile << "EXPLOSION|[E.epicenter_x]|[E.epicenter_y]|[E.epicenter_z]|[E.devastation_range]|[E.heavy_impact_range]|[E.light_impact_range]|[E.max_range]"
 	for(var/datum/stat/uplink_purchase_stat/U in uplink_purchases)
-		statfile << "UPLINK_ITEM|[U.purchaser_key]|[U.purchaser_name]|[U.purchaser_is_traitor]|[U.bundle]|[U.itemtype]"
+		statfile << STRIP_NEWLINE("UPLINK_ITEM|[U.purchaser_key]|[U.purchaser_name]|[U.purchaser_is_traitor]|[U.bundle]|[U.itemtype]")
 	for(var/datum/stat/uplink_badass_bundle_stat/B in badass_bundles)
-		var/o 	= 	"BADASS_BUNDLE|[B.purchaser_key]|[B.purchaser_name]|[B.purchaser_is_traitor]"
+		var/o 	= 	STRIP_NEWLINE("BADASS_BUNDLE|[B.purchaser_key]|[B.purchaser_name]|[B.purchaser_is_traitor]")
 		for(var/S in B.contains)
 			o += "|[S]"
 		statfile << "[o]"

--- a/code/datums/statistics/statcollection.dm
+++ b/code/datums/statistics/statcollection.dm
@@ -181,7 +181,7 @@
 	for(var/datum/mind/Mind in ticker.minds)
 		for(var/datum/objective/objective in Mind.objectives)
 			if(objective.explanation_text == "Free Objective")
-				statfile << "ANTAG_OBJ|[Mind.name]|[Mind.key]|[Mind.special_role]|FREE_OBJ"
+				statfile << STRIP_NEWLINE("ANTAG_OBJ|[Mind.name]|[Mind.key]|[Mind.special_role]|FREE_OBJ")
 			else if (objective.target)
 				statfile << STRIP_NEWLINE("ANTAG_OBJ|[Mind.name]|[Mind.key]|[Mind.special_role]|[objective.type]|[objective.target]|[objective.target.assigned_role]|[objective.target.name]|[objective.check_completion()]|[objective.explanation_text]")
 			else
@@ -214,7 +214,7 @@
 		uniquefilename = "[uniquefilename].dupe"
 	var/statfile = file("[STAT_OUTPUT_DIR]statistics_[filename_date].[uniquefilename].txt")
 
-	world << "Writing statistics to file"
+	to_chat(world, "Writing statistics to file")
 
 	var/start_time = world.realtime
 	Write_Header(statfile)


### PR DESCRIPTION
Newlines were appearing in, primarily:
 - Mob names, primarily those changed via VV
 - Antag objective descriptions entered by admins

This should catch all the current occurrences of those and strip newlines from them.
Which means less matches lost forever without someone getting their valid.
I tested that define in a sandboxed environment, as well.
```dm
world
	fps = 25		// 25 frames per second
	icon_size = 32	// 32x32 icon size by default

	view = 6		// show up to 6 tiles outward from center (13x13 view)


// Make objects move 8 pixels per tick when walking

#define STRIP_CRLF(S) replacetextEx(S, "\n", null)


mob
	step_size = 8
	desc = "Test\nTest"
	Login()
		..()
		world << desc
		world << "Hi [STRIP_CRLF(desc)]"

obj
	step_size = 8

```