### PR TITLE
ZAS Through Portals

### DIFF
--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -72,14 +72,18 @@
 				atmos_connected = TRUE
 				atmos_connection = new (get_turf(src), get_turf(P))
 
+/obj/effect/portal/proc/disconnect_atmospheres()
+	atmos_connected = FALSE
+	if(atmos_connection)
+		atmos_connection.erase()
+		atmos_connection = null
+
 /obj/effect/portal/Destroy()
 	if(undergoing_deletion)
 		return
 	undergoing_deletion = 1
 	playsound(loc,'sound/effects/portal_close.ogg',60,1)
-	if(atmos_connection)
-		atmos_connection.erase()
-		atmos_connection = null
+	disconnect_atmospheres()
 
 	purge_beams()
 	owner = null

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -10,6 +10,8 @@
 	anchored = 1.0
 	w_type=NOT_RECYCLABLE
 	var/undergoing_deletion = 0
+	var/atmos_connected = FALSE
+	var/connection/atmos_connection
 
 	var/list/exit_beams = list()
 
@@ -55,14 +57,29 @@
 		qdel(src)
 		return
 
+	spawn(5)
+		connect_atmospheres()
+
 	spawn(lifespan)
 		qdel(src)
+
+/obj/effect/portal/proc/connect_atmospheres()
+	if(!atmos_connected)
+		if(target)
+			if(istype(target, /obj/effect/portal))
+				var/obj/effect/portal/P = target
+				P.atmos_connected = TRUE
+				atmos_connected = TRUE
+				atmos_connection = new (get_turf(src), get_turf(P))
 
 /obj/effect/portal/Destroy()
 	if(undergoing_deletion)
 		return
 	undergoing_deletion = 1
 	playsound(loc,'sound/effects/portal_close.ogg',60,1)
+	if(atmos_connection)
+		atmos_connection.erase()
+		atmos_connection = null
 
 	purge_beams()
 	owner = null

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -68,9 +68,17 @@
 		if(target)
 			if(istype(target, /obj/effect/portal))
 				var/obj/effect/portal/P = target
-				P.atmos_connected = TRUE
-				atmos_connected = TRUE
-				atmos_connection = new (get_turf(src), get_turf(P))
+				if(get_turf(src) && get_turf(P))
+					var/valid_connection = FALSE
+					if(air_master.has_valid_zone(get_turf(src)))
+						atmos_connection = new (get_turf(src), get_turf(P))
+						valid_connection = TRUE
+					if(air_master.has_valid_zone(get_turf(P)))
+						P.atmos_connection = new (get_turf(P), get_turf(src))
+						valid_connection = TRUE
+					if(valid_connection)
+						P.atmos_connected = TRUE
+						atmos_connected = TRUE
 
 /obj/effect/portal/proc/disconnect_atmospheres()
 	atmos_connected = FALSE

--- a/code/modules/projectiles/guns/special.dm
+++ b/code/modules/projectiles/guns/special.dm
@@ -98,6 +98,8 @@
 			blue_portal.overlays.len = 0
 			blue_portal.target = null
 		return
+	red_portal.disconnect_atmospheres()
+	blue_portal.disconnect_atmospheres()
 
 	//connecting the portals
 	blue_portal.target = red_portal
@@ -112,3 +114,6 @@
 	red_portal.purge_beams()
 	blue_portal.add_beams()
 	red_portal.add_beams()
+
+	//updating their atmos connection
+	blue_portal.connect_atmospheres()


### PR DESCRIPTION
ZAS now functions through portals. Portals to space, for example, will drain the air from a room.

Gas transfer and pulling/pushing both fully work.
Pulling to space through a portal, specifically, appears to be broken.

Resolves #11971

:cl:
 * rscadd: ZAS now functions through portals.
