### PR TITLE
bottles now get their overlay back

### DIFF
--- a/code/modules/reagents/reagent_containers/glass/bottle.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle.dm
@@ -59,7 +59,6 @@
 	update_icon()
 
 /obj/item/weapon/reagent_containers/glass/bottle/update_icon()
-
 	overlays.len = 0
 
 	if(reagents.total_volume)
@@ -81,6 +80,7 @@
 				filling.icon_state = "[icon_state]30"
 
 		filling.icon += mix_color_from_reagents(reagents.reagent_list)
+		filling.alpha = mix_alpha_from_reagents(reagents.reagent_list)
 		overlays += filling
 
 	if(!is_open_container())
@@ -470,7 +470,7 @@
 	w_type = RECYK_MISC
 	melt_temperature = MELTPOINT_PLASTIC
 
-/obj/item/weapon/reagent_containers/glass/bottle/update_icon()
+/obj/item/weapon/reagent_containers/glass/bottle/bleach/update_icon()
 	overlays.len = 0
 
 	if(!is_open_container())


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl: (as the emoji)
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
Also the alpha from regular beakers and glasses is added to bottle update_icon

:cl:
* bugfix: Chemistry bottle overlay fixed