### PR TITLE
Fixes no-fruit powergaming

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -4299,7 +4299,7 @@
 	var/list/available_snacks = list()
 	var/switching = 0
 	var/current_path = null
-	var/counter = 1
+	var/counter = 10
 
 /obj/item/weapon/reagent_containers/food/snacks/pie/nofruitpie/New()
 	..()
@@ -4318,43 +4318,26 @@
 
 	verbs -= /obj/item/weapon/reagent_containers/food/snacks/pie/nofruitpie/verb/pick_leaf
 
-	randomize()
+	while(counter)
+		current_path = pick(available_snacks)
+		var/obj/item/weapon/reagent_containers/food/snacks/S = current_path
+		icon_state = initial(S.icon_state)
+		if(get_turf(src))
+			playsound(get_turf(src), 'sound/misc/click.ogg', 50, 1)
+		sleep(1)
+		counter--
 
-/obj/item/weapon/reagent_containers/food/snacks/pie/nofruitpie/attackby(obj/item/weapon/W, mob/user)
-	if(switching)
-		if(!current_path)
-			return
-		switching = 0
-		var/N = rand(1,3)
-		switch(N)
-			if(1)
-				playsound(user, 'sound/weapons/genhit1.ogg', 50, 1)
-			if(2)
-				playsound(user, 'sound/weapons/genhit2.ogg', 50, 1)
-			if(3)
-				playsound(user, 'sound/weapons/genhit3.ogg', 50, 1)
-		user.visible_message("[user] smacks \the [src] with \the [W].","You smack \the [src] with \the [W].")
-		if(src.loc == user)
-			user.drop_item(src, force_drop = 1)
-			var/I = new current_path(get_turf(user))
-			user.put_in_hands(I)
-		else
-			new current_path(get_turf(src))
-		qdel(src)
+	if(get_turf(usr))
+		playsound(get_turf(usr), 'sound/effect/snap.ogg', 50, 1)
 
+	if(src.loc == usr)
+		usr.drop_item(src, force_drop = 1)
+		var/I = new current_path(get_turf(usr))
+		usr.put_in_hands(I)
+	else
+		new current_path(get_turf(src))
 
-/obj/item/weapon/reagent_containers/food/snacks/pie/nofruitpie/proc/randomize()
-	switching = 1
-	spawn()
-		while(switching)
-			current_path = available_snacks[counter]
-			var/obj/item/weapon/reagent_containers/food/snacks/S = current_path
-			icon_state = initial(S.icon_state)
-			playsound(src, 'sound/misc/click.ogg', 50, 1)
-			sleep(1)
-			if(counter == available_snacks.len)
-				counter = 0
-			counter++
+	qdel(src)
 
 /obj/item/weapon/reagent_containers/food/snacks/sundayroast
 	name = "Sunday roast"

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -4328,7 +4328,7 @@
 		counter--
 
 	if(get_turf(usr))
-		playsound(get_turf(usr), 'sound/effect/snap.ogg', 50, 1)
+		playsound(get_turf(usr), 'sound/effects/snap.ogg', 50, 1)
 
 	if(src.loc == usr)
 		usr.drop_item(src, force_drop = 1)

--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -872,7 +872,7 @@
 	var/list/available_fruits = list()
 	var/switching = 0
 	var/current_path = null
-	var/counter = 1
+	var/counter = 10 // countdown to final grown
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/nofruit/New()
 	..()
@@ -889,42 +889,23 @@
 
 	verbs -= /obj/item/weapon/reagent_containers/food/snacks/grown/nofruit/verb/pick_leaf
 
-	randomize()
+	while(counter)
+		current_path = pick(available_fruits)
+		var/obj/item/weapon/reagent_containers/food/snacks/grown/G = current_path
+		icon_state = initial(G.icon_state)
+		if(get_turf(src))
+			playsound(get_turf(src), 'sound/misc/click.ogg', 50, 1)
+		sleep(1)
+		counter--
 
-/obj/item/weapon/reagent_containers/food/snacks/grown/nofruit/attackby(obj/item/weapon/W, mob/user)
-	if(switching)
-		if(!current_path)
-			return
-		switching = 0
-		var/N = rand(1,3)
-		if(get_turf(user))
-			switch(N)
-				if(1)
-					playsound(get_turf(user), 'sound/weapons/genhit1.ogg', 50, 1)
-				if(2)
-					playsound(get_turf(user), 'sound/weapons/genhit2.ogg', 50, 1)
-				if(3)
-					playsound(get_turf(user), 'sound/weapons/genhit3.ogg', 50, 1)
-		user.visible_message("[user] smacks \the [src] with \the [W].","You smack \the [src] with \the [W].")
-		if(src.loc == user)
-			user.drop_item(src, force_drop = 1)
-			var/I = new current_path(get_turf(user))
-			user.put_in_hands(I)
-		else
-			new current_path(get_turf(src))
-		qdel(src)
+	if(get_turf(usr))
+		playsound(get_turf(usr), 'sound/effects/snap.ogg', 50, 1)
 
+	if(src.loc == usr)
+		usr.drop_item(src, force_drop = 1)
+		var/I = new current_path(get_turf(usr))
+		usr.put_in_hands(I)
+	else
+		new current_path(get_turf(src))
 
-/obj/item/weapon/reagent_containers/food/snacks/grown/nofruit/proc/randomize()
-	switching = 1
-	spawn()
-		while(switching)
-			current_path = available_fruits[counter]
-			var/obj/item/weapon/reagent_containers/food/snacks/grown/G = current_path
-			icon_state = initial(G.icon_state)
-			if(get_turf(src))
-				playsound(get_turf(src), 'sound/misc/click.ogg', 50, 1)
-			sleep(1)
-			if(counter == available_fruits.len)
-				counter = 0
-			counter++
+	qdel(src)


### PR DESCRIPTION
No-fruit and its pie currently has two ways to powergame it for specific growns / foods:

- Because it cycles through the list of available growns / foods in the same order every time, you can just time your hits to make it much likelier that you get the grown / food you're looking for
- Because the growns / foods all come with different shapes and offsets, it's easy to find a pixel that will only hit your particular grown / fruit and just keep spam clicking it

Together these two factors make it so that it's more worthwhile for vox traders / NT botanists to try to get each others' wares through no-fruit than through actual **_departmental interactions_**

This fixes the above issue by making the pick-leaf verb cycle (randomly) through growns/foods for a second and then land on one without any player input.

Tested no-fruit and no-fruit pie in game. Only bug I could find is that if you have an empty hand selected while picking the no-fruit in your other hand, it "jumps" to your empty hand on landing, but this doesn't seem to matter and other combinations of empty/full hands don't have any buggy behaviour.

:cl:
 * "Changed no-fruit and no-fruit pie's pick leaf verb to cycle through growns / foods randomly and automatically land at one after one second (now using the snap sound effect). This prevents being able to powergame no-fruit for specific growns or foods by timing it and spamming specific pixels."