### PR TITLE
Gives brains dexterity

### DIFF
--- a/code/modules/mob/living/carbon/brain/brain.dm
+++ b/code/modules/mob/living/carbon/brain/brain.dm
@@ -71,3 +71,6 @@
 
 /mob/living/carbon/brain/proc/brain_dead_chat()
 	return !(container && (istype(container, /obj/item/device/mmi)))
+
+/mob/living/carbon/brain/dexterity_check()
+	return 1 //This is so certain mech tools work for MMIs and posibrains.


### PR DESCRIPTION
Closes #16616
:cl:
* tweak: Gave MMIs and posibrains dexterity. AFAIK the only thing this will affect is the mecha engineering switchtool, which MMI and posi piloted Clarkes will now be able to make full use of.