### PR TITLE
Fixes loyalty immunity to greytides

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -293,7 +293,7 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/jobspecific/greytide
 	name = "Greytide Implant"
-	desc = "A box containing an implanter filled with a greytide implant when injected into another person makes them loyal to the greytide and your cause, unless they're already implanted by someone else. Loyalty ends if he or she no longer has the implant."
+	desc = "A box containing an implanter filled with a greytide implant when injected into another person makes them loyal to the greytide and your cause, unless they're already implanted by someone else. Loyalty ends if he or she no longer has the implant. CAUTION: WILL NOT WORK ON SUBJECTS WITH NT LOYALTY IMPLANTS."
 	item = /obj/item/weapon/storage/box/syndie_kit/greytide
 	cost = 14
 	job = list("Assistant")

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -322,8 +322,10 @@ the implant may become unstable and either pre-maturely inject the subject or si
 	var/list/implanters
 	var/ref = "\ref[user.mind]"
 	if(!iscarbon(M))
+		to_chat(user, "<span class='danger'>The implant doesn't seem to be compatible with [M]!</span>")
 		return 0
 	if(!M.mind)
+		to_chat(user, "<span class='danger'>[M] lacks a mind to affect!</span>")
 		return 0
 	var/mob/living/carbon/H = M
 	if(M == user)
@@ -331,10 +333,12 @@ the implant may become unstable and either pre-maturely inject the subject or si
 		if(isliving(user))
 			user:brainloss += 10
 		return
-	if(locate(/obj/item/weapon/implant/traitor) in H.contents || locate(/obj/item/weapon/implant/loyalty) in H.contents)
-		H.visible_message("<span class='big danger'>[H] seems to resist the implant!</span>", "<span class='danger'>You feel a strange sensation in your head that quickly dissipates.</span>")
-		return 0
-	else if(H.mind in ticker.mode.traitors)
+	for(var/obj/item/weapon/implant/I in H)
+		if(istype(I, /obj/item/weapon/implant/traitor) || istype(I, /obj/item/weapon/implant/loyalty))
+			if(I.imp_in == H)
+				H.visible_message("<span class='big danger'>[H] seems to resist the implant!</span>", "<span class='danger'>You feel a strange sensation in your head that quickly dissipates.</span>")
+				return 0
+	if(H.mind in ticker.mode.traitors)
 		H.visible_message("<span class='big danger'>[H] seems to resist the implant!</span>", "<span class='danger'>You feel a familiar sensation in your head that quickly dissipates.</span>")
 		return 0
 	H.implanting = 1


### PR DESCRIPTION
Fun removal alert. Fixes a bug that causes loyalty implants to not protect the implanted from greytide implants. Maybe greytides ought to cost less TC or something.

History:
https://github.com/vgstation-coders/vgstation13/commit/ca79d7277332530b6407d5b356eb9df9a0ddfd27#diff-37fc2af99c6e0d25f3fdf1509f826e9bL338
https://github.com/vgstation-coders/vgstation13/commit/c7633895b6cd12a000180c8951ecadc383c7e255#diff-37fc2af99c6e0d25f3fdf1509f826e9bL319

:cl:
* bugfix: NT has patched a security flaw in loyalty implants that made them useless at blocking the effects of the Syndicate's so-called Greytide implant. Whichever implant that gets in first will override the other.