### PR TITLE
xeno disarms now take into account the targets armor

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/combat.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/combat.dm
@@ -1,15 +1,14 @@
 /mob/living/carbon/alien/humanoid/disarm_mob(mob/living/target)
 	if(target.disarmed_by(src))
 		return
-
-	if(prob(80))
+	var/datum/organ/external/affecting = get_organ(ran_zone(zone_sel.selecting))
+	if(prob(80) && run_armor_check(affecting, "melee", quiet = 1))
 		do_attack_animation(target, src)
 		playsound(loc, 'sound/weapons/pierce.ogg', 25, 1, -1)
-		target.Knockdown(rand(3,4))
-
+		target.apply_effect(4, WEAKEN, run_armor_check(affecting, "melee"))
 		visible_message("<span class='danger'>[src] has tackled down [target]!</span>")
 
-	else if (prob(80))
+	else if (prob(80) && run_armor_check(affecting, "melee", quiet = 1))
 		do_attack_animation(target, src)
 		playsound(loc, get_unarmed_hit_sound(), 25, 1, -1)
 		target.drop_item()

--- a/code/modules/mob/living/carbon/alien/humanoid/combat.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/combat.dm
@@ -2,13 +2,14 @@
 	if(target.disarmed_by(src))
 		return
 	var/datum/organ/external/affecting = get_organ(ran_zone(zone_sel.selecting))
-	if(prob(80) && run_armor_check(affecting, "melee", quiet = 1))
+	var/disarm_chance_modifier = target.run_armor_check(affecting, "melee", quiet = 1)
+	if(prob(80/(disarm_chance_modifier == 0 ? 1 : disarm_chance_modifier)))
 		do_attack_animation(target, src)
 		playsound(loc, 'sound/weapons/pierce.ogg', 25, 1, -1)
 		target.apply_effect(4, WEAKEN, run_armor_check(affecting, "melee"))
 		visible_message("<span class='danger'>[src] has tackled down [target]!</span>")
 
-	else if (prob(80) && run_armor_check(affecting, "melee", quiet = 1))
+	else if (prob(80/(disarm_chance_modifier == 0 ? 1 : disarm_chance_modifier)))
 		do_attack_animation(target, src)
 		playsound(loc, get_unarmed_hit_sound(), 25, 1, -1)
 		target.drop_item()


### PR DESCRIPTION
Literally just more layers of RNG that the affected can deck up in their favour.

No longer is the HoS as bad off as a lowly greyshirt when it comes to being in a fist fight with a xenomorph.

:cl:
* tweak: Xenomorph disarms now take into account the targets armor.
  