### PR TITLE
Runtime hunting: target stakes Move()

### DIFF
--- a/code/game/objects/structures/target_stake.dm
+++ b/code/game/objects/structures/target_stake.dm
@@ -9,7 +9,7 @@
 	siemens_coefficient = 1
 	var/obj/item/target/pinned_target // the current pinned target
 
-	Move()
+	Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 		..()
 		// Move the pinned target along with the stake
 		if(pinned_target in view(3, src))


### PR DESCRIPTION
```
x10 ,: bad arg name 'glide_size_override'
  proc name: Move (/obj/structure/target_stake/Move)
  usr: Adrian Coleman (mookin) (/mob/living/carbon/human)
  usr.loc: The floor (279, 188, 1) (/turf/simulated/floor)
  src: the target stake (/obj/structure/target_stake)
  src.loc: the floor (278,187,1) (/turf/simulated/floor)
  call stack:
  the target stake (/obj/structure/target_stake): Move(the floor (278,188,1) (/turf/simulated/floor), 1, null)
  Adrian Coleman (/mob/living/carbon/human): Move(the floor (279,188,1) (/turf/simulated/floor), 4, 0, 0, 0)
  Adrian Coleman (/mob/living/carbon/human): Move(the floor (279,188,1) (/turf/simulated/floor), 4, 0, 0, 0)
  Adrian Coleman (/mob/living/carbon/human): Move(the floor (279,188,1) (/turf/simulated/floor), 4, 0, 0, 0)
  Mookin (/client): Move(the floor (278,188,1) (/turf/simulated/floor), 4, 0, 0, 0)
  Mookin (/client): move loop()
```

0% tested