### PR TITLE
Fix bluespace tomato and atom locking things (maybe)

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -99,7 +99,7 @@
 		to_chat(user, "<span class='warning'>The [M] is too squishy to buckle in.</span>")
 		return
 
-	if(M == usr)
+	if(M == user)
 		M.visible_message(\
 			"<span class='notice'>[M.name] buckles in!</span>",\
 			"You buckle yourself to [src].",\

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -86,17 +86,10 @@
 		target = M
 	if((target) && (target.op_stage.butt == 4)) //Butt surgery is at stage 4
 		if(!M.knockdown)	//Spam prevention
-			if(M == usr)
-				M.visible_message(\
-					"<span class='notice'>[M.name] has no butt, and slides right out of [src]!</span>",\
-					"Having no butt, you slide right out of the [src]",\
-					"You hear metal clanking.")
-
-			else
-				M.visible_message(\
-					"<span class='notice'>[M.name] has no butt, and slides right out of [src]!</span>",\
-					"Having no butt, you slide right out of the [src]",\
-					"You hear metal clanking.")
+			M.visible_message(\
+				"<span class='notice'>[M.name] has no butt, and slides right out of [src]!</span>",\
+				"Having no butt, you slide right out of the [src]",\
+				"You hear metal clanking.")
 
 			M.Knockdown(5)
 		else

--- a/code/game/objects/structures/vehicles/adminbus.dm
+++ b/code/game/objects/structures/vehicles/adminbus.dm
@@ -307,8 +307,11 @@
 	update_mob()
 	update_rearview()
 
+/obj/structure/bed/chair/vehicle/adminbus/can_buckle(mob/M, mob/user)
+	return 1
+
 /obj/structure/bed/chair/vehicle/adminbus/buckle_mob(mob/M, mob/user)
-	if(M != user|| !ismob(M)|| get_dist(src, user) > 1|| user.restrained()|| user.lying|| user.stat|| M.locked_to|| istype(user, /mob/living/silicon)|| destroyed)
+	if(M != user || !ismob(M) || !Adjacent(user) || user.restrained() || user.lying || user.stat || user.locked_to || destroyed || istype(user, /mob/living/silicon))
 		return
 
 	if(!(istype(user,/mob/living/carbon/human/dummy) || istype(user,/mob/living/simple_animal/corgi/Ian)))

--- a/code/game/objects/structures/vehicles/adminbus_powers.dm
+++ b/code/game/objects/structures/vehicles/adminbus_powers.dm
@@ -219,24 +219,18 @@
 			bususer.gui_icons.adminbus_roadlights_1.icon_state = "icon_lights_1-off"
 			bususer.gui_icons.adminbus_roadlights_2.icon_state = "icon_lights_2-off"
 			lightsource.set_light(0)
-			if(roadlights == 1 || roadlights == 2)
-				overlays["roadlights"] = null
 			roadlights = 0
 		if(1)
 			bususer.gui_icons.adminbus_roadlights_0.icon_state = "icon_lights_0-off"
 			bususer.gui_icons.adminbus_roadlights_1.icon_state = "icon_lights_1-on"
 			bususer.gui_icons.adminbus_roadlights_2.icon_state = "icon_lights_2-off"
 			lightsource.set_light(2)
-			if(roadlights == 0)
-				overlays["roadlights"] = roadlights_image
 			roadlights = 1
 		if(2)
 			bususer.gui_icons.adminbus_roadlights_0.icon_state = "icon_lights_0-off"
 			bususer.gui_icons.adminbus_roadlights_1.icon_state = "icon_lights_1-off"
 			bususer.gui_icons.adminbus_roadlights_2.icon_state = "icon_lights_2-on"
 			lightsource.set_light(3)
-			if(roadlights == 0)
-				overlays["roadlights"] = roadlights_image
 			roadlights = 2
 
 	update_lightsource()

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -388,17 +388,21 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 
 	return
 
-/mob/living/simple_animal/MouseDrop(mob/living/carbon/human/M)
-	if(M != usr || !istype(M) || !Adjacent(M) || M.incapacitated())
+/mob/living/simple_animal/MouseDrop(atom/A)
+	if(!Adjacent(A) )
 		return
 
 	if(locked_to) //Atom locking
 		return
 
-	var/strength_of_M = (M.size - 1) //Can only pick up mobs whose size is less or equal to this value. Normal human's size is 3, so his strength is 2 - he can pick up TINY and SMALL animals. Varediting human's size to 5 will allow him to pick up goliaths.
+	if(ishuman(A) && A == usr)
+		var/mob/living/carbon/human/H = A
+		if(H.incapacitated() || H.restrained() || H.stat || H.lying)
+			return
+		var/strength_of_H = (H.size - 1) //Can only pick up mobs whose size is less or equal to this value. Normal human's size is 3, so his strength is 2 - he can pick up TINY and SMALL animals. Varediting human's size to 5 will allow him to pick up goliaths.
 
-	if((M.a_intent != I_HELP) && (src.size <= strength_of_M) && (isturf(src.loc)) && (src.holder_type))
-		scoop_up(M)
+		if((H.a_intent != I_HELP) && (src.size <= strength_of_H) && (isturf(src.loc)) && (src.holder_type))
+			scoop_up(H)
 	else
 		..()
 


### PR DESCRIPTION
Resolves #10884 probably
Some of this is actually overlapping but it's mostly a cherry-picked commit from https://github.com/Benblu/vgstation13/pull/41 by @Zaers 
One of his fixes assumed that `loc` is always `locked_to.loc`, and we have offsets for atom locking so I didn't think that'd be applicable
I can already see a bunch of stuff that'll probably need to be removed from this