### PR TITLE
The Ass Driver (and removes the no exosuit conditional on superfart blasts)

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -700,18 +700,20 @@
 						if(do_after(usr,usr,30))
 							visible_message("<span class = 'warning'><b>[name]</b> unleashes a [pick("tremendous","gigantic","colossal")] fart!</span>","<span class = 'warning'>You hear a [pick("tremendous","gigantic","colossal")] fart.</span>")
 							playsound(location, 'sound/effects/superfart.ogg', 50, 0)
-							if(!wearing_suit)
-								for(var/mob/living/V in view(src,aoe_range))
-									if(!airborne_can_reach(location,get_turf(V),aoe_range))
-										continue
-									shake_camera(V,10,5)
-									if (V == src)
-										continue
-									to_chat(V, "<span class = 'danger'>You're sent flying!</span>")
-									V.Knockdown(5) // why the hell was this set to 12 christ
-									step_away(V,location,15)
-									step_away(V,location,15)
-									step_away(V,location,15)
+							for(var/mob/living/V in view(src,aoe_range))
+								if(!airborne_can_reach(location,get_turf(V),aoe_range))
+									continue
+								shake_camera(V,10,5)
+								if (V == src)
+									continue
+								to_chat(V, "<span class = 'danger'>You're sent flying!</span>")
+								V.Knockdown(5) // why the hell was this set to 12 christ
+								step_away(V,location,15)
+								step_away(V,location,15)
+								step_away(V,location,15)
+							if (istype(usr.loc,/turf/space))
+								to_chat(usr, "<span class = 'notice'>The gastrointestinal blast sends you careening through space!</span>")
+								throw_at(get_edge_target_turf(usr, dir), 5, 5)
 						else
 							to_chat(usr, "<span class = 'notice'>You were interrupted and couldn't fart! Rude!</span>")
 

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -711,7 +711,8 @@
 								step_away(V,location,15)
 								step_away(V,location,15)
 								step_away(V,location,15)
-							if (!turf.has_gravity(usr))
+							var/turf/T = get_turf(usr)
+							if (!T.has_gravity(usr))
 								to_chat(usr, "<span class = 'notice'>The gastrointestinal blast sends you careening through space!</span>")
 								throw_at(get_edge_target_turf(usr, dir), 5, 5)
 						else

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -711,7 +711,7 @@
 								step_away(V,location,15)
 								step_away(V,location,15)
 								step_away(V,location,15)
-							if !turf.has_gravity(mob)
+							if (!turf.has_gravity(usr))
 								to_chat(usr, "<span class = 'notice'>The gastrointestinal blast sends you careening through space!</span>")
 								throw_at(get_edge_target_turf(usr, dir), 5, 5)
 						else

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -711,7 +711,7 @@
 								step_away(V,location,15)
 								step_away(V,location,15)
 								step_away(V,location,15)
-							if (istype(usr.loc,/turf/space))
+							if !turf.has_gravity(mob)
 								to_chat(usr, "<span class = 'notice'>The gastrointestinal blast sends you careening through space!</span>")
 								throw_at(get_edge_target_turf(usr, dir), 5, 5)
 						else


### PR DESCRIPTION
-successfully superfarting on a space tile(and any gravity deficient tile for that matter) will launch you mass driver style in the direction you are facing.
-removes the condition that you must not be wearing an exosuit in order to stun and launch people with the superfart (I can revert this if people aren't happy with it, superfart is criminally underpowered imo, so I figured a small buff would do it some good).

![the_ass_driver](https://user-images.githubusercontent.com/25192877/28452642-7b4ddb98-6da8-11e7-9f02-7be00c7b13a3.gif)


:cl:
* rscadd: A recent breakthrough in the study of genetically-enhanced gastrointestinal-emissions has opened the way to several new opportunities in the field of space propulsion and travel. Ask your local geneticist today!
* tweak: exosuits can no longer contain your superfarts