### PR TITLE
fixes being able to brick the protolathe/autolathe for the round

### DIFF
--- a/code/modules/research/rdmachines.dm
+++ b/code/modules/research/rdmachines.dm
@@ -1,3 +1,5 @@
+#define ANIM_LENGTH 10
+
 //This file was auto-corrected by findeclaration.exe on 25.5.2012 20:42:33
 var/global/list/rnd_machines = list()
 //All devices that link into the R&D console fall into thise type for easy identification and some shared procs.
@@ -171,7 +173,6 @@ var/global/list/rnd_machines = list()
 		to_chat(user, "\The [src] must be linked to an R&D console first!")
 		return 1
 	if(istype(O,/obj/item/stack/sheet) && research_flags &TAKESMATIN)
-		busy = 1
 
 		var/found = "" //the matID we're compatible with
 		for(var/matID in materials.storage)
@@ -180,45 +181,47 @@ var/global/list/rnd_machines = list()
 				found = matID
 		if(!found)
 			if(O.materials && research_flags &FAB_RECYCLER)
-				busy = 0
 				return 0 //let the autolathe try to do it's thing
 			to_chat(user, "<span class='warning'>\The [src] rejects \the [O.name].</span>")
-			busy = 0
 			return 1
 		if(allowed_materials && allowed_materials.len)
 			if(!(found in allowed_materials))
 				if(O.materials && research_flags &FAB_RECYCLER)
-					busy = 0
 					return 0 //let the autolathe try to do it's thing
 				to_chat(user, "<span class='warning'>\The [src] rejects \the [O.name].</span>")
-				busy = 0
 				return 1
 
 		var/obj/item/stack/sheet/S = O
 		if (TotalMaterials() + S.perunit > max_material_storage)
 			to_chat(user, "<span class='warning'>\The [src]'s material bin is full. Please remove material before adding more.</span>")
-			busy = 0
 			return 1
 
 		var/obj/item/stack/sheet/stack = O
 		var/amount = round(input("How many sheets do you want to add? (0 - [stack.amount])") as num)//No decimals
-		if(!O || !O.loc || (O.loc != user && !isgripper(O.loc)))
-			busy = 0
-			return
-		if(amount < 0)//No negative numbers
-			amount = 0
-		if(amount == 0)
-			busy = 0
-			return 1	//1 So the autolathe doesn't recycle the stack.
+		if(!user.Adjacent(src) || !O || !O.loc || (O.loc != user && !isgripper(O.loc)))
+			return 1
+		if(!(amount > 0))
+			return 1
+	//1 So the autolathe doesn't recycle the stack.
 		if(amount > stack.amount)
 			amount = stack.amount
 		if(max_material_storage - TotalMaterials() < (amount*stack.perunit))//Can't overfill
 			amount = min(stack.amount, round((max_material_storage-TotalMaterials())/stack.perunit))
 
+		if (!(amount > 0))
+			to_chat(user, "<span class='warning'>\The [src]'s material bin is full. Please remove material before adding more.</span>")
+			return 1
+
+		if (busy)
+			to_chat(user, "<span class='warning'>\The [src] is busy. Please wait for completion of previous operation.</span>")
+			return 1
+
+		busy = TRUE
+
 		if(research_flags & HASMAT_OVER)
 			update_icon()
 			overlays |= image(icon = icon, icon_state = "[base_state]_[stack.name]")
-			spawn(10)
+			spawn(ANIM_LENGTH)
 				overlays -= image(icon = icon, icon_state = "[base_state]_[stack.name]")
 
 		icon_state = "[base_state]"
@@ -229,7 +232,8 @@ var/global/list/rnd_machines = list()
 
 		var/datum/material/material = materials.getMaterial(found)
 		materials.addAmount(found, amount * material.cc_per_sheet)
-		busy = 0
+		spawn(ANIM_LENGTH)
+			busy = FALSE
 		return 1
 	src.updateUsrDialog()
 	return 0
@@ -248,3 +252,5 @@ var/global/list/rnd_machines = list()
 	. = get_step(get_turf(src), output_dir)
 	if(!.)
 		return loc // Map edge I guess.
+
+#undef ANIM_LENGTH


### PR DESCRIPTION
adds missing adjacency check for inserting materials

fixes the stupidity of the busy var, now it only changes when the mats are actually being inserted (instead of when you slap the machine with them)
it now also lasts exactly as long as the animation does/would (currently 1 second) aka no more bricking unless byond is bricking

added a second check after the input() on whether or not it's busy or the bin is full since people will be able to have input()s open at the same time now

I labeled it hotfix because it sort of is but I don't care if it gets held up due to the amount of change

fixes https://github.com/vgstation-coders/vgstation13/issues/17174