### PR TITLE
Allows grinding matches on a Mortar to acquire phosphorus.

### DIFF
--- a/code/modules/reagents/machinery/mortar.dm
+++ b/code/modules/reagents/machinery/mortar.dm
@@ -31,6 +31,7 @@
 		/obj/item/weapon/cell                 = list(LITHIUM, 10),
 		/obj/item/clothing/head/butt          = list(MERCURY, 10),
 		/obj/item/weapon/rocksliver           = list(GROUND_ROCK,30),
+        /obj/item/weapon/match                = list(PHOSPHORUS, 2),
 
 		//Recipes must include both variables!
 		/obj/item/weapon/reagent_containers/food = list("generic",0)

--- a/code/modules/reagents/machinery/mortar.dm
+++ b/code/modules/reagents/machinery/mortar.dm
@@ -31,7 +31,7 @@
 		/obj/item/weapon/cell                 = list(LITHIUM, 10),
 		/obj/item/clothing/head/butt          = list(MERCURY, 10),
 		/obj/item/weapon/rocksliver           = list(GROUND_ROCK,30),
-		/obj/item/weapon/match				  = list(PHOSPHORUS, 2),
+		/obj/item/weapon/match                = list(PHOSPHORUS, 2),
 
 		//Recipes must include both variables!
 		/obj/item/weapon/reagent_containers/food = list("generic",0)

--- a/code/modules/reagents/machinery/mortar.dm
+++ b/code/modules/reagents/machinery/mortar.dm
@@ -31,7 +31,7 @@
 		/obj/item/weapon/cell                 = list(LITHIUM, 10),
 		/obj/item/clothing/head/butt          = list(MERCURY, 10),
 		/obj/item/weapon/rocksliver           = list(GROUND_ROCK,30),
-        /obj/item/weapon/match                = list(PHOSPHORUS, 2),
+		/obj/item/weapon/match				  = list(PHOSPHORUS, 2),
 
 		//Recipes must include both variables!
 		/obj/item/weapon/reagent_containers/food = list("generic",0)


### PR DESCRIPTION
It kinda makes sense, and it feels like it's a nice alternative way to get Phosphorus
before the only way to ghetto chem that was to get a Groans Banned Soda: Sour Suprise and electrolyze the poly acid.
:cl:
 * rscadd: You can now grind matches on a Mortar to acquire Phosphorus (2u per Match)