### PR TITLE
Gives supply cyborgs a mining encryption key.

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -290,7 +290,7 @@
 
 		if("Supply")
 			module = new /obj/item/weapon/robot_module/miner(src)
-			radio.insert_key(new/obj/item/device/encryptionkey/headset_cargo(radio))
+			radio.insert_key(new/obj/item/device/encryptionkey/headset_mining(radio))
 			if(camera && CAMERANET_ROBOTS in camera.network)
 				camera.network.Add(CAMERANET_MINE)
 			module_sprites["Basic"] = "Miner_old"


### PR DESCRIPTION
I'm actually surprised this isn't a thing already.

:cl:
 * tweak: Supply cyborgs now have access to both cargo and mining radio instead of just cargo.
