### PR TITLE
Adds sanity to holsters

### DIFF
--- a/code/modules/clothing/accessories/holster.dm
+++ b/code/modules/clothing/accessories/holster.dm
@@ -35,6 +35,10 @@
 	if(!holstered)
 		return
 
+	if(user.stat || user.resting)
+		to_chat(user, "<span class='warning'>You can't hold \the [holstered] like this!</span>")
+		return
+
 	if(user.put_in_hands(holstered))
 		unholster_message(user)
 		holstered.add_fingerprint(user)


### PR DESCRIPTION
No more drawing your weapon when you can't hold it, it just breaks the proc halfway and don't update the holster's icon. And the whole thing isn't even useful/doesn't make sense as you can't grab things while lying.

Closes #15366