### PR TITLE
Fixes shield gen circuit imprinter pathing

### DIFF
--- a/code/modules/research/designs/boards/machine_engie.dm
+++ b/code/modules/research/designs/boards/machine_engie.dm
@@ -244,7 +244,7 @@
 	req_tech = list(Tc_BLUESPACE = 4, Tc_PLASMATECH = 3)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 2000, SACID = 20, MAT_PLASMA = 10000, MAT_DIAMOND = 5000, MAT_GOLD = 10000)
-	build_path = "/obj/machinery/shield_gen/external"
+	build_path = "/obj/item/weapon/circuitboard/shield_gen_ex"
 
 /datum/design/shield_gen
 	name = "Circuit Design (Experimental shield generator)"
@@ -253,7 +253,7 @@
 	req_tech = list(Tc_BLUESPACE = 4, Tc_PLASMATECH = 3)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 2000, SACID = 20, MAT_PLASMA = 10000, MAT_DIAMOND = 5000, MAT_GOLD = 10000)
-	build_path = "/obj/machinery/shield_gen/external"
+	build_path = "/obj/machinery/shield_gen"
 
 /datum/design/shield_cap
 	name = "Circuit Design (Experimental shield capacitor)"
@@ -262,4 +262,4 @@
 	req_tech = list(Tc_MAGNETS = 3, Tc_POWERSTORAGE = 4)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 2000, SACID = 20, MAT_PLASMA = 10000, MAT_DIAMOND = 5000, MAT_SILVER = 10000)
-	build_path = "/obj/machinery/shield_gen/external"
+	build_path = "/obj/item/weapon/circuitboard/shield_cap"


### PR DESCRIPTION
fixes #14939
tested

🆑 
 - bugfix: Printing a shield generator circuit at a circuit imprinter now creates a circuit rather than the machine the circuit is for