### PR TITLE
Makes round end on wizard's death

### DIFF
--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -217,9 +217,7 @@
 
 
 /datum/game_mode/wizard/check_finished()
-	return ..()
 
-	/*
 	if(istype(ticker.mode, /datum/game_mode/mixed))
 		mixed = 1
 	if(config.continous_rounds || mixed)
@@ -248,7 +246,6 @@
 		finished = 1
 		return 1
 
-	*/
 
 /datum/game_mode/wizard/declare_completion(var/ragin = 0)
 	if(finished && !ragin)


### PR DESCRIPTION
This just really isn't a good idea, there are less admins on late at night than ever which makes wiztended common as hell whenever there are actually enough people online at these times. This change was made entirely under the idea that there will be admins on to do something if a wizzy dies early into the round which is just down right awful. 