### PR TITLE
activated charcoal chemistry recipe

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -3005,5 +3005,14 @@
 	required_reagents = list(PETRITRICIN = 2, PACID = 3)
 	result_amount = 1
 
+/datum/chemical_reaction/active_charcoal
+	name = "Activated Charcoal"
+	id = CHARCOAL
+	result = CHARCOAL
+	required_reagents = list(CARBON = 1, SACID = 2)
+	required_temp = T0C + 450
+	result_amount = 1
+
+
 #undef ALERT_AMOUNT_ONLY
 #undef ALERT_ALL_REAGENTS


### PR DESCRIPTION
Uses the chemical activation method outlined in https://en.wikipedia.org/wiki/Activated_carbon#Production

Was not sure on the ratios of acid to carbon source, so 2 to 1 seemed a reasonable amount

:cl:
* rscadd: Activated charcoal recipe added. 2 parts acid, 1 part carbon. 450 degrees C