### PR TITLE
Construct spells now start out uncharged

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -1423,6 +1423,12 @@
 								M = null
 								to_chat(C, "<B>You are now an Artificer. You are incredibly weak and fragile, but you are able to construct new floors and walls, to break some walls apart, to repair allied constructs (by clicking on them), </B><I>and most important of all create new constructs</I><B> (Use your Artificer spell to summon a new construct shell and Summon Soulstone to create a new soulstone).</B>")
 								ticker.mode.update_cult_icons_added(C.mind)
+								for(var/spell/S in C.spell_list)
+									if(S.charge_type & Sp_RECHARGE)
+										if(S.charge_counter == S.charge_max) //Spell is fully charged - let the proc handle everything
+											S.take_charge()
+										else //Spell is on cooldown and already recharging - there's no need to call S.process(), just reset charges to 0
+											S.charge_counter = 0
 				qdel(src)
 				return
 			else

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -77,6 +77,12 @@
 	default_language = all_languages[LANGUAGE_CULT]
 	for(var/spell in construct_spells)
 		src.add_spell(new spell, "const_spell_ready")
+	for(var/spell/S in spell_list)
+		if(S.charge_type & Sp_RECHARGE)
+			if(S.charge_counter == S.charge_max) //Spell is fully charged - let the proc handle everything
+				S.take_charge()
+			else //Spell is on cooldown and already recharging - there's no need to call S.process(), just reset charges to 0
+				S.charge_counter = 0
 	updateicon()
 
 /mob/living/simple_animal/construct/Die()

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -77,12 +77,6 @@
 	default_language = all_languages[LANGUAGE_CULT]
 	for(var/spell in construct_spells)
 		src.add_spell(new spell, "const_spell_ready")
-	for(var/spell/S in spell_list)
-		if(S.charge_type & Sp_RECHARGE)
-			if(S.charge_counter == S.charge_max) //Spell is fully charged - let the proc handle everything
-				S.take_charge()
-			else //Spell is on cooldown and already recharging - there's no need to call S.process(), just reset charges to 0
-				S.charge_counter = 0
 	updateicon()
 
 /mob/living/simple_animal/construct/Die()


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl: (as the emoji)
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
Fixes #13938 

:cl:
* rscadd: Constructs now start out with their spells uncharged