### PR TITLE
allows grenade launcher on armor suit slot

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -10,6 +10,7 @@
 		/obj/item/weapon/gun/lawgiver,
 		/obj/item/weapon/gun/siren,
 		/obj/item/weapon/gun/mahoguny,
+		/obj/item/weapon/gun/grenadelauncher,
 		/obj/item/weapon/bikehorn/baton,
 		/obj/item/weapon/blunderbuss
 		)


### PR DESCRIPTION
🆑 
 - tweak: You can now slot grenade launchers onto armored vests.