### PR TITLE
Deathwhisper Radio Hotfix

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -370,7 +370,7 @@ var/list/department_radio_keys = list(
 
 /mob/living/proc/get_speech_flags(var/message_mode)
 	switch(message_mode)
-		if(MODE_WHISPER)
+		if(MODE_WHISPER, SPEECH_MODE_FINAL)
 			return NOPASS
 		if(MODE_HEADSET, MODE_SECURE_HEADSET, MODE_R_HAND, MODE_L_HAND, MODE_INTERCOM, MODE_BINARY)
 			return ITALICS | REDUCE_RANGE //most cases


### PR DESCRIPTION
Tested using atom proccall on monkeymen to call whisper(text)

* Cannot deathwhisper over headset radio
* Can deathwhisper over SBRs as you always have been able to
* Can still normal whisper over radios of course
* And of course normal whispering will not be picked up by your headset either

🆑 
* bugfix: You can no longer deathwhisper over radio