### PR TITLE
Cult pylon funtimes

### DIFF
--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -24,7 +24,7 @@
 	var/isbroken = 0
 	light_range = 5
 	light_color = LIGHT_COLOR_RED
-	var/last_check
+	var/last_check = 0
 
 /obj/structure/cult/pylon/New()
 	..()
@@ -36,9 +36,8 @@
 
 /obj/structure/cult/pylon/process()
 	if(!isbroken && world.time > last_check + 3 SECONDS)
-		var/list/can_see = view(src, 3)
 		last_check = world.time
-		for(var/mob/living/simple_animal/construct/C in can_see)
+		for(var/mob/living/simple_animal/construct/C in view(src, 3))
 			if(C.health < C.maxHealth)
 				if(prob(15))
 					src.visible_message("<span class='sinister'>\the [src] mends some of \the <EM>[C]'s</EM> wounds.</span>")
@@ -50,6 +49,10 @@
 	attackpylon(M, 5)
 
 /obj/structure/cult/pylon/attack_animal(mob/living/simple_animal/user as mob)
+	if(istype(M, /mob/living/simple_animal/construct/builder))
+		if(isbroken && prob(20))
+			repair(M)
+			return
 	attackpylon(user, user.melee_damage_upper)
 
 /obj/structure/cult/pylon/attackby(obj/item/W as obj, mob/user as mob)
@@ -72,19 +75,14 @@
 			to_chat(user, "You hit the pylon!")
 			playsound(get_turf(src), 'sound/effects/Glasshit.ogg', 75, 1)
 	else
+		playsound(get_turf(src), 'sound/effects/Glasshit.ogg', 75, 1)
 		if(prob(damage * 2))
 			to_chat(user, "You pulverize what was left of the pylon!")
 			qdel(src)
 		else
 			to_chat(user, "You hit the pylon!")
-		playsound(get_turf(src), 'sound/effects/Glasshit.ogg', 75, 1)
 
-/obj/structure/cult/pylon/attack_animal(mob/living/simple_animal/M)
-	if(istype(M, /mob/living/simple_animal/construct/builder))
-		if(isbroken && prob(20))
-			repair(M)
-			return
-	..()
+
 
 /obj/structure/cult/pylon/proc/repair(mob/user as mob)
 	if(isbroken)

--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -49,9 +49,9 @@
 	attackpylon(M, 5)
 
 /obj/structure/cult/pylon/attack_animal(mob/living/simple_animal/user as mob)
-	if(istype(M, /mob/living/simple_animal/construct/builder))
+	if(istype(user, /mob/living/simple_animal/construct/builder))
 		if(isbroken && prob(20))
-			repair(M)
+			repair(user)
 			return
 	attackpylon(user, user.melee_damage_upper)
 

--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -31,8 +31,9 @@
 	processing_objects.Add(src)
 
 /obj/structure/cult/pylon/Destroy()
-	..()
 	processing_objects.Remove(src)
+	..()
+
 
 /obj/structure/cult/pylon/process()
 	if(!isbroken && world.time > last_check + 3 SECONDS)
@@ -50,9 +51,12 @@
 
 /obj/structure/cult/pylon/attack_animal(mob/living/simple_animal/user as mob)
 	if(istype(user, /mob/living/simple_animal/construct/builder))
-		if(isbroken && prob(20))
-			repair(user)
-			return
+		if(isbroken)
+			if(prob(20))
+				repair(user)
+				return
+			else
+				to_chat(user, "You fail to repair the pylon")
 	attackpylon(user, user.melee_damage_upper)
 
 /obj/structure/cult/pylon/attackby(obj/item/W as obj, mob/user as mob)

--- a/code/modules/spells/aoe_turf/conjure/construct.dm
+++ b/code/modules/spells/aoe_turf/conjure/construct.dm
@@ -103,7 +103,7 @@
 	desc = "This spell conjures a fragile crystal from Nar-Sie's realm. Makes for a convenient light source."
 
 	charge_max = 200
-	spell_flags = CONSTRUCT_CHECK
+	spell_flags = CONSTRUCT_CHECK|IGNORESPACE|IGNOREDENSE|NODUPLICATE
 	invocation = "none"
 	invocation_type = SpI_NONE
 	range = 0


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl: (as the emoji)
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
Further abuse of the tracker effects, this time with cult pylons by giving them some form of use.

Should a construct near one when it is damaged, the pylon will repair the construct, albeit slowly

Don't believe the wepon var was actually doing anything, so opted to delete it

There is so much shit in the cult construct stuff that's not even utilized it's unbelievable.

:cl:
* rscadd: Cult pylons now heal constructs within sight and vicinity