### PR TITLE
Reworks how the circuit imprinter stores reagents

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -219,6 +219,10 @@ var/global/list/ghdel_profiling = list()
 /atom/proc/is_open_container()
 	return flags & OPENCONTAINER
 
+// For when we want an open container that doesn't show its reagents on examine
+/atom/proc/hide_our_reagents()
+	return FALSE
+
 // As a rule of thumb, should smoke be able to pop out from inside this object?
 // Currently only used for chemical reactions, see Chemistry-Recipes.dm
 /atom/proc/is_airtight()
@@ -414,7 +418,7 @@ its easier to just keep the beam vertical.
 	if(desc)
 		to_chat(user, desc)
 
-	if(reagents && is_open_container() && !ismob(src)) //is_open_container() isn't really the right proc for this, but w/e
+	if(reagents && is_open_container() && !ismob(src) && !hide_our_reagents()) //is_open_container() isn't really the right proc for this, but w/e
 		if(get_dist(user,src) > 3)
 			to_chat(user, "<span class='info'>You can't make out the contents.</span>")
 		else

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -220,7 +220,7 @@ var/global/list/ghdel_profiling = list()
 	return flags & OPENCONTAINER
 
 // For when we want an open container that doesn't show its reagents on examine
-/atom/proc/hide_our_reagents()
+/atom/proc/hide_own_reagents()
 	return FALSE
 
 // As a rule of thumb, should smoke be able to pop out from inside this object?
@@ -418,7 +418,7 @@ its easier to just keep the beam vertical.
 	if(desc)
 		to_chat(user, desc)
 
-	if(reagents && is_open_container() && !ismob(src) && !hide_our_reagents()) //is_open_container() isn't really the right proc for this, but w/e
+	if(reagents && is_open_container() && !ismob(src) && !hide_own_reagents()) //is_open_container() isn't really the right proc for this, but w/e
 		if(get_dist(user,src) > 3)
 			to_chat(user, "<span class='info'>You can't make out the contents.</span>")
 		else

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -255,6 +255,8 @@
 											components += P
 											req_components[I]--
 											update_desc()
+											if(P.is_open_container())
+												. = 1
 											break
 								to_chat(user, desc)
 

--- a/code/modules/research/circuitprinter.dm
+++ b/code/modules/research/circuitprinter.dm
@@ -40,6 +40,8 @@ using metal and glass, it uses glass and reagents (usually sulfuric acis).
 						MAT_SILVER
 	)
 
+	var/draining = FALSE
+
 /obj/machinery/r_n_d/fabricator/circuit_imprinter/New()
 	. = ..()
 
@@ -76,17 +78,22 @@ using metal and glass, it uses glass and reagents (usually sulfuric acis).
 	if (O.is_open_container())
 		return 0
 
-/obj/machinery/r_n_d/fabricator/circuit_imprinter/process()
-	if(reagents && reagents.reagent_list.len)
-		for(var/obj/item/weapon/reagent_containers/RC in component_parts)
-			var/empty_volume = RC.reagents.maximum_volume - RC.reagents.total_volume
-			if(empty_volume <= 0)
-				continue
-			reagents.trans_to(RC, empty_volume)
+/obj/machinery/r_n_d/fabricator/circuit_imprinter/on_reagent_change()
+	if(!draining)
+		drain_to_beakers()
 
-		update_buffer_size()
-
-	..()
+/obj/machinery/r_n_d/fabricator/circuit_imprinter/proc/drain_to_beakers()
+	draining = TRUE
+	for(var/obj/item/weapon/reagent_containers/RC in component_parts)
+		if(RC.reagents.is_full())
+			continue
+		var/empty_volume = RC.reagents.maximum_volume - RC.reagents.total_volume
+		reagents.trans_to(RC, empty_volume)
+		if(reagents.is_empty())
+			break
+	reagents.clear_reagents()
+	update_buffer_size()
+	draining = FALSE
 
 /obj/machinery/r_n_d/fabricator/circuit_imprinter/update_buffer_size()
 	var/total_empty_volume = 0

--- a/code/modules/research/circuitprinter.dm
+++ b/code/modules/research/circuitprinter.dm
@@ -99,12 +99,6 @@ using metal and glass, it uses glass and reagents (usually sulfuric acis).
 	for(var/obj/item/weapon/reagent_containers/RC in component_parts)
 		all_volume += RC.reagents.total_volume
 	return all_volume
-/*
-/obj/machinery/r_n_d/fabricator/circuit_imprinter/examine(mob/user)
-	..()
-	for(var/obj/item/weapon/reagent_containers/RC in component_parts)
-		to_chat(user, "<span class='info'>There is \a [RC.name] inside.</span>")
-		RC.show_list_of_reagents(user)
-*/
-/obj/machinery/r_n_d/fabricator/circuit_imprinter/hide_our_reagents()
+
+/obj/machinery/r_n_d/fabricator/circuit_imprinter/hide_own_reagents()
 	return TRUE

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -973,8 +973,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			dat += {"[CircuitImprinterHeader()]
 				Chemical Storage<HR>"}
 
-			/var/beaker_index
-			beaker_index = 0 //Need to do it this way or it doesn't reset properly on refresh
+			var/beaker_index = 0
 			for(var/obj/item/weapon/reagent_containers/RC in linked_imprinter.component_parts)
 				beaker_index++
 				dat += "<b>Reservoir [beaker_index] - [RC.name]:</b><BR>"

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -976,7 +976,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			var/beaker_index = 0
 			for(var/obj/item/weapon/reagent_containers/RC in linked_imprinter.component_parts)
 				beaker_index++
-				dat += "<b>Reservoir [beaker_index] - [RC.name]:</b><BR>"
+				dat += "<b>Reservoir [beaker_index] &mdash; [RC.name]:</b><BR>"
 				if(RC.reagents.reagent_list && RC.reagents.reagent_list.len)
 					for(var/datum/reagent/R in RC.reagents.reagent_list)
 						dat += {"[R.name] | Units: [R.volume]


### PR DESCRIPTION
Thanks to @DamianX for helping me with the console interface part of this.

:cl:
* tweak: Reworked circuit imprinter reagent storage. Imprinters now actually hold reagents in their internal beakers instead of a phantom reagent holder that was destroyed when parts were swapped.