### PR TITLE
Generator hotfix

### DIFF
--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -284,9 +284,9 @@
 			last_gen = energy_transfer * thermal_efficiency * 0.05
 
 			//If our circulators are lubed get extra power
-			if(circ1.reagents.has_reagent(LUBE))
+			if(circ1.reagents.get_reagent_amount(LUBE)>=1)
 				last_gen *= 1 + (circ1.volume_capacity_used/16.5) //Up to x3 if flow capacity is 33%
-			if(circ2.reagents.has_reagent(LUBE))
+			if(circ2.reagents.get_reagent_amount(LUBE)>=1)
 				last_gen *= 1 + (circ2.volume_capacity_used/16.5)
 
 			if(air2.temperature > air1.temperature)


### PR DESCRIPTION
I doubt anyone has thought of this yet, but it occurred to me tonight while doing TEG stuff for the wiki that because the reaction for toxic waste requires 1u lube, you could put less than 1u lube in the circulator to make it last forever.

That will still happen, but now you gotta have at least 1u lube left to get the bonus power.