### PR TITLE
Dimensional Push Fix

### DIFF
--- a/code/modules/spells/targeted/push.dm
+++ b/code/modules/spells/targeted/push.dm
@@ -20,6 +20,10 @@
 	var/list/valid_targets = list()
 	var/list/options = ..()
 	for(var/atom/movable/target in options)
+		if(target == holder.locked_to)
+			to_chat(holder, "<span class='warning'>You can't push something away if you're attached to it.</span>")
+			valid_targets = list()
+			break
 		valid_targets += target
 	if(!holder.z)
 		to_chat(holder, "<span class='warning'>You can't seem to get enough leverage for a push from here.</span>")
@@ -51,6 +55,7 @@
 		to_chat(holder, "The spell matrix was unable to locate a suitable destination for an unknown reason. Sorry.")
 		return
 
+	var/list/backup_L = L
 	for(var/atom/movable/target in targets)
 		target.unlock_from()
 		var/attempt = null
@@ -63,7 +68,7 @@
 			else
 				break
 		if(!success)
-			target.forceMove(pick(L))
+			target.forceMove(pick(backup_L))
 
 /spell/targeted/push/get_upgrade_price(upgrade_type)
 	return price / 2


### PR DESCRIPTION
Wizards can no longer push themselves via buckling to something and pushing it.
Fixes the contingency in the loop at the end of `cast()` so it doesn't pick from an empty list.