### PR TITLE
Adds manual frequency setpoint for headsets, station bounced radios, and intercoms

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -97,12 +97,7 @@
 
 	dat += {"
 				Speaker: [listening ? "<A href='byond://?src=\ref[src];listen=0'>Engaged</A>" : "<A href='byond://?src=\ref[src];listen=1'>Disengaged</A>"]<BR>
-				Frequency:
-				<A href='byond://?src=\ref[src];freq=-10'>-</A>
-				<A href='byond://?src=\ref[src];freq=-2'>-</A>
-				[format_frequency(frequency)]
-				<A href='byond://?src=\ref[src];freq=2'>+</A>
-				<A href='byond://?src=\ref[src];freq=10'>+</A><BR>
+				Frequency: <A href='byond://?src=\ref[src];set_freq=-1'>[format_frequency(frequency)]</a><BR>
 				"}
 
 	for (var/ch_name in channels)
@@ -164,11 +159,14 @@
 
 		return
 
-	else if (href_list["freq"])
-		var/new_frequency = (frequency + text2num(href_list["freq"]))
-		if (!freerange || (frequency < 1200 || frequency > 1600))
+	else if("set_freq" in href_list)
+		var/new_frequency=frequency
+		if(href_list["set_freq"]!="-1")
+			new_frequency = text2num(href_list["set_freq"])
+		else
+			new_frequency = input(usr, "Set a new frequency (1200-1600 kHz).", src, frequency) as null|num
 			new_frequency = sanitize_frequency(new_frequency, maxf)
-		set_frequency(new_frequency)
+			set_frequency(new_frequency)
 		if(hidden_uplink)
 			if(hidden_uplink.check_trigger(usr, frequency, traitor_frequency))
 				usr << browse(null, "window=radio")

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -171,13 +171,9 @@
 		return
 
 	else if("set_freq" in href_list)
-		new_frequency=frequency
-		if(href_list["set_freq"]!="-1")
-			new_frequency = text2num(href_list["set_freq"])
-		else
-			new_frequency = input(usr, "Set a new frequency (1200-1600 kHz).", src, frequency) as null|num
-			new_frequency = sanitize_frequency(new_frequency, maxf)
-			set_frequency(new_frequency)
+		new_frequency = input(usr, "Set a new frequency (1200-1600 kHz).", src, frequency) as null|num
+		new_frequency = sanitize_frequency(new_frequency, maxf)
+		set_frequency(new_frequency)
 		if (check_traitor_uplink(frequency))
 			return
 

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -176,13 +176,12 @@
 		if(href_list["set_freq"]!="-1")
 			new_frequency = text2num(href_list["set_freq"])
 		else
-			new_frequency = input(usr, "Set a new frequency (1200-1600 KHz).", src, frequency) as null|num
+			new_frequency = input(usr, "Set a new frequency (1200-1600 kHz).", src, frequency) as null|num
 			new_frequency = sanitize_frequency(new_frequency, maxf)
 			set_frequency(new_frequency)
 		check_traitor_uplink(frequency)
 
 	else if (href_list["freq"])
-		new_frequency=frequency
 		new_frequency = (frequency + text2num(href_list["freq"]))
 		new_frequency = sanitize_frequency(new_frequency, maxf)
 		set_frequency(new_frequency)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -128,8 +128,7 @@
 	if(hidden_uplink)
 		if(hidden_uplink.check_trigger(usr, frequency, traitor_frequency))
 			usr << browse(null, "window=radio")
-			return
-	return
+			return 1
 
 /obj/item/device/radio/Topic(href, href_list)
 	var/new_frequency
@@ -179,13 +178,15 @@
 			new_frequency = input(usr, "Set a new frequency (1200-1600 kHz).", src, frequency) as null|num
 			new_frequency = sanitize_frequency(new_frequency, maxf)
 			set_frequency(new_frequency)
-		check_traitor_uplink(frequency)
+		if (check_traitor_uplink(frequency))
+			return
 
 	else if (href_list["freq"])
 		new_frequency = (frequency + text2num(href_list["freq"]))
 		new_frequency = sanitize_frequency(new_frequency, maxf)
 		set_frequency(new_frequency)
-		check_traitor_uplink(frequency)
+		if (check_traitor_uplink(frequency))
+			return
 
 	else if (href_list["talk"])
 		broadcasting = text2num(href_list["talk"])

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -7,7 +7,6 @@
 	var/on = 1 // 0 for off
 	var/last_transmission
 	var/frequency = 1459 //common chat
-	var/new_frequency
 	var/traitor_frequency = 0 //tune to frequency to unlock traitor supplies
 	var/canhear_range = 3 // the range which mobs can hear this radio from
 	var/obj/item/device/radio/patch_link = null
@@ -130,9 +129,10 @@
 		if(hidden_uplink.check_trigger(usr, frequency, traitor_frequency))
 			usr << browse(null, "window=radio")
 			return
+	return
 
 /obj/item/device/radio/Topic(href, href_list)
-	//..()
+	var/new_frequency
 	if (usr.stat || !on)
 		return
 

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -131,7 +131,6 @@
 			return 1
 
 /obj/item/device/radio/Topic(href, href_list)
-	var/new_frequency
 	if (usr.stat || !on)
 		return
 
@@ -171,6 +170,7 @@
 		return
 
 	else if("set_freq" in href_list)
+		var/new_frequency
 		new_frequency = input(usr, "Set a new frequency (1200-1600 kHz).", src, frequency) as null|num
 		new_frequency = sanitize_frequency(new_frequency, maxf)
 		set_frequency(new_frequency)
@@ -178,6 +178,7 @@
 			return
 
 	else if (href_list["freq"])
+		var/new_frequency
 		new_frequency = (frequency + text2num(href_list["freq"]))
 		new_frequency = sanitize_frequency(new_frequency, maxf)
 		set_frequency(new_frequency)


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl:
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
What it says on the tin. Enter a specific frequency using a manual input rather than fiddling with the +- knob on your headset/SBR/intercom. Discussed in #18276 to some extent. 

:cl:
 * rscadd: headsets, station bounced radios, and station intercoms now allow direct frequency input