### PR TITLE
Staff of the necromancer fixes

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -1008,3 +1008,8 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		if(HUD_SECURITY)
 			return selectedHUD == HUD_SECURITY
 	return
+
+/mob/dead/observer/proc/can_reenter_corpse()
+	var/mob/M = get_top_transmogrification()
+	return (M && M.client && can_reenter_corpse)
+

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -209,13 +209,13 @@
 
 	switch(raisetype)
 		if(ZOMBIE)
-			var/mob/living/simple_animal/hostile/necro/zombie/turned/T = new(get_turf(target), user, H.mind)
+			var/mob/living/simple_animal/hostile/necro/zombie/turned/T = new(get_turf(target), user, H)
 			T.get_clothes(H, T)
 			T.name = H.real_name
 			T.host = H
 			H.loc = null
 		if(SKELETON)
-			new /mob/living/simple_animal/hostile/necro/skeleton(get_turf(target), user, H.mind)
+			new /mob/living/simple_animal/hostile/necro/skeleton(get_turf(target), user, H)
 			H.gib()
 	charges--
 


### PR DESCRIPTION
Closes #13805
Closes #13460
Closes #14254
Closes #17810
Closes #11526
:cl:
 * bugfix: Staff of the necromancer will no longer put dead players that became some other mob back into their old zombie.
* bugfix: Unzombified zombies will properly regain their original player.
