### PR TITLE
Readds lootcrates to the merch computer but no longer gib the user.

### DIFF
--- a/code/game/machinery/computer/store.dm
+++ b/code/game/machinery/computer/store.dm
@@ -25,7 +25,7 @@
 			/datum/storeitem/beachball,
 			/datum/storeitem/snap_pops,
 			/datum/storeitem/crayons,
-			///datum/storeitem/dorkcube,
+			/datum/storeitem/dorkcube,
 			),
 		"Clothing" = list(
 			/datum/storeitem/robotnik_labcoat,

--- a/code/game/objects/items/weapons/gift_wrappaper.dm
+++ b/code/game/objects/items/weapons/gift_wrappaper.dm
@@ -316,15 +316,20 @@
 
 ///Loot crate///
 /obj/item/weapon/winter_gift/dorkcube
-	name = "loot box"
-	desc = "Don't forget to shout the magic phrase when you open it! It has a tag on it: Made by GIBLOOTPLS."
+	name = "lootbox"
+	desc = "Don't forget to shout the magic phrase when you open it! Made by Dorkcube."
 	icon = 'icons/obj/storage/storage.dmi'
 	icon_state = "lootbox_purple"
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/toolbox_ihl.dmi', "right_hand" = 'icons/mob/in-hand/right/toolbox_ihr.dmi')
 	item_state = "lootbox_purple"
 
+/obj/item/weapon/winter_gift/dorkcube/New()
+	..()
+	reagents.add_reagent(BLOOD, 10)
+
 /obj/item/weapon/winter_gift/dorkcube/attack_self(mob/user)
 	user.say("Loot get!")
 	playsound(get_turf(src), 'sound/misc/achievement.ogg', 30, 1)
-	user.gib()
+	splash_sub(reagents, user, -1, user)
+	gibs(loc)
 	qdel(src)


### PR DESCRIPTION
Over here at Dorkcube we've heard some complaints about our products being potentially dangerous to all life in existence. We are happy to announce that we will be bringing back our lootboxes but with brand new contents in them as well as those contents being of higher quality.
Lootboxes now contain a full gallon of <b>REAL</b> all natural blood from <b>REAL</b> endangered space polarbears.

Lootboxes will now just splash blood rather than gibbing the user.
:cl:
 * rscadd: Lootcrates are back and are better than ever at the cargo merch computer. They may no longer gib you and they now contain an even better prize(s)!

  