### PR TITLE
[Optics] Fixes Beamsplitter Beam Duplication

### DIFF
--- a/code/modules/optics/mirrors/mirror.dm
+++ b/code/modules/optics/mirrors/mirror.dm
@@ -94,7 +94,7 @@ var/global/list/obj/machinery/mirror/mirror_list = list()
 	if(. == 1)
 		if(beams && beams.len)
 			kill_all_beams()
-			update_beams()
+		update_beams()
 	return .
 
 /obj/machinery/mirror/beam_connect(var/obj/effect/beam/emitter/B)
@@ -133,8 +133,8 @@ var/global/list/obj/machinery/mirror/mirror_list = list()
 	overlays.len = 0
 
 	var/list/beam_dirs[4] // dir = list(
-		                  //  type = power
-		                  // )
+                        //  type = power
+                        // )
 
 	var/i = 0 // Iteration index.
 
@@ -185,19 +185,23 @@ var/global/list/obj/machinery/mirror/mirror_list = list()
 				beam_dirs[diridx]=dirdata
 
 
-	// Emit beams.
+	// Ensure our emitted beams list is at the required length
 	if(emitted_beams.len < 4)
-		emitted_beams.len = 4
+		emitted_beams.len=4
+
+	var/list/oldebs=emitted_beams.Copy()
+
+	// Emit beams
 	for(i=1;i<=4;i++)
 		var/cdir = cardinal[i]
 		var/list/dirdata = beam_dirs[i]
 		var/delbeam=0
 		var/obj/effect/beam/beam
 		if(dirdata.len > 0)
-			//testing("cdir=[cdir]")
 			for(var/beamtype in dirdata)
 				var/newbeam=0
 				beam = emitted_beams[i]
+
 				// If there's a beam and it's changed, nuke the existing beam.
 				if (beam && beam.type != beamtype)
 					qdel(beam)
@@ -211,6 +215,7 @@ var/global/list/obj/machinery/mirror/mirror_list = list()
 					beam.dir=cdir
 					newbeam=1
 
+				// Is it an emitter beam? Update its power.
 				if(istype(beam, /obj/effect/beam/emitter))
 					var/obj/effect/beam/emitter/EB=beam
 					EB.power = dirdata[beamtype]
@@ -225,9 +230,24 @@ var/global/list/obj/machinery/mirror/mirror_list = list()
 				break
 		else // dirdata.len == 0
 			delbeam=1
-		beam = emitted_beams[i] // One last check.
+
+		// N3X15 Jan 11 2017: GC is deleting shit from the list or something, so we have to ensure size again.
+		// Fix for #12077
+		if(emitted_beams.len < 4)
+			emitted_beams.len=4
+
+		beam = emitted_beams[i] // Crashes here
 		if(delbeam && beam)
 			qdel(beam)
 			emitted_beams[i]=null
 
 	overlays += mirror_state
+
+	// Ensure all beams have been cleaned up
+	// Another 12077 fix.
+	for(var/obj/effect/beam/B in oldebs)
+		if(B && !(B in emitted_beams))
+			// Ideally, I'd like to keep this warning to make Pomf bug Lummox,
+			// but the spam would just piss everyone off.
+			//testing("BUG: Beam \ref[B] is still around after getting deleted!")
+			qdel(B)


### PR DESCRIPTION
# Executive Summary
Fixes #12077, a severe exploitable issue that leaves beams floating around after a beam to a beamsplitter is interrupted.  This can result in free energy and crashes, and also causes some runtime errors.

# Analysis
This ended up being a fucking mess, and it looks like the underlying cause is a problem with BYOND's GC: When a list index is set from non-null to null, BYOND removes that position for some FUCKING reason.  In the case of the mirror, which requires everything to stay in their assigned positions, it results in the following sequence of events:
1. Mirror nukes a beam because it's no longer needed.
2. GC nukes that position in the list because it is retard fuckstupid.
3. Beam in the position above falls to the position just nuked.
4. Loop continues.
5. Loop runs into the end of the list because the list size changed from 4 to 3 and triggers a runtime and jumps out of the update process.
6. Players figure out they can stack beams and get jiggawatts of juice and even negative energy.

# Testing Apparatus
Just to show I did test this, the following in test_tiny.dmm is what I used to test the bug.
![dreammaker_2017-01-11_22-59-37](https://cloud.githubusercontent.com/assets/110073/21880044/a94fb954-d851-11e6-8ffd-f5651ac6d902.png)

# Changelog
:cl:
 * bugfix: Fixed a series of bugs and exploits involving mirrors. WE RESPECT THE LAW OF THERMODYNAMICS IN THIS HOUSE.