### PR TITLE
turrets check if the target is stunned, rather than if they're just lying down.

### DIFF
--- a/code/game/machinery/turrets.dm
+++ b/code/game/machinery/turrets.dm
@@ -99,7 +99,7 @@
 		if( iscarbon(T) )
 			var/mob/living/carbon/MC = T
 			if( !MC.stat )
-				if( !MC.lying || lasers ) //only shoots them while they're down if set to laser mode
+				if( !MC.isStunned() || lasers ) //only shoots them while they're down if set to laser mode
 					return 1
 		if(issilicon(T))
 			if(!shootsilicons || istype(T,/mob/living/silicon/ai))
@@ -131,7 +131,7 @@
 		if(!M.stat && !(M.flags & INVULNERABLE) && M.faction != faction)
 			if(iscarbon(M))
 				var/mob/living/carbon/C = M
-				if(!C.lying || lasers) //only shoots them while they're down if set to laser mode
+				if(!C.isStunned() || lasers) //only shoots them while they're down if set to laser mode
 					new_targets += C
 			else
 				new_targets += M
@@ -606,7 +606,7 @@
 	var/target = null
 	if(scan_for["human"])
 		for(var/mob/living/carbon/human/M in oview(scan_range,src))
-			if(M.stat || M.lying || M in exclude)
+			if(M.stat || M.isStunned() || M in exclude)
 				continue
 			pos_targets += M
 	if(scan_for["cyborg"])


### PR DESCRIPTION
Simple way of handling limboing around turrets.

closes #16724

:cl:
* tweak: Turrets now check if you are stunned rather than if you are lying down before firing at you