### PR TITLE
Bringing back flavor text

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -603,6 +603,7 @@ its easier to just keep the beam vertical.
 			if(!istype(H.dna, /datum/dna))
 				H.dna = new /datum/dna(null)
 				H.dna.real_name = H.real_name
+				H.dna.flavor_text = H.dna.flavor_text
 		H.check_dna()
 
 		//Now, deal with gloves.

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -603,7 +603,7 @@ its easier to just keep the beam vertical.
 			if(!istype(H.dna, /datum/dna))
 				H.dna = new /datum/dna(null)
 				H.dna.real_name = H.real_name
-				H.dna.flavor_text = H.dna.flavor_text
+				H.dna.flavor_text = H.flavor_text
 		H.check_dna()
 
 		//Now, deal with gloves.

--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -126,6 +126,7 @@ var/global/list/facial_hair_styles_female_list	= list()
 	var/b_type = "A+"  // Should probably change to an integer => string map but I'm lazy.
 	var/mutantrace = null  // The type of mutant race the player is, if applicable (i.e. potato-man)
 	var/real_name          // Stores the real name of the person who originally got this dna datum. Used primarily for changelings,
+	var/flavor_text
 
 	// New stuff
 	var/species = "Human"
@@ -138,6 +139,7 @@ var/global/list/facial_hair_styles_female_list	= list()
 	new_dna.b_type=b_type
 	new_dna.mutantrace=mutantrace
 	new_dna.real_name=real_name
+	new_dna.flavor_text=flavor_text
 	new_dna.species=species
 	for(var/b=1;b<=DNA_SE_LENGTH;b++)
 		new_dna.SE[b]=SE[b]

--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -944,6 +944,7 @@
 				databuf.dna = src.connected.occupant.dna.Clone()
 				if(ishuman(connected.occupant))
 					databuf.dna.real_name=connected.occupant.name
+					databuf.dna.flavor_text=connected.occupant.flavor_text
 				databuf.name = "Unique Identifier"
 				src.buffers[bufferId] = databuf
 			return 1
@@ -958,6 +959,7 @@
 				databuf.dna = src.connected.occupant.dna.Clone()
 				if(ishuman(connected.occupant))
 					databuf.dna.real_name=connected.occupant.name
+					databuf.dna.flavor_text=connected.occupant.flavor_text
 				databuf.name = "Unique Identifier + Unique Enzymes"
 				src.buffers[bufferId] = databuf
 			return 1
@@ -972,6 +974,7 @@
 				databuf.dna = src.connected.occupant.dna.Clone()
 				if(ishuman(connected.occupant))
 					databuf.dna.real_name=connected.occupant.name
+					databuf.dna.flavor_text=connected.occupant.flavor_text
 				databuf.name = "Structural Enzymes"
 				src.buffers[bufferId] = databuf
 			return 1
@@ -1009,6 +1012,7 @@
 				if ((buf.types & DNA2_BUF_UE))
 					src.connected.occupant.real_name = buf.dna.real_name
 					src.connected.occupant.name = buf.dna.real_name
+					src.connected.occupant.flavor_text = buf.dna.flavor_text
 				src.connected.occupant.UpdateAppearance(buf.dna.UI.Copy())
 			else if (buf.types & DNA2_BUF_SE)
 				src.connected.occupant.dna.SE = buf.dna.SE

--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -974,7 +974,6 @@
 				databuf.dna = src.connected.occupant.dna.Clone()
 				if(ishuman(connected.occupant))
 					databuf.dna.real_name=connected.occupant.name
-					databuf.dna.flavor_text=connected.occupant.flavor_text
 				databuf.name = "Structural Enzymes"
 				src.buffers[bufferId] = databuf
 			return 1

--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -29,8 +29,9 @@
 			if(!(P in src.verbs))
 				verb_holder.verbs += P.verbpath
 
-	mind.changeling.absorbed_dna |= dna
 	var/mob/living/carbon/human/H = src
+	dna.flavor_text = H.flavor_text
+	mind.changeling.absorbed_dna |= dna
 	if(istype(H))
 		mind.changeling.absorbed_species |= H.species.name
 	for(var/language in languages)
@@ -312,6 +313,7 @@
 	add_attacklogs(src, T, "absorbed")
 
 	T.dna.real_name = T.real_name //Set this again, just to be sure that it's properly set.
+	T.dna.flavor_text = T.flavor_text
 	changeling.absorbed_dna |= T.dna
 
 	if(istype(src,/mob/living/carbon/human))
@@ -405,6 +407,7 @@
 	var/oldspecies = src.dna.species
 	src.dna = chosen_dna.Clone()
 	src.real_name = chosen_dna.real_name
+	src.flavor_text = chosen_dna.flavor_text
 	src.UpdateAppearance()
 	var/mob/living/carbon/human/H = src
 	if(istype(H) && oldspecies != dna.species)
@@ -508,6 +511,7 @@
 	O.dna = C.dna.Clone()
 	C.dna = null
 	O.real_name = chosen_dna.real_name
+	O.flavor_text = chosen_dna.flavor_text
 	C.remove_changeling_verb()
 
 	for(var/obj/item/W in src)
@@ -1101,6 +1105,7 @@ var/list/datum/dna/hivemind_bank = list()
 	target.visible_message("<span class='warning'>[target] transforms!</span>")
 	target.dna = chosen_dna.Clone()
 	target.real_name = chosen_dna.real_name
+	target.flavor_text = chosen_dna.flavor_text
 	target.UpdateAppearance()
 	domutcheck(target, null)
 	feedback_add_details("changeling_powers","TS")
@@ -1197,6 +1202,7 @@ var/list/datum/dna/hivemind_bank = list()
 		return
 
 	target.dna.real_name = target.real_name
+	target.dna.flavor_text = target.flavor_text
 	changeling.absorbed_dna |= target.dna
 	if(target.species && !(changeling.absorbed_species.Find(target.species.name)))
 		changeling.absorbed_species += target.species.name

--- a/code/game/gamemodes/heist/heist.dm
+++ b/code/game/gamemodes/heist/heist.dm
@@ -99,6 +99,7 @@
 		vox.fully_replace_character_name(vox.real_name, vox.generate_name())
 		//vox.languages = HUMAN // Removing language from chargen.
 		vox.default_language = all_languages[LANGUAGE_VOX]
+		vox.flavor_text = ""
 		vox.species.default_language = LANGUAGE_VOX
 		vox.remove_language(LANGUAGE_GALACTIC_COMMON)
 		vox.h_style = "Short Vox Quills"

--- a/code/game/objects/items/weapons/dna_injector.dm
+++ b/code/game/objects/items/weapons/dna_injector.dm
@@ -106,6 +106,7 @@
 					M.UpdateAppearance(buf.dna.UI.Copy())
 					if (buf.types & DNA2_BUF_UE) //unique enzymes? yes
 						M.real_name = buf.dna.real_name
+						M.flavor_text = buf.dna.flavor_text
 						M.name = buf.dna.real_name
 					uses--
 				else

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -160,6 +160,7 @@ var/const/MAX_SAVE_SLOTS = 8
 
 	var/list/player_alt_titles = new()		// the default name of a job like "Medical Doctor"
 
+	var/flavor_text = ""
 	var/med_record = ""
 	var/sec_record = ""
 	var/gen_record = ""
@@ -255,7 +256,8 @@ var/const/MAX_SAVE_SLOTS = 8
 	<b>Organs:</b> <a href='byond://?src=\ref[user];preference=organs;task=input'>Set</a><br>
 	<b>Underwear:</b> [gender == MALE ? "<a href ='?_src_=prefs;preference=underwear;task=input'><b>[underwear_m[underwear]]</a>" : "<a href ='?_src_=prefs;preference=underwear;task=input'><b>[underwear_f[underwear]]</a>"]<br>
 	<b>Backpack:</b> <a href ='?_src_=prefs;preference=bag;task=input'><b>[backbaglist[backbag]]</a><br>
-	<b>Nanotrasen Relation</b>:<br><a href ='?_src_=prefs;preference=nt_relation;task=input'><b>[nanotrasen_relation]</b></a>
+	<b>Nanotrasen Relation</b>:<br><a href ='?_src_=prefs;preference=nt_relation;task=input'><b>[nanotrasen_relation]</b></a><br>
+	<b>Flavor Text:</b><a href='byond://?src=\ref[user];preference=flavor_text;task=input'>Set</a><br>
 	</td><td valign='top' width='21%'>
 	<h3>Hair Style</h3>
 	<a href='?_src_=prefs;preference=h_style;task=input'>[h_style]</a><BR>
@@ -1257,6 +1259,13 @@ NOTE:  The change will take effect AFTER any current recruiting periods."}
 					if(new_relation)
 						nanotrasen_relation = new_relation
 
+				if("flavor_text")
+					var/msg = input(usr,"Set the flavor text in your 'examine' verb. This can also be used for OOC notes and preferences!","Flavor Text",html_decode(flavor_text)) as message
+					if(msg != null)
+						msg = copytext(msg, 1, MAX_MESSAGE_LEN)
+						msg = html_encode(msg)
+
+						flavor_text = msg
 				if("limbs")
 					var/list/limb_input = list(
 						"Left Leg [organ_data[LIMB_LEFT_LEG]]" = LIMB_LEFT_LEG,
@@ -1571,8 +1580,10 @@ NOTE:  The change will take effect AFTER any current recruiting periods."}
 
 	character.real_name = real_name
 	character.name = character.real_name
+	character.flavor_text = flavor_text
 	if(character.dna)
 		character.dna.real_name = character.real_name
+		character.dna.flavor_text = character.flavor_text
 
 	character.med_record = med_record
 	character.sec_record = sec_record

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -301,6 +301,7 @@ SELECT
     players.age,
     players.species,
     players.language,
+    players.flavor_text,
     players.med_record,
     players.sec_record,
     players.gen_record,
@@ -390,6 +391,7 @@ AND players.player_slot = ? ;"}, ckey, slot)
 	age 				= text2num(preference_list["age"])
 	species				= preference_list["species"]
 	language			= preference_list["language"]
+	flavor_text			= preference_list["flavor_text"]
 	med_record			= preference_list["med_record"]
 	sec_record			= preference_list["sec_record"]
 	gen_record			= preference_list["gen_record"]
@@ -564,6 +566,7 @@ AND players.player_slot = ? ;"}, ckey, slot)
 	S["job_engsec_low"]		>> job_engsec_low
 
 	//Miscellaneous
+	S["flavor_text"]		>> flavor_text
 	S["med_record"]			>> med_record
 	S["sec_record"]			>> sec_record
 	S["gen_record"]			>> gen_record
@@ -709,17 +712,17 @@ AND players.player_slot = ? ;"}, ckey, slot)
 	check.Add("SELECT player_ckey FROM players WHERE player_ckey = ? AND player_slot = ?", ckey, slot)
 	if(check.Execute(db))           // WHEN ADDING NEW COLUMNS, REMEMBER THE BLOCK AT THE END OF THE LINE --->
 		if(!check.NextRow())          //1         2           3         4          5               6       7    8        9         10          11          12          13                 14            15                   16                   1  2  3  4  5  6  7  8  9  10 11 12 13 14 15 16
-			q.Add("INSERT INTO players (player_ckey,player_slot,ooc_notes,real_name, random_name,    gender, age, species, language, med_record, sec_record, gen_record, player_alt_titles, disabilities, nanotrasen_relation, random_body) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+			q.Add("INSERT INTO players (player_ckey,player_slot,ooc_notes,real_name, random_name,    gender, age, species, language, flavor_text, med_record, sec_record, gen_record, player_alt_titles, disabilities, nanotrasen_relation, random_body) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                                   //1         2           3         4          5               6       7    8        9         10          11          12          13                 14            15                   16
-                                  ckey,       slot,       metadata, real_name, be_random_name, gender, age, species, language, med_record, sec_record, gen_record, altTitles,         disabilities, nanotrasen_relation, be_random_body)
+                                  ckey,       slot,       metadata, real_name, be_random_name, gender, age, species, language, flavor_text, med_record, sec_record, gen_record, altTitles,         disabilities, nanotrasen_relation, be_random_body)
 			if(!q.Execute(db))
 				message_admins("Error #:[q.Error()] - [q.ErrorMsg()]")
 				WARNING("Error #:[q.Error()] - [q.ErrorMsg()]")
 				return 0
 			to_chat(user, "Created Character")
 		else
-			q.Add("UPDATE players SET ooc_notes=?,real_name=?,random_name=?,gender=?,age=?,species=?,language=?,med_record=?,sec_record=?,gen_record=?,player_alt_titles=?,disabilities=?,nanotrasen_relation=?,random_body=? WHERE player_ckey = ? AND player_slot = ?",\
-									  metadata, real_name, be_random_name, gender, age, species, language, med_record, sec_record, gen_record, altTitles, disabilities, nanotrasen_relation, be_random_body, ckey, slot)
+			q.Add("UPDATE players SET ooc_notes=?,real_name=?,random_name=?,gender=?,age=?,species=?,language=?,flavor_text=?,med_record=?,sec_record=?,gen_record=?,player_alt_titles=?,disabilities=?,nanotrasen_relation=?,random_body=? WHERE player_ckey = ? AND player_slot = ?",\
+									  metadata, real_name, be_random_name, gender, age, species, language, flavor_text, med_record, sec_record, gen_record, altTitles, disabilities, nanotrasen_relation, be_random_body, ckey, slot)
 			if(!q.Execute(db))
 				message_admins("Error #:[q.Error()] - [q.ErrorMsg()]")
 				WARNING("Error #:[q.Error()] - [q.ErrorMsg()]")
@@ -843,6 +846,7 @@ AND players.player_slot = ? ;"}, ckey, slot)
 	S["age"]                   << age
 	S["species"]               << species
 	S["language"]              << language
+	S["flavor_text"]           << flavor_text
 	S["med_record"]            << med_record
 	S["sec_record"]            << sec_record
 	S["gen_record"]            << gen_record

--- a/code/modules/events/heist.dm
+++ b/code/modules/events/heist.dm
@@ -87,6 +87,7 @@ var/global/list/datum/mind/raiders = list()  //Antags.
 		vox.set_species("Vox")
 		vox.fully_replace_character_name(vox.real_name, vox.generate_name())
 		//vox.languages = HUMAN // Removing language from chargen.
+		vox.flavor_text = ""
 		vox.add_language(LANGUAGE_VOX)
 		vox.remove_language(LANGUAGE_GALACTIC_COMMON)
 		vox.h_style = "Short Vox Quills"

--- a/code/modules/medical/cloning.dm
+++ b/code/modules/medical/cloning.dm
@@ -235,6 +235,7 @@
 
 	//Get the clone body ready
 	H.dna = R.dna.Clone()
+	H.dna.flavor_text = R.dna.flavor_text
 	H.dna.species = R.dna.species
 	if(H.dna.species != "Human")
 		H.set_species(H.dna.species, 1)
@@ -284,6 +285,7 @@
 	for(var/datum/language/L in R.languages)
 		H.add_language(L.name)
 	H.real_name = H.dna.real_name
+	H.flavor_text = H.dna.flavor_text
 
 	H.suiciding = 0
 	return 1

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -472,8 +472,8 @@
 		msg += {"<span class = 'deptradio'>Physical status:</span> <a href='?src=\ref[src];medical=1'>\[[medical]\]</a>\n
 			<span class = 'deptradio'>Medical records:</span> <a href='?src=\ref[src];medrecord=`'>\[View\]</a> <a href='?src=\ref[src];medrecordadd=`'>\[Add comment\]</a>\n"}
 
-	if(print_flavor_text())
-		msg += "[print_flavor_text()]\n"
+	if(print_flavor_text(user))
+		msg += "[print_flavor_text(user)]\n"
 
 
 	msg += "*---------*</span>"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -472,6 +472,10 @@
 		msg += {"<span class = 'deptradio'>Physical status:</span> <a href='?src=\ref[src];medical=1'>\[[medical]\]</a>\n
 			<span class = 'deptradio'>Medical records:</span> <a href='?src=\ref[src];medrecord=`'>\[View\]</a> <a href='?src=\ref[src];medrecordadd=`'>\[Add comment\]</a>\n"}
 
+	if(print_flavor_text())
+		msg += "[print_flavor_text()]\n"
+
+
 	msg += "*---------*</span>"
 
 	to_chat(user, msg)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -178,6 +178,7 @@
 
 	if(dna)
 		dna.real_name = real_name
+		dna.flavor_text = flavor_text
 
 	prev_gender = gender // Debug for plural genders
 	make_blood()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1156,6 +1156,40 @@ var/list/slot_equipment_priority = list( \
 	face_atom(I)
 	I.verb_pickup(src)
 
+/mob/proc/update_flavor_text()
+	set src in usr
+
+	if(usr != src)
+		to_chat(usr, "No.")
+		return
+
+	var/msg = input(usr,"Set the flavor text in your 'examine' verb. Can also be used for OOC notes about your character.","Flavor Text",html_decode(flavor_text)) as message|null
+
+	if(msg != null)
+		msg = copytext(msg, 1, MAX_MESSAGE_LEN)
+		msg = html_encode(msg)
+
+		flavor_text = msg
+
+/mob/proc/warn_flavor_changed()
+	if(flavor_text) // Don't spam people that don't use it!
+		to_chat(src, "<h2 class='alert'>OOC Warning:</h2>")
+		to_chat(src, "<span class='alert'>Your flavor text is likely out of date! <a href='?src=\ref[src];flavor_text=change'>Change</a></span>")
+
+/mob/proc/print_flavor_text()
+    if(flavor_text)
+        var/msg = replacetext(flavor_text, "\n", "<br />")
+        if (ishuman(src))
+            var/mob/living/carbon/human/H = src
+            var/datum/organ/external/head/limb_head = H.get_organ(LIMB_HEAD)
+            if((wear_mask && (is_slot_hidden(wear_mask.body_parts_covered,HIDEFACE))) || (H.head && (is_slot_hidden(H.head.body_parts_covered,HIDEFACE))) || !limb_head || limb_head.disfigured || (limb_head.status & ORGAN_DESTROYED) || !real_name || (M_HUSK in mutations) ) //Wearing a mask, having no head, being disfigured, or being a husk means no flavor text for you.
+                return
+
+            if(length(msg) <= 32)
+                return "<font color='#ffa000'><b>[msg]</b></font>"
+            else
+                return "<font color='#ffa000'><b>[copytext(msg, 1, 32)]...<a href='?src=\ref[src];flavor_text=[user]'>More</a></b></font>"
+
 /mob/verb/abandon_mob()
 	set name = "Respawn"
 	set category = "OOC"
@@ -1370,6 +1404,11 @@ var/list/slot_equipment_priority = list( \
 	//	if(usr.client)
 	//		var/client/C = usr.client
 	//		C.JoinResponseTeam()
+
+ 	switch(href_list["flavor_text"])
+        if("more")
+            usr << browse(text("<HTML><HEAD><TITLE>[]</TITLE></HEAD><BODY><TT>[]</TT></BODY></HTML>", name, replacetext(flavor_text, "\n", "<BR>")), text("window=[];size=500x200", name))
+            onclose(usr, "[name]")
 
 /mob/MouseDrop(mob/M as mob)
 	..()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1156,26 +1156,6 @@ var/list/slot_equipment_priority = list( \
 	face_atom(I)
 	I.verb_pickup(src)
 
-/mob/proc/update_flavor_text()
-	set src in usr
-
-	if(usr != src)
-		to_chat(usr, "No.")
-		return
-
-	var/msg = input(usr,"Set the flavor text in your 'examine' verb. Can also be used for OOC notes about your character.","Flavor Text",html_decode(flavor_text)) as message|null
-
-	if(msg != null)
-		msg = copytext(msg, 1, MAX_MESSAGE_LEN)
-		msg = html_encode(msg)
-
-		flavor_text = msg
-
-/mob/proc/warn_flavor_changed()
-	if(flavor_text) // Don't spam people that don't use it!
-		to_chat(src, "<h2 class='alert'>OOC Warning:</h2>")
-		to_chat(src, "<span class='alert'>Your flavor text is likely out of date! <a href='?src=\ref[src];flavor_text=change'>Change</a></span>")
-
 /mob/proc/print_flavor_text(user)
     if(flavor_text)
         var/msg = replacetext(flavor_text, "\n", "<br />")

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1176,7 +1176,7 @@ var/list/slot_equipment_priority = list( \
 		to_chat(src, "<h2 class='alert'>OOC Warning:</h2>")
 		to_chat(src, "<span class='alert'>Your flavor text is likely out of date! <a href='?src=\ref[src];flavor_text=change'>Change</a></span>")
 
-/mob/proc/print_flavor_text()
+/mob/proc/print_flavor_text(user)
     if(flavor_text)
         var/msg = replacetext(flavor_text, "\n", "<br />")
         if (ishuman(src))
@@ -1188,7 +1188,7 @@ var/list/slot_equipment_priority = list( \
             if(length(msg) <= 32)
                 return "<font color='#ffa000'><b>[msg]</b></font>"
             else
-                return "<font color='#ffa000'><b>[copytext(msg, 1, 32)]...<a href='?src=\ref[src];flavor_text=more'>More</a></b></font>"
+                return "<font color='#ffa000'><b>[copytext(msg, 1, 32)]...<a href='?src=\ref[user];flavor_text=[flavor_text];target_name=[name]'>More</a></b></font>"
 
 /mob/verb/abandon_mob()
 	set name = "Respawn"
@@ -1396,19 +1396,19 @@ var/list/slot_equipment_priority = list( \
 	return
 
 /mob/Topic(href,href_list[])
-    if(href_list["mach_close"])
-        var/t1 = text("window=[href_list["mach_close"]]")
-        unset_machine()
-        src << browse(null, t1)
-    //if (href_list["joinresponseteam"])
-    //    if(usr.client)
-    //        var/client/C = usr.client
-    //        C.JoinResponseTeam()
+	if(href_list["mach_close"])
+		var/t1 = text("window=[href_list["mach_close"]]")
+		unset_machine()
+		src << browse(null, t1)
+	//if (href_list["joinresponseteam"])
+	//	if(usr.client)
+	//		var/client/C = usr.client
+	//		C.JoinResponseTeam()
 
-    switch(href_list["flavor_text"])
-        if("more")
-            usr << browse(text("<HTML><HEAD><TITLE>[]</TITLE></HEAD><BODY><TT>[]</TT></BODY></HTML>", name, replacetext(flavor_text, "\n", "<BR>")), text("window=[];size=500x200", name))
-            onclose(usr, "[name]")
+	if((href_list["flavor_text"]) && (href_list["target_name"]))
+		var/datum/browser/popup = new(src, "\ref[src]", href_list["target_name"], 500, 200)
+		popup.set_content(replacetext(href_list["flavor_text"], "\n", "<br>"))
+		popup.open()
 
 /mob/MouseDrop(mob/M as mob)
 	..()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1188,7 +1188,7 @@ var/list/slot_equipment_priority = list( \
             if(length(msg) <= 32)
                 return "<font color='#ffa000'><b>[msg]</b></font>"
             else
-                return "<font color='#ffa000'><b>[copytext(msg, 1, 32)]...<a href='?src=\ref[src];flavor_text=[user]'>More</a></b></font>"
+                return "<font color='#ffa000'><b>[copytext(msg, 1, 32)]...<a href='?src=\ref[src];flavor_text=more'>More</a></b></font>"
 
 /mob/verb/abandon_mob()
 	set name = "Respawn"
@@ -1396,16 +1396,16 @@ var/list/slot_equipment_priority = list( \
 	return
 
 /mob/Topic(href,href_list[])
-	if(href_list["mach_close"])
-		var/t1 = text("window=[href_list["mach_close"]]")
-		unset_machine()
-		src << browse(null, t1)
-	//if (href_list["joinresponseteam"])
-	//	if(usr.client)
-	//		var/client/C = usr.client
-	//		C.JoinResponseTeam()
+    if(href_list["mach_close"])
+        var/t1 = text("window=[href_list["mach_close"]]")
+        unset_machine()
+        src << browse(null, t1)
+    //if (href_list["joinresponseteam"])
+    //    if(usr.client)
+    //        var/client/C = usr.client
+    //        C.JoinResponseTeam()
 
- 	switch(href_list["flavor_text"])
+    switch(href_list["flavor_text"])
         if("more")
             usr << browse(text("<HTML><HEAD><TITLE>[]</TITLE></HEAD><BODY><TT>[]</TT></BODY></HTML>", name, replacetext(flavor_text, "\n", "<BR>")), text("window=[];size=500x200", name))
             onclose(usr, "[name]")

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -85,6 +85,7 @@
 	var/stuttering = null	//Carbon
 	var/slurring = null		//Carbon
 	var/real_name = null
+	var/flavor_text = ""
 	var/med_record = ""
 	var/sec_record = ""
 	var/gen_record = ""

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -438,6 +438,7 @@ Round Duration: [round(hours)]h [round(mins)]m<br>"}
 		new_character.setGender(pick(MALE, FEMALE))
 		client.prefs.real_name = random_name(new_character.gender, new_character.species.name)
 		client.prefs.randomize_appearance_for(new_character)
+		client.prefs.flavor_text = ""
 	else
 		client.prefs.copy_to(new_character)
 


### PR DESCRIPTION
This PR will bring back flavor text, reverting it's deletion some time ago.

Additionally, this adds a dna.flavor_text variable that has been used to fix changelings, cloning, and DNA modifiers to allow them to copy flavor text correctly. 

Another feature makes it so that your flavor text will not appear if your face isn't recognizable. 

These two fixes should prevent all of the metagaming problems that the previous incarnation of flavor text had. 

This is my first PR in a long time, so I may be doing this wrong. There may be ways to simplify my code, I don't really understand byond that well yet.

Thanks to DamianQ on discord for the help in bugfixes.

:cl:
 * rscadd: Flavor text re-enabled. Now, changelings and genetics can copy flavor text. Flavor text will not be visible if anything would cause your face to be unrecognizable.