### PR TITLE
Misc TK fixes

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -48,7 +48,7 @@
 		delayNextAttack(10)
 
 	if(src.can_use_hand())
-		A.attack_hand(src, params)
+		A.attack_hand(src, params, proximity)
 	else
 		A.attack_stump(src, params)
 
@@ -56,14 +56,14 @@
 		Move(A, get_dir(src,A))
 		delayNextMove(movement_delay()*3,additive=1)
 
-/atom/proc/attack_hand(mob/user as mob, params)
+/atom/proc/attack_hand(mob/user as mob, params, var/proximity)
 	return
 
 //called when we try to click but have no hand
 //good for general purposes
-/atom/proc/attack_stump(mob/user as mob, params)
+/atom/proc/attack_stump(mob/user as mob, params, var/proximity)
 	if(!requires_dexterity(user))
-		attack_hand(user) //if the object doesn't need dexterity, we can use our stump
+		attack_hand(user, params, proximity) //if the object doesn't need dexterity, we can use our stump
 	else
 		to_chat(user, "Your [user.get_index_limb_name(user.active_hand)] is not fine enough for this action.")
 

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -20,9 +20,10 @@
 
 	var/list/exit_beams = list()
 
-/obj/effect/portal/attack_hand(var/mob/user)
-	spawn()
-		src.teleport(user)
+/obj/effect/portal/attack_hand(var/mob/user, params, proximity)
+	if(proximity)
+		spawn()
+			src.teleport(user)
 
 /obj/effect/portal/attackby(obj/item/weapon/O as obj, mob/user as mob)
 	if(O == creator)

--- a/code/game/objects/structures/fitness.dm
+++ b/code/game/objects/structures/fitness.dm
@@ -40,7 +40,9 @@
 	density = 1
 	anchored = 1
 
-/obj/structure/stacklifter/attack_hand(mob/user as mob)
+/obj/structure/stacklifter/attack_hand(mob/user, params, proximity)
+	if(!proximity)
+		return
 	if(in_use)
 		to_chat(user, "<span class='notice'>It's already in use - wait a bit.</span>")
 		return
@@ -77,7 +79,9 @@
 	density = 1
 	anchored = 1
 
-/obj/structure/weightlifter/attack_hand(mob/user as mob)
+/obj/structure/weightlifter/attack_hand(mob/user as mob, params, proximity)
+	if(!proximity)
+		return
 	if(in_use)
 		to_chat(user, "<span class='notice'>It's already in use - wait a bit.</span>")
 		return

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -218,13 +218,13 @@
 
 	return ..()
 
-/obj/structure/bed/chair/comfy/attack_hand(var/mob/user)
+/obj/structure/bed/chair/comfy/attack_hand(var/mob/user, params, proximity)
 	if(is_locking(lock_type))
 		return ..()
-
-	for (var/obj/item/I in src)
-		user.put_in_hands(I)
-		to_chat(user, "You pull out \the [I] between \the [src]'s cushions.")
+	if(proximity)
+		for (var/obj/item/I in src)
+			user.put_in_hands(I)
+			to_chat(user, "You pull out \the [I] between \the [src]'s cushions.")
 
 /obj/structure/bed/chair/comfy/brown
 	icon_state = "comfychair_brown"


### PR DESCRIPTION
attack_hand is now passed params and proximity. This is used to fix things from teleporting you/to you should you use TK, as that does not pass params or proximity when calling attack_hand on things.

Yaay operator overload.

closes #15418
closes #14810

Also you can't use gym equipment to teleport through walls either now.