### PR TITLE
Fixes fleshshot interfering with monkey ventcrawling

### DIFF
--- a/code/_onclick/ventcrawl.dm
+++ b/code/_onclick/ventcrawl.dm
@@ -12,7 +12,7 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 
 // Vent crawling whitelisted items, whoo
 /mob/living
-	var/canEnterVentWith = "/obj/item/weapon/implant=0&/obj/item/clothing/mask/facehugger=0&/obj/item/device/radio/borg=0&/obj/machinery/camera=0&/mob/living/simple_animal/borer=0&/obj/transmog_body_container=0&/obj/item/verbs=0"
+	var/canEnterVentWith = "/obj/item/weapon/implant=0&/obj/item/clothing/mask/facehugger=0&/obj/item/device/radio/borg=0&/obj/machinery/camera=0&/mob/living/simple_animal/borer=0&/obj/transmog_body_container=0&/obj/item/verbs=0&/obj/item/weapon/gun/hookshot/flesh=0"
 
 /mob/living/AltClickOn(var/atom/A)
 	if(is_type_in_list(A,ventcrawl_machinery))


### PR DESCRIPTION
Closes #17932

Note that borers always have this fleshshot object in their contents, and it doesn't affect their own ventcrawling ability since their own ``ventcrawl_carry()`` always returns true.

:cl:
* bugfix: Having a borer as a monkey or nymph will no longer prevent you from ventcrawling.