### PR TITLE
ROLE DATUMS - rounds now actually end

### DIFF
--- a/code/datums/gamemode/gamemode.dm
+++ b/code/datums/gamemode/gamemode.dm
@@ -197,5 +197,9 @@
 	for(var/datum/faction/F in factions)
 		if(F.check_win())
 			return 1
+	if(emergency_shuttle.location==2 || station_was_nuked)
+		return 1
+	return 0
+
 
 /datum/gamemode/proc/declare_completion()


### PR DESCRIPTION
turns out, back in the way back when, it would keep checking the game mode to see if the emergency shuttle had arrived, or the station had been nuked.