### PR TITLE
Make shuttle airlocks play sound effects when opened or closed

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -48,8 +48,9 @@ var/list/all_doors = list()
 
 	// turf animation
 	var/atom/movable/overlay/c_animation = null
-
+	var/makes_noise = 0
 	var/soundeffect = 'sound/machines/airlock.ogg'
+	var/soundpitch = 30
 
 	var/explosion_block = 0 //regular airlocks are 1, blast doors are 3, higher values mean increasingly effective at blocking explosions.
 
@@ -223,6 +224,9 @@ var/list/all_doors = list()
 	if(!operating)
 		operating = 1
 
+	if(makes_noise)
+		playsound(get_turf(src), soundeffect, soundpitch, 1)
+
 	set_opacity(0)
 	door_animate("opening")
 	sleep(animation_delay)
@@ -251,6 +255,9 @@ var/list/all_doors = list()
 	operating = 1
 
 	layer = closed_layer
+
+	if (makes_noise):
+		playsound(get_turf(src), soundeffect, soundpitch, 1)
 
 	density = 1
 	door_animate("closing")

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -256,7 +256,7 @@ var/list/all_doors = list()
 
 	layer = closed_layer
 
-	if (makes_noise):
+	if (makes_noise)
 		playsound(get_turf(src), soundeffect, soundpitch, 1)
 
 	density = 1

--- a/code/game/machinery/doors/unpowered.dm
+++ b/code/game/machinery/doors/unpowered.dm
@@ -33,6 +33,8 @@
 
 	explosion_block = 1
 
+	makes_noise = 1
+
 /obj/machinery/door/unpowered/shuttle/cultify()
 	new /obj/machinery/door/mineral/wood(loc)
 	..()

--- a/code/game/machinery/doors/unpowered.dm
+++ b/code/game/machinery/doors/unpowered.dm
@@ -33,66 +33,6 @@
 
 	explosion_block = 1
 
-	soundeffect = 'sound/machines/airlock.ogg'
-	var/pitch = 30
-
-// copy pasted from /obj/machinery/door and added playsound() in the middle
-/obj/machinery/door/unpowered/shuttle/open(var/forced=0)
-	if(!density)
-		return 1
-	if(operating > 0)
-		return
-	if(!ticker)
-		return 0
-	if(!operating)
-		operating = 1
-
-	set_opacity(0)
-	playsound(get_turf(src), soundeffect, pitch, 1)
-	door_animate("opening")
-	sleep(animation_delay)
-	layer = open_layer
-	density = 0
-	explosion_resistance = 0
-	update_icon()
-	set_opacity(0)
-	update_nearby_tiles()
-	//update_freelook_sight()
-
-	if(operating == 1)
-		operating = 0
-
-	return 1
-
-// copy pasted from /obj/machinery/door and added playsound() in the middle
-/obj/machinery/door/unpowered/shuttle/close(var/forced=0)
-	if (density || operating || jammed)
-		return
-	operating = 1
-
-	layer = closed_layer
-
-	density = 1
-	playsound(get_turf(src), soundeffect, pitch, 1)
-	door_animate("closing")
-	sleep(animation_delay)
-	update_icon()
-
-	if (!glass)
-		src.set_opacity(1)
-
-		var/obj/effect/beam/B = locate() in loc
-		if(B)
-			qdel(B)
-
-	// TODO: rework how fire works on doors
-	var/obj/fire/F = locate() in loc
-	if(F)
-		qdel(F)
-
-	update_nearby_tiles()
-	operating = 0
-
 /obj/machinery/door/unpowered/shuttle/cultify()
 	new /obj/machinery/door/mineral/wood(loc)
 	..()

--- a/code/game/machinery/doors/unpowered.dm
+++ b/code/game/machinery/doors/unpowered.dm
@@ -33,6 +33,66 @@
 
 	explosion_block = 1
 
+	soundeffect = 'sound/machines/airlock.ogg'
+	var/pitch = 30
+
+// copy pasted from /obj/machinery/door and added playsound() in the middle
+/obj/machinery/door/unpowered/shuttle/open(var/forced=0)
+	if(!density)
+		return 1
+	if(operating > 0)
+		return
+	if(!ticker)
+		return 0
+	if(!operating)
+		operating = 1
+
+	set_opacity(0)
+	playsound(get_turf(src), soundeffect, pitch, 1)
+	door_animate("opening")
+	sleep(animation_delay)
+	layer = open_layer
+	density = 0
+	explosion_resistance = 0
+	update_icon()
+	set_opacity(0)
+	update_nearby_tiles()
+	//update_freelook_sight()
+
+	if(operating == 1)
+		operating = 0
+
+	return 1
+
+// copy pasted from /obj/machinery/door and added playsound() in the middle
+/obj/machinery/door/unpowered/shuttle/close(var/forced=0)
+	if (density || operating || jammed)
+		return
+	operating = 1
+
+	layer = closed_layer
+
+	density = 1
+	playsound(get_turf(src), soundeffect, pitch, 1)
+	door_animate("closing")
+	sleep(animation_delay)
+	update_icon()
+
+	if (!glass)
+		src.set_opacity(1)
+
+		var/obj/effect/beam/B = locate() in loc
+		if(B)
+			qdel(B)
+
+	// TODO: rework how fire works on doors
+	var/obj/fire/F = locate() in loc
+	if(F)
+		qdel(F)
+
+	update_nearby_tiles()
+	operating = 0
+
 /obj/machinery/door/unpowered/shuttle/cultify()
 	new /obj/machinery/door/mineral/wood(loc)
 	..()


### PR DESCRIPTION
Because it bothers me that those are completely silent.

The way I did it is copypasting the open() and close() code from the parent and placing a playsound() in the middle. It sounds wrong, so please do tell if it should be done some other way.

:cl:
 * rscadd: Shuttle airlocks now make sounds when they open and close

