### PR TITLE
Cyborgs action buttons

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -173,7 +173,7 @@
 	desc = "A carbon dioxide jetpack suitable for low-gravity operations."
 	icon_state = "cyborg_upgrade3"
 	required_module = list(/obj/item/weapon/robot_module/miner,/obj/item/weapon/robot_module/engineering)
-	modules_to_add = list(/obj/item/weapon/tank/jetpack/carbondioxide)
+	modules_to_add = list(/obj/item/weapon/tank/jetpack/carbondioxide/silicon)
 	add_to_mommis = 1
 
 /obj/item/borg/upgrade/jetpack/attempt_action(var/mob/living/silicon/robot/R,var/mob/living/user)

--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -12,7 +12,7 @@
 	var/stabilization_on = 0
 	var/volume_rate = 500              //Needed for borg jetpack transfer
 	actions_types = list(/datum/action/item_action/set_internals, /datum/action/item_action/jetpack_stabilization,/datum/action/item_action/toggle_jetpack)
-	
+
 /obj/item/weapon/tank/jetpack/proc/toggle_rockets()
 	src.stabilization_on = !( src.stabilization_on )
 	to_chat(usr, "You toggle the stabilization [stabilization_on? "on":"off"].")
@@ -48,16 +48,16 @@
 	qdel(G)
 	G = null
 	return
-		
+
 /datum/action/item_action/toggle_jetpack
 	name = "Toggle Jetpack"
-	
+
 /datum/action/item_action/toggle_jetpack/Trigger()
 	var/obj/item/weapon/tank/jetpack/T = target
 	if(!istype(T))
 		return
 	T.toggle()
-	
+
 /datum/action/item_action/jetpack_stabilization
 	name = "Toggle Jetpack Stabilization"
 
@@ -66,7 +66,7 @@
 	if(!istype(J) || !J.on)
 		return 0
 	return ..()
-	
+
 /datum/action/item_action/jetpack_stabilization/Trigger()
 	var/obj/item/weapon/tank/jetpack/T = target
 	if(!istype(T))
@@ -122,3 +122,6 @@
 /obj/item/weapon/tank/jetpack/carbondioxide/New()
 	. = ..()
 	air_contents.adjust(, (6 * ONE_ATMOSPHERE) * volume / (R_IDEAL_GAS_EQUATION * T20C))
+
+/obj/item/weapon/tank/jetpack/carbondioxide/silicon
+	actions_types = list(/datum/action/item_action/jetpack_stabilization,/datum/action/item_action/toggle_jetpack)

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -29,6 +29,11 @@
 	contents -= module
 	if(module)
 		module.forceMove(src.module)
+		for(var/X in module.actions)
+			var/datum/action/A = X
+			A.Remove(src)
+	if(module)
+		module.forceMove(src.module)
 	hud_used.update_robot_modules_display()
 	return 1
 
@@ -74,6 +79,9 @@
 	if(activated(O))
 		to_chat(src, "<span class='notice'>Already activated</span>")
 		return
+	for(var/X in O.actions)
+		var/datum/action/A = X
+		A.Grant(src)
 	if(!module_state_1)
 		O.mouse_opacity = initial(O.mouse_opacity)
 		module_state_1 = O

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -32,8 +32,6 @@
 		for(var/X in module.actions)
 			var/datum/action/A = X
 			A.Remove(src)
-	if(module)
-		module.forceMove(src.module)
 	hud_used.update_robot_modules_display()
 	return 1
 

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -15,6 +15,7 @@
 
 	if(client)
 		handle_regular_hud_updates()
+		update_action_buttons()
 		update_items()
 	if (src.stat != DEAD) //still using power
 		use_power()

--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -1,8 +1,11 @@
-/mob/living/silicon/robot/Process_Spacemove()
+/mob/living/silicon/robot/Process_Spacemove(var/check_drift = 0)
 	if(module)
 		for(var/obj/item/weapon/tank/jetpack/J in module.modules)
 			if(J && istype(J, /obj/item/weapon/tank/jetpack))
-				if(J.allow_thrust(0.01))
+				if(((!check_drift) || (check_drift && J.stabilization_on)) && (J.allow_thrust(0.01, src)))
+					inertia_dir = 0
+					return 1
+				if((!check_drift && J.allow_thrust(0.01)))
 					return 1
 	if(..())
 		return 1


### PR DESCRIPTION
https://webmshare.com/3w35r

Adds action buttons for cyborg's selected modules, such as flashlight and jetpack, fixes jetpacks not working due no action buttons and also fixes an oversight with stabilization toogle not working for cyborgs. The webm still have the the set internals button but i removed it from cyborgs by creating a child jetpack without the button.

:cl:
 * rscadd: Adds cyborg action buttons
 * bugfix: Fixes cyborg jetpack not working
 * tweak: You can now toogle jetpack stabilization on and off