### PR TITLE
Fixes an error in parameters order that resulted in factions not being able to be set up properly

### DIFF
--- a/code/datums/gamemode/factions/faction.dm
+++ b/code/datums/gamemode/factions/faction.dm
@@ -66,10 +66,10 @@ var/list/factions_with_hud_icons = list()
 /datum/faction/proc/HandleNewMind(var/datum/mind/M) //Used on faction creation
 	for(var/datum/role/R in members)
 		if(R.antag == M)
-			warning("Mind was already a role in this faction")
+			WARNING("Mind was already a role in this faction")
 			return 0
 	if(M.GetRole(initial_role))
-		warning("Mind already had a role of [initial_role]!")
+		WARNING("Mind already had a role of [initial_role]!")
 		return 0
 	var/datum/role/newRole = new initroletype(null, src, initial_role)
 	if(!newRole.AssignToRole(M))
@@ -81,10 +81,10 @@ var/list/factions_with_hud_icons = list()
 /datum/faction/proc/HandleRecruitedMind(var/datum/mind/M)
 	for(var/datum/role/R in members)
 		if(R.antag == M)
-			warning("Mind was already a role in this faction")
+			WARNING("Mind was already a role in this faction")
 			return 0
 	if(M.GetRole(late_role))
-		warning("Mind already had a role of [late_role]!")
+		WARNING("Mind already had a role of [late_role]!")
 		return 0
 	var/datum/role/R = new roletype(fac = src, new_id = late_role)
 	if(!R.AssignToRole(M))

--- a/code/datums/gamemode/factions/faction.dm
+++ b/code/datums/gamemode/factions/faction.dm
@@ -66,12 +66,12 @@ var/list/factions_with_hud_icons = list()
 /datum/faction/proc/HandleNewMind(var/datum/mind/M) //Used on faction creation
 	for(var/datum/role/R in members)
 		if(R.antag == M)
-			WARNING("Mind was already a role in this faction")
+			warning("Mind was already a role in this faction")
 			return 0
 	if(M.GetRole(initial_role))
 		warning("Mind already had a role of [initial_role]!")
 		return 0
-	var/datum/role/newRole = new initroletype(src,null, initial_role)
+	var/datum/role/newRole = new initroletype(null, src, initial_role)
 	if(!newRole.AssignToRole(M))
 		newRole.Drop()
 		return 0
@@ -81,7 +81,7 @@ var/list/factions_with_hud_icons = list()
 /datum/faction/proc/HandleRecruitedMind(var/datum/mind/M)
 	for(var/datum/role/R in members)
 		if(R.antag == M)
-			WARNING("Mind was already a role in this faction")
+			warning("Mind was already a role in this faction")
 			return 0
 	if(M.GetRole(late_role))
 		warning("Mind already had a role of [late_role]!")

--- a/code/datums/gamemode/gamemode.dm
+++ b/code/datums/gamemode/gamemode.dm
@@ -93,7 +93,7 @@
 			if(!P.client.desires_role(F.required_pref) || jobban_isbanned(P, F.required_pref))
 				continue
 			if(!F.HandleNewMind(P.mind))
-				warning("[P.mind] failed [F] HandleNewMind!")
+				crash("[P.mind] failed [F] HandleNewMind!")
 				continue
 	return 1
 

--- a/code/datums/gamemode/gamemode.dm
+++ b/code/datums/gamemode/gamemode.dm
@@ -93,7 +93,7 @@
 			if(!P.client.desires_role(F.required_pref) || jobban_isbanned(P, F.required_pref))
 				continue
 			if(!F.HandleNewMind(P.mind))
-				crash("[P.mind] failed [F] HandleNewMind!")
+				CRASH("[P.mind] failed [F] HandleNewMind!")
 				continue
 	return 1
 

--- a/code/datums/gamemode/gamemode.dm
+++ b/code/datums/gamemode/gamemode.dm
@@ -93,7 +93,7 @@
 			if(!P.client.desires_role(F.required_pref) || jobban_isbanned(P, F.required_pref))
 				continue
 			if(!F.HandleNewMind(P.mind))
-				CRASH("[P.mind] failed [F] HandleNewMind!")
+				stack_trace("[P.mind] failed [F] HandleNewMind!")
 				continue
 	return 1
 

--- a/code/datums/gamemode/role/role.dm
+++ b/code/datums/gamemode/role/role.dm
@@ -122,10 +122,10 @@
 
 /datum/role/proc/AssignToRole(var/datum/mind/M,var/override = 0)
 	if(!istype(M) && !override)
-		crash("M is [M.type]!")
+		CRASH("M is [M.type]!")
 		return 0
 	if(!CanBeAssigned(M) && !override)
-		crash("[M] was to be assigned to [name] but failed CanBeAssigned!")
+		CRASH("[M] was to be assigned to [name] but failed CanBeAssigned!")
 		return 0
 
 	antag = M

--- a/code/datums/gamemode/role/role.dm
+++ b/code/datums/gamemode/role/role.dm
@@ -122,10 +122,10 @@
 
 /datum/role/proc/AssignToRole(var/datum/mind/M,var/override = 0)
 	if(!istype(M) && !override)
-		CRASH("M is [M.type]!")
+		stack_trace("M is [M.type]!")
 		return 0
 	if(!CanBeAssigned(M) && !override)
-		CRASH("[M] was to be assigned to [name] but failed CanBeAssigned!")
+		stack_trace("[M] was to be assigned to [name] but failed CanBeAssigned!")
 		return 0
 
 	antag = M

--- a/code/datums/gamemode/role/role.dm
+++ b/code/datums/gamemode/role/role.dm
@@ -122,10 +122,10 @@
 
 /datum/role/proc/AssignToRole(var/datum/mind/M,var/override = 0)
 	if(!istype(M) && !override)
-		WARNING("M is [M.type]!")
+		crash("M is [M.type]!")
 		return 0
 	if(!CanBeAssigned(M) && !override)
-		WARNING("[M] was to be assigned to [name] but failed CanBeAssigned!")
+		crash("[M] was to be assigned to [name] but failed CanBeAssigned!")
 		return 0
 
 	antag = M


### PR DESCRIPTION
You had : 
```dm
var/datum/role/newRole = new initroletype(null, src, initial_role)
```
With `src` being a faction, but the role's `New()` was : 
```dm
/datum/role/New(var/datum/mind/M, var/datum/faction/fac=null, var/new_id, var/override = FALSE)
```
IE, a `faction` was expected as the second parameter.
I also made a bunch of error runtime instead of just a warning to have an easier time tracking down the issue.