### PR TITLE
explosions inside bodies / open containers no longer remove all chems

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -79,7 +79,7 @@
 		if(L.stat != DEAD)
 			e.amount *= 0.5
 	e.start()
-	if(ismob(holder))
+	if(holder.my_atom.is_open_container())
 		holder.del_reagent(POTASSIUM)
 		holder.del_reagent(WATER)
 	else
@@ -476,7 +476,7 @@
 		if(L.stat!=DEAD)
 			e.amount *= 0.5
 	e.start()
-	if(ismob(holder))
+	if(holder.my_atom.is_open_container())
 		holder.del_reagent(GLYCEROL)
 		holder.del_reagent(PACID)
 		holder.del_reagent(SACID)

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -79,7 +79,7 @@
 		if(L.stat != DEAD)
 			e.amount *= 0.5
 	e.start()
-	if(holder.my_atom.is_open_container())
+	if(!holder.my_atom.is_open_container() || ismob(holder.my_atom))
 		holder.del_reagent(POTASSIUM)
 		holder.del_reagent(WATER)
 	else
@@ -476,7 +476,7 @@
 		if(L.stat!=DEAD)
 			e.amount *= 0.5
 	e.start()
-	if(holder.my_atom.is_open_container())
+	if(!holder.my_atom.is_open_container() || ismob(holder.my_atom))
 		holder.del_reagent(GLYCEROL)
 		holder.del_reagent(PACID)
 		holder.del_reagent(SACID)

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -476,7 +476,12 @@
 		if(L.stat!=DEAD)
 			e.amount *= 0.5
 	e.start()
-	holder.clear_reagents()
+		if(ismob(holder))
+		holder.del_reagent(GLYCEROL)
+		holder.del_reagent(PACID)
+		holder.del_reagent(SACID)
+	else
+		holder.clear_reagents()
 
 /datum/chemical_reaction/sodiumchloride
 	name = "Sodium Chloride"

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -79,7 +79,11 @@
 		if(L.stat != DEAD)
 			e.amount *= 0.5
 	e.start()
-	holder.clear_reagents()
+	if(ismob(holder))
+		holder.del_reagent(POTASSIUM)
+		holder.del_reagent(WATER)
+	else
+		holder.clear_reagents()
 
 /datum/chemical_reaction/creatine
 	name = "Creatine"

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -476,7 +476,7 @@
 		if(L.stat!=DEAD)
 			e.amount *= 0.5
 	e.start()
-		if(ismob(holder))
+	if(ismob(holder))
 		holder.del_reagent(GLYCEROL)
 		holder.del_reagent(PACID)
 		holder.del_reagent(SACID)


### PR DESCRIPTION
This removes the oversight/bug/exploit where a water+potassium / nitroglycerin reaction inside a open container / body would remove all their reagents from it/them. If you're worried about gameplay mechanics, I'd recommend just using active charcoal instead.

🆑 
 - bugfix: Water + potassium reactions and nitroglycerine explosions inside open containers and bodies no longer delete all reagents inside said container or body (Just use charcoal instead, it's pretty effective.)