### PR TITLE
Make lootcrates admin spawn only

### DIFF
--- a/code/game/machinery/computer/store.dm
+++ b/code/game/machinery/computer/store.dm
@@ -25,7 +25,7 @@
 			/datum/storeitem/beachball,
 			/datum/storeitem/snap_pops,
 			/datum/storeitem/crayons,
-			/datum/storeitem/dorkcube,
+			///datum/storeitem/dorkcube,
 			),
 		"Clothing" = list(
 			/datum/storeitem/robotnik_labcoat,


### PR DESCRIPTION
Hey everyone publically shame Angry Duck because he thinks that it's git's fault he can't read the manual
