### PR TITLE
Snowplanet micro away mission

### DIFF
--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -2432,6 +2432,10 @@ proc/process_adminbus_teleport_locs()
 	name = "Leviathan"
 	icon_state = "mining_production"
 
+/area/awaymission/snowplanet
+	name = "snowplanet"
+	icon_state = "mining_production"
+
 /////////////////////////////////////////////////////////////////////
 /*
  Lists of areas to be used with is_type_in_list.

--- a/maps/RandomZLevels/snowplanet.dmm
+++ b/maps/RandomZLevels/snowplanet.dmm
@@ -1,52 +1,52 @@
 "a" = (/turf/simulated/wall/invulnerable/ice,/area)
-"b" = (/turf/unsimulated/mineral/random/high_chance,/area/mine/unexplored)
-"c" = (/turf/simulated/floor/plating/snow/cold,/area/awaymission/snowplanet)
-"d" = (/obj/structure/flora/ausbushes/fullgrass,/turf/simulated/floor/plating/snow/cold,/area/awaymission/snowplanet)
-"e" = (/obj/structure/flora/rock,/turf/simulated/floor/plating/snow/cold,/area/awaymission/snowplanet)
-"f" = (/obj/structure/flora/rock/pile/snow,/turf/simulated/floor/plating/snow/cold,/area/awaymission/snowplanet)
-"g" = (/obj/structure/flora/bush,/turf/simulated/floor/plating/snow/cold,/area/awaymission/snowplanet)
-"h" = (/obj/structure/flora/tree/pine,/turf/simulated/floor/plating/snow/cold,/area/awaymission/snowplanet)
-"i" = (/obj/structure/flora/rock/pile,/turf/simulated/floor/plating/snow/cold,/area/awaymission/snowplanet)
-"j" = (/obj/structure/flora/tree/dead,/turf/simulated/floor/plating/snow/cold,/area/awaymission/snowplanet)
-"k" = (/obj/structure/flora/grass/both,/turf/simulated/floor/plating/snow/cold,/area/awaymission/snowplanet)
-"l" = (/obj/structure/flora/tree_stump,/turf/simulated/floor/plating/snow/cold,/area/awaymission/snowplanet)
-"m" = (/mob/living/simple_animal/crab/snowy,/turf/simulated/floor/plating/snow/cold,/area/awaymission/snowplanet)
-"n" = (/obj/structure/window/barricade/snow,/turf/simulated/floor/plating/snow/cold,/area/awaymission/snowplanet)
+"b" = (/turf/unsimulated/mineral/snow,/area/mine/unexplored)
+"c" = (/turf/unsimulated/floor/snow,/area/awaymission/snowplanet)
+"d" = (/obj/structure/flora/ausbushes/fullgrass,/turf/unsimulated/floor/snow,/area/awaymission/snowplanet)
+"e" = (/obj/structure/flora/rock,/turf/unsimulated/floor/snow,/area/awaymission/snowplanet)
+"f" = (/obj/structure/flora/rock/pile/snow,/turf/unsimulated/floor/snow,/area/awaymission/snowplanet)
+"g" = (/obj/structure/flora/bush,/turf/unsimulated/floor/snow,/area/awaymission/snowplanet)
+"h" = (/obj/structure/flora/tree/pine,/turf/unsimulated/floor/snow,/area/awaymission/snowplanet)
+"i" = (/obj/structure/flora/rock/pile,/turf/unsimulated/floor/snow,/area/awaymission/snowplanet)
+"j" = (/obj/structure/flora/tree/dead,/turf/unsimulated/floor/snow,/area/awaymission/snowplanet)
+"k" = (/obj/structure/flora/grass/both,/turf/unsimulated/floor/snow,/area/awaymission/snowplanet)
+"l" = (/obj/structure/flora/tree_stump,/turf/unsimulated/floor/snow,/area/awaymission/snowplanet)
+"m" = (/mob/living/simple_animal/crab/snowy,/turf/unsimulated/floor/snow,/area/awaymission/snowplanet)
+"n" = (/obj/structure/window/barricade/snow,/turf/unsimulated/floor/snow,/area/awaymission/snowplanet)
 "o" = (/turf/simulated/wall,/area/awaymission/snowplanet)
 "p" = (/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced{dir = 4},/obj/structure/window/reinforced{dir = 8},/obj/structure/grille,/turf/simulated/floor/plating,/area/awaymission/snowplanet)
 "q" = (/turf/simulated/floor{icon_state = "dark"},/area/awaymission/snowplanet)
 "r" = (/obj/machinery/gateway{dir = 9},/obj/effect/decal/warning_stripes{tag = "icon-warning (NORTHWEST)"; icon_state = "warning"; dir = 9},/turf/simulated/floor/bluegrid,/area/awaymission/snowplanet)
 "s" = (/obj/machinery/gateway{dir = 1},/turf/simulated/floor/bluegrid,/area/awaymission/snowplanet)
 "t" = (/obj/machinery/gateway{dir = 5},/obj/effect/decal/warning_stripes{tag = "icon-warning (NORTHEAST)"; icon_state = "warning"; dir = 5},/turf/simulated/floor/bluegrid,/area/awaymission/snowplanet)
-"u" = (/obj/structure/flora/ausbushes/sparsegrass,/turf/simulated/floor/plating/snow/cold,/area/awaymission/snowplanet)
+"u" = (/obj/structure/flora/ausbushes/sparsegrass,/turf/unsimulated/floor/snow,/area/awaymission/snowplanet)
 "v" = (/obj/machinery/gateway{dir = 8},/turf/simulated/floor/bluegrid,/area/awaymission/snowplanet)
 "w" = (/obj/machinery/gateway/centeraway,/obj/effect/decal/warning_stripes{dir = 4; icon_state = "unloading"},/turf/simulated/floor/light,/area/awaymission/snowplanet)
 "x" = (/obj/machinery/gateway{dir = 4},/turf/simulated/floor/bluegrid,/area/awaymission/snowplanet)
 "y" = (/obj/machinery/gateway{dir = 10},/obj/effect/decal/warning_stripes{tag = "icon-warning (SOUTHWEST)"; icon_state = "warning"; dir = 10},/turf/simulated/floor/bluegrid,/area/awaymission/snowplanet)
 "z" = (/obj/machinery/gateway,/obj/effect/decal/warning_stripes{tag = "icon-loading_area"; icon_state = "loading_area"; dir = 2},/turf/simulated/floor/bluegrid,/area/awaymission/snowplanet)
 "A" = (/obj/machinery/gateway{dir = 6},/obj/effect/decal/warning_stripes{tag = "icon-warning (SOUTHEAST)"; icon_state = "warning"; dir = 6},/turf/simulated/floor/bluegrid,/area/awaymission/snowplanet)
-"B" = (/obj/structure/flora/tree,/turf/simulated/floor/plating/snow/cold,/area/awaymission/snowplanet)
+"B" = (/obj/structure/flora/tree,/turf/unsimulated/floor/snow,/area/awaymission/snowplanet)
 "C" = (/turf/simulated/wall/mineral/wood,/area/awaymission/snowplanet)
 "D" = (/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced{dir = 4},/obj/structure/window/reinforced{dir = 8},/obj/structure/grille,/obj/structure/window/reinforced/tinted,/turf/simulated/floor/plating,/area/awaymission/snowplanet)
 "E" = (/obj/machinery/door/mineral/wood,/turf/simulated/floor/wood,/area/awaymission/snowplanet)
 "F" = (/obj/structure/hanging_lantern{dir = 8},/turf/simulated/floor/wood,/area/awaymission/snowplanet)
 "G" = (/turf/simulated/floor/wood,/area/awaymission/snowplanet)
 "H" = (/obj/machinery/space_heater/campfire/stove/fireplace,/turf/simulated/floor/wood,/area/awaymission/snowplanet)
-"I" = (/obj/structure/bed/chair/comfy/brown{dir = 4},/turf/simulated/floor/wood,/area/awaymission/snowplanet)
-"J" = (/obj/structure/table/woodentable,/turf/simulated/floor/wood,/area/awaymission/snowplanet)
-"K" = (/obj/structure/bed/chair/comfy/brown{dir = 8},/turf/simulated/floor/wood,/area/awaymission/snowplanet)
-"L" = (/obj/structure/bed/chair/wood/normal,/turf/simulated/floor/wood,/area/awaymission/snowplanet)
-"M" = (/obj/structure/bed/chair/wood/normal{dir = 1},/turf/simulated/floor/wood,/area/awaymission/snowplanet)
-"N" = (/mob/living/simple_animal/corgi/saint,/turf/simulated/floor/wood,/area/awaymission/snowplanet)
-"O" = (/obj/structure/hanging_lantern{dir = 4},/turf/simulated/floor/wood,/area/awaymission/snowplanet)
-"P" = (/obj/structure/window/reinforced{dir = 8},/obj/structure/window/reinforced{dir = 4},/obj/structure/window/reinforced{dir = 1},/obj/structure/grille,/turf/simulated/floor/plating,/area/awaymission/snowplanet)
-"Q" = (/obj/structure/closet/cabinet/snow,/turf/simulated/floor/wood,/area/awaymission/snowplanet)
-"R" = (/obj/structure/window/reinforced{dir = 8},/obj/structure/window/reinforced{dir = 4},/obj/structure/window/reinforced,/obj/structure/grille,/turf/simulated/floor/plating,/area/awaymission/snowplanet)
-"S" = (/obj/machinery/door/airlock/external,/turf/simulated/floor/plating/snow/cold,/area/awaymission/snowplanet)
-"T" = (/obj/structure/flora/ausbushes/ywflowers,/turf/simulated/floor/plating/snow/cold,/area/awaymission/snowplanet)
-"U" = (/turf/unsimulated/mineral/random,/area/mine/unexplored)
-"V" = (/obj/structure/flora/ausbushes/sunnybush,/turf/simulated/floor/plating/snow/cold,/area/awaymission/snowplanet)
-"W" = (/turf/unsimulated/mineral/random/high_chance_clown,/area/mine/unexplored)
+"I" = (/obj/item/stack/sheet/wood,/obj/item/stack/sheet/wood,/obj/item/weapon/lighter/zippo,/turf/simulated/floor/wood,/area/awaymission/snowplanet)
+"J" = (/obj/structure/bed/chair/comfy/brown{dir = 4},/turf/simulated/floor/wood,/area/awaymission/snowplanet)
+"K" = (/obj/structure/table/woodentable,/turf/simulated/floor/wood,/area/awaymission/snowplanet)
+"L" = (/obj/structure/bed/chair/comfy/brown{dir = 8},/turf/simulated/floor/wood,/area/awaymission/snowplanet)
+"M" = (/obj/structure/bed/chair/wood/normal,/turf/simulated/floor/wood,/area/awaymission/snowplanet)
+"N" = (/obj/structure/bed/chair/wood/normal{dir = 1},/turf/simulated/floor/wood,/area/awaymission/snowplanet)
+"O" = (/mob/living/simple_animal/corgi/saint,/turf/simulated/floor/wood,/area/awaymission/snowplanet)
+"P" = (/obj/structure/hanging_lantern{dir = 4},/turf/simulated/floor/wood,/area/awaymission/snowplanet)
+"Q" = (/obj/structure/window/reinforced{dir = 8},/obj/structure/window/reinforced{dir = 4},/obj/structure/window/reinforced{dir = 1},/obj/structure/grille,/turf/simulated/floor/plating,/area/awaymission/snowplanet)
+"R" = (/obj/structure/closet/cabinet/snow,/turf/simulated/floor/wood,/area/awaymission/snowplanet)
+"S" = (/obj/structure/window/reinforced{dir = 8},/obj/structure/window/reinforced{dir = 4},/obj/structure/window/reinforced,/obj/structure/grille,/turf/simulated/floor/plating,/area/awaymission/snowplanet)
+"T" = (/obj/machinery/door/airlock/external,/turf/unsimulated/floor/snow,/area/awaymission/snowplanet)
+"U" = (/obj/structure/flora/ausbushes/ywflowers,/turf/unsimulated/floor/snow,/area/awaymission/snowplanet)
+"V" = (/obj/structure/flora/ausbushes/sunnybush,/turf/unsimulated/floor/snow,/area/awaymission/snowplanet)
+"W" = (/obj/item/clothing/shoes/clown_shoes/elf,/obj/item/clothing/under/elf,/obj/item/clothing/head/elfhat,/turf/unsimulated/floor/snow,/area/awaymission/snowplanet)
 
 (1,1,1) = {"
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
@@ -71,32 +71,32 @@ acccccccgcccccccccccnoqyzAqonccccccccckcccccccccca
 acgccfcccccccccckcgcnpqqqqqpnccgcccccccccccgccccca
 acchccccccccccccgccnnoqqqqqonnccccccccccccccccccca
 acccckcccBcchcfccccnCoDoEoooCnecchcccccchckfccccca
-acccjccccccccccccccnCFGGGGHGCncccccchcckccccccccca
+acccjccccccccccccccnCFGGGGHICncccccchcckccccccccca
 accccccccccccccclccnpGGGGGGGpnccccccccccccccchccca
-acccccfgccfcccckcccnCGIJKGGLCnlckccccckcccckccccca
-accccccccccccccccccnpGGGGGGJpnccccccccccccccccccca
-acchcccckccjcccfccenCGGGGGGMCnccccccgccfcjccccccca
+acccccfgccfcccckcccnCGJKLGGMCnlckccccckcccckccccca
+accccccccccccccccccnpGGGGGGKpnccccccccccccccccccca
+acchcccckccjcccfccenCGGGGGGNCnccccccgccfcjccccccca
 accccccccccccccccccnpGGGGGGGpnlcccjcccccccccccccca
-accfcccccccccccccccnCGNGGGGOCnccccccccccccckchccca
+accfcccccccccccccccnCGOGGGGPCnccccccccccccckchccca
 acccgcchcccccfcckkcnCCCCECCCCnccccccccccccccccccca
-acccccccfccccccckkcnnnPQGGPnnncccckfccchcccccccfca
-acciccccccccccccccclcnRQGGRnccccccccccccckccccccca
-acccgccccccchccccckccgCCSCCccgccccccccccccchccccca
-acicchcccccccccccfcccTTTcTTTcccccchcccckccccccccca
-accccccckcccccccccckcTTTcTTTcccccccccccgccccccccca
-aUccUUUkcUcUiUUUccUcccglcVfcccccccccccccccccccccca
-aUUccUcUUUUecUUUUUcccccccccccccccccccfcckchcchccca
-aUUUUUUUUUUUUUbbbUcccccccccccccccccccjcccckcccccca
-aUUUUUUUUbUUUbbbUUcccjccccccccccccccccccccccccccca
-aUUUUUfkUUUUbbbbUcccicccccccckchccccccccccccccccca
-aUUUUUUcUUUbbUbbUcUccckcchcccicchccccccccccchcccca
-aUUUUUUUUUbbbbbUccUcccccccckccckcccccccchccccckcca
-aUUbbUUUbbUbbUUUcUccccccccfccccccchccccccccfccfcca
-aUUUbbbbbUUbUUUUkUccccccchccchckkccccckcckcccckcca
-aUUUbUUbUbbUUckUfUUkcckcccckckccccccccccccccccccca
-aUUbbUUUUUbUUUUUUUUccckchcccccfccchccfjcccccccccca
-aWWWWUUUUUbbUUUUUiccicccccccckcccccccccccccchcccca
-aWWWWUUfUUUUUUUUUUcfcccccchccccchcccccccccccccccca
-aWWWWUUUUUUUUUUUUUUckccckccchchcccccccccccccccccca
+acccccccfccccccckkcnnnQRGGQnnncccckfccchcccccccfca
+acciccccccccccccccclcnSRGGSnccccccccccccckccccccca
+acccgccccccchccccckccgCCTCCccgccccccccccccchccccca
+acicchcccccccccccfcccUUUcUUUcccccchcccckccccccccca
+accccccckcccccccccckcUUUcUUUcccccccccccgccccccccca
+abccbbbkcbcbibbbccbcccglcVfcccccccccccccccccccccca
+abbccbcbbbbecbbbbbcccccccccccccccccccfcckchcchccca
+abbbbbbbbbbbbbbbbbcccccccccccccccccccjcccckcccccca
+abbbbbbbbbbbbbbbbbcccjccccccccccccccccccccccccccca
+abbbbbfkbbbbbbbbbcccicccccccckchccccccccccccccccca
+abbbbbbcbbbbbbbbbcbccckcchcccicchccccccccccchcccca
+abbbbbbbbbbbbbbbccbcccccccckccckcccccccchccccckcca
+abbbbbbbbbbbbbbbcbccccccccfccccccchccccccccfccfcca
+abbbbbbbbbbbbbbbkbccccccchccchckkccccckcckcccckcca
+abbbbbbbbbbbbckbfbbkcckcccckckccccccccccccccccccca
+abbbbbbbbbbbbbbbbbbccckchccccWfccchccfjcccccccccca
+abbbbbbbbbbbbbbbbiccicccccccckcccccccccccccchcccca
+abbbbbbfbbbbbbbbbbcfcccccchccccchcccccccccccccccca
+abbbbbbbbbbbbbbbbbbckccckccchchcccccccccccccccccca
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 "}

--- a/maps/RandomZLevels/snowplanet.dmm
+++ b/maps/RandomZLevels/snowplanet.dmm
@@ -1,0 +1,102 @@
+"a" = (/turf/simulated/wall/invulnerable/ice,/area)
+"b" = (/turf/unsimulated/mineral/random/high_chance,/area/mine/unexplored)
+"c" = (/turf/simulated/floor/plating/snow/cold,/area/awaymission/snowplanet)
+"d" = (/obj/structure/flora/ausbushes/fullgrass,/turf/simulated/floor/plating/snow/cold,/area/awaymission/snowplanet)
+"e" = (/obj/structure/flora/rock,/turf/simulated/floor/plating/snow/cold,/area/awaymission/snowplanet)
+"f" = (/obj/structure/flora/rock/pile/snow,/turf/simulated/floor/plating/snow/cold,/area/awaymission/snowplanet)
+"g" = (/obj/structure/flora/bush,/turf/simulated/floor/plating/snow/cold,/area/awaymission/snowplanet)
+"h" = (/obj/structure/flora/tree/pine,/turf/simulated/floor/plating/snow/cold,/area/awaymission/snowplanet)
+"i" = (/obj/structure/flora/rock/pile,/turf/simulated/floor/plating/snow/cold,/area/awaymission/snowplanet)
+"j" = (/obj/structure/flora/tree/dead,/turf/simulated/floor/plating/snow/cold,/area/awaymission/snowplanet)
+"k" = (/obj/structure/flora/grass/both,/turf/simulated/floor/plating/snow/cold,/area/awaymission/snowplanet)
+"l" = (/obj/structure/flora/tree_stump,/turf/simulated/floor/plating/snow/cold,/area/awaymission/snowplanet)
+"m" = (/mob/living/simple_animal/crab/snowy,/turf/simulated/floor/plating/snow/cold,/area/awaymission/snowplanet)
+"n" = (/obj/structure/window/barricade/snow,/turf/simulated/floor/plating/snow/cold,/area/awaymission/snowplanet)
+"o" = (/turf/simulated/wall,/area/awaymission/snowplanet)
+"p" = (/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced{dir = 4},/obj/structure/window/reinforced{dir = 8},/obj/structure/grille,/turf/simulated/floor/plating,/area/awaymission/snowplanet)
+"q" = (/turf/simulated/floor{icon_state = "dark"},/area/awaymission/snowplanet)
+"r" = (/obj/machinery/gateway{dir = 9},/obj/effect/decal/warning_stripes{tag = "icon-warning (NORTHWEST)"; icon_state = "warning"; dir = 9},/turf/simulated/floor/bluegrid,/area/awaymission/snowplanet)
+"s" = (/obj/machinery/gateway{dir = 1},/turf/simulated/floor/bluegrid,/area/awaymission/snowplanet)
+"t" = (/obj/machinery/gateway{dir = 5},/obj/effect/decal/warning_stripes{tag = "icon-warning (NORTHEAST)"; icon_state = "warning"; dir = 5},/turf/simulated/floor/bluegrid,/area/awaymission/snowplanet)
+"u" = (/obj/structure/flora/ausbushes/sparsegrass,/turf/simulated/floor/plating/snow/cold,/area/awaymission/snowplanet)
+"v" = (/obj/machinery/gateway{dir = 8},/turf/simulated/floor/bluegrid,/area/awaymission/snowplanet)
+"w" = (/obj/machinery/gateway/centeraway,/obj/effect/decal/warning_stripes{dir = 4; icon_state = "unloading"},/turf/simulated/floor/light,/area/awaymission/snowplanet)
+"x" = (/obj/machinery/gateway{dir = 4},/turf/simulated/floor/bluegrid,/area/awaymission/snowplanet)
+"y" = (/obj/machinery/gateway{dir = 10},/obj/effect/decal/warning_stripes{tag = "icon-warning (SOUTHWEST)"; icon_state = "warning"; dir = 10},/turf/simulated/floor/bluegrid,/area/awaymission/snowplanet)
+"z" = (/obj/machinery/gateway,/obj/effect/decal/warning_stripes{tag = "icon-loading_area"; icon_state = "loading_area"; dir = 2},/turf/simulated/floor/bluegrid,/area/awaymission/snowplanet)
+"A" = (/obj/machinery/gateway{dir = 6},/obj/effect/decal/warning_stripes{tag = "icon-warning (SOUTHEAST)"; icon_state = "warning"; dir = 6},/turf/simulated/floor/bluegrid,/area/awaymission/snowplanet)
+"B" = (/obj/structure/flora/tree,/turf/simulated/floor/plating/snow/cold,/area/awaymission/snowplanet)
+"C" = (/turf/simulated/wall/mineral/wood,/area/awaymission/snowplanet)
+"D" = (/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced{dir = 4},/obj/structure/window/reinforced{dir = 8},/obj/structure/grille,/obj/structure/window/reinforced/tinted,/turf/simulated/floor/plating,/area/awaymission/snowplanet)
+"E" = (/obj/machinery/door/mineral/wood,/turf/simulated/floor/wood,/area/awaymission/snowplanet)
+"F" = (/obj/structure/hanging_lantern{dir = 8},/turf/simulated/floor/wood,/area/awaymission/snowplanet)
+"G" = (/turf/simulated/floor/wood,/area/awaymission/snowplanet)
+"H" = (/obj/machinery/space_heater/campfire/stove/fireplace,/turf/simulated/floor/wood,/area/awaymission/snowplanet)
+"I" = (/obj/structure/bed/chair/comfy/brown{dir = 4},/turf/simulated/floor/wood,/area/awaymission/snowplanet)
+"J" = (/obj/structure/table/woodentable,/turf/simulated/floor/wood,/area/awaymission/snowplanet)
+"K" = (/obj/structure/bed/chair/comfy/brown{dir = 8},/turf/simulated/floor/wood,/area/awaymission/snowplanet)
+"L" = (/obj/structure/bed/chair/wood/normal,/turf/simulated/floor/wood,/area/awaymission/snowplanet)
+"M" = (/obj/structure/bed/chair/wood/normal{dir = 1},/turf/simulated/floor/wood,/area/awaymission/snowplanet)
+"N" = (/mob/living/simple_animal/corgi/saint,/turf/simulated/floor/wood,/area/awaymission/snowplanet)
+"O" = (/obj/structure/hanging_lantern{dir = 4},/turf/simulated/floor/wood,/area/awaymission/snowplanet)
+"P" = (/obj/structure/window/reinforced{dir = 8},/obj/structure/window/reinforced{dir = 4},/obj/structure/window/reinforced{dir = 1},/obj/structure/grille,/turf/simulated/floor/plating,/area/awaymission/snowplanet)
+"Q" = (/obj/structure/closet/cabinet/snow,/turf/simulated/floor/wood,/area/awaymission/snowplanet)
+"R" = (/obj/structure/window/reinforced{dir = 8},/obj/structure/window/reinforced{dir = 4},/obj/structure/window/reinforced,/obj/structure/grille,/turf/simulated/floor/plating,/area/awaymission/snowplanet)
+"S" = (/obj/machinery/door/airlock/external,/turf/simulated/floor/plating/snow/cold,/area/awaymission/snowplanet)
+"T" = (/obj/structure/flora/ausbushes/ywflowers,/turf/simulated/floor/plating/snow/cold,/area/awaymission/snowplanet)
+"U" = (/turf/unsimulated/mineral/random,/area/mine/unexplored)
+"V" = (/obj/structure/flora/ausbushes/sunnybush,/turf/simulated/floor/plating/snow/cold,/area/awaymission/snowplanet)
+"W" = (/turf/unsimulated/mineral/random/high_chance_clown,/area/mine/unexplored)
+
+(1,1,1) = {"
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+abccdbbcccccccccccccccccccccccccccccccccccccccccca
+adcdcbbecccfccccccccccccccccccccccccccccccccccccca
+acbcdcccccccccghchcccccchcccccccccccccccccccccccca
+adbbbdcicfccccccccfcchccccfchcccchcccchcccccjcccca
+acdbbcccckccccfkcccccccccccccccccccccccckcccccccca
+accccccccccccccccccgccjcccccccccccccgccccfccccgcca
+acjcikccccgccccccccccckcchcchccccfccccccccccccccca
+accfccchcccchccccccchcccfcccccccchccchcckcccccccca
+accccccccccccccjccccckccccccccchccccccccccchccccca
+accccccgchckccfccckccccccccccccckcckccfckcccccccca
+acccfcccccccccccccccccchccccccccccccccccccccccccca
+accccccccfckcccccccccfcccchcchcccccgcccccccgcfccca
+accckccccccccchccccccclcccccccccccccchccccccccccca
+accgcchccccmccccccgcnnnnnnnnnccccccccccckcccccccca
+accccccccccccccccgccnooopooonccchcccccccchccccccca
+acccccccccccccccccccnoqrstqonccccgcccjccccccccccca
+accccccuchcckfccgclcnpqvwxqpnclcccccfcccckcchcgcca
+acccccccgcccccccccccnoqyzAqonccccccccckcccccccccca
+acgccfcccccccccckcgcnpqqqqqpnccgcccccccccccgccccca
+acchccccccccccccgccnnoqqqqqonnccccccccccccccccccca
+acccckcccBcchcfccccnCoDoEoooCnecchcccccchckfccccca
+acccjccccccccccccccnCFGGGGHGCncccccchcckccccccccca
+accccccccccccccclccnpGGGGGGGpnccccccccccccccchccca
+acccccfgccfcccckcccnCGIJKGGLCnlckccccckcccckccccca
+accccccccccccccccccnpGGGGGGJpnccccccccccccccccccca
+acchcccckccjcccfccenCGGGGGGMCnccccccgccfcjccccccca
+accccccccccccccccccnpGGGGGGGpnlcccjcccccccccccccca
+accfcccccccccccccccnCGNGGGGOCnccccccccccccckchccca
+acccgcchcccccfcckkcnCCCCECCCCnccccccccccccccccccca
+acccccccfccccccckkcnnnPQGGPnnncccckfccchcccccccfca
+acciccccccccccccccclcnRQGGRnccccccccccccckccccccca
+acccgccccccchccccckccgCCSCCccgccccccccccccchccccca
+acicchcccccccccccfcccTTTcTTTcccccchcccckccccccccca
+accccccckcccccccccckcTTTcTTTcccccccccccgccccccccca
+aUccUUUkcUcUiUUUccUcccglcVfcccccccccccccccccccccca
+aUUccUcUUUUecUUUUUcccccccccccccccccccfcckchcchccca
+aUUUUUUUUUUUUUbbbUcccccccccccccccccccjcccckcccccca
+aUUUUUUUUbUUUbbbUUcccjccccccccccccccccccccccccccca
+aUUUUUfkUUUUbbbbUcccicccccccckchccccccccccccccccca
+aUUUUUUcUUUbbUbbUcUccckcchcccicchccccccccccchcccca
+aUUUUUUUUUbbbbbUccUcccccccckccckcccccccchccccckcca
+aUUbbUUUbbUbbUUUcUccccccccfccccccchccccccccfccfcca
+aUUUbbbbbUUbUUUUkUccccccchccchckkccccckcckcccckcca
+aUUUbUUbUbbUUckUfUUkcckcccckckccccccccccccccccccca
+aUUbbUUUUUbUUUUUUUUccckchcccccfccchccfjcccccccccca
+aWWWWUUUUUbbUUUUUiccicccccccckcccccccccccccchcccca
+aWWWWUUfUUUUUUUUUUcfcccccchccccchcccccccccccccccca
+aWWWWUUUUUUUUUUUUUUckccckccchchcccccccccccccccccca
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+"}


### PR DESCRIPTION
Quick little away mission to showcase the snowmap code that's been added.  It's small and future PRs will enlarge it as code is added.  The best way to get feedback on all the great content you guys have been adding is to use it somewhere.  **Currently there is no way to access it.**

It currently contains the snowmap corgi, snowmap wardrobe, and that's about it. The map has no exterior lighting which makes it feel a bit bigger than it is.  

In future PRs I'd like to add this as a "default" state for the gateway so the gateway always has a destination.  That removes the reliance on admins and player pop.  By doing that the gateway now has a use all of the time instead of just once in a blue moon.  As well, there's plenty of fun stuff that needs done like snow turfs, making space not appear when you blow up the ground, snowy mining tiles, et cetera.  Probably day/night variants as well.

![image](https://user-images.githubusercontent.com/8550416/36721566-444eef4a-1b79-11e8-9a90-39a7155b2cfb.png)

![image](https://user-images.githubusercontent.com/8550416/36721879-246de6a8-1b7a-11e8-824f-6a43e487a2a3.png)

