### PR TITLE
Fixes xenoarch gun's missing their aditional description

### DIFF
--- a/code/modules/research/xenoarchaeology/finds/finds.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds.dm
@@ -415,7 +415,7 @@
 			new_item.icon = 'icons/obj/xenoarchaeology.dmi'
 			new_item.item_state = new_item.icon_state
 			new_item.inhand_states = list("left_hand" = 'icons/mob/in-hand/left/xenoarch.dmi', "right_hand" = 'icons/mob/in-hand/right/xenoarch.dmi')
-			additional_desc = "This is an antique projectile weapon, you're not sure if it will fire or not."
+			additional_desc = "Looks like an antique projectile weapon, you're not sure if it will fire or not."
 			if(prob(10)) // 10% chance to be a smart gun
 				new_item.can_take_pai = TRUE
 				additional_desc += "There seems to be some sort of slot in the handle."

--- a/code/modules/research/xenoarchaeology/finds/finds.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds.dm
@@ -386,11 +386,11 @@
 				new_item.icon = 'icons/obj/xenoarchaeology.dmi'
 				new_item.icon_state = "egun[rand(1,6)]"
 				new_item.item_state = new_item.icon_state
-				new_item.desc = "This is an antique energy weapon, you're not sure if it will fire or not."
+				additional_desc = "Looks like an antique energy weapon, you're not sure if it will fire or not."
 				new_item.inhand_states = list("left_hand" = 'icons/mob/in-hand/left/xenoarch.dmi', "right_hand" = 'icons/mob/in-hand/right/xenoarch.dmi')
 				if(prob(10)) // 10% chance to be a smart gun
 					new_item.can_take_pai = TRUE
-					new_item.desc += "There seems to be some sort of slot in the handle."
+					additional_desc += "There seems to be some sort of slot in the handle."
 				new_gun.charge_states = 0 //let's prevent it from losing that great icon if we charge it
 
 				//5% chance to explode when first fired
@@ -415,10 +415,10 @@
 			new_item.icon = 'icons/obj/xenoarchaeology.dmi'
 			new_item.item_state = new_item.icon_state
 			new_item.inhand_states = list("left_hand" = 'icons/mob/in-hand/left/xenoarch.dmi', "right_hand" = 'icons/mob/in-hand/right/xenoarch.dmi')
-			new_item.desc = "This is an antique projectile weapon, you're not sure if it will fire or not."
+			additional_desc = "This is an antique projectile weapon, you're not sure if it will fire or not."
 			if(prob(10)) // 10% chance to be a smart gun
 				new_item.can_take_pai = TRUE
-				new_item.desc += "There seems to be some sort of slot in the handle."
+				additional_desc += "There seems to be some sort of slot in the handle."
 
 			//let's get some ammunition in this gun : weighted to pick available ammo
 			new_gun.caliber = pick(50;list("357" = 1),


### PR DESCRIPTION
Seems like this was already broken i didn't test it properly last time i touched the code.

:cl:
 * bugfix: Fixes xenoarch guns not having their aditional description.