### PR TITLE
Fix for xeno pockets

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/inventory.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/inventory.dm
@@ -70,7 +70,7 @@
 				W.dropped(src)
 			if(W)
 				W.reset_plane_and_layer()
-return 1
+	return 1
 
 
 //Literally copypasted /mob/proc/attack_ui(slot, hand_index) while replacing attack_hand with attack_alien

--- a/code/modules/mob/living/carbon/alien/humanoid/inventory.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/inventory.dm
@@ -67,7 +67,6 @@
 				W.reset_plane_and_layer()
 	return 1
 
-
 //Literally copypasted /mob/proc/attack_ui(slot, hand_index) while replacing attack_hand with attack_alien
 /mob/living/carbon/alien/humanoid/attack_ui(slot, hand_index)
 	var/obj/item/W = get_active_hand()

--- a/code/modules/mob/living/carbon/alien/humanoid/inventory.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/inventory.dm
@@ -37,6 +37,41 @@
 		if(slot_handcuffed)
 			return handcuffed
 	return null
+	
+/mob/living/carbon/alien/humanoid/u_equip(obj/item/W as obj, dropped = 1, var/slot = null)
+	if(!W)
+		return 0
+	var/success = 0
+	var/index = is_holding_item(W)
+	if(index)
+		held_items[index] = null
+		success = 1
+		update_inv_hand(index)
+	else if (W == r_store)
+		r_store = null
+		success = 1
+		slot = slot_r_store
+		update_inv_pockets()
+	else if (W == l_store)
+		l_store = null
+		success = 1
+		slot = slot_l_store
+		update_inv_pockets()
+	else
+		..()
+
+	if(success)
+		if (W)
+			if (client)
+				client.screen -= W
+			W.unequipped(src, slot)
+			if(dropped)
+				W.forceMove(loc)
+				W.dropped(src)
+			if(W)
+				W.reset_plane_and_layer()
+return 1
+
 
 //Literally copypasted /mob/proc/attack_ui(slot, hand_index) while replacing attack_hand with attack_alien
 /mob/living/carbon/alien/humanoid/attack_ui(slot, hand_index)

--- a/code/modules/mob/living/carbon/alien/humanoid/inventory.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/inventory.dm
@@ -38,7 +38,7 @@
 			return handcuffed
 	return null
 	
-/mob/living/carbon/alien/humanoid/u_equip(obj/item/W as obj, dropped = 1, var/slot = null)
+/mob/living/carbon/alien/humanoid/u_equip(obj/item/W, dropped = 1, var/slot = null)
 	if(!W)
 		return 0
 	var/success = 0

--- a/code/modules/mob/living/carbon/alien/humanoid/inventory.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/inventory.dm
@@ -42,12 +42,7 @@
 	if(!W)
 		return 0
 	var/success = 0
-	var/index = is_holding_item(W)
-	if(index)
-		held_items[index] = null
-		success = 1
-		update_inv_hand(index)
-	else if (W == r_store)
+	if (W == r_store)
 		r_store = null
 		success = 1
 		slot = slot_r_store


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl: (as the emoji)
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
Fixes #16215
Xenomorph pockets weren't nulling facehuggers taken out of them. Re-adding a u_equip for aliens corrects this without messing with the inventory code. I'd like suggestions for a more elegant solution though.

:cl:
 * bugfix: Things taken out of xenomorph pockets are now properly removed from the contents.