### PR TITLE
Lowers xeno egg durability

### DIFF
--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -454,7 +454,7 @@
 	density = 0
 	anchored = 1
 
-	var/health = 100
+	var/health = 50
 	var/status = GROWING //can be GROWING, GROWN or BURST; all mutually exclusive
 
 	flags = PROXMOVE
@@ -541,8 +541,8 @@
 
 	var/damage = W.force
 
-	if(!W.is_hot())
-		damage = damage / 4.0
+	if(W.is_hot())
+		damage = damage * 2.0
 
 	src.health -= damage
 	src.healthcheck()


### PR DESCRIPTION
Halves xeno egg health, makes them take 2x damage from anything that is_hot() and not take 1/4th damage from anything that's not is_hot().  

Compiles works 100% tested.  

Closes #13370 

:cl:
 * tweak: Xeno eggs have less health and take more damage.  As example, they now take 4 toolbox hits or 2 welder hits to kill, instead of 27 toolbox hits or 7 welder hits.  