### PR TITLE
Extends Some Clown-Compatibility to Borgs

### DIFF
--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -122,3 +122,10 @@
 					step(M, M.dir)
 					M.visible_message("<span class='warning'>[M] slips on the icy floor!</span>", \
 					"<span class='warning'>You slip on the icy floor!</span>")
+
+	if(isrobot(AM) && wet == 1) //Only exactly water makes borgs glitch
+		var/mob/living/silicon/robot/R = AM
+		if(R.Slip(5,3))
+			//Don't step forward as a robot, we're not slipping just glitching.
+			R.visible_message("<span class='warning'>[R] short circuits on the water!</span>", \
+					"<span class='warning'>You short circuit on the water!</span>")

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -500,20 +500,21 @@
 /mob/living/carbon/CheckSlip()
 	return !locked_to && !lying && !unslippable
 
-/mob/living/carbon/proc/Slip(stun_amount, weaken_amount, slip_on_walking = 0)
+/mob/living/proc/Slip(stun_amount, weaken_amount, slip_on_walking = 0)
+	stop_pulling()
+	Stun(stun_amount)
+	Knockdown(weaken_amount)
+	return 1
+
+/mob/living/carbon/Slip(stun_amount, weaken_amount, slip_on_walking = 0)
 	if(!slip_on_walking && m_intent == "walk")
 		return 0
 
 	if (CheckSlip() < 1 || !on_foot())
 		return 0
-
-	stop_pulling()
-	Stun(stun_amount)
-	Knockdown(weaken_amount)
-
-	playsound(src, 'sound/misc/slip.ogg', 50, 1, -3)
-
-	return 1
+	if(..())
+		playsound(src, 'sound/misc/slip.ogg', 50, 1, -3)
+		return 1
 
 /mob/living/carbon/proc/transferImplantsTo(mob/living/carbon/newmob)
 	for(var/obj/item/weapon/implant/I in src)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -498,6 +498,13 @@
 	for(var/obj/item/stack/S in module.modules)
 		stat(null, text("[S.name]: [S.amount]/[S.max_amount]"))
 
+/mob/living/silicon/robot/Slip(stun_amount, weaken_amount, slip_on_walking = 0)
+	if(!(Holiday == APRIL_FOOLS_DAY))
+		return 0
+	if(..())
+		spark(src, 5, FALSE)
+		return 1
+
 // update the status screen display
 /mob/living/silicon/robot/Stat()
 	..()


### PR DESCRIPTION
Robots have a difficult life because they cannot properly appreciate the primary joy of clowns. This PR allows them to be clown compatible to a degree on April Fools.

🆑 
* rscadd: Silicons are now clown compatible.