### PR TITLE
Deployable barrier refactor

### DIFF
--- a/code/__HELPERS/_macros.dm
+++ b/code/__HELPERS/_macros.dm
@@ -179,6 +179,10 @@
 
 #define ismatrix(A) (istype(A, /matrix))
 
+#define isID(A) (istype(A, /obj/item/weapon/card/id))
+
+#define isPDA(A) (istype(A, /obj/item/device/pda))
+
 //Macros for antags
 
 #define isvampire(H) ((H.mind in ticker.mode.vampires) || H.mind && H.mind.vampire)

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -1,144 +1,82 @@
-/*
-CONTAINS:
-
-Deployable items
-Barricades
-
-for reference:
-
-	access_security = 1
-	access_brig = 2
-	access_armory = 3
-	access_forensics_lockers= 4
-	access_medical = 5
-	access_morgue = 6
-	access_rnd = 7
-	access_tox_storage = 8
-	access_genetics = 9
-	access_engine = 10
-	access_engine_equip= 11
-	access_maint_tunnels = 12
-	access_external_airlocks = 13
-	access_emergency_storage = 14
-	access_change_ids = 15
-	access_ai_upload = 16
-	access_teleporter = 17
-	access_eva = 18
-	access_heads = 19
-	access_captain = 20
-	access_all_personal_lockers = 21
-	access_chapel_office = 22
-	access_tech_storage = 23
-	access_atmospherics = 24
-	access_bar = 25
-	access_janitor = 26
-	access_crematorium = 27
-	access_kitchen = 28
-	access_robotics = 29
-	access_rd = 30
-	access_cargo = 31
-	access_construction = 32
-	access_chemistry = 33
-	access_cargo_bot = 34
-	access_hydroponics = 35
-	access_manufacturing = 36
-	access_library = 37
-	access_lawyer = 38
-	access_virology = 39
-	access_cmo = 40
-	access_qm = 41
-	access_court = 42
-	access_clown = 43
-	access_mime = 44
-
-*/
-
-//Actual Deployable machinery stuff
-
 /obj/machinery/deployable
 	name = "deployable"
 	desc = "deployable"
 	icon = 'icons/obj/objects.dmi'
-	req_access = list(access_security)//I'm changing this until these are properly tested./N
+	req_access = list(access_security)
 
 /obj/machinery/deployable/barrier
 	name = "deployable barrier"
-	desc = "A deployable barrier. Swipe your ID card to lock/unlock it."
+	desc = "Swipe your ID card to lock/unlock it."
 	icon = 'icons/obj/objects.dmi'
-	anchored = 0.0
-	density = 1.0
+	anchored = FALSE
+	density = TRUE
 	icon_state = "barrier0"
-	var/health = 140.0
-	var/maxhealth = 140.0
-	var/locked = 0.0
-//	req_access = list(access_maint_tunnels)
+	var/health = 140
+	var/maxhealth = 140
 
 	machine_flags = EMAGGABLE
 
 /obj/machinery/deployable/barrier/New()
 	..()
+	update_icon()
 
-	src.icon_state = "barrier[src.locked]"
+/obj/machinery/deployable/barrier/update_icon()
+	icon_state = "barrier[anchored]"
 
-/obj/machinery/deployable/barrier/emag(mob/user)
-	if(!emagged)
-		emagged = 1
-		req_access = list()
+/obj/machinery/deployable/barrier/emag(var/mob/user)
+	if (!emagged)
+		emagged = TRUE
+		req_access = 0
 		if(user)
-			to_chat(user, "You break the ID authentication lock on the [src].")
+			to_chat(user, "You break the ID authentication lock on \the [src].")
 		spark(src, 2)
-		desc = "A deployable barrier. Swipe your ID card to lock/unlock it. Seems like it's malfunctioning"
-		return
 
-/obj/machinery/deployable/barrier/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if (istype(W, /obj/item/weapon/card/id/))
-		if (src.allowed(user))
-			src.locked = !src.locked
-			src.anchored = !src.anchored
-			src.icon_state = "barrier[src.locked]"
-			if (src.locked == 1.0)
-				to_chat(user, "Barrier lock toggled on.")
-				return
-			else if (src.locked == 0.0)
-				to_chat(user, "Barrier lock toggled off.")
-				return
-		return
+/obj/machinery/deployable/barrier/examine(var/mob/user)
+	..()
+	if(emagged)
+		to_chat(user, "<span class='warning'>It seems to be malfunctioning.</span>")
+
+/obj/machinery/deployable/barrier/attackby(var/obj/item/weapon/W, var/mob/user)
+	if (isID(W) || isPDA(W))
+		if (!allowed(user))
+			to_chat(user, "<span class='warning'>Access denied.</span>")
+			return
+		anchored = !anchored
+		update_icon()
+		if (anchored)
+			to_chat(user, "Barrier lock toggled on.")
+		else
+			to_chat(user, "Barrier lock toggled off.")
 	else
-		visible_message("<span class='danger'>[src] has been hit by [user] with [W]</span>") //I have to put this because atom/proc/attackby is not triggering. No idea why
-		user.delayNextAttack(10)
-		switch(W.damtype)
-			if("fire")
-				src.health -= W.force * 1
-			if("brute")
-				src.health -= W.force * 0.75
-		if (src.health <= 0)
-			src.explode()
-		..()
+		. = ..()
+		if(.)
+			return
+		visible_message("<span class='danger'>[src] has been hit by [user] with [W].</span>")
+		user.delayNextAttack(1 SECONDS)
+		user.do_attack_animation(src, user)
+		take_damage(W.force, W.damtype)
 
-/obj/machinery/deployable/barrier/ex_act(severity)
+/obj/machinery/deployable/barrier/bullet_act(var/obj/item/projectile/Proj)
+	..()
+	if(Proj.damage)
+		take_damage(Proj.damage, Proj.damage_type)
+
+/obj/machinery/deployable/barrier/ex_act(var/severity)
 	switch(severity)
-		if(1.0)
-			src.explode()
-			return
-		if(2.0)
-			src.health -= 25
-			if (src.health <= 0)
-				src.explode()
-			return
+		if(1)
+			explode()
+		if(2)
+			take_damage(25)
 
-/obj/machinery/deployable/barrier/emp_act(severity)
+/obj/machinery/deployable/barrier/emp_act(var/severity)
 	if(stat & (BROKEN|NOPOWER))
 		return
 	if(prob(50/severity))
-		locked = !locked
 		anchored = !anchored
-		icon_state = "barrier[src.locked]"
+		icon_state = "barrier[anchored]"
 
 /obj/machinery/deployable/barrier/blob_act()
-	src.health -= 25
-	if (src.health <= 0)
-		src.explode()
-	return
+	take_damage(25)
 
 /obj/machinery/deployable/barrier/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)//So bullets will fly over and stuff.
 	if(air_group || (height==0))
@@ -150,9 +88,14 @@ for reference:
 
 /obj/machinery/deployable/barrier/proc/explode()
 	visible_message("<span class='danger'>[src] blows apart!</span>")
-
 	spark(src)
+	explosion(loc,-1,-1,0)
+	qdel(src)
 
-	explosion(src.loc,-1,-1,0)
-	if(src)
-		qdel(src)
+/obj/machinery/deployable/barrier/proc/take_damage(var/amount, var/kind = BRUTE)
+	var/modifier = 1
+	if(kind == BRUTE)
+		modifier = 0.75
+	health -= amount * modifier
+	if(health <= 0)
+		explode()


### PR DESCRIPTION
I just wanted to allow PDAs to toggle it, but ended up rewriting the whole thing.

- PDAs can be used to toggle the barrier
- Removed the `locked` var entirely, it was just mirroring `anchored`'s value
- Refactored the health logic into a single proc, `take_damage` - attack animations will play when hitting the barrier
- Projectiles will now damage the barrier (but can still be fired past it if not aimed directly)