### PR TITLE
Makes scattershot fire buckshot rounds

### DIFF
--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -208,12 +208,12 @@
 	name = "\improper LBX AC 10 \"Scattershot\""
 	icon_state = "mecha_scatter"
 	equip_cooldown = 20
-	projectile = /obj/item/projectile/bullet/midbullet
+	projectile = /obj/item/projectile/bullet/buckshot
 	fire_sound = 'sound/weapons/shotgun.ogg'
-	max_projectiles = 40
+	max_projectiles = 20
 	projectile_energy_cost = 25
-	var/projectiles_per_shot = 4
-//	var/deviation = 0.7  //the shots were perfectly accurate no matter what this was set to
+	var/projectiles_per_shot = 2
+	var/deviation = 0.7  //the shots were perfectly accurate no matter what this was set to
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/scattershot/action(atom/target)
 	if(!action_checks(target))

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -212,7 +212,7 @@
 	fire_sound = 'sound/weapons/shotgun.ogg'
 	max_projectiles = 20
 	projectile_energy_cost = 25
-	var/projectiles_per_shot = 2
+	var/projectiles_per_shot = 1
 	var/deviation = 0.7  //the shots were perfectly accurate no matter what this was set to
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/scattershot/action(atom/target)


### PR DESCRIPTION
tested
webm: https://puu.sh/w8ArE/8999940923.webm

🆑 
 - tweak: The LBX AC 10 "Scattershot" now fires buckshot rounds.