### PR TITLE
Drugs that remove hallucination are 3x as effective while sleeping, 2x resting

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -601,7 +601,8 @@
 		holder.remove_reagent(ZOMBIEPOWDER, 0.5 * REM)
 	if(holder.has_reagent(MINDBREAKER))
 		holder.remove_reagent(MINDBREAKER, 2 * REM)
-	M.hallucination = max(0, M.hallucination - 5 * REM)
+	var/lucidmod = M.sleeping ? 3 : M.lying + 1 //3x as effective if they're sleeping, 2x if they're lying down
+	M.hallucination = max(0, M.hallucination - 5 * REM * lucidmod)
 	M.adjustToxLoss(-2 * REM)
 
 /datum/reagent/phalanximine
@@ -2472,7 +2473,8 @@
 	M.AdjustKnockdown(-1)
 	if(holder.has_reagent("mindbreaker"))
 		holder.remove_reagent("mindbreaker", 5)
-	M.hallucination = max(0, M.hallucination - 10)
+	var/lucidmod = M.sleeping ? 3 : M.lying + 1
+	M.hallucination = max(0, M.hallucination - 10 * lucidmod)
 	if(prob(60))
 		M.adjustToxLoss(1)
 
@@ -4271,7 +4273,8 @@
 	M.drowsyness = max(M.drowsyness - 2 * REM, 0)
 	if(holder.has_reagent("discount"))
 		holder.remove_reagent("discount", 2 * REM)
-	M.hallucination = max(0, M.hallucination - 5 * REM)
+	var/lucidmod = M.sleeping ? 3 : M.lying + 1
+	M.hallucination = max(0, M.hallucination - 5 * REM * lucidmod)
 	M.adjustToxLoss(-2 * REM)
 
 /datum/reagent/clottingagent


### PR DESCRIPTION
It seems fair since you still have to stay in one place for an extended period of time, and being forced to kill yourself is a lame solution.

If you have all 3 and sleep / are in cryo it'll remove 60 per on_mob_life
40 if resting

this isn't really a nerf to the hallucination chems since:
spiritbreaker adds 200 per on_mob_life
mindbreaker adds 10 per on_mob_life
and both have 0.05 metabolism

although these chems slowly remove mindbreaker, nothing removes spiritbreaker from your system, which may be worth changing as well so that you can finally counter it somehow outside of killing yourself

:cl:
- tweak: "Chems that remove hallucination triple in effectiveness if you're asleep or in cryo, double if you rest."