### PR TITLE
Access requirements fixes in deff+meta

### DIFF
--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -154,7 +154,7 @@
 	selection_color = "#fff5cc"
 	idtype = /obj/item/weapon/card/id/engineering
 	access = list(access_eva, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction, access_mechanic, access_tcomsat, access_science)
-	minimal_access = list(access_maint_tunnels, access_emergency_storage, access_construction, access_engine_equip, access_external_airlocks, access_mechanic, access_science)
+	minimal_access = list(access_maint_tunnels, access_emergency_storage, access_construction, access_engine_equip, access_external_airlocks, access_mechanic, access_tcomsat, access_science)
 	alt_titles = list("Telecommunications Technician", "Spacepod Mechanic", "Greasemonkey")
 
 	pdaslot=slot_l_store


### PR DESCRIPTION
Closes #14289 and #14270

# Github changelog
- **Added tcomms access to mechanic's `minimal_access` list** 
By default, all jobs start with `minimal_access` in, at least, deff, but mechanics couldn't access tcomms, even though it's part of their job (they even got an alt title, tcomms tech).
- **Defficiency:**
  - Mechanic's windoors, EVA and tcomms airlocks now have proper access requirements
- **Metaclub:**
  - Mechanic's windoor now have proper access requirements

# In-game changelog

:cl:
 * bugfix: Defficiency: Mechanic's windoors, EVA and telecomms airlocks now have proper access requirements
 * bugfix: Metaclub: Mechanic's windoors now have proper access requirements
