### PR TITLE
Fix #16286

### DIFF
--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -71,7 +71,9 @@ client/proc/one_click_antag()
 
 		var/mob/living/carbon/human/candidate
 
-		for (var/i = 1 to min(candidates.len, 3))
+		var/antag_number = input("How many antags would you like to create?","Create Antagonists") as num|null
+
+		for (var/i = 1 to min(candidates.len, antag_number))
 			candidate = pick_n_take(candidates)
 
 			if (candidate)

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -73,6 +73,10 @@ client/proc/one_click_antag()
 
 		var/antag_number = input("How many antags would you like to create?","Create Antagonists") as num|null
 
+		if (!antag_number)
+			to_chat(usr, "<span class='warning'>0 traitors selected. Aborting.</span>")
+			return
+
 		for (var/i = 1 to min(candidates.len, antag_number))
 			candidate = pick_n_take(candidates)
 


### PR DESCRIPTION
Fixes #16286. Tested
:cl:
- tweak: Admins can now choose how many traitors they want to create with the "Create-Antagonist" verb.