### PR TITLE
Makes Decoy Balloons Scannable

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1325,11 +1325,12 @@
 /obj/item/toy/balloon/decoy
 	name = "inflatable decoy"
 	desc = "Use this to fool your enemies into thinking you're a balloon!"
-	icon_state = "decoy_balloon_deflated"
+	icon_state = "decoy_baslloon_deflated"
 	w_class = W_CLASS_TINY
 	col = null
 	inflated_type = /obj/item/toy/balloon/inflated/decoy
 	volume = 120	//liters
+	origin_tech = Tc_SYNDICATE + "=1;" + Tc_MATERIALS + "=1"
 	var/decoy_phrase = null
 
 /obj/item/toy/balloon/decoy/verb/record_phrase()

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1325,12 +1325,12 @@
 /obj/item/toy/balloon/decoy
 	name = "inflatable decoy"
 	desc = "Use this to fool your enemies into thinking you're a balloon!"
-	icon_state = "decoy_baslloon_deflated"
+	icon_state = "decoy_balloon_deflated"
 	w_class = W_CLASS_TINY
 	col = null
 	inflated_type = /obj/item/toy/balloon/inflated/decoy
 	volume = 120	//liters
-	origin_tech = Tc_SYNDICATE + "=1;" + Tc_MATERIALS + "=1"
+	origin_tech = Tc_MATERIALS + "=3"
 	var/decoy_phrase = null
 
 /obj/item/toy/balloon/decoy/verb/record_phrase()


### PR DESCRIPTION
Decoy balloons can now be scanned by the mechanic's device analyzer.
Fixes #14850

:cl:
 * tweak: Decoy balloons can now be scanned by the mechanic's device analyzer.
