### PR TITLE
Fixes invisible spider queen corpse bug

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/base_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/base_spider.dm
@@ -50,7 +50,7 @@
 	var/busy = 0
 	var/poison_per_bite = 5
 	var/poison_type = TOXIN
-	var/delimbable_icon = 1
+	var/delimbable_icon = TRUE
 
 	//Spider aren't affected by atmos.
 	min_oxy = 0

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/base_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/base_spider.dm
@@ -50,6 +50,7 @@
 	var/busy = 0
 	var/poison_per_bite = 5
 	var/poison_type = TOXIN
+	var/delimbable_icon = 1
 
 	//Spider aren't affected by atmos.
 	min_oxy = 0
@@ -66,7 +67,7 @@
 /mob/living/simple_animal/hostile/giant_spider/update_icons()
 	.=..()
 
-	if(stat == DEAD && butchering_drops)
+	if(stat == DEAD && butchering_drops && delimbable_icon)
 		var/datum/butchering_product/spider_legs/our_legs = locate(/datum/butchering_product/spider_legs) in butchering_drops
 		if(istype(our_legs))
 			icon_state = "[icon_dead][(our_legs.amount<8) ? our_legs.amount : ""]"

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/nurse.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/nurse.dm
@@ -197,6 +197,7 @@ var/list/spider_queens = list()
 	projectilesound = 'sound/weapons/pierce.ogg'
 	ranged = 1
 	size = SIZE_HUGE
+	delimbable_icon = 0
 
 /mob/living/simple_animal/hostile/giant_spider/nurse/queen_spider/New()
 	..()

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/nurse.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/nurse.dm
@@ -197,7 +197,7 @@ var/list/spider_queens = list()
 	projectilesound = 'sound/weapons/pierce.ogg'
 	ranged = 1
 	size = SIZE_HUGE
-	delimbable_icon = 0
+	delimbable_icon = FALSE
 
 /mob/living/simple_animal/hostile/giant_spider/nurse/queen_spider/New()
 	..()


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl: (as the emoji)
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
Fixes #14998
Spider queens don't have icon states for having cut-off legs, so what this does is leave the icon alone.

:cl:
 * bugfix: Delimbing a dead spider queen will no longer make it invisible.