### PR TITLE
Allows clickdrag for storage coats (clickdrag on table to empty, clickdrag on yourself to open it)

### DIFF
--- a/code/game/objects/storage/coat.dm
+++ b/code/game/objects/storage/coat.dm
@@ -42,21 +42,16 @@
 /obj/item/clothing/suit/storage/MouseDrop(atom/over_object)
 	if(ishuman(usr) || ismonkey(usr))
 		var/mob/M = usr
-		if (!( istype(over_object, /obj/abstract/screen/inventory) ))
-			return ..()
+		if(istype(over_object, /obj/abstract/screen/inventory)) //was clickdragged to an inventory slot, we want to be able to take our coat off
+			if(!M.incapacitated() && is_holder_of(M, src))
+				playsound(get_turf(src), "rustle", 50, 1, -5)
+				var/obj/abstract/screen/inventory/OI = over_object
 
-		if(!(src.loc == usr) || (src.loc && src.loc.loc == usr))
-			return
-
-		playsound(get_turf(src), "rustle", 50, 1, -5)
-		if (!M.incapacitated())
-			var/obj/abstract/screen/inventory/OI = over_object
-
-			if(OI.hand_index && M.put_in_hand_check(src, OI.hand_index))
-				M.u_equip(src, 0)
-				M.put_in_hand(OI.hand_index, src)
-				M.update_inv_wear_suit()
-				src.add_fingerprint(usr)
-			return
-
-		usr.attack_hand(src)
+				if(OI.hand_index && M.put_in_hand_check(src, OI.hand_index))
+					M.u_equip(src, 0)
+					M.put_in_hand(OI.hand_index, src)
+					M.update_inv_wear_suit()
+					src.add_fingerprint(usr)
+				return //don't let us take the coat's abstract internal storage though
+		else
+			hold.MouseDrop(over_object)


### PR DESCRIPTION
Because people would rather whine in OOC than make a feature request.

:cl:
 * rscadd: Implemented clickdrag actions for storage coats, same as other storage objects.