### PR TITLE
Prevents Nuke Disk From Being Lost in Nullspace

### DIFF
--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -389,5 +389,5 @@ var/obj/item/weapon/disk/nuclear/nukedisk
 	if(!get_turf(src))
 		var/atom/A
 		for(A=src, A && A.loc && !isturf(A.loc), A=A.loc);  // semicolon is for the empty statement
-		world.log << "\The [src] ended up in nullspace somehow, and has been replaced.[loc ? " It was contained in [A] when it was nullspaced." : ""]"
+		message_admins("\The [src] ended up in nullspace somehow, and has been replaced.[loc ? " It was contained in [A] when it was nullspaced." : ""]")
 		qdel(src)

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -386,9 +386,5 @@ var/obj/item/weapon/disk/nuclear/nukedisk
 		respawned = 1
 
 /obj/item/weapon/disk/nuclear/process()
-	if(loc == null)
+	if(!get_turf(src))
 		qdel(src)
-	else
-		var/atom/A = get_holder_at_turf_level(src)
-		if(!A || A.loc == null)
-			qdel(src)

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -387,4 +387,7 @@ var/obj/item/weapon/disk/nuclear/nukedisk
 
 /obj/item/weapon/disk/nuclear/process()
 	if(!get_turf(src))
+		var/atom/A
+		for(A=src, A && A.loc && !isturf(A.loc), A=A.loc);  // semicolon is for the empty statement
+		world.log << "\The [src] ended up in nullspace somehow, and has been replaced.[loc ? " It was contained in [A] when it was nullspaced." : ""]"
 		qdel(src)

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -360,8 +360,10 @@ var/obj/item/weapon/disk/nuclear/nukedisk
 	..()
 	if(!nukedisk)
 		nukedisk = src
+	processing_objects.Add(src)
 
 /obj/item/weapon/disk/nuclear/Destroy()
+	processing_objects.Remove(src)
 	..()
 	replace_disk()
 
@@ -369,6 +371,7 @@ var/obj/item/weapon/disk/nuclear/nukedisk
  * NOTE: Don't change it to Destroy().
  */
 /obj/item/weapon/disk/nuclear/Del()
+	processing_objects.Remove(src)
 	replace_disk()
 	..()
 
@@ -381,3 +384,11 @@ var/obj/item/weapon/disk/nuclear/nukedisk
 		message_admins("[log_message] [formatJumpTo(picked_turf, picked_area)]")
 		nukedisk = new /obj/item/weapon/disk/nuclear(picked_turf)
 		respawned = 1
+
+/obj/item/weapon/disk/nuclear/process()
+	if(loc == null)
+		qdel(src)
+	else
+		var/atom/A = get_holder_at_turf_level(src)
+		if(!A || A.loc == null)
+			qdel(src)


### PR DESCRIPTION
The disk now checks whether it can get a turf under it, so if it ends up in nullspace without being deleted somehow, it'll respawn itself.
Fixes #14033