### PR TITLE
 Projectile attack logs for player-controlled simple mobs 

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -299,6 +299,8 @@
 		ranged_cooldown = ranged_cooldown_cap
 		if(ranged_message)
 			visible_message("<span class='warning'><b>[src]</b> [ranged_message] at [target]!</span>", 1)
+		if(ckey)
+			add_attacklogs(src, target, "shot at")
 		if(casingtype)
 			new casingtype(get_turf(src),1)// empty casing
 

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -300,7 +300,7 @@
 		if(ranged_message)
 			visible_message("<span class='warning'><b>[src]</b> [ranged_message] at [target]!</span>", 1)
 		if(ckey)
-			add_attacklogs(src, target, "[ranged_message ? ranged_message :"shot"] at")
+			add_attacklogs(src, target, "[ranged_message ? ranged_message : "shot"] at")
 		if(casingtype)
 			new casingtype(get_turf(src),1)// empty casing
 

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -300,7 +300,7 @@
 		if(ranged_message)
 			visible_message("<span class='warning'><b>[src]</b> [ranged_message] at [target]!</span>", 1)
 		if(ckey)
-			add_attacklogs(src, target, "shot at")
+			add_attacklogs(src, target, "[ranged_message ? ranged_message :"shot"] at")
 		if(casingtype)
 			new casingtype(get_turf(src),1)// empty casing
 


### PR DESCRIPTION
Closes #17445
:cl:
* tweak: Projectile attacks made by player-controlled simple mobs are now logged.