### PR TITLE
Raises grenadecap to 3 dev, limits water+potass explosions, changes glycerol recipe

### DIFF
--- a/__DEFINES/reagents.dm
+++ b/__DEFINES/reagents.dm
@@ -130,7 +130,6 @@
 #define SPRINKLES 			"sprinkles"
 #define SYNDICREAM 			"syndicream"
 #define CORNOIL 			"cornoil"
-#define DEEPFRYINGOIL 			"deepfryingoil"
 #define ENZYME 			"enzyme"
 #define FLOUR 			"flour"
 #define RICE 			"rice"

--- a/__DEFINES/reagents.dm
+++ b/__DEFINES/reagents.dm
@@ -130,6 +130,7 @@
 #define SPRINKLES 			"sprinkles"
 #define SYNDICREAM 			"syndicream"
 #define CORNOIL 			"cornoil"
+#define DEEPFRYINGOIL 			"deepfryingoil"
 #define ENZYME 			"enzyme"
 #define FLOUR 			"flour"
 #define RICE 			"rice"

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -1066,9 +1066,9 @@ steam.start() -- spawns the effect
 			var/range = 0
 			// Clamp all values to MAX_EXPLOSION_RANGE
 			range = min (MAX_EXPLOSION_RANGE, light + round(amount/3))
-			devastation = round(min(1, range * 0.25)) // clamps to 1 devestation for grenades
-			heavy = round(min(3, range * 0.5)) // clamps to 3 heavy range for grenades
-			light = min(6, range) // clamps to 6 light range for grenades
+			devastation = round(min(3, range * 0.25)) // clamps to 3 devastation for grenades
+			heavy = round(min(5, range * 0.5)) // clamps to 5 heavy range for grenades
+			light = min(7, range) // clamps to 7 light range for grenades
 			flash = range * 1.5
 			/*
 			if (round(amount/12) > 0)

--- a/code/modules/food/cooking_machines.dm
+++ b/code/modules/food/cooking_machines.dm
@@ -391,7 +391,7 @@ var/global/ingredientLimit = 10
 
 /obj/machinery/cooking/deepfryer/initialize()
 	..()
-	reagents.add_reagent(DEEPFRYINGOIL, 300)
+	reagents.add_reagent(CORNOIL, 300)
 
 /obj/machinery/cooking/deepfryer/proc/empty_icon() //sees if the value is empty, and changes the icon if it is
 	reagents.update_total() //make the values refresh

--- a/code/modules/food/cooking_machines.dm
+++ b/code/modules/food/cooking_machines.dm
@@ -391,7 +391,7 @@ var/global/ingredientLimit = 10
 
 /obj/machinery/cooking/deepfryer/initialize()
 	..()
-	reagents.add_reagent(CORNOIL, 300)
+	reagents.add_reagent(DEEPFRYINGOIL, 300)
 
 /obj/machinery/cooking/deepfryer/proc/empty_icon() //sees if the value is empty, and changes the icon if it is
 	reagents.update_total() //make the values refresh

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -3671,11 +3671,6 @@
 		T.assume_air(lowertemp)
 		qdel(hotspot)
 
-/datum/reagent/cornoil/deepfryingoil 
-	name = "Deep-frying Oil" 
-	description = "A special oil bio-chemically engineered for perfect deep-frying."
-	id = DEEPFRYINGOIL
-		
 /datum/reagent/enzyme
 	name = "Universal Enzyme"
 	id = ENZYME

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -3671,6 +3671,11 @@
 		T.assume_air(lowertemp)
 		qdel(hotspot)
 
+/datum/reagent/cornoil/deepfryingoil 
+	name = "Deep-frying Oil" 
+	description = "A special oil bio-chemically engineered for perfect deep-frying."
+	id = DEEPFRYINGOIL
+		
 /datum/reagent/enzyme
 	name = "Universal Enzyme"
 	id = ENZYME

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -408,7 +408,7 @@
 	name = "Glycerol"
 	id = GLYCEROL
 	result = GLYCEROL
-	required_reagents = list(CORNOIL = 3, SACID = 1)
+	required_reagents = list(CORNOIL = 3, FORMIC_ACID = 1)
 	result_amount = 1
 
 /datum/chemical_reaction/nitroglycerin

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -66,7 +66,7 @@
 
 /datum/chemical_reaction/explosion_potassium/on_reaction(var/datum/reagents/holder, var/created_volume)
 	var/datum/effect/effect/system/reagents_explosion/e = new()
-	e.set_up(round (created_volume/10, 1), holder.my_atom, 0, 0)
+	e.set_up(min(round (created_volume/10, 1), 15), holder.my_atom, 0, 0)
 	e.holder_damage(holder.my_atom)
 	if(isliving(holder.my_atom))
 		e.amount *= 0.5


### PR DESCRIPTION
This raises the grenade explosion cap to 3,5,7.
You need about 144 corn oil to hit that.
Water + potassium reactions are mathemagically hard-limited to 1,2,4.
Glycerol is now made with corn oil + formic acid, meaning at least *some* botany is required,

I made this because I felt nitroglycerin is completely useless right now.
Values are up for discussion. I did some testing and figured 3,5,7 wasn't so bad.

Resolves #6128!

New grenade cap (Nitroglycerin, 3,5,7):
![nitro](https://user-images.githubusercontent.com/8468269/29779686-95460078-8c13-11e7-8f43-afa2990ce1b8.png)

**NEW** Water + Potassium cap (1,2,4):
![waterpotassnew](https://user-images.githubusercontent.com/8468269/29779923-4e183332-8c14-11e7-9dc4-cae0e973f17b.png)

*OLD* grenadecap (Water + Potassium or Nitroglycerin, 1,3,6)
![waterpotassold](https://user-images.githubusercontent.com/8468269/29780505-55e56eca-8c16-11e7-99e9-bbd3d2f1d524.png)

TODO:
- [x] update wiki

🆑 
 - tweak: the grenade explosion cap has been raised to 3, 5, 7
 - tweak: water/potassium explosions are now limited to 1, 2, 4
 - tweak: glycerol is now made with formic acid rather than sulphuric acid