### PR TITLE
Virology machinery and account database tweaks

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -748,3 +748,6 @@ Class Procs:
 			scan.forceMove(get_turf(src))
 			visible_message("<span class='notice'>\A [scan] pops out of \the [src]!</span>")
 			scan = null
+
+/obj/machinery/proc/is_operational()
+	return !(stat & (NOPOWER|BROKEN|MAINT))

--- a/code/modules/Economy/Accounts.dm
+++ b/code/modules/Economy/Accounts.dm
@@ -275,7 +275,7 @@ var/global/list/all_money_accounts = list()
 	. = ..()
 	if(.)
 		return
-	if(istype(O, /obj/item/weapon/card/id))
+	if(isID(O))
 		var/obj/item/weapon/card/id/idcard = O
 		if(access_level == 3)
 			return attack_hand(user)

--- a/code/modules/Economy/Accounts.dm
+++ b/code/modules/Economy/Accounts.dm
@@ -144,11 +144,12 @@ var/global/list/all_money_accounts = list()
 	var/source_terminal = ""
 
 /obj/machinery/account_database
-	name = "Accounts database"
+	name = "accounts database"
 	desc = "Holds transaction logs, account data and all kinds of other financial records."
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "account_db"
-	density = 1
+	density = TRUE
+	anchored = TRUE
 	req_one_access = list(access_hop, access_captain)
 	var/receipt_num
 	var/machine_id = ""
@@ -158,6 +159,7 @@ var/global/list/all_money_accounts = list()
 	var/creating_new_account = 0
 	var/activated = 1
 
+	machine_flags = EMAGGABLE | WRENCHMOVE | FIXED2WORK | EJECTNOTDEL
 	ghost_read=0
 	ghost_write=0
 
@@ -198,6 +200,9 @@ var/global/list/all_money_accounts = list()
 	..()
 
 /obj/machinery/account_database/attack_hand(mob/user as mob)
+	. = ..()
+	if(.)
+		return
 	if(ishuman(user) && !user.stat && get_dist(src,user) <= 1)
 		var/dat = "<b>Accounts Database</b><br>"
 
@@ -266,14 +271,14 @@ var/global/list/all_money_accounts = list()
 	else
 		user << browse(null,"window=account_db")
 
-/obj/machinery/account_database/attackby(O as obj, user as mob)//TODO:SANITY
-	if(istype(O, /obj/item/weapon/card))
+/obj/machinery/account_database/attackby(var/obj/O, var/mob/user)
+	. = ..()
+	if(.)
+		return
+	if(istype(O, /obj/item/weapon/card/id))
 		var/obj/item/weapon/card/id/idcard = O
 		if(access_level == 3)
 			return attack_hand(user)
-		if(istype(idcard, /obj/item/weapon/card/emag))
-			emag(user)
-			return
 		if(!held_card)
 			if(usr.drop_item(O, src))
 				held_card = idcard
@@ -282,8 +287,6 @@ var/global/list/all_money_accounts = list()
 					access_level = 2
 				else if(access_hop in idcard.access || access_captain in idcard.access)
 					access_level = 1
-	else
-		..()
 
 /obj/machinery/account_database/emag(mob/user)
 	if(emagged)

--- a/code/modules/virus2/analyser.dm
+++ b/code/modules/virus2/analyser.dm
@@ -1,11 +1,11 @@
 /obj/machinery/disease2/diseaseanalyser
-	name = "Disease Analyser"
+	name = "disease analyser"
 	desc = "For analysing and storing viral samples."
 	icon = 'icons/obj/virology.dmi'
 	icon_state = "analyser"
-	anchored = 1
-	density = 1
-	machine_flags = SCREWTOGGLE | CROWDESTROY
+	anchored = TRUE
+	density = TRUE
+	machine_flags = SCREWTOGGLE | CROWDESTROY | WRENCHMOVE | FIXED2WORK | EJECTNOTDEL
 
 	var/scanning = 0
 	var/pause = 0
@@ -39,7 +39,9 @@
 	process_time = round((initial(process_time) - lasercount))
 
 /obj/machinery/disease2/diseaseanalyser/attackby(var/obj/I as obj, var/mob/user as mob)
-	..()
+	. = ..()
+	if(.)
+		return
 	if(istype(I,/obj/item/weapon/virusdish))
 		var/mob/living/carbon/c = user
 		var/obj/item/weapon/virusdish/D = I
@@ -100,8 +102,12 @@
 /obj/machinery/disease2/diseaseanalyser/Topic(href, href_list)
 	if(..())
 		return 1
-	if(usr)
-		usr.set_machine(src)
+	if(href_list["close"])
+		usr << browse(null, "\ref[src]")
+		usr.unset_machine()
+		return 1
+
+	usr.set_machine(src)
 	if(href_list["eject"])
 		for(var/obj/item/weapon/virusdish/O in src.contents)
 			if("[O.virus2.uniqueID]" == href_list["name"])
@@ -115,6 +121,9 @@
 				PrintPaper(O)
 
 /obj/machinery/disease2/diseaseanalyser/attack_hand(var/mob/user as mob)
+	. = ..()
+	if(.)
+		return
 	user.set_machine(src)
 	var/dat = list()
 	dat += "Currently stored samples: [src.contents.len]<br><hr>"
@@ -144,7 +153,6 @@
 			dat += "</tr>"
 		dat += "</table>"
 	dat = jointext(dat,"")
-	var/datum/browser/popup = new(user, "disease_analyzer", "Viral Storage & Analysis Unit", 600, 350, src)
+	var/datum/browser/popup = new(user, "\ref[src]", "Viral Storage & Analysis Unit", 600, 350, src)
 	popup.set_content(dat)
 	popup.open()
-	onclose(user, "disease_analyzer")

--- a/code/modules/virus2/centrifuge.dm
+++ b/code/modules/virus2/centrifuge.dm
@@ -1,12 +1,13 @@
 /obj/machinery/centrifuge
-	name = "Isolation Centrifuge"
+	name = "isolation centrifuge"
 	desc = "Used to separate things with different weight. Spin 'em round, round, right round."
 	icon = 'icons/obj/virology.dmi'
 	icon_state = "centrifuge"
-	density = 1
+	density = TRUE
+	anchored = TRUE
 	idle_power_usage = 10
 	active_power_usage = 500
-	machine_flags = SCREWTOGGLE | CROWDESTROY
+	machine_flags = SCREWTOGGLE | CROWDESTROY | WRENCHMOVE | FIXED2WORK | EJECTNOTDEL
 
 	var/base_state = "centrifuge"
 	var/curing
@@ -36,18 +37,23 @@
 			manipcount += SP.rating
 	general_process_time = round((initial(general_process_time) / manipcount))
 
-/obj/machinery/centrifuge/attackby(var/obj/item/weapon/reagent_containers/glass/beaker/vial/I, var/mob/user as mob)
-	if(!istype(I))
-		return ..()
+/obj/machinery/centrifuge/attackby(var/obj/item/I, var/mob/user)
+	. = ..()
+	if(.)
+		return
+	if(!is_operational())
+		return FALSE
+	if(!istype(I, /obj/item/weapon/reagent_containers/glass/beaker/vial) || !iscarbon(user))
+		return FALSE
 
 	var/mob/living/carbon/C = user
 	if(!sample)
 		if(!C.drop_item(I, src))
-			return 1
-
+			return FALSE
 		sample = I
 
-	attack_hand(user)
+	updateUsrDialog()
+	return TRUE
 
 //Also handles luminosity
 /obj/machinery/centrifuge/update_icon()
@@ -65,7 +71,8 @@
 		set_light(0)
 
 /obj/machinery/centrifuge/attack_hand(var/mob/user as mob)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	user.set_machine(src)
 	var/dat = list()
@@ -98,10 +105,9 @@
 		dat += "</td></tr></table><br>"
 		dat += "<hr>"
 	dat = jointext(dat,"")
-	var/datum/browser/popup = new(user, "iso_centrifuge", "Isolation Centrifuge", 400, 300, src)
+	var/datum/browser/popup = new(user, "\ref[src]", "Isolation Centrifuge", 400, 300, src)
 	popup.set_content(dat)
 	popup.open()
-	onclose(user, "iso_centrifuge")
 
 /obj/machinery/centrifuge/process()
 
@@ -136,8 +142,12 @@
 	if(..())
 		return 1
 
-	if(usr)
-		usr.set_machine(src)
+	if(href_list["close"])
+		usr << browse(null, "\ref[src]")
+		usr.unset_machine()
+		return 1
+
+	usr.set_machine(src)
 
 	switch(href_list["action"])
 		if("antibody")


### PR DESCRIPTION
- Makes all the virology machinery & accounts database anchored but wrenchable, fixes #13605
- Adds sanity checks to prevent using the unanchored machinery from being used
- Fixes capitalization
- Fixed the pathogenic incubator window not properly closing (it would reopen each `process()`)

:cl:
 * bugfix: Made the virology machines and account database (un)wrenchable.
