### PR TITLE
Delivery chutes don't accept anchored objects

### DIFF
--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -130,6 +130,9 @@
 	return
 
 /obj/machinery/disposal/deliveryChute/Bumped(var/atom/movable/AM) //Go straight into the chute
+	if(AM.anchored)
+		return
+		
 	if(istype(AM, /obj/item/projectile) || istype(AM, /obj/item/weapon/dummy))
 		return
 


### PR DESCRIPTION
Fixes #16041
Fixes #15956

By logical definition of the word itself and of the intended functionality, if something is anchored then it shouldn't be able to be moved into the tube anyways. I checked all the other disposals machinery and all of them prevent anchored items as well.
This also blocks janicarts from being mailed I guess.

:cl:
 * bugfix: Delivery chutes don't accept anchored items. Please report if this breaks any intended Cargo delivery methods.
