### PR TITLE
MC update from TG

### DIFF
--- a/__DEFINES/MC.dm
+++ b/__DEFINES/MC.dm
@@ -1,4 +1,4 @@
-#define MC_TICK_CHECK ( world.tick_usage > CURRENT_TICKLIMIT ? pause() : 0 )
+#define MC_TICK_CHECK ( ( world.tick_usage > CURRENT_TICKLIMIT || src.state != SS_RUNNING ) ? pause() : 0 )
 // Used to smooth out costs to try and avoid oscillation.
 #define MC_AVERAGE_FAST(average, current) (0.7 * (average) + 0.3 * (current))
 #define MC_AVERAGE(average, current) (0.8 * (average) + 0.2 * (current))
@@ -44,6 +44,14 @@
 //	This flag overrides SS_KEEP_TIMING
 #define SS_POST_FIRE_TIMING 128
 
+//SUBSYSTEM STATES
+#define SS_IDLE 0     // aint doing shit.
+#define SS_QUEUED 1   // queued to run
+#define SS_RUNNING 2  // actively running
+#define SS_PAUSED 3   // paused by mc_tick_check
+#define SS_SLEEPING 4 // fire() slept.
+#define SS_PAUSING 5  // in the middle of pausing
+
 //Timing subsystem
-#define TIMER_NORMAL	"normal"
-#define TIMER_UNIQUE	"unique"
+#define TIMER_NORMAL "normal"
+#define TIMER_UNIQUE "unique"

--- a/code/controllers/mc/master.dm
+++ b/code/controllers/mc/master.dm
@@ -193,6 +193,7 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 		SS.queued_time = 0
 		SS.queue_next = null
 		SS.queue_prev = null
+		SS.state = SS_IDLE
 		if (SS.flags & SS_TICKER)
 			tickersubsystems += SS
 			timer += world.tick_lag * rand(1, 5)
@@ -301,7 +302,7 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 		if (!thing)
 			subsystemstocheck -= thing
 		SS = thing
-		if (SS.queued_time) //already in the queue
+		if (SS.state != SS_IDLE) //already in the queue
 			continue
 		if (SS.can_fire <= 0)
 			continue
@@ -380,19 +381,23 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 				ran_non_ticker = TRUE
 			ran = TRUE
 			tick_usage = world.tick_usage
-			queue_node_paused = queue_node.paused
-			queue_node.paused = FALSE
+			queue_node_paused = (queue_node.state == SS_PAUSED || queue_node.state == SS_PAUSING)
 			last_type_processed = queue_node
 
-			queue_node.fire(queue_node_paused)
+			queue_node.state = SS_RUNNING
 
+			var/state = queue_node.ignite(queue_node_paused)
+			if (state == SS_RUNNING)
+				state = SS_IDLE
 			current_tick_budget -= queue_node_priority
 			tick_usage = world.tick_usage - tick_usage
 
 			if (tick_usage < 0)
 				tick_usage = 0
 
-			if (queue_node.paused)
+			queue_node.state = state
+
+			if (state == SS_PAUSED)
 				queue_node.paused_ticks++
 				queue_node.paused_tick_usage += tick_usage
 				queue_node = queue_node.queue_next
@@ -461,7 +466,7 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 		SS.queue_prev = null
 		SS.queued_priority = 0
 		SS.queued_time = 0
-		SS.paused = 0
+		SS.state = SS_IDLE
 	if (queue_head && !istype(queue_head))
 		world.log << "MC: SoftReset: Found bad data in subsystem queue, queue_head = '[queue_head]'"
 	queue_head = null

--- a/code/controllers/mc/master.dm
+++ b/code/controllers/mc/master.dm
@@ -311,6 +311,7 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 		SS_flags = SS.flags
 		if (SS_flags & SS_NO_FIRE)
 			subsystemstocheck -= SS
+			continue
 		if (!(SS_flags & SS_TICKER) && (SS_flags & SS_KEEP_TIMING) && SS.last_fire + (SS.wait * 0.75) > world.time)
 			continue
 

--- a/code/controllers/mc/subsystem.dm
+++ b/code/controllers/mc/subsystem.dm
@@ -17,13 +17,13 @@
 	var/next_fire = 0     // Scheduled world.time for next fire()
 	var/cost = 0          // Average time to execute
 	var/tick_usage = 0    // Average tick usage
-	var/paused = 0        // Was this subsystem paused mid fire.
+	var/state = SS_IDLE   // Tracks the current state of the ss, running, paused, etc.
 	var/paused_ticks = 0  // Ticks this ss is taking to run right now.
 	var/paused_tick_usage // Total tick_usage of all of our runs while pausing this run
 	var/ticks = 1         // How many ticks does this ss take to run on avg.
 	var/times_fired = 0   // Number of times we have called fire()
 	var/queued_time = 0   // Time we entered the queue, (for timing and priority reasons)
-	var/queued_priority   // We keep a running total to make the math easier, if it changes mid-fire that would break our running total, so we store it here
+	var/queued_priority   // We keep a running total to make the math easier, if it changes priority mid-fire that would break our running total, so we store it here
 	// Linked list stuff for the queue
 	var/datum/subsystem/queue_next
 	var/datum/subsystem/queue_prev
@@ -39,10 +39,23 @@
 /datum/subsystem/proc/Shutdown()
 	return
 
+//This is used so the mc knows when the subsystem sleeps. do not override.
+/datum/subsystem/proc/ignite(resumed = 0)
+	set waitfor = 0
+	. = SS_SLEEPING
+	fire(resumed)
+	. = state
+	if (state == SS_SLEEPING)
+		state = SS_IDLE
+	if (state == SS_PAUSING)
+		var/QT = queued_time
+		enqueue()
+		state = SS_PAUSED
+		queued_time = QT
+
 //previously, this would have been named 'process()' but that name is used everywhere for different things!
 //fire() seems more suitable. This is the procedure that gets called every 'wait' deciseconds.
-//fire(), and the procs it calls, SHOULD NOT HAVE ANY SLEEP OPERATIONS in them!
-//YE BE WARNED!
+//Sleeping in here prevents future fires until returned.
 /datum/subsystem/proc/fire(resumed = 0)
 	set waitfor = 0 //this should not be depended upon, this is just to solve issues with sleeps messing up tick tracking
 	can_fire = 0
@@ -55,6 +68,9 @@
 	flags |= SS_NO_FIRE
 	Master.subsystems -= src
 
+// Queue it to run.
+//   (we loop thru a linked list until we get to the end or find the right point)
+//   (this lets us sort our run order correctly without having to re-sort the entire already sorted list)
 /datum/subsystem/proc/enqueue()
 	var/SS_priority = priority
 	var/SS_flags = flags
@@ -88,6 +104,7 @@
 
 	queued_time = world.time
 	queued_priority = SS_priority
+	state = SS_QUEUED
 	if (SS_flags & SS_BACKGROUND) //update our running total
 		Master.queue_priority_count_bg += SS_priority
 	else
@@ -122,12 +139,16 @@
 	if (src == Master.queue_head)
 		Master.queue_head = queue_next
 	queued_time = 0
+	if (state == SS_QUEUED)
+		state = SS_IDLE
 
 
 /datum/subsystem/proc/pause()
 	. = 1
-	paused = TRUE
-	paused_ticks++
+	if (state == SS_RUNNING)
+		state = SS_PAUSED
+	else if (state == SS_SLEEPING)
+		state = SS_PAUSING
 
 //used to initialize the subsystem AFTER the map has loaded
 /datum/subsystem/proc/Initialize(start_timeofday)
@@ -150,7 +171,25 @@
 	else
 		msg = "OFFLINE\t[msg]"
 
-	stat(name, statclick.update(msg))
+	var/title = name
+	if (can_fire)
+		title = "\[[state_letter()]] [title]"
+
+	stat(title, statclick.update(msg))
+
+/datum/subsystem/proc/state_letter()
+	switch (state)
+		if (SS_RUNNING)
+			. = "R"
+		if (SS_QUEUED)
+			. = "Q"
+		if (SS_PAUSED, SS_PAUSING)
+			. = "P"
+		if (SS_SLEEPING)
+			. = "S"
+		if (SS_IDLE)
+			. = "  "
+
 
 //could be used to postpone a costly subsystem for (default one) var/cycles, cycles
 //for instance, during cpu intensive operations like explosions
@@ -163,11 +202,11 @@
 /datum/subsystem/proc/Recover()
 	flags |= SS_NO_INIT
 
-//this is so the subsystem doesn't rapid fire to make up missed ticks causing more lag
 /*
 /datum/subsystem/vv_edit_var(var_name, var_value)
 	switch (var_name)
 		if ("can_fire")
+			//this is so the subsystem doesn't rapid fire to make up missed ticks causing more lag
 			if (var_value)
 				next_fire = world.time + wait
 		if ("queued_priority") //editing this breaks things.

--- a/code/controllers/mc/subsystem.dm
+++ b/code/controllers/mc/subsystem.dm
@@ -17,7 +17,7 @@
 	var/next_fire = 0     // Scheduled world.time for next fire()
 	var/cost = 0          // Average time to execute
 	var/tick_usage = 0    // Average tick usage
-	var/state = SS_IDLE   // Tracks the current state of the ss, running, paused, etc.
+	var/state = SS_IDLE   // Tracks the current state of the ss. Running, paused, etc.
 	var/paused_ticks = 0  // Ticks this ss is taking to run right now.
 	var/paused_tick_usage // Total tick_usage of all of our runs while pausing this run
 	var/ticks = 1         // How many ticks does this ss take to run on avg.
@@ -166,7 +166,7 @@
 	if(!statclick)
 		statclick = new/obj/effect/statclick/debug("Initializing...", src)
 
-	if(can_fire)
+	if(can_fire && !(SS_NO_FIRE in flags))
 		msg = "[round(cost,1)]ms|[round(tick_usage,1)]%|[round(ticks,0.1)]\t[msg]"
 	else
 		msg = "OFFLINE\t[msg]"

--- a/code/controllers/mc/subsystem.dm
+++ b/code/controllers/mc/subsystem.dm
@@ -166,7 +166,7 @@
 	if(!statclick)
 		statclick = new/obj/effect/statclick/debug("Initializing...", src)
 
-	if(can_fire && !(SS_NO_FIRE in flags))
+	if(can_fire && !(flags & SS_NO_FIRE))
 		msg = "[round(cost,1)]ms|[round(tick_usage,1)]%|[round(ticks,0.1)]\t[msg]"
 	else
 		msg = "OFFLINE\t[msg]"

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -256,7 +256,7 @@
 	return
 
 /mob/living/proc/adjust_fire_stacks(add_fire_stacks) //Adjusting the amount of fire_stacks we have on person
-    fire_stacks = Clamp(fire_stacks + add_fire_stacks, -20, 20)
+	fire_stacks = Clamp(fire_stacks + add_fire_stacks, -20, 20)
 
 /mob/living/proc/handle_fire()
 	if((flags & INVULNERABLE) && on_fire)


### PR DESCRIPTION
Ripped wholesale from the XGM branch, to which @PJB3005 ported it from tgstation/tgstation#23494.
My understanding of these changes is tenuous at best, but I can't *see* anything that could cause problems, and I ran a test round on local without any problems, so it's probably fine. I still want to do more testing when I'm more awake, though.

Theoretically fixes any bugs related to a subsystem sleeping in its `fire()`, but no code on this codebase allows that to happen, as far as I'm aware.

Oh, and also fixes `/mob/living/adjust_fire_stacks()` being tabbed with spaces rather than a tab. This is completely and utterly unrelated to the rest of the changes. It was just fixed in the same commit on the XGM branch and was minor enough I decided there was no reason not to.
I don't think it actually changes anything. Which is odd, because tabbing with spaces usually doesn't work. But apparently it did in this case, because the proc seems to already work.