### PR TITLE
Fixed is_type_in_list runtime on null lists

### DIFF
--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -58,7 +58,7 @@
 
 //Checks for specific types in a list
 /proc/is_type_in_list(datum/A, list/L)
-	if(!L.len || !A)
+	if(!L || !L.len || !A)
 		return 0
 
 	if(L[L[1]] != MAX_VALUE) //Is this already a generated typecache


### PR DESCRIPTION
```
[06:25:53] Runtime in lists.dm,61: Cannot read null.len
  proc name: is type in list (/proc/is_type_in_list)
  usr: A.D.O (electroblueguy) (/mob/living/silicon/robot)
  usr.loc: The floor (235, 258, 1) (/turf/simulated/floor)
  src: null
  call stack:
  is type in list(Larry Compton (/mob/living/carbon/human), null)
  the brobot\'s space beer (/obj/item/weapon/reagent_containers/glass/replenishing/cyborg): afterattack(Larry Compton (/mob/living/carbon/human), A.D.O (/mob/living/silicon/robot), 1, "icon-x=15;icon-y=17;left=1;scr...")
  A.D.O (/mob/living/silicon/robot): ClickOn(Larry Compton (/mob/living/carbon/human), "icon-x=15;icon-y=17;left=1;scr...")
  Larry Compton (/mob/living/carbon/human): Click(the floor (234,258,1) (/turf/simulated/floor), "mapwindow.map", "icon-x=15;icon-y=17;left=1;scr...")
  Larry Compton (/mob/living/carbon/human): Click(the floor (234,258,1) (/turf/simulated/floor), "mapwindow.map", "icon-x=15;icon-y=17;left=1;scr...")
```