### PR TITLE
Renames Show-Player-Info to Show-Player-Notes

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -369,7 +369,7 @@ var/global/floorIsLava = 0
 	return noteslist
 /datum/admins/proc/show_player_info(var/key as text)
 	set category = "Admin"
-	set name = "Show Player Info"
+	set name = "Show Player Notes"
 
 	if (!istype(src,/datum/admins))
 		src = usr.client.holder

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -872,7 +872,7 @@ var/list/admin_verbs_mod = list(
 	M.check_dna(M)
 
 /client/proc/playernotes()
-	set name = "Show Player Info"
+	set name = "Show Player Notes"
 	set category = "Admin"
 	if(holder)
 		holder.PlayerNotes()


### PR DESCRIPTION
:cl:
 * rscadd: Renames Show-Player-Info to Show-Player-Notes because I was too dumb to find it with the previous name