### PR TITLE
Cyborgs drop storage contents on reset or destruction

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -384,7 +384,7 @@
 
 /obj/item/weapon/gripper/Destroy()
 	if(gripper_sanity_check(src))
-		drop_item(force_drop = 1)
+		drop_item(force_drop = 1, dontsay = TRUE)
 	..()
 
 /obj/item/weapon/gripper/update_icon()

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -50,7 +50,7 @@
 		R.remove_module() //Helps remove screen references on robot end
 
 	for(var/obj/A in modules)
-		if(istype(A, /obj/item/weapon/storage))
+		if(loc && istype(A, /obj/item/weapon/storage))
 			A:empty_contents_to(loc)
 		qdel(A)
 	modules = null

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -50,8 +50,9 @@
 		R.remove_module() //Helps remove screen references on robot end
 
 	for(var/obj/A in modules)
-		if(loc && istype(A, /obj/item/weapon/storage))
-			A:empty_contents_to(loc)
+		if(istype(A, /obj/item/weapon/storage) && loc)
+			var/obj/item/weapon/storage/S = A
+			S.empty_contents_to(loc)
 		qdel(A)
 	modules = null
 	if(emag)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -50,6 +50,8 @@
 		R.remove_module() //Helps remove screen references on robot end
 
 	for(var/obj/A in modules)
+		if(istype(A, /obj/item/weapon/storage))
+			A:empty_contents_to(loc)
 		qdel(A)
 	modules = null
 	if(emag)


### PR DESCRIPTION
Currently if a cyborg is reset or destroyed and has anything stored in a pill collector, trash bag, sheet snatcher, or ore collector, then those things are simply deleted. This makes the contents drop instead. Also I noticed that although grippers already have this functionality, if you remote detonate a borg holding something in a gripper it gives _you_ the "you dropped X" message. This makes that message not display at all on destruction of the gripper, just with normal dropping.

:cl:
* tweak: Cyborgs that are reset or destroyed while holding items inside storage modules will drop those items instead of deleting them.