### PR TITLE
Cup Ramen self heating again

### DIFF
--- a/__DEFINES/reagents.dm
+++ b/__DEFINES/reagents.dm
@@ -333,6 +333,8 @@
 #define ALBUTEROL		"albuterol"
 #define LIQUIDBUTTER	"liquidbutter"
 #define SALTWATER		"saltwater"
+#define CALCIUMOXIDE		"calciumoxide"
+#define CALCIUMHYDROXIDE	"calciumhydroxide"
 
 #define TUNGSTEN 			"tungsten"
 #define LITHIUMSODIUMTUNGSTATE 			"lithiumsodiumtungstate"

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1367,7 +1367,7 @@ var/global/num_vending_terminals = 1
 	icon_state = "snack"
 	products = list(
 		/obj/item/weapon/reagent_containers/food/snacks/candy = 6,
-		/obj/item/weapon/reagent_containers/food/drinks/dry_ramen = 6,
+		/obj/item/weapon/reagent_containers/food/drinks/dry_ramen/heating = 6,
 		/obj/item/weapon/reagent_containers/food/snacks/chips =6,
 		/obj/item/weapon/reagent_containers/food/snacks/sosjerky = 6,
 		/obj/item/weapon/reagent_containers/food/snacks/no_raisin = 6,
@@ -1384,7 +1384,7 @@ var/global/num_vending_terminals = 1
 		)
 	prices = list(
 		/obj/item/weapon/reagent_containers/food/snacks/candy = 13,
-		/obj/item/weapon/reagent_containers/food/drinks/dry_ramen = 15,
+		/obj/item/weapon/reagent_containers/food/drinks/dry_ramen/heating = 15,
 		/obj/item/weapon/reagent_containers/food/snacks/chips = 30,
 		/obj/item/weapon/reagent_containers/food/snacks/sosjerky = 40,
 		/obj/item/weapon/reagent_containers/food/snacks/no_raisin = 60,

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -3997,7 +3997,7 @@
 /datum/reagent/dry_ramen
 	name = "Dry Ramen"
 	id = DRY_RAMEN
-	description = "Space age food, since August 25, 1958. Contains dried noodles, vegetables, and chemicals that boil in contact with water."
+	description = "Space age food, since August 25, 1958. Contains dried noodles and vegetables, best cooked in boiling water."
 	reagent_state = SOLID
 	nutriment_factor = REAGENTS_METABOLISM
 	color = "#302000" //rgb: 48, 32, 0
@@ -6490,3 +6490,19 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 	alpha = 64
 	density = 0.622
 	specheatcap = 99.27
+
+/datum/reagent/calciumoxide
+	name = "Calcium Oxide"
+	id = CALCIUMOXIDE
+	description = "Quicklime. Reacts strongly with water forming calcium hydrate and generating heat in the process"
+	color = "#FFFFFF"
+	density = 3.34
+	specheatcap = 42.09
+
+/datum/reagent/calciumhydroxide
+	name = "Calcium Hydroxide"
+	id = CALCIUMHYDROXIDE
+	description = "Hydrated lime, non-toxic."
+	color = "#FFFFFF"
+	density = 2.211
+	specheatcap = 87.45

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -6499,6 +6499,19 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 	density = 3.34
 	specheatcap = 42.09
 
+/datum/reagent/calciumoxide/on_mob_life(var/mob/living/M)
+
+	if(..())
+		return 1
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if((H.species && H.species.flags & NO_BREATHE) || M_NO_BREATH in H.mutations)
+			return
+		for(var/datum/organ/internal/lungs/L in H.internal_organs)
+			L.take_damage(0.5 * REM, 1)
+		if(prob(10))
+			M.visible_message("<span class='warning'>[M] [pick("dry heaves!", "coughs!", "splutters!")]</span>")
+
 /datum/reagent/calciumhydroxide
 	name = "Calcium Hydroxide"
 	id = CALCIUMHYDROXIDE

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -6507,8 +6507,7 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 		var/mob/living/carbon/human/H = M
 		if((H.species && H.species.flags & NO_BREATHE) || M_NO_BREATH in H.mutations)
 			return
-		for(var/datum/organ/internal/lungs/L in H.internal_organs)
-			L.take_damage(0.5 * REM, 1)
+		M.adjustFireLoss(0.5 * REM)
 		if(prob(10))
 			M.visible_message("<span class='warning'>[M] [pick("dry heaves!", "coughs!", "splutters!")]</span>")
 

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -2201,7 +2201,7 @@
 /datum/chemical_reaction/cheesewheel/on_reaction(var/datum/reagents/holder, var/created_volume)
 	var/location = get_turf(holder.my_atom)
 	new /obj/item/weapon/reagent_containers/food/snacks/sliceable/cheesewheel(location)
-	
+
 /datum/chemical_reaction/butter
 	name = "Butter"
 	id = "butter"
@@ -3079,6 +3079,15 @@
 	result = SALINE
 	required_reagents = list(SALTWATER = 10, AMMONIA = 1)
 	result_amount = 10
+
+/datum/chemical_reaction/calciumhydroxide
+	name = "Calcium Hydroxide"
+	id = CALCIUMHYDROXIDE
+	result = CALCIUMHYDROXIDE
+	required_reagents = list(WATER = 1, CALCIUMOXIDE = 1)
+	result_amount = 1
+	reaction_temp_change = 47
+
 
 #undef ALERT_AMOUNT_ONLY
 #undef ALERT_ALL_REAGENTS

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -3087,6 +3087,7 @@
 	required_reagents = list(WATER = 1, CALCIUMOXIDE = 1)
 	result_amount = 1
 	reaction_temp_change = 47
+	react_discretely = TRUE
 
 
 #undef ALERT_AMOUNT_ONLY

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -359,12 +359,12 @@
 
 /obj/item/weapon/reagent_containers/food/drinks/dry_ramen
 	name = "Cup Ramen"
-	desc = "Just add 10ml water, self heats! A taste that reminds you of your school years."
+	desc = "Just add 12ml water, self heats! A taste that reminds you of your school years."
 	icon_state = "ramen"
 /obj/item/weapon/reagent_containers/food/drinks/dry_ramen/New()
 	..()
 	reagents.add_reagent(DRY_RAMEN, 30)
-	reagents.add_reagent(CALCIUMOXIDE, 3)
+	reagents.add_reagent(CALCIUMOXIDE, 2)
 	src.pixel_x = rand(-10, 10) * PIXEL_MULTIPLIER
 	src.pixel_y = rand(-10, 10) * PIXEL_MULTIPLIER
 

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -364,6 +364,7 @@
 /obj/item/weapon/reagent_containers/food/drinks/dry_ramen/New()
 	..()
 	reagents.add_reagent(DRY_RAMEN, 30)
+	reagents.add_reagent(CALCIUMOXIDE, 3)
 	src.pixel_x = rand(-10, 10) * PIXEL_MULTIPLIER
 	src.pixel_y = rand(-10, 10) * PIXEL_MULTIPLIER
 

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -359,11 +359,20 @@
 
 /obj/item/weapon/reagent_containers/food/drinks/dry_ramen
 	name = "Cup Ramen"
-	desc = "Just add 12ml water, self heats! A taste that reminds you of your school years."
+	desc = "A taste that reminds you of your school years."
 	icon_state = "ramen"
 /obj/item/weapon/reagent_containers/food/drinks/dry_ramen/New()
 	..()
 	reagents.add_reagent(DRY_RAMEN, 30)
+	src.pixel_x = rand(-10, 10) * PIXEL_MULTIPLIER
+	src.pixel_y = rand(-10, 10) * PIXEL_MULTIPLIER
+
+/obj/item/weapon/reagent_containers/food/drinks/dry_ramen/heating //vendor version
+	name = "Cup Ramen"
+	desc = "Just add 12ml water, self heats!"
+	icon_state = "ramen"
+/obj/item/weapon/reagent_containers/food/drinks/dry_ramen/heating/New()
+	..()
 	reagents.add_reagent(CALCIUMOXIDE, 2)
 	src.pixel_x = rand(-10, 10) * PIXEL_MULTIPLIER
 	src.pixel_y = rand(-10, 10) * PIXEL_MULTIPLIER


### PR DESCRIPTION
<!--
Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.
When working with in body changelogs, the syntax is as follows:
:cl:
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
This PR adds calcium oxide as a reagent. Calcium oxide becomes calcium hydroxide in contact with water, and gets very hot. Two or three units are enough to boil water.
This also adds this construction material to cup ramen as a way to use it and a way to obtain it.
All the properties of the reagents were taken from various sources so if anyone is feeling picky about numbers it can be changed

Not included: any use for calcium hydroxide, ill effects to eating either, wiki update, calcium.
Ramen now needs a weird amount of water to fully boil and I don't know a good solution to that.

Fixes #16788

----
:cl:
* tweak: Cup ramen is self-heating again
* rscadd: Added quicklime as a heating chemical for your reagent temperature needs