### PR TITLE
keycard auth timer adjustment

### DIFF
--- a/code/modules/security levels/keycard authentication.dm
+++ b/code/modules/security levels/keycard authentication.dm
@@ -9,7 +9,7 @@ var/global/list/obj/machinery/keycard_auth/authenticators = list()
 	var/event = ""
 	var/screen = 1
 	var/confirmed = 0 //This variable is set by the device that confirms the request.
-	var/confirm_delay = 20 //(2 seconds)
+	var/confirm_delay = 5 SECONDS
 	var/busy = 0 //Busy when waiting for authentication or an event request has been sent from this device.
 	var/obj/machinery/keycard_auth/event_source
 	var/mob/event_triggered_by


### PR DESCRIPTION
As an aside, it takes this amount of time for the event to trigger, even if you confirm it 1 second in.

:cl:
* tweak: Keycard authenticators now allow up to 5 seconds to slide your card to confirm, up from 2.