### PR TITLE
Make travis statically link libvg crt.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,6 @@ script:
 - python tools/changelog/ss13_genchangelog.py html/changelog.html html/changelogs --dry-run
 - source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup
 - cd libvg
-- rm .cargo/config
 # --jobs 1 to prevent threading problems with the BYOND crate.
 - cargo test --jobs 1 --verbose
 - cd -

--- a/libvg/.cargo/config
+++ b/libvg/.cargo/config
@@ -1,4 +1,2 @@
 [build]
-# If you're gonna change anything here.
-# Make Travis not blindly delete this to be able to use stable.
-rustflags = ["-Z", "unstable-options", "-C", "target-feature=+crt-static"]
+rustflags = ["-C", "target-feature=+crt-static"]


### PR DESCRIPTION
This was disabled because it required nightly Rust.
With Rust 1.19, static crt linking is stable.