### PR TITLE
MoMMIs don't start with the default flashlight/flash anymore

### DIFF
--- a/code/modules/mob/living/silicon/mommi/mommi_modules.dm
+++ b/code/modules/mob/living/silicon/mommi/mommi_modules.dm
@@ -6,6 +6,7 @@
 	sprites = list("Basic" = "mommi")
 	respawnables = list (/obj/item/stack/cable_coil)
 	respawnables_max_amount = MOMMI_MAX_COIL
+	default_modules = FALSE
 	var/ae_type = "Default" //Anti-emancipation override type, pretty much just fluffy.
 
 /obj/item/weapon/robot_module/mommi/New(var/mob/living/silicon/robot/R)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -8,6 +8,7 @@
 	var/speed_modifier = CYBORG_STANDARD_SPEED_MODIFIER
 	var/can_be_pushed = TRUE
 	var/no_slip = FALSE
+	var/default_modules = TRUE //Do we start with a flash/light?
 
 	var/list/sprites = list()
 
@@ -77,12 +78,12 @@
 		emag.emp_act(severity)
 	..()
 
-/obj/item/weapon/robot_module/New(var/mob/living/silicon/robot/R, var/default = TRUE)
+/obj/item/weapon/robot_module/New(var/mob/living/silicon/robot/R)
 	..()
 	added_languages = list()
 	add_languages(R)
 	AddToProfiler()
-	if(default)
+	if(default_modules)
 		AddDefaultModules()
 	UpdateModuleHolder(R)
 	AddCameraNetworks(R)


### PR DESCRIPTION
They have no use for them, you don't even use flashes when building MoMMIs, they were just there due old module code hardcoding.

:cl:
 * rscdel: MoMMIs don't start with the default flashlight/flash anymore