### PR TITLE
Highlander/Bomberman honor overhaul.

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -1483,6 +1483,7 @@ var/proccalls = 1
 #define EVENT_PROC_INDEX "p"
 
 #define HIGHLANDER "highlander"
+#define BOMBERMAN "bomberman"
 
 #define SPELL_ANIMATION_TTL 2 MINUTES
 

--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -1485,6 +1485,11 @@ var/proccalls = 1
 #define HIGHLANDER "highlander"
 #define BOMBERMAN "bomberman"
 
+// /proc/is_honorable() flags.
+#define HONORABLE_BOMBERMAN  1
+#define HONORABLE_HIGHLANDER 2
+#define HONORABLE_ALL        HONORABLE_BOMBERMAN|HONORABLE_HIGHLANDER
+
 #define SPELL_ANIMATION_TTL 2 MINUTES
 
 //Grasp indexes

--- a/code/game/objects/loadouts.dm
+++ b/code/game/objects/loadouts.dm
@@ -515,3 +515,4 @@
 	var/list/randomhexes = list("7","8","9","a","b","c","d","e","f",)
 	M.color = "#[pick(randomhexes)][pick(randomhexes)][pick(randomhexes)][pick(randomhexes)][pick(randomhexes)][pick(randomhexes)]"
 	M.name = "Bomberman #[rand(1,999)]"
+	M.mind.special_role = BOMBERMAN // NEEDED FOR CHEAT CHECKS!

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -1,4 +1,9 @@
 var/global/list/reagents_to_log = list(FUEL, PLASMA, PACID, SACID, AMUTATIONTOXIN, MINDBREAKER, SPIRITBREAKER, CYANIDE, IMPEDREZENE, LUBE)
+
+// obj.honorable flags.
+#define HONORABLE_BOMBERMAN 1
+#define HONORABLE_HIGHLANDER 2
+
 /obj
 	var/origin_tech = null	//Used by R&D to determine what research bonuses it grants.
 	var/reliability = 100	//Used by SOME devices to determine how reliable they are.
@@ -39,6 +44,9 @@ var/global/list/reagents_to_log = list(FUEL, PLASMA, PACID, SACID, AMUTATIONTOXI
 	var/can_affix_to_dense_turf=0
 
 	var/has_been_invisible_sprayed = FALSE
+
+	// Tells is_honorable() which special_roles to respect.
+	var/honorable = HONORABLE_BOMBERMAN | HONORABLE_HIGHLANDER
 
 /obj/New()
 	..()
@@ -549,6 +557,20 @@ a {
 	if(istype(user))
 		return (M_CLUMSY in user.mutations)
 	return 0
+
+/**
+ * Honor check
+ * Returns TRUE if user is BOMBERMAN, HIGHLANDER...
+ * Respects honorable.
+ */
+/obj/proc/is_honorable(var/mob/living/user)
+	if(istype(user))
+		if(user.mind)
+			if(user.mind.special_role == BOMBERMAN && (honorable & HONORABLE_BOMBERMAN))
+				return TRUE
+			if(user.mind.special_role == HIGHLANDER && (honorable & HONORABLE_HIGHLANDER))
+				return TRUE
+	return FALSE
 
 //Proc that handles NPCs (gremlins) "tampering" with this object.
 //Return NPC_TAMPER_ACT_FORGET if there's no interaction (the NPC won't try to tamper with this again)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -1,9 +1,5 @@
 var/global/list/reagents_to_log = list(FUEL, PLASMA, PACID, SACID, AMUTATIONTOXIN, MINDBREAKER, SPIRITBREAKER, CYANIDE, IMPEDREZENE, LUBE)
 
-// obj.honorable flags.
-#define HONORABLE_BOMBERMAN 1
-#define HONORABLE_HIGHLANDER 2
-
 /obj
 	var/origin_tech = null	//Used by R&D to determine what research bonuses it grants.
 	var/reliability = 100	//Used by SOME devices to determine how reliable they are.
@@ -44,9 +40,6 @@ var/global/list/reagents_to_log = list(FUEL, PLASMA, PACID, SACID, AMUTATIONTOXI
 	var/can_affix_to_dense_turf=0
 
 	var/has_been_invisible_sprayed = FALSE
-
-	// Tells is_honorable() which special_roles to respect.
-	var/honorable = HONORABLE_BOMBERMAN | HONORABLE_HIGHLANDER
 
 /obj/New()
 	..()
@@ -557,20 +550,6 @@ a {
 	if(istype(user))
 		return (M_CLUMSY in user.mutations)
 	return 0
-
-/**
- * Honor check
- * Returns TRUE if user is BOMBERMAN, HIGHLANDER...
- * Respects honorable.
- */
-/obj/proc/is_honorable(var/mob/living/user)
-	if(istype(user))
-		if(user.mind)
-			if(user.mind.special_role == BOMBERMAN && (honorable & HONORABLE_BOMBERMAN))
-				return TRUE
-			if(user.mind.special_role == HIGHLANDER && (honorable & HONORABLE_HIGHLANDER))
-				return TRUE
-	return FALSE
 
 //Proc that handles NPCs (gremlins) "tampering" with this object.
 //Return NPC_TAMPER_ACT_FORGET if there's no interaction (the NPC won't try to tamper with this again)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -3322,6 +3322,7 @@
 						M.equip_to_slot_or_del(new /obj/item/clothing/suit/space/bomberman(M), slot_wear_suit)
 						M.equip_to_slot_or_del(new /obj/item/weapon/bomberman/(M), slot_s_store)
 						M.update_icons()
+						M.mind.special_role = BOMBERMAN // CHEAT CHECKS
 						to_chat(M, "Wait...what?")
 						spawn(50)
 							to_chat(M, "<span class='notice'>Tip: Use the BBD in your suit's pocket to place bombs.</span>")

--- a/code/modules/admin/verbs/onlyone.dm
+++ b/code/modules/admin/verbs/onlyone.dm
@@ -100,9 +100,12 @@
 	var/mob/living/carbon/human/H = ..(M)
 
 	ticker.mode.traitors += H.mind
-	H.mind.special_role = HIGHLANDER
+	H.mind.special_role = HIGHLANDER // NEEDED FOR CHEAT CHECKS!
 
 	H.mutations.Add(M_HULK) //all highlanders are permahulks
+	H.set_species("Human", force_organs=TRUE) // No Dionae
+	H.a_intent = I_HURT
+
 	H.update_mutations()
 	H.update_body()
 
@@ -152,7 +155,7 @@
 	H.equip_to_slot_or_del(W, slot_wear_id)
 
 	return H
-	
+
 
 //MAGIC MISSILE
 /datum/only_one/wizardwars

--- a/code/modules/bomberman/bomberman.dm
+++ b/code/modules/bomberman/bomberman.dm
@@ -1008,6 +1008,7 @@ var/global/list/arena_spawnpoints = list()//used by /mob/dead/observer/Logout()
 	B.destroy_environnement = 0
 	M.equip_to_slot_or_del(B, slot_s_store)
 	bombsuit.slowdown = HARDSUIT_SLOWDOWN_LOW
+	M.mind.special_role = BOMBERMAN
 	for(var/obj/item/clothing/C in M)
 		C.canremove = 0
 		if(violence)

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -173,6 +173,43 @@
 //		log_debug("No gloves, [M] is truing to infect [src]")
 		spread_disease_to(M, src, "Contact")
 
+	// CHEATER CHECKS
+	if(M.mind)
+		var/punishment = FALSE
+		var/bad_behavior = FALSE
+		if(M.mind.special_role == HIGHLANDER)
+			switch(M.a_intent)
+				if(I_DISARM)
+					bad_behavior = "disarm"
+				//if(I_HURT)
+				//	bad_behavior = "punch/kick"
+				//if(I_GRAB)
+				//	bad_behavior = "grab"
+			if(bad_behavior)
+				// In case we change our minds later...
+				//M.set_species("Tajaran")
+				//M.Cluwneize()
+				for(var/datum/organ/external/arm in M.organs)
+					if(istype(arm, /datum/organ/external/r_arm) || istype(arm, /datum/organ/external/l_arm))
+						arm.droplimb(1)
+				M.emote("scream", auto=TRUE)
+				visible_message("<span class='sinister'>[M] tried to [bad_behavior] [src]! [ticker.Bible_deity_name] has frowned upon the disgrace!</span>")
+				punishment = "disarmed"
+		if(M.mind.special_role == BOMBERMAN)
+			switch(M.a_intent)
+				if(I_DISARM)
+					bad_behavior = "disarm"
+				//if(I_HURT)
+				//	bad_behavior = "punch/kick"
+				//if(I_GRAB)
+				//	bad_behavior = "grab"
+			if(bad_behavior)
+				M.gib()
+				visible_message("<span class='sinister'>[M] tried to [bad_behavior] [src]! DISQUALIFIED!</span>")
+				punishment = "gibbed"
+		if(punishment)
+			message_admins("[M] tried to disarm [src] as a [M.mind.special_role] and was [punishment].")
+			return
 
 	switch(M.a_intent)
 		if(I_HELP)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -28,16 +28,16 @@
 
 mob/proc/isincrit()
 	return 0
-	
+
 mob/proc/get_heart()
 	return null
-	
+
 mob/proc/remove_internal_organ()
 	return null
 
 /mob/proc/get_broken_organs()
 	return list()
-	
+
 /mob/proc/get_bleeding_organs()
 	return list()
 
@@ -509,3 +509,17 @@ proc/is_blind(A)
 
 /mob/proc/get_survive_objective()
 	return new /datum/objective/survive
+
+/**
+* Honor check
+* Returns TRUE if user is BOMBERMAN, HIGHLANDER...
+* Respects honorable.
+*/
+/proc/is_honorable(var/mob/living/user, var/honorable = HONORABLE_ALL)
+	if(istype(user))
+		if(user.mind)
+			if(user.mind.special_role == BOMBERMAN && (honorable & HONORABLE_BOMBERMAN))
+				return TRUE
+			if(user.mind.special_role == HIGHLANDER && (honorable & HONORABLE_HIGHLANDER))
+				return TRUE
+	return FALSE

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -56,6 +56,9 @@
 
 	var/pai_safety = TRUE	//To allow the pAI to activate or deactivate firing capability
 
+	// Tells is_honorable() which special_roles to respect.
+	var/honorable = HONORABLE_BOMBERMAN | HONORABLE_HIGHLANDER
+
 /obj/item/weapon/gun/proc/ready_to_fire()
 	if(world.time >= last_fired + fire_delay)
 		last_fired = world.time
@@ -141,7 +144,7 @@
 		var/mob/living/M = user
 		if(clumsy_check && clumsy_check(M) && prob(50))
 			explode = TRUE
-		if(honor_check && is_honorable(M))
+		if(honor_check && is_honorable(M, honorable))
 			explode = TRUE
 			dehand = TRUE
 		if(explode)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -31,6 +31,7 @@
 	var/ejectshell = 1
 
 	var/clumsy_check = 1				//Whether the gun disallows clumsy users from firing it.
+	var/honor_check = 1                 // Same, but highlanders and bombermen.
 	var/advanced_tool_user_check = 1	//Whether the gun disallows users that cannot use advanced tools from firing it.
 	var/MoMMI_check = 1					//Whether the gun disallows MoMMIs from firing it.
 	var/nymph_check = 1					//Whether the gun disallows diona nymphs from firing it.
@@ -76,8 +77,8 @@
 		O.emp_act(severity)
 
 /obj/item/weapon/gun/proc/can_discharge() //because process_chambered() is an atrocity
-	return 0		
-		
+	return 0
+
 /obj/item/weapon/gun/afterattack(atom/A as mob|obj|turf|area, mob/living/user as mob|obj, flag, params, struggle = 0)
 	if(flag)
 		return //we're placing gun on a table or in backpack
@@ -134,15 +135,27 @@
 
 /obj/item/weapon/gun/proc/Fire(atom/target as mob|obj|turf|area, mob/living/user as mob|obj, params, reflex = 0, struggle = 0, var/use_shooter_turf = FALSE)//TODO: go over this
 	//Exclude lasertag guns from the M_CLUMSY check.
-	if(clumsy_check)
-		if(istype(user, /mob/living))
-			var/mob/living/M = user
-			if (clumsy_check(M) && prob(50))
+	var/explode = FALSE
+	var/dehand = FALSE
+	if(istype(user, /mob/living))
+		var/mob/living/M = user
+		if(clumsy_check && clumsy_check(M) && prob(50))
+			explode = TRUE
+		if(honor_check && is_honorable(M))
+			explode = TRUE
+			dehand = TRUE
+		if(explode)
+			if(dehand)
+				var/limb_index = user.is_holding_item(src)
+				var/datum/organ/external/L = M.find_organ_by_grasp_index(limb_index)
+				visible_message("<span class='sinister'>[src] blows up in [M]'s [L.display_name]!</span>")
+				L.droplimb(1)
+			else
 				to_chat(M, "<span class='danger'>[src] blows up in your face.</span>")
 				M.take_organ_damage(0,20)
-				M.drop_item(src, force_drop = 1)
-				qdel(src)
-				return
+			M.drop_item(src, force_drop = 1)
+			qdel(src)
+			return
 
 	if(!can_Fire(user, 1))
 		return

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -5,6 +5,9 @@
 #define REAGENTS_OVERDOSE 30
 #define REM REAGENTS_EFFECT_MULTIPLIER
 
+// Use in chem.flags.
+#define CHEMFLAG_DISHONORABLE 1
+
 //The reaction procs must ALWAYS set src = null, this detaches the proc from the object (the reagent)
 //so that it can continue working when the reagent is deleted while the proc is still active.
 
@@ -33,6 +36,7 @@
 	var/color = "#000000" //rgb: 0, 0, 0 (does not support alpha channels - yet!)
 	var/alpha = 255
 	var/dupeable = TRUE	//whether the reagent can be duplicated by standard reagent duplication methods such as a service borg shaker or odysseus
+	var/flags = 0
 
 /datum/reagent/proc/reaction_mob(var/mob/living/M, var/method = TOUCH, var/volume)
 	set waitfor = 0
@@ -123,6 +127,11 @@
 		M = holder.my_atom //Try to find the mob through the holder
 	if(!istype(M)) //Still can't find it, abort
 		return 1
+	if(M.mind)
+		if((M.mind.special_role == HIGHLANDER || M.mind.special_role == BOMBERMAN) && src.flags & CHEMFLAG_DISHONORABLE)
+			// TODO: HONORABLE_* checks.
+			return 1
+
 	if((overdose_am && volume >= overdose_am) || (overdose_tick && tick >= overdose_tick)) //Too much chems, or been in your system too long
 		on_overdose(M)
 
@@ -605,6 +614,7 @@
 	reagent_state = LIQUID
 	color = "#CF3600" //rgb: 207, 54, 0
 	custom_metabolism = 0.4
+	flags = CHEMFLAG_DISHONORABLE // NO CHEATING
 
 /datum/reagent/cyanide/on_mob_life(var/mob/living/M)
 
@@ -3061,9 +3071,9 @@
 	reagent_state = SOLID
 	color = "#000067" //rgb: 0, 0, 103
 	data = 1 //Used as a tally
+	flags = CHEMFLAG_DISHONORABLE // NO CHEATING
 
 /datum/reagent/chloralhydrate/on_mob_life(var/mob/living/M)
-
 	if(..())
 		return 1
 	switch(data)
@@ -6002,4 +6012,3 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 	spawn(volume * 10)
 		O.light_color = init_color
 		O.set_light(0)
-

--- a/html/changelogs/highland-honor.yml
+++ b/html/changelogs/highland-honor.yml
@@ -1,0 +1,17 @@
+# Your name.
+author: N3X15
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# There needs to be a space after the - and before the prefix. Don't use tabs anywhere in this file.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# If you're using characters such as # ' : - or the like in your changelog, surround the entire change with quotes as shown in the second example. These quotes don't show up on the changelog once it's merged and prevent errors.
+# SCREW ANY OF THIS UP AND IT WON'T WORK.
+changes:
+- rscadd: Trying to disarm someone as highlander will result in YOU being disarmed.
+- rscadd: Trying to disarm someone as bomberman will result in being disqualified.
+- rscadd: All humans are changed to the default human race during highlander.
+- rscadd: Chemicals can be marked DISHONORABLE to just not work on particular special roles like highlander.  This currently includes chloral and cyanide.
+- rscadd: Guns with honor_check will blow up if a highlander or bomberman tries to use them, taking their active hand with them.


### PR DESCRIPTION
# Executive Summary
Disarming, guns, and chloral are a bane of Highlander rounds. This attempts to make it harder to be a dishonorable peasant.

An honor system is added, where special roles like bomberman and highlander are considered honorable roles and attempts to use dishonorable attacks and disarms will result in immediate, painful consequences.

In short, read the changelog. :^)

# Testing
Changes were tested locally using a test dummy and myself.

# Readiness
This needs a few days of feedback before merging.  I know I haven't added DISHONORABLE to most of the chems that need it, for instance, and I may or may not need to add wizards to the gun checks, as well.

# Changelog
Included in YAML form.