### PR TITLE
Fixes Advanced Silicate Sprayers thinking everything is a window

### DIFF
--- a/code/game/objects/items/devices/silicate sprayer.dm
+++ b/code/game/objects/items/devices/silicate sprayer.dm
@@ -164,16 +164,16 @@
 	if(get_dist(A, user) > 1) // I purposely don't use proximity_flag so you can get to windows without needing adjacency. (window behind another window for example.)
 		return
 
-	if(!get_amount())
-		to_chat(user, "<span class='notice'>\The [src] is out of silicate!</span>")
-		return 1
-
 	if(iswindow(A))
 		return preattack_window(A, user)
 	else if(istype(A, /turf/simulated/floor/glass))
 		return preattack_glassfloor(A, user)
 
 /obj/item/device/silicate_sprayer/advanced/preattack_window(var/atom/A, var/mob/user)
+	if(!get_amount())
+		to_chat(user, "<span class='notice'>\The [src] is out of silicate!</span>")
+		return 1
+
 	var/obj/structure/window/W = A
 	var/initial_health = initial(W.health)
 
@@ -199,6 +199,10 @@
 	return 1
 
 /obj/item/device/silicate_sprayer/advanced/preattack_glassfloor(var/atom/A, var/mob/user)
+	if(!get_amount())
+		to_chat(user, "<span class='notice'>\The [src] is out of silicate!</span>")
+		return 1
+
 	var/turf/simulated/floor/glass/G = A
 	var/initial_health = initial(G.health)
 


### PR DESCRIPTION
The basic sprayer checks if the sprayer's filled on the proc for repairing windows/floors, while the advanced sprayer checks it in the same proc that checks if the atom is a window, or something like that, so I just changed the advanced sprayer to be in line with the basic one in that regard.

This could probably be done better, but I tested it and it fixes the issue.  At the same time, I discovered another issue wherein you can use the sprayer's repair function once on a fully intact window after reinforcing it, removing the extra health it was given - probably because the repair function just sets the window's health to its default?

I'll mess around with it a bit and see if I can work it out.

Fixes #15934.