### PR TITLE
Trader Premiums No Longer Dupe, +1 Item Choice

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -2880,7 +2880,7 @@ var/global/num_vending_terminals = 1
 		"Profits."
 	)
 	product_ads = list(
-		"When you charge a customer $100, and he pays you by mistake $200, you have an ethical dilemma — should you tell your partner?"
+		"When you charge a customer $100, and he pays you by mistake $200, you have an ethical dilemma: should you tell your partner?"
 	)
 	vend_reply = "Money money money!"
 	icon_state = "voxseed"
@@ -2895,9 +2895,6 @@ var/global/num_vending_terminals = 1
 		/obj/item/device/pda/trader = 100,
 		/obj/item/weapon/capsule = 10
 		)
-
-/obj/machinery/vending/trader/New()
-	..()
 
 	accepted_coins = list(/obj/item/weapon/coin/trader)
 
@@ -2914,9 +2911,11 @@ var/global/num_vending_terminals = 1
 		/obj/item/clothing/shoes/clown_shoes/advanced,
 		)
 
-	for(var/random_items = 1 to premium.len - 4)
+/obj/machinery/vending/trader/New()
+
+	for(var/random_items = 1 to premium.len - 5)
 		premium.Remove(pick(premium))
-	src.initialize()
+	..()
 
 /obj/machinery/vending/barber
 	name = "\improper BarberVend"


### PR DESCRIPTION
There was a longstanding bug where the four random trader items in the vendor would be listed twice, letting you buy, for example, two bluespace beakers. I am pretty sure this was unintended and just bad use of initialize().

However, because I feel this has probably become "normalized" to have ""eight"" choices (four options twice), in return I'm upping the number of items listed to five.

closes #17248

🆑 
* tweak: Tradervend no longer lists each option twice, but instead gives five choices (up from four)