### PR TITLE
Kick act for fabricators (protolathes, autolathes, exosuit, etc)

### DIFF
--- a/code/modules/research/fabricators.dm
+++ b/code/modules/research/fabricators.dm
@@ -452,6 +452,13 @@
 		temp = "Unable to connect to local R&D Database.<br>Please check your connections and try again.<br><a href='?src=\ref[src];clear_temp=1'>Return</a>"
 	src.updateUsrDialog()
 
+/obj/machinery/r_n_d/fabricator/kick_act(mob/living/H)
+	..()
+	if(stopped)
+		start_processing_queue()
+	else
+		stop_processing_queue()
+
 // Tell the machine to start processing the queue on the next process().
 /obj/machinery/r_n_d/fabricator/proc/start_processing_queue()
 	stopped=0

--- a/code/modules/research/fabricators.dm
+++ b/code/modules/research/fabricators.dm
@@ -456,8 +456,6 @@
 	..()
 	if(stopped)
 		start_processing_queue()
-	else
-		stop_processing_queue()
 
 // Tell the machine to start processing the queue on the next process().
 /obj/machinery/r_n_d/fabricator/proc/start_processing_queue()


### PR DESCRIPTION
This allows the player to start production of these machines on kick act.

Did you run out of materials while printing something? Is opening the whole menu after refilling a pain in the ass? Just kick the goddamn machine.

# 100% tested

:cl: 
- rscadd: You can now kick fabricators in general (protolathes, autolathes, exosuit fabricators, etc) to start production. Useful when you run out of materials and don't want to open the menu again after refilling