### PR TITLE
Chem master 3000 upgrade buff: Bigger pills

### DIFF
--- a/code/modules/reagents/machinery/chem_master.dm
+++ b/code/modules/reagents/machinery/chem_master.dm
@@ -27,6 +27,7 @@ var/global/list/pillIcon2Name = list("oblong purple-pink", "oblong green-white",
 	var/chem_board = /obj/item/weapon/circuitboard/chemmaster3000
 	var/max_bottle_size = 30
 	var/max_pill_count = 20
+	var/max_pill_size = 50
 
 	light_color = LIGHT_COLOR_BLUE
 	light_range_on = 3
@@ -78,6 +79,8 @@ var/global/list/pillIcon2Name = list("oblong purple-pink", "oblong green-white",
 	max_bottle_size = initial(max_bottle_size) + lasercount*5
 	max_pill_count = initial(max_pill_count) + manipcount*5
 	handle_new_reservoir(scancount*25+100)
+	max_pill_size = initial(max_pill_size)+manipcount*25 // i suck at math
+
 
 /obj/machinery/chem_master/proc/handle_new_reservoir(var/newvol)
 	if(reagents.maximum_volume == newvol)
@@ -310,8 +313,8 @@ var/global/list/pillIcon2Name = list("oblong purple-pink", "oblong green-white",
 				return
 
 			var/amount_per_pill = reagents.total_volume/count
-			if(amount_per_pill > 50)
-				amount_per_pill = 50
+			if(amount_per_pill > max_pill_size)
+				amount_per_pill = max_pill_size
 			if(href_list["createempty"])
 				amount_per_pill = 0 //If "createempty" is 1, pills are empty and no reagents are used.
 
@@ -554,8 +557,8 @@ var/global/list/pillIcon2Name = list("oblong purple-pink", "oblong green-white",
 			//
 			// BUTTONS
 			//
-			dat += {"<HR><A href='?src=\ref[src];createpill=1'>Create single pill (50 units max)</A><BR>
-					<A href='?src=\ref[src];createpill_multiple=1'>Create multiple pills (50 units max each; [max_pill_count] max)</A><BR>
+			dat += {"<HR><A href='?src=\ref[src];createpill=1'>Create single pill ([max_pill_size] units max)</A><BR>
+					<A href='?src=\ref[src];createpill_multiple=1'>Create multiple pills ([max_pill_size] units max each; [max_pill_count] max)</A><BR>
 					<A href='?src=\ref[src];createpill_multiple=1;createempty=1'>Create empty pills</A><BR>
 					<A href='?src=\ref[src];createbottle=1'>Create bottle ([max_bottle_size] units max)</A><BR>
 					<A href='?src=\ref[src];createbottle_multiple=1'>Create multiple bottles ([max_bottle_size] units max each; 4 max)</A><BR>"}

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -8,7 +8,7 @@
 	icon_state = null
 	item_state = "pill"
 	possible_transfer_amounts = null
-	volume = 50
+	volume = 100
 	starting_materials = null
 //	starting_materials = list(MAT_IRON = 5) //What?
 	w_type = RECYK_METAL


### PR DESCRIPTION
Before when you upgraded the chem master 3000 it would allow for a bigger chemical reservoir for ease of use, allowing you to make more pills in one batch, and raised the chem bottle size up from 30u to 50u (same as small beakers and pills). To buff upgrades now if the chem master's manipulator is upgraded it will allow for larger pills. No longer is the pill limit 50 (provided there is a nano or pico manipulator installed). T1 (default micro manip) is 50u per pill, T2 (nano manip) is 75u per pill and a T3 part is 100u per pill. You may think powercreep BUT when was the last time you saw someone bother to upgrade the chem lab?