### PR TITLE
Fixed bug that allowed lockboxes content to be dragged to tables

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -8,16 +8,6 @@
 	slot_flags = SLOT_BELT
 	attack_verb = list("whips", "lashes", "disciplines")
 
-
-/obj/item/weapon/storage/belt/proc/can_use()
-	if(!ismob(loc))
-		return 0
-	var/mob/M = loc
-	if(src in M.get_equipped_items())
-		return 1
-	else
-		return 0
-
 /obj/item/weapon/storage/belt/can_quick_store(var/obj/item/I)
 	return can_be_inserted(I,1)
 

--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -19,6 +19,9 @@
 	health = 50
 	var/oneuse = 0
 
+/obj/item/weapon/storage/lockbox/can_use()
+	return broken || !locked
+
 /obj/item/weapon/storage/lockbox/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if (istype(W, /obj/item/weapon/card/id))
 		var/obj/item/weapon/card/id/ID = W

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -30,13 +30,17 @@
 	var/foldable_amount = 1 // Number of foldables to produce, if any - N3X
 	var/internal_store = 0
 
+/obj/item/weapon/storage/proc/can_use()
+	return TRUE
+
 /obj/item/weapon/storage/MouseDrop(obj/over_object as obj)
 	if (ishuman(usr) || ismonkey(usr)) //so monkeys can take off their backpacks -- Urist
 		var/mob/M = usr
 		if(istype(over_object, /obj/structure/table) && M.Adjacent(over_object) && Adjacent(M))
 			var/mob/living/L = usr
 			if(istype(L) && !(L.incapacitated() || L.lying))
-				empty_contents_to(over_object)
+				if(can_use())
+					empty_contents_to(over_object)
 
 		if(!( istype(over_object, /obj/abstract/screen/inventory) ))
 			return ..()


### PR DESCRIPTION
…and removed an apparently unused `can_use()` proc from `belt.dm`. If it IS actually used I couldn't figure out where.

Fixes #14686

:cl:
 * bugfix: Fixed bug that allowed lockboxes content to be dragged to tables.