### PR TITLE
Undoes borg name restrictions but removes double (or more) whitespace

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -293,8 +293,8 @@ proc/checkhtml(var/t)
 
 	
 /proc/trimcenter(text) 
-	var/regex/trimcenterregex = regex("[ ]{2,}")
-	return trimcenterregex.Replace(text,"[ ]")
+	var/regex/trimcenterregex = regex("\\s{2,}","g")
+	return trimcenterregex.Replace(text," ")
 
 	
 //Returns a string with double spaces removed

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -291,17 +291,26 @@ proc/checkhtml(var/t)
 
 	return ""
 
+	
+/proc/trimcenter(text) 
+	var/regex/trimcenterregex = regex("[ ]{2,}")
+	return trimcenterregex.Replace(text,"[ ]")
+
+	
 //Returns a string with double spaces removed
+/*
 /proc/trimcenter(text) 
 	var/last_char_group			= 0
-	for(var/i=1, i<=length(t_in), i++)
-		var/ascii_char = text2ascii(t_in,i)
+	var/t_out			= ""
+	for(var/i=1, i<=length(text), i++)
+		var/ascii_char = text2ascii(text,i)
 		switch(ascii_char)
 			if(32)
 				if(last_char_group <= 1)
 					continue	//suppress double-spaces and spaces at start of string
 				t_out += ascii2text(ascii_char)
 				last_char_group = 1
+	return t_out*/
 	
 //Returns a string with reserved characters and spaces before the first word and after the last word removed.
 /proc/trim(text)

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -291,26 +291,10 @@ proc/checkhtml(var/t)
 
 	return ""
 
-	
+//Returns a string with double spaces removed	
 /proc/trimcenter(text) 
 	var/regex/trimcenterregex = regex("\\s{2,}","g")
 	return trimcenterregex.Replace(text," ")
-
-	
-//Returns a string with double spaces removed
-/*
-/proc/trimcenter(text) 
-	var/last_char_group			= 0
-	var/t_out			= ""
-	for(var/i=1, i<=length(text), i++)
-		var/ascii_char = text2ascii(text,i)
-		switch(ascii_char)
-			if(32)
-				if(last_char_group <= 1)
-					continue	//suppress double-spaces and spaces at start of string
-				t_out += ascii2text(ascii_char)
-				last_char_group = 1
-	return t_out*/
 	
 //Returns a string with reserved characters and spaces before the first word and after the last word removed.
 /proc/trim(text)

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -291,6 +291,18 @@ proc/checkhtml(var/t)
 
 	return ""
 
+//Returns a string with double spaces removed
+/proc/trimcenter(text) 
+	var/last_char_group			= 0
+	for(var/i=1, i<=length(t_in), i++)
+		var/ascii_char = text2ascii(t_in,i)
+		switch(ascii_char)
+			if(32)
+				if(last_char_group <= 1)
+					continue	//suppress double-spaces and spaces at start of string
+				t_out += ascii2text(ascii_char)
+				last_char_group = 1
+	
 //Returns a string with reserved characters and spaces before the first word and after the last word removed.
 /proc/trim(text)
 	return trim_left(trim_right(text))

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -463,7 +463,7 @@
 
 	var/newname
 	for(var/i = 1 to 3)
-		newname = reject_bad_name(copytext(stripped_input(src,"You are a robot. Enter a name, or leave blank for the default name.", "Name change [4-i] [0-i != 1 ? "tries":"try"] left",""),1,MAX_NAME_LEN),1)
+		newname = trimcenter(trim(stripped_input(src,"You are a robot. Enter a name, or leave blank for the default name.", "Name change [4-i] [0-i != 1 ? "tries":"try"] left",""),1,MAX_NAME_LEN))
 		if(newname == null)
 			if(alert(src,"Are you sure you want a default borg name?",,"Yes","No") == "Yes")
 				break


### PR DESCRIPTION
In #15333 I forced borgs to use the `reject_bad_name()` proc which sucks.
Now with the help of PJB it just regexes away all the double whitespace.

Fixes #15375

🆑 
 - tweak: Borg naming restrictions lifted, but you can't spam spaces in it anymore.