### PR TITLE
Solder-makeable circuitboards cost much less sacid to imprint

### DIFF
--- a/code/modules/research/designs/boards/machine_engie.dm
+++ b/code/modules/research/designs/boards/machine_engie.dm
@@ -50,7 +50,7 @@
 	id = "cellcharger"
 	req_tech = list(Tc_MATERIALS = 2, Tc_ENGINEERING = 2, Tc_POWERSTORAGE = 3)
 	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 2000, SACID = 20)
+	materials = list(MAT_GLASS = 2000, SACID = 3)
 	category = "Machine Boards"
 	build_path = /obj/item/weapon/circuitboard/cell_charger
 

--- a/code/modules/research/designs/boards/machine_hospitality.dm
+++ b/code/modules/research/designs/boards/machine_hospitality.dm
@@ -4,7 +4,7 @@
 	id = "microwave"
 	req_tech = list(Tc_PROGRAMMING = 2, Tc_ENGINEERING = 2, Tc_MAGNETS = 3)
 	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 2000, SACID = 20)
+	materials = list(MAT_GLASS = 2000, SACID = 3)
 	category = "Machine Boards"
 	build_path = /obj/item/weapon/circuitboard/microwave
 
@@ -67,3 +67,33 @@
 	materials = list(MAT_GLASS = 2000, SACID = 20)
 	category = "Machine Boards"
 	build_path = /obj/item/weapon/circuitboard/confectionator
+
+/datum/design/fishtank
+	name = "Circuit Design (Fishtank Filter)"
+	desc = "Allows for the construction of circuit boards used to build a fishtank."
+	id = "fishtank"
+	req_tech = list(Tc_PROGRAMMING = 1)
+	build_type = IMPRINTER
+	materials = list(MAT_GLASS = 2000, SACID = 3)
+	category = "Machine Boards"
+	build_path = /obj/item/weapon/circuitboard/fishtank
+
+/datum/design/fishwall
+	name = "Circuit Design (Large Fishtank Filter)"
+	desc = "Allows for the construction of circuit boards used to build a large fishtank."
+	id = "fishwall"
+	req_tech = list(Tc_PROGRAMMING = 1)
+	build_type = IMPRINTER
+	materials = list(MAT_GLASS = 2000, SACID = 3)
+	category = "Machine Boards"
+	build_path = /obj/item/weapon/circuitboard/fishwall
+
+/datum/design/conduction_plate
+	name = "Circuit Design (Conduction Plate)"
+	desc = "Allows for the construction of circuit boards used to build a conduction plate."
+	id = "conductionplate"
+	req_tech = list(Tc_PROGRAMMING = 1, Tc_ENGINEERING = 4)
+	build_type = IMPRINTER
+	materials = list(MAT_GLASS = 2000, SACID = 20)
+	category = "Machine Boards"
+	build_path = /obj/item/weapon/circuitboard/conduction_plate

--- a/code/modules/research/designs/boards/machine_hospitality.dm
+++ b/code/modules/research/designs/boards/machine_hospitality.dm
@@ -67,33 +67,3 @@
 	materials = list(MAT_GLASS = 2000, SACID = 20)
 	category = "Machine Boards"
 	build_path = /obj/item/weapon/circuitboard/confectionator
-
-/datum/design/fishtank
-	name = "Circuit Design (Fishtank Filter)"
-	desc = "Allows for the construction of circuit boards used to build a fishtank."
-	id = "fishtank"
-	req_tech = list(Tc_PROGRAMMING = 1)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 2000, SACID = 3)
-	category = "Machine Boards"
-	build_path = /obj/item/weapon/circuitboard/fishtank
-
-/datum/design/fishwall
-	name = "Circuit Design (Large Fishtank Filter)"
-	desc = "Allows for the construction of circuit boards used to build a large fishtank."
-	id = "fishwall"
-	req_tech = list(Tc_PROGRAMMING = 1)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 2000, SACID = 3)
-	category = "Machine Boards"
-	build_path = /obj/item/weapon/circuitboard/fishwall
-
-/datum/design/conduction_plate
-	name = "Circuit Design (Conduction Plate)"
-	desc = "Allows for the construction of circuit boards used to build a conduction plate."
-	id = "conductionplate"
-	req_tech = list(Tc_PROGRAMMING = 1, Tc_ENGINEERING = 4)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 2000, SACID = 20)
-	category = "Machine Boards"
-	build_path = /obj/item/weapon/circuitboard/conduction_plate

--- a/code/modules/research/designs/boards/machine_misc.dm
+++ b/code/modules/research/designs/boards/machine_misc.dm
@@ -82,7 +82,7 @@
 	id = "vendomat"
 	req_tech = list(Tc_MATERIALS = 1, Tc_ENGINEERING = 1, Tc_POWERSTORAGE = 1)
 	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 2000, SACID = 20)
+	materials = list(MAT_GLASS = 2000, SACID = 3)
 	category = "Misc"
 	build_path = /obj/item/weapon/circuitboard/vendomat
 

--- a/code/modules/research/designs/boards/machine_science.dm
+++ b/code/modules/research/designs/boards/machine_science.dm
@@ -34,7 +34,7 @@
 	id = "autolathe"
 	req_tech = list(Tc_PROGRAMMING = 2, Tc_ENGINEERING = 2)
 	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 2000, SACID = 20)
+	materials = list(MAT_GLASS = 2000, SACID = 3)
 	category = "Machine Boards"
 	build_path = /obj/item/weapon/circuitboard/autolathe
 

--- a/code/modules/research/designs/boards/misc.dm
+++ b/code/modules/research/designs/boards/misc.dm
@@ -4,7 +4,7 @@
 	id = "air_alarm"
 	req_tech = list(Tc_PROGRAMMING = 2)
 	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 2000, SACID = 20)
+	materials = list(MAT_GLASS = 2000, SACID = 3)
 	category = "Engineering Boards"
 	build_path = /obj/item/weapon/circuitboard/air_alarm
 
@@ -14,7 +14,7 @@
 	id = "fire_alarm"
 	req_tech = list(Tc_PROGRAMMING = 2)
 	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 2000, SACID = 20)
+	materials = list(MAT_GLASS = 2000, SACID = 3)
 	category = "Engineering Boards"
 	build_path = /obj/item/weapon/circuitboard/fire_alarm
 
@@ -24,7 +24,7 @@
 	id = "airlock"
 	req_tech = list(Tc_PROGRAMMING = 2)
 	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 2000, SACID = 20)
+	materials = list(MAT_GLASS = 2000, SACID = 3)
 	category = "Engineering Boards"
 	build_path = /obj/item/weapon/circuitboard/airlock
 
@@ -34,7 +34,7 @@
 	id = "intercom"
 	req_tech = list(Tc_PROGRAMMING = 2)
 	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 2000, SACID = 20)
+	materials = list(MAT_GLASS = 2000, SACID = 3)
 	category = "Engineering Boards"
 	build_path = /obj/item/weapon/intercom_electronics
 
@@ -44,7 +44,7 @@
 	id = "apc_board"
 	req_tech = list(Tc_POWERSTORAGE = 2)
 	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 2000, SACID = 20)
+	materials = list(MAT_GLASS = 2000, SACID = 3)
 	category = "Engineering Boards"
 	build_path = /obj/item/weapon/circuitboard/power_control
 
@@ -54,7 +54,7 @@
 	id = "station_map"
 	req_tech = list(Tc_MAGNETS = 2, Tc_PROGRAMMING = 2)
 	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 2000, SACID = 20)
+	materials = list(MAT_GLASS = 2000, SACID = 3)
 	category = "Engineering Boards"
 	build_path = /obj/item/weapon/circuitboard/station_map
 


### PR DESCRIPTION
https://github.com/vgstation-coders/vgstation13/blob/a36d4656d21eea49e9793ebafc25548a423ff78c/code/game/machinery/constructable_frame.dm#L290
It doesn't make sense for soldering irons to be 500% more efficient with sacid than the circuit imprinter, so this discounts everything solder-makeable. Note that there's a default material coefficent of 1.5 that gets applied so a cost of 3 becomes 4.5 sacid vs. the 5 that the soldering iron uses.

:cl:
* tweak: Circuit imprinters now use much less sulfuric acid when printing any circuit that is makeable with a soldering iron.