### PR TITLE
Makes bustanuts hardcore again

### DIFF
--- a/code/ZAS/Airflow.dm
+++ b/code/ZAS/Airflow.dm
@@ -478,7 +478,7 @@ mob/living/carbon/human/airflow_hit(atom/A)
 		T.add_blood(src)
 		bloody_body(src)
 
-	if(zas_settings.Get(/datum/ZAS_Setting/airflow_push))
+	if(zas_settings.Get(/datum/ZAS_Setting/airflow_push) || AirflowCanPush())
 		if(airflow_speed > 10)
 			paralysis += round(airflow_speed * zas_settings.Get(/datum/ZAS_Setting/airflow_stun))
 			stunned = max(stunned,paralysis + 3)

--- a/code/ZAS/Airflow.dm
+++ b/code/ZAS/Airflow.dm
@@ -268,9 +268,7 @@ proc/AirflowSpace(zone/A)
 	return 1
 
 /mob/AirflowCanPush()
-	if (M_HARDCORE in mutations)
-		return 1
-	return 0
+	return 1
 
 /atom/movable/proc/GotoAirflowDest(n)
 	last_airflow = world.time
@@ -480,7 +478,7 @@ mob/living/carbon/human/airflow_hit(atom/A)
 		T.add_blood(src)
 		bloody_body(src)
 
-	if(zas_settings.Get(/datum/ZAS_Setting/airflow_push) || AirflowCanPush())
+	if(zas_settings.Get(/datum/ZAS_Setting/airflow_push))
 		if(airflow_speed > 10)
 			paralysis += round(airflow_speed * zas_settings.Get(/datum/ZAS_Setting/airflow_stun))
 			stunned = max(stunned,paralysis + 3)

--- a/code/ZAS/Airflow.dm
+++ b/code/ZAS/Airflow.dm
@@ -268,8 +268,8 @@ proc/AirflowSpace(zone/A)
 
 /mob/AirflowCanPush()
 	if (M_HARDCORE in mutations)
-		return 0
-	return 1
+		return 1
+	return 0
 
 /atom/movable/proc/GotoAirflowDest(n)
 	last_airflow = world.time

--- a/code/ZAS/Airflow.dm
+++ b/code/ZAS/Airflow.dm
@@ -263,6 +263,7 @@ proc/AirflowSpace(zone/A)
 /atom/movable/var/tmp/last_airflow = 0
 
 // Mainly for bustanuts.
+
 /atom/movable/proc/AirflowCanPush()
 	return 1
 

--- a/code/ZAS/ConnectionGroup.dm
+++ b/code/ZAS/ConnectionGroup.dm
@@ -90,6 +90,8 @@ Class Procs:
 	if(!zas_settings.Get(/datum/ZAS_Setting/airflow_push))
 		return
 	for(var/atom/movable/M in movable)
+		if(!M.AirflowCanPush())
+			continue
 		//If they're already being tossed, don't do it again.
 		if(M.last_airflow > world.time - zas_settings.Get(/datum/ZAS_Setting/airflow_delay))
 			continue

--- a/code/ZAS/ConnectionGroup.dm
+++ b/code/ZAS/ConnectionGroup.dm
@@ -90,8 +90,6 @@ Class Procs:
 	if(!zas_settings.Get(/datum/ZAS_Setting/airflow_push))
 		return
 	for(var/atom/movable/M in movable)
-		if(!zas_settings.Get(/datum/ZAS_Setting/airflow_push) && !M.AirflowCanPush())
-			continue
 		//If they're already being tossed, don't do it again.
 		if(M.last_airflow > world.time - zas_settings.Get(/datum/ZAS_Setting/airflow_delay))
 			continue

--- a/code/ZAS/ConnectionGroup.dm
+++ b/code/ZAS/ConnectionGroup.dm
@@ -90,7 +90,7 @@ Class Procs:
 	if(!zas_settings.Get(/datum/ZAS_Setting/airflow_push))
 		return
 	for(var/atom/movable/M in movable)
-		if(!M.AirflowCanPush())
+		if(M.AirflowCanPush())
 			continue
 		//If they're already being tossed, don't do it again.
 		if(M.last_airflow > world.time - zas_settings.Get(/datum/ZAS_Setting/airflow_delay))

--- a/code/ZAS/ConnectionGroup.dm
+++ b/code/ZAS/ConnectionGroup.dm
@@ -90,7 +90,7 @@ Class Procs:
 	if(!zas_settings.Get(/datum/ZAS_Setting/airflow_push))
 		return
 	for(var/atom/movable/M in movable)
-		if(M.AirflowCanPush())
+		if(!zas_settings.Get(/datum/ZAS_Setting/airflow_push) && !M.AirflowCanPush())
 			continue
 		//If they're already being tossed, don't do it again.
 		if(M.last_airflow > world.time - zas_settings.Get(/datum/ZAS_Setting/airflow_delay))


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl: (as the emoji)
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
This is how bustanuts originally worked:
```
if(ismob(src))
	var/mob/living/L = src
	world << "BUSTANUT"
	if(L.reagents.has_reagent("bustanut"))
		world << "has dem nuts"
		return 1
```
This is how they later worked:
```
/mob/AirflowCanPush()
	return M_HARDCORE in mutations
```

This is what they were later changed to (in June of 2014):
```
if (M_HARDCORE in mutations)
	return 0
return 1
```

That last one is the complete opposite of the first two - instead of acting when you have bustanuts or the M_HARDCORE mutation (which you have as long as you have bustanuts in you), it *does not* act if you have the M_HARDCORE mutation.
I've just flipped the 1 and 0 and assumed it'll be fine, I have no idea how ZAS is handled.

Closes #13803 

🆑 

- bugfix: Bustanuts no longer makes you immune to ZAS