### PR TITLE
Also Fixes No-Fruit Powergaming

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -4306,6 +4306,7 @@
 	reagents.add_reagent(NOTHING, 20)
 	bitesize = 10
 	available_snacks = existing_typesof(/obj/item/weapon/reagent_containers/food/snacks) - typesof(/obj/item/weapon/reagent_containers/food/snacks/grown) - typesof(/obj/item/weapon/reagent_containers/food/snacks/customizable)
+	available_snacks = shuffle(available_snacks)
 
 /obj/item/weapon/reagent_containers/food/snacks/pie/nofruitpie/verb/pick_leaf()
 	set name = "Pick no-fruit pie leaf"
@@ -4345,6 +4346,7 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/pie/nofruitpie/proc/randomize()
 	switching = 1
+	mouse_opacity = 2
 	spawn()
 		while(switching)
 			current_path = available_snacks[counter]

--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -877,6 +877,7 @@
 /obj/item/weapon/reagent_containers/food/snacks/grown/nofruit/New()
 	..()
 	available_fruits = existing_typesof(/obj/item/weapon/reagent_containers/food/snacks/grown)
+	available_fruits = shuffle(available_fruits)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/nofruit/verb/pick_leaf()
 	set name = "Pick no-fruit leaf"
@@ -917,6 +918,7 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/nofruit/proc/randomize()
 	switching = 1
+	mouse_opacity = 2
 	spawn()
 		while(switching)
 			current_path = available_fruits[counter]


### PR DESCRIPTION
No-fruits and no-fruit pies now have mouse_opacity set to 2 while cycling, making every cycle have exactly the same clickable area. No more hunting specific pixels.

Each no-fruit and no-fruit pie has its own randomly shuffled result list, through which it cycles uniformly. You can still predict a fruit's change, but you need to learn that specific fruit's cycle to do so.

:cl:
 * tweak: No-fruits and no-fruit pies now have mouse_opacity set to 2 while cycling, making every cycle have exactly the same clickable area. No more hunting specific pixels.
 * tweak: Each no-fruit and no-fruit pie has its own randomly shuffled result list, through which it cycles uniformly. You can still predict a fruit's change, but you need to learn that specific fruit's cycle to do so.
