### PR TITLE
Cyborg gripper smart dropping

### DIFF
--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -45,6 +45,12 @@
 		to_chat(src, "<span class='warning'>Can't store something you're not holding!</span>")
 		return
 
+	if(isgripper(MA))
+		var/obj/item/weapon/gripper/G = MA
+		if(G.wrapped)
+			G.drop_item(force_drop = TRUE)
+			return
+
 	if(module_state_1 == module_active)
 		uneq_module(module_state_1)
 		module_state_1 = null

--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -299,20 +299,10 @@
 //Grippers: Simple cyborg manipulator. Limited use... SLIPPERY SLOPE POWERCREEP
 /obj/item/weapon/gripper
 	icon = 'icons/obj/device.dmi'
-	actions_types = list(/datum/action/item_action/magrip_drop)
 	var/obj/item/wrapped = null // Item currently being held.
 	var/list/can_hold = list() //Has a list of items that it can hold.
 	var/list/blacklist = list() //This is a list of items that can't be held even if their parent is whitelisted.
 	var/force_holder = null
-
-/datum/action/item_action/magrip_drop
-	name = "Drop Item"
-
-/datum/action/item_action/magrip_drop/Trigger()
-	var/obj/item/weapon/gripper/G = target
-	if(!istype(G))
-		return
-	G.drop_item(force_drop = 1)
 
 /obj/item/weapon/gripper/proc/grip_item(obj/item/I as obj, mob/user, var/feedback = TRUE)
 	//This function returns TRUE if we successfully took the item, or FALSE if it was invalid. This information is useful to the caller
@@ -397,8 +387,6 @@
 		overlays += olay
 	else
 		alpha = initial(alpha)
-	if(usr)
-		usr.update_action_buttons_icon()
 	..()
 
 /obj/item/weapon/gripper/examine(mob/user)


### PR DESCRIPTION
Resolves #18457 

With respect to @jknpj , this makes the action button redundant so I'm nixing it.

:cl:
* tweak: Cyborg grippers holding an item will now drop the item on the first "drop" command, and store the gripper on the second "drop" command. Accordingly there's no action button for dropping anymore.