### PR TITLE
Fixes mob AI bug with targeting objects

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -251,6 +251,7 @@
 /mob/living/simple_animal/hostile/proc/LoseAggro()
 	stop_automated_movement = 0
 	vision_range = idle_vision_range
+	search_objects = initial(search_objects)
 
 /mob/living/simple_animal/hostile/proc/LoseTarget()
 	stance = HOSTILE_STANCE_IDLE


### PR DESCRIPTION
`search_objects` wasn't being reset. This PR makes it so the mob AI goes back to its original behavior after losing sight of an attacker.