### PR TITLE
Records give times in seconds again

### DIFF
--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -23,8 +23,9 @@
 	return wtime + (time_offset + wusage) * world.tick_lag
 
 //Returns the world time in english
-/proc/worldtime2text(timestamp = world.time)
-	return "[(round(timestamp / 36000) + 12) % 24]:[(timestamp / 600 % 60) < 10 ? add_zero(timestamp / 600 % 60, 1) : timestamp / 600 % 60]"
+/proc/worldtime2text(timestamp = world.time, give_seconds = FALSE)
+	return "[(round(timestamp / 36000) + 12) % 24]:[(timestamp / 600 % 60) < 10 ? add_zero(timestamp / 600 % 60, 1) : timestamp / 600 % 60]\
+	[give_seconds ? ":[(timestamp / 10 % 60) < 10 ? add_zero(timestamp / 10 % 60, 1) : timestamp / 10 % 60]" : ""]"
 
 
 /proc/formatTimeDuration(var/deciseconds)

--- a/code/datums/mixed.dm
+++ b/code/datums/mixed.dm
@@ -25,7 +25,7 @@
 	var/counter = 1
 	while(fields["com_[counter]"])
 		counter++
-	fields["com_[counter]"] = "Made by [usr.identification_string()] on [time2text(world.realtime, "DDD MMM DD")] [worldtime2text()], [game_year]<br>[comment]"
+	fields["com_[counter]"] = "Made by [usr.identification_string()] on [time2text(world.realtime, "DDD MMM DD")] [worldtime2text(give_seconds = TRUE)], [game_year]<br>[comment]"
 
 /datum/data/text
 	name = "text"

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -427,7 +427,7 @@
 				var/counter = 1
 				while(src.active2.fields[text("com_[]", counter)])
 					counter++
-				src.active2.fields[text("com_[counter]")] = text("Made by [authenticated] ([rank]) on [time2text(world.realtime, "DDD MMM DD")] [worldtime2text()], [game_year]<BR>[t1]")
+				src.active2.fields[text("com_[counter]")] = text("Made by [authenticated] ([rank]) on [time2text(world.realtime, "DDD MMM DD")] [worldtime2text(give_seconds = TRUE)], [game_year]<BR>[t1]")
 
 			if (href_list["del_c"])
 				if ((istype(src.active2, /datum/data/record) && src.active2.fields[text("com_[]", href_list["del_c"])]))

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -363,7 +363,7 @@ What a mess.*/
 				var/counter = 1
 				while(active2.fields[text("com_[]", counter)])
 					counter++
-				active2.fields[text("com_[]", counter)] = text("Made by [] ([]) on [], []<BR>[]", authenticated, rank, "[time2text(world.realtime, "DDD MMM DD")] [worldtime2text()]", game_year, t1)
+				active2.fields[text("com_[]", counter)] = text("Made by [] ([]) on [], []<BR>[]", authenticated, rank, "[time2text(world.realtime, "DDD MMM DD")] [worldtime2text(give_seconds = TRUE)]", game_year, t1)
 
 			if ("Delete Record (ALL)")
 				if (active1)


### PR DESCRIPTION
Following up on #18658.

As requested, records are timestamped with the time in seconds again.