### PR TITLE
Fixes mein lieben still appearing and golden core reactions tweaks

### DIFF
--- a/__DEFINES/global.dm
+++ b/__DEFINES/global.dm
@@ -362,7 +362,7 @@ var/list/available_staff_transforms = list(
 	)
 
 //Broken mob list
-var/global/list/blacklisted_mobs = list(
+var/list/blacklisted_mobs = list(
 		/mob/living/simple_animal/space_worm, // Unfinished. Very buggy, they seem to just spawn additional space worms everywhere and eating your own tail results in new worms spawning.
 		/mob/living/simple_animal/hostile/humanoid, // JUST DON'T DO IT, OK?
 		/mob/living/simple_animal/hostile/retaliate/cockatrice, // I'm just copying this from transmog.
@@ -375,7 +375,7 @@ var/global/list/blacklisted_mobs = list(
 		)
 
 //Boss monster list
-var/global/list/boss_mobs = list(
+var/list/boss_mobs = list(
 	/mob/living/simple_animal/scp_173,						// Just a statue.
 	/mob/living/simple_animal/hostile/hivebot/tele,			// Hivebot spawner WIP thing
 	/mob/living/simple_animal/hostile/wendigo,				// Stupid strong evolving creature things that scream for help

--- a/__DEFINES/global.dm
+++ b/__DEFINES/global.dm
@@ -370,7 +370,7 @@ var/global/list/blacklisted_mobs = list(
 		/mob/living/simple_animal/hostile/asteroid/hivelordbrood, // They aren't supposed to be playable.
 		/mob/living/simple_animal/hologram, // Can't live outside the holodeck.
 		/mob/living/slime_pile, // They are dead.
-		/mob/living/adamantine_dust // Ditto
+		/mob/living/adamantine_dust, // Ditto
 		/mob/living/simple_animal/hostile/mining_drone //This thing is super broken in the hands of a player and it was never meant to be summoned out of actual mining drone cubes.
 		)
 

--- a/__DEFINES/global.dm
+++ b/__DEFINES/global.dm
@@ -362,7 +362,7 @@ var/list/available_staff_transforms = list(
 	)
 
 //Broken mob list
-var/list/blacklisted_mobs = list(
+var/global/list/blacklisted_mobs = list(
 		/mob/living/simple_animal/space_worm, // Unfinished. Very buggy, they seem to just spawn additional space worms everywhere and eating your own tail results in new worms spawning.
 		/mob/living/simple_animal/hostile/humanoid, // JUST DON'T DO IT, OK?
 		/mob/living/simple_animal/hostile/retaliate/cockatrice, // I'm just copying this from transmog.
@@ -371,10 +371,11 @@ var/list/blacklisted_mobs = list(
 		/mob/living/simple_animal/hologram, // Can't live outside the holodeck.
 		/mob/living/slime_pile, // They are dead.
 		/mob/living/adamantine_dust // Ditto
+		/mob/living/simple_animal/hostile/mining_drone //This thing is super broken in the hands of a player and it was never meant to be summoned out of actual mining drone cubes.
 		)
 
 //Boss monster list
-var/list/boss_mobs = existing_typesof(
+var/global/list/boss_mobs = list(
 	/mob/living/simple_animal/scp_173,						// Just a statue.
 	/mob/living/simple_animal/hostile/hivebot/tele,			// Hivebot spawner WIP thing
 	/mob/living/simple_animal/hostile/wendigo,				// Stupid strong evolving creature things that scream for help

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -1202,21 +1202,17 @@
 		sleep(50)
 
 	var/blocked = existing_typesof(
-		/mob/living/simple_animal/hostile/humanoid,
-		/mob/living/simple_animal/hostile/asteroid,
-		/mob/living/simple_animal/hostile/faithless,
+		/mob/living/simple_animal/hostile/faithless/cult,
 		/mob/living/simple_animal/hostile/scarybat/cult,
 		/mob/living/simple_animal/hostile/creature/cult,
 		/mob/living/simple_animal/hostile/retaliate/clown,
 		/mob/living/simple_animal/hostile/mushroom,
 		/mob/living/simple_animal/hostile/carp/holocarp,
 		/mob/living/simple_animal/hostile/slime,
-		/mob/living/simple_animal/hostile/mining_drone,
 		/mob/living/simple_animal/hostile/mimic,
-		/mob/living/simple_animal/hostile/retaliate/cockatrice
-		)//Exclusion list for things you don't want the reaction to create.
+		) + existing_typesof(boss_mobs) + existing_typesof(blacklisted_mobs)//Exclusion list for things you don't want the reaction to create.
 
-	var/list/critters = existing_typesof(/mob/living/simple_animal/hostile) - blocked - boss_mobs//List of possible hostile mobs
+	var/list/critters = existing_typesof(/mob/living/simple_animal/hostile) - blocked //List of possible hostile mobs
 
 	playsound(holder.my_atom, 'sound/effects/phasein.ogg', 100, 1)
 
@@ -1255,8 +1251,7 @@
 		holder.my_atom.visible_message("<span class='warning'>The slime extract begins to vibrate violently !</span>")
 		sleep(50)
 
-	var/blocked = list(
-		/mob/living/simple_animal/hostile/alien/queen/large,
+	var/blocked = existing_typesof(
 		/mob/living/simple_animal/hostile/retaliate/clown,
 		/mob/living/simple_animal/hostile/mushroom,
 		/mob/living/simple_animal/hostile/carp/holocarp,
@@ -1264,9 +1259,8 @@
 		/mob/living/simple_animal/hostile/scarybat/cult,
 		/mob/living/simple_animal/hostile/creature/cult,
 		/mob/living/simple_animal/hostile/slime,
-		/mob/living/simple_animal/hostile/hivebot/tele, //This thing spawns hostile mobs
-		/mob/living/simple_animal/hostile/mining_drone,
-		) + typesof(/mob/living/simple_animal/hostile/humanoid) + typesof(/mob/living/simple_animal/hostile/asteroid) //Exclusion list for things you don't want the reaction to create.
+		) + existing_typesof(boss_mobs) + existing_typesof(blacklisted_mobs)//Exclusion list for things you don't want the reaction to create.
+
 	var/list/critters = existing_typesof(/mob/living/simple_animal/hostile) - blocked //List of possible hostile mobs
 
 	playsound(holder.my_atom, 'sound/effects/phasein.ogg', 100, 1)


### PR DESCRIPTION
* Added the **blacklisted_mobs** and **boss_mobs** lists to the **blocked** list of both golden core reactions
* Added mining drones to the **blacklisted_mobs** list
* Made the **blacklisted_mobs** list a simple parent list instead of an existing_typesof list
* Made the blocked blood golden core reaction become an existing_typesof list
* Removed asteroid mobs from the **blocked** list, except for the hivelord brood.
* Fixed plasma golden core reaction not spawning normal faithless