### PR TITLE
New Artifact Effect: Menagerie

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -72,6 +72,9 @@
 	if(transmogged_from)
 		qdel(transmogged_from)
 		transmogged_from = null
+	if(transmogged_to)
+		qdel(transmogged_to)
+		transmogged_to = null
 
 	..()
 
@@ -1851,16 +1854,20 @@ mob/proc/on_foot()
 				var/mob/living/carbon/C = transmogged_from
 				if(istype(C.get_item_by_slot(slot_wear_mask), /obj/item/clothing/mask/morphing))
 					C.drop_item(C.wear_mask, force_drop = 1)
+			var/mob/returned_mob = transmogged_from
+			returned_mob.transmogged_to = null
 			transmogged_from = null
 			for(var/atom/movable/AM in contents)
 				AM.forceMove(get_turf(src))
 			qdel(src)
+			return returned_mob
 		return
 	if(!ispath(target_type, /mob))
 		EXCEPTION(target_type)
 		return
 	var/mob/M = new target_type(loc)
 	M.transmogged_from = src
+	transmogged_to = M
 	if(key)
 		M.key = key
 	if(offer_revert_spell)
@@ -1868,6 +1875,7 @@ mob/proc/on_foot()
 		M.add_spell(change_back)
 	src.forceMove(null)
 	timestopped = 1
+	return M
 
 /spell/aoe_turf/revert_form
 	name = "Revert Form"

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -285,6 +285,7 @@
 	var/see_invisible_override = 0
 
 	var/mob/transmogged_from	//holds a reference to the mob that this mob used to be before being transmogrified
+	var/mob/transmogged_to		//holds a reference to the mob which holds a reference to this mob in its transmogged_from var
 
 /mob/resetVariables()
 	..("callOnFace", "pinned", "embedded", "abilities", "grabbed_by", "requests", "mapobjs", "mutations", "spell_list", "viruses", "resistances", "radar_blips", "active_genes", "attack_log", "speak_emote", args)

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_menagerie.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_menagerie.dm
@@ -19,7 +19,8 @@
 				var/turf/T = get_turf(new_mob)
 				if(T)
 					playsound(T, 'sound/effects/phasein.ogg', 50, 1)
-				spawn(5 MINUTES)
+				var/transmog_time = rand(1 MINUTES, 5 MINUTES)
+				spawn(transmog_time)
 					var/mob/top_level = new_mob
 					if(top_level.transmogged_to)
 						while(top_level.transmogged_to)

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_menagerie.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_menagerie.dm
@@ -14,12 +14,16 @@
 			if(istype(M, /mob/living/silicon))
 				continue
 			if(!M.transmogged_from)
+				var/multiplier = GetAnomalySusceptibility(M)
+				if(multiplier == 0)
+					continue
 				var/target_type = pick(possible_types)
 				var/mob/new_mob = M.transmogrify(target_type)
 				var/turf/T = get_turf(new_mob)
 				if(T)
 					playsound(T, 'sound/effects/phasein.ogg', 50, 1)
 				var/transmog_time = rand(1 MINUTES, 5 MINUTES)
+				transmog_time *= multiplier
 				spawn(transmog_time)
 					var/mob/top_level = new_mob
 					if(top_level.transmogged_to)

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_menagerie.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_menagerie.dm
@@ -1,0 +1,32 @@
+/datum/artifact_effect/menagerie
+	effecttype = "menagerie"
+	effect_type = 5
+	effect = EFFECT_PULSE
+	var/static/list/possible_types = list()
+
+/datum/artifact_effect/menagerie/New()
+	..()
+	possible_types = existing_typesof(/mob/living) - existing_typesof(/mob/living/silicon)
+
+/datum/artifact_effect/menagerie/DoEffectPulse()
+	if(holder)
+		for(var/mob/living/M in range(effectrange,holder))
+			if(istype(M, /mob/living/silicon))
+				continue
+			if(!M.transmogged_from)
+				var/target_type = pick(possible_types)
+				var/mob/new_mob = M.transmogrify(target_type)
+				var/turf/T = get_turf(new_mob)
+				if(T)
+					playsound(T, 'sound/effects/phasein.ogg', 50, 1)
+				spawn(5 MINUTES)
+					var/mob/top_level = new_mob
+					if(top_level.transmogged_to)
+						while(top_level.transmogged_to)
+							top_level = top_level.transmogged_to
+					var/turf/T2 = get_turf(top_level)
+					while(top_level)
+						top_level = top_level.transmogrify()
+					if(T2)
+						playsound(T2, 'sound/effects/phasein.ogg', 50, 1)
+			return 1

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -1915,6 +1915,7 @@
 #include "code\modules\research\xenoarchaeology\artifact\effects\unknown_effect_heal.dm"
 #include "code\modules\research\xenoarchaeology\artifact\effects\unknown_effect_heat.dm"
 #include "code\modules\research\xenoarchaeology\artifact\effects\unknown_effect_hurt.dm"
+#include "code\modules\research\xenoarchaeology\artifact\effects\unknown_effect_menagerie.dm"
 #include "code\modules\research\xenoarchaeology\artifact\effects\unknown_effect_planthelper.dm"
 #include "code\modules\research\xenoarchaeology\artifact\effects\unknown_effect_plantkiller.dm"
 #include "code\modules\research\xenoarchaeology\artifact\effects\unknown_effect_projectiles.dm"


### PR DESCRIPTION
The menagerie artifact effect causes all non-silicon mobs within the artifact's pulse range to be transmogrified into a random non-silicon mob for a random length of time between 1 and 5 minutes.
Already-transmogrified mobs are not affected by the pulses, so no nesting transformations with the artifact.

:cl:
 * rscadd: Added a new artifact effect which transforms nearby mobs into a different mob for a random length of time between 1 and 5 minutes when it pulses.
