### PR TITLE
can no longer create multiple mass drivers on the same tile.

### DIFF
--- a/code/game/machinery/mass_driver.dm
+++ b/code/game/machinery/mass_driver.dm
@@ -122,14 +122,12 @@ var/list/mass_drivers = list()
 
 /obj/machinery/mass_driver_frame/proc/check_competition(var/turf/T = get_turf(src))
 	var/competition_found = 0
-	for(var/obj/machinery/mass_driver_frame/M in T)
+	for(var/obj/machinery/M in T)
 		if(M == src)
 			continue
-		competition_found=1
-		break
-	if(!competition_found)
-		for(var/obj/machinery/mass_driver/M in T)
+		if(istype(M, /obj/machinery/mass_driver_frame) || istype(M, /obj/machinery/mass_driver))
 			competition_found=1
+			break
 
 	return competition_found
 

--- a/code/game/machinery/mass_driver.dm
+++ b/code/game/machinery/mass_driver.dm
@@ -18,6 +18,16 @@ var/list/mass_drivers = list()
 /obj/machinery/mass_driver/New()
 	..()
 	mass_drivers += src
+	check_competition()
+
+/obj/machinery/mass_driver/proc/check_competition(var/turf/T = get_turf(src))
+	for(var/obj/machinery/mass_driver/M in T)
+		if(M == src)
+			continue
+		else
+			message_admins("Two mass drivers were placed on the same tile. This should not happen.(<A href='?_src_=holder;jumpto=\ref[T]'><b>Jump to</b></A>)")
+			qdel(src)
+			break
 
 /obj/machinery/mass_driver/Destroy()
 	mass_drivers -= src
@@ -110,6 +120,19 @@ var/list/mass_drivers = list()
 	anchored = 0
 	var/build = 0
 
+/obj/machinery/mass_driver_frame/proc/check_competition(var/turf/T = get_turf(src))
+	var/competition_found = 0
+	for(var/obj/machinery/mass_driver_frame/M in T)
+		if(M == src)
+			continue
+		competition_found=1
+		break
+	if(!competition_found)
+		for(var/obj/machinery/mass_driver/M in T)
+			competition_found=1
+
+	return competition_found
+
 /obj/machinery/mass_driver_frame/attackby(var/obj/item/W as obj, var/mob/user as mob)
 	switch(build)
 		if(0) // Loose frame
@@ -126,6 +149,9 @@ var/list/mass_drivers = list()
 					qdel(src)
 				return 1
 			if(iswrench(W))
+				if(check_competition())
+					to_chat(user, "<span class = 'notice'>You can't anchor \the [src], as there's a mass driver in that location already.</span>")
+					return
 				to_chat(user, "You begin to anchor \the [src] on the floor.")
 				playsound(get_turf(src), 'sound/items/Ratchet.ogg', 50, 1)
 				if(do_after(user, src, 10) && (build == 0))


### PR DESCRIPTION
Should technically 'close' #13350 but it does so by making sure you can't stack mass drivers, does nothing to sort the lag that would be caused by multiple mass drivers trying to throw things so only quoting, unless somebody reckons it addresses the problem entirely.

:cl:
* rscdel: Can no longer stack mass drivers on a tile