### PR TITLE
canes now have a use.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -36,9 +36,12 @@
 			if(!E || (E.status & ORGAN_DESTROYED))
 				. += 4
 			if(E.status & ORGAN_SPLINTED)
-				. += 0.5
+				if(!find_held_item_by_type(/obj/item/weapon/cane))
+					. += 0.5
 			else if(E.status & ORGAN_BROKEN)
-				. += 1.5
+				if(!find_held_item_by_type(/obj/item/weapon/cane))
+					. += 1
+				. += 0.5
 
 /mob/living/carbon/human/movement_tally_multiplier()
 	. = ..()


### PR DESCRIPTION
If your legs are broken and splintered, having a cane now takes off most of the slowdown that is incurred.

:cl:
* rscadd: Having a cane on you when your leg's broken now helps you move a bit faster than otherwise.