### PR TITLE
Fix dropping changeling verb holder on SoC

### DIFF
--- a/code/modules/projectiles/projectile/change.dm
+++ b/code/modules/projectiles/projectile/change.dm
@@ -29,6 +29,9 @@
 		M.overlays.len = 0
 		M.invisibility = 101
 
+		if(istype(M, /mob/living/carbon/human))
+			M.remove_changeling_verb()
+
 		if(istype(M, /mob/living/silicon/robot))
 			var/mob/living/silicon/robot/Robot = M
 			if(Robot.mmi)


### PR DESCRIPTION
fixes #14399
:cl:
 * bugfix: Staff of Change'd changelings will no longer drop their verb holder.