### PR TITLE
Delays automagdrops by half a second.

### DIFF
--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -229,10 +229,13 @@
 /obj/item/weapon/gun/projectile/afterattack(atom/target as mob|obj|turf|area, mob/living/user as mob|obj, flag, struggle = 0)
 	..()
 	if(!chambered && stored_magazine && !stored_magazine.ammo_count() && gun_flags &AUTOMAGDROP) //auto_mag_drop decides whether or not the mag is dropped once it empties
+		var/drop_me = stored_magazine // prevents dropping a fresh/different mag.
 		spawn(automagdrop_delay_time)
-			RemoveMag(user)
-			if(mag_drop_sound)
-				playsound(user, mag_drop_sound, 40, 1)
+			if(stored_magazine = drop_me)
+				RemoveMag(user)
+				if(mag_drop_sound)
+					playsound(user, mag_drop_sound, 40, 1)
+
 	return
 
 /obj/item/weapon/gun/projectile/examine(mob/user)

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -20,6 +20,7 @@
 	var/obj/item/ammo_casing/chambered = null
 	var/mag_type = ""
 	var/mag_drop_sound ='sound/weapons/magdrop_1.ogg'
+	var/automagdrop_delay_time = 5 // delays the automagdrop
 
 	var/gun_flags = EMPTYCASINGS	//Yay, flags
 
@@ -228,9 +229,10 @@
 /obj/item/weapon/gun/projectile/afterattack(atom/target as mob|obj|turf|area, mob/living/user as mob|obj, flag, struggle = 0)
 	..()
 	if(!chambered && stored_magazine && !stored_magazine.ammo_count() && gun_flags &AUTOMAGDROP) //auto_mag_drop decides whether or not the mag is dropped once it empties
-		RemoveMag(user)
-		if(mag_drop_sound)
-			playsound(user, mag_drop_sound, 40, 1)
+		spawn(automagdrop_delay_time)
+			RemoveMag(user)
+			if(mag_drop_sound)
+				playsound(user, mag_drop_sound, 40, 1)
 	return
 
 /obj/item/weapon/gun/projectile/examine(mob/user)

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -231,7 +231,7 @@
 	if(!chambered && stored_magazine && !stored_magazine.ammo_count() && gun_flags &AUTOMAGDROP) //auto_mag_drop decides whether or not the mag is dropped once it empties
 		var/drop_me = stored_magazine // prevents dropping a fresh/different mag.
 		spawn(automagdrop_delay_time)
-			if(stored_magazine = drop_me)
+			if(stored_magazine == drop_me)
 				RemoveMag(user)
 				if(mag_drop_sound)
 					playsound(user, mag_drop_sound, 40, 1)

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -17,6 +17,7 @@
 	load_method = 2
 	mag_type = "/obj/item/ammo_storage/magazine/smg9mm"
 
+
 /obj/item/weapon/gun/projectile/automatic/isHandgun()
 	return FALSE
 
@@ -108,6 +109,7 @@
 	mag_type = "/obj/item/ammo_storage/magazine/a12mm/ops"
 	fire_sound = 'sound/weapons/Gunshot_c20.ogg'
 	mag_drop_sound = 'sound/weapons/smg_empty_alarm.ogg'
+	automagdrop_delay_time = 0
 	load_method = 2
 
 	gun_flags = AUTOMAGDROP | EMPTYCASINGS


### PR DESCRIPTION
#13455 but with the delay being done in-code. Now also delays the actual magdrop for the same amount of time as the sound to increase immulsions.

:cl: 

 * tweak: Delayed the automagdrop of most weapons by half a second.