### PR TITLE
A revialver runtime

### DIFF
--- a/code/modules/projectiles/guns/projectile/constructable/revialver.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/revialver.dm
@@ -129,7 +129,7 @@
 		return
 
 	var/obj/item/weapon/cylinder/C = cylinder
-	if(!(C.chambers[C.current_chamber]))
+	if(!(istype(C) && C.chambers[C.current_chamber]))
 		click_empty(user)
 		return
 


### PR DESCRIPTION
```
[22:18:18] Runtime in revialver.dm,132: Cannot read null.chambers
  proc name: afterattack (/obj/item/weapon/gun/projectile/revialver/afterattack)
  usr: Marcos Conrad (panthid) (/mob/living/carbon/human)
  usr.loc: The floor (131, 143, 1) (/turf/simulated/floor/wood)
```