### PR TITLE
adds helpful text to preferences.dm when setting antag roles.

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1721,6 +1721,7 @@ NOTE:  The change will take effect AFTER any current recruiting periods."}
 			<dd>Accept this role for this round and all future rounds. You will not be polled again.</dd>
 		</dl>
 	</fieldset>
+	<h2>TO SAVE YOUR SPECIAL ROLE PREFERENCES, PRESS SUBMIT, NOT SAVE SETUP.</h2>
 
 	<table border=\"0\" padding-left = 20px;>
 		<thead>


### PR DESCRIPTION
A lot of the issues stemming from being able to save antag roles are because of misunderstanding what the buttons do.

This just adds a reminder in the window to press the right button.