### PR TITLE
Makes silicons able to use emotes

### DIFF
--- a/code/modules/mob/living/silicon/emote.dm
+++ b/code/modules/mob/living/silicon/emote.dm
@@ -13,7 +13,7 @@
 	var/mob/living/silicon/robot/R = user
 	if (!istype(R))
 		return FALSE
-	if (!(R.module && (R.module.quirk_flags & module_quirk_required)))
+	if (module_quirk_required && !(R.module && (R.module.quirk_flags & module_quirk_required)))
 		return FALSE
 
 /datum/emote/silicon/can_run_emote(var/mob/user, var/status_check = TRUE)
@@ -21,7 +21,7 @@
 	var/mob/living/silicon/robot/R = user
 	if (!istype(R))
 		return FALSE
-	if (!(R.module && (R.module.quirk_flags & module_quirk_required)))
+	if (module_quirk_required && !(R.module && (R.module.quirk_flags & module_quirk_required)))
 		return FALSE
 
 /datum/emote/silicon/boop


### PR DESCRIPTION
Since the module required was null by default, it meant that you could not use emotes at all :
```dm
if (ANYTHING & 0)
```
returns always false

Closes #18867, at least partly
MoMMis should still see the /mob/living emotes such as *dance & *stare, which is not the case.
*beep is misplaced and should be moved elsewhere