### PR TITLE
New alt title for janitors: Maid

### DIFF
--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -416,6 +416,7 @@
 	selection_color = "#dddddd"
 	access = list(access_janitor, access_maint_tunnels)
 	minimal_access = list(access_janitor, access_maint_tunnels)
+	alt_titles = list("Maid")
 
 	pdaslot=slot_belt
 	pdatype=/obj/item/device/pda/janitor
@@ -432,8 +433,17 @@
 				H.equip_or_collect(new /obj/item/weapon/storage/backpack/satchel(H), slot_back)
 			if(5)
 				H.equip_or_collect(new /obj/item/weapon/storage/backpack/messenger(H), slot_back)
-		H.equip_or_collect(new /obj/item/clothing/under/rank/janitor(H), slot_w_uniform)
-		H.equip_or_collect(new /obj/item/clothing/shoes/black(H), slot_shoes)
+
+		if (H.mind.role_alt_title)
+			switch(H.mind.role_alt_title)
+				if("Maid")
+					H.equip_or_collect(new /obj/item/clothing/under/maid(H), slot_w_uniform)
+					H.equip_or_collect(new /obj/item/clothing/suit/maidapron(H), slot_wear_suit)
+					H.equip_or_collect(new /obj/item/clothing/head/maidhat(H), slot_head)
+					H.equip_or_collect(new /obj/item/clothing/shoes/kneesocks(H), slot_shoes)
+		else
+			H.equip_or_collect(new /obj/item/clothing/under/rank/janitor(H), slot_w_uniform)
+			H.equip_or_collect(new /obj/item/clothing/shoes/black(H), slot_shoes)
 		H.put_in_hands(new /obj/item/weapon/storage/bag/plasticbag(H))
 		//H.equip_or_collect(new /obj/item/device/pda/janitor(H), slot_belt)
 		if(H.backbag == 1)


### PR DESCRIPTION
A very simple PR that allows janitors to select "maid" as an alternate job title at spawn. This will spawn them with maid clothing.

Men can also be maids if they so choose. I don't judge.

:cl:
 * rscadd: "Maid" added as an alternate job title for janitors.