### PR TITLE
Minor fix for explosive chemical reactions

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -78,7 +78,7 @@
 		if(L.stat != DEAD)
 			e.amount *= 0.5
 	e.start()    
-	if(ismob(holder)
+	if(ismob(holder))
 		holder.del_reagent(POTASSIUM)
 		holder.del_reagent(WATER)
 	else

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -79,10 +79,10 @@
 			e.amount *= 0.5
 	e.start()    
 	if(istype(holder, /mob))
-        holder.del_reagent(POTASSIUM)
-        holder.del_reagent(WATER)
-    else
-        holder.clear_reagents()
+		holder.del_reagent(POTASSIUM)
+		holder.del_reagent(WATER)
+	else
+		holder.clear_reagents()
 
 /datum/chemical_reaction/creatine
 	name = "Creatine"

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -77,8 +77,12 @@
 		var/mob/living/L = holder.my_atom
 		if(L.stat != DEAD)
 			e.amount *= 0.5
-	e.start()
-	holder.clear_reagents()
+	e.start()    
+	if(istype(holder, /mob))
+        holder.del_reagent(POTASSIUM)
+        holder.del_reagent(WATER)
+    else
+        holder.clear_reagents()
 
 /datum/chemical_reaction/creatine
 	name = "Creatine"

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -78,7 +78,7 @@
 		if(L.stat != DEAD)
 			e.amount *= 0.5
 	e.start()    
-	if(istype(holder, /mob))
+	if(ismob(holder)
 		holder.del_reagent(POTASSIUM)
 		holder.del_reagent(WATER)
 	else


### PR DESCRIPTION
# Changelog
:cl:
 * bugfix: Fixes a bug with explosive chemical mixtures erroneously removing holders in mobs.