### PR TITLE
Adamantine Golem Respawn Time

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -1543,3 +1543,6 @@ var/proccalls = 1
 #define NO_ANIMATION 0
 #define ITEM_ANIMATION 1
 #define PERSON_ANIMATION 2
+
+
+#define GOLEM_RESPAWN_TIME 10 MINUTES	//how much time must pass before someone who dies as an adamantine golem can use the golem rune again

--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -1037,8 +1037,9 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 			to_chat(O, "<span class='warning'>You are not eligible.</span>")
 			return
 		if(O.key in has_died_as_golem)
-			to_chat(O, "<span class='warning'>You have died as a golem too recently. You must wait longer before you can become a golem again.</span>")
-			return
+			if(world.time < has_died_as_golem[O.key] + GOLEM_RESPAWN_TIME)
+				to_chat(O, "<span class='warning'>You have died as a golem too recently. You must wait longer before you can become a golem again.</span>")
+				return
 		ghosts.Add(O)
 		to_chat(O, "<span class='notice'>You are signed up to be a golem.</span>")
 

--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -1034,7 +1034,10 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 		to_chat(O, "<span class='warning'>You are no longer signed up to be a golem.</span>")
 	else
 		if(!check_observer(O))
-			to_chat(O, "<span class='warning'>You are not eligable.</span>")
+			to_chat(O, "<span class='warning'>You are not eligible.</span>")
+			return
+		if(O.key in has_died_as_golem)
+			to_chat(O, "<span class='warning'>You have died as a golem too recently. You must wait longer before you can become a golem again.</span>")
 			return
 		ghosts.Add(O)
 		to_chat(O, "<span class='notice'>You are signed up to be a golem.</span>")

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -852,6 +852,8 @@ var/global/list/whitelisted_species = list("Human")
 /datum/species/golem/makeName()
 	return capitalize(pick(golem_names))
 
+var/list/has_died_as_golem = list()
+
 /datum/species/golem/handle_death(var/mob/living/carbon/human/H) //Handles any species-specific death events (such as dionaea nymph spawns).
 	if(!isgolem(H))
 		return
@@ -869,8 +871,11 @@ var/global/list/whitelisted_species = list("Human")
 		if(H.real_name)
 			A.real_name = H.real_name
 			A.desc = "The remains of what used to be [A.real_name]."
+		var/golem_key = H.key
+		has_died_as_golem.Add(golem_key)
+		spawn(GOLEM_RESPAWN_TIME)
+			has_died_as_golem.Remove(golem_key)
 		A.key = H.key
-		H.key = null
 	qdel(H)
 
 /datum/species/golem/can_artifact_revive()

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -865,16 +865,16 @@ var/list/has_died_as_golem = list()
 	anim(target = H, a_icon = 'icons/mob/mob.dmi', flick_anim = "dust-g", sleeptime = 15)
 	var/mob/living/adamantine_dust/A = new(H.loc)
 	if(golemmind)
+		var/golem_key = H.mind.key
+		has_died_as_golem.Add(golem_key)
+		spawn(GOLEM_RESPAWN_TIME)
+			has_died_as_golem.Remove(golem_key)
 		A.mind = golemmind
 		H.mind = null
 		golemmind.current = A
 		if(H.real_name)
 			A.real_name = H.real_name
 			A.desc = "The remains of what used to be [A.real_name]."
-		var/golem_key = H.key
-		has_died_as_golem.Add(golem_key)
-		spawn(GOLEM_RESPAWN_TIME)
-			has_died_as_golem.Remove(golem_key)
 		A.key = H.key
 	qdel(H)
 

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -865,10 +865,7 @@ var/list/has_died_as_golem = list()
 	anim(target = H, a_icon = 'icons/mob/mob.dmi', flick_anim = "dust-g", sleeptime = 15)
 	var/mob/living/adamantine_dust/A = new(H.loc)
 	if(golemmind)
-		var/golem_key = H.mind.key
-		has_died_as_golem.Add(golem_key)
-		spawn(GOLEM_RESPAWN_TIME)
-			has_died_as_golem.Remove(golem_key)
+		has_died_as_golem.Add(H.mind.key = world.time)
 		A.mind = golemmind
 		H.mind = null
 		golemmind.current = A


### PR DESCRIPTION
When a player dies as an adamantine golem, they must now wait 10 minutes before they can spawn again using an adamantine golem rune.
Golems are still replenishable, but hopefully no longer an endless stream of powerful combatants who respawn as soon as they die, a la manifested ghosts.

The time limit has been made a define so that it can easily be changed.

:cl:
 * tweak: When a player dies as an adamantine golem, they must now wait 10 minutes before they can spawn again using an adamantine golem rune.
