### PR TITLE
Adds two new artifact effects: Plant killer and Plant helper

### DIFF
--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_planthelper.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_planthelper.dm
@@ -9,12 +9,14 @@
 /datum/artifact_effect/planthelper/DoEffectAura()
 	if(holder)
 		for (var/obj/machinery/portable_atmospherics/hydroponics/H in range(src.effectrange,holder))
-			if(H.seed && !H.dead && prob(rand(6,12)))
+			if(H.seed && !H.dead)
 				switch(rand(1,4))
 					if(1)
-						H.waterlevel += rand(2,8)
+						if(H.waterlevel <= 75)
+							H.waterlevel += rand(5,15)
 					if(2)
-						H.nutrilevel++
+						if(H.nutrilevel <= 5)
+							H.nutrilevel += rand(1,5)
 					if(3)
 						H.weedlevel--
 					if(4)
@@ -24,18 +26,16 @@
 /datum/artifact_effect/planthelper/DoEffectPulse()
 	if(holder)
 		for(var/obj/machinery/portable_atmospherics/hydroponics/H in range(src.effectrange,holder))
-			if(H.seed && !H.dead && prob(rand(8,36)))
-				switch(rand(1,4))
+			if(H.seed && !H.dead)
+				switch(rand(1,3))
 					if(1)
-						H.waterlevel += rand(5,15)
-						H.nutrilevel += rand(1,10)
-					if(2) // This will totally end fine.
-						H.mutation_level++
-						H.mutation_mod++
-						H.yield_mod++
-					if(3)
+						if(H.waterlevel <= 90)
+							H.waterlevel += 10
+						if(H.nutrilevel <= 9)
+							H.nutrilevel++
+					if(2)
 						H.age--
-					if(4)
+					if(3)
 						H.weedlevel--
 						H.pestlevel--
 						H.toxins--

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_planthelper.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_planthelper.dm
@@ -1,0 +1,42 @@
+/datum/artifact_effect/planthelper
+	effecttype = "planthelper"
+	effect_type = 5
+
+/datum/artifact_effect/planthelper/New()
+	..()
+	effect = pick(EFFECT_AURA, EFFECT_PULSE)
+
+/datum/artifact_effect/planthelper/DoEffectAura()
+	if(holder)
+		for (var/obj/machinery/portable_atmospherics/hydroponics/H in range(src.effectrange,holder))
+			if(H.seed && !H.dead && prob(rand(6,12)))
+				switch(rand(1,4))
+					if(1)
+						H.waterlevel += rand(2,8)
+					if(2)
+						H.nutrilevel++
+					if(3)
+						H.weedlevel--
+					if(4)
+						H.pestlevel--
+		return 1
+
+/datum/artifact_effect/planthelper/DoEffectPulse()
+	if(holder)
+		for(var/obj/machinery/portable_atmospherics/hydroponics/H in range(src.effectrange,holder))
+			if(H.seed && !H.dead && prob(rand(8,36)))
+				switch(rand(1,4))
+					if(1)
+						H.waterlevel += rand(5,15)
+						H.nutrilevel += rand(1,10)
+					if(2) // This will totally end fine.
+						H.mutation_level++
+						H.mutation_mod++
+						H.yield_mod++
+					if(3)
+						H.age--
+					if(4)
+						H.weedlevel--
+						H.pestlevel--
+						H.toxins--
+			return 1

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_plantkiller.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_plantkiller.dm
@@ -1,0 +1,41 @@
+/datum/artifact_effect/plantkiller
+	effecttype = "plantkiller"
+	effect_type = 5
+
+/datum/artifact_effect/plantkiller/New()
+	..()
+	effect = pick(EFFECT_AURA, EFFECT_PULSE)
+
+/datum/artifact_effect/plantkiller/DoEffectAura()
+	if(holder)
+		for (var/obj/machinery/portable_atmospherics/hydroponics/H in range(src.effectrange,holder))
+			if(H.seed && !H.dead && prob(rand(5,25)))
+				switch(rand(1,3))
+					if(1)
+						H.waterlevel -= rand(1,5)
+						H.nutrilevel--
+					if(2)
+						H.weed_coefficient++
+						H.weedlevel++
+					if(3)
+						H.age++
+		return 1
+
+/datum/artifact_effect/plantkiller/DoEffectPulse()
+	if(holder)
+		for(var/obj/machinery/portable_atmospherics/hydroponics/H in range(src.effectrange,holder))
+			if(H.seed && !H.dead && prob(rand(20,50))) // Get your xenobotanist/vox trader/hydroponist mad with you in less than 1 minute with this simple trick.
+				switch(rand(1,3))
+					if(1)
+						H.waterlevel -= rand(1,10)
+						H.nutrilevel -= rand(1,10)
+					if(2)
+						H.yield_mod--
+						H.toxins += rand(1,10)
+					if(3)
+						H.weed_coefficient++
+						H.weedlevel++
+						H.pestlevel++
+						if(prob(1))
+							H.dead = 1
+			return 1

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_plantkiller.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_plantkiller.dm
@@ -14,7 +14,7 @@
 					if(1)
 						if(H.waterlevel >= 5)
 							H.waterlevel -= rand(1,5)
-							H.nutrilevel--
+						H.nutrilevel--
 					if(2)
 						H.weed_coefficient++
 						H.weedlevel++

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_plantkiller.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_plantkiller.dm
@@ -9,11 +9,12 @@
 /datum/artifact_effect/plantkiller/DoEffectAura()
 	if(holder)
 		for (var/obj/machinery/portable_atmospherics/hydroponics/H in range(src.effectrange,holder))
-			if(H.seed && !H.dead && prob(rand(5,25)))
+			if(H.seed && !H.dead)
 				switch(rand(1,3))
 					if(1)
-						H.waterlevel -= rand(1,5)
-						H.nutrilevel--
+						if(H.waterlevel >= 5)
+							H.waterlevel -= rand(1,5)
+							H.nutrilevel--
 					if(2)
 						H.weed_coefficient++
 						H.weedlevel++
@@ -24,18 +25,20 @@
 /datum/artifact_effect/plantkiller/DoEffectPulse()
 	if(holder)
 		for(var/obj/machinery/portable_atmospherics/hydroponics/H in range(src.effectrange,holder))
-			if(H.seed && !H.dead && prob(rand(20,50))) // Get your xenobotanist/vox trader/hydroponist mad with you in less than 1 minute with this simple trick.
+			if(H.seed && !H.dead) // Get your xenobotanist/vox trader/hydroponist mad with you in less than 1 minute with this simple trick.
 				switch(rand(1,3))
 					if(1)
-						H.waterlevel -= rand(1,10)
-						H.nutrilevel -= rand(1,10)
+						if(H.waterlevel >= 10)
+							H.waterlevel -= rand(1,10)
+						if(H.nutrilevel >= 5)
+							H.nutrilevel -= rand(1,5)
 					if(2)
-						H.yield_mod--
-						H.toxins += rand(1,10)
+						if(H.toxins <= 50)
+							H.toxins += rand(1,50)
 					if(3)
 						H.weed_coefficient++
 						H.weedlevel++
 						H.pestlevel++
-						if(prob(1))
+						if(prob(5))
 							H.dead = 1
 			return 1

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -1907,6 +1907,8 @@
 #include "code\modules\research\xenoarchaeology\artifact\effects\unknown_effect_heal.dm"
 #include "code\modules\research\xenoarchaeology\artifact\effects\unknown_effect_heat.dm"
 #include "code\modules\research\xenoarchaeology\artifact\effects\unknown_effect_hurt.dm"
+#include "code\modules\research\xenoarchaeology\artifact\effects\unknown_effect_planthelper.dm"
+#include "code\modules\research\xenoarchaeology\artifact\effects\unknown_effect_plantkiller.dm"
 #include "code\modules\research\xenoarchaeology\artifact\effects\unknown_effect_projectiles.dm"
 #include "code\modules\research\xenoarchaeology\artifact\effects\unknown_effect_radiate.dm"
 #include "code\modules\research\xenoarchaeology\artifact\effects\unknown_effect_reagentblock.dm"


### PR DESCRIPTION
Adds plant helper and plant killer as possible artifact effects. 

Plant Helper aura effect will refill your plants water and nutriment really slowly plus deal with weeds and pests.
Plant Helper pulse effect will refill water, nutriments, remove weeds, pests and toxins and even rejuvenate your crops.

Plant Killer aura effect will dry your crops of both water and nutriment, make them age faster and make weeds appear more often.
Plant Killer pulse effect will quickly remove water and nutriment, fill their trays with toxin and make pests and weeds appear easily. It will also have 5% of instantly killing a target when adding toxins to it.

:cl:
 * rscadd: Adds two new artifact effects: plant helper and plant killer.