### PR TITLE
Adds a way to make the fixovein and bone gel.

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -764,6 +764,34 @@
 	required_reagents = list(NANOBOTS = 1, MUTAGEN = 5, SILICATE = 5, IRON = 10)
 	result_amount = 2.5
 
+//Surgery tools from chemicals because why not? Requires a vial to make them and consumes it as a part of making the tool.
+//DO NOT COPY PASTE THESE WITHOUT SOME KIND OF CONTAINER/HOLDER CHECK BECAUSE qdel WILL DELETE ANY REAGENT CONTAINER WITHOUT IT. IE PLAYERS
+/datum/chemical_reaction/fixoveinmake
+	name = "FixOVein"
+	id = "fixovein"
+	result = null
+	required_reagents = list(BICARIDINE = 10, CLONEXADONE = 10)
+	result_amount = 1
+	required_container = /obj/item/weapon/reagent_containers/glass/beaker/vial //safety net and a case for the "crafting" of the tool
+
+/datum/chemical_reaction/fixoveinmake/on_reaction(var/datum/reagents/holder)
+	var/location = get_turf(holder.my_atom)
+	new /obj/item/weapon/FixOVein(location)
+	qdel(holder.my_atom)
+
+/datum/chemical_reaction/bonegelmake
+	name = "Bone Gel"
+	id = "bonegel"
+	result = null
+	required_reagents = list(MILK = 10, CRYOXADONE = 10) //milk is good for the bones
+	result_amount = 1
+	required_container = /obj/item/weapon/reagent_containers/glass/beaker/vial
+
+/datum/chemical_reaction/bonegelmake/on_reaction(var/datum/reagents/holder)
+	var/location = get_turf(holder.my_atom)
+	new /obj/item/weapon/bonegel(location)
+	qdel(holder.my_atom)
+
 ///////////////////////////////////////////////////////////////////////////////////
 
 //Foam and foam precursor


### PR DESCRIPTION
Currently there's not a very fast way to get an actual fixOvein or bone gel. While the ghetto tools do exist and you can order them from cargo it seems odd how all the other tools can be made in the auto lathe with ease. While I could have just added them to the lathe I decided I would give it a bit more of a medical approach to obtaining them and make them like a craft item for chemistry.
To make a bone gel you need 10u of milk and 10u of cryoxadone and for the fixOvein you need 10u bicaridine and 10u clonexadone. A big part to these is where the reaction occurs. <h1> You must do these reactions inside a vial!</h1>
This is done for two reasons, to make it look like a small tube is consumed in their creation and so you can't do the reaction inside something that would cause big issues since it consumes the container. IE say you did the reaction inside a person. That person would go poof.
:cl:
* rscadd: Bone gels can now be created. It requires you to mix 10u of milk and 10u of cryoxadone inside a vial.
* rscadd: Fix O veins can now be created as well. It requires you to mix 10u of bicaridine and 10u clonexadone inside a vial.