### PR TITLE
Silly cone examine() tweaks

### DIFF
--- a/code/modules/mob/living/silicon/ai/examine.dm
+++ b/code/modules/mob/living/silicon/ai/examine.dm
@@ -1,24 +1,25 @@
 /mob/living/silicon/ai/examine(mob/user)
-
 	var/msg = "<span class='info'>*---------*\nThis is [bicon(src)] <EM>[src]</EM>!\n"
-	if (src.stat == DEAD)
-		msg += "<span class='deadsay'>It appears to be powered-down.</span>\n"
-	else
-		msg += "<span class='warning'>"
-		if (src.getBruteLoss())
-			if (src.getBruteLoss() < 30)
-				msg += "It looks slightly dented.\n"
-			else
-				msg += "<B>It looks severely dented!</B>\n"
-		if (src.getFireLoss())
-			if (src.getFireLoss() < 30)
-				msg += "It looks slightly charred.\n"
-			else
-				msg += "<B>Its casing is melted and heat-warped!</B>\n"
+	msg += "<span class='warning'>"
+	if (getBruteLoss())
+		if (getBruteLoss() < maxHealth*0.5)
+			msg += "It looks slightly dented.\n"
+		else
+			msg += "<B>It looks severely dented!</B>\n"
+	if (getFireLoss())
+		if (getFireLoss() < maxHealth*0.5)
+			msg += "It looks slightly charred.\n"
+		else
+			msg += "<B>Its casing is melted and heat-warped!</B>\n"
+	if (health < -maxHealth*0.5)
+		msg += "It looks barely operational.\n"
+	msg += "</span>"
 
-		if (src.stat == UNCONSCIOUS)
-			msg += "It is non-responsive and displaying the text: \"RUNTIME: Sensory Overload, stack 26/3\".\n"
-		msg += "</span>"
+	switch(stat)
+		if(UNCONSCIOUS)
+			msg += "<span class='warning'>It is non-responsive and displaying the text: \"RUNTIME: Sensory Overload, stack 26/3\".</span>\n"
+		if(DEAD)
+			msg += "<span class='deadsay'>[name] E_UNEXPECTED 0x8000FFFF. If you are experiencing difficulty with an A.I. you are installing or running, contact central command with this displaying the error message.</span>\n"
 	msg += "*---------*</span>"
 
 	to_chat(user, msg)

--- a/code/modules/mob/living/silicon/examine.dm
+++ b/code/modules/mob/living/silicon/examine.dm
@@ -1,7 +1,7 @@
 /mob/living/silicon/examine(mob/user) //Diplay's a silicon's Laws to ghosts
 	if(laws && isobserver(user) && !istype(user,/mob/dead/observer/deafmute)) //Fuck off phantom mask users
 		var/mob/dead/observer/fag = user
-		if(!isAdminGhost(fag) && fag.mind)
+		if(!isAdminGhost(fag) && fag.mind && fag.mind.current)
 			if(fag.mind.isScrying || fag.mind.current.ajourn) //Scrying or astral travel, fuck them.
 				return
 		to_chat(fag, "<b>[src] has the following laws:</b>")

--- a/code/modules/mob/living/silicon/mommi/examine.dm
+++ b/code/modules/mob/living/silicon/mommi/examine.dm
@@ -2,18 +2,23 @@
 
 	var/msg = "<span class='info'>*---------*\nThis is [bicon(src)] \a <EM>[src]</EM>!\n"
 
-	msg += {"<p>It's like a crab, but it has a utility tool on one arm and a crude metal claw on the other.  That, and you doubt it'd survive in an ocean for very long.</p><span class='warning'>"}
-	if (src.getBruteLoss())
-		if (src.getBruteLoss() < 75)
+	msg += {"<p>It's like a crab, but it has a utility tool on one arm and a crude metal claw on the other.  That, and you doubt it'd survive in an ocean for very long.</p>"}
+
+	msg += "<span class='warning'>"
+	if (getBruteLoss())
+		if (getBruteLoss() < maxHealth*0.5)
 			msg += "It looks slightly dented.\n"
 		else
 			msg += "<B>It looks severely dented!</B>\n"
-	if (src.getFireLoss())
-		if (src.getFireLoss() < 75)
+	if (getFireLoss())
+		if (getFireLoss() < maxHealth*0.5)
 			msg += "It looks slightly charred.\n"
 		else
 			msg += "<B>It looks severely burnt and heat-warped!</B>\n"
+	if (health < -maxHealth*0.5)
+		msg += "It looks barely operational.\n"
 	msg += "</span>"
+
 	if(head_state)
 		msg += "It is wearing [bicon(head_state)] [head_state] on its head.\n"
 	if(tool_state)
@@ -24,6 +29,9 @@
 		msg += "<span class='warning'>Its cover is open and the power cell is [cell ? "installed" : "missing"].</span>\n"
 	else
 		msg += "Its cover is closed.\n"
+
+	if(cell && cell.charge <= 0)
+		msg += "<span class='warning'>Its battery indicator is blinking red!</span>\n"
 
 	switch(src.stat)
 		if(CONSCIOUS)
@@ -39,7 +47,7 @@
 
 	if(laws && isobserver(user) && !istype(user,/mob/dead/observer/deafmute)) //As a bastard child of robots, we don't call our parent's examine()
 		var/mob/dead/observer/fag = user
-		if(!isAdminGhost(fag) && fag.mind)
+		if(!isAdminGhost(fag) && fag.mind && fag.mind.current)
 			if(fag.mind.isScrying || fag.mind.current.ajourn)// Scrying or astral travel, fuck them.
 				return
 		to_chat(fag, "<b>[src] has the following laws:</b>")

--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -1,26 +1,35 @@
 /mob/living/silicon/robot/examine(mob/user)
-	var/msg = {"<span class='info'>*---------*\nThis is [bicon(src)] \a <EM>[src]</EM>[custom_name ? ", [modtype] [braintype]" : ""]!\n
-<span class='warning'>"}
-	if (src.getBruteLoss())
-		if (src.getBruteLoss() < 75)
+	var/msg = {"<span class='info'>*---------*\nThis is [bicon(src)] \a <EM>[src]</EM>[custom_name ? ", [modtype] [braintype]" : ""]!\n"}
+	msg += "<span class='warning'>"
+	if (getBruteLoss())
+		if (getBruteLoss() < maxHealth*0.5)
 			msg += "It looks slightly dented.\n"
 		else
 			msg += "<B>It looks severely dented!</B>\n"
-	if (src.getFireLoss())
-		if (src.getFireLoss() < 75)
+	if (getFireLoss())
+		if (getFireLoss() < maxHealth*0.5)
 			msg += "It looks slightly charred.\n"
 		else
 			msg += "<B>It looks severely burnt and heat-warped!</B>\n"
+	if (health < -maxHealth*0.5)
+		msg += "It looks barely operational.\n"
 	msg += "</span>"
+
+	if(module_active)
+		var/obj/item/I = module_active
+		msg += "It's using [I.gender==PLURAL?"some":"a"] [bicon(I)] [I.name] as its active module.\n"
 
 	if(opened)
 		msg += "<span class='warning'>Its cover is open and the power cell is [cell ? "installed" : "missing"].</span>\n"
 	else
 		msg += "Its cover is closed.\n"
 
-	switch(src.stat)
+	if(cell && cell.charge <= 0)
+		msg += "<span class='warning'>Its battery indicator is blinking red!</span>\n"
+
+	switch(stat)
 		if(CONSCIOUS)
-			if(!src.client)
+			if(!client)
 				msg += "It appears to be in stand-by mode.\n" //afk
 		if(UNCONSCIOUS)
 			msg += "<span class='warning'>It doesn't seem to be responding.</span>\n"


### PR DESCRIPTION
![dented](https://user-images.githubusercontent.com/17928298/29579297-c066eaee-8748-11e7-9efe-8d28e9d10616.png)
![rouge](https://user-images.githubusercontent.com/17928298/29642246-198756f4-883e-11e7-9aef-681342efafb7.png)

This is a partial salvage from the gripper PR:

* Active module now appears on examine.
* Both crabs and cyborgs now have low battery blink on examine.
* Silicons will appear **slightly dented/charred** if they have under half of their max health taken in that form of damage instead of magic numbers. 
* After taking 50% of their max health in damage silicons will look **barely operational**.
* Changes the AI dead message because almost all AIs show an ERROR icon on death instead of a blank screen.
* Adds a mind.current check to ghost examining laws to prevent runtimes with ajourn.

:cl:
 * rscadd: You can now see cyborg's active module using examine, hide that laser!
 * rscadd: Cyborgs and MoMMIs will now show a blinking light on examine when their battery is zero.
