### PR TITLE
Atmos console/gas sensors improvements

### DIFF
--- a/code/game/machinery/atmo_control.dm
+++ b/code/game/machinery/atmo_control.dm
@@ -18,6 +18,7 @@
 	// 8 for toxins concentration
 	// 16 for nitrogen concentration
 	// 32 for carbon dioxide concentration
+	// 64 for nitrous oxide concentration
 
 	machine_flags = WRENCHMOVE | MULTITOOL_MENU
 
@@ -38,6 +39,7 @@
 		<li>Monitor Plasma Concentration: <a href="?src=\ref[src];toggle_out_flag=8">[output&8 ? "Yes" : "No"]</a>
 		<li>Monitor Nitrogen Concentration: <a href="?src=\ref[src];toggle_out_flag=16">[output&16 ? "Yes" : "No"]</a>
 		<li>Monitor Carbon Dioxide Concentration: <a href="?src=\ref[src];toggle_out_flag=32">[output&32 ? "Yes" : "No"]</a>
+		<li>Monitor Nitrous Oxide Concentration: <a href="?src=\ref[src];toggle_out_flag=64">[output&64 ? "Yes" : "No"]</a>
 	</ul>"}
 
 /obj/machinery/air_sensor/multitool_topic(var/mob/user, var/list/href_list, var/obj/item/device/multitool/P)
@@ -47,7 +49,7 @@
 
 	if("toggle_out_flag" in href_list)
 		var/bitflag_value = text2num(href_list["toggle_out_flag"])//this is a string normally
-		if(!test_bitflag(bitflag_value) && bitflag_value <= 32) //Here to prevent breaking the sensors with HREF exploits
+		if(!test_bitflag(bitflag_value) && bitflag_value <= 64) //Here to prevent breaking the sensors with HREF exploits
 			return 0
 		if(output&bitflag_value)//the bitflag is on ATM
 			output &= ~bitflag_value
@@ -74,7 +76,7 @@
 		if(output&2)
 			signal.data["temperature"] = round(air_sample.temperature,0.1)
 
-		if(output>4)
+		if(output>=4)
 			var/total_moles = air_sample.total_moles()
 			if(total_moles > 0)
 				if(output&4)
@@ -85,11 +87,16 @@
 					signal.data["nitrogen"] = round(100*air_sample.nitrogen/total_moles,0.1)
 				if(output&32)
 					signal.data["carbon_dioxide"] = round(100*air_sample.carbon_dioxide/total_moles,0.1)
+				if(output&64)
+					var/datum/gas/sleeping_agent/G = locate(/datum/gas/sleeping_agent) in air_sample.trace_gases
+					var/n2o_moles = G ? G.moles : 0
+					signal.data["nitrous_oxide"] = round(100 *n2o_moles/total_moles,0.1)
 			else
 				signal.data["oxygen"] = 0
 				signal.data["toxins"] = 0
 				signal.data["nitrogen"] = 0
 				signal.data["carbon_dioxide"] = 0
+				signal.data["nitrous_oxide"] = 0
 		signal.data["sigtype"]="status"
 		radio_connection.post_signal(src, signal, filter = RADIO_ATMOSIA)
 
@@ -173,6 +180,8 @@
 						sensor_part += "<li>[data["carbon_dioxide"]]% CO<sub>2</sub></li>"
 					if(data["toxins"])
 						sensor_part += "<li>[data["toxins"]]% Plasma</li>"
+					if(data["nitrous_oxide"])
+						sensor_part += "<li>[data["nitrous_oxide"]]% N<sub>2</sub>O</li>"
 					sensor_part += "</ul></td></tr>"
 				sensor_part += "</table>"
 
@@ -274,7 +283,7 @@ font-weight:bold;
 		var/sensor = input(user, "Select a sensor:", "Sensor Data") as null|anything in sensor_list
 		if(!sensor)
 			return MT_ERROR
-		var/label = reject_bad_name( input(user, "Choose a sensor label:", "Sensor Label")  as text|null, allow_numbers=1)
+		var/label = strip_html(input(user, "Choose a sensor label:", "Sensor Label") as text|null)
 		if(!label)
 			return MT_ERROR
 

--- a/code/modules/atmos_automation/implementation/sensors.dm
+++ b/code/modules/atmos_automation/implementation/sensors.dm
@@ -41,7 +41,8 @@
 			"oxygen",
 			"toxins",
 			"nitrogen",
-			"carbon_dioxide"
+			"carbon_dioxide",
+			"nitrous_oxide"
 		)
 		parent.updateUsrDialog()
 		return 1


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/6307265/31019228-4af41bb0-a52f-11e7-8763-a8f7abb69506.png) ![image](https://user-images.githubusercontent.com/6307265/31019257-5b8f35ea-a52f-11e7-8f48-208c4325c449.png) ![image](https://user-images.githubusercontent.com/6307265/31019262-60e27e3a-a52f-11e7-8407-1b7a88c5c200.png)


- Fixed a bug where you couldn't have a sensor set to display O2 only.
- Removed the bad name check when adding a new sensor, replaced with stripping html and sanitization. This allows names like "A" or "1".

And:
:cl:
 * rscadd: Atmos monitor and AAC can now get N2O concentration from sensors.
