### PR TITLE
Phazon Mutation for Simple Animals

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1715,6 +1715,9 @@
 	if(prob(20))
 		M.advanced_mutate()
 
+/datum/reagent/phazon/reaction_animal(var/mob/living/M)
+	on_mob_life(M)
+
 /datum/reagent/aluminum
 	name = "Aluminum"
 	id = ALUMINUM


### PR DESCRIPTION
Simple animals don't have reagent containers, and so cannot be injected with reagents. However, I remembered that on-touch reactions are a thing.
This PR makes it so that when a simple animal, such as a bee, a corgi, a mouse, a goat, a space carp, et cetera, touches phazon via spraying, splashing, chemical smoke, and so on, it actually mutates.

:cl:
 * rscadd: Simple animals can now be mutated with phazon. Though they cannot be injected, the phazon can be applied to them via splashing, spraying, chemical smoke, and so on.
