### PR TITLE
Fixes transit tube atmos

### DIFF
--- a/code/ZAS/_gas_mixture.dm
+++ b/code/ZAS/_gas_mixture.dm
@@ -133,10 +133,7 @@
 		var/combined_heat_capacity = giver_heat_capacity + self_heat_capacity
 		temperature = (temp * giver_heat_capacity + temperature * self_heat_capacity) / combined_heat_capacity
 
-	adjust_gas(gasid, moles, FALSE)
-
-	if(update)
-		update_values()
+	adjust_gas(gasid, moles, update)
 
 
 //Variadic version of adjust_gas(). Takes any number of gas and mole pairs and applies them.

--- a/code/ZAS/_gas_mixture.dm
+++ b/code/ZAS/_gas_mixture.dm
@@ -133,7 +133,7 @@
 		var/combined_heat_capacity = giver_heat_capacity + self_heat_capacity
 		temperature = (temp * giver_heat_capacity + temperature * self_heat_capacity) / combined_heat_capacity
 
-	adjust_gas(gasid, moles, update)
+	adjust_gas(gasid, moles, FALSE)
 
 	if(update)
 		update_values()


### PR DESCRIPTION
Transit tubes now share their air with their area in a less idiotic way. This means they behave differently from how they did even before the ZAS changes. The new behavior is probably better, but is also probably too subtly different to be noticeable.

Fixes #16582.

Also, because I'd probably forget if I waited, fixes an unrelated error in the ZAS changes that (theoretically) had no effect on anything, but performed unnecessary computations. Gotta have those marginal performance increases.