### PR TITLE
Configurable smartfridge boards

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -685,6 +685,33 @@ obj/item/weapon/circuitboard/rdserver
 							"/obj/item/weapon/stock_parts/scanning_module" = 1,
 							"/obj/item/weapon/stock_parts/console_screen" = 2)
 
+
+
+/obj/item/weapon/circuitboard/smartfridge/attackby(var/obj/item/weapon/G, var/mob/user)
+	if(issolder(G))
+		var/obj/item/weapon/solder/S = G
+		var/list/static/smartfridge_choices = list("Food smartfridge" = /obj/item/weapon/circuitboard/smartfridge/,
+											"Secure chemistry smartfridge" = /obj/item/weapon/circuitboard/smartfridge/medbay,
+											"Chemistry smartfridge" = /obj/item/weapon/circuitboard/smartfridge/chemistry,
+											"Slime extract smartfridge" = /obj/item/weapon/circuitboard/smartfridge/extract,
+											"Seed smartfridge" = /obj/item/weapon/circuitboard/smartfridge/seeds,
+											"Drinks smartfridge" = /obj/item/weapon/circuitboard/smartfridge/drinks,)
+
+		var/choice = input(usr, "Which configuration would you like to set this board?", "According to the manual, if I disconnect this node, and connect this node...") in smartfridge_choices
+		if(choice)
+			var/to_spawn = smartfridge_choices[choice]
+			if(istype(src, to_spawn))
+				to_chat(user, "<span class = 'notice'>This board is already this type</span>")
+				return
+			if(do_after(user, src, 25))
+				if(S.remove_fuel(1,user))
+					playsound(user.loc, 'sound/items/Welder.ogg', 25, 1)
+					visible_message("<span class = 'notice'>\The [user] refashions \the [src] into \the [choice]</span>")
+					new to_spawn(get_turf(src))
+					qdel(src)
+					return
+
+	..()
 /obj/item/weapon/circuitboard/smartfridge/medbay
 	name = "Circuit Board (Medbay SmartFridge)"
 	build_path = "/obj/machinery/smartfridge/secure/medbay"

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -690,27 +690,28 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/smartfridge/attackby(var/obj/item/weapon/G, var/mob/user)
 	if(issolder(G))
 		var/obj/item/weapon/solder/S = G
-		var/list/static/smartfridge_choices = list("Food smartfridge" = /obj/item/weapon/circuitboard/smartfridge/,
-											"Secure chemistry smartfridge" = /obj/item/weapon/circuitboard/smartfridge/medbay,
-											"Chemistry smartfridge" = /obj/item/weapon/circuitboard/smartfridge/chemistry,
-											"Slime extract smartfridge" = /obj/item/weapon/circuitboard/smartfridge/extract,
-											"Seed smartfridge" = /obj/item/weapon/circuitboard/smartfridge/seeds,
-											"Drinks smartfridge" = /obj/item/weapon/circuitboard/smartfridge/drinks,)
+		var/list/static/smartfridge_choices = list(
+			"Food smartfridge" = /obj/item/weapon/circuitboard/smartfridge/,
+			"Secure chemistry smartfridge" = /obj/item/weapon/circuitboard/smartfridge/medbay,
+			"Chemistry smartfridge" = /obj/item/weapon/circuitboard/smartfridge/chemistry,
+			"Slime extract smartfridge" = /obj/item/weapon/circuitboard/smartfridge/extract,
+			"Seed smartfridge" = /obj/item/weapon/circuitboard/smartfridge/seeds,
+			"Drinks smartfridge" = /obj/item/weapon/circuitboard/smartfridge/drinks,
+		)
 
 		var/choice = input(usr, "Which configuration would you like to set this board?", "According to the manual, if I disconnect this node, and connect this node...") in smartfridge_choices
 		if(choice)
-			var/to_spawn = smartfridge_choices[choice]
+			var/obj/item/weapon/circuitboard/smartfridge/to_spawn = smartfridge_choices[choice]
 			if(istype(src, to_spawn))
 				to_chat(user, "<span class = 'notice'>This board is already this type</span>")
 				return
 			if(do_after(user, src, 25))
 				if(S.remove_fuel(1,user))
 					playsound(user.loc, 'sound/items/Welder.ogg', 25, 1)
-					visible_message("<span class = 'notice'>\The [user] refashions \the [src] into \the [choice]</span>")
-					new to_spawn(get_turf(src))
-					qdel(src)
+					visible_message("<span class = 'notice'>\The [user] refashions \the [src] into \the [to_spawn]</span>")
+					build_path = initial(to_spawn.build_path)
+					name = initial(to_spawn.name)
 					return
-
 	..()
 /obj/item/weapon/circuitboard/smartfridge/medbay
 	name = "Circuit Board (Medbay SmartFridge)"


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl: (as the emoji)
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
fixes #13925
fixes #10213
fixes #8055
fixes #7784

![smartfriiidge](https://cloud.githubusercontent.com/assets/9110500/22858520/f74e48ea-f0b7-11e6-8eec-08a2348fb028.PNG)



:cl:
* rscadd: Smartfridge boards can now be reconfigured using a soldering iron into its different types. This includes the chemistry smartfridge