### PR TITLE
Removes the recipe for hyperzine.

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -84,7 +84,7 @@
 	name = "Creatine"
 	id = CREATINE
 	result = CREATINE
-	required_reagents = list(NUTRIMENT = 1, BICARIDINE = 1, HYPERZINE = 1, MUTAGEN = 1)
+	required_reagents = list(NUTRIMENT = 1, BICARIDINE = 1, SUGAR = 1, MUTAGEN = 1)
 	result_amount = 2
 
 /datum/chemical_reaction/discount
@@ -381,14 +381,14 @@
 	result = BICARIDINE
 	required_reagents = list(INAPROVALINE = 1, CARBON = 1)
 	result_amount = 2
-
+/*
 /datum/chemical_reaction/hyperzine
 	name = "Hyperzine"
 	id = HYPERZINE
 	result = HYPERZINE
 	required_reagents = list(SUGAR = 1, PHOSPHORUS = 1, SULFUR = 1,)
 	result_amount = 3
-
+*/
 /datum/chemical_reaction/ryetalyn
 	name = "Ryetalyn"
 	id = RYETALYN
@@ -2992,7 +2992,7 @@
 	name = "hardcore induced heart attack"
 	id = MEDCORES
 	result = CHEESYGLOOP
-	required_reagents = list(MEDCORES = 0.1, HYPERZINE = 0.1)
+	required_reagents = list(MEDCORES = 0.1, SUGAR = 0.1)
 	result_amount = 2
 
 /datum/chemical_reaction/lithotorcrazine
@@ -3045,12 +3045,12 @@
 	required_reagents = list(CARBON = 1, SACID = 2)
 	required_temp = T0C + 450
 	result_amount = 1
-	
+
 /datum/chemical_reaction/albuterol
 	name = "Albuterol"
 	id = ALBUTEROL
 	result = ALBUTEROL
-	required_reagents = list(HYPERZINE = 1, INAPROVALINE = 1)
+	required_reagents = list(SUGAR = 1, INAPROVALINE = 1)
 	result_amount = 2
 
 #undef ALERT_AMOUNT_ONLY


### PR DESCRIPTION
This PR currently does two things.
Removes the recipe for hyperzine and replaces hyperzine for sugar in other recipes that require it.
You can still acquire hyperzine by other methods like borers, and trail mix but I'm willing to hunt down every easy way to acquire hyperzine and remove or nerf them.
The reason for the sugar change is so it doesn't affect the balance of other chems that require it in terms of difficulty to obtain since hyperzine required sugar and shouldn't cause issues with other reactions too much.
To avoid any confusion.
<h2>This PR does not remove hyperzine as a chemical. It just makes it harder to get. You can find it in places like trailmix still.</h2>

:cl:
 * rscdel: Removed the recipe for hyperzine. However it is still obtainable outside of chemistry in places like borers and botany.
 * tweak: Replaced hyperzine for sugar in other recipes that require it.