### PR TITLE
red ribbon now properly checks which slot it should be giving a new arm if equipped to

### DIFF
--- a/code/game/objects/items/misc_items.dm
+++ b/code/game/objects/items/misc_items.dm
@@ -49,7 +49,7 @@
 
 /obj/item/red_ribbon_arm/equipped(mob/living/carbon/human/H, equipped_slot)
 	..()
-	if(istype(H) && H.get_item_by_slot(slot_belt) == src && equipped_slot != null)
+	if(istype(H) && H.get_item_by_slot(slot_belt) == src && equipped_slot != null && equipped_slot == slot_belt)
 		H.set_hand_amount(H.held_items.len + 1)
 
 /obj/item/red_ribbon_arm/unequipped(mob/living/carbon/human/user, var/from_slot = null)


### PR DESCRIPTION
Turns out it wasn't because it wasn't removing the arms, it was because it was just adding a new arm each time.

closes #17897