### PR TITLE
Makes HONK upgrade's clown stamp work

### DIFF
--- a/__DEFINES/silicon.dm
+++ b/__DEFINES/silicon.dm
@@ -63,3 +63,4 @@ var/global/list/mommi_modules = list(
 #define MODULE_IS_THE_LAW 128
 #define MODULE_CAN_LIFT_SECTAPE 256
 #define MODULE_CAN_LIFT_ENGITAPE 512
+#define MODULE_IS_A_CLOWN 1024

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -173,7 +173,7 @@
 	if(!("Security" in R.module.sensor_augs)) //If they don't have a SECHUD, give them one.
 		pop(R.module.sensor_augs)
 		R.module.sensor_augs.Add("Security", "Disable")
-	
+
 	if(!(R.module.quirk_flags & MODULE_IS_THE_LAW)) //Make them able to *law and *halt
 		R.module.quirk_flags |= MODULE_IS_THE_LAW
 
@@ -337,6 +337,8 @@
 		C.Honkize()
 
 	playsound(R, 'sound/items/AirHorn.ogg', 50, 1)
+
+	R.module.quirk_flags |= MODULE_IS_A_CLOWN
 
 /obj/item/borg/upgrade/noir
 	name = "security cyborg N.O.I.R. upgrade board"

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -312,9 +312,6 @@
 
 /obj/item/weapon/paper/attackby(obj/item/weapon/P as obj, mob/user as mob)
 	..()
-	var/clown = 0
-	if(user.mind && (user.mind.assigned_role == "Clown"))
-		clown = 1
 
 	if(istype(P, /obj/item/weapon/pen) || istype(P, /obj/item/toy/crayon))
 		if ( istype(P, /obj/item/weapon/pen/robopen) && P:mode == 2 )
@@ -326,9 +323,17 @@
 
 	else if(istype(P, /obj/item/weapon/stamp))
 
-		if(istype(P, /obj/item/weapon/stamp/clown) && !clown)
-			to_chat(user, "<span class='notice'>You are totally unable to use the stamp. HONK!</span>")
-			return
+		if(istype(P, /obj/item/weapon/stamp/clown))
+			var/clown = FALSE
+			if(user.mind && (user.mind.assigned_role == "Clown"))
+				clown = TRUE
+			if(isrobot(user))
+				var/mob/living/silicon/robot/R = user
+				if(R.module && R.module.quirk_flags & MODULE_IS_A_CLOWN)
+					clown = TRUE
+			if(!clown)
+				to_chat(user, "<span class='notice'>You are totally unable to use the stamp. HONK!</span>")
+				return
 
 		stamps += (stamps=="" ? "<HR>" : "<BR>") + "<i>This [src.name] has been stamped with the [P.name].</i>"
 


### PR DESCRIPTION
I know I didn't _have_ to make a new quirk flag just for this, but it could be useful in the future.

:cl:
* bugfix: The clown stamp in the HONK upgrade for service borgs and hugborgs actually works now.