### PR TITLE
Fixes mobs changing direction in space to go after prey while drifting

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -189,7 +189,7 @@
 					OpenFire(target)
 			if(target.Adjacent(src))	//If they're next to us, attack
 				AttackingTarget()
-			if(canmove)
+			if(canmove && space_check())
 				if(retreat_distance != null && target_distance <= retreat_distance) //If we have a retreat distance, check if we need to run from our target
 					walk_away(src,target,retreat_distance,move_to_delay)
 				else
@@ -199,7 +199,7 @@
 	if(target.loc != null && get_dist(src, target.loc) <= vision_range)//We can't see our target, but he's in our vision range still
 		if(FindHidden(target) && environment_smash)//Check if he tried to hide in something to lose us
 			var/atom/A = target.loc
-			if(canmove)
+			if(canmove && space_check())
 				Goto(A,move_to_delay,minimum_distance)
 			if(A.Adjacent(src))
 				A.attack_animal(src)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -737,6 +737,13 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 	for(var/turf/T in range(src,1))
 		if(!istype(T, /turf/space))
 			spaced = 0
+			break
+		for(var/atom/A in T.contents)
+			if(istype(A,/obj/structure/lattice) \
+				|| istype(A, /obj/structure/window) \
+				|| istype(A, /obj/structure/grille))
+				spaced = 0
+				break
 	if(spaced)
 		walk(src,0)
 	return !spaced

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -27,7 +27,6 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 	var/stop_automated_movement = 0 //Use this to temporarely stop random movement or to if you write special movement code for animals.
 	var/wander = 1	// Does the mob wander around when idle?
 	var/stop_automated_movement_when_pulled = 1 //When set to 1 this stops the animal from moving when someone is pulling it.
-
 	//Interaction
 	var/response_help   = "pokes"
 	var/response_disarm = "shoves"
@@ -135,7 +134,8 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 
 // For changing wander behavior
 /mob/living/simple_animal/proc/wander_move(var/turf/dest)
-	Move(dest)
+	if(space_check())
+		Move(dest)
 
 /mob/living/simple_animal/Life()
 	if(timestopped)
@@ -729,5 +729,17 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 
 /mob/living/simple_animal/proc/pointed_at(var/mob/pointer)
 	return
+
+/mob/living/simple_animal/proc/space_check() //Returns a 1 if you can move in space or can kick off of something, 0 otherwise
+	if(Process_Spacemove())
+		return 1
+	var/spaced = 1
+	for(var/turf/T in range(src,1))
+		if(!istype(T, /turf/space))
+			spaced = 0
+	if(spaced)
+		walk(src,0)
+	return !spaced
+
 
 /datum/locking_category/simple_animal


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl: (as the emoji)
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
While taking a look at how mobs move in space, I found that, while they do have a drifting capability in space, they tend to try and move towards their prey, shifting their angle of drift through sheer willpower alone.

After further research, I found that it was down to GoTo using walk_to to walk towards the target, which it would keep doing so each tick regardless of gravity, spacing, etc.

Now, should the offending mob be in space, it will have its walk_to reset by using walk(src,0). However, as it uses Process_Spacemove to check for if a mob may be exempt from such limitations such as gravity (See space carp) it does mean that mobs such as spider queens and ranged hivebots can navigate space as mobs by pushing off their own fired projectiles.

Tested, but as this affects general mob movement I can't guarantee all will be well.

Mobs that just walk around and are generally not spacefaring such as chickens and cows still wandered as normal.