### PR TITLE
Ore smelter upgrade buff

### DIFF
--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -19,6 +19,7 @@
 
 	var/obj/item/weapon/card/id/id //Ref to the inserted ID card (for claiming points via the smelter).
 
+
 /obj/machinery/computer/smelting/New()
 	. = ..()
 
@@ -292,6 +293,8 @@
 
 	var/credits = 0 //Amount of money, set to -1 to disable the $ amount showing in the menu (recycling, for example)
 
+	var/ore_multiplier = 1// the multiplier for ore upgrades
+
 /obj/machinery/mineral/processing_unit/Destroy()
 	. = ..()
 
@@ -322,10 +325,12 @@
 
 	i = 0
 	for(var/obj/item/weapon/stock_parts/micro_laser/A in component_parts)
-		i += A.rating - 1
+		i += A.rating / 2
 
 	idle_power_usage = initial(idle_power_usage) - (i * (initial(idle_power_usage) / 4))
 	active_power_usage = initial(active_power_usage) - (i * (initial(active_power_usage) / 4))
+
+	ore_multiplier = initial(ore_multiplier) * i
 
 /obj/machinery/mineral/processing_unit/New()
 	. = ..()
@@ -408,13 +413,13 @@
 		if(!O.material)
 			continue
 
-		ore.addAmount(O.material, 1)//1 per ore
+		ore.addAmount(O.material, ore_multiplier)
 
 		var/datum/material/mat = ore.getMaterial(O.material)
 		if(!mat)
 			continue
 
-		credits += mat.value //Dosh.
+		credits += mat.value * ore_multiplier //Dosh.
 
 		qdel(O)
 


### PR DESCRIPTION
Currently upgrading the ore processor just makes it process ore faster removing a grand total of 5 seconds from a 10 second process. This is of course retarded and not even considerable to be upgraded. So what this PR does is it makes the micro lasers in the ore smelter if upgraded cause it to increase the ore produced. T1 micro lasers  just has it function normally. T2 high powered micro lasers makes 1 piece of ore worth 2 sheets of metal and T3 ultra high powered micro lasers makes it make 3 sheets per 1 ore.  So if i upgraded the Ore processor to T3 and fed it 2 pieces of sand it would in turn make 6 sheets of glass. I have also accounted for the extra cash meaning 1 piece of iron being turned into 2 sheets of metal gives the miner 2$ instead of 1$. This upgrade does not work on the recycler furnace. Just the ore processor. 