### PR TITLE
Change icon and name of pills with chemmaster

### DIFF
--- a/code/modules/reagents/machinery/chem_master.dm
+++ b/code/modules/reagents/machinery/chem_master.dm
@@ -162,6 +162,12 @@ var/global/list/pillIcon2Name = list("oblong purple-pink", "oblong green-white",
 		src.updateUsrDialog()
 		return 1
 
+	else if(istype(B, /obj/item/weapon/reagent_containers/pill/time_release))
+		var/name = reject_bad_text(input(usr,"Name:","Name your pill!","[B.reagents.get_master_reagent_name()] ([B.reagents.total_volume] units)") as null|text)
+		if(name)
+			B.name = "[name] pill"
+		B.icon_state = "pill"+pillsprite
+
 /obj/machinery/chem_master/Topic(href, href_list)
 
 	if(..())

--- a/code/modules/reagents/machinery/chem_master.dm
+++ b/code/modules/reagents/machinery/chem_master.dm
@@ -167,6 +167,7 @@ var/global/list/pillIcon2Name = list("oblong purple-pink", "oblong green-white",
 		if(name)
 			B.name = "[name] pill"
 		B.icon_state = "pill"+pillsprite
+		return 1
 
 /obj/machinery/chem_master/Topic(href, href_list)
 

--- a/code/modules/reagents/machinery/chem_master.dm
+++ b/code/modules/reagents/machinery/chem_master.dm
@@ -162,8 +162,8 @@ var/global/list/pillIcon2Name = list("oblong purple-pink", "oblong green-white",
 		src.updateUsrDialog()
 		return 1
 
-	else if(istype(B, /obj/item/weapon/reagent_containers/pill/time_release))
-		var/name = reject_bad_text(input(usr,"Name:","Name your pill!","[B.reagents.get_master_reagent_name()] ([B.reagents.total_volume] units)") as null|text)
+	else if(istype(B, /obj/item/weapon/reagent_containers/pill))
+		var/name = reject_bad_text(input(user,"Name:","Name your pill!","[B.reagents.get_master_reagent_name()] ([B.reagents.total_volume] units)") as null|text)
 		if(name)
 			B.name = "[name] pill"
 		B.icon_state = "pill"+pillsprite


### PR DESCRIPTION
Very simple. Currently any time-release pill you can make, beneficial or not, is forced to always be grey and named "time-release pill".

:cl: (as the (as the (as the emoji)))
 * rscadd: You can now use pills on a ChemMaster to change the pill's name and icon.