### PR TITLE
Library computer and Bible tweaks

### DIFF
--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -17,7 +17,8 @@ var/datum/controller/gameticker/ticker
 	var/Bible_icon_state	// icon_state the OFFICIAL chaplain has chosen for his bible
 	var/Bible_item_state	// item_state the OFFICIAL chaplain has chosen for his bible
 	var/Bible_name			// name of the bible
-	var/Bible_deity_name = "Space Jesus"
+	var/Bible_deity_name = "Space Jesus" 	// Default deity
+	var/datum/religion/chap_rel 			// Official religion of chappy
 	var/list/datum/religion/religions = list() // Religion(s) in the game
 
 	var/random_players = 0 	// if set to nonzero, ALL players who latejoin or declare-ready join will have random appearances/genders

--- a/code/game/jobs/job/civilian_chaplain.dm
+++ b/code/game/jobs/job/civilian_chaplain.dm
@@ -222,7 +222,8 @@
 			ticker.Bible_icon_state = B.icon_state
 			ticker.Bible_item_state = B.item_state
 			ticker.Bible_name = B.name
-			ticker.Bible_deity_name = B.my_rel.deity_name
+			ticker.Bible_deity_name = chap_religion.deity_name
+			ticker.chap_rel = chap_religion
 			ticker.religions += chap_religion
 		feedback_set_details("religion_deity","[new_deity]")
 		feedback_set_details("religion_book","[new_book_style]")

--- a/code/modules/library/computers/checkout.dm
+++ b/code/modules/library/computers/checkout.dm
@@ -315,14 +315,29 @@
 			if("6")
 				if(!bibledelay)
 
-					var/obj/item/weapon/storage/bible/B = new /obj/item/weapon/storage/bible(src.loc)
-					if(ticker && ( ticker.Bible_icon_state && ticker.Bible_item_state) )
+					bibledelay = 1
+
+					var/obj/item/weapon/storage/bible/B = new
+					B = new(src.loc)
+					if (usr.mind && usr.mind.faith) // The user has a faith
+						var/datum/religion/R = usr.mind.faith
+						var/obj/item/weapon/storage/bible/HB = R.holy_book
+						if (!HB)
+							B = chooseBible(R, usr)
+						else
+							B.icon_state = HB.icon_state
+							B.item_state = HB.item_state
+						B.name = R.bible_name
+						B.my_rel = R
+
+					else if (ticker && (ticker.Bible_icon_state && ticker.Bible_item_state)) // No faith
 						B.icon_state = ticker.Bible_icon_state
 						B.item_state = ticker.Bible_item_state
 						B.name = ticker.Bible_name
-						B.my_rel.deity_name = ticker.Bible_deity_name
+						B.my_rel = ticker.chap_rel
 
-					bibledelay = 1
+					B.forceMove(src.loc)
+
 					spawn(60)
 						bibledelay = 0
 


### PR DESCRIPTION
Closes #17703 

Unable to reproduce the part about dying and losing your religion 
https://www.youtube.com/watch?v=xwtdhWltSIg

:cl:
- bugfix: Custom religions can print their Bible at the library checkout computer, including the Chaplain's.