### PR TITLE
Initialize() refactor

### DIFF
--- a/__DEFINES/global.dm
+++ b/__DEFINES/global.dm
@@ -336,8 +336,6 @@ var/list/extraMiniMaps = list()
 
 var/list/holomap_markers = list()
 
-var/holomaps_initialized = 0
-
 //Staff of change
 #define SOC_CHANGETYPE_COOLDOWN 2 MINUTES
 #define SOC_MONKEY "Primate"

--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -193,6 +193,7 @@ var/MAX_EXPLOSION_RANGE = 14
 #define	NOREACT 		16384 // Reagents don't react inside this container.
 
 #define TIMELESS		32768 // Immune to time manipulation.
+#define INITIALIZED		65536 // set by initialize()
 
 #define ALL ~0
 #define NONE 0

--- a/__DEFINES/subsystem.dm
+++ b/__DEFINES/subsystem.dm
@@ -1,6 +1,14 @@
 // Subsystem defines.
 // All in one file so it's easier to see what everything is relative to.
 
+#define INITIALIZATION_INSSATOMS     0 // New should not call Initialize
+#define INITIALIZATION_INNEW_REGULAR 1 // New should call Initialize(FALSE)
+#define INITIALIZATION_INNEW_MAPLOAD 2 // New should call Initialize(TRUE)
+
+#define INITIALIZE_HINT_NORMAL   0 // Nothing happens
+#define INITIALIZE_HINT_LATELOAD 1 // Call LateInitialize
+#define INITIALIZE_HINT_QDEL     2 // Call qdel on the atom
+
 #define SS_INIT_TICKER_SPAWN       999
 #define SS_INIT_RUST               26
 #define SS_INIT_SUPPLY_SHUTTLE     25
@@ -11,7 +19,7 @@
 #define SS_INIT_HUMANS             21
 #define SS_INIT_MAP                20
 #define SS_INIT_POWER              19
-#define SS_INIT_OBJECT             18
+#define SS_INIT_ATOMS              18
 #define SS_INIT_PIPENET            17.5
 #define SS_INIT_XENOARCH           17
 #define SS_INIT_MORE_INIT          16
@@ -53,6 +61,7 @@
 #define SS_DISPLAY_LIGHTING       -80
 #define SS_DISPLAY_MOB            -70
 #define SS_DISPLAY_FAST_OBJECTS   -65
+#define SS_DISPLAY_ATOMS          -63
 #define SS_DISPLAY_OBJECTS        -60
 #define SS_DISPLAY_MACHINERY      -50
 #define SS_DISPLAY_PIPENET        -40

--- a/code/controllers/mc/subsystem.dm
+++ b/code/controllers/mc/subsystem.dm
@@ -161,9 +161,8 @@
 
 //hook for printing stats to the "MC" statuspanel for admins to see performance and related stats etc.
 /datum/subsystem/proc/stat_entry(msg)
-	if (flags & SS_NO_FIRE)
-		// Prevent init-only subsystems from cluttering everything.
-		return
+	//if (flags & SS_NO_FIRE)
+	//	return // Prevent init-only subsystems from cluttering everything.
 
 	if(!statclick)
 		statclick = new/obj/effect/statclick/debug("Initializing...", src)

--- a/code/controllers/subsystem/atoms.dm
+++ b/code/controllers/subsystem/atoms.dm
@@ -1,0 +1,146 @@
+#define BAD_INIT_QDEL_BEFORE 1
+#define BAD_INIT_DIDNT_INIT 2
+#define BAD_INIT_SLEPT 4
+#define BAD_INIT_NO_HINT 8
+
+var/datum/subsystem/atoms/SSatoms
+
+/datum/subsystem/atoms
+	name          = "Atoms"
+	display_order = SS_DISPLAY_ATOMS
+	init_order    = SS_INIT_ATOMS
+	flags         = SS_NO_FIRE
+
+	var/old_initialized
+
+	var/list/late_loaders
+	var/list/created_atoms
+
+	var/list/BadInitializeCalls = list()
+
+/datum/subsystem/atoms/New()
+	NEW_SS_GLOBAL(SSatoms)
+
+/datum/subsystem/atoms/Initialize()
+	initialized = INITIALIZATION_INNEW_MAPLOAD
+	InitializeAtoms()
+	..()
+
+/datum/subsystem/atoms/stat_entry()
+	..("Bad initialize calls: [BadInitializeCalls.len]")
+
+/datum/subsystem/atoms/proc/InitializeAtoms(var/list/atoms)
+	if(initialized == INITIALIZATION_INSSATOMS)
+		return
+
+	initialized = INITIALIZATION_INNEW_MAPLOAD
+
+	if(!late_loaders)
+		late_loaders = list()
+
+	var/count
+	var/list/mapload_arg = list(TRUE)
+	if(atoms)
+		created_atoms = list()
+		count = atoms.len
+		for(var/I in atoms)
+			var/atom/A = I
+			if(!(A.flags & INITIALIZED))
+				if(InitAtom(I, mapload_arg))
+					atoms -= I
+				CHECK_TICK
+	else
+		count = 0
+		for(var/atom/A in world)
+			if(!(A.flags & INITIALIZED))
+				InitAtom(A, mapload_arg)
+				++count
+				CHECK_TICK
+
+	log_startup_progress("Initialized [count] atoms")
+
+	initialized = INITIALIZATION_INNEW_REGULAR
+
+	if(late_loaders.len)
+		for(var/I in late_loaders)
+			var/atom/A = I
+			A.late_initialize()
+		log_startup_progress("Late initialized [late_loaders.len] atoms")
+		late_loaders.Cut()
+
+	if(atoms)
+		. = created_atoms + atoms
+		created_atoms = null
+
+/datum/subsystem/atoms/proc/InitAtom(var/atom/A, var/list/arguments)
+	var/the_type = A.type
+	if(A.gcDestroyed)
+		BadInitializeCalls[the_type] |= BAD_INIT_QDEL_BEFORE
+		return TRUE
+
+	var/start_tick = world.time
+
+	var/result = A.initialize(arglist(arguments))
+
+	if(start_tick != world.time)
+		BadInitializeCalls[the_type] |= BAD_INIT_SLEPT
+
+	var/qdeleted = FALSE
+
+	if(result != INITIALIZE_HINT_NORMAL)
+		switch(result)
+			if(INITIALIZE_HINT_LATELOAD)
+				if(arguments[1])	//mapload
+					late_loaders += A
+				else
+					A.late_initialize()
+			if(INITIALIZE_HINT_QDEL)
+				qdel(A)
+				qdeleted = TRUE
+			else
+				BadInitializeCalls[the_type] |= BAD_INIT_NO_HINT
+
+	if(!A)	//possible harddel
+		qdeleted = TRUE
+	else if(!(A.flags & INITIALIZED))
+		BadInitializeCalls[the_type] |= BAD_INIT_DIDNT_INIT
+
+	return qdeleted || A.gcDestroyed
+
+/datum/subsystem/atoms/proc/map_loader_begin()
+	old_initialized = initialized
+	initialized = INITIALIZATION_INSSATOMS
+
+/datum/subsystem/atoms/proc/map_loader_stop()
+	initialized = old_initialized
+
+/datum/subsystem/atoms/Recover()
+	initialized = SSatoms.initialized
+	if(initialized == INITIALIZATION_INNEW_MAPLOAD)
+		InitializeAtoms()
+	old_initialized = SSatoms.old_initialized
+	BadInitializeCalls = SSatoms.BadInitializeCalls
+
+/datum/subsystem/atoms/proc/WriteInitLog()
+	. = ""
+	for(var/path in BadInitializeCalls)
+		. += "Path : [path] \n"
+		var/fails = BadInitializeCalls[path]
+		if(fails & BAD_INIT_DIDNT_INIT)
+			. += "- Didn't call atom/Initialize()\n"
+		if(fails & BAD_INIT_NO_HINT)
+			. += "- Didn't return an Initialize hint\n"
+		if(fails & BAD_INIT_QDEL_BEFORE)
+			. += "- Qdel'd in New()\n"
+		if(fails & BAD_INIT_SLEPT)
+			. += "- Slept during Initialize()\n"
+	if(.)
+		world.log << .
+
+/datum/subsystem/atoms/Shutdown()
+	WriteInitLog()
+
+#undef BAD_INIT_QDEL_BEFORE
+#undef BAD_INIT_DIDNT_INIT
+#undef BAD_INIT_SLEPT
+#undef BAD_INIT_NO_HINT

--- a/code/controllers/subsystem/objects.dm
+++ b/code/controllers/subsystem/objects.dm
@@ -5,28 +5,15 @@ var/list/processing_objects = list()
 
 /datum/subsystem/obj
 	name          = "Objects"
-	init_order    = SS_INIT_OBJECT
 	display_order = SS_DISPLAY_OBJECTS
 	priority      = SS_PRIORITY_OBJECTS
 	wait          = 2 SECONDS
-
+	flags         = SS_NO_INIT
 	var/list/currentrun
 
 
 /datum/subsystem/obj/New()
 	NEW_SS_GLOBAL(SSobj)
-
-
-/datum/subsystem/obj/Initialize()
-	for(var/atom/object in world)
-		object.initialize()
-		CHECK_TICK
-	for(var/area/place in areas)
-		var/obj/machinery/power/apc/place_apc = place.areaapc
-		if(place_apc)
-			place_apc.update()
-	..()
-
 
 /datum/subsystem/obj/stat_entry()
 	..("P:[processing_objects.len]")

--- a/code/game/machinery/station_map.dm
+++ b/code/game/machinery/station_map.dm
@@ -39,8 +39,6 @@ var/list/station_holomaps = list()
 	station_holomaps += src
 	flow_flags |= ON_BORDER
 	component_parts = 0
-	if(ticker && holomaps_initialized)
-		initialize()
 
 /obj/machinery/station_map/Destroy()
 	station_holomaps -= src
@@ -156,6 +154,8 @@ var/list/station_holomaps = list()
 	update_icon()
 
 /obj/machinery/station_map/update_icon()
+	if(!SS_READY(SSmore_init))
+		return
 	overlays.len = 0
 	if(stat & BROKEN)
 		icon_state = "station_mapb"
@@ -347,8 +347,6 @@ var/list/station_holomaps = list()
 	..()
 	holomap_datum = new /datum/station_holomap/strategic()
 	original_zLevel = map.zMainStation
-	if(ticker && holomaps_initialized)
-		initialize()
 
 /obj/machinery/station_map/strategic/initialize()
 	holomap_datum.initialize_holomap()

--- a/code/game/objects/structures/gravpult.dm
+++ b/code/game/objects/structures/gravpult.dm
@@ -32,7 +32,7 @@ var/list/gravpults = list()
 	gravpults += src
 	station_holomaps += src
 	aim -= ID*2
-	if(ticker && holomaps_initialized)
+	if(SS_READY(SSmore_init))
 		initialize_holomaps()
 
 /obj/structure/deathsquad_gravpult/Destroy()

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -411,7 +411,6 @@
 		//		zone.SetStatus(ZONE_ACTIVE)
 
 		var/turf/W = new N(src)
-		W.initialize()
 
 		if(tell_universe)
 			universe.OnTurfChange(W)

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -40,8 +40,6 @@
 
 /obj/effect/landmark/corpse/New()
 	AddToProfiler()
-	if(ticker)
-		initialize()
 
 /obj/effect/landmark/corpse/initialize()
 	var/mob/living/carbon/human/H = createCorpse()

--- a/code/modules/html_interface/map/station_map.dm
+++ b/code/modules/html_interface/map/station_map.dm
@@ -36,8 +36,6 @@
 		generateStationMinimap(map.zDerelict)
 	//If they were built on another Z-Level, they will display an error screen.
 
-	holomaps_initialized = 1
-
 	for (var/obj/machinery/station_map/S in station_holomaps)
 		S.initialize()
 

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -147,7 +147,6 @@
 
 	if(ticker && ticker.current_state == GAME_STATE_PLAYING)
 		initialize()
-		update()
 
 /obj/machinery/power/apc/proc/init()
 	has_electronics = 2 //installed and secured
@@ -172,6 +171,7 @@
 	var/area/this_area = get_area(src)
 	name = "[this_area.name] APC"
 
+	update()
 	update_icon()
 	add_self_to_holomap()
 

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -176,6 +176,7 @@
 #include "code\controllers\mc\master.dm"
 #include "code\controllers\mc\subsystem.dm"
 #include "code\controllers\subsystem\air.dm"
+#include "code\controllers\subsystem\atoms.dm"
 #include "code\controllers\subsystem\disease.dm"
 #include "code\controllers\subsystem\emergency_shuttle.dm"
 #include "code\controllers\subsystem\event.dm"


### PR DESCRIPTION
### What

- Ported SSatoms from TG: responsible for initialization of atoms
- Initialize hints: Values returned by initialize() that determine what's to be done with the atom (delete it? delayed init? nothing at all?)
- Things won't be allowed to `initialize()` more then once
- Things won't be allowed to `qdel(src)` in New() anymore. They should return the right initialize hint instead

### What's wrong
- Holomaps look weird. No biggie, and I'm not going to look into it for now.
- Here's a log generated by `WriteInitLog()` that shows what needs to be done: https://pastebin.com/rhEi2ZF4
- The dmm reader might need to be touched a bit
- I thought unsetting the `INITIALIZED` flag would stop pooled atoms from erroring ("initialized twice!") but it doesn't, not sure what I'm missing - help would be nice

This shouldn't break anything as it is.