### PR TITLE
Lets dextrous monkeys do more

### DIFF
--- a/__DEFINES/_macros.dm
+++ b/__DEFINES/_macros.dm
@@ -10,7 +10,7 @@
 
 #define ismartian(A) istype(A, /mob/living/carbon/martian)
 
-#define ishigherbeing(A) (ishuman(A) || ismartian(A))
+#define ishigherbeing(A) (ishuman(A) || ismartian(A) || (ismonkey(A) && A.dexterity_check()))
 
 #define isvox(A) (ishuman(A) && A.species && istype(A.species, /datum/species/vox))
 


### PR DESCRIPTION
This is mainly so medical monkeys on methylin can use the cloner without help, but there's other things they get too. (This doesn't apply to diona nymphs by the way.)

:cl:
* tweak: Monkeys on methylin or in monkey mode can now do more than they could before. This includes: drag-dropping people into medical machines, folding bodybags, being converted to religions, piloting spacepods and more.