### PR TITLE
Removes the blood cost from hypnosis.

### DIFF
--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -165,13 +165,13 @@
 
 /client/proc/vampire_hypnotise()
 	set category = "Vampire"
-	set name = "Hypnotise (10)"
+	set name = "Hypnotise"
 	set desc= "A piercing stare that incapacitates your victim for a good length of time."
 	var/datum/mind/M = usr.mind
 	if(!M)
 		return
 
-	var/mob/living/carbon/C = M.current.vampire_active(10, 0, 1)
+	var/mob/living/carbon/C = M.current.vampire_active(0, 0, 1)
 	if(!C)
 		return
 
@@ -185,7 +185,6 @@
 			M.current.verbs += /client/proc/vampire_hypnotise
 	var/enhancements = ((C.knockdown ? 2 : 0) + (C.stunned ? 1 : 0) + (C.sleeping || C.paralysis ? 3 : 0))
 	if(do_mob(M.current, C, 10 - enhancements))
-		M.current.remove_vampire_blood(10)
 		if(C.mind && C.mind.vampire)
 			to_chat(M.current, "<span class='warning'>Your piercing gaze fails to knock out [C.name].</span>")
 			to_chat(C, "<span class='notice'>[M.current.name]'s feeble gaze is ineffective.</span>")


### PR DESCRIPTION
Currently, vampire as a gamemode is a joke to the point of being referred to as "vampstended".  This is a product of the vampire not possessing the independent ability of getting the ball rolling.  They are forced to rely on a few cookie cutter methods that are so predictable at this point, that they have become jokes in their own right: killing telecomms and killspreeing (going loud) or transferring to medbay and chloral'ing people.  Chloral-based antags are disgustingly lame and not fun for anyone.  The fact that most, if not all, successful vampires have to turn to this makes the gamemode itself a failure.  This change would allow vampires to return to making use of their powers and being vampires, not chloral monsters.

Special and unique types of antags should be making use of their powers, not being forced to chloral people.  I view the full issue being that they are a chloral-based, overpowered bat themed wizard.  This would correct the first half, and open the second half to be addressed as it appears and for the actual reason they are overpowered.  Making it too hard/too lame to get there is not a fun or acceptable solution.

:cl:
 * tweak: Removes the blood cost from Hypnosis for vampires.