### PR TITLE
Nerfs hive defenders

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hive_aliens.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hive_aliens.dm
@@ -296,6 +296,7 @@
 	aggro_vision_range = initial(aggro_vision_range)
 	idle_vision_range = initial(aggro_vision_range)
 	vision_range = initial(aggro_vision_range)
+	brute_damage_modifier = initial(brute_damage_modifier)
 
 	//Immediately find a target so that we're not useless for 1 Life() tick!
 	FindTarget()
@@ -313,6 +314,7 @@
 	aggro_vision_range = 1
 	idle_vision_range = 1
 	vision_range = 1
+	brute_damage_modifier = 2 * initial(brute_damage_modifier)
 
 	walk(src, 0)
 

--- a/code/modules/mob/living/simple_animal/hostile/hive_aliens.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hive_aliens.dm
@@ -314,7 +314,7 @@
 	aggro_vision_range = 1
 	idle_vision_range = 1
 	vision_range = 1
-	brute_damage_modifier = 2 * initial(brute_damage_modifier)
+	brute_damage_modifier = 3 * initial(brute_damage_modifier)
 
 	walk(src, 0)
 


### PR DESCRIPTION
They now take 3x brute damage when in attack mode, effectively giving them 94 health vs melee attacks and ballistic weapons

:cl:
 * tweak: Hive defenders now take 3x brute damage when in attack mode (other types of damage unaffected)