### PR TITLE
Windoors are now on the ABOVE_HUMAN_PLANE plane

### DIFF
--- a/__DEFINES/planes+layers.dm
+++ b/__DEFINES/planes+layers.dm
@@ -164,7 +164,8 @@ What is the naming convention for planes or layers?
 
 	#define VEHICLE_LAYER 			0
 	#define CHAIR_ARMREST_LAYER 	0
-	#define OPEN_CURTAIN_LAYER		1
+	#define WINDOOR_LAYER 			1
+	#define OPEN_CURTAIN_LAYER		2
 	// BELOW_OBJ_LAYER				2
 	// OBJ_LAYER 	 				3
 	// ABOVE_OBJ_LAYER				4

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -8,6 +8,8 @@
 	visible = 0.0
 	use_power = 0
 	flags = ON_BORDER
+	plane = ABOVE_HUMAN_PLANE //Make it so it appears above all mobs (AI included), it's a border object anyway
+	layer = WINDOOR_LAYER //Below curtains
 	opacity = 0
 	var/obj/item/weapon/circuitboard/airlock/electronics = null
 	var/dismantled = 0 // To avoid playing the glass shatter sound on Destroy()


### PR DESCRIPTION
fixes https://github.com/vgstation-coders/vgstation13/issues/15406

This also consequently puts it above things like canisters and shit, fixing the issue duny was having on his map PR

![2017-09-09_01-44-45](https://user-images.githubusercontent.com/4043940/30238757-71a9924a-9502-11e7-8744-180f3ddda923.png)

![2017-09-09_01-58-25](https://user-images.githubusercontent.com/4043940/30238760-73ba5ce0-9502-11e7-8a8a-b9f467f09c05.png)


beware the baddy paddy