### PR TITLE
virus runtime

### DIFF
--- a/code/modules/mob/living/carbon/human/life/handle_breath.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_breath.dm
@@ -120,7 +120,7 @@
 		if(virus2 && virus2.len > 0)
 			if(prob(10) && get_infection_chance(src))
 //					log_debug("[src] : Exhaling some viruses")
-				for(var/mob/living/M in view(1,src))
+				for(var/mob/living/M in range(1,src))
 					if(can_be_infected(M))
 						spread_disease_to(src,M)
 

--- a/code/modules/mob/living/carbon/human/life/handle_breath.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_breath.dm
@@ -121,7 +121,8 @@
 			if(prob(10) && get_infection_chance(src))
 //					log_debug("[src] : Exhaling some viruses")
 				for(var/mob/living/M in view(1,src))
-					spread_disease_to(src,M)
+					if(can_be_infected(M))
+						spread_disease_to(src,M)
 
 /mob/living/carbon/human/proc/get_breath_from_internal(volume_needed)
 	if(internal)


### PR DESCRIPTION
Hopefully fixes a runtime with viruses and simple animals
```
[07:00:46] Runtime in helpers.dm,133: undefined variable /mob/living/simple_animal/corgi/Ian/var/virus2
  proc name: spread disease to (/proc/spread_disease_to)
  src: null
  call stack:
  spread disease to(Anthony Aggley (/mob/living/carbon/human), Ian (/mob/living/simple_animal/corgi/Ian), "Airborne")
  Anthony Aggley (/mob/living/carbon/human): breathe()
  Anthony Aggley (/mob/living/carbon/human): Life()
  Mob (/datum/subsystem/mob): fire(1)
  Master (/datum/controller/master): RunQueue()
  Master (/datum/controller/master): Loop()
  Master (/datum/controller/master): StartProcessing()
```