### PR TITLE
Fixes bone repair surgery steps from looping.

### DIFF
--- a/code/modules/surgery/bones.dm
+++ b/code/modules/surgery/bones.dm
@@ -20,7 +20,7 @@
 
 /datum/surgery_step/glue_bone/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/datum/organ/external/affected = target.get_organ(target_zone)
-	return (affected.open >= 2 || (target.species.anatomy_flags & NO_SKIN)) && affected.stage == 0
+	return (affected.open >= 2 || (target.species.anatomy_flags & NO_SKIN)) && affected.stage == 0 && affected.status & ORGAN_BROKEN
 
 /datum/surgery_step/glue_bone/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/datum/organ/external/affected = target.get_organ(target_zone)
@@ -172,7 +172,7 @@
 
 /datum/surgery_step/bone_mender/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/datum/organ/external/affected = target.get_organ(target_zone)
-	return (affected.open >= 2 || (target.species.anatomy_flags & NO_SKIN)) && affected.stage <= 5
+	return (affected.open >= 2 || (target.species.anatomy_flags & NO_SKIN)) && affected.stage <= 5 && affected.status & ORGAN_BROKEN
 
 /datum/surgery_step/bone_mender/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/datum/organ/external/affected = target.get_organ(target_zone)

--- a/code/modules/surgery/butt.dm
+++ b/code/modules/surgery/butt.dm
@@ -209,6 +209,7 @@
 /datum/surgery_step/butt_replace/hips
 	allowed_tools = list(
 		/obj/item/weapon/bonegel = 100,
+		/obj/item/weapon/bonesetter/bone_mender = 100,
 		/obj/item/weapon/screwdriver = 75,
 		)
 


### PR DESCRIPTION
Bone repair surgery had an issue where it only checked to see if you were on stage 0 of bone repair before it went to do step one and not seeing if the bone was actually even broken, allowing things to go into a loop causing some confusion if they actually finished the steps. 
IE Gel > Bone setter > Gel (fixed) > Gel (pointless and starting over) > etc. 
OR 
Bone mender (fixed) > Bone mender (pointless and starting over) > etc.

Also adds the mender as a useable tool for butt repair surgery.
:cl:
 * bugfix: Bone repair surgery no longer loops.