### PR TITLE
Temporary removal of fleshshot due to server crashes.

### DIFF
--- a/code/modules/mob/living/simple_animal/borer/unlocks.dm
+++ b/code/modules/mob/living/simple_animal/borer/unlocks.dm
@@ -658,6 +658,7 @@
 	give_when_attached=1
 	antirequisites=list("bone_sword","bone_shield")
 
+/* FIXME - Removed October 2, 2017 due to server crashes that persist after multiple attempts at fixing, and inability to reproduce locally.
 /datum/unlockable/borer/arm/extend_o_arm_unlock
 	remove_on_detach = 0 // Borer-side, so we don't lose it.
 
@@ -672,6 +673,7 @@
 	cost=200
 	time=1 MINUTES
 	prerequisites=list("repair_bone")
+*/
 
 ////////////Leg Verbs////////////////////////////
 


### PR DESCRIPTION
On October 2nd, we experienced a recurrance of the server crashes that have hit us in the past with regards to fleshshots.  I spent an hour or so trying to reproduce the issue by using the hookshot, and then by becoming a borer and infesting a human and evolving the fleshshot.  I was unable to reproduce the problem, despite clicking on nearly every object on screen.

This issue has come and gone for months, and despite several attempts at fixing it, it has persisted.  Due to the severity of the problem, I have decided to remove it, both to prevent a recurrence, and to spur people into helping to debug and fix it.

And yes, I realize this will not make me popular but that seems to be my niche in life.

# Changelog
:cl:
* rscdel: Temporarily removed fleshshot from borer evolution tree while a severe server crash issue is fixed.

/:cl:

# Issues
* #16151 
* #15092 