### PR TITLE
fixes not being able to disarm mobs such as monkeys, martians, etc.

### DIFF
--- a/code/modules/mob/living/carbon/human/combat.dm
+++ b/code/modules/mob/living/carbon/human/combat.dm
@@ -26,19 +26,23 @@
 			var/turf/target = pick(turfs)
 			return G.afterattack(target, src, "struggle" = 1)
 
+	return 0
+
 /mob/living/carbon/human/disarm_mob(mob/living/target)
 	add_logs(src, target, "disarmed", admin = (src.ckey && target.ckey) ? TRUE : FALSE) //Only add this to the server logs if both mobs were controlled by player
-	var/mob/living/carbon/human/T = target
-	var/datum/organ/external/S = target.get_organ(src.zone_sel.selecting)
-	var/shushcooldown = 10 SECONDS
-	
-	if(!istype(S))
-		return
-	if(src.zone_sel.selecting == "mouth" && !(S.status & ORGAN_DESTROYED) && ishuman(target) && !(T.check_body_part_coverage(MOUTH)) && last_shush + shushcooldown <= world.time)
-		last_shush = world.time
-		T.forcesay("-")
-		visible_message("<span class='danger'>[src] places a hand over [target]'s mouth!</span>")
-		return
+
+	if(ishuman(target))
+		var/mob/living/carbon/human/T = target
+		var/datum/organ/external/S = target.get_organ(src.zone_sel.selecting)
+		var/shushcooldown = 10 SECONDS
+		if(!istype(S))
+			return
+
+		if(src.zone_sel.selecting == "mouth" && !(S.status & ORGAN_DESTROYED) && ishuman(target) && !(T.check_body_part_coverage(MOUTH)) && last_shush + shushcooldown <= world.time)
+			last_shush = world.time
+			T.forcesay("-")
+			visible_message("<span class='danger'>[src] places a hand over [target]'s mouth!</span>")
+			return
 
 	if(target.disarmed_by(src))
 		return

--- a/code/modules/mob/living/carbon/human/combat.dm
+++ b/code/modules/mob/living/carbon/human/combat.dm
@@ -26,7 +26,7 @@
 			var/turf/target = pick(turfs)
 			return G.afterattack(target, src, "struggle" = 1)
 
-	return 0
+	return FALSE
 
 /mob/living/carbon/human/disarm_mob(mob/living/target)
 	add_logs(src, target, "disarmed", admin = (src.ckey && target.ckey) ? TRUE : FALSE) //Only add this to the server logs if both mobs were controlled by player

--- a/code/modules/mob/living/carbon/martian/combat.dm
+++ b/code/modules/mob/living/carbon/martian/combat.dm
@@ -12,3 +12,75 @@
 			armorscore = head.armor[type]
 
 	return armorscore
+
+/mob/living/carbon/martian/attack_hand(mob/living/M)
+	switch(M.a_intent)
+		if(I_HELP)
+			help_shake_act(M)
+
+		if(I_HURT)
+			M.unarmed_attack_mob(src)
+
+		if(I_GRAB)
+			M.grab_mob(src)
+
+		if(I_DISARM)
+			M.disarm_mob(src)
+
+/mob/living/carbon/martian/attack_alien(mob/living/M)
+	switch(M.a_intent)
+		if (I_HELP)
+			visible_message("<span class='notice'>[M] caresses [src] with its scythe like arm.</span>")
+
+		if (I_HURT)
+			return M.unarmed_attack_mob(src)
+
+		if (I_GRAB)
+			return M.grab_mob(src)
+
+		if (I_DISARM)
+			return M.disarm_mob(src)
+
+/mob/living/carbon/martian/attack_slime(mob/living/carbon/slime/M)
+	M.unarmed_attack_mob(src)
+
+/mob/living/carbon/martian/attack_martian(mob/M)
+	return attack_hand(M)
+
+/mob/living/carbon/martian/attack_paw(mob/M)
+	return attack_hand(M)
+
+/mob/living/carbon/martian/disarm_mob(mob/living/target)
+	add_logs(src, target, "disarmed", admin = (src.ckey && target.ckey) ? TRUE : FALSE) //Only add this to the server logs if both mobs were controlled by player
+
+	if(target.disarmed_by(src))
+		return
+
+	if(prob(40)) //40% miss chance
+		playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
+		visible_message("<span class='danger'>[src] has attempted to disarm [target]!</span>")
+		return
+
+	do_attack_animation(target, src)
+
+	var/datum/organ/external/affecting = get_organ(ran_zone(zone_sel.selecting))
+
+	if(prob(40)) //True chance of something happening per click is hit_chance*event_chance, so in this case the stun chance is actually 0.6*0.4=24%
+		target.apply_effect(4, WEAKEN, run_armor_check(affecting, "melee"))
+		playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
+		visible_message("<span class='danger'>[src] has pushed [target]!</span>")
+		add_logs(src, target, "pushed", admin = (src.ckey && target.ckey) ? TRUE : FALSE) //Only add this to the server logs if both mobs were controlled by player
+		return
+
+	var/talked = 0
+
+	//Disarming breaks pulls
+	talked |= break_pulls(target)
+
+	//Disarming also breaks a grab - this will also stop someone being choked, won't it?
+	talked |= break_grabs(target)
+
+	if(!talked)
+		target.drop_item()
+		visible_message("<span class='danger'>[src] has disarmed [target]!</span>")
+	playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)

--- a/code/modules/mob/living/carbon/martian/martian.dm
+++ b/code/modules/mob/living/carbon/martian/martian.dm
@@ -25,6 +25,7 @@
 	icon_state = "martian"
 
 	species_type = /mob/living/carbon/martian
+	speak_emote = list("blorbles","burbles")
 
 	held_items = list(null, null, null, null, null, null) //6 hands
 
@@ -50,7 +51,7 @@
 /mob/living/carbon/martian/New()
 	create_reagents(200)
 	name = pick("martian","scootaloo","squid","rootmarian","phoronitian","sepiida","octopodiforme",\
-	"bolitaenides","belemnites","astrocanthoteuthis","octodad","ocotillo")
+	"bolitaenides","belemnites","astrocanthoteuthis","octodad","ocotillo","kalamarian")
 	..()
 
 /mob/living/carbon/martian/Destroy()
@@ -86,43 +87,6 @@
 
 /mob/living/carbon/martian/has_eyes()
 	return FALSE
-
-/mob/living/carbon/martian/attack_hand(mob/living/M)
-	switch(M.a_intent)
-		if(I_HELP)
-			help_shake_act(M)
-
-		if(I_HURT)
-			M.unarmed_attack_mob(src)
-
-		if(I_GRAB)
-			M.grab_mob(src)
-
-		if(I_DISARM)
-			M.disarm_mob(src)
-
-/mob/living/carbon/martian/attack_alien(mob/living/M)
-	switch(M.a_intent)
-		if (I_HELP)
-			visible_message("<span class='notice'>[M] caresses [src] with its scythe like arm.</span>")
-
-		if (I_HURT)
-			return M.unarmed_attack_mob(src)
-
-		if (I_GRAB)
-			return M.grab_mob(src)
-
-		if (I_DISARM)
-			return M.disarm_mob(src)
-
-/mob/living/carbon/martian/attack_slime(mob/living/carbon/slime/M)
-	M.unarmed_attack_mob(src)
-
-/mob/living/carbon/martian/attack_martian(mob/M)
-	return attack_hand(M)
-
-/mob/living/carbon/martian/attack_paw(mob/M)
-	return attack_hand(M)
 
 /mob/living/carbon/martian/updatehealth()
 	if(status_flags & GODMODE)

--- a/code/modules/mob/living/combat.dm
+++ b/code/modules/mob/living/combat.dm
@@ -27,7 +27,7 @@
 	return
 
 /mob/living/proc/disarmed_by(mob/living/disarmer) //For if you want to do something specific on disarm and nothing else.
-	return 0
+	return FALSE
 
 /mob/living/proc/break_grabs(mob/living/target)
 	for(var/obj/item/weapon/grab/G in target.held_items)

--- a/code/modules/mob/living/combat.dm
+++ b/code/modules/mob/living/combat.dm
@@ -26,8 +26,8 @@
 /mob/living/proc/disarm_mob(mob/living/target)
 	return
 
-/mob/living/proc/disarmed_by(mob/living/disarmer)
-	return
+/mob/living/proc/disarmed_by(mob/living/disarmer) //For if you want to do something specific on disarm and nothing else.
+	return 0
 
 /mob/living/proc/break_grabs(mob/living/target)
 	for(var/obj/item/weapon/grab/G in target.held_items)


### PR DESCRIPTION
closes #16048

disarm_act was returning at two points

First was if target.disarmed_by returned 1 it would not execute the rest of the code. Problem here is that it returned 1 by default so would fail on anything not a human, such as monkeys. The proc itself is meant for disarm intercepting for special behaviour (In the case of usage, it makes any held guns go off in a struggle)

Second was it would try to get_organ on the target, which by default would return null, so the !istype(S) check would mean you again couldn't disarm the thing.

*Also adds a helpful comment next to the proc disarmed_by so you know what it does, and does some misc changes to martians such as add another name, change their say text to blorbles/burbles (which doesn't work anyway and will be fixed in another issue) and moves their combat code to the proper file which is how I found this bug in the first place*

:cl:
* rscadd: You can now bully Monkeys with disarm again
* rscadd: You can now bully Martians with disarm
