### PR TITLE
Fixes Blind and Mutate not appearing on the spellbook

### DIFF
--- a/code/modules/spells/targeted/genetic.dm
+++ b/code/modules/spells/targeted/genetic.dm
@@ -52,6 +52,7 @@ code\game\\dna\genes\goon_powers.dm
 	hud_state = "wiz_blind"
 
 	price = 0.5 * Sp_BASE_PRICE //Half of the normal spell price
+	user_type = USER_TYPE_WIZARD
 
 /spell/targeted/genetic/mutate
 	name = "Mutate"
@@ -72,3 +73,4 @@ code\game\\dna\genes\goon_powers.dm
 	cooldown_min = 300 //25 deciseconds reduction per rank
 
 	hud_state = "wiz_hulk"
+	user_type = USER_TYPE_WIZARD


### PR DESCRIPTION
Fixes #17623

:cl:
 * bugfix: Fixed a bug that prevented the Blind and Mutate spells from appearing in wizard spellbooks.