### PR TITLE
Fixes cells inside the crank charger not updating their icon

### DIFF
--- a/code/game/machinery/cell_charger.dm
+++ b/code/game/machinery/cell_charger.dm
@@ -234,6 +234,7 @@
 			stored.charge += 100
 			state = !state
 			update_icon()
+			stored.updateicon()
 			playsound(get_turf(src), 'sound/items/crank.ogg',50,1)
 			if(stored.charge>stored.maxcharge)
 				stored.charge = stored.maxcharge


### PR DESCRIPTION
Fixes #17405

:cl:
 * rscadd: Crank cell chargers now update the cells icon