### PR TITLE
Adds a box of Body Bags to the Sterile Equipment Crate

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1482,7 +1482,8 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	contains = list(/obj/item/clothing/under/rank/medical/green,
 					/obj/item/clothing/under/rank/medical/green,
 					/obj/item/weapon/storage/box/masks,
-					/obj/item/weapon/storage/box/gloves)
+					/obj/item/weapon/storage/box/gloves,
+					/obj/item/weapon/storage/box/bodybags)
 	cost = 15
 	containertype = "/obj/structure/closet/crate"
 	containername = "sterile equipment crate"


### PR DESCRIPTION
There isn't really a way to get more Body Bags as far as I know.  While there are plenty on the station to begin with, this was requested and I thought it seemed reasonable.

There are seven bags in each box, and Sterile Equipment seemed to be the best place to put them, but I could add a seperate crate if it's preferable.

I'll update the wiki if/when this goes through.

:cl:
 * tweak: The Sterile Equipment Crate from Cargo now includes one box of Body Bags.