### PR TITLE
Spell prices update

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -1296,7 +1296,7 @@ var/default_colour_matrix = list(1,0,0,0,\
 #define GLOBALCAST -2
 
 //buying costs
-#define Sp_BASE_PRICE 2
+#define Sp_BASE_PRICE 20
 
 ///////WIZ END/////////
 

--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -1296,7 +1296,7 @@ var/default_colour_matrix = list(1,0,0,0,\
 #define GLOBALCAST -2
 
 //buying costs
-#define Sp_BASE_PRICE 5
+#define Sp_BASE_PRICE 2
 
 ///////WIZ END/////////
 

--- a/code/game/gamemodes/wizard/artifacts.dm
+++ b/code/game/gamemodes/wizard/artifacts.dm
@@ -62,7 +62,7 @@
 	abbreviation = "SN"
 	spawned_items = list(/obj/item/weapon/gun/energy/staff/necro)
 
-#define APPRENTICE_PRICE 5
+#define APPRENTICE_PRICE Sp_BASE_PRICE
 /datum/spellbook_artifact/apprentice
 	name = "Contract of Apprenticeship"
 	desc = "A magical contract binding an apprentice wizard to your service, using it will summon them to your side."

--- a/code/modules/spells/aoe_turf/conjure/forcewall.dm
+++ b/code/modules/spells/aoe_turf/conjure/forcewall.dm
@@ -12,6 +12,8 @@
 
 	hud_state = "wiz_shield"
 
+	price = 0.5 * Sp_BASE_PRICE //Half of the normal spell price
+
 /spell/aoe_turf/conjure/forcewall/mime
 	name = "Invisible wall"
 	desc = "Create an invisible wall on your location."
@@ -56,7 +58,7 @@
 	if(istype(mover, /obj/item/projectile/bullet/invisible))
 		return 1
 	..()
-	
+
 /obj/effect/forcefield/cultify()
 	new /obj/effect/forcefield/cult(get_turf(src))
 	qdel(src)

--- a/code/modules/spells/aoe_turf/conjure/forcewall.dm
+++ b/code/modules/spells/aoe_turf/conjure/forcewall.dm
@@ -5,7 +5,8 @@
 
 	summon_type = list(/obj/effect/forcefield/wizard)
 	duration = 300
-	charge_max = 100
+	charge_max = 10 SECONDS
+	cooldown_min = 2 SECONDS
 	spell_flags = 0
 	range = 0
 	cast_sound = null

--- a/code/modules/spells/aoe_turf/knock.dm
+++ b/code/modules/spells/aoe_turf/knock.dm
@@ -13,6 +13,8 @@
 
 	hud_state = "wiz_knock"
 
+	price = 0.5 * Sp_BASE_PRICE //Half of the normal spell price
+
 /spell/aoe_turf/knock/cast(list/targets)
 	for(var/turf/T in targets)
 		for(var/obj/machinery/door/door in T.contents)

--- a/code/modules/spells/targeted/genetic.dm
+++ b/code/modules/spells/targeted/genetic.dm
@@ -50,6 +50,8 @@ code\game\\dna\genes\goon_powers.dm
 
 	hud_state = "wiz_blind"
 
+	price = 0.5 * Sp_BASE_PRICE //Half of the normal spell price
+
 /spell/targeted/genetic/mutate
 	name = "Mutate"
 	desc = "This spell causes you to turn into a hulk and gain laser vision for a short while."


### PR DESCRIPTION
I made a mistake when I made spells cost 5 points, because 5 is a huge number that is also a prime, so you can't make a spell with 50% of normal cost

* Changed base spell price to ~~2~~ 20 points. Purely visual change (spellbooks have 100 spell points, noclothes cost 40, etc)

* The following spells now cost 1 point (50% of normal spell price) to buy and upgrade: blind, forcewall, knock

:cl:
 * tweak: Changed base spell price once again, this time from 5 points to 20 points. This change is purely visual and doesn't affect number of spells that the wizard can purchase (the spellbook has 100 points, allowing you to buy 5 spells)
 * tweak: Forcewall minimum cooldown increased to 2 seconds (used to be 0)
 * experiment: The following spells now cost 10 points (50% of normal spell price) to both buy and upgrade: blind, forcewall, knock