### PR TITLE
Removes blood (when using vampjaunt and shadowstep), adds blood cost adjustments

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -978,13 +978,14 @@ var/default_colour_matrix = list(1,0,0,0,\
 #define VAMP_CLOAK    7
 #define VAMP_BATS     8
 #define VAMP_SCREAM   9
-#define VAMP_JAUNT    10
-#define VAMP_SLAVE    11
-#define VAMP_BLINK    12
-#define VAMP_MATURE   13
-#define VAMP_SHADOW   14
-#define VAMP_CHARISMA 15
-#define VAMP_UNDYING  16
+#define VAMP_HEAL     10
+#define VAMP_JAUNT    11
+#define VAMP_SLAVE    12
+#define VAMP_BLINK    13
+#define VAMP_MATURE   14
+#define VAMP_SHADOW   15
+#define VAMP_CHARISMA 16
+#define VAMP_UNDYING  17
 
 // Moved from machine_interactions.dm
 #define STATION_Z  1

--- a/code/game/gamemodes/vampire/vampire.dm
+++ b/code/game/gamemodes/vampire/vampire.dm
@@ -338,6 +338,8 @@ You are weak to holy things and starlight. Don't go into space and avoid the Cha
 				verbs += /client/proc/vampire_bats
 			if(VAMP_SCREAM)
 				verbs += /client/proc/vampire_screech
+			if(VAMP_HEAL)
+				continue
 			if(VAMP_JAUNT)
 				verbs += /client/proc/vampire_jaunt
 			if(VAMP_BLINK)
@@ -455,8 +457,7 @@ You are weak to holy things and starlight. Don't go into space and avoid the Cha
 	if(vamp.bloodtotal >= 200)
 		vamp.powers |= VAMP_BATS
 		vamp.powers |= VAMP_SCREAM
-		// Commented out until we can figured out a way to stop this from spamming.
-//		to_chat(src, "<span class='notice'>Your rejuvination abilities have improved and will now heal you over time when used.</span>")
+		vamp.powers |= VAMP_HEAL
 
 	// TIER 3.5 (/vg/)
 	if(vamp.bloodtotal >= 250)
@@ -508,13 +509,18 @@ You are weak to holy things and starlight. Don't go into space and avoid the Cha
 					to_chat(src, "[msg]")
 					verbs += /client/proc/vampire_cloak
 				if(VAMP_BATS)
-					msg = "<span class='notice'>You have gained the Summon Bats ability."
+					msg = "<span class='notice'>You have gained the Summon Bats ability which allows you to summon a trio of angry space bats.</span>"
 					to_chat(src, "[msg]")
 					verbs += /client/proc/vampire_bats // work in progress
 				if(VAMP_SCREAM)
 					msg = "<span class='notice'>You have gained the Chiroptean Screech ability which stuns anything with ears in a large radius and shatters glass in the process.</span>"
 					to_chat(src, "[msg]")
 					verbs += /client/proc/vampire_screech
+				if(VAMP_HEAL)
+					msg = "<span class=notice'>Your rejuvination abilities have improved and will now heal you over time when used.</span>"
+					to_chat(src, "[msg]")
+					src.mind.store_memory("<font size = 1>[msg]</font>")
+					//no verb
 				if(VAMP_JAUNT)
 					msg = "<span class='notice'>You have gained the Mist Form ability which allows you to take on the form of mist for a short period and pass over any obstacle in your path.</span>"
 					to_chat(src, "[msg]")
@@ -668,7 +674,7 @@ You are weak to holy things and starlight. Don't go into space and avoid the Cha
 		if(prob(35))
 			to_chat(src, "<span class='danger'>This ground is blessed. Get away, or splatter it with blood to make it safe for you.</span>")
 
-	if(!((VAMP_MATURE in mind.vampire.powers)) && get_area(src) == /area/chapel) //stay out of the chapel unless you want to turn into a pile of ashes
+	if(!(VAMP_MATURE in mind.vampire.powers) && get_area(src) == /area/chapel) //stay out of the chapel unless you want to turn into a pile of ashes
 		mind.vampire.nullified = max(5, mind.vampire.nullified + 2)
 		if(prob(35))
 			to_chat(src, "<span class='sinister'>You feel yourself growing weaker.</span>")

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -76,7 +76,7 @@
 	victims -= mind.current
 	if(!victims.len)
 		return
-	var/mob/living/carbon/T 
+	var/mob/living/carbon/T
 	T = victims[1]
 	if (victims.len > 1)
 		T = input(src, "Victim?") as null|anything in victims
@@ -525,6 +525,7 @@
 		return
 
 	if(M.current.vampire_power(30, 0))
+		M.current.remove_vampire_blood(30)
 		M.current.verbs -= /client/proc/vampire_jaunt
 		new /mob/living/simple_animal/hostile/scarybat(M.current.loc, M.current)
 		ethereal_jaunt(M.current, duration, "batify", "debatify", 0)
@@ -584,6 +585,7 @@
 			var/turf/T = get_turf(M.current)
 			T.turf_animation('icons/effects/effects.dmi',"shadowstep")
 			usr.forceMove(picked)
+		M.current.remove_vampire_blood(20)
 		M.current.verbs -= /client/proc/vampire_shadowstep
 		sleep(20 SECONDS)
 		if(M && M.current)

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -105,7 +105,7 @@
 		//M.vampire.bloodusable -= 10
 		to_chat(M.current, "<span class='notice'>You flush your system with clean blood and remove any incapacitating effects.</span>")
 		spawn(1)
-			if(M.vampire.bloodtotal >= 200)
+			if(VAMP_HEAL in M.vampire.powers)
 				for(var/i = 0; i < 5; i++)
 					M.current.adjustBruteLoss(-2)
 					M.current.adjustOxyLoss(-5)
@@ -484,12 +484,12 @@
 
 /client/proc/vampire_bats()
 	set category = "Vampire"
-	set name = "Summon Bats (75)"
-	set desc = "You summon a pair of space bats who attack nearby targets until they or their target is dead."
+	set name = "Summon Bats (50)"
+	set desc = "You summon a trio of space bats who attack nearby targets until they or their target is dead."
 	var/datum/mind/M = usr.mind
 	if(!M)
 		return
-	if(M.current.vampire_power(75, 0))
+	if(M.current.vampire_power(50, 0))
 		var/list/turf/locs = new
 		var/number = 0
 		for(var/direction in alldirs) //looking for bat spawns
@@ -509,7 +509,7 @@
 			new /mob/living/simple_animal/hostile/scarybat(M.current.loc, M.current)
 			new /mob/living/simple_animal/hostile/scarybat(M.current.loc, M.current)
 			new /mob/living/simple_animal/hostile/scarybat(M.current.loc, M.current)
-		M.current.remove_vampire_blood(75)
+		M.current.remove_vampire_blood(50)
 		M.current.verbs -= /client/proc/vampire_bats
 		sleep(1200)
 		if(M && M.current) // Because our vampire can be completely destroyed after the sleep ends, who knows
@@ -517,15 +517,15 @@
 
 /client/proc/vampire_jaunt()
 	set category = "Vampire"
-	set name = "Bat Form (30)"
+	set name = "Bat Form (20)"
 	set desc = "You become ethereal and can travel through walls for a short time, while leaving a scary bat behind."
 	var/duration = 5 SECONDS
 	var/datum/mind/M = usr.mind
 	if(!M)
 		return
 
-	if(M.current.vampire_power(30, 0))
-		M.current.remove_vampire_blood(30)
+	if(M.current.vampire_power(20, 0))
+		M.current.remove_vampire_blood(20)
 		M.current.verbs -= /client/proc/vampire_jaunt
 		new /mob/living/simple_animal/hostile/scarybat(M.current.loc, M.current)
 		ethereal_jaunt(M.current, duration, "batify", "debatify", 0)
@@ -537,7 +537,7 @@
 // Less smoke spam.
 /client/proc/vampire_shadowstep()
 	set category = "Vampire"
-	set name = "Shadowstep (20)"
+	set name = "Shadowstep (10)"
 	set desc = "Vanish into the shadows."
 
 	var/datum/mind/M = usr.mind
@@ -551,7 +551,7 @@
 	// Maximum lighting_lumcount.
 	var/max_lum = 1
 
-	if(M.current.vampire_power(20, 0))
+	if(M.current.vampire_power(10, 0))
 		if (M.current.locked_to)
 			M.current.unlock_from()
 		spawn(0)
@@ -585,7 +585,7 @@
 			var/turf/T = get_turf(M.current)
 			T.turf_animation('icons/effects/effects.dmi',"shadowstep")
 			usr.forceMove(picked)
-		M.current.remove_vampire_blood(20)
+		M.current.remove_vampire_blood(10)
 		M.current.verbs -= /client/proc/vampire_shadowstep
 		sleep(20 SECONDS)
 		if(M && M.current)


### PR DESCRIPTION
Closes #17037
:cl:
* tweak: Vampire blood costs were adjusted. Bat Form and Shadowstep now actually spend blood and cost 20 and 10 usable blood respectively. Summon Bats costs 50 usable blood. 
* rscadd: Improved vamp rejuvenate now has a message telling you about the effect.
  