### PR TITLE
remove src from windoors

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -27,9 +27,9 @@
 
 /obj/machinery/door/window/New()
 	..()
-	if ((istype(src.req_access) && src.req_access.len) || istext(req_access))
-		src.icon_state = "[src.icon_state]"
-		src.base_state = src.icon_state
+	if ((istype(req_access) && req_access.len) || istext(req_access))
+		icon_state = "[icon_state]"
+		base_state = icon_state
 	return
 
 /obj/machinery/door/window/Destroy()
@@ -58,26 +58,26 @@
 	if (!ismob(AM))
 		var/obj/machinery/bot/bot = AM
 		if(istype(bot))
-			if(density && src.check_access(bot.botcard))
+			if(density && check_access(bot.botcard))
 				open()
 				sleep(50)
 				close()
 		else if(istype(AM, /obj/mecha))
 			var/obj/mecha/mecha = AM
 			if(density)
-				if(mecha.occupant && src.allowed(mecha.occupant))
+				if(mecha.occupant && allowed(mecha.occupant))
 					open()
 					sleep(50)
 					close()
 		return
 	if (!( ticker ))
 		return
-	if (src.operating)
+	if (operating)
 		return
-	if (src.density && src.allowed(AM))
+	if (density && allowed(AM))
 		open()
 		// What.
-		if(src.check_access(null))
+		if(check_access(null))
 			sleep(50)
 		else //secure doors close faster
 			sleep(20)
@@ -115,37 +115,37 @@
 /obj/machinery/door/window/open()
 	if (!density) //it's already open you silly cunt
 		return 0
-	if (src.operating == 1) //doors can still open when emag-disabled
+	if (operating == 1) //doors can still open when emag-disabled
 		return 0
 	if (!ticker)
 		return 0
-	if(!src.operating) //in case of emag
-		src.operating = 1
-	flick(text("[]opening", src.base_state), src)
+	if(!operating) //in case of emag
+		operating = 1
+	flick(text("[]opening", base_state), src)
 	playsound(get_turf(src), soundeffect, 100, 1)
-	src.icon_state = text("[]open", src.base_state)
+	icon_state = text("[]open", base_state)
 	sleep(animation_delay)
 
 	explosion_resistance = 0
-	src.density = 0
+	density = 0
 	if (smartwindow && opacity)
 		set_opacity(0) //Else we'd get opaque open windoors!
 		was_opaque = 1
 	update_nearby_tiles()
 
 	if(operating == 1) //emag again
-		src.operating = 0
+		operating = 0
 	return 1
 
 /obj/machinery/door/window/close()
-	if (src.operating)
+	if (operating)
 		return 0
-	src.operating = 1
-	flick(text("[]closing", src.base_state), src)
+	operating = 1
+	flick(text("[]closing", base_state), src)
 	playsound(get_turf(src), soundeffect, 100, 1)
-	src.icon_state = src.base_state
+	icon_state = base_state
 
-	src.density = 1
+	density = 1
 	explosion_resistance = initial(explosion_resistance)
 	if (smartwindow && was_opaque)
 		set_opacity(1)
@@ -154,14 +154,14 @@
 
 	sleep(animation_delay)
 
-	src.operating = 0
+	operating = 0
 	return 1
 
 /obj/machinery/door/window/proc/take_damage(var/damage)
-	src.health = max(0, src.health - damage)
-	if (src.health <= 0)
+	health = max(0, health - damage)
+	if (health <= 0)
 		getFromPool(shard, loc)
-		getFromPool(/obj/item/stack/cable_coil,src.loc,2)
+		getFromPool(/obj/item/stack/cable_coil,loc,2)
 		eject_electronics()
 		qdel(src)
 		return
@@ -187,55 +187,55 @@
 	return
 
 /obj/machinery/door/window/attack_ai(mob/user as mob)
-	src.add_hiddenprint(user)
-	return src.attack_hand(user)
+	add_hiddenprint(user)
+	return attack_hand(user)
 
 /obj/machinery/door/window/attack_paw(mob/living/user as mob)
 	if(istype(user, /mob/living/carbon/alien/humanoid) || istype(user, /mob/living/carbon/slime/adult))
-		if(src.operating)
+		if(operating)
 			return
 		user.delayNextAttack(8)
 		user.do_attack_animation(src, user)
-		src.health = max(0, src.health - 25)
+		health = max(0, health - 25)
 		playsound(get_turf(src), 'sound/effects/Glasshit.ogg', 75, 1)
-		visible_message("<span class='warning'>\The [user] smashes against \the [src.name].</span>", 1)
-		if (src.health <= 0)
+		visible_message("<span class='warning'>\The [user] smashes against \the [name].</span>", 1)
+		if (health <= 0)
 			getFromPool(shard, loc)
 			getFromPool(/obj/item/stack/cable_coil, loc, 2)
 			qdel(src)
 	else
-		return src.attack_hand(user)
+		return attack_hand(user)
 
 
 /obj/machinery/door/window/attack_animal(mob/living/user as mob)
-	if(src.operating)
+	if(operating)
 		return
 	var/mob/living/simple_animal/M = user
 	if(M.melee_damage_upper <= 0)
 		return
 	user.do_attack_animation(src, user)
 	user.delayNextAttack(8)
-	src.health = max(0, src.health - M.melee_damage_upper)
+	health = max(0, health - M.melee_damage_upper)
 	playsound(get_turf(src), 'sound/effects/Glasshit.ogg', 75, 1)
-	visible_message("<span class='warning'>\The [M] [M.attacktext] against \the [src.name].</span>", 1)
-	if (src.health <= 0)
+	visible_message("<span class='warning'>\The [M] [M.attacktext] against \the [name].</span>", 1)
+	if (health <= 0)
 		getFromPool(shard, loc)
 		getFromPool(/obj/item/stack/cable_coil, loc, 2)
 		qdel(src)
 
 
 /obj/machinery/door/window/attack_hand(mob/user as mob)
-	return src.attackby(user, user)
+	return attackby(user, user)
 
 /obj/machinery/door/window/attackby(obj/item/weapon/I as obj, mob/living/user as mob)
 	// Make emagged/open doors able to be deconstructed
-	if (!src.density && src.operating != 1 && iscrowbar(I))
+	if (!density && operating != 1 && iscrowbar(I))
 		user.visible_message("[user] removes the electronics from the windoor assembly.", "You start to remove the electronics from the windoor assembly.")
 		playsound(get_turf(src), 'sound/items/Crowbar.ogg', 100, 1)
-		if (do_after(user, src, 40) && src && !src.density && src.operating != 1)
+		if (do_after(user, src, 40) && src && !density && operating != 1)
 			to_chat(user, "<span class='notice'>You removed the windoor electronics!</span>")
 			make_assembly(user)
-			src.dismantled = 1 // Don't play the glass shatter sound
+			dismantled = 1 // Don't play the glass shatter sound
 			if(smartwindow)
 				qdel(smartwindow)
 				smartwindow = null
@@ -246,7 +246,7 @@
 		return
 
 	//If it's in the process of opening/closing or emagged, ignore the click
-	if (src.operating)
+	if (operating)
 		return
 
 	//If it's Smartglass shit, smartglassify it.
@@ -269,33 +269,33 @@
 		return
 		
 	//If it's a weapon, smash windoor. Unless it's an id card, agent card, ect.. then ignore it (Cards really shouldnt damage a door anyway)
-	if(src.density && istype(I, /obj/item/weapon) && !istype(I, /obj/item/weapon/card))
+	if(density && istype(I, /obj/item/weapon) && !istype(I, /obj/item/weapon/card))
 		var/aforce = I.force
 		user.do_attack_animation(src, I)
 		user.delayNextAttack(8)
 		if(I.damtype == BRUTE || I.damtype == BURN)
-			src.health = max(0, src.health - aforce)
+			health = max(0, health - aforce)
 		playsound(get_turf(src), 'sound/effects/Glasshit.ogg', 75, 1)
 		visible_message("<span class='danger'>[src] was hit by [I].</span>")
-		if (src.health <= 0)
+		if (health <= 0)
 			getFromPool(shard, loc)
-			getFromPool(/obj/item/stack/cable_coil, src.loc, 2)
+			getFromPool(/obj/item/stack/cable_coil, loc, 2)
 			qdel(src)
 		return
 
-	src.add_fingerprint(user)
-	if (!src.requiresID())
+	add_fingerprint(user)
+	if (!requiresID())
 		//don't care who they are or what they have, act as if they're NOTHING
 		user = null
 
 	if (isrobot(user))
-		if (src.density)
+		if (density)
 			return open()
 		else
 			return close()
 
-	if (!src.allowed(user) && src.density)
-		flick(text("[]deny", src.base_state), src)
+	if (!allowed(user) && density)
+		flick(text("[]deny", base_state), src)
 
 	return ..()
 
@@ -304,12 +304,12 @@
 	return hackOpen(used_emag, user)
 
 /obj/machinery/door/window/proc/hackOpen(obj/item/I, mob/user)
-	src.operating = -1
+	operating = -1
 
-	if (src.electronics)
-		src.electronics.icon_state = "door_electronics_smoked"
+	if (electronics)
+		electronics.icon_state = "door_electronics_smoked"
 
-	flick("[src.base_state]spark", src)
+	flick("[base_state]spark", src)
 	sleep(6)
 	open()
 	return 1
@@ -322,7 +322,7 @@
  * w.r.t. the tile it is on.
  */
 /obj/machinery/door/window/proc/is_left_opening()
-	return src.base_state == "left" || src.base_state == "leftsecure"
+	return base_state == "left" || base_state == "leftsecure"
 
 /**
  * Deconstructs a windoor properly. You probably want to delete
@@ -331,41 +331,41 @@
  */
 /obj/machinery/door/window/proc/make_assembly(mob/user as mob)
 	// Windoor assembly
-	var/obj/structure/windoor_assembly/WA = new /obj/structure/windoor_assembly(src.loc)
+	var/obj/structure/windoor_assembly/WA = new /obj/structure/windoor_assembly(loc)
 	set_assembly(user, WA)
 	return WA
 
 /obj/machinery/door/window/proc/set_assembly(mob/user as mob, var/obj/structure/windoor_assembly/WA)
 	WA.name = "Near finished Windoor Assembly"
-	WA.dir = src.dir
+	WA.dir = dir
 	WA.anchored = 1
 	WA.facing = (is_left_opening() ? "l" : "r")
 	WA.secure = ""
 	WA.state = "02"
 	WA.update_icon()
 
-	WA.fingerprints += src.fingerprints
-	WA.fingerprintshidden += src.fingerprints
+	WA.fingerprints += fingerprints
+	WA.fingerprintshidden += fingerprints
 	WA.fingerprintslast = user.ckey
 
 	// Pop out electronics
 	eject_electronics()
 
 /obj/machinery/door/window/proc/eject_electronics()
-	var/obj/item/weapon/circuitboard/airlock/AE = (src.electronics ? src.electronics : new /obj/item/weapon/circuitboard/airlock(src.loc))
-	if (src.electronics)
-		src.electronics = null
+	var/obj/item/weapon/circuitboard/airlock/AE = (electronics ? electronics : new /obj/item/weapon/circuitboard/airlock(loc))
+	if (electronics)
+		electronics = null
 		AE.installed = 0
 	else
 		if(operating == -1)
 			AE.icon_state = "door_electronics_smoked"
 		// Straight from /obj/machinery/door/airlock/attackby()
-		if (src.req_access && src.req_access.len > 0)
-			AE.conf_access = src.req_access
-		else if (src.req_one_access && src.req_one_access.len > 0)
-			AE.conf_access = src.req_one_access
+		if (req_access && req_access.len > 0)
+			AE.conf_access = req_access
+		else if (req_one_access && req_one_access.len > 0)
+			AE.conf_access = req_one_access
 			AE.one_access = 1
-	AE.forceMove(src.loc)
+	AE.forceMove(loc)
 
 /obj/machinery/door/window/brigdoor
 	name = "Secure Window Door"
@@ -394,7 +394,7 @@
 
 /obj/machinery/door/window/plasma/make_assembly(mob/user as mob)
 	// Windoor assembly
-	var/obj/structure/windoor_assembly/plasma/WA = new /obj/structure/windoor_assembly/plasma(src.loc)
+	var/obj/structure/windoor_assembly/plasma/WA = new /obj/structure/windoor_assembly/plasma(loc)
 	set_assembly(user, WA)
 	return WA
 


### PR DESCRIPTION
CTRL+H `src.` into nothing
compiled and tested, opened and closed a windoor, dissassembled and re-assembled, hit it a bit. All seems in order.

windoor code still looks and feels bad but at least i won't cringe every time i write something and see a `src.x` two lines over

definitely going to conflict with smartglass