### PR TITLE
Borer Tweaks

### DIFF
--- a/code/modules/mob/living/simple_animal/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer.dm
@@ -82,7 +82,7 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 	var/channeling_bone_shield = 0
 	var/channeling_bone_hammer = 0
 	var/channeling_bone_cocoon = 0
-	var/channeling_xray = 0
+	var/channeling_night_vision = 0
 
 	var/obj/item/weapon/gun/hookshot/flesh/extend_o_arm = null
 	var/extend_o_arm_unlocked = 0

--- a/code/modules/mob/living/simple_animal/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer.dm
@@ -82,6 +82,7 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 	var/channeling_bone_shield = 0
 	var/channeling_bone_hammer = 0
 	var/channeling_bone_cocoon = 0
+	var/channeling_xray = 0
 
 	var/obj/item/weapon/gun/hookshot/flesh/extend_o_arm = null
 	var/extend_o_arm_unlocked = 0

--- a/code/modules/mob/living/simple_animal/borer/chems.dm
+++ b/code/modules/mob/living/simple_animal/borer/chems.dm
@@ -24,27 +24,6 @@
 /datum/borer_chem/head/ryetalyn
 	name = RYETALYN
 
-/datum/borer_chem/head/hyperzine
-	name = HYPERZINE
-
-/datum/borer_chem/head/charcoal
-	name = CHARCOAL
-	cost = 2
-
-/datum/borer_chem/head/anti_toxin
-	name = ANTI_TOXIN
-
-/datum/borer_chem/head/leporazine
-	name = LEPORAZINE
-
-/datum/borer_chem/head/inaprovaline
-	name = INAPROVALINE
-	cost = 2
-
-/datum/borer_chem/head/kelotane
-	name = KELOTANE
-	cost = 2
-
 /datum/borer_chem/chest/blood
 	name = BLOOD
 
@@ -65,6 +44,20 @@
 
 /datum/borer_chem/chest/radium
 	name = RADIUM
+
+/datum/borer_chem/chest/leporazine
+	name = LEPORAZINE
+
+/datum/borer_chem/chest/charcoal
+	name = CHARCOAL
+	cost = 2
+
+/datum/borer_chem/chest/anti_toxin
+	name = ANTI_TOXIN
+
+/datum/borer_chem/chest/inaprovaline
+	name = INAPROVALINE
+	cost = 2
 
 /datum/borer_chem/arm/bicaridine
 	name = BICARIDINE
@@ -99,10 +92,6 @@
 
 /datum/borer_chem/head/unlockable/paracetamol
 	name = PARACETAMOL
-	cost = 2
-
-/datum/borer_chem/head/unlockable/dermaline
-	name = DERMALINE
 	cost = 2
 
 /datum/borer_chem/head/unlockable/dexalin
@@ -144,6 +133,10 @@
 /datum/borer_chem/chest/unlockable/clottingagent
 	name = CLOTTING_AGENT
 	cost = 10
+
+/datum/borer_chem/chest/unlockable/dermaline
+	name = DERMALINE
+	cost = 2
 
 /datum/borer_chem/arm/unlockable/cafe_latte
 	name = CAFE_LATTE

--- a/code/modules/mob/living/simple_animal/borer/unlocks.dm
+++ b/code/modules/mob/living/simple_animal/borer/unlocks.dm
@@ -96,16 +96,6 @@
 	time = 2 MINUTES
 	chem_type = /datum/borer_chem/head/unlockable/rezadone
 
-// Burn treatment research tree.
-
-/datum/unlockable/borer/head/chem_unlock/dermaline
-	id = "dermaline"
-	name = "Dermaline Secretion"
-	desc = "Learn how to synthesize dermaline."
-	cost = 150
-	time = 20 SECONDS
-	chem_type = /datum/borer_chem/head/unlockable/dermaline
-
 // Oxygen research tree
 /datum/unlockable/borer/head/chem_unlock/dexalin
 	id = "dexalin"
@@ -185,6 +175,16 @@
 	cost = 200
 	time = 60 SECONDS
 	chem_type = /datum/borer_chem/chest/unlockable/clottingagent
+
+// Burn treatment research tree.
+
+/datum/unlockable/borer/chest/chem_unlock/dermaline
+	id = "dermaline"
+	name = "Dermaline Secretion"
+	desc = "Learn how to synthesize dermaline."
+	cost = 150
+	time = 20 SECONDS
+	chem_type = /datum/borer_chem/chest/unlockable/dermaline
 
 /////////////////Arm Unlocks////////////////////////
 
@@ -281,15 +281,6 @@
 				host.update_mutations()
 				break
 
-// Metabolism tree
-/datum/unlockable/borer/head/gene_unlock/sober
-	id = "sober"
-	name = "Liver Function Boost"
-	desc = "Your host's liver is able to handle massive quantities of alcohol."
-	cost = 200
-	time = 30 SECONDS
-	gene_name = "SOBER"
-
 // Vision tree
 /datum/unlockable/borer/head/gene_unlock/farsight
 	id = "farsight"
@@ -298,15 +289,6 @@
 	cost = 200
 	time = 1 MINUTES
 	gene_name = "FARSIGHT"
-
-/datum/unlockable/borer/head/gene_unlock/xray
-	id = "xray"
-	name = "High-Energy Vision"
-	desc = "Adjusts your host's eyes to see in the X-Ray spectrum."
-	cost = 200
-	time = 2 MINUTES
-	gene_name = "XRAY"
-	prerequisites=list("farsight")
 
 //////////////Chest Unlocks/////////////////
 
@@ -358,6 +340,15 @@
 	time = 1 MINUTES
 	gene_name = "COLD"
 	prerequisites=list("frostoil")
+
+// Metabolism tree
+/datum/unlockable/borer/chest/gene_unlock/sober
+	id = "sober"
+	name = "Liver Function Boost"
+	desc = "Your host's liver is able to handle massive quantities of alcohol."
+	cost = 200
+	time = 30 SECONDS
+	gene_name = "SOBER"
 
 ///////////////Arm Unlocks//////////////////////
 
@@ -512,6 +503,16 @@
 	if(!istype(B))
 		return
 	B.taste_blood()
+
+/datum/unlockable/borer/head/verb_unlock/xray
+	id = "xray"
+	name = "High-Energy Vision"
+	desc = "Learn how to expend chemicals constantly in order to convert visual data from your host's eyes into the X-ray spectrum."
+	cost = 200
+	time = 2 MINUTES
+	verb_type = /obj/item/verbs/borer/attached_head/xray_vision
+	give_when_attached=1
+	prerequisites=list("farsight")
 
 //////////Chest Verbs///////////////////
 

--- a/code/modules/mob/living/simple_animal/borer/unlocks.dm
+++ b/code/modules/mob/living/simple_animal/borer/unlocks.dm
@@ -504,13 +504,13 @@
 		return
 	B.taste_blood()
 
-/datum/unlockable/borer/head/verb_unlock/xray
-	id = "xray"
-	name = "High-Energy Vision"
-	desc = "Learn how to expend chemicals constantly in order to convert visual data from your host's eyes into the X-ray spectrum."
+/datum/unlockable/borer/head/verb_unlock/night_vision
+	id = "night_vision"
+	name = "Night Vision"
+	desc = "Learn how to expend chemicals constantly in order to convert visual data from your host's eyes into the infrared spectrum."
 	cost = 200
 	time = 2 MINUTES
-	verb_type = /obj/item/verbs/borer/attached_head/xray_vision
+	verb_type = /obj/item/verbs/borer/attached_head/night_vision
 	give_when_attached=1
 	prerequisites=list("farsight")
 

--- a/code/modules/mob/living/simple_animal/borer/verbs_attached_head.dm
+++ b/code/modules/mob/living/simple_animal/borer/verbs_attached_head.dm
@@ -86,3 +86,56 @@
 	if(!istype(B))
 		return
 	B.analyze_host()
+
+/obj/item/verbs/borer/attached_head/xray_vision/verb/xray_vision()
+	set category = "Alien"
+	set name = "High-Energy Vision"
+	set desc = "Expend chemicals constantly in order to convert visual data from your host's eyes into the X-ray spectrum."
+
+	var/mob/living/simple_animal/borer/B=loc
+	if(!istype(B))
+		return
+	B.xray_vision()
+
+/mob/living/simple_animal/borer/proc/xray_vision()
+	set category = "Alien"
+	set name = "High-Energy Vision"
+	set desc = "Expend chemicals constantly in order to convert visual data from your host's eyes into the X-ray spectrum."
+
+	if(!check_can_do(0))
+		return
+
+	if(channeling && !channeling_xray)
+		to_chat(src, "<span class='warning'>You can't do this while your focus is directed elsewhere.</span>")
+		return
+	else if(channeling)
+		to_chat(src, "You cease your efforts to convert the visual data from your host's eyes.")
+		channeling = 0
+		channeling_xray = 0
+	else if(chemicals < 5)
+		to_chat(src, "<span class='warning'>You don't have enough chemicals stored to do this.</span>")
+		return
+	else
+		to_chat(src, "You begin to focus your efforts on converting the visual data from your host's eyes into the X-ray spectrum.")
+		channeling = 1
+		channeling_xray = 1
+		change_sight(adding = SEE_TURFS|SEE_MOBS|SEE_OBJS)
+		see_in_dark = 8
+		see_invisible = SEE_INVISIBLE_LEVEL_TWO
+		spawn()
+			var/time_spent_channeling = 0
+			while(chemicals >=5 && channeling && channeling_xray)
+				chemicals -= 5
+				time_spent_channeling++
+				sleep(10)
+			change_sight(removing = SEE_TURFS|SEE_MOBS|SEE_OBJS)
+			see_in_dark = initial(see_in_dark)
+			see_invisible = initial(see_invisible)
+			channeling = 0
+			channeling_xray = 0
+			var/showmessage = 0
+			if(chemicals < 5)
+				to_chat(src, "<span class='warning'>You lose consciousness as the last of your chemicals are expended.</span>")
+			else
+				showmessage = 1
+			passout(time_spent_channeling, showmessage)

--- a/code/modules/mob/living/simple_animal/borer/verbs_attached_head.dm
+++ b/code/modules/mob/living/simple_animal/borer/verbs_attached_head.dm
@@ -87,52 +87,55 @@
 		return
 	B.analyze_host()
 
-/obj/item/verbs/borer/attached_head/xray_vision/verb/xray_vision()
+/obj/item/verbs/borer/attached_head/night_vision/verb/night_vision()
 	set category = "Alien"
-	set name = "High-Energy Vision"
-	set desc = "Expend chemicals constantly in order to convert visual data from your host's eyes into the X-ray spectrum."
+	set name = "Night Vision"
+	set desc = "Expend chemicals constantly in order to convert visual data from your host's eyes into the infrared spectrum."
 
 	var/mob/living/simple_animal/borer/B=loc
 	if(!istype(B))
 		return
-	B.xray_vision()
+	B.night_vision()
 
-/mob/living/simple_animal/borer/proc/xray_vision()
+/mob/living/simple_animal/borer/proc/night_vision()
 	set category = "Alien"
-	set name = "High-Energy Vision"
-	set desc = "Expend chemicals constantly in order to convert visual data from your host's eyes into the X-ray spectrum."
+	set name = "Night Vision"
+	set desc = "Expend chemicals constantly in order to convert visual data from your host's eyes into the infrared spectrum."
 
 	if(!check_can_do(0))
 		return
 
-	if(channeling && !channeling_xray)
+	if(channeling && !channeling_night_vision)
 		to_chat(src, "<span class='warning'>You can't do this while your focus is directed elsewhere.</span>")
 		return
 	else if(channeling)
 		to_chat(src, "You cease your efforts to convert the visual data from your host's eyes.")
 		channeling = 0
-		channeling_xray = 0
+		channeling_night_vision = 0
 	else if(chemicals < 5)
 		to_chat(src, "<span class='warning'>You don't have enough chemicals stored to do this.</span>")
 		return
 	else
-		to_chat(src, "You begin to focus your efforts on converting the visual data from your host's eyes into the X-ray spectrum.")
+		to_chat(src, "You begin to focus your efforts on converting the visual data from your host's eyes into the infrared spectrum.")
 		channeling = 1
-		channeling_xray = 1
-		change_sight(adding = SEE_TURFS|SEE_MOBS|SEE_OBJS)
+		channeling_night_vision = 1
 		see_in_dark = 8
-		see_invisible = SEE_INVISIBLE_LEVEL_TWO
+		see_invisible = SEE_INVISIBLE_OBSERVER_NOLIGHTING
+		host.see_in_dark_override = 8
+		host.see_invisible_override = SEE_INVISIBLE_OBSERVER_NOLIGHTING
 		spawn()
 			var/time_spent_channeling = 0
-			while(chemicals >=5 && channeling && channeling_xray)
+			while(chemicals >=5 && channeling && channeling_night_vision)
 				chemicals -= 5
 				time_spent_channeling++
 				sleep(10)
 			change_sight(removing = SEE_TURFS|SEE_MOBS|SEE_OBJS)
 			see_in_dark = initial(see_in_dark)
 			see_invisible = initial(see_invisible)
+			host.see_in_dark_override = 0
+			host.see_invisible_override = 0
 			channeling = 0
-			channeling_xray = 0
+			channeling_night_vision = 0
 			var/showmessage = 0
 			if(chemicals < 5)
 				to_chat(src, "<span class='warning'>You lose consciousness as the last of your chemicals are expended.</span>")

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1757,6 +1757,12 @@ mob/proc/on_foot()
 /mob/acidable()
 	return 1
 
+/mob/proc/apply_vision_overrides()
+	if(see_in_dark_override)
+		see_in_dark = see_in_dark_override
+	if(see_invisible_override)
+		see_invisible = see_invisible_override
+
 /mob/actual_send_to_future(var/duration)
 	var/init_blinded = blinded
 	var/init_eye_blind = eye_blind

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -279,6 +279,9 @@
 	var/list/alphas = list()
 	var/spell_channeling
 
+	var/see_in_dark_override = 0	//for general guaranteed modification of these variables
+	var/see_invisible_override = 0
+
 /mob/resetVariables()
 	..("callOnFace", "pinned", "embedded", "abilities", "grabbed_by", "requests", "mapobjs", "mutations", "spell_list", "viruses", "resistances", "radar_blips", "active_genes", "attack_log", "speak_emote", args)
 	callOnFace = list()


### PR DESCRIPTION
In response to complaints of head borers being unreasonably capable relative to other types of borers:
Removes hyperzine, anti-toxin, charcoal, leporazine, inaprovaline, kelotane, dermaline unlock, liver function boost gene unlock, and X-ray vision gene unlock from head borers.

Adds night vision channeling ability unlock to head borers.
This ability requires unlocking telephoto vision at least once, and allows the borer to expend chemicals constantly in order to give both itself and its host night vision.

In response to complaints of chest borers being unreasonable weak relative to other types of borers:
Adds leporazine, charcoal, anti-toxin, inaprovaline, dermaline unlock, and liver function boost gene unlock to chest borers.

:cl:
 * tweak: Head borers can no longer secrete hyperzine, anti-toxin, charcoal, leporazine, inaprovaline, kelotane, or dermaline. Head borers can also no longer unlock the sober gene or X-ray gene for their host.
 * tweak: Head borers can now unlock a new ability that allows them to channel chemicals constantly in order to give themselves and their hosts night vision.
 * tweak: Chest borers can now secrete leporazine, charcoal, anti-toxin, inaprovaline, and dermaline. Additionally, chest borers can now unlock the sober gene for their host.
