### PR TITLE
Alien Infestations now get announced after 3-5 minutes instead of under a minute

### DIFF
--- a/code/modules/events/alien_infestation.dm
+++ b/code/modules/events/alien_infestation.dm
@@ -9,7 +9,7 @@
 
 
 /datum/event/alien_infestation/setup()
-	announceWhen = rand(300, 600)
+	announceWhen = rand(1500, 3000)
 	player_factor = round(player_list.len/10) //One bonus starting alium for 10 players
 	spawncount = rand(1, 2)+player_factor
 	sent_aliens_to_station = 1


### PR DESCRIPTION
If the announcement is that much of a problem @Duny- all you gotta do is tweak numbers and find a sweet spot.