### PR TITLE
Become Snakes Tweaks

### DIFF
--- a/code/_onclick/hud/spell_screen_objects.dm
+++ b/code/_onclick/hud/spell_screen_objects.dm
@@ -140,6 +140,10 @@
 	for(var/obj/abstract/screen/spell/spell in spell_objects)
 		spell.update_charge(forced)
 
+/obj/abstract/screen/movable/spell_master/proc/on_holder_death(mob/user)
+	for(var/obj/abstract/screen/spell/spell in spell_objects)
+		spell.spell.on_holder_death(user)
+
 
 /obj/abstract/screen/movable/spell_master/genetic
 	name = "Mutant Powers"

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -43,6 +43,9 @@
 	stat_collection.add_death_stat(src)
 	for(var/obj/item/I in src)
 		I.OnMobDeath(src)
+	if(spell_masters && spell_masters.len)
+		for(var/obj/abstract/screen/movable/spell_master/spell_master in spell_masters)
+			spell_master.on_holder_death(src)
 	if(transmogged_from)
 		var/obj/transmog_body_container/C = transmogged_from
 		var/mob/living/L = C.contained_mob

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -129,6 +129,10 @@
 
 var/list/wizard_snakes
 
+/mob/living/simple_animal/cat/snek/wizard
+	health = 5
+	maxHealth = 5
+
 /mob/living/simple_animal/cat/snek/wizard/New(turf/T, var/spell_holder)	//For the snake spell
 	..(T)
 	if(!wizard_snakes)

--- a/code/modules/spells/aoe_turf/aoe_turf.dm
+++ b/code/modules/spells/aoe_turf/aoe_turf.dm
@@ -7,12 +7,15 @@ Aoe turf spells have two useful flags: IGNOREDENSE and IGNORESPACE. These are ex
 /spell/aoe_turf //affects all turfs in view or range (depends)
 	spell_flags = IGNOREDENSE
 	var/inner_radius = -1 //for all your ring spell needs
+	var/center	//in case it's not supposed to center on the caster
 
 /spell/aoe_turf/choose_targets(mob/user = usr)
 	var/list/targets = list()
-
-	for(var/turf/target in view_or_range(range, holder, selection_type))
-		if(!(target in view_or_range(inner_radius, holder, selection_type)))
+	var/spell_center = holder
+	if(center)
+		spell_center = center
+	for(var/turf/target in view_or_range(range, spell_center, selection_type))
+		if(!(target in view_or_range(inner_radius, spell_center, selection_type)))
 			if(target.density && (spell_flags & IGNOREDENSE))
 				continue
 			if(istype(target, /turf/space) && (spell_flags & IGNORESPACE))
@@ -23,3 +26,13 @@ Aoe turf spells have two useful flags: IGNOREDENSE and IGNORESPACE. These are ex
 		return
 
 	return targets
+
+/spell/aoe_turf/is_valid_target(var/target, mob/user, options)
+	var/spell_center = user
+	if(center)
+		spell_center = center
+	return ((target in view_or_range(range, spell_center, selection_type)))
+
+/spell/aoe_turf/perform(mob/user = usr, skipcharge = 0, list/target_override)
+	. = ..()
+	center = null

--- a/code/modules/spells/aoe_turf/conjure/snakes.dm
+++ b/code/modules/spells/aoe_turf/conjure/snakes.dm
@@ -32,3 +32,7 @@
 		for(var/mob/M in wizard_snakes)
 			if(wizard_snakes[M] == holder)
 				qdel(M)
+
+/spell/aoe_turf/conjure/snakes/choose_targets(mob/user = usr)
+	center = pick(view_or_range(range, holder, selection_type))
+	return ..()

--- a/code/modules/spells/aoe_turf/conjure/snakes.dm
+++ b/code/modules/spells/aoe_turf/conjure/snakes.dm
@@ -14,13 +14,21 @@
 	summon_amt = 49
 
 /spell/aoe_turf/conjure/snakes/cast(list/targets, mob/user)
-	if(wizard_snakes)
-		for(var/mob/M in wizard_snakes)
-			if(wizard_snakes[M] == holder)
-				qdel(M)
+	delete_snakes()
 	if(!..())
 		user.visible_message("<span class='warning'>\The [user]'s body splits into a mass of snakes!</span>","<span class='notice'>Your body splits into a mass of snakes.</span>")
 		user.transmogrify(/mob/living/simple_animal/cat/snek/wizard, TRUE)
 
 /spell/aoe_turf/conjure/snakes/summon_object(var/type, var/location)
 	return new type(location, holder)
+
+/spell/aoe_turf/conjure/snakes/on_holder_death(mob/user)
+	delete_snakes(user)
+
+/spell/aoe_turf/conjure/snakes/proc/delete_snakes(mob/user)
+	if(!user)
+		user = holder
+	if(wizard_snakes)
+		for(var/mob/M in wizard_snakes)
+			if(wizard_snakes[M] == holder)
+				qdel(M)

--- a/code/modules/spells/spell_code.dm
+++ b/code/modules/spells/spell_code.dm
@@ -549,3 +549,6 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 
 /spell/proc/on_removed(mob/user)
 	return
+
+/spell/proc/on_holder_death(mob/user)
+	return


### PR DESCRIPTION
The health of wizard snakes has been reduced from 20 to 5.
Wizard snakes now disappear when the wizard who spawned them dies.
The wizard is no longer always in the center of the spawned snakes.
