### PR TITLE
Removes boss monsters from gold core reactions

### DIFF
--- a/__DEFINES/global.dm
+++ b/__DEFINES/global.dm
@@ -367,6 +367,15 @@ var/list/blacklisted_mobs = list(
 		/mob/living/adamantine_dust // Ditto
 		)
 
+//Boss monster list
+var/list/boss_mobs = existing_typesof(
+	/mob/living/simple_animal/scp_173,				// Just a statue.
+	/mob/living/simple_animal/hostile/hivebot/tele,	// Hivebot spawner WIP thing
+	/mob/living/simple_animal/hostile/wendigo,		// Stupid strong evolving creature things that scream for help
+	/mob/living/simple_animal/hostile/mechahitler,	// Sieg heil!
+	/mob/living/simple_animal/hostile/alien/queen,	// Queens can make eggs and spark the xenocalypse
+	)
+
 //Global list of all Cyborg/MoMMI modules.
 var/global/list/robot_modules = list(
 	"Standard"		= /obj/item/weapon/robot_module/standard,

--- a/__DEFINES/global.dm
+++ b/__DEFINES/global.dm
@@ -369,11 +369,11 @@ var/list/blacklisted_mobs = list(
 
 //Boss monster list
 var/list/boss_mobs = existing_typesof(
-	/mob/living/simple_animal/scp_173,				// Just a statue.
-	/mob/living/simple_animal/hostile/hivebot/tele,	// Hivebot spawner WIP thing
-	/mob/living/simple_animal/hostile/wendigo,		// Stupid strong evolving creature things that scream for help
-	/mob/living/simple_animal/hostile/mechahitler,	// Sieg heil!
-	/mob/living/simple_animal/hostile/alien/queen,	// Queens can make eggs and spark the xenocalypse
+	/mob/living/simple_animal/scp_173,						// Just a statue.
+	/mob/living/simple_animal/hostile/hivebot/tele,			// Hivebot spawner WIP thing
+	/mob/living/simple_animal/hostile/wendigo,				// Stupid strong evolving creature things that scream for help
+	/mob/living/simple_animal/hostile/mechahitler,			// Sieg heil!
+	/mob/living/simple_animal/hostile/alien/queen/large,	// The bigger and beefier version of queens.
 	)
 
 //Global list of all Cyborg/MoMMI modules.

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -1213,6 +1213,7 @@
 		/mob/living/simple_animal/hostile/slime,
 		/mob/living/simple_animal/hostile/mining_drone,
 		/mob/living/simple_animal/hostile/mimic,
+		/mob/living/simple_animal/hostile/retaliate/cockatrice
 		)//Exclusion list for things you don't want the reaction to create.
 
 	var/list/critters = existing_typesof(/mob/living/simple_animal/hostile) - blocked - boss_mobs//List of possible hostile mobs

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -1201,8 +1201,10 @@
 		holder.my_atom.visible_message("<span class='warning'>The slime extract begins to vibrate violently!</span>")
 		sleep(50)
 
-	var/blocked = list(
-		/mob/living/simple_animal/hostile/alien/queen/large,
+	var/blocked = existing_typesof(
+		/mob/living/simple_animal/hostile/humanoid,
+		/mob/living/simple_animal/hostile/asteroid,
+		/mob/living/simple_animal/hostile/faithless,
 		/mob/living/simple_animal/hostile/scarybat/cult,
 		/mob/living/simple_animal/hostile/creature/cult,
 		/mob/living/simple_animal/hostile/retaliate/clown,
@@ -1210,10 +1212,10 @@
 		/mob/living/simple_animal/hostile/carp/holocarp,
 		/mob/living/simple_animal/hostile/slime,
 		/mob/living/simple_animal/hostile/mining_drone,
-		/mob/living/simple_animal/hostile/mechahitler,
-		) + typesof(/mob/living/simple_animal/hostile/faithless) + typesof(/mob/living/simple_animal/hostile/humanoid) + typesof(/mob/living/simple_animal/hostile/asteroid) + typesof(/mob/living/simple_animal/hostile/wendigo) + typesof(/mob/living/simple_animal/hostile/mimic)//Exclusion list for things you don't want the reaction to create.
+		/mob/living/simple_animal/hostile/mimic,
+		)//Exclusion list for things you don't want the reaction to create.
 
-	var/list/critters = existing_typesof(/mob/living/simple_animal/hostile) - blocked //List of possible hostile mobs
+	var/list/critters = existing_typesof(/mob/living/simple_animal/hostile) - blocked - boss_mobs//List of possible hostile mobs
 
 	playsound(holder.my_atom, 'sound/effects/phasein.ogg', 100, 1)
 

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -1216,7 +1216,8 @@
 		/mob/living/simple_animal/hostile/mimic/crate,
 		/mob/living/simple_animal/hostile/mimic/crate/chest,
 		/mob/living/simple_animal/hostile/mimic/crate/item,
-		) + typesof(/mob/living/simple_animal/hostile/humanoid) + typesof(/mob/living/simple_animal/hostile/asteroid) //Exclusion list for things you don't want the reaction to create.
+		/mob/living/simple_animal/hostile/mechahitler,
+		) + typesof(/mob/living/simple_animal/hostile/humanoid) + typesof(/mob/living/simple_animal/hostile/asteroid) + typesof(/mob/living/simple_animal/hostile/wendigo)//Exclusion list for things you don't want the reaction to create.
 
 	var/list/critters = existing_typesof(/mob/living/simple_animal/hostile) - blocked //List of possible hostile mobs
 

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -1203,8 +1203,6 @@
 
 	var/blocked = list(
 		/mob/living/simple_animal/hostile/alien/queen/large,
-		/mob/living/simple_animal/hostile/faithless,
-		/mob/living/simple_animal/hostile/faithless/cult,
 		/mob/living/simple_animal/hostile/scarybat/cult,
 		/mob/living/simple_animal/hostile/creature/cult,
 		/mob/living/simple_animal/hostile/retaliate/clown,
@@ -1212,12 +1210,8 @@
 		/mob/living/simple_animal/hostile/carp/holocarp,
 		/mob/living/simple_animal/hostile/slime,
 		/mob/living/simple_animal/hostile/mining_drone,
-		/mob/living/simple_animal/hostile/mimic,
-		/mob/living/simple_animal/hostile/mimic/crate,
-		/mob/living/simple_animal/hostile/mimic/crate/chest,
-		/mob/living/simple_animal/hostile/mimic/crate/item,
 		/mob/living/simple_animal/hostile/mechahitler,
-		) + typesof(/mob/living/simple_animal/hostile/humanoid) + typesof(/mob/living/simple_animal/hostile/asteroid) + typesof(/mob/living/simple_animal/hostile/wendigo)//Exclusion list for things you don't want the reaction to create.
+		) + typesof(/mob/living/simple_animal/hostile/faithless) + typesof(/mob/living/simple_animal/hostile/humanoid) + typesof(/mob/living/simple_animal/hostile/asteroid) + typesof(/mob/living/simple_animal/hostile/wendigo) + typesof(/mob/living/simple_animal/hostile/mimic)//Exclusion list for things you don't want the reaction to create.
 
 	var/list/critters = existing_typesof(/mob/living/simple_animal/hostile) - blocked //List of possible hostile mobs
 


### PR DESCRIPTION
Because having boss monsters in the middle of tons of monsters is absolutely overkill. Adds a list of boss monsters and excludes them from reactions.

:cl:
 * rscdel: Mecha Hitler, Wendigos and Cockatrices can't be spawned by gold core+blood reactions anymore.
