### PR TITLE
Fixes a runtime in hugborg's logging and few other fixes

### DIFF
--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -16,7 +16,7 @@
 
 	attack(mob/M as mob, mob/living/silicon/robot/user as mob)
 		M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been attacked with [src.name] by [user.name] ([user.ckey])</font>")
-		user.attack_log += text("\[[time_stamp()]\] <font color='red'>Used the [src.name] to attack [M.name] ([M.ckey])</font>")
+		user.attack_log += text("\[[time_stamp()]\] <span class='danger'>Used the [src.name] to attack [M.name] ([M.ckey])</font>")
 		msg_admin_attack("[user.name] ([user.ckey]) used the [src.name] to attack [M.name] ([M.ckey]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
 
 
@@ -180,7 +180,7 @@
 	if(safety == TRUE)
 		user.visible_message("<span class='big danger'>HUMAN HARM</font>")
 		playsound(get_turf(src), 'sound/AI/harmalarm.ogg', 70, 3)
-		for(var/mob/living/carbon/M in ohearers(9, user))
+		for(var/mob/living/carbon/M in hearers(9, user))
 			if(M.earprot())
 				continue
 			to_chat(M, "<span class='warning'>[user] blares out a near-deafening siren from its speakers!</font>")
@@ -190,7 +190,7 @@
 			M.dizziness += 5
 			M.confused +=  5
 			M.Jitter(5)
-			add_logs(M, "alarmed by \the [src]", admin = FALSE)
+			add_gamelogs(user, "alarmed [key_name(M)] with \the [src]", tp_link = FALSE)
 		cooldown = world.time + 20 SECONDS
 		add_gamelogs(user, "used \the [src]", admin = TRUE, tp_link = TRUE, tp_link_short = FALSE, span_class = "notice")
 		return
@@ -201,11 +201,11 @@
 		for(var/mob/living/carbon/M in hearers(6, user))
 			if(M.earprot())
 				continue
-			M.sleeping = 0
+			M.sleeping = 0 // WAKE ME UP
 			M.stuttering += 30
 			M.ear_deaf += 10
-			M.Knockdown(7)
+			M.Knockdown(7) // CAN'T WAKE UP
 			M.Jitter(30)
-			add_logs(M, "alarmed by an emagged [name]", admin = FALSE)
+			add_gamelogs(user, "knocked out [key_name(M)] with an emagged [name]", tp_link = FALSE)
 		cooldown = world.time + 1 MINUTES
 		add_gamelogs(user, "used an emagged [name]", admin = TRUE, tp_link = TRUE, tp_link_short = FALSE, span_class = "danger")

--- a/code/modules/research/xenoarchaeology/finds/finds_strangeball.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds_strangeball.dm
@@ -1,5 +1,5 @@
 /obj/item/device/mmi/posibrain/strangeball
-	name = "strange ball"
+	name = "\improper strange ball"
 	desc = "A complex metallic ball with \"TG17355\" carved on its surface."
 	var/ball = "omoikaneball"
 	var/burger = "omoikane"
@@ -14,6 +14,8 @@
 	src.searching = 0
 	var/turf/T = get_turf(src)
 	var/mob/living/silicon/robot/M = new /mob/living/silicon/robot(T)
+	M.UnlinkSelf() //No Lawsync, No robotics console, No camera, final destination.
+	M.laws = new /datum/ai_laws/asimov() // WOOP WOOP HUMAN HARM
 	M.cell.maxcharge = 15000
 	M.cell.charge = 15000
 	M.pick_module(forced_module="TG17355")
@@ -22,7 +24,7 @@
 	M.ckey = candidate.ckey
 	M.Namepick()
 	M.updatename()
-	src.investigation_log(I_ARTIFACT, "|| [key_name(candidate)] spawned as TG17355 Cyborg.")
+	src.investigation_log(I_ARTIFACT, "|| [key_name(M)] spawned as TG17355 Cyborg.")
 	qdel(src)
 
 /obj/item/device/mmi/posibrain/strangeball/reset_search()
@@ -30,7 +32,7 @@
 	icon_state = ball
 
 /obj/item/device/mmi/posibrain/strangeball/strangeegg
-	name = "strange egg"
+	name = "\improper strange egg"
 	desc = "A complex egg-like machine with \"TG17355\" carved on its surface."
 	ball = "peaceegg"
 	burger = "peaceborg"

--- a/code/modules/research/xenoarchaeology/finds/finds_strangeball.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds_strangeball.dm
@@ -1,5 +1,5 @@
 /obj/item/device/mmi/posibrain/strangeball
-	name = "\improper strange ball"
+	name = "strange ball"
 	desc = "A complex metallic ball with \"TG17355\" carved on its surface."
 	var/ball = "omoikaneball"
 	var/burger = "omoikane"
@@ -32,7 +32,7 @@
 	icon_state = ball
 
 /obj/item/device/mmi/posibrain/strangeball/strangeegg
-	name = "\improper strange egg"
+	name = "strange egg"
 	desc = "A complex egg-like machine with \"TG17355\" carved on its surface."
 	ball = "peaceegg"
 	burger = "peaceborg"


### PR DESCRIPTION
`[06:13:14]DEBUG: Runtime in <b>mobs.dm</b>, line <b>168</b>: <b>Cannot read "alarmed by the sonic harm prev...".name</b> <a href='?_src_=holder;viewruntime=[0x210b3a34]'>[view]</a>
[06:13:14]GAME: <span class='notice'>Widget (sageoflight) has used the sonic harm prevention tool.</span> (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=255;Y=242;Z=1'>Starboard Primary Hallway - 255,242,1</a>)`

![fixit](https://cloud.githubusercontent.com/assets/17928298/23941213/c1727c8a-0946-11e7-94a2-f73023cdfeb6.png)

Other changes:
* Fixes an oversight with the default sonic harm prevention using ohearers instead of hearers
* Fixes TG17355 cyborg spawning log using the candidate's name/key
* Fixes TG17355 cyborgs starting linked to the station's AI and its laws.