### PR TITLE
kick_act() for Jukeboxes

### DIFF
--- a/code/modules/media/jukebox.dm
+++ b/code/modules/media/jukebox.dm
@@ -623,6 +623,14 @@ var/global/list/loopModeNames=list(
 	update_music()
 	return
 
+/obj/machinery/media/jukebox/kick_act(mob/living/H)
+	..()
+	if(stat & NOPOWER || any_power_cut())
+		return
+	playing=!playing
+	update_music()
+	update_icon()
+
 /obj/machinery/media/jukebox/bar
 	department = "Civilian"
 	req_access = list(access_bar)


### PR DESCRIPTION
I'm surprised this wasn't a thing already.

:cl:
 * rscadd: Jukeboxes can now be kicked in order to start or stop the music.
