### PR TITLE
Fix random body

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1561,10 +1561,6 @@ NOTE:  The change will take effect AFTER any current recruiting periods."}
 /datum/preferences/proc/copy_to(mob/living/carbon/human/character, safety = 0)
 	if(be_random_name)
 		real_name = random_name(gender,species)
-
-	if(be_random_body)
-		random_character(gender)
-
 	if(config.humans_need_surnames && species == "Human")
 		var/firstspace = findtext(real_name, " ")
 		var/name_length = length(real_name)
@@ -1582,25 +1578,30 @@ NOTE:  The change will take effect AFTER any current recruiting periods."}
 	character.sec_record = sec_record
 	character.gen_record = gen_record
 
-	character.setGender(gender)
-	character.age = age
 
-	character.r_eyes = r_eyes
-	character.g_eyes = g_eyes
-	character.b_eyes = b_eyes
+	if(be_random_body)
+		//random_character(gender) - This just selects a random character from the OLD character database.
+		randomize_appearance_for() // Correct.
+	else
+		character.setGender(gender)
+		character.age = age
 
-	character.r_hair = r_hair
-	character.g_hair = g_hair
-	character.b_hair = b_hair
+		character.r_eyes = r_eyes
+		character.g_eyes = g_eyes
+		character.b_eyes = b_eyes
 
-	character.r_facial = r_facial
-	character.g_facial = g_facial
-	character.b_facial = b_facial
+		character.r_hair = r_hair
+		character.g_hair = g_hair
+		character.b_hair = b_hair
 
-	character.s_tone = s_tone
+		character.r_facial = r_facial
+		character.g_facial = g_facial
+		character.b_facial = b_facial
 
-	character.h_style = h_style
-	character.f_style = f_style
+		character.s_tone = s_tone
+
+		character.h_style = h_style
+		character.f_style = f_style
 
 
 	character.skills = skills

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -384,6 +384,7 @@ AND players.player_slot = ? ;"}, ckey, slot)
 	metadata 			= preference_list["ooc_notes"]
 	real_name 			= preference_list["real_name"]
 	be_random_name 		= text2num(preference_list["random_name"])
+	be_random_body 		= text2num(preference_list["random_body"])
 	gender 				= preference_list["gender"]
 	age 				= text2num(preference_list["age"])
 	species				= preference_list["species"]
@@ -452,6 +453,7 @@ AND players.player_slot = ? ;"}, ckey, slot)
 	if(!real_name)
 		real_name = random_name(gender,species)
 	be_random_name	= sanitize_integer(be_random_name, 0, 1, initial(be_random_name))
+	be_random_body	= sanitize_integer(be_random_body, 0, 1, initial(be_random_body))
 	gender			= sanitize_gender(gender)
 	age				= sanitize_integer(age, AGE_MIN, AGE_MAX, initial(age))
 
@@ -526,6 +528,7 @@ AND players.player_slot = ? ;"}, ckey, slot)
 	S["OOC_Notes"]			>> metadata
 	S["real_name"]			>> real_name
 	S["name_is_always_random"] >> be_random_name
+	S["body_is_always_random"] >> be_random_body
 	S["gender"]				>> gender
 	S["age"]				>> age
 	S["species"]			>> species
@@ -586,6 +589,7 @@ AND players.player_slot = ? ;"}, ckey, slot)
 	if(!real_name)
 		real_name = random_name(gender,species)
 	be_random_name	= sanitize_integer(be_random_name, 0, 1, initial(be_random_name))
+	be_random_body	= sanitize_integer(be_random_body, 0, 1, initial(be_random_body))
 	gender			= sanitize_gender(gender)
 	age				= sanitize_integer(age, AGE_MIN, AGE_MAX, initial(age))
 	r_hair			= sanitize_integer(r_hair, 0, 255, initial(r_hair))
@@ -703,18 +707,18 @@ AND players.player_slot = ? ;"}, ckey, slot)
 
 	check.Add("SELECT player_ckey FROM players WHERE player_ckey = ? AND player_slot = ?", ckey, slot)
 	if(check.Execute(db))
-		if(!check.NextRow())          //1           2           3         4         5           6      7   8       9        10          11         12         13               14          15
-			q.Add("INSERT INTO players (player_ckey,player_slot,ooc_notes,real_name,random_name,gender,age,species,language,med_record,sec_record,gen_record,player_alt_titles,disabilities,nanotrasen_relation) \
+		if(!check.NextRow())          //1           2           3         4         5           6      7   8       9        10          11         12         13               14          15                  16
+			q.Add("INSERT INTO players (player_ckey,player_slot,ooc_notes,real_name,random_name,gender,age,species,language,med_record,sec_record,gen_record,player_alt_titles,disabilities,nanotrasen_relation, random_body) \
 				   VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
-				                        ckey,       slot,       metadata, real_name, be_random_name, gender, age, species, language, med_record, sec_record, gen_record, altTitles, disabilities, nanotrasen_relation)
+				                        ckey,       slot,       metadata, real_name, be_random_name, gender, age, species, language, med_record, sec_record, gen_record, altTitles, disabilities, nanotrasen_relation, be_random_body)
 			if(!q.Execute(db))
 				message_admins("Error #:[q.Error()] - [q.ErrorMsg()]")
 				WARNING("Error #:[q.Error()] - [q.ErrorMsg()]")
 				return 0
 			to_chat(user, "Created Character")
 		else
-			q.Add("UPDATE players SET ooc_notes=?,real_name=?,random_name=?,gender=?,age=?,species=?,language=?,med_record=?,sec_record=?,gen_record=?,player_alt_titles=?,disabilities=?,nanotrasen_relation=? WHERE player_ckey = ? AND player_slot = ?",\
-									  metadata, real_name, be_random_name, gender, age, species, language, med_record, sec_record, gen_record, altTitles, disabilities, nanotrasen_relation, ckey, slot)
+			q.Add("UPDATE players SET ooc_notes=?,real_name=?,random_name=?,gender=?,age=?,species=?,language=?,med_record=?,sec_record=?,gen_record=?,player_alt_titles=?,disabilities=?,nanotrasen_relation=?,random_body=? WHERE player_ckey = ? AND player_slot = ?",\
+									  metadata, real_name, be_random_name, gender, age, species, language, med_record, sec_record, gen_record, altTitles, disabilities, nanotrasen_relation, ckey, slot, be_random_body)
 			if(!q.Execute(db))
 				message_admins("Error #:[q.Error()] - [q.ErrorMsg()]")
 				WARNING("Error #:[q.Error()] - [q.ErrorMsg()]")
@@ -833,6 +837,7 @@ AND players.player_slot = ? ;"}, ckey, slot)
 	S["OOC_Notes"]             << metadata
 	S["real_name"]             << real_name
 	S["name_is_always_random"] << be_random_name
+	S["body_is_always_random"] << be_random_body
 	S["gender"]                << gender
 	S["age"]                   << age
 	S["species"]               << species

--- a/code/modules/migrations/SS13_Prefs/010-add-random-body.dm
+++ b/code/modules/migrations/SS13_Prefs/010-add-random-body.dm
@@ -1,0 +1,13 @@
+/datum/migration/sqlite/ss13_prefs/_010
+	id = 10
+	name = "Add Always Random Body"
+
+/datum/migration/sqlite/ss13_prefs/_010/up()
+	if(!hasColumn("players","random_body"))
+		return execute("ALTER TABLE `players` ADD COLUMN random_body INTEGER DEFAULT 0")
+	return TRUE
+
+/datum/migration/sqlite/ss13_prefs/_010/down()
+	if(hasColumn("players","random_body"))
+		return execute("ALTER TABLE `players` DROP COLUMN random_body")
+	return TRUE

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -150,6 +150,9 @@
 			observer.forceMove(O.loc)
 			observer.timeofdeath = world.time // Set the time of death so that the respawn timer works correctly.
 
+			// Has to be done here so we can get our random icon.
+			if(client.prefs.be_random_body)
+				client.prefs.randomize_appearance_for() // No argument means just the prefs are randomized.
 			client.prefs.update_preview_icon(1)
 			observer.icon = client.prefs.preview_icon
 			observer.alpha = 127

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -1331,6 +1331,7 @@
 #include "code\modules\migrations\SS13_Prefs\007-remove-flavortext.dm"
 #include "code\modules\migrations\SS13_Prefs\008-add-stumble.dm"
 #include "code\modules\migrations\SS13_Prefs\009-add-attackanim.dm"
+#include "code\modules\migrations\SS13_Prefs\010-add-random-body.dm"
 #include "code\modules\migrations\SS13_Prefs\_base.dm"
 #include "code\modules\mining\abandonedcrates.dm"
 #include "code\modules\mining\debug_shit.dm"


### PR DESCRIPTION
# Executive Summary
Implements the Always Random Save button's functionality.  While the button was there, it never actually worked and its state never saved.

# Failure Analysis
While the button was present and did set be_random_body, the code that actually triggered the appearance randomization was ordered incorrectly, taking place before stored appearance was set.  In addition, the method it used for randomization was just wrong.  Left as-is, it selects a random character slot from the old savefile system, which is deprecated.  Not only that, but the SQLite schema did not have a column to save the state of this button, nor the bindings to support it.  

In short, this thing was never implemented in the first place.

# Issues
* Fixes #13901

# Testing
Tested locally on BYOND 511.1385 on 6/24/2017

# Changelog
:cl:
- bugfix: Always Random Body button has now been completed and should work as expected.
/:cl: