### PR TITLE
Removes alien reproduction from SoC

### DIFF
--- a/code/modules/projectiles/projectile/change.dm
+++ b/code/modules/projectiles/projectile/change.dm
@@ -116,16 +116,12 @@
 				if(M.default_language)
 					Slime.default_language = M.default_language
 			if("xeno")
-				var/alien_caste = pick("Hunter","Sentinel","Drone","Larva")
+				var/alien_caste = pick("Hunter","Sentinel")
 				switch(alien_caste)
 					if("Hunter")
 						new_mob = new /mob/living/carbon/alien/humanoid/hunter(M.loc)
 					if("Sentinel")
 						new_mob = new /mob/living/carbon/alien/humanoid/sentinel(M.loc)
-					if("Drone")
-						new_mob = new /mob/living/carbon/alien/humanoid/drone(M.loc)
-					else
-						new_mob = new /mob/living/carbon/alien/larva(M.loc)
 				var/mob/living/carbon/alien/Alien = new_mob
 				Alien.languages |= M.languages
 				if(M.default_language)


### PR DESCRIPTION
Lets be honest, we all know that aliens at the moment are pretty fucking strong, they're designed to be that way because they're hard to get and a lot of that comes from the facerapers. I've seen a bunch of rounds where wizards SoC just turns the round into aliens and people completely forget about everything else. 

The drone and hunter are still both strong on their own, with one having stealth and the other having good health and ranged stuns. They still get to terrorize the crew but they don't take all the attention away from the wizard. 