### PR TITLE
Adds veganism disability

### DIFF
--- a/__DEFINES/global.dm
+++ b/__DEFINES/global.dm
@@ -1,4 +1,4 @@
-#define DNA_SE_LENGTH 55
+#define DNA_SE_LENGTH 56
 
 #define VOX_SHAPED "Vox","Skeletal Vox"
 

--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -369,6 +369,7 @@ var/global/list/BODY_COVER_VALUE_LIST=list("[HEAD]" = COVER_PROTECTION_HEAD,"[EY
 #define DISABILITY_FLAG_DEAF        8
 #define DISABILITY_FLAG_BLIND       16
 #define DISABILITY_FLAG_MUTE		32
+#define DISABILITY_FLAG_VEGAN		64
 
 ///////////////////////////////////////
 // MUTATIONS

--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -440,6 +440,7 @@ var/global/list/BODY_COVER_VALUE_LIST=list("[HEAD]" = COVER_PROTECTION_HEAD,"[EY
 #define M_SANS		211		// IF YOU SEE THIS WHILST BROWSING CODE, YOU HAVE BEEN VISITED BY: THE FONT OF SHITPOSTING. GREAT LUCK AND WEALTH WILL COME TO YOU, BUT ONLY IF YOU SAY 'fuck comic sans' IN YOUR PR.
 #define M_FARSIGHT	212		// Increases mob's view range by 2
 #define M_NOIR		213		// aww yis detective noir
+#define M_VEGAN		214
 
 var/global/list/NOIRMATRIX = list(0.33,0.33,0.33,0,\
 				 				  0.33,0.33,0.33,0,\

--- a/code/datums/religions.dm
+++ b/code/datums/religions.dm
@@ -660,3 +660,16 @@
 
 /datum/religion/dune/equip_chaplain(var/mob/living/carbon/human/H)
 	H.equip_or_collect(new /obj/item/clothing/under/stilsuit(H), slot_w_uniform)
+
+/datum/religion/vegan
+	name = "Veganism"
+
+	bible_name = "Mercy For Animals"
+	male_adept = "Animal Rights Activist"
+	female_adept = "Animal Rights Activist"
+	keys = list("vegan","vegetarian","veganism","vegetarianism", "animals", "animal rights")
+
+/datum/religion/vegan/equip_chaplain(var/mob/living/carbon/human/H)
+	//Add veganism disability
+	H.dna.SetSEState(VEGANBLOCK, 1)
+	domutcheck(H, null, MUTCHK_FORCED)

--- a/code/datums/religions.dm
+++ b/code/datums/religions.dm
@@ -672,4 +672,4 @@
 /datum/religion/vegan/equip_chaplain(var/mob/living/carbon/human/H)
 	//Add veganism disability
 	H.dna.SetSEState(VEGANBLOCK, 1)
-	domutcheck(H, null, MUTCHK_FORCED)
+	domutcheck(H, null, 1)

--- a/code/game/dna/genes/vg_disabilities.dm
+++ b/code/game/dna/genes/vg_disabilities.dm
@@ -86,7 +86,7 @@
 	CREAM,
 	CAFE_LATTE,
 	MILKSHAKE,
-	//Blood-based products (human blood is off-limit too)
+	//Blood-based products
 	BLOOD,
 	DEMONSBLOOD,
 	RED_MEAD,
@@ -108,7 +108,7 @@
 				to_chat(H, "<span class='warning'>Your body rejects the [reagent_name(R)]!</span>")
 
 				if(H.lastpuke) //If already puking, add some toxins
-					H.adjustToxLoss(5)
+					H.adjustToxLoss(2.5)
 				else
 					H.vomit()
 				break

--- a/code/game/dna/genes/vg_disabilities.dm
+++ b/code/game/dna/genes/vg_disabilities.dm
@@ -86,12 +86,17 @@
 	CREAM,
 	CAFE_LATTE,
 	MILKSHAKE,
+	OFFCOLORCHEESE,
+	CHEESYGLOOP, //this one doesn't leave your body naturally, but you'll vomit it out eventually
 	//Blood-based products
 	BLOOD,
 	DEMONSBLOOD,
 	RED_MEAD,
 	DEVILSKISS,
 	MEDCOFFEE,
+	//Misc
+	HORSEMEAT,
+	BONEMARROW,
 	)
 
 /datum/dna/gene/disability/veganism/New()

--- a/code/game/dna/genes/vg_disabilities.dm
+++ b/code/game/dna/genes/vg_disabilities.dm
@@ -78,7 +78,7 @@
 
 	mutation = M_VEGAN
 
-	var/static/list/bad_reagents = list(
+	var/global/static/list/nonvegan_reagents = list(
 	HONEY,
 	//Milk-based products
 	MILK,
@@ -103,7 +103,7 @@
 		return
 
 	if(prob(10))
-		for(var/R in bad_reagents)
+		for(var/R in nonvegan_reagents)
 			if(H.reagents.has_reagent(R))
 				to_chat(H, "<span class='warning'>Your body rejects the [reagent_name(R)]!</span>")
 

--- a/code/game/dna/genes/vg_disabilities.dm
+++ b/code/game/dna/genes/vg_disabilities.dm
@@ -69,3 +69,46 @@
 
 	OnSay(var/mob/M, var/datum/speech/speech)
 		speech.message_classes.Add("sans") // SPEECH 2.0!!!1
+
+/datum/dna/gene/disability/veganism
+	name = "Veganism"
+	desc = "Causes the digestive system to completely reject all animal products, from meat to dairy."
+	activation_message = "You feel vegan."
+	deactivation_message = "You're back on top of the food chain."
+
+	mutation = M_VEGAN
+
+	var/static/list/bad_reagents = list(
+	HONEY,
+	//Milk-based products
+	MILK,
+	VIRUSFOOD,
+	CREAM,
+	CAFE_LATTE,
+	MILKSHAKE,
+	//Blood-based products (human blood is off-limit too)
+	BLOOD,
+	DEMONSBLOOD,
+	RED_MEAD,
+	DEVILSKISS,
+	MEDCOFFEE,
+	)
+
+/datum/dna/gene/disability/veganism/New()
+	..()
+	block = VEGANBLOCK
+
+/datum/dna/gene/disability/veganism/OnMobLife(var/mob/living/carbon/human/H)
+	if(!istype(H))
+		return
+
+	if(prob(10))
+		for(var/R in bad_reagents)
+			if(H.reagents.has_reagent(R))
+				to_chat(H, "<span class='warning'>Your body rejects the [reagent_name(R)]!</span>")
+
+				if(H.lastpuke) //If already puking, add some toxins
+					H.adjustToxLoss(5)
+				else
+					H.vomit()
+				break

--- a/code/game/gamemodes/setupgame.dm
+++ b/code/game/gamemodes/setupgame.dm
@@ -69,6 +69,7 @@ var/WHISPERBLOCK = 0
 var/DIZZYBLOCK = 0
 var/SANSBLOCK = 0
 var/NOIRBLOCK = 0
+var/VEGANBLOCK = 0
 
 
 /proc/getAssignedBlock(var/name,var/list/blocksLeft, var/activity_bounds=DNA_DEFAULT_BOUNDS, var/good=0)
@@ -176,6 +177,7 @@ var/NOIRBLOCK = 0
 	DIZZYBLOCK     = getAssignedBlock("DIZZY",      numsToAssign)
 	SANSBLOCK      = getAssignedBlock("SANS",       numsToAssign)
 	NOIRBLOCK      = getAssignedBlock("NOIR",       numsToAssign)
+	VEGANBLOCK     = getAssignedBlock("VEGAN",      numsToAssign)
 
 	//
 	// Static Blocks

--- a/code/game/gamemodes/vampire/vampire.dm
+++ b/code/game/gamemodes/vampire/vampire.dm
@@ -271,6 +271,8 @@
 		//Forcefully remove veganism since it breaks you
 		vampire_mob.dna.SetSEState(VEGANBLOCK, 0)
 		domutcheck(vampire_mob, null, MUTCHK_FORCED)
+		//Just in case
+		vampire_mob.mutations.Remove(M_VEGAN)
 
 /datum/game_mode/proc/greet_vampire(var/datum/mind/vampire, var/you_are=1)
 	var/dat

--- a/code/game/gamemodes/vampire/vampire.dm
+++ b/code/game/gamemodes/vampire/vampire.dm
@@ -267,6 +267,10 @@
 	if(!istype(vampire_mob))
 		return
 	vampire_mob.make_vampire()
+	if(vampire_mob.dna)
+		//Forcefully remove veganism since it breaks you
+		vampire_mob.dna.SetSEState(VEGANBLOCK, 0)
+		domutcheck(vampire_mob, null, MUTCHK_FORCED)
 
 /datum/game_mode/proc/greet_vampire(var/datum/mind/vampire, var/you_are=1)
 	var/dat
@@ -385,6 +389,10 @@ You are weak to holy things and starlight. Don't go into space and avoid the Cha
 	while(do_mob(src, H, 50))
 		if(!mind.vampire || !(mind in ticker.mode.vampires))
 			to_chat(src, "<span class='warning'>Your fangs have disappeared!</span>")
+			src.mind.vampire.draining = null
+			return 0
+		if(src.mutations.Find(M_VEGAN))
+			to_chat(src, "<span class='warning'>Being a vegan, the mere thought of drinking blood disgusts you. You stop immediately.</span>")
 			src.mind.vampire.draining = null
 			return 0
 		if(H.species.anatomy_flags & NO_BLOOD)

--- a/code/game/objects/items/weapons/dna_injector.dm
+++ b/code/game/objects/items/weapons/dna_injector.dm
@@ -825,6 +825,28 @@
 	block = NERVOUSBLOCK
 	..()
 
+/obj/item/weapon/dnainjector/nofail/veganmut
+	name = "DNA-Injector (Vegan)"
+	desc = "Makes you vegan."
+	datatype = DNA2_BUF_SE
+	value = 0xFFF
+	//block = 11
+
+/obj/item/weapon/dnainjector/nofail/veganmut/New()
+	block = VEGANBLOCK
+	..()
+
+/obj/item/weapon/dnainjector/nofail/antivegan
+	name = "DNA-Injector (Anti-Vegan)"
+	desc = "Allows you to enjoy meat and animal products again."
+	datatype = DNA2_BUF_SE
+	value = 0x001
+	//block = 11
+
+/obj/item/weapon/dnainjector/nofail/antiblind/New()
+	block = VEGANBLOCK
+	..()
+
 /obj/item/weapon/dnainjector/nofail/blindmut
 	name = "DNA-Injector (Blind)"
 	desc = "Makes you not see anything."

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -636,6 +636,7 @@ var/const/MAX_SAVE_SLOTS = 8
 	HTML += ShowDisabilityState(user,DISABILITY_FLAG_DEAF,       "Deaf")
 	HTML += ShowDisabilityState(user,DISABILITY_FLAG_BLIND,      "Blind")
 	HTML += ShowDisabilityState(user,DISABILITY_FLAG_MUTE,       "Mute")
+	HTML += ShowDisabilityState(user,DISABILITY_FLAG_VEGAN,      "Vegan")
 	/*HTML += ShowDisabilityState(user,DISABILITY_FLAG_COUGHING,   "Coughing")
 	HTML += ShowDisabilityState(user,DISABILITY_FLAG_TOURETTES,   "Tourettes") Still working on it! -Angelite*/
 

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -460,6 +460,9 @@ Round Duration: [round(hours)]h [round(mins)]m<br>"}
 		new_character.dna.SetSEState(GLASSESBLOCK,1,1)
 		new_character.disabilities |= NEARSIGHTED
 
+	if(client.prefs.disabilities & DISABILITY_FLAG_VEGAN)
+		new_character.dna.SetSEState(VEGANBLOCK, 1, 1)
+
 	chosen_species = all_species[client.prefs.species]
 	if( (client.prefs.disabilities & DISABILITY_FLAG_FAT) && (chosen_species.anatomy_flags & CAN_BE_FAT) )
 		new_character.mutations += M_FAT
@@ -479,6 +482,7 @@ Round Duration: [round(hours)]h [round(mins)]m<br>"}
 		new_character.sdisabilities |= MUTE
 
 	new_character.dna.UpdateSE()
+	domutcheck(new_character, null, MUTCHK_FORCED)
 
 	new_character.key = key		//Manually transfer the key to log them in
 

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -780,6 +780,11 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 ///////////////////////////////////////////////////////////////////////////////////
 
 
+/proc/reagent_name(id)
+	var/datum/reagent/D = chemical_reagents_list[id]
+	if(D)
+		return D.name
+
 /*
  * Convenience proc to create a reagents holder for an atom
  * max_vol is maximum volume of holder

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -233,7 +233,7 @@
 				"<span class='warning'>\The [src] is disgusting! Your vegan digestive system rejects \him.</span>")
 
 				if(H.lastpuke) //If already puking, add some toxins
-					H.adjustToxLoss(5)
+					H.adjustToxLoss(2.5)
 				else
 					H.vomit()
 

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -226,6 +226,16 @@
 			H.visible_message("<span class='warning'>\The [src] falls through \the [eater] and onto the ground, completely untouched.</span>",\
 			"<span class='notice'>As [user] attempts to feed you \the [src], \he falls through your body and onto the ground, completely untouched.</span>")
 			return
+		if(H.mutations.Find(M_VEGAN))
+			if(food_flags & (FOOD_MEAT | FOOD_ANIMAL))
+			//if(prob(66))
+				H.visible_message("<span class='warning'>[H] winces at the taste of \the [src], finding it absolutely disgusting.</span>",\
+				"<span class='warning'>\The [src] is disgusting! Your vegan digestive system rejects \him.</span>")
+
+				if(H.lastpuke) //If already puking, add some toxins
+					H.adjustToxLoss(5)
+				else
+					H.vomit()
 
 	return 1
 

--- a/code/modules/virus2/effect/effect.dm
+++ b/code/modules/virus2/effect/effect.dm
@@ -550,6 +550,14 @@
 		var/mob/M = touched
 		add_attacklogs(mob, M, "damaged with keratin spikes",addition = "([M] bumped into [mob])", admin_warn = FALSE)
 
+/datum/disease2/effect/vegan
+	name = "Vegan Syndrome"
+	stage = 2
+
+/datum/disease2/effect/vegan/activate(var/mob/living/carbon/mob)
+	mob.dna.check_integrity()
+	mob.dna.SetSEState(VEGANBLOCK,1)
+	domutcheck(mob, null)
 
 ////////////////////////STAGE 3/////////////////////////////////
 
@@ -580,7 +588,6 @@
 	mob.dna.check_integrity()
 	mob.dna.SetSEState(REMOTETALKBLOCK,1)
 	domutcheck(mob, null)
-
 
 /datum/disease2/effect/mind
 	name = "Lazy Mind Syndrome"


### PR DESCRIPTION
See changelog. Players who become vampires lose the veganism gene, but it can be activated again through genetics.
Consuming animal products as a vegan causes you to become nauseous. If you continue eating them while nauseous, you receive 2.5 toxin damage per bite (in case of food), or per 10 ticks (in case of reagents such as milk or honey). Yes, this means you can murder vegans by force-feeding them steaks.

Also adds vegan syndrome as a stage 2 virus effect, and a veganism/animal rights religion

:cl:
 * rscadd: Added a new disability - veganism. It can be received either randomly at roundstart, by enabling it in your character preferences, through a new stage 2 virus effect, or through genetics. Also added a "veganism" / "animal rights" religion which automatically grants this disability.
 * rscadd: Eating animal products, meat, milk, honey and blood as a vegan will make you nauseous, and further continuing to do so will cause minor toxin damage. Vegan vampires are unable to drink blood, if turned vegan after becoming a vampire.
