### PR TITLE
area_entered proc, meson disabling area flag

### DIFF
--- a/__DEFINES/areas.dm
+++ b/__DEFINES/areas.dm
@@ -1,3 +1,4 @@
 //area-only flags
 #define NO_PORTALS 1
 #define NO_TELEPORT 2
+#define NO_MESONS 4

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -421,7 +421,9 @@ var/area/space_area
 	else if(istype(oldArea) && oldArea.project_shadows)
 		Obj.underlays -= Obj.shadow
 
+	Obj.area_entered(src)
 	for(var/atom/movable/thing in get_contents_in_object(Obj))
+		thing.area_entered(src)
 		thing.areaMaster = src
 
 	for(var/mob/mob_in_obj in Obj.contents)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -966,3 +966,6 @@
 
 /atom/movable/proc/on_tether_broken(atom/movable/other_end)	//To allow for code based on when a tether with a specific thing is broken
 	return
+
+/atom/movable/proc/area_entered(var/area/A)
+	return

--- a/code/modules/clothing/glasses/scanners.dm
+++ b/code/modules/clothing/glasses/scanners.dm
@@ -33,14 +33,14 @@
 		if(iscarbon(M))
 			apply_color(M)
 	..()
-	
+
 /obj/item/clothing/glasses/scanner/unequipped(mob/user, var/from_slot = null)
 	if(from_slot == slot_glasses)
 		if(on)
 			if(iscarbon(user))
 				remove_color(user)
 	..()
-	
+
 /obj/item/clothing/glasses/scanner/update_icon()
 	icon_state = initial(icon_state)
 
@@ -133,6 +133,10 @@
 	species_fit = list(GREY_SHAPED)
 
 /obj/item/clothing/glasses/scanner/meson/enable(var/mob/C)
+	var/area/A = get_area(src)
+	if(A.flags & NO_MESONS)
+		to_chat(C, "<span class = 'warning'>\The [src] flickers, but refuses to come online!</span>")
+		return
 	eyeprot = initial(eyeprot)
 	vision_flags |= SEE_TURFS
 	see_invisible |= SEE_INVISIBLE_MINIMUM
@@ -145,6 +149,11 @@
 	vision_flags &= ~SEE_TURFS
 	see_invisible &= ~SEE_INVISIBLE_MINIMUM
 	..()
+
+/obj/item/clothing/glasses/scanner/meson/area_entered(area/A)
+	if(A.flags & NO_MESONS && on)
+		visible_message("<span class = 'warning'>\The [src] sputter out.</span>")
+		disable()
 
 /obj/item/clothing/glasses/scanner/material
 	name = "optical material scanner"

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1194,8 +1194,12 @@
 				sensor_mode = NIGHT
 				to_chat(src, "<span class='notice'>Light amplification mode enabled.</span>")
 			if("Mesons")
-				sensor_mode = MESON_VISION
-				to_chat(src, "<span class='notice'>Meson Vison augmentation enabled.</span>")
+				var/area/A = get_area(src)
+				if(A.flags & NO_MESONS)
+					to_chat(src, "<span class = 'warning'>Unable to initialize Meson Vision. Probable cause: [pick("Atmospheric anomaly","Poor boot paramater","Bulb burn-out")]</span>")
+				else
+					sensor_mode = MESON_VISION
+					to_chat(src, "<span class='notice'>Meson Vision augmentation enabled.</span>")
 			if("Thermal")
 				sensor_mode = THERMAL_VISION
 				to_chat(src, "<span class='notice'>Thermal Optics augmentation enabled.</span>")

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1205,6 +1205,11 @@
 		handle_sensor_modes()
 		update_sight_hud()
 
+/mob/living/silicon/robot/area_entered(area/A)
+	if(A.flags & NO_MESONS && sensor_mode == MESON_VISION)
+		to_chat(src, "<span class='warning'>Your Meson Vision augmentation [pick("force-quits","shuts down unexpectedly","has received an update and needs to close")]!</span>")
+		unequip_sight()
+
 /mob/living/silicon/robot/proc/unequip_sight()
 	sensor_mode = 0
 	update_sight_hud()


### PR DESCRIPTION
adds area_entered proc for when you want something weird and wonderful to happen when something enters a certain area.

PoC is a new area flag that disables Mesons when you enter the area, and tells you off should you try to enable them in that area.

:cl:
* rscadd: Adds a code function to disable mesons for mappers so you can't peek at secret vaults