### PR TITLE
Fixes atmos connector continuity during shuttle transit

### DIFF
--- a/code/ATMOSPHERICS/components/unary/portables_connector.dm
+++ b/code/ATMOSPHERICS/components/unary/portables_connector.dm
@@ -47,7 +47,9 @@
 	if(!connected_device)
 		return
 	if(AM == connected_device)
-		connected_device.disconnect()
+		spawn(1)
+			if(AM.loc != src.loc)
+				connected_device.disconnect()
 
 /obj/machinery/atmospherics/unary/portables_connector/return_network(obj/machinery/atmospherics/reference)
 	build_network()

--- a/code/ATMOSPHERICS/components/unary/portables_connector.dm
+++ b/code/ATMOSPHERICS/components/unary/portables_connector.dm
@@ -48,7 +48,7 @@
 		return
 	if(AM == connected_device)
 		spawn(1)
-			if(AM.loc != src.loc)
+			if(src && AM && AM.loc != loc && connected_device)
 				connected_device.disconnect()
 
 /obj/machinery/atmospherics/unary/portables_connector/return_network(obj/machinery/atmospherics/reference)

--- a/code/game/machinery/atmoalter/portable_atmospherics.dm
+++ b/code/game/machinery/atmoalter/portable_atmospherics.dm
@@ -45,7 +45,9 @@
 // Things like the Dimensional Push spell can move ANYTHING
 /obj/machinery/portable_atmospherics/Uncrossed(var/atom/movable/AM)
 	if(AM == connected_port)
-		disconnect()
+		spawn(1)
+			if(src && AM && AM.loc != loc)
+				disconnect()
 
 /obj/machinery/portable_atmospherics/proc/connect(obj/machinery/atmospherics/unary/portables_connector/new_port)
 	//Make sure not already connected to something else


### PR DESCRIPTION
Closes #18050

:cl:
* bugfix: Portable atmos devices hooked to connectors aboard shuttles will no longer disconnect on departure and arrival.