### PR TITLE
Delay latejoin by X minutes (to be defined)

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -120,6 +120,8 @@
 	var/bones_can_break = 0
 	var/limbs_can_break = 0
 
+	var/delay_latejoin = 0
+
 	var/revival_pod_plants = 1
 	var/revival_cloning = 1
 	var/revival_brain_life = -1
@@ -579,6 +581,8 @@
 					discord_password = value
 				if("weighted_votes")
 					weighted_votes = TRUE
+				if("delay_latejoin")
+					config.delay_latejoin = value
 
 				else
 					diary << "Unknown setting in configuration: '[name]'"

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -86,6 +86,8 @@
 	if(revdata)
 		feedback_set_details("revision","[revdata.revision]")
 	feedback_set_details("server_ip","[world.internet_address]:[world.port]")
+	if (player_list.len < 15)
+		config.delay_latejoin = 0 // No delay if we're on lowpop.
 	return 1
 
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -77,7 +77,8 @@ var/list/admin_verbs_admin = list(
 	/client/proc/toggle_antagHUD_restrictions,
 	/client/proc/allow_character_respawn,    /* Allows a ghost to respawn */
 	/client/proc/watchdog_force_restart,	/*forces restart using watchdog feature*/
-	/client/proc/manage_religions
+	/client/proc/manage_religions,
+	/client/proc/toggle_latejoin_delay,
 )
 var/list/admin_verbs_ban = list(
 	/client/proc/unban_panel,

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1091,6 +1091,23 @@ Traitors and the like can also be revived with the previous role mostly intact.
 
 	feedback_add_details("admin_verb", "SCO") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
+/client/proc/toggle_latejoin_delay()
+	set category = "Admin"
+	set name = "Toggle latejoin delay"
+
+	if (!check_rights(R_ADMIN))
+		return FALSE
+	
+	if (config && config.delay_latejoin)
+		config.delay_latejoin = 0
+		log_admin("[key_name(usr)] has turned latejoin delay off.")
+		message_admins("<span class='notice'>[key_name(usr)] has turned latejoin delay off.</span>", 1)
+		return TRUE
+
+	if (!config || !config.delay_latejoin) 
+		to_chat(usr, "<span class='warning'>No delay on latejoining already.</span>")
+		return FALSE
+
 /client/proc/cmd_admin_equip_loadout(mob/M as mob in mob_list)
 	set category = "Fun"
 	set name = "Equip Loadout"

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -174,6 +174,14 @@
 			to_chat(usr, "<span class='warning'>The round is either not ready, or has already finished...</span>")
 			return
 
+		if (config && config.delay_latejoin && ticker.current_state == GAME_STATE_PLAYING && world.timeofday <= config.delay_latejoin && !check_rights())
+
+			var/time_left = config.delay_latejoin - world.timeofday
+			var/minutes = round(time_left/60)
+			var/seconds = time_left - 60*minutes
+			to_chat(usr, "<span class='warning'>Early latejoining is disabled. [minutes]:[seconds >= 10 ? seconds : "0[seconds]"] remaining.</span>")
+			return
+
 		if(client.prefs.species != "Human")
 
 			if(!is_alien_whitelisted(src, client.prefs.species) && config.usealienwhitelist)
@@ -372,7 +380,7 @@
 				if(istype(P.cartridge,/obj/item/weapon/cartridge/trader))
 					var/mob/living/L = get_holder_of_type(P,/mob/living)
 					if(L)
-						L.show_message("[bicon(P)] <b>Message from U¦ŸÉ8¥E1ÀÓÐ‹ (T¥u1B¤Õ), </b>\"Caw. Cousin [character] detected in sector.\".", 2)
+						L.show_message("[bicon(P)] <b>Message from Uï¿½ï¿½ï¿½8ï¿½E1ï¿½ï¿½Ð‹ (Tï¿½u1Bï¿½ï¿½), </b>\"Caw. Cousin [character] detected in sector.\".", 2)
 			for(var/mob/dead/observer/M in player_list)
 				if(M.stat == DEAD && M.client)
 					handle_render(M,"<span class='game say'>PDA Message - <span class='name'>Trader [character] has arrived in the sector from space.</span></span>",character) //This should generate a Follow link

--- a/config-example/config.txt
+++ b/config-example/config.txt
@@ -210,6 +210,11 @@ SOCKET_TALK 0
 ## How long the delay is before the Away Mission gate opens. Default is half an hour.
 GATEWAY_DELAY 18000
 
+## LATEJOIN_DELAY
+## Configures the delay latejoiners have to wait before joining in on the server
+## In deciseconds (seconds *10)
+LATEJOIN_DELAY 18000
+
 ## Remove the # to give assistants maint access.
 #ASSISTANT_MAINT
 


### PR DESCRIPTION
## Reasoning

The point is to avoid people latejoinings 2.5 seconds into a round to secure their favourite toy.
30 minutes is way too much, but I'm not sure what a reasonable delay would be.

It is toggleable by admins, and it's also automatically off on deadpop (<15 people).

Also this is not tested yet