### PR TITLE
Real hotfix for MoMMIs being completely broken

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -811,7 +811,7 @@
 	if(anchored) //Object isn't anchored
 		to_chat(user, "<span class='warning'>You can't pick that up!</span>")
 		return FALSE
-	if(!istype(loc, /turf) && loc != user) //Object is not on a turf
+	if(!istype(loc, /turf) && !is_holder_of(user, src)) //Object is not on a turf
 		to_chat(user, "<span class='warning'>You can't pick that up!</span>")
 		return FALSE
 	return TRUE


### PR DESCRIPTION
Fixes #18633
Believe it or not this was caused by the anvil update and not anything to do with grippers.

:cl:
* bugfix: Fixed MoMMI modules being completely unusable.