### PR TITLE
Allows Traders to Latejoin

### DIFF
--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -181,8 +181,8 @@ var/datum/controller/gameticker/ticker
 		mode.post_setup()
 		//Cleanup some stuff
 		for(var/obj/effect/landmark/start/S in landmarks_list)
-			//Deleting Startpoints but we need the ai point to AI-ize people later
-			if (S.name != "AI")
+			//Deleting Startpoints but we need the ai point to AI-ize people later and the Trader point to throw new ones
+			if (S.name != "AI" && S.name != "Trader")
 				qdel(S)
 		var/list/obj/effect/landmark/spacepod/random/L = list()
 		for(var/obj/effect/landmark/spacepod/random/SS in landmarks_list)

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -56,6 +56,7 @@
 	var/no_id = 0 //If 1, don't spawn with an ID
 	var/no_pda= 0 //If 1, don't spawn with a PDA
 	var/no_headset = 0 //If 1, don't spawn with a headset
+	//Throwing latejoin is handled in new_player, list of jobs at line 312
 
 	var/no_random_roll = 0 //If 1, don't select this job randomly!
 

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -56,7 +56,7 @@
 	var/no_id = 0 //If 1, don't spawn with an ID
 	var/no_pda= 0 //If 1, don't spawn with a PDA
 	var/no_headset = 0 //If 1, don't spawn with a headset
-	//Throwing latejoin is handled in new_player, list of jobs at line 312
+	var/spawns_from_edge = 0 //Instead of spawning on the shuttle, spawns in space and gets thrown
 
 	var/no_random_roll = 0 //If 1, don't select this job randomly!
 

--- a/code/game/jobs/job/whitelisted.dm
+++ b/code/game/jobs/job/whitelisted.dm
@@ -21,6 +21,8 @@
 	no_starting_money = 1
 	no_pda = 1
 
+	spawns_from_edge = 1
+
 	idtype = /obj/item/weapon/card/id/vox
 
 	no_headset = 1

--- a/code/game/jobs/job/whitelisted.dm
+++ b/code/game/jobs/job/whitelisted.dm
@@ -27,8 +27,6 @@
 
 	no_headset = 1
 
-	//Throwing latejoin is handled in new_player, list of jobs at line 312
-
 /datum/job/trader/equip(var/mob/living/carbon/human/H)
 	if(!H)
 		return 0

--- a/code/game/jobs/job/whitelisted.dm
+++ b/code/game/jobs/job/whitelisted.dm
@@ -3,7 +3,7 @@
 	flag = TRADER
 	department_flag = CIVILIAN
 	faction = "Station"
-	total_positions = 0
+	total_positions = 3
 	spawn_positions = 3
 	supervisors = "nobody"
 	selection_color = "#dddddd"
@@ -24,6 +24,8 @@
 	idtype = /obj/item/weapon/card/id/vox
 
 	no_headset = 1
+
+	//Throwing latejoin is handled in new_player, list of jobs at line 312
 
 /datum/job/trader/equip(var/mob/living/carbon/human/H)
 	if(!H)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -309,8 +309,6 @@
 		if(prob(10)) // 10% of those have a good mut.
 			H.dna.GiveRandomSE(notflags = GENE_UNNATURAL,genetype = GENETYPE_GOOD)
 
-var/global/list/meteor_spawn = list("Trader")
-
 /mob/new_player/proc/AttemptLateSpawn(rank)
 	if (src != usr)
 		return 0

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -333,8 +333,8 @@ var/global/list/meteor_spawn = list("Trader")
 	job_master.EquipRank(character, rank, 1)					//equips the human
 	EquipCustomItems(character)
 
-	// TODO:  Job-specific latejoin overrides.
-	if(meteor_spawn.Find(character.mind.assigned_role))
+	var/datum/job/J = GetJob(rank)
+	if(J.spawns_from_edge)
 		character.Meteortype_Latejoin(rank)
 	else
 		character.forceMove(pick((assistant_latejoin.len > 0 && rank == "Assistant") ? assistant_latejoin : latejoin))
@@ -368,7 +368,18 @@ var/global/list/meteor_spawn = list("Trader")
 	if(character.mind.assigned_role != "Cyborg")
 		data_core.manifest_inject(character)
 		ticker.minds += character.mind//Cyborgs and AIs handle this in the transform proc.	//TODO!!!!! ~Carn
-		if(!meteor_spawn.Find(character.mind.assigned_role))
+		if(character.mind.assigned_role == "Trader")
+			//If we're a trader, instead send a message to PDAs with the trader cartridge
+			for (var/obj/item/device/pda/P in PDAs)
+				if(istype(P.cartridge,/obj/item/weapon/cartridge/trader))
+					var/mob/living/L = get_holder_of_type(P,/mob/living)
+					if(L)
+						L.show_message("[bicon(P)] <b>Message from U¶ü…8•E1¿”–ã (T•u1B§’), </b>\"Caw. Cousin [character] detected in sector.\".", 2)
+			for(var/mob/dead/observer/M in player_list)
+				if(M.stat == DEAD && M.client)
+					handle_render(M,"<span class='game say'>PDA Message - <span class='name'>Trader [character] has arrived in the sector from space.</span></span>",character) //This should generate a Follow link
+
+		else
 			AnnounceArrival(character, rank)
 		FuckUpGenes(character)
 	else


### PR DESCRIPTION
Instead of spawning on the arrival shuttle...
* There is no arrival announcement
* Traders will spawn at the left edge of the mining Z-level in space and get HURLED AT HIGH SPEED toward the trade outpost (or, on meta, the crashed ship)
* The impact causes minor brute damage and usually bounces the new player one tile into space, so they will usually need to sacrifice an item like throwing a donk pocket in order to move

After hitting land, they'll need to wander along the asteroid in search of their outpost. I feel this is sufficiently ghetto to warrant latejoins - and after all, with the long shifts we've been having lately I rarely see traders.

🆑 
* rscadd: Traders can now latejoin (up to three slots). Doing so will hurl them through space toward the outpost, so be sure you can navigate the asteroid if you choose this option!