### PR TITLE
Butt replacement surgery

### DIFF
--- a/code/modules/surgery/butt.dm
+++ b/code/modules/surgery/butt.dm
@@ -163,5 +163,187 @@
 	playsound(get_turf(src), 'sound/effects/holler.ogg', 50, 1)
 
 
+//////////////////////////////////////////////////////////////////
+//						BUTT REPLACE							//
+//////////////////////////////////////////////////////////////////
+
+/datum/surgery_step/butt_replace
+	/datum/surgery_step/butt_replace/priority = 2 //this is more important than anything else!
+	/datum/surgery_step/butt_replace/can_infect = 0
+	/datum/surgery_step/butt_replace/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+		return target_zone == LIMB_GROIN && hasorgans(target)
+
+
+/////PULL FLESH////////
+/datum/surgery_step/butt_replace/peel
+	allowed_tools = list(
+		/obj/item/weapon/retractor = 100,
+		/obj/item/weapon/crowbar = 75,
+		/obj/item/weapon/kitchen/utensil/fork = 50,
+		)
+
+	min_duration = 80
+	max_duration = 100
+
+/datum/surgery_step/butt_replace/peel/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	return ..() && target.op_stage.butt_replace == 0 && target.op_stage.butt == 4 && istype(target)
+
+
+/datum/surgery_step/butt_replace/peel/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	user.visible_message("[user] peels back tattered flesh where [target]'s butt used to be with \the [tool].", \
+	"You start peeling back tattered flesh where [target]'s butt used to be with \the [tool].")
+	..()
+
+/datum/surgery_step/butt_replace/peel/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	user.visible_message("<span class='notice'>[user] peels back tattered flesh where [target]'s butt used to be with \the [tool].</span>",		\
+	"<span class='notice'>You peel back tattered flesh where [target]'s butt used to be with \the [tool].</span>")
+	target.op_stage.butt_replace = 1
+
+/datum/surgery_step/butt_replace/peel/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	var/datum/organ/external/affected = target.get_organ(target_zone)
+	user.visible_message("<span class='warning'>[user]'s hand slips, ripping [target]'s [affected.display_name] open!</span>", \
+	"<span class='warning'>Your hand slips,  ripping [target]'s [affected.display_name] open!</span>")
+	target.apply_damage(10, BRUTE, affected)
+
+//////REPAIR HIPS///////
+/datum/surgery_step/butt_replace/hips
+	allowed_tools = list(
+		/obj/item/weapon/bonegel = 100,
+		/obj/item/weapon/screwdriver = 75,
+		)
+
+	min_duration = 50
+	max_duration = 60
+
+/datum/surgery_step/butt_replace/hips/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	return ..() && target.op_stage.butt_replace == 1 && istype(target)
+
+
+/datum/surgery_step/butt_replace/hips/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	user.visible_message("[user] starts to mend [target]'s shortened hip bones with \the [tool].", \
+	"You start to mend [target]'s shortened hip bones with with \the [tool].")
+	..()
+
+/datum/surgery_step/butt_replace/hips/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	user.visible_message("<span class='notice'>[user] has restored [target]'s hip bones to their original state with \the [tool].</span>",	\
+	"<span class='notice'>You have restored [target]'s hip bones to their original state with \the [tool].</span>")
+	target.op_stage.butt_replace = 2
+
+/datum/surgery_step/bbutt_replace/hips/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	var/datum/organ/external/affected = target.get_organ(target_zone)
+	user.visible_message("<span class='warning'>[user]'s hand slips, smearing [tool] on the delicate tissues in [target]'s hindquarters!</span>", \
+	"<span class='warning'>Your hand slips, smearing [tool] on the delicate tissues in [target]'s hindquarters!</span>")
+	target.apply_damage(10, BRUTE, affected)
+
+
+//////SHAPE///////
+/datum/surgery_step/butt_replace/shape
+	allowed_tools = list(
+		/obj/item/weapon/FixOVein = 100,
+		/obj/item/stack/cable_coil = 75,
+		/obj/item/device/assembly/mousetrap = 10,	//ok chinsky
+		)
+
+	min_duration = 80
+	max_duration = 100
+
+/datum/surgery_step/butt_replace/shape/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	return ..() && target_zone == LIMB_GROIN && target.op_stage.butt_replace == 2 && istype(target)
+
+
+/datum/surgery_step/butt_replace/shape/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	user.visible_message("[user] is beginning to reshape [target]'s anus and gluteal tendons with \the [tool].", \
+	"You start to reshape [target]'s anus and gluteal tendons with \the [tool].")
+	..()
+
+/datum/surgery_step/butt_replace/shape/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	user.visible_message("<span class='notice'>[user] has finished repositioning flesh and tissue to something anatomically recognizable where [target]'s butt used to be with \the [tool].</span>",	\
+	"<span class='notice'>You have finished repositioning flesh and tissue to something anatomically recognizable where [target]'s butt used to be with \the [tool].</span>")
+	target.op_stage.butt_replace = 3
+
+/datum/surgery_step/butt_replace/shape/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	var/datum/organ/external/affected = target.get_organ(target_zone)
+	user.visible_message("<span class='warning'>[user]'s hand slips, further rending flesh on [target]'s backside!</span>", \
+	"<span class='warning'>Your hand slips, further rending flesh on [target]'s backside!</span>")
+	target.apply_damage(10, BRUTE, affected)
+
+//////ATTACH//////
+/datum/surgery_step/butt_replace/attach
+	allowed_tools = list(
+		/obj/item/clothing/head/butt = 100,
+		)
+
+	min_duration = 80
+	max_duration = 100
+
+/datum/surgery_step/butt_replace/attach/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	return ..() && target.op_stage.butt_replace == 3 && istype(target)
+
+/datum/surgery_step/butt_replace/attach/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	user.visible_message("[user] starts attaching [tool] to [target]'s reshaped backside.", \
+	"You start attaching [tool] to [target]'s reshaped backside.")
+
+/datum/surgery_step/butt_replace/attach/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	var/datum/organ/external/affected = target.get_organ(target_zone)
+	user.visible_message("<span class='notice'>[user] has attached [target]'s new butt to the body.</span>",	\
+	"<span class='notice'>You have attached [target]'s new butt to the body.</span>")
+
+	target.op_stage.butt = 0
+	target.op_stage.butt_replace = 4
+	affected.open = 1
+	affected.status |= ORGAN_BLEEDING
+
+	var/obj/item/clothing/head/butt/B = tool
+	user.u_equip(B,1)
+	qdel(B)
+
+
+/datum/surgery_step/butt_replace/attach/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	var/datum/organ/external/affected = target.get_organ(target_zone)
+	user.visible_message("<span class='warning'>[user]'s hand slips, damaging connectors on [target]'s backside!</span>", \
+	"<span class='warning'>Your hand slips, damaging connectors on [target]'s backside!</span>")
+	target.apply_damage(10, BRUTE, affected)
+
+
+///////CAUTERIZE NEW BUTT/////////
+/datum/surgery_step/butt_replace/cauterize/tool_quality(obj/item/tool)
+	if(tool.is_hot())
+		for (var/T in allowed_tools)
+			if (istype(tool,T))
+				return allowed_tools[T]
+	return 0
+/datum/surgery_step/butt_replace/cauterize
+	allowed_tools = list(
+		/obj/item/weapon/cautery = 100,
+		/obj/item/weapon/scalpel/laser = 100,
+		/obj/item/clothing/mask/cigarette = 75,
+		/obj/item/weapon/lighter = 50,
+		/obj/item/weapon/weldingtool = 25,
+		)
+
+	min_duration = 50
+	max_duration = 70
+
+/datum/surgery_step/butt_replace/cauterize/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	return ..() && target_zone == LIMB_GROIN && target.op_stage.butt == 3
+
+/datum/surgery_step/butt_replace/cauterize/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	user.visible_message("[user] begins to cauterize [target]'s ass with \the [tool].", \
+	"You begin to cauterize [target]'s ass with \the [tool].")
+	..()
+
+/datum/surgery_step/butt_replace/cauterize/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	var/datum/organ/external/affected = target.get_organ(target_zone)
+	user.visible_message("<span class='notice'>[user] finishes cauterizing [target]'s ass with \the [tool].</span>",		\
+	"<span class='notice'>You have cauterized [target]'s ass with \the [tool].</span>")
+	target.op_stage.butt_replace = 0
+	affected.open = 0
+	affected.clamp()
+
+/datum/surgery_step/butt_replace/cauterize/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	user.visible_message("<span class='warning'>[user]'s hand slips, burning the flesh around [target]'s butt with /the [tool]!</span>" , \
+	"<span class='warning'>Your hand slips, burning the flesh around [target]'s butt with /the [tool]!</span>" )
+	target.apply_damage(max(10, tool.force), BURN, LIMB_GROIN)
+
 
 //why god. //I know right.

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -169,6 +169,7 @@ proc/sort_surgeries()
 	var/appendix =	0
 	var/ribcage = 0
 	var/butt = 0
+	var/butt_replace = 0
 	var/genitals = 0
 	var/head_reattach = 0
 	var/current_organ


### PR DESCRIPTION
You've all been asking for it, here it is.

Butts are now replaceable with the following steps:
Retractor -> Boneglue -> FixOVein -> Butt -> Cautery

Can be completed with ghetto tools too.

Due to exploit concerns (buttbots), butts cannot be printed from the bioprinter.

:cl: 
 * rscadd: Butts are now replaceable with the following surgery: Retractor -> Boneglue -> FixOVein -> Butt -> Cautery