### PR TITLE
Adds two alias commands for smartglass; cycle and toggle

### DIFF
--- a/code/game/machinery/smartglass.dm
+++ b/code/game/machinery/smartglass.dm
@@ -127,5 +127,11 @@
 		
 		if("toggle_transparency")
 			toggle_smart_transparency()
+			
+		if("toggle")
+			toggle_smart_transparency()
+			
+		if("cycle")
+			toggle_smart_transparency()
 
 			

--- a/code/game/machinery/smartglass.dm
+++ b/code/game/machinery/smartglass.dm
@@ -125,13 +125,5 @@
 
 	switch(signal.data["command"])
 		
-		if("toggle_transparency")
-			toggle_smart_transparency()
-			
-		if("toggle")
-			toggle_smart_transparency()
-			
-		if("cycle")
-			toggle_smart_transparency()
-
-			
+		if("toggle_transparency", "toggle", "cycle")
+			toggle_smart_transparency()	


### PR DESCRIPTION
`toggle_transparency` takes too long to write, so the `cycle` command the buttons start with now works too
tested
🆑 
 - tweak: Added two alias commands for smartglass. The three valid commands are now toggle_transparency, toggle, and cycle.