### PR TITLE
hotfix: Adds the robutt pda cart to the pda cart vendor.

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1305,6 +1305,7 @@ var/global/num_vending_terminals = 1
 		/obj/item/weapon/cartridge/mechanic = 5,
 		/obj/item/weapon/cartridge/rd = 3,
 		/obj/item/weapon/cartridge/signal/toxins = 5,
+		/obj/item/weapon/cartridge/robotics = 5,
 		/obj/item/weapon/cartridge/hos = 3,
 		/obj/item/weapon/cartridge/security = 5,
 		/obj/item/weapon/cartridge/detective = 5,


### PR DESCRIPTION
Small thing forgotten in the original pr, putting it into the vendor. It really is something that's overlooked/not included in maps often.