### PR TITLE
Cyborg death funtimes

### DIFF
--- a/code/modules/mob/living/silicon/robot/death.dm
+++ b/code/modules/mob/living/silicon/robot/death.dm
@@ -51,9 +51,7 @@
 			RC.upgrade_finished = -1
 		RC.go_out()
 
-	change_sight(adding = SEE_TURFS|SEE_MOBS|SEE_OBJS)
-	see_in_dark = 8
-	see_invisible = SEE_INVISIBLE_LEVEL_TWO
+	handle_sensor_modes()
 
 	tod = worldtime2text() //weasellos time of death patch
 	if(mind)

--- a/code/modules/mob/living/silicon/robot/death.dm
+++ b/code/modules/mob/living/silicon/robot/death.dm
@@ -36,11 +36,11 @@
 /mob/living/silicon/robot/death(gibbed)
 	if(stat == DEAD)
 		return
-	if(!gibbed)
-		emote("deathgasp")
-		updateicon()
 	stat = DEAD
 	update_canmove()
+	if(!gibbed)
+		emote("deathgasp")
+		updateicon() //Don't call updateicon if you're already null.
 	if(camera)
 		camera.status = 0
 

--- a/code/modules/mob/living/silicon/robot/death.dm
+++ b/code/modules/mob/living/silicon/robot/death.dm
@@ -38,6 +38,7 @@
 		return
 	if(!gibbed)
 		emote("deathgasp")
+		updateicon()
 	stat = DEAD
 	update_canmove()
 	if(camera)
@@ -53,7 +54,6 @@
 	change_sight(adding = SEE_TURFS|SEE_MOBS|SEE_OBJS)
 	see_in_dark = 8
 	see_invisible = SEE_INVISIBLE_LEVEL_TWO
-	updateicon()
 
 	tod = worldtime2text() //weasellos time of death patch
 	if(mind)


### PR DESCRIPTION
Fixes a null.updateicon() runtime preventing the singulo from consuming cyborgs and leaving them stuck in the limbo. Also removes fucking copypaste because holy shit there's a proc for this.

:cl:
 * rscadd: Fixes a runtime that prevented cyborgs from being consumed by singularities