### PR TITLE
ERT is easier to call

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -158,10 +158,10 @@ var/shuttle_call/shuttle_calls[0]
 			if (istype(I, /obj/item/device/pda))
 				var/obj/item/device/pda/pda = I
 				I = pda.id
-			if (I && istype(I))
-				if(access_captain in I.access)
-					authenticated = 2
-			if(authenticated != 2)
+			//if (I && istype(I))
+			//	if(access_captain in I.access)
+			//		authenticated = 2
+			if(!authenticated)
 				to_chat(usr, "<span class='warning'>You do not have clearance to use this function.</span>")
 				return
 			setMenuState(usr,COMM_SCREEN_ERT)

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -198,7 +198,7 @@ var/shuttle_call/shuttle_calls[0]
 			if(!(get_security_level() in list("red", "delta")))
 				to_chat(usr, "<span class='notice'>The station must be in an emergency to request a Response Team.</span>")
 				return
-			if(authenticated != 1 || issilicon(usr))
+			if(!authenticated || issilicon(usr))
 				to_chat(usr, "<span class='warning'>\The [src.name]'s screen flashes, \"Access Denied\".</span>")
 				return
 

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -192,13 +192,13 @@ var/shuttle_call/shuttle_calls[0]
 			//	to_chat(usr, "<span class='notice'>The emergency response team is away on another mission, Please wait another [round((6000-world.time)/600)] minute\s before trying again.</span>")
 			//	return
 
-			if(emergency_shuttle.online)
-				to_chat(usr, "The emergency shuttle is already on its way.")
-				return
+			//if(emergency_shuttle.online)
+			//	to_chat(usr, "The emergency shuttle is already on its way.")
+			//	return
 			if(!(get_security_level() in list("red", "delta")))
 				to_chat(usr, "<span class='notice'>The station must be in an emergency to request a Response Team.</span>")
 				return
-			if(authenticated != 2 || issilicon(usr))
+			if(authenticated != 1 || issilicon(usr))
 				to_chat(usr, "<span class='warning'>\The [src.name]'s screen flashes, \"Access Denied\".</span>")
 				return
 


### PR DESCRIPTION
Follow-up to the discussion in #14837.
Closes #14837

:cl:
 * tweak: It is possible to call an ERT with a heads of staff ID, where previously a captain-access ID was needed. Also the ERT can be called once the shuttle is already en-route