### PR TITLE
Service borg H.U.E.Y. upgrade and upgrade tweaks/cleanup

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -18,11 +18,11 @@
 	w_type=RECYK_ELECTRONIC
 
 
-/obj/item/borg/upgrade/proc/locate_component(var/obj/C, var/mob/living/silicon/robot/R, var/mob/living/user)
+/obj/item/borg/upgrade/proc/locate_component(var/obj/item/C, var/mob/living/silicon/robot/R, var/mob/living/user)
 	if(!C || !R || !user)
 		return FAILED_TO_ADD
 
-	var/obj/I = locate(C) in R.module
+	var/obj/item/I = locate(C) in R.module
 	if(!I)
 		I = locate(C) in R.module.contents
 	if(!I)

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -20,7 +20,7 @@
 
 /obj/item/borg/upgrade/proc/locate_component(var/obj/item/C, var/mob/living/silicon/robot/R, var/mob/living/user)
 	if(!C || !R || !user)
-		return FAILED_TO_ADD
+		return
 
 	var/obj/item/I = locate(C) in R.module
 	if(!I)
@@ -29,7 +29,7 @@
 		I = locate(C) in R.module.modules
 	if(!I)
 		to_chat(user, "This cyborg is missing one of the needed components!")
-		return FAILED_TO_ADD
+		return
 	return I
 
 /obj/item/borg/upgrade/proc/attempt_action(var/mob/living/silicon/robot/R,var/mob/living/user)
@@ -82,6 +82,8 @@
 		return FAILED_TO_ADD
 
 	var/obj/item/weapon/gripper/chemistry/G = locate_component(/obj/item/weapon/gripper/chemistry, R, user)
+	if(!G)
+		return FAILED_TO_ADD
 	G.can_hold += list(/obj/item/weapon/reagent_containers/pill, /obj/item/weapon/storage/pill_bottle)
 
 /obj/item/borg/upgrade/reset
@@ -183,6 +185,8 @@
 
 /obj/item/borg/upgrade/tasercooler/attempt_action(var/mob/living/silicon/robot/R,var/mob/living/user)
 	var/obj/item/weapon/gun/energy/taser/cyborg/T = locate_component(/obj/item/weapon/gun/energy/taser/cyborg, R, user)
+	if(!T)
+		return FAILED_TO_ADD
 
 	if(T.recharge_time <= 2)
 		to_chat(R, "Maximum cooling achieved for this hardpoint!")
@@ -237,7 +241,7 @@
 	if(..())
 		return FAILED_TO_ADD
 
-	var/obj/item/device/material_synth/S = locate(/obj/item/device/material_synth) in R.module.modules
+	var/obj/item/device/material_synth/S = locate_component(/obj/item/device/material_synth, R, user)
 	if(!S)
 		return FAILED_TO_ADD
 
@@ -257,6 +261,8 @@
 		return FAILED_TO_ADD
 
 	var/obj/item/weapon/gripper/service/G = locate_component(/obj/item/weapon/gripper/service, R, user)
+	if(!G)
+		return FAILED_TO_ADD
 	G.can_hold += list(/obj/item/weapon/reagent_containers/food)
 
 /obj/item/borg/upgrade/magnetic_gripper

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -84,6 +84,7 @@
 	var/obj/item/weapon/gripper/chemistry/G = locate_component(/obj/item/weapon/gripper/chemistry, R, user)
 	if(!G)
 		return FAILED_TO_ADD
+
 	G.can_hold += list(/obj/item/weapon/reagent_containers/pill, /obj/item/weapon/storage/pill_bottle)
 
 /obj/item/borg/upgrade/reset
@@ -263,6 +264,7 @@
 	var/obj/item/weapon/gripper/service/G = locate_component(/obj/item/weapon/gripper/service, R, user)
 	if(!G)
 		return FAILED_TO_ADD
+
 	G.can_hold += list(/obj/item/weapon/reagent_containers/food)
 
 /obj/item/borg/upgrade/magnetic_gripper
@@ -291,4 +293,7 @@
 		return FAILED_TO_ADD
 
 	var/obj/item/weapon/gripper/service/G = locate_component(/obj/item/weapon/gripper/service, R, user)
+	if(!G)
+		return FAILED_TO_ADD
+
 	G.can_hold += list(/obj/item/seeds, /obj/item/weapon/reagent_containers/glass)

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -3,20 +3,34 @@
 
 #define FAILED_TO_ADD 1
 
-/obj/item/borg/upgrade/var/vtec_bonus = 0.25
+/obj/item/borg/upgrade/var/vtec_bonus = 0.25 //Define when
 
 /obj/item/borg/upgrade
 	name = "A borg upgrade module."
 	desc = "Protected by FRM."
 	icon = 'icons/obj/module.dmi'
 	icon_state = "cyborg_upgrade"
-	var/locked = 0
+	var/locked = FALSE
 	var/list/required_module = list()
-	var/add_to_mommis = 0
+	var/add_to_mommis = FALSE
 	var/list/modules_to_add = list()
-	var/multi_upgrades = 0
+	var/multi_upgrades = FALSE
 	w_type=RECYK_ELECTRONIC
 
+
+/obj/item/borg/upgrade/proc/locate_component(var/obj/C, var/mob/living/silicon/robot/R, var/mob/living/user)
+	if(!C || !R || !user)
+		return FAILED_TO_ADD
+
+	var/obj/I = locate(C) in R.module
+	if(!I)
+		I = locate(C) in R.module.contents
+	if(!I)
+		I = locate(C) in R.module.modules
+	if(!I)
+		to_chat(user, "This cyborg is missing one of the needed components!")
+		return FAILED_TO_ADD
+	return I
 
 /obj/item/borg/upgrade/proc/attempt_action(var/mob/living/silicon/robot/R,var/mob/living/user)
 	if(!R.module)
@@ -57,7 +71,7 @@
 // Medical Cyborg Stuff
 
 /obj/item/borg/upgrade/medical/surgery
-	name = "medical module board"
+	name = "medical cyborg MK-2 upgrade board"
 	desc = "Used to give a medical cyborg advanced care tools and upgrade their chemistry gripper to be able to handle pills and pill bottles."
 	icon_state = "cyborg_upgrade"
 	required_module = list(/obj/item/weapon/robot_module/medical)
@@ -67,14 +81,11 @@
 	if(..())
 		return FAILED_TO_ADD
 
-	var/obj/item/weapon/gripper/chemistry/C = locate(/obj/item/weapon/gripper/chemistry) in R.module.modules
-	if(!C)
-		return FAILED_TO_ADD
-
-	C.can_hold += list (/obj/item/weapon/reagent_containers/pill, /obj/item/weapon/storage/pill_bottle)
+	var/obj/item/weapon/gripper/chemistry/G = locate_component(/obj/item/weapon/gripper/chemistry, R, user)
+	G.can_hold += list(/obj/item/weapon/reagent_containers/pill, /obj/item/weapon/storage/pill_bottle)
 
 /obj/item/borg/upgrade/reset
-	name = "robotic module reset board"
+	name = "cyborg reset board"
 	desc = "Used to reset a cyborg's module. Destroys any other upgrades applied to the robot."
 	icon_state = "cyborg_upgrade1"
 
@@ -97,7 +108,7 @@
 
 /obj/item/borg/upgrade/rename
 	var/heldname = ""
-	name = "robot rename board"
+	name = "cyborg rename board"
 	desc = "Used to rename a cyborg, or allow a cyborg to rename themselves."
 	icon_state = "cyborg_upgrade1"
 
@@ -130,7 +141,7 @@
 		R.module.upgrades -= /obj/item/borg/upgrade/rename
 
 /obj/item/borg/upgrade/restart
-	name = "robot emergency restart module"
+	name = "cyborg emergency restart board"
 	desc = "Used to force a restart of a disabled-but-repaired robot, bringing it back online."
 	icon_state = "cyborg_upgrade1"
 
@@ -138,7 +149,7 @@
 /obj/item/borg/upgrade/restart/attempt_action(var/mob/living/silicon/robot/R,var/mob/living/user)
 	if(R.health < 0)
 		to_chat(user, "You have to repair the robot before using this module!")
-		return 0
+		return FALSE
 
 	if(!R.key)
 		for(var/mob/dead/observer/ghost in player_list)
@@ -149,10 +160,10 @@
 	R.resurrect()
 
 /obj/item/borg/upgrade/vtec
-	name = "robotic VTEC Module"
+	name = "cyborg VTEC upgrade board"
 	desc = "Used to kick in a robot's VTEC systems, increasing their speed."
 	icon_state = "cyborg_upgrade2"
-	add_to_mommis = 1
+	add_to_mommis = TRUE
 
 /obj/item/borg/upgrade/vtec/attempt_action(var/mob/living/silicon/robot/R,var/mob/living/user)
 
@@ -163,24 +174,15 @@
 
 
 /obj/item/borg/upgrade/tasercooler
-	name = "robotic Rapid Taser Cooling Module"
+	name = "security cyborg rapid taser cooling upgrade board"
 	desc = "Used to cool a mounted taser, increasing the potential current in it and thus its recharge rate."
 	icon_state = "cyborg_upgrade3"
 	required_module = list(/obj/item/weapon/robot_module/security)
-	multi_upgrades = 1
+	multi_upgrades = TRUE
 
 
 /obj/item/borg/upgrade/tasercooler/attempt_action(var/mob/living/silicon/robot/R,var/mob/living/user)
-
-
-	var/obj/item/weapon/gun/energy/taser/cyborg/T = locate() in R.module
-	if(!T)
-		T = locate() in R.module.contents
-	if(!T)
-		T = locate() in R.module.modules
-	if(!T)
-		to_chat(user, "This robot has had its taser removed!")
-		return FAILED_TO_ADD
+	var/obj/item/weapon/gun/energy/taser/cyborg/T = locate_component(/obj/item/weapon/gun/energy/taser/cyborg, R, user)
 
 	if(T.recharge_time <= 2)
 		to_chat(R, "Maximum cooling achieved for this hardpoint!")
@@ -193,12 +195,12 @@
 		T.recharge_time = max(2 , T.recharge_time - 4)
 
 /obj/item/borg/upgrade/jetpack
-	name = "utility robot jetpack"
+	name = "cyborg jetpack module board"
 	desc = "A carbon dioxide jetpack suitable for low-gravity operations."
 	icon_state = "cyborg_upgrade3"
 	required_module = list(/obj/item/weapon/robot_module/miner,/obj/item/weapon/robot_module/engineering,/obj/item/weapon/robot_module/combat)
 	modules_to_add = list(/obj/item/weapon/tank/jetpack/carbondioxide/silicon)
-	add_to_mommis = 1
+	add_to_mommis = TRUE
 
 /obj/item/borg/upgrade/jetpack/attempt_action(var/mob/living/silicon/robot/R,var/mob/living/user)
 	if(..())
@@ -208,13 +210,13 @@
 		R.internals = src
 
 /obj/item/borg/upgrade/syndicate/
-	name = "Illegal Equipment Module"
+	name = "cyborg illegal equipment board"
 	desc = "Unlocks the hidden, deadlier functions of a robot."
 	icon_state = "cyborg_upgrade3"
 
 /obj/item/borg/upgrade/syndicate/attempt_action(var/mob/living/silicon/robot/R,var/mob/living/user)
 
-	if(R.emagged == 1)
+	if(R.emagged == TRUE)
 		return FAILED_TO_ADD
 
 	if(..())
@@ -225,7 +227,7 @@
 	R.SetEmagged(2)
 
 /obj/item/borg/upgrade/engineering/
-	name = "Engineering Equipment Module"
+	name = "engineering cyborg MK-2 upgrade board"
 	desc = "Adds several tools and materials for the robot to use."
 	icon_state = "cyborg_upgrade3"
 	required_module = list(/obj/item/weapon/robot_module/engineering)
@@ -244,32 +246,43 @@
 								"carpet tiles" = /obj/item/stack/tile/carpet)
 
 /obj/item/borg/upgrade/service
-	name = "service module upgrade board"
-	desc = "Used to give a service cyborg cooking tools and upgrade their service gripper to be able to handle beakers, food and seeds."
+	name = "service cyborg cooking upgrade board"
+	desc = "Used to give a service cyborg cooking tools and upgrade their service gripper to be able to handle food."
 	icon_state = "cyborg_upgrade2"
 	required_module = list(/obj/item/weapon/robot_module/butler)
-	modules_to_add = list(/obj/item/weapon/kitchen/utensil/knife/large, /obj/item/weapon/kitchen/rollingpin, /obj/item/weapon/storage/bag/plants, /obj/item/weapon/storage/bag/food/borg)
+	modules_to_add = list(/obj/item/weapon/kitchen/utensil/knife/large, /obj/item/weapon/kitchen/rollingpin, /obj/item/weapon/storage/bag/food/borg)
 
 /obj/item/borg/upgrade/service/attempt_action(var/mob/living/silicon/robot/R,var/mob/living/user)
 	if(..())
 		return FAILED_TO_ADD
 
-	var/obj/item/weapon/gripper/service/G = locate(/obj/item/weapon/gripper/service) in R.module.modules
-	if(!G)
-		return FAILED_TO_ADD
-
-	G.can_hold += list (/obj/item/seeds, /obj/item/weapon/reagent_containers/glass, /obj/item/weapon/reagent_containers/food)
+	var/obj/item/weapon/gripper/service/G = locate_component(/obj/item/weapon/gripper/service, R, user)
+	G.can_hold += list(/obj/item/weapon/reagent_containers/food)
 
 /obj/item/borg/upgrade/magnetic_gripper
-	name = "magnetic gripper module board"
+	name = "engineering cyborg magnetic gripper upgrade board"
 	desc = "Used to give a engineering cyborg a magnetic gripper."
 	icon_state = "cyborg_upgrade2"
 	required_module = list(/obj/item/weapon/robot_module/engineering)
 	modules_to_add = list(/obj/item/weapon/gripper/no_use/magnetic)
 
 /obj/item/borg/upgrade/organ_gripper
-	name = "organ gripper module board"
+	name = "medical cyborg organ gripper upgrade board"
 	desc = "Used to give a medical cyborg a organ gripper."
 	icon_state = "cyborg_upgrade2"
 	required_module = list(/obj/item/weapon/robot_module/medical)
 	modules_to_add = list(/obj/item/weapon/gripper/organ)
+
+/obj/item/borg/upgrade/hydro
+	name = "service cyborg H.U.E.Y. upgrade board"
+	desc = "Used to give a service cyborg hydroponics tools and upgrade their service gripper to be able to handle seeds and glass containers."
+	icon_state = "cyborg_upgrade"
+	required_module = list(/obj/item/weapon/robot_module/butler)
+	modules_to_add = list(/obj/item/weapon/minihoe, /obj/item/weapon/wirecutters/clippers, /obj/item/weapon/storage/bag/plants, /obj/item/device/analyzer/plant_analyzer)
+
+/obj/item/borg/upgrade/service/attempt_action(var/mob/living/silicon/robot/R,var/mob/living/user)
+	if(..())
+		return FAILED_TO_ADD
+
+	var/obj/item/weapon/gripper/service/G = locate_component(/obj/item/weapon/gripper/service, R, user)
+	G.can_hold += list(/obj/item/seeds, /obj/item/weapon/reagent_containers/glass)

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -20,7 +20,7 @@
 
 /obj/item/borg/upgrade/proc/locate_component(var/obj/item/C, var/mob/living/silicon/robot/R, var/mob/living/user)
 	if(!C || !R || !user)
-		return
+		return null
 
 	var/obj/item/I = locate(C) in R.module
 	if(!I)
@@ -29,7 +29,7 @@
 		I = locate(C) in R.module.modules
 	if(!I)
 		to_chat(user, "This cyborg is missing one of the needed components!")
-		return
+		return null
 	return I
 
 /obj/item/borg/upgrade/proc/attempt_action(var/mob/living/silicon/robot/R,var/mob/living/user)

--- a/code/modules/hydroponics/seed_machines.dm
+++ b/code/modules/hydroponics/seed_machines.dm
@@ -88,6 +88,8 @@
 			to_chat(user, "That seed is not compatible with our genetics technology.")
 		else
 			user.drop_item(S, src, force_drop = 1)
+			if(S.loc != src) //How did you do that? Gimme that fucking seed pack.
+				S.forceMove(src)
 			loaded_seed = W
 			to_chat(user, "You load [W] into [src].")
 			nanomanager.update_uis(src)

--- a/code/modules/research/designs/borg_upgrades.dm
+++ b/code/modules/research/designs/borg_upgrades.dm
@@ -1,45 +1,15 @@
 /datum/design/borg_syndicate_module
-	name = "Borg Illegal Weapons Upgrade"
+	name = "Cyborg illegal equipment board"
 	desc = "Allows for the construction of illegal upgrades for cyborgs"
 	id = "borg_syndicate_module"
 	build_type = MECHFAB
 	req_tech = list(Tc_COMBAT = 4, Tc_SYNDICATE = 3)
 	build_path = /obj/item/borg/upgrade/syndicate
 	category = "Robotic_Upgrade_Modules"
-	materials = list(MAT_IRON=10000,MAT_GLASS=15000,MAT_DIAMOND = 10000)
-
-/datum/design/borg_engineer_upgrade
-	name = "engineering module board"
-	desc = "Used to give an engineering cyborg more materials."
-	id = "borg_engineer_module"
-	build_type = MECHFAB
-	req_tech = list(Tc_ENGINEERING = 1)
-	build_path = /obj/item/borg/upgrade/engineering
-	category = "Robotic_Upgrade_Modules"
-	materials = list(MAT_IRON=10000,MAT_GLASS=10000,MAT_PLASMA=5000)
-
-/datum/design/medical_module_surgery
-	name = "medical module board"
-	desc = "Used to give a medical cyborg surgery tools."
-	id = "medical_module_surgery"
-	req_tech = list(Tc_BIOTECH = 3, Tc_ENGINEERING = 3, Tc_ANOMALY = 2)
-	build_type = MECHFAB
-	materials = list(MAT_IRON = 80000, MAT_GLASS = 20000, MAT_SILVER=5000)
-	build_path = /obj/item/borg/upgrade/medical/surgery
-	category = "Robotic_Upgrade_Modules"
-
-/datum/design/borg_service_upgrade
-	name = "service module cooking upgrade board"
-	desc = "Used to give a service cyborg cooking tools."
-	id = "borg_service_module"
-	req_tech = list(Tc_BIOTECH = 2, Tc_ENGINEERING = 3, Tc_PROGRAMMING = 2, Tc_ANOMALY = 2)
-	build_type = MECHFAB
-	materials = list(MAT_IRON = 60000, MAT_GLASS = 10000, MAT_GOLD=5000)
-	build_path = /obj/item/borg/upgrade/service
-	category = "Robotic_Upgrade_Modules"
+	materials = list(MAT_IRON=10000, MAT_GLASS=15000, MAT_DIAMOND=10000)
 
 /datum/design/borg_reset_board
-	name = "cyborg reset module"
+	name = "Cyborg reset board"
 	desc = "Used to reset cyborgs to their default module."
 	id = "borg_reset_board"
 	req_tech = list(Tc_ENGINEERING = 1)
@@ -49,7 +19,7 @@
 	materials = list(MAT_IRON=10000)
 
 /datum/design/borg_rename_board
-	name = "cyborg rename module"
+	name = "Cyborg rename board"
 	desc = "Used to rename cyborgs."
 	id = "borg_rename_board"
 	req_tech = list(Tc_ENGINEERING = 1)
@@ -59,61 +29,101 @@
 	materials = list(MAT_IRON=35000)
 
 /datum/design/borg_restart_board
-	name = "cyborg restart module"
+	name = "Cyborg emergency restart board"
 	desc = "Used to restart cyborgs."
 	id = "borg_restart_board"
 	req_tech = list(Tc_ENGINEERING = 1)
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/restart
 	category = "Robotic_Upgrade_Modules"
-	materials = list(MAT_IRON=60000 , MAT_GLASS=5000)
+	materials = list(MAT_IRON=60000, MAT_GLASS=5000)
 
 /datum/design/borg_vtec_board
-	name = "cyborg VTEC module"
+	name = "Cyborg VTEC upgrade"
 	desc = "Used to upgrade a borg's speed."
 	id = "borg_vtec_board"
 	req_tech = list(Tc_ENGINEERING = 1)
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/vtec
 	category = "Robotic_Upgrade_Modules"
-	materials = list(MAT_IRON=80000, MAT_GLASS=6000, MAT_GOLD= 5000)
-
-/datum/design/borg_tasercooler_board
-	name = "cyborg taser cooling module"
-	desc = "Used to upgrade cyborg taser cooling."
-	id = "borg_tasercooler_board"
-	req_tech = list(Tc_COMBAT = 1)
-	build_type = MECHFAB
-	build_path = /obj/item/borg/upgrade/tasercooler
-	category = "Robotic_Upgrade_Modules"
-	materials = list(MAT_IRON=80000 , MAT_GLASS=6000 , MAT_GOLD= 2000, MAT_DIAMOND = 500)
+	materials = list(MAT_IRON=80000, MAT_GLASS=6000, MAT_GOLD=5000)
 
 /datum/design/borg_jetpack_board
-	name = "cyborg jetpack module"
+	name = "Cyborg jetpack upgrade"
 	desc = "Used to give cyborgs a jetpack."
 	id = "borg_jetpack_board"
 	req_tech = list(Tc_ENGINEERING = 1)
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/jetpack
 	category = "Robotic_Upgrade_Modules"
-	materials = list(MAT_IRON=10000,MAT_PLASMA=15000,MAT_URANIUM = 20000)
+	materials = list(MAT_IRON=10000, MAT_PLASMA=15000, MAT_URANIUM=20000)
 
-/datum/design/borg_organ_gripper_board
-	name = "cyborg organ gripper module"
-	desc = "Used to give a medical cyborg a organ gripper."
-	id = "borg_organ_gripper_board"
-	req_tech = list(Tc_BIOTECH = 5, Tc_ENGINEERING = 4, Tc_ANOMALY = 3)
+/datum/design/borg_tasercooler_board
+	name = "Security cyborg rapid taser cooling upgrade"
+	desc = "Used to upgrade cyborg taser cooling."
+	id = "borg_tasercooler_board"
+	req_tech = list(Tc_COMBAT = 1)
 	build_type = MECHFAB
-	build_path = /obj/item/borg/upgrade/organ_gripper
+	build_path = /obj/item/borg/upgrade/tasercooler
 	category = "Robotic_Upgrade_Modules"
-	materials = list(MAT_IRON=80000 , MAT_PLASMA=50000 , MAT_SILVER=5000 , MAT_GOLD=5000 , MAT_PLASTIC=5000)
+	materials = list(MAT_IRON=80000, MAT_GLASS=6000, MAT_GOLD=2000, MAT_DIAMOND=500)
+
+/datum/design/borg_engineer_upgrade
+	name = "Engineering cyborg MK-2 upgrade"
+	desc = "Used to give an engineering cyborg more materials."
+	id = "borg_engineer_module"
+	build_type = MECHFAB
+	req_tech = list(Tc_ENGINEERING = 1)
+	build_path = /obj/item/borg/upgrade/engineering
+	category = "Robotic_Upgrade_Modules"
+	materials = list(MAT_IRON=10000, MAT_GLASS=10000, MAT_PLASMA=5000)
 
 /datum/design/borg_magnetic_gripper_board
-	name = "cyborg magnetic gripper module"
+	name = "Engineering cyborg magnetic gripper upgrade"
 	desc = "Used to give a engineering cyborg a magnetic gripper."
 	id = "borg_magnetic_gripper_board"
 	req_tech = list(Tc_MAGNETS = 5, Tc_ENGINEERING = 5, Tc_ANOMALY = 3)
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/magnetic_gripper
 	category = "Robotic_Upgrade_Modules"
-	materials = list(MAT_IRON=80000 , MAT_PLASMA=50000 , MAT_URANIUM=5000 , MAT_DIAMOND=5000, MAT_PLASTIC=5000)
+	materials = list(MAT_IRON=80000, MAT_PLASMA=50000, MAT_URANIUM=5000, MAT_DIAMOND=5000, MAT_PLASTIC=5000)
+
+/datum/design/medical_module_surgery
+	name = "Medical cyborg MK-2 upgrade"
+	desc = "Used to give a medical cyborg advanced care tools and upgrade their chemistry gripper to be able to handle pills and pill bottles."
+	id = "medical_module_surgery"
+	req_tech = list(Tc_BIOTECH = 3, Tc_ENGINEERING = 3, Tc_ANOMALY = 2)
+	build_type = MECHFAB
+	materials = list(MAT_IRON=80000, MAT_GLASS=20000, MAT_SILVER=5000)
+	build_path = /obj/item/borg/upgrade/medical/surgery
+	category = "Robotic_Upgrade_Modules"
+
+/datum/design/borg_organ_gripper_board
+	name = "Medical cyborg organ gripper upgrade"
+	desc = "Used to give a medical cyborg a organ gripper."
+	id = "borg_organ_gripper_board"
+	req_tech = list(Tc_BIOTECH = 5, Tc_ENGINEERING = 4, Tc_ANOMALY = 3)
+	build_type = MECHFAB
+	build_path = /obj/item/borg/upgrade/organ_gripper
+	category = "Robotic_Upgrade_Modules"
+	materials = list(MAT_IRON=80000, MAT_PLASMA=50000, MAT_SILVER=5000, MAT_GOLD=5000, MAT_PLASTIC=5000)
+
+/datum/design/borg_service_upgrade
+	name = "Service cyborg cooking upgrade"
+	desc = "Used to give a service cyborg cooking tools and upgrade their service gripper to be able to handle food."
+	id = "borg_service_module"
+	req_tech = list(Tc_BIOTECH = 2, Tc_ENGINEERING = 3, Tc_PROGRAMMING = 2, Tc_ANOMALY = 2)
+	build_type = MECHFAB
+	materials = list(MAT_IRON=45000, MAT_GLASS=8000, MAT_GOLD=2500)
+	build_path = /obj/item/borg/upgrade/service
+	category = "Robotic_Upgrade_Modules"
+
+/datum/design/borg_service_upgrade_hydro
+	name = "Service cyborg H.U.E.Y. upgrade"
+	desc = "Used to give a service cyborg hydroponics tools and upgrade their service gripper to be able to handle seeds, weed killers, sprayers and glass containers.."
+	id = "borg_service_module_hydro"
+	req_tech = list(Tc_BIOTECH = 4, Tc_ENGINEERING = 2, Tc_PROGRAMMING = 2, Tc_ANOMALY = 2)
+	build_type = MECHFAB
+	materials = list(MAT_IRON=45000, MAT_GLASS=8000, MAT_PLASTIC=2500)
+	build_path = /obj/item/borg/upgrade/hydro
+	category = "Robotic_Upgrade_Modules"

--- a/code/modules/research/designs/borg_upgrades.dm
+++ b/code/modules/research/designs/borg_upgrades.dm
@@ -120,7 +120,7 @@
 
 /datum/design/borg_service_upgrade_hydro
 	name = "Service cyborg H.U.E.Y. upgrade"
-	desc = "Used to give a service cyborg hydroponics tools and upgrade their service gripper to be able to handle seeds, weed killers, sprayers and glass containers.."
+	desc = "Used to give a service cyborg hydroponics tools and upgrade their service gripper to be able to handle seeds, weed killers, sprayers and glass containers."
 	id = "borg_service_module_hydro"
 	req_tech = list(Tc_BIOTECH = 4, Tc_ENGINEERING = 2, Tc_PROGRAMMING = 2, Tc_ANOMALY = 2)
 	build_type = MECHFAB


### PR DESCRIPTION
![nunames](https://user-images.githubusercontent.com/17928298/32756070-5a66c2d8-c8bf-11e7-9d3c-c3d579adcdac.png)

Cleans up upgrade code a little, fixes an odd bug with the lyscis machine and grippers, removes the ability to hold seeds and glass containers from the cooking upgrade and adds the H.U.E.Y. upgrade, it gives service borgs a mini hoe, clippers, plant bag and analyzer.

Also makes the cooking module cheaper for losing the plant bag and gripper upgrades.

:cl:
 * rscadd: Adds the H.U.E.Y. upgrade to service cyborgs! It comes with a mini hoe, clippers, plant bag, plant analyzer and makes the service gripper able to handle seeds and glass containers.
 * tweak: Removes the botanics-related upgrades from the cooking upgrade and makes it cheaper.

