### PR TITLE
Reverts part of "Also Fixes No-Fruit Powergaming"

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -4306,7 +4306,6 @@
 	reagents.add_reagent(NOTHING, 20)
 	bitesize = 10
 	available_snacks = existing_typesof(/obj/item/weapon/reagent_containers/food/snacks) - typesof(/obj/item/weapon/reagent_containers/food/snacks/grown) - typesof(/obj/item/weapon/reagent_containers/food/snacks/customizable)
-	available_snacks = shuffle(available_snacks)
 
 /obj/item/weapon/reagent_containers/food/snacks/pie/nofruitpie/verb/pick_leaf()
 	set name = "Pick no-fruit pie leaf"

--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -877,7 +877,6 @@
 /obj/item/weapon/reagent_containers/food/snacks/grown/nofruit/New()
 	..()
 	available_fruits = existing_typesof(/obj/item/weapon/reagent_containers/food/snacks/grown)
-	available_fruits = shuffle(available_fruits)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/nofruit/verb/pick_leaf()
 	set name = "Pick no-fruit leaf"


### PR DESCRIPTION
https://github.com/d3athrow/vgstation13/pull/13613

Specifically, the part that makes it impossible to time either food.

It does nothing to "fix" no-fruit, and hurts people who use no-fruit pie for fun. There are two problems with no-fruits. One is the lag it causes in high quantities. This PR didn't fix that. It did fix the other exploit, involving aiming your cursor at a specific spot for what you wanted, which is why I’ve left that in. There is another, pseudo-problem perpetuated by despotate for no reason, which is that it may allow you to get all the fruits and vegetables too easily, and reduce departmental interaction. That it's unhealthy. That people use it in a bad way that's bad for the server.

Considering this PR has been out for days and that didn’t happen since (despite it being just as easy as before), and there were years beforehand where this didn't happen, and the only man in existence who cared about it was despotate, I see no reason why this should be merged.

But just in case you think this PR has any merit, any value, any purpose beyond ruining Chikiwek Bakery, the last holy grail of the universe... in case you think this PR "also fixes no-fruit powergaming", I present to you: fig. 1-6

![image](https://cloud.githubusercontent.com/assets/6062247/22402671/1172cd62-e5b5-11e6-8286-d0f5db294d46.png)
![image](https://cloud.githubusercontent.com/assets/6062247/22402673/159534b6-e5b5-11e6-8ad6-890970581f03.png)
![image](https://cloud.githubusercontent.com/assets/6062247/22402674/1e1327ec-e5b5-11e6-9ff6-b9dc1c78367e.png)
![image](https://cloud.githubusercontent.com/assets/6062247/22402676/201debe4-e5b5-11e6-9d6b-a37cd0cceb56.png)
![image](https://cloud.githubusercontent.com/assets/6062247/22402677/2316cd20-e5b5-11e6-8a03-a155785cb549.png)
![image](https://cloud.githubusercontent.com/assets/6062247/22402678/25254b0a-e5b5-11e6-99ff-395687a87a5a.png)

@Probe1 this is why you don't LUL FASTEMERGE things that are broken and still being discussed. I admire you in a lot of ways, but this is not one of them. Disappointed.

I'm not going to make an issue discussing alternative options, and there should not be a vote about alternative options. There are a grand total of 3 people who have actually powergamed with no-fruit, to my knowledge. One of them was just trying to have fun, and the other two were trying to prove a point-- me and Despotate. The only thing that no-fruit should receive is some fun, some bugfixes, not a massive, unwarranted CoderBalance(tm) nerf.

Why remove fun? Why remove no-fruit pie timing? The only applicable alternative option is not a nerf, it's a sidegrade-- aiming for no-fruit and no-fruit pie and needing fast reaction time rather than memory. But that's not this PR, and the perceived problem and false urgency that despotate and others stirred up should be put behind us.

(I haven't done github in like a year and this may suck shit, but seeing as it's not the most complex PR in the world... hopefully it works? I didn't make a branch off my fork, which is obviously bad practice, but I'm not sure it matters here)

:cl:
 * rscdel: No-fruit and no-fruit pie can be timed once again, but not manipulated.
