### PR TITLE
Envelopes Can Now Be Mailed

### DIFF
--- a/code/modules/paperwork/envelope.dm
+++ b/code/modules/paperwork/envelope.dm
@@ -5,6 +5,7 @@
 	var/obj/item/weapon/paper/contained_paper
 	var/open = TRUE
 	var/torn = FALSE
+	var/sortTag
 
 /obj/item/weapon/paper/envelope/update_icon()
 	overlays.len = 0
@@ -40,6 +41,20 @@
 			open()
 			user.visible_message("\The [user] slices the top of \the [src] open with \the [P].","You slice the top of \the [src] open with \the [P].")
 			playsound(get_turf(src), 'sound/effects/paper_tear.ogg', 10, 1)
+
+	if(istype(P, /obj/item/device/destTagger))
+		var/obj/item/device/destTagger/O = P
+		if(src.sortTag != O.currTag)
+			if(!O.currTag)
+				to_chat(user, "<span class='notice'>Select a destination first!</span>")
+				return
+			var/tag = uppertext(O.destinations[O.currTag])
+			to_chat(user, "<span class='notice'>*[tag]*</span>")
+			sortTag = tag
+			playsound(get_turf(src), 'sound/machines/twobeep.ogg', 100, 1)
+			overlays = 0
+			overlays += image(icon = icon, icon_state = "deliverytag")
+			desc = "It has a label reading [tag]."
 
 /obj/item/weapon/paper/envelope/AltClick(mob/user)
 	if(open && contained_paper)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -376,8 +376,9 @@
 	var/wrapcheck = 0
 	var/obj/structure/disposalholder/H = new()	// virtual holder object which actually
 										// travels through the pipes.
-	for(var/obj/item/delivery/O in src)
-		wrapcheck = 1
+	for(var/obj/item/I in src)
+		if(istype(I, /obj/item/delivery) || istype(I, /obj/item/weapon/paper/envelope))
+			wrapcheck = 1
 
 	if(wrapcheck == 1)
 		H.tomail = 1
@@ -562,6 +563,9 @@
 		if(istype(AM, /obj/item/delivery) && !hasmob)
 			var/obj/item/delivery/T = AM
 			src.destinationTag = T.sortTag
+		if(istype(AM, /obj/item/weapon/paper/envelope) && !hasmob)
+			var/obj/item/weapon/paper/envelope/E = AM
+			src.destinationTag = E.sortTag
 
 // start the movement process
 // argument is the disposal unit the holder started in


### PR DESCRIPTION
Envelopes can now be tagged with destination taggers and mailed via disposals.
Resolves #15045

:cl:
 * rscadd: Envelopes can now be tagged with destination taggers and mailed via disposals.
