### PR TITLE
Plasma No Longer Phases Through Airtight Suits

### DIFF
--- a/code/ZAS/Plasma.dm
+++ b/code/ZAS/Plasma.dm
@@ -96,6 +96,9 @@ var/image/contamination_overlay = image('icons/effects/contamination.dmi')
 		if(zas_settings.Get(/datum/ZAS_Setting/PLASMAGUARD_ONLY))
 			if(head.clothing_flags & PLASMAGUARD)
 				return 1
+			else if(check_body_part_coverage(EYES))
+				head.contaminate()
+				return 1
 		else if(check_body_part_coverage(EYES))
 			return 1
 	return 0
@@ -105,6 +108,9 @@ var/image/contamination_overlay = image('icons/effects/contamination.dmi')
 	if(wear_suit)
 		if(zas_settings.Get(/datum/ZAS_Setting/PLASMAGUARD_ONLY))
 			if(wear_suit.clothing_flags & PLASMAGUARD)
+				return 1
+			else if(is_slot_hidden(wear_suit.body_parts_covered,HIDEJUMPSUIT))
+				wear_suit.contaminate()
 				return 1
 		else
 			if(is_slot_hidden(wear_suit.body_parts_covered,HIDEJUMPSUIT))


### PR DESCRIPTION
Currently on our "Oh Shit!" plasma setting, suits without `PLASMAGUARD` don't protect you from plasma contamination, despite the fact that plasma is a gas and spacesuits are sealed environments. Even less intuitively, the spacesuit somehow *isn't* contaminated, despite being the only thing actually touching the plasma.

This PR makes it so that wearing a suit that covers your whole body protects your jumpsuit, shoes, and gloves from plasma contamination. However, if the suit lacks `PLASMAGUARD`, the suit itself becomes contaminated, and will deal toxin damage like all other contaminated clothing items do.
Similarly, wearing a head item that covers your eyes will prevent your eyes from being burned, though if the head item lacks `PLASMAGUARD`, it will become contaminated.

:cl:
 * tweak: Spacesuits now protect your jumpsuit, shoes, and gloves from plasma contamination regardless of whether they have PLASMAGUARD. Spacesuits without PLASMAGUARD now become contaminated when exposed to plasma.
