### PR TITLE
Add a cancel option to most text prompts

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -139,7 +139,7 @@ forLineInText(text)
 
 // Used to get a sanitized input.
 /proc/stripped_input(var/mob/user, var/message = "", var/title = "", var/default = "", var/max_length=MAX_MESSAGE_LEN)
-	var/name = input(user, message, title, default)
+	var/name = input(user, message, title, default) as null|text
 	return strip_html_simple(name, max_length)
 
 //Filters out undesirable characters from names

--- a/code/game/objects/items/weapons/ai_modules/targetted.dm
+++ b/code/game/objects/items/weapons/ai_modules/targetted.dm
@@ -41,6 +41,8 @@
 /obj/item/weapon/aiModule/targetted/attack_self(var/mob/user as mob)
 	..()
 	var/targName = stripped_input(usr, "Please enter the name of the person to [action].", "Who?", user.name)
+	if (!targName)
+		return FALSE
 	targetName = targName
 	updateLaw()
 

--- a/code/modules/reagents/machinery/pandemic.dm
+++ b/code/modules/reagents/machinery/pandemic.dm
@@ -130,6 +130,8 @@
 	else if(href_list["name_disease"])
 		var/norange = (usr.mutations && usr.mutations.len && (M_TK in usr.mutations))
 		var/new_name = stripped_input(usr, "Name the Disease", "New Name", "", MAX_NAME_LEN)
+		if (!new_name)
+			return FALSE
 		if(stat & (NOPOWER|BROKEN))
 			return
 		if(usr.stat || usr.restrained())


### PR DESCRIPTION
List of places where `stripped_input` isn't checked for null below
:cl:
- rscadd: Add a cancel option to text prompts which previously had none. 