### PR TITLE
Fixes "Cannot read null.gender" runtime

### DIFF
--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -20,7 +20,8 @@
 		msg += "It's using [I.gender==PLURAL?"some":"a"] [bicon(I)] [I.name] as its active module.\n"
 		if(isgripper(I))
 			var/obj/item/weapon/gripper/G = module_active
-			msg += "Its [G.name] is gripping [G.wrapped.gender==PLURAL?"some":"a"] [bicon(G.wrapped)] [G.wrapped.name].\n"
+			if(G.wrapped)
+				msg += "Its [G.name] is gripping [G.wrapped.gender==PLURAL?"some":"a"] [bicon(G.wrapped)] [G.wrapped.name].\n"
 
 	if(opened)
 		msg += "<span class='warning'>Its cover is open and the power cell is [cell ? "installed" : "missing"].</span>\n"


### PR DESCRIPTION
What a goof.

:cl:
 * bugfix: Fixes a runtime when examining cyborgs with activated grippers and no gripped item.