### PR TITLE
[WIP] Flashbang tweak concept #2

### DIFF
--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -23,7 +23,7 @@
 		var/turf/T = get_turf(M)
 		var/D = round(cheap_pythag(T.x - x0, T.y - y0), 1)
 		if(D > 8)
-			if(eye_safety < 1)
+			if(M.eyecheck() < 1)
 				M.flash_eyes(visual = 1, affect_silicon = 1)
 			to_chat(M, "<span class='danger'>BANG</span>")
 			playsound(get_turf(src), 'sound/effects/bang.ogg', 25, 1)

--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -23,6 +23,8 @@
 		var/turf/T = get_turf(M)
 		var/D = round(cheap_pythag(T.x - x0, T.y - y0), 1)
 		if(D > 8)
+			if(eye_safety < 1)
+				M.flash_eyes(visual = 1, affect_silicon = 1)
 			to_chat(M, "<span class='danger'>BANG</span>")
 			playsound(get_turf(src), 'sound/effects/bang.ogg', 25, 1)
 			continue


### PR DESCRIPTION
### This is independent from and mutually exclusive to my other flashbang tweak PR here: #17444

### This is how flashbangs work currently:

![squarebang2](https://user-images.githubusercontent.com/31839805/36258457-89469846-120f-11e8-9477-4e2c404dbc19.png)

As you can see, compared to an explosion, you might say flashbangs "cheat." They hog the corners

### Breakdown of effects

* Anywhere you are on this grid you will be stunned if the flashbang is in view and you don't have eye protection and also hearing protection.
* If you don't have eye protection or if you're a silicon you will be stunned for the full ~20 seconds anywhere on here.
* If you have the flashbang in your inventory you are stunned for the full ~20 seconds.

#### Red zone:
* If you have eye protection but not ear protection it's ~20 seconds.
* If you have eye protection and ear protection it's ~4 seconds.

#### Yellow zone:
* If you have eye protection but not ear protection you're stunned for ~16 seconds.
* If you have both you are not stunned.

#### Blue zone:
* If you have eye protection but not ear protection you're stunned for ~8 seconds.
* If you have both you're not stunned of course.



### This is what this PR does:

![circlebang2](https://user-images.githubusercontent.com/31839805/36258520-cd5440a6-120f-11e8-82d7-3e8577b0b31d.png)

With the other change being that a flashbang on your same tile will have the same effect as holding it. Also the old pattern will hold for the effect on blobs.

The intention here is to put at least some value in positioning with a one second timer and a rectangular room in mind, both on the side of the thrower and on the target.

:cl:
* tweak: The effect of flashbangs is now in a roughly circular pattern instead of square. (Excluding their effect on blobs.)
* tweak: Having a flashbang go off on your tile will always stun you for the maximum duration, same as one you're holding.