### PR TITLE
Harmbattons on harm intent will now properly stun people

### DIFF
--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -179,7 +179,7 @@
 
 		L.visible_message("<span class='danger'>\The [L] has been stunned with \the [src] by [user]!</span>",\
 			"<span class='userdanger'>You have been stunned with \the [src] by \the [user]!</span>",\
-			self_drugged_message="<span class='userdanger'>\the [user]'s [src] sucks the life right out of you!</span>")
+			self_drugged_message="<span class='userdanger'>\The [user]'s [src] sucks the life right out of you!</span>")
 		playsound(loc, 'sound/weapons/Egloves.ogg', 50, 1, -1)
 
 		deductcharge(hitcost)

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -51,8 +51,8 @@
 
 /obj/item/weapon/melee/baton/proc/canbehonkified()
 	return 1
-	
-			
+
+
 /obj/item/weapon/melee/baton/update_icon()
 	if(status)
 		icon_state = "[initial(name)]_active"
@@ -117,7 +117,7 @@
 				"<span class='notice'>You jam \the [src] into the mouth of \the [HONKER]. Honk!</span>")
 				qdel(HONKER)
 				qdel(src)
-		
+
 /obj/item/weapon/melee/baton/attack_self(mob/user)
 	if(status && clumsy_check(user) && prob(50))
 		user.simple_message("<span class='warning'>You grab the [src] on the wrong side.</span>",
@@ -159,28 +159,17 @@
 
 	var/mob/living/L = M
 
-	var/hit = 1
-	if(user.a_intent == I_HURT)
-		hit = ..()
-		if(hit)
-			playsound(loc, "swing_hit", 50, 1, -1)
-			user.do_attack_animation(M, src)
+	if(user.a_intent == I_HURT) // Harm intent : possibility to miss (in exchange for doing actual damage)
+		. = ..() // Does the actual damage and missing chance. Returns null on sucess ; 0 on failure (blame oldcoders)
+		playsound(loc, "swing_hit", 50, 1, -1)
+
 	else
-		hit = -1
-		if(!status)
-			L.visible_message("<span class='attack'>[L] has been prodded with the [src] by [user]. Luckily it was off.</span>",
-				self_drugged_message="<span class='warning'>The [name] decides to spare this one.</span>")
+		if(!status) // Help intent + no charge = nothing
+			L.visible_message("<span class='attack'>\The [L] has been prodded with \the [src] by \the [user]. Luckily it was off.</span>",
+				self_drugged_message="<span class='warning'>\The [name] decides to spare this one.</span>")
 			return
 
-	if(status && hit)
-		if(hit == -1)
-			//Copypasted from human/attacked_by()
-			var/target_zone = get_zone_with_miss_chance(user.zone_sel.selecting, L)
-			if(user == L) // Attacking yourself can't miss
-				target_zone = user.zone_sel.selecting
-			if(!target_zone && !L.stat)
-				visible_message("<span class='danger'>[user] misses [L] with \the [src]!</span>")
-				return
+	if(status && . != FALSE) // This is charged : we stun
 		user.lastattacked = L
 		L.lastattacker = user
 
@@ -188,9 +177,9 @@
 		L.apply_effect(10, STUTTER, 0)
 		L.Knockdown(stunforce)
 
-		L.visible_message("<span class='danger'>[L] has been stunned with [src] by [user]!</span>",\
-			"<span class='userdanger'>You have been stunned with [src] by [user]!</span>",\
-			self_drugged_message="<span class='userdanger'>[user]'s [src.name] sucks the life right out of you!</span>")
+		L.visible_message("<span class='danger'>\The [L] has been stunned with \the [src] by [user]!</span>",\
+			"<span class='userdanger'>You have been stunned with \the [src] by \the [user]!</span>",\
+			self_drugged_message="<span class='userdanger'>\the [user]'s [src] sucks the life right out of you!</span>")
 		playsound(loc, 'sound/weapons/Egloves.ogg', 50, 1, -1)
 
 		deductcharge(hitcost)
@@ -265,7 +254,7 @@
 
 /obj/item/weapon/melee/baton/cattleprod/canbehonkified()
 	return 0
-	
+
 // Yes, loaded, this is so attack_self() works.
 // In the unlikely event somebody manages to get a hold of this item, don't allow them to fuck with the nonexistant cell.
 /obj/item/weapon/melee/baton/loaded/borg/attackby(var/obj/item/W, var/mob/user)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -696,4 +696,3 @@
 			if(src)
 				body_alphas.Remove(source_define)
 				regenerate_icons()
-


### PR DESCRIPTION
Fixes #16838
Apparently `hit` was null, or improperly defined, which caused a silent runtime, I believe.
Tested