### PR TITLE
Adds sodium polyacrylate

### DIFF
--- a/__DEFINES/reagents.dm
+++ b/__DEFINES/reagents.dm
@@ -8,6 +8,7 @@
 #define VACCINE 			"vaccine"
 #define WATER 			"water"
 #define LUBE 			"lube"
+#define SODIUM_POLYACRYLATE			"sodium_polyacrylate"
 #define PHALANXIMINE 			"phalanximine"
 #define TOXIN 			"toxin"
 #define PLASTICIDE 			"plasticide"

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -555,8 +555,9 @@
 		return 1
 
 	if(T.wet)
-		var/obj/effect/decal/cleanable/molten_item/I = new/obj/effect/decal/cleanable/molten_item(T)
-		I.desc = "A bit of gel left over from sodium polyacrylate absorbing liquid."
+		if(!locate(/obj/effect/decal/cleanable/molten_item) in T)
+			var/obj/effect/decal/cleanable/molten_item/I = new/obj/effect/decal/cleanable/molten_item(T)
+			I.desc = "A bit of gel left over from sodium polyacrylate absorbing liquid."
 		T.dry(TURF_WET_LUBE) //Absorbs water or lube
 
 /datum/reagent/anti_toxin

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -540,6 +540,25 @@
 	if(volume >= 1)
 		T.wet(800, TURF_WET_LUBE)
 
+/datum/reagent/sodium_polyacrylate
+	name = "Sodium Polyacrylate"
+	id = SODIUM_POLYACRYLATE
+	description = "A super absorbent polymer that can absorb water based substances."
+	reagent_state = SOLID
+	color = "#FFFFFF"
+	density = 1.22
+	specheatcap = 4.14
+
+/datum/reagent/sodium_polyacrylate/reaction_turf(var/turf/simulated/T, var/volume)
+
+	if(..())
+		return 1
+
+	if(T.wet)
+		var/obj/effect/decal/cleanable/molten_item/I = new/obj/effect/decal/cleanable/molten_item(T)
+		I.desc = "A bit of gel left over from sodium polyacrylate absorbing liquid."
+		T.dry(TURF_WET_LUBE) //Absorbs water or lube
+
 /datum/reagent/anti_toxin
 	name = "Anti-Toxin (Dylovene)"
 	id = ANTI_TOXIN

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -237,6 +237,27 @@
 	required_reagents = list(WATER = 1, SILICON = 1, OXYGEN = 1)
 	result_amount = 4
 
+/datum/chemical_reaction/sodium_polyacrylate
+	name = "Sodium Polyacrylate"
+	id = SODIUM_POLYACRYLATE
+	result = SODIUM_POLYACRYLATE
+	required_reagents = list(CARBON = 3, HYDROGEN = 3, SODIUM = 1, OXYGEN = 2)
+	result_amount = 8
+
+/datum/chemical_reaction/spoly_absorb_water
+	name = "Absorb Water"
+	id = "absorbwater"
+	result = null
+	required_reagents = list(SODIUM_POLYACRYLATE = 0.3, WATER = 1)
+	result_amount = 0
+
+/datum/chemical_reaction/spoly_absorb_lube
+	name = "Absorb Lube"
+	id = "absorblube"
+	result = null
+	required_reagents = list(SODIUM_POLYACRYLATE = 0.3, LUBE = 1)
+	result_amount = 0
+
 /datum/chemical_reaction/sludge
 	name = "Sludge"
 	id = TOXICWASTE

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -247,16 +247,16 @@
 /datum/chemical_reaction/spoly_absorb_water
 	name = "Absorb Water"
 	id = "absorbwater"
-	result = null
+	result = CHEMICAL_WASTE
 	required_reagents = list(SODIUM_POLYACRYLATE = 0.3, WATER = 1)
-	result_amount = 0
+	result_amount = 0.3
 
 /datum/chemical_reaction/spoly_absorb_lube
 	name = "Absorb Lube"
 	id = "absorblube"
-	result = null
+	result = CHEMICAL_WASTE
 	required_reagents = list(SODIUM_POLYACRYLATE = 0.3, LUBE = 1)
-	result_amount = 0
+	result_amount = 0.3
 
 /datum/chemical_reaction/sludge
 	name = "Sludge"


### PR DESCRIPTION
One of the common complaints I keep hearing is something about "slippery slopes" and how there isn't anything to help fix the issue of the "slippery slope."
I have created sodium polyacrylate which is a super absorbent polymer that can absorb water and lube not only in reagent containers but on floors as well. Hopefully this will un-slip the slopes.
Made with 3 parts carbon, 3 parts hydrogen, 1 part sodium, and 2 parts oxygen. This may run into issues by creating water since hydrogen and oxygen are present in the recipe but adding them in the order above will result in sodium polyacrylate. (Tested)

:cl:
 * rscadd: Added sodium polyacrylate. It absorbs water and spacelube not only in containers but on floors as well. Made with 3u carbon, 3u hydrogen, 1u sodium, and 2u oxygen.