### PR TITLE
Makes artifact effect versions opt-in rather than defaulting to all of them

### DIFF
--- a/code/modules/research/xenoarchaeology/artifact/artifact_unknown.dm
+++ b/code/modules/research/xenoarchaeology/artifact/artifact_unknown.dm
@@ -2,7 +2,6 @@
 #define EFFECT_TOUCH 0
 #define EFFECT_AURA 1
 #define EFFECT_PULSE 2
-#define MAX_EFFECT 2
 
 /obj/machinery/artifact
 	name = "alien artifact"

--- a/code/modules/research/xenoarchaeology/artifact/effect.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effect.dm
@@ -2,7 +2,7 @@
 //override procs in children as necessary
 /datum/artifact_effect
 	var/effecttype = "unknown"		//purely used for admin checks ingame, not needed any more
-	var/effect = EFFECT_TOUCH
+	var/effect = EFFECT_TOUCH //Define this as a specific value if the effect only supports that one, or a list of the supported values if it supports multiple.
 	var/effectrange = 4
 	var/datum/artifact_trigger/trigger
 	var/atom/holder
@@ -27,7 +27,7 @@
 /datum/artifact_effect/New(var/atom/location, var/generate_trigger = 0)
 	..()
 	holder = location
-	effect = rand(0,MAX_EFFECT)
+	effect = pick(effect) //If effect is defined as a list, pick one of the options from the list. If it's defined specifically, pick that.
 
 	//this will be replaced by the excavation code later, but it's here just in case
 	artifact_id = "[pick("kappa","sigma","antaeres","beta","omicron","iota","epsilon","omega","gamma","delta","tau","alpha")]-[rand(100,999)]"

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_affect_cold.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_affect_cold.dm
@@ -2,13 +2,13 @@
 //inverse of /datum/artifact_effect/heat, the two effects split up for neatness' sake
 /datum/artifact_effect/cold
 	effecttype = "cold"
+	effect = list(EFFECT_TOUCH, EFFECT_AURA)
 	var/target_temp
 	copy_for_battery = list("target_temp")
 
 /datum/artifact_effect/cold/New()
 	..()
 	target_temp = rand(0, 250)
-	effect = pick(EFFECT_TOUCH, EFFECT_AURA)
 	effect_type = pick(5,6,7)
 
 /datum/artifact_effect/cold/DoEffectTouch(var/mob/user)

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_badfeeling.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_badfeeling.dm
@@ -1,6 +1,7 @@
 
 /datum/artifact_effect/badfeeling
 	effecttype = "badfeeling"
+	effect = list(EFFECT_TOUCH, EFFECT_AURA, EFFECT_PULSE)
 	effect_type = 2
 	var/list/messages = list("You feel worried.",\
 		"Something doesn't feel right.",\

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_cellcharge.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_cellcharge.dm
@@ -1,5 +1,6 @@
 /datum/artifact_effect/cellcharge
 	effecttype = "cellcharge"
+	effect = list(EFFECT_TOUCH, EFFECT_AURA, EFFECT_PULSE)
 	effect_type = 3
 	var/next_message
 

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_celldrain.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_celldrain.dm
@@ -2,6 +2,7 @@
 //todo
 /datum/artifact_effect/celldrain
 	effecttype = "celldrain"
+	effect = list(EFFECT_TOUCH, EFFECT_AURA, EFFECT_PULSE)
 	effect_type = 3
 	var/next_message
 

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_cultify.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_cultify.dm
@@ -1,10 +1,7 @@
 /datum/artifact_effect/cultify
 	effecttype = "cultify"
+	effect = list(EFFECT_AURA, EFFECT_PULSE)
 	effect_type = 2
-
-/datum/artifact_effect/cultify/New()
-	..()
-	effect = pick(EFFECT_AURA, EFFECT_PULSE)
 
 /datum/artifact_effect/cultify/DoEffectAura()
 	make_culty(min(3, effectrange))

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_darkness.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_darkness.dm
@@ -1,11 +1,11 @@
 /datum/artifact_effect/darkness
 	effecttype = "darkness"
+	effect = list(EFFECT_AURA, EFFECT_PULSE)
 	var/dark_level
 	copy_for_battery = list("dark_level")
 
 /datum/artifact_effect/darkness/New()
 	..()
-	effect = rand(1,2)
 	effect_type = pick(0,3,4)
 	effectrange = rand(2,12)
 	dark_level = rand(2,7)

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_darkrevive.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_darkrevive.dm
@@ -1,9 +1,9 @@
 /datum/artifact_effect/darkrevive
 	effecttype = "darkrevive"
+	effect = EFFECT_TOUCH
 
 /datum/artifact_effect/darkrevive/New()
 	..()
-	effect = EFFECT_TOUCH
 	effect_type = pick(0,2,5)
 
 /datum/artifact_effect/darkrevive/DoEffectTouch(var/mob/living/carbon/human/user)

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_deadharvest.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_deadharvest.dm
@@ -1,5 +1,6 @@
 /datum/artifact_effect/deadharvest
 	effecttype = "deadharvest"
+	effect = list(EFFECT_TOUCH, EFFECT_AURA, EFFECT_PULSE)
 	var/list/mob_spawn = list()
 	var/points = 0
 	var/can_be_controlled = 0
@@ -7,7 +8,6 @@
 
 /datum/artifact_effect/deadharvest/New()
 	..()
-	effect = pick(EFFECT_TOUCH, EFFECT_AURA, EFFECT_PULSE)
 	can_be_controlled = pick(0,1)
 	if(!mob_spawn.len)
 		new_mob_spawn_list()

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_dnaswitch.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_dnaswitch.dm
@@ -2,6 +2,7 @@
 //todo
 /datum/artifact_effect/dnaswitch
 	effecttype = "dnaswitch"
+	effect = list(EFFECT_TOUCH, EFFECT_AURA, EFFECT_PULSE)
 	effect_type = 5
 	var/severity
 	copy_for_battery = list("severity")

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_emp.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_emp.dm
@@ -1,11 +1,8 @@
 
 /datum/artifact_effect/emp
 	effecttype = "emp"
-	effect_type = 3
-
-/datum/artifact_effect/emp/New()
-	..()
 	effect = EFFECT_PULSE
+	effect_type = 3
 
 /datum/artifact_effect/emp/DoEffectPulse()
 	if(holder)

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_forcefield.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_forcefield.dm
@@ -1,12 +1,12 @@
 
 /datum/artifact_effect/forcefield
 	effecttype = "forcefield"
+	effect = EFFECT_AURA
 	var/list/created_field = list()
 	effect_type = 4
 
 /datum/artifact_effect/forcefield/New()
 	..()
-	effect = EFFECT_AURA
 	spawn(0)
 		if(trigger && !istype(trigger,/datum/artifact_trigger/touch/))
 			var/trigger_override = /datum/artifact_trigger/touch

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_gasco2.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_gasco2.dm
@@ -1,17 +1,13 @@
 
 /datum/artifact_effect/gasco2
 	effecttype = "gasco2"
+	effect = list(EFFECT_TOUCH, EFFECT_AURA)
 	var/max_pressure
 	var/target_percentage
 	copy_for_battery = list("max_pressure")
 
-/datum/artifact_effect/heat/New()
-	..()
-	effect_type = pick(6,7)
-
 /datum/artifact_effect/gasco2/New()
 	..()
-	effect = pick(EFFECT_TOUCH, EFFECT_AURA)
 	max_pressure = rand(115,1000)
 
 /datum/artifact_effect/gasco2/DoEffectTouch(var/mob/user)

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_gasnitro.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_gasnitro.dm
@@ -1,13 +1,13 @@
 
 /datum/artifact_effect/gasnitro
 	effecttype = "gasnitro"
+	effect = list(EFFECT_TOUCH, EFFECT_AURA)
 	var/max_pressure
 	var/target_percentage
 	copy_for_battery = list("max_pressure")
 
 /datum/artifact_effect/gasnitro/New()
 	..()
-	effect = pick(EFFECT_TOUCH, EFFECT_AURA)
 	effect_type = pick(6,7)
 	max_pressure = rand(115,1000)
 

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_gasoxy.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_gasoxy.dm
@@ -1,12 +1,12 @@
 
 /datum/artifact_effect/gasoxy
 	effecttype = "gasoxy"
+	effect = list(EFFECT_TOUCH, EFFECT_AURA)
 	var/max_pressure
 	copy_for_battery = list("max_pressure")
 
 /datum/artifact_effect/gasoxy/New()
 	..()
-	effect = pick(EFFECT_TOUCH, EFFECT_AURA)
 	max_pressure = rand(115,1000)
 	effect_type = pick(6,7)
 

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_gasplasma.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_gasplasma.dm
@@ -1,13 +1,13 @@
 
 /datum/artifact_effect/gasplasma
 	effecttype = "gasplasma"
+	effect = list(EFFECT_TOUCH, EFFECT_AURA)
 	var/max_pressure
 	var/target_percentage
 	copy_for_battery = list("max_pressure")
 
 /datum/artifact_effect/gasplasma/New()
 	..()
-	effect = pick(EFFECT_TOUCH, EFFECT_AURA)
 	max_pressure = rand(115,1000)
 	effect_type = pick(6,7)
 

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_gassleeping.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_gassleeping.dm
@@ -1,13 +1,13 @@
 
 /datum/artifact_effect/gassleeping
 	effecttype = "gassleeping"
+	effect = list(EFFECT_TOUCH, EFFECT_AURA)
 	var/max_pressure
 	var/target_percentage
 	copy_for_battery = list("max_pressure")
 
 /datum/artifact_effect/gassleeping/New()
 	..()
-	effect = pick(EFFECT_TOUCH, EFFECT_AURA)
 	max_pressure = rand(115,1000)
 	effect_type = pick(6,7)
 

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_goodfeeling.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_goodfeeling.dm
@@ -1,6 +1,7 @@
 
 /datum/artifact_effect/goodfeeling
 	effecttype = "goodfeeling"
+	effect = list(EFFECT_TOUCH, EFFECT_AURA, EFFECT_PULSE)
 	effect_type = 2
 	var/list/messages = list("You feel good.",\
 		"Everything seems to be going alright",\

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_gravity.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_gravity.dm
@@ -1,5 +1,6 @@
 /datum/artifact_effect/gravity
 	effecttype = "gravity"
+	effect = list(EFFECT_TOUCH, EFFECT_AURA, EFFECT_PULSE)
 	effect_type = 1
 
 	var/pull_strength

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_heal.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_heal.dm
@@ -1,6 +1,7 @@
 
 /datum/artifact_effect/heal
 	effecttype = "heal"
+	effect = list(EFFECT_TOUCH, EFFECT_AURA, EFFECT_PULSE)
 	effect_type = 5
 
 /datum/artifact_effect/heal/DoEffectTouch(var/mob/toucher)

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_heat.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_heat.dm
@@ -2,17 +2,14 @@
 //inverse of /datum/artifact_effect/cold, the two effects split up for neatness' sake
 /datum/artifact_effect/heat
 	effecttype = "heat"
+	effect = list(EFFECT_TOUCH, EFFECT_AURA)
 	var/target_temp
 	copy_for_battery = list("target_temp")
 
 /datum/artifact_effect/heat/New()
 	..()
 	effect_type = pick(5,6,7)
-
-/datum/artifact_effect/heat/New()
-	..()
 	target_temp = rand(300,600)
-	effect = pick(EFFECT_TOUCH, EFFECT_AURA)
 
 /datum/artifact_effect/heat/DoEffectTouch(var/mob/user)
 	if(holder)

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_hurt.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_hurt.dm
@@ -1,6 +1,7 @@
 
 /datum/artifact_effect/hurt
 	effecttype = I_HURT
+	effect = list(EFFECT_TOUCH, EFFECT_AURA, EFFECT_PULSE)
 	effect_type = 5
 
 /datum/artifact_effect/hurt/DoEffectTouch(var/mob/toucher)

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_menagerie.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_menagerie.dm
@@ -1,7 +1,7 @@
 /datum/artifact_effect/menagerie
 	effecttype = "menagerie"
-	effect_type = 5
 	effect = EFFECT_PULSE
+	effect_type = 5
 	var/static/list/possible_types = list()
 
 /datum/artifact_effect/menagerie/New()

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_planthelper.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_planthelper.dm
@@ -1,10 +1,7 @@
 /datum/artifact_effect/planthelper
 	effecttype = "planthelper"
+	effect = list(EFFECT_AURA, EFFECT_PULSE)
 	effect_type = 5
-
-/datum/artifact_effect/planthelper/New()
-	..()
-	effect = pick(EFFECT_AURA, EFFECT_PULSE)
 
 /datum/artifact_effect/planthelper/DoEffectAura()
 	if(holder)

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_plantkiller.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_plantkiller.dm
@@ -1,10 +1,7 @@
 /datum/artifact_effect/plantkiller
 	effecttype = "plantkiller"
+	effect = list(EFFECT_AURA, EFFECT_PULSE)
 	effect_type = 5
-
-/datum/artifact_effect/plantkiller/New()
-	..()
-	effect = pick(EFFECT_AURA, EFFECT_PULSE)
 
 /datum/artifact_effect/plantkiller/DoEffectAura()
 	if(holder)

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_projectiles.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_projectiles.dm
@@ -25,16 +25,15 @@
 
 /datum/artifact_effect/projectiles
 	effecttype = "projectiles"
-
+	effect = EFFECT_PULSE
+	effectrange = 7
 	var/projectiletype
 	var/num_of_shots
 	copy_for_battery = list("projectiletype", "num_of_shots")
 
 /datum/artifact_effect/projectiles/New()
 	..()
-	effect = EFFECT_PULSE
 	effect_type = pick(1,3,4,6)
-	effectrange = 7
 	chargelevelmax = rand(5, 20)
 	projectiletype = pick(validartifactprojectiles)
 	num_of_shots = pick(100;1, 100;2, 50;3, 25;4, 10;6)

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_radiate.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_radiate.dm
@@ -1,6 +1,7 @@
 
 /datum/artifact_effect/radiate
 	effecttype = "radiate"
+	effect = list(EFFECT_TOUCH, EFFECT_AURA, EFFECT_PULSE)
 	var/radiation_amount
 	copy_for_battery = list("radiation_amount")
 

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_reagentblock.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_reagentblock.dm
@@ -1,5 +1,6 @@
 /datum/artifact_effect/reagentblock
 	effecttype = "reagentblock"
+	effect = list(EFFECT_TOUCH, EFFECT_AURA, EFFECT_PULSE)
 	var/duration = 0
 	copy_for_battery = list("duration")
 

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_roboheal.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_roboheal.dm
@@ -1,6 +1,7 @@
 
 /datum/artifact_effect/roboheal
 	effecttype = "roboheal"
+	effect = list(EFFECT_TOUCH, EFFECT_AURA, EFFECT_PULSE)
 
 /datum/artifact_effect/roboheal/New()
 	..()

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_robohurt.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_robohurt.dm
@@ -1,6 +1,7 @@
 
 /datum/artifact_effect/robohurt
 	effecttype = "robohurt"
+	effect = list(EFFECT_TOUCH, EFFECT_AURA, EFFECT_PULSE)
 
 /datum/artifact_effect/robohurt/New()
 	..()

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_sleepy.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_sleepy.dm
@@ -2,6 +2,7 @@
 //todo
 /datum/artifact_effect/sleepy
 	effecttype = "sleepy"
+	effect = list(EFFECT_TOUCH, EFFECT_AURA, EFFECT_PULSE)
 
 /datum/artifact_effect/sleepy/New()
 	..()

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_stun.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_stun.dm
@@ -1,6 +1,7 @@
 
 /datum/artifact_effect/stun
 	effecttype = "stun"
+	effect = list(EFFECT_TOUCH, EFFECT_AURA, EFFECT_PULSE)
 
 /datum/artifact_effect/stun/New()
 	..()

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_teleport.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_teleport.dm
@@ -1,6 +1,7 @@
 
 /datum/artifact_effect/teleport
 	effecttype = "teleport"
+	effect = list(EFFECT_TOUCH, EFFECT_AURA, EFFECT_PULSE)
 	effect_type = 6
 
 /datum/artifact_effect/teleport/DoEffectTouch(var/mob/user)

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_timestop.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_timestop.dm
@@ -1,5 +1,6 @@
 /datum/artifact_effect/timestop
 	effecttype = "timestop"
+	effect = list(EFFECT_TOUCH, EFFECT_PULSE)
 
 	var/mob/caster
 	var/spell/aoe_turf/fall/fall
@@ -8,7 +9,6 @@
 
 /datum/artifact_effect/timestop/New()
 	..()
-	effect = pick(EFFECT_TOUCH, EFFECT_PULSE)
 	caster = new
 	caster.invisibility = 101
 	caster.density = 0


### PR DESCRIPTION
(I'm talking about the way a given effect behaves, which is confusing to talk about because the var that determines it is called `effect`. But I mean like touch, aura, or pulse versions of each effect.)

Making the default behavior be to pick from all possible effect types was unwise, because it meant that you had to manually specify (in `New()`, no less) which effect types were valid for a given effect. Not only was this confusing, but it GUARANTEED that if a fourth value for `effect` were ever added, most effects would break unless they were also changed.
Now you specify which values for `effect` are valid for each individual effect, in the type definition. Just define `effect` as a list of the valid values for that type, and one of them will be picked at random. It defaults to `EFFECT_TOUCH` only, but the only reason it doesn't default to nothing at all is because I was worried that would break something.

Unless I fucked up, the only gameplay change is that the Menagerie effect will no longer have a 2/3 chance of being broken. This was an unreported issue, as far as I know. It's also possible that a bug was fixed with the heat effect, because there were three separate definitions of its `New()` across two different files, which were all different. (?????) I condensed them. I don't know which one previously took priority, so said fixed bug could range anywhere from the possible examine texts being different to it working when it previously didn't.

No, I am not making a define for all effect types, because that would defeat most of the purpose of this PR.