### PR TITLE
Ports some cool /tg/ things

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # vgstation
 
 [![Build Status](https://travis-ci.org/vgstation-coders/vgstation13.svg?branch=master)](https://travis-ci.org/vgstation-coders/vgstation13) [![Krihelimeter](http://www.krihelinator.xyz/badge/vgstation-coders/vgstation13)](http://www.krihelinator.xyz/repositories/vgstation-coders/vgstation13)  
-[![Percentage of issues still open](http://isitmaintained.com/badge/open/vgstation-coders/vgstation13.svg)](http://isitmaintained.com/project/vgstation-coders/vgstation13 "Percentage of issues still open") [![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/vgstation-coders/vgstation13.svg)](http://isitmaintained.com/project/vgstation-coders/vgstation13 "Average time to resolve an issue") ![Coverage](https://s3.amazonaws.com/assets.coveralls.io/badges/coveralls_1.svg)  
-[![forthebadge](http://forthebadge.com/images/badges/built-with-resentment.svg)](http://forthebadge.com)
+[![Percentage of issues still open](http://isitmaintained.com/badge/open/vgstation-coders/vgstation13.svg)](http://isitmaintained.com/project/vgstation-coders/vgstation13 "Percentage of issues still open") [![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/vgstation-coders/vgstation13.svg)](http://isitmaintained.com/project/vgstation-coders/vgstation13 "Average time to resolve an issue") ![Coverage](https://s3.amazonaws.com/assets.coveralls.io/badges/coveralls_1.svg) 
 
 [Website](http://ss13.moe) - [Code](https://github.com/vgstation-coders/vgstation13)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # vgstation
 
-[![Build Status](https://travis-ci.org/vgstation-coders/vgstation13.svg?branch=master)](https://travis-ci.org/vgstation-coders/vgstation13) [![Krihelimeter](http://www.krihelinator.xyz/badge/vgstation-coders/vgstation13)](http://www.krihelinator.xyz/repositories/vgstation-coders/vgstation13)
-
+[![Build Status](https://travis-ci.org/vgstation-coders/vgstation13.svg?branch=master)](https://travis-ci.org/vgstation-coders/vgstation13) [![Krihelimeter](http://www.krihelinator.xyz/badge/vgstation-coders/vgstation13)](http://www.krihelinator.xyz/repositories/vgstation-coders/vgstation13)  
 [![Percentage of issues still open](http://isitmaintained.com/badge/open/vgstation-coders/vgstation13.svg)](http://isitmaintained.com/project/vgstation-coders/vgstation13 "Percentage of issues still open") [![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/vgstation-coders/vgstation13.svg)](http://isitmaintained.com/project/vgstation-coders/vgstation13 "Average time to resolve an issue") ![Coverage](https://s3.amazonaws.com/assets.coveralls.io/badges/coveralls_1.svg)  
 [![forthebadge](http://forthebadge.com/images/badges/built-with-resentment.svg)](http://forthebadge.com)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-# vgstation [![Build Status](https://travis-ci.org/vgstation-coders/vgstation13.svg?branch=master)](https://travis-ci.org/vgstation-coders/vgstation13) [![Percentage of issues still open](http://isitmaintained.com/badge/open/vgstation-coders/vgstation13.svg)](http://isitmaintained.com/project/vgstation-coders/vgstation13 "Percentage of issues still open") [![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/vgstation-coders/vgstation13.svg)](http://isitmaintained.com/project/vgstation-coders/vgstation13 "Average time to resolve an issue") ![Coverage](https://s3.amazonaws.com/assets.coveralls.io/badges/coveralls_0.svg)
+# vgstation
+
+[![Build Status](https://travis-ci.org/vgstation-coders/vgstation13.svg?branch=master)](https://travis-ci.org/vgstation-coders/vgstation13) [![Krihelimeter](http://www.krihelinator.xyz/badge/vgstation-coders/vgstation13)](http://www.krihelinator.xyz/repositories/vgstation-coders/vgstation13)
+
+[![Percentage of issues still open](http://isitmaintained.com/badge/open/vgstation-coders/vgstation13.svg)](http://isitmaintained.com/project/vgstation-coders/vgstation13 "Percentage of issues still open") [![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/vgstation-coders/vgstation13.svg)](http://isitmaintained.com/project/vgstation-coders/vgstation13 "Average time to resolve an issue") ![Coverage](https://s3.amazonaws.com/assets.coveralls.io/badges/coveralls_1.svg)  
+[![forthebadge](http://forthebadge.com/images/badges/built-with-resentment.svg)](http://forthebadge.com)
 
 [Website](http://ss13.moe) - [Code](https://github.com/vgstation-coders/vgstation13)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# vgstation [![Build Status](https://travis-ci.org/vgstation-coders/vgstation13.svg?branch=master)](https://travis-ci.org/vgstation-coders/vgstation13)
+# vgstation [![Build Status](https://travis-ci.org/vgstation-coders/vgstation13.svg?branch=master)](https://travis-ci.org/vgstation-coders/vgstation13) [![Percentage of issues still open](http://isitmaintained.com/badge/open/vgstation-coders/vgstation13.svg)](http://isitmaintained.com/project/vgstation-coders/vgstation13 "Percentage of issues still open") [![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/vgstation-coders/vgstation13.svg)](http://isitmaintained.com/project/vgstation-coders/vgstation13 "Average time to resolve an issue") ![Coverage](https://s3.amazonaws.com/assets.coveralls.io/badges/coveralls_0.svg)
 
 [Website](http://ss13.moe) - [Code](https://github.com/vgstation-coders/vgstation13)
 


### PR DESCRIPTION
Adds some hipster badges to the repo:

[![Build Status](https://travis-ci.org/vgstation-coders/vgstation13.svg?branch=master)](https://travis-ci.org/vgstation-coders/vgstation13) [![Krihelimeter](http://www.krihelinator.xyz/badge/vgstation-coders/vgstation13)](http://www.krihelinator.xyz/repositories/vgstation-coders/vgstation13)  
[![Percentage of issues still open](http://isitmaintained.com/badge/open/vgstation-coders/vgstation13.svg)](http://isitmaintained.com/project/vgstation-coders/vgstation13 "Percentage of issues still open") [![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/vgstation-coders/vgstation13.svg)](http://isitmaintained.com/project/vgstation-coders/vgstation13 "Average time to resolve an issue") ![Coverage](https://s3.amazonaws.com/assets.coveralls.io/badges/coveralls_1.svg)

port of https://github.com/tgstation/tgstation/pull/27146 and https://github.com/tgstation/tgstation/pull/29195

Build passing is existing obviously.

*Relicensed to /vg/ under gpl by the original author.*