### PR TITLE
Yep, You Guessed It: It's Even More Chemistry Autism, Yet Again

### DIFF
--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -112,12 +112,14 @@
 	if(src.attached && src.beaker)
 		// Give blood
 		if(mode)
-			if(src.beaker.volume > 0)
-				var/transfer_amount = REAGENTS_METABOLISM
+			if(beaker.volume > 0)
 				if(beaker.reagents.reagent_list.len == 1 && beaker.reagents.has_reagent(BLOOD))
 					// speed up transfer if the container has ONLY blood
-					transfer_amount = 4
-				src.beaker.reagents.trans_to(src.attached, transfer_amount)
+					beaker.reagents.trans_to(attached, 4)
+				else
+					// otherwise: transfer a little bit of all reagents to the patient. the reason why we don't transfer a set amount is because 0.2u of 10 different reagents is 0.02u of each, which is entirely too little.
+					for(var/datum/reagent/reagent in beaker.reagents.reagent_list)
+						beaker.reagents.trans_id_to(attached, reagent.id, reagent.custom_metabolism)
 				update_icon()
 
 		// Take blood
@@ -191,11 +193,16 @@
 /obj/machinery/iv_drip/examine(mob/user)
 	..()
 	to_chat(user, "<span class='info'>\The [src] is [mode ? "injecting" : "taking blood"].</span>")
+	to_chat(user, "<span class='info'>It is attached to [attached ? attached : "no one"].</span>")
 	if(beaker)
 		if(beaker.reagents && beaker.reagents.reagent_list.len)
-			to_chat(user, "<span class='info'>Attached is \a [beaker] with [beaker.reagents.total_volume] units of liquid.</span>")
+			if(beaker.reagents.reagent_list.len == 1 && beaker.reagents.has_reagent(BLOOD))
+				to_chat(user, "<span class='info'>Attached is \an [beaker] with [beaker.reagents.total_volume] units of blood remaining.</span>")
+			else
+				to_chat(user, "<span class='info'>Attached is \an [beaker] with a solution of:</span>")
+				for(var/datum/reagent/R in beaker.reagents.reagent_list)
+					to_chat(user, "<span class='info'>[R.volume] units of [R.name]</span>")
 		else
 			to_chat(user, "<span class='info'>Attached is \an empty [beaker].</span>")
 	else
 		to_chat(user, "<span class='info'>No chemicals are attached.</span>")
-	to_chat(user, "<span class='info'>It is attached to [attached ? attached : "no one"].</span>")

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -1,5 +1,5 @@
 /obj/item/weapon/reagent_containers/blood
-	name = "Bloodpack"
+	name = "\improper Bloodpack"
 	desc = "Contains blood used for transfusion."
 	icon = 'icons/obj/bloodpack.dmi'
 	icon_state = "empty"
@@ -10,14 +10,14 @@
 /obj/item/weapon/reagent_containers/blood/New()
 	..()
 	if(blood_type != null)
-		name = "[blood_type] Bloodpack"
+		name = "\improper[blood_type] Bloodpack"
 	reagents.add_reagent(BLOOD, 200, list("donor"=null,"viruses"=null,"blood_DNA"=null,"blood_type"=blood_type,"resistances"=null,"trace_chem"=null))
 	update_icon()
 
 /obj/item/weapon/reagent_containers/blood/on_reagent_change()
 	update_icon()
-	if(reagents.total_volume == 0 && name != "Empty Bloodback")
-		name = "Empty Bloodpack"
+	if(reagents.total_volume == 0 && name != "\improper Empty Bloodback")
+		name = "\improper Empty Bloodpack"
 		desc = "Seems pretty useless... Maybe if there were a way to fill it?"
 	else if (reagents.reagent_list.len > 0)
 		var/target_type = null
@@ -27,11 +27,11 @@
 				the_volume = A.volume
 				target_type = A.data["blood_type"]
 		if (target_type)
-			name = "[target_type] Bloodpack"
+			name = "\improper [target_type] Bloodpack"
 			desc = "A bloodpack filled with [target_type] blood."
 			blood_type = target_type
 		else
-			name = "Murky Bloodpack"
+			name = "\improper Murky Bloodpack"
 			desc = "A bloodpack that's clearly not filled with blood."
 
 /obj/item/weapon/reagent_containers/blood/update_icon()
@@ -85,7 +85,7 @@
 	blood_type = "O-"
 
 /obj/item/weapon/reagent_containers/blood/empty
-	name = "Empty Bloodpack"
+	name = "\improper Empty Bloodpack"
 	desc = "Seems pretty useless... Maybe if there were a way to fill it?"
 	icon_state = "empty"
 	New()
@@ -95,7 +95,7 @@
 		update_icon()
 
 /obj/item/weapon/reagent_containers/blood/chemo
-	name = "Phalanximine IV kit"
+	name = "\improper Phalanximine IV kit"
 	desc = "IV kit for chemotherapy."
 	icon = 'icons/obj/chemopack.dmi'
 	New()


### PR DESCRIPTION
@nuklearcellphoneg wanted this
When not loaded with a bloodpack, instead of a wonky set rate of transfer, IV drips will now transfer each chemical individually. Bloodpacks not affected. Here's the why/before/after/how/why:

BEFORE
IV loaded with a beaker containing 1 chemical: Transfers 0.2u per tick regardless of metabolism rate. Normal chemicals metabolise at 0.2u, so everything works OK. Chemicals will a lower metabolism rate slowly build up. Drinks, like DD, effectively have full effectiveness but are only drained half as fast, thus letting you squeeze twice as many heals.
IV loaded with a beaker containing 2 chemicals split 50-50: Transfers 0.2u per tick regardless of metabolism rate. Assuming both have default metabolism, you are effectively squeezing twice as many heals out of both. If either is DD it won't work.
IV loaded with a beaker containing 3+ chemicals: NONE OF THEM WORK BECAUSE THEY GO UNDER THE MINIMUM METABOLIZABLE AMOUNT

AFTER
IV loaded with # chemicals: All chemicals are individually transferred at their exact metabolism rate. No build-ups can happen and no effective "squeezing twice as much out of your chemical". If the chemicals in the beaker are at an uneven ratio, such as 40/60, some will simply run out before the others.

![dreamseeker_2017-01-19_00-41-17](https://cloud.githubusercontent.com/assets/6526157/22093078/7b1b99a0-dde1-11e6-9cc5-551f16664ee3.png)
after 1 tick
![dreamseeker_2017-01-19_00-41-37](https://cloud.githubusercontent.com/assets/6526157/22093081/810e84bc-dde1-11e6-8ee3-159269f3c5c2.png)
after a while
![dreamseeker_2017-01-19_00-52-16](https://cloud.githubusercontent.com/assets/6526157/22093089/911089be-dde1-11e6-9354-73f337875ce5.png)


:cl:
 * tweak: Changed how IV drips handle non-bloodbag containers, they will now transfer each chemical in the solution individually, meaning they should now work (at all) when loading a beaker with 2+ chemicals in it.
