### PR TITLE
You now get 40 bananium/phazon floortiles per sheet (up from 4), disables bananium/phazon scanning on cyborg matsynths

### DIFF
--- a/code/game/objects/items/devices/mat_synth.dm
+++ b/code/game/objects/items/devices/mat_synth.dm
@@ -34,6 +34,10 @@
 							 "floor tiles" = /obj/item/stack/tile/plasteel,
 							 "metal rods" = /obj/item/stack/rods)
 
+/obj/item/device/material_synth/robot/New()
+	. = ..()
+	can_scan = existing_typesof(/obj/item/stack/sheet) - list(/obj/item/stack/sheet/mineral/clown, /obj/item/stack/sheet/mineral/phazon)
+
 /obj/item/device/material_synth/robot/mommi //MoMMI version, a few more materials to start with.
 	materials_scanned = list("metal" = /obj/item/stack/sheet/metal,
 							 "glass" = /obj/item/stack/sheet/glass/glass,
@@ -150,7 +154,7 @@
 		materials_scanned["[initial(target.name)]"] = target.type
 		to_chat(user, "<span class='notice'>You successfully scan \the [target] into \the [src]'s material banks.</span>")
 		return 1
-	else if(istype(target, /obj/item/stack/sheet)) //We can't scan it, but, only display an error when trying to scan a sheet. Currently only happens with MoMMI matsynths.
+	else if(istype(target, /obj/item/stack/sheet)) //We can't scan it, but, only display an error when trying to scan a sheet.
 		to_chat(user, "<span class='warning'>Your [src.name] does not contain this functionality to scan this type of material.</span>")
 	return ..()
 

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -224,7 +224,7 @@ var/list/datum/stack_recipe/gold_recipes = list ( \
  * Phazon
  */
 var/list/datum/stack_recipe/phazon_recipes = list( \
-	new/datum/stack_recipe("phazon floor tile", /obj/item/stack/tile/mineral/phazon, 1, 4, 20), \
+	new/datum/stack_recipe("phazon floor tile", /obj/item/stack/tile/mineral/phazon, 1, 15, 20), \
 	)
 
 /obj/item/stack/sheet/mineral/phazon
@@ -290,7 +290,7 @@ var/list/datum/stack_recipe/silver_recipes = list ( \
 	recyck_mat = MAT_CLOWN
 
 var/list/datum/stack_recipe/clown_recipes = list ( \
-	new/datum/stack_recipe("bananium floor tile", /obj/item/stack/tile/mineral/clown, 1, 4, 20), \
+	new/datum/stack_recipe("bananium floor tile", /obj/item/stack/tile/mineral/clown, 1, 15, 20), \
 	)
 
 /obj/item/stack/sheet/mineral/clown/New(var/loc, var/amount=null)

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -224,7 +224,7 @@ var/list/datum/stack_recipe/gold_recipes = list ( \
  * Phazon
  */
 var/list/datum/stack_recipe/phazon_recipes = list( \
-	new/datum/stack_recipe("phazon floor tile", /obj/item/stack/tile/mineral/phazon, 1, 15, 20), \
+	new/datum/stack_recipe("phazon floor tile", /obj/item/stack/tile/mineral/phazon, 1, 40, 20), \
 	)
 
 /obj/item/stack/sheet/mineral/phazon
@@ -290,7 +290,7 @@ var/list/datum/stack_recipe/silver_recipes = list ( \
 	recyck_mat = MAT_CLOWN
 
 var/list/datum/stack_recipe/clown_recipes = list ( \
-	new/datum/stack_recipe("bananium floor tile", /obj/item/stack/tile/mineral/clown, 1, 15, 20), \
+	new/datum/stack_recipe("bananium floor tile", /obj/item/stack/tile/mineral/clown, 1, 40, 20), \
 	)
 
 /obj/item/stack/sheet/mineral/clown/New(var/loc, var/amount=null)


### PR DESCRIPTION
Why?
It's not characteristic of an engineering cyborg to just be used to dupe exotic materials like a bitch. That's not engineering work.
As far as I'm aware, this duping is only used for 2 things:
1. Cheesing materials and making a shitton of phazon from just 1 slime split, then having an effectively unlimited amount of sheets to spam phazon mechs and phazon mutations
2. Meme floors (basically impossible without duping)

I preserved the second option and made you not need to dupe so badly to use it. MoMMis can also still do it, since dropping the sheets would be interference and mineral floortiles cannot be recycled back into sheets.
As for the first: You CAN still synthesize phazon, you'll just have to use the regular matsynth that uses solid ammo.
>A device capable of producing very little material with a great deal of investment. Use wisely.


:cl:
 * tweak: You now get 40 bananium/phazon floortiles per sheet, up from 4
 * rscdel: Cyborg material synthetizers cannot dupe bananium or phazon. You can still synthetize it by using solid matter cartridges.