### PR TITLE
Radio messages no longer show the icon of the radio used to send them

### DIFF
--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -102,11 +102,8 @@ var/list/freqtoname = list(
 /atom/movable/proc/render_speech(var/datum/speech/speech)
 	say_testing(src, "render_speech() - Freq: [speech.frequency], radio=\ref[speech.radio]")
 	var/freqpart = ""
-	var/radioicon = ""
 	if(speech.frequency)
-		if(speech.radio)
-			radioicon = "[bicon(speech.radio)]"
-		freqpart = " [radioicon]\[[get_radio_name(speech.frequency)]\]"
+		freqpart = " \[[get_radio_name(speech.frequency)]\]"
 		speech.wrapper_classes.Add(get_radio_span(speech.frequency))
 	var/pooled=0
 	var/datum/speech/filtered_speech


### PR DESCRIPTION
Because it makes no sense

:cl:
* rscdel: Radio messages no longer show the icon of the radio used to send them.