### PR TITLE
Windoor fixes

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -207,6 +207,7 @@
 		if (health <= 0)
 			getFromPool(shard, loc)
 			getFromPool(/obj/item/stack/cable_coil, loc, 2)
+			eject_electronics()
 			qdel(src)
 	else
 		return attack_hand(user)
@@ -226,6 +227,7 @@
 	if (health <= 0)
 		getFromPool(shard, loc)
 		getFromPool(/obj/item/stack/cable_coil, loc, 2)
+		eject_electronics()
 		qdel(src)
 
 
@@ -283,6 +285,7 @@
 		if (health <= 0)
 			getFromPool(shard, loc)
 			getFromPool(/obj/item/stack/cable_coil, loc, 2)
+			eject_electronics()
 			qdel(src)
 		return
 

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -201,9 +201,9 @@
 			return
 		user.delayNextAttack(8)
 		user.do_attack_animation(src, user)
-		take_damage(25)
 		playsound(get_turf(src), 'sound/effects/Glasshit.ogg', 75, 1)
 		visible_message("<span class='warning'>\The [user] smashes against \the [name].</span>", 1)
+		take_damage(25)
 	else
 		return attack_hand(user)
 
@@ -215,9 +215,9 @@
 		return
 	user.do_attack_animation(src, user)
 	user.delayNextAttack(8)
-	take_damage(M.melee_damage_upper)
 	playsound(get_turf(src), 'sound/effects/Glasshit.ogg', 75, 1)
 	visible_message("<span class='warning'>\The [M] [M.attacktext] against \the [name].</span>", 1)
+	take_damage(M.melee_damage_upper)
 
 /obj/machinery/door/window/attack_hand(mob/user as mob)
 	return attackby(user, user)
@@ -266,10 +266,10 @@
 		var/aforce = I.force
 		user.do_attack_animation(src, I)
 		user.delayNextAttack(8)
-		if(I.damtype == BRUTE || I.damtype == BURN)
-			take_damage(aforce)
 		playsound(get_turf(src), 'sound/effects/Glasshit.ogg', 75, 1)
 		visible_message("<span class='danger'>[src] was hit by [I].</span>")
+		if(I.damtype == BRUTE || I.damtype == BURN)
+			take_damage(aforce)
 		return
 
 	add_fingerprint(user)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -201,17 +201,11 @@
 			return
 		user.delayNextAttack(8)
 		user.do_attack_animation(src, user)
-		health = max(0, health - 25)
+		take_damage(25)
 		playsound(get_turf(src), 'sound/effects/Glasshit.ogg', 75, 1)
 		visible_message("<span class='warning'>\The [user] smashes against \the [name].</span>", 1)
-		if (health <= 0)
-			getFromPool(shard, loc)
-			getFromPool(/obj/item/stack/cable_coil, loc, 2)
-			eject_electronics()
-			qdel(src)
 	else
 		return attack_hand(user)
-
 
 /obj/machinery/door/window/attack_animal(mob/living/user as mob)
 	if(operating)
@@ -221,15 +215,9 @@
 		return
 	user.do_attack_animation(src, user)
 	user.delayNextAttack(8)
-	health = max(0, health - M.melee_damage_upper)
+	take_damage(M.melee_damage_upper)
 	playsound(get_turf(src), 'sound/effects/Glasshit.ogg', 75, 1)
 	visible_message("<span class='warning'>\The [M] [M.attacktext] against \the [name].</span>", 1)
-	if (health <= 0)
-		getFromPool(shard, loc)
-		getFromPool(/obj/item/stack/cable_coil, loc, 2)
-		eject_electronics()
-		qdel(src)
-
 
 /obj/machinery/door/window/attack_hand(mob/user as mob)
 	return attackby(user, user)
@@ -279,14 +267,9 @@
 		user.do_attack_animation(src, I)
 		user.delayNextAttack(8)
 		if(I.damtype == BRUTE || I.damtype == BURN)
-			health = max(0, health - aforce)
+			take_damage(aforce)
 		playsound(get_turf(src), 'sound/effects/Glasshit.ogg', 75, 1)
 		visible_message("<span class='danger'>[src] was hit by [I].</span>")
-		if (health <= 0)
-			getFromPool(shard, loc)
-			getFromPool(/obj/item/stack/cable_coil, loc, 2)
-			eject_electronics()
-			qdel(src)
 		return
 
 	add_fingerprint(user)

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -146,13 +146,16 @@ obj/structure/windoor_assembly/Destroy()
 
 			//Adding cable to the assembly. Step 5 complete.
 			else if(istype(W, /obj/item/stack/cable_coil) && anchored)
+				var/obj/item/stack/cable_coil/CC = W
+				if(CC.amount < 2)
+					to_chat(user, "<span class='rose'>You need more cable for this!</span>")
+					return
 				user.visible_message("[user] wires the windoor assembly.", "You start to wire the windoor assembly.")
 
 				if(do_after(user, src, 40))
 					if(!src)
 						return
-					var/obj/item/stack/cable_coil/CC = W
-					CC.use(1)
+					CC.use(2)
 					to_chat(user, "<span class='notice'>You wire the windoor!</span>")
 					src.state = "02"
 					if(src.secure)
@@ -239,10 +242,15 @@ obj/structure/windoor_assembly/Destroy()
 						windoor.icon_state = "right[secure]open"
 						windoor.base_state = "right[secure]"
 					windoor.dir = src.dir
-					windoor.setDensity(FALSE) 
-					
-					windoor.req_access = src.electronics.conf_access
-					windoor.electronics = src.electronics
+					windoor.setDensity(FALSE)
+					windoor.fingerprints += src.fingerprints
+					windoor.fingerprintshidden += src.fingerprintshidden
+					windoor.fingerprintslast = user.ckey
+					if(src.electronics.one_access)
+						windoor.req_access = null
+						windoor.req_one_access = src.electronics.conf_access
+					else
+						windoor.req_access = src.electronics.conf_access
 					src.electronics.forceMove(windoor)
 					qdel(src)
 


### PR DESCRIPTION
Closes #17368
:cl:
* bugfix: Windoors that are destroyed will now drop their airlock electronics when destroyed by melee attacks too instead of just when destroyed by projectiles.
* tweak: Windoors now take 2 cables to make to match how many they drop, up from 1.
* bugfix: Newly constructed windoors are now compatible with the "one access" setting on airlock electronics.
* bugfix: Newly constructed windoors should now inherit fingerprints from the assembly they're made from.