### PR TITLE
Antag system - Faction datums

### DIFF
--- a/code/game/gamemodes/faction.dm
+++ b/code/game/gamemodes/faction.dm
@@ -1,0 +1,90 @@
+/*
+	Faction Datums
+		Used for keeping a collection of people under one banner, making for easier
+		objective syncing, communication, etc.
+
+	@name: String: Name of the faction
+	@desc: String: Description of the faction, their intentions, how they do things, etc. Something for lorewriters to use.
+	@restricted_species: list(String): Only species on this list can be part of this faction
+		(Vox Raiders, Skellington Pirates, Bewildering Basfellians, etc.)
+	@members: List(Reference): Who is a member of this faction
+	@max_roles: Integer: How many members this faction is limited to. Set to 0 for no limit
+	@objectives: objectives datum: What are the goals of this faction?
+
+	//TODO LATER
+	@faction_icon_state: String: The image name of the icon that appears next to people of this faction
+	@faction_icon: icon file reference: Where the icon is stored
+*/
+
+/datum/faction
+	var/name = "unknown faction"
+	var/desc = "This faction is bound to do something nefarious"
+	var/list/restricted_species = list()
+	var/list/members = list()
+	var/max_roles = 0
+	var/datum/objective_holder/objective_holder
+
+/datum/faction/proc/onPostSetup()
+	objective_holder = new
+	forgeObjectives()
+
+/datum/faction/proc/forgeObjectives()
+
+
+/*
+	appendObjective proc
+		Basically adds an objective to the objective holder, and
+			TODO LATER
+				Tells the faction of this new objective
+*/
+/datum/faction/proc/appendObjective(var/datum/objective/O)
+	ASSERT(O)
+	objective_holder.AddObjective(O)
+
+/datum/faction/proc/checkAllObjectives()
+	for(var/datum/objective/O in objective_holder.objectives)
+		O.Isfullfilled()
+
+/datum/faction/proc/GetScoreboard()
+	var/list/score_results = list()
+	for(var/datum/role/R in members)
+		var/results = R.GetScoreboard()
+		if(results)
+			score_results.Add(results)
+
+	return score_results
+
+/datum/faction/proc/GetObjectivesMenuHeader() //Returns what will show when the factions objective completion is summarized
+
+
+/datum/faction/syndicate
+	name = "The Syndicate"
+	desc = "A coalition of companies that actively work against Nanotrasen's intentions. Seen as Freedom fighters by some, Rebels and Malcontents by others."
+
+
+/datum/faction/syndicate/GetObjectivesMenuHeader()
+	var/icon/logo = icon('icons/mob/mob.dmi', "synd-logo")
+	var/header = {"<BR><img src='data:image/png;base64,[icon2base64(logo)]'> <FONT size = 2><B>Syndicate</B></FONT> <img src='data:image/png;base64,[icon2base64(logo)]'>"}
+	return header
+
+/datum/faction/changeling
+	name = "Changeling Hivemind"
+	desc = "An almost parasitic, shapeshifting entity that assumes the identity of its victims. Commonly used as smart bioweapons by the syndicate,\
+	or simply wandering malignant vagrants happening upon a meal of identity that can carry them to further feeding grounds."
+
+/datum/faction/changeling/GetObjectivesMenuHeader()
+	var/icon/logo_left = icon('icons/mob/mob.dmi', "changelogoa")
+	var/icon/logo_right = icon('icons/mob/mob.dmi', "changelogob")
+	var/header = {"<BR><img src='data:image/png;base64,[icon2base64(logo_left)]'> <FONT size = 2><B>Changelings Hivemind</B></FONT> <img src='data:image/png;base64,[icon2base64(logo_right)]'>"}
+	return header
+
+/datum/faction/wizard
+	name = "Wizard Federation"
+	desc = "A conglomeration of magically adept individuals, with no obvious heirachy, instead acting as equal individuals in the pursuit of magic-oriented endeavours.\
+	Their motivations for attacking seemingly peaceful enclaves or operations are as yet unknown, but they do so without respite or remorse.\
+	This has led to them being identified as enemies of humanity, and should be treated as such."
+
+/datum/faction/wizard/GetObjectivesMenuHeader()
+	var/icon/logo = icon('icons/mob/mob.dmi', "wizard-logo")
+	var/header = {"<BR><img src='data:image/png;base64,[icon2base64(logo)]'> <FONT size = 2><B>Wizard Federation</B></FONT> <img src='data:image/png;base64,[icon2base64(logo)]'>"}
+	return header

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -320,7 +320,7 @@
 #include "code\game\dna\genes\vg_powers.dm"
 #include "code\game\gamemodes\antag_spawner.dm"
 #include "code\game\gamemodes\events.dm"
-#include "code\game\gamemodes\factions.dm"
+#include "code\game\gamemodes\faction.dm"
 #include "code\game\gamemodes\game_mode.dm"
 #include "code\game\gamemodes\gameticker.dm"
 #include "code\game\gamemodes\intercept_report.dm"


### PR DESCRIPTION
(re)adds faction datums, a component of the planned antag system.

Basically a way of grouping up a bunch of roles under one faction for easier management

Lorewriters needed for better descriptions of each faction

Hopefully this will get the ball rolling

Checks will fail as half the stuff it's referencing doesn't exist yet