### PR TITLE
Chameleon projections affected by polyacid/sulfacid smoke.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ players2.sqlite
 cfg
 
 .vscode
+/byond

--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -134,26 +134,23 @@
 	master = C
 	master.active_dummy = src
 
-/obj/effect/dummy/chameleon/attackby()
+/obj/effect/dummy/chameleon/proc/disrupt()
 	for(var/mob/M in src)
 		to_chat(M, "<span class='warning'>Your chameleon-projector deactivates.</span>")
 	master.disrupt()
+
+
+/obj/effect/dummy/chameleon/attackby()
+	disrupt()
 
 /obj/effect/dummy/chameleon/attack_hand()
-	for(var/mob/M in src)
-		to_chat(M, "<span class='warning'>Your chameleon-projector deactivates.</span>")
-	master.disrupt()
+	disrupt()
 
 /obj/effect/dummy/chameleon/ex_act()
-	for(var/mob/M in src)
-		to_chat(M, "<span class='warning'>Your chameleon-projector deactivates.</span>")
-	master.disrupt()
+	disrupt()
 
 /obj/effect/dummy/chameleon/bullet_act()
-	for(var/mob/M in src)
-		to_chat(M, "<span class='warning'>Your chameleon-projector deactivates.</span>")
-	..()
-	master.disrupt()
+	disrupt()
 
 /obj/effect/dummy/chameleon/relaymove(var/mob/user, direction)
 	if(istype(loc, /turf/space))

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1283,6 +1283,9 @@
 		I.desc = "Looks like this was \an [O] some time ago."
 		O.visible_message("<span class='warning'>\The [O] melts.</span>")
 		qdel(O)
+	else if(istype(O,/obj/effect/dummy/chameleon))
+		var/obj/effect/dummy/chameleon/projection = O
+		projection.disrupt()
 
 /datum/reagent/pacid
 	name = "Polytrinic acid"
@@ -1377,6 +1380,9 @@
 		I.desc = "Looks like these were some [O.name] some time ago."
 		var/obj/effect/plantsegment/K = O
 		K.die_off()
+	else if(istype(O,/obj/effect/dummy/chameleon))
+		var/obj/effect/dummy/chameleon/projection = O
+		projection.disrupt()
 
 /datum/reagent/glycerol
 	name = "Glycerol"
@@ -6003,4 +6009,3 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 	spawn(volume * 10)
 		O.light_color = init_color
 		O.set_light(0)
-


### PR DESCRIPTION
# Executive Summary
Fixes an exploit that prevents chameleon projects from being affected by acid smoke.

# Justification
i died pls merge

Last night, someone got a chameleon projector, a syringe set to 1U, and a beaker or so of smoke ingredients and camped out in front of medbay for probably 15 minutes, pumping out thick clouds of polyacid smoke.  While hilarious, it is clear that the smoke should be affecting the chameleon projector.

# Changelog
:cl:
 - tweak: Chameleon Projectors no longer protect you from acid smoke.