### PR TITLE
Fixes the smartfridge soldering function

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -692,32 +692,27 @@ obj/item/weapon/circuitboard/rdserver
 
 
 
-/obj/item/weapon/circuitboard/smartfridge/attackby(var/obj/item/weapon/G, var/mob/user)
-	if(issolder(G))
-		var/obj/item/weapon/solder/S = G
-		var/list/static/smartfridge_choices = list(
-			"Food smartfridge" = /obj/item/weapon/circuitboard/smartfridge/,
-			"Secure chemistry smartfridge" = /obj/item/weapon/circuitboard/smartfridge/medbay,
-			"Chemistry smartfridge" = /obj/item/weapon/circuitboard/smartfridge/chemistry,
-			"Slime extract smartfridge" = /obj/item/weapon/circuitboard/smartfridge/extract,
-			"Seed smartfridge" = /obj/item/weapon/circuitboard/smartfridge/seeds,
-			"Drinks smartfridge" = /obj/item/weapon/circuitboard/smartfridge/drinks,
-		)
+/obj/item/weapon/circuitboard/smartfridge/solder_improve(mob/user)
+	var/list/static/smartfridge_choices = list(
+		"Food smartfridge" = /obj/item/weapon/circuitboard/smartfridge/,
+		"Secure chemistry smartfridge" = /obj/item/weapon/circuitboard/smartfridge/medbay,
+		"Chemistry smartfridge" = /obj/item/weapon/circuitboard/smartfridge/chemistry,
+		"Slime extract smartfridge" = /obj/item/weapon/circuitboard/smartfridge/extract,
+		"Seed smartfridge" = /obj/item/weapon/circuitboard/smartfridge/seeds,
+		"Drinks smartfridge" = /obj/item/weapon/circuitboard/smartfridge/drinks,
+	)
 
-		var/choice = input(usr, "Which configuration would you like to set this board?", "According to the manual, if I disconnect this node, and connect this node...") in smartfridge_choices
-		if(choice)
-			var/obj/item/weapon/circuitboard/smartfridge/to_spawn = smartfridge_choices[choice]
-			if(istype(src, to_spawn))
-				to_chat(user, "<span class = 'notice'>This board is already this type</span>")
-				return
-			if(do_after(user, src, 25))
-				if(S.remove_fuel(1,user))
-					playsound(user.loc, 'sound/items/Welder.ogg', 25, 1)
-					visible_message("<span class = 'notice'>\The [user] refashions \the [src] into \the [to_spawn]</span>")
-					build_path = initial(to_spawn.build_path)
-					name = initial(to_spawn.name)
-					return
-	..()
+	var/choice = input(usr, "Which configuration would you like to set this board?", "According to the manual, if I disconnect this node, and connect this node...") in smartfridge_choices
+	if(choice)
+		var/to_spawn = smartfridge_choices[choice]
+		if(src.type == to_spawn)
+			to_chat(user, "<span class = 'notice'>This board is already this type</span>")
+			return
+		if(do_after(user, src, 25))
+			var/spawned = new to_spawn(get_turf(src))
+			visible_message("<span class = 'notice'>\The [user] refashions \the [src] into \the [spawned]</span>")
+			qdel(src)
+
 /obj/item/weapon/circuitboard/smartfridge/medbay
 	name = "Circuit Board (Medbay SmartFridge)"
 	desc = "A circuit board used to run a machine that will hold beakers, pills and pill bottles."


### PR DESCRIPTION
Was looking through the soldering iron and its functions, and found an odd chunk of code that wasn't using the solder_improve proc, and was generally poorly formatted to the point it would print out things like' \The [user] refashions \the Circuit Board (Medbay SmartFridge) into \the /obj/item/weapon/circuitboard/smartfridge/drinks'