### PR TITLE
Deals with the contents of a destroyed AI card

### DIFF
--- a/code/game/objects/items/devices/aicard.dm
+++ b/code/game/objects/items/devices/aicard.dm
@@ -135,3 +135,13 @@
 		if(3.0)
 			if(prob(25))
 				qdel(src)
+
+/obj/item/device/aicard/Destroy()
+	for(var/mob/living/M in src)
+		if(!isAI(M) && loc) //I don't know how this happened but you never know
+			M.forceMove(loc)
+		else
+			M.death(1)
+			M.ghostize()
+			qdel(M)
+	..()


### PR DESCRIPTION
...instead of nullspacing them.
Fixes #16710
Fixes #18310 

:cl:
* bugfix: Destroying an AI card now properly kills an AI inside it, instead of just sending it to the Shadow Realm.