### PR TITLE
Fixes Phazon mech breaking immersions

### DIFF
--- a/code/game/mecha/combat/phazon.dm
+++ b/code/game/mecha/combat/phazon.dm
@@ -1,5 +1,5 @@
 /obj/mecha/combat/phazon
-	desc = "An exosuit which can only be described as 'WTF?'."
+	desc = "An exosuit which can only be described as 'What the Fuck?'."
 	name = "Phazon"
 	icon_state = "phazon"
 	initial_icon = "phazon"


### PR DESCRIPTION
changes the last part of the description from "WTF" to "What the Fuck"
honestly i just wanted to do something to remember how to use smartgit

:cl:

- tweak: Phazon mechs no longer break immersions