### PR TITLE
a bit of Hyperzine balance

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -625,7 +625,7 @@
 
 /mob/living/carbon/movement_tally_multiplier()
 	. = ..()
-	if(!istype(loc, /turf/space) && !reagents.has_any_reagents(list(HYPERZINE,COCAINE)))
+	if(!istype(loc, /turf/space))
 		for(var/obj/item/I in get_clothing_items())
 			if(I.slowdown <= 0)
 				testing("[I] HAD A SLOWDOWN OF <=0 OH DEAR")
@@ -635,6 +635,11 @@
 		for(var/obj/item/I in held_items)
 			if(I.flags & SLOWDOWN_WHEN_CARRIED)
 				. *= I.slowdown
+
+		if(reagents.has_any_reagents(list(HYPERZINE,COCAINE)))
+			. *= 0.4
+			if(. < 1)//we don't want to move faster than the base speed
+				. = 1
 
 /mob/living/carbon/base_movement_tally()
 	. = ..()

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -10,7 +10,7 @@
 	if(flying)
 		return // Calculate none of the following because we're technically on a vehicle
 	if(reagents.has_any_reagents(list(HYPERZINE,COCAINE)))
-		return // Hyperzine ignores slowdown
+		return // Hyperzine ignores base slowdown
 	if(istype(loc, /turf/space))
 		return // Space ignores slowdown
 

--- a/code/modules/projectiles/guns/projectile/minigun.dm
+++ b/code/modules/projectiles/guns/projectile/minigun.dm
@@ -9,6 +9,7 @@
 	recoil = 1
 	slot_flags = null
 	flags = FPRINT | TWOHANDABLE | SLOWDOWN_WHEN_CARRIED
+	slowdown = MINIGUN_SLOWDOWN_NONWIELDED
 	w_class = W_CLASS_HUGE//we be fuckin huge maaan
 	fire_delay = 0
 	fire_sound = 'sound/weapons/gatling_fire.ogg'
@@ -63,7 +64,7 @@
 /obj/item/weapon/gun/gatling/can_discharge() //Why is this gun not a child of gun/projectile?
 	if (current_shells && wielded)
 		return 1
-	
+
 /obj/item/weapon/gun/gatling/update_icon()
 	switch(current_shells)
 		if(150 to INFINITY)


### PR DESCRIPTION
No more sprinting while firing a gatling gun. tested with various spacesuits with magboots enabled/disabled. Xenoarchaeologist-friends should find the change tolerable (it's not like xenoarch isn't mostly about standing still in one place for hours anyway)

:cl:
* tweak: Hyperzine will now divide slowdown from worn clothing/held items (like magboots, spacesuits, or gatling guns) by 2.5 instead of completely removing it.