### PR TITLE
Aliens can only pick up whitelisted things

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -235,16 +235,6 @@
 	return TRUE
 
 /obj/item/attack_paw(mob/user as mob)
-
-	if(isalien(user)) // -- TLE
-		var/mob/living/carbon/alien/A = user
-
-		if(!A.has_fine_manipulation || w_class >= W_CLASS_LARGE)
-			if(src in A.contents) // To stop Aliens having items stuck in their pockets
-				A.drop_from_inventory(src)
-			to_chat(user, "Your claws aren't capable of such fine manipulation.")
-			return
-
 	if (istype(loc, /obj/item/weapon/storage))
 		for(var/mob/M in range(1, loc))
 			if (M.s_active == loc)

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -36,6 +36,7 @@
 	var/fire_alert = 0
 
 	var/heat_protection = 0.5
+	var/list/can_only_pickup = list(/obj/item/clothing/mask/facehugger, /obj/item/weapon/grab) //What types of object can the alien pick up?
 
 /mob/living/carbon/alien/AdjustPlasma(amount)
 	plasma = min(max(plasma + amount,0),max_plasma) //upper limit of max_plasma, lower limit of 0

--- a/code/modules/mob/living/carbon/alien/humanoid/inventory.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/inventory.dm
@@ -82,5 +82,6 @@
 
 /mob/living/carbon/alien/humanoid/put_in_hand_check(var/obj/item/W)
 	if(!has_fine_manipulation && !is_type_in_list(W, can_only_pickup))
+		to_chat(src, "Your claws aren't capable of such fine manipulation.")
 		return 0
 	return 1

--- a/code/modules/mob/living/carbon/alien/humanoid/inventory.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/inventory.dm
@@ -37,7 +37,7 @@
 		if(slot_handcuffed)
 			return handcuffed
 	return null
-	
+
 /mob/living/carbon/alien/humanoid/u_equip(obj/item/W, dropped = 1, var/slot = null)
 	if(!W)
 		return 0
@@ -79,3 +79,8 @@
 		W = get_item_by_slot(slot)
 		if(W)
 			W.attack_alien(src)
+
+/mob/living/carbon/alien/humanoid/put_in_hand_check(var/obj/item/W)
+	if(!has_fine_manipulation && !is_type_in_list(W, can_only_pickup))
+		return 0
+	return 1

--- a/code/modules/mob/living/carbon/alien/humanoid/inventory.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/inventory.dm
@@ -82,6 +82,6 @@
 
 /mob/living/carbon/alien/humanoid/put_in_hand_check(var/obj/item/W)
 	if(!has_fine_manipulation && !is_type_in_list(W, can_only_pickup))
-		to_chat(src, "Your claws aren't capable of such fine manipulation.")
+		to_chat(src, "<span class = 'warning'>Your claws aren't capable of such fine manipulation.</span>")
 		return 0
 	return 1


### PR DESCRIPTION
There were reports of aliens doing un-alien things, like robusting their young with an emergency toolbox, carrying handbags of facehuggers, and throwing flashbangs at security.

That shouldn't be the case anymore.

EDIT: Turns out this was intended from the start, but oldcoders were doing this on an object-by-object process in /attack_paw().

If an object overwrote attack_paw, it would skip the check, meaning xenos were never meant to pick up toolboxes and the like.

fixes #16871

:cl:
* tweak: Aliens can only pickup facehuggers now.