### PR TITLE
Robot Rename boards now actually work as intended

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -92,7 +92,7 @@
 	icon_state = "cyborg_upgrade1"
 
 /obj/item/borg/upgrade/rename/attack_self(mob/user as mob)
-	heldname = stripped_input(user, "Enter new robot name to force, or leave clear to let the robot pick a name", "Robot Rename", heldname, MAX_NAME_LEN)
+	heldname = reject_bad_name(stripped_input(user, "Enter new robot name to force, or leave clear to let the robot pick a name", "Robot Rename", heldname, MAX_NAME_LEN),1)
 	if (heldname)
 		desc = "Used to rename a cyborg, or allow a cyborg to rename themselves. Current selected name is \"[heldname]\"."
 	else

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -86,24 +86,38 @@
 	R.updateicon()
 
 /obj/item/borg/upgrade/rename
-	name = "robot reclassification board"
-	desc = "Used to rename a cyborg."
+	var/heldname = ""
+	name = "robot rename board"
+	desc = "Used to rename a cyborg, or allow a cyborg to rename themselves."
 	icon_state = "cyborg_upgrade1"
-	var/heldname = "default name"
 
 /obj/item/borg/upgrade/rename/attack_self(mob/user as mob)
-	heldname = stripped_input(user, "Enter new robot name", "Robot Reclassification", heldname, MAX_NAME_LEN)
+	heldname = stripped_input(user, "Enter new robot name to force, or leave clear to let the robot pick a name", "Robot Rename", heldname, MAX_NAME_LEN)
+	if (heldname != "")
+		desc = "Used to rename a cyborg, or allow a cyborg to rename themselves. Current selected name is \"[heldname]\"."
+	else
+		desc = "Used to rename a cyborg, or allow a cyborg to rename themselves."
 
 /obj/item/borg/upgrade/rename/attempt_action(var/mob/living/silicon/robot/R,var/mob/living/user)
 	if(..())
 		return FAILED_TO_ADD
 
-	R.name = ""
-	R.custom_name = null
-	R.real_name = ""
-	R.updatename()
-	R.updateicon()
-	to_chat(R, "<span class='warning'>You may now change your name.</span>")
+	if (heldname == "")
+		R.custom_name = null
+		R.updatename()
+		if(R.can_diagnose()) //Few know this verb exists, hence a message
+			to_chat(R, "<span class='info' style=\"font-family:Courier\">You may now change your name through the Namepick verb, under Robot Commands.</span>")
+		R.namepick_uses ++
+		R.module.upgrades -= /obj/item/borg/upgrade/rename //So you can rename more than once
+	else
+		R.name = heldname
+		R.custom_name = heldname
+		R.real_name = heldname
+		R.updatename()
+		R.updateicon()
+		if(R.can_diagnose())
+			to_chat(R, "<span class='info' style=\"font-family:Courier\">Your name has been changed to \"[heldname]\".</span>")
+		R.module.upgrades -= /obj/item/borg/upgrade/rename
 
 /obj/item/borg/upgrade/restart
 	name = "robot emergency restart module"

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -93,7 +93,7 @@
 
 /obj/item/borg/upgrade/rename/attack_self(mob/user as mob)
 	heldname = stripped_input(user, "Enter new robot name to force, or leave clear to let the robot pick a name", "Robot Rename", heldname, MAX_NAME_LEN)
-	if (heldname != "")
+	if (heldname)
 		desc = "Used to rename a cyborg, or allow a cyborg to rename themselves. Current selected name is \"[heldname]\"."
 	else
 		desc = "Used to rename a cyborg, or allow a cyborg to rename themselves."
@@ -102,7 +102,7 @@
 	if(..())
 		return FAILED_TO_ADD
 
-	if (heldname == "")
+	if (!heldname)
 		R.custom_name = null
 		R.updatename()
 		if(R.can_diagnose()) //Few know this verb exists, hence a message

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -462,16 +462,21 @@
 	namepick_uses--
 	var/newname
 	for(var/i = 1 to 3)
-		newname = reject_bad_name(copytext(stripped_input(src,"You are a robot. Enter a name, or leave blank for the default name.", "Name change [3-i] [0-i != 1 ? "tries":"try"] left",""),1,MAX_NAME_LEN),1)
-		if(newname == "")
-			continue
-		if(alert(src,"Do you really want the name:\n[newname]?",,"Yes","No") == "Yes")
-			break
+		newname = reject_bad_name(copytext(stripped_input(src,"You are a robot. Enter a name, or leave blank for the default name.", "Name change [4-i] [0-i != 1 ? "tries":"try"] left",""),1,MAX_NAME_LEN),1)
+		if(newname == null)
+			if(alert(src,"Are you sure you want a default borg name?",,"Yes","No") == "Yes")
+				break
+		else 
+			if(alert(src,"Do you really want the name:\n[newname]?",,"Yes","No") == "Yes")
+				break
 
-	if (newname != "")
-		custom_name = newname
+	custom_name = newname
 	updatename()
 	updateicon()
+	if(newname)
+		to_chat(src, "<span class='warning'>You have changed your name to [newname]. You can change your name [namepick_uses] more times.<span>")
+	else
+		to_chat(src, "<span class='warning'>You have reset your name. You can change your name [namepick_uses] more times.<span>")
 
 /mob/living/silicon/robot/verb/cmd_robot_alerts()
 	set category = "Robot Commands"

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -462,7 +462,7 @@
 	namepick_uses--
 	var/newname
 	for(var/i = 1 to 3)
-		newname = copytext(sanitize(input(src,"You are a robot. Enter a name, or leave blank for the default name.", "Name change [3-i] [0-i != 1 ? "tries":"try"] left","") as text),1,MAX_NAME_LEN)
+		newname = reject_bad_name(copytext(stripped_input(src,"You are a robot. Enter a name, or leave blank for the default name.", "Name change [3-i] [0-i != 1 ? "tries":"try"] left",""),1,MAX_NAME_LEN),1)
 		if(newname == "")
 			continue
 		if(alert(src,"Do you really want the name:\n[newname]?",,"Yes","No") == "Yes")


### PR DESCRIPTION
A human can use the board in-hand to force a name, or leave the entry empty to allow the borg to choose a new name.
fixes #15332
tested

🆑 
 - bugfix: Robot Rename boards now actually work as intended
 - bugfix: Robots can no longer get a blank name