### PR TITLE
Fixes charcoal.

### DIFF
--- a/code/modules/reagents/reagents/vg.dm
+++ b/code/modules/reagents/reagents/vg.dm
@@ -11,23 +11,27 @@ var/global/list/charcoal_doesnt_remove=list(
 	name = "Activated Charcoal"
 	id = CHARCOAL
 	reagent_state = LIQUID
-	color = "#333333" // rgb: 200, 16, 64
+	color = "#333333" // rgb: 51, 51, 51
+	custom_metabolism = 0.06
 
-/datum/reagent/charcoal/on_mob_life(var/mob/living/M as mob)
+/datum/reagent/charcoal/on_mob_life(var/mob/living/M)
 	if(!M)
 		M = holder.my_atom
 
 	if(ishuman(M) && prob(5))
 		var/mob/living/carbon/human/H=M
 		H.vomit()
-		holder.remove_reagent("charcoal",volume) // Remove all charcoal.
 		return
 
+	var/found_any = FALSE
 	for(var/datum/reagent/reagent in holder.reagent_list)
 		if(reagent.id in charcoal_doesnt_remove)
 			continue
-		holder.remove_reagent(reagent.id, 3*REM)
+		holder.remove_reagent(reagent.id, 15*REM)
+		found_any = TRUE
+
+	if (!found_any)
+		holder.remove_reagent(CHARCOAL, volume)
 
 	M.adjustToxLoss(-2*REM)
 	..()
-	return


### PR DESCRIPTION
Charcoal now gets used up slower, and gets instantly cleared from the system when all other reagents are gone. Vomiting no longer deletes charcoal. The rate of reagent removal is increased by a factor of 5.

🆑 
- tweak: charcoal works faster, longer, and doesn't remove itself upon vomiting anymore. 
