### PR TITLE
Beekeeping 3.6.2

### DIFF
--- a/code/game/machinery/bees_apiary.dm
+++ b/code/game/machinery/bees_apiary.dm
@@ -1,6 +1,7 @@
 //http://www.youtube.com/watch?v=-1GadTfGFvU
 
 #define MAX_BEES_PER_HIVE	40
+#define EXILE_RESTRICTION	200
 
 /*
 
@@ -39,6 +40,8 @@ var/list/apiary_reservation = list()
 
 	var/datum/bee_species/species = null
 
+	var/open_for_exile = 0
+
 	machine_flags = WRENCHMOVE
 
 /obj/machinery/apiary/New()
@@ -46,6 +49,8 @@ var/list/apiary_reservation = list()
 	overlays += image('icons/obj/apiary_bees_etc.dmi', icon_state=apiary_icon)
 	create_reagents(100)
 	consume = new()
+	spawn(EXILE_RESTRICTION)
+		open_for_exile = 1
 
 /obj/machinery/apiary/Destroy()
 	for (var/datum/bee/B in bees_outside_hive)
@@ -339,6 +344,8 @@ var/list/apiary_reservation = list()
 /obj/machinery/apiary/proc/exile_swarm(var/obj/machinery/apiary/A)
 	if (A == src)//can't colonize our own apiary
 		return 0
+	if (!A.open_for_exile)//This hive was made recently, homeless queen bees have priority to claim it for themselves
+		return 0
 	if (A in apiary_reservation)//another queen has marked this one for herself
 		return 0
 	if (A.queen_bees_inside > 0 || locate(/datum/bee/queen_bee) in A.bees_outside_hive)//another queen made her way there somehow
@@ -471,6 +478,7 @@ var/list/apiary_reservation = list()
 				B_mob.mood_change(BEE_OUT_FOR_PLANTS)
 			B_mob.update_icon()
 
+		//OFF TO COLONIZE EMPTY BEE-HIVES
 		if(queen_bees_inside > 1 && worker_bees_inside >= 10)
 			for(var/obj/machinery/apiary/A in range(src,5))
 				if (exile_swarm(A))
@@ -508,11 +516,17 @@ var/list/apiary_reservation = list()
 		var/obj/machinery/apiary/wild/W = new /obj/machinery/apiary/wild(loc)
 		W.icon_state = "[prefix][W.icon_state]"
 		for (var/mob/living/simple_animal/bee/B_mob in loc)
+			//The bees that built the hive become its starting population
 			if (B_mob.state == BEE_BUILDING)
 				for(var/datum/bee/B in B_mob.bees)
 					W.enterHive(B)
 				qdel(B_mob)
 
+			//Nearby homeless bees get a free invite.
+			if (W.species && W.species == B_mob.bee_species && (B_mob.bees + W.worker_bees_inside + W.queen_bees_inside) <= MAX_BEES_PER_HIVE)
+				for(var/datum/bee/B in B_mob.bees)
+					W.enterHive(B)
+				qdel(B_mob)
 		qdel(src)
 
 
@@ -678,3 +692,4 @@ var/list/apiary_reservation = list()
 	species = bees_species[BEESPECIES_HORNET]
 
 #undef MAX_BEES_PER_HIVE
+#undef EXILE_RESTRICTION

--- a/code/modules/mob/living/simple_animal/bees/bees_datums.dm
+++ b/code/modules/mob/living/simple_animal/bees/bees_datums.dm
@@ -63,6 +63,7 @@
 	maxHealth = 15
 	corpse = /obj/effect/decal/cleanable/bee/queen_bee
 	var/colonizing = 0
+	var/searching = 0//only attempt building our own hive once we've searched for a while already.
 
 /datum/bee/queen_bee/proc/setHome(var/obj/machinery/apiary/A)
 	state = BEE_SWARM

--- a/code/modules/mob/living/simple_animal/bees/bees_mob.dm
+++ b/code/modules/mob/living/simple_animal/bees/bees_mob.dm
@@ -181,6 +181,19 @@
 		if (3)
 			adjustBruteLoss(20)
 
+/mob/living/simple_animal/bee/nuke_act()
+	//first of all, we don't want more bees to come out of a hive that got nuked (for now at least)
+	if (home && home.z == z)
+		home.queen_bees_inside = 0
+		home.worker_bees_inside = 0
+
+	//this may or may not kill them all, but it'll at least spawn a good amount of bee corpses
+	adjustBruteLoss(100)
+
+	//cleanup
+	if (src)
+		qdel(src)
+
 /mob/living/simple_animal/bee/unarmed_attacked(mob/living/attacker, damage, damage_type, zone)
 	..()
 	panic_attack(attacker)

--- a/code/modules/mob/living/simple_animal/bees/bees_mob.dm
+++ b/code/modules/mob/living/simple_animal/bees/bees_mob.dm
@@ -7,7 +7,7 @@
 
 #define BOREDOM_TO_RETURN	30//once reached, the bee will head back to its hive
 
-#define EXHAUSTION_TO_DIE	600//once reached, the bee will begin to die
+#define EXHAUSTION_TO_DIE	300//once reached, the bee will begin to die
 
 #define MAX_BEES_PER_SWARM	20//explicit
 
@@ -466,7 +466,7 @@
 					qdel(B_mob)
 					updateDamage()
 
-			else if(prob(30) && state != BEE_OUT_FOR_ENEMIES && pollinating <= 0  && B_mob.pollinating <= 0 && state == B_mob.state)
+			else if((state == BEE_BUILDING) || (prob(30) && state != BEE_OUT_FOR_ENEMIES && pollinating <= 0  && B_mob.pollinating <= 0 && state == B_mob.state))
 				for (var/datum/bee/B in B_mob.bees)
 					addBee(B)
 				B_mob.bees = list()
@@ -615,16 +615,19 @@
 			home = null
 			//if there's a queen among us, let's gather a following
 			var/datum/bee/queen_bee/queen = null
+			var/list/queen_list = list()
 			for (var/D in bees)
 				if (istype(D,/datum/bee/queen_bee))
+					queen_list.Add(D)
 					queen = D
 			if (queen)
-				if (bees.len < 11)
+				if (bees.len < MAX_BEES_PER_SWARM)
 					var/turf/T = get_turf(loc)
 					for(var/mob/living/simple_animal/bee/B in range(src,3))
 						if (bee_species == B.bee_species && B.state == BEE_ROAMING && B.loc != T)
 							step_to(B, T)//come closer, the GROUPING segment above should take care of the merging after a moment.
-				else
+
+				if (bees.len >= 11)
 				//once there's enough of us, let's find a new home
 					for(var/obj/machinery/apiary/A in range(src,3))
 						if (exile_swarm(A))
@@ -634,15 +637,20 @@
 							update_icon()
 							return
 
-					//and if there isn't any decent home nearby...let's build one!
-					var/list/available_turfs = list()
-					for (var/turf/simulated/floor/T in range(src,2))
-						if(!T.has_dense_content() && !(locate(/obj/structure/wild_apiary) in T))
-							available_turfs.Add(T)
-					if (available_turfs.len>0)
-						building = pick(available_turfs)
-						if (building)
-							mood_change(BEE_BUILDING)
+
+					for (var/datum/bee/queen_bee/QB in queen_list)
+						QB.searching++
+						if (QB.searching>20)
+							//and if there isn't any decent home nearby (after searching for a while)...let's build one!
+							var/list/available_turfs = list()
+							for (var/turf/simulated/floor/T in range(src,2))
+								if(!T.has_dense_content() && !(locate(/obj/structure/wild_apiary) in T))
+									available_turfs.Add(T)
+							if (available_turfs.len>0)
+								building = pick(available_turfs)
+								if (building)
+									mood_change(BEE_BUILDING)
+							break
 
 
 			else
@@ -663,7 +671,7 @@
 				if (istype(D,/datum/bee/queen_bee))
 					queen = D
 			if(queen && building)
-				if (bees.len < 20)//Gathering some more volunteers.
+				if (bees.len < MAX_BEES_PER_SWARM)//Gathering some more volunteers.
 					var/turf/T = get_turf(loc)
 					for(var/mob/living/simple_animal/bee/B in range(src,3))
 						if (bee_species == B.bee_species && B.state == BEE_ROAMING && B.loc != T)


### PR DESCRIPTION
Addressing some of the concerns that came up in #18621

:cl:
* tweak: Newly placed apiary trays can only be colonized by either homeless queens or queen packets for the first 20 seconds of their existence. So if you place a hive after deconstructing an apiary, you know it won't get stolen by a queen from another apiary.
* tweak: Homeless queens have to be in the wandering state for 20 seconds before they become able to build a wild hive. Which should prevent them from starting building them before you've had the time to place the apiary trays back down.
* tweak: Queen-less homeless bee swarms now begin to lose health after 5 minutes, down from 10 minutes.
* tweak: Upon building a new wild hive, homeless bees of the same species that were standing on top but unable to join the builder swarm will get a free invite inside the finished hive (as long as there's room in it)
* bugfix: Made sure that bees can't survive nukes.
* bugfix: Made sure that nuked hives won't spawn more bees.