### PR TITLE
Adds More Shit To Autolathes.

### DIFF
--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -396,7 +396,7 @@
 	layer = OPEN_DOOR_LAYER
 	icon_state = "beartrap0"
 	desc = "A trap used to catch bears and other legged creatures."
-	starting_materials = list(MAT_IRON = 12500)
+	starting_materials = list(MAT_IRON = 50000)
 	w_type = RECYK_METAL
 	var/armed = 0
 	var/obj/item/weapon/grenade/iedcasing/IED = null

--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -396,6 +396,8 @@
 	layer = OPEN_DOOR_LAYER
 	icon_state = "beartrap0"
 	desc = "A trap used to catch bears and other legged creatures."
+	starting_materials = list(MAT_IRON = 12500)
+	w_type = RECYK_METAL
 	var/armed = 0
 	var/obj/item/weapon/grenade/iedcasing/IED = null
 

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -44,7 +44,6 @@
 		new /obj/item/weapon/wrench(), \
 		new /obj/item/weapon/solder(),\
 		new /obj/item/weapon/wirecutters/clippers(),\
-		new /obj/item/weapon/hatchet(),\
 		new /obj/item/weapon/minihoe(),\
 		new /obj/item/device/analyzer(), \
 		new /obj/item/weapon/pickaxe/shovel/spade(), \
@@ -58,7 +57,6 @@
 		new /obj/item/weapon/reagent_containers/food/drinks/mug(), \
 		new /obj/item/weapon/storage/toolbox(), \
 		new /obj/item/weapon/reagent_containers/glass/jar(), \
-		new /obj/item/weapon/reagent_containers/spray(),\
 		),
 		"Assemblies"=list(
 		new /obj/item/device/assembly/igniter(), \

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -112,9 +112,10 @@
 		new /obj/item/weapon/razor(), \
 		new /obj/item/device/rcd/tile_painter(), \
 		new /obj/item/device/rcd/matter/rsf(), \
-		new /obj/item/device/destTagger, \
-		new /obj/item/device/priceTagger, \
-		new /obj/item/device/breathalyzer, \
+		new /obj/item/device/destTagger(), \
+		new /obj/item/device/priceTagger(), \
+		new /obj/item/weapon/hand_labeler(), \
+		new /obj/item/device/breathalyzer(), \
 		),
 		"Misc_Other"=list(
 		new /obj/item/weapon/rcd_ammo(), \

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -43,6 +43,9 @@
 		new /obj/item/weapon/wirecutters(), \
 		new /obj/item/weapon/wrench(), \
 		new /obj/item/weapon/solder(),\
+		new /obj/item/weapon/wirecutters/clippers(),\
+		new /obj/item/weapon/hatchet(),\
+		new /obj/item/weapon/minihoe(),\
 		new /obj/item/device/analyzer(), \
 		new /obj/item/weapon/pickaxe/shovel/spade(), \
 		new /obj/item/device/silicate_sprayer/empty(), \
@@ -55,6 +58,7 @@
 		new /obj/item/weapon/reagent_containers/food/drinks/mug(), \
 		new /obj/item/weapon/storage/toolbox(), \
 		new /obj/item/weapon/reagent_containers/glass/jar(), \
+		new /obj/item/weapon/reagent_containers/spray(),\
 		),
 		"Assemblies"=list(
 		new /obj/item/device/assembly/igniter(), \
@@ -136,6 +140,7 @@
 		new /obj/item/ammo_casing/shotgun(), \
 		new /obj/item/ammo_casing/shotgun/dart(), \
 		new /obj/item/ammo_casing/shotgun/buckshot(),\
+		new /obj/item/weapon/legcuffs/beartrap(),\
 		)
 	)
 

--- a/code/modules/hydroponics/hydro_tools.dm
+++ b/code/modules/hydroponics/hydro_tools.dm
@@ -325,6 +325,8 @@
 	force = 5.0
 	throwforce = 7.0
 	w_class = W_CLASS_SMALL
+	starting_materials = list(MAT_IRON = 50)
+	w_type = RECYK_METAL
 	attack_verb = list("slashes", "slices", "cuts", "claws")
 
 
@@ -418,6 +420,8 @@
 	siemens_coefficient = 1
 	force = 12.0
 	w_class = W_CLASS_SMALL
+	starting_materials = list(MAT_IRON = 5000)
+	w_type = RECYK_METAL
 	throwforce = 15.0
 	throw_speed = 4
 	throw_range = 4

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -4,6 +4,8 @@
 	icon_state = "labeler0"
 	item_state = "labeler0"
 	origin_tech = Tc_MATERIALS + "=1"
+	starting_materials = list(MAT_IRON = 200, MAT_GLASS = 175)
+	w_type = RECYK_MISC
 	var/label = null
 	var/chars_left = 250 //Like in an actual label maker, uses an amount per character rather than per label.
 	var/mode = 0	//off or on.

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -8,6 +8,8 @@
 	slot_flags = SLOT_BELT
 	throwforce = 3
 	w_class = W_CLASS_SMALL
+	starting_materials = list(MAT_GLASS = 3500)
+	w_type = RECYK_GLASS
 	throw_speed = 2
 	throw_range = 10
 	amount_per_transfer_from_this = 10


### PR DESCRIPTION
Been sitting on this for a good week cause I kept forgetting to PR it. 

Adds several things to autolathes. 

Notably Botany tools (Cause seriously, if a lathe can make wirecutters why can't it make plant clippers? Same goes for minihoes and whatnot.) As well hand labelers, and contraband bear traps by player request.

Tested and works.

:cl:
 * rscadd: Adds several items to autolathes that felt like they were missing/were requested. Including some botany tools, hand labelers, bear traps and so on.