### PR TITLE
Adds a robot maintenance crate to cargo

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1661,12 +1661,15 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	contains = list(/obj/item/weapon/book/manual/robotics_cyborgs,
 					/obj/item/weapon/cell/high,
 					/obj/item/weapon/storage/toolbox/robotics,
+					/obj/item/robot_parts/robot_component/armour,
 					/obj/item/robot_parts/robot_component/actuator,
 					/obj/item/robot_parts/robot_component/radio,
+					/obj/item/robot_parts/robot_component/binary_communication_device,
 					/obj/item/robot_parts/robot_component/camera,
+					/obj/item/robot_parts/robot_component/diagnosis_unit,
 					/obj/item/borg/upgrade/restart
 					)
-	cost = 250
+	cost = 120
 	containertype = /obj/structure/closet/crate/sci
 	containername = "robot maintenance equipment crate"
 	group = "Science"

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1668,7 +1668,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					)
 	cost = 250
 	containertype = /obj/structure/closet/crate/sci
-	containername = "robot maintenance equipment"
+	containername = "robot maintenance equipment crate"
 	group = "Science"
 
 /datum/supply_packs/suspension_gen

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1656,6 +1656,21 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	access = list(access_robotics)
 	group = "Science"
 
+/datum/supply_packs/robot_maintenance
+	name = "Robot maintenance equipment"
+	contains = list(/obj/item/weapon/book/manual/robotics_cyborgs,
+					/obj/item/weapon/cell/high,
+					/obj/item/weapon/storage/toolbox/robotics,
+					/obj/item/robot_parts/robot_component/actuator,
+					/obj/item/robot_parts/robot_component/radio,
+					/obj/item/robot_parts/robot_component/camera,
+					/obj/item/borg/upgrade/restart
+					)
+	cost = 250
+	containertype = /obj/structure/closet/crate/sci
+	containername = "robot maintenance equipment"
+	group = "Science"
+
 /datum/supply_packs/suspension_gen
 	name = "Suspension field generator"
 	contains = list(/obj/machinery/suspension_gen)

--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -116,3 +116,17 @@
 	new /obj/item/stack/cable_coil(src,30,color)
 	new /obj/item/weapon/wirecutters(src)
 	new /obj/item/device/multitool(src)
+
+/obj/item/weapon/storage/toolbox/robotics
+	name = "robotics toolbox"
+
+/obj/item/weapon/storage/toolbox/robotics/New()
+	..()
+	var/color = pick("red","yellow","green","blue","pink","orange","cyan","white")
+	new /obj/item/device/robotanalyzer(src)
+	new /obj/item/weapon/crowbar(src)
+	new /obj/item/weapon/wrench(src)
+	new /obj/item/weapon/weldingtool(src)
+	new /obj/item/weapon/screwdriver(src)
+	new /obj/item/weapon/wirecutters(src)
+	new /obj/item/stack/cable_coil(src,30,color)


### PR DESCRIPTION
It contains a robotics manual, highcap cell, restart board, robotics toolbox and all cyborg components. Enough to get a single silicon functional again even if they're turbodead.

:cl:
 * rscadd: Adds a robot maintenance crate to cargo for 120 spessbucks.