### PR TITLE
Runtime hunting: Bloodbot targeting

### DIFF
--- a/code/game/machinery/bots/draculabot.dm
+++ b/code/game/machinery/bots/draculabot.dm
@@ -193,7 +193,7 @@
 			for(var/mob/living/carbon/human/H in view(7,src))
 				if(H.vessel.get_reagent_amount(BLOOD) && !(H.species.anatomy_flags & NO_BLOOD))
 					possible_targets += H
-			if(possible_targets)
+			if(possible_targets.len)
 				target = pick(possible_targets)
 			else
 				return


### PR DESCRIPTION
```
[19:51:51] Runtime in draculabot.dm,197: pick() from empty list
  proc name: process (/obj/machinery/bot/bloodbot/process)
  src: Doctor Acula (/obj/machinery/bot/bloodbot)
  src.loc: the floor (97,91,1) (/turf/simulated/floor)
  call stack:
  Doctor Acula (/obj/machinery/bot/bloodbot): process()
  Machinery (/datum/subsystem/machinery): fire(0)
  Machinery (/datum/subsystem/machinery): ignite(0)
  Master (/datum/controller/master): RunQueue()
  Master (/datum/controller/master): Loop()
  Master (/datum/controller/master): StartProcessing()
```