### PR TITLE
Fixes simple animal zero emote stings runtime

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/wolf.dm
+++ b/code/modules/mob/living/simple_animal/hostile/wolf.dm
@@ -31,6 +31,7 @@
 	icon_living = "wolf"
 	icon_dead = "wolf_dead"
 	speak_chance = 5
+	emote_hear = list("growls", "howls")
 	turns_per_move = 4
 	response_help = "pets"
 	response_disarm = "gently pushes aside"

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -325,6 +325,9 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 
 /mob/living/simple_animal/proc/handle_automated_speech()
 
+	if(!(speak.len || emote_hear.len || emote_see.len))
+		return
+
 	var/someone_in_earshot=0
 	if(!client && speak_chance && ckey == null) // Remove this if earshot is used elsewhere.
 		// All we're doing here is seeing if there's any CLIENTS nearby.


### PR DESCRIPTION
Fixes:
```
x27 simple_animal.dm,338: At least one element must have non-zero probability
  proc name: handle automated speech (/mob/living/simple_animal/proc/handle_automated_speech)
  src: the wolf alpha (410) (/mob/living/simple_animal/hostile/wolf/alpha)
  src.loc: the floor (253,248,1) (/turf/simulated/floor/wood)
  call stack:
  the wolf alpha (410) (/mob/living/simple_animal/hostile/wolf/alpha): handle automated speech()
  the wolf alpha (410) (/mob/living/simple_animal/hostile/wolf/alpha): Life()
  the wolf alpha (410) (/mob/living/simple_animal/hostile/wolf/alpha): Life()
  the wolf alpha (410) (/mob/living/simple_animal/hostile/wolf/alpha): Life()
  Mob (/datum/subsystem/mob): fire(0)
  Mob (/datum/subsystem/mob): ignite(0)
  Master (/datum/controller/master): RunQueue()
  Master (/datum/controller/master): Loop()
  Master (/datum/controller/master): StartProcessing()
```