### PR TITLE
UNATOMIC LANGUAGE TWEAKS/FIXES

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -13,7 +13,7 @@
 #define PROFILE_MACHINES // Disable when not debugging.
 
 #define ARBITRARILY_LARGE_NUMBER 10000 //Used in delays.dm and vehicle.dm. Upper limit on delays
-#define ARBITRARILY_PLANCK_NUMBER 1.417*(10**32) //1.417�10^32. Because ARBITRARILY_LARGE_NUMBER is too small and INF is too large
+#define ARBITRARILY_PLANCK_NUMBER 1.417*(10**32) //1.417×10^32. Because ARBITRARILY_LARGE_NUMBER is too small and INF is too large
 #define MAX_VALUE 65535
 
 #ifdef PROFILE_MACHINES

--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -13,7 +13,7 @@
 #define PROFILE_MACHINES // Disable when not debugging.
 
 #define ARBITRARILY_LARGE_NUMBER 10000 //Used in delays.dm and vehicle.dm. Upper limit on delays
-#define ARBITRARILY_PLANCK_NUMBER 1.417*(10**32) //1.417×10^32. Because ARBITRARILY_LARGE_NUMBER is too small and INF is too large
+#define ARBITRARILY_PLANCK_NUMBER 1.417*(10**32) //1.417ï¿½10^32. Because ARBITRARILY_LARGE_NUMBER is too small and INF is too large
 #define MAX_VALUE 65535
 
 #ifdef PROFILE_MACHINES
@@ -963,6 +963,7 @@ var/default_colour_matrix = list(1,0,0,0,\
 //Language flags.
 #define WHITELISTED 1  // Language is available if the speaker is whitelisted.
 #define RESTRICTED 2   // Language can only be accquired by spawning or an admin.
+#define CAN_BE_SECONDARY_LANGUAGE 4 // Language is available on character setup as secondary language.
 
 // Hairstyle flags
 #define HAIRSTYLE_CANTRIP 1 // 5% chance of tripping your stupid ass if you're running.

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1147,24 +1147,12 @@ NOTE:  The change will take effect AFTER any current recruiting periods."}
 									SetDepartmentFlags(job, i, F)
 
 				if("language")
-					var/languages_available
 					var/list/new_languages = list("None")
 
-					if(config.usealienwhitelist)
-						for(var/L in all_languages)
-							var/datum/language/lang = all_languages[L]
-							if((!(lang.flags & RESTRICTED)) && (is_alien_whitelisted(user, L)||(!( lang.flags & WHITELISTED ))))
-								new_languages += lang.name
-
-								languages_available = 1
-
-						if(!(languages_available))
-							alert(user, "There are not currently any available secondary languages.")
-					else
-						for(var/L in all_languages)
-							var/datum/language/lang = all_languages[L]
-							if(!(lang.flags & RESTRICTED))
-								new_languages += lang.name
+					for(var/L in all_languages)
+						var/datum/language/lang = all_languages[L]
+						if(lang.flags & CAN_BE_SECONDARY_LANGUAGE)
+							new_languages += lang.name
 
 					language = input("Please select a secondary language", "Character Generation", null) in new_languages
 

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -275,6 +275,7 @@
 	exclaim_verb = "blurbs"
 	key = "@"
 	colour = "grey"
+	flags = RESTRICTED
 	space_chance = 35
 	native = 1
 	syllables = list("khah","kig","kitol","kaor","bar","dar","dator","lok","ma","mu","o","och","gort","gal")

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -65,7 +65,6 @@
 	exclaim_verb = "roars"
 	colour = "soghun"
 	key = "o"
-	flags = RESTRICTED
 	syllables = list("ss","ss","ss","ss","skak","seeki","resh","las","esi","kor","sh")
 
 /datum/language/tajaran
@@ -76,7 +75,6 @@
 	exclaim_verb = "yowls"
 	colour = "tajaran"
 	key = "j"
-	flags = RESTRICTED
 	syllables = list("rr","rr","tajr","kir","raj","kii","mir","kra","ahk","nal","vah","khaz","jri","ran","darr", \
 	"mi","jri","dynh","manq","rhe","zar","rrhaz","kal","chur","eech","thaa","dra","jurl","mah","sanu","dra","ii'r", \
 	"ka","aasi","far","wa","baq","ara","qara","zir","sam","mak","hrar","nja","rir","khan","jun","dar","rik","kah", \
@@ -90,7 +88,6 @@
 	exclaim_verb = "warbles"
 	colour = "skrell"
 	key = "k"
-	flags = RESTRICTED
 	syllables = list("qr","qrr","xuq","qil","quum","xuqm","vol","xrim","zaoo","qu-uu","qix","qoo","zix","*","!")
 
 /datum/language/vox
@@ -101,7 +98,6 @@
 	exclaim_verb = "shrieks"
 	colour = "vox"
 	key = "v"
-	flags = RESTRICTED
 	syllables = list("ti","ti","ti","hi","hi","ki","ki","ki","ki","ya","ta","ha","ka","ya","chi","cha","kah", \
 	"SKRE","AHK","EHK","RAWK","KRA","AAA","EEE","KI","II","KRI","KA")
 
@@ -113,7 +109,6 @@
 	exclaim_verb = "rustles"
 	colour = "soghun"
 	key = "q"
-	flags = RESTRICTED
 	syllables = list("hs","zt","kr","st","sh")
 
 /datum/language/common
@@ -130,7 +125,6 @@
 	desc = "A bastardized hybrid of informal English and elements of Mandarin Chinese; the common language of the Sol system."
 	key = "7"
 	colour = "solcom"
-	flags = RESTRICTED
 
 /datum/language/human/monkey
 	name = LANGUAGE_MONKEY
@@ -149,6 +143,7 @@
 	colour = "say_quote"
 	key = "2"
 	space_chance = 100
+	flags = CAN_BE_SECONDARY_LANGUAGE
 	syllables = list("lorem", "ipsum", "dolor", "sit", "amet", "consectetur", "adipiscing", "elit",
 					 "sed", "do", "eiusmod", "tempor", "incididunt", "ut", "labore", "et", "dolore",
 					 "magna", "aliqua", "ut", "enim", "ad", "minim", "veniam", "quis", "nostrud",
@@ -164,6 +159,7 @@
 	speech_verb = "growls"
 	colour = "gutter"
 	key = "3"
+	flags = CAN_BE_SECONDARY_LANGUAGE
 	syllables = list("gra","ba","ba","breh","bra","rah","dur","ra","ro","gro","go","ber","bar","geh","heh","gra")
 
 /datum/language/grey
@@ -175,7 +171,6 @@
 	exclaim_verb = "quacks loudly"
 	colour = "grey"
 	native=1
-	flags = RESTRICTED
 	space_chance = 100
 	syllables = list("ACK", "AKACK", "ACK")
 
@@ -196,7 +191,6 @@
 	exclaim_verb = "chatters loudly"
 	colour = "sinister"
 	native=1
-	flags = RESTRICTED
 	space_chance = 95
 	syllables = list("CLICK", "CLACK")
 
@@ -210,7 +204,6 @@
 	colour = "golem"
 	native = 1
 	key = "8"
-	flags = RESTRICTED
 	syllables = list("oa","ur","ae","um","tu","gor","an","lo","ag","oon","po")
 
 /datum/language/slime
@@ -223,7 +216,6 @@
 	colour = "slime"
 	native = 1
 	key = "f"
-	flags = RESTRICTED
 	syllables = list("ba","ab","be","eb","bi","ib","bo","ob","bu","ub")
 
 /datum/language/skellington/say_misunderstood(mob/M, message)
@@ -274,7 +266,6 @@
 	key = "9"
 	space_chance = 80
 	syllables = list("squeak")
-	flags = RESTRICTED
 
 /datum/language/martian
 	name = LANGUAGE_MARTIAN
@@ -286,7 +277,6 @@
 	colour = "grey"
 	space_chance = 35
 	native = 1
-	flags = RESTRICTED
 	syllables = list("khah","kig","kitol","kaor","bar","dar","dator","lok","ma","mu","o","och","gort","gal")
 
 // Language handling.

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -76,23 +76,14 @@ var/list/ai_list = list()
 			if(A.real_name == pickedName && possibleNames.len > 1) //fixing the theoretically possible infinite loop
 				possibleNames -= pickedName
 				pickedName = null
-	add_language(LANGUAGE_GALACTIC_COMMON, TRUE)
-	add_language(LANGUAGE_UNATHI, TRUE)
-	add_language(LANGUAGE_CATBEAST, TRUE)
-	add_language(LANGUAGE_SKRELLIAN, TRUE)
-	add_language(LANGUAGE_ROOTSPEAK, TRUE)
-	add_language(LANGUAGE_GUTTER, TRUE)
-	add_language(LANGUAGE_CLATTER, TRUE)
-	add_language(LANGUAGE_GREY, TRUE)
-	add_language(LANGUAGE_MONKEY, TRUE)
-	add_language(LANGUAGE_VOX, TRUE)
-	add_language(LANGUAGE_GOLEM, TRUE)
-	add_language(LANGUAGE_TRADEBAND, TRUE)
-	add_language(LANGUAGE_MOUSE, TRUE)
-	add_language(LANGUAGE_GOLEM, TRUE)
-	add_language(LANGUAGE_SLIME, TRUE)
-	add_language(LANGUAGE_HUMAN, TRUE)
+
+	//AIs know all languages that aren't restricted(XENO, CULT).
+	for(var/language_name in all_languages)
+		var/datum/language/lang = all_languages[language_name]
+		if(!(lang.flags & RESTRICTED) && !(lang in languages))
+			add_language(lang.name)
 	default_language = all_languages[LANGUAGE_GALACTIC_COMMON]
+
 	real_name = pickedName
 	name = real_name
 	anchored = TRUE

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -146,13 +146,19 @@
 
 	playsound(get_turf(src), startup_sound, 75, 1)
 
+	//Borgs speak all common languages by default.
 	add_language(LANGUAGE_GALACTIC_COMMON)
+	add_language(LANGUAGE_HUMAN)
 	add_language(LANGUAGE_TRADEBAND)
-	default_language = all_languages[LANGUAGE_GALACTIC_COMMON]
+	add_language(LANGUAGE_GUTTER)
+
+	//But unlike AIs, they can only understand the rest.
 	for(var/L in all_languages)
 		var/datum/language/lang = all_languages[L]
-		if(~lang.flags & RESTRICTED && !(lang in languages))
-			add_language(lang, FALSE)
+		if(!(lang.flags & RESTRICTED) && !(lang in languages))
+			add_language(lang.name, can_speak = FALSE)
+
+	default_language = all_languages[LANGUAGE_GALACTIC_COMMON]
 
 // setup the PDA and its name
 /mob/living/silicon/robot/proc/setup_PDA()

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -23,10 +23,7 @@
 	var/module_holder = "nomod"
 
 	//Languages
-	var/list/languages = list(
-		LANGUAGE_GALACTIC_COMMON = TRUE,
-		LANGUAGE_TRADEBAND = TRUE,
-		)
+	var/list/languages = list()
 	var/list/added_languages //Bookkeeping
 
 	//Radio
@@ -166,13 +163,13 @@
 			modules += O
 
 /obj/item/weapon/robot_module/proc/add_languages(var/mob/living/silicon/robot/R)
-	for(var/language in languages)
-		if(R.add_language(language, languages[language]))
-			added_languages |= language
+	for(var/language_name in languages)
+		if(R.add_language(language_name))
+			added_languages |= language_name
 
 /obj/item/weapon/robot_module/proc/remove_languages(var/mob/living/silicon/robot/R)
-	for(var/language in added_languages)
-		R.remove_language(language)
+	for(var/language_name in added_languages)
+		R.remove_language(language_name, TRUE) //We remove the ability to speak but keep the ability to understand.
 	added_languages.Cut()
 
 //Modules
@@ -434,14 +431,14 @@
 		"R34 - SRV9a 'Llyod'" = "lloyd"
 		)
 	languages = list(
-		LANGUAGE_GALACTIC_COMMON = TRUE,
-		LANGUAGE_UNATHI	= TRUE,
-		LANGUAGE_CATBEAST = TRUE,
-		LANGUAGE_SKRELLIAN = TRUE,
-		LANGUAGE_ROOTSPEAK = TRUE,
-		LANGUAGE_TRADEBAND = TRUE,
-		LANGUAGE_GUTTER	= TRUE,
-		LANGUAGE_MONKEY	= TRUE,
+		LANGUAGE_UNATHI,
+		LANGUAGE_CATBEAST,
+		LANGUAGE_SKRELLIAN,
+		LANGUAGE_GREY,
+		LANGUAGE_CLATTER,
+		LANGUAGE_VOX,
+		LANGUAGE_GOLEM,
+		LANGUAGE_SLIME,
 		)
 	speed_modifier = CYBORG_SERVICE_SPEED_MODIFIER
 

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -269,17 +269,24 @@
 /mob/living/silicon/can_speak_lang(datum/language/speaking)
 	return universal_speak || (speaking in src.speech_synthesizer_langs)	//need speech synthesizer support to vocalize a language
 
-/mob/living/silicon/add_language(var/language, var/can_speak=1)
-	if (..(language) && can_speak)
-		speech_synthesizer_langs |= (all_languages[language])
+/mob/living/silicon/add_language(var/language_name, var/can_speak=1)
+	var/var/datum/language/added_language = all_languages[language_name]
+	if(!added_language) //Are you trying to pull my leg? This language does not exist.
+		return
+
+	. = ..(language_name)
+	if(can_speak && (added_language in languages) && !(added_language in speech_synthesizer_langs)) //This got changed because we couldn't give borgs the ability to speak a language that they already understood. Bay's solution.
+		speech_synthesizer_langs |= added_language
 		return 1
 
-/mob/living/silicon/remove_language(var/rem_language)
-	..(rem_language)
+/mob/living/silicon/remove_language(var/rem_language, var/can_understand=0)
+	var/var/datum/language/removed_language = all_languages[rem_language]
+	if(!removed_language) //Oh, look. Now you're trying to remove what does not exist.
+		return
 
-	for (var/datum/language/L in speech_synthesizer_langs)
-		if (L.name == rem_language)
-			speech_synthesizer_langs -= L
+	if(!can_understand)
+		..(rem_language)
+	speech_synthesizer_langs -= removed_language
 
 /mob/living/silicon/check_languages()
 	set name = "Check Known Languages"


### PR DESCRIPTION
Fixes #8331

![librarianfix](https://user-images.githubusercontent.com/17928298/38389316-6c8945c6-38f4-11e8-89a6-98443c066e4a.png)
![siliconfix](https://user-images.githubusercontent.com/17928298/38389317-6cb3517c-38f4-11e8-8a80-4b1b2c136918.png)

Removed the RESTRICTED flag from most languages and made borgs/AIs get all non-restricted languages instead of the hardcode that we had before. removing the RESTRICTED flag fixed both babel syndrome and librarian's random roundstart language too. 

Also fixed cyborg modules being unable to make cyborgs able to speak a language that they could understand and fixed modules removing borgs ability to understand a language when getting a reset from service.

:cl:
 * bugfix: Fixes cyborgs not understanding most languages and not being able to speak sol common/gutter by default.
 * tweak: Service cyborgs now speak more languages(Slime, Vox, Golem, Grey and Clatter)
 * bugfix: Fixes AIs not understanding a few newer languages.
 * bugfix: Fixes librarians not getting a random language at roundstart(Except cult/xenomorph/martian).
 * bugfix: Fixes babel syndrome not giving you a random(non cult/xenomorph/martian) language.
