### PR TITLE
Runtime hunting: toggle_internals with no tank

### DIFF
--- a/code/modules/mob/living/carbon/internals.dm
+++ b/code/modules/mob/living/carbon/internals.dm
@@ -55,6 +55,7 @@
 					to_chat(user, "<span class='warning'>\The [src] does not have \an [breathes] tank.</span>")
 				else
 					to_chat(user, "<span class='warning'>You don't have \an [breathes] tank.</span>")
+				return
 		internal = T
 		T.add_fingerprint(user)
 		if(internals)


### PR DESCRIPTION
```
internals.dm,59: Cannot execute null.add fingerprint().
  proc name: toggle internals (/mob/living/carbon/proc/toggle_internals)
  usr: Victoria Pyke (darkmother) (/mob/living/carbon/human)
  usr.loc: The floor (191, 235, 5) (/turf/simulated/floor)
  src: Victoria Pyke (/mob/living/carbon/human)
  src.loc: the floor (191,235,5) (/turf/simulated/floor)
  call stack:
  Victoria Pyke (/mob/living/carbon/human): toggle internals(Victoria Pyke (/mob/living/carbon/human), null)
  the internal (/obj/abstract/screen): Click(null, "mapwindow.map", "icon-x=28;icon-y=20;left=1;scr...")
Occurred 17 times.
```