### PR TITLE
actually limits borg names

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -303,7 +303,7 @@
 
 	var/newname
 	for(var/i = 1 to 3)
-		newname = trimcenter(trim(stripped_input(src,"You are a [braintype]. Enter a name, or leave blank for the default name.", "Name change [4-i] [0-i != 1 ? "tries":"try"] left",""),1,MAX_NAME_LEN))
+		newname = reject_bad_name(stripped_input(src,"You are a [braintype]. Enter a name, or leave blank for the default name.", "Name change [4-i] [0-i != 1 ? "tries":"try"] left",""),1,MAX_NAME_LEN)
 		if(newname == null)
 			if(alert(src,"Are you sure you want the default name?",,"Yes","No") == "Yes")
 				break


### PR DESCRIPTION
Previously you could have 'Validator 2: Validation Day: The Official Borg of the Movie - Validator 2: Validation Day: The Official Borg of the Movie' as a legitimate borg name.