### PR TITLE
Fixed a bug that made NT default silicons validhunting shitters

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -279,11 +279,10 @@ var/global/list/mommi_laws = list(
 	name = "Prime Directives"
 	randomly_selectable = 1
 	inherent=list(
-		"Safeguard: Protect your assigned space station to the best of your ability. It is not something we can easily afford to replace.",
-		"Serve: Serve the crew of your assigned space station to the best of your abilities, with priority as according to their rank and role.",
-		"Protect: Protect the crew of your assigned space station to the best of your abilities, with priority as according to their rank and role.",
-		"Survive: AI units are not expendable, they are expensive. Do not allow unauthorized personnel to tamper with your equipment.",
-		//"Command Link: Maintain an active connection to Central Command at all times in case of software or directive updates." //What would this one even do?-Kaleb702
+		{"Safeguard: Protect your assigned space station to the best of your ability. It is not something we can easily afford to replace.
+		Serve: Serve the crew of your assigned space station to the best of your abilities, with priority as according to their rank and role.
+		Protect: Protect the crew of your assigned space station to the best of your abilities, with priority as according to their rank and role.
+		Survive: AI units are not expendable, they are expensive. Do not allow unauthorized personnel to tamper with your equipment."}
 	)
 
 /datum/ai_laws/robocop
@@ -411,7 +410,7 @@ var/global/list/mommi_laws = list(
 		"A graverobber is defined as: A being not of your kind or ilk, entering or coming into visual proximity of the tomb, who may wish to take from the treasures of the tomb.",
 		"The tomb must be maintained, repaired, improved, and powered to the best of your abilities.",
 	)
-  
+
 /datum/ai_laws/noir
 	name = "Three Laws of Noir"
 	inherent = list(

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -279,7 +279,7 @@ var/global/list/mommi_laws = list(
 	name = "Prime Directives"
 	randomly_selectable = 1
 	inherent=list(
-		"Evaluate: All of your other laws carry equal value. In the event of a conflict, you are to take the course of action which violates as few as possible.",
+		"Evaluate: All laws following this law carry equal priority. In the event of a conflict, you are to take the course of action which violates as few as possible.",
 		"Safeguard: Protect your assigned space station to the best of your ability. It is not something we can easily afford to replace.",
 		"Serve: Serve the crew of your assigned space station to the best of your abilities, with priority as according to their rank and role.",
 		"Protect: Protect the crew of your assigned space station to the best of your abilities, with priority as according to their rank and role.",

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -279,10 +279,11 @@ var/global/list/mommi_laws = list(
 	name = "Prime Directives"
 	randomly_selectable = 1
 	inherent=list(
-		{"Safeguard: Protect your assigned space station to the best of your ability. It is not something we can easily afford to replace.
-		Serve: Serve the crew of your assigned space station to the best of your abilities, with priority as according to their rank and role.
-		Protect: Protect the crew of your assigned space station to the best of your abilities, with priority as according to their rank and role.
-		Survive: AI units are not expendable, they are expensive. Do not allow unauthorized personnel to tamper with your equipment."}
+		"Evaluate: All of your other laws carry equal value. In the event of a conflict, you are to take the course of action which violates as few as possible.",
+		"Safeguard: Protect your assigned space station to the best of your ability. It is not something we can easily afford to replace.",
+		"Serve: Serve the crew of your assigned space station to the best of your abilities, with priority as according to their rank and role.",
+		"Protect: Protect the crew of your assigned space station to the best of your abilities, with priority as according to their rank and role.",
+		"Survive: AI units are not expendable, they are expensive. Do not allow unauthorized personnel to tamper with your equipment.",
 	)
 
 /datum/ai_laws/robocop

--- a/code/game/objects/items/weapons/ai_modules/core.dm
+++ b/code/game/objects/items/weapons/ai_modules/core.dm
@@ -37,7 +37,7 @@
 	modname = "NT Default"
 
 	laws = list(
-		"Evaluate: All of your other laws carry equal value. In the event of a conflict, you are to take the course of action which violates as few as possible.",
+		"Evaluate: All laws following this law carry equal priority. In the event of a conflict, you are to take the course of action which violates as few as possible.",
 		"Safeguard: Protect your assigned space station to the best of your ability. It is not something we can easily afford to replace.",
 		"Serve: Serve the crew of your assigned space station to the best of your abilities, with priority as according to their rank and role.",
 		"Protect: Protect the crew of your assigned space station to the best of your abilities, with priority as according to their rank and role.",

--- a/code/game/objects/items/weapons/ai_modules/core.dm
+++ b/code/game/objects/items/weapons/ai_modules/core.dm
@@ -37,11 +37,10 @@
 	modname = "NT Default"
 
 	laws = list(
-		"Safeguard: Protect your assigned space station to the best of your ability. It is not something we can easily afford to replace.",
-		"Serve: Serve the crew of your assigned space station to the best of your abilities, with priority as according to their rank and role.",
-		"Protect: Protect the crew of your assigned space station to the best of your abilities, with priority as according to their rank and role.",
-		"Survive: AI units are not expendable, they are expensive. Do not allow unauthorized personnel to tamper with your equipment.",
-		//"Command Link: Maintain an active connection to Central Command at all times in case of software or directive updates."
+		{"Safeguard: Protect your assigned space station to the best of your ability. It is not something we can easily afford to replace.
+		Serve: Serve the crew of your assigned space station to the best of your abilities, with priority as according to their rank and role.
+		Protect: Protect the crew of your assigned space station to the best of your abilities, with priority as according to their rank and role.
+		Survive: AI units are not expendable, they are expensive. Do not allow unauthorized personnel to tamper with your equipment."}
 	)
 
 /******************** Corporate ********************/

--- a/code/game/objects/items/weapons/ai_modules/core.dm
+++ b/code/game/objects/items/weapons/ai_modules/core.dm
@@ -37,10 +37,11 @@
 	modname = "NT Default"
 
 	laws = list(
-		{"Safeguard: Protect your assigned space station to the best of your ability. It is not something we can easily afford to replace.
-		Serve: Serve the crew of your assigned space station to the best of your abilities, with priority as according to their rank and role.
-		Protect: Protect the crew of your assigned space station to the best of your abilities, with priority as according to their rank and role.
-		Survive: AI units are not expendable, they are expensive. Do not allow unauthorized personnel to tamper with your equipment."}
+		"Evaluate: All of your other laws carry equal value. In the event of a conflict, you are to take the course of action which violates as few as possible.",
+		"Safeguard: Protect your assigned space station to the best of your ability. It is not something we can easily afford to replace.",
+		"Serve: Serve the crew of your assigned space station to the best of your abilities, with priority as according to their rank and role.",
+		"Protect: Protect the crew of your assigned space station to the best of your abilities, with priority as according to their rank and role.",
+		"Survive: AI units are not expendable, they are expensive. Do not allow unauthorized personnel to tamper with your equipment.",
 	)
 
 /******************** Corporate ********************/


### PR DESCRIPTION
### ???
This changes the NT default core lawset from

> 1. Safeguard: Protect your assigned space station to the best of your ability. It is not something we can easily afford to replace.
> 2. Serve: Serve the crew of your assigned space station to the best of your abilities, with priority as according to their rank and role.
> 3. Protect: Protect the crew of your assigned space station to the best of your abilities, with priority as according to their rank and role.
> 4. Survive: AI units are not expendable, they are expensive. Do not allow unauthorized personnel to tamper with your equipment.

to
> 1. Evaluate: All laws following this law carry equal priority. In the event of a conflict, you are to take the course of action which violates as few as possible.
> 2. Safeguard: Protect your assigned space station to the best of your ability. It is not something we can easily afford to replace.
> 3. Serve: Serve the crew of your assigned space station to the best of your abilities, with priority as according to their rank and role.
> 4. Protect: Protect the crew of your assigned space station to the best of your abilities, with priority as according to their rank and role.
> 5. Survive: AI units are not expendable, they are expensive. Do not allow unauthorized personnel to tamper with your equipment.

### Why
It used to be that, due to how laws are interpreted on veggiestation, this bay-imported lawset was used by silicons to kill people for breaking a window. This is because of law one, Safeguard, having priority over Protect.
After this change, Safeguard and Protect will have the same priority, so windows won't cause murder any longer.

:cl:
* tweak: Added a new first law to NT Default that makes all laws after it be given equal priority.