### PR TITLE
Ghost creep

### DIFF
--- a/code/datums/mixed.dm
+++ b/code/datums/mixed.dm
@@ -23,7 +23,7 @@
 
 /datum/data/record/proc/add_comment(var/comment)
 	var/counter = 1
-	while(fields[text("com_[]", counter)])
+	while(fields["com_[counter]"])
 		counter++
 	fields["com_[counter]"] = "Made by [usr.identification_string()] on [time2text(world.realtime, "DDD MMM DD hh:mm:ss")], [game_year]<br>[comment]"
 

--- a/code/datums/mixed.dm
+++ b/code/datums/mixed.dm
@@ -21,6 +21,11 @@
 	size = 5.0
 	var/list/fields = list(  )
 
+/datum/data/record/proc/add_comment(var/comment)
+	var/counter = 1
+	while(fields[text("com_[]", counter)])
+		counter++
+	fields["com_[counter]"] = "Made by [usr.identification_string()] on [time2text(world.realtime, "DDD MMM DD hh:mm:ss")], [game_year]<br>[comment]"
 
 /datum/data/text
 	name = "text"

--- a/code/defines/obj.dm
+++ b/code/defines/obj.dm
@@ -34,6 +34,7 @@
  * This item is completely unused, but removing it will break something in R&D and Radio code causing PDA and Ninja code to fail on compile
  */
 
+// Holy shit someone make this a datum already
 /obj/effect/datacore
 	name = "datacore"
 	var/medical[] = list()
@@ -42,7 +43,27 @@
 	//This list tracks characters spawned in the world and cannot be modified in-game. Currently referenced by respawn_character().
 	var/locked[] = list()
 
+// Finds a record in 'general' based on the name, then finds a record in 'which' based on the ID
+// Returns the record if it finds one, null otherwise
+/obj/effect/datacore/proc/find_record_by_name(var/target_name, var/list/which)
+	for (var/datum/data/record/E in general)
+		if (E.fields["name"] == target_name)
+			for (var/datum/data/record/R in which)
+				if (R.fields["id"] == E.fields["id"])
+					return R
+	return null
 
+/obj/effect/datacore/proc/find_general_record_by_name(var/target_name)
+	for(var/datum/data/record/E in general)
+		if(E.fields["name"] == target_name)
+			return E
+	return null
+
+/obj/effect/datacore/proc/find_medical_record_by_name(var/target_name)
+	return find_record_by_name(target_name, medical)
+
+/obj/effect/datacore/proc/find_security_record_by_name(var/target_name)
+	return find_record_by_name(target_name, security)
 
 /obj/effect/datacore/proc/get_manifest(monochrome, OOC)
 	var/list/heads = new()

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -999,3 +999,11 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		if (source_turf in view(src))
 			rendered_speech = "<B>[rendered_speech]</B>"
 			to_chat(src, "<a href='?src=\ref[src];follow=\ref[source]'>(Follow)</a> [rendered_speech]")
+
+/mob/dead/observer/hasHUD(var/hud_kind)
+	switch(hud_kind)
+		if(HUD_MEDICAL)
+			return selectedHUD == HUD_MEDICAL
+		if(HUD_SECURITY)
+			return selectedHUD == HUD_SECURITY
+	return

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -430,7 +430,7 @@
 	if(butchery)
 		msg += "<span class='warning'>[butchery]</span>\n"
 
-	if(hasHUD(user,"security"))
+	if(user.hasHUD(HUD_SECURITY))
 		var/perpname = "wot"
 		var/criminal = "None"
 
@@ -455,7 +455,7 @@
 <span class = 'deptradio'>Security records:</span> <a href='?src=\ref[src];secrecord=`'>\[View\]</a>  <a href='?src=\ref[src];secrecordadd=`'>\[Add comment\]</a>\n"}
 			msg += {"[wpermit(src) ? "<span class = 'deptradio'>Has weapon permit.</span>\n" : ""]"}
 
-	if(hasHUD(user,"medical"))
+	if(user.hasHUD(HUD_MEDICAL))
 		var/perpname = "wot"
 		var/medical = "None"
 
@@ -486,36 +486,6 @@
 	to_chat(user, msg)
 	if(istype(user))
 		user.heard(src)
-
-//Helper procedure. Called by /mob/living/carbon/human/examine() and /mob/living/carbon/human/Topic() to determine HUD access to security and medical records.
-/proc/hasHUD(mob/M as mob, hudtype)
-	if(istype(M, /mob/living/carbon/human))
-		var/mob/living/carbon/human/H = M
-		switch(hudtype)
-			if("security")
-				return istype(H.glasses, /obj/item/clothing/glasses/hud/security) || istype(H.glasses, /obj/item/clothing/glasses/sunglasses/sechud)
-			if("medical")
-				return istype(H.glasses, /obj/item/clothing/glasses/hud/health)
-			else
-				return 0
-	else if(istype(M, /mob/living/silicon/robot))
-		var/mob/living/silicon/robot/R = M
-		switch(hudtype)
-			if("security")
-				return R.sensor_mode == 1
-			if("medical")
-				return R.sensor_mode == 2
-			else
-				return 0
-	else if(istype(M, /mob/living/silicon/pai))
-		var/mob/living/silicon/pai/P = M
-		switch(hudtype)
-			if("security")
-				return P.secHUD
-			if("medical")
-				return P.medHUD
-	else
-		return 0
 
 #undef Jitter_Medium
 #undef Jitter_High

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -431,52 +431,31 @@
 		msg += "<span class='warning'>[butchery]</span>\n"
 
 	if(user.hasHUD(HUD_SECURITY))
-		var/perpname = "wot"
+		var/perpname = get_id_name("wot")
 		var/criminal = "None"
 
-		if(wear_id)
-			var/obj/item/weapon/card/id/I = wear_id.GetID()
-			if(I)
-				perpname = I.registered_name
-			else
-				perpname = name
-		else
-			perpname = name
-
-		if(perpname)
-			for (var/datum/data/record/E in data_core.general)
-				if(E.fields["name"] == perpname)
-					for (var/datum/data/record/R in data_core.security)
-						if(R.fields["id"] == E.fields["id"])
-							criminal = R.fields["criminal"]
-
+		var/datum/data/record/sec_record = data_core.find_security_record_by_name(perpname)
+		if(sec_record)
+			criminal = sec_record.fields["criminal"]
 
 			msg += {"<span class = 'deptradio'>Criminal status:</span> <a href='?src=\ref[src];criminal=1'>\[[criminal]\]</a>
-<span class = 'deptradio'>Security records:</span> <a href='?src=\ref[src];secrecord=`'>\[View\]</a>  <a href='?src=\ref[src];secrecordadd=`'>\[Add comment\]</a>\n"}
+<span class = 'deptradio'>Security records:</span> <a href='?src=\ref[src];secrecord=`'>\[View\]</a>"}
+			if(!isjustobserver(user))
+				msg += "<a href='?src=\ref[src];secrecordadd=`'>\[Add comment\]</a>\n"
 			msg += {"[wpermit(src) ? "<span class = 'deptradio'>Has weapon permit.</span>\n" : ""]"}
 
 	if(user.hasHUD(HUD_MEDICAL))
-		var/perpname = "wot"
+		var/perpname = get_id_name("wot")
 		var/medical = "None"
 
-		if(wear_id)
-			if(istype(wear_id,/obj/item/weapon/card/id))
-				perpname = wear_id:registered_name
-			else if(istype(wear_id,/obj/item/device/pda))
-				var/obj/item/device/pda/tempPda = wear_id
-				perpname = tempPda.owner
-		else
-			perpname = src.name
-
-		for (var/datum/data/record/E in data_core.general)
-			if (E.fields["name"] == perpname)
-				for (var/datum/data/record/R in data_core.general)
-					if (R.fields["id"] == E.fields["id"])
-						medical = R.fields["p_stat"]
-
+		var/datum/data/record/gen_record = data_core.find_general_record_by_name(perpname)
+		if(gen_record)
+			medical = gen_record.fields["p_stat"]
 
 		msg += {"<span class = 'deptradio'>Physical status:</span> <a href='?src=\ref[src];medical=1'>\[[medical]\]</a>\n
-			<span class = 'deptradio'>Medical records:</span> <a href='?src=\ref[src];medrecord=`'>\[View\]</a> <a href='?src=\ref[src];medrecordadd=`'>\[Add comment\]</a>\n"}
+			<span class = 'deptradio'>Medical records:</span> <a href='?src=\ref[src];medrecord=`'>\[View\]</a>"}
+		if(!isjustobserver(user))
+			msg += "<a href='?src=\ref[src];medrecordadd=`'>\[Add comment\]</a>\n"
 
 	if(flavor_text && can_show_flavor_text())
 		msg += "[print_flavor_text()]\n"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -479,213 +479,106 @@
 			show_inv(machine)
 
 	else if (href_list["criminal"])
-		if(usr.hasHUD(HUD_SECURITY))
-			if(isjustobserver(usr))
-				return
-			var/perpname = "wot"
-			var/modified
-
-			if(wear_id)
-				var/obj/item/weapon/card/id/I = wear_id.GetID()
-				if(I)
-					perpname = I.registered_name
-				else
-					perpname = name
-			else
-				perpname = name
-
-			if(perpname)
-				for (var/datum/data/record/E in data_core.general)
-					if (E.fields["name"] == perpname)
-						for (var/datum/data/record/R in data_core.security)
-							if (R.fields["id"] == E.fields["id"])
-
-								var/setcriminal = input(usr, "Specify a new criminal status for this person.", "Security HUD", R.fields["criminal"]) in list("None", "*Arrest*", "Incarcerated", "Parolled", "Released", "Cancel")
-
-								if(usr.hasHUD(HUD_SECURITY))
-									if(setcriminal != "Cancel")
-										R.fields["criminal"] = setcriminal
-										modified = 1
-
-										spawn()
-											hud_updateflag |= 1 << WANTED_HUD
-											if(istype(usr,/mob/living/carbon/human))
-												var/mob/living/carbon/human/U = usr
-												U.handle_regular_hud_updates()
-											if(istype(usr,/mob/living/silicon/robot))
-												var/mob/living/silicon/robot/U = usr
-												U.handle_regular_hud_updates()
-
-			if(!modified)
-				to_chat(usr, "<span class='warning'>Unable to locate a data core entry for this person.</span>")
+		if(!usr.hasHUD(HUD_SECURITY) || isjustobserver(usr))
+			return
+		var/perpname = get_id_name("wot")
+		var/datum/data/record/sec_record = data_core.find_security_record_by_name(perpname)
+		if(!sec_record)
+			to_chat(usr, "<span class='warning'>Unable to locate a data core entry for this person.</span>")
+			return
+		var/setcriminal = input(usr, "Specify a new criminal status for this person.", "Security HUD", sec_record.fields["criminal"]) as null|anything in list("None", "*Arrest*", "Incarcerated", "Parolled", "Released")
+		if(!setcriminal || (usr.incapacitated() && !isAdminGhost(usr)) || !usr.hasHUD(HUD_SECURITY))
+			return
+		sec_record.fields["criminal"] = setcriminal	
 	else if (href_list["secrecord"])
-		if(usr.hasHUD(HUD_SECURITY))
-			var/perpname = "wot"
-			var/read = 0
-
-			if(wear_id)
-				if(istype(wear_id,/obj/item/weapon/card/id))
-					perpname = wear_id:registered_name
-				else if(istype(wear_id,/obj/item/device/pda))
-					var/obj/item/device/pda/tempPda = wear_id
-					perpname = tempPda.owner
-			else
-				perpname = src.name
-			for (var/datum/data/record/E in data_core.general)
-				if (E.fields["name"] == perpname)
-					for (var/datum/data/record/R in data_core.security)
-						if (R.fields["id"] == E.fields["id"])
-							if(usr.hasHUD(HUD_SECURITY))
-								to_chat(usr, "<b>Name:</b> [R.fields["name"]]	<b>Criminal Status:</b> [R.fields["criminal"]]")
-								to_chat(usr, "<b>Notes:</b> [R.fields["notes"]]")
-								var/counter = 1
-								to_chat(usr, "<b>Comments:</b>")
-								while(R.fields[text("com_[]", counter)])
-									to_chat(usr, text("[]", R.fields[text("com_[]", counter)]))
-									counter++
-								if (counter == 1)
-									to_chat(usr, "No comments found.")
-								read = 1
-								to_chat(usr, "<a href='?src=\ref[src];secrecordadd=`'>\[Add comment\]</a>")
-			if(!read)
-				to_chat(usr, "<span class='warning'>Unable to locate a data core entry for this person.</span>")
+		if(!usr.hasHUD(HUD_SECURITY))
+			return
+		var/perpname = get_id_name("wot")
+		var/datum/data/record/sec_record = data_core.find_security_record_by_name(perpname)
+		if(!sec_record)
+			to_chat(usr, "<span class='warning'>Unable to locate a data core entry for this person.</span>")
+			return
+		to_chat(usr, "<b>Name:</b> [sec_record.fields["name"]]	<b>Criminal status:</b> [sec_record.fields["criminal"]]")
+		to_chat(usr, "<b>Notes:</b> [sec_record.fields["notes"]]")
+		to_chat(usr, "<b>Comments:</b>")
+		var/counter = 1
+		while(sec_record.fields["com_[counter]"])
+			to_chat(usr, sec_record.fields["com_[counter]"])
+			counter++
+		if(counter == 1)
+			to_chat(usr, "No comments found.")
+		if(!isjustobserver(usr))
+			to_chat(usr, "<a href='?src=\ref[src];secrecordadd=`'>\[Add comment\]</a>")
 	else if (href_list["secrecordadd"])
-		if(usr.hasHUD(HUD_SECURITY))
-			if(isjustobserver(usr))
-				return
-			var/perpname = "wot"
-			if(wear_id)
-				if(istype(wear_id,/obj/item/weapon/card/id))
-					perpname = wear_id:registered_name
-				else if(istype(wear_id,/obj/item/device/pda))
-					var/obj/item/device/pda/tempPda = wear_id
-					perpname = tempPda.owner
-			else
-				perpname = src.name
-			for (var/datum/data/record/E in data_core.general)
-				if (E.fields["name"] == perpname)
-					for (var/datum/data/record/R in data_core.security)
-						if (R.fields["id"] == E.fields["id"])
-							var/t1 = copytext(sanitize(input("Add Comment:", "Sec. records", null, null)  as message),1,MAX_MESSAGE_LEN)
-							if (!t1 || (usr.incapacitated() && !isAdminGhost(usr)) || !usr.hasHUD(HUD_SECURITY))
-								return
-							var/counter = 1
-							while(R.fields[text("com_[]", counter)])
-								counter++
-							R.fields["com_[counter]"] = "Made by [usr.identification_string()] on [time2text(world.realtime, "DDD MMM DD hh:mm:ss")], [game_year]<BR>[t1]"
+		if(!usr.hasHUD(HUD_SECURITY) || isjustobserver(usr))
+			return
+		var/perpname = get_id_name("wot")
+		var/datum/data/record/sec_record = data_core.find_security_record_by_name(perpname)
+		if(!sec_record)
+			to_chat(usr, "<span class='warning'>Unable to locate a data core entry for this person.</span>")
+			return
+		var/t1 = copytext(sanitize(input(usr, "Add Comment:", "Security records") as message|null),1,MAX_MESSAGE_LEN)
+		if (!t1 || (usr.incapacitated() && !isAdminGhost(usr)) || !usr.hasHUD(HUD_SECURITY))
+			return
+		sec_record.add_comment(t1)
 	else if (href_list["medical"])
-		if(usr.hasHUD(HUD_MEDICAL))
-			if(isjustobserver(usr))
-				return
-			var/perpname = "wot"
-			var/modified = 0
-			if(wear_id)
-				if(istype(wear_id,/obj/item/weapon/card/id))
-					perpname = wear_id:registered_name
-				else if(istype(wear_id,/obj/item/device/pda))
-					var/obj/item/device/pda/tempPda = wear_id
-					perpname = tempPda.owner
-			else
-				perpname = src.name
-			for (var/datum/data/record/E in data_core.general)
-				if (E.fields["name"] == perpname)
-					for (var/datum/data/record/R in data_core.general)
-						if (R.fields["id"] == E.fields["id"])
-							var/setmedical = input(usr, "Specify a new medical status for this person.", "Medical HUD", R.fields["p_stat"]) in list("*SSD*", "*Deceased*", "Physically Unfit", "Active", "Disabled", "Cancel")
-							if(usr.hasHUD(HUD_MEDICAL))
-								if(setmedical != "Cancel")
-									R.fields["p_stat"] = setmedical
-									modified = 1
-									if(PDA_Manifest.len)
-										PDA_Manifest.len = 0
-									spawn()
-										if(istype(usr,/mob/living/carbon/human))
-											var/mob/living/carbon/human/U = usr
-											U.handle_regular_hud_updates()
-										if(istype(usr,/mob/living/silicon/robot))
-											var/mob/living/silicon/robot/U = usr
-											U.handle_regular_hud_updates()
-			if(!modified)
-				to_chat(usr, "<span class='warning'>Unable to locate a data core entry for this person.</span>")
+		if(!usr.hasHUD(HUD_MEDICAL) || isjustobserver(usr))
+			return
+		var/perpname = get_id_name("wot")
+		var/datum/data/record/gen_record = data_core.find_general_record_by_name(perpname)
+		if(!gen_record)
+			to_chat(usr, "<span class='warning'>Unable to locate a data core entry for this person.</span>")
+			return
+		var/setmedical = input(usr, "Specify a new medical status for this person.", "Medical HUD", gen_record.fields["p_stat"]) as null|anything in list("*SSD*", "*Deceased*", "Physically Unfit", "Active", "Disabled")
+		if(!setmedical|| (usr.incapacitated() && !isAdminGhost(usr)) || !usr.hasHUD(HUD_MEDICAL))
+			return
+		gen_record.fields["p_stat"] = setmedical
+		if(PDA_Manifest.len)
+			PDA_Manifest.len = 0
 	else if (href_list["medrecord"])
-		if(usr.hasHUD(HUD_MEDICAL))
-			var/perpname = "wot"
-			var/read = 0
-			if(wear_id)
-				if(istype(wear_id,/obj/item/weapon/card/id))
-					perpname = wear_id:registered_name
-				else if(istype(wear_id,/obj/item/device/pda))
-					var/obj/item/device/pda/tempPda = wear_id
-					perpname = tempPda.owner
-			else
-				perpname = src.name
-			for (var/datum/data/record/E in data_core.general)
-				if (E.fields["name"] == perpname)
-					for (var/datum/data/record/R in data_core.medical)
-						if (R.fields["id"] == E.fields["id"])
-							to_chat(usr, "<b>Name:</b> [R.fields["name"]]	<b>Blood Type:</b> [R.fields["b_type"]]")
-							to_chat(usr, "<b>DNA:</b> [R.fields["b_dna"]]")
-							to_chat(usr, "<b>Minor Disabilities:</b> [R.fields["mi_dis"]]")
-							to_chat(usr, "<b>Details:</b> [R.fields["mi_dis_d"]]")
-							to_chat(usr, "<b>Major Disabilities:</b> [R.fields["ma_dis"]]")
-							to_chat(usr, "<b>Details:</b> [R.fields["ma_dis_d"]]")
-							to_chat(usr, "<b>Notes:</b> [R.fields["notes"]]")
-							to_chat(usr, "<a href='?src=\ref[src];medrecordComment=`'>\[View Comment Log\]</a>")
-							read = 1
-			if(!read)
-				to_chat(usr, "<span class='warning'>Unable to locate a data core entry for this person.</span>")
+		if(!usr.hasHUD(HUD_MEDICAL))
+			return
+		var/perpname = get_id_name("wot")
+		var/datum/data/record/med_record = data_core.find_medical_record_by_name(perpname)
+		if(!med_record)
+			to_chat(usr, "<span class='warning'>Unable to locate a data core entry for this person.</span>")
+			return
+		to_chat(usr, "<b>Name:</b> [med_record.fields["name"]]	<b>Blood type:</b> [med_record.fields["b_type"]]")
+		to_chat(usr, "<b>DNA:</b> [med_record.fields["b_dna"]]")
+		to_chat(usr, "<b>Minor disabilities:</b> [med_record.fields["mi_dis"]]")
+		to_chat(usr, "<b>Details:</b> [med_record.fields["mi_dis_d"]]")
+		to_chat(usr, "<b>Major disabilities:</b> [med_record.fields["ma_dis"]]")
+		to_chat(usr, "<b>Details:</b> [med_record.fields["ma_dis_d"]]")
+		to_chat(usr, "<b>Notes:</b> [med_record.fields["notes"]]")
+		to_chat(usr, "<a href='?src=\ref[src];medrecordComment=`'>\[View Comment Log\]</a>")
 	else if (href_list["medrecordComment"])
-		if(usr.hasHUD(HUD_MEDICAL))
-			var/perpname = "wot"
-			var/read = 0
-			if(wear_id)
-				if(istype(wear_id,/obj/item/weapon/card/id))
-					perpname = wear_id:registered_name
-				else if(istype(wear_id,/obj/item/device/pda))
-					var/obj/item/device/pda/tempPda = wear_id
-					perpname = tempPda.owner
-			else
-				perpname = src.name
-			for (var/datum/data/record/E in data_core.general)
-				if (E.fields["name"] == perpname)
-					for (var/datum/data/record/R in data_core.medical)
-						if (R.fields["id"] == E.fields["id"])
-							read = 1
-							var/counter = 1
-							while(R.fields[text("com_[]", counter)])
-								to_chat(usr, text("[]", R.fields[text("com_[]", counter)]))
-								counter++
-							if (counter == 1)
-								to_chat(usr, "No comment found")
-							to_chat(usr, "<a href='?src=\ref[src];medrecordadd=`'>\[Add comment\]</a>")
-			if(!read)
-				to_chat(usr, "<span class='warning'>Unable to locate a data core entry for this person.</span>")
+		if(!usr.hasHUD(HUD_MEDICAL))
+			return
+		var/perpname = get_id_name("wot")
+		var/datum/data/record/med_record = data_core.find_medical_record_by_name(perpname)
+		if(!med_record)
+			to_chat(usr, "<span class='warning'>Unable to locate a data core entry for this person.</span>")
+			return
+		var/counter = 1
+		while(med_record.fields["com_[counter]"])
+			to_chat(usr, med_record.fields["com_[counter]"])
+			counter++
+		if (counter == 1)
+			to_chat(usr, "No comment found.")
+		if(!isjustobserver(usr))
+			to_chat(usr, "<a href='?src=\ref[src];medrecordadd=`'>\[Add comment\]</a>")
 	else if (href_list["medrecordadd"])
-		if(usr.hasHUD(HUD_MEDICAL))
-			if(isjustobserver(usr))
-				return
-			var/perpname = "wot"
-			if(wear_id)
-				if(istype(wear_id,/obj/item/weapon/card/id))
-					perpname = wear_id:registered_name
-				else if(istype(wear_id,/obj/item/device/pda))
-					var/obj/item/device/pda/tempPda = wear_id
-					perpname = tempPda.owner
-			else
-				perpname = src.name
-			for (var/datum/data/record/E in data_core.general)
-				if (E.fields["name"] == perpname)
-					for (var/datum/data/record/R in data_core.medical)
-						if (R.fields["id"] == E.fields["id"])
-							var/t1 = copytext(sanitize(input("Add Comment:", "Med. records", null, null)  as message),1,MAX_MESSAGE_LEN)
-							if (t1 || (usr.incapacitated() && !isAdminGhost(usr)) || !usr.hasHUD(HUD_MEDICAL))
-								return
-							var/counter = 1
-							while(R.fields[text("com_[]", counter)])
-								counter++
-							R.fields["com_[counter]"] = "Made by [usr.identification_string()] on [time2text(world.realtime, "DDD MMM DD hh:mm:ss")], [game_year]<BR>[t1]"
-		//else if(!. && error_msg && user)
-//			to_chat(user, "<span class='alert'>There is no exposed flesh or thin material [above_neck(target_zone) ? "on their head" : "on their body"].</span>")
+		if(!usr.hasHUD(HUD_MEDICAL) || isjustobserver(usr))
+			return
+		var/perpname = get_id_name("wot")
+		var/datum/data/record/med_record = data_core.find_medical_record_by_name(perpname)
+		if(!med_record)
+			to_chat(usr, "<span class='warning'>Unable to locate a data core entry for this person.</span>")
+			return
+		var/t1 = copytext(sanitize(input(usr, "Add comment:", "Medical records") as message|null),1,MAX_MESSAGE_LEN)
+		if (!t1 || (usr.incapacitated() && !isAdminGhost(usr)) || !usr.hasHUD(HUD_MEDICAL))
+			return
+		med_record.add_comment(t1)
 	else if (href_list["lookitem"])
 		var/obj/item/I = locate(href_list["lookitem"])
 		usr.examination(I)
@@ -1874,11 +1767,10 @@ mob/living/carbon/human/remove_internal_organ(var/mob/living/user, var/datum/org
 			G.on_wearer_threw_item(src,target,item)
 
 /mob/living/carbon/human/hasHUD(var/hud_kind)
+	var/glasses = get_item_by_slot(slot_glasses)
 	switch(hud_kind)
 		if(HUD_MEDICAL)
-			var/glasses = get_item_by_slot(slot_glasses)
 			return istype(glasses, /obj/item/clothing/glasses/hud/health)
 		if(HUD_SECURITY)
-			var/glasses = get_item_by_slot(slot_glasses)
 			return is_type_in_list(glasses, list(/obj/item/clothing/glasses/hud/security, /obj/item/clothing/glasses/sunglasses/sechud))
 	return FALSE

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -333,3 +333,11 @@
 
 /mob/living/silicon/pai/teleport_to(var/atom/A)
 	card.forceMove(get_turf(A))
+
+/mob/living/silicon/pai/hasHUD(var/hud_kind)
+	switch(hud_kind)
+		if(HUD_MEDICAL)
+			return medHUD
+		if(HUD_SECURITY)
+			return secHUD
+	return FALSE

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1594,3 +1594,14 @@
 			client.screen -= A
 	module.remove_languages(src)
 	module = null
+
+/mob/living/silicon/robot/hasHUD(var/hud_kind)
+	switch(hud_kind)
+		if(HUD_MEDICAL)
+			return sensor_mode == 2
+		if(HUD_SECURITY)
+			return sensor_mode == 1
+	return FALSE
+
+/mob/living/silicon/robot/identification_string()
+	return "[name] ([modtype] [braintype])"

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -542,3 +542,12 @@ proc/is_blind(A)
 			if(user.mind.special_role == HIGHLANDER && (honorable & HONORABLE_HIGHLANDER))
 				return TRUE
 	return FALSE
+
+// Called by /mob/living/carbon/human/examine() and /mob/living/carbon/human/Topic()
+// Returns whether the mob can see the specified HUD
+/mob/proc/hasHUD(var/hud_kind)
+	return FALSE
+
+// Returns a string that provides identification data for this mob
+/mob/proc/identification_string()
+	return name


### PR DESCRIPTION
- Refactored hasHUD, removing disgusting `istype` checks
- Cleaned up a lot of copypasted boilerplate in `human/Topic` related to showing the records
- Made it possible for ghosts to see the medical/security records just like the living do
- Badmin ghosts can edit the records the same way

I think I got the sanity checks to prevent ghosts setting people to arrest right.

:cl:
 * rscadd: Ghosts with the appropriate HUDs will be able to look at people's security and medical records by examining them.