### PR TITLE
Makes goliaths use tentacles only when target is not on a space tile

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -436,13 +436,12 @@ obj/item/asteroid/basilisk_hide/New()
 	size = SIZE_BIG
 
 /mob/living/simple_animal/hostile/asteroid/goliath/OpenFire(atom/ttarget)
-	if(istype(ttarget))
-		visible_message("<span class='warning'>\The [src] digs its tentacles under \the [ttarget]!</span>")
-
-	playsound(loc, 'sound/weapons/whip.ogg', 50, 1, -1)
 	var/tturf = get_turf(ttarget)
-	new /obj/effect/goliath_tentacle/original(tturf)
-	ranged_cooldown = ranged_cooldown_cap
+	if(!istype(tturf, /turf/space) && istype(ttarget))
+		visible_message("<span class='warning'>\The [src] digs its tentacles under \the [ttarget]!</span>")
+		playsound(loc, 'sound/weapons/whip.ogg', 50, 1, -1)
+		new /obj/effect/goliath_tentacle/original(tturf)
+		ranged_cooldown = ranged_cooldown_cap
 	return
 
 /mob/living/simple_animal/hostile/asteroid/goliath/adjustBruteLoss(var/damage)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -471,7 +471,8 @@ obj/item/asteroid/basilisk_hide/New()
 		var/spawndir = pick(directions)
 		directions -= spawndir
 		var/turf/T = get_step(src,spawndir)
-		new /obj/effect/goliath_tentacle(T)
+		if(!istype(T, /turf/space))
+			new /obj/effect/goliath_tentacle(T)
 	..()
 
 /obj/effect/goliath_tentacle/proc/Trip()


### PR DESCRIPTION
Fixes #5108
First coding attempt, tell me if I did something wrong. Tested on a local server and worked. 
What I did exactly:
add a check to see if the turf it wants to make tentacles on is space, and if it is not, spawn tentacles as usual. If it is space nothing happens.


I made a goliath follow me around in space and it did not create any tentacles on space tiles (confirmed that it did do this before).
Goliaths still create tentacles on other floors (tested on local server with this change)

:cl:
 * bugfix: Goliaths spawn tentacles only when the target is not in space