### PR TITLE
Unfucked briefcases

### DIFF
--- a/code/game/objects/items/weapons/storage/briefcase.dm
+++ b/code/game/objects/items/weapons/storage/briefcase.dm
@@ -11,6 +11,7 @@
 	w_class = W_CLASS_LARGE
 	fits_max_w_class = W_CLASS_MEDIUM
 	max_combined_w_class = 16
+	hitsound = "swing_hit"
 
 /obj/item/weapon/storage/briefcase/centcomm
 	icon_state = "briefcase-centcomm"
@@ -28,43 +29,36 @@
 	new /obj/item/weapon/paper/commendation_key(src)
 
 /obj/item/weapon/storage/briefcase/attack(mob/living/M as mob, mob/living/user as mob)
-	//..()
-
 	if (clumsy_check(user) && prob(50))
 		to_chat(user, "<span class='warning'>The [src] slips out of your hand and hits your head.</span>")
 		user.take_organ_damage(10)
 		user.Paralyse(2)
+		playsound(get_turf(src), "swing_hit", 50, 1, -1)
+		return
+	..()
+
+/obj/item/weapon/storage/briefcase/afterattack(var/atom/target, var/mob/user, var/proximity_flag, var/click_parameters)
+	if (!isliving(target))
 		return
 
+	var/mob/living/M = target
 
-	M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been attacked with [src.name] by [user.name] ([user.ckey])</font>")
-	user.attack_log += text("\[[time_stamp()]\] <font color='red'>Used the [src.name] to attack [M.name] ([M.ckey])</font>")
-	msg_admin_attack("[user.name] ([user.ckey]) attacked [M.name] ([M.ckey]) with [src.name] (INTENT: [uppertext(user.a_intent)]) (<A HREF='?_src_=holder;adminmoreinfo=\ref[user]'>?</A>)")
-	if(!iscarbon(user))
-		M.LAssailant = null
-	else
-		M.LAssailant = user
-
-	if (M.stat < 2 && M.health < 50 && prob(90))
-		var/mob/H = M
-		// ******* Check
-		if ((istype(H, /mob/living/carbon/human) && istype(H, /obj/item/clothing/head) && H.flags & 8 && prob(80)))
-			to_chat(M, "<span class='warning'>The helmet protects you from being hit hard in the head!</span>")
-			return
-		var/time = rand(2, 6)
-		if (prob(75))
-			M.Paralyse(time)
+	if (M.stat == CONSCIOUS && M.health < 50)
+		if(prob(90))
+			if ((istype(M, /mob/living/carbon/human) && istype(M, /obj/item/clothing/head) && M.flags & 8 && prob(80)))
+				to_chat(M, "<span class='warning'>The helmet protects you from being hit hard in the head!</span>")
+				return
+			var/time = rand(2, 6)
+			if (prob(75))
+				M.Paralyse(time)
+			else
+				M.Stun(time)
+			M.stat = UNCONSCIOUS
+			for(var/mob/O in viewers(M, null))
+				O.show_message(text("<span class='danger'>[] has been knocked unconscious!</span>", M), 1, "<span class='warning'>You hear someone fall.</span>", 2)
 		else
-			M.Stun(time)
-		if(M.stat != 2)
-			M.stat = 1
-		for(var/mob/O in viewers(M, null))
-			O.show_message(text("<span class='danger'>[] has been knocked unconscious!</span>", M), 1, "<span class='warning'>You hear someone fall.</span>", 2)
-	else
-		to_chat(M, text("<span class='warning'>[] tried to knock you unconcious!</span>",user))
-		M.eye_blurry += 3
-
-	return
+			to_chat(M, text("<span class='warning'>[] tried to knock you unconcious!</span>",user))
+			M.eye_blurry += 3
 
 /obj/item/weapon/storage/briefcase/false_bottomed
 	name = "briefcase"


### PR DESCRIPTION
Fixes #10459
Fixes #12643

Holy shit, this is like old code so old it's prehistoric. It's older than 2012.

:cl:
* bugfix: Briefcases can finally be used to hit people and deal actual damage.
* bugfix: You won't any longer be notified that you were gonna be stunned by a briefcase if you weren't conscious and bellow the health threshold.
* bugfix: Briefcase attacks are now logged.
