### PR TITLE
Makes newscasters more convenient to use

### DIFF
--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -650,7 +650,7 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 						var/datum/picture/P = photo
 						newMsg.img = P.fields["img"]
 						newMsg.img_info = P.fields["info"]
-					ejectPhoto()
+					EjectPhoto()
 				feedback_inc("newscaster_stories",1)
 				for(var/datum/feed_channel/FC in news_network.network_channels)
 					if(FC.channel_name == src.channel_name)

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -572,7 +572,7 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 					/*for(var/obj/machinery/newscaster/NEWSCASTER in allCasters)    //Let's add the new channel in all casters.
 						NEWSCASTER.channel_list += newChannel*/                     //Now that it is sane, get it into the list. -OBSOLETE
 					news_network.network_channels += newChannel                        //Adding channel to the global network
-					src.screen=5
+					src.screen = NEWSCASTER_MENU
 			src.updateUsrDialog()
 			//src.update_icon()
 
@@ -656,7 +656,7 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 					if(FC.channel_name == src.channel_name)
 						FC.messages += newMsg                  //Adding message to the network's appropriate feed_channel
 						break
-				src.screen=NEWSCASTER_NEW_MESSAGE_SUCCESS
+				src.screen = NEWSCASTER_MENU
 				for(var/obj/machinery/newscaster/NEWSCASTER in allCasters)
 					NEWSCASTER.newsAlert(src.channel_name)
 
@@ -950,6 +950,8 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 				var/obj/item/weapon/photo/P = I
 				if(istype(P) && !photo && user.drop_item(P, src))
 					photo = P
+					to_chat(user, "<span class='notice'>You add \the [P] to \the [src].</span>")
+					src.updateUsrDialog()
 
 				else if(istype(I, /obj/item/weapon) )
 					var/obj/item/weapon/W = I

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -650,6 +650,7 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 						var/datum/picture/P = photo
 						newMsg.img = P.fields["img"]
 						newMsg.img_info = P.fields["info"]
+					ejectPhoto()
 				feedback_inc("newscaster_stories",1)
 				for(var/datum/feed_channel/FC in news_network.network_channels)
 					if(FC.channel_name == src.channel_name)
@@ -946,7 +947,11 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 				visible_message("<EM>[user.name]</EM> further abuses the shattered [src].")
 
 			else
-				if(istype(I, /obj/item/weapon) )
+				var/obj/item/weapon/photo/P = I
+				if(istype(P) && !photo && user.drop_item(P, src))
+					photo = P
+
+				else if(istype(I, /obj/item/weapon) )
 					var/obj/item/weapon/W = I
 					if(W.force <15)
 						visible_message("[user.name] hits the [src] with the [W] with no visible effect." )


### PR DESCRIPTION
Tested it a bit and nothing was out of place.


Removes success screens but there's other feedback:
Feed creation success feedback - you clicked "yes" on the prompt that came up.
Story creation success feedback - an audible beep and its textual representation in chat.

:cl:
 * tweak: Newscasters now eject your photo used, if any, when you submit a story.
 * tweak: Newscasters can now be attacked with a photo to insert said photo for use in a story.
 * tweak: Newscasters no longer waste your time with a success screen when creating a new feed or submitting a story. They will still give you an explanation screen if something goes wrong.