### PR TITLE
Removes Leftover Debug Message

### DIFF
--- a/code/modules/medical/computer/cloning.dm
+++ b/code/modules/medical/computer/cloning.dm
@@ -411,7 +411,6 @@
 		scantemp = "Error: No signs of intelligence detected." //Self explainatory
 		return
 	if(!subject.mind) //This human was never controlled by a player, so they can't be cloned
-		to_chat(world, "[subject] HAS NO MIND")
 		scantemp = "Error: Mental interface failure."
 		return
 


### PR DESCRIPTION
It's a to_chat(world), so every player in the server was being informed when a monkeyman or something gets scanned in the cloner.