### PR TITLE
Remove redundant lines

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1500,8 +1500,6 @@ NOTE:  The change will take effect AFTER any current recruiting periods."}
 				if("save")
 					if(world.timeofday >= (lastPolled + POLLED_LIMIT))
 						SetRoles(user,href_list)
-						save_preferences_sqlite(user, user.ckey)
-						save_character_sqlite(user.ckey, user, default_slot)
 						lastPolled = world.timeofday
 					else
 						to_chat(user, "You need to wait [round((((lastPolled + POLLED_LIMIT) - world.timeofday) / 10))] seconds before you can save again.")


### PR DESCRIPTION
The SetRoles proc already does these lines.

Bla bla bla untested, just Ctrl+F /proc/SetRoles and you'll see that it is duplicated.

By the way I think I found an exploit somewhere in this file. I'll look into it sometime.

<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl:
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
