### PR TITLE
attack animation runtimes fix

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -848,6 +848,9 @@
 /atom/movable/proc/do_attack_animation(atom/target, atom/tool)
 	set waitfor = 0
 
+	if(!tool)
+		tool = src
+
 	if(target == src)
 		return
 	var/horizontal = 0

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -848,8 +848,7 @@
 /atom/movable/proc/do_attack_animation(atom/target, atom/tool)
 	set waitfor = 0
 
-	if(!tool)
-		tool = src
+	ASSERT(tool) //If no tool, shut down the proc and call the coder police
 
 	if(target == src)
 		return

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -476,7 +476,7 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 	else
 		user.delayNextAttack(8)
 		if(O.force)
-			user.do_attack_animation(src)
+			user.do_attack_animation(src, O)
 			var/damage = O.force
 			if (O.damtype == HALLOSS)
 				damage = 0

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -655,7 +655,7 @@
 /obj/machinery/power/apc/attack_alien(mob/living/carbon/alien/humanoid/user)
 	if(!user)
 		return
-	user.do_attack_animation(src)
+	user.do_attack_animation(src, user)
 	user.delayNextAttack(8)
 	user.visible_message("<span class='warning'>[user.name] slashes at the [src.name]!</span>", "<span class='notice'>You slash at the [src.name]!</span>")
 	playsound(get_turf(src), 'sound/weapons/slash.ogg', 100, 1)


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl: (as the emoji)
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
do_attack_animation against simple animals was not passing a tool, causing a runtime. Rectified.

do_attack_animation as a xeno against an APC was not passing a tool, causing a runtime. Rectified.

General handling for if do_attack_animation is not passed a tool where it assumes that the thing calling do_attack_animation is the tool itself, making it default to a fist.