### PR TITLE
Fixes a varedit bug

### DIFF
--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -504,7 +504,7 @@ body
 		var/original_name = "[D]"
 		var/edited_variable = href_list["varnameedit"]
 		var/new_value = variable_set(src, D, edited_variable, TRUE)
-		message_admins("[key_name_admin(src)] modified [original_name]'s [edited_variable] to [new_value]", 1)
+		message_admins("[key_name_admin(src)] modified [original_name]'s [edited_variable] to [html_encode(new_value)]", 1)
 		world.log << "### VarEdit by [src]: [D.type] [edited_variable]=[html_encode("[new_value]")]"
 	else if(href_list["togbit"])
 		if(!check_rights(R_VAREDIT))

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -533,7 +533,7 @@ body
 		var/original_name = "[D]"
 		var/edited_variable = href_list["varnamechange"]
 		var/new_value = variable_set(src, D, edited_variable)
-		message_admins("[key_name_admin(src)] modified [original_name]'s [edited_variable] to [new_value]", 1)
+		message_admins("[key_name_admin(src)] modified [original_name]'s [edited_variable] to [html_encode(new_value)]", 1)
 		world.log << "### VarEdit by [src]: [D.type] [edited_variable]=[html_encode("[new_value]")]"
 	else if(href_list["varnamemass"] && href_list["datummass"])
 		if(!check_rights(R_VAREDIT))

--- a/code/modules/admin/verbs/massmodvar.dm
+++ b/code/modules/admin/verbs/massmodvar.dm
@@ -44,7 +44,7 @@
 	//Log the action before actually performing it, in case it crashes the server
 	feedback_add_details("admin_verb","MEV")
 	log_admin("[key_name(src)] mass modified [target_type]'s [variable_name] to [reset_to_initial ? "its initial value" : " [new_value] "]")
-	message_admins("[key_name_admin(src)] mass modified [target_type]'s [variable_name] to [reset_to_initial ? "its initial value" : " [new_value] "]", 1)
+	message_admins("[key_name_admin(src)] mass modified [target_type]'s [variable_name] to [reset_to_initial ? "its initial value" : " [html_encode(new_value)] "]", 1)
 
 	mass_modify_variable(target_type, variable_name, new_value, reset_to_initial, include_subtypes)
 

--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -201,7 +201,7 @@ var/list/forbidden_varedit_object_types = list(
 			edited_datum.vars[edited_variable] = new_value
 
 		if(logging)
-			log_admin("[key_name(usr)] modified [edited_datum]'s [edited_variable] to [new_value]")
+			log_admin("[key_name(usr)] modified [edited_datum]'s [edited_variable] to [html_encode(new_value)]")
 
 	return new_value
 


### PR DESCRIPTION
Previously, HTML was not stripped from admin messages, creating ugly admin logs, and in some cases even crashing the admins' clients