### PR TITLE
disables baguloth on specified z levels

### DIFF
--- a/code/game/objects/items/weapons/storage/bluespace.dm
+++ b/code/game/objects/items/weapons/storage/bluespace.dm
@@ -44,16 +44,25 @@
 //BoH+BoH=Singularity, WAS commented out
 /obj/item/weapon/storage/backpack/holding/proc/singulocreate(var/obj/item/weapon/storage/backpack/holding/H, var/mob/user)
 	user.Knockdown(10)
-	investigation_log(I_SINGULO,"has become a singularity. Caused by [user.key]")
-	message_admins("[key_name_admin(user)] detonated [H] and [src], creating a singularity.")
-	log_game("[key_name(user)] detonated [H] and [src], creating a singularity.")
 	to_chat(user, "<span class = 'danger'>The Bluespace interfaces of the two devices catastrophically malfunction, throwing you to the ground in the process!</span>")
 	to_chat(user, "<span class='danger'>FUCK!</span>")
 	var/turf/T = get_turf(src)
 	qdel(H)
 	qdel(src)
-	var/obj/machinery/singularity/S = new (T)
-	S.Bumped(user)
+	var/datum/zLevel/ourzLevel = map.zLevels[user.z]
+	if(ourzLevel.bluespace_jammed)
+		//Stop breaking into centcomm via dungeons you shits
+		message_admins("[key_name_admin(user)] detonated [H] and [src], creating an explosion.")
+		log_game("[key_name(user)] detonated [H] and [src], creating an explosion.")
+		empulse(T,(20),(40))
+		explosion(T, 5, 10, 20, 40, 1)
+		user.gib() //Just to be sure
+	else
+		investigation_log(I_SINGULO,"has become a singularity. Caused by [user.key]")
+		message_admins("[key_name_admin(user)] detonated [H] and [src], creating a singularity.")
+		log_game("[key_name(user)] detonated [H] and [src], creating a singularity.")
+		var/obj/machinery/singularity/S = new (T)
+		S.consume(user) //So the BoHolder can't run away from his wrongdoing
 
 /obj/item/weapon/storage/backpack/holding/singularity_act(var/current_size,var/obj/machinery/singularity/S)
 	var/dist = max(current_size, 1)

--- a/maps/_map.dm
+++ b/maps/_map.dm
@@ -136,6 +136,7 @@ var/global/list/accessable_z_levels = list()
 	var/name = ""
 	var/teleJammed = 0
 	var/movementJammed = 0 //Prevents you from accessing the zlevel by drifting
+	var/bluespace_jammed = 0
 	var/movementChance = ZLEVEL_BASE_CHANCE
 	var/base_turf //Our base turf, what shows under the station when destroyed. Defaults to space because it's fukken Space Station 13
 	var/z //Number of the z-level (the z coordinate)
@@ -152,6 +153,7 @@ var/global/list/accessable_z_levels = list()
 	name = "centcomm"
 	teleJammed = 1
 	movementJammed = 1
+	bluespace_jammed = 1
 
 /datum/zLevel/space
 


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl: (as the emoji)
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
speaks for itself really. Recently had numerous raids on central command done by traders buying bags of holding, finding a vault with a dungeon, then breaching the wall with a singularity baguloth.

This should impede that.

fixes #14452