### PR TITLE
QoL for xenoarch handpicks and tape measures.

### DIFF
--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -237,12 +237,7 @@ turf/unsimulated/mineral/ChangeTurf(var/turf/N, var/tell_universe=1, var/force_l
 	if (istype(W, /obj/item/device/measuring_tape))
 		var/obj/item/device/measuring_tape/P = W
 		user.visible_message("<span class='notice'>[user] extends [P] towards [src].</span>","<span class='notice'>You extend [P] towards [src].</span>")
-		busy = 1
-		if(do_after(user, src,25))
-			to_chat(user, "<span class='notice'>[bicon(P)] [src] has been excavated to a depth of [2*excavation_level]cm.</span>")
-			busy = 0
-		else
-			busy = 0
+		to_chat(user, "<span class='notice'>[bicon(P)] [src] has been excavated to a depth of [2*excavation_level]cm.</span>")
 		return
 
 	if (istype(W, /obj/item/weapon/pickaxe))

--- a/code/modules/research/xenoarchaeology/artifact/artifact.dm
+++ b/code/modules/research/xenoarchaeology/artifact/artifact.dm
@@ -71,12 +71,7 @@
 	if (istype(W, /obj/item/device/measuring_tape))
 		var/obj/item/device/measuring_tape/P = W
 		user.visible_message("<span class='notice>[user] extends [P] towards [src].","<span class='notice'>You extend [P] towards [src].</span></span>")
-		busy = 1
-		if(do_after(user, src, 40))
-			busy = 0
-			to_chat(user, "<span class='notice'>[bicon(P)] [src] has been excavated to a depth of [2*src.excavation_level]cm.</span>")
-		else
-			busy = 0
+		to_chat(user, "<span class='notice'>[bicon(P)] [src] has been excavated to a depth of [2*src.excavation_level]cm.</span>")
 		return
 
 	if (istype(W, /obj/item/weapon/pickaxe))

--- a/code/modules/research/xenoarchaeology/tools/tools_pickaxe.dm
+++ b/code/modules/research/xenoarchaeology/tools/tools_pickaxe.dm
@@ -3,7 +3,7 @@
 // Excavation pickaxes - sorted in order of delicacy. Players will have to choose the right one for each part of excavation.
 
 /obj/item/weapon/pickaxe/brush
-	name = "brush"
+	name = "1 cm brush"
 	icon = 'icons/obj/xenoarchaeology.dmi'
 	icon_state = "pick_brush"
 	item_state = "syringe_0"
@@ -15,7 +15,7 @@
 	w_class = W_CLASS_SMALL
 
 /obj/item/weapon/pickaxe/one_pick
-	name = "1/6 pick"
+	name = "2 cm pick"
 	icon = 'icons/obj/xenoarchaeology.dmi'
 	icon_state = "pick1"
 	item_state = "syringe_0"
@@ -27,7 +27,7 @@
 	w_class = W_CLASS_SMALL
 
 /obj/item/weapon/pickaxe/two_pick
-	name = "1/3 pick"
+	name = "4 cm pick"
 	icon = 'icons/obj/xenoarchaeology.dmi'
 	icon_state = "pick2"
 	item_state = "syringe_0"
@@ -39,7 +39,7 @@
 	w_class = W_CLASS_SMALL
 
 /obj/item/weapon/pickaxe/three_pick
-	name = "1/2 pick"
+	name = "6 cm pick"
 	icon = 'icons/obj/xenoarchaeology.dmi'
 	icon_state = "pick3"
 	item_state = "syringe_0"
@@ -51,7 +51,7 @@
 	w_class = W_CLASS_SMALL
 
 /obj/item/weapon/pickaxe/four_pick
-	name = "2/3 pick"
+	name = "8 cm pick"
 	icon = 'icons/obj/xenoarchaeology.dmi'
 	icon_state = "pick4"
 	item_state = "syringe_0"
@@ -63,7 +63,7 @@
 	w_class = W_CLASS_SMALL
 
 /obj/item/weapon/pickaxe/five_pick
-	name = "5/6 pick"
+	name = "10 cm pick"
 	icon = 'icons/obj/xenoarchaeology.dmi'
 	icon_state = "pick5"
 	item_state = "syringe_0"
@@ -75,7 +75,7 @@
 	w_class = W_CLASS_SMALL
 
 /obj/item/weapon/pickaxe/six_pick
-	name = "1/1 pick"
+	name = "12 cm pick"
 	icon = 'icons/obj/xenoarchaeology.dmi'
 	icon_state = "pick6"
 	item_state = "syringe_0"


### PR DESCRIPTION
A bit of QoL and fix for xenoarch hand picks where they have the name of what they dig now. They were given depths based on burger units. An example is where the 1/1 pick is 12 **cm** when that would actually be referring to imperial units having 12 **in** to 1 ft. Yes the fractions are in relation to 12cm as it's whole but it's still odd how they have it at 12 cm for it's whole rather than 10.
Also making the measuring tape instant as another QoL feature.
:cl:
 * tweak: Xenoarch hand picks no longer refer to a fraction for their name and now refer to how much they dig directly in the name.
 * tweak: Xenoarch tape measures now read the depth of a wall instantly.