### PR TITLE
Change how action buttons move

### DIFF
--- a/code/_onclick/hud/action_button.dm
+++ b/code/_onclick/hud/action_button.dm
@@ -13,12 +13,22 @@
 	linked_action.Trigger()
 	return 1
 
+/obj/abstract/screen/movable/action_button/MouseDrop(over_object, src_location, over_location, src_control, over_control, params)
+	if(istype(over_object, /obj/abstract/screen/movable/action_button) && !istype(over_object, /obj/abstract/screen/movable/action_button/hide_toggle))
+		var/obj/abstract/screen/movable/action_button/B = over_object
+		var/list/actions = usr.actions
+		actions.Swap(actions.Find(src.linked_action), actions.Find(B.linked_action))
+		usr.update_action_buttons()
+
 //Hide/Show Action Buttons ... Button
 /obj/abstract/screen/movable/action_button/hide_toggle
 	name = "Hide Buttons"
 	icon = 'icons/mob/actions.dmi'
 	icon_state = "bg_default"
 	var/hidden = 0
+
+/obj/abstract/screen/movable/action_button/hide_toggle/MouseDrop(over_object, src_location, over_location, src_control, over_control, params)
+	return
 
 /obj/abstract/screen/movable/action_button/hide_toggle/Click(location,control,params)
 	var/list/modifiers = params2list(params)
@@ -34,13 +44,6 @@
 		name = "Hide Buttons"
 	UpdateIcon()
 	usr.update_action_buttons()
-
-/obj/abstract/screen/movable/action_button/MouseDrop(over_object, src_location, over_location, src_control, over_control, params)
-	if(istype(over_object, /obj/abstract/screen/movable/action_button))
-		var/obj/abstract/screen/movable/action_button/B = over_object
-		var/list/actions = usr.actions
-		actions.Swap(actions.Find(src.linked_action), actions.Find(B.linked_action))
-		usr.update_action_buttons()
 
 /obj/abstract/screen/movable/action_button/hide_toggle/proc/InitialiseIcon(mob/living/user)
 	if(isalien(user))

--- a/code/_onclick/hud/action_button.dm
+++ b/code/_onclick/hud/action_button.dm
@@ -35,6 +35,12 @@
 	UpdateIcon()
 	usr.update_action_buttons()
 
+/obj/abstract/screen/movable/action_button/MouseDrop(over_object, src_location, over_location, src_control, over_control, params)
+	if(istype(over_object, /obj/abstract/screen/movable/action_button))
+		var/obj/abstract/screen/movable/action_button/B = over_object
+		var/list/actions = usr.actions
+		actions.Swap(actions.Find(src.linked_action), actions.Find(B.linked_action))
+		usr.update_action_buttons()
 
 /obj/abstract/screen/movable/action_button/hide_toggle/proc/InitialiseIcon(mob/living/user)
 	if(isalien(user))


### PR DESCRIPTION
Action buttons can no longer be freely dragged around, but instead can be dragged onto each other to swap places.

I know it's a bit hasty considering I gave only an hour after my [issue](https://github.com/vgstation-coders/vgstation13/issues/17543), I just wanted to get a PR going. 

Comment whether you give a fuck about being able to move action buttons around. I just find it annoying and I never intend to do it.

:cl:
 * tweak: Instead of being able to move freely, action buttons can now be dragged on top of each other to swap places. 

<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl:
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
