### PR TITLE
Fixes mulebot pAI overlay not sticking

### DIFF
--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -477,6 +477,8 @@ var/global/mulebot_count = 0
 
 	mode = 1
 	overlays.len = 0
+	if(integratedpai)
+		overlays += image('icons/obj/aibots.dmi', "mulebot1_pai")
 
 	load.forceMove(src.loc)
 	load.pixel_y -= 9 * PIXEL_MULTIPLIER


### PR DESCRIPTION
Fixes #16568

I figure there's got to be a better way than just re-adding the overlay after it's cleared, but apparently overlays is in a special internal format and can't be manipulated like a normal list.

:cl:
* bugfix: Fixed the pAI appearance for pAI mulebots disappearing after unloading things.