### PR TITLE
Bee Tweaks

### DIFF
--- a/code/game/machinery/bees_apiary.dm
+++ b/code/game/machinery/bees_apiary.dm
@@ -1,5 +1,7 @@
 //http://www.youtube.com/watch?v=-1GadTfGFvU
 
+#define MAX_BEES_PER_HIVE	40
+
 /*
 
 > apiary tray
@@ -203,14 +205,28 @@
 	else if(istype(O, /obj/item/weapon/bee_net))
 		var/obj/item/weapon/bee_net/N = O
 		if(N.caught_bees.len)
-			for (var/datum/bee/B in N.caught_bees)
-				if (!species || !(queen_bees_inside || worker_bees_inside))
-					species = B.species
-				if (species == B.species)
-					enterHive(B)
-					N.caught_bees.Remove(B)
-			N.current_species = null
-			to_chat(user, "<span class='notice'>You empty the [species.common_name] into the apiary.</span>")
+			if (N.caught_bees.len+worker_bees_inside+queen_bees_inside+bees_outside_hive.len <= MAX_BEES_PER_HIVE)
+				for (var/datum/bee/B in N.caught_bees)
+					if (!species || !(queen_bees_inside || worker_bees_inside))
+						species = B.species
+					if (species == B.species)
+						enterHive(B)
+						N.caught_bees.Remove(B)
+				N.current_species = null
+				to_chat(user, "<span class='notice'>You empty the [species.common_name] into the apiary.</span>")
+			else
+				var allowed = MAX_BEES_PER_HIVE - worker_bees_inside+queen_bees_inside+bees_outside_hive.len
+				if (allowed == 0)
+					to_chat(user, "<span class='warning'>There are too many [species.common_name] in the apiary already.</span>")
+				else
+					for (var/i = 1 to allowed)
+						var/datum/bee/B = pick(N.caught_bees)
+						if (!species || !(queen_bees_inside || worker_bees_inside))
+							species = B.species
+						if (species == B.species)
+							enterHive(B)
+							N.caught_bees.Remove(B)
+					to_chat(user, "<span class='notice'>You empty [allowed] [species.common_name] into the apiary.</span>")
 		else
 			to_chat(user, "<span class='notice'>There are no more bees in the net.</span>")
 	else
@@ -388,7 +404,7 @@
 
 
 		//PRODUCING WORKER BEES
-		if(nutrilevel > 10 && queen_bees_inside > 0 && worker_bees_inside < 20)
+		if(nutrilevel > 10 && queen_bees_inside > 0 && worker_bees_inside < MAX_BEES_PER_HIVE/2)
 			worker_bees_inside += queen_bees_inside
 
 		// We're getting in dire need of nutrients, let's starve bees so others can survive
@@ -542,3 +558,5 @@
 /obj/machinery/apiary/wild/update_icon()
 	overlays.len = 0
 	return
+
+#undef MAX_BEES_PER_HIVE

--- a/code/game/machinery/bees_apiary.dm
+++ b/code/game/machinery/bees_apiary.dm
@@ -216,7 +216,7 @@
 				to_chat(user, "<span class='notice'>You empty the [species.common_name] into the apiary.</span>")
 			else
 				var allowed = MAX_BEES_PER_HIVE - worker_bees_inside+queen_bees_inside+bees_outside_hive.len
-				if (allowed == 0)
+				if (allowed <= 0)
 					to_chat(user, "<span class='warning'>There are too many [species.common_name] in the apiary already.</span>")
 				else
 					for (var/i = 1 to allowed)

--- a/code/modules/mob/living/simple_animal/bees/bees_items.dm
+++ b/code/modules/mob/living/simple_animal/bees/bees_items.dm
@@ -11,6 +11,9 @@
 
 */
 
+
+#define MAX_BEES_PER_NET	100
+
 /obj/item/queen_bee
 	name = "queen bee packet"
 	desc = "Place her into an apiary so she can get busy."
@@ -52,6 +55,10 @@
 	var/turf/T = get_turf(A)
 	var/caught = 0
 	for(var/mob/living/simple_animal/bee/B in T)
+		if (caught_bees.len >= MAX_BEES_PER_NET)
+			to_chat(user, "<span class='warning'>There are too many [current_species.common_name] inside \the [src] already! You have to release some before you can catch more.</span>")
+			return
+
 		if (current_species)
 			if (current_species != B.bee_species)
 				to_chat(user, "<span class='warning'>You gotta empty \the [src] of [current_species.common_name] before you can catch [B.bee_species.common_name] with it!</span>")
@@ -101,9 +108,9 @@
 		else
 			to_chat(M, "<span class='notice'>You empty \the [src].</span>")
 		//release a few swarms
-		while(caught_bees.len > 5)
+		while(caught_bees.len > 20)
 			var/mob/living/simple_animal/bee/B = new(get_turf(src))
-			for (var/i = 1 to 5)
+			for (var/i = 1 to 20)
 				var/datum/bee/BEE = pick(caught_bees)
 				caught_bees.Remove(BEE)
 				if (current_species.angery)
@@ -240,3 +247,5 @@
 				</body>
 				</html>
 				"}
+
+#undef MAX_BEES_PER_NET

--- a/code/modules/mob/living/simple_animal/bees/bees_mob.dm
+++ b/code/modules/mob/living/simple_animal/bees/bees_mob.dm
@@ -31,9 +31,18 @@
 
 /obj/effect/decal/cleanable/bee/New()
 	..()
-	dir = pick(cardinal)
-	pixel_x = rand(-10,10)
-	pixel_y = rand(-4,4)
+	var/image/I = image(icon,icon_state)
+	I.pixel_x = rand(-10,10)
+	I.pixel_y = rand(-4,4)
+	I.dir = pick(cardinal)
+
+	for (var/obj/effect/decal/cleanable/bee/corpse in get_turf(src))
+		if (corpse != src)
+			corpse.overlays += I
+			qdel(src)
+		else
+			icon_state = "bees0"
+			overlays += I
 
 /obj/effect/decal/cleanable/bee/queen_bee
 	name = "dead queen bee"

--- a/code/modules/mob/living/simple_animal/bees/bees_mob.dm
+++ b/code/modules/mob/living/simple_animal/bees/bees_mob.dm
@@ -40,6 +40,7 @@
 		if (corpse != src)
 			corpse.overlays += I
 			qdel(src)
+			return
 		else
 			icon_state = "bees0"
 			overlays += I


### PR DESCRIPTION
implementing part of the changes discussed in #17905

:cl:
* tweak: Bug nets now have a limit of 100 bugs that they can hold at once.
* tweak: Apiaries may no longer accept more than a total of 40 bees from a net.
* tweak: When emptying a bee net, bees are split in swarms of 20 instead of 5.
* tweak: Bee corpses now look for already existing corpses on spawn so they can add themselves as overlay. So there should no longer be more than one corpse per tile.