### PR TITLE
Inflatable Barrier Launchers and Metal Foam Grenade Launchers Can Now Be Used on Adjacent Tiles

### DIFF
--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -407,6 +407,7 @@
 	origin_tech = Tc_MATERIALS + "=3;" + Tc_MAGNETS + "=2;" + Tc_ENGINEERING + "=3"
 	can_pre_detonate = TRUE
 	equip_cooldown = 30
+	range = RANGED | MELEE
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/flashbang/metalfoam/can_attach(var/obj/mecha/working/clarke/M)
 	if(istype(M))
@@ -458,6 +459,8 @@
 		if(istype(target, /obj/structure/inflatable/door))
 			var/obj/structure/inflatable/door/D = target
 			D.toggle(chassis.occupant)
+		if(isturf(target))
+			..()
 		return
 	..()
 


### PR DESCRIPTION
Including the mech's own tile.
Fixes #16289 
Also adds changelog for the Clarke because I forgot to in the initial PR.

:cl:
 * rscadd: Added a new mech tailored for Engineering, the Clarke. It moves slightly faster than a normal human, can move freely in space, and can withstand temperatures up to 100,000 degrees. It also has four module slots, and a built-in air scrubber.
However, it has half the health of the Ripley, and is incapable of equipping any modules which deal damage. It can equip the Ripley's loading clamp, but still cannot use it as a weapon.