### PR TITLE
No-Fruit Compromise

### DIFF
--- a/code/__DEFINES/hydro.dm
+++ b/code/__DEFINES/hydro.dm
@@ -1,0 +1,2 @@
+#define HYDRO_PREHISTORIC 1
+#define HYDRO_VOX 2

--- a/code/modules/hydroponics/prehistoric_plants.dm
+++ b/code/modules/hydroponics/prehistoric_plants.dm
@@ -27,6 +27,7 @@
 	desc = "A clump of telriis grass, not recommended for consumption by sentients."
 	icon_state = "telriisclump"
 	plantname = "telriis"
+	hydroflags = HYDRO_PREHISTORIC
 
 /datum/seed/thaadra
 	name = "thaadra"
@@ -55,6 +56,7 @@
 	desc = "Looks chewy, might be good to eat."
 	icon_state = "thaadrabloom"
 	plantname = "thaadra"
+	hydroflags = HYDRO_PREHISTORIC
 
 /datum/seed/jurlmah
 	name = "jurlmah"
@@ -86,6 +88,7 @@
 	desc = "Bulbous and veiny, it appears to pulse slightly as you look at it."
 	icon_state = "jurlmahpod"
 	plantname = "jurlmah"
+	hydroflags = HYDRO_PREHISTORIC
 
 /datum/seed/amauri
 	name = "amauri"
@@ -118,6 +121,7 @@
 	desc = "It is small, round and hard. Its skin is a thick dark purple."
 	icon_state = "amaurifruit"
 	plantname = "amauri"
+	hydroflags = HYDRO_PREHISTORIC
 
 /datum/seed/gelthi
 	name = "gelthi"
@@ -149,6 +153,7 @@
 	icon_state = "gelthiberries"
 	gender = PLURAL
 	plantname = "gelthi"
+	hydroflags = HYDRO_PREHISTORIC
 
 /datum/seed/vale
 	name = "vale"
@@ -179,6 +184,7 @@
 	desc = "Small, curly leaves covered in a soft pale fur."
 	icon_state = "valeleaves"
 	plantname = "vale"
+	hydroflags = HYDRO_PREHISTORIC
 
 /datum/seed/surik
 	name = "surik"
@@ -209,3 +215,4 @@
 	desc = "Multiple layers of blue skin peeling away to reveal a spongey core, vaguely resembling an ear."
 	icon_state = "surikfruit"
 	plantname = "surik"
+	hydroflags = HYDRO_PREHISTORIC

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -1578,6 +1578,7 @@
 	packet_icon = "seed-nofruit"
 	plant_icon = "nofruit"
 	chems = list(NOTHING = list(1,20))
+	immutable = 1
 
 	lifespan = 30
 	maturation = 5
@@ -1585,7 +1586,7 @@
 	yield = 1
 	potency = 10
 	water_consumption = 6
-	nutrient_consumption = 0.10
+	nutrient_consumption = 1
 	growth_stages = 4
 
 // Vox Food

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -9,6 +9,7 @@
 	var/seed_type
 	var/datum/seed/seed
 	var/modified = 0
+	var/hydroflags = 0 // HYDRO_*, used for no-fruit exclusion lists, at the moment.
 
 /obj/item/seeds/New()
 	while(!plant_controller)
@@ -378,7 +379,7 @@
 	name = "packet of cinnamomum seeds"
 	seed_type = "cinnamomum"
 	vending_cat = "trees"
-	
+
 /obj/item/seeds/test
 	name = "packet of testing data seed"
 	seed_type = "test"
@@ -398,36 +399,43 @@
 	name = "packet of breadfruit seeds"
 	seed_type = "breadfruit"
 	vending_cat = "Vox hydroponics"
+	hydroflags = HYDRO_VOX
 
 /obj/item/seeds/woodapple
 	name = "packet of woodapple seeds"
 	seed_type = "woodapple"
 	vending_cat = "Vox hydroponics"
+	hydroflags = HYDRO_VOX
 
 /obj/item/seeds/chickenshroom
 	name = "packet of chicken-of-the-stars spores"
 	seed_type = "chickenshroom"
 	vending_cat = "Vox hydroponics"
+	hydroflags = HYDRO_VOX
 
 /obj/item/seeds/garlic
 	name = "packet of garlic growths"
 	seed_type = "garlic"
 	vending_cat = "Vox hydroponics"
+	hydroflags = HYDRO_VOX
 
 /obj/item/seeds/pitcher
 	name = "tissue culture of slipping pitchers"
 	seed_type = "pitcher"
 	vending_cat = "Vox hydroponics"
+	hydroflags = HYDRO_VOX
 
 /obj/item/seeds/aloe
 	name = "packet of aloe vera seeds"
 	seed_type = "aloe"
 	vending_cat = "Vox hydroponics"
+	hydroflags = HYDRO_VOX
 
 /obj/item/seeds/vaporsac
 	name = "packet of vapor sac spores"
 	seed_type = "vaporsac"
 	vending_cat = "Vox hydroponics"
+	hydroflags = HYDRO_VOX
 
 // Chili plants/variants.
 /datum/seed/chili

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -4353,9 +4353,10 @@
 			var/obj/item/weapon/reagent_containers/food/snacks/S = current_path
 			icon_state = initial(S.icon_state)
 			playsound(src, 'sound/misc/click.ogg', 50, 1)
-			sleep(1)
+			sleep(4)
 			if(counter == available_snacks.len)
 				counter = 0
+				available_snacks = shuffle(available_snacks)
 			counter++
 
 /obj/item/weapon/reagent_containers/food/snacks/sundayroast

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -4352,7 +4352,6 @@
 			current_path = available_snacks[counter]
 			var/obj/item/weapon/reagent_containers/food/snacks/S = current_path
 			icon_state = initial(S.icon_state)
-			playsound(src, 'sound/misc/click.ogg', 50, 1)
 			sleep(4)
 			if(counter == available_snacks.len)
 				counter = 0

--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -24,7 +24,8 @@ var/list/special_fruits = list()
 /proc/get_special_fruits(var/filter=HYDRO_PREHISTORIC|HYDRO_VOX)
 	. = list()
 	for(var/T in existing_typesof(/obj/item/weapon/reagent_containers/food/snacks/grown))
-		if(initial(T:hydroflags) & filter)
+		var/obj/item/weapon/reagent_containers/food/snacks/grown/G = T
+		if(initial(G.hydroflags) & filter)
 			. += T
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/New()

--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -926,7 +926,8 @@
 			icon_state = initial(G.icon_state)
 			if(get_turf(src))
 				playsound(get_turf(src), 'sound/misc/click.ogg', 50, 1)
-			sleep(1)
+			sleep(4)
 			if(counter == available_fruits.len)
 				counter = 0
+				available_fruits = shuffle(available_fruits)
 			counter++

--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -5,11 +5,13 @@
 // Data from the seeds carry over to these grown foods
 // ***********************************************************
 
+var/global/list/special_fruits = list()
 //Grown foods
 //Subclass so we can pass on values
 /obj/item/weapon/reagent_containers/food/snacks/grown/
 	var/plantname
 	var/potency = -1
+	var/hydroflags = 0
 	var/datum/seed/seed
 	icon = 'icons/obj/harvest.dmi'
 	New(newloc, newpotency)
@@ -18,6 +20,13 @@
 		..()
 		src.pixel_x = rand(-5, 5) * PIXEL_MULTIPLIER
 		src.pixel_y = rand(-5, 5) * PIXEL_MULTIPLIER
+
+/proc/get_special_fruits(var/filter=HYDRO_PREHISTORIC|HYDRO_VOX)
+	. = list()
+	for(var/type in existing_typesof(/obj/item/weapon/reagent_containers/food/snacks/grown))
+		var/obj/item/weapon/reagent_containers/food/snacks/grown/GT = type
+		if(initial(GT.hydroflags) & filter)
+			. += type
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/New()
 	..()
@@ -791,6 +800,7 @@
 	icon_state = "chickenshroom"
 	filling_color = "F2E33A"
 	plantname = "chickenshroom"
+	hydroflags = HYDRO_VOX
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/garlic
 	name = "garlic"
@@ -798,6 +808,7 @@
 	icon_state = "garlic"
 	filling_color = "EDEDE1"
 	plantname = "garlic"
+	hydroflags = HYDRO_VOX
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/breadfruit
 	name = "breadfruit"
@@ -805,6 +816,7 @@
 	icon_state = "breadfruit"
 	filling_color = "EDEDE1"
 	plantname = "breadfruit"
+	hydroflags = HYDRO_VOX
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/woodapple
 	name = "woodapple"
@@ -814,6 +826,7 @@
 	icon_state = "woodapple"
 	filling_color = "857663"
 	plantname = "woodapple"
+	hydroflags = HYDRO_VOX
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/pitcher
 	name = "pitcher plant" //results in "slippery pitcher plant"
@@ -821,6 +834,7 @@
 	icon_state = "pitcher"
 	filling_color = "7E8507"
 	plantname = "pitcher"
+	hydroflags = HYDRO_VOX
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/aloe
 	name = "aloe vera"
@@ -828,6 +842,7 @@
 	icon_state = "aloe"
 	filling_color = "77BA9F"
 	plantname = "aloe"
+	hydroflags = HYDRO_VOX
 
 // *************************************
 // Complex Grown Object Defines -
@@ -876,7 +891,7 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/nofruit/New()
 	..()
-	available_fruits = existing_typesof(/obj/item/weapon/reagent_containers/food/snacks/grown)
+	available_fruits = existing_typesof(/obj/item/weapon/reagent_containers/food/snacks/grown) - get_special_fruits()
 	available_fruits = shuffle(available_fruits)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/nofruit/verb/pick_leaf()
@@ -924,8 +939,6 @@
 			current_path = available_fruits[counter]
 			var/obj/item/weapon/reagent_containers/food/snacks/grown/G = current_path
 			icon_state = initial(G.icon_state)
-			if(get_turf(src))
-				playsound(get_turf(src), 'sound/misc/click.ogg', 50, 1)
 			sleep(4)
 			if(counter == available_fruits.len)
 				counter = 0

--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -5,7 +5,7 @@
 // Data from the seeds carry over to these grown foods
 // ***********************************************************
 
-var/global/list/special_fruits = list()
+var/list/special_fruits = list()
 //Grown foods
 //Subclass so we can pass on values
 /obj/item/weapon/reagent_containers/food/snacks/grown/
@@ -23,10 +23,9 @@ var/global/list/special_fruits = list()
 
 /proc/get_special_fruits(var/filter=HYDRO_PREHISTORIC|HYDRO_VOX)
 	. = list()
-	for(var/type in existing_typesof(/obj/item/weapon/reagent_containers/food/snacks/grown))
-		var/obj/item/weapon/reagent_containers/food/snacks/grown/GT = type
-		if(initial(GT.hydroflags) & filter)
-			. += type
+	for(var/T in existing_typesof(/obj/item/weapon/reagent_containers/food/snacks/grown))
+		if(initial(T:hydroflags) & filter)
+			. += T
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/New()
 	..()

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -34,6 +34,7 @@
 #include "code\names.dm"
 #include "code\world.dm"
 #include "code\__DEFINES\disease2.dm"
+#include "code\__DEFINES\hydro.dm"
 #include "code\__DEFINES\pai_software.dm"
 #include "code\__DEFINES\spell_flags.dm"
 #include "code\__DEFINES\turfs.dm"


### PR DESCRIPTION
I figured I'd see what people think of this change to no-fruit mechanics.

No-fruits and no-fruit pies now reshuffle their lists each time they reach the ends of them, rendering it impossible to predict the next result.
*To compensate*, the cycling time has been reduced from once every decisecond to once every four deciseconds. It's now humanly possible to react to the no-fruit's appearance and hit it before it changes, though it's still not easy.

EDIT:
In the interest of compromise, I've combined #13786 and #13807, removing as much theoretical lag as possible without changing the core functionality of the no-fruit.
* No-fruits and no-fruit pies no longer play a sound when cycling.
* No-fruit is now immutable.
* No-fruit now requires ten times the nutrition to grow.
* No-fruit can no longer roll prehistoric plants or vox plants.

I think that the reduction in cycling frequency, plus the removal of the sound, plus preventing them from being genetically modified, *plus* making them harder to grow in general, will make it far less trivial than it is now to produce enough no-fruit to tax clients, hopefully returning them to the position they were in for nearly a year without issue.

:cl:
 * tweak: No-fruit and no-fruit pie cycling is now truly random, and can't be predicted.
 * tweak: The cycling speed of no-fruit and no-fruit pie has been reduced, so that it's now humanly possible to react to the fruit's appearance before it changes again.
 * tweak: No-fruit is now immutable.
 * tweak: No-fruit now requires ten times the nutrition to grow.
 * tweak: No-fruit can no longer roll prehistoric plants or vox plants.
 * sounddel: No-fruit no longer plays a sound when cycling.
