### PR TITLE
PDA multicaster fixes

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -975,10 +975,10 @@ obj/item/weapon/circuitboard/rdserver
 
 // Telecomms circuit boards:
 
-/obj/item/weapon/circuitboard/telecomms/pda_multicaster
+/obj/item/weapon/circuitboard/pda_multicaster
 	name = "Circuit Board (PDA multicaster)"
 	desc = "A circuit board used to run a machine that resends messages."
-	build_path = "/obj/machinery/telecomms/pda_multicaster"
+	build_path = "/obj/machinery/pda_multicaster"
 	board_type = MACHINE
 	origin_tech = Tc_PROGRAMMING + "=4;" + Tc_ENGINEERING + "=3;" + Tc_BLUESPACE + "=2"
 	req_components = list(

--- a/code/game/machinery/telecomms/multicaster.dm
+++ b/code/game/machinery/telecomms/multicaster.dm
@@ -1,58 +1,64 @@
-/obj/machinery/telecomms/pda_multicaster
+var/list/pda_multicasters = list()
+
+/obj/machinery/pda_multicaster
 	name = "\improper PDA multicaster"
 	desc = "Duplicates messages and sends copies to departments."
 	icon = 'icons/obj/machines/telecomms.dmi'
-	icon_state = "pda_server"
+	icon_state = "pda_server-on"
 	density = 1
 	anchored = 1
 	use_power = 1
 	idle_power_usage = 750
 	var/obj/item/device/pda/camo/CAMO
+	var/on = TRUE
 
-/obj/machinery/telecomms/pda_multicaster/New()
+/obj/machinery/pda_multicaster/New()
 	..()
 	CAMO = new(src)
+	pda_multicasters.Add(src)
 
-/obj/machinery/telecomms/pda_multicaster/prebuilt/New()
+/obj/machinery/pda_multicaster/prebuilt/New()
 	..()
 
 	component_parts = newlist(
-		/obj/item/weapon/circuitboard/telecomms/pda_multicaster,
+		/obj/item/weapon/circuitboard/pda_multicaster,
 		/obj/item/weapon/stock_parts/subspace/filter,
 		/obj/item/weapon/stock_parts/manipulator
 	)
 
 	RefreshParts()
 
-/obj/machinery/telecomms/pda_multicaster/Destroy()
-	qdel(CAMO)
+/obj/machinery/pda_multicaster/Destroy()
+	pda_multicasters.Remove(src)
+	if(CAMO)
+		qdel(CAMO)
+		CAMO = null
 	..()
 
-/obj/machinery/telecomms/pda_multicaster/update_icon()
+/obj/machinery/pda_multicaster/update_icon()
 	if(stat & (BROKEN|NOPOWER|EMPED))
 		icon_state = "pda_server-nopower"
 	else
 		icon_state = "pda_server-[on ? "on" : "off"]"
 
-/obj/machinery/telecomms/pda_multicaster/attack_ai(mob/user)
-	attack_hand(user)
-
-/obj/machinery/telecomms/pda_multicaster/attack_hand(mob/user)
+/obj/machinery/pda_multicaster/attack_hand(mob/user)
+	if(user.incapacitated() && !isAdminGhost(user))
+		return
 	toggle_power(user)
 
-/obj/machinery/telecomms/pda_multicaster/proc/toggle_power(mob/user)
+/obj/machinery/pda_multicaster/proc/toggle_power(mob/user)
 	on = !on
 	visible_message("\the [user] turns \the [src] [on ? "on" : "off"].")
 	update_icon()
 
-/obj/machinery/telecomms/pda_multicaster/proc/check_status()
+/obj/machinery/pda_multicaster/proc/check_status()
 	return !(stat&(BROKEN|NOPOWER|EMPED))&&on
 
-/obj/machinery/telecomms/pda_multicaster/proc/update_PDAs(var/turn_off)
+/obj/machinery/pda_multicaster/proc/update_PDAs(var/turn_off)
 	for(var/obj/item/device/pda/pda in contents)
 		pda.toff = turn_off
 
-/obj/machinery/telecomms/pda_multicaster/proc/multicast(var/target,var/obj/item/device/pda/sender,var/mob/living/U,var/message)
+/obj/machinery/pda_multicaster/proc/multicast(var/target,var/obj/item/device/pda/sender,var/mob/living/U,var/message)
 	var/list/redirection_list = list(
 		"security" = list(/obj/item/device/pda/warden,/obj/item/device/pda/detective,/obj/item/device/pda/security,/obj/item/device/pda/heads/hos),
 		"engineering" = list(/obj/item/device/pda/engineering,/obj/item/device/pda/atmos,/obj/item/device/pda/heads/ce),

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1814,12 +1814,12 @@ var/global/list/obj/item/device/pda/PDAs = list()
 				if (last_text && world.time < last_text + 5)
 					return
 				last_text = world.time
-				for(var/obj/machinery/telecomms/pda_multicaster/multicaster in telecomms_list)
+				for(var/obj/machinery/pda_multicaster/multicaster in pda_multicasters)
 					if(multicaster.check_status())
 						multicaster.multicast(target,src,usr,t)
 						tnote += "<i><b>&rarr; To [target]:</b></i><br>[t]<br>"
 						return
-				to_chat(usr, "[bicon(src)]<span class='warning'>The PDA's screen flashes, 'Error, Messaging server is not responding.'</span>")
+				to_chat(usr, "[bicon(src)]<span class='warning'>The PDA's screen flashes, 'Error, CAMO server is not responding.'</span>")
 
 			if("transferFunds")
 				if(!id)


### PR DESCRIPTION
Fixes #18123 among other things.

In short, the multicaster had no reason for being a `/obj/machinery/telecomms` subtype. That only caused problems (such as turning itself back on every process(), keeping useless vars around, and more!).

