### PR TITLE
Fixes the intercom icon not updating properly.

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -535,6 +535,7 @@
 	else
 		user.show_message("<span class = 'notice'>\The [src] can no longer be modified or attached!</span>")
 	updateDialog()
+	update_icon()
 	add_fingerprint(user)
 
 /obj/item/device/radio/emp_act(severity)


### PR DESCRIPTION
Something I noticed when bugfixing #18276, was that the intercom's icon wouldn't update immediately when a screwdriver was used, but would instead have to wait on the next process() tick. This PR fixes that.

`/obj/item/device/radio/intercom/attackby` called its parent, but said parent didn't had an `update_icon` call in its code.