### PR TITLE
pAI signup verb for ghosts

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -1013,3 +1013,13 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	var/mob/M = get_top_transmogrification()
 	return (M && M.client && can_reenter_corpse)
 
+/mob/dead/observer/verb/pai_signup()
+	set name = "Sign up as pAI"
+	set category = "Ghost"
+	set desc = "Create and submit your pAI personality"
+
+	if(!paiController.check_recruit(src))
+		to_chat(src, "<span class='warning'>Not available. You may have been pAI-banned.</span>")
+		return
+
+	paiController.recruitWindow(src)

--- a/code/modules/mob/living/silicon/pai/recruit.dm
+++ b/code/modules/mob/living/silicon/pai/recruit.dm
@@ -90,7 +90,7 @@ var/datum/paiController/paiController			// Global handler for pAI candidates
 				if(candidate)
 					candidate.ready = 1
 					for(var/obj/item/device/paicard/p in world)
-						if(p.looking_for_personality == 1)
+						if(!p.pai)
 							p.alertUpdate()
 				usr << browse(null, "window=paiRecruit")
 				return


### PR DESCRIPTION
:cl:
* rscadd: Created a "Sign up as pAI" verb in the Ghost tab for submitting a pAI profile without having to be around for the recruitment prompts.