### PR TITLE
Radiation fixes to Singularity and ling QOL changes

### DIFF
--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -925,8 +925,11 @@ var/list/datum/dna/hivemind_bank = list()
 	var/list/victims = list()
 	for(var/mob/living/carbon/C in oview(changeling.sting_range))
 		victims += C
-	var/mob/living/carbon/T = input(src, "Who will we sting?") as null|anything in victims
-
+	var/mob/living/carbon/T
+	if (victims)
+		T = victims[1]
+		if (victims.len > 1)
+			T = input(src, "Who will we sting?") as null|anything in victims
 	if(!T)
 		return
 	if(!(T in view(changeling.sting_range)))

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -500,8 +500,8 @@
 	switch(numb)
 		if(1) //EMP.
 			emp_area()
-		if(2, 3) //Tox damage all carbon mobs in area.
-			toxmob()
+		if(2, 3) //RADIATION damage all carbon mobs in area.
+			radmob()
 		if(4) //Stun mobs who lack optic scanners.
 			mezzer()
 		else
@@ -511,21 +511,16 @@
 	return 1
 
 
-/obj/machinery/singularity/proc/toxmob()
-	var/toxrange = 10
-	var/toxdamage = 4
+/obj/machinery/singularity/proc/radmob()
+	var/radrange = 10
 	var/radiation = 15
 	var/radiationmin = 3
 	if(src.energy > 200)
-		toxdamage = round(((src.energy-150)/50)*4,1)
 		radiation = round(((src.energy-150)/50)*5,1)
 		radiationmin = round((radiation/5),1)
-	for(var/mob/living/M in view(toxrange, src.loc))
-		if(M.flags & INVULNERABLE)
-			continue
-		M.apply_effect(rand(radiationmin,radiation), IRRADIATE)
-		toxdamage = (toxdamage - (toxdamage*M.getarmor(null, "rad")))
-		M.apply_effect(toxdamage, TOX)
+	for(var/mob/living/M in view(radrange, src.loc))
+		radiation = (radiation - (rand(radiationmin, radiation)*M.getarmor(null, "rad")))
+		M.apply_effect(radiation, IRRADIATE)
 	return
 
 

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -519,7 +519,7 @@
 		radiation = round(((src.energy-150)/50)*5,1)
 		radiationmin = round((radiation/5),1)
 	for(var/mob/living/M in view(radrange, src.loc))
-		radiation = (radiation - (rand(radiationmin, radiation)*M.getarmor(null, "rad")))
+		radiation = rand(radiationmin, radiation)
 		M.apply_effect(radiation, IRRADIATE)
 	return
 

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -518,8 +518,8 @@
 	if(src.energy > 200)
 		radiation = round(((src.energy-150)/50)*5,1)
 		radiationmin = round((radiation/5),1)
-	for(var/mob/living/M in view(radrange, src.loc))
 		radiation = rand(radiationmin, radiation)
+	for(var/mob/living/M in view(radrange, src.loc))
 		M.apply_effect(radiation, IRRADIATE)
 	return
 

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -516,7 +516,7 @@
 	var/radiation = 15
 	var/radiationmin = 3
 	if(src.energy > 200)
-		radiation = round(((src.energy-150)/50)*5,1)
+		radiation = round(((src.energy-150)/50)*9,1)
 		radiationmin = round((radiation/5),1)
 		radiation = rand(radiationmin, radiation)
 	for(var/mob/living/M in view(radrange, src.loc))

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -298,6 +298,7 @@
 
 	for(var/mob/living/l in range(src, round((power / 100) ** 0.25)))
 		var/rads = (power / 10) * sqrt(1/(max(get_dist(l, src), 1)))
+		rads = (rads - (rads*l.getarmor(null, "rad"))) // apply radiation blocking from users suit.
 		l.apply_effect(rads, IRRADIATE)
 
 	power -= (power/500)**3

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -298,7 +298,6 @@
 
 	for(var/mob/living/l in range(src, round((power / 100) ** 0.25)))
 		var/rads = (power / 10) * sqrt(1/(max(get_dist(l, src), 1)))
-		rads = (rads - (rads*l.getarmor(null, "rad"))) // apply radiation blocking from users suit.
 		l.apply_effect(rads, IRRADIATE)
 
 	power -= (power/500)**3


### PR DESCRIPTION
Singularity was applying direct toxin damage in addition to radiation damage, essentially doubling the damage. I removed the toxin portion and applied a check against the users suit radiation resistance for the radiation damage.

Supermatter wasn't taking into account the users suit radiation resistance, so I applied the same check here.

The Supermatter is relatively the same, the Singularity will apply the correct amount of radiation without knocking you unconscious in one tic.