### PR TITLE
Lubricant fixes

### DIFF
--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -82,7 +82,17 @@
 		qdel(src)
 
 /obj/effect/overlay/puddle/Crossed(atom/movable/AM)
-	if(istype(AM, /mob/living/carbon))
+	//Check what can slip
+	if(isliving(AM))
+		var/mob/living/M = AM
+		if(!M.on_foot()) //Checks lying, flying and locked.to
+			return ..()
+
+
+	if(isslime(AM)) //Slimes just don't slip, end of story. Hard to slip when you're a living puddle.
+		return ..()
+
+	if(iscarbon(AM))
 		var/mob/living/carbon/M = AM
 		switch(src.wet)
 			if(1) //Water
@@ -92,21 +102,20 @@
 					"<span class='warning'>You slip on the wet floor!</span>")
 
 			if(2) //Lube
-				if(M.Slip(10,3,1))
+				step(M, M.dir)
+				spawn(1)
 					step(M, M.dir)
-					spawn(1)
-						step(M, M.dir)
-					spawn(2)
-						step(M, M.dir)
-					spawn(3)
-						step(M, M.dir)
-					spawn(4)
-						step(M, M.dir)
-					M.take_organ_damage(2) // Was 5 -- TLE
-					M.visible_message("<span class='warning'>[M] slips on the floor!</span>", \
-					"<span class='warning'>You slip on the floor!</span>")
-					playsound(get_turf(src), 'sound/misc/slip.ogg', 50, 1, -3)
-					M.Knockdown(10)
+				spawn(2)
+					step(M, M.dir)
+				spawn(3)
+					step(M, M.dir)
+				spawn(4)
+					step(M, M.dir)
+				M.take_organ_damage(2) // Was 5 -- TLE
+				M.visible_message("<span class='warning'>[M] slips on the floor!</span>", \
+				"<span class='warning'>You slip on the floor!</span>")
+				playsound(get_turf(src), 'sound/misc/slip.ogg', 50, 1, -3)
+				M.Knockdown(10)
 
 			if(3) // Ice
 				if(prob(30) && M.Slip(4, 3))

--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -92,21 +92,21 @@
 					"<span class='warning'>You slip on the wet floor!</span>")
 
 			if(2) //Lube
-				M.stop_pulling()
-				step(M, M.dir)
-				spawn(1)
+				if(M.Slip(10,3,1))
 					step(M, M.dir)
-				spawn(2)
-					step(M, M.dir)
-				spawn(3)
-					step(M, M.dir)
-				spawn(4)
-					step(M, M.dir)
-				M.take_organ_damage(2) // Was 5 -- TLE
-				M.visible_message("<span class='warning'>[M] slips on the floor!</span>", \
-				"<span class='warning'>You slip on the floor!</span>")
-				playsound(get_turf(src), 'sound/misc/slip.ogg', 50, 1, -3)
-				M.Knockdown(10)
+					spawn(1)
+						step(M, M.dir)
+					spawn(2)
+						step(M, M.dir)
+					spawn(3)
+						step(M, M.dir)
+					spawn(4)
+						step(M, M.dir)
+					M.take_organ_damage(2) // Was 5 -- TLE
+					M.visible_message("<span class='warning'>[M] slips on the floor!</span>", \
+					"<span class='warning'>You slip on the floor!</span>")
+					playsound(get_turf(src), 'sound/misc/slip.ogg', 50, 1, -3)
+					M.Knockdown(10)
 
 			if(3) // Ice
 				if(prob(30) && M.Slip(4, 3))


### PR DESCRIPTION
~~Previously, There was no Slip check but it didn't seem to slip vehicles. Now with the refactor vehicle drivers do slip and I am unable to find how it was an exception previously, so a need for a Slip() check was necessary.~~

~~Problem is this now means you can use galoshes to get around space lube spills.~~

Seems I was mistaken. There was a check before slipping when it was turf-tied. Thank you to @Pathid for bringing that to my attention.

closes #16862