### PR TITLE
Hopefully fixes some stupid glide size shit.

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -135,6 +135,26 @@
 
 	..()
 
+/atom/movable/proc/get_move_delay()
+	// Copied from Move().
+	if(ismob(src))
+		var/mob/M = src
+		if(M.client)
+			return (3+(M.client.move_delayer.next_allowed - world.time))*world.tick_lag
+	return max(5 * world.tick_lag, 1)
+
+// This is designed to only be used occasionally, since procs add overhead.
+/atom/movable/proc/reset_glide_size()
+	glide_size = Ceiling(WORLD_ICON_SIZE / src.get_move_delay() * world.tick_lag) - 1 //We always split up movements into cardinals for issues with diagonal movements.
+	//glide_size = WORLD_ICON_SIZE / max(move_delay, world.tick_lag) * world.tick_lag // Updated calc from http://www.byond.com/forum/?post=1573076
+
+/mob/verb/fix_gliding()
+	set category = "OOC"
+	set name = "Fix Movement"
+	set desc = "Fixes jerky movement caused by BYOND being dumb."
+	reset_glide_size()
+
+
 /atom/movable/Move(newLoc,Dir=0,step_x=0,step_y=0)
 	if(!loc || !newLoc)
 		return 0
@@ -267,6 +287,7 @@
 	locked_atoms    -= AM
 	AM.locked_to     = null
 	category.unlock(AM)
+	AM.reset_glide_size()
 
 	return TRUE
 


### PR DESCRIPTION
This was annoying me so I fixed it, of course.

# Executive Summary
Adds a proc and a verb for resetting `glide_size`, which is getting reset by what appears to be an issue with BYOND.

# Issues
* Fixes #15205 

# Testing Procedure
1. Two players join serb.
2. A joins game.
3. B observes and haunts A.
4. A beats himself to death or something.  The important part is that the player is slowed before dying.
5. B now tries to move.

# Acceptable Result
B moves at their set ghost speed after A dies with no tile-to-tile jerkiness.

# Changelog
:cl:
- bugfix: Fixes ghost glide size getting screwed up after the hauntee dies or something.
- rscadd: Added `fix_gliding` verb.