### PR TITLE
simple_animals make simple sounds while player controlled

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -16,6 +16,9 @@
 	turns_per_move = 5
 	see_in_dark = 6
 
+	speak_override = TRUE
+
+
 	can_breed = 1
 	species_type = /mob/living/simple_animal/cat
 	childtype = /mob/living/simple_animal/cat/kitten

--- a/code/modules/mob/living/simple_animal/friendly/corgi.dm
+++ b/code/modules/mob/living/simple_animal/friendly/corgi.dm
@@ -17,6 +17,8 @@
 	speak_chance = 1
 	turns_per_move = 10
 
+	speak_override = TRUE
+
 	meat_type = /obj/item/weapon/reagent_containers/food/snacks/meat/animal/corgi
 	holder_type = /obj/item/weapon/holder/animal/corgi
 

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -22,6 +22,7 @@
 	melee_damage_upper = 2
 	size = SIZE_BIG
 	environment_smash_flags = SMASH_LIGHT_STRUCTURES
+	speak_override = TRUE
 
 	var/datum/reagents/udder = null
 
@@ -106,6 +107,7 @@
 	response_harm   = "kicks"
 	attacktext = "kicks"
 	health = 50
+	speak_override = TRUE
 
 	size = SIZE_BIG
 	holder_type = /obj/item/weapon/holder/animal/cow
@@ -176,6 +178,7 @@
 	var/amount_grown = 0
 	pass_flags = PASSTABLE | PASSGRILLE
 	size = SIZE_TINY
+	speak_override = TRUE
 
 /mob/living/simple_animal/chick/New()
 	..()
@@ -216,6 +219,7 @@
 	var/body_color
 	pass_flags = PASSTABLE
 	size = SIZE_SMALL
+	speak_override = TRUE
 
 /mob/living/simple_animal/chicken/New()
 	if(prob(5))
@@ -292,6 +296,7 @@
 	max_n2 = 0
 	treadmill_speed = 1.5
 	var/fat = 0
+	speak_override = TRUE
 
 /mob/living/simple_animal/hostile/retaliate/box/New()
 	..()

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -33,6 +33,7 @@
 	maxbodytemp = 323	//Above 50 Degrees Celcius
 	universal_speak = 0
 	treadmill_speed = 0.2 //You can still do it, but you're not going to generate much power.
+	speak_override = TRUE
 
 	size = SIZE_TINY
 	holder_type = /obj/item/weapon/holder/animal/mouse

--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -26,6 +26,7 @@
 	melee_damage_lower = 20
 	melee_damage_upper = 30
 	size = SIZE_BIG
+	speak_override = TRUE
 
 	//Space bears aren't affected by atmos.
 	min_oxy = 0

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -41,7 +41,7 @@
 	emote_hear = list("squawks","bawks")
 	emote_see = list("flutters its wings")
 
-	speak_override = TRUE
+	speak_override = FALSE
 
 	speak_chance = 1 //1% (1 in 100) chance every tick; So about once per 150 seconds, assuming an average tick is 1.5s
 	turns_per_move = 5

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -41,6 +41,8 @@
 	emote_hear = list("squawks","bawks")
 	emote_see = list("flutters its wings")
 
+	speak_override = TRUE
+
 	speak_chance = 1 //1% (1 in 100) chance every tick; So about once per 150 seconds, assuming an average tick is 1.5s
 	turns_per_move = 5
 	meat_type = /obj/item/weapon/reagent_containers/food/snacks/cracker/

--- a/code/modules/mob/living/simple_animal/puddi.dm
+++ b/code/modules/mob/living/simple_animal/puddi.dm
@@ -15,6 +15,7 @@
 	response_help  = "pats"
 	response_disarm = "squishes"
 	response_harm   = "slaps"
+	speak_override = TRUE
 
 	meat_type = null
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -21,6 +21,8 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 	var/list/emote_hear = list()	//Hearable emotes
 	var/list/emote_see = list()		//Unlike speak_emote, the list of things in this variable only show by themselves with no spoken text. IE: Ian barks, Ian yaps
 
+	var/speak_override = FALSE
+
 	var/turns_per_move = 1
 	var/turns_since_move = 0
 
@@ -742,6 +744,12 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 	if(spaced)
 		walk(src,0)
 	return !spaced
+
+/mob/living/simple_animal/say()
+	if(speak_override == TRUE)
+		return ..(pick(speak))
+	else
+		return ..()
 
 
 /datum/locking_category/simple_animal

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -746,7 +746,7 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 	return !spaced
 
 /mob/living/simple_animal/say()
-	if(speak_override == TRUE)
+	if(speak_override)
 		return ..(pick(speak))
 	else
 		return ..()


### PR DESCRIPTION
adds speak_override = TRUE to cats,corgis,puddis,mice,parrots,bears,goats,pigs,chickens,chicks,and cows
adds speak_override to simple_animal to make their speech replaced with default say() options
can be toggled off

<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl:
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
