### PR TITLE
removes humanoids from the transmog lists

### DIFF
--- a/code/modules/clothing/masks/transmog.dm
+++ b/code/modules/clothing/masks/transmog.dm
@@ -123,7 +123,7 @@
 /obj/item/clothing/mask/morphing/amorphous/New()
 	..()
 	color = rgb(rand(0,255),rand(0,255),rand(0,255))
-	target_type = pick(existing_typesof(/mob/living/simple_animal))
+	target_type = pick(existing_typesof(/mob/living/simple_animal) - existing_typesof(/mob/living/simple_animal/hostile/humanoid))
 
 /obj/item/clothing/mask/morphing/ghost
 	name = "mask of the phantom"

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_menagerie.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_menagerie.dm
@@ -6,7 +6,7 @@
 
 /datum/artifact_effect/menagerie/New()
 	..()
-	possible_types = existing_typesof(/mob/living) - existing_typesof(/mob/living/silicon)
+	possible_types = existing_typesof(/mob/living) - (existing_typesof(/mob/living/silicon) + existing_typesof(/mob/living/simple_animal/hostile/humanoid))
 
 /datum/artifact_effect/menagerie/DoEffectPulse()
 	if(holder)


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl: (as the emoji)
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
Problem with hostile humanoids is that when they die, they qdel, and that means that whomever was the poor soul being humanoided is lost forever.

After hearing reports of a rogue artifact randomly transmogrifying people into pirate mobs and them dying a few seconds later making the person be lost forever, on top of the formless mask potentially taking the form of, say, a vox raider leading the wearer of the mask to end up dead and disappeared forever, it seems that it's a good idea to remove humanoids from the list.