### PR TITLE
Fixes cult space armor so it's wearable again

### DIFF
--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -101,7 +101,7 @@
 	item_state = "cult_helmet"
 	armor = list(melee = 60, bullet = 50, laser = 30,energy = 15, bomb = 30, bio = 30, rad = 30)
 	siemens_coefficient = 0
-	species_restricted = list() //So dionas can wear it, mainly.
+	species_restricted = null //So dionas can wear it, mainly.
 
 /obj/item/clothing/suit/space/cult
 	name = "cult armor"
@@ -113,4 +113,4 @@
 	slowdown = NO_SLOWDOWN
 	armor = list(melee = 60, bullet = 50, laser = 30,energy = 15, bomb = 30, bio = 30, rad = 30)
 	siemens_coefficient = 0
-	species_restricted = list()
+	species_restricted = null


### PR DESCRIPTION
Looks like I messed up and made cult space gear unwearable by using an empty list instead of null. Sorry about that.

:cl:
* bugfix: Fixed a bug that made cult space armor and space helmets unwearable.