### PR TITLE
Stopping surgery by dropping or storing your tool now harms the patient

### DIFF
--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -129,14 +129,13 @@ proc/do_surgery(mob/living/M, mob/living/user, obj/item/tool)
 					log_attack("<font color='red'>[user.name] ([user.ckey]) used \the [tool] to successfully complete surgery type [S.type] on [M.name] ([M.ckey])</font>")
 					S.end_step(user, M, user.zone_sel.selecting, tool)		//finish successfully
 				else
-					if ((tool in user.contents) && (user.Adjacent(M)))											//or
-						if(sleep_fail)
-							to_chat(user, "<span class='warning'>The patient is squirming around in pain!</span>")
-							M.emote("scream",,, 1)
-						M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has had surgery [S.type] with \the [tool] failed by [user.name] ([user.ckey])</font>")
-						user.attack_log += text("\[[time_stamp()]\] <font color='red'>Failed surgery [S.type] with \the [tool] on [M.name] ([M.ckey])</font>")
-						log_attack("<font color='red'>[user.name] ([user.ckey]) used \the [tool] to fail the surgery type [S.type] on [M.name] ([M.ckey])</font>")
-						S.fail_step(user, M, user.zone_sel.selecting, tool)		//malpractice~
+					if(sleep_fail)
+						to_chat(user, "<span class='warning'>The patient is squirming around in pain!</span>")
+						M.emote("scream",,, 1)
+					M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has had surgery [S.type] with \the [tool] failed by [user.name] ([user.ckey])</font>")
+					user.attack_log += text("\[[time_stamp()]\] <font color='red'>Failed surgery [S.type] with \the [tool] on [M.name] ([M.ckey])</font>")
+					log_attack("<font color='red'>[user.name] ([user.ckey]) used \the [tool] to fail the surgery type [S.type] on [M.name] ([M.ckey])</font>")
+					S.fail_step(user, M, user.zone_sel.selecting, tool)		//malpractice~
 				if(M) //good, we still exist
 					S.doing_surgery -= M
 				else


### PR DESCRIPTION
Fixes #13317 by removing line 132. Essentially, this line checked whether the attacking mob was adjacent AND had the tool in their contents (not inventory, which is an important difference) when determining if surgery properly fails. Until now, surgery could be halted with no consequences by putting the tool anywhere but in your hands or pockets.

This does not fix the lack of damage I came across when using a scalpel to incise and failing, but that's for another PR.

:cl:
* bugfix: Stopping surgery by dropping or storing your tool now harms the patient