### PR TITLE
Fix for cyborg deathgasp

### DIFF
--- a/code/modules/mob/living/silicon/robot/emote.dm
+++ b/code/modules/mob/living/silicon/robot/emote.dm
@@ -221,7 +221,7 @@
 		else
 			to_chat(src, "<span class='notice'>Unusable emote '[act]'. Say *help for a list.</span>")
 
-	if ((message && src.stat == 0))
+	if (message && (src.stat == CONSCIOUS || act == "deathgasp"))
 		if (m_type & 1)
 			for(var/mob/O in viewers(src, null))
 				O.show_message(message, m_type)


### PR DESCRIPTION
Closes #17104 
:cl:
* bugfix: Cyborgs deathgasp properly on death now.