### PR TITLE
Fixes Automap Areas to not always have dynamic lightning off

### DIFF
--- a/maps/randomvaults/objects.dm
+++ b/maps/randomvaults/objects.dm
@@ -30,9 +30,9 @@
 	new_area.tag = "[new_area.type]/\ref[ME]"
 	new_area.addSorted()
 
-/area/vault/automap/no_light
+
+/area/vault/automap/light
 	icon_state = "ME_vault_lit"
-	dynamic_lighting = FALSE
 
 /area/vault/icetruck
 

--- a/maps/randomvaults/objects.dm
+++ b/maps/randomvaults/objects.dm
@@ -31,8 +31,6 @@
 	new_area.addSorted()
 
 
-/area/vault/automap/light
-	icon_state = "ME_vault_lit"
 
 /area/vault/icetruck
 


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl: (as the emoji)
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
Closes https://github.com/vgstation-coders/vgstation13/issues/14816
This fixes the Automap Area always turning into a area without dynamic light, resulting in full brightness of the area. This is a quick and simple fix. It removes the no_light area and adds a simple light area. I tested this quickly and it seems that there were no problems. However I will still do one more test to make sure, but I think that this will work out.

:cl:
 * rscadd: Fixed Automap Areas always having dynamic light set off.