### PR TITLE
Fixes bots being able to open blast doors

### DIFF
--- a/code/game/machinery/bots/farmbot.dm
+++ b/code/game/machinery/bots/farmbot.dm
@@ -71,11 +71,9 @@
 	spawn(0)
 		if ((istype(M, /obj/machinery/door)) && (!isnull(src.botcard)))
 			var/obj/machinery/door/D = M
-			if (!istype(D, /obj/machinery/door/firedoor) && D.check_access(src.botcard))
+			if (!istype(D, /obj/machinery/door/firedoor) && !istype(D, /obj/machinery/door/poddoor) && D.check_access(src.botcard))
 				D.open()
 				src.frustration = 0
-		return
-	return
 
 /obj/machinery/bot/farmbot/turn_on()
 	. = ..()


### PR DESCRIPTION
Fixes #17349 
no but seriously why wasn't this fixed the day of the issue report

:cl:
 * bugfix: Fixed bots being able to open blast doors