### PR TITLE
Raises the amount of phazon per vein the same as bananium.

### DIFF
--- a/code/modules/mining/minerals.dm
+++ b/code/modules/mining/minerals.dm
@@ -77,7 +77,7 @@ mineral/clown
 mineral/phazon
 	display_name = "Phazon"
 	name = "Phazon"
-	result_amount = 2 // 1
+	result_amount = 3
 	spread = 0
 	ore = /obj/item/weapon/ore/phazon
 


### PR DESCRIPTION
Some complaints with the recent borg mat synth nerf is that you end up with too little phazon for even one mech after you put the effort into going to the clown roid for it.
Raises the amount from 2 ore to 3.
The hand synth is a joke in it's current state.
:cl:
 * tweak: Raised the amount of phazon you get per vein from 2 to 3.