### PR TITLE
Added power creep to the magnetic gripper

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -276,7 +276,7 @@
 	icon = 'icons/obj/device.dmi'
 	icon_state = "gripper"
 	required_module = list(/obj/item/weapon/robot_module/engineering)
-	modules_to_add = list(/obj/item/weapon/gripper/no_use/magnetic)
+	modules_to_add = list(/obj/item/weapon/gripper/magnetic)
 
 /obj/item/borg/upgrade/organ_gripper
 	name = "medical cyborg organ gripper upgrade"

--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -541,7 +541,7 @@
 		/obj/item/stack/sheet
 		)
 
-/obj/item/weapon/gripper/no_use/magnetic //No use because they don't need to open held tanks.
+/obj/item/weapon/gripper/magnetic //No use because they don't need to open held tanks.
 	name = "magnetic gripper"
 	desc = "A simple grasping tool specialized in construction and engineering work."
 	icon_state = "gripper"
@@ -552,7 +552,11 @@
 		/obj/item/weapon/tank,
 		/obj/item/weapon/circuitboard,
 		/obj/item/weapon/am_containment,
-		/obj/item/device/am_shielding_container
+		/obj/item/device/am_shielding_container,
+		/obj/item/weapon/table_parts,
+		/obj/item/weapon/rack_parts,
+		/obj/item/mounted/frame,
+		/obj/item/weapon/intercom_electronics
 		)
 
 	blacklist = list(

--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -541,7 +541,7 @@
 		/obj/item/stack/sheet
 		)
 
-/obj/item/weapon/gripper/magnetic //No use because they don't need to open held tanks.
+/obj/item/weapon/gripper/magnetic
 	name = "magnetic gripper"
 	desc = "A simple grasping tool specialized in construction and engineering work."
 	icon_state = "gripper"


### PR DESCRIPTION
:cl:
 * tweak: The engineering cyborgs magnetic gripper can now interact with things it's gripping (e.g. airlock electronics, tanks). It can also hold additional items such as table/rack parts, and mountable frames (for APC, air alarms, ...)