### PR TITLE
adds to_chat(zlevel) with PoC on blob telepathy

### DIFF
--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -313,7 +313,7 @@
 /mob/camera/blob/verb/telepathy_power()
 	set category = "Blob"
 	set name = "Psionic Message"
-	set desc = "Give a psionic message to all creatures on and around the station."
+	set desc = "Give a psionic message to all creatures on and around your 'local' vicinity."
 	telepathy()
 
 /mob/camera/blob/proc/telepathy(message as text)
@@ -322,8 +322,8 @@
 		return
 
 
-	to_chat(world, "<span class='warning'>Your vision becomes cloudy, and your mind becomes clear.</span>")
+	to_chat(src.z, "<span class='warning'>Your vision becomes cloudy, and your mind becomes clear.</span>")
 	spawn(5)
-	to_chat(world, "<span class='blob'>[message]</span>")
+	to_chat(src.z, "<span class='blob'>[message]</span>") //Only sends messages to things on its own z level
 	add_gamelogs(src, "used blob telepathy to convey \"[message]\"", tp_link = TRUE)
 	log_blobtelepathy("[key_name(usr)]: [message]")

--- a/goon/code/datums/browserOutput.dm
+++ b/goon/code/datums/browserOutput.dm
@@ -251,11 +251,18 @@ For the main html chat area
 	//Ok so I did my best but I accept that some calls to this will be for shit like sound and images
 	//It stands that we PROBABLY don't want to output those to the browser output so just handle them here
 	if (istype(message, /image) || istype(message, /sound) || istype(target, /savefile) || !(ismob(target) || islist(target) || isclient(target) || istype(target, /datum/log) || target == world))
+
+		if (IsInteger(target)) //Passing it to an entire z level
+			for(var/mob/M in player_list) //List of all mobs with clients, excluding new_player
+				if(M.z != target)
+					continue
+				to_chat(M, message)
+			return
+
 		target << message
 		if (!isatom(target)) // Really easy to mix these up, and not having to make sure things are mobs makes the code cleaner.
 			CRASH("DEBUG: Boutput called with invalid message")
 		return
-
 	//Otherwise, we're good to throw it at the user
 	else if (istext(message))
 		if (istext(target))


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl: (as the emoji)
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
You can now pass an integer to to_chat as the target for it to send the message to clients on the z level specified by the integer. Proof of concept is blob telepathy due to reported issues of it sending messages to people still in the lobby, as it was to_chat(world) previously

closes #15481
closes #14200