### PR TITLE
Fixes vaporizer infinitely looping on full mixing chamber

### DIFF
--- a/code/game/machinery/atmoalter/vaporizer.dm
+++ b/code/game/machinery/atmoalter/vaporizer.dm
@@ -80,7 +80,7 @@
 		on = 0
 		return
 	mixing_chamber.flags |= NOREACT
-	while(target>0)
+	while(target>0 && !mixing_chamber.is_full())
 		//First, try to pull out from the main tank
 		if(reagents.has_reagent(rid))
 			target -= reagents.trans_id_to(mixing_chamber,rid,min(target,1))


### PR DESCRIPTION
Fixes #18267

:cl:
* bugfix: Fixed industrial vaporizer having a full mixing chamber crashing the serb.