### PR TITLE
One-Way Window Fixes

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -29,7 +29,6 @@ var/list/one_way_windows
 
 	var/obj/abstract/Overlays/damage_overlay
 	var/image/oneway_overlay
-	var/image/oneway_self_overlay	//the image of itself that gets placed above the oneway_overlay
 	var/cracked_base = "crack"
 
 	var/fire_temp_threshold = 800
@@ -52,7 +51,14 @@ var/list/one_way_windows
 		if(!one_way_windows)
 			one_way_windows = list()
 		one_way_windows.Add(src)
+		update_oneway_nearby_clients()
 		overlays += oneway_overlay
+
+/obj/structure/window/proc/update_oneway_nearby_clients()
+	for(var/client/C in clients)
+		if(!istype(C.mob, /mob/dead/observer))
+			if(((x >= (C.mob.x - C.view)) && (x <= (C.mob.x + C.view))) && ((y >= (C.mob.y - C.view)) && (y <= (C.mob.y + C.view))))
+				C.update_one_way_windows(view(C.view,C.mob))
 
 /obj/structure/window/projectile_check()
 	return PROJREACT_WINDOWS
@@ -108,7 +114,7 @@ var/list/one_way_windows
 			damage_overlay.icon = icon('icons/obj/structures.dmi')
 			damage_overlay.dir = src.dir
 
-		overlays.Cut()
+		overlays -= damage_overlay
 
 		if(health < initial(health))
 			var/damage_fraction = Clamp(round((initial(health) - health) / initial(health) * 5) + 1, 1, 5) //gives a number, 1-5, based on damagedness
@@ -274,7 +280,7 @@ var/list/one_way_windows
 		animate(src, color="#222222", time=5)
 		set_opacity(1)
 	return opacity
-		
+
 /obj/structure/window/attackby(obj/item/weapon/W as obj, mob/living/user as mob)
 
 	if(istype(W, /obj/item/weapon/grab) && Adjacent(user))
@@ -314,10 +320,11 @@ var/list/one_way_windows
 			to_chat(user, "<span class='notice'>You pry the sheet of plastic off \the [src].</span>")
 			one_way = 0
 			one_way_windows.Remove(src)
+			update_oneway_nearby_clients()
 			drop_stack(/obj/item/stack/sheet/mineral/plastic, get_turf(user), 1, user)
 			overlays -= oneway_overlay
 			return
-	
+
 	if(istype(W, /obj/item/stack/sheet/mineral/plastic))
 		if(one_way)
 			to_chat(user, "<span class='notice'>This window already has one-way tint on it.</span>")
@@ -327,12 +334,13 @@ var/list/one_way_windows
 		if(!one_way_windows)
 			one_way_windows = list()
 		one_way_windows.Add(src)
+		update_oneway_nearby_clients()
 		P.use(1)
 		to_chat(user, "<span class='notice'>You place a sheet of plastic over the window.</span>")
 		overlays += oneway_overlay
 		return
 
-	
+
 	if(istype(W, /obj/item/stack/light_w))
 		var/obj/item/stack/light_w/LT = W
 		if (!anchored)
@@ -342,16 +350,16 @@ var/list/one_way_windows
 			to_chat(user, "<span class='notice'>This window already has electronics in it.</span>")
 			return 0
 		LT.use(1)
-		to_chat(user, "<span class='notice'>You add some electronics to the window.</span>")	
+		to_chat(user, "<span class='notice'>You add some electronics to the window.</span>")
 		smartwindow = new /obj/machinery/smartglass_electronics(src)
 		smartwindow.Ourwindow = src
 		return 1
-		
-		
+
+
 	if(ismultitool(W) && smartwindow)
 		smartwindow.update_multitool_menu(user)
-		return 
-		
+		return
+
 	//Start construction and deconstruction, absolute priority over the other object interactions to avoid hitting the window
 
 	if(reinforced) //Steps for all reinforced window types
@@ -545,6 +553,7 @@ var/list/one_way_windows
 		spawnBrokenPieces()
 	if(one_way)
 		one_way_windows.Remove(src)
+		update_oneway_nearby_clients()
 	..()
 
 /obj/structure/window/proc/spawnBrokenPieces()
@@ -663,7 +672,7 @@ var/list/one_way_windows
 	icon_state = "fwindow"
 	health = 30
 	sheettype = /obj/item/stack/sheet/glass/rglass //Ditto above
-	
+
 /obj/structure/window/send_to_past(var/duration)
 	..()
 	var/static/list/resettable_vars = list(

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -331,12 +331,12 @@ var/list/one_way_windows
 			return
 		if(is_fulltile())
 			update_nearby_tiles()
-			dir = turn(get_dir(get_turf(user),get_turf(src)),180)
-			if(!(dir % 3) || !(dir % 5))	//if its direction is diagonal
+			change_dir(turn(get_dir(get_turf(user),get_turf(src)),180))
+			if(!test_bitflag(dir))	//if its direction is diagonal
 				if(prob(50))
-					dir = turn(dir,45)
+					change_dir(turn(dir,45))
 				else
-					dir = turn(dir,315)
+					change_dir(turn(dir,315))
 			update_nearby_tiles()
 			ini_dir = dir
 		var/obj/item/stack/sheet/mineral/plastic/P = W

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -329,6 +329,16 @@ var/list/one_way_windows
 		if(one_way)
 			to_chat(user, "<span class='notice'>This window already has one-way tint on it.</span>")
 			return
+		if(is_fulltile())
+			update_nearby_tiles()
+			dir = turn(get_dir(get_turf(user),get_turf(src)),180)
+			if(!(dir % 3) || !(dir % 5))	//if its direction is diagonal
+				if(prob(50))
+					dir = turn(dir,45)
+				else
+					dir = turn(dir,315)
+			update_nearby_tiles()
+			ini_dir = dir
 		var/obj/item/stack/sheet/mineral/plastic/P = W
 		one_way = 1
 		if(!one_way_windows)

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -460,10 +460,11 @@ NOTE:  You will only be polled about this role once per round. To change your ch
 		if(parallax_initialized)
 			mob.hud_used.update_parallax_values()
 
-	for(var/obj/structure/window/W in one_way_windows)
-		if(((W.x >= (mob.x - view)) && (W.x <= (mob.x + view))) && ((W.y >= (mob.y - view)) && (W.y <= (mob.y + view))))
-			update_one_way_windows(view(view,mob))	//Updating the one-way window overlay if the client has one in the range of its view.
-			break
+	if(!istype(mob, /mob/dead/observer))	//If they are neither an observer nor someone with X-ray vision
+		for(var/obj/structure/window/W in one_way_windows)
+			if(((W.x >= (mob.x - view)) && (W.x <= (mob.x + view))) && ((W.y >= (mob.y - view)) && (W.y <= (mob.y + view))))
+				update_one_way_windows(view(view,mob))	//Updating the one-way window overlay if the client has one in the range of its view.
+				break
 
 /client/proc/update_one_way_windows(var/list/v)		//Needed for one-way windows to work.
 	var/Image										//Code heavily cannibalized from a demo made by Byond member Shadowdarke.


### PR DESCRIPTION
One-way windows are no longer calculated for ghosts. Fixes #15741
One-way windows no longer lose their tint when they take damage. Fixes #15923
One-way windows no longer leave obscured tiles when the last one in view is deconstructed. Fixes #15933