### PR TITLE
adds electrical fires random event

### DIFF
--- a/code/controllers/subsystem/machinery.dm
+++ b/code/controllers/subsystem/machinery.dm
@@ -48,5 +48,8 @@ var/list/machines = list()
 		if (M.use_power)
 			M.auto_use_power()
 
+		if (M.on_fire && prob(15) && M.use_power(1500) != 0)
+			spark(M, 5)
+
 		if (MC_TICK_CHECK)
 			return

--- a/code/modules/events/electrical_fire.dm
+++ b/code/modules/events/electrical_fire.dm
@@ -1,0 +1,25 @@
+/datum/event/electrical_fire
+
+/datum/event/electrical_fire/announce()
+	command_alert(/datum/command_alert/electrical_storm)
+
+/datum/event/electrical_fire/start()
+	var/list/possibleEpicentres = list()
+	for(var/obj/effect/landmark/newEpicentre in landmarks_list)
+		if(newEpicentre.name == "lightsout") //We're piggybacking off of the lightsout event to save on mapping
+			possibleEpicentres += newEpicentre
+
+	var/obj/effect/landmark/epicentre = pick(possibleEpicentres)
+
+	for(var/obj/machinery/M in range(epicentre,25))
+		if(is_type_in_list(M, list(/obj/machinery/door, /obj/machinery/disposal, /obj/machinery/atmospherics, /obj/machinery/light)))
+			continue
+		if(M.pixel_y != 0 || M.pixel_x != 0)
+			continue
+		to_chat(world, "[M] ignited [formatJumpTo(M.loc)]")
+		if(prob(60))
+			spark(M, 5)
+		if(prob(40))
+			M.ignite(T0C+35000)
+		if(prob(15))
+			break

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -1253,6 +1253,7 @@
 #include "code\modules\events\comms_blackout.dm"
 #include "code\modules\events\communications_blackout.dm"
 #include "code\modules\events\disease_outbreak.dm"
+#include "code\modules\events\electrical_fire.dm"
 #include "code\modules\events\electrical_storm.dm"
 #include "code\modules\events\event.dm"
 #include "code\modules\events\event_dynamic.dm"


### PR DESCRIPTION
Requested by Mattman in the discord

Same as the electrical blowout event which blows out the lights in an area, this causes machines to set alight in the same sort of areas.

Machines that are on fire spark and consume much more electricity than normal, and currently do nothing else. Will need to develop on it.