### PR TITLE
Remove flashbangs from the game.

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -207,7 +207,10 @@
 
 /proc/getAvailableRobotModules()
 	var/list/modules = list("Standard", "Engineering", "Medical", "Supply", "Janitor", "Service")
-	if (security_level == SEC_LEVEL_BLUE)
+	if (holiday == APRIL_FOOLS_DAY)
+		if (security_level == SEC_LEVEL_BLUE)
+			modules += "Security"
+	else
 		modules += "Security"
 	if (security_level == SEC_LEVEL_RED)
 		modules+="Combat"

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -207,7 +207,7 @@
 
 /proc/getAvailableRobotModules()
 	var/list/modules = list("Standard", "Engineering", "Medical", "Supply", "Janitor", "Service")
-	if (holiday == APRIL_FOOLS_DAY)
+	if (Holiday == APRIL_FOOLS_DAY)
 		if (security_level == SEC_LEVEL_BLUE)
 			modules += "Security"
 	else

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -206,8 +206,10 @@
 		sensor = null
 
 /proc/getAvailableRobotModules()
-	var/list/modules = list("Standard", "Engineering", "Medical", "Supply", "Janitor", "Service", "Security")
-	if(security_level == SEC_LEVEL_RED)
+	var/list/modules = list("Standard", "Engineering", "Medical", "Supply", "Janitor", "Service")
+	if (security_level == SEC_LEVEL_BLUE)
+		modules += "Security"
+	if (security_level == SEC_LEVEL_RED)
 		modules+="Combat"
 	return modules
 


### PR DESCRIPTION
Flashbangs are by far the worst and most overpowered object of the game,
offering a 10*10 stun of over 15 seconds to most foes, while being
abundant and virtually inoffensive against the security officers who use
it.

Most importantly, they stun cyborgs, who are by far in need of buffs in
the current ss13 meta.

This change aims to restore an attempt at balance in the ss13 ecosystem
by simply removing flashbangs from the game.

:cl:

- tweak: Flashbangs have been removed from the game.