### PR TITLE
small hotfixes

### DIFF
--- a/__DEFINES/planes+layers.dm
+++ b/__DEFINES/planes+layers.dm
@@ -204,7 +204,7 @@ What is the naming convention for planes or layers?
 	#define SUPER_PORTAL_LAYER		6
 	#define NARSIE_GLOW 			7
 
-#define AREA_PLANE				20
+#define ABOVE_LIGHTING_PLANE		20
 	#define MAPPING_AREA_LAYER	999
 
 #define STATIC_PLANE 			21		// For AI's static.

--- a/code/_onclick/hud/parallax.dm
+++ b/code/_onclick/hud/parallax.dm
@@ -28,6 +28,7 @@ var/list/parallax_icon[(GRID_WIDTH**2)*3]
 	appearance_flags = PLANE_MASTER
 	screen_loc = "CENTER,CENTER"
 	globalscreen = 1
+	mouse_opacity = 0
 
 /obj/abstract/screen/plane_master/parallax_master
 	plane = SPACE_PARALLAX_PLANE

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -11,7 +11,7 @@ var/area/space_area
 	var/list/area_turfs
 	var/turret_protected = 0
 	var/list/turretTargets = list()
-	plane = AREA_PLANE
+	plane = ABOVE_LIGHTING_PLANE
 	layer = MAPPING_AREA_LAYER
 	var/base_turf_type = null
 	var/shuttle_can_crush = TRUE

--- a/code/game/gamemodes/blob/overmind.dm
+++ b/code/game/gamemodes/blob/overmind.dm
@@ -11,7 +11,7 @@
 	pass_flags = PASSBLOB
 	faction = "blob"
 
-	plane = BASE_PLANE
+	plane = ABOVE_LIGHTING_PLANE
 
 	var/obj/effect/blob/core/blob_core = null // The blob overmind's core
 	var/blob_points = 0

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -453,7 +453,7 @@ var/list/department_radio_keys = list(
 			display_bubble_to_clientlist(image('icons/mob/talk.dmi', get_holder_at_turf_level(src), "h[bubble_type][say_test(message)]",MOB_LAYER+1), tracking_speech_bubble_recipients)
 
 /proc/display_bubble_to_clientlist(var/image/speech_bubble, var/clientlist)
-	speech_bubble.plane = BASE_PLANE
+	speech_bubble.plane = ABOVE_LIGHTING_PLANE
 	speech_bubble.appearance_flags = RESET_COLOR
 	flick_overlay(speech_bubble, clientlist, 30)
 


### PR DESCRIPTION
icon for voice bubble pops up above everything else due to plane being wrong
planesmasters now have mouse_opacity = 0. (fixes unreported bug where people could not alt click the tile they are on/use RPDs on the tile they're on)