### PR TITLE
Workaround for BYOND ~~bug~~ feature when Login() is called for nullspaced mobs

### DIFF
--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -37,6 +37,9 @@
 						message_admins("<font color='red'><B>Notice: </B><font color='blue'><A href='?src=\ref[usr];priv_msg=\ref[src]'>[key_name_admin(src)]</A> has the same [matches] as [key_name_admin(M)] (no longer logged in). </font>", 1)
 						log_access("Notice: [key_name(src)] has the same [matches] as [key_name(M)] (no longer logged in).")
 
+// Do not call ..()
+// If you do so and the mob is in nullspace BYOND will attempt to move the mob a gorillion times
+// See http://www.byond.com/docs/ref/info.html#/mob/proc/Login and http://www.byond.com/forum/?post=2151126
 /mob/Login()
 	player_list |= src
 	update_Login_details()
@@ -66,8 +69,6 @@
 	delayNextMove(0)
 
 	change_sight(adding = (SEE_SELF|SEE_BLACKNESS))
-
-	..()
 
 	reset_view()
 


### PR DESCRIPTION
Prevents the server lagging due to BYOND attempting to Move() mobs out of nullspace a ton of times, see links for more.