### PR TITLE
Fixes ring of fire not granting complete fire immunity

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -420,6 +420,7 @@ var/global/list/BODY_COVER_VALUE_LIST=list("[HEAD]" = COVER_PROTECTION_HEAD,"[EY
 #define M_FINGERPRINTS	108 	// no fingerprints
 #define M_NO_SHOCK		109 	// insulated hands
 #define M_DWARF			110 	// table climbing
+#define M_UNBURNABLE	111		// can't get set on fire
 
 // Goon muts
 #define M_OBESITY       200		// Decreased metabolism

--- a/code/ZAS/Fire.dm
+++ b/code/ZAS/Fire.dm
@@ -198,6 +198,9 @@ Attach to transfer valve and open. BOOM.
 
 	//im not sure how to implement a version that works for every creature so for now monkeys are firesafe
 	for(var/mob/living/carbon/human/M in loc)
+		if(M.mutations.Find(M_UNBURNABLE))
+			continue
+
 		M.FireBurn(firelevel, air_contents.temperature, air_contents.return_pressure() ) //Burn the humans!
 
 	for(var/atom/A in loc)

--- a/code/game/objects/effects/fire_blast.dm
+++ b/code/game/objects/effects/fire_blast.dm
@@ -75,6 +75,8 @@
 			for(var/mob/living/L in get_turf(src))
 				if(issilicon(L))
 					continue
+				if(L.mutations.Find(M_UNBURNABLE))
+					continue
 
 				if(!L.on_fire)
 					L.adjust_fire_stacks(0.5)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -280,6 +280,9 @@
 	location.hotspot_expose(700, 50, 1,surfaces=1)
 
 /mob/living/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
+	if(mutations.Find(M_UNBURNABLE))
+		return
+
 	adjust_fire_stacks(0.5)
 	IgniteMob()
 

--- a/code/modules/spells/general/ring_of_fire.dm
+++ b/code/modules/spells/general/ring_of_fire.dm
@@ -34,18 +34,18 @@
 	if(isliving(user))
 		var/mob/living/L = user
 
-		if(!L.mutations.Find(M_RESIST_HEAT))
-			to_chat(L, "<span class='info'>You feel resistant to fire.</span>")
+		if(!L.mutations.Find(M_RESIST_HEAT) || !L.mutations.Find(M_UNBURNABLE))
+			to_chat(L, "<span class='info'>You feel completely resistant to fire.</span>")
 
-		L.mutations.Add(M_RESIST_HEAT)
+		L.mutations.Add(M_RESIST_HEAT, M_UNBURNABLE)
 		L.update_mutations()
 
 		spawn(duration)
-			L.mutations.Remove(M_RESIST_HEAT)
+			L.mutations.Remove(M_RESIST_HEAT, M_UNBURNABLE)
 			L.update_mutations()
 
-			if(!L.mutations.Find(M_RESIST_HEAT))
-				to_chat(L, "<span class='info'>You are no longer resistant to fire.</span>")
+			if(!L.mutations.Find(M_UNBURNABLE))
+				to_chat(L, "<span class='info'>You are no longer fully resistant to fire.</span>")
 
 	..()
 


### PR DESCRIPTION
It prevented the damage, but the wizard still got set on fire, burning to death afterwards unless extinguished

Makes this spell fun with fire breath and/or arcane golems

:cl:
 * bugfix: Wizards with ring of fire active can no longer be set on fire in any way.
