### PR TITLE
Removes harmless weapons generating blood overlays or splatters

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -249,7 +249,7 @@ emp_act
 				knock_out_teeth(user)
 
 	var/bloody = FALSE
-	if(((I.damtype == BRUTE) || (I.damtype == HALLOSS)) && prob(25 + (I.force * 2)))
+	if(I.force && ((I.damtype == BRUTE) || (I.damtype == HALLOSS)) && prob(25 + (I.force * 2)))
 		I.add_blood(src)	//Make the weapon bloody, not the person.
 		if(prob(33))
 			bloody = TRUE


### PR DESCRIPTION
This fixes attacks with force 0 weapons like plastic bags and toy swords making people, items and turfs bloody. You'll have to use something with at least a little force like a newspaper to generate blood effects. I know it's weird that this whole block of code is totally disconnected from any actual wounding and bleeding mechanics but that will have to wait for another PR.