### PR TITLE
Runtime hunting: cyborgs recharging edition

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -144,7 +144,7 @@
 		I.mouse_opacity = 2
 
 /obj/item/weapon/robot_module/proc/respawn_consumable(var/mob/living/silicon/robot/R)
-	if(respawnables.len)
+	if(respawnables && respawnables.len)
 		for(var/T in respawnables)
 			if(!(locate(T) in modules))
 				modules -= null


### PR DESCRIPTION
```
x62 robot_modules.dm,147: Cannot read null.len
  proc name: respawn consumable (/obj/item/weapon/robot_module/proc/respawn_consumable)
  src: the service robot module (/obj/item/weapon/robot_module/butler)
  src.loc: Pinhead Larry (/mob/living/silicon/robot)
  call stack:
  the service robot module (/obj/item/weapon/robot_module/butler): respawn consumable(Pinhead Larry (/mob/living/silicon/robot))
  the cyborg recharging station (/obj/machinery/recharge_station): restock modules()
  the cyborg recharging station (/obj/machinery/recharge_station): process occupant()
  the cyborg recharging station (/obj/machinery/recharge_station): process()
  Machinery (/datum/subsystem/machinery): fire(0)
  Machinery (/datum/subsystem/machinery): ignite(0)
  Master (/datum/controller/master): RunQueue()
  Master (/datum/controller/master): Loop()
  Master (/datum/controller/master): StartProcessing()
```