### PR TITLE
Fixes runtimes on update_hidden_item_icons when human mob is qdel'd

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -1165,7 +1165,7 @@ var/global/list/damage_icon_parts = list()
 
 //lower cost way of updating the necessary human icons on equip and unequip
 /mob/living/carbon/human/proc/update_hidden_item_icons(var/obj/item/W)
-	if(!W)
+	if(!W || gcDestroyed)
 		return
 
 	if(is_slot_hidden(W.body_parts_covered,HIDEHEADHAIR) || is_slot_hidden(W.body_parts_covered,HIDEBEARDHAIR))


### PR DESCRIPTION
See title
```dm
[10:05:19] Runtime in update_icons.dm,961: Cannot read null.name
  proc name: update inv wear mask (/mob/living/carbon/human/update_inv_wear_mask)
  usr: Doug Dimmadome (anglosphere) (/mob/living/carbon/human)
  usr.loc: The floor (230, 191, 1) (/turf/simulated/floor)
  src: Doug Dimmadome (/mob/living/carbon/human)
  src.loc: the floor (230,191,1) (/turf/simulated/floor)
  call stack:
  Doug Dimmadome (/mob/living/carbon/human): update inv wear mask(1)
  Doug Dimmadome (/mob/living/carbon/human): update hidden item icons(the atmospherics hardsuit helm... (/obj/item/clothing/head/helmet/space/rig/atmos))
  Doug Dimmadome (/mob/living/carbon/human): u equip(the atmospherics hardsuit helm... (/obj/item/clothing/head/helmet/space/rig/atmos), 1, 9)
  Doug Dimmadome (/mob/living/carbon/human): drop from inventory(the atmospherics hardsuit helm... (/obj/item/clothing/head/helmet/space/rig/atmos))
  the atmospherics hardsuit helm... (/obj/item/clothing/head/helmet/space/rig/atmos): Destroy()
  the atmospherics hardsuit helm... (/obj/item/clothing/head/helmet/space/rig/atmos): Destroy()
  qdel(the atmospherics hardsuit helm... (/obj/item/clothing/head/helmet/space/rig/atmos), 0, 0)
  Doug Dimmadome (/mob/living/carbon/human): Destroy()
  Doug Dimmadome (/mob/living/carbon/human): Destroy()
  Doug Dimmadome (/mob/living/carbon/human): Destroy()
  Doug Dimmadome (/mob/living/carbon/human): Destroy()
  qdel(Doug Dimmadome (/mob/living/carbon/human), 0, 0)
  Doug Dimmadome (/mob/living/carbon/human): dust()
  Supermatter Shard (/obj/machinery/power/supermatter/shard): Consume(Doug Dimmadome (/mob/living/carbon/human))
  Supermatter Shard (/obj/machinery/power/supermatter/shard): Bumped(Doug Dimmadome (/mob/living/carbon/human))
  Doug Dimmadome (/mob/living/carbon/human): Bump(Supermatter Shard (/obj/machinery/power/supermatter/shard))
  Doug Dimmadome (/mob/living/carbon/human): Bump(Supermatter Shard (/obj/machinery/power/supermatter/shard))
  Doug Dimmadome (/mob/living/carbon/human): Bump(Supermatter Shard (/obj/machinery/power/supermatter/shard))
```
don't ask me why Destroy() calls itself three more times on a mob after the initial call