### PR TITLE
Fix eye protection typo in welding goggles

### DIFF
--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -156,7 +156,7 @@
 	if(!C.incapacitated())
 		if(src.up)
 			src.up = !src.up
-			eyeprot = 2
+			eyeprot = 3
 			body_parts_covered |= EYES
 			icon_state = initial(icon_state)
 			to_chat(C, "You flip the [src] down to protect your eyes.")


### PR DESCRIPTION
There was a typo in the code for the welding goggles. By default, welding goggles have an eye protection of 3. However, if you put them up and then put them back down, it would only give you an eye protection of 2. This is because of a typo. I don't know the implications of this.

:cl:
 * bugfix: Fix eye protection being lowered when toggling the welding goggles back on.