### PR TITLE
Simple animals now check for mobs in earshot before speaking.

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -207,7 +207,6 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 	var/someone_in_earshot=0
 	if(!client && speak_chance && (ckey == null)) // Remove this if earshot is used elsewhere.
 		// All we're doing here is seeing if there's any CLIENTS nearby.
-		// HOWEVER, this returns virtualhearers, so we have to test their attached mobs/atoms.
 		for(var/mob/M in get_hearers_in_view(7, src))
 			if(M.client)
 				someone_in_earshot=1

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -204,10 +204,19 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 					wander_move(destination)
 					turns_since_move = 0
 
+	var/someone_in_earshot=0
+	if(!client && speak_chance && (ckey == null)) // Remove this if earshot is used elsewhere.
+		// All we're doing here is seeing if there's any CLIENTS nearby.
+		// HOWEVER, this returns virtualhearers, so we have to test their attached mobs/atoms.
+		for(var/mob/M in get_hearers_in_view(7, src))
+			if(M.client)
+				someone_in_earshot=1
+				break
+
 	//Speaking
-	if(!client && speak_chance && (ckey == null))
-		if(rand(0,200) < speak_chance)
-			if(speak && speak.len)
+	if(!client && speak_chance && (ckey == null) && someone_in_earshot)
+		if(speak && speak.len)
+			if(rand(0,200) < speak_chance)
 				if((emote_hear && emote_hear.len) || (emote_see && emote_see.len))
 					var/length = speak.len
 					if(emote_hear && emote_hear.len)


### PR DESCRIPTION
# Executive Summary

No more cyber horror spam.  All simple animals now check to see if there's a client'd mob in earshot before they start yapping.

# Testing

Just loaded up tgstation and ghosted.  Then spawned some cyberhorrors in the bathrooms and ghosted around them.  They spoke, shut up when I moved out of range.

# Caveats

Does not check for possessed objects.

# Issues

* Fixes #13695
* May affect #13692

# Changelog
:cl:
 * bugfix: Simple animals (including cyber horrors) check for proximity of clients before they speak, vastly reducing spam.