### PR TITLE
Upgrades now drop from borgs when they get a module reset

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -15,6 +15,7 @@
 	var/add_to_mommis = FALSE
 	var/list/modules_to_add = list()
 	var/multi_upgrades = FALSE
+	var/salvageable = TRUE
 	w_type=RECYK_ELECTRONIC
 
 
@@ -66,7 +67,13 @@
 			R.module.modules += new module_to_add(R.module)
 
 	to_chat(user, "<span class='notice'>You successfully apply \the [src] to [R].</span>")
-	user.drop_item(src, R)
+
+	if(salvageable)
+		user.drop_item(src, R)
+	else
+		user.drop_item(src)
+		qdel(src)
+
 
 // Medical Cyborg Stuff
 
@@ -91,6 +98,7 @@
 	name = "cyborg reset board"
 	desc = "Used to reset a cyborg's module. Destroys any other upgrades applied to the robot."
 	icon_state = "cyborg_upgrade1"
+	salvageable = FALSE
 
 /obj/item/borg/upgrade/reset/attempt_action(var/mob/living/silicon/robot/R,var/mob/living/user)
 	if(..())
@@ -100,9 +108,6 @@
 		R.movement_speed_modifier -= vtec_bonus
 
 	for(var/obj/item/borg/upgrade/thing in R)
-		if(istype(thing, /obj/item/borg/upgrade/reset))
-			qdel(thing)
-			continue
 		thing.forceMove(R.loc)
 
 	qdel(R.module)

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -99,6 +99,12 @@
 	if (/obj/item/borg/upgrade/vtec in R.module.upgrades)
 		R.movement_speed_modifier -= vtec_bonus
 
+	for(var/obj/item/borg/upgrade/thing in R)
+		if(istype(thing, /obj/item/borg/upgrade/reset))
+			qdel(thing)
+			continue
+		thing.forceMove(R.loc)
+
 	qdel(R.module)
 	if(R.hands)
 		R.hands.icon_state = "nomod"


### PR DESCRIPTION
Requested by @Reviire and @DrSnips.

:cl:
 * rscadd: Applied upgrades now drop from borgs when they get a module reset(minus the reset board upgrade).