### PR TITLE
Adds roller bed holder for mediborgs

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -196,11 +196,11 @@
 	desc = "A rack for carrying a collapsed roller bed."
 	icon = 'icons/obj/rollerbed.dmi'
 	icon_state = "folded"
-	var/obj/item/roller/held
+	var/obj/structure/bed/roller/held
 
 /obj/item/roller_holder/New()
 	..()
-	held = new /obj/item/roller(src)
+	held = new(src)
 
 /obj/item/roller_holder/attack_self(mob/user as mob)
 
@@ -209,9 +209,8 @@
 		return
 
 	to_chat(user, "<span class='notice'>You deploy the roller bed.</span>")
-	var/obj/structure/bed/roller/R = new /obj/structure/bed/roller(user.loc)
-	R.add_fingerprint(user)
-	qdel(held)
+	held.add_fingerprint(user)
+	held.forceMove(get_turf(src))
 	held = null
 
 /datum/locking_category/buckle/bed

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -171,7 +171,9 @@
 
 		qdel(src)
 
-/obj/structure/bed/attackby(obj/item/weapon/W as obj, mob/user as mob)
+/obj/structure/bed/attackby(obj/item/weapon/W, mob/user)
+	if(istype(W,/obj/item/roller_holder))
+		manual_unbuckle(user)
 	if(iswrench(W))
 		playsound(get_turf(src), 'sound/items/Ratchet.ogg', 50, 1)
 		getFromPool(sheet_type, get_turf(src), 2)
@@ -180,6 +182,37 @@
 
 	. = ..()
 
+/obj/structure/bed/roller/attackby(obj/item/weapon/W, mob/user)
+	..()
+	if(istype(W,/obj/item/roller_holder))
+		var/obj/item/roller_holder/RH = W
+		if(!RH.held)
+			to_chat(user, "<span class='notice'>You collect the roller bed.</span>")
+			src.forceMove(RH)
+			RH.held = src
+
+/obj/item/roller_holder
+	name = "roller bed rack"
+	desc = "A rack for carrying a collapsed roller bed."
+	icon = 'icons/obj/rollerbed.dmi'
+	icon_state = "folded"
+	var/obj/item/roller/held
+
+/obj/item/roller_holder/New()
+	..()
+	held = new /obj/item/roller(src)
+
+/obj/item/roller_holder/attack_self(mob/user as mob)
+
+	if(!held)
+		to_chat(user, "<span class='notice'>The rack is empty.</span>")
+		return
+
+	to_chat(user, "<span class='notice'>You deploy the roller bed.</span>")
+	var/obj/structure/bed/roller/R = new /obj/structure/bed/roller(user.loc)
+	R.add_fingerprint(user)
+	qdel(held)
+	held = null
 
 /datum/locking_category/buckle/bed
 	flags = LOCKED_SHOULD_LIE

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -162,6 +162,7 @@
 	src.modules += new /obj/item/weapon/revivalprod(src)
 	src.modules += new /obj/item/weapon/crowbar(src)
 	src.modules += new /obj/item/weapon/inflatable_dispenser/robot(src)
+	src.modules += new /obj/item/roller_holder(src)
 	src.emag = new /obj/item/weapon/reagent_containers/spray(src)
 	sensor_augs = list("Medical", "Disable")
 


### PR DESCRIPTION
https://webmshare.com/KE16G

Holds one bed bed that can be deployed to safely transport patients to medbay. You need to grab the bed back with your holder when you're done, or another one if you somehow can't collect the old one because this is just a bed holder, not a fucking bed dispenser. 

:cl:
 * rscadd: Adds a roller bed holder for mediborgs, it can hold and deploy one roller bed when needed to avoid harm while transporting patients to medbay.