### PR TITLE
No-client messages for shades and constructs

### DIFF
--- a/code/game/gamemodes/wizard/soulstone.dm
+++ b/code/game/gamemodes/wizard/soulstone.dm
@@ -13,6 +13,13 @@
 /obj/item/device/soulstone/Destroy()
 	eject_shade()
 	..()
+
+/obj/item/device/soulstone/examine(mob/user)
+	..()
+	for(var/mob/living/simple_animal/shade/A in src)
+		if(!A.client)
+			to_chat(user, "<span class='warning'>The spirit within seems to be dormant.</span>")
+
 //////////////////////////////Capturing////////////////////////////////////////////////////////
 
 /obj/item/device/soulstone/attack(var/mob/living/M, mob/user as mob)
@@ -48,9 +55,6 @@
 	user << browse(dat, "window=aicard")
 	onclose(user, "aicard")
 	return
-
-
-
 
 /obj/item/device/soulstone/Topic(href, href_list)
 	var/mob/living/carbon/U = usr

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -100,6 +100,8 @@
 		else
 			msg += "<B>It looks severely dented!</B>\n"
 		msg += "</span>"
+	if(!client)
+		msg += "<span class='warning'>The spirit animating it seems to be dormant.</span>\n"
 	msg += "*---------*</span>"
 
 	to_chat(user, msg)

--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -86,6 +86,11 @@
 		health -= rand(5,45) //These guys are like ghosts, a collision with a shuttle wouldn't destroy one outright
 	return
 
+/mob/living/simple_animal/shade/examine(mob/user)
+	..()
+	if(!client)
+		to_chat(user, "<span class='warning'>[src] appears to be dormant.</span>")
+
 ////////////////HUD//////////////////////
 
 /mob/living/simple_animal/shade/Life()

--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -89,7 +89,7 @@
 /mob/living/simple_animal/shade/examine(mob/user)
 	..()
 	if(!client)
-		to_chat(user, "<span class='warning'>[src] appears to be dormant.</span>")
+		to_chat(user, "<span class='warning'>It appears to be dormant.</span>")
 
 ////////////////HUD//////////////////////
 


### PR DESCRIPTION
Resolves #18400

:cl:
* rscadd: Shades, soul stones and constructs now have examine text that shows if the player has logged out or ghosted.