### PR TITLE
Chloral Hydrate Rework

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -3324,7 +3324,10 @@
 			M.confused += 2
 			M.drowsyness += 2
 		if(2 to 80)
-			M.sleeping++
+			M.confused++
+			M.drowsyness++
+			if(volume >= 10)
+				M.sleeping++
 		if(81 to INFINITY)
 			M.sleeping++
 			M.toxloss += (data - 50)


### PR DESCRIPTION
I do realize this will probably be torn up and require a server vote or two.  That said, I honestly believe it is a change that is good for the health of the game.  From my perspective, no one enjoys Chloral Hydrate in its current form and how easy it is to make and use.  It does not make for a fun tool to both use as an antagonist and to have it used against you.  It currently is the go-to as the answer to a LARGE amount of situations on both sides.

What this changes is that Chloral Hydrate will only apply a knockout affect if the chloral in the system is greater than or equal to 10 units after the second tick is processed.  Instead, for the duration it is processed for amounts under 10u, it will apply the same confused/dizzyness state that is experienced during the initial effect.  This roughly weighs out to 50 seconds of a confused/dizzyness state for every 5u in the system.  It should be stated that the target will still be confused/dizzy for a short while after the initial sleep passes (which is actually really cool).

The knockout threshold will still allow for syringe guns and multiple hypospray uses (the confused and slow state makes such easier) to knockout a person, but it will essentially remove how chloral hydrate autoinjectors function and instead make it more of a combat oriented advantage to prick someone with one. 

:cl:
 * tweak: Reworks Chloral Hydrate to only apply a knockdown when above 10u and apply a confused/drowsy state for all amounts below 10u.