### PR TITLE
adds armor absorption, where armor absorbs a portion of the blow to you.

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -39,6 +39,7 @@
 	var/cant_drop_msg = " sticks to your hand!"
 
 	var/armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
+	var/armor_absorb = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0)
 
 	var/list/allowed = null //suit storage stuff.
 	var/obj/item/device/uplink/hidden/hidden_uplink = null // All items can have an uplink hidden inside, just remember to add the triggers.

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -46,6 +46,24 @@ emp_act
 		organnum++
 	return (armorval/max(organnum, 1))
 
+/mob/living/carbon/human/getarmorabsorb(var/def_zone, var/type)
+	var/armorval = 0
+	var/organnum = 0
+
+	if(def_zone)
+		if(isorgan(def_zone))
+			return checkarmorabsorb(def_zone, type)
+		var/datum/organ/external/affecting = get_organ(ran_zone(def_zone))
+		return checkarmorabsorb(affecting, type)
+		//If a specific bodypart is targetted, check how that bodypart is protected and return the value.
+
+	//If you don't specify a bodypart, it checks ALL your bodyparts for protection, and averages out the values
+	for(var/datum/organ/external/organ in organs)
+		armorval += checkarmorabsorb(organ, type)
+		organnum++
+	return (armorval/max(organnum, 1))
+
+
 /mob/living/carbon/human/proc/get_siemens_coefficient_organ(var/datum/organ/external/def_zone)
 	if(!def_zone)
 		return 1.0
@@ -75,6 +93,21 @@ emp_act
 		var/obj/mecha/M = loc
 		protection += M.rad_protection
 	return protection
+
+/mob/living/carbon/human/proc/checkarmorabsorb(var/datum/organ/external/def_zone, var/type)
+	if(!type)
+		return 0
+	var/protection = 0
+	var/list/body_parts = list(head, wear_mask, wear_suit, w_uniform, gloves, shoes)
+	for(var/bp in body_parts)
+		if(!bp)
+			continue
+		if(bp && istype(bp ,/obj/item/clothing))
+			var/obj/item/clothing/C = bp
+			if(C.body_parts_covered & def_zone.body_part)
+				protection += C.armor_absorb[type]
+	return protection
+
 
 /mob/living/carbon/human/proc/check_body_part_coverage(var/body_part_flags=0, var/obj/item/ignored)
 	if(!body_part_flags)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -100,9 +100,7 @@ emp_act
 	var/protection = 0
 	var/list/body_parts = list(head, wear_mask, wear_suit, w_uniform, gloves, shoes)
 	for(var/bp in body_parts)
-		if(!bp)
-			continue
-		if(bp && istype(bp ,/obj/item/clothing))
+		if(istype(bp, /obj/item/clothing))
 			var/obj/item/clothing/C = bp
 			if(C.body_parts_covered & def_zone.body_part)
 				protection += C.armor_absorb[type]

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -13,7 +13,7 @@
 		return 0
 
 	var/damage_done = damage/(blocked+1)
-
+	damage_done = run_armor_absorb(def_zone, damagetype, damage_done)
 	switch(damagetype)
 		if(BRUTE)
 			adjustBruteLoss(damage_done)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -39,6 +39,20 @@
 /mob/living/proc/getarmor(var/def_zone, var/type)
 	return 0
 
+/mob/living/proc/getarmorabsorb(var/def_zone, var/type)
+	return 0
+
+/mob/living/proc/run_armor_absorb(var/def_zone = null, var/attack_flag = "melee", var/initial_damage)
+	var/armor = getarmorabsorb(def_zone, attack_flag)
+	var/final_damage = initial_damage
+
+	if(armor)
+		var/damage_multiplier = final_damage/armor
+		if(damage_multiplier < 1)
+			final_damage *= damage_multiplier
+
+	return final_damage
+
 
 /mob/living/bullet_act(var/obj/item/projectile/P, var/def_zone)
 	var/obj/item/weapon/cloaking_device/C = locate((/obj/item/weapon/cloaking_device) in src)


### PR DESCRIPTION
the current armor system is two dice rolls of armor negation. First one succeeding means the damage received is half, second one succeeding means the damage is fully negated.

armor_absorb is how much of the final damage is negated (by taking the damage to be received and dividing it against armor_absorb, then multipling the damage by the variable given should it be below 1), and is done after the two dicerolls so as to be more effective.

### **Example situation**

You're hit with a bullet that would normally deal 30 damage, fired from the clown's bananagun. Lucky for you, you're wearing GTide's patented armored grey jumpsuit, with 25 bullet armor negation, and 25 bullet armor absorb.

When the bullet strikes, you roll out of 100. If you get 25 or more, the damage dealt is 15. You roll again, and if it's 25 or more, the damage dealt is 0. However in your situation, you're only so much lucky, only negating the bullets damage to 15 thanks to the power of GTide's armor dispersal system (Clumps of newspapers sealed together using a combination of welder fuel and strange moss found in station maintenance)

Now the thickness of the jumpsuit is taken into account of how much energy the bullet loses on its way to your abdomen beneath. The 15 damage bullet is now divided against the bullet armor absorb, 15/25 = 0.6. 15*0.6 = 9. 9 damage is dealt to your abdomen as the bullet tickles you.

Now, if it were the inverse (armor absorb calculated before armor negation) it would go something like this.

30/25 = 1.2, so the armor_absorb does jack squat in this case. The armor negation rolls succesful once as it does in the above example, reducing the damage down to 15.

9 damage received if AN before AA, 15 damage received if AA before AN.

### **TL;DR**

AN is probability out of 100 you halve the damage, and a further probability out of 100 you negate the damage entirely.

AA is how much of the damage is absorbed. If damage is greater than AA then it does nothing, otherwise it reduces the incoming damage by damage*(damage/AA)

Example: 30 incoming damage, 1 succesful roll of AN, 25 AA

_**If AA before AN**_

30/25 > 1, no damage absorbed, still 30.

1 succesful roll of AA halves damage, damage now 15.

15 damage received.


_**If AN before AA**_

1 succesful roll of AN halves damage, damage now 15.

15/25 < 1, damage absorbed. 15*(15/25) = 9.

9 damage received.


### **TL;DR of TL;DR**

AN before AA > AA before AN


**I can change it to be the opposite case should the majority feel it should be that way.**



