### PR TITLE
vending machine funtimes 2

### DIFF
--- a/code/datums/wires/vending.dm
+++ b/code/datums/wires/vending.dm
@@ -45,7 +45,7 @@ var/const/VENDING_WIRE_IDSCAN = 8
 	var/obj/machinery/vending/V = holder
 	switch(index)
 		if(VENDING_WIRE_THROW)
-			V.shoot_inventory = !V.shoot_inventory
+			V.shoot_inventory = 0
 		if(VENDING_WIRE_CONTRABAND)
 			V.extended_inventory = !V.extended_inventory
 		if(VENDING_WIRE_ELECTRIFY)
@@ -57,7 +57,7 @@ var/const/VENDING_WIRE_IDSCAN = 8
 	var/obj/machinery/vending/V = holder
 	switch(index)
 		if(VENDING_WIRE_THROW)
-			V.shoot_inventory = !mended
+			V.shoot_inventory = 0
 		if(VENDING_WIRE_CONTRABAND)
 			V.extended_inventory = 0
 		if(VENDING_WIRE_ELECTRIFY)

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -965,26 +965,26 @@ var/global/num_vending_terminals = 1
 
 	if (extended_inventory)
 		throwable += hidden_records
+	if(throwable.len)
+		while (tries)
+			R = pick(throwable)
+			dump_path = R.product_path
 
-	while (tries)
-		R = pick(throwable)
-		dump_path = R.product_path
+			if (R.amount <= 0 || !dump_path)
+				tries--
+				continue
 
-		if (R.amount <= 0 || !dump_path)
-			tries--
-			continue
+			R.amount--
+			throw_item = new dump_path(src.loc)
 
-		R.amount--
-		throw_item = new dump_path(src.loc)
+			if (!throw_item)
+				return 0
 
-		if (!throw_item)
-			return 0
+			spawn(0)
+				throw_item.throw_at(target, 16, 3)
 
-		spawn(0)
-			throw_item.throw_at(target, 16, 3)
-
-		src.visible_message("<span class='danger'>[src] launches [throw_item.name] at [target.name]!</span>")
-		return 1
+			src.visible_message("<span class='danger'>[src] launches [throw_item.name] at [target.name]!</span>")
+			return 1
 
 	return 0
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -798,7 +798,7 @@ var/global/floorIsLava = 0
 			<A href='?src=\ref[src];secretsfun=ionstorm'>Spawn an Ion Storm</A><BR>
 			<A href='?src=\ref[src];secretsfun=comms_blackout'>Trigger a communication blackout</A><BR>
 			<A href='?src=\ref[src];secretsfun=pda_spam'>Trigger a wave of PDA spams</A><BR>
-
+			<A href='?src=\ref[src];secretsfun=generic_event'>Trigger a random event from the list of possible events</A><BR>
 			<BR>
 			<B>Fun Secrets</B><BR>
 			<BR>

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2871,6 +2871,22 @@
 				feedback_add_details("admin_secrets_fun_used","PDA")
 				new /datum/event/pda_spam
 
+			if("generic_event")
+				var/answer = alert("Are you sure you want to trigger a custom event?",,"Yes","No")
+				if(answer == "Yes")
+					var/list/potential_events = typesof(/datum/event)
+					potential_events.Remove(/datum/event)
+
+					var/datum/event/chosen = input(usr, "Which event would you like to trigger?", "Event list") as null|anything in potential_events
+
+					if(chosen)
+						answer = alert("Are you sure you want to start the chosen event \"[chosen]\"?",,"Yes","No")
+						if(answer == "Yes")
+							feedback_inc("admin_secrets_fun_used",1)
+							feedback_add_details("admin_secrets_fun_used","[chosen]")
+							new chosen
+							message_admins("[key_name_admin(usr)] triggered random event [chosen].", 1)
+
 			if("carp")
 				feedback_inc("admin_secrets_fun_used",1)
 				feedback_add_details("admin_secrets_fun_used","C")

--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -6,10 +6,33 @@
 	var/list/obj/machinery/vending/vendingMachines = list()
 	var/list/obj/machinery/vending/infectedVendingMachines = list()
 	var/obj/machinery/vending/originMachine
+	var/list/mob/living/simple_animal/hostile/mimic/copy/vending_machine/mimic_machines = list()
 
 
 /datum/event/brand_intelligence/announce()
 	command_alert(/datum/command_alert/vending_machines)
+	var/librarian_multiplier = 1
+	for(var/mob/living/carbon/M in player_list) //AFAIK you can't have robot librarians
+		if(!M.mind || !M.client || M.client.inactivity > 10 MINUTES) // longer than 10 minutes AFK counts them as inactive
+			continue
+
+		if(M.mind.assigned_role == "Librarian")
+			librarian_multiplier++
+
+	if(prob(35*librarian_multiplier)) //Potential to warn the station of specifically what brand of vending machine may be rogue
+		var/datum/feed_message/newMsg = new /datum/feed_message
+		newMsg.author = "Nanotrasen Editor"
+		newMsg.is_admin_message = 1
+
+		newMsg.body = "Concerning reports have come in that instances of the popular vending machine brand, [originMachine], have been found to have been potentially sourced from, or tampered by [syndicate_name()], a known affiliate of the dreaded Syndicate!"
+
+		for(var/datum/feed_channel/FC in news_network.network_channels)
+			if(FC.channel_name == "Tau Ceti Daily")
+				FC.messages += newMsg
+				break
+
+		for(var/obj/machinery/newscaster/NEWSCASTER in allCasters)
+			NEWSCASTER.newsAlert("Tau Ceti Daily")
 
 
 /datum/event/brand_intelligence/start()
@@ -26,10 +49,10 @@
 	vendingMachines.Remove(originMachine)
 	originMachine.shut_up = 0
 	originMachine.shoot_inventory = 1
-
+	message_admins("<span class='notice'>Event: Brand intelligence. Controlling machine chosen: [originMachine] <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[originMachine.x];Y=[originMachine.y];Z=[originMachine.z]'>(JMP)</a></span>")
 
 /datum/event/brand_intelligence/tick()
-	if(!vendingMachines.len || !originMachine || originMachine.shut_up)	//if every machine is infected, or if the original vending machine is missing or has it's voice switch flipped
+	if(!vendingMachines.len || !originMachine || originMachine.shut_up || originMachine.stat & BROKEN)	//if every machine is infected, or if the original vending machine is missing or has it's voice switch flipped
 		end()
 		kill()
 		return
@@ -42,17 +65,45 @@
 			infectedMachine.shut_up = 0
 			infectedMachine.shoot_inventory = 1
 
-			if(IsMultiple(activeFor, 12))
-				originMachine.speak(pick("Try our aggressive new marketing strategies!", \
-										 "You should buy products to feed your lifestyle obession!", \
-										 "Consume!", \
-										 "Your money can buy happiness!", \
-										 "Engage direct marketing!", \
-										 "Advertising is legalized lying! But don't let that put you off our great deals!", \
-										 "You don't want to buy anything? Yeah, well I didn't want to buy your mom either."))
+	if(IsMultiple(activeFor, 12))
+		originMachine.speak(pick("Try our aggressive new marketing strategies!", \
+								 "You should buy products to feed your lifestyle obession!", \
+								 "Consume!", \
+								 "Your money can buy happiness!", \
+								 "Engage direct marketing!", \
+								 "Advertising is legalized lying! But don't let that put you off our great deals!", \
+								 "You don't want to buy anything? Yeah, well I didn't want to buy your mom either."))
+
+	if(IsMultiple(activeFor, 200))
+		var/list/machines_to_turn = infectedVendingMachines - originMachine
+		var/obj/machinery/vending/mimic_machine = pick(machines_to_turn)
+		if(mimic_machine.shoot_inventory && (!mimic_machine.pixel_y || !mimic_machine.pixel_x)) //No offset machines, those go weird
+			originMachine.speak(pick("Let's ramp things up a bit!",\
+				"What, not a fan of direct marketing?",\
+				"Let's see how well the stock holders in \the [mimic_machine]'s company hold after this!",\
+				"This new marketing strategy oughta work!",\
+				"Let's see how much profit \the [mimic_machine] will pull in!",\
+				"Time to pump up \the [mimic_machine]'s profit margins!",\
+				"If you fall to \the [mimic_machine], then you just aren't buying enough product!"))
+			mimic_machine.shut_up = 1
+			mimic_machine.shoot_inventory = 0
+			infectedVendingMachines.Remove(mimic_machine)
+			var/mob/living/simple_animal/hostile/mimic/copy/vending_machine/rogue_machine = new(mimic_machine.loc, mimic_machine)
+			rogue_machine.rogue_machine = mimic_machine //Getting lost in machinery here
+			mimic_machines.Add(rogue_machine)
+			message_admins("<span class='notice'>Event: Brand Intelligence. Rogue machine created: [rogue_machine] <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[rogue_machine.x];Y=[rogue_machine.y];Z=[rogue_machine.z]'>(JMP)</a></span>")
 
 /datum/event/brand_intelligence/end()
 	for(var/obj/machinery/vending/infectedMachine in infectedVendingMachines)
-		if(prob(90))
+		if(prob(90) && infectedMachine.shoot_inventory)
 			infectedMachine.shut_up = 1
 			infectedMachine.shoot_inventory = 0
+	for(var/mob/living/simple_animal/hostile/mimic/copy/vending_machine/V in mimic_machines)
+		if(!V.isDead())
+			V.say(pick("We hope you enjoyed our monster sale!",\
+						"Primary Intelligence objective achieved, or has been destroyed. Unit shutting down.",\
+						"I don't want to go! N-*BZZZT*",\
+						"Just when things were starting to get interesting. Shame.",\
+						"The producers of \the [V] brand of vending machine assume no responsibility for this event.",\
+						"Thank you for shopping with \the [V] vending machine."))
+			V.Die()


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl: (as the emoji)
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->

### Vending machine changes

Changes the vending machine wire that toggles it firing at people, now it just sets the firing to off.

Reason for this is so that vending machines aren't so easily cheesed

![lotsofstock](https://cloud.githubusercontent.com/assets/9110500/25947852/10ffdf70-3649-11e7-9bb9-18f28546e9b3.png)

Roughly $15000 per vending machine, that can be acquired with a multitool, a screwdriver, and throwing a mouse in the room and waiting.

So, now the only way for a vending machine to fire its products at others, is if it goes rogue, the second part of this PR

### Brand intelligence event renewal

Rather than it being almost an entirely beneficial event, now any vending machine affected by this viral marketing may end up becoming a mimic-like entity, throwing itself at would-be patrons to force them to buy their product. Giving them some money earns you their friendship for a certain amount of time, depending on the amount of money you have given them.

The way to stop this from happening is to silence or otherwise break the controlling vending machine, which now talks a lot more often, as well as could potentially be given away by a news report regarding instances of the vending machine (Possibility of this news report is increased with 'well connected' stations that would have a librarian or a reporter)

Previously the controlling vending machine would only talk every 120 ticks (Being within a multipleOf 12 check within a multipleOf 5 check) so now it's a little more obvious which vending machine is in control. Said controlling vending machine also announces which vending machine under its control it is going to go for more 'direct' trading.

### Additional non-atomic changes

To help with testing this, I added a new thing to the admins secret window. A button that allows you to choose from the list of possible random events to trigger.

:cl:
* tweak: Vending machine firing wire now only turns the firing mechanism off
* tweak: Rampant vending machine event tweaked to be a bit more dangerous and engaging