### PR TITLE
Hostile mob stopping

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -268,8 +268,8 @@
 
 /mob/living/simple_animal/hostile/death(var/gibbed = FALSE)
 	LoseAggro()
-	..(gibbed)
 	walk(src, 0)
+	..(gibbed)
 
 /mob/living/simple_animal/hostile/inherit_mind(mob/living/simple_animal/from)
 	..()


### PR DESCRIPTION
Hostile mobs stop WHEN they die, not after they die.

Fixes some oversight from the do_flick I put into simple_animal death(), where if a mob was on the hunt it wouldn't stop until after its death animation played.