### PR TITLE
Makes riot helmets slightly more facehug proof.

### DIFF
--- a/code/modules/clothing/head/tactical.dm
+++ b/code/modules/clothing/head/tactical.dm
@@ -100,6 +100,7 @@ obj/item/clothing/head/helmet/tactical/attack_self(mob/user)
 	flags = FPRINT
 	armor = list(melee = 82, bullet = 15, laser = 5,energy = 5, bomb = 5, bio = 2, rad = 0)
 	siemens_coefficient = 0.7
+	body_parts_covered = HEAD|MOUTH
 	eyeprot = 1
 
 /obj/item/clothing/head/helmet/tactical/swat


### PR DESCRIPTION
It gives them the `MOUTH` as a covered body part, but because facehuggers are awful that still only makes it a 50% chance for the facehugger to not fuck you up.

Better than nothing I guess.

Fixes #14494
:cl:
* tweak: Riot helmets can now block facehuggers (but it's no guarantee like every helmet type)