### PR TITLE
Optimize obj/New by removing it

### DIFF
--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -45,10 +45,12 @@ Pipelines + Other Objects -> Pipe network
 	var/piping_layer = PIPING_LAYER_DEFAULT //used in multi-pipe-on-tile - pipes only connect if they're on the same pipe layer
 
 	internal_gravity = 1 // Ventcrawlers can move in pipes without gravity since they have traction.
-	holomap = TRUE
 
 	// If a pipe node isn't connected, should it be pixel shifted to fit the object?
 	var/ex_node_offset = 0
+
+/obj/machinery/atmospherics/supports_holomap()
+	return TRUE
 
 /obj/machinery/atmospherics/New()
 	..()

--- a/code/ATMOSPHERICS/components/binary_devices/binary_atmos_base.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/binary_atmos_base.dm
@@ -121,9 +121,7 @@
 	node2 = findConnecting(dir)
 
 	update_icon()
-	var/turf/T = loc
-	if (istype(T))
-		T.soft_add_holomap(src)
+	add_self_to_holomap()
 
 /obj/machinery/atmospherics/binary/build_network()
 	if(!network1 && node1)

--- a/code/ATMOSPHERICS/components/trinary_devices/trinary_base.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/trinary_base.dm
@@ -135,9 +135,7 @@ obj/machinery/atmospherics/trinary/initialize()
 
 
 	update_icon()
-	var/turf/T = loc
-	if (istype(T))
-		T.soft_add_holomap(src)
+	add_self_to_holomap()
 
 obj/machinery/atmospherics/trinary/build_network()
 	if(!network1 && node1)

--- a/code/ATMOSPHERICS/components/unary/unary_base.dm
+++ b/code/ATMOSPHERICS/components/unary/unary_base.dm
@@ -70,10 +70,7 @@
 				node = target
 				break
 	update_icon()
-
-	var/turf/T = loc
-	if (istype(T))
-		T.soft_add_holomap(src)
+	add_self_to_holomap()
 
 /obj/machinery/atmospherics/unary/build_network()
 	if(!network && node)

--- a/code/ATMOSPHERICS/pipes.dm
+++ b/code/ATMOSPHERICS/pipes.dm
@@ -349,7 +349,7 @@
 	if(!suppress_icon_check)
 		update_icon()
 
-	T.soft_add_holomap(src)
+	add_self_to_holomap()
 
 /obj/machinery/atmospherics/pipe/simple/disconnect(obj/machinery/atmospherics/reference)
 	if(reference == node1)
@@ -594,7 +594,7 @@
 	if(!skip_icon_update)
 		update_icon()
 
-	T.soft_add_holomap(src)
+	add_self_to_holomap()
 
 /obj/machinery/atmospherics/pipe/manifold/scrubbers
 	name = "\improper Scrubbers pipe"
@@ -815,7 +815,7 @@
 	if(!skip_update_icon)
 		update_icon()
 
-	T.soft_add_holomap(src)
+	add_self_to_holomap()
 
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers
 	name = "\improper Scrubbers pipe"
@@ -1063,7 +1063,7 @@
 	if(!skip_update_icon)
 		update_icon()
 
-	T.soft_add_holomap(src)
+	add_self_to_holomap()
 
 /obj/machinery/atmospherics/pipe/layer_manifold/findAllConnections(var/connect_dirs)
 	for(var/direction in cardinal)
@@ -1246,7 +1246,7 @@
 	if(!skip_update_icon)
 		update_icon()
 
-	T.soft_add_holomap(src)
+	add_self_to_holomap()
 
 /obj/machinery/atmospherics/pipe/layer_adapter/findAllConnections(var/connect_dirs)
 	for(var/direction in cardinal)

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -79,9 +79,9 @@
 	var/list/TLV = list()
 
 	machine_flags = WIREJACK
-	holomap = TRUE
-	auto_holomap = TRUE
 
+/obj/machinery/alarm/supports_holomap()
+	return TRUE
 
 /obj/machinery/alarm/xenobio
 	preset = AALARM_PRESET_HUMAN
@@ -183,6 +183,7 @@
 
 
 /obj/machinery/alarm/initialize()
+	add_self_to_holomap()
 	set_frequency(frequency)
 	if (!master_is_operating())
 		elect_master()
@@ -919,8 +920,12 @@ FIRE ALARM
 	var/wiresexposed = 0
 	var/buildstage = 2 // 2 = complete, 1 = no wires,  0 = circuit gone
 
-	holomap = TRUE
-	auto_holomap = TRUE
+/obj/machinery/firealarm/supports_holomap()
+	return TRUE
+
+/obj/machinery/firealarm/initialize()
+	..()
+	add_self_to_holomap()
 
 /obj/machinery/firealarm/update_icon()
 	overlays.len = 0

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -8,10 +8,12 @@
 	anchored = 1.0
 	var/buildstage = 2
 	var/on = 0
-	//	luminosity = 1
 
-	holomap = TRUE
-	auto_holomap = TRUE
+/obj/machinery/light_switch/supports_holomap()
+	return TRUE
+
+/obj/machinery/light_switch/initialize()
+	add_self_to_holomap()
 
 /obj/machinery/light_switch/New(var/loc, var/ndir, var/building = 2)
 	..()

--- a/code/game/objects/items/devices/holomap.dm
+++ b/code/game/objects/items/devices/holomap.dm
@@ -74,7 +74,7 @@
 		target.holomap_data.Cut()
 
 	for (var/obj/O in target)
-		if (O.holomap)
+		if (O.supports_holomap())
 			target.add_holomap(O)
 
 	to_chat(user, "You reset the holomap data.")

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -12,11 +12,15 @@
 	var/last_tick //used to delay the powercheck
 	var/buildstage = 0
 
-	holomap = TRUE
-	auto_holomap = TRUE
+/obj/item/device/radio/intercom/supports_holomap()
+	return TRUE
 
 /obj/item/device/radio/intercom/universe/New()
 	return ..()
+
+/obj/item/device/radio/intercom/initialize()
+	..()
+	add_self_to_holomap()
 
 /obj/item/device/radio/intercom/New(turf/loc, var/ndir = 0, var/building = 3)
 	..()

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -706,11 +706,6 @@
 		holomap_data = list()
 	holomap_data += I
 
-// Calls the above, but only if the game has not yet started.
-/turf/proc/soft_add_holomap(var/atom/movable/AM)
-	if (!ticker || ticker.current_state != GAME_STATE_PLAYING)
-		add_holomap(AM)
-
 // Goddamnit BYOND.
 // So for some reason, I incurred a rendering issue with the usage of FLOAT_PLANE for the holomap plane.
 //   (For some reason the existance of underlays prevented the main icon and overlays to render)

--- a/code/modules/media/broadcast/receivers/radio.dm
+++ b/code/modules/media/broadcast/receivers/radio.dm
@@ -99,8 +99,12 @@
 	volume=0.25 // 25% of user's set volume.
 	var/buildstage = 0
 
-	holomap = TRUE
-	auto_holomap = TRUE
+/obj/machinery/media/receiver/boombox/wallmount/supports_holomap()
+	return TRUE
+
+/obj/machinery/media/receiver/boombox/wallmount/initialize()
+	..()
+	add_self_to_holomap()
 
 /obj/machinery/media/receiver/boombox/wallmount/New(turf/loc,var/ndir=0,var/building=2)
 	..()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -98,8 +98,9 @@
 	var/make_alerts = TRUE // Should this APC make power alerts to the area?
 
 	machine_flags = WIREJACK
-	holomap = TRUE
-	auto_holomap = TRUE
+
+/obj/machinery/power/apc/supports_holomap()
+	return TRUE
 
 /obj/machinery/power/apc/no_alerts
 	make_alerts = FALSE
@@ -144,7 +145,7 @@
 		operating = 0
 		stat |= MAINT
 
-	if(ticker)
+	if(ticker && ticker.current_state == GAME_STATE_PLAYING)
 		initialize()
 		update()
 
@@ -161,12 +162,10 @@
 /obj/machinery/power/apc/finalise_terminal()
 	// create a terminal object at the same position as original turf loc
 	// wires will attach to this
-	terminal = new/obj/machinery/power/terminal {auto_holomap = 0} (src.loc)
+	terminal = new/obj/machinery/power/terminal(src.loc)
 	terminal.dir = tdir
 	terminal.master = src
-	var/turf/T = loc
-	if (istype(T))
-		T.soft_add_holomap(terminal)
+	terminal.add_self_to_holomap()
 
 /obj/machinery/power/apc/initialize()
 	..()
@@ -174,6 +173,7 @@
 	name = "[areaMaster.name] APC"
 
 	update_icon()
+	add_self_to_holomap()
 
 /obj/machinery/power/apc/examine(mob/user)
 	..()

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -48,8 +48,8 @@ By design, d1 is the smallest direction and d2 is the highest
 	var/oldnewavail = 0
 	var/oldload = 0
 
-	holomap      = TRUE
-	auto_holomap = TRUE
+/obj/structure/cable/supports_holomap()
+	return TRUE
 
 /obj/structure/cable/yellow
 	_color = "yellow"
@@ -99,6 +99,10 @@ By design, d1 is the smallest direction and d2 is the highest
 		hide(T.intact)
 
 	cable_list += src		//add it to the global cable list
+
+/obj/structure/cable/initialize()
+	..()
+	add_self_to_holomap()
 
 /obj/structure/cable/Destroy()			// called when a cable is deleted
 	if(powernet)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -134,8 +134,8 @@ var/global/list/obj/machinery/light/alllights = list()
 
 	var/idle = 0 // For process().
 
-	holomap = TRUE
-	auto_holomap = TRUE
+/obj/machinery/light/supports_holomap()
+	return TRUE
 
 /obj/machinery/light/spook(mob/dead/observer/ghost)
 	if(..(ghost, TRUE))
@@ -189,11 +189,15 @@ var/global/list/obj/machinery/light/alllights = list()
 	update(0)
 	..()
 
+/obj/machinery/light/initialize()
+	..()
+	add_self_to_holomap()
+
 // create a new lighting fixture
 /obj/machinery/light/New()
 	..()
 	alllights += src
-
+	
 	spawn(2)
 		var/area/A = get_area(src)
 		if(A && !A.requires_power)

--- a/code/modules/power/terminal.dm
+++ b/code/modules/power/terminal.dm
@@ -13,9 +13,12 @@
 	anchored = 1
 	layer = WIRE_TERMINAL_LAYER
 
-	holomap = TRUE
-	auto_holomap = TRUE
+/obj/machinery/power/terminal/supports_holomap()
+	return TRUE
 
+/obj/machinery/power/terminal/initialize()
+	..()
+	add_self_to_holomap()
 
 /obj/machinery/power/terminal/New()
 	..()

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -25,8 +25,12 @@
 	var/template_path = "disposalsbin.tmpl"
 	var/deconstructable = TRUE	//Set to FALSE for disposal machinery that can be used for transporting players or things, but not tinkered with by players.
 
-	holomap = TRUE
-	auto_holomap = TRUE
+/obj/machinery/disposal/supports_holomap()
+	return TRUE
+
+/obj/machinery/disposal/initialize()
+	..()
+	add_self_to_holomap()
 
 /obj/machinery/disposal/no_deconstruct
 	deconstructable = FALSE
@@ -701,8 +705,6 @@
 	anchored = 1
 	density = 0
 
-	holomap = TRUE
-	auto_holomap = TRUE
 	level = LEVEL_BELOW_FLOOR			// underfloor only
 	var/dpdir = 0		// bitmask of pipe directions
 	dir = 0				// dir will contain dominant direction for junction pipes
@@ -712,7 +714,14 @@
 	var/base_icon_state	// initial icon state on map
 	var/deconstructable = TRUE
 
-	// new pipe, set the icon_state as on map
+/obj/structure/disposalpipe/supports_holomap()
+	return TRUE
+
+/obj/structure/disposalpipe/initialize()
+	..()
+	add_self_to_holomap()
+
+// new pipe, set the icon_state as on map
 /obj/structure/disposalpipe/New()
 	..()
 	base_icon_state = icon_state
@@ -1516,8 +1525,12 @@
 	var/obj/structure/disposalpipe/trunk/trunk
 	var/deconstructable = TRUE
 
-	holomap = TRUE
-	auto_holomap = TRUE
+/obj/structure/disposaloutlet/supports_holomap()
+	return TRUE
+
+/obj/structure/disposaloutlet/initialize()
+	..()
+	add_self_to_holomap()
 
 /obj/structure/disposaloutlet/no_deconstruct
 	deconstructable = FALSE

--- a/code/modules/research/xenoarchaeology/finds/finds_fossils.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds_fossils.dm
@@ -103,6 +103,7 @@
 	desc = "It's fossilised plant remains."
 
 /obj/item/weapon/fossil/plant/New()
+	..()
 	icon_state = "plant[rand(1,4)]"
 	var/prehistoric_plants = list(
 		/obj/item/seeds/telriis,


### PR DESCRIPTION
Makes world start a few seconds faster.
- Fixes #16589
- Rather than, inside `obj/New`, checking a var to find out whether the object should add itself to the holomap, we now call a proc to add the object to the holomap inside `initialize()`
- Also removes the `holomap` var, replaced with a proc. The reason for doing this is to save memory.