### PR TITLE
Airlock screwdriver sound addition.

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1036,6 +1036,7 @@ About the new airlock wires panel:
 /obj/machinery/door/airlock/togglePanelOpen(var/obj/toggleitem, mob/user)
 	if(!operating)
 		panel_open = !panel_open
+		playsound(get_turf(src), 'sound/items/Screwdriver.ogg', 25, 1, -6)
 		update_icon()
 		return 1
 	return


### PR DESCRIPTION
Adds a screwdriver sound to airlocks when you toggle the maint panel on them. **THE SOUND ONLY HAS A RANGE OF ONE SO ONLY THE PEOPLE NEXT TO THE AIRLOCK CAN HEAR IT.**
This time I'm not going to merge it myself.

:cl:
 * rscadd: Airlocks have a screwdriver sound when opening and closing the maint panel. The sound only has a range of one so only people right next to the airlock will hear it. No jokes this time.