### PR TITLE
Fixes xenoarch guns goofing, again.

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -351,7 +351,7 @@
 	if(P.pai)
 		to_chat(P.pai, "<span class='info'><b>You have been connected to \a [src].</b></span>")
 		to_chat(P.pai, "<span class='info'>Your controls are:</span>")
-		to_chat(P.pai, "<span class='info'>- (Z) Use hotkey: Connect or disconnect from \the [src]'s firing mechanism.</span>")
+		to_chat(P.pai, "<span class='info'>- PageDown / Z(hotkey mode): Connect or disconnect from \the [src]'s firing mechanism.</span>")
 		to_chat(P.pai, "<span class='info'>- Click on a target: Fire \the [src] at the target.</span>")
 
 /obj/item/weapon/gun/attack_integrated_pai(mob/living/silicon/pai/user)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -347,6 +347,20 @@
 	else
 		return ..() //Pistolwhippin'
 
+/obj/item/weapon/gun/state_controls_pai(obj/item/device/paicard/P)
+	if(P.pai)
+		to_chat(P.pai, "<span class='info'><b>You have been connected to \a [src].</b></span>")
+		to_chat(P.pai, "<span class='info'>Your controls are:</span>")
+		to_chat(P.pai, "<span class='info'>- (Z) Use hotkey: Connect or disconnect from \the [src]'s firing mechanism.</span>")
+		to_chat(P.pai, "<span class='info'>- Click on a target: Fire \the [src] at the target.</span>")
+
+/obj/item/weapon/gun/attack_integrated_pai(mob/living/silicon/pai/user)
+	if(!pai_safety)
+		to_chat(user, "<span class='notice'>You connect to \the [src]'s firing mechanism.</span>")
+	else
+		to_chat(user, "<span class='notice'>You disconnect from \the [src]'s firing mechanism.</span>")
+	pai_safety = !pai_safety
+
 /obj/item/weapon/gun/on_integrated_pai_click(mob/living/silicon/pai/user, var/atom/A)	//to allow any gun to be pAI-compatible, on a basic level, just by varediting
 	if(check_pai_can_fire(user))
 		Fire(A,user,use_shooter_turf = TRUE)

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -372,20 +372,6 @@
 	can_take_pai = TRUE
 	origin_tech = Tc_COMBAT + "=3;" + Tc_MAGNETS + "=2;" + Tc_ENGINEERING + "=2;" + Tc_PROGRAMMING + "=4"
 
-/obj/item/weapon/gun/energy/laser/smart/state_controls_pai(obj/item/device/paicard/P)
-	if(P.pai)
-		to_chat(P.pai, "<span class='info'><b>You have been connected to \a [src].</b></span>")
-		to_chat(P.pai, "<span class='info'>Your controls are:</span>")
-		to_chat(P.pai, "<span class='info'>- (Z) Use hotkey: Connect or disconnect from \the [src]'s firing mechanism.</span>")
-		to_chat(P.pai, "<span class='info'>- Click on a target: Fire \the [src] at the target.</span>")
-
-/obj/item/weapon/gun/energy/laser/smart/attack_integrated_pai(mob/living/silicon/pai/user)
-	if(!pai_safety)
-		to_chat(user, "<span class='notice'>You connect to \the [src]'s firing mechanism.</span>")
-	else
-		to_chat(user, "<span class='notice'>You disconnect from \the [src]'s firing mechanism.</span>")
-	pai_safety = !pai_safety
-
 /obj/item/weapon/gun/energy/laser/rainbow
 
 	name = "rainbow laser"

--- a/code/modules/research/xenoarchaeology/finds/finds.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds.dm
@@ -375,10 +375,10 @@
 			/obj/item/weapon/gun/energy/laser,\
 			/obj/item/weapon/gun/energy/xray,\
 			/obj/item/weapon/gun/energy/laser/captain,\
-			/obj/item/weapon/gun/energy/temperature,\
+			/obj/item/weapon/gun/energy/ionrifle,\
 			/obj/item/weapon/gun/energy/plasma/pistol,\
 			/obj/item/weapon/gun/energy/floragun,\
-			/obj/item/weapon/gun/energy/bison,\
+			/obj/item/weapon/gun/energy/laser/rainbow,\
 			/obj/item/weapon/gun/energy/taser)
 			if(spawn_type)
 				var/obj/item/weapon/gun/energy/new_gun = new spawn_type(src.loc)

--- a/code/modules/research/xenoarchaeology/finds/finds.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds.dm
@@ -376,7 +376,7 @@
 			/obj/item/weapon/gun/energy/xray,\
 			/obj/item/weapon/gun/energy/laser/captain,\
 			/obj/item/weapon/gun/energy/temperature,\
-			/obj/item/weapon/gun/energy/plasma,\
+			/obj/item/weapon/gun/energy/plasma/pistol,\
 			/obj/item/weapon/gun/energy/floragun,\
 			/obj/item/weapon/gun/energy/bison,\
 			/obj/item/weapon/gun/energy/taser)
@@ -390,7 +390,7 @@
 				new_item.inhand_states = list("left_hand" = 'icons/mob/in-hand/left/xenoarch.dmi', "right_hand" = 'icons/mob/in-hand/right/xenoarch.dmi')
 				if(prob(10)) // 10% chance to be a smart gun
 					new_item.can_take_pai = TRUE
-					additional_desc += "There seems to be some sort of slot in the handle."
+					additional_desc += " There seems to be some sort of slot in the handle."
 				new_gun.charge_states = 0 //let's prevent it from losing that great icon if we charge it
 
 				//5% chance to explode when first fired
@@ -418,7 +418,7 @@
 			additional_desc = "Looks like an antique projectile weapon, you're not sure if it will fire or not."
 			if(prob(10)) // 10% chance to be a smart gun
 				new_item.can_take_pai = TRUE
-				additional_desc += "There seems to be some sort of slot in the handle."
+				additional_desc += " There seems to be some sort of slot in the handle."
 
 			//let's get some ammunition in this gun : weighted to pick available ammo
 			new_gun.caliber = pick(50;list("357" = 1),


### PR DESCRIPTION
![pewpew](https://cloud.githubusercontent.com/assets/17928298/24625774/73fb9f96-1886-11e7-9302-78a50002d895.png)

Fixes a space goof, unfucks plasma xenoguns using a dud projectile and moves smartgun's procs to gun level so any gun with can_take_pai get info about their shortcuts.


:cl:
 * spellcheck: Fixes an issue with smart xenoguns missing a space in their description.
 * bugfix: Unfucks plasma xenoguns projectiles.
 * tweak: Removes temperature gun and rison from the possible energy weapon list due icon fuckery, adds ion rifle and rainbow laser to the list in their place.
 * tweak: Moves smart laser gun's info procs to gun level, so any gun with can_take_pai now get info about their shortcuts.