### PR TITLE
Fixes plant air somewhat

### DIFF
--- a/code/modules/hydroponics/hydro_tray_process.dm
+++ b/code/modules/hydroponics/hydro_tray_process.dm
@@ -176,17 +176,11 @@
 		for(var/gas in seed.exude_gasses)
 			environment.adjust_gas(gas, max(1,round((seed.exude_gasses[gas]*round(seed.potency))/seed.exude_gasses.len)))
 
-	// This was adapted from the air alarm code
-	// I've never done atmos or touched atmos code before so there's a chance I've fucked this up
 	if(seed.alter_temp)
-		if(istype(T, /turf/simulated/))
-			var/datum/gas_mixture/room = T.remove_air(environment.total_moles)
-			if(room.temperature < seed.ideal_heat-seed.heat_tolerance)
-				room.temperature += (seed.potency*3)
-			else if (room.temperature > seed.ideal_heat+seed.heat_tolerance)
-				room.temperature -= (seed.potency*3)
-			room.react()
-			T.assume_air(room)
+		if((environment.temperature < seed.ideal_heat - seed.heat_tolerance) || (environment.temperature > seed.ideal_heat + seed.heat_tolerance))
+			var/energy_cap = seed.potency * 60 * MOLES_CELLSTANDARD //This is totally arbitrary. It just serves to approximate the behavior from when this modified temperature rather than thermal energy.
+			var/energy_change = Clamp(environment.get_thermal_energy_change(seed.ideal_heat), -energy_cap, energy_cap)
+			environment.add_thermal_energy(energy_change)
 
 	// If we're attached to a pipenet, then we should let the pipenet know we might have modified some gasses
 	//if (closed_system && connected_port)


### PR DESCRIPTION
1. Fixes plants that adjust air temperature being *way* too powerful after the ZAS changes
2. Fixes #18118 

They also now adjust the thermal energy of their environment rather than the absolute temperature. In an atmosphere of normal air at standard pressure, the behavior will be exactly as it was before the ZAS changes, but will be significantly different if the atmosphere is significantly different.
Actually, that's not quite true. They also no longer overshoot their target temperature. This prevents the temperature of their environment from oscillating around their target without ever hitting it, and *also* prevents them from dropping the environment temperature below absolute zero at high potency.
(This applies even if their target temperature is somehow below absolute zero, because `add_thermal_energy()` will not allow the temperature to go below `TCMB`)

Theoretically, you could now use plants to adjust the temperature of an atmos contraption, but since the tray only has a volume of 10 liters, they are very bad at it even at high potency.