### PR TITLE
Makes the hand held tracking implant tool tolerable.

### DIFF
--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -67,16 +67,15 @@ Frequency:
 						var/turf/tr = get_turf(W)
 						if (tr.z == sr.z && tr)
 							var/direct = max(abs(tr.x - sr.x), abs(tr.y - sr.y))
-							if (direct < 5)
-								direct = "very strong"
-							else
-								if (direct < 10)
+							switch (direct)
+								if (0 to 5)
+									direct = "very strong"
+								if (5 to 10)
 									direct = "strong"
+								if (10 to 20)
+									direct = "weak"
 								else
-									if (direct < 20)
-										direct = "weak"
-									else
-										direct = "very weak"
+									direct = "very weak"
 							src.temp += "[W.code]-[dir2text(get_dir(sr, tr))]-[direct]<BR>"
 
 				src.temp += "<B>Extranneous Signals:</B><BR>"
@@ -92,16 +91,15 @@ Frequency:
 					var/turf/tr = get_turf(W)
 					if (tr.z == sr.z && tr)
 						var/direct = max(abs(tr.x - sr.x), abs(tr.y - sr.y))
-						if (direct < 5)
-							direct = "very strong"
-						else
-							if (direct < 10)
+						switch (direct)
+							if (0 to 5)
+								direct = "very strong"
+							if (5 to 10)
 								direct = "strong"
+							if (10 to 20)
+								direct = "weak"
 							else
-								if (direct < 20)
-									direct = "weak"
-								else
-									direct = "very weak"
+								direct = "very weak"
 						src.temp += "[W.id]-[dir2text(get_dir(sr, tr))]-[direct]<BR>"
 
 				src.temp += "<B>You are at \[[sr.x-WORLD_X_OFFSET[sr.z]],[sr.y-WORLD_Y_OFFSET[sr.z]],[sr.z]\]</B> in orbital coordinates.<BR><BR><A href='byond://?src=\ref[src];refresh=1'>Refresh</A><BR>"

--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -93,16 +93,16 @@ Frequency:
 					if (tr.z == sr.z && tr)
 						var/direct = max(abs(tr.x - sr.x), abs(tr.y - sr.y))
 						if (direct < 5)
-								direct = "very strong"
+							direct = "very strong"
+						else
+							if (direct < 10)
+								direct = "strong"
 							else
-								if (direct < 10)
-									direct = "strong"
+								if (direct < 20)
+									direct = "weak"
 								else
-									if (direct < 20)
-										direct = "weak"
-									else
-										direct = "very weak"
-							src.temp += "[W.id]-[dir2text(get_dir(sr, tr))]-[direct]<BR>"
+									direct = "very weak"
+						src.temp += "[W.id]-[dir2text(get_dir(sr, tr))]-[direct]<BR>"
 
 				src.temp += "<B>You are at \[[sr.x-WORLD_X_OFFSET[sr.z]],[sr.y-WORLD_Y_OFFSET[sr.z]],[sr.z]\]</B> in orbital coordinates.<BR><BR><A href='byond://?src=\ref[src];refresh=1'>Refresh</A><BR>"
 			else

--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -92,14 +92,16 @@ Frequency:
 					var/turf/tr = get_turf(W)
 					if (tr.z == sr.z && tr)
 						var/direct = max(abs(tr.x - sr.x), abs(tr.y - sr.y))
-						if (direct < 20)
-							if (direct < 5)
+						if (direct < 5)
 								direct = "very strong"
 							else
 								if (direct < 10)
 									direct = "strong"
 								else
-									direct = "weak"
+									if (direct < 20)
+										direct = "weak"
+									else
+										direct = "very weak"
 							src.temp += "[W.id]-[dir2text(get_dir(sr, tr))]-[direct]<BR>"
 
 				src.temp += "<B>You are at \[[sr.x-WORLD_X_OFFSET[sr.z]],[sr.y-WORLD_Y_OFFSET[sr.z]],[sr.z]\]</B> in orbital coordinates.<BR><BR><A href='byond://?src=\ref[src];refresh=1'>Refresh</A><BR>"


### PR DESCRIPTION
Currently tracking implants are a joke due to the hand held tracking implant locator being an absolute pile of garbage.

![hasbro tracking implant](https://user-images.githubusercontent.com/20872793/34411476-72d599c0-eb9c-11e7-820c-914e7cbe6736.png)

The above represents the current distance that a tracking implant will outright not show up on the hand locator.  The person right down the hall may as well be on z-6 standing on a wall with his sensors turned off and a full oxygen tank on his back.  While you may point to prisoner console, the location provided by the prisoner console can be overcome simply by hiding in a disposal bin as well as the console being immobile.  This, coupled with the fact that you are required to hit a refresh button that cancels your window focus away from your ability to move, makes it for a very unfun experience as a Warden attempting to use these implants.

This change adds the "very weak" signal strength for tracking implants which will allow for a z-level wide direction indicator.  For some reason the signal strength level was omitted from the implants, while it is available for tracking beacons when using the hand held locator (ultimately just making it better to implant an actual beacon into the target).

:cl:
 * tweak: Increased the tracking ability of the hand held tracking implant tool
