### PR TITLE
Shocking Handshakes

### DIFF
--- a/code/modules/clothing/gloves/stungloves.dm
+++ b/code/modules/clothing/gloves/stungloves.dm
@@ -72,8 +72,12 @@
 	if(prox == TRUE)//Stungloves. ANY contact will stun the alien.
 		if(ishuman(user))
 			var/mob/living/carbon/human/H = user
+			var/datum/organ/external/S = H.get_organ(H.zone_sel.selecting)
+
 			if(H.check_body_part_coverage(HANDS,src)) //can't touch someone if something is on top of them
 				return
+			else if((H.zone_sel.selecting == "l_hand" && !(S.status & ORGAN_DESTROYED)) || (H.zone_sel.selecting == "r_hand" && !(S.status & ORGAN_DESTROYED)))
+				return //attempt to stun handshake
 		visible_message("<span class='danger'>\The [A] has been touched with the stun gloves by [user]!</span>")
 
 		if(cell.charge >= STUNGLOVES_CHARGE_COST)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -246,7 +246,7 @@
 					shock_damage = T.siemens_coefficient * shock_damage
 
 				if (U && U.wired && U.cell && U.cell.charge >= STUNGLOVES_CHARGE_COST && !(istype(src.get_item_by_slot(slot_gloves), /obj/item/clothing/gloves/yellow)))
-					sparks.set_up(3, 0, src)
+					sparks.set_up(1, 0, src)
 					add_logs(src, M, "stungloved", admin = TRUE)
 					visible_message("<span class='danger'>\The [src] can't seem to let go from \the [M]'s shocking handshake!</span>")
 					src.apply_effect(effect = 1, effecttype = PARALYZE)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -243,7 +243,7 @@
 				if (istype(T, /obj/item/clothing/gloves))
 					shock_damage = T.siemens_coefficient * shock_damage
 
-				if (U && U.wired && U.cell && U.cell.charge >= STUNGLOVES_CHARGE_COST && !(istype(T, /obj/item/clothing/gloves/yellow)))
+				if (U && U.wired && U.cell && U.cell.charge >= STUNGLOVES_CHARGE_COST && T.siemens_coefficient > 0)
 					shock_time = U.cell.charge/STUNGLOVES_CHARGE_COST
 					shock_damage = shock_damage * shock_time
 
@@ -273,7 +273,7 @@
 						M.SetStunned(0)
 						to_chat(M, "<span class='notice'>Your gloves run out of power.</span>")
 				else
-					if (U && U.wired && U.cell && U.cell.charge >= STUNGLOVES_CHARGE_COST && istype(T, /obj/item/clothing/gloves/yellow))
+					if (U && U.wired && U.cell && U.cell.charge >= STUNGLOVES_CHARGE_COST && T.siemens_coefficient == 0)
 						to_chat(M, "<span class='notice'>\The [src]'s insulated gloves prevent them from being shocked.</span>")
 
 					playsound(get_turf(src), 'sound/weapons/thudswoosh.ogg', 50, 1, -1)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -269,6 +269,7 @@
 						U.cell.charge = 0
 						H.remove_jitter()
 						H.SetStunned(0)
+						H.SetKnockdown(5)
 						M.SetStunned(0)
 						to_chat(M, "<span class='notice'>Your gloves run out of power.</span>")
 				else

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -157,11 +157,6 @@
 			hand_hud_object.icon_state = "hand_inactive"
 
 /mob/living/carbon/proc/help_shake_act(mob/living/carbon/M)
-	var/shock_damage = 5
-	var/obj/item/clothing/gloves/U
-	var/obj/item/clothing/gloves/T
-	var/datum/effect/effect/system/spark_spread/sparks = new /datum/effect/effect/system/spark_spread()
-
 	if (src.health >= config.health_threshold_crit)
 		if(src == M && istype(src, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = src
@@ -238,31 +233,48 @@
 					"<span class='notice'>You pat [src]'s head.</span>", \
 					)
 			else if((M.zone_sel.selecting == "l_hand" && !(S.status & ORGAN_DESTROYED)) || (M.zone_sel.selecting == "r_hand" && !(S.status & ORGAN_DESTROYED)))
-				if (istype(M.get_item_by_slot(slot_gloves), /obj/item/clothing/gloves))
-					U = M.get_item_by_slot(slot_gloves)
+				var/shock_damage = 5
+				var/shock_time = 0
+				var/obj/item/clothing/gloves/U = M.get_item_by_slot(slot_gloves)
+				var/obj/item/clothing/gloves/T = src.get_item_by_slot(slot_gloves)
+				var/mob/living/carbon/human/H
+				var/datum/effect/effect/system/spark_spread/sparks = new /datum/effect/effect/system/spark_spread()
 
-				if (istype(src.get_item_by_slot(slot_gloves), /obj/item/clothing/gloves/fyellow))
-					T = src.get_item_by_slot(slot_gloves)
+				if (istype(T, /obj/item/clothing/gloves))
 					shock_damage = T.siemens_coefficient * shock_damage
 
-				if (U && U.wired && U.cell && U.cell.charge >= STUNGLOVES_CHARGE_COST && !(istype(src.get_item_by_slot(slot_gloves), /obj/item/clothing/gloves/yellow)))
-					sparks.set_up(1, 0, src)
-					add_logs(src, M, "stungloved", admin = TRUE)
-					visible_message("<span class='danger'>\The [src] can't seem to let go from \the [M]'s shocking handshake!</span>")
-					src.apply_effect(effect = 1, effecttype = PARALYZE)
-					playsound(src,(src.gender == MALE) ? pick(male_scream_sound) : pick(female_scream_sound),50,1)
-					while(U.cell.charge >= STUNGLOVES_CHARGE_COST)
-						U.cell.charge -= STUNGLOVES_CHARGE_COST
-						src.apply_damage(damage = shock_damage, damagetype = BURN, def_zone = (M.zone_sel.selecting == "r_hand") ? "r_hand" : "l_hand" )
-						sparks.start()
-						sleep(1)
-						animate(src, pixel_y = pixel_y + 2 * PIXEL_MULTIPLIER, time = 1, loop = 2)
-						sleep(1)
-						animate(src, pixel_y = pixel_y - 2 * PIXEL_MULTIPLIER, time = 1, loop = 2)
-					to_chat(M, "<span class='notice'>Your gloves run out of power.</span>")
+				if (U && U.wired && U.cell && U.cell.charge >= STUNGLOVES_CHARGE_COST && !(istype(T, /obj/item/clothing/gloves/yellow)))
+					shock_time = U.cell.charge/STUNGLOVES_CHARGE_COST
+					shock_damage = shock_damage * shock_time
+
+					if ((M_CLUMSY in M.mutations) && prob(10))
+						to_chat(M, "<span class='warning'>You accidentally shake hands with yourself!</span>")
+						H = M
+					else
+						H = src
+						visible_message("<span class='danger'>\The [H] can't seem to let go from \the [M]'s shocking handshake!</span>")
+						add_logs(H, M, "stungloved", admin = TRUE)
+			
+					playsound(H,(H.gender == MALE) ? pick(male_scream_sound) : pick(female_scream_sound),50,1)
+					H.apply_damage(damage = shock_damage, damagetype = BURN, def_zone = (M.zone_sel.selecting == "r_hand") ? "r_hand" : "l_hand" )
+
+					sparks.set_up(3, 0, H)
+					sparks.start()
+
+					H.Stun(shock_time SECONDS)
+					M.Stun(shock_time SECONDS)
+					H.Jitter(shock_time SECONDS)
+
+					spawn(shock_time SECONDS)
+						U.cell.charge = 0
+						H.remove_jitter()
+						H.SetStunned(0)
+						M.SetStunned(0)
+						to_chat(M, "<span class='notice'>Your gloves run out of power.</span>")
 				else
-					if (U && U.wired && U.cell && U.cell.charge >= STUNGLOVES_CHARGE_COST && istype(src.get_item_by_slot(slot_gloves), /obj/item/clothing/gloves/yellow))
-						to_chat(M, "<span class='notice'>The [src]'s insulated gloves prevent them from being shocked.</span>")
+					if (U && U.wired && U.cell && U.cell.charge >= STUNGLOVES_CHARGE_COST && istype(T, /obj/item/clothing/gloves/yellow))
+						to_chat(M, "<span class='notice'>\The [src]'s insulated gloves prevent them from being shocked.</span>")
+
 					playsound(get_turf(src), 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 					M.visible_message( \
 						"<span class='notice'>[M] shakes hands with [src].</span>", \

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -2,7 +2,6 @@
 	gender = NEUTER
 	voice_name = "synthesized voice"
 	can_butcher = 0
-	var/flashed = 0
 	var/syndicate = 0
 	var/datum/ai_laws/laws = null//Now... THEY ALL CAN ALL HAVE LAWS
 	var/list/alarms_to_show = list()

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -2,6 +2,7 @@
 	gender = NEUTER
 	voice_name = "synthesized voice"
 	can_butcher = 0
+	var/flashed = 0
 	var/syndicate = 0
 	var/datum/ai_laws/laws = null//Now... THEY ALL CAN ALL HAVE LAWS
 	var/list/alarms_to_show = list()


### PR DESCRIPTION
Requires stungloves.
- Handshaking with people will continue until the battery is drained.
- Better battery cells = longer handshake = more damage
- Shittier gloves(budget) on the target = more damage(depends on siemens coefficient)
- Insulated gloves protect you from shocking handshakes
- 10% clumsy chance to shake hands with yourself

Things to do
- ~~Check for clumsy and make them handshake themselves~~

Example image
![](http://i.imgur.com/gnAo7Tw.gif)
:cl:
 * rscadd: You can now handshake shock people with stungloves
