### PR TITLE
Fixes transit pod's pressure

### DIFF
--- a/code/game/objects/structures/transit_tubes.dm
+++ b/code/game/objects/structures/transit_tubes.dm
@@ -364,16 +364,9 @@ obj/structure/ex_act(severity)
 
 // Should I return a copy here? If the caller edits or del()s the returned
 //  datum, there might be problems if I don't...
+//	Shut up bitch, let's do it MY way
 /obj/structure/transit_tube_pod/return_air()
-	var/datum/gas_mixture/GM = new()
-	GM.oxygen			= air_contents.oxygen
-	GM.carbon_dioxide	= air_contents.carbon_dioxide
-	GM.nitrogen			= air_contents.nitrogen
-	GM.toxins			= air_contents.toxins
-	GM.temperature		= air_contents.temperature
-	GM.pressure			= air_contents.pressure
-	GM.total_moles		= air_contents.total_moles
-	return GM
+	return air_contents
 
 // For now, copying what I found in an unused FEA file (and almost identical in a
 //  used ZAS file). Means that assume_air and remove_air don't actually alter the

--- a/code/game/objects/structures/transit_tubes.dm
+++ b/code/game/objects/structures/transit_tubes.dm
@@ -79,7 +79,7 @@ obj/structure/ex_act(severity)
 	air_contents.nitrogen = MOLES_N2STANDARD
 	air_contents.temperature = T20C
 	air_contents.pressure = ONE_ATMOSPHERE
-	air_contents.total_moles = 103.934
+	air_contents.total_moles = MOLES_CELLSTANDARD
 
 	// Give auto tubes time to align before trying to start moving
 	spawn (5)

--- a/code/game/objects/structures/transit_tubes.dm
+++ b/code/game/objects/structures/transit_tubes.dm
@@ -78,6 +78,8 @@ obj/structure/ex_act(severity)
 	air_contents.oxygen = MOLES_O2STANDARD
 	air_contents.nitrogen = MOLES_N2STANDARD
 	air_contents.temperature = T20C
+	air_contents.pressure = ONE_ATMOSPHERE
+	air_contents.total_moles = 103.934
 
 	// Give auto tubes time to align before trying to start moving
 	spawn (5)
@@ -369,6 +371,8 @@ obj/structure/ex_act(severity)
 	GM.nitrogen			= air_contents.nitrogen
 	GM.toxins			= air_contents.toxins
 	GM.temperature		= air_contents.temperature
+	GM.pressure			= air_contents.pressure
+	GM.total_moles		= air_contents.total_moles
 	return GM
 
 // For now, copying what I found in an unused FEA file (and almost identical in a

--- a/code/game/objects/structures/transit_tubes.dm
+++ b/code/game/objects/structures/transit_tubes.dm
@@ -212,7 +212,7 @@ obj/structure/ex_act(severity)
 		open_animation()
 		sleep(OPEN_DURATION + 2)
 		pod_moving = 0
-		//pod.mix_air()
+		pod.mix_air()
 
 		if(automatic_launch_time)
 			var/const/wait_step = 5

--- a/code/game/objects/structures/transit_tubes.dm
+++ b/code/game/objects/structures/transit_tubes.dm
@@ -75,7 +75,7 @@ obj/structure/ex_act(severity)
 
 /obj/structure/transit_tube_pod/New()
 	. = ..()
-	air_contents.oxygen = MOLES_O2STANDARD * 2
+	air_contents.oxygen = MOLES_O2STANDARD
 	air_contents.nitrogen = MOLES_N2STANDARD
 	air_contents.temperature = T20C
 
@@ -210,7 +210,7 @@ obj/structure/ex_act(severity)
 		open_animation()
 		sleep(OPEN_DURATION + 2)
 		pod_moving = 0
-		pod.mix_air()
+		//pod.mix_air()
 
 		if(automatic_launch_time)
 			var/const/wait_step = 5


### PR DESCRIPTION
So what was the problem here? _`return_air`_ wasn't returning the pressure or the total_moles. So the mob couldn't tell how much pressure was in it. This has been tested and the fix works. _I actually don't know why return_air's been designed like this, but oh well_

_**Note to mappers:**_ Just in case you didn't know, when a transit pod reaches a station, `pod.mix_air `gets called, mixing the contents of the room with the pod itself. So if you put a pod station in the outside without any atmos, it'll depressurize the pod.

Closes #7244

:cl:
- bugfix: Transit pods now calculate their pressure correctly. You don't need to wear hardsuits to use them anymore.