### PR TITLE
Nerfs the cyborg mat synth.

### DIFF
--- a/code/game/objects/items/devices/mat_synth.dm
+++ b/code/game/objects/items/devices/mat_synth.dm
@@ -39,11 +39,11 @@
 	can_scan = list(/obj/item/stack/tile/carpet, /obj/item/stack/tile/arcade, /obj/item/stack/sheet/wood, /obj/item/stack/sheet/mineral/plastic)
 
 /obj/item/device/material_synth/robot/mommi //MoMMI version, more materials but has very restricted scanning.
-	materials_scanned = list("metal" = /obj/item/stack/sheet/metal,
+	materials_scanned = list("plasma glass" = /obj/item/stack/sheet/glass/plasmaglass,
+							 "reinforced plasma glass" = /obj/item/stack/sheet/glass/plasmarglass,
+							 "metal" = /obj/item/stack/sheet/metal,
 							 "glass" = /obj/item/stack/sheet/glass/glass,
 							 "reinforced glass" = /obj/item/stack/sheet/glass/rglass,
-							 "plasma glass" = /obj/item/stack/sheet/glass/plasmaglass,
-							 "reinforced plasma glass" = /obj/item/stack/sheet/glass/plasmarglass,
 							 "plasteel" = /obj/item/stack/sheet/plasteel)
 	can_scan = list(/obj/item/stack/tile/carpet, /obj/item/stack/tile/arcade, /obj/item/stack/sheet/wood, /obj/item/stack/sheet/mineral/plastic)
 

--- a/code/game/objects/items/devices/mat_synth.dm
+++ b/code/game/objects/items/devices/mat_synth.dm
@@ -38,13 +38,14 @@
 							 "plasteel" = /obj/item/stack/sheet/plasteel)
 	can_scan = list(/obj/item/stack/tile/carpet, /obj/item/stack/tile/arcade, /obj/item/stack/sheet/wood, /obj/item/stack/sheet/mineral/plastic)
 
-/obj/item/device/material_synth/robot/mommi //MoMMI version, more materials and has scanning to help avoid interaction.
+/obj/item/device/material_synth/robot/mommi //MoMMI version, more materials but has very restricted scanning.
 	materials_scanned = list("metal" = /obj/item/stack/sheet/metal,
 							 "glass" = /obj/item/stack/sheet/glass/glass,
 							 "reinforced glass" = /obj/item/stack/sheet/glass/rglass,
 							 "plasma glass" = /obj/item/stack/sheet/glass/plasmaglass,
 							 "reinforced plasma glass" = /obj/item/stack/sheet/glass/plasmarglass,
 							 "plasteel" = /obj/item/stack/sheet/plasteel)
+	can_scan = list(/obj/item/stack/tile/carpet, /obj/item/stack/tile/arcade, /obj/item/stack/sheet/wood, /obj/item/stack/sheet/mineral/plastic)
 
 /obj/item/device/material_synth/update_icon()
 	icon_state = "mat_synth[mode ? "on" : "off"]"

--- a/code/game/objects/items/devices/mat_synth.dm
+++ b/code/game/objects/items/devices/mat_synth.dm
@@ -32,16 +32,19 @@
 							 "glass" = /obj/item/stack/sheet/glass/glass,
 							 "reinforced glass" = /obj/item/stack/sheet/glass/rglass,
 							 "floor tiles" = /obj/item/stack/tile/plasteel,
-							 "metal rods" = /obj/item/stack/rods)
-
-/obj/item/device/material_synth/robot/mommi //MoMMI version, more materials but has very restricted scanning.
-	materials_scanned = list("plasma glass" = /obj/item/stack/sheet/glass/plasmaglass,
+							 "metal rods" = /obj/item/stack/rods,
+							 "plasma glass" = /obj/item/stack/sheet/glass/plasmaglass,
 							 "reinforced plasma glass" = /obj/item/stack/sheet/glass/plasmarglass,
-							 "metal" = /obj/item/stack/sheet/metal,
-							 "glass" = /obj/item/stack/sheet/glass/glass,
-							 "reinforced glass" = /obj/item/stack/sheet/glass/rglass,
 							 "plasteel" = /obj/item/stack/sheet/plasteel)
 	can_scan = list(/obj/item/stack/tile/carpet, /obj/item/stack/tile/arcade, /obj/item/stack/sheet/wood, /obj/item/stack/sheet/mineral/plastic)
+
+/obj/item/device/material_synth/robot/mommi //MoMMI version, more materials and has scanning to help avoid interaction.
+	materials_scanned = list("metal" = /obj/item/stack/sheet/metal,
+							 "glass" = /obj/item/stack/sheet/glass/glass,
+							 "reinforced glass" = /obj/item/stack/sheet/glass/rglass,
+							 "plasma glass" = /obj/item/stack/sheet/glass/plasmaglass,
+							 "reinforced plasma glass" = /obj/item/stack/sheet/glass/plasmarglass,
+							 "plasteel" = /obj/item/stack/sheet/plasteel)
 
 /obj/item/device/material_synth/update_icon()
 	icon_state = "mat_synth[mode ? "on" : "off"]"


### PR DESCRIPTION
# THIS PR IS FOR DISCUSSION ONLY, THE CHANGES IN THIS PR DON'T REFLECT THE FINAL CHANGES AND WILL NOT BE MERGED LIKE THIS.

I plan to balance mat synths as a whole to make it so cyborg mat synths don't outperform other mat synths so largely.
-Make matter carts have varying values and make it so you can turn any type of ore to matter carts. Reverse mat synth.
<s>-Make the mommi and cyborg synth on type of synth where it has the starting list of the mommi one but cannot scan materials.
-After an upgrade module is applied to a cyborg/mommi they can use the unlocked mat synth where it can scan mineral sheets like it's currently.
-Balance the cost of energy used in silicon mat synths when generating sheets. You can make several super power cells for the cost of one matter cart right now, meaning that the cyborg synth can outperform the handheld one by a long shot in terms of efficiency.
-The upgrade for silicons will be similar in cost to make as the handheld mat synth's cost.</s>
(vote failed so not happening)

<s>
For a long time, cyborgs have been abused to create infinite materials making miners feel unnecessary after they bring a single drop of materials as well as being able to create materials that should be hard to obtain like phazon.
This removes ore synth from cyborgs and might make the supply module a bit more commonly picked by cyborgs that want to provide materials.
This effectively makes the cyborg synth have the mommi mat synths scanning abilities. Borgs can still scan some things like plastic, carpet, and some other things but not minerals. This also gives cyborgs plasma stuff (plasteel, plasma glass, R plasma glass) to make up for the loss of the old materials.
</s>
<b>Mommi changes moved to a separate PR. </b>
#16016 

I know this PR is going to get some heavy resistance from many cyborg players, but I think it's time for cheesing mats to be fixed.
:cl:
 * rscdel: Cyborg mat synth no longer can scan/produce mineral sheets.
 * rscadd: Cyborgs mat synth now gets plasma glass, plasteel, and reinforced plasma glass to start to make up for the loss in scanning abilities.