### PR TITLE
Medbay intercoms

### DIFF
--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -165,3 +165,11 @@
 	starting_materials = list(MAT_IRON = 50, MAT_GLASS = 50)
 	w_type = RECYK_ELECTRONIC
 	melt_temperature = MELTPOINT_SILICON
+
+/obj/item/device/radio/intercom/medbay
+	name = "station intercom (Medbay)"
+	frequency = 1485
+
+/obj/item/device/radio/intercom/medbay/broadcast_nospeaker
+	broadcasting = 1
+	listening = 0


### PR DESCRIPTION
**DO NOT MERGE.** I still have to do Meta Club, there will be conflicts if I do it before the other map PR gets merged.

Closes #10993

**The idea is that medbay's intercoms are a "closed system". Some intercoms in key areas broadcast by default, meaning you can be heard in *all* of medbay.**

# Github changelog
- Replaced *all* medbay's intercoms with a subtype that has:
  - New name "station intercom (Medbay)"
  - Frequency 1485
  - The following intercoms broadcast by default and have their speaker turned off:
    - The one near the cloning pod
    - The ones that are near the entrance's desk (2 for box, 1 for deff)
    - The ones in patient rooms (2 for box, 1 for deff)

# In-game changelog
:cl: 
 * rscadd: All maps: medbay's intercoms are now a closed system. Talk in one, be heard everywhere inside.
 * rscadd: All maps: medbay's intercoms near the entrance, cloning pod and inside patient rooms broadcast by default.
