### PR TITLE
Saner failure mode for infestation events

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -3564,6 +3564,7 @@
 					"incinerator" = LOC_INCIN,
 					"chapel" = LOC_CHAPEL,
 					"library" = LOC_LIBRARY,
+					"hydroponics" = LOC_HYDRO,
 					"vault" = LOC_VAULT,
 					"technical storage" = LOC_TECH,
 					)

--- a/code/modules/events/infestation.dm
+++ b/code/modules/events/infestation.dm
@@ -94,14 +94,19 @@
 
 	var/number = rand(2, max_number)
 
-	for(var/i = 0, i <= number, i++)
-		var/area/A = locate(spawn_area_type)
-		var/list/turf/simulated/floor/valid = list()
-		//Loop through each floor in the supply drop area
-		for(var/turf/simulated/floor/F in A)
-			if(!F.has_dense_content())
-				valid.Add(F)
+	var/area/A = locate(spawn_area_type)
+	var/list/turf/simulated/floor/valid = list()
+	//Loop through each floor in the supply drop area
+	for(var/turf/simulated/floor/F in A)
+		if(!F.has_dense_content())
+			valid.Add(F)
+	if(!valid.len)
+		message_admins("Infestation event failed! Could not find any valid spawn locations in [spawn_area_type].")
+		announceWhen = -1
+		endWhen = 0
+		return
 
+	for(var/i = 0, i <= number, i++)
 		var/picked = pick(valid)
 		if(vermin == VERM_SPIDERS)
 			var/mob/living/simple_animal/hostile/giant_spider/spiderling/S = new(picked)

--- a/code/modules/events/infestation.dm
+++ b/code/modules/events/infestation.dm
@@ -101,7 +101,7 @@
 		if(!F.has_dense_content())
 			valid.Add(F)
 	if(!valid.len)
-		message_admins("Infestation event failed! Could not find any valid spawn locations in [spawn_area_type].")
+		message_admins("Infestation event failed! Could not find any viable turfs in [spawn_area_type] at which to spawn [number + 1] [vermstring].")
 		announceWhen = -1
 		endWhen = 0
 		return
@@ -113,7 +113,12 @@
 			S.amount_grown = 0
 		else
 			var/spawn_type = pick(spawn_types)
-			new spawn_type(picked)
+			var/mob/M = new spawn_type(picked)
+			if(M.density)
+				valid -= picked
+		if(!valid.len)
+			message_admins("Infestation event could not find enough viable turfs in [spawn_area_type] to spawn all vermin. [number - i] [vermstring] were unable to spawn!")
+			break
 
 /datum/event/infestation/announce()
 	var/warning = "Clear them out, before this starts to affect productivity."


### PR DESCRIPTION
```
[03:48:26] Runtime in infestation.dm,105: pick() from empty list
  proc name: start (/datum/event/infestation/start)
  src: /datum/event/infestation (/datum/event/infestation)
  call stack:
  /datum/event/infestation (/datum/event/infestation): start()
  /datum/event/infestation (/datum/event/infestation): process()
  Event (/datum/subsystem/event): fire(0)
  Event (/datum/subsystem/event): ignite(0)
  Master (/datum/controller/master): RunQueue()
  Master (/datum/controller/master): Loop()
  Master (/datum/controller/master): StartProcessing()
```

This fixes that, messages admins when it happens and cancels the announce message. Also makes it not have to needlessly loop through every turf in the area for every mob that spawns.