### PR TITLE
Adds some sanity to lighting_source.dm

### DIFF
--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -278,8 +278,8 @@
 	L = affecting_turfs - turfs // Now-gone turfs, remove us from the affecting lights.
 	affecting_turfs -= L
 	for (var/turf/T in L)
-		if(T.affecting_lights && T.affecting_lights.Find(src))
-			T.affecting_lights -= src
+		if(T.affecting_lights)
+			T.affecting_lights.Remove(src)
 
 	for (var/datum/lighting_corner/C in corners - effect_str) // New corners
 		C.affecting += src

--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -278,7 +278,8 @@
 	L = affecting_turfs - turfs // Now-gone turfs, remove us from the affecting lights.
 	affecting_turfs -= L
 	for (var/turf/T in L)
-		T.affecting_lights -= src
+		if(T.affecting_lights && T.affecting_lights.Find(src))
+			T.affecting_lights -= src
 
 	for (var/datum/lighting_corner/C in corners - effect_str) // New corners
 		C.affecting += src


### PR DESCRIPTION
[04:55:53] Runtime in lighting_source.dm,281: type mismatch: null -= /datum/light_source (/datum/light_source) seems to imply that as it itterates through the turfs at that point where it tries to remove itself from that turfs affecting_lights, it finds that it isn't in the turfs affecting lights, and crashes, causing light to cease functioning.

A little bit of sanity to make sure the turfs affecting lights both exists, and contains the src, should help resolve this issue