### PR TITLE
Tweak cargo crate names

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -42,7 +42,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/device/toner)
 	cost = 10
 	containertype = /obj/structure/closet/crate
-	containername = "\improper toner cartridges crate"
+	containername = "toner cartridges crate"
 	group = "Supplies"
 
 /datum/supply_packs/labels
@@ -52,7 +52,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/storage/box/labels) //so this might be a bit excessive.
 	cost = 10
 	containertype = /obj/structure/closet/crate
-	containername = "\improper label rolls crate"
+	containername = "label rolls crate"
 	group = "Supplies"
 
 /datum/supply_packs/internals
@@ -65,7 +65,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/tank/air)
 	cost = 10
 	containertype = /obj/structure/closet/crate/internals
-	containername = "\improper internals crate"
+	containername = "internals crate"
 	group = "Supplies"
 
 /datum/supply_packs/evacuation
@@ -90,7 +90,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/machinery/bot/medbot)
 	cost = 40
 	containertype = /obj/structure/closet/crate/internals
-	containername = "\improper emergency crate"
+	containername = "emergency crate"
 	group = "Supplies"
 
 /datum/supply_packs/janitor
@@ -111,7 +111,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/structure/mopbucket)
 	cost = 10
 	containertype = /obj/structure/closet/crate
-	containername = "\improper janitorial supplies crate"
+	containername = "janitorial supplies crate"
 	group = "Supplies"
 
 /datum/supply_packs/lightbulbs
@@ -121,7 +121,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/storage/box/lights/mixed)
 	cost = 10
 	containertype = /obj/structure/closet/crate
-	containername = "\improper replacement lights crate"
+	containername = "replacement lights crate"
 	group = "Supplies"
 
 /datum/supply_packs/helightbulbs
@@ -130,7 +130,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/storage/box/lights/he)
 	cost = 20
 	containertype = /obj/structure/closet/crate
-	containername = "\improper high efficiency lights crate"
+	containername = "high efficiency lights crate"
 	group = "Supplies"
 
 /datum/supply_packs/newscaster
@@ -140,7 +140,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/mounted/frame/newscaster)
 	cost = 10
 	containertype = /obj/structure/closet/crate
-	containername = "\improper newscaster crate"
+	containername = "newscaster crate"
 	group = "Supplies"
 
 /datum/supply_packs/mule
@@ -156,7 +156,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	contains = list()
 	cost = 10
 	containertype = /obj/structure/largecrate/porcelain
-	containername = "\improper porcelain crate"
+	containername = "porcelain crate"
 	group = "Supplies"
 
 /datum/supply_packs/showers
@@ -164,7 +164,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	contains = list()
 	cost = 10
 	containertype = /obj/structure/largecrate/showers
-	containername = "\improper showers crate"
+	containername = "showers crate"
 	group = "Supplies"
 
 /datum/supply_packs/metal50
@@ -173,7 +173,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	amount = 50
 	cost = 10
 	containertype = /obj/structure/closet/crate/engi
-	containername = "\improper metal sheets crate"
+	containername = "metal sheets crate"
 	group = "Supplies"
 
 /datum/supply_packs/glass50
@@ -182,7 +182,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	amount = 50
 	cost = 10
 	containertype = /obj/structure/closet/crate/engi
-	containername = "\improper glass sheets crate"
+	containername = "glass sheets crate"
 	group = "Supplies"
 
 /datum/supply_packs/wood25
@@ -191,7 +191,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	amount = 25
 	cost = 12
 	containertype = /obj/structure/closet/crate/engi
-	containername = "\improper wooden planks crate"
+	containername = "wooden planks crate"
 	group = "Supplies"
 
 /datum/supply_packs/carpet
@@ -200,7 +200,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	amount = 30
 	cost = 15
 	containertype = /obj/structure/closet/crate
-	containername = "\improper carpet crate"
+	containername = "carpet crate"
 	group = "Supplies"
 
 /datum/supply_packs/arcade
@@ -209,7 +209,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	amount = 30
 	cost = 15
 	containertype = /obj/structure/closet/crate
-	containername = "\improper arcade tiles crate"
+	containername = "arcade tiles crate"
 	group = "Supplies"
 
 /datum/supply_packs/grass
@@ -218,7 +218,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	amount = 30
 	cost = 15
 	containertype = /obj/structure/closet/crate
-	containername = "\improper grass crate"
+	containername = "grass crate"
 	group = "Supplies"
 
 /datum/supply_packs/watertank
@@ -226,7 +226,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	contains = list(/obj/structure/reagent_dispensers/watertank)
 	cost = 8
 	containertype = /obj/structure/largecrate
-	containername = "\improper water tank crate"
+	containername = "water tank crate"
 	group = "Supplies"
 
 /datum/supply_packs/fueltank
@@ -234,7 +234,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	contains = list(/obj/structure/reagent_dispensers/fueltank)
 	cost = 8
 	containertype = /obj/structure/largecrate
-	containername = "\improper fuel tank crate"
+	containername = "fuel tank crate"
 	group = "Supplies"
 
 /datum/supply_packs/silicatetank
@@ -242,7 +242,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	contains = list(/obj/structure/reagent_dispensers/silicate)
 	cost = 8
 	containertype = /obj/structure/largecrate
-	containername = "\improper silicate tank crate"
+	containername = "silicate tank crate"
 	group = "Supplies"
 
 /datum/supply_packs/mining
@@ -261,7 +261,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/storage/bag/money)
 	cost = 20
 	containertype = /obj/structure/closet/crate
-	containername = "\improper mining equipment crate"
+	containername = "mining equipment crate"
 	access = access_mining
 	group = "Supplies"
 
@@ -287,7 +287,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	/obj/item/stack/package_wrap/gift)
 	cost = 10
 	containertype = "/obj/structure/closet/crate"
-	containername = "\improper arts and crafts crate"
+	containername = "\improper Arts and Crafts crate"
 	group = "Supplies"
 
 /datum/supply_packs/marbleblock
@@ -295,7 +295,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	contains = list(/obj/structure/block)
 	cost = 50
 	containertype = /obj/structure/largecrate
-	containername = "\improper marble block crate"
+	containername = "marble block crate"
 	group = "Supplies"
 
 /datum/supply_packs/randomised/contraband
@@ -309,7 +309,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	name = "Contraband crate"
 	cost = 30
 	containertype = /obj/structure/closet/crate
-	containername = "\improper unlabeled crate"
+	containername = "unlabeled crate"
 	contraband = 1
 	group = "Supplies"
 
@@ -327,7 +327,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	/obj/item/weapon/storage/box)
 	cost = 10
 	containertype = "/obj/structure/closet/crate"
-	containername = "\improper empty box crate"
+	containername = "empty box crate"
 	group = "Supplies"
 
 /datum/supply_packs/eftpos
@@ -343,7 +343,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	contains = list(/obj/machinery/floodlight)
 	cost = 10
 	containertype = /obj/structure/largecrate
-	containername = "\improper emergency floodlight crate"
+	containername = "emergency floodlight crate"
 	group = "Supplies"
 
 //////CLOTHING//////
@@ -365,7 +365,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/hair_dye)
 	cost = 10
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper standard costumes crate"
+	containername = "standard costumes crate"
 	access = access_theatre
 	group = "Clothing"
 
@@ -377,7 +377,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/clothing/head/snake)
 	cost = 31
 	containertype = /obj/structure/closet/crate
-	containername = "\improper halloween costumes crate"
+	containername = "halloween costumes crate"
 	group = "Clothing"
 
 /datum/supply_packs/wizard
@@ -388,7 +388,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/clothing/head/wizard/fake)
 	cost = 20
 	containertype = /obj/structure/closet/crate
-	containername = "\improper wizard costume crate"
+	containername = "wizard costume crate"
 	group = "Clothing"
 
 /datum/supply_packs/randomised
@@ -416,7 +416,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	name = "Collectable hats!"
 	cost = 200
 	containertype = /obj/structure/closet/crate
-	containername = "\improper collectable hat crate"
+	containername = "collectable hat crate"
 	group = "Clothing"
 
 /datum/supply_packs/randomised/New()
@@ -426,7 +426,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 /datum/supply_packs/randomised/cheap_hats
 	name = "Cheap hats"
 	cost = 50
-	containername = "\improper dusty crate"
+	containername = "dusty crate"
 	num_contained = 5
 	contains = list(\
 	/obj/item/clothing/head/bandana,
@@ -463,7 +463,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 /datum/supply_packs/randomised/cheap_glasses
 	name = "Cheap glasses"
 	cost = 50
-	containername = "\improper dusty crate"
+	containername = "dusty crate"
 	num_contained = 5
 	contains = list(\
 	/obj/item/clothing/glasses/eyepatch,
@@ -497,7 +497,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	name = "Formalwear closet"
 	cost = 30
 	containertype = /obj/structure/closet
-	containername = "\improper formalwear crate"
+	containername = "formalwear crate"
 	group = "Clothing"
 
 /datum/supply_packs/formal_wear/armored
@@ -508,7 +508,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	name = "Armored formalwear closet"
 	cost = 100
 	containertype = /obj/structure/closet
-	containername = "\improper armored formalwear crate"
+	containername = "armored formalwear crate"
 	contraband = 1
 	group = "Clothing"
 
@@ -531,7 +531,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/lipstick/random)
 	cost = 30
 	containertype = /obj/structure/closet/crate
-	containername = "\improper feminine formalwear crate"
+	containername = "feminine formalwear crate"
 	group = "Clothing"
 
 /datum/supply_packs/knight //why seperate them
@@ -546,7 +546,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/clothing/head/helmet/knight/blue)
 	cost = 35
 	containertype = /obj/structure/closet/crate
-	containername = "\improper knight armor crate"
+	containername = "knight armor crate"
 	group = "Clothing"
 
 /datum/supply_packs/vox_supply
@@ -557,7 +557,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/clothing/mask/breath/vox)
 	cost = 100
 	containertype = /obj/structure/closet/crate
-	containername = "\improper vox supplies crate"
+	containername = "vox supplies crate"
 	group = "Clothing"
 
 /datum/supply_packs/plasmaman_supply
@@ -568,7 +568,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/clothing/mask/breath)
 	cost = 100
 	containertype = /obj/structure/closet/crate
-	containername = "\improper plasmaman supplies crate"
+	containername = "plasmaman supplies crate"
 	group = "Clothing"
 
 /datum/supply_packs/grey_supply
@@ -579,7 +579,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/clothing/mask/breath)
 	cost = 100
 	containertype = /obj/structure/closet/crate
-	containername = "\improper grey Space-Ex crate"
+	containername = "grey Space-Ex crate"
 	group = "Clothing"
 
 /datum/supply_packs/neorussian
@@ -594,7 +594,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/clothing/shoes/jackboots/neorussian)
 	cost = 225
 	containertype = /obj/structure/closet/crate
-	containername = "\improper neo-Russian crate"
+	containername = "neo-Russian crate"
 	group = "Clothing"
 	contraband = 1
 
@@ -608,7 +608,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/clothing/suit/russofurcoat)
 	cost = 50
 	containertype = /obj/structure/closet/crate
-	containername = "\improper russian clothing crate"
+	containername = "russian clothing crate"
 	group = "Clothing"
 	contraband = 1
 //////SECURITY//////
@@ -623,7 +623,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/ammo_storage/magazine/c45)
 	cost = 20
 	containertype = /obj/structure/closet/crate
-	containername = "\improper special ops crate"
+	containername = "special ops crate"
 	group = "Security"
 	hidden = 1
 
@@ -644,7 +644,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/gun/energy/laser/LaserAK)
 	cost = 150
 	containertype = /obj/structure/closet/crate
-	containername = "\improper russian weapons crate"
+	containername = "russian weapons crate"
 	group = "Security"
 	hidden = 1
 
@@ -653,7 +653,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	contains = list(/obj/structure/bed/chair/vehicle/secway)
 	cost = 500
 	containertype = /obj/structure/closet/crate/secure/large
-	containername = "\improper secway crate"
+	containername = "secway crate"
 	access = access_security
 	group = "Security"
 
@@ -671,7 +671,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/ammo_casing/shotgun/beanbag)
 	cost = 10
 	containertype = /obj/structure/closet/crate
-	containername = "\improper beanbag shells crate"
+	containername = "beanbag shells crate"
 	group = "Security"
 
 /datum/supply_packs/weapons
@@ -687,7 +687,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/storage/box/bolas)
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure/weapon
-	containername = "\improper weapons crate"
+	containername = "weapons crate"
 	access = access_security
 	group = "Security"
 
@@ -699,7 +699,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/gun/energy/laser/smart)
 	cost = 60
 	containertype = /obj/structure/closet/crate/secure/weapon
-	containername = "\improper smart laser guns crate"
+	containername = "smart laser guns crate"
 	access = access_armory
 	group = "Security"
 
@@ -714,7 +714,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/grenade/chem_grenade/incendiary)
 	cost = 25
 	containertype = /obj/structure/closet/crate/secure/weapon
-	containername = "\improper incendiary weapons crate"
+	containername = "incendiary weapons crate"
 	access = access_heads
 	group = "Security"
 
@@ -726,7 +726,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/clothing/suit/armor/vest)
 	cost = 15
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper armor crate"
+	containername = "armor crate"
 	access = access_security
 	group = "Security"
 
@@ -754,7 +754,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/storage/box/bolas)
 	cost = 60
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper riot gear crate"
+	containername = "riot gear crate"
 	access = access_armory
 	group = "Security"
 
@@ -763,7 +763,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	contains = list (/obj/item/weapon/storage/lockbox/loyalty)
 	cost = 60
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper loyalty implant crate"
+	containername = "loyalty implant crate"
 	access = access_armory
 	group = "Security"
 
@@ -772,7 +772,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	contains = list (/obj/item/weapon/storage/lockbox/tracking)
 	cost = 50
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper tracking implant crate"
+	containername = "tracking implant crate"
 	access = access_armory
 	group = "Security"
 
@@ -781,7 +781,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	contains = list (/obj/item/weapon/storage/lockbox/chem)
 	cost = 50
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper chemical implant crate"
+	containername = "chemical implant crate"
 	access = access_armory
 	group = "Security"
 
@@ -793,7 +793,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/gun/projectile/shotgun/pump/combat)
 	cost = 50
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper ballistic gear crate"
+	containername = "ballistic gear crate"
 	access = access_armory
 	group = "Security"
 
@@ -806,7 +806,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/storage/box/dartshells)
 	cost = 20
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper shotgun shells crate"
+	containername = "shotgun shells crate"
 	access = access_armory
 	group = "Security"
 
@@ -818,7 +818,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/gun/energy/gun)
 	cost = 50
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper experimental energy gear crate"
+	containername = "experimental energy gear crate"
 	access = access_armory
 	group = "Security"
 
@@ -830,7 +830,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/clothing/suit/armor/riot)
 	cost = 35
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper experimental armor crate"
+	containername = "experimental armor crate"
 	access = access_armory
 	group = "Security"
 
@@ -843,7 +843,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/machinery/detector)
 	cost = 10
 	containertype = /obj/structure/closet/crate/secure/gear
-	containername = "\improper security checkpoint crate"
+	containername = "security checkpoint crate"
 	group = "Security"
 
 /datum/supply_packs/fourtyfive
@@ -852,7 +852,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/gun/projectile/sec)
 	cost = 200
 	containertype = /obj/structure/closet/crate/secure/weapon
-	containername = "\improper .45 pistols crate"
+	containername = ".45 pistols crate"
 	access = access_armory
 	group = "Security"
 
@@ -864,7 +864,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/ammo_storage/magazine/c45)
 	cost = 50
 	containertype = /obj/structure/closet/crate/secure/gear
-	containername = "\improper .45 pistol lethal ammo crate"
+	containername = ".45 pistol lethal ammo crate"
 	access = access_armory
 	group = "Security"
 
@@ -876,7 +876,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/ammo_storage/magazine/c45/practice)
 	cost = 10
 	containertype = /obj/structure/closet/crate/secure/gear
-	containername = "\improper .45 pistol practice ammo crate"
+	containername = ".45 pistol practice ammo crate"
 	access = access_security
 	group = "Security"
 
@@ -888,7 +888,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/ammo_storage/magazine/c45/rubber)
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure/gear
-	containername = "\improper .45 pistol rubber ammo crate"
+	containername = ".45 pistol rubber ammo crate"
 	access = access_security
 	group = "Security"
 
@@ -905,7 +905,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/storage/fancy/egg_box)
 	cost = 10
 	containertype = /obj/structure/closet/crate/freezer
-	containername = "\improper basic cooking crate"
+	containername = "basic cooking crate"
 	group = "Hospitality"
 
 /datum/supply_packs/randomised/fruit
@@ -924,7 +924,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/reagent_containers/food/snacks/grown/orange)
 	cost = 20
 	containertype = /obj/structure/closet/crate/freezer
-	containername = "\improper fruit crate"
+	containername = "fruit crate"
 	group = "Hospitality"
 
 /datum/supply_packs/exotic_garnishes //We don't use a randomised crate because we want some special reagents, and also to control chances
@@ -937,7 +937,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/reagent_containers/food/condiment/exotic)
 	cost = 15
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper exotic garnishes crate"
+	containername = "exotic garnishes crate"
 	access = access_kitchen
 	group = "Hospitality"
 
@@ -957,7 +957,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/reagent_containers/food/snacks/meat/crabmeat)
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper trophy meats crate"
+	containername = "trophy meats crate"
 	access = access_kitchen
 	group = "Hospitality"
 
@@ -982,7 +982,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/storage/box/balloons)
 	cost = 20
 	containertype = /obj/structure/closet/crate
-	containername = "\improper party equipment crate"
+	containername = "party equipment crate"
 	group = "Hospitality"
 
 /datum/supply_packs/randomised/pizza
@@ -994,7 +994,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	name = "Surprise pack of five pizzas"
 	cost = 75
 	containertype = /obj/structure/closet/crate/freezer
-	containername = "\improper pizza crate"
+	containername = "pizza crate"
 	group = "Hospitality"
 
 /datum/supply_packs/cafe
@@ -1005,7 +1005,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	/obj/item/weapon/reagent_containers/glass/kettle/red)
 	cost = 20
 	containertype = /obj/structure/closet/crate
-	containername = "\improper cafe equipment crate"
+	containername = "cafe equipment crate"
 	group = "Hospitality"
 
 /datum/supply_packs/bar
@@ -1017,7 +1017,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	/obj/item/weapon/reagent_containers/food/drinks/shaker)
 	cost = 40
 	containertype = /obj/structure/closet/crate
-	containername = "\improper bartending equipment crate"
+	containername = "bartending equipment crate"
 	group = "Hospitality"
 
 /datum/supply_packs/festive
@@ -1041,7 +1041,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/clothing/under/wintercasualwear)
 	cost = 30
 	containertype = /obj/structure/closet/crate
-	containername = "\improper festive supplies crate"
+	containername = "festive supplies crate"
 	group = "Hospitality"
 
 /datum/supply_packs/randomised/instruments
@@ -1060,7 +1060,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	name = "Random instrument"
 	cost = 50
 	containertype = /obj/structure/closet/crate
-	containername = "\improper random instrument crate"
+	containername = "random instrument crate"
 	group = "Hospitality"
 
 /datum/supply_packs/bigband
@@ -1079,7 +1079,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	name = "Big band instrument collection"
 	cost = 500
 	containertype = /obj/structure/largecrate
-	containername = "\improper big band musical instruments crate"
+	containername = "big band musical instruments crate"
 	group = "Hospitality"
 
 //////ENGINEERING//////
@@ -1096,7 +1096,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/cell/high)
 	cost = 15
 	containertype = /obj/structure/closet/crate/engi
-	containername = "\improper electrical maintenance crate"
+	containername = "electrical maintenance crate"
 	group = "Engineering"
 
 /datum/supply_packs/mechanical
@@ -1112,7 +1112,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/clothing/head/hardhat)
 	cost = 10
 	containertype = /obj/structure/closet/crate/engi
-	containername = "\improper mechanical maintenance crate"
+	containername = "mechanical maintenance crate"
 	group = "Engineering"
 
 /datum/supply_packs/solar
@@ -1143,7 +1143,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/paper/solar)
 	cost = 20
 	containertype = /obj/structure/closet/crate/engi
-	containername = "\improper solar panels crate"
+	containername = "solar panels crate"
 	group = "Engineering"
 
 /datum/supply_packs/engine
@@ -1152,7 +1152,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/machinery/power/emitter)
 	cost = 10
 	containertype = /obj/structure/closet/crate/secure/engisec
-	containername = "\improper emitter crate"
+	containername = "emitter crate"
 	access = access_ce
 	group = "Engineering"
 
@@ -1161,7 +1161,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	contains = list(/obj/machinery/field_generator,
 					/obj/machinery/field_generator)
 	containertype = /obj/structure/closet/crate/secure/engisec
-	containername = "\improper field generator crate"
+	containername = "field generator crate"
 	access = access_ce
 	group = "Engineering"
 
@@ -1169,7 +1169,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	name = "Singularity generator"
 	contains = list(/obj/machinery/the_singularitygen)
 	containertype = /obj/structure/closet/crate/secure/engisec
-	containername = "\improper singularity generator crate"
+	containername = "singularity generator crate"
 	access = access_ce
 	group = "Engineering"
 
@@ -1178,7 +1178,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	contains = list(/obj/machinery/power/rad_collector,
 					/obj/machinery/power/rad_collector,
 					/obj/machinery/power/rad_collector)
-	containername = "\improper collector crate"
+	containername = "collector crate"
 	group = "Engineering"
 
 /datum/supply_packs/engine/PA
@@ -1192,7 +1192,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/structure/particle_accelerator/power_box,
 					/obj/structure/particle_accelerator/end_cap)
 	containertype = /obj/structure/closet/crate/secure/engisec
-	containername = "\improper particle accelerator crate"
+	containername = "particle accelerator crate"
 	access = access_ce
 	group = "Engineering"
 
@@ -1225,7 +1225,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/machinery/shieldwallgen)
 	cost = 20
 	containertype = /obj/structure/closet/crate/secure/engisec
-	containername = "\improper shield generators crate"
+	containername = "shield generators crate"
 	access = access_teleporter
 	group = "Engineering"
 
@@ -1234,7 +1234,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	contains = list(/obj/machinery/power/am_control_unit)
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure/engisec
-	containername = "\improper antimatter control unit crate"
+	containername = "antimatter control unit crate"
 	access = access_engine
 	group = "Engineering"
 
@@ -1254,7 +1254,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/device/am_shielding_container)
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure/engisec
-	containername = "\improper packaged antimatter reactor crate"
+	containername = "packaged antimatter reactor crate"
 	access = access_engine
 	group = "Engineering"
 
@@ -1265,7 +1265,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/am_containment)
 	cost = 15
 	containertype = /obj/structure/closet/crate/secure/engisec
-	containername = "\improper antimatter containment jar crate"
+	containername = "antimatter containment jar crate"
 	access = access_engine
 	group = "Engineering"
 
@@ -1319,7 +1319,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	name = "Exp. shield generator board"
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure/engisec
-	containername = "\improper experimental shield generator crate"
+	containername = "experimental shield generator crate"
 	group = "Engineering"
 	access = access_ce
 
@@ -1328,7 +1328,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	name = "Exp. shield capacitor board"
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure/engisec
-	containername = "\improper experimental shield capacitor crate"
+	containername = "experimental shield capacitor crate"
 	group = "Engineering"
 	access = access_ce
 
@@ -1337,7 +1337,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	name = "Mark I Thermoelectric generator"
 	cost = 75
 	containertype = /obj/structure/closet/crate/secure/large
-	containername = "\improper mk1 TEG crate"
+	containername = "mk1 TEG crate"
 	group = "Engineering"
 	access = access_engine
 
@@ -1346,7 +1346,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	name = "Binary atmospheric circulator"
 	cost = 60
 	containertype = /obj/structure/closet/crate/secure/large
-	containername = "\improper atmospheric circulator crate"
+	containername = "atmospheric circulator crate"
 	group = "Engineering"
 	access = access_engine
 
@@ -1355,7 +1355,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	name = "Supermatter shard"
 	cost = 500 //So cargo thinks thrice before killing themselves with it. You're going to need a department account most likely.
 	containertype = /obj/structure/closet/crate/secure/engisec
-	containername = "\improper supermatter shard crate"
+	containername = "supermatter shard crate"
 	group = "Engineering"
 	access = access_ce
 
@@ -1369,7 +1369,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	name = "Portable SMES parts"
 	cost = 70
 	containertype = /obj/structure/closet/crate/secure/engisec
-	containername = "\improper portable SMES crate"
+	containername = "portable SMES crate"
 	group = "Engineering"
 	access = access_engine
 
@@ -1398,7 +1398,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					 /obj/item/weapon/storage/box/inflatables)
 	cost = 15
 	containertype = /obj/structure/closet/crate/engi
-	containername = "\improper inflatable structures crate"
+	containername = "inflatable structures crate"
 	group = "Engineering"
 
 //////MEDICAL//////
@@ -1417,7 +1417,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/storage/box/autoinjectors)
 	cost = 10
 	containertype = /obj/structure/closet/crate/medical
-	containername = "\improper medical crate"
+	containername = "medical crate"
 	group = "Medical"
 
 /datum/supply_packs/virus
@@ -1440,7 +1440,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/virusdish/random)
 	cost = 25
 	containertype = "/obj/structure/closet/crate/secure"
-	containername = "\improper virus crate"
+	containername = "virus crate"
 	access = access_cmo
 	group = "Medical"
 
@@ -1459,7 +1459,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/circular_saw)
 	cost = 25
 	containertype = "/obj/structure/closet/crate/secure"
-	containername = "\improper surgery crate"
+	containername = "surgery crate"
 	access = access_medical
 	group = "Medical"
 
@@ -1471,7 +1471,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/storage/box/gloves)
 	cost = 15
 	containertype = "/obj/structure/closet/crate"
-	containername = "\improper sterile equipment crate"
+	containername = "sterile equipment crate"
 	group = "Medical"
 
 /datum/supply_packs/bloodbags
@@ -1485,7 +1485,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/reagent_containers/blood/empty)
 	cost = 10
 	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper bloodbag crate"
+	containername = "bloodbag crate"
 	access = access_medical
 	group = "Medical"
 
@@ -1494,7 +1494,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	contains = list(/obj/structure/bed/chair/vehicle/wheelchair)
 	cost = 40
 	containertype = /obj/structure/closet/crate/medical
-	containername = "\improper wheelchair crate"
+	containername = "wheelchair crate"
 	group = "Medical"
 
 /datum/supply_packs/wheelchair_motorized
@@ -1502,7 +1502,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	contains = list(/obj/structure/bed/chair/vehicle/wheelchair/motorized)
 	cost = 200
 	containertype = "/obj/structure/closet/crate/secure"
-	containername = "\improper motorized wheelchair crate"
+	containername = "motorized wheelchair crate"
 	access = access_cmo
 	group = "Medical"
 
@@ -1510,7 +1510,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	name = "Hanging skeleton model"
 	cost = 30
 	containertype = /obj/structure/largecrate/skele_stand
-	containername = "\improper hanging skeleton model crate"
+	containername = "hanging skeleton model crate"
 	group = "Medical"
 
 //////SCIENCE//////
@@ -1533,7 +1533,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/stock_parts/micro_laser)
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure/scisec
-	containername = "\improper research and development stock parts crate"
+	containername = "research and development stock parts crate"
 	access = access_science
 	group = "Science"
 
@@ -1545,7 +1545,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 		)
 	cost = 80
 	containertype = /obj/structure/closet/crate/secure/scisec
-	containername = "\improper research and development experimental crate"
+	containername = "research and development experimental crate"
 	access = access_science
 	group = "Science"
 
@@ -1563,7 +1563,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/cell/high)
 	cost = 10
 	containertype = /obj/structure/closet/crate/secure/scisec
-	containername = "\improper robotics assembly crate"
+	containername = "robotics assembly crate"
 	access = access_robotics
 	group = "Science"
 
@@ -1572,7 +1572,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	contains = list(/obj/machinery/suspension_gen)
 	cost = 50
 	containertype = /obj/structure/largecrate
-	containername = "\improper suspension field generator crate"
+	containername = "suspension field generator crate"
 	access = access_science
 	group = "Science"
 
@@ -1591,7 +1591,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 		)
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure/scisec
-	containername = "\improper excavation equipment crate"
+	containername = "excavation equipment crate"
 	access = access_science
 	group = "Science"
 
@@ -1611,7 +1611,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/device/assembly/timer)
 	cost = 10
 	containertype = /obj/structure/closet/crate/secure/plasma
-	containername = "\improper plasma assembly crate"
+	containername = "plasma assembly crate"
 	access = access_tox_storage
 	group = "Science"
 
@@ -1620,7 +1620,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	contains = list (/obj/item/weapon/reagent_containers/food/snacks/borer_egg)
 	cost = 100
 	containertype = /obj/structure/closet/crate/secure/scisec
-	containername = "\improper borer egg crate"
+	containername = "borer egg crate"
 	access = access_xenobiology
 	group = "Science"
 
@@ -1632,7 +1632,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	contains = list (/obj/item/weapon/storage/box/monkeycubes)
 	cost = 20
 	containertype = /obj/structure/closet/crate/freezer
-	containername = "\improper monkey crate"
+	containername = "monkey crate"
 	group = "Hydroponics"
 
 /datum/supply_packs/farwa
@@ -1640,7 +1640,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	contains = list (/obj/item/weapon/storage/box/monkeycubes/farwacubes)
 	cost = 30
 	containertype = /obj/structure/closet/crate/freezer
-	containername = "\improper farwa crate"
+	containername = "farwa crate"
 	group = "Hydroponics"
 
 /datum/supply_packs/skrell
@@ -1648,7 +1648,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	contains = list (/obj/item/weapon/storage/box/monkeycubes/neaeracubes)
 	cost = 30
 	containertype = /obj/structure/closet/crate/freezer
-	containername = "\improper neaera crate"
+	containername = "neaera crate"
 	group = "Hydroponics"
 
 /datum/supply_packs/stok
@@ -1656,7 +1656,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	contains = list (/obj/item/weapon/storage/box/monkeycubes/stokcubes)
 	cost = 30
 	containertype = /obj/structure/closet/crate/freezer
-	containername = "\improper stok crate"
+	containername = "stok crate"
 	group = "Hydroponics"
 
 /datum/supply_packs/vox
@@ -1664,7 +1664,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	contains = list(/obj/item/weapon/storage/fancy/egg_box/vox)
 	cost = 30
 	containertype = /obj/structure/closet/crate/freezer
-	containername = "\improper green egg crate"
+	containername = "green egg crate"
 	group = "Hydroponics"
 
 /* Defined below
@@ -1673,7 +1673,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	contains = list()
 	cost = 50
 	containertype = /obj/structure/largecrate/lisa
-	containername = "\improper Corgi Crate"
+	containername = "Corgi Crate"
 	group = "Hydroponics" */
 
 /datum/supply_packs/hydroponics // -- Skie
@@ -1691,7 +1691,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/storage/box/botanydisk) //Updated with flora disks
 	cost = 15
 	containertype = /obj/structure/closet/crate/hydroponics
-	containername = "\improper hydroponics crate"
+	containername = "hydroponics crate"
 	access = access_hydroponics
 	group = "Hydroponics"
 
@@ -1700,7 +1700,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	name = "Cow"
 	cost = 30
 	containertype = /obj/structure/largecrate/cow
-	containername = "\improper cow crate"
+	containername = "cow crate"
 	access = access_hydroponics
 	group = "Hydroponics"
 
@@ -1708,7 +1708,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	name = "Goat"
 	cost = 25
 	containertype = /obj/structure/largecrate/goat
-	containername = "\improper goat crate"
+	containername = "goat crate"
 	access = access_hydroponics
 	group = "Hydroponics"
 
@@ -1716,7 +1716,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	name = "Chicken"
 	cost = 20
 	containertype = /obj/structure/largecrate/chick
-	containername = "\improper chicken crate"
+	containername = "chicken crate"
 	access = access_hydroponics
 	group = "Hydroponics"
 
@@ -1725,7 +1725,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	contains = list()
 	cost = 50
 	containertype = /obj/structure/largecrate/lisa
-	containername = "\improper corgi Crate"
+	containername = "corgi Crate"
 	group = "Hydroponics"
 
 /datum/supply_packs/weedcontrol
@@ -1736,7 +1736,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/grenade/chem_grenade/antiweed)
 	cost = 20
 	containertype = /obj/structure/closet/crate/secure/hydrosec
-	containername = "\improper weed control crate"
+	containername = "weed control crate"
 	access = access_hydroponics
 	group = "Hydroponics"
 
@@ -1756,7 +1756,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/seeds/nofruitseed)
 	cost = 15
 	containertype = /obj/structure/closet/crate/secure/hydrosec
-	containername = "\improper exotic seeds crate"
+	containername = "exotic seeds crate"
 	access = access_hydroponics
 	group = "Hydroponics"
 
@@ -1777,7 +1777,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 		)
 	cost = 20
 	containertype = /obj/structure/closet/crate/secure/hydrosec
-	containername = "\improper beekeeping crate"
+	containername = "beekeeping crate"
 	access = access_hydroponics
 	group = "Hydroponics"
 
@@ -1796,7 +1796,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 		)
 	cost = 15
 	containertype = /obj/structure/closet/crate/hydroponics
-	containername = "\improper ranching crate"
+	containername = "ranching crate"
 	group = "Hydroponics"
 
 /datum/supply_packs/Hydroponics_Trays
@@ -1820,7 +1820,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/stock_parts/console_screen)
 	cost = 12
 	containertype = /obj/structure/closet/crate/secure/hydrosec
-	containername = "\improper hydroponic trays components crate"
+	containername = "hydroponic trays components crate"
 	access = access_hydroponics
 	group = "Hydroponics"
 
@@ -1866,7 +1866,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/structure/vendomatpack/security)
 	cost = 10
 	containertype = /obj/structure/stackopacks
-	containername = "\improper security stack of packs"
+	containername = "security stack of packs"
 	group = "Vending Machine packs"
 
 /datum/supply_packs/medbaymachines
@@ -1875,7 +1875,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/structure/vendomatpack/medical)
 	cost = 10
 	containertype = /obj/structure/stackopacks
-	containername = "\improper medical stack of packs"
+	containername = "medical stack of packs"
 	group = "Vending Machine packs"
 
 /datum/supply_packs/botanymachines
@@ -1884,7 +1884,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/structure/vendomatpack/hydroseeds)
 	cost = 10
 	containertype = /obj/structure/stackopacks
-	containername = "\improper hydroponics stack of packs"
+	containername = "hydroponics stack of packs"
 	group = "Vending Machine packs"
 
 /datum/supply_packs/toolsmachines
@@ -1905,7 +1905,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/structure/vendomatpack/shoedispenser)
 	cost = 15
 	containertype = /obj/structure/stackopacks
-	containername = "\improper clothing stack of packs"
+	containername = "clothing stack of packs"
 	group = "Vending Machine packs"
 
 /*
@@ -1917,7 +1917,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/structure/vendomatpack/sovietvend)
 	cost = 20
 	containertype = /obj/structure/stackopacks
-	containername = "\improper Old and Forgotten stack of packs"
+	containername = "Old and Forgotten stack of packs"
 	group = "Vending Machine packs"
 	hidden = 1
 */
@@ -1927,6 +1927,6 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	contains = list(/obj/structure/vendomatpack/magivend)
 	cost = 80
 	containertype = /obj/structure/stackopacks
-	containername = "\improper strange and bright stack of packs"
+	containername = "\improper Strange and Bright stack of packs"
 	group = "Vending Machine packs"
 	hidden = 1

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -33,7 +33,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 //////SUPPLIES//////
 
 /datum/supply_packs/toner
-	name = "Toner Cartridges"
+	name = "Toner cartridges"
 	contains = list(/obj/item/device/toner,
 					/obj/item/device/toner,
 					/obj/item/device/toner,
@@ -42,21 +42,21 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/device/toner)
 	cost = 10
 	containertype = /obj/structure/closet/crate
-	containername = "toner cartridges crate"
+	containername = "\improper toner cartridges crate"
 	group = "Supplies"
 
 /datum/supply_packs/labels
-	name = "Label Rolls"
+	name = "Label rolls"
 	contains = list(/obj/item/weapon/storage/box/labels,
 					/obj/item/weapon/storage/box/labels, //21 label rolls is enough to label Beepsky "SHITCURITRON" 375 times,
 					/obj/item/weapon/storage/box/labels) //so this might be a bit excessive.
 	cost = 10
 	containertype = /obj/structure/closet/crate
-	containername = "Label Rolls"
+	containername = "\improper label rolls crate"
 	group = "Supplies"
 
 /datum/supply_packs/internals
-	name = "Internals crate"
+	name = "Internals resupply"
 	contains = list(/obj/item/clothing/mask/gas,
 					/obj/item/clothing/mask/gas,
 					/obj/item/clothing/mask/gas,
@@ -65,7 +65,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/tank/air)
 	cost = 10
 	containertype = /obj/structure/closet/crate/internals
-	containername = "internals crate"
+	containername = "\improper internals crate"
 	group = "Supplies"
 
 /datum/supply_packs/evacuation
@@ -90,7 +90,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/machinery/bot/medbot)
 	cost = 40
 	containertype = /obj/structure/closet/crate/internals
-	containername = "emergency crate"
+	containername = "\improper emergency crate"
 	group = "Supplies"
 
 /datum/supply_packs/janitor
@@ -111,7 +111,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/structure/mopbucket)
 	cost = 10
 	containertype = /obj/structure/closet/crate
-	containername = "janitorial supplies crate"
+	containername = "\improper janitorial supplies crate"
 	group = "Supplies"
 
 /datum/supply_packs/lightbulbs
@@ -121,7 +121,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/storage/box/lights/mixed)
 	cost = 10
 	containertype = /obj/structure/closet/crate
-	containername = "replacement lights crate"
+	containername = "\improper replacement lights crate"
 	group = "Supplies"
 
 /datum/supply_packs/helightbulbs
@@ -130,21 +130,21 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/storage/box/lights/he)
 	cost = 20
 	containertype = /obj/structure/closet/crate
-	containername = "high efficiency lights"
+	containername = "\improper high efficiency lights crate"
 	group = "Supplies"
 
 /datum/supply_packs/newscaster
-	name = "Newscaster crate"
+	name = "Newscaster"
 	contains = list(/obj/item/mounted/frame/newscaster,
 					/obj/item/mounted/frame/newscaster,
 					/obj/item/mounted/frame/newscaster)
 	cost = 10
 	containertype = /obj/structure/closet/crate
-	containername = "newscaster crate"
+	containername = "\improper newscaster crate"
 	group = "Supplies"
 
 /datum/supply_packs/mule
-	name = "MULEbot Crate"
+	name = "MULEbot"
 	contains = list(/obj/machinery/bot/mulebot)
 	cost = 20
 	containertype = /obj/structure/largecrate/mule
@@ -152,101 +152,101 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	group = "Supplies"
 
 /datum/supply_packs/porcelain
-	name = "Porcelain Crate"
+	name = "Porcelain furniture"
 	contains = list()
 	cost = 10
 	containertype = /obj/structure/largecrate/porcelain
-	containername = "porcelain crate"
+	containername = "\improper porcelain crate"
 	group = "Supplies"
 
 /datum/supply_packs/showers
-	name = "Showers Crate"
+	name = "Showers"
 	contains = list()
 	cost = 10
 	containertype = /obj/structure/largecrate/showers
-	containername = "showers crate"
+	containername = "\improper showers crate"
 	group = "Supplies"
 
 /datum/supply_packs/metal50
-	name = "50 Metal Sheets"
+	name = "50 metal sheets"
 	contains = list(/obj/item/stack/sheet/metal)
 	amount = 50
 	cost = 10
 	containertype = /obj/structure/closet/crate/engi
-	containername = "metal sheets crate"
+	containername = "\improper metal sheets crate"
 	group = "Supplies"
 
 /datum/supply_packs/glass50
-	name = "50 Glass Sheets"
+	name = "50 glass sheets"
 	contains = list(/obj/item/stack/sheet/glass/glass)
 	amount = 50
 	cost = 10
 	containertype = /obj/structure/closet/crate/engi
-	containername = "glass sheets crate"
+	containername = "\improper glass sheets crate"
 	group = "Supplies"
 
 /datum/supply_packs/wood25
-	name = "25 Wooden Planks"
+	name = "25 wooden planks"
 	contains = list(/obj/item/stack/sheet/wood)
 	amount = 25
 	cost = 12
 	containertype = /obj/structure/closet/crate/engi
-	containername = "wooden planks crate"
+	containername = "\improper wooden planks crate"
 	group = "Supplies"
 
 /datum/supply_packs/carpet
-	name = "30 Carpet Tiles"
+	name = "30 carpet tiles"
 	contains = list(/obj/item/stack/tile/carpet)
 	amount = 30
 	cost = 15
 	containertype = /obj/structure/closet/crate
-	containername = "carpet crate"
+	containername = "\improper carpet crate"
 	group = "Supplies"
 
 /datum/supply_packs/arcade
-	name = "30 Arcade Tiles"
+	name = "30 arcade tiles"
 	contains = list(/obj/item/stack/tile/arcade)
 	amount = 30
 	cost = 15
 	containertype = /obj/structure/closet/crate
-	containername = "arcade tiles crate"
+	containername = "\improper arcade tiles crate"
 	group = "Supplies"
 
 /datum/supply_packs/grass
-	name = "30 Grass Tiles"
+	name = "30 grass tiles"
 	contains = list(/obj/item/stack/tile/grass)
 	amount = 30
 	cost = 15
 	containertype = /obj/structure/closet/crate
-	containername = "grass crate"
+	containername = "\improper grass crate"
 	group = "Supplies"
 
 /datum/supply_packs/watertank
-	name = "Water tank crate"
+	name = "Water tank"
 	contains = list(/obj/structure/reagent_dispensers/watertank)
 	cost = 8
 	containertype = /obj/structure/largecrate
-	containername = "water tank crate"
+	containername = "\improper water tank crate"
 	group = "Supplies"
 
 /datum/supply_packs/fueltank
-	name = "Fuel tank crate"
+	name = "Fuel tank"
 	contains = list(/obj/structure/reagent_dispensers/fueltank)
 	cost = 8
 	containertype = /obj/structure/largecrate
-	containername = "fuel tank crate"
+	containername = "\improper fuel tank crate"
 	group = "Supplies"
 
 /datum/supply_packs/silicatetank
-	name = "Silicate tank crate"
+	name = "Silicate tank"
 	contains = list(/obj/structure/reagent_dispensers/silicate)
 	cost = 8
 	containertype = /obj/structure/largecrate
-	containername = "silicate tank crate"
+	containername = "\improper silicate tank crate"
 	group = "Supplies"
 
 /datum/supply_packs/mining
-	name = "Mining Equipment"
+	name = "Mining equipment"
 	contains = list(/obj/item/weapon/pickaxe/drill,
 					/obj/item/weapon/pickaxe,
 					/obj/item/weapon/pickaxe,
@@ -261,7 +261,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/storage/bag/money)
 	cost = 20
 	containertype = /obj/structure/closet/crate
-	containername = "Mining Equipment Crate"
+	containername = "\improper mining equipment crate"
 	access = access_mining
 	group = "Supplies"
 
@@ -287,15 +287,15 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	/obj/item/stack/package_wrap/gift)
 	cost = 10
 	containertype = "/obj/structure/closet/crate"
-	containername = "arts and crafts crate"
+	containername = "\improper arts and crafts crate"
 	group = "Supplies"
 
 /datum/supply_packs/marbleblock
-	name = "Marble Block crate"
+	name = "Marble block"
 	contains = list(/obj/structure/block)
 	cost = 50
 	containertype = /obj/structure/largecrate
-	containername = "marble block crate"
+	containername = "\improper marble block crate"
 	group = "Supplies"
 
 /datum/supply_packs/randomised/contraband
@@ -309,12 +309,12 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	name = "Contraband crate"
 	cost = 30
 	containertype = /obj/structure/closet/crate
-	containername = "unlabeled crate"
+	containername = "\improper unlabeled crate"
 	contraband = 1
 	group = "Supplies"
 
 /datum/supply_packs/boxes
-	name = "Empty Box supplies"
+	name = "Empty box supply"
 	contains = list(/obj/item/weapon/storage/box,
 	/obj/item/weapon/storage/box,
 	/obj/item/weapon/storage/box,
@@ -327,7 +327,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	/obj/item/weapon/storage/box)
 	cost = 10
 	containertype = "/obj/structure/closet/crate"
-	containername = "empty box crate"
+	containername = "\improper empty box crate"
 	group = "Supplies"
 
 /datum/supply_packs/eftpos
@@ -339,17 +339,17 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	group = "Supplies"
 
 /datum/supply_packs/floodlight
-	name = "Emergency Floodlight crate"
+	name = "Emergency floodlight"
 	contains = list(/obj/machinery/floodlight)
 	cost = 10
 	containertype = /obj/structure/largecrate
-	containername = "emergency floodlight crate"
+	containername = "\improper emergency floodlight crate"
 	group = "Supplies"
 
 //////CLOTHING//////
 
 /datum/supply_packs/costume
-	name = "Standard Costume crate"
+	name = "Standard costumes"
 	contains = list(/obj/item/weapon/storage/backpack/clown,
 					/obj/item/clothing/shoes/clown_shoes,
 					/obj/item/clothing/mask/gas/clown_hat,
@@ -365,19 +365,19 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/hair_dye)
 	cost = 10
 	containertype = /obj/structure/closet/crate/secure
-	containername = "standard costumes"
+	containername = "\improper standard costumes crate"
 	access = access_theatre
 	group = "Clothing"
 
 /datum/supply_packs/spookycostume
-	name = "Halloween Costume crate"
+	name = "Halloween costumes"
 	contains = list(/obj/item/clothing/suit/space/plasmaman/moltar,
 					/obj/item/clothing/head/helmet/space/plasmaman/moltar,
 					/obj/item/clothing/under/skelevoxsuit,
 					/obj/item/clothing/head/snake)
 	cost = 31
 	containertype = /obj/structure/closet/crate
-	containername = "halloween costumes"
+	containername = "\improper halloween costumes crate"
 	group = "Clothing"
 
 /datum/supply_packs/wizard
@@ -388,7 +388,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/clothing/head/wizard/fake)
 	cost = 20
 	containertype = /obj/structure/closet/crate
-	containername = "wizard costume crate"
+	containername = "\improper wizard costume crate"
 	group = "Clothing"
 
 /datum/supply_packs/randomised
@@ -413,10 +413,10 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/clothing/head/collectable/slime,
 					/obj/item/clothing/head/collectable/xenom,
 					/obj/item/clothing/head/collectable/petehat)
-	name = "Collectable hat crate!"
+	name = "Collectable hats!"
 	cost = 200
 	containertype = /obj/structure/closet/crate
-	containername = "collectable hats crate"
+	containername = "\improper collectable hat crate"
 	group = "Clothing"
 
 /datum/supply_packs/randomised/New()
@@ -424,9 +424,9 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	..()
 
 /datum/supply_packs/randomised/cheap_hats
-	name = "Hat crate"
+	name = "Cheap hats"
 	cost = 50
-	containername = "dusty crate"
+	containername = "\improper dusty crate"
 	num_contained = 5
 	contains = list(\
 	/obj/item/clothing/head/bandana,
@@ -461,9 +461,9 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	)
 
 /datum/supply_packs/randomised/cheap_glasses
-	name = "Glasses crate"
+	name = "Cheap glasses"
 	cost = 50
-	containername = "dusty crate"
+	containername = "\improper dusty crate"
 	num_contained = 5
 	contains = list(\
 	/obj/item/clothing/glasses/eyepatch,
@@ -497,7 +497,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	name = "Formalwear closet"
 	cost = 30
 	containertype = /obj/structure/closet
-	containername = "formalwear crate"
+	containername = "\improper formalwear crate"
 	group = "Clothing"
 
 /datum/supply_packs/formal_wear/armored
@@ -508,7 +508,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	name = "Armored formalwear closet"
 	cost = 100
 	containertype = /obj/structure/closet
-	containername = "armored formalwear crate"
+	containername = "\improper armored formalwear crate"
 	contraband = 1
 	group = "Clothing"
 
@@ -531,11 +531,11 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/lipstick/random)
 	cost = 30
 	containertype = /obj/structure/closet/crate
-	containername = "feminine clothing crate"
+	containername = "\improper feminine formalwear crate"
 	group = "Clothing"
 
 /datum/supply_packs/knight //why seperate them
-	name = "Knight Armor Crate"
+	name = "Knight armors"
 	contains = list(/obj/item/clothing/suit/armor/knight,
 					/obj/item/clothing/suit/armor/knight/red,
 					/obj/item/clothing/suit/armor/knight/yellow,
@@ -546,44 +546,44 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/clothing/head/helmet/knight/blue)
 	cost = 35
 	containertype = /obj/structure/closet/crate
-	containername = "knight armor crate"
+	containername = "\improper knight armor crate"
 	group = "Clothing"
 
 /datum/supply_packs/vox_supply
-	name = "Vox Resupply Crate"
+	name = "Vox supplies"
 	contains = list(/obj/item/clothing/suit/space/vox/civ,
 					/obj/item/clothing/head/helmet/space/vox/civ,
 					/obj/item/weapon/tank/nitrogen,
 					/obj/item/clothing/mask/breath/vox)
 	cost = 100
 	containertype = /obj/structure/closet/crate
-	containername = "vox resupply crate"
+	containername = "\improper vox supplies crate"
 	group = "Clothing"
 
 /datum/supply_packs/plasmaman_supply
-	name = "Plasmaman Containment Crate"
+	name = "Plasmaman supplies"
 	contains = list(/obj/item/clothing/suit/space/plasmaman/assistant,
 					/obj/item/clothing/head/helmet/space/plasmaman/assistant,
 					/obj/item/weapon/tank/plasma/plasmaman,
 					/obj/item/clothing/mask/breath)
 	cost = 100
 	containertype = /obj/structure/closet/crate
-	containername = "plasmaman containment crate"
+	containername = "\improper plasmaman supplies crate"
 	group = "Clothing"
 
 /datum/supply_packs/grey_supply
-	name = "Grey Space-Ex Crate"
+	name = "Grey Space-Ex"
 	contains = list(/obj/item/clothing/suit/space/grey,
 					/obj/item/clothing/head/helmet/space/grey,
 					/obj/item/weapon/tank/oxygen/red,
 					/obj/item/clothing/mask/breath)
 	cost = 100
 	containertype = /obj/structure/closet/crate
-	containername = "grey Space-Ex crate"
+	containername = "\improper grey Space-Ex crate"
 	group = "Clothing"
 
 /datum/supply_packs/neorussian
-	name = "Neo-Russian Crate"
+	name = "Neo-Russian supplies"
 	contains = list(/obj/item/clothing/suit/armor/vest/neorussian,
 					/obj/item/clothing/mask/neorussian,
 					/obj/item/clothing/head/helmet/neorussian,
@@ -594,7 +594,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/clothing/shoes/jackboots/neorussian)
 	cost = 225
 	containertype = /obj/structure/closet/crate
-	containername = "neo-Russian crate"
+	containername = "\improper neo-Russian crate"
 	group = "Clothing"
 	contraband = 1
 
@@ -608,7 +608,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/clothing/suit/russofurcoat)
 	cost = 50
 	containertype = /obj/structure/closet/crate
-	containername = "russian clothing crate"
+	containername = "\improper russian clothing crate"
 	group = "Clothing"
 	contraband = 1
 //////SECURITY//////
@@ -623,7 +623,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/ammo_storage/magazine/c45)
 	cost = 20
 	containertype = /obj/structure/closet/crate
-	containername = "special ops crate"
+	containername = "\improper special ops crate"
 	group = "Security"
 	hidden = 1
 
@@ -642,19 +642,18 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/ammo_storage/box/b762x55,
 					/obj/item/weapon/gun/energy/laser/LaserAK,
 					/obj/item/weapon/gun/energy/laser/LaserAK)
-	name = "Rusian Weapons"
 	cost = 150
 	containertype = /obj/structure/closet/crate
-	containername = "russian weapons crate"
+	containername = "\improper russian weapons crate"
 	group = "Security"
 	hidden = 1
 
 /datum/supply_packs/secway
-	name = "Secway crate"
+	name = "Secway"
 	contains = list(/obj/structure/bed/chair/vehicle/secway)
 	cost = 500
 	containertype = /obj/structure/closet/crate/secure/large
-	containername = "secway crate"
+	containername = "\improper secway crate"
 	access = access_security
 	group = "Security"
 
@@ -672,11 +671,11 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/ammo_casing/shotgun/beanbag)
 	cost = 10
 	containertype = /obj/structure/closet/crate
-	containername = "beanbag shells crate"
+	containername = "\improper beanbag shells crate"
 	group = "Security"
 
 /datum/supply_packs/weapons
-	name = "Weapons crate"
+	name = "Weapons"
 	contains = list(/obj/item/weapon/melee/baton/loaded,
 					/obj/item/weapon/melee/baton/loaded,
 					/obj/item/weapon/gun/energy/laser,
@@ -688,24 +687,24 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/storage/box/bolas)
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure/weapon
-	containername = "weapons crate"
+	containername = "\improper weapons crate"
 	access = access_security
 	group = "Security"
 
 /datum/supply_packs/smartlaser
-	name = "Smart laser gun crate"
+	name = "Smart laser guns"
 	contains = list(/obj/item/weapon/gun/energy/laser/smart,
 					/obj/item/weapon/gun/energy/laser/smart,
 					/obj/item/weapon/gun/energy/laser/smart,
 					/obj/item/weapon/gun/energy/laser/smart)
 	cost = 60
 	containertype = /obj/structure/closet/crate/secure/weapon
-	containername = "smart laser gun crate"
+	containername = "\improper smart laser guns crate"
 	access = access_armory
 	group = "Security"
 
 /datum/supply_packs/eweapons
-	name = "Incendiary weapons crate"
+	name = "Incendiary weapons"
 	contains = list(/obj/item/weapon/gun/projectile/flamethrower/full,
 					/obj/item/weapon/tank/plasma,
 					/obj/item/weapon/tank/plasma,
@@ -715,24 +714,24 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/grenade/chem_grenade/incendiary)
 	cost = 25
 	containertype = /obj/structure/closet/crate/secure/weapon
-	containername = "incendiary weapons crate"
+	containername = "\improper incendiary weapons crate"
 	access = access_heads
 	group = "Security"
 
 /datum/supply_packs/armor
-	name = "Armor crate"
+	name = "Armor"
 	contains = list(/obj/item/clothing/head/helmet/tactical/sec,
 					/obj/item/clothing/head/helmet/tactical/sec,
 					/obj/item/clothing/suit/armor/vest,
 					/obj/item/clothing/suit/armor/vest)
 	cost = 15
 	containertype = /obj/structure/closet/crate/secure
-	containername = "armor crate"
+	containername = "\improper armor crate"
 	access = access_security
 	group = "Security"
 
 /datum/supply_packs/riot
-	name = "Riot gear crate"
+	name = "Riot gear"
 	contains = list(/obj/item/weapon/melee/baton/loaded,
 					/obj/item/weapon/melee/baton/loaded,
 					/obj/item/weapon/melee/baton/loaded,
@@ -755,46 +754,46 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/storage/box/bolas)
 	cost = 60
 	containertype = /obj/structure/closet/crate/secure
-	containername = "riot gear crate"
+	containername = "\improper riot gear crate"
 	access = access_armory
 	group = "Security"
 
 /datum/supply_packs/loyalty
-	name = "Loyalty implant crate"
+	name = "Loyalty implants"
 	contains = list (/obj/item/weapon/storage/lockbox/loyalty)
 	cost = 60
 	containertype = /obj/structure/closet/crate/secure
-	containername = "loyalty implant crate"
+	containername = "\improper loyalty implant crate"
 	access = access_armory
 	group = "Security"
 
 /datum/supply_packs/tracking
-	name = "Tracking implant crate"
+	name = "Tracking implants"
 	contains = list (/obj/item/weapon/storage/lockbox/tracking)
 	cost = 50
 	containertype = /obj/structure/closet/crate/secure
-	containername = "tracking implant crate"
+	containername = "\improper tracking implant crate"
 	access = access_armory
 	group = "Security"
 
 /datum/supply_packs/chem
-	name = "Chemical implant crate"
+	name = "Chemical implants"
 	contains = list (/obj/item/weapon/storage/lockbox/chem)
 	cost = 50
 	containertype = /obj/structure/closet/crate/secure
-	containername = "chemical implant crate"
+	containername = "\improper chemical implant crate"
 	access = access_armory
 	group = "Security"
 
 /datum/supply_packs/ballistic
-	name = "Ballistic gear crate"
+	name = "Ballistic gear"
 	contains = list(/obj/item/clothing/suit/armor/bulletproof,
 					/obj/item/clothing/suit/armor/bulletproof,
 					/obj/item/weapon/gun/projectile/shotgun/pump/combat,
 					/obj/item/weapon/gun/projectile/shotgun/pump/combat)
 	cost = 50
 	containertype = /obj/structure/closet/crate/secure
-	containername = "ballistic gear crate"
+	containername = "\improper ballistic gear crate"
 	access = access_armory
 	group = "Security"
 
@@ -807,36 +806,36 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/storage/box/dartshells)
 	cost = 20
 	containertype = /obj/structure/closet/crate/secure
-	containername = "shotgun shells crate"
+	containername = "\improper shotgun shells crate"
 	access = access_armory
 	group = "Security"
 
 /datum/supply_packs/expenergy
-	name = "Experimental energy gear crate"
+	name = "Experimental energy gear"
 	contains = list(/obj/item/clothing/suit/armor/laserproof,
 					/obj/item/clothing/suit/armor/laserproof,
 					/obj/item/weapon/gun/energy/gun,
 					/obj/item/weapon/gun/energy/gun)
 	cost = 50
 	containertype = /obj/structure/closet/crate/secure
-	containername = "experimental energy gear crate"
+	containername = "\improper experimental energy gear crate"
 	access = access_armory
 	group = "Security"
 
 /datum/supply_packs/exparmor
-	name = "Experimental armor crate"
+	name = "Experimental armor"
 	contains = list(/obj/item/clothing/suit/armor/laserproof,
 					/obj/item/clothing/suit/armor/bulletproof,
 					/obj/item/clothing/head/helmet/tactical/riot,
 					/obj/item/clothing/suit/armor/riot)
 	cost = 35
 	containertype = /obj/structure/closet/crate/secure
-	containername = "experimental armor crate"
+	containername = "\improper experimental armor crate"
 	access = access_armory
 	group = "Security"
 
 /datum/supply_packs/securitybarriers
-	name = "Security Checkpoint Equipment"
+	name = "Security checkpoint equipment"
 	contains = list(/obj/machinery/deployable/barrier,
 					/obj/machinery/deployable/barrier,
 					/obj/machinery/deployable/barrier,
@@ -844,21 +843,21 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/machinery/detector)
 	cost = 10
 	containertype = /obj/structure/closet/crate/secure/gear
-	containername = "security barriers crate"
+	containername = "\improper security checkpoint crate"
 	group = "Security"
 
 /datum/supply_packs/fourtyfive
-	name = "\improper .45 Security Pistol crate"
+	name = ".45 pistols"
 	contains = list(/obj/item/weapon/gun/projectile/sec,
 					/obj/item/weapon/gun/projectile/sec)
 	cost = 200
 	containertype = /obj/structure/closet/crate/secure/weapon
-	containername = ".45 pistols crate"
+	containername = "\improper .45 pistols crate"
 	access = access_armory
 	group = "Security"
 
 /datum/supply_packs/fourtyfive/lethals
-	name = ".45 Security Pistol Lethal Ammo crate"
+	name = ".45 pistol lethal ammo"
 	contains = list(/obj/item/ammo_storage/box/c45,
 					/obj/item/ammo_storage/magazine/c45/empty,
 					/obj/item/ammo_storage/magazine/c45/empty,
@@ -870,7 +869,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	group = "Security"
 
 /datum/supply_packs/fourtyfive/practice
-	name = ".45 Security Pistol Practice Ammo crate"
+	name = ".45 pistol practice ammo"
 	contains = list(/obj/item/ammo_storage/box/c45/practice,
 					/obj/item/ammo_storage/magazine/c45/practice/empty,
 					/obj/item/ammo_storage/magazine/c45/practice/empty,
@@ -882,7 +881,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	group = "Security"
 
 /datum/supply_packs/fourtyfive/rubber
-	name = ".45 Security Pistol Rubber Ammo crate"
+	name = ".45 pistol rubber ammo"
 	contains = list(/obj/item/ammo_storage/box/c45/rubber,
 					/obj/item/ammo_storage/magazine/c45/rubber/empty,
 					/obj/item/ammo_storage/magazine/c45/rubber/empty,
@@ -896,7 +895,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 //////HOSPITALITY//////
 
 /datum/supply_packs/food
-	name = "Basic cooking crate"
+	name = "Basic cooking supplies"
 	contains = list(/obj/item/weapon/reagent_containers/food/drinks/flour,
 					/obj/item/weapon/reagent_containers/food/drinks/flour,
 					/obj/item/weapon/reagent_containers/food/drinks/flour,
@@ -906,11 +905,11 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/storage/fancy/egg_box)
 	cost = 10
 	containertype = /obj/structure/closet/crate/freezer
-	containername = "basic cooking crate"
+	containername = "\improper basic cooking crate"
 	group = "Hospitality"
 
 /datum/supply_packs/randomised/fruit
-	name = "Fruit crate"
+	name = "Fresh fruit"
 	num_contained = 16
 	contains = list(/obj/item/weapon/reagent_containers/food/snacks/grown/tomato,
 					/obj/item/weapon/reagent_containers/food/snacks/grown/banana,
@@ -925,7 +924,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/reagent_containers/food/snacks/grown/orange)
 	cost = 20
 	containertype = /obj/structure/closet/crate/freezer
-	containername = "fruit crate"
+	containername = "\improper fruit crate"
 	group = "Hospitality"
 
 /datum/supply_packs/exotic_garnishes //We don't use a randomised crate because we want some special reagents, and also to control chances
@@ -938,7 +937,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/reagent_containers/food/condiment/exotic)
 	cost = 15
 	containertype = /obj/structure/closet/crate/secure
-	containername = "exotic garnishes crate"
+	containername = "\improper exotic garnishes crate"
 	access = access_kitchen
 	group = "Hospitality"
 
@@ -958,7 +957,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/reagent_containers/food/snacks/meat/crabmeat)
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure
-	containername = "trophy meats crate"
+	containername = "\improper trophy meats crate"
 	access = access_kitchen
 	group = "Hospitality"
 
@@ -983,7 +982,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/storage/box/balloons)
 	cost = 20
 	containertype = /obj/structure/closet/crate
-	containername = "party equipment crate"
+	containername = "\improper party equipment crate"
 	group = "Hospitality"
 
 /datum/supply_packs/randomised/pizza
@@ -995,7 +994,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	name = "Surprise pack of five pizzas"
 	cost = 75
 	containertype = /obj/structure/closet/crate/freezer
-	containername = "pizza crate"
+	containername = "\improper pizza crate"
 	group = "Hospitality"
 
 /datum/supply_packs/cafe
@@ -1006,11 +1005,11 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	/obj/item/weapon/reagent_containers/glass/kettle/red)
 	cost = 20
 	containertype = /obj/structure/closet/crate
-	containername = "cafe equipment crate"
+	containername = "\improper cafe equipment crate"
 	group = "Hospitality"
 
 /datum/supply_packs/bar
-	name = "Advanced Bartending equipment"
+	name = "Advanced bartending equipment"
 	contains = list(/obj/item/weapon/circuitboard/chem_dispenser/soda_dispenser,
 	/obj/item/weapon/circuitboard/chem_dispenser/booze_dispenser,
 	/obj/item/weapon/storage/box/drinkingglasses,
@@ -1018,7 +1017,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	/obj/item/weapon/reagent_containers/food/drinks/shaker)
 	cost = 40
 	containertype = /obj/structure/closet/crate
-	containername = "bartending equipment crate"
+	containername = "\improper bartending equipment crate"
 	group = "Hospitality"
 
 /datum/supply_packs/festive
@@ -1042,7 +1041,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/clothing/under/wintercasualwear)
 	cost = 30
 	containertype = /obj/structure/closet/crate
-	containername = "festivus supplies crate"
+	containername = "\improper festive supplies crate"
 	group = "Hospitality"
 
 /datum/supply_packs/randomised/instruments
@@ -1061,7 +1060,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	name = "Random instrument"
 	cost = 50
 	containertype = /obj/structure/closet/crate
-	containername = "random instruments crate"
+	containername = "\improper random instrument crate"
 	group = "Hospitality"
 
 /datum/supply_packs/bigband
@@ -1080,13 +1079,13 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	name = "Big band instrument collection"
 	cost = 500
 	containertype = /obj/structure/largecrate
-	containername = "big band musical instruments crate"
+	containername = "\improper big band musical instruments crate"
 	group = "Hospitality"
 
 //////ENGINEERING//////
 
 /datum/supply_packs/electrical
-	name = "Electrical maintenance crate"
+	name = "Electrical maintenance equipment"
 	contains = list(/obj/item/weapon/storage/toolbox/electrical,
 					/obj/item/weapon/storage/toolbox/electrical,
 					/obj/item/clothing/gloves/yellow,
@@ -1097,11 +1096,11 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/cell/high)
 	cost = 15
 	containertype = /obj/structure/closet/crate/engi
-	containername = "electrical maintenance crate"
+	containername = "\improper electrical maintenance crate"
 	group = "Engineering"
 
 /datum/supply_packs/mechanical
-	name = "Mechanical maintenance crate"
+	name = "Mechanical maintenance equipment"
 	contains = list(/obj/item/weapon/storage/belt/utility/full,
 					/obj/item/weapon/storage/belt/utility/full,
 					/obj/item/weapon/storage/belt/utility/full,
@@ -1113,11 +1112,11 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/clothing/head/hardhat)
 	cost = 10
 	containertype = /obj/structure/closet/crate/engi
-	containername = "mechanical maintenance crate"
+	containername = "\improper mechanical maintenance crate"
 	group = "Engineering"
 
 /datum/supply_packs/solar
-	name = "Solar Pack crate"
+	name = "Solar panels kit"
 	contains  = list(/obj/machinery/power/solar_assembly,
 					/obj/machinery/power/solar_assembly,
 					/obj/machinery/power/solar_assembly,
@@ -1144,46 +1143,46 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/paper/solar)
 	cost = 20
 	containertype = /obj/structure/closet/crate/engi
-	containername = "solar pack crate"
+	containername = "\improper solar panels crate"
 	group = "Engineering"
 
 /datum/supply_packs/engine
-	name = "Emitter crate"
+	name = "Emitters"
 	contains = list(/obj/machinery/power/emitter,
 					/obj/machinery/power/emitter)
 	cost = 10
 	containertype = /obj/structure/closet/crate/secure/engisec
-	containername = "emitter crate"
+	containername = "\improper emitter crate"
 	access = access_ce
 	group = "Engineering"
 
 /datum/supply_packs/engine/field_gen
-	name = "Field Generator crate"
+	name = "Field generators"
 	contains = list(/obj/machinery/field_generator,
 					/obj/machinery/field_generator)
 	containertype = /obj/structure/closet/crate/secure/engisec
-	containername = "field generator crate"
+	containername = "\improper field generator crate"
 	access = access_ce
 	group = "Engineering"
 
 /datum/supply_packs/engine/sing_gen
-	name = "Singularity Generator crate"
+	name = "Singularity generator"
 	contains = list(/obj/machinery/the_singularitygen)
 	containertype = /obj/structure/closet/crate/secure/engisec
-	containername = "singularity generator crate"
+	containername = "\improper singularity generator crate"
 	access = access_ce
 	group = "Engineering"
 
 /datum/supply_packs/engine/collector
-	name = "Collector crate"
+	name = "Radiation collectors"
 	contains = list(/obj/machinery/power/rad_collector,
 					/obj/machinery/power/rad_collector,
 					/obj/machinery/power/rad_collector)
-	containername = "collector crate"
+	containername = "\improper collector crate"
 	group = "Engineering"
 
 /datum/supply_packs/engine/PA
-	name = "Particle Accelerator crate"
+	name = "Particle accelerator parts"
 	cost = 40
 	contains = list(/obj/structure/particle_accelerator/fuel_chamber,
 					/obj/machinery/particle_accelerator/control_box,
@@ -1193,12 +1192,12 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/structure/particle_accelerator/power_box,
 					/obj/structure/particle_accelerator/end_cap)
 	containertype = /obj/structure/closet/crate/secure/engisec
-	containername = "particle accelerator crate"
+	containername = "\improper particle accelerator crate"
 	access = access_ce
 	group = "Engineering"
 
 /datum/supply_packs/mecha_ripley
-	name = "Circuit Crate (\"Ripley\" APLU)"
+	name = "\"Ripley\" APLU circuit board"
 	contains = list(/obj/item/weapon/book/manual/ripley_build_and_repair,
 					/obj/item/weapon/circuitboard/mecha/ripley/main, //TEMPORARY due to lack of circuitboard printer
 					/obj/item/weapon/circuitboard/mecha/ripley/peripherals) //TEMPORARY due to lack of circuitboard printer
@@ -1209,7 +1208,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	group = "Engineering"
 
 /datum/supply_packs/mecha_odysseus
-	name = "Circuit Crate (\"Odysseus\")"
+	name = "\"Odysseus\" circuit board"
 	contains = list(/obj/item/weapon/circuitboard/mecha/odysseus/peripherals, //TEMPORARY due to lack of circuitboard printer
 					/obj/item/weapon/circuitboard/mecha/odysseus/main) //TEMPORARY due to lack of circuitboard printer
 	cost = 25
@@ -1219,28 +1218,28 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	group = "Engineering"
 
 /datum/supply_packs/shieldgens
-	name = "Shield Generators"
+	name = "Shield generators"
 	contains = list(/obj/machinery/shieldwallgen,
 					/obj/machinery/shieldwallgen,
 					/obj/machinery/shieldwallgen,
 					/obj/machinery/shieldwallgen)
 	cost = 20
 	containertype = /obj/structure/closet/crate/secure/engisec
-	containername = "shield generators crate"
+	containername = "\improper shield generators crate"
 	access = access_teleporter
 	group = "Engineering"
 
 /datum/supply_packs/engine/amrcontrol
-	name = "Antimatter control unit crate"
+	name = "Antimatter control unit"
 	contains = list(/obj/machinery/power/am_control_unit)
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure/engisec
-	containername = "antimatter control unit crate"
+	containername = "\improper antimatter control unit crate"
 	access = access_engine
 	group = "Engineering"
 
 /datum/supply_packs/engine/amrparts
-	name = "AMR Parts crate"
+	name = "Antimatter reactor parts"
 	contains  = list(/obj/item/device/am_shielding_container,
 					/obj/item/device/am_shielding_container,
 					/obj/item/device/am_shielding_container,
@@ -1255,18 +1254,18 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/device/am_shielding_container)
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure/engisec
-	containername = "packaged antimatter reactor crate"
+	containername = "\improper packaged antimatter reactor crate"
 	access = access_engine
 	group = "Engineering"
 
 /datum/supply_packs/engine/amrcontainment
-	name = "Antimatter containment jar crate"
+	name = "Antimatter containment jars"
 	contains = list(/obj/item/weapon/am_containment,
 					/obj/item/weapon/am_containment,
 					/obj/item/weapon/am_containment)
 	cost = 15
 	containertype = /obj/structure/closet/crate/secure/engisec
-	containername = "antimatter containment jar crate"
+	containername = "\improper antimatter containment jar crate"
 	access = access_engine
 	group = "Engineering"
 
@@ -1290,7 +1289,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 
 /datum/supply_packs/rust_compressor
 	contains = list(/obj/item/weapon/module/rust_fuel_compressor)
-	name = "R-UST Mk. 7 fuel compressor circuitry"
+	name = "R-UST Mk. 7 fuel compressor board"
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure/engisec
 	containername = "\improper R-UST Mk. 7 fuel compressor circuitry crate"
@@ -1299,7 +1298,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 
 /datum/supply_packs/rust_assembly_port
 	contains = list(/obj/item/weapon/module/rust_fuel_port)
-	name = "R-UST Mk. 7 fuel assembly port circuitry"
+	name = "R-UST Mk. 7 fuel assembly port board"
 	cost = 20
 	containertype = /obj/structure/closet/crate/secure/engisec
 	containername = "\improper R-UST Mk. 7 fuel assembly port circuitry crate"
@@ -1308,7 +1307,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 
 /datum/supply_packs/rust_core
 	contains = list(/obj/machinery/power/rust_core)
-	name = "R-UST Mk. 7 Tokamak Core"
+	name = "R-UST Mk. 7 Tokamak core"
 	cost = 50
 	containertype = /obj/structure/closet/crate/secure/large
 	containername = "\improper R-UST Mk. 7 tokamak crate"
@@ -1317,28 +1316,28 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 
 /datum/supply_packs/shield_gen
 	contains = list(/obj/item/weapon/circuitboard/shield_gen)
-	name = "Experimental shield generator circuitry"
+	name = "Exp. shield generator board"
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure/engisec
-	containername = "experimental shield generator crate"
+	containername = "\improper experimental shield generator crate"
 	group = "Engineering"
 	access = access_ce
 
 /datum/supply_packs/shield_cap
 	contains = list(/obj/item/weapon/circuitboard/shield_cap)
-	name = "Experimental shield capacitor circuitry"
+	name = "Exp. shield capacitor board"
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure/engisec
-	containername = "experimental shield capacitor crate"
+	containername = "\improper experimental shield capacitor crate"
 	group = "Engineering"
 	access = access_ce
 
 /datum/supply_packs/teg
 	contains = list(/obj/machinery/power/generator)
-	name = "Mark I Thermoelectric Generator"
+	name = "Mark I Thermoelectric generator"
 	cost = 75
 	containertype = /obj/structure/closet/crate/secure/large
-	containername = "mk1 TEG crate"
+	containername = "\improper mk1 TEG crate"
 	group = "Engineering"
 	access = access_engine
 
@@ -1347,16 +1346,16 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	name = "Binary atmospheric circulator"
 	cost = 60
 	containertype = /obj/structure/closet/crate/secure/large
-	containername = "atmospheric circulator crate"
+	containername = "\improper atmospheric circulator crate"
 	group = "Engineering"
 	access = access_engine
 
 /datum/supply_packs/supermatter_shard
 	contains = list(/obj/machinery/power/supermatter/shard)
-	name = "Supermatter Shard"
+	name = "Supermatter shard"
 	cost = 500 //So cargo thinks thrice before killing themselves with it. You're going to need a department account most likely.
 	containertype = /obj/structure/closet/crate/secure/engisec
-	containername = "supermatter shard crate"
+	containername = "\improper supermatter shard crate"
 	group = "Engineering"
 	access = access_ce
 
@@ -1367,15 +1366,15 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 						/obj/item/weapon/stock_parts/capacitor,
 						/obj/item/weapon/stock_parts/capacitor,
 						/obj/item/weapon/stock_parts/console_screen)
-	name = "Portable SMES"
+	name = "Portable SMES parts"
 	cost = 70
 	containertype = /obj/structure/closet/crate/secure/engisec
-	containername = "portable SMES crate"
+	containername = "\improper portable SMES crate"
 	group = "Engineering"
 	access = access_engine
 
 /datum/supply_packs/rcs_device
-	name = "Rapid Crate Sender Crate"
+	name = "Rapid-Crate-Sender"
 	contains = list (/obj/item/weapon/rcs)
 	cost = 80
 	containertype = /obj/structure/closet/crate/engi
@@ -1383,7 +1382,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	group = "Engineering"
 
 /datum/supply_packs/rcs_telepad
-	name = "Cargo Telepad Crate"
+	name = "Cargo telepads"
 	contains = list (/obj/item/device/telepad_beacon,
 					 /obj/item/device/telepad_beacon,
 					 /obj/item/device/telepad_beacon)
@@ -1393,19 +1392,19 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	group = "Engineering"
 
 /datum/supply_packs/inflatables
-	name = "Inflatable Structures Pack"
+	name = "Inflatable structures pack"
 	contains = list (/obj/item/weapon/storage/box/inflatables,
 					 /obj/item/weapon/storage/box/inflatables,
 					 /obj/item/weapon/storage/box/inflatables)
 	cost = 15
 	containertype = /obj/structure/closet/crate/engi
-	containername = "inflatable structures crate"
+	containername = "\improper inflatable structures crate"
 	group = "Engineering"
 
 //////MEDICAL//////
 
 /datum/supply_packs/medical
-	name = "Medical crate"
+	name = "Medical supplies"
 	contains = list(/obj/item/weapon/storage/firstaid/regular,
 					/obj/item/weapon/storage/firstaid/fire,
 					/obj/item/weapon/storage/firstaid/toxin,
@@ -1418,11 +1417,11 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/storage/box/autoinjectors)
 	cost = 10
 	containertype = /obj/structure/closet/crate/medical
-	containername = "medical crate"
+	containername = "\improper medical crate"
 	group = "Medical"
 
 /datum/supply_packs/virus
-	name = "Virus crate"
+	name = "Virus dishes"
 /*	contains = list(/obj/item/weapon/reagent_containers/glass/bottle/flu_virion,
 					/obj/item/weapon/reagent_containers/glass/bottle/cold,
 					/obj/item/weapon/reagent_containers/glass/bottle/epiglottis_virion,
@@ -1441,12 +1440,12 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/virusdish/random)
 	cost = 25
 	containertype = "/obj/structure/closet/crate/secure"
-	containername = "virus crate"
+	containername = "\improper virus crate"
 	access = access_cmo
 	group = "Medical"
 
 /datum/supply_packs/surgery
-	name = "Surgery crate"
+	name = "Surgery tools"
 	contains = list(/obj/item/weapon/cautery,
 					/obj/item/weapon/surgicaldrill,
 					/obj/item/clothing/mask/breath/medical,
@@ -1460,23 +1459,23 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/circular_saw)
 	cost = 25
 	containertype = "/obj/structure/closet/crate/secure"
-	containername = "surgery crate"
+	containername = "\improper surgery crate"
 	access = access_medical
 	group = "Medical"
 
 /datum/supply_packs/sterile
-	name = "Sterile equipment crate"
+	name = "Sterile equipment"
 	contains = list(/obj/item/clothing/under/rank/medical/green,
 					/obj/item/clothing/under/rank/medical/green,
 					/obj/item/weapon/storage/box/masks,
 					/obj/item/weapon/storage/box/gloves)
 	cost = 15
 	containertype = "/obj/structure/closet/crate"
-	containername = "sterile equipment crate"
+	containername = "\improper sterile equipment crate"
 	group = "Medical"
 
 /datum/supply_packs/bloodbags
-	name = "Bloodbag Crate"
+	name = "Bloodbags"
 	contains = list(/obj/item/weapon/reagent_containers/blood/APlus,
 					/obj/item/weapon/reagent_containers/blood/AMinus,
 					/obj/item/weapon/reagent_containers/blood/BPlus,
@@ -1486,38 +1485,38 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/reagent_containers/blood/empty)
 	cost = 10
 	containertype = /obj/structure/closet/crate/secure
-	containername = "bloodbag crate"
+	containername = "\improper bloodbag crate"
 	access = access_medical
 	group = "Medical"
 
 /datum/supply_packs/wheelchair
-	name = "Wheelchair Crate"
+	name = "Wheelchair"
 	contains = list(/obj/structure/bed/chair/vehicle/wheelchair)
 	cost = 40
 	containertype = /obj/structure/closet/crate/medical
-	containername = "wheelchair crate"
+	containername = "\improper wheelchair crate"
 	group = "Medical"
 
 /datum/supply_packs/wheelchair_motorized
-	name = "Motorized Wheelchair Crate"
+	name = "Motorized wheelchair"
 	contains = list(/obj/structure/bed/chair/vehicle/wheelchair/motorized)
 	cost = 200
 	containertype = "/obj/structure/closet/crate/secure"
-	containername = "motorized wheelchair crate"
+	containername = "\improper motorized wheelchair crate"
 	access = access_cmo
 	group = "Medical"
-	
+
 /datum/supply_packs/skele_stand
-	name = "Hanging Skeleton Model crate"
+	name = "Hanging skeleton model"
 	cost = 30
 	containertype = /obj/structure/largecrate/skele_stand
-	containername = "hanging skeleton model crate"
+	containername = "\improper hanging skeleton model crate"
 	group = "Medical"
 
 //////SCIENCE//////
 
 /datum/supply_packs/research_parts
-	name = "RnD Stock Parts Crate"
+	name = "RnD stock parts"
 	contains = list(
 					/obj/item/weapon/circuitboard/protolathe,
 					/obj/item/weapon/circuitboard/rdconsole,
@@ -1534,24 +1533,24 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/stock_parts/micro_laser)
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure/scisec
-	containername = "research and development stock parts crate"
+	containername = "\improper research and development stock parts crate"
 	access = access_science
 	group = "Science"
 
 /datum/supply_packs/research_nanotrasen
-	name = "RnD Experimental Crate"
+	name = "RnD experimental tech"
 	contains = list(
 		/obj/item/weapon/disk/tech_disk/nanotrasen,
 		/obj/item/weapon/paper/tech_nanotrasen,
 		)
 	cost = 80
 	containertype = /obj/structure/closet/crate/secure/scisec
-	containername = "research and development experimental crate"
+	containername = "\improper research and development experimental crate"
 	access = access_science
 	group = "Science"
 
 /datum/supply_packs/robotics
-	name = "Robotics Assembly Crate"
+	name = "Robotics assembly kit"
 	contains = list(/obj/item/device/assembly/prox_sensor,
 					/obj/item/device/assembly/prox_sensor,
 					/obj/item/device/assembly/prox_sensor,
@@ -1564,16 +1563,16 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/cell/high)
 	cost = 10
 	containertype = /obj/structure/closet/crate/secure/scisec
-	containername = "robotics assembly crate"
+	containername = "\improper robotics assembly crate"
 	access = access_robotics
 	group = "Science"
 
 /datum/supply_packs/suspension_gen
-	name = "Suspension Field Generator crate"
+	name = "Suspension field generator"
 	contains = list(/obj/machinery/suspension_gen)
 	cost = 50
 	containertype = /obj/structure/largecrate
-	containername = "suspension field generator crate"
+	containername = "\improper suspension field generator crate"
 	access = access_science
 	group = "Science"
 
@@ -1592,12 +1591,12 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 		)
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure/scisec
-	containername = "excavation equipment crate"
+	containername = "\improper excavation equipment crate"
 	access = access_science
 	group = "Science"
 
 /datum/supply_packs/plasma
-	name = "Plasma assembly crate"
+	name = "Plasma assembly kit"
 	contains = list(/obj/item/weapon/tank/plasma,
 					/obj/item/weapon/tank/plasma,
 					/obj/item/weapon/tank/plasma,
@@ -1612,16 +1611,16 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/device/assembly/timer)
 	cost = 10
 	containertype = /obj/structure/closet/crate/secure/plasma
-	containername = "plasma assembly crate"
+	containername = "\improper plasma assembly crate"
 	access = access_tox_storage
 	group = "Science"
 
 /datum/supply_packs/borer
-	name = "Borer Egg Crate"
+	name = "Borer egg"
 	contains = list (/obj/item/weapon/reagent_containers/food/snacks/borer_egg)
 	cost = 100
 	containertype = /obj/structure/closet/crate/secure/scisec
-	containername = "borer egg crate"
+	containername = "\improper borer egg crate"
 	access = access_xenobiology
 	group = "Science"
 
@@ -1629,43 +1628,43 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 //////HYDROPONICS//////
 
 /datum/supply_packs/monkey
-	name = "Monkey crate"
+	name = "Monkey cubes"
 	contains = list (/obj/item/weapon/storage/box/monkeycubes)
 	cost = 20
 	containertype = /obj/structure/closet/crate/freezer
-	containername = "monkey crate"
+	containername = "\improper monkey crate"
 	group = "Hydroponics"
 
 /datum/supply_packs/farwa
-	name = "Farwa crate"
+	name = "Farwa cubes"
 	contains = list (/obj/item/weapon/storage/box/monkeycubes/farwacubes)
 	cost = 30
 	containertype = /obj/structure/closet/crate/freezer
-	containername = "farwa crate"
+	containername = "\improper farwa crate"
 	group = "Hydroponics"
 
 /datum/supply_packs/skrell
-	name = "Neaera crate"
+	name = "Neaera cubes"
 	contains = list (/obj/item/weapon/storage/box/monkeycubes/neaeracubes)
 	cost = 30
 	containertype = /obj/structure/closet/crate/freezer
-	containername = "neaera crate"
+	containername = "\improper neaera crate"
 	group = "Hydroponics"
 
 /datum/supply_packs/stok
-	name = "Stok crate"
+	name = "Stok cubes"
 	contains = list (/obj/item/weapon/storage/box/monkeycubes/stokcubes)
 	cost = 30
 	containertype = /obj/structure/closet/crate/freezer
-	containername = "stok crate"
+	containername = "\improper stok crate"
 	group = "Hydroponics"
 
 /datum/supply_packs/vox
-	name = "Genetically modified chicken crate"
+	name = "Genetically modified chicken eggs"
 	contains = list(/obj/item/weapon/storage/fancy/egg_box/vox)
 	cost = 30
 	containertype = /obj/structure/closet/crate/freezer
-	containername = "green egg crate"
+	containername = "\improper green egg crate"
 	group = "Hydroponics"
 
 /* Defined below
@@ -1674,11 +1673,11 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	contains = list()
 	cost = 50
 	containertype = /obj/structure/largecrate/lisa
-	containername = "Corgi Crate"
+	containername = "\improper Corgi Crate"
 	group = "Hydroponics" */
 
 /datum/supply_packs/hydroponics // -- Skie
-	name = "Hydroponics Supply Crate"
+	name = "Hydroponics supplies"
 	contains = list(/obj/item/weapon/reagent_containers/spray/plantbgone,
 					/obj/item/weapon/reagent_containers/spray/plantbgone,
 					/obj/item/weapon/reagent_containers/glass/bottle/ammonia,
@@ -1692,57 +1691,57 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/storage/box/botanydisk) //Updated with flora disks
 	cost = 15
 	containertype = /obj/structure/closet/crate/hydroponics
-	containername = "hydroponics crate"
+	containername = "\improper hydroponics crate"
 	access = access_hydroponics
 	group = "Hydroponics"
 
 //farm animals - useless and annoying, but potentially a good source of food
 /datum/supply_packs/cow
-	name = "Cow Crate"
+	name = "Cow"
 	cost = 30
 	containertype = /obj/structure/largecrate/cow
-	containername = "cow crate"
+	containername = "\improper cow crate"
 	access = access_hydroponics
 	group = "Hydroponics"
 
 /datum/supply_packs/goat
-	name = "Goat Crate"
+	name = "Goat"
 	cost = 25
 	containertype = /obj/structure/largecrate/goat
-	containername = "goat crate"
+	containername = "\improper goat crate"
 	access = access_hydroponics
 	group = "Hydroponics"
 
 /datum/supply_packs/chicken
-	name = "Chicken Crate"
+	name = "Chicken"
 	cost = 20
 	containertype = /obj/structure/largecrate/chick
-	containername = "chicken crate"
+	containername = "\improper chicken crate"
 	access = access_hydroponics
 	group = "Hydroponics"
 
 /datum/supply_packs/lisa
-	name = "Corgi Crate"
+	name = "Corgi"
 	contains = list()
 	cost = 50
 	containertype = /obj/structure/largecrate/lisa
-	containername = "corgi Crate"
+	containername = "\improper corgi Crate"
 	group = "Hydroponics"
 
 /datum/supply_packs/weedcontrol
-	name = "Weed Control Crate"
+	name = "Weed control equipment"
 	contains = list(/obj/item/weapon/scythe,
 					/obj/item/clothing/mask/gas,
 					/obj/item/weapon/grenade/chem_grenade/antiweed,
 					/obj/item/weapon/grenade/chem_grenade/antiweed)
 	cost = 20
 	containertype = /obj/structure/closet/crate/secure/hydrosec
-	containername = "weed control crate"
+	containername = "\improper weed control crate"
 	access = access_hydroponics
 	group = "Hydroponics"
 
 /datum/supply_packs/exoticseeds
-	name = "Exotic seeds crate"
+	name = "Exotic seeds"
 	contains = list(/obj/item/seeds/dionanode,
 					/obj/item/seeds/dionanode,
 					/obj/item/seeds/libertymycelium,
@@ -1757,12 +1756,12 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/seeds/nofruitseed)
 	cost = 15
 	containertype = /obj/structure/closet/crate/secure/hydrosec
-	containername = "exotic seeds crate"
+	containername = "\improper exotic seeds crate"
 	access = access_hydroponics
 	group = "Hydroponics"
 
 /datum/supply_packs/bee_keeper
-	name = "Beekeeping Crate"
+	name = "Beekeeping kit"
 	contains = list(
 		/obj/item/beezeez,
 		/obj/item/beezeez,
@@ -1778,12 +1777,12 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 		)
 	cost = 20
 	containertype = /obj/structure/closet/crate/secure/hydrosec
-	containername = "beekeeping crate"
+	containername = "\improper beekeeping crate"
 	access = access_hydroponics
 	group = "Hydroponics"
 
 /datum/supply_packs/ranching
-	name = "Ranching Crate"
+	name = "Ranching kit"
 	contains = list(
 			/obj/item/weapon/circuitboard/egg_incubator,
 			/obj/item/weapon/stock_parts/capacitor,
@@ -1797,11 +1796,11 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 		)
 	cost = 15
 	containertype = /obj/structure/closet/crate/hydroponics
-	containername = "ranching crate"
+	containername = "\improper ranching crate"
 	group = "Hydroponics"
 
 /datum/supply_packs/Hydroponics_Trays
-	name = "Hydroponic Trays Components Crate"
+	name = "Hydroponic trays parts"
 	contains = list(
 					/obj/item/weapon/circuitboard/hydroponics,
 					/obj/item/weapon/stock_parts/matter_bin,
@@ -1821,7 +1820,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/stock_parts/console_screen)
 	cost = 12
 	containertype = /obj/structure/closet/crate/secure/hydrosec
-	containername = "hydroponic trays components crate"
+	containername = "\improper hydroponic trays components crate"
 	access = access_hydroponics
 	group = "Hydroponics"
 
@@ -1852,13 +1851,13 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	group = "Vending Machine packs"
 
 /datum/supply_packs/hospitalitymachines
-	name = "Theatre, Bar n Kitchen stack of packs"
+	name = "Theatre, Bar, Kitchen stack of packs"
 	contains = list(/obj/structure/vendomatpack/boozeomat,
 					/obj/structure/vendomatpack/dinnerware,
 					/obj/structure/vendomatpack/autodrobe)
 	cost = 15
 	containertype = /obj/structure/stackopacks
-	containername = "\improper Theatre, Bar n Kitchen stack of packs"
+	containername = "\improper Theatre, Bar, Kitchen stack of packs"
 	group = "Vending Machine packs"
 
 /datum/supply_packs/securitymachines
@@ -1867,7 +1866,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/structure/vendomatpack/security)
 	cost = 10
 	containertype = /obj/structure/stackopacks
-	containername = "security stack of packs"
+	containername = "\improper security stack of packs"
 	group = "Vending Machine packs"
 
 /datum/supply_packs/medbaymachines
@@ -1876,7 +1875,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/structure/vendomatpack/medical)
 	cost = 10
 	containertype = /obj/structure/stackopacks
-	containername = "medical stack of packs"
+	containername = "\improper medical stack of packs"
 	group = "Vending Machine packs"
 
 /datum/supply_packs/botanymachines
@@ -1885,7 +1884,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/structure/vendomatpack/hydroseeds)
 	cost = 10
 	containertype = /obj/structure/stackopacks
-	containername = "hydroponics stack of packs"
+	containername = "\improper hydroponics stack of packs"
 	group = "Vending Machine packs"
 
 /datum/supply_packs/toolsmachines
@@ -1906,7 +1905,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/structure/vendomatpack/shoedispenser)
 	cost = 15
 	containertype = /obj/structure/stackopacks
-	containername = "clothing stack of packs"
+	containername = "\improper clothing stack of packs"
 	group = "Vending Machine packs"
 
 /*
@@ -1918,7 +1917,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/structure/vendomatpack/sovietvend)
 	cost = 20
 	containertype = /obj/structure/stackopacks
-	containername = "Old and Forgotten stack of packs"
+	containername = "\improper Old and Forgotten stack of packs"
 	group = "Vending Machine packs"
 	hidden = 1
 */
@@ -1928,6 +1927,6 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	contains = list(/obj/structure/vendomatpack/magivend)
 	cost = 80
 	containertype = /obj/structure/stackopacks
-	containername = "strange and bright stack of packs"
+	containername = "\improper strange and bright stack of packs"
 	group = "Vending Machine packs"
 	hidden = 1


### PR DESCRIPTION
Assertions:
- Menu entries should NOT have "crate" at the end, it is superfluous.
- The actual crate that comes via shuttle SHOULD have the crate suffix, it is a crate, after all.
- Capitalization rules must be followed.

Given that, this PR does the following:
- Makes capitalization consistent
- ~~Makes all crate names \improper~~ Prefixes \improper where needed
- Removes the "crate" suffix from the menu entries
- Appends, where missing, the crate suffix to the containername
- Adjusts some names, fixes typos
- Leaves everything else the same (content, price, categories)

The one thing I'm not so sure about is the usage of \improper. Comments regarding that are more than welcome.

meme screenshot below:
![2017-01-29_20-05-27](https://cloud.githubusercontent.com/assets/6307265/22407056/6683692e-e65f-11e6-875b-8d85f3d5770e.png)


:cl:
 * tweak: Tweaks cargo crate names and menu entries