### PR TITLE
Changes the light_color of two consoles

### DIFF
--- a/code/game/machinery/telecomms/traffic_control.dm
+++ b/code/game/machinery/telecomms/traffic_control.dm
@@ -19,7 +19,7 @@
 	var/list/access_log = list()
 	var/process = 0
 
-	light_color = LIGHT_COLOR_GREEN
+	light_color = LIGHT_COLOR_ORANGE
 
 	req_access = list(access_tcomsat)
 

--- a/code/modules/mining/machine_stacking.dm
+++ b/code/modules/mining/machine_stacking.dm
@@ -4,7 +4,7 @@
 	name = "stacking machine console"
 	icon = 'icons/obj/computer.dmi'
 	icon_state = "stacking_machine_console"
-	light_color = LIGHT_COLOR_GREEN
+	light_color = LIGHT_COLOR_BLUE
 	circuit = "/obj/item/weapon/circuitboard/stacking_machine_console"
 
 	var/stacker_tag//The ID of the stacker this console should control


### PR DESCRIPTION
Changes the telecommunications traffic control console and stacking machine console to have orange and blue colours respectively.

Fixes #16157.