### PR TITLE
Possible fix to overlapping dungeons

### DIFF
--- a/code/datums/map_elements.dm
+++ b/code/datums/map_elements.dm
@@ -52,6 +52,12 @@ var/list/datum/map_element/map_elements = list()
 
 	return list(width, height)
 
+/datum/map_element/proc/assign_dimensions()
+	var/list/dimensions = get_dimensions()
+
+	width = dimensions[1]
+	height = dimensions[2]
+
 //Return a list with strings associated with points
 //For example: list("Discovered a vault!" = 500) will add 500 points to the crew's score for discovering a vault
 /datum/map_element/proc/process_scoreboard()

--- a/code/modules/randomMaps/dungeons.dm
+++ b/code/modules/randomMaps/dungeons.dm
@@ -44,8 +44,8 @@ proc/load_dungeon(dungeon_type)
 	//Highest dungeon in the current row
 
 	for(var/datum/map_element/dungeon in existing_dungeons) //Go through all dungeons in the order they were created
-		if(!dungeon.location)
-			continue
+		//if(!dungeon.location)
+		//	continue
 
 		if(dungeon.height > tallest_dungeon_height)
 			tallest_dungeon_height = dungeon.height

--- a/code/modules/randomMaps/dungeons.dm
+++ b/code/modules/randomMaps/dungeons.dm
@@ -63,8 +63,11 @@ proc/load_dungeon(dungeon_type)
 				spawn_y = spawn_y + tallest_dungeon_height + 1 //So that nothing in the new row overlaps with the previous one
 				spawn_x = dungeon_area.x
 
+	if(!ME.width) //If the map element doesn't have its width/height calculated yet, do it now and add the map element to the dungeon list
+		ME.assign_dimensions()
+	existing_dungeons.Add(ME) //Add it now, to prevent issues occuring when two dungeons are loaded at once
+
 	//Reduce X and Y by 1 because these arguments are actually offsets, and they're added to 1;1 in the map loader. Without this, spawning something at 1;1 would result in it getting spawned at 2;2
 	var/result = ME.load(spawn_x - 1, spawn_y - 1, dungeon_area.z)
-	existing_dungeons.Add(ME)
 
 	return result


### PR DESCRIPTION
#14144

I don't know the exact cause of that bug but this might be it. The dungeons were added to the dungeon list only after they were fully loaded, so if a second dungeon started loading alongside the first one, they'd overlap