### PR TITLE
dorf fort mommi spawner now doesn't spawn as wrench2move

### DIFF
--- a/code/game/machinery/mommi_spawner.dm
+++ b/code/game/machinery/mommi_spawner.dm
@@ -17,12 +17,10 @@
 	var/dorf = FALSE
 
 /obj/machinery/mommi_spawner/dorf
-	machine_flags = WRENCHMOVE
-	desc = "A large pad mounted to the ground with large bolts."
 	dorf = TRUE
 
 /obj/machinery/mommi_spawner/dorf/attack_ghost(var/mob/dead/observer/user)
-	if(stat & NOPOWER|BROKEN)
+	if(stat & (NOPOWER|BROKEN))
 		return
 	..()
 
@@ -176,7 +174,7 @@
 		if(use_mmi)
 			M.mmi = use_mmi
 			use_mmi.forceMove(M)
-		
+
 		if(!use_mmi)
 			M.key = user.key
 			qdel(user)

--- a/code/game/machinery/mommi_spawner.dm
+++ b/code/game/machinery/mommi_spawner.dm
@@ -19,11 +19,6 @@
 /obj/machinery/mommi_spawner/dorf
 	dorf = TRUE
 
-/obj/machinery/mommi_spawner/dorf/attack_ghost(var/mob/dead/observer/user)
-	if(stat & (NOPOWER|BROKEN))
-		return
-	..()
-
 /obj/machinery/mommi_spawner/power_change()
 	if (powered())
 		stat &= ~NOPOWER


### PR DESCRIPTION
Fixes #17805

now it is literally just a subtype with the dorf variable active.