### PR TITLE
X-ray Beam Penetration

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -586,9 +586,9 @@ var/list/beam_master = list()
 
 /obj/item/projectile/beam/xray/Bump(atom/A)
 	if(..())
-		damage -= 5
-		if(istype(A, /turf/simulated/wall/r_wall))
-			damage -= 5
+		damage -= 3
+		if(istype(A, /turf/simulated/wall/r_wall) || (istype(A, /obj/machinery/door/poddoor) && !istype(A, /obj/machinery/door/poddoor/shutters)))	//if we hit an rwall or blast doors, but not shutters, the beam dies
+			bullet_die()
 		if(damage <= 0)
 			bullet_die()
 

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -587,6 +587,8 @@ var/list/beam_master = list()
 /obj/item/projectile/beam/xray/Bump(atom/A)
 	if(..())
 		damage -= 5
+		if(istype(A, /turf/simulated/wall/r_wall))
+			damage -= 5
 		if(damage <= 0)
 			bullet_die()
 

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -95,6 +95,7 @@ var/list/beam_master = list()
 	var/first = 1
 	var/tS = 0
 	while(src && src.loc)// only stop when we've hit something, or hit the end of the map
+		bumped = 0
 		if(first && timestopped)
 			tS = 1
 			timestopped = 0
@@ -578,7 +579,16 @@ var/list/beam_master = list()
 	name = "xray beam"
 	icon_state = "xray"
 	damage = 30
+	kill_count = 500
+	phase_type = PROJREACT_WALLS|PROJREACT_WINDOWS|PROJREACT_OBJS|PROJREACT_MOBS|PROJREACT_BLOB
+	penetration = -1
 	fire_sound = 'sound/weapons/laser3.ogg'
+
+/obj/item/projectile/beam/xray/Bump(atom/A)
+	if(..())
+		damage -= 2
+		if(damage <= 0)
+			bullet_die()
 
 /obj/item/projectile/beam/pulse
 	name = "pulse"

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -586,7 +586,7 @@ var/list/beam_master = list()
 
 /obj/item/projectile/beam/xray/Bump(atom/A)
 	if(..())
-		damage -= 2
+		damage -= 5
 		if(damage <= 0)
 			bullet_die()
 


### PR DESCRIPTION
X-ray beams now have infinite penetration.
Every time an X-ray beam passes through an object, its damage is reduced by 3.
The beam is deleted when its damage reaches 0.

Fixes #13577

:cl:
 * rscadd: X-ray beams now penetrate obstacles, decreasing in damage with each obstacle they penetrate.
