### PR TITLE
Adds sanity for consumables with respect to mouth obstructions

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -214,7 +214,7 @@ var/global/list/all_graffitis = list(
 		if(ishuman(user))
 			var/mob/living/carbon/human/H = user
 			if(H.check_body_part_coverage(MOUTH))
-				to_chat(user, "<span class='notice'><B>Remove [H.get_body_part_coverage(MOUTH)]!</B></span>")
+				to_chat(user, "<span class='notice'><B>Remove \the [H.get_body_part_coverage(MOUTH)]!</B></span>")
 				return
 		user.visible_message("<span class='notice'>[user] bites a chunk out of \the [src].</span>", \
 			"<span class='notice'>You bite a chunk out of \the [src].</span>")

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -214,7 +214,7 @@ var/global/list/all_graffitis = list(
 		if(ishuman(user))
 			var/mob/living/carbon/human/H = user
 			if(H.check_body_part_coverage(MOUTH))
-				to_chat(user, "<span class='notice'><B>Remove your [H.get_body_part_coverage(MOUTH)]!</B></span>")
+				to_chat(user, "<span class='notice'><B>Remove [H.get_body_part_coverage(MOUTH)]!</B></span>")
 				return
 		user.visible_message("<span class='notice'>[user] bites a chunk out of \the [src].</span>", \
 			"<span class='notice'>You bite a chunk out of \the [src].</span>")

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -211,11 +211,8 @@ var/global/list/all_graffitis = list(
 
 /obj/item/toy/crayon/attack(mob/M as mob, mob/user as mob)
 	if(M == user)
-		if(ishuman(user))
-			var/mob/living/carbon/human/H = user
-			if(H.check_body_part_coverage(MOUTH))
-				to_chat(user, "<span class='notice'><B>Remove \the [H.get_body_part_coverage(MOUTH)]!</B></span>")
-				return
+		if(user.covered_mouth_consumables_check(user))
+			return
 		user.visible_message("<span class='notice'>[user] bites a chunk out of \the [src].</span>", \
 			"<span class='notice'>You bite a chunk out of \the [src].</span>")
 		user.nutrition += 5

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -211,6 +211,11 @@ var/global/list/all_graffitis = list(
 
 /obj/item/toy/crayon/attack(mob/M as mob, mob/user as mob)
 	if(M == user)
+		if(ishuman(user))
+			var/mob/living/carbon/human/H = user
+			if(H.check_body_part_coverage(MOUTH))
+				to_chat(user, "<span class='notice'><B>Remove your [H.get_body_part_coverage(MOUTH)]!</B></span>")
+				return
 		user.visible_message("<span class='notice'>[user] bites a chunk out of \the [src].</span>", \
 			"<span class='notice'>You bite a chunk out of \the [src].</span>")
 		user.nutrition += 5

--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -84,10 +84,20 @@
 	if (src.loaded_food)
 		reagents.update_total()
 		if(M == user)
+			if(ishuman(user))
+				var/mob/living/carbon/human/H = user
+				if(H.check_body_part_coverage(MOUTH))
+					to_chat(user, "<span class='notice'><B>Remove your [H.get_body_part_coverage(MOUTH)]!</B></span>")
+					return
 			user.visible_message("<span class='notice'>[user] eats a delicious forkful of [loaded_food_name]!</span>")
 			feed_to(user, user)
 			return
 		else
+			if(ishuman(M))
+				var/mob/living/carbon/human/H = M
+				if(H.check_body_part_coverage(MOUTH))
+					to_chat(user, "<span class='notice'><B>Remove their [H.get_body_part_coverage(MOUTH)]!</B></span>")
+					return
 			user.visible_message("<span class='notice'>[user] attempts to feed [M] a delicious forkful of [loaded_food_name].</span>")
 			if(do_mob(user, M))
 				if(!loaded_food)

--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -87,7 +87,7 @@
 			if(ishuman(user))
 				var/mob/living/carbon/human/H = user
 				if(H.check_body_part_coverage(MOUTH))
-					to_chat(user, "<span class='notice'><B>Remove [H.get_body_part_coverage(MOUTH)]!</B></span>")
+					to_chat(user, "<span class='notice'><B>Remove \the [H.get_body_part_coverage(MOUTH)]!</B></span>")
 					return
 			user.visible_message("<span class='notice'>[user] eats a delicious forkful of [loaded_food_name]!</span>")
 			feed_to(user, user)
@@ -96,7 +96,7 @@
 			if(ishuman(M))
 				var/mob/living/carbon/human/H = M
 				if(H.check_body_part_coverage(MOUTH))
-					to_chat(user, "<span class='notice'><B>Remove [H.get_body_part_coverage(MOUTH)]!</B></span>")
+					to_chat(user, "<span class='notice'><B>Remove \the [H.get_body_part_coverage(MOUTH)]!</B></span>")
 					return
 			user.visible_message("<span class='notice'>[user] attempts to feed [M] a delicious forkful of [loaded_food_name].</span>")
 			if(do_mob(user, M))

--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -87,7 +87,7 @@
 			if(ishuman(user))
 				var/mob/living/carbon/human/H = user
 				if(H.check_body_part_coverage(MOUTH))
-					to_chat(user, "<span class='notice'><B>Remove your [H.get_body_part_coverage(MOUTH)]!</B></span>")
+					to_chat(user, "<span class='notice'><B>Remove [H.get_body_part_coverage(MOUTH)]!</B></span>")
 					return
 			user.visible_message("<span class='notice'>[user] eats a delicious forkful of [loaded_food_name]!</span>")
 			feed_to(user, user)
@@ -96,7 +96,7 @@
 			if(ishuman(M))
 				var/mob/living/carbon/human/H = M
 				if(H.check_body_part_coverage(MOUTH))
-					to_chat(user, "<span class='notice'><B>Remove their [H.get_body_part_coverage(MOUTH)]!</B></span>")
+					to_chat(user, "<span class='notice'><B>Remove [H.get_body_part_coverage(MOUTH)]!</B></span>")
 					return
 			user.visible_message("<span class='notice'>[user] attempts to feed [M] a delicious forkful of [loaded_food_name].</span>")
 			if(do_mob(user, M))

--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -84,20 +84,14 @@
 	if (src.loaded_food)
 		reagents.update_total()
 		if(M == user)
-			if(ishuman(user))
-				var/mob/living/carbon/human/H = user
-				if(H.check_body_part_coverage(MOUTH))
-					to_chat(user, "<span class='notice'><B>Remove \the [H.get_body_part_coverage(MOUTH)]!</B></span>")
-					return
+			if(user.covered_mouth_consumables_check(user))
+				return
 			user.visible_message("<span class='notice'>[user] eats a delicious forkful of [loaded_food_name]!</span>")
 			feed_to(user, user)
 			return
 		else
-			if(ishuman(M))
-				var/mob/living/carbon/human/H = M
-				if(H.check_body_part_coverage(MOUTH))
-					to_chat(user, "<span class='notice'><B>Remove \the [H.get_body_part_coverage(MOUTH)]!</B></span>")
-					return
+			if(user.covered_mouth_consumables_check(M))
+				return
 			user.visible_message("<span class='notice'>[user] attempts to feed [M] a delicious forkful of [loaded_food_name].</span>")
 			if(do_mob(user, M))
 				if(!loaded_food)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -2015,9 +2015,8 @@ mob/proc/on_foot()
 /mob/proc/covered_mouth_consumables_check(var/mob/feedee)
 	if(ishuman(feedee))
 		var/mob/living/carbon/human/H = feedee
-		if(H.check_body_part_coverage(MOUTH))
-			if(H.species.breath_type == "oxygen")
-				to_chat(src, "<span class='notice'><B>Remove \the [H.get_body_part_coverage(MOUTH)]!</B></span>")
-				return TRUE
-			else
-				return FALSE 
+		if(H.check_body_part_coverage(MOUTH) && H.species.breath_type == "oxygen" && !(H.job in list("Clown", "Mime")))
+			to_chat(src, "<span class='notice'><B>Remove \the [H.get_body_part_coverage(MOUTH)]!</B></span>")
+			return TRUE
+		else
+			return FALSE 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -2016,7 +2016,8 @@ mob/proc/on_foot()
 	if(ishuman(feedee))
 		var/mob/living/carbon/human/H = feedee
 		if(H.check_body_part_coverage(MOUTH))
-			to_chat(src, "<span class='notice'><B>Remove \the [H.get_body_part_coverage(MOUTH)]!</B></span>")
-			return TRUE
-		else
-			return FALSE 
+			if(H.species.breath_type == "oxygen")
+				to_chat(src, "<span class='notice'><B>Remove \the [H.get_body_part_coverage(MOUTH)]!</B></span>")
+				return TRUE
+			else
+				return FALSE 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -2011,3 +2011,12 @@ mob/proc/on_foot()
 
 #undef MOB_SPACEDRUGS_HALLUCINATING
 #undef MOB_MINDBREAKER_HALLUCINATING
+
+/mob/proc/covered_mouth_consumables_check(var/mob/feedee)
+	if(ishuman(feedee))
+		var/mob/living/carbon/human/H = feedee
+		if(H.check_body_part_coverage(MOUTH))
+			to_chat(src, "<span class='notice'><B>Remove \the [H.get_body_part_coverage(MOUTH)]!</B></span>")
+			return TRUE
+		else
+			return FALSE 

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -108,7 +108,7 @@ var/list/LOGGED_SPLASH_REAGENTS = list(FUEL, THERMITE)
 	else if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(H.check_body_part_coverage(MOUTH))
-			to_chat(user, "<span class='notice'><B>Remove [H.get_body_part_coverage(MOUTH)]!</B></span>")
+			to_chat(user, "<span class='notice'><B>Remove \the [H.get_body_part_coverage(MOUTH)]!</B></span>")
 			return 0
 		user.visible_message("<span class='danger'>[user] attempts to feed [M] \the [src].</span>", "<span class='danger'>You attempt to feed [M] \the [src].</span>")
 
@@ -345,7 +345,7 @@ var/list/LOGGED_SPLASH_REAGENTS = list(FUEL, THERMITE)
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		if(H.check_body_part_coverage(MOUTH))
-			to_chat(user, "<span class='notice'><B>Remove [H.get_body_part_coverage(MOUTH)]!</B></span>")
+			to_chat(user, "<span class='notice'><B>Remove \the [H.get_body_part_coverage(MOUTH)]!</B></span>")
 			return 0
 
 	to_chat(user, "<span  class='notice'>You swallow a gulp of \the [src].</span>")

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -105,11 +105,8 @@ var/list/LOGGED_SPLASH_REAGENTS = list(FUEL, THERMITE)
 		imbibe(user)
 		return 1
 
-	else if(ishuman(M))
-		var/mob/living/carbon/human/H = M
-		if(H.check_body_part_coverage(MOUTH))
-			to_chat(user, "<span class='notice'><B>Remove \the [H.get_body_part_coverage(MOUTH)]!</B></span>")
-			return 0
+	else if(user.covered_mouth_consumables_check(M))
+		return 0
 		user.visible_message("<span class='danger'>[user] attempts to feed [M] \the [src].</span>", "<span class='danger'>You attempt to feed [M] \the [src].</span>")
 
 		if(!do_mob(user, M, 30))
@@ -342,11 +339,8 @@ var/list/LOGGED_SPLASH_REAGENTS = list(FUEL, THERMITE)
 	return 0
 
 /obj/item/weapon/reagent_containers/proc/imbibe(mob/user) //Drink the liquid within
-	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		if(H.check_body_part_coverage(MOUTH))
-			to_chat(user, "<span class='notice'><B>Remove \the [H.get_body_part_coverage(MOUTH)]!</B></span>")
-			return 0
+	if(user.covered_mouth_consumables_check(user))
+		return 0
 
 	to_chat(user, "<span  class='notice'>You swallow a gulp of \the [src].</span>")
 	playsound(user.loc,'sound/items/drink.ogg', rand(10,50), 1)

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -108,7 +108,7 @@ var/list/LOGGED_SPLASH_REAGENTS = list(FUEL, THERMITE)
 	else if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(H.check_body_part_coverage(MOUTH))
-			to_chat(user, "<span class='notice'><B>Remove their [H.get_body_part_coverage(MOUTH)]!</B></span>")
+			to_chat(user, "<span class='notice'><B>Remove [H.get_body_part_coverage(MOUTH)]!</B></span>")
 			return 0
 		user.visible_message("<span class='danger'>[user] attempts to feed [M] \the [src].</span>", "<span class='danger'>You attempt to feed [M] \the [src].</span>")
 
@@ -345,7 +345,7 @@ var/list/LOGGED_SPLASH_REAGENTS = list(FUEL, THERMITE)
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		if(H.check_body_part_coverage(MOUTH))
-			to_chat(user, "<span class='notice'><B>Remove your [H.get_body_part_coverage(MOUTH)]!</B></span>")
+			to_chat(user, "<span class='notice'><B>Remove [H.get_body_part_coverage(MOUTH)]!</B></span>")
 			return 0
 
 	to_chat(user, "<span  class='notice'>You swallow a gulp of \the [src].</span>")

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -106,6 +106,10 @@ var/list/LOGGED_SPLASH_REAGENTS = list(FUEL, THERMITE)
 		return 1
 
 	else if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(H.check_body_part_coverage(MOUTH))
+			to_chat(user, "<span class='notice'><B>Remove their [H.get_body_part_coverage(MOUTH)]!</B></span>")
+			return 0
 		user.visible_message("<span class='danger'>[user] attempts to feed [M] \the [src].</span>", "<span class='danger'>You attempt to feed [M] \the [src].</span>")
 
 		if(!do_mob(user, M, 30))
@@ -338,6 +342,12 @@ var/list/LOGGED_SPLASH_REAGENTS = list(FUEL, THERMITE)
 	return 0
 
 /obj/item/weapon/reagent_containers/proc/imbibe(mob/user) //Drink the liquid within
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		if(H.check_body_part_coverage(MOUTH))
+			to_chat(user, "<span class='notice'><B>Remove your [H.get_body_part_coverage(MOUTH)]!</B></span>")
+			return 0
+
 	to_chat(user, "<span  class='notice'>You swallow a gulp of \the [src].</span>")
 	playsound(user.loc,'sound/items/drink.ogg', rand(10,50), 1)
 

--- a/code/modules/reagents/reagent_containers/food/condiment.dm
+++ b/code/modules/reagents/reagent_containers/food/condiment.dm
@@ -39,7 +39,7 @@
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
 			if(H.check_body_part_coverage(MOUTH))
-				to_chat(user, "<span class='notice'><B>Remove your [H.get_body_part_coverage(MOUTH)]!</B></span>")
+				to_chat(user, "<span class='notice'><B>Remove [H.get_body_part_coverage(MOUTH)]!</B></span>")
 				return 0
 
 		to_chat(M, "<span class='notice'>You swallow some of the contents of \the [src].</span>")
@@ -56,7 +56,7 @@
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
 			if(H.check_body_part_coverage(MOUTH))
-				to_chat(user, "<span class='notice'><B>Remove their [H.get_body_part_coverage(MOUTH)]!</B></span>")
+				to_chat(user, "<span class='notice'><B>Remove [H.get_body_part_coverage(MOUTH)]!</B></span>")
 				return 0
 
 		M.visible_message("<span class='danger'>[user] attempts to feed [M] \the [src]</span>", \

--- a/code/modules/reagents/reagent_containers/food/condiment.dm
+++ b/code/modules/reagents/reagent_containers/food/condiment.dm
@@ -35,6 +35,12 @@
 		return 0
 
 	if(M == user) //user drinking it
+	
+		if(ishuman(M))
+			var/mob/living/carbon/human/H = M
+			if(H.check_body_part_coverage(MOUTH))
+				to_chat(user, "<span class='notice'><B>Remove your [H.get_body_part_coverage(MOUTH)]!</B></span>")
+				return 0
 
 		to_chat(M, "<span class='notice'>You swallow some of the contents of \the [src].</span>")
 		if(reagents.total_volume) //Deal with the reagents in the food
@@ -46,6 +52,12 @@
 		return 1
 
 	else if(istype(M, /mob/living/carbon)) //user feeding M the condiment. M also being carbon
+	
+		if(ishuman(M))
+			var/mob/living/carbon/human/H = M
+			if(H.check_body_part_coverage(MOUTH))
+				to_chat(user, "<span class='notice'><B>Remove their [H.get_body_part_coverage(MOUTH)]!</B></span>")
+				return 0
 
 		M.visible_message("<span class='danger'>[user] attempts to feed [M] \the [src]</span>", \
 		"<span class='danger'>[user] attempts to feed you \the [src]</span>")

--- a/code/modules/reagents/reagent_containers/food/condiment.dm
+++ b/code/modules/reagents/reagent_containers/food/condiment.dm
@@ -36,11 +36,8 @@
 
 	if(M == user) //user drinking it
 	
-		if(ishuman(M))
-			var/mob/living/carbon/human/H = M
-			if(H.check_body_part_coverage(MOUTH))
-				to_chat(user, "<span class='notice'><B>Remove \the [H.get_body_part_coverage(MOUTH)]!</B></span>")
-				return 0
+		if(user.covered_mouth_consumables_check(M))
+			return 0
 
 		to_chat(M, "<span class='notice'>You swallow some of the contents of \the [src].</span>")
 		if(reagents.total_volume) //Deal with the reagents in the food
@@ -53,11 +50,8 @@
 
 	else if(istype(M, /mob/living/carbon)) //user feeding M the condiment. M also being carbon
 	
-		if(ishuman(M))
-			var/mob/living/carbon/human/H = M
-			if(H.check_body_part_coverage(MOUTH))
-				to_chat(user, "<span class='notice'><B>Remove \the [H.get_body_part_coverage(MOUTH)]!</B></span>")
-				return 0
+		if(user.covered_mouth_consumables_check(M))
+			return 0
 
 		M.visible_message("<span class='danger'>[user] attempts to feed [M] \the [src]</span>", \
 		"<span class='danger'>[user] attempts to feed you \the [src]</span>")

--- a/code/modules/reagents/reagent_containers/food/condiment.dm
+++ b/code/modules/reagents/reagent_containers/food/condiment.dm
@@ -39,7 +39,7 @@
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
 			if(H.check_body_part_coverage(MOUTH))
-				to_chat(user, "<span class='notice'><B>Remove [H.get_body_part_coverage(MOUTH)]!</B></span>")
+				to_chat(user, "<span class='notice'><B>Remove \the [H.get_body_part_coverage(MOUTH)]!</B></span>")
 				return 0
 
 		to_chat(M, "<span class='notice'>You swallow some of the contents of \the [src].</span>")
@@ -56,7 +56,7 @@
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
 			if(H.check_body_part_coverage(MOUTH))
-				to_chat(user, "<span class='notice'><B>Remove [H.get_body_part_coverage(MOUTH)]!</B></span>")
+				to_chat(user, "<span class='notice'><B>Remove \the [H.get_body_part_coverage(MOUTH)]!</B></span>")
 				return 0
 
 		M.visible_message("<span class='danger'>[user] attempts to feed [M] \the [src]</span>", \

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -39,11 +39,8 @@
 		viewcontents = 1
 
 /obj/item/weapon/reagent_containers/food/drinks/attack_self(mob/user as mob)
-	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		if(H.check_body_part_coverage(MOUTH))
-			to_chat(user, "<span class='notice'><B>Remove \the [H.get_body_part_coverage(MOUTH)]!</B></span>")
-			return 0
+	if(user.covered_mouth_consumables_check(user))
+		return 0
 
 	if(!is_open_container())
 		to_chat(user, "<span class='warning'>You can't, \the [src] is closed.</span>")//Added this here and elsewhere to prevent drinking, etc. from closed drink containers. - Hinaichigo
@@ -162,11 +159,8 @@
 		return 0
 
 	else if(istype(M, /mob/living/carbon/human))
-		if(ishuman(M))
-			var/mob/living/carbon/human/H = M
-			if(H.check_body_part_coverage(MOUTH))
-				to_chat(user, "<span class='notice'><B>Remove \the [H.get_body_part_coverage(MOUTH)]!</B></span>")
-				return 0
+		if(user.covered_mouth_consumables_check(M))
+			return 0
 
 		user.visible_message("<span class='danger'>[user] attempts to feed [M] \the [src].</span>", "<span class='danger'>You attempt to feed [M] \the [src].</span>")
 

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -42,7 +42,7 @@
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		if(H.check_body_part_coverage(MOUTH))
-			to_chat(user, "<span class='notice'><B>Remove your [H.get_body_part_coverage(MOUTH)]!</B></span>")
+			to_chat(user, "<span class='notice'><B>Remove [H.get_body_part_coverage(MOUTH)]!</B></span>")
 			return 0
 
 	if(!is_open_container())
@@ -165,7 +165,7 @@
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
 			if(H.check_body_part_coverage(MOUTH))
-				to_chat(user, "<span class='notice'><B>Remove their [H.get_body_part_coverage(MOUTH)]!</B></span>")
+				to_chat(user, "<span class='notice'><B>Remove [H.get_body_part_coverage(MOUTH)]!</B></span>")
 				return 0
 
 		user.visible_message("<span class='danger'>[user] attempts to feed [M] \the [src].</span>", "<span class='danger'>You attempt to feed [M] \the [src].</span>")

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -42,7 +42,7 @@
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		if(H.check_body_part_coverage(MOUTH))
-			to_chat(user, "<span class='notice'><B>Remove [H.get_body_part_coverage(MOUTH)]!</B></span>")
+			to_chat(user, "<span class='notice'><B>Remove \the [H.get_body_part_coverage(MOUTH)]!</B></span>")
 			return 0
 
 	if(!is_open_container())
@@ -165,7 +165,7 @@
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
 			if(H.check_body_part_coverage(MOUTH))
-				to_chat(user, "<span class='notice'><B>Remove [H.get_body_part_coverage(MOUTH)]!</B></span>")
+				to_chat(user, "<span class='notice'><B>Remove \the [H.get_body_part_coverage(MOUTH)]!</B></span>")
 				return 0
 
 		user.visible_message("<span class='danger'>[user] attempts to feed [M] \the [src].</span>", "<span class='danger'>You attempt to feed [M] \the [src].</span>")

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -39,6 +39,12 @@
 		viewcontents = 1
 
 /obj/item/weapon/reagent_containers/food/drinks/attack_self(mob/user as mob)
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		if(H.check_body_part_coverage(MOUTH))
+			to_chat(user, "<span class='notice'><B>Remove your [H.get_body_part_coverage(MOUTH)]!</B></span>")
+			return 0
+
 	if(!is_open_container())
 		to_chat(user, "<span class='warning'>You can't, \the [src] is closed.</span>")//Added this here and elsewhere to prevent drinking, etc. from closed drink containers. - Hinaichigo
 
@@ -156,6 +162,11 @@
 		return 0
 
 	else if(istype(M, /mob/living/carbon/human))
+		if(ishuman(M))
+			var/mob/living/carbon/human/H = M
+			if(H.check_body_part_coverage(MOUTH))
+				to_chat(user, "<span class='notice'><B>Remove their [H.get_body_part_coverage(MOUTH)]!</B></span>")
+				return 0
 
 		user.visible_message("<span class='danger'>[user] attempts to feed [M] \the [src].</span>", "<span class='danger'>You attempt to feed [M] \the [src].</span>")
 

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -110,6 +110,12 @@
 		if(target == user)	//If you're eating it yourself
 			if(!can_consume(M, user))
 				return 0
+				
+			if(ishuman(target))
+				var/mob/living/carbon/human/H = target
+				if(H.check_body_part_coverage(MOUTH))
+					to_chat(user, "<span class='notice'><B>Remove your [H.get_body_part_coverage(MOUTH)]!</B></span>")
+					return 0
 
 			var/fullness = target.nutrition + (target.reagents.get_reagent_amount(NUTRIMENT) * 25) //This reminds me how unlogical mob nutrition is
 
@@ -127,6 +133,12 @@
 				"<span class='notice'>You unwillingly [eatverb] some of \the [src].</span>")
 
 		else //Feeding someone else, target is eating, user is feeding
+		
+			if(ishuman(target))
+				var/mob/living/carbon/human/H = target
+				if(H.check_body_part_coverage(MOUTH))
+					to_chat(user, "<span class='notice'><B>Remove their [H.get_body_part_coverage(MOUTH)]!</B></span>")
+					return 0
 
 			var/fullness = target.nutrition + (target.reagents.get_reagent_amount(NUTRIMENT) * 25)
 
@@ -155,6 +167,13 @@
 /obj/item/weapon/reagent_containers/food/snacks/proc/consume(mob/living/carbon/eater, messages = 0)
 	if(!istype(eater))
 		return
+		
+	if(ishuman(eater))
+		var/mob/living/carbon/human/H = eater
+		if(H.check_body_part_coverage(MOUTH))
+			to_chat(eater, "<span class='notice'><B>Remove your [H.get_body_part_coverage(MOUTH)]!</B></span>")
+			return 0
+		
 	if(!eatverb)
 		eatverb = pick("bite", "chew", "nibble", "gnaw", "gobble", "chomp")
 

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -114,7 +114,7 @@
 			if(ishuman(target))
 				var/mob/living/carbon/human/H = target
 				if(H.check_body_part_coverage(MOUTH))
-					to_chat(user, "<span class='notice'><B>Remove [H.get_body_part_coverage(MOUTH)]!</B></span>")
+					to_chat(user, "<span class='notice'><B>Remove \the [H.get_body_part_coverage(MOUTH)]!</B></span>")
 					return 0
 
 			var/fullness = target.nutrition + (target.reagents.get_reagent_amount(NUTRIMENT) * 25) //This reminds me how unlogical mob nutrition is
@@ -137,7 +137,7 @@
 			if(ishuman(target))
 				var/mob/living/carbon/human/H = target
 				if(H.check_body_part_coverage(MOUTH))
-					to_chat(user, "<span class='notice'><B>Remove [H.get_body_part_coverage(MOUTH)]!</B></span>")
+					to_chat(user, "<span class='notice'><B>Remove \the [H.get_body_part_coverage(MOUTH)]!</B></span>")
 					return 0
 
 			var/fullness = target.nutrition + (target.reagents.get_reagent_amount(NUTRIMENT) * 25)
@@ -171,7 +171,7 @@
 	if(ishuman(eater))
 		var/mob/living/carbon/human/H = eater
 		if(H.check_body_part_coverage(MOUTH))
-			to_chat(eater, "<span class='notice'><B>Remove [H.get_body_part_coverage(MOUTH)]!</B></span>")
+			to_chat(eater, "<span class='notice'><B>Remove \the [H.get_body_part_coverage(MOUTH)]!</B></span>")
 			return 0
 		
 	if(!eatverb)

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -114,7 +114,7 @@
 			if(ishuman(target))
 				var/mob/living/carbon/human/H = target
 				if(H.check_body_part_coverage(MOUTH))
-					to_chat(user, "<span class='notice'><B>Remove your [H.get_body_part_coverage(MOUTH)]!</B></span>")
+					to_chat(user, "<span class='notice'><B>Remove [H.get_body_part_coverage(MOUTH)]!</B></span>")
 					return 0
 
 			var/fullness = target.nutrition + (target.reagents.get_reagent_amount(NUTRIMENT) * 25) //This reminds me how unlogical mob nutrition is
@@ -137,7 +137,7 @@
 			if(ishuman(target))
 				var/mob/living/carbon/human/H = target
 				if(H.check_body_part_coverage(MOUTH))
-					to_chat(user, "<span class='notice'><B>Remove their [H.get_body_part_coverage(MOUTH)]!</B></span>")
+					to_chat(user, "<span class='notice'><B>Remove [H.get_body_part_coverage(MOUTH)]!</B></span>")
 					return 0
 
 			var/fullness = target.nutrition + (target.reagents.get_reagent_amount(NUTRIMENT) * 25)
@@ -171,7 +171,7 @@
 	if(ishuman(eater))
 		var/mob/living/carbon/human/H = eater
 		if(H.check_body_part_coverage(MOUTH))
-			to_chat(eater, "<span class='notice'><B>Remove your [H.get_body_part_coverage(MOUTH)]!</B></span>")
+			to_chat(eater, "<span class='notice'><B>Remove [H.get_body_part_coverage(MOUTH)]!</B></span>")
 			return 0
 		
 	if(!eatverb)

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -111,11 +111,8 @@
 			if(!can_consume(M, user))
 				return 0
 				
-			if(ishuman(target))
-				var/mob/living/carbon/human/H = target
-				if(H.check_body_part_coverage(MOUTH))
-					to_chat(user, "<span class='notice'><B>Remove \the [H.get_body_part_coverage(MOUTH)]!</B></span>")
-					return 0
+			if(user.covered_mouth_consumables_check(target))
+				return 0
 
 			var/fullness = target.nutrition + (target.reagents.get_reagent_amount(NUTRIMENT) * 25) //This reminds me how unlogical mob nutrition is
 
@@ -134,11 +131,8 @@
 
 		else //Feeding someone else, target is eating, user is feeding
 		
-			if(ishuman(target))
-				var/mob/living/carbon/human/H = target
-				if(H.check_body_part_coverage(MOUTH))
-					to_chat(user, "<span class='notice'><B>Remove \the [H.get_body_part_coverage(MOUTH)]!</B></span>")
-					return 0
+			if(user.covered_mouth_consumables_check(target))
+				return 0
 
 			var/fullness = target.nutrition + (target.reagents.get_reagent_amount(NUTRIMENT) * 25)
 
@@ -168,11 +162,8 @@
 	if(!istype(eater))
 		return
 		
-	if(ishuman(eater))
-		var/mob/living/carbon/human/H = eater
-		if(H.check_body_part_coverage(MOUTH))
-			to_chat(eater, "<span class='notice'><B>Remove \the [H.get_body_part_coverage(MOUTH)]!</B></span>")
-			return 0
+	if(eater.covered_mouth_consumables_check(eater))
+		return 0
 		
 	if(!eatverb)
 		eatverb = pick("bite", "chew", "nibble", "gnaw", "gobble", "chomp")

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -23,7 +23,7 @@
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		if(H.check_body_part_coverage(MOUTH))
-			to_chat(user, "<span class='notice'><B>Remove your [H.get_body_part_coverage(MOUTH)]!</B></span>")
+			to_chat(user, "<span class='notice'><B>Remove [H.get_body_part_coverage(MOUTH)]!</B></span>")
 			return 0
 
 	return attack(user, user) //Dealt with in attack code
@@ -33,7 +33,7 @@
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(H.check_body_part_coverage(MOUTH))
-			to_chat(user, "<span class='notice'><B>Remove their [H.get_body_part_coverage(MOUTH)]!</B></span>")
+			to_chat(user, "<span class='notice'><B>Remove [H.get_body_part_coverage(MOUTH)]!</B></span>")
 			return 0
 	if (user != M && (ishuman(M) || ismonkey(M)))
 		user.visible_message("<span class='warning'>[user] attempts to force [M] to swallow \the [src].</span>", "<span class='notice'>You attempt to force [M] to swallow \the [src].</span>")

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -20,21 +20,15 @@
 
 /obj/item/weapon/reagent_containers/pill/attack_self(mob/user as mob)
 
-	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		if(H.check_body_part_coverage(MOUTH))
-			to_chat(user, "<span class='notice'><B>Remove \the [H.get_body_part_coverage(MOUTH)]!</B></span>")
-			return 0
+	if(user.covered_mouth_consumables_check(user))
+		return 0
 
 	return attack(user, user) //Dealt with in attack code
 
 /obj/item/weapon/reagent_containers/pill/attack(mob/M as mob, mob/user as mob, def_zone)
 	// Feeding others needs time to succeed
-	if(ishuman(M))
-		var/mob/living/carbon/human/H = M
-		if(H.check_body_part_coverage(MOUTH))
-			to_chat(user, "<span class='notice'><B>Remove \the [H.get_body_part_coverage(MOUTH)]!</B></span>")
-			return 0
+	if(user.covered_mouth_consumables_check(M))
+		return 0
 	if (user != M && (ishuman(M) || ismonkey(M)))
 		user.visible_message("<span class='warning'>[user] attempts to force [M] to swallow \the [src].</span>", "<span class='notice'>You attempt to force [M] to swallow \the [src].</span>")
 

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -23,7 +23,7 @@
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		if(H.check_body_part_coverage(MOUTH))
-			to_chat(user, "<span class='notice'><B>Remove [H.get_body_part_coverage(MOUTH)]!</B></span>")
+			to_chat(user, "<span class='notice'><B>Remove \the [H.get_body_part_coverage(MOUTH)]!</B></span>")
 			return 0
 
 	return attack(user, user) //Dealt with in attack code
@@ -33,7 +33,7 @@
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(H.check_body_part_coverage(MOUTH))
-			to_chat(user, "<span class='notice'><B>Remove [H.get_body_part_coverage(MOUTH)]!</B></span>")
+			to_chat(user, "<span class='notice'><B>Remove \the [H.get_body_part_coverage(MOUTH)]!</B></span>")
 			return 0
 	if (user != M && (ishuman(M) || ismonkey(M)))
 		user.visible_message("<span class='warning'>[user] attempts to force [M] to swallow \the [src].</span>", "<span class='notice'>You attempt to force [M] to swallow \the [src].</span>")

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -20,10 +20,21 @@
 
 /obj/item/weapon/reagent_containers/pill/attack_self(mob/user as mob)
 
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		if(H.check_body_part_coverage(MOUTH))
+			to_chat(user, "<span class='notice'><B>Remove your [H.get_body_part_coverage(MOUTH)]!</B></span>")
+			return 0
+
 	return attack(user, user) //Dealt with in attack code
 
 /obj/item/weapon/reagent_containers/pill/attack(mob/M as mob, mob/user as mob, def_zone)
 	// Feeding others needs time to succeed
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(H.check_body_part_coverage(MOUTH))
+			to_chat(user, "<span class='notice'><B>Remove their [H.get_body_part_coverage(MOUTH)]!</B></span>")
+			return 0
 	if (user != M && (ishuman(M) || ismonkey(M)))
 		user.visible_message("<span class='warning'>[user] attempts to force [M] to swallow \the [src].</span>", "<span class='notice'>You attempt to force [M] to swallow \the [src].</span>")
 


### PR DESCRIPTION
With this change, all oral consumables will require an unobstructed mouth for yourself or anyone you wish to assist.

:cl:
 * rscadd: Consumables require an unobstructed mouth.
