### PR TITLE
Service borg's Instrument Synth

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -503,7 +503,7 @@
 /obj/item/weapon/gripper/service //Used to handle food, drinks and seeds.
 	name = "service gripper"
 	icon_state = "gripper-old"
-	desc = "A simple grasping tool used to perform tasks in the service sector, such as handling food, drinks, and seeds."
+	desc = "A simple grasping tool used to perform tasks in the service sector, such as handling drinks and... fedoras!"
 
 	can_hold = list(
 		/obj/item/weapon/reagent_containers/food/drinks,
@@ -556,3 +556,43 @@
 		/obj/item/weapon/circuitboard/aiupload,
 		/obj/item/weapon/circuitboard/borgupload
 		)
+
+//Cyborg Instrument Synth. Remember to always play REMOVE KEBAB on malf rounds.
+/obj/item/device/instrument/instrument_synth
+	name = "instrument synthesizer"
+	desc = "An advanced electronic synthesizer that can be used as various instruments."
+	icon = 'icons/obj/device.dmi'
+	icon_state = "soundsynth"
+	item_state = "radio"
+	instrumentId = "piano"
+	instrumentExt = "ogg"
+	var/static/list/insTypes = list("accordion" = "mid", "bikehorn" = "ogg", "glockenspiel" = "mid", "guitar" = "ogg", "harmonica" = "mid", "piano" = "ogg", "recorder" = "mid", "saxophone" = "mid", "trombone" = "mid", "violin" = "mid", "xylophone" = "mid", "drum" = "mid")
+	actions_types = list(/datum/action/item_action/synthswitch, /datum/action/item_action/instrument)
+
+/obj/item/device/instrument/instrument_synth/proc/changeInstrument(name = "piano")
+	song.instrumentDir = name
+	song.instrumentExt = insTypes[name]
+
+/datum/action/item_action/synthswitch
+	name = "Change Synthesizer Instrument"
+	desc = "Change the type of instrument your synthesizer is playing as."
+
+/datum/action/item_action/synthswitch/Trigger()
+	if(istype(target, /obj/item/device/instrument/instrument_synth))
+		var/obj/item/device/instrument/instrument_synth/synth = target
+		var/chosen = input("Choose the type of instrument you want to use", "Instrument Selection", "piano") as null|anything in synth.insTypes
+		if(!synth.insTypes[chosen])
+			return
+		return synth.changeInstrument(chosen)
+	return ..()
+
+/datum/action/item_action/instrument
+	name = "Use Instrument"
+	desc = "Use the instrument specified"
+
+/datum/action/item_action/instrument/Trigger()
+	if(istype(target, /obj/item/device/instrument))
+		var/obj/item/device/instrument/I = target
+		I.interact(usr)
+		return
+	return ..()

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -56,11 +56,22 @@
 /obj/item/weapon/robot_module/New(var/mob/living/silicon/robot/R)
 	..()
 
-	languages = list(	LANGUAGE_GALACTIC_COMMON = 1, LANGUAGE_TRADEBAND = 1, LANGUAGE_VOX = 0,
-						LANGUAGE_ROOTSPEAK = 0, LANGUAGE_GREY = 0, LANGUAGE_CLATTER = 0,
-						LANGUAGE_MONKEY = 0, LANGUAGE_UNATHI = 0, LANGUAGE_CATBEAST = 0,
-						LANGUAGE_SKRELLIAN = 0, LANGUAGE_GUTTER = 0, LANGUAGE_MONKEY = 0,
-						LANGUAGE_MOUSE = 0, LANGUAGE_HUMAN = 0)
+	languages = list(
+		LANGUAGE_GALACTIC_COMMON = TRUE,
+		LANGUAGE_TRADEBAND = TRUE,
+		LANGUAGE_VOX = FALSE,
+		LANGUAGE_ROOTSPEAK = FALSE,
+		LANGUAGE_GREY = FALSE,
+		LANGUAGE_CLATTER = FALSE,
+		LANGUAGE_MONKEY = FALSE,
+		LANGUAGE_UNATHI = FALSE,
+		LANGUAGE_CATBEAST = FALSE,
+		LANGUAGE_SKRELLIAN = FALSE,
+		LANGUAGE_GUTTER = FALSE,
+		LANGUAGE_MONKEY = FALSE,
+		LANGUAGE_MOUSE = FALSE,
+		LANGUAGE_HUMAN = FALSE
+		)
 	added_languages = list()
 	if(!isMoMMI(R))
 		add_languages(R)
@@ -95,6 +106,7 @@
 #define STANDARD_MAX_KIT 15
 /obj/item/weapon/robot_module/standard/New()
 	..()
+
 	modules += new /obj/item/weapon/melee/baton/loaded/borg(src)
 	modules += new /obj/item/weapon/extinguisher(src)
 	modules += new /obj/item/weapon/wrench(src)
@@ -103,19 +115,17 @@
 	modules += new /obj/item/weapon/soap/nanotrasen(src)
 	modules += new /obj/item/device/taperecorder(src)
 	modules += new /obj/item/device/megaphone(src)
-	emag = new /obj/item/weapon/melee/energy/sword(src)
-	sensor_augs = list("Security", "Medical", "Mesons", "Disable")
-
-
 	var/obj/item/stack/medical/bruise_pack/B = new /obj/item/stack/medical/bruise_pack(src)
 	B.max_amount = STANDARD_MAX_KIT
 	B.amount = STANDARD_MAX_KIT
 	modules += B
-
 	var/obj/item/stack/medical/ointment/O = new /obj/item/stack/medical/ointment(src)
 	O.max_amount = STANDARD_MAX_KIT
 	O.amount = STANDARD_MAX_KIT
 	modules += O
+	emag = new /obj/item/weapon/melee/energy/sword(src)
+
+	sensor_augs = list("Security", "Medical", "Mesons", "Disable")
 
 	fix_modules()
 
@@ -134,8 +144,6 @@
 			modules += O
 			O.amount = 1
 	return
-
-
 
 /obj/item/weapon/robot_module/medical
 	name = "medical robot module"
@@ -164,26 +172,23 @@
 	modules += new /obj/item/weapon/crowbar(src)
 	modules += new /obj/item/weapon/inflatable_dispenser/robot(src)
 	modules += new /obj/item/roller_holder(src)
-	emag = new /obj/item/weapon/reagent_containers/spray(src)
-	sensor_augs = list("Medical", "Disable")
-
-	emag.reagents.add_reagent(PACID, 250)
-	emag.name = "Polyacid spray"
-
 	var/obj/item/stack/medical/advanced/bruise_pack/B = new /obj/item/stack/medical/advanced/bruise_pack(src)
 	B.max_amount = MEDBORG_MAX_KIT
 	B.amount = MEDBORG_MAX_KIT
 	modules += B
-
 	var/obj/item/stack/medical/advanced/ointment/O = new /obj/item/stack/medical/advanced/ointment(src)
 	O.max_amount = MEDBORG_MAX_KIT
 	O.amount = MEDBORG_MAX_KIT
 	modules += O
-
 	var/obj/item/stack/medical/splint/S = new /obj/item/stack/medical/splint(src)
 	S.max_amount = MEDBORG_MAX_KIT
 	S.amount = MEDBORG_MAX_KIT
 	modules += S
+	emag = new /obj/item/weapon/reagent_containers/spray(src)
+	emag.reagents.add_reagent(PACID, 250)
+	emag.name = "Polyacid spray"
+
+	sensor_augs = list("Medical", "Disable")
 
 	fix_modules()
 
@@ -207,11 +212,9 @@
 /obj/item/weapon/robot_module/engineering
 	name = "engineering robot module"
 
-
 /obj/item/weapon/robot_module/engineering/New()
 	..()
 
-	emag = new /obj/item/borg/stun(src)
 	modules += new /obj/item/device/rcd/borg/engineering(src)
 	modules += new /obj/item/device/rcd/rpd(src) //What could possibly go wrong?
 	modules += new /obj/item/weapon/extinguisher(src)
@@ -231,12 +234,13 @@
 	modules += new /obj/item/device/silicate_sprayer(src)
 	modules += new /obj/item/device/holomap(src)
 	modules += new /obj/item/weapon/inflatable_dispenser/robot(src)
-	sensor_augs = list("Mesons", "Disable")
-
 	var/obj/item/stack/cable_coil/W = new /obj/item/stack/cable_coil(src)
 	W.amount = 50
 	W.max_amount = 50
 	modules += W
+	emag = new /obj/item/borg/stun(src)
+
+	sensor_augs = list("Mesons", "Disable")
 
 	fix_modules()
 
@@ -283,14 +287,17 @@
 
 /obj/item/weapon/robot_module/security/New()
 	..()
+
+	modules += new /obj/item/weapon/crowbar(src)
 	modules += new /obj/item/weapon/melee/baton/loaded/borg(src)
 	modules += new /obj/item/weapon/gun/energy/taser/cyborg(src)
 	modules += new /obj/item/weapon/handcuffs/cyborg(src)
 	modules += new /obj/item/weapon/reagent_containers/spray/pepper(src)
 	modules += new /obj/item/taperoll/police(src)
-	modules += new /obj/item/weapon/crowbar(src)
 	emag = new /obj/item/weapon/gun/energy/laser/cyborg(src)
+
 	sensor_augs = list("Security", "Medical", "Disable")
+
 	fix_modules()
 
 /obj/item/weapon/robot_module/janitor
@@ -298,16 +305,17 @@
 
 /obj/item/weapon/robot_module/janitor/New()
 	..()
+
+	modules += new /obj/item/weapon/crowbar(src)
 	modules += new /obj/item/weapon/soap/nanotrasen(src)
 	modules += new /obj/item/weapon/storage/bag/trash(src)
 	modules += new /obj/item/weapon/mop(src)
 	modules += new /obj/item/device/lightreplacer/borg(src)
 	modules += new /obj/item/weapon/reagent_containers/glass/bucket(src)
-	modules += new /obj/item/weapon/crowbar(src)
 	emag = new /obj/item/weapon/reagent_containers/spray(src)
-
 	emag.reagents.add_reagent(LUBE, 250)
 	emag.name = "Lube spray"
+
 	fix_modules()
 
 
@@ -316,46 +324,46 @@
 	name = "service robot module"
 
 /obj/item/weapon/robot_module/butler/New()
-	languages = list(
-					LANGUAGE_GALACTIC_COMMON	= 1,
-					LANGUAGE_UNATHI		= 1,
-					LANGUAGE_CATBEAST	= 1,
-					LANGUAGE_SKRELLIAN	= 1,
-					LANGUAGE_ROOTSPEAK	= 1,
-					LANGUAGE_TRADEBAND	= 1,
-					LANGUAGE_GUTTER		= 1,
-					LANGUAGE_MONKEY		= 1,
-					)
 	..()
-	modules += new /obj/item/weapon/gripper/service(src)
-	modules += new /obj/item/weapon/tray/robotray(src)
+
+	languages = list(
+		LANGUAGE_GALACTIC_COMMON = TRUE,
+		LANGUAGE_UNATHI	= TRUE,
+		LANGUAGE_CATBEAST = TRUE,
+		LANGUAGE_SKRELLIAN = TRUE,
+		LANGUAGE_ROOTSPEAK = TRUE,
+		LANGUAGE_TRADEBAND = TRUE,
+		LANGUAGE_GUTTER	= TRUE,
+		LANGUAGE_MONKEY	= TRUE,
+		)
+
 	modules += new /obj/item/weapon/crowbar(src)
+	modules += new /obj/item/weapon/gripper/service(src)
 	modules += new /obj/item/weapon/pen/robopen(src)
 	modules += new /obj/item/weapon/dice/borg(src)
 	modules += new /obj/item/device/rcd/borg/rsf(src)
+	modules += new /obj/item/weapon/lighter/zippo(src)
+	modules += new /obj/item/device/instrument/instrument_synth(src)
+	modules += new /obj/item/weapon/tray/robotray(src)
 	modules += new /obj/item/weapon/reagent_containers/dropper/robodropper(src)
 	modules += new /obj/item/weapon/reagent_containers/glass/replenishing/cyborg(src)
-	var/obj/item/weapon/lighter/zippo/L = new /obj/item/weapon/lighter/zippo(src)
-	L.lit = 1
-	L.update_brightness()
-	modules += L
+	
 	emag = new /obj/item/weapon/reagent_containers/glass/replenishing/cyborg/hacked(src)
+
 	fix_modules()
-
-
 
 /obj/item/weapon/robot_module/miner
 	name = "supply robot module"
 
 /obj/item/weapon/robot_module/miner/New()
 	..()
-	emag = new /obj/item/borg/stun(src)
+	
+	modules += new /obj/item/weapon/crowbar(src)
 	modules += new /obj/item/weapon/storage/bag/ore(src)
 	modules += new /obj/item/weapon/pickaxe/drill/borg(src)
 	modules += new /obj/item/weapon/storage/bag/sheetsnatcher/borg(src)
 	modules += new /obj/item/device/mining_scanner(src)
-	modules += new /obj/item/weapon/gun/energy/kinetic_accelerator/cyborg(src)
-	modules += new /obj/item/weapon/crowbar(src)
+	modules += new /obj/item/weapon/gun/energy/kinetic_accelerator/cyborg(src)	
 	modules += new /obj/item/weapon/gripper/no_use/inserter(src)
 	var/obj/item/device/destTagger/tag = new /obj/item/device/destTagger(src)
 	tag.mode = 1 //For editing the tag list
@@ -364,8 +372,10 @@
 	W.amount = 24
 	W.max_amount = 24
 	modules += W
+	emag = new /obj/item/borg/stun(src)
 
 	sensor_augs = list("Mesons", "Disable")
+
 	fix_modules()
 
 /obj/item/weapon/robot_module/miner/respawn_consumable(var/mob/living/silicon/robot/R)
@@ -384,27 +394,33 @@
 /obj/item/weapon/robot_module/syndicate
 	name = "syndicate robot module"
 
-
 /obj/item/weapon/robot_module/syndicate/New()
+	..()
+
+	modules += new /obj/item/weapon/crowbar(src)
 	modules += new /obj/item/weapon/melee/energy/sword(src)
 	modules += new /obj/item/weapon/gun/energy/pulse_rifle/destroyer(src)
 	modules += new /obj/item/weapon/card/emag(src)
-	modules += new /obj/item/weapon/crowbar(src)
+
 	sensor_augs = list("Security", "Medical", "Mesons", "Thermal", "Light Amplification", "Disable")
+
 	fix_modules()
 
 /obj/item/weapon/robot_module/combat
 	name = "combat robot module"
 
 /obj/item/weapon/robot_module/combat/New()
+	..()
+
+	modules += new /obj/item/weapon/crowbar(src)
 	modules += new /obj/item/weapon/gun/energy/laser/cyborg(src)
 	modules += new /obj/item/weapon/pickaxe/plasmacutter(src)
 	modules += new /obj/item/weapon/pickaxe/jackhammer/combat(src)
 	modules += new /obj/item/borg/combat/shield(src)
 	modules += new /obj/item/borg/combat/mobility(src)
 	modules += new /obj/item/weapon/wrench(src) //Is a combat android really going to be stopped by a chair?
-	modules += new /obj/item/weapon/crowbar(src)
 	emag = new /obj/item/weapon/gun/energy/laser/cannon/cyborg(src)
+
 	sensor_augs = list("Security", "Medical", "Mesons", "Thermal", "Light Amplification", "Disable")
 
 	fix_modules()
@@ -414,6 +430,7 @@
 
 /obj/item/weapon/robot_module/tg17355/New()
 	..()
+
 	modules += new /obj/item/weapon/cookiesynth(src)
 	modules += new /obj/item/device/harmalarm(src)
 	modules += new /obj/item/weapon/reagent_containers/borghypo/peace(src)
@@ -421,7 +438,9 @@
 	modules += new /obj/item/borg/cyborghug(src)
 	modules += new /obj/item/weapon/extinguisher(src)
 	emag = new /obj/item/weapon/reagent_containers/borghypo/peace/hacked(src)
+
 	sensor_augs = list("Medical", "Disable")
+
 	fix_modules()
 
 /obj/item/weapon/robot_module/proc/add_languages(var/mob/living/silicon/robot/R)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -152,6 +152,7 @@
 /obj/item/weapon/robot_module/medical/New()
 	..()
 
+	modules += new /obj/item/weapon/crowbar(src)
 	modules += new /obj/item/device/healthanalyzer(src)
 	modules += new /obj/item/weapon/reagent_containers/borghypo(src)
 	modules += new /obj/item/weapon/gripper/chemistry(src)
@@ -169,7 +170,6 @@
 	modules += new /obj/item/weapon/FixOVein(src)
 	modules += new /obj/item/weapon/surgicaldrill(src)
 	modules += new /obj/item/weapon/revivalprod(src)
-	modules += new /obj/item/weapon/crowbar(src)
 	modules += new /obj/item/weapon/inflatable_dispenser/robot(src)
 	modules += new /obj/item/roller_holder(src)
 	var/obj/item/stack/medical/advanced/bruise_pack/B = new /obj/item/stack/medical/advanced/bruise_pack(src)
@@ -215,6 +215,7 @@
 /obj/item/weapon/robot_module/engineering/New()
 	..()
 
+	modules += new /obj/item/weapon/crowbar(src)
 	modules += new /obj/item/device/rcd/borg/engineering(src)
 	modules += new /obj/item/device/rcd/rpd(src) //What could possibly go wrong?
 	modules += new /obj/item/weapon/extinguisher(src)
@@ -222,7 +223,6 @@
 	modules += new /obj/item/weapon/weldingtool/largetank(src)
 	modules += new /obj/item/weapon/screwdriver(src)
 	modules += new /obj/item/weapon/wrench(src)
-	modules += new /obj/item/weapon/crowbar(src)
 	modules += new /obj/item/weapon/wirecutters(src)
 	modules += new /obj/item/device/multitool(src)
 	modules += new /obj/item/device/t_scanner(src)


### PR DESCRIPTION
![synth](https://user-images.githubusercontent.com/17928298/33775421-7c1a89e0-dc25-11e7-8816-e0bf29568956.png)

Ports TG's Piano Synth as the **Instrument Synthesizer**. It can be used as **any** instrument, you can even switch the type while you're playing a song. Also clean the robot_modules.dm a little bit and fixes both the service gripper desc(as they don't start able to pick up seeds or food) and combat/syndie borgs not having a flash/flashlight.

:cl:
 * rscadd: Adds the instrument synthesizer to the default service cyborg loadout.

