### PR TITLE
adds the currently unused in_hand food.dmi to foods and the kfc bucket

### DIFF
--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -434,6 +434,7 @@
 	desc = "Now we're doing it!"
 	icon_state = "kfc_drumsticks"
 	item_state = "kfc_bucket"
+	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/food.dmi', "right_hand" = 'icons/mob/in-hand/right/food.dmi')
 	icon_type = "drumstick"
 	can_only_hold = list("/obj/item/weapon/reagent_containers/food/snacks/chicken_drumstick")
 	starting_materials = list(MAT_CARDBOARD = 3750)

--- a/code/modules/reagents/reagent_containers/food.dm
+++ b/code/modules/reagents/reagent_containers/food.dm
@@ -5,6 +5,7 @@
 //Food is basically a glorified beaker with a lot of fancy coding. Now you know, and knowing is half the battle
 /obj/item/weapon/reagent_containers/food
 	icon = 'icons/obj/food.dmi'
+	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/food.dmi', "right_hand" = 'icons/mob/in-hand/right/food.dmi')
 	possible_transfer_amounts = null
 	volume = 50 //Food can contain a beaker's worth of reagents unless specified otherwise. Do note large servings of complex food items can contain well over 50 reagents total
 


### PR DESCRIPTION
noticed while trawling the current sprites that left/food.dmi and right/food.dmi were unused, seemingly be accident in #2153 and currently only contain 2 sprites, the kfc bucket and chicken legs (Which look like maracas when held)

I want to add more in-hands to certain foods, but to keep the PR atomic, I'll do that in another PR