### PR TITLE
 Runtime hunting, action buttons ACT 3

### DIFF
--- a/code/_onclick/hud/action_button.dm
+++ b/code/_onclick/hud/action_button.dm
@@ -74,7 +74,7 @@
 	if(!hud_used || !client)
 		return
 
-	if(hud_used.hud_shown != 1)
+	if(hud_used.hud_shown != 1 || !hud_used.hide_actions_toggle)
 		return
 
 	var/button_number = 0
@@ -99,8 +99,10 @@
 		if(!button_number)
 			hud_used.hide_actions_toggle.screen_loc = null
 			return
+
 	if(!hud_used.hide_actions_toggle.screen_loc)
 		reload_screen = 1
+
 	if(!hud_used.hide_actions_toggle.moved)
 		hud_used.hide_actions_toggle.screen_loc = hud_used.ButtonNumberToScreenCoords(button_number+1)
 	else

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -34,9 +34,11 @@ var/global/obj/abstract/screen/clicker/catcher = new()
 
 /datum/hud/New(mob/owner)
 	mymob = owner
-	instantiate()
+
 	hide_actions_toggle = new
 	hide_actions_toggle.InitialiseIcon(mymob)
+
+	instantiate()
 	..()
 
 /datum/hud/Destroy()


### PR DESCRIPTION
Blobs aren't freaking out in 512, god bless. Added the check to update_action_buttons() too because fuuuuck these runtimes.

:cl:
 * bugfix: Fixes two 2-years old runtimes with action buttons.
