### PR TITLE
Increased the slime tiles generated from one extract.

### DIFF
--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -155,7 +155,7 @@ obj/item/stack/tile/slime
 	throw_range = 20
 	flags = FPRINT
 	siemens_coefficient = 1
-	max_amount = 30
+	max_amount = 60
 
 /obj/item/stack/tile/slime/adjust_slowdown(mob/living/L, current_slowdown)
 	if(ishuman(L))

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -1082,7 +1082,7 @@
 /datum/chemical_reaction/slimetile/on_reaction(var/datum/reagents/holder)
 	feedback_add_details("slime_cores_used", "[replacetext(name, " ", "_")]")
 	var/obj/item/stack/tile/slime/T = new /obj/item/stack/tile/slime
-	T.amount = 10
+	T.amount = 20
 	T.forceMove(get_turf(holder.my_atom))
 
 /datum/chemical_reaction/slimeheart

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -1082,7 +1082,7 @@
 /datum/chemical_reaction/slimetile/on_reaction(var/datum/reagents/holder)
 	feedback_add_details("slime_cores_used", "[replacetext(name, " ", "_")]")
 	var/obj/item/stack/tile/slime/T = new /obj/item/stack/tile/slime
-	T.amount = 5
+	T.amount = 10
 	T.forceMove(get_turf(holder.my_atom))
 
 /datum/chemical_reaction/slimeheart


### PR DESCRIPTION
Someone complained about it in discord and so I adjusted it to how much they suggested. Five tiles does seem like a very low number of tiles for one whole slime extract, 10 might still be a little on the low side. Feel free to add your own suggestions on the suggested tile quantity.
  
:cl:
* tweak: Increased slime tiles generated from green slime reaction to 20.
* tweak: Increased max slime tile stack size to 60.