### PR TITLE
Fixes laser hit sounds causing all sounds to stop.

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -139,7 +139,8 @@ var/list/impact_master = list()
 	L.apply_effects(stun, weaken, paralyze, irradiate, stutter, eyeblur, drowsy, agony, blocked) // add in AGONY!
 	if(jittery)
 		L.Jitter(jittery)
-	playsound(loc, hitsound, 35, 1)
+	if(!isnull(hitsound))
+		playsound(loc, hitsound, 35, 1)
 	return 1
 
 /obj/item/projectile/proc/check_fire(var/mob/living/target as mob, var/mob/living/user as mob)  //Checks if you can hit them or not.


### PR DESCRIPTION
This is why your admin music stops playing when someone gets shot. @clusterfack helped after I yelled at him enough that it wasn't sound channels, and so did @Intigracy and @Sprok0 

🆑 
 - bugfix: Someone getting shot by a laser will no longer break all sounds.