### PR TITLE
Magboot stomp buff

### DIFF
--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -10,13 +10,15 @@
 	species_fit = list(VOX_SHAPED)
 	footprint_type = /obj/effect/decal/cleanable/blood/tracks/footprints/magboots
 
-	var/stomp_attack_power = 20
+	var/stomp_attack_power = 45
 
 /obj/item/clothing/shoes/magboots/on_kick(mob/living/carbon/human/user, mob/living/victim)
 	if(!stomp_attack_power)
 		return
 
 	var/turf/T = get_turf(src)
+	var/datum/organ/external/affecting = victim.get_organ(user.get_unarmed_damage_zone(victim))
+	
 	if(magpulse && victim.lying && T == victim.loc && !istype(T, /turf/space)) //To stomp on somebody, you have to be on the same tile as them. You can't be in space, and they have to be lying
 		//NUCLEAR MAGBOOT STUMP INCOMING (it takes 3 seconds)
 
@@ -28,15 +30,12 @@
 				return //Magboots enabled
 			if(!victim.lying || (victim.loc != T))
 				return //Victim moved
-			if(locate(/obj/structure/table) in T) //Can't curbstomp on a table
-				to_chat(user, "<span class='info'>There is a table in the way!</span>")
-				return
 
 			user.attack_log += "\[[time_stamp()]\] Magboot-stomped <b>[user] ([user.ckey])</b>"
 			victim.attack_log += "\[[time_stamp()]\] Was magboot-stomped by <b>[src] ([victim.ckey])</b>"
 
-			victim.visible_message("<span class='danger'>\The [user] crushes \the [victim] with the activated [src.name]!", "<span class='userdanger'>\The [user] crushes you with \his [src.name]!</span>")
-			victim.adjustBruteLoss(stomp_attack_power)
+			victim.visible_message("<span class='danger'>\The [user] crushes \the [victim]'s [affecting.display_name] with the activated [src.name]!", "<span class='userdanger'>\The [user] crushes your [affecting.display_name] with \his [src.name]!</span>")
+			victim.apply_damage(stomp_attack_power, BRUTE, affecting)
 			playsound(get_turf(victim), 'sound/effects/gib3.ogg', 100, 1)
 		else
 			return

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -34,7 +34,7 @@
 			user.attack_log += "\[[time_stamp()]\] Magboot-stomped <b>[user] ([user.ckey])</b>"
 			victim.attack_log += "\[[time_stamp()]\] Was magboot-stomped by <b>[src] ([victim.ckey])</b>"
 
-			victim.visible_message("<span class='danger'>\The [user] crushes \the [victim]'s [affecting.display_name] with the activated [src.name]!", "<span class='userdanger'>\The [user] crushes your [affecting.display_name] with \his [src.name]!</span>")
+			victim.visible_message("<span class='danger'>\The [user] crushes \the [victim] with the activated [src.name]!", "<span class='userdanger'>\The [user] crushes you with \his [src.name]!</span>")
 			victim.apply_damage(stomp_attack_power, BRUTE, affecting)
 			playsound(get_turf(victim), 'sound/effects/gib3.ogg', 100, 1)
 		else


### PR DESCRIPTION
From 20 damage to 45. For comparison, that's the damage you can deal if you just hit your target with a toolbox for the 3 seconds that it takes to perform this move

Also removed table check, since you have to be standing on top of the victim to do the stomp - I don't see why it was there in the first place

:cl:
 * rscadd: Magnetic magboot stomp now deals 45 damage, rather than 20. To perform it, stand on top of a lying mob with magboots enabled, and stomp on them (takes 3 seconds).

