### PR TITLE
[1/2] Removes taser from security cyborgs, moves it behind research/emag/hacking.

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -174,6 +174,17 @@
 
 	R.movement_speed_modifier += vtec_bonus
 
+/obj/item/borg/upgrade/tasermodule
+	name = "security cyborg taser module board"
+	desc = "Used to provide security cyborgs with a taser module, improving their combat capabilities."
+	icon_state = "cyborg_upgrade3"
+	required_module = list(/obj/item/weapon/robot_module/security)
+	modules_to_add = list(/obj/item/weapon/gun/energy/taser/cyborg)
+
+/obj/item/borg/upgrade/tasermodule/attempt_action(var/mob/living/silicon/robot/R,var/mob/living/user)
+
+	if(..())
+		return FAILED_TO_ADD
 
 /obj/item/borg/upgrade/tasercooler
 	name = "security cyborg rapid taser cooling upgrade board"
@@ -181,7 +192,6 @@
 	icon_state = "cyborg_upgrade3"
 	required_module = list(/obj/item/weapon/robot_module/security)
 	multi_upgrades = TRUE
-
 
 /obj/item/borg/upgrade/tasercooler/attempt_action(var/mob/living/silicon/robot/R,var/mob/living/user)
 	var/obj/item/weapon/gun/energy/taser/cyborg/T = locate_component(/obj/item/weapon/gun/energy/taser/cyborg, R, user)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -294,13 +294,12 @@
 
 	modules += new /obj/item/weapon/crowbar(src)
 	modules += new /obj/item/weapon/melee/baton/loaded/borg(src)
-	modules += new /obj/item/weapon/gun/energy/taser/cyborg(src)
 	modules += new /obj/item/weapon/handcuffs/cyborg(src)
 	modules += new /obj/item/weapon/reagent_containers/spray/pepper(src)
 	modules += new /obj/item/taperoll/police(src)
 	modules += new /obj/item/device/hailer(src)
 	emag = new /obj/item/weapon/gun/energy/laser/cyborg(src)
-
+	emag = new /obj/item/weapon/gun/energy/taser/cyborg(src)
 	sensor_augs = list("Security", "Medical", "Disable")
 
 	fix_modules()

--- a/code/modules/research/designs/borg_upgrades.dm
+++ b/code/modules/research/designs/borg_upgrades.dm
@@ -58,6 +58,16 @@
 	category = "Robotic_Upgrade_Modules"
 	materials = list(MAT_IRON=10000, MAT_PLASMA=15000, MAT_URANIUM=20000)
 
+/datum/design/borg_taser_board
+	name = "Security cyborg taser module board"
+	desc = "Used to give security cyborgs a taser module."
+	id = "borg_taser_board"
+	req_tech = list(Tc_COMBAT = 3)
+	build_type = MECHFAB
+	build_path = /obj/item/borg/upgrade/tasermodule
+	category = "Robotic_Upgrade_Modules"
+	materials = list(MAT_IRON=50000, MAT_GLASS=6000, MAT_GOLD=1000, MAT_DIAMOND=500)
+
 /datum/design/borg_tasercooler_board
 	name = "Security cyborg rapid taser cooling upgrade"
 	desc = "Used to upgrade cyborg taser cooling."


### PR DESCRIPTION
# Please note that each of the PR's in this series is independent of each other, they represent two different directions.

This is the first of 2 pull requests I'm making as a response to the current solution to the secborg issue that is currently open at #17332. Why 2 pull requests you might ask? I wanted to give both sides of the issue some choice about the direction they would like to see security cyborg take and after discussing it at length with other coders and @ShiftyRail who is the author of #17332 this is what I've come up with as some happy mediums to the issue at hand. Keep in mind that I would only like one of these changes to be pushed through, the one with the most support.

The aim of this first pull request is to remove the taser from roundstart security cyborgs and move it behind an upgrade while keeping it for emagged and hacked silicons. This puts the taser behind a gate of research and materials while the security module stays in the game, albeit gimped a bit. 

This PR also has the added benefit of having few metagaming issues that didn't already exist with other things. Compared to the current proposed solutions, nobody will scream malfunctioning or traitor AI on the basis of there being a security cyborg around with this solution.

All changes were tested extensively locally without any issue. Any and all feedback about any part of the PR is appreciated and will be taken into note in any potential changes. Please also make sure to read the other PR here: #17370 and leave feedback regarding that issue there if possible.

:cl:
 * rscadd: adds security cyborg taser module board.
 * rscadd: adds security cyborg taser to the emag module list and the hacked module list.
 * rscdel: removes cyborg taser module from cyborgs, moves it behind research.