### PR TITLE
Fixed mech GC runtimes

### DIFF
--- a/code/datums/helper_datums/events.dm
+++ b/code/datums/helper_datums/events.dm
@@ -10,6 +10,12 @@
 	..()
 	events = new
 
+/datum/events/Destroy()
+	for(var/datum/event/E in events)
+		qdel(E)
+	events = null
+	..()
+
 /datum/events/proc/addEventType(event_type as text)
 	if(!(event_type in events) || !islist(events[event_type]))
 		events[event_type] = list()
@@ -58,6 +64,10 @@
 	listener = tlistener
 	proc_name = tprocname
 	return ..()
+
+/datum/event/Destroy()
+	listener = null
+	..()
 
 /datum/event/proc/Fire()
 //	to_chat(world, "Event fired")

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -111,8 +111,45 @@
 /obj/mecha/Destroy()
 	src.go_out(loc, TRUE)
 	mechas_list -= src //global mech list
+	if(cell)
+		qdel(cell)
+		cell = null
+	if(internal_tank)
+		qdel(internal_tank)
+		internal_tank = null
+	if(cabin_air)
+		qdel(cabin_air)
+		cabin_air = null
+	connected_port = null
+	if(radio)
+		qdel(radio)
+		radio = null
+	if(electropack)
+		qdel(electropack)
+		electropack = null
+	if(tracking)
+		qdel(tracking)
+		tracking = null
+	if(pr_int_temp_processor)
+		qdel(pr_int_temp_processor)
+		pr_int_temp_processor = null
+	if(pr_inertial_movement)
+		qdel(pr_inertial_movement)
+		pr_inertial_movement = null
+	if(pr_give_air)
+		qdel(pr_give_air)
+		pr_give_air = null
+	if(pr_internal_damage)
+		qdel(pr_internal_damage)
+		pr_internal_damage = null
+	for(var/obj/item/mecha_parts/mecha_equipment/eq in equipment)
+		qdel(eq)
+	equipment = null
+	selected = null
+	if(events)
+		qdel(events)
+		events = null
 	..()
-	return
 
 /obj/mecha/can_apply_inertia()
 	return 1 //No anchored check - so that mechas can fly off into space


### PR DESCRIPTION
Turns out mechs didn't qdel/null any of their references

```
x424 mecha.dm,2021: Cannot execute null.return pressure().
  proc name: process (/datum/global_iterator/mecha_tank_give_air/process)
  usr: Nick Fiend (apegod) (/mob/living/carbon/human)
  usr.loc: The floor (247, 221, 1) (/turf/simulated/floor)
  src: /datum/global_iterator/mecha_t... (/datum/global_iterator/mecha_tank_give_air)
  call stack:
  /datum/global_iterator/mecha_t... (/datum/global_iterator/mecha_tank_give_air): process(APLU \"Ripley\" (/obj/mecha/working/ripley))
  /datum/global_iterator/mecha_t... (/datum/global_iterator/mecha_tank_give_air): main()
  /datum/global_iterator/mecha_t... (/datum/global_iterator/mecha_tank_give_air): start(null)
```