### PR TITLE
Locks Crawling behind a do_after of 1 second, modified by the number of missing limbs.

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -53,9 +53,10 @@
 		A.attack_stump(src, params)
 
 	if(src.lying && !(isUnconscious() || stunned || paralysis) && check_crawl_ability() && isfloor(A) && isfloor(get_turf(src)) && proximity && !pulledby && !locked_to && !client.move_delayer.blocked())
-		var/crawldelay = movement_delay()*3
-		Move(A, get_dir(src,A), glide_size_override = crawldelay)
-		delayNextMove(crawldelay,additive=1)
+		if (do_after(src, A, 1 SECONDS))
+			var/crawldelay = movement_delay()*3
+			Move(A, get_dir(src,A), glide_size_override = crawldelay)
+			delayNextMove(crawldelay,additive=1)
 
 /atom/proc/attack_hand(mob/user as mob, params, var/proximity)
 	return

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -55,9 +55,8 @@
 	if(src.lying && !(isUnconscious() || stunned || paralysis) && check_crawl_ability() && isfloor(A) && isfloor(get_turf(src)) && proximity && !pulledby && !locked_to && !client.move_delayer.blocked())
 		var/delay = round(1 + base_movement_tally()/5) * 1 SECONDS
 		if (do_after(src, A, delay))
-			var/crawldelay = movement_delay()*3
 			Move(A, get_dir(src,A), glide_size_override = delay) // So that we're still smooth
-			delayNextMove(crawldelay,additive=1)
+			delayNextMove(delay, additive=1)
 
 /atom/proc/attack_hand(mob/user as mob, params, var/proximity)
 	return

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -53,9 +53,10 @@
 		A.attack_stump(src, params)
 
 	if(src.lying && !(isUnconscious() || stunned || paralysis) && check_crawl_ability() && isfloor(A) && isfloor(get_turf(src)) && proximity && !pulledby && !locked_to && !client.move_delayer.blocked())
-		if (do_after(src, A, 1 SECONDS))
+		var/delay = round(1 + base_movement_tally()/5) * 1 SECONDS
+		if (do_after(src, A, delay))
 			var/crawldelay = movement_delay()*3
-			Move(A, get_dir(src,A), glide_size_override = crawldelay)
+			Move(A, get_dir(src,A), glide_size_override = delay) // So that we're still smooth
 			delayNextMove(crawldelay,additive=1)
 
 /atom/proc/attack_hand(mob/user as mob, params, var/proximity)


### PR DESCRIPTION
Before : 
https://streamable.com/yu7om
After : 
https://streamable.com/d3deg

### Reasoning
Crawling is, in its current form, almost a straight upgrade to walking as it shields you from lubbed floors, makes you harder to hit by certain projectiles, and is also a good camouflage/ambush tool, while still offering the same movement speed and the possibility to disarm spam.

Said movement speed is a bug, and entirely unintended by @MadmanMartian, original coder of crawling.

As such, this PR locks the act of crawling behind a do_after of 1 seconds, preventing you from spamming that mouse button to escape security.

An intended, but additional effect is that it also locks you in a direction. If you clicked on a tile, you'll crawl on that tile exactly one second after.

You can still crawl diagonally.

:cl:
- tweak: Crawling now requires you to stand still for exactly 1 seconds before moving. Missing/damaged limbs significantly increase that delay. Hyperzine counteracts those adverse effects. Additionally, once you've began to crawl in a certain direction, you can no longer change said direction.