### PR TITLE
Hologram Hotfix

### DIFF
--- a/code/game/machinery/computer/HolodeckControl.dm
+++ b/code/game/machinery/computer/HolodeckControl.dm
@@ -23,6 +23,9 @@
 	return
 
 /obj/machinery/computer/HolodeckControl/attack_ghost(mob/dead/observer/user)
+	if(!ticker || ticker.current_state != GAME_STATE_PLAYING)
+		to_chat(user, "<span class='notice'>You can't do this until the game has started.</span>")
+		return
 	if(!linkedholodeck)
 		return
 	var/turf/spawnturf


### PR DESCRIPTION
Prevents holograms from spawning before the round starts, as it would allow them to leave the holodeck.