### PR TITLE
Prevents some duplicate calls of update_icon() during explosions

### DIFF
--- a/code/ATMOSPHERICS/datum_pipeline.dm
+++ b/code/ATMOSPHERICS/datum_pipeline.dm
@@ -234,7 +234,7 @@
 		network.update = 1
 
 
-//Slows down the rate of update_icon() when many of them are called simultaneously and prevents some duplicate processing
+//Prevents duplicate processing of update_icon() during events such as explosions
 /datum/pipeline/proc/process_update_icon_queue()
 	for (var/obj/machinery/atmospherics/P in update_icon_queue)//P is the pipe that needs to call update_icon()
 		if (P.update_icon_dup_flag == TRUE)//Sets this flag to TRUE when it gets added to the list
@@ -248,3 +248,4 @@
 	update_icon_queue += pipe
 	if (processing_update_queue == FALSE)
 		processing_update_queue = TRUE
+		process_update_icon_queue()


### PR DESCRIPTION
### update_icon() is needlessly called many times during explosions. ###
----
* A pipe that's destroyed will call update_icon() on itself and on any nearby pipes that will be visually affected by this pipe disappearing. 
* It's a pretty meaty proc, so this isn't a very good thing to have happen when it doesn't need to.
----
### The solution that clusterfack suggested I implement was the following:
* Whenever a pipe would call update_icon(), instead add it to a list in its parent pipeline, and set a flag equal to true
* In the parent pipeline, whenever something is added to this list, the list begins processing this as a queue by taking the pipe stored in the list and calling update_icon() for it if its update flag is set to true. 
* Then, after update_icon() is called, set this flag to false. If this pipe is in the list multiple times, it will be prevented from calling this function needlessly.

The results of this change are as follows:

![image](https://user-images.githubusercontent.com/3300686/27311191-2cfc276c-5514-11e7-91e6-1a02dd850be1.png)



<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl: (as the emoji)
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
