### PR TITLE
Adds mech_flags to grenades

### DIFF
--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -18,6 +18,7 @@
 	var/obj/item/weapon/reagent_containers/glass/beaker/noreactgrenade/reservoir = null
 	var/extract_uses = 0
 	var/mob/primed_by = "N/A" //"name (ckey)". For logging purposes
+	mech_flags = null
 
 /obj/item/weapon/grenade/chem_grenade/attack_self(mob/user as mob)
 	if(!stage || stage==1)

--- a/code/game/objects/items/weapons/grenades/chronogrenade.dm
+++ b/code/game/objects/items/weapons/grenades/chronogrenade.dm
@@ -7,6 +7,7 @@
 	flags = FPRINT | TIMELESS
 	var/duration = 10 SECONDS
 	var/radius = 5		//in tiles
+	mech_flags = MECH_SCAN_FAIL
 
 /obj/item/weapon/grenade/chronogrenade/prime()
 	timestop(src, duration, radius)

--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -128,6 +128,7 @@
 	name = "clusterbang"
 	icon = 'icons/obj/grenade.dmi'
 	icon_state = "clusterbang"
+	mech_flags = MECH_SCAN_FAIL
 
 /obj/item/weapon/grenade/flashbang/clusterbang/prime()
 	var/numspawned = rand(4,8)

--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -128,7 +128,6 @@
 	name = "clusterbang"
 	icon = 'icons/obj/grenade.dmi'
 	icon_state = "clusterbang"
-	mech_flags = MECH_SCAN_FAIL
 
 /obj/item/weapon/grenade/flashbang/clusterbang/prime()
 	var/numspawned = rand(4,8)

--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -12,6 +12,7 @@
 	slot_flags = SLOT_BELT
 	var/active = 0
 	var/det_time = 50
+	mech_flags = MECH_SCAN_ILLEGAL
 
 /obj/item/weapon/grenade/proc/clown_check(var/mob/living/user)
 	if(clumsy_check(user) && prob(50))

--- a/code/game/objects/items/weapons/grenades/inflatable.dm
+++ b/code/game/objects/items/weapons/grenades/inflatable.dm
@@ -2,6 +2,7 @@
 	name = "inflatable barrier grenade"
 	desc = "An inflatable barrier conveniently packaged into a casing for remote delivery. Non-reusable."
 	var/deploy_path = /obj/structure/inflatable/wall
+	mech_flags = null
 
 /obj/item/weapon/grenade/inflatable/prime()
 	playsound(get_turf(src), 'sound/items/zip.ogg', 75, 1)

--- a/code/game/objects/items/weapons/grenades/smokebomb.dm
+++ b/code/game/objects/items/weapons/grenades/smokebomb.dm
@@ -8,28 +8,28 @@
 	flags = FPRINT
 	slot_flags = SLOT_BELT
 	var/datum/effect/effect/system/smoke_spread/bad/smoke
+	mech_flags = null
 
-	New()
-		..()
-		src.smoke = new /datum/effect/effect/system/smoke_spread/bad
-		src.smoke.attach(src)
+/obj/item/weapon/grenade/smokebomb/New()
+	..()
+	smoke = new /datum/effect/effect/system/smoke_spread/bad
+	smoke.attach(src)
 
-	prime()
-		playsound(get_turf(src), 'sound/effects/smoke.ogg', 50, 1, -3)
-		src.smoke.set_up(10, 0, usr.loc)
-		spawn(0)
-			src.smoke.start()
-			sleep(10)
-			src.smoke.start()
-			sleep(10)
-			src.smoke.start()
-			sleep(10)
-			src.smoke.start()
+/obj/item/weapon/grenade/smokebomb/prime()
+	playsound(get_turf(src), 'sound/effects/smoke.ogg', 50, 1, -3)
+	smoke.set_up(10, 0, usr.loc)
+	spawn(0)
+		smoke.start()
+		sleep(10)
+		smoke.start()
+		sleep(10)
+		smoke.start()
+		sleep(10)
+		smoke.start()
 
-		for(var/obj/effect/blob/B in view(8,src))
-			var/damage = round(30/(get_dist(B,src)+1))
-			B.health -= damage
-			B.update_icon()
-		sleep(80)
-		qdel(src)
-		return
+	for(var/obj/effect/blob/B in view(8,src))
+		var/damage = round(30/(get_dist(B,src)+1))
+		B.health -= damage
+		B.update_icon()
+	sleep(80)
+	qdel(src)


### PR DESCRIPTION
Mechanics were a mistake.

:cl:
 * tweak: From now on most grenades will only be scannable the the traitor device analyser.
 * rscdel: the device analyser(both normal and traitor versions) can't scan chrono grenades anymore.
 * tweak: Inflatables and smoke grenades can still be scanned by normal device analysers.