### PR TITLE
Role Panel extras

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult_runes.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_runes.dm
@@ -85,7 +85,7 @@ var/list/uristrune_cache = list()//icon cache, so the whole blending process is 
 
 	//cultists can read the words, and be informed if it calls a spell
 	if (iscultist(user))
-		to_chat(user, "<span class='info'>It reads: <i>[word1.rune] [word2.rune] [word3.rune]</i>.[rune_name ? " That's \a <b>[initial(rune_name.name)]</b> rune." : "It doesn't match any rune spells."]</span>")
+		to_chat(user, "<span class='info'>It reads: <i>[word1.rune] [word2.rune] [word3.rune]</i>.[rune_name ? " That's a <b>[initial(rune_name.name)]</b> rune." : "It doesn't match any rune spells."]</span>")
 	if (rune_name)
 		if (initial(rune_name.Act_restriction) <= 1000)//TODO: SET TO CURRENT CULT FACTION ACT
 			to_chat(user, initial(rune_name.desc))

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
@@ -144,9 +144,9 @@
 			speaker_name = H.real_name
 		rendered_message = speech.render_message()
 		for(var/mob/living/L in player_list)//&& iscultist DUH
-			to_chat(L, "<span class='game say'><b>[speaker_name]</b>'s voice echoes in your head, <B><span class='sinister'>[rendered_message]</span></B></span>")
+			to_chat(L, "<span class='game say'><b>[speaker_name]</b>'s voice echoes in your head, <B><span class='sinister'>[speech.message]</span></B></span>")
 		for(var/mob/dead/observer/O in player_list)
-			to_chat(O, "<span class='game say'><b>[speaker_name]</b> communicates, <span class='sinister'>[rendered_message]</span></span>")
+			to_chat(O, "<span class='game say'><b>[speaker_name]</b> communicates, <span class='sinister'>[speech.message]</span></span>")
 		log_cultspeak("[key_name(speech.speaker)] Cult Communicate Rune: [rendered_message]")
 
 /obj/effect/cult_ritual/cult_communication/HasProximity(var/atom/movable/AM)

--- a/code/datums/gamemode/role/cultist.dm
+++ b/code/datums/gamemode/role/cultist.dm
@@ -33,10 +33,10 @@
 	switch(greeting)
 		if ("roundstart")
 			to_chat(antag.current, {"<img src='data:image/png;base64,[icon2base64(logo)]' style='position: relative; top: 10;'/> <span class='sinister'><font size=3>You are a cultist of <span class='danger'><font size=3>Nar-Sie</font></span>!</font><br>
-				I, the Geometer of Blood want you to thin the veil between reality and his realm<br>
+				I, the Geometer of Blood, want you to thin the veil between reality and his realm<br>
 				so I can pull this place onto my plane of existence.<br>
 				You've managed to get a job here, and the time has come to put our plan into motion.<br>
-				However the veil is currently so thick that I can barely bestow any power to you.<br>
+				However, the veil is currently so thick that I can barely bestow any power to you.<br>
 				Other cultists made their way into the crew. Talk to them. <span class='danger'>Self Other Technology</span>!<br>
 				Meet up with them. Raise an altar in my name. <span class='danger'>Blood Technology Join</span>!<br>
 				</span>"})

--- a/code/datums/gamemode/role/cultist.dm
+++ b/code/datums/gamemode/role/cultist.dm
@@ -33,7 +33,7 @@
 	switch(greeting)
 		if ("roundstart")
 			to_chat(antag.current, {"<img src='data:image/png;base64,[icon2base64(logo)]' style='position: relative; top: 10;'/> <span class='sinister'><font size=3>You are a cultist of <span class='danger'><font size=3>Nar-Sie</font></span>!</font><br>
-				I, the Geometer of Blood, want you to thin the veil between reality and his realm<br>
+				I, the Geometer of Blood, want you to thin the veil between your reality and my realm<br>
 				so I can pull this place onto my plane of existence.<br>
 				You've managed to get a job here, and the time has come to put our plan into motion.<br>
 				However, the veil is currently so thick that I can barely bestow any power to you.<br>

--- a/code/datums/gamemode/role/cultist.dm
+++ b/code/datums/gamemode/role/cultist.dm
@@ -3,38 +3,60 @@
 	name = "Cultist"
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Chaplain", "Head of Personnel", "Internal Affairs Agent")
 	logo_state = "cult-logo"
+	greets = list("default","custom","roundstart","admintoggle")
 
+/datum/role/cultist/New(var/datum/mind/M, var/datum/faction/fac=null, var/new_id)
+	..()
+	wikiroute = role_wiki[ROLE_CULTIST]
 
 /datum/role/cultist/OnPostSetup()
 	. = ..()
 	if(!.)
 		return
 
+	antag.current.add_language(LANGUAGE_CULT)
 	if(!(locate(/spell/cult) in antag.current.spell_list))
 		antag.current.add_spell(new /spell/cult/trace_rune, "cult_spell_ready", /obj/abstract/screen/movable/spell_master/bloodcult)
 		antag.current.add_spell(new /spell/cult/erase_rune, "cult_spell_ready", /obj/abstract/screen/movable/spell_master/bloodcult)
 
 /datum/role/cultist/RemoveFromRole(var/datum/mind/M)
+	antag.current.remove_language(LANGUAGE_CULT)
 	for(var/spell/cult/spell_to_remove in antag.current.spell_list)
 		antag.current.remove_spell(spell_to_remove)
 	..()
 
-/datum/role/cultist/Greet()
-	to_chat(antag.current, {"<span class='sinister'><font size=3>You are a cultist of <span class='danger'><font size=3>Nar-Sie</font></span>!</font><br>
-	I, the Geometer of Blood want you to thin the veil between reality and his realm<br>
-	so I can pull this place onto my plane of existence.<br>
-	You've managed to get a job here, and the time has come to put our plan into motion.<br>
-	However the veil is currently so thick that I can barely bestow any power to you.<br>
-	Other cultists made their way into the crew. Talk to them. <span class='danger'>Self Other Technology</span>!<br>
-	Meet up with them. Raise an altar in my name. <span class='danger'>Blood Technology Join</span>!<br>
-	</span>"})
-
-/*
-/datum/role/cultist/RoleTopic(href, href_list)
-	..()
-	if(!ismob(usr))
+/datum/role/cultist/Greet(var/greeting,var/custom)
+	if(!greeting)
 		return
-*/
+
+	var/icon/logo = icon('icons/logos.dmi', logo_state)
+	switch(greeting)
+		if ("roundstart")
+			to_chat(antag.current, {"<img src='data:image/png;base64,[icon2base64(logo)]' style='position: relative; top: 10;'/> <span class='sinister'><font size=3>You are a cultist of <span class='danger'><font size=3>Nar-Sie</font></span>!</font><br>
+				I, the Geometer of Blood want you to thin the veil between reality and his realm<br>
+				so I can pull this place onto my plane of existence.<br>
+				You've managed to get a job here, and the time has come to put our plan into motion.<br>
+				However the veil is currently so thick that I can barely bestow any power to you.<br>
+				Other cultists made their way into the crew. Talk to them. <span class='danger'>Self Other Technology</span>!<br>
+				Meet up with them. Raise an altar in my name. <span class='danger'>Blood Technology Join</span>!<br>
+				</span>"})
+		if ("admintoggle")
+			to_chat(antag.current, "<img src='data:image/png;base64,[icon2base64(logo)]' style='position: relative; top: 10;'/> <span class='sinister'>You catch a glimpse of the Realm of Nar-Sie, The Geometer of Blood. You now see how flimsy the world is, you see that it should be open to the knowledge of Nar-Sie.</span>")
+			to_chat(antag.current, "<span class='sinister'>Assist your new compatriots in their dark dealings. Their goal is yours, and yours is theirs. You serve the Dark One above all else. Bring It back.</span>")
+		if ("custom")
+			to_chat(antag.current, "<img src='data:image/png;base64,[icon2base64(logo)]' style='position: relative; top: 10;'/> <span class='sinister'>[custom]</span>")
+		else
+			if (faction && faction.ID == BLOODCULT)
+				to_chat(antag.current, "<img src='data:image/png;base64,[icon2base64(logo)]' style='position: relative; top: 10;'/> <span class='sinister'>You are a lone cultist. You've spent years studying the language of Nar-Sie, but haven't associated with his followers.</span>")
+			else
+				to_chat(antag.current, "<img src='data:image/png;base64,[icon2base64(logo)]' style='position: relative; top: 10;'/> <span class='sinister'>You are cultist, from the cult of Nar-Sie, the Geometer of Blood.</span>")
+
+
+	to_chat(antag.current, "<span class='info'><a HREF='?src=\ref[antag.current];getwiki=[wikiroute]'>(Wiki Guide)</a></span>")
+	to_chat(antag.current, "<span class='sinister'>You find yourself to be well-versed in the runic alphabet of the cult.</span>")
+
+
+
 
 /mob/living/carbon/proc/muted()
 	return (iscultist(src) && reagents && reagents.has_reagent(HOLYWATER))

--- a/code/datums/gamemode/role/role.dm
+++ b/code/datums/gamemode/role/role.dm
@@ -96,7 +96,9 @@
 
 	var/icon/logo_state = "synd-logo"
 
-	var/list/greets = list()
+	var/list/greets = list("default","custom")
+
+	var/wikiroute
 
 /datum/role/New(var/datum/mind/M, var/datum/faction/fac=null, var/new_id)
 	// Link faction.
@@ -238,12 +240,19 @@
  - <a href='?src=\ref[usr];priv_msg=\ref[M]'>(priv msg)</a>
  - <a href='?_src_=holder;traitor=\ref[M]'>(role panel)</a>"}
 
-/datum/role/proc/Greet(var/you_are=1)
-	if(you_are) //Getting a bit philosphical, but there we go
-		to_chat(antag.current, "<B>You are \a [name][faction ? ", a member of the [faction.GetObjectivesMenuHeader()]":"."]</B>")
-	to_chat(antag.current, "[ReturnObjectivesString(check_name = FALSE)]")
-	antag.store_memory("[ReturnObjectivesString(check_name = FALSE)]")
+/datum/role/proc/Greet(var/greeting,var/custom)
+	if(!greeting)
+		return
 
+	var/icon/logo = icon('icons/logos.dmi', logo_state)
+	switch(greeting)
+		if ("custom")
+			to_chat(antag.current, "<img src='data:image/png;base64,[icon2base64(logo)]' style='position: relative; top: 10;'/> <B>[custom]</B>")
+		else
+			to_chat(antag.current, "<img src='data:image/png;base64,[icon2base64(logo)]' style='position: relative; top: 10;'/> <B>You are \a [name][faction ? ", a member of the [faction.GetObjectivesMenuHeader()]":"."]</B>")
+
+/datum/role/proc/AnnounceObjectives()
+	to_chat(antag.current, "[ReturnObjectivesString(check_name = FALSE)]")
 
 /datum/role/proc/PreMindTransfer(var/datum/mind/M)
 	return
@@ -289,11 +298,17 @@
 
 	to_chat(world, text)
 
+/datum/role/proc/extraPanelButtons()
+	var/dat = ""
+	//example:
+	//dat = " - <a href='?src=\ref[M];spawnpoint=\ref[src]'>(move to spawn)</a>"
+	return dat
+
 /datum/role/proc/GetMemory(var/datum/mind/M, var/admin_edit = FALSE)
 	var/icon/logo = icon('icons/logos.dmi', logo_state)
 	var/text = "<b><img src='data:image/png;base64,[icon2base64(logo)]' style='position: relative; top: 10;'/> [name]</b>"
 	if (admin_edit)
-		text += " - <a href='?src=\ref[M];role_edit=\ref[src];remove_role=1'>(remove)</a>"
+		text += " - <a href='?src=\ref[M];role_edit=\ref[src];remove_role=1'>(remove)</a> - <a href='?src=\ref[M];greet_role=\ref[src]'>(greet)</a>[extraPanelButtons()]"
 	text += "<br>faction: "
 	if (faction)
 		text += faction.name

--- a/code/datums/gamemode/role/role.dm
+++ b/code/datums/gamemode/role/role.dm
@@ -96,6 +96,8 @@
 
 	var/icon/logo_state = "synd-logo"
 
+	var/list/greets = list()
+
 /datum/role/New(var/datum/mind/M, var/datum/faction/fac=null, var/new_id)
 	// Link faction.
 	faction=fac

--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -10,6 +10,7 @@
 	disallow_job = FALSE
 	restricted_jobs = list("AI", "Cyborg", "Mobile MMI", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Chaplain")
 	logo_state = "vampire-logo"
+	greets = list("default","custom","admintoggle")
 
 
 	// -- Vampire mechanics --
@@ -28,14 +29,28 @@
 
 	var/static/list/roundstart_powers = list(/datum/power/vampire/hypnotise, /datum/power/vampire/glare, /datum/power/vampire/rejuvenate)
 
-/datum/role/vampire/Greet(var/you_are = TRUE)
-	var/dat
-	if (you_are)
-		dat = "<span class='danger'>You are a Vampire!</br></span>"
-	dat += {"To drink blood from somebody, just bite their head (switch to harm intent, enable biting and attack the victim in the head with an empty hand). Drink blood to gain new powers and use coffins to regenerate your body if injured.
-	You are weak to holy things and starlight. Don't go into space and avoid the Chaplain, the chapel, and especially Holy Water."}
-	to_chat(antag.current, dat)
-	to_chat(antag.current, "<B>You must complete the following tasks:</B>")
+/datum/role/vampire/New(var/datum/mind/M, var/datum/faction/fac=null, var/new_id)
+	..()
+	wikiroute = role_wiki[ROLE_VAMPIRE]
+
+/datum/role/vampire/Greet(var/greeting,var/custom)
+	if(!greeting)
+		return
+
+	var/icon/logo = icon('icons/logos.dmi', logo_state)
+	switch(greeting)
+		if ("custom")
+			to_chat(antag.current, "<img src='data:image/png;base64,[icon2base64(logo)]' style='position: relative; top: 10;'/> [custom]")
+		if ("admintoggle")
+			to_chat(antag.current, "<img src='data:image/png;base64,[icon2base64(logo)]' style='position: relative; top: 10;'/> <span class='danger'>Your powers are awoken. Your lust for blood grows... You are a Vampire!</span></B>")
+		else
+			to_chat(antag.current, "<img src='data:image/png;base64,[icon2base64(logo)]' style='position: relative; top: 10;'/> <span class='danger'>You are a Vampire!</br></span>")
+			to_chat(antag.current, "To drink blood from somebody, just bite their head (switch to harm intent, enable biting and attack the victim in the head with an empty hand).\
+				 Drink blood to gain new powers and use coffins to regenerate your body if injured.\
+				 You are weak to holy things and starlight.\
+				 Don't go into space and avoid the Chaplain, the chapel, and especially Holy Water.")
+
+	to_chat(antag.current, "<span class='info'><a HREF='?src=\ref[antag.current];getwiki=[wikiroute]'>(Wiki Guide)</a></span>")
 	antag.current << sound('sound/effects/vampire_intro.ogg')
 
 /datum/role/vampire/OnPostSetup()

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -464,6 +464,16 @@
 			return
 		assigned_role = new_job
 
+	if (href_list["greet_role"])
+		var/datum/role/R = locate(href_list["greet_role"])
+		var/chosen_greeting
+		var/custom_greeting
+		if (R.greets.len)
+			chosen_greeting = input("Choose a greeting", "Assigned role", null) as null|anything in R.greets
+			if (chosen_greeting == "custom")
+				custom_greeting = input("Choose a custom greeting", "Assigned role", "")
+			R.Greet(chosen_greeting,custom_greeting)
+
 	if (href_list["add_role"])
 		var/list/available_roles = list()
 		for(var/role in subtypesof(/datum/role))
@@ -485,7 +495,7 @@
 		var/list/all_factions = list()
 		if (alert("Do you want that role to be part of a faction?", "Assigned role", "Yes", "No") == "Yes")
 			all_factions = get_faction_list()
-			var/join_faction = input("Select new faction", "Assigned faction", null) as null|anything in all_factions
+			joined_faction = input("Select new faction", "Assigned faction", null) as null|anything in all_factions
 
 
 		var/role_type = available_roles[new_role]
@@ -494,8 +504,13 @@
 			WARNING("Role killed itself or was otherwise missing!")
 			return
 
-		if (alert("Do you want to greet them as their new role?", "Assigned role", "Yes", "No") == "Yes")
-			var/
+		var/chosen_greeting
+		var/custom_greeting
+		if (newRole.greets.len)
+			if (alert("Do you want to greet them as their new role?", "Assigned role", "Yes", "No") == "Yes")
+				chosen_greeting = input("Choose a greeting", "Assigned role", null) as null|anything in newRole.greets
+				if (chosen_greeting == "custom")
+					custom_greeting = input("Choose a custom greeting", "Assigned role", "")
 
 		if(!newRole.AssignToRole(src,1))//it shouldn't fail since we're using our admin powers to force the role
 			newRole.Drop()//but just in case
@@ -515,7 +530,9 @@
 					joined.members.Add(newRole)
 					newRole.faction = joined
 
-		newRole.OnPostSetup(FALSE)//later we might make custom Greet() for admin-designated antags.
+		newRole.OnPostSetup(FALSE)
+		if (chosen_greeting)
+			newRole.Greet(chosen_greeting,custom_greeting)
 
 	else if(href_list["role_edit"])
 		var/datum/role/R = locate(href_list["role_edit"])

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -471,8 +471,10 @@
 		if (R.greets.len)
 			chosen_greeting = input("Choose a greeting", "Assigned role", null) as null|anything in R.greets
 			if (chosen_greeting == "custom")
-				custom_greeting = input("Choose a custom greeting", "Assigned role", "")
-			R.Greet(chosen_greeting,custom_greeting)
+				custom_greeting = input("Choose a custom greeting", "Assigned role", "") as null|text
+
+			if ((chosen_greeting && chosen_greeting != "custom") || (chosen_greeting == "custom" && custom_greeting))
+				R.Greet(chosen_greeting,custom_greeting)
 
 	if (href_list["add_role"])
 		var/list/available_roles = list()
@@ -510,7 +512,7 @@
 			if (alert("Do you want to greet them as their new role?", "Assigned role", "Yes", "No") == "Yes")
 				chosen_greeting = input("Choose a greeting", "Assigned role", null) as null|anything in newRole.greets
 				if (chosen_greeting == "custom")
-					custom_greeting = input("Choose a custom greeting", "Assigned role", "")
+					custom_greeting = input("Choose a custom greeting", "Assigned role", "") as null|text
 
 		if(!newRole.AssignToRole(src,1))//it shouldn't fail since we're using our admin powers to force the role
 			newRole.Drop()//but just in case
@@ -531,7 +533,7 @@
 					newRole.faction = joined
 
 		newRole.OnPostSetup(FALSE)
-		if (chosen_greeting)
+		if ((chosen_greeting && chosen_greeting != "custom") || (chosen_greeting == "custom" && custom_greeting))
 			newRole.Greet(chosen_greeting,custom_greeting)
 
 	else if(href_list["role_edit"])


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7573912/36637238-35f2e9e4-19d8-11e8-87c2-546f62e326be.png)

* when adding a role via the role panel, you can now specify a faction and/or a greet message so the player gets them all at the same time.
* the role panel now features (greet) buttons for roles.
* Greet() now takes two args. The first one lets you specify the greet message (said arg must also be part of the role's greets list var so it can be chosen from the role panel) so each role can have multiple greet messages. the second one can carry an optional custom greeting.
* improved the Communication rune's message transmissions a bit.
* Cultists now learn/forget the Cult language upon their role getting added/removed.
* added an extraPanelButtons() role proc so extra buttons can be set up to appear on the role panel (for example, buttons to teleport the player to spawn or equip him)