### PR TITLE
Stops "You can't pick things up!" spam for holopeople

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -806,8 +806,9 @@
 		return FALSE
 	if(user.incapacitated() || !Adjacent(user))
 		return FALSE
-	if((!istype(user, /mob/living/carbon) && !isMoMMI(user)) || istype(user, /mob/living/carbon/brain)) //Is not a carbon being, MoMMI, or is a brain
+	if((!iscarbon(user) && !isMoMMI(user)) && !ishologram(user) || isbrain(user)) //Is not a carbon being, MoMMI, advanced hologram, or is a brain
 		to_chat(user, "You can't pick things up!")
+		return FALSE
 	if(anchored) //Object isn't anchored
 		to_chat(user, "<span class='warning'>You can't pick that up!</span>")
 		return FALSE


### PR DESCRIPTION
:cl:
* bugfix: Stopped holopeople getting spammed with "You can't pick things up!" when picking things up.