### PR TITLE
Speech from atoms inside containers will now be properly made bold to…

### DIFF
--- a/code/modules/mob/dead/observer/say.dm
+++ b/code/modules/mob/dead/observer/say.dm
@@ -33,7 +33,7 @@
 
 	say_testing(src, "/mob/dead/observer/Hear(): source=[source], frequency=[speech.frequency], source_turf=[formatJumpTo(source_turf)]")
 
-	if (get_dist(source_turf, src) <= world.view) // If this isn't true, we can't be in view, so no need for costlier proc.
+	if (get_dist(source_turf, src) <= client ? client.view : world.view) // If this isn't true, we can't be in view, so no need for costlier proc.
 		rendered_speech = "<B>[rendered_speech]</B>"
 	else
 		if(client && client.prefs)

--- a/code/modules/mob/dead/observer/say.dm
+++ b/code/modules/mob/dead/observer/say.dm
@@ -34,8 +34,7 @@
 	say_testing(src, "/mob/dead/observer/Hear(): source=[source], frequency=[speech.frequency], source_turf=[formatJumpTo(source_turf)]")
 
 	if (get_dist(source_turf, src) <= world.view) // If this isn't true, we can't be in view, so no need for costlier proc.
-		if (source_turf in view(src))
-			rendered_speech = "<B>[rendered_speech]</B>"
+		rendered_speech = "<B>[rendered_speech]</B>"
 	else
 		if(client && client.prefs)
 			if (!speech.frequency)

--- a/code/modules/mob/dead/observer/say.dm
+++ b/code/modules/mob/dead/observer/say.dm
@@ -33,7 +33,7 @@
 
 	say_testing(src, "/mob/dead/observer/Hear(): source=[source], frequency=[speech.frequency], source_turf=[formatJumpTo(source_turf)]")
 
-	if (get_dist(source_turf, src) <= client ? client.view : world.view) // If this isn't true, we can't be in view, so no need for costlier proc.
+	if (get_dist(source_turf, src) <= get_view_range())
 		rendered_speech = "<B>[rendered_speech]</B>"
 	else
 		if(client && client.prefs)


### PR DESCRIPTION
… observers in vision range

Basically, before this PR: Be ghost, (Follow) X, X goes inside a closet, X speaks, the text is not bold despite being in your view.

I _think_ doing it this way is okay because ghost vision shouldn't be obstructed anyway, therefore a simple distance check should suffice, right?

This is my most nitpicky change as of yet.