### PR TITLE
Buildmode update 2

### DIFF
--- a/code/WorkInProgress/buildmode.dm
+++ b/code/WorkInProgress/buildmode.dm
@@ -532,17 +532,7 @@ obj/effect/bmode/buildholder/New()
 										if(areaAction == MASS_DELETE)
 											T.ChangeTurf(get_base_turf(T.z))
 								else
-									if(ispath(holder.buildmode.objholder, /turf))
-										if(areaAction == SELECTIVE_FILL)
-											if(strict)
-												if(T.type != chosen)
-													continue
-											else
-												if(!istype(T, chosen))
-													continue
-
-										T.ChangeTurf(holder.buildmode.objholder)
-									else if(ispath(holder.buildmode.objholder, /area) || istype(holder.buildmode.copycat, /area))
+									if(ispath(holder.buildmode.objholder, /area) || istype(holder.buildmode.copycat, /area))
 										//In case of a selective fill, make sure the turf fits into the criteria before changing it
 										if(areaAction == SELECTIVE_FILL)
 											if(strict)
@@ -559,6 +549,16 @@ obj/effect/bmode/buildholder/New()
 											A = locate(holder.buildmode.objholder)
 
 										T.set_area(A)
+									else if(ispath(holder.buildmode.objholder, /turf))
+										if(areaAction == SELECTIVE_FILL)
+											if(strict)
+												if(T.type != chosen)
+													continue
+											else
+												if(!istype(T, chosen))
+													continue
+
+										T.ChangeTurf(holder.buildmode.objholder)
 									else
 										if(areaAction == SELECTIVE_FILL)
 											for(var/atom/thing in T.contents)

--- a/code/WorkInProgress/buildmode.dm
+++ b/code/WorkInProgress/buildmode.dm
@@ -97,6 +97,7 @@
 				to_chat(usr, "<span class='notice'>Left Mouse Button on turf/obj          = Place objects</span>")
 				to_chat(usr, "<span class='notice'>Right Mouse Button                     = Delete objects</span>")
 				to_chat(usr, "<span class='notice'>Middle Mouse Button                    = Copy atom</span>")
+				to_chat(usr, "<span class='notice'>Middle Mouse Button twice on a turf    = Area editing mode</span>")
 				to_chat(usr, "")
 				to_chat(usr, "<span class='notice'>Ctrl+Shift+Left Mouse Button           = Sets bottom left corner for fill mode</span>")
 				to_chat(usr, "<span class='notice'>Ctrl+Shift+Right Mouse Button           = Sets top right corner for fill mode</span>")
@@ -295,17 +296,7 @@ obj/effect/bmode/buildholder/New()
 								if(areaAction == MASS_DELETE)
 									T.ChangeTurf(get_base_turf(T.z))
 						else
-							if(ispath(whatfill, /turf))
-								if(areaAction == SELECTIVE_FILL)
-									if(strict)
-										if(T.type != chosen)
-											continue
-									else
-										if(!istype(T, chosen))
-											continue
-
-								T.ChangeTurf(whatfill)
-							else if(ispath(whatfill, /area))
+							if(ispath(whatfill, /area) || istype(holder.buildmode.copycat, /area))
 								//In case of a selective fill, make sure the turf fits into the criteria before changing it
 								if(areaAction == SELECTIVE_FILL)
 									if(strict)
@@ -315,8 +306,23 @@ obj/effect/bmode/buildholder/New()
 										if(!istype(T, chosen))
 											continue
 
-								var/area/A = locate(whatfill)
+								var/area/A
+								if(istype(holder.buildmode.copycat, /area))
+									A = holder.buildmode.copycat
+								else
+									A = locate(whatfill)
+
 								T.set_area(A)
+							else if(ispath(whatfill, /turf))
+								if(areaAction == SELECTIVE_FILL)
+									if(strict)
+										if(T.type != chosen)
+											continue
+									else
+										if(!istype(T, chosen))
+											continue
+
+								T.ChangeTurf(whatfill)
 							else
 								if(areaAction == SELECTIVE_FILL)
 									for(var/atom/thing in T.contents)
@@ -644,7 +650,7 @@ obj/effect/bmode/buildholder/New()
 						if(isturf(object))
 							//Middle mouse buttoning a turf twice will enter area editing mode for its area. Use the build-adv function to modify the area
 							if(holder.buildmode.copycat == object)
-								to_chat(usr, "<span class='info'>Modifying area of [object] ([formatJumpTo(object)]). Use the build-adv function to add tiles.</span>")
+								to_chat(usr, "<span class='info'>Modifying area of [object] ([formatJumpTo(object)]). Use the build-adv function to add tiles. Middle-click anywhere outside of the area to stop.</span>")
 								var/area/A = get_area(object)
 								holder.buildmode.copycat = A
 								holder.buildmode.area_overlay.loc = A

--- a/code/game/objects/structures/ladders.dm
+++ b/code/game/objects/structures/ladders.dm
@@ -49,9 +49,11 @@ var/list/ladders = list()
 
 		if(L.id == id)
 			if(L.height == (height - 1))
-				down = L
+				src.down = L
+				L.up = src
 			else if(L.height == (height + 1))
-				up = L
+				src.up = L
+				L.down = src
 
 		if(up && down)	//if both our connections are filled
 			break

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1309,6 +1309,11 @@ var/global/floorIsLava = 0
 	if(ispath(chosen,/turf))
 		var/turf/T = get_turf(usr.loc)
 		T.ChangeTurf(chosen)
+	else if(ispath(chosen, /area))
+		var/area/A = locate(chosen)
+		var/turf/T = get_turf(usr.loc)
+
+		T.set_area(A)
 	else
 		new chosen(usr.loc)
 

--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -194,13 +194,14 @@ var/list/forbidden_varedit_object_types = list(
 				to_chat(user, "Unknown type: [selected_type]")
 
 	if(edited_datum && edited_variable)
+		if(edited_datum.variable_edited(edited_variable, old_value, new_value))
+		//variable_edited() can block the edit in case there's special behavior for a variable (for example, updating lights after they're changed)
+			new_value = edited_datum.vars[edited_variable]
+		else
+			edited_datum.vars[edited_variable] = new_value
+
 		if(logging)
 			log_admin("[key_name(usr)] modified [edited_datum]'s [edited_variable] to [new_value]")
-
-		if(edited_datum.variable_edited(edited_variable, old_value, new_value))
-			new_value = old_value //Return the old value if the variable_edited proc blocked the edit
-
-		edited_datum.vars[edited_variable] = new_value
 
 	return new_value
 


### PR DESCRIPTION
* Fixed issues with varediting special variables (related to light (didn't work at all) and ladders (the other end of the ladder wasn't updated))
* Buildmode now supports area modification:
  * While in build-advanced mode, hit middle mouse button twice on a turf to start expanding its area. Middle-click anywhere outside of the edited area to stop. Comes with a blueprint-like interface.
  * Alternatively, type the area's path into the build-advanced function.

![](https://i.imgur.com/hDMQ8EC.gif)

:cl:
 * bugfix: Fixed admins not being able to modify lighting parameters on objects
 * experiment: Buildmode now supports area modification. While in build-adv mode, middle-click on a turf twice to begin expanding its area. This works like the station's blueprints, but also supports click-dragging to convert large amounts of turfs quickly. Middle-click anywhere outside of the edited area to stop. Areas may now be spawned from paths as well, just like any other object, using either "spawn" or buildmode.
