### PR TITLE
Stops cloning pods putting inaprovaline in vox

### DIFF
--- a/code/modules/medical/cloning.dm
+++ b/code/modules/medical/cloning.dm
@@ -318,14 +318,14 @@
 			//Premature clones may have brain damage.
 			occupant.adjustBrainLoss(-1*time_coeff) //Ditto above
 
-			//So clones don't die of oxyloss in a running pod.
-			if (occupant.reagents.get_reagent_amount(INAPROVALINE) < 30)
-				occupant.reagents.add_reagent(INAPROVALINE, 60)
-
 			var/mob/living/carbon/human/H = occupant
 
 			if(istype(H.species, /datum/species/vox) & occupant.reagents.get_reagent_amount(NITROGEN) < 30)
 				occupant.reagents.add_reagent(NITROGEN, 60)
+
+			//So clones don't die of oxyloss in a running pod.
+			else if (occupant.reagents.get_reagent_amount(INAPROVALINE) < 30) //Done like this because inaprovaline is poisonous to vox
+				occupant.reagents.add_reagent(INAPROVALINE, 60)
 
 			//Also heal some oxyloss ourselves because inaprovaline is so bad at preventing it!!
 			occupant.adjustOxyLoss(-4)

--- a/code/modules/medical/cloning.dm
+++ b/code/modules/medical/cloning.dm
@@ -320,11 +320,12 @@
 
 			var/mob/living/carbon/human/H = occupant
 
-			if(istype(H.species, /datum/species/vox) & occupant.reagents.get_reagent_amount(NITROGEN) < 30)
-				occupant.reagents.add_reagent(NITROGEN, 60)
+			if(isvox(H))
+				if(occupant.reagents.get_reagent_amount(NITROGEN) < 30)
+					occupant.reagents.add_reagent(NITROGEN, 60)
 
 			//So clones don't die of oxyloss in a running pod.
-			else if (occupant.reagents.get_reagent_amount(INAPROVALINE) < 30) //Done like this because inaprovaline is poisonous to vox
+			else if(occupant.reagents.get_reagent_amount(INAPROVALINE) < 30) //Done like this because inaprovaline is toxic to vox
 				occupant.reagents.add_reagent(INAPROVALINE, 60)
 
 			//Also heal some oxyloss ourselves because inaprovaline is so bad at preventing it!!


### PR DESCRIPTION
Cloning pods fill the occupant with inaprovaline. Inaprovaline is toxic to vox. This is offset largely by the nitrogen they also get, but is there a point in having it at all? You could make an argument that it's just a racial disadvantage, however in the end it makes a bit more of a headache for medbay and I don't know if anyone really wants this.

:cl:
* tweak: Cloning pods don't inject vox with toxic inaprovaline anymore.