### PR TITLE
Mice eating rework.

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1386,6 +1386,9 @@ Thanks.
 		else
 			A.name = "[initial(src.name)] meat"
 			A.animal_name = initial(src.name)
+
+	if(reagents)
+		reagents.trans_to(A,round (reagents.total_volume * (meat_amount/meat_taken), 1))
 	return M
 
 /mob/living/proc/butcher()
@@ -1498,8 +1501,8 @@ Thanks.
 		src.being_butchered = 0
 		return
 
-	src.drop_meat(get_turf(src))
 	src.meat_taken++
+	src.drop_meat(get_turf(src))
 	src.being_butchered = 0
 	if(tool_name)
 		if(!advanced_butchery)

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -45,6 +45,10 @@
 	var/list/datum/disease2/disease/virus2 = list() //For disease carrying
 	var/antibodies = 0
 
+/mob/living/simple_animal/mouse/New()
+	..()
+	create_reagents(100)
+
 
 /mob/living/simple_animal/mouse/Life()
 	if(timestopped)
@@ -77,11 +81,11 @@
 	if(nutrition >= MOUSEFAT && is_fat == 0)
 		is_fat = 1
 		speed = 6
-		meat_amount = initial(meat_amount) + 1
+		meat_amount += 1
 	else if ((nutrition <= MOUSEFAT-25 && is_fat == 1) || (nutrition > MOUSEHUNGRY && is_fat == 0))
 		is_fat = 0
 		speed = initial(speed)
-		meat_amount = initial(meat_amount)
+		meat_amount = size //What it is on living/New(),
 	if(nutrition <= MOUSESTARVE && prob(5) && client)
 		to_chat(src, "<span class = 'warning'>You are starving!</span>")
 		health -= 1

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -188,8 +188,7 @@
 			to_chat(user, "<span class = 'danger'>It seems a bit hungry.</span>")
 
 /mob/living/simple_animal/mouse/proc/splat()
-	src.health = 0
-	src.stat = DEAD
+	Die()
 	src.icon_dead = "mouse_[_color]_splat"
 	src.icon_state = "mouse_[_color]_splat"
 	if(client)

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -361,10 +361,10 @@
 			else
 				to_chat(N, ("<span class='notice'>You nibble away at \the [src].</span>"))
 			N.health = min(N.health + 1, N.maxHealth)
-			bitecount += 0.25
 			N.nutrition += 5
-			if(bitecount >= ANIMALBITECOUNT)
-				qdel(src)
+			reagents.trans_to(N, 0.25)
+			bitecount+= 0.25
+			after_consume(M,src.reagents)
 
 /obj/item/weapon/reagent_containers/food/snacks/send_to_past(var/duration)
 	..()


### PR DESCRIPTION
Rather than mice eating going to the arbitrary 3 bites and the food is gone, now it acts like normal eating where it takes into account how much reagent is in the food.

When a mouse eats, it takes the reagents from the food and adds it to the mouse, and runs after_consume (Checks if the food still has reagents. If not, it deletes it)

When you butcher a mouse, it will yield the reagents it has eaten in the mouse steak. Cheeky well-fed mice are now worth their weight in ~~burgers~~ gold.

This also adds a system where, when butchering things, the contents of their reagents will be present in the meat, as if you were throwing them in a gibber.

Also fixes the oversight where mice meat_amount would be 0 (1 if overfed), now it is 1 (2 if overfed)

closes #13752 as running after_consume drops the trash
