### PR TITLE
Reduced electrode stun time from 10 seconds to 7 seconds

### DIFF
--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -19,7 +19,7 @@
 	melt_temperature = MELTPOINT_STEEL
 	origin_tech = Tc_MATERIALS + "=1"
 	restraint_apply_sound = 'sound/weapons/handcuffs.ogg'
-	restraint_resist_time = 1 MINUTE
+	restraint_resist_time = 2 MINUTES
 
 /obj/item/weapon/handcuffs/restraint_apply_intent_check(mob/user)
 	return 1

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -19,7 +19,7 @@
 	melt_temperature = MELTPOINT_STEEL
 	origin_tech = Tc_MATERIALS + "=1"
 	restraint_apply_sound = 'sound/weapons/handcuffs.ogg'
-	restraint_resist_time = 2 MINUTES
+	restraint_resist_time = 1 MINUTE
 
 /obj/item/weapon/handcuffs/restraint_apply_intent_check(mob/user)
 	return 1

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -13,9 +13,9 @@
 	name = "electrode"
 	icon_state = "spark"
 	nodamage = 1
-	stun = 10
-	weaken = 10
-	stutter = 10
+	stun = 7
+	weaken = 7
+	stutter = 7
 	hitsound = 'sound/weapons/taserhit.ogg'
 
 /*/vg/ EDIT


### PR DESCRIPTION
Who knew that changing a number in the right place could affect gameplay severely?
This is part of a plan to tone down Security, stuns are so overwhelmingly powerful that the entire outcome of a combat situation relies on it. Security is handed stun weapons like candy, rendering people completely unable to do anything for 10 seconds. Not only can the stuns be re-applied to refresh the duration, but the stuns are also counted in BYOND seconds IIRC, so it's actually longer than 10 seconds. This PR's purpose is to reduce the duration of the stun, from an extremely harsh 10 seconds (during which in 1/3rd of the time you can get cuffed, and can be hit 10 times with a melee object) to 7 seconds (a little bit over 1/2 the time, can be hit 7 times with a melee object). I have plans to create other PRs, their purpose being to reduce stun duration. However, they have to be separate PRs, because otherwise it wouldn't be atomic. I am open to criticism, feedback, and suggestions. Personally, I would like to see the PR temporarily merged to see the impact it has on the gameplay.
:cl:
 * experiment: Electrode weapons, like tasers and energy guns, had their stun duration reduced from 10 seconds to 7 seconds.