### PR TITLE
Toggle for catatonic/braindead messages on examine

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -236,7 +236,7 @@
 			if(!key)
 				msg += "<span class='deadsay'>[t_He] [t_is] totally catatonic. The stresses of life in deep space must have been too much for [t_him]. Any recovery is unlikely.</span>\n"
 			else if(!client)
-				msg += "[t_He] [t_has] a vacant, braindead stare...\n""
+				msg += "[t_He] [t_has] a vacant, braindead stare...\n"
 
 	var/list/wound_flavor_text = list()
 	var/list/is_destroyed = list()

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -231,11 +231,12 @@
 
 	msg += "</span>"
 
-	if(has_brain() && stat != DEAD)
-		if(!key)
-			msg += "<span class='deadsay'>[t_He] [t_is] totally catatonic. The stresses of life in deep space must have been too much for [t_him]. Any recovery is unlikely.</span>\n"
-		else if(!client)
-			msg += "[t_He] [t_has] a vacant, braindead stare...\n"
+	if(show_client_status_on_examine || isAdminGhost(user))
+		if(has_brain() && stat != DEAD)
+			if(!key)
+				msg += "<span class='deadsay'>[t_He] [t_is] totally catatonic. The stresses of life in deep space must have been too much for [t_him]. Any recovery is unlikely.</span>\n"
+			else if(!client)
+				msg += "[t_He] [t_has] a vacant, braindead stare...\n""
 
 	var/list/wound_flavor_text = list()
 	var/list/is_destroyed = list()

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -91,4 +91,6 @@
 	fire_sprite = "Standing"
 	plane = HUMAN_PLANE
 
+	var/show_client_status_on_examine = TRUE //If false, don't display catatonic/braindead messages to non-admins
+
 	var/become_zombie_after_death = FALSE


### PR DESCRIPTION
for admin events and such, to prevent destruction of immersions