### PR TITLE
Wizard Mode can now have groups of Wizards

### DIFF
--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -19,14 +19,16 @@
 
 	var/finished = 0
 
+	var/const/players_per_wizard = 10
 	var/const/waittime_l = 600 //lower bound on time before intercept arrives (in tenths of seconds)
 	var/const/waittime_h = 1800 //upper bound on time before intercept arrives (in tenths of seconds)
+	var/wizard_amount= 1
 
 	can_be_mixed = TRUE
 
 /datum/game_mode/wizard/announce()
 	to_chat(world, "<B>The current game mode is - Wizard!</B>")
-	to_chat(world, "<B>There is a <span class='danger'>SPACE WIZARD on the station. You can't let him achieve his objective!</span>")
+	to_chat(world, "<B>There are a number of <span class='danger'>SPACE WIZARDS on the station. You can't let them achieve their objective!</span>")
 
 /datum/game_mode/wizard/pre_setup()
 	var/list/datum/mind/possible_wizards = get_players_for_role(ROLE_WIZARD)
@@ -34,29 +36,29 @@
 		log_admin("Failed to set-up a round of wizard. Couldn't find any volunteers to be wizards.")
 		message_admins("Failed to set-up a round of wizard. Couldn't find any volunteers to be wizards.")
 		return 0
-	var/datum/mind/wizard
-	while(possible_wizards.len)
-		wizard = pick(possible_wizards)
-		if(wizard.special_role || (mixed && (wizard in ticker.mode.modePlayer)))
-			possible_wizards -= wizard
-			wizard = null
-			continue
-		else
+
+	wizard_amount= max(round(num_players()/players_per_wizard, 1), 1)
+
+	for(var/j = 0, j < wizard_amount, j++)
+		if(!possible_wizards.len)
 			break
-	if(isnull(wizard))
-		log_admin("COULD NOT MAKE A WIZARD, Mixed mode is [mixed ? "enabled" : "disabled"]")
-		message_admins("COULD NOT MAKE A WIZARD, Mixed mode is [mixed ? "enabled" : "disabled"]")
-		return 0
-	wizards += wizard
-	modePlayer += wizard
+		var/datum/mind/wizard = pick(possible_wizards)
+		possible_wizards -= wizard
+		if(wizard.special_role || (mixed && (wizard in ticker.mode.modePlayer)))
+			continue
+		wizards += wizard
+		modePlayer += wizard
+		wizard.assigned_role = "MODE" //So they aren't chosen for other jobs.
+		wizard.special_role = "Wizard"
+		wizard.original = wizard.current
+
 	if(mixed)
 		ticker.mode.modePlayer += wizards //merge into master antag list
 		ticker.mode.wizards += wizards
-	wizard.assigned_role = "MODE" //So they aren't chosen for other jobs.
-	wizard.special_role = "Wizard"
-	wizard.original = wizard.current
+
 	if(wizardstart.len == 0)
-		to_chat(wizard.current, "<span class='danger'>A starting location for you could not be found, please report this bug!</span>")
+		for(var/datum/mind/wwwizard in wizards)
+			to_chat(wwwizard.current, "<span class='danger'>A starting location for you could not be found, please report this bug!</span>")
 		log_admin("Failed to set-up a round of wizard. Couldn't find any wizard spawn points.")
 		message_admins("Failed to set-up a round of wizard. Couldn't find any wizard spawn points.")
 		return 0
@@ -142,7 +144,7 @@
 	var/wizard_name_second = pick(wizard_second)
 	var/randomname = "[wizard_name_first] [wizard_name_second]"
 	spawn(0)
-		var/newname = copytext(sanitize(input(wizard_mob, "You are the Space Wizard. Would you like to change your name to something else?", "Name change", randomname) as null|text),1,MAX_NAME_LEN)
+		var/newname = copytext(sanitize(input(wizard_mob, "You are a Space Wizard. Would you like to change your name to something else?", "Name change", randomname) as null|text),1,MAX_NAME_LEN)
 
 		if (!newname)
 			newname = randomname
@@ -154,7 +156,7 @@
 /datum/game_mode/proc/greet_wizard(var/datum/mind/wizard, var/you_are=1)
 	if (you_are)
 		var/wikiroute = role_wiki[ROLE_WIZARD]
-		to_chat(wizard.current, "<span class='danger'>You are the Space Wizard!</span> <span class='info'><a HREF='?src=\ref[wizard.current];getwiki=[wikiroute]'>(Wiki Guide)</a></span>")
+		to_chat(wizard.current, "<span class='danger'>You are a Space Wizard!</span> <span class='info'><a HREF='?src=\ref[wizard.current];getwiki=[wikiroute]'>(Wiki Guide)</a></span>")
 	to_chat(wizard.current, "<B>The Space Wizards Federation has given you the following tasks:</B>")
 
 	var/obj_count = 1

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -28,7 +28,7 @@
 
 /datum/game_mode/wizard/announce()
 	to_chat(world, "<B>The current game mode is - Wizard!</B>")
-	to_chat(world, "<B>There are a number of <span class='danger'>SPACE WIZARDS on the station. You can't let them achieve their objective!</span>")
+	to_chat(world, "<B>There are several <span class='danger'>SPACE WIZARDS on the station. You can't let them achieve their objectives!</span>")
 
 /datum/game_mode/wizard/pre_setup()
 	var/list/datum/mind/possible_wizards = get_players_for_role(ROLE_WIZARD)
@@ -45,6 +45,7 @@
 		var/datum/mind/wizard = pick(possible_wizards)
 		possible_wizards -= wizard
 		if(wizard.special_role || (mixed && (wizard in ticker.mode.modePlayer)))
+			j--
 			continue
 		wizards += wizard
 		modePlayer += wizard

--- a/html/changelogs/Furbeh.yml
+++ b/html/changelogs/Furbeh.yml
@@ -1,3 +1,4 @@
 author: Furbeh
-changes: []
 delete-after: false
+changes: 
+- tweak: Multiple wizards can spawn at roundstart during a Wizard round, proportional to number of players

--- a/html/changelogs/Furbeh.yml
+++ b/html/changelogs/Furbeh.yml
@@ -1,4 +1,3 @@
 author: Furbeh
+changes: []
 delete-after: false
-changes: 
-- rscadd: Multiple wizards can spawn at roundstart during a Wizard round, proportional to number of players

--- a/html/changelogs/Furbeh.yml
+++ b/html/changelogs/Furbeh.yml
@@ -1,4 +1,4 @@
 author: Furbeh
 delete-after: false
 changes: 
-- tweak: Multiple wizards can spawn at roundstart during a Wizard round, proportional to number of players
+- rscadd: Multiple wizards can spawn at roundstart during a Wizard round, proportional to number of players


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl: (as the emoji)
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->

Wizard Mode is basically Ragin' Mages without reinforcments at this moment, so I improved it.
Each wizard has separate objectives.

Has been tested by changing the ratio to 1 wizard per person, and logging in on a private server with an additional guest account, as suggested by Sonix.

:cl:
 * rscadd: Wizard mode spawns a number of wizards proportional to the number of players.
 * tweak: Ratio currently is 10 players to 1 wizard,  minimum of 1 wizard.