### PR TITLE
Fixed being unable to cancel crawling out of vents

### DIFF
--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -348,14 +348,17 @@ Pipelines + Other Objects -> Pipe network
 
 	var/obj/machinery/atmospherics/target_move = findConnecting(direction, user.ventcrawl_layer)
 	if(target_move)
-		if(is_type_in_list(target_move, ventcrawl_machinery) && target_move.can_crawl_through())
+		if(is_type_in_list(target_move, ventcrawl_machinery) && target_move.can_crawl_through() && !user.ventcrawl_exit_target)
 			user.visible_message("Something is squeezing through the ducts...", "You start crawling out the ventilation system.")
 			target_move.shake(2, 3)
-			if(do_after(user, target_move, 10))
-				user.remove_ventcrawl()
-				user.forceMove(target_move.loc) //handles entering and so on
-				user.visible_message("You hear something squeeze through the ducts.", "You climb out the ventilation system.")
-		else if(target_move.can_crawl_through())
+			user.ventcrawl_exit_target = target_move
+			spawn
+				if(do_after(user, src, 1 SECONDS))
+					user.remove_ventcrawl()
+					user.forceMove(target_move.loc) //handles entering and so on
+					user.visible_message("You hear something squeeze through the ducts.", "You climb out the ventilation system.")
+				user.ventcrawl_exit_target = null
+		else if(target_move != user.ventcrawl_exit_target && target_move.can_crawl_through())
 			if(target_move.return_network(target_move) != return_network(src))
 				user.remove_ventcrawl()
 				user.add_ventcrawl(target_move)

--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -352,7 +352,7 @@ Pipelines + Other Objects -> Pipe network
 			user.visible_message("Something is squeezing through the ducts...", "You start crawling out the ventilation system.")
 			target_move.shake(2, 3)
 			user.ventcrawl_exit_target = target_move
-			spawn
+			spawn()
 				if(do_after(user, src, 1 SECONDS))
 					user.remove_ventcrawl()
 					user.forceMove(target_move.loc) //handles entering and so on

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -62,7 +62,7 @@
 	var/list/icon/pipes_shown = list()
 	var/last_played_vent
 	var/is_ventcrawling = 0
-	var/ventcrawl_exit_target = FALSE // Used in [ATMOSPHERICS/atmospherics.dm] to prevent message spam and being able to ventcrawl past vents
+	var/ventcrawl_exit_target = null // Used in [ATMOSPHERICS/atmospherics.dm] to prevent message spam and being able to ventcrawl past vents
 
 	var/species_type
 	var/holder_type = /obj/item/weapon/holder/animal	//When picked up, put us into a holder of this type. Dionae use /obj/item/weapon/holder/diona, others - the default one

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -62,6 +62,7 @@
 	var/list/icon/pipes_shown = list()
 	var/last_played_vent
 	var/is_ventcrawling = 0
+	var/ventcrawl_exit_target = FALSE // Used in [ATMOSPHERICS/atmospherics.dm] to prevent message spam and being able to ventcrawl past vents
 
 	var/species_type
 	var/holder_type = /obj/item/weapon/holder/animal	//When picked up, put us into a holder of this type. Dionae use /obj/item/weapon/holder/diona, others - the default one


### PR DESCRIPTION
Related to the changes in #14923

Everything about this PR makes me uncomfortable: I'd like someone to comment on the usage of `spawn` and if there's a way to accomplish what this does without adding a new `mob/living`-level var.

At least it works.