### PR TITLE
Fixes diona nymph having no NO_BREATH flag

### DIFF
--- a/code/modules/mob/living/carbon/monkey/diona.dm
+++ b/code/modules/mob/living/carbon/monkey/diona.dm
@@ -1,7 +1,4 @@
-/*
-  Tiny babby plant critter plus procs.
-*/
-
+//  Tiny babby plant critter plus procs.
 //Holders have been moved to code/modules/mob/living/holders.dm
 
 //Mob defines.
@@ -13,13 +10,14 @@
 	species_type = /mob/living/carbon/monkey/diona
 	holder_type = /obj/item/weapon/holder/diona
 	var/list/donors = list()
-	var/ready_evolve = 0
-	canWearHats = 1
-	canWearClothes = 0
-	canWearGlasses = 0
+	var/ready_evolve = FALSE
+	canWearHats = TRUE
+	canWearClothes = FALSE
+	canWearGlasses = FALSE
 	burn_damage_modifier = 2.5 //TREEEEEES
 	languagetoadd = LANGUAGE_ROOTSPEAK
 	meat_type = /obj/item/weapon/reagent_containers/food/snacks/meat/diona
+	flag = NO_BREATHE
 
 /mob/living/carbon/monkey/diona/attack_hand(mob/living/carbon/human/M as mob)
 
@@ -35,7 +33,7 @@
 	setGender(NEUTER)
 	dna.mutantrace = "plant"
 	greaterform = "Diona"
-	alien = 1
+	alien = TRUE
 
 //Verbs after this point.
 
@@ -90,7 +88,7 @@
 
 	if(!is_alien_whitelisted(src, "Diona") && config.usealienwhitelist)
 		to_chat(src, alert("You are currently not whitelisted to play an adult Diona."))
-		return 0
+		return FALSE
 
 	if(stat == DEAD)
 		to_chat(src, "You cannot evolve if you are dead!")
@@ -133,7 +131,7 @@
 	if (istype(other, /mob/living/carbon/human))
 		if(speaking && speaking.name == LANGUAGE_GALACTIC_COMMON)
 			if(donors.len >= 2) // They have sucked down some blood.
-				return 1
+				return TRUE
 	return ..()
 
 /mob/living/carbon/monkey/diona/can_read()
@@ -171,7 +169,7 @@
 
 	switch(progress) //Stop them from skipping levels
 		if(5)
-			ready_evolve = 1
+			ready_evolve = TRUE
 			to_chat(src, "<span class='good'>You feel ready to move on to your next stage of growth.</span>")
 		if(4)
 			to_chat(src, "<span class='good'>You feel your vocal range expand, and realize you know how to speak with the creatures around you.</span>")
@@ -186,12 +184,12 @@
 			to_chat(src, "<span class='good'>The blood seeps into your small form, and you draw out the echoes of memories and personality from it, working them into your budding mind.</span>")
 
 /mob/living/carbon/monkey/diona/dexterity_check()
-	return 0
+	return FALSE
 
 /mob/living/carbon/monkey/diona/update_icons()
 	update_hud()
 	lying_prev = lying	//so we don't update overlays for lying/standing unless our stance changes again
-	overlays.len = 0
+	overlays.Cut()
 	var/matrix/M = matrix()
 	for(var/image/I in overlays_standing)
 		overlays += I


### PR DESCRIPTION
@ihadtoregisterforthis removed the snowflake check breath check for nymphs/rocks but he forgot to give nymphs the NO_BREATH flag.

Fixes #15293
Closes #14096 (I forgot to link this when i fixed it ages ago)

In memory of all nymphs that died after being used as hat by heartless botanists.

:cl:
 * bugfix: Fixes diona nymphs suffocating when held by humans
