### PR TITLE
REMOVE_TRAITOR_AI

### DIFF
--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -7,7 +7,7 @@
 /datum/game_mode/traitor
 	name = "traitor"
 	config_tag = "traitor"
-	restricted_jobs = list("Cyborg","Mobile MMI")//They are part of the AI if he is traitor so are they, they use to get double chances
+	restricted_jobs = list("Cyborg","Mobile MMI","AI")
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain")//AI", Currently out of the list as malf does not work for shit
 	required_players = 0
 	required_enemies = 1


### PR DESCRIPTION
I noticed that the AI could be a traitor and found the concept incredibly stupid, there is already an entire gamemode for the traitor AI (malfunction), allowing AI to be a traitor adds nothing to the game and just makes the rounds in which it happen incredibly confusing and quite honestly unfun.

The AI should either be a malfunctioning AI or a loyal, normal AI (given that no one changes it's laws of course). There is literally no good reason whatsoever to allow AI to be an antagonist during traitor rounds.

I love silicons and love the malfunction gamemode, but there is simply no point in having rogue AI exist outside of it, traitor antagonist should be restricted to non-silicons only.