### PR TITLE
Should fix floating items in the event that you are unsuccesful at removing an object from a storage item

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -207,7 +207,8 @@
 	if (istype(loc, /obj/item/weapon/storage))
 		//If the item is in a storage item, take it out.
 		var/obj/item/weapon/storage/S = loc
-		S.remove_from_storage(src, user)
+		if(!S.remove_from_storage(src, user))
+			return
 
 	throwing = FALSE
 	if (loc == user)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -364,11 +364,8 @@
 		var/obj/item/weapon/storage/fancy/F = src
 		F.update_icon(1)
 
-	for(var/mob/M in range(1, get_turf(src)))
-		if (M.s_active == src)
-			if (M.client)
-				M.client.screen -= W
 
+	var/success = 1
 	if(new_location)
 		var/mob/M
 		if(ismob(loc))
@@ -376,7 +373,8 @@
 			W.dropped(M)
 		if(ismob(new_location))
 			M = new_location
-			M.put_in_active_hand(W)
+			if(!M.put_in_active_hand(W))
+				success = 0
 		else
 			if(istype(new_location, /obj/item/weapon/storage))
 				var/obj/item/weapon/storage/A = new_location
@@ -385,6 +383,14 @@
 				W.forceMove(new_location)
 	else
 		W.forceMove(get_turf(src))
+
+	if(!success)
+		return 0
+
+	for(var/mob/M in range(1, get_turf(src)))
+		if (M.s_active == src)
+			if (M.client)
+				M.client.screen -= W
 
 	if(usr)
 		src.orient2hud(usr)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -365,7 +365,6 @@
 		F.update_icon(1)
 
 
-	var/success = 1
 	if(new_location)
 		var/mob/M
 		if(ismob(loc))
@@ -374,7 +373,7 @@
 		if(ismob(new_location))
 			M = new_location
 			if(!M.put_in_active_hand(W))
-				success = 0
+				return 0
 		else
 			if(istype(new_location, /obj/item/weapon/storage))
 				var/obj/item/weapon/storage/A = new_location
@@ -383,9 +382,6 @@
 				W.forceMove(new_location)
 	else
 		W.forceMove(get_turf(src))
-
-	if(!success)
-		return 0
 
 	for(var/mob/M in range(1, get_turf(src)))
 		if (M.s_active == src)


### PR DESCRIPTION
@Pathid brought this to my attention in #16880 where if you were unsuccessful at removing an object from a container, it would call put_in_hand twice (un-necessary), as well as leave phantom objects on your screen from them not being removed from your screen properly.