### PR TITLE
Required reagent container subtype checking

### DIFF
--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -388,7 +388,7 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 					matching_container = 1
 
 				else
-					if(my_atom.type == C.required_container)
+					if(my_atom.type in typesof(C.required_container))
 						matching_container = 1
 
 				if(!C.required_other)


### PR DESCRIPTION
Instead of checking if the atom type is the same as required_container, the holder will check for all types of required_container (such as /obj/item/weapon/reagent_containers).
I looked through [Chemistry-Recipes](https://github.com/vgstation-coders/vgstation13/blob/Bleeding-Edge/code/modules/reagents/Chemistry-Recipes.dm) for reagents requiring a specific container type but I couldn't find anything that this would break. 54 out of the 61 matches for `required_container` was just slime stuff, 4 were for plasma beakers, 2 were for making bone gel and Fix-O-Vein in vials, 1 was for mimic shapeshifting, and 1 was the var definition.
Guessing this *shouldn't* use existing_typesof() instead. Not really sure when it caches but we don't really care about abstract types with this.
Tested by adding `required_container = /obj/item/weapon/reagent_containers` to the anti-tox recipe:
![image](https://user-images.githubusercontent.com/5942183/36844056-65d7b302-1d51-11e8-9e6c-b870ba9ee750.png)
Keep in mind that not all reagent containers are of type /obj/item/weapon/reagent_container. Slime cores come to mind. They're just subtypes of /obj/item.