### PR TITLE
[2/2]  Doubles cyborg taser recharge time, improves taser charging in cyborg charger.

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -196,7 +196,7 @@
 	if(..())
 		return FAILED_TO_ADD
 	else
-		T.recharge_time = max(2 , T.recharge_time - 4)
+		T.recharge_time = max(2 , T.recharge_time - 6)
 
 /obj/item/borg/upgrade/jetpack
 	name = "cyborg jetpack module board"

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -305,6 +305,23 @@
 
 	fix_modules()
 
+
+/obj/item/weapon/robot_module/security/respawn_consumable(var/mob/living/silicon/robot/R)
+	for(var/T in modules)
+		if(!(locate(T) in modules)) //Remove nulls
+			modules -= null
+
+	if(R.module && R.module.modules)
+		var/list/um = R.contents|R.module.modules
+		// ^ makes single list of active (R.contents) and inactive modules (R.module.modules)
+		for(var/obj/item/weapon/gun/energy/taser/cyborg/I in um)
+			I.restock()
+		if(R)
+			if(R.module)
+				R.module.respawn_consumable(R)
+				R.module.fix_modules()
+
+
 /obj/item/weapon/robot_module/janitor
 	name = "janitorial robot module"
 

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -21,7 +21,7 @@
 	projectile_type = "/obj/item/projectile/energy/electrode"
 	cell_type = "/obj/item/weapon/cell/secborg"
 	var/charge_tick = 0
-	var/recharge_time = 10 //Time it takes for shots to recharge (in ticks)
+	var/recharge_time = 20 //Time it takes for shots to recharge (in ticks)
 
 /obj/item/weapon/gun/energy/taser/cyborg/New()
 	..()


### PR DESCRIPTION
# Please note that each of the PR's in this series is independent of each other, they represent two different directions.

This is the second of 2 pull requests I'm making as a response to the current solution to the secborg issue that is currently open at #17332. Why 2 pull requests you might ask? I wanted to give both sides of the issue some choice about the direction they would like to see security cyborg take and after discussing it at length with other coders and @ShiftyRail who is the author of #17332 this is what I've come up with as some happy mediums to the issue at hand. Keep in mind that I would only like one of these changes to be pushed through, the one with the most support.

The aim of this second pull request is to double the cyborg taser mobile recharge time, while improving both taser charging in charger and improving the effects of the tasercooling upgrade board by a slight amount to compensate. In practical terms, this will take the time of a full cyborg taser recharge from around 2 minutes to around 4 minutes from my testing and individual shots from a low 20 seconds to a whopping 40 seconds. This is not a buff to the tasercooling module as you will need 2 upgrades to even bring it to old taser recharge levels and 3 to completely max out the charge time, which was on par with the old maximum. This will greatly improve taser charging time while in the charger which will promote healthier gameplay as security cyborgs will have to play smarter and won't have the infinite chase and tase potential they once had. 

From a metagame standpoint, this solution is much healthier than my first one as nothing will change in terms of what admins or players have to deal with since seeing a taser or a security cyborg will have no meta implications.

All changes were tested extensively locally without any issue. Any and all feedback about any part of the PR is appreciated and will be taken into note in any potential changes. Please also make sure to read the other PR here: #17369 and leave feedback regarding that issue there if possible.

:cl:
 * rscadd: doubles cyborg taser recharge time
 * rscadd: improves taser charging in charger
 * rscadd: changes tasercooling module cooling to 6 seconds per module, up from 4, retains old maximum cooling limit.