### PR TITLE
Radstorms cause mutations and disabilities again

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -486,4 +486,4 @@ This function restores all organs.
 	if(reagents)
 		if(reagents.has_reagent(LITHOTORCRAZINE))
 			rads = rads/2
-	..()
+	return ..()

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -113,6 +113,7 @@
 
 /mob/living/proc/apply_radiation(var/rads, var/application = RAD_EXTERNAL)
 	if(application == RAD_EXTERNAL) //Supermatter, PA particles, jukebox, transmitter
-		apply_effect(rads, IRRADIATE)
+		return apply_effect(rads, IRRADIATE)
 	if(application == RAD_INTERNAL) //
 		radiation += rads
+		return rads


### PR DESCRIPTION
https://github.com/vgstation-coders/vgstation13/blob/49df48fabc88cfc507ec99d2c0b7921e173f08c3/code/modules/events/radiation_storm.dm#L57

Currently applied_rads is useless since apply_radiation() always returns null.

:cl:
* bugfix: Radstorms cause mutations and disabilities once more.