### PR TITLE
Fixes runtimes associated with the cockatrice zoo bus vault

### DIFF
--- a/code/modules/mob/living/carbon/monkey/death.dm
+++ b/code/modules/mob/living/carbon/monkey/death.dm
@@ -38,7 +38,7 @@
 
 	update_canmove()
 	update_icons()
-
-	ticker.mode.check_win()
+	if(ticker.mode)
+		ticker.mode.check_win()
 
 	return ..(gibbed)

--- a/code/modules/mob/living/simple_animal/hostile/human/diona.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/diona.dm
@@ -87,8 +87,9 @@
 	toxin_dmg = 1300
 
 /obj/effect/landmark/corpse/diona/junkie/New()
-	..()
 
 	var/turf/T = get_turf(src)
 	T.visible_message("<span class='danger'>Some green fluid flows out of the chemical pack!</span>") //because the pack spawns empty
 	getFromPool(/obj/effect/decal/cleanable/greenglow, T)
+	..()
+


### PR DESCRIPTION
Fixes runtimes associated with the cockatrice zoo bus vault

 - Monkeys checking if the game has ended before it has even begun

 - Junkies dropping a pool of goo right into the void