### PR TITLE
Atom density event fixes

### DIFF
--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -39,7 +39,7 @@
 	icon_closed = "bodybag_closed"
 	icon_opened = "bodybag_open"
 	density = 0
-
+	sound_file = 'sound/items/zip.ogg'
 
 /obj/structure/closet/body_bag/attackby(W as obj, mob/user as mob)
 	if(istype(W,/obj/item/stack/sheet/metal))
@@ -63,14 +63,6 @@
 	..()
 	src.overlays.len = 0
 
-
-/obj/structure/closet/body_bag/close()
-	if(..())
-		setDensity(FALSE)
-		return 1
-	return 0
-
-
 /obj/structure/closet/body_bag/MouseDrop(over_object, src_location, over_location)
 	..()
 	if((over_object == usr && (in_range(src, usr) || usr.contents.Find(src))))
@@ -91,6 +83,10 @@
 		icon_state = icon_closed
 	else
 		icon_state = icon_opened
+
+/obj/structure/closet/body_bag/relaymove(mob/user as mob)
+	if(user.stat || !isturf(src.loc))
+		return
 
 //Cryobag (statis bag) below, not currently functional it seems
 

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -84,10 +84,6 @@
 	else
 		icon_state = icon_opened
 
-/obj/structure/closet/body_bag/relaymove(mob/user as mob)
-	if(user.stat || !isturf(src.loc))
-		return
-
 //Cryobag (statis bag) below, not currently functional it seems
 
 /obj/item/bodybag/cryobag

--- a/code/game/objects/items/weapons/cash.dm
+++ b/code/game/objects/items/weapons/cash.dm
@@ -149,6 +149,7 @@ var/global/list/moneytypes = list(
 	for(var/i = 1 to rand(3,10))
 		var/typepath = pick(types)
 		new typepath(src)
+	..()
 
 /proc/dispense_cash(var/amount, var/loc)
 	for(var/cashtype in moneytypes)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -101,7 +101,7 @@
 	src.opened = 1
 	setDensity(FALSE)
 	src.dump_contents()
-	playsound(get_turf(src), sound_file, 15, 1, -3)
+	playsound(src, sound_file, 15, 1, -3)
 	return 1
 
 
@@ -172,7 +172,7 @@
 	src.icon_state = src.icon_closed
 	src.opened = 0
 	setDensity(initial(density))
-	playsound(get_turf(src), sound_file, 15, 1, -3)
+	playsound(src, sound_file, 15, 1, -3)
 	return 1
 
 /obj/structure/closet/proc/toggle()

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -19,6 +19,7 @@
 	var/storage_capacity = 30 //This is so that someone can't pack hundreds of items in a locker/crate
 							  //then open it in a populated area to crash clients.
 	var/breakout_time = 2 //2 minutes by default
+	var/sound_file = 'sound/machines/click.ogg'
 
 	starting_materials = list(MAT_IRON = 2*CC_PER_SHEET_METAL)
 	w_type = RECYK_METAL
@@ -96,16 +97,13 @@
 	if(!src.can_open())
 		return 0
 
-
 	src.icon_state = src.icon_opened
 	src.opened = 1
 	setDensity(FALSE)
 	src.dump_contents()
-	if(istype(src, /obj/structure/closet/body_bag))
-		playsound(get_turf(src), 'sound/items/zip.ogg', 15, 1, -3)
-	else
-		playsound(get_turf(src), 'sound/machines/click.ogg', 15, 1, -3)
+	playsound(get_turf(src), sound_file, 15, 1, -3)
 	return 1
+
 
 /obj/structure/closet/proc/insert(var/atom/movable/AM)
 
@@ -138,6 +136,7 @@
 		return 0
 
 	take_contents()
+
 	/* /vg/: Delete if there's no code in here we need.
 	var/itemcount = 0
 
@@ -172,11 +171,9 @@
 	*/
 	src.icon_state = src.icon_closed
 	src.opened = 0
-	if(istype(src, /obj/structure/closet/body_bag))
-		playsound(get_turf(src), 'sound/items/zip.ogg', 15, 1, -3)
-	else
-		playsound(get_turf(src), 'sound/machines/click.ogg', 15, 1, -3)
-	setDensity(TRUE)
+	setDensity(initial(density))
+	playsound(get_turf(src), sound_file, 15, 1, -3)
+	return 1
 
 /obj/structure/closet/proc/toggle()
 	if(src.opened)


### PR DESCRIPTION
- Bodybags
They were dense before, due to `setDensity(TRUE)` and all the events being called in the parent.
I use `playsound(get_turf(src), soundfile, ...)` because else it believe "soundfile" is a turf in the proc call.
Reported by anon(s) on the thread.

- Cash closets
They used to simply block the beam, not to receive damage from it, and when put out of the way, they would freeze the beam until it got updated by another atom crossing it.
The cause was not having `on_moved` events, which caused them to runtimes when crossed by a beam. I believe it was already here before.
