### PR TITLE
Warning stripes now inherit their pixel_x and pixel_y mapping values

### DIFF
--- a/code/game/objects/effects/decals/warning_stripes.dm
+++ b/code/game/objects/effects/decals/warning_stripes.dm
@@ -5,6 +5,8 @@
 	. = ..()
 	var/turf/T=get_turf(src)
 	var/image/I=image(icon, icon_state = icon_state, dir = dir)
+	I.pixel_x = pixel_x
+	I.pixel_y = pixel_y
 	I.color=color
 	T.AddDecal(I)
 	qdel(src)


### PR DESCRIPTION
The warning stripes weren't inheriting pixel_x and pixel_y from their corresponding spawn object, which made things such as the defficiency radiation symbols spawn on the floor, rather than on the walls.