### PR TITLE
[DNM] Revert TG memleak hotfix hack

### DIFF
--- a/code/modules/lighting/lighting_corner.dm
+++ b/code/modules/lighting/lighting_corner.dm
@@ -110,9 +110,9 @@
 	else if (mx < LIGHTING_SOFT_THRESHOLD)
 		. = 0 // 0 means soft lighting.
 
-	cache_r  = lum_r * . + (rand(1,999)/100000) || LIGHTING_SOFT_THRESHOLD
-	cache_g  = lum_g * . + (rand(1,999)/100000) || LIGHTING_SOFT_THRESHOLD
-	cache_b  = lum_b * . + (rand(1,999)/100000) || LIGHTING_SOFT_THRESHOLD
+	cache_r  = lum_r * . || LIGHTING_SOFT_THRESHOLD
+	cache_g  = lum_g * . || LIGHTING_SOFT_THRESHOLD
+	cache_b  = lum_b * . || LIGHTING_SOFT_THRESHOLD
 	cache_mx = mx
 
 	for (var/TT in masters)


### PR DESCRIPTION
Staging for >= 511.1377, which has fixed this issue.

More information: http://www.byond.com/forum/?post=2220974

Leaving the rand() calls in there may result in lower performance since sampling random noise is slow.