### PR TITLE
Borer Utility Bone Repair Fix

### DIFF
--- a/code/modules/mob/living/simple_animal/borer/verbs_attached_arm.dm
+++ b/code/modules/mob/living/simple_animal/borer/verbs_attached_arm.dm
@@ -351,8 +351,7 @@
 		if(O.is_broken())
 			O.status &= ~ORGAN_BROKEN
 			O.perma_injury = 0
-			var/minimum_broken_damage_hand = O.min_broken_damage
-			O.brute_dam = ((minimum_broken_damage_hand * config.organ_health_multiplier)-1)
+			O.heal_damage(O.brute_dam - ((O.min_broken_damage * config.organ_health_multiplier) - 1))
 			to_chat(src, "<span class='notice'>You've repaired the bones in your host's [hostlimb == LIMB_RIGHT_ARM ? "right" : "left"] hand.</span>")
 			to_chat(host, "<span class='notice'>You feel the bones in your [hostlimb == LIMB_RIGHT_ARM ? "right" : "left"] hand mend together.</span>")
 			chemicals -= 30
@@ -367,8 +366,7 @@
 				return
 		current_limb.status &= ~ORGAN_BROKEN
 		current_limb.perma_injury = 0
-		var/minimum_broken_damage_arm = current_limb.min_broken_damage
-		current_limb.brute_dam = ((minimum_broken_damage_arm * config.organ_health_multiplier)-1)
+		current_limb.heal_damage(current_limb.brute_dam - ((current_limb.min_broken_damage * config.organ_health_multiplier) - 1))
 		to_chat(src, "<span class='notice'>You've repaired the bones in your host's [hostlimb == LIMB_RIGHT_ARM ? "right" : "left"] arm.</span>")
 		to_chat(host, "<span class='notice'>You feel the bones in your [hostlimb == LIMB_RIGHT_ARM ? "right" : "left"] arm mend together.</span>")
 		chemicals -= 50


### PR DESCRIPTION
Fixes an issue I discovered when making the new chems, where directly setting `brute_dam` to a smaller value wouldn't work correctly if the arm had wound datums.
Now it uses the `heal_damage()` proc which handles wounds and such.