### PR TITLE
Greys out internal organ items when they die

### DIFF
--- a/code/modules/organs/organ_objects.dm
+++ b/code/modules/organs/organ_objects.dm
@@ -84,10 +84,19 @@
 	name = "dead [initial(name)]"
 	if(dead_icon)
 		icon_state = dead_icon
+	var/icon/original = icon(icon, icon_state)
+	original.GrayScale()
+	icon = original
 	health = 0
 	processing_objects -= src
-	//TODO: Grey out the icon state.
 	//TODO: Inject an organ with peridaxon to make it alive again.
+
+/obj/item/organ/internal/proc/revive()
+	name = initial(name)
+	icon_state = initial(icon_state)
+	icon = initial(icon)
+	health = 1
+	processing_objects += src
 
 /obj/item/organ/internal/proc/roboticize()
 

--- a/code/modules/organs/organ_objects.dm
+++ b/code/modules/organs/organ_objects.dm
@@ -48,7 +48,7 @@
 	if(!had_mind)
 		user.simple_message("<span class='warning'>The organ seems limp and lifeless.  Perhaps it never was controlled by an intelligent mind?</span>","<span class='warning'>This thing is bummed.</span>")
 	else
-		user.simple_message("<span class='info'>The organ seems to be full of life!</span>","<span class='info'>It's making happy little cooing noises at you. Aw.</span>")
+		user.simple_message("<span class='info'>The organ seems [health ? "to be full of life!" : "like it was full of life once."]</span>","<span class='info'>It's making [health ? "happy" : "spooky"] little cooing noises at you. Aw.</span>")
 
 /obj/item/organ/internal/process()
 

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -2653,6 +2653,8 @@
 
 	if(istype(O, /obj/item/organ/internal))
 		var/obj/item/organ/internal/I = O
+		if(I.health <= 0)
+			I.revive()
 		if(I.health < initial(I.health))
 			I.health = min(I.health+rand(1,3), initial(I.health))
 		if(I.organ_data)


### PR DESCRIPTION
Since we have a HARDCORE organ death system and there's an age-old TODO for this.

![dead organs](https://user-images.githubusercontent.com/31839805/42530267-9899b7d6-8435-11e8-86c5-3cd4ffb7532a.PNG)

:cl:
* imageadd: Organ items now grey out when they die after being left out too long.
* bugfix: Fixed dead organs not getting fully reset when revived.