### PR TITLE
Fixes #15416

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -14,6 +14,7 @@ var/global/num_vending_terminals = 1
 	var/display_color = "blue"
 	var/category = CAT_NORMAL//available by default, contraband, or premium (requires a coin)
 	var/subcategory = null
+	var/mini_icon = null
 
 /* TODO: Add this to deconstruction for vending machines
 /obj/item/compressed_vend
@@ -309,7 +310,8 @@ var/global/num_vending_terminals = 1
 			is_custom = TRUE
 			var/obj/O = R.product_path
 			R.price = O.price
-			R.product_name = "[O.name] (Orig name-[initial(O.name)])"
+			R.product_name = "[O.name]"
+			R.mini_icon = costly_bicon(O)
 		if (hidden)
 			R.category=CAT_HIDDEN
 			hidden_records  += R
@@ -594,7 +596,8 @@ var/global/num_vending_terminals = 1
 	return attack_hand(user)
 
 /obj/machinery/vending/proc/GetProductLine(var/datum/data/vending_product/P)
-	var/dat = {"<FONT color = '[P.display_color]'><B>[P.product_name]</B>:
+	var/micon = !isnull(P.mini_icon) ? "<td class='fridgeIcon cropped'>[P.mini_icon]</td>" : ""
+	var/dat = {"[micon]<FONT color = '[P.display_color]'><B>[P.product_name]</B>:
 		<b>[P.amount]</b> </font>"}
 	if(P.price)
 		dat += " <b>($[P.price])</b>"

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -304,9 +304,12 @@ var/global/num_vending_terminals = 1
 		R.original_amount = amount
 		R.price = price
 		R.display_color = pick("red", "blue", "green")
+		var/is_custom = FALSE
 		if(check_for_custom_vendor())
+			is_custom = TRUE
 			var/obj/O = R.product_path
 			R.price = O.price
+			R.product_name = "[O.name] (Orig name-[initial(O.name)])"
 		if (hidden)
 			R.category=CAT_HIDDEN
 			hidden_records  += R
@@ -321,7 +324,8 @@ var/global/num_vending_terminals = 1
 			product_records.Add(R)
 
 		var/obj/item/initializer = typepath
-		R.product_name = initial(initializer.name)
+		if(!is_custom)
+			R.product_name = initial(initializer.name)
 		R.subcategory = initial(initializer.vending_cat)
 
 /obj/machinery/vending/proc/get_item_by_type(var/this_type)

--- a/html/changelogs/Pomf123.yml
+++ b/html/changelogs/Pomf123.yml
@@ -1,3 +1,3 @@
 author: Pomf123
 changes:
-- bugfix: Fixed Custom Vending Machines not showing the proper item names, it also shows the original name to prevent scams.
+- bugfix: Fixed Custom Vending Machines not showing the proper item names, it also shows a mini icon of the item to lower chances of scams by name.

--- a/html/changelogs/Pomf123.yml
+++ b/html/changelogs/Pomf123.yml
@@ -1,2 +1,3 @@
 author: Pomf123
-changes: []
+changes:
+- bugfix: Fixed Custom Vending Machines not showing the proper item names, it also shows the original name to prevent scams.


### PR DESCRIPTION
Custom Vending Machines now show the proper item name and an icon of the item
![example](http://ss13.moe/uploads/2017-07-15_01-36-50.png)