### PR TITLE
No tracking footprints while on a vehicle

### DIFF
--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -30,8 +30,8 @@
 
 	if (istype(A,/mob/living/carbon))
 		var/mob/living/carbon/M = A
-		if(M.lying)
-			return
+		if(!M.on_foot())
+			return ..()
 		if(istype(M, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = M
 
@@ -68,14 +68,6 @@
 						if (H.Slip(4, 5))
 							step(H, H.dir)
 							to_chat(H, "<span class='notice'>You tripped over your hair!</span>")
-
-		//Anything beyond that point will not fire if the mob isn't physically walking here
-		if(!M.on_foot()) //Checks lying, flying and locked.to
-			return ..()
-
-		//And anything beyond that point will not fire for slimes
-		if(isslime(M)) //Slimes just don't slip, end of story
-			return ..()
 	..()
 
 //returns 1 if made bloody, returns 0 otherwise


### PR DESCRIPTION
Closes #17431
I'm pretty sure there's vehicle tracks objects in the code but they seem to be nonfunctional currently. Instead of messing with that I'm doing this, just so you don't get blood and vomit on your shoes while on a vehicle. Maybe I'll update this as I figure it out though.
:cl:
* bugfix: You no longer track footprints while riding a vehicle.