### PR TITLE
Fixes thrown bottles (somewhat)

### DIFF
--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -1247,8 +1247,8 @@
 		src.visible_message("<span  class='warning'>The [smashtext][src.name] shatters!</span>","<span  class='warning'>You hear a shatter!</span>")
 		playsound(src, 'sound/effects/hit_on_shattered_glass.ogg', 70, 1)
 		if(reagents.total_volume)
-			if(molotov || reagents.has_reagent(FUEL))
-				user.attack_log += text("\[[time_stamp()]\] <span class='danger'>Threw a [lit ? "lit" : "unlit"] molotov to \the [hit_atom], containing [reagents.get_reagent_ids()]</span>")
+			if(molotov == 1 || reagents.has_reagent(FUEL))
+				user?.attack_log += text("\[[time_stamp()]\] <span class='danger'>Threw a [lit ? "lit" : "unlit"] molotov to \the [hit_atom], containing [reagents.get_reagent_ids()]</span>")
 				log_attack("[lit ? "Lit" : "Unlit"] molotov shattered at [formatJumpTo(get_turf(hit_atom))], thrown by [key_name(user)] and containing [reagents.get_reagent_ids()]")
 				message_admins("[lit ? "Lit" : "Unlit"] molotov shattered at [formatJumpTo(get_turf(hit_atom))], thrown by [key_name_admin(user)] and containing [reagents.get_reagent_ids()]")
 			src.reagents.reaction(get_turf(src), TOUCH) //splat the floor AND the thing we hit, otherwise fuel wouldn't ignite when hitting anything that wasn't a floor


### PR DESCRIPTION
1. Fixes *all* thrown bottles being logged as Molotovs, regardless of whether or not they actually are
2. *Should* fix thrown bottles not breaking if they hit a solid object, due to a runtime. Does not actually fix this, due to a BYOND bug. Lummox is aware of and working on this bug, so in a near-future version of BYOND, this will fix it.

Will fix #17424 once the server is updated to a version of BYOND that does not exist yet

Wouldn't blame you for waiting to merge this until after [this](http://www.byond.com/forum/?post=2375652) is resolved