### PR TITLE
Heart Attack Syndrome

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1683,7 +1683,7 @@ mob/living/carbon/human/isincrit()
 
 //Moved from internal organ surgery
 //Removes organ from src, places organ object under user
-//example: H.remove_internal_organ(H.internal_organs_by_name["heart"],H.get_organ(LIMB_CHEST))
+//example: H.remove_internal_organ(H,H.internal_organs_by_name["heart"],H.get_organ(LIMB_CHEST))
 mob/living/carbon/human/remove_internal_organ(var/mob/living/user, var/datum/organ/internal/targetorgan, var/datum/organ/external/affectedarea)
 	var/obj/item/organ/extractedorgan
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1678,12 +1678,12 @@ mob/living/carbon/human/isincrit()
 				return_organs += damagedorgan
 		return return_organs
 
-/mob/living/carbon/human/get_heart()	
+/mob/living/carbon/human/get_heart()
 	return internal_organs_by_name["heart"]
-	
+
 //Moved from internal organ surgery
 //Removes organ from src, places organ object under user
-//example: H.remove_internal_organ(H,internal_organs_by_name["heart"],H.get_organ(LIMB_CHEST))
+//example: H.remove_internal_organ(H.internal_organs_by_name["heart"],H.get_organ(LIMB_CHEST))
 mob/living/carbon/human/remove_internal_organ(var/mob/living/user, var/datum/organ/internal/targetorgan, var/datum/organ/external/affectedarea)
 	var/obj/item/organ/extractedorgan
 
@@ -1698,15 +1698,15 @@ mob/living/carbon/human/remove_internal_organ(var/mob/living/user, var/datum/org
 			var/datum/reagent/blood/organ_blood = extractedorgan.reagents.reagent_list[BLOOD]
 			if(!organ_blood || !organ_blood.data["blood_DNA"])
 				vessel.trans_to(extractedorgan, 5, 1, 1)
-			
+
 			internal_organs_by_name[targetorgan.name] = null
 			internal_organs_by_name -= targetorgan.name
 			internal_organs -= extractedorgan.organ_data
 			affectedarea.internal_organs -= extractedorgan.organ_data
 			extractedorgan.removed(src,user)
-			
+
 			return extractedorgan
-		
+
 /mob/living/carbon/human/feels_pain()
 	if(!species)
 		return FALSE

--- a/code/modules/virus2/effect/effect.dm
+++ b/code/modules/virus2/effect/effect.dm
@@ -1449,10 +1449,8 @@ datum/disease2/effect/lubefoot/deactivate(var/mob/living/carbon/mob)
 			if(!spawn_turfs.len)
 				spawn_turfs.Add(get_turf(H))
 			var/mob/living/simple_animal/hostile/heart_attack = new(pick(spawn_turfs))
-			heart_attack.name = blown_heart.name
-			heart_attack.icon = blown_heart.icon
-			heart_attack.icon_state = blown_heart.icon_state
-			heart_attack.icon_living = blown_heart.icon_state
+			heart_attack.appearance = blown_heart.appearance
+			heart_attack.icon_dead = "heart-off"
 			heart_attack.environment_smash = 0
 			heart_attack.melee_damage_lower = 15
 			heart_attack.melee_damage_upper = 15

--- a/code/modules/virus2/effect/effect.dm
+++ b/code/modules/virus2/effect/effect.dm
@@ -1458,6 +1458,7 @@ datum/disease2/effect/lubefoot/deactivate(var/mob/living/carbon/mob)
 			heart_attack.melee_damage_upper = 15
 			heart_attack.health = 50
 			heart_attack.maxHealth = 50
+			heart_attack.stat_attack = 1
 			qdel(blown_heart)
 
 

--- a/code/modules/virus2/effect/effect.dm
+++ b/code/modules/virus2/effect/effect.dm
@@ -217,8 +217,8 @@
 /datum/disease2/effect/heart_attack/activate(var/mob/living/carbon/mob)
 	if(ishuman(mob))
 		var/mob/living/carbon/human/H = mob
-		if(internal_organs_by_name["heart"])
-			var/obj/item/organ/blown_heart = H.remove_internal_organ(H,internal_organs_by_name["heart"],H.get_organ(LIMB_CHEST))
+		if(H.internal_organs_by_name["heart"])
+			var/obj/item/organ/blown_heart = H.remove_internal_organ(H.internal_organs_by_name["heart"],H.get_organ(LIMB_CHEST))
 			var/list/spawn_turfs = list()
 			for(var/turf/T in orange(1, H))
 				if(!T.density)

--- a/code/modules/virus2/effect/effect.dm
+++ b/code/modules/virus2/effect/effect.dm
@@ -209,6 +209,31 @@
 			for(var/i = 0 to multiplier)
 				new/mob/living/simple_animal/bee(get_turf(mob))
 
+/datum/disease2/effect/heart_attack
+	name = "Heart Attack Syndrome"
+	stage = 1
+	max_count = 1
+
+/datum/disease2/effect/heart_attack/activate(var/mob/living/carbon/mob)
+	if(ishuman(mob))
+		var/mob/living/carbon/human/H = mob
+		if(internal_organs_by_name["heart"])
+			var/obj/item/organ/blown_heart = H.remove_internal_organ(H,internal_organs_by_name["heart"],H.get_organ(LIMB_CHEST))
+			var/list/spawn_turfs = list()
+			for(var/turf/T in orange(1, H))
+				if(!T.density)
+					spawn_turfs.Add(T)
+			if(!spawn_turfs.len)
+				spawn_turfs.Add(get_turf(H))
+			var/mob/living/simple_animal/hostile/heart_attack = new(pick(spawn_turfs))
+			heart_attack.name = blown_heart.name
+			heart_attack.icon = blown_heart.icon
+			heart_attack.icon_state = blown_heart.icon_state
+			heart_attack.icon_living = blown_heart.icon_state
+			heart_attack.environment_smash = 0
+			H.visible_message("<span class='danger'>\The [H]'s heart bursts out of \his chest!</span>","<span class='danger'>Your heart bursts out of your chest!</span>")
+			qdel(blown_heart)
+
 
 ////////////////////////STAGE 2/////////////////////////////////
 

--- a/code/modules/virus2/effect/effect.dm
+++ b/code/modules/virus2/effect/effect.dm
@@ -209,31 +209,6 @@
 			for(var/i = 0 to multiplier)
 				new/mob/living/simple_animal/bee(get_turf(mob))
 
-/datum/disease2/effect/heart_attack
-	name = "Heart Attack Syndrome"
-	stage = 1
-	max_count = 1
-
-/datum/disease2/effect/heart_attack/activate(var/mob/living/carbon/mob)
-	if(ishuman(mob))
-		var/mob/living/carbon/human/H = mob
-		if(H.internal_organs_by_name["heart"])
-			var/obj/item/organ/blown_heart = H.remove_internal_organ(H.internal_organs_by_name["heart"],H.get_organ(LIMB_CHEST))
-			var/list/spawn_turfs = list()
-			for(var/turf/T in orange(1, H))
-				if(!T.density)
-					spawn_turfs.Add(T)
-			if(!spawn_turfs.len)
-				spawn_turfs.Add(get_turf(H))
-			var/mob/living/simple_animal/hostile/heart_attack = new(pick(spawn_turfs))
-			heart_attack.name = blown_heart.name
-			heart_attack.icon = blown_heart.icon
-			heart_attack.icon_state = blown_heart.icon_state
-			heart_attack.icon_living = blown_heart.icon_state
-			heart_attack.environment_smash = 0
-			H.visible_message("<span class='danger'>\The [H]'s heart bursts out of \his chest!</span>","<span class='danger'>Your heart bursts out of your chest!</span>")
-			qdel(blown_heart)
-
 
 ////////////////////////STAGE 2/////////////////////////////////
 
@@ -1455,6 +1430,37 @@ datum/disease2/effect/lubefoot/deactivate(var/mob/living/carbon/mob)
 				H.species.anatomy_flags |= HAS_SWEAT_GLANDS
 		to_chat(mob, "<span class='notice'>Your skin feels nice and smooth again!</span>")
 	..()
+
+/datum/disease2/effect/heart_attack
+	name = "Heart Attack Syndrome"
+	stage = 4
+	max_count = 1
+
+/datum/disease2/effect/heart_attack/activate(var/mob/living/carbon/mob)
+	if(ishuman(mob))
+		var/mob/living/carbon/human/H = mob
+		if(H.get_heart())
+			H.visible_message("<span class='danger'>\The [H]'s heart bursts out of \his chest!</span>","<span class='danger'>Your heart bursts out of your chest!</span>")
+			var/obj/item/organ/blown_heart = H.remove_internal_organ(H,H.get_heart(),H.get_organ(LIMB_CHEST))
+			var/list/spawn_turfs = list()
+			for(var/turf/T in orange(1, H))
+				if(!T.density)
+					spawn_turfs.Add(T)
+			if(!spawn_turfs.len)
+				spawn_turfs.Add(get_turf(H))
+			var/mob/living/simple_animal/hostile/heart_attack = new(pick(spawn_turfs))
+			heart_attack.name = blown_heart.name
+			heart_attack.icon = blown_heart.icon
+			heart_attack.icon_state = blown_heart.icon_state
+			heart_attack.icon_living = blown_heart.icon_state
+			heart_attack.environment_smash = 0
+			heart_attack.melee_damage_lower = 15
+			heart_attack.melee_damage_upper = 15
+			heart_attack.health = 50
+			heart_attack.maxHealth = 50
+			qdel(blown_heart)
+
+
 ////////////////////////SPECIAL/////////////////////////////////
 
 


### PR DESCRIPTION
Adds new stage 4 virus symptom, heart attack syndrome.
If the infected has a heart, this symptom causes the infected's heart to burst out of their chest and begin attacking them.
It can only trigger once, so you don't have to worry about being unable to replace their heart before curing the virus.

:cl:
 * rscadd: Added heart attack syndrome as a new stage 4 virus symptom, it causes your heart to burst out of your chest and begin attacking you.
