### PR TITLE
Allow req_one_access for supply packs, allow scientists to open exotic seeds crates

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -15,7 +15,8 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	var/cost = null
 	var/containertype = null
 	var/containername = null
-	var/access = null
+	var/access = null // See code/game/jobs/access.dm
+	var/one_access = null // See above
 	var/hidden = 0 //Emaggable
 	var/contraband = 0 //Hackable via tools
 	var/group = "Supplies"
@@ -270,7 +271,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 20
 	containertype = /obj/structure/closet/crate
 	containername = "mining equipment crate"
-	access = access_mining
+	access = list(access_mining)
 	group = "Supplies"
 
 /datum/supply_packs/artscrafts
@@ -386,7 +387,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 10
 	containertype = /obj/structure/closet/crate/secure
 	containername = "standard costumes crate"
-	access = access_theatre
+	access = list(access_theatre)
 	group = "Clothing"
 
 /datum/supply_packs/spookycostume
@@ -677,7 +678,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 500
 	containertype = /obj/structure/closet/crate/secure/large
 	containername = "secway crate"
-	access = access_security
+	access = list(access_security)
 	group = "Security"
 
 /datum/supply_packs/beanbagammo
@@ -711,7 +712,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "weapons crate"
-	access = access_security
+	access = list(access_security)
 	group = "Security"
 
 /datum/supply_packs/smartlaser
@@ -723,7 +724,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 60
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "smart laser guns crate"
-	access = access_armory
+	access = list(access_armory)
 	group = "Security"
 
 /datum/supply_packs/eweapons
@@ -738,7 +739,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 25
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "incendiary weapons crate"
-	access = access_heads
+	access = list(access_heads)
 	group = "Security"
 
 /datum/supply_packs/armor
@@ -750,7 +751,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 15
 	containertype = /obj/structure/closet/crate/secure
 	containername = "armor crate"
-	access = access_security
+	access = list(access_security)
 	group = "Security"
 
 /datum/supply_packs/riot
@@ -778,7 +779,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 60
 	containertype = /obj/structure/closet/crate/secure
 	containername = "riot gear crate"
-	access = access_armory
+	access = list(access_armory)
 	group = "Security"
 
 /datum/supply_packs/loyalty
@@ -787,7 +788,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 60
 	containertype = /obj/structure/closet/crate/secure
 	containername = "loyalty implant crate"
-	access = access_armory
+	access = list(access_armory)
 	group = "Security"
 
 /datum/supply_packs/tracking
@@ -796,7 +797,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 50
 	containertype = /obj/structure/closet/crate/secure
 	containername = "tracking implant crate"
-	access = access_armory
+	access = list(access_armory)
 	group = "Security"
 
 /datum/supply_packs/chem
@@ -805,7 +806,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 50
 	containertype = /obj/structure/closet/crate/secure
 	containername = "chemical implant crate"
-	access = access_armory
+	access = list(access_armory)
 	group = "Security"
 
 /datum/supply_packs/ballistic
@@ -817,7 +818,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 50
 	containertype = /obj/structure/closet/crate/secure
 	containername = "ballistic gear crate"
-	access = access_armory
+	access = list(access_armory)
 	group = "Security"
 
 /datum/supply_packs/shotgunammo
@@ -830,7 +831,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 20
 	containertype = /obj/structure/closet/crate/secure
 	containername = "shotgun shells crate"
-	access = access_armory
+	access = list(access_armory)
 	group = "Security"
 
 /datum/supply_packs/expenergy
@@ -842,7 +843,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 50
 	containertype = /obj/structure/closet/crate/secure
 	containername = "experimental energy gear crate"
-	access = access_armory
+	access = list(access_armory)
 	group = "Security"
 
 /datum/supply_packs/exparmor
@@ -854,7 +855,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 35
 	containertype = /obj/structure/closet/crate/secure
 	containername = "experimental armor crate"
-	access = access_armory
+	access = list(access_armory)
 	group = "Security"
 
 /datum/supply_packs/securitybarriers
@@ -878,7 +879,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 200
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = ".45 pistols crate"
-	access = access_armory
+	access = list(access_armory)
 	group = "Security"
 
 /datum/supply_packs/auto380/lethals
@@ -890,7 +891,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 50
 	containertype = /obj/structure/closet/crate/secure/gear
 	containername = ".45 pistol lethal ammo crate"
-	access = access_armory
+	access = list(access_armory)
 	group = "Security"
 
 /datum/supply_packs/auto380/practice
@@ -902,7 +903,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 10
 	containertype = /obj/structure/closet/crate/secure/gear
 	containername = ".45 pistol practice ammo crate"
-	access = access_security
+	access = list(access_security)
 	group = "Security"
 
 /datum/supply_packs/auto380/rubber
@@ -914,7 +915,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure/gear
 	containername = ".45 pistol rubber ammo crate"
-	access = access_security
+	access = list(access_security)
 	group = "Security"
 
 //////HOSPITALITY//////
@@ -963,7 +964,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 15
 	containertype = /obj/structure/closet/crate/secure
 	containername = "exotic garnishes crate"
-	access = access_kitchen
+	access = list(access_kitchen)
 	group = "Hospitality"
 
 /datum/supply_packs/randomised/trophy_meats
@@ -983,7 +984,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure
 	containername = "trophy meats crate"
-	access = access_kitchen
+	access = list(access_kitchen)
 	group = "Hospitality"
 
 /datum/supply_packs/party
@@ -1181,7 +1182,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 10
 	containertype = /obj/structure/closet/crate/secure/engisec
 	containername = "emitter crate"
-	access = access_ce
+	access = list(access_ce)
 	group = "Engineering"
 
 /datum/supply_packs/engine/field_gen
@@ -1190,7 +1191,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/machinery/field_generator)
 	containertype = /obj/structure/closet/crate/secure/engisec
 	containername = "field generator crate"
-	access = access_ce
+	access = list(access_ce)
 	group = "Engineering"
 
 /datum/supply_packs/engine/sing_gen
@@ -1198,7 +1199,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	contains = list(/obj/machinery/the_singularitygen)
 	containertype = /obj/structure/closet/crate/secure/engisec
 	containername = "singularity generator crate"
-	access = access_ce
+	access = list(access_ce)
 	group = "Engineering"
 
 /datum/supply_packs/engine/collector
@@ -1228,7 +1229,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/structure/particle_accelerator/end_cap)
 	containertype = /obj/structure/closet/crate/secure/engisec
 	containername = "particle accelerator crate"
-	access = access_ce
+	access = list(access_ce)
 	group = "Engineering"
 
 /datum/supply_packs/shieldgens
@@ -1240,7 +1241,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 20
 	containertype = /obj/structure/closet/crate/secure/engisec
 	containername = "shield generators crate"
-	access = access_teleporter
+	access = list(access_teleporter)
 	group = "Engineering"
 
 /datum/supply_packs/engine/amrcontrol
@@ -1249,7 +1250,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure/engisec
 	containername = "antimatter control unit crate"
-	access = access_engine
+	access = list(access_engine)
 	group = "Engineering"
 
 /datum/supply_packs/engine/amrparts
@@ -1269,7 +1270,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure/engisec
 	containername = "packaged antimatter reactor crate"
-	access = access_engine
+	access = list(access_engine)
 	group = "Engineering"
 
 /datum/supply_packs/engine/amrcontainment
@@ -1280,7 +1281,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 15
 	containertype = /obj/structure/closet/crate/secure/engisec
 	containername = "antimatter containment jar crate"
-	access = access_engine
+	access = list(access_engine)
 	group = "Engineering"
 
 /datum/supply_packs/rust_injector
@@ -1290,7 +1291,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	containertype = /obj/structure/closet/crate/secure/large
 	containername = "\improper R-UST Mk. 7 injector crate"
 	group = "Engineering"
-	access = access_engine
+	access = list(access_engine)
 
 /datum/supply_packs/rust_gyrotron
 	contains = list(/obj/machinery/rust/gyrotron)
@@ -1299,7 +1300,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	containertype = /obj/structure/closet/crate/secure/large
 	containername = "\improper R-UST Mk. 7 gyrotron crate"
 	group = "Engineering"
-	access = access_engine
+	access = list(access_engine)
 
 /datum/supply_packs/rust_compressor
 	contains = list(/obj/item/weapon/module/rust_fuel_compressor)
@@ -1308,7 +1309,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	containertype = /obj/structure/closet/crate/secure/engisec
 	containername = "\improper R-UST Mk. 7 fuel compressor circuitry crate"
 	group = "Engineering"
-	access = access_engine
+	access = list(access_engine)
 
 /datum/supply_packs/rust_assembly_port
 	contains = list(/obj/item/weapon/module/rust_fuel_port)
@@ -1317,7 +1318,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	containertype = /obj/structure/closet/crate/secure/engisec
 	containername = "\improper R-UST Mk. 7 fuel assembly port circuitry crate"
 	group = "Engineering"
-	access = access_engine
+	access = list(access_engine)
 
 /datum/supply_packs/rust_core
 	contains = list(/obj/machinery/power/rust_core)
@@ -1326,7 +1327,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	containertype = /obj/structure/closet/crate/secure/large
 	containername = "\improper R-UST Mk. 7 tokamak crate"
 	group = "Engineering"
-	access = access_engine
+	access = list(access_engine)
 
 /datum/supply_packs/shield_gen
 	contains = list(/obj/item/weapon/circuitboard/shield_gen)
@@ -1335,7 +1336,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	containertype = /obj/structure/closet/crate/secure/engisec
 	containername = "Starscreen shield generator crate"
 	group = "Engineering"
-	access = access_ce
+	access = list(access_ce)
 
 /datum/supply_packs/shield_cap
 	contains = list(/obj/item/weapon/circuitboard/shield_cap)
@@ -1344,7 +1345,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	containertype = /obj/structure/closet/crate/secure/engisec
 	containername = "Starscreen shield capacitor crate"
 	group = "Engineering"
-	access = access_ce
+	access = list(access_ce)
 
 /datum/supply_packs/teg
 	contains = list(/obj/machinery/power/generator)
@@ -1353,7 +1354,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	containertype = /obj/structure/closet/crate/secure/large
 	containername = "mk1 TEG crate"
 	group = "Engineering"
-	access = access_engine
+	access = list(access_engine)
 
 /datum/supply_packs/circulator
 	contains = list(/obj/machinery/atmospherics/binary/circulator)
@@ -1362,7 +1363,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	containertype = /obj/structure/closet/crate/secure/large
 	containername = "atmospheric circulator crate"
 	group = "Engineering"
-	access = access_engine
+	access = list(access_engine)
 
 /datum/supply_packs/supermatter_shard
 	contains = list(/obj/machinery/power/supermatter/shard)
@@ -1371,7 +1372,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	containertype = /obj/structure/closet/crate/secure/large/reinforced/shard/empty
 	containername = "supermatter shard crate"
 	group = "Engineering"
-	access = access_engine_equip
+	access = list(access_engine_equip)
 
 /datum/supply_packs/portable_smes
 	contains = list(/obj/machinery/power/battery/portable,
@@ -1385,7 +1386,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	containertype = /obj/structure/closet/crate/secure/engisec
 	containername = "portable SMES crate"
 	group = "Engineering"
-	access = access_engine
+	access = list(access_engine)
 
 /datum/supply_packs/rcs_device
 	name = "Rapid-Crate-Sender"
@@ -1455,7 +1456,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 25
 	containertype = "/obj/structure/closet/crate/secure"
 	containername = "virus crate"
-	access = access_cmo
+	access = list(access_cmo)
 	group = "Medical"
 
 /datum/supply_packs/surgery
@@ -1474,7 +1475,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 25
 	containertype = "/obj/structure/closet/crate/secure"
 	containername = "surgery crate"
-	access = access_medical
+	access = list(access_medical)
 	group = "Medical"
 
 /datum/supply_packs/sterile
@@ -1501,7 +1502,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 10
 	containertype = /obj/structure/closet/crate/secure
 	containername = "bloodbag crate"
-	access = access_medical
+	access = list(access_medical)
 	group = "Medical"
 
 /datum/supply_packs/bloodbot
@@ -1530,7 +1531,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 200
 	containertype = "/obj/structure/closet/crate/secure"
 	containername = "motorized wheelchair crate"
-	access = access_cmo
+	access = list(access_cmo)
 	group = "Medical"
 
 /datum/supply_packs/skele_stand
@@ -1561,7 +1562,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure/scisec
 	containername = "research and development stock parts crate"
-	access = access_science
+	access = list(access_science)
 	group = "Science"
 
 /datum/supply_packs/research_nanotrasen
@@ -1573,7 +1574,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 80
 	containertype = /obj/structure/closet/crate/secure/scisec
 	containername = "research and development experimental crate"
-	access = access_science
+	access = list(access_science)
 	group = "Science"
 
 /datum/supply_packs/robotics
@@ -1591,7 +1592,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 10
 	containertype = /obj/structure/closet/crate/secure/scisec
 	containername = "robotics assembly crate"
-	access = access_robotics
+	access = list(access_robotics)
 	group = "Science"
 
 /datum/supply_packs/suspension_gen
@@ -1600,7 +1601,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 50
 	containertype = /obj/structure/largecrate
 	containername = "suspension field generator crate"
-	access = access_science
+	access = list(access_science)
 	group = "Science"
 
 /datum/supply_packs/excavation_gear
@@ -1619,7 +1620,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure/scisec
 	containername = "excavation equipment crate"
-	access = access_science
+	access = list(access_science)
 	group = "Science"
 
 /datum/supply_packs/plasma
@@ -1639,7 +1640,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 10
 	containertype = /obj/structure/closet/crate/secure/plasma
 	containername = "plasma assembly crate"
-	access = access_tox_storage
+	access = list(access_tox_storage)
 	group = "Science"
 
 /datum/supply_packs/borer
@@ -1648,7 +1649,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 100
 	containertype = /obj/structure/closet/crate/secure/scisec
 	containername = "borer egg crate"
-	access = access_xenobiology
+	access = list(access_xenobiology)
 	group = "Science"
 
 /datum/supply_packs/anomaly_container
@@ -1726,7 +1727,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 15
 	containertype = /obj/structure/closet/crate/hydroponics
 	containername = "hydroponics crate"
-	access = access_hydroponics
+	access = list(access_hydroponics)
 	group = "Hydroponics"
 
 //farm animals - useless and annoying, but potentially a good source of food
@@ -1735,7 +1736,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 30
 	containertype = /obj/structure/largecrate/cow
 	containername = "cow crate"
-	access = access_hydroponics
+	access = list(access_hydroponics)
 	group = "Hydroponics"
 
 /datum/supply_packs/goat
@@ -1743,7 +1744,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 25
 	containertype = /obj/structure/largecrate/goat
 	containername = "goat crate"
-	access = access_hydroponics
+	access = list(access_hydroponics)
 	group = "Hydroponics"
 
 /datum/supply_packs/chicken
@@ -1751,7 +1752,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 20
 	containertype = /obj/structure/largecrate/chick
 	containername = "chicken crate"
-	access = access_hydroponics
+	access = list(access_hydroponics)
 	group = "Hydroponics"
 
 /datum/supply_packs/lisa
@@ -1779,7 +1780,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 20
 	containertype = /obj/structure/closet/crate/secure/hydrosec
 	containername = "weed control crate"
-	access = access_hydroponics
+	access = list(access_hydroponics)
 	group = "Hydroponics"
 
 /datum/supply_packs/exoticseeds
@@ -1799,7 +1800,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 15
 	containertype = /obj/structure/closet/crate/secure/hydrosec
 	containername = "exotic seeds crate"
-	access = access_hydroponics
+	one_access = list(access_hydroponics, access_science)
 	group = "Hydroponics"
 
 /datum/supply_packs/bee_keeper
@@ -1820,7 +1821,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 20
 	containertype = /obj/structure/closet/crate/secure/hydrosec
 	containername = "beekeeping crate"
-	access = access_hydroponics
+	access = list(access_hydroponics)
 	group = "Hydroponics"
 
 /datum/supply_packs/ranching
@@ -1863,7 +1864,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 12
 	containertype = /obj/structure/closet/crate/secure/hydrosec
 	containername = "hydroponic trays components crate"
-	access = access_hydroponics
+	access = list(access_hydroponics)
 	group = "Hydroponics"
 
 /////VENDING MACHINES PACKS////////

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -227,8 +227,10 @@ var/datum/controller/supply_shuttle/supply_shuttle = new
 			CONTENTS:<br><ul>"}
 		//spawn the stuff, finish generating the manifest while you're at it
 		if(SP.access)
-			A:req_access = list()
-			A:req_access += text2num(SP.access)
+			A:req_access = SP.access
+
+		if(SP.one_access)
+			A:req_one_access = SP.one_access
 
 		var/list/contains
 		if(istype(SP,/datum/supply_packs/randomised))


### PR DESCRIPTION
Closes #16692

Refactored supply packs to support `req_one_access` and
:cl:
 * tweak: Science access lets you open exotic seeds crates (hydroponics access still works).