### PR TITLE
Runtime hunting: nullspaced deadsay

### DIFF
--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -57,7 +57,8 @@
 
 	var/turf/T = get_turf(src)
 	message = src.say_quote("\"[html_encode(message)]\"")
-	log_say("[name]/[key_name(src)] (@[T.x],[T.y],[T.z]) Deadsay: [message]")
+	var/location_text = loc ? "[T.x],[T.y],[T.z]" : "nullspace"
+	log_say("[name]/[key_name(src)] (@[location_text]) Deadsay: [message]")
 	//var/rendered = "<span class='game deadsay'><span class='prefix'>DEAD:</span> <span class='name'>[name]</span>[alt_name] <span class='message'>[message]</span></span>"
 	var/rendered2 = null//edited
 	for(var/mob/M in player_list)


### PR DESCRIPTION
Happens to fix nullspaced ghosts being unable to speak.
```
Runtime in say.dm,60: Cannot read null.x
  proc name: say dead (/mob/proc/say_dead)
  usr: Unknown (herrytheafroheadcrab) (/mob/living/carbon/human)
  usr.loc: (nullspace)
  src: Unknown (/mob/living/carbon/human)
  src.loc: null
  call stack:
  Unknown (/mob/living/carbon/human): say dead("stammers, \"Po vey\"")
  Unknown (/mob/living/carbon/human): say("Po vey", null)
  Unknown (/mob/living/carbon/human): Say("po vey")

```