### PR TITLE
Heist Mode Improvements

### DIFF
--- a/code/game/gamemodes/heist/heist.dm
+++ b/code/game/gamemodes/heist/heist.dm
@@ -142,9 +142,12 @@
 	return TRUE
 
 /datum/game_mode/heist/proc/forge_vox_objectives()
-	if(prob(25))
+	if(prob(50))
 		raid_objectives += new/datum/objective/heist/kidnap
-	raid_objectives += new/datum/objective/steal/heist
+	else
+		raid_objectives += new/datum/objective/steal/heist_easy
+		raid_objectives += new/datum/objective/steal/heist_easy
+	raid_objectives += new/datum/objective/steal/heist_hard
 	//raid_objectives += new/datum/objective/steal/salvage
 	raid_objectives += new/datum/objective/heist/inviolate_crew
 	//raid_objectives += new/datum/objective/heist/inviolate_death // Crew death permitted. No tears.
@@ -154,6 +157,7 @@
 
 	for(var/datum/objective/steal/O in raid_objectives)
 		O.find_target()
+
 
 /datum/game_mode/heist/proc/greet_vox(const/datum/mind/raider)
 	to_chat(raider.current, {"<span class='notice'><B>You are a Vox Raider, fresh from the Shoal!</b>

--- a/code/game/gamemodes/heist/objectives.dm
+++ b/code/game/gamemodes/heist/objectives.dm
@@ -282,7 +282,7 @@
 	return (valid_organs >= required_amount)
 
 /datum/theft_objective/number/heist_hard/organs/appendix
-	name = "lungs"
+	name = "appendixes"
 	typepath = /obj/item/organ/appendix
 	min = 3
 	max = 6

--- a/code/game/gamemodes/heist/objectives.dm
+++ b/code/game/gamemodes/heist/objectives.dm
@@ -17,7 +17,7 @@
  */
 
 /datum/objective/heist/kidnap/choose_target()
-	var/list/roles = list("Chief Engineer", "Research Director", "Roboticist", "Chemist", "Station Engineer")
+	var/list/roles = list("Chief Engineer", "Research Director", "Roboticist", "Chemist", "Medical Doctor", "Janitor", "Bartender")
 
 	for(var/role in shuffle(roles))
 		find_target_by_role(role)
@@ -80,16 +80,25 @@
  * heist
  */
 
-/datum/objective/steal/heist
-	target_category = "heist"
+/datum/objective/steal/heist_easy
+	target_category = "heist_easy"
 
-/datum/objective/steal/heist/format_explanation()
-	return "We are lacking in hardware. Steal [steal_target.name]."
+/datum/objective/steal/heist_hard
+	target_category = "heist_hard"
 
-/datum/theft_objective/number/heist
+/datum/objective/steal/heist_easy/format_explanation()
+	return "We are lacking in some trivial devices. Steal [steal_target.name]."
+
+/datum/objective/steal/heist_hard/format_explanation()
+	return "We are lacking in expensive hardware or bioware. Steal [steal_target.name]."
+
+/datum/theft_objective/number/heist_easy
 	areas = list(/area/shuttle/vox/station)
 
-/datum/theft_objective/number/heist/check_completion()
+/datum/theft_objective/number/heist_hard
+	areas = list(/area/shuttle/vox/station)
+
+/datum/theft_objective/number/heist_easy/check_completion()
 	var/list/search = list()
 	var/found = 0
 	for(var/A in areas)
@@ -99,29 +108,15 @@
 		found++
 	return (found >= required_amount)
 
-/datum/theft_objective/number/heist/particle_accelerator
-	name = "complete particle accelerator"
-	typepath = /obj/structure/particle_accelerator
-	min = 1
-	max = 1
-
-/datum/theft_objective/number/heist/particle_accelerator/check_completion()
-	var/list/contents = list(/obj/structure/particle_accelerator/end_cap, \
-							/obj/structure/particle_accelerator/fuel_chamber, \
-							/obj/structure/particle_accelerator/particle_emitter/center, \
-							/obj/structure/particle_accelerator/particle_emitter/left, \
-							/obj/structure/particle_accelerator/particle_emitter/right, \
-							/obj/structure/particle_accelerator/power_box,)
+/datum/theft_objective/number/heist_hard/check_completion()
 	var/list/search = list()
+	var/found = 0
 	for(var/A in areas)
 		var/area/B = locate(A)
-		search += recursive_type_check(B, /obj/structure/particle_accelerator)
-	for(var/C in contents)
-		for(var/atom/A in search)
-			if(istype(A,C)) //Does search contain this part type
-				continue
-			return FALSE //It didn't, fail the object
-	return TRUE
+		search += recursive_type_check(B, typepath)
+	for(var/C in search)
+		found++
+	return (found >= required_amount)
 
 /* LAME
 /datum/theft_objective/number/heist/singulogen
@@ -143,25 +138,137 @@
 	max = 4
 */
 
-/datum/theft_objective/number/heist/nuke
-	name = "thermonuclear device"
-	typepath = /obj/machinery/nuclearbomb
-	min = 1
-	max = 1
+///easy objectives (near the outside of the station or common///
 
-/datum/theft_objective/number/heist/gun
+/datum/theft_objective/number/heist_easy/gun
 	name = "guns"
 	typepath = /obj/item/weapon/gun
-	min = 6
+	min = 4
 	max = 6
 
-/datum/theft_objective/number/heist/supermatter
+/datum/theft_objective/number/heist_easy/supermatter
 	name = "supermatter shard"
 	typepath = /obj/machinery/power/supermatter/shard
 	min = 1
 	max = 1
 
-/datum/theft_objective/number/heist/organs/check_completion()
+/datum/theft_objective/number/heist_easy/jukebox
+	name = "jukebox"
+	typepath = /obj/machinery/media/jukebox
+	min = 1
+	max = 1
+
+/datum/theft_objective/number/heist_easy/microwave
+	name = "microwave ovens"
+	typepath = /obj/machinery/microwave
+	min = 2
+	max = 2
+
+/datum/theft_objective/number/heist_easy/camera
+	name = "polaroid cameras"
+	typepath = /obj/item/device/camera
+	min = 4
+	max = 4
+
+/datum/theft_objective/number/heist_easy/canister
+	name = "canister of plasma"
+	typepath = /obj/machinery/portable_atmospherics/canister/plasma
+	min = 1
+	max = 1
+
+/datum/theft_objective/number/heist_easy/plants
+	name = "house plants"
+	typepath = /obj/structure/flora
+	min = 6
+	max = 10
+
+/datum/theft_objective/number/heist_easy/borgrecharger
+	name = "cyborg recharging stations"
+	typepath = /obj/machinery/recharge_station
+	min = 2
+	max = 2
+
+/datum/theft_objective/number/heist_easy/fueltank
+	name = "welding fuel tanks"
+	typepath = /obj/structure/reagent_dispensers/fueltank
+	min = 2
+	max = 4
+
+/datum/theft_objective/number/heist_easy/filingcabinet
+	name = "filing cabinets"
+	typepath = /obj/structure/filingcabinet
+	min = 2
+	max = 4
+
+///hard objectives (near the inside of the station or rare///
+
+/datum/theft_objective/number/heist_hard/particle_accelerator
+	name = "complete and assembled particle accelerator"
+	typepath = /obj/structure/particle_accelerator
+	min = 1
+	max = 1
+
+/datum/theft_objective/number/heist_hard/particle_accelerator/check_completion()
+	var/list/contents = list(/obj/structure/particle_accelerator/end_cap, \
+							/obj/structure/particle_accelerator/fuel_chamber, \
+							/obj/structure/particle_accelerator/particle_emitter/center, \
+							/obj/structure/particle_accelerator/particle_emitter/left, \
+							/obj/structure/particle_accelerator/particle_emitter/right, \
+							/obj/structure/particle_accelerator/power_box,)
+	var/list/search = list()
+	for(var/A in areas)
+		var/area/B = locate(A)
+		search += recursive_type_check(B, /obj/structure/particle_accelerator)
+	for(var/C in contents)
+		for(var/atom/A in search)
+			if(istype(A,C)) //Does search contain this part type
+				continue
+			return FALSE //It didn't, fail the object
+	return TRUE
+
+/datum/theft_objective/number/heist_hard/nuke
+	name = "thermonuclear device"
+	typepath = /obj/machinery/nuclearbomb
+	min = 1
+	max = 1
+
+/datum/theft_objective/number/heist_hard/cat
+	name = "cat"
+	typepath = /mob/living/simple_animal/cat
+	min = 1
+	max = 1
+
+/datum/theft_objective/number/heist_hard/duck
+	name = "rubber ducky"
+	typepath = /obj/item/weapon/bikehorn/rubberducky
+	min = 1
+	max = 1
+
+/datum/theft_objective/number/heist_hard/borgupload
+	name = "cyborg upload console circuit board"
+	typepath = /obj/item/weapon/circuitboard/borgupload
+	min = 1
+	max = 1
+
+/datum/theft_objective/number/heist_hard/amplifier
+	name = "subspace amplifiers"
+	typepath = /obj/item/weapon/stock_parts/subspace/amplifier
+	min = 4
+	max = 6
+
+/datum/theft_objective/number/heist_hard/clownmask
+	name = "clown's mask"
+	typepath = /obj/item/clothing/mask/gas/clown_hat
+	min = 1
+	max = 1
+
+/datum/theft_objective/number/heist_hard/piano
+	name = "space piano"
+	typepath = /obj/structure/piano
+	min = 1
+	max = 1
+
+/datum/theft_objective/number/heist_hard/organs/check_completion()
 	var/list/search = list()
 	for(var/A in areas)
 		var/area/B = locate(A)
@@ -174,13 +281,13 @@
 				valid_organs++
 	return (valid_organs >= required_amount)
 
-/datum/theft_objective/number/heist/organs/lungs
+/datum/theft_objective/number/heist_hard/organs/appendix
 	name = "lungs"
-	typepath = /obj/item/organ/lungs
+	typepath = /obj/item/organ/appendix
 	min = 3
 	max = 6
 
-/datum/theft_objective/number/heist/organs/eyes
+/datum/theft_objective/number/heist_hard/organs/eyes
 	name = "eyes"
 	typepath = /obj/item/organ/eyes
 	min = 3

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -3,7 +3,8 @@
 var/list/potential_theft_objectives=list(
 	"traitor" = typesof(/datum/theft_objective/traitor) - /datum/theft_objective/traitor,
 	"special" = typesof(/datum/theft_objective/special) - /datum/theft_objective/special,
-	"heist"   = typesof(/datum/theft_objective/number/heist) - /datum/theft_objective/number/heist
+	"heist_easy"   = typesof(/datum/theft_objective/number/heist_easy) - /datum/theft_objective/number/heist_easy,
+	"heist_hard"   = typesof(/datum/theft_objective/number/heist_hard) - /datum/theft_objective/number/heist_hard,
 	//"salvage" = typesof(/datum/theft_objective/number/salvage) - /datum/theft_objective/number/salvage
 )
 

--- a/code/game/shuttles/vox.dm
+++ b/code/game/shuttles/vox.dm
@@ -45,14 +45,18 @@ var/global/datum/shuttle/vox/vox_shuttle = new(starting_area=/area/shuttle/vox/s
 
 /datum/shuttle/vox/travel_to(var/obj/docking_port/D, var/obj/machinery/computer/shuttle_control/broadcast = null, var/mob/user)
 	if(D == dock_home)
-		if(ticker && istype(ticker.mode, /datum/game_mode/heist))
-			switch(alert(usr,"Returning to the deep space will end your raid and report your success or failure. Are you sure?","Vox Skipjack","Yes","No"))
-				if("Yes")
-					var/location = get_turf(user)
-					message_admins("[key_name_admin(user)] attempts to end the raid - [formatJumpTo(location)]")
-					log_admin("[key_name(user)] attempts to end the raid - [formatLocation(location)]")
-				if("No")
-					return
+		if(world.time < 6000)
+			to_chat(user, "<span class='notice'>Error: Bluespace engines are still cooling. We will be ready to return home in: [round(((6000 - world.time) / 10) / 60)] minutes.</span>")
+			return
+		else
+			if(ticker && istype(ticker.mode, /datum/game_mode/heist))
+				switch(alert(usr,"Returning to the deep space will end your raid and report your success or failure. Are you sure?","Vox Skipjack","Yes","No"))
+					if("Yes")
+						var/location = get_turf(user)
+						message_admins("[key_name_admin(user)] attempts to end the raid - [formatJumpTo(location)]")
+						log_admin("[key_name(user)] attempts to end the raid - [formatLocation(location)]")
+					if("No")
+						return
 	.=..()
 
 /datum/shuttle/vox/after_flight()

--- a/code/modules/events/heist.dm
+++ b/code/modules/events/heist.dm
@@ -155,11 +155,15 @@ var/global/list/datum/mind/raiders = list()  //Antags.
 	objs += new /datum/objective/heist/inviolate_crew
 	objs += new /datum/objective/heist/inviolate_death */
 
-	if(prob(25)) // This is an asspain.
-		raid_objectives += new /datum/objective/heist/kidnap
-	raid_objectives += new /datum/objective/steal/heist
-	//raid_objectives += new /datum/objective/steal/salvage
-	raid_objectives += new /datum/objective/heist/inviolate_crew
+
+	if(prob(50))
+		raid_objectives += new/datum/objective/heist/kidnap
+	else
+		raid_objectives += new/datum/objective/steal/heist_easy
+		raid_objectives += new/datum/objective/steal/heist_easy
+	raid_objectives += new/datum/objective/steal/heist_hard
+	//raid_objectives += new/datum/objective/steal/salvage
+	raid_objectives += new/datum/objective/heist/inviolate_crew
 	raid_objectives += new /datum/objective/heist/inviolate_death
 
 	for(var/datum/objective/heist/O in raid_objectives)


### PR DESCRIPTION
Everyone complains about heist mode being too fast. I have made this PR with the following suggested changes:

First, Raiders will now have multiple goals. Either two "easy" thefts, or one kidnap, and always one "hard" theft.

Second, with the theft goals split into two types, now raiders will need to plan a little better. Hard theft goals are things deep inside the station, or few in number. These include the complete particle accelerator, the nuke, one of the station's cats, a rubber ducky, a cyborg upload module, 4-6 subspace amplifiers (will require disassembling telecoms), the clown's mask, or human organs ("lungs" goal replaced with "appendix", because it didn't make sense to both try to minimize casualties and fatally wound people)

Easy objectives include: 4-6 guns, the supermatter shard, a jukebox, microwaves, cameras, plants, cyborg rechargers, fuel tanks, a plasma canister, and filing cabinets.

Objectives were chosen mostly based on their locations on Box, and to differentiate them from normal traitor objectives, plus humor, since who knows what goes on in the minds of Vox.

Third, I expanded the list of possible job roles that could be selected for kidnapping, and removed engineers. The previous list was almost exclusively jobs that worked near the edge of the station, making them easy to capture.

Finally, I added a 10 minute timer at round start to prevent the Vox from just heading home right away.

PLEASE REVIEW THIS VERY CAREFULLY. I have successfully compiled it, but I have not tested it, because I am not sure how.

:cl: 
 * rscadd: Heist mode tweaked. Now, the Vox Raiders will have one 'hard' theft goal, and then the possibility of a 'kidnap' goal or two 'easy' theft goals. 
* rscadd: There is also now a 10 minute timer that prevents Vox Raiders from instantly ending the round.
