### PR TITLE
Buffs greytide kit plus adds syndishades

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -293,7 +293,7 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/jobspecific/greytide
 	name = "Greytide Implant"
-	desc = "A box containing an implanter filled with a greytide implant when injected into another person makes them loyal to the greytide and your cause, unless they're already implanted by someone else. Loyalty ends if he or she no longer has the implant. CAUTION: WILL NOT WORK ON SUBJECTS WITH NT LOYALTY IMPLANTS."
+	desc = "A box containing an implanter filled with two greytide implants that when injected into another person makes them loyal to the greytide and your cause, unless they're already implanted by someone else. Loyalty ends if he or she no longer has the implant. CAUTION: WILL NOT WORK ON SUBJECTS WITH NT LOYALTY IMPLANTS. Now with disguised sechud sunglasses. These will have limited access until you can get your hands on some containing security codes."
 	item = /obj/item/weapon/storage/box/syndie_kit/greytide
 	cost = 14
 	job = list("Assistant")

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -293,7 +293,7 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/jobspecific/greytide
 	name = "Greytide Implant"
-	desc = "A box containing an implanter filled with two greytide implants that when injected into another person makes them loyal to the greytide and your cause, unless they're already implanted by someone else. Loyalty ends if he or she no longer has the implant. CAUTION: WILL NOT WORK ON SUBJECTS WITH NT LOYALTY IMPLANTS. Now with disguised sechud sunglasses. These will have limited access until you can get your hands on some containing security codes."
+	desc = "A box containing two greytide implanters that when injected into another person makes them loyal to the greytide and your cause, unless they're already implanted by someone else. Loyalty ends if he or she no longer has the implant. CAUTION: WILL NOT WORK ON SUBJECTS WITH NT LOYALTY IMPLANTS. Now with disguised sechud sunglasses. These will have limited access until you can get your hands on some containing security codes."
 	item = /obj/item/weapon/storage/box/syndie_kit/greytide
 	cost = 14
 	job = list("Assistant")

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -222,9 +222,9 @@
 
 	New()
 		..()
-		var/obj/item/weapon/implanter/O = new(src)
-		O.imp = new /obj/item/weapon/implant/traitor(O)
-		O.update()
+		new /obj/item/weapon/implanter/traitor(src)
+		new /obj/item/weapon/implanter/traitor(src)
+		new /obj/item/clothing/glasses/sunglasses/sechud/syndishades(src)
 
 /obj/item/weapon/storage/box/syndie_kit/boolets
 	name = "Shotgun shells"

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -122,13 +122,13 @@
 	name = "red star-shaped sunglasses"
 	desc = "Novelty sunglasses with a fancy silver frame and two red-tinted star-shaped lenses. You should probably stomp on them and get a pair of normal ones."
 	icon_state = "sun_star_silver"
-	
+
 /obj/item/clothing/glasses/sunglasses/red
 	name = "red sunglasses"
 	desc = "Strangely ancient technology used to help provide rudimentary eye cover. Enhanced shielding blocks many flashes, and the colored lenses let you see the world in red."
 	icon_state = "sunred"
 	item_state = "sunred"
-	
+
 /obj/item/clothing/glasses/sunglasses/security
 	name = "security sunglasses"
 	desc = "Strangely ancient technology used to help provide rudimentary eye cover. Enhanced shielding blocks many flashes. Often worn by budget security officers."
@@ -240,6 +240,56 @@
 		if(prob(55))
 			hud = null
 			qdel(hud)
+
+/obj/item/clothing/glasses/sunglasses/sechud/syndishades
+	desc = "Strangely ancient technology used to help provide rudimentary eye cover. Enhanced shielding blocks many flashes."
+	name = "sunglasses"
+	icon_state = "sun"
+	item_state = "sunglasses"
+	darkness_view = 0 //Subtly better than normal shades
+	origin_tech = Tc_SYNDICATE + "=3"
+	actions_types = list(/datum/action/item_action/change_appearance_shades)
+	var/list/clothing_choices = list()
+	var/full_access = FALSE
+
+/obj/item/clothing/glasses/sunglasses/sechud/syndishades/New()
+	..()
+	for(var/Type in existing_typesof(/obj/item/clothing/glasses) - /obj/item/clothing/glasses - typesof(/obj/item/clothing/glasses/sunglasses/sechud/syndishades))
+		clothing_choices += new Type
+
+/obj/item/clothing/glasses/sunglasses/sechud/syndishades/attackby(obj/item/I, mob/user)
+	..()
+	if(istype(I, /obj/item/clothing/glasses/sunglasses/sechud) || istype(I, /obj/item/clothing/glasses/hud/security))
+		var/obj/item/clothing/glasses/sunglasses/sechud/syndishades/S = I
+		if(istype(S) && !S.full_access)
+			return
+		if(full_access)
+			to_chat(user, "<span class='warning'>\The [src] already has those access codes.</span>")
+			return
+		else
+			to_chat(user, "<span class='notice'>You transfer the security access codes from \the [I] to \the [src].</span>")
+			full_access = TRUE
+
+/datum/action/item_action/change_appearance_shades
+	name = "Change Shades Appearance"
+
+/datum/action/item_action/change_appearance_shades/Trigger()
+	var/obj/item/clothing/glasses/sunglasses/sechud/syndishades/T = target
+	if(!istype(T))
+		return
+	T.change()
+
+/obj/item/clothing/glasses/sunglasses/sechud/syndishades/proc/change()
+	var/obj/item/clothing/glasses/A
+	A = input("Select style to change it to", "BOOYEA", A) as null|anything in clothing_choices
+	if(!A ||(usr.stat))
+		return
+	desc = A.desc
+	name = A.name
+	icon_state = A.icon_state
+	item_state = A.item_state
+	_color = A._color
+	usr.update_inv_glasses()
 
 /obj/item/clothing/glasses/thermal
 	name = "Optical Thermal Scanner"

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -281,8 +281,8 @@
 
 /obj/item/clothing/glasses/sunglasses/sechud/syndishades/proc/change()
 	var/obj/item/clothing/glasses/A
-	A = input("Select style to change it to", "BOOYEA", A) as null|anything in clothing_choices
-	if(!A ||(usr.stat))
+	A = input("Select style to change it to", "Styles", A) as null|anything in clothing_choices
+	if(!src || src.gcDestroyed || !A || usr.incapacitated() || !Adjacent(usr))
 		return
 	desc = A.desc
 	name = A.name

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -249,13 +249,16 @@
 	darkness_view = 0 //Subtly better than normal shades
 	origin_tech = Tc_SYNDICATE + "=3"
 	actions_types = list(/datum/action/item_action/change_appearance_shades)
-	var/list/clothing_choices = list()
+	var/static/list/clothing_choices = null
 	var/full_access = FALSE
 
 /obj/item/clothing/glasses/sunglasses/sechud/syndishades/New()
 	..()
-	for(var/Type in existing_typesof(/obj/item/clothing/glasses) - /obj/item/clothing/glasses - typesof(/obj/item/clothing/glasses/sunglasses/sechud/syndishades))
-		clothing_choices += new Type
+	if(!clothing_choices)
+		clothing_choices = list()
+		for(var/Type in existing_typesof(/obj/item/clothing/glasses) - /obj/item/clothing/glasses - typesof(/obj/item/clothing/glasses/sunglasses/sechud/syndishades))
+			var/obj/glass = Type
+			clothing_choices[initial(glass.name)] = glass
 
 /obj/item/clothing/glasses/sunglasses/sechud/syndishades/attackby(obj/item/I, mob/user)
 	..()
@@ -281,14 +284,14 @@
 
 /obj/item/clothing/glasses/sunglasses/sechud/syndishades/proc/change()
 	var/obj/item/clothing/glasses/A
-	A = input("Select style to change it to", "Styles", A) as null|anything in clothing_choices
-	if(!src || src.gcDestroyed || !A || usr.incapacitated() || !Adjacent(usr))
+	A = input("Select style to change it to", "Style Selector", A) as null|anything in clothing_choices
+	if(src.gcDestroyed || !A || usr.incapacitated() || !Adjacent(usr))
 		return
-	desc = A.desc
-	name = A.name
-	icon_state = A.icon_state
-	item_state = A.item_state
-	_color = A._color
+	desc = initial(clothing_choices[A].desc)
+	name = initial(clothing_choices[A].name)
+	icon_state = initial(clothing_choices[A].icon_state)
+	item_state = initial(clothing_choices[A].item_state)
+	_color = initial(clothing_choices[A]._color)
 	usr.update_inv_glasses()
 
 /obj/item/clothing/glasses/thermal

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1798,5 +1798,8 @@ mob/living/carbon/human/remove_internal_organ(var/mob/living/user, var/datum/org
 		if(HUD_MEDICAL)
 			return istype(glasses, /obj/item/clothing/glasses/hud/health)
 		if(HUD_SECURITY)
+			if(istype(glasses, /obj/item/clothing/glasses/sunglasses/sechud/syndishades))
+				var/obj/item/clothing/glasses/sunglasses/sechud/syndishades/S = glasses
+				return S.full_access
 			return is_type_in_list(glasses, list(/obj/item/clothing/glasses/hud/security, /obj/item/clothing/glasses/sunglasses/sechud))
 	return FALSE


### PR DESCRIPTION
Following up on #18108. I figured adding another implant to the kit might be fair, as well adding something to spot officers that don't have implants from cloning, promotion or whatever.

:cl:
* rscadd: Added syndishades: disguised secHUD sunglasses that can't set arrest status until they get the codes from a normal pair.
* tweak: Changed number of implants in a greytide kit from one to two. Added syndishades to the kit.