### PR TITLE
Remove redundant sanitization on telecomms scripts

### DIFF
--- a/code/modules/scripting/Implementations/Telecomms.dm
+++ b/code/modules/scripting/Implementations/Telecomms.dm
@@ -236,9 +236,9 @@
 	interpreter.Run()
 
 	// Backwards-apply variables onto signal data
-	/* sanitize EVERYTHING. fucking players can't be trusted with SHIT */
+	/* sanitize (almost) EVERYTHING. fucking players can't be trusted with SHIT */
 
-	signal.data["message"] 	= interpreter.GetCleanVar("$content", signal.data["message"])
+	signal.data["message"] 	= interpreter.GetVar("$content")
 	signal.frequency 		= interpreter.GetCleanVar("$freq", signal.frequency)
 
 	var/setname = interpreter.GetCleanVar("$source", signal.data["name"])


### PR DESCRIPTION
This would cause any characters like " to be broken if you use tcomms scripts.

🆑 
 - bugfix: Fixed NTSL scripts scrambling characters like >. You can make a script that adds meme arrows to everything now.