### PR TITLE
Adds a tile painter to the default service borg loadout

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -347,6 +347,7 @@
 	modules += new /obj/item/weapon/pen/robopen(src)
 	modules += new /obj/item/weapon/dice/borg(src)
 	modules += new /obj/item/device/rcd/borg/rsf(src)
+	modules += new /obj/item/device/rcd/tile_painter(src)
 	modules += new /obj/item/weapon/lighter/zippo(src)
 	modules += new /obj/item/device/instrument/instrument_synth(src)
 	modules += new /obj/item/weapon/tray/robotray(src)


### PR DESCRIPTION
Requested by @Jubisloviu 

:cl:
 * rscadd: Added a tile painter to the default service cyborg loadout.
