### PR TITLE
Toggles off CONTROL_FREAK

### DIFF
--- a/code/modules/client/client defines.dm
+++ b/code/modules/client/client defines.dm
@@ -35,7 +35,7 @@
 	var/next_allowed_topic_time = 10
 	// comment out the line below when debugging locally to enable the options & messages menu
 	// CONTROL_FREAK_MACROS allows new macros to be made, but won't permit overriding skin-defined ones.  http://www.byond.com/forum/?post=2219001#comment22205313
-	control_freak = CONTROL_FREAK_ALL | CONTROL_FREAK_MACROS
+	//control_freak = CONTROL_FREAK_ALL | CONTROL_FREAK_MACROS
 
 
 		////////////////////////////////////


### PR DESCRIPTION
Continuation of bugwatch

http://www.byond.com/forum/?post=2219001
https://github.com/d3athrow/vgstation13/pull/14233
https://github.com/tgstation/tgstation/pull/24556/files

CONTROL_FREAK removes players abilities to reconnect through the client, coders ability to access the profiler, players ability to see if resources are downloading, and some other stuff that isn't super applicable to us.   Initially I appraised this as a loss of QoL but it's more serious than I thought due to all the stuff above.   Access to the profiler is extremely important for debugging when the server takes a dump.

/tg/ doesn't need it.  Do we?