### PR TITLE
Fixed merch computer runtimes

### DIFF
--- a/code/modules/store/store.dm
+++ b/code/modules/store/store.dm
@@ -54,12 +54,12 @@ var/global/datum/store/centcomm_store=new
 		D = linked_db.attempt_account_access(card.associated_account_number, 0, 2, 0)
 		using_account = "Bank Account"
 		if(!D)								//first we check if there IS a bank account in the first place
-			to_chat(usr, "[bicon(src)]<span class='warning'>You don't have that much money on your virtual wallet!</span>")
-			to_chat(usr, "[bicon(src)]<span class='warning'>Unable to access your bank account.</span>")
+			to_chat(usr, "[bicon(merchcomp)]<span class='warning'>You don't have that much money on your virtual wallet!</span>")
+			to_chat(usr, "[bicon(merchcomp)]<span class='warning'>Unable to access your bank account.</span>")
 			return 0
 		else if(D.security_level > 0)		//next we check if the security is low enough to pay directly from it
-			to_chat(usr, "[bicon(src)]<span class='warning'>You don't have that much money on your virtual wallet!</span>")
-			to_chat(usr, "[bicon(src)]<span class='warning'>Lower your bank account's security settings if you wish to pay directly from it.</span>")
+			to_chat(usr, "[bicon(merchcomp)]<span class='warning'>You don't have that much money on your virtual wallet!</span>")
+			to_chat(usr, "[bicon(merchcomp)]<span class='warning'>Lower your bank account's security settings if you wish to pay directly from it.</span>")
 			return 0
 		else if(D.money < amount)			//and lastly we check if there's enough money on it, duh
 			to_chat(user, "[bicon(merchcomp)]<span class='warning'>You don't have that much money on your bank account!</span>")


### PR DESCRIPTION
```
[10:45:01] Runtime in browserOutput.dm,224: undefined variable /datum/store/var/icon
  proc name: bicon (/proc/bicon)
  usr: Gerardo Kanaga (lolimilkaparatus) (/mob/living/carbon/human)
  usr.loc: The floor (207, 233, 1) (/turf/simulated/floor)
  src: null
  call stack:
  bicon(/datum/store (/datum/store))
  /datum/store (/datum/store): charge(Gerardo Kanaga (/mob/living/carbon/human), 400, Boombox (/datum/storeitem/boombox), Merch Computer (/obj/machinery/computer/merch))
  /datum/store (/datum/store): PlaceOrder(Gerardo Kanaga (/mob/living/carbon/human), "/datum/storeitem/boombox", Merch Computer (/obj/machinery/computer/merch))
  Merch Computer (/obj/machinery/computer/merch): Topic("src=\[0x2006b3c];choice=buy;ch...", /list (/list))
  LoliMilkAparatus (/client): Topic("src=\[0x2006b3c];choice=buy;ch...", /list (/list), Merch Computer (/obj/machinery/computer/merch))
  LoliMilkAparatus (/client): Topic("src=\[0x2006b3c];choice=buy;ch...", /list (/list), Merch Computer (/obj/machinery/computer/merch))
```
