### PR TITLE
Adds "Brotherhood of the Yellow Sign" Religion

### DIFF
--- a/code/datums/religions.dm
+++ b/code/datums/religions.dm
@@ -264,6 +264,12 @@
 	bible_names = list("The Necronomicon", "The Book of Eibon", "De Vermis Mysteriis", "Unaussprechlichen Kulten")
 	keys = list("cthulhu", "old ones", "great old ones", "outer gods", "elder gods", "esoteric order of dagon")
 
+/datum/religion/hastur
+	name = "Brotherhood of the Yellow Sign" //I'm fed up with people think I worship Dagon. We're moving out.
+	deity_name = "Hastur"
+	bible_name = "The King in Yellow" //The name of the titular fictional play in the 1895 book by Robert Chambers
+	keys = list("hastur","yellow sign","king in yellow","brotherhood of the yellow sign")
+
 /datum/religion/islam
 	name = "Islam"
 	deity_name = "Allah"

--- a/code/datums/religions.dm
+++ b/code/datums/religions.dm
@@ -265,7 +265,7 @@
 	keys = list("cthulhu", "old ones", "great old ones", "outer gods", "elder gods", "esoteric order of dagon")
 
 /datum/religion/hastur
-	name = "Brotherhood of the Yellow Sign" //I'm fed up with people think I worship Dagon. We're moving out.
+	name = "Brotherhood of The Yellow Sign" //I'm fed up with people think I worship Dagon. We're moving out.
 	deity_name = "Hastur"
 	bible_name = "The King in Yellow" //The name of the titular fictional play in the 1895 book by Robert Chambers
 	keys = list("hastur","yellow sign","king in yellow","brotherhood of the yellow sign")


### PR DESCRIPTION
I know there's a religion for lovecraft shit already, but the religion name (which it shows to converts) is "Esoteric order of Dagon". People see this and assume I worship Dagon, which makes sense, because Dagon (a specific entity) appears to be the object of worship here. This, however, is not supposed to be an unatomic commit, so I'm fixing the problem by adding another religion. I play chaplain often, so it would definitely see use. Any criticism or suggested changes are welcome, and I'll probably open an issue on the whole "all lovecraft things are dagon" bit for further discussion

Edit: Issue raised here: #18160 

:cl:
 * rscadd: Added "Brotherhood of the Yellow Sign" religion.