### PR TITLE
Changes What Envelopes Can Hold

### DIFF
--- a/code/modules/paperwork/envelope.dm
+++ b/code/modules/paperwork/envelope.dm
@@ -2,7 +2,12 @@
 	name = "envelope"
 	icon_state = "envelope_open"
 
-	var/obj/item/weapon/paper/contained_paper
+	var/list/never_allowed = list(/obj/item/weapon/paper/envelope)	//Not allowed out of sanity/necessity, not convenience.
+	var/list/not_allowed = list(/obj/item/weapon/pen,	//These have interactions with paper/envelopes and it would really be a nuisance if they were stuck into envelopes every time they were used on one.
+								/obj/item/toy/crayon,
+								/obj/item/weapon/stamp,
+								/obj/item/device/destTagger)
+	var/obj/item/contained_item
 	var/open = TRUE
 	var/torn = FALSE
 	var/sortTag
@@ -16,9 +21,9 @@
 			icon_state = "envelope_torn"
 		else
 			icon_state = "envelope_open"
-		if(contained_paper)
-			var/image/paper_overlay = image(contained_paper.icon, src, contained_paper.icon_state)
-			overlays += paper_overlay
+		if(contained_item)
+			var/image/item_overlay = image(contained_item.icon, src, contained_item.icon_state)
+			overlays += item_overlay
 			var/image/envelope_overlay = image('icons/obj/bureaucracy.dmi', src, overlay_state)
 			overlays += envelope_overlay
 	else
@@ -27,15 +32,8 @@
 /obj/item/weapon/paper/envelope/attackby(obj/item/weapon/P, mob/user)
 	. = ..()
 	if(open)
-		if(istype(P, /obj/item/weapon/paper) && !istype(P, /obj/item/weapon/paper/envelope))
-			if(contained_paper)
-				to_chat(user, "<span class='notice'>There is already \a [contained_paper] inside \the [src].</span>")
-				return
-			if(user.drop_item(P))
-				contained_paper = P
-				P.forceMove(src)
-				user.visible_message("\The [user] puts something into \the [src].","You put \the [P] into \the [src].")
-				update_icon()
+		if(!is_type_in_list(P, not_allowed))
+			insert_item(user, P)
 	else
 		if(P.sharpness && P.sharpness_flags & SHARP_BLADE)
 			open()
@@ -57,17 +55,33 @@
 			desc = "It has a label reading [tag]."
 
 /obj/item/weapon/paper/envelope/AltClick(mob/user)
-	if(open && contained_paper)
-		if(!user.put_in_active_hand(contained_paper))
-			contained_paper.forceMove(get_turf(user))
-		user.visible_message("\The [user] takes something out of \the [src].","You take \the [contained_paper] out of \the [src].")
-		contained_paper = null
-		update_icon()
+	if(open)
+		if(contained_item)
+			if(!user.put_in_active_hand(contained_item))
+				contained_item.forceMove(get_turf(user))
+			user.visible_message("\The [user] takes something out of \the [src].","You take \the [contained_item] out of \the [src].")
+			contained_item = null
+			update_icon()
+		else
+			var/obj/item/I = user.get_active_hand()
+			if(I != src)
+				insert_item(user, I)
+
+/obj/item/weapon/paper/envelope/proc/insert_item(mob/user, obj/item/I)
+	if(istype(I) && I.w_class == W_CLASS_TINY && !is_type_in_list(I, never_allowed))
+		if(contained_item)
+			to_chat(user, "<span class='notice'>There is already \a [contained_item] inside \the [src].</span>")
+			return
+		if(user.drop_item(I))
+			contained_item = I
+			I.forceMove(src)
+			user.visible_message("\The [user] puts something into \the [src].","You put \the [I] into \the [src].")
+			update_icon()
 
 /obj/item/weapon/paper/envelope/Destroy()
-	if(contained_paper)
-		qdel(contained_paper)
-		contained_paper = null
+	if(contained_item)
+		qdel(contained_item)
+		contained_item = null
 	..()
 
 /obj/item/weapon/paper/envelope/attack_self(mob/living/user)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -334,7 +334,7 @@
 			var/obj/C = loc
 			C.update_icon()
 
-	else if(istype(P, /obj/item/weapon/photo))
+	else if(istype(P, /obj/item/weapon/photo) && !istype(src, /obj/item/weapon/paper/envelope))
 		if(user.drop_item(P, src))
 			if(img)
 				to_chat(user, "<span class='notice'>This paper already has a photo attached.</span>")


### PR DESCRIPTION
Envelopes can now have any item of `w_class` tiny inserted into them, rather than just sheets of paper. Items can now be inserted via Alt+clicking with the item in your active hand. Items which have interactions with paper/envelopes, such as pens, crayons, stamps, and destination taggers, can *only* be inserted in this manner.
Photos can no longer be attached to envelopes, but can now be inserted into envelopes.
Fixes #15220

:cl:
 * rscadd: Envelopes can now hold all tiny items. Items which have interactions with paper/envelopes, such as pens, stamps, et cetera must be inserted via Alt+clicking the envelope with the item in your active hand.
 * tweak: Photos can no longer be attached to the front of envelopes, but can now be inserted inside envelopes.
