### PR TITLE
Reduces price of the RPED

### DIFF
--- a/code/modules/research/designs/engineering.dm
+++ b/code/modules/research/designs/engineering.dm
@@ -99,7 +99,7 @@
 	id = "rped"
 	req_tech = list(Tc_ENGINEERING = 4, Tc_MATERIALS = 4, Tc_PROGRAMMING = 2)
 	build_type = PROTOLATHE
-	materials = list(MAT_IRON = 60000, MAT_GLASS = 30000)
+	materials = list(MAT_IRON = 15000, MAT_GLASS = 5000)
 	build_path = /obj/item/weapon/storage/bag/gadgets/part_replacer
 	category = "Engineering"
 


### PR DESCRIPTION
currently the RPED costs 30 metal and 20 glass sheets. While this isnt a unreasonable price it brings up a separate issue: Construction time. Taking roughly 2 minutes to build in the protolathe. While this may not seem like a lot for the 2 minutes it is constructing the protolathe is completely locked down preventing anything else from being made. This wouldnt be bad for high ultra level tech but the RPED is a simple tool which basically is used for the sub par upgrades. With how good and how noticeable upgrading machines are the price point and construction time is just to high for what you get out of it. 