### PR TITLE
Runtime hunting: Thrown batons

### DIFF
--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -15,7 +15,6 @@
 	var/status = 0
 	var/obj/item/weapon/cell/bcell = null
 	var/hitcost = 100 // 10 hits on crap cell
-	var/mob/foundmob = "" //Used in throwing proc.
 
 /obj/item/weapon/melee/baton/suicide_act(mob/user)
 	to_chat(viewers(user), "<span class='danger'>[user] is putting the live [src.name] in \his mouth! It looks like \he's trying to commit suicide.</span>")
@@ -209,38 +208,39 @@
 			M.LAssailant = user
 
 /obj/item/weapon/melee/baton/throw_impact(atom/hit_atom)
-	foundmob = directory[ckey(fingerprintslast)]
-	if (prob(50))
-		if(istype(hit_atom, /mob/living))
-			var/mob/living/L = hit_atom
-			if(status)
-				if(foundmob)
-					foundmob.lastattacked = L
-					L.lastattacker = foundmob
+	if(prob(50))
+		return ..()
+	if(!istype(hit_atom, /mob/living))
+		return
+	if(!status)
+		return
+	var/client/foundclient = directory[ckey(fingerprintslast)]
+	var/mob/foundmob = foundclient.mob
+	var/mob/living/L = hit_atom
+	if(foundmob && ismob(foundmob))
+		foundmob.lastattacked = L
+		L.lastattacker = foundmob
 
-				L.Stun(stunforce)
-				L.Knockdown(stunforce)
-				L.apply_effect(STUTTER, stunforce)
+	L.Stun(stunforce)
+	L.Knockdown(stunforce)
+	L.apply_effect(STUTTER, stunforce)
 
-				L.visible_message("<span class='danger'>[L] has been stunned with [src] by [foundmob ? foundmob : "Unknown"]!</span>")
-				playsound(loc, 'sound/weapons/Egloves.ogg', 50, 1, -1)
+	L.visible_message("<span class='danger'>[L] has been stunned with [src] by [foundmob ? foundmob : "Unknown"]!</span>")
+	playsound(loc, 'sound/weapons/Egloves.ogg', 50, 1, -1)
 
-				deductcharge(hitcost)
+	deductcharge(hitcost)
 
-				if(ishuman(L))
-					var/mob/living/carbon/human/H = L
-					H.forcesay(hit_appends)
+	if(ishuman(L))
+		var/mob/living/carbon/human/H = L
+		H.forcesay(hit_appends)
 
-				foundmob.attack_log += "\[[time_stamp()]\]<font color='red'> Stunned [L.name] ([L.ckey]) with [name]</font>"
-				L.attack_log += "\[[time_stamp()]\]<font color='orange'> Stunned by thrown [src] by [istype(foundmob) ? foundmob.name : ""] ([istype(foundmob) ? foundmob.ckey : ""])</font>"
-				log_attack("<font color='red'>Flying [src.name], thrown by [istype(foundmob) ? foundmob.name : ""] ([istype(foundmob) ? foundmob.ckey : ""]) stunned [L.name] ([L.ckey])</font>" )
-				if(!iscarbon(foundmob))
-					L.LAssailant = null
-				else
-					L.LAssailant = foundmob
-
-				return
-	return ..()
+	foundmob.attack_log += "\[[time_stamp()]\]<font color='red'> Stunned [L.name] ([L.ckey]) with [name]</font>"
+	L.attack_log += "\[[time_stamp()]\]<font color='orange'> Stunned by thrown [src] by [istype(foundmob) ? foundmob.name : ""] ([istype(foundmob) ? foundmob.ckey : ""])</font>"
+	log_attack("<font color='red'>Flying [src.name], thrown by [istype(foundmob) ? foundmob.name : ""] ([istype(foundmob) ? foundmob.ckey : ""]) stunned [L.name] ([L.ckey])</font>" )
+	if(!iscarbon(foundmob))
+		L.LAssailant = null
+	else
+		L.LAssailant = foundmob
 
 /obj/item/weapon/melee/baton/emp_act(severity)
 	if(bcell)

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -210,9 +210,7 @@
 /obj/item/weapon/melee/baton/throw_impact(atom/hit_atom)
 	if(prob(50))
 		return ..()
-	if(!istype(hit_atom, /mob/living))
-		return
-	if(!status)
+	if(!isliving(hit_atom) || !status)
 		return
 	var/client/foundclient = directory[ckey(fingerprintslast)]
 	var/mob/foundmob = foundclient.mob


### PR DESCRIPTION
Thanks, oldcoders.
    >declaring a var only used inside a proc on the atom itself

```
stunbaton.dm,218: Undefined variable /client/var/lastattacked
  proc name: throw impact (/obj/item/weapon/melee/baton/throw_impact)
  usr: Jonathan Miles (adam0742) (/mob/living/carbon/human)
  usr.loc: The floor (136, 100, 2) (/turf/unsimulated/floor)
  src: the stunprod (/obj/item/weapon/melee/baton/cattleprod)
  src.loc: the floor (135,99,2) (/turf/unsimulated/floor)
  call stack:
  the stunprod (/obj/item/weapon/melee/baton/cattleprod): throw impact(Anthony Conrad (/mob/living/carbon/human), 2, Jonathan Miles (/mob/living/carbon/human))
  the stunprod (/obj/item/weapon/melee/baton/cattleprod): hit check(2, Jonathan Miles (/mob/living/carbon/human))
  the stunprod (/obj/item/weapon/melee/baton/cattleprod): throw at(Anthony Conrad (/mob/living/carbon/human), 7, 2, 1, 2)
  Jonathan Miles (/mob/living/carbon/human): throw item(Anthony Conrad (/mob/living/carbon/human), null)
  Jonathan Miles (/mob/living/carbon/human): throw item(Anthony Conrad (/mob/living/carbon/human), null)
  Jonathan Miles (/mob/living/carbon/human): ClickOn(Anthony Conrad (/mob/living/carbon/human), "icon-x=16;icon-y=13;left=1;scr...")
  Anthony Conrad (/mob/living/carbon/human): Click(the floor (135,99,2) (/turf/unsimulated/floor), "mapwindow.map", "icon-x=16;icon-y=13;left=1;scr...")
  Anthony Conrad (/mob/living/carbon/human): Click(the floor (135,99,2) (/turf/unsimulated/floor), "mapwindow.map", "icon-x=16;icon-y=13;left=1;scr...")
```