### PR TITLE
Robotics console hacking

### DIFF
--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -144,6 +144,7 @@
 	name = "Circuit board (Robotics Control)"
 	desc = "A circuit board for running a computer used for monitoring and locking or destroying cyborgs."
 	build_path = "/obj/machinery/computer/robotics"
+	var/access_hacked = 0
 	origin_tech = Tc_PROGRAMMING + "=3"
 /obj/item/weapon/circuitboard/cloning
 	name = "Circuit board (Cloning Console)"
@@ -358,6 +359,11 @@
 	contraband_enabled = !contraband_enabled
 	return
 
+/obj/item/weapon/circuitboard/robotics/solder_improve(mob/user as mob)
+	to_chat(user, "<span class='notice'>You [access_hacked ? "" : "un"]connect the security fuse.</span>")
+	access_hacked = !access_hacked
+	return
+
 /obj/item/weapon/circuitboard/security/solder_improve(mob/user as mob)
 	if(istype(src,/obj/item/weapon/circuitboard/security/advanced))
 		return ..()
@@ -490,6 +496,11 @@
 					var/obj/machinery/computer/supplycomp/SC = B
 					var/obj/item/weapon/circuitboard/supplycomp/C = circuit
 					SC.can_order_contraband = C.contraband_enabled
+				if(istype(circuit,/obj/item/weapon/circuitboard/robotics))
+					var/obj/machinery/computer/robotics/SC = B
+					var/obj/item/weapon/circuitboard/robotics/C = circuit
+					SC.access_removed = C.access_hacked
+
 				else if(istype(circuit,/obj/item/weapon/circuitboard/arcade))
 					var/obj/machinery/computer/arcade/arcade = B
 					var/obj/item/weapon/circuitboard/arcade/C = circuit

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -360,9 +360,8 @@
 	return
 
 /obj/item/weapon/circuitboard/robotics/solder_improve(mob/user as mob)
-	to_chat(user, "<span class='notice'>You [access_hacked ? "" : "un"]connect the security fuse.</span>")
+	to_chat(user, "<span class='notice'>You [access_hacked ? "" : "dis"]connect the security fuse.</span>")
 	access_hacked = !access_hacked
-	return
 
 /obj/item/weapon/circuitboard/security/solder_improve(mob/user as mob)
 	if(istype(src,/obj/item/weapon/circuitboard/security/advanced))

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -2,7 +2,7 @@
 
 
 /obj/machinery/computer/robotics
-	name = "Robotics Control"
+	name = "robotics Control"
 	desc = "Used to remotely lockdown or detonate linked Cyborgs."
 	icon = 'icons/obj/computer.dmi'
 	icon_state = "robot"


### PR DESCRIPTION
The robotics control console can be hacked in a way similar to how the cargo console is hacked. If you solder the robotics console board, build the console, and multitool the console it removes access on the robotics console. This can be undone by dismantling and soldering the robotics console board again.