### PR TITLE
Added CANKNOCKDOWN flag to aliens

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -552,10 +552,11 @@ var/list/global_mutations = list() // list of hidden mutation things
 #define OXYLOSS 8
 
 //Bitflags defining which status effects could be or are inflicted on a mob
-#define CANSTUN		1
-#define CANKNOCKDOWN	2
-#define CANPARALYSE	4
-#define CANPUSH		8
+#define CANSTUN				1
+#define CANKNOCKDOWN		2
+#define CANPARALYSE			4
+#define CANPUSH				8
+#define CANAIRFLOWKNOCKDOWN	16
 #define GODMODE		4096
 #define FAKEDEATH	8192	//Replaces stuff like changeling.changeling_fakedeath
 #define DISFIGURED	16384	//I'll probably move this elsewhere if I ever get wround to writing a bitflag mob-damage system

--- a/code/ZAS/Airflow.dm
+++ b/code/ZAS/Airflow.dm
@@ -54,7 +54,7 @@ mob/proc/airflow_stun()
 		return 0
 	if(last_airflow_stun > world.time - zas_settings.Get(/datum/ZAS_Setting/airflow_stun_cooldown))
 		return 0
-	if(!(status_flags & CANSTUN) && !(status_flags & CANKNOCKDOWN))
+	if(!(status_flags & CANSTUN) && !(status_flags & CANAIRFLOWKNOCKDOWN))
 		to_chat(src, "<span class='notice'>You stay upright as the air rushes past you.</span>")
 		return 0
 
@@ -78,7 +78,7 @@ mob/living/carbon/human/airflow_stun()
 	if(shoes)
 		if(CheckSlip() < 1)
 			return 0
-	if(!(status_flags & CANSTUN) && !(status_flags & CANKNOCKDOWN))
+	if(!(status_flags & CANSTUN) && !(status_flags & CANAIRFLOWKNOCKDOWN))
 		to_chat(src, "<span class='notice'>You stay upright as the air rushes past you.</span>")
 		return 0
 

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -27,7 +27,7 @@
 
 	var/move_delay_add = 0 // movement delay to add
 
-	status_flags = CANPARALYSE|CANPUSH
+	status_flags = CANPARALYSE|CANPUSH|CANKNOCKDOWN
 	var/heal_rate = 2.5
 	var/plasma_rate = 5
 

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -221,7 +221,7 @@
 
 	var/update_icon = 1 //Set to 1 to trigger update_icons() at the next life() call
 
-	var/status_flags = CANSTUN|CANKNOCKDOWN|CANPARALYSE|CANPUSH	//bitflags defining which status effects can be inflicted (replaces CANKNOCKDOWN, canstun, etc)
+	var/status_flags = CANSTUN|CANKNOCKDOWN|CANAIRFLOWKNOCKDOWN|CANPARALYSE|CANPUSH	//bitflags defining which status effects can be inflicted (replaces CANKNOCKDOWN, canstun, etc)
 
 	var/digitalcamo = 0 // Can they be tracked by the AI?
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -138,7 +138,8 @@ var/list/impact_master = list()
 	var/mob/living/L = atarget
 	if(L.flags & INVULNERABLE)
 		return 0
-	L.apply_effects(stun, weaken, paralyze, irradiate, stutter, eyeblur, drowsy, agony, blocked) // add in AGONY!
+	if(!isalienadult(atarget))
+		L.apply_effects(stun, weaken, paralyze, irradiate, stutter, eyeblur, drowsy, agony, blocked) // add in AGONY!
 	if(jittery)
 		L.Jitter(jittery)
 	if(!isnull(hitsound))


### PR DESCRIPTION
What this does:
* The 5% chance to push aliens down now actually works (they get up a second later anyway)
* Aliens getting electrocuted by shocked doors, APCs, etc, now get properly knocked down
* Marauder Rocket Dash will now work on aliens.
* Aliens can now slip on peels, water, and lube

However:
* They still don't get knocked down by ZAS
* Projectiles still don't stun them