### PR TITLE
Implements cantpass_flags

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -766,6 +766,9 @@ its easier to just keep the beam vertical.
 /atom/movable/proc/checkpass(passflag)
 	return pass_flags&passflag
 
+/atom/movable/proc/check_cantpass(passflag) //Currently only implemented for PASSMOB (mob_movement.dm)
+	return cantpass_flags&passflag
+
 /datum/proc/setGender(gend = FEMALE)
 	if(!("gender" in vars))
 		CRASH("Oh shit you stupid nigger the [src] doesn't have a gender variable.")

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -17,6 +17,7 @@
 	var/moved_recently = 0
 	var/mob/pulledby = null
 	var/pass_flags = 0
+	var/cantpass_flags = 0
 
 	var/area/areaMaster
 

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -18,6 +18,17 @@
 	..()
 	handle_layer()
 
+//For unanchored/moving chairs: We aren't dense, so let's be a little pickier on what we can and can't pass through. Mobs can't walk through us, so let's not walk through them.
+//NOTE: Vehicles are "moving chairs", but they shouldn't be able to move through people either! The firebird can do this, because pass_flags override cantpass_flags.
+/obj/structure/bed/chair/lock_atom(var/atom/movable/AM)
+	. = ..()
+	cantpass_flags |= PASSMOB
+
+
+/obj/structure/bed/chair/unlock_atom(var/atom/movable/AM)
+	. = ..()
+	cantpass_flags &= ~PASSMOB
+
 /obj/structure/bed/chair/can_spook()
 	. = ..()
 	if(.)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -11,7 +11,11 @@
 		if ((other_mobs && moving_mob.other_mobs))
 			return 1
 
-	return (!mover.density || !density || lying)
+	if(!density || lying)
+		return 1
+
+	if(!mover.density && !mover.check_cantpass(PASSMOB))
+		return 1
 
 /client/Northeast()
 	treat_hotkeys(NORTHEAST)
@@ -574,7 +578,7 @@
 			. += MOB_RUN_TALLY+config.run_speed
 		if("walk")
 			. += MOB_WALK_TALLY+config.walk_speed
-	
+
 	var/obj/item/weapon/grab/Findgrab = locate() in src
 	if(Findgrab)
 		. += 7


### PR DESCRIPTION
I spent 2 hours trying everything I could think of in regards to movement code.

This is what the BYOND documentation says: 
>2.newloc.Enter(src) is called for any turfs or areas that may be entered for the first time, or the container if moving into an obj or mob. neighbor.Cross(src) is called for any movable atoms that may be in collision with this object if the move fully succeeds. If any of these return 0 (failure), then a slide can be cut short but a jump will fail completely.

>3.If any obstacles were encountered via Enter() or Cross() failing, then src.Bump(obstacle) will be called for each of them

And so, we simply can't modify a chair's to_bump because it happens after the Cross() fails or succeeds, and there is no reciprocal proc when an atom is being Cross()ed to have the moving atom check for shit.
Necessarily you gotta do this with the stationary item, in Cross(), and in our code the only things that do that are density and passflags. I had to add cantpass_flags, unless I misunderstand something here.

