### PR TITLE
Does absolutely nothing

### DIFF
--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -827,7 +827,7 @@ var/global/blood_virus_spreading_disabled = 0
 	set desc = "Reload the Style Sheet (be careful)."
 
 	for(var/client/C in clients)
-		winset(C, null, "outputwindow.output.style=[config.world_style_config];")
+		winset(C, null, "window1.msay_output.style=[config.world_style_config];")
 	message_admins("The style sheet has been reloaded by [src.ckey]")
 
 /client/proc/reset_style_sheet()
@@ -836,7 +836,7 @@ var/global/blood_virus_spreading_disabled = 0
 	set desc = "Reset the Style Sheet (restore to default)."
 
 	for(var/client/C in clients)
-		winset(C, null, "outputwindow.output.style=[world_style];")
+		winset(C, null, "window1.msay_output.style=[world_style];")
 	config.world_style_config = world_style
 	message_admins("The style sheet has been reset by [src.ckey]")
 

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -127,8 +127,7 @@
 	chatOutput = new /datum/chatOutput(src) // Right off the bat.
 	// world.log << "Done creating chatOutput"
 	if(config)
-		winset(src, null, "outputwindow.output.style=[config.world_style_config];")
-		winset(src, null, "window1.msay_output.style=[config.world_style_config];") // it isn't possible to set two window elements in the same winset so we need to call it for each element we're assigning a stylesheet.
+		winset(src, null, "window1.msay_output.style=[config.world_style_config];")
 	else
 		to_chat(src, "<span class='warning'>The stylesheet wasn't properly setup call an administrator to reload the stylesheet or relog.</span>")
 


### PR DESCRIPTION
For once, that's actually serious.
The `outputwindow.output` element hasn't existed since #9043, so all these lines of code did was throw clientside errors, which you'd only notice if you looked for them.

It is extremely unlikely this has anything to do with the screenfreeze, but it can't hurt to find out, since this code doesn't do anything anyway

Also, whoever merges this, either ping me to fix the secret repo conflict, or just do it yourself.