### PR TITLE
Fixes automated emotes from NPC mobs

### DIFF
--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -45,7 +45,7 @@
 		// Type 2 (Audible) emotes are sent to anyone in hear range
 		// of the *LOCATION* -- this is important for pAIs to be heard
 		else if (m_type & 2)
-			for(var/mob/living/M in get_hearers_in_view(get_turf(src), null))
+			for(var/mob/M in get_hearers_in_view(7, src))
 				M.show_message(message, m_type)
 
 /mob/proc/emote_dead(var/message)

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -76,7 +76,7 @@
 			for(var/mob/living/simple_animal/mouse/M in view(1,src))
 				if(!M.stat)
 					M.splat()
-					emote("<span class='warning'>[pick(kill_verbs)] \the [M]!</span>")
+					visible_message("<span class='warning'>\The [name] [pick(kill_verbs)] \the [M]!</span>")
 					movement_target = null
 					stop_automated_movement = 0
 					break
@@ -84,8 +84,8 @@
 	..()
 
 	for(var/mob/living/simple_animal/mouse/snack in oview(src, 3))
-		if(prob(15))
-			emote(pick("[pick(growl_verbs)] at [snack]!", "eyes [snack] hungrily."))
+		if(prob(15) && !snack.stat)
+			emote("me",, pick("[pick(growl_verbs)] at [snack]!", "eyes [snack] hungrily."))
 		break
 
 	if(!stat && !resting && !locked_to)

--- a/code/modules/mob/living/simple_animal/hostile/bat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bat.dm
@@ -59,7 +59,7 @@
 /mob/living/simple_animal/hostile/scarybat/FindTarget()
 	. = ..()
 	if(.)
-		emote("me", MESSAGE_SEE, "flutters towards [.]!")
+		emote("me",, "flutters towards [.]!")
 
 /mob/living/simple_animal/hostile/scarybat/Found(var/atom/A)//This is here as a potential override to pick a specific target if available
 	if(istype(A) && A == owner)

--- a/code/modules/mob/living/simple_animal/hostile/bat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bat.dm
@@ -59,7 +59,7 @@
 /mob/living/simple_animal/hostile/scarybat/FindTarget()
 	. = ..()
 	if(.)
-		emote("flutters towards [.]")
+		emote("me", MESSAGE_SEE, "flutters towards [.]!")
 
 /mob/living/simple_animal/hostile/scarybat/Found(var/atom/A)//This is here as a potential override to pick a specific target if available
 	if(istype(A) && A == owner)

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -86,7 +86,7 @@
 /mob/living/simple_animal/hostile/carp/FindTarget()
 	. = ..()
 	if(.)
-		emote("me", MESSAGE_SEE, "gnashes at [.]!")
+		emote("me",, "gnashes at [.]!")
 
 /mob/living/simple_animal/hostile/carp/AttackingTarget()
 	if(!target)

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -86,7 +86,7 @@
 /mob/living/simple_animal/hostile/carp/FindTarget()
 	. = ..()
 	if(.)
-		emote("nashes at [.]")
+		emote("me", MESSAGE_SEE, "gnashes at [.]!")
 
 /mob/living/simple_animal/hostile/carp/AttackingTarget()
 	if(!target)

--- a/code/modules/mob/living/simple_animal/hostile/human/nazi.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/nazi.dm
@@ -9,8 +9,8 @@
 
 	speak = list("Schweinhunds!","Can you feel ze Schadenfreude?","Ach, was ist los?")
 	speak_emote = list("says")
-	emote_hear = list("says")
-	emote_see = list("hums")
+	emote_hear = list("hums")
+	emote_see = list("goose-steps", "heils")
 	attacktext = "punches"
 	attack_sound = "punch"
 	speak_chance = 5
@@ -309,8 +309,8 @@
 
 	speak = list("Die, Allied schweinhund!","Die Welt ist unser!","Guten Tag!" ,"Scheise!")
 	speak_emote = list("says")
-	emote_hear = list("says")
-	emote_see = list("hums")
+	emote_hear = list("hums")
+	emote_see = list("stomps")
 	attacktext = "crushes"
 	attack_sound = 'sound/weapons/heavysmash.ogg'
 	speak_chance = 20

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/cluwne.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/cluwne.dm
@@ -17,7 +17,7 @@
 	response_harm = "hits the"
 	speak = list("HONK", "Honk!", "PLEASE KILL ME")
 	speak_emote = list("squeals", "cries","sobs")
-	emote_see = list("honks sadly")
+	emote_hear = list("honks sadly")
 	speak_chance = 1
 	a_intent = I_HELP
 	var/footstep=0 // For clownshoe noises
@@ -300,8 +300,7 @@
 		return //under effects of time magick
 
 	var/msg = pick("quietly sobs into a dirty handkerchief","cries into [gender==MALE?"his":"her"] hands","bawls like a cow")
-	msg = "<B>[src]</B> [msg]"
-	return ..(msg)
+	return ..("me",, msg)
 
 /mob/living/simple_animal/hostile/retaliate/cluwne/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	. = ..()
@@ -325,7 +324,7 @@
 	response_help = "honks the"
 	speak = list("Honk!")
 	speak_emote = list("sqeaks")
-	emote_see = list("honks")
+	emote_hear = list("honks")
 	maxHealth = 100
 	health = 100
 	size = 1

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/cluwne.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/cluwne.dm
@@ -300,7 +300,7 @@
 		return //under effects of time magick
 
 	var/msg = pick("quietly sobs into a dirty handkerchief","cries into [gender==MALE?"his":"her"] hands","bawls like a cow")
-	return ..("me",, msg)
+	return ..(msg)
 
 /mob/living/simple_animal/hostile/retaliate/cluwne/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/tree.dm
+++ b/code/modules/mob/living/simple_animal/hostile/tree.dm
@@ -42,7 +42,7 @@
 /mob/living/simple_animal/hostile/tree/FindTarget()
 	. = ..()
 	if(.)
-		emote("growls at [.]")
+		emote("me",, "growls at [.]")
 
 /mob/living/simple_animal/hostile/tree/AttackingTarget()
 	. =..()

--- a/code/modules/mob/living/simple_animal/hostile/tree.dm
+++ b/code/modules/mob/living/simple_animal/hostile/tree.dm
@@ -42,7 +42,7 @@
 /mob/living/simple_animal/hostile/tree/FindTarget()
 	. = ..()
 	if(.)
-		emote("me",, "growls at [.]")
+		emote("me",, "growls at [.]!")
 
 /mob/living/simple_animal/hostile/tree/AttackingTarget()
 	. =..()

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -208,48 +208,7 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 					wander_move(destination)
 					turns_since_move = 0
 
-	var/someone_in_earshot=0
-	if(!client && speak_chance && (ckey == null)) // Remove this if earshot is used elsewhere.
-		// All we're doing here is seeing if there's any CLIENTS nearby.
-		for(var/mob/M in get_hearers_in_view(7, src))
-			if(M.client)
-				someone_in_earshot=1
-				break
-
-	//Speaking
-	if(!client && speak_chance && (ckey == null) && someone_in_earshot)
-		if(speak && speak.len)
-			if(rand(0,200) < speak_chance)
-				if((emote_hear && emote_hear.len) || (emote_see && emote_see.len))
-					var/length = speak.len
-					if(emote_hear && emote_hear.len)
-						length += emote_hear.len
-					if(emote_see && emote_see.len)
-						length += emote_see.len
-					var/randomValue = rand(1,length)
-					if(randomValue <= speak.len)
-						say(pick(speak))
-					else
-						randomValue -= speak.len
-						if(emote_see && randomValue <= emote_see.len)
-							emote(pick(emote_see),1)
-						else
-							emote(pick(emote_hear),2)
-				else
-					say(pick(speak))
-			else
-				if(!(emote_hear && emote_hear.len) && (emote_see && emote_see.len))
-					emote(pick(emote_see),1)
-				if((emote_hear && emote_hear.len) && !(emote_see && emote_see.len))
-					emote(pick(emote_hear),2)
-				if((emote_hear && emote_hear.len) && (emote_see && emote_see.len))
-					var/length = emote_hear.len + emote_see.len
-					var/pick = rand(1,length)
-					if(pick <= emote_see.len)
-						emote(pick(emote_see),1)
-					else
-						emote(pick(emote_hear),2)
-
+	handle_automated_speech()
 
 	//Atmos
 	if(flags & INVULNERABLE)
@@ -583,6 +542,32 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 	health = Clamp(health - damage, 0, maxHealth)
 	if(health < 1 && stat != DEAD)
 		Die()
+
+/mob/living/simple_animal/proc/handle_automated_speech()
+
+	var/someone_in_earshot=0
+	if(!client && speak_chance && (ckey == null)) // Remove this if earshot is used elsewhere.
+		// All we're doing here is seeing if there's any CLIENTS nearby.
+		for(var/mob/M in get_hearers_in_view(7, src))
+			if(M.client)
+				someone_in_earshot=1
+				break
+
+	if(!client && speak_chance && ckey == null && someone_in_earshot)
+		if(rand(0,200) < speak_chance)
+			var/mode = pick(
+			speak.len;      1,
+			emote_hear.len; 2,
+			emote_see.len;  3
+			)
+
+			switch(mode)
+				if(1)
+					say(pick(speak))
+				if(2)
+					emote("me", MESSAGE_HEAR, "[pick(emote_hear)].")
+				if(3)
+					emote("me", MESSAGE_SEE, "[pick(emote_see)].")
 
 /mob/living/simple_animal/proc/skinned()
 	if(butchering_drops)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -313,7 +313,36 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 	if(act == "scream")
 		desc = "makes a loud and pained whimper"  //ugly hack to stop animals screaming when crushed :P
 		act = "me"
+	if(!desc)
+		desc = act
+		act = "me"
 	..(act, type, desc)
+
+/mob/living/simple_animal/proc/handle_automated_speech()
+
+	var/someone_in_earshot=0
+	if(!client && speak_chance && (ckey == null)) // Remove this if earshot is used elsewhere.
+		// All we're doing here is seeing if there's any CLIENTS nearby.
+		for(var/mob/M in get_hearers_in_view(7, src))
+			if(M.client)
+				someone_in_earshot=1
+				break
+
+	if(!client && speak_chance && ckey == null && someone_in_earshot)
+		if(rand(0,200) < speak_chance)
+			var/mode = pick(
+			speak.len;      1,
+			emote_hear.len; 2,
+			emote_see.len;  3
+			)
+
+			switch(mode)
+				if(1)
+					say(pick(speak))
+				if(2)
+					emote("me", MESSAGE_HEAR, "[pick(emote_hear)].")
+				if(3)
+					emote("me", MESSAGE_SEE, "[pick(emote_see)].")
 
 /mob/living/simple_animal/attack_animal(mob/living/simple_animal/M)
 	M.unarmed_attack_mob(src)
@@ -542,32 +571,6 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 	health = Clamp(health - damage, 0, maxHealth)
 	if(health < 1 && stat != DEAD)
 		Die()
-
-/mob/living/simple_animal/proc/handle_automated_speech()
-
-	var/someone_in_earshot=0
-	if(!client && speak_chance && (ckey == null)) // Remove this if earshot is used elsewhere.
-		// All we're doing here is seeing if there's any CLIENTS nearby.
-		for(var/mob/M in get_hearers_in_view(7, src))
-			if(M.client)
-				someone_in_earshot=1
-				break
-
-	if(!client && speak_chance && ckey == null && someone_in_earshot)
-		if(rand(0,200) < speak_chance)
-			var/mode = pick(
-			speak.len;      1,
-			emote_hear.len; 2,
-			emote_see.len;  3
-			)
-
-			switch(mode)
-				if(1)
-					say(pick(speak))
-				if(2)
-					emote("me", MESSAGE_HEAR, "[pick(emote_hear)].")
-				if(3)
-					emote("me", MESSAGE_SEE, "[pick(emote_see)].")
 
 /mob/living/simple_animal/proc/skinned()
 	if(butchering_drops)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -321,14 +321,14 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 /mob/living/simple_animal/proc/handle_automated_speech()
 
 	var/someone_in_earshot=0
-	if(!client && speak_chance && (ckey == null)) // Remove this if earshot is used elsewhere.
+	if(!client && speak_chance && ckey == null) // Remove this if earshot is used elsewhere.
 		// All we're doing here is seeing if there's any CLIENTS nearby.
 		for(var/mob/M in get_hearers_in_view(7, src))
 			if(M.client)
 				someone_in_earshot=1
 				break
 
-	if(!client && speak_chance && ckey == null && someone_in_earshot)
+	if(someone_in_earshot)
 		if(rand(0,200) < speak_chance)
 			var/mode = pick(
 			speak.len;      1,

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -314,7 +314,7 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 		desc = "makes a loud and pained whimper"  //ugly hack to stop animals screaming when crushed :P
 		act = "me"
 	if(!desc)
-		desc = act
+		desc = "[act]."
 		act = "me"
 	..(act, type, desc)
 


### PR DESCRIPTION
Fixes the `emote_hear` and `emote_see` messages for simple animals being broken in multiple ways.
:cl:
* bugfix: Lots of automated NPC emotes will display correctly now.