### PR TITLE
pAI recruitment pings to ghosts only hidden on "never"

### DIFF
--- a/code/modules/mob/living/silicon/pai/recruit.dm
+++ b/code/modules/mob/living/silicon/pai/recruit.dm
@@ -191,8 +191,8 @@ var/datum/paiController/paiController			// Global handler for pAI candidates
 	user << browse(dat, "window=findPai")
 
 /datum/paiController/proc/requestRecruits(var/obj/item/device/paicard/p)
-	for(var/mob/dead/observer/O in get_active_candidates(ROLE_PAI)) // We handle polling ourselves.
-		if(O.client)
+	for(var/mob/dead/observer/O in player_list) // We handle polling ourselves.
+		if(O.client && get_role_desire_str(O.client.prefs.roles[ROLE_PAI]) != "Never")
 			if(check_recruit(O))
 				to_chat(O, "<span class='recruit'>A pAI card is looking for personalities. (<a href='?src=\ref[src];signup=1'>Sign Up</a> | <a href='?src=\ref[O];jump=\ref[p]'>Teleport</a>)</span>")
 				//question(O.client)


### PR DESCRIPTION
:cl:
* tweak: pAI recruitment pings will now display to all ghosts unless they have their pAI role preference set to "never."