### PR TITLE
Code salvage: Centcomm orders

### DIFF
--- a/code/game/centcomm_orders.dm
+++ b/code/game/centcomm_orders.dm
@@ -40,7 +40,7 @@ var/global/current_centcomm_order_id=124901
 		// Don't claim stuff that other orders may want.
 		if(fulfilled[O.type]==requested[O.type])
 			return 0
-		fulfilled[O.type]=fulfilled[O.type]+amount
+		fulfilled[O.type]+=amount
 		qdel(O)
 		return 1
 

--- a/code/game/centcomm_orders.dm
+++ b/code/game/centcomm_orders.dm
@@ -60,12 +60,11 @@ var/global/current_centcomm_order_id=124901
 	for(var/path in requested)
 		if(!path)
 			continue
-		var/atom/movable/AM = new path()
+		var/atom/movable/AM = path
 		if(html_format)
-			manifest += "<li>[AM.name], amount: [requested[path]]</li>"
+			manifest += "<li>[initial(AM.name)], amount: [requested[path]]</li>"
 		else
-			manifest += "[AM.name], amount: [requested[path]]"
-		qdel(AM)//just to make sure they're deleted by the garbage collector
+			manifest += "[initial(AM.name)], amount: [requested[path]]"
 	if(html_format)
 		manifest += "</ul>"
 	return manifest
@@ -82,7 +81,6 @@ var/global/current_centcomm_order_id=124901
 			manifest += "<li>[initial(AM.name)], amount: [fulfilled[path]]</li>"
 		else
 			manifest += "[initial(AM.name)], amount: [fulfilled[path]]"
-		qdel(AM)//just to make sure they're deleted by the garbage collector
 	if(html_format)
 		manifest += "</ul>"
 	return manifest

--- a/code/game/centcomm_orders.dm
+++ b/code/game/centcomm_orders.dm
@@ -77,11 +77,11 @@ var/global/current_centcomm_order_id=124901
 	for(var/path in fulfilled)
 		if(!path)
 			continue
-		var/atom/movable/AM = new path()
+		var/atom/movable/AM = path
 		if(html_format)
-			manifest += "<li>[AM.name], amount: [fulfilled[path]]</li>"
+			manifest += "<li>[initial(AM.name)], amount: [fulfilled[path]]</li>"
 		else
-			manifest += "[AM.name], amount: [fulfilled[path]]"
+			manifest += "[initial(AM.name)], amount: [fulfilled[path]]"
 		qdel(AM)//just to make sure they're deleted by the garbage collector
 	if(html_format)
 		manifest += "</ul>"

--- a/code/game/centcomm_orders.dm
+++ b/code/game/centcomm_orders.dm
@@ -9,6 +9,7 @@ var/global/current_centcomm_order_id=124901
 	var/id = 0 // Some bullshit ID we use for fluff.
 	var/name = "CentComm" // Name of the ordering entity. Fluff.
 	var/datum/money_account/acct // account we pay to
+	var/acct_by_string = "unknown"
 
 	// Amount decided upon
 	var/worth = 0
@@ -51,6 +52,17 @@ var/global/current_centcomm_order_id=124901
 
 /datum/centcomm_order/proc/Pay()
 	acct.charge(-worth,null,"Payment for order #[id]",dest_name = name)
+
+/datum/centcomm_order/proc/getRequestsByName()
+	var/manifest = "<ul>"
+	for(var/path in requested)
+		if(!path)
+			continue
+		var/atom/movable/AM = new path()
+		manifest += "<li>[AM.name], amount: [requested[path]]</li>"
+		qdel(AM)//just to make sure they're deleted by the garbage collector
+	manifest += "</ul>"
+	return manifest
 
 /datum/centcomm_order/proc/OnPostUnload()
 	return

--- a/code/game/centcomm_orders.dm
+++ b/code/game/centcomm_orders.dm
@@ -10,10 +10,6 @@ var/global/current_centcomm_order_id=124901
 	var/name = "CentComm" // Name of the ordering entity. Fluff.
 	var/datum/money_account/acct // account we pay to
 
-	// Amounts centcomm is willing to pay
-	var/credits_min = 0
-	var/credits_max = 0
-
 	// Amount decided upon
 	var/worth = 0
 
@@ -34,12 +30,16 @@ var/global/current_centcomm_order_id=124901
 	if(!O)
 		return 0
 	if(O.type in requested)
+		var/amount = 1
+		if(istype(O, /obj/item/stack))
+			var/obj/item/stack/S = O
+			amount = S.amount
 		if(!(O.type in fulfilled))
 			fulfilled[O.type]=0
 		// Don't claim stuff that other orders may want.
 		if(fulfilled[O.type]==requested[O.type])
 			return 0
-		fulfilled[O.type]=fulfilled[O.type]+1
+		fulfilled[O.type]=fulfilled[O.type]+amount
 		qdel(O)
 		return 1
 

--- a/code/game/centcomm_orders.dm
+++ b/code/game/centcomm_orders.dm
@@ -53,15 +53,38 @@ var/global/current_centcomm_order_id=124901
 /datum/centcomm_order/proc/Pay()
 	acct.charge(-worth,null,"Payment for order #[id]",dest_name = name)
 
-/datum/centcomm_order/proc/getRequestsByName()
-	var/manifest = "<ul>"
+/datum/centcomm_order/proc/getRequestsByName(var/html_format = 0)
+	var/manifest = ""
+	if(html_format)
+		manifest = "<ul>"
 	for(var/path in requested)
 		if(!path)
 			continue
 		var/atom/movable/AM = new path()
-		manifest += "<li>[AM.name], amount: [requested[path]]</li>"
+		if(html_format)
+			manifest += "<li>[AM.name], amount: [requested[path]]</li>"
+		else
+			manifest += "[AM.name], amount: [requested[path]]"
 		qdel(AM)//just to make sure they're deleted by the garbage collector
-	manifest += "</ul>"
+	if(html_format)
+		manifest += "</ul>"
+	return manifest
+
+/datum/centcomm_order/proc/getFulfilledByName(var/html_format = 0)
+	var/manifest = ""
+	if(html_format)
+		manifest = "<ul>"
+	for(var/path in fulfilled)
+		if(!path)
+			continue
+		var/atom/movable/AM = new path()
+		if(html_format)
+			manifest += "<li>[AM.name], amount: [fulfilled[path]]</li>"
+		else
+			manifest += "[AM.name], amount: [fulfilled[path]]"
+		qdel(AM)//just to make sure they're deleted by the garbage collector
+	if(html_format)
+		manifest += "</ul>"
 	return manifest
 
 /datum/centcomm_order/proc/OnPostUnload()

--- a/code/game/machinery/computer/cargo.dm
+++ b/code/game/machinery/computer/cargo.dm
@@ -175,6 +175,12 @@ For vending packs, see vending_packs.dm*/
 		if(SO)
 			orders_list.Add(list(list("ordernum" = SO.ordernum, "supply_type" = SO.object.name, "orderedby" = SO.orderedby, "comment" = SO.comment)))
 	data["orders"] = orders_list
+
+	var/centcomm_list[0]
+	for(var/datum/centcomm_order/O in supply_shuttle.centcomm_orders)
+		centcomm_list.Add(list(list("id" = O.id, "requested" = O.getRequestsByName(), "fulfilled" = O.getFulfilledByName(), "name" = O.name, "worth" = O.worth, "to" = O.acct_by_string)))
+	data["centcomm_orders"] = centcomm_list
+
 	data["money"] = current_acct.fmtBalance()
 	data["send"] = list("send" = 1)
 	data["moving"] = supply_shuttle.moving
@@ -182,7 +188,7 @@ For vending packs, see vending_packs.dm*/
 	data["show_permissions"] = permissions_screen
 	data["restriction"] = supply_shuttle.restriction
 	data["requisition"] = supply_shuttle.requisition
-	data["centcomm_orders"] = supply_shuttle.centcomm_orders
+
 	data["screen"] = screen
 
 	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)

--- a/code/game/machinery/computer/cargo.dm
+++ b/code/game/machinery/computer/cargo.dm
@@ -40,6 +40,15 @@ For vending packs, see vending_packs.dm*/
 
 	light_color = LIGHT_COLOR_BROWN
 
+/obj/machinery/computer/supplycomp/New()
+	..()
+	supply_shuttle.supply_consoles.Add(src)
+
+/obj/machinery/computer/supplycomp/Destroy()
+	supply_shuttle.supply_consoles.Remove(src)
+	..()
+
+
 /obj/machinery/computer/supplycomp/attack_ai(var/mob/user as mob)
 	add_hiddenprint(user)
 	return attack_hand(user)

--- a/code/game/machinery/computer/cargo.dm
+++ b/code/game/machinery/computer/cargo.dm
@@ -340,7 +340,8 @@ For vending packs, see vending_packs.dm*/
 	else if (href_list["screen"])
 		if(!check_restriction(usr))
 			return
-		screen = text2num(href_list["screen"])
+		if(text2num(href_list["screen"]) == SCR_MAIN || text2num(href_list["screen"]) == SCR_CENTCOM)
+			screen = text2num(href_list["screen"])
 		return 1
 	else if (href_list["close"])
 		if(usr.machine == src)

--- a/code/game/machinery/computer/cargo.dm
+++ b/code/game/machinery/computer/cargo.dm
@@ -25,6 +25,9 @@ For vending packs, see vending_packs.dm*/
 	acc_info["account"] = account
 	return acc_info
 
+#define SCR_MAIN 1
+#define SCR_CENTCOM 2
+
 /obj/machinery/computer/supplycomp
 	name = "Supply shuttle console"
 	icon = 'icons/obj/computer.dmi'
@@ -37,7 +40,7 @@ For vending packs, see vending_packs.dm*/
 	var/permissions_screen = FALSE
 	var/last_viewed_group = "Supplies" // not sure how to get around hard coding this
 	var/datum/money_account/current_acct
-
+	var/screen = SCR_MAIN
 	light_color = LIGHT_COLOR_BROWN
 
 /obj/machinery/computer/supplycomp/New()
@@ -180,6 +183,7 @@ For vending packs, see vending_packs.dm*/
 	data["restriction"] = supply_shuttle.restriction
 	data["requisition"] = supply_shuttle.requisition
 	data["centcomm_orders"] = supply_shuttle.centcomm_orders
+	data["screen"] = screen
 
 	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)
@@ -332,6 +336,11 @@ For vending packs, see vending_packs.dm*/
 		if(!check_restriction(usr))
 			return
 		supply_shuttle.requisition = text2num(href_list["requisition_status"])
+		return 1
+	else if (href_list["screen"])
+		if(!check_restriction(usr))
+			return
+		screen = text2num(href_list["screen"])
 		return 1
 	else if (href_list["close"])
 		if(usr.machine == src)
@@ -535,3 +544,6 @@ For vending packs, see vending_packs.dm*/
 		return 1
 
 	add_fingerprint(usr)
+
+#undef SCR_MAIN
+#undef SCR_CENTCOM

--- a/code/game/machinery/computer/cargo.dm
+++ b/code/game/machinery/computer/cargo.dm
@@ -340,8 +340,9 @@ For vending packs, see vending_packs.dm*/
 	else if (href_list["screen"])
 		if(!check_restriction(usr))
 			return
-		if(text2num(href_list["screen"]) == SCR_MAIN || text2num(href_list["screen"]) == SCR_CENTCOM)
-			screen = text2num(href_list["screen"])
+		var/result = text2num(href_list["screen"])
+		if(result == SCR_MAIN || result == SCR_CENTCOM)
+			screen = result
 		return 1
 	else if (href_list["close"])
 		if(usr.machine == src)

--- a/code/game/machinery/computer/cargo.dm
+++ b/code/game/machinery/computer/cargo.dm
@@ -170,6 +170,7 @@ For vending packs, see vending_packs.dm*/
 	data["show_permissions"] = permissions_screen
 	data["restriction"] = supply_shuttle.restriction
 	data["requisition"] = supply_shuttle.requisition
+	data["centcomm_orders"] = supply_shuttle.centcomm_orders
 
 	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -299,3 +299,10 @@ var/datum/controller/supply_shuttle/supply_shuttle = new
 			shoppinglist += O
 		else
 			to_chat(user, "<span class='warning'>[O.orderedby] does not have enough funds for this request.</span>")
+
+/datum/controller/supply_shuttle/proc/add_centcomm_order(var/datum/centcomm_order/C)
+	 centcomm_orders.Add(C)
+	 /*TODO -- ADD WAY TO ANNOUNCE TO THE CREW
+	 		IDEA 1: JUST PRINT TO THE STATION COMPUTERS LIKE ANNOUNCEMENTS DO
+	 		IDEA 2: ADD THE QM CONSOLE. QM-ACCESS ONLY, ALLOWS YOU TO SEE THE LAST TRANSACTIONS ON THE SHIP, LAST ORDERS, AND CURRENT CENTCOMM ORDERS.
+	 */

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -31,6 +31,7 @@ var/datum/controller/supply_shuttle/supply_shuttle = new
 	var/list/shoppinglist = list()
 	var/list/requestlist = list()
 	var/list/supply_packs = list()
+	var/list/supply_consoles = list()
 	//shuttle movement
 	var/at_station = 0
 	var/movetime = 1200
@@ -40,6 +41,7 @@ var/datum/controller/supply_shuttle/supply_shuttle = new
 	var/datum/materials/materials_list
 	var/restriction = 1 //Who can approve orders? 0 = autoapprove; 1 = has access; 2 = has an ID (omits silicons); 3 = actions require PIN
 	var/requisition = 0 //Are orders being paid for by the department? 0 = no; 1 = auto; possible future: allow with pin?
+
 
 /datum/controller/supply_shuttle/New()
 	ordernum = rand(1,9000)
@@ -301,8 +303,23 @@ var/datum/controller/supply_shuttle/supply_shuttle = new
 			to_chat(user, "<span class='warning'>[O.orderedby] does not have enough funds for this request.</span>")
 
 /datum/controller/supply_shuttle/proc/add_centcomm_order(var/datum/centcomm_order/C)
-	 centcomm_orders.Add(C)
+	centcomm_orders.Add(C)
 	 /*TODO -- ADD WAY TO ANNOUNCE TO THE CREW
 	 		IDEA 1: JUST PRINT TO THE STATION COMPUTERS LIKE ANNOUNCEMENTS DO
 	 		IDEA 2: ADD THE QM CONSOLE. QM-ACCESS ONLY, ALLOWS YOU TO SEE THE LAST TRANSACTIONS ON THE SHIP, LAST ORDERS, AND CURRENT CENTCOMM ORDERS.
+	 		Let's just go with printing out a piece of paper and 'a new order has arrived' at cargo consoles.
 	 */
+	var/name = "External order form - [C.name] order number [C.id]"
+	var/info = {"<h3>Central command supply requisition form</h3<><hr>
+	 			INDEX: #[C.id]<br>
+	 			REQUESTED BY: [C.name]<br>
+	 			MUST BE IN CRATE: [C.must_be_in_crate ? "YES" : "NO"]
+	 			REQUESTED ITEMS:<br>
+	 			[C.getRequestsByName()]
+	 			WORTH: [C.worth] credits TO [C.acct_by_string]
+	 			"}
+	for(var/obj/machinery/computer/supplycomp/S in supply_consoles)
+		var/obj/item/weapon/paper/reqform = new /obj/item/weapon/paper(S.loc)
+		reqform.name = name
+		reqform.info = info
+		reqform.update_icon()

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -303,8 +303,6 @@ var/datum/controller/supply_shuttle/supply_shuttle = new
 
 /datum/controller/supply_shuttle/proc/add_centcomm_order(var/datum/centcomm_order/C)
 	centcomm_orders.Add(C)
-	for(var/I in centcomm_orders)
-		to_chat(world, "[I]")
 	var/name = "External order form - [C.name] order number [C.id]"
 	var/info = {"<h3>Central command supply requisition form</h3<><hr>
 	 			INDEX: #[C.id]<br>

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -165,19 +165,18 @@ var/datum/controller/supply_shuttle/supply_shuttle = new
 					qdel(A)
 					continue
 
-				SellObjToOrders(A,0)
+				SellObjToOrders(A,1)
 
-				// Delete it. (Fixes github #473)
 				if(A)
 					qdel(A)
 		else
-			SellObjToOrders(MA,1)
+			SellObjToOrders(MA,0)
 
 		// PAY UP BITCHES
 		for(var/datum/centcomm_order/O in centcomm_orders)
 			if(O.CheckFulfilled())
 				O.Pay()
-				centcomm_orders -= O
+				centcomm_orders.Remove(O)
 //		to_chat(world, "deleting [MA]/[MA.type] it was [!MA.anchored ? "not ": ""] anchored")
 		qdel(MA)
 
@@ -304,18 +303,15 @@ var/datum/controller/supply_shuttle/supply_shuttle = new
 
 /datum/controller/supply_shuttle/proc/add_centcomm_order(var/datum/centcomm_order/C)
 	centcomm_orders.Add(C)
-	 /*TODO -- ADD WAY TO ANNOUNCE TO THE CREW
-	 		IDEA 1: JUST PRINT TO THE STATION COMPUTERS LIKE ANNOUNCEMENTS DO
-	 		IDEA 2: ADD THE QM CONSOLE. QM-ACCESS ONLY, ALLOWS YOU TO SEE THE LAST TRANSACTIONS ON THE SHIP, LAST ORDERS, AND CURRENT CENTCOMM ORDERS.
-	 		Let's just go with printing out a piece of paper and 'a new order has arrived' at cargo consoles.
-	 */
+	for(var/I in centcomm_orders)
+		to_chat(world, "[I]")
 	var/name = "External order form - [C.name] order number [C.id]"
 	var/info = {"<h3>Central command supply requisition form</h3<><hr>
 	 			INDEX: #[C.id]<br>
 	 			REQUESTED BY: [C.name]<br>
-	 			MUST BE IN CRATE: [C.must_be_in_crate ? "YES" : "NO"]
+	 			MUST BE IN CRATE: [C.must_be_in_crate ? "YES" : "NO"]<br>
 	 			REQUESTED ITEMS:<br>
-	 			[C.getRequestsByName()]
+	 			[C.getRequestsByName(1)]
 	 			WORTH: [C.worth] credits TO [C.acct_by_string]
 	 			"}
 	for(var/obj/machinery/computer/supplycomp/S in supply_consoles)
@@ -323,3 +319,4 @@ var/datum/controller/supply_shuttle/supply_shuttle = new
 		reqform.name = name
 		reqform.info = info
 		reqform.update_icon()
+		S.say("New central command request available")

--- a/code/modules/events/centcomm_order.dm
+++ b/code/modules/events/centcomm_order.dm
@@ -1,0 +1,83 @@
+//Refer to game/centcomm_orders.dm
+
+/datum/event/centcomm_order
+
+
+/datum/event/centcomm_order/start()
+	var/datum/centcomm_order/C = new
+	C.name = command_name()
+	if(prob(50))
+		C.must_be_in_crate = rand(0,1)
+
+	//Who is it paying to
+	var/department = pick("Cargo","Medical","Science")
+	var/list/chosen
+	C.acct = department_accounts[department]
+	switch(department)
+		if("Cargo") //Minerals
+			chosen = pick(
+				list(
+					"item" = /obj/item/stack/sheet/mineral/diamond,
+					"amount" = rand(5,50),
+					"value" = rand(400, 2500)
+					),
+				list(
+					"item" = /obj/item/stack/sheet/mineral/uranium,
+					"amount" = rand(5,50),
+					"value" = rand(200, 1500)
+					),
+				list(
+					"item" = /obj/item/stack/sheet/mineral/gold,
+					"amount" = rand(5,50),
+					"value" = rand(200, 1500)
+					),
+				list(
+					"item" = /obj/item/stack/sheet/mineral/silver,
+					"amount" = rand(5,50),
+					"value" = rand(200, 1500)
+					),
+				list(
+					"item" = /obj/item/stack/sheet/mineral/phazon,
+					"amount" = rand(1,10),
+					"value" = rand(400, 5000)
+					),
+				list(
+					"item" = /obj/item/stack/sheet/mineral/clown,
+					"amount" = rand(1,10),
+					"value" = rand(200, 3500)
+					)
+				)
+
+		if("Medical")
+			chosen = pick(
+				list(
+					"item" = /obj/item/weapon/gun/energy/gun/nuclear,
+					"amount" = rand(1,5),
+					"value" = rand(350,1250),
+					),
+				list(
+					"item" = /obj/item/weapon/subspacetunneler,
+					"amount" = rand(1,3),
+					"value" = rand(350,1250),
+					)
+				)
+		if("Science")
+			chosen = pick(
+				list(
+					"item" = /obj/item/organ/internal/kidneys,
+					"amount" = rand(1,3),
+					"value" = rand(300,900),
+					),
+				list(
+					"item" = /obj/item/organ/external/head,
+					"amount" = rand(1,2),
+					"value" = rand(250,750),
+				)
+			)
+
+
+	var/list/product = chosen["item"]
+	product[chosen["item"]] = chosen["amount"]
+	C.requested = product
+	C.worth = chosen["value"]
+	supply_shuttle.add_centcomm_order(C)

--- a/code/modules/events/centcomm_order.dm
+++ b/code/modules/events/centcomm_order.dm
@@ -77,8 +77,12 @@
 
 
 	var/list/chosen = pick(choices)
-	var/list/product = chosen["item"]
-	product[chosen["item"]] = chosen["amount"]
+	var/item = chosen["item"]
+	var/amount = chosen["amount"]
+	var/value = chosen["value"]
+	var/list/product = list(item)
+	product[item] = amount
 	C.requested = product
-	C.worth = chosen["value"]
+	C.worth = value
+	C.acct_by_string = department
 	supply_shuttle.add_centcomm_order(C)

--- a/code/modules/events/centcomm_order.dm
+++ b/code/modules/events/centcomm_order.dm
@@ -13,6 +13,7 @@
 	var/department = pick("Cargo","Medical","Science","Civilian")
 	var/list/choices
 	C.acct = department_accounts[department]
+	C.acct_by_string = department
 	switch(department)
 		if("Cargo") //Minerals
 			choices = list(
@@ -68,11 +69,6 @@
 					"amount" = rand(1,3),
 					"value" = rand(300,900),
 					),
-				list(
-					"item" = /obj/item/organ/external/head,
-					"amount" = rand(1,2),
-					"value" = rand(250,750),
-					)
 				)
 		if("Civilian") //FOOD
 			choices = list(

--- a/code/modules/events/centcomm_order.dm
+++ b/code/modules/events/centcomm_order.dm
@@ -10,7 +10,7 @@
 		C.must_be_in_crate = rand(0,1)
 
 	//Who is it paying to
-	var/department = pick("Cargo","Medical","Science")
+	var/department = pick("Cargo","Medical","Science","Civilian")
 	var/list/choices
 	C.acct = department_accounts[department]
 	switch(department)
@@ -48,7 +48,7 @@
 					)
 				)
 
-		if("Science")
+		if("Science") //Guns
 			choices = list(
 				list(
 					"item" = /obj/item/weapon/gun/energy/gun/nuclear,
@@ -61,7 +61,7 @@
 					"value" = rand(350,1250),
 					)
 				)
-		if("Medical")
+		if("Medical") //Stolen organs
 			choices = list(
 				list(
 					"item" = /obj/item/organ/internal/kidneys,
@@ -74,12 +74,63 @@
 					"value" = rand(250,750),
 					)
 				)
+		if("Civilian") //FOOD
+			choices = list(
+				list(
+					"item" = /obj/item/weapon/reagent_containers/food/snacks/pie,
+					"amount" = rand(3,12),
+					"value" = rand(60,190),
+					"name_override" = "Clown Federation" //Honk
+					),
+				list(
+					"item" = /obj/structure/poutineocean/poutinecitadel,
+					"amount" = 1,
+					"value" = rand(1000,3000),
+					),
+				list(
+					"item" = /obj/item/weapon/reagent_containers/food/snacks/sweetsundaeramen,
+					"amount" = rand(1,3),
+					"value" = rand(150,700),
+					),
+				list(
+					"item" = /obj/item/weapon/reagent_containers/food/snacks/superbiteburger,
+					"amount" = rand(1,3),
+					"value" = rand(300,800),
+					),
+				list(
+					"item" = /obj/item/weapon/reagent_containers/food/snacks/sliceable/turkey,
+					"amount" = rand(1,2),
+					"value" = rand(100,400),
+					),
+				list(
+					"item" = /obj/structure/popout_cake,
+					"amount" = 1,
+					"value" = rand(600,2000),
+					),
+				list(
+					"item" = /obj/item/weapon/reagent_containers/food/snacks/bleachkipper,
+					"amount" = rand(2,5),
+					"value" = rand(120,500),
+					),
+				list(
+					"item" = /obj/item/weapon/reagent_containers/food/snacks/potentham,
+					"amount" = rand(1,2),
+					"value" = rand(400,2001),
+					),
+				list(
+					"item" = /obj/item/weapon/reagent_containers/food/snacks/sundayroast,
+					"amount" = rand(1,2),
+					"value" = rand(400,900),
+					),
+				)
 
 
 	var/list/chosen = pick(choices)
 	var/item = chosen["item"]
 	var/amount = chosen["amount"]
 	var/value = chosen["value"]
+	if(chosen["name_override"])
+		C.name = chosen["name_override"]
 	var/list/product = list(item)
 	product[item] = amount
 	C.requested = product

--- a/code/modules/events/centcomm_order.dm
+++ b/code/modules/events/centcomm_order.dm
@@ -11,11 +11,11 @@
 
 	//Who is it paying to
 	var/department = pick("Cargo","Medical","Science")
-	var/list/chosen
+	var/list/choices
 	C.acct = department_accounts[department]
 	switch(department)
 		if("Cargo") //Minerals
-			chosen = pick(
+			choices = list(
 				list(
 					"item" = /obj/item/stack/sheet/mineral/diamond,
 					"amount" = rand(5,50),
@@ -48,8 +48,8 @@
 					)
 				)
 
-		if("Medical")
-			chosen = pick(
+		if("Science")
+			choices = list(
 				list(
 					"item" = /obj/item/weapon/gun/energy/gun/nuclear,
 					"amount" = rand(1,5),
@@ -61,8 +61,8 @@
 					"value" = rand(350,1250),
 					)
 				)
-		if("Science")
-			chosen = pick(
+		if("Medical")
+			choices = list(
 				list(
 					"item" = /obj/item/organ/internal/kidneys,
 					"amount" = rand(1,3),
@@ -72,10 +72,11 @@
 					"item" = /obj/item/organ/external/head,
 					"amount" = rand(1,2),
 					"value" = rand(250,750),
+					)
 				)
-			)
 
 
+	var/list/chosen = pick(choices)
 	var/list/product = chosen["item"]
 	product[chosen["item"]] = chosen["amount"]
 	C.requested = product

--- a/nano/templates/supply_console.tmpl
+++ b/nano/templates/supply_console.tmpl
@@ -79,57 +79,67 @@ Used In File(s): \code\game\supplyshuttle.dm
 	</div>
 {{/if}}
 <div class="item">
-	<div class="itemLabel">
-		Supply Orders
+	<div class="itemLabel">Screen:</div>
+	<div class="itemContents">
+		{{:helper.link('Main',      'gear',{'screen':1},(data.screen==1)?'linkOn':'')}}
+		{{:helper.link('Central Command Requests',     'gear',{'screen':2},(data.screen==2)?'linkOn':'')}}
 	</div>
-	<div class="itemContentWide">
-		<div class="statusDisplay">
-			<div class="line" style="overflow-y: auto; overflow-x: hidden; scrollbar-base-color: #336699; scrollbar-arrow-color: #ffffff; height: 220px;">
-				<u><b>Requests</b></u>
-				<br>
-				{{for data.requests}}
-					<div class="line">
-						{{:value.ordernum}} - {{:value.supply_type}} for {{:value.orderedby}}
-							<div class="line" style="font-style: italic;">
-								{{:value.comment}}
-							</div>
-						{{:helper.link('APPROVE', null, value.command1, null)}} {{:helper.link('REJECT', null, value.command2, null)}}
-					</div>
-				{{empty}}
-					No active requests.
-				{{/for}}
-				<br><br>
-				<u><b>Orders</b></u>
-				<br>
-				{{for data.orders}}
-					<div class="line">
-						#{{:value.ordernum}} - {{:value.supply_type}} for {{:value.orderedby}}
-					</div>
-				{{empty}}
-					No confirmed orders.
-				{{/for}}
+</div>
+{{if data.screen == 1}}
+	<div class="item">
+		<div class="itemLabel">
+			Supply Orders
+		</div>
+		<div class="itemContentWide">
+			<div class="statusDisplay">
+				<div class="line" style="overflow-y: auto; overflow-x: hidden; scrollbar-base-color: #336699; scrollbar-arrow-color: #ffffff; height: 220px;">
+					<u><b>Requests</b></u>
+					<br>
+					{{for data.requests}}
+						<div class="line">
+							{{:value.ordernum}} - {{:value.supply_type}} for {{:value.orderedby}}
+								<div class="line" style="font-style: italic;">
+									{{:value.comment}}
+								</div>
+							{{:helper.link('APPROVE', null, value.command1, null)}} {{:helper.link('REJECT', null, value.command2, null)}}
+						</div>
+					{{empty}}
+						No active requests.
+					{{/for}}
+					<br><br>
+					<u><b>Orders</b></u>
+					<br>
+					{{for data.orders}}
+						<div class="line">
+							#{{:value.ordernum}} - {{:value.supply_type}} for {{:value.orderedby}}
+						</div>
+					{{empty}}
+						No confirmed orders.
+					{{/for}}
+				</div>
 			</div>
 		</div>
 	</div>
-</div>
-<div class="item">
-	<div class="itemLabel">
-		Centcomm Requests
-	</div>
-	<div class="itemContentWide">
-		<div class="statusDisplay">
-			<div class="line" style="overflow-y: auto; overflow-x: hidden; scrollbar-base-color: #336699; scrollbar-arrow-color: #ffffff; height: 220px;">
-				<u><b>Requests</b></u>
-				<br>
-				{{for data.centcomm_orders}}
-					<div class="line">
-						{{:value.id}} - {{:value.requested}} for {{:value.name}}: worth {{:value.worth}}
-					</div>
-				{{empty}}
-					No active requests.
-				{{/for}}
-				<br><br>
+{{else data.screen == 2}}
+	<div class="item">
+		<div class="itemLabel">
+			Centcomm Requests
+		</div>
+		<div class="itemContentWide">
+			<div class="statusDisplay">
+				<div class="line" style="overflow-y: auto; overflow-x: hidden; scrollbar-base-color: #336699; scrollbar-arrow-color: #ffffff; height: 220px;">
+					<u><b>Requests</b></u>
+					<br>
+					{{for data.centcomm_orders}}
+						<div class="line">
+							{{:value.id}} - {{:value.requested}} for {{:value.name}}: worth {{:value.worth}}
+						</div>
+					{{empty}}
+						No active requests.
+					{{/for}}
+					<br><br>
+				</div>
 			</div>
 		</div>
 	</div>
-</div>
+{{/if}}

--- a/nano/templates/supply_console.tmpl
+++ b/nano/templates/supply_console.tmpl
@@ -1,5 +1,5 @@
-<!-- 
-Title: Supply Console UI 
+<!--
+Title: Supply Console UI
 Used In File(s): \code\game\supplyshuttle.dm
 -->
 
@@ -108,6 +108,27 @@ Used In File(s): \code\game\supplyshuttle.dm
 				{{empty}}
 					No confirmed orders.
 				{{/for}}
+			</div>
+		</div>
+	</div>
+</div>
+<div class="item">
+	<div class="itemLabel">
+		Centcomm Requests
+	</div>
+	<div class="itemContentWide">
+		<div class="statusDisplay">
+			<div class="line" style="overflow-y: auto; overflow-x: hidden; scrollbar-base-color: #336699; scrollbar-arrow-color: #ffffff; height: 220px;">
+				<u><b>Requests</b></u>
+				<br>
+				{{for data.centcomm_orders}}
+					<div class="line">
+						{{:value.id}} - {{:value.requested}} for {{:value.name}}: worth {{:value.worth}}
+					</div>
+				{{empty}}
+					No active requests.
+				{{/for}}
+				<br><br>
 			</div>
 		</div>
 	</div>

--- a/nano/templates/supply_console.tmpl
+++ b/nano/templates/supply_console.tmpl
@@ -132,7 +132,12 @@ Used In File(s): \code\game\supplyshuttle.dm
 					<br>
 					{{for data.centcomm_orders}}
 						<div class="line">
-							{{:value.id}} - {{:value.requested}} for {{:value.name}}: worth {{:value.worth}}
+							#{{:value.id}}<br>
+							Requested:<br>
+								{{:value.requested}}<br>
+							Fulfilled:<br>
+							 	{{:value.fulfilled}}<br>
+							for {{:value.name}}: worth {{:value.worth}} to {{:value.to}}<br>
 						</div>
 					{{empty}}
 						No active requests.

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -1238,6 +1238,7 @@
 #include "code\modules\events\bluespaceanomaly.dm"
 #include "code\modules\events\brand_intelligence.dm"
 #include "code\modules\events\carp_migration.dm"
+#include "code\modules\events\centcomm_order.dm"
 #include "code\modules\events\comms_blackout.dm"
 #include "code\modules\events\communications_blackout.dm"
 #include "code\modules\events\disease_outbreak.dm"


### PR DESCRIPTION
while I was looking at the supply_shuttle code, I noticed something called 'centcomm orders'

They're basically custom orders that centcomm can request of the station. Going to try and salvage this and make it into a random event

- [x] Centcomm orders work again
- [x] Active orders can be browsed in some way
- [x] Don't break the supply shuttle
- [x] Populate the list of things that can be requested
- [x] Balance Tweaks