### PR TITLE
Improves refreshing, removes autorefresh on DNA modifier console

### DIFF
--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -451,6 +451,7 @@
 		connected = findScanner()
 		connected.connected = src
 		spawn(250)
+			nanomanager.update_uis(src)
 			src.injector_ready = 1
 		return
 	return
@@ -1063,6 +1064,7 @@
 					I.name += " ([buf.name])"
 					src.injector_ready = 0
 					spawn(connected.injector_cooldown)
+						nanomanager.update_uis(src)
 						src.injector_ready = 1
 			return 1
 

--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -244,6 +244,8 @@
 		if(user.drop_item(beaker, src))
 			beaker = item
 			user.visible_message("[user] adds \a [item] to \the [src]!", "You add \a [item] to \the [src]!")
+			if(connected)
+				nanomanager.update_uis(connected)
 			return
 	else if(istype(item, /obj/item/weapon/grab)) //sanity checks, you chucklefucks
 		var/obj/item/weapon/grab/G = item
@@ -268,6 +270,9 @@
 	M.reset_view()
 	src.occupant = M
 	src.icon_state = "scanner_1"
+
+	if(connected)
+		nanomanager.update_uis(connected)
 
 	// search for ghosts, if the corpse is empty and the scanner is connected to a cloner
 	for(dir in cardinal)
@@ -311,6 +316,9 @@
 		var/obj/machinery/computer/cloning/C = locate(/obj/machinery/computer/cloning) in get_step(src, dir)
 		if(C)
 			C.update_icon()
+
+	if(connected)
+		nanomanager.update_uis(connected)
 
 	return 1
 
@@ -395,15 +403,10 @@
 	var/list/datum/dna2/record/buffers[3]
 	var/irradiating = 0
 	var/list/datum/block_label/labels[DNA_SE_LENGTH]
-
-	// Quick fix for issue 286 (screwdriver the screen twice to restore injector) -Pete.
 	var/injector_ready = 0
-
 	var/obj/machinery/dna_scannernew/connected
 	var/obj/item/weapon/disk/data/disk
 	var/selected_menu_key
-
-	// Fix for #274 (Mash create block injector without answering dialog to make unlimited injectors) - N3X.
 	var/waiting_for_user_input = 0
 
 	light_color = LIGHT_COLOR_BLUE
@@ -435,6 +438,7 @@
 			if (user.drop_item(O, src))
 				disk = O
 				to_chat(user, "You insert [O].")
+				nanomanager.update_uis(src)
 	return
 
 /obj/machinery/computer/scan_consolenew/New()
@@ -630,8 +634,6 @@
 		ui.set_initial_data(data)
 		// open the new ui window
 		ui.open()
-		// auto update every Master Controller tick
-		ui.set_auto_update(1)
 
 /obj/machinery/computer/scan_consolenew/proc/pulse_radiation(mob/user)
 	if(connected.contains_husk())
@@ -641,8 +643,8 @@
 	var/lock_state = src.connected.locked
 	src.connected.locked = 1//lock it
 
+	nanomanager.update_uis(src)
 	sleep(10*src.radiation_duration) // sleep for radiation_duration seconds
-
 	irradiating = 0
 
 	if(!src.connected.occupant)
@@ -661,6 +663,7 @@
 
 	src.connected.occupant.radiation += ((src.radiation_intensity*3)+src.radiation_duration*3)
 	src.connected.locked = lock_state
+	nanomanager.update_uis(src)
 
 /obj/machinery/computer/scan_consolenew/npc_tamper_act(mob/living/L)
 	radiation_duration = rand(1, MAX_RADIATION_DURATION)
@@ -694,7 +697,7 @@
 
 	if (href_list["pulseRadiation"])
 		pulse_radiation(usr)
-		return 1 // return 1 forces an update to all Nano uis attached to src
+		return // pulse_radiation() handles the updating
 
 	if (href_list["radiationDuration"])
 		if (text2num(href_list["radiationDuration"]) > 0)
@@ -777,8 +780,8 @@
 		var/lock_state = src.connected.locked
 		src.connected.locked = 1//lock it
 
+		nanomanager.update_uis(src)
 		sleep(10*src.radiation_duration) // sleep for radiation_duration seconds
-
 		irradiating = 0
 
 		if (!src.connected.occupant)
@@ -838,8 +841,8 @@
 		var/lock_state = src.connected.locked
 		src.connected.locked = 1 //lock it
 
+		nanomanager.update_uis(src)
 		sleep(10*src.radiation_duration) // sleep for radiation_duration seconds
-
 		irradiating = 0
 
 		if(src.connected.occupant)

--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -451,8 +451,7 @@
 		connected = findScanner()
 		connected.connected = src
 		spawn(250)
-			nanomanager.update_uis(src)
-			src.injector_ready = 1
+			setInjectorReady()
 		return
 	return
 
@@ -664,6 +663,10 @@
 
 	src.connected.occupant.radiation += ((src.radiation_intensity*3)+src.radiation_duration*3)
 	src.connected.locked = lock_state
+	nanomanager.update_uis(src)
+
+/obj/machinery/computer/scan_consolenew/proc/setInjectorReady()
+	injector_ready = 1
 	nanomanager.update_uis(src)
 
 /obj/machinery/computer/scan_consolenew/npc_tamper_act(mob/living/L)
@@ -1062,10 +1065,9 @@
 				if(success)
 					I.forceMove(src.loc)
 					I.name += " ([buf.name])"
-					src.injector_ready = 0
+					injector_ready = 0
 					spawn(connected.injector_cooldown)
-						nanomanager.update_uis(src)
-						src.injector_ready = 1
+						setInjectorReady()
 			return 1
 
 		if (bufferOption == "loadDisk")


### PR DESCRIPTION
Properly refreshes when adding/removing occupant and on block pulse.
Since the UI won't refresh when idle this should be a slight optimization as well.