### PR TITLE
blob_act and null sound plays on windows, grilles

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -265,6 +265,7 @@
 
 // this should probably use dump_contents()
 /obj/structure/closet/blob_act()
+	anim(target = loc, a_icon = 'icons/mob/blob/blob.dmi', flick_anim = "blob_act", sleeptime = 15, lay = 12)
 	if(prob(75))
 		for(var/atom/movable/A as mob|obj in src)
 			A.forceMove(src.loc)

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -54,7 +54,7 @@
 	return
 
 /obj/structure/grille/blob_act()
-	..()
+	anim(target = loc, a_icon = 'icons/mob/blob/blob.dmi', flick_anim = "blob_act", sleeptime = 15, lay = 12)
 	health -= rand(initial(health)*0.8, initial(health)*3) //Grille will always be blasted, but chances of leaving things over
 	healthcheck(hitsound = 1)
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -128,7 +128,7 @@
 			return
 
 /obj/structure/window/blob_act()
-	..()
+	anim(target = loc, a_icon = 'icons/mob/blob/blob.dmi', flick_anim = "blob_act", sleeptime = 15, lay = 12)
 	health -= rand(30, 50)
 	healthcheck()
 


### PR DESCRIPTION
Wow how did I not notice this last time I looked at this
```dm
[10:51:09] Runtime in sound.dm,30: code/game/sound.dm:30:Assertion Failed: !isnull(turf_source)
  proc name: playsound (/proc/playsound)
  src: null
  call stack:
  playsound(null, 'sound/effects/grillehit.ogg', 80, 1, null, null, 1, 0)
  the grille (/obj/structure/grille): healthcheck(1)
  the grille (/obj/structure/grille): blob act()
  the blob (/obj/effect/blob/normal): expand(the plating (347,225,1) (/turf/simulated/floor/plating/airless), 1)
  the blob (/obj/effect/blob/normal): Pulse(30, 4)
  the blob (/obj/effect/blob/normal): Pulse(29, 8)
```

```dm
obj/structure/blob_act(var/destroy = 0)
    ..()
    if(destroy || (prob(50))) // before I changed it the prob check meant that health checks happened AFTER possible and probably qdeltion
        qdel(src)

/obj/structure/window/blob_act()
    ..()
    health -= rand(30, 50)
    healthcheck()

/obj/structure/grille/blob_act()
	..()
	health -= rand(initial(health)*0.8, initial(health)*3) //Grille will always be blasted, but chances of leaving things over
	healthcheck(hitsound = 1)
```
For both of these, healthcheck() is what qdel's the window as well as playing sounds so the parent call would qdel then it would qdel itself again while playing a sound in nullspace