### PR TITLE
Automatic shuttlecalls fix

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -626,15 +626,15 @@ var/shuttle_call/shuttle_calls[0]
 /obj/machinery/computer/communications/Destroy()
 
 	for(var/obj/machinery/computer/communications/commconsole in machines)
-		if(istype(commconsole.loc,/turf) && commconsole != src)
+		if(istype(commconsole.loc,/turf) && commconsole != src && commconsole.z != map.zCentcomm)
 			return ..()
 
 	for(var/obj/item/weapon/circuitboard/communications/commboard in world)
-		if(istype(commboard.loc,/turf) || istype(commboard.loc,/obj/item/weapon/storage))
+		if((istype(commboard.loc,/turf) || istype(commboard.loc,/obj/item/weapon/storage)) && commboard.z != map.zCentcomm)
 			return ..()
 
 	for(var/mob/living/silicon/ai/shuttlecaller in player_list)
-		if(!shuttlecaller.stat && shuttlecaller.client && istype(shuttlecaller.loc,/turf))
+		if(!shuttlecaller.stat && shuttlecaller.client && istype(shuttlecaller.loc,/turf) && shuttlecaller.z != map.zCentcomm)
 			return ..()
 
 	if(ticker.mode.name == "revolution" || ticker.mode.name == "AI malfunction")
@@ -651,15 +651,15 @@ var/shuttle_call/shuttle_calls[0]
 /obj/item/weapon/circuitboard/communications/Destroy()
 
 	for(var/obj/machinery/computer/communications/commconsole in machines)
-		if(istype(commconsole.loc,/turf))
+		if(istype(commconsole.loc,/turf) && commconsole.z != map.zCentcomm)
 			return ..()
 
 	for(var/obj/item/weapon/circuitboard/communications/commboard in world)
-		if((istype(commboard.loc,/turf) || istype(commboard.loc,/obj/item/weapon/storage)) && commboard != src)
+		if((istype(commboard.loc,/turf) || istype(commboard.loc,/obj/item/weapon/storage)) && commboard != src && commboard.z != map.zCentcomm)
 			return ..()
 
 	for(var/mob/living/silicon/ai/shuttlecaller in player_list)
-		if(!shuttlecaller.stat && shuttlecaller.client && istype(shuttlecaller.loc,/turf))
+		if(!shuttlecaller.stat && shuttlecaller.client && istype(shuttlecaller.loc,/turf) && shuttlecaller.z != map.zCentcomm)
 			return ..()
 
 	if(ticker.mode.name == "revolution" || ticker.mode.name == "AI malfunction")


### PR DESCRIPTION
Makes comms console and commboard Destroy() more consistent with
https://github.com/vgstation-coders/vgstation13/blob/8d561d8fb8b126c93d204b1ca22c48826592d820/code/modules/mob/living/silicon/ai/death.dm#L17-L48
As in it won't count shuttle callers on the Centcomm z level. This does represent a gameplay change: anyone will be able to call the emergency shuttle if they can destroy all the comms consoles, boards and living AIs. (And it's not revs or malf.)

:cl:
* bugfix: Automatic shuttle calling no longer counts calling devices at Centcomm.