### PR TITLE
New Botanist Traitor Item: Briefcase Full of Bees

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -226,6 +226,13 @@ var/list/uplink_items = list()
 	cost = 2
 	job = list("Botanist")
 
+/datum/uplink_item/jobspecific/beecase
+	name = "Briefcase Full of Bees"
+	desc = "A briefcase containing twenty angry bees."
+	item = /obj/item/weapon/storage/briefcase/bees
+	cost = 4
+	job = list("Botanist")
+
 //Chef
 /datum/uplink_item/jobspecific/specialsauce
 	name = "Chef Excellence's Special Sauce"

--- a/code/game/objects/items/weapons/storage/briefcase.dm
+++ b/code/game/objects/items/weapons/storage/briefcase.dm
@@ -143,3 +143,22 @@
 	var/obj/item/weapon/gun/projectile/automatic/SMG = new
 	SMG.gun_flags &= ~AUTOMAGDROP //dont want to drop mags in null space, do we?
 	stored_item = SMG
+
+/obj/item/weapon/storage/briefcase/bees
+	var/released = FALSE
+
+/obj/item/weapon/storage/briefcase/bees/show_to(mob/user as mob)
+	if(!released)
+		release()
+	..()
+
+/obj/item/weapon/storage/briefcase/bees/proc/release()
+	visible_message("<span class='danger'>A swarm of bees pours out of \the [src]!</span>")
+	var/mob/living/simple_animal/bee/BEE = new(get_turf(src))
+	BEE.strength = 20
+	BEE.toxic = 5
+	BEE.mut = 2
+	BEE.feral = 25
+	BEE.icon_state = "bees_swarm-feral"
+	BEE.newTarget()
+	released = TRUE


### PR DESCRIPTION
Traitor botanists can now buy a briefcase containing a swarm of twenty angry bees for 4 TC. The bees are released when the briefcase's inventory is opened.

:cl:
 * rscadd: Traitor botanists can now buy a briefcase containing twenty angry bees for 4 TC.