### PR TITLE
Fixes HUD oversights

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -431,7 +431,7 @@
 		msg += "<span class='warning'>[butchery]</span>\n"
 
 	if(user.hasHUD(HUD_SECURITY))
-		var/perpname = get_id_name("wot")
+		var/perpname = get_identification_name(get_face_name())
 		var/criminal = "None"
 
 		var/datum/data/record/sec_record = data_core.find_security_record_by_name(perpname)
@@ -441,11 +441,11 @@
 			msg += {"<span class = 'deptradio'>Criminal status:</span> <a href='?src=\ref[src];criminal=1'>\[[criminal]\]</a>
 <span class = 'deptradio'>Security records:</span> <a href='?src=\ref[src];secrecord=`'>\[View\]\n</a>"}
 			if(!isjustobserver(user))
-				msg += "<a href='?src=\ref[src];secrecordadd=`'>\[Add comment\]\n</a>\n"
+				msg += "<a href='?src=\ref[src];secrecordadd=`'>\[Add comment\]</a>\n"
 			msg += {"[wpermit(src) ? "<span class = 'deptradio'>Has weapon permit.</span>\n" : ""]"}
 
 	if(user.hasHUD(HUD_MEDICAL))
-		var/perpname = get_id_name("wot")
+		var/perpname = get_identification_name(get_face_name())
 		var/medical = "None"
 
 		var/datum/data/record/gen_record = data_core.find_general_record_by_name(perpname)


### PR DESCRIPTION
In #17176 I added one newline that didn't belong there, this fixes that.
In #17064 I changed the way HUDs looked up the name for the examined perp; turns out this made it so you couldn't look up the records for people not wearing an ID. This was especially annoying for brigged guys that had their ID removed. This fixes that.

:cl:
 * bugfix: Fixed a bug that prevented HUDs from finding records for people wearing no ID.