### PR TITLE
Fixed Emergency Shuttle now always playing its hyperspace warm-up sound

### DIFF
--- a/code/controllers/shuttle_controller.dm
+++ b/code/controllers/shuttle_controller.dm
@@ -35,6 +35,8 @@ datum/emergency_shuttle
 
 	var/voting_cache = 0
 
+	var/warmup_sound = 0
+
 	// call the shuttle
 	// if not called before, set the endtime to T+600 seconds
 	// otherwise if outgoing, switch to incoming
@@ -310,6 +312,10 @@ datum/emergency_shuttle/proc/process()
 		timeleft = 0
 	if(timeleft < 0)		// Sanity
 		timeleft = 0
+
+	if(timeleft > 6)
+		warmup_sound = 0
+
 	switch(location)
 		if(0)
 
@@ -356,8 +362,8 @@ datum/emergency_shuttle/proc/process()
 				return 1
 
 		if(1)
-
-			if(timeleft == 6 || timeleft == 5)
+			if(timeleft <= 6 && !warmup_sound)
+				warmup_sound = 1
 				hyperspace_sounds("begin")
 			// Just before it leaves, close the damn doors!
 			if(timeleft == 2 || timeleft == 1)

--- a/code/controllers/shuttle_controller.dm
+++ b/code/controllers/shuttle_controller.dm
@@ -357,7 +357,7 @@ datum/emergency_shuttle/proc/process()
 
 		if(1)
 
-			if(timeleft == 5)
+			if(timeleft == 6 || timeleft == 5)
 				hyperspace_sounds("begin")
 			// Just before it leaves, close the damn doors!
 			if(timeleft == 2 || timeleft == 1)


### PR DESCRIPTION
The way timeleft is calculated causes the countdown to generally skip every other second, thus it skips the second at which the sound is supposed to start playing.

:cl:
* bugfix: The Emergency Shuttle should now always be playing its hyperspace warm up sound.