### PR TITLE
Revert "it's just a balloon"

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -88,7 +88,7 @@
 
 /obj/item/toy/syndicateballoon
 	name = "syndicate balloon"
-	desc = "It's just a balloon. There is a tag on the back that reads \"FUK NT!11!\"."
+	desc = "There is a tag on the back that reads \"FUK NT!11!\"."
 	throwforce = 0
 	throw_speed = 4
 	throw_range = 20


### PR DESCRIPTION
Reverts d3athrow/vgstation13#8636
Since the policy looks like it's changed/changing, should remove this.

fixes #13859

:cl:
* tweak: "The syndicate balloon has had its description edited after the admin policy changed to make it make you valid again."