### PR TITLE
Integrated hailer for Security PDAs

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -8,6 +8,7 @@
 #define SCANMODE_ATMOS		5
 #define SCANMODE_DEVICE		6
 #define SCANMODE_ROBOTICS	7
+#define SCANMODE_HAILER		8
 
 #define PDA_MINIMAP_WIDTH	256
 #define PDA_MINIMAP_OFFSET_X	8
@@ -59,6 +60,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	var/obj/item/device/paicard/pai = null	// A slot for a personal AI device
 	var/obj/item/device/analyzer/atmos_analys = new
 	var/obj/item/device/robotanalyzer/robo_analys = new
+	var/obj/item/device/hailer/integ_hailer = new
 	var/obj/item/device/device_analyser/dev_analys = null
 
 	var/MM = null
@@ -740,7 +742,9 @@ var/global/list/obj/item/device/pda/PDAs = list()
 
 						dat += {"<h4>Security Functions</h4>
 							<ul>
-							<li><a href='byond://?src=\ref[src];choice=45'><span class='pda_icon pda_cuffs'></span> Security Records</A></li>"}
+							<li><a href='byond://?src=\ref[src];choice=45'><span class='pda_icon pda_cuffs'></span> Security Records</A></li>
+							<li><a href='byond://?src=\ref[src];choice=Integrated Hailer'><span class='pda_icon pda_signaler'></span> [scanmode == SCANMODE_HAILER ? "Disable" : "Enable"] Integrated Hailer</a></li>
+							"}
 					if(istype(cartridge.radio, /obj/item/radio/integrated/beepsky))
 
 						dat += {"<li><a href='byond://?src=\ref[src];choice=46'><span class='pda_icon pda_cuffs'></span> Security Bot Access</a></li>
@@ -1723,6 +1727,11 @@ var/global/list/obj/item/device/pda/PDAs = list()
 					scanmode = SCANMODE_NONE
 				else if((!isnull(cartridge)) && (cartridge.access_engine))
 					scanmode = SCANMODE_HALOGEN
+			if("Integrated Hailer")
+				if(scanmode == SCANMODE_HAILER)
+					scanmode = SCANMODE_NONE
+				else if((!isnull(cartridge)) && (cartridge.access_security))
+					scanmode = SCANMODE_HAILER
 			if("Honk")
 				if ( !(last_honk && world.time < last_honk + 20) )
 					playsound(loc, 'sound/items/bikehorn.ogg', 50, 1)
@@ -2309,6 +2318,12 @@ obj/item/device/pda/AltClick()
 		robo_analys.cant_drop = 1
 		if(!A.attackby(robo_analys, user))
 			robo_analys.afterattack(A, user, 1)
+
+	else if(scanmode == SCANMODE_HAILER)
+		if(!integ_hailer)
+			return
+		integ_hailer.cant_drop = 1
+		integ_hailer.afterattack(A, user, proximity_flag)
 
 	else if (!scanmode && istype(A, /obj/item/weapon/paper) && owner)
 		note = A:info

--- a/code/game/objects/items/devices/whistle.dm
+++ b/code/game/objects/items/devices/whistle.dm
@@ -24,12 +24,12 @@
 
 /obj/item/device/hailer/proc/do_your_sound(var/mob/user)
 	if(emagged && insults)
-		playsound(get_turf(src), 'sound/voice/binsult.ogg', 100, 1, vary = 0)
+		playsound(get_turf(user), 'sound/voice/binsult.ogg', 100, 1, vary = 0)
 		insults--
 	else
-		playsound(get_turf(src), 'sound/voice/halt.ogg', 100, 1, vary = 0)
+		playsound(get_turf(user), 'sound/voice/halt.ogg', 100, 1, vary = 0)
 	if(user)
-		var/list/bystanders = get_hearers_in_view(world.view, src)
+		var/list/bystanders = get_hearers_in_view(world.view, user)
 		flick_overlay(image('icons/mob/talk.dmi', user, "hail", MOB_LAYER+1), clients_in_moblist(bystanders), 2 SECONDS)
 	nextuse = world.time + cooldown
 
@@ -78,7 +78,7 @@
 		return
 
 	// ~ drawing the images ~ //
-	var/list/bystanders = get_hearers_in_view(world.view, src)
+	var/list/bystanders = get_hearers_in_view(world.view, user)
 	for(var/mob/living/M in suspects)
 		flick_overlay(image('icons/mob/talk.dmi', M, "halt", MOB_LAYER+1), clients_in_moblist(bystanders), 2 SECONDS) //One image for each suspect
 


### PR DESCRIPTION
Because the hailer is nice but not "worth a slot in my belt" nice.

:cl:
 * rscadd: Security PDAs can now enable an integrated hailer from the PDA menu, similar to other gadgets in PDAs.

