### PR TITLE
Material synth whitelist

### DIFF
--- a/code/game/objects/items/devices/mat_synth.dm
+++ b/code/game/objects/items/devices/mat_synth.dm
@@ -24,12 +24,13 @@
 									  "glass" = /obj/item/stack/sheet/glass/glass,
 									  "reinforced glass" = /obj/item/stack/sheet/glass/rglass,
 									  "plasteel" = /obj/item/stack/sheet/plasteel)
-	
+
 	var/list/can_scan = list(/obj/item/stack/sheet/metal,
 							/obj/item/stack/sheet/glass/,
 							/obj/item/stack/sheet/wood,
 							/obj/item/stack/sheet/plasteel,
 							/obj/item/stack/sheet/mineral)
+	var/list/cant_scan = list()
 	var/matter = 0
 
 /obj/item/device/material_synth/robot/engiborg //Cyborg version, has less materials but can make rods n shit as well as scan.
@@ -41,11 +42,7 @@
 
 /obj/item/device/material_synth/robot/engiborg/New() //We have to do this during New() because BYOND can't pull a typesof() during compile time.
 	. = ..()
-	can_scan = existing_typesof(list(/obj/item/stack/sheet/metal,
-							/obj/item/stack/sheet/glass/,
-							/obj/item/stack/sheet/wood,
-							/obj/item/stack/sheet/plasteel,
-							/obj/item/stack/sheet/mineral) - list(/obj/item/stack/sheet/mineral/clown, /obj/item/stack/sheet/mineral/phazon)
+	var/list/cant_scan = list(/obj/item/stack/sheet/mineral/clown, /obj/item/stack/sheet/mineral/phazon)
 
 /obj/item/device/material_synth/robot/mommi //MoMMI version, a few more materials to start with.
 	materials_scanned = list("metal" = /obj/item/stack/sheet/metal,
@@ -155,7 +152,7 @@
 /obj/item/device/material_synth/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	if(!proximity_flag)
 		return 0 // not adjacent
-	if(is_type_in_list(target, can_scan)) //Can_scan, can you?
+	if(is_type_in_list(target, can_scan) && !is_type_in_list(target, cant_scan))
 		for(var/matID in materials_scanned)
 			if(materials_scanned[matID] == target.type)
 				to_chat(user, "<span class='warning'>You have already scanned \the [target].</span>")

--- a/code/game/objects/items/devices/mat_synth.dm
+++ b/code/game/objects/items/devices/mat_synth.dm
@@ -42,7 +42,7 @@
 
 /obj/item/device/material_synth/robot/engiborg/New() //We have to do this during New() because BYOND can't pull a typesof() during compile time.
 	. = ..()
-	var/list/cant_scan = list(/obj/item/stack/sheet/mineral/clown, /obj/item/stack/sheet/mineral/phazon)
+	cant_scan = list(/obj/item/stack/sheet/mineral/clown, /obj/item/stack/sheet/mineral/phazon)
 
 /obj/item/device/material_synth/robot/mommi //MoMMI version, a few more materials to start with.
 	materials_scanned = list("metal" = /obj/item/stack/sheet/metal,

--- a/code/game/objects/items/devices/mat_synth.dm
+++ b/code/game/objects/items/devices/mat_synth.dm
@@ -24,7 +24,12 @@
 									  "glass" = /obj/item/stack/sheet/glass/glass,
 									  "reinforced glass" = /obj/item/stack/sheet/glass/rglass,
 									  "plasteel" = /obj/item/stack/sheet/plasteel)
-	var/list/can_scan = list(/obj/item/stack/sheet)
+	
+	var/list/can_scan = list(/obj/item/stack/sheet/metal,
+							/obj/item/stack/sheet/glass/,
+							/obj/item/stack/sheet/wood,
+							/obj/item/stack/sheet/plasteel,
+							/obj/item/stack/sheet/mineral)
 	var/matter = 0
 
 /obj/item/device/material_synth/robot/engiborg //Cyborg version, has less materials but can make rods n shit as well as scan.
@@ -36,7 +41,11 @@
 
 /obj/item/device/material_synth/robot/engiborg/New() //We have to do this during New() because BYOND can't pull a typesof() during compile time.
 	. = ..()
-	can_scan = existing_typesof(/obj/item/stack/sheet) - list(/obj/item/stack/sheet/mineral/clown, /obj/item/stack/sheet/mineral/phazon)
+	can_scan = existing_typesof(list(/obj/item/stack/sheet/metal,
+							/obj/item/stack/sheet/glass/,
+							/obj/item/stack/sheet/wood,
+							/obj/item/stack/sheet/plasteel,
+							/obj/item/stack/sheet/mineral) - list(/obj/item/stack/sheet/mineral/clown, /obj/item/stack/sheet/mineral/phazon)
 
 /obj/item/device/material_synth/robot/mommi //MoMMI version, a few more materials to start with.
 	materials_scanned = list("metal" = /obj/item/stack/sheet/metal,


### PR DESCRIPTION
Material synthesizers can now only scan the intended items.  Engineering borgs are blocked from scanning bananium and phazon in a new way.  

Whitelist:
/obj/item/stack/sheet/**metal**
/obj/item/stack/sheet/**glass**/,
/obj/item/stack/sheet/**wood**,
/obj/item/stack/sheet/**plasteel**,
/obj/item/stack/sheet/**mineral**
Mineral includes gold, plasma, plastic, phazon, et cetera.  If there's anything on this list you felt should have been included feel free to shout it out and call me an evil bastard destroying vgstation.


Resolves https://github.com/vgstation-coders/vgstation13/issues/16901

<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl:
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->

🆑 

* bugfix: Material synthesizers can no longer scan stuff like leather or cardboard.  