### PR TITLE
Add ctrl+click and alt+click shortcuts for cryo, as well as a verb to remove beakers.

### DIFF
--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -197,7 +197,7 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 					count++
 				else
 					to_chat(user, "A figure floats in the depths, they appear to be [floater.name]")
-			
+
 			if (count)
 				// Let's just assume you can only have observers if there's a mob too.
 				to_chat(user, "<i>...[count] shape\s float behind them...</i>")
@@ -635,6 +635,20 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 	if (usr.isUnconscious() || stat & (NOPOWER|BROKEN))
 		return
 	put_mob(usr)
+	return
+
+/obj/machinery/atmospherics/unary/cryo_cell/verb/remove_beaker()
+	set name = "Remove beaker"
+	set category = "Object"
+	set src in oview(1)
+	if(usr.incapacitated() || usr.lying || usr.locked_to || !(iscarbon(usr) || issilicon(usr))) //are you cuffed, dying, lying, stunned or other
+		return
+	if(panel_open)
+		to_chat(usr, "<span class='bnotice'>Close the maintenance panel first.</span>")
+		return
+	if(beaker)// If there is, effectively, a beaker
+		detach()
+	add_fingerprint(usr)
 	return
 
 /obj/machinery/atmospherics/unary/cryo_cell/return_air()

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -649,7 +649,6 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 	if(beaker)// If there is, effectively, a beaker
 		detach()
 	add_fingerprint(usr)
-	return
 
 /obj/machinery/atmospherics/unary/cryo_cell/return_air()
 	return air_contents

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -601,26 +601,10 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 	set name = "Eject occupant"
 	set category = "Object"
 	set src in oview(1)
-	if(panel_open)
-		to_chat(usr, "<span class='bnotice'>Close the maintenance panel first.</span>")
-		return
-	if(usr == occupant)//If the user is inside the tube...
-		if (usr.isDead())//and he's not dead....
-			return
-		to_chat(usr, "<span class='notice'>Release sequence activated. This will take thirty seconds.</span>")
-		sleep(300)
-		if(!src || !usr || !occupant || (occupant != usr)) //Check if someone's released/replaced/bombed him already
-			return
-		go_out()//and release him from the eternal prison.
-	else
-		if (usr.isUnconscious() || istype(usr, /mob/living/simple_animal))
-			return
-		go_out()
-	add_fingerprint(usr)
-	return
+	AltClick(usr)
 
 /obj/machinery/atmospherics/unary/cryo_cell/verb/move_inside()
-	set name = "Move Inside"
+	set name = "Move inside"
 	set category = "Object"
 	set src in oview(1)
 	if(usr.incapacitated() || usr.lying || usr.locked_to) //are you cuffed, dying, lying, stunned or other
@@ -635,20 +619,12 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 	if (usr.isUnconscious() || stat & (NOPOWER|BROKEN))
 		return
 	put_mob(usr)
-	return
 
 /obj/machinery/atmospherics/unary/cryo_cell/verb/remove_beaker()
 	set name = "Remove beaker"
 	set category = "Object"
 	set src in oview(1)
-	if(usr.incapacitated() || usr.lying || usr.locked_to || !(iscarbon(usr) || issilicon(usr))) //are you cuffed, dying, lying, stunned or other
-		return
-	if(panel_open)
-		to_chat(usr, "<span class='bnotice'>Close the maintenance panel first.</span>")
-		return
-	if(beaker)// If there is, effectively, a beaker
-		detach()
-	add_fingerprint(usr)
+	CtrlClick(usr)
 
 /obj/machinery/atmospherics/unary/cryo_cell/return_air()
 	return air_contents
@@ -666,6 +642,35 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 		message_admins("[key_name(L)] has ejected [occupant] from \the [src]! [formatJumpTo(src)]")
 		go_out()
 
+/obj/machinery/atmospherics/unary/cryo_cell/AltClick(mob/user as mob) // AltClick = most common action = removing the patient
+	if(!Adjacent(user))
+		return
+	if(panel_open)
+		to_chat(user, "<span class='bnotice'>Close the maintenance panel first.</span>")
+		return
+	if(user == occupant)//If the user is inside the tube...
+		if (user.isDead())//and he's not dead....
+			return
+		to_chat(user, "<span class='notice'>Release sequence activated. This will take thirty seconds.</span>")
+		sleep(300)
+		if(!src || !user || !occupant || (occupant != user)) //Check if someone's released/replaced/bombed him already
+			return
+		go_out()//and release him from the eternal prison.
+	else
+		if (user.isUnconscious() || istype(user, /mob/living/simple_animal))
+			return
+		go_out()
+	add_fingerprint(user)
+
+/obj/machinery/atmospherics/unary/cryo_cell/CtrlClick(mob/user as mob) // CtrlClick = less common action = retrieving the beaker
+	if(!Adjacent(user) || user.incapacitated() || user.lying || user.locked_to || !(iscarbon(user) || issilicon(user))) //are you cuffed, dying, lying, stunned or other
+		return
+	if(panel_open)
+		to_chat(user, "<span class='bnotice'>Close the maintenance panel first.</span>")
+		return
+	if(beaker)// If there is, effectively, a beaker
+		detach()
+	add_fingerprint(user)
 
 /datum/data/function/proc/reset()
 	return

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -642,7 +642,7 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 		message_admins("[key_name(L)] has ejected [occupant] from \the [src]! [formatJumpTo(src)]")
 		go_out()
 
-/obj/machinery/atmospherics/unary/cryo_cell/AltClick(mob/user as mob) // AltClick = most common action = removing the patient
+/obj/machinery/atmospherics/unary/cryo_cell/AltClick(mob/user) // AltClick = most common action = removing the patient
 	if(!Adjacent(user))
 		return
 	if(panel_open)
@@ -662,8 +662,8 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 		go_out()
 	add_fingerprint(user)
 
-/obj/machinery/atmospherics/unary/cryo_cell/CtrlClick(mob/user as mob) // CtrlClick = less common action = retrieving the beaker
-	if(!Adjacent(user) || user.incapacitated() || user.lying || user.locked_to || !(iscarbon(user) || issilicon(user))) //are you cuffed, dying, lying, stunned or other
+/obj/machinery/atmospherics/unary/cryo_cell/CtrlClick(mob/user) // CtrlClick = less common action = retrieving the beaker
+	if(!Adjacent(user) || user.incapacitated() || user.lying || user.locked_to || user == occupant || !(iscarbon(user) || issilicon(user))) //are you cuffed, dying, lying, stunned or other
 		return
 	if(panel_open)
 		to_chat(user, "<span class='bnotice'>Close the maintenance panel first.</span>")


### PR DESCRIPTION
Reasoning : you can remove the patient with both the verb and nanoUI, why not do the same with the beaker ?
And while we're at it, why not add some shortcuts to have a better _quality of life_ ?
(oh and I removed a trailing return and a typo error in passing)
Tested.
Fixes #16342
:cl:
- tweak: You can now remove the beaker from a cryotube with a verb accessible in the right-click contextual menu.
- rscadd: Adds shortcuts to the cryocell. Alt+click to remove the patient within it (including yourself), Ctrl+click to remove the beaker.