### PR TITLE
Camera bug tweaks

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -428,7 +428,28 @@ its easier to just keep the beam vertical.
 			to_chat(user, harm_label_examine[1])
 		else
 			to_chat(user, harm_label_examine[2])
-	return
+
+	var/obj/item/device/camera_bug/bug = locate() in src
+	if(bug)
+		var/this_turf = get_turf(src)
+		var/user_turf = get_turf(user)
+		var/distance = get_dist(this_turf, user_turf)
+		if(Adjacent(user))
+			to_chat(user, "<a href='?src=\ref[src];bug=\ref[bug]'>There's something hidden in there.</a>")
+		else if(isobserver(user) || prob(100 / (distance + 2)))
+			to_chat(user, "There's something hidden in there.")
+
+/atom/Topic(href, href_list)
+	. = ..()
+	if(.)
+		return
+	var/obj/item/device/camera_bug/bug = locate(href_list["bug"])
+	if(istype(bug))
+		. = 1
+		if(isAdminGhost(usr))
+			bug.removed(null, null, FALSE)
+		if(ishuman(usr) && !usr.incapacitated() && Adjacent(usr) && usr.dexterity_check())
+			bug.removed(usr)
 
 // /atom/proc/MouseDrop_T()
 // 	return

--- a/code/game/objects/items/devices/camera_bug.dm
+++ b/code/game/objects/items/devices/camera_bug.dm
@@ -29,7 +29,7 @@
 
 /obj/item/device/camera_bug/afterattack(var/atom/A, var/mob/user, var/proximity_flag)
 	if(!proximity_flag)
-		to_chat(user, "<span class='warning'>You're too far away.</span>")
+		to_chat(user, "<span class='warning'>You can't seem to reach \the [A].</span>")
 		return 0
 	var/atom/movable/AM = A
 	if(isatommovable(AM))
@@ -84,7 +84,8 @@
 		user.put_in_hands(src)
 	else
 		forceMove(get_turf(src))
-	visible_message(message)
+	if(message)
+		visible_message(message)
 	if(catastrophic)
 		spawn(0.5 SECONDS)
 			explosion(loc, 0, prob(15), 2, 0)

--- a/code/game/objects/items/devices/camera_bug.dm
+++ b/code/game/objects/items/devices/camera_bug.dm
@@ -7,59 +7,86 @@
 	item_state = ""
 	throw_speed = 4
 	throw_range = 20
-	flags = FPRINT  | NO_ATTACK_MSG
+	flags = FPRINT | NO_ATTACK_MSG
 	var/c_tag = ""
-	var/active = 0
+	var/active = FALSE
 	var/network = ""
-	var/list/excludes = list(/turf/simulated/floor, /turf/space, /turf/simulated/shuttle, /mob/living/carbon, /obj/item/weapon/storage)
-/obj/item/device/camera_bug/attack_self(mob/user)
-	var/newtag = sanitize(input("Set camera tag") as null|text)
+	var/list/excludes = list(
+		/obj/effect,
+		/turf/simulated/floor,
+		/turf/space,
+		/turf/simulated/shuttle,
+		/mob/living/carbon,
+		/obj/item/weapon/storage
+	)
+
+/obj/item/device/camera_bug/attack_self(var/mob/user)
+	var/newtag = sanitize(input(user, "Choose a unique ID tag:", name, c_tag) as null|text)
 	if(newtag)
 		c_tag = newtag
 		if(user.mind)
 			network = "\ref[user.mind]"
 
-/obj/item/device/camera_bug/afterattack(atom/A, mob/user)
+/obj/item/device/camera_bug/afterattack(var/atom/A, var/mob/user, var/proximity_flag)
+	if(!proximity_flag)
+		to_chat(user, "<span class='warning'>You're too far away.</span>")
+		return 0
+	var/atom/movable/AM = A
+	if(isatommovable(AM))
+		var/turf/atom_turf = get_turf(A)
+		if(AM.level == LEVEL_BELOW_FLOOR && isturf(atom_turf) && atom_turf.intact)
+			to_chat(user, "<span class='notice'>You need to remove the plating first.</span>")
+			return 0
 	if(!c_tag || c_tag == "")
-		to_chat(user, "<span class='notice'>Set the tag first dumbass</span>")
+		to_chat(user, "<span class='notice'>Set the tag first, dumbass.</span>")
 		return 0
 	if(is_type_in_list(A, excludes))
 		to_chat(user, "<span class='warning'>\The [src] won't stick!</span>")
 		return 0
 	if(istype(A, /obj/item))
 		var/obj/item/I = A
-		if(I.w_class > W_CLASS_MEDIUM)
-			to_chat(user, "<span class='warning'>\The [I] is too small for \the [src]</span>")
+		if(I.w_class < W_CLASS_MEDIUM)
+			to_chat(user, "<span class='warning'>\The [I] is too small for \the [src].</span>")
 			return 0
-	if(user.drop_item(src, A))
-		to_chat(user, "<span class='notice'>You stealthily place \the [src] onto \the [A]</span>")
-		active = 1
-		camera_bugs += src
-		return 1
+	var/obj/item/device/camera_bug/bug = locate() in A
+	if(bug)
+		to_chat(user, "<span class='warning'>\A [bug] is already on \the [A].</span>")
+		return 0
+	if(!user.drop_item(src, A))
+		to_chat(user, "<span class='warning'>You can't let go of \the [src]!</span>")
+		return 0
+	to_chat(user, "<span class='notice'>You stealthily place \the [src] onto \the [A].</span>")
+	active = TRUE
+	camera_bugs += src
+	return 1
 
-/obj/item/device/camera_bug/emp_act(severity)
+/obj/item/device/camera_bug/emp_act(var/severity)
+	var/message = "<span class='notice'>\The [src] deactivates and falls off!</span>"
 	switch(severity)
 		if(3)
 			if(prob(10))
-				removed(message = "<span class='notice'>\The [src] deactivates and falls off!</span>", catastrophic = prob(1))
+				removed(null, message, prob(1))
 		if(2)
 			if(prob(40))
-				removed(message = "<span class='notice'>\The [src] deactivates and falls off!</span>", catastrophic = prob(5))
+				removed(null, message, prob(5))
 		if(1)
-			removed(message = "<span class='notice'>\The [src] deactivates and falls off!</span>", catastrophic = prob(30))
+			removed(null, message, prob(30))
 
 /*
   user is who removed it if possible
   message is the displayed message on removal
   catastrophic is whether it should explode on removal or not
 */
-/obj/item/device/camera_bug/proc/removed(mob/user = null, message = "[user] pries \the [src] away from \the [loc]", catastrophic = 0)
-	active = 0
-	camera_bugs  -= src
-	loc = get_turf(src)
+/obj/item/device/camera_bug/proc/removed(var/mob/user = null, var/message = "[user] pries \the [src] away from \the [loc].", var/catastrophic = FALSE)
+	active = FALSE
+	camera_bugs -= src
+	if(user)
+		user.put_in_hands(src)
+	else
+		forceMove(get_turf(src))
 	visible_message(message)
 	if(catastrophic)
-		spawn(5)
+		spawn(0.5 SECONDS)
 			explosion(loc, 0, prob(15), 2, 0)
 
 /obj/item/device/camera_bug/Destroy()


### PR DESCRIPTION
- Sanity checks
- Spelling
- You can remove bugs by examining the object they're installed on, a link pops up.
- There's a flavor text that MAY OR MAY NOT appear when you examine a bugged item from a distance
- Need to be adjacent to the atom you're placing the bug on
- Can't place more than one bug on an atom
- Can't place bugs on items you can't directly see (pipes under tiles)
- Can't place bugs on things smaller than `W_CLASS_MEDIUM`

Fixes #16268
Fixes #16242

I wanted a way to remove bugs that wasn't an obvious entry in the right-click menu and came up with the above but I'm open to ideas.