### PR TITLE
make poutine with a wedge rather than a wheel

### DIFF
--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -2195,7 +2195,7 @@
 	reagents = list(GRAVY = 5)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/fries,
-		/obj/item/weapon/reagent_containers/food/snacks/sliceable/cheesewheel
+		/obj/item/weapon/reagent_containers/food/snacks/cheesewedge
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/poutine
 


### PR DESCRIPTION
Requested by Quebone on the discord.
Will update wiki when it's merged.

:cl:
 - tweak: Poutine is now made with a single cheese wedge, rather than a whole wheel.