### PR TITLE
Aligns chemmaster buttons, adds buttons to transfer from all chemicals in beaker at the same time

### DIFF
--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -213,6 +213,17 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 	return amount
 */
 
+//Pretty straightforward, remove from all of our chemicals at once, as if transfering to a nonexistant container or something.
+/datum/reagents/proc/remove_all(var/amount=1)
+	amount = min(amount, src.total_volume)
+	var/part = amount / src.total_volume
+	for (var/datum/reagent/current_reagent in src.reagent_list)
+		if (!current_reagent)
+			continue
+		if(src.remove_reagent(current_reagent.id, current_reagent.volume * part))
+			. = 1 //We removed SOMETHING.
+	src.handle_reactions()
+
 /datum/reagents/proc/copy_to(var/obj/target, var/amount=1, var/multiplier=1, var/preserve_data=1)
 	if(!target)
 		return

--- a/html/browser/chem_master.css
+++ b/html/browser/chem_master.css
@@ -1,5 +1,21 @@
+table{
+    width: 100%;
+    border-collapse: collapse;
+}
+.column1{
+	width: 100%;
+	overflow: hidden;
+}
+.column2{
+	white-space: nowrap;
+}
+
 .li{
 	padding: 0px 0px 4px;
+}
+
+.pillIconsContainer {
+	text-align: center
 }
 
 .pillIconWrapper{


### PR DESCRIPTION
OLD:
![2017-01-23_22-28-06](https://cloud.githubusercontent.com/assets/6526157/22230252/42e44bf8-e1bb-11e6-96ff-816278a58d8b.gif)

NEW 1:
![2017-01-23_22-03-08](https://cloud.githubusercontent.com/assets/6526157/22230260/496551fc-e1bb-11e6-8f90-a96ac3fb0717.gif)

NEW 2:
![2017-01-23_22-09-28](https://cloud.githubusercontent.com/assets/6526157/22230285/63e6ee32-e1bb-11e6-8ac8-87f627e461ae.gif)

The main purpose of this change is to make it less insufferable to try to use bluespace beakers with the 100u cache of a chemmaster. Since you can only use 100u at a time, you have to manually use custom amounts to send half of each chemical OR just pour half of the bluespace beaker into a large beaker which kind of defeats the purpose of having a bluespace beaker in the first place and isn't even doable if your autist mixture isn't divisible by 10. Adding a way to add/remove from all chemicals in the beaker at once solves these problems and only adds 2/3 buttons.
Also adds an "All" button, which is what you want to do most of the time probably.
Finally, resizes the window to take up a little less space, since after a talk with other chemistry regulars I realized most of it goes unused and people mostly just drag the right end of the window slightly outside their monitor anyways.

# Aligning the buttons is not final and is open to feedback.

