### PR TITLE
NT Port can be closed to trade

### DIFF
--- a/code/datums/shuttle.dm
+++ b/code/datums/shuttle.dm
@@ -190,6 +190,20 @@
 
 	return D
 
+//The reverse
+/datum/shuttle/proc/remove_dock(var/D)
+	if(ispath(D))
+		for(var/obj/docking_port/destination/dock in all_docking_ports)
+			if(istype(dock,D))
+				dock.unlink_from_shuttle(src)
+				return dock
+	else if(istype(D,/obj/docking_port/destination))
+		var/obj/docking_port/destination/dock = D
+		dock.unlink_from_shuttle(src)
+		return dock
+
+	return D
+
 //Adds a docking port as a transit area, accepts path or the port itself
 /datum/shuttle/proc/set_transit_dock(var/D)
 	if(ispath(D))

--- a/code/game/shuttles/trade.dm
+++ b/code/game/shuttles/trade.dm
@@ -14,7 +14,9 @@ var/global/datum/shuttle/trade/trade_shuttle = new(starting_area = /area/shuttle
 	stable = 0 //Don't stun everyone and don't throw anything when moving
 	can_rotate = 0 //Sleepers, body scanners and multi-tile airlocks aren't rotated properly
 
-
+/datum/shuttle/trade/proc/notify_port_toggled(var/reason)
+	for(var/obj/machinery/computer/shuttle_control/trade/T in control_consoles)
+		T.notify_port_toggled(reason)
 
 /datum/shuttle/trade/initialize()
 	.=..()
@@ -32,6 +34,31 @@ var/global/datum/shuttle/trade/trade_shuttle = new(starting_area = /area/shuttle
 /obj/machinery/computer/shuttle_control/trade/New() //Main shuttle_control code is in code/game/machinery/computer/shuttle_computer.dm
 	link_to(trade_shuttle)
 	.=..()
+
+/obj/machinery/computer/shuttle_control/trade/proc/notify_port_toggled(var/reason)
+	if(!reason)
+		//Port opened
+		var/obj/item/weapon/paper/P = new(get_turf(src))
+		P.name = "NT Port Opened - [worldtime2text()]"
+		P.info = "This is official notification that sanctioned arrival of Vox trading vessels has resumed as normal."
+		P.update_icon()
+		playsound(get_turf(src), "sound/effects/fax.ogg", 50, 1)
+		var/image/stampoverlay = image('icons/obj/bureaucracy.dmi')
+		stampoverlay.icon_state = "paper_stamp-cent"
+		P.stamped += /obj/item/weapon/stamp
+		P.overlays += stampoverlay
+		P.stamps += "<HR><i>This paper has been stamped by the Central Command Quantum Relay.</i>"
+	if(reason)
+		var/obj/item/weapon/paper/P = new(get_turf(src))
+		P.name = "NT Port Closure - [worldtime2text()]"
+		P.info = "This is official notification that sanctioned arrival of Vox trading vessels has been indefinitely suspended with no guarantee of appeal. The provided justification was:<BR><BR>[reason]"
+		P.update_icon()
+		playsound(get_turf(src), "sound/effects/fax.ogg", 50, 1)
+		var/image/stampoverlay = image('icons/obj/bureaucracy.dmi')
+		stampoverlay.icon_state = "paper_stamp-cent"
+		P.stamped += /obj/item/weapon/stamp
+		P.overlays += stampoverlay
+		P.stamps += "<HR><i>This paper has been stamped by the Central Command Quantum Relay.</i>"
 
 //code/game/objects/structures/docking_port.dm
 

--- a/nano/templates/comm_console.tmpl
+++ b/nano/templates/comm_console.tmpl
@@ -64,6 +64,9 @@ Used In File(s): /code/game/machinery/computers/communications.dm
 			<div class="line">
 				{{:helper.link('Message List','comment',{'operation':'messagelist'})}}
 			</div>
+			<div class="line">
+				{{:helper.link('Toggle Port Status','key',{'operation':'SetPortRestriction'})}}
+			</div>
 			{{if data.str_security_level == "red" || data.str_security_level == "delta"}}
 				<div class="line">
 					{{:helper.link('Request Response Team','alert',{'operation':'emergency_screen'})}}


### PR DESCRIPTION
![untitled](https://user-images.githubusercontent.com/9782036/37879510-c3e5f4da-303f-11e8-9ef4-e307502460e8.png)

Traders have gotten a lot of buffs lately. I think it's only fair that NT get some tools to fight back against nuisance traders. With this change, traders will need to at least behave themselves well enough that they don't get the BEGONE THOT treatment. If the trade shuttle is docked at NT station when the port is closed, it is automatically sent to a random port on its docking list (usually the outpost but can be either port on metaclub).

I plan to do a followup PR to give IAAs a little leverage over traders as well.

🆑 
* rscadd: The communications computer can now be used to close off the station dock from traders, requiring an ID with HoS access or head access during a red alert. The same access is required to re-open the port.
* rscadd: Admins can now use the communications computer and all its features.