### PR TITLE
Fixes storage items not calling dropped() on their u_equip() when handling item insertion 2

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -323,7 +323,7 @@
 	if(!istype(W))
 		return 0
 	if(usr)
-		usr.u_equip(W,0)
+		usr.u_equip(W,1)
 		usr.update_icons()	//update our overlays
 	W.forceMove(src)
 	W.on_enter_storage(src)


### PR DESCRIPTION
Fuck me i actually forgot this one.
Fixes #15625

:cl:
 * bugfix: Fixes rogue action buttons and the effect of a certain pair of fairy wings staying after you insert the item inside storages.
