### PR TITLE
Fix special role preferences not saving some of the time

### DIFF
--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -177,6 +177,7 @@
 		preferences_datums[ckey] = prefs
 	prefs.last_ip = address				//these are gonna be used for banning
 	prefs.last_id = computer_id			//these are gonna be used for banning
+	prefs.client = src
 
 	. = ..()	//calls mob.Login()
 	chatOutput.start()

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1793,7 +1793,10 @@ NOTE:  The change will take effect AFTER any current recruiting periods."}
 	return 1
 
 /datum/preferences/Topic(href, href_list)
-	if(!usr || !client)
+	if(!client)
+		return
+	if(!usr)
+		WARNING("No usr on Topic for [client] with href [href]!")
 		return
 	if(client.mob!=usr)
 		to_chat(usr, "YOU AREN'T ME GO AWAY")


### PR DESCRIPTION
In some cases (from my testing reconnecting seemed to cause it) the preferences datum for a given client wasn't holding a reference to the client datum, making saving the special roles save button not work (regular preferences saving is handled by the client's topic).
This patch fixes it for all cases I was able to test and adds some additional logging in case the role preferences fail to save
Fixes #13433 
:cl:
 * bugfix: Special role preferences should now properly save when the submit button is pressed