### PR TITLE
adds can_discharge() check proc

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -338,9 +338,9 @@
 	if (can_discharge()) //Need to have something to fire but not load it up yet
 		//Point blank shooting if on harm intent or target we were targeting.
 		if(user.a_intent == I_HURT)
-			process_chambered() //Load whatever it is we fire
 			user.visible_message("<span class='danger'> \The [user] fires \the [src] point blank at [M]!</span>")
-			in_chamber.damage *= 1.3
+			if (process_chambered()) //Load whatever it is we fire
+				in_chamber.damage *= 1.3 //Some guns don't work with damage / chambers, like dart guns!
 			src.Fire(M,user,0,0,1)
 			return
 		else if(target && M in target)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -75,6 +75,9 @@
 	for(var/obj/O in contents)
 		O.emp_act(severity)
 
+/obj/item/weapon/gun/proc/can_discharge() //because process_chambered() is an atrocity
+	return 0		
+		
 /obj/item/weapon/gun/afterattack(atom/A as mob|obj|turf|area, mob/living/user as mob|obj, flag, params, struggle = 0)
 	if(flag)
 		return //we're placing gun on a table or in backpack
@@ -332,14 +335,16 @@
 			mouthshoot = 0
 			return
 
-	if (src.process_chambered())
+	if (src.can_discharge()) //Need to have something to fire but not load it up yet
 		//Point blank shooting if on harm intent or target we were targeting.
 		if(user.a_intent == I_HURT)
+			process_chambered() //Load whatever it is we fire
 			user.visible_message("<span class='danger'> \The [user] fires \the [src] point blank at [M]!</span>")
 			in_chamber.damage *= 1.3
 			src.Fire(M,user,0,0,1)
 			return
 		else if(target && M in target)
+			process_chambered()
 			src.Fire(M,user,0,0,1) ///Otherwise, shoot!
 			return
 		else

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -335,7 +335,7 @@
 			mouthshoot = 0
 			return
 
-	if (src.can_discharge()) //Need to have something to fire but not load it up yet
+	if (can_discharge()) //Need to have something to fire but not load it up yet
 		//Point blank shooting if on harm intent or target we were targeting.
 		if(user.a_intent == I_HURT)
 			process_chambered() //Load whatever it is we fire

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -27,14 +27,7 @@
 		return 0
 	
 /obj/item/weapon/gun/energy/process_chambered()
-	if(in_chamber)
-		return 1
-	if(!power_supply)
-		return 0
-	if(!power_supply.use(charge_cost))
-		return 0
-	if(!projectile_type)
-		return 0
+	can_discharge()
 	in_chamber = new projectile_type(src)
 	return 1
 

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -16,6 +16,16 @@
 	..() //parent emps the battery removing charge
 	update_icon()
 
+/obj/item/weapon/gun/energy/can_discharge()
+	if(in_chamber)
+		return 1
+	if(!power_supply)
+		return 0
+	if(!power_supply.use(charge_cost))
+		return 0
+	if(!projectile_type)
+		return 0
+	
 /obj/item/weapon/gun/energy/process_chambered()
 	if(in_chamber)
 		return 1

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -124,7 +124,10 @@
 
 /obj/item/weapon/gun/projectile/process_chambered()
 	var/obj/item/ammo_casing/AC = getAC()
-	can_discharge()
+	if(in_chamber)
+		return 1 //{R}
+	if(isnull(AC) || !istype(AC))
+		return 0
 	if(mag_type && load_method == 2)
 		chambered = null //Remove casing from chamber.
 		chamber_round()

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -143,6 +143,16 @@
 		return 1
 	return 0
 
+/obj/item/weapon/gun/projectile/can_discharge()
+	var/obj/item/ammo_casing/AC = getAC()
+	if(in_chamber)
+		return 1 
+	if(isnull(AC) || !istype(AC))
+		return 0
+	else
+		return 1
+	
+	
 /obj/item/weapon/gun/projectile/attackby(var/obj/item/A as obj, mob/user as mob)
 	if(istype(A, /obj/item/gun_part/silencer) && src.gun_flags &SILENCECOMP)
 		if(!user.is_holding_item(src))	//if we're not in his hands

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -124,10 +124,7 @@
 
 /obj/item/weapon/gun/projectile/process_chambered()
 	var/obj/item/ammo_casing/AC = getAC()
-	if(in_chamber)
-		return 1 //{R}
-	if(isnull(AC) || !istype(AC))
-		return
+	can_discharge()
 	if(mag_type && load_method == 2)
 		chambered = null //Remove casing from chamber.
 		chamber_round()

--- a/code/modules/projectiles/guns/projectile/banannon.dm
+++ b/code/modules/projectiles/guns/projectile/banannon.dm
@@ -75,3 +75,7 @@
 			playsound(get_turf(src), 'sound/items/Deconstruct.ogg', 25, 1)
 			qdel(W)
 			update_icon()
+			
+/obj/item/weapon/gun/banannon/can_discharge()
+	if(current_ammo)
+		return 1

--- a/code/modules/projectiles/guns/projectile/bulletstorm.dm
+++ b/code/modules/projectiles/guns/projectile/bulletstorm.dm
@@ -30,5 +30,9 @@
 
 	Fire(A,user,params, "struggle" = struggle)
 
+/obj/item/weapon/gun/bulletstorm/can_discharge()
+	if(in_chamber)
+		return 1
+	
 /obj/item/weapon/gun/bulletstorm/process_chambered()
 	return in_chamber

--- a/code/modules/projectiles/guns/projectile/mahoguny.dm
+++ b/code/modules/projectiles/guns/projectile/mahoguny.dm
@@ -19,6 +19,10 @@
 	..()
 	to_chat(user, "<span class='info'>It has [current_ammo] round\s remaining.</span>")
 
+/obj/item/weapon/gun/mahoguny/can_discharge()
+	if (current_ammo)
+		return 1
+	
 /obj/item/weapon/gun/mahoguny/afterattack(atom/A as mob|obj|turf|area, mob/living/user as mob|obj, flag, params, struggle = 0)
 	if(flag)
 		return //we're placing gun on a table or in backpack

--- a/code/modules/projectiles/guns/projectile/minigun.dm
+++ b/code/modules/projectiles/guns/projectile/minigun.dm
@@ -61,7 +61,7 @@
 	return 0
 
 /obj/item/weapon/gun/gatling/can_discharge() //Why is this gun not a child of gun/projectile?
-	if (current_shells)
+	if (current_shells && wielded)
 		return 1
 	
 /obj/item/weapon/gun/gatling/update_icon()

--- a/code/modules/projectiles/guns/projectile/minigun.dm
+++ b/code/modules/projectiles/guns/projectile/minigun.dm
@@ -60,6 +60,10 @@
 		return 1
 	return 0
 
+/obj/item/weapon/gun/gatling/can_discharge() //Why is this gun not a child of gun/projectile?
+	if (current_shells)
+		return 1
+	
 /obj/item/weapon/gun/gatling/update_icon()
 	switch(current_shells)
 		if(150 to INFINITY)

--- a/code/modules/projectiles/guns/projectile/osipr.dm
+++ b/code/modules/projectiles/guns/projectile/osipr.dm
@@ -36,6 +36,12 @@
 		to_chat(user, "<span class='info'>It has no pulse magazine inserted!</span>")
 	to_chat(user, "<span class='info'>Has [energy_balls] dark energy core\s remaining.</span>")
 
+/obj/item/weapon/gun/osipr/can_discharge()
+	if (mode & OSIPR_PRIMARY_FIRE && magazine.bullets)
+		return 1
+	if (mode & OSIPR_SECONDARY_FIRE && energy_balls)
+		return 1
+	
 /obj/item/weapon/gun/osipr/process_chambered()
 	if(in_chamber)
 		return 1

--- a/code/modules/projectiles/guns/projectile/siren.dm
+++ b/code/modules/projectiles/guns/projectile/siren.dm
@@ -91,7 +91,7 @@
 	return in_chamber
 
 /obj/item/weapon/gun/siren/can_discharge()
-	if(reagents.total_volume > 10)
+	if(reagents.total_volume < 10)
 		return 1
 	
 /obj/item/weapon/gun/siren/supersoaker

--- a/code/modules/projectiles/guns/projectile/siren.dm
+++ b/code/modules/projectiles/guns/projectile/siren.dm
@@ -90,6 +90,10 @@
 /obj/item/weapon/gun/siren/process_chambered()
 	return in_chamber
 
+/obj/item/weapon/gun/siren/can_discharge()
+	if(reagents.total_volume > 10)
+		return 1
+	
 /obj/item/weapon/gun/siren/supersoaker
 	name = "super soaker"
 	desc = "For ages 10 and up."

--- a/code/modules/projectiles/guns/projectile/stickylauncher.dm
+++ b/code/modules/projectiles/guns/projectile/stickylauncher.dm
@@ -93,7 +93,10 @@
 		return 1
 	return 0
 
-
+/obj/item/weapon/gun/stickybomb/can_discharge()
+	if(loaded.len)
+		return 1
+	
 /obj/item/stickybomb
 	name = "anti-personnel stickybomb"
 	desc = "Ammo for a stickybomb launcher. Only affects living beings, produces a decent amount of knockback."

--- a/code/modules/projectiles/guns/projectile/stickylauncher.dm
+++ b/code/modules/projectiles/guns/projectile/stickylauncher.dm
@@ -94,8 +94,7 @@
 	return 0
 
 /obj/item/weapon/gun/stickybomb/can_discharge()
-	if(loaded.len)
-		return 1
+	return loaded.len
 	
 /obj/item/stickybomb
 	name = "anti-personnel stickybomb"

--- a/code/modules/reagents/dartgun.dm
+++ b/code/modules/reagents/dartgun.dm
@@ -115,6 +115,10 @@
 	else
 		return cartridge.darts
 
+/obj/item/weapon/gun/dartgun/can_discharge()
+	if(can_fire())
+		return 1
+		
 /obj/item/weapon/gun/dartgun/proc/has_selected_beaker_reagents()
 	return 0
 

--- a/code/modules/reagents/dartgun.dm
+++ b/code/modules/reagents/dartgun.dm
@@ -116,8 +116,7 @@
 		return cartridge.darts
 
 /obj/item/weapon/gun/dartgun/can_discharge()
-	if(can_fire())
-		return 1
+	return can_fire()
 		
 /obj/item/weapon/gun/dartgun/proc/has_selected_beaker_reagents()
 	return 0

--- a/code/modules/reagents/syringe_gun.dm
+++ b/code/modules/reagents/syringe_gun.dm
@@ -46,6 +46,9 @@
 /obj/item/weapon/gun/syringe/can_fire()
 	return syringes.len
 
+/obj/item/weapon/gun/syringe/can_discharge()
+	return can_fire()
+	
 /obj/item/weapon/gun/syringe/can_hit(var/mob/living/target as mob, var/mob/living/user as mob)
 	return 1		//SHOOT AND LET THE GOD GUIDE IT (probably will hit a wall anyway)
 


### PR DESCRIPTION
can_discharge() checks if a gun has enough ammo (ballistic or energy) to fire off another shot. Currently only used in the point-blank firing / melee check with guns, because this was using process_chambered(), which caused it to drop a shell casing on the first melee attempt. 
Fixes #15277.

🆑 
 - bugfix: Meleeing with weapons no longer ejects an empty shell casing, no matter how cool it was.
 - rscadd: You can now fire syringe guns and dart guns at point blank