### PR TITLE
Changes the Albuteol (athsma medication) recipe.

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -3055,7 +3055,7 @@
 	name = "Albuterol"
 	id = ALBUTEROL
 	result = ALBUTEROL
-	required_reagents = list(HYPERZINE = 1, INAPROVALINE = 1)
+	required_reagents = list(TRAMADOL = 1, INAPROVALINE = 1)
 	result_amount = 2
 
 /datum/chemical_reaction/saltwater


### PR DESCRIPTION
The Albuterol recipe took Hyperzine + Inaprovaline, but you get pumped out of cloning full of Inaprov, which meant Hyperzine in the mix, or as a floor pill, was practically useless.

This changes the recipe from Hyperzine + Inaprovaline to Hyperzine + Tramadol.

:cl:
- tweak: Albuterol (the medecine for athsma) now requires Hyperzine + Tramadol rather than Hyperzine + Inaprovaline.