### PR TITLE
Fixes AI-eye runtime

### DIFF
--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -65,9 +65,10 @@
 
 
 /mob/living/silicon/ai/Destroy()
-	eyeobj.ai = null
-	qdel(eyeobj) // No AI, no Eye
-	eyeobj = null
+	if(eyeobj)
+		eyeobj.ai = null
+		qdel(eyeobj) // No AI, no Eye
+		eyeobj = null
 	..()
 
 /atom/proc/move_camera_by_click()


### PR DESCRIPTION
Resolves #18315 

:cl:
* bugfix: Building an AI core without a brain or posibrain will now result in an inactive AI core you can upload a carded AI to. Previously this would bug out and make an AI without a player to control it.