### PR TITLE
Fixes Transmog Mob Looting

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1854,6 +1854,7 @@ mob/proc/on_foot()
 			transmogged_from = null
 			for(var/atom/movable/AM in contents)
 				AM.forceMove(get_turf(src))
+			forceMove(null)
 			qdel(src)
 		return
 	if(!ispath(target_type, /mob))


### PR DESCRIPTION
A mob's transmogrified form is now moved to nullspace before being deleted, so items that are dropped from mobs on destruction, such as the mimic's loot, can't be obtained by players simply from putting on its mask and removing it.
Fixes #14032