### PR TITLE
Adding a verb allowing admins to debug strike team datums

### DIFF
--- a/code/game/striketeams/striketeam_datums.dm
+++ b/code/game/striketeams/striketeam_datums.dm
@@ -93,6 +93,9 @@ var/list/sent_strike_teams = list()
 			qdel(src)
 			return
 
+		log_admin("[applicants.len] players volunteered for [striketeam_name].")
+		message_admins("[applicants.len] players volunteered for [striketeam_name].")
+
 		var/list/commando_spawns = list_commando_spawns()
 		var/commando_count = min(applicants.len,team_size)
 		var/leader = FALSE
@@ -114,12 +117,14 @@ var/list/sent_strike_teams = list()
 					applicant = M
 
 			if(!applicant || !applicant.key)
+				i++
 				continue
 
 			applicants -= applicant.key
 
 			if(!isobserver(applicant))
 				//Making sure we don't recruit people who got back into the game since they applied
+				i++
 				continue
 
 			if (leader)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -186,6 +186,7 @@ var/list/admin_verbs_debug = list(
 	/client/proc/set_teleport_pref,
 	/client/proc/check_convertables,
 	/client/proc/check_spiral,
+	/client/proc/check_striketeams,
 	/client/proc/cmd_admin_find_bad_blood_tracks,
 	/client/proc/debugNatureMapGenerator,
 	/client/proc/callatomproc,

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -1348,6 +1348,18 @@ client/proc/check_convertables()
 	else
 		spiral_block(epicenter,max_range,0,1)
 
+/client/proc/check_striketeams()
+	set name = "Check StrikeTeams"
+	set category = "Debug"
+
+	if(!sent_strike_teams || sent_strike_teams.len <= 0)
+		to_chat(usr, "<span class='warning'>No strike teams have been sent so far!</span>")
+		return
+
+	var/teamToDebug = input(usr,"Choose a Strike Team.", "Check StrikeTeams") in sent_strike_teams
+
+	debug_variables(sent_strike_teams[teamToDebug])
+
 /client/proc/view_runtimes()
 	set category = "Debug"
 	set name = "View Runtimes"

--- a/code/modules/html_interface/map/station_map.dm
+++ b/code/modules/html_interface/map/station_map.dm
@@ -106,7 +106,6 @@
 			allowed_areas = list(
 				/area/centcom/specops,
 				/area/centcom/control,
-				/area/centcom/creed,
 				/area/centcom/test,
 				/area/centcom/ferry,
 				/area/centcom/holding,
@@ -114,9 +113,8 @@
 				)
 		if(HOLOMAP_FILTER_ERT)
 			allowed_areas = list(
-				/area/centcom/specops,
+				/area/centcom/ert,
 				/area/centcom/control,
-				/area/centcom/creed,
 				/area/centcom/test,
 				/area/centcom/ferry,
 				/area/centcom/holding,


### PR DESCRIPTION
might help me understand why sometimes ERT doesn't load up.

also might fix a bug that cause a strike team to have less people than it should sometimes.

and lastly added ERT preparation to the areas that appear on the ERT holominimaps, duh