### PR TITLE
Creatine Last Stand pills for nuke ops

### DIFF
--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -291,7 +291,7 @@
 	synd_mob.equip_to_slot_or_del(new /obj/item/ammo_storage/magazine/a12mm/ops(synd_mob), slot_in_backpack)
 	synd_mob.equip_to_slot_or_del(new /obj/item/ammo_storage/magazine/a12mm/ops(synd_mob), slot_in_backpack)
 	synd_mob.equip_to_slot_or_del(new /obj/item/weapon/reagent_containers/pill/cyanide(synd_mob), slot_in_backpack) // For those who hate fun
-	synd_mob.equip_to_slot_or_del(new /obj/item/weapon/reagent_containers/pill/creatine(synd_mob), slot_in_backpack) // HOOOOOO HOOHOHOHOHOHO - N3X
+	synd_mob.equip_to_slot_or_del(new /obj/item/weapon/reagent_containers/pill/laststand(synd_mob), slot_in_backpack) // HOOOOOO HOOHOHOHOHOHO - N3X
 	synd_mob.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/automatic/c20r(synd_mob), slot_belt)
 	synd_mob.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival/engineer(synd_mob.back), slot_in_backpack)
 	var/obj/item/weapon/implant/explosive/E = new/obj/item/weapon/implant/explosive/nuclear(synd_mob)

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -90,6 +90,20 @@
 /obj/item/weapon/reagent_containers/pill/creatine/New()
 	..()
 	reagents.add_reagent(CREATINE, 50)
+	
+/obj/item/weapon/reagent_containers/pill/laststand
+	name = "Creatine \"Last Stand\" suicide pill"
+	desc = "For when you really want to spend your last moments punching things to death."
+	icon_state = "pill5" //bright red oblong with stripe
+
+/obj/item/weapon/reagent_containers/pill/laststand/New()
+	..()
+	reagents.add_reagent(DEXALINP, 5) //STOP LAYING AROUND
+	reagents.add_reagent(MEDNANOBOTS, 0.4) //GET UP
+	reagents.add_reagent(HYPOZINE, 5) //GO FAST
+	reagents.add_reagent(COMNANOBOTS, 4.6) //FIGHT HARD
+	reagents.add_reagent(OXYCODONE, 5) //NO PAIN
+	reagents.add_reagent(CREATINE, 30) //ONLY FIST
 
 /obj/item/weapon/reagent_containers/pill/antitox
 	name = "Anti-toxins pill"


### PR DESCRIPTION
30 creatine, 5 oxycodone, 5 dexalinplus, 5 hypozine, 0.4 mednanos and 4.6 combatnanos
For about a minute of extreme punching action
also 100 PRs milestone finally

🆑 
 - Tweak: The 50u Creatine pill usually supplied to syndicate nuclear operatives has been modified to also rejuvenate it's user a bit.