### PR TITLE
Added a threshold to the dizziness effect.

### DIFF
--- a/code/modules/mob/living/carbon/human/life/handle_regular_status_updates.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_regular_status_updates.dm
@@ -127,7 +127,7 @@
 					while(dizziness)
 						C = client
 						dizzy_effect_in_loop = TRUE
-						if(C)
+						if(C && (dizziness >= 120))
 							//https://en.wikipedia.org/wiki/Rose_(mathematics) with 3 petals
 							for(var/i=30; i <= 390; i+=(360/100))
 								C = client


### PR DESCRIPTION
Some people have complained about the drunk/dizzy effect happening too early and it causes you to have unplayable screen shaking after one sip. This makes it so you have to be above a certain point of dizziness to have the screen shake effect.
A threshold might not be the best solution here so I'm open to what people think might be a better idea. Maybe at lower levels of dizziness the effect is less frequent?
:cl:
 * rscadd: Added a minor threshold to the dizziness/drunk effect so you don't experience a magnitude 10 earthquake when you only take one sip from a basic bar drink. 