### PR TITLE
Fixes flashes not working on those with negative eye protection

### DIFF
--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -98,7 +98,7 @@
 			user.visible_message("<span class='notice'>[user] fails to blind [M] with the flash!</span>")
 		else
 			if(Subject.eyecheck() <= 0)
-				Subject.Knockdown(Subject.eyecheck() * 5 * -1 +5)
+				Subject.Knockdown(Subject.eyecheck() * 5 * -1 +10)
 			if(user.mind && isrevhead(user)) // alien revhead when?
 				if(ishuman(Subject))
 					if(Subject.stat != DEAD)

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -93,13 +93,12 @@
 
 	if(iscarbon(M))
 		var/mob/living/carbon/Subject = M
-		if(!flashfail && Subject.eyecheck())
-			flashfail = TRUE
-
-		if(flashfail)
+		
+		if(Subject.eyecheck() > 0)
 			user.visible_message("<span class='notice'>[user] fails to blind [M] with the flash!</span>")
 		else
-			Subject.Knockdown(10)
+			if(Subject.eyecheck() <= 0)
+				Subject.Knockdown(Subject.eyecheck() * 5 * -1 +5)
 			if(user.mind && isrevhead(user)) // alien revhead when?
 				if(ishuman(Subject))
 					if(Subject.stat != DEAD)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -704,7 +704,7 @@
 		usr.examination(M)*/
 
 /**
- * Returns a number between -1 to 2.
+ * Returns a number between -2 to 2.
  * TODO: What's the default return value?
  */
 /mob/living/carbon/human/eyecheck()
@@ -722,7 +722,7 @@
 	if(E)
 		. += E.eyeprot
 
-	return Clamp(., -1, 2)
+	return Clamp(., -2, 2)
 
 
 /mob/living/carbon/human/IsAdvancedToolUser()


### PR DESCRIPTION
Tested:
Flashed catbeasts with and without eyewear, including sunglasses, welding helmets, mesons and thermals
Tested rev conversion; it failed on those with positive protection and succeeded on those with negative protection.

Also tested:
if helmets (syndies in particular) provide enough protection to cancel out thermals -- They do

edit: A quick look at the hardsuit helmet says it's got protection 3, and thermals are -2, so if my math isn't off that should work out just fine. Softsuits, however, do not provide enough protection with thermals on.

:cl:
 - bugfix: Flashes now work on people with negative eye protection (mesons, thermals)
 - tweak: Knockdown from getting flashed now depends on the level of negative eye protection