### PR TITLE
Infinite cell tweaks

### DIFF
--- a/code/game/objects/items/weapons/power_cells.dm
+++ b/code/game/objects/items/weapons/power_cells.dm
@@ -161,7 +161,7 @@
 /obj/item/weapon/cell/infinite
 	name = "infinite-capacity power cell!"
 	icon_state = "icell"
-	origin_tech = Tc_POWERSTORAGE + "=6;" + Tc_NANOTRASEN + "=5"
+	origin_tech = null
 	maxcharge = 35000
 	starting_materials = list(MAT_IRON = 700, MAT_GLASS = 80)
 

--- a/code/game/objects/items/weapons/power_cells.dm
+++ b/code/game/objects/items/weapons/power_cells.dm
@@ -91,15 +91,6 @@
 	..()
 	charge = 0
 
-/obj/item/weapon/cell/infinite
-	name = "infinite-capacity power cell!"
-	icon_state = "icell"
-	origin_tech =  null
-	maxcharge = 30000
-	starting_materials = list(MAT_IRON = 700, MAT_GLASS = 80)
-	use()
-		return 1
-
 /obj/item/weapon/cell/potato
 	name = "potato battery"
 	desc = "A rechargeable starch based power cell."
@@ -166,3 +157,22 @@
 
 	reset_vars_after_duration(resettable_vars, duration)
 
+
+/obj/item/weapon/cell/infinite
+	name = "infinite-capacity power cell!"
+	icon_state = "icell"
+	origin_tech = Tc_POWERSTORAGE + "=6;" + Tc_NANOTRASEN + "=5"
+	maxcharge = 35000
+	starting_materials = list(MAT_IRON = 700, MAT_GLASS = 80)
+
+/obj/item/weapon/cell/infinite/New()
+	..()
+	desc = "This cell is the latest in NT technology, having the capability to perpetually recharge itself. It has a power rating of Infinity!"
+	processing_objects.Add(src)
+
+/obj/item/weapon/cell/infinite/Destroy()
+	processing_objects.Remove(src)
+	..()
+
+/obj/item/weapon/cell/infinite/process()
+	charge = maxcharge

--- a/code/game/objects/items/weapons/power_cells.dm
+++ b/code/game/objects/items/weapons/power_cells.dm
@@ -168,11 +168,8 @@
 /obj/item/weapon/cell/infinite/New()
 	..()
 	desc = "This cell is the latest in NT technology, having the capability to perpetually recharge itself. It has a power rating of Infinity!"
-	processing_objects.Add(src)
 
-/obj/item/weapon/cell/infinite/Destroy()
-	processing_objects.Remove(src)
+/obj/item/weapon/cell/infinite/use()
 	..()
-
-/obj/item/weapon/cell/infinite/process()
 	charge = maxcharge
+	return 1


### PR DESCRIPTION
Before:

Dumb maxcharge that breaks things and doesn't account for explode() (which can still be called with EMPs and blob_act())

use() just returns 1

Now:

They have a maxcharge of 35,000

Examination of the cell says infinity instead of the maxcharge

use() now calls the parent proc, which means it can and will explode if injected with plasma and stuck into something (and this is why the maxcharge isn't comically high)