### PR TITLE
can't perform CPR if you have no lungs

### DIFF
--- a/code/modules/mob/living/carbon/human/combat.dm
+++ b/code/modules/mob/living/carbon/human/combat.dm
@@ -208,6 +208,12 @@
 	..()
 
 /mob/living/carbon/human/proc/perform_cpr(mob/living/target)
+	if(!get_lungs())
+		to_chat(src, "<span class='notice'><B>You have no lungs with which to perform CPR with!</B></span>")
+		return 0
+	if(src.species && src.species.flags & NO_BREATHE)
+		to_chat(src, "<span class='notice'><B>You don't breathe, so you can't help \the [target]!</B></span>")
+		return 0
 	if(src.check_body_part_coverage(MOUTH))
 		to_chat(src, "<span class='notice'><B>Remove your [src.get_body_part_coverage(MOUTH)]!</B></span>")
 		return 0


### PR DESCRIPTION
for consistency sake, if you can't blow up a balloon, you can't blow into somebodies mouth to blow up a pair of lungs.

Pointed out by 
![crab_atting_me](https://user-images.githubusercontent.com/30557196/38458009-48704624-3a90-11e8-9115-b2e41d79a806.PNG)

:cl:
* rscadd: You can no longer perform CPR if you lack lungs or can not breathe.
