### PR TITLE
Emote runtime with hivelord broods

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -325,11 +325,11 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 
 /mob/living/simple_animal/proc/handle_automated_speech()
 
-	if(!(speak.len || emote_hear.len || emote_see.len))
+	if(!speak_chance || !(speak.len || emote_hear.len || emote_see.len))
 		return
 
 	var/someone_in_earshot=0
-	if(!client && speak_chance && ckey == null) // Remove this if earshot is used elsewhere.
+	if(!client && ckey == null) // Remove this if earshot is used elsewhere.
 		// All we're doing here is seeing if there's any CLIENTS nearby.
 		for(var/mob/M in get_hearers_in_view(7, src))
 			if(M.client)


### PR DESCRIPTION
```
x175 simple_animal.dm,328: Cannot read .len
  proc name: handle automated speech (/mob/living/simple_animal/proc/handle_automated_speech)
  src: the hivelord brood (/mob/living/simple_animal/hostile/asteroid/hivelordbrood)
  src.loc: Asteroid (71,409,5) (/turf/unsimulated/floor/asteroid)
  call stack:
  the hivelord brood (/mob/living/simple_animal/hostile/asteroid/hivelordbrood): handle automated speech()
  the hivelord brood (/mob/living/simple_animal/hostile/asteroid/hivelordbrood): Life()
  the hivelord brood (/mob/living/simple_animal/hostile/asteroid/hivelordbrood): Life()
  Mob (/datum/subsystem/mob): fire(0)
  Mob (/datum/subsystem/mob): ignite(0)
  Master (/datum/controller/master): RunQueue()
  Master (/datum/controller/master): Loop()
  Master (/datum/controller/master): StartProcessing()
```

I don't know what happens to those empty lists but at least I can get rid of the runtime.