### PR TITLE
Removes lungspam

### DIFF
--- a/code/modules/organs/internal/lungs/lung.dm
+++ b/code/modules/organs/internal/lungs/lung.dm
@@ -103,7 +103,7 @@
 			spawn owner.emote("me", 1, "gasps for air!")
 			if (owner.losebreath <= 30)
 				owner.losebreath += 5
-		else if(prob(chance))
+		else if(prob(chance) && !(owner.species && owner.species.anatomy_flags & NO_BLOOD))
 			spawn owner.emote("me", 1, "coughs up blood!")
 			owner.drip(10)
 

--- a/code/modules/organs/internal/lungs/lung.dm
+++ b/code/modules/organs/internal/lungs/lung.dm
@@ -103,9 +103,9 @@
 			spawn owner.emote("me", 1, "gasps for air!")
 			if (owner.losebreath <= 30)
 				owner.losebreath += 5
-		else if(prob(chance) && !(owner.species && owner.species.anatomy_flags & NO_BLOOD))
-			spawn owner.emote("me", 1, "coughs up blood!")
-			owner.drip(10)
+		else if(prob(chance))
+			if(owner.drip(10))
+				spawn owner.emote("me", 1, "coughs up blood!")
 
 
 /datum/organ/internal/lungs/vox

--- a/code/modules/organs/internal/lungs/lung.dm
+++ b/code/modules/organs/internal/lungs/lung.dm
@@ -90,6 +90,9 @@
 
 /datum/organ/internal/lungs/process()
 	..()
+	if((owner.species && owner.species.flags & NO_BREATHE) || M_NO_BREATH in owner.mutations)
+		return
+
 	if (germ_level > INFECTION_LEVEL_ONE)
 		if(prob(5))
 			owner.audible_cough()		//respitory tract infection

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1196,6 +1196,8 @@
 		return 1
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
+		if((H.species && H.species.flags & NO_BREATHE) || M_NO_BREATH in H.mutations)
+			return
 		for(var/datum/organ/internal/lungs/L in H.internal_organs)
 			L.take_damage(REM, 1)
 


### PR DESCRIPTION
#### Main purpose of this PR is to get rid of this kind of thing:
![1134](https://user-images.githubusercontent.com/31839805/36931782-5849bb46-1e72-11e8-9701-803d5c829f73.PNG)

Two dionas hit by chloramine who were fine except for the constant emotes.

I threw in a little M_NO_BREATH creep in there since why not?