### PR TITLE
remove centcomm already this is ridiculous

### DIFF
--- a/code/game/objects/items/devices/uplinks.dm
+++ b/code/game/objects/items/devices/uplinks.dm
@@ -22,8 +22,12 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 		return
 
 /obj/item/device/uplink/initialize()
-	welcome = ticker.mode.uplink_welcome
-	uses = ticker.mode.uplink_uses
+	if(ticker.mode)
+		welcome = ticker.mode.uplink_welcome
+		uses = ticker.mode.uplink_uses
+	else
+		welcome = "THANKS FOR MAPPING IN THIS THING AND NOT CHECKING FOR RUNTIMES BUDDY"
+		uses = 90 // Because this is only happening on centcomm's snowflake uplink
 
 //Let's build a menu!
 /obj/item/device/uplink/proc/generate_menu(mob/user as mob)


### PR DESCRIPTION
Fixes a runtime that I can't find the original issue for anymore
WHOEVER MAPPED IN THIS SHIT IN CENTCOMM
ACTUALLY FUCK YOU
Uplinks' initialize() gets called before the gamemode is setup and this code would try to access the mode before it was set so hey runtime