### PR TITLE
Biogenerator Package Wrap Buff

### DIFF
--- a/code/game/machinery/biogenerator.dm
+++ b/code/game/machinery/biogenerator.dm
@@ -183,14 +183,14 @@
 	cost=25
 	id="giftwrap"
 	name="Gift Wrap"
-	other_amounts=list(5,10)
+	amount_per_unit = 24
 	result=/obj/item/stack/package_wrap/gift
 
 /datum/biogen_recipe/paper/packagewrap
 	cost=30
 	id="packagewrap"
 	name="Package Wrap"
-	other_amounts=list(5,10)
+	amount_per_unit = 24
 	result=/obj/item/stack/package_wrap
 
 /datum/biogen_recipe/paper/paperbin


### PR DESCRIPTION
Now makes a full stack
closes #15240
closes #11963

Tested

🆑 
* The biogenerator now makes a full stack (24) package wrap or gift wrap instead of just a single sheet.