### PR TITLE
Makes MoMMI jetpacks usable

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -213,6 +213,10 @@
 
 	for(var/obj/item/weapon/tank/jetpack/carbondioxide in R.module.modules)
 		R.internals = src
+		if(isMoMMI(R))
+			for(var/X in carbondioxide.actions)
+				var/datum/action/A = X
+				A.Grant(R)
 
 /obj/item/borg/upgrade/syndicate/
 	name = "cyborg illegal equipment board"

--- a/code/modules/mob/living/silicon/mommi/life.dm
+++ b/code/modules/mob/living/silicon/mommi/life.dm
@@ -16,6 +16,7 @@
 
 	if(client)
 		handle_regular_hud_updates()
+		update_action_buttons()
 		update_items()
 	if (src.stat != DEAD) //still using power
 		use_power()
@@ -276,11 +277,11 @@
 				mmi = null
 			gib()
 
-			
+
 /mob/living/silicon/robot/mommi/handle_pressure_damage(datum/gas_mixture/environment)
 	..()
-	
+
 /mob/living/silicon/robot/mommi/handle_heat_damage(datum/gas_mixture/environment)
 	..()
-			
+
 #undef MOMMI_LOW_POWER

--- a/code/modules/mob/living/silicon/mommi/mommi_movement.dm
+++ b/code/modules/mob/living/silicon/mommi/mommi_movement.dm
@@ -1,16 +1,13 @@
 // MoMMIs do spess construction, so shouldn't slip.
 /mob/living/silicon/robot/mommi/Process_Spaceslipping(var/prob_slip=5)
 	return 0
-
-/mob/living/silicon/robot/mommi/Process_Spacemove(var/check_drift = 0)
+/*
+/mob/living/silicon/robot/mommi/Process_Spacemove()			//Prevents MoMMIs from using stabilization control?
 	if(module)
 		for(var/obj/item/weapon/tank/jetpack/J in module.modules)
 			if(J && istype(J, /obj/item/weapon/tank/jetpack))
-				if(((!check_drift) || (check_drift && J.stabilization_on)) && (J.allow_thrust(0.01, src)))
-					inertia_dir = 0
-					return 1
-				if((!check_drift && J.allow_thrust(0.01)))
+				if(J.allow_thrust(0.01))
 					return 1
 	if(..())
 		return 1
-	return 0
+	return 0 */

--- a/code/modules/mob/living/silicon/mommi/mommi_movement.dm
+++ b/code/modules/mob/living/silicon/mommi/mommi_movement.dm
@@ -1,13 +1,3 @@
 // MoMMIs do spess construction, so shouldn't slip.
 /mob/living/silicon/robot/mommi/Process_Spaceslipping(var/prob_slip=5)
 	return 0
-/*
-/mob/living/silicon/robot/mommi/Process_Spacemove()			//Prevents MoMMIs from using stabilization control?
-	if(module)
-		for(var/obj/item/weapon/tank/jetpack/J in module.modules)
-			if(J && istype(J, /obj/item/weapon/tank/jetpack))
-				if(J.allow_thrust(0.01))
-					return 1
-	if(..())
-		return 1
-	return 0 */

--- a/code/modules/mob/living/silicon/mommi/mommi_movement.dm
+++ b/code/modules/mob/living/silicon/mommi/mommi_movement.dm
@@ -2,11 +2,14 @@
 /mob/living/silicon/robot/mommi/Process_Spaceslipping(var/prob_slip=5)
 	return 0
 
-/mob/living/silicon/robot/mommi/Process_Spacemove()
+/mob/living/silicon/robot/mommi/Process_Spacemove(var/check_drift = 0)
 	if(module)
 		for(var/obj/item/weapon/tank/jetpack/J in module.modules)
 			if(J && istype(J, /obj/item/weapon/tank/jetpack))
-				if(J.allow_thrust(0.01))
+				if(((!check_drift) || (check_drift && J.stabilization_on)) && (J.allow_thrust(0.01, src)))
+					inertia_dir = 0
+					return 1
+				if((!check_drift && J.allow_thrust(0.01)))
 					return 1
 	if(..())
 		return 1


### PR DESCRIPTION
Closes #16266
:cl:
* bugfix: Once installed, robot jetpacks now function in MoMMIs as they were supposed to. Godspeed, little crabs.