### PR TITLE
Teleporting using scroll/spell is now logged

### DIFF
--- a/code/game/objects/items/weapons/scrolls.dm
+++ b/code/game/objects/items/weapons/scrolls.dm
@@ -98,3 +98,5 @@
 
 	smoke.start()
 	src.uses -= 1
+
+	log_game("[key_name(user)] teleported to [thearea.name] using a scroll.")

--- a/code/modules/spells/general/area_teleport.dm
+++ b/code/modules/spells/general/area_teleport.dm
@@ -70,6 +70,8 @@
 	if(!success)
 		user.forceMove(pick(L))
 
+	log_game("[key_name(user)] teleported to [thearea.name] using the teleportation spell.")
+
 /spell/area_teleport/after_cast()
 	return
 


### PR DESCRIPTION
Because you can't rely on the incantation as the log of teleporting.