### PR TITLE
confectionator printing fix

### DIFF
--- a/code/modules/research/designs/boards/machine_hospitality.dm
+++ b/code/modules/research/designs/boards/machine_hospitality.dm
@@ -64,4 +64,4 @@
 	id = "confectionator"
 	req_tech = list(Tc_BIOTECH = 2)
 	category = "Machine Boards"
-	build_path = /obj/machinery/cooking/deepfryer/confectionator
+	build_path = /obj/item/weapon/circuitboard/confectionator


### PR DESCRIPTION
makes the circuit imprinter just print a confectionator board rather than the entire machine
fixes #15807

🆑 
 - bugfix: fixed circuit imprinters printing entire confectionators rather than just circuit boards