### PR TITLE
removes depreciated factions list

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1543,8 +1543,8 @@ Game Mode config tags:
 
 /proc/find_active_faction(var/faction_name)
 	var/found_faction = null
-	if(ticker && ticker.factions.len)
-		for(var/datum/faction/F in ticker.factions)
+	if(ticker && ticker.mode && ticker.mode.factions.len)
+		for(var/datum/faction/F in ticker.mode.factions)
 			if(faction_name in F.ID)
 				found_faction = F
 				break
@@ -1556,8 +1556,8 @@ Game Mode config tags:
 	var/found_faction = null
 	if(R.GetFaction())
 		return R.GetFaction()
-	if(ticker && ticker.factions.len)
-		for(var/datum/faction/F in ticker.factions)
+	if(ticker && ticker.mode && ticker.mode.factions.len)
+		for(var/datum/faction/F in ticker.mode.factions)
 			if(R in F.members)
 				found_faction = F
 				break

--- a/code/controllers/subsystem/init/more_init_stuff.dm
+++ b/code/controllers/subsystem/init/more_init_stuff.dm
@@ -9,7 +9,6 @@ var/datum/subsystem/more_init/SSmore_init
 	NEW_SS_GLOBAL(SSmore_init)
 
 /datum/subsystem/more_init/Initialize(timeofday)
-	setupfactions()
 	setup_economy()
 	var/watch=start_watch()
 	log_startup_progress("Caching damage icons...")

--- a/code/datums/statistics/statcollection.dm
+++ b/code/datums/statistics/statcollection.dm
@@ -209,7 +209,7 @@
 	statfile << "STATLOG_START|[STAT_OUTPUT_VERSION]|[map.nameLong]|[start_timestamp]|[end_timestamp]"
 	statfile << "MASTERMODE|[master_mode]" // sekrit, or whatever else was decided as the 'actual' mode on round start.
 	var/T = "GAMEMODE"
-	for(var/datum/faction/GM in ticker.factions)
+	for(var/datum/faction/GM in ticker.mode.factions)
 		T += "|[GM.name]"
 	statfile << T
 

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -29,10 +29,6 @@ var/datum/controller/gameticker/ticker
 
 	var/hardcore_mode = 0	//If set to nonzero, hardcore mode is enabled (current hardcore mode features: damage from hunger)
 							//Use the hardcore_mode_on macro - if(hardcore_mode_on) to_chat(user,"You're hardcore!")
-
-	var/list/syndicate_coalition = list() // list of traitor-compatible factions
-	var/list/factions = list()			  // list of all factions
-	var/list/availablefactions = list()	  // list of factions with openings
 	var/datum/rune_controller/rune_controller
 
 	var/pregame_timeleft = 0
@@ -458,12 +454,6 @@ var/datum/controller/gameticker/ticker
 				delay_end = 2
 
 	return 1
-
-/datum/controller/gameticker/proc/getfactionbyname(var/name)
-	for(var/datum/faction/F in factions)
-		if(F.name == name)
-			return F
-
 
 /datum/controller/gameticker/proc/init_PDAgames_leaderboard()
 	init_snake_leaderboard()

--- a/code/game/gamemodes/scoreboard.dm
+++ b/code/game/gamemodes/scoreboard.dm
@@ -1,6 +1,6 @@
 /datum/controller/gameticker/proc/scoreboard(var/completions)
 
-	for(var/datum/faction/F in ticker.factions)
+	for(var/datum/faction/F in ticker.mode.factions)
 		completions += F.GetObjectivesMenuHeader()
 		completions += F.GetScoreboard()
 

--- a/code/game/gamemodes/setupgame.dm
+++ b/code/game/gamemodes/setupgame.dm
@@ -229,19 +229,3 @@ var/NOIRBLOCK = 0
 				all_species[name]=species
 
 	speciesinit = 1
-
-
-/proc/setupfactions()
-	// Populate the factions list:
-	for(var/x in typesof(/datum/faction))
-		var/datum/faction/F = new x
-		if(!F.name)
-			del(F)
-			continue
-		else
-			ticker.factions.Add(F)
-			ticker.availablefactions.Add(F)
-
-	// Populate the syndicate coalition:
-	for(var/datum/faction/syndicate/S in ticker.factions)
-		ticker.syndicate_coalition.Add(S)

--- a/code/game/gamemodes/wizard/soulstone.dm
+++ b/code/game/gamemodes/wizard/soulstone.dm
@@ -315,7 +315,7 @@
 				return
 
 			var/mob/living/T = target
-			for(var/datum/faction/cult/C in ticker.factions)
+			for(var/datum/faction/cult/C in ticker.mode.factions)
 				if(C.is_sacrifice_target(T.mind))
 					to_chat(U, "<span class='warning'>The soul stone is unable to rip this soul. Such a powerful soul, it must be coveted by some powerful being.</span>")
 					return


### PR DESCRIPTION
Seems that there were variables very similar to the ones we were using in gameticker, so I fucked up and ended up using them by accident.

This remedies this.