### PR TITLE
Makes AME shut down when out of fuel

### DIFF
--- a/code/modules/power/antimatter/control.dm
+++ b/code/modules/power/antimatter/control.dm
@@ -66,7 +66,7 @@
 	if(stat & (NOPOWER|BROKEN) || !active)//can update the icons even without power
 		return
 
-	if(!fueljar)//No fuel but we are on, shutdown
+	if(!fueljar || fueljar.fuel <= 0)//No fuel but we are on, shutdown
 		toggle_power()
 		//Angry buzz or such here
 		return


### PR DESCRIPTION
This is so the AME will visibly turn off when it runs out of fuel instead of staying lit up forever. Not that it would make power in that state, it's mainly a cosmetic and QoL thing. Maybe ideally it should have some third visual state for this but screw it.

Once upon a time these things used to explode when they ran out of fuel, right? Probably why it's like this. I know technically I'm dumbing the engine down even more but this seems like a minor enough change that's also logical.

:cl:
* tweak: The AME now shuts down when out of fuel instead of staying in an "active" state while producing no power.