### PR TITLE
Adminghosts no longer respect poltergeist cooldowns

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -797,8 +797,12 @@ its easier to just keep the beam vertical.
 		investigation_log(I_GHOST, "|| was Boo!'d by [key_name(ghost)][ghost.locked_to ? ", who was haunting [ghost.locked_to]" : ""]")
 	return 1
 
-/atom/proc/can_spook()
-	return !blessed
+/atom/proc/can_spook(var/msg = 1)
+	if(blessed)
+		if(msg)
+			to_chat(usr, "Your hand goes right through \the [src]... Is that some holy water dripping from it?")
+		return FALSE
+	return TRUE
 
 //Called on holy_water's reaction_obj()
 /atom/proc/bless()

--- a/code/game/machinery/floodlight.dm
+++ b/code/game/machinery/floodlight.dm
@@ -71,12 +71,11 @@
 	update_icon()
 
 /obj/machinery/floodlight/attack_ghost(var/mob/dead/observer/ghost)
-	if(blessed)
-		to_chat(ghost, "Your hand goes right through \the [src]...Is that some holy water dripping from it?")
-		return 0
+	if(!can_spook())
+		return FALSE
 	if(!ghost.can_poltergeist())
 		to_chat(ghost, "Your poltergeist abilities are still cooling down.")
-		return 0
+		return FALSE
 	investigation_log(I_GHOST, "|| was switched [on ? "off" : "on"] by [key_name(ghost)][ghost.locked_to ? ", who was haunting [ghost.locked_to]" : ""]")
 	return ..()
 

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -89,12 +89,11 @@
 	src.attack_hand(user)
 
 /obj/machinery/light_switch/attack_ghost(var/mob/dead/observer/ghost)
-	if(blessed)
-		to_chat(ghost, "Your hand goes right through the switch...Is that some holy water dripping from it?")
-		return 0
+	if(!can_spook())
+		return FALSE
 	if(!ghost.can_poltergeist())
 		to_chat(ghost, "Your poltergeist abilities are still cooling down.")
-		return 0
+		return FALSE
 	investigation_log(I_GHOST, "|| was switched [on ? "off" : "on"] by [key_name(ghost)][ghost.locked_to ? ", who was haunting [ghost.locked_to]" : ""]")
 	return ..()
 

--- a/code/game/machinery/station_map.dm
+++ b/code/game/machinery/station_map.dm
@@ -119,8 +119,8 @@ var/list/station_holomaps = list()
 	src.attack_hand(user)
 
 /obj/machinery/station_map/attack_ghost(var/mob/user)
-	if(blessed)
-		return
+	if(!can_spook())
+		return FALSE
 	add_hiddenprint(user)
 	flick("station_map_activate", src)
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -327,11 +327,13 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 // Check for last poltergeist activity.
 /mob/dead/observer/proc/can_poltergeist(var/start_cooldown=1)
+	if(isAdminGhost(src))
+		return TRUE
 	if(world.time >= next_poltergeist)
 		if(start_cooldown)
 			start_poltergeist_cooldown()
-		return 1
-	return 0
+		return TRUE
+	return FALSE
 
 /mob/dead/observer/proc/start_poltergeist_cooldown()
 	next_poltergeist=world.time + POLTERGEIST_COOLDOWN

--- a/code/modules/mob/dead/observer/spells.dm
+++ b/code/modules/mob/dead/observer/spells.dm
@@ -56,7 +56,7 @@ var/global/list/boo_phrases_silicon=list(
 /spell/aoe_turf/boo/cast(list/targets)
 	for(var/turf/T in targets)
 		for(var/atom/A in T.contents)
-			if(A.can_spook())
+			if(A.can_spook(0))
 				A.spook(holder)
 
 /* FIXME

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -422,7 +422,7 @@ var/global/list/obj/machinery/light/alllights = list()
 		update(0)
 
 /obj/machinery/light/attack_ghost(mob/user)
-	if(blessed)
+	if(!can_spook())
 		return
 	src.add_hiddenprint(user)
 	src.flicker(1)


### PR DESCRIPTION
This means they can turn light switches on and off as much as they want, basically.

The boo! verb still has a cooldown, just like everyone else.

Leaves chaplain blessing unchanged.

:cl:
* tweak: Adminghosts no longer have to wait on the cooldown for turning on and off light switches.