### PR TITLE
Camera to blinder fixes

### DIFF
--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -133,6 +133,7 @@
 	var/panelopen = FALSE
 	var/obj/item/weapon/light/bulb/flashbulb = null
 	var/start_with_bulb = TRUE
+	var/decon_path = /obj/item/device/camera
 
 /obj/item/device/camera/New()
 	..()
@@ -156,6 +157,7 @@
 	icon_on = "sepia-camera"
 	icon_off = "sepia-camera_off"
 	mech_flags = MECH_SCAN_FAIL
+	decon_path = /obj/item/device/camera/sepia/empty
 
 /obj/item/device/camera/sepia/empty
 	start_with_bulb = FALSE
@@ -164,6 +166,7 @@
 /obj/item/device/camera/big_photos
 	name = "\improper XL camera"
 	photo_size = 5
+	decon_path = /obj/item/device/camera/big_photos/empty
 
 /obj/item/device/camera/big_photos/set_zoom()
 	return
@@ -175,6 +178,7 @@
 /obj/item/device/camera/huge_photos
 	name = "\improper XXL camera"
 	photo_size = 7
+	decon_path = /obj/item/device/camera/huge_photos/empty
 
 /obj/item/device/camera/huge_photos/set_zoom()
 	return
@@ -292,15 +296,7 @@
 	blinder.icon_state = icon_state
 	blinder.item_state = item_state
 	blinder.mech_flags = mech_flags
-
-	var/decon_paths = list(
-	/obj/item/device/camera/sepia = /obj/item/device/camera/sepia/empty,
-	/obj/item/device/camera/big_photos = /obj/item/device/camera/big_photos/empty,
-	/obj/item/device/camera/huge_photos = /obj/item/device/camera/huge_photos/empty
-	)
-
-	if(is_type_in_list(src, decon_paths))
-		blinder.decon_path = decon_paths[type]
+	blinder.decon_path = decon_path
 
 /obj/item/device/camera/proc/camera_get_icon(list/turfs, turf/center)
 	var/atoms[] = list()

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -132,11 +132,11 @@
 
 	var/panelopen = FALSE
 	var/obj/item/weapon/light/bulb/flashbulb = null
-	var/start_without_bulb = FALSE
+	var/start_with_bulb = TRUE
 
 /obj/item/device/camera/New()
 	..()
-	if(!start_without_bulb)
+	if(start_with_bulb)
 		flashbulb = new /obj/item/weapon/light/bulb(src)
 
 /obj/item/device/camera/Destroy()
@@ -145,7 +145,7 @@
 	..()
 
 /obj/item/device/camera/empty
-	start_without_bulb = TRUE
+	start_with_bulb = FALSE
 	pictures_left = 0
 
 /obj/item/device/camera/sepia
@@ -212,7 +212,7 @@
 
 /obj/item/device/camera/silicon
 	name = "silicon photo camera"
-	start_without_bulb = TRUE
+	start_with_bulb = FALSE
 	var/in_camera_mode = FALSE
 
 /obj/item/device/camera/silicon/ai_camera //camera AI can take pictures with

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -132,17 +132,21 @@
 
 	var/panelopen = FALSE
 	var/obj/item/weapon/light/bulb/flashbulb = null
-	var/skipbulb = FALSE
+	var/start_without_bulb = FALSE
 
 /obj/item/device/camera/New()
 	..()
-	if(!skipbulb)
+	if(!start_without_bulb)
 		flashbulb = new /obj/item/weapon/light/bulb(src)
 
 /obj/item/device/camera/Destroy()
 	qdel(flashbulb)
 	flashbulb = null
 	..()
+
+/obj/item/device/camera/empty
+	start_without_bulb = TRUE
+	pictures_left = 0
 
 /obj/item/device/camera/sepia
 	name = "camera"
@@ -208,8 +212,8 @@
 
 /obj/item/device/camera/silicon
 	name = "silicon photo camera"
+	start_without_bulb = TRUE
 	var/in_camera_mode = FALSE
-	skipbulb = TRUE
 
 /obj/item/device/camera/silicon/ai_camera //camera AI can take pictures with
 	name = "\improper AI photo camera"
@@ -240,11 +244,11 @@
 		to_chat(user, "You attach [C.amount > 5 ? "some" : "the"] wires to \the [src]'s flash circuit.")
 		if(loc == user)
 			user.drop_item(src, force_drop = 1)
-			var/obj/item/device/blinder/Q = new (get_turf(user))
+			var/obj/item/device/blinder/empty/Q = new(get_turf(user))
 			handle_blinder(Q)
 			user.put_in_hands(Q)
 		else
-			var/obj/item/device/blinder/Q = new (get_turf(loc))
+			var/obj/item/device/blinder/empty/Q = new(get_turf(loc))
 			handle_blinder(Q)
 		C.use(5)
 		qdel(src)
@@ -265,9 +269,6 @@
 	..()
 
 /obj/item/device/camera/proc/handle_blinder(obj/item/device/blinder/blinder)
-	if(blinder.flashbulb)
-		qdel(blinder.flashbulb)
-		blinder.flashbulb = null
 	if(flashbulb)
 		blinder.flashbulb = flashbulb
 		flashbulb.forceMove(blinder)

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -131,6 +131,18 @@
 	var/photo_size = 3 //Default is 3x3. 1x1, 5x5, 7x7 are also options
 
 	var/panelopen = FALSE
+	var/obj/item/weapon/light/bulb/flashbulb = null
+	var/skipbulb = FALSE
+
+/obj/item/device/camera/New()
+	..()
+	if(!skipbulb)
+		flashbulb = new /obj/item/weapon/light/bulb(src)
+
+/obj/item/device/camera/Destroy()
+	qdel(flashbulb)
+	flashbulb = null
+	..()
 
 /obj/item/device/camera/sepia
 	name = "camera"
@@ -197,6 +209,7 @@
 /obj/item/device/camera/silicon
 	name = "silicon photo camera"
 	var/in_camera_mode = FALSE
+	skipbulb = TRUE
 
 /obj/item/device/camera/silicon/ai_camera //camera AI can take pictures with
 	name = "\improper AI photo camera"
@@ -228,9 +241,11 @@
 		if(loc == user)
 			user.drop_item(src, force_drop = 1)
 			var/obj/item/device/blinder/Q = new (get_turf(user))
+			handle_blinder(Q)
 			user.put_in_hands(Q)
 		else
-			new /obj/item/device/blinder(get_turf(loc))
+			var/obj/item/device/blinder/Q = new (get_turf(loc))
+			handle_blinder(Q)
 		C.use(5)
 		qdel(src)
 
@@ -249,6 +264,14 @@
 			return
 	..()
 
+/obj/item/device/camera/proc/handle_blinder(obj/item/device/blinder/blinder)
+	if(blinder.flashbulb)
+		qdel(blinder.flashbulb)
+		blinder.flashbulb = null
+	if(flashbulb)
+		blinder.flashbulb = flashbulb
+		flashbulb.forceMove(blinder)
+		flashbulb = null
 
 /obj/item/device/camera/proc/camera_get_icon(list/turfs, turf/center)
 	var/atoms[] = list()

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -157,6 +157,10 @@
 	icon_off = "sepia-camera_off"
 	mech_flags = MECH_SCAN_FAIL
 
+/obj/item/device/camera/sepia/empty
+	start_with_bulb = FALSE
+	pictures_left = 0
+
 /obj/item/device/camera/big_photos
 	name = "\improper XL camera"
 	photo_size = 5
@@ -164,12 +168,20 @@
 /obj/item/device/camera/big_photos/set_zoom()
 	return
 
+/obj/item/device/camera/big_photos/empty
+	start_with_bulb = FALSE
+	pictures_left = 0
+
 /obj/item/device/camera/huge_photos
 	name = "\improper XXL camera"
 	photo_size = 7
 
 /obj/item/device/camera/huge_photos/set_zoom()
 	return
+
+/obj/item/device/camera/huge_photos/empty
+	start_with_bulb = FALSE
+	pictures_left = 0
 
 /obj/item/device/camera/examine(mob/user)
 	..()
@@ -273,6 +285,22 @@
 		blinder.flashbulb = flashbulb
 		flashbulb.forceMove(blinder)
 		flashbulb = null
+
+	blinder.name = name
+	blinder.icon = icon
+	blinder.desc = "[desc] The film chamber is filled with wire for some reason."
+	blinder.icon_state = icon_state
+	blinder.item_state = item_state
+	blinder.mech_flags = mech_flags
+
+	var/decon_paths = list(
+	/obj/item/device/camera/sepia = /obj/item/device/camera/sepia/empty,
+	/obj/item/device/camera/big_photos = /obj/item/device/camera/big_photos/empty,
+	/obj/item/device/camera/huge_photos = /obj/item/device/camera/huge_photos/empty
+	)
+
+	if(is_type_in_list(src, decon_paths))
+		blinder.decon_path = decon_paths[type]
 
 /obj/item/device/camera/proc/camera_get_icon(list/turfs, turf/center)
 	var/atoms[] = list()

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -197,7 +197,7 @@ var/global/list/obj/machinery/light/alllights = list()
 /obj/machinery/light/New()
 	..()
 	alllights += src
-	
+
 	spawn(2)
 		var/area/A = get_area(src)
 		if(A && !A.requires_power)
@@ -734,9 +734,10 @@ var/global/list/obj/machinery/light/alllights = list()
 
 	shatter()
 
-/obj/item/weapon/light/proc/shatter()
+/obj/item/weapon/light/proc/shatter(verbose = TRUE)
 	if(status == LIGHT_OK || status == LIGHT_BURNED)
-		src.visible_message("<span class='warning'>[name] shatters.</span>","<span class='warning'>You hear a small glass object shatter.</span>")
+		if(verbose)
+			src.visible_message("<span class='warning'>[name] shatters.</span>","<span class='warning'>You hear a small glass object shatter.</span>")
 		status = LIGHT_BROKEN
 		force = 5
 		playsound(src, 'sound/effects/Glasshit.ogg', 75, 1)

--- a/code/modules/projectiles/guns/projectile/constructable/blinder.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/blinder.dm
@@ -12,29 +12,32 @@
 	starting_materials = list(MAT_IRON = 2000)
 	w_type = RECYK_ELECTRONIC
 	var/cell = null
-	var/bulb = 1
-	var/burnedout = 0
+	var/obj/item/weapon/light/bulb/flashbulb = null
 	var/powercost = 10000
 
 /obj/item/device/blinder/Destroy()
 	if(cell)
 		qdel(cell)
 		cell = null
+	if(flashbulb)
+		qdel(flashbulb)
+		flashbulb = null
 	..()
 
 /obj/item/device/blinder/New()
 	..()
+	flashbulb = new(src)
 	update_verbs()
 
 /obj/item/device/blinder/examine(mob/user)
 	..()
-	if(bulb && burnedout)
-		to_chat(user, "<span class='warning'>\The [src]'s flash bulb is broken.</span>")
-	else if (!bulb)
-		to_chat(user, "<span class='info'>\The [src] appears to be missing a flash bulb.</span>")
+	if(flashbulb && flashbulb.status >= LIGHT_BROKEN)
+		to_chat(user, "<span class='warning'>\The [src]'s flashbulb is broken.</span>")
+	else if (!flashbulb)
+		to_chat(user, "<span class='info'>\The [src] appears to be missing a flashbulb.</span>")
 
 /obj/item/device/blinder/attack_self(mob/user as mob)
-	if(!bulb || burnedout || !cell)
+	if(!flashbulb || flashbulb.status >= LIGHT_BROKEN || !cell)
 		if (user)
 			user.visible_message("*click click*", "<span class='danger'>*click*</span>")
 			playsound(user, 'sound/weapons/empty.ogg', 100, 1)
@@ -46,8 +49,8 @@
 	if(cell)
 		var/obj/item/weapon/cell/C = cell
 		if(C.charge < powercost)
-			user.visible_message("[user] presses the button on \the [src], but the flash bulb merely flickers.","You press the button on \the [src], but the flash bulb merely flickers.")
-			to_chat(user, "<span class='warning'>There's not enough energy in the cell to power the flash bulb!</span>")
+			user.visible_message("[user] presses the button on \the [src], but the flashbulb merely flickers.","You press the button on \the [src], but the flashbulb merely flickers.")
+			to_chat(user, "<span class='warning'>There's not enough energy in the cell to power the flashbulb!</span>")
 			playsound(src, 'sound/weapons/empty.ogg', 100, 1)
 			return
 
@@ -62,8 +65,9 @@
 		to_chat(user, "<span class='warning'>\The [src]'s flash bulb shatters!</span>")
 
 		C.charge -= powercost
+		C.updateicon()
 
-		burnedout = 1
+		flashbulb.shatter(verbose = FALSE)
 		update_verbs()
 
 /obj/item/device/blinder/proc/flash(var/turf/T , var/mob/living/M)
@@ -87,7 +91,7 @@
 		verbs += /obj/item/device/blinder/verb/remove_cell
 	else
 		verbs -= /obj/item/device/blinder/verb/remove_cell
-	if(bulb && burnedout)
+	if(flashbulb && flashbulb.status >= LIGHT_BROKEN)
 		verbs += /obj/item/device/blinder/verb/remove_bulb
 	else
 		verbs -= /obj/item/device/blinder/verb/remove_bulb
@@ -121,16 +125,13 @@
 		to_chat(usr, "You can't do that while unconscious.")
 		return
 
-	if(!bulb)
+	if(!flashbulb)
 		return
 	else
-		var/obj/item/weapon/light/bulb/B = new (get_turf(usr))
-		B.status = LIGHT_BROKEN
-		B.update()
-		usr.put_in_hands(B)
-		bulb = 0
-		burnedout = 0
-		to_chat(usr, "You remove the broken [B.name] from \the [src].")
+		flashbulb.forceMove(get_turf(loc))
+		usr.put_in_hands(flashbulb)
+		to_chat(usr, "You remove the broken [flashbulb.name] from \the [src].")
+		flashbulb = null
 	update_verbs()
 
 /obj/item/device/blinder/attackby(obj/item/weapon/W, mob/user)
@@ -147,8 +148,8 @@
 		update_verbs()
 
 	if(istype(W, /obj/item/weapon/light/bulb))
-		if(bulb)
-			if(burnedout)
+		if(flashbulb)
+			if(flashbulb.status >= LIGHT_BROKEN)
 				to_chat(user, "<span class='warning'>You need to remove the damaged bulb first.</span>")
 				return
 			else
@@ -161,9 +162,11 @@
 		else if(B.status == LIGHT_BURNED)
 			to_chat(user, "<span class='warning'>That [B.name] is burned out, it won't function in \the [src].</span>")
 			return
-		bulb = 1
+		if(!user.drop_item(W, src))
+			to_chat(user, "<span class='warning'>You can't let go of \the [W]!</span>")
+			return 1
+		flashbulb = B
 		user.visible_message("[user] inserts \the [W] into \the [src].","You insert \the [W] into \the [src].")
-		qdel(W)
 		update_verbs()
 
 	if(istype(W, /obj/item/device/camera_film))
@@ -179,9 +182,22 @@
 		if(src.loc == user)
 			user.drop_item(src, force_drop = 1)
 			var/obj/item/device/camera/I = new (get_turf(user))
+			handle_camera(I)
 			user.put_in_hands(I)
 		else
-			new /obj/item/device/camera(get_turf(src.loc))
+			var/obj/item/device/camera/I = new(get_turf(loc))
+			handle_camera(I)
 		var/obj/item/stack/cable_coil/C = new (get_turf(user))
 		C.amount = 5
 		qdel(src)
+
+/obj/item/device/blinder/proc/handle_camera(obj/item/device/camera/camera)
+	if(camera.flashbulb)
+		qdel(camera.flashbulb)
+		camera.flashbulb = null
+	if(flashbulb)
+		camera.flashbulb = flashbulb
+		flashbulb.forceMove(camera)
+		flashbulb = null
+
+	camera.pictures_left = 0

--- a/code/modules/projectiles/guns/projectile/constructable/blinder.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/blinder.dm
@@ -14,6 +14,7 @@
 	var/cell = null
 	var/obj/item/weapon/light/bulb/flashbulb = null
 	var/start_with_bulb = TRUE
+	var/decon_path = /obj/item/device/camera/empty
 	var/powercost = 10000
 
 /obj/item/device/blinder/Destroy()
@@ -186,11 +187,11 @@
 		playsound(user, 'sound/items/Wirecutter.ogg', 50, 1)
 		if(src.loc == user)
 			user.drop_item(src, force_drop = 1)
-			var/obj/item/device/camera/empty/I = new(get_turf(user))
+			var/obj/item/device/camera/empty/I = new decon_path(get_turf(user))
 			handle_camera(I)
 			user.put_in_hands(I)
 		else
-			var/obj/item/device/camera/empty/I = new(get_turf(loc))
+			var/obj/item/device/camera/empty/I = new decon_path(get_turf(loc))
 			handle_camera(I)
 		var/obj/item/stack/cable_coil/C = new (get_turf(user))
 		C.amount = 5

--- a/code/modules/projectiles/guns/projectile/constructable/blinder.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/blinder.dm
@@ -13,6 +13,7 @@
 	w_type = RECYK_ELECTRONIC
 	var/cell = null
 	var/obj/item/weapon/light/bulb/flashbulb = null
+	var/start_without_bulb = FALSE
 	var/powercost = 10000
 
 /obj/item/device/blinder/Destroy()
@@ -26,8 +27,12 @@
 
 /obj/item/device/blinder/New()
 	..()
-	flashbulb = new(src)
+	if(!start_without_bulb)
+		flashbulb = new(src)
 	update_verbs()
+
+/obj/item/device/blinder/empty
+	start_without_bulb = TRUE
 
 /obj/item/device/blinder/examine(mob/user)
 	..()
@@ -181,23 +186,18 @@
 		playsound(user, 'sound/items/Wirecutter.ogg', 50, 1)
 		if(src.loc == user)
 			user.drop_item(src, force_drop = 1)
-			var/obj/item/device/camera/I = new (get_turf(user))
+			var/obj/item/device/camera/empty/I = new(get_turf(user))
 			handle_camera(I)
 			user.put_in_hands(I)
 		else
-			var/obj/item/device/camera/I = new(get_turf(loc))
+			var/obj/item/device/camera/empty/I = new(get_turf(loc))
 			handle_camera(I)
 		var/obj/item/stack/cable_coil/C = new (get_turf(user))
 		C.amount = 5
 		qdel(src)
 
 /obj/item/device/blinder/proc/handle_camera(obj/item/device/camera/camera)
-	if(camera.flashbulb)
-		qdel(camera.flashbulb)
-		camera.flashbulb = null
 	if(flashbulb)
 		camera.flashbulb = flashbulb
 		flashbulb.forceMove(camera)
 		flashbulb = null
-
-	camera.pictures_left = 0

--- a/code/modules/projectiles/guns/projectile/constructable/blinder.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/blinder.dm
@@ -13,7 +13,7 @@
 	w_type = RECYK_ELECTRONIC
 	var/cell = null
 	var/obj/item/weapon/light/bulb/flashbulb = null
-	var/start_without_bulb = FALSE
+	var/start_with_bulb = TRUE
 	var/powercost = 10000
 
 /obj/item/device/blinder/Destroy()
@@ -27,12 +27,12 @@
 
 /obj/item/device/blinder/New()
 	..()
-	if(!start_without_bulb)
+	if(start_with_bulb)
 		flashbulb = new(src)
 	update_verbs()
 
 /obj/item/device/blinder/empty
-	start_without_bulb = TRUE
+	start_with_bulb = FALSE
 
 /obj/item/device/blinder/examine(mob/user)
 	..()


### PR DESCRIPTION
Closes #17359 

:cl:
* bugfix: Retooled camera-to-blinder conversion and deconversion. No more infinite bulbs/film. Also, sepia, XL and XXL cameras will no longer be turned into normal cameras by it. Note that the process destroys all unused film inside.