### PR TITLE
Can now solder Starscreen circuits to switch between normal and EX

### DIFF
--- a/code/WorkInProgress/Cael_Aislinn/ShieldGen/circuits.dm
+++ b/code/WorkInProgress/Cael_Aislinn/ShieldGen/circuits.dm
@@ -4,7 +4,7 @@
 
 /obj/item/weapon/circuitboard/shield_gen_ex
 	name = "Circuit board (Starscreen-EX external shield generator)"
-	desc = "A circuit board used to run a Starscreen-EX external shield generator."
+	desc = "A circuit board used to run a Starscreen-EX external shield generator. There's a plate soldered just over one of the identifying chips."
 	board_type = MACHINE
 	build_path = "/obj/machinery/shield_gen/external"
 	origin_tech = Tc_BLUESPACE + "=4;" + Tc_PLASMATECH + "=3"
@@ -16,12 +16,20 @@
 							"/obj/item/weapon/stock_parts/console_screen" = 1,
 							"/obj/item/stack/cable_coil" = 5)
 
+/obj/item/weapon/circuitboard/shield_gen_ex/attackby(var/obj/item/weapon/G, var/mob/user)
+	if(issolder(G))
+		var/obj/item/weapon/solder/S = G
+		if(S.remove_fuel(1,user))
+			to_chat(user, "<span class = 'notice'>You set the shield generator circuit to project normal shields.</span>")
+			qdel(src)
+			new /obj/item/weapon/circuitboard/shield_gen
+
 ////////////////////////////////////////
 // Shield Generator
 
 /obj/item/weapon/circuitboard/shield_gen
 	name = "Circuit board (Starscreen shield generator)"
-	desc = "A circuit board used to run a Starscreen shield generator."
+	desc = "A circuit board used to run a Starscreen shield generator. There's a plate soldered just under one of the identifying chips."
 	board_type = MACHINE
 	build_path = "/obj/machinery/shield_gen"
 	origin_tech = Tc_BLUESPACE + "=4;" + Tc_PLASMATECH + "=3"
@@ -32,6 +40,14 @@
 							"/obj/item/weapon/stock_parts/subspace/amplifier" = 1,
 							"/obj/item/weapon/stock_parts/console_screen" = 1,
 							"/obj/item/stack/cable_coil" = 5)
+
+/obj/item/weapon/circuitboard/shield_gen/attackby(var/obj/item/weapon/G, var/mob/user)
+	if(issolder(G))
+		var/obj/item/weapon/solder/S = G
+		if(S.remove_fuel(1,user))
+			to_chat(user, "<span class = 'notice'>You set the shield generator circuit to project external hull shields.</span>")
+			qdel(src)
+			new /obj/item/weapon/circuitboard/shield_gen_ex
 
 ////////////////////////////////////////
 // Shield Capacitor


### PR DESCRIPTION
Most people don't even know the EX EX-ists.

TODO:
- [x] update wiki, I guess

🆑 
 - Tweak: You can now use a soldering iron on a Starscreen shield generator circuit board to switch between normal (bubble shield) and EX (external hull shield) modes.