### PR TITLE
Added an engineering GPS to the atmos tech's locker

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -164,6 +164,7 @@
 		new /obj/item/device/rcd/rpd(src)
 		new /obj/item/device/analyzer(src)
 		new /obj/item/clothing/glasses/scanner/material(src)
+		new /obj/item/device/gps/engineering(src)
 		return
 
 /obj/structure/closet/secure_closet/engineering_mechanic


### PR DESCRIPTION
Because I don't want to steal from the engi one even though nobody takes them.
:cl:
 * rscadd: Added an engineering GPS to the atmos tech's locker.