### PR TITLE
QoL improvements to PDA

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1990,7 +1990,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 		id = null
 
 /obj/item/device/pda/proc/create_message(var/mob/living/U = usr, var/obj/item/device/pda/P)
-	var/t = input(U, "Please enter message", "[P]", null) as text
+	var/t = input(U, "Please enter message", "Message to [P]", null) as text|null
 	t = copytext(sanitize(t), 1, MAX_MESSAGE_LEN)
 	if (!t || !istype(P))
 		return

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1990,9 +1990,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 		id = null
 
 /obj/item/device/pda/proc/create_message(var/mob/living/U = usr, var/obj/item/device/pda/P)
-
-
-	var/t = input(U, "Please enter message", name, null) as text
+	var/t = input(U, "Please enter message", "[P]", null) as text
 	t = copytext(sanitize(t), 1, MAX_MESSAGE_LEN)
 	if (!t || !istype(P))
 		return
@@ -2069,12 +2067,12 @@ var/global/list/obj/item/device/pda/PDAs = list()
 
 		if(L)
 			L.show_message("[bicon(P)] <b>Message from [src.owner] ([ownjob]), </b>\"[t]\" (<a href='byond://?src=\ref[P];choice=Message;skiprefresh=1;target=\ref[src]'>Reply</a>)", 2)
-
+		U.show_message("[bicon(src)] <span class='notice'>Message for <a href='byond://?src=\ref[P];choice=Message;skiprefresh=1;target=\ref[src]'>[P]</a> has been sent.</span>")
 		log_pda("[usr] (PDA: [src.name]) sent \"[t]\" to [P.name]")
 		P.overlays.len = 0
 		P.overlays += image('icons/obj/pda.dmi', "pda-r")
 	else
-		to_chat(U, "<span class='notice'>ERROR: Messaging server is not responding.</span>")
+		to_chat(U, "[bicon(src)] <span class='notice'>ERROR: Messaging server is not responding.</span>")
 
 
 /obj/item/device/pda/verb/verb_remove_id()


### PR DESCRIPTION
![dreamseeker_2017-03-25_17-48-30](https://cloud.githubusercontent.com/assets/6307265/24324320/98018044-1184-11e7-8bf4-1d90f1342212.png)
![dreamseeker_2017-03-25_17-28-28](https://cloud.githubusercontent.com/assets/6307265/24324321/9dd9efe2-1184-11e7-9bad-c8dd46365aba.png)

Now the title for the input dialog where you type your PDA message into is the name of the recipient, previously it used to be your PDA's name. The idea is that you can make sure you're sending the message to the right person.
I've also added a (clickable, for further ease of use) confirmation to the sender's PDA whenever a message is successfully sent, and made the error message for when the message can't get through look like the rest of the messages (added a bicon() in front). For some reason the last line of the file has been deleted, so that's the #undef showing up in the diff.

:cl:
 * rscadd: Successfully sent PDA messages now give you a notification. The input box for sending PDA messages is now titled after the recipient.