### PR TITLE
Inserting money into PDAs now states the amount inserted

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -2243,14 +2243,10 @@ obj/item/device/pda/AltClick()
 		T.date = current_date_string
 		T.time = worldtime2text()
 		id.virtual_wallet.transaction_log.Add(T)
-		if(T.amount == 1)
-			to_chat(user, "<span class='info'>You insert [T.amount] credit into the PDA.</span>")
-			qdel(dosh)
-			updateUsrDialog()
-		else
-			to_chat(user, "<span class='info'>You insert [T.amount] credits into the PDA.</span>")
-			qdel(dosh)
-			updateUsrDialog()
+		to_chat(user, "<span class='info'>You insert [T.amount] credit\s into the PDA.</span>")
+		qdel(dosh)
+		updateUsrDialog()
+
 	return
 
 /obj/item/device/pda/attack(mob/living/carbon/C, mob/living/user as mob)

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -2243,11 +2243,14 @@ obj/item/device/pda/AltClick()
 		T.date = current_date_string
 		T.time = worldtime2text()
 		id.virtual_wallet.transaction_log.Add(T)
-
-		to_chat(user, "<span class='info'>You insert [dosh] into the PDA.</span>")
-		qdel(dosh)
-		updateUsrDialog()
-
+		if(T.amount == 1)
+			to_chat(user, "<span class='info'>You insert [T.amount] credit into the PDA.</span>")
+			qdel(dosh)
+			updateUsrDialog()
+		else
+			to_chat(user, "<span class='info'>You insert [T.amount] credits into the PDA.</span>")
+			qdel(dosh)
+			updateUsrDialog()
 	return
 
 /obj/item/device/pda/attack(mob/living/carbon/C, mob/living/user as mob)


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl: (as the emoji)
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
Changes PDAs to show the actual amount of credits being inserted into them. Previously it would say what kind of credit it was (ie, 'You insert the 100 credit chip' when it could be 100 credits or 100,000 credits).

* rscadd: Inserting credits into PDAs now tells you the amount inserted.

