### PR TITLE
Adds the ability to toggle subspace transmission on mech radios

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1514,7 +1514,7 @@
 						<span id="rfreq">[format_frequency(radio.frequency)]</span>
 						<a href='?src=\ref[src];rfreq=2'>+</a>
 						<a href='?src=\ref[src];rfreq=10'>+</a><br>
-						<a href='?src=\ref[src];subspace=1'>Toggle Broadcast Mode</a><br>
+						Subspace transmission: <a href='?src=\ref[src];subtoggle=1'><span id="substate">[radio.subspace_transmission?"Enabled":"Disabled"]</span></a><br>
 						</div>
 						</div>
 						<div class='wr'>
@@ -1707,11 +1707,12 @@
 		radio.set_frequency(new_frequency)
 		send_byjax(src.occupant,"exosuit.browser","rfreq","[format_frequency(radio.frequency)]")
 		return
-	if (href_list["subspace"])
+	if (href_list["subtoggle"])
 		if(usr != src.occupant)
 			return
-		subspace_transmission = !subspace_transmission
-		to_chat(usr, "Subspace Transmission is [(radio.subspace_transmission) ? "enabled" : "disabled"]")
+		radio.subspace_transmission = !radio.subspace_transmission
+		send_byjax(src.occupant,"exosuit.browser","substate",(radio.subspace_transmission?"Enabled":"Disabled"))
+		return
 	if(href_list["port_disconnect"])
 		if(usr != src.occupant)
 			return

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1514,6 +1514,7 @@
 						<span id="rfreq">[format_frequency(radio.frequency)]</span>
 						<a href='?src=\ref[src];rfreq=2'>+</a>
 						<a href='?src=\ref[src];rfreq=10'>+</a><br>
+						<a href='?src=\ref[src];subspace=1'>Toggle Broadcast Mode</a><br>
 						</div>
 						</div>
 						<div class='wr'>
@@ -1706,6 +1707,11 @@
 		radio.set_frequency(new_frequency)
 		send_byjax(src.occupant,"exosuit.browser","rfreq","[format_frequency(radio.frequency)]")
 		return
+	if (href_list["subspace"])
+		if(usr != src.occupant)
+			return
+		subspace_transmission = !subspace_transmission
+		to_chat(usr, "Subspace Transmission is [(radio.subspace_transmission) ? "enabled" : "disabled"]")
 	if(href_list["port_disconnect"])
 		if(usr != src.occupant)
 			return


### PR DESCRIPTION
Gives the same functionality to mech radios that silicon radios have. Turn off subspace transmission to make it operate like an SBR for when comms are down.
:cl:
 * rscadd: Added the ability to toggle subspace transmission on mech radios.