### PR TITLE
Runtime hunting, action.dm ACT 2

### DIFF
--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -34,9 +34,9 @@ var/global/obj/abstract/screen/clicker/catcher = new()
 
 /datum/hud/New(mob/owner)
 	mymob = owner
-	instantiate()
 	hide_actions_toggle = new
 	hide_actions_toggle.InitialiseIcon(mymob)
+	instantiate()
 	..()
 
 /datum/hud/Destroy()


### PR DESCRIPTION
Kills **Runtime in action.dm,53: Cannot modify null.moved** for good. Now there's only **Runtime in action_button.dm,93: Cannot read null.screen_loc** left.

Thanks to  @N3X15 for the insight.

> N3X15 - Last Tuesday at 2:41 PM
> I already see the problem
> It's trying to get the hud datum before it's even completed New()
> so the variable containing the datum is null
> the variable in question is hide_actions_toggle on the /datum/hud
> however
> In /datum/hud/instantiate(), it calls update_action_buttons() at the end, which then does a bunch of shit to hide_actions_toggle.
> there's a problem though.
> instantiate(), which eventually accesses hide_toggle_actions, is called before hide_toggle_actions is ever initialized.
> And that's why you get runtimes.
> So, two solutions:
> 1. Instantiate hide_actions_toggle before instantiate()
> 2. Add if(hide_actions_toggle!=null) checks in update_action_buttons(), but that may cause problems.