### PR TITLE
Subspace Tunneler and Bluespace Crystal Fix

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -15,6 +15,7 @@ var/area/space_area
 	layer = AREA_LAYER_MEME_NAME_BECAUSE_CELT_IS_A_FUCKING_RETARD
 	var/base_turf_type = null
 	var/shuttle_can_crush = TRUE
+	flags = 0
 
 /area/New()
 	area_turfs = list()


### PR DESCRIPTION
Fixes `/area` inheriting `FPRINT` from `/atom`, which coincidentally has the same value as the `NO_TELEPORT` flag.
Fixes subspace tunnelers and bluespace crystal crushing not working.
Fixes #14714

:cl:
 * bugfix: Fixes the subspace tunneler not working.
 * bugfix: Fixes nothing happening when you crush a bluespace crystal.
