### PR TITLE
Changed the CMC and Adv. sec cameras Z-level picker

### DIFF
--- a/code/modules/html_interface/map/adv_sec/adv_camera.dm
+++ b/code/modules/html_interface/map/adv_sec/adv_camera.dm
@@ -85,7 +85,12 @@ var/global/datum/interactive_map/camera/adv_camera = new
 			hi.updateContent("content", \
 			"<div id='switches'><a href=\"javascript:switchTo(0);\">Switch to mini map</a> \
 			<a href=\"javascript:switchTo(1);\">Switch to text-based</a> \
-			<a href='javascript:changezlevels();'>Change Z-Level</a> \
+			Z-Level: \
+			<a href='javascript:changezlevels(1);'>1</a> \
+			<a href='javascript:changezlevels(3);'>3</a> \
+			<a href='javascript:changezlevels(4);'>4</a> \
+			<a href='javascript:changezlevels(5);'>5</a> \
+			<a href='javascript:changezlevels(6);'>6</a> \
 			<a href='byond://?src=\ref[hi]&cancel=1'>Cancel Viewing</a></div> \
 			<div id=\"uiMapContainer\"><div id=\"uiMap\" unselectable=\"on\"></div></div>\
 			<div id=\"textbased\"></div>")

--- a/code/modules/html_interface/map/adv_sec/adv_camera.dm
+++ b/code/modules/html_interface/map/adv_sec/adv_camera.dm
@@ -85,12 +85,7 @@ var/global/datum/interactive_map/camera/adv_camera = new
 			hi.updateContent("content", \
 			"<div id='switches'><a href=\"javascript:switchTo(0);\">Switch to mini map</a> \
 			<a href=\"javascript:switchTo(1);\">Switch to text-based</a> \
-			Z-Level: \
-			<a href='javascript:changezlevels(1);'>1</a> \
-			<a href='javascript:changezlevels(3);'>3</a> \
-			<a href='javascript:changezlevels(4);'>4</a> \
-			<a href='javascript:changezlevels(5);'>5</a> \
-			<a href='javascript:changezlevels(6);'>6</a> \
+			[get_zlevel_ui_buttons_js()] \
 			<a href='byond://?src=\ref[hi]&cancel=1'>Cancel Viewing</a></div> \
 			<div id=\"uiMapContainer\"><div id=\"uiMap\" unselectable=\"on\"></div></div>\
 			<div id=\"textbased\"></div>")

--- a/code/modules/html_interface/map/interactive_map.dm
+++ b/code/modules/html_interface/map/interactive_map.dm
@@ -9,7 +9,14 @@
 "<div id='switches'>\
 <a href=\"javascript:switchTo(0);\">Switch to mini map</a> \
 <a href=\"javascript:switchTo(1);\">Switch to text-based</a> \
-<a href='javascript:changezlevels();'>Change Z-Level</a> </div>\
+Z-Level: \
+<a href='javascript:changezlevels(1);'>1</a> \
+<a href='javascript:changezlevels(2);'>2</a> \
+<a href='javascript:changezlevels(3);'>3</a> \
+<a href='javascript:changezlevels(4);'>4</a> \
+<a href='javascript:changezlevels(5);'>5</a> \
+<a href='javascript:changezlevels(6);'>6</a> \
+</div> \
 <div id=\"uiMapContainer\">\
 <div id=\"uiMap\" unselectable=\"on\"></div></div>\
 <div id=\"textbased\"></div>"

--- a/code/modules/html_interface/map/interactive_map.dm
+++ b/code/modules/html_interface/map/interactive_map.dm
@@ -11,7 +11,6 @@
 <a href=\"javascript:switchTo(1);\">Switch to text-based</a> \
 Z-Level: \
 <a href='javascript:changezlevels(1);'>1</a> \
-<a href='javascript:changezlevels(2);'>2</a> \
 <a href='javascript:changezlevels(3);'>3</a> \
 <a href='javascript:changezlevels(4);'>4</a> \
 <a href='javascript:changezlevels(5);'>5</a> \

--- a/code/modules/html_interface/map/interactive_map.dm
+++ b/code/modules/html_interface/map/interactive_map.dm
@@ -9,16 +9,19 @@
 "<div id='switches'>\
 <a href=\"javascript:switchTo(0);\">Switch to mini map</a> \
 <a href=\"javascript:switchTo(1);\">Switch to text-based</a> \
-Z-Level: \
-<a href='javascript:changezlevels(1);'>1</a> \
-<a href='javascript:changezlevels(3);'>3</a> \
-<a href='javascript:changezlevels(4);'>4</a> \
-<a href='javascript:changezlevels(5);'>5</a> \
-<a href='javascript:changezlevels(6);'>6</a> \
+[get_zlevel_ui_buttons_js()] \
 </div> \
 <div id=\"uiMapContainer\">\
 <div id=\"uiMap\" unselectable=\"on\"></div></div>\
 <div id=\"textbased\"></div>"
+
+/proc/get_zlevel_ui_buttons_js()
+	var/list/s = list("Z-Level:")
+	for(var/i in 1 to world.maxz)
+		if(i == map.zCentcomm) continue
+		s += "<a href='javascript:changezlevel([i]);'>[i]</a>"
+	return s.Join()
+
 // Base datum for html_interface interactive maps.
 var/const/MAX_ICON_DIMENSION = 2000
 var/const/ICON_SIZE = 4

--- a/code/modules/html_interface/map/map_shared.js
+++ b/code/modules/html_interface/map/map_shared.js
@@ -279,9 +279,9 @@ function setzoom(val){
 	changeZoom(val - defaultzoom);
 }
 
-function changezlevels()
+function changezlevels(val)
 {
-	var newZ = parseInt(Math.min(Math.max(prompt("View which Z-Level?", z), 1), 6));
+	var newZ = parseInt(Math.min(Math.max(val, 1), 6));
 	if(newZ == z)
 		return
 	window.location.href = "byond://?src=" + hSrc + "&action=changez&value=" + newZ;

--- a/code/modules/html_interface/map/map_shared.js
+++ b/code/modules/html_interface/map/map_shared.js
@@ -279,9 +279,8 @@ function setzoom(val){
 	changeZoom(val - defaultzoom);
 }
 
-function changezlevels(val)
+function changezlevel(newZ)
 {
-	var newZ = parseInt(Math.min(Math.max(val, 1), 6));
 	if(newZ == z)
 		return
 	window.location.href = "byond://?src=" + hSrc + "&action=changez&value=" + newZ;


### PR DESCRIPTION
Because if you've ever used the CMC before you know how much of a pain in the ass that was.
The CMC's UI has other issues but this is all I'm going to address with this PR.
![image](https://user-images.githubusercontent.com/6307265/29490812-edce464c-8547-11e7-903d-31256c0350d0.png)


This DOESN'T fix shit like #15598, as the whole 

> when you do change z-level a lot of the time the map will update but it will continue to show the sensors reported by Z-1 instead.

is still there.

:cl:
 * tweak: Changed the crew monitoring console's and advanced security camera's Z-level picker.