### PR TITLE
Removes Happiest Mask from xenoarch finds

### DIFF
--- a/code/modules/research/xenoarchaeology/finds/finds.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds.dm
@@ -522,7 +522,8 @@
 			anomaly_factor = 4
 			apply_material_decorations = 0
 			var/list/possible_spawns = list()
-			possible_spawns += /obj/item/clothing/mask/happy
+			possible_spawns += /obj/item/clothing/mask/necklace/xeno_claw
+			//possible_spawns += /obj/item/clothing/mask/happy WHO THOUGHT THIS WAS A GOOD IDEA
 			//possible_spawns += /obj/item/clothing/mask/stone WHEN I CODE IT
 			var/new_type = pick(possible_spawns)
 			new_item = new new_type(src.loc)


### PR DESCRIPTION
closes #10581

In case you don't know; the Happiest Mask rips the souls out of anyone that dies (and even goes in crit?) nearby, and turnes them into shades with no way of returning to their bodies.

It's almost exclusively used by non-antags, half the time without them knowing what the fuck is going on. It's a nightmare for asimov.

Replaces the mask with xeno claw necklace. 
You can still get a Happiest Mask from the Tomb away mission. 



🆑 
- The Happiest Mask can no longer be found on the roid.