### PR TITLE
Adds magboots to voidsuit lockers.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/malfunction.dm
+++ b/code/game/objects/structures/crates_lockers/closets/malfunction.dm
@@ -12,6 +12,7 @@
 	new /obj/item/clothing/mask/breath(src)
 	new /obj/item/clothing/head/helmet/space/nasavoid(src)
 	new /obj/item/clothing/suit/space/nasavoid(src)
+	new /obj/item/clothing/shoes/magboots/nasavoid(src)
 	new /obj/item/weapon/crowbar(src)
 	new /obj/item/weapon/cell(src)
 	new /obj/item/device/multitool(src)

--- a/code/modules/clothing/spacesuits/void.dm
+++ b/code/modules/clothing/spacesuits/void.dm
@@ -8,11 +8,16 @@
 	icon_state = "void"
 	item_state = "void"
 
-
 /obj/item/clothing/suit/space/nasavoid
 	name = "NASA Voidsuit"
 	icon_state = "void"
 	item_state = "void"
 	species_restricted = list("exclude",VOX_SHAPED)
-	desc = "A high tech, NASA Centcom branch designed, dark red Space suit. Used for AI satellite maintenance."
+	desc = "A high tech, NASA Centcom branch designed, dark red space suit. Used for AI satellite maintenance."
 	slowdown = HARDSUIT_SLOWDOWN_LOW
+
+/obj/item/clothing/shoes/magboots/nasavoid
+	name = "NASA Voidboots"
+	desc = "A high tech, NASA Centcom branch designed, dark red pair of magboots. Used for AI satellite maintenance."
+	icon_state = "syndiemag0"
+	base_state = "syndiemag"


### PR DESCRIPTION
Does what it says on the tin. Adds a pair of red magboots to the voidsuit locker they have the syndie sprites to keep with the color theme of the void suit.
This is intended for being consistent with other suit storage's having magboots in them as well as fixing the issues on maps like bagel AI core being a ZAS death trap with no magboots around and other places with similar issues that have voidsuit lockers stationed at them but should have magboots.
:cl:
 * rscadd: NASA voidsuit lockers now have a pair of red magboots in them.