### PR TITLE
Kick act for chemistry dispensers and chem masters

### DIFF
--- a/code/modules/reagents/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/machinery/chem_dispenser.dm
@@ -237,6 +237,7 @@ USE THIS CHEMISTRY DISPENSER FOR MAPS SO THEY START AT 100 ENERGY
 	return 1 // update UIs attached to this object
 
 /obj/machinery/chem_dispenser/kick_act(mob/living/H)
+	..()
 	if(container)
 		detach()
 

--- a/code/modules/reagents/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/machinery/chem_dispenser.dm
@@ -236,6 +236,10 @@ USE THIS CHEMISTRY DISPENSER FOR MAPS SO THEY START AT 100 ENERGY
 	add_fingerprint(usr)
 	return 1 // update UIs attached to this object
 
+/obj/machinery/chem_dispenser/kick_act(mob/living/H)
+	if(container)
+		detach()
+
 /obj/machinery/chem_dispenser/proc/detach()
 	targetMoveKey=null
 

--- a/code/modules/reagents/machinery/chem_master.dm
+++ b/code/modules/reagents/machinery/chem_master.dm
@@ -581,6 +581,7 @@ var/global/list/pillIcon2Name = list("oblong purple-pink", "oblong green-white",
 		return 0
 
 /obj/machinery/chem_master/kick_act(mob/living/H)
+	..()
 	if(beaker)
 		detach()
 

--- a/code/modules/reagents/machinery/chem_master.dm
+++ b/code/modules/reagents/machinery/chem_master.dm
@@ -580,6 +580,10 @@ var/global/list/pillIcon2Name = list("oblong purple-pink", "oblong green-white",
 	else
 		return 0
 
+/obj/machinery/chem_master/kick_act(mob/living/H)
+	if(beaker)
+		detach()
+
 /obj/machinery/chem_master/update_icon()
 
 	overlays.len = 0

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -2123,7 +2123,7 @@
 #include "interface\web\interface.dms"
 #include "maprendering\maprendering.dm"
 #include "maps\_map.dm"
-#include "maps\tgstation.dm"
+#include "maps\test_tiny.dm"
 #include "maps\defficiency\areas.dm"
 #include "maps\defficiency\pipes.dm"
 #include "maps\randomvaults\dance_revolution.dm"

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -2123,7 +2123,7 @@
 #include "interface\web\interface.dms"
 #include "maprendering\maprendering.dm"
 #include "maps\_map.dm"
-#include "maps\test_tiny.dm"
+#include "maps\tgstation.dm"
 #include "maps\defficiency\areas.dm"
 #include "maps\defficiency\pipes.dm"
 #include "maps\randomvaults\dance_revolution.dm"


### PR DESCRIPTION
Kicking chemdispensers and chemmasters now eject the beaker inside (if there's any). Reasons?

1. I think this is quality stuff
2. Sometimes you're in a hurry and all of sudden the machinery stops responding (someone ahelped this today), so instead of kicking your own computer while you reopen the game, you can now simply kick the stupid machinery not responding and get your shit done before the CMO demotes you.
3. I think this is fun

100% tested

:cl:
- rscadd: You can now kick chemistry dispensers and chem masters to eject the inserted container