### PR TITLE
Restricts mining machine access, adds contraband and premium items

### DIFF
--- a/code/modules/mining/mine_vending.dm
+++ b/code/modules/mining/mine_vending.dm
@@ -1,6 +1,7 @@
 /obj/machinery/vending/mining
 	name = "Dwarven Mining Equipment"
 	desc = "Get your mining equipment here, and above all keep digging!"
+	req_access = list(access_cargo)
 	product_slogans = "This asteroid isn't going to dig itself!;Stay safe in the tunnels, bring two Kinetic Accelerators!;Jetpacks, anyone?"
 	product_ads = "Hungry, thirsty or unequipped? We have your fix!"
 	vend_reply = "What a glorious time to mine!"
@@ -25,6 +26,15 @@
 		/obj/item/weapon/gun/hookshot = 3,
 		/obj/item/weapon/lazarus_injector/advanced = 4,
 		)
+	contraband = list(
+		/obj/item/weapon/pickaxe/hand = 2,
+		/obj/item/weapon/storage/bag/money = 2,
+		)
+	premium = list(
+		/obj/item/weapon/pickaxe/silver = 1,
+		/obj/item/weapon/pickaxe/gold = 1,
+		/obj/item/weapon/pickaxe/diamond = 1,
+		)
 	prices = list(
 		/obj/item/toy/canary = 100,
 		/obj/item/weapon/reagent_containers/food/snacks/hotchili = 100,
@@ -36,14 +46,19 @@
 		/obj/item/weapon/storage/belt/lazarus = 500,
 		/obj/item/device/mobcapsule = 250,
 		/obj/item/weapon/lazarus_injector = 1000,
+		/obj/item/weapon/pickaxe/hand = 500,
 		/obj/item/weapon/pickaxe/jackhammer = 500,
 		/obj/item/weapon/mining_drone_cube = 500,
 		/obj/item/device/wormhole_jaunter = 250,
 		/obj/item/weapon/resonator = 750,
+		/obj/item/weapon/storage/bag/money = 1000,
 		/obj/item/weapon/gun/energy/kinetic_accelerator = 1000,
+		/obj/item/weapon/pickaxe/silver = 1000,
+		/obj/item/weapon/pickaxe/gold = 2000,
 		/obj/item/weapon/tank/jetpack/carbondioxide = 2000,
 		/obj/item/weapon/gun/hookshot = 3000,
 		/obj/item/weapon/lazarus_injector/advanced = 3000,
+		/obj/item/weapon/pickaxe/diamond = 3000,
 		)
 
 	pack = /obj/structure/vendomatpack/mining

--- a/code/modules/mining/mine_vending.dm
+++ b/code/modules/mining/mine_vending.dm
@@ -27,7 +27,6 @@
 		/obj/item/weapon/lazarus_injector/advanced = 4,
 		)
 	contraband = list(
-		/obj/item/weapon/pickaxe/hand = 2,
 		/obj/item/weapon/storage/bag/money = 2,
 		)
 	premium = list(


### PR DESCRIPTION
~~Two~~ ONE contraband item:~~s a hand pick (500$) and~~ a money bag (1000$).
Three premium items; A silver (1000$), gold (1500$) and diamond (2000$) pickaxe.

:cl:
 - tweak: Mining vending machines now require cargo access.
 - tweak: Mining vending machines now have contraband and premium items!