### PR TITLE
Don't populate the Create Object list on load

### DIFF
--- a/html/create_object.html
+++ b/html/create_object.html
@@ -54,7 +54,6 @@
 		var objects = object_paths == null ? new Array() : object_paths.split(";");
 		
 		document.spawner.filter.focus();
-		populateList(objects);
 		
 		function populateList(from_list)
 		{


### PR DESCRIPTION
Makes the window load faster by not loading the full list the first time you open the window.