### PR TITLE
Fixes two fucking stupid bugs with APC construction, and also optimizes get_area()

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -8,19 +8,9 @@
 	return null
 
 /proc/get_area(const/atom/O)
-	if (isnull(O))
-		return
-
-	var/atom/A = O
-
-	for (var/i = 0, ++i <= 16)
-		if (isarea(A))
-			return A
-
-		if (istype(A))
-			A = A.loc
-		else
-			return
+	var/turf/T = get_turf(O)
+	if(T)
+		return T.loc
 
 /proc/get_area_master(const/O)
 	var/area/A = get_area(O)

--- a/code/game/objects/items/mountable_frames/apc_frame.dm
+++ b/code/game/objects/items/mountable_frames/apc_frame.dm
@@ -19,8 +19,9 @@
 /obj/item/mounted/frame/apc_frame/try_build(turf/on_wall, mob/user)
 	if(..())
 		var/turf/turf_loc = get_turf(user)
+		var/area/area_loc = turf_loc.loc
 
-		if (areaMaster.areaapc)
+		if (area_loc.areaapc)
 			to_chat(user, "<span class='rose'>This area already has an APC.</span>")
 			return //only one APC per area
 		for(var/obj/machinery/power/terminal/T in turf_loc)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -113,6 +113,12 @@
 
 /obj/machinery/power/apc/New(loc, var/ndir, var/building=0)
 	..(loc)
+
+	if(areaMaster.areaapc)
+		world.log << "Second APC detected in area: [areaMaster.name]. Deleting the second APC."
+		qdel(src)
+		return
+
 	wires = new(src)
 	// offset 24 pixels in direction of dir
 	// this allows the APC to be embedded in a wall, yet still inside an area
@@ -121,10 +127,6 @@
 	src.tdir = dir		// to fix Vars bug
 	dir = SOUTH
 
-	if(areaMaster.areaapc)
-		world.log << "Secondary APC detected in area: [areaMaster.name], deleting the second APC"
-		qdel(src)
-		return
 	areaMaster.set_apc(src)
 
 	if(src.tdir & 3)
@@ -1295,25 +1297,24 @@ obj/machinery/power/apc/proc/autoset(var/val, var/on)
 				sleep(1)
 
 /obj/machinery/power/apc/Destroy()
-	areaMaster.remove_apc(src)
-	if(malfai && operating)
-		if (ticker.mode.config_tag == "malfunction")
-			if (STATION_Z == z)
-				ticker.mode:apcs--
-	areaMaster.power_light = 0
-	areaMaster.power_equip = 0
-	areaMaster.power_environ = 0
-	areaMaster.power_change()
+	if(areaMaster.areaapc == src)
+		areaMaster.remove_apc(src)
+		if(malfai && operating)
+			if (ticker.mode.config_tag == "malfunction")
+				if (STATION_Z == z)
+					var/datum/game_mode/malfunction/M = ticker.mode
+					M.apcs--
+
+		areaMaster.power_light = 0
+		areaMaster.power_equip = 0
+		areaMaster.power_environ = 0
+		areaMaster.power_change()
 	if(occupant)
 		malfvacate(1)
 
 	if(cell)
 		cell.forceMove(loc)
 		cell = null
-
-	if(terminal)
-		terminal.master = null
-		terminal = null
 
 	if(wires)
 		qdel(wires)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1304,11 +1304,11 @@ obj/machinery/power/apc/proc/autoset(var/val, var/on)
 				if (STATION_Z == z)
 					var/datum/game_mode/malfunction/M = ticker.mode
 					M.apcs--
-
 		areaMaster.power_light = 0
 		areaMaster.power_equip = 0
 		areaMaster.power_environ = 0
 		areaMaster.power_change()
+
 	if(occupant)
 		malfvacate(1)
 


### PR DESCRIPTION
I was going to use `get_area()` to fix the bugs, but then I didn't. So this is *almost* atomic.

Since it's not AT ALL clear what the bugs were from the code: `areaMaster` for non-mobs is only updated on `/area/Entered()`, meaning that if anything that isn't a mob is moved between areas while inside something else, it won't be updated. Since APC construction checked the `areaMaster` of the APC frame *item*, you couldn't build an APC if you picked up the frame while in an area with an APC, and you could completely fucking ruin the power in an area by trying to build a new APC in an area that already had one by picking up the frame while in an area without an APC.

Fixes #13974