### PR TITLE
Pintpointer Tweak

### DIFF
--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -11,6 +11,7 @@ var/const/INGEST = 2
 	var/total_volume = 0
 	var/maximum_volume = 100
 	var/atom/my_atom = null
+	var/last_ckey_transferred_to_this = ""	//The ckey of the last player who transferred reagents into this reagent datum.
 
 /datum/reagents/New(maximum=100)
 	maximum_volume = maximum
@@ -150,6 +151,8 @@ var/const/INGEST = 2
 	//R.update_total()
 	R.handle_reactions()
 	src.handle_reactions()
+	if(whodunnit)
+		R.last_ckey_transferred_to_this = key_name(whodunnit, include_name = FALSE)
 
 	if(log_transfer && logged_message.len)
 		var/turf/T = get_turf(my_atom)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -5365,7 +5365,7 @@
 /datum/reagent/ethanol/deadrumm/pintpointer
 	name = "Pintpointer"
 	id = PINTPOINTER
-	description = "An attempt to create a navigation system which even a drunk spaceman can use."
+	description = "A little help finding the bartender."
 	reagent_state = LIQUID
 	color = "#664300" //rgb: 102, 67, 0
 

--- a/code/modules/reagents/reagent_containers/food/drinks/drinkingglass.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/drinkingglass.dm
@@ -549,10 +549,12 @@
 					desc = "A questionable concoction of objects found within maintenance. Tastes just like you'd expect."
 				if(PINTPOINTER)
 					var/obj/item/weapon/reagent_containers/food/drinks/drinkingglass/pintpointer/P = new (get_turf(src))
+					if(reagents.last_ckey_transferred_to_this)
+						for(var/client/C in clients)
+							if(C.ckey == reagents.last_ckey_transferred_to_this)
+								var/mob/M = C.mob
+								P.creator = M
 					reagents.trans_to(P, reagents.total_volume)
-					var/mob/M = get_holder_at_turf_level(src)
-					if(istype(M))
-						P.creator = M
 					spawn(1)
 						qdel(src)
 				else

--- a/code/modules/reagents/reagent_containers/food/drinks/pintpointer.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/pintpointer.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/reagent_containers/food/drinks/drinkingglass/pintpointer
 	name = "\improper Pintpointer"
-	desc = "A little help finding the bartender."
+	desc = "An attempt to create a navigation system which even a drunk spaceman can use."
 	icon_state = "pintdist5"
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/items_lefthand.dmi', "right_hand" = 'icons/mob/in-hand/right/items_righthand.dmi')
 	item_state = "electronic"


### PR DESCRIPTION
The pintpointer's tracking function is now based on who pours the drink, not who is holding the glass into which the drink is poured.
What this means is that if you pour it into a glass that is sitting on the ground, for example, it will still track you.

Also switches the descriptions of the reagent and the item due to it being pointed out that the reagent's description was better.

:cl:
 * tweak: The pintpointer's tracking function is now based on who pours the drink, not who is holding the glass into which the drink is poured. This means that, for example, if you pour pintpointer into a glass that is sitting on the ground, that new pintpointer will still track you. Also, as a reminder, the distance to the target is indicated by how full the mug on the pintpointer's screen is, if it has a target.
