### PR TITLE
Ejecting from a mech puts you in front of the mech rather than under it, to prevent exploits

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -104,7 +104,7 @@
 	return
 
 /obj/mecha/Destroy()
-	src.go_out()
+	src.go_out(loc, TRUE)
 	mechas_list -= src //global mech list
 	..()
 	return
@@ -623,7 +623,7 @@
 
 /obj/mecha/proc/destroy()
 	spawn()
-		go_out()
+		go_out(loc, TRUE)
 		var/turf/T = get_turf(src)
 		tag = "\ref[src]" //better safe then sorry
 		if(loc)
@@ -1270,11 +1270,11 @@
 			O.forceMove(src.loc)
 	return
 
-/obj/mecha/proc/go_out(var/exit = loc)
+/obj/mecha/proc/go_out(var/exit = loc, var/exploding = FALSE)
 	if(!src.occupant)
 		return
 
-	if(exit == loc) //We don't actually want to eject our occupant on the same tile that we are, that puts them "under" us, which lets them use the mech like a personal forcefield they can shoot out of.
+	if(!exploding && exit == loc) //We don't actually want to eject our occupant on the same tile that we are, that puts them "under" us, which lets them use the mech like a personal forcefield they can shoot out of.
 		var/list/turf_candidates = list(get_step(loc, dir)) + trange(1, loc) //Evaluate all 9 turfs around us, but put "directly in front of us" as the first choice.
 		for(var/turf/simulated/T in turf_candidates)
 			if(!is_blocked_turf(T) && Adjacent(T))

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1273,6 +1273,14 @@
 /obj/mecha/proc/go_out(var/exit = loc)
 	if(!src.occupant)
 		return
+
+	if(exit == loc) //We don't actually want to eject our occupant on the same tile that we are, that puts them "under" us, which lets them use the mech like a personal forcefield they can shoot out of.
+		var/list/turf_candidates = list(get_step(loc, dir)) + trange(1, loc) //Evaluate all 9 turfs around us, but put "directly in front of us" as the first choice.
+		for(var/turf/simulated/T in turf_candidates)
+			if(!is_blocked_turf(T) && Adjacent(T))
+				exit = T
+				break
+
 	var/atom/movable/mob_container
 	if(ishuman(occupant))
 		mob_container = src.occupant

--- a/code/game/mecha/mecha_wreckage.dm
+++ b/code/game/mecha/mecha_wreckage.dm
@@ -14,6 +14,13 @@
 	var/list/wirecutters_salvage = list(/obj/item/stack/cable_coil)
 	var/list/crowbar_salvage
 
+/obj/effect/decal/mecha_wreckage/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+	if(air_group)
+		return 1
+	if(istype(mover) && mover.checkpass(PASSTABLE))
+		return 1
+	return ..()
+
 /obj/effect/decal/mecha_wreckage/New()
 	..()
 	crowbar_salvage = new


### PR DESCRIPTION
This is so that people can't turn the mech into a "forcefield" that they can shoot out of, kind of like jaunting on top of a wall.

I think the same logic should be applied when jaunting directly on top of a wall, I'll probably do that if this goes.

"Nearby tile" means: Directly in front if available, go clockwise in surrounding 3*3 if directly in front is blocked, can't go through windows etc. You can still choose which tile you want to eject to it just picks one for you if you deliberately clickdrag to the same tile as the mech.