### PR TITLE
Fixes the cancel button on the AI shuttle call not working

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -392,6 +392,8 @@ var/list/ai_list = list()
 			return
 
 	var/justification = stripped_input(usr, "Please input a concise justification for the shuttle call. Note that failure to properly justify a shuttle call may lead to recall or termination.", "Nanotrasen Anti-Comdom Systems")
+	if(!justification)
+		return
 	var/confirm = alert("Are you sure you want to call the shuttle?", "Confirm Shuttle Call", "Yes", "Cancel")
 	if(confirm == "Yes")
 		call_shuttle_proc(src, justification)


### PR DESCRIPTION
Previously it would just ask for another prompt and even let you call with no justification.