### PR TITLE
Fixed a bug that caused only the first implant to show up on secHUDs

### DIFF
--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -120,7 +120,6 @@ proc/process_sec_hud(var/mob/M, var/advanced_mode,var/mob/eye)
 					else
 						continue
 					C.images += holder
-					break
 
 		var/perpname = perp.get_face_name()
 		if(lowertext(perpname) == "unknown" || !perpname)


### PR DESCRIPTION
Two years later, five characters less
Fixes #11119
![image](https://user-images.githubusercontent.com/6307265/36479681-d5041174-1709-11e8-866e-be22c4e26c2b.png)

:cl:
 * bugfix: Fixed a bug that caused only the first implant to show up on secHUDs.

