### PR TITLE
Fixed areaMaster not updating if the moved atom was inside another

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -421,6 +421,9 @@ var/area/space_area
 	else if(istype(oldArea) && oldArea.project_shadows)
 		Obj.underlays -= Obj.shadow
 
+	for(var/atom/movable/thing in get_contents_in_object(Obj))
+		thing.areaMaster = src
+
 	for(var/mob/mob_in_obj in Obj.contents)
 
 		CallHook("MobAreaChange", list("mob" = mob_in_obj, "new" = Obj.areaMaster, "old" = oldArea))


### PR DESCRIPTION
This fixes a number of issues. The one I encountered was building an air alarm frame inside an area in which air alarm cannot be built, holding it while I moved to an area in which they can be built, and attempting to build it.
`areaMaster` was set to the old value and so prevented the construction.
