### PR TITLE
nukes rand() calls that use 0. decimals

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/combat.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/combat.dm
@@ -57,4 +57,4 @@
 	if(iscarbon(target) && !isslime(target))
 		if(damage > 25)
 			visible_message("<span class='danger'>[src] has wounded [target]!</span>")
-			target.apply_effect(rand(0.5,3), WEAKEN, armor)
+			target.apply_effect(rand(5,30)/10, WEAKEN, armor)

--- a/code/modules/mob/living/simple_animal/roach.dm
+++ b/code/modules/mob/living/simple_animal/roach.dm
@@ -122,7 +122,7 @@
 				//And yeah, roaches can lay eggs on their own eggs. This is kinda intended
 
 				if(F && F.reagents)
-					F.reagents.add_reagent(TOXIN, rand(0.2,0.6)) //Add some toxin to the food
+					F.reagents.add_reagent(TOXIN, rand(2,6)/10) //Add some toxin to the food
 					lay_eggs()
 
 		return //Don't do anything after that

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -392,7 +392,7 @@ var/global/list/obj/machinery/light/alllights = list()
 			spark(src)
 			//if(!user.mutations & M_RESIST_COLD)
 			if (prob(75))
-				electrocute_mob(user, get_area(src), src, rand(0.7,1.0))
+				electrocute_mob(user, get_area(src), src, rand(7,10)/10)
 
 /*
  * Returns whether this light has power

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -4049,7 +4049,7 @@
 /datum/reagent/discount/New()
 	..()
 	density = rand(12,48)
-	specheatcap = rand(25,250)/10
+	specheatcap = rand(25,2500)/100
 
 /datum/reagent/discount/on_mob_life(var/mob/living/M)
 

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1959,7 +1959,7 @@
 
 		for(var/mob/living/carbon/human/H in T)
 			if(isslimeperson(H))
-				H.adjustToxLoss(rand(0.5, 1))
+				H.adjustToxLoss(rand(5, 10)/10)
 
 /datum/reagent/space_cleaner/reaction_mob(var/mob/living/M, var/method = TOUCH, var/volume)
 
@@ -4049,7 +4049,7 @@
 /datum/reagent/discount/New()
 	..()
 	density = rand(12,48)
-	specheatcap = rand(0.25,25)
+	specheatcap = rand(25,250)/10
 
 /datum/reagent/discount/on_mob_life(var/mob/living/M)
 

--- a/code/modules/reagents/reagent_containers/food/snacks/egg.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/egg.dm
@@ -108,4 +108,4 @@
 /obj/item/weapon/reagent_containers/food/snacks/egg/cockatrice/New()
 	..()
 
-	reagents.add_reagent(PETRITRICIN, rand(0.5,1.5))
+	reagents.add_reagent(PETRITRICIN, rand(5,15)/10)

--- a/code/modules/research/xenoarchaeology/machinery/analysis_isotope_ratio.dm
+++ b/code/modules/research/xenoarchaeology/machinery/analysis_isotope_ratio.dm
@@ -38,7 +38,7 @@
 		var/accuracy = GetResultSpecifity(scanned_sample, carrier_name)
 		accuracy += 0.5 * (1 - accuracy) / scanned_sample.total_spread
 		if(!accuracy)
-			accuracy = rand(0.01, 0.5)
+			accuracy = rand(1, 50)/100
 		results = "Isotope decay analysis in carrier ([carrier_name]) indicates age ([100 * accuracy]% accuracy): <br><br>"
 
 		if(scanned_sample.age_billion)


### PR DESCRIPTION
rand() clamps, so if something were to be below 1, it would return 0.

This was causing a runtime

[10:35:07] Runtime in Chemistry-Holder.dm, line 547: Division by zero
proc name: add reagent (/datum/reagents/proc/add_reagent)
src: /datum/reagents (/datum/reagents)
call stack:
/datum/reagents (/datum/reagents): add reagent("toxin", 0, null, 300)
the cockroach (/mob/living/simple_animal/cockroach): wander move(the floor (234,235,1) (/turf/simulated/floor))

And has likely led to a few odd rounding errors.