### PR TITLE
Clarifies the infinite invisible spray (infinite -> permanent)

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -183,8 +183,8 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/jobspecific/invisible_spray
 	name = "Can of Invisible Spray"
-	desc = "Spray something to render it invisible! One-time use."
-	item = /obj/item/weapon/invisible_spray/infinite
+	desc = "Spray something to render it permanently invisible! One-time use. Permanence not guaranteed when exposed to water."
+	item = /obj/item/weapon/invisible_spray/permanent
 	cost = 5
 	job = list("Clown", "Mime")
 

--- a/code/game/objects/items/weapons/cosmetics.dm
+++ b/code/game/objects/items/weapons/cosmetics.dm
@@ -200,7 +200,7 @@
 	icon_state = "invisible_spray"
 	flags = FPRINT
 	w_class = W_CLASS_SMALL
-	var/infinite = 0
+	var/permanent = 0
 	var/invisible_time = 5 MINUTES
 	var/sprays_left = 1
 
@@ -220,7 +220,7 @@
 			var/mob/living/carbon/C = target
 			C.body_alphas[INVISIBLESPRAY] = 1
 			C.regenerate_icons()
-			if(!infinite)
+			if(!permanent)
 				spawn(invisible_time)
 					if(C)
 						C.body_alphas.Remove(INVISIBLESPRAY)
@@ -229,7 +229,7 @@
 			var/mob/M = target
 			M.alpha = 1	//to cloak immediately instead of on the next Life() tick
 			M.alphas[INVISIBLESPRAY] = 1
-			if(!infinite)
+			if(!permanent)
 				spawn(invisible_time)
 					if(M)
 						M.alpha = initial(M.alpha)
@@ -241,7 +241,7 @@
 			O.has_been_invisible_sprayed = TRUE
 			if(O.loc == user)
 				user.regenerate_icons()
-			if(!infinite)
+			if(!permanent)
 				spawn(invisible_time)
 					if(O)
 						O.alpha = initial(O.alpha)
@@ -257,6 +257,6 @@
 	sprays_left--
 	return 1
 
-/obj/item/weapon/invisible_spray/infinite
+/obj/item/weapon/invisible_spray/permanent
 	desc = "A can of... invisibility?"
-	infinite = 1
+	permanent = 1


### PR DESCRIPTION
Also adds a small disclaimer to the uplink desc to tell you how to remove it.

fixes #13732

:cl:
* tweak: "Clarifies how the invisible spray works in its uplink description. It's not infinite, it's permanent. Just don't add water."