### PR TITLE
Cultify artifact effect changes

### DIFF
--- a/code/game/turfs/simulated/shuttle.dm
+++ b/code/game/turfs/simulated/shuttle.dm
@@ -65,6 +65,7 @@
 /turf/simulated/shuttle/floor/cultify()
 	if((icon_state != "cult")&&(icon_state != "cult-narsie"))
 		name = "engraved floor"
+		icon = 'icons/turf/floors.dmi'
 		icon_state = "cult"
 		turf_animation('icons/effects/effects.dmi',"cultfloor",0,0,MOB_LAYER-1, anim_plane = OBJ_PLANE)
 	return
@@ -98,6 +99,7 @@
 /turf/simulated/shuttle/floor4/cultify()
 	if((icon_state != "cult")&&(icon_state != "cult-narsie"))
 		name = "engraved floor"
+		icon = 'icons/turf/floors.dmi'
 		icon_state = "cult"
 		turf_animation('icons/effects/effects.dmi',"cultfloor",0,0,MOB_LAYER-1, anim_plane = OBJ_PLANE)
 	return

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_cultify.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_cultify.dm
@@ -19,5 +19,14 @@
 			for(var/obj/structure/grille/G in T)
 				G.cultify()
 			for(var/obj/structure/window/W in T)
-				W.cultify()
+				if(istype(W,/obj/structure/window/full))
+					W.cultify()
+				else
+					W.color = "red"
+			for(var/obj/structure/table/TB in T)
+				if(TB.type == /obj/structure/table)
+					TB.cultify()
+			for(var/obj/structure/bed/chair/C in T)
+				if(C.type == /obj/structure/bed/chair)
+					C.cultify()
 			sleep(1)

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_cultify.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_cultify.dm
@@ -14,9 +14,7 @@
 
 /datum/artifact_effect/cultify/proc/make_culty(var/range)
 	if(holder)
-		for(var/turf/T in spiral_block(get_turf(holder), range))
-			if(!istype(T, /turf/simulated))
-				continue
+		for(var/turf/simulated/T in spiral_block(get_turf(holder), range))
 			T.cultify()
 			for(var/obj/structure/grille/G in T)
 				G.cultify()

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_cultify.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_cultify.dm
@@ -15,6 +15,8 @@
 /datum/artifact_effect/cultify/proc/make_culty(var/range)
 	if(holder)
 		for(var/turf/T in spiral_block(get_turf(holder), range))
+			if(!istype(T, /turf/simulated))
+				continue
 			T.cultify()
 			for(var/obj/structure/grille/G in T)
 				G.cultify()


### PR DESCRIPTION
Fixes most of #14006.
Cultify effect doesn't effect unsimulated tiles
Only fulltile windows are removed, directional windows are colored blood-red
Normal tables and chairs are cultified for more cult ambiance.
![cultify](https://cloud.githubusercontent.com/assets/19806447/22990575/a77b9b4c-f387-11e6-93cb-c813aa54344b.png)

Also fixes a bug where shuttle floors would lose their icon when cultified