### PR TITLE
Patient zeros don't roll for natural immunity

### DIFF
--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -11,7 +11,7 @@ var/global/list/disease2_list = list()
 	var/list/datum/disease2/effect/effects = list()
 	var/antigen = 0 // 16 bits describing the antigens, when one bit is set, a cure with that bit can dock here
 	var/max_stage = 4
-	var/patient_zero = FALSE // Bypasses the roll for natural antibodies
+	var/patient_zero = FALSE // Bypasses the roll for natural antibodies if true
 
 	var/log = ""
 	var/logged_virusfood=0

--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -33,7 +33,7 @@ var/global/list/disease2_list = list()
 	e.chance = rand(1, e.max_chance)
 	return e
 
-/datum/disease2/disease/proc/makerandom(var/greater = FALSE, patient_zero)
+/datum/disease2/disease/proc/makerandom(var/greater = FALSE, var/pz)
 	log_debug("Randomizing virus [uniqueID] with greater=[greater]")
 	for(var/i = 1; i <= max_stage; i++)
 		if(greater)
@@ -50,6 +50,7 @@ var/global/list/disease2_list = list()
 	antigen |= text2num(pick(ANTIGENS))
 	antigen |= text2num(pick(ANTIGENS))
 	spreadtype = prob(70) ? "Airborne" : prob(20) ? "Blood" :"Contact" //Try for airborne then try for blood.
+	patient_zero = pz
 
 /proc/virus2_make_custom(client/C)
 	if(!C.holder || !istype(C))

--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -11,6 +11,7 @@ var/global/list/disease2_list = list()
 	var/list/datum/disease2/effect/effects = list()
 	var/antigen = 0 // 16 bits describing the antigens, when one bit is set, a cure with that bit can dock here
 	var/max_stage = 4
+	var/patient_zero = FALSE // Bypasses the roll for natural antibodies
 
 	var/log = ""
 	var/logged_virusfood=0
@@ -32,7 +33,7 @@ var/global/list/disease2_list = list()
 	e.chance = rand(1, e.max_chance)
 	return e
 
-/datum/disease2/disease/proc/makerandom(var/greater=0)
+/datum/disease2/disease/proc/makerandom(var/greater = FALSE, patient_zero)
 	log_debug("Randomizing virus [uniqueID] with greater=[greater]")
 	for(var/i = 1; i <= max_stage; i++)
 		if(greater)
@@ -79,6 +80,7 @@ var/global/list/disease2_list = list()
 	//pick random antigens for the disease to have
 	D.antigen |= text2num(pick(ANTIGENS))
 	D.antigen |= text2num(pick(ANTIGENS))
+	D.patient_zero = TRUE
 
 	D.spreadtype = input(C, "Select spread type", "Spread Type") in list("Airborne", "Contact", "Blood") // select how the disease is spread
 	infectedMob.virus2["[D.uniqueID]"] = D // assign the disease datum to the infectedMob/ selected user.
@@ -94,7 +96,7 @@ var/global/list/disease2_list = list()
 
 	if(mob.stat == 2)
 		return
-	if(stage <= 1 && clicks == 0) 	// with a certain chance, the mob may become immune to the disease before it starts properly
+	if(stage <= 1 && clicks == 0 && !patient_zero) 	// with a certain chance, the mob may become immune to the disease before it starts properly. Not if they're patient zero though.
 		if(prob(5))
 			log_debug("[key_name(mob)] rolled for starting immunity against virus [uniqueID] and received antigens [antigens2string(antigen)].")
 			mob.antibodies |= antigen // 20% immunity is a good chance IMO, because it allows finding an immune person easily

--- a/code/modules/virus2/helpers.dm
+++ b/code/modules/virus2/helpers.dm
@@ -94,14 +94,14 @@ proc/airborne_can_reach(turf/source, turf/target, var/radius=5)
 //Infects mob M with random lesser disease, if he doesn't have one
 /proc/infect_mob_random_lesser(var/mob/living/carbon/M)
 	var/datum/disease2/disease/D = new /datum/disease2/disease("infect_mob_random_lesser")
-	D.makerandom()
+	D.makerandom(FALSE, TRUE)
 	D.infectionchance = 1
 	M.virus2["[D.uniqueID]"] = D
 
 //Infects mob M with random greated disease, if he doesn't have one
 /proc/infect_mob_random_greater(var/mob/living/carbon/M)
 	var/datum/disease2/disease/D = new /datum/disease2/disease("infect_mob_random_greater")
-	D.makerandom(1)
+	D.makerandom(TRUE, TRUE)
 	M.virus2["[D.uniqueID]"] = D
 
 //Fancy prob() function.


### PR DESCRIPTION
In response to https://github.com/vgstation-coders/vgstation13/pull/17295#issuecomment-362259648
:cl:
* tweak: Patients zero of a viral outbreak no longer get a roll for natural immunity to that virus.