### PR TITLE
Ghost with examine: "i am growing stronger."

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -482,3 +482,13 @@
 		"health")
 
 	reset_vars_after_duration(resettable_vars, duration)
+
+/obj/structure/closet/examine(mob/user)
+	..()
+	if(!opened && isobserver(user) && !istype(user,/mob/dead/observer/deafmute)) //Fuck off phantom mask users
+		var/mob/dead/observer/ghost = user
+		if(!isAdminGhost(ghost) && ghost.mind && ghost.mind.current)
+			if(ghost.mind.isScrying || ghost.mind.current.ajourn) //Scrying or astral travel, fuck them.
+				return
+		to_chat(ghost, "It contains: <span class='info'>[english_list(contents)]</span>.")
+		investigation_log(I_GHOST, "|| had its contents checked by [key_name(ghost)][ghost.locked_to ? ", who was haunting [ghost.locked_to]" : ""]")


### PR DESCRIPTION
![closet](https://user-images.githubusercontent.com/17928298/33957246-36cb2e10-e028-11e7-9f66-5e2923751e71.png)

Pretty much copypaste from silicon law examine. I swear i'll move these mask/journey/scry checks to a mob-level helper proc someday, but not today.

:cl:
 * rscadd: Ghosts can now examine closed lockers to check its contents