### PR TITLE
Fix null screens on clientless mobs

### DIFF
--- a/code/game/dna/genes/vg_powers.dm
+++ b/code/game/dna/genes/vg_powers.dm
@@ -141,9 +141,11 @@ var/noir_master = list(new /obj/abstract/screen/plane_master/noir_master(),new /
 /datum/dna/gene/basic/noir/activate(var/mob/M)
 	..()
 	M.update_colour()
-	M.client.screen += noir_master
+	if(M.client) // wow it's almost like non-client mobs can get mutations!
+		M.client.screen += noir_master
 
 /datum/dna/gene/basic/noir/deactivate(var/mob/M,var/connected,var/flags)
 	if(..())
 		M.update_colour()
-		M.client.screen -= noir_master
+		if(M.client)
+			M.client.screen -= noir_master


### PR DESCRIPTION
Because wow it's almost like genetic's test dummy humans exist and don't have clients