### PR TITLE
fixes the health analyzer wrongly checking for ghosts in heads

### DIFF
--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -1803,9 +1803,9 @@ obj/item/organ/external/head/attackby(obj/item/weapon/W as obj, mob/user as mob)
 		if(!organ_data)
 			to_chat(user, "<span class='warning'>\The [src] has no brain!</span>")
 			return
-		if(brainmob && brainmob.mind)
+		if(brainmob)
 			var/mind_found = 0
-			if(brainmob.mind.active)
+			if(brainmob.client)
 				mind_found = 1
 				to_chat(user, "<span class='notice'>[pick("The eyes","The jaw","The ears")] of \the [src] twitch ever so slightly.</span>")
 			else


### PR DESCRIPTION
I was wrongly interpreting what the variables on the mind datum were, and should have been checking for an active or inactive client instead.

thank you to @SonixApache for telling me how to do the guest testing thing, this should help a lot with testing other multi-player oriented features in the future.

closes #16272