### PR TITLE
Xenoarchaeology Finds Fix

### DIFF
--- a/code/modules/research/xenoarchaeology/finds/finds.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds.dm
@@ -96,7 +96,7 @@
 	if(new_item_type)
 		find_type = new_item_type
 	else
-		find_type = rand(1,39)	//update this when you add new find types
+		find_type = rand(1,MAX_ARCHAEO)
 
 	var/anomaly_factor = 1		//anomaly origin_tech
 	var/item_type = "object"


### PR DESCRIPTION
I wonder for how long people have been incrementing the number in their PRs instead of just using the define.
This is a good example of why defines are useful.

:cl:
 * bugfix: Fixed Xenoarchaeology find picking so that recent Xenoarch additions can now be obtained in-game.
