### PR TITLE
Increases borg RCD cost for making airlocks

### DIFF
--- a/code/modules/RCD/engie.dm
+++ b/code/modules/RCD/engie.dm
@@ -27,7 +27,7 @@
 	/datum/rcd_schematic/decon,
 	/datum/rcd_schematic/con_floors,
 	/datum/rcd_schematic/con_walls,
-	/datum/rcd_schematic/con_airlock
+	/datum/rcd_schematic/con_airlock/borg
 	)
 
 /obj/item/weapon/rcd_ammo

--- a/code/modules/RCD/schematics/engi.dm
+++ b/code/modules/RCD/schematics/engi.dm
@@ -107,6 +107,9 @@
 	var/list/schematics			= list()
 	var/ready
 
+/datum/rcd_schematic/con_airlock/borg
+	energy_cost					= 30
+
 /datum/rcd_schematic/con_airlock/show(var/mob/living/user, close = 0)
 	if(!close)
 		user.shown_schematics_background = 1


### PR DESCRIPTION
![rcd](https://user-images.githubusercontent.com/26525955/32907086-b99c3f10-cadd-11e7-82a5-b9ce387e3f50.png)
I was able to recreate this screenshot as an engiborg with an unupgraded power cell and I was still at 50% energy remaining. That's just ridiculous.

With this new energy cost a borg will still be able to squeeze out about 12 airlocks in one full charge, which is around 9 more than what it should take for any construction project or non-griff law2 order.

:cl:
 * tweak: Increases energy cost of airlocks made with with borg RCDs