### PR TITLE
Fixes robotics console bypassing hacked traitor borgs anti-termination safety

### DIFF
--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -164,14 +164,9 @@
 					var/choice = input("Are you certain you wish to detonate [R.name]?") in list("Confirm", "Abort")
 					if(choice == "Confirm")
 						if(R && istype(R))
-							if(R.mind && R.mind.special_role && R.emagged)
-								to_chat(R, "Extreme danger.  Termination codes detected.  Scrambling security codes and automatic AI unlink triggered.")
-								R.ResetSecurityCodes()
-
-							else
+							if(R.self_destruct())
 								message_admins("<span class='notice'>[key_name_admin(usr)] detonated [R.name]!</span>")
 								log_game("<span class='notice'>[key_name_admin(usr)] detonated [R.name]!</span>")
-								R.self_destruct()
 			else
 				to_chat(usr, "<span class='warning'>Access Denied.</span>")
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1236,8 +1236,12 @@
 		return
 
 /mob/living/silicon/robot/proc/self_destruct()
+	if(mind && mind.special_role && emagged)
+		to_chat(src, "<span class='danger'>Termination signal detected. Scrambling security and identification codes.</span>")
+		UnlinkSelf()
+		return FALSE
 	gib()
-	return
+	return TRUE
 
 /mob/living/silicon/robot/proc/UnlinkSelf()
 	if(connected_ai)
@@ -1261,7 +1265,7 @@
 
 	if(R)
 		R.UnlinkSelf()
-		to_chat(R, "Buffers flushed and reset. Camera system shutdown.  All systems operational.")
+		to_chat(R, "Buffers flushed and reset. Camera system shutdown. All systems operational.")
 		verbs -= /mob/living/silicon/robot/proc/ResetSecurityCodes
 
 /mob/living/silicon/robot/mode()


### PR DESCRIPTION
It simply wouldn't apply when you used the blow all borgs button so i moved the check to self_destruct(). Slapping LEEEEEGACY bug on this one.


:cl:
 * bugfix: Fixed an ancient bug that allowed the robotics console bypass hacked traitor borgs anti-termination safety