### PR TITLE
Allows pest spray to be used on roaches

### DIFF
--- a/code/modules/hydroponics/hydro_tools.dm
+++ b/code/modules/hydroponics/hydro_tools.dm
@@ -281,6 +281,16 @@
 	icon_state = "pestspray"
 	pest_kill_str = 6
 
+/obj/item/weapon/plantspray/pests/proc/use(amount = 1)
+	if(pest_kill_str >= amount)
+		pest_kill_str -= amount
+
+		if(pest_kill_str == 0)
+			name = "empty [src]"
+
+		return TRUE
+	return FALSE
+
 /obj/item/weapon/plantspray/pests/old
 	name = "bottle of pestkiller"
 	icon = 'icons/obj/chemical.dmi'

--- a/code/modules/mob/living/simple_animal/roach.dm
+++ b/code/modules/mob/living/simple_animal/roach.dm
@@ -153,8 +153,8 @@
 		var/check_dir = get_dir(src, dest)
 
 		//Climb on it!
-		var/new_px = rand(-8,8) * PIXEL_MULTIPLIER + cos(dir2angle(check_dir)) * WORLD_ICON_SIZE
-		var/new_py = rand(-8,8) * PIXEL_MULTIPLIER + sin(dir2angle(check_dir)) * WORLD_ICON_SIZE
+		var/new_px = rand(-8,8) * PIXEL_MULTIPLIER + cos(dir2angle(check_dir)) * WORLD_ICON_SIZE * 0.5
+		var/new_py = rand(-8,8) * PIXEL_MULTIPLIER + sin(dir2angle(check_dir)) * WORLD_ICON_SIZE * 0.5
 
 		//Modify pixel_x and pixel_y to make it look like the cockroach is on the wall
 		animate(src, pixel_x = new_px, rand(5,15), 1, ELASTIC_EASING)
@@ -254,6 +254,12 @@
 		W.desc = "[initial(W.desc)] <span class='notice'>There is a splattered [src] on the back.</span>"
 
 		adjustBruteLoss(5)
+	else if(istype(W, /obj/item/weapon/plantspray/pests))
+		var/obj/item/weapon/plantspray/pests/P = W
+		if(P.use(1))
+			to_chat(user, "You spray \the [src] with \the [P].")
+			playsound(loc, 'sound/effects/spray3.ogg', 50, 1, -6)
+			Die(gore = 0)
 	else
 		return ..()
 


### PR DESCRIPTION
Adds an easier way to get roach meat. The pest spray has 6 uses and becomes less effective for botany on each use.

Also makes roach pixel_x/y offsets slightly less crazy (fixes a visual *bug* where they may appear completely behind a wall that they're climbing on)

:cl:
 * rscadd: Pest spray may now be used on cockroaches to kill them without leaving a big mess.
