### PR TITLE
R-UST Tokamak can be (de)constructed

### DIFF
--- a/code/WorkInProgress/Cael_Aislinn/Rust/circuits.dm
+++ b/code/WorkInProgress/Cael_Aislinn/Rust/circuits.dm
@@ -56,8 +56,7 @@
 							"/obj/item/weapon/stock_parts/manipulator/nano/pico" = 2,
 							"/obj/item/weapon/stock_parts/micro_laser/high/ultra" = 1,
 							"/obj/item/weapon/stock_parts/subspace/crystal" = 1,
-							"/obj/item/weapon/stock_parts/console_screen" = 1,
-							"/obj/item/stack/cable_coil" = 5)
+							"/obj/item/weapon/stock_parts/console_screen" = 1)
 
 //////////////////////////////////////
 // RUST Fuel Injector board

--- a/code/WorkInProgress/Cael_Aislinn/Rust/core_gen.dm
+++ b/code/WorkInProgress/Cael_Aislinn/Rust/core_gen.dm
@@ -65,11 +65,20 @@ max volume of plasma storeable by the field = the total volume of a number of ti
 	idle_power_usage = 50
 	active_power_usage = 500	//multiplied by field strength
 	anchored = 0
-
-	machine_flags = WRENCHMOVE | FIXED2WORK | WELD_FIXED | EMAGGABLE | MULTITOOL_MENU
+	machine_flags = SCREWTOGGLE | CROWDESTROY | WRENCHMOVE | FIXED2WORK | WELD_FIXED | MULTITOOL_MENU
 
 /obj/machinery/power/rust_core/New()
 	. = ..()
+
+	component_parts = newlist(
+		/obj/item/weapon/circuitboard/rust_core,
+		/obj/item/weapon/stock_parts/manipulator/nano/pico,
+		/obj/item/weapon/stock_parts/manipulator/nano/pico,
+		/obj/item/weapon/stock_parts/micro_laser/high/ultra,
+		/obj/item/weapon/stock_parts/subspace/crystal,
+		/obj/item/weapon/stock_parts/console_screen
+	)
+
 	if(ticker)
 		initialize()
 
@@ -84,7 +93,7 @@ max volume of plasma storeable by the field = the total volume of a number of ti
 
 /obj/machinery/power/rust_core/weldToFloor(var/obj/item/weapon/weldingtool/WT, mob/user)
 	if(owned_field)
-		to_chat(user, user << "<span class='warning'>Turn \the [src] off first!</span>")
+		to_chat(user, "<span class='warning'>Turn \the [src] off first!</span>")
 		return -1
 
 	if(..() == 1)

--- a/code/modules/research/designs/boards/machine_engie.dm
+++ b/code/modules/research/designs/boards/machine_engie.dm
@@ -216,8 +216,8 @@
 /datum/design/rust_core
 	name = "Internal circuitry (R-UST Mk. 7 tokamak core)"
 	desc = "The circuit board that for a RUST-pattern tokamak fusion core."
-	id = "pacman"
-	req_tech = list(bluespace = 3, plasmatech = 4, magnets = 5, powerstorage = 6)
+	id = "rust_core"
+	req_tech = list(Tc_BLUESPACE = 3, Tc_PLASMATECH = 4, Tc_MAGNETS = 5, Tc_POWERSTORAGE = 6)
 	build_type = IMPRINTER
 	reliability_base = 79
 	materials = list(MAT_GLASS = 2000, SACID = 20, MAT_PLASMA = 3000, MAT_DIAMOND = 2000)


### PR DESCRIPTION
Something something #16190

:cl:
 * tweak: The R-UST tokamak no longer requires cable coils to be constructed. It can now also be deconstructed. Its circuit board is available at the circuit imprinter.
