### PR TITLE
Makes the disability unit test pass

### DIFF
--- a/code/game/dna/genes/goon_disabilities.dm
+++ b/code/game/dna/genes/goon_disabilities.dm
@@ -87,7 +87,7 @@
 /////////////////////////
 
 // WAS: /datum/bioEffect/smile
-/datum/dna/gene/disability/speech/smile
+/datum/dna/gene/disability/smile
 	name = "Smile"
 	desc = "Causes the speech center of the subject's brain to produce large amounts of seratonin and a chemical resembling ecstacy when engaged."
 	activation_message = "You feel so happy. Nothing can be wrong with anything :)"
@@ -148,7 +148,7 @@
 
 
 // WAS: /datum/bioEffect/elvis
-/datum/dna/gene/disability/speech/elvis
+/datum/dna/gene/disability/elvis
 	name = "Elvis"
 	desc = "Forces the language center and primary motor cortex of the subject's brain to talk and act like the King of Rock and Roll."
 	activation_message = "You feel pretty good, honeydoll."
@@ -187,7 +187,7 @@
 
 
 // WAS: /datum/bioEffect/chav
-/datum/dna/gene/disability/speech/chav
+/datum/dna/gene/disability/chav
 	name = "Chav"
 	desc = "Forces the language center of the subject's brain to construct sentences in a more rudimentary manner."
 	activation_message = "Ye feel like a reet prat like, innit?"
@@ -224,7 +224,7 @@
 		speech.message = replacetext(speech.message,"security","coppers")
 
 // WAS: /datum/bioEffect/swedish
-/datum/dna/gene/disability/speech/swedish
+/datum/dna/gene/disability/swedish
 	name = "Swedish"
 	desc = "Forces the language center of the subject's brain to construct sentences in a vaguely norse manner."
 	activation_message = "You feel Swedish, however that works."

--- a/code/game/dna/genes/vg_disabilities.dm
+++ b/code/game/dna/genes/vg_disabilities.dm
@@ -1,15 +1,15 @@
 
-/datum/dna/gene/disability/speech/loud
+/datum/dna/gene/disability/loud
 	name = "Loud"
 	desc = "Forces the speaking centre of the subjects brain to yell every sentence."
 	activation_message = "YOU FEEL LIKE YELLING!"
 	deactivation_message = "You feel like being quiet.."
 
-/datum/dna/gene/disability/speech/loud/New()
+/datum/dna/gene/disability/loud/New()
 	..()
 	block=LOUDBLOCK
 
-/datum/dna/gene/disability/speech/loud/OnSay(var/mob/M, var/datum/speech/speech)
+/datum/dna/gene/disability/loud/OnSay(var/mob/M, var/datum/speech/speech)
 	speech.message = replacetext(speech.message,".","!")
 	speech.message = replacetext(speech.message,"?","?!")
 	speech.message = replacetext(speech.message,"!","!!")
@@ -17,23 +17,23 @@
 	speech.message = uppertext(speech.message)
 
 
-/datum/dna/gene/disability/speech/whisper
+/datum/dna/gene/disability/whisper
 	name = "Quiet"
 	desc = "Damages the subjects vocal cords"
 	activation_message = "<i>Your throat feels sore..</i>"
 	deactivation_message = "You feel fine again."
 
-/datum/dna/gene/disability/speech/whisper/New()
+/datum/dna/gene/disability/whisper/New()
 	..()
 	block=WHISPERBLOCK
 
-/datum/dna/gene/disability/speech/whisper/can_activate(var/mob/M,var/flags)
+/datum/dna/gene/disability/whisper/can_activate(var/mob/M,var/flags)
 	// No loud whispering.
 	if(M_LOUD in M.mutations)
 		return 0
 	return ..(M,flags)
 
-/datum/dna/gene/disability/speech/whisper/OnSay(var/mob/M, var/datum/speech/speech)
+/datum/dna/gene/disability/whisper/OnSay(var/mob/M, var/datum/speech/speech)
 	//M.whisper(message)
 	return 0
 
@@ -57,7 +57,7 @@
 			M.Dizzy(300)
 
 
-/datum/dna/gene/disability/speech/sans
+/datum/dna/gene/disability/sans
 	name = "Wacky"
 	desc = "Forces the subject to talk in an odd manner."
 	activation_message = "You feel an off sensation in your voicebox.."
@@ -159,8 +159,8 @@ var/list/milk_reagents = list(
 /datum/dna/gene/disability/lactose
 	name = "Lactose intolerance"
 	desc = "A condition where your body is unable to digest Lactose, a sugar commonly found in milk."
-	activation_message = ""
-	deactivation_message = ""
+	activation_message = "Your stomach feels upset and bloated."
+	deactivation_message = "The discomfort in your stomach fades away."
 	disability = LACTOSE
 
 	mutation = M_LACTOSE


### PR DESCRIPTION
Addresses part of #18295 
- Added an activation and deactivation message for lactose intolerance
- Changed `/datum/dna/gene/disability/speech` subtypes to just `/datum/dna/gene/disability` subtypes - the speech thing was never defined/used anyway.