### PR TITLE
A flashbang on your tile ignores protection

### DIFF
--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -40,7 +40,7 @@
 	var/eye_safety = 0
 	var/ear_safety = 0
 
-	if(!ignore_protection)
+	if(!ignore_protection && loc != M.loc)
 		eye_safety = M.eyecheck()
 		ear_safety = M.earprot() //some arbitrary measurement of ear protection, I guess? doesn't even matter if it goes above 1
 


### PR DESCRIPTION
![bangermemes](https://user-images.githubusercontent.com/31839805/40640832-8935a8a2-62cc-11e8-8ac8-ee04bc53c301.PNG)

We're nowhere near there yet, but needing to do slightly more than press z+q is a step forward.

:cl:
* tweak: Flashbangs going off on someone's same tile now affect them for the full duration regardless of their protection.