### PR TITLE
Phazon Mutation Tweaks

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1489,15 +1489,15 @@ Thanks.
 		eye_blurry = rand(0,100)
 	if(prob(5))
 		ear_deaf = rand(0,100)
-	brute_damage_modifier += rand(-5,10)/10
-	burn_damage_modifier += rand(-5,10)/10
-	tox_damage_modifier += rand(-5,10)/10
-	oxy_damage_modifier += rand(-5,10)/10
-	clone_damage_modifier += rand(-5,10)/10
-	brain_damage_modifier += rand(-5,10)/10
-	hal_damage_modifier += rand(-5,10)/10
+	brute_damage_modifier += rand(-5,5)/10
+	burn_damage_modifier += rand(-5,5)/10
+	tox_damage_modifier += rand(-5,5)/10
+	oxy_damage_modifier += rand(-5,5)/10
+	clone_damage_modifier += rand(-5,5)/10
+	brain_damage_modifier += rand(-5,5)/10
+	hal_damage_modifier += rand(-5,5)/10
 
-	movement_speed_modifier += rand(-9,10)/10
+	movement_speed_modifier += rand(-9,9)/10
 	if(prob(1))
 		universal_speak = !universal_speak
 	if(prob(1))
@@ -1508,6 +1508,6 @@ Thanks.
 	if(prob(5))
 		cap_calorie_burning_bodytemp = !cap_calorie_burning_bodytemp
 	if(prob(10))
-		calorie_burning_heat_multiplier += rand(-5,10)/10
+		calorie_burning_heat_multiplier += rand(-5,5)/10
 	if(prob(10))
-		thermal_loss_multiplier += rand(-5,10)/10
+		thermal_loss_multiplier += rand(-5,5)/10


### PR DESCRIPTION
I had initially made it so that `advanced_mutate()` would alter a mob's damage modifiers by a value that would fall between halving and doubling the normal modifier value. Since it chooses a random integer within those values, it resulted in the code being twice as likely to increase the modifiers, to some degree, than it was to decrease them to some degree.

This tweaks the code so that a mob has equal chance to have its damage modifiers and speed modifier increased or decreased to some degree.