### PR TITLE
Hailer for the security module

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -294,6 +294,7 @@
 	modules += new /obj/item/weapon/handcuffs/cyborg(src)
 	modules += new /obj/item/weapon/reagent_containers/spray/pepper(src)
 	modules += new /obj/item/taperoll/police(src)
+	modules += new /obj/item/device/hailer(src)
 	emag = new /obj/item/weapon/gun/energy/laser/cyborg(src)
 
 	sensor_augs = list("Security", "Medical", "Disable")


### PR DESCRIPTION
Sure, secborgs already can use a say "*halt macro to play the audio, but they should be able to target it so they put the overlay on the perps too.

:cl:
* tweak: Security cyborgs now have a hailer for your targeted hailing needs.