### PR TITLE
 General Security-related mapping improvements.

### DIFF
--- a/code/game/machinery/door_control.dm
+++ b/code/game/machinery/door_control.dm
@@ -207,7 +207,7 @@
 /obj/machinery/door_control/mapped/interogation_room
 	name = "smartglass control"
 	desc = "Toogle smartglass"
-	id_tag = "InterogatioRoomIDTag"
+	id_tag = "InterogationRoomIDTag"
 
 
 /obj/machinery/door_control/mapped/interogation_room/attack_hand(var/mob/user)

--- a/code/game/machinery/door_control.dm
+++ b/code/game/machinery/door_control.dm
@@ -211,11 +211,10 @@
 
 
 /obj/machinery/door_control/mapped/interogation_room/attack_hand(var/mob/user)
-	. = ..() // Sanity
-	if (.)
-		for (var/obj/structure/window/reinforced/plasma/interogation_room/W in range(range))
-			if (W.smartwindow && src.id_tag == W.smartwindow.id_tag)
-				W.smartwindow.toggle_smart_transparency()
-		for (var/obj/machinery/door/window/plasma/secure/interogation_room/W in range(range))
-			if (W.smartwindow && src.id_tag == W.smartwindow.id_tag)
-				W.smartwindow.toggle_smart_transparency()
+	..() // Sanity
+	for (var/obj/structure/window/reinforced/plasma/interogation_room/W in range(range))
+		if (W.smartwindow && src.id_tag == W.smartwindow.id_tag)
+			W.smartwindow.toggle_smart_transparency()
+	for (var/obj/machinery/door/window/plasma/secure/interogation_room/W in range(range))
+		if (W.smartwindow && src.id_tag == W.smartwindow.id_tag)
+			W.smartwindow.toggle_smart_transparency()

--- a/code/game/machinery/door_control.dm
+++ b/code/game/machinery/door_control.dm
@@ -203,3 +203,19 @@
 
 	icon_state = "launcherbtt"
 	active = 0
+
+/obj/machinery/door_control/mapped/interogation_room
+	name = "smartglass control"
+	desc = "Toogle smartglass"
+	id_tag = "InterogatioRoomIDTag"
+
+
+/obj/machinery/door_control/mapped/interogation_room/attack_hand(var/mob/user)
+	. = ..() // Sanity
+	if (.)
+		for (var/obj/structure/window/reinforced/plasma/interogation_room/W in range(range))
+			if (W.smartwindow && src.id_tag == W.smartwindow.id_tag)
+				W.smartwindow.toggle_smart_transparency()
+		for (var/obj/machinery/door/window/plasma/secure/interogation_room/W in range(range))
+			if (W.smartwindow && src.id_tag == W.smartwindow.id_tag)
+				W.smartwindow.toggle_smart_transparency()

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -405,4 +405,4 @@
 // Used on Packed ; smartglassified roundstart
 /obj/machinery/door/window/plasma/secure/interogation_room/initialize()
 	smartwindow = new(src)
-	smartwindow.id_tag = "InterogatioRoomIDTag"
+	smartwindow.id_tag = "InterogationRoomIDTag"

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -401,3 +401,8 @@
 	WA.secure = "secure_"
 	WA.update_icon()
 	return WA
+
+// Used on Packed ; smartglassified roundstart
+/obj/machinery/door/window/plasma/secure/interogation_room/initialize()
+	smartwindow = new(src)
+	smartwindow.id_tag = "InterogatioRoomIDTag"

--- a/code/game/objects/items/devices/remote/remote_buttons.dm
+++ b/code/game/objects/items/devices/remote/remote_buttons.dm
@@ -50,3 +50,8 @@
 
 /obj/item/device/remote_button/proc/on_press(mob/user)
 	return
+
+
+
+
+

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -99,41 +99,44 @@
 	icon_broken = "hossecurebroken"
 	icon_off = "hossecureoff"
 
-	New()
-		..()
-		sleep(2)
-		if(prob(50))
-			new /obj/item/weapon/storage/backpack/security(src)
-		else
-			new /obj/item/weapon/storage/backpack/satchel_sec(src)
-		new /obj/item/clothing/head/helmet/tactical/HoS(src)
-		new /obj/item/device/flashlight/tactical(src)
-		new /obj/item/clothing/accessory/holster/knife/boot/preloaded/tactical(src)
-		new /obj/item/clothing/suit/armor/vest(src)
-		new /obj/item/clothing/under/rank/head_of_security/jensen(src)
-		if(prob(50))
-			new /obj/item/clothing/suit/armor/hos/jensen(src)
-		else
-			new /obj/item/clothing/suit/armor/hos/sundowner(src)
-		new /obj/item/clothing/head/helmet/tactical/HoS/dermal(src)
-		new /obj/item/weapon/cartridge/hos(src)
-		new /obj/item/device/detective_scanner(src)
-		new /obj/item/device/radio/headset/heads/hos(src)
-		new /obj/item/clothing/glasses/sunglasses/sechud(src)
-		new /obj/item/weapon/shield/riot(src)
-		new /obj/item/weapon/storage/lockbox/loyalty(src)
-		new /obj/item/weapon/storage/box/flashbangs(src)
-		new /obj/item/weapon/storage/belt/security(src)
-		new /obj/item/device/flash(src)
-		new /obj/item/weapon/melee/baton/loaded(src)
-		new /obj/item/weapon/storage/lockbox/lawgiver(src)
-		new /obj/item/ammo_storage/magazine/lawgiver(src)
-		new /obj/item/clothing/accessory/holster/handgun/waist(src)
-		new /obj/item/weapon/melee/telebaton(src)
-		new /obj/item/device/gps/secure(src)
-		return
-
-
+/obj/structure/closet/secure_closet/hos/New()
+	..()
+	sleep(2)
+	if(prob(50))
+		new /obj/item/weapon/storage/backpack/security(src)
+	else
+		new /obj/item/weapon/storage/backpack/satchel_sec(src)
+	new /obj/item/clothing/head/helmet/tactical/HoS(src)
+	new /obj/item/device/flashlight/tactical(src)
+	new /obj/item/clothing/accessory/holster/knife/boot/preloaded/tactical(src)
+	new /obj/item/clothing/suit/armor/vest(src)
+	new /obj/item/clothing/under/rank/head_of_security/jensen(src)
+	if(prob(50))
+		new /obj/item/clothing/suit/armor/hos/jensen(src)
+	else
+		new /obj/item/clothing/suit/armor/hos/sundowner(src)
+	new /obj/item/clothing/head/helmet/tactical/HoS/dermal(src)
+	new /obj/item/weapon/cartridge/hos(src)
+	new /obj/item/device/detective_scanner(src)
+	new /obj/item/device/radio/headset/heads/hos(src)
+	new /obj/item/clothing/glasses/sunglasses/sechud(src)
+	new /obj/item/weapon/shield/riot(src)
+	new /obj/item/weapon/storage/lockbox/loyalty(src)
+	new /obj/item/weapon/storage/box/flashbangs(src)
+	new /obj/item/weapon/storage/belt/security(src)
+	new /obj/item/device/flash(src)
+	new /obj/item/weapon/melee/baton/loaded(src)
+	new /obj/item/weapon/storage/lockbox/lawgiver(src)
+	new /obj/item/ammo_storage/magazine/lawgiver(src)
+	new /obj/item/clothing/accessory/holster/handgun/waist(src)
+	new /obj/item/weapon/melee/telebaton(src)
+	new /obj/item/device/gps/secure(src)
+	new /obj/item/clothing/suit/armor/hos(src)
+	new /obj/item/taperoll/police(src)
+	new /obj/item/device/hailer(src)
+	new /obj/item/weapon/reagent_containers/spray/pepper(src)
+	new /obj/item/weapon/grenade/flashbang(src)
+	new /obj/item/weapon/gun/energy/taser(src)
 
 /obj/structure/closet/secure_closet/warden
 	name = "Warden's Locker"
@@ -146,32 +149,35 @@
 	icon_off = "wardensecureoff"
 
 
-	New()
-		..()
-		sleep(2)
-		if(prob(50))
-			new /obj/item/weapon/storage/backpack/security(src)
-		else
-			new /obj/item/weapon/storage/backpack/satchel_sec(src)
-		new /obj/item/clothing/suit/armor/vest/security(src)
-		new /obj/item/clothing/under/rank/warden(src)
-		new /obj/item/clothing/suit/armor/vest/warden(src)
-		new /obj/item/clothing/head/helmet/tactical/warden(src)
-		new /obj/item/device/flashlight/tactical(src)
-//		new /obj/item/weapon/cartridge/security(src)
-		new /obj/item/device/radio/headset/headset_sec(src)
-		new /obj/item/clothing/glasses/sunglasses/sechud(src)
-		new /obj/item/weapon/storage/box/flashbangs(src)
-		new /obj/item/weapon/storage/belt/security(src)
-		new /obj/item/weapon/reagent_containers/spray/pepper(src)
-		new /obj/item/weapon/melee/baton/loaded(src)
-		new /obj/item/weapon/gun/energy/taser(src)
-		new /obj/item/weapon/storage/box/bolas(src)
-		new /obj/item/weapon/batteringram(src)
-		new /obj/item/device/gps/secure(src)
-		return
-
-
+/obj/structure/closet/secure_closet/warden/New()
+	..()
+	sleep(2)
+	if(prob(50))
+		new /obj/item/weapon/storage/backpack/security(src)
+	else
+		new /obj/item/weapon/storage/backpack/satchel_sec(src)
+	new /obj/item/clothing/suit/armor/vest/security(src)
+	new /obj/item/clothing/under/rank/warden(src)
+	new /obj/item/clothing/suit/armor/vest/warden(src)
+	new /obj/item/clothing/head/helmet/tactical/warden(src)
+	new /obj/item/device/flashlight/tactical(src)
+//	new /obj/item/weapon/cartridge/security(src)
+	new /obj/item/device/radio/headset/headset_sec(src)
+	new /obj/item/clothing/glasses/sunglasses/sechud(src)
+	new /obj/item/weapon/storage/box/flashbangs(src)
+	new /obj/item/weapon/storage/belt/security(src)
+	new /obj/item/weapon/reagent_containers/spray/pepper(src)
+	new /obj/item/weapon/melee/baton/loaded(src)
+	new /obj/item/weapon/gun/energy/taser(src)
+	new /obj/item/weapon/storage/box/bolas(src)
+	new /obj/item/weapon/batteringram(src)
+	new /obj/item/device/gps/secure(src)
+	new /obj/item/taperoll/police(src)
+	new /obj/item/device/hailer(src)
+	new /obj/item/weapon/reagent_containers/spray/pepper(src)
+	new /obj/item/weapon/grenade/flashbang(src)
+	new /obj/item/clothing/accessory/holster/knife/boot/preloaded/tactical(src)
+	new /obj/item/weapon/gun/energy/taser(src)
 
 /obj/structure/closet/secure_closet/security
 	name = "Security Officer's Locker"
@@ -183,34 +189,32 @@
 	icon_broken = "secbroken"
 	icon_off = "secoff"
 
-	New()
-		..()
-		sleep(2)
-		if(prob(50))
-			new /obj/item/weapon/storage/backpack/security(src)
-		else
-			new /obj/item/weapon/storage/backpack/satchel_sec(src)
-		new /obj/item/clothing/suit/armor/vest/security(src)
-		new /obj/item/clothing/head/helmet/tactical/sec/preattached(src)
-		new /obj/item/clothing/accessory/holster/knife/boot/preloaded/tactical(src)
-//		new /obj/item/weapon/cartridge/security(src)
-		new /obj/item/device/radio/headset/headset_sec(src)
-		new /obj/item/weapon/storage/belt/security(src)
-		new /obj/item/device/flash(src)
-		new /obj/item/weapon/reagent_containers/spray/pepper(src)
-		new /obj/item/weapon/grenade/flashbang(src)
-		new /obj/item/weapon/melee/baton/loaded(src)
-		new /obj/item/weapon/gun/energy/taser(src)
-		if(prob(50))
-			new /obj/item/clothing/glasses/sunglasses/sechud/prescription(src)
-		else
-			new /obj/item/clothing/glasses/sunglasses/sechud(src)
-		new /obj/item/taperoll/police(src)
-		new /obj/item/device/hailer(src) //wonder if vg would spam this
-		new /obj/item/clothing/gloves/black(src)
-		new /obj/item/device/gps/secure(src)
-		return
-
+/obj/structure/closet/secure_closet/security/New()
+	..()
+	sleep(2)
+	if(prob(50))
+		new /obj/item/weapon/storage/backpack/security(src)
+	else
+		new /obj/item/weapon/storage/backpack/satchel_sec(src)
+	new /obj/item/clothing/suit/armor/vest/security(src)
+	new /obj/item/clothing/head/helmet/tactical/sec/preattached(src)
+	new /obj/item/clothing/accessory/holster/knife/boot/preloaded/tactical(src)
+//	new /obj/item/weapon/cartridge/security(src)
+	new /obj/item/device/radio/headset/headset_sec(src)
+	new /obj/item/weapon/storage/belt/security(src)
+	new /obj/item/device/flash(src)
+	new /obj/item/weapon/reagent_containers/spray/pepper(src)
+	new /obj/item/weapon/grenade/flashbang(src)
+	new /obj/item/weapon/melee/baton/loaded(src)
+	new /obj/item/weapon/gun/energy/taser(src)
+	if(prob(50))
+		new /obj/item/clothing/glasses/sunglasses/sechud/prescription(src)
+	else
+		new /obj/item/clothing/glasses/sunglasses/sechud(src)
+	new /obj/item/taperoll/police(src)
+	new /obj/item/device/hailer(src) //wonder if vg would spam this
+	new /obj/item/clothing/gloves/black(src)
+	new /obj/item/device/gps/secure(src)
 
 /obj/structure/closet/secure_closet/security/cargo
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -670,7 +670,7 @@ var/list/one_way_windows
 // Used on Packed ; smartglassified roundstart
 /obj/structure/window/reinforced/plasma/interogation_room/initialize()
 	smartwindow = new(src)
-	smartwindow.id_tag = "InterogatioRoomIDTag"
+	smartwindow.id_tag = "InterogationRoomIDTag"
 
 /obj/structure/window/reinforced/plasma/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	return

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -666,6 +666,12 @@ var/list/one_way_windows
 	health = 160
 	penetration_dampening = 7
 
+
+// Used on Packed ; smartglassified roundstart
+/obj/structure/window/reinforced/plasma/interogation_room/initialize()
+	smartwindow = new(src)
+	smartwindow.id_tag = "InterogatioRoomIDTag"
+
 /obj/structure/window/reinforced/plasma/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	return
 

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -3055,7 +3055,7 @@
 	name = "Albuterol"
 	id = ALBUTEROL
 	result = ALBUTEROL
-	required_reagents = list(HYPERZINE = 1, INAPROVALINE = 1)
+	required_reagents = list(TRAMADOL = 1, INAPROVALINE = 1)
 	result_amount = 2
 
 /datum/chemical_reaction/saltwater

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -3055,7 +3055,7 @@
 	name = "Albuterol"
 	id = ALBUTEROL
 	result = ALBUTEROL
-	required_reagents = list(TRAMADOL = 1, INAPROVALINE = 1)
+	required_reagents = list(HYPERZINE = 1, INAPROVALINE = 1)
 	result_amount = 2
 
 /datum/chemical_reaction/saltwater


### PR DESCRIPTION
## All maps
- Head of Security locker starts with an alternative armour skin (previously, this was hard-mapped on Deff only)
- Head of Security & Warden lockers start with more equipment (a flashbang, a taser, a pepperspray, security tape, and a hailer - basically everything normal security got but the big boys didn't)

## Defficiency
- Arrivals checkpoint : 
![deff arrivals](https://user-images.githubusercontent.com/31417754/41804394-2265f018-7696-11e8-8ef2-e11a92f07abd.png)
Added a security locker, a windoor, put the items lying on the ground on the table. (I was always under the impression the checkpoint had been vandalised since there never was a locker + the flash was on the ground)

- Medbay checkpoint : 
![deff checkpoint](https://user-images.githubusercontent.com/31417754/41804405-5242502e-7696-11e8-940e-cd7c4c88db37.png)
Added a door from lobby, put a security cameras computer, put a radio that was on the ground on the table.

- Perma ;
![permeme](https://user-images.githubusercontent.com/31417754/41804412-6f90811e-7696-11e8-989f-6c8c09351445.png)
Layered plasma windows + grilles **on top** of the existing rwalls, making the escape attempts a bit more time-consuming as well as making more noise.

- Misc : 
The internal morgue door (medbay => morgue) can be opened with security access like in Box and Bagel.
Added a second sec vend to brig.

## Packed
- Interrogation room : 
![brig packed](https://user-images.githubusercontent.com/31417754/41804434-d9c6b094-7696-11e8-8440-85cac4b377b5.png)
Cleared up a bit of space by replacing windows with smartglass (courtesy of @SonixApache), currently trying to make it so they are toggelable by a hard-mapped button, but my unga bunga brian doesn't manage to do it. Help wanted
Also, fixed a few glass windoors when the rest was already plasma windows, and nudged the cuffs box away from the holobadge one.

- Misc : 
The internal morgue door (medbay => morgue) can be opened with security access like in Box and Bagel.

## Meta

- Misc : 
The internal morgue door (medbay => morgue) can be opened with security access like in Box and Bagel.

:cl:
- rscadd: Meta: Security has access to the internal morgue airlock, like in Box and Bagel.
- rscadd: Packed: Security has access to the internal morgue airlock, like in Box and Bagel.
- rscadd: Packed: Interrogation room designed to allow more space to manoeuvre prisoners, and privacy in the form of Smartglasses that can be toggled on or off.
- rscadd: Deff: Security checkpoint in medbay can be accessed via medical lobby, and now has a security cameras computer.
- rscadd: Deff: Perma is more secured, with a layer of grille + plasma window on top of the renforced wall outside. This means you can no longer sneak in with a false wall unnoticed.
- rscadd: Deff: Added a security locker to the arrivals checkpoint.
- rscadd: Deff: Added a second sec vend.
- rscadd: Deff: Security has access to the internal morgue airlock, like in Box and Bagel.
- rscadd: Warden and HoS lockers will now start with gear that was otherwise missing in them but found in security officer lockers, such as a hailer.
