### PR TITLE
Teratoma Syndrome

### DIFF
--- a/code/modules/virus2/effect/effect.dm
+++ b/code/modules/virus2/effect/effect.dm
@@ -963,6 +963,16 @@ datum/disease2/effect/lubefoot/deactivate(var/mob/living/carbon/mob)
 					break
 
 
+/datum/disease2/effect/teratoma
+	name = "Teratoma Syndrome"
+	stage = 3
+
+/datum/disease2/effect/teratoma/activate(var/mob/living/carbon/mob)
+	var/organ_type = pick(existing_typesof(/obj/item/organ) + /obj/item/stack/teeth)
+	var/obj/item/spawned_organ = new organ_type(get_turf(mob))
+	mob.visible_message("<span class='warning'>\A [spawned_organ.name] is extruded from \the [mob]'s body and falls to the ground!</span>","<span class='warning'>\A [spawned_organ.name] is extruded from your body and falls to the ground!</span>")
+
+
 ////////////////////////STAGE 4/////////////////////////////////
 
 


### PR DESCRIPTION
Adds a new stage 3 symptom, teratoma syndrome, which causes the infected to periodically create and extrude random organs and/or teeth from their body, which are then dropped on the ground.
All subtypes of `/obj/item/organ` are included, even prosthetic ones.

:cl:
 * rscadd: Added teratoma syndrome as a new stage 3 virus symptom, it causes your body to periodically create and extrude random organs and/or teeth.
