### PR TITLE
Adds self-diagnosis messages for various borg interactions

### DIFF
--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -25,11 +25,14 @@
 /datum/robot_component/proc/destroy()
 	var/obj/item/broken_device/G = new/obj/item/broken_device
 	G.component = wrapped.type // the broken component now "remembers" the component it used to be, now it's scrap. This is used to fix the scrap into the component it was.
+	var/brokenpartname = wrapped.name
 	wrapped = G
 
 	// The thing itself isn't there anymore, but some fried remains are.
 	installed = -1
 	uninstall()
+	if(src.owner.can_diagnose())
+		to_chat(src.owner, "<span class='alert' style=\"font-family:Courier\">Warning: Critical damage to [brokenpartname] sustained. Component offline.</span>")
 
 /datum/robot_component/proc/take_damage(brute, electronics, sharp)
 	if(installed != 1)

--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -31,8 +31,8 @@
 	// The thing itself isn't there anymore, but some fried remains are.
 	installed = -1
 	uninstall()
-	if(src.owner.can_diagnose())
-		to_chat(src.owner, "<span class='alert' style=\"font-family:Courier\">Warning: Critical damage to [brokenpartname] sustained. Component offline.</span>")
+	if(owner.can_diagnose())
+		to_chat(owner, "<span class='alert' style=\"font-family:Courier\">Warning: Critical damage to [brokenpartname] sustained. Component offline.</span>")
 
 /datum/robot_component/proc/take_damage(brute, electronics, sharp)
 	if(installed != 1)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -501,8 +501,11 @@
 	viewalerts = 1
 	src << browse(dat, "window=robotalerts&can_close=0")
 
+/mob/living/silicon/robot/can_diagnose()
+	return is_component_functioning("diagnosis unit") 
+	
 /mob/living/silicon/robot/proc/self_diagnosis()
-	if(!is_component_functioning("diagnosis unit"))
+	if(!can_diagnose())
 		return null
 
 	var/dat = "<HEAD><TITLE>[src.name] Self-Diagnosis Report</TITLE></HEAD><BODY>\n"
@@ -517,7 +520,7 @@
 	set category = "Robot Commands"
 	set name = "Self Diagnosis"
 
-	if(!self_diagnosis())
+	if(!can_diagnose())
 		to_chat(src, "<span class='warning'>Your self-diagnosis component isn't functioning.</span>")
 
 	var/dat = self_diagnosis()
@@ -818,8 +821,8 @@
 				W.forceMove(null)
 
 				to_chat(usr, "<span class='notice'>You install the [W.name].</span>")
-				if(src.self_diagnosis())
-					to_chat(src, "<span class='info'><span style=\"font-family:Courier\">New [W.name] installed.</span>")
+				if(src.can_diagnose())
+					to_chat(src, "<span class='info' style=\"font-family:Courier\">New [W.name] installed.</span>")
 
 				return
 
@@ -853,15 +856,15 @@
 		if(opened)
 			if(cell)
 				to_chat(user, "You close the cover.")
-				if(src.self_diagnosis())
-					to_chat(src, "<span class='info'><span style=\"font-family:Courier\">Cover closed.</span>")
+				if(src.can_diagnose())
+					to_chat(src, "<span class='info' style=\"font-family:Courier\">Cover closed.</span>")
 				opened = 0
 				updateicon()
 			else if(mmi && wiresexposed && wires.IsAllCut())
 				//Cell is out, wires are exposed, remove MMI, produce damaged chassis, baleet original mob.
 				to_chat(user, "You jam the crowbar into the robot and begin levering [mmi].")
-				if(src.self_diagnosis())
-					to_chat(src, "<span class='info'><span style=\"font-family:Courier\">Chassis disassembly in progress.</span>")
+				if(src.can_diagnose())
+					to_chat(src, "<span class='alert' style=\"font-family:Courier\">Chassis disassembly in progress.</span>")
 				if (do_after(user, src,3))
 					to_chat(user, "You damage some parts of the chassis, but eventually manage to rip out [mmi]!")
 					var/obj/item/robot_parts/robot_suit/C = new/obj/item/robot_parts/robot_suit(loc)
@@ -889,16 +892,16 @@
 				if(istype(C.wrapped, /obj/item/broken_device))
 					var/obj/item/broken_device/I = C.wrapped
 					to_chat(user, "You remove \the [I].")
-					if(src.self_diagnosis())
-						to_chat(src, "<span class='info'><span style=\"font-family:Courier\">Destroyed [I.name] removed.</span>")
+					if(src.can_diagnose())
+						to_chat(src, "<span class='info' style=\"font-family:Courier\">Destroyed [C] removed.</span>")
 					I.forceMove(src.loc)
 				else
 					var/obj/item/robot_parts/robot_component/I = C.wrapped
 					I.brute_damage = C.brute_damage
 					I.electronics_damage = C.electronics_damage
 					to_chat(user, "You remove \the [I].")
-					if(src.self_diagnosis())
-						to_chat(src, "<span class='info'><span style=\"font-family:Courier\">Functional [I.name] removed.</span>")
+					if(src.can_diagnose())
+						to_chat(src, "<span class='info' style=\"font-family:Courier\">Functional [I.name] removed.</span>")
 					I.forceMove(src.loc)
 
 				if(C.installed == 1)
@@ -910,8 +913,8 @@
 				to_chat(user, "The cover is locked and cannot be opened.")
 			else
 				to_chat(user, "You open the cover.")
-				if(src.self_diagnosis())
-					to_chat(src, "<span class='info'><span style=\"font-family:Courier\">Cover opened.</span>")
+				if(src.can_diagnose())
+					to_chat(src, "<span class='info' style=\"font-family:Courier\">Cover opened.</span>")
 				opened = 1
 				updateicon()
 
@@ -929,15 +932,15 @@
 			oldpowercell.brute_damage = C.brute_damage
 			user.drop_item(W, src)
 			user.put_in_hands(oldpowercell)
-			if(src.self_diagnosis())
-				to_chat(src, "<span class='info'><span style=\"font-family:Courier\">Cell removed.</span>")
+			if(src.can_diagnose())
+				to_chat(src, "<span class='info' style=\"font-family:Courier\">Cell removed.</span>")
 			C.installed = 1
 			C.wrapped = W
 			C.electronics_damage = cell.electronics_damage
 			C.brute_damage = cell.brute_damage
 			C.install()
-			if(src.self_diagnosis())
-				to_chat(src, "<span class='info'><span style=\"font-family:Courier\">New cell installed. Type: [cell.name]. Charge: [cell.charge].</span>")
+			if(src.can_diagnose())
+				to_chat(src, "<span class='info' style=\"font-family:Courier\">New cell installed. Type: [cell.name]. Charge: [cell.charge].</span>")
 		else
 			user.drop_item(W, src)
 			cell = W
@@ -948,8 +951,8 @@
 			C.electronics_damage = cell.electronics_damage
 			C.brute_damage = cell.brute_damage
 			C.install()
-			if(src.self_diagnosis())
-				to_chat(src, "<span class='info'><span style=\"font-family:Courier\">New cell installed. Type: [cell.name]. Charge: [cell.charge].</span>")
+			if(src.can_diagnose())
+				to_chat(src, "<span class='info' style=\"font-family:Courier\">New cell installed. Type: [cell.name]. Charge: [cell.charge].</span>")
 
 	else if (iswiretool(W))
 		if (wiresexposed)
@@ -960,15 +963,15 @@
 	else if(isscrewdriver(W) && opened && !cell)	// haxing
 		wiresexposed = !wiresexposed
 		to_chat(user, "The wires have been [wiresexposed ? "exposed" : "unexposed"].")
-		if(src.self_diagnosis())
-			to_chat(src, "<span class='info'><span style=\"font-family:Courier\">Internal wiring [wiresexposed ? "exposed" : "unexposed"].</span>")
+		if(src.can_diagnose())
+			to_chat(src, "<span class='info' style=\"font-family:Courier\">Internal wiring [wiresexposed ? "exposed" : "unexposed"].</span>")
 		updateicon()
 
 	else if(isscrewdriver(W) && opened && cell)	// radio
 		if(radio)
 			radio.attackby(W,user)//Push it to the radio to let it handle everything
-			if(src.self_diagnosis())
-				to_chat(src, "<span class='info'><span style=\"font-family:Courier\">Radio encryption keys modified.</span>")
+			if(src.can_diagnose())
+				to_chat(src, "<span class='info' style=\"font-family:Courier\">Radio encryption keys modified.</span>")
 		else
 			to_chat(user, "Unable to locate a radio.")
 		updateicon()
@@ -976,8 +979,8 @@
 	else if(istype(W, /obj/item/device/encryptionkey/) && opened)
 		if(radio)//sanityyyyyy
 			radio.attackby(W,user)//GTFO, you have your own procs
-			if (src.self_diagnosis())
-				to_chat(src, "<span class='info'><span style=\"font-family:Courier\">Radio encryption key installed.</span>")
+			if (src.can_diagnose())
+				to_chat(src, "<span class='info' style=\"font-family:Courier\">Radio encryption key installed.</span>")
 		else
 			to_chat(user, "Unable to locate a radio.")
 
@@ -990,18 +993,20 @@
 			if(allowed(usr))
 				locked = !locked
 				to_chat(user, "You [ locked ? "lock" : "unlock"] [src]'s interface.")
-				if(src.self_diagnosis())
-					to_chat(src, "<span class='info'><span style=\"font-family:Courier\">Interface [ locked ? "locked" : "unlocked"].</span>")
+				if(src.can_diagnose())
+					to_chat(src, "<span class='info' style=\"font-family:Courier\">Interface [ locked ? "locked" : "unlocked"].</span>")
 				updateicon()
 			else
 				to_chat(user, "<span class='warning'>Access denied.</span>")
 
 	else if(istype(W, /obj/item/borg/upgrade/))
 		var/obj/item/borg/upgrade/U = W
-		U.attempt_action(src,user)
-		if(src.self_diagnosis())
-			to_chat(src, "<span class='info'><span style=\"font-family:Courier\">Installation of [U.name] attempted.</span>")
-
+		if (U.attempt_action(src,user))
+			if(src.can_diagnose())
+				to_chat(src, "<span class='info' style=\"font-family:Courier\">Installation of [U.name] failed.</span>")
+		else
+			if(src.can_diagnose())
+				to_chat(src, "<span class='info' style=\"font-family:Courier\">Installation of [U.name] succeeded.</span>")
 	else if(istype(W, /obj/item/device/camera_bug))
 		help_shake_act(user)
 		return 0
@@ -1070,8 +1075,8 @@
 			user.put_in_active_hand(cell)
 			user.visible_message("<span class='warning'>[user] removes [src]'s [cell.name].</span>", \
 			"<span class='notice'>You remove [src]'s [cell.name].</span>")
-			if(src.self_diagnosis())
-				to_chat(src, "<span class='info'><span style=\"font-family:Courier\">Cell removed.</span>")
+			if(src.can_diagnose())
+				to_chat(src, "<span class='info' style=\"font-family:Courier\">Cell removed.</span>")
 			src.attack_log += "\[[time_stamp()]\] <font color='orange'>Has had their [cell.name] removed by [user.name] ([user.ckey])</font>"
 			user.attack_log += "\[[time_stamp()]\] <font color='red'>Removed the [cell.name] of [src.name] ([src.ckey])</font>"
 			log_attack("<font color='red'>[user.name] ([user.ckey]) removed [src]'s [cell.name] ([src.ckey])</font>")
@@ -1085,8 +1090,8 @@
 			var/obj/item/broken_device = cell_component.wrapped
 			to_chat(user, "You remove \the [broken_device].")
 			user.put_in_active_hand(broken_device)
-			if(src.self_diagnosis())
-				to_chat(src, "<span class='info'><span style=\"font-family:Courier\">Destroyed [broken_device] removed.</span>")
+			if(src.can_diagnose())
+				to_chat(src, "<span class='info' style=\"font-family:Courier\">Destroyed power cell removed.</span>")
 			return
 
 	switch(user.a_intent)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -821,7 +821,7 @@
 				W.forceMove(null)
 
 				to_chat(usr, "<span class='notice'>You install the [W.name].</span>")
-				if(src.can_diagnose())
+				if(can_diagnose())
 					to_chat(src, "<span class='info' style=\"font-family:Courier\">New [W.name] installed.</span>")
 
 				return
@@ -856,14 +856,14 @@
 		if(opened)
 			if(cell)
 				to_chat(user, "You close the cover.")
-				if(src.can_diagnose())
+				if(can_diagnose())
 					to_chat(src, "<span class='info' style=\"font-family:Courier\">Cover closed.</span>")
 				opened = 0
 				updateicon()
 			else if(mmi && wiresexposed && wires.IsAllCut())
 				//Cell is out, wires are exposed, remove MMI, produce damaged chassis, baleet original mob.
 				to_chat(user, "You jam the crowbar into the robot and begin levering [mmi].")
-				if(src.can_diagnose())
+				if(can_diagnose())
 					to_chat(src, "<span class='alert' style=\"font-family:Courier\">Chassis disassembly in progress.</span>")
 				if (do_after(user, src,3))
 					to_chat(user, "You damage some parts of the chassis, but eventually manage to rip out [mmi]!")
@@ -892,7 +892,7 @@
 				if(istype(C.wrapped, /obj/item/broken_device))
 					var/obj/item/broken_device/I = C.wrapped
 					to_chat(user, "You remove \the [I].")
-					if(src.can_diagnose())
+					if(can_diagnose())
 						to_chat(src, "<span class='info' style=\"font-family:Courier\">Destroyed [C] removed.</span>")
 					I.forceMove(src.loc)
 				else
@@ -900,7 +900,7 @@
 					I.brute_damage = C.brute_damage
 					I.electronics_damage = C.electronics_damage
 					to_chat(user, "You remove \the [I].")
-					if(src.can_diagnose())
+					if(can_diagnose())
 						to_chat(src, "<span class='info' style=\"font-family:Courier\">Functional [I.name] removed.</span>")
 					I.forceMove(src.loc)
 
@@ -913,7 +913,7 @@
 				to_chat(user, "The cover is locked and cannot be opened.")
 			else
 				to_chat(user, "You open the cover.")
-				if(src.can_diagnose())
+				if(can_diagnose())
 					to_chat(src, "<span class='info' style=\"font-family:Courier\">Cover opened.</span>")
 				opened = 1
 				updateicon()
@@ -932,14 +932,14 @@
 			oldpowercell.brute_damage = C.brute_damage
 			user.drop_item(W, src)
 			user.put_in_hands(oldpowercell)
-			if(src.can_diagnose())
+			if(can_diagnose())
 				to_chat(src, "<span class='info' style=\"font-family:Courier\">Cell removed.</span>")
 			C.installed = 1
 			C.wrapped = W
 			C.electronics_damage = cell.electronics_damage
 			C.brute_damage = cell.brute_damage
 			C.install()
-			if(src.can_diagnose())
+			if(can_diagnose())
 				to_chat(src, "<span class='info' style=\"font-family:Courier\">New cell installed. Type: [cell.name]. Charge: [cell.charge].</span>")
 		else
 			user.drop_item(W, src)
@@ -951,7 +951,7 @@
 			C.electronics_damage = cell.electronics_damage
 			C.brute_damage = cell.brute_damage
 			C.install()
-			if(src.can_diagnose())
+			if(can_diagnose())
 				to_chat(src, "<span class='info' style=\"font-family:Courier\">New cell installed. Type: [cell.name]. Charge: [cell.charge].</span>")
 
 	else if (iswiretool(W))
@@ -963,14 +963,14 @@
 	else if(isscrewdriver(W) && opened && !cell)	// haxing
 		wiresexposed = !wiresexposed
 		to_chat(user, "The wires have been [wiresexposed ? "exposed" : "unexposed"].")
-		if(src.can_diagnose())
+		if(can_diagnose())
 			to_chat(src, "<span class='info' style=\"font-family:Courier\">Internal wiring [wiresexposed ? "exposed" : "unexposed"].</span>")
 		updateicon()
 
 	else if(isscrewdriver(W) && opened && cell)	// radio
 		if(radio)
 			radio.attackby(W,user)//Push it to the radio to let it handle everything
-			if(src.can_diagnose())
+			if(can_diagnose())
 				to_chat(src, "<span class='info' style=\"font-family:Courier\">Radio encryption keys modified.</span>")
 		else
 			to_chat(user, "Unable to locate a radio.")
@@ -993,7 +993,7 @@
 			if(allowed(usr))
 				locked = !locked
 				to_chat(user, "You [ locked ? "lock" : "unlock"] [src]'s interface.")
-				if(src.can_diagnose())
+				if(can_diagnose())
 					to_chat(src, "<span class='info' style=\"font-family:Courier\">Interface [ locked ? "locked" : "unlocked"].</span>")
 				updateicon()
 			else
@@ -1002,10 +1002,10 @@
 	else if(istype(W, /obj/item/borg/upgrade/))
 		var/obj/item/borg/upgrade/U = W
 		if (U.attempt_action(src,user))
-			if(src.can_diagnose())
+			if(can_diagnose())
 				to_chat(src, "<span class='info' style=\"font-family:Courier\">Installation of [U.name] failed.</span>")
 		else
-			if(src.can_diagnose())
+			if(can_diagnose())
 				to_chat(src, "<span class='info' style=\"font-family:Courier\">Installation of [U.name] succeeded.</span>")
 	else if(istype(W, /obj/item/device/camera_bug))
 		help_shake_act(user)
@@ -1075,7 +1075,7 @@
 			user.put_in_active_hand(cell)
 			user.visible_message("<span class='warning'>[user] removes [src]'s [cell.name].</span>", \
 			"<span class='notice'>You remove [src]'s [cell.name].</span>")
-			if(src.can_diagnose())
+			if(can_diagnose())
 				to_chat(src, "<span class='info' style=\"font-family:Courier\">Cell removed.</span>")
 			src.attack_log += "\[[time_stamp()]\] <font color='orange'>Has had their [cell.name] removed by [user.name] ([user.ckey])</font>"
 			user.attack_log += "\[[time_stamp()]\] <font color='red'>Removed the [cell.name] of [src.name] ([src.ckey])</font>"
@@ -1090,7 +1090,7 @@
 			var/obj/item/broken_device = cell_component.wrapped
 			to_chat(user, "You remove \the [broken_device].")
 			user.put_in_active_hand(broken_device)
-			if(src.can_diagnose())
+			if(can_diagnose())
 				to_chat(src, "<span class='info' style=\"font-family:Courier\">Destroyed power cell removed.</span>")
 			return
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -517,7 +517,7 @@
 	set category = "Robot Commands"
 	set name = "Self Diagnosis"
 
-	if(!is_component_functioning("diagnosis unit"))
+	if(!self_diagnosis())
 		to_chat(src, "<span class='warning'>Your self-diagnosis component isn't functioning.</span>")
 
 	var/dat = self_diagnosis()
@@ -752,7 +752,7 @@
 				else
 					to_chat(user, "You fail to emag the cover lock.")
 					if(prob(25))
-						to_chat(src, "Hack attempt detected.")
+						to_chat(src, "<span class='danger'><span style=\"font-family:Courier\">Hack attempt detected.</span>")
 			else
 				to_chat(user, "The cover is already open.")
 		else
@@ -799,7 +799,7 @@
 				else
 					to_chat(user, "You fail to unlock [src]'s interface.")
 					if(prob(25))
-						to_chat(src, "Hack attempt detected.")
+						to_chat(src, "<span class='danger'><span style=\"font-family:Courier\">Hack attempt detected.</span>")
 	return 1
 
 
@@ -818,6 +818,8 @@
 				W.forceMove(null)
 
 				to_chat(usr, "<span class='notice'>You install the [W.name].</span>")
+				if(src.self_diagnosis())
+					to_chat(src, "<span class='info'><span style=\"font-family:Courier\">New [W.name] installed.</span>")
 
 				return
 
@@ -851,11 +853,15 @@
 		if(opened)
 			if(cell)
 				to_chat(user, "You close the cover.")
+				if(src.self_diagnosis())
+					to_chat(src, "<span class='info'><span style=\"font-family:Courier\">Cover closed.</span>")
 				opened = 0
 				updateicon()
 			else if(mmi && wiresexposed && wires.IsAllCut())
 				//Cell is out, wires are exposed, remove MMI, produce damaged chassis, baleet original mob.
 				to_chat(user, "You jam the crowbar into the robot and begin levering [mmi].")
+				if(src.self_diagnosis())
+					to_chat(src, "<span class='info'><span style=\"font-family:Courier\">Chassis disassembly in progress.</span>")
 				if (do_after(user, src,3))
 					to_chat(user, "You damage some parts of the chassis, but eventually manage to rip out [mmi]!")
 					var/obj/item/robot_parts/robot_suit/C = new/obj/item/robot_parts/robot_suit(loc)
@@ -883,12 +889,16 @@
 				if(istype(C.wrapped, /obj/item/broken_device))
 					var/obj/item/broken_device/I = C.wrapped
 					to_chat(user, "You remove \the [I].")
+					if(src.self_diagnosis())
+						to_chat(src, "<span class='info'><span style=\"font-family:Courier\">Destroyed [I.name] removed.</span>")
 					I.forceMove(src.loc)
 				else
 					var/obj/item/robot_parts/robot_component/I = C.wrapped
 					I.brute_damage = C.brute_damage
 					I.electronics_damage = C.electronics_damage
 					to_chat(user, "You remove \the [I].")
+					if(src.self_diagnosis())
+						to_chat(src, "<span class='info'><span style=\"font-family:Courier\">Functional [I.name] removed.</span>")
 					I.forceMove(src.loc)
 
 				if(C.installed == 1)
@@ -900,6 +910,8 @@
 				to_chat(user, "The cover is locked and cannot be opened.")
 			else
 				to_chat(user, "You open the cover.")
+				if(src.self_diagnosis())
+					to_chat(src, "<span class='info'><span style=\"font-family:Courier\">Cover opened.</span>")
 				opened = 1
 				updateicon()
 
@@ -917,11 +929,15 @@
 			oldpowercell.brute_damage = C.brute_damage
 			user.drop_item(W, src)
 			user.put_in_hands(oldpowercell)
+			if(src.self_diagnosis())
+				to_chat(src, "<span class='info'><span style=\"font-family:Courier\">Cell removed.</span>")
 			C.installed = 1
 			C.wrapped = W
 			C.electronics_damage = cell.electronics_damage
 			C.brute_damage = cell.brute_damage
 			C.install()
+			if(src.self_diagnosis())
+				to_chat(src, "<span class='info'><span style=\"font-family:Courier\">New cell installed. Type: [cell.name]. Charge: [cell.charge].</span>")
 		else
 			user.drop_item(W, src)
 			cell = W
@@ -932,6 +948,8 @@
 			C.electronics_damage = cell.electronics_damage
 			C.brute_damage = cell.brute_damage
 			C.install()
+			if(src.self_diagnosis())
+				to_chat(src, "<span class='info'><span style=\"font-family:Courier\">New cell installed. Type: [cell.name]. Charge: [cell.charge].</span>")
 
 	else if (iswiretool(W))
 		if (wiresexposed)
@@ -942,11 +960,15 @@
 	else if(isscrewdriver(W) && opened && !cell)	// haxing
 		wiresexposed = !wiresexposed
 		to_chat(user, "The wires have been [wiresexposed ? "exposed" : "unexposed"].")
+		if(src.self_diagnosis())
+			to_chat(src, "<span class='info'><span style=\"font-family:Courier\">Internal wiring [wiresexposed ? "exposed" : "unexposed"].</span>")
 		updateicon()
 
 	else if(isscrewdriver(W) && opened && cell)	// radio
 		if(radio)
 			radio.attackby(W,user)//Push it to the radio to let it handle everything
+			if(src.self_diagnosis())
+				to_chat(src, "<span class='info'><span style=\"font-family:Courier\">Radio encryption keys modified.</span>")
 		else
 			to_chat(user, "Unable to locate a radio.")
 		updateicon()
@@ -954,6 +976,8 @@
 	else if(istype(W, /obj/item/device/encryptionkey/) && opened)
 		if(radio)//sanityyyyyy
 			radio.attackby(W,user)//GTFO, you have your own procs
+			if (src.self_diagnosis())
+				to_chat(src, "<span class='info'><span style=\"font-family:Courier\">Radio encryption key installed.</span>")
 		else
 			to_chat(user, "Unable to locate a radio.")
 
@@ -966,6 +990,8 @@
 			if(allowed(usr))
 				locked = !locked
 				to_chat(user, "You [ locked ? "lock" : "unlock"] [src]'s interface.")
+				if(src.self_diagnosis())
+					to_chat(src, "<span class='info'><span style=\"font-family:Courier\">Interface [ locked ? "locked" : "unlocked"].</span>")
 				updateicon()
 			else
 				to_chat(user, "<span class='warning'>Access denied.</span>")
@@ -973,6 +999,8 @@
 	else if(istype(W, /obj/item/borg/upgrade/))
 		var/obj/item/borg/upgrade/U = W
 		U.attempt_action(src,user)
+		if(src.self_diagnosis())
+			to_chat(src, "<span class='info'><span style=\"font-family:Courier\">Installation of [U.name] attempted.</span>")
 
 	else if(istype(W, /obj/item/device/camera_bug))
 		help_shake_act(user)
@@ -1042,6 +1070,8 @@
 			user.put_in_active_hand(cell)
 			user.visible_message("<span class='warning'>[user] removes [src]'s [cell.name].</span>", \
 			"<span class='notice'>You remove [src]'s [cell.name].</span>")
+			if(src.self_diagnosis())
+				to_chat(src, "<span class='info'><span style=\"font-family:Courier\">Cell removed.</span>")
 			src.attack_log += "\[[time_stamp()]\] <font color='orange'>Has had their [cell.name] removed by [user.name] ([user.ckey])</font>"
 			user.attack_log += "\[[time_stamp()]\] <font color='red'>Removed the [cell.name] of [src.name] ([src.ckey])</font>"
 			log_attack("<font color='red'>[user.name] ([user.ckey]) removed [src]'s [cell.name] ([src.ckey])</font>")
@@ -1055,6 +1085,8 @@
 			var/obj/item/broken_device = cell_component.wrapped
 			to_chat(user, "You remove \the [broken_device].")
 			user.put_in_active_hand(broken_device)
+			if(src.self_diagnosis())
+				to_chat(src, "<span class='info'><span style=\"font-family:Courier\">Destroyed [broken_device] removed.</span>")
 			return
 
 	switch(user.a_intent)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -979,7 +979,7 @@
 	else if(istype(W, /obj/item/device/encryptionkey/) && opened)
 		if(radio)//sanityyyyyy
 			radio.attackby(W,user)//GTFO, you have your own procs
-			if (src.can_diagnose())
+			if (can_diagnose())
 				to_chat(src, "<span class='info' style=\"font-family:Courier\">Radio encryption key installed.</span>")
 		else
 			to_chat(user, "Unable to locate a radio.")

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -30,6 +30,9 @@
 /mob/living/silicon/feels_pain()
 	return FALSE
 
+/mob/living/silicon/proc/can_diagnose()
+	return null
+	
 /mob/living/silicon/proc/cancelAlarm()
 	return
 


### PR DESCRIPTION
Adds self-diagnosis messages for various borg related things, like
- interface locking and unlocking
- cover opening and closing
- component additions and removals
- radio modifications
- cell changes
- upgrade installations

all of these only when the self-diagnosis component is functional 

Revision 1:
- Added a helper proc to slightly reduce resource usage
- added messages for when components are destroyed *except for the self-diagnosis unit*
- fixed up the message saying which broken component is removed
- added failure / success message to upgrade installations

![image](https://cloud.githubusercontent.com/assets/8468269/26740354/7a679870-47d5-11e7-8f88-b0f68235024a.png)
![image](https://cloud.githubusercontent.com/assets/8468269/26740515/345dcaba-47d6-11e7-9e07-38a736797592.png)

resolves #13989
tested
🆑 
 - rscadd: Borgs now get some messages regarding what's happening to their body and components, as long as their self-diagnosis unit is working.