### PR TITLE
Insulated constructs

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -431,6 +431,9 @@
 		return L
 
 /mob/living/proc/electrocute_act(const/shock_damage, const/obj/source, const/siemens_coeff = 1.0)
+	if(status_flags & GODMODE || M_NO_SHOCK in src.mutations)
+		return 0
+
 	var/damage = shock_damage * siemens_coeff
 
 	if(damage <= 0)

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -29,6 +29,7 @@
 	flying = 1
 	treadmill_speed = 0 //It floats!
 	var/nullblock = 0
+	mutations = list(M_NO_SHOCK)
 
 	mob_property_flags = MOB_CONSTRUCT
 	mob_swap_flags = HUMAN|SIMPLE_ANIMAL|SLIME|MONKEY


### PR DESCRIPTION
Sick of seeing these things made of obsidian or whatever get dusted instantly by shocked grilles and doors. Granted, a robust construct wouldn't touch them in the first place, but generally they don't get to choose themselves.
:cl:
* tweak: Constructs are now shock-immune.