### PR TITLE
Prevent coat internal storage from going into disposals (then teleporting itself back to the coat anyways)

### DIFF
--- a/code/game/objects/storage/coat.dm
+++ b/code/game/objects/storage/coat.dm
@@ -52,6 +52,9 @@
 					M.put_in_hand(OI.hand_index, src)
 					M.update_inv_wear_suit()
 					src.add_fingerprint(usr)
-				return //don't let us take the coat's abstract internal storage though
-		else
-			hold.MouseDrop(over_object)
+				return
+		else if(over_object == usr) //show container to user
+			return hold.MouseDrop(over_object)
+		else if(istype(over_object, /obj/structure/table)) //empty on table
+			return hold.MouseDrop(over_object)
+	return ..() //don't let us move the coat's abstract internal storage!


### PR DESCRIPTION
I wanted a more generic way to detect this, I tried both
```
/obj/item/weapon/storage/internal/Move(var/newLoc)
	if(newLoc != master_item)
		CRASH("Abstract clothing storage ([src.type]) attempted to be separated from [master_item.type]! Make a bug report with this call stack:")
	return ..()
```
and 
```
/obj/item/clothing/suit/storage/Exit(atom/movable/AM)
	if(AM == hold)
		CRASH("Abstract clothing storage ([hold.type]) attempted to be separated from [src.type]! Make a bug report with this call stack:"
		return 0
	return ..()
```
neither worked