### PR TITLE
Refactors suit dispenser code

### DIFF
--- a/code/__HELPERS/globalaccess.dm
+++ b/code/__HELPERS/globalaccess.dm
@@ -21,8 +21,6 @@
 			return global.sent_spiders_to_station;
 		if("exclude")
 			return global.exclude;
-		if("_all_globals")
-			return global._all_globals;
 		if("asset_cache")
 			return global.asset_cache;
 		if("error_last_seen")
@@ -407,6 +405,14 @@
 			return global.holomap_markers;
 		if("holomaps_initialized")
 			return global.holomaps_initialized;
+		if("available_staff_transforms")
+			return global.available_staff_transforms;
+		if("blacklisted_mobs")
+			return global.blacklisted_mobs;
+		if("clickmaster")
+			return global.clickmaster;
+		if("clickmaster_dummy")
+			return global.clickmaster_dummy;
 		if("tachycardics")
 			return global.tachycardics;
 		if("bradycardics")
@@ -537,6 +543,8 @@
 			return global.med_hud_users;
 		if("sec_hud_users")
 			return global.sec_hud_users;
+		if("diagnostic_hud_users")
+			return global.diagnostic_hud_users;
 		if("escape_list")
 			return global.escape_list;
 		if("church_name")
@@ -723,6 +731,16 @@
 			return global.map_elements;
 		if("modules")
 			return global.modules;
+		if("PROFILE_STORE")
+			return global.PROFILE_STORE;
+		if("PROFILE_LINE")
+			return global.PROFILE_LINE;
+		if("PROFILE_FILE")
+			return global.PROFILE_FILE;
+		if("PROFILE_SLEEPCHECK")
+			return global.PROFILE_SLEEPCHECK;
+		if("PROFILE_TIME")
+			return global.PROFILE_TIME;
 		if("sun")
 			return global.sun;
 		if("all_supply_groups")
@@ -741,6 +759,8 @@
 			return global.animal_butchering_products;
 		if("revdata")
 			return global.revdata;
+		if("datum_donotcopy")
+			return global.datum_donotcopy;
 		if("same_wires")
 			return global.same_wires;
 		if("wireColours")
@@ -1005,6 +1025,8 @@
 			return global.SANSBLOCK;
 		if("NOIRBLOCK")
 			return global.NOIRBLOCK;
+		if("VEGANBLOCK")
+			return global.VEGANBLOCK;
 		if("blobs")
 			return global.blobs;
 		if("blob_cores")
@@ -1047,10 +1069,10 @@
 			return global.rune_list;
 		if("halloween_spawns")
 			return global.halloween_spawns;
-		if("snow_recipes")
-			return global.snow_recipes;
 		if("snowsound")
 			return global.snowsound;
+		if("snow_recipes")
+			return global.snow_recipes;
 		if("Holiday")
 			return global.Holiday;
 		if("blob_candidates")
@@ -1341,8 +1363,6 @@
 			return global.voxresearch_shuttle;
 		if("response_team_members")
 			return global.response_team_members;
-		if("distributed_ert_suits")
-			return global.distributed_ert_suits;
 		if("sent_strike_teams")
 			return global.sent_strike_teams;
 		if("icons_to_ignore_at_floor_init")
@@ -1573,6 +1593,10 @@
 			return global.thing_storm_types;
 		if("watchdog")
 			return global.watchdog;
+		if("fish_eggs_list")
+			return global.fish_eggs_list;
+		if("fish_items_list")
+			return global.fish_items_list;
 		if("non_fakeattack_weapons")
 			return global.non_fakeattack_weapons;
 		if("deepFriedEverything")
@@ -1627,6 +1651,8 @@
 			return global.material_list;
 		if("initial_materials")
 			return global.initial_materials;
+		if("icon_state_to_appearance")
+			return global.icon_state_to_appearance;
 		if("name_to_mineral")
 			return global.name_to_mineral;
 		if("mining_surprises")
@@ -1757,8 +1783,6 @@
 			return global.bullet_master;
 		if("impact_master")
 			return global.impact_master;
-		if("available_staff_transforms")
-			return global.available_staff_transforms;
 		if("beam_master")
 			return global.beam_master;
 		if("existing_dungeons")
@@ -1893,7 +1917,7 @@
 			return global.sc_safecode4;
 		if("sc_safecode5")
 			return global.sc_safecode5;
-
+		
 /proc/writeglobal(which, newval)
 	switch(which)
 		if("map")
@@ -1916,8 +1940,6 @@
 			global.sent_spiders_to_station=newval
 		if("exclude")
 			global.exclude=newval
-		if("_all_globals")
-			global._all_globals=newval
 		if("asset_cache")
 			global.asset_cache=newval
 		if("error_last_seen")
@@ -2302,6 +2324,14 @@
 			global.holomap_markers=newval
 		if("holomaps_initialized")
 			global.holomaps_initialized=newval
+		if("available_staff_transforms")
+			global.available_staff_transforms=newval
+		if("blacklisted_mobs")
+			global.blacklisted_mobs=newval
+		if("clickmaster")
+			global.clickmaster=newval
+		if("clickmaster_dummy")
+			global.clickmaster_dummy=newval
 		if("tachycardics")
 			global.tachycardics=newval
 		if("bradycardics")
@@ -2432,6 +2462,8 @@
 			global.med_hud_users=newval
 		if("sec_hud_users")
 			global.sec_hud_users=newval
+		if("diagnostic_hud_users")
+			global.diagnostic_hud_users=newval
 		if("escape_list")
 			global.escape_list=newval
 		if("church_name")
@@ -2618,6 +2650,16 @@
 			global.map_elements=newval
 		if("modules")
 			global.modules=newval
+		if("PROFILE_STORE")
+			global.PROFILE_STORE=newval
+		if("PROFILE_LINE")
+			global.PROFILE_LINE=newval
+		if("PROFILE_FILE")
+			global.PROFILE_FILE=newval
+		if("PROFILE_SLEEPCHECK")
+			global.PROFILE_SLEEPCHECK=newval
+		if("PROFILE_TIME")
+			global.PROFILE_TIME=newval
 		if("sun")
 			global.sun=newval
 		if("all_supply_groups")
@@ -2636,6 +2678,8 @@
 			global.animal_butchering_products=newval
 		if("revdata")
 			global.revdata=newval
+		if("datum_donotcopy")
+			global.datum_donotcopy=newval
 		if("same_wires")
 			global.same_wires=newval
 		if("wireColours")
@@ -2900,6 +2944,8 @@
 			global.SANSBLOCK=newval
 		if("NOIRBLOCK")
 			global.NOIRBLOCK=newval
+		if("VEGANBLOCK")
+			global.VEGANBLOCK=newval
 		if("blobs")
 			global.blobs=newval
 		if("blob_cores")
@@ -2942,10 +2988,10 @@
 			global.rune_list=newval
 		if("halloween_spawns")
 			global.halloween_spawns=newval
-		if("snow_recipes")
-			global.snow_recipes=newval
 		if("snowsound")
 			global.snowsound=newval
+		if("snow_recipes")
+			global.snow_recipes=newval
 		if("Holiday")
 			global.Holiday=newval
 		if("blob_candidates")
@@ -3236,8 +3282,6 @@
 			global.voxresearch_shuttle=newval
 		if("response_team_members")
 			global.response_team_members=newval
-		if("distributed_ert_suits")
-			global.distributed_ert_suits=newval
 		if("sent_strike_teams")
 			global.sent_strike_teams=newval
 		if("icons_to_ignore_at_floor_init")
@@ -3468,6 +3512,10 @@
 			global.thing_storm_types=newval
 		if("watchdog")
 			global.watchdog=newval
+		if("fish_eggs_list")
+			global.fish_eggs_list=newval
+		if("fish_items_list")
+			global.fish_items_list=newval
 		if("non_fakeattack_weapons")
 			global.non_fakeattack_weapons=newval
 		if("deepFriedEverything")
@@ -3522,6 +3570,8 @@
 			global.material_list=newval
 		if("initial_materials")
 			global.initial_materials=newval
+		if("icon_state_to_appearance")
+			global.icon_state_to_appearance=newval
 		if("name_to_mineral")
 			global.name_to_mineral=newval
 		if("mining_surprises")
@@ -3652,8 +3702,6 @@
 			global.bullet_master=newval
 		if("impact_master")
 			global.impact_master=newval
-		if("available_staff_transforms")
-			global.available_staff_transforms=newval
 		if("beam_master")
 			global.beam_master=newval
 		if("existing_dungeons")
@@ -3788,5 +3836,5 @@
 			global.sc_safecode4=newval
 		if("sc_safecode5")
 			global.sc_safecode5=newval
-
-/var/list/_all_globals=list("map","masterdatumPool","pooledvariables","prox_sensor_ignored_types","ability_verbs","sent_aliens_to_station","account_hack_attempted","spacevines_spawned","sent_spiders_to_station","exclude","_all_globals","asset_cache","error_last_seen","error_cooldown","html_interfaces","all_lighting_corners","LIGHTING_CORNER_DIAGONAL","validartifactprojectiles","cargo_telepads","chatResources","bicon_cache","dview_mob","meteor_wave_delay","meteors_in_wave","meteor_wave_active","max_meteor_size","chosen_dir","create_mob_html","create_object_html","create_turf_html","any","asset_cache_populated","total_runtimes","total_runtimes_skipped","error_cache","dummy_lighting_corner","security_level","iconCache","round_end_info","deadmins","lockedvars","nevervars","type_instances","data_core","plmaster","slmaster","account_DBs","global_map","universe","paper_tag_whitelist","paper_blacklist","skipupdate","eventchance","event","hadevent","blobevent","starticon","midicon","endicon","diary","diaryofmeanpeople","admin_diary","href_logfile","station_name","game_version","changelog_hash","game_year","going","master_mode","secret_force_mode","host","aliens_allowed","ooc_allowed","looc_allowed","dooc_allowed","traitor_scaling","dna_ident","abandon_allowed","enter_allowed","guests_allowed","shuttle_frozen","shuttle_left","tinted_weldhelh","jobMax","bombers","admin_log","lawchanges","shuttles","reg_dna","CELLRATE","CHARGELEVEL","WORLD_X_OFFSET","WORLD_Y_OFFSET","shuttle_z","airtunnel_start","airtunnel_stop","airtunnel_bottom","monkeystart","wizardstart","newplayer_start","latejoin","assistant_latejoin","prisonwarp","holdingfacility","xeno_spawn","endgame_safespawns","endgame_exits","tdome1","tdome2","tdomeobserve","tdomeadmin","prisonsecuritywarp","prisonwarped","blobstart","ninjastart","cardinal","diagonal","alldirs","universal_cult_chat","start_state","config","combatlog","IClog","OOClog","adminlog","suspend_alert","Debug","Debug2","debugobj","mods","wavesecret","gravity_is_on","shuttlecoming","join_motd","forceblob","polarstar","nanomanager","sqladdress","sqlport","sqldb","sqllogin","sqlpass","sqlfdbkdb","sqlfdbklogin","sqlfdbkpass","sqllogging","forumsqladdress","forumsqlport","forumsqldb","forumsqllogin","forumsqlpass","forum_activated_group","forum_authenticated_group","fileaccess_timer","custom_event_msg","dbcon","dbcon_old","recall_time_limit","score","trash_items","decals","on_login","on_ban","on_unban","plugins","space_gas","announcement_intercom","sortedAreas","bomberman_mode","bomberman_hurt","bomberman_destroy","volunteer_gladiators","ready_gladiators","never_gladiators","achievements","end_icons","arena_leaderboard","arena_rounds","arena_top_score","endgame_info_logged","explosion_newmethod","snake_station_highscores","snake_best_players","minesweeper_station_highscores","minesweeper_best_players","nanocoins_rates","nanocoins_lastchange","speciesinit","minimapinit","bees_species","stat_collection","hardcore_mode","mineral_turfs","static_list","grayscale","adminblob_icon","adminblob_size","adminblob_beat","holoMiniMaps","centcommMiniMaps","extraMiniMaps","holomap_markers","holomaps_initialized","tachycardics","bradycardics","heartstopper","cheartstopper","disable_scrubbers","disable_vents","Space_Tile","MAX_EXPLOSION_RANGE","BODY_PARTS","BODY_COVER_VALUE_LIST","NOIRMATRIX","bad_changing_colour_ckeys","global_mutations","scarySounds","RESTRICTED_CAMERA_NETWORKS","default_colour_matrix","ai_names","wizard_first","wizard_second","ninja_titles","ninja_names","commando_names","first_names_male","first_names_female","last_names","clown_names","verbs","adjectives","vox_name_syllables","golem_names","borer_names","hologram_names","autoborg_silly_names","panicfile","failed_db_connections","failed_old_db_connections","desire_ranks","cmp_field","cmp_dist_origin","DummyCache","genders","clients","admins","directory","mixed_modes","player_list","mob_list","living_mob_list","dead_mob_list","observers","areas","chemical_reactions_list","chemical_reagents_list","landmarks_list","surgery_steps","mechas_list","poster_designs","underwear_m","underwear_f","backbaglist","hit_appends","epilepsy_appends","table_recipes","med_hud_users","sec_hud_users","escape_list","church_name","command_name","religion_name","syndicate_name","syndicate_code_phrase","syndicate_code_response","watt_suffixes","number_digits","number_tens","number_units","quote","get_matching_types_cache","get_vars_from_type_cache","existing_typesof_cache","common_tools","WALLITEMS","sortInstance","hooks","ventcrawl_machinery","catcher","parallax_on_clients","parallax_initialized","space_color","parallax_icon","unstackable_pipes","heat_pipes","bent_dirs","pipeID2State","nlist","straight_pipes","bent_pipes","manifold_pipes","garbageCollector","soft_dels","emergency_shuttle","Failsafe","Master","MC_restart_clear","MC_restart_timeout","MC_restart_count","CURRENT_TICKLIMIT","SSair","tick_multiplier","SSdisease","active_diseases","SSemergency_shuttle","SSevent","events","SSfast_machinery","fast_machines","SSgarbage","SShtml_ui","html_machines","SSinactivity","SSlighting","lighting_update_lights","lighting_update_corners","lighting_update_overlays","SSmachinery","machines","SSmob","SSnano","SSobj","processing_objects","SSpipenet","atmos_machines","pipe_networks","on_pipenet_tick","SSpower","power_machines","powernets","cable_list","SSsun","SSsupply_shuttle","SSticker","SSvote","SSassets","SSfinish","SSgenetics","SSjob","SSmap","SSminimap","SSmore_init","SSrust","SScreate_ticker","SSxenoarch","randomize_laws","base_law_type","mommi_base_law_type","diseases","map_elements","modules","sun","all_supply_groups","uplink_items","archive_diseases","advance_cures","list_symptoms","dictionary_symptoms","animal_butchering_products","revdata","same_wires","wireColours","PDA_Manifest","vox_sounds","vox_wordlen","outbreak_level_words","spawned_surprises","max_secret_rooms","del_profiling","gdel_profiling","ghdel_profiling","current_centcomm_order_id","all_radios","radiochannels","radiochannelsreverse","CENT_FREQS","radio_controller","pointers","nextDecTalkDelay","lastDecTalkUse","freqtospan","freqtoname","ghostimg","resethearers","smoothable_unsims","shatter_sound","explosion_sound","small_explosion_sound","spark_sound","rustle_sound","punch_sound","clown_sound","swing_hit_sound","hiss_sound","page_sound","mechstep_sound","gib_sound","mommicomment_sound","polaroid_sound","male_scream_sound","female_scream_sound","male_cough_sound","female_cough_sound","lightning_sound","soulstone_sound","fracture_sound","machete_hit_sound","machete_throw_sound","machete_throw_hit_sound","supply_shuttle","space_area","ignored_keys","moved_landmarks","transparent_icons","teleportlocs","ghostteleportlocs","adminbusteleportlocs","centcom_areas","the_station_areas","dna_activity_bounds","assigned_gene_blocks","assigned_blocks","dna_genes","good_blocks","bad_blocks","skin_styles_female_list","hair_styles_list","hair_styles_male_list","hair_styles_female_list","facial_hair_styles_list","facial_hair_styles_male_list","facial_hair_styles_female_list","noir_master","ticker","potential_theft_objectives","BLINDBLOCK","DEAFBLOCK","HULKBLOCK","TELEBLOCK","FIREBLOCK","XRAYBLOCK","CLUMSYBLOCK","FAKEBLOCK","COUGHBLOCK","GLASSESBLOCK","EPILEPSYBLOCK","TWITCHBLOCK","NERVOUSBLOCK","MONKEYBLOCK","BLOCKADD","DIFFMUT","HEADACHEBLOCK","NOBREATHBLOCK","REMOTEVIEWBLOCK","REGENERATEBLOCK","INCREASERUNBLOCK","REMOTETALKBLOCK","MORPHBLOCK","COLDBLOCK","HALLUCINATIONBLOCK","NOPRINTSBLOCK","SHOCKIMMUNITYBLOCK","SMALLSIZEBLOCK","LISPBLOCK","MUTEBLOCK","RADBLOCK","FATBLOCK","CHAVBLOCK","SWEDEBLOCK","SCRAMBLEBLOCK","TOXICFARTBLOCK","STRONGBLOCK","HORNSBLOCK","SMILEBLOCK","ELVISBLOCK","SOBERBLOCK","PSYRESISTBLOCK","FARSIGHTBLOCK","CHAMELEONBLOCK","CRYOBLOCK","EATBLOCK","JUMPBLOCK","MELTBLOCK","EMPATHBLOCK","SUPERFARTBLOCK","IMMOLATEBLOCK","POLYMORPHBLOCK","LOUDBLOCK","WHISPERBLOCK","DIZZYBLOCK","SANSBLOCK","NOIRBLOCK","blobs","blob_cores","blob_nodes","blob_resources","blob_overminds","blob_looks_admin","blob_looks_player","possible_changeling_IDs","hivemind_bank","powers","powerinstances","narsie_behaviour","narsie_cometh","narsie_list","mr_clean_targets","cultwords","runedec","engwords","rnwords","rune_list","halloween_spawns","snow_recipes","Holiday","blob_candidates","mixed_allowed","bomb_set","nukedisk","hsboxspawn","hrefs","banned_sandbox_types","all_jobs","job_master","assistant_occupations","command_positions","engineering_positions","medical_positions","science_positions","civilian_positions","cargo_positions","security_positions","nonhuman_positions","misc_positions","whitelist","alien_whitelist","firealarms","cryo_health_indicator","doppler_arrays","flashers","holosigns","igniters","multitool_var_whitelist","mass_drivers","navbeacons","news_network","allCasters","req_console_assistance","req_console_supplies","req_console_information","allConsoles","station_holomaps","status_displays","ai_emotions","status_display_images","dispenser_presets","num_vending_terminals","floorbot_targets","mulebot_count","camera_names","camera_messages","tv_monitors","shuttle_calls","prison_shuttle_moving_to_station","prison_shuttle_moving_to_prison","prison_shuttle_at_station","prison_shuttle_can_send","prison_shuttle_time","prison_shuttle_timeleft","specops_shuttle_moving_to_station","specops_shuttle_moving_to_centcom","specops_shuttle_at_station","specops_shuttle_can_send","specops_shuttle_time","specops_shuttle_timeleft","syndicate_elite_shuttle_moving_to_station","syndicate_elite_shuttle_moving_to_mothership","syndicate_elite_shuttle_at_station","syndicate_elite_shuttle_can_send","syndicate_elite_shuttle_time","syndicate_elite_shuttle_timeleft","taxi_computers","all_doors","alert_overlays_global","poddoors","recentmessages","message_delay","telecomms_list","word_to_uristrune_table","uristrune_cache","explosion_shake_message_cooldown","explosion_turfs","explosion_in_progress","blood_overlays","reagents_to_log","BUMP_TELEPORTERS","portal_cache","splatter_cache","blood_list","fluidtrack_cache","beacons","all_graffitis","living_balloons","deskbell_default_frequencies","deskbell_freq_cargo","deskbell_freq_hop","deskbell_freq_medbay","deskbell_freq_brig","deskbell_freq_rnd","camera_bugs","pda_app_menus","chatrooms","PDAs","available_paintings","cable_recipes","metal_recipes","plasteel_recipes","wood_recipes","cardboard_recipes","leather_recipes","sandstone_recipes","diamond_recipes","uranium_recipes","plasma_recipes","plastic_recipes","gold_recipes","phazon_recipes","silver_recipes","clown_recipes","charcoal_recipes","lightfloor_colors","moneytypes","cached_icons","tracking_implants","bottle_colour_choices","hidden_doors","all_docking_ports","ladders","one_way_windows","cargo_shuttle","escape_shuttle","mining_shuttle","arrival_shuttle","transport_shuttle","ert_shuttle","deathsquad_shuttle","elite_syndie_shuttle","strike_team_shuttle","admin_shuttle","research_shuttle","salvage_shuttle","security_shuttle","syndicate_shuttle","taxi_a","taxi_b","trade_shuttle","vox_shuttle","voxresearch_shuttle","response_team_members","distributed_ert_suits","sent_strike_teams","icons_to_ignore_at_floor_init","plating_icons","wood_icons","w_overlays","_flatIcons","directional","exception","directional_turfs","BSACooldown","floorIsLava","admin_shuttle_location","alien_ship_location","investigations","admin_ranks","admin_verbs_default","admin_verbs_admin","admin_verbs_ban","admin_verbs_sounds","admin_verbs_fun","admin_verbs_spawn","admin_verbs_server","admin_verbs_debug","admin_verbs_possess","admin_verbs_permissions","admin_verbs_rejuv","admin_verbs_polling","admin_verbs_hideable","admin_verbs_mod","appearanceban_runonce","appearance_keylist","jobban_runonce","jobban_keylist","oocban_keylist","admin_datums","CMinutes","Banlist","Banlistjob","adminhelp_ignored_words","checked_for_inactives","inactive_keys","blood_virus_spreading_disabled","camera_range_display_status","intercom_range_display_status","prevent_airgroup_regroup","say_disabled","movement_disabled","movement_disabled_exception","forbidden_varedit_object_types","PROFILING_VERBS","vox_tick","assembly_short_name_to_type","comparison_circuit_operations","math_circuit_operations_list","automation_types","gas_labels","existing_away_missions","awaydestinations","away_mission_subtypes","gateways","maploader","_preloader","map_dimension_cache","swapmaps_iconcache","swapmaps_mode","swapmaps_compiled_maxx","swapmaps_compiled_maxy","swapmaps_compiled_maxz","swapmaps_initialized","swapmaps_loaded","swapmaps_byname","bombermangear","arenas","arena_spawnpoints","person_animation_viewers","item_animation_viewers","preferences_datums","special_roles","antag_roles","nonantag_roles","role_wiki","opposite_dirs","holomap_chips","holomap_cache","has_been_shade","current_date_string","num_financial_terminals","num_financial_database","num_vending_machines","num_pda_terminals","num_merch_computers","station_account","department_accounts","next_account_number","centcomm_account_db","vendor_account","all_money_accounts","setup_economy","weighted_randomevent_locations","weighted_mundaneevent_locations","station_departments","current_pos_id","pos_sales","wages_enabled","roundstart_enable_wages","event_last_fired","allEvents","potentialRandomEvents","eventTimeLower","eventTimeUpper","scheduledEvent","vox_kills","vox_sent","raiders","thing_storm_types","watchdog","non_fakeattack_weapons","deepFriedEverything","deepFriedNutriment","foodNesting","recursiveFood","ingredientLimit","wizard_cards_rare","wizard_cards_normal","adv_camera","crewmonitor","vote","plant_controller","seed_types","gene_tag_masks","library_catalog","library_section_names","liquid_delay","puddles","global_playlists","loopModeNames","media_receivers","media_transmitters","migration_controller_mysql","migration_controller_sqlite","valid_abandoned_crate_types","material_list","initial_materials","name_to_mineral","mining_surprises","slot_equipment_priority","intents","boo_phrases","boo_phrases_drugs","boo_phrases_silicon","virtualhearers","movable_hearers","mob_hearers","stationary_hearers","coldwarning_light","coldwarning_hard","department_radio_keys","language_keys","all_languages","all_species","whitelisted_species","has_died_as_golem","unconscious_overlays","oxyloss_overlays","brutefireloss_overlays","organ_damage_overlays","damage_icon_parts","cover_protection_value_list","ai_list","announcing_vox","vox_digits","vox_tens","vox_units","cameranet","paiController","borer_chem_types_head","borer_chem_types_chest","borer_chem_types_arm","borer_chem_types_leg","borer_unlock_types_head","borer_unlock_types_chest","borer_unlock_types_arm","borer_unlock_types_leg","animal_count","wizard_snakes","nest_locations","bad_gremlin_items","crate_mimic_disguises","item_mimic_disguises","protected_objects","spider_queens","photocollector_list","prism_list","mirror_list","paper_folding_results","paperwork","paperwork_library","battery_charge","battery_charging","battery_online","alllights","powernets_broke","smes_list","solars_list","rad_collectors","field_gen_list","bullet_master","impact_master","available_staff_transforms","beam_master","existing_dungeons","dungeon_area","existing_vaults","disposalpipeID2State","paint_variants","chifir_doesnt_remove","tonio_doesnt_remove","LOGGED_SPLASH_REAGENTS","pillIcon2Name","juice_items","bomb_like_items","special_fruits","valid_random_food_types","cockroach_egg_amount","charcoal_doesnt_remove","message_servers","blackbox","rnd_machines","design_list","tech_list","hidden_tech","responsive_carriers","finds_as_strings","authenticators","maint_all_access","spells","falltempoverlays","doppelgangers","centcomm_store","GPS_list","SPS_list","telesci_warnings","ANTIGENS","disease2_list","virusDB","compatible_mobs","buildmodeholders","newscaster_standard_feeds","announced_news_types","allfaxes","alldepartments","atmos_controllers","ul_FastRoot","sharing_lookup_table","assigned","created","merged","invalid_zone","air_blocked","zone_blocked","blocked","mark","zas_settings","contamination_overlay","accessable_z_levels","shop_prices","circuitboards","circuitboard_prices","clothing","clothing_prices","hive_pylons","sc_safecode1","sc_safecode2","sc_safecode3","sc_safecode4","sc_safecode5")
+		
+/var/list/_all_globals=list("map","masterdatumPool","pooledvariables","prox_sensor_ignored_types","ability_verbs","sent_aliens_to_station","account_hack_attempted","spacevines_spawned","sent_spiders_to_station","exclude","asset_cache","error_last_seen","error_cooldown","html_interfaces","all_lighting_corners","LIGHTING_CORNER_DIAGONAL","validartifactprojectiles","cargo_telepads","chatResources","bicon_cache","dview_mob","meteor_wave_delay","meteors_in_wave","meteor_wave_active","max_meteor_size","chosen_dir","create_mob_html","create_object_html","create_turf_html","any","asset_cache_populated","total_runtimes","total_runtimes_skipped","error_cache","dummy_lighting_corner","security_level","iconCache","round_end_info","deadmins","lockedvars","nevervars","type_instances","data_core","plmaster","slmaster","account_DBs","global_map","universe","paper_tag_whitelist","paper_blacklist","skipupdate","eventchance","event","hadevent","blobevent","starticon","midicon","endicon","diary","diaryofmeanpeople","admin_diary","href_logfile","station_name","game_version","changelog_hash","game_year","going","master_mode","secret_force_mode","host","aliens_allowed","ooc_allowed","looc_allowed","dooc_allowed","traitor_scaling","dna_ident","abandon_allowed","enter_allowed","guests_allowed","shuttle_frozen","shuttle_left","tinted_weldhelh","jobMax","bombers","admin_log","lawchanges","shuttles","reg_dna","CELLRATE","CHARGELEVEL","WORLD_X_OFFSET","WORLD_Y_OFFSET","shuttle_z","airtunnel_start","airtunnel_stop","airtunnel_bottom","monkeystart","wizardstart","newplayer_start","latejoin","assistant_latejoin","prisonwarp","holdingfacility","xeno_spawn","endgame_safespawns","endgame_exits","tdome1","tdome2","tdomeobserve","tdomeadmin","prisonsecuritywarp","prisonwarped","blobstart","ninjastart","cardinal","diagonal","alldirs","universal_cult_chat","start_state","config","combatlog","IClog","OOClog","adminlog","suspend_alert","Debug","Debug2","debugobj","mods","wavesecret","gravity_is_on","shuttlecoming","join_motd","forceblob","polarstar","nanomanager","sqladdress","sqlport","sqldb","sqllogin","sqlpass","sqlfdbkdb","sqlfdbklogin","sqlfdbkpass","sqllogging","forumsqladdress","forumsqlport","forumsqldb","forumsqllogin","forumsqlpass","forum_activated_group","forum_authenticated_group","fileaccess_timer","custom_event_msg","dbcon","dbcon_old","recall_time_limit","score","trash_items","decals","on_login","on_ban","on_unban","plugins","space_gas","announcement_intercom","sortedAreas","bomberman_mode","bomberman_hurt","bomberman_destroy","volunteer_gladiators","ready_gladiators","never_gladiators","achievements","end_icons","arena_leaderboard","arena_rounds","arena_top_score","endgame_info_logged","explosion_newmethod","snake_station_highscores","snake_best_players","minesweeper_station_highscores","minesweeper_best_players","nanocoins_rates","nanocoins_lastchange","speciesinit","minimapinit","bees_species","stat_collection","hardcore_mode","mineral_turfs","static_list","grayscale","adminblob_icon","adminblob_size","adminblob_beat","holoMiniMaps","centcommMiniMaps","extraMiniMaps","holomap_markers","holomaps_initialized","available_staff_transforms","blacklisted_mobs","clickmaster","clickmaster_dummy","tachycardics","bradycardics","heartstopper","cheartstopper","disable_scrubbers","disable_vents","Space_Tile","MAX_EXPLOSION_RANGE","BODY_PARTS","BODY_COVER_VALUE_LIST","NOIRMATRIX","bad_changing_colour_ckeys","global_mutations","scarySounds","RESTRICTED_CAMERA_NETWORKS","default_colour_matrix","ai_names","wizard_first","wizard_second","ninja_titles","ninja_names","commando_names","first_names_male","first_names_female","last_names","clown_names","verbs","adjectives","vox_name_syllables","golem_names","borer_names","hologram_names","autoborg_silly_names","panicfile","failed_db_connections","failed_old_db_connections","desire_ranks","cmp_field","cmp_dist_origin","DummyCache","genders","clients","admins","directory","mixed_modes","player_list","mob_list","living_mob_list","dead_mob_list","observers","areas","chemical_reactions_list","chemical_reagents_list","landmarks_list","surgery_steps","mechas_list","poster_designs","underwear_m","underwear_f","backbaglist","hit_appends","epilepsy_appends","table_recipes","med_hud_users","sec_hud_users","diagnostic_hud_users","escape_list","church_name","command_name","religion_name","syndicate_name","syndicate_code_phrase","syndicate_code_response","watt_suffixes","number_digits","number_tens","number_units","quote","get_matching_types_cache","get_vars_from_type_cache","existing_typesof_cache","common_tools","WALLITEMS","sortInstance","hooks","ventcrawl_machinery","catcher","parallax_on_clients","parallax_initialized","space_color","parallax_icon","unstackable_pipes","heat_pipes","bent_dirs","pipeID2State","nlist","straight_pipes","bent_pipes","manifold_pipes","garbageCollector","soft_dels","emergency_shuttle","Failsafe","Master","MC_restart_clear","MC_restart_timeout","MC_restart_count","CURRENT_TICKLIMIT","SSair","tick_multiplier","SSdisease","active_diseases","SSemergency_shuttle","SSevent","events","SSfast_machinery","fast_machines","SSgarbage","SShtml_ui","html_machines","SSinactivity","SSlighting","lighting_update_lights","lighting_update_corners","lighting_update_overlays","SSmachinery","machines","SSmob","SSnano","SSobj","processing_objects","SSpipenet","atmos_machines","pipe_networks","on_pipenet_tick","SSpower","power_machines","powernets","cable_list","SSsun","SSsupply_shuttle","SSticker","SSvote","SSassets","SSfinish","SSgenetics","SSjob","SSmap","SSminimap","SSmore_init","SSrust","SScreate_ticker","SSxenoarch","randomize_laws","base_law_type","mommi_base_law_type","diseases","map_elements","modules","PROFILE_STORE","PROFILE_LINE","PROFILE_FILE","PROFILE_SLEEPCHECK","PROFILE_TIME","sun","all_supply_groups","uplink_items","archive_diseases","advance_cures","list_symptoms","dictionary_symptoms","animal_butchering_products","revdata","datum_donotcopy","same_wires","wireColours","PDA_Manifest","vox_sounds","vox_wordlen","outbreak_level_words","spawned_surprises","max_secret_rooms","del_profiling","gdel_profiling","ghdel_profiling","current_centcomm_order_id","all_radios","radiochannels","radiochannelsreverse","CENT_FREQS","radio_controller","pointers","nextDecTalkDelay","lastDecTalkUse","freqtospan","freqtoname","ghostimg","resethearers","smoothable_unsims","shatter_sound","explosion_sound","small_explosion_sound","spark_sound","rustle_sound","punch_sound","clown_sound","swing_hit_sound","hiss_sound","page_sound","mechstep_sound","gib_sound","mommicomment_sound","polaroid_sound","male_scream_sound","female_scream_sound","male_cough_sound","female_cough_sound","lightning_sound","soulstone_sound","fracture_sound","machete_hit_sound","machete_throw_sound","machete_throw_hit_sound","supply_shuttle","space_area","ignored_keys","moved_landmarks","transparent_icons","teleportlocs","ghostteleportlocs","adminbusteleportlocs","centcom_areas","the_station_areas","dna_activity_bounds","assigned_gene_blocks","assigned_blocks","dna_genes","good_blocks","bad_blocks","skin_styles_female_list","hair_styles_list","hair_styles_male_list","hair_styles_female_list","facial_hair_styles_list","facial_hair_styles_male_list","facial_hair_styles_female_list","noir_master","ticker","potential_theft_objectives","BLINDBLOCK","DEAFBLOCK","HULKBLOCK","TELEBLOCK","FIREBLOCK","XRAYBLOCK","CLUMSYBLOCK","FAKEBLOCK","COUGHBLOCK","GLASSESBLOCK","EPILEPSYBLOCK","TWITCHBLOCK","NERVOUSBLOCK","MONKEYBLOCK","BLOCKADD","DIFFMUT","HEADACHEBLOCK","NOBREATHBLOCK","REMOTEVIEWBLOCK","REGENERATEBLOCK","INCREASERUNBLOCK","REMOTETALKBLOCK","MORPHBLOCK","COLDBLOCK","HALLUCINATIONBLOCK","NOPRINTSBLOCK","SHOCKIMMUNITYBLOCK","SMALLSIZEBLOCK","LISPBLOCK","MUTEBLOCK","RADBLOCK","FATBLOCK","CHAVBLOCK","SWEDEBLOCK","SCRAMBLEBLOCK","TOXICFARTBLOCK","STRONGBLOCK","HORNSBLOCK","SMILEBLOCK","ELVISBLOCK","SOBERBLOCK","PSYRESISTBLOCK","FARSIGHTBLOCK","CHAMELEONBLOCK","CRYOBLOCK","EATBLOCK","JUMPBLOCK","MELTBLOCK","EMPATHBLOCK","SUPERFARTBLOCK","IMMOLATEBLOCK","POLYMORPHBLOCK","LOUDBLOCK","WHISPERBLOCK","DIZZYBLOCK","SANSBLOCK","NOIRBLOCK","VEGANBLOCK","blobs","blob_cores","blob_nodes","blob_resources","blob_overminds","blob_looks_admin","blob_looks_player","possible_changeling_IDs","hivemind_bank","powers","powerinstances","narsie_behaviour","narsie_cometh","narsie_list","mr_clean_targets","cultwords","runedec","engwords","rnwords","rune_list","halloween_spawns","snowsound","snow_recipes","Holiday","blob_candidates","mixed_allowed","bomb_set","nukedisk","hsboxspawn","hrefs","banned_sandbox_types","all_jobs","job_master","assistant_occupations","command_positions","engineering_positions","medical_positions","science_positions","civilian_positions","cargo_positions","security_positions","nonhuman_positions","misc_positions","whitelist","alien_whitelist","firealarms","cryo_health_indicator","doppler_arrays","flashers","holosigns","igniters","multitool_var_whitelist","mass_drivers","navbeacons","news_network","allCasters","req_console_assistance","req_console_supplies","req_console_information","allConsoles","station_holomaps","status_displays","ai_emotions","status_display_images","dispenser_presets","num_vending_terminals","floorbot_targets","mulebot_count","camera_names","camera_messages","tv_monitors","shuttle_calls","prison_shuttle_moving_to_station","prison_shuttle_moving_to_prison","prison_shuttle_at_station","prison_shuttle_can_send","prison_shuttle_time","prison_shuttle_timeleft","specops_shuttle_moving_to_station","specops_shuttle_moving_to_centcom","specops_shuttle_at_station","specops_shuttle_can_send","specops_shuttle_time","specops_shuttle_timeleft","syndicate_elite_shuttle_moving_to_station","syndicate_elite_shuttle_moving_to_mothership","syndicate_elite_shuttle_at_station","syndicate_elite_shuttle_can_send","syndicate_elite_shuttle_time","syndicate_elite_shuttle_timeleft","taxi_computers","all_doors","alert_overlays_global","poddoors","recentmessages","message_delay","telecomms_list","word_to_uristrune_table","uristrune_cache","explosion_shake_message_cooldown","explosion_turfs","explosion_in_progress","blood_overlays","reagents_to_log","BUMP_TELEPORTERS","portal_cache","splatter_cache","blood_list","fluidtrack_cache","beacons","all_graffitis","living_balloons","deskbell_default_frequencies","deskbell_freq_cargo","deskbell_freq_hop","deskbell_freq_medbay","deskbell_freq_brig","deskbell_freq_rnd","camera_bugs","pda_app_menus","chatrooms","PDAs","available_paintings","cable_recipes","metal_recipes","plasteel_recipes","wood_recipes","cardboard_recipes","leather_recipes","sandstone_recipes","diamond_recipes","uranium_recipes","plasma_recipes","plastic_recipes","gold_recipes","phazon_recipes","silver_recipes","clown_recipes","charcoal_recipes","lightfloor_colors","moneytypes","cached_icons","tracking_implants","bottle_colour_choices","hidden_doors","all_docking_ports","ladders","one_way_windows","cargo_shuttle","escape_shuttle","mining_shuttle","arrival_shuttle","transport_shuttle","ert_shuttle","deathsquad_shuttle","elite_syndie_shuttle","strike_team_shuttle","admin_shuttle","research_shuttle","salvage_shuttle","security_shuttle","syndicate_shuttle","taxi_a","taxi_b","trade_shuttle","vox_shuttle","voxresearch_shuttle","response_team_members","sent_strike_teams","icons_to_ignore_at_floor_init","plating_icons","wood_icons","_flatIcons","directional","exception","directional_turfs","BSACooldown","floorIsLava","admin_shuttle_location","alien_ship_location","investigations","admin_ranks","admin_verbs_default","admin_verbs_admin","admin_verbs_ban","admin_verbs_sounds","admin_verbs_fun","admin_verbs_spawn","admin_verbs_server","admin_verbs_debug","admin_verbs_possess","admin_verbs_permissions","admin_verbs_rejuv","admin_verbs_polling","admin_verbs_hideable","admin_verbs_mod","appearanceban_runonce","appearance_keylist","jobban_runonce","jobban_keylist","oocban_keylist","admin_datums","CMinutes","Banlist","Banlistjob","adminhelp_ignored_words","checked_for_inactives","inactive_keys","blood_virus_spreading_disabled","camera_range_display_status","intercom_range_display_status","prevent_airgroup_regroup","say_disabled","movement_disabled","movement_disabled_exception","forbidden_varedit_object_types","PROFILING_VERBS","vox_tick","assembly_short_name_to_type","comparison_circuit_operations","math_circuit_operations_list","automation_types","gas_labels","existing_away_missions","awaydestinations","away_mission_subtypes","gateways","maploader","_preloader","map_dimension_cache","swapmaps_iconcache","swapmaps_mode","swapmaps_compiled_maxx","swapmaps_compiled_maxy","swapmaps_compiled_maxz","swapmaps_initialized","swapmaps_loaded","swapmaps_byname","bombermangear","arenas","arena_spawnpoints","person_animation_viewers","item_animation_viewers","preferences_datums","special_roles","antag_roles","nonantag_roles","role_wiki","opposite_dirs","holomap_chips","holomap_cache","has_been_shade","current_date_string","num_financial_terminals","num_financial_database","num_vending_machines","num_pda_terminals","num_merch_computers","station_account","department_accounts","next_account_number","centcomm_account_db","vendor_account","all_money_accounts","setup_economy","weighted_randomevent_locations","weighted_mundaneevent_locations","station_departments","current_pos_id","pos_sales","wages_enabled","roundstart_enable_wages","event_last_fired","allEvents","potentialRandomEvents","eventTimeLower","eventTimeUpper","scheduledEvent","vox_kills","vox_sent","raiders","thing_storm_types","watchdog","fish_eggs_list","fish_items_list","non_fakeattack_weapons","deepFriedEverything","deepFriedNutriment","foodNesting","recursiveFood","ingredientLimit","wizard_cards_rare","wizard_cards_normal","adv_camera","crewmonitor","vote","plant_controller","seed_types","gene_tag_masks","library_catalog","library_section_names","liquid_delay","puddles","global_playlists","loopModeNames","media_receivers","media_transmitters","migration_controller_mysql","migration_controller_sqlite","valid_abandoned_crate_types","material_list","initial_materials","icon_state_to_appearance","name_to_mineral","mining_surprises","slot_equipment_priority","intents","boo_phrases","boo_phrases_drugs","boo_phrases_silicon","virtualhearers","movable_hearers","mob_hearers","stationary_hearers","coldwarning_light","coldwarning_hard","department_radio_keys","language_keys","all_languages","all_species","whitelisted_species","has_died_as_golem","unconscious_overlays","oxyloss_overlays","brutefireloss_overlays","organ_damage_overlays","damage_icon_parts","cover_protection_value_list","ai_list","announcing_vox","vox_digits","vox_tens","vox_units","cameranet","paiController","borer_chem_types_head","borer_chem_types_chest","borer_chem_types_arm","borer_chem_types_leg","borer_unlock_types_head","borer_unlock_types_chest","borer_unlock_types_arm","borer_unlock_types_leg","animal_count","wizard_snakes","nest_locations","bad_gremlin_items","crate_mimic_disguises","item_mimic_disguises","protected_objects","spider_queens","photocollector_list","prism_list","mirror_list","paper_folding_results","paperwork","paperwork_library","battery_charge","battery_charging","battery_online","alllights","powernets_broke","smes_list","solars_list","rad_collectors","field_gen_list","bullet_master","impact_master","beam_master","existing_dungeons","dungeon_area","existing_vaults","disposalpipeID2State","paint_variants","chifir_doesnt_remove","tonio_doesnt_remove","LOGGED_SPLASH_REAGENTS","pillIcon2Name","juice_items","bomb_like_items","special_fruits","valid_random_food_types","cockroach_egg_amount","charcoal_doesnt_remove","message_servers","blackbox","rnd_machines","design_list","tech_list","hidden_tech","responsive_carriers","finds_as_strings","authenticators","maint_all_access","spells","falltempoverlays","doppelgangers","centcomm_store","GPS_list","SPS_list","telesci_warnings","ANTIGENS","disease2_list","virusDB","compatible_mobs","buildmodeholders","newscaster_standard_feeds","announced_news_types","allfaxes","alldepartments","atmos_controllers","ul_FastRoot","sharing_lookup_table","assigned","created","merged","invalid_zone","air_blocked","zone_blocked","blocked","mark","zas_settings","contamination_overlay","accessable_z_levels","shop_prices","circuitboards","circuitboard_prices","clothing","clothing_prices","hive_pylons","sc_safecode1","sc_safecode2","sc_safecode3","sc_safecode4","sc_safecode5")

--- a/code/game/machinery/suit_dispenser.dm
+++ b/code/game/machinery/suit_dispenser.dm
@@ -2,7 +2,20 @@
 // SUIT DISPENSER UNIT ///////////////
 //////////////////////////////////////
 
+#define SD_BUSY			1		// the dispenser is busy.
+#define SD_ONESUIT		2		// only one type of suit comes out of this dispenser.
+#define SD_NOGREED		4		// no-one is allowed more than one suit from this TYPE of dispenser unless emagged
+#define SD_UNLIMITED	8		// will not deplete amount when armour is taken
+
 var/list/dispenser_presets = list()
+
+/datum/suit
+	var/name = "suit"
+	var/list/to_spawn = list()
+	var/amount = 0
+
+/datum/suit/custom
+	name = "custom"
 
 /obj/machinery/suit_dispenser
 	name = "Suit Dispenser"
@@ -11,111 +24,157 @@ var/list/dispenser_presets = list()
 	icon_state = "suitdispenser"
 	anchored = 1
 	density = 1
+	var/list/suits = list() // put your suit datums here!
+	var/datum/suit/one_suit
+	var/global/list/suit_distributed_to = list()
+	var/dispenser_flags = SD_NOGREED|SD_UNLIMITED
+	machine_flags = EMAGGABLE
+
+/obj/machinery/suit_dispenser/New()
+	if(!suit_distributed_to["[type]"] && (dispenser_flags & SD_NOGREED))
+		suit_distributed_to["[type]"] = list()
+	var/list/real_suits_list = list()
+	for(var/suit in suits)
+		var/datum/suit/S = new suit
+		real_suits_list[S.name] = S
+	if(one_suit)
+		one_suit = new one_suit
+	suits = real_suits_list
+	..()
+
+/obj/machinery/suit_dispenser/attack_hand(var/mob/living/carbon/human/user)
+	if(!can_use(user))
+		return
+	dispenser_flags |= SD_BUSY
+	if(!(dispenser_flags & SD_ONESUIT))
+		var/suit_list = get_suit_list(user)
+		suit_list["CANCEL"] = "CANCEL"
+		var/choice = input("Choose your suit specialisation.", "Suit Dispenser") in suit_list
+		if(choice == "CANCEL")
+			return
+		dispense(suit_list[choice],user)
+	else
+		dispense(one_suit,user)
 
 
+/obj/machinery/suit_dispenser/proc/can_use(var/mob/living/carbon/human/user)
+	var/list/used_by = suit_distributed_to["[type]"]
+	if(!istype(user))
+		to_chat(user,"<span class='warning'>You can't use this!</span>")
+		return 0
+	if((dispenser_flags & SD_BUSY))
+		to_chat(user,"<span class='warning'>Someone else is using this!</span>")
+		return 0
+	if((dispenser_flags & SD_ONESUIT) && !one_suit.amount)
+		to_chat(user,"<span class='warning'>There's nothing in here!</span>")
+		return 0
+	if ((dispenser_flags & SD_NOGREED) && (user in used_by) && !emagged)
+		to_chat(user,"<span class='warning'>You've already picked up your suit!</span>")
+		playsound(get_turf(src), 'sound/machines/buzz-sigh.ogg', 50, 0)
+		return 0
+	else if(emagged)
+		say("!'^&YouVE alreaDY pIC&$!Ked UP yOU%r Su^!it.")
+		playsound(get_turf(src), 'sound/machines/buzz-sigh.ogg', 100, 0)
+		return 1
+	return 1
+
+/obj/machinery/suit_dispenser/proc/get_suit_list(var/mob/living/carbon/human/user)
+	return suits
+
+/obj/machinery/suit_dispenser/proc/dispense(var/datum/suit/S,var/mob/living/carbon/human/user,var/greet=TRUE)
+	if(!S.amount && !(dispenser_flags & SD_UNLIMITED))
+		to_chat(user,"<span class='warning'>There are no more [S.name] suits left!</span>")
+		dispenser_flags &= ~SD_BUSY
+		return 1
+	else if(!(dispenser_flags & SD_UNLIMITED))
+		S.amount--
+	if((dispenser_flags & SD_NOGREED) && !emagged)
+		suit_distributed_to["[type]"] |= user
+	flick("suitdispenser-flick",src)
+	dispenser_flags |= SD_BUSY
+	sleep(17)
+	dispenser_flags &= ~SD_BUSY
+
+	var/turf/T = get_turf(src)
+	if(!(S && T)) // in case we got destroyed while we slept
+		return 1
+	for(var/O in S.to_spawn)
+		new O(T)
+	if(emagged)
+		emagged = FALSE
+	if(greet && user && !user.stat) // in case we got destroyed while we slept
+		to_chat(user,"<span class='notice'>[S.name] specialisation processed. Have a good day.</span>")
+
+
+/obj/machinery/suit_dispenser/emag(var/mob/user)
+	if(!emagged)
+		emagged = TRUE
+		if(user)
+			user.visible_message("<span class='warning'>\The [user] slides a weird looking ID into \the [src], and sparks come flying out!</span>","<span class='warning'>You temporarily short the safety mechanisms.</span>")
+		playsound(get_turf(src), pick(spark_sound), 75, 1)
+		spark(src,4)
+
+/obj/machinery/suit_dispenser/proc/promptfornum(var/mob/user)
+	var/num = input(user,"How many supplies would you like to add? (Set to -1 for infinite)","Suit Dispenser", null) as num|null
+	if(num == -1)
+		dispenser_flags |= SD_UNLIMITED
+	else return num
+
+////////////////////////////// ERT SUIT DISPENSERS ///////////////////////////
+
+
+/datum/suit/ert/security
+	name = "Security"
+	to_spawn = list(/obj/item/clothing/suit/space/ert/security,/obj/item/clothing/head/helmet/space/ert/security)
+
+/datum/suit/ert/medical
+	name = "Medical"
+	to_spawn = list(/obj/item/clothing/suit/space/ert/medical,/obj/item/clothing/head/helmet/space/ert/medical)
+
+/datum/suit/ert/engineer
+	name = "Engineering"
+	to_spawn = list(/obj/item/clothing/suit/space/ert/engineer,/obj/item/clothing/head/helmet/space/ert/engineer)
+
+/datum/suit/ert/commander
+	name = "Commander"
+	to_spawn = list(/obj/item/clothing/suit/space/ert/commander,/obj/item/clothing/head/helmet/space/ert/commander)
 
 /obj/machinery/suit_dispenser/ert
 	desc = "An industrial U-Tak-It Dispenser unit designed to fetch all kinds of space suits. This one distribributes Emergency Responder space suits."
+	suits = list(/datum/suit/ert/security,/datum/suit/ert/medical,/datum/suit/ert/engineer)
 
-/obj/machinery/suit_dispenser/ert/attack_hand(var/mob/user)
+/obj/machinery/suit_dispenser/ert/can_use(var/mob/living/carbon/human/user)
+	if(!..())
+		return
 	if(sentStrikeTeams(TEAM_ERT))
-		var/datum/striketeam/ert/team = sent_strike_teams[TEAM_ERT]
-		if (user in response_team_members)
-			if (user in distributed_ert_suits)
-				to_chat(user,"<span class='warning'>You've already picked up your suit.</span>")
-			else
-				if (user.key == team.leader_key)
-					to_chat(user,"<span class='notice'>Identified as [user.real_name]. Here is your suit commander. Have a good day.</span>")
-
-					flick("suitdispenser-flick",src)
-
-					sleep(17)
-
-					if (user in distributed_ert_suits)
-						return
-
-					distributed_ert_suits |= user
-
-					var/turf/T = get_turf(src)
-
-					new /obj/item/clothing/suit/space/ert/commander(T)
-					new /obj/item/clothing/head/helmet/space/ert/commander(T)
-
-				else
-					to_chat(user,"<span class='notice'>Identified as [user.real_name]. Please choose your suit specialization.")
-
-					var/list/suit_list = list(
-						"Security",
-						"Medical",
-						"Engineer",
-						"CANCEL"
-						)
-
-					var/choice = input("Choose your suit specialization.", "Suit Dispenser") in suit_list
-
-					if(choice == "CANCEL")
-						return
-
-					flick("suitdispenser-flick",src)
-
-					sleep(17)
-
-					if (user in distributed_ert_suits)
-						return
-
-					distributed_ert_suits |= user
-
-					var/turf/T = get_turf(src)
-
-					switch(choice)
-						if("Security")
-							new /obj/item/clothing/suit/space/ert/security(T)
-							new /obj/item/clothing/head/helmet/space/ert/security(T)
-							to_chat(user,"<span class='notice'>Security specialization processed. Have a good day.</span>")
-						if("Medical")
-							new /obj/item/clothing/suit/space/ert/medical(T)
-							new /obj/item/clothing/head/helmet/space/ert/medical(T)
-							to_chat(user,"<span class='notice'>Medical specialization processed. Have a good day.</span>")
-						if("Engineer")
-							new /obj/item/clothing/suit/space/ert/engineer(T)
-							new /obj/item/clothing/head/helmet/space/ert/engineer(T)
-							to_chat(user,"<span class='notice'>Engineer specialization processed. Have a good day.</span>")
-
+		if(user in response_team_members)
+			return 1
 		else
 			to_chat(user,"<span class='warning'>Access Denied. You aren't part of the Emergency Response Team.</span>")
 	else
 		to_chat(user,"<span class='warning'>Access Denied. No Emergency Response Team has been dispatched yet.</span>")
 
+/obj/machinery/suit_dispenser/ert/attack_hand(var/mob/living/carbon/human/user)
+	var/list/used_by = suit_distributed_to["[type]"]
+	var/datum/striketeam/ert/team = sent_strike_teams[TEAM_ERT]
+	if (user.key == team.leader_key && !(user in used_by))
+		if(!can_use(user))
+			return
+		to_chat(user,"<span class='notice'>Identified as [user.real_name]. Have a good day, Commander!</span>")
+		dispense(new /datum/suit/ert/commander,user,greet=FALSE)
+	else ..()
 
 /obj/machinery/suit_dispenser/striketeam
 	icon_state = "suitdispenser-empty"
-	var/preset = null
-	var/used = 0
+	dispenser_flags = SD_ONESUIT
 
-/obj/machinery/suit_dispenser/striketeam/attack_hand(var/mob/user)
-	if(!preset)
+/obj/machinery/suit_dispenser/striketeam/can_use(var/mob/living/carbon/human/user)
+	if(!..())
+		return
+	if(!one_suit)
 		to_chat(user,"<span class='warning'>Error. No presets have been set.</span>")
 		return
-
-	if(used)
-		to_chat(user,"<span class='warning'>This dispenser must be reloaded by authorities in charge before you can use it again.</span>")
-		return
-
-	used = 1
-
-	var/list/items_to_spawn = dispenser_presets[preset]
-
-	icon_state = "suitdispenser-open"
-	flick("suitdispenser-once",src)
-
-	sleep(17)
-
-	var/turf/T = get_turf(src)
-
-	for(var/i = 1 to items_to_spawn.len)
-		var/spawntype = items_to_spawn[i]
-		new spawntype(T)
-
+	return 1
 
 /obj/machinery/suit_dispenser/striketeam/attack_ghost(var/mob/user)
 	if(isAdminGhost(user))
@@ -124,7 +183,7 @@ var/list/dispenser_presets = list()
 			"Choose a Preset",
 			)
 
-		if (used)
+		if (one_suit && !one_suit.amount)
 			choices |= "Resupply"
 
 		choices |= "CANCEL"
@@ -135,27 +194,116 @@ var/list/dispenser_presets = list()
 			if("CANCEL")
 				return
 			if("Define Preset from items on top")
-				var/list/items_on_top = list()
+				var/datum/suit/custom/preset = new
 				for (var/obj/item/I in get_turf(src))
-					items_on_top += I.type
-				if (items_on_top.len <= 0)
+					preset.to_spawn += I.type
+				if (!preset.to_spawn.len)
 					to_chat(user,"<span class='warning'>Error. No items on top of the dispenser. Place items on top of the dispenser to define them as presets.</span>")
 					return
 				else
-					var/preset_name = input(user,"[items_on_top.len] items found. Name your Preset","Suit Dispenser", null) as text|null
+					var/preset_name = input(user,"[preset.to_spawn.len] items found. Name your Preset","Suit Dispenser", null) as text|null
 					if (!preset_name)
+						qdel(preset)
 						return
-					dispenser_presets[preset_name] = items_on_top
-			if("Choose a Preset")
-				if (dispenser_presets.len <= 0)
-					to_chat(user,"<span class='warning'>Error. No presets have been set. Place items on top of the dispenser to define them as presets.</span>")
-					return
-				var/no_preset = !preset
-				preset = input(user,"Choose a Preset.", "Suit Dispenser") in dispenser_presets
-				if (preset && no_preset)
+					preset.name = preset_name
+					dispenser_presets[preset_name] = preset
+					one_suit = preset
 					icon_state = "suitdispenser"
 					flick("suitdispenser-fill",src)
+					one_suit.amount = promptfornum(user)
+
+			if("Choose a Preset")
+				if (!dispenser_presets.len)
+					to_chat(user,"<span class='warning'>Error. No presets have been set. Place items on top of the dispenser to define them as presets.</span>")
+					return
+				var/datum/suit/custom/preset = input(user,"Choose a Preset.", "Suit Dispenser") in dispenser_presets
+				if (preset && !one_suit)
+					icon_state = "suitdispenser"
+					flick("suitdispenser-fill",src)
+				one_suit = new /datum/suit/custom
+				one_suit.name = preset.name
+				one_suit.to_spawn = preset.to_spawn
+				one_suit.amount = promptfornum(user)
+
+
 			if("Resupply")
-				used = 0
+				one_suit.amount = promptfornum(user)
 				icon_state = "suitdispenser"
 				flick("suitdispenser-resupply",src)
+
+
+////////////////// DORF FORT DISPENSER //////////////////
+// do NOT spawn this on the main map or I will SCREAM //
+
+/datum/suit/dorf/standard
+	name = "Standard"
+	to_spawn = list(/obj/item/clothing/head/helmet/space,/obj/item/clothing/suit/space)
+
+/datum/suit/dorf/security
+	name = "Security"
+	to_spawn = list(/obj/item/clothing/head/helmet/space/rig/security,/obj/item/clothing/suit/space/rig/security)
+
+/datum/suit/dorf/engineering
+	name = "Engineering"
+	to_spawn = list(/obj/item/clothing/head/helmet/space/rig,/obj/item/clothing/suit/space/rig)
+
+/datum/suit/dorf/medical
+	name = "Medical"
+	to_spawn = list(/obj/item/clothing/head/helmet/space/rig/medical,/obj/item/clothing/suit/space/rig/medical)
+
+/datum/suit/dorf/atmos
+	name = "Atmospherics Technician"
+	to_spawn = list(/obj/item/clothing/head/helmet/space/rig/atmos,/obj/item/clothing/suit/space/rig/atmos)
+
+/datum/suit/dorf/paramedic
+	name = "Paramedic"
+	to_spawn = list(/obj/item/clothing/head/helmet/space/paramedic,/obj/item/clothing/suit/space/paramedic)
+
+/datum/suit/dorf/mining
+	name = "Mining"
+	to_spawn = list(/obj/item/clothing/suit/space/rig/mining, /obj/item/clothing/head/helmet/space/rig/mining)
+
+/*/datum/suit/dorf/head
+	amount = 1
+
+/datum/suit/dorf/head/captain
+	name = "Captain"
+	to_spawn = (/obj/item/clothing/suit/armor/captain,/obj/item/clothing/head/helmet/space/capspace)
+
+/datum/suit/dorf/head/chiefengie
+	name = "Chief Engineer"
+	to_spawn = (/obj/item/clothing/suit/space/rig/elite,/obj/item/clothing/head/helmet/space/rig/elite,/obj/item/clothing/shoes/magboots/elite)*/
+
+
+/obj/machinery/suit_dispenser/dorf
+	desc = "An industrial U-Tak-It Dispenser unit designed to fetch all kinds of space suits. This one is specialised towards asteroid reclamation teams."
+	suits = list(/datum/suit/dorf/standard,/datum/suit/dorf/security,/datum/suit/dorf/engineering,/datum/suit/dorf/medical,/datum/suit/dorf/atmos,/datum/suit/dorf/paramedic)
+
+/obj/machinery/suit_dispenser/dorf/get_suit_list(var/mob/living/carbon/human/user)
+	if(emagged)
+		return suits
+	var/list/suit_list = list()
+	suit_list["Standard"] = suits["Standard"]
+	var/obj/item/weapon/card/id/card = user.get_id_card()
+	if(!card)
+		return suit_list
+	for(var/job in card.access)
+		switch(job)
+			if(access_brig)
+				suit_list["Security"] = suits["Security"]
+			if(access_medical)
+				suit_list["Medical"] = suits["Medical"]
+			if(access_mining)
+				suit_list["Mining"] = suits["Mining"]
+			if(access_paramedic)
+				suit_list["Paramedic"] = suits["Paramedic"]
+			if(access_atmospherics)
+				suit_list["Atmospherics Technician"] = suits["Atmospherics Technician"]
+			if(access_engine)
+				suit_list["Engineering"] = suits["Engineering"]
+	return suit_list
+
+/obj/machinery/suit_dispenser/standard
+	desc = "An industrial U-Tak-It Dispenser unit designed to fetch a specific mass produced suit."
+	dispenser_flags = SD_ONESUIT|SD_NOGREED|SD_UNLIMITED
+	one_suit = /datum/suit/dorf/standard

--- a/code/game/striketeams/emergency_response_team.dm
+++ b/code/game/striketeams/emergency_response_team.dm
@@ -1,7 +1,6 @@
 //ERT
 
 var/list/response_team_members = list()
-var/list/distributed_ert_suits = list()
 
 /datum/striketeam/ert
 	striketeam_name = TEAM_ERT


### PR DESCRIPTION
- Refactors suit dispenser code to be super duper modular.
- Adds two new suit dispensers; "dorf" mode; which reads your ID and offers you suits your ID permits,
"standard", which gets you a standard shitty space suit.
- You can only get one suit out of these.
- Upgrades the custom suit dispenser to carry multiple of the same suit selection if the admin so chooses
- Emagging the suit dispenser has some neato effects (more than one suit + suits not ID specific on the dorf.)
- Also lots of potential for expandability

<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl:
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
