### PR TITLE
GPS transmitting locations to others is now toggleable

### DIFF
--- a/code/modules/telesci/gps.dm
+++ b/code/modules/telesci/gps.dm
@@ -186,7 +186,7 @@ var/list/SPS_list = list()
 
 	for(var/E in SPS_list)
 		var/obj/item/device/gps/secure/S = E //No idea why casting it like this makes it work better instead of just defining it in the for each
-			S.announce(wearer, src, "has detected the death of their wearer",dead=TRUE)
+		S.announce(wearer, src, "has detected the death of their wearer",dead=TRUE)
 
 /obj/item/device/gps/secure/stripped(mob/wearer)
 	if(!transmitting)
@@ -195,7 +195,7 @@ var/list/SPS_list = list()
 	var/num = 0
 	for(var/E in SPS_list)
 		var/obj/item/device/gps/secure/S = E
-			S.announce(wearer, src, "has been stripped from their wearer",num)
+		S.announce(wearer, src, "has been stripped from their wearer",num)
 			num++
 
 var/list/deathsound = list('sound/items/die1.wav', 'sound/items/die2.wav', 'sound/items/die3.wav','sound/items/die4.wav')

--- a/code/modules/telesci/gps.dm
+++ b/code/modules/telesci/gps.dm
@@ -131,6 +131,8 @@ var/list/SPS_list = list()
 		return TRUE
 	if(href_list["toggle_transmit"])
 		transmitting = !transmitting
+		if(emped)
+				transmitting = FALSE		
 		return TRUE
 
 	if(..())

--- a/code/modules/telesci/gps.dm
+++ b/code/modules/telesci/gps.dm
@@ -66,7 +66,7 @@ var/list/SPS_list = list()
 /obj/item/device/gps/proc/get_location_name()
 	var/turf/device_turf = get_turf(src)
 	var/area/device_area = get_area(src)
-	else if(!device_turf || !device_area)
+	if(!device_turf || !device_area)
 		return "UNKNOWN"
 	else if(device_turf.z > WORLD_X_OFFSET.len)
 		return "[format_text(device_area.name)] (UNKNOWN, UNKNOWN, UNKNOWN)"

--- a/code/modules/telesci/gps.dm
+++ b/code/modules/telesci/gps.dm
@@ -214,7 +214,7 @@ var/const/DEATHSOUND_CHANNEL = 300
 
 /obj/item/device/gps/secure/proc/deathsound(var/turf/pos,var/dead=FALSE,num)
 	var/sound_channel = DEATHSOUND_CHANNEL + num
-	if(dead && transmitting)
+	if(dead)
 		playsound(src, pick(deathsound), 100, 0,channel = sound_channel,wait = TRUE)
 	if(prob(75))
 		playsound(src, 'sound/items/on3.wav',100, 0,channel = sound_channel,wait = TRUE)

--- a/code/modules/telesci/gps.dm
+++ b/code/modules/telesci/gps.dm
@@ -196,7 +196,7 @@ var/list/SPS_list = list()
 	for(var/E in SPS_list)
 		var/obj/item/device/gps/secure/S = E
 		S.announce(wearer, src, "has been stripped from their wearer",num)
-			num++
+		num++
 
 var/list/deathsound = list('sound/items/die1.wav', 'sound/items/die2.wav', 'sound/items/die3.wav','sound/items/die4.wav')
 
@@ -214,7 +214,7 @@ var/const/DEATHSOUND_CHANNEL = 300
 
 /obj/item/device/gps/secure/proc/deathsound(var/turf/pos,var/dead=FALSE,num)
 	var/sound_channel = DEATHSOUND_CHANNEL + num
-	if(dead)
+	if(dead && transmitting)
 		playsound(src, pick(deathsound), 100, 0,channel = sound_channel,wait = TRUE)
 	if(prob(75))
 		playsound(src, 'sound/items/on3.wav',100, 0,channel = sound_channel,wait = TRUE)

--- a/code/modules/telesci/gps.dm
+++ b/code/modules/telesci/gps.dm
@@ -132,7 +132,7 @@ var/list/SPS_list = list()
 	if(href_list["toggle_transmit"])
 		transmitting = !transmitting
 		if(emped)
-				transmitting = FALSE		
+			transmitting = FALSE		
 		return TRUE
 
 	if(..())

--- a/code/modules/telesci/gps.dm
+++ b/code/modules/telesci/gps.dm
@@ -46,7 +46,7 @@ var/list/SPS_list = list()
 
 /obj/item/device/gps/emp_act(severity)
 	emped = TRUE
-	transmitting = FALSE //turns off transmission when emp'd
+	transmitting = FALSE
 	overlays -= image(icon = icon, icon_state = "working")
 	overlays += image(icon = icon, icon_state = "emp")
 	spawn(30 SECONDS)
@@ -66,8 +66,6 @@ var/list/SPS_list = list()
 /obj/item/device/gps/proc/get_location_name()
 	var/turf/device_turf = get_turf(src)
 	var/area/device_area = get_area(src)
-	if(emped)
-		return "ERROR"
 	else if(!device_turf || !device_area)
 		return "UNKNOWN"
 	else if(device_turf.z > WORLD_X_OFFSET.len)
@@ -89,8 +87,8 @@ var/list/SPS_list = list()
 		for(var/D in get_list())
 			var/obj/item/device/gps/G = D
 			if(src != G)
-				var/device_data[0]
 				if (G.transmitting)
+					var/device_data[0]
 					device_data["tag"] = G.gpstag
 					device_data["location_text"] = G.get_location_name()
 					devices += list(device_data)
@@ -183,22 +181,20 @@ var/list/SPS_list = list()
 	return SPS_list
 
 /obj/item/device/gps/secure/OnMobDeath(mob/wearer)
-	if(emped)
+	if(!transmitting)
 		return
 
 	for(var/E in SPS_list)
 		var/obj/item/device/gps/secure/S = E //No idea why casting it like this makes it work better instead of just defining it in the for each
-		if (transmitting == TRUE)
 			S.announce(wearer, src, "has detected the death of their wearer",dead=TRUE)
 
 /obj/item/device/gps/secure/stripped(mob/wearer)
-	if(emped)
+	if(!transmitting)
 		return
 	. = ..()
 	var/num = 0
 	for(var/E in SPS_list)
 		var/obj/item/device/gps/secure/S = E
-		if (transmitting == TRUE)
 			S.announce(wearer, src, "has been stripped from their wearer",num)
 			num++
 

--- a/nano/templates/gps.tmpl
+++ b/nano/templates/gps.tmpl
@@ -22,6 +22,12 @@ Used In File(s): \code\modules\telesci\gps.dm
 		{{:helper.link(data.autorefresh ? 'On' : 'Off', 'refresh', {'toggle_refresh' : '1'}, null)}}
 	</div>
 </div>
+<div class="item">
+	<div class="itemLabel">Transmit Signal:</div>
+	<div class="itemContent">
+		{{:helper.link(data.transmit ? 'On' : 'Off', null, {'toggle_transmit' : '1'}, null)}}
+	</div>
+</div>
 
 <h3>Detected signals</h3>
 <div class="item">

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -2303,7 +2303,7 @@
 #include "interface\web\interface.dms"
 #include "maprendering\maprendering.dm"
 #include "maps\_map.dm"
-#include "maps\test_tiny.dm"
+#include "maps\tgstation.dm"
 #include "maps\defficiency\areas.dm"
 #include "maps\defficiency\pipes.dm"
 #include "maps\packedstation\telecomms.dm"

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -2303,7 +2303,7 @@
 #include "interface\web\interface.dms"
 #include "maprendering\maprendering.dm"
 #include "maps\_map.dm"
-#include "maps\tgstation.dm"
+#include "maps\test_tiny.dm"
 #include "maps\defficiency\areas.dm"
 #include "maps\defficiency\pipes.dm"
 #include "maps\packedstation\telecomms.dm"


### PR DESCRIPTION
GPS now have a button that determines whether they are transmitting their location to other GPS' or not when turned on or off. This also affects SPS devices as they won't send out death and strip alerts if they're not set to transmit during the action.  note that the receiving SPS doesn't need to be transmitting, it'll receive the alarm regardless of its own state. All GPS start with transmission off. EMPs will turn the transmission to off, much like how they turn headsets off, requiring the user to manually pull it out and set it back to on.

I thought this would be a nice feature, because it would trim down the GPS list of all non-active GPS (many times that spawn in locations like vaults and Z-2 centcomm ERT prep)
It also lets assistants/sci-shitters spy on sec officers without them ever finding out.

resolves #18407

<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl:
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
:cl:
 * rscadd: GPS are now outfitted with the option to transmit their location to other GPS. Make sure you set transmission to on before leaving the station.