### PR TITLE
Facehugger behavior changes

### DIFF
--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -499,7 +499,7 @@
 	new /obj/item/clothing/mask/facehugger(src)
 
 	for(var/mob/M in range(2,src))
-		if(CanHug(M))
+		if(GetFacehugger().CanHug(M))
 			Burst(0)
 			break
 
@@ -522,7 +522,7 @@
 				child.Die()
 			else
 				for(var/mob/M in range(1,src))
-					if(CanHug(M))
+					if(child.CanHug(M))
 						child.Attach(M)
 						break
 				if(!ismob(child.loc))
@@ -573,7 +573,7 @@
 
 /obj/effect/alien/egg/HasProximity(atom/movable/AM as mob|obj)
 	if(status == GROWN)
-		if(!CanHug(AM))
+		if(!GetFacehugger().CanHug(AM))
 			return
 
 		var/mob/living/carbon/C = AM

--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -498,8 +498,8 @@
 	status = GROWN
 	new /obj/item/clothing/mask/facehugger(src)
 
-	for(var/mob/M in range(2,src))
-		if(GetFacehugger().CanHug(M))
+	for(var/mob/living/M in range(2,src))
+		if(CanHug(M))
 			Burst(0)
 			break
 
@@ -522,7 +522,7 @@
 				child.Die()
 			else
 				for(var/mob/M in range(1,src))
-					if(child.CanHug(M))
+					if(CanHug(M, child))
 						child.Attach(M)
 						break
 				if(!ismob(child.loc))
@@ -573,11 +573,12 @@
 
 /obj/effect/alien/egg/HasProximity(atom/movable/AM as mob|obj)
 	if(status == GROWN)
-		if(!GetFacehugger().CanHug(AM))
+		if(!isliving(AM))
 			return
-
-		var/mob/living/carbon/C = AM
-		if(C.stat == CONSCIOUS && C.status_flags & XENO_HOST)
+		var/mob/living/L = AM
+		if(!CanHug(L))
+			return
+		if(L.isUnconscious())
 			return
 
 		Burst(0)

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -516,17 +516,6 @@ proc/move_mining_shuttle()
 	//tint = 3 //Makes it feel more authentic when it latches on
 	real = FALSE
 
-/*
-/obj/item/clothing/mask/facehugger/toy/spreadout()
-	if(!target && isturf(loc))
-		for(var/obj/item/clothing/mask/facehugger/F in loc)
-			if(F != src)
-				step(src, pick(alldirs), 0)
-				break
-
-/obj/item/clothing/mask/facehugger/toy/Die()
-	return
-*/
 /**********************Mining drone cube**********************/
 
 /obj/item/weapon/mining_drone_cube

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -514,10 +514,19 @@ proc/move_mining_shuttle()
 	throwforce = 0
 	sterile = 1
 	//tint = 3 //Makes it feel more authentic when it latches on
+	real = FALSE
+
+/*
+/obj/item/clothing/mask/facehugger/toy/spreadout()
+	if(!target && isturf(loc))
+		for(var/obj/item/clothing/mask/facehugger/F in loc)
+			if(F != src)
+				step(src, pick(alldirs), 0)
+				break
 
 /obj/item/clothing/mask/facehugger/toy/Die()
 	return
-
+*/
 /**********************Mining drone cube**********************/
 
 /obj/item/weapon/mining_drone_cube

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -61,7 +61,7 @@
 	for(var/mob/living/T in hearers(src,4))
 		if(!CanHug(T, src))
 			continue
-		if(T && (!T.isDead() && !T.isUnconscious() ) )
+		if(T && (!T.isUnconscious() ) )
 
 			if(get_dist(loc, T.loc) <= 4)
 				target = T
@@ -70,7 +70,7 @@
 /obj/item/clothing/mask/facehugger/proc/followtarget()
 	if(!real)
 		return // Why are you trying to path stupid toy
-	if(!target || target.isDead() || target.isUnconscious() || target.status_flags & XENO_HOST)
+	if(!target || target.isUnconscious() || target.status_flags & XENO_HOST)
 		findtarget()
 		return
 	if(loc && isturf(loc) && !attached && !stat && nextwalk <= world.time)
@@ -200,9 +200,8 @@
 
 /obj/item/clothing/mask/facehugger/HasProximity(atom/movable/AM as mob|obj)
 	if(isliving(AM))
-		var/mob/living/L = AM
-		if(CanHug(L, src))
-			return Attach(L)
+		if(CanHug(AM, src))
+			return Attach(AM)
 	return FALSE
 
 /obj/item/clothing/mask/facehugger/throw_at(atom/target, range, speed)

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -218,11 +218,11 @@
 
 /obj/item/clothing/mask/facehugger/proc/Attach(mob/living/M as mob)
 	var/preggers = rand(MIN_IMPREGNATION_TIME,MAX_IMPREGNATION_TIME)
-	if(!CanHug(M))
-		return FALSE
-	if(iscarbon(M) && M.status_flags & XENO_HOST)
+	if(M.status_flags & XENO_HOST)
 		visible_message("<span class='danger'>An alien tries to place a facehugger on [M] but it refuses sloppy seconds!</span>")
 		return
+	if(!CanHug(M))
+		return FALSE
 	if(attached)
 		return FALSE
 	if(!Adjacent(M))

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -59,7 +59,7 @@
 		return
 	target = null
 	for(var/mob/living/T in hearers(src,4))
-		if(!CanHug(T))
+		if(!CanHug(T, src))
 			continue
 		if(T && (!T.isDead() && !T.isUnconscious() ) )
 
@@ -87,7 +87,7 @@
 		else
 			step_towards(src, target, 0)
 			if(dist <= 1)
-				if(CanHug(target) && isturf(target.loc)) //Fix for hugging through mechs and closets
+				if(CanHug(target, src) && isturf(target.loc)) //Fix for hugging through mechs and closets
 					Attach(target)
 					return
 				else
@@ -199,9 +199,10 @@
 	return FALSE
 
 /obj/item/clothing/mask/facehugger/HasProximity(atom/movable/AM as mob|obj)
-	if(istype(AM, /mob/living))
-		if(CanHug(AM))
-			return Attach(AM)
+	if(isliving(AM))
+		var/mob/living/L = AM
+		if(CanHug(L, src))
+			return Attach(L)
 	return FALSE
 
 /obj/item/clothing/mask/facehugger/throw_at(atom/target, range, speed)
@@ -242,7 +243,7 @@
 
 	L.visible_message("<span class='danger'>\The [src] leaps at [L]'s face!</span>")
 
-	if(!CanHug(L))
+	if(!CanHug(L, src))
 		return FALSE
 
 	if(ishuman(L))
@@ -395,7 +396,9 @@
 
 	return
 
-/obj/item/clothing/mask/facehugger/proc/CanHug(var/mob/living/M)
+/proc/CanHug(mob/living/M, obj/item/clothing/mask/facehugger/hugger = null)
+	if(isalien(M))
+		return FALSE
 
 	if(M.status_flags & XENO_HOST)
 		return FALSE
@@ -413,7 +416,7 @@
 	var/mob/living/carbon/C = M
 	var/obj/item/clothing/mask/facehugger/F = C.is_wearing_item(/obj/item/clothing/mask/facehugger, slot_wear_mask)
 
-	if(F && (!F.sterile || src.sterile) && F != src) // Lamarr won't fight over faces and neither will normal huggers.
+	if(F && (!F.sterile || hugger.sterile) && F != hugger) // Lamarr won't fight over faces and neither will normal huggers.
 		return FALSE
 
 	return TRUE

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -38,7 +38,7 @@
 	var/target_time = 0.5 // seconds
 	var/walk_speed = 1
 	var/nextwalk = FALSE
-	var/mob/living/carbon/target = null
+	var/mob/living/target = null
 
 /obj/item/clothing/mask/facehugger/can_contaminate()
 	return FALSE
@@ -60,7 +60,7 @@
 	for(var/mob/living/T in hearers(src,4))
 		if(!CanHug(T))
 			continue
-		if(T && (T.stat != DEAD && T.stat != UNCONSCIOUS) )
+		if(T && (!T.isDead() && !T.isUnconscious() ) )
 
 			if(get_dist(loc, T.loc) <= 4)
 				target = T
@@ -69,7 +69,7 @@
 /obj/item/clothing/mask/facehugger/proc/followtarget()
 	if(!real)
 		return // Why are you trying to path stupid toy
-	if(!target || target.stat == DEAD || target.stat == UNCONSCIOUS || target.status_flags & XENO_HOST)
+	if(!target || target.isDead() || target.isUnconscious() || target.status_flags & XENO_HOST)
 		findtarget()
 		return
 	if(loc && isturf(loc) && !attached && !stat && nextwalk <= world.time)
@@ -97,8 +97,8 @@
 /obj/item/clothing/mask/facehugger/proc/spreadout()
 	if(!target && isturf(loc))
 		for(var/obj/item/clothing/mask/facehugger/F in loc)
-			if(F != src)
-				step(src, pick(cardinal), 0)
+			if(F != src && F.stat != DEAD)
+				step(src, pick(alldirs), 0)
 				break
 
 //END HUGGER MOVEMENT AI
@@ -263,7 +263,7 @@
 				GoIdle(TIME_IDLE_AFTER_HEAD_DENIED)
 				return
 			else
-				H.visible_message("<span class='danger'>\The [src] bounces off of the [mouth_protection]!</span>")
+				H.visible_message("<span class='danger'>\The [src] bounces off of \the [mouth_protection]!</span>")
 				if(prob(CHANCE_TO_DIE_AFTER_HEAD_DENIED) && !sterile)
 					Die()
 					return
@@ -312,7 +312,7 @@
 				GoIdle(TIME_IDLE_AFTER_HEAD_DENIED)
 				return
 			else
-				C.visible_message("<span class='danger'>\The [src] bounces off of the [headwear]!</span>")
+				C.visible_message("<span class='danger'>\The [src] bounces off of \the [headwear]!</span>")
 				if(prob(CHANCE_TO_DIE_AFTER_HEAD_DENIED) && !sterile)
 					Die()
 					return
@@ -398,6 +398,9 @@
 
 /proc/CanHug(var/mob/M)
 
+	if(M.status_flags & XENO_HOST)
+		return FALSE
+
 	if(iscorgi(M))
 		var/mob/living/simple_animal/corgi/corgi = M
 		if(corgi.facehugger && !corgi.facehugger.sterile)
@@ -412,9 +415,6 @@
 	var/obj/item/clothing/mask/facehugger/F = C.is_wearing_item(/obj/item/clothing/mask/facehugger, slot_wear_mask)
 
 	if(F && !F.sterile)
-		return FALSE
-
-	if(C.status_flags & XENO_HOST)
 		return FALSE
 
 	return TRUE

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -276,6 +276,7 @@
 	if(iscarbon(L))
 		var/mob/living/carbon/target = L
 		var/obj/item/clothing/W = target.get_item_by_slot(slot_wear_mask)
+		var/obj/item/weapon/tank/had_internal = target.internal
 
 		if(W && W != src)
 			if(prob(CHANCE_TO_NOT_REMOVE_MASKS))
@@ -289,6 +290,8 @@
 		forceMove(target)
 		target.equip_to_slot(src, slot_wear_mask)
 		target.update_inv_wear_mask()
+		target.internal = had_internal //Try to keep the host ALIVE
+		target.update_internals()
 
 		if(!sterile && target.hasmouth)
 			L.Paralyse((preggers/10)+10) //something like 25 ticks = 20 seconds with the default settings
@@ -351,7 +354,7 @@
 		stat_collection.xeno_faces_hugged++
 
 		Die()
-		target.drop_from_inventory(src)
+		//target.drop_from_inventory(src)
 		icon_state = "[initial(icon_state)]_impregnated"
 
 		if(iscorgi(target))

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -52,12 +52,13 @@
 /obj/item/clothing/mask/facehugger/process()
 	healthcheck()
 	followtarget()
+	spreadout()
 
 /obj/item/clothing/mask/facehugger/proc/findtarget()
 	if(!real)
 		return
 	for(var/mob/living/carbon/T in hearers(src,4))
-		if(!ishuman(T) && !ismonkey(T))
+		if(!ishuman(T) && !ismonkey(T) && !iscorgi(T))
 			continue
 		if(!CanHug(T))
 			continue
@@ -94,6 +95,13 @@
 					walk(src,0)
 					findtarget()
 					return
+
+/obj/item/clothing/mask/facehugger/proc/spreadout()
+	if(!target && isturf(loc))
+		for(var/obj/item/clothing/mask/facehugger/F in loc)
+			if(F != src)
+				step(src, pick(1,2,4,8), 0)
+				break
 
 //END HUGGER MOVEMENT AI
 
@@ -314,6 +322,7 @@
 		stat_collection.xeno_faces_hugged++
 
 		Die()
+		target.drop_from_inventory(src)
 		icon_state = "[initial(icon_state)]_impregnated"
 
 		if(iscorgi(target))

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -96,7 +96,7 @@
 					return
 
 /obj/item/clothing/mask/facehugger/proc/spreadout()
-	if(!target && isturf(loc))
+	if(!target && isturf(loc) && stat == CONSCIOUS)
 		for(var/obj/item/clothing/mask/facehugger/F in loc)
 			if(F != src && F.stat != DEAD)
 				step(src, pick(alldirs), 0)

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -217,7 +217,8 @@
 	..()
 	if(stat == CONSCIOUS)
 		icon_state = "[initial(icon_state)]"
-		Attach(hit_atom)
+		if(isliving(hit_atom))
+			Attach(hit_atom)
 
 /obj/item/clothing/mask/facehugger/proc/Attach(mob/living/L)
 	var/preggers = rand(MIN_IMPREGNATION_TIME,MAX_IMPREGNATION_TIME)
@@ -289,7 +290,7 @@
 		target.equip_to_slot(src, slot_wear_mask)
 		target.update_inv_wear_mask()
 
-		if(!sterile)
+		if(!sterile && target.hasmouth)
 			L.Paralyse((preggers/10)+10) //something like 25 ticks = 20 seconds with the default settings
 	else if (iscorgi(L))
 		var/mob/living/simple_animal/corgi/C = L
@@ -337,7 +338,9 @@
 	if(!target || target.wear_mask != src || target.stat == DEAD) //was taken off or something
 		return
 
-	if(!sterile)
+	var/mob/living/carbon/CA = target
+
+	if(!sterile && !(istype(CA) && !CA.hasmouth))
 		var/obj/item/alien_embryo/E = new (target)
 		target.status_flags |= XENO_HOST
 		if(istype(target, /mob/living/carbon/human))

--- a/code/modules/mob/living/simple_animal/friendly/corgi.dm
+++ b/code/modules/mob/living/simple_animal/friendly/corgi.dm
@@ -34,7 +34,7 @@
 
 	var/obj/item/inventory_head
 	var/obj/item/inventory_back
-	var/facehugger
+	var/obj/item/clothing/mask/facehugger/facehugger
 	var/list/spin_emotes = list("dances around","chases its tail")
 //	colourmatrix = list(1,0.0,0.0,0,\
 						0,0.5,0.5,0,\
@@ -134,7 +134,14 @@
 			if(health>0 && prob(15))
 				emote("looks at [user] with [pick("an amused","an annoyed","a confused","a resentful", "a happy", "an excited")] expression")
 			return
+	else
+		var/obj/item/clothing/mask/facehugger/F = O
+		if(istype(F))
+			user.drop_from_inventory(F)
+			F.Attach(src)
+			return
 	..()
+
 
 /mob/living/simple_animal/corgi/Topic(href, href_list)
 	if(usr.stat)

--- a/code/modules/mob/living/simple_animal/friendly/corgi.dm
+++ b/code/modules/mob/living/simple_animal/friendly/corgi.dm
@@ -142,7 +142,6 @@
 			return
 	..()
 
-
 /mob/living/simple_animal/corgi/Topic(href, href_list)
 	if(usr.stat)
 		return


### PR DESCRIPTION
Seen some complaints about big stacks of huggers being unfair to deal with. I'm submitting this as a potential resolution, if it's wanted that is. This PR gives them a very simple spreading out behavior: if a hugger that is on a turf and has no target finds another hugger on the same tile, it will move one turf in a ~~cardinal~~ direction.

In addition:
- ~~They'll drop off once they impregnate a host. Right now they die but stay on the face.~~  **_Nixed that, had another idea._**
- They'll go after corgis, which they are able to impregnate already but have to be manually applied for some reason.
(More added since. See below.)

Closes #11920
Closes #16924

:cl:
* rscadd: Facehuggers now wander a little if they find another facehugger on their turf.
* bugfix: Toy facehuggers no longer hunt or remove equipment (although Lamarr still will). Wearing a dead, toy, or sterile facehugger no longer fools hugger AI. Huggers should no longer hug through mechs, closets or other containers.
* tweak: Facehuggers will try to keep their victims alive by auto-connecting to any internals they had enabled. (Don't ask how they know how to do that.)