### PR TITLE
Fixed test_tiny minimap runtimes

### DIFF
--- a/code/modules/html_interface/map/station_map.dm
+++ b/code/modules/html_interface/map/station_map.dm
@@ -30,8 +30,10 @@
 
 	//Station Holomaps display the map of the Z-Level they were built on.
 	generateStationMinimap(map.zMainStation)
-	generateStationMinimap(map.zAsteroid)
-	generateStationMinimap(map.zDerelict)
+	if(world.maxz >= map.zAsteroid)
+		generateStationMinimap(map.zAsteroid)
+	if(world.maxz >= map.zDerelict)
+		generateStationMinimap(map.zDerelict)
 	//If they were built on another Z-Level, they will display an error screen.
 
 	holomaps_initialized = 1


### PR DESCRIPTION
```
[15:01:06] Runtime in station_map.dm,168: list index out of bounds
  proc name: generateStationMinimap (/proc/generateStationMinimap)
  src: null
  call stack:
  generateStationMinimap(5)
  generateHoloMinimaps()
  Uncategorized Init (/datum/subsystem/more_init): Initialize(540650)
  Master (/datum/controller/master): Setup()
[15:01:06] Runtime in station_map.dm,168: list index out of bounds
  proc name: generateStationMinimap (/proc/generateStationMinimap)
  src: null
  call stack:
  generateStationMinimap(4)
  generateHoloMinimaps()
  Uncategorized Init (/datum/subsystem/more_init): Initialize(540650)
  Master (/datum/controller/master): Setup()
```