### PR TITLE
jar fixes

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -188,6 +188,9 @@
 			else
 				to_chat(user, "You cannot recycle your built in tools.")
 				return 1
+		else if(!I.recyclable())
+			to_chat(user, "<span class = 'notice'>You can not recycle /the [I] at this time.</span>")
+			return 1
 
 		if(user.drop_item(I, src))
 			materials.removeFrom(I.materials)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1228,3 +1228,6 @@ var/global/list/image/blood_overlays = list()
 //Called when user clicks on an object while looking through a camera (passed to the proc as [eye])
 /obj/item/proc/remote_attack(atom/target, mob/user, atom/movable/eye)
 	return
+
+/obj/item/proc/recyclable() //Called by RnD machines, for added object-specific sanity.
+	return TRUE

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -504,9 +504,9 @@
 		if(ismob(O.loc))
 			var/mob/M = O.loc
 			M.regenerate_icons()
-
-	var/turf/T = get_turf(O)
-	self.reaction_turf(T, volume)
+	if(isturf(O.loc))
+		var/turf/T = get_turf(O)
+		self.reaction_turf(T, volume)
 
 	if(istype(O, /obj/item/weapon/reagent_containers/food/snacks/monkeycube))
 		var/obj/item/weapon/reagent_containers/food/snacks/monkeycube/cube = O
@@ -1911,9 +1911,9 @@
 	var/datum/reagent/self = src
 	if(..())
 		return 1
-
-	var/turf/T = get_turf(O)
-	self.reaction_turf(T, volume)
+	if(isturf(O.loc))
+		var/turf/T = get_turf(O)
+		self.reaction_turf(T, volume)
 
 
 /datum/reagent/fuel/reaction_turf(var/turf/simulated/T, var/volume)

--- a/code/modules/reagents/reagent_containers/glass/jar.dm
+++ b/code/modules/reagents/reagent_containers/glass/jar.dm
@@ -7,7 +7,7 @@
 	possible_transfer_amounts = list(5,10,15,25,30)
 	flags = FPRINT  | OPENCONTAINER
 	volume = 250
-	starting_materials = list(MAT_GLASS = 1000)
+	starting_materials = list(MAT_GLASS = CC_PER_SHEET_GLASS+250)
 	w_type = RECYK_GLASS
 	w_class = W_CLASS_MEDIUM
 	melt_temperature = MELTPOINT_GLASS
@@ -76,6 +76,10 @@
 		to_chat(user, "<span class = 'info'>It has \a [held_item] floating within.</span>")
 		to_chat(user, "<span class = 'info'><a HREF='?src=\ref[user];lookitem=\ref[held_item]'>Take a closer look.</a></span>")
 
+/obj/item/weapon/reagent_containers/glass/jar/recyclable()
+	if(held_item)
+		return FALSE
+	return TRUE
 
 /obj/item/weapon/reagent_containers/glass/jar/on_reagent_change()
 	update_icon()


### PR DESCRIPTION
splashing water and fuel on something doesn't magically splash the floor too, unless that thing happens to be on the floor.

autolathes now have an obj-level recyclable sanity check, in case you want some custom recycle sanity for your object.

it's now worth a little bit more than a shard of glass.

closes #17898 