### PR TITLE
Yet more door fixes

### DIFF
--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -74,6 +74,9 @@ var/list/poddoors = list()
 			return
 	return
 
+/obj/machinery/door/poddoor/allowed(mob/M)
+	return 0
+
 /obj/machinery/door/poddoor/open()
 	if (src.operating == 1) //doors can still open when emag-disabled
 		return

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -274,9 +274,6 @@
 		//don't care who they are or what they have, act as if they're NOTHING
 		user = null
 
-	if (!allowed(user))
-		return
-
 	return ..()
 
 /obj/machinery/door/window/emag(mob/user)


### PR DESCRIPTION
removes redundant is allowed check on windoors, that would prevent you emagging them unless you already had access to them.

Tweaks the allowed check on blast doors, so you can't open them by hand, and bots can't bump them open.

closes #18667 
closes  #14071
closes #18668
