### PR TITLE
Brands experimental shield generator as 'starscreen' shield generators

### DIFF
--- a/code/WorkInProgress/Cael_Aislinn/ShieldGen/circuits.dm
+++ b/code/WorkInProgress/Cael_Aislinn/ShieldGen/circuits.dm
@@ -3,8 +3,8 @@
 // External Shield Generator
 
 /obj/item/weapon/circuitboard/shield_gen_ex
-	name = "Circuit board (Experimental hull shield generator)"
-	desc = "A circuit board used to run an experimental hull shield generator."
+	name = "Circuit board (Starscreen-EX external shield generator)"
+	desc = "A circuit board used to run a Starscreen-EX external shield generator."
 	board_type = MACHINE
 	build_path = "/obj/machinery/shield_gen/external"
 	origin_tech = Tc_BLUESPACE + "=4;" + Tc_PLASMATECH + "=3"
@@ -20,8 +20,8 @@
 // Shield Generator
 
 /obj/item/weapon/circuitboard/shield_gen
-	name = "Circuit board (Experimental shield generator)"
-	desc = "A circuit board used to run an experimental shield generator."
+	name = "Circuit board (Starscreen shield generator)"
+	desc = "A circuit board used to run a Starscreen shield generator."
 	board_type = MACHINE
 	build_path = "/obj/machinery/shield_gen"
 	origin_tech = Tc_BLUESPACE + "=4;" + Tc_PLASMATECH + "=3"
@@ -37,8 +37,8 @@
 // Shield Capacitor
 
 /obj/item/weapon/circuitboard/shield_cap
-	name = "Circuit board (Experimental shield capacitor)"
-	desc = "A circuit board used to run an experimental shield capacitor."
+	name = "Circuit board (Starscreen shield capacitor)"
+	desc = "A circuit board used to run a Starscreen shield capacitor."
 	board_type = MACHINE
 	build_path = "/obj/machinery/shield_capacitor"
 	origin_tech = Tc_MAGNETS + "=3;" + Tc_POWERSTORAGE + "=4"

--- a/code/WorkInProgress/Cael_Aislinn/ShieldGen/energy_field.dm
+++ b/code/WorkInProgress/Cael_Aislinn/ShieldGen/energy_field.dm
@@ -2,8 +2,8 @@
 //---------- actual energy field
 
 /obj/effect/energy_field
-	name = "energy field"
-	desc = "Impenetrable field of energy, capable of blocking anything as long as it's active."
+	name = "energy wall"
+	desc = "Sparkles, tingles, and stops you in your tracks."
 	icon = 'code/WorkInProgress/Cael_Aislinn/ShieldGen/shielding.dmi'
 	icon_state = "shieldsparkles"
 	anchored = 1

--- a/code/WorkInProgress/Cael_Aislinn/ShieldGen/shield_capacitor.dm
+++ b/code/WorkInProgress/Cael_Aislinn/ShieldGen/shield_capacitor.dm
@@ -3,8 +3,8 @@
 //pulls energy out of a power net and charges an adjacent generator
 
 /obj/machinery/shield_capacitor
-	name = "shield capacitor"
-	desc = "Machine that charges a shield generator."
+	name = "starscreen shield capacitor"
+	desc = "Charges Starscreen shield generators."
 	icon = 'code/WorkInProgress/Cael_Aislinn/ShieldGen/shielding.dmi'
 	icon_state = "capacitor"
 	var/active = 1

--- a/code/WorkInProgress/Cael_Aislinn/ShieldGen/shield_capacitor.dm
+++ b/code/WorkInProgress/Cael_Aislinn/ShieldGen/shield_capacitor.dm
@@ -3,7 +3,7 @@
 //pulls energy out of a power net and charges an adjacent generator
 
 /obj/machinery/shield_capacitor
-	name = "Starscreen shield capacitor"
+	name = "\improper Starscreen shield capacitor"
 	desc = "Charges Starscreen shield generators."
 	icon = 'code/WorkInProgress/Cael_Aislinn/ShieldGen/shielding.dmi'
 	icon_state = "capacitor"

--- a/code/WorkInProgress/Cael_Aislinn/ShieldGen/shield_capacitor.dm
+++ b/code/WorkInProgress/Cael_Aislinn/ShieldGen/shield_capacitor.dm
@@ -3,7 +3,7 @@
 //pulls energy out of a power net and charges an adjacent generator
 
 /obj/machinery/shield_capacitor
-	name = "starscreen shield capacitor"
+	name = "Starscreen shield capacitor"
 	desc = "Charges Starscreen shield generators."
 	icon = 'code/WorkInProgress/Cael_Aislinn/ShieldGen/shielding.dmi'
 	icon_state = "capacitor"

--- a/code/WorkInProgress/Cael_Aislinn/ShieldGen/shield_gen.dm
+++ b/code/WorkInProgress/Cael_Aislinn/ShieldGen/shield_gen.dm
@@ -8,8 +8,8 @@
 //explosion damage is cumulative. if a tile is in range of light, medium and heavy damage, it will take a hit from all three
 
 /obj/machinery/shield_gen
-	name = "shield generator"
-	desc = "Machine that generates an impenetrable field of energy when activated."
+	name = "Starscreen shield generator"
+	desc = "Gnerates a box-shaped wall of energy when active."
 	icon = 'code/WorkInProgress/Cael_Aislinn/ShieldGen/shielding.dmi'
 	icon_state = "generator0"
 	var/active = 0

--- a/code/WorkInProgress/Cael_Aislinn/ShieldGen/shield_gen.dm
+++ b/code/WorkInProgress/Cael_Aislinn/ShieldGen/shield_gen.dm
@@ -9,7 +9,7 @@
 
 /obj/machinery/shield_gen
 	name = "Starscreen shield generator"
-	desc = "Gnerates a box-shaped wall of energy when active."
+	desc = "Generates a box-shaped wall of energy when active."
 	icon = 'code/WorkInProgress/Cael_Aislinn/ShieldGen/shielding.dmi'
 	icon_state = "generator0"
 	var/active = 0

--- a/code/WorkInProgress/Cael_Aislinn/ShieldGen/shield_gen.dm
+++ b/code/WorkInProgress/Cael_Aislinn/ShieldGen/shield_gen.dm
@@ -8,7 +8,7 @@
 //explosion damage is cumulative. if a tile is in range of light, medium and heavy damage, it will take a hit from all three
 
 /obj/machinery/shield_gen
-	name = "Starscreen shield generator"
+	name = "\improper Starscreen shield generator"
 	desc = "Generates a box-shaped wall of energy when active."
 	icon = 'code/WorkInProgress/Cael_Aislinn/ShieldGen/shielding.dmi'
 	icon_state = "generator0"

--- a/code/WorkInProgress/Cael_Aislinn/ShieldGen/shield_gen_external.dm
+++ b/code/WorkInProgress/Cael_Aislinn/ShieldGen/shield_gen_external.dm
@@ -3,6 +3,8 @@
 //generates an energy field that loops around any built up area in space (is useless inside) halts movement and airflow, is blocked by walls, windows, airlocks etc
 
 /obj/machinery/shield_gen/external/New()
+	name = "Starscreen-EX external shield generator"
+	desc = "Generates a hull-hugging wall of energy when active. Place near space."
 	..()
 
 /obj/machinery/shield_gen/external/get_shielded_turfs()

--- a/code/WorkInProgress/Cael_Aislinn/ShieldGen/shield_gen_external.dm
+++ b/code/WorkInProgress/Cael_Aislinn/ShieldGen/shield_gen_external.dm
@@ -3,7 +3,7 @@
 //generates an energy field that loops around any built up area in space (is useless inside) halts movement and airflow, is blocked by walls, windows, airlocks etc
 
 /obj/machinery/shield_gen/external
-	name = "Starscreen-EX external shield generator"
+	name = "\improper Starscreen-EX external shield generator"
 	desc = "Generates a hull-hugging wall of energy when active. Place near space."
 
 /obj/machinery/shield_gen/external/get_shielded_turfs()

--- a/code/WorkInProgress/Cael_Aislinn/ShieldGen/shield_gen_external.dm
+++ b/code/WorkInProgress/Cael_Aislinn/ShieldGen/shield_gen_external.dm
@@ -2,10 +2,9 @@
 //---------- external shield generator
 //generates an energy field that loops around any built up area in space (is useless inside) halts movement and airflow, is blocked by walls, windows, airlocks etc
 
-/obj/machinery/shield_gen/external/New()
+/obj/machinery/shield_gen/external
 	name = "Starscreen-EX external shield generator"
 	desc = "Generates a hull-hugging wall of energy when active. Place near space."
-	..()
 
 /obj/machinery/shield_gen/external/get_shielded_turfs()
 	var

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1340,19 +1340,19 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 
 /datum/supply_packs/shield_gen
 	contains = list(/obj/item/weapon/circuitboard/shield_gen)
-	name = "Exp. shield generator board"
+	name = "Starscreen generator board"
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure/engisec
-	containername = "experimental shield generator crate"
+	containername = "Starscreen shield generator crate"
 	group = "Engineering"
 	access = access_ce
 
 /datum/supply_packs/shield_cap
 	contains = list(/obj/item/weapon/circuitboard/shield_cap)
-	name = "Exp. shield capacitor board"
+	name = "Starscreen capacitor board"
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure/engisec
-	containername = "experimental shield capacitor crate"
+	containername = "Starscreen shield capacitor crate"
 	group = "Engineering"
 	access = access_ce
 

--- a/code/modules/research/designs/boards/machine_engie.dm
+++ b/code/modules/research/designs/boards/machine_engie.dm
@@ -238,8 +238,8 @@
 //Cael shield gen designs.
 
 /datum/design/shield_gen_ex
-	name = "Circuit Design (Experimental hull shield generator)"
-	desc = "Allows for the construction of circuit boards used to build an experimental hull shield generator."
+	name = "Circuit Design (Starscreen-EX External shield generator)"
+	desc = "Allows for the construction of circuit boards used to build a Starscreen-EX external shield generator."
 	id = "shield_gen"
 	req_tech = list(Tc_BLUESPACE = 4, Tc_PLASMATECH = 3)
 	build_type = IMPRINTER
@@ -247,8 +247,8 @@
 	build_path = "/obj/machinery/shield_gen/external"
 
 /datum/design/shield_gen
-	name = "Circuit Design (Experimental shield generator)"
-	desc = "Allows for the construction of circuit boards used to build an experimental shield generator."
+	name = "Circuit Design (Starscreen shield generator)"
+	desc = "Allows for the construction of circuit boards used to build a Starscreen shield generator."
 	id = "shield_gen"
 	req_tech = list(Tc_BLUESPACE = 4, Tc_PLASMATECH = 3)
 	build_type = IMPRINTER
@@ -256,8 +256,8 @@
 	build_path = "/obj/machinery/shield_gen/external"
 
 /datum/design/shield_cap
-	name = "Circuit Design (Experimental shield capacitor)"
-	desc = "Allows for the construction of circuit boards used to build an experimental shielding capacitor."
+	name = "Circuit Design (Starscreen shield capacitor)"
+	desc = "Allows for the construction of circuit boards used to build a Starscreen shield capacitor."
 	id = "shield_cap"
 	req_tech = list(Tc_MAGNETS = 3, Tc_POWERSTORAGE = 4)
 	build_type = IMPRINTER


### PR DESCRIPTION
Brans the experimental shield generators and their related circuits as 'Starscreen'.
Only the front-end is affected; no paths or object names were changed.
Also fixes  #14940
Tested.

:cl:
 - spellcheck: Branded the formerly experimental shield generators as 'Starscreen' shield generators