### PR TITLE
Tweaks artifact_find_type list

### DIFF
--- a/code/modules/research/xenoarchaeology/artifact/artifact.dm
+++ b/code/modules/research/xenoarchaeology/artifact/artifact.dm
@@ -15,16 +15,17 @@
 	artifact_id = "[pick("kappa","sigma","antaeres","beta","omicron","iota","epsilon","omega","gamma","delta","tau","alpha")]-[rand(100,999)]"
 
 	artifact_find_type = pick(\
-	5;/obj/structure/constructshell,\
 	5;/obj/machinery/syndicate_beacon,\
+	5;/obj/item/clothing/mask/stone,\
+	5;/obj/item/changeling_vial,\
+	10;/obj/structure/constructshell,\
 	25;/obj/machinery/power/supermatter,\
-	50;/obj/structure/cult/pylon,\
 	100;/obj/machinery/auto_cloner,\
 	100;/obj/machinery/giga_drill,\
 	100;/obj/mecha/working/hoverpod,\
 	100;/obj/machinery/replicator,\
-	150;/obj/structure/crystal,\
 	100;/obj/machinery/communication,\
+	150;/obj/structure/crystal,\
 	1000;/obj/machinery/artifact)
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Adds ling vial and stone mask with the same chance as the syndicate beacon(5), buffs construct shell probability from 5 to 10 and removes pylon.

:cl:
 * rscadd: Adds Changeling Vial and Stone Mask to the list of possible large artifacts.
 * rscdel: Removes Pylon from the list of possible large artifacts.