### PR TITLE
Undoes accidental kitchen spike nerf

### DIFF
--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -73,6 +73,8 @@
 						C.drop_stomach_contents()
 						user.visible_message("<span class='warning'>\The [C]'s stomach contents drop to the ground!</span>")
 
+				occupant.meat_amount++
+
 				returnToPool(G)
 				return
 


### PR DESCRIPTION
Through an oversight, #17019 took away the kitchen spike's property of yielding an additional piece of meat for a given animal.