### PR TITLE
Adds functionality to the two previously useless autolathe/protolathe wires

### DIFF
--- a/code/datums/wires/rnd_wires.dm
+++ b/code/datums/wires/rnd_wires.dm
@@ -6,13 +6,15 @@
 	wire_names=list(
 		"[RND_WIRE_DISABLE]"	= "Disable",
 		"[RND_WIRE_SHOCK]" 		= "Shock",
-		"[RND_WIRE_HACK]" 		= "Hack"
+		"[RND_WIRE_HACK]" 		= "Hack",
+		"[RND_WIRE_AUTOMAKE]"	= "Automake"
 	)
 	..()
 
 var/const/RND_WIRE_DISABLE = 1
 var/const/RND_WIRE_SHOCK = 2
 var/const/RND_WIRE_HACK = 4
+var/const/RND_WIRE_AUTOMAKE = 8
 
 /datum/wires/rnd/CanUse(var/mob/living/L)
 	if(!..())
@@ -28,6 +30,7 @@ var/const/RND_WIRE_HACK = 4
 	. += "The red light is [rnd.disabled ? "off" : "on"].<BR>"
 	. += "The green light is [rnd.shocked ? "off" : "on"].<BR>"
 	. += "The blue light is [rnd.hacked ? "off" : "on"].<BR>"
+	. += "The yellow light is [rnd.auto_make ? "on": "off"].<BR>"
 
 /datum/wires/rnd/UpdatePulsed(var/index)
 	var/obj/machinery/r_n_d/rnd = holder
@@ -39,6 +42,8 @@ var/const/RND_WIRE_HACK = 4
 		if(RND_WIRE_HACK)
 			rnd.hacked = !rnd.hacked
 			rnd.update_hacked()
+		if(RND_WIRE_AUTOMAKE)
+			rnd.auto_make = !rnd.auto_make
 
 /datum/wires/rnd/UpdateCut(var/index, var/mended)
 	var/obj/machinery/r_n_d/rnd = holder
@@ -50,3 +55,5 @@ var/const/RND_WIRE_HACK = 4
 		if(RND_WIRE_HACK)
 			rnd.hacked = 0
 			rnd.update_hacked()
+		if(RND_WIRE_AUTOMAKE)
+			rnd.auto_make = 0

--- a/code/datums/wires/rnd_wires.dm
+++ b/code/datums/wires/rnd_wires.dm
@@ -7,7 +7,8 @@
 		"[RND_WIRE_DISABLE]"	= "Disable",
 		"[RND_WIRE_SHOCK]" 		= "Shock",
 		"[RND_WIRE_HACK]" 		= "Hack",
-		"[RND_WIRE_AUTOMAKE]"	= "Automake"
+		"[RND_WIRE_AUTOMAKE]"	= "Automake",
+		"[RND_WIRE_JOBFINISHED]"= "Job finished"
 	)
 	..()
 
@@ -15,6 +16,7 @@ var/const/RND_WIRE_DISABLE = 1
 var/const/RND_WIRE_SHOCK = 2
 var/const/RND_WIRE_HACK = 4
 var/const/RND_WIRE_AUTOMAKE = 8
+var/const/RND_WIRE_JOBFINISHED = 16
 
 /datum/wires/rnd/CanUse(var/mob/living/L)
 	if(!..())

--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -224,6 +224,12 @@ var/const/POWER = 8
 	else
 		CRASH("[colour] is not a key in wires.")
 
+/datum/wires/proc/GetColour(var/index)
+	for(var/i in wires)
+		if(wires[i] == index)
+			return i
+	CRASH("[index] is not in wires.")
+
 //
 // Is Index/Colour Cut procs
 //
@@ -273,6 +279,13 @@ var/const/POWER = 8
 			PulseColour(colour)
 			holder.investigation_log(I_WIRES, "|| [GetWireName(wires[colour]) || colour] wire pulsed by \a [S] \ref[S] ([src.type])")
 			break
+
+/datum/wires/proc/SignalIndex(var/index)
+	if(IsIndexCut(index))
+		return
+	var/obj/item/device/assembly/signaler/S = GetAttached(GetColour(index))
+	if(S)
+		S.activate()
 
 
 //

--- a/code/modules/research/fabricators.dm
+++ b/code/modules/research/fabricators.dm
@@ -29,7 +29,7 @@
 	var/screen = 0
 	var/temp
 	var/list/part_sets = list()
-
+	var/datum/design/last_made
 	var/start_end_anims = 0
 
 	machine_flags	= SCREWTOGGLE | CROWDESTROY | WRENCHMOVE | FIXED2WORK | EMAGGABLE
@@ -156,8 +156,14 @@
 
 /obj/machinery/r_n_d/fabricator/process()
 	..()
-	if(busy || stopped || being_built)
+	if(busy || being_built)
 		return
+	if(stopped)
+		if(auto_make && !queue.len)
+			add_to_queue(last_made)
+			start_processing_queue()
+		else
+			return
 	if(queue.len==0)
 		stopped=1
 		return
@@ -294,6 +300,7 @@
 		being_built.forceMove(get_turf(output))
 		src.visible_message("[bicon(src)] \The [src] beeps: \"Successfully completed \the [being_built.name].\"")
 		src.being_built = null
+		last_made = part
 	src.updateUsrDialog()
 	src.busy = 0
 	return 1

--- a/code/modules/research/fabricators.dm
+++ b/code/modules/research/fabricators.dm
@@ -159,7 +159,7 @@
 	if(busy || being_built)
 		return
 	if(stopped)
-		if(auto_make && !queue.len)
+		if(auto_make && last_made && !queue.len)
 			add_to_queue(last_made)
 			start_processing_queue()
 		else
@@ -301,6 +301,7 @@
 		src.visible_message("[bicon(src)] \The [src] beeps: \"Successfully completed \the [being_built.name].\"")
 		src.being_built = null
 		last_made = part
+		wires.SignalIndex(RND_WIRE_JOBFINISHED)
 	src.updateUsrDialog()
 	src.busy = 0
 	return 1

--- a/code/modules/research/rdmachines.dm
+++ b/code/modules/research/rdmachines.dm
@@ -18,6 +18,7 @@ var/global/list/rnd_machines = list()
 	var/stopped		= 0
 	var/base_state	= ""
 	var/build_time	= 0
+	var/auto_make = 0
 
 	machine_flags	= SCREWTOGGLE | CROWDESTROY | WRENCHMOVE | FIXED2WORK
 


### PR DESCRIPTION
Found some PoC sprites for inserters, so why not take us down the road to factorio town?

When hacking an RnD machine, there were two useless wires. Now there is  none, as the one is now used to toggle the automatic production function on said RnD machines, while the other is used for signaling purposes.

Don't fancy pressing the make 10 of pico manipulators button 6 times to get 60 pico manipulators? Just press it once, and leave the machine to make them for you.

Fun if combined with conveyors to move the final product, and the output of others, to the same conveyor to one spot.

:cl:
* rscadd: Adds functionality to the previously useless wires on the rnd machines, one if you pulse it, it keep creating the last thing it was told to make. The other if you attach a signaler to it, it will pulse a signal through that signaler.