### PR TITLE
Freezer/heater tweaks

### DIFF
--- a/code/ATMOSPHERICS/components/unary/cold_sink.dm
+++ b/code/ATMOSPHERICS/components/unary/cold_sink.dm
@@ -28,6 +28,6 @@
 
 	//todo: have current temperature affected. require power to bring down current temperature again
 
-	if(abs(old_temperature-air_contents.temperature) > 1)
+	if(abs(old_temperature-air_contents.temperature) > 0.1)
 		network.update = 1
 	return 1

--- a/code/ATMOSPHERICS/components/unary/heat_source.dm
+++ b/code/ATMOSPHERICS/components/unary/heat_source.dm
@@ -30,6 +30,6 @@
 
 	//todo: have current temperature affected. require power to bring up current temperature again
 
-	if(abs(old_temperature-air_contents.temperature) > 1)
+	if(abs(old_temperature-air_contents.temperature) > 0.1)
 		network.update = 1
 	return 1

--- a/code/game/machinery/Freezer.dm
+++ b/code/game/machinery/Freezer.dm
@@ -2,7 +2,7 @@
 #define FREEZER_MAX_TEMPERATURE T20C
 
 /obj/machinery/atmospherics/unary/cold_sink/freezer
-	name = "Freezer"
+	name = "freezer"
 	icon = 'icons/obj/Cryogenic2.dmi'
 	icon_state = "freezer_0"
 	density = 1
@@ -53,32 +53,24 @@
 	else
 		icon_state = "freezer_0"
 	..()
-/obj/machinery/atmospherics/unary/cold_sink/freezer/attack_ai(mob/user as mob)
-	src.add_hiddenprint(user)
-	return src.attack_hand(user)
-
-/obj/machinery/atmospherics/unary/cold_sink/freezer/attack_paw(mob/user as mob)
-	return src.attack_hand(user)
 
 /obj/machinery/atmospherics/unary/cold_sink/freezer/crowbarDestroy(mob/user)
-	if(src.on || anchored)
+	if(on)
+		to_chat(user, "You have to turn off the \[src]!")
 		return
 	return ..()
 
 /obj/machinery/atmospherics/unary/cold_sink/freezer/togglePanelOpen(var/obj/toggleitem, mob/user)
-	if(anchored)
-		to_chat(user, "You have to unanchor the [src] first!")
-		return
-	if(src.on)
-		to_chat(user, "You have to turn off the [src]!")
+	if(on)
+		to_chat(user, "You have to turn off \the [src]!")
 		return
 	return ..()
 
 /obj/machinery/atmospherics/unary/cold_sink/freezer/wrenchAnchor(mob/user)
-	if(src.on)
-		to_chat(user, "You have to turn off the [src] first!")
-		return
-	..()
+	if(on)
+		to_chat(user, "You have to turn off \the [src] first!")
+		return -1
+	. = ..()
 	if(!anchored)
 		verbs += rotate_verbs
 		if(node)
@@ -94,11 +86,6 @@
 		if (node)
 			node.initialize()
 			node.build_network()
-	return
-
-/obj/machinery/atmospherics/unary/cold_sink/freezer/attackby(var/obj/item/weapon/W as obj, var/mob/user as mob)
-	..()
-
 
 /obj/machinery/atmospherics/unary/cold_sink/freezer/attack_hand(mob/user as mob)
 	user.set_machine(src)
@@ -184,7 +171,7 @@
 #define HEATER_MAX_TEMPERATURE T20C + 280
 
 /obj/machinery/atmospherics/unary/heat_reservoir/heater
-	name = "Heater"
+	name = "heater"
 	icon = 'icons/obj/Cryogenic2.dmi'
 	icon_state = "freezer_0"
 	density = 1
@@ -236,32 +223,23 @@
 	..()
 	return
 
-/obj/machinery/atmospherics/unary/heat_reservoir/heater/attack_ai(mob/user as mob)
-	src.add_hiddenprint(user)
-	return src.attack_hand(user)
-
-/obj/machinery/atmospherics/unary/heat_reservoir/heater/attack_paw(mob/user as mob)
-	return src.attack_hand(user)
-
 /obj/machinery/atmospherics/unary/heat_reservoir/heater/crowbarDestroy(mob/user)
-	if(src.on || anchored)
+	if(on)
+		to_chat(user, "You have to turn off the \[src]!")
 		return
 	return ..()
 
 /obj/machinery/atmospherics/unary/heat_reservoir/heater/togglePanelOpen(var/obj/toggleitem, mob/user)
-	if(anchored)
-		to_chat(user, "You have to unanchor the [src] first!")
-		return
-	if(src.on)
-		to_chat(user, "You have to turn off the [src]!")
+	if(on)
+		to_chat(user, "You have to turn off the \[src]!")
 		return
 	return ..()
 
 /obj/machinery/atmospherics/unary/heat_reservoir/heater/wrenchAnchor(mob/user)
-	if(src.on)
-		to_chat(user, "You have to turn off the [src] first!")
-		return
-	..()
+	if(on)
+		to_chat(user, "You have to turn off \the [src] first!")
+		return -1
+	. = ..()
 	if(!anchored)
 		verbs += rotate_verbs
 		if(node)
@@ -277,10 +255,6 @@
 		if (node)
 			node.initialize()
 			node.build_network()
-	return
-
-/obj/machinery/atmospherics/unary/heat_reservoir/heater/attackby(var/obj/item/weapon/W as obj, var/mob/user as mob)
-	..()
 
 /obj/machinery/atmospherics/unary/heat_reservoir/heater/attack_hand(mob/user as mob)
 	user.set_machine(src)


### PR DESCRIPTION
Fixes #15709
Fixes #11307, or at least mitigates it.

Changed the capitalization for their names, as well.

:cl:
 * bugfix: Heaters and freezers can be correctly upgraded with the RPED.
 * tweak: Heaters and freezers update the pipe network more frequency, which should lead to more accurate readings.