### PR TITLE
50% discount on Ring of Fire

### DIFF
--- a/code/modules/spells/general/ring_of_fire.dm
+++ b/code/modules/spells/general/ring_of_fire.dm
@@ -14,6 +14,7 @@
 	invocation = "E ROHA"
 	invocation_type = SpI_SHOUT
 	hud_state = "wiz_firering"
+	price = Sp_BASE_PRICE / 2
 
 	duration = 100
 	range = 3


### PR DESCRIPTION
Grab it while it's hot! Come home, pyromancer wizard.

Fully upgraded version (permanent ring of fire that moves with you) now costs only 50 points, down from 100

Why? Its damage output is rather disappointing, it doesn't incapacitate enemies outright, and its defensive side is very situational

:cl:
 * tweak: Ring of fire and its upgrades now cost 10 spell points (down from 20)
