### PR TITLE
Fix incorrect URL on header.

### DIFF
--- a/html/templates/header.html
+++ b/html/templates/header.html
@@ -29,7 +29,7 @@ ADDING CREDITS?  EDIT templates/header.html (or footer.html if they're for old t
 		<div class="header">
 			<h1>/vg/station - A Space Station 13 Server</h1>
 			<p>
-				<b>Forum | <a href="http://ss13.moe/wiki/index.php/Main_Page">Wiki</a> | <a href="https://github.com/d3athrow/vgstation13">Source</a></b>
+				<b>Forum | <a href="http://ss13.moe/wiki/index.php/Main_Page">Wiki</a> | <a href="https://github.com/vgstation-coders/vgstation13">Source</a></b>
 			</p>
 			<p>
 				<b>Visit our IRC channel:</b><a href="irc://irc.rizon.net/vgstation">#vgstation on irc.rizon.net</a>

--- a/html/templates/header.html
+++ b/html/templates/header.html
@@ -29,7 +29,7 @@ ADDING CREDITS?  EDIT templates/header.html (or footer.html if they're for old t
 		<div class="header">
 			<h1>/vg/station - A Space Station 13 Server</h1>
 			<p>
-				<b>Forum | <a href="http://baystation12.net/wiki/">Wiki</a> | <a href="https://github.com/d3athrow/vgstation13">Source</a></b>
+				<b>Forum | <a href="http://ss13.moe/wiki/index.php/Main_Page">Wiki</a> | <a href="https://github.com/d3athrow/vgstation13">Source</a></b>
 			</p>
 			<p>
 				<b>Visit our IRC channel:</b><a href="irc://irc.rizon.net/vgstation">#vgstation on irc.rizon.net</a>


### PR DESCRIPTION
Still had the old Baystation wiki URL instead of the one on ss13.moe. Admittedly, I didn't test this, but come on. It's a link change. I don't think it'll break the server.