### PR TITLE
Trader access on trader air alarms

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -95,7 +95,8 @@
 
 /obj/machinery/alarm/vox
 	preset = AALARM_PRESET_VOX
-	req_access = list()
+	req_one_access = list()
+	req_access = list(access_trade)
 
 /obj/machinery/alarm/proc/apply_preset(var/no_cycle_after=0)
 	// Propogate settings.


### PR DESCRIPTION
Whoever set this up tried to make them free access to anyone, but it's bugged because they didn't clear `req_one_access`. There's a choice here between giving them trader access and free access, and I went with the former. I don't really care either way.
:cl:
* tweak: Trader outpost air alarms require trader access now.