### PR TITLE
HUDs and AI Cameras No Longer Track Invisible Mobs

### DIFF
--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -86,7 +86,7 @@ proc/process_sec_hud(var/mob/M, var/advanced_mode,var/mob/eye)
 	else
 		T = get_turf(M)
 	for(var/mob/living/carbon/human/perp in range(T))
-		if(!check_HUD_visibility(patient, M))
+		if(!check_HUD_visibility(perp, M))
 			continue
 		holder = perp.hud_list[ID_HUD]
 		if(!holder)

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -39,10 +39,10 @@ proc/process_med_hud(var/mob/M, var/mob/eye)
 				continue
 			for(var/i in patient.alphas)
 				if(patient.alphas[i] <= 1)
-				continue mob_loop
+					continue mob_loop
 			for(var/i in patient.body_alphas)
 				if(patient.body_alphas[i] <= 1)
-				continue mob_loop
+					continue mob_loop
 			if(!C)
 				continue
 
@@ -90,10 +90,10 @@ proc/process_sec_hud(var/mob/M, var/advanced_mode,var/mob/eye)
 				continue
 			for(var/i in perp.alphas)
 				if(perp.alphas[i] <= 1)
-				continue mob_loop
+					continue mob_loop
 			for(var/i in perp.body_alphas)
 				if(perp.body_alphas[i] <= 1)
-				continue mob_loop
+					continue mob_loop
 			holder = perp.hud_list[ID_HUD]
 			if(!holder)
 				continue

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -13,7 +13,7 @@ mob/proc/regular_hud_updates() //Used in the life.dm of mobs that can use HUDs.
 	if(src in sec_hud_users)
 		sec_hud_users -= src
 
-proc/check_HUD_visibility(var/mob/living/carbon/human/target, var/mob/user)
+proc/check_HUD_visibility(var/mob/living/target, var/mob/user)
 	if(user.see_invisible < target.invisibility)
 		return FALSE
 	if(target.alpha <= 1)
@@ -21,9 +21,11 @@ proc/check_HUD_visibility(var/mob/living/carbon/human/target, var/mob/user)
 	for(var/i in target.alphas)
 		if(target.alphas[i] <= 1)
 			return FALSE
-	for(var/i in target.body_alphas)
-		if(target.body_alphas[i] <= 1)
-			return FALSE
+	if(iscarbon(target))
+		var/mob/living/carbon/C = target
+		for(var/i in C.body_alphas)
+			if(C.body_alphas[i] <= 1)
+				return FALSE
 	return TRUE
 
 //Medical HUD outputs. Called by the Life() proc of the mob using it, usually.

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -34,6 +34,8 @@ proc/process_med_hud(var/mob/M, var/mob/eye)
 			continue
 		if(M.see_invisible < patient.invisibility)
 			continue
+		if(patient.alpha <= 1)
+			continue
 		if(!C)
 			continue
 
@@ -75,6 +77,8 @@ proc/process_sec_hud(var/mob/M, var/advanced_mode,var/mob/eye)
 		T = get_turf(M)
 	for(var/mob/living/carbon/human/perp in range(T))
 		if(M.see_invisible < perp.invisibility)
+			continue
+		if(perp.alpha <= 1)
 			continue
 		holder = perp.hud_list[ID_HUD]
 		if(!holder)

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -14,7 +14,7 @@ mob/proc/regular_hud_updates() //Used in the life.dm of mobs that can use HUDs.
 		sec_hud_users -= src
 
 proc/check_HUD_visibility(var/mob/living/carbon/human/target, var/mob/user)
-	if(M.see_invisible < target.invisibility)
+	if(user.see_invisible < target.invisibility)
 		return FALSE
 	if(target.alpha <= 1)
 		return FALSE

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -29,35 +29,42 @@ proc/process_med_hud(var/mob/M, var/mob/eye)
 		T = get_turf(eye)
 	else
 		T = get_turf(M)
-	for(var/mob/living/carbon/human/patient in range(T))
-		if(patient.head && istype(patient.head,/obj/item/clothing/head/tinfoil)) //Tinfoil hat? Move along.
-			continue
-		if(M.see_invisible < patient.invisibility)
-			continue
-		if(patient.alpha <= 1)
-			continue
-		if(!C)
-			continue
+	mob_loop:
+		for(var/mob/living/carbon/human/patient in range(T))
+			if(patient.head && istype(patient.head,/obj/item/clothing/head/tinfoil)) //Tinfoil hat? Move along.
+				continue
+			if(M.see_invisible < patient.invisibility)
+				continue
+			if(patient.alpha <= 1)
+				continue
+			for(var/i in patient.alphas)
+				if(patient.alphas[i] <= 1)
+				continue mob_loop
+			for(var/i in patient.body_alphas)
+				if(patient.body_alphas[i] <= 1)
+				continue mob_loop
+			if(!C)
+				continue
 
-		holder = patient.hud_list[HEALTH_HUD]
-		if(holder)
-			if(patient.stat == 2)
-				holder.icon_state = "hudhealth-100"
-			else
-				holder.icon_state = "hud[RoundHealth(patient.health)]"
-			C.images += holder
+			holder = patient.hud_list[HEALTH_HUD]
+			if(holder)
+				if(patient.stat == 2)
+					holder.icon_state = "hudhealth-100"
+				else
+					holder.icon_state = "hud[RoundHealth(patient.health)]"
+				C.images += holder
 
-		holder = patient.hud_list[STATUS_HUD]
-		if(holder)
-			if(patient.stat == 2)
-				holder.icon_state = "huddead"
-			else if(patient.status_flags & XENO_HOST)
-				holder.icon_state = "hudxeno"
-			else if(has_any_recorded_disease(patient))
-				holder.icon_state = "hudill"
-			else
-				holder.icon_state = "hudhealthy"
-			C.images += holder
+			holder = patient.hud_list[STATUS_HUD]
+			if(holder)
+				if(patient.stat == 2)
+					holder.icon_state = "huddead"
+				else if(patient.status_flags & XENO_HOST)
+					holder.icon_state = "hudxeno"
+				else if(has_any_recorded_disease(patient))
+					holder.icon_state = "hudill"
+				else
+					holder.icon_state = "hudhealthy"
+				C.images += holder
 
 
 //Security HUDs. Pass a value for the second argument to enable implant viewing or other special features.
@@ -75,59 +82,66 @@ proc/process_sec_hud(var/mob/M, var/advanced_mode,var/mob/eye)
 		T = get_turf(eye)
 	else
 		T = get_turf(M)
-	for(var/mob/living/carbon/human/perp in range(T))
-		if(M.see_invisible < perp.invisibility)
-			continue
-		if(perp.alpha <= 1)
-			continue
-		holder = perp.hud_list[ID_HUD]
-		if(!holder)
-			continue
-		holder.icon_state = "hudno_id"
-		if(perp.head && istype(perp.head,/obj/item/clothing/head/tinfoil)) //Tinfoil hat? Move along.
-			C.images += holder
-			continue
-		var/obj/item/weapon/card/id/card = perp.get_id_card()
-		if(card)
-			holder.icon_state = "hud[ckey(card.GetJobName())]"
-		C.images += holder
-
-		if(advanced_mode) //If set, the SecHUD will display the implants a person has.
-			for(var/obj/item/weapon/implant/I in perp)
-				if(I.implanted)
-					if(istype(I,/obj/item/weapon/implant/tracking))
-						holder = perp.hud_list[IMPTRACK_HUD]
-						holder.icon_state = "hud_imp_tracking"
-					else if(istype(I,/obj/item/weapon/implant/loyalty))
-						holder = perp.hud_list[IMPLOYAL_HUD]
-						holder.icon_state = "hud_imp_loyal"
-					else if(istype(I,/obj/item/weapon/implant/chem))
-						holder = perp.hud_list[IMPCHEM_HUD]
-						holder.icon_state = "hud_imp_chem"
-					else
-						continue
-					C.images += holder
-					break
-
-		var/perpname = perp.get_face_name()
-		if(lowertext(perpname) == "unknown" || !perpname)
-			perpname = perp.get_id_name("Unknown")
-		if(perpname)
-			var/datum/data/record/R = find_record("name", perpname, data_core.security)
-			if(R)
-				holder = perp.hud_list[WANTED_HUD]
-				switch(R.fields["criminal"])
-					if("*Arrest*")
-						holder.icon_state = "hudwanted"
-					if("Incarcerated")
-						holder.icon_state = "hudprisoner"
-					if("Parolled")
-						holder.icon_state = "hudparolled"
-					if("Released")
-						holder.icon_state = "hudreleased"
-					else
-						continue
+	mob_loop:
+		for(var/mob/living/carbon/human/perp in range(T))
+			if(M.see_invisible < perp.invisibility)
+				continue
+			if(perp.alpha <= 1)
+				continue
+			for(var/i in perp.alphas)
+				if(perp.alphas[i] <= 1)
+				continue mob_loop
+			for(var/i in perp.body_alphas)
+				if(perp.body_alphas[i] <= 1)
+				continue mob_loop
+			holder = perp.hud_list[ID_HUD]
+			if(!holder)
+				continue
+			holder.icon_state = "hudno_id"
+			if(perp.head && istype(perp.head,/obj/item/clothing/head/tinfoil)) //Tinfoil hat? Move along.
 				C.images += holder
+				continue
+			var/obj/item/weapon/card/id/card = perp.get_id_card()
+			if(card)
+				holder.icon_state = "hud[ckey(card.GetJobName())]"
+			C.images += holder
+
+			if(advanced_mode) //If set, the SecHUD will display the implants a person has.
+				for(var/obj/item/weapon/implant/I in perp)
+					if(I.implanted)
+						if(istype(I,/obj/item/weapon/implant/tracking))
+							holder = perp.hud_list[IMPTRACK_HUD]
+							holder.icon_state = "hud_imp_tracking"
+						else if(istype(I,/obj/item/weapon/implant/loyalty))
+							holder = perp.hud_list[IMPLOYAL_HUD]
+							holder.icon_state = "hud_imp_loyal"
+						else if(istype(I,/obj/item/weapon/implant/chem))
+							holder = perp.hud_list[IMPCHEM_HUD]
+							holder.icon_state = "hud_imp_chem"
+						else
+							continue
+						C.images += holder
+						break
+
+			var/perpname = perp.get_face_name()
+			if(lowertext(perpname) == "unknown" || !perpname)
+				perpname = perp.get_id_name("Unknown")
+			if(perpname)
+				var/datum/data/record/R = find_record("name", perpname, data_core.security)
+				if(R)
+					holder = perp.hud_list[WANTED_HUD]
+					switch(R.fields["criminal"])
+						if("*Arrest*")
+							holder.icon_state = "hudwanted"
+						if("Incarcerated")
+							holder.icon_state = "hudprisoner"
+						if("Parolled")
+							holder.icon_state = "hudparolled"
+						if("Released")
+							holder.icon_state = "hudreleased"
+						else
+							continue
+					C.images += holder
 
 //Unsure of where to put this, but since most of it is HUDs it seemed fitting to go here.
 /mob/proc/handle_glasses_vision_updates(var/obj/item/clothing/glasses/G)

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -63,9 +63,7 @@
 			continue
 		if(M == usr)
 			continue
-		if(see_invisible < M.invisibility) //cloaked
-			continue
-		if(M.alpha <= 1) //fully transparent
+		if(!check_camera_visibility(M, src))
 			continue
 		if(M.digitalcamo)
 			continue
@@ -99,6 +97,21 @@
 
 	var/list/targets = sortList(track.humans) + sortList(track.others)
 	return targets
+
+/mob/living/silicon/ai/proc/check_camera_visibility(var/mob/living/target, var/mob/user)
+	if(user.see_invisible < target.invisibility)
+		return FALSE
+	if(target.alpha <= 1)
+		return FALSE
+	for(var/i in target.alphas)
+		if(target.alphas[i] <= 1)
+			return FALSE
+	if(iscarbon(target))
+		var/mob/living/carbon/C = target
+		for(var/i in C.body_alphas)
+			if(C.body_alphas[i] <= 1)
+				return FALSE
+	return TRUE
 
 /mob/living/silicon/ai/verb/ai_camera_track(var/target_name as null|anything in trackable_mobs())
 	set name = "track"

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -63,7 +63,7 @@
 			continue
 		if(M == usr)
 			continue
-		if(!check_camera_visibility(M, src))
+		if(!check_HUD_visibility(M, src))
 			continue
 		if(M.digitalcamo)
 			continue
@@ -97,21 +97,6 @@
 
 	var/list/targets = sortList(track.humans) + sortList(track.others)
 	return targets
-
-/mob/living/silicon/ai/proc/check_camera_visibility(var/mob/living/target, var/mob/user)
-	if(user.see_invisible < target.invisibility)
-		return FALSE
-	if(target.alpha <= 1)
-		return FALSE
-	for(var/i in target.alphas)
-		if(target.alphas[i] <= 1)
-			return FALSE
-	if(iscarbon(target))
-		var/mob/living/carbon/C = target
-		for(var/i in C.body_alphas)
-			if(C.body_alphas[i] <= 1)
-				return FALSE
-	return TRUE
 
 /mob/living/silicon/ai/verb/ai_camera_track(var/target_name as null|anything in trackable_mobs())
 	set name = "track"


### PR DESCRIPTION
Specifically mobs made invisible or practically invisible via `alpha` manipulation, such as with a cloaking cloak or invisible spray.
Fixes #14691 

:cl:
 * rscadd: Mobs made invisible or practically invisible via alpha manipulation, such as via a cloaking cloak or invisible spray, can no longer be seen by HUDs or tracked by AI cameras.
