### PR TITLE
Return crates via disposals

### DIFF
--- a/code/modules/recycling/compactor.dm
+++ b/code/modules/recycling/compactor.dm
@@ -45,6 +45,9 @@
 /obj/machinery/disposal/compactor/handle_trunk()
 	return
 
+/obj/machinery/disposal/compactor/can_load_crates()
+	return FALSE
+
 /obj/machinery/disposal/compactor/update_icon()
 	icon_state = "compactor_[stat & NOPOWER ? "off" : "on"]"
 

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -460,6 +460,9 @@
 	else
 		return ..(mover, target, height, air_group)
 
+/obj/machinery/disposal/proc/can_load_crates()
+	return TRUE
+
 /obj/machinery/disposal/MouseDrop_T(atom/movable/dropping, mob/user)
 
 	if(isAI(user))
@@ -476,6 +479,14 @@
 				return
 
 			attackby(dropping, user)
+		else if(istype(dropping, /obj/structure/closet/crate) && can_load_crates())
+			if(do_after(user,src,20))
+				if(dropping.locked_to || user.restrained() || !user.canmove)
+					return
+				user.visible_message("[user] hoists \the [dropping] into \the [src].", "You hoist \the [dropping] into \the [src].")
+				add_fingerprint(user)
+				dropping.forceMove(src)
+				update_icon()
 		return
 
 	//From there, we are working on a mob (as our target, user is supposed to be a mob)


### PR DESCRIPTION
🆑 
* rscadd: You may now drag crates onto disposal bins to return your emptied mail.