### PR TITLE
Makes health-based pain slowdown scale with maxHealth

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -651,8 +651,8 @@
 
 	if(feels_pain() && !has_painkillers())
 		var/health_deficiency = (maxHealth - health - halloss)
-		if(health_deficiency >= (maxHealth * 0.4)
-			. += (health_deficiency / (maxHealth * 0.25)
+		if(health_deficiency >= (maxHealth * 0.4))
+			. += (health_deficiency / (maxHealth * 0.25))
 
 
 /mob/living/carbon/proc/can_mind_interact(var/mob/M)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -650,9 +650,9 @@
 		return // Space ignores slowdown
 
 	if(feels_pain() && !has_painkillers())
-		var/health_deficiency = (100 - health - halloss)
-		if(health_deficiency >= 40)
-			. += (health_deficiency / 25)
+		var/health_deficiency = (maxHealth - health - halloss)
+		if(health_deficiency >= (maxHealth * 0.4)
+			. += (health_deficiency / (maxHealth * 0.25)
 
 
 /mob/living/carbon/proc/can_mind_interact(var/mob/M)


### PR DESCRIPTION
Resolves #16780 

:cl:
* tweak: Carbon mobs will now receive damage slowdown proportional for their maximum health, instead of always being based on 100.