### PR TITLE
Fixes typo in "Hypnotise", now renamed into "Hypnotize".

### DIFF
--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -165,7 +165,7 @@
 
 /client/proc/vampire_hypnotise()
 	set category = "Vampire"
-	set name = "Hypnotise (10)"
+	set name = "Hypnotize (10)"
 	set desc= "A piercing stare that incapacitates your victim for a good length of time."
 	var/datum/mind/M = usr.mind
 	if(!M)


### PR DESCRIPTION
[Exactly what it says on the tin.](http://tvtropes.org/pmwiki/pmwiki.php/Main/ExactlyWhatItSaysOnTheTin)
:cl:
 * spellcheck: Renamed "Hypnotise" to "Hypnotize"