### PR TITLE
Prevents duplicate sand decals

### DIFF
--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -40,7 +40,8 @@
 /obj/item/weapon/ore/glass/throw_impact(atom/hit_atom)
 	//Intentionally not calling ..()
 	if(isturf(hit_atom))
-		new/obj/effect/decal/cleanable/scattered_sand(hit_atom)
+		if(!locate(/obj/effect/decal/cleanable/scattered_sand) in hit_atom)
+			new/obj/effect/decal/cleanable/scattered_sand(hit_atom)
 		qdel(src)
 	else if(ishuman(hit_atom))
 		var/mob/living/carbon/human/H = hit_atom


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl:
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
Fixes #17476 
![image](https://user-images.githubusercontent.com/5942183/36335341-94e59d48-137f-11e8-916c-ba750632f3a1.png)
Turfs should no longer get turned entirely yellow from a miner fucking about with pocket sand.
Issue was raised after a miner put sand ore in the chute on the outpost near the high-yield chunks on Box, which goes directly to the smelter in the main mining outpost.
:cl:
- bugfix: Sand decal will now only be added if it isn't already in the contents of the turf.