### PR TITLE
Nanobots cannot be duped with service borg shakers

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -2811,6 +2811,7 @@
 	id = NANITES
 	description = "Microscopic construction robots."
 	reagent_state = SOLID
+	dupeable = FALSE
 	color = "#535E66" //rgb: 83, 94, 102
 	var/diseasetype = /datum/disease/robotic_transformation
 /datum/reagent/nanites/reaction_mob(var/mob/living/M, var/method = TOUCH, var/volume)
@@ -2846,6 +2847,7 @@
 	id = NANOBOTS
 	description = "Microscopic robots intended for use in humans. Must be loaded with further chemicals to be useful."
 	reagent_state = SOLID
+	dupeable = FALSE
 	color = "#3E3959" //rgb: 62, 57, 89
 
 
@@ -2856,6 +2858,7 @@
 	id = MEDNANOBOTS
 	description = "Microscopic robots intended for use in humans. Configured for rapid healing upon infiltration into the body."
 	reagent_state = SOLID
+	dupeable = FALSE
 	color = "#593948" //rgb: 89, 57, 72
 	custom_metabolism = 0.005
 	var/spawning_horror = 0
@@ -2943,6 +2946,7 @@
 	id = COMNANOBOTS
 	description = "Microscopic robots intended for use in humans. Configured to grant great resistance to damage."
 	reagent_state = SOLID
+	dupeable = FALSE
 	color = "#343F42" //rgb: 52, 63, 66
 	custom_metabolism = 0.01
 	var/has_been_armstrong = 0


### PR DESCRIPTION
As far as I can tell they were made non-dupable through odyseuss in a hacky way before the dupable var existed, this keeps consistency. Nanobots are supposed to have a very expensive recipe and being able to dupe it just like that is bad.