### PR TITLE
This Message Will Self-Destruct

### DIFF
--- a/code/modules/paperwork/explosive_paper.dm
+++ b/code/modules/paperwork/explosive_paper.dm
@@ -18,7 +18,7 @@
 		if(info)
 			info += "<BR><BR>THIS MESSAGE WILL SELF-DESTRUCT IN [fuse_time/10] SECONDS"
 			updateinfolinks()
+			detonating = TRUE
 			spawn(fuse_time)
-				detonating = TRUE
 				explosion(get_turf(src), -1, 0, 2)
 				qdel(src)

--- a/code/modules/paperwork/explosive_paper.dm
+++ b/code/modules/paperwork/explosive_paper.dm
@@ -1,0 +1,24 @@
+/obj/item/weapon/paper/explosive
+	var/fuse_time = 5 SECONDS
+	var/detonating = FALSE
+
+/obj/item/weapon/paper/explosive/examine(mob/user)
+	if(user.range_check(src))
+		detonate()
+	..()
+
+/obj/item/weapon/paper/explosive/attackby(obj/item/weapon/P as obj, mob/user as mob)
+	if(istype(P, /obj/item/weapon/pen) || istype(P, /obj/item/toy/crayon))
+		if(!(istype(P, /obj/item/weapon/pen/robopen) && P:mode == 2))
+			detonate()
+	..()
+
+/obj/item/weapon/paper/explosive/proc/detonate()
+	if(!detonating)
+		if(info)
+			info += "<BR><BR>THIS MESSAGE WILL SELF-DESTRUCT IN [fuse_time/10] SECONDS"
+			updateinfolinks()
+			spawn(fuse_time)
+				detonating = TRUE
+				explosion(get_turf(src), -1, 0, 2)
+				qdel(src)

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -1618,6 +1618,7 @@
 #include "code\modules\organs\internal\lungs\lung_gasses.dm"
 #include "code\modules\overlays\mobs.dm"
 #include "code\modules\paperwork\clipboard.dm"
+#include "code\modules\paperwork\explosive_paper.dm"
 #include "code\modules\paperwork\filingcabinet.dm"
 #include "code\modules\paperwork\folders.dm"
 #include "code\modules\paperwork\handlabeler.dm"


### PR DESCRIPTION
Adds explosive paper.
Once something is written on explosive paper, when it is read, it will notify the reader that it will self-destruct after a set amount of seconds, and will explode once that time is up.
The explosion is small enough to not cause a breach, though it will still hurt.

The default time is five seconds, though it can be varedited/subtyped to change that as needed.