### PR TITLE
Malf AI delta countdown doesn't tick down if the AI is outside the station z-level

### DIFF
--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -21,6 +21,8 @@
 	var/to_nuke_or_not_to_nuke = 0
 	var/apcs = 0 //Adding dis to track how many APCs the AI hacks. --NeoFite
 
+	var/last_AI_warning_msg = 0 //I'm so sorry that this is a variable.
+
 
 /datum/game_mode/malfunction/announce()
 	to_chat(world, {"<B>The current game mode is - AI Malfunction!</B><br>
@@ -101,8 +103,15 @@ Once done, you will be able to interface with all systems, notably the onboard n
 
 
 /datum/game_mode/malfunction/process()
-	if(apcs >= 3 && malf_mode_declared && can_malf_ai_takeover())
-		AI_win_timeleft -= ((apcs / 6) * SSticker.getLastTickerTimeDuration()) //Victory timer now de-increments based on how many APCs are hacked. --NeoFite
+	if(apcs >= 3)
+		if(!can_malf_ai_takeover())
+			if(last_AI_warning_msg < world.time)
+				last_AI_warning_msg = world.time + (60 SECONDS)
+				for(var/datum/mind/AI_mind in malf_ai)
+					to_chat(AI_mind.current, "<span class='warning'>You are too far away from the station to fully access its subsystems. You will not be able to takeover from here.</span>")
+		else
+			if(malf_mode_declared)
+				AI_win_timeleft -= ((apcs / 6) * SSticker.getLastTickerTimeDuration()) //Victory timer de-increments based on how many APCs are hacked.
 
 	..()
 

--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -101,7 +101,7 @@ Once done, you will be able to interface with all systems, notably the onboard n
 
 
 /datum/game_mode/malfunction/process()
-	if(apcs >= 3 && malf_mode_declared)
+	if(apcs >= 3 && malf_mode_declared && can_malf_ai_takeover())
 		AI_win_timeleft -= ((apcs / 6) * SSticker.getLastTickerTimeDuration()) //Victory timer now de-increments based on how many APCs are hacked. --NeoFite
 
 	..()
@@ -142,6 +142,12 @@ You should now be able to use your Explode spell to interface with the nuclear f
 			all_dead = 0
 	return all_dead
 
+/datum/game_mode/proc/can_malf_ai_takeover()
+	for(var/datum/mind/AI_mind in malf_ai) //if there happens to be more than one malfunctioning AI, there only needs to be one in the main station: the crew can just kill that one and the countdown stops while they get the rest
+		var/turf/T = get_turf(AI_mind.current)
+		if(T && (T.z == map.zMainStation))
+			return TRUE
+	return FALSE
 
 /datum/game_mode/malfunction/check_finished()
 	if (station_captured && !to_nuke_or_not_to_nuke)


### PR DESCRIPTION
You know your gamemode is shit when it has to take lessons from Rev.

This is an attempt to prevent AIs from just getting a borg to drag them away to the asteroid prior to going Delta, which was obviously extremely effective at wasting everyone's time for the entire countdown (and pretty much a guaranteed victory if you just get teleported to deep space or something)

AS-IS PROBLEM: The AI can just shunt into the main station while their core is on another z-level. This is already a step-up but ideally they couldn't do that. I can't think of anything besides not letting them shunt while their core is outside station z-level.
Also I mean I guess this doesn't prevent the AI from getting itself into any z1 random space coords but at the very least the pinpointer would actually work in that scenario.

:cl:
 * tweak: Malfunctioning AIs may no longer just get someone to relocate their core to another z-level, doing so now makes the delta countdown stop until they get back.