### PR TITLE
Meter Broadcasting Fix

### DIFF
--- a/code/game/machinery/atmoalter/meter.dm
+++ b/code/game/machinery/atmoalter/meter.dm
@@ -9,7 +9,6 @@
 	power_channel = ENVIRON
 	var/frequency = 1439
 	var/id_tag
-	var/broadcasting = FALSE
 	use_power = 1
 	idle_power_usage = 2
 	active_power_usage = 4
@@ -73,7 +72,7 @@
 	else
 		icon_state = "meter4"
 
-	if(broadcasting && frequency)
+	if(id_tag && frequency)
 		var/datum/radio_frequency/radio_connection = radio_controller.return_frequency(frequency)
 
 		if(!radio_connection)
@@ -145,16 +144,9 @@
 	return {"
 	<b>Main</b>
 	<ul>
-		<li><b>Frequency:</b> <a href="?src=\ref[src];set_freq=-1">[format_frequency(frequency)] GHz</a> (<a href="?src=\ref[src];set_freq=[initial(frequency)]">Reset</a>)(<a href="?src=\ref[src];toggle_broadcast=0">Turn broadcasting [broadcasting ? "off" : "on"]</a>)</li>
+		<li><b>Frequency:</b> <a href="?src=\ref[src];set_freq=-1">[format_frequency(frequency)] GHz</a> (<a href="?src=\ref[src];set_freq=[initial(frequency)]">Reset</a>)</li>
 		<li>[format_tag("ID Tag","id_tag")]</li>
 	</ul>"}
-
-/obj/machinery/meter/multitool_topic(var/mob/user,var/list/href_list,var/obj/O)
-	. = ..()
-	if("toggle_broadcast" in href_list)
-		broadcasting = !broadcasting
-		return MT_UPDATE|MT_REINIT
-	return 0
 
 /obj/machinery/meter/attackby(var/obj/item/weapon/W as obj, var/mob/user as mob)
 	if (!iswrench(W))

--- a/code/game/machinery/atmoalter/meter.dm
+++ b/code/game/machinery/atmoalter/meter.dm
@@ -149,6 +149,13 @@
 		<li>[format_tag("ID Tag","id_tag")]</li>
 	</ul>"}
 
+/obj/machinery/meter/multitool_topic(var/mob/user,var/list/href_list,var/obj/O)
+	. = ..()
+	if("toggle_broadcast" in href_list)
+		broadcasting = !broadcasting
+		return MT_UPDATE|MT_REINIT
+	return 0
+
 /obj/machinery/meter/attackby(var/obj/item/weapon/W as obj, var/mob/user as mob)
 	if (!iswrench(W))
 		return ..()

--- a/code/game/machinery/atmoalter/meter.dm
+++ b/code/game/machinery/atmoalter/meter.dm
@@ -9,6 +9,7 @@
 	power_channel = ENVIRON
 	var/frequency = 1439
 	var/id_tag
+	var/broadcasting = FALSE
 	use_power = 1
 	idle_power_usage = 2
 	active_power_usage = 4
@@ -72,7 +73,7 @@
 	else
 		icon_state = "meter4"
 
-	if(frequency)
+	if(broadcasting && frequency)
 		var/datum/radio_frequency/radio_connection = radio_controller.return_frequency(frequency)
 
 		if(!radio_connection)
@@ -144,7 +145,7 @@
 	return {"
 	<b>Main</b>
 	<ul>
-		<li><b>Frequency:</b> <a href="?src=\ref[src];set_freq=-1">[format_frequency(frequency)] GHz</a> (<a href="?src=\ref[src];set_freq=[initial(frequency)]">Reset</a>)</li>
+		<li><b>Frequency:</b> <a href="?src=\ref[src];set_freq=-1">[format_frequency(frequency)] GHz</a> (<a href="?src=\ref[src];set_freq=[initial(frequency)]">Reset</a>)(<a href="?src=\ref[src];toggle_broadcast=0">Turn broadcasting [broadcasting ? "off" : "on"]</a>)</li>
 		<li>[format_tag("ID Tag","id_tag")]</li>
 	</ul>"}
 

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -274,6 +274,12 @@ Class Procs:
 			if(newfreq < 10000)
 				src:frequency = newfreq
 				return MT_UPDATE|MT_REINIT
+	if("toggle_broadcast" in href_list)
+		if(!("broadcasting" in vars))
+			warning("toggle_broadcast: [type] has no broadcasting var.")
+			return 0
+		src:broadcasting = !src:broadcasting
+		return MT_UPDATE|MT_REINIT
 	return 0
 
 /obj/machinery/proc/handle_multitool_topic(var/href, var/list/href_list, var/mob/user)

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -274,12 +274,6 @@ Class Procs:
 			if(newfreq < 10000)
 				src:frequency = newfreq
 				return MT_UPDATE|MT_REINIT
-	if("toggle_broadcast" in href_list)
-		if(!("broadcasting" in vars))
-			warning("toggle_broadcast: [type] has no broadcasting var.")
-			return 0
-		src:broadcasting = !src:broadcasting
-		return MT_UPDATE|MT_REINIT
 	return 0
 
 /obj/machinery/proc/handle_multitool_topic(var/href, var/list/href_list, var/mob/user)


### PR DESCRIPTION
Fixes all pipe meters broadcasting at all times.
Pipe meters will now only broadcast if they have an `id_tag`.
Fixes #16315