### PR TITLE
More emotes fixes

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -74,6 +74,8 @@
 		if(H.wear_mask)
 			skipface |= H.check_hidden_head_flags(HIDEFACE)
 		if((slot_w_uniform in obscured) && skipface)
+			if(findtext(message, "%s"))
+				message = replacetext(message, "%s", "")
 			return message
 		else
 			switch(H.gender)
@@ -82,11 +84,19 @@
 						message = replacetext(message, "their", "his")
 					if(findtext(message, "them"))
 						message = replacetext(message, "them", "him")
+					if(findtext(message, "they"))
+						message = replacetext(message, "they", "he")
+					if(findtext(message, "%s"))
+						message = replacetext(message, "%s", "s")
 				if(FEMALE)
 					if(findtext(message, "their"))
 						message = replacetext(message, "their", "her")
 					if(findtext(message, "them"))
 						message = replacetext(message, "them", "her")
+					if(findtext(message, "they"))
+						message = replacetext(message, "they", "she")
+					if(findtext(message, "%s"))
+						message = replacetext(message, "%s", "s")
 	return message
 
 /datum/emote/proc/select_message_type(mob/user)

--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -112,7 +112,7 @@
 					playsound(src, scream, 50, 0)
 					H.last_emote_sound = world.time
 					return ..()
-				else
-					return ..()
+			else
+				return ..()
 		else
 			message = "makes a very loud noise."

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -169,10 +169,11 @@
 					to_chat(H, "<span class = 'notice'>You were interrupted and couldn't fart! Rude!</span>")
 					return
 
-		H.lastFart=world.time
+			H.lastFart=world.time
 
-		var/obj/item/weapon/storage/bible/B = locate(/obj/item/weapon/storage/bible) in H.loc
-		if(B)
+			var/obj/item/weapon/storage/bible/B = locate(/obj/item/weapon/storage/bible) in H.loc
+			if (!B)
+				return
 			if(iscult(H))
 				to_chat(H, "<span class='sinister'>Nar-Sie shields you from [B.my_rel.deity_name]'s wrath!</span>")
 			else
@@ -186,16 +187,13 @@
 					spawn(rand(10,30))
 						if(H && B)
 							H.show_message("<span class='game say'><span class='name'>[B.my_rel.deity_name]</span> says, \"Thou hast angered me, mortal!\"",2)
-
 							sleep(10)
+
 							if(H && B)
 								to_chat(H, "<span class='danger'>You were disintegrated by [B.my_rel.deity_name]'s bolt of lightning.</span>")
 								H.attack_log += text("\[[time_stamp()]\] <font color='orange'>Farted on a bible and suffered [B.my_rel.deity_name]'s wrath.</font>")
-
 								explosion(get_turf(H),-1,-1,1,5) //Tiny explosion with flash
-
 								H.dust()
-			return
 		else
 			message = "strains, and nothing happens."
 			emote_type = EMOTE_VISIBLE

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -310,7 +310,7 @@
 	key_third_person = "trembles"
 	message = "trembles in fear!"
 
-/datum/emote/living/
+/datum/emote/living/twitch
 	key = "twitch"
 	key_third_person = "twitches"
 	message = "twitches violently."

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -291,7 +291,7 @@
 /datum/emote/living/surrender
 	key = "surrender"
 	key_third_person = "surrenders"
-	message = "puts their hands on their head and falls to the ground, they surrender!"
+	message = "puts their hands on their head and falls to the ground, they surrender%s!"
 	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/surrender/run_emote(mob/user, params)
@@ -310,7 +310,7 @@
 	key_third_person = "trembles"
 	message = "trembles in fear!"
 
-/datum/emote/living/twitch
+/datum/emote/living/
 	key = "twitch"
 	key_third_person = "twitches"
 	message = "twitches violently."
@@ -342,8 +342,7 @@
 	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/custom
-	key = "me"
-	key_third_person = "custom"
+	key = "custom"
 	message = null
 
 /datum/emote/living/custom/proc/check_invalid(mob/user, input)
@@ -396,10 +395,10 @@
 /datum/emote/living/help/run_emote(mob/user, params)
 	var/list/keys = list()
 	var/list/message = list("Available emotes, you can use them with say \"*emote\": ")
-
+	
 	var/datum/emote/E
-	var/list/emote_list = E.emote_list
-	for(var/datum/emote/e in emote_list)
+
+	for(var/e in emote_list)
 		if(e in keys)
 			continue
 		E = emote_list[e]
@@ -419,10 +418,3 @@
 	message = jointext(message, "")
 
 	to_chat(user, message)
-
-/datum/emote/sound/beep
-	key = "beep"
-	key_third_person = "beeps"
-	message = "beeps."
-	message_param = "beeps at %t."
-	sound = 'sound/machines/twobeep.ogg'

--- a/code/modules/mob/living/silicon/emote.dm
+++ b/code/modules/mob/living/silicon/emote.dm
@@ -29,6 +29,14 @@
 	key_third_person = "boops"
 	message = "boops."
 
+
+/datum/emote/sound/silicon/beep
+	key = "beep"
+	key_third_person = "beeps"
+	message = "beeps."
+	message_param = "beeps at %t."
+	sound = 'sound/machines/twobeep.ogg'
+
 /datum/emote/sound/silicon/buzz
 	key = "buzz"
 	key_third_person = "buzzes"


### PR DESCRIPTION
- *help works
- A rare emote used "they" as a pronoun, it now uses your pronoun if your face is not hidden.
- Fix non-forced *scream (indent error last time meant it only worked for forced screams)
- Fixes #18874 
- Two emotes shared the same key, but one of them was never used so it went un-noticed

Thanks for your patience