### PR TITLE
Hand Restraint Refactor

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -45,6 +45,9 @@ obj/item/proc/get_clamped_volume()
 		return Clamp(src.w_class * 6, 10, 100) // Multiply the item's weight class by 6, then clamp the value between 10 and 100
 
 /obj/item/proc/attack(mob/living/M as mob, mob/living/user as mob, def_zone, var/originator = null)
+	if(restraint_resist_time > 0)
+		if(restraint_apply_check(M, user))
+			return attempt_apply_restraints(M, user)
 	if(originator)
 		return handle_attack(src, M, user, def_zone, originator)
 	else

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -56,6 +56,9 @@
 
 	var/vending_cat = null// subcategory for vending machines.
 	var/list/dynamic_overlay[0] //For items which need to slightly alter their on-mob appearance while being worn.
+	var/restraint_resist_time = 0	//When set, allows the item to be applied as restraints, which take this amount of time to resist out of
+	var/restraint_apply_time = 3 SECONDS
+	var/restraint_apply_sound = null
 
 /obj/item/proc/return_thermal_protection()
 	return return_cover_protection(body_parts_covered) * (1 - src.heat_conductivity)
@@ -1127,3 +1130,72 @@ var/global/list/image/blood_overlays = list()
 
 	spawn(duration + 1)
 		hud_layerise()
+
+/obj/item/proc/restraint_apply_intent_check(mob/user)
+	if(user.a_intent == I_GRAB)
+		return 1
+
+/obj/item/proc/restraint_apply_check(mob/living/carbon/M, mob/user)
+	if(!istype(M))
+		return
+
+	if(!restraint_apply_intent_check(user))
+		return
+
+	if(!user.dexterity_check())
+		to_chat(usr, "<span class='warning'>You don't have the dexterity to do this!</span>")
+		return
+
+	if(M.handcuffed)
+		return
+
+	M.attack_log += text("\[[time_stamp()]] <span style='color: orange'>Has been restrained (attempt) by [user.name] ([user.ckey]) with \the [src].</span>")
+	user.attack_log += text("\[[time_stamp()]] <span style='color: red'>Attempted to restrain [M.name] ([M.ckey]) with \the [src].</span>")
+	if(!iscarbon(user))
+		M.LAssailant = null
+	else
+		M.LAssailant = user
+
+	log_attack("[user.name] ([user.ckey]) Attempted to restrain [M.name] ([M.ckey]) with \the [src].")
+	return 1
+
+/obj/item/proc/attempt_apply_restraints(mob/living/carbon/C, mob/user)
+	if(!istype(C)) //Sanity doesn't hurt, right ?
+		return FALSE
+
+	if(ishuman(C))
+		var/mob/living/carbon/human/H = C
+		if (!H.has_organ_for_slot(slot_handcuffed))
+			to_chat(user, "<span class='danger'>\The [C] needs at least two wrists before you can cuff them together!</span>")
+			return
+
+	if(restraint_apply_sound)
+		playsound(get_turf(src), restraint_apply_sound, 30, 1, -2)
+	user.visible_message("<span class='danger'>[user] is trying to restrain \the [C] with \the [src]!</span>",
+						 "<span class='danger'>You try to restrain \the [C] with \the [src]!</span>")
+
+	if(do_after(user, C, restraint_apply_time))
+		feedback_add_details("handcuffs", "[name]")
+
+		if(clumsy_check(user) && prob(50))
+			to_chat(user, "<span class='warning'>Uh... how is this done?!</span>")
+			C = user
+
+		user.visible_message("<span class='danger'>\The [user] has restrained \the [C] with \the [src]!</span>")
+		user.attack_log += text("\[[time_stamp()]\] <font color='red'>Has restrained [C.name] ([C.ckey]) with \the [src].</font>")
+		C.attack_log += text("\[[time_stamp()]\] <font color='red'>Restrained with \the [src] by [user.name] ([user.ckey])</font>")
+		log_attack("[user.name] ([user.ckey]) has restrained [C.name] ([C.ckey]) with \the [src]")
+
+		var/obj/item/cuffs = src
+		if(istype(src, /obj/item/weapon/handcuffs/cyborg)) //There's GOT to be a better way to check for this.
+			cuffs = new /obj/item/weapon/handcuffs/cyborg(get_turf(user))
+		else
+			user.drop_from_inventory(cuffs)
+		C.equip_to_slot(cuffs, slot_handcuffed)
+		cuffs.on_restraint_apply(C)
+
+/obj/item/proc/on_restraint_removal(var/mob/living/carbon/C) //Needed for syndicuffs
+	return
+
+/obj/item/proc/on_restraint_apply(var/mob/living/carbon/C)
+	return

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -18,72 +18,16 @@
 	w_type = RECYK_METAL
 	melt_temperature = MELTPOINT_STEEL
 	origin_tech = Tc_MATERIALS + "=1"
-	var/cuffing_sound = 'sound/weapons/handcuffs.ogg'
-	var/breakouttime = 2 MINUTES
+	restraint_apply_sound = 'sound/weapons/handcuffs.ogg'
+	restraint_resist_time = 2 MINUTES
 
-/obj/item/weapon/handcuffs/attack(var/mob/living/carbon/M, var/mob/user, var/def_zone)
-	if(!istype(M))
-		return
-
-	if(!user.dexterity_check())
-		to_chat(usr, "<span class='warning'>You don't have the dexterity to do this!</span>")
-		return
-
-	if(M.handcuffed)
-		return
-
-	M.attack_log += text("\[[time_stamp()]] <span style='color: orange'>Has been handcuffed (attempt) by [user.name] ([user.ckey])</span>")
-	user.attack_log += text("\[[time_stamp()]] <span style='color: red'>Attempted to handcuff [M.name] ([M.ckey])</span>")
-	if(!iscarbon(user))
-		M.LAssailant = null
-	else
-		M.LAssailant = user
-
-	log_attack("[user.name] ([user.ckey]) Attempted to handcuff [M.name] ([M.ckey])")
-
-	handcuffs_apply(M, user)
-
-//Our inventory procs should be able to handle the following, but our inventory code is hot spaghetti bologni, so here we go //There's no real reason for this to be a separate proc now but whatever
-/obj/item/weapon/handcuffs/proc/handcuffs_apply(var/mob/living/carbon/C, var/mob/user, var/clumsy = FALSE)
-	if(!istype(C)) //Sanity doesn't hurt, right ?
-		return FALSE
-
-	if(ishuman(C))
-		var/mob/living/carbon/human/H = C
-		if (!H.has_organ_for_slot(slot_handcuffed))
-			to_chat(user, "<span class='danger'>\The [C] needs at least two wrists before you can cuff them together!</span>")
-			return
-
-	playsound(get_turf(src), cuffing_sound, 30, 1, -2)
-	user.visible_message("<span class='danger'>[user] is trying to handcuff \the [C]!</span>",
-						 "<span class='danger'>You try to handcuff \the [C]!</span>")
-
-	if(do_after(user, C, 3 SECONDS))
-		if(istype(src, /obj/item/weapon/handcuffs/cable))
-			feedback_add_details("handcuffs", "C")
-		else
-			feedback_add_details("handcuffs", "H")
-
-		if(clumsy_check(user) && prob(50))
-			to_chat(user, "<span class='warning'>Uh... how do these things work?!</span>")
-			C = user
-
-		user.visible_message("<span class='danger'>\The [user] has put \the [src] on \the [C]!</span>")
-		user.attack_log += text("\[[time_stamp()]\] <font color='red'>Has put \the [src] on [C.name] ([C.ckey])</font>")
-		C.attack_log += text("\[[time_stamp()]\] <font color='red'>Handcuffed with \the [src] by [user.name] ([user.ckey])</font>")
-		log_attack("[user.name] ([user.ckey]) has cuffed [C.name] ([C.ckey]) with \the [src]")
-
-		var/obj/item/weapon/handcuffs/cuffs = src
-		if(istype(src, /obj/item/weapon/handcuffs/cyborg)) //There's GOT to be a better way to check for this.
-			cuffs = new /obj/item/weapon/handcuffs/cyborg(get_turf(user))
-		else
-			user.drop_from_inventory(cuffs)
-		C.equip_to_slot(cuffs, slot_handcuffed)
+/obj/item/weapon/handcuffs/restraint_apply_intent_check(mob/user)
+	return 1
 
 /obj/item/weapon/handcuffs/cyborg
 //This space intentionally left blank
 
-/obj/item/weapon/handcuffs/cyborg/on_remove(var/mob/living/carbon/C)
+/obj/item/weapon/handcuffs/cyborg/on_restraint_removal(var/mob/living/carbon/C)
 	spawn(1)
 		qdel(src)
 
@@ -109,10 +53,7 @@
 	if(slot == slot_handcuffed && mode == SYNDICUFFS_ON_APPLY && !charge_detonated)
 		detonate(1)
 
-/obj/item/weapon/handcuffs/proc/on_remove(var/mob/living/carbon/C) //Needed for syndicuffs
-	return
-
-/obj/item/weapon/handcuffs/syndicate/on_remove(mob/living/carbon/C)
+/obj/item/weapon/handcuffs/syndicate/on_restraint_removal(mob/living/carbon/C)
 	if(mode == SYNDICUFFS_ON_REMOVE && !charge_detonated)
 		detonate(0) //This handles cleaning up the inventory already
 		return //Don't clean up twice, we don't want runtimes
@@ -164,8 +105,8 @@
 	desc = "Looks like some cables tied together. Could be used to tie something up."
 	icon_state = "cuff_red"
 	_color = "red"
-	breakouttime = 300 //Deciseconds = 30s
-	cuffing_sound = 'sound/weapons/cablecuff.ogg'
+	restraint_resist_time = 30 SECONDS
+	restraint_apply_sound = 'sound/weapons/cablecuff.ogg'
 
 /obj/item/weapon/handcuffs/cable/red
 	icon_state = "cuff_red"

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -7,6 +7,8 @@
 	flags = FPRINT
 	slot_flags = SLOT_BELT
 	attack_verb = list("whips", "lashes", "disciplines")
+	restraint_resist_time = 30 SECONDS
+	restraint_apply_sound = "rustle"
 
 /obj/item/weapon/storage/belt/can_quick_store(var/obj/item/I)
 	return can_be_inserted(I,1)

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -9,7 +9,7 @@
 	var/life_tick = 0      // The amount of life ticks that have processed on this mob.
 	// total amount of wounds on mob, used to spread out healing and the like over all wounds
 	var/number_wounds = 0
-	var/obj/item/weapon/handcuffs/handcuffed = null //Whether or not the mob is handcuffed.
+	var/obj/item/handcuffed = null //Whether or not the mob is handcuffed.
 	var/obj/item/legcuffed = null  //Same as handcuffs but for legs. Bear traps use this.
 	//Surgery info
 	var/datum/surgery_status/op_stage = new/datum/surgery_status

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -326,7 +326,7 @@
 		slot = slot_back
 		update_inv_back()
 	else if (W == handcuffed)
-		if(handcuffed.on_remove(src)) //If this returns 1, then the unquipping action was interrupted
+		if(handcuffed.on_restraint_removal(src)) //If this returns 1, then the unquipping action was interrupted
 			return 0
 		handcuffed = null
 		success = 1

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -15,7 +15,7 @@
 	if(!W)
 		return 0
 	else if (W == handcuffed)
-		if(handcuffed.on_remove(src)) //If this returns 1, then the unquipping action was interrupted
+		if(handcuffed.on_restraint_removal(src)) //If this returns 1, then the unquipping action was interrupted
 			return 0
 		handcuffed = null
 		success = 1

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1115,10 +1115,10 @@ Thanks.
 					if(do_after(CM, CM, 50))
 						if(!CM.handcuffed || CM.locked_to)
 							return
-						CM.visible_message("<span class='danger'>[CM] manages to break the handcuffs!</span>",
-										   "<span class='notice'>You successfuly break your handcuffs.</span>")
+						CM.visible_message("<span class='danger'>[CM] manages to break \the [CM.handcuffed]!</span>",
+										   "<span class='notice'>You successfully break \the [CM.handcuffed].</span>")
 						CM.say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" ))
-						var/obj/item/weapon/handcuffs/cuffs = CM.handcuffed
+						var/obj/item/cuffs = CM.handcuffed
 						CM.drop_from_inventory(cuffs)
 						if(!cuffs.gcDestroyed) //If these were not qdel'd already (exploding cuffs, anyone?)
 							qdel(cuffs)
@@ -1127,23 +1127,23 @@ Thanks.
 
 
 			else
-				var/obj/item/weapon/handcuffs/HC = CM.handcuffed
-				var/breakouttime = HC.breakouttime
-				if(!(breakouttime))
-					breakouttime = 1200 //Default
-				CM.visible_message("<span class='danger'>[CM] attempts to remove [HC]!</span>",
-								   "<span class='warning'>You attempt to remove [HC] (this will take around [(breakouttime)/600] minutes and you need to stand still).</span>",
+				var/obj/item/HC = CM.handcuffed
+				var/resist_time = HC.restraint_resist_time
+				if(!(resist_time))
+					resist_time = 2 MINUTES //Default
+				CM.visible_message("<span class='danger'>[CM] attempts to remove \the [HC]!</span>",
+								   "<span class='warning'>You attempt to remove \the [HC] (this will take around [(resist_time)/600] minutes and you need to stand still).</span>",
 								   self_drugged_message="<span class='warning'>You attempt to regain control of your hands (this will take a while).</span>")
 				spawn(0)
-					if(do_after(CM,CM, breakouttime))
+					if(do_after(CM,CM, resist_time))
 						if(!CM.handcuffed || CM.locked_to)
 							return // time leniency for lag which also might make this whole thing pointless but the server
-						CM.visible_message("<span class='danger'>[CM] manages to remove [HC]!</span>",
-										   "<span class='notice'>You successfuly remove [HC].</span>",
+						CM.visible_message("<span class='danger'>[CM] manages to remove \the [HC]!</span>",
+										   "<span class='notice'>You successfully remove \the [HC].</span>",
 										   self_drugged_message="<span class='notice'>You successfully regain control of your hands.</span>")
 						CM.drop_from_inventory(HC)
 					else
-						CM.simple_message("<span class='warning'>Your uncuffing attempt was interrupted.</span>",
+						CM.simple_message("<span class='warning'>Your attempt to remove \the [HC] was interrupted.</span>",
 							"<span class='warning'>Your attempt to regain control of your hands was interrupted. Damn it!</span>")
 
 		else if(CM.legcuffed && CM.canmove && CM.special_delayer.blocked())


### PR DESCRIPTION
Is refactor the right word? I'm not sure.
Anyway, this PR moves hand restraining from `/obj/item/weapon/handcuffs` all the way up to `/obj/item`.
Now any item with its `restraint_resist_time` var set can be used to restrain a mob's hands. In most cases, this will require being in grab intent. Handcuffs/cablecuffs can still be used to restrain a mob while in any intent.
As a demonstration of the new capability, belts can now be used to restrain a mob's hands, having the same resist time as cablecuffs do.

The goal with this PR is to make truly improvised restraints more possible, and so hopefully cut down on the need people feel to powergame handcuffs/cablecuffs.

:cl:
 * rscadd: Belts can now be used to restrain a player's hands. To do so, simply attack the player with the belt while in grab intent.
