### PR TITLE
adds white glubs to premium goods in autodrobe

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -2426,6 +2426,7 @@ var/global/num_vending_terminals = 1
 		/obj/item/clothing/suit/wizrobe/magician/fake = 3,
 		/obj/item/clothing/head/wizard/magician = 3,
 		/obj/item/clothing/suit/sakura_kimono = 3,
+		/obj/item/clothing/gloves/white = 3,
 		)
 
 	pack = /obj/structure/vendomatpack/autodrobe


### PR DESCRIPTION
the PR which changed latex gloves from white to seethrough blue was the worst PR ever ever ever ever ever ever

:cl:
 * rscadd: adds white gloves to premium goods (insert coin) in autodrobe