### PR TITLE
Gives biosuits plasma resistance

### DIFF
--- a/code/modules/clothing/suits/bio.dm
+++ b/code/modules/clothing/suits/bio.dm
@@ -4,7 +4,7 @@
 	icon_state = "bio"
 	desc = "A hood that protects the head and face from biological comtaminants."
 	permeability_coefficient = 0.01
-	flags = FPRINT
+	flags = FPRINT | PLASMAGUARD
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 100, rad = 20)
 	body_parts_covered = HEAD|EARS|EYES|MOUTH
 	siemens_coefficient = 0.9
@@ -17,7 +17,7 @@
 	w_class = W_CLASS_LARGE//bulky item
 	gas_transfer_coefficient = 0.01
 	permeability_coefficient = 0.01
-	flags = FPRINT
+	flags = FPRINT | PLASMAGUARD
 	body_parts_covered = ARMS|LEGS|FULL_TORSO|FEET|HANDS
 	slowdown = 1.0
 	allowed = list(/obj/item/weapon/tank/emergency_oxygen,/obj/item/weapon/tank/emergency_nitrogen,/obj/item/weapon/pen,/obj/item/device/flashlight/pen)


### PR DESCRIPTION
Adds plasmaguard to biosuits, allowing those with access to them to brave plasma spills without their clothes being contaminated.
![whoops](https://cloud.githubusercontent.com/assets/15067109/26799522/ef045b96-4a2d-11e7-9797-6dc9893df5da.png)
 
If that plasma becomes ignited or is at high pressure you're still screwed however.
:cl:
 * rscadd: Biosuits now prevent plasma clothing contamination, toxins can now clean up its own mistakes!
