### PR TITLE
Tweaks gas inside disposals

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -5,7 +5,8 @@
 // Automatically recharges air (unless off), will flush when ready if pre-set
 // Can hold items and human size things, no other draggables
 // Toilets are a type of disposal bin for small objects only and work on magic. By magic, I mean torque rotation
-#define SEND_PRESSURE 0.05*ONE_ATMOSPHERE
+#define SEND_PRESSURE 2*ONE_ATMOSPHERE
+#define SEND_VOLUME 0.21*CELL_VOLUME
 
 /obj/machinery/disposal
 	name = "disposal unit"
@@ -58,7 +59,7 @@
 		flush = 0
 
 	air_contents = new/datum/gas_mixture()
-	//gas.volume = 1.05 * CELLSTANDARD
+	air_contents.volume = SEND_VOLUME
 	update_icon()
 
 /obj/machinery/disposal/Destroy()
@@ -365,7 +366,7 @@
 	var/atom/L = loc						// recharging from loc turf
 
 	var/datum/gas_mixture/env = L.return_air()
-	var/pressure_delta = (SEND_PRESSURE*1.01) - air_contents.return_pressure()
+	var/pressure_delta = (SEND_PRESSURE*1.05) - air_contents.return_pressure()
 
 	if(env.temperature > 0)
 		var/transfer_moles = 0.1 * pressure_delta * air_contents.volume / (env.temperature * R_IDEAL_GAS_EQUATION)
@@ -399,7 +400,6 @@
 		H.tomail = 1
 
 
-	air_contents = new()		// new empty gas resv.
 
 	sleep(10)
 	if(last_sound < world.time + 1)
@@ -409,6 +409,9 @@
 
 
 	H.init(src)	// copy the contents of disposer to holder
+
+	air_contents = new()		// new empty gas resv.
+	air_contents.volume = SEND_VOLUME
 
 	H.start(src) // start the holder processing movement
 	flushing = 0
@@ -693,6 +696,15 @@
 /obj/structure/disposalholder/proc/vent_gas(var/atom/location)
 	location.assume_air(gas)  // vent all gas to turf
 	return
+
+/obj/structure/disposalholder/return_air()
+	return gas
+
+/obj/structure/disposalholder/handle_internal_lifeform(mob/lifeform_inside_me, breath_request)
+	if(breath_request > 0)
+		return gas.remove(breath_request)
+	else
+		return null
 
 // Disposal pipes
 

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -177,6 +177,24 @@
 		H.destinationTag = "DISPOSALS"
 
 	air_contents = new()		// new empty gas resv.
+	air_contents.volume = SEND_VOLUME
+
+	var/atom/L = loc						// recharging from loc turf
+
+	var/datum/gas_mixture/env = L.return_air()
+	var/pressure_delta
+	var/transfer_moles
+	var/datum/gas_mixture/removed
+	var/max_cycles = 100
+
+	while(env.temperature > 0 && air_contents.return_pressure() < SEND_PRESSURE && max_cycles-- > 0)
+		pressure_delta = (SEND_PRESSURE*1.05) - air_contents.return_pressure()
+		transfer_moles = 0.1 * pressure_delta * air_contents.volume / (env.temperature * R_IDEAL_GAS_EQUATION)
+
+		//Actually transfer the gas
+		removed = env.remove(transfer_moles)
+		air_contents.merge(removed)
+
 
 	sleep(10)
 	playsound(src, 'sound/machines/disposalflush.ogg', 50, 0, 0)


### PR DESCRIPTION
Resolves #18590

I started this by just overriding ``return_air()`` inside disposal holders, since although they had their own gas mix, nothing inside was getting a reference to it instead of the gas above the pipe. Turns out I had to change a few more things to get it to work the way I wanted.

Part of this is reverting a change (https://github.com/vgstation-coders/vgstation13/commit/d521357c068fc3cc86a6dcdf339e3fd24f95e8d2) that made the air pressure inside these things cap out at 5 kPa. Instead I'm dealing with the "hungry for air" issue by reducing the volume of the gas mix.

Upshot of this change is, while you're being flushed through disposals, your environment will be the air that the disposal bin/chute sucked up earlier. Disposals will now also move quite a bit more air than they did, though not as much as before https://github.com/vgstation-coders/vgstation13/commit/d521357c068fc3cc86a6dcdf339e3fd24f95e8d2. (To replicate the current amount of air they move I'd have to reduce the gas volume to less than the volume of a human. Which is doable, but I dunno if it makes sense.) At any rate the air volume might have to be adjusted. 21% of the cell volume is 525 liters and it's probably too high.

Also I'm sure that what I did for chutes is bad and will need to be revised, since it's just the bin process behavior shitcoded to happen instantly.

:cl:
* experiment: The way that disposal pipes handle gasses has been adjusted. Lifeforms inside the pipes will be exposed to the air that the disposal equipment sucked up earlier, instead of the air above the pipe. Disposal bins will move significantly more gas than they did, and delivery chutes will now also move gas when they didn't before.