### PR TITLE
Increased Mednano/Combatnano recipe yield. Removed Odysseus being able to analyze nanites and its children. Buffed Cyber Horrors slightly.

### DIFF
--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -629,10 +629,8 @@
 		if(R.reagent_state == 2 && add_known_reagent(R.id,R.name))
 			occupant_message("Reagent analyzed, identified as [R.name] and added to database.")
 			send_byjax(chassis.occupant,"msyringegun.browser","reagents_form",get_reagents_form())
-			occupant_message("Analyzis complete.")
-		else
-			occupant_message("<span class='warning'>ERROR: Can't analyze reagent or the reagent is already in the database.</span>")
-		return 1
+	occupant_message("Analyzis complete.")
+	return 1
 
 /obj/item/mecha_parts/mecha_equipment/tool/syringe_gun/proc/add_known_reagent(r_id,r_name)
 	set_ready_state(0)

--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -629,8 +629,10 @@
 		if(R.reagent_state == 2 && add_known_reagent(R.id,R.name))
 			occupant_message("Reagent analyzed, identified as [R.name] and added to database.")
 			send_byjax(chassis.occupant,"msyringegun.browser","reagents_form",get_reagents_form())
-	occupant_message("Analyzis complete.")
-	return 1
+			occupant_message("Analyzis complete.")
+		else
+			occupant_message("<span class='warning'>ERROR: Can't analyze reagent or the reagent is already in the database.</span>")
+		return 1
 
 /obj/item/mecha_parts/mecha_equipment/tool/syringe_gun/proc/add_known_reagent(r_id,r_name)
 	set_ready_state(0)

--- a/code/modules/mob/living/simple_animal/hostile/monster.dm
+++ b/code/modules/mob/living/simple_animal/hostile/monster.dm
@@ -75,8 +75,8 @@
 	speak_chance = 20
 	turns_per_move = 5
 	see_in_dark = 6
-	maxHealth = 150
-	health = 150
+	maxHealth = 175
+	health = 175
 	melee_damage_lower = 5
 	melee_damage_upper = 15
 	attacktext = "flails around and hits"
@@ -91,7 +91,7 @@
 	..()
 
 	if(prob(90) && health+emp_damage<maxHealth)
-		health+=4                                                                        //Created by misuse of medical nanobots, so it heals
+		health+=6                                                                        //Created by misuse of medical nanobots, so it heals
 		if(prob(15))
 			visible_message("<span class='warning'>[src]'s wounds heal slightly!</span>")
 

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -2501,7 +2501,7 @@
 	name = "Nanites"
 	id = NANITES
 	description = "Microscopic construction robots."
-	reagent_state = LIQUID
+	reagent_state = SOLID
 	color = "#535E66" //rgb: 83, 94, 102
 	var/diseasetype = /datum/disease/robotic_transformation
 /datum/reagent/nanites/reaction_mob(var/mob/living/M, var/method = TOUCH, var/volume)
@@ -2536,7 +2536,7 @@
 	name = "Nanobots"
 	id = NANOBOTS
 	description = "Microscopic robots intended for use in humans. Must be loaded with further chemicals to be useful."
-	reagent_state = LIQUID
+	reagent_state = SOLID
 	color = "#3E3959" //rgb: 62, 57, 89
 
 
@@ -2546,7 +2546,7 @@
 	name = "Medical Nanobots"
 	id = MEDNANOBOTS
 	description = "Microscopic robots intended for use in humans. Configured for rapid healing upon infiltration into the body."
-	reagent_state = LIQUID
+	reagent_state = SOLID
 	color = "#593948" //rgb: 89, 57, 72
 	custom_metabolism = 0.005
 	var/spawning_horror = 0
@@ -2694,7 +2694,7 @@
 	name = "Combat Nanobots"
 	id = COMNANOBOTS
 	description = "Microscopic robots intended for use in humans. Configured to grant great resistance to damage."
-	reagent_state = LIQUID
+	reagent_state = SOLID
 	color = "#343F42" //rgb: 52, 63, 66
 	custom_metabolism = 0.01
 	var/has_been_armstrong = 0

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -728,7 +728,7 @@
 	name = "Nanobots2"
 	id = "nanobots2"
 	result = NANOBOTS
-	required_reagents = list(MEDNANOBOTS = 1, CRYOXADONE = 2)
+	required_reagents = list(MEDNANOBOTS = 2.5, CRYOXADONE = 2) //2.5 here since otherwise you could just dupe again with this return recipe.
 	result_amount = 1
 
 /datum/chemical_reaction/mednanobots
@@ -736,14 +736,14 @@
 	id = MEDNANOBOTS
 	result = MEDNANOBOTS
 	required_reagents = list(NANOBOTS = 1, DOCTORSDELIGHT = 5)
-	result_amount = 1
+	result_amount = 2.5
 
 /datum/chemical_reaction/comnanobots
 	name = "Combat Nanobots"
 	id = COMNANOBOTS
 	result = COMNANOBOTS
 	required_reagents = list(NANOBOTS = 1, MUTAGEN = 5, SILICATE = 5, IRON = 10)
-	result_amount = 1
+	result_amount = 2.5
 
 ///////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
This PR is related to this one #12987  simply because I got ideas from the old PR and this PR is more or less used to complement the other one.
---
Mednano/combatnano recipe yield increased to make it worthwhile doing the recipe. You will now get a maximum of 10 med/combatnanos from one roburger.
10 might feel like a very low amount but with my other PR hopefully getting merged it would mean the chem is much stronger and more reliable so even with a minor increase in yield it will be good I believe.

Cyber Horrors buffed slightly because of a discussion in the old PR. They felt weak and were downed very quickly to anyone with a weapon. I hope this change will make them more dangerous.

Odysseus cannot analyze nanites and its children anymore because otherwise the recipe would still be pointless. 
This PR used to add an error message to incompatible scans but Shadowmech has done it better in a different PR so I reverted it.
:cl:
 * rscadd: Increased the yield on the mednano and combatnano recipe
 * rscadd: Buffed Cyber horror health and regen slightly
 * rscadd: Added an error message when trying to analyze a reagent the Odysseus can't
 * rscdel: Odysseus can no longer analyze nanites and its children


