### PR TITLE
Better logging for singularity runtimes

### DIFF
--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -359,6 +359,10 @@
 		catch(var/exception/e)
 			error("Singularity eat() caught exception:")
 			error(e)
+
+			spawn(0) //So the following line doesn't stop execution
+				throw e //So ALL debug information is sent to the runtime log
+
 			continue
 
 	//for(var/turf/T in trange(grav_pull, src)) // TODO: Create a similar trange for orange to prevent snowflake of self check.


### PR DESCRIPTION
The `try`/`catch` that prevents singulo runtimes from fucking up more than one object at a time now *also* sends the runtime to `/world/Error()` (which can't be called manually) so that all debugging information is logged. This should help greatly in diagnosing #18334.

The principle was tested with MoMMI, but since we don't even know how to reproduce that bug, in-game testing is impossible.

An alternative solution would be to put this code in `error()` itself. If people would prefer that, I can do it instead.