### PR TITLE
Allows Players to See Readied High Job Prefs

### DIFF
--- a/code/defines/obj.dm
+++ b/code/defines/obj.dm
@@ -250,94 +250,14 @@ We don't care about names, DNA, accounts, activity, any of that. We're just gonn
 		crystal_ball[J] += 1
 
 /datum/controller/occupations/proc/flags_to_job(var/flags, var/department)
-	//Takes a flag and returns a job. First it tries to get it from a hardcoded list for speed, but if that doesn't work we just loop through (for forward compatibility)
-	switch(department)
-		if(CIVILIAN)
-			switch(flags)
-				if(1)
-					return "Head of Personnel" //datum/job/hop
-				if(2)
-					return "Bartender" //datum/job/bartender
-				if(4)
-					return "Botanist" //datum/job/hydro
-				if(8)
-					return "Chef" //datum/job/chef
-				if(16)
-					return "Janitor" //datum/job/janitor
-				if(32)
-					return "Librarian" //datum/job/librarian
-				if(64)
-					return "Quartermaster" //datum/job/qm
-				if(128)
-					return "Cargo Technician" //datum/job/cargo_tech
-				if(256)
-					return "Shaft Miner" //datum/job/mining
-				if(512)
-					return "Internal Affairs" //datum/job/lawyer
-				if(1024)
-					return "Chaplain" //datum/job/chaplain
-				if(2048)
-					return "Clown" //datum/job/clown
-				if(4096)
-					return "Mime" //datum/job/mime
-				if(8192)
-					return "Assistant" //datum/job/assistant
-				if(16384)
-					return "Trader" //datum/job/trader
-		if(MEDSCI)
-			switch(flags)
-				if(1)
-					return "Research Director" //datum/job/rd
-				if(2)
-					return "Scientist" //datum/job/scientist
-				if(4)
-					return "Chemist" //datum/job/chemist
-				if(8)
-					return "Chief Medical Officer" //datum/job/cmo
-				if(16)
-					return "Medical Doctor" //datum/job/doctor
-				if(32)
-					return "Geneticist" //datum/job/geneticist
-				if(64)
-					return "Virologist" //datum/job/virologist
-				if(128)
-					return "Paramedic" //datum/job/paramedic
-		if(ENGSEC)
-			switch(flags)
-				if(1)
-					return "Captain" //datum/job/captain
-				if(2)
-					return "Head of Security" //datum/job/hos
-				if(4)
-					return "Warden" //datum/job/warden
-				if(8)
-					return "Detective" //datum/job/detective
-				if(16)
-					return "Security Officer" //datum/job/officer
-				if(32)
-					return "Chief Engineer" //datum/job/chief_engineer
-				if(64)
-					return "Station Engineer" //datum/job/engineer
-				if(128)
-					return "Atmospherics Tech." //datum/job/atmos
-				if(256)
-					return "Roboticist" //datum/job/roboticist //Why is this here? Mystery
-				if(512)
-					return "A.I." //datum/job/ai
-				if(1024)
-					return "Cyborg" //datum/job/cyborg
-				if(2048)
-					return "Mobile MMI" //datum/job/mommi
-				if(4096)
-					return "Mechanic" //datum/job/mechanic
-	//Still haven't found anything? Let's try this the hard way.
 	var/list/searchable_jobs = typesof(/datum/job) - /datum/job
-	for(var/datum/job/J in searchable_jobs)
-		if(J.department_flag != department)
+	for(var/path in searchable_jobs)
+		var/datum/job/J = path
+		if(initial(J.department_flag) != department)
 			continue
-		if(J.flag != flags)
+		if(initial(J.flag) != flags)
 			continue
-		return J.title
+		return initial(J.title)
 	return null //Still nothing? Null it is
 
 /*

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -12,6 +12,9 @@ var/global/datum/controller/occupations/job_master
 		//Debug info
 	var/list/job_debug = list()
 
+	var/list/crystal_ball = list() //This should be an assoc. list. Job = # of players ready. Configured by predict_manifest() in obj.dm
+	var/list/searchable_jobs = list()
+
 
 /datum/controller/occupations/proc/SetupOccupations(var/faction = "Station")
 	occupations = list()
@@ -497,7 +500,7 @@ var/global/datum/controller/occupations/job_master
 			H.put_in_hand(GRASP_LEFT_HAND, new /obj/item/device/inhaler(H))
 		else
 			H.equip_or_collect(new /obj/item/device/inhaler(H), slot_in_backpack)
-		
+
 	return 1
 
 

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -13,7 +13,6 @@ var/global/datum/controller/occupations/job_master
 	var/list/job_debug = list()
 
 	var/list/crystal_ball = list() //This should be an assoc. list. Job = # of players ready. Configured by predict_manifest() in obj.dm
-	var/list/searchable_jobs = list()
 
 
 /datum/controller/occupations/proc/SetupOccupations(var/faction = "Station")

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -26,11 +26,11 @@
 
 	output += {"<p><a href='byond://?src=\ref[src];show_preferences=1'>Setup Character</A></p>"}
 	if(!ticker || ticker.current_state <= GAME_STATE_PREGAME)
+		output += "<a href='byond://?src=\ref[src];predict=1'>Manifest Prediction (Unreliable)</A><br>"
 		if(!ready)
 			output += "<p><a href='byond://?src=\ref[src];ready=1'>Declare Ready</A></p>"
 		else
 			output += "<p><b>You are ready</b> (<a href='byond://?src=\ref[src];ready=2'>Cancel</A>)</p>"
-
 	else
 		ready = 0 // prevent setup character issues
 		output += {"<a href='byond://?src=\ref[src];manifest=1'>View the Crew Manifest</A><br>
@@ -181,7 +181,13 @@
 				return 0
 
 		LateChoices()
+	if(href_list["predict"])
+		var/dat = {"<html><body>
+		<h4>High Job Preferences</h4>"}
+		dat += job_master.display_prediction()
 
+		src << browse(dat, "window=manifest;size=400x420;can_close=1")
+		return 1 //This lets us keep it on top
 	if(href_list["manifest"])
 		ViewManifest()
 

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -187,7 +187,7 @@
 		dat += job_master.display_prediction()
 
 		src << browse(dat, "window=manifest;size=400x420;can_close=1")
-		return 1 //This lets us keep it on top
+		return 1
 	if(href_list["manifest"])
 		ViewManifest()
 


### PR DESCRIPTION
![untitled](https://user-images.githubusercontent.com/9782036/42744278-e822d13e-8890-11e8-9132-e73dabc101f6.png)

I spoke to players and asked them what made them latejoin. For many people it was "I want to take a job that is not already filled... If I go medbay, we have no power; If I go engineer, we have no medbay". I wanted a solution that would not give a perfectly predictive manifest though. For a few reasons: with displayed player names or a complete list, it might be easy to guess when it's Nuclear Operatives or to metagrudge someone somehow.

This predictor ONLY lists the high prefs of people who are readied up. It doesn't list a name or who will get what. If you don't have a high pref you will not be tallied for the list.

Places where the system could be improved
* Make UI prettier
* Make UI appear on top instead of popping under the new player panel

🆑 
* rscadd: You can now see a count of how many players are readied up for each role.