### PR TITLE
Fixes telecomms overheating and potentially other stuff

### DIFF
--- a/code/ZAS/_gas_mixture.dm
+++ b/code/ZAS/_gas_mixture.dm
@@ -150,6 +150,7 @@
 
 
 //Variadic version of adjust_gas_temp(). Takes any number of gas, mole and temperature associations and applies them.
+//This proc is evil. Temperature will not behave how you expect it to. You have been warned.
 /datum/gas_mixture/proc/adjust_multi_temp()
 	ASSERT(!(args.len % 3))
 
@@ -165,11 +166,15 @@
 	if(!giver)
 		return 0
 
-	adjust_multi_temp(\
-		"oxygen", giver.oxygen, giver.temperature,\
-		"nitrogen", giver.nitrogen, giver.temperature,\
-		"plasma", giver.toxins, giver.temperature,\
-		"carbon_dioxide", giver.carbon_dioxide, giver.temperature)
+	var/self_heat_capacity = heat_capacity()
+	var/giver_heat_capacity = giver.heat_capacity()
+
+	temperature = (temperature * self_heat_capacity + giver.temperature * giver_heat_capacity) / (self_heat_capacity + giver_heat_capacity)
+	adjust_multi(\
+		"oxygen", giver.oxygen,\
+		"nitrogen", giver.nitrogen,\
+		"plasma", giver.toxins,\
+		"carbon_dioxide", giver.carbon_dioxide)
 
 	if(giver.trace_gases.len) //This really should use adjust(), but I think it would break things, and I don't care enough to fix a system I'm removing soon anyway.
 		for(var/datum/gas/trace_gas in giver.trace_gases)

--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -250,14 +250,8 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 		var/turf/simulated/L = loc
 		if(istype(L))
 			var/datum/gas_mixture/env = L.return_air()
-			var/transfer_moles = 0.25 * env.total_moles()
-			var/datum/gas_mixture/removed = env.remove(transfer_moles)
-
-			if(removed)
-				var/heat_capacity = removed.heat_capacity() || 1 // Prevent division by zero
-				removed.temperature += heating_power/heat_capacity
-				L.assume_air(removed)
-				use_power(heating_power / 1000) // This doesn't work?
+			env.add_thermal_energy(heating_power)
+			use_power(heating_power / 1000) // This doesn't work?
 /*
 	The receiver idles and receives messages from subspace-compatible radio equipment;
 	primarily headsets. They then just relay this information to all linked devices,


### PR DESCRIPTION
Fixes #16452

These calculations seem like they'd be equivalent, but apparently are not. The proof of this is presumably not very hard, but definitely way more tedious than I am willing to put up with.

Under constant strain, telecomms reaches equilibrium around -70 or -75 Celsius. Is this what it was before? I sure fucking hope so because I have no idea what else could have changed to affect that

Oh, and just for good measure, telecomms machinery now actually uses the correct proc to heat the environment, as well.