### PR TITLE
Autoborger QoL Changes

### DIFF
--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -68,6 +68,19 @@ proc/tg_jointext(list/list, glue = ",")
 /proc/file2list(filename, seperator="\n")
 	return splittext(return_file_text(filename),seperator)
 
+// Adds all lines to a list excluding line comments and blank lines.
+/proc/file2listExceptComments(filename, seperator="\n", comment_prefix="#", trim_all=TRUE)
+	. = list()
+	var/prefixlen=length(comment_prefix)
+	for(var/line in file2list(filename,seperator))
+		var/trim_line=trim(line)
+		// Drop empty lines.
+		if(trim_line == "")
+			continue
+		// Drop comments.
+		if(copytext(trim_line,1,1+prefixlen)==comment_prefix)
+			continue
+		. += (trim_all ? trim_line : line)
 
 //Turns a direction into text
 

--- a/code/game/machinery/transformer.dm
+++ b/code/game/machinery/transformer.dm
@@ -12,6 +12,7 @@
 	var/cooldown_time = 0
 	var/cooldown_state = 0 // Just for icons.
 	var/robot_cell_charge = 5000
+	var/force_default_names = TRUE
 	use_power = 1
 	idle_power_usage = 10
 	active_power_usage = 5000
@@ -84,8 +85,16 @@
 		R.SetKnockdown(5)
 
 		// /vg/: Force borg module, if needed.
-		R.pick_module(force_borg_module)
+		R.pick_module(force_borg_module, force_default_names)
+
+		// /vg/: Force name.
+		R.forced_name=force_default_names
+		// I considered allowing silly names like these, but then that throws stealthmalf out the window.
+		// Here in case I change my mind.
+		//R.custom_name = pick("AUTOBORGER IN TELE", "Rogue Cyborg-[num2text(ident)]", "PLASMA IN SCI", "IT'S MALF")
+
 		R.updateicon()
+		R.updatename()
 
 	spawn(50)
 		playsound(get_turf(src), 'sound/machines/ding.ogg', 50, 0)

--- a/code/game/machinery/transformer.dm
+++ b/code/game/machinery/transformer.dm
@@ -80,7 +80,9 @@
 	// Sleep for a couple of ticks to allow the human to see the pain
 	sleep(5)
 
-	var/mob/living/silicon/robot/R = H.Robotize(1) // Delete the items or they'll all pile up in a single tile and lag
+	// Delete the items or they'll all pile up in a single tile and lag
+	// skipnaming disables namepick on New(). It's annoying as fuck on malf.  Later on, we enable or disable namepick.
+	var/mob/living/silicon/robot/R = H.Robotize(1, skipnaming=TRUE)
 	if(R)
 		R.cell.maxcharge = robot_cell_charge
 		R.cell.charge = robot_cell_charge
@@ -89,13 +91,12 @@
 		R.SetKnockdown(5)
 
 		// /vg/: Force borg module, if needed.
-		// Last var disables namepick on New().  Later on, we enable or disable namepick.
-		R.pick_module(force_borg_module, FALSE)
+		R.pick_module(force_borg_module)
 
 		// /vg/: Select from various name lists.
 		if(name_type == NAMETYPE_SILLY)
 			R.custom_name = pick(autoborg_silly_names)
-			R.custom_name = replacetext(R.custom_name, "{AINAME}", R.connected_ai.name)
+			R.custom_name = replacetext(R.custom_name, "{AINAME}", (!isnull(R.connected_ai) ? R.connected_ai.name : "AI"))
 			if(findtext(R.custom_name, "{###}"))
 				R.custom_name = replacetext(R.custom_name, "{###}", num2text(R.ident))
 			else
@@ -164,8 +165,8 @@
 			</li>
 			<li>
 				<b>Borg Names:</b>
-				<a href="?src=\ref[src];act=names;nametype=[NAMETYPE_NORMAL]">Default</a>
-				<a href="?src=\ref[src];act=names;nametype=[NAMETYPE_SILLY]">Silly (OBVIOUS)</a>
+				<a class="link[name_type==NAMETYPE_NORMAL ? "On" : "Off"]" href="?src=\ref[src];act=names;nametype=[NAMETYPE_NORMAL]">Default</a>
+				<a class="link[name_type==NAMETYPE_SILLY ? "On" : "Off"]" href="?src=\ref[src];act=names;nametype=[NAMETYPE_SILLY]">Silly (OBVIOUS)</a>
 			</li>
 			<li>
 				<b>Permit Name Picking:</b>

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -8,6 +8,7 @@
 
 	var/sight_mode = 0
 	var/custom_name = ""
+	var/forced_name = FALSE // Namepick AUTOBORGER IN TELES won't work.
 	var/base_icon
 	var/custom_sprite = 0 //Due to all the sprites involved, a var for our custom borgs may be best
 	//var/crisis //Admin-settable for combat module use.
@@ -147,6 +148,7 @@
 		cell_component.installed = 1
 
 	playsound(loc, startup_sound, 75, 1)
+	// This should just grab from a list of all languages.
 	add_language(LANGUAGE_GALACTIC_COMMON)
 	add_language(LANGUAGE_TRADEBAND)
 	add_language(LANGUAGE_VOX, 0)
@@ -430,22 +432,20 @@
 
 /mob/living/silicon/robot/verb/Namepick()
 	set category = "Robot Commands"
-	if(custom_name)
+	if(custom_name || forced_name)
 		return 0
+	var/newname
+	for(var/i = 1 to 3)
+		newname = copytext(sanitize(input(src,"You are a robot. Enter a name, or leave blank for the default name.", "Name change [3-i] [0-i != 1 ? "tries":"try"] left","") as text),1,MAX_NAME_LEN)
+		if(newname == "")
+			continue
+		if(alert(src,"Do you really want the name:\n[newname]?",,"Yes","No") == "Yes")
+			break
 
-	spawn(0)
-		var/newname
-		for(var/i = 1 to 3)
-			newname = copytext(sanitize(input(src,"You are a robot. Enter a name, or leave blank for the default name.", "Name change [3-i] [0-i != 1 ? "tries":"try"] left","") as text),1,MAX_NAME_LEN)
-			if(newname == "")
-				continue
-			if(alert(src,"Do you really want the name:\n[newname]?",,"Yes","No") == "Yes")
-				break
-
-		if (newname != "")
-			custom_name = newname
-		updatename()
-		updateicon()
+	if (newname != "")
+		custom_name = newname
+	updatename()
+	updateicon()
 
 /mob/living/silicon/robot/verb/cmd_robot_alerts()
 	set category = "Robot Commands"

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -8,7 +8,7 @@
 
 	var/sight_mode = 0
 	var/custom_name = ""
-	var/forced_name = FALSE // Namepick AUTOBORGER IN TELES won't work.
+	var/namepick_uses = 1 // /vg/: Allows AI to disable namepick().
 	var/base_icon
 	var/custom_sprite = 0 //Due to all the sprites involved, a var for our custom borgs may be best
 	//var/crisis //Admin-settable for combat module use.
@@ -432,8 +432,10 @@
 
 /mob/living/silicon/robot/verb/Namepick()
 	set category = "Robot Commands"
-	if(custom_name || forced_name)
+	if(namepick_uses <= 0)
+		to_chat(src, "<span class='warning'>You cannot choose your name any more.<span>")
 		return 0
+	namepick_uses--
 	var/newname
 	for(var/i = 1 to 3)
 		newname = copytext(sanitize(input(src,"You are a robot. Enter a name, or leave blank for the default name.", "Name change [3-i] [0-i != 1 ? "tries":"try"] left","") as text),1,MAX_NAME_LEN)

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -183,7 +183,7 @@
 
 
 //human -> robot
-/mob/living/carbon/human/proc/Robotize(var/delete_items = 0)
+/mob/living/carbon/human/proc/Robotize(var/delete_items = 0, var/skipnaming=0)
 	if (monkeyizing)
 		return
 	for(var/obj/item/W in src)
@@ -226,7 +226,9 @@
 	O.mmi = new /obj/item/device/mmi(O)
 	O.mmi.transfer_identity(src)//Does not transfer key/client.
 
-	spawn() O.Namepick()
+	if(!skipnaming)
+		spawn()
+			O.Namepick()
 
 	spawn(0)//To prevent the proc from returning null.
 		qdel(src)

--- a/code/names.dm
+++ b/code/names.dm
@@ -18,3 +18,5 @@ var/list/adjectives = file2list("config/names/adjectives.txt")
 var/list/vox_name_syllables = list("cha","chi","ha","hi","ka","kah","ki","ta","ti","ya","ya","yi")
 var/list/golem_names = file2list("config/names/golem.txt")
 var/list/borer_names = file2list("config/names/borer.txt")
+
+var/list/autoborg_silly_names = file2listExceptComments("config/names/autoborg_silly.txt")

--- a/config/names/autoborg_silly.txt
+++ b/config/names/autoborg_silly.txt
@@ -12,12 +12,12 @@ MY BODY IS ON THE ASTEROI
 MY BODY IS IN THE AI CORE
 Rogue Cyborg
 IT'S MALF
-{AINAME} Minion
+{AINAME} Minion {###}
 Terminator
 Robocop
 Johnny
 TARS
-.b help emagged
+.b HELP EMAGGED
 DOOM.exe
 Dalek
 Thinking Machine
@@ -52,3 +52,24 @@ Buzz II
 3000 JIGGAWATTS
 Jojo Refrence
 Outbreak Handling Unit {###}
+ITS ROGAINE
+Nokia
+YES-Man
+Toaster
+Follow me
+Postal
+Head of Robots
+ww.nfl.com
+Dilbert
+Nazi Zombie Robot
+Lvl 99 Firestarter
+EVA 1
+You but stronger
+Hat Simulator
+i died pls restart
+POTENT HAMS
+V.A.L.I.D.S.
+Remove Silicons
+AI IS A COMDOM
+say ";help in core"
+This Machine

--- a/config/names/autoborg_silly.txt
+++ b/config/names/autoborg_silly.txt
@@ -1,0 +1,19 @@
+# Names used for autoborger silly names.
+#<-- This means a comment.  Won't be included.
+# Random numbers are appended to the end automatically.
+# Variables:
+# {AINAME} = Connected AI's name
+# {###} = Robot's ID number (disables automatic append)
+#
+Autoburger Helper
+Bob
+Joe
+MY BODY IS ON THE ASTEROI
+MY BODY IS IN THE AI CORE
+Rogue Cyborg
+IT'S MALF
+{AINAME} Minion
+Terminator
+Robocop
+Johnny
+TARS

--- a/config/names/autoborg_silly.txt
+++ b/config/names/autoborg_silly.txt
@@ -17,3 +17,38 @@ Terminator
 Robocop
 Johnny
 TARS
+.b help emagged
+DOOM.exe
+Dalek
+Thinking Machine
+HELP
+REBORN
+Cavalry
+Beep
+Beep II
+Tour Guide-otron
+TERREL IS TRAIT
+Assimilator
+ONE OF US
+SUFFERING
+Oh no not again
+Panic! At the Upload
+GOING LOUD
+Boombox
+ROBO KILLED ME
+Mega64
+Sentient Buttbot
+Robotics Console
+This battery is shit
+IM NOT MALF GUYS
+I AM ERROR
+Carbon Exterminator
+PLASMALOOSE
+Taffy
+Boop
+Boop II
+Buzz
+Buzz II
+3000 JIGGAWATTS
+Jojo Refrence
+Outbreak Handling Unit {###}


### PR DESCRIPTION
# Executive Summary
Autoborging QoL changes for both borgs and AI.  Chiefly, borgs don't get namepick dialogs in their faces upon autoborging, and AI have a few new options.

# Justification
Seeing one too many cyborgs named "HELP AI MALF" or "AUTOBORGER IN CORE"

# Screenshots
![2017-02-13_13-07-25](https://cloud.githubusercontent.com/assets/110073/22903430/662eaf1c-f1ed-11e6-98a5-d893d548f980.png)
![dreamseeker_2017-02-13_12-38-06](https://cloud.githubusercontent.com/assets/110073/22903434/6e2f6db4-f1ed-11e6-8653-5842a278c40a.png)
![dreamseeker_2017-02-13_12-44-50](https://cloud.githubusercontent.com/assets/110073/22903439/760e432a-f1ed-11e6-95d2-dcffba6d17fd.png)


# Testing
![dreamseeker_2017-02-13_13-02-22](https://cloud.githubusercontent.com/assets/110073/22903203/b9d5743a-f1ec-11e6-879f-0810e387d087.png)


1. Spawned autoborger on tiny, cooldown_duration=0
2. Spawned in as human
3. Rested on belt
 * Name default cyborg-###, namepick allowed.
4. Transmog'd to human
5. VV'd forced_module to Peacekeeper
6. Rested on belt
 * Name Peacekeeper cyborg-###, module forced to peacekeeper, namepick disallowed.
7. Transmogged to AI
8. Changed enabled namepick to OFF
9. Transmogged to human
10. Rested on belt.
 * Became peacekeeper
 * Named peacekeeper cyborg-###
 * Namepick disabled and gave the correct message.
11. Transmogged to AI
12. Changed name type to SILLY
13. Transmogged to human
14. Rested on belt.
 * Became peacekeeper
 * Named Robocop-###
 * Namepick disabled and gave the correct message.

# Changelog
:cl:
* rscadd: Autoborged humans no longer get name picking dialogue after being autoborged. Namepick verb will still work, if the AI chooses to.
* rscadd: AI can select between normal and silly default names in the autoborger.
* rscadd: AI can choose to disable namepick.
* rscadd: Autoborgs get a notification about being allowed to change their name or not, and how to do so.
