### PR TITLE
Fixes golem death runtime

### DIFF
--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -886,7 +886,7 @@ var/list/has_died_as_golem = list()
 	anim(target = H, a_icon = 'icons/mob/mob.dmi', flick_anim = "dust-g", sleeptime = 15)
 	var/mob/living/adamantine_dust/A = new(H.loc)
 	if(golemmind)
-		has_died_as_golem.Add(H.mind.key = world.time)
+		has_died_as_golem[H.mind.key] = world.time
 		A.mind = golemmind
 		H.mind = null
 		golemmind.current = A


### PR DESCRIPTION
``Runtime in species.dm,889: illegal use of list2args() or named parameters``

:cl:
* bugfix: Fixed an error concerning how golem death was handled. Golems will now leave behind only dust instead of dust and a redundant body. Reviving golems via adamantine slime extract should work properly now. Cooldown timer for being a new golem after dying as a golem should work properly now.