### PR TITLE
Spams the admin logs with debug informations related to the job controller

### DIFF
--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -4,6 +4,8 @@ var/global/datum/controller/occupations/job_master
 #define BE_ASSISTANT 1
 #define RETURN_TO_LOBBY 2
 
+#define JOB_CONTROLLER_DEBUG TRUE
+
 /datum/controller/occupations
 		//List of all jobs
 	var/list/occupations = list()
@@ -12,10 +14,10 @@ var/global/datum/controller/occupations/job_master
 		//Debug info
 	var/list/job_debug = list()
 
-
 /datum/controller/occupations/proc/SetupOccupations(var/faction = "Station")
 	occupations = list()
 	var/list/all_jobs = typesof(/datum/job)
+	log_admin("JOB SS debug: SetupOccupations() started.")
 	if(!all_jobs.len)
 		to_chat(world, "<span class='danger'>Error setting up jobs, no job datums found</span>")
 		return 0
@@ -39,9 +41,10 @@ var/global/datum/controller/occupations/job_master
 
 
 /datum/controller/occupations/proc/Debug(var/text)
-	if(!Debug2)
+	if(!JOB_CONTROLLER_DEBUG)
 		return 0
 	job_debug.Add(text)
+	log_admin(text) // Permanently log what happens + a timestamp. Should help with the cuck cube problem.
 	return 1
 
 


### PR DESCRIPTION
Hopefully this will helps us know whatever the hell is slowing in server startup and causes people to wait in a painful limbo.

This is to be reverted as soon as the issues with cube are fixed.