### PR TITLE
Replaces the step_x (and such) map file checker on Travis with a Python script.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,13 +27,13 @@ addons:
     - libstdc++6:i386
 
 install:
-- pip install --user PyYaml beautifulsoup4 subprocess32 -q
+- pip install --user PyYaml beautifulsoup4 subprocess32 colorama -q
 
 before_script:
 - tools/travis/install-byond.sh
 
 script:
-- find maps/ -name '*.dmm' -exec cat {} \; | awk '/(step_[xy]|layer) =/ { exit 1 }'
+- tools/travis/check_map_files.py maps/
 - find -name '*.dme' -exec cat {} \; | awk '/maps\\test.*/ { exit 1 }'
 - python tools/changelog/ss13_genchangelog.py html/changelog.html html/changelogs --dry-run
 - source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,8 @@ before_script:
 - tools/travis/install-byond.sh
 
 script:
-- tools/travis/check_map_files.py maps/
+# Has to use Python 2 instead of 3 because else it won't find colorama.
+- python tools/travis/check_map_files.py maps/
 - find -name '*.dme' -exec cat {} \; | awk '/maps\\test.*/ { exit 1 }'
 - python tools/changelog/ss13_genchangelog.py html/changelog.html html/changelogs --dry-run
 - source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup

--- a/tools/travis/check_map_files.py
+++ b/tools/travis/check_map_files.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# Checks the map files for bad strings like step_x, step_y and layer.
+# Isn't smart enough to ignore string contents, however.
+import sys
+import os
+import re
+
+# Try using colorama for colored output, otherwise fall back to uncolored.
+try:
+    from colorama import init, Fore, Style
+    init()
+
+except ImportError:
+    # Just give an empty string for everything, no colored output.
+    class ColorDummy(object):
+        def __getattr__(self, name):
+            return ""
+
+    Fore = ColorDummy()
+    Style = ColorDummy()
+
+BAD_STRINGS = {
+    "step_x": re.compile(r"\bstep_x\b"),
+    "step_y": re.compile(r"\bstep_y\b"),
+    "layer": re.compile(r"\blayer\b")
+}
+
+def main():
+    if len(sys.argv) != 2:
+        print(Fore.RED + "ERROR: Incorrect amount of arguments supplied: one needed." + Style.RESET_ALL)
+        exit(1)
+
+    passed = True
+    rootpath = sys.argv[1]
+    for root, _, files in os.walk(rootpath):
+        for filename in files:
+            if not checkfile(os.path.join(root, filename)):
+                passed = False
+
+    if not passed:
+        exit(1)
+
+
+def checkfile(filename):
+    if not filename.endswith(".dmm"):
+        return True
+
+    retval = True
+    print(Fore.CYAN + Style.DIM + "Checking file: {}".format(filename) + Style.RESET_ALL)
+    with open(filename, "r") as f:
+        for linenumber, line in enumerate(f.readlines()):
+            for string, regex in BAD_STRINGS.items():
+                if regex.search(line) != None:
+                    print(Fore.RED + ("ERROR: '{}' found on line {}. Remove it, please."
+                          .format(string, linenumber+1)) + Style.RESET_ALL)
+                    retval = False
+
+    return retval
+
+if __name__ == '__main__':
+    main()

--- a/tools/travis/check_map_files.py
+++ b/tools/travis/check_map_files.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # Checks the map files for bad strings like step_x, step_y and layer.
 # Isn't smart enough to ignore string contents, however.
+from __future__ import print_function
 import sys
 import os
 import re


### PR DESCRIPTION
Features:
* Proper logging, including line numbers.
* Colors! (optional, falls back to no colors if `colorama` isn't installed)
* Uses word bounds to match the bad strings, so less false positives.
* Works in Python 2 and 3.

![image](https://user-images.githubusercontent.com/8107459/28605817-e6d658a2-71d3-11e7-80b8-ef8b729fd555.png)

Because Packed Station failed to pass Travis because this damn one liner didn't check word bounds and I couldn't be bothered to read man pages for an hour to fix it.
