### PR TITLE
Changes to Suicide, make Suicide Syndrome less shit

### DIFF
--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -21,16 +21,16 @@
 	anchored = 1.0
 
 /obj/structure/morgue/proc/update()
-	if (connected)
+	if(connected)
 		icon_state = "morgue0"
 	else
-		if (contents.len > 0)
+		if(contents.len > 0)
 			var/list/inside = recursive_type_check(src, /mob)
-			if (!inside.len)
+			if(!inside.len)
 				icon_state = "morgue3" // no mobs at all, but objects inside
 			else
-				for (var/mob/body in inside)
-					if (body && body.client && !body.suiciding)
+				for(var/mob/living/body in inside)
+					if(body && body.client && !body.suiciding)
 						icon_state = "morgue4" // clone that mofo
 						return
 				icon_state = "morgue2" // dead no-client mob

--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -75,18 +75,6 @@
 			to_chat(src, "<span class='warning'>You cannot commit suicide, your host is clinging to life enough to resist it.</span>")
 			return
 
-		var/permitted = 1
-		var/list/allowed = list("Syndicate", "traitor", "Wizard", "Head Revolutionary", "Cultist", "Changeling")
-		for(var/T in allowed)
-			if(mind.special_role == T)
-				permitted = 1
-				break
-
-		if(!permitted)
-			message_admins("<span class='danger'>[ckey] has tried to suicide, but they were not permitted to due to being an antagonist.</span>", 1) //Fairly urgent
-			to_chat(src, "<span class='warning'>Your masters and the gods won't let you do that without a proper reason.</span>")
-			return
-
 		if(!canmove || restrained()) //Just while I finish up the new 'fun' suiciding verb. This is to prevent metagaming via suicide
 			to_chat(src, "<span class='warning'>You can't commit suicide whilst restrained!</span>")
 			return
@@ -189,7 +177,7 @@
 	visible_message(pick("<span class='danger'>[src] is powering down. It looks like \he's trying to commit suicide.</span>", \
 						 "<span class='danger'>[src] is force-deleting \his system files. It looks like \he's trying to commit suicide.</span>", \
 						 "<span class='danger'>[src] is turning off \his runtime safety. It looks like \he's trying to commit suicide.</span>", \
-						 "<span class='danger'>[src] is analyzing case situations of his lawset in details. It looks like \he's trying to commit suicide.</span>", \
+						 "<span class='danger'>[src] is analyzing case situations of \his lawset in details. It looks like \he's trying to commit suicide.</span>", \
 						 "<span class='danger'>[src] is processing the Ultimate Question of Life, the Universe, and Everything. It looks like \he's trying to commit suicide.</span>"))
 	death(0)
 

--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -1,302 +1,281 @@
-/mob/var/suiciding = 0
+/mob/living/var/suiciding = 0
 
-/mob/living/carbon/human/verb/suicide()
+/mob/living/verb/suicide()
 	set hidden = 1
-	if(!ticker)
-		to_chat(src, "<span class='warning'>You can't commit suicide before the game starts!</span>")
-		return
 
-	if(stat == DEAD)
-		to_chat(src, "<span class='warning'>You're already dead!</span>")
-		return
+	attempt_suicide(0, 1)
 
-	if(istype(wear_mask, /obj/item/clothing/mask/happy))
-		to_chat(src, "<span class='sinister'>BUT WHY? I'M SO HAPPY!</span>")
-		return
+//Only the living may seek respite from death
+//Forced proc will skip all the anti-meta safeties and prompts and just suicide the guy, use this for forced suicides like the suicide virus
+//Suicide set will indicate the game this mob has suicided in a way that has taken it out of the round, set the suiciding flag
+/mob/living/proc/attempt_suicide(var/forced = 0, var/suicide_set = 1)
+	to_chat(src, "<span class='warning'>You can't commit suicide!</span>")
+	return 0
 
-	var/mob/living/simple_animal/borer/B = has_brain_worms()
-	if(B && B.controlling) //Borer
-		to_chat(src, "<span class='warning'>You cannot commit suicide, your host is clinging to life enough to resist it.</span>")
-		return
+//Attempt to perform suicide with an item in our hand
+//Return 0 if the suicide failed, return 1 if succesful. Returning 1 does not perform the default suicide afterwards
+/mob/living/proc/attempt_item_suicide(var/obj/item/suicide_item)
 
-	var/permitted = 1
-	var/list/allowed = list("Syndicate", "traitor", "Wizard", "Head Revolutionary", "Cultist", "Changeling")
-	for(var/T in allowed)
-		if(mind.special_role == T)
-			permitted = 1
-			break
+	if(suicide_item) //We need the item to be there to begin, otherwise abort
+		var/damagetype = suicide_item.suicide_act(src)
+		if(damagetype)
+			var/damage_mod = 1
+			switch(damagetype) //Sorry about the magic numbers.
+							   //brute = 1, burn = 2, tox = 4, oxy = 8
+				if(15) //4 damage types
+					damage_mod = 4
 
-	if(!permitted)
-		message_admins("<span class='danger'>[ckey] has tried to suicide, but they were not permitted to due to being an antagonist.</span>", 1) //Fairly urgent
-		to_chat(src, "<span class='warning'>Your masters and the gods won't let you do that without a proper reason.</span>")
-		return
+				if(6, 11, 13, 14) //3 damage types
+					damage_mod = 3
 
-	if(suiciding)
-		to_chat(src, "<span class='warning'>You're already committing suicide! Be patient!</span>")
-		return
+				if(3, 5, 7, 9, 10, 12) //2 damage types
+					damage_mod = 2
 
-	var/confirm = alert("Are you sure you want to commit suicide?", "Confirm Suicide", "Yes", "No")
+				if(1, 2, 4, 8) //1 damage type
+					damage_mod = 1
 
-	if(confirm == "Yes")
+				else //No special suicide exists for this item or something fucked up, abort and go for a normal suicide instead
+					return
+
+			//Do 175 damage divided by the number of damage types applied.
+			if(damagetype & BRUTELOSS)
+				adjustBruteLoss(175/damage_mod)
+
+			if(damagetype & FIRELOSS)
+				adjustFireLoss(175/damage_mod)
+
+			if(damagetype & TOXLOSS)
+				adjustToxLoss(175/damage_mod)
+
+			if(damagetype & OXYLOSS)
+				adjustOxyLoss(175/damage_mod)
+
+			updatehealth()
+			return 1
+
+/mob/living/carbon/human/attempt_suicide(forced = 0, suicide_set = 1)
+
+	if(!forced)
+
+		var/confirm = alert("Are you sure you want to commit suicide? This action cannot be undone and you will not able to be revived.", "Confirm Suicide", "Yes", "No")
+
+		if(confirm != "Yes")
+			return
+
+		if(stat != CONSCIOUS)
+			to_chat(src, "<span class='warning'>You can't commit suicide in this state!</span>")
+			return
+
+		if(istype(wear_mask, /obj/item/clothing/mask/happy))
+			to_chat(src, "<span class='sinister'>BUT WHY? I'M SO HAPPY!</span>")
+			return
+
+		var/mob/living/simple_animal/borer/B = has_brain_worms()
+		if(B && B.controlling) //Borer
+			to_chat(src, "<span class='warning'>You cannot commit suicide, your host is clinging to life enough to resist it.</span>")
+			return
+
+		var/permitted = 1
+		var/list/allowed = list("Syndicate", "traitor", "Wizard", "Head Revolutionary", "Cultist", "Changeling")
+		for(var/T in allowed)
+			if(mind.special_role == T)
+				permitted = 1
+				break
+
+		if(!permitted)
+			message_admins("<span class='danger'>[ckey] has tried to suicide, but they were not permitted to due to being an antagonist.</span>", 1) //Fairly urgent
+			to_chat(src, "<span class='warning'>Your masters and the gods won't let you do that without a proper reason.</span>")
+			return
+
 		if(!canmove || restrained()) //Just while I finish up the new 'fun' suiciding verb. This is to prevent metagaming via suicide
 			to_chat(src, "<span class='warning'>You can't commit suicide whilst restrained!</span>")
 			return
+
+		log_attack("<font color='red'>[key_name(src)] has committed suicide via the suicide verb.</font>")
+
+	if(suicide_set)
 		suiciding = 1
-		var/obj/item/held_item = get_active_hand()
-		if(held_item)
-			var/damagetype = held_item.suicide_act(src)
-			if(damagetype)
-				var/damage_mod = 1
-				switch(damagetype) //Sorry about the magic numbers.
-								   //brute = 1, burn = 2, tox = 4, oxy = 8
-					if(15) //4 damage types
-						damage_mod = 4
 
-					if(6, 11, 13, 14) //3 damage types
-						damage_mod = 3
+	var/obj/item/held_item = get_active_hand()
 
-					if(3, 5, 7, 9, 10, 12) //2 damage types
-						damage_mod = 2
-
-					if(1, 2, 4, 8) //1 damage type
-						damage_mod = 1
-
-					else //This should not happen, but if it does, everything should still work
-						damage_mod = 1
-
-				//Do 175 damage divided by the number of damage types applied.
-				if(damagetype & BRUTELOSS)
-					adjustBruteLoss(175/damage_mod)
-
-				if(damagetype & FIRELOSS)
-					adjustFireLoss(175/damage_mod)
-
-				if(damagetype & TOXLOSS)
-					adjustToxLoss(175/damage_mod)
-
-				if(damagetype & OXYLOSS)
-					adjustOxyLoss(175/damage_mod)
-
-				//If something went wrong, just do normal oxyloss
-				if(!(damagetype | BRUTELOSS) && !(damagetype | FIRELOSS) && !(damagetype | TOXLOSS) && !(damagetype | OXYLOSS))
-					adjustOxyLoss(max(175 - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
-
-				updatehealth()
-				return
-
-
+	if(!attempt_item_suicide(held_item)) //Failed to perform a special item suicide, go for normal stuff
 		visible_message(pick("<span class='danger'>[src] is attempting to bite \his tongue off! It looks like \he's trying to commit suicide.</span>", \
-							"<span class='danger'>[src] is jamming \his thumbs into \his eye sockets! It looks like \he's trying to commit suicide.</span>", \
-							"<span class='danger'>[src] is twisting \his own neck! It looks like \he's trying to commit suicide.</span>", \
-							"<span class='danger'>[src] is holding \his breath! It looks like \he's trying to commit suicide.</span>"))
+							 "<span class='danger'>[src] is jamming \his thumbs into \his eye sockets! It looks like \he's trying to commit suicide.</span>", \
+							 "<span class='danger'>[src] is twisting \his own neck! It looks like \he's trying to commit suicide.</span>", \
+							 "<span class='danger'>[src] is holding \his breath! It looks like \he's trying to commit suicide.</span>"))
 		adjustOxyLoss(max(175 - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
 		updatehealth()
-		log_attack("<font color='red'>[key_name(src)] used the suicide verb.</font>")
 
-/mob/living/carbon/brain/verb/suicide()
-	set hidden = 1
-	if(!ticker)
-		to_chat(src, "<span class='warning'>You can't commit suicide before the game starts!</span>")
-		return
-
-	if(stat == DEAD)
-		to_chat(src, "<span class='warning'>You're already dead!</span>")
-		return
-
-	if(suiciding)
-		to_chat(src, "<span class='warning'>You're already committing suicide! Be patient!</span>")
-		return
-
-	var/confirm = alert("Are you sure you want to commit suicide?", "Confirm Suicide", "Yes", "No")
-
-	if(confirm == "Yes")
-		suiciding = 1
-		if(!container)
-			visible_message("<span class='danger'>[src]'s brain is growing dull and lifeless. It looks like it has lost the will to live.</span>")
-		log_attack("<font color='red'>[key_name(src)] used the suicide verb.</font>")
-		spawn(50)
-			death(0)
-			suiciding = 0
-
-/mob/living/carbon/monkey/verb/suicide()
-	set hidden = 1
-	if(!ticker)
-		to_chat(src, "<span class='warning'>You can't commit suicide before the game starts!</span>")
-		return
-
-	if(stat == DEAD)
-		to_chat(src, "<span class='warning'>You're already dead!</span>")
-		return
-
-	if(suiciding)
-		to_chat(src, "<span class='warning'>You're already committing suicide! Be patient!</span>")
-		return
-
-	var/mob/living/simple_animal/borer/B=has_brain_worms()
-	if (B && B.controlling) // Borer
-		to_chat(src, "Your can't suicide while controlling your host, you dick.")
-		return
+/mob/living/carbon/brain/attempt_suicide(forced = 0, suicide_set = 1)
 
 
-	var/confirm = alert("Are you sure you want to commit suicide?", "Confirm Suicide", "Yes", "No")
+	if(!forced)
 
-	if(confirm == "Yes")
-		if(!canmove || restrained())
-			to_chat(src, "You can't commit suicide whilst restrained! ((You can type Ghost instead however.))")
+		var/confirm = alert("Are you sure you want to commit suicide? This action cannot be undone and you will not able to be revived.", "Confirm Suicide", "Yes", "No")
+
+		if(!confirm == "Yes")
 			return
+
+		if(stat != CONSCIOUS)
+			to_chat(src, "<span class='warning'>You can't commit suicide in this state!</span>")
+			return
+
+		log_attack("<font color='red'>[key_name(src)] has committed suicide via the suicide verb.</font>")
+
+	if(suicide_set)
 		suiciding = 1
-		//instead of killing them instantly, just put them at -175 health and let 'em gasp for a while
-		visible_message("<span class='danger'>\The [src] is attempting to bite \his tongue off. It looks like \he's trying to commit suicide.</span>")
+
+	if(!container)
+		visible_message("<span class='danger'>[src]'s brain is growing dull and lifeless. It looks like \he's trying to commit suicide.</span>")
+	log_attack("<font color='red'>[key_name(src)] has committed suicide via the suicide verb.</font>")
+
+	death(0)
+
+/mob/living/carbon/monkey/attempt_suicide(forced = 0, suicide_set = 1)
+
+	if(!forced)
+		var/confirm = alert("Are you sure you want to commit suicide? This action cannot be undone and you will not able to be revived.", "Confirm Suicide", "Yes", "No")
+
+		if(!confirm == "Yes")
+			return
+
+		if(stat != CONSCIOUS)
+			to_chat(src, "<span class='warning'>You can't commit suicide in this state!</span>")
+			return
+
+		var/mob/living/simple_animal/borer/B = has_brain_worms()
+		if(B && B.controlling) //Borer
+			to_chat(src, "<span class='warning'>You cannot commit suicide, your host is clinging to life enough to resist it.</span>")
+			return
+
+		if(!canmove || restrained())
+			to_chat(src, "<span class='warning'>You can't commit suicide whilst restrained!</span>")
+			return
+
+		log_attack("<font color='red'>[key_name(src)] has committed suicide via the suicide verb.</font>")
+
+	if(suicide_set)
+		suiciding = 1
+
+	var/obj/item/held_item = get_active_hand()
+	attempt_item_suicide(held_item)
+
+	if(!attempt_item_suicide(held_item)) //Failed to perform a special item suicide, go for normal stuff
+		visible_message(pick("<span class='danger'>[src] is attempting to bite \his tongue off! It looks like \he's trying to commit suicide.</span>", \
+							 "<span class='danger'>[src] is jamming \his thumbs into \his eye sockets! It looks like \he's trying to commit suicide.</span>", \
+							 "<span class='danger'>[src] is twisting \his own neck! It looks like \he's trying to commit suicide.</span>", \
+							 "<span class='danger'>[src] is holding \his breath! It looks like \he's trying to commit suicide.</span>"))
 		adjustOxyLoss(max(175 - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
 		updatehealth()
-		log_attack("<font color='red'>[key_name(src)] used the suicide verb.</font>")
 
-/mob/living/silicon/ai/verb/suicide()
-	set hidden = 1
-	if(stat == DEAD)
-		to_chat(src, "<span class='warning'>You're already dead!</span>")
-		return
+//All silicons work basically the same when it comes to dying, so suicide is universal
+/mob/living/silicon/attempt_suicide(forced = 0, suicide_set = 1)
 
-	if(suiciding)
-		to_chat(src, "<span class='warning'>You're already committing suicide! Be patient!</span>")
-		return
+	if(!forced)
+		var/confirm = alert("Are you sure you want to commit suicide? This action cannot be undone and you will not able to be revived.", "Confirm Suicide", "Yes", "No")
 
-	var/confirm = alert("Are you sure you want to commit suicide?", "Confirm Suicide", "Yes", "No")
+		if(!confirm == "Yes")
+			return
 
-	if(confirm == "Yes")
+		if(stat != CONSCIOUS)
+			to_chat(src, "<span class='warning'>You can't commit suicide in this state!</span>")
+			return
+
+		log_attack("<font color='red'>[key_name(src)] has committed suicide via the suicide verb.</font>")
+
+	if(suicide_set)
 		suiciding = 1
-		visible_message("<span class='danger'>[src] is powering down. It looks like \he's trying to commit suicide.</span>")
-		//put em at -175
-		adjustOxyLoss(max(maxHealth * 2 - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
-		updatehealth()
-		log_attack("<font color='red'>[key_name(src)] used the suicide verb.</font>")
 
-/mob/living/silicon/robot/verb/suicide()
-	set hidden = 1
-	if(stat == DEAD)
-		to_chat(src, "<span class='warning'>You're already dead!</span>")
-		return
+	visible_message(pick("<span class='danger'>[src] is powering down. It looks like \he's trying to commit suicide.</span>", \
+						 "<span class='danger'>[src] is force-deleting \his system files. It looks like \he's trying to commit suicide.</span>", \
+						 "<span class='danger'>[src] is turning off \his runtime safety. It looks like \he's trying to commit suicide.</span>", \
+						 "<span class='danger'>[src] is analyzing case situations of his lawset in details. It looks like \he's trying to commit suicide.</span>", \
+						 "<span class='danger'>[src] is processing the Ultimate Question of Life, the Universe, and Everything. It looks like \he's trying to commit suicide.</span>"))
+	death(0)
 
-	if(suiciding)
-		to_chat(src, "<span class='warning'>You're already committing suicide! Be patient!</span>")
-		return
+//pAI suicide does not set suicide flags since any player can jump in after the last one is gone
+/mob/living/silicon/pai/attempt_suicide(forced = 0, suicide_set = 1)
 
-	var/confirm = alert("Are you sure you want to commit suicide?", "Confirm Suicide", "Yes", "No")
+	if(!forced)
+		var/confirm = alert("Are you sure you want to commit suicide? This action cannot be undone and you will not able to be revived.", "Confirm Suicide", "Yes", "No")
 
-	if(confirm == "Yes")
+		if(!confirm == "Yes")
+			return
+
+		if(stat != CONSCIOUS)
+			to_chat(src, "<span class='warning'>You can't commit suicide in this state!</span>")
+			return
+
+		log_attack("<font color='red'>[key_name(src)] has committed suicide via the suicide verb.</font>")
+
+	card.removePersonality()
+	visible_message("<span class='notice'>[src] flashes a message on its screen, \"Wiping core files. Please acquire a new personality to continue using pAI device functions.\"</span>")
+	death(0)
+
+/mob/living/carbon/alien/humanoid/attempt_suicide(forced = 0, suicide_set = 1)
+
+	if(!forced)
+		var/confirm = alert("Are you sure you want to commit suicide? This action cannot be undone and you will not able to be revived.", "Confirm Suicide", "Yes", "No")
+
+		if(!confirm == "Yes")
+			return
+
+		if(stat != CONSCIOUS)
+			to_chat(src, "<span class='warning'>You can't commit suicide in this state!</span>")
+			return
+
+		log_attack("<font color='red'>[key_name(src)] has committed suicide via the suicide verb.</font>")
+
+	if(suicide_set)
 		suiciding = 1
-		visible_message("<span class='danger'>[src] is powering down. It looks like \he's trying to commit suicide.</span>")
-		//put em at -175
-		adjustOxyLoss(max(maxHealth * 2 - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
-		stat = DEAD //new robot shit doesnt care about oxyloss
-		updatehealth()
-		log_attack("<font color='red'>[key_name(src)] used the suicide verb.</font>")
 
-/mob/living/silicon/pai/verb/suicide()
-	set category = "pAI Commands"
-	set desc = "Kill yourself and become a ghost (You will receive a confirmation prompt)"
-	set name = "pAI Suicide"
-	var/answer = input("REALLY kill yourself? This action can't be undone.", "Suicide", "No") in list ("Yes", "No")
-	if(answer == "Yes")
-		card.removePersonality()
-		src.visible_message("<span class='notice'>[src] flashes a message across its screen, \"Wiping core files. Please acquire a new personality to continue using pAI device functions.\"</span>")
-		log_attack("<font color='red'>[key_name(src)] used the suicide verb.</font>")
-		death(0)
+	visible_message(pick("<span class='danger'>[src] suddenly starts thrashing around wildly! It looks like \he's trying to commit suicide.</span>", \
+						 "<span class='danger'>[src] suddenly starts mauling \himself! It looks like \he's trying to commit suicide.</span>"))
+	adjustOxyLoss(max(175 - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
+	updatehealth()
 
-/mob/living/carbon/alien/humanoid/verb/suicide()
-	set hidden = 1
-	if(stat == DEAD)
-		to_chat(src, "<span class='warning'>You're already dead!</span>")
-		return
+/mob/living/carbon/slime/attempt_suicide(forced = 0, suicide_set = 1)
 
-	if(suiciding)
-		to_chat(src, "<span class='warning'>You're already committing suicide! Be patient!</span>")
-		return
+	if(!forced)
+		var/confirm = alert("Are you sure you want to commit suicide? This action cannot be undone and you will not able to be revived.", "Confirm Suicide", "Yes", "No")
 
-	var/confirm = alert("Are you sure you want to commit suicide?", "Confirm Suicide", "Yes", "No")
+		if(!confirm == "Yes")
+			return
 
-	if(confirm == "Yes")
+		if(stat != CONSCIOUS)
+			to_chat(src, "<span class='warning'>You can't commit suicide in this state!</span>")
+			return
+
+		log_attack("<font color='red'>[key_name(src)] has committed suicide via the suicide verb.</font>")
+
+	if(suicide_set)
 		suiciding = 1
-		visible_message("<span class='danger'>[src] is thrashing around wildly! It looks like \he's trying to commit suicide.</span>")
-		//put em at -175
-		adjustOxyLoss(max(175 - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
-		updatehealth()
-		log_attack("<font color='red'>[key_name(src)] used the suicide verb.</font>")
 
-/mob/living/carbon/slime/verb/suicide()
-	set hidden = 1
-	if(stat == DEAD)
-		to_chat(src, "<span class='warning'>You're already dead!</span>")
-		return
-
-	if(suiciding)
-		to_chat(src, "<span class='warning'>You're already committing suicide! Be patient!</span>")
-		return
-
-	var/confirm = alert("Are you sure you want to commit suicide?", "Confirm Suicide", "Yes", "No")
-
-	if(confirm == "Yes")
-		suiciding = 1
-		visible_message("<span class='danger'>[src] starts vibrating uncontrollably! It looks like \he's trying to commit suicide.</span>")
-		setOxyLoss(100)
-		adjustBruteLoss(100 - getBruteLoss())
-		setToxLoss(100)
-		setCloneLoss(100)
-		updatehealth()
-		log_attack("<font color='red'>[key_name(src)] used the suicide verb.</font>")
+	visible_message("<span class='danger'>[src] starts vibrating uncontrollably! It looks like \he's trying to commit suicide.</span>")
+	setOxyLoss(100)
+	adjustBruteLoss(100 - getBruteLoss())
+	setToxLoss(100)
+	setCloneLoss(100)
+	updatehealth()
 
 //Default for all simple animals, using the Die() proc. Custom cases below
-/mob/living/simple_animal/verb/suicide()
-	set hidden = 1
-	if(stat == DEAD)
-		to_chat(src, "<span class='warning'>You're already dead!</span>")
-		return
+/mob/living/simple_animal/attempt_suicide(forced = 0, suicide_set = 1)
 
-	if(suiciding)
-		to_chat(src, "<span class='warning'>You're already committing suicide! Be patient!</span>")
-		return
+	if(!forced)
+		var/confirm = alert("Are you sure you want to commit suicide? This action cannot be undone and you will not able to be revived.", "Confirm Suicide", "Yes", "No")
 
-	var/confirm = alert("Are you sure you want to commit suicide?", "Confirm Suicide", "Yes", "No")
+		if(!confirm == "Yes")
+			return
 
-	if(confirm == "Yes")
+		if(stat != CONSCIOUS)
+			to_chat(src, "<span class='warning'>You can't commit suicide in this state!</span>")
+			return
+
+		log_attack("<font color='red'>[key_name(src)] has committed suicide via the suicide verb.</font>")
+
+	if(suicide_set)
 		suiciding = 1
-		visible_message("<span class='danger'>[src] suddenly starts thrashing around! It looks like \he's trying to commit suicide.</span>")
-		log_attack("<font color='red'>[key_name(src)] used the suicide verb.</font>")
-		Die()
 
-/mob/living/simple_animal/spiderbot/suicide()
-	set hidden = 1
-	if(stat == DEAD)
-		to_chat(src, "<span class='warning'>You're already dead!</span>")
-		return
-
-	if(suiciding)
-		to_chat(src, "<span class='warning'>You're already committing suicide! Be patient!</span>")
-		return
-
-	var/confirm = alert("Are you sure you want to commit suicide?", "Confirm Suicide", "Yes", "No")
-
-	if(confirm == "Yes")
-		suiciding = 1
-		visible_message("<span class='danger'>[src] suddenly topples over and starts thrashing around! It looks like \he's trying to commit suicide.</span>")
-		log_attack("<font color='red'>[key_name(src)] used the suicide verb.</font>")
-		Die() //Handles death properly enough
-
-/mob/living/simple_animal/borer/suicide()
-	set hidden = 1
-	if(stat == DEAD)
-		to_chat(src, "<span class='warning'>You're already dead!</span>")
-		return
-
-	if(suiciding)
-		to_chat(src, "<span class='warning'>You're already committing suicide! Be patient!</span>")
-		return
-
-	var/confirm = alert("Are you sure you want to commit suicide?", "Confirm Suicide", "Yes", "No")
-
-	if(confirm == "Yes")
-		suiciding = 1
-		visible_message("<span class='danger'>[src] suddenly starts trashing around [host ? "[host]'s head":""]! It looks like \he's trying to commit suicide.</span>")
-		detach()
-		log_attack("<font color='red'>[key_name(src)] used the suicide verb.</font>")
-		Die()
+	visible_message(pick("<span class='danger'>[src] suddenly starts thrashing around wildly! It looks like \he's trying to commit suicide.</span>", \
+						 "<span class='danger'>[src] suddenly starts mauling \himself! It looks like \he's trying to commit suicide.</span>"))
+	Die()

--- a/code/modules/virus2/effect/effect.dm
+++ b/code/modules/virus2/effect/effect.dm
@@ -1024,7 +1024,7 @@ datum/disease2/effect/lubefoot/deactivate(var/mob/living/carbon/mob)
 
 /datum/disease2/effect/suicide/activate(var/mob/living/carbon/mob)
 
-	if(mob.stat != CONSCIOUS || !canmove || restrained()) //Try as we might, we still can't snap our neck when we are KO or restrained, even if forced.
+	if(mob.stat != CONSCIOUS || !mob.canmove || mob.restrained()) //Try as we might, we still can't snap our neck when we are KO or restrained, even if forced.
 		return
 
 	mob.attempt_suicide(1, 0)

--- a/code/modules/virus2/effect/effect.dm
+++ b/code/modules/virus2/effect/effect.dm
@@ -1023,14 +1023,8 @@ datum/disease2/effect/lubefoot/deactivate(var/mob/living/carbon/mob)
 	badness = 2
 
 /datum/disease2/effect/suicide/activate(var/mob/living/carbon/mob)
-	mob.suiciding = 1
-	//instead of killing them instantly, just put them at -175 health and let 'em gasp for a while
-	to_chat(viewers(mob), "<span class='danger'>[mob.name] is holding \his breath. It looks like \he's trying to commit suicide.</span>")
-	mob.adjustOxyLoss(175 - mob.getToxLoss() - mob.getFireLoss() - mob.getBruteLoss() - mob.getOxyLoss())
-	mob.updatehealth()
-	spawn(200) //in case they get revived by cryo chamber or something stupid like that, let them suicide again in 20 seconds
-		mob.suiciding = 0
 
+	mob.attempt_suicide(1, 0)
 
 /datum/disease2/effect/killertoxins
 	name = "Toxification Syndrome"

--- a/code/modules/virus2/effect/effect.dm
+++ b/code/modules/virus2/effect/effect.dm
@@ -1024,6 +1024,9 @@ datum/disease2/effect/lubefoot/deactivate(var/mob/living/carbon/mob)
 
 /datum/disease2/effect/suicide/activate(var/mob/living/carbon/mob)
 
+	if(mob.stat != CONSCIOUS || !canmove || restrained()) //Try as we might, we still can't snap our neck when we are KO or restrained, even if forced.
+		return
+
 	mob.attempt_suicide(1, 0)
 
 /datum/disease2/effect/killertoxins


### PR DESCRIPTION
- All suicide vars and procs are now defined on the /mob/living level
- Suicide is now a single verb, defined on the /mob/living level. Mobs without specific suicide instructions don't get to suicide
- Moved the actual "commit suicide" part to a new proc called attempt_suicide. It has two arguments, forced and suicide_set, which allows us to force a mob to suicide without all the other shit getting in the way, and to perform a suicide without the suicide flag bothering us and preventing a revive
- Added another proc, attempt_item_suicide, to make invoking suicide_act cleaner (only used by humans and monkeys since they are the only ones capable of grabbing most items in the game)
- Added a bunch of expertly written and magnificently written new suicide messages, notably for silicons, yours truly
- Used inheritance to get rid of a few unneeded cases, like robots (now all silicons use the same suicide) and sub-simple animals (all simple animals use the same suicide)
- Suicide as a Silicon will now actually kill you properly, you will bluescreen as an AI and your lights will RIP forever as a robutt
- Suicide Syndrome now actually uses suicide instead of some badly written piece of shit. It will also no longer trigger if you are unconscious, restrained or incapable of moving, since you actually need to be conscious to fracture your skull. It will also not set the suiciding flag at all, allowing revives
- Suicide Syndrome can now trigger special suicides, holding an item while the virus is going around has never gotten any funnier

Fixes #14145
Fixes #14149