### PR TITLE
Dissalows plasmamen from being HoS, HoP and captain again

### DIFF
--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -13,7 +13,7 @@
 	minimal_access = list() 	//See get_access()
 	minimal_player_age = 14
 
-	species_whitelist = list("Human", "Plasmaman")
+	species_whitelist = list("Human")
 
 	pdaslot=slot_l_store
 	pdatype=/obj/item/device/pda/captain
@@ -72,7 +72,7 @@
 	req_admin_notify = 1
 	minimal_player_age = 10
 
-	species_whitelist = list("Human", "Plasmaman")
+	species_whitelist = list("Human")
 
 	access = list(access_security, access_sec_doors, access_brig, access_court, access_weapons, access_forensics_lockers,
 			            access_medical, access_engine, access_change_ids, access_ai_upload, access_eva, access_heads,

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -19,7 +19,7 @@
 			            access_heads, access_hos, access_RC_announce, access_keycard_auth, access_gateway)
 	minimal_player_age = 14
 
-	species_whitelist = list("Human", "Plasmaman")
+	species_whitelist = list("Human")
 
 	pdaslot=slot_belt
 	pdatype=/obj/item/device/pda/heads/hos


### PR DESCRIPTION
We forgot to revert one of the april fools jokes, whoops.

:cl:
- rscdel: Plasmamen can no longer be Captains, Heads of Personnel or Heads of Security.