### PR TITLE
Mommi mat synth buff

### DIFF
--- a/code/game/objects/items/devices/mat_synth.dm
+++ b/code/game/objects/items/devices/mat_synth.dm
@@ -34,14 +34,13 @@
 							 "floor tiles" = /obj/item/stack/tile/plasteel,
 							 "metal rods" = /obj/item/stack/rods)
 
-/obj/item/device/material_synth/robot/mommi //MoMMI version, more materials but has very restricted scanning.
-	materials_scanned = list("plasma glass" = /obj/item/stack/sheet/glass/plasmaglass,
-							 "reinforced plasma glass" = /obj/item/stack/sheet/glass/plasmarglass,
-							 "metal" = /obj/item/stack/sheet/metal,
+/obj/item/device/material_synth/robot/mommi //MoMMI version, a few more materials to start with.
+	materials_scanned = list("metal" = /obj/item/stack/sheet/metal,
 							 "glass" = /obj/item/stack/sheet/glass/glass,
 							 "reinforced glass" = /obj/item/stack/sheet/glass/rglass,
-							 "plasteel" = /obj/item/stack/sheet/plasteel)
-	can_scan = list(/obj/item/stack/tile/carpet, /obj/item/stack/tile/arcade, /obj/item/stack/sheet/wood, /obj/item/stack/sheet/mineral/plastic)
+							 "plasteel" = /obj/item/stack/sheet/plasteel,
+							 "plasma glass" = /obj/item/stack/sheet/glass/plasmaglass,
+							 "reinforced plasma glass" = /obj/item/stack/sheet/glass/plasmarglass)
 
 /obj/item/device/material_synth/update_icon()
 	icon_state = "mat_synth[mode ? "on" : "off"]"


### PR DESCRIPTION
**Seperated the changes of #16014** 
This allows mommis to scan/produce any materials they want now similar to the cyborg mat synth. This is intended to allow crabs with keeper law sets to use materials but not use up any from other beings.
:cl:
 * rscadd: MoMMI material synth can now scan/produce more materials.