### PR TITLE
Adds sanity to fabricator process

### DIFF
--- a/code/modules/research/fabricators.dm
+++ b/code/modules/research/fabricators.dm
@@ -156,7 +156,7 @@
 
 /obj/machinery/r_n_d/fabricator/process()
 	..()
-	if(busy || being_built)
+	if(busy || being_built || stat&(NOPOWER|BROKEN))
 		return
 	if(stopped)
 		if(auto_make && last_made && !queue.len)


### PR DESCRIPTION
closes #18526

Turns out process just didn't check if the fabricator was broken or unpowered. The supercall is 

/obj/machinery/r_n_d/process()
	..()
	if(shocked>0)
		shocked--

And the supercall of that is 

/obj/machinery/process() // If you dont use process or power why are you here
	set waitfor = FALSE
	return PROCESS_KILL