### PR TITLE
Vox are no longer full of nitrogen after cloning

### DIFF
--- a/code/modules/medical/cloning.dm
+++ b/code/modules/medical/cloning.dm
@@ -323,8 +323,8 @@
 
 			var/mob/living/carbon/human/H = occupant
 
-			if(istype(H.species, /datum/species/vox))
-				occupant.reagents.add_reagent(NITROGEN, 10)
+			if(istype(H.species, /datum/species/vox) & occupant.reagents.get_reagent_amount(NITROGEN) < 30)
+				occupant.reagents.add_reagent(NITROGEN, 60)
 
 			//Also heal some oxyloss ourselves because inaprovaline is so bad at preventing it!!
 			occupant.adjustOxyLoss(-4)


### PR DESCRIPTION
Before this change if you left vox in the cloner for the duration of the clone they would pop out with about 950u of nitrogen and 50u of inaprovaline. While a buffer is nice to allow someone to pull you to the cryo tube without dying, becoming nearly invulnerable to toxin/oxyloss for the next few hours is a mistake. This changes it to about the same amount of inaprovaline you would get normally from cloning.