### PR TITLE
Doppelganger tweaks/nerfs

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/human/wizard.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/wizard.dm
@@ -65,6 +65,8 @@
 
 /mob/living/simple_animal/hostile/humanoid/wizard/doppelganger/Destroy()
 	spell = null
+	var/mob/my_wiz = doppelgangers[src]
+	doppelgangers_count_by_wizards[my_wiz]--
 	doppelgangers[src] = null
 	doppelgangers -= src
 	..()

--- a/code/modules/spells/aoe_turf/conjure/doppelganger.dm
+++ b/code/modules/spells/aoe_turf/conjure/doppelganger.dm
@@ -38,7 +38,7 @@ var/list/doppelgangers = list()
 		doppelgangers[D] = holder
 	D.appearance = holder.appearance
 	D.alpha = OPAQUE // No more invisible doppels
-	doppelgangers_count_by_wizards[user]++ // Update the counts of doppels we summoned
+	doppelgangers_count_by_wizards[holder]++ // Update the counts of doppels we summoned
 	spawn (spell_duration)
 		D.death()
 

--- a/code/modules/spells/aoe_turf/conjure/doppelganger.dm
+++ b/code/modules/spells/aoe_turf/conjure/doppelganger.dm
@@ -23,7 +23,7 @@ var/list/doppelgangers = list()
 
 // Sanity : don't copy more than one guy
 /spell/aoe_turf/conjure/doppelganger/cast_check(skipcharge = 0,mob/user = usr)
-	if (doppelgangers_count_by_wizards[user] > MAX_DOPPELS) // We summoned too much doppels :(
+	if (doppelgangers_count_by_wizards[user] > MAX_DOPPLES) // We summoned too much doppels :(
 		to_chat(user, "<span class = 'warning'>We have duplicated ourselves too much in this plane.</span>")
 		return FALSE
 	var/list/L = view(user, 0)
@@ -38,7 +38,7 @@ var/list/doppelgangers = list()
 		doppelgangers[D] = holder
 	D.appearance = holder.appearance
 	D.alpha = OPAQUE // No more invisible doppels
-	doppelgangers_by_wizards[user]++ // Update the counts of doppels we summoned
+	doppelgangers_count_by_wizards[user]++ // Update the counts of doppels we summoned
 	spawn (spell_duration)
 		D.death()
 

--- a/code/modules/spells/aoe_turf/conjure/doppelganger.dm
+++ b/code/modules/spells/aoe_turf/conjure/doppelganger.dm
@@ -14,11 +14,18 @@
 	invocation_type = SpI_SHOUT
 	spell_flags = NEEDSCLOTHES
 	hud_state = "wiz_doppelganger"
+	var/spell_duration = 8 MINUTES
 
+
+var/list/doppelgangers_count_by_wizards = list()
 var/list/doppelgangers = list()
+#define MAX_DOPPLES 15
 
 // Sanity : don't copy more than one guy
 /spell/aoe_turf/conjure/doppelganger/cast_check(skipcharge = 0,mob/user = usr)
+	if (doppelgangers_count_by_wizards[user] > MAX_DOPPELS) // We summoned too much doppels :(
+		to_chat(user, "<span class = 'warning'>We have duplicated ourselves too much in this plane.</span>")
+		return FALSE
 	var/list/L = view(user, 0)
 	L -= user
 	for (var/mob/M in L)
@@ -31,6 +38,9 @@ var/list/doppelgangers = list()
 		doppelgangers[D] = holder
 	D.appearance = holder.appearance
 	D.alpha = OPAQUE // No more invisible doppels
+	doppelgangers_by_wizards[user]++ // Update the counts of doppels we summoned
+	spawn (spell_duration)
+		D.death()
 
 /spell/aoe_turf/conjure/doppelganger/on_holder_death(mob/user)
 	if(!user)


### PR DESCRIPTION
**What :** Nerfs Doppelgangers by limiting the simultaneous amount of them a wizard can summon to 15, and making them disappear naturally after 8 minutes.

**Why :** Doppel aren't fun to play with mostly because they stay in place almost forever after their wizard has gone to parts unknown. This aims to make them a little less spammable and a little less persistant. You'll need to conjure them again if you still want to condemn a zone.

This shouldn't remove their ability to cause chaos - 15 doppels is a reasonable amount, and 8 minutes a reasonable time. The chaos they cause should simply be less permanent.
This doesn't change their combat robutness and ability to stun people.

It seems also intended that Doppels should dissappear on their conjurer's death, _but_ I've never witnessed such a behaviour. It should be something to check/correct if needed.

Open to criticism/suggestions etc

:cl:
- tweak: A single wizard can only summon 15 Doppelgängers at the time, and Doppelgängers now naturally dissappear after 8 minutes.