### PR TITLE
Adds MECH_SCAN_FAIL to the mysterious/cursed dice

### DIFF
--- a/code/game/objects/items/weapons/dice.dm
+++ b/code/game/objects/items/weapons/dice.dm
@@ -130,10 +130,11 @@
 
 
 /obj/item/weapon/dice/d20/cursed
-	desc = "Something about this dice seems wrong"
 	name = "\improper Mysterious d20"
+	desc = "Something about this dice seems wrong"
 	var/deactivated = 0 //Eventually the dice runs out of power
 	var/infinite = 0 //dice with 1 will not run out
+	mech_flags = MECH_SCAN_FAIL
 
 /obj/item/weapon/dice/d20/cursed/pickup(mob/user as mob)
 	..()


### PR DESCRIPTION
![arthur](https://user-images.githubusercontent.com/17928298/36416426-c2df8418-1607-11e8-8db0-310ed8c126b0.png)

:cl:
 * rscdel: The mysterious/cursed dice can't be scanned by device analysers anymore.