### PR TITLE
Adds warning cooldown to vehicles

### DIFF
--- a/code/game/objects/structures/vehicles/clowncart.dm
+++ b/code/game/objects/structures/vehicles/clowncart.dm
@@ -260,7 +260,7 @@
 		unlock_atom(user)
 		return
 	if(empstun > 0)
-		if(user)
+		if(user && can_warn())
 			to_chat(user, "<span class='warning'>[src]'s banana essence battery has been shorted out.</span>")
 		return
 	if(reagents.total_volume <= 0 && max_health < HEALTH_FOR_FREE_MOVEMENT) //No fuel
@@ -292,7 +292,8 @@
 				new /obj/item/weapon/bananapeel/traitorpeel/(old_pos)
 				reagents.remove_reagent(BANANA,BANANA_FOR_TRAITOR_PEEL)
 	else
-		to_chat(user, "<span class='notice'>You have to honk to be able to ride [src].</span>")
+		if(can_warn())
+			to_chat(user, "<span class='notice'>You have to honk to be able to ride [src].</span>")
 
 /obj/structure/bed/chair/vehicle/clowncart/die()
 	density = 0

--- a/code/game/objects/structures/vehicles/vehicle.dm
+++ b/code/game/objects/structures/vehicles/vehicle.dm
@@ -47,6 +47,7 @@
 	var/mob/occupant
 	lock_type = /datum/locking_category/buckle/chair/vehicle
 	var/wreckage_type = /obj/effect/decal/mecha_wreckage/vehicle
+	var/last_warn
 
 /obj/structure/bed/chair/vehicle/proc/getMovementDelay()
 	return movement_delay
@@ -104,10 +105,11 @@
 		unlock_atom(user)
 		return
 	if(!check_key(user))
-		to_chat(user, "<span class='notice'>You'll need the keys in one of your hands to drive \the [src].</span>")
+		if(can_warn())
+			to_chat(user, "<span class='notice'>You'll need the keys in one of your hands to drive \the [src].</span>")
 		return 0
 	if(empstun > 0)
-		if(user)
+		if(user && can_warn(user))
 			to_chat(user, "<span class='warning'>\The [src] is unresponsive.</span>")
 		return 0
 	if(move_delayer.blocked())
@@ -149,6 +151,12 @@
 	if(istype(src.loc, /turf/space) && (!src.Process_Spacemove(0, user)))
 		var/turf/space/S = src.loc
 		S.Entered(src)*/
+
+/obj/structure/bed/chair/vehicle/proc/can_warn() //Should be used for any instance of to_chat in relaymove
+	if(world.time < last_warn + 1 SECONDS)
+		return 0
+	last_warn = world.time
+	return 1
 
 /obj/structure/bed/chair/vehicle/proc/can_buckle(mob/M, mob/user)
 	if(M != user || !ishuman(user) || !Adjacent(user) || user.restrained() || user.lying || user.stat || user.locked_to || occupant)

--- a/code/game/objects/structures/vehicles/wheelchair.dm
+++ b/code/game/objects/structures/vehicles/wheelchair.dm
@@ -134,7 +134,8 @@
 
 /obj/structure/bed/chair/vehicle/wheelchair/relaymove(var/mob/user, direction)
 	if(!check_key(user))
-		to_chat(user, "<span class='warning'>You need at least one hand to use [src]!</span>")
+		if(can_warn())
+			to_chat(user, "<span class='warning'>You need at least one hand to use [src]!</span>")
 		return 0
 	return ..()
 


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl: (as the emoji)
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
Seems that mounting a vehicle and going on its keys with server lag would cause some users to crash as it tried to print out 'You don't have the keys' about 10 times a second, so now there's a delay function for any use of to_chat in canmove