### PR TITLE
Makes everything smooth as a pomf's behind.

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -1326,8 +1326,9 @@ var/proccalls = 1
 //incorporeal_move values
 #define INCORPOREAL_DEACTIVATE	0
 #define INCORPOREAL_GHOST		1
-#define INCORPOREAL_NINJA		2
-#define INCORPOREAL_ETHEREAL	3
+#define INCORPOREAL_ETHEREAL	2
+#define GHOST_MOVEDELAY 1
+#define ETHEREAL_MOVEDELAY 2
 
 
 //MALFUNCTION FLAGS
@@ -1556,3 +1557,12 @@ var/proccalls = 1
 #define HUD_NONE 0
 #define HUD_MEDICAL 1
 #define HUD_SECURITY 2
+
+#define INERTIA_MOVEDELAY 5
+
+#define FRACTIONAL_GLIDESIZES 1
+#ifdef FRACTIONAL_GLIDESIZES
+#define DELAY2GLIDESIZE(delay) (WORLD_ICON_SIZE / max(Ceiling(delay / world.tick_lag), 1))
+#else
+#define DELAY2GLIDESIZE(delay) (Ceiling(WORLD_ICON_SIZE / max(Ceiling(delay / world.tick_lag), 1)))
+#endif

--- a/__DEFINES/subsystem.dm
+++ b/__DEFINES/subsystem.dm
@@ -42,6 +42,7 @@
 #define SS_PRIORITY_GARBAGE        2
 #define SS_PRIORITY_INACTIVITY     1
 
+#define SS_WAIT_FAST_MACHINERY 0.7 SECONDS //TODO move the rest of these to defines
 
 #define SS_DISPLAY_GARBAGE        -100
 #define SS_DISPLAY_AIR            -90

--- a/code/WorkInProgress/pomf/spacepods/spacepods.dm
+++ b/code/WorkInProgress/pomf/spacepods/spacepods.dm
@@ -460,11 +460,11 @@
 			return stop()
 		return
 
-/obj/spacepod/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0)
-	var/oldloc = src.loc
+/obj/spacepod/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
+	var/oldloc = loc
 	. = ..()
-	if(dir && (oldloc != NewLoc))
-		src.loc.Entered(src, oldloc)
+	if(Dir && (oldloc != NewLoc))
+		loc.Entered(src, oldloc)
 
 /obj/spacepod/Process_Spacemove(var/check_drift = 0, mob/user)
 	var/dense_object = 0

--- a/code/ZAS/Airflow.dm
+++ b/code/ZAS/Airflow.dm
@@ -134,7 +134,7 @@ atom/movable/GotoAirflowDest(n)
 /atom/movable/var/tmp/airflow_time = 0
 /atom/movable/var/tmp/last_airflow = 0
 
-/atom/movable/proc/GotoAirflowDest(n)
+/atom/movable/proc/GotoAirflowDest(n) //TODO GLIDESIZE HERE
 	if(!airflow_dest || pulledby)
 		return
 	if(world.time < last_airflow + zas_settings.Get(/datum/ZAS_Setting/airflow_delay))

--- a/code/ZAS/Airflow.dm
+++ b/code/ZAS/Airflow.dm
@@ -173,15 +173,17 @@ atom/movable/GotoAirflowDest(n)
 		while(airflow_speed > 0 && Process_Spacemove(1))
 			airflow_speed = min(airflow_speed,15)
 			airflow_speed -= zas_settings.Get(/datum/ZAS_Setting/airflow_speed_decay)
+			var/sleep_time
 			if(airflow_speed > 7)
 				if(airflow_time++ >= airflow_speed - 7)
 					if(od)
 						setDensity(FALSE)
-					sleep(tick_multiplier)
+					sleep_time = tick_multiplier
 			else
 				if(od)
 					setDensity(FALSE)
-				sleep(max(1,10-(airflow_speed+3)) * tick_multiplier)
+				sleep_time = max(1,10-(airflow_speed+3)) * tick_multiplier
+			sleep(sleep_time)
 			if(od)
 				setDensity(TRUE)
 			if ((!( src.airflow_dest ) || src.loc == src.airflow_dest))
@@ -190,6 +192,7 @@ atom/movable/GotoAirflowDest(n)
 				break
 			if(!isturf(loc))
 				break
+			set_glide_size(DELAY2GLIDESIZE(sleep_time))
 			step_towards(src, src.airflow_dest)
 			var/mob/M = src
 			if(istype(M) && M.client)

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -53,8 +53,9 @@
 		A.attack_stump(src, params)
 
 	if(src.lying && !(isUnconscious() || stunned || paralysis) && check_crawl_ability() && isfloor(A) && isfloor(get_turf(src)) && proximity && !pulledby && !locked_to && !client.move_delayer.blocked())
-		Move(A, get_dir(src,A))
-		delayNextMove(movement_delay()*3,additive=1)
+		var/crawldelay = movement_delay()*3
+		Move(A, get_dir(src,A), glide_size_override = crawldelay)
+		delayNextMove(crawldelay,additive=1)
 
 /atom/proc/attack_hand(mob/user as mob, params, var/proximity)
 	return

--- a/code/controllers/subsystem/fast_machinery.dm
+++ b/code/controllers/subsystem/fast_machinery.dm
@@ -5,7 +5,7 @@ var/list/fast_machines = list()
 
 /datum/subsystem/machinery/fast
 	name          = "Fast Machinery"
-	wait          = 0.7 SECONDS
+	wait          = SS_WAIT_FAST_MACHINERY
 	priority      = SS_PRIORITY_FAST_MACHINERY
 	display_order = SS_DISPLAY_FAST_MACHINERY
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -195,8 +195,6 @@
 
 	if(glide_size_override > 0)
 		set_glide_size(glide_size_override)
-	else
-		set_glide_size(get_glide_size())
 
 	var/atom/oldloc = loc
 	if((bound_height != WORLD_ICON_SIZE || bound_width != WORLD_ICON_SIZE) && (loc == NewLoc))

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -142,19 +142,8 @@
 
 	..()
 
-/atom/movable/proc/get_move_delay()
-	return max(5 * world.tick_lag, 1)
-
-/mob/get_move_delay()
-	if(client)
-		return world.tick_lag*(3+(client.move_delayer.next_allowed - world.time))
-	return ..()
-
-/atom/movable/proc/get_glide_size()
-	return Ceiling(WORLD_ICON_SIZE / get_move_delay() * world.tick_lag) - 1
-
+//TODO move this somewhere else
 /atom/movable/proc/set_glide_size(glide_size_override = 0)
-	if(src.name == "TEST") to_chat(world, "We're [src], setting glide size. Old: [glide_size]. New: Ceil([WORLD_ICON_SIZE]/[get_move_delay()]*[world.tick_lag])-1 = [Ceiling(WORLD_ICON_SIZE / get_move_delay() * world.tick_lag) - 1]. Override: [glide_size_override]")
 	glide_size = glide_size_override
 
 /atom/movable/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
@@ -569,7 +558,7 @@
 					. = 0
 					break
 
-				src.Move(step, dy)
+				src.Move(step, dy, glide_size_override = DELAY2GLIDESIZE(fly_speed))
 				. = hit_check(speed, user)
 				error += dist_x
 				dist_travelled++
@@ -583,7 +572,7 @@
 					. = 0
 					break
 
-				src.Move(step, dx)
+				src.Move(step, dx, glide_size_override = DELAY2GLIDESIZE(fly_speed))
 				. = hit_check(speed, user)
 				error -= dist_y
 				dist_travelled++
@@ -605,7 +594,7 @@
 					. = 0
 					break
 
-				src.Move(step, dx)
+				src.Move(step, dx, glide_size_override = DELAY2GLIDESIZE(fly_speed))
 				. = hit_check(speed, user)
 				error += dist_y
 				dist_travelled++
@@ -619,7 +608,7 @@
 					. = 0
 					break
 
-				src.Move(step, dy)
+				src.Move(step, dy, glide_size_override = DELAY2GLIDESIZE(fly_speed))
 				. = hit_check(speed, user)
 				error -= dist_x
 				dist_travelled++
@@ -759,12 +748,13 @@
 		inertia_dir  = 0
 		return
 
-	sleep(5)
+	sleep(INERTIA_MOVEDELAY)
 
 	if(can_apply_inertia() && (src.loc == start))
 		if(!inertia_dir)
 			return //inertia_dir = last_move
 
+		set_glide_size(DELAY2GLIDESIZE(INERTIA_MOVEDELAY))
 		step(src, inertia_dir)
 
 /atom/movable/proc/reset_inertia()

--- a/code/game/gamemodes/blob/overmind.dm
+++ b/code/game/gamemodes/blob/overmind.dm
@@ -220,7 +220,7 @@
 		stat(null, "Total Overminds: [blob_cores.len]")
 	return
 
-/mob/camera/blob/Move(var/NewLoc, var/Dir = 0)
+/mob/camera/blob/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	var/obj/effect/blob/B = locate() in range("3x3", NewLoc)
 	if(B)
 		forceEnter(B.loc)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -391,7 +391,7 @@ var/list/all_doors = list()
 		else
 			source.thermal_conductivity = initial(source.thermal_conductivity)
 
-/obj/machinery/door/Move(new_loc, new_dir)
+/obj/machinery/door/Move()
 	update_nearby_tiles()
 	. = ..()
 	if(width > 1)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -358,6 +358,7 @@
 	return 1
 
 /obj/mecha/proc/mechstep(direction)
+	set_glide_size(DELAY2GLIDESIZE(step_in))
 	var/result = step(src,direction)
 	if(result)
 	 playsound(src, get_sfx("mechstep"),40,1)
@@ -365,6 +366,7 @@
 
 
 /obj/mecha/proc/mechsteprand()
+	set_glide_size(DELAY2GLIDESIZE(step_in))
 	var/result = step_rand(src)
 	if(result)
 	 playsound(src, get_sfx("mechstep"),40,1)

--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -388,7 +388,6 @@
 	if(istype(target,/atom/movable))
 		var/atom/movable/locker = target
 		locker.lock_atom(src, /datum/locking_category/acid)
-		glide_size = locker.glide_size
 
 	if(isturf(target)) // Turf take twice as long to take down.
 		target_strength = 8

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -42,7 +42,7 @@ would spawn and follow the beaker, even if it is carried or thrown.
 
 	..()
 
-/obj/effect/effect/water/Move(NewLoc,Dir=0,step_x=0,step_y=0)
+/obj/effect/effect/water/Move()
 	//var/turf/T = src.loc
 	//if (istype(T, /turf))
 	//	T.firelevel = 0 //TODO: FIX

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -160,6 +160,7 @@
 				var/obj/B = user.locked_to
 				var/movementdirection = turn(direction,180)
 				for(var/i in list(1,1,1,1,2,2,3,3,3))
+					B.set_glide_size(DELAY2GLIDESIZE(i))
 					if(!step(B, movementdirection))
 						B.change_dir(turn(movementdirection, 180)) //don't turn around when hitting a wall
 						break
@@ -249,6 +250,7 @@
 				var/obj/B = user.locked_to
 				var/movementdirection = turn(direction,180)
 				for(var/i in list(1,1,1,1,2,2,3,3,3))
+					B.set_glide_size(DELAY2GLIDESIZE(i))
 					if(!step(B, movementdirection))
 						B.change_dir(turn(movementdirection, 180)) //don't turn around when hitting a wall
 						break

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -595,6 +595,7 @@ a {
 			else
 				user.visible_message("<span class='warning'>[user] kicks \himself away from \the [A].</span>", "<span class='notice'>You kick yourself away from \the [A]. Wee!</span>")
 				for(var/i in list(2,2,3,3))
+					set_glide_size(DELAY2GLIDESIZE(i))
 					if(!step(src, movementdirection))
 						change_dir(turn(movementdirection, 180)) //stop, but don't turn around when hitting a wall
 						break

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -304,13 +304,17 @@
 
 	//forwards, scoot slow
 	if(direction == dir)
+		var/scootdelay = user.movement_delay()*6
+		set_glide_size(DELAY2GLIDESIZE(scootdelay))
 		step(src, direction)
-		user.delayNextMove(user.movement_delay()*6)
+		user.delayNextMove(scootdelay)
 	//backwards, scoot fast
 	else if(direction == turn(dir, 180))
+		var/scootdelay = user.movement_delay()*3
+		set_glide_size(DELAY2GLIDESIZE(scootdelay))
 		step(src, direction)
 		change_dir(turn(direction, 180)) //face away from where we're going
-		user.delayNextMove(user.movement_delay()*3)
+		user.delayNextMove(scootdelay)
 	//sideways, swivel to face
 	else
 		change_dir(direction)

--- a/code/game/objects/structures/vehicles/vehicle.dm
+++ b/code/game/objects/structures/vehicles/vehicle.dm
@@ -38,7 +38,7 @@
 
 	var/vin=null
 	var/datum/delay_controller/move_delayer = new(1, ARBITRARILY_LARGE_NUMBER) //See setup.dm, 12
-	var/movement_delay = 0 //Speed of the vehicle decreases as this value increases. Anything above 6 is slow, 1 is fast and 0 is very fast
+	var/movement_delay = 1 //Speed of the vehicle decreases as this value increases. Do NOT set to 0 holy shit.
 
 	var/obj/machinery/cart/next_cart = null
 	var/can_have_carts = TRUE
@@ -139,8 +139,10 @@
 			tether_datum.snap = 1
 			tether_datum.Delete_Chain()
 
+	var/movedelay = getMovementDelay()
+	set_glide_size(DELAY2GLIDESIZE(movedelay))
 	step(src, direction)
-	delayNextMove(getMovementDelay())
+	delayNextMove(movedelay)
 
 	if(T != loc)
 		user.handle_hookchain(direction)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -610,7 +610,7 @@ var/list/one_way_windows
 		for(var/obj/structure/window/W in get_step(T,direction))
 			W.update_icon()
 
-/obj/structure/window/forceMove(var/atom/A)
+/obj/structure/window/forceMove()
 	var/turf/T = loc
 	..()
 	update_nearby_icons(T)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -981,9 +981,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	speed = text2num(copytext(speed,1,4))/100
 	movespeed = 1/speed
 
-/mob/dead/observer/get_move_delay()
-	return world.tick_lag*(3+movespeed)
-
 /datum/locking_category/observer
 
 /mob/dead/observer/deafmute/say(var/message)	//A ghost without access to ghostchat. An IC ghost, if you will.

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -435,7 +435,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 /mob/dead/observer/verb/toggle_secHUD()
 	set category = "Ghost"
 	set name = "Toggle SecHUD"
-	
+
 	if(!client)
 		return
 	if(selectedHUD == HUD_SECURITY)
@@ -980,6 +980,9 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		return
 	speed = text2num(copytext(speed,1,4))/100
 	movespeed = 1/speed
+
+/mob/dead/observer/get_move_delay()
+	return world.tick_lag*(3+movespeed)
 
 /datum/locking_category/observer
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -19,7 +19,7 @@
 	if(!istype(AM, /mob/living/carbon))
 		handle_symptom_on_touch(AM, src, BUMP)
 
-/mob/living/carbon/Move(NewLoc,Dir=0,step_x=0,step_y=0)
+/mob/living/carbon/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	. = ..()
 
 	if(.)

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -127,10 +127,10 @@
 	prob_slip = round(prob_slip)
 	return(prob_slip)
 
-/mob/living/carbon/human/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0)
+/mob/living/carbon/human/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	var/old_z = src.z
 
-	. = ..(NewLoc, Dir, step_x, step_y)
+	. = ..()
 
 	/*if(status_flags & FAKEDEATH)
 		return 0*/

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1309,7 +1309,7 @@ Thanks.
 			if((tmob.a_intent == I_HELP || tmob.restrained()) && (a_intent == I_HELP || src.restrained()) && tmob.canmove && canmove && !dense && can_move_mob(tmob, 1, 0)) // mutual brohugs all around!
 				var/turf/oldloc = loc
 				forceMove(tmob.loc)
-				tmob.forceMove(oldloc)
+				tmob.forceMove(oldloc, glide_size_override = src.glide_size)
 				now_pushing = 0
 				for(var/mob/living/carbon/slime/slime in view(1,tmob))
 					if(slime.Victim == tmob)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -655,13 +655,13 @@ Thanks.
 
 	return
 
-/mob/living/Move(atom/newloc, direct,Dir=0,step_x=0,step_y=0)
-	if (locked_to && locked_to.loc != newloc)
+/mob/living/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
+	if (locked_to && locked_to.loc != NewLoc)
 		var/datum/locking_category/category = locked_to.get_lock_cat_for(src)
 		if (locked_to.anchored || category.flags & CANT_BE_MOVED_BY_LOCKED_MOBS)
 			return 0
 		else
-			return locked_to.Move(newloc, direct)
+			return locked_to.Move(NewLoc, Dir)
 
 	if (restrained())
 		stop_pulling()
@@ -717,7 +717,7 @@ Thanks.
 						if (ok)
 							var/atom/movable/secondarypull = M.pulling
 							M.stop_pulling()
-							pulling.Move(T, get_dir(pulling, T))
+							pulling.Move(T, get_dir(pulling, T), glide_size_override = src.glide_size)
 							if(M && secondarypull)
 								M.start_pulling(secondarypull)
 
@@ -762,7 +762,7 @@ Thanks.
 													add_logs(src, HM, "caused drag damage bloodloss to", admin = (HM.ckey))
 					else
 						if (pulling)
-							pulling.Move(T, get_dir(pulling, T))
+							pulling.Move(T, get_dir(pulling, T), glide_size_override = src.glide_size)
 				else
 					stop_pulling()
 	else
@@ -777,14 +777,14 @@ Thanks.
 			M.UpdateFeed(src)
 
 	if(T != loc)
-		handle_hookchain(direct)
+		handle_hookchain(Dir)
 
 	if(.)
 		for(var/obj/item/weapon/gun/G in targeted_by) //Handle moving out of the gunner's view.
 			var/mob/living/M = G.loc
 			if(!(M in view(src)))
 				NotTargeted(G)
-		for(var/obj/item/weapon/gun/G in src) //Handle the gunner loosing sight of their target/s
+		for(var/obj/item/weapon/gun/G in src) //Handle the gunner losing sight of their target/s
 			if(G.target)
 				for(var/mob/living/M in G.target)
 					if(M && !(M in view(src)))

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -10,6 +10,7 @@
 	var/list/visibleCameraChunks = list()
 	var/mob/living/silicon/ai/ai = null
 	var/high_res = 0
+	glide_size = WORLD_ICON_SIZE //AI eyes are hyperspeed, who knows
 	flags = HEAR_ALWAYS | TIMELESS
 
 // Use this when setting the aiEye's location.

--- a/code/modules/mob/living/silicon/mommi/mommi.dm
+++ b/code/modules/mob/living/silicon/mommi/mommi.dm
@@ -449,10 +449,6 @@ They can only use one tool at a time, they can't choose modules, and they have 1
 /mob/living/silicon/robot/mommi/radio_menu()
 	radio.interact(src)//Just use the radio's Topic() instead of bullshit special-snowflake code
 
-
-/mob/living/silicon/robot/mommi/Move(a, b, flag)
-	..()
-
 /mob/living/silicon/robot/mommi/CheckSlip()
 	return -1
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1411,7 +1411,7 @@
 	radio.interact(src)//Just use the radio's Topic() instead of bullshit special-snowflake code
 
 
-/mob/living/silicon/robot/Move(a, b, flag)
+/mob/living/silicon/robot/Move()
 
 	. = ..()
 

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/cluwne.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/cluwne.dm
@@ -303,8 +303,8 @@
 	msg = "<B>[src]</B> [msg]"
 	return ..(msg)
 
-/mob/living/simple_animal/hostile/retaliate/cluwne/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0)
-	. = ..(NewLoc, Dir, step_x, step_y)
+/mob/living/simple_animal/hostile/retaliate/cluwne/Move()
+	. = ..()
 
 	if(.)
 		if(m_intent == "run")

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -345,6 +345,7 @@
 
 		mob.delayNextMove(move_delay)
 		mob.last_move_intent = world.time + 10
+		mob.set_glide_size(mob.get_glide_size()) //Since we're moving OUT OF OUR OWN VOLITION AND BY OURSELVES we can update our glide_size here!
 
 		// Something with pulling things
 		var/obj/item/weapon/grab/Findgrab = locate() in src
@@ -427,6 +428,8 @@
 ///Allows mobs to run though walls
 /client/proc/Process_Incorpmove(direct)
 	var/turf/mobloc = get_turf(mob)
+
+	mob.set_glide_size(mob.get_glide_size()) //Since we're moving OUT OF OUR OWN VOLITION AND BY OURSELVES we can update our glide_size here!
 
 	switch(mob.incorporeal_move)
 		if(INCORPOREAL_GHOST)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -345,7 +345,7 @@
 
 		mob.delayNextMove(move_delay)
 		mob.last_move_intent = world.time + 10
-		mob.set_glide_size(mob.get_glide_size()) //Since we're moving OUT OF OUR OWN VOLITION AND BY OURSELVES we can update our glide_size here!
+		mob.set_glide_size(DELAY2GLIDESIZE(move_delay)) //Since we're moving OUT OF OUR OWN VOLITION AND BY OURSELVES we can update our glide_size here!
 
 		// Something with pulling things
 		var/obj/item/weapon/grab/Findgrab = locate() in src
@@ -427,16 +427,17 @@
 ///Called by client/Move()
 ///Allows mobs to run though walls
 /client/proc/Process_Incorpmove(direct)
-	var/turf/mobloc = get_turf(mob)
-
-	mob.set_glide_size(mob.get_glide_size()) //Since we're moving OUT OF OUR OWN VOLITION AND BY OURSELVES we can update our glide_size here!
-
 	switch(mob.incorporeal_move)
 		if(INCORPOREAL_GHOST)
 			if(isobserver(mob)) //Typecast time
 				var/mob/dead/observer/observer = mob
 				if(observer.locked_to) //Ghosts can move at any time to unlock themselves (in theory from following a mob)
 					observer.manual_stop_follow(observer.locked_to)
+			var/movedelay = GHOST_MOVEDELAY
+			if(isobserver(mob))
+				var/mob/dead/observer/observer = mob
+				movedelay = observer.movespeed
+			mob.set_glide_size(DELAY2GLIDESIZE(movedelay))
 			var/turf/T = get_step(mob, direct)
 			var/area/A = get_area(T)
 			if(A && A.anti_ethereal && !isAdminGhost(mob))
@@ -447,52 +448,10 @@
 				else
 					mob.forceEnter(get_step(mob, direct))
 					mob.dir = direct
-			if(isobserver(mob))
-				var/mob/dead/observer/observer = mob
-				mob.delayNextMove(observer.movespeed)
-			else
-				mob.delayNextMove(1)
-		if(INCORPOREAL_NINJA)
-			if(prob(50))
-				var/locx
-				var/locy
-				switch(direct)
-					if(NORTH)
-						locx = mobloc.x
-						locy = (mobloc.y+2)
-						if(locy>world.maxy)
-							return
-					if(SOUTH)
-						locx = mobloc.x
-						locy = (mobloc.y-2)
-						if(locy<1)
-							return
-					if(EAST)
-						locy = mobloc.y
-						locx = (mobloc.x+2)
-						if(locx>world.maxx)
-							return
-					if(WEST)
-						locy = mobloc.y
-						locx = (mobloc.x-2)
-						if(locx<1)
-							return
-					else
-						return
-				mob.forceMove(locate(locx,locy,mobloc.z))
-				spawn(0)
-					var/limit = 2//For only two trailing shadows.
-					for(var/turf/T in getline(mobloc, mob.loc))
-						anim(T,mob,'icons/mob/mob.dmi',,"shadow",,mob.dir)
-						limit--
-						if(limit<=0)
-							break
-			else
-				anim(mobloc,mob,'icons/mob/mob.dmi',,"shadow",,mob.dir)
-				mob.forceEnter(get_step(mob, direct))
-			mob.dir = direct
-			mob.delayNextMove(1)
+			mob.delayNextMove(movedelay)
 		if(INCORPOREAL_ETHEREAL) //Jaunting, without needing to be done through relaymove
+			var/movedelay = ETHEREAL_MOVEDELAY
+			mob.set_glide_size(DELAY2GLIDESIZE(movedelay))
 			var/turf/newLoc = get_step(mob,direct)
 			if(!(newLoc.turf_flags & NOJAUNT))
 				mob.forceEnter(newLoc)
@@ -500,7 +459,7 @@
 			else
 				to_chat(mob, "<span class='warning'>Some strange aura is blocking the way!</span>")
 			INVOKE_EVENT(mob.on_moved,list("dir"=direct))
-			mob.delayNextMove(2)
+			mob.delayNextMove(movedelay)
 			return 1
 	// Crossed is always a bit iffy
 	for(var/obj/S in mob.loc)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -497,7 +497,7 @@ Round Duration: [round(hours)]h [round(mins)]m<br>"}
 
 	src << browse(dat, "window=manifest;size=370x420;can_close=1")
 
-/mob/new_player/Move(NewLoc,Dir=0,step_x=0,step_y=0)
+/mob/new_player/Move()
 	return 0
 
 

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -642,7 +642,7 @@
 /obj/machinery/singularity/acidable()
 	return 0
 
-/obj/machinery/singularity/Move(newLoc, movedir)
+/obj/machinery/singularity/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	if(timestopped)
 		return 0
-	return forceMove(get_step(src,movedir))
+	return forceMove(get_step(src,Dir))

--- a/code/modules/projectiles/guns/hookshot.dm
+++ b/code/modules/projectiles/guns/hookshot.dm
@@ -372,7 +372,7 @@
 		else if(A == extremity_B)
 			return extremity_A.attempt_to_follow(src, A.loc)
 
-/obj/effect/overlay/chain/Move(newLoc,Dir=0,step_x=0,step_y=0)//for when someone pulls a part the chain.
+/obj/effect/overlay/chain/Move()//for when someone pulls a part the chain.
 	var/turf/T = loc
 	if(..())
 		var/obj/effect/overlay/chain/CA = extremity_A

--- a/code/modules/recycling/compactor.dm
+++ b/code/modules/recycling/compactor.dm
@@ -108,7 +108,7 @@
 		return
 	..()
 
-/obj/machinery/disposal/compactor/Move(atom/newloc, direct)
+/obj/machinery/disposal/compactor/Move()
 	..()
 	if(prob(2))
 		var/atom/movable/AM = pick(contents)

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -242,6 +242,7 @@
 		for(var/atom/movable/A in affecting)
 			if(!A.anchored)
 				if(A.loc == src.loc) // prevents the object from being affected if it's not currently here.
+					A.set_glide_size(DELAY2GLIDESIZE(SS_WAIT_FAST_MACHINERY))
 					step(A,movedir)
 					items_moved++
 			if(items_moved >= max_moved)

--- a/code/unused/hivebot/hivebot.dm
+++ b/code/unused/hivebot/hivebot.dm
@@ -421,7 +421,7 @@ Frequency:
 	return
 
 
-/mob/living/silicon/hivebot/Move(a, b, flag)
+/mob/living/silicon/hivebot/Move()
 
 	if (src.buckled)
 		return


### PR DESCRIPTION
This is something that needs to be experienced first-hand to fully understand it.
I also couldn't add a new argument to step() since it's a BYOND proc, so I'm just setting the glide_size before every step().

https://a.uguu.se/Y7JuBWYR6zst_2018-01-08_21-47-40.mp4
https://user-images.githubusercontent.com/33260604/34704533-711ae136-f4d8-11e7-8eb7-0a723ddfe9aa.gif


:cl:
 * rscadd: Properly implemented glide_size on a lot of things. This means, for example, dragging a corpse won't make it look like it's teleporting everywhere, ghosts won't rollerskate in the air after haunting a slow person, plus smooth conveyor belts, smooth space inertia, and other things. If you still notice old no-glidesize behavior of stuff teleporting around, make a bug report.
  
  
  