### PR TITLE
Fixes teleporting the Nuclear Disk away

### DIFF
--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -187,7 +187,7 @@
 
 /datum/teleport/instant/science/teleportChecks(var/ignore_jamming = FALSE)
 	if(istype(teleatom, /obj/item/weapon/disk/nuclear)) // Don't let nuke disks get teleported --NeoFite
-		teleatom.visible_message("<span class='danger'>The [teleatom] bounces off of the portal!</span>")
+		teleatom.visible_message("<span class='danger'>\The [teleatom] bounces off of the portal!</span>")
 		return FALSE
 	if(teleatom.locked_to)
 		return FALSE
@@ -195,9 +195,9 @@
 	if(!isemptylist(teleatom.search_contents_for(/obj/item/weapon/disk/nuclear)))
 		if(istype(teleatom, /mob/living))
 			var/mob/living/MM = teleatom
-			MM.visible_message("<span class='danger'>The [MM] bounces off of the portal!</span>","<span class='warning'>Something you are carrying seems to be unable to pass through the portal. Better drop it if you want to go through.</span>")
+			MM.visible_message("<span class='danger'>\The [MM] bounces off of the portal!</span>","<span class='warning'>Something you are carrying seems to be unable to pass through the portal. Better drop it if you want to go through.</span>")
 		else
-			teleatom.visible_message("<span class='danger'>The [teleatom] bounces off of the portal!</span>")
+			teleatom.visible_message("<span class='danger'>\The [teleatom] bounces off of the portal!</span>")
 		return FALSE
 
 	if(destination.z == map.zCentcomm) //centcomm z-level

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -259,6 +259,7 @@ var/global/list/ghdel_profiling = list()
  * RETURNS: list of found atoms
  */
 
+
 /atom/proc/search_contents_for(path,list/filter_path=null)
 	var/list/found = list()
 	for(var/atom/A in src)
@@ -272,7 +273,12 @@ var/global/list/ghdel_profiling = list()
 				continue
 		if(A.contents.len)
 			found += A.search_contents_for(path,filter_path)
+	if (istype(src, /atom/movable)) // Vehicules
+		var/atom/movable/AM = src
+		for (var/atom/A in AM.locked_atoms)
+			found += A.search_contents_for(path,filter_path)
 	return found
+
 
 /*
  *	atom/proc/contains_atom_from_list(var/list/L)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -273,10 +273,6 @@ var/global/list/ghdel_profiling = list()
 				continue
 		if(A.contents.len)
 			found += A.search_contents_for(path,filter_path)
-	if (istype(src, /atom/movable)) // Vehicules
-		var/atom/movable/AM = src
-		for (var/atom/A in AM.locked_atoms)
-			found += A.search_contents_for(path,filter_path)
 	return found
 
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -260,6 +260,12 @@
 	INVOKE_EVENT(on_moved,list("loc"=newLoc))
 	return .
 
+/atom/movable/search_contents_for(path,list/filter_path=null) // For vehicles
+	var/list/found = ..()
+	for (var/atom/A in locked_atoms)
+		found += A.search_contents_for(path,filter_path)
+	return found
+
 //The reason behind change_dir()
 /atom/movable/proc/update_dir()
 	for(var/atom/movable/AM in locked_atoms)

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -294,7 +294,7 @@ var/obj/item/weapon/disk/nuclear/nukedisk
 	if( bomb_location && (bomb_location.z == map.zMainStation) )
 		var/map_center_x = world.maxx * 0.5
 		var/map_center_y = world.maxy * 0.5
-		
+
 		if( (bomb_location.x < (map_center_x-NUKERANGE)) || (bomb_location.x > (map_center_x+NUKERANGE)) || (bomb_location.y < (map_center_y-NUKERANGE)) || (bomb_location.y > (map_center_y+NUKERANGE)) )
 			off_station = 1
 	else
@@ -390,8 +390,15 @@ var/obj/item/weapon/disk/nuclear/nukedisk
 		respawned = 1
 
 /obj/item/weapon/disk/nuclear/process()
-	if(!get_turf(src))
+	var/turf/T = get_turf(src)
+	if(!T)
 		var/atom/A
 		for(A=src, A && A.loc && !isturf(A.loc), A=A.loc);  // semicolon is for the empty statement
 		message_admins("\The [src] ended up in nullspace somehow, and has been replaced.[loc ? " It was contained in [A] when it was nullspaced." : ""]")
 		qdel(src)
+	if(T.z != map.zMainStation && T.z != map.zCentcomm)
+		var/atom/A
+		for(A=src, A && A.loc && !isturf(A.loc), A=A.loc);  // semicolon is for the empty statement
+		message_admins("\The [src] ended up in a non-authorised z-Level somehow, and has been replaced.[loc ? " It was contained in [A] when it was moved." : ""]")
+		qdel(src)
+


### PR DESCRIPTION
Fixes #16586 
Incidently, it could have happened with any and all vehicle.
Also implement Kurf's suggestion to make the Disk checks its Z-Level periodically.
Finally, also transformed a bunch of `The` into `\The` while investigating the bug.