### PR TITLE
P-ray scanners now cost 10x the materials

### DIFF
--- a/code/modules/research/designs/engineering.dm
+++ b/code/modules/research/designs/engineering.dm
@@ -159,7 +159,7 @@
 	id = "pray_scanner"
 	req_tech = list(Tc_ENGINEERING = 3, Tc_MAGNETS = 3)
 	build_type = PROTOLATHE
-	materials = list(MAT_IRON = 500, MAT_GLASS = 100)
+	materials = list(MAT_IRON = 5000, MAT_GLASS = 1000)
 	build_path = /obj/item/device/t_scanner/advanced
 	category = "Engineering"
 


### PR DESCRIPTION
Fixes #16902

:cl:
 * tweak: P-ray scanners are now 10 times as expensive to build compared to the T-ray scanners.