### PR TITLE
Moves simple_animal Environment Destruction to Flag System

### DIFF
--- a/__DEFINES/simple_animal_defines.dm
+++ b/__DEFINES/simple_animal_defines.dm
@@ -1,0 +1,5 @@
+//Environment smash flags
+#define SMASH_LIGHT_STRUCTURES 1	//tables, racks
+#define SMASH_CONTAINERS 2	//closets, crates
+#define SMASH_WALLS 4
+#define SMASH_RWALLS 8

--- a/code/game/gamemodes/endgame/xmas/snowman.dm
+++ b/code/game/gamemodes/endgame/xmas/snowman.dm
@@ -22,7 +22,7 @@
 	minimum_distance = 3
 	projectilesound = 'sound/weapons/punchmiss.ogg'
 	projectiletype = /obj/item/projectile/snowball
-	environment_smash = 0
+	environment_smash_flags = 0
 
 	can_butcher = 0
 

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -262,7 +262,7 @@
 	..(user)
 
 /obj/structure/closet/attack_animal(mob/living/simple_animal/user as mob)
-	if(user.environment_smash)
+	if(user.environment_smash_flags & SMASH_CONTAINERS)
 //		user.do_attack_animation(src, user) //This will look stupid
 		visible_message("<span class='warning'>[user] destroys the [src]. </span>")
 		for(var/atom/movable/A as mob|obj in src)

--- a/code/game/objects/structures/crates_lockers/closets/statue.dm
+++ b/code/game/objects/structures/crates_lockers/closets/statue.dm
@@ -166,7 +166,7 @@
 	return
 
 /obj/structure/closet/statue/attack_animal(mob/living/simple_animal/user as mob)
-	if(user.environment_smash)
+	if(user.environment_smash_flags & SMASH_CONTAINERS)
 		for(var/mob/M in src)
 			shatter(M)
 

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -430,7 +430,7 @@
 
 /obj/structure/cultgirder/attack_animal(var/mob/living/simple_animal/M)
 	M.delayNextAttack(8)
-	if(M.environment_smash >= 2)
+	if(M.environment_smash_flags & SMASH_WALLS)
 		new /obj/effect/decal/remains/human(get_turf(src))
 		M.visible_message("<span class='danger'>[M] smashes through \the [src].</span>", \
 		"<span class='attack'>You smash through \the [src].</span>")

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -280,7 +280,7 @@
 	destroy()
 
 /obj/structure/table/attack_animal(mob/living/simple_animal/user)
-	if(user.environment_smash>0)
+	if(user.environment_smash_flags & SMASH_LIGHT_STRUCTURES)
 		user.do_attack_animation(src, user)
 		visible_message("<span class='danger'>[user] smashes [src] apart!</span>")
 		destroy()
@@ -810,7 +810,7 @@
 	destroy()
 
 /obj/structure/rack/attack_animal(mob/living/simple_animal/user)
-	if(user.environment_smash>0)
+	if(user.environment_smash_flags & SMASH_LIGHT_STRUCTURES)
 		user.do_attack_animation(src, user)
 		visible_message("<span class='danger'>[user] smashes [src] apart!</span>")
 		destroy()

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -85,9 +85,9 @@
 
 /turf/simulated/wall/attack_animal(var/mob/living/simple_animal/M)
 	M.delayNextAttack(8)
-	if(M.environment_smash >= 2)
+	if(M.environment_smash_flags & SMASH_WALLS)
 		if(istype(src, /turf/simulated/wall/r_wall))
-			if(M.environment_smash == 3)
+			if(M.environment_smash_flags & SMASH_RWALLS)
 				dismantle_wall(1)
 				M.visible_message("<span class='danger'>[M] smashes through \the [src].</span>", \
 				"<span class='attack'>You smash through \the [src].</span>")

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -561,7 +561,7 @@ proc/move_mining_shuttle()
 	maxHealth = 100
 	melee_damage_lower = 15
 	melee_damage_upper = 15
-	environment_smash = 0
+	environment_smash_flags = 0
 	attacktext = "drills"
 	attack_sound = 'sound/weapons/circsawhit.ogg'
 	ranged = 1

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -152,7 +152,7 @@
 	melee_damage_upper = 30
 	attacktext = "smashes their armoured gauntlet into"
 	speed = 4
-	environment_smash = 2
+	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | SMASH_WALLS
 	attack_sound = 'sound/weapons/heavysmash.ogg'
 	status_flags = 0
 	construct_spells = list(/spell/aoe_turf/conjure/forcewall/lesser)
@@ -213,7 +213,7 @@
 	melee_damage_upper = 25
 	attacktext = "slashes"
 	speed = 1
-	environment_smash = 1
+	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS
 	see_in_dark = 7
 	attack_sound = 'sound/weapons/rapidslice.ogg'
 	construct_spells = list(/spell/targeted/ethereal_jaunt/shift)
@@ -239,7 +239,7 @@
 	melee_damage_upper = 5
 	attacktext = "rams"
 	speed = 1
-	environment_smash = 1
+	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS
 	attack_sound = 'sound/weapons/rapidslice.ogg'
 	construct_spells = list(/spell/aoe_turf/conjure/construct/lesser,
 							/spell/aoe_turf/conjure/wall,
@@ -269,7 +269,7 @@
 	melee_damage_upper = 50
 	attacktext = "brutally crushes"
 	speed = 6
-	environment_smash = 2
+	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | SMASH_WALLS
 	attack_sound = 'sound/weapons/heavysmash.ogg'
 	var/energy = 0
 	var/max_energy = 1000
@@ -314,7 +314,7 @@
 	melee_damage_upper = 25
 	attacktext = "violently stabs"
 	speed = 1
-	environment_smash = 1
+	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS
 	see_in_dark = 7
 	attack_sound = 'sound/weapons/pierce.ogg'
 

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -21,6 +21,7 @@
 	melee_damage_lower = 1
 	melee_damage_upper = 2
 	size = SIZE_BIG
+	environment_smash_flags = SMASH_LIGHT_STRUCTURES
 
 	var/datum/reagents/udder = null
 

--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -32,7 +32,7 @@ var/list/nest_locations = list()
 	max_n2 = 0
 	unsuitable_atoms_damage = 15
 	faction = "alien"
-	environment_smash = 2
+	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | SMASH_WALLS
 	status_flags = CANPUSH
 	minbodytemp = 0
 	heat_damage_per_tick = 20
@@ -78,7 +78,7 @@ var/list/nest_locations = list()
 				stop_pulling()
 
 /mob/living/simple_animal/hostile/alien/DestroySurroundings()
-	if(environment_smash)
+	if(environment_smash_flags & SMASH_LIGHT_STRUCTURES)
 		EscapeConfinement()
 		for(var/dir in cardinal)
 			var/turf/T = get_step(src, dir)

--- a/code/modules/mob/living/simple_animal/hostile/bat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bat.dm
@@ -36,7 +36,7 @@
 
 	holder_type = null //Can't pick a SWARM OF BATS up
 
-	environment_smash = 1
+	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS
 	size = SIZE_TINY
 
 	faction = "scarybat"
@@ -175,7 +175,7 @@ mob/living/simple_animal/hostile/scarybat/book/New()
 	icon_dead = "bookbat_woody_dead"
 	icon_gib = "bookbat_woody_dead"
 	book_cover = "woody"
-	environment_smash = 0
+	environment_smash_flags = 0
 	harm_intent_damage = 0
 	melee_damage_lower = 0
 	melee_damage_upper = 0

--- a/code/modules/mob/living/simple_animal/hostile/decoy.dm
+++ b/code/modules/mob/living/simple_animal/hostile/decoy.dm
@@ -1,7 +1,7 @@
 //on aggro, these decoys delete themselves and spawn a given replacement atom
 /mob/living/simple_animal/hostile/decoy
 	wander = 0
-	environment_smash = 0
+	environment_smash_flags = 0
 	faction = "decoy"
 	vision_range = 5	//no point in having the decoy if it aggros before the player sees it
 	min_oxy = 0

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/spiderling.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/spiderling.dm
@@ -38,7 +38,7 @@
 	search_objects = 0
 	wanted_objects = list(/obj/machinery/atmospherics/unary/vent_pump)
 
-	environment_smash = 0//spiderlings cannot smash tables and windows anymore when getting stomped
+	environment_smash_flags = 0//spiderlings cannot smash tables and windows anymore when getting stomped
 	var/static/list/spider_types = list(/mob/living/simple_animal/hostile/giant_spider, /mob/living/simple_animal/hostile/giant_spider/nurse, /mob/living/simple_animal/hostile/giant_spider/hunter)
 
 /mob/living/simple_animal/hostile/giant_spider/spiderling/New()

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -1,7 +1,7 @@
 /mob/living/simple_animal/hostile
 	faction = "hostile"
 	stop_automated_movement_when_pulled = 0
-	environment_smash = 1 //Set to 1 to break closets,tables,racks, etc; 2 for walls; 3 for rwalls
+	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS	//defines are in simple_animal_defines.dm
 
 	var/stance = HOSTILE_STANCE_IDLE	//Used to determine behavior
 	var/atom/target // /vg/ edit:  Removed type specification so spiders can target doors.
@@ -60,7 +60,7 @@
 
 		switch(stance)
 			if(HOSTILE_STANCE_IDLE)
-				if(environment_smash)
+				if(environment_smash_flags & SMASH_LIGHT_STRUCTURES)
 					EscapeConfinement()
 				var/new_target = FindTarget()
 				GiveTarget(new_target)
@@ -197,7 +197,7 @@
 			return
 
 	if(target.loc != null && get_dist(src, target.loc) <= vision_range)//We can't see our target, but he's in our vision range still
-		if(FindHidden(target) && environment_smash)//Check if he tried to hide in something to lose us
+		if(FindHidden(target) && (environment_smash_flags & SMASH_LIGHT_STRUCTURES))//Check if he tried to hide in something to lose us
 			var/atom/A = target.loc
 			if(canmove && space_check())
 				Goto(A,move_to_delay,minimum_distance)
@@ -352,7 +352,7 @@
 	return 1
 
 /mob/living/simple_animal/hostile/proc/DestroySurroundings()
-	if(environment_smash)
+	if(environment_smash_flags & SMASH_LIGHT_STRUCTURES)
 		EscapeConfinement()
 		var/list/smash_dirs = list(0)
 		if(!target || !CanAttack(target))

--- a/code/modules/mob/living/simple_animal/hostile/human/nazi.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/nazi.dm
@@ -36,7 +36,7 @@
 	projectilesound = 'sound/weapons/Gunshot.ogg'
 	casingtype = /obj/item/ammo_casing/c9mm
 
-	environment_smash = 0
+	environment_smash_flags = 0
 
 	var/ammo = 8
 	var/reloads = 1
@@ -332,7 +332,7 @@
 	casingtype = null
 	ranged_cooldown_cap = 1
 
-	environment_smash = 3
+	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | SMASH_WALLS | SMASH_RWALLS
 
 	min_oxy = 0
 	max_oxy = 0

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -10,7 +10,7 @@
 	max_n2 = 0
 	unsuitable_atoms_damage = 15
 	faction = "mining"
-	environment_smash = 2
+	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | SMASH_WALLS
 	minbodytemp = 0
 	heat_damage_per_tick = 20
 	response_help = "pokes"
@@ -249,7 +249,7 @@ obj/item/asteroid/basilisk_hide/New()
 	throw_message = "falls right through the strange body of the"
 	ranged_cooldown = 0
 	ranged_cooldown_cap = 0
-	environment_smash = 0
+	environment_smash_flags = 0
 	retreat_distance = 3
 	minimum_distance = 3
 	pass_flags = PASSTABLE
@@ -399,7 +399,7 @@ obj/item/asteroid/basilisk_hide/New()
 	melee_damage_upper = 2
 	attacktext = "slashes"
 	throw_message = "falls right through the strange body of the"
-	environment_smash = 0
+	environment_smash_flags = 0
 	pass_flags = PASSTABLE
 
 /mob/living/simple_animal/hostile/asteroid/hivelordbrood/New()

--- a/code/modules/mob/living/simple_animal/hostile/mushroom.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mushroom.dm
@@ -21,7 +21,7 @@
 	attack_same = 2
 	attacktext = "chomps"
 	faction = "mushroom"
-	environment_smash = 0
+	environment_smash_flags = 0
 	stat_attack = 2
 	speed = 2
 	var/powerlevel = 0 //Tracks our general strength level gained from eating other shrooms

--- a/code/modules/mob/living/simple_animal/hostile/necro.dm
+++ b/code/modules/mob/living/simple_animal/hostile/necro.dm
@@ -65,7 +65,7 @@
 	max_n2 = 0
 	minbodytemp = 0
 
-	environment_smash = 1
+	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS
 	meat_type = null
 /*
 #define EVOLVING 1
@@ -115,7 +115,7 @@
 	max_n2 = 0
 	minbodytemp = 0
 
-	environment_smash = 1
+	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS
 
 	var/times_revived //Tracks how many times the zombie has regenerated from death
 	var/times_eaten //Tracks how many times the zombie has chewed on a human corpse

--- a/code/modules/mob/living/simple_animal/hostile/necromorph.dm
+++ b/code/modules/mob/living/simple_animal/hostile/necromorph.dm
@@ -93,7 +93,7 @@
 					else
 						if(prob(30))
 							step_towards(src, vent)//Step towards it
-							if(environment_smash)
+							if(environment_smash_flags & SMASH_LIGHT_STRUCTURES)
 								EscapeConfinement()
 						break
 

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/cluwne.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/cluwne.dm
@@ -329,6 +329,7 @@
 	maxHealth = 100
 	health = 100
 	size = 1
+	environment_smash_flags = SMASH_LIGHT_STRUCTURES
 
 	speed = 1
 	turns_per_move = 1

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/cockatrice.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/cockatrice.dm
@@ -31,7 +31,7 @@
 	attack_sound = 'sound/weapons/bite.ogg'
 	move_to_delay = 3
 
-	environment_smash = 0
+	environment_smash_flags = 0
 
 	species_type = /mob/living/simple_animal/hostile/retaliate/cockatrice
 	childtype = /mob/living/simple_animal/hostile/retaliate/cockatrice/chick

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
@@ -22,7 +22,7 @@
 	speed = 9
 	projectiletype = /obj/item/projectile/beam/drone
 	projectilesound = 'sound/weapons/laser3.ogg'
-	environment_smash = 2
+	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | SMASH_WALLS
 	minimum_distance = 3
 	retreat_distance = 2
 	can_butcher = 0

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -67,7 +67,8 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 	var/attacktext = "attacks"
 	var/attack_sound = null
 	var/friendly = "nuzzles" //If the mob does no damage with it's attack
-	var/environment_smash = 0 //Set to 1 to allow breaking of crates,lockers,racks,tables; 2 for walls; 3 for Rwalls
+//	var/environment_smash = 0 //Set to 1 to allow breaking of crates,lockers,racks,tables; 2 for walls; 3 for Rwalls
+	var/environment_smash_flags = 0
 
 	var/speed = 1 //Higher speed is slower, decimal speed is faster. DO NOT SET THIS TO NEGATIVES OR 0. MAKING THIS SMALLER THAN 1 MAKES YOUR MOB SUPER FUCKING FAST BE WARNED.
 

--- a/code/modules/mob/living/simple_animal/vox.dm
+++ b/code/modules/mob/living/simple_animal/vox.dm
@@ -14,7 +14,7 @@
 	melee_damage_upper = 40
 	attacktext = "slammed its enormous claws into"
 	speed = 1
-	environment_smash = 2 // WALLS
+	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | SMASH_WALLS // WALLS
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	status_flags = 0
 

--- a/code/modules/mob/living/simple_animal/worm.dm
+++ b/code/modules/mob/living/simple_animal/worm.dm
@@ -30,7 +30,7 @@
 
 	a_intent = I_HURT //so they don't get pushed around
 
-	environment_smash = 2
+	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | SMASH_WALLS
 
 	speed = 1
 

--- a/code/modules/virus2/effect/effect.dm
+++ b/code/modules/virus2/effect/effect.dm
@@ -1483,7 +1483,7 @@ datum/disease2/effect/lubefoot/deactivate(var/mob/living/carbon/mob)
 			var/mob/living/simple_animal/hostile/heart_attack = new(pick(spawn_turfs))
 			heart_attack.appearance = blown_heart.appearance
 			heart_attack.icon_dead = "heart-off"
-			heart_attack.environment_smash = 0
+			heart_attack.environment_smash_flags = 0
 			heart_attack.melee_damage_lower = 15
 			heart_attack.melee_damage_upper = 15
 			heart_attack.health = 50

--- a/maps/randomvaults/objects.dm
+++ b/maps/randomvaults/objects.dm
@@ -543,7 +543,7 @@
 	update_icon()
 
 /mob/living/simple_animal/hostile/retaliate/malf_drone/vault
-	environment_smash = 1
+	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS
 	speak_chance = 1
 
 /obj/machinery/atmospherics/unary/vent/visible

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -31,6 +31,7 @@
 #include "__DEFINES\research_levels.dm"
 #include "__DEFINES\security.dm"
 #include "__DEFINES\setup.dm"
+#include "__DEFINES\simple_animal_defines.dm"
 #include "__DEFINES\striketeam_defines.dm"
 #include "__DEFINES\stylesheet.dm"
 #include "__DEFINES\subsystem.dm"


### PR DESCRIPTION
Environment destruction is now governed by flags rather than an integer.
Goats and clown goblins can no longer destroy closets and crates, though they remain able to destroy racks and tables.
Fixes #10825