### PR TITLE
Makes genetic powers have a guaranteed chance to manifest

### DIFF
--- a/code/game/dna/genes/gene.dm
+++ b/code/game/dna/genes/gene.dm
@@ -103,7 +103,7 @@
 	var/mutation=0
 
 	// Activation probability
-	var/activation_prob=45
+	var/activation_prob=100 //THE GUAC
 
 	// Possible activation messages
 	var/list/activation_messages=list()

--- a/code/game/dna/genes/powers.dm
+++ b/code/game/dna/genes/powers.dm
@@ -313,7 +313,7 @@
 	drug_deactivation_messages=list("You feel normal again.")
 
 	mutation=M_TK
-	activation_prob=15
+	activation_prob=100 //Redundant but hey it's worth a shot
 
 	New()
 		block=TELEBLOCK


### PR DESCRIPTION
This is my first PR on vgstation, couldn't have made this PR without the aid of @unid15 . I am not actually sure if it works, but it's a few harmless numbers. I will test this locally as soon as possible.
The problem with genetics is that it's a very long task. There are 54 different blocks that you have to get to their respective thresholds to activate them. However, genetic powers have only a chance, on top of being lucky enough to reach the threshold, to manifest. The genetics machine is already unreliable because of the high chance of other blocks being affected aside from the one you've changed, and upgrading the components only causes injectors to recharge faster. This PR has been made with the purpose of making genetics less annoying on the long-term, and hopefully make it at least a bit faster as you won't waste too much time irradiating yourself with the injectors until the power actually manifests.

:cl:
 * rscadd: Genetic powers now always manifest, instead of having a random chance