### PR TITLE
Adds console screens to the protolathe.

### DIFF
--- a/code/game/objects/items/weapons/stock_parts.dm
+++ b/code/game/objects/items/weapons/stock_parts.dm
@@ -18,7 +18,7 @@
 
 /obj/item/weapon/stock_parts/console_screen
 	name = "console screen"
-	desc = "Used in the construction of computers and other devices with a interactive console."
+	desc = "Used in the construction of computers and other devices with an interactive console."
 	icon_state = "screen"
 	origin_tech = Tc_MATERIALS + "=1"
 	starting_materials = list(MAT_GLASS = 200)

--- a/code/modules/research/designs/stock_parts.dm
+++ b/code/modules/research/designs/stock_parts.dm
@@ -49,6 +49,16 @@
 	category = "Stock Parts"
 	build_path = /obj/item/weapon/stock_parts/matter_bin
 
+/datum/design/console_screen
+	name = "Console Screen"
+	desc = "Used in the construction of computers and other devices with a interactive console."
+	id = "console_screen"
+	req_tech = list(Tc_MATERIALS = 1)
+	build_type = PROTOLATHE | AUTOLATHE
+	materials = list(MAT_GLASS = 200)
+	category = "Stock Parts"
+	build_path = /obj/item/weapon/stock_parts/console_screen
+
 /datum/design/adv_capacitor
 	name = "Advanced Capacitor"
 	desc = "A stock part used in the construction of various devices."

--- a/code/modules/research/designs/stock_parts.dm
+++ b/code/modules/research/designs/stock_parts.dm
@@ -51,7 +51,7 @@
 
 /datum/design/console_screen
 	name = "Console Screen"
-	desc = "Used in the construction of computers and other devices with a interactive console."
+	desc = "Used in the construction of computers and other devices with an interactive console."
 	id = "console_screen"
 	req_tech = list(Tc_MATERIALS = 1)
 	build_type = PROTOLATHE | AUTOLATHE

--- a/code/modules/research/designs/stock_parts.dm
+++ b/code/modules/research/designs/stock_parts.dm
@@ -51,7 +51,7 @@
 
 /datum/design/console_screen
 	name = "Console Screen"
-	desc = "Used in the construction of computers and other devices with an interactive console"
+	desc = "Used in the construction of computers and other devices with an interactive console."
 	id = "console_screen"
 	req_tech = list(Tc_MATERIALS = 1)
 	build_type = PROTOLATHE | AUTOLATHE

--- a/code/modules/research/designs/stock_parts.dm
+++ b/code/modules/research/designs/stock_parts.dm
@@ -51,7 +51,7 @@
 
 /datum/design/console_screen
 	name = "Console Screen"
-	desc = "Used in the construction of computers and other devices with an interactive console."
+	desc = "Used in the construction of computers and other devices with an interactive console"
 	id = "console_screen"
 	req_tech = list(Tc_MATERIALS = 1)
 	build_type = PROTOLATHE | AUTOLATHE


### PR DESCRIPTION
Does what it says on the tin. Adds the console screens to the list of basic stock parts the protolathe can make.
Resolves #16509 