### PR TITLE
More readable body scan rad_tick readout

### DIFF
--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -325,6 +325,7 @@
 		"toxloss" = H.getToxLoss(),
 		"rads" = H.radiation,
 		"radtick" = H.rad_tick,
+		"radstage" = H.get_rad_stage(),
 		"cloneloss" = H.getCloneLoss(),
 		"brainloss" = H.getBrainLoss(),
 		"paralysis" = H.paralysis,
@@ -373,7 +374,7 @@
 
 	dat += text("[]\tRadiation Level %: []</font><br>", (occ["rads"] < 10 ?"<font color='blue'>" : "<font color='red'>"), occ["rads"])
 	if(occ["radtick"] > 0)
-		dat += text("<font color='red'>Absorbed rads danger index: <b>[occ["radtick"]]</b></font><br>")
+		dat += text("<font color='red'>Radiation sickness progression: <b>[occ["radtick"]]</b> Stage: <b>[occ["radstage"]]</b></font><br>")
 	dat += text("[]\tGenetic Tissue Damage %: []</font><br>", (occ["cloneloss"] < 1 ?"<font color='blue'>" : "<font color='red'>"), occ["cloneloss"])
 	dat += text("[]\tApprox. Brain Damage %: []</font><br>", (occ["brainloss"] < 1 ?"<font color='blue'>" : "<font color='red'>"), occ["brainloss"])
 	dat += text("Paralysis Summary %: [] ([] seconds left!)<br>", occ["paralysis"], round(occ["paralysis"] / 4))

--- a/code/modules/mob/living/carbon/human/life/handle_mutations_and_radiation.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_mutations_and_radiation.dm
@@ -303,3 +303,22 @@
 							Knockdown(3)
 							regenerate_icons()
 							visible_message("<span class='danger'>\The [src]'s form loses bulk as they collapse to the ground.</span>")
+
+/mob/living/proc/get_rad_stage()
+	switch(rad_tick)
+		if(0)
+			return "none"
+		if(1 to RADDOSELIGHT)
+			return "Early"
+		if(RADDOSELIGHT to RADDOSEMINOR)
+			return "Light"
+		if(RADDOSEMINOR to RADDOSEADVANCED)
+			return "Minor"
+		if(RADDOSEADVANCED to RADDOSECRITICAL)
+			return "Advanced"
+		if(RADDOSECRITICAL to RADDOSEDEADLY)
+			return "Critical"
+		if(RADDOSEDEADLY to RADDOSEFATAL)
+			return "Deadly"
+		if(RADDOSEFATAL to INFINITY)
+			return "Fatal"

--- a/code/modules/mob/living/carbon/human/life/handle_mutations_and_radiation.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_mutations_and_radiation.dm
@@ -307,7 +307,7 @@
 /mob/living/proc/get_rad_stage()
 	switch(rad_tick)
 		if(0)
-			return "none"
+			return "N/A"
 		if(1 to RADDOSELIGHT)
 			return "Early"
 		if(RADDOSELIGHT to RADDOSEMINOR)

--- a/code/modules/mob/living/simple_animal/borer/verbs_attached_chest.dm
+++ b/code/modules/mob/living/simple_animal/borer/verbs_attached_chest.dm
@@ -82,6 +82,7 @@
 		"virus_present" = H.virus2.len,
 		"rads" = H.radiation,
 		"radtick" = H.rad_tick,
+		"radstage" = H.get_rad_stage(),
 		"cloneloss" = H.getCloneLoss(),
 		"brainloss" = H.getBrainLoss(),
 		"paralysis" = H.paralysis,
@@ -124,7 +125,7 @@
 		dat += "<font color='red'>Viral pathogen detected in blood stream.</font><br>"
 	dat += text("[]\tRadiation Level %: []</font><br>", (occ["rads"] < 10 ?"<font color='blue'>" : "<font color='red'>"), occ["rads"])
 	if(occ["radtick"] > 0)
-		dat += text("<font color='red'>Absorbed rads danger index: <b>[occ["radtick"]]</b></font><br>")
+		dat += text("<font color='red'>Radiation sickness progression: <b>[occ["radtick"]]</b> Stage: <b>[occ["radstage"]]</b></font><br>")
 	dat += text("[]\tGenetic Tissue Damage %: []</font><br>", (occ["cloneloss"] < 1 ?"<font color='blue'>" : "<font color='red'>"), occ["cloneloss"])
 	dat += text("[]\tApprox. Brain Damage %: []</font><br>", (occ["brainloss"] < 1 ?"<font color='blue'>" : "<font color='red'>"), occ["brainloss"])
 	dat += text("Paralysis Summary %: [] ([] seconds left!)<br>", occ["paralysis"], round(occ["paralysis"] / 4))


### PR DESCRIPTION
:cl:
* tweak: Renamed the body scanner's "Absorbed rads danger index" to "Radiation sickness progression" which is more descriptive of what it is. Also now it will give the name of the stage the patient is in.