### PR TITLE
Fixed improper permeability check for infection by nanites

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -3065,7 +3065,7 @@
 		return 1
 
 	if((prob(10) && method == TOUCH) || method == INGEST)
-		M.contract_disease(new diseasetype)
+		M.contract_disease(new diseasetype, 1)
 
 /datum/reagent/nanites/autist
 	name = "Autist nanites"


### PR DESCRIPTION
The robotic infection from eating or injecting nanites fails when wearing a hardsuit or biosuit. Turns out contract_disease has an argument for skipping an unwanted permeability check that wasn't set properly here. Plus reagents on touch have their own permeability check anyway.

:cl:
* bugfix: Fixed a bug with nanite infection where it had to pass a redundant permeability check.