### PR TITLE
Map element scoreboard functionality

### DIFF
--- a/code/datums/map_elements.dm
+++ b/code/datums/map_elements.dm
@@ -51,3 +51,8 @@ var/list/datum/map_element/map_elements = list()
 		return maploader.get_map_dimensions(file)
 
 	return list(width, height)
+
+//Return a list with strings associated with points
+//For example: list("Discovered a vault!" = 500) will add 500 points to the crew's score for discovering a vault
+/datum/map_element/proc/process_scoreboard()
+	return

--- a/code/datums/map_elements.dm
+++ b/code/datums/map_elements.dm
@@ -56,3 +56,31 @@ var/list/datum/map_element/map_elements = list()
 //For example: list("Discovered a vault!" = 500) will add 500 points to the crew's score for discovering a vault
 /datum/map_element/proc/process_scoreboard()
 	return
+
+//Proc for statskeeping and tracking objects. Cleans references afterwards - very safe to use. Use it to assign objects as values to variables
+//Example use:
+//  boss_enemy = track_atom(new /mob/living/simple_animal/corgi)
+
+/datum/map_element/proc/track_atom(atom/A)
+	if(!istype(A))
+		return
+
+	A.on_destroyed.Add(src, "clear_references")
+
+	return A
+
+
+/datum/map_element/proc/clear_references(list/params)
+	var/atom/A = locate(/atom) in params
+
+	//Remove instances by brute force (there aren't that many vars in map element datums)
+	for(var/key in vars)
+		if(vars[key] == A)
+			vars[key] = null
+		else if(istype(vars[key], /list))
+			var/list/L = vars[key]
+
+			//Remove all instances from the list
+			while(L.Remove(A))
+				continue
+

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -129,7 +129,7 @@ var/global/list/ghdel_profiling = list()
 
 	// Idea by ChuckTheSheep to make the object even more unreferencable.
 	invisibility = 101
-	INVOKE_EVENT(on_destroyed, list()) // No args.
+	INVOKE_EVENT(on_destroyed, list(src)) // 1 argument - the object itself
 	if(on_destroyed)
 		on_destroyed.holder = null
 		on_destroyed = null

--- a/code/game/gamemodes/scoreboard.dm
+++ b/code/game/gamemodes/scoreboard.dm
@@ -442,6 +442,17 @@
 	<B>Number of Arena Rounds:</B> [score["arenafights"]]<BR>
 	<B>Total money trasferred:</B> [score["totaltransfer"]]<BR>"}
 
+	for(var/datum/map_element/ME in map_elements)
+		var/list/L = ME.process_scoreboard()
+		if(!L)
+			continue
+
+		dat += "<u>[capitalize(ME.name)]</u><br>"
+		for(var/score_value in L)
+			dat += "<b>[score_value]: </b> [L[score_value]]<br>"
+			score["crewscore"] += L[score_value]
+		dat += "<br>"
+
 	if(arena_top_score)
 		dat += "<B>Best Arena Fighter (won [arena_top_score] rounds!):</B> [score["arenabest"]]<BR>"
 

--- a/code/game/gamemodes/scoreboard.dm
+++ b/code/game/gamemodes/scoreboard.dm
@@ -447,9 +447,10 @@
 		if(!L)
 			continue
 
-		dat += "<u>[capitalize(ME.name)]</u><br>"
+		dat += "<u>[ME.name ? uppertext(ME.name) : "UNKNOWN SPACE STRUCTURE"]</u><br>"
+
 		for(var/score_value in L)
-			dat += "<b>[score_value]: </b> [L[score_value]]<br>"
+			dat += "<b>[score_value]</b>[L[score_value] ? "<b>:</b> [L[score_value]]" : ""]<br>"
 			score["crewscore"] += L[score_value]
 		dat += "<br>"
 

--- a/code/modules/randomMaps/vault_definitions.dm
+++ b/code/modules/randomMaps/vault_definitions.dm
@@ -123,12 +123,3 @@ var/list/existing_vaults = list()
 
 /datum/map_element/vault/research_facility
 	file_path = "maps/randomvaults/research_facility.dmm"
-
-/datum/map_element/vault/supermarket
-	file_path = "maps/randomvaults/spessmart.dmm"
-
-/datum/map_element/vault/supermarket/initialize(list/objects)
-	..()
-
-	var/area/vault/supermarket/shop/S = locate(/area/vault/supermarket/shop)
-	S.initialize()

--- a/code/modules/randomMaps/vault_definitions.dm
+++ b/code/modules/randomMaps/vault_definitions.dm
@@ -51,7 +51,29 @@ var/list/existing_vaults = list()
 	file_path = "maps/randomvaults/rust.dmm"
 
 /datum/map_element/vault/dance_revolution
+	name = "Dance Dance Revolution"
 	file_path = "maps/randomvaults/dance_revolution.dmm"
+	var/obj/structure/dance_dance_revolution/machine
+
+/datum/map_element/vault/dance_revolution/initialize(list/objects)
+	.=..()
+
+	machine = track_atom(locate(/obj/structure/dance_dance_revolution) in objects)
+
+/datum/map_element/vault/dance_revolution/process_scoreboard()
+	var/list/L = list()
+
+	if(!machine)
+		L += "The game has been destroyed!"
+	else if(machine.wins || machine.attempts)
+		L += "[machine.attempts] attempts have been made in total."
+		L += "Of them, [machine.wins] were successful."
+		if(machine.winner)
+			L += "The first dancer to successfully finish the game was [machine.winner]."
+		else
+			L += "Nobody was good enough to finish the game."
+
+	return L
 
 /datum/map_element/vault/spacegym
 	file_path = "maps/randomvaults/spacegym.dmm"

--- a/maps/randomvaults/dance_revolution.dm
+++ b/maps/randomvaults/dance_revolution.dm
@@ -25,6 +25,11 @@
 
 	var/process_delay = 15 //in deciseconds
 
+	//Stats!
+	var/attempts = 0
+	var/wins = 0
+	var/winner = "" //Name of the winner
+
 /obj/structure/dance_dance_revolution/Destroy()
 	stop_game()
 
@@ -47,14 +52,20 @@
 	for(var/obj/effect/ddr_instruction/D in get_area(src))
 		instruction_effects.Add(D)
 
+	attempts++
+
 	spawn()
 		process()
 
 /obj/structure/dance_dance_revolution/proc/win()
 	to_chat(dancer, "<span class='info'>You win!</span>")
+	if(!winner)
+		winner = "[dancer]"
 
 	stop_game()
 	playsound(get_turf(src), 'sound/machines/ding2.ogg', 50)
+
+	wins++
 
 	spawn()
 		for(var/obj/effect/ddr_loot/E in get_area(src))

--- a/maps/randomvaults/spessmart.dm
+++ b/maps/randomvaults/spessmart.dm
@@ -142,7 +142,7 @@ var/list/clothing_prices = list()	//gets filled on initialize()
 
 	var/datum/map_element/vault/supermarket/map_element
 
-/area/vault/supermarket/loaded_by_map_element(datum/map_element/ME)
+/area/vault/supermarket/spawned_by_map_element(datum/map_element/ME)
 	if(istype(ME, /datum/map_element/vault/supermarket))
 		map_element = ME
 

--- a/maps/randomvaults/spessmart.dm
+++ b/maps/randomvaults/spessmart.dm
@@ -97,6 +97,40 @@ var/list/shop_prices = list( //Cost in space credits
 //No guns sorry
 )
 
+
+/datum/map_element/vault/supermarket
+	file_path = "maps/randomvaults/spessmart.dmm"
+
+	//Statistics gathering!
+	var/credits_spent   = 0
+	var/goods_purchased = 0
+	var/alarm_activated = "" //Holds the explanation for alarm's activation
+
+/datum/map_element/vault/supermarket/process_scoreboard()
+	var/list/L = list()
+
+	if(credits_spent || goods_purchased || alarm_activated)
+		L += "Credits spent: $[credits_spent]"
+		L += "Goods purchased: [goods_purchased]"
+
+		if(alarm_activated)
+			L += "Alarm activated: [alarm_activated]"
+
+	return L
+
+/datum/map_element/vault/supermarket/proc/set_stats_alarm_activated(msg)
+	if(alarm_activated)
+		return
+
+	alarm_activated = msg
+
+/datum/map_element/vault/supermarket/initialize(list/objects)
+	..()
+
+	var/area/vault/supermarket/shop/S = locate(/area/vault/supermarket/shop)
+	S.initialize()
+
+
 var/list/circuitboards = existing_typesof(/obj/item/weapon/circuitboard) - /obj/item/weapon/circuitboard/card/centcom //All circuit boards can be bought in Spessmart
 var/list/circuitboard_prices = list()	//gets filled on initialize()
 var/list/clothing = existing_typesof(/obj/item/clothing) - typesof(/obj/item/clothing/suit/space/ert) - typesof(/obj/item/clothing/head/helmet/space/ert) - list(/obj/item/clothing/suit/space/rig/elite, /obj/item/clothing/suit/space/rig/deathsquad, /obj/item/clothing/suit/space/rig/wizard, /obj/item/clothing/head/helmet/space/bomberman, /obj/item/clothing/suit/space/bomberman, /obj/item/clothing/mask/stone/infinite) //What in the world could go wrong
@@ -105,6 +139,14 @@ var/list/clothing_prices = list()	//gets filled on initialize()
 /area/vault/supermarket
 	name = "Spessmart"
 	flags = NO_PORTALS | NO_TELEPORT
+
+	var/datum/map_element/vault/supermarket/map_element
+
+/area/vault/supermarket/loaded_by_map_element(datum/map_element/ME)
+	if(istype(ME, /datum/map_element/vault/supermarket))
+		map_element = ME
+
+	..()
 
 /area/vault/supermarket/entrance
 	name = "Spessmart Entrance"
@@ -163,17 +205,21 @@ var/list/clothing_prices = list()	//gets filled on initialize()
 		return
 
 	if(items.Find(AM))
-		return on_theft()
+		return on_theft(AM)
 	else
 		var/list/AM_contents = get_contents_in_object(AM, /obj/item)
 
 		for(var/obj/item/I in AM_contents)
 			if(items.Find(I))
-				return on_theft()
+				return on_theft(I)
 
-/area/vault/supermarket/shop/proc/purchased(obj/item/I)
+/area/vault/supermarket/shop/proc/purchased(obj/item/I, price)
 	items.Remove(I)
 	I.name = initial(I.name)
+
+	if(map_element)
+		map_element.goods_purchased++
+		map_element.credits_spent += price
 
 /area/vault/supermarket/shop/proc/item_destroyed()
 	for(var/obj/item/I in items)
@@ -181,10 +227,19 @@ var/list/clothing_prices = list()	//gets filled on initialize()
 			items.Remove(I)
 			message_admins("Spessmart has entered lockdown due to the destruction of \a [I]!")
 
+			if(map_element)
+				map_element.set_stats_alarm_activated("Destruction of \a [I][usr ? " by [usr]" : ""]")
+
 	if(customer_has_entered)
 		on_theft()
 
-/area/vault/supermarket/shop/proc/on_theft()
+/area/vault/supermarket/shop/proc/on_robot_kill()
+	if(map_element)
+		map_element.set_stats_alarm_activated("Destruction of a robot[usr ? " by [usr]" : ""]")
+
+	on_theft()
+
+/area/vault/supermarket/shop/proc/on_theft(obj/item/I)
 	if(lockdown)
 		return
 
@@ -204,6 +259,9 @@ var/list/clothing_prices = list()	//gets filled on initialize()
 
 	src.firealert()
 	entrance.firealert()
+
+	if(map_element)
+		map_element.set_stats_alarm_activated("Theft of [I ? "\a [I]" : "an unknown item"]")
 
 ///////ROBOTS
 /mob/living/simple_animal/robot
@@ -330,7 +388,7 @@ var/list/clothing_prices = list()	//gets filled on initialize()
 /mob/living/simple_animal/robot/robot_cashier/Die()
 	var/area/vault/supermarket/shop/A = get_area(src)
 	if(istype(A))
-		A.on_theft()
+		A.on_robot_kill()
 
 	return ..()
 
@@ -366,7 +424,7 @@ var/list/clothing_prices = list()	//gets filled on initialize()
 					else
 						say("[found_items.len] items for $[price].00 space credits. Change: $[loaded_cash - price].00 space credits. Thank you for shopping at Spessmart!")
 						for(var/obj/item/I in found_items)
-							shop.purchased(I)
+							shop.purchased(I, shop.items[I])
 						if(shop.destination_disks > 0)
 							say("Please take this complimentary Spessmart shuttle destination disk as well. Shop smart, shop Spessmart!")
 							new /obj/item/weapon/disk/shuttle_coords/vault/supermarket(input_loc)
@@ -572,7 +630,7 @@ var/list/clothing_prices = list()	//gets filled on initialize()
 	var/area/vault/supermarket/A = get_area(src)
 	if(istype(A))
 		var/area/vault/supermarket/shop/AS = locate(/area/vault/supermarket/shop)
-		AS.on_theft()
+		AS.on_robot_kill()
 
 /mob/living/simple_animal/hostile/spessmart_guardian/secure_area/attack_hand(mob/user)
 	if(user.a_intent == I_HELP)

--- a/maps/randomvaults/spessmart.dm
+++ b/maps/randomvaults/spessmart.dm
@@ -99,6 +99,7 @@ var/list/shop_prices = list( //Cost in space credits
 
 
 /datum/map_element/vault/supermarket
+	name = "Spessmart"
 	file_path = "maps/randomvaults/spessmart.dmm"
 
 	//Statistics gathering!


### PR DESCRIPTION
Works

Ripped from the Hive because it's a cool feature and The Hive is still mostly WIP. Map elements can now display stuff on the scoreboard as well as add/subtract the crew score

Looks like this except the map element's name is capitalized (to be more in line with other headers.

![](https://camo.githubusercontent.com/5ffab32f1de8abb13e7b90b002c4a7cfa9a3ed74/687474703a2f2f7075752e73682f754b3044392f333234643638306530302e706e67)

Spessmart and DDR have been updated to use this functionality! Spessmart will display amount of purchased goods, spent credits and reason for triggering of the alarm. DDR will display amount of attempts, amount of wins, and the first winner.

:cl:
 * tweak: Added ability for vaults and away missions to track statistics and display them on the scoreboard
 * rscadd: The Spessmart and Dance Dance Revolution will now display special statistics on the round end scoreboard.
