### PR TITLE
Removes unnecessary delays on handled attackby.

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -113,10 +113,8 @@
 				resolved = A.attackby(held_item, src, params)
 				if(ismob(A) || istype(A, /obj/mecha) || istype(held_item, /obj/item/weapon/grab))
 					delayNextAttack(item_attack_delay)
-				if(!resolved && A && held_item)
+				if(!resolved && A && !A.gcDestroyed && held_item)
 					held_item.afterattack(A,src,1,params) // 1 indicates adjacency
-				else
-					delayNextAttack(item_attack_delay)
 		else
 			if(ismob(A) || istype(held_item, /obj/item/weapon/grab))
 				delayNextAttack(10)


### PR DESCRIPTION
You know how when wrenching pipes, if you misclick and hit one you already placed, you can't place pipes for a moment?

Yeah some genius decided that if an attackby is handled it MUST generate a cooldown. Every object that DIDN'T have a cooldown on attackby was literally misusing attackby.

This dumb cooldown is finally removed. There's still cooldowns on attacking and stuff as far as I can tell.

If anything becomes exploitable and spam clickable we can fix that later.
