### PR TITLE
Hostile mobs now take windoors into account when breaking their surroundings

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -365,7 +365,12 @@
 			if(istype(T, /turf/simulated/wall) && Adjacent(T))
 				UnarmedAttack(T)
 			for(var/atom/A in T)
-				if((istype(A, /obj/structure/window) || istype(A, /obj/structure/closet) || istype(A, /obj/structure/table) || istype(A, /obj/structure/grille) || istype(A, /obj/structure/rack)) && Adjacent(A))
+				if((istype(A, /obj/structure/window)\
+				 || istype(A, /obj/structure/closet)\
+				 || istype(A, /obj/structure/table)\
+				 || istype(A, /obj/structure/grille)\
+				 || istype(A, /obj/structure/rack)\
+				 || istype(A, /obj/machinery/door/window)) && Adjacent(A))
 					UnarmedAttack(A)
 	return
 


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl: (as the emoji)
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
closes #12778 technically, as giant spiders can now 'deal' with windoors

As the check was reaching above 200 characters horizontally, I thought it would be best to make it more vertically inclined for better readability