### PR TITLE
fixes taxi pods not being constructable

### DIFF
--- a/code/WorkInProgress/pomf/spacepods/construction.dm
+++ b/code/WorkInProgress/pomf/spacepods/construction.dm
@@ -219,7 +219,7 @@
 					Co_DESC = "A space pod with unsecured armor.",
 					Co_BACKSTEP = list(
 						Co_KEY      = /obj/item/weapon/crowbar,
-						Co_VIS_MSG  = "{USER} prie{s} off {HOLDER}'s armor."
+						Co_VIS_MSG  = "{USER} remove{s} {HOLDER}'s armor."
 					),
 					Co_NEXTSTEP = list(
 						Co_KEY      = /obj/item/weapon/wrench,
@@ -265,7 +265,7 @@
 					Co_DESC = "A space pod with unsecured armor.",
 					Co_BACKSTEP = list(
 						Co_KEY      = /obj/item/weapon/crowbar,
-						Co_VIS_MSG  = "{USER} prie{s} off {HOLDER}'s armor."
+						Co_VIS_MSG  = "{USER} remove{s} {HOLDER}'s armor."
 					),
 					Co_NEXTSTEP = list(
 						Co_KEY      = /obj/item/weapon/wrench,

--- a/code/WorkInProgress/pomf/spacepods/construction.dm
+++ b/code/WorkInProgress/pomf/spacepods/construction.dm
@@ -19,6 +19,11 @@
 
 	dir = EAST
 
+/obj/structure/spacepod_frame/Destroy()
+	qdel(construct)
+	construct = null
+	..()
+
 /obj/structure/spacepod_frame/attackby(obj/item/W as obj, mob/user as mob)
 	if(!construct || !construct.action(W, user))
 		return ..()
@@ -40,9 +45,9 @@
 /obj/structure/spacepod_frame/attackby(obj/item/W, mob/user)
 	if(!construct)
 		if(istype(W,/obj/item/pod_parts/armor/civ))
-			construct = new /datum/construction/reversible/pod/civ(src)
+			construct = new /datum/construction/reversible/pod/unarmored/civ(src)
 		else if(istype(W, /obj/item/pod_parts/armor/taxi))
-			construct = new /datum/construction/reversible/pod/taxi(src)
+			construct = new /datum/construction/reversible/pod/unarmored/taxi(src)
 	..()
 
 /////////////////////////////////
@@ -184,7 +189,15 @@
 /////////////////////////////////
 // PODS
 /////////////////////////////////
-/datum/construction/reversible/pod/civ
+/datum/construction/reversible/pod/unarmored/custom_action(index, diff, atom/used_atom, mob/user)
+	if(!..())
+		return 0
+
+	holder.icon_state = "pod_[9 + (steps.len - index + 1 - diff)]"
+	return 1
+
+
+/datum/construction/reversible/pod/unarmored/civ
 	result = /obj/spacepod/civilian
 	//taskpath = /datum/job_objective/make_pod
 	steps = list(
@@ -230,7 +243,7 @@
 			)
 		)
 
-/datum/construction/reversible/pod/taxi
+/datum/construction/reversible/pod/unarmored/taxi
 	result = /obj/spacepod/taxi
 	//taskpath = /datum/job_objective/make_pod
 	steps = list(

--- a/code/WorkInProgress/pomf/spacepods/construction.dm
+++ b/code/WorkInProgress/pomf/spacepods/construction.dm
@@ -15,7 +15,7 @@
 	bound_width = 64
 	bound_height = 64
 
-	construct = new /datum/construction/reversible/pod(src)
+	construct = new /datum/construction/reversible/pod/chassis(src)
 
 	dir = EAST
 
@@ -27,53 +27,31 @@
 /obj/structure/spacepod_frame/attack_hand()
 	return
 
+/obj/structure/spacepod_frame/unarmored
+	name = "unarmored spacepod"
+	desc = "A space pod with unwelded bulkhead panelling exposed."
+	icon_state = "pod_9"
+
+/obj/structure/spacepod_frame/unarmored/New()
+	..()
+	qdel(construct)
+	construct = null
+
+/obj/structure/spacepod_frame/attackby(obj/item/W, mob/user)
+	if(!construct)
+		if(istype(W,/obj/item/pod_parts/armor/civ))
+			construct = new /datum/construction/reversible/pod/civ(src)
+		else if(istype(W, /obj/item/pod_parts/armor/taxi))
+			construct = new /datum/construction/reversible/pod/taxi(src)
+	..()
+
 /////////////////////////////////
 // CONSTRUCTION STEPS
 /////////////////////////////////
-/datum/construction/reversible/pod
-	result = /obj/spacepod/civilian
+/datum/construction/reversible/pod/chassis
+	result = /obj/structure/spacepod_frame/unarmored
 	//taskpath = /datum/job_objective/make_pod
 	steps = list(
-				// 12. Bolted-down armor
-				list(
-					Co_DESC = "A space pod with unsecured armor.",
-					Co_BACKSTEP = list(
-						Co_KEY      = /obj/item/weapon/wrench,
-						Co_VIS_MSG  = "{USER} unsecure{s} {HOLDER}'s armor."
-					),
-					Co_NEXTSTEP = list(
-						Co_KEY      = /obj/item/weapon/weldingtool,
-						Co_VIS_MSG  = "{USER} weld{s} {HOLDER}'s armor.",
-						Co_AMOUNT = 3
-					)
-				),
-				// 11. Loose armor
-				list(
-					Co_DESC = "A space pod with unsecured armor.",
-					Co_BACKSTEP = list(
-						Co_KEY      = /obj/item/weapon/crowbar,
-						Co_VIS_MSG  = "{USER} prie{s} off {HOLDER}'s armor."
-					),
-					Co_NEXTSTEP = list(
-						Co_KEY      = /obj/item/weapon/wrench,
-						Co_VIS_MSG  = "{USER} bolt{s} down {HOLDER}'s armor."
-					)
-				),
-				// 10. Welded bulkhead
-				list(
-					Co_DESC = "A space pod with sealed bulkhead panelling exposed.",
-					Co_BACKSTEP = list(
-						Co_KEY      = /obj/item/weapon/weldingtool,
-						Co_VIS_MSG  = "{USER} cut{s} {HOLDER}'s bulkhead panelling loose.",
-						Co_AMOUNT   = 3
-					),
-					Co_NEXTSTEP = list(
-						Co_KEY      = /obj/item/pod_parts/armor,
-						Co_VIS_MSG  = "{USER} install{s} {HOLDER}'s armor plating.",
-						Co_AMOUNT   = 1,
-						Co_KEEP
-					)
-				),
 				// 9. Bulkhead secured with bolts
 				list(
 					Co_DESC = "A space pod with unwelded bulkhead panelling exposed.",
@@ -192,7 +170,7 @@
 	feedback_inc("spacepod_created",1)
 	return
 
-/datum/construction/reversible/pod/custom_action(index, diff, atom/used_atom, mob/user)
+/datum/construction/reversible/pod/chassis/custom_action(index, diff, atom/used_atom, mob/user)
 	if(!..())
 		return 0
 
@@ -204,13 +182,13 @@
 	return check_step(used_atom,user)
 
 /////////////////////////////////
-// TAXI
+// PODS
 /////////////////////////////////
-/datum/construction/reversible/pod/taxi
-	result = /obj/spacepod/taxi
+/datum/construction/reversible/pod/civ
+	result = /obj/spacepod/civilian
 	//taskpath = /datum/job_objective/make_pod
 	steps = list(
-				// 12. Bolted-down armor
+				// 3. Bolted-down armor
 				list(
 					Co_DESC = "A space pod with unsecured armor.",
 					Co_BACKSTEP = list(
@@ -223,7 +201,7 @@
 						Co_AMOUNT = 3
 					)
 				),
-				// 11. Loose armor
+				// 2. Loose armor
 				list(
 					Co_DESC = "A space pod with unsecured armor.",
 					Co_BACKSTEP = list(
@@ -235,7 +213,53 @@
 						Co_VIS_MSG  = "{USER} bolt{s} down {HOLDER}'s armor."
 					)
 				),
-				// 10. Welded bulkhead
+				// 1. Welded bulkhead
+				list(
+					Co_DESC = "A space pod with sealed bulkhead panelling exposed.",
+					Co_BACKSTEP = list(
+						Co_KEY      = /obj/item/weapon/weldingtool,
+						Co_VIS_MSG  = "{USER} cut{s} {HOLDER}'s bulkhead panelling loose.",
+						Co_AMOUNT   = 3
+					),
+					Co_NEXTSTEP = list(
+						Co_KEY      = /obj/item/pod_parts/armor/civ,
+						Co_VIS_MSG  = "{USER} install{s} {HOLDER}'s armor plating.",
+						Co_AMOUNT   = 1,
+						Co_KEEP
+					)
+			)
+		)
+
+/datum/construction/reversible/pod/taxi
+	result = /obj/spacepod/taxi
+	//taskpath = /datum/job_objective/make_pod
+	steps = list(
+				// 3. Bolted-down armor
+				list(
+					Co_DESC = "A space pod with unsecured armor.",
+					Co_BACKSTEP = list(
+						Co_KEY      = /obj/item/weapon/wrench,
+						Co_VIS_MSG  = "{USER} unsecure{s} {HOLDER}'s armor."
+					),
+					Co_NEXTSTEP = list(
+						Co_KEY      = /obj/item/weapon/weldingtool,
+						Co_VIS_MSG  = "{USER} weld{s} {HOLDER}'s armor.",
+						Co_AMOUNT = 3
+					)
+				),
+				// 2. Loose armor
+				list(
+					Co_DESC = "A space pod with unsecured armor.",
+					Co_BACKSTEP = list(
+						Co_KEY      = /obj/item/weapon/crowbar,
+						Co_VIS_MSG  = "{USER} prie{s} off {HOLDER}'s armor."
+					),
+					Co_NEXTSTEP = list(
+						Co_KEY      = /obj/item/weapon/wrench,
+						Co_VIS_MSG  = "{USER} bolt{s} down {HOLDER}'s armor."
+					)
+				),
+				// 1. Welded bulkhead
 				list(
 					Co_DESC = "A space pod with sealed bulkhead panelling exposed.",
 					Co_BACKSTEP = list(
@@ -249,116 +273,5 @@
 						Co_AMOUNT   = 1,
 						Co_KEEP
 					)
-				),
-				// 9. Bulkhead secured with bolts
-				list(
-					Co_DESC = "A space pod with unwelded bulkhead panelling exposed.",
-					Co_BACKSTEP = list(
-						Co_KEY      = /obj/item/weapon/wrench,
-						Co_VIS_MSG  = "{USER} unbolt{s} {HOLDER}'s bulkhead panelling.",
-					),
-					Co_NEXTSTEP = list(
-						Co_KEY      = /obj/item/weapon/weldingtool,
-						Co_VIS_MSG  = "{USER} seal{s} {HOLDER}'s bulkhead panelling with a weld.",
-						Co_AMOUNT   = 3
-					)
-				),
-				// 8. Bulkhead added
-				list(
-					Co_DESC = "A space pod with loose bulkhead panelling exposed.",
-					Co_BACKSTEP = list(
-						Co_KEY      = /obj/item/weapon/crowbar,
-						Co_VIS_MSG  = "{USER} pop{s} {HOLDER}'s bulkhead panelling loose.",
-					),
-					Co_NEXTSTEP = list(
-						Co_KEY      = /obj/item/weapon/wrench,
-						Co_VIS_MSG  = "{USER} secure{s} {HOLDER}'s bulkhead panelling."
-					)
-				),
-				// 7. Core secured
-				list(
-					Co_DESC = "A naked space pod with an exposed core. How lewd.",
-					Co_BACKSTEP = list(
-						Co_KEY      = /obj/item/weapon/wrench,
-						Co_VIS_MSG  = "{USER} unsecure{s} {HOLDER}'s core."
-					),
-					Co_NEXTSTEP = list(
-						Co_KEY      = /obj/item/stack/sheet/metal,
-						Co_AMOUNT   = 5,
-						Co_VIS_MSG  = "{USER} fabricate{s} a pressure bulkhead for {HOLDER}.",
-					)
-				),
-				// 6. Core inserted
-				list(
-					Co_DESC = "A naked space pod with a loose core.",
-					Co_BACKSTEP = list(
-						Co_KEY      = /obj/item/weapon/crowbar,
-						Co_VIS_MSG  = "{USER} delicately remove{s} the core from {HOLDER} with a crowbar."
-					),
-					Co_NEXTSTEP = list(
-						Co_KEY      = /obj/item/weapon/wrench,
-						Co_VIS_MSG  = "{USER} secure{s} the core's bolts."
-					)
-				),
-				// 5. Circuit secured
-				list(
-					Co_DESC = "A wired pod frame with a secured mainboard.",
-					Co_BACKSTEP = list(
-						Co_KEY      = /obj/item/weapon/screwdriver,
-						Co_VIS_MSG  = "{USER} unsecure{s} the mainboard."
-					),
-					Co_NEXTSTEP = list(
-						Co_KEY      = /obj/item/pod_parts/core,
-						Co_VIS_MSG  = "{USER} insert{s} the core into {HOLDER}.",
-						Co_AMOUNT   = 1,
-						Co_KEEP
-					)
-				),
-				// 4. Circuit added
-				list(
-					Co_DESC = "A wired pod frame with a loose mainboard.",
-					Co_BACKSTEP = list(
-						Co_KEY      = /obj/item/weapon/crowbar,
-						Co_VIS_MSG  = "{USER} prie{s} out the mainboard."
-					),
-					Co_NEXTSTEP = list(
-						Co_KEY      = /obj/item/weapon/screwdriver,
-						Co_VIS_MSG  = "{USER} secure{s} the mainboard."
-					)
-				),
-				// 3. Cleanly wired
-				list(
-					Co_DESC = "A wired pod frame.",
-					Co_BACKSTEP = list(
-						Co_KEY      = /obj/item/weapon/screwdriver,
-						Co_VIS_MSG  = "{USER} unclip{s} {HOLDER}'s wiring harnesses."
-					),
-					Co_NEXTSTEP = list(
-						Co_KEY      = /obj/item/weapon/circuitboard/mecha/pod,
-						Co_VIS_MSG  = "{USER} insert{s} the mainboard into {HOLDER}.",
-						Co_AMOUNT   = 1,
-						Co_KEEP
-					)
-				),
-				// 2. Crudely Wired
-				list(
-					Co_DESC = "A crudely-wired pod frame.",
-					Co_BACKSTEP = list(
-						Co_KEY      = /obj/item/weapon/wirecutters,
-						Co_VIS_MSG  = "{USER} cut{s} out {HOLDER}'s wiring."
-					),
-					Co_NEXTSTEP = list(
-						Co_KEY      = /obj/item/weapon/screwdriver,
-						Co_VIS_MSG  = "{USER} adjust{s} the wiring."
-					)
-				),
-				// 1. Initial state
-				list(
-					Co_DESC = "An empty pod frame.",
-					Co_NEXTSTEP = list(
-						Co_KEY      = /obj/item/stack/cable_coil,
-						Co_VIS_MSG  = "{USER} wire{s} {HOLDER}.",
-						Co_AMOUNT   = 10
-					)
-				)
 			)
+		)

--- a/code/WorkInProgress/pomf/spacepods/parts.dm
+++ b/code/WorkInProgress/pomf/spacepods/parts.dm
@@ -123,6 +123,12 @@
 	link_angle = 270
 
 /obj/item/pod_parts/armor
+	name = "pod armor"
+	icon = 'icons/pods/pod_parts.dmi'
+	icon_state = "pod_armor_civ"
+	desc = "Spacepod armor. This one seems unfinished, best to report how you got this and put it back."
+
+/obj/item/pod_parts/armor/civ
 	name = "civilian pod armor"
 	icon = 'icons/pods/pod_parts.dmi'
 	icon_state = "pod_armor_civ"

--- a/code/modules/research/designs/spacepod/construction.dm
+++ b/code/modules/research/designs/spacepod/construction.dm
@@ -26,7 +26,7 @@
 	id = "podarmor_civ"
 	build_type = PODFAB
 	req_tech = list(Tc_MATERIALS = 3, Tc_PLASMATECH = 3)
-	build_path = /obj/item/pod_parts/armor
+	build_path = /obj/item/pod_parts/armor/civ
 	category = "Pod_Armor"
 	materials = list(MAT_IRON=15000,MAT_GLASS=5000,MAT_PLASMA=10000)
 


### PR DESCRIPTION
Construction datums are a fickle fiend

closes #15682

Seems the mapcleaner does not take 'taxi station' into account? Might be an oversight of some form

Current problems
 - All those changed lines on taxistation (Apparently irrelevant as we don't use it anyway)

:cl: 
 * bugfix: You can now actually make taxi pods. Sorry folks