### PR TITLE
makes revsquad flashes unscannable

### DIFF
--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -94,7 +94,7 @@
 
 	if(iscarbon(M))
 		var/mob/living/carbon/Subject = M
-		
+
 		if(Subject.eyecheck() > 0)
 			user.visible_message("<span class='notice'>[user] fails to blind [M] with the flash!</span>")
 		else
@@ -254,3 +254,4 @@
 
 /obj/item/device/flash/revsquad
 	limited_conversions = REVSQUAD_FLASH_USES
+	mech_flags = MECH_SCAN_FAIL


### PR DESCRIPTION
Flashes seem like a clusterfuck of code that should be changed entirely, but that's out of scope of the issue given.

This just adds the MECH_SCAN_FAIL flag to revsquad flashes, so they're unreproducable

closes #15899 in theory, but flashes by themselves are fucked anyway