### PR TITLE
fixes supermatter collisions irregularly irradiating

### DIFF
--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -431,7 +431,7 @@
 	power += 200
 
 		//Some poor sod got eaten, go ahead and irradiate people nearby.
-	for(var/mob/living/l in range(10))
+	for(var/mob/living/l in range(10,src))
 		if(l in view())
 			l.show_message("<span class=\"warning\">As \the [src] slowly stops resonating, you find your skin covered in new radiation burns.</span>", 1,\
 				"<span class=\"warning\">The unearthly ringing subsides and you notice you have new radiation burns.</span>", 2)


### PR DESCRIPTION
Seems that it passed the usr argument of whatever had last interacted with the object that was colliding with the supermatter, so you'd actually be irradiating everyone in a 10 tile radius around you, rather than a 10 tile radius around the supermatter

closes #15608 
closes #15707