### PR TITLE
Soaps nerf

### DIFF
--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -32,12 +32,12 @@
 	if(!user.Adjacent(target))
 		return
 
-	if(!do_after(user, target, 60))
-		return
-
 	if(user.client && (target in user.client.screen) && !(user.is_holding_item(target)))
 		user.simple_message("<span class='notice'>You need to take that [target.name] off before cleaning it.</span>",
 			"<span class='notice'>You need to take that [target.name] off before destroying it.</span>")
+
+	if(!do_after(user, target, 60))
+		return
 
 	else if(istype(target,/obj/effect/decal/cleanable))
 		user.simple_message("<span class='notice'>You scrub \the [target.name] out.</span>",

--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -32,6 +32,9 @@
 	if(!user.Adjacent(target))
 		return
 
+	if(!do_after(user, target, 60))
+		return
+
 	if(user.client && (target in user.client.screen) && !(user.is_holding_item(target)))
 		user.simple_message("<span class='notice'>You need to take that [target.name] off before cleaning it.</span>",
 			"<span class='notice'>You need to take that [target.name] off before destroying it.</span>")


### PR DESCRIPTION
Before, soaps had NO cooldown/took no time to clean things. This made them extremely godly compared to mops and any other thing that cleans floors/objects.

# In-game changelog
:cl: 
 * tweak: Soaps now take time to clean things