### PR TITLE
Alters access requirements on lesser used engineering and medical supply crates.

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1212,7 +1212,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 10
 	containertype = /obj/structure/closet/crate/secure/engisec
 	containername = "emitter crate"
-	access = list(access_ce)
+	access = list(access_engine)
 	group = "Engineering"
 
 /datum/supply_packs/engine/field_gen
@@ -1221,7 +1221,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/machinery/field_generator)
 	containertype = /obj/structure/closet/crate/secure/engisec
 	containername = "field generator crate"
-	access = list(access_ce)
+	access = list(access_engine)
 	group = "Engineering"
 
 /datum/supply_packs/engine/sing_gen
@@ -1259,7 +1259,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/structure/particle_accelerator/end_cap)
 	containertype = /obj/structure/closet/crate/secure/engisec
 	containername = "particle accelerator crate"
-	access = list(access_ce)
+	access = list(access_engine)
 	group = "Engineering"
 
 /datum/supply_packs/shieldgens
@@ -1271,7 +1271,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 20
 	containertype = /obj/structure/closet/crate/secure/engisec
 	containername = "shield generators crate"
-	access = list(access_teleporter)
+	access = list(access_engine)
 	group = "Engineering"
 
 /datum/supply_packs/engine/amrcontrol
@@ -1366,7 +1366,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	containertype = /obj/structure/closet/crate/secure/engisec
 	containername = "Starscreen shield generator crate"
 	group = "Engineering"
-	access = list(access_ce)
+	access = list(access_engine)
 
 /datum/supply_packs/shield_cap
 	contains = list(/obj/item/weapon/circuitboard/shield_cap)
@@ -1375,7 +1375,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	containertype = /obj/structure/closet/crate/secure/engisec
 	containername = "Starscreen shield capacitor crate"
 	group = "Engineering"
-	access = list(access_ce)
+	access = list(access_engine)
 
 /datum/supply_packs/teg
 	contains = list(/obj/machinery/power/generator)
@@ -1569,7 +1569,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 200
 	containertype = "/obj/structure/closet/crate/secure"
 	containername = "motorized wheelchair crate"
-	access = list(access_cmo)
+	access = list(access_medical)
 	group = "Medical"
 
 /datum/supply_packs/skele_stand


### PR DESCRIPTION
This PR aims to alter access requirements on the more seldom used engineering and medical supply crates while not touching the more controversial ones such as virus dishes, singularity generators and shard crates. The full list of changed crates and their respective new access requirements is as follows:

Emitter Crate - Engine Access
Field Generator Crate - Engine Access
Particle Accelerator Crate - Engine Access
Shield Generator Crate - Engine Access
Starscreen Shield Generator Crate - Engine Access
Starscreen Shield Capacitor Crate - Engine Access
Motorized Wheelchair Crate - Medical Access

Previously these crates required head access from their respective departments to open, but I personally don't see them as high risk items that would require head of staff approval to open on their own. Tested locally without issues. I would appreciate any and all feedback regarding this pr.

:cl:
 * tweak: Altered several engineering crates (emitter, field generator, particle accelerator, shield generator, starscreen shield generator and capacitor crates) access requirements from CE to engine access.
 * tweak: Altered motorized wheelchair crate access requirements from CMO to medical access.
