### PR TITLE
Runtime Hunting: Action Buttons ACT 4 - The viewport Freezing

### DIFF
--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -54,6 +54,7 @@ var/global/obj/abstract/screen/clicker/catcher = new()
 	move_intent = null
 	adding = null
 	other = null
+	qdel(hide_actions_toggle)
 	hide_actions_toggle = null
 	hotkeybuttons = null
 	mymob = null

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -54,7 +54,6 @@ var/global/obj/abstract/screen/clicker/catcher = new()
 	move_intent = null
 	adding = null
 	other = null
-	qdel(hide_actions_toggle)
 	hide_actions_toggle = null
 	hotkeybuttons = null
 	mymob = null

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -31,29 +31,34 @@
 	return ..()
 
 /datum/action/proc/Grant(mob/M)
-	if(owner)
-		if(owner == M)
-			return
+	if(M)
+		if(owner)
+			if(owner == M)
+				return
+			Remove(owner)
+		owner = M
+		M.actions += src
+		if(!button)
+			button = new
+		button.name = name
+		button.linked_action = src
+		button.actiontooltipstyle = buttontooltipstyle
+		if(desc)
+			button.desc = desc
+		if(M.client)
+			M.client.screen += button
+		M.update_action_buttons()
+	else
 		Remove(owner)
-	owner = M
-	M.actions += src
-	button = new
-	button.linked_action = src
-	button.name = name
-	button.actiontooltipstyle = buttontooltipstyle
-	if(desc)
-		button.desc = desc
-	if(M.client)
-		M.client.screen += button
-	M.update_action_buttons()
 
 /datum/action/proc/Remove(mob/M)
-	if(M.client)
-		M.client.screen -= button
-	button.moved = FALSE //so the button appears in its normal position when given to another owner.
-	M.actions -= src
-	M.update_action_buttons()
+	if(M)
+		if(M.client)
+			M.client.screen -= button
+		M.actions -= src
+		M.update_action_buttons()
 	owner = null
+	button.moved = FALSE //so the button appears in its normal position when given to another owner.
 
 /datum/action/proc/Trigger()
 	if(!IsAvailable())
@@ -84,7 +89,7 @@
 	if(button)
 		button.icon = button_icon
 		button.icon_state = background_icon_state
-
+ 
 		ApplyIcon(button)
 
 		if(!IsAvailable())

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -326,8 +326,6 @@
 			var/mob/living/carbon/C = M
 			C.stomach_contents.Add(to_drop)
 
-	to_drop.dropped(src)
-
 	if(to_drop && to_drop.loc)
 		return 1
 	return 0


### PR DESCRIPTION
Alright this fixes the action.dm 53 runtimes caused by Remove() being called twice when quick-equipping or dropping items with action buttons as well tries to fix the viewport freeze. Test Server here we go.

DO NOT MERGE THIS YET IT CREATES MUSTARD GAS