### PR TITLE
Specific humanoid message for the Staff of Change

### DIFF
--- a/code/modules/projectiles/projectile/change.dm
+++ b/code/modules/projectiles/projectile/change.dm
@@ -51,6 +51,7 @@
 			if(M.mind && M.mind.wizard_spells && M.mind.wizard_spells.len)
 				for (var/spell/S in M.mind.wizard_spells)
 					new_mob.spell_list += new S.type
-			to_chat(new_mob, "<B>Your form morphs into that of a [randomize].</B>")
+			var/mob/living/carbon/human/H = new_mob
+			to_chat(new_mob, "<B>Your form morphs into that of a [(istype(H) && H.species && H.species.name) ? H.species.name : randomize].</B>")
 			return new_mob
 


### PR DESCRIPTION
Fixes this:
![human](https://user-images.githubusercontent.com/31839805/38401136-db5532a8-3908-11e8-8a19-5f5f5bb3f34a.png)

:cl:
* rscadd: Getting changed into a humanoid form by the staff of change will now tell you your species instead of "Human."