### PR TITLE
hotfix for UNLIMITED ENERGY GUNS

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -27,7 +27,14 @@
 		return 0
 	
 /obj/item/weapon/gun/energy/process_chambered()
-	can_discharge()
+	if(in_chamber)
+		return 1
+	if(!power_supply)
+		return 0
+	if(!power_supply.use(charge_cost))
+		return 0
+	if(!projectile_type)
+		return 0
 	in_chamber = new projectile_type(src)
 	return 1
 


### PR DESCRIPTION
Related to #15306
I shot an energy gun until it was empty and it clickclick'd, so I guess this is working.