### PR TITLE
Allows construction permits to fit in wallets

### DIFF
--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -26,6 +26,7 @@
 		"/obj/item/weapon/photo",
 		"/obj/item/weapon/reagent_containers/dropper",
 		"/obj/item/weapon/screwdriver",
+		"/obj/item/blueprints/construction_permit",
 		"/obj/item/weapon/stamp")
 	slot_flags = SLOT_ID|SLOT_BELT
 


### PR DESCRIPTION
Just as the title says, allows construction permits to fit in wallets and judging by the sprite and size of the object, it seems feasible for that to happen. Tested locally without issue on all wallet subtypes.

Closes #17299 

:cl:
 * rscadd: allows for construction permits to fit in wallets
