### PR TITLE
Makes queens tough girls

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/queen.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/queen.dm
@@ -11,6 +11,9 @@
 /mob/living/carbon/alien/humanoid/queen/movement_tally_multiplier()
 	. = ..()
 	. *= 5 // Queens are slow as fuck
+	
+/mob/living/carbon/alien/humanoid/queen/feels_pain()
+	return FALSE // Queens are slow enough as they are
 
 /mob/living/carbon/alien/humanoid/queen/New()
 	create_reagents(100)


### PR DESCRIPTION
#16781 exacerbated an issue that already existed: the alien queen is very slow to begin with and the pain slowdown from low health practically makes her a statue. I see no reason to punish the baddest alien so much in a situation where she's going to be in a lot of trouble anyway so giving her this trait that dionas, golems and horrorforms have seems like a good idea.
:cl:
* tweak: Due to their inherent slowness, alien queens aren't affected by pain slowdown any longer.