### PR TITLE
organ surgery maintains the organ type

### DIFF
--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -1836,11 +1836,17 @@ obj/item/organ/external/head/attackby(obj/item/weapon/W as obj, mob/user as mob)
 
 					//TODO: ORGAN REMOVAL UPDATE.
 					var/turf/T = get_turf(src)
-					if(istype(src,/obj/item/organ/external/head/posi))
-						var/obj/item/device/mmi/posibrain/B = new(T)
-						B.transfer_identity(brainmob)
+					if(isatom(organ_data.removed_type))
+						var/obj/I = organ_data.removed_type
+						if(istype(organ_data.removed_type, /obj/item/device/mmi/posibrain))
+							var/obj/item/device/mmi/posibrain/B = organ_data.removed_type
+							B.transfer_identity(brainmob)
+						else if(istype(organ_data.removed_type, /obj/item/organ/internal/brain))
+							var/obj/item/organ/internal/brain/B = organ_data.removed_type
+							B.transfer_identity(brainmob)
+						I.forceMove(T)
 					else
-						var/obj/item/organ/internal/brain/B = new(T)
+						var/obj/item/organ/internal/brain/B = new organ_data.removed_type(T)
 						B.transfer_identity(brainmob)
 
 					if(borer)

--- a/code/modules/organs/organ_internal.dm
+++ b/code/modules/organs/organ_internal.dm
@@ -230,8 +230,14 @@
 
 	if(!removed_type)
 		return 0
+	var/obj/item/organ/internal/removed_organ
 
-	var/obj/item/organ/internal/removed_organ = new removed_type(get_turf(user))
+	if(isatom(removed_type))
+		removed_organ = removed_type
+		removed_organ.forceMove(get_turf(user))
+		removed_type = null
+	else
+		removed_organ = new removed_type(get_turf(user))
 
 	if(istype(removed_organ))
 		removed_organ.organ_data = src
@@ -239,6 +245,7 @@
 			removed_organ.had_mind = !isnull(owner.mind)
 		removed_organ.update()
 		organ_holder = removed_organ
+		removed_organ.stabilized = FALSE
 	return removed_organ
 
 /datum/organ/internal/send_to_past(var/duration)

--- a/code/modules/organs/organ_objects.dm
+++ b/code/modules/organs/organ_objects.dm
@@ -16,6 +16,7 @@
 	var/prosthetic_icon                       // Icon for robotic organ.
 	var/is_printed = FALSE                    // Used for heist.
 	var/had_mind = FALSE                      // Owner had a mind at some point. (heist)
+	var/stabilized = FALSE
 
 /obj/item/organ/internal/attack_self(mob/user as mob)
 
@@ -57,6 +58,10 @@
 
 	// Don't process if we're in a freezer, an MMI or a stasis bag. //TODO: ambient temperature?
 	if(istype(loc,/obj/item/device/mmi) || istype(loc,/obj/item/bodybag/cryobag) || istype(loc,/obj/structure/closet/crate/freezer))
+		return
+
+	//We're stabilized somehow.
+	if(stabilized)
 		return
 
 	if(fresh && prob(40))

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -510,6 +510,9 @@
 		target.internal_organs_by_name[O.organ_tag] = O.organ_data
 		O.organ_data.status |= ORGAN_CUT_AWAY
 		O.replaced(target)
+		var/datum/organ/internal/I = target.internal_organs_by_name[O.organ_tag]
+		if(I.removed_type != O.type)
+			I.removed_type = O.type
 
 	qdel(O)
 	O = null

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -510,11 +510,10 @@
 		target.internal_organs_by_name[O.organ_tag] = O.organ_data
 		O.organ_data.status |= ORGAN_CUT_AWAY
 		O.replaced(target)
-		var/datum/organ/internal/I = target.internal_organs_by_name[O.organ_tag]
-		if(I.removed_type != O.type)
-			I.removed_type = O.type
-
-	qdel(O)
+	var/datum/organ/internal/I = target.internal_organs_by_name[O.organ_tag]
+	I.removed_type = O
+	O.stabilized = TRUE
+	O.loc = null
 	O = null
 
 /datum/surgery_step/internal/replace_organ/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)


### PR DESCRIPTION
organs now store the organ object they were sourced from, so you can hold certain aspects of the object persistently (MaMIs having posbrains, for instance)

closes #15072