### PR TITLE
Cloning Pod Mousedrop_T() and kick_act()

### DIFF
--- a/code/modules/medical/cloning.dm
+++ b/code/modules/medical/cloning.dm
@@ -390,7 +390,7 @@
 			to_chat(user, "System unlocked.")
 	if (istype(W, /obj/item/weapon/reagent_containers/food/snacks/meat))
 		if(user.drop_item(W))
-			playsound(get_turf(src), 'sound/machines/juicer.ogg', 30, 1)
+			playsound(get_turf(src), 'sound/machines/juicerfast.ogg', 30, 1)
 			to_chat(user, "<span class='notice'>\The [src] processes \the [W].</span>")
 			biomass += BIOMASS_CHUNK
 			qdel(W)
@@ -526,13 +526,13 @@
 	if(!busy)
 		busy = TRUE
 		if(!issilicon(usr) && !usr.incapacitated() && Adjacent(usr) && !(stat & (NOPOWER|BROKEN)))
-			for(var/obj/item/weapon/reagent_containers/food/snacks/meat in range(1, src))
+			for(var/obj/item/weapon/reagent_containers/food/snacks/meat/meat in range(1, src))
 				biomass += BIOMASS_CHUNK
 				qdel(meat)
 				visible_message = TRUE // Prevent chatspam when multiple meat are near
 
 			if(visible_message)
-				playsound(get_turf(src), 'sound/machines/juicerfast.ogg', 30, 1)
+				playsound(get_turf(src), 'sound/machines/juicer.ogg', 30, 1)
 				visible_message("<span class = 'notice'>[src] sucks in and processes the nearby biomass.</span>")
 		busy = FALSE
 

--- a/code/modules/medical/cloning.dm
+++ b/code/modules/medical/cloning.dm
@@ -4,23 +4,24 @@
 //Potential replacement for genetics revives or something I dunno (?)
 
 #define CLONE_BIOMASS 150
+#define BIOMASS_CHUNK 50
 
 /obj/machinery/cloning/clonepod
-	anchored = 1
+	anchored = TRUE
 	name = "cloning pod"
 	desc = "An electronically-lockable pod for growing organic tissue."
-	density = 1
+	density = TRUE
 	icon = 'icons/obj/cloning.dmi'
 	icon_state = "pod_0"
 	req_access = list(access_genetics) //For premature unlocking.
 	var/mob/living/occupant
 	var/heal_level = 90 //The clone is released once its health reaches this level.
-	var/locked = 0
+	var/locked = FALSE
 	var/frequency = 0
 	var/obj/machinery/computer/cloning/connected = null //So we remember the connected clone machine.
-	var/mess = 0 //Need to clean out it if it's full of exploded clone.
-	var/working = 0 //One clone attempt at a time thanks
-	var/eject_wait = 0 //Don't eject them as soon as they are created fuckkk
+	var/mess = FALSE //Need to clean out it if it's full of exploded clone.
+	var/working = FALSE //One clone attempt at a time thanks
+	var/eject_wait = FALSE //Don't eject them as soon as they are created fuckkk
 	var/biomass = 0
 	var/time_coeff = 1 //Upgraded via part upgrading
 	var/resource_efficiency = 1
@@ -113,7 +114,7 @@
 
 /obj/item/weapon/disk/data/monkey
 	name = "data disk - 'Mr. Muggles'"
-	read_only = 1
+	read_only = TRUE
 
 /obj/item/weapon/disk/data/monkey/New()
 	..()
@@ -152,12 +153,12 @@
 	icon_state = "datadisk[diskcolor]"
 
 /obj/item/weapon/disk/data/attack_self(mob/user as mob)
-	src.read_only = !src.read_only
-	to_chat(user, "You flip the write-protect tab to [src.read_only ? "protected" : "unprotected"].")
+	read_only = !read_only
+	to_chat(user, "You flip the write-protect tab to [read_only ? "protected" : "unprotected"].")
 
 /obj/item/weapon/disk/data/examine(mob/user)
 	..()
-	to_chat(user, "The write-protect tab is set to [src.read_only ? "protected" : "unprotected"].")
+	to_chat(user, "The write-protect tab is set to [read_only ? "protected" : "unprotected"].")
 
 //Health Tracker Implant
 
@@ -166,26 +167,26 @@
 	var/healthstring = ""
 
 /obj/item/weapon/implant/health/proc/sensehealth()
-	if (!src.implanted)
+	if (!implanted)
 		return "ERROR"
 	else
-		if(isliving(src.implanted))
-			var/mob/living/L = src.implanted
-			src.healthstring = "[round(L.getOxyLoss())] - [round(L.getFireLoss())] - [round(L.getToxLoss())] - [round(L.getBruteLoss())]"
-		if (!src.healthstring)
-			src.healthstring = "ERROR"
-		return src.healthstring
+		if(isliving(implanted))
+			var/mob/living/L = implanted
+			healthstring = "[round(L.getOxyLoss())] - [round(L.getFireLoss())] - [round(L.getToxLoss())] - [round(L.getBruteLoss())]"
+		if (!healthstring)
+			healthstring = "ERROR"
+		return healthstring
 
 /obj/machinery/cloning/clonepod/attack_ai(mob/user as mob)
-	src.add_hiddenprint(user)
+	add_hiddenprint(user)
 	return attack_hand(user)
 /obj/machinery/cloning/clonepod/attack_paw(mob/user as mob)
 	return attack_hand(user)
 /obj/machinery/cloning/clonepod/attack_hand(mob/user as mob)
-	if ((isnull(src.occupant)) || (stat & NOPOWER))
+	if ((isnull(occupant)) || (stat & NOPOWER))
 		return
-	if ((!isnull(src.occupant)) && (src.occupant.stat != 2))
-		var/completion = (100 * ((src.occupant.health + 100) / (src.heal_level + 100)))
+	if ((!isnull(occupant)) && (occupant.stat != 2))
+		var/completion = (100 * ((occupant.health + 100) / (heal_level + 100)))
 		to_chat(user, "Current clone cycle is [round(completion)]% complete.")
 	return
 
@@ -194,15 +195,15 @@
 //Start growing a human clone in the pod!
 /obj/machinery/cloning/clonepod/proc/growclone(var/datum/dna2/record/R)
 	if(mess || working)
-		return 0
+		return FALSE
 	var/datum/mind/clonemind = locate(R.mind)
 	if(!istype(clonemind,/datum/mind))	//not a mind
-		return 0
+		return FALSE
 	if( clonemind.current && clonemind.current.stat != DEAD )	//mind is associated with a non-dead body
-		return 0
+		return FALSE
 	if(clonemind.active)	//somebody is using that mind
 		if( ckey(clonemind.key)!=R.ckey )
-			return 0
+			return FALSE
 	else
 		for(var/mob/G in player_list)
 			if(G.ckey == R.ckey)
@@ -210,21 +211,21 @@
 					if(G:can_reenter_corpse)
 						break
 					else
-						return 0
+						return FALSE
 				else
 					if((G.mind && (G.mind.current.stat != DEAD) ||  G.mind != clonemind))
-						return 0
+						return FALSE
 
 
-	src.heal_level = rand(10,40) //Randomizes what health the clone is when ejected
-	src.working = 1 //One at a time!!
-	src.locked = 1
+	heal_level = rand(10,40) //Randomizes what health the clone is when ejected
+	working = TRUE //One at a time!!
+	locked = TRUE
 
-	src.eject_wait = 1
+	eject_wait = TRUE
 	spawn(30)
-		src.eject_wait = 0
+		eject_wait = FALSE
 
-	var/mob/living/carbon/human/H = new /mob/living/carbon/human(src, R.dna.species, delay_ready_dna=1)
+	var/mob/living/carbon/human/H = new /mob/living/carbon/human(src, R.dna.species, delay_ready_dna = TRUE)
 	occupant = H
 
 	if(!connected.emagged)
@@ -239,10 +240,10 @@
 	H.dna.flavor_text = R.dna.flavor_text
 	H.dna.species = R.dna.species
 	if(H.dna.species != "Human")
-		H.set_species(H.dna.species, 1)
+		H.set_species(H.dna.species, TRUE)
 
 	H.adjustCloneLoss(150) //new damage var so you can't eject a clone early then stab them to abuse the current damage system --NeoFite
-	H.adjustBrainLoss(src.heal_level + 50 + rand(10, 30)) // The rand(10, 30) will come out as extra brain damage
+	H.adjustBrainLoss(heal_level + 50 + rand(10, 30)) // The rand(10, 30) will come out as extra brain damage
 	H.Paralyse(4)
 	H.stat = UNCONSCIOUS //There was a bug which allowed you to talk for a few seconds after being cloned, because your stat wasn't updated until next Life() tick. This is a fix for this!
 
@@ -262,7 +263,7 @@
 	if(isnukeop(H))
 		ticker.mode.update_all_synd_icons()
 	if (iscult(H))
-		ticker.mode.add_cultist(src.occupant.mind)
+		ticker.mode.add_cultist(occupant.mind)
 		ticker.mode.update_all_cult_icons() //So the icon actually appears
 	if(iswizard(H) || isapprentice(H))
 		ticker.mode.update_all_wizard_icons()
@@ -288,60 +289,60 @@
 	H.real_name = H.dna.real_name
 	H.flavor_text = H.dna.flavor_text
 
-	H.suiciding = 0
-	return 1
+	H.suiciding = FALSE
+	return TRUE
 
 //Grow clones to maturity then kick them out.  FREELOADERS
 /obj/machinery/cloning/clonepod/process()
 
 	if(stat & NOPOWER) //Autoeject if power is lost
-		if (src.occupant)
-			src.locked = 0
-			src.go_out()
+		if (occupant)
+			locked = FALSE
+			go_out()
 		return
 
-	if((src.occupant) && (src.occupant.loc == src))
-		if((src.occupant.stat == DEAD) || (src.occupant.suiciding) || !occupant.key)  //Autoeject corpses and suiciding dudes.
-			src.locked = 0
-			src.go_out()
-			src.connected_message("Clone Rejected: Deceased.")
+	if((occupant) && (occupant.loc == src))
+		if((occupant.stat == DEAD) || (occupant.suiciding) || !occupant.key)  //Autoeject corpses and suiciding dudes.
+			locked = FALSE
+			go_out()
+			connected_message("Clone Rejected: Deceased.")
 			return
 
-		else if(src.occupant.health < src.heal_level)
-			src.occupant.Paralyse(4)
+		else if(occupant.health < heal_level)
+			occupant.Paralyse(4)
 
 			 //Slowly get that clone healed and finished.
-			src.occupant.adjustCloneLoss(-1*time_coeff) //Very slow, new parts = much faster
+			occupant.adjustCloneLoss(-1*time_coeff) //Very slow, new parts = much faster
 
 			//Premature clones may have brain damage.
-			src.occupant.adjustBrainLoss(-1*time_coeff) //Ditto above
+			occupant.adjustBrainLoss(-1*time_coeff) //Ditto above
 
 			//So clones don't die of oxyloss in a running pod.
-			if (src.occupant.reagents.get_reagent_amount(INAPROVALINE) < 30)
-				src.occupant.reagents.add_reagent(INAPROVALINE, 60)
+			if (occupant.reagents.get_reagent_amount(INAPROVALINE) < 30)
+				occupant.reagents.add_reagent(INAPROVALINE, 60)
 
-			var/mob/living/carbon/human/H = src.occupant
+			var/mob/living/carbon/human/H = occupant
 
 			if(istype(H.species, /datum/species/vox))
-				src.occupant.reagents.add_reagent(NITROGEN, 10)
+				occupant.reagents.add_reagent(NITROGEN, 10)
 
 			//Also heal some oxyloss ourselves because inaprovaline is so bad at preventing it!!
-			src.occupant.adjustOxyLoss(-4)
+			occupant.adjustOxyLoss(-4)
 
 			use_power(7500) //This might need tweaking.
 			return
 
-		else if((src.occupant.health >= src.heal_level) && (!src.eject_wait))
-			src.connected_message("Cloning Process Complete.")
-			src.locked = 0
-			src.go_out()
+		else if((occupant.health >= heal_level) && (!eject_wait))
+			connected_message("Cloning Process Complete.")
+			locked = FALSE
+			go_out()
 			return
 
-	else if ((!src.occupant) || (src.occupant.loc != src))
-		src.occupant = null
-		if (src.locked)
-			src.locked = 0
-		if (!src.mess)
+	else if ((!occupant) || (occupant.loc != src))
+		occupant = null
+		if (locked)
+			locked = FALSE
+		if (!mess)
 			icon_state = "pod_0"
 		use_power(200)
 		return
@@ -349,18 +350,18 @@
 	return
 
 /obj/machinery/cloning/clonepod/emag(mob/user as mob)
-	if (isnull(src.occupant))
+	if (isnull(occupant))
 		return
 	to_chat(user, "You force an emergency ejection.")
-	src.locked = 0
-	src.go_out()
+	locked = FALSE
+	go_out()
 	return
 
 /obj/machinery/cloning/clonepod/crowbarDestroy(mob/user)
 	if(occupant)
 		to_chat(user, "<span class='warning'>You cannot disassemble \the [src], it's occupado.</span>")
 		return
-	for(biomass; biomass > 0;biomass -= 50)
+	for(biomass; biomass > 0;biomass -= BIOMASS_CHUNK)
 		new /obj/item/weapon/reagent_containers/food/snacks/meat/syntiflesh(loc)
 	return..()
 
@@ -379,31 +380,31 @@
 	if(.)
 		return .
 	if (istype(W, /obj/item/weapon/card/id)||istype(W, /obj/item/device/pda))
-		if (!src.check_access(W))
+		if (!check_access(W))
 			to_chat(user, "<span class='warning'>Access Denied.</span>")
 			return
-		else if ((!src.locked) || (isnull(src.occupant)))
+		else if ((!locked) || (isnull(occupant)))
 			return
 		else
-			src.locked = 0
+			locked = FALSE
 			to_chat(user, "System unlocked.")
 	if (istype(W, /obj/item/weapon/reagent_containers/food/snacks/meat))
 		if(user.drop_item(W))
 			to_chat(user, "<span class='notice'>\The [src] processes \the [W].</span>")
-			biomass += 50
+			biomass += BIOMASS_CHUNK
 			qdel(W)
 			return
 
 //Put messages in the connected computer's temp var for display.
 /obj/machinery/cloning/clonepod/proc/connected_message(var/message)
-	if ((isnull(src.connected)) || (!istype(src.connected, /obj/machinery/computer/cloning)))
-		return 0
+	if ((isnull(connected)) || (!istype(connected, /obj/machinery/computer/cloning)))
+		return FALSE
 	if (!message)
-		return 0
+		return FALSE
 
-	src.connected.temp = message
-	src.connected.updateUsrDialog()
-	return 1
+	connected.temp = message
+	connected.updateUsrDialog()
+	return TRUE
 
 /obj/machinery/cloning/clonepod/verb/eject()
 	set name = "Eject Cloner"
@@ -412,40 +413,30 @@
 
 	if (usr.isUnconscious())
 		return
-	src.go_out()
+	go_out()
 	add_fingerprint(usr)
 	return
 
-/obj/machinery/cloning/clonepod/proc/go_out(var/exit = src.loc)
+/obj/machinery/cloning/clonepod/proc/go_out(var/exit = loc)
 	if (locked)
 		return
 
 	if (mess) //Clean that mess and dump those gibs!
-		mess = 0
-		working = 0 //NOW we're done.
+		mess = FALSE
+		working = FALSE //NOW we're done.
 		gibs(loc)
 		icon_state = "pod_0"
-
-		/*
-		for(var/obj/O in src)
-			O.forceMove(src.loc)
-		*/
 		return
 
-	if (!(src.occupant))
+	if (!(occupant))
 		return
-
-	/*
-	for(var/obj/O in src)
-		O.forceMove(src.loc)
-	*/
 
 	if (occupant.client)
 		occupant.client.eye = occupant.client.mob
 		occupant.client.perspective = MOB_PERSPECTIVE
 	occupant.forceMove(exit)
 	icon_state = "pod_0"
-	eject_wait = 0 //If it's still set somehow.
+	eject_wait = FALSE //If it's still set somehow.
 	domutcheck(occupant) //Waiting until they're out before possible monkeyizing.
 	occupant.add_side_effect("Bad Stomach") // Give them an extra side-effect for free.
 	occupant = null
@@ -455,9 +446,9 @@
 		biomass = 0
 
 	connected.update_icon()
-	working = 0 //NOW we're done.
+	working = FALSE //NOW we're done.
 
-	return 1
+	return TRUE
 
 /obj/machinery/cloning/clonepod/MouseDrop(over_object, src_location, var/turf/over_location, src_control, over_control, params)
 	if(!occupant || occupant == usr || (!ishuman(usr) && !isrobot(usr)) || usr.incapacitated() || usr.lying)
@@ -483,19 +474,19 @@
 		add_fingerprint(usr)
 
 /obj/machinery/cloning/clonepod/proc/malfunction()
-	if(src.occupant)
-		src.connected_message("Critical Error!")
-		src.mess = 1
+	if(occupant)
+		connected_message("Critical Error!")
+		mess = TRUE
 		icon_state = "pod_g"
-		src.occupant.ghostize()
+		occupant.ghostize()
 		spawn(5)
-			qdel(src.occupant)
+			qdel(occupant)
 	return
 
 /obj/machinery/cloning/clonepod/relaymove(mob/user as mob)
 	if (user.stat)
 		return
-	src.go_out()
+	go_out()
 	return
 
 /obj/machinery/cloning/clonepod/emp_act(severity)
@@ -507,26 +498,49 @@
 	switch(severity)
 		if(1.0)
 			for(var/atom/movable/A as mob|obj in src)
-				A.forceMove(src.loc)
+				A.forceMove(loc)
 				ex_act(severity)
 			qdel(src)
 			return
 		if(2.0)
 			if (prob(50))
 				for(var/atom/movable/A as mob|obj in src)
-					A.forceMove(src.loc)
+					A.forceMove(loc)
 					ex_act(severity)
 				qdel(src)
 				return
 		if(3.0)
 			if (prob(25))
 				for(var/atom/movable/A as mob|obj in src)
-					A.forceMove(src.loc)
+					A.forceMove(loc)
 					ex_act(severity)
 				qdel(src)
 				return
 		else
 	return
+
+/obj/machinery/cloning/clonepod/AltClick()
+	var/visible_message = FALSE
+	var/busy = FALSE
+	if(!busy)
+		busy = TRUE
+		if(!issilicon(usr) && !usr.incapacitated() && Adjacent(usr) && !(stat & (NOPOWER|BROKEN)) && usr.dexterity_check())
+			for(var/obj/item/weapon/reagent_containers/food/snacks/meat in range(1, src))
+				biomass += BIOMASS_CHUNK
+				qdel(meat)
+				visible_message = TRUE // Prevent chatspam when multiple meat are near
+
+			if(visible_message)
+				visible_message("<span class = 'notice'>[src] sucks in and processes the nearby biomass.</span>")
+		busy = FALSE
+
+/obj/machinery/cloning/clonepod/kick_act()
+	..()
+	if(prob(5))
+		visible_message("<span class='notice'>[src] buzzes.</span>","<span class='warning'>You hear a buzz.</span>")
+		playsound(get_turf(src), 'sound/machines/buzz-sigh.ogg', 50, 0)
+		locked = FALSE
+	go_out() // Try to remove the occupant anyways
 
 /*
  *	Diskette Box
@@ -573,9 +587,3 @@
 	<i>A good diskette is a great way to counter aforementioned genetic drift!</i><br>
 	<br>
 	<font size=1>This technology produced under license from Thinktronic Systems, LTD.</font>"}
-
-//SOME SCRAPS I GUESS
-/* EMP grenade/spell effect
-		if(istype(A, /obj/machinery/clonepod))
-			A:malfunction()
-*/

--- a/code/modules/medical/cloning.dm
+++ b/code/modules/medical/cloning.dm
@@ -390,6 +390,7 @@
 			to_chat(user, "System unlocked.")
 	if (istype(W, /obj/item/weapon/reagent_containers/food/snacks/meat))
 		if(user.drop_item(W))
+			playsound(get_turf(src), 'sound/machines/juicer.ogg', 30, 1)
 			to_chat(user, "<span class='notice'>\The [src] processes \the [W].</span>")
 			biomass += BIOMASS_CHUNK
 			qdel(W)
@@ -524,23 +525,27 @@
 	var/busy = FALSE
 	if(!busy)
 		busy = TRUE
-		if(!issilicon(usr) && !usr.incapacitated() && Adjacent(usr) && !(stat & (NOPOWER|BROKEN)) && usr.dexterity_check())
+		if(!issilicon(usr) && !usr.incapacitated() && Adjacent(usr) && !(stat & (NOPOWER|BROKEN)))
 			for(var/obj/item/weapon/reagent_containers/food/snacks/meat in range(1, src))
 				biomass += BIOMASS_CHUNK
 				qdel(meat)
 				visible_message = TRUE // Prevent chatspam when multiple meat are near
 
 			if(visible_message)
+				playsound(get_turf(src), 'sound/machines/juicerfast.ogg', 30, 1)
 				visible_message("<span class = 'notice'>[src] sucks in and processes the nearby biomass.</span>")
 		busy = FALSE
 
 /obj/machinery/cloning/clonepod/kick_act()
 	..()
-	if(prob(5))
+	if(occupant && prob(5))
 		visible_message("<span class='notice'>[src] buzzes.</span>","<span class='warning'>You hear a buzz.</span>")
 		playsound(get_turf(src), 'sound/machines/buzz-sigh.ogg', 50, 0)
 		locked = FALSE
-	go_out() // Try to remove the occupant anyways
+		go_out()
+	else
+		AltClick()
+	
 
 /*
  *	Diskette Box

--- a/code/modules/medical/cloning.dm
+++ b/code/modules/medical/cloning.dm
@@ -520,32 +520,45 @@
 		else
 	return
 
-/obj/machinery/cloning/clonepod/AltClick()
-	var/visible_message = FALSE
+/obj/machinery/cloning/clonepod/MouseDrop_T(obj/item/weapon/reagent_containers/food/snacks/meat/M, mob/living/user)
 	var/busy = FALSE
+	var/visible_message = FALSE
+
+	if(!istype(M))
+		return
+
+	if(issilicon(user))
+		return //*buzz
+
+	if(!Adjacent(user) || !user.Adjacent(src) || M.loc == user || !isturf(M.loc) || !isturf(user.loc) || user.loc==null)
+		return
+
+	if(user.incapacitated() || user.lying)
+		return
+
+	if(stat & (NOPOWER|BROKEN))
+		return
+
 	if(!busy)
 		busy = TRUE
-		if(!issilicon(usr) && !usr.incapacitated() && Adjacent(usr) && !(stat & (NOPOWER|BROKEN)))
-			for(var/obj/item/weapon/reagent_containers/food/snacks/meat/meat in range(1, src))
-				biomass += BIOMASS_CHUNK
-				qdel(meat)
-				visible_message = TRUE // Prevent chatspam when multiple meat are near
+		for(var/obj/item/weapon/reagent_containers/food/snacks/meat/meat in M.loc)
+			biomass += BIOMASS_CHUNK
+			qdel(meat)
+			visible_message = TRUE // Prevent chatspam when multiple meat are near
 
-			if(visible_message)
-				playsound(get_turf(src), 'sound/machines/juicer.ogg', 30, 1)
-				visible_message("<span class = 'notice'>[src] sucks in and processes the nearby biomass.</span>")
+		if(visible_message)
+			playsound(get_turf(src), 'sound/machines/juicer.ogg', 30, 1)
+			visible_message("<span class = 'notice'>[src] sucks in and processes the nearby biomass.</span>")
 		busy = FALSE
 
 /obj/machinery/cloning/clonepod/kick_act()
 	..()
+
 	if(occupant && prob(5))
 		visible_message("<span class='notice'>[src] buzzes.</span>","<span class='warning'>You hear a buzz.</span>")
 		playsound(get_turf(src), 'sound/machines/buzz-sigh.ogg', 50, 0)
 		locked = FALSE
 		go_out()
-	else
-		AltClick()
-	
 
 /*
  *	Diskette Box


### PR DESCRIPTION
Ports biomass processing from paradise, adds a kick act that has 5% chance to eject the pod's occupant every time you kick the pod. Also cleans the file a little bit and adds the juicing sound effect to biomass processing.

:cl:
 * rscadd: You can now drag and drop a piece of meat on cloning pods to make them suck and process every piece of meat in the same tile as the one being dragged(this feature can't be used by silicons).
 * rscadd: Kicking a cloning pod now has 5% chance to unlock and eject its occupant.
