### PR TITLE
Smart Laser Gun Safety

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -53,6 +53,8 @@
 
 	var/projectile_color = null
 
+	var/pai_safety = TRUE	//To allow the pAI to activate or deactivate firing capability
+
 /obj/item/weapon/gun/proc/ready_to_fire()
 	if(world.time >= last_fired + fire_delay)
 		last_fired = world.time
@@ -348,11 +350,13 @@
 /obj/item/weapon/gun/on_integrated_pai_click(mob/living/silicon/pai/user, var/atom/A)	//to allow any gun to be pAI-compatible, on a basic level, just by varediting
 	if(check_pai_can_fire(user))
 		Fire(A,user,use_shooter_turf = TRUE)
-	else
-		to_chat(user, "<span class='warning'>You can't aim the gun properly from this location!</span>")
 
 /obj/item/weapon/gun/proc/check_pai_can_fire(mob/living/silicon/pai/user)	//for various restrictions on when pAIs can fire a gun into which they're integrated
 	if(get_holder_of_type(user, /obj/structure/disposalpipe) || get_holder_of_type(user, /obj/machinery/atmospherics/pipe))	//can't fire the gun from inside pipes or disposal pipes
+		to_chat(user, "<span class='warning'>You can't aim \the [src] properly from this location!</span>")
+		return FALSE
+	else if(!pai_safety)
+		to_chat(user, "<span class='warning'>You're not connected to \the [src]'s firing mechanism!</span>")
 		return FALSE
 	else
 		return TRUE

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -372,6 +372,20 @@
 	can_take_pai = TRUE
 	origin_tech = Tc_COMBAT + "=3;" + Tc_MAGNETS + "=2;" + Tc_ENGINEERING + "=2;" + Tc_PROGRAMMING + "=4"
 
+/obj/item/weapon/gun/energy/laser/smart/state_controls_pai(obj/item/device/paicard/P)
+	if(P.pai)
+		to_chat(P.pai, "<span class='info'><b>You have been connected to \a [src].</b></span>")
+		to_chat(P.pai, "<span class='info'>Your controls are:</span>")
+		to_chat(P.pai, "<span class='info'>- (Z) Use hotkey: Connect or disconnect from \the [src]'s firing mechanism.</span>")
+		to_chat(P.pai, "<span class='info'>- Click on a target: Fire \the [src] at the target.</span>")
+
+/obj/item/weapon/gun/energy/laser/smart/attack_integrated_pai(mob/living/silicon/pai/user)
+	if(!pai_safety)
+		to_chat(user, "<span class='notice'>You connect to \the [src]'s firing mechanism.</span>")
+	else
+		to_chat(user, "<span class='notice'>You disconnect from \the [src]'s firing mechanism.</span>")
+	pai_safety = !pai_safety
+
 /obj/item/weapon/gun/energy/laser/rainbow
 
 	name = "rainbow laser"


### PR DESCRIPTION
pAIs inside a smart laser gun may now click the gun or use the Use hotkey to connect or disconnect themselves from the gun's firing mechanism, allowing them to prevent misfires.
Fulfills second part of #13470.

:cl:
 * rscadd: pAIs inside a smart laser gun may now click the gun or use the Use hotkey to connect or disconnect themselves from the gun's firing mechanism, allowing them to prevent misfires.
