### PR TITLE
stops ghosts from removing things from deepfryers

### DIFF
--- a/code/__HELPERS/_macros.dm
+++ b/code/__HELPERS/_macros.dm
@@ -93,6 +93,8 @@
 
 #define isobserver(A) istype(A, /mob/dead/observer)
 
+#define isjustobserver(A) (isobserver(A) && !isAdminGhost(A))
+
 #define isnewplayer(A) istype(A, /mob/new_player)
 
 #define isovermind(A) istype(A, /mob/camera/blob)

--- a/code/modules/food/cooking_machines.dm
+++ b/code/modules/food/cooking_machines.dm
@@ -170,6 +170,9 @@ var/global/ingredientLimit = 10
 	set category = "Object"
 	set src in oview(1)
 
+	if(ghostCheck(usr))
+		return
+
 	if(cooks_in_reagents)
 		if(do_after(usr, src, src.reagents.total_volume / 10))
 			src.reagents.clear_reagents()

--- a/code/modules/food/cooking_machines.dm
+++ b/code/modules/food/cooking_machines.dm
@@ -170,7 +170,7 @@ var/global/ingredientLimit = 10
 	set category = "Object"
 	set src in oview(1)
 
-	if(ghostCheck(usr))
+	if(isjustobserver(usr))
 		return
 
 	if(cooks_in_reagents)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -104,6 +104,10 @@ mob/proc/remove_internal_organ()
 			return 1
 	return 0
 
+/proc/ghostCheck(A) //Ghostbusters. Returns 1 if it's a ghost, returns 0 if they're an adminghost or otherwise
+	if(isobserver(A) && !isAdminGhost(A))
+		return 1
+	return 0
 
 /proc/canGhostRead(var/mob/A, var/obj/target, var/flags=PERMIT_ALL)
 	if(isAdminGhost(A))

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -104,11 +104,6 @@ mob/proc/remove_internal_organ()
 			return 1
 	return 0
 
-/proc/ghostCheck(A) //Ghostbusters. Returns 1 if it's a ghost, returns 0 if they're an adminghost or otherwise
-	if(isobserver(A) && !isAdminGhost(A))
-		return 1
-	return 0
-
 /proc/canGhostRead(var/mob/A, var/obj/target, var/flags=PERMIT_ALL)
 	if(isAdminGhost(A))
 		return 1


### PR DESCRIPTION
What it says in the title, stops ghosts from using the verb to remove things from deep fryers.

Also adds a proc to check if a user is a ghost, but is not an adminghost, as one of similar functionality seemed to be absent.

If the proc passes inspection, I'll get onto things in #14223

closes #15894

