### PR TITLE
nerfs ghetto spacesuits

### DIFF
--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -36,7 +36,7 @@
 		stage = 2
 	if(istype(W,/obj/item/clothing/head/hardhat/red) && stage == 2)
 		to_chat(user,"<span class='notice'>You finish the ghetto helmet.</span>")
-		var/obj/ghetto = new /obj/item/clothing/head/helmet/space/rig/ghettorig (src.loc)
+		var/obj/ghetto = new /obj/item/clothing/head/hardhat/red/ghettorig (src.loc)
 		qdel(src)
 		qdel(W)
 		user.put_in_hands(ghetto)

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -54,6 +54,36 @@
 	armor = list(melee = 60, bullet = 50, laser = 30,energy = 15, bomb = 30, bio = 30, rad = 30)
 	siemens_coefficient = 0.9
 
+/obj/item/clothing/suit/space/ghettorig
+	name = "jury-rigged space-proof firesuit"
+	icon_state = "ghettorig"
+	item_state = "ghettorig"
+	desc = "A firesuit jury-rigged into being 'space-proof' somehow."
+	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
+	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank/emergency_oxygen,/obj/item/weapon/tank/emergency_nitrogen,/obj/item/weapon/extinguisher)
+	pressure_resistance = 4 * ONE_ATMOSPHERE
+	slowdown = 5 //just wear a firesuit instead if you want to go fast
+	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
+	heat_conductivity = 0 //thanks, blanket
+	gas_transfer_coefficient = 0.60
+	permeability_coefficient = 0.30
+
+/obj/item/clothing/head/hardhat/red/ghettorig //yes, it's actually just a hardhat
+	name = "jury-rigged space-proof fire helmet"
+	desc = "A firefighter helmet and gas mask combined and jury-rigged into being 'space-proof' somehow."
+	icon = 'icons/mob/head.dmi'
+	icon_state = "hardhat0_ghetto"
+	item_state = "hardhat0_ghetto"
+	_color = "ghetto"
+	pressure_resistance = 4 * ONE_ATMOSPHERE
+	body_parts_covered = FULL_HEAD|BEARD
+	heat_conductivity = 0
+	gas_transfer_coefficient = 0.01
+	permeability_coefficient = 0.01
+	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
+	eyeprot = 0
+	species_fit = list(GREY_SHAPED)
+
 /obj/item/clothing/suit/space/ancient //slightly better then an anomalist's space suit
 	name = "ancient space suit"
 	icon_state = "nasa"

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -80,7 +80,6 @@
 	heat_conductivity = 0
 	gas_transfer_coefficient = 0.01
 	permeability_coefficient = 0.01
-	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
 	eyeprot = 0
 	species_fit = list(GREY_SHAPED)
 

--- a/code/modules/clothing/spacesuits/rig.dm
+++ b/code/modules/clothing/spacesuits/rig.dm
@@ -26,16 +26,6 @@
 	update_brightness()
 	update_icon()
 
-/obj/item/clothing/head/helmet/space/rig/ghettorig
-	name = "jury-rigged fire helmet"
-	desc = "Let me give it to you straight like a pear cider made from 100% pears, this helmet isn't particularly good."
-	icon_state = "ghettorig"
-	_color = "ghetto"
-	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
-	eyeprot = 0
-	species_fit = list(GREY_SHAPED)
-
-
 /obj/item/clothing/head/helmet/space/rig/examine(mob/user)
 
 	..()
@@ -95,15 +85,6 @@
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/weapon/storage/bag/ore,/obj/item/device/t_scanner,/obj/item/weapon/pickaxe, /obj/item/device/rcd, /obj/item/weapon/wrench/socket)
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	pressure_resistance = 200 * ONE_ATMOSPHERE
-
-/obj/item/clothing/suit/space/rig/ghettorig
-	name = "jury-rigged firesuit"
-	icon_state = "ghettorig"
-	item_state = "ghettorig"
-	desc = "Let me give it to you straight like a pear cider made from 100% pears, this space suit isn't particularly good."
-	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
-	species_fit = list(GREY_SHAPED)
-
 
 //Chief Engineer's rig
 /obj/item/clothing/head/helmet/space/rig/elite

--- a/code/modules/clothing/suits/utility.dm
+++ b/code/modules/clothing/suits/utility.dm
@@ -43,7 +43,7 @@
 			return
 		to_chat(user,"<span class='notice'>you tie up \the [src] with some of \the [C]</span>")
 		C.use(4)
-		var/obj/ghetto = new /obj/item/clothing/suit/space/rig/ghettorig (src.loc)
+		var/obj/ghetto = new /obj/item/clothing/suit/space/ghettorig (src.loc)
 		qdel(src)
 		user.put_in_hands(ghetto)
 


### PR DESCRIPTION
Ghetto space suit is now a child of the normal space softsuit rather than hardsuit.
It's protection is a combination of a firesuit and space blanket.
It's suit storage slot is limited to what you can wear on firesuits.
It makes you slow as balls.

Ghetto space helmet is now a child of the hardhat it's made from.
Protection values are a mix of a gas mask, hardhat and space blanket.

:cl:
 - tweak: Ghetto space suits are no longer superior in every way to civilian softsuits.