### PR TITLE
Bomb Rebalancing

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1667,6 +1667,15 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	containername = "anomaly container crate"
 	group = "Science"
 
+/datum/supply_packs/ttv
+	name = "Tank Transfer Valve"
+	contains = list(/obj/item/device/transfer_valve)
+	cost = 50
+	containertype = /obj/structure/closet/crate/secure/plasma
+	containername = "tank transfer valve crate"
+	access = access_rd
+	group = "Science"
+
 
 //////HYDROPONICS//////
 


### PR DESCRIPTION
This PR is going to piss off a few people, but I don't really care. For people who plan on doing more than just meme gut reactions, I've listed out my thought process below.

This will remove all of the tank transfer valves from the station. Instead, anyone who wants to make bombs using them will need to order them from cargo.

After several weeks of consideration and in the meantime countless rounds ended prematurely, I've decided this is the most balanced way to approach bombs. My reasoning is thus:

Station bombing is overwhelmingly the easiest, fastest, and most effective way to destroy the station and kill nearly everyone. You currently don't even need to spend a single telecrystal to do so. Even one single bomb usually results in a shuttle call at a minimum. No other method of station destruction can be done so quickly and easily. Engineering sabotage can be caught and fixed by an AI before it gets to far. The Supermatter crystal gives a warning alert. The singularity beacon needs to be secured in maint, on the far side of the station where anyone can find it, and it can still be stopped various ways before it even gets there. Even a plasmaflood doesn't kill people instantly, and leaves cloning functional; a smart atmos tech or AI can reverse it. 

I, and I believe a decent sized portion of the player base, are quite sick of uncreative antags ending the round prematurely for everyone else, include antags who are trying to do something fun and clever for everyone - especially when they do it every single time they roll antag.

By locking bombs behind cargo, you force those uncreative antags to get clever if they want to bomb. Perhaps they need to come up with a good enough excuse, or get the RD to take their side and order them. Maybe they find it easier to kidnap a cargo tech in maint, wear a mask and steal his identity. Perhaps they steal the RD's stamp and fake an order, and then verify the fake order with a voice changer. Maybe they break into cargo with a gun and kill everyone, then order their bombs and try to get them before they get arrested. Cargo based antags could try to break into science, instead of the other way around. Or heck, you might see antags use their code words and actually work as a team. Locking bombs behind cargo doesn't prevent bombing - especially when there is a legitimate reason (blob)  - but it does make it far, far more interesting. 

Other solutions are mostly unworkable. Putting the TTVs behind a locked door just makes the antag buy an emag and it costs them a few seconds to make bombs. Locking them behind R&D just makes bomb building take another 5 minutes. Making them build the burn chamber every round is the same. Leaving it alone isn't an option, tons of people are pissed at the current situation. The only workable solution is to make it so someone can't make bombs with the tools already in the science department. 

Finally, as further evidence of balance, let's consider some other stuff that is locked behind cargo: 
*Guns (even though Science can make them too)
*Loyalty implants (even though they only affect one person each)
*Spare engine parts (even though a single supermatter shard isn't as deadly as a well placed bomb, let alone 5 round start TTV)
*Even motorized wheelchairs require CMO access to open.
So, why on earth is the second most dangerous object on the station NOT locked behind something?

:cl:
 * rscdel: Removed tank transfer valves from all four main stations.
 * rscadd: Added tank transfer valves as a crate one can order from cargo.