### PR TITLE
Running out of power will kill the lights before the equipment

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1134,9 +1134,9 @@
 			environ = autoset(environ, 1)
 			if(this_area.poweralm && make_alerts)
 				this_area.poweralert(0, src)
-		else if(cell.percent() < 30 && longtermpower < 0)			// <30%, turn off equipment
-			equipment = autoset(equipment, 2)
-			lighting = autoset(lighting, 1)
+		else if(cell.percent() < 30 && longtermpower < 0)			// <30%, turn off lighting
+			equipment = autoset(equipment, 1)
+			lighting = autoset(lighting, 2)
 			environ = autoset(environ, 1)
 			if(this_area.poweralm && make_alerts)
 				this_area.poweralert(0, src)


### PR DESCRIPTION
Because running the machines is more important

:cl:
 * tweak: APCs running out of power will now disable lighting first and equipment second.