### PR TITLE
bleach kippers are now actually made with bleach.

### DIFF
--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -1717,7 +1717,7 @@
 	result = /obj/item/weapon/reagent_containers/food/snacks/fishtacosupreme
 
 /datum/recipe/bleachkipper
-	reagents = list(SODIUM = 10, HYDROGEN = 10, CHLORINE = 10, PHAZON = 1)
+	reagents = list(BLEACH = 30, PHAZON = 1)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/meat/carpmeat,
 		/obj/item/robot_parts/head,

--- a/html/changelogs/ArthurDentist.yml
+++ b/html/changelogs/ArthurDentist.yml
@@ -1,2 +1,3 @@
 author: ArthurDentist
-changes: []
+changes:
+  - tweak: Bleach Kippers are now made with real bleach.


### PR DESCRIPTION
Bleach Kippers were added just before the bleach reagent was. Updated the recipe so they are made with actual bleach. 