### PR TITLE
fixes cable coils being fucky regarding recycling

### DIFF
--- a/code/game/objects/items/stacks/cable.dm
+++ b/code/game/objects/items/stacks/cable.dm
@@ -41,11 +41,10 @@ var/global/list/datum/stack_recipe/cable_recipes = list ( \
 	to_chat(viewers(user), "<span class='danger'>[user] is strangling \himself with the [src.name]! It looks like \he's trying to commit suicide.</span>")
 	return(OXYLOSS)
 
-/obj/item/stack/cable_coil/New(loc, length = MAXCOIL, var/param_color = null, amount = length)
+/obj/item/stack/cable_coil/New(loc, amount, var/param_color = null)
 	..()
 
 	recipes = cable_recipes
-	src.amount = amount
 	if(param_color)
 		_color = param_color
 
@@ -274,7 +273,7 @@ var/global/list/datum/stack_recipe/cable_recipes = list ( \
 /obj/item/stack/cable_coil/cut
 	item_state = "coil_red2"
 
-/obj/item/stack/cable_coil/cut/New(loc, length = MAXCOIL, var/param_color = null, amount)
+/obj/item/stack/cable_coil/cut/New(loc, amount, var/param_color = null)
 	..(loc)
 	if(!amount)
 		src.amount = rand(1, 2)
@@ -310,7 +309,7 @@ var/global/list/datum/stack_recipe/cable_recipes = list ( \
 	_color = "white"
 	icon_state = "coil_white"
 
-/obj/item/stack/cable_coil/random/New(loc, length = MAXCOIL, var/param_color = null, amount = length)
+/obj/item/stack/cable_coil/random/New(loc, amount, var/param_color = null)
 	..()
 	_color = pick("red","yellow","green","blue","pink")
 	icon_state = "coil_[_color]"


### PR DESCRIPTION
For some rather silly reason, stacks of cable coils decided to have their second constructor argument be 'length' (which wasn't used anywhere, just in the constructor) and have it default to being 30, then having var/amount be set to length in the constructor.

This meant, in the supercall it would think its amount was 30, and set its material amount as such, then it would be set back to 1 (assuming you were doing this by attack_handing a stack to take a single coil piece) after the set_materials() call.

Now new cable coils should obey the laws of conservation, as new 1-stack cable pieces are now worth 1 sheet as they are supposed to.

closes #13733