### PR TITLE
Changes the recipe for Mead to use Honey instead of Sugar

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -2504,7 +2504,7 @@
 	name = "Mead"
 	id = MEAD
 	result = MEAD
-	required_reagents = list(SUGAR = 1, WATER = 1)
+	required_reagents = list(HONEY = 1, WATER = 1)
 	required_catalysts = list(ENZYME = 5)
 	result_amount = 2
 


### PR DESCRIPTION
Mead is impossible to make due to the Sprinkles recipe taking priority, and we actually have honey now!

Will update the wiki if merged!

:cl:
 * tweak: The recipe for Mead now uses Honey instead of Sugar.