### PR TITLE
Removes vampire blood costs, increases vampire cooldowns of abilities that used to cost blood.

### DIFF
--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -93,7 +93,7 @@
 /client/proc/vampire_rejuvinate()
 	set category = "Vampire"
 	set name = "Rejuvenate"
-	set desc= "Flush your system with spare blood to remove any incapacitating effects."
+	set desc= "Concentrate your power to remove any incapacitating effects. With enough total blood, you can heal yourself."
 	var/datum/mind/M = usr.mind
 	if(!M)
 		return
@@ -180,7 +180,7 @@
 		return
 	M.current.visible_message("<span class='warning'>[M.current.name]'s eyes flash briefly as he stares into [C.name]'s eyes</span>")
 	M.current.verbs -= /client/proc/vampire_hypnotise
-	spawn(1800)
+	spawn(2400)
 		if(M && M.current)
 			M.current.verbs += /client/proc/vampire_hypnotise
 	var/enhancements = ((C.knockdown ? 2 : 0) + (C.stunned ? 1 : 0) + (C.sleeping || C.paralysis ? 3 : 0))
@@ -202,7 +202,7 @@
 /client/proc/vampire_disease()
 	set category = "Vampire"
 	set name = "Diseased Touch"
-	set desc = "Touches your victim with infected blood giving them the Shutdown Syndrome which quickly shutsdown their major organs resulting in a quick painful death."
+	set desc = "Touches your victim with infected blood giving them the Shutdown Syndrome, which will result in a quick death."
 	var/datum/mind/M = usr.mind
 	if(!M)
 		return
@@ -235,7 +235,7 @@
 	infect_virus2(C,shutdown,0)
 	//M.current.remove_vampire_blood(50)//
 	M.current.verbs -= /client/proc/vampire_disease
-	sleep(1800)
+	sleep(3000)
 	if(M && M.current)
 		M.current.verbs += /client/proc/vampire_disease
 
@@ -339,14 +339,14 @@
 		playsound(M.current.loc, 'sound/effects/creepyshriek.ogg', 100, 1)
 		//M.current.remove_vampire_blood(30)//
 		M.current.verbs -= /client/proc/vampire_screech
-		sleep(1800)
+		sleep(2400)
 		if(M && M.current)
 			M.current.verbs += /client/proc/vampire_screech
 
 /client/proc/vampire_enthrall()
 	set category = "Vampire"
 	set name = "Enthrall"
-	set desc = "You use a large portion of your power to sway those loyal to none to be loyal to you only."
+	set desc = "You focus your power to sway those loyal to none to be loyal to you only."
 	var/datum/mind/M = usr.mind
 	if(!M)
 		return
@@ -364,7 +364,7 @@
 				//M.current.remove_vampire_blood(150)//
 				M.current.handle_enthrall(C)
 				M.current.verbs -= /client/proc/vampire_enthrall
-				sleep((VAMP_CHARISMA in M.vampire.powers) ? 600 : 1800)
+				sleep((VAMP_CHARISMA in M.vampire.powers) ? 600 : 6000)
 				if(M && M.current)
 					M.current.verbs += /client/proc/vampire_enthrall
 				return
@@ -512,7 +512,7 @@
 			new /mob/living/simple_animal/hostile/scarybat(M.current.loc, M.current)
 		//M.current.remove_vampire_blood(50)//
 		M.current.verbs -= /client/proc/vampire_bats
-		sleep(1200)
+		sleep(2400)
 		if(M && M.current) // Because our vampire can be completely destroyed after the sleep ends, who knows
 			M.current.verbs += /client/proc/vampire_bats
 
@@ -530,7 +530,7 @@
 		M.current.verbs -= /client/proc/vampire_jaunt
 		new /mob/living/simple_animal/hostile/scarybat(M.current.loc, M.current)
 		ethereal_jaunt(M.current, duration, "batify", "debatify", 0)
-		sleep(600)
+		sleep(900)
 		if(M && M.current)
 			M.current.verbs += /client/proc/vampire_jaunt
 
@@ -588,7 +588,7 @@
 			usr.forceMove(picked)
 		//M.current.remove_vampire_blood(10)//
 		M.current.verbs -= /client/proc/vampire_shadowstep
-		sleep(20 SECONDS)
+		sleep(100)
 		if(M && M.current)
 			M.current.verbs += /client/proc/vampire_shadowstep
 

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -92,7 +92,7 @@
 
 /client/proc/vampire_rejuvinate()
 	set category = "Vampire"
-	set name = "Rejuvenate "
+	set name = "Rejuvenate"
 	set desc= "Flush your system with spare blood to remove any incapacitating effects."
 	var/datum/mind/M = usr.mind
 	if(!M)
@@ -165,7 +165,7 @@
 
 /client/proc/vampire_hypnotise()
 	set category = "Vampire"
-	set name = "Hypnotise (10)"
+	set name = "Hypnotise"
 	set desc= "A piercing stare that incapacitates your victim for a good length of time."
 	var/datum/mind/M = usr.mind
 	if(!M)
@@ -185,7 +185,7 @@
 			M.current.verbs += /client/proc/vampire_hypnotise
 	var/enhancements = ((C.knockdown ? 2 : 0) + (C.stunned ? 1 : 0) + (C.sleeping || C.paralysis ? 3 : 0))
 	if(do_mob(M.current, C, 10 - enhancements))
-		M.current.remove_vampire_blood(10)
+		//M.current.remove_vampire_blood(10)
 		if(C.mind && C.mind.vampire)
 			to_chat(M.current, "<span class='warning'>Your piercing gaze fails to knock out [C.name].</span>")
 			to_chat(C, "<span class='notice'>[M.current.name]'s feeble gaze is ineffective.</span>")
@@ -201,7 +201,7 @@
 
 /client/proc/vampire_disease()
 	set category = "Vampire"
-	set name = "Diseased Touch (50)"
+	set name = "Diseased Touch"
 	set desc = "Touches your victim with infected blood giving them the Shutdown Syndrome which quickly shutsdown their major organs resulting in a quick painful death."
 	var/datum/mind/M = usr.mind
 	if(!M)
@@ -233,7 +233,7 @@
 	shutdown.stage = 2
 	shutdown.clicks = 185
 	infect_virus2(C,shutdown,0)
-	M.current.remove_vampire_blood(50)
+	//M.current.remove_vampire_blood(50)//
 	M.current.verbs -= /client/proc/vampire_disease
 	sleep(1800)
 	if(M && M.current)
@@ -312,7 +312,7 @@
 
 /client/proc/vampire_screech()
 	set category = "Vampire"
-	set name = "Chiroptean Screech (30)"
+	set name = "Chiroptean Screech"
 	set desc = "An extremely loud shriek that stuns nearby humans and breaks windows as well."
 	var/datum/mind/M = usr.mind
 	if(!M)
@@ -337,7 +337,7 @@
 		for(var/obj/structure/window/W in view(4))
 			W.Destroy(brokenup = 1)
 		playsound(M.current.loc, 'sound/effects/creepyshriek.ogg', 100, 1)
-		M.current.remove_vampire_blood(30)
+		//M.current.remove_vampire_blood(30)//
 		M.current.verbs -= /client/proc/vampire_screech
 		sleep(1800)
 		if(M && M.current)
@@ -345,7 +345,7 @@
 
 /client/proc/vampire_enthrall()
 	set category = "Vampire"
-	set name = "Enthrall (150)"
+	set name = "Enthrall"
 	set desc = "You use a large portion of your power to sway those loyal to none to be loyal to you only."
 	var/datum/mind/M = usr.mind
 	if(!M)
@@ -361,7 +361,7 @@
 		to_chat(C, "<span class='sinister'>You feel the tendrils of evil [(VAMP_CHARISMA in M.vampire.powers) ? "aggressively" : "slowly"] invade your mind.</span>")
 		if(do_mob(M.current, C, (VAMP_CHARISMA in M.vampire.powers) ? 150 : 300))
 			if(M.current.vampire_power(150, 0)) // recheck
-				M.current.remove_vampire_blood(150)
+				//M.current.remove_vampire_blood(150)//
 				M.current.handle_enthrall(C)
 				M.current.verbs -= /client/proc/vampire_enthrall
 				sleep((VAMP_CHARISMA in M.vampire.powers) ? 600 : 1800)
@@ -485,7 +485,7 @@
 
 /client/proc/vampire_bats()
 	set category = "Vampire"
-	set name = "Summon Bats (50)"
+	set name = "Summon Bats"
 	set desc = "You summon a trio of space bats who attack nearby targets until they or their target is dead."
 	var/datum/mind/M = usr.mind
 	if(!M)
@@ -510,7 +510,7 @@
 			new /mob/living/simple_animal/hostile/scarybat(M.current.loc, M.current)
 			new /mob/living/simple_animal/hostile/scarybat(M.current.loc, M.current)
 			new /mob/living/simple_animal/hostile/scarybat(M.current.loc, M.current)
-		M.current.remove_vampire_blood(50)
+		//M.current.remove_vampire_blood(50)//
 		M.current.verbs -= /client/proc/vampire_bats
 		sleep(1200)
 		if(M && M.current) // Because our vampire can be completely destroyed after the sleep ends, who knows
@@ -518,7 +518,7 @@
 
 /client/proc/vampire_jaunt()
 	set category = "Vampire"
-	set name = "Bat Form (20)"
+	set name = "Bat Form"
 	set desc = "You become ethereal and can travel through walls for a short time, while leaving a scary bat behind."
 	var/duration = 5 SECONDS
 	var/datum/mind/M = usr.mind
@@ -526,7 +526,7 @@
 		return
 
 	if(M.current.vampire_power(20, 0))
-		M.current.remove_vampire_blood(20)
+		//M.current.remove_vampire_blood(20)//
 		M.current.verbs -= /client/proc/vampire_jaunt
 		new /mob/living/simple_animal/hostile/scarybat(M.current.loc, M.current)
 		ethereal_jaunt(M.current, duration, "batify", "debatify", 0)
@@ -538,7 +538,7 @@
 // Less smoke spam.
 /client/proc/vampire_shadowstep()
 	set category = "Vampire"
-	set name = "Shadowstep (10)"
+	set name = "Shadowstep"
 	set desc = "Vanish into the shadows."
 
 	var/datum/mind/M = usr.mind
@@ -586,7 +586,7 @@
 			var/turf/T = get_turf(M.current)
 			T.turf_animation('icons/effects/effects.dmi',"shadowstep")
 			usr.forceMove(picked)
-		M.current.remove_vampire_blood(10)
+		//M.current.remove_vampire_blood(10)//
 		M.current.verbs -= /client/proc/vampire_shadowstep
 		sleep(20 SECONDS)
 		if(M && M.current)


### PR DESCRIPTION
 * experiment: Vampires have been slightly reworked!
 * tweak: Vampire abilities no longer cost blood.
 * tweak: All vampire abilities that used to have a cost had their cooldown increased.
 * tweak: Very slight description changes 

:cl:
This is more of an experimental PR. It's not properly done and it's a bit shoddy, but it should work. Personally, I want the community's opinion and coding advice. Vampires are controversial antagonists because they tend to do nothing for most of the round, players having dubbed it "vampstended". I believe that this can be attributed to a lack of confidence for vampires. It may be attributed to the following:
- Lack of powers as well as the give-away that you are a vampire when using the abilities.
- Cannot drink blood from dead people, which is an issue that was likely unintended, but I do not know how to fix.
- Some roles may have a very limited access to maintenance, or being in places that are too frequented by other players.
- Rounds with an AI and security personnel, you cannot kill or strip security personnel without setting off their secure GPS, while silicons are allowed to kill you on the default Asimov lawset, as well as being immune to most of your abilities.
- The only area of effect attacks available are both stuns, so you are at a massive disadvantage if a group comes after you. This is not a really viable design for solitary antagonists.

The purpose of the change is to encourage vampires to act without being restricted by the active blood mechanic, because they cannot drink from corpses. Personally, I would have wanted to turn vampires into a potential mid-round antagonist, they are unfit to have a fully dedicated antagonist role. However, I advise increasing the amount of players required until vampire is a gamemode that can be rolled, but adding this change to the PR would turn it into a bundle. It will become a separate PR at some point.
As I have mentioned, the changes are experimental, serving as both a way to assess the public opinion on vampires and agreed ways to make them better as well as hopefully receive feedback related to coding.
As for the list related to the vampire abilities, the cooldowns are as following:
- Hypnotise from 3 minutes to 4 minutes.
- Diseased touch from 3 minutes to 5 minutes.
- Chiroptean Screech from 3 minutes to 4 minutes.
- Enthrall from 3 minutes to 10 minutes.
- Summon Bats from 2 minutes to 4 minutes.
- Bat form from 1 minute to 1 minute and 30 seconds.
- Shadowstep from 2 seconds to 10 seconds. (I believe that the previous cooldown was 20 seconds, I will make the proper adjustments if this is the case.)
