### PR TITLE
Re-adds action button runtimes

### DIFF
--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -326,6 +326,8 @@
 			var/mob/living/carbon/C = M
 			C.stomach_contents.Add(to_drop)
 
+	to_drop.dropped(src)
+
 	if(to_drop && to_drop.loc)
 		return 1
 	return 0


### PR DESCRIPTION
Reverts the change made in inventory code, making the action buttons runtime re-appear but fixing the issue with objects that need this dropped for some reason i don't know yet since dropped is called twice anyways.
