### PR TITLE
leap now casts properly

### DIFF
--- a/code/game/dna/genes/goon_powers.dm
+++ b/code/game/dna/genes/goon_powers.dm
@@ -437,7 +437,8 @@
 	hud_state = "gen_leap"
 	override_base = "genetic"
 
-/spell/targeted/leap/after_cast(list/targets)
+/spell/targeted/leap/cast(list/targets)
+	set waitfor = FALSE
 	for(var/mob/living/target in targets)
 		if (istype(target.loc,/mob/) || target.lying || target.stunned || target.locked_to)
 			to_chat(target, "<span class='warning'>You can't jump right now!</span>")
@@ -447,8 +448,18 @@
 		if (istype(target.loc,/turf/))
 
 			if(istype(target.loc, /turf/space))
-				to_chat(target, "<span class='warning'>You're in space. No.</span>")
-				return
+				var/spaced = 1
+				for(var/turf/T in oview(1,target))
+					if(T.has_gravity(target))
+						spaced = 0
+						break
+					for(var/obj/O in T.contents)
+						if((O) && (O.density) && (O.anchored))
+							spaced = 0
+							break
+				if(spaced)
+					to_chat(target, "<span class='warning'>There is nothing to leap off of!.</span>")
+					return
 
 			if(target.restrained())//Why being pulled while cuffed prevents you from moving
 				for(var/mob/M in range(target, 1))

--- a/code/game/dna/genes/goon_powers.dm
+++ b/code/game/dna/genes/goon_powers.dm
@@ -437,7 +437,7 @@
 	hud_state = "gen_leap"
 	override_base = "genetic"
 
-/spell/targeted/leap/cast(list/targets, mob/user)
+/spell/targeted/leap/after_cast(list/targets)
 	for(var/mob/living/target in targets)
 		if (istype(target.loc,/mob/) || target.lying || target.stunned || target.locked_to)
 			to_chat(target, "<span class='warning'>You can't jump right now!</span>")
@@ -445,6 +445,10 @@
 
 		var/failed_leap = 0
 		if (istype(target.loc,/turf/))
+
+			if(istype(target.loc, /turf/space))
+				to_chat(target, "<span class='warning'>You're in space. No.</span>")
+				return
 
 			if(target.restrained())//Why being pulled while cuffed prevents you from moving
 				for(var/mob/M in range(target, 1))


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl: (as the emoji)
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
As it depends on a sleep for its fancy animation, it would take some time for cast to finally call take_charge, which would let you stack casts of the jump spell.

Now, everything's handled in after_cast, as cast just had a second argument that was never used anyway.

Also adds some sanity so you're not jumping in space of all places.

Tested, no runtimes that I could see. Couldn't stack-jump or jump into the nth dimension in space.

Fixes #15278
Fixes #13581