### PR TITLE
De-stealths CYBORG hyposprays

### DIFF
--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -74,7 +74,9 @@
 	if(!ismob(M))
 		return
 
-	to_chat(user, "<span class='info'>You inject [M] with the injector.<span>")
+	user.visible_message(\
+		"<span class='warning'>[user] injects [M] with [src].</span>",\
+		"<span class='info'>You inject [M] with with [src].<span>")
 	to_chat(M, "<span class='warning'>You feel a tiny prick!</span>")
 	reagents.reaction(M, INGEST)
 

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -74,6 +74,7 @@
 	if(!ismob(M))
 		return
 
+	user.do_attack_animation(M, src)
 	user.visible_message(\
 		"<span class='warning'>[user] injects [M] with [src].</span>",\
 		"<span class='info'>You inject [M] with with [src].<span>")

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -74,6 +74,9 @@
 	if(!ismob(M))
 		return
 
+	if(issilicon(M))
+		return
+
 	user.do_attack_animation(M, src)
 	user.visible_message(\
 		"<span class='warning'>[user] injects [M] with [src].</span>",\


### PR DESCRIPTION
You can now see when a mediborg/hugborg injects someone. Also adds a check to prevent silicons from injecting silicons

:cl:
 * tweak: De-stealths cyborg hyposprays