### PR TITLE
Defib burn husks again

### DIFF
--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -136,15 +136,15 @@
 		to_chat(user, "<span class='notice'>You shock [target] with the paddles.</span>")
 		var/datum/organ/internal/heart/heart = target.get_heart()
 		if(!heart)
-			to_chat(user, "<span class='warning'>[src] buzzes: Defibrillation failed. Subject requires a heart.</span>")
+			target.visible_message("<span class='warning'>[src] buzzes: Defibrillation failed. Subject requires a heart.</span>")
 			target.apply_damage(rand(1,5),BURN,LIMB_CHEST)
 			return
 		var/datum/organ/external/head/head = target.get_organ(LIMB_HEAD)
 		if(!head || head.status & ORGAN_DESTROYED)
 			target.visible_message("<span class='warning'>[src] buzzes: Defibrillation failed. Severe cranial damage detected.</span>")
 			return
-		if(M_HUSK in target.mutations)
-			target.visible_message("<span class='warning'>[src] buzzes: Defibrillation failed. Irremediable cellular damage detected.</span>")
+		if((M_HUSK in target.mutations) && (M_NOCLONE in target.mutations))
+			target.visible_message("<span class='warning'>[src] buzzes: Defibrillation failed. Irremediable genetic damage detected.</span>")
 			return
 		if(!target.has_brain())
 			target.visible_message("<span class='warning'>[src] buzzes: Defibrillation failed. No central nervous system detected.</span>")
@@ -168,10 +168,10 @@
 					ghostmob << 'sound/effects/adminhelp.ogg'
 					to_chat(ghostmob, "<span class='interface big'><span class='bold'>Someone is trying to revive your body. Return to it if you want to be resurrected!</span> \
 						(Verbs -> Ghost -> Re-enter corpse, or <a href='?src=\ref[ghost];reentercorpse=1'>click here!</a>)</span>")
-					to_chat(user, "<span class='warning'>[src] buzzes: Defibrillation failed. Vital signs are too weak, please try again in five seconds.</span>")
+					target.visible_message(user, "<span class='warning'>[src] buzzes: Defibrillation failed. Vital signs are too weak, please try again in five seconds.</span>")
 					return
 			//we couldn't find a suitable ghost.
-			target.visible_message("<span class='warning'>[src] buzzes: Defibrillation failed. No brain waves detected.</span>")
+			target.visible_message("<span class='warning'>[src] buzzes: Defibrillation failed. No brainwaves detected.</span>")
 			return
 		if(prob(25))
 			heart.damage += 5 //Allow the defibrilator to possibly worsen heart damage. Still rare enough to just be the "clone damage" of the defib


### PR DESCRIPTION
#18187 locked extreme burn victims out of ever getting defibbed. Since this wasn't really part of the purpose of that PR, and it contributes slightly to the clonebay situation, I want to dial it back. This will make it so neither being burned to a husk, nor being severely irradiated alone will make a person categorically unable to be defibbed. Only having both statuses together will do this, since mutations-wise it imitates being absorbed by a changeling.

:cl:
* tweak: Extreme burn victims aren't impossible to defib anymore, unless they also happen to have severe radiation damage.