### PR TITLE
adds stubborn brain syndrome, reworks becoming a zombie after death a bit

### DIFF
--- a/code/game/objects/items/potions.dm
+++ b/code/game/objects/items/potions.dm
@@ -238,7 +238,7 @@
 	return ishuman(user)
 
 /obj/item/potion/zombie/imbibe_effect(mob/living/carbon/human/user)
-	user.become_zombie_after_death = TRUE
+	user.become_zombie_after_death = TRUE+1
 
 /obj/item/potion/zombie/impact_atom(atom/target)
 	var/mob/M = get_last_player_touched()

--- a/code/game/objects/items/potions.dm
+++ b/code/game/objects/items/potions.dm
@@ -238,14 +238,14 @@
 	return ishuman(user)
 
 /obj/item/potion/zombie/imbibe_effect(mob/living/carbon/human/user)
-	user.become_zombie_after_death = TRUE+1
+	user.become_zombie_after_death = 2
 
 /obj/item/potion/zombie/impact_atom(atom/target)
 	var/mob/M = get_last_player_touched()
 	var/list/L = get_all_mobs_in_dview(get_turf(src))
 	for(var/mob/living/carbon/human/H in L)
 		if(H.isDeadorDying())
-			if(prob(50))
+			if(prob(50) && isjusthuman(M))
 				H.make_zombie(M)
 			else
 				new /mob/living/simple_animal/hostile/necro/skeleton(get_turf(H), M, H.mind)

--- a/code/game/objects/items/potions.dm
+++ b/code/game/objects/items/potions.dm
@@ -245,7 +245,7 @@
 	var/list/L = get_all_mobs_in_dview(get_turf(src))
 	for(var/mob/living/carbon/human/H in L)
 		if(H.isDeadorDying())
-			if(prob(50) && isjusthuman(M))
+			if(prob(50) && isjusthuman(H))
 				H.make_zombie(M)
 			else
 				new /mob/living/simple_animal/hostile/necro/skeleton(get_turf(H), M, H.mind)

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -115,10 +115,10 @@
 		sql_report_death(src)
 		ticker.mode.check_win() //Calls the rounds wincheck, mainly for wizard, malf, and changeling now
 	species.handle_death(src)
-	if(become_zombie_after_death)
+	if(become_zombie_after_death && isjusthuman(src)) //2 if they retain their mind, 1 if they don't
 		spawn(30 SECONDS)
 			if(!gcDestroyed)
-				make_zombie()
+				make_zombie(retain_mind = become_zombie_after_death-1)
 	return ..(gibbed)
 
 /mob/living/carbon/human/proc/makeSkeleton()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -490,7 +490,7 @@
 		var/setcriminal = input(usr, "Specify a new criminal status for this person.", "Security HUD", sec_record.fields["criminal"]) as null|anything in list("None", "*Arrest*", "Incarcerated", "Parolled", "Released")
 		if(!setcriminal || (usr.incapacitated() && !isAdminGhost(usr)) || !usr.hasHUD(HUD_SECURITY))
 			return
-		sec_record.fields["criminal"] = setcriminal	
+		sec_record.fields["criminal"] = setcriminal
 	else if (href_list["secrecord"])
 		if(!usr.hasHUD(HUD_SECURITY))
 			return
@@ -1750,8 +1750,8 @@ mob/living/carbon/human/remove_internal_organ(var/mob/living/user, var/datum/org
 	// ...means no flavor text for you. Otherwise, good to go.
 	return TRUE
 
-/mob/living/carbon/human/proc/make_zombie(mob/master)
-	var/mob/living/simple_animal/hostile/necro/zombie/turned/T = new(get_turf(src), master, mind)
+/mob/living/carbon/human/proc/make_zombie(mob/master, var/retain_mind = TRUE)
+	var/mob/living/simple_animal/hostile/necro/zombie/turned/T = new(get_turf(src), master, (retain_mind ? mind : null))
 	T.get_clothes(src, T)
 	T.name = real_name
 	T.host = src

--- a/code/modules/virus2/effect/effect.dm
+++ b/code/modules/virus2/effect/effect.dm
@@ -1077,6 +1077,16 @@ datum/disease2/effect/lubefoot/deactivate(var/mob/living/carbon/mob)
 			if(h.set_species("Tajaran"))
 				h.regenerate_icons()
 
+/datum/disease2/effect/zombie
+	name = "Stubborn brain syndrome"
+	stage = 4
+	badness = 2
+
+/datum/disease2/effect/zombie/activate(var/mob/living/carbon/mob)
+	if(ishuman(mob))
+		var/mob/living/carbon/human/h = mob
+		h.become_zombie_after_death = TRUE
+
 
 /datum/disease2/effect/voxpox
 	name = "Vox Pox"

--- a/code/modules/virus2/effect/effect.dm
+++ b/code/modules/virus2/effect/effect.dm
@@ -1085,7 +1085,7 @@ datum/disease2/effect/lubefoot/deactivate(var/mob/living/carbon/mob)
 /datum/disease2/effect/zombie/activate(var/mob/living/carbon/mob)
 	if(ishuman(mob))
 		var/mob/living/carbon/human/h = mob
-		h.become_zombie_after_death = TRUE
+		h.become_zombie_after_death = 1
 
 
 /datum/disease2/effect/voxpox


### PR DESCRIPTION
Stubborn brain syndrome - where the brain is just too stubborn to stay dead.

become_zombie_after_death isn't a boolean anymore. If 1, the subject becomes a zombie without a mind to control it. If 2, the subject becomes a zombie with a mind to control it.

Also, sweet jesus zombies need a rework. Tested the virus on an unathi, and it became a bald dude with a lizard tail.