### PR TITLE
Removes one of the sources of telecomms lag

### DIFF
--- a/code/game/machinery/telecomms/broadcaster.dm
+++ b/code/game/machinery/telecomms/broadcaster.dm
@@ -57,10 +57,6 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 			return
 		recentmessages.Add(signal_message)
 
-		// This may be causing some performance issues. - N3X
-		if(signal.data["slow"] > 0)
-			sleep(signal.data["slow"]) // simulate the network lag if necessary
-
 		signal.data["level"] |= listening_level
 
 	   /** #### - Normal Broadcast - #### **/
@@ -158,9 +154,6 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 		var/datum/signal/original = signal.data["original"]
 		if(original)
 			original.data["done"] = 1
-
-		if(signal.data["slow"] > 0)
-			sleep(signal.data["slow"]) // simulate the network lag if necessary
 
 		/* ###### Broadcast a message using signal.data ###### */
 
@@ -608,7 +601,6 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 
 	// --- Finally, tag the actual signal with the appropriate values ---
 	signal.data = list(
-		"slow" = 0, // how much to sleep() before broadcasting - simulates net lag
 		"message" = "TEST",
 		"compression" = rand(45, 50), // If the signal is compressed, compress our message too.
 		"traffic" = 0, // dictates the total traffic sum that the signal went through

--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -48,13 +48,6 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 		return
 	var/send_count = 0
 
-	signal.data["slow"] += rand(0, round((100-get_integrity()))) // apply some lag based on integrity TODO: delet this
-
-	// Apply some lag based on traffic rates
-	var/netlag = round(traffic / 50)
-	if(netlag > signal.data["slow"])
-		signal.data["slow"] = netlag
-
 // Loop through all linked machines and send the signal or copy.
 	for(var/obj/machinery/telecomms/machine in links)
 		if(!machine.loc)
@@ -88,7 +81,6 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 				"compression" = signal.data["compression"],
 				"message" = signal.data["message"],
 				"radio" = signal.data["radio"],
-				"slow" = signal.data["slow"],
 				"traffic" = signal.data["traffic"],
 				"type" = signal.data["type"],
 				"server" = signal.data["server"],
@@ -504,16 +496,11 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 			if(send_to_processor)
 				return
 			// failed to send to a processor, relay information anyway
-			signal.data["slow"] += rand(1, 5) // slow the signal down only slightly
 			src.receive_information(signal, src)
 
 		// Try sending it!
 		var/list/try_send = list("/obj/machinery/telecomms/server", "/obj/machinery/telecomms/hub", "/obj/machinery/telecomms/broadcaster", "/obj/machinery/telecomms/bus")
-		var/i = 0
 		for(var/send in try_send)
-			if(i)
-				signal.data["slow"] += rand(0, 1) // slow the signal down only slightly
-			i++
 			var/can_send = relay_information(signal, send)
 			if(can_send)
 				break
@@ -569,7 +556,6 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 		if(istype(machine_from, /obj/machinery/telecomms/bus))
 			relay_direct_information(signal, machine_from) // send the signal back to the machine
 		else // no bus detected - send the signal to servers instead
-			signal.data["slow"] += rand(5, 10) // slow the signal down
 			relay_information(signal, "/obj/machinery/telecomms/server")
 
 

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -349,7 +349,6 @@
 			"compression" = rand(45,50), // compressed radio signal
 			"message" = speech.message, // the actual sent message
 			"radio" = src, // stores the radio used for transmission
-			"slow" = 0, // how much to sleep() before broadcasting - simulates net lag
 			"traffic" = 0, // dictates the total traffic sum that the signal went through
 			"type" = 0, // determines what type of radio input it is: normal broadcast
 			"server" = null, // the last server to log this signal
@@ -409,7 +408,6 @@
 		"compression" = 0, // uncompressed radio signal
 		"message" = speech.message, // the actual sent message
 		"radio" = src, // stores the radio used for transmission
-		"slow" = 0,
 		"traffic" = 0,
 		"type" = 0,
 		"server" = null,


### PR DESCRIPTION
Damaged telecomms machines would increase the radio signal's `slow` value, then the broadcaster would do `sleep(slow)` before relaying your message. This resulted in all sorts of Bad Things because of how saycode works: if you talked on a radio, or were in range of an intercom/SBR your message would get delayed (including the voice coming out of your character's mouth, since for SOME REASON that's processed AFTER the radio message), rendering communication impossible (and breaking my emulsions).

With these changes the slowdown is completely gone. This does mean that the only downside to damaging telecomms is that they'll stop working entirely once the integrity goes to 0, but I'm sure this is better than what we had before. Eventually ™️ this behavior could be changed to something else in a later PR, but for now REMOVE THIS SHIT.

:cl:
 * tweak: Damaged telecommunications machinery will no longer delay relayed messages.