### PR TITLE
Fixes nymphs not updating icons

### DIFF
--- a/code/modules/mob/living/carbon/monkey/update_icons.dm
+++ b/code/modules/mob/living/carbon/monkey/update_icons.dm
@@ -18,7 +18,7 @@
 
 /mob/living/carbon/monkey/regenerate_icons()
 	..()
-	var/icon/opacity_icon = new(icon, icon_state)
+	var/icon/opacity_icon = new(icon)
 	if(body_alphas.len)
 		opacity_icon.ChangeOpacity(ARBITRARILY_LARGE_NUMBER)
 		var/lowest_alpha = get_lowest_body_alpha()


### PR DESCRIPTION
They can't change their icon_state if there's only the default icon_state in their icon var. Thanks @gbasood for helping me out with this