### PR TITLE
Emote fixes

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -65,7 +65,7 @@
 			else
 				alert("Unable to use this emote, must be either hearable or visible.")
 				return
-			return custom_emote(m_type, msg)
+			return custom_emote(m_type, input)
 
 		if ("me")
 			if(silent)

--- a/code/modules/mob/living/simple_animal/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer.dm
@@ -301,7 +301,8 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 			return
 
 	if (copytext(message, 1, 2) == "*")
-		return emote(copytext(message, 2))
+		to_chat(src, "<span class = 'notice'>This type of mob doesn't support this. Use the Me verb instead.</span>")
+		return
 
 	if (copytext(message, 1, 2) == ";") //Brain borer hivemind.
 		return borer_speak(copytext(message,2))

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -311,7 +311,7 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 	if(stat)
 		return
 	if(act == "scream")
-		desc = "makes a loud and pained whimper"  //ugly hack to stop animals screaming when crushed :P
+		desc = "makes a loud and pained whimper!"  //ugly hack to stop animals screaming when crushed :P
 		act = "me"
 	if(!desc && act != "me")
 		desc = "[act]."

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -313,10 +313,15 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 	if(act == "scream")
 		desc = "makes a loud and pained whimper"  //ugly hack to stop animals screaming when crushed :P
 		act = "me"
-	if(!desc)
+	if(!desc && act != "me")
 		desc = "[act]."
 		act = "me"
 	..(act, type, desc)
+
+/mob/living/simple_animal/check_emote(message)
+	if(copytext(message, 1, 2) == "*")
+		to_chat(src, "<span class = 'notice'>This type of mob doesn't support this. Use the Me verb instead.</span>")
+		return 1
 
 /mob/living/simple_animal/proc/handle_automated_speech()
 

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -30,12 +30,9 @@
 
 	message = utf8_sanitize(message, usr, MAX_MESSAGE_LEN)
 
-	if(!message)
-		return
-
 	if(usr.stat == DEAD)
 		usr.emote_dead(message)
-	else
+	else if(message)
 		usr.emote("me",usr.emote_type,message)
 
 /mob/proc/say_dead(var/message)

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -30,6 +30,9 @@
 
 	message = utf8_sanitize(message, usr, MAX_MESSAGE_LEN)
 
+	if(!message)
+		return
+
 	if(usr.stat == DEAD)
 		usr.emote_dead(message)
 	else


### PR DESCRIPTION
Fixes emoting the word "me" as a simple animal when using the Me verb and no input.
Fixes having to cancel a Me input twice.
Fixes Say "* " acting like Me for simple animals. This now gives a warning message. Otherwise you get things like 

**The mouse (223)** help.
**The mouse (223)** fart.

etc.

The only *emote that was working for simple animals was *scream anyway and that was the result of a hack to have door crushing not make them do human screams, which still works.
Fixes #17042

:cl:
* bugfix: Fixed having to enter *custom emotes twice.