### PR TITLE
De-stealths hyposprays and subtypes

### DIFF
--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -49,7 +49,8 @@
 		M = user
 
 	if (reagents.total_volume)
-		to_chat(user, inject_message)
+		user.visible_message("<span class='warning'>[M == user ? "[user] injects \himself" : "[user] injects [M]"] with [src].</span>", \
+		"[inject_message]")
 		to_chat(M, "<span class='warning'>You feel a tiny prick!</span>")
 		playsound(get_turf(src), 'sound/items/hypospray.ogg', 50, 1)
 

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -49,6 +49,7 @@
 		M = user
 
 	if (reagents.total_volume)
+		user.do_attack_animation(M, src)
 		user.visible_message("<span class='warning'>[M == user ? "[user] injects \himself" : "[user] injects [M]"] with [src].</span>", \
 		"[inject_message]")
 		to_chat(M, "<span class='warning'>You feel a tiny prick!</span>")


### PR DESCRIPTION
![pshht](https://user-images.githubusercontent.com/17928298/29642125-6136ba7c-883d-11e7-9e00-1c6fab3e11d7.png)


:cl:
 * tweak: De-stealths hyposprays and subtypes. Sleepy pen stays as the go-to stealth chem injecting weapon,