### PR TITLE
Manifest ghost extendability nerf

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -659,12 +659,14 @@
 
 	var/mob/living/user = usr
 	while(this_rune && user && user.stat==CONSCIOUS && user.client && user.loc==this_rune.loc)
-		user.take_organ_damage(1, 0)
+		user.take_organ_damage(2, 1)
 		sleep(30)
 	if(D)
 		D.visible_message("<span class='warning'>[D] slowly dissipates into dust and bones.</span>", \
-		"<span class='warning'>You feel pain, as bonds formed between your soul and this homunculus break.</span>", \
+		"<span class='warning'>You feel horrible pain, as bonds formed between your soul and this homunculus break.</span>", \
 		"<span class='warning'>You hear faint rustle.</span>")
+		user.take_organ_damage(10, 10)
+		user.adjustCloneLoss(5)
 		D.dust()
 	return
 

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -659,7 +659,7 @@
 
 	var/mob/living/user = usr
 	while(this_rune && user && user.stat==CONSCIOUS && user.client && user.loc==this_rune.loc)
-		user.take_organ_damage(2, 1)
+		user.take_organ_damage(1, 1)
 		sleep(30)
 	if(D)
 		D.visible_message("<span class='warning'>[D] slowly dissipates into dust and bones.</span>", \


### PR DESCRIPTION
Resolves #14126 ?
Tested.

:cl:
 - tweak: Manifest ghost now does additional burn damage to the summoner while being used.
 - tweak: Manifest ghost now causes feedback to the summoner when the ghost dies.