### PR TITLE
Lockbox EMP Cleanup

### DIFF
--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -83,7 +83,6 @@
 	..()
 	if(health <= 0)
 		for(var/atom/movable/A in src)
-			for(var/obj/O in src)
 			remove_from_storage(A, get_turf(src))
 
 		qdel(src)
@@ -96,14 +95,12 @@
 		if(2)
 			if(prob(80))
 				for(var/atom/movable/A in src)
-					for(var/obj/O in src)
 					remove_from_storage(A, get_turf(src))
 					A.ex_act(3)
 				qdel(src)
 		if(3)
 			if(prob(50))
 				for(var/atom/movable/A in src)
-					for(var/obj/O in src)
 					remove_from_storage(A, get_turf(src))
 				qdel(src)
 
@@ -120,8 +117,8 @@
 			locked = !locked
 			src.update_icon()
 			if(!locked)
-				for(var/obj/O in src)
-					remove_from_storage(O, get_turf(src))
+				for(var/atom/movable/A in src)
+					remove_from_storage(A, get_turf(src))
 				if(oneuse)
 					qdel(src)
 

--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -120,9 +120,8 @@
 			locked = !locked
 			src.update_icon()
 			if(!locked)
-				for(var/atom/movable/A in src)
-					for(var/obj/O in src)
-						remove_from_storage(A, get_turf(src))
+				for(var/obj/O in src)
+					remove_from_storage(A, get_turf(src))
 				if(oneuse)
 					qdel(src)
 

--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -110,37 +110,23 @@
 /obj/item/weapon/storage/lockbox/emp_act(severity)
 	..()
 	if(!broken)
+		var/probab
 		switch(severity)
 			if(1)
-				if(prob(80))
-					locked = !locked
-					src.update_icon()
-					if(!locked)
-						for(var/atom/movable/A in src)
-							for(var/obj/O in src)
-							remove_from_storage(A, get_turf(src))
-						if(oneuse)
-							qdel(src)
+				probab = 80
 			if(2)
-				if(prob(50))
-					locked = !locked
-					src.update_icon()
-					if(!locked)
-						for(var/atom/movable/A in src)
-							for(var/obj/O in src)
-							remove_from_storage(A, get_turf(src))
-						if(oneuse)
-							qdel(src)
-			if(3)
-				if(prob(25))
-					locked = !locked
-					src.update_icon()
-					if(!locked)
-						for(var/atom/movable/A in src)
-							for(var/obj/O in src)
-							remove_from_storage(A, get_turf(src))
-						if(oneuse)
-							qdel(src)
+				probab = 50
+		if(prob(probab))
+			locked = !locked
+			src.update_icon()
+			if(!locked)
+				for(var/atom/movable/A in src)
+					for(var/obj/O in src)
+						remove_from_storage(A, get_turf(src))
+				if(oneuse)
+					qdel(src)
+
+
 
 /obj/item/weapon/storage/lockbox/update_icon()
 	..()

--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -121,7 +121,7 @@
 			src.update_icon()
 			if(!locked)
 				for(var/obj/O in src)
-					remove_from_storage(A, get_turf(src))
+					remove_from_storage(O, get_turf(src))
 				if(oneuse)
 					qdel(src)
 


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl:
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
The emp_act() proc in lockboxes contains a redundant case for a severity of 3 as well as ugly copy-paste in the conditional. This PR removes those and restructures it slightly.
Unnecessary loops in the emp_act(), ex_act() and bullet_act() procs were removed.