### PR TITLE
Runtime hunting: ejecting cloning pod

### DIFF
--- a/code/modules/medical/cloning.dm
+++ b/code/modules/medical/cloning.dm
@@ -476,8 +476,9 @@
 			to_chat(usr, "<span class='warning'>You do not have the means to do this!</span>")
 			return
 
+	var/_occupant = occupant // occupant is null after go_out()
 	if(go_out(over_location))
-		visible_message("[usr] removes [occupant.name] from \the [src].")
+		visible_message("[usr] removes \the [_occupant] from \the [src].")
 		add_fingerprint(usr)
 
 /obj/machinery/cloning/clonepod/proc/malfunction()


### PR DESCRIPTION
```
cloning.dm,480: Cannot read null.name
  proc name: MouseDrop (/obj/machinery/cloning/clonepod/MouseDrop)
  usr: Little Doris (waismuth) (/mob/living/carbon/human)
  usr.loc: The floor (211, 241, 1) (/turf/simulated/floor)
  src: the cloning pod (/obj/machinery/cloning/clonepod/full)
  src.loc: the floor (212,240,1) (/turf/simulated/floor)
  call stack:
  the cloning pod (/obj/machinery/cloning/clonepod/full): MouseDrop(Maximus Langston (/mob/living/carbon/human), the floor (212,240,1) (/turf/simulated/floor), the floor (212,241,1) (/turf/simulated/floor), "mapwindow.map", "mapwindow.map", "icon-x=14;icon-y=20;left=1;scr...")
  Waismuth (/client): MouseDrop(the cloning pod (/obj/machinery/cloning/clonepod/full), Maximus Langston (/mob/living/carbon/human), the floor (212,240,1) (/turf/simulated/floor), the floor (212,241,1) (/turf/simulated/floor), "mapwindow.map", "mapwindow.map", "icon-x=14;icon-y=20;left=1;scr...")
```