### PR TITLE
pAI Fixes

### DIFF
--- a/code/game/machinery/bots/medbot.dm
+++ b/code/game/machinery/bots/medbot.dm
@@ -520,6 +520,7 @@
 	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
 	s.set_up(3, 1, src)
 	s.start()
+	eject_integratedpai_if_present()
 	qdel(src)
 	return
 
@@ -682,13 +683,14 @@
 	pai_analyze_mode = !pai_analyze_mode
 
 /obj/machinery/bot/medbot/state_controls_pai(obj/item/device/paicard/P)
-	to_chat(P.pai, "<span class='info'><b>Welcome to your new body. Remember: you're a pAI inside a medbot, not a medbot.</b></span>")
-	to_chat(P.pai, "<span class='info'>It is highly recommended to download the Medical Supplement from the pAI software interface as it gives you MedHUD.</span>")
-	to_chat(P.pai, "<span class='info'>Your controls are:</span>")
-	to_chat(P.pai, "<span class='info'>- (Q) Drop hotkey: You state there's a patient in critical condition</span>")
-	to_chat(P.pai, "<span class='info'>- (X) Swap hands:  You switch to inject or analyze mode.</span>")
-	to_chat(P.pai, "<span class='info'>- Click on somebody: Depending on your mode, you inject or analyze a person.</span>")
-	to_chat(P.pai, "<span class='info'>What you inject depends on the medbot's configuration. You can't modify it</span>")
-	to_chat(P.pai, "<span class='info'>If you want to exit the medbot, somebody has to right-click you and press 'Remove pAI'.</span>")
+	if(..())
+		to_chat(P.pai, "<span class='info'><b>Welcome to your new body. Remember: you're a pAI inside a medbot, not a medbot.</b></span>")
+		to_chat(P.pai, "<span class='info'>It is highly recommended to download the Medical Supplement from the pAI software interface as it gives you MedHUD.</span>")
+		to_chat(P.pai, "<span class='info'>Your controls are:</span>")
+		to_chat(P.pai, "<span class='info'>- (Q) Drop hotkey: You state there's a patient in critical condition</span>")
+		to_chat(P.pai, "<span class='info'>- (X) Swap hands:  You switch to inject or analyze mode.</span>")
+		to_chat(P.pai, "<span class='info'>- Click on somebody: Depending on your mode, you inject or analyze a person.</span>")
+		to_chat(P.pai, "<span class='info'>What you inject depends on the medbot's configuration. You can't modify it</span>")
+		to_chat(P.pai, "<span class='info'>If you want to exit the medbot, somebody has to right-click you and press 'Remove pAI'.</span>")
 
 #undefine

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -81,8 +81,10 @@ var/global/list/reagents_to_log = list(FUEL, PLASMA, PACID, SACID, AMUTATIONTOXI
 			state_controls_pai(W)
 			playsound(src, 'sound/misc/cartridge_in.ogg', 25)
 
-/obj/proc/state_controls_pai(obj/item/device/paicard/P) //text the pAI receives when is inserted into something. EXAMPLE: to_chat(P.pai, "Welcome to your new body")
-	return
+/obj/proc/state_controls_pai(obj/item/device/paicard/P)			//text the pAI receives when is inserted into something. EXAMPLE: to_chat(P.pai, "Welcome to your new body")
+	if(P.pai)
+		return 1
+	return 0
 
 /obj/proc/attack_integrated_pai(mob/living/silicon/pai/user)	//called when integrated pAI clicks on the object, or uses the attack_self() hotkey
 	return
@@ -150,11 +152,17 @@ var/global/list/reagents_to_log = list(FUEL, PLASMA, PACID, SACID, AMUTATIONTOXI
 		return
 
 	to_chat(M, "You eject \the [integratedpai] from \the [src].")
-	integratedpai.forceMove(get_turf(src))
-	M.put_in_hands(integratedpai)
-	integratedpai = null
+	M.put_in_hands(eject_integratedpai_if_present())
 	playsound(src, 'sound/misc/cartridge_out.ogg', 25)
-	verbs -= /obj/verb/remove_pai
+
+/obj/proc/eject_integratedpai_if_present()
+	if(integratedpai)
+		integratedpai.forceMove(get_turf(src))
+		verbs -= /obj/verb/remove_pai
+		var/obj/item/device/paicard/P = integratedpai
+		integratedpai = null
+		return P
+	return 0
 
 /obj/recycle(var/datum/materials/rec)
 	if(..())

--- a/code/modules/mob/living/silicon/pai/life.dm
+++ b/code/modules/mob/living/silicon/pai/life.dm
@@ -5,6 +5,7 @@
 	if (src.stat == 2)
 		return
 
+	handle_regular_status_updates()
 	regular_hud_updates()
 	if(src.secHUD)
 		process_sec_hud(src)
@@ -21,3 +22,65 @@
 		stat = CONSCIOUS
 	else
 		health = maxHealth - getBruteLoss() - getFireLoss()
+
+/mob/living/silicon/pai/proc/handle_regular_status_updates()
+
+	updatehealth()
+
+	if(sleeping)
+		Paralyse(3)
+		sleeping--
+
+	if(resting)
+		Knockdown(5)
+
+	if(health <= 0 && stat != 2) //die only once
+		death()
+
+	if (stat != 2) //Alive.
+		if (paralysis || stunned || knockdown) //Stunned etc.
+			stat = 1
+			if (stunned > 0)
+				AdjustStunned(-1)
+			if (knockdown > 0)
+				AdjustKnockdown(-1)
+			if (paralysis > 0)
+				AdjustParalysis(-1)
+				blinded = 1
+			else
+				blinded = 0
+
+		else	//Not stunned.
+			stat = 0
+
+	else //Dead.
+		blinded = 1
+		stat = 2
+
+	if (stuttering)
+		stuttering--
+
+	if (eye_blind)
+		eye_blind--
+		blinded = 1
+
+	if (ear_deaf > 0)
+		ear_deaf--
+	if (ear_damage < 25)
+		ear_damage -= 0.05
+		ear_damage = max(ear_damage, 0)
+
+	if (sdisabilities & BLIND)
+		blinded = 1
+	if (sdisabilities & DEAF)
+		ear_deaf = 1
+
+	if (eye_blurry > 0)
+		eye_blurry--
+		eye_blurry = max(0, eye_blurry)
+
+	if (druggy > 0)
+		druggy--
+		druggy = max(0, druggy)
+
+	return 1


### PR DESCRIPTION
Fixes #13091
Fixes #13508
Fixes runtime error when placing an empty pAI into a medbot.

:cl:
 * bugfix: Fixed pAIs being stunned forever after being hit by a flashbang.
 * bugfix: Fixed pAIs not being ejected from a medbot when it gets destroyed..
