### PR TITLE
Adds config option for hardcore mode every round

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -642,6 +642,8 @@
 					config.silent_borg = 1
 				if("borer_takeover_immediately")
 					config.borer_takeover_immediately = 1
+				if("hardcore_mode")
+					hardcore_mode = value
 				else
 					diary << "Unknown setting in configuration: '[name]'"
 

--- a/config-example/game_options.txt
+++ b/config-example/game_options.txt
@@ -79,3 +79,8 @@ EMAG_RECHARGE_RATE 0
 # Number of ticks per recharge cycle
 ## DEFAULT: 0 (no recharging)
 EMAG_RECHARGE_TICKS 0
+
+# Whether hardcore mode (starvation kills) is enabled by default
+# Can be disabled during game!
+## DEFAULT: 0
+HARDCORE_MODE 0

--- a/html/changelogs/unid-ew.yml
+++ b/html/changelogs/unid-ew.yml
@@ -1,0 +1,30 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general deleting of nice things)
+#   rscadd (general adding of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.
+author: Unid
+
+delete-after: True
+
+changes: 
+- experiment: "Added a config option to make hardcore mode (which adds negative side-effects to starvation) enabled every round."


### PR DESCRIPTION
#6943

A reminder that hardcore mode is on, as well as a brief description of what it does, is shown to every spawned human (be it a roundstart player or somebody fresh out of the cloning pod)