### PR TITLE
Update to the ore processing console UI

### DIFF
--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -15,8 +15,6 @@
 
 	var/list/smelter_data //All the data we have about the smelter, since it uses radio connection based RC.
 
-	var/show_all_ores = 0 //Should we show all ores? (even ones we don't have).
-
 	var/obj/item/weapon/card/id/id //Ref to the inserted ID card (for claiming points via the smelter).
 
 /obj/machinery/computer/smelting/New()
@@ -69,17 +67,15 @@
 	user.set_machine(src)
 
 	var/dat = {"
+	<div style="overflow:hidden;">
+	<div style="float:left;" class="block">
 	<table>
 		<tr>
 			<th>Mineral</th>
 			<th>Amount</th>
-			<th colspan="2">Controls</th>
 		</tr>"}
 
 	for(var/ore_id in smelter_data["ore"])
-		if(!smelter_data["ore"][ore_id]["amount"] && !show_all_ores)
-			continue
-
 		dat += {"
 		<tr>
 			<td>[smelter_data["ore"][ore_id]["name"]]</td>
@@ -87,12 +83,11 @@
 		</tr>
 		"}
 
-	dat += "</table><br>"
-
-	dat += "Currently displaying [show_all_ores ? "all ore types" : "only available ore types"]. <A href='?src=\ref[src];toggle_ores=1'>\[[show_all_ores ? "show less" : "show more"]\]</a><hr>"
+	dat += "</table></div>"
 
 	dat += {"
-	<b>Available recipes:</b><br>
+	<div style="float:left;" class="block">
+	<b>Available recipes: </b><br>
 	<table>
 		<tr>
 			<th>Output</th>
@@ -124,7 +119,8 @@
 		"}
 
 	dat += {"
-	</table><hr>
+	</table></div>
+	<div style="float:left" class="block">
 	The ore processor is currently <A href='?src=\ref[src];toggle_power=1' class='[smelter_data["on"] ? "linkOn" : "linkDanger"]'>[smelter_data["on"] ? "processing" : "disabled"]</a>
 	"}
 
@@ -135,13 +131,13 @@
 			dat += "You have [id.GetBalance(format = 1)] credits in your bank account. <A href='?src=\ref[src];eject=1'>Eject ID.</A><br>"
 			dat += "<A href='?src=\ref[src];claim=1'>Claim points.</A><br>"
 		else
-			dat += text("No ID inserted.  <A href='?src=\ref[src];insert=1'>Insert ID.</A><br>")
+			dat += text("No ID inserted. <A href='?src=\ref[src];insert=1'>Insert ID.</A><br>")
 
 	else if(id)	//I don't care but the ID got in there in some way, allow them to eject it atleast.
-		dat += "<br><A href='?src=\ref[src];eject=1'>Eject ID.</A>"
+		dat += "<br><A href='?src=\ref[src];eject=1'>Eject ID.</A></div></div>"
 
 
-	var/datum/browser/popup = new(user, "console_processing_unit", name, 400, 500, src)
+	var/datum/browser/popup = new(user, "console_processing_unit", name, 800, 500, src)
 	popup.set_content(dat)
 	popup.open()
 
@@ -160,10 +156,6 @@
 	if(href_list["toggle_power"])
 		send_signal(list("toggle_power" = 1))
 		request_status()
-		return 1
-
-	if(href_list["toggle_ores"])
-		show_all_ores = !show_all_ores
 		return 1
 
 	if(href_list["eject"])


### PR DESCRIPTION
Before:
![image](https://cloud.githubusercontent.com/assets/6307265/24763573/11973cd4-1af2-11e7-9c0a-97388e36bdb8.png)

Now:
![image](https://cloud.githubusercontent.com/assets/6307265/24763616/29aa4578-1af2-11e7-8bc8-b4ab4d757a2f.png)

Previously you had to either make the window as tall as your screen or scroll down, which sucked because the window updates every second, and it doesn't use nano so it would reset your scrolling.

Also, see all that empty space under the third column? Should I get rid of the ore stacking console and integrate it into this?

:cl:
 - tweak: Changed the mining ore processor UI.