### PR TITLE
Zombie Powder can now be removed by reagents-clearing methods

### DIFF
--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -478,6 +478,7 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 		var/datum/reagent/R = A
 		if (R.id == reagent)
 			R.reagent_deleted()
+			R.on_removal()
 			reagent_list -= A
 			R.holder = null
 			total_dirty=1


### PR DESCRIPTION
Fixes #16360, using what Exxion/Aurx suggested

Tested.