### PR TITLE
Fixed apiary/attackby runtime

### DIFF
--- a/code/game/machinery/bees_apiary.dm
+++ b/code/game/machinery/bees_apiary.dm
@@ -514,8 +514,8 @@
 		to_chat(user,"<span class='warning'>You hit \the [src] with your [O].</span>")
 		if(queen_bees_inside || worker_bees_inside)
 			angry_swarm(user)
-
-		playsound(src, O.hitsound, 50, 1, -1)
+		if(O.hitsound)
+			playsound(src, O.hitsound, 50, 1, -1)
 		health -= O.force
 		updateHealth()
 


### PR DESCRIPTION
```
x24 sound.dm,35: code/game/sound.dm:35:Assertion Failed: !(isnull(soundin) && channel == 0)
  proc name: playsound (/proc/playsound)
  usr: Braylon Steele (dan909) (/mob/living/carbon/human)
  usr.loc: Carpet (282, 249, 1) (/turf/simulated/floor/carpet)
  src: null
  call stack:
  playsound(the angry-bee hive (/obj/machinery/apiary/wild), null, 50, 1, -1, null, 1, 0, 0)
  the angry-bee hive (/obj/machinery/apiary/wild): attackby(the scythe (/obj/item/weapon/scythe), Braylon Steele (/mob/living/carbon/human), "icon-x=15;icon-y=16;left=1;scr...")
  Braylon Steele (/mob/living/carbon/human): ClickOn(the angry-bee hive (/obj/machinery/apiary/wild), "icon-x=15;icon-y=16;left=1;scr...")
  the angry-bee hive (/obj/machinery/apiary/wild): Click(Carpet (282,250,1) (/turf/simulated/floor/carpet), "mapwindow.map", "icon-x=15;icon-y=16;left=1;scr...")
```