### PR TITLE
Adjusted cables salvaged from wired glass sheets

### DIFF
--- a/code/game/objects/items/stacks/sheets/light.dm
+++ b/code/game/objects/items/stacks/sheets/light.dm
@@ -16,7 +16,7 @@
 /obj/item/stack/light_w/attackby(var/obj/item/O as obj, var/mob/user as mob)
 	if(istype(O,/obj/item/weapon/wirecutters))
 		var/obj/item/stack/cable_coil/CC = new/obj/item/stack/cable_coil(user.loc)
-		CC.amount = 5
+		CC.amount = 2
 		amount--
 		new/obj/item/stack/sheet/glass/glass(user.loc)
 		if(amount <= 0)


### PR DESCRIPTION
Resolves #16504
:cl:
 * tweak: Wired glass sheets no longer yield more cables than it takes to construct them.