### PR TITLE
Makes add_attacklogs able to take non-mob targets

### DIFF
--- a/code/__HELPERS/logging.dm
+++ b/code/__HELPERS/logging.dm
@@ -73,7 +73,7 @@
  */
 /proc/add_attacklogs(var/mob/user, var/mob/target, var/what_done, var/object = null, var/addition = null, var/admin_warn = TRUE)
 	var/user_txt = (user ? "[user][user.ckey ? " ([user.ckey])" : ""]" : "\<NULL USER\>")
-	var/target_txt = (target ? "[target][target.ckey ? " ([target.ckey])" : ""]" : "\<NULL TARGET\>")
+	var/target_txt = (target ? ismob(target) ? "[target][target.ckey ? " ([target.ckey])" : ""]" : "[target]" : "\<NULL TARGET\>")
 	var/object_txt = (object ? " with \the [object]" : "")
 	var/intent_txt = (user ? " (INTENT: [uppertext(user.a_intent)])" : "")
 	var/addition_txt = (addition ? " ([addition])" : "")

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -301,7 +301,7 @@
 		if(ranged_message)
 			visible_message("<span class='warning'><b>[src]</b> [ranged_message] at [target]!</span>", 1)
 		if(ckey)
-			add_attacklogs(src, target, "[ranged_message ? ranged_message : "shot"] at", admin_warn = FALSE)
+			add_attacklogs(src, target, "[ranged_message ? ranged_message : "shot"] at")
 		if(casingtype)
 			new casingtype(get_turf(src),1)// empty casing
 

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -301,7 +301,7 @@
 		if(ranged_message)
 			visible_message("<span class='warning'><b>[src]</b> [ranged_message] at [target]!</span>", 1)
 		if(ckey)
-			add_attacklogs(src, target, "[ranged_message ? ranged_message : "shot"] at")
+			add_attacklogs(src, target, "[ranged_message ? ranged_message : "shot"] at", admin_warn = FALSE)
 		if(casingtype)
 			new casingtype(get_turf(src),1)// empty casing
 


### PR DESCRIPTION
Closes #17664
~~This also makes player simple mobs shooting not adminwarn as a followup to #17451, since I assume they don't want their chat to be a million Mecha Hitler bullets.~~