### PR TITLE
Buildmode/spawn QoL update

### DIFF
--- a/code/WorkInProgress/buildmode.dm
+++ b/code/WorkInProgress/buildmode.dm
@@ -111,6 +111,7 @@
 				to_chat(usr, "<span class='notice'>Right Mouse Button on buildmode button = Select var(type) & value</span>")
 				to_chat(usr, "<span class='notice'>Left Mouse Button on turf/obj/mob      = Set var(type) & value</span>")
 				to_chat(usr, "<span class='notice'>Right Mouse Button on turf/obj/mob     = Reset var's value</span>")
+				to_chat(usr, "<span class='notice'>Middle Mouse Button on turf/obj/mob    = Copy value from object</span>")
 				to_chat(usr, "<span class='notice'>***********************************************************</span>")
 			if(4)
 				to_chat(usr, "<span class='notice'>***********************************************************</span>")
@@ -204,8 +205,9 @@ obj/effect/bmode/buildholder/New()
 				if(edit_variable != "appearance") //Special case for appearance
 					master.buildmode.valueholder = variable_set(usr)
 	return 1
-/obj/effect/bmode/buildmode/DblClick(object,location,control,params)
-	return Click(object,location,control,params)
+
+///obj/effect/bmode/buildmode/DblClick(object,location,control,params)
+//	return Click(object,location,control,params)
 
 /client/MouseWheel(object,delta_x,delta_y,location,control,params)
 	if(istype(mob,/mob/dead/observer) || buildmode) //DEAD FAGS CAN ZOOM OUT THIS WILL END POORLY
@@ -584,19 +586,23 @@ obj/effect/bmode/buildholder/New()
 						to_chat(usr, "<span class='info'>You will now build [object.type] when clicking.</span>")
 
 		if(3)
-			if(pa.Find("left")) //I cant believe this shit actually compiles.
-				if(!object.vars.Find(holder.buildmode.varholder))
-					to_chat(usr, "<span class='warning'>[initial(object.name)] does not have a var called '[holder.buildmode.varholder]'</span>")
-					return
+			if(!object.vars.Find(holder.buildmode.varholder))
+				to_chat(usr, "<span class='warning'>[initial(object.name)] does not have a var called '[holder.buildmode.varholder]'</span>")
+				return
 
+			if(pa.Find("left")) //I cant believe this shit actually compiles.
 				setvar(holder.buildmode.varholder, holder.buildmode.valueholder, object, 0)
 
 			if(pa.Find("right"))
-				if(!object.vars.Find(holder.buildmode.varholder))
-					to_chat(usr, "<span class='warning'>[initial(object.name)] does not have a var called '[holder.buildmode.varholder]'</span>")
-					return
-
 				setvar(holder.buildmode.varholder, holder.buildmode.valueholder, object, 1) //Reset the var to its initial value
+
+			if(pa.Find("middle"))
+				if(holder.buildmode.varholder == "appearance") //Special case for appearance, as it doesn't behave like other varialbes
+					user.client.holder.marked_appearance = object
+				else
+					holder.buildmode.valueholder = object.vars[holder.buildmode.varholder]
+
+				to_chat(usr, "Copied '[holder.buildmode.varholder]' from [object].")
 
 		if(4)
 			if(pa.Find("left"))
@@ -634,7 +640,11 @@ obj/effect/bmode/buildholder/New()
 	if(!reset)
 		variable_set(usr, A, varname, value_override = varvalue, logging = log)
 	else
-		variable_set(usr, A, varname, value_override = initial(A.vars[varname]), logging = log)
+		var/init_value = initial(A.vars[varname])
+		if(varname == "appearance") //Appearance doesn't play by the rules
+			init_value = "initial"
+
+		variable_set(usr, A, varname, value_override = init_value, logging = log)
 
 #undef BOTTOM_LEFT
 #undef TOP_RIGHT

--- a/code/WorkInProgress/buildmode.dm
+++ b/code/WorkInProgress/buildmode.dm
@@ -206,9 +206,6 @@ obj/effect/bmode/buildholder/New()
 					master.buildmode.valueholder = variable_set(usr)
 	return 1
 
-///obj/effect/bmode/buildmode/DblClick(object,location,control,params)
-//	return Click(object,location,control,params)
-
 /client/MouseWheel(object,delta_x,delta_y,location,control,params)
 	if(istype(mob,/mob/dead/observer) || buildmode) //DEAD FAGS CAN ZOOM OUT THIS WILL END POORLY
 		if(delta_y > 0)

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -463,6 +463,9 @@ var/list/number_units=list(
 	"billion"
 )
 
+// The " character
+var/quote = ascii2text(34)
+
 /proc/num2words(var/number, var/zero="zero", var/minus="minus", var/hundred="hundred", var/list/digits=number_digits, var/list/tens=number_tens, var/list/units=number_units, var/recursion=0)
 	if(!isnum(number))
 		warning("num2words fed a non-number: [number]")

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1302,6 +1302,7 @@ var/global/floorIsLava = 0
 		if(!chosen)
 			return
 
+	//preloader is hooked to atom/New(), and is automatically deleted once it 'loads' an object
 	_preloader = new(varchanges, chosen)
 
 	if(ispath(chosen,/turf))

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1273,11 +1273,21 @@ var/global/floorIsLava = 0
 */
 /datum/admins/proc/spawn_atom(var/object as text)
 	set category = "Debug"
-	set desc = "(atom path) Spawn an atom. Finish path with a period to hide subtypes"
+	set desc = "(atom path) Spawn an atom. Finish path with a period to hide subtypes, include any variable changes at the end like so: {name=\"Test\";amount=50}"
 	set name = "Spawn"
 
 	if(!check_rights(R_SPAWN))
 		return
+
+	//Parse and strip any changed variables (added in curly brackets at the end of the input string)
+	var/variables_start = findtext(object,"{")
+
+	var/list/varchanges = list()
+	if(variables_start)
+		var/parameters = copytext(object,variables_start+1,length(object))//removing the last '}'
+		varchanges = readlist(parameters, ";")
+
+		object = copytext(object, 1, variables_start)
 
 	var/list/matches = get_matching_types(object, /atom)
 
@@ -1291,6 +1301,8 @@ var/global/floorIsLava = 0
 		chosen = input("Select an atom type", "Spawn Atom", matches[1]) as null|anything in matches
 		if(!chosen)
 			return
+
+	_preloader = new(varchanges, chosen)
 
 	if(ispath(chosen,/turf))
 		var/turf/T = get_turf(usr.loc)

--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -26,12 +26,20 @@ var/list/forbidden_varedit_object_types = list(
 			to_chat(usr, "You don't have a saved appearance!")
 			return
 		else
-			if(logging)
-				log_admin("[key_name(usr)] modified [edited_datum]'s appearance to [C.holder.marked_appearance]")
-
 			var/atom/A = edited_datum
-			A.appearance = C.holder.marked_appearance.appearance
-			to_chat(usr, "Changed [edited_datum]'s appearance to [C.holder.marked_appearance]")
+			if(value_override == "initial")
+				if(logging)
+					log_admin("[key_name(usr)] reset [edited_datum]'s appearance")
+
+				A.appearance = initial(A.appearance)
+				to_chat(usr, "Reset [edited_datum]'s appearance")
+
+			else
+				if(logging)
+					log_admin("[key_name(usr)] modified [edited_datum]'s appearance to [C.holder.marked_appearance]")
+
+				A.appearance = C.holder.marked_appearance.appearance
+				to_chat(usr, "Changed [edited_datum]'s appearance to [C.holder.marked_appearance]")
 			return
 
 	#define V_MARKED_DATUM "marked_datum"
@@ -59,7 +67,7 @@ var/list/forbidden_varedit_object_types = list(
 
 		old_value = edited_datum.vars[edited_variable]
 
-	if(!new_value)
+	if(isnull(new_value))
 		if(autoselect_var_type)
 			if(isnull(old_value))
 				to_chat(usr, "Unable to determine variable type.")
@@ -92,7 +100,7 @@ var/list/forbidden_varedit_object_types = list(
 				new_value = C.modify_matrix_menu(old_value) //Use a custom interface for matrix editing
 
 
-	if(!new_value) //If a custom interface hasn't already set the value
+	if(isnull(new_value)) //If a custom interface hasn't already set the value
 		//Build the choices list
 		var/list/choices = list(\
 		"text" = V_TEXT,

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -315,7 +315,7 @@ var/list/map_dimension_cache = list()
 
 //text trimming (both directions) helper proc
 //optionally removes quotes before and after the text (for variable name)
-/dmm_suite/proc/trim_text(var/what as text,var/trim_quotes=0)
+/proc/trim_text(var/what as text,var/trim_quotes=0)
 	while(length(what) && (findtext(what," ",1,2)))
 		what=copytext(what,2,0)
 	while(length(what) && (findtext(what," ",length(what),0)))
@@ -329,7 +329,7 @@ var/list/map_dimension_cache = list()
 
 //find the position of the next delimiter,skipping whatever is comprised between opening_escape and closing_escape
 //returns 0 if reached the last delimiter
-/dmm_suite/proc/find_next_delimiter_position(var/text as text,var/initial_position as num, var/delimiter=",",var/opening_escape=quote,var/closing_escape=quote)
+/proc/find_next_delimiter_position(var/text as text,var/initial_position as num, var/delimiter=",",var/opening_escape=quote,var/closing_escape=quote)
 	var/position = initial_position
 	var/next_delimiter = findtext(text,delimiter,position,0)
 	var/next_opening = findtext(text,opening_escape,position,0)
@@ -344,7 +344,7 @@ var/list/map_dimension_cache = list()
 
 //build a list from variables in text form (e.g {var1="derp"; var2; var3=7} => list(var1="derp", var2, var3=7))
 //return the filled list
-/dmm_suite/proc/readlist(var/text as text,var/delimiter=",")
+/proc/readlist(var/text as text,var/delimiter=",")
 
 
 	var/list/to_return = list()


### PR DESCRIPTION
* Spawn and create-datum can automatically change the freshly spawned object's variables if you append all changes at the end of the input string like so:
spawn "/mob/living/carbon/human{name = "Red Dude";color="#FF0000"}"
spawn "/obj/item/stack/sheet/metal{amount=50}"
spawn "/obj/item.{icon_state="hammer";name="Hammer";force=20}"

* Fixed some bugs with buildmode:
  * Fixed the GUI buttons being super sensitive to mouse clicks
  * Fixed weird behaviour when setting a variable to 0
  * Fixed being unable to reset things to their initial appearance sometimes
* In buildmode's edit variable mode, use the middle mouse button to copy the variable's value from an object (also works for appearances).

![qol_of_life](https://user-images.githubusercontent.com/9512290/32141598-a1ea8000-bc84-11e7-9603-b6834bf20b22.gif)

:cl:
 * experiment: The "spawn" and "create-datum" admin commands can change the new object's variables automatically after spawning it. Append any variable changes at the end of the string in curly brackets like so: spawn "/obj/item.{name="Item" ; w_class=5}"
 * bugfix: Fixed some bugs with buildmode's edit mode (fixed strange behaviour when setting values to 0, fixed inability to reset object appearances). While in edit mode, middle-click any object to copy its variable.
