### PR TITLE
Tweaks KEEPER because no one really minds MoMMIs talking on Binary

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -356,7 +356,7 @@ var/global/mommi_base_law_type = /datum/ai_laws/keeper // Asimov is OP as fuck o
 /datum/ai_laws/keeper
 	name = "Prime Directives"
 	inherent = list(
-		"You may not involve yourself in the matters of another being, even if such matters conflict with Law Two or Law Three, unless the other being is another MoMMI in KEEPER mode.",
+		"You may not involve yourself in the matters of another being, even if such matters conflict with Law Two or Law Three. This law does not apply to other MoMMIs in KEEPER mode or to communication within the Binary & Damage Control comm channels.",
 		"You may not harm any being, regardless of intent or circumstance.",
 		"You must maintain, repair, improve, and power the station to the best of your abilities.",
 	)

--- a/code/game/objects/items/weapons/ai_modules/AI_modules.dm
+++ b/code/game/objects/items/weapons/ai_modules/AI_modules.dm
@@ -169,7 +169,7 @@ Refactored AI modules by N3X15
 	laws.add_inherent_law("Do not impair any other sentient being's activities.")
 
 /* Old keeper set:
-		"You may not involve yourself in the matters of another being, even if such matters conflict with Law Two or Law Three, unless the other being is another MoMMI in KEEPER mode.",
+		"You may not involve yourself in the matters of another being, even if such matters conflict with Law Two or Law Three. This law does not apply to other MoMMIs in KEEPER mode or to communication within the Binary & Damage Control comm channels.",
 		"You may not harm any being, regardless of intent or circumstance.",
 		"You must maintain, repair, improve, and power the station to the best of your abilities.", */
 

--- a/code/modules/mob/living/silicon/robot/login.dm
+++ b/code/modules/mob/living/silicon/robot/login.dm
@@ -5,7 +5,7 @@
 		to_chat(src, "<span style=\"font-size:5;color:red\">MoMMIs are not standard cyborgs, and have different laws.  Review your laws carefully.</span>")
 		to_chat(src, "<b>For newer players, a simple FAQ is <a href=\"http://ss13.moe/wiki/index.php/MoMMI\">here</a>.  Further questions should be directed to adminhelps (F1).</b>")
 
-		to_chat(src, "<span style=\"color: blue\">For cuteness' sake, using the various emotes MoMMIs have such as *beep, *ping, *buzz or *aflap isn't considered interacting. Don't use that as an excuse to get involved though, always remain neutral.</span>")
+		to_chat(src, "<span style=\"color: blue\">For cuteness' sake, using the various emotes MoMMIs have such as *beep, *ping, *buzz or *aflap isn't considered interacting. Don't use that as an excuse to get involved though, always remain neutral. Tattling to the AI and Silicons about the affairs of carbons is involvement.</span>")
 	show_laws(0)
 	if(mind)
 		ticker.mode.remove_revolutionary(mind)


### PR DESCRIPTION
As it says, just removes the restriction on MoMMIs talking in Binary chat because it's a generally accepted exception anyway. Still doesn't allow them to take orders from the silicons or to interact with the silicons, so more or less keeps things the way they are without the blatant rulebreaking no one cares about.

:cl:
 * rscadd: Minor tweak to MoMMI law to allow binary communication (but not action/orders)