### PR TITLE
Cyborg handcuffs are no longer reusable.

### DIFF
--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -83,6 +83,8 @@
 /obj/item/weapon/handcuffs/cyborg
 //This space intentionally left blank
 
+/obj/item/weapon/handcuffs/cyborg/on_remove(var/mob/living/carbon/C)
+	qdel(src)
 
 //Syndicate Cuffs. Disguised as regular cuffs, they are pretty explosive
 /obj/item/weapon/handcuffs/syndicate

--- a/html/changelogs/icantthinkofanameritenow.yml
+++ b/html/changelogs/icantthinkofanameritenow.yml
@@ -1,0 +1,6 @@
+author: Icantthinkofanameritenow
+
+delete-after: True
+
+changes: 
+- tweak: The cuffs applied by peacekeeper cyborgs now delete themselves on removal. 


### PR DESCRIPTION
Cyborg-applied handcuffs now delete themselves upon removal. Now greyshits can't pocket the cuffs that a peacekeeper borg used to arrest them with after being let out of the brig. 