### PR TITLE
Hot_edge things can light candles and cigs

### DIFF
--- a/code/game/objects/items/candle.dm
+++ b/code/game/objects/items/candle.dm
@@ -23,7 +23,7 @@
 
 /obj/item/candle/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	..()
-	if(W.is_hot())
+	if(W.is_hot() || W.sharpness_flags & (HOT_EDGE))
 		light("<span class='notice'>[user] lights [src] with [W].</span>")
 
 /obj/item/candle/proc/light(var/flavor_text = "<span class='notice'>[usr] lights [src].</span>")

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -242,7 +242,7 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 		if(L.is_hot())
 			light("<span class='notice'>After some fiddling, [user] manages to light \his [name] with \the [W].</span>")
 
-	else if(istype(W, /obj/item/weapon/melee/energy/sword))
+	else if(istype(W, /obj/item/weapon/melee/energy))
 		var/obj/item/weapon/melee/energy/sword/S = W
 		if(S.is_hot())
 			light("<span class='warning'>[user] raises \his [W.name], lighting \the [src]. Holy fucking shit.</span>")
@@ -253,7 +253,7 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 			light("<span class='notice'>[user] fiddles with \his [W.name], and manages to light their [name].</span>")
 
 	//All other items are included here, any item that is hot can light the cigarette
-	else if(W.is_hot())
+	else if(W.is_hot() || W.sharpness_flags & (HOT_EDGE))
 		light("<span class='notice'>[user] lights \his [name] with \the [W].</span>")
 	return
 

--- a/code/game/objects/items/weapons/surgery_tools.dm
+++ b/code/game/objects/items/weapons/surgery_tools.dm
@@ -197,6 +197,9 @@
 	sharpness_flags = SHARP_BLADE | SERRATED_BLADE | CHOPWOOD | HOT_EDGE
 	origin_tech = Tc_MATERIALS + "=5;" + Tc_BIOTECH + "=5;" + Tc_ENGINEERING + "=4;" + Tc_PLASMATECH + "=3"
 
+/obj/item/weapon/circular_saw/plasmasaw/is_hot()
+	return 1
+
 
 /obj/item/weapon/circular_saw/suicide_act(mob/user)
 	to_chat(viewers(user), "<span class='danger'>[user] is sawing \his head in two with the [src.name]! It looks like \he's  trying to commit suicide!</span>")


### PR DESCRIPTION
Fixes the plasma saw not being able to light things and lets all melee energy items light things if they are hot. The `hot_edge` check may be redundant in this but it's there for good measure.
:cl:
 * bugfix: Things with hot edges can light your candles and smokes for sure now.