### PR TITLE
Fixes silicon view_photo()

### DIFF
--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -45,7 +45,7 @@
 /obj/item/weapon/photo/proc/photocreate(var/inicon, var/inimg, var/ininfo, var/inblueprints)
 	icon = inicon
 	img = inimg
-	desc = ininfo
+	info = ininfo
 	blueprints = inblueprints
 
 /obj/item/weapon/photo/attackby(obj/item/weapon/P, mob/user)


### PR DESCRIPTION
What a goof.

Fixes #17506 

:cl:
 * rscadd: Fixes silicons being unable to check the information of photos took by their cameras
