### PR TITLE
Tweaks the metabolism rate of inaprovaline to be slower so it lasts longer.

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -853,7 +853,7 @@
 	description = "Inaprovaline is a synaptic stimulant and cardiostimulant. Commonly used to stabilize patients."
 	reagent_state = LIQUID
 	color = "#C8A5DC" //rgb: 200, 165, 220
-	custom_metabolism = 0.5
+	custom_metabolism = 0.2
 	pain_resistance = 25
 	density = 1.66
 	specheatcap = 0.8


### PR DESCRIPTION
Inaprovaline originally had a much slower metabolism rate.  Dylanstrategie altered this unatomically in a PR and no one caught it.  This has led to it being metabolized at a rate 250% higher than comparable chems.  Players would like to see this tweaked so a more basic chem has more use in the game rather than something that is only used to create higher tier chemicals.  This level of metabolism will match dexalin plus, 

For an in depth discussion on the merits of this change please see the following issue:
Closes https://github.com/vgstation-coders/vgstation13/issues/18045


🆑 

* tweak: Inaprovalines metabolism has been lowered so it lasts much longer.