### PR TITLE
Reverts unintended buff to diona photosynthesis

### DIFF
--- a/code/modules/mob/living/carbon/human/life/handle_chemicals_in_body.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_chemicals_in_body.dm
@@ -34,7 +34,7 @@
 		var/light_amount = 0 //How much light there is in the place, affects receiving nutrition and healing
 		if(isturf(loc)) //Else, there's considered to be no light
 			var/turf/T = loc
-			light_amount = T.get_lumcount() * 10
+			light_amount = (T.get_lumcount() * 10) - 5
 
 		nutrition += light_amount
 		pain_shock_stage -= light_amount

--- a/code/modules/mob/living/carbon/monkey/life.dm
+++ b/code/modules/mob/living/carbon/monkey/life.dm
@@ -520,7 +520,7 @@
 		if(isturf(loc)) //else, there's considered to be no light
 			var/turf/T = loc
 			if(T.dynamic_lighting)
-				light_amount = T.get_lumcount() * 10
+				light_amount = (T.get_lumcount() * 10) - 5
 			else
 				light_amount = 5
 		nutrition += light_amount


### PR DESCRIPTION
Closes #16588

Exhibit A: https://github.com/vgstation-coders/vgstation13/commit/3bc5d862634d3cc2aabcb0dedb6da2132cedb77c#diff-2de2df982739a4fbdb54a4b2715d6f92L1057
Exhibit B: https://github.com/vgstation-coders/vgstation13/commit/a9b0b2b047f7db0e4b5a7944e0232ce59981c1ae#diff-b6a4e686098dd0edc416d2b553c872a7L35

Upshot is that where lighting goes from 0 to 10, they were originally supposed to have 5 subtracted from what they get out of it. No doubt #16588 is referring to this. Also please note that #14721 was merged based on the bugged regen.

Current calculation:
https://github.com/vgstation-coders/vgstation13/blob/2304d397cd08bcdd9bd0bf6929d3dbb8d44f48a2/code/modules/mob/living/carbon/human/life/handle_chemicals_in_body.dm#L37

Original calculation:
https://github.com/vgstation-coders/vgstation13/blob/54a563cb0df1e76337ebae4745114cef7488fad9/code/modules/mob/living/carbon/human/life.dm#L1057

![line](https://user-images.githubusercontent.com/31839805/37312645-190ac2d8-2609-11e8-90a7-45b066d98ffe.PNG)

:cl:
* bugfix: Returned diona photosynthesis to how it was before a major unintended buff.