### PR TITLE
Fixed the icon in the examine text always being the first examined mob

### DIFF
--- a/goon/code/datums/browserOutput.dm
+++ b/goon/code/datums/browserOutput.dm
@@ -221,7 +221,7 @@ For the main html chat area
 
 	// Either an atom or somebody fucked up and is gonna get a runtime, which I'm fine with.
 	var/atom/A = obj
-	var/key = "\ref[A.icon]:[A.icon_state]"
+	var/key = "[A.icon]" || "\ref[A.icon]"+":[A.icon_state]"
 	if (!bicon_cache[key]) // Doesn't exist, make it.
 		var/icon/I = icon(A.icon, A.icon_state, SOUTH, 1)
 		if (ishuman(obj)) // Shitty workaround for a BYOND issue.

--- a/goon/code/datums/browserOutput.dm
+++ b/goon/code/datums/browserOutput.dm
@@ -221,7 +221,7 @@ For the main html chat area
 
 	// Either an atom or somebody fucked up and is gonna get a runtime, which I'm fine with.
 	var/atom/A = obj
-	var/key = "[istype(A.icon, /icon) ? "\ref[A.icon]" : A.icon]:[A.icon_state]"
+	var/key = "\ref[A.icon]:[A.icon_state]"
 	if (!bicon_cache[key]) // Doesn't exist, make it.
 		var/icon/I = icon(A.icon, A.icon_state, SOUTH, 1)
 		if (ishuman(obj)) // Shitty workaround for a BYOND issue.

--- a/goon/code/datums/browserOutput.dm
+++ b/goon/code/datums/browserOutput.dm
@@ -221,7 +221,7 @@ For the main html chat area
 
 	// Either an atom or somebody fucked up and is gonna get a runtime, which I'm fine with.
 	var/atom/A = obj
-	var/key = "[A.icon]" || "\ref[A.icon]"+":[A.icon_state]"
+	var/key = ("[A.icon]" || "\ref[A.icon]")+":[A.icon_state]"
 	if (!bicon_cache[key]) // Doesn't exist, make it.
 		var/icon/I = icon(A.icon, A.icon_state, SOUTH, 1)
 		if (ishuman(obj)) // Shitty workaround for a BYOND issue.

--- a/goon/code/datums/browserOutput.dm
+++ b/goon/code/datums/browserOutput.dm
@@ -224,7 +224,7 @@ For the main html chat area
 	var/key = ("[A.icon]" || "\ref[A.icon]")+":[A.icon_state]"
 	if (!bicon_cache[key]) // Doesn't exist, make it.
 		var/icon/I = icon(A.icon, A.icon_state, SOUTH, 1)
-		if (ishuman(obj)) // Shitty workaround for a BYOND issue.
+		if (!"[A.icon]") // Shitty workaround for a BYOND issue.
 			var/icon/temp = I
 			I = icon()
 			I.Insert(temp, dir = SOUTH)


### PR DESCRIPTION
This fixes the bug where you:

1. examine a vox
2. examine a human
3. the human shows up as the first vox

That said, I haven't tested it a whole lot nor do I know why it was made the way it was in the first place. ~~So do not merge until @PJB3005 comments on it, since he made the thing originally, I guess?~~

Closes #9384