### PR TITLE
Timestamps med and sec records with the in-game time instead of the server time

### DIFF
--- a/code/datums/mixed.dm
+++ b/code/datums/mixed.dm
@@ -25,7 +25,7 @@
 	var/counter = 1
 	while(fields["com_[counter]"])
 		counter++
-	fields["com_[counter]"] = "Made by [usr.identification_string()] on [time2text(world.realtime, "DDD MMM DD hh:mm:ss")], [game_year]<br>[comment]"
+	fields["com_[counter]"] = "Made by [usr.identification_string()] on [time2text(world.realtime, "DDD MMM DD")] [worldtime2text()], [game_year]<br>[comment]"
 
 /datum/data/text
 	name = "text"

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -427,7 +427,7 @@
 				var/counter = 1
 				while(src.active2.fields[text("com_[]", counter)])
 					counter++
-				src.active2.fields[text("com_[counter]")] = text("Made by [authenticated] ([rank]) on [time2text(world.realtime, "DDD MMM DD hh:mm:ss")]<BR>[t1]")
+				src.active2.fields[text("com_[counter]")] = text("Made by [authenticated] ([rank]) on [time2text(world.realtime, "DDD MMM DD")] [worldtime2text()], [game_year]<BR>[t1]")
 
 			if (href_list["del_c"])
 				if ((istype(src.active2, /datum/data/record) && src.active2.fields[text("com_[]", href_list["del_c"])]))

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -363,7 +363,7 @@ What a mess.*/
 				var/counter = 1
 				while(active2.fields[text("com_[]", counter)])
 					counter++
-				active2.fields[text("com_[]", counter)] = text("Made by [] ([]) on [], 2053<BR>[]", authenticated, rank, time2text(world.realtime, "DDD MMM DD hh:mm:ss"), t1)
+				active2.fields[text("com_[]", counter)] = text("Made by [] ([]) on [], []<BR>[]", authenticated, rank, "[time2text(world.realtime, "DDD MMM DD")] [worldtime2text()]", game_year, t1)
 
 			if ("Delete Record (ALL)")
 				if (active1)


### PR DESCRIPTION
Resolves #18657

Fair warning, because this is using worldtime2text it's going to be hh:mm instead of hh:mm:ss. It's not going to have that second-by-second granularity anymore.

:cl:
* bugfix: Comments added to security and medical records are now timestamped with the in-game time instead of the server time.