### PR TITLE
Makes autoinjectors closed containers

### DIFF
--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -83,13 +83,13 @@
 	item_state = "autoinjector"
 	amount_per_transfer_from_this = 5
 	volume = 5
+	flags = FPRINT
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/attack(mob/M as mob, mob/user as mob)
 	..()
-	if(reagents.total_volume <= 0) //Prevents autoinjectors to be refilled.
-		flags &= ~OPENCONTAINER
+//	if(reagents.total_volume <= 0) //Prevents autoinjectors to be refilled.
+//		flags &= ~OPENCONTAINER
 	update_icon()
-	return
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/update_icon()
 	if(reagents.total_volume > 0)


### PR DESCRIPTION
No more nerfing all chems and leaving the real issue untouched. This will make the CMO's hypospray and traitor sleepypens actually worthy the trouble, too.

:cl:
 * rscdel: Autoinjectors are now closed containers, meaning you can't manipulate its chems anymore.
