### PR TITLE
Fixes bone menders not fixing rib cage bones properly.

### DIFF
--- a/code/modules/surgery/encased.dm
+++ b/code/modules/surgery/encased.dm
@@ -197,6 +197,7 @@
 /datum/surgery_step/open_encased/mend
 	allowed_tools = list(
 		/obj/item/weapon/bonegel = 100,
+		/obj/item/weapon/bonesetter/bone_mender = 100,
 		/obj/item/weapon/screwdriver = 75,
 		)
 


### PR DESCRIPTION
Opening a rib cage manually is slightly different than breaking it causing issues with the mender when trying to fix ribs that were manually opened.