### PR TITLE
Lets cyborgs unload storage onto tables

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -35,13 +35,16 @@
 	return TRUE
 
 /obj/item/weapon/storage/MouseDrop(obj/over_object as obj)
-	if (ishuman(usr) || ismonkey(usr)) //so monkeys can take off their backpacks -- Urist
+	if (ishuman(usr) || ismonkey(usr) || isrobot(usr) && is_holder_of(usr, src)) //so monkeys can take off their backpacks -- Urist
 		var/mob/M = usr
 		if(istype(over_object, /obj/structure/table) && M.Adjacent(over_object) && Adjacent(M))
 			var/mob/living/L = usr
 			if(istype(L) && !(L.incapacitated() || L.lying))
 				if(can_use())
 					empty_contents_to(over_object)
+
+		if(isrobot(usr))
+			return
 
 		if(!( istype(over_object, /obj/abstract/screen/inventory) ))
 			return ..()


### PR DESCRIPTION
Mainly so medborgs can unload their pill collector onto tables instead of the floor.

:cl:
* tweak: Cyborgs with storage modules (such as pill collectors) can now unload them onto tables by click-dragging.