### PR TITLE
Smarter blade equipping from armor talismans

### DIFF
--- a/code/game/gamemodes/cult/talisman.dm
+++ b/code/game/gamemodes/cult/talisman.dm
@@ -71,6 +71,7 @@
 			if("newtome")
 				call(/obj/effect/rune/proc/tomesummon)()
 			if("armor") //Fuck off with your shit /tg/. This isn't Edgy Rev+
+				user.drop_from_inventory(src) //So that the blade goes straight to your active hand.
 				call(/obj/effect/rune/proc/armor)()
 			if("emp")
 				call(/obj/effect/rune/proc/emp)(usr.loc,3)


### PR DESCRIPTION
:cl:
* tweak: Made it so that when an armor talisman is used, the blade from it goes straight into the user's active hand instead of their off hand, or worse, the ground.