### PR TITLE
Fixed exosuit fabricator cyborg component tab

### DIFF
--- a/nano/templates/exofab.tmpl
+++ b/nano/templates/exofab.tmpl
@@ -205,9 +205,8 @@ Used In File(s): \code\game\mecha\mech_fabricator.dm
 					{{for data.parts.Robot_Part}}
 						<div class="line">
 							<div class="statusValue">
-								{{:helper.link(value.name, 'gear', null, null, null, 'misc')}}
+								{{:helper.link(value.name, 'gear', value.command2, null, null, 'misc')}}
 								{{:helper.link(value.cost, null, null, null, null, 'cost')}}
-								{{:helper.link('Build', 'gear', value.command2, null, 'fixedLeft')}}
 								{{:helper.link('Queue', 'gear', value.command1, null, 'fixedLeft')}}
 							</div>
 						</div>


### PR DESCRIPTION
#17796 increased the size of the requirements div and this tab in particular happened to be retarded. All other tabs are "name (build) | reqs | queue" but this one was "name | reqs | build | queue".

before
![image](https://user-images.githubusercontent.com/6307265/37251942-6a312fbc-2519-11e8-96fd-8389473c5e7e.png)

after
![image](https://user-images.githubusercontent.com/6307265/37251944-6e10bd64-2519-11e8-9d58-3b33fa0b6de3.png)
