### PR TITLE
Specifying a form with the staff of change is now logged 

### DIFF
--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -126,7 +126,7 @@ var/available_staff_transforms=list("monkey","robot","slime","xeno","human","fur
 		to_chat(user, "<span class='danger'>You monster.</span>")
 	else
 		to_chat(user, "<span class='info'>You have selected to make your next victim have a [selected] form.</span>")
-
+	add_gamelogs(user, "set \the [src] to \ [selected]", admin = TRUE, tp_link = TRUE, tp_link_short = FALSE, span_class = "warning")
 	switch(selected)
 		if("random")
 			changetype=null


### PR DESCRIPTION
Does what the title says. Adds a simple notification for admins whenever someone uses the staff of change to change the form they want their victim to have.
Looks like this
![soc-logging](https://user-images.githubusercontent.com/19466872/27832218-3dc551d4-60ce-11e7-8041-48227f73edbb.png)

Ignore the disgusting resolution. Please let me know if there is anything you'd want me to change.

:cl:
 * rscadd: Added admin logs when someone selects a form with the Staff of Change

