### PR TITLE
Deletes contents of movable atoms on Destroy()

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -107,6 +107,9 @@
 			if(VH.attached == src)
 				returnToPool(VH)
 
+	for(var/atom/movable/AM in src)
+		qdel(AM)
+
 	..()
 
 /proc/delete_profile(var/type, code = 0)


### PR DESCRIPTION
As suggested in https://github.com/vgstation-coders/vgstation13/issues/16710#issuecomment-350478398
Fixes #16710
Fixes #18310
Fixes #12869
Fixes #15454
Fixes #7161
Fixes #17087 (?) (However, now you'll just get deleted instead.)

Did some very basic testing so far. Can confirm that closets and crates drop contents instead of deleting them so that's good.