### PR TITLE
Fixed a few more mechas issues

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -395,7 +395,7 @@
 
 		else if(istype(obstacle, /mob/living))
 			var/mob/living/L = obstacle
-			if (!(L.status_flags & CANKNOCKDOWN) || (L.flags & INVULNERABLE))
+			if (!(L.status_flags & CANKNOCKDOWN) || (L.flags & INVULNERABLE) || (M_HULK in L.mutations))
 				src.throwing = 0//so mechas don't get stuck when landing after being sent by a Mass Driver
 				src.crashing = null
 			else

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -404,12 +404,12 @@
 				src.crashing = null
 				L.take_overall_damage(5,0)
 				if(L.locked_to)
-					L.locked_to = 0
+					L.locked_to.unlock_atom(L)
 			else
 				var/hit_sound = list('sound/weapons/genhit1.ogg','sound/weapons/genhit2.ogg','sound/weapons/genhit3.ogg')
 				L.take_overall_damage(5,0)
 				if(L.locked_to)
-					L.locked_to = 0
+					L.locked_to.unlock_atom(L)
 				L.Stun(5)
 				L.Knockdown(5)
 				L.apply_effect(STUTTER, 5)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -395,13 +395,18 @@
 
 		else if(istype(obstacle, /mob/living))
 			var/mob/living/L = obstacle
-			if (!(L.status_flags & CANKNOCKDOWN) || (L.flags & INVULNERABLE) || (M_HULK in L.mutations))
-				src.throwing = 0//so mechas don't get stuck when landing after being sent by a Mass Driver
+			if (L.flags & INVULNERABLE)
+				src.throwing = 0
 				src.crashing = null
+			else if (!(L.status_flags & CANKNOCKDOWN) || (M_HULK in L.mutations) || istype(L,/mob/living/silicon))
+				//can't be knocked down? you'll still take the damage.
+				src.throwing = 0
+				src.crashing = null
+				L.take_overall_damage(5,0)
+				if(L.locked_to)
+					L.locked_to = 0
 			else
 				var/hit_sound = list('sound/weapons/genhit1.ogg','sound/weapons/genhit2.ogg','sound/weapons/genhit3.ogg')
-				if(L.flags & INVULNERABLE)
-					return
 				L.take_overall_damage(5,0)
 				if(L.locked_to)
 					L.locked_to = 0

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -3,6 +3,7 @@
 	voice_name = "synthesized voice"
 	can_butcher = 0
 	mob_property_flags = MOB_ROBOTIC
+	status_flags = CANSTUN|CANPARALYSE|CANPUSH
 
 	var/flashed = 0
 	var/syndicate = 0

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -3,7 +3,6 @@
 	voice_name = "synthesized voice"
 	can_butcher = 0
 	mob_property_flags = MOB_ROBOTIC
-	status_flags = CANSTUN|CANPARALYSE|CANPUSH
 
 	var/flashed = 0
 	var/syndicate = 0


### PR DESCRIPTION
Fixes #15604 

~~removed the CANKNOCKDOWN status_flag from borgs since they can't be knocked down anyway. So mechas will no longer infinitely dash into them.~~ Whoever decided that borgs being knocked down meant not being actually knocked down can go eat a dick

Mecha throws now also check for HULK'd mobs.

If a Mecha is thrown against a non-invulnerable mob that can't be knocked down, the mob will still take the damage.