### PR TITLE
Fixes grille cultify() doing both returnToPool() and qdel()

### DIFF
--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -24,7 +24,6 @@
 /obj/structure/grille/cultify()
 	new /obj/structure/grille/cult(get_turf(src))
 	returnToPool(src)
-	..()
 
 /obj/structure/grille/proc/healthcheck(var/hitsound = 0) //Note : Doubles as the destruction proc()
 	if(hitsound)


### PR DESCRIPTION
Fixes #18833

:cl:
* bugfix: Cultified grilles were turning into invisible walls after deconstruction and other weird stuff.