### PR TITLE
Adds New Restraint Options

### DIFF
--- a/code/WorkInProgress/Ported/policetape.dm
+++ b/code/WorkInProgress/Ported/policetape.dm
@@ -5,6 +5,7 @@
 	icon_state = "rollstart"
 	flags = FPRINT
 	w_class = W_CLASS_TINY
+	restraint_resist_time = 20 SECONDS
 	var/turf/start
 	var/turf/end
 	var/tape_type = /obj/item/tape

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -60,6 +60,7 @@
 	desc = "Some sterile gauze to wrap around bloody stumps."
 	icon_state = "brutepack"
 	origin_tech = Tc_BIOTECH + "=1"
+	restraint_resist_time = 20 SECONDS
 
 /obj/item/stack/medical/bruise_pack/bandaid
 	name = "small bandage"

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -18,7 +18,7 @@ LINEN BINS
 	throw_range = 2
 	w_class = W_CLASS_TINY
 	_color = "white"
-	restraint_resist_time = 30 SECONDS
+	restraint_resist_time = 20 SECONDS
 	restraint_apply_sound = "rustle"
 
 //cutting the bedsheet into rags

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -18,6 +18,8 @@ LINEN BINS
 	throw_range = 2
 	w_class = W_CLASS_TINY
 	_color = "white"
+	restraint_resist_time = 30 SECONDS
+	restraint_apply_sound = "rustle"
 
 //cutting the bedsheet into rags
 /obj/item/weapon/bedsheet/attackby(var/obj/item/I, mob/user as mob)

--- a/code/modules/clothing/accessories/accessory.dm
+++ b/code/modules/clothing/accessories/accessory.dm
@@ -95,6 +95,10 @@
 /obj/item/clothing/accessory/pinksquare/can_attach_to(obj/item/clothing/C)
 	return 1
 
+/obj/item/clothing/accessory/tie
+	restraint_resist_time = 30 SECONDS
+	restraint_apply_sound = "rustle"
+
 /obj/item/clothing/accessory/tie/can_attach_to(obj/item/clothing/C)
 	if(istype(C))
 		return (C.body_parts_covered & UPPER_TORSO) //Sure why not
@@ -124,6 +128,8 @@
 	icon_state = "stethoscope"
 	_color = "stethoscope"
 	origin_tech = Tc_BIOTECH + "=1"
+	restraint_resist_time = 30 SECONDS
+	restraint_apply_sound = "rustle"
 
 /obj/item/clothing/accessory/stethoscope/attack(mob/living/carbon/human/M, mob/living/user)
 	if(ishuman(M) && isliving(user))

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -114,6 +114,7 @@
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "label_cart" //Placeholder image; recolored police tape
 	w_class = W_CLASS_TINY
+	restraint_resist_time = 5 SECONDS
 	var/left = 250
 
 /obj/item/device/label_roll/New(var/loc, var/amount=null)

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -2058,6 +2058,7 @@
 	desc = "A plain dish of noodles, this sucks."
 	icon_state = "spaghettiboiled"
 	trash = /obj/item/trash/plate
+	restraint_resist_time = 1 SECONDS
 
 /obj/item/weapon/reagent_containers/food/snacks/boiledspaghetti/New()
 	..()


### PR DESCRIPTION
:cl:
 * rscadd: Police tape, engineering tape, atmospherics tape, label rolls, gauze, ties, stethoscopes, bedsheets, and boiled spaghetti can now be used as restraints.
