### PR TITLE
syndicate IDs and voice changers now block AI camera tracking when worn

### DIFF
--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -155,6 +155,13 @@
 /mob/living/silicon/ai/proc/ai_actual_track(mob/living/target as mob)
 	if(!istype(target))
 		return
+
+	if(ishuman(target))
+		var/mob/living/carbon/human/H = target
+		if((H.wear_id && istype(H.wear_id.GetID(), /obj/item/weapon/card/id/syndicate)) || H.is_wearing_item(/obj/item/clothing/mask/gas/voice))
+			to_chat(usr, "Target is not near any active cameras.")
+			return
+
 	var/mob/living/silicon/ai/U = usr
 
 	U.cameraFollow = target


### PR DESCRIPTION
closes #15812 

They never receive the name at this point. It's akin to if they're off cameras entirely. Can potentially backfire if you're just wearing the IDs out and about like in #11010 , and the detective voice changer can throw a false positive.

:cl:
* rscadd: Syndicate IDs or voice changers now block AI camera tracking as it was causing an exploit that would yield the persons real identity