### PR TITLE
Fishtank research designs

### DIFF
--- a/code/modules/research/designs/boards/machine_hospitality.dm
+++ b/code/modules/research/designs/boards/machine_hospitality.dm
@@ -67,3 +67,33 @@
 	materials = list(MAT_GLASS = 2000, SACID = 20)
 	category = "Machine Boards"
 	build_path = /obj/item/weapon/circuitboard/confectionator
+
+/datum/design/fishtank
+	name = "Circuit Design (Fishtank Filter)"
+	desc = "Allows for the construction of circuit boards used to build a fishtank."
+	id = "fishtank"
+	req_tech = list(Tc_PROGRAMMING = 1)
+	build_type = IMPRINTER
+	materials = list(MAT_GLASS = 2000, SACID = 3)
+	category = "Machine Boards"
+	build_path = /obj/item/weapon/circuitboard/fishtank
+
+/datum/design/fishwall
+	name = "Circuit Design (Large Fishtank Filter)"
+	desc = "Allows for the construction of circuit boards used to build a large fishtank."
+	id = "fishwall"
+	req_tech = list(Tc_PROGRAMMING = 1)
+	build_type = IMPRINTER
+	materials = list(MAT_GLASS = 2000, SACID = 3)
+	category = "Machine Boards"
+	build_path = /obj/item/weapon/circuitboard/fishwall
+
+/datum/design/conduction_plate
+	name = "Circuit Design (Conduction Plate)"
+	desc = "Allows for the construction of circuit boards used to build a conduction plate."
+	id = "conductionplate"
+	req_tech = list(Tc_PROGRAMMING = 1, Tc_ENGINEERING = 4)
+	build_type = IMPRINTER
+	materials = list(MAT_GLASS = 2000, SACID = 20)
+	category = "Machine Boards"
+	build_path = /obj/item/weapon/circuitboard/conduction_plate


### PR DESCRIPTION
The first two are already makeable with a soldering iron. The conduction plate circuit has to be ordered from cargo as far as I know, so that's possibly a more significant change.

:cl:
* tweak: Fishtank-related circuits are now makeable from circuit imprinters.