### PR TITLE
Mysterious d20s scannable by syndie device analyzers

### DIFF
--- a/code/game/objects/items/weapons/dice.dm
+++ b/code/game/objects/items/weapons/dice.dm
@@ -134,7 +134,7 @@
 	desc = "Something about this dice seems wrong"
 	var/deactivated = 0 //Eventually the dice runs out of power
 	var/infinite = 0 //dice with 1 will not run out
-	mech_flags = MECH_SCAN_FAIL
+	mech_flags = MECH_SCAN_ILLEGAL
 
 /obj/item/weapon/dice/d20/cursed/pickup(mob/user as mob)
 	..()


### PR DESCRIPTION
:cl:
* tweak: Mysterious d20s are now scannable again (by the syndie device analyzer only).