### PR TITLE
Can no longer crawl under plastic flaps

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -52,7 +52,7 @@
 	else
 		A.attack_stump(src, params)
 
-	if(src.lying && !(isUnconscious() || stunned || paralysis) && check_crawl_ability() && istype(A, /turf/simulated) && proximity && !pulledby && !locked_to && !client.move_delayer.blocked())
+	if(src.lying && !(isUnconscious() || stunned || paralysis) && check_crawl_ability() && istype(A, /turf/simulated) && proximity && !pulledby && !locked_to && !client.move_delayer.blocked() && !(locate(/obj/structure/plasticflaps) in A))
 		Move(A, get_dir(src,A))
 		delayNextMove(movement_delay()*3,additive=1)
 


### PR DESCRIPTION
You can still be thrown/slipped under plastic flaps, you now can't just click to crawl under a plastic flap.

closes #16925