### PR TITLE
Dispenser messages are more clear for silicons

### DIFF
--- a/code/modules/reagents/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/machinery/chem_dispenser.dm
@@ -275,6 +275,7 @@ USE THIS CHEMISTRY DISPENSER FOR MAPS SO THEY START AT 100 ENERGY
 
 	if(isrobot(user))
 		if(!can_use(user))
+			to_chat(user, "Your programming forbids interaction with this device.")
 			return
 
 	if(istype(D, /obj/item/weapon/reagent_containers/glass) || istype(D, /obj/item/weapon/reagent_containers/food/drinks))


### PR DESCRIPTION
A message is now provided when a Cyborg or MoMMI tries to interact with a chem dispenser that they're not allowed to. This should help avoid confusion on why they can't place items in it, as opposed to just nothing happening.