### PR TITLE
Runtime hunting: cloning computer initialization

### DIFF
--- a/code/modules/medical/computer/cloning.dm
+++ b/code/modules/medical/computer/cloning.dm
@@ -44,7 +44,8 @@
 
 /obj/machinery/computer/cloning/initialize()
 	pod1 = findcloner()
-	pod1.connected = src
+	if(pod1 && !pod1.connected)
+		pod1.connected = src
 
 /obj/machinery/computer/cloning/multitool_menu(var/mob/user, var/obj/item/device/multitool/P)
 	return ""
@@ -66,7 +67,8 @@
 
 /obj/machinery/computer/cloning/proc/updatemodules()
 	scanner = findscanner()
-	scanner.connected = src
+	if(scanner && !scanner.connected)
+		scanner.connected = src
 
 /obj/machinery/computer/cloning/proc/findscanner()
 	var/obj/machinery/dna_scannernew/scannerf = null


### PR DESCRIPTION
```
cloning.dm,47: Cannot modify null.connected.
  proc name: initialize (/obj/machinery/computer/cloning/initialize)
  usr: Kiyihichikitihiyichiyiti (themegagoat) (/mob/living/carbon/human)
  usr.loc: The reinforced floor (175, 240, 1) (/turf/simulated/floor/engine)
  src: the cloning console (/obj/machinery/computer/cloning)
  src.loc: the reinforced floor (175,241,1) (/turf/simulated/floor/engine)
  call stack:
  the cloning console (/obj/machinery/computer/cloning): initialize()
  the cloning console (/obj/machinery/computer/cloning): New(the reinforced floor (175,241,1) (/turf/simulated/floor/engine))
  the cloning console (/obj/machinery/computer/cloning): New(the reinforced floor (175,241,1) (/turf/simulated/floor/engine))
  the computer frame (/obj/structure/computerframe): attackby(the screwdriver (/obj/item/weapon/screwdriver), Kiyihichikitihiyichiyiti (/mob/living/carbon/human), "icon-x=25;icon-y=19;left=1;scr...")
  Kiyihichikitihiyichiyiti (/mob/living/carbon/human): ClickOn(the computer frame (/obj/structure/computerframe), "icon-x=25;icon-y=19;left=1;scr...")
  the computer frame (/obj/structure/computerframe): Click(the reinforced floor (175,241,1) (/turf/simulated/floor/engine), "mapwindow.map", "icon-x=25;icon-y=19;left=1;scr...")
```

