### PR TITLE
Fixed combat cyborg infinite laser cannon

### DIFF
--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -233,8 +233,7 @@
 		return 1
 	if(isrobot(src.loc))
 		var/mob/living/silicon/robot/R = src.loc
-		if(R && R.cell)
-			R.cell.use(250)
+		if(R && R.cell && R.cell.use(250))
 			in_chamber = new/obj/item/projectile/beam/heavylaser(src)
 			return 1
 	return 0


### PR DESCRIPTION
Fixes #15112
:cl:
 * bugfix: The cyborg laser cannon can no longer be fired without sufficient charge.
