### PR TITLE
Fixed telecomms heat generation and link dropping, changed construction, deconstruction, repair

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -912,7 +912,6 @@ obj/item/weapon/circuitboard/rdserver
 	origin_tech = Tc_PROGRAMMING + "=4;" + Tc_ENGINEERING + "=4"
 	req_components = list(
 							"/obj/item/weapon/stock_parts/manipulator" = 2,
-							"/obj/item/stack/cable_coil" = 2,
 							"/obj/item/weapon/stock_parts/subspace/filter" = 2)
 
 /obj/item/weapon/circuitboard/telecomms/relay
@@ -923,7 +922,6 @@ obj/item/weapon/circuitboard/rdserver
 	origin_tech = Tc_PROGRAMMING + "=3;" + Tc_ENGINEERING + "=4;" + Tc_BLUESPACE + "=3"
 	req_components = list(
 							"/obj/item/weapon/stock_parts/manipulator" = 2,
-							"/obj/item/stack/cable_coil" = 2,
 							"/obj/item/weapon/stock_parts/subspace/filter" = 2)
 
 /obj/item/weapon/circuitboard/telecomms/bus
@@ -934,7 +932,6 @@ obj/item/weapon/circuitboard/rdserver
 	origin_tech = Tc_PROGRAMMING + "=4;" + Tc_ENGINEERING + "=4"
 	req_components = list(
 							"/obj/item/weapon/stock_parts/manipulator" = 2,
-							"/obj/item/stack/cable_coil" = 1,
 							"/obj/item/weapon/stock_parts/subspace/filter" = 1)
 
 /obj/item/weapon/circuitboard/telecomms/processor
@@ -948,7 +945,6 @@ obj/item/weapon/circuitboard/rdserver
 							"/obj/item/weapon/stock_parts/subspace/filter" = 1,
 							"/obj/item/weapon/stock_parts/subspace/treatment" = 2,
 							"/obj/item/weapon/stock_parts/subspace/analyzer" = 1,
-							"/obj/item/stack/cable_coil" = 2,
 							"/obj/item/weapon/stock_parts/subspace/amplifier" = 1)
 
 /obj/item/weapon/circuitboard/telecomms/server
@@ -959,7 +955,6 @@ obj/item/weapon/circuitboard/rdserver
 	origin_tech = Tc_PROGRAMMING + "=4;" + Tc_ENGINEERING + "=4"
 	req_components = list(
 							"/obj/item/weapon/stock_parts/manipulator" = 2,
-							"/obj/item/stack/cable_coil" = 1,
 							"/obj/item/weapon/stock_parts/subspace/filter" = 1)
 
 /obj/item/weapon/circuitboard/telecomms/broadcaster
@@ -970,7 +965,6 @@ obj/item/weapon/circuitboard/rdserver
 	origin_tech = Tc_PROGRAMMING + "=4;" + Tc_ENGINEERING + "=4;" + Tc_BLUESPACE + "=2"
 	req_components = list(
 							"/obj/item/weapon/stock_parts/manipulator" = 2,
-							"/obj/item/stack/cable_coil" = 1,
 							"/obj/item/weapon/stock_parts/subspace/filter" = 1,
 							"/obj/item/weapon/stock_parts/subspace/crystal" = 1,
 							"/obj/item/weapon/stock_parts/micro_laser/high" = 2)

--- a/code/game/machinery/telecomms/broadcaster.dm
+++ b/code/game/machinery/telecomms/broadcaster.dm
@@ -20,9 +20,21 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 	use_power = 1
 	idle_power_usage = 25
 	machinetype = 5
-	heatgen = 0
 	delay = 7
-	circuitboard = "/obj/item/weapon/circuitboard/telecomms/broadcaster"
+
+/obj/machinery/telecomms/broadcaster/New()
+	..()
+	component_parts = newlist(
+		/obj/item/weapon/circuitboard/telecomms/broadcaster,
+		/obj/item/weapon/stock_parts/subspace/filter,
+		/obj/item/weapon/stock_parts/manipulator,
+		/obj/item/weapon/stock_parts/manipulator,
+		/obj/item/weapon/stock_parts/subspace/crystal,
+		/obj/item/weapon/stock_parts/micro_laser/high,
+		/obj/item/weapon/stock_parts/micro_laser/high
+	)
+
+	RefreshParts()
 
 /obj/machinery/telecomms/broadcaster/receive_information(var/datum/signal/signal, var/obj/machinery/telecomms/machine_from)
 	// Don't broadcast rejected signals
@@ -121,7 +133,7 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 	use_power = 0
 	idle_power_usage = 0
 	machinetype = 6
-	heatgen = 0
+	heating_power = 0
 	var/intercept = 0 // if nonzero, broadcasts all messages to syndicate channel
 	var/syndi_allinone = 0
 	var/raider_allinone = 0

--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -1,118 +1,65 @@
-
-
-
-/*
-
-	All telecommunications interactions:
-
-*/
+#define TELECOMMS_MAX_INTEGRITY 100
 
 /obj/machinery/telecomms
 	var/temp = "" // output message
-	var/construct_op = 0
-	machine_flags = MULTITOOL_MENU
+	machine_flags = MULTITOOL_MENU | SCREWTOGGLE | CROWDESTROY
 
+/obj/item/weapon/circuitboard/telecomms
+	var/integrity = TELECOMMS_MAX_INTEGRITY
 
-/obj/machinery/telecomms/attackby(obj/item/P as obj, mob/user as mob)
+/obj/machinery/telecomms/proc/get_integrity()
+	var/obj/item/weapon/circuitboard/telecomms/C = locate() in component_parts
+	if(istype(C))
+		return C.integrity
+	. = TELECOMMS_MAX_INTEGRITY // If there's no circuitboard (allinone.dm) just treat it as maximum integrity
 
-	// Using a multitool lets you access the receiver's interface
+/obj/machinery/telecomms/proc/set_integrity(var/new_integrity)
+	var/obj/item/weapon/circuitboard/telecomms/C = locate() in component_parts
+	if (!istype(C))
+		return
+	C.integrity = new_integrity
+
+/obj/item/weapon/circuitboard/telecomms/attackby(var/obj/item/W, var/mob/user, var/params)
+	if(issolder(W))
+		if(integrity >= TELECOMMS_MAX_INTEGRITY)
+			to_chat(user, "It's not damaged.")
+			return
+		var/obj/item/weapon/solder/S = W
+		if (!S.remove_fuel(2, user))
+			to_chat(user, "You need more fuel.")
+			return
+		playsound(get_turf(user), 'sound/items/Welder.ogg', 100, 1)
+		integrity = TELECOMMS_MAX_INTEGRITY
+		to_chat(user, "<span class='notice'>You repair the damaged internals of \the [src].</span>")
+		updateUsrDialog()
+		return 1
+
+/obj/machinery/telecomms/attackby(var/obj/item/W, var/mob/user)
 	. = ..()
 	if(.)
-		return .
+		return
+	if(issolder(W))
+		. = TRUE
+		if(!panel_open)
+			to_chat(user, "You need to open the maintenance panel first!")
+			return
+		var/obj/item/weapon/circuitboard/telecomms/C = locate() in component_parts
+		if(istype(C))
+			C.attackby(W, user)
+	update_power_and_icon()
 
-	switch(construct_op)
-		if(0)
-			if(isscrewdriver(P))
-				to_chat(user, "You unfasten the bolts.")
-				playsound(get_turf(src), 'sound/items/Screwdriver.ogg', 50, 1)
-				construct_op ++
-		if(1)
-			if(isscrewdriver(P))
-				to_chat(user, "You fasten the bolts.")
-				playsound(get_turf(src), 'sound/items/Screwdriver.ogg', 50, 1)
-				construct_op --
-			if(iswrench(P))
-				to_chat(user, "You dislodge the external plating.")
-				playsound(get_turf(src), 'sound/items/Ratchet.ogg', 75, 1)
-				construct_op ++
-		if(2)
-			if(iswrench(P))
-				to_chat(user, "You secure the external plating.")
-				playsound(get_turf(src), 'sound/items/Ratchet.ogg', 75, 1)
-				construct_op --
-			if(iswirecutter(P))
-				playsound(get_turf(src), 'sound/items/Wirecutter.ogg', 50, 1)
-				to_chat(user, "You remove the cables.")
-				construct_op ++
-				var/obj/item/stack/cable_coil/A = new /obj/item/stack/cable_coil( user.loc )
-				A.amount = 5
-				stat |= BROKEN // the machine's been borked!
-		if(3)
-			if(istype(P, /obj/item/stack/cable_coil))
-				var/obj/item/stack/cable_coil/A = P
-				if(A.amount >= 5)
-					to_chat(user, "You insert the cables.")
-					A.amount -= 5
-					if(A.amount <= 0)
-						user.drop_item(A, force_drop = 1)
-						returnToPool(A)
-					construct_op --
-					stat &= ~BROKEN // the machine's not borked anymore!
-				else
-					to_chat(user, "You need more cable")
-			if(iscrowbar(P))
-				to_chat(user, "You begin prying out the circuit board and components...")
-				playsound(get_turf(src), 'sound/items/Crowbar.ogg', 50, 1)
-				if(do_after(user, src,60))
-					to_chat(user, "You finish prying out the components.")
-
-					// Drop all the component stuff
-					if(contents.len > 0)
-						for(var/obj/x in src)
-							x.forceMove(user.loc)
-					else
-
-						// If the machine wasn't made during runtime, probably doesn't have components:
-						// manually find the components and drop them!
-						var/newpath = text2path(circuitboard)
-						var/obj/item/weapon/circuitboard/C = new newpath
-						for(var/I in C.req_components)
-							for(var/i = 1, i <= C.req_components[I], i++)
-								newpath = text2path(I)
-								var/obj/item/s = new newpath
-								s.forceMove(user.loc)
-								if(istype(s, /obj/item/stack/cable_coil))
-									var/obj/item/stack/cable_coil/A = s
-									A.amount = 1
-
-						// Drop a circuit board too
-						C.forceMove(user.loc)
-
-					// Create a machine frame and delete the current machine
-					var/obj/machinery/constructable_frame/machine_frame/F = new
-					F.set_build_state(2)
-					F.forceMove(src.loc)
-					qdel(src)
-
-
-/obj/machinery/telecomms/attack_ai(var/mob/user as mob)
-	src.add_hiddenprint(user)
-	attack_hand(user)
-
-/obj/machinery/telecomms/attack_hand(var/mob/user as mob)
+/obj/machinery/telecomms/attack_hand(var/mob/user)
 	update_multitool_menu(user)
 
-/obj/machinery/telecomms/proc/formatInput(var/label,var/varname, var/input)
-	var/value = vars[varname]
-	if(!value || value=="")
-		value="-----"
+/obj/machinery/telecomms/proc/formatInput(var/label, var/varname, var/input)
+	var/value = vars[varname] ||  "-----"
 	return "<b>[label]:</b> <a href=\"?src=\ref[src];input=[varname]\">[value]</a>"
 
-/obj/machinery/telecomms/multitool_menu(var/mob/user,var/obj/item/device/multitool/P)
+/obj/machinery/telecomms/multitool_menu(var/mob/user, var/obj/item/device/multitool/P)
 	// You need a multitool to use this, or be silicon
 	if(!issilicon(user))
 		// istype returns false if the value is null
-		if(!istype(user.get_active_hand(), /obj/item/device/multitool))
+		if(!ismultitool(user.get_active_hand()))
 			return
 
 	if(stat & (BROKEN|NOPOWER))
@@ -122,7 +69,9 @@
 
 	dat = {"
 		<p>[temp]</p>
-		<p><b>Power Status:</b> <a href='?src=\ref[src];input=toggle'>[src.toggled ? "On" : "Off"]</a></p>"}
+		<p><b>Power Status:</b> <a href='?src=\ref[src];input=toggle'>[toggled ? "On" : "Off"]</a></p>
+		<p><b>Integrity:</b> [Clamp(get_integrity(), 0, TELECOMMS_MAX_INTEGRITY)]%</p>
+	"}
 	if(on && toggled)
 		dat += {"
 			<p>[formatInput("Identification String","id","id")]</p>
@@ -130,7 +79,7 @@
 			<p><b>Prefabrication:</b> [autolinkers.len ? "TRUE" : "FALSE"]</p>
 		"}
 		if(hide)
-			dat += "<p>Shadow Link: ACTIVE</p>"
+			dat += "<p><b>Shadow Link: ACTIVE</b></p>"
 
 		//Show additional options for certain machines.
 		dat += Options_Menu()
@@ -284,7 +233,7 @@
 			if("toggle")
 				src.toggled = !src.toggled
 				temp = "<font color = #666633>-% [src] has been [src.toggled ? "activated" : "deactivated"].</font color>"
-				update_power()
+				update_power_and_icon()
 
 			/*
 			if("hide")
@@ -299,11 +248,11 @@
 					temp = "<font color = #666633>-% New ID assigned: \"[id]\" %-</font color>"
 
 			if("network")
-				var/newnet = input(usr, "Specify the new network for this machine. This will break all current links.", src, network) as null|text
+				var/newnet = reject_bad_text(input(usr, "Specify the new network for this machine. This will break all current links.", src, network) as null|text)
 				if(newnet && canAccess(usr))
 
 					if(length(newnet) > 15)
-						temp = "<font color = #666633>-% Too many characters in new network tag %-</font color>"
+						temp = "<font color = #666633>-% Too many characters in new network tag (15 max) %-</font color>"
 
 					else
 						for(var/obj/machinery/telecomms/T in links)
@@ -338,6 +287,7 @@
 	usr.set_machine(src)
 	updateUsrDialog()
 
+// NOTE: A user won't be provided if unlinked by deletion!
 /obj/machinery/telecomms/unlinkFrom(var/mob/user, var/mob/O)
 	if(O && O in links)
 		var/obj/machinery/telecomms/T=O
@@ -369,6 +319,8 @@
 		return 0
 
 /obj/machinery/telecomms/proc/canAccess(var/mob/user)
-	if(issilicon(user) || in_range(src,user))
-		return 1
-	return 0
+	if(!issilicon(user) && !in_range(src, user))
+		return FALSE
+	return !user.incapacitated()
+
+#undef TELECOMMS_MAX_INTEGRITY

--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -17,7 +17,7 @@
 	var/obj/item/weapon/circuitboard/telecomms/C = locate() in component_parts
 	if (!istype(C))
 		return
-	C.integrity = new_integrity
+	C.integrity = Clamp(new_integrity, 0, TELECOMMS_MAX_INTEGRITY)
 
 /obj/item/weapon/circuitboard/telecomms/attackby(var/obj/item/W, var/mob/user, var/params)
 	if(issolder(W))
@@ -288,17 +288,20 @@
 	updateUsrDialog()
 
 // NOTE: A user won't be provided if unlinked by deletion!
-/obj/machinery/telecomms/unlinkFrom(var/mob/user, var/mob/O)
+/obj/machinery/telecomms/unlinkFrom(var/mob/user, var/obj/O)
+	var/obj/machinery/telecomms/T=O
 	if(O && O in links)
-		var/obj/machinery/telecomms/T=O
 		if(T.links)
 			T.links.Remove(src)
 		links.Remove(O)
-		temp = "<font color = #666633>-% Removed \ref[T] [T.name] from linked entities. %-</font color>"
-		return 1
+		. = 1
 	else
-		temp = "<font color = #666633>-% Unable to locate machine to unlink from, try again. %-</font color>"
-		return 0
+		. = 0
+	if(user) // This was a manual unlink, update the status display
+		if(.)
+			temp = "<font color = #666633>-% Removed \ref[T] [T.name] from linked entities. %-</font color>"
+		else
+			temp = "<font color = #666633>-% Unable to locate machine to unlink from, try again. %-</font color>"
 
 /obj/machinery/telecomms/linkWith(var/mob/user, var/mob/O)
 	if(O && O != src && istype(O, /obj/machinery/telecomms))

--- a/code/game/machinery/telecomms/presets.dm
+++ b/code/game/machinery/telecomms/presets.dm
@@ -31,7 +31,7 @@
 	//anchored = 1
 	//use_power = 0
 	//idle_power_usage = 0
-	heatgen = 0
+	heating_power = 0
 	autolinkers = list("c_relay")
 
 //HUB

--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -164,6 +164,8 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 
 
 /obj/machinery/telecomms/Destroy()
+	for(var/link in links)
+		unlinkFrom(null, link)
 	telecomms_list -= src
 	..()
 
@@ -231,7 +233,7 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 	// Checks heat from the environment and applies any integrity damage
 	var/datum/gas_mixture/environment = loc.return_air()
 	if(environment.temperature > T20C + 20)
-		set_integrity(max(0, get_integrity() - 1))
+		set_integrity(get_integrity() - 1)
 		if(get_integrity() <= 0)
 			update_power()
 	if(delay > 0)
@@ -244,7 +246,6 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 /obj/machinery/telecomms/proc/produce_heat()
 	if(!heating_power)
 		return
-
 	if(!(stat & (NOPOWER|BROKEN))) //Blatently stolen from space heater.
 		var/turf/simulated/L = loc
 		if(istype(L))
@@ -256,7 +257,7 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 				var/heat_capacity = removed.heat_capacity() || 1 // Prevent division by zero
 				removed.temperature += heating_power/heat_capacity
 				L.assume_air(removed)
-				use_power(heating_power / 1000)
+				use_power(heating_power / 1000) // This doesn't work?
 /*
 	The receiver idles and receives messages from subspace-compatible radio equipment;
 	primarily headsets. They then just relay this information to all linked devices,

--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -28,12 +28,9 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 	var/machinetype = 0 // just a hacky way of preventing alike machines from pairing
 	var/toggled = 1 	// Is it toggled on
 	var/on = 1
-	var/integrity = 100 // basically HP, loses integrity by heat
-	var/heatgen = 20 // how much heat to transfer to the environment
 	var/delay = 10 // how many process() ticks to delay per heat
-	var/heating_power = 40000
+	var/heating_power = 40000 // how much heat to transfer to the environment
 	var/long_range_link = 0	// Can you link it across Z levels or on the otherside of the map? (Relay & Hub)
-	var/circuitboard = null // string pointing to a circuitboard type
 	var/hide = 0				// Is it a hidden machine?
 	var/listening_level = 0	// 0 = auto set in New() - this is the z level that the machine is listening to.
 
@@ -50,7 +47,7 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 		return
 	var/send_count = 0
 
-	signal.data["slow"] += rand(0, round((100-integrity))) // apply some lag based on integrity
+	signal.data["slow"] += rand(0, round((100-get_integrity()))) // apply some lag based on integrity TODO: delet this
 
 	// Apply some lag based on traffic rates
 	var/netlag = round(traffic / 50)
@@ -146,10 +143,6 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 
 
 /obj/machinery/telecomms/New()
-	if(ticker) // if built in the round
-		construct_op = 3
-		stat |= BROKEN
-
 	telecomms_list += src
 	..()
 
@@ -186,21 +179,30 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 					break
 
 /obj/machinery/telecomms/update_icon()
+	overlays.Cut()
 	if(on)
 		icon_state = initial(icon_state)
 	else
 		icon_state = "[initial(icon_state)]_off"
+	if(panel_open)
+		overlays += "[initial(icon_state)]_panel"
 
 /obj/machinery/telecomms/proc/update_power()
-
-
 	if(toggled)
-		if(stat & (BROKEN|NOPOWER|EMPED) || integrity <= 0) // if powered, on. if not powered, off. if too damaged, off
-			on = 0
+		if(stat & (BROKEN|NOPOWER|EMPED) || get_integrity() <= 0) // if powered, on. if not powered, off. if too damaged, off
+			on = FALSE
 		else
-			on = 1
+			on = TRUE
 	else
-		on = 0
+		on = FALSE
+
+/obj/machinery/telecomms/proc/update_power_and_icon()
+	update_power()
+	update_icon()
+
+/obj/machinery/telecomms/power_change()
+	..()
+	update_power_and_icon()
 
 /obj/machinery/telecomms/process()
 	update_power()
@@ -218,49 +220,43 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 	if(prob(100/severity))
 		if(!(stat & EMPED))
 			stat |= EMPED
+			update_power_and_icon()
 			var/duration = (300 * 10)/severity
 			spawn(rand(duration - 20, duration + 20)) // Takes a long time for the machines to reboot.
 				stat &= ~EMPED
+				update_power_and_icon()
 	..()
 
 /obj/machinery/telecomms/proc/checkheat()
 	// Checks heat from the environment and applies any integrity damage
 	var/datum/gas_mixture/environment = loc.return_air()
-	switch(environment.temperature)
-		if(T0C to (T20C + 20))
-			integrity = Clamp(integrity, 0, 100)
-		if((T20C + 20) to (T0C + 70))
-			integrity = max(0, integrity - 1)
-	if(delay)
+	if(environment.temperature > T20C + 20)
+		set_integrity(max(0, get_integrity() - 1))
+		if(get_integrity() <= 0)
+			update_power()
+	if(delay > 0)
 		delay--
-	else
-		// If the machine is on, ready to produce heat, and has positive traffic, genn some heat
-		if(on && traffic > 0)
-			produce_heat(heatgen)
-			delay = initial(delay)
+		return
+	if(on && traffic > 0)
+		produce_heat()
+		delay = initial(delay)
 
-/obj/machinery/telecomms/proc/produce_heat(heat_amt)
-	if(heatgen == 0)
+/obj/machinery/telecomms/proc/produce_heat()
+	if(!heating_power)
 		return
 
 	if(!(stat & (NOPOWER|BROKEN))) //Blatently stolen from space heater.
 		var/turf/simulated/L = loc
 		if(istype(L))
 			var/datum/gas_mixture/env = L.return_air()
-			if(env.temperature < (heat_amt+T0C))
+			var/transfer_moles = 0.25 * env.total_moles()
+			var/datum/gas_mixture/removed = env.remove(transfer_moles)
 
-				var/transfer_moles = 0.25 * env.total_moles()
-
-				var/datum/gas_mixture/removed = env.remove(transfer_moles)
-
-				if(removed)
-
-					var/heat_capacity = removed.heat_capacity()
-					if(heat_capacity == 0 || heat_capacity == null)
-						heat_capacity = 1
-					removed.temperature = min((removed.temperature*heat_capacity + heating_power)/heat_capacity, 1000)
-
-				env.merge(removed)
+			if(removed)
+				var/heat_capacity = removed.heat_capacity() || 1 // Prevent division by zero
+				removed.temperature += heating_power/heat_capacity
+				L.assume_air(removed)
+				use_power(heating_power / 1000)
 /*
 	The receiver idles and receives messages from subspace-compatible radio equipment;
 	primarily headsets. They then just relay this information to all linked devices,
@@ -279,8 +275,20 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 	use_power = 1
 	idle_power_usage = 30
 	machinetype = 1
-	heatgen = 0
-	circuitboard = "/obj/item/weapon/circuitboard/telecomms/receiver"
+
+/obj/machinery/telecomms/receiver/New()
+	..()
+
+	component_parts = newlist(
+		/obj/item/weapon/circuitboard/telecomms/receiver,
+		/obj/item/weapon/stock_parts/subspace/ansible,
+		/obj/item/weapon/stock_parts/subspace/filter,
+		/obj/item/weapon/stock_parts/manipulator,
+		/obj/item/weapon/stock_parts/manipulator,
+		/obj/item/weapon/stock_parts/micro_laser
+	)
+
+	RefreshParts()
 
 /obj/machinery/telecomms/receiver/receive_signal(datum/signal/signal)
 #ifdef SAY_DEBUG
@@ -347,11 +355,21 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 	use_power = 1
 	idle_power_usage = 80
 	machinetype = 7
-	heatgen = 40
-	circuitboard = "/obj/item/weapon/circuitboard/telecomms/hub"
 	long_range_link = 1
 	netspeed = 40
 
+/obj/machinery/telecomms/hub/New()
+	..()
+
+	component_parts = newlist(
+		/obj/item/weapon/circuitboard/telecomms/hub,
+		/obj/item/weapon/stock_parts/subspace/filter,
+		/obj/item/weapon/stock_parts/subspace/filter,
+		/obj/item/weapon/stock_parts/manipulator,
+		/obj/item/weapon/stock_parts/manipulator
+	)
+
+	RefreshParts()
 
 /obj/machinery/telecomms/hub/receive_information(datum/signal/signal, obj/machinery/telecomms/machine_from)
 	if(is_freq_listening(signal))
@@ -382,12 +400,24 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 	use_power = 1
 	idle_power_usage = 30
 	machinetype = 8
-	heatgen = 0
-	circuitboard = "/obj/item/weapon/circuitboard/telecomms/relay"
+	heating_power = 0
 	netspeed = 5
 	long_range_link = 1
 	var/broadcasting = 1
 	var/receiving = 1
+
+/obj/machinery/telecomms/relay/New()
+	..()
+
+	component_parts = newlist(
+		/obj/item/weapon/circuitboard/telecomms/relay,
+		/obj/item/weapon/stock_parts/subspace/filter,
+		/obj/item/weapon/stock_parts/subspace/filter,
+		/obj/item/weapon/stock_parts/manipulator,
+		/obj/item/weapon/stock_parts/manipulator
+	)
+
+	RefreshParts()
 
 /obj/machinery/telecomms/relay/receive_information(datum/signal/signal, obj/machinery/telecomms/machine_from)
 
@@ -434,10 +464,20 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 	use_power = 1
 	idle_power_usage = 50
 	machinetype = 2
-	heatgen = 20
-	circuitboard = "/obj/item/weapon/circuitboard/telecomms/bus"
 	netspeed = 40
 	var/change_frequency = 0
+
+/obj/machinery/telecomms/bus/New()
+	..()
+
+	component_parts = newlist(
+		/obj/item/weapon/circuitboard/telecomms/bus,
+		/obj/item/weapon/stock_parts/subspace/filter,
+		/obj/item/weapon/stock_parts/manipulator,
+		/obj/item/weapon/stock_parts/manipulator
+	)
+
+	RefreshParts()
 
 /obj/machinery/telecomms/bus/receive_information(datum/signal/signal, obj/machinery/telecomms/machine_from)
 
@@ -487,25 +527,39 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 	use_power = 1
 	idle_power_usage = 30
 	machinetype = 3
-	heatgen = 100
 	delay = 5
-	circuitboard = "/obj/item/weapon/circuitboard/telecomms/processor"
 	var/process_mode = 1 // 1 = Uncompress Signals, 0 = Compress Signals
 
-	receive_information(datum/signal/signal, obj/machinery/telecomms/machine_from)
+/obj/machinery/telecomms/processor/New()
+	..()
 
-		if(is_freq_listening(signal))
+	component_parts = newlist(
+		/obj/item/weapon/circuitboard/telecomms/processor,
+		/obj/item/weapon/stock_parts/subspace/filter,
+		/obj/item/weapon/stock_parts/manipulator,
+		/obj/item/weapon/stock_parts/manipulator,
+		/obj/item/weapon/stock_parts/manipulator,
+		/obj/item/weapon/stock_parts/subspace/treatment,
+		/obj/item/weapon/stock_parts/subspace/treatment,
+		/obj/item/weapon/stock_parts/subspace/analyzer,
+		/obj/item/weapon/stock_parts/subspace/amplifier
+	)
 
-			if(process_mode)
-				signal.data["compression"] = 0 // uncompress subspace signal
-			else
-				signal.data["compression"] = 100 // even more compressed signal
+	RefreshParts()
 
-			if(istype(machine_from, /obj/machinery/telecomms/bus))
-				relay_direct_information(signal, machine_from) // send the signal back to the machine
-			else // no bus detected - send the signal to servers instead
-				signal.data["slow"] += rand(5, 10) // slow the signal down
-				relay_information(signal, "/obj/machinery/telecomms/server")
+/obj/machinery/telecomms/processor/receive_information(datum/signal/signal, obj/machinery/telecomms/machine_from)
+	if(is_freq_listening(signal))
+
+		if(process_mode)
+			signal.data["compression"] = 0 // uncompress subspace signal
+		else
+			signal.data["compression"] = 100 // even more compressed signal
+
+		if(istype(machine_from, /obj/machinery/telecomms/bus))
+			relay_direct_information(signal, machine_from) // send the signal back to the machine
+		else // no bus detected - send the signal to servers instead
+			signal.data["slow"] += rand(5, 10) // slow the signal down
+			relay_information(signal, "/obj/machinery/telecomms/server")
 
 
 /*
@@ -526,8 +580,6 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 	use_power = 1
 	idle_power_usage = 15
 	machinetype = 4
-	heatgen = 50
-	circuitboard = "/obj/item/weapon/circuitboard/telecomms/server"
 	var/list/log_entries = list()
 	var/list/stored_names = list()
 	var/list/TrafficActions = list()
@@ -551,6 +603,15 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 	Compiler = new()
 	Compiler.Holder = src
 	server_radio = new()
+
+	component_parts = newlist(
+		/obj/item/weapon/circuitboard/telecomms/server,
+		/obj/item/weapon/stock_parts/subspace/filter,
+		/obj/item/weapon/stock_parts/manipulator,
+		/obj/item/weapon/stock_parts/manipulator
+	)
+
+	RefreshParts()
 
 /obj/machinery/telecomms/server/Destroy()
 	// Garbage collects all the NTSL datums.


### PR DESCRIPTION
- Changed the recipe to not require cable coils
- Changed the way you repair the machines from replacing wires to soldering the board, can be perform with the machine still running
- Removed the special snowflake construction/deconstruction (Fixes #15349, ~~I think. I need to test it.~~ It does.)
- Fixed the integrity not decreasing in environments hotter than ~~90~~ 70C (Fixes #13157)
- Fixes #13156

~~While this probably doesn't break horribly as it is now, I need to test this more, write the wiki changes and play with the numbers to make the machines heat up something reasonable.~~ Tested

~~I'll update the wiki once this is ready for merge.~~ Wiki has already been updated.

(http://ss13.moe/wiki/index.php?title=Telecommunications&diff=next&oldid=10739)
(http://ss13.moe/wiki/index.php?title=Guide_to_Advanced_Construction&diff=next&oldid=11419)

This is starting to feel unatomic.

:cl: 
 * tweak: Changed the telecommunications machines construction/deconstruction/repair procedures. See wiki.
 * bugfix: Fixed the telecommunications machines not degrading at high temperatures.
 * bugfix: Fixed the telecommunications machines not removing the links between them upon deletion.
 * tweak: Allowed the telecommunications machines to be scanned by the device analyzer