### PR TITLE
fixes select_active_ai_with_fewest_borgs() proc

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -331,7 +331,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 	var/mob/living/silicon/ai/selected
 	var/list/active = active_ais()
 	for(var/mob/living/silicon/ai/A in active)
-		if(!selected || (selected.connected_robots > A.connected_robots))
+		if(!selected || (selected.connected_robots.len > A.connected_robots.len))
 			selected = A
 
 	return selected


### PR DESCRIPTION
5 year old bug
resolves  #14952
tested

:cl:
 - bugfix: Cyborgs now properly get assigned to the AI with the least borgs when they are built.