### PR TITLE
Fixed runtime in DNA scanner console Destroy()

### DIFF
--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -516,7 +516,8 @@
 	if(!..())
 		if(!connected)
 			connected = findScanner() //lets get that machine
-			connected.connected = src
+			if(connected)
+				connected.connected = src
 		ui_interact(user)
 
 /obj/machinery/computer/scan_consolenew/AltClick()

--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -412,9 +412,10 @@
 	light_color = LIGHT_COLOR_BLUE
 
 /obj/machinery/computer/scan_consolenew/Destroy()
-	if(connected.connected == src)
-		connected.connected = null
-	connected = null
+	if(connected)
+		if(connected.connected == src)
+			connected.connected = null
+		connected = null
 	for(var/datum/block_label/label in labels)
 		returnToPool(label)
 	labels.Cut()


### PR DESCRIPTION
This caused the console to survive singularities.
```
[06:46:19] Runtime in dna_modifier.dm,415: Cannot read null.connected
  proc name: Destroy (/obj/machinery/computer/scan_consolenew/Destroy)
  src: DNA Modifier Access Console (/obj/machinery/computer/scan_consolenew)
  src.loc: space (212,205,1) (/turf/space)
  call stack:
  DNA Modifier Access Console (/obj/machinery/computer/scan_consolenew): Destroy()
  qdel(DNA Modifier Access Console (/obj/machinery/computer/scan_consolenew), 0, 0)
  DNA Modifier Access Console (/obj/machinery/computer/scan_consolenew): ex act(1)
  DNA Modifier Access Console (/obj/machinery/computer/scan_consolenew): singularity act(9, the gravitational singularity (/obj/machinery/singularity))
  the gravitational singularity (/obj/machinery/singularity): consume(DNA Modifier Access Console (/obj/machinery/computer/scan_consolenew))
  the gravitational singularity (/obj/machinery/singularity): Crossed(DNA Modifier Access Console (/obj/machinery/computer/scan_consolenew))
  DNA Modifier Access Console (/obj/machinery/computer/scan_consolenew): Move(space (212,205,1) (/turf/space), 8, 0, 0)
  DNA Modifier Access Console (/obj/machinery/computer/scan_consolenew): GotoAirflowDest(6.15934)
```