### PR TITLE
Non-infectious facehuggers are no longer acidproof

### DIFF
--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -369,4 +369,4 @@ var/const/MAX_ACTIVE_TIME = 400
 	return 1
 
 /obj/item/clothing/mask/facehugger/acidable()
-	return 0
+	return sterile


### PR DESCRIPTION
Facehuggers were made acidproof to avoid having actual alien victims have their huggers melted off before they could be implanted.
Sterile facehuggers can now be melted by acid.