### PR TITLE
Disfigurement-related fixes

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -561,7 +561,6 @@ var/list/global_mutations = list() // list of hidden mutation things
 #define CANPUSH		8
 #define GODMODE		4096
 #define FAKEDEATH	8192	//Replaces stuff like changeling.changeling_fakedeath
-#define DISFIGURED	16384	//I'll probably move this elsewhere if I ever get wround to writing a bitflag mob-damage system
 #define XENO_HOST	32768	//Tracks whether we're gonna be a baby alien's mummy.
 
 var/static/list/scarySounds = list('sound/weapons/thudswoosh.ogg','sound/weapons/Taser.ogg','sound/weapons/armbomb.ogg','sound/voice/hiss1.ogg','sound/voice/hiss2.ogg','sound/voice/hiss3.ogg','sound/voice/hiss4.ogg','sound/voice/hiss5.ogg','sound/voice/hiss6.ogg','sound/effects/Glassbr1.ogg','sound/effects/Glassbr2.ogg','sound/effects/Glassbr3.ogg','sound/items/Welder.ogg','sound/items/Welder2.ogg','sound/machines/airlock.ogg','sound/effects/clownstep1.ogg','sound/effects/clownstep2.ogg')

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -132,7 +132,8 @@
 	update_hair(0)
 
 	mutations.Add(SKELETON)
-	status_flags |= DISFIGURED
+	var/datum/organ/external/head/head_organ = get_organ(LIMB_HEAD)
+	head_organ.disfigure("burn")
 	update_body(0)
 	update_mutantrace()
 	return
@@ -147,7 +148,8 @@
 	update_hair(0)
 
 	mutations.Add(M_HUSK)
-	status_flags |= DISFIGURED	//Makes them unknown without fucking up other stuff like admintools
+	var/datum/organ/external/head/head_organ = get_organ(LIMB_HEAD)
+	head_organ.disfigure("brute")
 	update_body(0)
 	update_mutantrace()
 	vessel.remove_reagent(BLOOD,vessel.get_reagent_amount(BLOOD))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -952,7 +952,7 @@
 		O.heal_damage(1000,1000,1,1)
 
 	var/datum/organ/external/head/h = organs_by_name[LIMB_HEAD]
-	h.disfigured = 0
+	h.disfigured = FALSE
 
 	if(species && !(species.anatomy_flags & NO_BLOOD))
 		vessel.add_reagent(BLOOD,560-vessel.total_volume)

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -1392,7 +1392,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	max_damage = 130
 	min_broken_damage = 40
 	body_part = HEAD
-	var/disfigured = 0
+	var/disfigured = FALSE
 	vital = 1
 	encased = "skull"
 
@@ -1473,7 +1473,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		owner.visible_message("<span class='warning'>[owner]'s face disfigures.</span>",
 		                      "<span class='danger'>Your face becomes an unrecognizable, mangled mess!</span>")
 
-	disfigured = 1
+	disfigured = TRUE
 
 /****************************************************
 			   EXTERNAL ORGAN ITEMS

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -454,11 +454,11 @@
 
 				if(M.acidable())
 					if(prob(15) && volume >= 30)
-						var/datum/organ/external/affecting = H.get_organ(LIMB_HEAD)
-						if(affecting)
-							if(affecting.take_damage(25, 0))
+						var/datum/organ/external/head/head_organ = H.get_organ(LIMB_HEAD)
+						if(head_organ)
+							if(head_organ.take_damage(25, 0))
 								H.UpdateDamageIcon(1)
-							H.status_flags |= DISFIGURED
+							head_organ.disfigure("burn")
 							H.emote("scream", , , 1)
 					else
 						M.take_organ_damage(min(15, volume * 2)) //Uses min() and volume to make sure they aren't being sprayed in trace amounts (1 unit != insta rape) -- Doohl
@@ -955,14 +955,14 @@
 
 					if(H.acidable())
 						if(prob(15) && volume >= 30)
-							var/datum/organ/external/affecting = H.get_organ(LIMB_HEAD)
-							if(affecting)
+							var/datum/organ/external/head/head_organ = H.get_organ(LIMB_HEAD)
+							if(head_organ)
 								if(!(VAMP_MATURE in H.mind.vampire.powers))
 									to_chat(H, "<span class='danger'>A freezing liquid covers your face. Its melting!</span>")
 									H.mind.vampire.smitecounter += 60 //Equivalent from metabolizing all this holy water normally
-									if(affecting.take_damage(30, 0))
+									if(head_organ.take_damage(30, 0))
 										H.UpdateDamageIcon(1)
-									H.status_flags |= DISFIGURED
+									head_organ.disfigure("burn")
 									H.emote("scream",,, 1)
 								else
 									to_chat(H, "<span class='warning'>A freezing liquid covers your face. Your vampiric powers protect you!</span>")
@@ -1358,11 +1358,11 @@
 				var/mob/living/carbon/human/H = M
 				if(H.species.name == "Grey")
 					return //Greys lurve dem some sacid
-				var/datum/organ/external/affecting = H.get_organ(LIMB_HEAD)
-				if(affecting)
-					if(affecting.take_damage(25, 0))
+				var/datum/organ/external/head/head_organ = H.get_organ(LIMB_HEAD)
+				if(head_organ)
+					if(head_organ.take_damage(25, 0))
 						H.UpdateDamageIcon(1)
-					H.status_flags |= DISFIGURED
+					head_organ.disfigure("burn")
 					H.emote("scream", , , 1)
 			else
 				M.take_organ_damage(min(15, volume * 2)) //uses min() and volume to make sure they aren't being sprayed in trace amounts (1 unit != insta rape) -- Doohl
@@ -1437,8 +1437,8 @@
 				return
 
 			if(H.acidable())
-				var/datum/organ/external/affecting = H.get_organ(LIMB_HEAD)
-				if(affecting.take_damage(15, 0))
+				var/datum/organ/external/head/head_organ = H.get_organ(LIMB_HEAD)
+				if(head_organ.take_damage(15, 0))
 					H.UpdateDamageIcon(1)
 				H.emote("scream", , , 1)
 
@@ -1460,11 +1460,11 @@
 		if(M.acidable()) //I think someone doesn't know what this does
 			if(ishuman(M))
 				var/mob/living/carbon/human/H = M
-				var/datum/organ/external/affecting = H.get_organ(LIMB_HEAD)
-				if(affecting.take_damage(15, 0))
+				var/datum/organ/external/head/head_organ = H.get_organ(LIMB_HEAD)
+				if(head_organ.take_damage(15, 0))
 					H.UpdateDamageIcon(1)
 				H.emote("scream", , , 1)
-				H.status_flags |= DISFIGURED
+				head_organ.disfigure("burn")
 			else
 				M.take_organ_damage(min(15, volume * 4))
 
@@ -2843,7 +2843,15 @@
 		if(15 to 35)
 			M.adjustCloneLoss(-2)
 			M.heal_organ_damage(2, 1)
-			M.status_flags &= ~DISFIGURED
+			if(ishuman(M))
+				var/mob/living/carbon/human/H = M
+				var/datum/organ/external/head/head_organ = H.get_organ(LIMB_HEAD)
+				if(head_organ.disfigured)
+					head_organ.disfigured = FALSE
+					if(H.get_face_name() != "Unknown")
+						H.visible_message("<span class='notice'>[H]'s face shifts and knits itself back into shape!</span>","<span class='notice'>You feel your face shifting and repairing itself!</span>")
+					else if(!(H.stat == UNCONSCIOUS || H.sleeping > 0))
+						to_chat(H,"<span class='notice'>You feel your face shifting and repairing itself!</span>")
 
 	data++
 

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -2850,7 +2850,7 @@
 					head_organ.disfigured = FALSE
 					if(H.get_face_name() != "Unknown")
 						H.visible_message("<span class='notice'>[H]'s face shifts and knits itself back into shape!</span>","<span class='notice'>You feel your face shifting and repairing itself!</span>")
-					else if(!(H.stat == UNCONSCIOUS || H.sleeping > 0))
+					else if(!H.isUnconscious())
 						to_chat(H,"<span class='notice'>You feel your face shifting and repairing itself!</span>")
 
 	data++

--- a/code/modules/surgery/bones.dm
+++ b/code/modules/surgery/bones.dm
@@ -114,7 +114,7 @@
 		"<span class='warning'>Your hand slips, damaging [target]'s face with \the [tool]!</span>")
 	var/datum/organ/external/head/h = affected
 	h.createwound(BRUISE, 10)
-	h.disfigured = 1
+	h.disfigure("brute")
 
 
 

--- a/code/modules/surgery/face.dm
+++ b/code/modules/surgery/face.dm
@@ -150,8 +150,9 @@
 	affected.open = 0
 	affected.status &= ~ORGAN_BLEEDING
 	if (target.op_stage.face == 3)
-		var/datum/organ/external/head/h = affected
-		h.disfigured = 0
+		var/datum/organ/external/head/head_organ = affected
+		head_organ.disfigured = FALSE
+		target.visible_message("<span class='notice'>[target]'s face has been repaired.</span>")
 	target.op_stage.face = 0
 	target.op_stage.tooth_replace = 0
 


### PR DESCRIPTION
* Clears out and fixes up the remnants of the DISFIGURED status flag.
* Makes rezadone's un-disfiguring effect work again.
* Adds messages to rezadone's un-disfiguring effect.
* Adds an additional message to face surgery completion.
* Applied `disfigure()` in more places.

As an aside: I have no idea why pacid hates the face and head so much when injected, and leaves your identity untouched when it's splashed on you, but that's how it has been before. I'm all for changing it.

:cl:
* bugfix: Chemical effects that cause disfigurement (acid, mainly) and undo disfigurement (rezadone) should work again.
* rscadd: Added messages to a few disfigurement/un-disfigurement events.