### PR TITLE
ASSERT to prevent null sounds from unintentionally being played.

### DIFF
--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -28,6 +28,7 @@ var/list/fracture_sound = list('sound/effects/bonebreak1.ogg','sound/effects/bon
 	var/turf/turf_source = get_turf(source)
 
 	ASSERT(!isnull(turf_source))
+	ASSERT(!(isnull(soundin) && channel == 0)) // Unless a channel is specified, prevent null sounds.
 
 	var/frequency = get_rand_frequency() // Same frequency for everybody
 


### PR DESCRIPTION
Mostly for coders.
This'll mean we can track down unintentional null sounds playing with a stack trace.
If you specify a channel when you call `playsound` though it'll ignore that, assuming you want to stop a specific sound instead.