### PR TITLE
Fixes binarycheck() not actually checking borgs components

### DIFF
--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -33,6 +33,9 @@
 /mob/living/silicon/binarycheck()
 	return 1
 
+/mob/living/silicon/robot/binarycheck()
+	return is_component_functioning("binary communication device")
+
 /mob/living/silicon/lingcheck()
 	return 0 //Borged or AI'd lings can't speak on the ling channel.
 


### PR DESCRIPTION
Fixes #17779

:cl:
 * bugfix: Fixes cyborgs having access to binary even if their binary communication device is broken or offline