### PR TITLE
Fixes maploader being much more laggy than it needs to be

### DIFF
--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -135,7 +135,7 @@ var/list/map_dimension_cache = list()
 			for(var/mpos=1;mpos<=x_depth;mpos+=key_len)
 				xcrd++
 				var/model_key = copytext(grid_line,mpos,mpos+key_len)
-				spawned_atoms += parse_grid(grid_models[model_key],xcrd,ycrd,zcrd+z_offset)
+				spawned_atoms |= parse_grid(grid_models[model_key],xcrd,ycrd,zcrd+z_offset)
 			if(map_element)
 				map_element.width = xcrd - x_offset
 
@@ -242,7 +242,7 @@ var/list/map_dimension_cache = list()
 
 	if(!isspace(instance)) //Space is the default area and contains every loaded turf by default
 		instance.contents.Add(locate(xcrd,ycrd,zcrd))
-		spawned_atoms |= instance
+		spawned_atoms.Add(instance)
 
 	if(_preloader && instance)
 		_preloader.load(instance)
@@ -286,7 +286,8 @@ var/list/map_dimension_cache = list()
 
 	//finally instance all remainings objects/mobs
 	for(index=1,index < first_turf_index,index++)
-		spawned_atoms.Add(instance_atom(members[index],members_attributes[index],xcrd,ycrd,zcrd))
+		var/atom/new_atom = instance_atom(members[index],members_attributes[index],xcrd,ycrd,zcrd)
+		spawned_atoms.Add(new_atom)
 
 	return spawned_atoms
 


### PR DESCRIPTION
The spawned_atoms list contained a reference to an area for every created turf. Then, the initialize() proc went through each of those area references and called power_change().
no longer the case now

Official theme song: https://www.youtube.com/watch?v=PX7zPlQjAr8

:cl:
 * bugfix: Fixed maploader being very laggy and crashing the server when loading away missions