### PR TITLE
Raises photo album storage capacity to 50

### DIFF
--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -91,6 +91,8 @@
 	icon_state = "album"
 	item_state = "briefcase"
 	can_only_hold = list("/obj/item/weapon/photo",)
+	storage_slots = 50
+	max_combined_w_class = 200
 
 
 /*


### PR DESCRIPTION
Closes #17360
:cl:
* tweak: Photo albums can store 50 photos now, up from 7.