### PR TITLE
Adds bees to blacklisted_mobs

### DIFF
--- a/__DEFINES/global.dm
+++ b/__DEFINES/global.dm
@@ -372,7 +372,8 @@ var/list/blacklisted_mobs = list(
 		/mob/living/slime_pile, // They are dead.
 		/mob/living/adamantine_dust, // Ditto
 		/mob/living/simple_animal/hostile/viscerator, //Nope.
-		/mob/living/simple_animal/hostile/mining_drone //This thing is super broken in the hands of a player and it was never meant to be summoned out of actual mining drone cubes.
+		/mob/living/simple_animal/hostile/mining_drone, //This thing is super broken in the hands of a player and it was never meant to be summoned out of actual mining drone cubes.
+		/mob/living/simple_animal/bee //Aren't set up to be playable
 		)
 
 //Boss monster list


### PR DESCRIPTION
Fixes #18559 

Because transforming into bees 3.0 with the amorphous mask seems to make you die.

Also the "menagerie" large artifact effect doesn't look like it even uses this list like it probably should.