### PR TITLE
Prevents syndie thermals metagaming

### DIFF
--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -234,20 +234,20 @@
 	invisa_view = 2
 	eyeprot = -2 //prepare for your eyes to get shit on
 
-	emp_act(severity)
-		if(istype(src.loc, /mob/living/carbon/human))
-			var/mob/living/carbon/human/M = src.loc
-			to_chat(M, "<span class='warning'>The Optical Thermal Scanner overloads and blinds you!</span>")
-			if(M.glasses == src)
-				M.eye_blind = 3
-				M.eye_blurry = 5
-				M.disabilities |= NEARSIGHTED
-				spawn(100)
-					M.disabilities &= ~NEARSIGHTED
-		..()
+/obj/item/clothing/glasses/thermal/emp_act(severity)
+	if(istype(src.loc, /mob/living/carbon/human))
+		var/mob/living/carbon/human/M = src.loc
+		to_chat(M, "<span class='warning'>\The [src] overloads and blinds you!</span>")
+		if(M.glasses == src)
+			M.eye_blind = 3
+			M.eye_blurry = 5
+			M.disabilities |= NEARSIGHTED
+			spawn(100)
+				M.disabilities &= ~NEARSIGHTED
+	..()
 
 /obj/item/clothing/glasses/thermal/syndi	//These are now a traitor item, concealed as mesons.	-Pete
-	name = "Optical Meson Scanner"
+	name = "optical meson scanner"
 	desc = "Used for seeing walls, floors, and stuff through anything."
 	icon_state = "meson"
 	origin_tech = Tc_MAGNETS + "=3;" + Tc_SYNDICATE + "=4"


### PR DESCRIPTION
Before this change you could metagame that someone had the syndie themals because their name was capitalized differently (Optical Meson Scanner vs optical meson scanner), now you can't.

![dreamseeker_2017-07-02_21-30-43](https://user-images.githubusercontent.com/6307265/27772979-18bba520-5f6e-11e7-8d58-a0f69daded43.png)