### PR TITLE
Banana Gun

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -193,6 +193,13 @@ var/list/uplink_items = list()
 	cost = 6
 	job = list("Clown")
 
+/datum/uplink_item/jobspecific/bananagun
+	name = "Banana Gun"
+	desc = "One shot only, appears to be a banana until fired. Do not attempt to eat."
+	item = /obj/item/weapon/gun/projectile/banana
+	cost = 2
+	job = list("Clown")
+
 /datum/uplink_item/jobspecific/superglue
 	name = "1 Bottle of Superglue"
 	desc = "Considered illegal everywhere except for the Clown Planet, this water-resistant superglue can instantly bind human flesh to ANY material, permanently. One-time use."

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -273,3 +273,33 @@
 		..()
 		cocked = FALSE
 		update_icon()
+
+/obj/item/weapon/gun/projectile/banana
+	name = "banana"
+	desc = "It's an excellent prop for a comedy."
+	icon = 'icons/obj/items.dmi'
+	icon_state = "banana"
+	item_state = "banana"
+	max_shells = 1
+	gun_flags = 0
+	conventional_firearm = 0
+
+/obj/item/weapon/gun/projectile/banana/proc/make_peel(mob/user)
+	user.drop_item(src, force_drop = 1)
+	var/obj/item/weapon/bananapeel/B = new(get_turf(src))
+	user.put_in_hands(B)
+	qdel(src)
+
+/obj/item/weapon/gun/projectile/banana/Fire(atom/target, mob/living/user, params, reflex = 0, struggle = 0)
+	. = ..()
+	make_peel(user)
+
+/obj/item/weapon/gun/projectile/banana/attack_self(mob/living/user)
+	if(process_chambered())
+		playsound(user, fire_sound, fire_volume, 1)
+		in_chamber.on_hit(user)
+		user.apply_damage(in_chamber.damage*1.5, in_chamber.damage_type, LIMB_HEAD, used_weapon = "Point blank shot in the mouth with \a [in_chamber]")
+		qdel(in_chamber)
+		in_chamber = null
+		make_peel(user)
+		user.visible_message("<span class='danger'>\The [src] explodes as \the [user] bites into it!</span>","<span class='danger'>\The [src] explodes as you bite into it!</span>")

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -283,6 +283,7 @@
 	max_shells = 1
 	gun_flags = 0
 	conventional_firearm = 0
+	clumsy_check = 0
 
 /obj/item/weapon/gun/projectile/banana/proc/make_peel(mob/user)
 	user.drop_item(src, force_drop = 1)


### PR DESCRIPTION
Adds the banana gun to clown traitor uplinks for 2 TC.
The banana gun appears to be a banana until fired. It only has a single shot, and can't be reloaded. Once fired, it becomes a banana peel.
Attempting to eat a banana gun will cause it to go off in your face, dealing 90 brute damage.

:cl:
 * rscadd: Added the banana gun to clown traitor uplinks for 2 TC. It appears to be a banana until fired. It only has one shot, and can't be reloaded.
