### PR TITLE
Changes to the Fist Spell

### DIFF
--- a/code/modules/spells/targeted/fist.dm
+++ b/code/modules/spells/targeted/fist.dm
@@ -4,12 +4,11 @@
 	abbreviation = "FS"
 	user_type = USER_TYPE_WIZARD
 
-	price = Sp_BASE_PRICE/2
 	charge_max = 50
 	cooldown_min = 10
 	invocation = "I CAST FIST"
 	invocation_type = SpI_SHOUT
-	max_targets = 0
+	max_targets = 3
 
 	compatible_mobs = list(/mob/living)
 


### PR DESCRIPTION
The Fist Spell (alongside Push) is probably one of the least interesting spells to be up against. Its problems come from the fact that it is extraordinarily cheap, but it provides you with very easy stuns. It isn't a spell you can "run from" easily, because the wizard doesn't need to be near you to cast it, and combined with the scrying orb it can be cast through walls. Furthermore it can be bought for the same prize as the Shoe Snatch charm and other weak spells, and that means it isn't too expensive to upgrade all the way. Combined with the mutate spell, it becomes a nightmare to do anything against.

Two Changes I have made are as follows:
1. Fist now costs the same as a standard spell - I think this is the most important of the two changes. This makes it much more costly to upgrade, and wizards will have to sacrifice something else if they want to get Fist to its maximum potential.

2. Fist now targets three people at a time - I am not particularly married to this change, but it does prevent you from clearing entire rooms of people without facing any real consequences. You would no longer be able to beat on everybody in medbay or security, meaning you might have to think a bit more about where you spam the spell, and it would give other people in crowded rooms an opportunity to react. Three targets is still a lot of targets. 

Obviously balance changes are always controversial, and if you think I'm a fucking idiot or you simply disagree with the direction I want to take this spell, please post below. These are just some of the things that I **personally** believe would be better, but your millage may vary.  

TL;DR Admin wants to nerf spell because he hates fun