### PR TITLE
Minor inventory cleanup

### DIFF
--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -81,18 +81,11 @@ obj/item/weapon/storage/bag/plasticbag/quick_store(var/obj/item/I)
 		return CANNOT_EQUIP
 
 /obj/item/weapon/storage/bag/plasticbag/can_be_inserted()
-	if(ishuman(loc))
-		var/mob/living/carbon/human/H = loc
-		if(H.head == src) //If worn
+	if(isliving(loc))
+		var/mob/living/L = loc
+		if(L.is_wearing_item(src, slot_head)) //Wearing the bag on the head
 			return FALSE
-	if(ismonkey(loc))
-		var/mob/living/carbon/monkey/M = loc
-		if(M.hat == src) //If worn
-			return FALSE
-	if(isMoMMI(loc))
-		var/mob/living/silicon/robot/mommi/MoM = loc
-		if(MoM.head_state == src) //If worn
-			return FALSE
+
 	return ..()
 
 /obj/item/weapon/storage/bag/plasticbag/suicide_act(mob/user)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -409,6 +409,20 @@
 /mob/proc/has_organ_for_slot(slot)
 	return TRUE
 
+//Returns true if mob is wearing the item in any of the inventory slots (NOT hands). If slot is specified, only checks if the item is in that slot
+//Item can be either an object or a path. In the second case, the proc checks if there is a worn item of that type (in that slot), and returns the item
+/mob/proc/is_wearing_item(obj/item/I, slot = null)
+	if(slot)
+		if(ispath(I))
+			var/obj/item/item = get_item_by_slot(slot)
+			if(istype(item, I))
+				return item
+		return (get_item_by_slot(slot) == I)
+	else
+		if(ispath(I))
+			return (locate(I) in get_equipped_items())
+		return (I in get_equipped_items())
+
 /mob/living/carbon/human/proc/equip_if_possible(obj/item/W, slot, act_on_fail = EQUIP_FAILACTION_DELETE) // since byond doesn't seem to have pointers, this seems like the best way to do this :/
 	//warning: icky code
 	var/equipped = 0

--- a/code/modules/mob/living/carbon/alien/humanoid/emote.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/emote.dm
@@ -9,7 +9,7 @@
 
 	if(findtext(act,"s",-1) && !findtext(act,"_",-2))//Removes ending s's unless they are prefixed with a '_'
 		act = copytext(act,1,length(act))
-	var/muzzled = istype(src.wear_mask, /obj/item/clothing/mask/muzzle)
+	var/muzzled = is_wearing_item(/obj/item/clothing/mask/muzzle, slot_wear_mask)
 
 	switch(act)
 		if("me")

--- a/code/modules/mob/living/carbon/alien/humanoid/life.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/life.dm
@@ -157,7 +157,8 @@
 		if(internal)
 			if(!contents.Find(internal))
 				internal = null
-			if(!wear_mask || !(wear_mask.clothing_flags & MASKINTERNALS) )
+			var/obj/item/mask = get_item_by_slot(slot_wear_mask)
+			if(!mask || !(mask.clothing_flags & MASKINTERNALS) )
 				internal = null
 			if(internal)
 				if(internals)

--- a/code/modules/mob/living/carbon/alien/larva/emote.dm
+++ b/code/modules/mob/living/carbon/alien/larva/emote.dm
@@ -9,7 +9,7 @@
 
 	if(findtext(act,"s",-1) && !findtext(act,"_",-2))//Removes ending s's unless they are prefixed with a '_'
 		act = copytext(act,1,length(act))
-	var/muzzled = istype(src.wear_mask, /obj/item/clothing/mask/muzzle)
+	var/muzzled = is_muzzled()
 
 	switch(act)
 		if("me")

--- a/code/modules/mob/living/carbon/alien/larva/life.dm
+++ b/code/modules/mob/living/carbon/alien/larva/life.dm
@@ -137,7 +137,9 @@
 	if(internal)
 		if (!contents.Find(internal))
 			internal = null
-		if (!wear_mask || !(wear_mask.clothing_flags & MASKINTERNALS) )
+
+		var/obj/item/mask = get_item_by_slot(slot_wear_mask)
+		if (!mask || !(mask.clothing_flags & MASKINTERNALS) )
 			internal = null
 		if(internal)
 			if (internals)

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -78,11 +78,11 @@
 		var/dist = get_dist(loc, target.loc)
 		if(dist > 4)
 			return //We'll let the facehugger do nothing for a bit, since it's fucking up.
-		if(target.wear_mask && istype(target.wear_mask, /obj/item/clothing/mask/facehugger))
-			var/obj/item/clothing/mask/facehugger/F = target.wear_mask
-			if(F.sterile) // Toy's won't prevent real huggers
-				findtarget()
-				return
+
+		var/obj/item/clothing/mask/facehugger/F = target.is_wearing_item(/obj/item/clothing/mask/facehugger, slot_wear_mask)
+		if(F && F.sterile) // Toy's won't prevent real huggers
+			findtarget()
+			return
 		else
 			step_towards(src, target, 0)
 			if(dist <= 1)
@@ -242,7 +242,7 @@
 		var/obj/item/mouth_protection = H.get_body_part_coverage(MOUTH)
 		if(!real && mouth_protection)
 			return //Toys really shouldn't be forcefully removing gear
-		var/obj/item/clothing/mask/facehugger/hugger = H.wear_mask
+		var/obj/item/clothing/mask/facehugger/hugger = H.get_item_by_slot(slot_wear_mask)
 		if(istype(hugger) && !hugger.sterile && !sterile) // Lamarr won't fight over faces and neither will normal huggers.
 			return
 
@@ -269,7 +269,7 @@
 	if(iscarbon(M))
 		var/mob/living/carbon/target = L
 
-		if(target.wear_mask)
+		if(target.get_item_by_slot(slot_wear_mask))
 			if(prob(CHANCE_TO_NOT_REMOVE_MASKS))
 				return FALSE
 			var/obj/item/clothing/W = target.wear_mask

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -589,7 +589,7 @@
 		return 0
 
 /mob/living/carbon/is_muzzled()
-	return(istype(src.wear_mask, /obj/item/clothing/mask/muzzle))
+	return(istype(get_item_by_slot(slot_wear_mask), /obj/item/clothing/mask/muzzle))
 
 
 /mob/living/carbon/proc/isInCrit()

--- a/code/modules/mob/living/carbon/internals.dm
+++ b/code/modules/mob/living/carbon/internals.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/proc/has_breathing_mask()
-	return istype(wear_mask, /obj/item/clothing/mask)
+	return is_wearing_item(/obj/item/clothing/mask, slot_wear_mask)
 
 /mob/living/carbon/proc/internals_candidates() //These are checked IN ORDER.
 	return get_all_slots() + held_items

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1433,13 +1433,8 @@ Thanks.
 			speed_mod = 0.0
 
 		if(H.organ_has_mutation(LIMB_HEAD, M_BEAK))
-			if(istype(H.wear_mask))
-				var/obj/item/clothing/mask/M = H.wear_mask
-				if(!(M.body_parts_covered & MOUTH)) //If our mask doesn't cover mouth, we can use our beak to help us while butchering
-					speed_mod += 0.25
-					if(!tool_name)
-						tool_name = "beak"
-			else
+			var/obj/item/mask = H.get_item_by_slot(slot_wear_mask)
+			if(!mask || !(mask.body_parts_covered & MOUTH)) //If our mask doesn't cover mouth, we can use our beak to help us while butchering
 				speed_mod += 0.25
 				if(!tool_name)
 					tool_name = "beak"

--- a/code/modules/mob/living/silicon/mommi/inventory.dm
+++ b/code/modules/mob/living/silicon/mommi/inventory.dm
@@ -247,6 +247,12 @@
 /mob/living/silicon/robot/mommi/cycle_modules()
 	return
 
+/mob/living/silicon/robot/mommi/get_item_by_slot(slot_id)
+	switch(slot_id)
+		if(slot_head)
+			return head_state
+	return null
+
 // Equip an item to the MoMMI. Currently the only thing you can equip is hats
 // Returns a 0 or 1 based on whether or not the equipping worked
 /mob/living/silicon/robot/mommi/equip_to_slot(obj/item/W as obj, slot, redraw_mob = 1)

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -144,13 +144,19 @@
 	var/m_intent = "run"//Living
 	var/lastKnownIP = null
 
+	//Tank used as internals
+	var/obj/item/weapon/tank/internal = null
+
+	//Active storage item (i.e. the backpack or cardboard box that you're looking inside of)
+	var/obj/item/weapon/storage/s_active = null
+
+	//Inventory
+
 	var/active_hand = 1 //Current active hand. Contains an index of the held_items list
 	var/list/obj/item/held_items = list(null, null) //Contains items held in hands
 
-	var/obj/item/weapon/back = null//Human/Monkey
-	var/obj/item/weapon/tank/internal = null//Human/Monkey
-	var/obj/item/weapon/storage/s_active = null//Carbon
-	var/obj/item/clothing/mask/wear_mask = null//Carbon
+	var/obj/item/weapon/back = null
+	var/obj/item/clothing/mask/wear_mask = null
 
 	var/seer = 0 //for cult//Carbon, probably Human
 

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -391,8 +391,12 @@ proc/Gibberish(t, p)//t is the inputted message, and any value higher than 70 fo
 
 		return 1
 
-	if(full_body && (src.back || src.wear_mask))
-		return 1
+	if(full_body)
+		for(var/obj/item/I in get_equipped_items())
+			if(I.abstract)
+				continue
+
+			return 1
 
 	return 0
 


### PR DESCRIPTION
* Added 'is_wearing_item(item, slot)' helper proc for mobs

* Cleaned up some code

```
if(ishuman(loc))
	var/mob/living/carbon/human/H = loc
	if(H.head == src) //If worn
		return FALSE
if(ismonkey(loc))
	var/mob/living/carbon/monkey/M = loc
	if(M.hat == src) //If worn
		return FALSE
if(isMoMMI(loc))
	var/mob/living/silicon/robot/mommi/MoM = loc
	if(MoM.head_state == src) //If worn
		return FALSE
```
^ from now on, this is very haram. Use mob.is_wearing_item(src, slot_head) instead
