### PR TITLE
Remove crossbow frame recipe

### DIFF
--- a/code/game/objects/items/stacks/stack_recipes.dm
+++ b/code/game/objects/items/stacks/stack_recipes.dm
@@ -222,7 +222,6 @@ var/list/datum/stack_recipe/wood_recipes = list (
 	new/datum/stack_recipe("boomerang",			/obj/item/weapon/boomerang,				6,		time = 50),
 	new/datum/stack_recipe("buckler",			/obj/item/weapon/shield/riot/buckler,	5,		time = 50),
 	new/datum/stack_recipe("wooden paddle",		/obj/item/weapon/macuahuitl,			1,		time = 50),
-	new/datum/stack_recipe("crossbow frame",	/obj/item/crossbowframe,				5,		time = 50),
 	new/datum/stack_recipe("peg limb",			/obj/item/weapon/peglimb,				2,		time = 50)
 	)
 


### PR DESCRIPTION
Assistants having any number of infinite ammo 1-shot-kill weapons in 5 minutes was a mistake.

:cl:
 * rscdel: Removed the ability to craft crossbows. 