### PR TITLE
Attempt at HREF exploit patch related to MoMMIs

### DIFF
--- a/code/modules/mob/living/silicon/mommi/mommi.dm
+++ b/code/modules/mob/living/silicon/mommi/mommi.dm
@@ -415,7 +415,7 @@ They can only use one tool at a time, they can't choose modules, and they have 1
 
 	if (href_list["mod"])
 		var/obj/item/O = locate(href_list["mod"])
-		if (O)
+		if (O && O == tool_state)
 			O.attack_self(src)
 
 	if (href_list["act"])


### PR DESCRIPTION
I think this should sort the reference issue, as it's checking for a specifically referenced item now in the silicons tool_state.

Need a second opinion, as I'm not sure if it does sort the problem.

closes #12188

