### PR TITLE
Fixes borer arm-hook firing on shift-click

### DIFF
--- a/code/modules/mob/living/simple_animal/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer.dm
@@ -1187,6 +1187,8 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 
 /mob/living/simple_animal/borer/ClickOn( var/atom/A, var/params )
 	..()
+	if(params2list(params)["shift"])
+		return
 	if(host)
 		if(extend_o_arm_unlocked)
 			if(hostlimb == LIMB_RIGHT_ARM || hostlimb == LIMB_LEFT_ARM)


### PR DESCRIPTION
Closes #16845
Closes #16791
Not sure if this is the most efficient way to do this, but it works.
:cl:
* bugfix: The borer extend-o-arm will no longer fire when shift-clicking.