### PR TITLE
Makes 'equip' spells unequip items correctly

### DIFF
--- a/code/modules/spells/targeted/equip/equip.dm
+++ b/code/modules/spells/targeted/equip/equip.dm
@@ -19,14 +19,13 @@
 			slot_id = text2num(slot_id) //because the index is text, we access this instead
 			var/obj/item/new_item = summon_item(to_create)
 			var/obj/item/old_item = L.get_item_by_slot(slot_id)
-			L.equip_to_slot(new_item, slot_id)
 			if(old_item)
 				L.remove_from_mob(old_item)
 				if(delete_old)
 					qdel(old_item)
 				else
 					old_item.forceMove(L.loc)
-
+			L.equip_to_slot(new_item, slot_id)
 			if(duration)
 				summoned_items += new_item //we store it in a list to remove later
 


### PR DESCRIPTION
Turns out you have to unequip the old item BEFORE equipping the new.

Fixes #16943