### PR TITLE
fixes things not pulling/moving properly 

### DIFF
--- a/code/ATMOSPHERICS/pipe/construction.dm
+++ b/code/ATMOSPHERICS/pipe/construction.dm
@@ -322,7 +322,7 @@ var/list/manifold_pipes = list(PIPE_MANIFOLD4W, PIPE_INSUL_MANIFOLD4W, PIPE_HE_M
 	//src.pipe_dir = get_pipe_dir()
 	return
 
-/obj/item/pipe/Move()
+/obj/item/pipe/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	..()
 	if ((pipe_type in bent_pipes) \
 		&& (src.dir in cardinal))

--- a/code/WorkInProgress/explosion_particles.dm
+++ b/code/WorkInProgress/explosion_particles.dm
@@ -12,7 +12,7 @@
 		qdel(src)
 	return
 
-/obj/effect/expl_particles/Move()
+/obj/effect/expl_particles/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	..()
 	return
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -146,7 +146,7 @@
 /atom/movable/proc/set_glide_size(glide_size_override = 0)
 	glide_size = glide_size_override
 
-/atom/movable/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
+/atom/movable/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, var/glide_size_override = 0)
 	if(!loc || !NewLoc)
 		return 0
 

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -391,7 +391,7 @@ var/list/all_doors = list()
 		else
 			source.thermal_conductivity = initial(source.thermal_conductivity)
 
-/obj/machinery/door/Move()
+/obj/machinery/door/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	update_nearby_tiles()
 	. = ..()
 	if(width > 1)

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -411,7 +411,7 @@ obj/machinery/teleport/station/New()
 	src.range--
 	return
 
-/obj/effect/laser/Move()
+/obj/effect/laser/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	src.range--
 	return
 

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -288,7 +288,7 @@
 ////////  Movement procs  ////////
 //////////////////////////////////
 
-/obj/mecha/Move()
+/obj/mecha/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	. = ..()
 	if(.)
 		events.fireEvent("onMove",get_turf(src))

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -42,7 +42,7 @@ would spawn and follow the beaker, even if it is carried or thrown.
 
 	..()
 
-/obj/effect/effect/water/Move()
+/obj/effect/effect/water/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	//var/turf/T = src.loc
 	//if (istype(T, /turf))
 	//	T.firelevel = 0 //TODO: FIX
@@ -172,7 +172,7 @@ steam.start() -- spawns the effect
 
 	..()
 
-/obj/effect/effect/sparks/Move()
+/obj/effect/effect/sparks/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	..()
 	var/turf/T = src.loc
 	if (istype(T, /turf))
@@ -272,7 +272,7 @@ steam.start() -- spawns the effect
 /obj/effect/effect/smoke/bad
 	time_to_live = 200
 
-/obj/effect/effect/smoke/bad/Move()
+/obj/effect/effect/smoke/bad/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	..()
 	for(var/mob/living/carbon/M in get_turf(src))
 		affect(M)
@@ -301,7 +301,7 @@ steam.start() -- spawns the effect
 
 /obj/effect/effect/smoke/sleepy
 
-/obj/effect/effect/smoke/sleepy/Move()
+/obj/effect/effect/smoke/sleepy/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	..()
 	for(var/mob/living/carbon/M in get_turf(src))
 		affect(M)
@@ -326,7 +326,7 @@ steam.start() -- spawns the effect
 	name = "mustard gas"
 	icon_state = "mustard"
 
-/obj/effect/effect/smoke/mustard/Move()
+/obj/effect/effect/smoke/mustard/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	..()
 	for(var/mob/living/carbon/human/R in get_turf(src))
 		affect(R)
@@ -416,7 +416,7 @@ steam.start() -- spawns the effect
 	. = ..()
 	create_reagents(500)
 
-/obj/effect/effect/smoke/chem/Move()
+/obj/effect/effect/smoke/chem/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	..()
 	for(var/atom/A in view(2, src))
 		if(reagents.has_reagent(RADIUM)||reagents.has_reagent(URANIUM)||reagents.has_reagent(CARBON)||reagents.has_reagent(THERMITE)||reagents.has_reagent(BLEACH))//Prevents unholy radium spam by reducing the number of 'greenglows' down to something reasonable -Sieve

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -133,7 +133,7 @@
 		bound_height = width * WORLD_ICON_SIZE
 	..()
 
-/obj/structure/door_assembly/multi_tile/Move()
+/obj/structure/door_assembly/multi_tile/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	. = ..()
 	if(dir in list(EAST, WEST))
 		bound_width = width * WORLD_ICON_SIZE

--- a/code/game/objects/structures/vehicles/adminbus.dm
+++ b/code/game/objects/structures/vehicles/adminbus.dm
@@ -146,7 +146,7 @@
 							L.pixel_y = 4 * PIXEL_MULTIPLIER
 			L.dir = dir
 
-/obj/structure/bed/chair/vehicle/adminbus/Move()
+/obj/structure/bed/chair/vehicle/adminbus/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	var/turf/T = get_turf(src)
 	..()
 	update_lightsource()

--- a/code/game/objects/structures/vehicles/carts/cart.dm
+++ b/code/game/objects/structures/vehicles/carts/cart.dm
@@ -33,7 +33,7 @@
 			to_chat(user, "\The [src] already has a cart connected to it!", "red")
 			return
 
-/obj/machinery/cart/Move()
+/obj/machinery/cart/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	var/oldloc = src.loc
 	..()
 	if (src.loc == oldloc)

--- a/code/game/objects/structures/vehicles/carts/mining_cart.dm
+++ b/code/game/objects/structures/vehicles/carts/mining_cart.dm
@@ -3,7 +3,7 @@
 	icon = 'icons/obj/vehicles.dmi'
 	icon_state = "mining_cart"
 
-/*/obj/cart/mining_cart/Move()
+/*/obj/cart/mining_cart/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
   ..()
   for(var/obj in loc)
 

--- a/code/game/objects/structures/vehicles/janicart.dm
+++ b/code/game/objects/structures/vehicles/janicart.dm
@@ -103,7 +103,7 @@
 		return
 	..()
 
-/obj/structure/bed/chair/vehicle/janicart/Move()
+/obj/structure/bed/chair/vehicle/janicart/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	..()
 	if(upgraded)
 		var/turf/tile = loc

--- a/code/game/objects/structures/vehicles/vehicle.dm
+++ b/code/game/objects/structures/vehicles/vehicle.dm
@@ -342,7 +342,7 @@
 
 	update_mob()
 
-/obj/structure/bed/chair/vehicle/Move()
+/obj/structure/bed/chair/vehicle/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	var/oldloc = loc
 	..()
 	if (loc == oldloc)

--- a/code/game/objects/structures/vehicles/wheelchair.dm
+++ b/code/game/objects/structures/vehicles/wheelchair.dm
@@ -214,7 +214,7 @@
 	else
 		to_chat(user, "<span class='warning'>The 'check battery' light is blinking.</span>")
 
-/obj/structure/bed/chair/vehicle/wheelchair/motorized/Move()
+/obj/structure/bed/chair/vehicle/wheelchair/motorized/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	..()
 	if(internal_battery)
 		internal_battery.use(2) //Example use: 100 charge to get from the cargo desk to medbay side entrance

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -573,7 +573,7 @@ var/list/one_way_windows
 	if(reinforced)
 		new /obj/item/stack/rods(loc, sheetamount)
 
-/obj/structure/window/Move()
+/obj/structure/window/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 
 	update_nearby_tiles()
 	..()

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -34,7 +34,7 @@ var/intercom_range_display_status = 0
 	icon = 'icons/turf/areas.dmi'
 	icon_state = "yellow"
 
-/obj/effect/debugging/marker/Move()
+/obj/effect/debugging/marker/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	return 0
 
 /client/proc/do_not_use_these()

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -139,7 +139,7 @@
 			var/obj/item/S = special_assembly
 			S.on_found(finder)
 
-/obj/item/device/assembly_holder/Move()
+/obj/item/device/assembly_holder/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	..()
 	if(a_left && a_right)
 		a_left.holder_movement()

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -95,7 +95,7 @@
 	return
 
 
-/obj/item/device/assembly/infra/Move()
+/obj/item/device/assembly/infra/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	var/t = dir
 	..()
 	dir = t

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -126,7 +126,7 @@
 		grenade.primed(scanning)
 	return
 
-/obj/item/device/assembly/prox_sensor/Move()
+/obj/item/device/assembly/prox_sensor/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	..()
 	sense()
 	return

--- a/code/modules/liquid/splash_simulation.dm
+++ b/code/modules/liquid/splash_simulation.dm
@@ -138,7 +138,7 @@ obj/effect/liquid/proc/apply_calculated_effect()
 	new_volume = 0
 	update_icon2()
 
-obj/effect/liquid/Move()
+obj/effect/liquid/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	return 0
 
 obj/effect/liquid/Destroy()

--- a/code/modules/media/machinery.dm
+++ b/code/modules/media/machinery.dm
@@ -87,7 +87,7 @@
 			M.update_music()
 	master_area=null
 
-/obj/machinery/media/Move()
+/obj/machinery/media/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	..()
 	if(anchored)
 		update_music()

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -36,7 +36,7 @@
 			var/obj/machinery/hologram/holopad/H = ai.current
 			H.move_hologram()
 
-/mob/camera/aiEye/Move()
+/mob/camera/aiEye/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	return 0
 
 /mob/camera/aiEye/on_see(var/message, var/blind_message, var/drugged_message, var/blind_drugged_message, atom/A) //proc for eye seeing visible messages from atom A, only possible with the high_res camera module

--- a/code/modules/mob/living/silicon/ai/freelook/update_triggers.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/update_triggers.dm
@@ -62,7 +62,7 @@
 // This might be laggy, comment it out if there are problems.
 /mob/living/silicon/robot/var/updating = 0
 
-/mob/living/silicon/robot/Move()
+/mob/living/silicon/robot/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	var/oldLoc = src.loc
 	var/oldZ = src.loc.z
 	. = ..()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1411,7 +1411,7 @@
 	radio.interact(src)//Just use the radio's Topic() instead of bullshit special-snowflake code
 
 
-/mob/living/silicon/robot/Move()
+/mob/living/silicon/robot/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 
 	. = ..()
 

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -66,7 +66,7 @@
 		..()
 		src.visible_message("<span class='warning'>[src] gets an evil-looking gleam in \his eye.</span>")
 
-/mob/living/simple_animal/hostile/retaliate/goat/Move()
+/mob/living/simple_animal/hostile/retaliate/goat/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	..()
 	if(!stat)
 		if(locate(/obj/effect/plantsegment) in loc)

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -138,7 +138,7 @@
 
 		nutrition = max(0, nutrition - STANDCOST)
 
-/mob/living/simple_animal/mouse/Move()
+/mob/living/simple_animal/mouse/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	..()
 	var/multiplier = 1
 	if(nutrition >= MOUSEFAT) //Fat mice lose nutrition faster through movement

--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -75,7 +75,7 @@
 	melee_damage_lower=10
 	melee_damage_upper=40
 
-/mob/living/simple_animal/hostile/bear/Move()
+/mob/living/simple_animal/hostile/bear/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	..()
 	if(stat != DEAD)
 		if(loc && istype(loc,/turf/space))

--- a/code/modules/mob/living/simple_animal/hostile/frog.dm
+++ b/code/modules/mob/living/simple_animal/hostile/frog.dm
@@ -88,7 +88,7 @@
 		S.forceMove(src)
 		update_spear()
 
-/mob/living/simple_animal/hostile/frog/Move()
+/mob/living/simple_animal/hostile/frog/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	..()
 
 	if(!isDead() && isturf(loc) && !locked_to && !throwing)

--- a/code/modules/mob/living/simple_animal/hostile/hive_aliens.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hive_aliens.dm
@@ -141,7 +141,7 @@
 		qdel(summoned_spikes)
 		summoned_spikes = null
 
-/mob/living/simple_animal/hostile/hive_alien/constructor/Move()
+/mob/living/simple_animal/hostile/hive_alien/constructor/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	.=..()
 
 	if(istype(loc, /turf/unsimulated/floor/evil))

--- a/code/modules/mob/living/simple_animal/hostile/human/halloween.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/halloween.dm
@@ -277,7 +277,7 @@
 /mob/living/simple_animal/hostile/blood_splot/adjustBruteLoss()
 	return
 
-/mob/living/simple_animal/hostile/blood_splot/Move()
+/mob/living/simple_animal/hostile/blood_splot/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	..()
 	var/turf/T = get_turf(src)
 	var/blood_found
@@ -444,7 +444,7 @@
 		icon_living = "syphoner"
 		icon_state = "syphoner"
 
-/mob/living/simple_animal/hostile/syphoner/Move()
+/mob/living/simple_animal/hostile/syphoner/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	..()
 	if(prob(30))
 		if(istype(src.loc, /turf/simulated/floor))

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/cluwne.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/cluwne.dm
@@ -303,7 +303,7 @@
 	msg = "<B>[src]</B> [msg]"
 	return ..(msg)
 
-/mob/living/simple_animal/hostile/retaliate/cluwne/Move()
+/mob/living/simple_animal/hostile/retaliate/cluwne/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	. = ..()
 
 	if(.)

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/cockatrice.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/cockatrice.dm
@@ -187,7 +187,7 @@
 
 	return ..()
 
-/mob/living/simple_animal/hostile/retaliate/cockatrice/Move()
+/mob/living/simple_animal/hostile/retaliate/cockatrice/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	.=..()
 
 	for(var/mob/living/L in loc)

--- a/code/modules/mob/living/simple_animal/hostile/wolf.dm
+++ b/code/modules/mob/living/simple_animal/hostile/wolf.dm
@@ -344,7 +344,7 @@
 				to_chat(user, "<span class='info'>It seems to be going somewhere.</span>")
 			if(ALPHASTAY)
 				to_chat(user, "<span class='info'>It seems to be sitting down, waiting patiently.</span>")
-/mob/living/simple_animal/hostile/wolf/Move()
+/mob/living/simple_animal/hostile/wolf/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	..()
 	nutrition -= MOVECOST
 

--- a/code/modules/mob/living/simple_animal/roach.dm
+++ b/code/modules/mob/living/simple_animal/roach.dm
@@ -165,7 +165,7 @@
 	//No food, trash, walls or anything - just modify our pixel_x and pixel_y
 	animate(src, pixel_x = rand(-20,20) * PIXEL_MULTIPLIER, pixel_y = rand(-20,20) * PIXEL_MULTIPLIER, (flying ? 5 : 15) , 1) //This animation takes 1.5 seconds, or 0.5 if flying
 
-/mob/living/simple_animal/cockroach/Move()
+/mob/living/simple_animal/cockroach/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	..()
 
 	if(!flying)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1067,6 +1067,7 @@ var/list/slot_equipment_priority = list( \
 	set category = "IC"
 
 	if(pulling)
+		to_chat(world, "stop pulling called. pulling was [pulling], puller was [pulling.pulledby]")
 		pulling.pulledby = null
 		pulling = null
 		update_pull_icon()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1067,7 +1067,6 @@ var/list/slot_equipment_priority = list( \
 	set category = "IC"
 
 	if(pulling)
-		to_chat(world, "stop pulling called. pulling was [pulling], puller was [pulling.pulledby]")
 		pulling.pulledby = null
 		pulling = null
 		update_pull_icon()

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -393,7 +393,7 @@
 			mob.Facing()
 
 ///Process_Grab()
-///Called by client/Move()
+///Called by client/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 ///Checks to see if you are being grabbed and if so attemps to break it
 /client/proc/Process_Grab()
 	if(locate(/obj/item/weapon/grab, locate(/obj/item/weapon/grab, mob.grabbed_by.len)))
@@ -424,7 +424,7 @@
 
 
 ///Process_Incorpmove
-///Called by client/Move()
+///Called by client/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 ///Allows mobs to run though walls
 /client/proc/Process_Incorpmove(direct)
 	switch(mob.incorporeal_move)
@@ -470,7 +470,7 @@
 
 
 ///Process_Spacemove
-///Called by /client/Move()
+///Called by /client/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 ///For moving in space
 ///Return 1 for movement 0 for none
 /mob/Process_Spacemove(var/check_drift = 0,var/ignore_slip = 0)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -497,7 +497,7 @@ Round Duration: [round(hours)]h [round(mins)]m<br>"}
 
 	src << browse(dat, "window=manifest;size=370x420;can_close=1")
 
-/mob/new_player/Move()
+/mob/new_player/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	return 0
 
 

--- a/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
@@ -133,7 +133,7 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 	return
 
 
-/obj/structure/particle_accelerator/Move()
+/obj/structure/particle_accelerator/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	..()
 	if(master && master.active)
 		master.toggle_power()

--- a/code/modules/projectiles/guns/hookshot.dm
+++ b/code/modules/projectiles/guns/hookshot.dm
@@ -372,7 +372,7 @@
 		else if(A == extremity_B)
 			return extremity_A.attempt_to_follow(src, A.loc)
 
-/obj/effect/overlay/chain/Move()//for when someone pulls a part the chain.
+/obj/effect/overlay/chain/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)//for when someone pulls a part the chain.
 	var/turf/T = loc
 	if(..())
 		var/obj/effect/overlay/chain/CA = extremity_A

--- a/code/modules/recycling/compactor.dm
+++ b/code/modules/recycling/compactor.dm
@@ -108,7 +108,7 @@
 		return
 	..()
 
-/obj/machinery/disposal/compactor/Move()
+/obj/machinery/disposal/compactor/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	..()
 	if(prob(2))
 		var/atom/movable/AM = pick(contents)

--- a/code/modules/research/xenoarchaeology/artifact/artifact_unknown.dm
+++ b/code/modules/research/xenoarchaeology/artifact/artifact_unknown.dm
@@ -151,7 +151,7 @@
 			on_explode.Invoke(list("", "EXPLOSION"))
 	return
 
-/obj/machinery/artifact/Move()
+/obj/machinery/artifact/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	..()
 	if(primary_effect)
 		primary_effect.UpdateMove()

--- a/maps/randomvaults/spessmart.dm
+++ b/maps/randomvaults/spessmart.dm
@@ -674,7 +674,7 @@ var/list/clothing_prices = list()	//gets filled on initialize()
 	robogibs(get_turf(src))
 	qdel(src)
 
-/mob/living/simple_animal/hostile/spessmart_guardian/Move()
+/mob/living/simple_animal/hostile/spessmart_guardian/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	if(alert_on_movement && !canmove)
 		Retaliate()
 


### PR DESCRIPTION
by giving them the proper arguments that were expected

Seems that adding a new argument to a byond-standard proc means you have to add the argument to every instance of trying to override it. Odd as you'd assume they would inherit from atom/movable, but that didn't seem to be the case.

closes #17056
closes #17057
closes #17052