### PR TITLE
Fixes bluespace and stasis beakers having wrong overlays

### DIFF
--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -232,6 +232,9 @@
 	flags = FPRINT  | OPENCONTAINER | NOREACT
 	origin_tech = Tc_BLUESPACE + "=3;" + Tc_MATERIALS + "=4"
 
+/obj/item/weapon/reagent_containers/glass/beaker/noreact/update_icon()
+	return
+
 /obj/item/weapon/reagent_containers/glass/beaker/noreact/large
 	name = "large stasis beaker"
 	desc = "A beaker powered by experimental bluespace technology. Chemicals are held in stasis and do not react inside of it. Can hold up to 100 units."
@@ -250,6 +253,9 @@
 	possible_transfer_amounts = list(5,10,15,25,30,50,100,200)
 	flags = FPRINT  | OPENCONTAINER
 	origin_tech = Tc_BLUESPACE + "=2;" + Tc_MATERIALS + "=3"
+
+/obj/item/weapon/reagent_containers/glass/beaker/bluespace/update_icon()
+	return
 
 /obj/item/weapon/reagent_containers/glass/beaker/bluespace/large
 	name = "large bluespace beaker"


### PR DESCRIPTION
Closes #14342

# Comments
I don't know what *is* wrong, I am not sure if it started to happen with #14227, or with my other bloodpack PR.
Containers share `filling.icon_state = "[icon_state]#"` so it makes no sense that a certain container ends up with the wrong fillings, perhaps it has to do with the fact that stasis and bluespace beakers actually have no filling overlays, but who knows.

So yeah, this is what I could come up with.

# In-game changelog
:cl: 
 * bugfix: Fixed bluespace and stasis beakers having wrong overlays