### PR TITLE
Makes TTVs large, moves 5 TTVs to RD's locker

### DIFF
--- a/code/game/objects/effects/spawners/bombspawner.dm
+++ b/code/game/objects/effects/spawners/bombspawner.dm
@@ -126,7 +126,7 @@
 /obj/effect/spawner/newbomb/New()
 	..()
 
-	var/obj/item/device/transfer_valve/V = new(src.loc)
+	var/obj/item/device/transfer_valve/mediumsize/V = new(src.loc)
 	var/obj/item/weapon/tank/plasma/PT = new(V)
 	var/obj/item/weapon/tank/oxygen/OT = new(V)
 

--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -11,6 +11,8 @@
 	var/toggle = 1
 
 	var/damaged = 0
+	
+	w_class = W_CLASS_LARGE
 
 	flags = FPRINT | PROXMOVE
 
@@ -236,3 +238,8 @@
 // eventually maybe have it update icon to show state (timer, prox etc.) like old bombs
 /obj/item/device/transfer_valve/proc/c_state()
 	return
+
+/obj/item/device/transfer_valve/mediumsize
+	name = "modified tank transfer valve"
+	desc = "Regulates the transfer of air between two tanks. This one was modified to be smaller."
+	w_class = W_CLASS_MEDIUM

--- a/code/modules/projectiles/guns/projectile/constructable/blastcannon.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/blastcannon.dm
@@ -83,6 +83,7 @@
 		user.visible_message("[user] attaches \the [W] to \the [src].","You attach \the [W] to \the [src].")
 		name = "blast cannon"
 		desc = "A weapon of devastating force, the explosive power from the tank transfer valve is funneled straight out of its barrel."
+		w_class = W_CLASS_LARGE
 	update_icon()
 
 /obj/item/weapon/gun/projectile/blastcannon/afterattack(atom/A as mob|obj|turf|area, mob/living/user as mob|obj, flag, params, struggle = 0)

--- a/code/modules/projectiles/guns/projectile/constructable/blastcannon.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/blastcannon.dm
@@ -42,6 +42,7 @@
 		bomb_appearance = null
 		name = "pipe gun"
 		desc = "A pipe welded onto a gun stock. You're not sure how you could even use this."
+		w_class = W_CLASS_MEDIUM
 	update_icon()
 
 /obj/item/weapon/gun/projectile/blastcannon/pickup(mob/user as mob)


### PR DESCRIPTION
Alternative to #15192.
Syndicate TTV bombs are unaffected.

🆑 
 - tweak: TTVs are now w_class LARGE, meaning they don't fit in backpacks or toolboxes. Syndicate special operations teams have learned to modify their valves to not be affected by this.
 - tweak: 5 out of 6 TTVs now spawn in the RD's locker.