### PR TITLE
fixes glock caliber

### DIFF
--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -147,7 +147,7 @@
 	ammo_type = "/obj/item/ammo_casing/c380auto"
 	mag_type = "/obj/item/ammo_storage/magazine/m380auto"
 	max_shells = 8
-	caliber = list(".45"  = 1)
+	caliber = list(".380AUTO"  = 1)
 	origin_tech = Tc_COMBAT + "=3"
 	fire_sound = 'sound/weapons/semiauto.ogg'
 	load_method = 2


### PR DESCRIPTION
fixed a minor oversight made during the 45 -> 380AUTO conversion -- you could only load .45 bullets into the chamber, rather than .380auto.

🆑 
 - bugfix: Nanotrasen has removed the auxiliary .45 chamber-loading option from their glock lineup.