### PR TITLE
Spiky Skin Runtime Fix

### DIFF
--- a/code/modules/virus2/effect/effect.dm
+++ b/code/modules/virus2/effect/effect.dm
@@ -506,6 +506,8 @@
 /datum/disease2/effect/spiky_skin/on_touch(var/mob/living/carbon/mob, var/toucher, var/touched, var/touch_type)
 	if(!count || skip)
 		return
+	if(!istype(toucher, /mob) || !istype(touched, /mob))
+		return
 	var/datum/organ/external/E
 	var/mob/living/carbon/human/H
 	if(toucher == mob)	//we bumped into someone else


### PR DESCRIPTION
Spiky skin no longer triggers when bumping or being bumped by non-mobs.
Fixes #14049