### PR TITLE
Fixes cyborg inventory spaghetti

### DIFF
--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -75,7 +75,7 @@
 	if(activated(O))
 		to_chat(src, "<span class='notice'>Already activated</span>")
 		return
-	I.equipped(src)
+	O.equipped(src)
 	if(!module_state_1)
 		O.mouse_opacity = initial(O.mouse_opacity)
 		module_state_1 = O

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -29,9 +29,7 @@
 	contents -= module
 	if(module)
 		module.forceMove(src.module)
-		for(var/X in module.actions)
-			var/datum/action/A = X
-			A.Remove(src)
+	module.dropped(src)
 	hud_used.update_robot_modules_display()
 	return 1
 
@@ -77,9 +75,7 @@
 	if(activated(O))
 		to_chat(src, "<span class='notice'>Already activated</span>")
 		return
-	for(var/X in O.actions)
-		var/datum/action/A = X
-		A.Grant(src)
+	I.equipped(src)
 	if(!module_state_1)
 		O.mouse_opacity = initial(O.mouse_opacity)
 		module_state_1 = O

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -29,7 +29,7 @@
 	contents -= module
 	if(module)
 		module.forceMove(src.module)
-	module.dropped(src)
+		module.dropped(src)
 	hud_used.update_robot_modules_display()
 	return 1
 


### PR DESCRIPTION
Makes use of equipped() and dropped() instead of doing the dirty job manually. Thanks @clusterfack for pointing out my retardness.