### PR TITLE
Makes local host admin by default

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -5,6 +5,8 @@
 
 	var/nudge_script_path = "nudge.py"  // where the nudge.py script is located
 
+	var/localhost_autoadmin = 0			// Give local host clients +HOST upon joining
+
 	var/log_ooc = 0						// log OOC channel
 	var/tts_server = ""					// TTS Server
 	var/log_access = 0					// log login/logout
@@ -256,6 +258,9 @@
 
 				if ("use_recursive_explosions")
 					use_recursive_explosions = 1
+
+				if ("localhost_autoadmin")
+					localhost_autoadmin = 1
 
 				if ("log_ooc")
 					config.log_ooc = 1

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -140,6 +140,11 @@
 		admins += src
 		holder.owner = src
 
+	var/localhost_addresses = list("127.0.0.1","::1")
+	if(!address || (address in localhost_addresses))
+		var/datum/admins/D = new /datum/admins("Host", R_HOST, src.ckey)
+		D.associate(src)
+
 	if(connection != "seeker")			//Invalid connection type.
 		if(connection == "web")
 			if(!holder)

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -141,7 +141,7 @@
 		holder.owner = src
 
 	var/localhost_addresses = list("127.0.0.1","::1")
-	if(!address || (address in localhost_addresses))
+	if((!address && !world.port) || (address in localhost_addresses))
 		var/datum/admins/D = new /datum/admins("Host", R_HOST, src.ckey)
 		D.associate(src)
 

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -141,9 +141,10 @@
 		holder.owner = src
 
 	var/localhost_addresses = list("127.0.0.1","::1")
-	if((!address && !world.port) || (address in localhost_addresses))
-		var/datum/admins/D = new /datum/admins("Host", R_HOST, src.ckey)
-		D.associate(src)
+	if(config.localhost_autoadmin)
+		if((!address && !world.port) || (address in localhost_addresses))
+			var/datum/admins/D = new /datum/admins("Host", R_HOST, src.ckey)
+			D.associate(src)
 
 	if(connection != "seeker")			//Invalid connection type.
 		if(connection == "web")

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -140,7 +140,7 @@
 		admins += src
 		holder.owner = src
 
-	var/localhost_addresses = list("127.0.0.1","::1")
+	var/static/list/localhost_addresses = list("127.0.0.1","::1")
 	if(config.localhost_autoadmin)
 		if((!address && !world.port) || (address in localhost_addresses))
 			var/datum/admins/D = new /datum/admins("Host", R_HOST, src.ckey)

--- a/config-example/config.txt
+++ b/config-example/config.txt
@@ -28,6 +28,9 @@ JOBS_HAVE_MINIMAL_ACCESS
 ## Unhash this to use recursive explosions, keep it hashed to use circle explosions. Recursive explosions react to walls, airlocks and blast doors, making them look a lot cooler than the boring old circular explosions. They require more CPU and are (as of january 2013) experimental
 #USE_RECURSIVE_EXPLOSIONS
 
+## Automatically give localhost clients +HOST access
+LOCALHOST_AUTOADMIN
+
 ## log OOC channel
 LOG_OOC
 

--- a/config-example/config.txt
+++ b/config-example/config.txt
@@ -28,7 +28,7 @@ JOBS_HAVE_MINIMAL_ACCESS
 ## Unhash this to use recursive explosions, keep it hashed to use circle explosions. Recursive explosions react to walls, airlocks and blast doors, making them look a lot cooler than the boring old circular explosions. They require more CPU and are (as of january 2013) experimental
 #USE_RECURSIVE_EXPLOSIONS
 
-## Automatically give localhost clients +HOST access
+## (SECURITY RISK ON PUBLIC SERVERS) Automatically give localhost clients +HOST access.
 LOCALHOST_AUTOADMIN
 
 ## log OOC channel


### PR DESCRIPTION
Clients joining with loopback ip (127.0.0.1) or something of the sort are automatically given the Host rank upon joining. Has config option so it can be easily disabled or enabled.

This took me way longer to figure out than it should have.

🆑 

* rscadd: By default, clients joining with a local / loopback IP will receive the Host rank, this can be disabled via config.