### PR TITLE
Fixes hand-tele icon glitch

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -319,7 +319,7 @@
 	if(!istype(W))
 		return 0
 	if(usr)
-		usr.u_equip(W,1)
+		usr.u_equip(W,0)
 		usr.update_icons()	//update our overlays
 	W.forceMove(src)
 	W.on_enter_storage(src)


### PR DESCRIPTION
Fixes #14269

Was setting dropped to TRUE whenever you input an item into your backpack, thus dropping it into the newly created portal and storing a ghost icon in your backpack
