### PR TITLE
Fixes ID cards in hands not being detected by vending machines

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -483,6 +483,10 @@ var/global/num_vending_terminals = 1
 			add_item(W)
 			src.updateUsrDialog()
 	else if(istype(W, /obj/item/weapon/card))
+		if(currently_vending) //We're trying to pay, not set the account
+			connect_account(user, W)
+			src.updateUsrDialog()
+			return
 		//attempt to connect to a new db, and if that doesn't work then fail
 		if(linked_account)
 			if(account_first_linked)
@@ -885,6 +889,8 @@ var/global/num_vending_terminals = 1
 		var/obj/item/weapon/card/card = usr.get_id_card()
 		if(card)
 			connect_account(usr, card)
+		else
+			to_chat(usr, "<span class='warning'>Please present a valid ID.</span>")
 		src.updateUsrDialog()
 		return
 

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -513,7 +513,7 @@
 	return equipped
 
 /mob/proc/get_id_card()
-	for(var/obj/item/I in src.get_all_slots())
+	for(var/obj/item/I in src.get_all_slots() + held_items)
 		. = I.GetID()
 		if(.)
 			break

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -14,7 +14,7 @@
 			to_chat(H, "<span class='warning'>You are unable to equip that.</span>")
 
 /mob/living/carbon/human/get_all_slots()
-	. = get_head_slots() | get_body_slots()
+	. = held_items + get_head_slots() | get_body_slots()
 
 /mob/living/carbon/human/proc/get_body_slots()
 	return list(

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -14,7 +14,7 @@
 			to_chat(H, "<span class='warning'>You are unable to equip that.</span>")
 
 /mob/living/carbon/human/get_all_slots()
-	. = held_items + get_head_slots() | get_body_slots()
+	. = get_head_slots() | get_body_slots()
 
 /mob/living/carbon/human/proc/get_body_slots()
 	return list(


### PR DESCRIPTION
~~get_all_slots() now also checks held_items on humans, this fixed the issue. This might fuck up something that used that proc, but I didn't see anything in testing.~~
Now checks hands in the `get_id_card()` proc. This has as consequence that you can open airlocks with an ID in your off-hand, but that's all.
Also made attacking the vending machine with an ID while it's waiting for payment pay for the item rather than try to set the linked account number.
Lastly, added a little message when hitting 'pay' without an ID.

Fixes #17363

:cl:
 - bugfix: Slapping vending machines with an ID to pay for a product now works again. That includes the 'Pay' button and touching your ID to the physical machine.