### PR TITLE
Changes the cost of picos to plasma.

### DIFF
--- a/code/modules/research/designs/stock_parts.dm
+++ b/code/modules/research/designs/stock_parts.dm
@@ -129,7 +129,7 @@
 	id = "pico_mani"
 	req_tech = list(Tc_MATERIALS = 5, Tc_PROGRAMMING = 2)
 	build_type = PROTOLATHE
-	materials = list(MAT_IRON = 40, MAT_PLASMA = 20)
+	materials = list(MAT_IRON = 40, MAT_PLASMA = 40)
 	reliability_base = 73
 	category = "Stock Parts"
 	build_path = /obj/item/weapon/stock_parts/manipulator/nano/pico

--- a/code/modules/research/designs/stock_parts.dm
+++ b/code/modules/research/designs/stock_parts.dm
@@ -129,7 +129,7 @@
 	id = "pico_mani"
 	req_tech = list(Tc_MATERIALS = 5, Tc_PROGRAMMING = 2)
 	build_type = PROTOLATHE
-	materials = list(MAT_IRON = 30, MAT_URANIUM = 10, MAT_SILVER = 20)
+	materials = list(MAT_IRON = 40, MAT_PLASMA = 20)
 	reliability_base = 73
 	category = "Stock Parts"
 	build_path = /obj/item/weapon/stock_parts/manipulator/nano/pico


### PR DESCRIPTION
Changes the cost of pico manipulators to use plasma in place of the silver and uranium. Plasma is hardly used for anything in the protolathe and plasma isn't used in any other upgrade stock parts so this will finally give a use for the stack of 10,000 sheets of plasma miners hurl at mechanics and science.
:cl:
* tweak: Pico manipulators now use plasma in place of the old materials.