### PR TITLE
the Strike Team rewrite

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -1583,11 +1583,6 @@ var/proccalls = 1
 
 #define DEFAULT_BLOOD "#A10808"
 
-//Strike Team Defines
-#define TEAM_DEATHSQUAD			"Death Squad"
-#define TEAM_ERT					"Emergency Response Team"
-#define TEAM_ELITE_SYNDIE			"Elite Strike Team"
-
 //Return values for /obj/machinery/proc/npc_tamper_act(mob/living/L)
 #define NPC_TAMPER_ACT_FORGET 1 //Don't try to tamper with this again
 #define NPC_TAMPER_ACT_NOMSG  2 //Don't produce a visible message

--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -1584,9 +1584,9 @@ var/proccalls = 1
 #define DEFAULT_BLOOD "#A10808"
 
 //Strike Team Defines
-#TEAM_DEATHSQUAD			"Death Squad"
-#TEAM_ERT					"Emergency Response Team"
-#TEAM_ELITE_SYNDIE			"Elite Strike Team"
+#define TEAM_DEATHSQUAD			"Death Squad"
+#define TEAM_ERT					"Emergency Response Team"
+#define TEAM_ELITE_SYNDIE			"Elite Strike Team"
 
 //Return values for /obj/machinery/proc/npc_tamper_act(mob/living/L)
 #define NPC_TAMPER_ACT_FORGET 1 //Don't try to tamper with this again

--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -1583,6 +1583,11 @@ var/proccalls = 1
 
 #define DEFAULT_BLOOD "#A10808"
 
+//Strike Team Defines
+#TEAM_DEATHSQUAD			"Death Squad"
+#TEAM_ERT					"Emergency Response Team"
+#TEAM_ELITE_SYNDIE			"Elite Strike Team"
+
 //Return values for /obj/machinery/proc/npc_tamper_act(mob/living/L)
 #define NPC_TAMPER_ACT_FORGET 1 //Don't try to tamper with this again
 #define NPC_TAMPER_ACT_NOMSG  2 //Don't produce a visible message

--- a/__DEFINES/striketeam_defines.dm
+++ b/__DEFINES/striketeam_defines.dm
@@ -1,0 +1,4 @@
+//Strike Team Defines
+#define TEAM_DEATHSQUAD			"Death Squad"
+#define TEAM_ERT				"Emergency Response Team"
+#define TEAM_ELITE_SYNDIE		"Elite Strike Team"

--- a/code/__HELPERS/globalaccess.dm
+++ b/code/__HELPERS/globalaccess.dm
@@ -1289,16 +1289,8 @@
 			return global.voxresearch_shuttle;
 		if("response_team_members")
 			return global.response_team_members;
-		if("send_emergency_team")
-			return global.send_emergency_team;
-		if("ert_base_chance")
-			return global.ert_base_chance;
-		if("can_call_ert")
-			return global.can_call_ert;
-		if("sent_strike_team")
-			return global.sent_strike_team;
-		if("sent_syndicate_strike_team")
-			return global.sent_syndicate_strike_team;
+		if("sent_strike_teams")
+			return global.sent_strike_teams;
 		if("icons_to_ignore_at_floor_init")
 			return global.icons_to_ignore_at_floor_init;
 		if("plating_icons")
@@ -3114,16 +3106,8 @@
 			global.voxresearch_shuttle=newval
 		if("response_team_members")
 			global.response_team_members=newval
-		if("send_emergency_team")
-			global.send_emergency_team=newval
-		if("ert_base_chance")
-			global.ert_base_chance=newval
-		if("can_call_ert")
-			global.can_call_ert=newval
-		if("sent_strike_team")
-			global.sent_strike_team=newval
-		if("sent_syndicate_strike_team")
-			global.sent_syndicate_strike_team=newval
+		if("sent_strike_teams")
+			global.sent_strike_teams=newval
 		if("icons_to_ignore_at_floor_init")
 			global.icons_to_ignore_at_floor_init=newval
 		if("plating_icons")

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1609,6 +1609,9 @@ Game Mode config tags:
 /proc/stack_trace(message = "Getting a stack trace.")
 	CRASH(message)
 
+/proc/sentStrikeTeams(var/team)
+	return (team in sent_strike_teams)
+
 
 /proc/get_exact_dist(atom/A, atom/B)	//returns the coordinate distance between the coordinates of the turfs of A and B
 	var/turf/T1 = A

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -397,7 +397,11 @@ var/shuttle_call/shuttle_calls[0]
 		list("id"=SEC_LEVEL_BLUE,  "name"="Blue"),
 		//SEC_LEVEL_RED = list("name"="Red"),
 	)
-	data["ert_sent"] = "Emergency Response Team" in sent_strike_teams
+	var/sent = 0
+	if ("Emergency Response Team" in sent_strike_teams)
+		sent = 1
+
+	data["ert_sent"] = sent
 
 	var/msg_data[0]
 	for(var/i=1;i<=src.messagetext.len;i++)

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -180,11 +180,11 @@ var/shuttle_call/shuttle_calls[0]
 				to_chat(usr, "<span class='notice'>\The [src.name] cannot establish a bluespace connection.</span>")
 				return
 
-			if("Death Squad" in sent_strike_teams)
+			if(sentStrikeTeams(TEAM_DEATHSQUAD))
 				to_chat(usr, "<span class='warning'>PKI AUTH ERROR: SERVER REPORTS BLACKLISTED COMMUNICATION KEY PLEASE CONTACT SERVICE TECHNICIAN</span>")
 				return
 
-			if("Emergency Response Team" in sent_strike_teams)
+			if(sentStrikeTeams(TEAM_ERT))
 				to_chat(usr, "<span class='notice'>Central Command has already dispatched a Response Team to [station_name()]</span>")
 				return
 
@@ -398,7 +398,7 @@ var/shuttle_call/shuttle_calls[0]
 		//SEC_LEVEL_RED = list("name"="Red"),
 	)
 	var/sent = 0
-	if ("Emergency Response Team" in sent_strike_teams)
+	if(sentStrikeTeams(TEAM_ERT))
 		sent = 1
 
 	data["ert_sent"] = sent

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -180,13 +180,18 @@ var/shuttle_call/shuttle_calls[0]
 				to_chat(usr, "<span class='notice'>\The [src.name] cannot establish a bluespace connection.</span>")
 				return
 
-			if(sent_strike_team)
+			if("Death Squad" in sent_strike_teams)
 				to_chat(usr, "<span class='warning'>PKI AUTH ERROR: SERVER REPORTS BLACKLISTED COMMUNICATION KEY PLEASE CONTACT SERVICE TECHNICIAN</span>")
 				return
 
-			if(world.time < 6000)
-				to_chat(usr, "<span class='notice'>The emergency response team is away on another mission, Please wait another [round((6000-world.time)/600)] minute\s before trying again.</span>")
+			if("Emergency Response Team" in sent_strike_teams)
+				to_chat(usr, "<span class='notice'>Central Command has already dispatched a Response Team to [station_name()]</span>")
 				return
+
+			//if(world.time < 6000)
+			//	to_chat(usr, "<span class='notice'>The emergency response team is away on another mission, Please wait another [round((6000-world.time)/600)] minute\s before trying again.</span>")
+			//	return
+
 			if(emergency_shuttle.online)
 				to_chat(usr, "The emergency shuttle is already on its way.")
 				return
@@ -195,9 +200,6 @@ var/shuttle_call/shuttle_calls[0]
 				return
 			if(authenticated != 2 || issilicon(usr))
 				to_chat(usr, "<span class='warning'>\The [src.name]'s screen flashes, \"Access Denied\".</span>")
-				return
-			if(send_emergency_team)
-				to_chat(usr, "<span class='notice'>Central Command has already dispatched a Response Team to [station_name()]</span>")
 				return
 
 			var/response = alert(usr,"Are you sure you want to request a response team?", "ERT Request", "Yes", "No")
@@ -209,7 +211,9 @@ var/shuttle_call/shuttle_calls[0]
 				return
 			if(!Adjacent(usr) || usr.incapacitated())
 				return
-			trigger_armed_response_team(1,ert_reason)
+			var/datum/striketeam/ert/response_team = new()
+			response_team.mission = ert_reason
+			response_team.trigger_strike()
 			log_game("[key_name(usr)] has called an ERT with reason: [ert_reason]")
 			message_admins("[key_name_admin(usr)] has called an ERT with reason: [ert_reason]")
 			setMenuState(usr,COMM_SCREEN_MAIN)
@@ -393,7 +397,7 @@ var/shuttle_call/shuttle_calls[0]
 		list("id"=SEC_LEVEL_BLUE,  "name"="Blue"),
 		//SEC_LEVEL_RED = list("name"="Red"),
 	)
-	data["ert_sent"] = send_emergency_team
+	data["ert_sent"] = "Emergency Response Team" in sent_strike_teams
 
 	var/msg_data[0]
 	for(var/i=1;i<=src.messagetext.len;i++)
@@ -488,9 +492,10 @@ var/shuttle_call/shuttle_calls[0]
 	if(!map.linked_to_centcomm)
 		to_chat(usr, "<span class='danger'>Error: No connection can be made to central command .</span>")
 		return
-	if(sent_strike_team == 1)
-		to_chat(user, "Centcom will not allow the shuttle to be called. Consider all contracts terminated.")
-		return
+
+	//if(sent_strike_team == 1)
+	//	to_chat(user, "Centcom will not allow the shuttle to be called. Consider all contracts terminated.")
+	//	return
 
 	if(world.time < 6000) // Ten minute grace period to let the game get going without lolmetagaming. -- TLE
 		to_chat(user, "The emergency shuttle is refueling. Please wait another [round((6000-world.time)/600)] minute\s before trying again.")
@@ -539,9 +544,9 @@ var/shuttle_call/shuttle_calls[0]
 			to_chat(user, "Centcom does not currently have a shuttle available in your sector. Please try again later.")
 			return
 
-		if(sent_strike_team == 1)
-			to_chat(user, "Centcom will not allow the shuttle to be called. Consider all contracts terminated.")
-			return
+		//if(sent_strike_team == 1)
+		//	to_chat(user, "Centcom will not allow the shuttle to be called. Consider all contracts terminated.")
+		//	return
 
 		if(world.time < 54000) // 30 minute grace period to let the game get going
 			to_chat(user, "The shuttle is refueling. Please wait another [round((54000-world.time)/600)] minutes before trying again.")//may need to change "/600"
@@ -631,7 +636,7 @@ var/shuttle_call/shuttle_calls[0]
 		if(!shuttlecaller.stat && shuttlecaller.client && istype(shuttlecaller.loc,/turf))
 			return ..()
 
-	if(ticker.mode.name == "revolution" || ticker.mode.name == "AI malfunction" || sent_strike_team)
+	if(ticker.mode.name == "revolution" || ticker.mode.name == "AI malfunction")
 		return ..()
 
 	emergency_shuttle.incall(2)
@@ -656,7 +661,7 @@ var/shuttle_call/shuttle_calls[0]
 		if(!shuttlecaller.stat && shuttlecaller.client && istype(shuttlecaller.loc,/turf))
 			return ..()
 
-	if(ticker.mode.name == "revolution" || ticker.mode.name == "AI malfunction" || sent_strike_team)
+	if(ticker.mode.name == "revolution" || ticker.mode.name == "AI malfunction")
 		return ..()
 
 	emergency_shuttle.incall(2)

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -397,11 +397,7 @@ var/shuttle_call/shuttle_calls[0]
 		list("id"=SEC_LEVEL_BLUE,  "name"="Blue"),
 		//SEC_LEVEL_RED = list("name"="Red"),
 	)
-	var/sent = 0
-	if(sentStrikeTeams(TEAM_ERT))
-		sent = 1
-
-	data["ert_sent"] = sent
+	data["ert_sent"] = sentStrikeTeams(TEAM_ERT)
 
 	var/msg_data[0]
 	for(var/i=1;i<=src.messagetext.len;i++)

--- a/code/game/machinery/computer/specops_shuttle.dm
+++ b/code/game/machinery/computer/specops_shuttle.dm
@@ -267,10 +267,6 @@ var/specops_shuttle_timeleft = 0
 		to_chat(user, "<span class='warning'>Access Denied.</span>")
 		return
 
-	if (sent_strike_team == 0 && send_emergency_team == 0)
-		to_chat(usr, "<span class='warning'>The strike team has not yet deployed.</span>")
-		return
-
 	if(..())
 		return
 

--- a/code/game/striketeams/nanotrasen_deathsquad.dm
+++ b/code/game/striketeams/nanotrasen_deathsquad.dm
@@ -1,106 +1,18 @@
-//STRIKE TEAMS
+//DEATH SQUAD
 
-var/const/commandos_possible = 6 //if more Commandos are needed in the future
-var/global/sent_strike_team = 0
+/datum/striketeam/deathsquad
+	striketeam_name = "Death Squad"
+	faction_name = "Nanotrasen"
+	mission = "Clean up the Station of all enemies of Nanotrasen. Avoid damage to Nanotrasen assets, unless you judge it necessary."
+	team_size = 6
+	min_size_for_leader = 4//set to 0 so there's always a designated team leader or to -1 so there is no leader.
+	spawns_name = "Commando"
+	can_customize = FALSE
+	logo = "death-logo"
 
-/client/proc/strike_team()
-	if(!ticker)
-		to_chat(usr, "<font color='red'>The game hasn't started yet!</font>")
-		return
-	if(world.time < 6000)
-		to_chat(usr, "<font color='red'>There are [(6000-world.time)/10] seconds remaining before it may be called.</font>")
-		return
-	if(sent_strike_team == 1)
-		to_chat(usr, "<font color='red'>CentCom is already sending a team.</font>")
-		return
-	if(alert("Do you want to send in the CentCom death squad? Once enabled, this is irreversible.",,"Yes","No")!="Yes")
-		return
-	alert("This 'mode' will go on until everyone is dead or the station is destroyed. You may also admin-call the evac shuttle when appropriate. Spawned commandos have internals cameras which are viewable through a monitor inside the Spec. Ops. Office. Assigning the team's detailed task is recommended from there. While you will be able to manually pick the candidates from active ghosts, their assignment in the squad will be random.")
-
-	var/input = null
-	while(!input)
-		input = copytext(sanitize(input(src, "Please specify which mission the death commando squad shall undertake.", "Specify Mission", "")),1,MAX_MESSAGE_LEN)
-		if(!input)
-			if(alert("Error, no mission set. Do you want to exit the setup process?",,"Yes","No")=="Yes")
-				return
-
-	if(sent_strike_team)
-		to_chat(usr, "Looks like someone beat you to it.")
-		return
-
-	sent_strike_team = 1
-
-	if (emergency_shuttle.direction == 1 && emergency_shuttle.online == 1)
-		emergency_shuttle.recall()
-
-	var/commando_number = commandos_possible //for selecting a leader
-	var/leader_selected = 0 //when the leader is chosen. The last person spawned.
-
-//Code for spawning a nuke auth code.
-	var/nuke_code
-	var/temp_code
-	for(var/obj/machinery/nuclearbomb/N in machines)
-		temp_code = text2num(N.r_code)
-		if(temp_code)//if it's actually a number. It won't convert any non-numericals.
-			nuke_code = N.r_code
-			break
-
-//Generates a list of commandos from active ghosts. Then the user picks which characters to respawn as the commandos.
-	var/list/candidates = list()	//candidates for being a commando out of all the active ghosts in world.
-	var/list/commandos = list()			//actual commando ghosts as picked by the user.
-	for(var/mob/dead/observer/G	 in player_list)
-		if(!G.client.holder && !G.client.is_afk())	//Whoever called/has the proc won't be added to the list.
-			if(!(G.mind && G.mind.current && G.mind.current.stat != DEAD))
-				candidates += G.key
-	for(var/i=commandos_possible,(i>0&&candidates.len),i--)//Decrease with every commando selected.
-		var/candidate = input("Pick characters to spawn as the commandos. This will go on until there either no more ghosts to pick from or the slots are full.", "Active Players") as null|anything in candidates	//It will auto-pick a person when there is only one candidate.
-		candidates -= candidate		//Subtract from candidates.
-		commandos += candidate//Add their ghost to commandos.
-
-//Spawns commandos and equips them.
-	for(var/obj/effect/landmark/L in landmarks_list)
-		if(commando_number<=0)
-			break
-		if (L.name == "Commando")
-			leader_selected = commando_number == 1?1:0
-
-			var/mob/living/carbon/human/new_commando = create_death_commando(L, leader_selected)
-
-			if(commandos.len)
-				new_commando.key = pick(commandos)
-				commandos -= new_commando.key
-				new_commando.internal = new_commando.s_store
-				new_commando.internals.icon_state = "internal1"
-
-			//So they don't forget their code or mission.
-			if(nuke_code)
-				new_commando.mind.store_memory("<B>Nuke Code:</B> <span class='warning'>[nuke_code].</span>")
-			new_commando.mind.store_memory("<B>Mission:</B> <span class='warning'>[input].</span>")
-
-			to_chat(new_commando, "<span class='notice'>You are a Special Ops. [!leader_selected?"commando":"<B>LEADER</B>"] in the service of Central Command. Check the table ahead for detailed instructions.\nYour current mission is: <span class='danger'>[input]</span></span>")
-
-			commando_number--
-
-//Spawns the rest of the commando gear.
-	for (var/obj/effect/landmark/L in landmarks_list)
-		if (L.name == "Commando_Manual")
-			//new /obj/item/weapon/gun/energy/pulse_rifle(L.loc)
-			var/obj/item/weapon/paper/P = new(L.loc)
-			P.info = "<p><b>Good morning soldier!</b>. This compact guide will familiarize you with standard operating procedure. There are three basic rules to follow:<br>#1 Work as a team.<br>#2 Accomplish your objective at all costs.<br>#3 Leave no witnesses.<br>You are fully equipped and stocked for your mission--before departing on the Spec. Ops. Shuttle due South, make sure that all operatives are ready. Actual mission objective will be relayed to you by Central Command through your headsets.<br>If deemed appropriate, Central Command will also allow members of your team to equip assault power-armor for the mission. You will find the armor storage due West of your position. Once you are ready to leave, utilize the Special Operations shuttle console and toggle the hull doors via the other console.</p><p>In the event that the team does not accomplish their assigned objective in a timely manner, or finds no other way to do so, attached below are instructions on how to operate a Nanotrasen Nuclear Device. Your operations <b>LEADER</b> is provided with a nuclear authentication disk and a pin-pointer for this reason. You may easily recognize them by their rank: Lieutenant, Captain, or Major. The nuclear device itself will be present somewhere on your destination.</p><p>Hello and thank you for choosing Nanotrasen for your nuclear information needs. Today's crash course will deal with the operation of a Fission Class Nanotrasen made Nuclear Device.<br>First and foremost, <b>DO NOT TOUCH ANYTHING UNTIL THE BOMB IS IN PLACE.</b> Pressing any button on the compacted bomb will cause it to extend and bolt itself into place. If this is done to unbolt it one must completely log in which at this time may not be possible.<br>To make the device functional:<br>#1 Place bomb in designated detonation zone<br> #2 Extend and anchor bomb (attack with hand).<br>#3 Insert Nuclear Auth. Disk into slot.<br>#4 Type numeric code into keypad ([nuke_code]).<br>Note: If you make a mistake press R to reset the device.<br>#5 Press the E button to log onto the device.<br>You now have activated the device. To deactivate the buttons at anytime, for example when you have already prepped the bomb for detonation, remove the authentication disk OR press the R on the keypad. Now the bomb CAN ONLY be detonated using the timer. A manual detonation is not an option.<br>Note: Toggle off the <b>SAFETY</b>.<br>Use the - - and + + to set a detonation time between 5 seconds and 10 minutes. Then press the timer toggle button to start the countdown. Now remove the authentication disk so that the buttons deactivate.<br>Note: <b>THE BOMB IS STILL SET AND WILL DETONATE</b><br>Now before you remove the disk if you need to move the bomb you can: Toggle off the anchor, move it, and re-anchor.</p><p>The nuclear authorization code is: <b>[nuke_code ? nuke_code : "None provided"]</b></p><p><b>Good luck, soldier!</b></p>"
-			P.name = "Spec. Ops. Manual"
-
-	for (var/obj/effect/landmark/L in landmarks_list)
-		if (L.name == "Commando-Bomb")
-			new /obj/effect/spawner/newbomb/timer/syndicate(L.loc)
-			qdel(L)
-
-	message_admins("<span class='notice'>[key_name_admin(usr)] has spawned a CentCom strike squad.</span>", 1)
-	log_admin("[key_name(usr)] used Spawn Death Squad.")
-	return 1
-
-/client/proc/create_death_commando(obj/spawn_location, leader_selected = 0)
+/datum/striketeam/deathsquad/create_commando(obj/spawn_location, leader_selected = 0)
 	var/mob/living/carbon/human/new_commando = new(spawn_location.loc)
-	var/commando_leader_rank = pick("Lieutenant", "Captain", "Major")
+	var/commando_leader_rank = "Major"
 	var/commando_rank = pick("Corporal", "Sergeant", "Staff Sergeant", "Sergeant 1st Class", "Master Sergeant", "Sergeant Major")
 	var/commando_name = pick(last_names)
 
@@ -109,7 +21,7 @@ var/global/sent_strike_team = 0
 	var/datum/preferences/A = new()//Randomize appearance for the commando.
 	A.randomize_appearance_for(new_commando)
 
-	new_commando.real_name = "[!leader_selected ? commando_rank : commando_leader_rank] [commando_name]"
+	new_commando.real_name = "[!leader_selected ? commando_rank : commando_leader_rank] [!leader_selected ? commando_name : "Creed"]"
 	new_commando.age = !leader_selected ? rand(23,35) : rand(35,45)
 
 	new_commando.dna.ready_dna(new_commando)//Creates DNA.
@@ -124,37 +36,58 @@ var/global/sent_strike_team = 0
 	ticker.mode.deathsquad += new_commando.mind
 	return new_commando
 
-/mob/living/carbon/human/proc/equip_death_commando(leader_selected = 0)
+/datum/striketeam/deathsquad/greet_commando(var/mob/living/carbon/human/H)
+	if(H.key == leader_key)
+		to_chat(H, "<span class='notice'>You are [H.real_name], a tactical genius and the leader of the Death Squad, in the service of Nanotrasen.</span>")
+	else
+		to_chat(H, "<span class='notice'>You are [H.real_name], a Death Squad commando, in the service of Nanotrasen.</span>")
+		if (leader_key != "")
+			to_chat(H, "<span class='notice'>Follow directions from your superior, Creed.</span>")
+	to_chat(H, "<span class='notice'>Your mission is: <span class='danger'>[mission]</span></span>")
 
-
+/mob/living/carbon/human/proc/equip_death_commando(leader = 0)
+	//Special radio setup
 	equip_to_slot_or_del(new /obj/item/device/radio/headset/deathsquad(src), slot_ears)
 
-	if (leader_selected == 0)
-		equip_to_slot_or_del(new /obj/item/clothing/under/deathsquad(src), slot_w_uniform)
+	//Adding Camera Network
+	var/obj/machinery/camera/camera = new /obj/machinery/camera(src) //Gives all the commandos internals cameras.
+	camera.network = "CREED"
+	camera.c_tag = real_name
+
+	//Basic Uniform
+	if (leader)
+		var/obj/item/clothing/under/rank/centcom_officer/uni = new /obj/item/clothing/under/rank/centcom_officer(src)
+		uni.attach_accessory(new/obj/item/clothing/accessory/holomap_chip/deathsquad(src))
+		equip_to_slot_or_del(uni, slot_w_uniform)
 	else
-		equip_to_slot_or_del(new /obj/item/clothing/under/rank/centcom_officer(src), slot_w_uniform)
+		equip_to_slot_or_del(new /obj/item/clothing/under/deathsquad(src), slot_w_uniform)
+	equip_to_slot_or_del(new /obj/item/weapon/melee/energy/sword(src), slot_l_store)
+	equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/mateba(src), slot_belt)
+
+	//Shoes & gloves
 	equip_to_slot_or_del(new /obj/item/clothing/shoes/magboots/deathsquad(src), slot_shoes)
-	equip_to_slot_or_del(new /obj/item/clothing/suit/space/rig/deathsquad(src), slot_wear_suit)
 	equip_to_slot_or_del(new /obj/item/clothing/gloves/combat(src), slot_gloves)
-	equip_to_slot_or_del(new /obj/item/clothing/head/helmet/space/rig/deathsquad(src), slot_head)
-	equip_to_slot_or_del(new /obj/item/clothing/mask/gas/swat(src), slot_wear_mask)
+
+	//Glasses
 	equip_to_slot_or_del(new /obj/item/clothing/glasses/thermal(src), slot_glasses)
 
+	//Mask & Armor
+	equip_to_slot_or_del(new /obj/item/clothing/head/helmet/space/rig/deathsquad(src), slot_head)
+	equip_to_slot_or_del(new /obj/item/clothing/mask/gas/swat(src), slot_wear_mask)
+	equip_to_slot_or_del(new /obj/item/clothing/suit/space/rig/deathsquad(src), slot_wear_suit)
+	equip_to_slot_or_del(new /obj/item/weapon/tank/emergency_oxygen/double(src), slot_s_store)
+
+	//Backpack
 	equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/security(src), slot_back)
 	equip_to_slot_or_del(new /obj/item/weapon/storage/box(src), slot_in_backpack)
-
 	equip_to_slot_or_del(new /obj/item/ammo_storage/box/a357(src), slot_in_backpack)
 	equip_to_slot_or_del(new /obj/item/weapon/storage/firstaid/regular(src), slot_in_backpack)
 	equip_to_slot_or_del(new /obj/item/weapon/pinpointer(src), slot_in_backpack)
 	equip_to_slot_or_del(new /obj/item/weapon/shield/energy(src), slot_in_backpack)
-	if (!leader_selected)
-		equip_to_slot_or_del(new /obj/item/weapon/plastique(src), slot_in_backpack)
-	else
+	if (leader)
 		equip_to_slot_or_del(new /obj/item/weapon/disk/nuclear(src), slot_in_backpack)
-
-	equip_to_slot_or_del(new /obj/item/weapon/melee/energy/sword(src), slot_l_store)
-	equip_to_slot_or_del(new /obj/item/weapon/tank/emergency_oxygen/double(src), slot_s_store)
-	equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/mateba(src), slot_belt)
+	else
+		equip_to_slot_or_del(new /obj/item/weapon/plastique(src), slot_in_backpack)
 
 	put_in_hands(new /obj/item/weapon/gun/energy/pulse_rifle(src))
 

--- a/code/game/striketeams/striketeam_datums.dm
+++ b/code/game/striketeams/striketeam_datums.dm
@@ -1,0 +1,185 @@
+var/list/sent_strike_teams = list()
+
+/datum/striketeam
+	var/striketeam_name = "Spec.Ops."
+	var/faction_name = "Nanotrasen"
+	var/mission = "Clean up the Station of all enemies of Nanotrasen. Avoid damage to Nanotrasen assets, unless you judge it necessary."
+	var/team_size = 6
+	var/min_size_for_leader = 4//set to 0 so there's always a designated team leader or to -1 so there is no leader.
+	var/spawns_name = "Commando"
+	var/can_customize = FALSE
+	var/logo = "nano-logo"
+
+	var/list/applicants = list()
+	var/searching = FALSE
+
+	var/leader_key = ""
+	var/list/team_composition = list()
+
+
+/datum/striketeam/proc/trigger_strike(var/mob/user)
+	//Is the game started
+	if(!ticker)
+		if(user)
+			to_chat(user, "<span class='warning'>The game hasn't started yet!</span>")
+		qdel(src)
+		return
+
+	//Has someone already sent a strike team of this type
+	if(striketeam_name in sent_strike_teams)
+		if(user)
+			to_chat(user, "<span class='warning'>[faction_name] has already sent \a [striketeam_name].</span>")
+		qdel(src)
+		return
+
+	//Logging
+	message_admins("<span class='notice'>[key_name(user)] is preparing a [striketeam_name].</span>", 1)
+
+	if(user)
+		if(alert("Do you really want [faction_name] to send in the [striketeam_name]?",,"Yes","No")!="Yes")
+			qdel(src)
+			return
+
+		mission = input(user, "Please specify which mission the [striketeam_name] shall undertake.", "Specify Mission", "")
+
+		if(!mission)
+			if(alert("Error, no mission set. Do you want to exit the setup process?",,"Yes","No")=="Yes")
+				qdel(src)
+				return
+			else
+				mission = initial(mission)
+
+		if(striketeam_name in sent_strike_teams)
+			to_chat(user, "Looks like someone beat you to it.")
+			qdel(src)
+			return
+
+	sent_strike_teams |= striketeam_name
+	sent_strike_teams[striketeam_name] = src
+
+	if(user)
+		to_chat(user, "<span class='notice'>[faction_name] has received your request. Commando applications will be open for the next minute.</span>")
+
+	searching = TRUE
+
+	var/icon/team_logo = icon('icons/mob/mob.dmi', logo)
+	for(var/mob/dead/observer/O in dead_mob_list)
+		if(jobban_isbanned(O, "Strike Team") || O.client.is_afk())
+			continue
+
+		to_chat(O, "[bicon(team_logo)]<span class='recruit'>[faction_name] needs YOU to become part of its upcoming [striketeam_name]. (<a href='?src=\ref[src];signup=\ref[O]'>Apply now!</a>)</span>[bicon(team_logo)]")
+
+	spawn(600)
+		searching = FALSE
+
+		for(var/mob/dead/observer/O in dead_mob_list)
+			if(jobban_isbanned(O, "Strike Team") || O.client.is_afk())
+				continue
+			to_chat(O, "[bicon(team_logo)]<span class='recruit'>Applications for [faction_name]'s [striketeam_name] are now closed.</span>[bicon(team_logo)]")
+
+		if(!applicants || applicants.len <= 0)
+			if(user)
+				to_chat(user, "<span class='warning'>[faction_name] received no applications for the [striketeam_name].</span>")
+			failure()
+			qdel(src)
+			return
+
+		var/list/commando_spawns = list_commando_spawns()
+		var/commando_count = min(applicants.len,team_size)
+		var/leader = FALSE
+
+		if(min_size_for_leader >= 0 && applicants.len >= min_size_for_leader)
+			leader = TRUE
+
+		for (var/i = commando_count, i > 0, i--)
+			if (commando_spawns.len <= 0)
+				commando_spawns = list_commando_spawns()
+				//The point here is to try not having commandos spawn atop each others.
+
+			if(applicants.len <= 0)
+				break
+
+			var/mob/applicant = null
+			for(var/mob/M in player_list)
+				if(M.key == pick(applicants))
+					applicant = M
+			applicants -= applicant.key
+
+			if(!istype(applicant, /mob/dead/observer))
+				//Making sure we don't recruit people who got back into the game since they applied
+				continue
+
+			var/obj/effect/landmark/L = pick(commando_spawns)
+			commando_spawns -= L
+
+			spawn()//not waiting for players to customize their characters to move on
+				var/mob/living/carbon/human/new_commando = create_commando(L, leader, applicant.key)
+				team_composition |= new_commando
+				new_commando.key = applicant.key
+
+				if (leader)
+					leader_key = new_commando.key
+					leader = FALSE
+
+				new_commando.mind.store_memory("<B>Mission:</B> <span class='warning'>[mission].</span>")
+
+				greet_commando(new_commando)
+		extras()
+
+/datum/striketeam/proc/create_commando(var/obj/spawn_location,var/leader_selected=0,var/mob_key = "")
+	var/mob/living/carbon/human/new_commando = new(spawn_location.loc)
+	return new_commando
+
+/datum/striketeam/proc/greet_commando(var/mob/living/carbon/human/H)
+	to_chat(H, "<span class='notice'>You are a [striketeam_name] commando, in the service of [faction_name].</span>")
+	to_chat(H, "<span class='notice'>Your current mission is: <span class='danger'>[mission]</span></span>")
+
+/datum/striketeam/Topic(var/href, var/list/href_list)
+	if(href_list["signup"])
+		var/mob/dead/observer/O = locate(href_list["signup"])
+		if(!O)
+			return
+
+		volunteer(O)
+
+/datum/striketeam/proc/failure()
+
+/datum/striketeam/proc/extras()
+
+/datum/striketeam/proc/volunteer(var/mob/dead/observer/O)
+	if(!searching || !istype(O))
+		return
+
+	if(jobban_isbanned(O, "Strike Team"))
+		to_chat(O, "<span class='warning'>Your application to the [striketeam_name] has been discarded due to past conduct..</span>")
+		return
+
+	if(O in applicants)
+		to_chat(O, "<span class='notice'>Removed from the [striketeam_name] registration list.</span>")
+		applicants -= O.key
+		return
+
+	else
+		to_chat(O, "<span class='notice'>Added to the [striketeam_name] registration list.</span>")
+		applicants |= O.key
+		return
+
+
+/datum/striketeam/proc/list_commando_spawns()
+	var/list/commando_spawns = list()
+	for(var/obj/effect/landmark/L in landmarks_list)
+		if (L.name == spawns_name)
+			commando_spawns |= L
+	return commando_spawns
+
+///////////////////////////////////////CUSTOM STRIKE TEAMS///////////////////////////////////
+
+/datum/striketeam/custom/trigger_strike(var/mob/user)
+	striketeam_name = input(user, "Name your strike team.", "Custom Strike Team", "")
+	faction_name = input(user, "Name the organization sending this strike team.", "Custom Strike Team", "")
+	team_size = input(user, "Set the maximum amount of commandos in your squad", "Custom Strike Team", "") as num
+	min_size_for_leader = -1
+	spawns_name = input(user, "What are named the landmarks you want your squadies to spawn at?", "Custom Strike Team", "")
+	can_customize = FALSE
+	logo = input(user, "Got a custom logo for your strike team?", "Custom Strike Team", "nano-logo")
+	..()

--- a/code/game/striketeams/striketeam_datums.dm
+++ b/code/game/striketeams/striketeam_datums.dm
@@ -1,3 +1,8 @@
+//Strike Team Defines
+#define TEAM_DEATHSQUAD			"Death Squad"
+#define TEAM_ERT				"Emergency Response Team"
+#define TEAM_ELITE_SYNDIE		"Elite Strike Team"
+
 var/list/sent_strike_teams = list()
 
 /datum/striketeam

--- a/code/game/striketeams/striketeam_datums.dm
+++ b/code/game/striketeams/striketeam_datums.dm
@@ -1,7 +1,3 @@
-//Strike Team Defines
-#define TEAM_DEATHSQUAD			"Death Squad"
-#define TEAM_ERT				"Emergency Response Team"
-#define TEAM_ELITE_SYNDIE		"Elite Strike Team"
 
 var/list/sent_strike_teams = list()
 

--- a/code/game/striketeams/syndicate_elite_squad.dm
+++ b/code/game/striketeams/syndicate_elite_squad.dm
@@ -1,110 +1,22 @@
-//STRIKE TEAMS
+//ELITE SYNDICATE STRIKE TEAM
 
-var/const/syndicate_commandos_possible = 6 //if more Commandos are needed in the future
-var/global/sent_syndicate_strike_team = 0
-/client/proc/syndicate_strike_team()
-	set category = "Fun"
-	set name = "Spawn Syndicate Strike Team"
-	set desc = "Spawns a squad of commandos in the Syndicate Mothership if you want to run an admin event."
+/datum/striketeam/syndicate
+	striketeam_name = "Elite Strike Team"
+	faction_name = "the Syndicate"
+	mission = "Purify the station."
+	team_size = 6
+	min_size_for_leader = -1//set to 0 so there's always a designated team leader or to -1 so there is no leader.
+	spawns_name = "Syndicate-Commando"
+	can_customize = FALSE
+	logo = "synd-logo"
 
-	if(!src.holder)
-		to_chat(src, "Only administrators may use this command.")
-		return
-	if(!ticker)
-		alert("The game hasn't started yet!")
-		return
-//	if(world.time < 6000)
-//		alert("Not so fast, buddy. Wait a few minutes until the game gets going. There are [(6000-world.time)/10] seconds remaining.")
-//		return
-	if(sent_syndicate_strike_team == 1)
-		alert("The Syndicate are already sending a team, Mr. Dumbass.")
-		return
-	if(alert("Do you want to send in the Syndicate Strike Team? Once enabled, this is irreversible.",,"Yes","No")=="No")
-		return
-	alert("This 'mode' will go on until everyone is dead or the station is destroyed. You may also admin-call the evac shuttle when appropriate. Spawned syndicates have internals cameras which are viewable through a monitor inside the Syndicate Mothership Bridge. Assigning the team's detailed task is recommended from there. While you will be able to manually pick the candidates from active ghosts, their assignment in the squad will be random.")
 
-	var/input = null
-	while(!input)
-		input = copytext(sanitize(input(src, "Please specify which mission the syndicate strike team shall undertake.", "Specify Mission", "")),1,MAX_MESSAGE_LEN)
-		if(!input)
-			if(alert("Error, no mission set. Do you want to exit the setup process?",,"Yes","No")=="Yes")
-				return
-
-	if(sent_syndicate_strike_team)
-		to_chat(src, "Looks like someone beat you to it.")
-		return
-
-	sent_syndicate_strike_team = 1
-
-	if (emergency_shuttle.direction == 1 && emergency_shuttle.online == 1)
-		emergency_shuttle.recall()
-
-	var/syndicate_commando_number = syndicate_commandos_possible //for selecting a leader
-	var/syndicate_leader_selected = 0 //when the leader is chosen. The last person spawned.
-
-//Code for spawning a nuke auth code.
-	var/nuke_code
-	var/temp_code
-	for(var/obj/machinery/nuclearbomb/N in machines)
-		temp_code = text2num(N.r_code)
-		if(temp_code)//if it's actually a number. It won't convert any non-numericals.
-			nuke_code = N.r_code
-			break
-
-//Generates a list of commandos from active ghosts. Then the user picks which characters to respawn as the commandos.
-	var/list/candidates = list()	//candidates for being a commando out of all the active ghosts in world.
-	var/list/commandos = list()			//actual commando ghosts as picked by the user.
-	for(var/mob/dead/observer/G	 in player_list)
-		if(!G.client.holder && !G.client.is_afk())	//Whoever called/has the proc won't be added to the list.
-			if(!(G.mind && G.mind.current && G.mind.current.stat != DEAD))
-				candidates += G.key
-	for(var/i=commandos_possible,(i>0&&candidates.len),i--)//Decrease with every commando selected.
-		var/candidate = input("Pick characters to spawn as the commandos. This will go on until there either no more ghosts to pick from or the slots are full.", "Active Players") as null|anything in candidates	//It will auto-pick a person when there is only one candidate.
-		candidates -= candidate		//Subtract from candidates.
-		commandos += candidate//Add their ghost to commandos.
-
-//Spawns commandos and equips them.
-	for(var/obj/effect/landmark/L in landmarks_list)
-		if(syndicate_commando_number<=0)
-			break
-		if (L.name == "Syndicate-Commando")
-			syndicate_leader_selected = syndicate_commando_number == 1?1:0
-
-			var/mob/living/carbon/human/new_syndicate_commando = create_syndicate_death_commando(L, syndicate_leader_selected)
-
-			if(commandos.len)
-				new_syndicate_commando.key = pick(commandos)
-				commandos -= new_syndicate_commando.key
-				new_syndicate_commando.internal = new_syndicate_commando.s_store
-				new_syndicate_commando.internals.icon_state = "internal1"
-
-			//So they don't forget their code or mission.
-			if(nuke_code)
-				new_syndicate_commando.mind.store_memory("<B>Nuke Code:</B> <span class='warning'>[nuke_code].</span>")
-			new_syndicate_commando.mind.store_memory("<B>Mission:</B> <span class='warning'>[input].</span>")
-
-			to_chat(new_syndicate_commando, "<span class='notice'>You are an Elite Syndicate. [!syndicate_leader_selected?"commando":"<B>LEADER</B>"] in the service of the Syndicate. \nYour current mission is: <span class='danger'>[input]</span></span>")
-
-			syndicate_commando_number--
-
-//Spawns the rest of the commando gear.
-//	for (var/obj/effect/landmark/L)
-	//	if (L.name == "Commando_Manual")
-			//new /obj/item/weapon/gun/energy/pulse_rifle(L.loc)
-		//	var/obj/item/weapon/paper/P = new(L.loc)
-		//	P.info = "<p><b>Good morning soldier!</b>. This compact guide will familiarize you with standard operating procedure. There are three basic rules to follow:<br>#1 Work as a team.<br>#2 Accomplish your objective at all costs.<br>#3 Leave no witnesses.<br>You are fully equipped and stocked for your mission--before departing on the Spec. Ops. Shuttle due South, make sure that all operatives are ready. Actual mission objective will be relayed to you by Central Command through your headsets.<br>If deemed appropriate, Central Command will also allow members of your team to equip assault power-armor for the mission. You will find the armor storage due West of your position. Once you are ready to leave, utilize the Special Operations shuttle console and toggle the hull doors via the other console.</p><p>In the event that the team does not accomplish their assigned objective in a timely manner, or finds no other way to do so, attached below are instructions on how to operate a Nanotrasen Nuclear Device. Your operations <b>LEADER</b> is provided with a nuclear authentication disk and a pin-pointer for this reason. You may easily recognize them by their rank: Lieutenant, Captain, or Major. The nuclear device itself will be present somewhere on your destination.</p><p>Hello and thank you for choosing Nanotrasen for your nuclear information needs. Today's crash course will deal with the operation of a Fission Class Nanotrasen made Nuclear Device.<br>First and foremost, <b>DO NOT TOUCH ANYTHING UNTIL THE BOMB IS IN PLACE.</b> Pressing any button on the compacted bomb will cause it to extend and bolt itself into place. If this is done to unbolt it one must completely log in which at this time may not be possible.<br>To make the device functional:<br>#1 Place bomb in designated detonation zone<br> #2 Extend and anchor bomb (attack with hand).<br>#3 Insert Nuclear Auth. Disk into slot.<br>#4 Type numeric code into keypad ([nuke_code]).<br>Note: If you make a mistake press R to reset the device.<br>#5 Press the E button to log onto the device.<br>You now have activated the device. To deactivate the buttons at anytime, for example when you have already prepped the bomb for detonation, remove the authentication disk OR press the R on the keypad. Now the bomb CAN ONLY be detonated using the timer. A manual detonation is not an option.<br>Note: Toggle off the <b>SAFETY</b>.<br>Use the - - and + + to set a detonation time between 5 seconds and 10 minutes. Then press the timer toggle button to start the countdown. Now remove the authentication disk so that the buttons deactivate.<br>Note: <b>THE BOMB IS STILL SET AND WILL DETONATE</b><br>Now before you remove the disk if you need to move the bomb you can: Toggle off the anchor, move it, and re-anchor.</p><p>The nuclear authorization code is: <b>[nuke_code ? nuke_code : "None provided"]</b></p><p><b>Good luck, soldier!</b></p>"
-		//	P.name = "Spec. Ops. Manual"
-
+/datum/striketeam/syndicate/extras()
 	for (var/obj/effect/landmark/L in landmarks_list)
 		if (L.name == "Syndicate-Commando-Bomb")
 			new /obj/effect/spawner/newbomb/timer/syndicate(L.loc)
-			del(L)
 
-	message_admins("<span class='notice'>[key_name_admin(usr)] has spawned a Syndicate strike squad.</span>", 1)
-	log_admin("[key_name(usr)] used Spawn Syndicate Squad.")
-	feedback_add_details("admin_verb","SDTHS") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-
-/client/proc/create_syndicate_death_commando(obj/spawn_location, syndicate_leader_selected = 0)
+/datum/striketeam/syndicate/create_commando(obj/spawn_location, syndicate_leader_selected = 0)
 	var/mob/living/carbon/human/new_syndicate_commando = new(spawn_location.loc)
 	var/syndicate_commando_leader_rank = pick("Lieutenant", "Captain", "Major")
 	var/syndicate_commando_rank = pick("Corporal", "Sergeant", "Staff Sergeant", "Sergeant 1st Class", "Master Sergeant", "Sergeant Major")
@@ -126,52 +38,59 @@ var/global/sent_syndicate_strike_team = 0
 	new_syndicate_commando.mind.special_role = "Syndicate Commando"
 	ticker.mode.traitors |= new_syndicate_commando.mind	//Adds them to current traitor list. Which is really the extra antagonist list.
 	new_syndicate_commando.equip_syndicate_commando(syndicate_leader_selected)
-	del(spawn_location)
 	return new_syndicate_commando
 
-/mob/living/carbon/human/proc/equip_syndicate_commando(syndicate_leader_selected = 0)
+/datum/striketeam/syndicate/greet_commando(var/mob/living/carbon/human/H)
+	to_chat(H, "<span class='notice'>You are [H.real_name], an Elite commando, in the service of the Syndicate.</span>")
+	to_chat(H, "<span class='notice'>Your mission is: <span class='danger'>[mission]</span></span>")
 
-
+/mob/living/carbon/human/proc/equip_syndicate_commando(leader = 0)
+	//Special radio setup
 	var/obj/item/device/radio/R = new /obj/item/device/radio/headset/syndicate(src)
 	R.set_frequency(SYND_FREQ) //Same frequency as the syndicate team in Nuke mode.
 	equip_to_slot_or_del(R, slot_ears)
 
+	//Basic Uniform
 	var/obj/item/clothing/under/syndicate/uni = new /obj/item/clothing/under/syndicate(src)
 	uni.attach_accessory(new/obj/item/clothing/accessory/holomap_chip/elite(src))
 	equip_to_slot_or_del(uni, slot_w_uniform)
+	equip_to_slot_or_del(new /obj/item/weapon/melee/energy/sword(src), slot_l_store)
+	equip_to_slot_or_del(new /obj/item/weapon/grenade/empgrenade(src), slot_r_store)
+	equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/silenced(src), slot_belt)
 
+	//Shoes & gloves
 	equip_to_slot_or_del(new /obj/item/clothing/shoes/swat(src), slot_shoes)
-	if (!syndicate_leader_selected)
-		equip_to_slot_or_del(new /obj/item/clothing/suit/space/syndicate/black(src), slot_wear_suit)
-	else
-		equip_to_slot_or_del(new /obj/item/clothing/suit/space/syndicate/black/red(src), slot_wear_suit)
 	equip_to_slot_or_del(new /obj/item/clothing/gloves/swat(src), slot_gloves)
-	if (!syndicate_leader_selected)
-		equip_to_slot_or_del(new /obj/item/clothing/head/helmet/space/syndicate/black(src), slot_head)
-	else
-		equip_to_slot_or_del(new /obj/item/clothing/head/helmet/space/syndicate/black/red(src), slot_head)
-	equip_to_slot_or_del(new /obj/item/clothing/mask/gas/syndicate(src), slot_wear_mask)
+
+	//Glasses)
 	equip_to_slot_or_del(new /obj/item/clothing/glasses/thermal(src), slot_glasses)
 
+	//Mask & Armor
+	equip_to_slot_or_del(new /obj/item/clothing/mask/gas/syndicate(src), slot_wear_mask)
+	if (leader)
+		equip_to_slot_or_del(new /obj/item/clothing/head/helmet/space/syndicate/black/red(src), slot_head)
+		equip_to_slot_or_del(new /obj/item/clothing/suit/space/syndicate/black/red(src), slot_wear_suit)
+	else
+		equip_to_slot_or_del(new /obj/item/clothing/head/helmet/space/syndicate/black(src), slot_head)
+		equip_to_slot_or_del(new /obj/item/clothing/suit/space/syndicate/black(src), slot_wear_suit)
+	equip_to_slot_or_del(new /obj/item/weapon/tank/emergency_oxygen(src), slot_s_store)
+
+	//Backpack
 	equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/security(src), slot_back)
 	equip_to_slot_or_del(new /obj/item/weapon/storage/box(src), slot_in_backpack)
-
 	equip_to_slot_or_del(new /obj/item/ammo_storage/box/c45(src), slot_in_backpack)
 	equip_to_slot_or_del(new /obj/item/weapon/storage/firstaid/regular(src), slot_in_backpack)
 	equip_to_slot_or_del(new /obj/item/weapon/plastique(src), slot_in_backpack)
-	equip_to_slot_or_del(new /obj/item/device/flashlight(src), slot_in_backpack)
-	if (!syndicate_leader_selected)
-		equip_to_slot_or_del(new /obj/item/weapon/plastique(src), slot_in_backpack)
-	else
+	equip_to_slot_or_del(new /obj/item/osipr_core(src), slot_in_backpack)
+	if (leader)
 		equip_to_slot_or_del(new /obj/item/weapon/pinpointer(src), slot_in_backpack)
 		equip_to_slot_or_del(new /obj/item/weapon/disk/nuclear(src), slot_in_backpack)
+	else
+		equip_to_slot_or_del(new /obj/item/weapon/plastique(src), slot_in_backpack)
+		equip_to_slot_or_del(new /obj/item/energy_magazine/osipr(src), slot_in_backpack)
 
-	equip_to_slot_or_del(new /obj/item/weapon/melee/energy/sword(src), slot_l_store)
-	equip_to_slot_or_del(new /obj/item/weapon/grenade/empgrenade(src), slot_r_store)
-	equip_to_slot_or_del(new /obj/item/weapon/tank/emergency_oxygen(src), slot_s_store)
-	equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/silenced(src), slot_belt)
 
-	put_in_hands(new /obj/item/weapon/gun/energy/pulse_rifle(src)) //Will change to something different at a later time -- Superxpdude
+	put_in_hands(new /obj/item/weapon/gun/osipr(src))
 
 	var/obj/item/weapon/card/id/syndicate/W = new(src) //Untrackable by AI
 	W.name = "[real_name]'s ID Card"

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -727,12 +727,13 @@ var/global/floorIsLava = 0
 		dat += {"
 			<A href='?src=\ref[src];secretsfun=spawnselfdummy'>Spawn yourself as a Test Dummy</A><BR>
 			<BR>
+			<BR>
 			"}
 
 	if(check_rights(R_ADMIN,0))
 		dat += {"
 			<B>Admin Secrets</B><BR>
-			<BR><BR>
+			<BR>
 			<A href='?src=\ref[src];secretsadmin=manifest'>Show Crew Manifest</A><BR>
 			<A href='?src=\ref[src];secretsadmin=showgm'>Show Game Mode</A><BR>
 			<A href='?src=\ref[src];secretsadmin=check_antagonist'>Show current traitors and objectives</A><BR>
@@ -749,6 +750,20 @@ var/global/floorIsLava = 0
 			<BR>
 			<BR>
 			"}
+
+
+	if(check_rights(R_ADMIN,0))
+		dat += {"
+			<B>Strike Teams</B><BR>
+			<BR>
+			<A href='?src=\ref[src];secretsfun=striketeam-deathsquad'>Send in a Death Squad!</A><BR>
+			<A href='?src=\ref[src];secretsfun=striketeam-ert'>Send in an Emergency Response Team!</A><BR>
+			<A href='?src=\ref[src];secretsfun=striketeam-syndi'>Send in a Syndicate Elite Strike Team!</A><BR>
+			<A href='?src=\ref[src];secretsfun=striketeam-custom'>Send in a Custom Strike Team! (Work in Progress!)</A><BR>
+			<BR>
+			<BR>
+			"}
+
 
 	if(check_rights(R_FUN,0))
 		dat += {"
@@ -805,7 +820,6 @@ var/global/floorIsLava = 0
 			<A href='?src=\ref[src];secretsfun=fakealerts'>Trigger a fake alert</A><BR>
 			<A href='?src=\ref[src];secretsfun=fakebooms'>Adds in some Micheal Bay to the shift without major destruction</A><BR>
 			<BR>
-			<A href='?src=\ref[src];secretsfun=striketeam'>Send in a strike team</A><BR>
 			<A href='?src=\ref[src];secretsfun=placeturret'>Create a turret</A><BR>
 			<BR>
 			<A href='?src=\ref[src];secretsfun=traitor_all'>Make everyone traitors</A><BR>

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -73,7 +73,6 @@ var/list/admin_verbs_admin = list(
 	/client/proc/check_customitem_activity,
 	// /client/proc/man_up,
 	// /client/proc/global_man_up,
-	/client/proc/response_team, // Response Teams admin verb
 	/client/proc/toggle_antagHUD_use,
 	/client/proc/toggle_antagHUD_restrictions,
 	/client/proc/allow_character_respawn,    /* Allows a ghost to respawn */

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -907,11 +907,11 @@
 		else
 			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=wizard;jobban4=\ref[M]'>[replacetext("Wizard", " ", "&nbsp")]</a></td>"
 
-		//ERT
-		if(jobban_isbanned(M, "Emergency Response Team") || isbanned_dept)
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=Emergency Response Team;jobban4=\ref[M]'><font color=red>Emergency Response Team</font></a></td>"
+		//Strike Team
+		if(jobban_isbanned(M, "Strike Team") || isbanned_dept)
+			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=Strike Team;jobban4=\ref[M]'><font color=red>Strike Team</font></a></td>"
 		else
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=Emergency Response Team;jobban4=\ref[M]'>Emergency Response Team</a></td>"
+			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=Strike Team;jobban4=\ref[M]'>Strike Team</a></td>"
 
 
 		//Vox Raider
@@ -2559,10 +2559,26 @@
 				for(var/mob/living/carbon/human/H in mob_list)
 					spawn(0)
 						H.corgize()
-			if("striketeam")
-				if(usr.client.strike_team())
-					feedback_inc("admin_secrets_fun_used",1)
-					feedback_add_details("admin_secrets_fun_used","Strike")
+			if("striketeam-deathsquad")
+				feedback_inc("admin_secrets_fun_used",1)
+				feedback_add_details("admin_secrets_fun_used","DeathQuad")
+				var/datum/striketeam/deathsquad/team = new /datum/striketeam/deathsquad()
+				team.trigger_strike(usr)
+			if("striketeam-ert")
+				feedback_inc("admin_secrets_fun_used",1)
+				feedback_add_details("admin_secrets_fun_used","ERT")
+				var/datum/striketeam/ert/team = new /datum/striketeam/ert()
+				team.trigger_strike(usr)
+			if("striketeam-syndi")
+				feedback_inc("admin_secrets_fun_used",1)
+				feedback_add_details("admin_secrets_fun_used","SyndiStrikeTeam")
+				var/datum/striketeam/syndicate/team = new /datum/striketeam/syndicate()
+				team.trigger_strike(usr)
+			if("striketeam-custom")
+				feedback_inc("admin_secrets_fun_used",1)
+				feedback_add_details("admin_secrets_fun_used","CustomStrikeTeam")
+				var/datum/striketeam/custom/team = new /datum/striketeam/custom()
+				team.trigger_strike(usr)
 			if("tripleAI")
 				usr.client.triple_ai()
 				feedback_inc("admin_secrets_fun_used",1)

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -990,7 +990,7 @@ Pressure: [env.return_pressure()]"}
 			M.equip_to_slot_or_del(W, slot_wear_id)
 
 		if("emergency response team")
-			M.equip_strike_team()
+			M.equip_response_team()
 
 		if("special ops officer")
 			M.equip_to_slot_or_del(new /obj/item/clothing/under/syndicate/combat(M), slot_w_uniform)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -23,6 +23,7 @@ var/global/list/special_roles = list(
 	ROLE_VAMPIRE      = IS_MODE_COMPILED("vampire"),
 	ROLE_VOXRAIDER    = IS_MODE_COMPILED("heist"),
 	ROLE_WIZARD       = 1,
+	ROLE_COMMANDO	  = 1,
 )
 
 var/list/antag_roles = list(
@@ -37,6 +38,7 @@ var/list/antag_roles = list(
 	ROLE_VAMPIRE      = IS_MODE_COMPILED("vampire"),
 	ROLE_VOXRAIDER    = IS_MODE_COMPILED("heist"),
 	ROLE_WIZARD       = 1,
+	ROLE_COMMANDO	  = 1,
 //	"infested monkey" = IS_MODE_COMPILED("monkey"),
 )
 

--- a/code/modules/mob/living/silicon/ai/death.dm
+++ b/code/modules/mob/living/silicon/ai/death.dm
@@ -37,7 +37,7 @@
 			break
 		callshuttle++
 
-	if(ticker.mode.name == "revolution" || ticker.mode.name == "AI malfunction" || sent_strike_team)
+	if(ticker.mode.name == "revolution" || ticker.mode.name == "AI malfunction")
 		callshuttle = 0
 
 	if(callshuttle == 3) //if all three conditions are met

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1292,10 +1292,10 @@ var/list/slot_equipment_priority = list( \
 		var/t1 = text("window=[href_list["mach_close"]]")
 		unset_machine()
 		src << browse(null, t1)
-	if (href_list["joinresponseteam"])
-		if(usr.client)
-			var/client/C = usr.client
-			C.JoinResponseTeam()
+	//if (href_list["joinresponseteam"])
+	//	if(usr.client)
+	//		var/client/C = usr.client
+	//		C.JoinResponseTeam()
 
 /mob/proc/pull_damage()
 	if(ishuman(src))

--- a/code/modules/security levels/keycard authentication.dm
+++ b/code/modules/security levels/keycard authentication.dm
@@ -179,7 +179,9 @@ var/global/list/obj/machinery/keycard_auth/authenticators = list()
 			revoke_maint_all_access()
 			feedback_inc("alert_keycard_auth_maintRevoke",1)
 		if("Emergency Response Team")
-			trigger_armed_response_team(1,ert_reason)
+			var/datum/striketeam/ert/response_team = new()
+			response_team.mission = ert_reason
+			response_team.trigger_strike()
 			feedback_inc("alert_keycard_auth_ert",1)
 
 var/global/maint_all_access = 0

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -29,6 +29,7 @@
 #include "__DEFINES\research_levels.dm"
 #include "__DEFINES\security.dm"
 #include "__DEFINES\setup.dm"
+#include "__DEFINES\striketeam_defines.dm"
 #include "__DEFINES\stylesheet.dm"
 #include "__DEFINES\subsystem.dm"
 #include "__DEFINES\tick.dm"

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -937,6 +937,7 @@
 #include "code\game\shuttles\voxresearch_shuttle.dm"
 #include "code\game\striketeams\emergency_response_team.dm"
 #include "code\game\striketeams\nanotrasen_deathsquad.dm"
+#include "code\game\striketeams\striketeam_datums.dm"
 #include "code\game\striketeams\syndicate_elite_squad.dm"
 #include "code\game\turfs\simulated.dm"
 #include "code\game\turfs\turf.dm"


### PR DESCRIPTION
Moved from #13611 

It's happening!

Here's how strike team work now:
* When a strike team is called, a message is sent to every ghost that isn't job-banned from Strike Teams. After a minute, if at least one ghost applied, every selected applicant gets spawned at their spawning landmarks.
* If there are enough commando, one of them might be a leader. Other commando have to follow his orders. The deathsquad leader (Creed) can spawn when there are at least 4 deathsquads, the ERT leader always spawn even if he's alone, the Elite Syndicate strike teams don't have leaders.

The revamp isn't fully over though, next come the map changes. I'll wait for this part to go through.

![secret](https://cloud.githubusercontent.com/assets/21122521/22229837/74b4dbd8-e1da-11e6-837d-f4dbe7e80586.png)
![save](https://cloud.githubusercontent.com/assets/21122521/22229839/75c8b936-e1da-11e6-958e-09fcf533fa26.png)
![recruit](https://cloud.githubusercontent.com/assets/21122521/22229842/77b9a3fe-e1da-11e6-90d8-6fd6b51dcd2b.png)
![bravo](https://cloud.githubusercontent.com/assets/21122521/22229844/78a0c978-e1da-11e6-92c7-57055bcb67c6.png)

These changes will allow new/custom strike teams to be easy to implement, and remove heaps of snowflaking (like seriously, whoever created ERTs, I'm looking at you)

:cl:
* rscadd: Added strike team datums, thus purging lots of copypasted code, and allowing for the easy adding of new strike teams types.
* tweak: Removed the JoinResponseTeam and the like buttons. Now ghosts join strike teams just like dionae and posibrains.
* rscadd: The strike team buttons for admins have been grouped together for easy use.
* experimental: Added framework for custom strike teams.
* tweak: Syndicate Elite Strike Teams now spawn with OSIPR instead of pulse rifles. Although they still cannot reach the station on most maps yet.