### PR TITLE
Speeds up service borgs beer synth

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -276,7 +276,8 @@
 	reagent_list = BEER
 	artifact = FALSE
 	can_be_placed_into = null
-	var/synth_cost = 10 //Around 1666 cell charge for 50u beer
+	units_per_tick = 1
+	var/synth_cost = 30 // 1500 cell charge for 50u beer
 
 /obj/item/weapon/reagent_containers/glass/replenishing/cyborg/fits_in_iv_drip()
 	return FALSE
@@ -292,6 +293,7 @@
 /obj/item/weapon/reagent_containers/glass/replenishing/cyborg/hacked
 	name = "mickey finn's special brew"
 	reagent_list = BEER2
+	units_per_tick = 0.3
 	synth_cost = 25 //4165 cell charge for 50u !NotShitterJuice.
 
 //Grippers: Simple cyborg manipulator. Limited use... SLIPPERY SLOPE POWERCREEP

--- a/code/modules/research/xenoarchaeology/finds/finds_special.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds_special.dm
@@ -6,6 +6,7 @@
 	var/spawning_id = null
 	var/artifact = TRUE
 	var/artifact_id = null
+	var/units_per_tick = 0.3
 
 /obj/item/weapon/reagent_containers/glass/replenishing/New()
 	..()
@@ -20,4 +21,4 @@
 	..()
 
 /obj/item/weapon/reagent_containers/glass/replenishing/process()
-	reagents.add_reagent(spawning_id, 0.3)
+	reagents.add_reagent(spawning_id, units_per_tick)


### PR DESCRIPTION
It was pitifully slow. Keeps the chloral dispenser as it is.
:cl:
 * tweak: Buffed the service borg beer synthesizer to produce 1u each tick (previously 0.3u)