### PR TITLE
Removes Anomaly requirement for chef/botany borg upgrades.

### DIFF
--- a/code/modules/research/designs/borg_upgrades.dm
+++ b/code/modules/research/designs/borg_upgrades.dm
@@ -92,7 +92,7 @@
 	name = "Medical cyborg MK-2 upgrade"
 	desc = "Used to give a medical cyborg advanced care tools and upgrade their chemistry gripper to be able to handle pills and pill bottles."
 	id = "medical_module_surgery"
-	req_tech = list(Tc_BIOTECH = 3, Tc_ENGINEERING = 3, Tc_MATERIALS = 6)
+	req_tech = list(Tc_BIOTECH = 3, Tc_ENGINEERING = 3, Tc_ANOMALY = 3)
 	build_type = MECHFAB
 	materials = list(MAT_IRON=80000, MAT_GLASS=20000, MAT_SILVER=5000)
 	build_path = /obj/item/borg/upgrade/medical/surgery

--- a/code/modules/research/designs/borg_upgrades.dm
+++ b/code/modules/research/designs/borg_upgrades.dm
@@ -92,7 +92,7 @@
 	name = "Medical cyborg MK-2 upgrade"
 	desc = "Used to give a medical cyborg advanced care tools and upgrade their chemistry gripper to be able to handle pills and pill bottles."
 	id = "medical_module_surgery"
-	req_tech = list(Tc_BIOTECH = 3, Tc_ENGINEERING = 3, Tc_ANOMALY = 3)
+	req_tech = list(Tc_BIOTECH = 3, Tc_ENGINEERING = 3, Tc_ANOMALY = 2)
 	build_type = MECHFAB
 	materials = list(MAT_IRON=80000, MAT_GLASS=20000, MAT_SILVER=5000)
 	build_path = /obj/item/borg/upgrade/medical/surgery

--- a/code/modules/research/designs/borg_upgrades.dm
+++ b/code/modules/research/designs/borg_upgrades.dm
@@ -82,7 +82,7 @@
 	name = "Engineering cyborg magnetic gripper upgrade"
 	desc = "Used to give a engineering cyborg a magnetic gripper."
 	id = "borg_magnetic_gripper_board"
-	req_tech = list(Tc_MAGNETS = 5, Tc_ENGINEERING = 5, Tc_ANOMALY = 3)
+	req_tech = list(Tc_MAGNETS = 5, Tc_ENGINEERING = 5, Tc_MATERIALS = 6)
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/magnetic_gripper
 	category = "Robotic_Upgrade_Modules"
@@ -92,7 +92,7 @@
 	name = "Medical cyborg MK-2 upgrade"
 	desc = "Used to give a medical cyborg advanced care tools and upgrade their chemistry gripper to be able to handle pills and pill bottles."
 	id = "medical_module_surgery"
-	req_tech = list(Tc_BIOTECH = 3, Tc_ENGINEERING = 3, Tc_ANOMALY = 2)
+	req_tech = list(Tc_BIOTECH = 3, Tc_ENGINEERING = 3, Tc_MATERIALS = 6)
 	build_type = MECHFAB
 	materials = list(MAT_IRON=80000, MAT_GLASS=20000, MAT_SILVER=5000)
 	build_path = /obj/item/borg/upgrade/medical/surgery
@@ -102,7 +102,7 @@
 	name = "Medical cyborg organ gripper upgrade"
 	desc = "Used to give a medical cyborg a organ gripper."
 	id = "borg_organ_gripper_board"
-	req_tech = list(Tc_BIOTECH = 5, Tc_ENGINEERING = 4, Tc_ANOMALY = 3)
+	req_tech = list(Tc_BIOTECH = 5, Tc_ENGINEERING = 4, Tc_MATERIALS = 6)
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/organ_gripper
 	category = "Robotic_Upgrade_Modules"
@@ -112,7 +112,7 @@
 	name = "Service cyborg cooking upgrade"
 	desc = "Used to give a service cyborg cooking tools and upgrade their service gripper to be able to handle food."
 	id = "borg_service_module"
-	req_tech = list(Tc_BIOTECH = 2, Tc_ENGINEERING = 3, Tc_PROGRAMMING = 2, Tc_ANOMALY = 2)
+	req_tech = list(Tc_BIOTECH = 2, Tc_ENGINEERING = 3, Tc_PROGRAMMING = 2, Tc_MATERIALS = 6)
 	build_type = MECHFAB
 	materials = list(MAT_IRON=45000, MAT_GLASS=8000, MAT_GOLD=2500)
 	build_path = /obj/item/borg/upgrade/service
@@ -122,7 +122,7 @@
 	name = "Service cyborg H.U.E.Y. upgrade"
 	desc = "Used to give a service cyborg hydroponics tools and upgrade their service gripper to be able to handle seeds, weed killers, sprayers and glass containers."
 	id = "borg_service_module_hydro"
-	req_tech = list(Tc_BIOTECH = 4, Tc_ENGINEERING = 2, Tc_PROGRAMMING = 2, Tc_ANOMALY = 2)
+	req_tech = list(Tc_BIOTECH = 4, Tc_ENGINEERING = 2, Tc_PROGRAMMING = 2)
 	build_type = MECHFAB
 	materials = list(MAT_IRON=45000, MAT_GLASS=8000, MAT_PLASTIC=2500)
 	build_path = /obj/item/borg/upgrade/hydro

--- a/code/modules/research/designs/borg_upgrades.dm
+++ b/code/modules/research/designs/borg_upgrades.dm
@@ -82,7 +82,7 @@
 	name = "Engineering cyborg magnetic gripper upgrade"
 	desc = "Used to give a engineering cyborg a magnetic gripper."
 	id = "borg_magnetic_gripper_board"
-	req_tech = list(Tc_MAGNETS = 5, Tc_ENGINEERING = 5, Tc_MATERIALS = 6)
+	req_tech = list(Tc_MAGNETS = 5, Tc_ENGINEERING = 5, Tc_ANOMALY = 3)
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/magnetic_gripper
 	category = "Robotic_Upgrade_Modules"


### PR DESCRIPTION
Is this how one PRs?

Removes the anomaly research requirement for some borg upgrades. It practically never gets done, and the chef/botany borg upgrades have no reason to be gated behind it. 

Closes #17107

:cl:
*rscadd: Removes anomaly requirement for botany/chef borg upgrades.
