### PR TITLE
Using the mining scanner on ore boxes allows interaction with them

### DIFF
--- a/code/modules/mining/ore_box.dm
+++ b/code/modules/mining/ore_box.dm
@@ -10,6 +10,10 @@
 	starting_materials = list()
 
 /obj/structure/ore_box/attackby(obj/item/weapon/W as obj, mob/user as mob)
+	// this makes it possible for supply cyborgs to interact with the box
+	if (istype(W, /obj/item/device/mining_scanner))
+		attack_hand(user)
+		return
 	if (istype(W, /obj/item/weapon/ore))
 		var/obj/item/weapon/ore/O = W
 		if(O.material)


### PR DESCRIPTION
Before this supply cyborgs couldn't interact with ore boxes to check how many ores they had collected, this change allows them to do that by smacking the crate with the mining scanner.

This is my first PR so I picked a small QoL improvement, something that looks hard to fuck up. Nonetheless, point out anything that seems out of place. I tested this and it works.

![unnecessary picture](https://cloud.githubusercontent.com/assets/6307265/22404518/a36860a6-e632-11e6-99da-f4e77b37ea89.png)

:cl:
 * rscadd: Supply cyborgs can now use the mining scanner on ore boxes to check the contents.