### PR TITLE
Fix away missions not loading properly

### DIFF
--- a/code/datums/map_elements.dm
+++ b/code/datums/map_elements.dm
@@ -8,7 +8,7 @@ var/list/datum/map_element/map_elements = list()
 	var/type_abbreviation //Very short string that determines the map element's type (whether it's an away mission, a small vault, or something else)
 
 	var/file_path = "maps/randomvaults/new.dmm"
-	var/load_at_once = FALSE //If true, lag reduction methods will not be applied when this is loaded, freezing atmos and mob simulations until the map element is loaded.
+	var/load_at_once = TRUE //If true, lag reduction methods will not be applied when this is loaded, freezing atmos and mob simulations until the map element is loaded.
 
 	var/turf/location //Lower left turf of the map element
 


### PR DESCRIPTION
Basically reverts #15875 - while it removed some lag, it caused a lot of issues in big away missions due to atmos and mobs being processed before the map could load completely (according to the PR description it didn't happen on my machine, but it's very noticeable on the live server).
There's probably a way to fix this issue properly (by freezing mobs and atmos while they're loading), but it might be pretty hard.