### PR TITLE
No fruit has been relegated to its proper place once and for all.

### DIFF
--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -378,7 +378,7 @@
 	name = "packet of cinnamomum seeds"
 	seed_type = "cinnamomum"
 	vending_cat = "trees"
-	
+
 /obj/item/seeds/test
 	name = "packet of testing data seed"
 	seed_type = "test"
@@ -1571,7 +1571,9 @@
 	plant_icon = "nofruit"
 	chems = list(NOTHING = list(1,20))
 
+	immutable = 1
 	lifespan = 30
+	endurance = 30 // So you can't use cuttings to get more seeds
 	maturation = 5
 	production = 5
 	yield = 1

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -4299,7 +4299,6 @@
 	var/list/available_snacks = list()
 	var/switching = 0
 	var/current_path = null
-	var/counter = 1
 
 /obj/item/weapon/reagent_containers/food/snacks/pie/nofruitpie/New()
 	..()
@@ -4334,12 +4333,13 @@
 			if(3)
 				playsound(user, 'sound/weapons/genhit3.ogg', 50, 1)
 		user.visible_message("[user] smacks \the [src] with \the [W].","You smack \the [src] with \the [W].")
+		var/obj/item/weapon/reagent_containers/food/snacks/chosen = rand(available_snacks)
 		if(src.loc == user)
 			user.drop_item(src, force_drop = 1)
-			var/I = new current_path(get_turf(user))
+			var/I = new chosen(get_turf(user))
 			user.put_in_hands(I)
 		else
-			new current_path(get_turf(src))
+			new chosen(get_turf(src))
 		qdel(src)
 
 
@@ -4347,14 +4347,10 @@
 	switching = 1
 	spawn()
 		while(switching)
-			current_path = available_snacks[counter]
-			var/obj/item/weapon/reagent_containers/food/snacks/S = current_path
+			var/obj/item/weapon/reagent_containers/food/snacks/S = rand(available_snacks)
 			icon_state = initial(S.icon_state)
 			playsound(src, 'sound/misc/click.ogg', 50, 1)
 			sleep(1)
-			if(counter == available_snacks.len)
-				counter = 0
-			counter++
 
 /obj/item/weapon/reagent_containers/food/snacks/sundayroast
 	name = "Sunday roast"

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -4321,8 +4321,6 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/pie/nofruitpie/attackby(obj/item/weapon/W, mob/user)
 	if(switching)
-		if(!current_path)
-			return
 		switching = 0
 		var/N = rand(1,3)
 		switch(N)

--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -871,8 +871,6 @@
 	plantname = "nofruit"
 	var/list/available_fruits = list()
 	var/switching = 0
-	var/current_path = null
-	var/counter = 1
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/nofruit/New()
 	..()
@@ -906,12 +904,13 @@
 				if(3)
 					playsound(get_turf(user), 'sound/weapons/genhit3.ogg', 50, 1)
 		user.visible_message("[user] smacks \the [src] with \the [W].","You smack \the [src] with \the [W].")
+		var/obj/item/weapon/reagent_containers/food/snacks/grown/chosen = rand(available_fruits)
 		if(src.loc == user)
 			user.drop_item(src, force_drop = 1)
-			var/I = new current_path(get_turf(user))
+			var/I = new chosen(get_turf(user))
 			user.put_in_hands(I)
 		else
-			new current_path(get_turf(src))
+			new chosen(get_turf(src))
 		qdel(src)
 
 
@@ -919,12 +918,8 @@
 	switching = 1
 	spawn()
 		while(switching)
-			current_path = available_fruits[counter]
-			var/obj/item/weapon/reagent_containers/food/snacks/grown/G = current_path
+			var/obj/item/weapon/reagent_containers/food/snacks/grown/G = rand(available_fruits)
 			icon_state = initial(G.icon_state)
 			if(get_turf(src))
 				playsound(get_turf(src), 'sound/misc/click.ogg', 50, 1)
 			sleep(1)
-			if(counter == available_fruits.len)
-				counter = 0
-			counter++

--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -891,8 +891,6 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/nofruit/attackby(obj/item/weapon/W, mob/user)
 	if(switching)
-		if(!current_path)
-			return
 		switching = 0
 		var/N = rand(1,3)
 		if(get_turf(user))


### PR DESCRIPTION
- No-fruit and no-fruit pie now cycle randomly, and more importantly, their result is random after you hit it. You can no longer time it, autoclick it, or specific-pixel click it to aim for a specific grown or food.
- The no-fruit plant is now immutable with its endurance lowered to 30 so you can't clip more seeds out of it than you start with.

> B-b-but-

Go trade for those seeds with the Vox Traders, get them from Xenoarchs, or mutate them yourself like you should be doing instead of relying on your all-fruit.

**This is still a useful and fun item to have. Yes, it's possible to have fun without trying to powergame your no-fruits to the extent that you don't ever have to talk to the traders or xenoarchs or actually do botany. No-fruits are that special bonus "random roll" you get at the end of the exotic seed crate and the Traders get two of them in their hacked vendor with which they might get human seeds to use, might get exotic and unobtainable seeds to trade, or might get unlucky.**

:cl:
 * Tweak: No-fruits are now truly random, immutable, and too fragile to reproduce with cuttings.