### PR TITLE
Slimes now split at least one new color.

### DIFF
--- a/code/modules/mob/living/carbon/slime/life.dm
+++ b/code/modules/mob/living/carbon/slime/life.dm
@@ -372,6 +372,8 @@
 						newslime = primarytype
 					else
 						newslime = slime_mutation[rand(1,4)]
+					if(i == 4)
+						newslime = slime_mutation[rand(1,4)]
 
 					var/mob/living/carbon/slime/M = new newslime(loc)
 					M.powerlevel = round(powerlevel/4)

--- a/code/modules/mob/living/carbon/slime/powers.dm
+++ b/code/modules/mob/living/carbon/slime/powers.dm
@@ -249,6 +249,8 @@
 					newslime = primarytype
 				else
 					newslime = slime_mutation[rand(1,4)]
+				if(i == 4)
+					newslime = slime_mutation[rand(1,4)]
 
 				var/mob/living/carbon/slime/M = new newslime(loc)
 				M.nutrition = new_nutrition


### PR DESCRIPTION
Exactly what's on the tin, this makes it so when a slime splits(player or AI) it has at least one new color. **This does not mean it makes you advance forward faster exactly**, it also means that you can be forced backwards/in the wrong direction over and over. All this does is prevent you from getting four of the exact same slime in a split. This will likely prevent hair pulling and suicidal thoughts of many xenobiologists.
:cl:
* tweak: Slimes now split into at least one different color. This does not always mean forward in the slime gene paths.