### PR TITLE
Removing conductivity from some tiles & sheet

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -92,6 +92,8 @@
 	autoignition_temperature=AUTOIGNITION_WOOD
 	sheettype = "wood"
 	w_type = RECYK_WOOD
+	siemens_coefficient = 0 //no conduct
+
 
 /obj/item/stack/sheet/wood/afterattack(atom/Target, mob/user, adjacent, params)
 	..()

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -49,7 +49,7 @@
 	throw_speed = 5
 	throw_range = 20
 	flags = FPRINT
-	siemens_coefficient = 1
+	siemens_coefficient = 0 //no conduct
 	max_amount = 60
 	origin_tech = Tc_BIOTECH + "=1"
 
@@ -69,7 +69,7 @@
 	throw_speed = 5
 	throw_range = 20
 	flags = FPRINT
-	siemens_coefficient = 1
+	siemens_coefficient = 0 //no conduct
 	max_amount = 60
 
 	material = "wood"
@@ -123,7 +123,7 @@
 	throw_speed = 5
 	throw_range = 20
 	flags = FPRINT
-	siemens_coefficient = 1
+	siemens_coefficient = 0 //no conduct
 	max_amount = 60
 
 	material = "fabric"
@@ -139,7 +139,7 @@
 	throw_speed = 5
 	throw_range = 20
 	flags = FPRINT
-	siemens_coefficient = 1
+	siemens_coefficient = 0 //no conduct
 	max_amount = 60
 
 	material = "fabric"


### PR DESCRIPTION
Suspension of disbelief fix

So you won't get shocked to death anymore when accidentally touching a wire while placing wooden floor.

:cl:
* tweak: Sheets of wood, wooden floor tiles, grass tiles, carpets and arcade carpets, are no longer conductive.