### PR TITLE
Starscreen capacitors now require capacitors

### DIFF
--- a/code/WorkInProgress/Cael_Aislinn/ShieldGen/circuits.dm
+++ b/code/WorkInProgress/Cael_Aislinn/ShieldGen/circuits.dm
@@ -51,7 +51,7 @@
 	build_path = "/obj/machinery/shield_capacitor"
 	origin_tech = Tc_MAGNETS + "=3;" + Tc_POWERSTORAGE + "=4"
 	req_components = list(
-							"/obj/item/weapon/stock_parts/manipulator/nano/pico" = 2,
+							"/obj/item/weapon/stock_parts/capacitor" = 2,
 							"/obj/item/weapon/stock_parts/subspace/filter" = 1,
 							"/obj/item/weapon/stock_parts/subspace/treatment" = 1,
 							"/obj/item/weapon/stock_parts/subspace/analyzer" = 1,

--- a/code/WorkInProgress/Cael_Aislinn/ShieldGen/shield_capacitor.dm
+++ b/code/WorkInProgress/Cael_Aislinn/ShieldGen/shield_capacitor.dm
@@ -29,8 +29,8 @@
 
 	component_parts = newlist(
 		/obj/item/weapon/circuitboard/shield_cap,
-		/obj/item/weapon/stock_parts/manipulator/nano/pico,
-		/obj/item/weapon/stock_parts/manipulator/nano/pico,
+		/obj/item/weapon/stock_parts/capacitor,
+		/obj/item/weapon/stock_parts/capacitor,
 		/obj/item/weapon/stock_parts/subspace/filter,
 		/obj/item/weapon/stock_parts/subspace/treatment,
 		/obj/item/weapon/stock_parts/subspace/analyzer,


### PR DESCRIPTION
Capacitors instead of pico manipulators because I feel that makes more sense.
Any capacitors for now, paving the way for a future total rework or just future upgradability.

- [x] update wiki

:cl:
 - tweak: Starscreen shield generators are now built with two capacitors rather than two pico manipulators.