### PR TITLE
Fixes unable to order odysseus/ripley circuits at cargo #15177

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1220,27 +1220,6 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	access = access_ce
 	group = "Engineering"
 
-/datum/supply_packs/mecha_ripley
-	name = "Ripley APLU circuit board"
-	contains = list(/obj/item/weapon/book/manual/ripley_build_and_repair,
-					/obj/item/weapon/circuitboard/mecha/ripley/main, //TEMPORARY due to lack of circuitboard printer
-					/obj/item/weapon/circuitboard/mecha/ripley/peripherals) //TEMPORARY due to lack of circuitboard printer
-	cost = 30
-	containertype = /obj/structure/closet/crate/secure/scisec
-	containername = "\improper APLU \"Ripley\" circuit crate"
-	access = access_robotics
-	group = "Engineering"
-
-/datum/supply_packs/mecha_odysseus
-	name = "Odysseus circuit board"
-	contains = list(/obj/item/weapon/circuitboard/mecha/odysseus/peripherals, //TEMPORARY due to lack of circuitboard printer
-					/obj/item/weapon/circuitboard/mecha/odysseus/main) //TEMPORARY due to lack of circuitboard printer
-	cost = 25
-	containertype = /obj/structure/closet/crate/secure/scisec
-	containername = "\improper \"Odysseus\" circuit crate"
-	access = access_robotics
-	group = "Engineering"
-
 /datum/supply_packs/shieldgens
 	name = "Shield generators"
 	contains = list(/obj/machinery/shieldwallgen,

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1221,7 +1221,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	group = "Engineering"
 
 /datum/supply_packs/mecha_ripley
-	name = "\"Ripley\" APLU circuit board"
+	name = "Ripley APLU circuit board"
 	contains = list(/obj/item/weapon/book/manual/ripley_build_and_repair,
 					/obj/item/weapon/circuitboard/mecha/ripley/main, //TEMPORARY due to lack of circuitboard printer
 					/obj/item/weapon/circuitboard/mecha/ripley/peripherals) //TEMPORARY due to lack of circuitboard printer
@@ -1232,7 +1232,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	group = "Engineering"
 
 /datum/supply_packs/mecha_odysseus
-	name = "\"Odysseus\" circuit board"
+	name = "Odysseus circuit board"
 	contains = list(/obj/item/weapon/circuitboard/mecha/odysseus/peripherals, //TEMPORARY due to lack of circuitboard printer
 					/obj/item/weapon/circuitboard/mecha/odysseus/main) //TEMPORARY due to lack of circuitboard printer
 	cost = 25

--- a/html/changelogs/SarahJohnson-FixCrate.yml
+++ b/html/changelogs/SarahJohnson-FixCrate.yml
@@ -33,4 +33,4 @@ delete-after: True
 # If you're using characters such as # ' : - or the like in your changelog, surround the entire change with quotes as shown in the second example. These quotes don't show up on the changelog once it's merged and prevent errors.
 # SCREW ANY OF THIS UP AND IT WON'T WORK.
 changes: 
-- bugfix: Fixes not being able to order odysseus/Ripley circuits from cargo.Fixes #15177
+- bugfix: Removes broken Odysseus/Ripley circuits crates from cargo. Concensus was use the imprinter if you need em. Fixes #15177

--- a/html/changelogs/SarahJohnson-FixCrate.yml
+++ b/html/changelogs/SarahJohnson-FixCrate.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general deleting of nice things)
+#   rscadd (general adding of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.
+author: SarahJohnson
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# There needs to be a space after the - and before the prefix. Don't use tabs anywhere in this file.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# If you're using characters such as # ' : - or the like in your changelog, surround the entire change with quotes as shown in the second example. These quotes don't show up on the changelog once it's merged and prevent errors.
+# SCREW ANY OF THIS UP AND IT WON'T WORK.
+changes: 
+- bugfix: Fixes not being able to order odysseus/Ripley circuits from cargo.Fixes #15177


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl: (as the emoji)
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
Fixes unable to order odysseus/ripley circuits at cargo #15177 . Tested what he said and what happened was you'd click to order it and it wouldn't bring up the dialog box. I guess the \", \" messed with the new reason dialog box system? Crates order now and it didn't throw any message into the dream daemon window so home free?

Proof of crates ordering now, 
![untitled](https://user-images.githubusercontent.com/5564796/28187226-5f15a8cc-67ca-11e7-8e32-3064331bc73d.png)
