### PR TITLE
Sound added to airlock maintenance panel opening/closing.

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1036,6 +1036,7 @@ About the new airlock wires panel:
 /obj/machinery/door/airlock/togglePanelOpen(var/obj/toggleitem, mob/user)
 	if(!operating)
 		panel_open = !panel_open
+		playsound(get_turf(src), 'sound/items/Screwdriver.ogg', 100, 1)
 		update_icon()
 		return 1
 	return

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1036,7 +1036,7 @@ About the new airlock wires panel:
 /obj/machinery/door/airlock/togglePanelOpen(var/obj/toggleitem, mob/user)
 	if(!operating)
 		panel_open = !panel_open
-		playsound(get_turf(src), 'sound/items/Screwdriver.ogg', 100, 1)
+		playsound(get_turf(src), 'sound/items/Screwdriver.ogg', 50, 1)
 		update_icon()
 		return 1
 	return

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1036,7 +1036,7 @@ About the new airlock wires panel:
 /obj/machinery/door/airlock/togglePanelOpen(var/obj/toggleitem, mob/user)
 	if(!operating)
 		panel_open = !panel_open
-		playsound(get_turf(src), 'sound/items/Screwdriver.ogg', 50, 1)
+		playsound(get_turf(src), 'sound/items/Screwdriver.ogg', 25, 1, -5)
 		update_icon()
 		return 1
 	return

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1036,7 +1036,7 @@ About the new airlock wires panel:
 /obj/machinery/door/airlock/togglePanelOpen(var/obj/toggleitem, mob/user)
 	if(!operating)
 		panel_open = !panel_open
-		playsound(get_turf(src), 'sound/items/Screwdriver.ogg', 25, 1, -5)
+		playsound(get_turf(src), 'sound/items/Screwdriver.ogg', 25, 1, -6)
 		update_icon()
 		return 1
 	return


### PR DESCRIPTION
Airlocks lacked a sound for when the maintenance panel was toggled on them with a screwdriver. Not sure why this hasn't been fixed for so long.
# **The greytiders wanted it to have only one tile of range so it's one tile of range. Stop asking.**
:cl: 
 * rscadd: Airlocks now make a small screwdriver sound when you screwdriver the panel on them. 