### PR TITLE
pAI Holomap Viewer

### DIFF
--- a/code/__DEFINES/pai_software.dm
+++ b/code/__DEFINES/pai_software.dm
@@ -11,3 +11,4 @@
 #define SOFT_SS "security supplement"
 #define SOFT_AS "atmosphere sensor"
 #define SOFT_PS "pai positioning system"
+#define SOFT_HM "holomap viewer"

--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -186,3 +186,7 @@
 	for(var/mob/M in src)
 		M.emp_act(severity)
 	..()
+
+/obj/item/device/paicard/dropped(mob/user)
+	if(pai && pai.holomap_device)
+		pai.holomap_device.stopWatching()

--- a/code/modules/mob/living/silicon/pai/death.dm
+++ b/code/modules/mob/living/silicon/pai/death.dm
@@ -18,5 +18,9 @@
 	living_mob_list -= src
 	if(pPS) // Removes it from the GPS List.
 		GPS_list.Remove(src)
+	if(holomap_device)
+		holomap_device.stopWatching()
+		qdel(holomap_device)
+		holomap_device = null
 	ghostize()
 	qdel(src)

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -52,6 +52,9 @@
 	var/pPS = 0 //Are we a pPS in the GPS list?
 	var/ppstag = "PAI0" // Our pPS tag
 
+	var/obj/item/device/station_map/holomap_device // Our holomap device.
+	var/holo_target = "show_map" // Our holomap target.
+
 /mob/living/silicon/pai/New(var/obj/item/device/paicard)
 	change_sight(removing = BLIND)
 	canmove = 0

--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -10,21 +10,12 @@
 															SOFT_CS = 30,
 															SOFT_FS = 30,
 															SOFT_UT = 30,
-
-															//"departmental assistance package" = 55
-															//Medical: access crew monitor, med records, gain med hud
-															//Sec: access sec records, gain sec hud
-															//Engineering: access station alerts, central atmos, gain atmos sensor
-															//Cargo: access supply shuttle console
-
-															//"autonomous movement system" = 55
-															//maybe later
-
-															//legacy, until the departmental is ready
 															SOFT_MS = 30, //records + HUD
 															SOFT_SS = 30, //records + HUD
 															SOFT_AS = 5,
-															SOFT_PS = 10
+															SOFT_PS = 10,
+															SOFT_HM = 25
+
 															)
 
 
@@ -76,6 +67,8 @@
 				left_part = src.softwareLight()
 			if("pps")
 				left_part = src.softwarepPS()
+			if("holomap")
+				left_part = src.softwareHolomap()
 
 	//usr << browse_rsc('windowbak.png')		// This has been moved to the mob's Login() proc
 
@@ -333,6 +326,18 @@
 					return
 				else
 					ppstag = tag
+		if("holomap")
+			if(href_list["switch_target"])
+				if(holo_target == initial(holo_target))
+					holo_target = "show_user"
+				else
+					holo_target = initial(holo_target)
+			if(href_list["show_user"])
+				var/mob/M = get_holder_of_type(loc, /mob)
+				if(M) //Sanity
+					holomap_device.toggleHolomap(M)
+			if(href_list["show_map"])
+				holomap_device.toggleHolomap(src)
 	src.paiInterface()		 // So we'll just call the update directly rather than doing some default checks
 	return
 
@@ -382,15 +387,15 @@
 			dat += "<a href='byond://?src=\ref[src];software=chemsynth;sub=0'>Chemical Synthesizer</a> <br>"
 		if(s == SOFT_FS)
 			dat += "<a href='byond://?src=\ref[src];software=foodsynth;sub=0'>Nutrition Synthesizer</a> <br>"
-		if(s == SOFT_PS)
-			dat += "<a href='byond://?src=\ref[src];software=pps;sub=0'>pAI Positioning System</a> <br>"
 	dat += "<br>"
 
-	// Advanced
-	dat += "<b>Advanced</b> <br>"
+	// Navigation
+	dat += "<b>Navigation</b> <br>"
 	for(var/s in src.software)
-		//This is where the computer interface software will go
-
+		if(s == SOFT_PS)
+			dat += "<a href='byond://?src=\ref[src];software=pps;sub=0'>pAI Positioning System</a> <br>"
+		if(s == SOFT_HM)
+			dat += "<a href='byond://?src=\ref[src];software=holomap;sub=0'>Holomap Viewer</a> <br>"
 	dat += {"<br>
 		<br>
 		<a href='byond://?src=\ref[src];software=buy;sub=0'>Download additional software</a>"}
@@ -766,4 +771,13 @@ Target Machine: "}
 			dat += "<BR>[tag]: [format_text(area.name)] (UNKNOWN, UNKNOWN, UNKNOWN)"
 		else
 			dat += "<BR>[tag]: [format_text(area.name)] ([pos.x-WORLD_X_OFFSET[pos.z]], [pos.y-WORLD_Y_OFFSET[pos.z]], [pos.z])"
+	return dat
+
+/mob/living/silicon/pai/proc/softwareHolomap()
+	if(!holomap_device)
+		holomap_device = new()
+	var/dat = "<h2>Holomap Viewer</h2>"
+	dat+= "Creates a virtual map of the surrounding area.<BR>"
+	dat+= "Current mode: [holo_target == initial(holo_target)? "Internal Viewer" : "External Projector"] | <a href='byond://?src=\ref[src];software=holomap;switch_target=1;sub=0'>Switch Type</a><BR>"
+	dat+= "<BR><a href='byond://?src=\ref[src];software=holomap;[holo_target]=1;sub=0'>Toogle Holomap</a><BR>"
 	return dat


### PR DESCRIPTION
![holomap viewer](https://user-images.githubusercontent.com/17928298/28747329-7baf5fb4-7472-11e7-9a72-5fa1dcce91b6.png)
Because what kind of smart device has no map app? Can either show the holomap to the pAI or protect it for its holder. 

Also changes the WYCI Advanced tab on pAIs to Navigation, both pPS and holomap viewer now appear instead of the standard tab.

:cl:
 * rscadd: Adds the pAI Holomap Viewer App for 25 memory points.