### PR TITLE
Supply total display for light replacers

### DIFF
--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -190,6 +190,7 @@
 
 
 		<h3>Supply Container:</h3>"} //It's not clear here, but the argument to build is the part of the typepath after /obj/item/weapon/light/
+		dat += {"<b>Filled: </b>[supply.contents.len]/[supply.storage_slots]"}
 		var/list/light_types = new()
 		var/lightname
 		for(var/obj/item/weapon/light/L in supply)
@@ -260,6 +261,7 @@
 
 
 		<h3>Supply Container:</h3>"}
+		dat += {"<b>Filled: </b>[supply.contents.len]/[supply.storage_slots]"}
 		var/list/light_types = new()
 		var/lightname
 		for(var/obj/item/weapon/light/L in supply)


### PR DESCRIPTION
Simple QoL addition to the light replacer: displaying the total slots filled and available in the supply box, so you don't have to mentally add up the lights to be sure they're less than 21 when fabricating.
:cl:
* tweak: Light replacers now show the total number of slots filled in the supply container.