### PR TITLE
Wreckage fixes

### DIFF
--- a/code/game/mecha/mecha_wreckage.dm
+++ b/code/game/mecha/mecha_wreckage.dm
@@ -14,10 +14,10 @@
 	var/list/wirecutters_salvage = list(/obj/item/stack/cable_coil)
 	var/list/crowbar_salvage
 
-	New()
-		..()
-		crowbar_salvage = new
-		return
+/obj/effect/decal/mecha_wreckage/New()
+	..()
+	crowbar_salvage = new
+	return
 
 /obj/effect/decal/mecha_wreckage/ex_act(severity)
 	if(severity < 2)

--- a/code/game/mecha/mecha_wreckage.dm
+++ b/code/game/mecha/mecha_wreckage.dm
@@ -69,7 +69,7 @@
 
 /obj/effect/decal/mecha_wreckage/proc/pick_random_loot(var/list/possible, const/max_loot=2, const/loot_prob=40)
 	var/list/provided = list()
-	for(var/i=0;i<max_loot;i++)
+	for(var/i = 1 to max_loot)
 		if(!isemptylist(possible) && prob(loot_prob))
 			provided += pick_n_take(possible)
 	return provided

--- a/code/game/mecha/mecha_wreckage.dm
+++ b/code/game/mecha/mecha_wreckage.dm
@@ -13,7 +13,7 @@
 	var/list/welder_salvage = list(/obj/item/stack/sheet/plasteel,/obj/item/stack/sheet/metal,/obj/item/stack/rods)
 	var/list/wirecutters_salvage = list(/obj/item/stack/cable_coil)
 	var/list/crowbar_salvage
-	var/salvage_num = 5
+	var/list/final_removal_salvage = list(/obj/item/stack/sheet/metal)
 
 	New()
 		..()
@@ -22,45 +22,64 @@
 
 /obj/effect/decal/mecha_wreckage/ex_act(severity)
 	if(severity < 2)
-		spawn
+		spawn // Why.
 			qdel(src)
 	return
 
 /obj/effect/decal/mecha_wreckage/bullet_act(var/obj/item/projectile/Proj)
 	return
 
+/obj/effect/decal/mecha_wreckage/examine(var/mob/user)
+	..()
+	if(!isemptylist(welder_salvage))
+		to_chat(user, "<span class='info'>Looks like you might be able to cut something out, if you have a welder.</span>")
+	if(!isemptylist(wirecutters_salvage))
+		to_chat(user, "<span class='info'>There are some salvagable wires that you can reach with wirecutters.</span>")
+	if(!isemptylist(crowbar_salvage))
+		to_chat(user, "<span class='info'>You might be able to pry something out.</span>")
+
+/obj/effect/decal/mecha_wreckage/proc/die()
+	qdel(src)
+
+/obj/effect/decal/mecha_wreckage/proc/check_salvage()
+	if(isemptylist(welder_salvage) && isemptylist(wirecutters_salvage) && isemptylist(crowbar_salvage))
+		die()
+
+/obj/effect/decal/mecha_wreckage/proc/pick_random_loot(var/list/possible, const/max_loot=2, const/loot_prob=40)
+	var/list/provided = list()
+	for(var/i=0;i<max_loot;i++)
+		if(!isemptylist(possible) && prob(loot_prob))
+			provided += pick_n_take(possible)
+	return provided
 
 /obj/effect/decal/mecha_wreckage/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(istype(W, /obj/item/weapon/weldingtool))
 		var/obj/item/weapon/weldingtool/WT = W
-		if(salvage_num <= 0)
+		if(isemptylist(welder_salvage))
 			to_chat(user, "You don't see anything that can be cut with [W].")
 			return
-		if (!isemptylist(welder_salvage) && WT.remove_fuel(0,user))
+		if (WT.remove_fuel(0,user))
 			var/type = prob(70)?pick(welder_salvage):null
 			if(type)
 				var/N = new type(get_turf(user))
 				user.visible_message("[user] cuts [N] from [src]", "You cut [N] from [src]", "You hear a sound of welder nearby")
 				if(istype(N, /obj/item/mecha_parts/part))
 					welder_salvage -= type
-				salvage_num--
 			else
 				to_chat(user, "You failed to salvage anything valuable from [src].")
 		else
 			to_chat(user, "<span class='notice'>You need more welding fuel to complete this task.</span>")
 			return
 	if(iswirecutter(W))
-		if(salvage_num <= 0)
+		if(isemptylist(wirecutters_salvage))
 			to_chat(user, "You don't see anything that can be cut with [W].")
 			return
-		else if(!isemptylist(wirecutters_salvage))
-			var/type = prob(70)?pick(wirecutters_salvage):null
-			if(type)
-				var/N = new type(get_turf(user))
-				user.visible_message("[user] cuts [N] from [src].", "You cut [N] from [src].")
-				salvage_num--
-			else
-				to_chat(user, "You failed to salvage anything valuable from [src].")
+		var/type = prob(70)?pick(wirecutters_salvage):null
+		if(type)
+			var/N = new type(get_turf(user))
+			user.visible_message("[user] cuts [N] from [src].", "You cut [N] from [src].")
+		else
+			to_chat(user, "You failed to salvage anything valuable from [src].")
 	if(iscrowbar(W))
 		if(!isemptylist(crowbar_salvage))
 			var/obj/S = pick(crowbar_salvage)
@@ -68,7 +87,8 @@
 				S.forceMove(get_turf(user))
 				crowbar_salvage -= S
 				user.visible_message("[user] pries [S] from [src].", "You pry [S] from [src].")
-			return
+			else
+				to_chat(user, "You failed to salvage anything valuable from [src].")
 		else
 			to_chat(user, "You don't see anything that can be pried with [W].")
 	else
@@ -88,12 +108,7 @@
 									/obj/item/mecha_parts/part/gygax_right_arm,
 									/obj/item/mecha_parts/part/gygax_left_leg,
 									/obj/item/mecha_parts/part/gygax_right_leg)
-		for(var/i=0;i<2;i++)
-			if(!isemptylist(parts) && prob(40))
-				var/part = pick(parts)
-				welder_salvage += part
-				parts -= part
-		return
+		welder_salvage += pick_random_loot(parts)
 
 /obj/effect/decal/mecha_wreckage/gygax/dark
 	name = "Dark Gygax wreckage"
@@ -114,11 +129,7 @@
 		/obj/item/mecha_parts/part/marauder_right_leg,
 		)
 
-	for(var/i=0;i<2;i++)
-		if(prob(40))
-			var/part = pick(parts)
-			welder_salvage += part
-			parts -= part
+	welder_salvage += pick_random_loot(parts)
 
 /obj/effect/decal/mecha_wreckage/mauler
 	name = "Mauler Wreckage"
@@ -140,12 +151,7 @@
 									/obj/item/mecha_parts/part/ripley_right_arm,
 									/obj/item/mecha_parts/part/ripley_left_leg,
 									/obj/item/mecha_parts/part/ripley_right_leg)
-		for(var/i=0;i<2;i++)
-			if(!isemptylist(parts) && prob(40))
-				var/part = pick(parts)
-				welder_salvage += part
-				parts -= part
-		return
+		welder_salvage += pick_random_loot(parts)
 
 /obj/effect/decal/mecha_wreckage/ripley/firefighter
 	name = "Firefighter wreckage"
@@ -159,12 +165,7 @@
 									/obj/item/mecha_parts/part/ripley_left_leg,
 									/obj/item/mecha_parts/part/ripley_right_leg,
 									/obj/item/clothing/suit/fire)
-		for(var/i=0;i<2;i++)
-			if(!isemptylist(parts) && prob(40))
-				var/part = pick(parts)
-				welder_salvage += part
-				parts -= part
-		return
+		welder_salvage += pick_random_loot(parts)
 
 /obj/effect/decal/mecha_wreckage/ripley/deathripley
 	name = "Death-Ripley wreckage"
@@ -184,12 +185,7 @@
 								/obj/item/mecha_parts/part/honker_right_arm,
 								/obj/item/mecha_parts/part/honker_left_leg,
 								/obj/item/mecha_parts/part/honker_right_leg)
-		for(var/i=0;i<2;i++)
-			if(!isemptylist(parts) && prob(40))
-				var/part = pick(parts)
-				welder_salvage += part
-				parts -= part
-		return
+		welder_salvage += pick_random_loot(parts)
 
 /obj/effect/decal/mecha_wreckage/durand
 	name = "Durand wreckage"
@@ -204,12 +200,7 @@
 									/obj/item/mecha_parts/part/durand_right_arm,
 									/obj/item/mecha_parts/part/durand_left_leg,
 									/obj/item/mecha_parts/part/durand_right_leg)
-		for(var/i=0;i<2;i++)
-			if(!isemptylist(parts) && prob(40))
-				var/part = pick(parts)
-				welder_salvage += part
-				parts -= part
-		return
+		welder_salvage += pick_random_loot(parts)
 
 
 /obj/effect/decal/mecha_wreckage/durand/old
@@ -234,9 +225,10 @@
 									/obj/item/mecha_parts/part/odysseus_right_arm,
 									/obj/item/mecha_parts/part/odysseus_left_leg,
 									/obj/item/mecha_parts/part/odysseus_right_leg)
-		for(var/i=0;i<2;i++)
-			if(!isemptylist(parts) && prob(40))
-				var/part = pick(parts)
-				welder_salvage += part
-				parts -= part
-		return
+		welder_salvage += pick_random_loot(parts)
+
+/obj/effect/decal/mecha_wreckage/vehicle
+	name = "(BUG) BASE VEHICLE WRECKAGE"
+	icon = 'icons/obj/vehicles.dmi'
+	icon_state = "pussywagon_destroyed"
+	desc = "Remains of some unfortunate vehicle. Completely unrepairable."

--- a/code/game/objects/structures/vehicles/adminbus.dm
+++ b/code/game/objects/structures/vehicles/adminbus.dm
@@ -308,7 +308,7 @@
 	update_rearview()
 
 /obj/structure/bed/chair/vehicle/adminbus/buckle_mob(mob/M, mob/user)
-	if(M != user|| !ismob(M)|| get_dist(src, user) > 1|| user.restrained()|| user.lying|| user.stat|| M.locked_to|| istype(user, /mob/living/silicon)|| destroyed)
+	if(M != user|| !ismob(M)|| get_dist(src, user) > 1|| user.restrained()|| user.lying|| user.stat|| M.locked_to|| istype(user, /mob/living/silicon))
 		return
 
 	if(!(istype(user,/mob/living/carbon/human/dummy) || istype(user,/mob/living/simple_animal/corgi/Ian)))

--- a/code/game/objects/structures/vehicles/cargo_tractor.dm
+++ b/code/game/objects/structures/vehicles/cargo_tractor.dm
@@ -8,6 +8,7 @@
 	icon = 'goon/icons/vehicles.dmi'
 	icon_state = "tractor"
 	keytype = /obj/item/key/tractor
+	wreckage_type = /obj/effect/decal/mecha_wreckage/vehicle/tractor
 
 /obj/structure/bed/chair/vehicle/tractor/update_mob()
 	if(!occupant)
@@ -34,3 +35,10 @@
 	else
 		plane = ABOVE_HUMAN_PLANE
 		layer = VEHICLE_LAYER
+
+/obj/effect/decal/mecha_wreckage/vehicle/tractor
+	// TODO: SPRITE PLS
+	//icon = 'goon/icons/vehicles.dmi'
+	//icon_state="tractor_destroyed"
+	name = "tractor wreckage"
+	desc = "The quartermaster sobs quietly on a pile of guns."

--- a/code/game/objects/structures/vehicles/clowncart.dm
+++ b/code/game/objects/structures/vehicles/clowncart.dm
@@ -17,6 +17,7 @@
 	name = "clowncart"
 	desc = "A goofy-looking cart, commonly used by space clowns for entertainment. There appears to be a coin slot on its side."
 	icon = 'icons/obj/vehicles.dmi'
+	wreckage_type = /obj/effect/decal/mecha_wreckage/vehicle/clowncart
 	icon_state = "clowncart0"
 	anchored = 1
 	density = 1
@@ -365,6 +366,12 @@
 		to_chat(user, "<span class='notice'>\The [W] doesn't contain any banana essence!</span>")
 		return 0
 
+/obj/effect/decal/mecha_wreckage/vehicle/clowncart
+	// TODO: Icons plz
+	//icon = 'icons/obj/vehicles.dmi'
+	//icon_state = "pussywagon_destroyed"
+	name = "clowncart wreckage"
+	desc = "Now the clown needs cheering up."
 #undef HEALTH_FOR_70X_MODIFIER
 #undef HEALTH_FOR_80X_MODIFIER
 #undef HEALTH_FOR_FLOWER_RECHARGE

--- a/code/game/objects/structures/vehicles/clowncart.dm
+++ b/code/game/objects/structures/vehicles/clowncart.dm
@@ -78,9 +78,6 @@
 
 /obj/structure/bed/chair/vehicle/clowncart/attackby(obj/item/W, mob/user)
 	if (istype(W, /obj/item/weapon/bikehorn))
-		if(destroyed)
-			to_chat(user, "<span class='danger'>[src] is completely wrecked, it's over.</span>")
-			return
 		if(honk + 20 > world.timeofday)
 			return
 		add_fingerprint(user)
@@ -258,7 +255,7 @@
 				to_chat(user, "Selected color: Boring Black")
 
 /obj/structure/bed/chair/vehicle/clowncart/relaymove(mob/user, direction)
-	if(user.incapacitated() || destroyed)
+	if(user.incapacitated())
 		unlock_atom(user)
 		return
 	if(empstun > 0)
@@ -297,7 +294,6 @@
 		to_chat(user, "<span class='notice'>You have to honk to be able to ride [src].</span>")
 
 /obj/structure/bed/chair/vehicle/clowncart/die()
-	destroyed = 1
 	density = 0
 	visible_message("<span class='warning'>[nick] explodes in a puff of pure potassium!</span>")
 	playsound(get_turf(src), 'sound/items/bikehorn.ogg', 75, 1)

--- a/code/game/objects/structures/vehicles/gigadrill.dm
+++ b/code/game/objects/structures/vehicles/gigadrill.dm
@@ -9,6 +9,7 @@
 	name = "gigadrill"
 	icon_state = "gigadrill"
 	keytype = /obj/item/key/gigadrill
+	wreckage_type = /obj/effect/decal/mecha_wreckage/vehicle/gigadrill
 	var/turf/drilling_turf
 
 /obj/structure/bed/chair/vehicle/gigadrill/buckle_mob(mob/M, mob/user)
@@ -47,5 +48,12 @@
 	if(istype(target, /turf/unsimulated/mineral))
 		var/turf/unsimulated/mineral/M = target
 		M.GetDrilled()
+
+/obj/effect/decal/mecha_wreckage/vehicle/gigadrill
+	// TODO: SPRITE PLS
+	//icon = 'icons/obj/vehicles.dmi'
+	//icon_state = "gigadrill_wreck"
+	name = "gigadrill wreckage"
+	desc = "The rocks are safer.  For now."
 
 #undef DRILL_TIME

--- a/code/game/objects/structures/vehicles/gokart.dm
+++ b/code/game/objects/structures/vehicles/gokart.dm
@@ -11,6 +11,7 @@
 	keytype = /obj/item/key/gokart
 	noghostspin = 0
 	can_have_carts = FALSE
+	wreckage_type = /obj/effect/decal/mecha_wreckage/vehicle/gokart
 
 /obj/structure/bed/chair/vehicle/gokart/unlock_atom(var/atom/movable/AM)
 	. = ..()
@@ -40,3 +41,12 @@
 		if(EAST)
 			occupant.pixel_x = -4 * PIXEL_MULTIPLIER
 			occupant.pixel_y = 7 * PIXEL_MULTIPLIER
+
+
+
+/obj/effect/decal/mecha_wreckage/vehicle/gokart
+	// TODO: SPRITE PLS
+	//icon = 'icons/obj/vehicles.dmi'
+	//icon_state = "gokart_wreck"
+	name = "\improper Go-Kart wreckage"
+	desc = "You don't think AAA will cover this."

--- a/code/game/objects/structures/vehicles/janicart.dm
+++ b/code/game/objects/structures/vehicles/janicart.dm
@@ -16,6 +16,7 @@
 	keytype = /obj/item/key/janicart
 	flags = OPENCONTAINER
 	noghostspin = 0
+	wreckage_type = /obj/effect/decal/mecha_wreckage/vehicle/janicart
 	var/amount_per_transfer_from_this = 5 //shit I dunno, adding this so syringes stop runtime erroring. --NeoFite
 	var/obj/item/weapon/storage/bag/trash/mybag	= null
 
@@ -43,7 +44,7 @@
 
 /obj/structure/bed/chair/vehicle/janicart/attackby(obj/item/W, mob/user)
 	..()
-	if(istype(W, /obj/item/mecha_parts/janicart_upgrade) && !upgraded && !destroyed)
+	if(istype(W, /obj/item/mecha_parts/janicart_upgrade) && !upgraded)
 		if(user.drop_item(W))
 			qdel(W)
 			to_chat(user, "<span class='notice'>You upgrade \the [nick].</span>")
@@ -123,3 +124,9 @@
 						cleaned_human.clean_blood()
 						to_chat(cleaned_human, "<span class='warning'>[src] cleans your face!</span>")
 	return
+
+/obj/effect/decal/mecha_wreckage/vehicle/janicart
+	icon = 'icons/obj/vehicles.dmi'
+	icon_state = "pussywagon_destroyed"
+	name = "\improper Go-Kart wreckage"
+	desc = "You don't think AAA will cover this."

--- a/code/game/objects/structures/vehicles/janicart.dm
+++ b/code/game/objects/structures/vehicles/janicart.dm
@@ -79,9 +79,7 @@
 		usr.put_in_hands(mybag)
 		mybag = null
 
-/obj/structure/bed/chair/vehicle/janicart/die()
-	var/obj/effect/decal/mecha_wreckage/vehicle/wreck = ..()
-
+/obj/structure/bed/chair/vehicle/janicart/setup_wreckage(var/obj/effect/decal/mecha_wreckage/wreck)
 	// Add janicart upgrade to wreck, if it passes the roll.
 	if(upgraded)
 		wreck.add_salvagable(new /obj/item/mecha_parts/janicart_upgrade(src)) // 30% chance

--- a/code/game/objects/structures/vehicles/janicart.dm
+++ b/code/game/objects/structures/vehicles/janicart.dm
@@ -29,7 +29,7 @@
 /obj/structure/bed/chair/vehicle/janicart/examine(mob/user)
 	..()
 	if(in_range(src, user) && reagents.has_reagent(LUBE))
-		to_chat(user, "<span class='warning'> Something is very off about this water.</span>")
+		to_chat(user, "<span class='warning'>Something is very off about this water.</span>")
 	switch(health)
 		if(75 to 99)
 			to_chat(user, "<span class='info'>It appears slightly dented.</span>")
@@ -77,6 +77,18 @@
 	if(mybag && !usr.incapacitated() && Adjacent(usr) && usr.dexterity_check())
 		mybag.forceMove(get_turf(usr))
 		usr.put_in_hands(mybag)
+		mybag = null
+
+/obj/structure/bed/chair/vehicle/janicart/die()
+	var/obj/effect/decal/mecha_wreckage/vehicle/wreck = ..()
+
+	// Add janicart upgrade to wreck, if it passes the roll.
+	if(upgraded)
+		wreck.add_salvagable(new /obj/item/mecha_parts/janicart_upgrade(src)) // 30% chance
+
+	// Same with the bag
+	if(mybag)
+		wreck.add_salvagable(mybag, 75)
 		mybag = null
 
 /obj/structure/bed/chair/vehicle/janicart/attack_hand(mob/user)
@@ -128,5 +140,5 @@
 /obj/effect/decal/mecha_wreckage/vehicle/janicart
 	icon = 'icons/obj/vehicles.dmi'
 	icon_state = "pussywagon_destroyed"
-	name = "\improper Go-Kart wreckage"
-	desc = "You don't think AAA will cover this."
+	name = "janicart wreckage"
+	desc = "Guess it's back to the mop."

--- a/code/game/objects/structures/vehicles/lightcycle.dm
+++ b/code/game/objects/structures/vehicles/lightcycle.dm
@@ -66,6 +66,7 @@
 	keytype = /obj/item/key/lightcycle
 	layer = FLY_LAYER
 	pass_flags = PASSMOB|PASSDOOR
+	wreckage_type = /obj/effect/decal/mecha_wreckage/vehicle/lightcycle
 	var/obj/item/key/lightcycle/summoning_rod = null
 	var/delay_ribbon = 0
 	var/l_color = "#FFFFFF"
@@ -126,7 +127,7 @@
 /obj/structure/bed/chair/vehicle/lightcycle/proc/movement_process()
 	if(!occupant)
 		return
-	if(occupant.incapacitated() || destroyed)
+	if(occupant.incapacitated())
 		unlock_atom(occupant)
 		return
 	if(!check_key(occupant))
@@ -250,3 +251,10 @@
 				spawn(1)
 					L.erase()
 	qdel(src)
+
+/obj/effect/decal/mecha_wreckage/vehicle/lightcycle
+	// TODO: SPRITE PLS
+	//icon = 'icons/obj/vehicles.dmi'
+	//icon_state = "lightcycle_wreck"
+	name = "light cycle wreckage"
+	desc = "Awaiting garbage collection."

--- a/code/game/objects/structures/vehicles/secway.dm
+++ b/code/game/objects/structures/vehicles/secway.dm
@@ -4,6 +4,7 @@
 	icon_state = "secway"
 	keytype = /obj/item/key/security
 	can_have_carts = FALSE
+	wreckage_type = /obj/effect/decal/mecha_wreckage/vehicle/secway
 	var/clumsy_check = 1
 
 /obj/item/key/security
@@ -64,3 +65,10 @@
 		var/mob/living/idiot = obstacle
 		idiot.Knockdown(2)
 		idiot.Stun(2)
+
+/obj/effect/decal/mecha_wreckage/vehicle/secway
+	// TODO: SPRITE PLS
+	//icon = 'icons/obj/vehicles.dmi'
+	//icon_state = "gokart_wreck"
+	name = "secway wreckage"
+	desc = "Nothing to see here!"

--- a/code/game/objects/structures/vehicles/vehicle.dm
+++ b/code/game/objects/structures/vehicles/vehicle.dm
@@ -27,7 +27,6 @@
 	var/empstun = 0
 	var/health = 100
 	var/max_health = 100
-	var/destroyed = 0
 
 	plane = ABOVE_HUMAN_PLANE
 	layer = VEHICLE_LAYER
@@ -47,6 +46,7 @@
 
 	var/mob/occupant
 	lock_type = /datum/locking_category/buckle/chair/vehicle
+	var/wreckage_type = /obj/effect/decal/mecha_wreckage/vehicle
 
 /obj/structure/bed/chair/vehicle/proc/getMovementDelay()
 	return movement_delay
@@ -80,8 +80,6 @@
 	if (istype(W, /obj/item/weapon/weldingtool))
 		var/obj/item/weapon/weldingtool/WT = W
 		if (WT.remove_fuel(0))
-			if(destroyed)
-				to_chat(user, "<span class='warning'>\The [src.name] is destroyed beyond repair.</span>")
 			add_fingerprint(user)
 			user.visible_message("<span class='notice'>[user] has fixed some of the dents on \the [src].</span>", "<span class='notice'>You fix some of the dents on \the [src]</span>")
 			health += 20
@@ -102,7 +100,7 @@
 		return user.is_holding_item(mykey)
 
 /obj/structure/bed/chair/vehicle/relaymove(var/mob/living/user, direction)
-	if(user.incapacitated()  || destroyed)
+	if(user.incapacitated())
 		unlock_atom(user)
 		return
 	if(!check_key(user))
@@ -153,7 +151,7 @@
 		S.Entered(src)*/
 
 /obj/structure/bed/chair/vehicle/proc/can_buckle(mob/M, mob/user)
-	if(M != user || !ishuman(user) || !Adjacent(user) || user.restrained() || user.lying || user.stat || user.locked_to || destroyed || occupant)
+	if(M != user || !ishuman(user) || !Adjacent(user) || user.restrained() || user.lying || user.stat || user.locked_to || occupant)
 		return 0
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
@@ -273,7 +271,7 @@
 /obj/structure/bed/chair/vehicle/proc/HealthCheck()
 	if(health > max_health)
 		health = max_health
-	if(health <= 0 && !destroyed)
+	if(health <= 0)
 		die()
 
 /obj/structure/bed/chair/vehicle/ex_act(severity)
@@ -287,12 +285,19 @@
 	HealthCheck()
 
 /obj/structure/bed/chair/vehicle/proc/die() //called when health <= 0
-	destroyed = 1
 	density = 0
 	visible_message("<span class='warning'>\The [nick] explodes!</span>")
 	explosion(src.loc,-1,0,2,7,10)
-	icon_state = "pussywagon_destroyed"
+	//icon_state = "pussywagon_destroyed"
 	unlock_atom(occupant)
+	if(wreckage_type)
+		var/obj/effect/decal/mecha_wreckage/wreck = new wreckage_type(src.loc)
+		setup_wreckage(wreck)
+	qdel(src)
+
+/obj/structure/bed/chair/vehicle/proc/setup_wreckage(var/obj/effect/decal/mecha_wreckage/wreck)
+	// Transfer salvagables here.
+	return
 
 /obj/structure/bed/chair/vehicle/Bump(var/atom/movable/obstacle)
 	if(obstacle == src || (is_locking(/datum/locking_category/buckle/chair/vehicle, subtypes=TRUE) && obstacle == get_locked(/datum/locking_category/buckle/chair/vehicle, subtypes=TRUE)[1]))

--- a/code/game/objects/structures/vehicles/wheelchair.dm
+++ b/code/game/objects/structures/vehicles/wheelchair.dm
@@ -52,7 +52,7 @@
 		overlays -= wheel_overlay
 
 /obj/structure/bed/chair/vehicle/wheelchair/can_buckle(mob/M, mob/user)
-	if(M != user || !Adjacent(user) || (!ishuman(user) && !isalien(user) && !ismonkey(user)) || user.restrained() || user.stat || user.locked_to || destroyed || occupant) //Same as vehicle/can_buckle, minus check for user.lying as well as allowing monkey and ayliens
+	if(M != user || !Adjacent(user) || (!ishuman(user) && !isalien(user) && !ismonkey(user)) || user.restrained() || user.stat || user.locked_to || occupant) //Same as vehicle/can_buckle, minus check for user.lying as well as allowing monkey and ayliens
 		return 0
 	return 1
 
@@ -176,7 +176,7 @@
 
 /obj/structure/bed/chair/vehicle/wheelchair/multi_people/can_buckle(mob/M, mob/user)
 	//Same as parent's, but no occupant check!
-	if(M != user || !Adjacent(user) || (!ishuman(user) && !isalien(user) && !ismonkey(user)) || user.restrained() || user.stat || user.locked_to || destroyed)
+	if(M != user || !Adjacent(user) || (!ishuman(user) && !isalien(user) && !ismonkey(user)) || user.restrained() || user.stat || user.locked_to)
 		return 0
 	return 1
 

--- a/code/game/objects/structures/vehicles/wizmobile.dm
+++ b/code/game/objects/structures/vehicles/wizmobile.dm
@@ -28,6 +28,7 @@
 	layer = FLY_LAYER
 	plane = ABOVE_HUMAN_PLANE
 	pass_flags = PASSMOB|PASSDOOR
+	wreckage_type = /obj/effect/decal/mecha_wreckage/vehicle/firebird
 
 	var/datum/effect/effect/system/trail/firebird/ion_trail
 
@@ -98,3 +99,10 @@
 	name = "snowmobile"
 	desc = "After a complaint from space PETA, santa's been forced to take a less elegant ride."
 	icon_state = "snowmobile"
+
+/obj/effect/decal/mecha_wreckage/vehicle/firebird
+	// TODO: SPRITE PLS
+	//icon = 'icons/obj/vehicles.dmi'
+	//icon_state = "gokart_wreck"
+	name = "\improper Firebird wreckage"
+	desc = "The magic is gone."

--- a/html/changelogs/N3X15-wreckfixes.yml
+++ b/html/changelogs/N3X15-wreckfixes.yml
@@ -1,0 +1,39 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general deleting of nice things)
+#   rscadd (general adding of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.
+author: N3X15
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# There needs to be a space after the - and before the prefix. Don't use tabs anywhere in this file.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# If you're using characters such as # ' : - or the like in your changelog, surround the entire change with quotes as shown in the second example. These quotes don't show up on the changelog once it's merged and prevent errors.
+# SCREW ANY OF THIS UP AND IT WON'T WORK.
+changes: 
+- rscadd: "Mecha wrecks are removed after completely salvaging them."
+- rscadd: "Mecha wrecks display possible salvaging options when examining them."
+- wip: "Vehicle (janicart, clowncart, etc) wrecks now work the same as mecha wrecks. (Some icons still need to be made, so your secway may turn into a burning janicart.)"
+- bugfix: "Vehicle wrecks can no longer be repaired."


### PR DESCRIPTION
# Executive Summary
This PR makes mecha wrecks and vehicle wrecks operate similarly, and permits them to be removed after salvaging.  This also fixes a minor bug that allows janicarts to be "repaired" after being wrecked (without actually fixing anything).

Other minor fixes and cleanups have been done.

# Caveats
* I'm not a (good) spriter and some vehicles do not have wreckage sprites.
* Some balancing work may be needed.

# Changelog
See `html/changelogs/N3X15-wreckfixes.yml`.