### PR TITLE
Hacking the cargo console removes its access requirement

### DIFF
--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -110,6 +110,7 @@ var/list/mechtoys = list(
 	var/reqtime = 0 //Cooldown for requisitions - Quarxink
 	var/hacked = 0
 	var/can_order_contraband = 0
+	var/all_access = 0
 	var/last_viewed_group = "Supplies" // not sure how to get around hard coding this
 	var/datum/money_account/current_acct
 
@@ -593,7 +594,7 @@ var/list/mechtoys = list(
 	return
 
 /obj/machinery/computer/supplycomp/attack_hand(var/mob/user as mob)
-	if(!allowed(user))
+	if(!allowed(user) && !can_order_contraband) //if board is hacked then it removes access requirement
 		to_chat(user, "<span class='warning'>Access Denied.</span>")
 		return
 
@@ -648,6 +649,7 @@ var/list/mechtoys = list(
 				qdel(src)
 	else
 		return ..()
+
 
 /obj/machinery/computer/supplycomp/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null)
 	// data to send to ui

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -110,7 +110,6 @@ var/list/mechtoys = list(
 	var/reqtime = 0 //Cooldown for requisitions - Quarxink
 	var/hacked = 0
 	var/can_order_contraband = 0
-	var/all_access = 0
 	var/last_viewed_group = "Supplies" // not sure how to get around hard coding this
 	var/datum/money_account/current_acct
 


### PR DESCRIPTION
Hacking and unlocking contraband using a solder iron would have a new function in this PR. If the board is hacked with solder then what it does is remove the access requirement on the console meaning you do not need cargo access to buy things (but you still need a ID with a functional bank account and $$$). 

The reasoning behind this is that it is common past half a hour for cargo techs to all die/fuck off/refuse to do orders leaving people who need stuff from cargo to be forced to beg the hop for access (which commonly says no) or ask the sillicons (which turns into a mess of its own).

 If there is no one in cargo to stop someone from breaking in, deconstructing the console, hacking it, and rebuilding it then there really is no reason why they should not be stopped from doing so since if no cargo techs walk in on you for the 60 seconds needed for this process then it probably means cargo wont be doing their jobs at all.

Note it has to be hacked with a solder iron. Not emagged