### PR TITLE
Component human mob fixes

### DIFF
--- a/code/modules/components/ai/human/brain.dm
+++ b/code/modules/components/ai/human/brain.dm
@@ -154,8 +154,8 @@
 						if(DESIRE_ID)
 							if((I.slot_flags & SLOT_ID) && I.mob_can_equip(H, slot_wear_id))
 								goal = I
-			if(goal)
-				break
+					if(goal)
+						break processing_desires
 	return goal
 
 /datum/component/ai/human_brain/proc/AcquireItem(mob/living/carbon/human/H, obj/item/I)

--- a/code/modules/components/ai/human/human_target_finder.dm
+++ b/code/modules/components/ai/human/human_target_finder.dm
@@ -10,7 +10,7 @@
 	for(var/mob/M in view(range, container.holder))
 		if(is_type_in_list(M, exclude_types))
 			continue
-		if(M.stat)
+		if(M.isUnconscious())
 			continue
 		if((M in B.enemies) || (M.faction && M.faction in B.enemy_factions) || (M.type in B.enemy_types))
 			o += M


### PR DESCRIPTION
Mobs stop attacking the person if they're unconscious

When searching for something to wear, the component mob stops looping through everything once it finds a goal, rather than looping through everything and choosing the last thing (This would lead to the component mob constantly flittering back and forth between objects if there were 2 of the same desire-type in vicinity)