### PR TITLE
Fixed multitool cloning for the supermatter

### DIFF
--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -61,9 +61,10 @@
 	var/obj/item/device/radio/radio
 
 	// Monitoring shit
-	var/frequency = 0
+	var/frequency = 1439
 	var/id_tag
-
+	var/datum/radio_frequency/radio_connection
+	
 	//Add types to this list so it doesn't make a message or get desroyed by the Supermatter on touch.
 	var/list/message_exclusions = list(/obj/effect/effect/sparks)
 	machine_flags = MULTITOOL_MENU
@@ -91,11 +92,14 @@
 /obj/machinery/power/supermatter/New()
 	. = ..()
 	radio = new (src)
-
+	if(frequency)
+		set_frequency(frequency)
 
 /obj/machinery/power/supermatter/Destroy()
 	qdel(radio)
 	radio = null
+	qdel(radio_connection)
+	radio_connection = null
 	. = ..()
 
 /obj/machinery/power/supermatter/proc/explode()
@@ -146,6 +150,9 @@
 		return 1
 	. = ..()
 
+/obj/machinery/power/supermatter/proc/stability()
+	return round((damage / explosion_point) * 100)
+
 /obj/machinery/power/supermatter/process()
 
 	var/turf/L = loc
@@ -162,7 +169,7 @@
 	for(var/obj/effect/beam/emitter/B in beams)
 		power += B.get_damage() * config_bullet_energy
 
-	var/stability = round((damage / explosion_point) * 100)
+	var/stability = stability()
 	if(damage > warning_point) // while the core is still damaged and it's still worth noting its status
 
 		var/list/audio_sounds = list('sound/AI/supermatter_integrity_before.ogg')
@@ -216,24 +223,7 @@
 
 			explode()
 
-	if(frequency)
-		var/datum/radio_frequency/radio_connection = radio_controller.return_frequency(frequency)
-
-		if(!radio_connection)
-			return
-
-		var/datum/signal/signal = getFromPool(/datum/signal)
-		signal.source = src
-		signal.transmission_method = 1
-		signal.data = list(
-			"tag" = id_tag,
-			"device" = "SM",
-			"instability" = stability,
-			"damage" = damage,
-			"power" = power,
-			"sigtype" = "status"
-		)
-		radio_connection.post_signal(src, signal)
+	broadcast_status()
 
 	//Ok, get the air from the turf
 	var/datum/gas_mixture/env = L.return_air()
@@ -443,3 +433,36 @@
 
 /obj/machinery/power/supermatter/blob_act()
 	explode()
+
+/obj/machinery/power/supermatter/proc/set_frequency(new_frequency)
+	radio_controller.remove_object(src, frequency)
+	frequency = new_frequency
+	if(frequency)
+		radio_connection = radio_controller.add_object(src, frequency, filter = RADIO_ATMOSIA)
+
+/obj/machinery/power/supermatter/proc/broadcast_status()
+	if(!radio_connection)
+		return 0
+
+	var/datum/signal/signal = new()
+	signal.transmission_method = SIGNAL_RADIO
+	signal.source = src
+
+	signal.data = list(
+		"tag" = id_tag,
+		"device" = "SM",
+		"instability" = stability(),
+		"damage" = damage,
+		"power" = power,
+		"sigtype" = "status"
+	)
+	radio_connection.post_signal(src, signal)
+	return 1
+
+/obj/machinery/power/supermatter/canClone(var/obj/O)
+	return istype(O, /obj/machinery/power/supermatter)
+
+/obj/machinery/power/supermatter/clone(var/obj/machinery/power/supermatter/O)
+	id_tag = O.id_tag
+	set_frequency(O.frequency)
+	return 1


### PR DESCRIPTION
Made it so cloning works, resetting the frequency works.
Shards now start on the 143.9 frequency instead of 0, but don't get assigned a tag automatically. I guess you could metaknow that a vault with a shard spawned, otherwise.
Also a little refactoring of the `/datum/radio_frequency`, now it keeps a single reference to it instead of creating one on every `process()`, because it sounds like something that makes sense.
Closes #15771, somewhat? I guess?

:cl:
 * bugfix: Made multitool cloning work for the supermatter.