### PR TITLE
Makes bolas automatically throw when clicking.

### DIFF
--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -195,6 +195,9 @@
 	var/trip_prob = 90
 	var/thrown_from
 
+/obj/item/weapon/legcuffs/bolas/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
+	user.throw_item(target)
+
 /obj/item/weapon/legcuffs/bolas/suicide_act(mob/living/user)
 	to_chat(viewers(user), "<span class='danger'>[user] is wrapping the [src.name] around \his neck! It looks like \he's trying to commit suicide.</span>")
 	return(OXYLOSS)


### PR DESCRIPTION
Doesn't need throw mode to be on anymore.

webm: http://84.195.252.227/static/ShareX/2017/10/2017-10-28_23-55-40.webm

:cl:
* rscadd: Bolas now automatically throw, even when not in throw mode.
