### PR TITLE
Hides the amount of people readied up to non-admins

### DIFF
--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -170,7 +170,7 @@ var/datum/controller/gameticker/ticker
 			to_chat(world, "<B>The current game mode is - [pick("Chivalry","Crab Battle","Bay Transfer","Dwarf Fortress","Ian Says","Admins Funhouse","Meteor","Xenoarchaeology Appreciation","Clowns versus [pick("Mimes","Assistants","the Universe")]","Dino wars","Malcolm in the Middle","Six hours of extended where one person with all the access refuses to call the shuttle while everyone else goes braindead","Monkey Study","Nations","Nations by Hasbro","High roleplay Extended","DarkRP","Babies Day out","Ians Day out","Shortstaffed medical")]!</B>")
 		else
 			to_chat(world, "<B>The current game mode is - Secret!</B>")
-			to_chat(world, "<B>Possibilities:</B> [english_list(modes)]")
+			//to_chat(world, "<B>Possibilities:</B> [english_list(modes)]")
 	else
 		src.mode.announce()
 

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -372,7 +372,7 @@
 				if(istype(P.cartridge,/obj/item/weapon/cartridge/trader))
 					var/mob/living/L = get_holder_of_type(P,/mob/living)
 					if(L)
-						L.show_message("[bicon(P)] <b>Message from U���8�E1��Ћ (T�u1B��), </b>\"Caw. Cousin [character] detected in sector.\".", 2)
+						L.show_message("[bicon(P)] <b>Message from U¦É8¥E1ÀÓÐ< (T¥u1B¤Õ), </b>\"Caw. Cousin [character] detected in sector.\".", 2)
 			for(var/mob/dead/observer/M in player_list)
 				if(M.stat == DEAD && M.client)
 					handle_render(M,"<span class='game say'>PDA Message - <span class='name'>Trader [character] has arrived in the sector from space.</span></span>",character) //This should generate a Follow link

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -66,7 +66,7 @@
 
 /mob/new_player/Stat()
 	..()
-
+	var/time_to_start = (round(ticker.pregame_timeleft - world.timeofday) / 10)
 	if(statpanel("Status") && ticker)
 		if (ticker.current_state != GAME_STATE_PREGAME)
 			stat(null, "Station Time: [worldtime2text()]")
@@ -79,13 +79,13 @@
 
 		if(SSticker.initialized)
 			if((ticker.current_state == GAME_STATE_PREGAME) && going)
-				stat("Time To Start:", (round(ticker.pregame_timeleft - world.timeofday) / 10)) //rounding because people freak out at decimals i guess
+				stat("Time To Start:", time_to_start) //rounding because people freak out at decimals i guess
 			if((ticker.current_state == GAME_STATE_PREGAME) && !going)
 				stat("Time To Start:", "DELAYED")
 		else
 			stat("Time To Start:", "LOADING...")
 
-		if(SSticker.initialized && ticker.current_state == GAME_STATE_PREGAME)
+		if(SSticker.initialized && ticker.current_state == GAME_STATE_PREGAME && check_rights(0)) // Only admins can see who readied up
 			stat("Players: [totalPlayers]", "Players Ready: [totalPlayersReady]")
 			totalPlayers = 0
 			totalPlayersReady = 0
@@ -372,7 +372,7 @@
 				if(istype(P.cartridge,/obj/item/weapon/cartridge/trader))
 					var/mob/living/L = get_holder_of_type(P,/mob/living)
 					if(L)
-						L.show_message("[bicon(P)] <b>Message from U¦ŸÉ8¥E1ÀÓÐ‹ (T¥u1B¤Õ), </b>\"Caw. Cousin [character] detected in sector.\".", 2)
+						L.show_message("[bicon(P)] <b>Message from Uï¿½ï¿½ï¿½8ï¿½E1ï¿½ï¿½Ð‹ (Tï¿½u1Bï¿½ï¿½), </b>\"Caw. Cousin [character] detected in sector.\".", 2)
 			for(var/mob/dead/observer/M in player_list)
 				if(M.stat == DEAD && M.client)
 					handle_render(M,"<span class='game say'>PDA Message - <span class='name'>Trader [character] has arrived in the sector from space.</span></span>",character) //This should generate a Follow link


### PR DESCRIPTION
## Reasoning

This should help with the "24 readied up"phenomenon as well as help to prevent the Nuke Ops manifest count roundstart.

:cl:

- rscdel: Non-admins can no longer see the amount of people who readied up in the pre-game lobby.