### PR TITLE
Robots can lift tape

### DIFF
--- a/__DEFINES/silicon.dm
+++ b/__DEFINES/silicon.dm
@@ -61,3 +61,5 @@ var/global/list/mommi_modules = list(
 #define MODULE_CLEAN_ON_MOVE 32
 #define MODULE_HAS_MAGPULSE 64
 #define MODULE_IS_THE_LAW 128
+#define MODULE_CAN_LIFT_SECTAPE 256
+#define MODULE_CAN_LIFT_ENGITAPE 512

--- a/code/WorkInProgress/Ported/policetape.dm
+++ b/code/WorkInProgress/Ported/policetape.dm
@@ -17,6 +17,7 @@
 	anchored = 1
 	density = 1
 	var/icon_base
+	var/robot_compatibility
 
 /obj/item/taperoll/police
 	name = "police tape"
@@ -30,6 +31,7 @@
 	desc = "A length of police tape.  Do not cross."
 	req_access = list(access_security)
 	icon_base = "police"
+	robot_compatibility = MODULE_CAN_LIFT_SECTAPE
 
 /obj/item/taperoll/engineering
 	name = "engineering tape"
@@ -43,6 +45,7 @@
 	desc = "A length of engineering tape. Better not cross it."
 	req_one_access = list(access_engine,access_atmospherics)
 	icon_base = "engineering"
+	robot_compatibility = MODULE_CAN_LIFT_ENGITAPE
 
 /obj/item/taperoll/atmos
 	name = "atmospherics tape"
@@ -56,6 +59,7 @@
 	desc = "A length of atmospherics tape. Better not cross it."
 	req_one_access = list(access_engine,access_atmospherics)
 	icon_base = "atmos"
+	robot_compatibility = MODULE_CAN_LIFT_ENGITAPE
 
 /obj/item/taperoll/attack_self(mob/user as mob)
 	if(icon_state == "[icon_base]_start")
@@ -178,6 +182,17 @@
 			return
 		breaktape(null, user)
 
+/obj/item/tape/attack_robot(mob/user)
+	if(Adjacent(user))
+		return attack_hand(user)
+
+/obj/item/tape/allowed(mob/user)
+	if(isrobot(user))
+		var/mob/living/silicon/robot/R = user
+		return R.module && (R.module.quirk_flags & robot_compatibility)
+
+	return ..()
+
 /obj/item/tape/attack_paw(mob/user as mob)
 	breaktape(null,user, TRUE)
 
@@ -292,7 +307,7 @@
 			var/mob/living/carbon/human/H = user
 			if (H.has_organ_for_slot(slot_handcuffed))
 				H.visible_message("<span class='danger'>[H] wraps \his hands on the tape!</span>", "<span class='danger'>The tape wraps itself on your hands!</span>")
-				var/obj/item/taperoll/police/cuffs 
+				var/obj/item/taperoll/police/cuffs
 				cuffs = new(get_turf(src))
 				cuffs.on_restraint_apply(H)
 				H.put_in_hands(cuffs) // Unlike normal cuffs, those cuffs don't transfer from one inventory to another. We need to place them in an inventory first for the icon to show.

--- a/code/WorkInProgress/Ported/policetape.dm
+++ b/code/WorkInProgress/Ported/policetape.dm
@@ -187,7 +187,7 @@
 		return attack_hand(user)
 
 /obj/item/tape/allowed(mob/user)
-	if(isrobot(user))
+	if(isrobot(user) && !isMoMMI(user))
 		var/mob/living/silicon/robot/R = user
 		return R.module && (R.module.quirk_flags & robot_compatibility)
 

--- a/code/modules/mob/living/silicon/mommi/mommi_modules.dm
+++ b/code/modules/mob/living/silicon/mommi/mommi_modules.dm
@@ -1,7 +1,7 @@
 
 /obj/item/weapon/robot_module/mommi
 	name = "mobile mmi robot module"
-	quirk_flags = MODULE_CAN_BE_PUSHED | MODULE_HAS_MAGPULSE | MODULE_CAN_HANDLE_CHEMS | MODULE_CAN_BUY | MODULE_CAN_LIFT_ENGITAPE
+	quirk_flags = MODULE_CAN_BE_PUSHED | MODULE_HAS_MAGPULSE | MODULE_CAN_HANDLE_CHEMS | MODULE_CAN_BUY
 	languages = list()
 	sprites = list("Basic" = "mommi")
 	respawnables = list (/obj/item/stack/cable_coil)

--- a/code/modules/mob/living/silicon/mommi/mommi_modules.dm
+++ b/code/modules/mob/living/silicon/mommi/mommi_modules.dm
@@ -1,7 +1,7 @@
 
 /obj/item/weapon/robot_module/mommi
 	name = "mobile mmi robot module"
-	quirk_flags = MODULE_CAN_BE_PUSHED | MODULE_HAS_MAGPULSE | MODULE_CAN_HANDLE_CHEMS | MODULE_CAN_BUY 
+	quirk_flags = MODULE_CAN_BE_PUSHED | MODULE_HAS_MAGPULSE | MODULE_CAN_HANDLE_CHEMS | MODULE_CAN_BUY | MODULE_CAN_LIFT_ENGITAPE
 	languages = list()
 	sprites = list("Basic" = "mommi")
 	respawnables = list (/obj/item/stack/cable_coil)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -295,7 +295,7 @@
 /obj/item/weapon/robot_module/engineering
 	name = "engineering robot module"
 	module_holder = "engineer"
-	quirk_flags = MODULE_CAN_BE_PUSHED | MODULE_HAS_MAGPULSE
+	quirk_flags = MODULE_CAN_BE_PUSHED | MODULE_HAS_MAGPULSE | MODULE_CAN_LIFT_ENGITAPE
 	networks = list(CAMERANET_ENGI)
 	radio_key = /obj/item/device/encryptionkey/headset_eng
 	sprites = list(
@@ -350,7 +350,7 @@
 /obj/item/weapon/robot_module/security
 	name = "security robot module"
 	module_holder = "security"
-	quirk_flags = MODULE_IS_THE_LAW
+	quirk_flags = MODULE_IS_THE_LAW | MODULE_CAN_LIFT_SECTAPE
 	radio_key = /obj/item/device/encryptionkey/headset_sec
 	sprites = list(
 		"Default" = "secbot",


### PR DESCRIPTION
Resolves #18186

:cl:
* rscadd: Security cyborgs can now lift security tape. Engineering cyborgs can now lift engineering and atmos tape.