### PR TITLE
Allows arcane golems to use spell upgrades

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/arcane_golem.dm
+++ b/code/modules/mob/living/simple_animal/friendly/arcane_golem.dm
@@ -38,7 +38,6 @@
 	heat_damage_per_tick = 0
 	cold_damage_per_tick = 0
 	stop_automated_movement = 1
-	wander = 0
 
 
 /mob/living/simple_animal/hostile/arcane_golem/Destroy()
@@ -83,10 +82,8 @@
 
 		//Alive - follow the master
 		if(!isDead())
-			if(canmove && get_dist(master, src) > 2)
+			if(canmove)
 				Goto(master, move_to_delay)
-			else
-				walk(src, 0)
 
 /mob/living/simple_animal/hostile/arcane_golem/Die()
 	..()

--- a/code/modules/mob/living/simple_animal/friendly/arcane_golem.dm
+++ b/code/modules/mob/living/simple_animal/friendly/arcane_golem.dm
@@ -38,6 +38,7 @@
 	heat_damage_per_tick = 0
 	cold_damage_per_tick = 0
 	stop_automated_movement = 1
+	wander = 0
 
 
 /mob/living/simple_animal/hostile/arcane_golem/Destroy()
@@ -84,6 +85,8 @@
 		if(!isDead())
 			if(canmove && get_dist(master, src) > 2)
 				Goto(master, move_to_delay)
+			else
+				walk(src, 0)
 
 /mob/living/simple_animal/hostile/arcane_golem/Die()
 	..()

--- a/code/modules/mob/living/simple_animal/friendly/arcane_golem.dm
+++ b/code/modules/mob/living/simple_animal/friendly/arcane_golem.dm
@@ -82,7 +82,7 @@
 
 		//Alive - follow the master
 		if(!isDead())
-			if(canmove)
+			if(canmove && get_dist(master, src) > 2)
 				Goto(master, move_to_delay)
 
 /mob/living/simple_animal/hostile/arcane_golem/Die()

--- a/code/modules/spells/aoe_turf/conjure/arcane_golem.dm
+++ b/code/modules/spells/aoe_turf/conjure/arcane_golem.dm
@@ -1,12 +1,14 @@
+#define ADDITIONAL_GOLEMS_PER_UPGRADE_LEVEL 2
+
 /spell/aoe_turf/conjure/arcane_golem
 	name = "Forge Arcane Golem"
 	desc = "Creates a fragile construct that follows you around. It knows a basic version of all of your spells, and will cast them simultaneously with you - at the same target. If cast while an arcane golem is already summoned, your arcane golems will be teleported to you instead. It's unable to learn Mind Transfer and Forge Arcane Golem."
 
-	charge_max = 20 SECONDS
+	charge_max = 10 SECONDS
 	cooldown_min = 1 SECONDS
 
 	spell_levels = list(Sp_SPEED = 0, Sp_AMOUNT = 0)
-	level_max = list(Sp_TOTAL = 3, Sp_SPEED = 1, Sp_AMOUNT = 2) //each level of power grants 1 additional target.
+	level_max = list(Sp_TOTAL = 2, Sp_SPEED = 1, Sp_AMOUNT = 1) //each level of power grants 1 additional target.
 
 	spell_flags = NEEDSCLOTHES | Z2NOCAST
 	invocation = "ARCANUM VIRIUM CONGREGABO"
@@ -52,16 +54,6 @@
 			golems.Remove(AG)
 
 /spell/aoe_turf/conjure/arcane_golem/on_creation(mob/living/simple_animal/hostile/arcane_golem/AG, mob/user)
-	for(var/spell/S in user.spell_list)
-		if(is_type_in_list(S, forbidden_spells))
-			continue
-
-		var/spell/copy = new S.type
-		copy.spell_flags = S.spell_flags & ~NEEDSCLOTHES //Remove robes requirement
-		copy.charge_max = 0 //This is gonna suck with player controlled golems
-
-		AG.add_spell(copy)
-
 	AG.faction = "\ref[user]"
 	to_chat(user, "<span class='sinister'>You infuse \the [AG] with your mana and knowledge. If it dies, your arcane abilities will be affected.</span>")
 	src.golems.Add(AG)
@@ -71,6 +63,8 @@
 	var/target = arguments["target"]
 
 	if(!istype(spell_to_copy) || !istype(spell_to_copy.holder))
+		return
+	if(is_type_in_list(spell_to_copy, forbidden_spells))
 		return
 
 	var/turf/caster_turf = get_turf(spell_to_copy.holder)
@@ -88,9 +82,7 @@
 		targets = list(target)
 
 	for(var/mob/living/simple_animal/hostile/arcane_golem/AG in golems)
-		var/spell/cast_spell = locate(spell_to_copy.type) in AG.spell_list
-		if(!istype(cast_spell))
-			continue
+		var/spell/cast_spell = spell_to_copy
 
 		AG.change_dir(cast_dir) //Face the same direction as the wizard
 
@@ -101,14 +93,20 @@
 
 		//Golems cast spells AFTER the wizard
 		spawn(rand(1,3))
-			AG.cast_spell(cast_spell, targets.Copy())
+			//Instead of giving each golem an copy of each of the wiz's spells,
+			//Use the wizard's spell object for every golem
+			//This ensures that the spells are identical, and that all upgrades are copied
+
+			//Spell code makes golems ignore spell cooldowns/charges, so it isn't an issue
+
+			cast_spell.perform(AG, target_override = targets.Copy())
 
 //UPGRADES
 /spell/aoe_turf/conjure/arcane_golem/apply_upgrade(upgrade_type)
 	switch(upgrade_type)
 		if(Sp_AMOUNT)
 			spell_levels[Sp_AMOUNT]++
-			golem_limit++
+			golem_limit += ADDITIONAL_GOLEMS_PER_UPGRADE_LEVEL
 
 			return "You can now sustain [golem_limit] golems at once."
 
@@ -119,6 +117,8 @@
 /spell/aoe_turf/conjure/arcane_golem/get_upgrade_info(upgrade_type)
 	switch(upgrade_type)
 		if(Sp_AMOUNT)
-			return "Gain the ability to sustain [golem_limit + 1] golems at once."
+			return "Gain the ability to sustain [golem_limit + ADDITIONAL_GOLEMS_PER_UPGRADE_LEVEL] golems at once."
 
 	return ..()
+
+#undef ADDITIONAL_GOLEMS_PER_UPGRADE_LEVEL

--- a/code/modules/spells/aoe_turf/conjure/arcane_golem.dm
+++ b/code/modules/spells/aoe_turf/conjure/arcane_golem.dm
@@ -1,14 +1,14 @@
-#define ADDITIONAL_GOLEMS_PER_UPGRADE_LEVEL 2
+#define ADDITIONAL_GOLEMS_PER_UPGRADE_LEVEL 1
 
 /spell/aoe_turf/conjure/arcane_golem
 	name = "Forge Arcane Golem"
 	desc = "Creates a fragile construct that follows you around. It knows a basic version of all of your spells, and will cast them simultaneously with you - at the same target. If cast while an arcane golem is already summoned, your arcane golems will be teleported to you instead. It's unable to learn Mind Transfer and Forge Arcane Golem."
 
-	charge_max = 10 SECONDS
+	charge_max = 20 SECONDS
 	cooldown_min = 1 SECONDS
 
 	spell_levels = list(Sp_SPEED = 0, Sp_AMOUNT = 0)
-	level_max = list(Sp_TOTAL = 2, Sp_SPEED = 1, Sp_AMOUNT = 1) //each level of power grants 1 additional target.
+	level_max = list(Sp_TOTAL = 3, Sp_SPEED = 1, Sp_AMOUNT = 2) //each level of power grants 1 additional target.
 
 	spell_flags = NEEDSCLOTHES | Z2NOCAST
 	invocation = "ARCANUM VIRIUM CONGREGABO"

--- a/code/modules/spells/general/lightning.dm
+++ b/code/modules/spells/general/lightning.dm
@@ -99,17 +99,17 @@
 	return 1
 
 // Listener for /atom/movable/on_moved
-/spell/lightning/cast(var/list/targets)
+/spell/lightning/cast(var/list/targets, mob/user)
 	var/mob/living/L = targets[1]
 	if(istype(L))
 		zapzap--
 		if(zapzap)
-			to_chat(holder, "<span class='info'>You can throw lightning [zapzap] more time\s</span>")
+			to_chat(user, "<span class='info'>You can throw lightning [zapzap] more time\s</span>")
 			. = 1
 
-		invocation(holder)
+		invocation(user)
 		spawn()
-			zapmuthafucka(holder, L, bounces)
+			zapmuthafucka(user, L, bounces)
 		src.process()
 
 /spell/lightning/proc/zapmuthafucka(var/mob/user, var/mob/living/target, var/chained = bounces, var/list/zapped = list(), var/oursound = null)
@@ -169,7 +169,7 @@
 		var/currdist = -1
 		for(var/mob/living/M in view(target,bounce_range))
 //			to_chat(world, "checking [formatJumpTo(M)] (<a href='?_src_=vars;Vars=\ref[M]'>VV</a>) for a bounce")
-			if((M != holder && M != usr) && M != user)
+			if(M != holder && M != user)
 				if(!(M in zapped) && target == otarget)//we are chaining off something going to our original target
 					continue
 				var/dist = get_dist(M, user)

--- a/code/modules/spells/spell_code.dm
+++ b/code/modules/spells/spell_code.dm
@@ -376,6 +376,10 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 	return 1
 
 /spell/proc/check_charge(var/skipcharge, mob/user)
+	//Arcane golems have no cooldowns on their spells
+	if(istype(user, /mob/living/simple_animal/hostile/arcane_golem))
+		return 1
+
 	if(!skipcharge)
 		if(charge_type & Sp_RECHARGE)
 			if(charge_counter < charge_max)

--- a/code/modules/spells/targeted/shoesnatch.dm
+++ b/code/modules/spells/targeted/shoesnatch.dm
@@ -34,7 +34,7 @@
 			user.put_in_active_hand(old_shoes)
 
 		else if(spawn_shards) //Spawn shards if the target isn't wearing shoes
-			to_chat("<span class='danger'>You conjure several glass shards around \the [target].</span>")
+			to_chat(user, "<span class='danger'>You conjure several glass shards around \the [target].</span>")
 			target.show_message("<span class='danger'>You are surrounded by glass shards!</span>", MESSAGE_SEE)
 			summon_shards(get_turf(target), cardinal)
 


### PR DESCRIPTION
* Arcane golems will now completely copy their wizard's cast spells, allowing golems to make use of spell upgrades. This affects shoe snatching scourge (instantly surrounds the target with shards, no matter their shoe status), ring of fire (will move together with them if upgraded) and arc lightning, as well as any spell upgrades that will be added in the future

* Fixes a runtime that happened when you used shoe snatching scourge

:cl:
 * tweak: Wizard's arcane golems can now use upgraded spells (like the moving ring of fire and shoe snatching scourge)