### PR TITLE
Small Gremlin Update

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -283,3 +283,12 @@ proc/add_ghostlogs(var/mob/user, var/obj/target, var/what_done, var/admin=1, var
 			L.Remove(organ)
 
 	return L
+
+/proc/adjacent_atoms(atom/center)
+	var/list/L = list()
+
+	for(var/atom/A in range(1, center))
+		if(center.Adjacent(A))
+			L.Add(A)
+
+	return L

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -140,6 +140,9 @@
 /obj/abstract/screen/gun/MouseExited()
 	closeToolTip(usr)
 
+/proc/get_random_zone_sel()
+	return pick("l_foot", "r_foot", "l_leg", "r_leg", "l_hand", "r_hand", "l_arm", "r_arm", "chest", "groin", "eyes", "mouth", "head")
+
 /obj/abstract/screen/zone_sel
 	name = "damage zone"
 	icon_state = "zone_sel"

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -186,7 +186,7 @@
 		pickable_items.Add(I)
 
 	if(!pickable_items.len)
-		user.visible_message("<span class='notice'>\The [user] tries to think of a way to screw \the [victum] up without any tools nearby, but fails miserably.</span>")
+		user.visible_message("<span class='notice'>\The [user] tries to think of a way to screw \the [victim] up without any tools nearby, but fails miserably.</span>")
 		return
 
 	var/obj/item/tool = pick(pickable_items)

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -172,4 +172,27 @@
 	if(isrobot(user))
 		return
 	//user.drop_item(W, src.loc) why?
-	return
+
+/obj/machinery/optable/npc_tamper_act(mob/living/user)
+	//Messages are overridden for this proc
+	. = NPC_TAMPER_ACT_NOMSG
+
+	if(!victim)
+		return
+
+	var/list/pickable_items = list()
+
+	for(var/obj/item/I in adjacent_atoms(user))
+		pickable_items.Add(I)
+
+	if(!pickable_items.len)
+		user.visible_message("<span class='notice'>\The [user] tries to think of a way to screw \the [victum] up without any tools nearby, but fails miserably.</span>")
+		return
+
+	var/obj/item/tool = pick(pickable_items)
+
+	user.visible_message(pick(
+	"<span class='danger'>\The [user] grabs \a nearby [tool] and contemplates using it on \the [victim]!</span>",
+	"<span class='danger'>\The [user]'s eyes light up as \he tries to use \the [tool] to operate on \the [victim]</span>",
+	"<span class='danger'>\The [user] rubs its hands devilishly and attempts to operate on \the [victim] with \the [tool].</span>"))
+	global.do_surgery(victim, user, tool)

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -195,4 +195,8 @@
 	"<span class='danger'>\The [user] grabs \a nearby [tool] and contemplates using it on \the [victim]!</span>",
 	"<span class='danger'>\The [user]'s eyes light up as \he tries to use \the [tool] to operate on \the [victim]</span>",
 	"<span class='danger'>\The [user] rubs its hands devilishly and attempts to operate on \the [victim] with \the [tool].</span>"))
+	if(isgremlin(user))
+		var/mob/living/simple_animal/hostile/gremlin/G = user
+		G.stand_still(4)
+
 	global.do_surgery(victim, user, tool)

--- a/code/modules/food/cooking_machines.dm
+++ b/code/modules/food/cooking_machines.dm
@@ -469,7 +469,7 @@ var/global/ingredientLimit = 10
 	//Deepfry a random nearby item
 	var/list/pickable_items = list()
 
-	for(var/obj/item/I in range(1, L))
+	for(var/obj/item/I in adjacent_atoms(L))
 		pickable_items.Add(I)
 
 	if(!pickable_items.len)

--- a/code/modules/mob/living/simple_animal/hostile/gremlin.dm
+++ b/code/modules/mob/living/simple_animal/hostile/gremlin.dm
@@ -95,7 +95,7 @@ var/list/bad_gremlin_items = list()
 	M.add_custom_fibers("Hairs from a gremlin.", 0)
 	return TRUE
 
-/mob/living/simple_animal/hostile/gremlin/proc/stay_still(var/tick_amount)
+/mob/living/simple_animal/hostile/gremlin/proc/stand_still(var/tick_amount)
 	time_chasing_target -= tick_amount
 
 /mob/living/simple_animal/hostile/gremlin/CanAttack(atom/new_target)

--- a/code/modules/mob/living/simple_animal/hostile/gremlin.dm
+++ b/code/modules/mob/living/simple_animal/hostile/gremlin.dm
@@ -95,6 +95,9 @@ var/list/bad_gremlin_items = list()
 	M.add_custom_fibers("Hairs from a gremlin.", 0)
 	return TRUE
 
+/mob/living/simple_animal/hostile/gremlin/proc/stay_still(var/tick_amount)
+	time_chasing_target -= tick_amount
+
 /mob/living/simple_animal/hostile/gremlin/CanAttack(atom/new_target)
 	if(bad_gremlin_items.Find(new_target.type))
 		return FALSE

--- a/code/modules/mob/living/simple_animal/hostile/gremlin.dm
+++ b/code/modules/mob/living/simple_animal/hostile/gremlin.dm
@@ -126,14 +126,15 @@ var/list/bad_gremlin_items = list()
 /mob/living/simple_animal/hostile/gremlin/EscapeConfinement()
 	if(istype(loc, /obj) && CanAttack(loc)) //If we're inside a machine, screw with it
 		var/obj/M = loc
-		tamper(M)
+		return tamper(M)
 
 	return ..()
 
 //This allows player-controlled gremlins to tamper with machinery
 /mob/living/simple_animal/hostile/gremlin/UnarmedAttack(var/atom/A)
 	if(istype(A, /obj/machinery) || istype(A, /obj/structure))
-		tamper(A)
+		if(CanAttack(A))
+			tamper(A)
 
 	return ..()
 

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -106,11 +106,14 @@ proc/do_surgery(mob/living/M, mob/living/user, obj/item/tool)
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		clumsy = ((M_CLUMSY in H.mutations) && prob(50))
+
+	var/target_area = user.zone_sel ? user.zone_sel.selecting : get_random_zone_sel()
+
 	for(var/datum/surgery_step/S in surgery_steps)
 		//check if tool is right or close enough and if this step is possible
 		sleep_fail = 0
 		if(S.tool_quality(tool))
-			var/canuse = S.can_use(user, M, user.zone_sel.selecting, tool)
+			var/canuse = S.can_use(user, M, target_area, tool)
 			if(canuse == -1)
 				sleep_fail = 1
 			if(canuse && S.is_valid_mutantrace(M) && !(M in S.doing_surgery))
@@ -120,14 +123,15 @@ proc/do_surgery(mob/living/M, mob/living/user, obj/item/tool)
 				user.attack_log += text("\[[time_stamp()]\] <font color='red'>Started surgery [S.type] with \the [tool] on [M.name] ([M.ckey])</font>")
 				log_attack("<font color='red'>[user.name] ([user.ckey]) used \the [tool] to perform surgery type [S.type] on [M.name] ([M.ckey])</font>")
 				S.doing_surgery += M
-				S.begin_step(user, M, user.zone_sel.selecting, tool)		//start on it
-				var/selection = user.zone_sel.selecting
+				S.begin_step(user, M, target_area, tool)		//start on it
+
+				var/selection = user.zone_sel ? user.zone_sel.selecting : null //Check if the zone selection hasn't changed
 				//We had proper tools! (or RNG smiled.) and user did not move or change hands.
-				if(do_mob(user, M, rand(S.min_duration, S.max_duration) * tool.surgery_speed) && (prob(S.tool_quality(tool) / (sleep_fail + clumsy + 1))) && selection == user.zone_sel.selecting)
+				if(do_mob(user, M, rand(S.min_duration, S.max_duration) * tool.surgery_speed) && (prob(S.tool_quality(tool) / (sleep_fail + clumsy + 1))) && (!user.zone_sel || selection == user.zone_sel.selecting)) //Last part checks whether the zone selection hasn't changed
 					M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has had surgery [S.type] with \the [tool] successfully completed by [user.name] ([user.ckey])</font>")
 					user.attack_log += text("\[[time_stamp()]\] <font color='red'>Successfully completed surgery [S.type] with \the [tool] on [M.name] ([M.ckey])</font>")
 					log_attack("<font color='red'>[user.name] ([user.ckey]) used \the [tool] to successfully complete surgery type [S.type] on [M.name] ([M.ckey])</font>")
-					S.end_step(user, M, user.zone_sel.selecting, tool)		//finish successfully
+					S.end_step(user, M, target_area, tool)		//finish successfully
 				else
 					if(sleep_fail)
 						to_chat(user, "<span class='warning'>The patient is squirming around in pain!</span>")
@@ -135,7 +139,7 @@ proc/do_surgery(mob/living/M, mob/living/user, obj/item/tool)
 					M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has had surgery [S.type] with \the [tool] failed by [user.name] ([user.ckey])</font>")
 					user.attack_log += text("\[[time_stamp()]\] <font color='red'>Failed surgery [S.type] with \the [tool] on [M.name] ([M.ckey])</font>")
 					log_attack("<font color='red'>[user.name] ([user.ckey]) used \the [tool] to fail the surgery type [S.type] on [M.name] ([M.ckey])</font>")
-					S.fail_step(user, M, user.zone_sel.selecting, tool)		//malpractice~
+					S.fail_step(user, M, target_area, tool)		//malpractice~
 				if(M) //good, we still exist
 					S.doing_surgery -= M
 				else


### PR DESCRIPTION
Fixes #15958

![](https://i.imgur.com/9JBFS4n.png)

:cl:
* bugfix: Fixed gremlins spamming messages when locked in cages, or when near windows
* rscadd: Gremlins can now use operating tables to perform surgery (operating them in the same way as deepfryers - using nearby items). Given their tendency to run around, the surgery can fail if they aren't restrained.
