### PR TITLE
Body scanners and sleepers no longer bodysnatch patients

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -173,7 +173,7 @@
 	var/amounts = list(5, 10)
 	var/obj/machinery/sleep_console/connected = null
 	var/sedativeblock = 0 //To prevent people from being surprisesoporific'd
-	machine_flags = SCREWTOGGLE | CROWDESTROY | WRENCHMOVE
+	machine_flags = SCREWTOGGLE | CROWDESTROY | WRENCHMOVE | EJECTNOTDEL
 	component_parts = newlist(
 		/obj/item/weapon/circuitboard/sleeper,
 		/obj/item/weapon/stock_parts/scanning_module,
@@ -626,7 +626,7 @@
 	light_color = LIGHT_COLOR_ORANGE
 	automatic = 1
 	drag_delay = 0
-	machine_flags = SCREWTOGGLE | CROWDESTROY | EMAGGABLE
+	machine_flags = SCREWTOGGLE | CROWDESTROY | EMAGGABLE | EJECTNOTDEL
 
 
 /obj/machinery/sleeper/mancrowave/go_out(var/exit = src.loc)

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -12,7 +12,7 @@
 	var/orient = "LEFT"
 	var/scanning = 1
 	var/obj/machinery/body_scanconsole/connected = null //This will save us a lot of locates
-	machine_flags = SCREWTOGGLE | CROWDESTROY
+	machine_flags = SCREWTOGGLE | CROWDESTROY | EJECTNOTDEL
 	component_parts = newlist(
 		/obj/item/weapon/circuitboard/fullbodyscanner,
 		/obj/item/weapon/stock_parts/scanning_module,
@@ -324,6 +324,7 @@
 /obj/machinery/body_scanconsole/New()
 	..()
 	spawn(5)
+		addHear()
 		if(orient == "RIGHT")
 			icon_state = "body_scannerconsole-r"
 			src.connected = locate(/obj/machinery/bodyscanner, get_step(src, EAST))
@@ -349,6 +350,10 @@
 /obj/machinery/body_scanconsole/blob_act()
 	if(prob(50))
 		qdel(src)
+
+/obj/machinery/body_scanconsole/Destroy()
+	removeHear()
+	..()
 
 /obj/machinery/body_scanconsole/power_change()
 	if(powered())
@@ -653,9 +658,11 @@
 /obj/machinery/body_scanconsole/Hear(var/datum/speech/speech, var/rendered_speech="")
 	if(!src.connected || src.connected.scanning<3)
 		return
-	if(speech.speaker && speech.speaker in range(src,3) && findtext(speech.message, "scanner, print"))
-		if(!src.connected.occupant||!istype(src.connected.occupant,/mob/living/carbon/human))
-			return
-		var/obj/item/weapon/paper/R = new(src.loc)
-		R.name = "paper - 'body scan report'"
-		R.info = format_occupant_data(src.connected.get_occupant_data())
+	if(speech.speaker && !speech.frequency)
+		if(findtext(speech.message, "print"))
+			if(!src.connected.occupant||!istype(src.connected.occupant,/mob/living/carbon/human))
+				return
+			say("Now outputting diagnostic.")
+			var/obj/item/weapon/paper/R = new(src.loc)
+			R.name = "paper - 'body scan report'"
+			R.info = format_occupant_data(src.connected.get_occupant_data())

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -320,11 +320,11 @@
 	density = 1
 	anchored = 1
 	var/orient = "LEFT"
+	flags = HEAR
 
 /obj/machinery/body_scanconsole/New()
 	..()
 	spawn(5)
-		addHear()
 		if(orient == "RIGHT")
 			icon_state = "body_scannerconsole-r"
 			src.connected = locate(/obj/machinery/bodyscanner, get_step(src, EAST))
@@ -350,10 +350,6 @@
 /obj/machinery/body_scanconsole/blob_act()
 	if(prob(50))
 		qdel(src)
-
-/obj/machinery/body_scanconsole/Destroy()
-	removeHear()
-	..()
 
 /obj/machinery/body_scanconsole/power_change()
 	if(powered())

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -320,7 +320,7 @@
 	density = 1
 	anchored = 1
 	var/orient = "LEFT"
-	flags = HEAR
+	flags = FPRINT | HEAR
 
 /obj/machinery/body_scanconsole/New()
 	..()


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl: (as the emoji)
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
fixes #14191

Also fixes the unused feature of body scanners having voice activation. virtual hearers are fun.

:cl:

* bugfix: Body scanners now no longer eat people should you try to scan somebody during deconstruction
* rscadd: Body scanners with scanning level 3 now have voice activation. Say print to print out current patient diagnostic