### PR TITLE
Fixes signaler importing

### DIFF
--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -284,6 +284,6 @@
 
 /obj/item/device/assembly/signaler/set_value(var/var_name, var/new_value)
 	if(var_name == "frequency")
-		new_value = sanitize_frequency(new_value)
-
-	return ..(var_name, new_value)
+		set_frequency(sanitize_frequency(new_value))
+	else
+		return ..()


### PR DESCRIPTION
Fixes #18119
The `radio_controller` isn't updated unless the frequency is set by `set_frequency()`, so the signaler would never receive the signal.