### PR TITLE
Fixes oversight that probably has no current effect

### DIFF
--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -521,7 +521,7 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 						R.reaction_mob(A, TOUCH, R.volume+volume_modifier)
 				if(isturf(A))
 					R.reaction_turf(A, R.volume+volume_modifier)
-				if(isobj(A))
+				if(istype(A, /obj))
 					R.reaction_obj(A, R.volume+volume_modifier)
 		if(INGEST)
 			for(var/datum/reagent/R in reagent_list)
@@ -532,7 +532,7 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 						R.reaction_mob(A, INGEST, R.volume+volume_modifier)
 				if(isturf(A) && R)
 					R.reaction_turf(A, R.volume+volume_modifier)
-				if(isobj(A) && R)
+				if(istype(A, /obj) && R)
 					R.reaction_obj(A, R.volume+volume_modifier)
 	return
 


### PR DESCRIPTION
Reagent smoke would apply `reaction_obj()` to lighting overlays. As far as I am aware, no current `reaction_obj()` actually *affects* lighting overlays, but #18492 does.

The reason this change works: `isobj(Val)` is not, in fact, equivalent to `istype(Val, /obj)`. Internally, all movable atoms are either mobs or objs. Code-defined children of `/atom/movable` are thus objs, even though they do not inherit from `/obj`. `isobj()` therefore returns true for them.
All direct children of `/atom/movable` that we use are "virtual" objects like the lighting overlay, and none of them should be affected by reagents. I don't believe any of them would have ever been in a position where that mattered, though, so this really only applies to the lighting overlays.