### PR TITLE
Buff harm syringes to be less RNG-dependant

### DIFF
--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -327,7 +327,7 @@
 
 	// Break the syringe and transfer some of the reagents to the target
 	src.reagents.reaction(target, INGEST)
-	var/syringestab_amount_transferred = rand(0, (reagents.total_volume - 5)) //nerfed by popular demand
+	var/syringestab_amount_transferred = rand(min(reagents.total_volume, 2), (reagents.total_volume - 5)) //nerfed by popular demand
 	src.reagents.trans_to(target, syringestab_amount_transferred)
 	src.desc += " It is broken."
 	src.mode = SYRINGE_BROKEN


### PR DESCRIPTION
Now, for a non-empty syringe, there is always a chance of at least 2 units being transferred.

Reasoning : 
Syringes have always been a very frustrating way to deal with enemies as there is always a chance of your attack being completly neglected even if your target is not wearing any armour.
This changes that.
With the removal of autoinjectors, and the (soon ?) revert of Chloral Nerf, I believe it's time to show the stabby syringes some love.

Sorry for the lazy GitHub commit, I wanted to gather feedback early so.

:cl:
- tweak: Non-empty syringes on harm-intent will now transfer a minimum amount of 2u of the reagent they contain on unarmoured targets.