### PR TITLE
Runtime hunting: make_robot_limbs_organic()

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1513,7 +1513,7 @@
 /mob/living/carbon/human/proc/make_robot_limbs_organic()
 	for(var/datum/organ/external/O in src.organs)
 		if(O.is_robotic())
-			O &= ~ORGAN_ROBOT
+			O.status &= ~ORGAN_ROBOT
 	update_icons()
 
 // Makes all robot internal organs organic.


### PR DESCRIPTION
```
Runtime in human.dm,1516: type mismatch: l_arm (/datum/organ/external/l_arm) &= 65407
  proc name: make robot limbs organic (/mob/living/carbon/human/proc/make_robot_limbs_organic)
```