### PR TITLE
Adds an access requirement to supermatter shard crates

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1379,9 +1379,9 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	name = "Supermatter shard"
 	cost = 500 //So cargo thinks thrice before killing themselves with it. You're going to need a department account most likely.
 	containertype = /obj/structure/closet/crate/secure/large/reinforced/shard/empty
-	containername = "Supermatter Shard Crate"
+	containername = "supermatter shard crate"
 	group = "Engineering"
-	access = access_engine
+	access = access_engine_equip
 
 /datum/supply_packs/portable_smes
 	contains = list(/obj/machinery/power/battery/portable,

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1378,10 +1378,10 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	contains = list(/obj/machinery/power/supermatter/shard)
 	name = "Supermatter shard"
 	cost = 500 //So cargo thinks thrice before killing themselves with it. You're going to need a department account most likely.
-	containertype = /obj/structure/closet/crate/secure/engisec
-	containername = "supermatter shard crate"
+	containertype = /obj/structure/closet/crate/secure/large/reinforced/shard/empty
+	containername = "Supermatter Shard Crate"
 	group = "Engineering"
-	access = access_ce
+	access = access_engine
 
 /datum/supply_packs/portable_smes
 	contains = list(/obj/machinery/power/battery/portable,

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -211,6 +211,7 @@
 
 /obj/structure/closet/crate/secure/large/reinforced/shard
 	name = "Supermatter Shard Crate"
+	req_access = list(access_engine)
 	var/payload = /obj/machinery/power/supermatter/shard
 	New()
 		..()

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -210,8 +210,8 @@
 
 
 /obj/structure/closet/crate/secure/large/reinforced/shard
-	name = "Supermatter Shard Crate"
-	req_access = list(access_engine)
+	name = "supermatter shard crate"
+	req_access = list(access_engine_equip)
 	var/payload = /obj/machinery/power/supermatter/shard
 	New()
 		..()
@@ -232,7 +232,7 @@
 
 
 /obj/structure/closet/crate/secure/large/reinforced/shard/crystal
-	name = "Supermatter Crystal Crate"
+	name = "supermatter crystal crate"
 	payload = /obj/machinery/power/supermatter
 
 /obj/structure/closet/crate/secure/large/reinforced/shard/empty

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -216,7 +216,8 @@
 	New()
 		..()
 		sleep(2)
-		new payload(src)
+		if(payload)
+			new payload(src)
 
 /obj/structure/closet/crate/secure/large/reinforced/shard/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(istype(mover,/obj/machinery/power/supermatter))

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -233,3 +233,6 @@
 /obj/structure/closet/crate/secure/large/reinforced/shard/crystal
 	name = "Supermatter Crystal Crate"
 	payload = /obj/machinery/power/supermatter
+
+/obj/structure/closet/crate/secure/large/reinforced/shard/empty
+	payload = null


### PR DESCRIPTION
The fancy black supermatter crates had a lock, but no access checks on them, so anyone can open them.
The supermatter crate now has access_engine_equip required to open it.
Makes the shard orderable from cargo also come in a shard crate, and changes it's access and name to match the existing shard crate.

