### PR TITLE
More action buttons fixes

### DIFF
--- a/code/_onclick/hud/action_button.dm
+++ b/code/_onclick/hud/action_button.dm
@@ -74,7 +74,7 @@
 	if(!hud_used || !client)
 		return
 
-	if(hud_used.hud_shown != 1 || !hud_used.hide_actions_toggle)
+	if(hud_used.hud_shown != 1)
 		return
 
 	var/button_number = 0

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -326,8 +326,6 @@
 			var/mob/living/carbon/C = M
 			C.stomach_contents.Add(to_drop)
 
-	to_drop.dropped(src)
-
 	if(to_drop && to_drop.loc)
 		return 1
 	return 0


### PR DESCRIPTION
Basically fixes `[00:20:59] Runtime in action.dm,53: Cannot modify null.moved.` and the vanishing action buttons on reconnecting.

Closes #18023 
Fixes #17999 