### PR TITLE
Changes How Transmogrification Works

### DIFF
--- a/code/_onclick/ventcrawl.dm
+++ b/code/_onclick/ventcrawl.dm
@@ -12,7 +12,7 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 
 // Vent crawling whitelisted items, whoo
 /mob/living
-	var/canEnterVentWith = "/obj/item/weapon/implant=0&/obj/item/clothing/mask/facehugger=0&/obj/item/device/radio/borg=0&/obj/machinery/camera=0&/mob/living/simple_animal/borer=0&/obj/item/verbs=0"
+	var/canEnterVentWith = "/obj/item/weapon/implant=0&/obj/item/clothing/mask/facehugger=0&/obj/item/device/radio/borg=0&/obj/machinery/camera=0&/mob/living/simple_animal/borer=0&/obj/transmog_body_container=0&/obj/item/verbs=0"
 
 /mob/living/AltClickOn(var/atom/A)
 	if(is_type_in_list(A,ventcrawl_machinery) && src.can_ventcrawl())

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -44,7 +44,8 @@
 	for(var/obj/item/I in src)
 		I.OnMobDeath(src)
 	if(transmogged_from)
-		var/mob/living/L = transmogged_from
+		var/obj/transmog_body_container/C = transmogged_from
+		var/mob/living/L = C.contained_mob
 		transmogrify()
 		L.visible_message("<span class='danger'>\The [L]'s body shifts and contorts!</span>")
 		if(istype(L))

--- a/code/modules/mob/living/simple_animal/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer.dm
@@ -313,7 +313,9 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 	var/encoded_message = html_encode(message)
 
 	to_chat(src, "You drop words into [host]'s body: <span class='borer2host'>\"[encoded_message]\"</span>")
-	if(hostlimb == LIMB_HEAD)
+	if(host.transmogged_to)
+		to_chat(host.transmogged_to, "<b>Something speaks within you:</b> <span class='borer2host'>\"[encoded_message]\"</span>")
+	else if(hostlimb == LIMB_HEAD)
 		to_chat(host, "<b>Your mind speaks to you:</b> <span class='borer2host'>\"[encoded_message]\"</span>")
 	else
 		to_chat(host, "<b>Your [limb_to_name(hostlimb)] speaks to you:</b> <span class='borer2host'>\"[encoded_message]\"</span>")

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -954,7 +954,7 @@ var/list/slot_equipment_priority = list( \
 	if (ismob(AM))
 		var/mob/M = AM
 		if (M.locked_to) //If the mob is locked_to on something, let's just try to pull the thing they're locked_to to for convenience's sake.
-			P = M.locked_to		
+			P = M.locked_to
 
 	if (!P.anchored)
 		P.add_fingerprint(src)
@@ -978,7 +978,7 @@ var/list/slot_equipment_priority = list( \
 				M.LAssailant = usr
 				/*if(ishuman(AM))
 					var/mob/living/carbon/human/HM = AM
-					if (HM.drag_damage()) 
+					if (HM.drag_damage())
 						if (HM.isincrit())
 							to_chat(usr,"<span class='warning'>Pulling \the [HM] in their current condition would probably be a bad idea.</span>")
 							add_logs(src, HM, "started dragging critically wounded", admin = (HM.ckey))*/
@@ -1861,47 +1861,39 @@ mob/proc/on_foot()
 /mob/proc/transmogrify(var/target_type, var/offer_revert_spell = FALSE)	//transforms the mob into a new member of the given mob type, while preserving the mob's body
 	if(!target_type)
 		if(transmogged_from)
-			transmogged_from.forceMove(loc)
-			if(key)
-				transmogged_from.key = key
-			transmogged_from.timestopped = 0
-			if(istype(transmogged_from, /mob/living/carbon))
-				var/mob/living/carbon/C = transmogged_from
-				if(istype(C.get_item_by_slot(slot_wear_mask), /obj/item/clothing/mask/morphing))
-					C.drop_item(C.wear_mask, force_drop = 1)
-			var/mob/returned_mob = transmogged_from
-			returned_mob.transmogged_to = null
-			transmogged_from = null
-			for(var/atom/movable/AM in contents)
-				AM.forceMove(get_turf(src))
-			forceMove(null)
-			qdel(src)
-			return returned_mob
+			var/obj/transmog_body_container/tC = transmogged_from
+			if(tC.contained_mob)
+				tC.contained_mob.forceMove(loc)
+				if(key)
+					tC.contained_mob.key = key
+				tC.contained_mob.timestopped = 0
+				if(istype(tC.contained_mob, /mob/living/carbon))
+					var/mob/living/carbon/C = tC.contained_mob
+					if(istype(C.get_item_by_slot(slot_wear_mask), /obj/item/clothing/mask/morphing))
+						C.drop_item(C.wear_mask, force_drop = 1)
+				var/mob/returned_mob = tC.contained_mob
+				returned_mob.transmogged_to = null
+				tC.get_rid_of()
+				transmogged_from = null
+				for(var/atom/movable/AM in contents)
+					AM.forceMove(get_turf(src))
+				forceMove(null)
+				qdel(src)
+				return returned_mob
 		return
 	if(!ispath(target_type, /mob))
 		EXCEPTION(target_type)
 		return
 	var/mob/M = new target_type(loc)
-	M.transmogged_from = src
+	var/obj/transmog_body_container/C = new (M)
+	M.transmogged_from = C
 	transmogged_to = M
 	if(key)
 		M.key = key
 	if(offer_revert_spell)
 		var/spell/change_back = new /spell/aoe_turf/revert_form
 		M.add_spell(change_back)
-	var/static/list/drop_on_transmog = list(
-		/obj/item/weapon/disk/nuclear,
-		/obj/item/weapon/holder,
-		/obj/item/device/paicard,
-		/obj/item/device/soulstone,
-		/obj/item/device/mmi,
-		)
-	for(var/i in drop_on_transmog)
-		var/list/L = search_contents_for(i)
-		if(L.len)
-			for(var/A in L)
-				drop_item(A, force_drop = 1)
-	src.forceMove(null)
+	C.set_contained_mob(src)
 	timestopped = 1
 	return M
 
@@ -1919,6 +1911,36 @@ mob/proc/on_foot()
 /spell/aoe_turf/revert_form/cast(var/list/targets, mob/user)
 	user.transmogrify()
 	user.remove_spell(src)
+
+/obj/transmog_body_container
+	name = "transmog body container"
+	desc = "You should not be seeing this."
+	flags = TIMELESS
+	var/mob/contained_mob
+
+/obj/transmog_body_container/proc/set_contained_mob(var/mob/M)
+	if(M)
+		M.forceMove(src)
+		contained_mob = M
+
+/obj/transmog_body_container/proc/get_rid_of()
+	for(var/atom/movable/AM in contents)
+		AM.forceMove(get_turf(src))
+	contained_mob = null
+	qdel(src)
+
+/obj/transmog_body_container/proc/get_contained_mob()
+	if(!contents.len)
+		return null
+	else
+		for(var/i in contents)
+			return i
+
+/obj/transmog_body_container/Destroy()
+	contained_mob = null
+	for(var/i in contents)
+		qdel(i)
+	..()
 
 /mob/attack_icon()
 	return image(icon = 'icons/mob/attackanims.dmi', icon_state = "default")

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1919,22 +1919,15 @@ mob/proc/on_foot()
 	var/mob/contained_mob
 
 /obj/transmog_body_container/proc/set_contained_mob(var/mob/M)
-	if(M)
-		M.forceMove(src)
-		contained_mob = M
+	ASSERT(M)
+	M.forceMove(src)
+	contained_mob = M
 
 /obj/transmog_body_container/proc/get_rid_of()
 	for(var/atom/movable/AM in contents)
 		AM.forceMove(get_turf(src))
 	contained_mob = null
 	qdel(src)
-
-/obj/transmog_body_container/proc/get_contained_mob()
-	if(!contents.len)
-		return null
-	else
-		for(var/i in contents)
-			return i
 
 /obj/transmog_body_container/Destroy()
 	contained_mob = null

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -285,7 +285,7 @@
 	var/see_in_dark_override = 0	//for general guaranteed modification of these variables
 	var/see_invisible_override = 0
 
-	var/mob/transmogged_from	//holds a reference to the mob that this mob used to be before being transmogrified
+	var/obj/transmog_body_container/transmogged_from	//holds a reference to the container holding the mob that this mob used to be before being transmogrified
 	var/mob/transmogged_to		//holds a reference to the mob which holds a reference to this mob in its transmogged_from var
 
 /mob/resetVariables()


### PR DESCRIPTION
Now, when a mob is transmogrified, instead of moving the mob's old body to nullspace for safekeeping, it is instead placed inside a special object which is then placed inside the new mob.
This has the positive effect of allowing pAIs/posibrains/soulstones/etc to have their views remain centered on the new mob, rather than getting stuck in a black void. It also removes the need for certain objects to be force-dropped upon transmogrification.

Additionally, this PR allows borers to speak to their host even while their host is transmogrified.

Fixes #14611
Fixes #14699