### PR TITLE
staff of necromancy changes

### DIFF
--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -193,13 +193,33 @@ var/available_staff_transforms=list("monkey","robot","slime","xeno","human","fur
 	var/mob/living/carbon/human/H = target
 	if(!H.stat || H.health > config.health_threshold_crit)
 		return 0
+
+	//Pretty particles
+	make_tracker_effects(get_turf(H), user)
+	//Not so pretty manical laughter
+	if(iswizard(user) || isapprentice(user))
+		user.say(pick("ARISE, [pick("MY CREATION","MY MINION","CH'KUN")].",\
+		"BOW BEFORE [pick("MY POWER","ME, [uppertext(H.real_name)]")].",\
+		"G'T T'FUK UP.",\
+		"IF YOU DIE, YOU DIE FOR ME.",\
+		"EVEN IN DEATH YOU MAY SERVE.",\
+		"YOUR SUFFERING IS MY ENJOYMENT.",\
+		"A NEW PLAYTHING FOR MY COLLECTION.",\
+		"YOUR TIME HAS NOT COME, YET.",\
+		"YOUR SOUL MAY BELONG TO [uppertext(ticker.Bible_deity_name)] BUT YOU BELONG TO ME."))
+
+	playsound(get_turf(src), get_sfx("soulstone"), 50,1)
+
 	switch(raisetype)
 		if(ZOMBIE)
-			new /mob/living/simple_animal/hostile/necro/zombie(get_turf(target), user, H.mind)
+			var/mob/living/simple_animal/hostile/necro/zombie/turned/T = new(get_turf(target), user, H.mind)
+			T.get_clothes(H, T)
+			T.name = H.real_name
+			T.host = H
+			H.loc = null
 		if(SKELETON)
 			new /mob/living/simple_animal/hostile/necro/skeleton(get_turf(target), user, H.mind)
-
-	H.gib()
+			H.gib()
 	charges--
 
 


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl: (as the emoji)
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
Zombies swapped out for the infectious zombies

Now rather than clickngib, it instead makes a fancy soul trail to the caster

Wizards and apprentices are overly dramatic about their necromancy