### PR TITLE
human monkeyization now returns the monkey created.

### DIFF
--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -80,7 +80,7 @@
 	return Mo
 
 /mob/living/carbon/human/monkeyize(ignore_primitive = FALSE)
-	..()
+	.=..()
 
 /mob/proc/Cluwneize()
 	if(!Premorph())


### PR DESCRIPTION
Found while testing changeling in role datums. It wouldn't return the monkey result that would occur from monkeyization, so changeling lesser form would bug out and you'd be left as a normal monkey.

:cl:
* bugfix: Fixes the unreported bug of changeling monkeys not getting their powers