### PR TITLE
 Fixes decoy balloons examine

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -239,7 +239,7 @@
 				msg += "[t_He] [t_has] a vacant, braindead stare...\n"
 
 	// Religions
-	if (user.mind && user.mind.faith && user.mind.faith.isReligiousLeader(user) && mind)
+	if (ismob(user) && user.mind && user.mind.faith && user.mind.faith.isReligiousLeader(user) && mind)
 		if (src.mind.faith == user.mind.faith)
 			msg += "<span class='notice'>You recognise [t_him] as a follower of [user.mind.faith.name].</span><br/>"
 


### PR DESCRIPTION
Fixes #17400

:cl:
 * bugfix: Fixes decoy balloons examine text not appearing
