### PR TITLE
Display cases and fish bowls can now be built again

### DIFF
--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -1,65 +1,4 @@
-/obj/structure/displaycase_frame
-	name = "display case frame"
-	icon = 'icons/obj/stock_parts.dmi'
-	icon_state="box_glass"
-	var/obj/item/weapon/circuitboard/airlock/circuit=null
-	var/state=0
-
-/obj/structure/displaycase_frame/Destroy()
-	..()
-	if(circuit)
-		qdel(circuit)
-		circuit = null
-
-/obj/structure/displaycase_frame/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	var/pstate=state
-	var/turf/T=get_turf(src)
-	switch(state)
-		if(0)
-			if(istype(W, /obj/item/weapon/circuitboard/airlock) && W:icon_state != "door_electronics_smoked")
-				if(user.drop_item(W, src))
-					circuit=W
-					circuit.installed = 1
-					state++
-					playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
-			if(iscrowbar(W))
-				var/obj/machinery/constructable_frame/machine_frame/MF = new /obj/machinery/constructable_frame/machine_frame(T)
-				MF.state = 1
-				MF.set_build_state(1)
-				new /obj/item/stack/sheet/glass/glass(T)
-				qdel(src)
-				playsound(src, 'sound/items/Crowbar.ogg', 50, 1)
-				return
-
-		if(1)
-			if(isscrewdriver(W))
-				var/obj/structure/displaycase/C=new(T)
-				if(circuit.one_access)
-					C.req_access = null
-					C.req_one_access = circuit.conf_access
-				else
-					C.req_access = circuit.conf_access
-					C.req_one_access = null
-				playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
-				qdel(src)
-				return
-			if(iscrowbar(W))
-				circuit.forceMove(T)
-				circuit.installed = 0
-				circuit=null
-				state--
-				playsound(src, 'sound/items/Crowbar.ogg', 50, 1)
-	if(pstate!=state)
-		pstate=state
-		update_icon()
-
-/obj/structure/displaycase_frame/update_icon()
-	switch(state)
-		if(1)
-			icon_state="box_glass_circuit"
-		else
-			icon_state="box_glass"
-
+//Construction handled in code/game/machinery/constructable_frame.dm (05032018-Oculus)
 
 /obj/structure/displaycase
 	name = "display case"
@@ -201,30 +140,35 @@
 		user.visible_message("[user.name] pries \the [src] apart.", \
 			"You pry \the [src] apart.", \
 			"You hear something pop.")
-		var/turf/T=get_turf(src)
-		playsound(T, 'sound/items/Crowbar.ogg', 50, 1)
+		playsound(src, 'sound/items/Crowbar.ogg', 50, 1)
 		dump()
-		var/obj/item/weapon/circuitboard/airlock/C=circuit
+
+		var/obj/item/weapon/circuitboard/airlock/C = circuit
 		if(!C)
-			C=new (src)
+			C = new (src)
 			C.installed = 1
 		C.one_access=!(req_access && req_access.len>0)
 		if(!C.one_access)
 			C.conf_access=req_access
 		else
 			C.conf_access=req_one_access
+
 		if(!destroyed)
-			var/obj/structure/displaycase_frame/F=new(T)
-			F.state=1
-			F.circuit=C
-			F.circuit.forceMove(F)
-			F.update_icon()
+			var /obj/machinery/constructable_frame/machine_frame/new_machine_frame = new(get_turf(src))
+			new_machine_frame.build_path = 1
+			new_machine_frame.build_state = 2
+			new_machine_frame.circuit = C
+			C.forceMove(new_machine_frame)
+			circuit = null
+			C = null
+			new_machine_frame.icon_state="box_glass_circuit"
 		else
-			C.forceMove(T)
+			C.forceMove(get_turf(src))
 			C.installed = 0
-			circuit=null
-			new /obj/machinery/constructable_frame/machine_frame(T)
+			new /obj/machinery/constructable_frame/machine_frame(get_turf(src))
 		qdel(src)
+		return
+
 	else if(user.a_intent == I_HURT)
 		user.delayNextAttack(8)
 		src.health -= W.force
@@ -286,10 +230,10 @@
 
 
 /obj/structure/displaycase/broken
-	name = "display case"
+	name = "broken display case"
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "glassbox2b"
-	desc = "A display case for prized possessions."
+	desc = "A display case for prized possessions. It seems to be broken."
 	density = 0
 	health = 0
 	destroyed = 1

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -1,4 +1,4 @@
-//Construction handled in code/game/machinery/constructable_frame.dm (05032018-Oculus)
+//Construction handled in code/game/machinery/constructable_frame.dm
 
 /obj/structure/displaycase
 	name = "display case"

--- a/code/modules/fish/fish_tank.dm
+++ b/code/modules/fish/fish_tank.dm
@@ -23,7 +23,7 @@
 
 // Made by FalseIncarnate on Paradise
 // Ported to /vg/ by Shifty and jakmak(s)
-// Fish Bowl construction moved to code/game/machinery/constructable_frame.dm (05032018-Oculus)
+// Fish Bowl construction moved to code/game/machinery/constructable_frame.dm
 
 /obj/machinery/fishtank
 	name = "placeholder tank"

--- a/code/modules/fish/fish_tank.dm
+++ b/code/modules/fish/fish_tank.dm
@@ -23,7 +23,7 @@
 
 // Made by FalseIncarnate on Paradise
 // Ported to /vg/ by Shifty and jakmak(s)
-
+// Fish Bowl construction moved to code/game/machinery/constructable_frame.dm (05032018-Oculus)
 
 /obj/machinery/fishtank
 	name = "placeholder tank"
@@ -740,16 +740,6 @@
 		user.visible_message("<span class='danger'>\The [src] has been attacked by \the [user] with \the [O]!</span>")
 		hit(O, user)
 	return TRUE
-
-/* tank construction */
-
-/obj/structure/displaycase_frame/attackby(var/obj/item/weapon/F, var/mob/user) // FISH BOWL
-	if (iswelder(F))
-		to_chat(user, "<span class='notice'>You use the machine frame as a vice and shape the glass with the welder into a fish bowl.</span>")
-		getFromPool(/obj/item/stack/sheet/metal, get_turf(src), 5)
-		new /obj/machinery/fishtank/bowl(get_turf(src))
-		qdel(src)
-		return TRUE
 
 //Conduction plate for electric eels
 

--- a/code/modules/maps/spawners/spawners.dm
+++ b/code/modules/maps/spawners/spawners.dm
@@ -207,7 +207,6 @@
 		/obj/machinery/vending/sovietsoda,
 		/obj/structure/AIcore,
 		/obj/structure/piano,
-		/obj/structure/displaycase_frame,
 		/obj/structure/particle_accelerator/fuel_chamber,
 		/obj/structure/reagent_dispensers/fueltank,
 		/obj/structure/reagent_dispensers/water_cooler,


### PR DESCRIPTION
fixes #17716
- Cause: Fish bowl construction overriding display case construction
- Solution: Fish bowl construction and display case construction merged into constructable_frame.dm
- Notes: My first multiple-line bugfix. I don't think it's particularly pretty, and I'm going to be redoing constructable_frame.dm in the near future to increase the modularity it was intended to have in the first place.

:cl:
* bugfix: Display cases and fish bowls can now be built again