### PR TITLE
Tweaks biogenerator's cardboard, gift wrap, package wrap, paper bin prices and quantities

### DIFF
--- a/code/game/machinery/biogenerator.dm
+++ b/code/game/machinery/biogenerator.dm
@@ -180,14 +180,14 @@
 	result=/obj/item/stack/sheet/cardboard
 
 /datum/biogen_recipe/paper/giftwrap
-	cost=75
+	cost=25
 	id="giftwrap"
 	name="Gift Wrap"
 	other_amounts=list(5,10)
 	result=/obj/item/stack/package_wrap/gift
 
 /datum/biogen_recipe/paper/packagewrap
-	cost=100
+	cost=30
 	id="packagewrap"
 	name="Package Wrap"
 	other_amounts=list(5,10)

--- a/code/game/machinery/biogenerator.dm
+++ b/code/game/machinery/biogenerator.dm
@@ -173,26 +173,28 @@
 	result=/obj/item/weapon/clipboard
 
 /datum/biogen_recipe/paper/cardboard
-	cost=100
+	cost=25
 	id="cardboard"
 	name="Cardboard Sheet"
-	other_amounts=list(5,10)
+	other_amounts=list(5,10,50)
 	result=/obj/item/stack/sheet/cardboard
 
 /datum/biogen_recipe/paper/giftwrap
-	cost=300
+	cost=75
 	id="giftwrap"
 	name="Gift Wrap"
+	other_amounts=list(5,10)
 	result=/obj/item/stack/package_wrap/gift
 
 /datum/biogen_recipe/paper/packagewrap
-	cost=350
+	cost=100
 	id="packagewrap"
 	name="Package Wrap"
+	other_amounts=list(5,10)
 	result=/obj/item/stack/package_wrap
 
 /datum/biogen_recipe/paper/paperbin
-	cost=550 //100 from the cardboard, 30*15=450 from the paper
+	cost=475 //25 from the cardboard, 30*15=450 from the paper
 	id="paperbin"
 	name="Paper Bin (30 sheets)"
 	result=/obj/item/weapon/paper_bin


### PR DESCRIPTION
Cardboard and package wrap are too expensive, especially for vox traders. This lowers the prices to reasonable not-theorycrafting-I-actually-play-botanist-and-trader-these-are-what-they-should-be amounts.

Before:
- Cardboard is 100 per sheet. You make one (1) empty box from two full chickenshroom harvests if you're a trader or two harvests of most human plants. This is a laughably high amount of effort. Easier to just get evidence boxes from the securivend and flatten them.
- Package wrap is 350 per one (1) single sheet of package wrap. It takes three (3) sheets of package wrap to wrap a single crate. That's 1050 biobucks per crate wrapped. A chickenshroom harvest is 3 * 2 * 9 biobucks. You'd need to harvest 20 chickenshrooms to wrap one crate. Also, you have to print these three package wraps individually, and they sure love to take their time to come out. Even if you MAXIMUM powergame (120 potency pumpkins with grasserelle dev), you need two full harvests to wrap one crate. That's insane effort, it's much easier to just ask for or steal it from another department.

After:
- Cardboard is 25 per sheet. Can now make 50 at a time in the biogenerator.
- Gift wrap is 25 per sheet. Can now make 5 and 10 at a time in the biogenerator.
- Package wrap is 30 per sheet. Can now make 5 and 10 at a time in the biogenerator.
- Paper bin is 475 instead of 550 to coincide with decrease in cardboard price.

Closes https://github.com/d3athrow/vgstation13/issues/13621

:cl:
 * tweak: Cardboard, gift wrap, package wrap, and paper bin prices in the biogenerator have been reduced significantly, and you can now print larger amounts of them at a time.