### PR TITLE
Fixed being able to access a flamethrower's window from anywhere

### DIFF
--- a/code/modules/projectiles/guns/projectile/constructable/flamethrower.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/flamethrower.dm
@@ -205,6 +205,8 @@
 		onclose(user, "flamethrower", src)
 
 /obj/item/weapon/gun/projectile/flamethrower/Topic(href,href_list[])
+	if (..())
+		return
 	if(href_list["close"])
 		usr << browse(null, "window=flamethrower")
 		usr.unset_machine()


### PR DESCRIPTION
:cl:
* bugfix: Fixed being able to toggle a flamethrower's lit state and pressure values from anywhere as long as you had the window open.