### PR TITLE
Fixes a few fuckups with mech flags

### DIFF
--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -198,6 +198,7 @@
 	throw_range = 8
 	w_class = W_CLASS_MEDIUM
 	flags = FPRINT
+	mech_flags = MECH_SCAN_ILLEGAL
 	siemens_coefficient = 1
 	origin_tech = Tc_COMBAT + "=3" + Tc_SYNDICATE + "=3"
 	attack_verb = list("attacks", "dices", "cleaves", "tears", "cuts", "slashes",)

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -335,6 +335,7 @@
 	attack_delay = 25 // Heavy.
 	w_class = W_CLASS_LARGE
 	flags = FPRINT | TWOHANDABLE
+	mech_flags = MECH_SCAN_ILLEGAL
 	sharpness_flags = SHARP_BLADE | SERRATED_BLADE
 	origin_tech = Tc_COMBAT + "=6" + Tc_SYNDICATE + "=6"
 	attack_verb = list("attacks", "slashes", "stabs", "slices", "tears", "rips", "dices", "cuts")

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -220,6 +220,7 @@
 	sharpness_flags = SHARP_TIP | SHARP_BLADE | CHOPWOOD
 	w_class = W_CLASS_LARGE
 	flags = FPRINT | TWOHANDABLE
+	mech_flags = MECH_SCAN_FAIL
 	origin_tech = Tc_MAGNETS + "=4;" + Tc_COMBAT + "=5"
 
 /obj/item/weapon/katana/hfrequency/update_wield(mob/user)

--- a/code/modules/research/xenoarchaeology/finds/finds_special.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds_special.dm
@@ -1,7 +1,7 @@
 //What the fuck are these things made of?
 
 /obj/item/weapon/reagent_containers/glass/replenishing
-	mech_flags = MECH_SCAN_ILLEGAL
+	mech_flags = MECH_SCAN_FAIL
 	var/spawning_id
 	var/artifact_id
 


### PR DESCRIPTION
**Github Changelog**
* Changes the self-replenishing containers to MECH_SCAN_FAIL
* Adds MECH_SCAN_ILLEGAL to HF machetes.
* Adds MECH_SCAN_FAIL to HF blades

:cl:
 * tweak: High-Frequency Machetes are no longer scannable by the normal and advanced device analyzers, just by the syndicate analyzer.
 * tweak: High-Frequency Blades are no longer scannable by any means