### PR TITLE
More holster sanity (hopefully)

### DIFF
--- a/code/modules/clothing/accessories/holster.dm
+++ b/code/modules/clothing/accessories/holster.dm
@@ -39,7 +39,7 @@
 		to_chat(user, "<span class='warning'>You can't hold \the [holstered] like this!</span>")
 		return
 
-	if(user.put_in_hands(holstered))
+	if(user.put_in_empty_hands(holstered))
 		unholster_message(user)
 		holstered.add_fingerprint(user)
 		holstered = null

--- a/code/modules/clothing/accessories/holster.dm
+++ b/code/modules/clothing/accessories/holster.dm
@@ -39,7 +39,7 @@
 		to_chat(user, "<span class='warning'>You can't hold \the [holstered] like this!</span>")
 		return
 
-	if(user.put_in_empty_hands(holstered))
+	if(user.put_in_active_hand(holstered) || user.put_in_inactive_hand(holstered))
 		unholster_message(user)
 		holstered.add_fingerprint(user)
 		holstered = null

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -236,7 +236,6 @@
 //Puts the item our active hand if possible. Failing that it tries our inactive hand. Returns 1 on success.
 //If both fail it drops it on the floor and returns 0.
 //This is probably the main one you need to know :)
-
 /mob/proc/put_in_empty_hands(var/obj/item/W) // This proc won't put things on the grounds in case of failure. Useful for holsters
 	if(!W)
 		return 0

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -236,19 +236,14 @@
 //Puts the item our active hand if possible. Failing that it tries our inactive hand. Returns 1 on success.
 //If both fail it drops it on the floor and returns 0.
 //This is probably the main one you need to know :)
-/mob/proc/put_in_empty_hands(var/obj/item/W) // This proc won't put things on the grounds in case of failure. Useful for holsters
+/mob/proc/put_in_hands(var/obj/item/W)
 	if(!W)
 		return 0
 	if(put_in_active_hand(W))
 		return 1
 	else if(put_in_inactive_hand(W))
 		return 1
-	else return 0
-
-/mob/proc/put_in_hands(var/obj/item/W)
-	if(!W)
-		return 0
-	if(!put_in_empty_hands(W))
+	else
 		W.forceMove(get_turf(src))
 		W.reset_plane_and_layer()
 		W.dropped()

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -236,14 +236,20 @@
 //Puts the item our active hand if possible. Failing that it tries our inactive hand. Returns 1 on success.
 //If both fail it drops it on the floor and returns 0.
 //This is probably the main one you need to know :)
-/mob/proc/put_in_hands(var/obj/item/W)
+
+/mob/proc/put_in_empty_hands(var/obj/item/W) // This proc won't put things on the grounds in case of failure. Useful for holsters
 	if(!W)
 		return 0
 	if(put_in_active_hand(W))
 		return 1
 	else if(put_in_inactive_hand(W))
 		return 1
-	else
+	else return 0
+
+/mob/proc/put_in_hands(var/obj/item/W)
+	if(!W)
+		return 0
+	if(!put_in_empty_hands(W))
 		W.forceMove(get_turf(src))
 		W.reset_plane_and_layer()
 		W.dropped()


### PR DESCRIPTION
Creates a new proc, `put_in_empty_hands`, which put things in your hands if there is room for it and does nothing otherwise.
The old `put_in_hands` is for all intents and purposes similar to the one in this PR.
Not sure if there is anything I can do about the double `if(!W)`.
Should fix #16329.

Tested with knife holster, working as intended (a proper message failure, and only that, when I try to holster my knife.)

:cl:
- bugfix: Fixes sanity issues with knife and gun holsters. 
