### PR TITLE
Phazon Mutations

### DIFF
--- a/__DEFINES/reagents.dm
+++ b/__DEFINES/reagents.dm
@@ -53,6 +53,7 @@
 #define GOLD 			"gold"
 #define SILVER 			"silver"
 #define URANIUM 			"uranium"
+#define PHAZON 			"phazon"
 #define ALUMINUM 			"aluminum"
 #define SILICON 			"silicon"
 #define FUEL 			"fuel"

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -671,3 +671,8 @@
 	for(var/alpha_modification in body_alphas)
 		lowest_alpha = min(lowest_alpha,body_alphas[alpha_modification])
 	return lowest_alpha
+
+/mob/living/carbon/advanced_mutate()
+	..()
+	if(prob(5))
+		hasmouth = !hasmouth

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1669,3 +1669,38 @@
 	if(pain_numb)
 		return FALSE
 	return TRUE
+
+/mob/living/carbon/human/advanced_mutate()
+	..()
+	if(prob(10))
+		species.punch_damage = rand(1,5)
+	species.max_hurt_damage = rand(1,10)
+	if(prob(10))
+		species.breath_type = pick("oxygen","toxins","nitrogen","carbon_dioxide")
+
+	species.heat_level_3 = rand(800, 1200)
+	species.heat_level_2 = round(species.heat_level_3 / 2.5)
+	species.heat_level_1 = round(species.heat_level_2 / 1.11)
+	species.cold_level_1 = rand(160, 360)
+	species.cold_level_2 = round(species.cold_level_1 / 1.3)
+	species.cold_level_3 = round(species.cold_level_2 / 1.66)
+
+	if(prob(30))
+		species.darksight = rand(0,8)
+	species.hazard_high_pressure *= rand(5,20)/10
+	species.warning_high_pressure = round(species.hazard_high_pressure / 1.69)
+	species.hazard_low_pressure *= rand(5,20)/10
+	species.warning_low_pressure = round(species.hazard_low_pressure * 2.5)
+	if(prob(5))
+		species.warning_low_pressure = -1
+		species.hazard_low_pressure = -1
+
+	species.brute_mod *= rand(5,20)/10
+	species.burn_mod *= rand(5,20)/10
+
+	if(prob(5))
+		species.flags = rand(0,65535)
+	if(prob(5))
+		species.anatomy_flags = rand(0,65535)
+	if(prob(5))
+		species.chem_flags = rand(0,65535)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1476,3 +1476,38 @@ Thanks.
 		// flick("e_flash", flash)
 		overlay_fullscreen("flash", type)
 		return 1
+
+/mob/living/proc/advanced_mutate()
+	color = list(rand(),rand(),rand(),0,
+				rand(),rand(),rand(),0,
+				rand(),rand(),rand(),0,
+				0,0,0,1,
+				0,0,0,0)
+	if(prob(5))
+		eye_blind = rand(0,100)
+	if(prob(10))
+		eye_blurry = rand(0,100)
+	if(prob(5))
+		ear_deaf = rand(0,100)
+	brute_damage_modifier += rand(-5,10)/10
+	burn_damage_modifier += rand(-5,10)/10
+	tox_damage_modifier += rand(-5,10)/10
+	oxy_damage_modifier += rand(-5,10)/10
+	clone_damage_modifier += rand(-5,10)/10
+	brain_damage_modifier += rand(-5,10)/10
+	hal_damage_modifier += rand(-5,10)/10
+
+	movement_speed_modifier += rand(-9,10)/10
+	if(prob(1))
+		universal_speak = !universal_speak
+	if(prob(1))
+		universal_understand = !universal_understand
+
+	maxHealth = rand(50,200)
+	meat_type = pick(typesof(/obj/item/weapon/reagent_containers/food/snacks/meat))
+	if(prob(5))
+		cap_calorie_burning_bodytemp = !cap_calorie_burning_bodytemp
+	if(prob(10))
+		calorie_burning_heat_multiplier += rand(-5,10)/10
+	if(prob(10))
+		thermal_loss_multiplier += rand(-5,10)/10

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1595,6 +1595,21 @@
 		if(!(locate(/obj/effect/decal/cleanable/greenglow) in T))
 			new /obj/effect/decal/cleanable/greenglow(T)
 
+/datum/reagent/phazon
+	name = "Phazon"
+	id = PHAZON
+	description = "The properties of this rare metal are not well-known."
+	reagent_state = SOLID
+	color = "#5E02F8" //rgb: 94, 2, 248
+
+/datum/reagent/phazon/on_mob_life(var/mob/living/M)
+	if(..())
+		return 1
+
+	M.apply_effect(5, IRRADIATE, 0)
+	if(prob(20))
+		M.advanced_mutate()
+
 /datum/reagent/aluminum
 	name = "Aluminum"
 	id = ALUMINUM

--- a/code/modules/reagents/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/machinery/reagentgrinder.dm
@@ -24,6 +24,7 @@
 		/obj/item/stack/sheet/mineral/clown   = list(BANANA = 20),
 		/obj/item/stack/sheet/mineral/silver  = list(SILVER = 20),
 		/obj/item/stack/sheet/mineral/gold    = list(GOLD = 20),
+		/obj/item/stack/sheet/mineral/phazon  = list(PHAZON = 1),
 		/obj/item/weapon/grown/nettle         = list(SACID = 0),
 		/obj/item/weapon/grown/deathnettle    = list(PACID = 0),
 		/obj/item/stack/sheet/charcoal        = list("charcoal" = 20),


### PR DESCRIPTION
Phazon metal can now be ground into a reagent.
When phazon is metabolized by a mob, the mob is irradiated, and each tick there is a 20% chance for the mob's `advanced_mutate()` to be called.
`advanced_mutate()` applies a random color matrix to the mob, as well as randomly altering some of the mob's vars, especially those that can't be easily altered by other means, such as `movement_speed_modifier`, `brute_damage_modifier`, `maxHealth`, et cetera. In humans the possible mutations are more varied, with random changes being made to their species datum.
Any particular change could be positive or negative, it's completely random.

:cl:
 * rscadd: Phazon metal can now be ground into a reagent. Injecting ground phazon into a mob causes random and otherwise inaccessible changes.
