### PR TITLE
Extends most of water's capabilities to holy water

### DIFF
--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -743,7 +743,7 @@ steam.start() -- spawns the effect
 		icon += ccolor
 	var/savedtemp
 	//playsound(src, 'sound/effects/bubbles2.ogg', 80, 1, -3)
-	if(reagents.has_reagent(WATER))
+	if(reagents.has_any_reagents(list(WATER, HOLYWATER)))
 		var/turf/simulated/T = get_turf(src)
 		var/datum/gas_mixture/old_air = T.return_air()
 		savedtemp = old_air.temperature

--- a/code/modules/hydroponics/hydroponics_reagents.dm
+++ b/code/modules/hydroponics/hydroponics_reagents.dm
@@ -53,6 +53,11 @@
 	..()
 	T.adjust_water(1)
 
+/datum/reagent/water/holywater/on_plant_life(var/obj/machinery/portable_atmospherics/hydroponics/T)
+	..()
+	if(T.seed && !T.dead)
+		T.health += 0.1
+
 /datum/reagent/mutagen
 	custom_plant_metabolism = 2
 /datum/reagent/mutagen/on_plant_life(var/obj/machinery/portable_atmospherics/hydroponics/T)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -484,6 +484,9 @@
 	if(volume >= 3) //Hardcoded
 		T.wet(800)
 
+	douse(T, volume)
+
+/datum/reagent/water/proc/douse(var/turf/simulated/T, var/volume)
 	var/hotspot = (locate(/obj/effect/fire) in T)
 	if(hotspot)
 		var/datum/gas_mixture/lowertemp = T.remove_air(T:air:total_moles())
@@ -996,13 +999,7 @@
 	if(volume >= 5)
 		T.bless()
 
-	var/hotspot = (locate(/obj/effect/fire) in T)
-	if(hotspot)
-		var/datum/gas_mixture/lowertemp = T.remove_air(T:air:total_moles())
-		lowertemp.temperature = max(min(lowertemp.temperature-2000, lowertemp.temperature / 2), 0)
-		lowertemp.react()
-		T.assume_air(lowertemp)
-		qdel(hotspot)
+	call(/datum/reagent/water/proc/douse)(T, volume)
 
 /datum/reagent/serotrotium
 	name = "Serotrotium"
@@ -4013,13 +4010,8 @@
 
 	if(volume >= 3)
 		T.wet(800)
-	var/hotspot = (locate(/obj/effect/fire) in T)
-	if(hotspot)
-		var/datum/gas_mixture/lowertemp = T.remove_air(T:air:total_moles())
-		lowertemp.temperature = max( min(lowertemp.temperature-2000,lowertemp.temperature / 2), 0)
-		lowertemp.react()
-		T.assume_air(lowertemp)
-		qdel(hotspot)
+
+	call(/datum/reagent/water/proc/douse)(T, volume)
 
 /datum/reagent/enzyme
 	name = "Universal Enzyme"

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -911,6 +911,8 @@
 	if(volume >= 1)
 		O.bless()
 
+	call(/datum/reagent/water/reaction_obj)(O, volume)
+
 /datum/reagent/holywater/on_mob_life(var/mob/living/M, var/alien)
 
 	if(..())
@@ -993,6 +995,14 @@
 		return 1
 	if(volume >= 5)
 		T.bless()
+
+	var/hotspot = (locate(/obj/effect/fire) in T)
+	if(hotspot)
+		var/datum/gas_mixture/lowertemp = T.remove_air(T:air:total_moles())
+		lowertemp.temperature = max(min(lowertemp.temperature-2000, lowertemp.temperature / 2), 0)
+		lowertemp.react()
+		T.assume_air(lowertemp)
+		qdel(hotspot)
 
 /datum/reagent/serotrotium
 	name = "Serotrotium"

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -7,6 +7,7 @@
 
 // Use in chem.flags.
 #define CHEMFLAG_DISHONORABLE 1
+#define CHEMFLAG_WETSFLOOR 2
 
 /*	The reaction procs must ALWAYS set src = null, this detaches the proc from the object (the reagent)
 	so that it can continue working when the reagent is deleted while the proc is still active.
@@ -117,6 +118,9 @@
 		return 1
 	if(!istype(T))
 		return 1
+
+	if(flags & CHEMFLAG_WETSFLOOR && volume >= 3) //Hardcoded
+		T.wet(800)
 
 	src = null
 
@@ -409,6 +413,7 @@
 	alpha = 128
 	specheatcap = 4.184
 	density = 1
+	flags = CHEMFLAG_WETSFLOOR
 
 /datum/reagent/water/on_mob_life(var/mob/living/M, var/alien)
 
@@ -480,9 +485,6 @@
 
 	if(..())
 		return 1
-
-	if(volume >= 3) //Hardcoded
-		T.wet(800)
 
 	douse(T, volume)
 
@@ -897,7 +899,7 @@
 	if(prob(7))
 		M.emote(pick("twitch", "drool", "moan", "giggle"))
 
-/datum/reagent/holywater
+/datum/reagent/water/holywater
 	name = "Holy Water"
 	id = HOLYWATER
 	description = "An ashen-obsidian-water mix, this solution will alter certain sections of the brain's rationality."
@@ -905,8 +907,9 @@
 	color = "#0064C8" //rgb: 0, 100, 200
 	custom_metabolism = 5 //High metabolism to prevent extended uncult rolls. Approx 5 units per roll
 	specheatcap = 4.183
+	flags = 0
 
-/datum/reagent/holywater/reaction_obj(var/obj/O, var/volume)
+/datum/reagent/water/holywater/reaction_obj(var/obj/O, var/volume)
 
 	if(..())
 		return 1
@@ -914,9 +917,7 @@
 	if(volume >= 1)
 		O.bless()
 
-	call(/datum/reagent/water/reaction_obj)(O, volume)
-
-/datum/reagent/holywater/on_mob_life(var/mob/living/M, var/alien)
+/datum/reagent/water/holywater/on_mob_life(var/mob/living/M, var/alien)
 
 	if(..())
 		return 1
@@ -944,7 +945,7 @@
 			H.visible_message("<span class='notice'>[H] suddenly becomes calm and collected again, \his eyes clear up.</span>",
 			"<span class='notice'>Your blood cools down and you are inhabited by a sensation of untold calmness.</span>")
 
-/datum/reagent/holywater/reaction_mob(var/mob/living/M, var/method = TOUCH, var/volume)//Splashing people with water can help put them out!
+/datum/reagent/water/holywater/reaction_mob(var/mob/living/M, var/method = TOUCH, var/volume)//Splashing people with water can help put them out!
 
 	if(..())
 		return 1
@@ -992,14 +993,12 @@
 						H.take_organ_damage(min(15, volume * 2))
 						H.mind.vampire.smitecounter += 5
 
-/datum/reagent/holywater/reaction_turf(var/turf/simulated/T, var/volume)
+/datum/reagent/water/holywater/reaction_turf(var/turf/simulated/T, var/volume)
 
 	if(..())
 		return 1
 	if(volume >= 5)
 		T.bless()
-
-	call(/datum/reagent/water/proc/douse)(T, volume)
 
 /datum/reagent/serotrotium
 	name = "Serotrotium"
@@ -3995,6 +3994,7 @@
 	reagent_state = LIQUID
 	nutriment_factor = 20 * REAGENTS_METABOLISM
 	color = "#302000" //rgb: 48, 32, 0
+	flags = CHEMFLAG_WETSFLOOR
 
 /datum/reagent/cornoil/on_mob_life(var/mob/living/M)
 
@@ -4007,9 +4007,6 @@
 
 	if(..())
 		return 1
-
-	if(volume >= 3)
-		T.wet(800)
 
 	call(/datum/reagent/water/proc/douse)(T, volume)
 


### PR DESCRIPTION
Closes #17066

:cl:
* tweak: Holy water now has most of the same capabilities water does, including firefighting, harming slimes, and watering plants. Notable things it doesn't do: slip, and act as water in reactions.