### PR TITLE
B52 flame out

### DIFF
--- a/code/modules/reagents/reagent_containers/food/drinks/drinkingglass.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/drinkingglass.dm
@@ -30,13 +30,13 @@
 				switch(R.id)*/
 		viewcontents = 1
 		overlays.len = 0
+		flammable = 0
+		if(!molotov)
+			lit = 0
+		light_color = null
+		set_light(0)
 		if (reagents.reagent_list.len > 0)
 			//mrid = R.get_master_reagent_id()
-			flammable = 0
-			if(!molotov)
-				lit = 0
-			light_color = null
-			set_light(0)
 			isGlass = 1
 			item_state = "glass_empty"
 			switch(reagents.get_master_reagent_id())


### PR DESCRIPTION
Fixes #4611

The bug was still occurring if the glass was emptied while still lit.

:cl:
* bugfix: Fixed a bug that caused emptied out Flamming B-52s to still emit light.