### PR TITLE
Morphing Mask Fixes

### DIFF
--- a/code/modules/clothing/masks/transmog.dm
+++ b/code/modules/clothing/masks/transmog.dm
@@ -107,7 +107,7 @@
 /obj/item/clothing/mask/morphing/xeno
 	name = "mask of the xenomorph"
 	desc = "It appears to be modeled after a xenomorph."
-	target_type = /mob/living/carbon/alien/humanoid
+	target_type = /mob/living/carbon/alien/humanoid/hunter
 	icon_state = "xeno_mask"
 
 /obj/item/clothing/mask/morphing/human
@@ -125,7 +125,7 @@
 	..()
 	color = rgb(rand(0,255),rand(0,255),rand(0,255))
 	//Remove cockatrices because they're somewhat OP when player controlled
-	target_type = pick(existing_typesof(/mob/living/simple_animal) - existing_typesof(/mob/living/simple_animal/hostile/humanoid) - typesof(/mob/living/simple_animal/hostile/retaliate/cockatrice))
+	target_type = pick(existing_typesof(/mob/living/simple_animal) - existing_typesof(/mob/living/simple_animal/hostile/humanoid) - typesof(/mob/living/simple_animal/hostile/retaliate/cockatrice) - typesof(/mob/living/simple_animal/hostile/giant_spider/hunter/dead) - typesof(/mob/living/simple_animal/hostile/asteroid/hivelordbrood))
 
 /obj/item/clothing/mask/morphing/ghost
 	name = "mask of the phantom"

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/nurse.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/nurse.dm
@@ -25,7 +25,7 @@
 			stop_automated_movement = 0
 
 /mob/living/simple_animal/hostile/giant_spider/nurse/proc/check_evolve()
-	if(spider_queens.len < MAX_SQUEENS)
+	if(spider_queens.len < MAX_SQUEENS && !key)	//don't evolve if there's a player inside
 		var/mob/living/simple_animal/hostile/giant_spider/nurse/queen_spider/NQ = new(src.loc)
 		NQ.inherit_mind(src)
 		qdel(src)


### PR DESCRIPTION
Xeno masks no longer turn the wearer into an invisible xeno. They now transform the wearer into a xenomorph hunter.
Nurse spiders with players in them will no longer turn into queens.
Hivelord broods and dead spiders are no longer valid amorphous mask choices.
Fixes #15296
Closes #15928