### PR TITLE
"Projectile" for shotgun blanks

### DIFF
--- a/code/modules/projectiles/ammunition/bullets.dm
+++ b/code/modules/projectiles/ammunition/bullets.dm
@@ -117,7 +117,7 @@
 	name = "blank shell"
 	desc = "A blank shell.  Does not contain any projectile material."
 	icon_state = "blshell"
-	projectile_type = ""
+	projectile_type = "/obj/item/projectile/bullet/blank"
 	starting_materials = list(MAT_IRON = 250)
 	w_type = RECYK_METAL
 

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -24,6 +24,13 @@
 	damage_type = TOX
 	weaken = 5
 
+/obj/item/projectile/bullet/blank
+	name = "hot gas discharge"
+	icon_state = null
+	damage = 10
+	damage_type = BURN
+	kill_count = 1 //Limits the range to one tile
+
 /obj/item/projectile/bullet/shrapnel
 
 	name = "shrapnel"

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -30,6 +30,7 @@
 	damage = 10
 	damage_type = BURN
 	kill_count = 1 //Limits the range to one tile
+	embed = 0
 
 /obj/item/projectile/bullet/shrapnel
 


### PR DESCRIPTION
Resolves #18069 

Made blanks work by giving them an invisible projectile with a range of one tile that does 10 burn. If anyone has opinions on how much damage this should do, or whether it should do any damage, feel free. Currently it's less than a welder does. Apparently the kill_count = 1 method doesn't let you shoot a diagonal tile either. Also the harm intent point blank shots don't work with shotguns right now it seems.

:cl:
* rscadd: Shotgun blanks work now, when previously they could not be loaded into anything. They may be for putting on a show, but they will do some moderate burn damage to someone up close.