### PR TITLE
Fixed a spell buttons runtime

### DIFF
--- a/code/modules/mob/spells.dm
+++ b/code/modules/mob/spells.dm
@@ -53,12 +53,15 @@
 	if(!spell_masters || !spell_masters.len)
 		return
 
+	var/obj/abstract/screen/movable/spell_master/master = spell_to_remove.connected_button.spellmaster
+	if(!(master in spell_masters))
+		return
+	master.remove_spell(spell_to_remove)
+
 	spell_to_remove.on_removed(src)
 	if(mind && mind.wizard_spells)
 		mind.wizard_spells.Remove(spell_to_remove)
 	spell_list.Remove(spell_to_remove)
-	for(var/obj/abstract/screen/movable/spell_master/spell_master in spell_masters)
-		spell_master.remove_spell(spell_to_remove)
 	return 1
 
 /mob/proc/silence_spells(var/amount = 0)


### PR DESCRIPTION
There was a runtime caused by this proc when a mob had more than one spell_master. When called, `mob/remove_spell()` would loop over all mob's spell masters and attempt to remove the spell from them.
`spell_master/remove_spell()` would then try to returnToPool the spell's associated button. This was a problem because each iteration after the first would be effectively doing `returnToPool(null)`.

Looping through each spell_master seems unnecessary, so instead we just get the button associated to the spell we're removing, we get the spell master associated to that button, and remove the spell from this spell master.

I made the following assumptions which may not (always?) be true?
- A spell is only present in one spell_master's spell list
- All spells passed to this proc have a `connected_button`
- If the spell's button's spell master is not in this mob's list of spell masters we don't want to have anything to do with it

I tested it in the sense that spells are removed correctly, spell masters are removed correctly and no runtime is thrown, but I'm not sure in how many ways this could break the universe.