### PR TITLE
Fixes xeno eggs not affected by explosions

### DIFF
--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -550,6 +550,15 @@
 	src.health -= damage
 	src.healthcheck()
 
+/obj/effect/alien/egg/ex_act(var/severity)
+	switch(severity)
+		if(1)
+			health -= 70
+		if(2)
+			health -= 25
+		if(3)
+			health -= 15
+	healthcheck()
 
 /obj/effect/alien/egg/proc/healthcheck()
 	if(health <= 0)


### PR DESCRIPTION
Fixes #15767
:cl:
 * rscadd: Xenomorph eggs will now be damaged by explosions.
