### PR TITLE
Tweaked isspecies defines

### DIFF
--- a/__DEFINES/_macros.dm
+++ b/__DEFINES/_macros.dm
@@ -4,7 +4,7 @@
 // fun if you want to typecast humans/monkeys/etc without writing long path-filled lines.
 #define ishuman(A) istype(A, /mob/living/carbon/human)
 
-#define isjusthuman(A) (ishuman(A) && A.species && istype(A.species, /datum/species/human))
+#define isjusthuman(A) (ishuman(A) && istype(A:species, /datum/species/human))
 
 #define ismonkey(A) istype(A, /mob/living/carbon/monkey)
 
@@ -12,33 +12,33 @@
 
 #define ishigherbeing(A) (ishuman(A) || ismartian(A) || (ismonkey(A) && A.dexterity_check()))
 
-#define isvox(A) (ishuman(A) && A.species && istype(A.species, /datum/species/vox))
+#define isvox(A) (ishuman(A) && istype(A:species, /datum/species/vox))
 
-#define isdiona(A) (ishuman(A) && A.species && istype(A.species, /datum/species/diona))
+#define isdiona(A) (ishuman(A) && istype(A:species, /datum/species/diona))
 
-#define isgrey(A) (ishuman(A) && A.species && istype(A.species, /datum/species/grey))
+#define isgrey(A) (ishuman(A) && istype(A:species, /datum/species/grey))
 
-#define isplasmaman(A) (ishuman(A) && A.species && istype(A.species, /datum/species/plasmaman))
+#define isplasmaman(A) (ishuman(A) && istype(A:species, /datum/species/plasmaman))
 
-#define isskellington(A) (ishuman(A) && A.species && istype(A.species, /datum/species/skellington))
+#define isskellington(A) (ishuman(A) && istype(A:species, /datum/species/skellington))
 
-#define iscatbeast(A) (ishuman(A) && A.species && istype(A.species, /datum/species/tajaran))
+#define iscatbeast(A) (ishuman(A) && istype(A:species, /datum/species/tajaran))
 
-#define isunathi(A) (ishuman(A) && A.species && istype(A.species, /datum/species/unathi))
+#define isunathi(A) (ishuman(A) && istype(A:species, /datum/species/unathi))
 
-#define isskrell(A) (ishuman(A) && A.species && istype(A.species, /datum/species/skrell))
+#define isskrell(A) (ishuman(A) && istype(A:species, /datum/species/skrell))
 
-#define ismuton(A) (ishuman(A) && A.species && istype(A.species, /datum/species/muton))
+#define ismuton(A) (ishuman(A) && istype(A:species, /datum/species/muton))
 
-#define isgolem(A) (ishuman(A) && A.species && istype(A.species, /datum/species/golem))
+#define isgolem(A) (ishuman(A) && istype(A:species, /datum/species/golem))
 
 #define isslimeperson(A) (ishuman(A) && istype(A:species, /datum/species/slime))
 
-#define ishorrorform(A) (ishuman(A) && A.species && istype(A.species, /datum/species/horror))
+#define ishorrorform(A) (ishuman(A) && istype(A:species, /datum/species/horror))
 
-#define isgrue(A) (ishuman(A) && A.species && istype(A.species, /datum/species/grue))
+#define isgrue(A) (ishuman(A) && istype(A:species, /datum/species/grue))
 
-#define ismushroom(A) ((ishuman(A) && A.species && istype(A.species, /datum/species/mushroom)) || (istype(A, /mob/living/carbon/monkey/mushroom)))
+#define ismushroom(A) ((ishuman(A) && istype(A:species, /datum/species/mushroom)) || (istype(A, /mob/living/carbon/monkey/mushroom)))
 
 #define ishologram(A) (istype(A, /mob/living/simple_animal/hologram/advanced))
 


### PR DESCRIPTION
### ???
Changed the is[species] defines to not require casting the local variable to human.

### Why?
Previously you had to write code like this to even get it to compile, due to how the macros were written:
```
if(ishuman(C))
	var/mob/living/carbon/human/H = C
	if(isslimeperson(H))
		do_the_thing()
```
So you're doing an extra `ishuman()` check.

With this change you can just do
```
if(isslimeperson(H))
	do_the_thing()
```
because the `isslimeperson` macro now accesses the species var via the `:` operator.