### PR TITLE
Replaces Happiest Mask With Morphing Mask and Amorphous Mask in Xenoarch Finds

### DIFF
--- a/code/modules/research/xenoarchaeology/finds/finds.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds.dm
@@ -522,7 +522,9 @@
 			anomaly_factor = 4
 			apply_material_decorations = 0
 			var/list/possible_spawns = list()
-			possible_spawns += /obj/item/clothing/mask/happy
+			possible_spawns += /obj/item/clothing/mask/morphing
+			possible_spawns += /obj/item/clothing/mask/morphing/amorphous
+			//possible_spawns += /obj/item/clothing/mask/happy PENDING REWORK
 			//possible_spawns += /obj/item/clothing/mask/stone WHEN I CODE IT
 			var/new_type = pick(possible_spawns)
 			new_item = new new_type(src.loc)


### PR DESCRIPTION
I plan to re-add the happiest mask after I re-work it to make it not terrible.
Fixes #10581

:cl:
 * rscadd: The morphing mask and amorphous mask can now be found as small Xenoarch artifacts.
 * rscdel: The happiest mask can no longer be found as a small Xenoarch artifact..
