### PR TITLE
Restores hardcore feature that was accidentally casualized in unrelated code refactor part two 'tis the season

### DIFF
--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -198,16 +198,22 @@
 			"<span class='notice'>You place \a [WD] on \the [src].</span>")
 		return
 
+	var/dam = 0
 	if(istype(W, /obj/item/weapon/fireaxe)) //Fireaxes instantly kill grilles
-		health = 0
-		healthcheck()
+		dam = health
+	else if(istype(W, /obj/item/weapon/shard))
+		dam = W.force * 0.1 //Turns the base shard into a .5 damage item. If you want to break an electrified grille with that, you're going to EARN IT, ROD. BY. ROD.
+	else
+		switch(W.damtype)
+			if("fire")
+				dam = W.force //Fire-based tools like welding tools are ideal to work through small metal rods !
+			if("brute")
+				dam = W.force * 0.5 //Rod matrices have an innate resistance to brute damage
 
-	switch(W.damtype)
-		if("fire")
-			health -= W.force //Fire-based tools like welding tools are ideal to work through small metal rods !
-		if("brute")
-			health -= W.force * 0.5 //Rod matrices have an innate resistance to brute damage
-	shock(user, 100 * W.siemens_coefficient) //Chance of getting shocked is proportional to conductivity
+	if(!(W.sharpness_flags & INSULATED_EDGE))
+		shock(user, 100 * W.siemens_coefficient) //Chance of getting shocked is proportional to conductivity
+
+	health -= dam
 	healthcheck(hitsound = 1)
 	..()
 	return


### PR DESCRIPTION
Glass shards used to be the only things that could attack shocked grilles without shocking you, but they had a special check that made them only do 0.5 damage, so it would take forever to go through a grille.
Comic worked on conductivity and accidentally removed the part that made the shards do less damage.
The end result was that now, shocked grilles are a joke because you can go through them in 3 seconds flat with a shard.
And that's terrible.

Also, makes weapons with insulated edges (currently spears and energy swords) able to attack grilles without shocking you, because that makes sense.

:cl:
 * rscadd: Re-added the long-gone check that made glass shards do less damage to grilles.
 * tweak: Since glass shards are nonconductive, glass shard spears will not shock you when attacking a shocked grille, because that makes sense. Same thing for energy swords.
