### PR TITLE
Discord MoMMI routing refactor.

### DIFF
--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -67,7 +67,7 @@ var/datum/controller/gameticker/ticker
 		))
 	login_music = fcopy_rsc(oursong)
 
-	send2maindiscord("Server is loaded and in pre-game lobby at [config.server? "byond://[config.server]" : "byond://[world.address]:[world.port]"]")
+	send2maindiscord("**Server is loaded** and in pre-game lobby at `[config.server? "byond://[config.server]" : "byond://[world.address]:[world.port]"]`")
 
 	do
 		var/delay_timetotal = 3000 //actually 5 minutes or incase this is changed from 3000, (time_in_seconds * 10)

--- a/code/modules/ext_scripts/discord.dm
+++ b/code/modules/ext_scripts/discord.dm
@@ -1,12 +1,18 @@
+// Sends to the SERVER STATUS channels.
+// This sends to the "server_status" gamenudge route.
 /proc/send2maindiscord(var/msg)
-	send2discord(msg, FALSE)
+	send2discord(msg, "server_status")
 
+// Sends to the adminbus ahelp channels.
+// This sends to the "adminhelp" gamenudge route.
 /proc/send2admindiscord(var/msg, var/ping = FALSE)
-	send2discord(msg, TRUE, ping)
+	send2discord(msg, "adminhelp", ping)
 
-/proc/send2discord(var/msg, var/admin = FALSE, var/ping = FALSE)
+// Meta argument here is the MoMMI meta argument to send to the gamenudge route.
+// AKA the MoMMI config file chooses where to send it based on this key.
+/proc/send2discord(var/msg, var/meta, var/ping = FALSE)
 	if (!global.config.discord_url || !global.config.discord_password)
 		return
 
-	var/url = "[global.config.discord_url]?pass=[url_encode(global.config.discord_password)]&admin=[admin ? "true" : "false"]&content=[url_encode(msg)]&ping=[ping ? "true" : "false"]"
+	var/url = "[global.config.discord_url]?pass=[url_encode(global.config.discord_password)]&meta=[url_encode(meta)]&content=[url_encode(msg)]&ping=[ping ? "true" : "false"]"
 	world.Export(url)


### PR DESCRIPTION
Now correctly uses meta routes instead of admin y/n. None of you know what this means so just merge this ¯\\\_(ツ)_/¯.

