### PR TITLE
Check locked atoms when attempting to cross a mob

### DIFF
--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -8,8 +8,12 @@
 	if(ismob(mover))
 		var/mob/moving_mob = mover
 
-		if ((other_mobs && moving_mob.other_mobs))
+		if ((other_mobs && moving_mob.other_mobs)) //I have no fucking idea what this is. I think it's for dragging via grab, but only if 2+ mobs are being grabbed?
 			return 1
+
+	for(var/atom/movable/passenger in mover.locked_atoms) //If we're being crossed by something with locked atoms, like a chair or something, have ALL of them try to cross us.
+		if(!Cross(passenger, target, height, air_group))
+			return 0
 
 	return (!mover.density || !density || lying)
 
@@ -574,7 +578,7 @@
 			. += MOB_RUN_TALLY+config.run_speed
 		if("walk")
 			. += MOB_WALK_TALLY+config.walk_speed
-	
+
 	var/obj/item/weapon/grab/Findgrab = locate() in src
 	if(Findgrab)
 		. += 7


### PR DESCRIPTION
Fixes #15963 and any other instances of office chairs phasing through mobs while occupied

As discussed in #15965 and #15963

Will eventually give office chairs DENSE_WHILE_LOCKED after I f i x #15964