### PR TITLE
Adds a magical number for chemical heating multiplying

### DIFF
--- a/__DEFINES/reagents.dm
+++ b/__DEFINES/reagents.dm
@@ -367,6 +367,7 @@
 #define TEMPERATURE_FLAME 700
 #define TEMPERATURE_WELDER 3480
 #define TEMPERATURE_PLASMA 4500
+#define HEAT_TRANSFER_MULTIPLIER 7 //Multiplies the numbers above when heating a reagent container. A truly magical number.
 
 // By defining the effect multiplier this way, it'll exactly adjust
 // all effects according to how they originally were with the 0.4 metabolism

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -774,7 +774,7 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 	var/heat_capacity = get_heatcapacity()
 	var/energy = power_transfer
 	var/mass = get_overall_mass()
-	var/temp_change = energy / (mass * heat_capacity)
+	var/temp_change = (energy / (mass * heat_capacity))* HEAT_TRANSFER_MULTIPLIER
 	if(power_transfer > 0)
 		chem_temp = min(chem_temp + temp_change, received_temperature)
 	else


### PR DESCRIPTION
Now heating is 7 times faster than before.

At 3 it took 10 minutes and 90~ units of glycerol to 25 units of density separated sample to melting temperature, so as this is a video game and time is a commodity, the magic number is now 7.

closes #16926 

:cl:
* rscadd: Made chemical heating less of a pain in the ass.