### PR TITLE
Reapproach how lung popping works

### DIFF
--- a/code/modules/mob/living/carbon/human/life/handle_breath.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_breath.dm
@@ -60,9 +60,12 @@
 
 				breath = loc.remove_air(breath_moles)
 
-				if(!is_lung_ruptured())
-					if(!breath || breath.total_moles < BREATH_MOLES / 5 || breath.total_moles > BREATH_MOLES * 5)
-						if(prob(5)) //5 % chance for a lung rupture if air intake is less of a fifth, or more than five times the threshold
+				if(!breath || breath.total_moles < BREATH_MOLES / 5 || breath.total_moles > BREATH_MOLES * 5)
+					if(prob(15)) // 15% chance for lung damage if air intake is less of a fifth, or more than five times the threshold
+						L.damage += 1
+					if(!is_lung_ruptured())
+						var/chance_break = (L.damage / L.min_bruised_damage)*50 // Chance to rupture: 1/15 = 3%, 2/15 = 7%, etc...
+						if(prob(chance_break))
 							rupture_lung()
 
 				//Handle filtering

--- a/code/modules/organs/internal/lungs/filter.dm
+++ b/code/modules/organs/internal/lungs/filter.dm
@@ -3,6 +3,9 @@
 	name = "advanced lungs"
 	removed_type = /obj/item/organ/lungs/filter
 
+	min_bruised_damage = 15
+	min_broken_damage = 30
+
 	gasses = list()
 	var/list/intake_settings=list(
 		"oxygen" = list(

--- a/code/modules/organs/internal/lungs/lung.dm
+++ b/code/modules/organs/internal/lungs/lung.dm
@@ -8,6 +8,9 @@
 	parent_organ = LIMB_CHEST
 	removed_type = /obj/item/organ/lungs
 
+	min_bruised_damage = 8
+	min_broken_damage = 15
+
 	// /vg/ now delegates breathing to the appropriate organ.
 
 	// DEFAULTS FOR HUMAN LUNGS:
@@ -89,10 +92,10 @@
 			owner.audible_cough()		//respitory tract infection
 
 	if(is_bruised())
-		if(prob(2))
+		if(prob(((damage-min_bruised_damage)/min_broken_damage)*100))
 			spawn owner.emote("me", 1, "coughs up blood!")
 			owner.drip(10)
-		if(prob(4))
+		if(prob(((damage-min_bruised_damage)/min_broken_damage)*150))
 			spawn owner.emote("me", 1, "gasps for air!")
 			owner.losebreath += 5
 


### PR DESCRIPTION
Resurrects #14169 by halving those fukken values

:cl:
 * tweak: The probability of losing blood/breath scales with lung damage.
 * tweak: Being exposed to exceedingly low or high pressures now steadily damages your lungs instead of having a random chance of bursting. Advanced lungs have twice the resistance to damage compared to standard lungs.