### PR TITLE
Encryption keys are now tiny

### DIFF
--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -5,6 +5,7 @@
 	icon = 'icons/obj/radio.dmi'
 	icon_state = "cypherkey"
 	item_state = ""
+	w_class = W_CLASS_TINY
 	var/translate_binary = 0
 	var/translate_hive = 0
 	var/syndie = 0


### PR DESCRIPTION
Fixes #17765

:cl:
 * tweak: Headset encryption keys are now tiny.
