### PR TITLE
Holopeople no longer behind admin intervention

### DIFF
--- a/code/game/machinery/computer/HolodeckControl.dm
+++ b/code/game/machinery/computer/HolodeckControl.dm
@@ -13,7 +13,7 @@
 	var/damaged = 0
 	var/last_change = 0
 
-	var/holopeople_enabled = FALSE //Set this to true to allow observers become holodudes
+	var/holopeople_enabled = TRUE //Set this to true to allow observers become holodudes
 	var/list/connected_holopeople = list()
 	var/maximum_holopeople = 4
 


### PR DESCRIPTION
In our infinite wisdom as admins we knee-jerk reacted and put Holomen behind admin buttons based on a couple of events where players would act like holoshitters and some other bugs.
Forgetting the fact that we as admin instead should have done what we are supposed to do and told these people to knock it off.

This reinstates the holomen to the public and for those who forget, this is the message you get when becoming a holodude.
![dreamseeker_2018-07-04_15-11-28](https://user-images.githubusercontent.com/19466872/42282307-599d4ff4-7fa6-11e8-956b-e007258c6914.png)

So this time will be different and anyone skirting around these very obvious directives will be dealt with accordingly. In short, don't use holodudes to be a shitter.

:cl:
 * rscadd: You can now, once again, become a holoperson by clicking the hologram computer as a ghost
