### PR TITLE
Makes cell chargers 750% faster, cells made from protolathes start empty, can make cell chargers with a soldering iron

### DIFF
--- a/code/game/machinery/cell_charger.dm
+++ b/code/game/machinery/cell_charger.dm
@@ -10,7 +10,7 @@
 	active_power_usage = 10 //Power is already drained to charge batteries
 	power_channel = EQUIP
 	var/obj/item/weapon/cell/charging = null
-	var/transfer_rate = 200 //How much power do we output every process tick ?
+	var/transfer_rate = 1500 //How much power do we output every process tick ?
 	var/transfer_efficiency = 0.7 //How much power ends up in the battery in percentage ?
 	var/transfer_rate_coeff = 1 //What is the quality of the parts that transfer energy (capacitators) ?
 	var/transfer_efficiency_bonus = 0 //What is the efficiency "bonus" (additive to percentage) from the parts used (scanning module) ?
@@ -62,7 +62,7 @@
 	..()
 	to_chat(user, "There's [charging ? "a" : "no"] cell in the charger.")
 	if(charging)
-		to_chat(user, "Current charge: [charging.charge]")
+		to_chat(user, "Current charge: [round(charging.percent() )]%")
 
 /obj/machinery/cell_charger/attackby(obj/item/weapon/W, mob/user)
 	if(stat & BROKEN)
@@ -142,12 +142,12 @@
 		charging.give(transfer_rate*transfer_rate_coeff*(transfer_efficiency+transfer_efficiency_bonus)) //Inefficiency (Joule effect + other shenanigans)
 
 	updateicon()
-	
+
 //Emergency Charger
 //craftable by combining an APC frame, metal rod, cables, and wirecutter
 /datum/construction/reversible/crank_charger
 	result = /obj/item/device/crank_charger
-	steps = list(	
+	steps = list(
 					//1
 					list(Co_DESC="The cabling is messily strewn throughout.",
 						Co_NEXTSTEP = list(Co_KEY=/obj/item/weapon/screwdriver,
@@ -247,7 +247,7 @@
 		update_icon()
 	else
 		..()
-		
+
 /obj/item/device/crank_charger/Destroy()
 	if(stored)
 		qdel(stored)

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -239,7 +239,7 @@ to destroy them and players will be able to make replacements.
 	icon = 'icons/obj/module.dmi'
 	icon_state = "blank_mod"
 	//var/datum/circuits/local_fuses = null
-	var/list/allowed_boards = list("autolathe"=/obj/item/weapon/circuitboard/autolathe,"intercom"=/obj/item/weapon/intercom_electronics,"air alarm"=/obj/item/weapon/circuitboard/air_alarm,"fire alarm"=/obj/item/weapon/circuitboard/fire_alarm,"airlock"=/obj/item/weapon/circuitboard/airlock,"APC"=/obj/item/weapon/circuitboard/power_control,"vendomat"=/obj/item/weapon/circuitboard/vendomat,"microwave"=/obj/item/weapon/circuitboard/microwave,"station map"=/obj/item/weapon/circuitboard/station_map)
+	var/list/allowed_boards = list("autolathe"=/obj/item/weapon/circuitboard/autolathe,"intercom"=/obj/item/weapon/intercom_electronics,"air alarm"=/obj/item/weapon/circuitboard/air_alarm,"fire alarm"=/obj/item/weapon/circuitboard/fire_alarm,"airlock"=/obj/item/weapon/circuitboard/airlock,"APC"=/obj/item/weapon/circuitboard/power_control,"vendomat"=/obj/item/weapon/circuitboard/vendomat,"microwave"=/obj/item/weapon/circuitboard/microwave,"station map"=/obj/item/weapon/circuitboard/station_map,"cell charger"=/obj/item/weapon/circuitboard/cell_charger)
 	var/soldering = 0 //Busy check
 
 /obj/item/weapon/circuitboard/blank/New()

--- a/code/game/objects/items/weapons/power_cells.dm
+++ b/code/game/objects/items/weapons/power_cells.dm
@@ -25,6 +25,10 @@
 	to_chat(viewers(user), "<span class='danger'>[user] is licking the electrodes of the [src.name]! It looks like \he's trying to commit suicide.</span>")
 	return (FIRELOSS)
 
+/obj/item/weapon/cell/empty/New()
+	..()
+	charge = 0
+
 /obj/item/weapon/cell/crap
 	name = "\improper Nanotrasen brand rechargeable AA battery"
 	desc = "You can't top the plasma top." //TOTALLY TRADEMARK INFRINGEMENT
@@ -76,6 +80,7 @@
 	icon_state = "scell"
 	maxcharge = 20000
 	starting_materials = list(MAT_IRON = 700, MAT_GLASS = 70)
+
 /obj/item/weapon/cell/super/empty/New()
 	..()
 	charge = 0

--- a/code/modules/research/designs/engineering.dm
+++ b/code/modules/research/designs/engineering.dm
@@ -5,7 +5,7 @@
 	req_tech = list(Tc_POWERSTORAGE = 1)
 	build_type = PROTOLATHE | AUTOLATHE | MECHFAB | PODFAB
 	materials = list(MAT_IRON = 700, MAT_GLASS = 50)
-	build_path = /obj/item/weapon/cell
+	build_path = /obj/item/weapon/cell/empty
 	category = "Engineering"
 
 /datum/design/high_cell
@@ -15,7 +15,7 @@
 	req_tech = list(Tc_POWERSTORAGE = 2)
 	build_type = PROTOLATHE | AUTOLATHE | MECHFAB | PODFAB
 	materials = list(MAT_IRON = 700, MAT_GLASS = 60)
-	build_path = /obj/item/weapon/cell/high
+	build_path = /obj/item/weapon/cell/high/empty
 	category = "Engineering"
 
 /datum/design/super_cell
@@ -26,7 +26,7 @@
 	reliability_base = 75
 	build_type = PROTOLATHE | MECHFAB | PODFAB
 	materials = list(MAT_IRON = 700, MAT_GLASS = 70)
-	build_path = /obj/item/weapon/cell/super
+	build_path = /obj/item/weapon/cell/super/empty
 	category = "Engineering"
 
 /datum/design/hyper_cell
@@ -37,7 +37,7 @@
 	reliability_base = 70
 	build_type = PROTOLATHE | MECHFAB | PODFAB
 	materials = list(MAT_IRON = 400, MAT_GOLD = 150, MAT_SILVER = 150, MAT_GLASS = 70)
-	build_path = /obj/item/weapon/cell/hyper
+	build_path = /obj/item/weapon/cell/hyper/empty
 	category = "Engineering"
 
 /datum/design/light_replacer


### PR DESCRIPTION
It's become clear to me that a few people want to do this, but nobody wants to make the PR because they care too much about their image to deal with the backlash.
I don't give a fuck about my image so here you go. If this gets voted for, let it be, if it gets voted against, let it not be. I don't care.

Reasons for this change:
- Prevents R&D from cheesing power outages by just magically printing power out of nowhere.

- A less harsh nerf for silicon matsynth/RCD abuse. The last nerf for it had ~50% votes for, but maybe it was a little too much. This should be a little tamer.

- Maybe the cell charger will actually be used at all now.

Notes:
- Borg recharging stations automatically charge cells put into them for quickswap, so you don't need to charge those.
- Filling a hi-cap cell (10k) takes approx. the same amount of time as it takes a standard weapon charger to fill a stunbaton (1k). I have never heard of someone complain that weapon chargers take too long so I figure that's a good starting point. Remember that you can upgrade cell chargers to make them 3x faster.
- In case you didn't know because nobody ever uses them, R&D starts with a cell charger and so does Robotics.

:cl: (as the emoji)
 * tweak: Cell chargers are now 750% faster.
 * tweak: Cells made from Protolathes now start empty.
 * rscadd: You can now make cell charger circuitboards with a soldering iron.