### PR TITLE
Basic way to eject things from transit tube pods

### DIFF
--- a/code/game/objects/structures/transit_tubes.dm
+++ b/code/game/objects/structures/transit_tubes.dm
@@ -135,10 +135,11 @@ obj/structure/transit_tube_pod/ex_act(severity)
 						for(var/atom/movable/AM in pod)
 							if(isobserver(AM))
 								continue
-							AM.forceMove(get_turf(user))
+							AM.forceMove(get_step(loc, dir))
 							unloaded = TRUE
 						if(unloaded)
 							user.visible_message("<span class='notice'>[user] unloads everything from the pod.</span>", "<span class='notice'>You unload everything from the pod.</span>")
+							return
 					close_animation()
 				else
 					open_animation()

--- a/code/game/objects/structures/transit_tubes.dm
+++ b/code/game/objects/structures/transit_tubes.dm
@@ -130,8 +130,14 @@ obj/structure/transit_tube_pod/ex_act(severity)
 		for(var/obj/structure/transit_tube_pod/pod in loc)
 			if(!pod.moving && pod.dir in directions())
 				if(open)
+					if(!user.lying)
+						var/unloaded = FALSE
+						for(var/atom/movable/AM in pod)
+							AM.forceMove(get_turf(user))
+							unloaded = TRUE
+						if(unloaded)
+							user.visible_message("<span class='notice'>[user] unloads everything from the pod.</span>", "<span class='notice'>You unload everything from the pod.</span>")
 					close_animation()
-
 				else
 					open_animation()
 

--- a/code/game/objects/structures/transit_tubes.dm
+++ b/code/game/objects/structures/transit_tubes.dm
@@ -153,13 +153,14 @@ obj/structure/transit_tube_pod/ex_act(severity)
 	..()
 	if(ismob(AM) && contents.len > 1)
 		var/mob/M = AM
-		if(M.blinded)
+		if(M.blinded || !M.client)
 			return
 		var/others = contents.Copy() - M
 		for(var/atom/movable/O in others)
 			if(O.invisibility > M.see_invisible)
 				others -= O
-		to_chat(M, "<span class='info'>You notice the pod contains [english_list(others)]</span>.")
+		if(others.len)
+			to_chat(M, "<span class='info'>You notice the pod contains [english_list(others)]</span>.")
 
 
 /obj/structure/transit_tube/station/proc/open_animation()

--- a/code/game/objects/structures/transit_tubes.dm
+++ b/code/game/objects/structures/transit_tubes.dm
@@ -1,3 +1,4 @@
+#define TUBE_POD_UNLOAD_LIMIT 20
 
 // Basic transit tubes. Straight pieces, curved sections,
 //  and basic splits/joins (no routing logic).
@@ -131,16 +132,25 @@ obj/structure/transit_tube_pod/ex_act(severity)
 			if(!pod.moving && pod.dir in directions())
 				if(open)
 					if(!user.lying && user.loc != pod)
-						var/unloaded = FALSE
+						var/unloaded = 0
+						var/incomplete = FALSE
+
 						for(var/atom/movable/AM in pod)
 							if(isobserver(AM))
 								continue
+							if(unloaded >= TUBE_POD_UNLOAD_LIMIT)
+								incomplete = TRUE
+								break
 							AM.forceMove(get_step(loc, dir))
-							unloaded = TRUE
+							unloaded++
+
 						if(unloaded)
-							user.visible_message("<span class='notice'>[user] unloads everything from the pod.</span>", "<span class='notice'>You unload everything from the pod.</span>")
+							user.visible_message("<span class='notice'>[user] unloads [incomplete ? "some things" : "everything"] from the tube pod.</span>", \
+							"<span class='notice'>You unload [incomplete ? "some things" : "everything"] from the tube pod.</span>")
 							return
+
 					close_animation()
+
 				else
 					open_animation()
 
@@ -161,7 +171,7 @@ obj/structure/transit_tube_pod/ex_act(severity)
 			if(O.invisibility > M.see_invisible)
 				others -= O
 		if(others.len)
-			to_chat(M, "<span class='info'>You notice the pod contains [english_list(others)]</span>.")
+			to_chat(M, "<span class='info'>You notice the tube pod contains [english_list(others)]</span>.")
 
 
 /obj/structure/transit_tube/station/proc/open_animation()
@@ -648,3 +658,5 @@ obj/structure/transit_tube_pod/ex_act(severity)
 			return "SW"
 		else
 	return
+
+#undef TUBE_POD_UNLOAD_LIMIT

--- a/code/game/objects/structures/transit_tubes.dm
+++ b/code/game/objects/structures/transit_tubes.dm
@@ -125,14 +125,16 @@ obj/structure/transit_tube_pod/ex_act(severity)
 	..()
 
 
-/obj/structure/transit_tube/station/attack_hand(mob/user as mob)
+/obj/structure/transit_tube/station/attack_hand(mob/user)
 	if(!pod_moving)
 		for(var/obj/structure/transit_tube_pod/pod in loc)
 			if(!pod.moving && pod.dir in directions())
 				if(open)
-					if(!user.lying)
+					if(!user.lying && user.loc != pod)
 						var/unloaded = FALSE
 						for(var/atom/movable/AM in pod)
+							if(isobserver(AM))
+								continue
 							AM.forceMove(get_turf(user))
 							unloaded = TRUE
 						if(unloaded)
@@ -141,6 +143,23 @@ obj/structure/transit_tube_pod/ex_act(severity)
 				else
 					open_animation()
 
+
+/obj/structure/transit_tube/station/attack_robot(mob/user)
+	if(Adjacent(user))
+		attack_hand(user)
+
+
+/obj/structure/transit_tube_pod/Entered(atom/movable/AM)
+	..()
+	if(ismob(AM) && contents.len > 1)
+		var/mob/M = AM
+		if(M.blinded)
+			return
+		var/others = contents.Copy() - M
+		for(var/atom/movable/O in others)
+			if(O.invisibility > M.see_invisible)
+				others -= O
+		to_chat(M, "<span class='info'>You notice the pod contains [english_list(others)]</span>.")
 
 
 /obj/structure/transit_tube/station/proc/open_animation()

--- a/code/game/objects/structures/transit_tubes.dm
+++ b/code/game/objects/structures/transit_tubes.dm
@@ -155,7 +155,7 @@ obj/structure/transit_tube_pod/ex_act(severity)
 		var/mob/M = AM
 		if(M.blinded || !M.client)
 			return
-		var/others = contents.Copy() - M
+		var/list/others = contents.Copy() - M
 		for(var/atom/movable/O in others)
 			if(O.invisibility > M.see_invisible)
 				others -= O

--- a/code/game/objects/structures/transit_tubes.dm
+++ b/code/game/objects/structures/transit_tubes.dm
@@ -160,18 +160,28 @@ obj/structure/transit_tube_pod/ex_act(severity)
 		attack_hand(user)
 
 
-/obj/structure/transit_tube_pod/Entered(atom/movable/AM)
+/obj/structure/transit_tube_pod/examine(mob/user)
 	..()
-	if(ismob(AM) && contents.len > 1)
-		var/mob/M = AM
-		if(M.blinded || !M.client)
+	show_occupants(user)
+
+
+/obj/structure/transit_tube/examine(mob/user)
+	..()
+	for(var/obj/structure/transit_tube_pod/pod in loc)
+		pod.show_occupants(user)
+
+
+/obj/structure/transit_tube_pod/proc/show_occupants(mob/user)
+	if(contents.len)
+		var/list/occupants = contents.Copy()
+		for(var/atom/movable/O in occupants)
+			if(O.invisibility > user.see_invisible)
+				occupants -= O
+		if(occupants.len)
+			to_chat(user, "<span class='info'>The tube pod contains [english_list(occupants)].</span>")
 			return
-		var/list/others = contents.Copy() - M
-		for(var/atom/movable/O in others)
-			if(O.invisibility > M.see_invisible)
-				others -= O
-		if(others.len)
-			to_chat(M, "<span class='info'>You notice the tube pod contains [english_list(others)]</span>.")
+
+	to_chat(user, "<span class='info'>The tube pod looks empty.</span>")
 
 
 /obj/structure/transit_tube/station/proc/open_animation()


### PR DESCRIPTION
Resolves #15034

This dumps everything in the pod onto ~~your own turf, so maybe not perfect~~ the turf in front of the pod station.

:cl:
* rscadd: Added a basic way to eject people and objects from transit tube pods. Just click the open pod with your empty hand. Additionally, examining the pod or the tube will now show you what's in it.