### PR TITLE
Hasty fix to a round-ending runtime

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -92,7 +92,10 @@
 	//handles "call on life", allowing external life-related things to be processed
 	for(var/toCall in src.callOnLife)
 		if(locate(toCall) && callOnLife[toCall])
-			call(locate(toCall),callOnLife[toCall])()
+			try
+				call(locate(toCall),callOnLife[toCall])()
+			catch(var/exception/e)
+				stack_trace(e)
 		else
 			callOnLife -= toCall
 


### PR DESCRIPTION
Somehow in a recent round an illegal proc was being called, which ended Life() abruptly and broke everything.
This should prevent such a thing from happening.