### PR TITLE
Fixes empathy drag damage

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -710,7 +710,7 @@ Thanks.
 								if(prob(HM.getBruteLoss() / 5)) //Chance to damage
 									for(var/datum/organ/external/damagedorgan in HM.drag_damage())
 										if((damagedorgan.brute_dam) < damagedorgan.max_damage)
-											apply_damage(2, BRUTE, damagedorgan)
+											HM.apply_damage(2, BRUTE, damagedorgan)
 											HM.visible_message("<span class='warning'>The wounds on \the [HM]'s [damagedorgan.display_name] worsen from being dragged!</span>")
 											HM.UpdateDamageIcon()
 								if(prob(HM.getBruteLoss() / 8)) //Chance to bleed
@@ -724,7 +724,7 @@ Thanks.
 								if(prob(15))
 									for(var/datum/organ/external/damagedorgan in HM.drag_damage())
 										if((damagedorgan.brute_dam) < damagedorgan.max_damage)
-											apply_damage(4, BRUTE, damagedorgan)
+											HM.apply_damage(4, BRUTE, damagedorgan)
 											HM.visible_message("<span class='warning'>The wounds on \the [HM]'s [damagedorgan.display_name] worsen terribly from being dragged!</span>")
 											add_logs(src, HM, "caused drag damage to", admin = (M.ckey))
 											HM.UpdateDamageIcon()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -954,14 +954,7 @@ var/list/slot_equipment_priority = list( \
 	if (ismob(AM))
 		var/mob/M = AM
 		if (M.locked_to) //If the mob is locked_to on something, let's just try to pull the thing they're locked_to to for convenience's sake.
-			P = M.locked_to
-		if(ishuman(AM))
-			var/mob/living/carbon/human/HM = AM
-			if (HM.drag_damage()) 
-				if (HM.isincrit())
-					to_chat(usr,"<span class='warning'>Pulling \the [HM] in their current condition would probably be a bad idea.</span>")
-					add_logs(src, HM, "started dragging critically wounded", admin = (HM.ckey))
-		
+			P = M.locked_to		
 
 	if (!P.anchored)
 		P.add_fingerprint(src)
@@ -983,6 +976,12 @@ var/list/slot_equipment_priority = list( \
 				M.LAssailant = null
 			else
 				M.LAssailant = usr
+				if(ishuman(AM))
+					var/mob/living/carbon/human/HM = AM
+					if (HM.drag_damage()) 
+						if (HM.isincrit())
+							to_chat(usr,"<span class='warning'>Pulling \the [HM] in their current condition would probably be a bad idea.</span>")
+							add_logs(src, HM, "started dragging critically wounded", admin = (HM.ckey))
 
 /mob/verb/stop_pulling()
 	set name = "Stop Pulling"

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -976,12 +976,13 @@ var/list/slot_equipment_priority = list( \
 				M.LAssailant = null
 			else
 				M.LAssailant = usr
-				if(ishuman(AM))
+				/*if(ishuman(AM))
 					var/mob/living/carbon/human/HM = AM
 					if (HM.drag_damage()) 
 						if (HM.isincrit())
 							to_chat(usr,"<span class='warning'>Pulling \the [HM] in their current condition would probably be a bad idea.</span>")
-							add_logs(src, HM, "started dragging critically wounded", admin = (HM.ckey))
+							add_logs(src, HM, "started dragging critically wounded", admin = (HM.ckey))*/
+// Commented out till I can figure out how to fix people still pulling when they're pulled --snx
 
 /mob/verb/stop_pulling()
 	set name = "Stop Pulling"


### PR DESCRIPTION
Apparently had to indicate who should take damage

Also comments out the crit message because it fires every fucking step if you pull someone who is pulling away because shitcode, see also #14671

resolves #14669

tested, seems to fix the issues

:cl:
 - bugfix: You longer take damage when dragging someone who is injured.