### PR TITLE
Allows admins to add songs to jukeboxes

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -1,4 +1,17 @@
 #define HTMLTAB "&nbsp;&nbsp;&nbsp;&nbsp;"
+
+//Loops through every line in (text). The 'line' variable holds the current line
+//Example use:
+/*
+var/text = {"Line 1
+Line 2
+Line 3
+"}
+forLineInText(text)
+	world.log << line
+*/
+#define forLineInText(text) for({var/__index=1;var/line=copytext(text, __index, findtext(text, "\n", __index))} ; {__index != 0} ; {__index = findtext(text, "\n", __index+1) ; line = copytext(text, __index+1, findtext(text, "\n", __index+1))})
+
 /*
  * Holds procs designed to help with filtering text
  * Contains groups:

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -291,11 +291,11 @@ proc/checkhtml(var/t)
 
 	return ""
 
-//Returns a string with double spaces removed	
-/proc/trimcenter(text) 
+//Returns a string with double spaces removed
+/proc/trimcenter(text)
 	var/regex/trimcenterregex = regex("\\s{2,}","g")
 	return trimcenterregex.Replace(text," ")
-	
+
 //Returns a string with reserved characters and spaces before the first word and after the last word removed.
 /proc/trim(text)
 	return trim_left(trim_right(text))

--- a/code/modules/media/jukebox.dm
+++ b/code/modules/media/jukebox.dm
@@ -527,12 +527,15 @@ var/global/list/loopModeNames=list(
 			if(!choice)
 				return
 
+			log_admin("[key_name(usr)] is adding some songs to the jukebox [formatJumpTo(src)]:")
+			log_admin("[choice]")
+
 			var/success = 0
 			var/error = 0
-			for(var/lpos=1; lpos<length(choice) && lpos != findtext(choice,"\n",lpos,0)+1; lpos=findtext(choice,"\n",lpos,0)+1)
-				var/tline = copytext(choice, lpos, findtext(choice,"\n",lpos,0))
 
-				var/list/L = params2list(tline)
+			//Loop through each line
+			forLineInText(choice)
+				var/list/L = params2list(line)
 				if(L.len >= 3)
 					var/list/params = list()
 					params["url"]   = L[1]
@@ -555,6 +558,7 @@ var/global/list/loopModeNames=list(
 					error++
 
 			to_chat(usr, "Added [success] songs successfully. Encountered [error] errors.")
+			message_admins("[key_name(usr)] has added [success] songs to the jukebox [formatJumpTo(src)]")
 		else
 			to_chat(usr, "Only admin ghosts can do this.")
 

--- a/code/modules/media/jukebox.dm
+++ b/code/modules/media/jukebox.dm
@@ -523,30 +523,38 @@ var/global/list/loopModeNames=list(
 
 	if(href_list["add_custom"])
 		if(isAdminGhost(usr))
-			var/choice = input(usr, "Enter the song's URL, length (in seconds!), title, artist and album in that exact order, separated by a semicolon. Artist and album may be omitted. Example: http://music.com/song.mp3;192;Song Name;Artist;Album", "Custom Jukebox") as null|text
+			var/choice = input(usr, "Enter the song's URL, length (in seconds!), title, artist and album in that exact order, separated by a semicolon. Artist and album may be omitted. Example: http://music.com/song.mp3;192;Song Name;Artist;Album. If adding more than one song, each song has to be on its own line.", "Custom Jukebox") as null|message
 			if(!choice)
 				return
 
-			var/list/L = params2list(choice)
-			if(L.len >= 3)
-				var/list/params = list()
-				params["url"]   = L[1]
-				params["length"]= text2num(L[2])*10 //The song_info datum stores this value in deciseconds
-				params["title"] = L[3]
+			var/success = 0
+			var/error = 0
+			for(var/lpos=1; lpos<length(choice) && lpos != findtext(choice,"\n",lpos,0)+1; lpos=findtext(choice,"\n",lpos,0)+1)
+				var/tline = copytext(choice, lpos, findtext(choice,"\n",lpos,0))
 
-				if(L.len >= 4)
-					params["artist"]= L[4]
-				if(L.len >= 5)
-					params["album"] = L[5]
+				var/list/L = params2list(tline)
+				if(L.len >= 3)
+					var/list/params = list()
+					params["url"]   = L[1]
+					params["length"]= text2num(L[2])*10 //The song_info datum stores this value in deciseconds
+					params["title"] = L[3]
+					params["artist"]= ""
+					params["album"] = ""
 
-				//Initialize playlist if needed
-				if(!playlist)
-					playlist = list()
-				playlist.Add(new /datum/song_info(params))
+					if(L.len >= 4)
+						params["artist"]= L[4]
+					if(L.len >= 5)
+						params["album"] = L[5]
 
-				to_chat(usr, "The song has been added to the jukebox's current playlist.")
-			else
-				to_chat(usr, "URL, length and title are mandatory!")
+					//Initialize playlist if needed
+					if(!playlist)
+						playlist = list()
+					playlist.Add(new /datum/song_info(params))
+					success++
+				else
+					error++
+
+			to_chat(usr, "Added [success] songs successfully. Encountered [error] errors.")
 		else
 			to_chat(usr, "Only admin ghosts can do this.")
 

--- a/code/modules/media/jukebox.dm
+++ b/code/modules/media/jukebox.dm
@@ -288,6 +288,9 @@ var/global/list/loopModeNames=list(
 	t += "<h1>Jukebox Interface</h1>"
 	t += "<b>Power:</b> <a href='?src=\ref[src];power=1'>[playing?"On":"Off"]</a><br />"
 	t += "<b>Play Mode:</b> <a href='?src=\ref[src];mode=1'>[allowed_modes[loop_mode]]</a><br />"
+	if(isAdminGhost(user))
+		t += "<a href='?src=\ref[src];add_custom=1'>Add new song</a><br>"
+
 	if(playlist == null)
 		t += "\[DOWNLOADING PLAYLIST, PLEASE WAIT\]"
 	else
@@ -517,6 +520,35 @@ var/global/list/loopModeNames=list(
 					change_access = list()
 
 				screen=POS_SCREEN_SETTINGS
+
+	if(href_list["add_custom"])
+		if(isAdminGhost(usr))
+			var/choice = input(usr, "Enter the song's URL, length (in seconds!), title, artist and album in that exact order, separated by a semicolon. Artist and album may be omitted. Example: http://music.com/song.mp3;192;Song Name;Artist;Album", "Custom Jukebox") as null|text
+			if(!choice)
+				return
+
+			var/list/L = params2list(choice)
+			if(L.len >= 3)
+				var/list/params = list()
+				params["url"]   = L[1]
+				params["length"]= text2num(L[2])*10 //The song_info datum stores this value in deciseconds
+				params["title"] = L[3]
+
+				if(L.len >= 4)
+					params["artist"]= L[4]
+				if(L.len >= 5)
+					params["album"] = L[5]
+
+				//Initialize playlist if needed
+				if(!playlist)
+					playlist = list()
+				playlist.Add(new /datum/song_info(params))
+
+				to_chat(usr, "The song has been added to the jukebox's current playlist.")
+			else
+				to_chat(usr, "URL, length and title are mandatory!")
+		else
+			to_chat(usr, "Only admin ghosts can do this.")
 
 	if (href_list["playlist"])
 		if(isobserver(usr) && !canGhostWrite(usr,src,""))


### PR DESCRIPTION
The songs have to be hosted online, and you have to manually specify their length in seconds. You can add songs in batches, so you can make your own playlists in notepad and then add them all at once.

:cl:
 * rscadd: Admins can now add custom songs to jukeboxes. Added songs don't transfer between rounds.