### PR TITLE
Makes disposals check for fat guys more

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -614,7 +614,7 @@
 				H.take_overall_damage(20, 0, "Blunt Trauma")//horribly maim any living creature jumping down disposals.  c'est la vie
 				*/
 
-		if(prob(2) // chance of becoming stuck per segment if contains a fat guy
+		if(prob(2)) // chance of becoming stuck per segment if contains a fat guy
 			if(has_fat_guy())
 				active = 0
 			// find the fat guys

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -614,12 +614,13 @@
 				H.take_overall_damage(20, 0, "Blunt Trauma")//horribly maim any living creature jumping down disposals.  c'est la vie
 				*/
 
-		if(prob(2) && has_fat_guy()) // chance of becoming stuck per segment if contains a fat guy
-			active = 0
+		if(prob(2) // chance of becoming stuck per segment if contains a fat guy
+			if(has_fat_guy())
+				active = 0
 			// find the fat guys
-			for(var/mob/living/carbon/human/H in src)
+				for(var/mob/living/carbon/human/H in src)
 
-			break
+				break
 		sleep(1)		// was 1
 		if(!loc || isnull(loc))
 			qdel(src)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -550,11 +550,14 @@
 	var/active = 0	// true if the holder is moving, otherwise inactive
 	dir = 0
 	var/count = 1000	//*** can travel 1000 steps before going inactive (in case of loops)
-	var/has_fat_guy = 0	// true if contains a fat person
 	var/destinationTag = "DISPOSALS"// changes if contains a delivery container
 	var/tomail = 0 //changes if contains wrapped package
 	var/hasmob = 0 //If it contains a mob
 
+/obj/structure/disposalholder/proc/has_fat_guy()
+	for(var/mob/living/carbon/human/H in src)
+		if(((M_FAT in H.mutations) && (H.species && H.species.anatomy_flags & CAN_BE_FAT)) || H.species.anatomy_flags & IS_BULKY)
+			return TRUE
 
 	// initialize a holder from the contents of a disposal unit
 /obj/structure/disposalholder/proc/init(var/obj/machinery/disposal/D)
@@ -578,10 +581,6 @@
 	// note AM since can contain mobs or objs
 	for(var/atom/movable/AM in D)
 		AM.forceMove(src)
-		if(istype(AM, /mob/living/carbon/human))
-			var/mob/living/carbon/human/H = AM
-			if(((M_FAT in H.mutations) && (H.species && H.species.anatomy_flags & CAN_BE_FAT)) || H.species.anatomy_flags & IS_BULKY)		// is a human and fat?
-				has_fat_guy = 1			// set flag on holder
 		if(istype(AM, /obj/item/delivery/large) && !hasmob)
 			var/obj/item/delivery/large/T = AM
 			src.destinationTag = T.sortTag
@@ -615,7 +614,7 @@
 				H.take_overall_damage(20, 0, "Blunt Trauma")//horribly maim any living creature jumping down disposals.  c'est la vie
 				*/
 
-		if(has_fat_guy && prob(2)) // chance of becoming stuck per segment if contains a fat guy
+		if(prob(2) && has_fat_guy()) // chance of becoming stuck per segment if contains a fat guy
 			active = 0
 			// find the fat guys
 			for(var/mob/living/carbon/human/H in src)
@@ -663,8 +662,6 @@
 			if(M.client)	// if a client mob, update eye to follow this holder
 				M.client.eye = src
 
-	if(other.has_fat_guy)
-		has_fat_guy = 1
 	qdel(other)
 
 


### PR DESCRIPTION
Closes #17425

So, okay. This doesn't exactly unstick you. But it does get rid of "phantom fatness" from becoming fit in the time after being flushed. Hope I did this right. I don't know what that for statement does on line 620 though, is that a mistake or leftover code?
:cl:
* bugfix: Changed how disposals pipes check for fat people, so that you will stop being considered fat in the event you lose weight in transit. (Although if you're already stuck, this won't unstick you without another package to push you through.)