### PR TITLE
Make small lightable objects not work in an environment with little oxygen

### DIFF
--- a/code/ATMOSPHERICS/hvac/spaceheater.dm
+++ b/code/ATMOSPHERICS/hvac/spaceheater.dm
@@ -126,8 +126,11 @@
 /obj/machinery/space_heater/campfire/attackby(obj/item/I, mob/user)
 	..()
 	var/turf/T = get_turf(src)
-	var/datum/gas_mixture/env = T.return_air()
-	if(!on && cell.charge > 0 && env.oxygen >= 5)
+	var/datum/gas_mixture/env = T.return_air()\
+	if(env.oxygen < 5)
+		to_chat(user, "<span class='notice'>You try to light \the [name], but it won't catch on fire!")
+		return
+	if(!on && cell.charge > 0)
 	//Items with special messages go first - yes, this is all stolen from cigarette code. sue me.
 		if(istype(I, /obj/item/weapon/weldingtool))
 			var/obj/item/weapon/weldingtool/WT = I

--- a/code/ATMOSPHERICS/hvac/spaceheater.dm
+++ b/code/ATMOSPHERICS/hvac/spaceheater.dm
@@ -273,7 +273,7 @@
 
 /obj/machinery/space_heater/process()
 	if(on)
-		if(cell && cell.charge > 0 && env.oxygen >= 5)
+		if(cell && cell.charge > 0)
 			var/turf/simulated/L = loc
 			if(istype(L))
 				var/datum/gas_mixture/env = L.return_air()

--- a/code/ATMOSPHERICS/hvac/spaceheater.dm
+++ b/code/ATMOSPHERICS/hvac/spaceheater.dm
@@ -125,7 +125,9 @@
 
 /obj/machinery/space_heater/campfire/attackby(obj/item/I, mob/user)
 	..()
-	if(!on && cell.charge > 0)
+	var/turf/T = get_turf(src)
+	var/datum/gas_mixture/env = T.return_air()
+	if(!on && cell.charge > 0 && env.oxygen > 10)
 	//Items with special messages go first - yes, this is all stolen from cigarette code. sue me.
 		if(istype(I, /obj/item/weapon/weldingtool))
 			var/obj/item/weapon/weldingtool/WT = I
@@ -270,12 +272,12 @@
 
 
 /obj/machinery/space_heater/process()
+	var/turf/T = get_turf(src)
+	var/datum/gas_mixture/env = T.return_air()
 	if(on)
-		if(cell && cell.charge > 0)
+		if(cell && cell.charge > 0 && env.oxygen > 10)
 
-			var/turf/simulated/L = loc
-			if(istype(L))
-				var/datum/gas_mixture/env = L.return_air()
+			if(istype(T))
 				if(env.temperature != set_temperature + T0C)
 
 					var/transfer_moles = 0.25 * env.total_moles()

--- a/code/ATMOSPHERICS/hvac/spaceheater.dm
+++ b/code/ATMOSPHERICS/hvac/spaceheater.dm
@@ -127,7 +127,7 @@
 	..()
 	var/turf/T = get_turf(src)
 	var/datum/gas_mixture/env = T.return_air()
-	if(!on && cell.charge > 0 && env.oxygen > 10)
+	if(!on && cell.charge > 0 && env.oxygen > 5)
 	//Items with special messages go first - yes, this is all stolen from cigarette code. sue me.
 		if(istype(I, /obj/item/weapon/weldingtool))
 			var/obj/item/weapon/weldingtool/WT = I
@@ -275,7 +275,7 @@
 	var/turf/T = get_turf(src)
 	var/datum/gas_mixture/env = T.return_air()
 	if(on)
-		if(cell && cell.charge > 0 && env.oxygen > 10)
+		if(cell && cell.charge > 0 && env.oxygen > 5)
 
 			if(istype(T))
 				if(env.temperature != set_temperature + T0C)

--- a/code/ATMOSPHERICS/hvac/spaceheater.dm
+++ b/code/ATMOSPHERICS/hvac/spaceheater.dm
@@ -126,7 +126,7 @@
 /obj/machinery/space_heater/campfire/attackby(obj/item/I, mob/user)
 	..()
 	var/turf/T = get_turf(src)
-	var/datum/gas_mixture/env = T.return_air()\
+	var/datum/gas_mixture/env = T.return_air()
 	if(env.oxygen < 5)
 		to_chat(user, "<span class='notice'>You try to light \the [name], but it won't catch on fire!")
 		return

--- a/code/ATMOSPHERICS/hvac/spaceheater.dm
+++ b/code/ATMOSPHERICS/hvac/spaceheater.dm
@@ -127,7 +127,7 @@
 	..()
 	var/turf/T = get_turf(src)
 	var/datum/gas_mixture/env = T.return_air()
-	if(!on && cell.charge > 0 && env.oxygen > 5)
+	if(!on && cell.charge > 0 && env.oxygen >= 5)
 	//Items with special messages go first - yes, this is all stolen from cigarette code. sue me.
 		if(istype(I, /obj/item/weapon/weldingtool))
 			var/obj/item/weapon/weldingtool/WT = I
@@ -272,12 +272,11 @@
 
 
 /obj/machinery/space_heater/process()
-	var/turf/T = get_turf(src)
-	var/datum/gas_mixture/env = T.return_air()
 	if(on)
-		if(cell && cell.charge > 0 && env.oxygen > 5)
-
-			if(istype(T))
+		if(cell && cell.charge > 0 && env.oxygen >= 5)
+			var/turf/simulated/L = loc
+			if(istype(L))
+				var/datum/gas_mixture/env = L.return_air()
 				if(env.temperature != set_temperature + T0C)
 
 					var/transfer_moles = 0.25 * env.total_moles()
@@ -312,10 +311,12 @@
 
 /obj/machinery/space_heater/campfire/process()
 	..()
+	var/turf/T = get_turf(src)
+	var/datum/gas_mixture/env = T.return_air()
 	var/list/comfyfire = list('sound/misc/comfyfire1.ogg','sound/misc/comfyfire2.ogg','sound/misc/comfyfire3.ogg',)
 	if(Floor(cell.charge/10) != lastcharge)
 		update_icon()
-	if(!(cell && cell.charge > 0) && nocell != 2)
+	if(!(cell && cell.charge > 0) && nocell != 2 | env.oxygen < 5)
 		new /obj/effect/decal/cleanable/campfire(get_turf(src))
 		qdel(src)
 		return

--- a/code/game/objects/items/candle.dm
+++ b/code/game/objects/items/candle.dm
@@ -37,6 +37,14 @@
 	if(!lit)
 		return
 	wax--
+	var/turf/T = get_turf(src)
+	var/datum/gas_mixture/env = T.return_air()
+	if(env.oxygen < 5)
+		src.lit = 0
+		set_light(0)
+		processing_objects.Remove(src)
+		update_icon()
+		return
 	if(!wax)
 		new/obj/item/trash/candle(src.loc)
 		if(istype(src.loc, /mob))
@@ -44,8 +52,7 @@
 		qdel(src)
 		return
 	update_icon()
-	if(istype(loc, /turf)) //Start a fire if possible
-		var/turf/T = loc
+	if(istype(T)) //Start a fire if possible
 		T.hotspot_expose(700, 5, surfaces = 0)
 
 /obj/item/candle/attack_self(mob/user as mob)

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -33,7 +33,6 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 	light_color = LIGHT_COLOR_FIRE
 
 /obj/item/weapon/match/New()
-
 	..()
 	update_brightness() //Useful if you want to spawn burnt matches, or burning ones you maniac
 
@@ -43,7 +42,6 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 	processing_objects -= src
 
 /obj/item/weapon/match/examine(mob/user)
-
 	..()
 	switch(lit)
 		if(1)
@@ -55,7 +53,6 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 
 //Also updates the name, the damage and item_state for good measure
 /obj/item/weapon/match/update_icon()
-
 	switch(lit)
 		if(1)
 			name = "lit [initial(name)]"
@@ -74,8 +71,6 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 			damtype = BRUTE
 
 /obj/item/weapon/match/proc/update_brightness()
-
-
 	if(lit == 1) //I wish I didn't need the == 1 part, but Dreamkamer is a dumb puppy
 		processing_objects.Add(src)
 		set_light(brightness_on)
@@ -85,13 +80,19 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 	update_icon()
 
 /obj/item/weapon/match/process()
+	var/mob/living/M = get_holder_of_type(src,/mob/living)
 	var/turf/location = get_turf(src)
 	smoketime--
 	var/datum/gas_mixture/env = location.return_air()
-	if(smoketime <= 0 | env.oxygen < 5)
+	if(smoketime <= 0)
 		lit = -1
 		update_brightness()
 		return
+	if(env.oxygen < 5)
+		lit = -1
+		update_brightness()
+		to_chat(M, "The flame on the [src] suddenly goes out in a weak fashion.")
+
 	if(location)
 		location.hotspot_expose(heat_production, 5, surfaces = istype(loc, /turf))
 		return
@@ -184,7 +185,6 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 	..()
 	to_chat(user, "\The [src] is [lit ? "":"un"]lit.")//Shared with all cigarette sub-types
 
-
 //Also updates the name, the damage and item_state for good measure
 /obj/item/clothing/mask/cigarette/update_icon()
 
@@ -201,8 +201,6 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 			damtype = BRUTE
 
 /obj/item/clothing/mask/cigarette/proc/update_brightness()
-
-
 	if(lit)
 		processing_objects.Add(src)
 		set_light(brightness_on)
@@ -258,7 +256,6 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 	else if(W.is_hot())
 		light("<span class='notice'>[user] lights \his [name] with \the [W].</span>")
 	return
-
 
 /obj/item/clothing/mask/cigarette/afterattack(obj/item/weapon/reagent_containers/glass/glass, mob/user as mob)
 	..()
@@ -350,7 +347,10 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 		lit = 0 //Actually unlight the cigarette so that the lighting can update correctly
 		update_brightness()
 		if(ismob(loc))
-			to_chat(M, "<span class='notice'>Your [name] goes out.</span>")
+			if(env.oxygen < 5)
+				to_chat(M, "<span class='notice'>The [name] suddenly goes out in a weak fashion.</span>")
+			else
+				to_chat(M, "<span class='notice'>Your [name] goes out.</span>")
 			M.u_equip(src, 0)	//Un-equip it so the overlays can update
 		qdel(src)
 		return
@@ -644,7 +644,6 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 
 //Also updates the name, the damage and item_state for good measure
 /obj/item/weapon/lighter/update_icon()
-
 	switch(lit)
 		if(1)
 			name = "lit [initial(name)]"
@@ -658,8 +657,6 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 			damtype = BRUTE
 
 /obj/item/weapon/lighter/proc/update_brightness()
-
-
 	if(lit)
 		processing_objects.Add(src)
 		set_light(brightness_on)
@@ -677,12 +674,14 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 		"<span class='notice'>You refuel \the [src].</span>")
 		playsound(get_turf(src), 'sound/effects/refill.ogg', 50, 1, -6)
 		return
-/obj/item/weapon/lighter/attack_self(mob/living/user)
 
+/obj/item/weapon/lighter/attack_self(mob/living/user)
+	var/turf/T = get_turf(src)
+	var/datum/gas_mixture/env = T.return_air()
 	user.delayNextAttack(5) //Hold on there cowboy
-	if(!fuel)
+	if(!fuel | env.oxygen < 5)
 		user.visible_message("<span class='rose'>[user] attempts to light \the [src] to no avail.</span>", \
-		"<span class='notice'>\The [src] doesn't have enough fuel to ignite</span>")
+		"<span class='notice'>You try to light \the [src], but no flame appears.</span>")
 		return
 	if(!lit) //Lighting the lighter
 		playsound(get_turf(src), pick(lightersound), 50, 1)
@@ -705,10 +704,12 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 		update_brightness()
 
 /obj/item/weapon/lighter/zippo/attack_self(mob/living/user)
+	var/turf/T = get_turf(src)
+	var/datum/gas_mixture/env = T.return_air()
 	user.delayNextAttack(5) //Hold on there cowboy
-	if(!fuel)
+	if(!fuel | env.oxygen < 5)
 		user.visible_message("<span class='rose'>[user] attempts to light \the [src] to no avail.</span>", \
-		"<span class='notice'>\The [src] doesn't have enough fuel to ignite</span>")
+		"<span class='notice'>You try to light \the [src], but no flame appears.</span>")
 		return
 	lit = !lit
 	if(lit) //Was lit
@@ -759,4 +760,4 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 	if(env.oxygen < 5)
 		lit = 0
 		update_brightness()
-		visible_message("<span class='warning'>Without warning, \the [src] suddenly shuts off.</span>")
+		visible_message("<span class='warning'>Without warning, the flame on \the [src] suddenly goes out in a weak fashion.</span>")

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -87,7 +87,8 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 /obj/item/weapon/match/process()
 	var/turf/location = get_turf(src)
 	smoketime--
-	if(smoketime <= 0)
+	var/datum/gas_mixture/env = location.return_air()
+	if(smoketime <= 0 | env.oxygen < 10)
 		lit = -1
 		update_brightness()
 		return
@@ -341,7 +342,8 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 	if(isliving(loc))
 		M.IgniteMob()
 	smoketime--
-	if(smoketime <= 0)
+	var/datum/gas_mixture/env = location.return_air()
+	if(smoketime <= 0 | env.oxygen < 10)
 		if(!inside_item)
 			var/atom/new_butt = new type_butt(location) //Spawn the cigarette butt
 			transfer_fingerprints_to(new_butt)
@@ -753,3 +755,8 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 			update_brightness()
 			visible_message("<span class='warning'>Without warning, \the [src] suddenly shuts off.</span>")
 			fueltime = null
+	var/datum/gas_mixture/env = location.return_air()
+	if(env.oxygen < 10)
+		lit = 0
+		update_brightness()
+		visible_message("<span class='warning'>Without warning, \the [src] suddenly shuts off.</span>")

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -88,7 +88,7 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 	var/turf/location = get_turf(src)
 	smoketime--
 	var/datum/gas_mixture/env = location.return_air()
-	if(smoketime <= 0 | env.oxygen < 10)
+	if(smoketime <= 0 | env.oxygen < 5)
 		lit = -1
 		update_brightness()
 		return
@@ -343,7 +343,7 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 		M.IgniteMob()
 	smoketime--
 	var/datum/gas_mixture/env = location.return_air()
-	if(smoketime <= 0 | env.oxygen < 10)
+	if(smoketime <= 0 | env.oxygen < 5)
 		if(!inside_item)
 			var/atom/new_butt = new type_butt(location) //Spawn the cigarette butt
 			transfer_fingerprints_to(new_butt)
@@ -756,7 +756,7 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 			visible_message("<span class='warning'>Without warning, \the [src] suddenly shuts off.</span>")
 			fueltime = null
 	var/datum/gas_mixture/env = location.return_air()
-	if(env.oxygen < 10)
+	if(env.oxygen < 5)
 		lit = 0
 		update_brightness()
 		visible_message("<span class='warning'>Without warning, \the [src] suddenly shuts off.</span>")

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -348,7 +348,7 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 		update_brightness()
 		if(ismob(loc))
 			if(env.oxygen < 5)
-				to_chat(M, "<span class='notice'>\The [name] suddenly goes out in a weak fashion.</span>")
+				to_chat(M, "<span class='notice'>\The [src] suddenly goes out in a weak fashion.</span>")
 			else
 				to_chat(M, "<span class='notice'>Your [name] goes out.</span>")
 			M.u_equip(src, 0)	//Un-equip it so the overlays can update

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -91,8 +91,8 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 	if(env.oxygen < 5)
 		lit = -1
 		update_brightness()
-		to_chat(M, "The flame on the [src] suddenly goes out in a weak fashion.")
-
+		if(M)
+			to_chat(M, "The flame on \the [src] suddenly goes out in a weak fashion.")
 	if(location)
 		location.hotspot_expose(heat_production, 5, surfaces = istype(loc, /turf))
 		return
@@ -348,7 +348,7 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 		update_brightness()
 		if(ismob(loc))
 			if(env.oxygen < 5)
-				to_chat(M, "<span class='notice'>The [name] suddenly goes out in a weak fashion.</span>")
+				to_chat(M, "<span class='notice'>\The [name] suddenly goes out in a weak fashion.</span>")
 			else
 				to_chat(M, "<span class='notice'>Your [name] goes out.</span>")
 			M.u_equip(src, 0)	//Un-equip it so the overlays can update


### PR DESCRIPTION
Fixes #14417

Makes sense, right? 
No, I didn't touch welders.

:cl:
* tweak: You can no longer light lighters, matches, campfires, or cigarettes in space.