### PR TITLE
Makes TG17355 cyborgs the new Peacekeepers, Security-series is only avaiable at security level blue.

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -231,6 +231,8 @@
 
 /proc/getAvailableRobotModules()
 	var/list/modules = list("Standard", "Engineering", "Medical", "Supply", "Janitor", "Service", "Peacekeeper")
+	if(security_level >= SEC_LEVEL_BLUE)
+		modules+="Security"
 	if(security_level == SEC_LEVEL_RED) //Add crisis to this check if you want to make it available at an admin's whim
 		modules+="Combat"
 	return modules

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -313,7 +313,7 @@
 			module_sprites["Arachne"] = "arachne"
 			speed = -2
 
-		if("Peacekeeper")
+		if("Security")
 			module = new /obj/item/weapon/robot_module/security(src)
 			radio.insert_key(new/obj/item/device/encryptionkey/headset_sec(radio))
 			module_sprites["Basic"] = "secborg"
@@ -327,7 +327,7 @@
 			to_chat(src, "<span class='warning'><big><b>Just a reminder, by default you do not follow space law, you follow your lawset</b></big></span>")
 			speed = 0
 
-		if("TG17355")
+		if("Peacekeeper")
 			module = new /obj/item/weapon/robot_module/tg17355(src)
 			module_sprites["Peacekeeper"] = "peaceborg"
 			module_sprites["Omoikane"] = "omoikane"

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -276,7 +276,7 @@
 
 
 /obj/item/weapon/robot_module/security
-	name = "peacekeeper robot module"
+	name = "security robot module"
 
 /obj/item/weapon/robot_module/security/New()
 	..()
@@ -425,7 +425,7 @@
 	fix_modules()
 
 /obj/item/weapon/robot_module/tg17355
-	name = "tg17355 robot module"
+	name = "peacekeeper robot module"
 
 /obj/item/weapon/robot_module/tg17355/New()
 	..()


### PR DESCRIPTION

:cl:
 * tweak: TG177355's are now the new Peacekeepers and avaiable at roundstart.
 * tweak: Security borgs are back to being named Security but follow YOUR laws, not space law, dipshit.
 * tweak: Security module now needs at least code blue to be available.