### PR TITLE
Makes remove_air() operate on the gas_mixture returned by return_air() by default

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -231,6 +231,8 @@ var/global/list/reagents_to_log = list(FUEL, PLASMA, PACID, SACID, AMUTATIONTOXI
 	set waitfor = FALSE
 	processing_objects.Remove(src)
 
+//At some point, this proc should be changed to work like remove_air() below does.
+//However, this would likely cause problems, such as CO2 buildup in mechs and spacepods, so I'm not doing it right now.
 /obj/assume_air(datum/gas_mixture/giver)
 	if(loc)
 		return loc.assume_air(giver)
@@ -238,10 +240,8 @@ var/global/list/reagents_to_log = list(FUEL, PLASMA, PACID, SACID, AMUTATIONTOXI
 		return null
 
 /obj/remove_air(amount)
-	if(loc)
-		return loc.remove_air(amount)
-	else
-		return null
+	var/datum/gas_mixture/my_air = return_air()
+	return my_air?.remove(amount)
 
 /obj/return_air()
 	if(loc)


### PR DESCRIPTION
Before this, overriding `return_air()` on an object that mobs could be inside would make them use the pressure of the given `gas_mixture` for calculating pressure damage, but would not affect breathing. For that, you also had to override `remove_air()`. This was stupid.

Judging from the code, this shouldn't affect any gameplay except ventcrawling. Now you'll need to use internals if you're crawling through pipes containing gas you can't breathe. (This really only applies to monkeys and people using the contortionist's jumpsuit, I believe.)
It would theoretically affect cryopods as well, but I'm pretty sure you don't breathe while in cryo anyway.
Everything else to which this is relevant already overrode `remove_air()` and thus will be completely unaffected.

As the comment I wrote in the code says, `assume_air()` *should* work this way too, but would likely fuck shit up without additional work being put in to avoid it, so this PR only changes `remove_air()`.