### PR TITLE
Fixes cyborg hypospray logging

### DIFF
--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -81,7 +81,7 @@
 	if(M.reagents)
 		var/transferred = reagents.trans_to(M, amount_per_transfer_from_this)
 		to_chat(user, "<span class='notice'>[transferred] units injected. [reagents.total_volume] units remaining.</span>")
-		add_logs(user, M, "injected [transferred]u [reagents] with \the [src]", admin = (user.ckey && M.ckey)) //We don't care about monkeymen, right?
+		add_logs(user, M, "injected [transferred]u [reagent_ids[mode]] with \the [src]", admin = (user.ckey && M.ckey)) //We don't care about monkeymen, right?
 
 /obj/item/weapon/reagent_containers/borghypo/attack_self(mob/user as mob)
 	playsound(get_turf(src), 'sound/effects/pop.ogg', 50, 0) // change the mode


### PR DESCRIPTION
![3rdtimeisthecharm](https://user-images.githubusercontent.com/17928298/29005710-934e85b4-7ab7-11e7-9b10-5ee630f00525.png)
I almost forgot to commit this.


:cl:
 * rscadd: Fixes cyborg hypospray's attack log showing "datum/reagent" instead of the actual reagent.
