### PR TITLE
Clone damage on slimepeople can be healed

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -334,7 +334,7 @@
 	if(ishuman(src))
 		var/mob/living/carbon/human/H = src
 		if(isslimeperson(H))
-			amount = 0
+			amount = min(amount, 0)
 
 	cloneloss = min(max(cloneloss + (amount * clone_damage_modifier), 0),(maxHealth*2))
 

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -727,10 +727,6 @@
 		var/mob/living/carbon/human/human = M
 		if(!isslimeperson(human))
 			to_chat(M, "<span class='warning'>Your flesh rapidly mutates!</span>")
-			if(human.getCloneLoss() > 0)
-				var/cdamage = human.getCloneLoss()
-				human.setCloneLoss(0)
-				human.adjustToxLoss(cdamage * 1.5)
 			human.set_species("Evolved Slime")
 			human.regenerate_icons()
 

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -727,6 +727,10 @@
 		var/mob/living/carbon/human/human = M
 		if(!isslimeperson(human))
 			to_chat(M, "<span class='warning'>Your flesh rapidly mutates!</span>")
+			if(human.getCloneLoss() > 0)
+				var/cdamage = human.getCloneLoss()
+				human.setCloneLoss(0)
+				human.adjustToxLoss(cdamage * 1.5)
 			human.set_species("Evolved Slime")
 			human.regenerate_icons()
 


### PR DESCRIPTION
Closes #16937
This makes it so clone damage on slime people can be healed.

~~Since slime people shouldn't have clone damage in the first place, I went a step further and made it so the transformation converts clone damage into toxin damage at an exchange rate of 1.5, midway between the human and slimeperson toxin damage modifiers. ALTHOUGH this does mean mutationtoxin plus dylovene can be used as a replacement for rezadone in exchange for becoming a slime person. If the exchange isn't punishing enough I can add more damage and/or types of damage.~~

Not atomic so splitting into new PR.

:cl:
* bugfix: Clone damage on slimepeople can be healed now.