### PR TITLE
Disappearing Borg Cuffs Except It Works Now

### DIFF
--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -75,7 +75,7 @@
 
 		var/obj/item/weapon/handcuffs/cuffs = src
 		if(istype(src, /obj/item/weapon/handcuffs/cyborg)) //There's GOT to be a better way to check for this.
-			cuffs = new(get_turf(user))
+			cuffs = new /obj/item/weapon/handcuffs/cyborg(get_turf(user))
 		else
 			user.drop_from_inventory(cuffs)
 		C.equip_to_slot(cuffs, slot_handcuffed)
@@ -83,6 +83,9 @@
 /obj/item/weapon/handcuffs/cyborg
 //This space intentionally left blank
 
+/obj/item/weapon/handcuffs/cyborg/on_remove(var/mob/living/carbon/C)
+	spawn(1)
+		qdel(src)
 
 //Syndicate Cuffs. Disguised as regular cuffs, they are pretty explosive
 /obj/item/weapon/handcuffs/syndicate


### PR DESCRIPTION
Re-adds #13880 except the handcuffs can actually be removed from people.

Tested by spawning in as a borg, choosing the peacekeeper module, cuffing a human, and then successfully uncuffing them.

:cl:
 * rscadd: Cyborg cuffs now disappear when removed.
