### PR TITLE
Triumvirate has three borg slots

### DIFF
--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -221,6 +221,9 @@ var/global/datum/controller/occupations/job_master
 		for(var/datum/job/ai/A in occupations)
 			if(ticker.triai)
 				A.spawn_positions = 3
+		for(var/datum/job/cyborg/C in occupations)
+			if(ticker.triai)
+				C.spawn_positions = 3
 
 	//Get the players who are ready
 	for(var/mob/new_player/player in player_list)


### PR DESCRIPTION
Switching on Triumvirate mode also sets the amount of borg job slots to 3.
Tested. Thanks, damian and shadowmech.

🆑 
 - tweak: Triumvirate mode now allows for up to three borgs as well as three AIs at roundstart.