### PR TITLE
Role Panel addendum

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult_items.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_items.dm
@@ -144,10 +144,12 @@
 	autoignition_temperature = AUTOIGNITION_PAPER
 	fire_fuel = 1
 
+/*
 /obj/item/weapon/bloodcult_pamphlet/attack_self(var/mob/user)
 	initialize_cultwords()
 	var/datum/faction/bloodcult/cult = find_active_faction(BLOODCULT)
 	if (cult)
 		cult.HandleRecruitedMind(user.mind)
-	user.add_spell(new /spell/trace_rune, "cult_spell_ready", /obj/abstract/screen/movable/spell_master/bloodcult)
-	user.add_spell(new /spell/erase_rune, "cult_spell_ready", /obj/abstract/screen/movable/spell_master/bloodcult)
+	user.add_spell(new /spell/cult/trace_rune, "cult_spell_ready", /obj/abstract/screen/movable/spell_master/bloodcult)
+	user.add_spell(new /spell/cult/erase_rune, "cult_spell_ready", /obj/abstract/screen/movable/spell_master/bloodcult)
+*/

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_spells.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_spells.dm
@@ -1,6 +1,6 @@
 
 //SPELL I
-/spell/trace_rune
+/spell/cult/trace_rune
 	name = "Trace Rune"
 	desc = "Use available blood to write down words. Three words form a rune."
 	panel = "Cult"
@@ -21,11 +21,11 @@
 	var/datum/cultword/word = null
 	var/obj/effect/rune/rune = null
 
-/spell/trace_rune/choose_targets(var/mob/user = usr)
+/spell/cult/trace_rune/choose_targets(var/mob/user = usr)
 	return list(user)
 
 
-/spell/trace_rune/before_channel(mob/user)
+/spell/cult/trace_rune/before_channel(mob/user)
 	var/mob/living/carbon/C = user
 	var/muted = C.muted()
 	if (muted)
@@ -33,7 +33,7 @@
 	return muted
 
 
-/spell/trace_rune/spell_do_after(var/mob/user, var/delay, var/numticks = 3)
+/spell/cult/trace_rune/spell_do_after(var/mob/user, var/delay, var/numticks = 3)
 
 	if(block)
 		return 0
@@ -74,7 +74,7 @@
 
 	return ..()
 
-/spell/trace_rune/cast(var/list/targets, var/mob/living/carbon/user)
+/spell/cult/trace_rune/cast(var/list/targets, var/mob/living/carbon/user)
 	..()
 	if (rune && rune.word1 && rune.word2 && rune.word3)
 		to_chat(user, "<span class='warning'>You cannot add more than 3 words to a rune.</span>")
@@ -83,7 +83,7 @@
 		perform(user)//imediately try writing another word
 
 //SPELL II
-/spell/erase_rune
+/spell/cult/erase_rune
 	name = "Erase Rune"
 	desc = "Remove the last word written of the rune you're standing above."
 	panel = "Cult"
@@ -100,10 +100,10 @@
 
 	cast_delay = 0
 
-/spell/erase_rune/choose_targets(var/mob/user = usr)
+/spell/cult/erase_rune/choose_targets(var/mob/user = usr)
 	return list(user)
 
-/spell/erase_rune/cast(var/list/targets, var/mob/living/carbon/user)
+/spell/cult/erase_rune/cast(var/list/targets, var/mob/living/carbon/user)
 	..()
 	var/removed_word = erase_rune_word(get_turf(user))
 	if (removed_word)

--- a/code/datums/gamemode/role/cultist.dm
+++ b/code/datums/gamemode/role/cultist.dm
@@ -4,13 +4,20 @@
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Chaplain", "Head of Personnel", "Internal Affairs Agent")
 	logo_state = "cult-logo"
 
+
 /datum/role/cultist/OnPostSetup()
 	. = ..()
 	if(!.)
 		return
 
-	antag.current.add_spell(new /spell/trace_rune, "cult_spell_ready", /obj/abstract/screen/movable/spell_master/bloodcult)
-	antag.current.add_spell(new /spell/erase_rune, "cult_spell_ready", /obj/abstract/screen/movable/spell_master/bloodcult)
+	if(!(locate(/spell/cult) in antag.current.spell_list))
+		antag.current.add_spell(new /spell/cult/trace_rune, "cult_spell_ready", /obj/abstract/screen/movable/spell_master/bloodcult)
+		antag.current.add_spell(new /spell/cult/erase_rune, "cult_spell_ready", /obj/abstract/screen/movable/spell_master/bloodcult)
+
+/datum/role/cultist/RemoveFromRole(var/datum/mind/M)
+	for(var/spell/cult/spell_to_remove in antag.current.spell_list)
+		antag.current.remove_spell(spell_to_remove)
+	..()
 
 /datum/role/cultist/Greet()
 	to_chat(antag.current, {"<span class='sinister'><font size=3>You are a cultist of <span class='danger'><font size=3>Nar-Sie</font></span>!</font><br>

--- a/code/datums/gamemode/role/role.dm
+++ b/code/datums/gamemode/role/role.dm
@@ -192,10 +192,11 @@
 	return 1
 
 // Return 1 on success, 0 on failure.
-/datum/role/proc/OnPostSetup()
-	ForgeObjectives()
-	Greet(1)
-	MemorizeObjectives()
+/datum/role/proc/OnPostSetup(var/auto_antag = TRUE)
+	if (auto_antag)
+		ForgeObjectives()
+		Greet(1)
+		MemorizeObjectives()
 	return 1
 
 /datum/role/proc/process()

--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -46,6 +46,15 @@
 		var/spell/S = new type_S
 		antag.current.add_spell(S)
 
+/datum/role/vampire/RemoveFromRole(var/datum/mind/M)
+	for(var/spell/spell in antag.current.spell_list)
+		if (is_type_in_list(spell,roundstart_spells))//TODO: HAVE A LIST WITH EVERY VAMPIRE SPELLS
+			antag.current.remove_spell(spell)
+	if(antag.current.client && antag.current.hud_used)
+		if(antag.current.hud_used.vampire_blood_display)
+			antag.current.client.screen -= list(antag.current.hud_used.vampire_blood_display)
+	..()
+
 /* we're gonna have procedural faction generation to handle thralls and apprentices
 /datum/role/vampire/AdminPanelEntry()
 	. = ..()

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -475,6 +475,8 @@
 		if(!newRole.AssignToRole(src,1))//it shouldn't fail since we're using our admin powers to force the role
 			newRole.Drop()//but just in case
 
+		newRole.OnPostSetup(FALSE)//later we might make custom Greet() for admin-designated antags.
+
 	else if(href_list["role_edit"])
 		var/datum/role/R = locate(href_list["role_edit"])
 

--- a/code/world.dm
+++ b/code/world.dm
@@ -103,6 +103,8 @@ var/savefile/panicfile
 
 	paperwork_setup()
 
+	initialize_cultwords()
+
 	for(var/x in typesof(/datum/bee_species))
 		var/datum/bee_species/species = new x
 		bees_species[species.common_name] = species


### PR DESCRIPTION
 - [x] When adding or removing a role (such as vampire or cultist), hud, spells and abilities, are updated accordingly.
 - [x] When using the role panel to add or remove roles, no random objectives are created, and no greet messages are sent to the player.

also included:
* Cult words are now initialized at server start, commented out Cult Pamphlet debug item as it is now obsolete. Might re-add it later so non-admins can test Cult 3.0 in sandbox mode.

Todo in a later PR:
* Allow admins to send a custom greet message.