### PR TITLE
Changelog PR

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
 This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.
 
-Test your changes.  PRs that do not compile will not be accepted.
+Test your changes. PRs that do not compile will not be accepted.
 Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.
 
 Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.


### PR DESCRIPTION
removed a space in the text, needed a file change to create a PR in order to update the change log for a past PR of mine that was merged (forgot to do this on the initial PR, oops)

:cl:
 * rscadd: Added camera bugs and handheld tv to the item list for the detective's secure closet
 * rscdel: Removed the camera bugs and handheld tv that were mapped into bagelstation to prevent duplication of these items.

