### PR TITLE
Refactor wrenchAnchor()

### DIFF
--- a/code/ATMOSPHERICS/components/binary_devices/MSGS.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/MSGS.dm
@@ -246,8 +246,10 @@
 		if(on)
 			overlays += image(icon = icon, icon_state = "i")
 
-/obj/machinery/atmospherics/binary/msgs/wrenchAnchor(mob/user)
-	..()
+/obj/machinery/atmospherics/binary/msgs/wrenchAnchor(var/mob/user) 
+	. = ..()
+	if(!.)
+		return
 	if(anchored)
 		if(dir & (NORTH|SOUTH))
 			initialize_directions = NORTH|SOUTH

--- a/code/ATMOSPHERICS/components/binary_devices/circulator.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/circulator.dm
@@ -103,8 +103,10 @@
 
 	return 1
 
-/obj/machinery/atmospherics/binary/circulator/wrenchAnchor(mob/user)
+/obj/machinery/atmospherics/binary/circulator/wrenchAnchor(var/mob/user)
 	. = ..()
+	if(!.)
+		return
 	if(anchored)
 		if(dir & (NORTH|SOUTH))
 			initialize_directions = NORTH|SOUTH
@@ -123,7 +125,6 @@
 		var/gendir = turn(dir, -90)
 		for(var/obj/machinery/power/generator/pot_gen in get_step(src, gendir))
 			pot_gen.reconnect()
-
 	else
 		if(node1)
 			node1.disconnect(src)
@@ -138,7 +139,6 @@
 		node2 = null
 
 		linked_generator.reconnect()
-
 
 /obj/machinery/atmospherics/binary/circulator/verb/rotate_clockwise()
 	set category = "Object"

--- a/code/ATMOSPHERICS/pipe/pipe_dispenser.dm
+++ b/code/ATMOSPHERICS/pipe/pipe_dispenser.dm
@@ -147,15 +147,17 @@
 	else
 		return ..()
 
-/obj/machinery/pipedispenser/wrenchAnchor(mob/user)
-	if(..() == 1)
-		if(anchored)
-			src.stat &= ~MAINT
-			power_change()
-		else
-			src.stat |= MAINT
-			if (user.machine==src)
-				user << browse(null, "window=pipedispenser")
+/obj/machinery/pipedispenser/wrenchAnchor(var/mob/user)
+	. = ..()
+	if(!.)
+		return
+	if(anchored)
+		src.stat &= ~MAINT
+		power_change()
+	else
+		src.stat |= MAINT
+		if (user.machine==src)
+			user << browse(null, "window=pipedispenser")
 
 
 /obj/machinery/pipedispenser/disposal

--- a/code/WorkInProgress/Cael_Aislinn/Rust/fuel_injector.dm
+++ b/code/WorkInProgress/Cael_Aislinn/Rust/fuel_injector.dm
@@ -33,11 +33,11 @@
 
 	cached_power_avail = avail()
 
-/obj/machinery/power/rust_fuel_injector/wrenchAnchor(mob/user)
+/obj/machinery/power/rust_fuel_injector/wrenchAnchor(var/mob/user)
 	if(injecting)
-		to_chat(user, "Turn off the [src] first.")
-		return -1
-	return ..()
+		to_chat(user, "Turn off \the [src] first.")
+		return FALSE
+	. =  ..()
 
 /obj/machinery/power/rust_fuel_injector/weldToFloor(var/obj/item/weapon/weldingtool/WT, mob/user)
 	if(..() == 1)

--- a/code/WorkInProgress/Cael_Aislinn/Rust/gyrotron_controller.dm
+++ b/code/WorkInProgress/Cael_Aislinn/Rust/gyrotron_controller.dm
@@ -27,7 +27,9 @@
 
 /obj/machinery/computer/rust_gyrotron_controller/wrenchAnchor(var/mob/user)
 	. = ..()
-	if(. == 1 && state) //We're set to anchored again.
+	if(!.)
+		return
+	if(state) //We're set to anchored again.
 		for(var/obj/machinery/rust/gyrotron/gyro in linked_gyrotrons)
 			if(get_dist(src, gyro) > RUST_GYROTRON_RANGE) //We've been moved so far we're out of range.
 				linked_gyrotrons -= gyro

--- a/code/WorkInProgress/Cael_Aislinn/ShieldGen/shield_capacitor.dm
+++ b/code/WorkInProgress/Cael_Aislinn/ShieldGen/shield_capacitor.dm
@@ -55,15 +55,16 @@
 	playsound(get_turf(src), 'sound/effects/sparks4.ogg', 75, 1)
 
 /obj/machinery/shield_capacitor/wrenchAnchor(var/mob/user)
-	if(..())
-		for(var/obj/machinery/shield_gen/gen in range(1, src))
-			if(!anchored && gen.owned_capacitor == src)
-				gen.owned_capacitor = null
-				break
-			else if(anchored && !gen.owned_capacitor)
-				gen.find_capacitor()
-		nanomanager.update_uis(src)
-		return 1
+	. = ..()
+	if(!.)
+		return
+	for(var/obj/machinery/shield_gen/gen in range(1, src))
+		if(!anchored && gen.owned_capacitor == src)
+			gen.owned_capacitor = null
+			break
+		else if(anchored && !gen.owned_capacitor)
+			gen.find_capacitor()
+	nanomanager.update_uis(src)
 
 /obj/machinery/shield_capacitor/attackby(var/obj/item/W, var/mob/user)
 	if(..())

--- a/code/WorkInProgress/Cael_Aislinn/ShieldGen/shield_gen.dm
+++ b/code/WorkInProgress/Cael_Aislinn/ShieldGen/shield_gen.dm
@@ -86,13 +86,14 @@
 	playsound(get_turf(src), 'sound/effects/sparks4.ogg', 75, 1)
 
 /obj/machinery/shield_gen/wrenchAnchor(var/mob/user)
-	if(..())
-		if(anchored)
-			find_capacitor()
-		else if(owned_capacitor)
-			owned_capacitor = null
-		nanomanager.update_uis(src)
-		return 1
+	. = ..()
+	if(!.)
+		return
+	if(anchored)
+		find_capacitor()
+	else if(owned_capacitor)
+		owned_capacitor = null
+	nanomanager.update_uis(src)
 
 /obj/machinery/shield_gen/attackby(var/obj/item/W, var/mob/user)
 	if(..())

--- a/code/game/machinery/Freezer.dm
+++ b/code/game/machinery/Freezer.dm
@@ -66,19 +66,14 @@
 		return
 	return ..()
 
-/obj/machinery/atmospherics/unary/cold_sink/freezer/wrenchAnchor(mob/user)
+/obj/machinery/atmospherics/unary/cold_sink/freezer/wrenchAnchor(var/mob/user)
 	if(on)
 		to_chat(user, "You have to turn off \the [src] first!")
-		return -1
+		return FALSE
 	. = ..()
-	if(!anchored)
-		verbs += rotate_verbs
-		if(node)
-			node.disconnect(src)
-			qdel(network)
-			network = null
-			node = null
-	else if(anchored)
+	if(!.)
+		return
+	if(anchored)
 		verbs -= rotate_verbs
 		initialize_directions = dir
 		initialize()
@@ -86,6 +81,14 @@
 		if (node)
 			node.initialize()
 			node.build_network()
+	else
+		verbs += rotate_verbs
+		if(node)
+			node.disconnect(src)
+			qdel(network)
+			network = null
+			node = null
+		
 
 /obj/machinery/atmospherics/unary/cold_sink/freezer/attack_hand(mob/user as mob)
 	user.set_machine(src)
@@ -235,19 +238,14 @@
 		return
 	return ..()
 
-/obj/machinery/atmospherics/unary/heat_reservoir/heater/wrenchAnchor(mob/user)
+/obj/machinery/atmospherics/unary/heat_reservoir/heater/wrenchAnchor(var/mob/user)
 	if(on)
 		to_chat(user, "You have to turn off \the [src] first!")
-		return -1
+		return FALSE
 	. = ..()
-	if(!anchored)
-		verbs += rotate_verbs
-		if(node)
-			node.disconnect(src)
-			qdel(network)
-			network = null
-			node = null
-	else if(anchored)
+	if(!.)
+		return
+	if(anchored)
 		verbs -= rotate_verbs
 		initialize_directions = dir
 		initialize()
@@ -255,6 +253,13 @@
 		if (node)
 			node.initialize()
 			node.build_network()
+		verbs += rotate_verbs
+	else
+		node.disconnect(src)
+		qdel(network)
+		network = null
+		node = null
+		
 
 /obj/machinery/atmospherics/unary/heat_reservoir/heater/attack_hand(mob/user as mob)
 	user.set_machine(src)

--- a/code/game/machinery/atmoalter/gas_mine.dm
+++ b/code/game/machinery/atmoalter/gas_mine.dm
@@ -29,11 +29,13 @@
 	air_contents.update_values()
 	update_icon()
 
-/obj/machinery/atmospherics/miner/wrenchAnchor(mob/user)
+/obj/machinery/atmospherics/miner/wrenchAnchor(var/mob/user)
+	. = ..()
+	if(!.)
+		return
 	if(on)
 		on = 0
 		update_icon()
-	..()
 
 // Critical equipment.
 /obj/machinery/atmospherics/miner/ex_act(severity)

--- a/code/game/machinery/atmoalter/vaporizer.dm
+++ b/code/game/machinery/atmoalter/vaporizer.dm
@@ -183,8 +183,10 @@
 	nanomanager.update_uis(src)
 	return 1
 
-/obj/machinery/vaporizer/wrenchAnchor(mob/user)
-	..()
+/obj/machinery/vaporizer/wrenchAnchor(var/mob/user)
+	. = ..()
+	if(!.)
+		return
 	power_change()
 	update_icon()
 

--- a/code/game/machinery/cell_charger.dm
+++ b/code/game/machinery/cell_charger.dm
@@ -112,11 +112,11 @@
 		chargelevel = -1
 		updateicon()
 
-/obj/machinery/cell_charger/wrenchAnchor(mob/user)
+/obj/machinery/cell_charger/wrenchAnchor(var/mob/user)
 	if(charging)
 		to_chat(user, "<span class='warning'>Remove the cell first!</span>")
-		return
-	..()
+		return FALSE
+	. = ..()
 
 /obj/machinery/cell_charger/attack_ai(mob/user)
 	return

--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -19,8 +19,6 @@
 	. = ..()
 	laws = new base_law_type
 
-/obj/structure/AIcore/wrenchAnchor/wrenchAnchor(var/mob/user)
-
 /obj/structure/AIcore/attackby(obj/item/P as obj, mob/user as mob)
 	if(iswrench(P))
 		wrenchAnchor(user, time_to_wrench = 2 SECONDS)

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -581,8 +581,7 @@ Class Procs:
 				to_chat(user, "\The [src] has to be unwelded from the floor first.")
 				return -1 //state set to 2, can't do it
 			else
-				// wrenchAnchor returns -1 on check failures, for some reason.
-				if(wrenchAnchor(user) == 1 && machine_flags & FIXED2WORK) //wrenches/unwrenches into place if possible, then updates the power and state if necessary
+				if(wrenchAnchor(user) && machine_flags & FIXED2WORK) //wrenches/unwrenches into place if possible, then updates the power and state if necessary
 					state = anchored
 					power_change() //updates us to turn on or off as necessary
 					return 1

--- a/code/game/machinery/metaldetector.dm
+++ b/code/game/machinery/metaldetector.dm
@@ -263,8 +263,10 @@
 		if ((src.anchored))
 			src.flash()
 
-/obj/machinery/detector/wrenchAnchor(mob/user)
-	if(..() == 1)
-		overlays.len = 0
-		if(anchored)
-			src.overlays += image(icon = icon, icon_state = "[base_state]-s")
+/obj/machinery/detector/wrenchAnchor(var/mob/user)
+	. = ..()
+	if(!.)
+		return
+	overlays.len = 0
+	if(anchored)
+		src.overlays += image(icon = icon, icon_state = "[base_state]-s")

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -71,14 +71,16 @@
 		update_icon()
 		return 1
 
-/obj/machinery/recharger/wrenchAnchor(mob/user)
+/obj/machinery/recharger/wrenchAnchor(var/mob/user)
 	if(charging)
 		to_chat(user, "<span class='notice'>Remove the charging item first!</span>")
+		return FALSE
+	. = ..()
+	if(!.)
 		return
-	if(..() == 1)
-		pixel_x = 0
-		pixel_y = 0
-		update_icon()
+	pixel_x = 0
+	pixel_y = 0
+	update_icon()
 
 /obj/machinery/recharger/attack_hand(mob/user)
 	if(issilicon(user) || ..())

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -258,16 +258,17 @@
 		update_icon()
 		return 1
 
-/obj/machinery/shieldgen/wrenchAnchor(mob/user)
+/obj/machinery/shieldgen/wrenchAnchor(var/mob/user)
 	if(locked)
 		to_chat(user, "The bolts are covered, unlocking this would retract the covers.")
-		return
+		return FALSE
 	if(active)
 		to_chat(user, "Turn \the [src] off first!")
+		return FALSE
 	if(panel_open)
 		to_chat(user, "You have to close \the [src]'s maintenance panel before you can do that.")
-		return
-	return ..()
+		return FALSE
+	. = ..()
 
 /obj/machinery/shieldgen/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(..())
@@ -472,14 +473,14 @@
 		CF.forceMove(T)
 		CF.dir = field_dir
 
-/obj/machinery/shieldwallgen/wrenchAnchor(mob/user)
+/obj/machinery/shieldwallgen/wrenchAnchor(var/mob/user)
 	if(active)
 		to_chat(user, "Turn off the field generator first.")
+		return FALSE
+	. = ..()
+	if(!.)
 		return
-	if(..())
-		power()
-		return 1
-
+	power()
 
 /obj/machinery/shieldwallgen/attack_ghost(mob/user)
 	if(isAdminGhost(user))

--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -197,12 +197,13 @@
 		to_chat(user, "<span class='warning'>\The [src] doesn't work on the fly, wrench it down first.</span>")
 		return
 
-/obj/machinery/singularity_beacon/wrenchAnchor(mob/user)
-
+/obj/machinery/singularity_beacon/wrenchAnchor(var/mob/user)
 	if(active)
 		to_chat(user, "<span class='warning'>Turn off \the [src] first.</span>")
+		return FALSE
+	. = ..()
+	if(!.)
 		return
-	..()
 	if(attached)
 		attached = null //Reset attached cable
 

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -450,34 +450,33 @@ a {
 	return TRUE
 
 /** Anchors shit to the deck via wrench.
- * NOTE: WHOEVER CODED THIS IS AN ABSOLUTE FUCKING RETARD AND USES -1 AS FAIL INSTEAD OF 0.
  * @param user The mob doing the wrenching
  * @param time_to_wrench The time to complete the wrenchening
- * @returns 1 on success, -1 on fail
+ * @returns TRUE on success, FALSE on fail
  */
-/obj/proc/wrenchAnchor(var/mob/user, var/time_to_wrench=30) //proc to wrench an object that can be secured
+/obj/proc/wrenchAnchor(var/mob/user, var/time_to_wrench = 3 SECONDS) //proc to wrench an object that can be secured
 	if(!canAffixHere(user))
-		return -1
+		return FALSE
 	if(!anchored)
 		if(!istype(src.loc, /turf/simulated/floor)) //Prevent from anchoring shit to shuttles / space
 			if(istype(src.loc, /turf/simulated/shuttle) && !can_wrench_shuttle()) //If on the shuttle and not wrenchable to shuttle
 				to_chat(user, "<span class = 'notice'>You can't secure \the [src] to this!</span>")
-				return -1
+				return FALSE
 			if(istype(src.loc, /turf/space)) //if on a space tile
 				to_chat(user, "<span class = 'notice'>You can't secure \the [src] to space!</span>")
-				return -1
+				return FALSE
 	user.visible_message(	"[user] begins to [anchored ? "unbolt" : "bolt"] \the [src] [anchored ? "from" : "to" ] the floor.",
 							"You begin to [anchored ? "unbolt" : "bolt"] \the [src] [anchored ? "from" : "to" ] the floor.")
 	playsound(loc, 'sound/items/Ratchet.ogg', 50, 1)
 	if(do_after(user, src, time_to_wrench))
 		if(!canAffixHere(user))
-			return -1
+			return FALSE
 		anchored = !anchored
 		user.visible_message(	"<span class='notice'>[user] [anchored ? "wrench" : "unwrench"]es \the [src] [anchored ? "in place" : "from its fixture"]</span>",
 								"<span class='notice'>[bicon(src)] You [anchored ? "wrench" : "unwrench"] \the [src] [anchored ? "in place" : "from its fixture"].</span>",
 								"<span class='notice'>You hear a ratchet.</span>")
-		return 1
-	return -1
+		return TRUE
+	return FALSE
 
 /obj/item/proc/updateSelfDialog()
 	var/mob/M = src.loc

--- a/code/game/objects/structures/mannequin.dm
+++ b/code/game/objects/structures/mannequin.dm
@@ -138,15 +138,15 @@
 /obj/structure/mannequin/attack_paw(mob/user as mob)
 	return attack_hand(user)
 
-/obj/structure/mannequin/wrenchAnchor(var/mob/user, var/time_to_wrench=30)
+/obj/structure/mannequin/wrenchAnchor(var/mob/user)
 	if(trapped_strip)
 		Awaken()
-		return
-	..()
+		return FALSE
+	. = ..()
 
 /obj/structure/mannequin/attackby(var/obj/item/weapon/W,var/mob/user)
 	if(iswrench(W))
-		return wrenchAnchor(user, 50)
+		return wrenchAnchor(user, 5 SECONDS)
 	else if(user.a_intent == I_HURT)
 		user.delayNextAttack(8)
 		getDamage(W.force)
@@ -771,7 +771,7 @@
 
 /obj/structure/block/attackby(var/obj/item/weapon/W,var/mob/user)
 	if(iswrench(W))
-		return wrenchAnchor(user, 50)
+		return wrenchAnchor(user, 5 SECONDS)
 	else if(istype(W, /obj/item/weapon/chisel))
 
 		var/chosen_sculpture = input("Choose a sculpture type.", "[name]") as null|anything in available_sculptures

--- a/code/game/objects/structures/stool_bed_chair_nest/guillotine.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/guillotine.dm
@@ -171,10 +171,13 @@
 	if(user == victim)
 		return
 	if(iswrench(W))
-		if(victim)
-			to_chat(user, "<span class='warning'>You can't unsecure \the [src] from the floor while someone's inside it!</span>")
-			return
 		wrenchAnchor(user)
+
+/obj/structure/bed/guillotine/wrenchAnchor(var/mob/user)
+	if(victim)
+		to_chat(user, "<span class='warning'>You can't unsecure \the [src] from the floor while someone's inside it!</span>")
+		return FALSE
+	. = ..()
 
 /obj/structure/bed/guillotine/AltClick(var/mob/user)
 	if(!Adjacent(user) || user.incapacitated() || istype(user, /mob/living/silicon/pai) || user == victim)	//same restrictions as putting someone into it

--- a/code/modules/media/broadcast/transmitters/broadcast.dm
+++ b/code/modules/media/broadcast/transmitters/broadcast.dm
@@ -62,16 +62,16 @@
 	power_connection.connect()
 	update_icon()
 
-/obj/machinery/media/transmitter/broadcast/wrenchAnchor(mob/user)
-	if(..())
-		if(anchored) // We are now anchored
-			power_connection.connect() // Connect to the powernet
-		else // We are now NOT anchored
-			power_connection.disconnect() // Ditch powernet.
-			on=0
-			update_on()
-		return 1
-	return
+/obj/machinery/media/transmitter/broadcast/wrenchAnchor(var/mob/user)
+	. = ..()
+	if(!.)
+		return
+	if(anchored) // We are now anchored
+		power_connection.connect() // Connect to the powernet
+	else // We are now NOT anchored
+		power_connection.disconnect() // Ditch powernet.
+		on=0
+		update_on()
 
 /obj/machinery/media/transmitter/broadcast/proc/hook_media_sources()
 	if(!sources.len)

--- a/code/modules/media/jukebox.dm
+++ b/code/modules/media/jukebox.dm
@@ -464,11 +464,19 @@ var/global/list/loopModeNames=list(
 	update_icon()
 	update_music()
 
-/obj/machinery/media/jukebox/wrenchAnchor(mob/user)
-	if(..())
-		playing = emagged
-		update_music()
-		update_icon()
+/obj/machinery/media/jukebox/wrenchAnchor(var/mob/user)
+	. = ..()
+	if(!.)
+		return
+	playing = emagged
+	update_music()
+	update_icon()
+
+	// Needed, or jukeboxes will fail to unhook from previous areas.
+	if(!anchored)
+		disconnect_media_source()
+	else
+		update_media_source()
 
 /obj/machinery/media/jukebox/proc/successful_purchase()
 		next_song = selected_song

--- a/code/modules/media/machinery.dm
+++ b/code/modules/media/machinery.dm
@@ -107,11 +107,3 @@
 /obj/machinery/media/Destroy()
 	disconnect_media_source()
 	..()
-
-// Needed, or jukeboxes will fail to unhook from previous areas.
-/obj/machinery/media/jukebox/wrenchAnchor(var/mob/user)
-	..(user)
-	if(!anchored)
-		disconnect_media_source()
-	else
-		update_media_source()

--- a/code/modules/optics/mirrors/mirror.dm
+++ b/code/modules/optics/mirrors/mirror.dm
@@ -91,11 +91,12 @@ var/global/list/obj/machinery/mirror/mirror_list = list()
 
 /obj/machinery/mirror/wrenchAnchor(var/mob/user)
 	. = ..()
-	if(. == 1)
-		if(beams && beams.len)
-			kill_all_beams()
-		update_beams()
-	return .
+	if(!.)
+		return
+
+	if(beams && beams.len)
+		kill_all_beams()
+	update_beams()
 
 /obj/machinery/mirror/beam_connect(var/obj/effect/beam/emitter/B)
 	if(istype(B))

--- a/code/modules/optics/photocollector.dm
+++ b/code/modules/optics/photocollector.dm
@@ -43,14 +43,14 @@ var/list/obj/machinery/power/photocollector/photocollector_list = list()
 		add_avail(power_produced)
 		last_power = power_produced
 
-/obj/machinery/power/photocollector/wrenchAnchor(mob/user)
-	if(..() == 1)
-		if(anchored)
-			connect_to_network()
-		else
-			disconnect_from_network()
-		return 1
-	return -1
+/obj/machinery/power/photocollector/wrenchAnchor(var/mob/user)
+	. = ..()
+	if(!.)
+		return
+	if(anchored)
+		connect_to_network()
+	else
+		disconnect_from_network()
 
 /obj/machinery/power/photocollector/attackby(obj/item/W, mob/user)
 	if(..())

--- a/code/modules/optics/prism.dm
+++ b/code/modules/optics/prism.dm
@@ -65,10 +65,10 @@ var/list/obj/machinery/prism/prism_list = list()
 
 /obj/machinery/prism/wrenchAnchor(var/mob/user)
 	. = ..()
-	if(. == 1)
-		if(beams && beams.len)
-			update_beams()
-	return .
+	if(!.)
+		return
+	if(beams && beams.len)
+		update_beams()
 
 /obj/machinery/prism/beam_connect(var/obj/effect/beam/emitter/B)
 	if(istype(B))

--- a/code/modules/power/battery_ion.dm
+++ b/code/modules/power/battery_ion.dm
@@ -63,17 +63,17 @@
 		return connected_to.surplus()
 	return 0
 
-/obj/machinery/power/battery/portable/wrenchAnchor(mob/user)
-	if(..() == 1)
-		if(anchored)
-			var/obj/machinery/power/battery_port/port = locate() in src.loc
-			if(port)
-				port.connect_battery(src)
-		else
-			if(connected_to)
-				connected_to.disconnect_battery()
-		return 1
-	return -1
+/obj/machinery/power/battery/portable/wrenchAnchor(var/mob/user)
+	. = ..()
+	if(!.)
+		return
+	if(anchored)
+		var/obj/machinery/power/battery_port/port = locate() in src.loc
+		if(port)
+			port.connect_battery(src)
+	else
+		if(connected_to)
+			connected_to.disconnect_battery()
 
 /obj/machinery/power/battery/portable/update_icon()
 	if(stat & BROKEN)

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -247,6 +247,8 @@
 
 /obj/machinery/power/generator/wrenchAnchor()
 	. = ..()
+	if(!.)
+		return
 	reconnect()
 
 /obj/machinery/power/generator/proc/operable()

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -220,14 +220,14 @@ display round(lastgen) and plasmatank amount
 		return 1
 	return -1
 
-/obj/machinery/power/port_gen/pacman/wrenchAnchor(mob/user)
-	if(..() == 1)
-		if(anchored)
-			connect_to_network()
-		else
-			disconnect_from_network()
-		return 1
-	return -1
+/obj/machinery/power/port_gen/pacman/wrenchAnchor(var/mob/user)
+	. = ..()
+	if(!.)
+		return
+	if(anchored)
+		connect_to_network()
+	else
+		disconnect_from_network()
 
 /obj/machinery/power/port_gen/pacman/attackby(var/obj/item/O as obj, var/mob/user as mob)
 	if(istype(O, sheet_path))

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -90,18 +90,18 @@ var/global/list/rad_collectors = list()
 	else
 		return
 
-/obj/machinery/power/rad_collector/wrenchAnchor(mob/user)
+/obj/machinery/power/rad_collector/wrenchAnchor(var/mob/user)
 	if(P)
 		to_chat(user, "<span class='warning'>Remove the plasma tank first.</span>")
+		return FALSE
+	. = ..()
+	if(!.)
 		return
-	if(..() == 1)
-		if(anchored)
-			connect_to_network()
-		else
-			disconnect_from_network()
-			last_power = 0
-		return 1
-	return -1
+	if(anchored)
+		connect_to_network()
+	else
+		disconnect_from_network()
+		last_power = 0
 
 /obj/machinery/power/rad_collector/ex_act(severity)
 	switch(severity)

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -248,12 +248,11 @@
 		user.visible_message("<span class='danger'>[user] shorts out \the [src]'s lock.</span>", "<span class='warning'>You short out \the [src]'s lock.</span>")
 		return
 
-/obj/machinery/power/emitter/wrenchAnchor(mob/user)
-
+/obj/machinery/power/emitter/wrenchAnchor(var/mob/user)
 	if(active)
 		to_chat(user, "<span class='warning'>Turn off \the [src] first.</span>")
-		return
-	return ..()
+		return FALSE
+	. = ..()
 
 /obj/machinery/power/emitter/weldToFloor()
 

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -103,21 +103,11 @@ var/global/list/obj/machinery/field_generator/field_gen_list = list()
 		to_chat(user, "The [src] needs to be firmly secured to the floor first.")
 		return 0
 
-/obj/machinery/field_generator/wrenchAnchor(mob/user)
+/obj/machinery/field_generator/wrenchAnchor(var/mob/user)
 	if(active)
 		to_chat(user, "Turn off the [src] first.")
-		return -1
-	return ..()
-
-
-/obj/machinery/field_generator/attackby(obj/item/W, mob/user)
-	if(active)
-		to_chat(user, "The [src] needs to be off.")
-		return
-	else if(..())
-		return 1
-	return
-
+		return FALSE
+	. = ..()
 
 /obj/machinery/field_generator/emp_act()
 	return 0

--- a/code/modules/power/singularity/generator.dm
+++ b/code/modules/power/singularity/generator.dm
@@ -27,9 +27,6 @@
 	new /obj/machinery/singularity(get_turf(src), 50)
 	qdel(src)
 
-/obj/machinery/the_singularitygen/wrenchAnchor(mob/user)
+/obj/machinery/the_singularitygen/wrenchAnchor(var/mob/user)
 	src.add_hiddenprint(user)
-	return ..()
-
-/obj/machinery/the_singularitygen/attackby(obj/item/W, mob/user)
-	return ..()
+	. = ..()

--- a/code/modules/power/treadmill.dm
+++ b/code/modules/power/treadmill.dm
@@ -101,8 +101,10 @@
 	else
 		return 1
 
-/obj/machinery/power/treadmill/wrenchAnchor(mob/user)
-	..()
+/obj/machinery/power/treadmill/wrenchAnchor(var/mob/user)
+	. = ..()
+	if(!.)
+		return
 	if(anchored)
 		connect_to_network()
 	else

--- a/code/modules/recycling/compactor.dm
+++ b/code/modules/recycling/compactor.dm
@@ -95,7 +95,7 @@
 /obj/machinery/disposal/compactor/attackby(var/obj/item/I, var/mob/user)
 	add_fingerprint(user)
 	if(iswrench(I)) //We want this to be a high level operation, before any of the place in bin code or disassemble bin code
-		wrenchAnchor(user, 30)
+		wrenchAnchor(user)
 		power_change()
 		return
 	if(!emagged && istype(I,/obj/item/weapon/card/emag))


### PR DESCRIPTION
Changed wrenchAnchor to return FALSE on failure.
Went through every single override of `wrenchAnchor` and changed it so that:
- Overridden methods do their own special snowflake and return FALSE early, in case of failure
- If all special snowflake checks passed, we call the parent, which does the actual `do_after` wrenching/unwrenching
- If that failed, we return early
- Otherwise, we optionally check for `anchored` where applicable and do things according to that.

I opted to use `return FALSE` for the checks that explictly fail, but to just use `return` for the `if(!.)`. I think this style is fine but I'm willing to change it if you don't like it, as long as we get this thing over with.

I then went through every single usage of `wrenchAnchor `and removed the old `== 1` checks.

Then, I tested every single object for which `wrenchAnchor` is defined or used, and got the following:

![dreamseeker_2017-09-30_18-00-01](https://user-images.githubusercontent.com/6307265/31047423-ab35b066-a60a-11e7-806a-731607af102c.png)

`proc name: wrenchAnchor (/obj/machinery/atmospherics/binary/circulator/wrenchAnchor)
usr: Gabriel Harris (damianq) (/mob/living/carbon/human)
usr.loc: The floor (217, 188, 1) (/turf/simulated/floor)
src: the circulator (/obj/machinery/atmospherics/binary/circulator)
src.loc: the floor (216,189,1) (/turf/simulated/floor)
call stack:
the circulator (/obj/machinery/atmospherics/binary/circulator): wrenchAnchor(Gabriel Harris (/mob/living/carbon/human))
the circulator (/obj/machinery/atmospherics/binary/circulator): attackby(the wrench (/obj/item/weapon/wrench), Gabriel Harris (/mob/living/carbon/human), "icon-x=5;icon-y=20;left=1;scre...")
the circulator (/obj/machinery/atmospherics/binary/circulator): attackby(the wrench (/obj/item/weapon/wrench), Gabriel Harris (/mob/living/carbon/human), "icon-x=5;icon-y=20;left=1;scre...")
Gabriel Harris (/mob/living/carbon/human): ClickOn(the circulator (/obj/machinery/atmospherics/binary/circulator), "icon-x=5;icon-y=20;left=1;scre...")
the circulator (/obj/machinery/atmospherics/binary/circulator): Click(the floor (216,189,1) (/turf/simulated/floor), "mapwindow.map", "icon-x=5;icon-y=20;left=1;scre...")`

`proc name: process (/obj/machinery/power/photocollector/process)
src: Photocollector (/obj/machinery/power/photocollector)
src.loc: the floor (247,196,1) (/turf/simulated/floor)
call stack:
Photocollector (/obj/machinery/power/photocollector): process()
Power (/datum/subsystem/power): fire(0)
Power (/datum/subsystem/power): ignite(0)
Master (/datum/controller/master): RunQueue()
Master (/datum/controller/master): Loop()
Master (/datum/controller/master): StartProcessing()`

`proc name: dumbfire (/obj/item/projectile/beam/dumbfire)
usr: Gabriel Harris (damianq) (/mob/living/carbon/human)
usr.loc: The floor (238, 210, 1) (/turf/simulated/floor)
(This error will now be silenced for 10 minutes)`

All objects successfully wrenched, unwrenched, verified working and not working.

I'll investigate the runtimes at a later time but I'm putting the PR up now for review.