### PR TITLE
Smartglass

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -258,6 +258,7 @@
 		smartwindow = new /obj/machinery/smartglass_electronics(src)
 		if (!density) //if it's open, keep it see-through
 			opacity = 0
+			was_opaque = 1
 		return smartwindow
 	
 	//If its a multitool and our windoor is smart, open the menu

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -25,9 +25,9 @@
 
 /obj/machinery/door/window/New()
 	..()
-	if ((istype(req_access) && req_access.len) || istext(req_access))
-		icon_state = "[icon_state]"
-		base_state = icon_state
+	if ((istype(src.req_access) && src.req_access.len) || istext(req_access))
+		src.icon_state = "[src.icon_state]"
+		src.base_state = src.icon_state
 	return
 
 /obj/machinery/door/window/Destroy()
@@ -56,26 +56,26 @@
 	if (!ismob(AM))
 		var/obj/machinery/bot/bot = AM
 		if(istype(bot))
-			if(density && check_access(bot.botcard))
+			if(density && src.check_access(bot.botcard))
 				open()
 				sleep(50)
 				close()
 		else if(istype(AM, /obj/mecha))
 			var/obj/mecha/mecha = AM
 			if(density)
-				if(mecha.occupant && allowed(mecha.occupant))
+				if(mecha.occupant && src.allowed(mecha.occupant))
 					open()
 					sleep(50)
 					close()
 		return
 	if (!( ticker ))
 		return
-	if (operating)
+	if (src.operating)
 		return
-	if (density && allowed(AM))
+	if (src.density && src.allowed(AM))
 		open()
 		// What.
-		if(check_access(null))
+		if(src.check_access(null))
 			sleep(50)
 		else //secure doors close faster
 			sleep(20)
@@ -113,37 +113,37 @@
 /obj/machinery/door/window/open()
 	if (!density) //it's already open you silly cunt
 		return 0
-	if (operating == 1) //doors can still open when emag-disabled
+	if (src.operating == 1) //doors can still open when emag-disabled
 		return 0
 	if (!ticker)
 		return 0
-	if(!operating) //in case of emag
-		operating = 1
-	flick(text("[]opening", base_state), src)
+	if(!src.operating) //in case of emag
+		src.operating = 1
+	flick(text("[]opening", src.base_state), src)
 	playsound(get_turf(src), soundeffect, 100, 1)
-	icon_state = text("[]open", base_state)
+	src.icon_state = text("[]open", src.base_state)
 	sleep(animation_delay)
 
 	explosion_resistance = 0
-	density = 0
+	src.density = 0
 	if (smartwindow && opacity)
 		set_opacity(0) //Else we'd get opaque open windoors!
 		was_opaque = 1
 	update_nearby_tiles()
 
 	if(operating == 1) //emag again
-		operating = 0
+		src.operating = 0
 	return 1
 
 /obj/machinery/door/window/close()
-	if (operating)
+	if (src.operating)
 		return 0
-	operating = 1
-	flick(text("[]closing", base_state), src)
+	src.operating = 1
+	flick(text("[]closing", src.base_state), src)
 	playsound(get_turf(src), soundeffect, 100, 1)
-	icon_state = base_state
+	src.icon_state = src.base_state
 
-	density = 1
+	src.density = 1
 	explosion_resistance = initial(explosion_resistance)
 	if (smartwindow && was_opaque)
 		set_opacity(1)
@@ -152,14 +152,14 @@
 
 	sleep(animation_delay)
 
-	operating = 0
+	src.operating = 0
 	return 1
 
 /obj/machinery/door/window/proc/take_damage(var/damage)
-	health = max(0, health - damage)
-	if (health <= 0)
+	src.health = max(0, src.health - damage)
+	if (src.health <= 0)
 		getFromPool(shard, loc)
-		getFromPool(/obj/item/stack/cable_coil,loc,2)
+		getFromPool(/obj/item/stack/cable_coil,src.loc,2)
 		eject_electronics()
 		qdel(src)
 		return
@@ -185,19 +185,19 @@
 	return
 
 /obj/machinery/door/window/attack_ai(mob/user as mob)
-	add_hiddenprint(user)
+	src.add_hiddenprint(user)
 	return src.attack_hand(user)
 
 /obj/machinery/door/window/attack_paw(mob/living/user as mob)
 	if(istype(user, /mob/living/carbon/alien/humanoid) || istype(user, /mob/living/carbon/slime/adult))
-		if(operating)
+		if(src.operating)
 			return
 		user.delayNextAttack(8)
 		user.do_attack_animation(src, user)
-		health = max(0, health - 25)
+		src.health = max(0, src.health - 25)
 		playsound(get_turf(src), 'sound/effects/Glasshit.ogg', 75, 1)
 		visible_message("<span class='warning'>\The [user] smashes against \the [src.name].</span>", 1)
-		if (health <= 0)
+		if (src.health <= 0)
 			getFromPool(shard, loc)
 			getFromPool(/obj/item/stack/cable_coil, loc, 2)
 			qdel(src)
@@ -206,17 +206,17 @@
 
 
 /obj/machinery/door/window/attack_animal(mob/living/user as mob)
-	if(operating)
+	if(src.operating)
 		return
 	var/mob/living/simple_animal/M = user
 	if(M.melee_damage_upper <= 0)
 		return
 	user.do_attack_animation(src, user)
 	user.delayNextAttack(8)
-	health = max(0, health - M.melee_damage_upper)
+	src.health = max(0, src.health - M.melee_damage_upper)
 	playsound(get_turf(src), 'sound/effects/Glasshit.ogg', 75, 1)
 	visible_message("<span class='warning'>\The [M] [M.attacktext] against \the [src.name].</span>", 1)
-	if (health <= 0)
+	if (src.health <= 0)
 		getFromPool(shard, loc)
 		getFromPool(/obj/item/stack/cable_coil, loc, 2)
 		qdel(src)
@@ -227,13 +227,13 @@
 
 /obj/machinery/door/window/attackby(obj/item/weapon/I as obj, mob/living/user as mob)
 	// Make emagged/open doors able to be deconstructed
-	if (!density && !operating && iscrowbar(I))
+	if (!src.density && src.operating != 1 && iscrowbar(I))
 		user.visible_message("[user] removes the electronics from the windoor assembly.", "You start to remove the electronics from the windoor assembly.")
 		playsound(get_turf(src), 'sound/items/Crowbar.ogg', 100, 1)
-		if (do_after(user, src, 40) && src && !density && !operating)
+		if (do_after(user, src, 40) && src && !src.density && src.operating != 1)
 			to_chat(user, "<span class='notice'>You removed the windoor electronics!</span>")
 			make_assembly(user)
-			dismantled = 1 // Don't play the glass shatter sound
+			src.dismantled = 1 // Don't play the glass shatter sound
 			if(smartwindow)
 				qdel(smartwindow)
 				smartwindow = null
@@ -244,7 +244,7 @@
 		return
 
 	//If it's in the process of opening/closing or emagged, ignore the click
-	if (operating)
+	if (src.operating)
 		return
 
 	//If it's Smartglass shit, smartglassify it.
@@ -267,33 +267,33 @@
 		return
 		
 	//If it's a weapon, smash windoor. Unless it's an id card, agent card, ect.. then ignore it (Cards really shouldnt damage a door anyway)
-	if(density && istype(I, /obj/item/weapon) && !istype(I, /obj/item/weapon/card))
+	if(src.density && istype(I, /obj/item/weapon) && !istype(I, /obj/item/weapon/card))
 		var/aforce = I.force
 		user.do_attack_animation(src, I)
 		user.delayNextAttack(8)
 		if(I.damtype == BRUTE || I.damtype == BURN)
-			health = max(0, health - aforce)
+			src.health = max(0, src.health - aforce)
 		playsound(get_turf(src), 'sound/effects/Glasshit.ogg', 75, 1)
 		visible_message("<span class='danger'>[src] was hit by [I].</span>")
-		if (health <= 0)
+		if (src.health <= 0)
 			getFromPool(shard, loc)
-			getFromPool(/obj/item/stack/cable_coil, loc, 2)
+			getFromPool(/obj/item/stack/cable_coil, src.loc, 2)
 			qdel(src)
 		return
 
-	add_fingerprint(user)
-	if (!requiresID())
+	src.add_fingerprint(user)
+	if (!src.requiresID())
 		//don't care who they are or what they have, act as if they're NOTHING
 		user = null
 
 	if (isrobot(user))
-		if (density)
+		if (src.density)
 			return open()
 		else
 			return close()
 
-	if (!allowed(user) && density)
-		flick(text("[]deny", base_state), src)
+	if (!src.allowed(user) && src.density)
+		flick(text("[]deny", src.base_state), src)
 
 	return ..()
 
@@ -302,12 +302,12 @@
 	return hackOpen(used_emag, user)
 
 /obj/machinery/door/window/proc/hackOpen(obj/item/I, mob/user)
-	operating = -1
+	src.operating = -1
 
-	if (electronics)
-		electronics.icon_state = "door_electronics_smoked"
+	if (src.electronics)
+		src.electronics.icon_state = "door_electronics_smoked"
 
-	flick("[base_state]spark", src)
+	flick("[src.base_state]spark", src)
 	sleep(6)
 	open()
 	return 1
@@ -320,7 +320,7 @@
  * w.r.t. the tile it is on.
  */
 /obj/machinery/door/window/proc/is_left_opening()
-	return base_state == "left" || base_state == "leftsecure"
+	return src.base_state == "left" || src.base_state == "leftsecure"
 
 /**
  * Deconstructs a windoor properly. You probably want to delete
@@ -329,41 +329,41 @@
  */
 /obj/machinery/door/window/proc/make_assembly(mob/user as mob)
 	// Windoor assembly
-	var/obj/structure/windoor_assembly/WA = new /obj/structure/windoor_assembly(loc)
+	var/obj/structure/windoor_assembly/WA = new /obj/structure/windoor_assembly(src.loc)
 	set_assembly(user, WA)
 	return WA
 
 /obj/machinery/door/window/proc/set_assembly(mob/user as mob, var/obj/structure/windoor_assembly/WA)
 	WA.name = "Near finished Windoor Assembly"
-	WA.dir = dir
+	WA.dir = src.dir
 	WA.anchored = 1
 	WA.facing = (is_left_opening() ? "l" : "r")
 	WA.secure = ""
 	WA.state = "02"
 	WA.update_icon()
 
-	WA.fingerprints += fingerprints
-	WA.fingerprintshidden += fingerprints
+	WA.fingerprints += src.fingerprints
+	WA.fingerprintshidden += src.fingerprints
 	WA.fingerprintslast = user.ckey
 
 	// Pop out electronics
 	eject_electronics()
 
 /obj/machinery/door/window/proc/eject_electronics()
-	var/obj/item/weapon/circuitboard/airlock/AE = (electronics ? electronics : new /obj/item/weapon/circuitboard/airlock(loc))
-	if (electronics)
-		electronics = null
+	var/obj/item/weapon/circuitboard/airlock/AE = (src.electronics ? src.electronics : new /obj/item/weapon/circuitboard/airlock(src.loc))
+	if (src.electronics)
+		src.electronics = null
 		AE.installed = 0
 	else
 		if(operating == -1)
 			AE.icon_state = "door_electronics_smoked"
 		// Straight from /obj/machinery/door/airlock/attackby()
-		if (req_access && req_access.len > 0)
-			AE.conf_access = req_access
-		else if (req_one_access && req_one_access.len > 0)
-			AE.conf_access = req_one_access
+		if (src.req_access && src.req_access.len > 0)
+			AE.conf_access = src.req_access
+		else if (src.req_one_access && src.req_one_access.len > 0)
+			AE.conf_access = src.req_one_access
 			AE.one_access = 1
-	AE.forceMove(loc)
+	AE.forceMove(src.loc)
 
 /obj/machinery/door/window/brigdoor
 	name = "Secure Window Door"
@@ -392,7 +392,7 @@
 
 /obj/machinery/door/window/plasma/make_assembly(mob/user as mob)
 	// Windoor assembly
-	var/obj/structure/windoor_assembly/plasma/WA = new /obj/structure/windoor_assembly/plasma(loc)
+	var/obj/structure/windoor_assembly/plasma/WA = new /obj/structure/windoor_assembly/plasma(src.loc)
 	set_assembly(user, WA)
 	return WA
 

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -25,9 +25,9 @@
 
 /obj/machinery/door/window/New()
 	..()
-	if ((istype(src.req_access) && src.req_access.len) || istext(req_access))
-		src.icon_state = "[src.icon_state]"
-		src.base_state = src.icon_state
+	if ((istype(req_access) && req_access.len) || istext(req_access))
+		icon_state = "[icon_state]"
+		base_state = icon_state
 	return
 
 /obj/machinery/door/window/Destroy()
@@ -121,7 +121,7 @@
 		operating = 1
 	flick(text("[]opening", base_state), src)
 	playsound(get_turf(src), soundeffect, 100, 1)
-	icon_state = text("[]open", src.base_state)
+	icon_state = text("[]open", base_state)
 	sleep(animation_delay)
 
 	explosion_resistance = 0
@@ -139,9 +139,9 @@
 	if (operating)
 		return 0
 	operating = 1
-	flick(text("[]closing", src.base_state), src)
+	flick(text("[]closing", base_state), src)
 	playsound(get_turf(src), soundeffect, 100, 1)
-	src.icon_state = src.base_state
+	icon_state = base_state
 
 	density = 1
 	explosion_resistance = initial(explosion_resistance)
@@ -156,10 +156,10 @@
 	return 1
 
 /obj/machinery/door/window/proc/take_damage(var/damage)
-	src.health = max(0, src.health - damage)
-	if (src.health <= 0)
+	health = max(0, health - damage)
+	if (health <= 0)
 		getFromPool(shard, loc)
-		getFromPool(/obj/item/stack/cable_coil,src.loc,2)
+		getFromPool(/obj/item/stack/cable_coil,loc,2)
 		eject_electronics()
 		qdel(src)
 		return
@@ -185,7 +185,7 @@
 	return
 
 /obj/machinery/door/window/attack_ai(mob/user as mob)
-	src.add_hiddenprint(user)
+	add_hiddenprint(user)
 	return src.attack_hand(user)
 
 /obj/machinery/door/window/attack_paw(mob/living/user as mob)
@@ -194,10 +194,10 @@
 			return
 		user.delayNextAttack(8)
 		user.do_attack_animation(src, user)
-		src.health = max(0, src.health - 25)
+		health = max(0, health - 25)
 		playsound(get_turf(src), 'sound/effects/Glasshit.ogg', 75, 1)
 		visible_message("<span class='warning'>\The [user] smashes against \the [src.name].</span>", 1)
-		if (src.health <= 0)
+		if (health <= 0)
 			getFromPool(shard, loc)
 			getFromPool(/obj/item/stack/cable_coil, loc, 2)
 			qdel(src)
@@ -213,10 +213,10 @@
 		return
 	user.do_attack_animation(src, user)
 	user.delayNextAttack(8)
-	src.health = max(0, src.health - M.melee_damage_upper)
+	health = max(0, health - M.melee_damage_upper)
 	playsound(get_turf(src), 'sound/effects/Glasshit.ogg', 75, 1)
 	visible_message("<span class='warning'>\The [M] [M.attacktext] against \the [src.name].</span>", 1)
-	if (src.health <= 0)
+	if (health <= 0)
 		getFromPool(shard, loc)
 		getFromPool(/obj/item/stack/cable_coil, loc, 2)
 		qdel(src)
@@ -257,7 +257,7 @@
 		smartwindow = new /obj/machinery/smartglass_electronics(src)
 		smart_toggle()
 		if (!density) //if it's open, keep it see-through
-			opacity = 1
+			opacity = 0
 		return smartwindow
 	
 	//If its a multitool and our windoor is smart, open the menu
@@ -271,17 +271,17 @@
 		user.do_attack_animation(src, I)
 		user.delayNextAttack(8)
 		if(I.damtype == BRUTE || I.damtype == BURN)
-			src.health = max(0, src.health - aforce)
+			health = max(0, health - aforce)
 		playsound(get_turf(src), 'sound/effects/Glasshit.ogg', 75, 1)
 		visible_message("<span class='danger'>[src] was hit by [I].</span>")
-		if (src.health <= 0)
+		if (health <= 0)
 			getFromPool(shard, loc)
-			getFromPool(/obj/item/stack/cable_coil, src.loc, 2)
+			getFromPool(/obj/item/stack/cable_coil, loc, 2)
 			qdel(src)
 		return
 
-	src.add_fingerprint(user)
-	if (!src.requiresID())
+	add_fingerprint(user)
+	if (!requiresID())
 		//don't care who they are or what they have, act as if they're NOTHING
 		user = null
 
@@ -291,8 +291,8 @@
 		else
 			return close()
 
-	if (!src.allowed(user) && density)
-		flick(text("[]deny", src.base_state), src)
+	if (!allowed(user) && density)
+		flick(text("[]deny", base_state), src)
 
 	return ..()
 
@@ -303,10 +303,10 @@
 /obj/machinery/door/window/proc/hackOpen(obj/item/I, mob/user)
 	operating = -1
 
-	if (src.electronics)
-		src.electronics.icon_state = "door_electronics_smoked"
+	if (electronics)
+		electronics.icon_state = "door_electronics_smoked"
 
-	flick("[src.base_state]spark", src)
+	flick("[base_state]spark", src)
 	sleep(6)
 	open()
 	return 1
@@ -319,7 +319,7 @@
  * w.r.t. the tile it is on.
  */
 /obj/machinery/door/window/proc/is_left_opening()
-	return src.base_state == "left" || src.base_state == "leftsecure"
+	return base_state == "left" || base_state == "leftsecure"
 
 /**
  * Deconstructs a windoor properly. You probably want to delete
@@ -328,41 +328,41 @@
  */
 /obj/machinery/door/window/proc/make_assembly(mob/user as mob)
 	// Windoor assembly
-	var/obj/structure/windoor_assembly/WA = new /obj/structure/windoor_assembly(src.loc)
+	var/obj/structure/windoor_assembly/WA = new /obj/structure/windoor_assembly(loc)
 	set_assembly(user, WA)
 	return WA
 
 /obj/machinery/door/window/proc/set_assembly(mob/user as mob, var/obj/structure/windoor_assembly/WA)
 	WA.name = "Near finished Windoor Assembly"
-	WA.dir = src.dir
+	WA.dir = dir
 	WA.anchored = 1
 	WA.facing = (is_left_opening() ? "l" : "r")
 	WA.secure = ""
 	WA.state = "02"
 	WA.update_icon()
 
-	WA.fingerprints += src.fingerprints
-	WA.fingerprintshidden += src.fingerprints
+	WA.fingerprints += fingerprints
+	WA.fingerprintshidden += fingerprints
 	WA.fingerprintslast = user.ckey
 
 	// Pop out electronics
 	eject_electronics()
 
 /obj/machinery/door/window/proc/eject_electronics()
-	var/obj/item/weapon/circuitboard/airlock/AE = (src.electronics ? src.electronics : new /obj/item/weapon/circuitboard/airlock(src.loc))
-	if (src.electronics)
-		src.electronics = null
+	var/obj/item/weapon/circuitboard/airlock/AE = (electronics ? electronics : new /obj/item/weapon/circuitboard/airlock(loc))
+	if (electronics)
+		electronics = null
 		AE.installed = 0
 	else
 		if(operating == -1)
 			AE.icon_state = "door_electronics_smoked"
 		// Straight from /obj/machinery/door/airlock/attackby()
-		if (src.req_access && src.req_access.len > 0)
-			AE.conf_access = src.req_access
-		else if (src.req_one_access && src.req_one_access.len > 0)
-			AE.conf_access = src.req_one_access
+		if (req_access && req_access.len > 0)
+			AE.conf_access = req_access
+		else if (req_one_access && req_one_access.len > 0)
+			AE.conf_access = req_one_access
 			AE.one_access = 1
-	AE.forceMove(src.loc)
+	AE.forceMove(loc)
 
 /obj/machinery/door/window/brigdoor
 	name = "Secure Window Door"
@@ -391,7 +391,7 @@
 
 /obj/machinery/door/window/plasma/make_assembly(mob/user as mob)
 	// Windoor assembly
-	var/obj/structure/windoor_assembly/plasma/WA = new /obj/structure/windoor_assembly/plasma(src.loc)
+	var/obj/structure/windoor_assembly/plasma/WA = new /obj/structure/windoor_assembly/plasma(loc)
 	set_assembly(user, WA)
 	return WA
 

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -21,6 +21,7 @@
 	penetration_dampening = 2
 	animation_delay = 7
 	var/obj/machinery/smartglass_electronics/smartwindow
+	var/was_opaque
 
 /obj/machinery/door/window/New()
 	..()
@@ -125,8 +126,9 @@
 
 	explosion_resistance = 0
 	density = 0
-	if (smartwindow)
-		set_opacity(1) //Else we'd get opaque open windoors!
+	if (smartwindow && opacity)
+		set_opacity(0) //Else we'd get opaque open windoors!
+		was_opaque = 1
 	update_nearby_tiles()
 
 	if(operating == 1) //emag again
@@ -143,8 +145,9 @@
 
 	density = 1
 	explosion_resistance = initial(explosion_resistance)
-//	if(src.visible)
-//		SetOpacity(1)	//TODO: why is this here? Opaque windoors? ~Carn
+	if (smartwindow && was_opaque)
+		set_opacity(1)
+		was_opaque = 0
 	update_nearby_tiles()
 
 	sleep(animation_delay)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -38,10 +38,10 @@
 
 /obj/machinery/door/window/proc/smart_toggle() //For "smart" windows
 	if(opacity)
-		animate(src, color="#FFFFFF", time=5)
+		animate(src, color="#FFFFFF", alpha=255, time=5)
 		set_opacity(0)
 	else
-		animate(src, color="#222222", time=5)
+		animate(src, color="#222222", alpha=0, time=5)
 		set_opacity(1)
 	return opacity
 	
@@ -56,14 +56,14 @@
 	if (!ismob(AM))
 		var/obj/machinery/bot/bot = AM
 		if(istype(bot))
-			if(density && src.check_access(bot.botcard))
+			if(density && check_access(bot.botcard))
 				open()
 				sleep(50)
 				close()
 		else if(istype(AM, /obj/mecha))
 			var/obj/mecha/mecha = AM
 			if(density)
-				if(mecha.occupant && src.allowed(mecha.occupant))
+				if(mecha.occupant && allowed(mecha.occupant))
 					open()
 					sleep(50)
 					close()
@@ -72,10 +72,10 @@
 		return
 	if (operating)
 		return
-	if (density && src.allowed(AM))
+	if (density && allowed(AM))
 		open()
 		// What.
-		if(src.check_access(null))
+		if(check_access(null))
 			sleep(50)
 		else //secure doors close faster
 			sleep(20)
@@ -119,9 +119,9 @@
 		return 0
 	if(!operating) //in case of emag
 		operating = 1
-	flick(text("[]opening", src.base_state), src)
+	flick(text("[]opening", base_state), src)
 	playsound(get_turf(src), soundeffect, 100, 1)
-	src.icon_state = text("[]open", src.base_state)
+	icon_state = text("[]open", src.base_state)
 	sleep(animation_delay)
 
 	explosion_resistance = 0
@@ -233,7 +233,7 @@
 		if (do_after(user, src, 40) && src && !density && !operating)
 			to_chat(user, "<span class='notice'>You removed the windoor electronics!</span>")
 			make_assembly(user)
-			src.dismantled = 1 // Don't play the glass shatter sound
+			dismantled = 1 // Don't play the glass shatter sound
 			qdel(smartwindow)
 			smartwindow = null
 			if (opacity)
@@ -256,6 +256,8 @@
 		to_chat(user, "<span class='notice'>You add some electronics to the windoor.</span>")	
 		smartwindow = new /obj/machinery/smartglass_electronics(src)
 		smart_toggle()
+		if (!density) //if it's open, keep it see-through
+			opacity = 1
 		return smartwindow
 	
 	//If its a multitool and our windoor is smart, open the menu

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -256,7 +256,6 @@
 		LT.use(1)
 		to_chat(user, "<span class='notice'>You add some electronics to the windoor.</span>")	
 		smartwindow = new /obj/machinery/smartglass_electronics(src)
-		smart_toggle()
 		if (!density) //if it's open, keep it see-through
 			opacity = 0
 		return smartwindow

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -38,10 +38,10 @@
 
 /obj/machinery/door/window/proc/smart_toggle() //For "smart" windows
 	if(opacity)
-		animate(src, color="#FFFFFF", alpha=255, time=5)
+		animate(src, color="#FFFFFF", time=5)
 		set_opacity(0)
 	else
-		animate(src, color="#222222", alpha=0, time=5)
+		animate(src, color="#222222", time=5)
 		set_opacity(1)
 	return opacity
 	

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -234,11 +234,12 @@
 			to_chat(user, "<span class='notice'>You removed the windoor electronics!</span>")
 			make_assembly(user)
 			dismantled = 1 // Don't play the glass shatter sound
-			qdel(smartwindow)
-			smartwindow = null
-			if (opacity)
-				smart_toggle()
-			drop_stack(/obj/item/stack/light_w, get_turf(src), 1, user)
+			if(smartwindow)
+				qdel(smartwindow)
+				smartwindow = null
+				if (opacity)
+					smart_toggle()
+				drop_stack(/obj/item/stack/light_w, get_turf(src), 1, user)
 			qdel(src)
 		return
 

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -382,6 +382,7 @@ Class Procs:
 				to_chat(usr, "<span class='warning'>WARNING: Unable to interface with \the [src.name].</span>")
 				return 1
 		if ((!in_range(src, usr) || !istype(src.loc, /turf)) && !istype(usr, /mob/living/silicon))
+			to_chat(usr, "<span class='warning'>WARNING: Connection failure. Reduce range.</span>")
 			return 1
 	else if(!custom_aghost_alerts)
 		log_adminghost("[key_name(usr)] screwed with [src] ([href])!")

--- a/code/game/machinery/smartglass.dm
+++ b/code/game/machinery/smartglass.dm
@@ -12,15 +12,21 @@
 	icon_state = "access_control_standby"
 	anchored = 0
 	density = 0
-	use_power = 0
+	use_power = 2
 	idle_power_usage = 0
-	active_power_usage = 0
+	active_power_usage = 5
 	power_channel = ENVIRON
-	var/id_tag	
 	machine_flags = MULTITOOL_MENU
+	
+	//Smartglass vars
 	var/smart_power = 0
 	var/one_way_power = 0
-	var/obj/structure/window/GLASS
+	var/obj/structure/window/GLASS //Ref to the window we're in
+	
+	//Radio vars
+	var/id_tag	
+	var/frequency = 1449
+	var/datum/radio_frequency/radio_connection
 	
 /obj/machinery/smartglass_electronics/cultify()
 	qdel(src)
@@ -28,6 +34,7 @@
 	
 /obj/machinery/smartglass_electronics/New()
 	..()
+	radio_connection = radio_controller.add_object(src, frequency, RADIO_AIRLOCK)
 	
 //Multitool menu needs to communicate with the glass the electronics are inside
 
@@ -35,11 +42,19 @@
 	return {"
 		<ul>
 			<li>[format_tag("ID Tag", "id_tag","set_id")]</a></li>
-			<li><a href="?src=\ref[src];toggle_smart_power()">Toggle Transparency</a></li>
-			<li><a href="?src=\ref[src];toggle_oneway_power()">Toggle One-way mode</a></li>
+			<li><a href='?src=\ref[src];transparentoggle=1'>Toggle Transparency</a></li>
+			<li><a href='?src=\ref[src];onewaytoggle=1'>Toggle One-way mode</a></li>
 		</ul>
 		"}
-
+	
+	
+/*
+	var/dat = "[format_tag("ID Tag", "id_tag","set_id")]</a>"
+	dat += "<A href='?src=\ref[src];transparentoggle=1`>Toggle_Transparency</a>"
+	if (GLASS.one_way)
+		dat += "<A href='?src=\ref[src];onewaytoggle=1`>Toggle_Oneway</a>"
+	return dat
+*/
 /*	
 //			[format_tag("ID Tag","id_tag")]
 			
@@ -53,25 +68,60 @@
 		active_power_usage -= 5
 		if (!one_way_power)
 			use_power = 0
-		else
-			smart_power = 1
-			active_power_usage += 5
-			use_power = 2
-		GLASS.smart_toggle()
+	else
+		smart_power = 1
+		active_power_usage += 5
+		use_power = 2
+	GLASS.smart_toggle()
+	return smart_power
 
 /obj/machinery/smartglass_electronics/proc/toggle_oneway_power()
+	if(!GLASS.one_way)
+		return
 	if (one_way_power)
 		one_way_power = 0
 		active_power_usage -= 5
 		if (!smart_power)
 			use_power = 0
-		else
-			one_way_power = 1
-			active_power_usage += 5
-			use_power = 2
-		GLASS.oneway_toggle()
+	else
+		one_way_power = 1
+		active_power_usage += 5
+		use_power = 2
+	GLASS.oneway_toggle()
+	return one_way_power
 
 
+/obj/machinery/smartglass_electronics/power_change()
+	if(stat & (NOPOWER | BROKEN))
+		if (smart_power)
+			smart_power = 0
+			GLASS.smart_toggle()
+		if (one_way_power)
+			one_way_power = 0
+			GLASS.oneway_toggle()
+		
+// This is here to allow access to the electronics.
+/obj/machinery/smartglass_electronics/Topic(href, href_list)
+	if(stat & (NOPOWER|BROKEN))
+		return 1
+	if(href_list["close"])
+		return
+	var/ghost_flags=0
+	if(ghost_write)
+		ghost_flags |= PERMIT_ALL
+	if(!canGhostWrite(usr,src,"",ghost_flags))
+		if(usr.restrained() || usr.lying || usr.stat)
+			return 1
+	else if(!custom_aghost_alerts)
+		log_adminghost("[key_name(usr)] screwed with [src] ([href])!")
+
+	return handle_multitool_topic(href,href_list,usr)
+		
+		
+/*************************************
+// RADIO SHIT
+*************************************/
+		
 /obj/machinery/smartglass_electronics/multitool_topic(var/mob/user, var/list/href_list, var/obj/structure/window/GLASS)
 	if("set_id" in href_list)
 		var/newid = copytext(reject_bad_text(input(usr, "Specify the new ID tag for this machine", src, id_tag) as null|text), 1, MAX_MESSAGE_LEN)
@@ -79,5 +129,28 @@
 			id_tag = newid
 			initialize()
 		return MT_UPDATE
-
+	
+	if("transparentoggle" in href_list)
+		toggle_smart_power()
+		return MT_UPDATE	
+	
+	if("onewaytoggle" in href_list)
+		toggle_oneway_power()
+		return MT_UPDATE
+	
 	return ..()
+	
+/obj/machinery/smartglass_electronics/receive_signal(datum/signal/signal)
+	if(!signal || signal.encryption)
+		return
+
+	if(id_tag != signal.data["tag"] || !signal.data["command"])
+		return
+
+	switch(signal.data["command"])
+		
+		if("toggle_transparency")
+			toggle_smart_power()
+			
+		if("toggle_oneway")
+			toggle_oneway_power()

--- a/code/game/machinery/smartglass.dm
+++ b/code/game/machinery/smartglass.dm
@@ -6,33 +6,78 @@
 /////////////////////////////////////////
 
 /obj/machinery/smartglass_electronics
-	name = "internal smartglass electronics"
-	desc = "This inside a pane of smart glass. How are you seeing this?"
-	icon = null
-	icon_state = null
+	name = "smartglass electronics"
+	desc = "This should be inside a pane of smart glass. How are you seeing this?"
+	icon = 'icons/obj/airlock_machines.dmi'
+	icon_state = "access_control_standby"
 	anchored = 0
 	density = 0
-	use_power = 2 //It uses power to amke the window transparent
+	use_power = 0
 	idle_power_usage = 0
-	active_power_usage = 2
+	active_power_usage = 0
 	power_channel = ENVIRON
 	var/id_tag	
+	machine_flags = MULTITOOL_MENU
+	var/smart_power = 0
+	var/one_way_power = 0
+	var/obj/structure/window/GLASS
 	
 /obj/machinery/smartglass_electronics/cultify()
-	return //TODO: change to cultglass
+	qdel(src)
+	return
 	
 /obj/machinery/smartglass_electronics/New()
 	..()
-	machine_flags |= MULTITOOL_MENU
 	
-//Needs multitool menu option to toggle power (aka opaque/transparent)
-//Needs multitool menu option to toggle one-way
-	/*
-/obj/smartglass_electronics/multitool_menu(mob/user as mob)
+//Multitool menu needs to communicate with the glass the electronics are inside
+
+/obj/machinery/smartglass_electronics/multitool_menu(var/mob/user)
 	return {"
 		<ul>
-			[format_tag("ID Tag","id_tag")]
-			(<a href="?src=\ref[src];smart_toggle()">Toggle power</a>)
-		</ul>"
-		}
-*/
+			<li>[format_tag("ID Tag", "id_tag","set_id")]</a></li>
+			<li><a href="?src=\ref[src];toggle_smart_power()">Toggle Transparency</a></li>
+			<li><a href="?src=\ref[src];toggle_oneway_power()">Toggle One-way mode</a></li>
+		</ul>
+		"}
+
+/*	
+//			[format_tag("ID Tag","id_tag")]
+			
+			<li>[format_tag("Transparency", "smart_power","toggle_smart_power")]</a></li></br>
+			<li>[format_tag("One-way", "one_way_power","toggle_oneway_power")]</a></li></br>
+*/			
+
+/obj/machinery/smartglass_electronics/proc/toggle_smart_power()
+	if (smart_power)
+		smart_power = 0
+		active_power_usage -= 5
+		if (!one_way_power)
+			use_power = 0
+		else
+			smart_power = 1
+			active_power_usage += 5
+			use_power = 2
+		GLASS.smart_toggle()
+
+/obj/machinery/smartglass_electronics/proc/toggle_oneway_power()
+	if (one_way_power)
+		one_way_power = 0
+		active_power_usage -= 5
+		if (!smart_power)
+			use_power = 0
+		else
+			one_way_power = 1
+			active_power_usage += 5
+			use_power = 2
+		GLASS.oneway_toggle()
+
+
+/obj/machinery/smartglass_electronics/multitool_topic(var/mob/user, var/list/href_list, var/obj/structure/window/GLASS)
+	if("set_id" in href_list)
+		var/newid = copytext(reject_bad_text(input(usr, "Specify the new ID tag for this machine", src, id_tag) as null|text), 1, MAX_MESSAGE_LEN)
+		if(newid)
+			id_tag = newid
+			initialize()
+		return MT_UPDATE
+
+	return ..()

--- a/code/game/machinery/smartglass.dm
+++ b/code/game/machinery/smartglass.dm
@@ -39,7 +39,7 @@
 	..()
 	GLASS = loc
 	radio_connection = radio_controller.add_object(src, frequency, RADIO_AIRLOCK)
-	electromagic=new(src,src)
+	electromagic=new(GLASS,GLASS)
 	electromagic.idle_usage=idle_power_usage
 	electromagic.active_usage=active_power_usage
 

--- a/code/game/machinery/smartglass.dm
+++ b/code/game/machinery/smartglass.dm
@@ -35,6 +35,9 @@
 /obj/machinery/smartglass_electronics/New()
 	..()
 	radio_connection = radio_controller.add_object(src, frequency, RADIO_AIRLOCK)
+	GLASS = loc
+	testing("[src] now located at [GLASS]")
+	power_change()
 
 /obj/machinery/smartglass_electronics/Destroy()
 	radio_controller.remove_object(src, frequency)
@@ -47,19 +50,34 @@
 **********************/
 	
 /obj/machinery/smartglass_electronics/emp_act(severity)
-	if(stat & (BROKEN|NOPOWER))
-		..(severity)
-		return
-	power_change()
-	..(severity)	
-	//should add randomized window states here	
+	switch(severity)
+		if(1)
+			if(prob(90))
+				GLASS.smart_toggle()
+				if(prob(60))
+					GLASS.smart_toggle()
+					if(prob(30))
+						GLASS.smart_toggle()
+		if(2)
+			if(prob(50))
+				GLASS.smart_toggle()
+	
 	
 /obj/machinery/smartglass_electronics/power_change()
-	if(stat & (NOPOWER | BROKEN))
-		if (smart_transparency)
+	testing("[src] running power_change()")
+	if(stat & (NOPOWER | BROKEN) || !use_power() || !auto_use_power())
+		if (!smart_transparency)
 			smart_transparency = !smart_transparency
 			GLASS.smart_toggle()
+			testing("[src] switched modes during power_change()")
+	testing("[src] power_change() complete")
+	
 
+/obj/machinery/smartglass_electronics/use_power()
+	areaMaster = GLASS.areaMaster
+	testing("setting areaMaster [areaMaster] on [src]()")
+	return ..()
+		
 /**********************
 // SMARTGLASS PROCS
 **********************/

--- a/code/game/machinery/smartglass.dm
+++ b/code/game/machinery/smartglass.dm
@@ -1,0 +1,38 @@
+/////////////////////////////////////////
+// Machine that makes glass 'smart'
+// Held within a pane of glass
+// used for linking to buttons 'n shit
+// made when a floor light is attached to a window
+/////////////////////////////////////////
+
+/obj/machinery/smartglass_electronics
+	name = "internal smartglass electronics"
+	desc = "This inside a pane of smart glass. How are you seeing this?"
+	icon = null
+	icon_state = null
+	anchored = 0
+	density = 0
+	use_power = 2 //It uses power to amke the window transparent
+	idle_power_usage = 0
+	active_power_usage = 2
+	power_channel = ENVIRON
+	var/id_tag	
+	
+/obj/machinery/smartglass_electronics/cultify()
+	return //TODO: change to cultglass
+	
+/obj/machinery/smartglass_electronics/New()
+	..()
+	machine_flags |= MULTITOOL_MENU
+	
+//Needs multitool menu option to toggle power (aka opaque/transparent)
+//Needs multitool menu option to toggle one-way
+	/*
+/obj/smartglass_electronics/multitool_menu(mob/user as mob)
+	return {"
+		<ul>
+			[format_tag("ID Tag","id_tag")]
+			(<a href="?src=\ref[src];smart_toggle()">Toggle power</a>)
+		</ul>"
+		}
+*/

--- a/code/game/machinery/smartglass.dm
+++ b/code/game/machinery/smartglass.dm
@@ -76,7 +76,7 @@
 	return smart_power
 
 /obj/machinery/smartglass_electronics/proc/toggle_oneway_power()
-	if(!GLASS.one_way)
+	if(!GLASS.one_way && !GLASS.one_way_smart)
 		return
 	if (one_way_power)
 		one_way_power = 0
@@ -111,6 +111,9 @@
 		ghost_flags |= PERMIT_ALL
 	if(!canGhostWrite(usr,src,"",ghost_flags))
 		if(usr.restrained() || usr.lying || usr.stat)
+			return 1
+		if ((!in_range(GLASS, usr) || !istype(GLASS.loc, /turf)) && !istype(usr, /mob/living/silicon))
+			to_chat(usr, "<span class='warning'>WARNING: Connection failure. Reduce range.</span>")
 			return 1
 	else if(!custom_aghost_alerts)
 		log_adminghost("[key_name(usr)] screwed with [src] ([href])!")
@@ -154,3 +157,10 @@
 			
 		if("toggle_oneway")
 			toggle_oneway_power()
+			
+			
+/obj/machinery/smartglass_electronics/Destroy()
+	..()
+	radio_controller.remove_object(src, frequency)
+	qdel(radio_connection)
+	radio_connection = null

--- a/code/game/machinery/smartglass.dm
+++ b/code/game/machinery/smartglass.dm
@@ -2,7 +2,7 @@
 // Machine that makes glass 'smart'
 // Held within a pane of glass
 // used for linking to buttons 'n shit
-// made when a floor light is attached to a window
+// made when a floor light tile is attached to a window
 /////////////////////////////////////////
 
 /obj/machinery/smartglass_electronics
@@ -12,23 +12,20 @@
 	icon_state = "access_control_standby"
 	anchored = 0
 	density = 0
-	use_power = 0 //Apparently we use power_connection for this
-	idle_power_usage = 0
+	use_power = 1
+	idle_power_usage = 1
 	active_power_usage = 50
 	power_channel = ENVIRON
 	machine_flags = MULTITOOL_MENU
 	
 	//Smartglass vars
-	var/smart_power = 0
+	var/smart_transparency = 0
 	var/obj/structure/window/GLASS //Ref to the window we're in
 	
 	//Radio vars
 	var/id_tag	
 	var/frequency = 1449
 	var/datum/radio_frequency/radio_connection
-	
-	//power vars
-	var/datum/power_connection/consumer/electromagic = null
 	
 	
 /obj/machinery/smartglass_electronics/cultify()
@@ -37,22 +34,12 @@
 	
 /obj/machinery/smartglass_electronics/New()
 	..()
-	GLASS = loc
 	radio_connection = radio_controller.add_object(src, frequency, RADIO_AIRLOCK)
-	electromagic=new(GLASS,GLASS)
-	electromagic.idle_usage=idle_power_usage
-	electromagic.active_usage=active_power_usage
-	electromagic.power_changed.Add(src,"power_change")
-	electromagic.use = 2
-	electromagic.set_enabled()
 
 /obj/machinery/smartglass_electronics/Destroy()
 	radio_controller.remove_object(src, frequency)
 	qdel(radio_connection)
 	radio_connection = null
-	if(electromagic)
-		qdel(electromagic)
-		electromagic = null
 	..()
 	
 /**********************
@@ -69,21 +56,22 @@
 	
 /obj/machinery/smartglass_electronics/power_change()
 	if(stat & (NOPOWER | BROKEN))
-		if (smart_power)
-			smart_power = 0
+		if (smart_transparency)
+			smart_transparency = !smart_transparency
 			GLASS.smart_toggle()
 
 /**********************
 // SMARTGLASS PROCS
 **********************/
 			
-/obj/machinery/smartglass_electronics/proc/toggle_smart_power()
-	if (smart_power)
-		smart_power = 0
-	else
-		smart_power = 1
+/obj/machinery/smartglass_electronics/proc/toggle_smart_transparency()
+	smart_transparency = !smart_transparency
 	GLASS.smart_toggle()
-	return smart_power
+	if (use_power == 1)
+		use_power = 2
+	else
+		use_power = 1
+	return smart_transparency
 
 
 /**********************
@@ -132,7 +120,7 @@
 		return MT_UPDATE
 	
 	if("transparentoggle" in href_list)
-		toggle_smart_power()
+		toggle_smart_transparency()
 		return MT_UPDATE	
 	
 	return ..()
@@ -147,6 +135,6 @@
 	switch(signal.data["command"])
 		
 		if("toggle_transparency")
-			toggle_smart_power()
+			toggle_smart_transparency()
 
 			

--- a/code/game/machinery/smartglass.dm
+++ b/code/game/machinery/smartglass.dm
@@ -91,11 +91,11 @@
 
 	return handle_multitool_topic(href,href_list,usr)
 	
-/obj/machinery/smartglass_electronics/canClone(var/obj/CLONE)
-	return istype(CLONE, /obj/machinery/smartglass_electronics)
+/obj/machinery/smartglass_electronics/canClone(var/obj/O)
+	return istype(O, /obj/machinery/smartglass_electronics)
 	
-/obj/machinery/smartglass_electronics/clone(var/obj/machinery/smartglass_electronics/CLONE)
-	id_tag = CLONE.id_tag
+/obj/machinery/smartglass_electronics/clone(var/obj/machinery/smartglass_electronics/O)
+	id_tag = O.id_tag
 	return 1
 
 /*************************************

--- a/code/game/machinery/smartglass.dm
+++ b/code/game/machinery/smartglass.dm
@@ -36,8 +36,7 @@
 	..()
 	radio_connection = radio_controller.add_object(src, frequency, RADIO_AIRLOCK)
 	GLASS = loc
-	testing("[src] now located at [GLASS]")
-	power_change()
+	GLASS.smart_toggle()
 
 /obj/machinery/smartglass_electronics/Destroy()
 	radio_controller.remove_object(src, frequency)
@@ -45,39 +44,6 @@
 	radio_connection = null
 	..()
 	
-/**********************
-// POWER SHIT
-**********************/
-	
-/obj/machinery/smartglass_electronics/emp_act(severity)
-	switch(severity)
-		if(1)
-			if(prob(90))
-				GLASS.smart_toggle()
-				if(prob(60))
-					GLASS.smart_toggle()
-					if(prob(30))
-						GLASS.smart_toggle()
-		if(2)
-			if(prob(50))
-				GLASS.smart_toggle()
-	
-	
-/obj/machinery/smartglass_electronics/power_change()
-	testing("[src] running power_change()")
-	if(stat & (NOPOWER | BROKEN) || !use_power() || !auto_use_power())
-		if (!smart_transparency)
-			smart_transparency = !smart_transparency
-			GLASS.smart_toggle()
-			testing("[src] switched modes during power_change()")
-	testing("[src] power_change() complete")
-	
-
-/obj/machinery/smartglass_electronics/use_power()
-	areaMaster = GLASS.areaMaster
-	testing("setting areaMaster [areaMaster] on [src]()")
-	return ..()
-		
 /**********************
 // SMARTGLASS PROCS
 **********************/
@@ -125,6 +91,13 @@
 
 	return handle_multitool_topic(href,href_list,usr)
 	
+/obj/machinery/smartglass_electronics/canClone(var/obj/CLONE)
+	return istype(CLONE, /obj/machinery/smartglass_electronics)
+	
+/obj/machinery/smartglass_electronics/clone(var/obj/machinery/smartglass_electronics/CLONE)
+	id_tag = CLONE.id_tag
+	return 1
+
 /*************************************
 // RADIO SHIT
 *************************************/

--- a/code/game/machinery/smartglass.dm
+++ b/code/game/machinery/smartglass.dm
@@ -42,6 +42,9 @@
 	electromagic=new(GLASS,GLASS)
 	electromagic.idle_usage=idle_power_usage
 	electromagic.active_usage=active_power_usage
+	electromagic.power_changed.Add(src,"power_change")
+	electromagic.use = 2
+	electromagic.set_enabled()
 
 /obj/machinery/smartglass_electronics/Destroy()
 	radio_controller.remove_object(src, frequency)
@@ -56,12 +59,6 @@
 // POWER SHIT
 **********************/
 	
-/obj/machinery/smartglass_electronics/initialize()
-	electromagic.power_changed.Add(src,"power_change")
-	electromagic.use = 2
-	electromagic.set_enabled()
-
-
 /obj/machinery/smartglass_electronics/emp_act(severity)
 	if(stat & (BROKEN|NOPOWER))
 		..(severity)

--- a/code/game/machinery/smartglass.dm
+++ b/code/game/machinery/smartglass.dm
@@ -20,7 +20,7 @@
 	
 	//Smartglass vars
 	var/smart_transparency = 0
-	var/obj/structure/window/GLASS //Ref to the window we're in
+	var/obj/structure/window/Ourwindow //Ref to the window we're in
 	
 	//Radio vars
 	var/id_tag	
@@ -35,8 +35,8 @@
 /obj/machinery/smartglass_electronics/New()
 	..()
 	radio_connection = radio_controller.add_object(src, frequency, RADIO_AIRLOCK)
-	GLASS = loc
-	GLASS.smart_toggle()
+	Ourwindow = loc
+	Ourwindow.smart_toggle()
 
 /obj/machinery/smartglass_electronics/Destroy()
 	radio_controller.remove_object(src, frequency)
@@ -45,12 +45,12 @@
 	..()
 	
 /**********************
-// SMARTGLASS PROCS
+// SMARTOurwindow PROCS
 **********************/
 			
 /obj/machinery/smartglass_electronics/proc/toggle_smart_transparency()
 	smart_transparency = !smart_transparency
-	GLASS.smart_toggle()
+	Ourwindow.smart_toggle()
 	if (use_power == 1)
 		use_power = 2
 	else
@@ -83,7 +83,7 @@
 	if(!canGhostWrite(usr,src,"",ghost_flags))
 		if(usr.restrained() || usr.lying || usr.stat)
 			return 1
-		if ((!in_range(GLASS, usr) || !istype(GLASS.loc, /turf)) && !istype(usr, /mob/living/silicon))
+		if ((!in_range(Ourwindow, usr) || !istype(Ourwindow.loc, /turf)) && !istype(usr, /mob/living/silicon))
 			to_chat(usr, "<span class='warning'>WARNING: Connection failure. Reduce range.</span>")
 			return 1
 	else if(!custom_aghost_alerts)
@@ -102,7 +102,7 @@
 // RADIO SHIT
 *************************************/
 		
-/obj/machinery/smartglass_electronics/multitool_topic(var/mob/user, var/list/href_list, var/obj/structure/window/GLASS)
+/obj/machinery/smartglass_electronics/multitool_topic(var/mob/user, var/list/href_list, var/obj/structure/window/Ourwindow)
 	if("set_id" in href_list)
 		var/newid = copytext(reject_bad_text(input(usr, "Specify the new ID tag for this machine", src, id_tag) as null|text), 1, MAX_MESSAGE_LEN)
 		if(newid)

--- a/code/game/machinery/smartglass.dm
+++ b/code/game/machinery/smartglass.dm
@@ -12,21 +12,24 @@
 	icon_state = "access_control_standby"
 	anchored = 0
 	density = 0
-	use_power = 2
+	use_power = 0 //Apparently we use power_connection for this
 	idle_power_usage = 0
-	active_power_usage = 5
+	active_power_usage = 50
 	power_channel = ENVIRON
 	machine_flags = MULTITOOL_MENU
 	
 	//Smartglass vars
 	var/smart_power = 0
-	var/one_way_power = 0
 	var/obj/structure/window/GLASS //Ref to the window we're in
 	
 	//Radio vars
 	var/id_tag	
 	var/frequency = 1449
 	var/datum/radio_frequency/radio_connection
+	
+	//power vars
+	var/datum/power_connection/consumer/electromagic = null
+	
 	
 /obj/machinery/smartglass_electronics/cultify()
 	qdel(src)
@@ -36,69 +39,72 @@
 	..()
 	GLASS = loc
 	radio_connection = radio_controller.add_object(src, frequency, RADIO_AIRLOCK)
+	electromagic=new(src,src)
+	electromagic.idle_usage=idle_power_usage
+	electromagic.active_usage=active_power_usage
+
+/obj/machinery/smartglass_electronics/Destroy()
+	radio_controller.remove_object(src, frequency)
+	qdel(radio_connection)
+	radio_connection = null
+	if(electromagic)
+		qdel(electromagic)
+		electromagic = null
+	..()
 	
-//Multitool menu needs to communicate with the glass the electronics are inside
+/**********************
+// POWER SHIT
+**********************/
+	
+/obj/machinery/smartglass_electronics/initialize()
+	electromagic.power_changed.Add(src,"power_change")
+	electromagic.use = 2
+	electromagic.set_enabled()
+
+
+/obj/machinery/smartglass_electronics/emp_act(severity)
+	if(stat & (BROKEN|NOPOWER))
+		..(severity)
+		return
+	power_change()
+	..(severity)	
+	//should add randomized window states here	
+	
+/obj/machinery/smartglass_electronics/power_change()
+	if(stat & (NOPOWER | BROKEN))
+		if (smart_power)
+			smart_power = 0
+			GLASS.smart_toggle()
+
+/**********************
+// SMARTGLASS PROCS
+**********************/
+			
+/obj/machinery/smartglass_electronics/proc/toggle_smart_power()
+	if (smart_power)
+		smart_power = 0
+	else
+		smart_power = 1
+	GLASS.smart_toggle()
+	return smart_power
+
+
+/**********************
+// MULTITOOL SHIT
+**********************/
 
 /obj/machinery/smartglass_electronics/multitool_menu(var/mob/user)
 	return {"
 		<ul>
 			<li>[format_tag("ID Tag", "id_tag","set_id")]</a></li>
 			<li><a href='?src=\ref[src];transparentoggle=1'>Toggle Transparency</a></li>
-			<li><a href='?src=\ref[src];onewaytoggle=1'>Toggle One-way mode</a></li>
 		</ul>
 		"}	
-
-/obj/machinery/smartglass_electronics/proc/toggle_smart_power()
-	if(stat & (NOPOWER | BROKEN))
-		power_change()
-	if (smart_power)
-		smart_power = 0
-		if (active_power_usage > 5)
-			active_power_usage -= 5
-		if (!one_way_power)
-			use_power = 0
-	else
-		smart_power = 1
-		active_power_usage += 5
-		use_power = 2
-	GLASS.smart_toggle()
-	return smart_power
-
-/obj/machinery/smartglass_electronics/proc/toggle_oneway_power()
-	if(stat & (NOPOWER | BROKEN))
-		power_change()
-	if(!GLASS.one_way && !GLASS.one_way_smart)
-		return
-	if (one_way_power)
-		one_way_power = 0
-		if (active_power_usage > 5)
-			active_power_usage -= 5
-		if (!smart_power)
-			use_power = 0
-	else
-		one_way_power = 1
-		active_power_usage += 5
-		use_power = 2
-	GLASS.oneway_toggle()
-	return one_way_power
-
-
-/obj/machinery/smartglass_electronics/power_change()
-	if(stat & (NOPOWER | BROKEN))
-		if (smart_power)
-			smart_power = 0
-			GLASS.smart_toggle()
-		if (one_way_power)
-			one_way_power = 0
-			GLASS.oneway_toggle()
-		if (use_power)
-			use_power = 0
-		if (active_power_usage > 5)
-			active_power_usage = 5
 		
-// This is here to allow access to the electronics.
+// Overwrite standard behavior else it'll never work
 /obj/machinery/smartglass_electronics/Topic(href, href_list)
 	if(stat & (NOPOWER|BROKEN))
+		to_chat(usr, "<span class='warning'>WARNING: Device is not powered.</span>")
 		return 1
 	if(href_list["close"])
 		return
@@ -115,8 +121,7 @@
 		log_adminghost("[key_name(usr)] screwed with [src] ([href])!")
 
 	return handle_multitool_topic(href,href_list,usr)
-		
-		
+	
 /*************************************
 // RADIO SHIT
 *************************************/
@@ -133,10 +138,6 @@
 		toggle_smart_power()
 		return MT_UPDATE	
 	
-	if("onewaytoggle" in href_list)
-		toggle_oneway_power()
-		return MT_UPDATE
-	
 	return ..()
 	
 /obj/machinery/smartglass_electronics/receive_signal(datum/signal/signal)
@@ -150,13 +151,5 @@
 		
 		if("toggle_transparency")
 			toggle_smart_power()
+
 			
-		if("toggle_oneway")
-			toggle_oneway_power()
-			
-			
-/obj/machinery/smartglass_electronics/Destroy()
-	..()
-	radio_controller.remove_object(src, frequency)
-	qdel(radio_connection)
-	radio_connection = null

--- a/code/game/machinery/smartglass.dm
+++ b/code/game/machinery/smartglass.dm
@@ -34,6 +34,7 @@
 	
 /obj/machinery/smartglass_electronics/New()
 	..()
+	GLASS = loc
 	radio_connection = radio_controller.add_object(src, frequency, RADIO_AIRLOCK)
 	
 //Multitool menu needs to communicate with the glass the electronics are inside
@@ -45,27 +46,15 @@
 			<li><a href='?src=\ref[src];transparentoggle=1'>Toggle Transparency</a></li>
 			<li><a href='?src=\ref[src];onewaytoggle=1'>Toggle One-way mode</a></li>
 		</ul>
-		"}
-	
-	
-/*
-	var/dat = "[format_tag("ID Tag", "id_tag","set_id")]</a>"
-	dat += "<A href='?src=\ref[src];transparentoggle=1`>Toggle_Transparency</a>"
-	if (GLASS.one_way)
-		dat += "<A href='?src=\ref[src];onewaytoggle=1`>Toggle_Oneway</a>"
-	return dat
-*/
-/*	
-//			[format_tag("ID Tag","id_tag")]
-			
-			<li>[format_tag("Transparency", "smart_power","toggle_smart_power")]</a></li></br>
-			<li>[format_tag("One-way", "one_way_power","toggle_oneway_power")]</a></li></br>
-*/			
+		"}	
 
 /obj/machinery/smartglass_electronics/proc/toggle_smart_power()
+	if(stat & (NOPOWER | BROKEN))
+		power_change()
 	if (smart_power)
 		smart_power = 0
-		active_power_usage -= 5
+		if (active_power_usage > 5)
+			active_power_usage -= 5
 		if (!one_way_power)
 			use_power = 0
 	else
@@ -76,11 +65,14 @@
 	return smart_power
 
 /obj/machinery/smartglass_electronics/proc/toggle_oneway_power()
+	if(stat & (NOPOWER | BROKEN))
+		power_change()
 	if(!GLASS.one_way && !GLASS.one_way_smart)
 		return
 	if (one_way_power)
 		one_way_power = 0
-		active_power_usage -= 5
+		if (active_power_usage > 5)
+			active_power_usage -= 5
 		if (!smart_power)
 			use_power = 0
 	else
@@ -99,6 +91,10 @@
 		if (one_way_power)
 			one_way_power = 0
 			GLASS.oneway_toggle()
+		if (use_power)
+			use_power = 0
+		if (active_power_usage > 5)
+			active_power_usage = 5
 		
 // This is here to allow access to the electronics.
 /obj/machinery/smartglass_electronics/Topic(href, href_list)

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -4,6 +4,7 @@
  *		Reinforced glass sheets
  *		Plasma Glass Sheets
  *		Reinforced Plasma Glass Sheets (AKA Holy fuck strong windows)
+ *		Smart Glass Sheets
  */
 
 /obj/item/stack/sheet/glass

--- a/code/game/objects/items/stacks/sheets/light.dm
+++ b/code/game/objects/items/stacks/sheets/light.dm
@@ -1,7 +1,7 @@
 /obj/item/stack/light_w
-	name = "wired glass tiles"
-	singular_name = "wired glass floor tile"
-	desc = "A glass tile, which is wired, somehow."
+	name = "wired glass sheets"
+	singular_name = "wired glass sheet"
+	desc = "A sheet of glass with wire attached."
 	icon_state = "glass_wire"
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/sheets_n_ores.dmi', "right_hand" = 'icons/mob/in-hand/right/sheets_n_ores.dmi')
 	w_class = W_CLASS_MEDIUM

--- a/code/game/objects/structures/fullwindow.dm
+++ b/code/game/objects/structures/fullwindow.dm
@@ -149,7 +149,7 @@
 	base_state = "fwindow"
 	health = 30
 	sheettype = /obj/item/stack/sheet/glass/rglass //Ditto above
-	
+
 #undef WINDOWLOOSE
 #undef WINDOWLOOSEFRAME
 #undef WINDOWUNSECUREFRAME

--- a/code/game/objects/structures/fullwindow.dm
+++ b/code/game/objects/structures/fullwindow.dm
@@ -149,7 +149,7 @@
 	base_state = "fwindow"
 	health = 30
 	sheettype = /obj/item/stack/sheet/glass/rglass //Ditto above
-
+	
 #undef WINDOWLOOSE
 #undef WINDOWLOOSEFRAME
 #undef WINDOWUNSECUREFRAME

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -330,6 +330,9 @@ var/list/one_way_windows
 	
 	if(istype(W, /obj/item/stack/light_w))
 		var/obj/item/stack/light_w/LT = W
+		if (!anchored)
+			to_chat(user, "<span class='notice'>Secure the window before trying this.</span>")
+			return 0
 		if (smartwindow)
 			to_chat(user, "<span class='notice'>This window already has electronics in it.</span>")
 			return 0

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -257,14 +257,26 @@ var/list/one_way_windows
 		return
 	attack_generic(user, rand(10, 15))
 
-/obj/structure/window/proc/smart_toggle(var/state) //For "smart" windows
-	if(state) //Power on, visibility 0
+/obj/structure/window/proc/smart_toggle() //For "smart" windows
+	if(opacity)
 		animate(src, color="#FFFFFF", time=5)
 		set_opacity(0)
+		return opacity
 	else
 		animate(src, color="#222222", time=5)
 		set_opacity(1)
-	
+		return opacity
+
+/obj/structure/window/proc/oneway_toggle() //For "smart" windows
+	if(src in one_way_windows) 
+		one_way_windows.Remove(src)
+		overlays -= oneway_overlay
+		return 1
+	else 
+		one_way_windows.Add(src)
+		overlays += oneway_overlay
+		return 0
+		
 /obj/structure/window/attackby(obj/item/weapon/W as obj, mob/living/user as mob)
 
 	if(istype(W, /obj/item/weapon/grab) && Adjacent(user))
@@ -310,7 +322,7 @@ var/list/one_way_windows
 	
 	if(istype(W, /obj/item/stack/sheet/mineral/plastic))
 		if(one_way)
-			to_chat(user, "<span class='notice'>This [src] already has one-way tint on it.</span>")
+			to_chat(user, "<span class='notice'>This window already has one-way tint on it.</span>")
 			return
 		var/obj/item/stack/sheet/mineral/plastic/P = W
 		one_way = 1
@@ -318,7 +330,7 @@ var/list/one_way_windows
 			one_way_windows = list()
 		one_way_windows.Add(src)
 		P.use(1)
-		to_chat(user, "<span class='notice'>You place a sheet of plastic over the [src].</span>")
+		to_chat(user, "<span class='notice'>You place a sheet of plastic over the window.</span>")
 		overlays += oneway_overlay
 		return
 
@@ -326,19 +338,20 @@ var/list/one_way_windows
 	if(istype(W, /obj/item/stack/light_w))
 		var/obj/item/stack/light_w/LT = W
 		if (smartwindow)
-			to_chat(user, "<span class='notice'>This [src] already has electronics in it.</span>")
+			to_chat(user, "<span class='notice'>This window already has electronics in it.</span>")
 			return
 		LT.use(1)
-		to_chat(user, "<span class='notice'>You add some electronics to the [src].</span>")	
-		smartwindow = new /obj/machinery/smartglass_electronics
+		to_chat(user, "<span class='notice'>You add some electronics to the window.</span>")	
+		smartwindow = new /obj/machinery/smartglass_electronics(src.contents)
+		smartwindow.GLASS = src
 		return
 		
 		
 	if(ismultitool(W) && smartwindow)
 		//has to relay to machine inside the window
-		smart_toggle(opacity) //debug option to just toggle the transparency
+		//smart_toggle(opacity) //debug option to just toggle the transparency
 		
-		//smartwindow.multitool_menu(user)
+		smartwindow.update_multitool_menu(user)
 		return
 		
 	//Start construction and deconstruction, absolute priority over the other object interactions to avoid hitting the window

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -339,7 +339,7 @@ var/list/one_way_windows
 		LT.use(1)
 		to_chat(user, "<span class='notice'>You add some electronics to the window.</span>")	
 		smartwindow = new /obj/machinery/smartglass_electronics(src)
-		smartwindow.GLASS = src
+		smartwindow.Ourwindow = src
 		return 1
 		
 		

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -37,7 +37,6 @@ var/list/one_way_windows
 
 	var/one_way = 0 //If set to 1, it will act as a one-way window.
 	var/obj/machinery/smartglass_electronics/smartwindow //holds internal machinery
-	var/one_way_smart = 0
 
 /obj/structure/window/New(loc)
 
@@ -270,21 +269,6 @@ var/list/one_way_windows
 		animate(src, color="#222222", time=5)
 		set_opacity(1)
 	return opacity
-
-/obj/structure/window/proc/oneway_toggle() //For "smart" windows
-	if (!one_way && !one_way_smart)
-		return
-	if(one_way) 
-		one_way_smart = 1
-		one_way = 0
-		one_way_windows.Remove(src)
-		overlays -= oneway_overlay
-	else 
-		one_way_windows.Add(src)
-		overlays += oneway_overlay
-		one_way = 1
-		one_way_smart = 0
-	return one_way_smart
 		
 /obj/structure/window/attackby(obj/item/weapon/W as obj, mob/living/user as mob)
 
@@ -327,8 +311,6 @@ var/list/one_way_windows
 			one_way_windows.Remove(src)
 			drop_stack(/obj/item/stack/sheet/mineral/plastic, get_turf(user), 1, user)
 			overlays -= oneway_overlay
-			if (one_way_smart)
-				one_way_smart = 0
 			return
 	
 	if(istype(W, /obj/item/stack/sheet/mineral/plastic))
@@ -355,8 +337,6 @@ var/list/one_way_windows
 		to_chat(user, "<span class='notice'>You add some electronics to the window.</span>")	
 		smartwindow = new /obj/machinery/smartglass_electronics(src)
 		smart_toggle()
-		if (one_way)
-			oneway_toggle()
 		return 1
 		
 		

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -420,11 +420,12 @@ var/list/one_way_windows
 					update_nearby_tiles() //Ditto above, but in reverse
 					update_nearby_icons()
 					update_icon()
-					qdel(smartwindow)
-					smartwindow = null
-					if (opacity)
-						smart_toggle()
-					drop_stack(/obj/item/stack/light_w, get_turf(src), 1, user)
+					if(smartwindow)
+						qdel(smartwindow)
+						smartwindow = null
+						if (opacity)
+							smart_toggle()
+						drop_stack(/obj/item/stack/light_w, get_turf(src), 1, user)
 					return
 
 				if(istype(W, /obj/item/weapon/weldingtool))

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -25,7 +25,6 @@ var/list/one_way_windows
 	var/sheettype = /obj/item/stack/sheet/glass/glass //Used for deconstruction
 	var/sheetamount = 1 //Number of sheets needed to build this window (determines how much shit is spawned via Destroy())
 	var/reinforced = 0 //Used for deconstruction steps
-	var/obj/machinery/smartglass_electronics/smartwindow //For opaque/transparent windows. Also holds the internal machinery.
 	penetration_dampening = 1
 
 	var/obj/abstract/Overlays/damage_overlay
@@ -37,6 +36,8 @@ var/list/one_way_windows
 	var/fire_volume_mod = 100
 
 	var/one_way = 0 //If set to 1, it will act as a one-way window.
+	var/obj/machinery/smartglass_electronics/smartwindow //holds internal machinery
+	var/one_way_smart = 0
 
 /obj/structure/window/New(loc)
 
@@ -65,7 +66,7 @@ var/list/one_way_windows
 	if(!anchored)
 		to_chat(user, "It appears to be completely loose and movable.")
 	if(smartwindow)
-		to_chat(user, "It is NT-15925 SmartGlass compliant.")
+		to_chat(user, "It's NT-15925 SmartGlass™ compliant.")
 	if(one_way)
 		to_chat(user, "It has a plastic coating.")
 	//switch most likely can't take inequalities, so here's that if block
@@ -272,16 +273,20 @@ var/list/one_way_windows
 		return opacity
 
 /obj/structure/window/proc/oneway_toggle() //For "smart" windows
-	if (!one_way)
+	if (!one_way && !one_way_smart)
 		return
-	if(src in one_way_windows) 
+	if(one_way) 
+		one_way_smart = 1
+		one_way = 0
 		one_way_windows.Remove(src)
 		overlays -= oneway_overlay
-		return 1
+		return "ON"
 	else 
 		one_way_windows.Add(src)
 		overlays += oneway_overlay
-		return 0
+		one_way = 1
+		one_way_smart = 0
+		return "OFF"
 		
 /obj/structure/window/attackby(obj/item/weapon/W as obj, mob/living/user as mob)
 
@@ -324,6 +329,8 @@ var/list/one_way_windows
 			one_way_windows.Remove(src)
 			drop_stack(/obj/item/stack/sheet/mineral/plastic, get_turf(user), 1, user)
 			overlays -= oneway_overlay
+			if (one_way_smart)
+				one_way_smart = 0
 			return
 	
 	if(istype(W, /obj/item/stack/sheet/mineral/plastic))

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -64,6 +64,10 @@ var/list/one_way_windows
 /obj/structure/window/proc/examine_health(mob/user)
 	if(!anchored)
 		to_chat(user, "It appears to be completely loose and movable.")
+	if(smartwindow)
+		to_chat(user, "It is NT-15925 SmartGlass compliant.")
+	if(one_way)
+		to_chat(user, "It has a plastic coating.")
 	//switch most likely can't take inequalities, so here's that if block
 	if(health >= initial(health)) //Sanity
 		to_chat(user, "It's in perfect shape without a single scratch.")
@@ -268,6 +272,8 @@ var/list/one_way_windows
 		return opacity
 
 /obj/structure/window/proc/oneway_toggle() //For "smart" windows
+	if (!one_way)
+		return
 	if(src in one_way_windows) 
 		one_way_windows.Remove(src)
 		overlays -= oneway_overlay
@@ -339,12 +345,15 @@ var/list/one_way_windows
 		var/obj/item/stack/light_w/LT = W
 		if (smartwindow)
 			to_chat(user, "<span class='notice'>This window already has electronics in it.</span>")
-			return
+			return 0
 		LT.use(1)
 		to_chat(user, "<span class='notice'>You add some electronics to the window.</span>")	
-		smartwindow = new /obj/machinery/smartglass_electronics(src.contents)
+		smartwindow = new /obj/machinery/smartglass_electronics(src)
 		smartwindow.GLASS = src
-		return
+		smart_toggle()
+		if (one_way)
+			oneway_toggle()
+		return 1
 		
 		
 	if(ismultitool(W) && smartwindow)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -335,9 +335,8 @@ var/list/one_way_windows
 			return 0
 		LT.use(1)
 		to_chat(user, "<span class='notice'>You add some electronics to the window.</span>")	
-		smartwindow = new /obj/machinery/smartglass_electronics(src.loc)
+		smartwindow = new /obj/machinery/smartglass_electronics(src)
 		smartwindow.GLASS = src
-		smart_toggle()
 		return 1
 		
 		

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -335,7 +335,8 @@ var/list/one_way_windows
 			return 0
 		LT.use(1)
 		to_chat(user, "<span class='notice'>You add some electronics to the window.</span>")	
-		smartwindow = new /obj/machinery/smartglass_electronics(src)
+		smartwindow = new /obj/machinery/smartglass_electronics(src.loc)
+		smartwindow.GLASS = src
 		smart_toggle()
 		return 1
 		
@@ -393,11 +394,12 @@ var/list/one_way_windows
 					update_nearby_tiles() //Needed if it's a full window, since unanchored windows don't link
 					update_nearby_icons()
 					update_icon()
-					qdel(smartwindow)
-					smartwindow = null
-					if (opacity)
-						smart_toggle()
-					drop_stack(/obj/item/stack/light_w, get_turf(src), 1, user)
+					if(smartwindow)
+						qdel(smartwindow)
+						smartwindow = null
+						if (opacity)
+							smart_toggle()
+						drop_stack(/obj/item/stack/light_w, get_turf(src), 1, user)
 					//Perform pressure check since window no longer blocks air
 					var/pdiff = performWallPressureCheck(src.loc)
 					if(pdiff > 0)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -266,11 +266,10 @@ var/list/one_way_windows
 	if(opacity)
 		animate(src, color="#FFFFFF", time=5)
 		set_opacity(0)
-		return opacity
 	else
 		animate(src, color="#222222", time=5)
 		set_opacity(1)
-		return opacity
+	return opacity
 
 /obj/structure/window/proc/oneway_toggle() //For "smart" windows
 	if (!one_way && !one_way_smart)
@@ -280,13 +279,12 @@ var/list/one_way_windows
 		one_way = 0
 		one_way_windows.Remove(src)
 		overlays -= oneway_overlay
-		return "ON"
 	else 
 		one_way_windows.Add(src)
 		overlays += oneway_overlay
 		one_way = 1
 		one_way_smart = 0
-		return "OFF"
+	return one_way_smart
 		
 /obj/structure/window/attackby(obj/item/weapon/W as obj, mob/living/user as mob)
 
@@ -356,7 +354,6 @@ var/list/one_way_windows
 		LT.use(1)
 		to_chat(user, "<span class='notice'>You add some electronics to the window.</span>")	
 		smartwindow = new /obj/machinery/smartglass_electronics(src)
-		smartwindow.GLASS = src
 		smart_toggle()
 		if (one_way)
 			oneway_toggle()
@@ -364,11 +361,8 @@ var/list/one_way_windows
 		
 		
 	if(ismultitool(W) && smartwindow)
-		//has to relay to machine inside the window
-		//smart_toggle(opacity) //debug option to just toggle the transparency
-		
 		smartwindow.update_multitool_menu(user)
-		return
+		return 
 		
 	//Start construction and deconstruction, absolute priority over the other object interactions to avoid hitting the window
 
@@ -419,6 +413,11 @@ var/list/one_way_windows
 					update_nearby_tiles() //Needed if it's a full window, since unanchored windows don't link
 					update_nearby_icons()
 					update_icon()
+					qdel(smartwindow)
+					smartwindow = null
+					if (opacity)
+						smart_toggle()
+					drop_stack(/obj/item/stack/light_w, get_turf(src), 1, user)
 					//Perform pressure check since window no longer blocks air
 					var/pdiff = performWallPressureCheck(src.loc)
 					if(pdiff > 0)
@@ -437,6 +436,11 @@ var/list/one_way_windows
 					update_nearby_tiles() //Ditto above, but in reverse
 					update_nearby_icons()
 					update_icon()
+					qdel(smartwindow)
+					smartwindow = null
+					if (opacity)
+						smart_toggle()
+					drop_stack(/obj/item/stack/light_w, get_turf(src), 1, user)
 					return
 
 				if(istype(W, /obj/item/weapon/weldingtool))

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -470,6 +470,7 @@
 #include "code\game\machinery\scp_294.dm"
 #include "code\game\machinery\shieldgen.dm"
 #include "code\game\machinery\Sleeper.dm"
+#include "code\game\machinery\smartglass.dm"
 #include "code\game\machinery\station_map.dm"
 #include "code\game\machinery\status_display.dm"
 #include "code\game\machinery\suit_dispenser.dm"


### PR DESCRIPTION
![smartglass](https://user-images.githubusercontent.com/8468269/30299697-27c4106e-9751-11e7-981d-900f36b453ac.gif)
General idea:
https://streamable.com/rk43v
Applying to windows:
https://streamable.com/x7uit
Button functionality:
https://streamable.com/qxj3x
Windoors:
https://streamable.com/u6td8

### Functionality:
- Smartglass can be ~~powered~~ toggled to be transparent, else is opaque
- Add wired glass (glass + wire) to any window or windoor to convert to smartglass
- Use multitool menu to get/set ID tag for buttons - the command is `toggle_transparency`
- Use multitool menu to toggle transparent/opaque
- Unanchor a window to remove the wired glass from it

🆑 
 - rscadd: Added smartglass; glass that can be digitally switched between transparent and opaque. Apply a wired glass tile to a window or windoor to create it, then multitool it for setup.