### PR TITLE
Fixed grammer for soybeans in microwave (#16579)

### DIFF
--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -244,6 +244,17 @@
 				display_name = "Turnovers"
 				items_measures[display_name] = "turnover"
 				items_measures_p[display_name] = "turnovers"
+			if (istype(O,/obj/item/weapon/reagent_containers/food/snacks/grown/soybeans))
+				items_measures[display_name] = "soybean"
+				items_measures_p[display_name] = "soybeans"
+			if (istype(O,/obj/item/weapon/reagent_containers/food/snacks/grown/grapes))
+				display_name = "Grapes"
+				items_measures[display_name] = "bunch of grapes"
+				items_measures_p[display_name] = "bunches of grapes"
+			if (istype(O,/obj/item/weapon/reagent_containers/food/snacks/grown/greengrapes))
+				display_name = "Green Grapes"
+				items_measures[display_name] = "bunch of green grapes"
+				items_measures_p[display_name] = "bunches of green grapes"
 			items_counts[display_name]++
 		for (var/O in items_counts)
 			var/N = items_counts[O]


### PR DESCRIPTION
Fixes #16579 

where soybeans would display as 'soybeanss' when there were more than one in the microwave along with that I gave the treatment to the grapes and green grapes.

:cl:
- bugfix: Having more than one soybean in the microwave will display 'Soybeans' instead of 'Soybeans'
- bugfix: Having more than one grape or green grape will display bunches of grapes now