### PR TITLE
Fixes a few bugs related to religions.

### DIFF
--- a/code/game/objects/items/weapons/storage/bible.dm
+++ b/code/game/objects/items/weapons/storage/bible.dm
@@ -193,10 +193,11 @@
 		to_chat(usr, "<span class='warning'> You do not have a religion to convert people to.</span>")
 		return FALSE
 
-	var/list/mob/moblist = range(1, owner)
+	var/list/mob/living/carbon/human/moblist = range(1, owner)
 	moblist -= owner
-	for (var/mob/dead/observer/O in moblist)
-		moblist -= O
+	for (var/mob/M in moblist)
+		if(!istype(M))
+			moblist -= M
 
 	var/mob/living/subject = input(owner, "Who do you wish to convert?", "Religious converting") as null|mob in moblist
 

--- a/code/game/objects/items/weapons/storage/bible.dm
+++ b/code/game/objects/items/weapons/storage/bible.dm
@@ -193,8 +193,10 @@
 		to_chat(usr, "<span class='warning'> You do not have a religion to convert people to.</span>")
 		return FALSE
 
-	var/list/mob/living/moblist = range(1, owner)
+	var/list/mob/moblist = range(1, owner)
 	moblist -= owner
+	for (var/mob/dead/observer/O in moblist)
+		moblist -= O
 
 	var/mob/living/subject = input(owner, "Who do you wish to convert?", "Religious converting") as null|mob in moblist
 

--- a/code/game/objects/items/weapons/storage/bible.dm
+++ b/code/game/objects/items/weapons/storage/bible.dm
@@ -193,11 +193,11 @@
 		to_chat(usr, "<span class='warning'> You do not have a religion to convert people to.</span>")
 		return FALSE
 
-	var/list/mob/living/carbon/human/moblist = range(1, owner)
-	moblist -= owner
-	for (var/mob/M in moblist)
-		if(!istype(M))
-			moblist -= M
+	var/list/mob/moblist_t = range(1, owner)
+	moblist_t -= owner
+	var/list/mob/moblist = list()
+	for (var/mob/carbon/human/H in moblist)
+		moblist += H
 
 	var/mob/living/subject = input(owner, "Who do you wish to convert?", "Religious converting") as null|mob in moblist
 

--- a/code/game/objects/items/weapons/storage/bible.dm
+++ b/code/game/objects/items/weapons/storage/bible.dm
@@ -193,11 +193,10 @@
 		to_chat(usr, "<span class='warning'> You do not have a religion to convert people to.</span>")
 		return FALSE
 
-	var/list/mob/moblist_t = range(1, owner)
-	moblist_t -= owner
 	var/list/mob/moblist = list()
-	for (var/mob/living/carbon/human/H in moblist)
+	for (var/mob/living/carbon/human/H in range(1, owner))
 		moblist += H
+	moblist -= owner
 
 	var/mob/living/subject = input(owner, "Who do you wish to convert?", "Religious converting") as null|mob in moblist
 

--- a/code/game/objects/items/weapons/storage/bible.dm
+++ b/code/game/objects/items/weapons/storage/bible.dm
@@ -196,7 +196,7 @@
 	var/list/mob/moblist_t = range(1, owner)
 	moblist_t -= owner
 	var/list/mob/moblist = list()
-	for (var/mob/carbon/human/H in moblist)
+	for (var/mob/living/carbon/human/H in moblist)
 		moblist += H
 
 	var/mob/living/subject = input(owner, "Who do you wish to convert?", "Religious converting") as null|mob in moblist

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -4621,7 +4621,8 @@
 					to_chat(usr, "<span class='warning'>Error: no deity or message selected.</span>")
 
 				for (var/datum/mind/M in R.adepts)
-					to_chat(M.current, "You hear [deity]'s voice in your head... <i>[message]</i>")
+					if (M.current)
+						to_chat(M.current, "You hear [deity]'s voice in your head... <i>[message]</i>")
 
 				var/msg = "[key_name(usr)] sent message [message] to [R.name]'s adepts as [deity]"
 				message_admins(msg)


### PR DESCRIPTION
- Fixes a runtime in goonchat when addressing a mind which has no current body.

```
[08:32:19] Runtime in browserOutput.dm,264: DEBUG: Boutput called with invalid message
  proc name: to chat (/proc/to_chat)
  usr: The alien queen (shiftyrail) (/mob/dead/observer)
  usr.loc: space (203, 294, 1) (/turf/space)
  src: null
  call stack:
  to chat(null, "You hear Allah\'s voice in you...")
  /datum/admins (/datum/admins): Topic("src=\[0x2106a72b];religions=gl...", /list (/list))
  Shifty_rail (/client): Topic("src=\[0x2106a72b];religions=gl...", /list (/list), /datum/admins (/datum/admins))
  Shifty_rail (/client): Topic("src=\[0x2106a72b];religions=gl...", /list (/list), /datum/admins (/datum/admins))
```

- Fixes Chaplain seeing ghosts in the converting menu, because it's metagay. It also should fix them seeing xenos, borers, or anything not eligible.
