### PR TITLE
Removes the interaction of slimes(mob) and phazon.

### DIFF
--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -76,6 +76,8 @@
 	Victim = null
 	Target = null
 
+/mob/living/carbon/slime/advanced_mutate()
+	return
 
 /mob/living/carbon/slime/New()
 	var/datum/reagents/R = new/datum/reagents(100)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1712,7 +1712,7 @@
 		return 1
 
 	M.apply_radiation(5, RAD_INTERNAL)
-	if(prob(20))
+	if(prob(20) && !istype(M, /mob/living/carbon/slime))
 		M.advanced_mutate()
 
 /datum/reagent/aluminum

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1712,7 +1712,7 @@
 		return 1
 
 	M.apply_radiation(5, RAD_INTERNAL)
-	if(prob(20) && !istype(M, /mob/living/carbon/slime))
+	if(prob(20))
 		M.advanced_mutate()
 
 /datum/reagent/aluminum


### PR DESCRIPTION
With the recent issues and concerns of slimes on phazon, I have removed the interaction. To say there has been a bit of an uproar about the abuse of phazon in slimes is an understatement.
Resolves #15802 
:cl: 
 * rscdel: Slimes (the mob) can no longer be phazon junkies and get phazon mutations.