### PR TITLE
Raise AIRLOCK_CONTROL_RANGE to 8 (just over one screen of view range)

### DIFF
--- a/code/game/machinery/airlock_control.dm
+++ b/code/game/machinery/airlock_control.dm
@@ -1,4 +1,4 @@
-#define AIRLOCK_CONTROL_RANGE 5
+#define AIRLOCK_CONTROL_RANGE 8
 
 // This code allows for airlocks to be controlled externally by setting an id_tag and comm frequency (disables ID access)
 obj/machinery/door/airlock


### PR DESCRIPTION
I got pissed off by not being able to toggle all the smartglass in the box chapel.
Ideally you could just use one access button to toggle everything in a single room, but still.
This *might* break some very carefully (and badly) crafted airlock/button-related things. If it does, that's a good thing, because we can actually fix it at the core.

:cl:
 - tweak: Raised access button range to 8 (just over one screen of view range)