### PR TITLE
Removes some lag from map loader

### DIFF
--- a/code/datums/map_elements.dm
+++ b/code/datums/map_elements.dm
@@ -8,6 +8,7 @@ var/list/datum/map_element/map_elements = list()
 	var/type_abbreviation //Very short string that determines the map element's type (whether it's an away mission, a small vault, or something else)
 
 	var/file_path = "maps/randomvaults/new.dmm"
+	var/load_at_once = FALSE //If true, lag reduction methods will not be applied when this is loaded, freezing atmos and mob simulations until the map element is loaded.
 
 	var/turf/location //Lower left turf of the map element
 

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -45,6 +45,11 @@ var/area/space_area
 //	spawn(15)
 	power_change()		// all machines set to current power level, also updates lighting icon
 
+/area/spawned_by_map_element(datum/map_element/ME, list/objects)
+	..()
+
+	power_change()
+
 /area/Destroy()
 	..()
 	areaapc = null

--- a/code/game/objects/structures/ladders.dm
+++ b/code/game/objects/structures/ladders.dm
@@ -28,7 +28,8 @@ var/list/ladders = list()
 
 	switch(variable_name)
 		if("down", "up", "height", "id")
-			update_links()
+			spawn()
+				update_links()
 
 /obj/structure/ladder/Destroy()
 	..()

--- a/code/game/objects/structures/ladders.dm
+++ b/code/game/objects/structures/ladders.dm
@@ -19,6 +19,17 @@ var/list/ladders = list()
 	spawn(10)
 		update_links()
 
+/obj/structure/ladder/spawned_by_map_element(datum/map_element/ME, list/objects)
+	..()
+	update_links()
+
+/obj/structure/ladder/variable_edited(variable_name, old_value, new_value)
+	..()
+
+	switch(variable_name)
+		if("down", "up", "height", "id")
+			update_links()
+
 /obj/structure/ladder/Destroy()
 	..()
 

--- a/code/modules/awaymissions/maploader/dmm_suite.dm
+++ b/code/modules/awaymissions/maploader/dmm_suite.dm
@@ -53,9 +53,11 @@ dmm_suite{
 
 		*/
 
-	verb/load_map(var/dmm_file as file, var/z_offset as num, var/x_offset as num, var/y_offset as num, var/datum/map_element/map_element as null){
+	verb/load_map(var/dmm_file as file, var/z_offset as num, var/x_offset as num, var/y_offset as num, var/datum/map_element/map_element as null, var/fast_load as null){
 		// dmm_file: A .dmm file to load (Required).
 		// z_offset: A number representing the z-level on which to start loading the map (Optional).
+		// map_element: The map element that the .dmm file belongs to (Optional).
+		// fast_load: If true,
 		}
 	verb/write_map(var/turf/t1 as turf, var/turf/t2 as turf, var/flags as num){
 		// t1: A turf representing one corner of a three dimensional grid (Required).

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -137,7 +137,8 @@ var/list/map_dimension_cache = list()
 
 			ycrd--
 
-			sleep(-1)
+			if(ticker) //If the game has already started, perform some lag reduction procedures.
+				CHECK_TICK
 
 		if(map_element)
 			map_element.height = y_depth

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -61,6 +61,14 @@ var/list/map_dimension_cache = list()
 	if(!z_offset)//what z_level we are creating the map on
 		z_offset = world.maxz+1
 
+	//If this is true, the lag is reduced at the cost of slower loading speed, and tiny atmos leaks during loading
+	var/remove_lag
+	if(map_element.load_at_once)
+		remove_lag = FALSE
+	else if(ticker && ticker.current_state > GAME_STATE_PREGAME)
+		//Lag doesn't matter before the game
+		remove_lag = TRUE
+
 	var/list/spawned_atoms = list()
 
 	var/quote = ascii2text(34)
@@ -137,8 +145,10 @@ var/list/map_dimension_cache = list()
 
 			ycrd--
 
-			if(ticker) //If the game has already started, perform some lag reduction procedures.
+			if(remove_lag)
 				CHECK_TICK
+			else
+				sleep(-1)
 
 		if(map_element)
 			map_element.height = y_depth

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -29,18 +29,27 @@
 
 /obj/machinery/power/initialize()
 	..()
+
 	if(starting_terminal)
-		for(var/d in cardinal)
-			var/turf/T = get_step(src, d)
-			for(var/obj/machinery/power/terminal/term in T)
-				if(term && term.dir == turn(d, 180))
-					terminal = term
-					break
-			if(terminal)
+		find_terminal()
+
+/obj/machinery/power/spawned_by_map_element()
+	..()
+
+	find_terminal()
+
+/obj/machinery/power/proc/find_terminal()
+	for(var/d in cardinal)
+		var/turf/T = get_step(src, d)
+		for(var/obj/machinery/power/terminal/term in T)
+			if(term && term.dir == turn(d, 180))
+				terminal = term
 				break
 		if(terminal)
-			terminal.master = src
-			update_icon()
+			break
+	if(terminal)
+		terminal.master = src
+		update_icon()
 
 /obj/machinery/power/Destroy()
 	disconnect_from_network()
@@ -82,7 +91,7 @@
 		return powernet.load
 	else
 		return 0
-		
+
 /obj/machinery/power/proc/get_powernet()
 	check_rebuild()
 	return powernet

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -50,6 +50,11 @@ var/list/smes_list = list()
 		if(!terminal)
 			stat |= BROKEN
 
+/obj/machinery/power/battery/smes/spawned_by_map_element()
+	..()
+
+	initialize()
+
 /obj/machinery/power/battery/smes/attackby(var/obj/item/weapon/W as obj, var/mob/user as mob) //these can only be moved by being reconstructed, solves having to remake the powernet.
 	if(iscrowbar(W) && panel_open && terminal)
 		to_chat(user, "<span class='warning'>You must first cut the terminal from the SMES!</span>")


### PR DESCRIPTION
Removes some of the lag when maps are loaded mid-round. The game still freezes for 10-20 seconds when a new z-level is created. After that, however, the game is playable.

The tradeoff is that the maps are loaded more slowly, and there's a possibility (I tested this on a few maps and haven't encountered it, but it might still exist) of air/mobs moving through unloaded turfs while loading. I have to test it a bit more
