### PR TITLE
Spiderbot misc. fixes

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -305,7 +305,7 @@
 		speech.job = "Personal AI"
 
 	// --- Cold, emotionless machines. ---
-	else if(isobj(speech.speaker))
+	else if(isobj(speech.speaker) || istype(speech.speaker, /mob/living/simple_animal/spiderbot))
 		speech.job = "Machine"
 
 	// --- Unidentifiable mob ---

--- a/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
@@ -200,6 +200,23 @@
 	robogibs(src.loc, viruses)
 	qdel(src)
 
+/mob/living/simple_animal/spiderbot/emp_act(severity)
+	if(flags & INVULNERABLE)
+		return ..()
+
+	switch(severity)
+		if(1)
+			if(prob(5))
+				explode()
+				return
+			adjustBruteLoss(rand(4,5))
+		if(2)
+			adjustBruteLoss(rand(2,3))
+	flash_eyes(visual = 1, type = /obj/abstract/screen/fullscreen/flash/noise)
+	to_chat(src, "<span class='danger'>*BZZZT*</span>")
+	to_chat(src, "<span class='warning'>Warning: Electromagnetic pulse detected.</span>")
+	..()
+
 //copy paste from alien/larva, if that func is updated please update this one also
 /mob/living/simple_animal/spiderbot/verb/ventcrawl()
 	set name = "Crawl through Vent"
@@ -245,7 +262,7 @@
 		var/lob_dir = dir
 		var/turf/start_turf = get_turf(src)
 		var/current_turf = start_turf
-		for(var/i = 1; i <= lob_range; i++)
+		for(var/i in 1 to lob_range)
 			current_turf = get_step(current_turf, lob_dir)
 		lob_target = current_turf
 
@@ -322,4 +339,4 @@
 		to_chat(src, "Can't do that while incapacitated or dead.")
 
 	radio.listening = !radio.listening
-	to_chat(src, "<span class='notice'>Radio is [radio.listening ? "" : "no longer"] receiving broadcasts.</span>")
+	to_chat(src, "<span class='notice'>Radio is [radio.listening ? "" : " no longer "]receiving broadcasts.</span>")

--- a/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
@@ -246,7 +246,7 @@
 	set category = "Spiderbot"
 	set desc = "Drop the item you're holding."
 
-	if(stat)
+	if(incapacitated())
 		return
 
 	if(!held_item)
@@ -286,7 +286,7 @@
 	set category = "Spiderbot"
 	set desc = "Allows you to take a nearby small item."
 
-	if(stat)
+	if(incapacitated())
 		return -1
 
 	if(held_item)
@@ -335,7 +335,7 @@
 	set desc = "Toggle listening channel on or off."
 	set category = "Spiderbot"
 
-	if(stat)
+	if(incapacitated())
 		to_chat(src, "Can't do that while incapacitated or dead.")
 
 	radio.listening = !radio.listening

--- a/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
@@ -337,6 +337,7 @@
 
 	if(incapacitated())
 		to_chat(src, "Can't do that while incapacitated or dead.")
+		return
 
 	radio.listening = !radio.listening
 	to_chat(src, "<span class='notice'>Radio is [radio.listening ? "" : "no longer "]receiving broadcasts.</span>")

--- a/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
@@ -294,27 +294,9 @@
 /mob/living/simple_animal/spiderbot/say(var/message)
 	return ..(message, "R")
 
-/mob/living/simple_animal/spiderbot/radio(var/datum/speech/speech, var/message_mode)
-	. = ..()
-	if(. != 0)
-		return .
-	if(message_mode == "robot")
-		if(radio)
-			radio.talk_into(speech)
-		return REDUCE_RANGE
-
-	else if(message_mode in radiochannels)
-		if(radio)
-			radio.talk_into(speech, message_mode)
-			return ITALICS | REDUCE_RANGE
-	return 0
-
-/mob/living/simple_animal/spiderbot/get_message_mode(message)
-	. = ..()
-	if(..() == MODE_HEADSET)
-		return MODE_ROBOT
-	else
-		return .
+/mob/living/simple_animal/spiderbot/treat_speech(var/datum/speech/speech, genesay = 0)
+	..(speech)
+	speech.message_classes.Add("siliconsay")
 
 /mob/living/simple_animal/spiderbot/verb/Toggle_Listening()
 	set name = "Toggle Listening"

--- a/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
@@ -286,6 +286,9 @@
 	if(selection)
 		for(var/obj/item/I in view(1, src))
 			if(selection == I)
+				if(selection.anchored)
+					to_chat(src, "<span class='warning'>It's fastened down!</span>")
+					return 0
 				held_item = selection
 				selection.forceMove(src)
 				visible_message("<span class='notice'>[src] scoops up \the [held_item]!</span>", "<span class='notice'>You grab \the [held_item]!</span>", "You hear a skittering noise and a clink.")

--- a/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
@@ -20,9 +20,12 @@
 	icon_living = "spiderbot-chassis"
 	icon_dead = "spiderbot-smashed"
 	wander = 0
+	voice_name = "synthesized voice"
 
 	health = 10
 	maxHealth = 10
+
+	mob_property_flags = MOB_ROBOTIC
 
 	attacktext = "shocks"
 	melee_damage_lower = 1
@@ -287,3 +290,39 @@
 
 /mob/living/simple_animal/spiderbot/CheckSlip()
 	return -1
+
+/mob/living/simple_animal/spiderbot/say(var/message)
+	return ..(message, "R")
+
+/mob/living/simple_animal/spiderbot/radio(var/datum/speech/speech, var/message_mode)
+	. = ..()
+	if(. != 0)
+		return .
+	if(message_mode == "robot")
+		if(radio)
+			radio.talk_into(speech)
+		return REDUCE_RANGE
+
+	else if(message_mode in radiochannels)
+		if(radio)
+			radio.talk_into(speech, message_mode)
+			return ITALICS | REDUCE_RANGE
+	return 0
+
+/mob/living/simple_animal/spiderbot/get_message_mode(message)
+	. = ..()
+	if(..() == MODE_HEADSET)
+		return MODE_ROBOT
+	else
+		return .
+
+/mob/living/simple_animal/spiderbot/verb/Toggle_Listening()
+	set name = "Toggle Listening"
+	set desc = "Toggle listening channel on or off."
+	set category = "Spiderbot"
+
+	if(stat)
+		to_chat(src, "Can't do that while incapacitated or dead.")
+
+	radio.listening = !radio.listening
+	to_chat(src, "<span class='notice'>Radio is [radio.listening ? "" : "no longer"] receiving broadcasts.</span>")

--- a/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
@@ -36,6 +36,7 @@
 	response_harm   = "stomps on"
 
 	var/obj/item/held_item = null //Storage for single item they can hold.
+	var/lob_range = 3
 	var/emagged = 0               //IS WE EXPLODEN?
 	var/syndie = 0                //IS WE SYNDICAT? (currently unused)
 	speed = 1                    //Spiderbots gotta go fast.
@@ -238,8 +239,19 @@
 	if(istype(held_item, /obj/item/weapon/grenade))
 		visible_message("<span class='warning'>[src] launches \the [held_item]!</span>", "<span class='warning'>You launch \the [held_item]!</span>", "You hear a skittering noise and a thump!")
 		var/obj/item/weapon/grenade/G = held_item
-		G.forceMove(src.loc)
-		G.prime()
+
+		//Make a dumbfire throw
+		var/turf/lob_target
+		var/lob_dir = dir
+		var/turf/start_turf = get_turf(src)
+		var/current_turf = start_turf
+		for(var/i = 1; i <= lob_range; i++)
+			current_turf = get_step(current_turf, lob_dir)
+		lob_target = current_turf
+
+		throw_item(lob_target, G)
+
+		G.activate(src)
 		held_item = null
 		return 1
 

--- a/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
@@ -339,4 +339,4 @@
 		to_chat(src, "Can't do that while incapacitated or dead.")
 
 	radio.listening = !radio.listening
-	to_chat(src, "<span class='notice'>Radio is [radio.listening ? "" : " no longer "]receiving broadcasts.</span>")
+	to_chat(src, "<span class='notice'>Radio is [radio.listening ? "" : "no longer "]receiving broadcasts.</span>")


### PR DESCRIPTION
Closes #15778
~~By the power of copypaste I'm fulfilling anon's request from the thread. This enables spiderbots to use the radio they had inside of them all along.~~ (_Changed, see below._) ~~It only gets the common channel. Still trying to figure out how to make their speech appear in the silicon font.~~

~~I have concerns about letting ventcrawling tattletales run around all the time so I might make the borg radio have to be installed in them instead of spawning on creation, I don't know yet.~~

Edit: See https://github.com/vgstation-coders/vgstation13/pull/17446#issuecomment-365713469, I'm calling off giving them the ability to transmit since I think being able to radio from inside vents would be too strong.

:cl:
* rscadd: Spider-bot speech is in the "siliconsay" style, has the robotic speech bubble and tcomms shows them as "machine" instead of "unknown."
* rscadd: Spider-bots have a verb to turn their radio listening on and off.
* tweak: Spider-bots' ability to launch certain "fun" items works and launches properly.
* bugfix: Fixed spider-bots being able to pick up anchored objects.
* tweak: Spider-bots take damage from EMPs and have a small chance to explode.