### PR TITLE
Volume and gas pumps can be multitool-cloned, fixed emitter cloning

### DIFF
--- a/code/ATMOSPHERICS/components/binary_devices/pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/pump.dm
@@ -223,4 +223,12 @@ Thus, the two variables affect pump operation are set in New():
 	src.update_icon()
 	src.updateUsrDialog()
 
+/obj/machinery/atmospherics/binary/pump/canClone(var/obj/O)
+	return istype(O, /obj/machinery/atmospherics/binary/pump)
+
+/obj/machinery/atmospherics/binary/pump/clone(var/obj/machinery/atmospherics/binary/pump/O)
+	id_tag = O.id_tag
+	set_frequency(O.frequency)
+	return 1
+
 #undef MAX_PRESSURE

--- a/code/ATMOSPHERICS/components/binary_devices/volume_pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/volume_pump.dm
@@ -204,4 +204,12 @@ Thus, the two variables affect pump operation are set in New():
 	src.update_icon()
 	src.updateUsrDialog()
 
+/obj/machinery/atmospherics/binary/volume_pump/canClone(var/obj/O)
+	return istype(O, /obj/machinery/atmospherics/binary/volume_pump)
+
+/obj/machinery/atmospherics/binary/volume_pump/clone(var/obj/machinery/atmospherics/binary/volume_pump/O)
+	id_tag = O.id_tag
+	set_frequency(O.frequency)
+	return 1
+
 #undef MAX_TRANSFER_RATE

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -343,7 +343,8 @@
 
 /obj/machinery/power/emitter/clone(var/obj/machinery/power/emitter/O)
 	id_tag = O.id_tag
-	set_frequency(O.id_tag)
+	set_frequency(O.frequency)
+	return 1
 
 /obj/machinery/power/emitter/npc_tamper_act(mob/living/L)
 	attack_hand(L)


### PR DESCRIPTION
Fixes #15769
Fixes #15770

:cl:
 * rscadd: Gas pumps and volume pumps support multitool cloning.
 * bugfix: Emitters' frequency will now be correctly cloned.
