### PR TITLE
Fixes to lung popping

### DIFF
--- a/code/modules/organs/internal/lungs/lung.dm
+++ b/code/modules/organs/internal/lungs/lung.dm
@@ -92,12 +92,14 @@
 			owner.audible_cough()		//respitory tract infection
 
 	if(is_bruised())
-		if(prob(((damage-min_bruised_damage)/min_broken_damage)*100))
+		var/chance = min(50, (damage-min_bruised_damage)/min_broken_damage*50)
+		if(prob(chance))
+			spawn owner.emote("me", 1, "gasps for air!")
+			if (owner.losebreath <= 30)
+				owner.losebreath += 5
+		else if(prob(chance))
 			spawn owner.emote("me", 1, "coughs up blood!")
 			owner.drip(10)
-		if(prob(((damage-min_bruised_damage)/min_broken_damage)*150))
-			spawn owner.emote("me", 1, "gasps for air!")
-			owner.losebreath += 5
 
 
 /datum/organ/internal/lungs/vox


### PR DESCRIPTION
This changes the way the effects of popped lungs are activated:

 * Reduced and capped the chance of both gasping and coughing up blood to be more tolerable but still lethal after a while.
 * Can no longer gasp for air and cough up blood during the same tick.
 * Capped the `losebreath` var to something sane. Before this change, that value could spike to very high numbers, resulting in the annoying gasping that persisted after lung damage was treated.
