### PR TITLE
Sheet dropping refactor, table parts file cleanup

### DIFF
--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -583,37 +583,6 @@
 	name = "warning cone"
 	icon_state = "cone"
 
-/obj/item/weapon/rack_parts
-	name = "rack parts"
-	desc = "Parts of a rack."
-	icon = 'icons/obj/items.dmi'
-	icon_state = "rack_parts"
-	flags = FPRINT
-	siemens_coefficient = 1
-	starting_materials = list(MAT_IRON = 3750)
-	w_type = RECYK_METAL
-	melt_temperature=MELTPOINT_STEEL
-
-/obj/item/weapon/rack_parts/attackby(obj/item/weapon/W, mob/user)
-	..()
-	if(istype(W, /obj/item/weapon/weldingtool))
-		var/obj/item/weapon/weldingtool/WT = W
-		if(WT.remove_fuel(0, user))
-			to_chat(user, "You begin slicing through \the [src].")
-			playsound(user, 'sound/items/Welder.ogg', 50, 1)
-			if(do_after(user, src, 60))
-				to_chat(user, "You cut \the [src] into a gun stock.")
-				if(src.loc == user)
-					user.drop_item(src, force_drop = 1)
-					var/obj/item/weapon/metal_gun_stock/I = new (get_turf(user))
-					user.put_in_hands(I)
-					qdel(src)
-				else
-					new /obj/item/weapon/metal_gun_stock(get_turf(src.loc))
-					qdel(src)
-		else
-			to_chat(user, "<span class='notice'>You need more welding fuel to complete this task.</span>")
-
 /obj/item/weapon/SWF_uplink
 	name = "station-bounced radio"
 	desc = "Used for communication, it appears."
@@ -715,58 +684,6 @@
 	throw_range = 5
 	w_class = W_CLASS_SMALL
 	flags = FPRINT
-
-/obj/item/weapon/table_parts
-	name = "table parts"
-	desc = "Parts of a table. Poor table."
-	gender = PLURAL
-	icon = 'icons/obj/items.dmi'
-	icon_state = "table_parts"
-	starting_materials = list(MAT_IRON = 3750)
-	w_type = RECYK_METAL
-	melt_temperature=MELTPOINT_STEEL
-	flags = FPRINT
-	siemens_coefficient = 1
-	attack_verb = list("slams", "bashes", "batters", "bludgeons", "thrashes", "whacks")
-
-/obj/item/weapon/table_parts/cultify()
-	new /obj/item/weapon/table_parts/wood(loc)
-	..()
-
-/obj/item/weapon/table_parts/reinforced
-	name = "reinforced table parts"
-	desc = "Hard table parts. Well...harder..."
-	icon = 'icons/obj/items.dmi'
-	icon_state = "reinf_tableparts"
-	starting_materials = list(MAT_IRON = 7500)
-	w_type = RECYK_METAL
-	melt_temperature=MELTPOINT_STEEL
-	flags = FPRINT
-	siemens_coefficient = 1
-
-/obj/item/weapon/table_parts/glass
-	name = "glass table parts"
-	desc = "Glass table parts for the spaceman with style."
-	icon = 'icons/obj/items.dmi'
-	icon_state = "glass_tableparts"
-	starting_materials = list(MAT_GLASS = 3750)
-	w_type = RECYK_GLASS
-	melt_temperature=MELTPOINT_GLASS
-	flags = FPRINT
-	siemens_coefficient = 0 //copying from glass sheets and shards even if its bad balance
-
-/obj/item/weapon/table_parts/wood
-	name = "wooden table parts"
-	desc = "Keep away from fire."
-	icon_state = "wood_tableparts"
-	flags = 0
-
-/obj/item/weapon/table_parts/wood/poker
-	name = "gambling table parts"
-	icon_state = "gambling_tableparts"
-
-/obj/item/weapon/table_parts/wood/cultify()
-	return
 
 /obj/item/weapon/wire
 	desc = "This is just a simple piece of regular insulated wire."

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -385,7 +385,7 @@
 							return
 						playsound(get_turf(src), 'sound/items/Welder.ogg', 50, 1)
 						user.visible_message("[user] welds the frame back into metal.", "You weld the frame back into metal.", "You hear welding.")
-						new /obj/item/stack/sheet/metal/(src.loc, 5)
+						drop_stack(/obj/item/stack/sheet/metal/, loc, 5, user)
 						state = -1
 						qdel(src)
 				return 1

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -74,9 +74,7 @@
 				if(iswrench(P))
 					playsound(get_turf(src), 'sound/items/Ratchet.ogg', 75, 1)
 					to_chat(user, "<span class='notice'>You dismantle the frame.</span>")
-					//new /obj/item/stack/sheet/metal(src.loc, 5)
-					var/obj/item/stack/sheet/metal/M = getFromPool(/obj/item/stack/sheet/metal, src.loc)
-					M.amount = 5
+					drop_stack(/obj/item/stack/sheet/metal, get_turf(src), 5, user)
 					qdel(src)
 		if(2)
 			if(!..())

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -330,7 +330,7 @@
 
  */
 
-/proc/drop_stack(new_stack_type = /obj/item/stack, turf/loc, add_amount = 1, mob/user)
+/proc/drop_stack(new_stack_type = /obj/item/stack, atom/loc, add_amount = 1, mob/user)
 	for(var/obj/item/stack/S in loc)
 		if(S.can_stack_with(new_stack_type))
 			if(S.max_amount >= S.amount + add_amount)
@@ -339,7 +339,7 @@
 				to_chat(user, "<span class='info'>You add [add_amount] item\s to the stack. It now contains [S.amount] [CORRECT_STACK_NAME(S)].</span>")
 				return S
 
-	var/obj/item/stack/S = getFromPool(new_stack_type, loc)
+	var/obj/item/stack/S = new new_stack_type(loc)
 	S.amount = add_amount
 	return S
 

--- a/code/game/objects/items/weapons/table_rack_parts.dm
+++ b/code/game/objects/items/weapons/table_rack_parts.dm
@@ -1,134 +1,188 @@
 /* Table parts and rack parts
  * Contains:
- *		Table Parts
- *		Reinforced Table Parts
- *		Wooden Table Parts
- *		Rack Parts
+ *		table parts
+ *		reinforced table Parts
+ *		wooden table parts
+ * 		wooden poker table parts
+ * 		glass table parts
+ *		rack parts
  */
 
-/*
- * Table Parts
- */
-/obj/item/weapon/table_parts/attackby(obj/item/weapon/W as obj, mob/user as mob)
+/obj/item/weapon/table_parts
+	name = "table parts"
+	desc = "Parts of a table. Poor table."
+	gender = PLURAL
+	icon = 'icons/obj/items.dmi'
+	icon_state = "table_parts"
+	starting_materials = list(MAT_IRON = 3750)
+	w_type = RECYK_METAL
+	melt_temperature=MELTPOINT_STEEL
+	flags = FPRINT
+	siemens_coefficient = 1
+	attack_verb = list("slams", "bashes", "batters", "bludgeons", "thrashes", "whacks")
+
+/obj/item/weapon/table_parts/cultify()
+	new /obj/item/weapon/table_parts/wood(loc)
+	..()
+
+/obj/item/weapon/table_parts/attackby(obj/item/weapon/W, mob/user)
 	..()
 	if (iswrench(W))
-		var/obj/item/stack/sheet/metal/M = getFromPool(/obj/item/stack/sheet/metal, get_turf(src))
-		M.amount = 1
-		//SN src = null
+		drop_stack(/obj/item/stack/sheet/metal, loc, 1, user)
 		qdel(src)
+		return
 	if (istype(W, /obj/item/stack/rods))
 		var/obj/item/stack/rods/rods = W
 		if (rods.amount >= 4)
-			new /obj/item/weapon/table_parts/reinforced( user.loc )
+			new /obj/item/weapon/table_parts/reinforced(user.loc)
 			to_chat(user, "<span class='notice'>You reinforce the [name].</span>")
 			rods.use(4)
 			qdel(src)
 		else if (rods.amount < 4)
 			to_chat(user, "<span class='warning'>You need at least four rods to do this.</span>")
+		return
 	if (istype(W, /obj/item/stack/sheet/glass/glass))
 		var/obj/item/stack/sheet/glass/glass = W
 		if (glass.amount >= 1)
-			new /obj/item/weapon/table_parts/glass( user.loc )
+			new /obj/item/weapon/table_parts/glass(user.loc)
 			to_chat(user, "<span class='notice'>You add glass panes to \the [name].</span>")
 			glass.use(1)
 			qdel(src)
-		
 
-/obj/item/weapon/table_parts/attack_self(mob/user as mob)
-	new /obj/structure/table( user.loc )
+/obj/item/weapon/table_parts/attack_self(mob/user)
+	new /obj/structure/table(user.loc)
 	user.drop_item(src, force_drop = 1)
 	qdel(src)
-	
 
 
-/*
- * Reinforced Table Parts
- */
-/obj/item/weapon/table_parts/reinforced/attackby(obj/item/weapon/W as obj, mob/user as mob)
+/obj/item/weapon/table_parts/reinforced
+	name = "reinforced table parts"
+	desc = "Hard table parts. Well...harder..."
+	icon = 'icons/obj/items.dmi'
+	icon_state = "reinf_tableparts"
+	starting_materials = list(MAT_IRON = 7500)
+	w_type = RECYK_METAL
+	melt_temperature=MELTPOINT_STEEL
+	flags = FPRINT
+	siemens_coefficient = 1
+
+/obj/item/weapon/table_parts/reinforced/attackby(obj/item/weapon/W, mob/user)
 	if (iswrench(W))
-		var/obj/item/stack/sheet/metal/M = getFromPool(/obj/item/stack/sheet/metal, get_turf(src))
-		M.amount = 1
-		new /obj/item/stack/rods( user.loc )
+		drop_stack(/obj/item/stack/sheet/metal, loc, 1, user)
+		drop_stack(/obj/item/stack/rods, loc, 1, user)
 		qdel(src)
 
-/obj/item/weapon/table_parts/reinforced/attack_self(mob/user as mob)
-	new /obj/structure/table/reinforced( user.loc )
+/obj/item/weapon/table_parts/reinforced/attack_self(mob/user)
+	new /obj/structure/table/reinforced(user.loc)
 	user.drop_item(src, force_drop = 1)
 	qdel(src)
 	return
 
-/*
- * Wooden Table Parts
- */
-/obj/item/weapon/table_parts/wood/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if (iswrench(W))
-		new /obj/item/stack/sheet/wood( user.loc )
-		qdel(src)
 
+/obj/item/weapon/table_parts/wood
+	name = "wooden table parts"
+	desc = "Keep away from fire."
+	icon_state = "wood_tableparts"
+	flags = 0
+
+/obj/item/weapon/table_parts/wood/cultify()
+	return
+
+/obj/item/weapon/table_parts/wood/attackby(obj/item/weapon/W, mob/user)
+	if (iswrench(W))
+		drop_stack(/obj/item/stack/sheet/wood, loc, 1, user)
+		qdel(src)
+		return
 	if (istype(W, /obj/item/stack/tile/grass))
 		var/obj/item/stack/tile/grass/Grass = W
 
 		if(!Grass.use(1))
 			return
 
-		new /obj/item/weapon/table_parts/wood/poker( get_turf(src) )
+		new /obj/item/weapon/table_parts/wood/poker(loc)
 		visible_message("<span class='notice'>[user] adds grass to the wooden table parts.</span>")
 		qdel(src)
 
-/obj/item/weapon/table_parts/wood/attack_self(mob/user as mob)
-	new /obj/structure/table/woodentable( user.loc )
+/obj/item/weapon/table_parts/wood/poker
+	name = "gambling table parts"
+	icon_state = "gambling_tableparts"
+
+/obj/item/weapon/table_parts/wood/attack_self(mob/user)
+	new /obj/structure/table/woodentable(user.loc)
 	user.drop_item(src, force_drop = 1)
 	qdel(src)
 	return
 
-
-/*
- * Poker Table Parts
- */
-
-/obj/item/weapon/table_parts/wood/poker/attackby(obj/item/weapon/W as obj, mob/user as mob)
+/obj/item/weapon/table_parts/wood/poker/attackby(obj/item/weapon/W, mob/user)
 	if (iswrench(W))
-		new /obj/item/stack/sheet/wood( user.loc )
-		new /obj/item/stack/tile/grass( user.loc )
+		drop_stack(/obj/item/stack/sheet/wood, loc, 1, user)
+		drop_stack(/obj/item/stack/tile/grass, loc, 1, user)
 		qdel(src)
 
-/obj/item/weapon/table_parts/wood/poker/attack_self(mob/user as mob)
-	new /obj/structure/table/woodentable/poker( user.loc )
+/obj/item/weapon/table_parts/wood/poker/attack_self(mob/user)
+	new /obj/structure/table/woodentable/poker(user.loc)
 	user.drop_item(src, force_drop = 1)
 	qdel(src)
-	return
 
-/*
-* Glass
-*/
+/obj/item/weapon/table_parts/glass
+	name = "glass table parts"
+	desc = "Glass table parts for the spaceman with style."
+	icon = 'icons/obj/items.dmi'
+	icon_state = "glass_tableparts"
+	starting_materials = list(MAT_GLASS = 3750)
+	w_type = RECYK_GLASS
+	melt_temperature=MELTPOINT_GLASS
+	flags = FPRINT
+	siemens_coefficient = 0 //copying from glass sheets and shards even if its bad balance
 
-/obj/item/weapon/table_parts/glass/attackby(obj/item/weapon/W as obj, mob/user as mob)
+/obj/item/weapon/table_parts/glass/attackby(obj/item/weapon/W, mob/user)
 	if (iswrench(W))
-		new /obj/item/stack/sheet/glass/glass( user.loc )
-		new /obj/item/stack/sheet/metal( user.loc )
+		drop_stack(/obj/item/stack/sheet/glass/glass, loc, 1, user)
+		drop_stack(/obj/item/stack/sheet/metal, loc, 1, user)
 		qdel(src)
 
-/obj/item/weapon/table_parts/glass/attack_self(mob/user as mob)
-	new /obj/structure/table/glass( user.loc )
+/obj/item/weapon/table_parts/glass/attack_self(mob/user)
+	new /obj/structure/table/glass(user.loc)
 	qdel(src)
-	
 
 
-/*
- * Rack Parts
- */
-/obj/item/weapon/rack_parts/attackby(obj/item/weapon/W as obj, mob/user as mob)
+/obj/item/weapon/rack_parts
+	name = "rack parts"
+	desc = "Parts of a rack."
+	icon = 'icons/obj/items.dmi'
+	icon_state = "rack_parts"
+	flags = FPRINT
+	siemens_coefficient = 1
+	starting_materials = list(MAT_IRON = 3750)
+	w_type = RECYK_METAL
+	melt_temperature=MELTPOINT_STEEL
+
+/obj/item/weapon/rack_parts/attackby(obj/item/weapon/W, mob/user)
 	..()
 	if (iswrench(W))
-		var/obj/item/stack/sheet/metal/M = getFromPool(/obj/item/stack/sheet/metal, get_turf(src))
-		M.amount = 1
+		drop_stack(/obj/item/stack/sheet/metal, loc, 1, user)
 		qdel(src)
 		return
-	return
+	if(istype(W, /obj/item/weapon/weldingtool))
+		var/obj/item/weapon/weldingtool/WT = W
+		if(WT.remove_fuel(0, user))
+			to_chat(user, "You begin slicing through \the [src].")
+			playsound(user, 'sound/items/Welder.ogg', 50, 1)
+			if(do_after(user, src, 60))
+				to_chat(user, "You cut \the [src] into a gun stock.")
+				if(src.loc == user)
+					user.drop_item(src, force_drop = 1)
+					var/obj/item/weapon/metal_gun_stock/I = new (user.loc)
+					user.put_in_hands(I)
+					qdel(src)
+				else
+					new /obj/item/weapon/metal_gun_stock(loc)
+					qdel(src)
+		else
+			to_chat(user, "<span class='notice'>You need more welding fuel to complete this task.</span>")
 
-/obj/item/weapon/rack_parts/attack_self(mob/user as mob)
-	var/obj/structure/rack/R = new /obj/structure/rack( user.loc )
+/obj/item/weapon/rack_parts/attack_self(mob/user)
+	var/obj/structure/rack/R = new /obj/structure/rack(user.loc)
 	R.add_fingerprint(user)
 	user.drop_item(src, force_drop = 1)
 	qdel(src)
-	return

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -176,7 +176,7 @@
 		manual_unbuckle(user)
 	if(iswrench(W))
 		playsound(get_turf(src), 'sound/items/Ratchet.ogg', 50, 1)
-		getFromPool(sheet_type, get_turf(src), 2)
+		drop_stack(sheet_type, loc, 2, user)
 		qdel(src)
 		return
 

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -38,7 +38,7 @@
 
 	if(iswrench(W))
 		playsound(get_turf(src), 'sound/items/Ratchet.ogg', 50, 1)
-		getFromPool(sheet_type, get_turf(src), sheet_amt)
+		drop_stack(sheet_type, loc, sheet_amt, user)
 		qdel(src)
 		return
 

--- a/code/game/objects/structures/stool_bed_chair_nest/stools.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/stools.dm
@@ -36,7 +36,7 @@
 /obj/item/weapon/stool/attackby(var/obj/item/weapon/W, var/mob/user)
 	if(iswrench(W) && sheet_path)
 		playsound(get_turf(src), 'sound/items/Ratchet.ogg', 50, 1)
-		getFromPool(sheet_path, get_turf(src), 1)
+		drop_stack(sheet_path, loc, 1, user)
 		qdel(src)
 
 	. = ..()


### PR DESCRIPTION
Before this change dropping stackable things (like when deconstructing things) would end up creating a stack that overrode one of the stacks already present on the same location, if there was one. This resulted in the previous stack disappearing and a lot of sadness in general.

Thankfully someone wrote this handy `drop_stack` proc, which is now used instead.
I also moved the table parts definitions to the file they belong to, and cleaned up said file. I just had to.

Closes #15237

:cl:
 * bugfix: Creating stackable items in a location that already contains a stack will now result in the correct amount of items. 