### PR TITLE
Debugging login sequence.

### DIFF
--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -1,5 +1,17 @@
 //handles setting lastKnownIP and computer_id for use by the ban systems as well as checking for multikeying
 /mob/proc/update_Login_details()
+	if(!client)
+		WARNING("update_Login_details(): client for [src] is [client]!")
+		message_admins("<span class='warning'><B>WARNING:</B> <A href='?src=\ref[usr];priv_msg=\ref[src]'>[key_name_admin(src)]</A> has a null .client (BYOND issue, not malicious)!</span>", 1)
+
+	else
+		if(!client.address)
+			WARNING("update_Login_details(): client.address for [src] is [client.address]!")
+			message_admins("<span class='warning'><B>WARNING:</B> <A href='?src=\ref[usr];priv_msg=\ref[src]'>[key_name_admin(src)]</A> has a null .client.address (BYOND issue, not malicious)!</span>", 1)
+		if(!client.computer_id)
+			WARNING("update_Login_details(): client.computer_id for [src] is [client.computer_id]!")
+			message_admins("<span class='warning'><B>WARNING:</B> <A href='?src=\ref[usr];priv_msg=\ref[src]'>[key_name_admin(src)]</A> has a null .client.computer_id (BYOND issue, not malicious)!</span>", 1)
+
 	//Multikey checks and logging
 	lastKnownIP	= client.address
 	computer_id	= client.computer_id


### PR DESCRIPTION
# Executive Summary
Current theory as to why client prefs are failing to load (among other bugs) is that .client isn't being completely populated by BYOND, or is even null, during Login().  This will find out.

# Full Explanation
Currently, we assume that login is conducted in a synchronous manner.  This means that SS13 expects .client and all .client fields to be filled when Login() is sent.  If they are not, bad things will happen.  While discussing possible causes for client pref failures, some weird runtimes about null clients appeared in logs.  While these could just be flukes caused by out-of-memory exceptions blocking assignment, I'd like to double-check.

My current hypothesis is that Lummox is experimenting with *asynchronous* logins in 511+, which means that some stuff isn't sent with the Login() and arrives later.  This would result in .client being null during login, and possibly empty or null fields.

# Changelog
Nothing clients should see, other than some new logspam for admins

# References
* #15360 
* #15684 
* #15331 
* #15260 
* Black screen issues