### PR TITLE
Uncucks the cube 2.0: AI camera boogaloo

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -96,7 +96,6 @@ var/list/ai_list = list()
 	default_language = all_languages[LANGUAGE_GALACTIC_COMMON]
 	real_name = pickedName
 	name = real_name
-	view_core()
 	anchored = 1
 	canmove = 0
 	setDensity(TRUE)

--- a/code/modules/mob/living/silicon/ai/login.dm
+++ b/code/modules/mob/living/silicon/ai/login.dm
@@ -8,4 +8,5 @@
 		for(var/obj/machinery/ai_status_display/O in machines) //change status
 			O.mode = 1
 			O.emotion = "Neutral"
+	view_core()
 	client.CAN_MOVE_DIAGONALLY = TRUE


### PR DESCRIPTION
Fixes #17617 

view_core() got moved to New() in #17324 , making the AI eye focus in the cuck cube before it gets teleported to its spawn point. This PR moves it back to Login()

:cl:
 * rscadd: Fixes AI starting with their cameras stuck in the roundstart cuck cube
