### PR TITLE
Added 'Does Not Tip' backdoor traitor item

### DIFF
--- a/__DEFINES/global.dm
+++ b/__DEFINES/global.dm
@@ -384,3 +384,5 @@ var/list/boss_mobs = list(
 	/mob/living/simple_animal/hostile/alien/queen/large,	// The bigger and beefier version of queens.
 	)
 
+// Set by traitor item, affects cargo supplies
+var/station_does_not_tip = FALSE

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -31,6 +31,10 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 		AM.forceMove(null)	//just to make sure they're deleted by the garbage collector
 	manifest += "</ul>"
 
+// Called after a crate containing the items specified by this datum is created
+/datum/supply_packs/proc/post_creation(var/atom/movable/container)
+	return
+
 //////SUPPLIES//////
 
 /datum/supply_packs/toner
@@ -1084,6 +1088,15 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	containertype = /obj/structure/closet/crate/freezer
 	containername = "pizza crate"
 	group = "Hospitality"
+
+/datum/supply_packs/randomised/pizza/post_creation(var/atom/movable/container)
+	if(!station_does_not_tip)
+		return
+	for(var/obj/item/pizzabox/box in container)
+		var/obj/item/weapon/reagent_containers/food/snacks/sliceable/pizza/pizza = box.pizza
+		if(!pizza)
+			continue
+		pizza.make_poisonous()
 
 /datum/supply_packs/cafe
 	name = "Cafe equipment"

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -56,6 +56,8 @@ var/list/uplink_items = list()
 	var/list/job = null
 	var/only_on_month	//two-digit month as string
 	var/only_on_day		//two-digit day as string
+	var/unique = FALSE	// Can only be bought once, globally
+	var/static/times_bought = 0
 
 /datum/uplink_item/proc/spawn_item(var/turf/loc, var/obj/item/device/uplink/U, mob/user)
 	U.uses -= max(cost, 0)
@@ -278,6 +280,14 @@ var/list/uplink_items = list()
 	name = "Meat Cleaver"
 	desc = "A mean looking meat cleaver that does damage comparable to an Energy Sword but with the added benefit of chopping your victim into hunks of meat after they've died and the chance to stun when thrown."
 	item = /obj/item/weapon/kitchen/utensil/knife/large/butch/meatcleaver
+	cost = 10
+	job = list("Chef")
+
+/datum/uplink_item/jobspecific/does_not_tip_note
+	name = "\"Does Not Tip\" database backdoor"
+	desc = "Lets you add or remove your station to the \"does not tip\" list kept by the cargo workers at Central Command. You can be sure all pizza orders will be poisoned from the moment the screen flashes red."
+	item = /obj/item/device/does_not_tip_backdoor
+	unique = TRUE
 	cost = 10
 	job = list("Chef")
 

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -709,7 +709,7 @@ var/list/uplink_items = list()
 	cost = 6
 	gamemodes = list("nuclear emergency")
 
-/datum/uplink_item/does_not_tip_note
+/datum/uplink_item/device_tools/does_not_tip_note
 	name = "\"Does Not Tip\" database backdoor"
 	desc = "Lets you add or remove your station to the \"does not tip\" list kept by the cargo workers at Central Command. You can be sure all pizza orders will be poisoned from the moment the screen flashes red."
 	item = /obj/item/device/does_not_tip_backdoor

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -288,14 +288,6 @@ var/list/uplink_items = list()
 	cost = 10
 	job = list("Chef")
 
-/datum/uplink_item/jobspecific/does_not_tip_note
-	name = "\"Does Not Tip\" database backdoor"
-	desc = "Lets you add or remove your station to the \"does not tip\" list kept by the cargo workers at Central Command. You can be sure all pizza orders will be poisoned from the moment the screen flashes red."
-	item = /obj/item/device/does_not_tip_backdoor
-	unique = TRUE
-	cost = 10
-	job = list("Chef")
-
 //Janitor
 /datum/uplink_item/jobspecific/cautionsign
 	name = "Proximity Mine"
@@ -716,6 +708,13 @@ var/list/uplink_items = list()
 	item = /obj/structure/popout_cake
 	cost = 6
 	gamemodes = list("nuclear emergency")
+
+/datum/uplink_item/does_not_tip_note
+	name = "\"Does Not Tip\" database backdoor"
+	desc = "Lets you add or remove your station to the \"does not tip\" list kept by the cargo workers at Central Command. You can be sure all pizza orders will be poisoned from the moment the screen flashes red."
+	item = /obj/item/device/does_not_tip_backdoor
+	unique = TRUE
+	cost = 10
 
 // IMPLANTS
 

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -77,6 +77,10 @@ var/list/uplink_items = list()
 	if (!( istype(user, /mob/living/carbon/human)))
 		return 0
 
+	if(unique && times_bought >= 1)
+		to_chat(user, "<span class='warning'>This item is not available anymore.</span>")
+		return 0
+
 	// If the uplink's holder is in the user's contents
 	if ((U.loc in user.contents || (in_range(U.loc, user) && istype(U.loc.loc, /turf))))
 		user.set_machine(U)
@@ -105,6 +109,7 @@ var/list/uplink_items = list()
 
 			U.purchase_log += {"[user] ([user.ckey]) bought <img src="logo_[tempstate].png"> [name] for [cost]."}
 			stat_collection.uplink_purchase(src, I, user)
+			times_bought += 1
 			if(user.mind)
 				user.mind.uplink_items_bought += {"<img src="logo_[tempstate].png"> [bundlename]"}
 				user.mind.spent_TC += cost

--- a/code/game/objects/items/devices/does_not_tip.dm
+++ b/code/game/objects/items/devices/does_not_tip.dm
@@ -1,0 +1,15 @@
+/obj/item/device/does_not_tip_backdoor
+	name = "\improper PDA"
+	desc = "The screen seems to be blank."
+	icon = 'icons/obj/pda.dmi'
+	icon_state = "pda"
+	w_class = W_CLASS_TINY
+	flags = FPRINT
+
+/obj/item/device/does_not_tip_backdoor/attack_self(var/mob/user)
+	if(alert(user, "A cryptic message appears on the screen: \"Are you sure you want to do it?\".", name, "Yes", "No") != "Yes")
+		return
+	if(user.incapacitated() || !Adjacent(user))
+		return
+	station_does_not_tip = !station_does_not_tip
+	to_chat(user, "<span class='notice'>\The [src]'s screen flashes [station_does_not_tip ? "red" : "green"] for a moment.</span>")

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -257,6 +257,8 @@ var/datum/controller/supply_shuttle/supply_shuttle = new
 				B2:amount = SP.amount
 			slip.info += "<li>[B2.name]</li>" //add the item to the manifest
 
+		SP.post_creation(A)
+
 		//manifest finalisation
 
 		slip.info += {"</ul><br>

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -88,6 +88,9 @@
 
 	return
 
+/obj/item/weapon/reagent_containers/food/snacks/proc/make_poisonous()
+	return
+
 /obj/item/weapon/reagent_containers/food/snacks/attack_self(mob/user)
 	if(can_consume(user, user))
 		consume(user, 1)
@@ -2952,6 +2955,22 @@
 	reagents.add_reagent(TOMATOJUICE, 6)
 	bitesize = 2
 
+/obj/item/weapon/reagent_containers/food/snacks/sliceable/pizza/margherita/make_poisonous()
+	reagents.clear_reagents()
+	var/static/list/possible_poisons = list(
+		BLEACH,
+		PLASMA,
+		TOXIN,
+		SOLANINE,
+		PLASTICIDE,
+		RADIUM,
+		CRYPTOBIOLIN,
+		IMPEDREZENE,
+		SOYSAUCE
+	)
+	for(var/i in 1 to 6)
+		reagents.add_reagent(pick(possible_poisons), rand(5, 10))
+
 /obj/item/weapon/reagent_containers/food/snacks/margheritaslice
 	name = "Margherita slice"
 	desc = "A slice of the most cheezy pizza in galaxy"
@@ -2972,6 +2991,24 @@
 	reagents.add_reagent(NUTRIMENT, 50)
 	reagents.add_reagent(TOMATOJUICE, 6)
 	bitesize = 2
+
+/obj/item/weapon/reagent_containers/food/snacks/sliceable/pizza/meatpizza/make_poisonous()
+	reagents.clear_reagents()
+
+	var/datum/disease2/disease/new_virus = new /datum/disease2/disease
+	new_virus.makerandom()
+
+	var/list/blood_data = list(
+		"donor" = null,
+		"viruses" = null,
+		"blood_DNA" = null,
+		"blood_type" = "AB+",
+		"resistances" = null,
+		"trace_chem" = null,
+		"virus2" = list()
+	)
+	blood_data["virus2"]["[new_virus.uniqueID]"] = new_virus
+	reagents.add_reagent(BLOOD, 56, blood_data)
 
 /obj/item/weapon/reagent_containers/food/snacks/meatpizzaslice
 	name = "Meatpizza slice"
@@ -3012,6 +3049,14 @@
 	reagents.add_reagent(NUTRIMENT, 35)
 	bitesize = 2
 
+/obj/item/weapon/reagent_containers/food/snacks/sliceable/pizza/mushroompizza/make_poisonous()
+	reagents.clear_reagents()
+	var/static/list/possible_poisons = list(
+		MINDBREAKER,
+		SPIRITBREAKER
+	)
+	reagents.add_reagent(pick(possible_poisons), 35)
+
 /obj/item/weapon/reagent_containers/food/snacks/mushroompizzaslice
 	name = "Mushroompizza slice"
 	desc = "Maybe it is the last slice of pizza in your life."
@@ -3033,6 +3078,10 @@
 	reagents.add_reagent(TOMATOJUICE, 6)
 	reagents.add_reagent(IMIDAZOLINE, 12)
 	bitesize = 2
+
+/obj/item/weapon/reagent_containers/food/snacks/sliceable/pizza/vegetablepizza/make_poisonous()
+	reagents.clear_reagents()
+	reagents.add_reagent(MUTAGEN, 48)
 
 /obj/item/weapon/reagent_containers/food/snacks/vegetablepizzaslice
 	name = "Vegetable pizza slice"

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -2956,6 +2956,7 @@
 	bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/sliceable/pizza/margherita/make_poisonous()
+	var/original_total_volume = reagents.total_volume
 	reagents.clear_reagents()
 	var/static/list/possible_poisons = list(
 		BLEACH,
@@ -2968,7 +2969,7 @@
 		IMPEDREZENE,
 		SOYSAUCE
 	)
-	for(var/i in 1 to 6)
+	while(reagents.total_volume < original_total_volume)
 		reagents.add_reagent(pick(possible_poisons), rand(5, 10))
 
 /obj/item/weapon/reagent_containers/food/snacks/margheritaslice
@@ -2993,6 +2994,7 @@
 	bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/sliceable/pizza/meatpizza/make_poisonous()
+	var/original_total_volume = reagents.total_volume
 	reagents.clear_reagents()
 
 	var/datum/disease2/disease/new_virus = new /datum/disease2/disease
@@ -3008,7 +3010,7 @@
 		"virus2" = list()
 	)
 	blood_data["virus2"]["[new_virus.uniqueID]"] = new_virus
-	reagents.add_reagent(BLOOD, 56, blood_data)
+	reagents.add_reagent(BLOOD, original_total_volume, blood_data)
 
 /obj/item/weapon/reagent_containers/food/snacks/meatpizzaslice
 	name = "Meatpizza slice"
@@ -3050,12 +3052,13 @@
 	bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/sliceable/pizza/mushroompizza/make_poisonous()
+	var/original_total_volume = reagents.total_volume
 	reagents.clear_reagents()
 	var/static/list/possible_poisons = list(
 		MINDBREAKER,
 		SPIRITBREAKER
 	)
-	reagents.add_reagent(pick(possible_poisons), 35)
+	reagents.add_reagent(pick(possible_poisons), original_total_volume)
 
 /obj/item/weapon/reagent_containers/food/snacks/mushroompizzaslice
 	name = "Mushroompizza slice"
@@ -3080,8 +3083,9 @@
 	bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/sliceable/pizza/vegetablepizza/make_poisonous()
+	var/original_total_volume = reagents.total_volume
 	reagents.clear_reagents()
-	reagents.add_reagent(MUTAGEN, 48)
+	reagents.add_reagent(MUTAGEN, original_total_volume)
 
 /obj/item/weapon/reagent_containers/food/snacks/vegetablepizzaslice
 	name = "Vegetable pizza slice"

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -692,6 +692,7 @@
 #include "code\game\objects\items\devices\codebreaker.dm"
 #include "code\game\objects\items\devices\debugger.dm"
 #include "code\game\objects\items\devices\deskbell.dm"
+#include "code\game\objects\items\devices\does_not_tip.dm"
 #include "code\game\objects\items\devices\flash.dm"
 #include "code\game\objects\items\devices\flashlight.dm"
 #include "code\game\objects\items\devices\fuse_bomb.dm"


### PR DESCRIPTION
Closes #18402

Disguised as a PDA, lets you put the station on or off the "Does Not Tip" list.
Being on the list means all pizza orders will be poisoned in various ways.

- All nutriment is removed from the pizza
- Pizza can contain virii, toxic chemicals, mutagen, or strong acids
- Costs 10 TC

Extras: 
- Added a `unique` var for uplink item datums, if set only one item of this kind can be bought during the round. This could be a lame idea.

:cl:
 * rscadd: Added a new traitor item: "Does Not Tip" database backdoor. Once purchased, lets you add the station to Central Command's "Does Not Tip" database. Stations on the list get extra condiment with their pizza.