### PR TITLE
Fixing some dumb bee-related runtime

### DIFF
--- a/code/modules/mob/living/simple_animal/bees/bees_mob.dm
+++ b/code/modules/mob/living/simple_animal/bees/bees_mob.dm
@@ -639,9 +639,10 @@
 					for (var/turf/simulated/floor/T in range(src,2))
 						if(!T.has_dense_content() && !(locate(/obj/structure/wild_apiary) in T))
 							available_turfs.Add(T)
-					building = pick(available_turfs)
-					if (building)
-						mood_change(BEE_BUILDING)
+					if (available_turfs.len>0)
+						building = pick(available_turfs)
+						if (building)
+							mood_change(BEE_BUILDING)
 
 
 			else


### PR DESCRIPTION
So today I learned that Byond doesn't like it when you pick() from an empty list.

![image](https://user-images.githubusercontent.com/7573912/41933909-771c0074-7985-11e8-9a69-6ab5c09b10dd.png)
