### PR TITLE
Fixed butterfly knife runtime

### DIFF
--- a/code/game/objects/items/weapons/butterfly.dm
+++ b/code/game/objects/items/weapons/butterfly.dm
@@ -65,11 +65,11 @@
 		else
 			fold()
 
-/obj/item/weapon/butterflyknife/proc/rearm(mob/user)
+/obj/item/weapon/butterflyknife/proc/rearm()
 	counting = null
 	bug = initial(bug)
 	playsound(src, 'sound/items/healthanalyzer.ogg', 10, 1)
-	to_chat(user, "<span class='notice'>\The [src] chimes.</span>")
+	visible_message("<span class='notice'>\The [src] chimes.</span>")
 
 /obj/item/weapon/butterflyknife/proc/unfold()
 	open = TRUE


### PR DESCRIPTION
```
[11:43:29] Runtime in browserOutput.dm,264: DEBUG: Boutput called with invalid message
  proc name: to chat (/proc/to_chat)
  src: null
  call stack:
  to chat(null, "<span class=\'notice\'>The but...")
  the butterfly knife (/obj/item/weapon/butterflyknife/viscerator): rearm(null)
  the butterfly knife (/obj/item/weapon/butterflyknife/viscerator): process()
  Objects (/datum/subsystem/obj): fire(0)
  Objects (/datum/subsystem/obj): ignite(0)
  Master (/datum/controller/master): RunQueue()
  Master (/datum/controller/master): Loop()
  Master (/datum/controller/master): StartProcessing()
```