### PR TITLE
Improving Trader Options

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -493,7 +493,7 @@ var/global/num_vending_terminals = 1
 			to_chat(user, "<span class='info'>[src] responds with a soft beep.</span>")
 		else
 			to_chat(user, "<span class='info'>Nothing happens.</span>")
-				
+
 	else if(istype(W, /obj/item/weapon/card))
 		//attempt to connect to a new db, and if that doesn't work then fail
 		if(linked_account)
@@ -2914,15 +2914,12 @@ var/global/num_vending_terminals = 1
 	accepted_coins = list(/obj/item/weapon/coin/trader)
 
 	premium = list(
-		/obj/item/weapon/storage/trader_marauder,
-		//obj/item/weapon/storage/backpack/holding, //Players did exactly what you would expect and bought them for their own use.  Keep in mind that an obj should be good but not so good they want it for themselves
+		/obj/item/weapon/storage/trader_chemistry,
+		/obj/structure/closet/secure_closet/wonderful,
+		/obj/item/weapon/disk/shuttle_coords/vault/mecha_graveyard,
 		/obj/item/weapon/reagent_containers/glass/beaker/bluespace,
 		/obj/item/weapon/storage/bluespace_crystal,
-		//obj/item/clothing/shoes/magboots/elite,
 		/obj/item/weapon/reagent_containers/food/snacks/borer_egg,
-		/obj/item/weapon/reagent_containers/glass/bottle/peridaxon,
-		/obj/item/weapon/reagent_containers/glass/bottle/rezadone,
-		/obj/item/weapon/reagent_containers/glass/bottle/nanobotssmall,
 		/obj/item/clothing/shoes/clown_shoes/advanced,
 		/obj/item/fish_eggs/seadevil,
 		)
@@ -2933,6 +2930,9 @@ var/global/num_vending_terminals = 1
 
 	for(var/random_items = 1 to premium.len - 5)
 		premium.Remove(pick(premium))
+
+	if(premium.Find(/obj/item/weapon/disk/shuttle_coords/vault/mecha_graveyard))
+		load_dungeon(/datum/map_element/dungeon/mecha_graveyard)
 	..()
 
 /obj/machinery/vending/barber

--- a/code/game/objects/items/trader.dm
+++ b/code/game/objects/items/trader.dm
@@ -30,6 +30,7 @@
 	item_state = "box_of_doom"
 
 /obj/item/weapon/storage/trader_chemistry/New()
+	..()
 	new /obj/item/weapon/reagent_containers/glass/bottle/peridaxon(src)
 	new /obj/item/weapon/reagent_containers/glass/bottle/rezadone(src)
 	new /obj/item/weapon/reagent_containers/glass/bottle/nanobotssmall(src)
@@ -59,6 +60,7 @@
 	icon_off = "cabinetdetective_broken"
 
 /obj/structure/closet/secure_closet/wonderful/New()
+	..()
 	var/random_clothes = clothing.Copy()
 	for(var/amount = 1 to 20)
 		var/path = pick_n_take(random_clothes)

--- a/code/game/objects/items/trader.dm
+++ b/code/game/objects/items/trader.dm
@@ -22,6 +22,18 @@
 	//new /obj/item/weapon/circuitboard/mecha/marauder/targeting(src)
 	new /obj/item/weapon/circuitboard/mecha/marauder/main(src)
 
+/obj/item/weapon/storage/trader_chemistry
+	name = "chemist's pallet"
+	desc = "Everything you need to make art."
+	icon = 'icons/obj/storage/smallboxes.dmi'
+	icon_state = "box_of_doom"
+	item_state = "box_of_doom"
+
+/obj/item/weapon/storage/trader_chemistry/New()
+	new /obj/item/weapon/reagent_containers/glass/bottle/peridaxon(src)
+	new /obj/item/weapon/reagent_containers/glass/bottle/rezadone(src)
+	new /obj/item/weapon/reagent_containers/glass/bottle/nanobotssmall(src)
+
 /obj/item/weapon/storage/bluespace_crystal
 	name = "natural bluespace crystals box"
 	desc = "Hmmm... it smells like tomato"
@@ -35,6 +47,23 @@
 		new /obj/item/bluespace_crystal(src)
 	new /obj/item/weapon/reagent_containers/food/snacks/grown/bluespacetomato(src)
 
+/obj/structure/closet/secure_closet/wonderful
+	name = "wonderful wardrobe"
+	desc = "Stolen from Space Narnia."
+	req_access = list(access_trade)
+	icon_state = "cabinetdetective_locked"
+	icon_closed = "cabinetdetective"
+	icon_locked = "cabinetdetective_locked"
+	icon_opened = "cabinetdetective_open"
+	icon_broken = "cabinetdetective_broken"
+	icon_off = "cabinetdetective_broken"
+
+/obj/structure/closet/secure_closet/wonderful/New()
+	var/random_clothes = clothing.Copy()
+	for(var/amount = 1 to 20)
+		var/path = pick_n_take(random_clothes)
+		new path(src)
+
 /*/obj/structure/cage/with_random_slime
 	..()
 
@@ -43,3 +72,56 @@
 /mob/living/carbon/slime/proc/randomSlime()
 */
 
+/area/vault/mecha_graveyard
+
+/obj/item/weapon/disk/shuttle_coords/vault/mecha_graveyard
+	name = "Coordinates to the Mecha Graveyard"
+	desc = "Here lay the dead steel of lost mechas, so says some gypsy."
+	destination = /obj/docking_port/destination/vault/mecha_graveyard
+
+/obj/docking_port/destination/vault/mecha_graveyard
+	areaname = "mecha graveyard"
+
+/datum/map_element/dungeon/mecha_graveyard
+	file_path = "maps/randomvaults/dungeons/mecha_graveyard.dmm"
+
+/obj/effect/decal/mecha_wreckage/graveyard_ripley
+	name = "Ripley wreckage"
+	desc = "Surprisingly well preserved."
+	icon_state = "ripley-broken"
+
+/obj/effect/decal/mecha_wreckage/graveyard_ripley/New()
+	..()
+	var/list/parts = list(/obj/item/mecha_parts/part/ripley_torso,
+								/obj/item/mecha_parts/part/ripley_left_arm,
+								/obj/item/mecha_parts/part/ripley_right_arm,
+								/obj/item/mecha_parts/part/ripley_left_leg,
+								/obj/item/mecha_parts/part/ripley_right_leg)
+	welder_salvage += parts
+
+	if(prob(80))
+		add_salvagable_equipment(new /obj/item/mecha_parts/mecha_equipment/tool/drill,100)
+	else
+		add_salvagable_equipment(new /obj/item/mecha_parts/mecha_equipment/tool/drill/diamonddrill,100)
+	add_salvagable_equipment(new /obj/item/mecha_parts/mecha_equipment/tool/hydraulic_clamp,100)
+	add_salvagable_equipment(new /obj/item/mecha_parts/mecha_equipment/jetpack,100)
+
+/obj/effect/decal/mecha_wreckage/graveyard_clarke
+	name = "Clarke wreckage"
+	desc = "Surprisingly well preserved."
+	icon_state = "clarke-broken"
+
+/obj/effect/decal/mecha_wreckage/graveyard_clarke/New()
+	..()
+	var/list/parts = list(
+								/obj/item/mecha_parts/part/clarke_torso,
+								/obj/item/mecha_parts/part/clarke_head,
+								/obj/item/mecha_parts/part/clarke_left_arm,
+								/obj/item/mecha_parts/part/clarke_right_arm,
+								/obj/item/mecha_parts/part/clarke_left_tread,
+								/obj/item/mecha_parts/part/clarke_right_tread)
+	welder_salvage += parts
+
+	add_salvagable_equipment(new /obj/item/mecha_parts/mecha_equipment/tool/collector,100)
+	add_salvagable_equipment(new /obj/item/mecha_parts/mecha_equipment/tool/tiler,100)
+	add_salvagable_equipment(new /obj/item/mecha_parts/mecha_equipment/tool/switchtool,100)

--- a/code/game/turfs/unsimulated/walls.dm
+++ b/code/game/turfs/unsimulated/walls.dm
@@ -91,10 +91,3 @@ turf/unsimulated/wall/splashscreen
 
 	if(prob(80))
 		icon_state = "evilwall_[rand(1,8)]"
-
-/turf/unsimulated/wall/void
-	name = "turbulent void"
-	desc = "Far too dangerous to risk crossing."
-	icon = 'icons/turf/space.dmi'
-	icon_state = "void"
-	canSmoothWith = null

--- a/code/game/turfs/unsimulated/walls.dm
+++ b/code/game/turfs/unsimulated/walls.dm
@@ -91,3 +91,10 @@ turf/unsimulated/wall/splashscreen
 
 	if(prob(80))
 		icon_state = "evilwall_[rand(1,8)]"
+
+/turf/unsimulated/wall/void
+	name = "turbulent void"
+	desc = "Far too dangerous to risk crossing."
+	icon = 'icons/turf/space.dmi'
+	icon_state = "void"
+	canSmoothWith = null

--- a/maps/randomvaults/dungeons/mecha_graveyard.dmm
+++ b/maps/randomvaults/dungeons/mecha_graveyard.dmm
@@ -1,0 +1,114 @@
+"aa" = (/turf/unsimulated/wall/void,/area)
+"ab" = (/turf/space,/area)
+"ac" = (/turf/simulated/wall,/area/vault/mecha_graveyard)
+"ad" = (/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"ae" = (/turf/unsimulated/mineral/random,/area/vault/mecha_graveyard)
+"af" = (/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"ag" = (/obj/item/stack/rods,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"ah" = (/obj/effect/decal/cleanable/dirt,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"ai" = (/turf/unsimulated/floor/asteroid{icon_state = "asteroid_dug"},/area/vault/mecha_graveyard)
+"aj" = (/obj/effect/decal/cleanable/blood/gibs/robot,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"ak" = (/obj/structure/hanging_lantern{dir = 1},/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"al" = (/obj/effect/decal/cleanable/blood/gibs/robot/limb,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"am" = (/obj/item/weapon/ore/glass,/turf/unsimulated/floor/asteroid{icon_state = "asteroid_dug"},/area/vault/mecha_graveyard)
+"an" = (/obj/effect/decal/mecha_wreckage/graveyard_ripley,/turf/unsimulated/floor/asteroid{icon_state = "asteroid_dug"},/area/vault/mecha_graveyard)
+"ao" = (/obj/effect/decal/cleanable/soot,/turf/unsimulated/floor/asteroid{icon_state = "asteroid_dug"},/area/vault/mecha_graveyard)
+"ap" = (/obj/item/weapon/ore/iron,/turf/unsimulated/floor/asteroid{icon_state = "asteroid_dug"},/area/vault/mecha_graveyard)
+"aq" = (/obj/structure/hanging_lantern,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"ar" = (/obj/effect/decal/mecha_wreckage/graveyard_ripley,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"as" = (/obj/structure/girder,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"at" = (/obj/structure/girder,/obj/item/stack/rods,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"au" = (/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"; dir = 1},/area/vault/mecha_graveyard)
+"av" = (/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"; dir = 5},/area/vault/mecha_graveyard)
+"aw" = (/obj/effect/decal/cleanable/blood/gibs/robot/down,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"ax" = (/obj/effect/decal/cleanable/ash,/turf/unsimulated/floor/asteroid{icon_state = "asteroid_dug"},/area/vault/mecha_graveyard)
+"ay" = (/obj/effect/decal/cleanable/blood/gibs/robot,/turf/unsimulated/floor/asteroid{icon_state = "asteroid_dug"},/area/vault/mecha_graveyard)
+"az" = (/obj/machinery/status_display{pixel_y = 32},/obj/effect/decal/mecha_wreckage/durand,/obj/effect/decal/cleanable/soot,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"aA" = (/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"; dir = 4},/area/vault/mecha_graveyard)
+"aB" = (/obj/item/stack/sheet/plasteel,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"aC" = (/obj/effect/decal/mecha_wreckage/marauder,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"aD" = (/obj/item/mecha_parts/mecha_equipment/repair_droid,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"aE" = (/obj/effect/decal/cleanable/blood/gibs/robot,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"aF" = (/obj/item/weapon/ore/slag,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"aG" = (/obj/effect/decal/cleanable/soot,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"aH" = (/obj/effect/decal/mecha_wreckage/durand,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"aI" = (/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"; dir = 10},/area/vault/mecha_graveyard)
+"aJ" = (/obj/effect/decal/cleanable/dirt,/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"},/area/vault/mecha_graveyard)
+"aK" = (/obj/effect/decal/mecha_wreckage/gygax,/obj/effect/decal/cleanable/soot,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"aL" = (/obj/effect/decal/cleanable/ash,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"aM" = (/obj/structure/grille/broken,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"aN" = (/obj/structure/hanging_lantern{dir = 8},/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"aO" = (/obj/effect/decal/cleanable/blood/oil,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"aP" = (/obj/structure/disposalpipe/segment{dir = 4},/obj/item/weapon/broken_pipe_tomahawk,/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"; dir = 4},/area/vault/mecha_graveyard)
+"aQ" = (/obj/structure/disposalpipe/segment{dir = 4},/turf/unsimulated/floor/asteroid/plating,/area/vault/mecha_graveyard)
+"aR" = (/obj/effect/decal/cleanable/blood/gibs/robot/up,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"aS" = (/obj/item/broken_device,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"aT" = (/obj/structure/hanging_lantern{dir = 4},/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"; dir = 9},/area/vault/mecha_graveyard)
+"aU" = (/obj/structure/reagent_dispensers/fueltank,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"aV" = (/obj/structure/ore_box,/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"; dir = 8},/area/vault/mecha_graveyard)
+"aW" = (/obj/structure/grille,/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced{dir = 4},/obj/structure/window/reinforced{dir = 8},/obj/structure/window/reinforced,/obj/structure/window/full/reinforced,/turf/simulated/floor/plating,/area/vault/mecha_graveyard)
+"aX" = (/obj/effect/decal/remains/human,/turf/simulated/floor/airless{icon_state = "damaged5"},/area/vault/mecha_graveyard)
+"aY" = (/obj/effect/decal/mecha_wreckage/graveyard_clarke,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"aZ" = (/turf/unsimulated/floor/airless{icon_state = "asteroidplating"},/area/vault/mecha_graveyard)
+"ba" = (/obj/effect/decal/cleanable/blood/gibs/robot/limb,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"bb" = (/obj/item/weapon/broken_bottle,/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"; dir = 8},/area/vault/mecha_graveyard)
+"bc" = (/obj/machinery/door/airlock/external,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"bd" = (/obj/item/weapon/screwdriver,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"be" = (/obj/machinery/mech_bay_recharge_port,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"bf" = (/obj/machinery/mech_bay_recharge_floor{icon_state = "recharge_floor_asteroid"},/turf/simulated/floor,/area/vault/mecha_graveyard)
+"bg" = (/obj/machinery/computer/mech_bay_power_console,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"bh" = (/obj/item/clothing/glasses/scanner/meson,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"bi" = (/obj/structure/girder/displaced,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"bj" = (/obj/item/clothing/shoes/galoshes/broken,/turf/unsimulated/floor/airless{icon_state = "asteroidplating"},/area/vault/mecha_graveyard)
+"bk" = (/obj/machinery/mineral/unloading_machine,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"bl" = (/obj/machinery/conveyor{dir = 4; id_tag = "mining_west"},/obj/item/stack/sheet/plasteel,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"bm" = (/obj/machinery/conveyor{dir = 4; id_tag = "mining_west"},/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"bn" = (/obj/item/weapon/shard,/turf/space,/area)
+"bo" = (/obj/item/weapon/shard{icon_state = "small"},/turf/space,/area)
+"bp" = (/obj/structure/lattice,/turf/space,/area)
+"bq" = (/obj/docking_port/destination/vault/mecha_graveyard{dir = 2},/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"br" = (/obj/item/weapon/shard{icon_state = "medium"},/turf/space,/area)
+"bs" = (/obj/item/weapon/shard{icon_state = "medium"},/obj/item/weapon/shard,/turf/space,/area)
+
+(1,1,1) = {"
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaababababababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabababababababababababaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaabababababababababababababababababababababaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaabababababababababababababababababababababababababababababaaaaaaaaaa
+aaaaaaaaaaabababababababacacacadadadadaeaeaeaeababababababababababababaaaaaaaaaa
+aaaaaaabababababababababafafacadadadadaeaeaeaeabababababababababababaaaaaaaaaaaa
+aaaaabababababababababagadahacadadadaiaeaeaeaeaeaeaeaeabababababababaaaaaaaaaaaa
+aaaaababababababababadadadajakadadaiaiaiaiaeaeaeaeaeaeabababababababaaaaaaaaaaaa
+aaaaababababababadadadaladadadadadamamaiaiaianaeaeaeaeaeaeaeababababaaaaaaaaaaaa
+aaaaabababababadadadadadadadagadadaiamaiaoaiapaiaiaiaiaiadadababababaaaaaaaaaaaa
+aaaaabababababadadafadadadadadadaeaiapapaiamamaiaiaiapaiadadababababaaaaaaaaaaaa
+aaabababababadadadafaqadadadadaeaeaeaearapamamaiapaiamajadadababababaaaaaaaaaaaa
+aaabababababasadatacacacauavawadaeaeaeaeapaiaxaiayaiaiaiaiaiababababaaaaaaaaaaaa
+aaababababadadauadazafafafaAadadaBaeaeaeaiadaiamaiaiaiaiaiaiababababababaaaaaaaa
+aaababababaCadahaDafafaEahaAagadafaeaeaFadadadaGadadadaiaeabababababababaaaaaaaa
+aaababababadaHaIaJafafaKafaAadadadadaLadadadadadadadadaeaeabababababababaaaaaaaa
+aaabababababadadaMacacaNaOaPaQadaRafaSadaTacacacadadadabababababababababaaaaaaaa
+aaababababababasadagaBasaUadadagadafadafaVaWaXaYadababababababababababaaaaaaaaaa
+aaaaababababababadadadacaZaZaZaZadafadbabbbcaObdabababababababababababaaaaaaaaaa
+aaaaaaaaababababababababaZbebfbgadafadbhaIbiagajabababababababababababaaaaaaaaaa
+aaaaaaaaababababababababaZbjaZaZafaRadbkblbmbiadababababababababababaaaaaaaaaaaa
+aaaaaaaaaaaaababababababababagadafadadadabbnabboababababababababababaaaaaaaaaaaa
+aaaaaaaaaaaaabababababababbpadadadbqadadbpbpbrabbsababababababababaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaabababababbpabababababababbpabboababababababaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaabababababbpabababababababbpababababababababaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaabababbpabababababababbpababababababaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaabababbpabababababababbpababababaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaabababbpabababababababbpababababaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaabababbpbpbpbpbpbpbpbpbpababababaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaababababababababababababababababaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaababababababababababababababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaababababababababababababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+"}

--- a/maps/randomvaults/dungeons/mecha_graveyard.dmm
+++ b/maps/randomvaults/dungeons/mecha_graveyard.dmm
@@ -1,119 +1,131 @@
-"aa" = (/turf/space/transit/north,/area)
-"ab" = (/turf/space/transit/east,/area)
-"ac" = (/turf/space/transit/west,/area)
-"ad" = (/turf/space,/area)
-"ae" = (/turf/simulated/wall,/area/vault/mecha_graveyard)
-"af" = (/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
-"ag" = (/turf/unsimulated/mineral/random,/area/vault/mecha_graveyard)
-"ah" = (/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
-"ai" = (/obj/item/stack/rods,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
-"aj" = (/obj/effect/decal/cleanable/dirt,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
-"ak" = (/turf/unsimulated/floor/asteroid{icon_state = "asteroid_dug"},/area/vault/mecha_graveyard)
-"al" = (/obj/effect/decal/cleanable/blood/gibs/robot,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
-"am" = (/obj/structure/hanging_lantern{dir = 1},/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
-"an" = (/obj/effect/decal/cleanable/blood/gibs/robot/limb,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
-"ao" = (/obj/item/weapon/ore/glass,/turf/unsimulated/floor/asteroid{icon_state = "asteroid_dug"},/area/vault/mecha_graveyard)
-"ap" = (/obj/effect/decal/mecha_wreckage/graveyard_ripley,/turf/unsimulated/floor/asteroid{icon_state = "asteroid_dug"},/area/vault/mecha_graveyard)
-"aq" = (/obj/effect/decal/cleanable/soot,/turf/unsimulated/floor/asteroid{icon_state = "asteroid_dug"},/area/vault/mecha_graveyard)
-"ar" = (/obj/item/weapon/ore/iron,/turf/unsimulated/floor/asteroid{icon_state = "asteroid_dug"},/area/vault/mecha_graveyard)
-"as" = (/obj/structure/hanging_lantern,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
-"at" = (/obj/effect/decal/mecha_wreckage/graveyard_ripley,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
-"au" = (/obj/structure/girder,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
-"av" = (/obj/structure/girder,/obj/item/stack/rods,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
-"aw" = (/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"; dir = 1},/area/vault/mecha_graveyard)
-"ax" = (/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"; dir = 5},/area/vault/mecha_graveyard)
-"ay" = (/obj/effect/decal/cleanable/blood/gibs/robot/down,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
-"az" = (/obj/effect/decal/cleanable/ash,/turf/unsimulated/floor/asteroid{icon_state = "asteroid_dug"},/area/vault/mecha_graveyard)
-"aA" = (/obj/effect/decal/cleanable/blood/gibs/robot,/turf/unsimulated/floor/asteroid{icon_state = "asteroid_dug"},/area/vault/mecha_graveyard)
-"aB" = (/obj/machinery/status_display{pixel_y = 32},/obj/effect/decal/mecha_wreckage/durand,/obj/effect/decal/cleanable/soot,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
-"aC" = (/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"; dir = 4},/area/vault/mecha_graveyard)
-"aD" = (/obj/item/stack/sheet/plasteel,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
-"aE" = (/obj/effect/decal/mecha_wreckage/marauder,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
-"aF" = (/obj/item/mecha_parts/mecha_equipment/repair_droid,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
-"aG" = (/obj/effect/decal/cleanable/blood/gibs/robot,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
-"aH" = (/obj/item/weapon/ore/slag,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
-"aI" = (/obj/effect/decal/cleanable/soot,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
-"aJ" = (/obj/effect/decal/mecha_wreckage/durand,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
-"aK" = (/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"; dir = 10},/area/vault/mecha_graveyard)
-"aL" = (/obj/effect/decal/cleanable/dirt,/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"},/area/vault/mecha_graveyard)
-"aM" = (/obj/effect/decal/mecha_wreckage/gygax,/obj/effect/decal/cleanable/soot,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
-"aN" = (/obj/effect/decal/cleanable/ash,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
-"aO" = (/obj/structure/grille/broken,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
-"aP" = (/obj/structure/hanging_lantern{dir = 8},/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
-"aQ" = (/obj/effect/decal/cleanable/blood/oil,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
-"aR" = (/obj/structure/disposalpipe/segment{dir = 4},/obj/item/weapon/broken_pipe_tomahawk,/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"; dir = 4},/area/vault/mecha_graveyard)
-"aS" = (/obj/structure/disposalpipe/segment{dir = 4},/turf/unsimulated/floor/asteroid/plating,/area/vault/mecha_graveyard)
-"aT" = (/obj/effect/decal/cleanable/blood/gibs/robot/up,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
-"aU" = (/obj/item/broken_device,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
-"aV" = (/obj/structure/hanging_lantern{dir = 4},/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"; dir = 9},/area/vault/mecha_graveyard)
-"aW" = (/obj/structure/reagent_dispensers/fueltank,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
-"aX" = (/obj/structure/ore_box,/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"; dir = 8},/area/vault/mecha_graveyard)
-"aY" = (/obj/structure/grille,/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced{dir = 4},/obj/structure/window/reinforced{dir = 8},/obj/structure/window/reinforced,/obj/structure/window/full/reinforced,/turf/simulated/floor/plating,/area/vault/mecha_graveyard)
-"aZ" = (/obj/effect/decal/remains/human,/turf/simulated/floor/airless{icon_state = "damaged5"},/area/vault/mecha_graveyard)
-"ba" = (/obj/effect/decal/mecha_wreckage/graveyard_clarke,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
-"bb" = (/turf/unsimulated/floor/airless{icon_state = "asteroidplating"},/area/vault/mecha_graveyard)
-"bc" = (/obj/effect/decal/cleanable/blood/gibs/robot/limb,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
-"bd" = (/obj/item/weapon/broken_bottle,/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"; dir = 8},/area/vault/mecha_graveyard)
-"be" = (/obj/machinery/door/airlock/external,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
-"bf" = (/obj/item/weapon/screwdriver,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
-"bg" = (/obj/machinery/mech_bay_recharge_port,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
-"bh" = (/obj/machinery/mech_bay_recharge_floor{icon_state = "recharge_floor_asteroid"},/turf/simulated/floor,/area/vault/mecha_graveyard)
-"bi" = (/obj/machinery/computer/mech_bay_power_console,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
-"bj" = (/obj/item/clothing/glasses/scanner/meson,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
-"bk" = (/obj/structure/girder/displaced,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
-"bl" = (/obj/item/clothing/shoes/galoshes/broken,/turf/unsimulated/floor/airless{icon_state = "asteroidplating"},/area/vault/mecha_graveyard)
-"bm" = (/obj/machinery/mineral/unloading_machine,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
-"bn" = (/obj/machinery/conveyor{dir = 4; id_tag = "mining_west"},/obj/item/stack/sheet/plasteel,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
-"bo" = (/obj/machinery/conveyor{dir = 4; id_tag = "mining_west"},/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
-"bp" = (/turf/unsimulated/floor/airless{icon_state = "asteroidplating"},/area)
-"bq" = (/obj/item/weapon/shard,/turf/unsimulated/floor/airless{icon_state = "asteroidplating"},/area)
-"br" = (/obj/item/weapon/shard{icon_state = "small"},/turf/space,/area)
-"bs" = (/obj/structure/lattice,/turf/space,/area)
-"bt" = (/obj/docking_port/destination/vault/mecha_graveyard{dir = 2},/obj/machinery/door/airlock/external,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
-"bu" = (/obj/item/weapon/shard{icon_state = "medium"},/turf/space,/area)
-"bv" = (/obj/item/weapon/shard{icon_state = "medium"},/obj/item/weapon/shard,/turf/space,/area)
-"bw" = (/turf/space/transit/south,/area)
-"bx" = (/obj/structure/lattice,/obj/structure/girder,/turf/space,/area)
+"aa" = (/obj/effect/step_trigger/teleporter/random,/turf/space/transit/west,/area)
+"ab" = (/obj/effect/step_trigger/teleporter/random,/turf/space/transit/north,/area)
+"ac" = (/obj/effect/step_trigger/teleporter/random,/turf/space/transit/east,/area)
+"ad" = (/turf/space/transit/west,/area)
+"ae" = (/turf/space/transit/north,/area)
+"af" = (/turf/space/transit/east,/area)
+"ag" = (/obj/effect/step_trigger/thrower/north,/turf/space/transit/north,/area)
+"ah" = (/turf/space,/area)
+"ai" = (/obj/effect/step_trigger/thrower/west,/turf/space/transit/west,/area)
+"aj" = (/obj/effect/step_trigger/thrower/east,/turf/space/transit/east,/area)
+"ak" = (/turf/simulated/wall,/area/vault/mecha_graveyard)
+"al" = (/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"am" = (/turf/unsimulated/mineral/random,/area/vault/mecha_graveyard)
+"an" = (/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"ao" = (/obj/item/stack/rods,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"ap" = (/obj/effect/decal/cleanable/dirt,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"aq" = (/turf/unsimulated/floor/asteroid{icon_state = "asteroid_dug"},/area/vault/mecha_graveyard)
+"ar" = (/obj/effect/decal/cleanable/blood/gibs/robot,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"as" = (/obj/structure/hanging_lantern{dir = 1},/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"at" = (/obj/effect/decal/cleanable/blood/gibs/robot/limb,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"au" = (/obj/item/weapon/ore/glass,/turf/unsimulated/floor/asteroid{icon_state = "asteroid_dug"},/area/vault/mecha_graveyard)
+"av" = (/obj/effect/decal/mecha_wreckage/graveyard_ripley,/turf/unsimulated/floor/asteroid{icon_state = "asteroid_dug"},/area/vault/mecha_graveyard)
+"aw" = (/obj/effect/decal/cleanable/soot,/turf/unsimulated/floor/asteroid{icon_state = "asteroid_dug"},/area/vault/mecha_graveyard)
+"ax" = (/obj/item/weapon/ore/iron,/turf/unsimulated/floor/asteroid{icon_state = "asteroid_dug"},/area/vault/mecha_graveyard)
+"ay" = (/obj/structure/hanging_lantern,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"az" = (/obj/effect/decal/mecha_wreckage/graveyard_ripley,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"aA" = (/obj/structure/girder,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"aB" = (/obj/structure/girder,/obj/item/stack/rods,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"aC" = (/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"; dir = 1},/area/vault/mecha_graveyard)
+"aD" = (/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"; dir = 5},/area/vault/mecha_graveyard)
+"aE" = (/obj/effect/decal/cleanable/blood/gibs/robot/down,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"aF" = (/obj/effect/decal/cleanable/ash,/turf/unsimulated/floor/asteroid{icon_state = "asteroid_dug"},/area/vault/mecha_graveyard)
+"aG" = (/obj/effect/decal/cleanable/blood/gibs/robot,/turf/unsimulated/floor/asteroid{icon_state = "asteroid_dug"},/area/vault/mecha_graveyard)
+"aH" = (/obj/machinery/status_display{pixel_y = 32},/obj/effect/decal/mecha_wreckage/durand,/obj/effect/decal/cleanable/soot,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"aI" = (/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"; dir = 4},/area/vault/mecha_graveyard)
+"aJ" = (/obj/item/stack/sheet/plasteel,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"aK" = (/obj/effect/decal/mecha_wreckage/marauder,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"aL" = (/obj/item/mecha_parts/mecha_equipment/repair_droid,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"aM" = (/obj/effect/decal/cleanable/blood/gibs/robot,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"aN" = (/obj/item/weapon/ore/slag,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"aO" = (/obj/effect/decal/cleanable/soot,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"aP" = (/obj/effect/decal/mecha_wreckage/durand,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"aQ" = (/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"; dir = 10},/area/vault/mecha_graveyard)
+"aR" = (/obj/effect/decal/cleanable/dirt,/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"},/area/vault/mecha_graveyard)
+"aS" = (/obj/effect/decal/mecha_wreckage/gygax,/obj/effect/decal/cleanable/soot,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"aT" = (/obj/effect/decal/cleanable/ash,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"aU" = (/obj/structure/grille/broken,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"aV" = (/obj/structure/hanging_lantern{dir = 8},/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"aW" = (/obj/effect/decal/cleanable/blood/oil,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"aX" = (/obj/structure/disposalpipe/segment{dir = 4},/obj/item/weapon/broken_pipe_tomahawk,/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"; dir = 4},/area/vault/mecha_graveyard)
+"aY" = (/obj/structure/disposalpipe/segment{dir = 4},/turf/unsimulated/floor/asteroid/plating,/area/vault/mecha_graveyard)
+"aZ" = (/obj/effect/decal/cleanable/blood/gibs/robot/up,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"ba" = (/obj/item/broken_device,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"bb" = (/obj/structure/hanging_lantern{dir = 4},/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"; dir = 9},/area/vault/mecha_graveyard)
+"bc" = (/obj/structure/reagent_dispensers/fueltank,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"bd" = (/obj/structure/ore_box,/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"; dir = 8},/area/vault/mecha_graveyard)
+"be" = (/obj/structure/grille,/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced{dir = 4},/obj/structure/window/reinforced{dir = 8},/obj/structure/window/reinforced,/obj/structure/window/full/reinforced,/turf/simulated/floor/plating,/area/vault/mecha_graveyard)
+"bf" = (/obj/effect/decal/remains/human,/turf/simulated/floor/airless{icon_state = "damaged5"},/area/vault/mecha_graveyard)
+"bg" = (/obj/effect/decal/mecha_wreckage/graveyard_clarke,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"bh" = (/turf/unsimulated/floor/airless{icon_state = "asteroidplating"},/area/vault/mecha_graveyard)
+"bi" = (/obj/effect/decal/cleanable/blood/gibs/robot/limb,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"bj" = (/obj/item/weapon/broken_bottle,/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"; dir = 8},/area/vault/mecha_graveyard)
+"bk" = (/obj/machinery/door/airlock/external,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"bl" = (/obj/item/weapon/screwdriver,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"bm" = (/obj/machinery/mech_bay_recharge_port,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"bn" = (/obj/machinery/mech_bay_recharge_floor{icon_state = "recharge_floor_asteroid"},/turf/simulated/floor,/area/vault/mecha_graveyard)
+"bo" = (/obj/machinery/computer/mech_bay_power_console,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"bp" = (/obj/item/clothing/glasses/scanner/meson,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"bq" = (/obj/structure/girder/displaced,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"br" = (/obj/item/clothing/shoes/galoshes/broken,/turf/unsimulated/floor/airless{icon_state = "asteroidplating"},/area/vault/mecha_graveyard)
+"bs" = (/obj/machinery/mineral/unloading_machine,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"bt" = (/obj/machinery/conveyor{dir = 4; id_tag = "mining_west"},/obj/item/stack/sheet/plasteel,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"bu" = (/obj/machinery/conveyor{dir = 4; id_tag = "mining_west"},/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"bv" = (/obj/item/weapon/shard,/turf/unsimulated/floor/airless{icon_state = "asteroidplating"},/area/vault/mecha_graveyard)
+"bw" = (/obj/item/weapon/shard{icon_state = "small"},/turf/space,/area)
+"bx" = (/obj/structure/lattice,/turf/space,/area)
+"by" = (/obj/docking_port/destination/vault/mecha_graveyard{dir = 2},/obj/machinery/door/airlock/external,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"bz" = (/obj/item/weapon/shard{icon_state = "medium"},/turf/space,/area)
+"bA" = (/obj/item/weapon/shard{icon_state = "medium"},/obj/item/weapon/shard,/turf/space,/area)
+"bB" = (/obj/structure/lattice,/obj/structure/girder,/turf/space,/area)
+"bC" = (/obj/effect/step_trigger/thrower,/turf/space/transit/south,/area)
+"bD" = (/turf/space/transit/south,/area)
+"bE" = (/obj/effect/step_trigger/teleporter/random,/turf/space/transit/south,/area)
 
 (1,1,1) = {"
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabab
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabab
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaababab
-acaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaababab
-acacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaababababab
-acacacaaaaaaaaaaaaaaaaaaaaaaaaadadadadadadaaaaaaaaaaaaaaaaaaaaaaaaaaaaababababab
-acacacaaaaaaaaaaaaaaaaaaaaaaaaadadadadadadadadadadadaaaaaaaaaaaaaaaaabababababab
-acacacacacacaaaaadadadadadadadadadadadadadadadadadadadadadaaaaaaaaababababababab
-acacacacacacadadadadadadadadadadadadadadadadadadadadadadadadadadadadadababababab
-acacacacacadadadadadadadaeaeaeafafafafagagagagadadadadadadadadadadadadababababab
-acacacadadadadadadadadadahahaeafafafafagagagagadadadadadadadadadadadabababababab
-acacadadadadadadadadadaiafajaeafafafakagagagagagagagagadadadadadadadabababababab
-acacadadadadadadadadafafafalamafafakakakakagagagagagagadadadadadadadabababababab
-acacadadadadadadafafafanafafafafafaoaoakakakapagagagagagagagadadadadabababababab
-acacadadadadadafafafafafafafaiafafakaoakaqakarakakakakakafafadadadadabababababab
-acacadadadadadafafahafafafafafafagakararakaoaoakakakarakafafadadadadabababababab
-acadadadadadafafafahasafafafafagagagagataraoaoakarakaoalafafadadadadabababababab
-acadadadadadauafavaeaeaeawaxayafagagagagarakazakaAakakakakakadadadadabababababab
-acadadadadafafawafaBahahahaCafafaDagagagakafakaoakakakakakakadadadadadadabababab
-acadadadadaEafajaFahahaGajaCaiafahagagaHafafafaIafafafakagadadadadadadadabababab
-acadadadadafaJaKaLahahaMahaCafafafafaNafafafafafafafafagagadadadadadadadabababab
-acadadadadadafafaOaeaeaPaQaRaSafaTahaUafaVaeaeaeafafafadadadadadadadadadabababab
-acadadadadadadauafaiaDauaWafafaiafahafahaXaYaZbaafadadadadadadadadadadababababab
-acacadadadadadadafafafaebbbbbbbbafahafbcbdbeaQbfadadadadadadadadadadadababababab
-acacacacadadadadadadadadbbbgbhbiafahafbjaKbkaialadadadadadadadadadadadababababab
-acacacacadadadadadadadadbbblbbbbahaTafbmbnbobkafadadadadadadadadadadabababababab
-acacacacacacadadadadadadadadaiafahafafafbpbqadbradadadadadadadadadadabababababab
-acacacacacacadadadadadadadbsafaeaebtaeaubsbsbuadbvadadadadadadadadababababababab
-acacacacacacacacadadadadadbsadadadadadadadbsadbradadadadadadabababababababababab
-acacacacacacacacadadadadadbsadadadadadadadbsadadadadadadadadabababababababababab
-acacacacacacacacbwbwadadadbsadadadadadadadbxadadadadadadbwbwabababababababababab
-acacacacacacacacbwbwadadadbsadadadadadadadbsadadadadbwbwbwbwbwbwabababababababab
-acacacacacacacacbwbwadadadbxadadadadadadadbsadadadadbwbwbwbwbwbwabababababababab
-acacacacacbwbwbwbwbwadadadbsbsbsbxbsbsbsbsbsadadadadbwbwbwbwbwbwbwbwabababababab
-acacacacbwbwbwbwbwbwadadadadadadadadadadadadadadadadbwbwbwbwbwbwbwbwabababababab
-acacacacbwbwbwbwbwbwbwadadadadadadadadadadadadadadbwbwbwbwbwbwbwbwbwbwbwabababab
-acacbwbwbwbwbwbwbwbwbwadadadadadadadadadadadadbwbwbwbwbwbwbwbwbwbwbwbwbwabababab
-acacbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwabab
-acacbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwab
-bwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbw
+aaaaabababababababababababababababababababababababababababababababababababababababababacac
+aaadadaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeafac
+aaadadadaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeafafac
+aaadadadadadaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeafafac
+aaadadadadadadaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeafafafafac
+aaadadadadadadadaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeafafafafac
+aaadadadadadadadaeaeaeaeagagagagagagagagagagagagagagagagagagagagagagagaeaeaeaeafafafafafac
+aaadadadadadadadadadadagagahahahahahahahahahahahahahahahahahahahahahagagaeaeafafafafafafac
+aaadadadadadadadadaiaiahahahahahahahahahahahahahahahahahahahahahahahahajajafafafafafafafac
+aaadadadadadadadaiaiahahahahahahahakakakalalalalamamamamahahahahahahahahajajafafafafafafac
+aaadadadadadadadaiahahahahahahahahananakalalalalamamamamahahahahahahahahahajafafafafafafac
+aaadadadadadadaiaiahahahahahahahaoalapakalalalaqamamamamamamamamahahahahahajafafafafafafac
+aaadadadadadadaiahahahahahahahalalalarasalalaqaqaqaqamamamamamamahahahahahajafafafafafafac
+aaadadadadadadaiahahahahahalalalatalalalalalauauaqaqaqavamamamamamamamahahajafafafafafafac
+aaadadadadadadaiahahahahalalalalalalalaoalalaqauaqawaqaxaqaqaqaqaqalalahahajafafafafafafac
+aaadadadadadadaiahahahahalalanalalalalalalamaqaxaxaqauauaqaqaqaxaqalalahahajafafafafafafac
+aaadadadadadadaiahahahalalalanayalalalalamamamamazaxauauaqaxaqauaralalahahajafafafafafafac
+aaadadadadadaiaiahahahaAalaBakakakaCaDaEalamamamamaxaqaFaqaGaqaqaqaqaqahahajafafafafafafac
+aaadadadadadaiahahahalalaCalaHanananaIalalaJamamamaqalaqauaqaqaqaqaqaqahahajafafafafafafac
+aaadadadadadaiahahahaKalapaLananaMapaIaoalanamamaNalalalaOalalalaqamahahahajafafafafafafac
+aaadadadadadaiahahahalaPaQaRananaSanaIalalalalaTalalalalalalalalamamahahahajafafafafafafac
+aaadadadadadaiahahahahalalaUakakaVaWaXaYalaZanbaalbbakakakalalalahahahahahajafafafafafafac
+aaadadadadadaiahahahahahaAalaoaJaAbcalalaoalanalanbdbebfbgalahahahahahahahajafafafafafafac
+aaadadadadadaiahahahahahahalalalakbhbhbhbhalanalbibjbkaWblahahahahahahahahajafafafafafafac
+aaadadadadadaiahahahahahahahahahahbhbmbnboalanalbpaQbqaoarahahahahahahahahajafafafafafafac
+aaadadadadadaiaiahahahahahahahahahbhbrbhbhanaZalbsbtbubqalahahahahahahahahajafafafafafafac
+aaadadadadadadaiaiahahahahahahahahahahaoalanalalalbhbvahbwahahahahahahahahajafafafafafafac
+aaadadadadadadadaiahahahahahahahahahbxalakakbyakaAbxbxbzahbAahahahahahahahajafafafafafafac
+aaadadadadadadadaiaiahahahahahahahahbxahahahahahahahbxahbwahahahahahahajajajafafafafafafac
+aaadadadadadadadadaiahahahahahahahahbxahahahahahahahbxahahahahahahahahajafafafafafafafafac
+aaadadadadadadadadaiahahahahahahahahbxahahahahahahahbBahahahahahahajajafafafafafafafafafac
+aaadadadadadadadadaiaiahahahahahahahbxahahahahahahahbxahahahahbCbCafafafafafafafafafafafac
+aaadadadadadadadadadaiahahahahahahahbBahahahahahahahbxahahahahbCbDbDbDafafafafafafafafafac
+aaadadadadadadadadadaiaiahahahahahahbxbxbxbBbxbxbxbxbxahahahahbCbDbDbDafafafafafafafafafac
+aaadadadadadadadadadadbCahahahahahahahahahahahahahahahahahahbCbCbDbDbDbDafafafafafafafafac
+aaadadadadadadadadadbDbDbCbCahahahahahahahahahahahahahahahahbCbDbDbDbDbDafafafafafafafafac
+aaadadadadadadadadadbDbDbDbCbCahahahahahahahahahahahahahahbCbCbDbDbDbDbDbDbDafafafafafafac
+aaadadadadadadadadadbDbDbDbDbCbCbCbCbCbCbCbCbCbCbCbCbCbCbCbCbDbDbDbDbDbDbDbDafafafafafafac
+aaadadadadadadbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDafafafafafafac
+aaadadadadadbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDafafafafafac
+aaadadadadadbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDafafafac
+aaadadbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDafafafac
+aaadadbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDafac
+aaadadbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDbDac
+bEbEbEbEbEbEbEbEbEbEbEbEbEbEbEbEbEbEbEbEbEbEbEbEbEbEbEbEbEbEbEbEbEbEbEbEbEbEbEbEbEbEbEbEbE
 "}

--- a/maps/randomvaults/dungeons/mecha_graveyard.dmm
+++ b/maps/randomvaults/dungeons/mecha_graveyard.dmm
@@ -1,114 +1,119 @@
-"aa" = (/turf/unsimulated/wall/void,/area)
-"ab" = (/turf/space,/area)
-"ac" = (/turf/simulated/wall,/area/vault/mecha_graveyard)
-"ad" = (/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
-"ae" = (/turf/unsimulated/mineral/random,/area/vault/mecha_graveyard)
-"af" = (/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
-"ag" = (/obj/item/stack/rods,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
-"ah" = (/obj/effect/decal/cleanable/dirt,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
-"ai" = (/turf/unsimulated/floor/asteroid{icon_state = "asteroid_dug"},/area/vault/mecha_graveyard)
-"aj" = (/obj/effect/decal/cleanable/blood/gibs/robot,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
-"ak" = (/obj/structure/hanging_lantern{dir = 1},/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
-"al" = (/obj/effect/decal/cleanable/blood/gibs/robot/limb,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
-"am" = (/obj/item/weapon/ore/glass,/turf/unsimulated/floor/asteroid{icon_state = "asteroid_dug"},/area/vault/mecha_graveyard)
-"an" = (/obj/effect/decal/mecha_wreckage/graveyard_ripley,/turf/unsimulated/floor/asteroid{icon_state = "asteroid_dug"},/area/vault/mecha_graveyard)
-"ao" = (/obj/effect/decal/cleanable/soot,/turf/unsimulated/floor/asteroid{icon_state = "asteroid_dug"},/area/vault/mecha_graveyard)
-"ap" = (/obj/item/weapon/ore/iron,/turf/unsimulated/floor/asteroid{icon_state = "asteroid_dug"},/area/vault/mecha_graveyard)
-"aq" = (/obj/structure/hanging_lantern,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
-"ar" = (/obj/effect/decal/mecha_wreckage/graveyard_ripley,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
-"as" = (/obj/structure/girder,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
-"at" = (/obj/structure/girder,/obj/item/stack/rods,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
-"au" = (/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"; dir = 1},/area/vault/mecha_graveyard)
-"av" = (/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"; dir = 5},/area/vault/mecha_graveyard)
-"aw" = (/obj/effect/decal/cleanable/blood/gibs/robot/down,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
-"ax" = (/obj/effect/decal/cleanable/ash,/turf/unsimulated/floor/asteroid{icon_state = "asteroid_dug"},/area/vault/mecha_graveyard)
-"ay" = (/obj/effect/decal/cleanable/blood/gibs/robot,/turf/unsimulated/floor/asteroid{icon_state = "asteroid_dug"},/area/vault/mecha_graveyard)
-"az" = (/obj/machinery/status_display{pixel_y = 32},/obj/effect/decal/mecha_wreckage/durand,/obj/effect/decal/cleanable/soot,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
-"aA" = (/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"; dir = 4},/area/vault/mecha_graveyard)
-"aB" = (/obj/item/stack/sheet/plasteel,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
-"aC" = (/obj/effect/decal/mecha_wreckage/marauder,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
-"aD" = (/obj/item/mecha_parts/mecha_equipment/repair_droid,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
-"aE" = (/obj/effect/decal/cleanable/blood/gibs/robot,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
-"aF" = (/obj/item/weapon/ore/slag,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
-"aG" = (/obj/effect/decal/cleanable/soot,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
-"aH" = (/obj/effect/decal/mecha_wreckage/durand,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
-"aI" = (/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"; dir = 10},/area/vault/mecha_graveyard)
-"aJ" = (/obj/effect/decal/cleanable/dirt,/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"},/area/vault/mecha_graveyard)
-"aK" = (/obj/effect/decal/mecha_wreckage/gygax,/obj/effect/decal/cleanable/soot,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
-"aL" = (/obj/effect/decal/cleanable/ash,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
-"aM" = (/obj/structure/grille/broken,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
-"aN" = (/obj/structure/hanging_lantern{dir = 8},/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
-"aO" = (/obj/effect/decal/cleanable/blood/oil,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
-"aP" = (/obj/structure/disposalpipe/segment{dir = 4},/obj/item/weapon/broken_pipe_tomahawk,/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"; dir = 4},/area/vault/mecha_graveyard)
-"aQ" = (/obj/structure/disposalpipe/segment{dir = 4},/turf/unsimulated/floor/asteroid/plating,/area/vault/mecha_graveyard)
-"aR" = (/obj/effect/decal/cleanable/blood/gibs/robot/up,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
-"aS" = (/obj/item/broken_device,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
-"aT" = (/obj/structure/hanging_lantern{dir = 4},/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"; dir = 9},/area/vault/mecha_graveyard)
-"aU" = (/obj/structure/reagent_dispensers/fueltank,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
-"aV" = (/obj/structure/ore_box,/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"; dir = 8},/area/vault/mecha_graveyard)
-"aW" = (/obj/structure/grille,/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced{dir = 4},/obj/structure/window/reinforced{dir = 8},/obj/structure/window/reinforced,/obj/structure/window/full/reinforced,/turf/simulated/floor/plating,/area/vault/mecha_graveyard)
-"aX" = (/obj/effect/decal/remains/human,/turf/simulated/floor/airless{icon_state = "damaged5"},/area/vault/mecha_graveyard)
-"aY" = (/obj/effect/decal/mecha_wreckage/graveyard_clarke,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
-"aZ" = (/turf/unsimulated/floor/airless{icon_state = "asteroidplating"},/area/vault/mecha_graveyard)
-"ba" = (/obj/effect/decal/cleanable/blood/gibs/robot/limb,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
-"bb" = (/obj/item/weapon/broken_bottle,/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"; dir = 8},/area/vault/mecha_graveyard)
-"bc" = (/obj/machinery/door/airlock/external,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
-"bd" = (/obj/item/weapon/screwdriver,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
-"be" = (/obj/machinery/mech_bay_recharge_port,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
-"bf" = (/obj/machinery/mech_bay_recharge_floor{icon_state = "recharge_floor_asteroid"},/turf/simulated/floor,/area/vault/mecha_graveyard)
-"bg" = (/obj/machinery/computer/mech_bay_power_console,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
-"bh" = (/obj/item/clothing/glasses/scanner/meson,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
-"bi" = (/obj/structure/girder/displaced,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
-"bj" = (/obj/item/clothing/shoes/galoshes/broken,/turf/unsimulated/floor/airless{icon_state = "asteroidplating"},/area/vault/mecha_graveyard)
-"bk" = (/obj/machinery/mineral/unloading_machine,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
-"bl" = (/obj/machinery/conveyor{dir = 4; id_tag = "mining_west"},/obj/item/stack/sheet/plasteel,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
-"bm" = (/obj/machinery/conveyor{dir = 4; id_tag = "mining_west"},/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
-"bn" = (/obj/item/weapon/shard,/turf/space,/area)
-"bo" = (/obj/item/weapon/shard{icon_state = "small"},/turf/space,/area)
-"bp" = (/obj/structure/lattice,/turf/space,/area)
-"bq" = (/obj/docking_port/destination/vault/mecha_graveyard{dir = 2},/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
-"br" = (/obj/item/weapon/shard{icon_state = "medium"},/turf/space,/area)
-"bs" = (/obj/item/weapon/shard{icon_state = "medium"},/obj/item/weapon/shard,/turf/space,/area)
+"aa" = (/turf/space/transit/north,/area)
+"ab" = (/turf/space/transit/east,/area)
+"ac" = (/turf/space/transit/west,/area)
+"ad" = (/turf/space,/area)
+"ae" = (/turf/simulated/wall,/area/vault/mecha_graveyard)
+"af" = (/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"ag" = (/turf/unsimulated/mineral/random,/area/vault/mecha_graveyard)
+"ah" = (/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"ai" = (/obj/item/stack/rods,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"aj" = (/obj/effect/decal/cleanable/dirt,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"ak" = (/turf/unsimulated/floor/asteroid{icon_state = "asteroid_dug"},/area/vault/mecha_graveyard)
+"al" = (/obj/effect/decal/cleanable/blood/gibs/robot,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"am" = (/obj/structure/hanging_lantern{dir = 1},/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"an" = (/obj/effect/decal/cleanable/blood/gibs/robot/limb,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"ao" = (/obj/item/weapon/ore/glass,/turf/unsimulated/floor/asteroid{icon_state = "asteroid_dug"},/area/vault/mecha_graveyard)
+"ap" = (/obj/effect/decal/mecha_wreckage/graveyard_ripley,/turf/unsimulated/floor/asteroid{icon_state = "asteroid_dug"},/area/vault/mecha_graveyard)
+"aq" = (/obj/effect/decal/cleanable/soot,/turf/unsimulated/floor/asteroid{icon_state = "asteroid_dug"},/area/vault/mecha_graveyard)
+"ar" = (/obj/item/weapon/ore/iron,/turf/unsimulated/floor/asteroid{icon_state = "asteroid_dug"},/area/vault/mecha_graveyard)
+"as" = (/obj/structure/hanging_lantern,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"at" = (/obj/effect/decal/mecha_wreckage/graveyard_ripley,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"au" = (/obj/structure/girder,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"av" = (/obj/structure/girder,/obj/item/stack/rods,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"aw" = (/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"; dir = 1},/area/vault/mecha_graveyard)
+"ax" = (/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"; dir = 5},/area/vault/mecha_graveyard)
+"ay" = (/obj/effect/decal/cleanable/blood/gibs/robot/down,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"az" = (/obj/effect/decal/cleanable/ash,/turf/unsimulated/floor/asteroid{icon_state = "asteroid_dug"},/area/vault/mecha_graveyard)
+"aA" = (/obj/effect/decal/cleanable/blood/gibs/robot,/turf/unsimulated/floor/asteroid{icon_state = "asteroid_dug"},/area/vault/mecha_graveyard)
+"aB" = (/obj/machinery/status_display{pixel_y = 32},/obj/effect/decal/mecha_wreckage/durand,/obj/effect/decal/cleanable/soot,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"aC" = (/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"; dir = 4},/area/vault/mecha_graveyard)
+"aD" = (/obj/item/stack/sheet/plasteel,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"aE" = (/obj/effect/decal/mecha_wreckage/marauder,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"aF" = (/obj/item/mecha_parts/mecha_equipment/repair_droid,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"aG" = (/obj/effect/decal/cleanable/blood/gibs/robot,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"aH" = (/obj/item/weapon/ore/slag,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"aI" = (/obj/effect/decal/cleanable/soot,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"aJ" = (/obj/effect/decal/mecha_wreckage/durand,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"aK" = (/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"; dir = 10},/area/vault/mecha_graveyard)
+"aL" = (/obj/effect/decal/cleanable/dirt,/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"},/area/vault/mecha_graveyard)
+"aM" = (/obj/effect/decal/mecha_wreckage/gygax,/obj/effect/decal/cleanable/soot,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"aN" = (/obj/effect/decal/cleanable/ash,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"aO" = (/obj/structure/grille/broken,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"aP" = (/obj/structure/hanging_lantern{dir = 8},/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"aQ" = (/obj/effect/decal/cleanable/blood/oil,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"aR" = (/obj/structure/disposalpipe/segment{dir = 4},/obj/item/weapon/broken_pipe_tomahawk,/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"; dir = 4},/area/vault/mecha_graveyard)
+"aS" = (/obj/structure/disposalpipe/segment{dir = 4},/turf/unsimulated/floor/asteroid/plating,/area/vault/mecha_graveyard)
+"aT" = (/obj/effect/decal/cleanable/blood/gibs/robot/up,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"aU" = (/obj/item/broken_device,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"aV" = (/obj/structure/hanging_lantern{dir = 4},/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"; dir = 9},/area/vault/mecha_graveyard)
+"aW" = (/obj/structure/reagent_dispensers/fueltank,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"aX" = (/obj/structure/ore_box,/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"; dir = 8},/area/vault/mecha_graveyard)
+"aY" = (/obj/structure/grille,/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced{dir = 4},/obj/structure/window/reinforced{dir = 8},/obj/structure/window/reinforced,/obj/structure/window/full/reinforced,/turf/simulated/floor/plating,/area/vault/mecha_graveyard)
+"aZ" = (/obj/effect/decal/remains/human,/turf/simulated/floor/airless{icon_state = "damaged5"},/area/vault/mecha_graveyard)
+"ba" = (/obj/effect/decal/mecha_wreckage/graveyard_clarke,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"bb" = (/turf/unsimulated/floor/airless{icon_state = "asteroidplating"},/area/vault/mecha_graveyard)
+"bc" = (/obj/effect/decal/cleanable/blood/gibs/robot/limb,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"bd" = (/obj/item/weapon/broken_bottle,/turf/unsimulated/floor/airless{icon_state = "asteroidwarning"; dir = 8},/area/vault/mecha_graveyard)
+"be" = (/obj/machinery/door/airlock/external,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"bf" = (/obj/item/weapon/screwdriver,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"bg" = (/obj/machinery/mech_bay_recharge_port,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"bh" = (/obj/machinery/mech_bay_recharge_floor{icon_state = "recharge_floor_asteroid"},/turf/simulated/floor,/area/vault/mecha_graveyard)
+"bi" = (/obj/machinery/computer/mech_bay_power_console,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"bj" = (/obj/item/clothing/glasses/scanner/meson,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"bk" = (/obj/structure/girder/displaced,/turf/unsimulated/floor/asteroid,/area/vault/mecha_graveyard)
+"bl" = (/obj/item/clothing/shoes/galoshes/broken,/turf/unsimulated/floor/airless{icon_state = "asteroidplating"},/area/vault/mecha_graveyard)
+"bm" = (/obj/machinery/mineral/unloading_machine,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"bn" = (/obj/machinery/conveyor{dir = 4; id_tag = "mining_west"},/obj/item/stack/sheet/plasteel,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"bo" = (/obj/machinery/conveyor{dir = 4; id_tag = "mining_west"},/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"bp" = (/turf/unsimulated/floor/airless{icon_state = "asteroidplating"},/area)
+"bq" = (/obj/item/weapon/shard,/turf/unsimulated/floor/airless{icon_state = "asteroidplating"},/area)
+"br" = (/obj/item/weapon/shard{icon_state = "small"},/turf/space,/area)
+"bs" = (/obj/structure/lattice,/turf/space,/area)
+"bt" = (/obj/docking_port/destination/vault/mecha_graveyard{dir = 2},/obj/machinery/door/airlock/external,/turf/unsimulated/floor/airless{icon_state = "asteroidfloor"},/area/vault/mecha_graveyard)
+"bu" = (/obj/item/weapon/shard{icon_state = "medium"},/turf/space,/area)
+"bv" = (/obj/item/weapon/shard{icon_state = "medium"},/obj/item/weapon/shard,/turf/space,/area)
+"bw" = (/turf/space/transit/south,/area)
+"bx" = (/obj/structure/lattice,/obj/structure/girder,/turf/space,/area)
 
 (1,1,1) = {"
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaababababababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabababababababababababaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaabababababababababababababababababababababaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaabababababababababababababababababababababababababababababaaaaaaaaaa
-aaaaaaaaaaabababababababacacacadadadadaeaeaeaeababababababababababababaaaaaaaaaa
-aaaaaaabababababababababafafacadadadadaeaeaeaeabababababababababababaaaaaaaaaaaa
-aaaaabababababababababagadahacadadadaiaeaeaeaeaeaeaeaeabababababababaaaaaaaaaaaa
-aaaaababababababababadadadajakadadaiaiaiaiaeaeaeaeaeaeabababababababaaaaaaaaaaaa
-aaaaababababababadadadaladadadadadamamaiaiaianaeaeaeaeaeaeaeababababaaaaaaaaaaaa
-aaaaabababababadadadadadadadagadadaiamaiaoaiapaiaiaiaiaiadadababababaaaaaaaaaaaa
-aaaaabababababadadafadadadadadadaeaiapapaiamamaiaiaiapaiadadababababaaaaaaaaaaaa
-aaabababababadadadafaqadadadadaeaeaeaearapamamaiapaiamajadadababababaaaaaaaaaaaa
-aaabababababasadatacacacauavawadaeaeaeaeapaiaxaiayaiaiaiaiaiababababaaaaaaaaaaaa
-aaababababadadauadazafafafaAadadaBaeaeaeaiadaiamaiaiaiaiaiaiababababababaaaaaaaa
-aaababababaCadahaDafafaEahaAagadafaeaeaFadadadaGadadadaiaeabababababababaaaaaaaa
-aaababababadaHaIaJafafaKafaAadadadadaLadadadadadadadadaeaeabababababababaaaaaaaa
-aaabababababadadaMacacaNaOaPaQadaRafaSadaTacacacadadadabababababababababaaaaaaaa
-aaababababababasadagaBasaUadadagadafadafaVaWaXaYadababababababababababaaaaaaaaaa
-aaaaababababababadadadacaZaZaZaZadafadbabbbcaObdabababababababababababaaaaaaaaaa
-aaaaaaaaababababababababaZbebfbgadafadbhaIbiagajabababababababababababaaaaaaaaaa
-aaaaaaaaababababababababaZbjaZaZafaRadbkblbmbiadababababababababababaaaaaaaaaaaa
-aaaaaaaaaaaaababababababababagadafadadadabbnabboababababababababababaaaaaaaaaaaa
-aaaaaaaaaaaaabababababababbpadadadbqadadbpbpbrabbsababababababababaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaabababababbpabababababababbpabboababababababaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaabababababbpabababababababbpababababababababaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaabababbpabababababababbpababababababaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaabababbpabababababababbpababababaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaabababbpabababababababbpababababaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaabababbpbpbpbpbpbpbpbpbpababababaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaababababababababababababababababaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaababababababababababababababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaababababababababababababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabab
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabab
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaababab
+acaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaababab
+acacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaababababab
+acacacaaaaaaaaaaaaaaaaaaaaaaaaadadadadadadaaaaaaaaaaaaaaaaaaaaaaaaaaaaababababab
+acacacaaaaaaaaaaaaaaaaaaaaaaaaadadadadadadadadadadadaaaaaaaaaaaaaaaaabababababab
+acacacacacacaaaaadadadadadadadadadadadadadadadadadadadadadaaaaaaaaababababababab
+acacacacacacadadadadadadadadadadadadadadadadadadadadadadadadadadadadadababababab
+acacacacacadadadadadadadaeaeaeafafafafagagagagadadadadadadadadadadadadababababab
+acacacadadadadadadadadadahahaeafafafafagagagagadadadadadadadadadadadabababababab
+acacadadadadadadadadadaiafajaeafafafakagagagagagagagagadadadadadadadabababababab
+acacadadadadadadadadafafafalamafafakakakakagagagagagagadadadadadadadabababababab
+acacadadadadadadafafafanafafafafafaoaoakakakapagagagagagagagadadadadabababababab
+acacadadadadadafafafafafafafaiafafakaoakaqakarakakakakakafafadadadadabababababab
+acacadadadadadafafahafafafafafafagakararakaoaoakakakarakafafadadadadabababababab
+acadadadadadafafafahasafafafafagagagagataraoaoakarakaoalafafadadadadabababababab
+acadadadadadauafavaeaeaeawaxayafagagagagarakazakaAakakakakakadadadadabababababab
+acadadadadafafawafaBahahahaCafafaDagagagakafakaoakakakakakakadadadadadadabababab
+acadadadadaEafajaFahahaGajaCaiafahagagaHafafafaIafafafakagadadadadadadadabababab
+acadadadadafaJaKaLahahaMahaCafafafafaNafafafafafafafafagagadadadadadadadabababab
+acadadadadadafafaOaeaeaPaQaRaSafaTahaUafaVaeaeaeafafafadadadadadadadadadabababab
+acadadadadadadauafaiaDauaWafafaiafahafahaXaYaZbaafadadadadadadadadadadababababab
+acacadadadadadadafafafaebbbbbbbbafahafbcbdbeaQbfadadadadadadadadadadadababababab
+acacacacadadadadadadadadbbbgbhbiafahafbjaKbkaialadadadadadadadadadadadababababab
+acacacacadadadadadadadadbbblbbbbahaTafbmbnbobkafadadadadadadadadadadabababababab
+acacacacacacadadadadadadadadaiafahafafafbpbqadbradadadadadadadadadadabababababab
+acacacacacacadadadadadadadbsafaeaebtaeaubsbsbuadbvadadadadadadadadababababababab
+acacacacacacacacadadadadadbsadadadadadadadbsadbradadadadadadabababababababababab
+acacacacacacacacadadadadadbsadadadadadadadbsadadadadadadadadabababababababababab
+acacacacacacacacbwbwadadadbsadadadadadadadbxadadadadadadbwbwabababababababababab
+acacacacacacacacbwbwadadadbsadadadadadadadbsadadadadbwbwbwbwbwbwabababababababab
+acacacacacacacacbwbwadadadbxadadadadadadadbsadadadadbwbwbwbwbwbwabababababababab
+acacacacacbwbwbwbwbwadadadbsbsbsbxbsbsbsbsbsadadadadbwbwbwbwbwbwbwbwabababababab
+acacacacbwbwbwbwbwbwadadadadadadadadadadadadadadadadbwbwbwbwbwbwbwbwabababababab
+acacacacbwbwbwbwbwbwbwadadadadadadadadadadadadadadbwbwbwbwbwbwbwbwbwbwbwabababab
+acacbwbwbwbwbwbwbwbwbwadadadadadadadadadadadadbwbwbwbwbwbwbwbwbwbwbwbwbwabababab
+acacbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwabab
+acacbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwab
+bwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbwbw
 "}


### PR DESCRIPTION
![untitled](https://user-images.githubusercontent.com/9782036/36340109-e11c1b90-139a-11e8-8a40-cd30619be1b3.png)

Mecha graveyard has several mechas you can salvage for parts, but the 2 RIPLEYs and CLARK have been extra beefed up to be sure to drop plenty of goodies. **Important note: the trader shuttle cannot go to the mecha graveyard, only the mining or research shuttle will fit the dock.**

Wonderful Wardrobe can end up getting stuff like thermals, vampire cape, security plasmaman suit, cat morphing mask, medal of captaincy, advanced hardsuit helmet, security sunglasses... or even just 19 random worthless jumpsuits and a maid outfit... It uses the completely unaltered list from Spessmart. This might need more blacklisting or less items, I'll let github help me decide on that. Just remember it is a premium item so it should have a chance for *something* exciting. I think 20 is a safe number because in a set I usually see 2-3 "exciting" items, like the ones mentioned above (that's everything of note from 3 wardrobe spawns)

🆑 
* tweak: Replaced box of marauder parts at the trader vendor with a destination disk for a mecha graveyard full of wonderful salvageable robotics stuff. Bring your toolbelt and a suit!
* tweak: Replaced bottle of nanobots, bottle of rezadone, and bottle of peridazon with a box containing all three
* rscadd: Added the Wonderful Wardrobe. It contains 20 random Spessmart approved clothing items.