### PR TITLE
Finally fucking fixes mismatched glide_sizes for vehicles and occupants.

### DIFF
--- a/code/datums/locking_category.dm
+++ b/code/datums/locking_category.dm
@@ -68,7 +68,7 @@
 		if (newer_loc) // Edge (no pun intended) case for map borders.
 			new_loc = newer_loc
 
-	AM.forceMove(new_loc)
+	AM.forceMove(new_loc, 0, 0, owner.glide_size)
 
 // Modifies the atom to undo changes in lock().
 /datum/locking_category/proc/unlock(var/atom/movable/AM)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -150,18 +150,6 @@
 			return (3+(M.client.move_delayer.next_allowed - world.time))*world.tick_lag
 	return max(5 * world.tick_lag, 1)
 
-// This is designed to only be used occasionally, since procs add overhead.
-/atom/movable/proc/reset_glide_size()
-	glide_size = Ceiling(WORLD_ICON_SIZE / src.get_move_delay() * world.tick_lag) - 1 //We always split up movements into cardinals for issues with diagonal movements.
-	//glide_size = WORLD_ICON_SIZE / max(move_delay, world.tick_lag) * world.tick_lag // Updated calc from http://www.byond.com/forum/?post=1573076
-
-/mob/verb/fix_gliding()
-	set category = "OOC"
-	set name = "Fix Movement"
-	set desc = "Fixes jerky movement caused by BYOND being dumb."
-	reset_glide_size()
-
-
 /atom/movable/Move(newLoc,Dir=0,step_x=0,step_y=0)
 	if(!loc || !newLoc)
 		return 0
@@ -417,7 +405,9 @@
 		Obstacle.Bumped(src)
 
 // harderforce is for things like lighting overlays which should only be moved in EXTREMELY specific sitations.
-/atom/movable/proc/forceMove(atom/destination,var/no_tp=0, var/harderforce = FALSE)
+/atom/movable/proc/forceMove(atom/destination,var/no_tp=0, var/harderforce = FALSE, glide_size_override = 0)
+	if(glide_size_override)
+		glide_size = glide_size_override
 	var/atom/old_loc = loc
 	loc = destination
 	last_moved = world.time


### PR DESCRIPTION
Before
![2017-12-10_22-34-32](https://user-images.githubusercontent.com/26525955/33812240-6090148e-ddfa-11e7-8aed-f9a718615e45.gif)
After
![2017-12-10_21-45-46](https://user-images.githubusercontent.com/26525955/33812229-4ef670ec-ddfa-11e7-9c98-582f668ea0d3.gif)

There are many other things that cause this, including pulling the diona, I'll go through the causes one by one so if everything breaks spectacularly I at least know exactly what did it.

:cl:
 * bugfix: Fixes mismatched glide_sizes for vehicles (possibly other things as well). This means wounded people riding vehicles won't wobble all over the place anymore.

