### PR TITLE
Undupeable Reagents

### DIFF
--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -625,12 +625,18 @@
 		occupant_message("<span class=\"alert\">No reagent info gained from [A].</span>")
 		return 0
 	occupant_message("Analyzing reagents...")
+	var/any_success = FALSE
 	for(var/datum/reagent/R in A.reagents.reagent_list)
-		if(R.reagent_state == 2 && add_known_reagent(R.id,R.name))
-			occupant_message("Reagent analyzed, identified as [R.name] and added to database.")
-			send_byjax(chassis.occupant,"msyringegun.browser","reagents_form",get_reagents_form())
-	occupant_message("Analyzis complete.")
-	return 1
+		if(R.dupeable)
+			if(R.reagent_state == 2 && add_known_reagent(R.id,R.name))
+				occupant_message("Reagent analyzed, identified as [R.name] and added to database.")
+				send_byjax(chassis.occupant,"msyringegun.browser","reagents_form",get_reagents_form())
+				any_success = TRUE
+		else
+			occupant_message("<span class=\"alert\">Analysis of [R.name] failed, unit not equipped for synthesis of this reagent.</span>")
+	if(any_success)
+		occupant_message("Analyzis complete.")
+		return 1
 
 /obj/item/mecha_parts/mecha_equipment/tool/syringe_gun/proc/add_known_reagent(r_id,r_name)
 	set_ready_state(0)

--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -632,10 +632,10 @@
 				occupant_message("Reagent analyzed, identified as [R.name] and added to database.")
 				send_byjax(chassis.occupant,"msyringegun.browser","reagents_form",get_reagents_form())
 				any_success = TRUE
-		else
-			occupant_message("<span class=\"alert\">Analysis of [R.name] failed, unit not equipped for synthesis of this reagent.</span>")
+				continue
+		occupant_message("<span class=\"alert\">Analysis of [R.name] failed, unit not equipped for synthesis of this reagent.</span>")
 	if(any_success)
-		occupant_message("Analyzis complete.")
+		occupant_message("Analysis complete.")
 		return 1
 
 /obj/item/mecha_parts/mecha_equipment/tool/syringe_gun/proc/add_known_reagent(r_id,r_name)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1620,6 +1620,7 @@
 	description = "The properties of this rare metal are not well-known."
 	reagent_state = SOLID
 	color = "#5E02F8" //rgb: 94, 2, 248
+	dupeable = FALSE
 
 /datum/reagent/phazon/on_mob_life(var/mob/living/M)
 	if(..())

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -29,6 +29,7 @@
 	//var/list/viruses = list()
 	var/color = "#000000" //rgb: 0, 0, 0 (does not support alpha channels - yet!)
 	var/alpha = 255
+	var/dupeable = TRUE	//whether the reagent can be duplicated by standard reagent duplication methods such as a service borg shaker or odysseus
 
 /datum/reagent/proc/reaction_mob(var/mob/living/M, var/method = TOUCH, var/volume)
 	set waitfor = 0

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -212,12 +212,13 @@
 	// Attempt to transfer from our glass
 	var/refill_id = reagents.get_master_reagent_id()
 	var/refill_name = reagents.get_master_reagent_name()
+	var/datum/reagent/R = reagents.get_reagent(refill_id)
 
 	var/sent_amount = transfer(target, user, can_send = TRUE, can_receive = FALSE)
 
 	// Service borgs regenerate the amount transferred after a while
 	// TODO Why doesn't the borg module handle this nonsense?
-	if (sent_amount > 0 && isrobot(user))
+	if (sent_amount > 0 && isrobot(user) && R.dupeable)
 		var/mob/living/silicon/robot/borg = user
 		if (!istype(borg.module, /obj/item/weapon/robot_module/butler) || !borg.cell)
 			return


### PR DESCRIPTION
Adds a var to reagents that can be set in order to prevent the reagent from being duplicated by standard reagent duplication means such as the oddyseus syringe gun and service borg shakers.
Makes the phazon reagent undupeable.