### PR TITLE
fixes bedsheet bins not being deconstructable

### DIFF
--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -133,6 +133,16 @@ LINEN BINS
 	var/list/sheets = list()
 	var/obj/item/hidden = null
 
+/obj/structure/bedsheetbin/Destroy()
+	if(sheets)
+		for(var/sheet in sheets)
+			sheets.Remove(sheet)
+			qdel(sheet)
+	if(hidden)
+		hidden = null
+		qdel(hidden)
+	..()
+
 
 /obj/structure/bedsheetbin/examine(mob/user)
 	..()
@@ -154,6 +164,31 @@ LINEN BINS
 
 
 /obj/structure/bedsheetbin/attackby(obj/item/I as obj, mob/user as mob)
+	if(iswrench(I))
+		wrenchAnchor(user, time_to_wrench = 2 SECONDS)
+		return
+	if(iswelder(I))
+		if(anchored)
+			to_chat(user, "<span class='warning'>\The [src] is still secured to whatever surface it is on. Unsecure it first!</span>")
+			return
+		var/obj/item/weapon/weldingtool/W = I
+		if(W.remove_fuel(2,user))
+			to_chat(user, "<span class='notice'>You break \the [src] down into a pile of rods.</span>")
+			new /obj/item/stack/rods(get_turf(src),rand(3,5))
+			if(sheets)
+				for(var/obj/sheet in sheets)
+					sheet.forceMove(loc)
+					sheets.Remove(sheet)
+					amount--
+			while(amount > 0)
+				new /obj/item/weapon/bedsheet(loc)
+				amount--
+			if(hidden)
+				to_chat(user, "<span class='notice'>\The [hidden] falls out of the [src]!</span>")
+				hidden.forceMove(loc)
+				hidden = null
+			qdel(src)
+			return
 	if(istype(I, /obj/item/weapon/bedsheet))
 		if(user.drop_item(I, src))
 			sheets.Add(I)

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -138,8 +138,8 @@ LINEN BINS
 		qdel(sheet)
 	sheets.Cut()
 	if(hidden)
-		hidden = null
 		qdel(hidden)
+		hidden = null
 	..()
 
 

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -134,10 +134,9 @@ LINEN BINS
 	var/obj/item/hidden = null
 
 /obj/structure/bedsheetbin/Destroy()
-	if(sheets)
-		for(var/sheet in sheets)
-			sheets.Remove(sheet)
-			qdel(sheet)
+	for(var/sheet in sheets)
+		qdel(sheet)
+	sheets.Cut()
 	if(hidden)
 		hidden = null
 		qdel(hidden)
@@ -147,11 +146,11 @@ LINEN BINS
 /obj/structure/bedsheetbin/examine(mob/user)
 	..()
 	if(amount == 0)
-		to_chat(user, "<span class='info'>There are no bed sheets in the bin.</span>")
+		to_chat(user, "<span class='info'>There are no bed sheets in \the [src].</span>")
 	else if(amount == 1)
-		to_chat(user, "<span class='info'>There is one bed sheet in the bin.</span>")
+		to_chat(user, "<span class='info'>There is one bed sheet in \the [src].</span>")
 	else
-		to_chat(user, "<span class='info'>There are [amount] bed sheets in the bin.</span>")
+		to_chat(user, "<span class='info'>There are [amount] bed sheets in \the [src].</span>")
 
 
 /obj/structure/bedsheetbin/update_icon()
@@ -175,16 +174,15 @@ LINEN BINS
 		if(W.remove_fuel(2,user))
 			to_chat(user, "<span class='notice'>You break \the [src] down into a pile of rods.</span>")
 			new /obj/item/stack/rods(get_turf(src),rand(3,5))
-			if(sheets)
-				for(var/obj/sheet in sheets)
-					sheet.forceMove(loc)
-					sheets.Remove(sheet)
-					amount--
+			for(var/obj/sheet in sheets)
+				sheet.forceMove(loc)
+				amount--
+			sheets.Cut()
 			while(amount > 0)
 				new /obj/item/weapon/bedsheet(loc)
 				amount--
 			if(hidden)
-				to_chat(user, "<span class='notice'>\The [hidden] falls out of the [src]!</span>")
+				to_chat(user, "<span class='notice'>\The [hidden] falls out of \the [src]!</span>")
 				hidden.forceMove(loc)
 				hidden = null
 			qdel(src)


### PR DESCRIPTION
Bedsheet bins can now be deconstructed by unanchoring them, then welding them to yield the metal rods, and the contents of the bin.

Also adds destroy handling for the bedsheet bin, so it doesn't hold references and keep itself from the abyss