### PR TITLE
Fixes rollerbeds making you immune to bullets etc

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -29,6 +29,13 @@
 	I.dir = dir
 	. = ..()
 
+/obj/structure/bed/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+	if(air_group || (height==0))
+		return 1
+	if(istype(mover) && mover.checkpass(PASSTABLE)) //NOTE: This includes ALL chairs as well! Vehicles have their own override.
+		return 1
+	return ..()
+
 /obj/structure/bed/attack_paw(mob/user as mob)
 	return attack_hand(user)
 

--- a/code/game/objects/structures/vehicles/vehicle.dm
+++ b/code/game/objects/structures/vehicles/vehicle.dm
@@ -54,6 +54,10 @@
 /obj/structure/bed/chair/vehicle/proc/delayNextMove(var/delay, var/additive=0)
 	move_delayer.delayNext(delay,additive)
 
+//Just a copypaste of atom/movable/Cross(). Vehicles are children of beds for some fucking reason and none of the current movement code has any inheritance, so whatever.
+/obj/structure/bed/chair/vehicle/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+	return (!density || !height || air_group)
+
 /obj/structure/bed/chair/vehicle/proc/is_too_heavy(var/turf/simulated/floor/glass/glassfloor)
 	return !istype(glassfloor, /turf/simulated/floor/glass/plasma)
 


### PR DESCRIPTION
Fixes #15964

Works essentially like the person was lying down and the rollerbed wasn't there. The bullet flies over it, unless you click on the person directly.

Vehicles remain completely unchanged.

:cl: 
 * bugfix: Fixed rollerbeds stopping bullets if someone was buckled in.
