### PR TITLE
Drag damage: bloodloss-related changes

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1679,23 +1679,19 @@ mob/living/carbon/human/isincrit()
 
 /mob/living/carbon/human/get_broken_organs()
 	var/mob/living/carbon/human/H = src
-	var/turf/TH = H.loc
 	var/list/return_organs = list()
-	if (TH.has_gravity() && H.lying)
-		for(var/datum/organ/external/damagedorgan in H.organs)
-			if(damagedorgan.status & ORGAN_BROKEN && !(damagedorgan.status & ORGAN_SPLINTED))
-				return_organs += damagedorgan
-		return return_organs
+	for(var/datum/organ/external/damagedorgan in H.organs)
+		if(damagedorgan.status & ORGAN_BROKEN && !(damagedorgan.status & ORGAN_SPLINTED))
+			return_organs += damagedorgan
+	return return_organs
 
 /mob/living/carbon/human/get_bleeding_organs()
 	var/mob/living/carbon/human/H = src
-	var/turf/TH = H.loc
 	var/list/return_organs = list()
-	if (TH.has_gravity() && H.lying)
-		for(var/datum/organ/external/damagedorgan in H.organs)
-			if(damagedorgan.status & ORGAN_BLEEDING)
-				return_organs += damagedorgan
-		return return_organs		
+	for(var/datum/organ/external/damagedorgan in H.organs)
+		if(damagedorgan.status & ORGAN_BLEEDING)
+			return_organs += damagedorgan
+	return return_organs		
 		
 /mob/living/carbon/human/get_heart()
 	return internal_organs_by_name["heart"]

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1677,16 +1677,26 @@ mob/living/carbon/human/isincrit()
 	if (health - halloss <= config.health_threshold_softcrit)
 		return 1
 
-/mob/living/carbon/human/drag_damage()
+/mob/living/carbon/human/get_broken_organs()
 	var/mob/living/carbon/human/H = src
 	var/turf/TH = H.loc
 	var/list/return_organs = list()
 	if (TH.has_gravity() && H.lying)
 		for(var/datum/organ/external/damagedorgan in H.organs)
-			if(damagedorgan.status & ORGAN_BROKEN && !(damagedorgan.status & ORGAN_SPLINTED) || damagedorgan.status & ORGAN_BLEEDING)
+			if(damagedorgan.status & ORGAN_BROKEN && !(damagedorgan.status & ORGAN_SPLINTED))
 				return_organs += damagedorgan
 		return return_organs
 
+/mob/living/carbon/human/get_bleeding_organs()
+	var/mob/living/carbon/human/H = src
+	var/turf/TH = H.loc
+	var/list/return_organs = list()
+	if (TH.has_gravity() && H.lying)
+		for(var/datum/organ/external/damagedorgan in H.organs)
+			if(damagedorgan.status & ORGAN_BLEEDING)
+				return_organs += damagedorgan
+		return return_organs		
+		
 /mob/living/carbon/human/get_heart()
 	return internal_organs_by_name["heart"]
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -739,10 +739,10 @@ Thanks.
 													add_logs(src, HM, "caused drag damage to", admin = (M.ckey))
 													HM.UpdateDamageIcon()
 								
-								if (bleeding_organs.len)
+								if (bleeding_organs.len && !(HM.species.anatomy_flags & NO_BLOOD))
 									var/blood_volume = round(HM:vessel.get_reagent_amount("blood"))
 									/*Sometimes species with NO_BLOOD get blood, hence weird check*/
-									if(blood_volume > 0 || !(HM.species.anatomy_flags & NO_BLOOD))
+									if(blood_volume > 0)
 										if(isturf(HM.loc))
 											if(!HM.isincrit())
 												if(prob(blood_volume / 89.6)) //Chance to bleed based on blood remaining

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -742,7 +742,7 @@ Thanks.
 								if (bleeding_organs.len)
 									var/blood_volume = round(HM:vessel.get_reagent_amount("blood"))
 									/*Sometimes species with NO_BLOOD get blood, hence weird check*/
-									if(blood_volume > 0 || (HM.species.anatomy_flags & NO_BLOOD))
+									if(blood_volume > 0 || !(HM.species.anatomy_flags & NO_BLOOD))
 										if(isturf(HM.loc))
 											if(!HM.isincrit())
 												if(prob(blood_volume / 89.6)) //Chance to bleed based on blood remaining

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -720,40 +720,41 @@ Thanks.
 							var/mob/living/carbon/human/HM = M
 							var/list/damaged_organs = HM.get_broken_organs()
 							var/list/bleeding_organs = HM.get_bleeding_organs()
+							if (T.has_gravity() && HM.lying)
 							
-							if (damaged_organs.len)
-								if(!HM.isincrit())
-									if(prob(HM.getBruteLoss() / 5)) //Chance for damage based on current damage
-										for(var/datum/organ/external/damagedorgan in damaged_organs)
-											if((damagedorgan.brute_dam) < damagedorgan.max_damage) //To prevent organs from accruing thousands of damage
-												HM.apply_damage(2, BRUTE, damagedorgan)
-												HM.visible_message("<span class='warning'>The wounds on \the [HM]'s [damagedorgan.display_name] worsen from being dragged!</span>")
-												HM.UpdateDamageIcon()
-								else
-									if(prob(15))
-										for(var/datum/organ/external/damagedorgan in damaged_organs)
-											if((damagedorgan.brute_dam) < damagedorgan.max_damage)
-												HM.apply_damage(4, BRUTE, damagedorgan)
-												HM.visible_message("<span class='warning'>The wounds on \the [HM]'s [damagedorgan.display_name] worsen terribly from being dragged!</span>")
-												add_logs(src, HM, "caused drag damage to", admin = (M.ckey))
-												HM.UpdateDamageIcon()
-							
-							if (bleeding_organs.len)
-								var/blood_volume = round(HM:vessel.get_reagent_amount("blood"))
-								/*Sometimes species with NO_BLOOD get blood, hence weird check*/
-								if(blood_volume > 0 || (HM.species.anatomy_flags & NO_BLOOD))
-									if(isturf(HM.loc))
-										if(!HM.isincrit())
-											if(prob(blood_volume / 89.6)) //Chance to bleed based on blood remaining
-												blood_splatter(HM.loc,HM)
-												HM.vessel.remove_reagent("blood",4)
-												HM.visible_message("<span class='warning'>\The [HM] loses some blood from being dragged!</span>")
-										else
-											if(prob(blood_volume / 44.8)) //Crit mode means double chance of blood loss
-												blood_splatter(HM.loc,HM,1)
-												HM.vessel.remove_reagent("blood",8)
-												HM.visible_message("<span class='danger'>\The [HM] loses a lot of blood from being dragged!</span>")
-												add_logs(src, HM, "caused drag damage bloodloss to", admin = (HM.ckey))
+								if (damaged_organs.len)
+									if(!HM.isincrit())
+										if(prob(HM.getBruteLoss() / 5)) //Chance for damage based on current damage
+											for(var/datum/organ/external/damagedorgan in damaged_organs)
+												if((damagedorgan.brute_dam) < damagedorgan.max_damage) //To prevent organs from accruing thousands of damage
+													HM.apply_damage(2, BRUTE, damagedorgan)
+													HM.visible_message("<span class='warning'>The wounds on \the [HM]'s [damagedorgan.display_name] worsen from being dragged!</span>")
+													HM.UpdateDamageIcon()
+									else
+										if(prob(15))
+											for(var/datum/organ/external/damagedorgan in damaged_organs)
+												if((damagedorgan.brute_dam) < damagedorgan.max_damage)
+													HM.apply_damage(4, BRUTE, damagedorgan)
+													HM.visible_message("<span class='warning'>The wounds on \the [HM]'s [damagedorgan.display_name] worsen terribly from being dragged!</span>")
+													add_logs(src, HM, "caused drag damage to", admin = (M.ckey))
+													HM.UpdateDamageIcon()
+								
+								if (bleeding_organs.len)
+									var/blood_volume = round(HM:vessel.get_reagent_amount("blood"))
+									/*Sometimes species with NO_BLOOD get blood, hence weird check*/
+									if(blood_volume > 0 || (HM.species.anatomy_flags & NO_BLOOD))
+										if(isturf(HM.loc))
+											if(!HM.isincrit())
+												if(prob(blood_volume / 89.6)) //Chance to bleed based on blood remaining
+													blood_splatter(HM.loc,HM)
+													HM.vessel.remove_reagent("blood",4)
+													HM.visible_message("<span class='warning'>\The [HM] loses some blood from being dragged!</span>")
+											else
+												if(prob(blood_volume / 44.8)) //Crit mode means double chance of blood loss
+													blood_splatter(HM.loc,HM,1)
+													HM.vessel.remove_reagent("blood",8)
+													HM.visible_message("<span class='danger'>\The [HM] loses a lot of blood from being dragged!</span>")
+													add_logs(src, HM, "caused drag damage bloodloss to", admin = (HM.ckey))
 					else
 						if (pulling)
 							pulling.Move(T, get_dir(pulling, T))

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -35,7 +35,10 @@ mob/proc/get_heart()
 mob/proc/remove_internal_organ()
 	return null
 
-/mob/proc/drag_damage()
+/mob/proc/get_broken_organs()
+	return list()
+	
+/mob/proc/get_bleeding_organs()
 	return list()
 
 /mob/dead/observer/get_screen_colour()

--- a/html/changelogs/SonixApache.yml
+++ b/html/changelogs/SonixApache.yml
@@ -1,0 +1,38 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general deleting of nice things)
+#   rscadd (general adding of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.
+author: SonixApache
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# There needs to be a space after the - and before the prefix. Don't use tabs anywhere in this file.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# If you're using characters such as # ' : - or the like in your changelog, surround the entire change with quotes as shown in the second example. These quotes don't show up on the changelog once it's merged and prevent errors.
+# SCREW ANY OF THIS UP AND IT WON'T WORK.
+changes: 
+- bugfix: Drag damage now checks if a species has the NO_BLOOD flag rather than if they just don't have blood, since bloodless xenos kept growing blood vessels somehow
+- tweak: Drag damage bloodloss chance is now dependent on how much blood is left -- less blood, less chance
+- wip: Drag damage back-end has been cleaned up a bit, bleeding and broken organs are now seperately checked


### PR DESCRIPTION
fixes #15270

Split and renamed `drag_damage()` proc to `get_broken_organs()` and `get_bleeding_organs()`

:cl:
- bugfix: Drag damage now checks if a species has the NO_BLOOD flag rather than if they just don't have blood, since bloodless xenos kept growing blood vessels somehow
- tweak: Drag damage bloodloss chance is now dependent on how much blood is left -- less blood, less chance
- wip: Drag damage back-end has been cleaned up a bit, bleeding and broken organs are now seperately checked