### PR TITLE
Fixes internals.dm runtime

### DIFF
--- a/code/modules/mob/living/carbon/internals.dm
+++ b/code/modules/mob/living/carbon/internals.dm
@@ -55,8 +55,6 @@
 					to_chat(user, "<span class='warning'>\The [src] does not have \an [breathes] tank.</span>")
 				else
 					to_chat(user, "<span class='warning'>You don't have \an [breathes] tank.</span>")
-		internal = T
-		T.add_fingerprint(user)
 		if(internals)
 			internals.icon_state = "internal1"
 		if(user != src)


### PR DESCRIPTION
`DEBUG: Runtime in internals.dm, line 59: Cannot execute null.add fingerprint(). [view]`

Not only was this runtiming, it was redundant code because it was already stated before

`	if(internal)
		internal.add_fingerprint(user)`

Note that internal and internals are 2 different variables. Internals with **s** is the hud variable.