### PR TITLE
Ports the 'Toggle Floor Bolts' AI verb from TG

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -37,6 +37,8 @@ var/list/ai_list = list()
 	var/obj/item/device/station_map/station_holomap = null
 	var/custom_sprite = 0 //For our custom sprites
 	var/obj/item/device/camera/ai_camera/aicamera = null
+	var/busy = FALSE //Toggle Floor Bolt busy var.
+
 //Hud stuff
 
 	//MALFUNCTION

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -150,13 +150,15 @@ var/list/ai_list = list()
 	set category = "AI Commands"
 	set name = "Toggle Floor Bolts"
 
-	if(!isturf(loc) || busy)
+	if(stat || aiRestorePowerRoutine || !isturf(loc) || busy)
 		return
 	busy = TRUE
 	playsound(loc, 'sound/items/Ratchet.ogg', 50, 1)
 	if(do_after(src, src, 30))
 		anchored = !anchored
 		to_chat(src, "You are now <b>[anchored ? "" : "un"]anchored</b>.")
+		busy = FALSE
+	else
 		busy = FALSE
 
 /mob/living/silicon/ai/verb/radio_interact()

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -150,16 +150,14 @@ var/list/ai_list = list()
 	set category = "AI Commands"
 	set name = "Toggle Floor Bolts"
 
-	if(stat || aiRestorePowerRoutine || !isturf(loc) || busy)
+	if(incapacitated() || aiRestorePowerRoutine || !isturf(loc) || busy)
 		return
 	busy = TRUE
 	playsound(loc, 'sound/items/Ratchet.ogg', 50, 1)
 	if(do_after(src, src, 30))
 		anchored = !anchored
 		to_chat(src, "You are now <b>[anchored ? "" : "un"]anchored</b>.")
-		busy = FALSE
-	else
-		busy = FALSE
+	busy = FALSE
 
 /mob/living/silicon/ai/verb/radio_interact()
 	set category = "AI Commands"

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -144,6 +144,19 @@ var/list/ai_list = list()
 	..()
 	return
 
+/mob/living/silicon/ai/verb/toggle_anchor()
+	set category = "AI Commands"
+	set name = "Toggle Floor Bolts"
+
+	if(!isturf(loc) || busy)
+		return
+	busy = TRUE
+	playsound(loc, 'sound/items/Ratchet.ogg', 50, 1)
+	if(do_after(src, src, 30))
+		anchored = !anchored
+		to_chat(src, "You are now <b>[anchored ? "" : "un"]anchored</b>.")
+		busy = FALSE
+
 /mob/living/silicon/ai/verb/radio_interact()
 	set category = "AI Commands"
 	set name = "Radio Configuration"


### PR DESCRIPTION
But tweaked to use do_after() instead of being instant so you can still drag them even against their will.

Requested by @SonixApache 

:cl:
 * rscadd: Ports the 'Toggle Floor Bolts' AI verb from TG
