### PR TITLE
Fix some sheets of recycled material not having the correct starting materials

### DIFF
--- a/code/__HELPERS/datumpool.dm
+++ b/code/__HELPERS/datumpool.dm
@@ -9,7 +9,7 @@
 /datum/var/disposed
 
 // Read-only or compile-time vars and special exceptions.
-/var/list/exclude = list("inhand_states", "loc", "locs", "parent_type", "vars", "verbs", "type", "x", "y", "z","group", "animate_movement")
+/var/list/exclude = list("inhand_states", "loc", "locs", "parent_type", "vars", "verbs", "type", "x", "y", "z","group", "animate_movement", "starting_materials")
 
 /var/global/list/masterdatumPool = new
 /var/global/list/pooledvariables = new

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -101,6 +101,10 @@
 
 	..()
 
+/atom/movable/resetVariables()
+	..()
+	pooledvariables[type]["starting_materials"] =  vars["starting_materials"] //BYOND doesn't properly handle the initial() of lists, that fixes it for this thing
+
 /proc/delete_profile(var/type, code = 0)
 	if(!ticker || ticker.current_state < 3)
 		return

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -24,7 +24,7 @@ Mineral Sheets
 		return 0
 
 	rec.addAmount(recyck_mat, amount)
-	. = 1
+	return 1
 
 /*
  * Sandstone

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -237,6 +237,8 @@
 /obj/item/stack/proc/update_materials()
 	if(amount && starting_materials)
 		for(var/matID in starting_materials)
+			if(!materials)
+				materials = getFromPool(/datum/materials, src)
 			materials.storage[matID] = max(0, starting_materials[matID]*amount)
 	if(amount < 2)
 		gender = NEUTER

--- a/code/modules/mining/machine_stacking.dm
+++ b/code/modules/mining/machine_stacking.dm
@@ -210,8 +210,7 @@
 
 			stacks["[stackA.type]"] = stack
 			returnToPool(stackA)
-		//else if (istype(O, /obj/item/weapon/ore/slag))
-		//	returnToPool(O)
+
 		else
 			A.forceMove(out_T)
 
@@ -241,6 +240,7 @@
 	var/release_amount = min(stack.amount, stack_amt)
 
 	stacked.amount = release_amount
+	stacked.update_materials()
 	stacked.forceMove(out_T)
 	stack.amount -= release_amount
 


### PR DESCRIPTION
So this issue was actually twofold: the first is byond being terrible at the initial() for lists and thus the starting_materials list was getting nulled when a sheet was sent to the pool and the second is that the stacking machines machines weren't correctly updating the materials in the sheets sent out
This fixes most parts of #13694 (I couldn't repro the not making plasteel part of it, so I can't specifically say if that's actually fixed)
:cl:
 * bugfix: Recyclers should now properly process sheets

