### PR TITLE
Lazily fixes MoMMI holomaps fucking up

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_verbs.dm
+++ b/code/modules/mob/living/silicon/robot/robot_verbs.dm
@@ -51,7 +51,7 @@
 	set name = "Toggle Station Holomap"
 	set desc = "Toggle station holomap on your screen"
 
-	if(isDead() || !is_component_functioning("camera"))
+	if(!isUnconscious())
 		return
 
 	station_holomap.toggleHolomap(src)


### PR DESCRIPTION
Basically the MoMMI camera/radio components always fail an is_component_functioning() check even if they're functioning(and i have no clue why, yet.) but i was supposed to make this verb only rely on power cell anyways so here we go.

Closes #18551

:cl:
 * bugfix: Fixes MoMMIs being unable to use their station holomap verb