### PR TITLE
Nerf layers for certain atmos objects.

### DIFF
--- a/code/ATMOSPHERICS/pipe/construction.dm
+++ b/code/ATMOSPHERICS/pipe/construction.dm
@@ -48,7 +48,19 @@ Buildable meters
 #define DISP_SORT_JUNCTION		8
 #define DISP_SORT_WRAP_JUNCTION	9
 
-var/global/list/unstackable_pipes = list(PIPE_LAYER_MANIFOLD)
+var/global/list/unstackable_pipes = list(
+	PIPE_LAYER_MANIFOLD,
+	PIPE_UVENT,
+	PIPE_SCRUBBER,
+	PIPE_HEAT_EXCHANGE,
+	PIPE_THERMAL_PLATE,
+	PIPE_INJECTOR,
+	PIPE_DP_VENT,
+	PIPE_PASV_VENT,
+	PIPE_JUNCTION,
+	PIPE_HE_BENT,
+	PIPE_HE_STRAIGHT
+)
 var/global/list/heat_pipes = list(PIPE_HE_STRAIGHT, PIPE_HE_BENT, PIPE_JUNCTION)
 
 /obj/item/pipe_spawner

--- a/code/ATMOSPHERICS/pipe/construction.dm
+++ b/code/ATMOSPHERICS/pipe/construction.dm
@@ -59,7 +59,9 @@ var/global/list/unstackable_pipes = list(
 	PIPE_PASV_VENT,
 	PIPE_JUNCTION,
 	PIPE_HE_BENT,
-	PIPE_HE_STRAIGHT
+	PIPE_HE_STRAIGHT,
+	PIPE_GAS_FILTER,
+	PIPE_GAS_MIXER
 )
 var/global/list/heat_pipes = list(PIPE_HE_STRAIGHT, PIPE_HE_BENT, PIPE_JUNCTION)
 


### PR DESCRIPTION
You can no longer stack the following types of pipes with layers:

* H/E piping
* Heat exchangers
* Thermal plates
* Vents
* Scrubbers
* Injectors

:cl:
* rscdel: You can no longer stack H/E pipes, vents and the alike with layers. Pumps and valves and such left alone. <b>You can still use them on non-default layers, just not use two in the same direction with layers</b>.