### PR TITLE
Immovable rods are now immune to teleportation via portal/wormholes

### DIFF
--- a/code/modules/events/immovablerod.dm
+++ b/code/modules/events/immovablerod.dm
@@ -171,7 +171,7 @@
 		if(prob(50))
 			clong()
 
-/obj/item/projectile/immovablerod/forceMove(atom/destination,var/no_tp=0)
+/obj/item/projectile/immovablerod/forceMove(atom/destination,var/no_tp=1)
 	..()
 	if(z != starting.z)
 		qdel(src)


### PR DESCRIPTION
As amusing as it is, it's supposed to be immovable.
And teleporting around during a wormhole event causes EXTREME amounts of destruction that you have no chance of avoiding.