### PR TITLE
[Dis] Reapproach of how lung popping functions

### DIFF
--- a/code/modules/mob/living/carbon/human/life/handle_breath.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_breath.dm
@@ -60,11 +60,14 @@
 
 				breath = loc.remove_air(breath_moles)
 
-				if(!is_lung_ruptured())
-					if(!breath || breath.total_moles < BREATH_MOLES / 5 || breath.total_moles > BREATH_MOLES * 5)
-						if(prob(5)) //5 % chance for a lung rupture if air intake is less of a fifth, or more than five times the threshold
+				if(!breath || breath.total_moles < BREATH_MOLES / 5 || breath.total_moles > BREATH_MOLES * 5)
+					if(prob(15)) //15 % chance for lung damage if air intake is less of a fifth, or more than five times the threshold
+						to_chat(world, "lung damage on [src]")
+						L.damage += 1
+					if(!is_lung_ruptured())
+						var/chance_break = (L.damage / L.min_bruised_damage)*50 //So, 1/15 = 3% chance to rupture, 2/15 = 7% chance, etc.
+						if(prob(chance_break))
 							rupture_lung()
-
 				//Handle filtering
 				var/block = 0
 				if(wear_mask)

--- a/code/modules/mob/living/carbon/human/life/handle_breath.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_breath.dm
@@ -62,7 +62,6 @@
 
 				if(!breath || breath.total_moles < BREATH_MOLES / 5 || breath.total_moles > BREATH_MOLES * 5)
 					if(prob(15)) //15 % chance for lung damage if air intake is less of a fifth, or more than five times the threshold
-						to_chat(world, "lung damage on [src]")
 						L.damage += 1
 					if(!is_lung_ruptured())
 						var/chance_break = (L.damage / L.min_bruised_damage)*50 //So, 1/15 = 3% chance to rupture, 2/15 = 7% chance, etc.

--- a/code/modules/organs/internal/lungs/filter.dm
+++ b/code/modules/organs/internal/lungs/filter.dm
@@ -3,6 +3,8 @@
 	name = "advanced lungs"
 	removed_type = /obj/item/organ/lungs/filter
 
+	min_bruised_damage = 30
+	min_broken_damage = 60
 	gasses = list()
 	var/list/intake_settings=list(
 		"oxygen" = list(
@@ -19,7 +21,7 @@
 		),
 		"plasma" = list(
 			new /datum/lung_gas/metabolizable("toxins", min_pp=16, max_pp=280),
-			new /datum/lung_gas/waste("oxygen",         max_pp=10),
+			new /datum/lung_gas/waste("carbon_dioxide",         max_pp=10),
 			new /datum/lung_gas/sleep_agent("/datum/gas/sleeping_agent", trace_gas=1, min_giggle_pp=1, min_para_pp=5, min_sleep_pp=10),
 		)
 	)

--- a/code/modules/organs/internal/lungs/filter.dm
+++ b/code/modules/organs/internal/lungs/filter.dm
@@ -21,7 +21,7 @@
 		),
 		"plasma" = list(
 			new /datum/lung_gas/metabolizable("toxins", min_pp=16, max_pp=280),
-			new /datum/lung_gas/waste("carbon_dioxide",         max_pp=10),
+			new /datum/lung_gas/waste("oxygen",         max_pp=10),
 			new /datum/lung_gas/sleep_agent("/datum/gas/sleeping_agent", trace_gas=1, min_giggle_pp=1, min_para_pp=5, min_sleep_pp=10),
 		)
 	)

--- a/code/modules/organs/internal/lungs/lung.dm
+++ b/code/modules/organs/internal/lungs/lung.dm
@@ -8,6 +8,8 @@
 	parent_organ = LIMB_CHEST
 	removed_type = /obj/item/organ/lungs
 
+	min_bruised_damage = 15
+	min_broken_damage = 30
 	// /vg/ now delegates breathing to the appropriate organ.
 
 	// DEFAULTS FOR HUMAN LUNGS:
@@ -89,10 +91,10 @@
 			owner.audible_cough()		//respitory tract infection
 
 	if(is_bruised())
-		if(prob(2))
+		if(prob(((damage-min_bruised_damage)/min_broken_damage)*100))
 			spawn owner.emote("me", 1, "coughs up blood!")
 			owner.drip(10)
-		if(prob(4))
+		if(prob(((damage-min_bruised_damage)/min_broken_damage)*150))
 			spawn owner.emote("me", 1, "gasps for air!")
 			owner.losebreath += 5
 


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl: (as the emoji)
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
Changes how lungs react to low pressure, now rather than 'Oh you've been in low pressure bang there go your lungs', your lungs now steadily deteriorate in low pressure, with a chance of bursting scaling with how much damage your lungs have received.

Also, now the probabilities of when you lose breath/blood from busted lungs now scales with the damage dealt to said lungs.

This basically gives some reason to get the advanced lungs bar being a vox.