### PR TITLE
Removes pipe construction delay on the RPD

### DIFF
--- a/code/modules/RCD/schematics/pipe.dm
+++ b/code/modules/RCD/schematics/pipe.dm
@@ -152,8 +152,8 @@
 
 	to_chat(user, "Building gas sensor...")
 	playsound(get_turf(master), 'sound/machines/click.ogg', 50, 1)
-	if(!do_after(user, A, 20))
-		return 1
+//	if(!do_after(user, A, 1))
+//		return 1
 
 	playsound(get_turf(master), 'sound/items/Deconstruct.ogg', 50, 1)
 	new /obj/item/pipe_gsensor(A)
@@ -169,8 +169,8 @@
 
 	to_chat(user, "Building pipe meter...")
 	playsound(get_turf(master), 'sound/machines/click.ogg', 50, 1)
-	if(!do_after(user, A, 20))
-		return 1
+//	if(!do_after(user, A, 1))
+	//	return 1
 
 	playsound(get_turf(master), 'sound/items/Deconstruct.ogg', 50, 1)
 	new /obj/item/pipe_meter(A)
@@ -338,8 +338,8 @@
 	playsound(get_turf(user), 'sound/machines/click.ogg', 50, 1)
 	var/thislayer = layer
 	var/thisdir = selected_dir
-	if(!do_after(user, A, 20))
-		return 1
+//	if(!do_after(user, A, 1))
+	//	return 1
 
 	playsound(get_turf(user), 'sound/items/Deconstruct.ogg', 50, 1)
 
@@ -382,8 +382,8 @@
 /datum/rcd_schematic/pipe/disposal/attack(var/atom/A, var/mob/user)
 	to_chat(user, "Building Pipes ...")
 	playsound(get_turf(user), 'sound/machines/click.ogg', 50, 1)
-	if(!do_after(user, A, 20))
-		return 1
+//	if(!do_after(user, A, 1))
+//		return 1
 
 	playsound(get_turf(user), 'sound/items/Deconstruct.ogg', 50, 1)
 

--- a/code/modules/RCD/schematics/pipe.dm
+++ b/code/modules/RCD/schematics/pipe.dm
@@ -169,7 +169,7 @@
 
 	to_chat(user, "Building pipe meter...")
 	playsound(get_turf(master), 'sound/machines/click.ogg', 50, 1)
-//	if(!do_after(user, A, 1))
+//	if(!do_after(user, A, 1))  this was the pipe delay code which had that annoying delay for making pipes
 	//	return 1
 
 	playsound(get_turf(master), 'sound/items/Deconstruct.ogg', 50, 1)

--- a/code/modules/RCD/schematics/pipe.dm
+++ b/code/modules/RCD/schematics/pipe.dm
@@ -169,7 +169,7 @@
 
 	to_chat(user, "Building pipe meter...")
 	playsound(get_turf(master), 'sound/machines/click.ogg', 50, 1)
-//	if(!do_after(user, A, 1))  this was the pipe delay code which had that annoying delay for making pipes
+//	if(!do_after(user, A, 1))  this was the pipe delay code which had that annoying delay for making pipes. it was originally set to 20 instead of 1
 	//	return 1
 
 	playsound(get_turf(master), 'sound/items/Deconstruct.ogg', 50, 1)
@@ -382,8 +382,8 @@
 /datum/rcd_schematic/pipe/disposal/attack(var/atom/A, var/mob/user)
 	to_chat(user, "Building Pipes ...")
 	playsound(get_turf(user), 'sound/machines/click.ogg', 50, 1)
-//	if(!do_after(user, A, 1))
-//		return 1
+	if(!do_after(user, A, 20))
+		return 1
 
 	playsound(get_turf(user), 'sound/items/Deconstruct.ogg', 50, 1)
 
@@ -406,6 +406,7 @@ var/global/list/disposalpipeID2State = list(
 	"pipe-j1s",
 	"pipe-j1s",
 )
+
 
 //This is a meta thing to send a blended pipe sprite to clients, basically the default straight pipe, but blended blue.
 //Yes I tried to find a proper way to blend things in HTML/CSS, alas.


### PR DESCRIPTION
remake of https://github.com/d3athrow/vgstation13/pull/13583 because git


This removes that 5 second delay that the RPD has when building pipes so now they are constructed instantly. Works with borg and carbon RPD's. I dont even know why it was added in the first place since all it does is make construction unnecessarily tedious and slows down autism projects.

NOTE i kept the delay in for disposals pipes to stop hallway blockage