### PR TITLE
Can extinguish people with clothes on help intent

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -13,6 +13,7 @@
 	var/list/obj/item/clothing/accessory/accessories = list()
 	var/goliath_reinforce = FALSE
 	var/extinguishingProb = 15
+	var/can_extinguish = FALSE
 
 /obj/item/clothing/Destroy()
 	for(var/obj/item/clothing/accessory/A in accessories)
@@ -221,7 +222,7 @@
 /obj/item/clothing/attack(var/mob/living/M, var/mob/living/user, def_zone, var/originator = null)
 	if (!(iscarbon(user)  \
 	&& user.a_intent == I_HELP \
-	&& (istype(src, /obj/item/clothing/under) || (istype(src, /obj/item/clothing/suit) && !istype(src, /obj/item/clothing/suit/space))) \
+	&& can_extinguish \
 	&& ishuman(M) && M.on_fire))
 		..()
 	else
@@ -469,6 +470,7 @@ BLIND     // can't see anything
 	var/blood_overlay_type = "suit"
 	species_restricted = list("exclude","Muton")
 	siemens_coefficient = 0.9
+	can_extinguish = TRUE
 
 //Spacesuit
 //Note: Everything in modules/clothing/spacesuits should have the entire suit grouped together.
@@ -506,6 +508,7 @@ BLIND     // can't see anything
 	siemens_coefficient = 0.9
 	species_restricted = list("exclude","Diona","Muton")
 	heat_conductivity = SPACESUIT_HEAT_CONDUCTIVITY
+	can_extinguish = FALSE
 
 //Under clothing
 /obj/item/clothing/under
@@ -526,6 +529,7 @@ BLIND     // can't see anything
 		3 = Report location
 		*/
 	var/displays_id = 1
+	can_extinguish = TRUE
 
 /obj/item/clothing/under/Destroy()
 	for(var/obj/machinery/computer/crew/C in machines)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -219,19 +219,21 @@
 			armor[A] -= rand(armor[A]/3, armor[A])
 
 /obj/item/clothing/attack(var/mob/living/M, var/mob/living/user, def_zone, var/originator = null)
-	if(iscarbon(user))
-		if(user.a_intent == I_HELP && (istype(src, /obj/item/clothing/under) || (istype(src, /obj/item/clothing/suit) && !istype(src, /obj/item/clothing/suit/space))))
-			if(ishuman(M) && M.on_fire)
-				var/mob/living/carbon/human/target = M
-				if(isplasmaman(target)) // Cannot put out plasmamen, else they could just go around with a jumpsuit and not need a space suit.
-					visible_message("<span class='warning'>\The [user] attempts to put out the fire on \the [target], but plasmafires are too hot. It is no use.</span>")
-				else
-					visible_message("<span class='warning'>\The [user] attempts to put out the fire on \the [target] with \the [src].</span>")
-					if(prob(extinguishingProb))
-						M.ExtinguishMob()
-						visible_message("<span class='notice'>\The [user] puts out the fire on \the [target].</span>")
-				return
-	..()
+	if (!(iscarbon(user)  \
+	&& user.a_intent == I_HELP \
+	&& (istype(src, /obj/item/clothing/under) || (istype(src, /obj/item/clothing/suit) && !istype(src, /obj/item/clothing/suit/space))) \
+	&& ishuman(M) && M.on_fire))
+		..()
+	else
+		var/mob/living/carbon/human/target = M
+		if(isplasmaman(target)) // Cannot put out plasmamen, else they could just go around with a jumpsuit and not need a space suit.
+			visible_message("<span class='warning'>\The [user] attempts to put out the fire on \the [target], but plasmafires are too hot. It is no use.</span>")
+		else
+			visible_message("<span class='warning'>\The [user] attempts to put out the fire on \the [target] with \the [src].</span>")
+			if(prob(extinguishingProb))
+				M.ExtinguishMob()
+				visible_message("<span class='notice'>\The [user] puts out the fire on \the [target].</span>")
+		return
 
 //Ears: headsets, earmuffs and tiny objects
 /obj/item/clothing/ears

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -12,6 +12,7 @@
 
 	var/list/obj/item/clothing/accessory/accessories = list()
 	var/goliath_reinforce = FALSE
+	var/extinguishingProb = 15
 
 /obj/item/clothing/Destroy()
 	for(var/obj/item/clothing/accessory/A in accessories)
@@ -217,7 +218,7 @@
 		for(var/A in armor)
 			armor[A] -= rand(armor[A]/3, armor[A])
 
-/obj/item/clothing/attack(mob/living/M, mob/living/user, def_zone, var/originator = null)
+/obj/item/clothing/attack(var/mob/living/M, var/mob/living/user, def_zone, var/originator = null)
 	if(iscarbon(user))
 		if(user.a_intent == I_HELP)
 			if(istype(src, /obj/item/clothing/under) || (istype(src, /obj/item/clothing/suit) && !istype(src, /obj/item/clothing/suit/space)))
@@ -228,11 +229,12 @@
 						return
 					else
 						visible_message("<span class='warning'>\The [user] attempts to put out the fire on \the [target] with \the [src].</span>")
-						if(prob(15) || (istype(src, /obj/item/clothing/suit/spaceblanket) && prob(70))) // Blankets are better at putting out fire
+						if(prob(extinguishingProb))
 							M.ExtinguishMob()
 							visible_message("<span class='notice'>\The [user] puts out the fire on \the [target].</span>")
 						return
 	..()
+	return
 
 //Ears: headsets, earmuffs and tiny objects
 /obj/item/clothing/ears

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -230,8 +230,8 @@
 						visible_message("<span class='warning'>\The [user] attempts to put out the fire on \the [target], but plasmafires are too hot. It is no use.</span>")
 						return
 					else
-						visible_message("<span class='warning'>\The [user] attempts to put out the fire on \the [target].</span>")
-						if(prob(15))
+						visible_message("<span class='warning'>\The [user] attempts to put out the fire on \the [target] with \the [src].</span>")
+						if(prob(15) || (istype(src, /obj/item/clothing/suit/spaceblanket) && prob(70)))
 							M.ExtinguishMob()
 							visible_message("<span class='notice'>\The [user] have put out the fire on \the [target].</span>")
 						return

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -220,18 +220,17 @@
 
 /obj/item/clothing/attack(var/mob/living/M, var/mob/living/user, def_zone, var/originator = null)
 	if(iscarbon(user))
-		if(user.a_intent == I_HELP)
-			if(istype(src, /obj/item/clothing/under) || (istype(src, /obj/item/clothing/suit) && !istype(src, /obj/item/clothing/suit/space)))
-				if(ishuman(M) && M.on_fire)
-					var/mob/living/carbon/human/target = M
-					if(isplasmaman(target)) // Cannot put out plasmamen, else they could just go around with a jumpsuit and not need a space suit.
-						visible_message("<span class='warning'>\The [user] attempts to put out the fire on \the [target], but plasmafires are too hot. It is no use.</span>")
-					else
-						visible_message("<span class='warning'>\The [user] attempts to put out the fire on \the [target] with \the [src].</span>")
-						if(prob(extinguishingProb))
-							M.ExtinguishMob()
-							visible_message("<span class='notice'>\The [user] puts out the fire on \the [target].</span>")
-					return
+		if(user.a_intent == I_HELP && (istype(src, /obj/item/clothing/under) || (istype(src, /obj/item/clothing/suit) && !istype(src, /obj/item/clothing/suit/space))))
+			if(ishuman(M) && M.on_fire)
+				var/mob/living/carbon/human/target = M
+				if(isplasmaman(target)) // Cannot put out plasmamen, else they could just go around with a jumpsuit and not need a space suit.
+					visible_message("<span class='warning'>\The [user] attempts to put out the fire on \the [target], but plasmafires are too hot. It is no use.</span>")
+				else
+					visible_message("<span class='warning'>\The [user] attempts to put out the fire on \the [target] with \the [src].</span>")
+					if(prob(extinguishingProb))
+						M.ExtinguishMob()
+						visible_message("<span class='notice'>\The [user] puts out the fire on \the [target].</span>")
+				return
 	..()
 
 //Ears: headsets, earmuffs and tiny objects

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -217,6 +217,41 @@
 		for(var/A in armor)
 			armor[A] -= rand(armor[A]/3, armor[A])
 
+// Redefines the attack proc so that when we attack somebody on fire on help intent with a piece of clothing, we have a small chance of putting out the fire.
+/obj/item/clothing/attack(mob/living/M as mob, mob/living/user as mob, def_zone, var/originator = null)
+	if(iscarbon(user)) // First, we check if it's a a carbon.
+		if(user.a_intent == I_HELP) // Then we check if he wants to help.
+			if(istype(src, /obj/item/clothing/under) || (istype(src, /obj/item/clothing/suit) && !istype(src, /obj/item/clothing/suit/space))) // Then we check if the item is either a jumpsuit or suit-but-not-a-spacesut
+				if(ishuman(M) && M.on_fire) // If he is on fire
+					/var/mob/living/carbon/human/target = new/mob/living/carbon/human()
+					target = M
+					// Good old polymorphism. We are allowed to do that because we checked if M was a human before.
+					// This allows us to check for their species
+					if(isplasmaman(target)) // Cannot put out plasmamen, else they could just go arround with a jumpsuit and not need a space suit.
+						for(var/mob/spectator in view())
+							to_chat(spectator, "<span class='warning'>\the [user] attempts to put out the fire on \the [target], but plasmafires are too hot. It is no use.</span>")
+						return
+					else
+						for(var/mob/spectator in view())
+							to_chat(spectator, "<span class='warning'>\the [user] attempts to put out the fire on \the [target].</span>")
+						if(prob(15))
+							M.ExtinguishMob()
+							for(var/mob/spectator in view())
+								to_chat(spectator, "<span class='notice'>\the [user] have put out the fire on \the [target].</span>")
+						return
+				else
+					..()
+					return
+			else
+				..()
+				return
+		else
+			..()
+			return
+	else
+		..()
+		return
+
 //Ears: headsets, earmuffs and tiny objects
 /obj/item/clothing/ears
 	name = "ears"

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -226,15 +226,13 @@
 					var/mob/living/carbon/human/target = M
 					if(isplasmaman(target)) // Cannot put out plasmamen, else they could just go around with a jumpsuit and not need a space suit.
 						visible_message("<span class='warning'>\The [user] attempts to put out the fire on \the [target], but plasmafires are too hot. It is no use.</span>")
-						return
 					else
 						visible_message("<span class='warning'>\The [user] attempts to put out the fire on \the [target] with \the [src].</span>")
 						if(prob(extinguishingProb))
 							M.ExtinguishMob()
 							visible_message("<span class='notice'>\The [user] puts out the fire on \the [target].</span>")
-						return
+					return
 	..()
-	return
 
 //Ears: headsets, earmuffs and tiny objects
 /obj/item/clothing/ears

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -218,7 +218,7 @@
 			armor[A] -= rand(armor[A]/3, armor[A])
 
 // Redefines the attack proc so that when we attack somebody on fire on help intent with a piece of clothing, we have a small chance of putting out the fire.
-/obj/item/clothing/attack(mob/living/M as mob, mob/living/user as mob, def_zone, var/originator = null)
+/obj/item/clothing/attack(mob/living/M, mob/living/user, def_zone, var/originator = null)
 	if(iscarbon(user)) // First, we check if it's a a carbon.
 		if(user.a_intent == I_HELP) // Then we check if he wants to help.
 			if(istype(src, /obj/item/clothing/under) || (istype(src, /obj/item/clothing/suit) && !istype(src, /obj/item/clothing/suit/space))) // Then we check if the item is either a jumpsuit or suit-but-not-a-spacesut
@@ -622,3 +622,4 @@ BLIND     // can't see anything
 	w_class = W_CLASS_SMALL
 	throwforce = 2
 	slot_flags = SLOT_BACK
+

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -624,3 +624,4 @@ BLIND     // can't see anything
 	throwforce = 2
 	slot_flags = SLOT_BACK
 
+

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -233,7 +233,7 @@
 						visible_message("<span class='warning'>\The [user] attempts to put out the fire on \the [target] with \the [src].</span>")
 						if(prob(15) || (istype(src, /obj/item/clothing/suit/spaceblanket) && prob(70)))
 							M.ExtinguishMob()
-							visible_message("<span class='notice'>\The [user] have put out the fire on \the [target].</span>")
+							visible_message("<span class='notice'>\The [user] has put out the fire on \the [target].</span>")
 						return
 	..()
 	return

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -223,34 +223,20 @@
 		if(user.a_intent == I_HELP) // Then we check if he wants to help.
 			if(istype(src, /obj/item/clothing/under) || (istype(src, /obj/item/clothing/suit) && !istype(src, /obj/item/clothing/suit/space))) // Then we check if the item is either a jumpsuit or suit-but-not-a-spacesut
 				if(ishuman(M) && M.on_fire) // If he is on fire
-					/var/mob/living/carbon/human/target = new/mob/living/carbon/human()
-					target = M
+					var/mob/living/carbon/human/target = M
 					// Good old polymorphism. We are allowed to do that because we checked if M was a human before.
 					// This allows us to check for their species
 					if(isplasmaman(target)) // Cannot put out plasmamen, else they could just go arround with a jumpsuit and not need a space suit.
-						for(var/mob/spectator in view())
-							to_chat(spectator, "<span class='warning'>\the [user] attempts to put out the fire on \the [target], but plasmafires are too hot. It is no use.</span>")
+						visible_message("<span class='warning'>\The [user] attempts to put out the fire on \the [target], but plasmafires are too hot. It is no use.</span>")
 						return
 					else
-						for(var/mob/spectator in view())
-							to_chat(spectator, "<span class='warning'>\the [user] attempts to put out the fire on \the [target].</span>")
+						visible_message("<span class='warning'>\The [user] attempts to put out the fire on \the [target].</span>")
 						if(prob(15))
 							M.ExtinguishMob()
-							for(var/mob/spectator in view())
-								to_chat(spectator, "<span class='notice'>\the [user] have put out the fire on \the [target].</span>")
+							visible_message("<span class='notice'>\The [user] have put out the fire on \the [target].</span>")
 						return
-				else
-					..()
-					return
-			else
-				..()
-				return
-		else
-			..()
-			return
-	else
-		..()
-		return
+	..()
+	return
 
 //Ears: headsets, earmuffs and tiny objects
 /obj/item/clothing/ears
@@ -636,5 +622,3 @@ BLIND     // can't see anything
 	w_class = W_CLASS_SMALL
 	throwforce = 2
 	slot_flags = SLOT_BACK
-
-

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -217,26 +217,22 @@
 		for(var/A in armor)
 			armor[A] -= rand(armor[A]/3, armor[A])
 
-// Redefines the attack proc so that when we attack somebody on fire on help intent with a piece of clothing, we have a small chance of putting out the fire.
 /obj/item/clothing/attack(mob/living/M, mob/living/user, def_zone, var/originator = null)
-	if(iscarbon(user)) // First, we check if it's a a carbon.
-		if(user.a_intent == I_HELP) // Then we check if he wants to help.
-			if(istype(src, /obj/item/clothing/under) || (istype(src, /obj/item/clothing/suit) && !istype(src, /obj/item/clothing/suit/space))) // Then we check if the item is either a jumpsuit or suit-but-not-a-spacesut
-				if(ishuman(M) && M.on_fire) // If he is on fire
+	if(iscarbon(user))
+		if(user.a_intent == I_HELP)
+			if(istype(src, /obj/item/clothing/under) || (istype(src, /obj/item/clothing/suit) && !istype(src, /obj/item/clothing/suit/space)))
+				if(ishuman(M) && M.on_fire)
 					var/mob/living/carbon/human/target = M
-					// Good old polymorphism. We are allowed to do that because we checked if M was a human before.
-					// This allows us to check for their species
-					if(isplasmaman(target)) // Cannot put out plasmamen, else they could just go arround with a jumpsuit and not need a space suit.
+					if(isplasmaman(target)) // Cannot put out plasmamen, else they could just go around with a jumpsuit and not need a space suit.
 						visible_message("<span class='warning'>\The [user] attempts to put out the fire on \the [target], but plasmafires are too hot. It is no use.</span>")
 						return
 					else
 						visible_message("<span class='warning'>\The [user] attempts to put out the fire on \the [target] with \the [src].</span>")
-						if(prob(15) || (istype(src, /obj/item/clothing/suit/spaceblanket) && prob(70)))
+						if(prob(15) || (istype(src, /obj/item/clothing/suit/spaceblanket) && prob(70))) // Blankets are better at putting out fire
 							M.ExtinguishMob()
-							visible_message("<span class='notice'>\The [user] has put out the fire on \the [target].</span>")
+							visible_message("<span class='notice'>\The [user] puts out the fire on \the [target].</span>")
 						return
 	..()
-	return
 
 //Ears: headsets, earmuffs and tiny objects
 /obj/item/clothing/ears

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -474,6 +474,8 @@
 	heat_conductivity = 0 // Good luck losing heat in this!
 	slowdown = HARDSUIT_SLOWDOWN_BULKY
 	var/bearpelt = 0
+	extinguishingProb = 70
+
 
 /obj/item/clothing/suit/spaceblanket/attackby(obj/item/W,mob/user)
 	..()


### PR DESCRIPTION
Closes #16224. Credits to @WhiteHusky for the idea
Tested it and it works. Should be ready for merge now, I guess.

## What it does
If you are a carbon on help intent hitting another carbon on fire, while on help intent, it has a 15% chance of putting out the fire.
Note that you can't extinguish plasmamen because otherwise they wouldn't need a spacesuit anymore.
The number is arbitrary and can be changed if needed.
Space Blankets are very effective since they were designed for that purpose.

## Issues
- ~~The code is, IMO, very ugly and could use some improvement. I am open to review~~
- ~~A little issue with Dionas when testing : they seems to extinguish themselves but their sprite is still on fire. Don't know if I can/should fix.~~ Yes, it's linked to how Dionas heal themselves. Not in the scope of this PR.
- ~~When testing I sometimes got my shoes covered in a red fluid and spraying it everywhere. I _assume_ it is welder fluid but I prefer to notify just in case.~~ It was indeed welder fluid.
- ~~There could be a small chance of destroying the item used, but it could lead to exploit (like trying to destroy the CMO's jumpsuit so that no traitor can steal it.)~~ I decided we are not going to do that.

:cl:
- rscadd: You can now extinguish people by hitting them with clothing while on help intent.