### PR TITLE
Lets cyborgs click on equipped items to select them

### DIFF
--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -49,7 +49,7 @@
 	var/obj/item/W = get_active_hand()
 
 	var/equipped_slot = get_equipped_module_index(A)
-	if(equipped_slot)
+	if(equipped_slot && W != A)
 		select_module(equipped_slot)
 		return
 

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -48,6 +48,11 @@
 
 	var/obj/item/W = get_active_hand()
 
+	var/equipped_slot = get_equipped_module_index(A)
+	if(equipped_slot)
+		select_module(equipped_slot)
+		return
+
 	// Cyborgs have no range-checking unless there is item use
 	if(!W)
 		A.add_hiddenprint(src)

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -11,6 +11,11 @@
 /mob/living/silicon/robot/get_all_slots()
 	return list(module_state_1, module_state_2, module_state_3)
 
+// Returns the index of the module slot the `item` is in, or 0
+/mob/living/silicon/robot/proc/get_equipped_module_index(var/item)
+	var/list/equipped_modules = get_all_slots()
+	return equipped_modules.Find(item)
+
 //overridden from parent since they technically have no 'hands'
 /mob/living/silicon/robot/get_equipped_items()
 	return get_all_slots()


### PR DESCRIPTION
Previously you either had to click on the slot holding the item or use the hotkeys, now you can just click on the item itself. It was especially annoying for items like the holomap that take up 90% of the slot.

~~I've made a huge mistake, don't merge this.~~
Huge mistake is no more.