### PR TITLE
Adds more value to the .45 pistol crates

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -849,7 +849,9 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 /datum/supply_packs/fourtyfive
 	name = ".45 pistols"
 	contains = list(/obj/item/weapon/gun/projectile/sec,
-					/obj/item/weapon/gun/projectile/sec)
+					/obj/item/weapon/gun/projectile/sec,
+					/obj/item/voucher/free_item/hot_drink,
+					/obj/item/voucher/free_item/snack)
 	cost = 200
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = ".45 pistols crate"

--- a/code/game/objects/items/vouchers.dm
+++ b/code/game/objects/items/vouchers.dm
@@ -24,3 +24,11 @@
 	freebies = list(/obj/item/weapon/reagent_containers/food/drinks/coffee, /obj/item/weapon/reagent_containers/food/drinks/tea, /obj/item/weapon/reagent_containers/food/drinks/h_chocolate)
 	vend_amount = 1
 	shred_on_use = 0
+
+/obj/item/voucher/free_item/snack
+	name = "free snack voucher"
+	desc = "Perk Up Your Day, with this handy free snack from your trusted name-brand vending machines."
+
+	freebies = list(/obj/item/weapon/reagent_containers/food/snacks/candy,/obj/item/weapon/reagent_containers/food/drinks/dry_ramen,/obj/item/weapon/reagent_containers/food/snacks/chips,/obj/item/weapon/reagent_containers/food/snacks/sosjerky,/obj/item/weapon/reagent_containers/food/snacks/no_raisin,/obj/item/weapon/reagent_containers/food/snacks/spacetwinkie,/obj/item/weapon/reagent_containers/food/snacks/cheesiehonkers)
+	vend_amount = 1
+	shred_on_use = 0


### PR DESCRIPTION
After a discussion I had with some folks on how the pistol crates are at least twice as expensive as the other weapon crates, yet only come with two guns whereas the other ones come with armor too.
This seemed like the obvious solution.

:cl:
- rscadd: .45 pistol crates now have way more bang for their buck!