### PR TITLE
gee supply borg, how come your AI let you have TWO sheet inserters

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -364,7 +364,6 @@
 	W.amount = 24
 	W.max_amount = 24
 	modules += W
-	modules += new /obj/item/weapon/gripper/no_use/inserter(src)
 
 	sensor_augs = list("Mesons", "Disable")
 	fix_modules()


### PR DESCRIPTION
:cl:
 * rscdel: Removes the duplicated sheet inserter from supply borgs