### PR TITLE
Fixed silicon consumables not setting mouse_opacity

### DIFF
--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -264,6 +264,7 @@
 				if(R)
 					if(R.module)
 						R.module.respawn_consumable(R)
+						R.module.fix_modules()
 
 /obj/machinery/recharge_station/verb/move_eject()
 	set category = "Object"


### PR DESCRIPTION
Before this, if you completely consumed (for instance) cable coils and recharged, the new item would be hard to click on due to `mouse_opacity` not being set.