### PR TITLE
Tank Dispenser Refactor

### DIFF
--- a/code/game/objects/structures/tank_dispenser.dm
+++ b/code/game/objects/structures/tank_dispenser.dm
@@ -24,19 +24,26 @@
 
 /obj/structure/dispenser/New()
 	. = ..()
+	while(oxygentanks>0)
+		var/obj/item/weapon/tank/oxygen/O = new(src)
+		oxytanks.Add(O)
+		oxygentanks--
+	while(plasmatanks>0)
+		var/obj/item/weapon/tank/plasma/P = new(src)
+		platanks.Add(P)
+		plasmatanks--
 	update_icon()
-
 
 /obj/structure/dispenser/update_icon()
 	overlays.len = 0
-	switch(oxygentanks)
+	switch(oxytanks.len)
 		if(1 to 3)
-			overlays += image(icon = icon, icon_state = "oxygen-[oxygentanks]")
+			overlays += image(icon = icon, icon_state = "oxygen-[oxytanks.len]")
 		if(4 to INFINITY)
 			overlays += image(icon = icon, icon_state = "oxygen-4")
-	switch(plasmatanks)
+	switch(platanks.len)
 		if(1 to 4)
-			overlays += image(icon = icon, icon_state = "plasma-[plasmatanks]")
+			overlays += image(icon = icon, icon_state = "plasma-[platanks.len]")
 		if(5 to INFINITY)
 			overlays += image(icon = icon, icon_state = "plasma-5")
 
@@ -50,8 +57,8 @@
 	user.set_machine(src)
 	var/dat = "[src]<br><br>"
 
-	dat += {"Oxygen tanks: [oxygentanks] - [oxygentanks ? "<A href='?src=\ref[src];oxygen=1'>Dispense</A>" : "empty"]<br>
-		Plasma tanks: [plasmatanks] - [plasmatanks ? "<A href='?src=\ref[src];plasma=1'>Dispense</A>" : "empty"]"}
+	dat += {"Oxygen tanks: [oxytanks.len] - [oxytanks.len ? "<A href='?src=\ref[src];oxygen=1'>Dispense</A>" : "empty"]<br>
+		Plasma tanks: [platanks.len] - [platanks.len ? "<A href='?src=\ref[src];plasma=1'>Dispense</A>" : "empty"]"}
 	user << browse(dat, "window=dispenser")
 	onclose(user, "dispenser")
 	return
@@ -59,10 +66,9 @@
 
 /obj/structure/dispenser/attackby(obj/item/I as obj, mob/user as mob)
 	if(istype(I, /obj/item/weapon/tank/oxygen) || istype(I, /obj/item/weapon/tank/air) || istype(I, /obj/item/weapon/tank/anesthetic))
-		if(oxygentanks < 10)
+		if(oxytanks.len < 10)
 			if(user.drop_item(I, src))
 				oxytanks.Add(I)
-				oxygentanks++
 				to_chat(user, "<span class='notice'>You put [I] in [src].</span>")
 				update_icon()
 		else
@@ -70,10 +76,9 @@
 		updateUsrDialog()
 		return
 	if(istype(I, /obj/item/weapon/tank/plasma))
-		if(plasmatanks < 10)
+		if(platanks.len < 10)
 			if(user.drop_item(I, src))
 				platanks.Add(I)
-				plasmatanks++
 				to_chat(user, "<span class='notice'>You put [I] in [src].</span>")
 				update_icon()
 		else
@@ -97,28 +102,18 @@
 	if(Adjacent(usr))
 		usr.set_machine(src)
 		if(href_list["oxygen"])
-			if(oxygentanks > 0)
-				var/obj/item/weapon/tank/oxygen/O
-				if(oxytanks.len == oxygentanks)
-					O = oxytanks[1]
-					oxytanks.Remove(O)
-				else
-					O = new /obj/item/weapon/tank/oxygen(loc)
-				O.forceMove(loc)
+			if(oxytanks.len > 0)
+				var/obj/item/weapon/tank/oxygen/O = oxytanks[oxytanks.len]
+				oxytanks.Remove(O)
+				usr.put_in_hands(O)
 				to_chat(usr, "<span class='notice'>You take [O] out of [src].</span>")
-				oxygentanks--
 				update_icon()
 		if(href_list["plasma"])
-			if(plasmatanks > 0)
-				var/obj/item/weapon/tank/plasma/P
-				if(platanks.len == plasmatanks)
-					P = platanks[1]
-					platanks.Remove(P)
-				else
-					P = new /obj/item/weapon/tank/plasma(loc)
-				P.forceMove(loc)
+			if(platanks.len > 0)
+				var/obj/item/weapon/tank/plasma/P = platanks[platanks.len]
+				platanks.Remove(P)
+				usr.put_in_hands(P)
 				to_chat(usr, "<span class='notice'>You take [P] out of [src].</span>")
-				plasmatanks--
 				update_icon()
 		add_fingerprint(usr)
 		updateUsrDialog()


### PR DESCRIPTION
Previous functionality:
* Tanks in tank dispensers are spawned on demand
* Prioritizes creating new tank over removing existing tank
* FIFO after all tanks are spawned

New functionality
* Tanks are spawned at roundstart
* LIFO

Fully tested
fixes #15494

🆑 
* tweak: Tank dispensers are now LIFO (were FIFO)
* tweak: Tank dispensers will now attempt to place removed tanks in your hand instead of the floor