### PR TITLE
Clumsy people can now use advanced clown shoes without fear

### DIFF
--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -179,7 +179,7 @@
 	var/random_sound = 0
 
 /obj/item/clothing/shoes/clown_shoes/advanced/attack_self(mob/user)
-	if(user.mind && user.mind.assigned_role != "Clown")
+	if(user.mind && user.mind.assigned_role != "Clown" && !clumsy_check(user))
 		to_chat(user, "<span class='danger'>These shoes are too powerful for you to handle!</span>")
 		if(prob(25))
 			if(ishuman(user))
@@ -219,7 +219,7 @@
 	if(ishuman(loc))
 		var/mob/living/carbon/human/H = loc
 
-		if(H.mind && H.mind.assigned_role != "Clown")
+		if(H.mind && H.mind.assigned_role != "Clown" && !clumsy_check(H))
 			if( ( H.mind.assigned_role == "Mime" ) )
 				H.Slip(3, 2, 1)
 


### PR DESCRIPTION
Clumsy needs more feature creep.
Added since traders have an object useful JUST for clowns (without this PR).

:cl:
 * tweak: Clumsy people (and clowns still) can now use clown shoes without fear.