### PR TITLE
Drag damage check and effect changes

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1676,6 +1676,20 @@
 /mob/living/carbon/human/is_fat()
 	return (M_FAT in mutations) && (species && species.anatomy_flags & CAN_BE_FAT)
 
+mob/living/carbon/human/isincrit()
+	if (health - halloss <= config.health_threshold_softcrit)
+		return 1
+		
+/mob/living/carbon/human/drag_damage()
+	var/mob/living/carbon/human/H = src
+	var/turf/TH = H.loc	
+	var/list/return_organs = list()
+	if (TH.has_gravity() && H.lying)
+		for(var/datum/organ/external/damagedorgan in H.organs)
+			if(damagedorgan.status & ORGAN_BROKEN && !(damagedorgan.status & ORGAN_SPLINTED) || damagedorgan.status & ORGAN_BLEEDING)
+				return_organs += damagedorgan
+		return return_organs
+	
 /mob/living/carbon/human/feels_pain()
 	if(!species)
 		return FALSE

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -718,7 +718,7 @@ Thanks.
 										var/mob/living/carbon/H = M
 										var/blood_volume = round(H:vessel.get_reagent_amount("blood"))
 										if(blood_volume > 0)
-											H:vessel.remove_reagent("blood",2)
+											H:vessel.remove_reagent("blood",4)
 											M.visible_message("<span class='warning'>\The [M] loses some blood from being dragged!</span>")
 								
 							if(M.drag_damage() && (M.health - M.halloss <= config.health_threshold_softcrit)) //Crit damage boost
@@ -728,6 +728,7 @@ Thanks.
 											apply_damage(4, BRUTE, damagedorgan)
 											M.visible_message("<span class='warning'>The wounds on \The [M]'s [damagedorgan.display_name] worsen terribly from being dragged!</span>")
 											var/mob/living/carbon/human/updatetarget = M
+											add_logs(src, M, "caused drag damage to", admin = (M.ckey))
 											updatetarget.update_body()
 								if(prob(8))
 									if(isturf(M.loc))
@@ -736,9 +737,9 @@ Thanks.
 											var/mob/living/carbon/H = M
 											var/blood_volume = round(H:vessel.get_reagent_amount("blood"))
 											if(blood_volume > 0)
-												H:vessel.remove_reagent("blood",5)
+												H:vessel.remove_reagent("blood",8)
 												M.visible_message("<span class='danger'>\The [M] loses a lot of blood from being dragged!</span>")
-												add_logs(usr, M, "caused critical drag-damage-induced bloodloss to", admin = FALSE)
+												add_logs(src, M, "caused drag damage bloodloss to", admin = (M.ckey))
 					else
 						if (pulling)
 							pulling.Move(T, get_dir(pulling, T))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -705,14 +705,14 @@ Thanks.
 								M.start_pulling(secondarypull)
 							/* Drag damage is here!*/							
 							if(M.drag_damage() && !(M.health - M.halloss <= config.health_threshold_softcrit))
-								if(prob(M.getBruteLoss() / 4)) //Chance to damage
+								if(prob(M.getBruteLoss() / 5)) //Chance to damage
 									for(var/datum/organ/external/damagedorgan in M.drag_damage())
 										if((damagedorgan.brute_dam) < damagedorgan.max_damage)
-											apply_damage(1, BRUTE, damagedorgan)
-											M.visible_message("<span class='warning'>\The [damagedorgan.display_name] wounds on [M] worsen from being dragged!</span>")
+											apply_damage(2, BRUTE, damagedorgan)
+											M.visible_message("<span class='warning'>The wounds on \The [M]'s [damagedorgan.display_name] worsen from being dragged!</span>")
 											var/mob/living/carbon/human/updatetarget = M
 											updatetarget.update_body()
-								if(prob(M.getBruteLoss() / 6)) //Chance to bleed
+								if(prob(M.getBruteLoss() / 8)) //Chance to bleed
 									blood_splatter(M.loc,M)
 									if(ishuman(M))
 										var/mob/living/carbon/H = M
@@ -722,23 +722,23 @@ Thanks.
 											M.visible_message("<span class='warning'>\The [M] loses some blood from being dragged!</span>")
 								
 							if(M.drag_damage() && (M.health - M.halloss <= config.health_threshold_softcrit)) //Crit damage boost
-								if(prob(M.getBruteLoss() / 3))
+								if(prob(15))
 									for(var/datum/organ/external/damagedorgan in M.drag_damage())
 										if((damagedorgan.brute_dam) < damagedorgan.max_damage)
-											apply_damage(2, BRUTE, damagedorgan)
-											M.visible_message("<span class='warning'>\The [damagedorgan.display_name] wounds on [M] worsen terribly from being dragged!</span>")
+											apply_damage(4, BRUTE, damagedorgan)
+											M.visible_message("<span class='warning'>The wounds on \The [M]'s [damagedorgan.display_name] worsen terribly from being dragged!</span>")
 											var/mob/living/carbon/human/updatetarget = M
 											updatetarget.update_body()
-									if(prob(15))
-										if(isturf(M.loc))
-											blood_splatter(M.loc,M,1)
-											if(ishuman(M))
-												var/mob/living/carbon/H = M
-												var/blood_volume = round(H:vessel.get_reagent_amount("blood"))
-												if(blood_volume > 0)
-													H:vessel.remove_reagent("blood",5)
-													M.visible_message("<span class='danger'>\The [M] loses a lot of blood from being dragged!</span>")
-													add_logs(usr, M, "caused critical drag-damage-induced bloodloss to", admin = FALSE)
+								if(prob(8))
+									if(isturf(M.loc))
+										blood_splatter(M.loc,M,1)
+										if(ishuman(M))
+											var/mob/living/carbon/H = M
+											var/blood_volume = round(H:vessel.get_reagent_amount("blood"))
+											if(blood_volume > 0)
+												H:vessel.remove_reagent("blood",5)
+												M.visible_message("<span class='danger'>\The [M] loses a lot of blood from being dragged!</span>")
+												add_logs(usr, M, "caused critical drag-damage-induced bloodloss to", admin = FALSE)
 					else
 						if (pulling)
 							pulling.Move(T, get_dir(pulling, T))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -703,10 +703,8 @@ Thanks.
 							pulling.Move(T, get_dir(pulling, T))
 							if(M && secondarypull)
 								M.start_pulling(secondarypull)
-
 							//this is the gay blood on floor shit -- Added back --snx
-							var/turf/TM = M.loc
-							if (TM.has_gravity() && M.lying && (prob(M.getBruteLoss() / 3)))
+							if(M.pull_damage())
 								if(prob(6)) //Too much bloooooood
 									blood_splatter(M.loc,M)
 									if(ishuman(M))
@@ -716,10 +714,9 @@ Thanks.
 											H:vessel.remove_reagent("blood",2)
 											M.visible_message("<span class='warning'>\The [M] loses some blood from being dragged!</span>")
 								if(prob(50))
-									if(isturf(M.loc))
-										M.adjustBruteLoss(1)
-										M.visible_message("<span class='warning'>\The [M]'s wounds worsen from being dragged!</span>")
-							if(M.pull_damage())
+									M.adjustBruteLoss(1)
+									M.visible_message("<span class='warning'>\The [M]'s wounds worsen from being dragged!</span>")
+							if(M.pull_damage_crit())
 								if(prob(25))
 									M.adjustBruteLoss(2)
 									M.visible_message("<span class='danger'>\The [M]'s wounds worsen terribly from being dragged!</span>")
@@ -1528,7 +1525,7 @@ Thanks.
 	affect_silicon = 0 means that the flash won't affect silicons at all.
 
 */
-/mob/living/proc/flash_eyes(intensity = 1, override_blindness_check = 0, affect_silicon = 0, visual = 0, type = /obj/abstract/screen/fullscreen/flash)
+/mob/living/proc/flash_eyes(intensity = 1, override_blindness_check = 0, affect_silicon = 0, visual = 0, type = /obj/screen/fullscreen/flash)
 	if(override_blindness_check || !(disabilities & BLIND))
 		// flick("e_flash", flash)
 		overlay_fullscreen("flash", type)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -703,9 +703,16 @@ Thanks.
 							pulling.Move(T, get_dir(pulling, T))
 							if(M && secondarypull)
 								M.start_pulling(secondarypull)
-							//this is the gay blood on floor shit -- Added back --snx
-							if(M.pull_damage())
-								if(prob(4))
+							/* Drag damage is here!*/							
+							if(M.drag_damage() && !(M.health - M.halloss <= config.health_threshold_softcrit))
+								if(prob(M.getBruteLoss() / 4)) //Chance to damage
+									for(var/datum/organ/external/damagedorgan in M.drag_damage())
+										if((damagedorgan.brute_dam) < damagedorgan.max_damage)
+											apply_damage(1, BRUTE, damagedorgan)
+											M.visible_message("<span class='warning'>\The [damagedorgan.display_name] wounds on [M] worsen from being dragged!</span>")
+											var/mob/living/carbon/human/updatetarget = M
+											updatetarget.update_body()
+								if(prob(M.getBruteLoss() / 6)) //Chance to bleed
 									blood_splatter(M.loc,M)
 									if(ishuman(M))
 										var/mob/living/carbon/H = M
@@ -713,14 +720,16 @@ Thanks.
 										if(blood_volume > 0)
 											H:vessel.remove_reagent("blood",2)
 											M.visible_message("<span class='warning'>\The [M] loses some blood from being dragged!</span>")
-								if(prob(30))
-									M.adjustBruteLoss(1)
-									M.visible_message("<span class='warning'>\The [M]'s wounds worsen from being dragged!</span>")
-							if(M.pull_damage_crit())
-								if(prob(25))
-									M.adjustBruteLoss(2)
-									M.visible_message("<span class='danger'>\The [M]'s wounds worsen terribly from being dragged!</span>")
-									if(prob(25))
+								
+							if(M.drag_damage() && (M.health - M.halloss <= config.health_threshold_softcrit)) //Crit damage boost
+								if(prob(M.getBruteLoss() / 3))
+									for(var/datum/organ/external/damagedorgan in M.drag_damage())
+										if((damagedorgan.brute_dam) < damagedorgan.max_damage)
+											apply_damage(2, BRUTE, damagedorgan)
+											M.visible_message("<span class='warning'>\The [damagedorgan.display_name] wounds on [M] worsen terribly from being dragged!</span>")
+											var/mob/living/carbon/human/updatetarget = M
+											updatetarget.update_body()
+									if(prob(15))
 										if(isturf(M.loc))
 											blood_splatter(M.loc,M,1)
 											if(ishuman(M))
@@ -729,6 +738,7 @@ Thanks.
 												if(blood_volume > 0)
 													H:vessel.remove_reagent("blood",5)
 													M.visible_message("<span class='danger'>\The [M] loses a lot of blood from being dragged!</span>")
+													add_logs(usr, M, "caused critical drag-damage-induced bloodloss to", admin = FALSE)
 					else
 						if (pulling)
 							pulling.Move(T, get_dir(pulling, T))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -703,43 +703,38 @@ Thanks.
 							pulling.Move(T, get_dir(pulling, T))
 							if(M && secondarypull)
 								M.start_pulling(secondarypull)
-							/* Drag damage is here!*/							
-							if(M.drag_damage() && !(M.health - M.halloss <= config.health_threshold_softcrit))
-								if(prob(M.getBruteLoss() / 5)) //Chance to damage
-									for(var/datum/organ/external/damagedorgan in M.drag_damage())
+							/* Drag damage is here!*/	
+							var/mob/living/carbon/human/HM = M
+							if(HM.drag_damage() && !(HM.health - HM.halloss <= config.health_threshold_softcrit))
+								if(prob(HM.getBruteLoss() / 5)) //Chance to damage
+									for(var/datum/organ/external/damagedorgan in HM.drag_damage())
 										if((damagedorgan.brute_dam) < damagedorgan.max_damage)
 											apply_damage(2, BRUTE, damagedorgan)
-											M.visible_message("<span class='warning'>The wounds on \The [M]'s [damagedorgan.display_name] worsen from being dragged!</span>")
-											var/mob/living/carbon/human/updatetarget = M
-											updatetarget.update_body()
-								if(prob(M.getBruteLoss() / 8)) //Chance to bleed
-									blood_splatter(M.loc,M)
-									if(ishuman(M))
-										var/mob/living/carbon/H = M
-										var/blood_volume = round(H:vessel.get_reagent_amount("blood"))
-										if(blood_volume > 0)
-											H:vessel.remove_reagent("blood",4)
-											M.visible_message("<span class='warning'>\The [M] loses some blood from being dragged!</span>")
+											HM.visible_message("<span class='warning'>The wounds on \The [HM]'s [damagedorgan.display_name] worsen from being dragged!</span>")
+											HM.update_body()
+								if(prob(HM.getBruteLoss() / 8)) //Chance to bleed
+									blood_splatter(HM.loc,HM)
+									var/blood_volume = round(HM:vessel.get_reagent_amount("blood"))
+									if(blood_volume > 0)
+										HM:vessel.remove_reagent("blood",4)
+										HM.visible_message("<span class='warning'>\The [HM] loses some blood from being dragged!</span>")
 								
-							if(M.drag_damage() && (M.health - M.halloss <= config.health_threshold_softcrit)) //Crit damage boost
+							if(HM.drag_damage() && (HM.health - HM.halloss <= config.health_threshold_softcrit)) //Crit damage boost
 								if(prob(15))
-									for(var/datum/organ/external/damagedorgan in M.drag_damage())
+									for(var/datum/organ/external/damagedorgan in HM.drag_damage())
 										if((damagedorgan.brute_dam) < damagedorgan.max_damage)
 											apply_damage(4, BRUTE, damagedorgan)
-											M.visible_message("<span class='warning'>The wounds on \The [M]'s [damagedorgan.display_name] worsen terribly from being dragged!</span>")
-											var/mob/living/carbon/human/updatetarget = M
-											add_logs(src, M, "caused drag damage to", admin = (M.ckey))
-											updatetarget.update_body()
+											HM.visible_message("<span class='warning'>The wounds on \The [HM]'s [damagedorgan.display_name] worsen terribly from being dragged!</span>")
+											add_logs(src, HM, "caused drag damage to", admin = (M.ckey))
+											HM.update_body()
 								if(prob(8))
-									if(isturf(M.loc))
-										blood_splatter(M.loc,M,1)
-										if(ishuman(M))
-											var/mob/living/carbon/H = M
-											var/blood_volume = round(H:vessel.get_reagent_amount("blood"))
-											if(blood_volume > 0)
-												H:vessel.remove_reagent("blood",8)
-												M.visible_message("<span class='danger'>\The [M] loses a lot of blood from being dragged!</span>")
-												add_logs(src, M, "caused drag damage bloodloss to", admin = (M.ckey))
+									if(isturf(HM.loc))
+										blood_splatter(HM.loc,HM,1)
+										var/blood_volume = round(HM:vessel.get_reagent_amount("blood"))
+										if(blood_volume > 0)
+											HM:vessel.remove_reagent("blood",8)
+											HM.visible_message("<span class='danger'>\The [HM] loses a lot of blood from being dragged!</span>")
+											add_logs(src, HM, "caused drag damage bloodloss to", admin = (HM.ckey))
 					else
 						if (pulling)
 							pulling.Move(T, get_dir(pulling, T))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -705,13 +705,13 @@ Thanks.
 								M.start_pulling(secondarypull)
 							/* Drag damage is here!*/	
 							var/mob/living/carbon/human/HM = M
-							if(HM.drag_damage() && !(HM.health - HM.halloss <= config.health_threshold_softcrit))
+							if(HM.drag_damage() && !HM.isincrit())
 								if(prob(HM.getBruteLoss() / 5)) //Chance to damage
 									for(var/datum/organ/external/damagedorgan in HM.drag_damage())
 										if((damagedorgan.brute_dam) < damagedorgan.max_damage)
 											apply_damage(2, BRUTE, damagedorgan)
-											HM.visible_message("<span class='warning'>The wounds on \The [HM]'s [damagedorgan.display_name] worsen from being dragged!</span>")
-											HM.update_body()
+											HM.visible_message("<span class='warning'>The wounds on \the [HM]'s [damagedorgan.display_name] worsen from being dragged!</span>")
+											HM.UpdateDamageIcon()
 								if(prob(HM.getBruteLoss() / 8)) //Chance to bleed
 									blood_splatter(HM.loc,HM)
 									var/blood_volume = round(HM:vessel.get_reagent_amount("blood"))
@@ -719,14 +719,14 @@ Thanks.
 										HM:vessel.remove_reagent("blood",4)
 										HM.visible_message("<span class='warning'>\The [HM] loses some blood from being dragged!</span>")
 								
-							if(HM.drag_damage() && (HM.health - HM.halloss <= config.health_threshold_softcrit)) //Crit damage boost
+							if(HM.drag_damage() && HM.isincrit()) //Crit damage boost
 								if(prob(15))
 									for(var/datum/organ/external/damagedorgan in HM.drag_damage())
 										if((damagedorgan.brute_dam) < damagedorgan.max_damage)
 											apply_damage(4, BRUTE, damagedorgan)
-											HM.visible_message("<span class='warning'>The wounds on \The [HM]'s [damagedorgan.display_name] worsen terribly from being dragged!</span>")
+											HM.visible_message("<span class='warning'>The wounds on \the [HM]'s [damagedorgan.display_name] worsen terribly from being dragged!</span>")
 											add_logs(src, HM, "caused drag damage to", admin = (M.ckey))
-											HM.update_body()
+											HM.UpdateDamageIcon()
 								if(prob(8))
 									if(isturf(HM.loc))
 										blood_splatter(HM.loc,HM,1)
@@ -1531,7 +1531,7 @@ Thanks.
 	affect_silicon = 0 means that the flash won't affect silicons at all.
 
 */
-/mob/living/proc/flash_eyes(intensity = 1, override_blindness_check = 0, affect_silicon = 0, visual = 0, type = /obj/screen/fullscreen/flash)
+/mob/living/proc/flash_eyes(intensity = 1, override_blindness_check = 0, affect_silicon = 0, visual = 0, type = /obj/abstract/screen/fullscreen/flash)
 	if(override_blindness_check || !(disabilities & BLIND))
 		// flick("e_flash", flash)
 		overlay_fullscreen("flash", type)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -705,7 +705,7 @@ Thanks.
 								M.start_pulling(secondarypull)
 							//this is the gay blood on floor shit -- Added back --snx
 							if(M.pull_damage())
-								if(prob(6)) //Too much bloooooood
+								if(prob(4))
 									blood_splatter(M.loc,M)
 									if(ishuman(M))
 										var/mob/living/carbon/H = M
@@ -713,7 +713,7 @@ Thanks.
 										if(blood_volume > 0)
 											H:vessel.remove_reagent("blood",2)
 											M.visible_message("<span class='warning'>\The [M] loses some blood from being dragged!</span>")
-								if(prob(50))
+								if(prob(30))
 									M.adjustBruteLoss(1)
 									M.visible_message("<span class='warning'>\The [M]'s wounds worsen from being dragged!</span>")
 							if(M.pull_damage_crit())

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -953,13 +953,14 @@ var/list/slot_equipment_priority = list( \
 
 	if (ismob(AM))
 		var/mob/M = AM
-		if (M.drag_damage()) 
-			var/mob/living/carbon/HM = M
-			if (HM.health - HM.halloss <= config.health_threshold_softcrit)
-				to_chat(usr,"<span class='warning'>Pulling \the [HM] in their current condition would probably be a bad idea.</span>")
-				add_logs(src, HM, "started dragging critically wounded", admin = (M.ckey))
 		if (M.locked_to) //If the mob is locked_to on something, let's just try to pull the thing they're locked_to to for convenience's sake.
 			P = M.locked_to
+		var/mob/living/carbon/human/HM = AM
+		if (HM.drag_damage()) 
+			if (HM.health - HM.halloss <= config.health_threshold_softcrit)
+				to_chat(usr,"<span class='warning'>Pulling \the [HM] in their current condition would probably be a bad idea.</span>")
+				add_logs(src, HM, "started dragging critically wounded", admin = (HM.ckey))
+		
 
 	if (!P.anchored)
 		P.add_fingerprint(src)
@@ -1303,15 +1304,17 @@ var/list/slot_equipment_priority = list( \
 	//		C.JoinResponseTeam()
 
 /mob/proc/drag_damage()
-	if(ishuman(src))
-		var/mob/living/carbon/human/H = src
-		var/turf/TH = H.loc	
-		var/list/return_organs = list()
-		if (TH.has_gravity() && H.lying)
-			for(var/datum/organ/external/damagedorgan in H.organs)
-				if(damagedorgan.status & ORGAN_BROKEN && !(damagedorgan.status & ORGAN_SPLINTED) || damagedorgan.status & ORGAN_BLEEDING)
-					return_organs += damagedorgan
-			return return_organs
+	return list()
+	
+/mob/living/carbon/human/drag_damage()
+	var/mob/living/carbon/human/H = src
+	var/turf/TH = H.loc	
+	var/list/return_organs = list()
+	if (TH.has_gravity() && H.lying)
+		for(var/datum/organ/external/damagedorgan in H.organs)
+			if(damagedorgan.status & ORGAN_BROKEN && !(damagedorgan.status & ORGAN_SPLINTED) || damagedorgan.status & ORGAN_BLEEDING)
+				return_organs += damagedorgan
+		return return_organs
 
 /mob/MouseDrop(mob/M as mob)
 	..()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -953,7 +953,7 @@ var/list/slot_equipment_priority = list( \
 
 	if (ismob(AM))
 		var/mob/M = AM
-		if(M.pull_damage()) //Pulling someone who's messed up will mess them up a lot further, inform the user.
+		if(M.pull_damage_crit()) //Pulling someone who's messed up will mess them up a lot further, inform the user.
 			to_chat(usr,"<span class='warning'>Pulling \the [M] in their current condition would probably be a bad idea.</span>")
 		if (M.locked_to) //If the mob is locked_to on something, let's just try to pull the thing they're locked_to to for convenience's sake.
 			P = M.locked_to
@@ -1300,6 +1300,19 @@ var/list/slot_equipment_priority = list( \
 	//		C.JoinResponseTeam()
 
 /mob/proc/pull_damage()
+	if(ishuman(src))
+		var/mob/living/carbon/human/H = src
+		var/turf/TH = H.loc	
+		if (TH.has_gravity())
+			for(var/name in H.organs_by_name)
+				var/datum/organ/external/e = H.organs_by_name[name]
+				if(H.lying)
+					if(((e.status & ORGAN_BROKEN && !(e.status & ORGAN_SPLINTED)) || e.status & ORGAN_BLEEDING))
+						return 1
+						break
+		return 0
+	
+/mob/proc/pull_damage_crit() //More damage!
 	if(ishuman(src))
 		var/mob/living/carbon/human/H = src
 		var/turf/TH = H.loc	

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -957,7 +957,7 @@ var/list/slot_equipment_priority = list( \
 			var/mob/living/carbon/HM = M
 			if (HM.health - HM.halloss <= config.health_threshold_softcrit)
 				to_chat(usr,"<span class='warning'>Pulling \the [HM] in their current condition would probably be a bad idea.</span>")
-				add_logs(usr, HM, "started dragging critically wounded", admin = FALSE)
+				add_logs(src, HM, "started dragging critically wounded", admin = (M.ckey))
 		if (M.locked_to) //If the mob is locked_to on something, let's just try to pull the thing they're locked_to to for convenience's sake.
 			P = M.locked_to
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -955,11 +955,12 @@ var/list/slot_equipment_priority = list( \
 		var/mob/M = AM
 		if (M.locked_to) //If the mob is locked_to on something, let's just try to pull the thing they're locked_to to for convenience's sake.
 			P = M.locked_to
-		var/mob/living/carbon/human/HM = AM
-		if (HM.drag_damage()) 
-			if (HM.health - HM.halloss <= config.health_threshold_softcrit)
-				to_chat(usr,"<span class='warning'>Pulling \the [HM] in their current condition would probably be a bad idea.</span>")
-				add_logs(src, HM, "started dragging critically wounded", admin = (HM.ckey))
+		if(ishuman(AM))
+			var/mob/living/carbon/human/HM = AM
+			if (HM.drag_damage()) 
+				if (HM.isincrit())
+					to_chat(usr,"<span class='warning'>Pulling \the [HM] in their current condition would probably be a bad idea.</span>")
+					add_logs(src, HM, "started dragging critically wounded", admin = (HM.ckey))
 		
 
 	if (!P.anchored)
@@ -1302,19 +1303,6 @@ var/list/slot_equipment_priority = list( \
 	//	if(usr.client)
 	//		var/client/C = usr.client
 	//		C.JoinResponseTeam()
-
-/mob/proc/drag_damage()
-	return list()
-	
-/mob/living/carbon/human/drag_damage()
-	var/mob/living/carbon/human/H = src
-	var/turf/TH = H.loc	
-	var/list/return_organs = list()
-	if (TH.has_gravity() && H.lying)
-		for(var/datum/organ/external/damagedorgan in H.organs)
-			if(damagedorgan.status & ORGAN_BROKEN && !(damagedorgan.status & ORGAN_SPLINTED) || damagedorgan.status & ORGAN_BLEEDING)
-				return_organs += damagedorgan
-		return return_organs
 
 /mob/MouseDrop(mob/M as mob)
 	..()

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -26,6 +26,12 @@
 /mob/proc/is_fat()
 	return 0
 
+mob/proc/isincrit()
+	return 0
+	
+/mob/proc/drag_damage()
+	return list()
+	
 /mob/dead/observer/get_screen_colour()
 	return default_colour_matrix
 


### PR DESCRIPTION
Damage now applies only to bodyparts that are either broken (and unsplinted) or bleeding. 
The damage will continue till the bodypart reaches it's max allotted damage. 
Damage / bleed chances have been modified a bit.
Also added some logging.
And I renamed the actual proc drag_damage.

Tested on catbeasts, seems to work as it should.

:cl:
 - tweak: Drag damage tweaks: Applies only to unsplinted or bleeding bodyparts until that bodypart reaches max damage. Chances reduced.