### PR TITLE
Bone Hurting Juice

### DIFF
--- a/__DEFINES/reagents.dm
+++ b/__DEFINES/reagents.dm
@@ -324,6 +324,7 @@
 #define LITHOTORCRAZINE "lithotorcrazine"
 #define HEMOSCYANINE	"hemoscyanine"
 #define ANTHRACENE		"anthracene"
+#define BONEJUICE		"bonejuice"
 
 #define TUNGSTEN 			"tungsten"
 #define LITHIUMSODIUMTUNGSTATE 			"lithiumsodiumtungstate"

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -5273,6 +5273,32 @@
 					H.adjustToxLoss(3)
 				H.adjustToxLoss(0.3)
 
+/datum/reagent/ethanol/deadrum/bonejuice
+	name = "Bone Hurting Juice"
+	id = BONEJUICE
+	description = "A juice that hurts your bones. Possibly addictive."
+	reagent_state = LIQUID
+	color = "#8E18A9" //rgb: 142, 24, 169
+
+/datum/reagent/ethanol/deadrum/bonejuice/on_mob_life(var/mob/living/M)
+	if(..())
+		return 1
+
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(H.species && (H.species.anatomy_flags & NO_BONES))
+			return
+		else
+			switch(volume)
+				if(1 to 50)
+					if(prob(15))
+						to_chat(H,"<span class='warning'>Ow. Oof. Oooouch. Your bones hurt.</span>")
+				if(51 to INFINITY)
+					if(prob(25))
+						to_chat(H,"<span class='warning'>OW! OOF! AAAHH! Your bones REALLY hurt.</span>")
+					for (var/datum/organ/external/E in H.organs)
+						E.min_broken_damage = max(5, E.min_broken_damage - 30)
+
 
 //Eventually there will be a way of making vinegar.
 /datum/reagent/vinegar

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -2689,6 +2689,13 @@
 	required_catalysts = list(ENZYME = 5)
 	result_amount = 5
 
+/datum/chemical_reaction/bonejuice
+	name = "Bone Hurting Juice"
+	id = BONEJUICE
+	result = BONEJUICE
+	required_reagents = list(MILK = 1, PACID = 1, WHISKEY = 1)
+	result_amount = 3
+
 //Cafe stuff!
 /datum/chemical_reaction/acidtea
 	name = "Earl's Grey Tea"

--- a/code/modules/reagents/reagent_containers/food/drinks/drinkingglass.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/drinkingglass.dm
@@ -547,6 +547,11 @@
 					item_state = "ginvodkaglass"
 					name = "glass of Grey vodka"
 					desc = "A questionable concoction of objects found within maintenance. Tastes just like you'd expect."
+				if(BONEJUICE)
+					icon_state = "pwineglass"
+					item_state = "pwineglass"
+					name = "glass of bone hurting juice"
+					desc = "It's a juice that hurts your bones. Possibly addictive."
 				else
 					icon_state ="glass_colour"
 					item_state ="glass_colour"


### PR DESCRIPTION
A silly PR for a silly drink.

This adds a new bartender drink: Bone hurting juice. Drinking it hurts your bones.

If you for some reason decide to drink more than 50 units of it, (which requires at least two glasses) it damages your bones to give you an effect similar to the "fragile bones" virus effect.

Crafting it requires polyacid, so we shouldn't see too many bartenders spiking drinks with it.

Doesn't have a custom sprite, so it's using the currently unused "pwine" sprite.

:cl:
 * rscadd: Added Bone Hurting Juice. Craft it with 1 part whiskey, 1 part polyacid, and 1 part milk (to make it stick to bones). Drinking it will cause bone pain. If you overdose (51+ Units) it eats away at your bones and gives you fragile bones.
