### PR TITLE
Cyborgs and MoMMIs can use their modules while buckled

### DIFF
--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -52,10 +52,6 @@
 		A.attack_robot(src)
 		return
 
-	// locked_to cannot prevent machine interlinking but stops arm movement
-	if(locked_to)
-		return
-
 	if(W == A)
 		/*next_move = world.time + 8
 		if(W.flags&USEDELAY)


### PR DESCRIPTION
I challenged a human to a chair scooting race and was defeated due to cyborgs' inability to spray their extinguishers while buckled. This is wrong!

https://webmshare.com/oPEYY

:cl:
 * tweak: Cyborgs and MoMMIs can now use their modules while buckled.