### PR TITLE
Fixed health scanner runtime

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -181,7 +181,7 @@ Subject's pulse: ??? BPM"})
 		OX = fake_oxy > 50 ? "<font color='blue'><b>Severe oxygen deprivation detected</b></font>" : "Subject bloodstream oxygen level normal"
 	message += ("<br>[OX] | [TX] | [BU] | [BR]")
 
-	if(M.reagents.total_volume)
+	if(M.reagents && M.reagents.total_volume)
 		message += "<br><span class='warning'>Warning: Unknown substance detected in subject's blood.</span>"
 	if(hardcore_mode_on && ishuman(M) && eligible_for_hardcore_mode(M))
 		var/mob/living/carbon/human/H = M


### PR DESCRIPTION
This runtime was the only thing preventing the health analyzer from working on pretty much everything, from borers to fucking borgs. Perhaps it needs more sanity, so DNM until discussed, I suppose?

```
x1 scanners.dm,184: Cannot read null.total_volume
  proc name: healthanalyze (/proc/healthanalyze)
  usr: Affytaff Bickerson (fadyftj) (/mob/living/carbon/human)
  usr.loc: The floor (198, 228, 1) (/turf/simulated/floor)
  src: null
  call stack:
  healthanalyze(Moetron 9000 (/mob/living/silicon/robot), Affytaff Bickerson (/mob/living/carbon/human), 1, 0, 0)
  the health analyzer (/obj/item/device/healthanalyzer): attack(Moetron 9000 (/mob/living/silicon/robot), Affytaff Bickerson (/mob/living/carbon/human))
  Moetron 9000 (/mob/living/silicon/robot): attackby(the health analyzer (/obj/item/device/healthanalyzer), Affytaff Bickerson (/mob/living/carbon/human), "icon-x=21;icon-y=13;left=1;scr...", null)
  Moetron 9000 (/mob/living/silicon/robot): attackby(the health analyzer (/obj/item/device/healthanalyzer), Affytaff Bickerson (/mob/living/carbon/human), "icon-x=21;icon-y=13;left=1;scr...")
  Affytaff Bickerson (/mob/living/carbon/human): ClickOn(Moetron 9000 (/mob/living/silicon/robot), "icon-x=21;icon-y=13;left=1;scr...")
  Moetron 9000 (/mob/living/silicon/robot): Click(the floor (197,229,1) (/turf/simulated/floor), "mapwindow.map", "icon-x=21;icon-y=13;left=1;scr...")
  Moetron 9000 (/mob/living/silicon/robot): Click(the floor (197,229,1) (/turf/simulated/floor), "mapwindow.map", "icon-x=21;icon-y=13;left=1;scr...")
```