### PR TITLE
Paper bugfixes

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -349,10 +349,11 @@
 			C.update_icon()
 
 	else if(istype(P, /obj/item/weapon/photo) && !istype(src, /obj/item/weapon/paper/envelope))
+		if(img)
+			to_chat(user, "<span class='notice'>This paper already has a photo attached.</span>")
+			return
+
 		if(user.drop_item(P, src))
-			if(img)
-				to_chat(user, "<span class='notice'>This paper already has a photo attached.</span>")
-				return
 			img = P
 			to_chat(user, "<span class='notice'>You attach the photo to the piece of paper.</span>")
 	else if(P.is_hot())

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -253,35 +253,49 @@
 		var/id = href_list["write"]
 		//var/t = strip_html_simple(input(usr, "What text do you wish to add to " + (id=="end" ? "the end of the paper" : "field "+id) + "?", "[name]", null),8192) as message
 		//var/t =  strip_html_simple(input("Enter what you want to write:", "Write", null, null)  as message, MAX_MESSAGE_LEN)
-		var/t = sanitize(input("Enter what you want to write:", "Write", null, null) as message, MAX_MESSAGE_LEN)
-		var/obj/item/i = usr.get_active_hand() // Check to see if he still got that darn pen, also check if he's using a crayon or pen.
-		if(!istype(i,/obj/item/weapon/pen) && !istype(i,/obj/item/toy/crayon))
-			to_chat(usr, "<span class='warning'>Please ensure your pen is in your active hand and that you're holding the paper.</span>")
-			return
+		var/new_text
 
-		if(!Adjacent(usr, 1)) //the 1 means that the paper can be in one other item and be written on
-			return
+		//Wrap this part in a loop to prevent text from getting lost
+		do
+			new_text = sanitize(input("Enter what you want to write:", "Write", new_text) as null|message, MAX_MESSAGE_LEN)
+			var/obj/item/i = usr.get_active_hand() // Check to see if he still got that darn pen, also check if he's using a crayon or pen.
 
-		log += "<br />\[[time_stamp()]] [key_name(usr)] added: [t]"
+			//The user either entered a non-value, or logged off
+			if(isnull(new_text) || !usr.key)
+				return
 
-		t = replacetext(t, "\n", "<BR>")
+			//Not writing with a pen or crayon
+			if(!istype(i,/obj/item/weapon/pen) && !istype(i,/obj/item/toy/crayon))
+				to_chat(usr, "<span class='warning'>Please ensure your pen is in your active hand and that you're holding the paper.</span>")
+				continue
+
+			//Lost the paper or lost consciousness
+			if(!Adjacent(usr, 1) || usr.isUnconscious()) //the 1 means that the paper can be in one other item and be written on
+				to_chat(usr, "<span class='warning'>You are to unable to write on this paper.</span>")
+				continue
+
+		while(isnull(new_text))
+
+		log += "<br />\[[time_stamp()]] [key_name(usr)] added: [new_text]"
+
+		new_text = replacetext(new_text, "\n", "<BR>")
 
 		spawn()
-			t = parsepencode(usr,i,t)
+			new_text = parsepencode(usr, usr.get_active_hand() ,new_text)
 
 			//Count the fields
 			var/laststart = 1
 			while(1)
-				var/j = findtext(t, "<span class=\"paper_field\">", laststart)
+				var/j = findtext(new_text, "<span class=\"paper_field\">", laststart)
 				if(j==0)
 					break
 				laststart = j+1
 				fields++
 
 			if(id!="end")
-				addtofield(text2num(id), t) // He wants to edit a field, let him.
+				addtofield(text2num(id), new_text) // He wants to edit a field, let him.
 			else
-				info += t // Oh, he wants to edit to the end of the file, let him.
+				info += new_text // Oh, he wants to edit to the end of the file, let him.
 				updateinfolinks()
 
 			show_text(usr, links = TRUE)

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -148,7 +148,15 @@ var/paperwork_library
 					sleep(1) //too much for us.
 		t = replacetext(t, "\[sign\]", "<font face=\"Times New Roman\"><i>[user.real_name]</i></font>")
 		t = replacetext(t, "\[field\]", "<span class=\"paper_field\"></span>")
-	return "<span style=\"[style];color:[P.color]\">[t]</span>"
+
+	var/text_color
+	if(istype(P, /obj/item/weapon/pen))
+		text_color = P.color
+	else if(istype(P, /obj/item/toy/crayon))
+		var/obj/item/toy/crayon/C = P
+		text_color = C.colour
+
+	return "<span style=\"[style];color:[text_color]\">[t]</span>"
 
 /datum/writing_style/pen/New()
 	addReplacement(REG_BBTAG("\\*"), "<li>")


### PR DESCRIPTION
Fixes #16506 
Fixes #12263
Fixes #15235

:cl:
 * bugfix: Text written on paper with crayons is now colored again
 * tweak: Text written on paper is no longer permanently lost if the act of writing somehow fails, only if you press the 'Cancel' button