### PR TITLE
Unrestricts cult armor species

### DIFF
--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -96,11 +96,12 @@
 
 /obj/item/clothing/head/helmet/space/cult
 	name = "cult helmet"
-	desc = "A space worthy helmet used by the followers of Nar-Sie"
+	desc = "A space worthy helmet used by the followers of Nar-Sie."
 	icon_state = "cult_helmet"
 	item_state = "cult_helmet"
 	armor = list(melee = 60, bullet = 50, laser = 30,energy = 15, bomb = 30, bio = 30, rad = 30)
 	siemens_coefficient = 0
+	species_restricted = list() //So dionas can wear it, mainly.
 
 /obj/item/clothing/suit/space/cult
 	name = "cult armor"
@@ -112,3 +113,4 @@
 	slowdown = NO_SLOWDOWN
 	armor = list(melee = 60, bullet = 50, laser = 30,energy = 15, bomb = 30, bio = 30, rad = 30)
 	siemens_coefficient = 0
+	species_restricted = list()


### PR DESCRIPTION
Sort of an obscure cult feature: Currently when using an armor rune while the Nar-Sie summon objective is unlocked a cultist will get some space-worthy armor instead of the normal robes. Dionas though (also mutons), can't wear space suits so they get cheated out of robes or armor in this case. Either we could make them get the normal robes, or we could create a variant armor that fits them, but the least hassle seems to be just to remove the restriction.

:cl:
* tweak: Cult space armor no longer has species restrictions.