### PR TITLE
Fixes right-click corrosive acid consuming 0 Plasma

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
@@ -228,6 +228,10 @@ Doesn't work on other aliens/AI.*/
 
 	if(powerc(200))
 		if(O in oview(1))
+			if(!O.acidable())
+				to_chat(usr, "<span class='alien'>You cannot dissolve this object.</span>")
+				return
+			AdjustPlasma(-200)
 			acidify(O, usr)
 		else
 			to_chat(usr, "<span class='alien'>Target is too far away.</span>")


### PR DESCRIPTION
It still have no busy var nor cooldown but hey it's not like you can spam it now.


:cl:
 * bugfix: Fixes Xenomorph's right-click corrosive acid not consuming plasma.