### PR TITLE
Fix dropping changeling verb holder on SoC ACT 2

### DIFF
--- a/code/game/objects/items/verb_holder.dm
+++ b/code/game/objects/items/verb_holder.dm
@@ -11,8 +11,10 @@
 	name = "verb holder"
 	desc = "You shouldn't see this."
 
-	density=0
-	abstract=1
+	density = FALSE
+	abstract = TRUE
 
+/obj/item/verbs/dropped()
+	qdel(src)
 // Then you just slap verbs in here and send_verbs(mob).
 // Done.


### PR DESCRIPTION
fixes #14399

:cl:
 * bugfix: Fixes verb holders falling out of your pocket.