### PR TITLE
fixes flashpowder functionality

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -452,9 +452,8 @@
 
 		playsound(get_turf(src), 'sound/effects/phasein.ogg', 25, 1)
 
-		var/eye_safety = 0
-
 		for(var/mob/living/M in viewers(get_turf(holder.my_atom), null))
+			var/eye_safety = 0
 			if(iscarbon(M))
 				eye_safety = M.eyecheck()
 


### PR DESCRIPTION
Previously, it checked if only one person in line of sight, moving outwards from itself, had eye protection.

If so, it would fail to flash everyone else after that

closes #13922