### PR TITLE
Enables ghost pointing

### DIFF
--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -46,6 +46,9 @@
 	//next_move = world.time + 8
 
 	var/list/modifiers = params2list(params)
+	if(modifiers["middle"] && modifiers["shift"])
+		MiddleShiftClickOn(A)
+		return
 	if(modifiers["middle"])
 		MiddleClickOn(A)
 		return

--- a/code/modules/mob/living/simple_animal/hostile/wolf.dm
+++ b/code/modules/mob/living/simple_animal/hostile/wolf.dm
@@ -387,7 +387,7 @@
 			alpha_target = target
 
 /mob/living/simple_animal/hostile/wolf/pointed_at(mob/pointer)
-	if(!isDead())
+	if(!isDead() && see_invisible >= pointer.invisibility)
 		if(pointer == pack_alpha)
 			switch(alpha_stance)
 				if(ALPHAFOLLOW)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -997,7 +997,7 @@ var/list/slot_equipment_priority = list( \
 	set name = "Point To"
 	set category = "Object"
 
-	if(!src || usr.isUnconscious() || !isturf(src.loc) || !(A in view(src.loc)))
+	if(!src || (usr.isUnconscious() && !isobserver(src)) || !isturf(src.loc) || !(A in view(src.loc)))
 		return 0
 
 	if(istype(A, /obj/effect/decal/point))


### PR DESCRIPTION
So I noticed ghosts seem to have all the proper sanity for pointing and not revealing things to the living. They're only locked out of it because of how ``isUnconscious()`` works.

:cl:
* tweak: Ghosts can point now.