### PR TITLE
Hotfix for stacking bug

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -26,7 +26,7 @@
 	if (amount)
 		src.amount=amount
 	update_materials()
-	forceMove(loc) // So that Crossed gets called, so that stacks can be merged
+	//forceMove(loc) // So that Crossed gets called, so that stacks can be merged
 
 /obj/item/stack/Destroy()
 	if (usr && usr.machine==src)


### PR DESCRIPTION
Closes #16083

The intent of that line was to have stacks attempt automatic merging with the other stacks on the tile, at the moment of creation. I guess we just can't have nice things