### PR TITLE
Fixes gripper upgrades being a shit

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -30,6 +30,7 @@
 	if(!I)
 		to_chat(user, "This cyborg is missing one of the needed components!")
 		return null
+	world.log << I
 	return I
 
 /obj/item/borg/upgrade/proc/attempt_action(var/mob/living/silicon/robot/R,var/mob/living/user)
@@ -85,7 +86,7 @@
 	if(!G)
 		return FAILED_TO_ADD
 
-	G.can_hold += list(/obj/item/weapon/reagent_containers/pill, /obj/item/weapon/storage/pill_bottle)
+	G.can_hold.Add(/obj/item/weapon/reagent_containers/pill, /obj/item/weapon/storage/pill_bottle)
 
 /obj/item/borg/upgrade/reset
 	name = "cyborg reset board"
@@ -265,19 +266,21 @@
 	if(!G)
 		return FAILED_TO_ADD
 
-	G.can_hold += list(/obj/item/weapon/reagent_containers/food)
+	G.can_hold.Add(/obj/item/weapon/reagent_containers/food)
 
 /obj/item/borg/upgrade/magnetic_gripper
-	name = "engineering cyborg magnetic gripper upgrade board"
+	name = "engineering cyborg magnetic gripper upgrade"
 	desc = "Used to give a engineering cyborg a magnetic gripper."
-	icon_state = "cyborg_upgrade2"
+	icon = 'icons/obj/device.dmi'
+	icon_state = "gripper"
 	required_module = list(/obj/item/weapon/robot_module/engineering)
 	modules_to_add = list(/obj/item/weapon/gripper/no_use/magnetic)
 
 /obj/item/borg/upgrade/organ_gripper
-	name = "medical cyborg organ gripper upgrade board"
+	name = "medical cyborg organ gripper upgrade"
 	desc = "Used to give a medical cyborg a organ gripper."
-	icon_state = "cyborg_upgrade2"
+	icon = 'icons/obj/device.dmi'
+	icon_state = "gripper-medical"
 	required_module = list(/obj/item/weapon/robot_module/medical)
 	modules_to_add = list(/obj/item/weapon/gripper/organ)
 
@@ -288,7 +291,7 @@
 	required_module = list(/obj/item/weapon/robot_module/butler)
 	modules_to_add = list(/obj/item/weapon/minihoe, /obj/item/weapon/wirecutters/clippers, /obj/item/weapon/storage/bag/plants, /obj/item/device/analyzer/plant_analyzer)
 
-/obj/item/borg/upgrade/service/attempt_action(var/mob/living/silicon/robot/R,var/mob/living/user)
+/obj/item/borg/upgrade/hydro/attempt_action(var/mob/living/silicon/robot/R,var/mob/living/user)
 	if(..())
 		return FAILED_TO_ADD
 
@@ -296,4 +299,4 @@
 	if(!G)
 		return FAILED_TO_ADD
 
-	G.can_hold += list(/obj/item/seeds, /obj/item/weapon/reagent_containers/glass)
+	G.can_hold.Add(/obj/item/seeds, /obj/item/weapon/reagent_containers/glass)

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -30,7 +30,6 @@
 	if(!I)
 		to_chat(user, "This cyborg is missing one of the needed components!")
 		return null
-	world.log << I
 	return I
 
 /obj/item/borg/upgrade/proc/attempt_action(var/mob/living/silicon/robot/R,var/mob/living/user)

--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -276,8 +276,7 @@
 	reagent_list = BEER
 	artifact = FALSE
 	can_be_placed_into = null
-	units_per_tick = 1
-	var/synth_cost = 30 // 1500 cell charge for 50u beer
+	var/synth_cost = 10 //Around 1666 cell charge for 50u beer
 
 /obj/item/weapon/reagent_containers/glass/replenishing/cyborg/fits_in_iv_drip()
 	return FALSE
@@ -293,7 +292,6 @@
 /obj/item/weapon/reagent_containers/glass/replenishing/cyborg/hacked
 	name = "mickey finn's special brew"
 	reagent_list = BEER2
-	units_per_tick = 0.3
 	synth_cost = 25 //4165 cell charge for 50u !NotShitterJuice.
 
 //Grippers: Simple cyborg manipulator. Limited use... SLIPPERY SLOPE POWERCREEP
@@ -322,7 +320,12 @@
 			to_chat(R, "<span class='danger'>ERROR. Safety protocols prevent self-disassembling.</span>")
 			return FALSE
 	if (!wrapped)
-		if(is_type_in_list(I, can_hold) && !is_type_in_list(I, blacklist))
+		var/grab = FALSE
+		for(var/typepath in can_hold)
+			if(istype(I,typepath))
+				grab = TRUE
+				break
+		if(grab && !is_type_in_list(I, blacklist))
 			if(feedback)
 				to_chat(user, "<span class='notice'>You collect \the [I].</span>")
 			I.loc = src

--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -276,7 +276,8 @@
 	reagent_list = BEER
 	artifact = FALSE
 	can_be_placed_into = null
-	var/synth_cost = 10 //Around 1666 cell charge for 50u beer
+	units_per_tick = 1
+	var/synth_cost = 30 // 1500 cell charge for 50u beer
 
 /obj/item/weapon/reagent_containers/glass/replenishing/cyborg/fits_in_iv_drip()
 	return FALSE
@@ -292,6 +293,7 @@
 /obj/item/weapon/reagent_containers/glass/replenishing/cyborg/hacked
 	name = "mickey finn's special brew"
 	reagent_list = BEER2
+	units_per_tick = 0.3
 	synth_cost = 25 //4165 cell charge for 50u !NotShitterJuice.
 
 //Grippers: Simple cyborg manipulator. Limited use... SLIPPERY SLOPE POWERCREEP


### PR DESCRIPTION
Turns out using is_type_in_list to check the whitelist and then adding types to it later wasn't my greatest idea. Also fixes a goof ith the H.U.E.Y. upgrade attempt_action() and makes both magnetic and organ upgrade look just like the actual thing.

:cl:
 * bugfix: Cyborg upgrades (Medical MK-2, Service Cooking, Service H.U.E.Y.) will upgrade both chem/service gripper properly now.

fixes #16764
closes #16749