### PR TITLE
Atmos shortcuts (THIS TIME WITH NO GHOST PLASMAFLOODING)

### DIFF
--- a/code/ATMOSPHERICS/components/binary_devices/MSGS.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/MSGS.dm
@@ -15,7 +15,6 @@
 	var/max_pressure = 10000
 
 	var/target_pressure = 4500	//Output pressure.
-	var/on = 0								//Are we taking in gas?
 
 	var/datum/gas_mixture/air				//Internal tank.
 
@@ -298,6 +297,9 @@
 		return
 
 	src.dir = turn(src.dir, -90)
+
+/obj/machinery/atmospherics/binary/msgs/toggle_status(var/mob/user)
+	return FALSE
 
 #undef MSGS_ON
 #undef MSGS_INPUT

--- a/code/ATMOSPHERICS/components/binary_devices/binary_atmos_base.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/binary_atmos_base.dm
@@ -14,6 +14,7 @@
 
 	var/activity_log = ""
 	layer = BINARY_PIPE_LAYER
+	var/on = FALSE
 
 /obj/machinery/atmospherics/binary/investigation_log(var/subject, var/message)
 	activity_log += ..()
@@ -46,6 +47,23 @@
 /obj/machinery/atmospherics/binary/update_icon(var/adjacent_procd)
 	var/node_list = list(node1,node2)
 	..(adjacent_procd,node_list)
+
+// Returns TRUE if successful
+/obj/machinery/atmospherics/binary/proc/toggle_status(var/mob/user)
+	if(!allowed(user))
+		to_chat(user, "<span class='warning'>Access denied.</span>")
+		return FALSE
+	on = !on
+	investigation_log(I_ATMOS, "was turned [on ? "on" : "off"] by [key_name(user)].")
+	update_icon()
+	return TRUE
+
+/obj/machinery/atmospherics/binary/AltClick(var/mob/user)
+	if(user.incapacitated() || (!issilicon(user) && !Adjacent(user)))
+		..()
+		return
+	if(!toggle_status(user)) // Subtypes returning FALSE do not allow alt-clicking to toggle power
+		..()
 
 /obj/machinery/atmospherics/binary/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
 	dir = pipe.dir

--- a/code/ATMOSPHERICS/components/binary_devices/circulator.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/circulator.dm
@@ -166,3 +166,6 @@
 		return
 
 	src.dir = turn(src.dir, -90)
+
+/obj/machinery/atmospherics/binary/circulator/toggle_status(var/mob/user)
+	return FALSE

--- a/code/ATMOSPHERICS/components/binary_devices/dp_vent_pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/dp_vent_pump.dm
@@ -10,7 +10,6 @@
 
 	level = 1
 
-	var/on = 0
 	var/pump_direction = 1 //0 = siphoning, 1 = releasing
 
 	var/external_pressure_bound = ONE_ATMOSPHERE
@@ -220,3 +219,6 @@
 	id_tag = O.id_tag
 	set_frequency(O.frequency)
 	return 1
+
+/obj/machinery/atmospherics/binary/dp_vent_pump/toggle_status(var/mob/user)
+	return FALSE

--- a/code/ATMOSPHERICS/components/binary_devices/passive_gate.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/passive_gate.dm
@@ -9,7 +9,6 @@
 	name = "Passive gate"
 	desc = "A one-way air valve that does not require power"
 
-	var/on = 0
 	var/target_pressure = ONE_ATMOSPHERE
 
 	var/frequency = 0

--- a/code/ATMOSPHERICS/components/binary_devices/pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/pump.dm
@@ -20,7 +20,6 @@ Thus, the two variables affect pump operation are set in New():
 
 	name = "Gas pump"
 	desc = "A pump."
-	var/on = 0
 	var/target_pressure = ONE_ATMOSPHERE
 
 	var/frequency = 0
@@ -166,8 +165,7 @@ Thus, the two variables affect pump operation are set in New():
 	if(..())
 		return
 	if(href_list["power"])
-		on = !on
-		investigation_log(I_ATMOS,"was turned [on ? "on" : "off"] by [key_name(usr)].")
+		toggle_status()
 	if(href_list["set_press"])
 		var/new_pressure = input(usr,"Enter new output pressure (0-[MAX_PRESSURE]kPa)","Pressure control",src.target_pressure) as num
 		src.target_pressure = max(0, min(MAX_PRESSURE, new_pressure))

--- a/code/ATMOSPHERICS/components/binary_devices/pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/pump.dm
@@ -165,7 +165,8 @@ Thus, the two variables affect pump operation are set in New():
 	if(..())
 		return
 	if(href_list["power"])
-		toggle_status()
+		on = !on
+		investigation_log(I_ATMOS,"was turned [on ? "on" : "off"] by [key_name(usr)].")
 	if(href_list["set_press"])
 		var/new_pressure = input(usr,"Enter new output pressure (0-[MAX_PRESSURE]kPa)","Pressure control",src.target_pressure) as num
 		src.target_pressure = max(0, min(MAX_PRESSURE, new_pressure))

--- a/code/ATMOSPHERICS/components/binary_devices/valve.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/valve.dm
@@ -214,7 +214,11 @@
 		investigation_log(I_ATMOS,"was [(open ? "opened" : "closed")] by a signal")
 
 /obj/machinery/atmospherics/binary/valve/npc_tamper_act(mob/living/L)
-	toggle_status()
+	if(open)
+		close()
+	else
+		open()
+	investigation_log(I_ATMOS,"was [(open ? "opened" : "closed")] by [key_name(L)]")
 
 /obj/machinery/atmospherics/binary/valve/toggle_status(var/mob/user)
 	if(!allowed(user))

--- a/code/ATMOSPHERICS/components/binary_devices/valve.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/valve.dm
@@ -4,11 +4,11 @@
 
 	name = "manual valve"
 	desc = "A pipe valve."
-	var/open = 0
+	var/open = FALSE
 	var/openDuringInit = 0
 
 /obj/machinery/atmospherics/binary/valve/open
-	open = 1
+	open = TRUE
 	icon_state = "hvalve1"
 
 /obj/machinery/atmospherics/binary/valve/update_icon(var/adjacent_procd,var/animation)
@@ -33,12 +33,10 @@
 	return null
 
 /obj/machinery/atmospherics/binary/valve/proc/open()
-
-
 	if(open)
 		return 0
 
-	open = 1
+	open = TRUE
 	update_icon()
 
 	if(network1&&network2)
@@ -53,12 +51,10 @@
 	return 1
 
 /obj/machinery/atmospherics/binary/valve/proc/close()
-
-
 	if(!open)
 		return 0
 
-	open = 0
+	open = FALSE
 	update_icon()
 
 	if(network1)
@@ -218,8 +214,15 @@
 		investigation_log(I_ATMOS,"was [(open ? "opened" : "closed")] by a signal")
 
 /obj/machinery/atmospherics/binary/valve/npc_tamper_act(mob/living/L)
+	toggle_status()
+
+/obj/machinery/atmospherics/binary/valve/toggle_status(var/mob/user)
+	if(!allowed(user))
+		to_chat(user, "<span class='warning'>Access denied.</span>")
+		return FALSE
 	if(open)
 		close()
 	else
 		open()
-	investigation_log(I_ATMOS,"was [(open ? "opened" : "closed")] by [key_name(L)]")
+	investigation_log(I_ATMOS,"was [(open ? "opened" : "closed")] by [key_name(user)]")
+	return TRUE

--- a/code/ATMOSPHERICS/components/binary_devices/volume_pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/volume_pump.dm
@@ -21,7 +21,6 @@ Thus, the two variables affect pump operation are set in New():
 	name = "Volumetric gas pump"
 	desc = "A volumetric pump"
 
-	var/on = 0
 	var/transfer_rate = MAX_TRANSFER_RATE
 
 	var/frequency = 0

--- a/code/ATMOSPHERICS/pipe/construction.dm
+++ b/code/ATMOSPHERICS/pipe/construction.dm
@@ -322,6 +322,12 @@ var/list/manifold_pipes = list(PIPE_MANIFOLD4W, PIPE_INSUL_MANIFOLD4W, PIPE_HE_M
 	//src.pipe_dir = get_pipe_dir()
 	return
 
+/obj/item/pipe/AltClick(var/mob/user)
+	if(user.incapacitated() || !Adjacent(user))
+		..()
+		return
+	rotate()
+
 /obj/item/pipe/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	..()
 	if ((pipe_type in bent_pipes) \


### PR DESCRIPTION
Differences from #16543

- Defines instead of numbers
- Renamed the proc from `toggle_power` to `toggle_status`, making the valves reuse the existing `open` var, since you're not really turning off valves (why do we need these shortcuts for valves, anyway? `attack_hand` already does this, I guess for consistency)
- Added sanity checks to `AltClick`: ghosts can no longer plasma flood

Changelog not needed as it wasn't reverted