### PR TITLE
Fix double antag as well as double Head of Staff for revsquad.

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -279,13 +279,14 @@
 				if(!(player.mind in drafted) || !(player.mind in candidates)) // Players were getting placed in candidates AND drafted lists.
 					if(player.client.desires_role(role, display_to_user=poll)) // We don't have enough people who want to be antagonist, make a seperate list of people who don't want to be one
 						if(!jobban_isbanned(player, "Syndicate") && !jobban_isbanned(player, role)) //Nodrak/Carn: Antag Job-bans
-							drafted += player.mind
-
-	if(restricted_jobs)
-		for(var/datum/mind/player in drafted)				// Remove people who can't be an antagonist
-			for(var/job in restricted_jobs)
-				if(player.assigned_role == job)
-					drafted -= player
+							if (restricted_jobs) // Can't draft something that's restricted.
+								var/datum/mind/M = player.mind
+								if (!(M.assigned_job in restricted_jobs))
+									drafted += M
+								else
+									continue
+							else
+								drafted += player.mind
 
 	drafted = shuffle(drafted) // Will hopefully increase randomness, Donkie
 
@@ -350,8 +351,9 @@
 ///////////////////////////////////
 /datum/game_mode/proc/get_living_heads()
 	var/list/heads = list()
-	for(var/mob/living/carbon/human/player in mob_list)
-		if(player.stat!=2 && player.mind && (player.mind.assigned_role in command_positions))
+	for(var/client/C in clients)
+		var/mob/living/carbon/human/player = C.mob
+		if(istype(player) && player.stat!=2 && player.mind && (player.mind.assigned_role in command_positions))
 			heads += player.mind
 	return heads
 
@@ -361,15 +363,17 @@
 ////////////////////////////
 /datum/game_mode/proc/get_all_heads()
 	var/list/heads = list()
-	for(var/mob/player in mob_list)
-		if(player.mind && (player.mind.assigned_role in command_positions))
+	for(var/client/C in clients)
+		var/mob/living/carbon/human/player = C.mob
+		if(istype(player) && player.mind && (player.mind.assigned_role in command_positions))
 			heads += player.mind
 	return heads
 
 /datum/game_mode/proc/get_assigned_head_roles()
 	var/list/roles = list()
-	for(var/mob/player in mob_list)
-		if(player.mind && (player.mind.assigned_role in command_positions))
+	for(var/client/C in clients)
+		var/mob/living/carbon/human/player = C.mob
+		if(istype(player) && player.mind && (player.mind.assigned_role in command_positions))
 			roles += player.mind.assigned_role
 	return roles
 

--- a/code/game/gamemodes/revolution/revsquad.dm
+++ b/code/game/gamemodes/revolution/revsquad.dm
@@ -61,18 +61,18 @@
 	if(master_mode=="secret" && secret_force_mode=="secret")
 		if(head_revolutionaries.len==0 || head_check.len <= minimum_heads)
 			log_admin("Failed to set-up a round of revsquad. Couldn't find any heads of staffs or any volunteers to be revolutionaries.")
-			log_admin("Number of headrevs: [head_revolutionaries.len] Number of heads: [head_check]")
+			log_admin("Number of headrevs: [head_revolutionaries.len] Number of heads: [head_check.len]")
 			message_admins("Failed to set-up a round of revsquad. Couldn't find any heads of staffs or any volunteers to be revolutionaries.")
 			message_admins("Number of headrevs: [head_revolutionaries.len] Heads of Staff: [get_assigned_head_roles()]")
 			return 0
 
-	else if (head_revolutionaries.len==0 || head_check <= 0)
+	else if (head_revolutionaries.len==0 || head_check.len <= 0)
 		log_admin("Failed to set-up a secret-forced round of revsquad. Couldn't find any heads of staffs or any volunteers to be revolutionaries.")
 		message_admins("Failed to set-up a secret-forced round of revsquad. Couldn't find any heads of staffs or any volunteers to be revolutionaries.")
 		return 0
 
-	log_admin("Starting a round of revsquad with [head_revolutionaries.len] revolutionaries and [head_check] heads of staff.")
-	message_admins("Starting a round of revsquad with [head_revolutionaries.len] revolutionaries and [head_check] heads of staff.")
+	log_admin("Starting a round of revsquad with [head_revolutionaries.len] revolutionaries and [head_check.len] heads of staff.")
+	message_admins("Starting a round of revsquad with [head_revolutionaries.len] revolutionaries and [head_check.len] heads of staff.")
 	return 1
 
 /datum/game_mode/revsquad/post_setup()

--- a/code/game/gamemodes/revolution/revsquad.dm
+++ b/code/game/gamemodes/revolution/revsquad.dm
@@ -17,7 +17,7 @@
 	var/checkwin_counter = 0
 	var/const/waittime_l = 600 //lower bound on time before intercept arrives (in tenths of seconds)
 	var/const/waittime_h = 1800 //upper bound on time before intercept arrives (in tenths of seconds)
-	var/minimum_heads = 2
+	var/minimum_heads = 3
 	var/list/possible_items = list(/obj/item/weapon/card/emag,
 								   /obj/item/clothing/gloves/yellow,
 								   /obj/item/weapon/gun/projectile/automatic,
@@ -40,10 +40,10 @@
 
 	var/list/datum/mind/possible_revs = get_players_for_role(ROLE_REV)
 
-	var/head_check = 0
+	var/list/head_check = list()
 	for(var/mob/new_player/player in player_list)
-		if(player.mind.assigned_role in command_positions)
-			head_check++
+		if(player.mind.assigned_role in command_positions && !(player in head_check))
+			head_check += player
 
 	for(var/datum/mind/player in possible_revs)
 		for(var/job in restricted_jobs)//Removing heads and such from the list
@@ -59,14 +59,14 @@
 
 	// If an admin forces this mode, we set the minimum head count to 1, otherwise check minimum heads
 	if(master_mode=="secret" && secret_force_mode=="secret")
-		if(head_revolutionaries.len==0 || head_check < minimum_heads)
+		if(head_revolutionaries.len==0 || head_check.len <= minimum_heads)
 			log_admin("Failed to set-up a round of revsquad. Couldn't find any heads of staffs or any volunteers to be revolutionaries.")
 			log_admin("Number of headrevs: [head_revolutionaries.len] Number of heads: [head_check]")
 			message_admins("Failed to set-up a round of revsquad. Couldn't find any heads of staffs or any volunteers to be revolutionaries.")
 			message_admins("Number of headrevs: [head_revolutionaries.len] Heads of Staff: [get_assigned_head_roles()]")
 			return 0
 
-	else if (head_revolutionaries.len==0 || head_check < 1)
+	else if (head_revolutionaries.len==0 || head_check <= 0)
 		log_admin("Failed to set-up a secret-forced round of revsquad. Couldn't find any heads of staffs or any volunteers to be revolutionaries.")
 		message_admins("Failed to set-up a secret-forced round of revsquad. Couldn't find any heads of staffs or any volunteers to be revolutionaries.")
 		return 0


### PR DESCRIPTION
### Disclaimer
Since I do not 15+ autistic spessmen at my disposal, this isn't live-tested.
If you do know a way to actually test it locally, feel free to tell so : otherwise, I think we'll have to test-merge it somewhere and draft volunteers to see if it works properly.

### Scope of this PR
It should : 
- Fix #16884 
- Fix #17030 

### What it does :
Fix unfit people showing up in the `drafted` list for antags, removing the possibility of the ticker to believe there is enough people to do a cult when there isn't : this could cause more "BEEP BOOP ERROR SETTING UP SECRET" memes.

In a somehow hacky way, checks if we don't double-draft heads of staff for revsquad, fixing #17030.

Finally, replace going through all the mobs of the `mob_list`, by only going through clients/players for checking heads : this could have been the cause of errors.
  