### PR TITLE
fixes both the multitool and the crowbar not updating conveyor destination direction

### DIFF
--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -129,6 +129,7 @@
 	dir = newdirection
 	update_nearby_conveyors() //Try to resmooth with nearby diagonals
 	updateConfig()
+	setmove()
 
 /obj/machinery/conveyor/proc/copy_radio_from_neighbors()
 	var/obj/machinery/conveyor_switch/lever = locate() in orange(src,1)


### PR DESCRIPTION
continuation of #17048 

17048 updated the forwards and backwards, this actually updates the direction it sends you.