### PR TITLE
Allows light replacers to fit in tool-belts

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -26,12 +26,13 @@
 
 /obj/item/weapon/storage/belt/utility
 	name = "tool-belt" //Carn: utility belt is nicer, but it bamboozles the text parsing.
-	desc = "It has a tag that rates it for compatibility with standard tools, device analyzers, flashlights, cables, engineering tape, small fire extinguishers, compressed matter cartridges, and fuel cans."
+	desc = "It has a tag that rates it for compatibility with standard tools, device analyzers, flashlights, cables, engineering tape, small fire extinguishers, compressed matter cartridges, light replacers, and fuel cans."
 	icon_state = "utilitybelt"
 	item_state = "utility"
 	w_class = W_CLASS_LARGE
 	storage_slots = 14
 	max_combined_w_class = 200 //This actually doesn't matter as long as it is arbitrarily high, bar will be set by storage slots
+	fits_max_w_class = 3
 	can_only_hold = list(
 		"/obj/item/weapon/crowbar",
 		"/obj/item/weapon/screwdriver",

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -26,7 +26,7 @@
 
 /obj/item/weapon/storage/belt/utility
 	name = "tool-belt" //Carn: utility belt is nicer, but it bamboozles the text parsing.
-	desc = "It has a tag that rates it for compatibility with standard tools, device analyzers, flashlights, cables, engineering tape, small fire extinguishers, compressed matter cartridges, light replacers, and fuel cans."
+	desc = "It has a tag that rates it for compatibility with standard tools, device analyzers, flashlights, cables, engineering tape, small fire extinguishers, compressed matter cartridges, and fuel cans."
 	icon_state = "utilitybelt"
 	item_state = "utility"
 	w_class = W_CLASS_LARGE

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -32,7 +32,9 @@
 	w_class = W_CLASS_LARGE
 	storage_slots = 14
 	max_combined_w_class = 200 //This actually doesn't matter as long as it is arbitrarily high, bar will be set by storage slots
-	fits_max_w_class = 3
+	fits_ignoring_w_class = list(
+		"/obj/item/device/lightreplacer"
+		)
 	can_only_hold = list(
 		"/obj/item/weapon/crowbar",
 		"/obj/item/weapon/screwdriver",


### PR DESCRIPTION
~~Removes light replacers from the examine list, seeing as they apparently have a w_class too high to fit inside, but leaves them in the can_only_hold list because Kurfusten said so and I trust him more than myself.~~

~~Tosses in a fits_max_w_class var for the tool-belt because max_combined_w_class doesn't actually do anything tangible, apparently. Doesn't break anything, either, surprisingly!~~

I hijacked this PR and did it the correct way since OP dropped off the face of the earth.

Closes #14768

:cl:
* tweak: Toolbelts now fit light replacers.