### PR TITLE
Disallows un-transmogrifying as a ghost on Z2

### DIFF
--- a/code/modules/clothing/masks/transmog.dm
+++ b/code/modules/clothing/masks/transmog.dm
@@ -9,6 +9,7 @@
 	mech_flags = MECH_SCAN_ILLEGAL
 	var/target_type = null
 	var/cursed = FALSE
+	var/revert_spell_type //The path of the revert spell to use if not cursed, in case extra checks are necessary, etc. Leave undefined for the universal default.
 	var/list/skin_to_mask = list(
 		/obj/item/asteroid/goliath_hide         =   /obj/item/clothing/mask/morphing/goliath,
 		/obj/item/clothing/head/bearpelt/real   =   /obj/item/clothing/mask/morphing/bear,
@@ -33,7 +34,7 @@
 				if(cursed)
 					C.transmogrify(target_type)
 				else
-					C.transmogrify(target_type, TRUE)
+					C.transmogrify(target_type, revert_spell_type || TRUE)
 
 /obj/item/clothing/mask/morphing/attackby(obj/item/weapon/W, mob/user)
 	if(!target_type)
@@ -131,6 +132,7 @@
 	desc = "It appears to be modeled after a ghost. It looks as though it might disappear at any moment."
 	target_type = /mob/dead/observer/deafmute
 	icon_state = "ghost_mask"
+	revert_spell_type = /spell/aoe_turf/revert_form/no_z2 //Don't
 
 /obj/item/clothing/mask/morphing/ghost/equipped(mob/living/carbon/C, wear_mask)
 	if(target_type && istype(C))
@@ -142,7 +144,7 @@
 				if(cursed)
 					M = C.transmogrify(target_type)
 				else
-					M = C.transmogrify(target_type, TRUE)
+					M = C.transmogrify(target_type, revert_spell_type || TRUE)
 				M.forceMove(T)
 				to_chat(M, "<span class='warning'>\The [src] dissipates into thin air!</span>")
 				qdel(src)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1963,7 +1963,11 @@ mob/proc/on_foot()
 	if(key)
 		M.key = key
 	if(offer_revert_spell)
-		var/spell/change_back = new /spell/aoe_turf/revert_form
+		var/spell/change_back
+		if(ispath(offer_revert_spell)) //I don't like this but I'm not rewriting the whole system for a hotfix
+			change_back = new offer_revert_spell
+		else
+			change_back = new /spell/aoe_turf/revert_form
 		M.add_spell(change_back)
 	C.set_contained_mob(src)
 	timestopped = 1
@@ -1983,6 +1987,9 @@ mob/proc/on_foot()
 /spell/aoe_turf/revert_form/cast(var/list/targets, mob/user)
 	user.transmogrify()
 	user.remove_spell(src)
+
+/spell/aoe_turf/revert_form/no_z2 //Used if you don't want it reverting on Z2. So far only important for ghosts.
+	spell_flags = GHOSTCAST | Z2NOCAST
 
 /obj/transmog_body_container
 	name = "transmog body container"


### PR DESCRIPTION
Yeah this'll mildly fuck up people on shuttles but lol who cares
Better than getting to CentComm
I put a (rather shitty but still functional) framework in place so that if anyone cares enough, they can make the check more specific rather than just universally disallowing untransmogrification from the Mask of the Phantom on Z2
But this'll do for now

Fixes #15397 