### PR TITLE
Vermin infestation event update

### DIFF
--- a/code/datums/helper_datums/command_alerts.dm
+++ b/code/datums/helper_datums/command_alerts.dm
@@ -371,15 +371,6 @@ The access requirements on the Asteroid Shuttles' consoles have now been revoked
 
 	message = "One or more hostile creatures have entered the station in [localestring]. External security cameras indicate that the creature has [monsterstring]."
 
-/datum/command_alert/vermin
-	name = "Vermin Alert"
-	alert_title = "Vermin infestation"
-
-/datum/command_alert/vermin/New(vermstring = "various vermin", locstring = "the station's maintenance tunnels", warning = "Clear them out, before this starts to affect productivity.")
-	..()
-
-	message = "Bioscans indicate that [vermstring] have been breeding in [locstring]. [warning]"
-
 /datum/command_alert/mob_swarm
 	name = "Mob Swarm"
 

--- a/code/modules/events/infestation.dm
+++ b/code/modules/events/infestation.dm
@@ -1,21 +1,10 @@
-#define LOC_KITCHEN 0
-#define LOC_ATMOS 1
-#define LOC_INCIN 2
-#define LOC_CHAPEL 3
-#define LOC_LIBRARY 4
-#define LOC_HYDRO 5
-#define LOC_VAULT 6
-#define LOC_TECH 7
-
 #define VERM_MICE    0
-#define VERM_LIZARDS 1
-#define VERM_SPIDERS 2
-#define VERM_SLIMES  3
-#define VERM_BATS    4
-#define VERM_BORERS  5
-#define VERM_MIMICS  6
-#define VERM_ROACHES 7
-#define VERM_GREMLINS 8
+#define VERM_SPIDERS 1
+#define VERM_SLIMES  2
+#define VERM_BATS    3
+#define VERM_MIMICS  4
+#define VERM_ROACHES 5
+#define VERM_GREMLINS 6
 
 /datum/event/infestation
 	announceWhen = 15
@@ -24,53 +13,58 @@
 	var/vermstring
 	var/vermin = VERM_MICE
 
-/datum/event/infestation/start()
-
-	var/location = pick(LOC_KITCHEN, LOC_ATMOS, LOC_INCIN, LOC_CHAPEL, LOC_LIBRARY, LOC_HYDRO, LOC_VAULT, LOC_TECH)
-	var/spawn_area_type
-
 	//TODO:  These locations should be specified by the map datum or by the area. //Area datums, any day now
 	//Something like area.is_quiet=1 or map.quiet_areas=list()
-	switch(location)
-		if(LOC_KITCHEN)
-			spawn_area_type = /area/crew_quarters/kitchen
-			locstring = "the Kitchen"
-		if(LOC_ATMOS)
-			spawn_area_type = /area/engineering/atmos
-			locstring = "Atmospherics"
-		if(LOC_INCIN)
-			spawn_area_type = /area/maintenance/incinerator
-			locstring = "the Incinerator"
-		if(LOC_CHAPEL)
-			spawn_area_type = /area/chapel/main
-			locstring = "the Chapel"
-		if(LOC_LIBRARY)
-			spawn_area_type = /area/library
-			locstring = "the Library"
-		if(LOC_HYDRO)
-			spawn_area_type = /area/hydroponics
-			locstring = "Hydroponics"
-		if(LOC_VAULT)
-			spawn_area_type = /area/storage/nuke_storage
-			locstring = "the Vault"
-		if(LOC_TECH)
-			spawn_area_type = /area/storage/tech
-			locstring = "Technical Storage"
+	var/list/valid_areas = list(
+	/area/crew_quarters/kitchen,
+	/area/engineering/atmos,
+	/area/maintenance/incinerator,
+	/area/chapel/main,
+	/area/library,
+	/area/hydroponics,
+	/area/storage/tech, //tech storage
+	/area/lawoffice,
+	/area/security/perma, //permabrig
+	/area/bridge/meeting_room,
+	/area/crew_quarters/toilet, //dorms toilet
+
+	//maintenance
+	/area/maintenance/aft,
+	/area/maintenance/asmaint,
+	/area/maintenance/fore,
+	/area/maintenance/fpmaint,
+	)
+
+/datum/event/infestation/start()
+
+	//Area where the vermin should spawn
+	var/area/area_loc
+
+	/* Some maps might not include some areas, so try to avoid spawning them in areas that don't exist
+	   by picking another area if the currently picked area is empty */
+	while(!area_loc && valid_areas.len)
+		area_loc = locate(pick_n_take(valid_areas))
+
+		if(!istype(area_loc) || !area_loc.contents.len)
+			area_loc = null
+
+	//Throw a runtime if every area in the valid_areas list is empty
+	ASSERT(istype(area_loc) && area_loc.contents.len)
+
+	locstring = "in \the [area_loc.name]"
 
 	var/list/spawn_types = list()
 	var/max_number = 4
+	var/min_number = 2
 
-	vermin = pick(VERM_MICE, VERM_LIZARDS, VERM_SPIDERS, VERM_SLIMES, VERM_BATS, VERM_BORERS, VERM_MIMICS, VERM_ROACHES, VERM_GREMLINS)
+	vermin = pick(VERM_MICE, VERM_SPIDERS, VERM_SLIMES, VERM_BATS, VERM_MIMICS, VERM_ROACHES, VERM_GREMLINS)
 
 	switch(vermin)
 		if(VERM_MICE)
-			spawn_types = list(/mob/living/simple_animal/mouse/gray, /mob/living/simple_animal/mouse/brown, /mob/living/simple_animal/mouse/white)
-			max_number = 12
-			vermstring = "mice"
-		if(VERM_LIZARDS)
-			spawn_types = list(/mob/living/simple_animal/lizard)
-			max_number = 6
-			vermstring = "lizards"
+			spawn_types = list(/mob/living/simple_animal/mouse, /mob/living/simple_animal/mouse/wire_biter, /mob/living/simple_animal/mouse/plague/random_virus)
+			min_number = 4
+			max_number = 10
+			vermstring = "rats"
 		if(VERM_SPIDERS)
 			spawn_types = list(/mob/living/simple_animal/hostile/giant_spider/spiderling)
 			vermstring = "spiderlings"
@@ -80,30 +74,27 @@
 		if(VERM_BATS)
 			spawn_types = /mob/living/simple_animal/hostile/scarybat
 			vermstring = "space bats"
-		if(VERM_BORERS)
-			spawn_types = /mob/living/simple_animal/borer
-			vermstring = "borers"
-			max_number = 5
 		if(VERM_MIMICS)
 			spawn_types = /mob/living/simple_animal/hostile/mimic/crate/item
 			vermstring = "mimics"
-			max_number = 1 //1 to 2
+			min_number = 3
+			max_number = 5
+			locstring = "on the station" //Don't reveal the mimics' location for fun times
 		if(VERM_ROACHES)
 			spawn_types = /mob/living/simple_animal/cockroach
 			vermstring = "roaches"
-			max_number = 30 //Thanks obama
+			max_number = 30
 		if(VERM_GREMLINS)
 			spawn_types = /mob/living/simple_animal/hostile/gremlin
 			vermstring = "gremlins"
 			max_number = 4 //2 to 4
 
-	var/number = rand(2, max_number)
+	var/number = rand(min_number, max_number)
 
 	for(var/i = 0, i <= number, i++)
-		var/area/A = locate(spawn_area_type)
 		var/list/turf/simulated/floor/valid = list()
 		//Loop through each floor in the supply drop area
-		for(var/turf/simulated/floor/F in A)
+		for(var/turf/simulated/floor/F in area_loc)
 			if(!F.has_dense_content())
 				valid.Add(F)
 
@@ -121,6 +112,17 @@
 		warning = "Drive them away!" //DF reference
 
 	command_alert(new /datum/command_alert/vermin(vermstring, locstring, warning))
+
+//Command alert
+
+/datum/command_alert/vermin
+	name = "Vermin Alert"
+	alert_title = "Vermin infestation"
+
+/datum/command_alert/vermin/New(vermstring = "various vermin", locstring = "in the station's maintenance tunnels", warning = "Clear them out, before this starts to affect productivity.")
+	..()
+
+	message = "Bioscans indicate that [vermstring] have been breeding [locstring]. [warning]"
 
 #undef LOC_KITCHEN
 #undef LOC_ATMOS

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -316,3 +316,19 @@
 
 /mob/living/simple_animal/mouse/plague
 	disease_carrier = 1
+
+/mob/living/simple_animal/mouse/plague/random_virus/New()
+	..()
+
+	//Give the mouse either a random virus existing in the world, or a brand new one
+	if(disease2_list.len) //There are already existing viruses
+
+		//The disease2_list list contains IDs associated with the viruses
+		var/datum/disease2/disease/virus = disease2_list[pick(disease2_list)]
+
+		virus2["[virus.uniqueID]"] = virus
+	else //Make a random one
+		var/datum/disease2/disease/new_virus = new /datum/disease2/disease("Introduced to the station by a plague rat.")
+		new_virus.makerandom()
+
+		virus2["[new_virus.uniqueID]"] = new_virus


### PR DESCRIPTION
* Removed lizards and borers from the vermin infestation event since they were useless and boring

* Mice spawned by the event have a 1/3 chance of being ordinary fluffies, 1/3 chance of being wire chewers and 1/3 chance of being plague-infested, starting with a random disease

* Mimics have learned to hide their location from the bioscanners - the event will no longer reveal their location, only their existence (and there are 3-5 of them now, rather than 1-2)

* Added some new locations for the event, including maintenance and permabrig

:cl:
 * tweak: Updated the vermin infestation event - added more possible spawn locations, and removed the possibility of it spawning borers or lizard
 * tweak: Some mice spawned from the vermin infestation event can chew exposed wires and carry diseases
 * tweak: Location of mimics is no longer revealed by the event