### PR TITLE
Atmos analyzers get air from the user's location instead of the turf

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -851,7 +851,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 			if (3)
 				dat += "<h4><span class='pda_icon pda_atmos'></span> Atmospheric Readings</h4>"
 
-				var/turf/T = get_turf(user.loc)
+				var/atom/T = user.loc
 				if (isnull(T))
 					dat += "Unable to obtain a reading.<br>"
 				else

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -851,31 +851,34 @@ var/global/list/obj/item/device/pda/PDAs = list()
 			if (3)
 				dat += "<h4><span class='pda_icon pda_atmos'></span> Atmospheric Readings</h4>"
 
-				var/atom/T = user.loc
-				if (isnull(T))
+				if (isnull(user.loc))
 					dat += "Unable to obtain a reading.<br>"
 				else
-					var/datum/gas_mixture/environment = T.return_air()
+					var/datum/gas_mixture/environment = user.loc.return_air()
 
-					var/pressure = environment.return_pressure()
-					var/total_moles = environment.total_moles()
+					if(!environment)
+						dat += "No gasses detected.<br>"
 
-					dat += "Air Pressure: [round(pressure,0.1)] kPa<br>"
+					else
+						var/pressure = environment.return_pressure()
+						var/total_moles = environment.total_moles()
 
-					if (total_moles)
-						var/o2_level = environment.oxygen/total_moles
-						var/n2_level = environment.nitrogen/total_moles
-						var/co2_level = environment.carbon_dioxide/total_moles
-						var/plasma_level = environment.toxins/total_moles
-						var/unknown_level =  1-(o2_level+n2_level+co2_level+plasma_level)
+						dat += "Air Pressure: [round(pressure,0.1)] kPa<br>"
 
-						dat += {"Nitrogen: [round(n2_level*100)]%<br>
-							Oxygen: [round(o2_level*100)]%<br>
-							Carbon Dioxide: [round(co2_level*100)]%<br>
-							Plasma: [round(plasma_level*100)]%<br>"}
-						if(unknown_level > 0.01)
-							dat += "OTHER: [round(unknown_level)]%<br>"
-					dat += "Temperature: [round(environment.temperature-T0C)]&deg;C<br>"
+						if (total_moles)
+							var/o2_level = environment.oxygen/total_moles
+							var/n2_level = environment.nitrogen/total_moles
+							var/co2_level = environment.carbon_dioxide/total_moles
+							var/plasma_level = environment.toxins/total_moles
+							var/unknown_level =  1-(o2_level+n2_level+co2_level+plasma_level)
+
+							dat += {"Nitrogen: [round(n2_level*100)]%<br>
+								Oxygen: [round(o2_level*100)]%<br>
+								Carbon Dioxide: [round(co2_level*100)]%<br>
+								Plasma: [round(plasma_level*100)]%<br>"}
+							if(unknown_level > 0.01)
+								dat += "OTHER: [round(unknown_level)]%<br>"
+						dat += "Temperature: [round(environment.temperature-T0C)]&deg;C<br>"
 				dat += "<br>"
 
 			if (5)

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -294,21 +294,16 @@ Subject's pulse: ??? BPM"})
 		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
 		return
 
-	var/atom/location
-
-	var/mob/M = get_holder_of_type(src, /mob)
-
-	if(M == user)
-		location = M.loc
-	else //We're either in a mech's equipment loadout or something weird so get the outside air
-		location = get_turf(src)
+	var/atom/location = is_holder_of(user, src) ? user.loc : get_turf(src) //If user isn't the holder we're either in a mech's equipment loadout or something weird so get the outside environment
 
 	if(!location) //Somehow
 		return
 
 	var/datum/gas_mixture/environment = location.return_air()
 
-	to_chat(user, output_gas_scan(environment, location, 1, CELL_VOLUME))
+	var/unit_vol = environment && environment.volume > CELL_VOLUME ? CELL_VOLUME : null
+
+	to_chat(user, output_gas_scan(environment, location, 1, unit_vol))
 
 	src.add_fingerprint(user)
 	return

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -294,7 +294,14 @@ Subject's pulse: ??? BPM"})
 		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
 		return
 
-	var/turf/location = get_turf(user)
+	var/atom/location
+
+	var/mob/M = get_holder_of_type(src, /mob)
+
+	if(M == user)
+		location = M.loc
+	else //We're either in a mech's equipment loadout or something weird so get the outside air
+		location = get_turf(src)
 
 	if(!location) //Somehow
 		return

--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -581,31 +581,34 @@
 /mob/living/silicon/pai/proc/softwareAtmo()
 	var/dat = "<h3>Atmospheric Sensor</h4>"
 
-	var/turf/T = get_turf(loc)
-	if (isnull(T))
+	if (isnull(loc))
 		dat += "Unable to obtain a reading.<br>"
 	else
-		var/datum/gas_mixture/environment = T.return_air()
+		var/datum/gas_mixture/environment = loc.return_air()
 
-		var/pressure = environment.return_pressure()
-		var/total_moles = environment.total_moles()
+		if(isnull(environment))
+			dat += "No gasses detected.<br>"
 
-		dat += "Air Pressure: [round(pressure,0.1)] kPa<br>"
+		else
+			var/pressure = environment.return_pressure()
+			var/total_moles = environment.total_moles()
 
-		if (total_moles)
-			var/o2_level = environment.oxygen/total_moles
-			var/n2_level = environment.nitrogen/total_moles
-			var/co2_level = environment.carbon_dioxide/total_moles
-			var/plasma_level = environment.toxins/total_moles
-			var/unknown_level =  1-(o2_level+n2_level+co2_level+plasma_level)
+			dat += "Air Pressure: [round(pressure,0.1)] kPa<br>"
 
-			dat += {"Nitrogen: [round(n2_level*100)]%<br>
-				Oxygen: [round(o2_level*100)]%<br>
-				Carbon Dioxide: [round(co2_level*100)]%<br>
-				Plasma: [round(plasma_level*100)]%<br>"}
-			if(unknown_level > 0.01)
-				dat += "OTHER: [round(unknown_level)]%<br>"
-		dat += "Temperature: [round(environment.temperature-T0C)]&deg;C<br>"
+			if (total_moles)
+				var/o2_level = environment.oxygen/total_moles
+				var/n2_level = environment.nitrogen/total_moles
+				var/co2_level = environment.carbon_dioxide/total_moles
+				var/plasma_level = environment.toxins/total_moles
+				var/unknown_level =  1-(o2_level+n2_level+co2_level+plasma_level)
+
+				dat += {"Nitrogen: [round(n2_level*100)]%<br>
+					Oxygen: [round(o2_level*100)]%<br>
+					Carbon Dioxide: [round(co2_level*100)]%<br>
+					Plasma: [round(plasma_level*100)]%<br>"}
+				if(unknown_level > 0.01)
+					dat += "OTHER: [round(unknown_level)]%<br>"
+			dat += "Temperature: [round(environment.temperature-T0C)]&deg;C<br>"
 
 	dat += {"<a href='byond://?src=\ref[src];software=atmosensor;sub=0'>Refresh Reading</a> <br>
 		<br>"}


### PR DESCRIPTION
Something I found out while doing #18603: Analyzers don't work properly when you're inside an airtight object. They get the turf air outside the object instead of the air inside.

:cl:
* bugfix: Slightly tweaked atmospheric analyzers so they'll work properly while you're inside an airtight object.