### PR TITLE
Fixed spiritbreaker being invisible

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -2996,7 +2996,7 @@
 	id = SPIRITBREAKER
 	description = "An extremely dangerous hallucinogen often used for torture. Extracted from the leaves of the rare Ambrosia Cruciatus plant."
 	reagent_state = LIQUID
-	color = "3B0805" //rgb: 59, 8, 5
+	color = "#3B0805" //rgb: 59, 8, 5
 	custom_metabolism = 0.05
 
 /datum/reagent/spiritbreaker/on_mob_life(var/mob/living/M)


### PR DESCRIPTION
...and causing countless runtimes
```
x9 bottle.dm,82: bad icon operation
  proc name: update icon (/obj/item/weapon/reagent_containers/glass/bottle/update_icon)
  usr: Darin Edwards (lunstra) (/mob/living/carbon/human)
  usr.loc: The floor (273, 256, 1) (/turf/simulated/floor)
  src: Space Drugs (30 units) bottle (/obj/item/weapon/reagent_containers/glass/bottle/unrecyclable)
  src.loc: the floor (272,255,1) (/turf/simulated/floor)
  call stack:
  Space Drugs (30 units) bottle (/obj/item/weapon/reagent_containers/glass/bottle/unrecyclable): update icon()
  Space Drugs (30 units) bottle (/obj/item/weapon/reagent_containers/glass/bottle/unrecyclable): on reagent change()
  /datum/reagents (/datum/reagents): add reagent("spiritbreaker", 30, null, 293)
  /datum/reagents (/datum/reagents): trans to(Space Drugs (30 units) bottle (/obj/item/weapon/reagent_containers/glass/bottle/unrecyclable), 30, 1, 1, 0, null)
  the ChemMaster 3000 (/obj/machinery/chem_master): Topic("src=\[0x20087ed];createbottle=...", /list (/list))
  Lunstra (/client): Topic("src=\[0x20087ed];createbottle=...", /list (/list), the ChemMaster 3000 (/obj/machinery/chem_master))
  Lunstra (/client): Topic("src=\[0x20087ed];createbottle=...", /list (/list), the ChemMaster 3000 (/obj/machinery/chem_master))
```