### PR TITLE
Incredibly huge plasma nerf

### DIFF
--- a/code/ZAS/Plasma.dm
+++ b/code/ZAS/Plasma.dm
@@ -110,7 +110,7 @@ var/image/contamination_overlay = image('icons/effects/contamination.dmi')
 			if(is_slot_hidden(wear_suit.body_parts_covered,HIDEJUMPSUIT))
 				return 1
 	return 0
-
+/*
 /mob/living/carbon/human/proc/suit_contamination()
 	//Runs over the things that can be contaminated and does so.
 	if(w_uniform)
@@ -119,6 +119,7 @@ var/image/contamination_overlay = image('icons/effects/contamination.dmi')
 		shoes.contaminate()
 	if(gloves)
 		gloves.contaminate()
+*/
 
 /*
 /turf/Entered(atom/movable/Obj, atom/OldLoc)


### PR DESCRIPTION
comments out section that causes jumpsuits, gloves, and shoes to become plasma-fied. Ive seen it proposed multiple times but ever actually acted on. The reasoning is that plasma already such an easy win for anyone using it that having it toxify clothing was irrelevant since if it is going to kill someone it will burn someone to death. This was also silly because naked people could come out unscathed meaning that wearing these objects decreased your chances of survival.

0% tested I did this entirely on github

<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl: (as the emoji)
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
:cl:
 * rscdel: Removed plasma toxification of jumpsuits, shoes and gloves.