### PR TITLE
Syringe icon bug fix.

### DIFF
--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -107,6 +107,8 @@
 		overlays.len = 0
 		return
 	var/rounded_vol = round(reagents.total_volume,5)
+	if(0 < reagents.total_volume && reagents.total_volume < 5)
+		rounded_vol = 5
 	overlays.len = 0
 	if(ismob(loc))
 		var/injoverlay


### PR DESCRIPTION
Fixes: #14704
:cl:
 * bugfix: Fixed syringes having a bloodbag icon over them when they had a small amount of reagents in them.