### PR TITLE
Adds a helper macro to swap the contents of two vars

### DIFF
--- a/__DEFINES/_macros.dm
+++ b/__DEFINES/_macros.dm
@@ -283,3 +283,7 @@ proc/get_space_area()
 #define SNOW_THEME (map.snow_theme || Holiday == XMAS || Holiday == XMAS_EVE)
 
 #define get_conductivity(A) (A ? A.siemens_coefficient : 1)
+
+//Swaps the contents of the variables A and B. The if(TRUE) is there simply to restrict the scope of _.
+//Yes, _ is a shitty variable name. Hopefully so shitty it won't ever be used anywhere it could conflict with this.
+#define swap_vars(A, B) if(TRUE){var/_ = A; A = B; B = _}


### PR DESCRIPTION
Does not implement said macro anywhere.
This will be useful for something I plan to do after returning from vacation in 10 days or so, but is a separate PR for atomicity reasons.
Confirmed working with MoMMI, and confirmed not to conflict even theoretically with anything else in the codebase with regex, so I will unironically claim it's 100% tested