### PR TITLE
Firelock frame manipulation (construction/deconstruction)

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -240,11 +240,10 @@ var/global/list/alert_overlays_global = list()
 		force_open(user, C)
 		return
 
-	if(istype(C, /obj/item/weapon/wrench/socket))
+	if(istype(C, /obj/item/weapon/wrench))
 		if(blocked)
 			user.visible_message("<span class='attack'>\The [user] starts to deconstruct \the [src] with \a [C].</span>",\
-			"You begin to deconstruct \the [src] with \the [C].",\
-			"You hear a racket from a ratchet.")
+			"You begin to deconstruct \the [src] with \the [C].")
 			if(do_after(user, src, 5 SECONDS))
 				new/obj/item/firedoor_frame(get_turf(src))
 				qdel(src)
@@ -540,6 +539,25 @@ var/global/list/alert_overlays_global = list()
 	if(!user.IsAdvancedToolUser())
 		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
 		return 0
+
+	if(!user.is_holding_item(src))
+		return 1
+	var/current_turf = get_turf(src)
+	var/turf_face = get_step(current_turf,user.dir)
+	if(SSair.air_blocked(current_turf, turf_face))
+		to_chat(user, "<span class = 'warning'>That way is blocked already.</span>")
+		return 1
+	var/obj/machinery/door/firedoor/border_only/F = locate(/obj/machinery/door/firedoor) in get_turf(user)
+	if(F && F.dir == user.dir)
+		to_chat(user, "<span class = 'warning'>There is already a firedoor facing that direction.</span>")
+		return 1
+	if(do_after(user, src, 5 SECONDS))
+		var/obj/machinery/door/firedoor/border_only/B = new(get_turf(src))
+		B.change_dir(user.dir)
+		qdel(src)
+
+//Removed pending a fix for atmos issues caused by full tile firelocks.
+/*
 	switch(alert("firedoor construction", "Would you like to construct a full tile firedoor or one direction?", "One Direction", "Full Firedoor", "Cancel", null))
 		if("One Direction")
 			if(!user.is_holding_item(src))
@@ -566,3 +584,4 @@ var/global/list/alert_overlays_global = list()
 			if(do_after(user, src, 5 SECONDS))
 				new /obj/machinery/door/firedoor(get_turf(src))
 				qdel(src)
+*/

--- a/code/game/objects/items/stacks/stack_recipes.dm
+++ b/code/game/objects/items/stacks/stack_recipes.dm
@@ -76,6 +76,7 @@ var/list/datum/stack_recipe/metal_recipes = list (
 	null,
 	new/datum/stack_recipe("computer frame", /obj/structure/computerframe,                      5, time = 25, one_per_turf = 1			    ),
 	new/datum/stack_recipe("wall girders",   /obj/structure/girder,                             2, time = 50, one_per_turf = 1, on_floor = 1),
+	new/datum/stack_recipe("firelock frame", /obj/item/firedoor_frame,                          5, time = 50),
 	new/datum/stack_recipe("machine frame",  /obj/machinery/constructable_frame/machine_frame,  5, time = 25, one_per_turf = 1, on_floor = 1),
 	new/datum/stack_recipe("mirror frame",   /obj/structure/mirror_frame,                       5, time = 25, one_per_turf = 1, on_floor = 1),
 	new/datum/stack_recipe("turret frame",   /obj/machinery/porta_turret_construct,             5, time = 25, one_per_turf = 1, on_floor = 1),


### PR DESCRIPTION
Summary:
Increases the player's ability to interact with firelocks.

Features:
- Deconstruction via welding then wrenching (as opposed to the much less available socket wrench)
- Construction of frames via stack recipe (5 metal, 5 seconds)

Testing:
- [x] Construction from metal
- [x] Deconstruction using welder wrench
- [x] Expected behavior when using fire alarms

If you have any thoughts on balance, or the change from socket wrench to wrench for deconstruction, let me know.

:cl:
 * rscadd: Firelock frame construction. Use 5 metal in hand.
 * tweak: Firelock deconstruction, weld and wrench rather than socketwrench.
