### PR TITLE
Removed warning for null values passed to isSmoothableNeighbor

### DIFF
--- a/code/game/smoothwall.dm
+++ b/code/game/smoothwall.dm
@@ -24,13 +24,11 @@
 
 /atom/proc/isSmoothableNeighbor(atom/A)
 	if(!A)
-		WARNING("[__FILE__]L[__LINE__]: atom/isSmoothableNeighbor given bad atom")
 		return 0
 	return isInTypes(A, canSmoothWith)
 
 /turf/simulated/wall/isSmoothableNeighbor(atom/A)
 	if(!A)
-		WARNING("[__FILE__]L[__LINE__]: turf/isSmoothableNeighbor given bad atom")
 		return 0
 	if(isInTypes(A, canSmoothWith))
 		// COLON OPERATORS ARE TERRIBLE BUT I HAVE NO CHOICE


### PR DESCRIPTION
Something something #16085

Happens when you have a wall on the map border, it tries to find an adjacent wall but it's passed null instead. The proc just returns in that case, completely harmless.