### PR TITLE
Adds a rad_tick readout to bodyscans

### DIFF
--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -324,6 +324,7 @@
 		"oxyloss" = H.getOxyLoss(),
 		"toxloss" = H.getToxLoss(),
 		"rads" = H.radiation,
+		"radtick" = H.rad_tick,
 		"cloneloss" = H.getCloneLoss(),
 		"brainloss" = H.getBrainLoss(),
 		"paralysis" = H.paralysis,
@@ -371,6 +372,8 @@
 	dat += text("[]\t-Burn Severity %: []</font><br><br>", (occ["fireloss"] < 60 ? "<font color='blue'>" : "<font color='red'>"), occ["fireloss"])
 
 	dat += text("[]\tRadiation Level %: []</font><br>", (occ["rads"] < 10 ?"<font color='blue'>" : "<font color='red'>"), occ["rads"])
+	if(occ["radtick"] > 0)
+		dat += text("<font color='red'>Absorbed rads danger index: <b> [occ["radtick"]]</b></font><br>")
 	dat += text("[]\tGenetic Tissue Damage %: []</font><br>", (occ["cloneloss"] < 1 ?"<font color='blue'>" : "<font color='red'>"), occ["cloneloss"])
 	dat += text("[]\tApprox. Brain Damage %: []</font><br>", (occ["brainloss"] < 1 ?"<font color='blue'>" : "<font color='red'>"), occ["brainloss"])
 	dat += text("Paralysis Summary %: [] ([] seconds left!)<br>", occ["paralysis"], round(occ["paralysis"] / 4))

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -373,7 +373,7 @@
 
 	dat += text("[]\tRadiation Level %: []</font><br>", (occ["rads"] < 10 ?"<font color='blue'>" : "<font color='red'>"), occ["rads"])
 	if(occ["radtick"] > 0)
-		dat += text("<font color='red'>Absorbed rads danger index: <b> [occ["radtick"]]</b></font><br>")
+		dat += text("<font color='red'>Absorbed rads danger index: <b>[occ["radtick"]]</b></font><br>")
 	dat += text("[]\tGenetic Tissue Damage %: []</font><br>", (occ["cloneloss"] < 1 ?"<font color='blue'>" : "<font color='red'>"), occ["cloneloss"])
 	dat += text("[]\tApprox. Brain Damage %: []</font><br>", (occ["brainloss"] < 1 ?"<font color='blue'>" : "<font color='red'>"), occ["brainloss"])
 	dat += text("Paralysis Summary %: [] ([] seconds left!)<br>", occ["paralysis"], round(occ["paralysis"] / 4))

--- a/code/modules/mob/living/simple_animal/borer/verbs_attached_chest.dm
+++ b/code/modules/mob/living/simple_animal/borer/verbs_attached_chest.dm
@@ -124,7 +124,7 @@
 		dat += "<font color='red'>Viral pathogen detected in blood stream.</font><br>"
 	dat += text("[]\tRadiation Level %: []</font><br>", (occ["rads"] < 10 ?"<font color='blue'>" : "<font color='red'>"), occ["rads"])
 	if(occ["radtick"] > 0)
-		dat += text("<font color='red'>Absorbed rads danger index: <b> [occ["radtick"]]</b></font><br>")
+		dat += text("<font color='red'>Absorbed rads danger index: <b>[occ["radtick"]]</b></font><br>")
 	dat += text("[]\tGenetic Tissue Damage %: []</font><br>", (occ["cloneloss"] < 1 ?"<font color='blue'>" : "<font color='red'>"), occ["cloneloss"])
 	dat += text("[]\tApprox. Brain Damage %: []</font><br>", (occ["brainloss"] < 1 ?"<font color='blue'>" : "<font color='red'>"), occ["brainloss"])
 	dat += text("Paralysis Summary %: [] ([] seconds left!)<br>", occ["paralysis"], round(occ["paralysis"] / 4))

--- a/code/modules/mob/living/simple_animal/borer/verbs_attached_chest.dm
+++ b/code/modules/mob/living/simple_animal/borer/verbs_attached_chest.dm
@@ -81,6 +81,7 @@
 		"health" = H.health,
 		"virus_present" = H.virus2.len,
 		"rads" = H.radiation,
+		"radtick" = H.rad_tick,
 		"cloneloss" = H.getCloneLoss(),
 		"brainloss" = H.getBrainLoss(),
 		"paralysis" = H.paralysis,
@@ -122,6 +123,8 @@
 	if(occ["virus_present"])
 		dat += "<font color='red'>Viral pathogen detected in blood stream.</font><br>"
 	dat += text("[]\tRadiation Level %: []</font><br>", (occ["rads"] < 10 ?"<font color='blue'>" : "<font color='red'>"), occ["rads"])
+	if(occ["radtick"] > 0)
+		dat += text("<font color='red'>Absorbed rads danger index: <b> [occ["radtick"]]</b></font><br>")
 	dat += text("[]\tGenetic Tissue Damage %: []</font><br>", (occ["cloneloss"] < 1 ?"<font color='blue'>" : "<font color='red'>"), occ["cloneloss"])
 	dat += text("[]\tApprox. Brain Damage %: []</font><br>", (occ["brainloss"] < 1 ?"<font color='blue'>" : "<font color='red'>"), occ["brainloss"])
 	dat += text("Paralysis Summary %: [] ([] seconds left!)<br>", occ["paralysis"], round(occ["paralysis"] / 4))


### PR DESCRIPTION
Now you can really know how fucked somebody is from the radiation system. I labeled the number "Absorbed rads danger index" instead of rad_tick but that's open to change.
:cl:
* rscadd: Body scans now show a number for the progress of radiation poisoning, in addition to the radiation level, which doesn't tell the whole story.