### PR TITLE
Cyborg gripper transparent examining

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -402,9 +402,10 @@
 	..()
 
 /obj/item/weapon/gripper/examine(mob/user)
-	. = ..()
 	if(wrapped)
-		to_chat(user, "It is holding \a [bicon(wrapped)] [wrapped].")
+		return wrapped.examine(user)
+	else
+		return ..()
 
 /obj/item/weapon/gripper/attackby(obj/item/thing, mob/living/user)
 	if(gripper_sanity_check(src))


### PR DESCRIPTION
Could have it display the description for both the gripper and the item it's holding, but I feel like this is just more streamlined.

:cl:
* tweak: Examining a cyborg gripper holding an item will examine the item instead.