### PR TITLE
adds proximity check to stop people from crawlaporting with TK

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -52,7 +52,7 @@
 	else
 		A.attack_stump(src, params)
 
-	if(src.lying && !(isUnconscious() || stunned || paralysis) && check_crawl_ability() && istype(A, /turf/simulated) && !pulledby && !locked_to && !client.move_delayer.blocked())
+	if(src.lying && !(isUnconscious() || stunned || paralysis) && check_crawl_ability() && istype(A, /turf/simulated) && proximity && !pulledby && !locked_to && !client.move_delayer.blocked())
 		Move(A, get_dir(src,A))
 		delayNextMove(movement_delay()*3,additive=1)
 


### PR DESCRIPTION
closes #16767

Proximity is 1 if the thing is in actual proximity, otherwise it is 0 if not.