### PR TITLE
Telecommunications network monitoring console improvements

### DIFF
--- a/code/game/machinery/telecomms/telemonitor.dm
+++ b/code/game/machinery/telecomms/telemonitor.dm
@@ -101,7 +101,7 @@
 
 			if("boost")
 				if(SelectedMachine.boost_signal())
-					temp = "<b>- SUCESS: \[[SelectedMachine]\] SIGNAL AMPLIFIED -</b>"
+					temp = "<b>- SUCCESS: \[[SelectedMachine]\] SIGNAL AMPLIFIED -</b>"
 				else
 					temp = "<font color = #D70B00>- FAILED: NO LOCAL INTERFERENCE DETECTED -</font color>"
 

--- a/code/game/machinery/telecomms/telemonitor.dm
+++ b/code/game/machinery/telecomms/telemonitor.dm
@@ -57,6 +57,8 @@
 				<center><a href='?src=\ref[src];operation=mainmenu'>\[Main Menu\]</a></center>
 				<br>Current Network: [network]<br>
 				Selected Network Entity: [SelectedMachine.name] ([SelectedMachine.id])<br>
+				Machine Integrity: [SelectedMachine.get_integrity() < 100 ? "<font color = #D70B00><b>[SelectedMachine.get_integrity()]%</b></font color>" : "<b>100%</b>"]<br>
+				[SelectedMachine.stat & EMPED ? "<b>Local Interference Detected:</b><br>[SelectedMachine.emptime] seconds remaining <a href='?src=\ref[src];operation=boost'>\[Boost Signal\]</a><br>" : ""]
 				Linked Entities: <ol>"}
 			for(var/obj/machinery/telecomms/T in SelectedMachine.links)
 				if(!T.hide)
@@ -96,6 +98,12 @@
 
 			if("mainmenu")
 				screen = 0
+
+			if("boost")
+				if(SelectedMachine.boost_signal())
+					temp = "<b>- SUCESS: \[[SelectedMachine]\] SIGNAL AMPLIFIED -</b>"
+				else
+					temp = "<font color = #D70B00>- FAILED: NO LOCAL INTERFERENCE DETECTED -</font color>"
 
 			if("probe")
 				if(machinelist.len > 0)


### PR DESCRIPTION
The telecommunications network monitoring console is sort of the redheaded stepchild of telecoms computers. Your server monitor and message monitor are useful chat logs, the traffic controller is used for scripting, but the network monitor is only good for checking links which is a rarer form of sabotage. Similarly, the most common cause of telecoms blackout is the random event, but a mechanic who diagnoses this problem can't do anything to fix it but wait it out. Now when viewing an individual machine, it will display the integrity of that machine and, if it has been affected by an EMP (usually from the comms blackout event), you can signal boost the machine to get it working again immediately. The signal boost button will not appear if the machine is not EMPED.

![untitled](https://user-images.githubusercontent.com/9782036/32686647-a793d33c-c66e-11e7-9337-b281a6f8e647.png)


🆑 
* rscadd: The telecommunications network monitoring console can now boost the signal of telecomms machines affected by ionospheric interference, rebooting them immediately. This will cause increased temperature and power expense for five minutes.
* rscadd: The network monitor will also remotely display machine integrity.