### PR TITLE
Removes the ability to use items over large distances through cameras

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -126,15 +126,20 @@
 
 	//Clicked on a non-adjacent atom
 	else
-		var/view_range = get_view_range() + 2 //Extend clickable zone by 2 tiles to allow clicking on the edge of the screen while moving
-		var/atom_distance = get_dist(A, src) //Distance from the clicker to the clickee
+		//If the player's view is not centered on the mob, check how far the clicked object is from the mob
+		//This is to prevent abuse with remote view / camera consoles
+		if(client && client.eye && client.eye != client.mob)
+			var/view_range = get_view_range() + 2 //Extend clickable zone by 2 tiles to allow clicking on the edge of the screen while the camera is moving
+			var/atom_distance = get_dist(A, src)  //Distance from the player's mob to the clicked atom
 
-		if(atom_distance <= view_range)
-			//Clicked on a non-adjacent atom in view
-			RangedClickOn(A, params, held_item)
+			if(atom_distance <= view_range)
+				//Clicked on a non-adjacent atom in view
+				RangedClickOn(A, params, held_item)
+			else
+				//Clicked on a non-adjacent atom that is not in view
+				RemoteClickOn(A, params, held_item, client.eye)
 		else
-			//Clicked on a non-adjacent atom that is not in view
-			RemoteClickOn(A, params, held_item)
+			RangedClickOn(A, params, held_item)
 
 /mob/proc/RangedClickOn(atom/A, params, obj/item/held_item)
 	if(held_item)
@@ -151,8 +156,9 @@
 		RangedAttack(A, params)
 
 //By default, do nothing if clicked on something that is not in view
-/mob/proc/RemoteClickOn(atom/A, params, obj/item/held_item)
-	return
+/mob/proc/RemoteClickOn(atom/A, params, obj/item/held_item, atom/movable/eye)
+	if(held_item)
+		held_item.remote_attack(A, src, eye)
 
 // Default behavior: ignore double clicks, consider them normal clicks instead
 /mob/proc/DblClickOn(var/atom/A, var/params)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -87,57 +87,71 @@
 		throw_item(A)
 		return
 
-	var/obj/item/W = get_active_hand()
+	var/obj/item/held_item = get_active_hand()
 	var/item_attack_delay = 0
 
-	if(W == A)
-		/*next_move = world.time + 6
-		if(W.flags&USEDELAY)
-			next_move += 5*/
-		W.attack_self(src, params)
+	if(held_item == A)
+		held_item.attack_self(src, params)
 		update_inv_hand(active_hand)
 
 		return
 
 	if(!isturf(loc) && !is_holder_of(src, A))
 		if(loc == A) //Can attack_hand our holder (a locked closet, for example) from inside, but can't hit it with a tool
-			if(W)
+			if(held_item)
 				return
 		else
 			return
 
-	// Allows you to click on a box's contents, if that box is on the ground, but no deeper than that
+	//Clicked on an adjacent atom
+	// - Allows you to click on a box's contents, if that box is on the ground, but no deeper than that
 	if(A.Adjacent(src, MAX_ITEM_DEPTH)) // see adjacent.dm
-		if(W)
-			item_attack_delay = W.attack_delay
-			var/resolved = W.preattack(A, src, 1, params)
+		if(held_item)
+			item_attack_delay = held_item.attack_delay
+			var/resolved = held_item.preattack(A, src, 1, params)
 			if(!resolved)
-				resolved = A.attackby(W,src, params)
-				if(ismob(A) || istype(A, /obj/mecha) || istype(W, /obj/item/weapon/grab))
+				resolved = A.attackby(held_item, src, params)
+				if(ismob(A) || istype(A, /obj/mecha) || istype(held_item, /obj/item/weapon/grab))
 					delayNextAttack(item_attack_delay)
-				if(!resolved && A && W)
-					W.afterattack(A,src,1,params) // 1 indicates adjacency
+				if(!resolved && A && held_item)
+					held_item.afterattack(A,src,1,params) // 1 indicates adjacency
 				else
 					delayNextAttack(item_attack_delay)
 		else
-			if(ismob(A) || istype(W, /obj/item/weapon/grab))
+			if(ismob(A) || istype(held_item, /obj/item/weapon/grab))
 				delayNextAttack(10)
 			if(INVOKE_EVENT(on_uattack,list("atom"=A))) //This returns 1 when doing an action intercept
 				return
 			UnarmedAttack(A, 1, params)
-		return
-	else // non-adjacent click
-		if(W)
-			if(ismob(A))
-				delayNextAttack(item_attack_delay)
-			if(!W.preattack(A, src, 0,  params))
-				W.afterattack(A,src,0,params) // 0: not Adjacent
+
+	//Clicked on a non-adjacent atom
+	else
+		var/view_range = get_view_range() + 2 //Extend clickable zone by 2 tiles to allow clicking on the edge of the screen while moving
+		var/atom_distance = get_dist(A, src) //Distance from the clicker to the clickee
+
+		if(atom_distance <= view_range)
+			//Clicked on a non-adjacent atom in view
+			RangedClickOn(A, params, held_item)
 		else
-			if(ismob(A))
-				delayNextAttack(10)
-			if(INVOKE_EVENT(on_uattack,list("atom"=A))) //This returns 1 when doing an action intercept
-				return
-			RangedAttack(A, params)
+			//Clicked on a non-adjacent atom that is not in view
+			RemoteClickOn(A, params, held_item)
+
+/mob/proc/RangedClickOn(atom/A, params, obj/item/held_item)
+	if(held_item)
+		if(ismob(A))
+			delayNextAttack(held_item.attack_delay)
+
+		if(!held_item.preattack(A, src, 0,  params))
+			held_item.afterattack(A,src,0,params) // 0: not Adjacent
+	else
+		if(ismob(A))
+			delayNextAttack(10)
+		if(INVOKE_EVENT(on_uattack,list("atom"=A))) //This returns 1 when doing an action intercept
+			return
+		RangedAttack(A, params)
+
+//By default, do nothing if clicked on something that is not in view
+/mob/proc/RemoteClickOn(atom/A, params, obj/item/held_item)
 	return
 
 // Default behavior: ignore double clicks, consider them normal clicks instead

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1202,3 +1202,7 @@ var/global/list/image/blood_overlays = list()
 
 /obj/item/proc/on_restraint_apply(var/mob/living/carbon/C)
 	return
+
+//Called when user clicks on an object while looking through a camera (passed to the proc as [eye])
+/obj/item/proc/remote_attack(atom/target, mob/user, atom/movable/eye)
+	return

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1879,6 +1879,11 @@ mob/proc/on_foot()
 /mob/acidable()
 	return 1
 
+/mob/proc/get_view_range()
+	if(client)
+		return client.view
+	return world.view
+
 /mob/proc/apply_vision_overrides()
 	if(see_in_dark_override)
 		see_in_dark = see_in_dark_override

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -576,6 +576,10 @@
 			icon_state = icon_on
 			on = 1
 
+/obj/item/device/camera/remote_attack(atom/target, mob/user, atom/movable/eye)
+	if(istype(eye, /obj/machinery/camera))
+		return afterattack(target, user) //Allow taking photos when looking through cameras
+
 /obj/item/device/camera/ai_camera/proc/toggle_camera_mode()
 	if(in_camera_mode)
 		camera_mode_off()

--- a/code/modules/projectiles/guns/projectile/constructable/subspacetunneler.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/subspacetunneler.dm
@@ -202,6 +202,9 @@
 			receive(target,user)
 			return
 
+/obj/item/weapon/subspacetunneler/remote_attack(atom/target, mob/user, atom/movable/eye)
+	return afterattack(target, user) //Allow using the tunneler through cameras and remote view
+
 /obj/item/weapon/subspacetunneler/proc/send(turf/T as turf, mob/living/user as mob|obj)
 	if(!T)
 		T = get_random_nearby_turf()


### PR DESCRIPTION
You can no longer click on stuff that's too far away from you

Prime offenders were gravity wells, as you could devastate the entire station from complete safety with a gravity well and a camera console / remote view power. Other items that could be abused were photo cameras and subspace tunnelers.

This PR will allow using cameras to take photos through camera computers, but not through the remote view power.

:cl:
 * bugfix: You can no longer use most items or telekinesis through security cameras or remote view.
 * tweak: Polaroids can take photos through security cameras. Subspace tunnelers can be used through both cameras and remote view.
