### PR TITLE
Fruit [DNM]

### DIFF
--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -1570,6 +1570,7 @@
 	packet_icon = "seed-nofruit"
 	plant_icon = "nofruit"
 	chems = list(NOTHING = list(1,20))
+	immutable = 1
 
 	lifespan = 30
 	maturation = 5
@@ -1577,7 +1578,7 @@
 	yield = 1
 	potency = 10
 	water_consumption = 6
-	nutrient_consumption = 0.10
+	nutrient_consumption = 1.00
 	growth_stages = 4
 
 // Vox Food

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -4358,10 +4358,10 @@
 			current_path = available_snacks[counter]
 			var/obj/item/weapon/reagent_containers/food/snacks/S = current_path
 			icon_state = initial(S.icon_state)
-			playsound(src, 'sound/misc/click.ogg', 50, 1)
-			sleep(1)
+			sleep(4)
 			if(counter == available_snacks.len)
 				counter = 0
+				available_snacks = shuffle(available_snacks)
 			counter++
 
 /obj/item/weapon/reagent_containers/food/snacks/sundayroast

--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -924,9 +924,8 @@
 			current_path = available_fruits[counter]
 			var/obj/item/weapon/reagent_containers/food/snacks/grown/G = current_path
 			icon_state = initial(G.icon_state)
-			if(get_turf(src))
-				playsound(get_turf(src), 'sound/misc/click.ogg', 50, 1)
-			sleep(1)
+			sleep(4)
 			if(counter == available_fruits.len)
 				counter = 0
+				available_fruits = shuffle(available_fruits)
 			counter++


### PR DESCRIPTION
Using shadowmech's PR/ideas as well as, potentially, N3X15’s exclusion to xenofruit and vox plants.

**What PR aims to do**

- No-fruit now takes ten times more nutrients to grow than previously. You will need to pay a lot more attention to grow it in large quantities, and if you persist and grow no-fruit in every tray, future botany is going to be a mess. Now there's a tradeoff.
- No-fruit and no-fruit pie no longer tick. This is because although you need many, many no-fruit to cause FPS lag/jitteriness, audio distortion and lag and annoyance occur at 5+.
- No-fruit is now immutable. With this and the first change, it should become incredibly, ridiculously unlikely that people will use it to lag the server. @N3X15 I'm looking at you. Here's a fix.
- No-fruit and no-fruit pie is now aimable. It ticks slower, and if you have great reflexes, you can occasionally land on what you want. With the other changes, you still shouldn't be able to get everything you ever want, especially not from no-fruit, but this feature is a lot of fun and I realize plenty of people enjoy it as it existed before this whole shitstorm.
- No-fruit can't make xenoarch plants or vox plants. I realize this is sort of controversial for a lot of people, and originally I didn't think it was a good idea, but I think it'd be really healthy for botany players in the _future_ because xenoarch plants can become more interesting and Vox plants can get sold more often.

**What still needs implementation**

The last point, there-- excluding xenoarch plants and vox plants from the no-fruit list. I've seen the code that N3X15 made for it, and I can't figure out how to separate it out, as it seems linked to the rest of the changes. Also, the .dmis can't be edited on web-Github, and I'm not sure if they're necessary to the change.
I'm not a smart boy with coding and need some help.

Until this change is made, probably not good to merge this as the CL will be misleading.

**Why to do this instead of one of the other PRs**

- It fixes no-fruit audio distortion completely, which no other PR besides N3X15’s does.
- It nearly completely eradicates potential for lag for anyone but the most autistic, crazed botanists. In any case, shouldn't intentionally lagging a server be at least _partially_ that player's fault, and not solely a reason to remove the feature?
- It allows aiming for no-fruit pie items, and a lot of people want that. No other PR besides Shadowmech’s does that.
- It doesn't remove features besides the ticking. Even people that like the ticking: you can't deny it's fucking annoying in a huge quantity.
- You can no longer grow a lot of no-fruit and get xenofruit or vox plants for free. The only reason you would make no-fruit as an average botanist would be either to have a fun way of getting fruit or food, OR to get mutated plants in a roundabout way.
- It ends this goddamn debate with a compromise, and fewer are unhappy. Hopefully.

I'm really trying to come up with a solution that hits @despotate's points as well as @N3X15's, but also stays true to the playerbase that likes this plant and pie and doesn't want it gimped.
Please, if you have problems or suggestions, voice them.

🆑

 - tweak: "Reworks no-fruit and no-fruit pie. No-fruit is now more intensive to grow and immutable, but both it and the pie tick slower, and with quick reaction time, can be used to land on a specific fruit or food."