### PR TITLE
Plasma Man tweak: NO_HUNGER + NO_EAT

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -945,7 +945,7 @@ var/default_colour_matrix = list(1,0,0,0,\
 #define NO_SPLASH 4
 #define NO_INJECT 8
 #define NO_CRYO 16
-#define NO_HUNGER 4096
+#define NO_HUNGER 32
 
 
 // from bay station

--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -945,6 +945,7 @@ var/default_colour_matrix = list(1,0,0,0,\
 #define NO_SPLASH 4
 #define NO_INJECT 8
 #define NO_CRYO 16
+#define NO_HUNGER 4096
 
 
 // from bay station

--- a/code/modules/mob/living/carbon/human/life/handle_chemicals_in_body.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_chemicals_in_body.dm
@@ -82,7 +82,7 @@
 				update_inv_wear_suit()
 
 	//Nutrition decrease
-	if(stat != DEAD)
+	if(stat != DEAD && !(species.chem_flags & NO_HUNGER))
 		var/reduce_nutrition_by = HUNGER_FACTOR
 		if(sleeping)
 			reduce_nutrition_by *= 0.75 //Reduce hunger factor by 25%

--- a/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
@@ -186,7 +186,7 @@
 								healths.icon_state = "health6"
 
         if(nutrition_icon)
-        	if(species.chem_flags && NO_HUNGER)
+        	if(species.chem_flags & NO_HUNGER)
         		nutrition_icon.icon_state = "nutrition1"
         	else
         		switch(nutrition)

--- a/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
@@ -185,22 +185,25 @@
 							else
 								healths.icon_state = "health6"
 
-		if(nutrition_icon)
-			switch(nutrition)
-				if(450 to INFINITY)
-					nutrition_icon.icon_state = "nutrition0"
-				if(350 to 450)
-					nutrition_icon.icon_state = "nutrition1"
-				if(250 to 350)
-					nutrition_icon.icon_state = "nutrition2"
-				if(150 to 250)
-					nutrition_icon.icon_state = "nutrition3"
-				else
-					nutrition_icon.icon_state = "nutrition4"
+        if(nutrition_icon)
+        	if(species.chem_flags && NO_HUNGER)
+        		nutrition_icon.icon_state = "nutrition1"
+        	else
+        		switch(nutrition)
+        			if(450 to INFINITY)
+        				nutrition_icon.icon_state = "nutrition0"
+        			if(350 to 450)
+        				nutrition_icon.icon_state = "nutrition1"
+        			if(250 to 350)
+        				nutrition_icon.icon_state = "nutrition2"
+        			if(150 to 250)
+        				nutrition_icon.icon_state = "nutrition3"
+        			else
+        				nutrition_icon.icon_state = "nutrition4"
 
-			if(ticker && ticker.hardcore_mode) //Hardcore mode: flashing nutrition indicator when starving!
-				if(nutrition < STARVATION_MIN)
-					nutrition_icon.icon_state = "nutrition5"
+        	if(ticker && ticker.hardcore_mode) //Hardcore mode: flashing nutrition indicator when starving!
+        		if(nutrition < STARVATION_MIN)
+        			nutrition_icon.icon_state = "nutrition5"
 
 		if(pressure)
 			pressure.icon_state = "pressure[pressure_alert]"

--- a/code/modules/mob/living/carbon/human/plasmaman/species.dm
+++ b/code/modules/mob/living/carbon/human/plasmaman/species.dm
@@ -7,6 +7,7 @@
 
 	flags = IS_WHITELISTED | PLASMA_IMMUNE
 	anatomy_flags = NO_BLOOD
+	chem_flags = NO_EAT | NO_HUNGER
 
 	//default_mutations=list(SKELETON) // This screws things up
 	primitive = /mob/living/carbon/monkey/skellington/plasma

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -224,10 +224,10 @@
 				M.drop_from_inventory(src)
 			src.forceMove(get_turf(H))
 		if(istype(H.head,/obj/item/clothing/head/helmet))
-			H.visible_message("<span class='warning'>\The [src] bounces off of the biosuit.</span>", "<span class='notice'>You watch as \the [src] falls to the ground below you.</span>")
+			H.visible_message("<span class='warning'>\The [src] smashes into then slides off of the biosuit helmet, and falls to the floor below you.</span>", "<span class='notice'>\The [src] slides off of the biosuit helmet and falls to the floor below you.</span>")
 			return
 		else
-			H.visible_message("<span class='warning'>\The [src] slips through a hole within the putrid jaw.</span>", "<span class='notice'>You watch as \the [src] falls to the ground below you.</span>")
+			H.visible_message("<span class='warning'>\The [src] falls out of the putrid jaw and tumbles down onto the floor, gross. </span>", "<span class='notice'>\The [src] falls out of the putrid jaw and onto the ground below you.</span>")
 		return
 		if((H.species.chem_flags & NO_EAT) && !(src.food_flags & FOOD_SKELETON_FRIENDLY))
 			if(ismob(loc))

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -223,12 +223,12 @@
 				var/mob/M = loc
 				M.drop_from_inventory(src)
 			src.forceMove(get_turf(H))
-		if(istype(H.get_item_by_slot(slot_head),/obj/item/clothing/head/helmet))
-			H.visible_message("<span class='warning'>\The [src] smashes into then slides off of the sealed helmet, and falls to the floor below you.</span>", "<span class='notice'>\The [src] slides off of the sealed helmet and falls to the floor below you.</span>")
-			return
-		else
+			if(H.is_wearing_item(/obj/item/clothing/head/helmet,slot_head))
+				H.visible_message("<span class='warning'>\The [src] slides off of the sealed helmet, falling to the floor below you.</span>", "<span class='notice'>\The [src] slides off of the sealed helmet and falls to the floor below you.</span>")
+				return
+				
 			H.visible_message("<span class='warning'>\The [src] falls out of the putrid jaw and tumbles down onto the floor, gross. </span>", "<span class='notice'>\The [src] falls out of the putrid jaw and onto the ground below you.</span>")
-		return
+			return
 		if((H.species.chem_flags & NO_EAT) && !(src.food_flags & FOOD_SKELETON_FRIENDLY))
 			if(ismob(loc))
 				var/mob/M = loc

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -218,6 +218,17 @@
 
 	if(ishuman(eater))
 		var/mob/living/carbon/human/H = eater
+		if((H.species.chem_flags & NO_EAT) && (istype(H.species,/datum/species/plasmaman)))
+			if(ismob(loc))
+				var/mob/M = loc
+				M.drop_from_inventory(src)
+			src.forceMove(get_turf(H))
+		if(istype(H.head,/obj/item/clothing/head/helmet))
+			H.visible_message("<span class='warning'>\The [src] bounces off of the biosuit.</span>", "<span class='notice'>You watch as \the [src] falls to the ground below you.</span>")
+			return
+		else
+			H.visible_message("<span class='warning'>\The [src] slips through a hole within the putrid jaw.</span>", "<span class='notice'>You watch as \the [src] falls to the ground below you.</span>")
+		return
 		if((H.species.chem_flags & NO_EAT) && !(src.food_flags & FOOD_SKELETON_FRIENDLY))
 			if(ismob(loc))
 				var/mob/M = loc

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -218,13 +218,13 @@
 
 	if(ishuman(eater))
 		var/mob/living/carbon/human/H = eater
-		if((H.species.chem_flags & NO_EAT) && (istype(H.species,/datum/species/plasmaman)))
+		if((H.species.chem_flags & NO_EAT) && (isplasmaman(H)))
 			if(ismob(loc))
 				var/mob/M = loc
 				M.drop_from_inventory(src)
 			src.forceMove(get_turf(H))
-		if(istype(H.head,/obj/item/clothing/head/helmet))
-			H.visible_message("<span class='warning'>\The [src] smashes into then slides off of the biosuit helmet, and falls to the floor below you.</span>", "<span class='notice'>\The [src] slides off of the biosuit helmet and falls to the floor below you.</span>")
+		if(istype(H.get_item_by_slot(slot_head),/obj/item/clothing/head/helmet))
+			H.visible_message("<span class='warning'>\The [src] smashes into then slides off of the sealed helmet, and falls to the floor below you.</span>", "<span class='notice'>\The [src] slides off of the sealed helmet and falls to the floor below you.</span>")
 			return
 		else
 			H.visible_message("<span class='warning'>\The [src] falls out of the putrid jaw and tumbles down onto the floor, gross. </span>", "<span class='notice'>\The [src] falls out of the putrid jaw and onto the ground below you.</span>")

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -44,7 +44,7 @@
 			src.forceMove(get_turf(H))
 			if(isplasmaman(H))
 				if(H.is_wearing_item(/obj/item/clothing/head/helmet,slot_head))
-					H.visible_message("<span class='warning'>\The [src] slides off of the sealed helmet, and falls to the floor.</span>", "<span class='notice'>\The [src] bounces off of the sealed helmet, and falls to the floor</span>")
+					H.visible_message("<span class='warning'>\The [src] slides off of the sealed helmet, and falls to the floor.</span>", "<span class='notice'>\The [src] bounces off of the sealed helmet, and falls to the floor.</span>")
 				else
 					H.visible_message("<span class='warning'>\The [src] slips through a hole within the putrid jaw and falls to the floor.</span>", "<span class='notice'>\The [src] slips through the putrid jaw and falls to the ground.</span>")
 			else

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -44,10 +44,10 @@
 			src.forceMove(get_turf(H))
 			if(istype(H.species,/datum/species/plasmaman))
 				if(istype(H.head,/obj/item/clothing/head/helmet))
-					H.visible_message("<span class='warning'>\The [src] bounces off of the biosuit.</span>", "<span class='notice'>You watch as \the [src] falls to the ground below you.</span>")
+					H.visible_message("<span class='warning'>\The [src] slides off of the biosuit helmet, and falls to the floor.</span>", "<span class='notice'>\The [src] bounces off of the biosuit helmet, and falls to the floor</span>")
 				return 0
 			else
-				H.visible_message("<span class='warning'>\The [src] slips through a hole within the putrid jaw.</span>", "<span class='notice'>You watch as \the [src] falls to the ground below you.</span>")
+				H.visible_message("<span class='warning'>\The [src] slips through a hole within the putrid jaw and falls to the floor.</span>", "<span class='notice'>You watch as \the [src] falls to the ground below you.</span>")
 			return 0
 		else
 			H.visible_message("<span class='warning'>\The [src] falls through and onto the ground.</span>", "<span class='notice'>You hear \the [src] plinking around for a second before it hits the ground below you.</span>")

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -42,16 +42,14 @@
 		var/mob/living/carbon/human/H = M
 		if(H.species.chem_flags & NO_EAT)
 			src.forceMove(get_turf(H))
-			if(istype(H.species,/datum/species/plasmaman))
-				if(istype(H.head,/obj/item/clothing/head/helmet))
-					H.visible_message("<span class='warning'>\The [src] slides off of the biosuit helmet, and falls to the floor.</span>", "<span class='notice'>\The [src] bounces off of the biosuit helmet, and falls to the floor</span>")
-				return 0
+			if(isplasmaman(H))
+				if(H.is_wearing_item(/obj/item/clothing/head/helmet,slot_head))
+					H.visible_message("<span class='warning'>\The [src] slides off of the sealed helmet, and falls to the floor.</span>", "<span class='notice'>\The [src] bounces off of the sealed helmet, and falls to the floor</span>")
+				else
+					H.visible_message("<span class='warning'>\The [src] slips through a hole within the putrid jaw and falls to the floor.</span>", "<span class='notice'>\The [src] slips through the putrid jaw and falls to the ground.</span>")
 			else
-				H.visible_message("<span class='warning'>\The [src] slips through a hole within the putrid jaw and falls to the floor.</span>", "<span class='notice'>You watch as \the [src] falls to the ground below you.</span>")
-			return 0
-		else
-			H.visible_message("<span class='warning'>\The [src] falls through and onto the ground.</span>", "<span class='notice'>You hear \the [src] plinking around for a second before it hits the ground below you.</span>")
-			return 0
+				H.visible_message("<span class='warning'>\The [src] falls through and onto the ground.</span>", "<span class='notice'>You hear \the [src] plinking around for a second before it hits the ground below you.</span>")
+		return 0
 	injest(M)
 	return 1
 

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -42,6 +42,14 @@
 		var/mob/living/carbon/human/H = M
 		if(H.species.chem_flags & NO_EAT)
 			src.forceMove(get_turf(H))
+			if(istype(H.species,/datum/species/plasmaman))
+				if(istype(H.head,/obj/item/clothing/head/helmet))
+					H.visible_message("<span class='warning'>\The [src] bounces off of the biosuit.</span>", "<span class='notice'>You watch as \the [src] falls to the ground below you.</span>")
+				return 0
+			else
+				H.visible_message("<span class='warning'>\The [src] slips through a hole within the putrid jaw.</span>", "<span class='notice'>You watch as \the [src] falls to the ground below you.</span>")
+			return 0
+		else
 			H.visible_message("<span class='warning'>\The [src] falls through and onto the ground.</span>", "<span class='notice'>You hear \the [src] plinking around for a second before it hits the ground below you.</span>")
 			return 0
 	injest(M)
@@ -90,7 +98,7 @@
 /obj/item/weapon/reagent_containers/pill/creatine/New()
 	..()
 	reagents.add_reagent(CREATINE, 50)
-	
+
 /obj/item/weapon/reagent_containers/pill/laststand
 	name = "Creatine \"Last Stand\" suicide pill"
 	desc = "For when you really want to spend your last moments punching things to death."


### PR DESCRIPTION
This PR gives plasmamen two chemical flags, NO_HUNGER and NO_EAT, The goal is to remove their requirement and ability to eat solids, as a result they can no longer take pills but also do not suffer from hunger debuffs. I made changes to pills.dm and snacks.dm to add in specific checks for plasmamen, similar to that of skellingtons. However it uses two different checks with their own in game messages. One simply checks if the plasmaman has a helmet on or not.
 
From a balance perspective. They gain the ability to work for extended periods of time without having to worry about hunger, as well as having no blood, however, they are now limited to fluids and injections for medication while still taking increased brute damage, being unable to regulate body temperature,  and are still restricted to a suit that is a massive liability.
 
tl;dr
Allows the freaks of nature to seclude themselves, as they should, and work for extended periods of time.

:cl:
 * tweak: Gave Plasmamen NO_HUNGER.
 * tweak: Removed Plasmamen's ability to eat solid food and medication.
