### PR TITLE
feral ghoul fixes

### DIFF
--- a/code/modules/mob/living/carbon/human/life/handle_mutations_and_radiation.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_mutations_and_radiation.dm
@@ -174,7 +174,10 @@
 					organ_to_damage.Add(I)
 				if(organ_to_damage.len)
 					var/datum/organ/internal/victim = pick(organ_to_damage)
-					victim.take_damage(rand(1,5)*rad_multiplier,silent = 0)
+					if(istype(victim, /datum/organ/internal/brain))
+						adjustBrainLoss(rand(1,4)*major_rad_multiplier)
+					else
+						victim.take_damage(rand(1,5)*rad_multiplier,silent = 0)
 			if(prob(0.5*major_rad_multiplier))
 				//Become uncloneable
 				if(!(M_NOCLONE in mutations))

--- a/code/modules/mob/living/simple_animal/hostile/necro.dm
+++ b/code/modules/mob/living/simple_animal/hostile/necro.dm
@@ -643,7 +643,7 @@
 
 /mob/living/simple_animal/hostile/necro/zombie/ghoul/Life()
 	..()
-	if(radiation && health < maxHealth)
+	if(!isDead() && radiation && health < maxHealth)
 		health++
 		radiation--
 
@@ -671,11 +671,10 @@
 
 /mob/living/simple_animal/hostile/necro/zombie/ghoul/glowing_one/Life()
 	..()
-
-
-	if(world.time > last_rad_blast+20 SECONDS)
-		rad_blast()
-	radiation+=5
+	if(!isDead())
+		if(world.time > last_rad_blast+20 SECONDS)
+			rad_blast()
+		radiation+=5
 
 /mob/living/simple_animal/hostile/necro/zombie/ghoul/glowing_one/proc/rad_blast()
 	if(radiation > RAD_COST)
@@ -688,14 +687,19 @@
 				var/rad_cost = min(radiation, rand(10,20))
 				H.apply_radiation(rad_cost, RAD_EXTERNAL)
 				radiation -= rad_cost
-			for(var/mob/living/simple_animal/hostile/necro/zombie/ghoul/G in can_see)
-				if(G.isDead() && radiation > 100)
-					G.revive()
-					radiation -= 100
-				if(radiation > 25)
-					var/rad_cost = min(radiation, rand(10,20))
-					G.apply_radiation(10, RAD_EXTERNAL)
-					radiation -= rad_cost
+				if(!radiation)
+					break
+			if(radiation > 25)
+				for(var/mob/living/simple_animal/hostile/necro/zombie/ghoul/G in can_see)
+					if(G.isDead() && radiation > 100)
+						G.revive()
+						radiation -= 100
+					if(radiation > 25)
+						var/rad_cost = min(radiation, rand(10,20))
+						G.apply_radiation(10, RAD_EXTERNAL)
+						radiation -= rad_cost
+					if(radiation < 25)
+						break
 			last_rad_blast = world.time
 			spawn(3 SECONDS)
 				set_light(1, 2, "#5dca31")


### PR DESCRIPTION
During some more blood moon event testing, I noticed this server actually has feral ghouls, and they were quite broken.

- Refusing to stay dead, but not actually getting up, so you would end up getting weird crawling things that would revive while you were butchering them
- The world would freeze every time a glowing one would let loose a 'rad blast'

So, added some isdead checks so they would actually stay dead unless otherwise instructed, and some breaks out of for loops so as to reduce complexity. 

:cl:
* rscadd: Feral ghouls are fixed
* tweak: It is now easier to become a ghoul somewhat. Less uncurable brain damage.