### PR TITLE
Runtime hunting: Macuahuitl/Destroy() edition

### DIFF
--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -354,8 +354,10 @@ obj/item/weapon/banhammer/admin
 /obj/item/weapon/macuahuitl/Destroy()
 	if(blades.len)
 		for(var/i in blades)
+			var/blade = blades[i]
 			blades.Remove(i)
-			qdel(i)
+			qdel(blade)
+			blade = null
 	..()
 
 /obj/item/weapon/macuahuitl/proc/get_current_blade_count()


### PR DESCRIPTION
```
garbage.dm,133: Cannot execute "blade_4".being sent to past().
  proc name: qdel (/proc/qdel)
  usr: Lenny Webb (blithering) (/mob/living/carbon/human)
  usr.loc: The surface (110, 88, 2) (/turf/unsimulated/floor/mars/air)
  src: null
  call stack:
  qdel("blade_4", 0, 0)
  the wooden paddle (/obj/item/weapon/macuahuitl): Destroy()
  qdel(the wooden paddle (/obj/item/weapon/macuahuitl), 0, 0)
  the wooden paddle (/obj/item/weapon/macuahuitl): ex act(3)
  explosion(the surface (108,93,2) (/turf/unsimulated/floor/mars/air), -1, 1, 3, null, 1, 0, 1)
```