### PR TITLE
Humans who lie down/crawl can pick up/use items.

### DIFF
--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -203,7 +203,7 @@
 	return put_in_hand(GRASP_RIGHT_HAND, W)
 
 /mob/proc/put_in_hand_check(var/obj/item/W, index)
-	if(lying) //&& !(W.flags & ABSTRACT))
+	if(incapacitated()) //&& !(W.flags & ABSTRACT))
 		return 0
 	if(!isitem(W))
 		return 0
@@ -298,7 +298,6 @@
 //Drops the item in our hand - you can specify an item and a location to drop to
 
 /mob/proc/drop_item(var/obj/item/to_drop, var/atom/Target, force_drop = 0) //Set force_drop to 1 to force the item to drop (even if it can't be dropped normally)
-
 	if(!candrop) //can't drop items while etheral
 		return 0
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1503,11 +1503,15 @@ var/list/slot_equipment_priority = list( \
 			lying = (category.flags & LOCKED_SHOULD_LIE) ? TRUE : FALSE //A lying value that !=1 will break this
 
 
-	else if(isUnconscious() || knockdown || paralysis || resting)
+	else if(isUnconscious() || knockdown || paralysis)
 		stop_pulling()
 		lying = 1
 		canmove = 0
 		drop_hands()
+	else if (resting)
+		stop_pulling()
+		lying = 1
+		canmove = 0
 	else if(stunned)
 //		lying = 0
 		canmove = 0

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1503,13 +1503,15 @@ var/list/slot_equipment_priority = list( \
 			lying = (category.flags & LOCKED_SHOULD_LIE) ? TRUE : FALSE //A lying value that !=1 will break this
 
 
-	else if(isUnconscious() || knockdown || paralysis || resting || !can_stand)
+	else if(isUnconscious() || knockdown || paralysis || resting)
 		stop_pulling()
 		lying = 1
 		canmove = 0
+		drop_hands()
 	else if(stunned)
 //		lying = 0
 		canmove = 0
+		drop_hands()
 	else if(captured)
 		anchored = 1
 		canmove = 0
@@ -1521,7 +1523,6 @@ var/list/slot_equipment_priority = list( \
 	reset_layer() //Handles layer setting in hiding
 	if(lying)
 		density = 0
-		drop_hands()
 	else
 		density = 1
 

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -97,6 +97,9 @@ proc/spread_germs_to_organ(datum/organ/external/E, mob/living/carbon/human/user)
 		E.germ_level = max(germ_level,E.germ_level) //as funny as scrubbing microbes out with clean gloves is - no.
 
 proc/do_surgery(mob/living/M, mob/living/user, obj/item/tool)
+	if (M == user)
+		to_chat(world, "No self-surgery")
+		return 0
 	if(!istype(M,/mob/living/carbon/human))
 		return 0
 	if (user.a_intent == I_HURT)	//check for Hippocratic Oath

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -98,7 +98,6 @@ proc/spread_germs_to_organ(datum/organ/external/E, mob/living/carbon/human/user)
 
 proc/do_surgery(mob/living/M, mob/living/user, obj/item/tool)
 	if (M == user)
-		to_chat(world, "No self-surgery")
 		return 0
 	if(!istype(M,/mob/living/carbon/human))
 		return 0


### PR DESCRIPTION
Requested by ChugMonkey on discord.
I'm not very confident about the change myself, especially with how powerful/fast crawling is right now.

I would highly advise against merging this before crawling allowing you to crawl at sanic speeds is fixed.
Also consider this : ordering someone to rest is no longer a guarantee that the person is harmless.

However, this does not change stunning people, which will still make them drop all of their items as well as rendering them unable to pick up for a few seconds.

Tested.
:cl:
- tweak; People who lie down/crawl can now pick up and use items. Form now on, be careful of unassuming supposedly dead corpses.