### PR TITLE
[hotfix] Religions runtime

### DIFF
--- a/code/datums/religions.dm
+++ b/code/datums/religions.dm
@@ -462,7 +462,7 @@
 	bible_type = /obj/item/weapon/storage/bible/booze
 	male_adept = "Retard"
 	female_adept = "Retard"
-	keys = list("lol", "wtf", "ass", "poo", "badmin", "shitmin", "deadmin", "nigger", "dickbutt", ":^)", "XD", "le", "meme", "memes", "ayy", "ayy lmao", "lmao", "reddit", "4chan", "tumblr", "9gag")
+	keys = list("lol", "wtf", "ass", "poo", "badmin", "shitmin", "deadmin", "nigger", "dickbutt", ":^)", "XD", "le", "meme", "memes", "ayy", "ayy lmao", "lmao", "reddit", "4chan", "tumblr", "9gag", "brian damage")
 
 /datum/religion/retard/equip_chaplain(var/mob/living/carbon/human/H)
 	H.setBrainLoss(100) //Starts off retarded as fuck, that'll teach him

--- a/code/datums/religions.dm
+++ b/code/datums/religions.dm
@@ -462,7 +462,7 @@
 	bible_type = /obj/item/weapon/storage/bible/booze
 	male_adept = "Retard"
 	female_adept = "Retard"
-	keys = list("lol", "wtf", "ass", "poo", "badmin", "shitmin", "deadmin", "nigger", "dickbutt", ":^)", "XD", "le", "meme", "memes", "ayy", "ayy lmao", "lmao", "reddit", "4chan", "tumblr", "9gag", "brian damage")
+	keys = list("lol", "wtf", "ass", "poo", "badmin", "shitmin", "deadmin", "nigger", "dickbutt", ":^)", "XD", "le", "meme", "memes", "ayy", "ayy lmao", "lmao", "reddit", "4chan", "tumblr", "9gag")
 
 /datum/religion/retard/equip_chaplain(var/mob/living/carbon/human/H)
 	H.setBrainLoss(100) //Starts off retarded as fuck, that'll teach him

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -239,7 +239,7 @@
 				msg += "[t_He] [t_has] a vacant, braindead stare...\n"
 
 	// Religions
-	if (user.mind && user.mind.faith && user.mind.faith.isReligiousLeader(user))
+	if (user.mind && user.mind.faith && user.mind.faith.isReligiousLeader(user) && src.mind)
 		if (src.mind.faith == user.mind.faith)
 			msg += "<span class='notice'>You recognise [t_him] as a follower of [user.mind.faith.name].</span><br/>"
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -239,7 +239,7 @@
 				msg += "[t_He] [t_has] a vacant, braindead stare...\n"
 
 	// Religions
-	if (user.mind && user.mind.faith && user.mind.faith.isReligiousLeader(user) && src.mind)
+	if (user.mind && user.mind.faith && user.mind.faith.isReligiousLeader(user) && mind)
 		if (src.mind.faith == user.mind.faith)
 			msg += "<span class='notice'>You recognise [t_him] as a follower of [user.mind.faith.name].</span><br/>"
 


### PR DESCRIPTION
Fixes a runtime related to religions.
```proc name: examine (/mob/living/carbon/human/examine)
usr: Evil Dave (as Spaggy Maddetti) (adamhunt9) (/mob/living/carbon/human)
usr.loc: The floor (294, 245, 1) (/turf/simulated/floor/carpet)
src: Unknown (/mob/living/carbon/human)
src.loc: Carpet (297,246,1) (/turf/simulated/floor/carpet)
call stack:
Unknown (/mob/living/carbon/human): examine(Evil Dave (as Spaggy Maddetti) (/mob/living/carbon/human))
Evil Dave (as Spaggy Maddetti) (/mob/living/carbon/human): Examine(Unknown (/mob/living/carbon/human))
Unknown (/mob/living/carbon/human): ShiftClick(Evil Dave (as Spaggy Maddetti) (/mob/living/carbon/human))
Evil Dave (as Spaggy Maddetti) (/mob/living/carbon/human): ShiftClickOn(Unknown (/mob/living/carbon/human))
Evil Dave (as Spaggy Maddetti) (/mob/living/carbon/human): ClickOn(Unknown (/mob/living/carbon/human), "icon-x=12;icon-y=20;left=1;shi...")
Unknown (/mob/living/carbon/human): Click(Carpet (297,246,1) (/turf/simulated/floor/carpet), "mapwindow.map", "icon-x=12;icon-y=20;left=1;shi...")
Unknown (/mob/living/carbon/human): Click(Carpet (297,246,1) (/turf/simulated/floor/carpet), "mapwindow.map", "icon-x=12;icon-y=20;left=1;shi...")
```

I apologise for the messy commits as well.
  