### PR TITLE
Modifies drag damage to high chance brute, low chance bleed

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -729,7 +729,7 @@ Thanks.
 												var/blood_volume = round(H:vessel.get_reagent_amount("blood"))
 												if(blood_volume > 0)
 													H:vessel.remove_reagent("blood",5)
-													M.visible_message("<span class='danger'>\The [M] loses some a lot of blood from being dragged!</span>")
+													M.visible_message("<span class='danger'>\The [M] loses a lot of blood from being dragged!</span>")
 					else
 						if (pulling)
 							pulling.Move(T, get_dir(pulling, T))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -703,29 +703,33 @@ Thanks.
 							pulling.Move(T, get_dir(pulling, T))
 							if(M && secondarypull)
 								M.start_pulling(secondarypull)
-						//this is the gay blood on floor shit -- Added back --snx
-							if (M.lying && (prob(M.getBruteLoss() / 3)))
-								/*if(isturf(M.loc))
-									blood_splatter(M.loc,M)
-									if(ishuman(M))
-										var/mob/living/carbon/H = M
-										var/blood_volume = round(H:vessel.get_reagent_amount("blood"))
-										if(blood_volume > 0)
-											H:vessel.remove_reagent("blood",2)*/ //Commented out till we can un-fuck lag from blood
-								if(prob(50)) //ha, ha, rip and tear
+//this is the gay blood on floor shit -- Added back --snx
+							if (M.lying && (prob(M.getBruteLoss() / 3)))	
+								if(prob(6)) //Too much bloooooood
+									if(isturf(M.loc))
+										blood_splatter(M.loc,M)
+										if(ishuman(M))
+											var/mob/living/carbon/H = M
+											var/blood_volume = round(H:vessel.get_reagent_amount("blood"))
+											if(blood_volume > 0)
+												H:vessel.remove_reagent("blood",2)
+												M.visible_message("<span class='warning'>\The [M] loses some blood from being dragged!</span>")
+								if(prob(50))
 									M.adjustBruteLoss(1)
 									M.visible_message("<span class='warning'>\The [M]'s wounds worsen from being dragged!</span>")
 							if(M.pull_damage())
 								if(prob(25))
 									M.adjustBruteLoss(2)
 									M.visible_message("<span class='danger'>\The [M]'s wounds worsen terribly from being dragged!</span>")
-									if(isturf(M.loc))
-										blood_splatter(M.loc,M,1)
-										if(ishuman(M))
-											var/mob/living/carbon/H = M
-											var/blood_volume = round(H:vessel.get_reagent_amount("blood"))
-											if(blood_volume > 0)
-												H:vessel.remove_reagent("blood",5)
+									if(prob(25))
+										if(isturf(M.loc))
+											blood_splatter(M.loc,M,1)
+											if(ishuman(M))
+												var/mob/living/carbon/H = M
+												var/blood_volume = round(H:vessel.get_reagent_amount("blood"))
+												if(blood_volume > 0)
+													H:vessel.remove_reagent("blood",5)
+													M.visible_message("<span class='danger'>\The [M] loses some a lot of blood from being dragged!</span>")
 					else
 						if (pulling)
 							pulling.Move(T, get_dir(pulling, T))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -712,7 +712,7 @@ Thanks.
 										var/blood_volume = round(H:vessel.get_reagent_amount("blood"))
 										if(blood_volume > 0)
 											H:vessel.remove_reagent("blood",2)*/ //Commented out till we can un-fuck lag from blood
-								if(prob(6))
+								if(prob(50)) //ha, ha, rip and tear
 									M.adjustBruteLoss(1)
 									M.visible_message("<span class='warning'>\The [M]'s wounds worsen from being dragged!</span>")
 							if(M.pull_damage())

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -705,13 +705,13 @@ Thanks.
 								M.start_pulling(secondarypull)
 						//this is the gay blood on floor shit -- Added back --snx
 							if (M.lying && (prob(M.getBruteLoss() / 3)))
-								if(isturf(M.loc))
+								/*if(isturf(M.loc))
 									blood_splatter(M.loc,M)
 									if(ishuman(M))
 										var/mob/living/carbon/H = M
 										var/blood_volume = round(H:vessel.get_reagent_amount("blood"))
 										if(blood_volume > 0)
-											H:vessel.remove_reagent("blood",2)
+											H:vessel.remove_reagent("blood",2)*/ //Commented out till we can un-fuck lag from blood
 								if(prob(6))
 									M.adjustBruteLoss(1)
 									M.visible_message("<span class='warning'>\The [M]'s wounds worsen from being dragged!</span>")


### PR DESCRIPTION
Update to #14447, discuss further in #14469.
Modifies drag damage for a relatively high chance to cause brute damage, and a relatively low chance to cause bloodloss.
0% tested

:cl:
 - Tweak: Dragging someone who is bleeding no longer causes massive bloodloss. Still in effect for people in crit, though.