### PR TITLE
Fixes silicon album showing duplicated info when examining a photo

### DIFF
--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -588,7 +588,6 @@
 	P.pixel_y = selection.fields["pixel_y"]
 
 	P.show(usr)
-	to_chat(usr, P.info)
 	qdel(P)    //so 10 thousdand pictures items are not left in memory should an AI take them and then view them all.
 
 /obj/item/device/camera/silicon/proc/viewpictures(var/mob/user)


### PR DESCRIPTION
![quota](https://user-images.githubusercontent.com/17928298/36622113-4e86d028-18da-11e8-90c6-bcb19d954a73.png)

:cl:
 * bugfix: Fixes silicon album showing duplicated info when examining a photo

