### PR TITLE
Fixes runtime in gripper drop_item()

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -341,9 +341,11 @@
 		return FALSE
 	if(!target) //Just drop it, baka.
 		target = loc
-	if(!dontsay)
-		to_chat(usr, "<span class='warning'>You drop \the [wrapped].</span>")
-	wrapped.dropped(usr)
+	var/mob/holder = get_holder_of_type(src, /mob)
+	if(holder)
+		if(!dontsay)
+			to_chat(holder, "<span class='warning'>You drop \the [wrapped].</span>")
+		wrapped.dropped(holder)
 	if(force_drop)
 		wrapped.loc = get_turf(target)
 	else


### PR DESCRIPTION
```
[11:12:34] Runtime in browserOutput.dm,264: DEBUG: Boutput called with invalid message
  proc name: to chat (/proc/to_chat)
  src: null
  call stack:
  to chat(null, "You dr...")
  the chemistry gripper (/obj/item/weapon/gripper/chemistry): drop item(null, the medical robot module (/obj/item/weapon/robot_module/medical), 1, null)
  Medical Cyborg-538 (/mob/living/silicon/robot): uneq module(the chemistry gripper (/obj/item/weapon/gripper/chemistry))
  Medical Cyborg-538 (/mob/living/silicon/robot): uneq all()
  Medical Cyborg-538 (/mob/living/silicon/robot): use power()
  Medical Cyborg-538 (/mob/living/silicon/robot): Life()
  Mob (/datum/subsystem/mob): fire(0)
  Mob (/datum/subsystem/mob): ignite(0)
  Master (/datum/controller/master): RunQueue()
  Master (/datum/controller/master): Loop()
  Master (/datum/controller/master): StartProcessing()
```