### PR TITLE
Changes M_NOCLONE to M_HUSK for some things

### DIFF
--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -139,7 +139,7 @@
 				return
 			if(!T.dna)
 				return
-			if(M_NOCLONE in T.mutations)
+			if(M_HUSK in T.mutations)
 				return
 
 			// If the human is losing too much blood, beep.

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -406,7 +406,7 @@ Subject's pulse: ??? BPM"})
 			return
 		if(!C.dna)
 			return
-		if(M_NOCLONE in C.mutations)
+		if(M_HUSK in C.mutations)
 			return
 
 		var/datum/reagent/B = C.take_blood(src, src.reagents.maximum_volume)

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -143,11 +143,11 @@
 		if(!head || head.status & ORGAN_DESTROYED)
 			target.visible_message("<span class='warning'>[src] buzzes: Defibrillation failed. Severe cranial damage detected.</span>")
 			return
-		if(M_NOCLONE in target.mutations)
-			target.visible_message("<span class='warning'>[src] buzzes: Defibrillation failed. Irremediable genetic damage detected.</span>")
+		if(M_HUSK in target.mutations)
+			target.visible_message("<span class='warning'>[src] buzzes: Defibrillation failed. Irremediable cellular damage detected.</span>")
 			return
 		if(!target.has_brain())
-			target.visible_message("<span class='warning'>[src] buzzes: Defibrillation failed. No nervous system detected.</span>")
+			target.visible_message("<span class='warning'>[src] buzzes: Defibrillation failed. No central nervous system detected.</span>")
 			return
 		if(target.suiciding)
 			target.visible_message("<span class='warning'>[src] buzzes: Defibrillation failed. Severe nerve trauma detected.</span>") // They suicided so they fried their brain. Space Magic.

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -163,7 +163,7 @@
 				warning("Tried to draw blood or equivalent from [target] (\ref[target]) but it's missing their DNA datum!")
 				return
 
-			if (M_NOCLONE in T.mutations) // Target has been husked
+			if (M_HUSK in T.mutations) // Target has been husked
 				to_chat(user, "<span class='warning'>You are unable to locate any blood.</span>")
 				return
 


### PR DESCRIPTION
The new radiation system made it possible (and not all that difficult either) for people to get M_NOCLONE while they're alive. Trouble is, currently this doesn't just make you unclonable, it also makes you unable to be defibbed, or injected with an IV drip. This doesn't seem like intended behavior. I'm changing these things to check for M_HUSK instead. Changeling absorption sets both M_NOCLONE and M_HUSK to on.

:cl:
* tweak: Being made unclonable by radiation will no longer render you unable to be defibbed out of hand, or unable to be hooked up to IVs.