### PR TITLE
Reasonable Radiation

### DIFF
--- a/code/modules/media/broadcast/transmitters/broadcast.dm
+++ b/code/modules/media/broadcast/transmitters/broadcast.dm
@@ -20,7 +20,7 @@
 	var/datum/wires/transmitter/wires = null
 	var/datum/power_connection/consumer/cable/power_connection = null
 
-	var/const/RADS_PER_TICK=150
+	var/const/RADS_PER_TICK=75
 	var/const/MAX_TEMP=70 // Celsius
 	machine_flags = MULTITOOL_MENU | SCREWTOGGLE | WRENCHMOVE | FIXED2WORK
 
@@ -221,8 +221,8 @@
 
 		// Radiation
 		for(var/mob/living/carbon/M in view(src,3))
-			var/rads = RADS_PER_TICK * sqrt( 1 / (get_dist(M, src) + 1) )
-			M.apply_radiation((rads*count_rad_wires()),RAD_EXTERNAL)
+			var/rads = RADS_PER_TICK * sqrt( 1 / (get_dist(M, src) + 1) ) //Distance/rads: 1 = 27, 2 = 21, 3 = 19
+			M.apply_radiation(round(rads*count_rad_wires()/2),RAD_EXTERNAL)
 
 		// Heat output
 		var/turf/simulated/L = loc

--- a/code/modules/media/jukebox.dm
+++ b/code/modules/media/jukebox.dm
@@ -493,8 +493,8 @@ var/global/list/loopModeNames=list(
 
 /obj/machinery/media/jukebox/proc/rad_pulse() //Called by pulsing the transmit wire
 	for(var/mob/living/carbon/M in view(src,3))
-		var/rads = 50 * sqrt( 1 / (get_dist(M, src) + 1) ) //It's like a transmitter, but 1/3 as powerful
-		M.apply_radiation((rads*2),RAD_EXTERNAL)
+		var/rads = 50 * sqrt( 1 / (get_dist(M, src) + 1) ) //It's like a transmitter, but 1/3 as powerful.
+		M.apply_radiation(round(rads/2),RAD_EXTERNAL) //Distance/rads: 1 = 18, 2 = 14, 3 = 12
 
 /obj/machinery/media/jukebox/Topic(href, href_list)
 	if(isobserver(usr) && !isAdminGhost(usr))

--- a/code/modules/mob/living/carbon/human/life/handle_mutations_and_radiation.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_mutations_and_radiation.dm
@@ -22,14 +22,7 @@
 		gene.OnMobLife(src)
 
 	if(radiation)
-		rad_tick++
-		//Whoever wrote those next two blocks of code obviously never heard of mathematical helpers
-		//Whoever wrote this next block needs shoved into supermatter
-		/*if(radiation > 100)
-			radiation = 100
-			Knockdown(10)
-			to_chat(src, "<span class='warning'>You feel weak.</span>")
-			emote("collapse")*/
+		rad_tick += round(radiation/50)
 
 		if(radiation < 0)
 			radiation = 0
@@ -84,13 +77,11 @@
 					rad_tick += 3
 					adjustToxLoss(3)
 					damage = 1
-					/*
-					if(prob(1))
+					/*if(prob(1))
 						to_chat(src, "<span class='warning'>You mutate!</span>")
 						randmutb(src)
 						domutcheck(src,null)
-						emote("gasp")
-					*/
+						emote("gasp")*/
 					updatehealth()
 
 			if(damage && organs.len)
@@ -98,7 +89,7 @@
 				if(istype(O))
 					O.add_autopsy_data("Radiation Poisoning", damage)
 	else
-		rad_tick = max(rad_tick-1,0)
+		rad_tick = max(rad_tick-3,0)
 
 	if(rad_tick)
 		/*

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -537,12 +537,12 @@
 	var/radiationmin = 3
 	if(src.energy > 200)
 		toxdamage = round(((src.energy-150)/50)*4,1)
-		radiation = round(((src.energy-150)/50)*5,1)
-		radiationmin = round((radiation/5),1)
+		//radiation = round(((src.energy-150)/50)*5,1)
+		//radiationmin = round((radiation/5),1)
 	for(var/mob/living/M in view(toxrange, src.loc))
 		if(M.flags & INVULNERABLE)
 			continue
-		M.apply_radiation(rand(radiationmin,radiation), RAD_EXTERNAL)
+		//M.apply_radiation(rand(radiationmin,radiation), RAD_EXTERNAL)
 		toxdamage = (toxdamage - (toxdamage*M.getarmor(null, "rad")))
 		M.apply_effect(toxdamage, TOX)
 	return

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -286,7 +286,7 @@
 			l.hallucination = max(0, min(200, l.hallucination + power * config_hallucination_power * sqrt( 1 / max(1,get_dist(l, src)) ) ) )
 
 	for(var/mob/living/l in range(src, round((power / 100) ** 0.25)))
-		var/rads = (power / 10) * sqrt(1/(max(get_dist(l, src), 1)))
+		var/rads = (power / 50) * sqrt(1/(max(get_dist(l, src), 1)))
 		l.apply_radiation(rads, RAD_EXTERNAL)
 
 	power -= (power/500)**3
@@ -380,7 +380,7 @@
 	user.drop_from_inventory(W)
 	Consume(W)
 
-	user.apply_radiation(150, RAD_EXTERNAL)
+	user.apply_radiation(50, RAD_EXTERNAL)
 
 
 /obj/machinery/power/supermatter/Bumped(atom/AM as mob|obj)
@@ -424,7 +424,7 @@
 				"<span class=\"warning\">The unearthly ringing subsides and you notice you have new radiation burns.</span>", 2)
 		else
 			l.show_message("<span class=\"warning\">You hear an uneartly ringing and notice your skin is covered in fresh radiation burns.</span>", 2)
-		var/rads = 500 * sqrt( 1 / (get_dist(l, src) + 1) )
+		var/rads = 75 * sqrt( 1 / (get_dist(l, src) + 1) )
 		l.apply_radiation(rads, RAD_EXTERNAL) // Permit blocking
 
 

--- a/maps/RandomZLevels/hive.dm
+++ b/maps/RandomZLevels/hive.dm
@@ -600,7 +600,7 @@ var/list/hive_pylons = list()
 
 		emit_radiation(radiation_range, radiation_power)
 		radiation_range = rand(10,15)
-		radiation_power = rand(10,30) * radiation_multiplier
+		radiation_power = rand(6,20) * radiation_multiplier
 
 /obj/structure/hive/pylon/proc/emit_radiation(rad_range, rad_power )
 	// Radiation


### PR DESCRIPTION
I've been talking about doing this since half a year ago, in January.

Old radiation effects gave out rads like candy because they knew it wasn't that dangerous. New radiation wanted to use smaller numbers for big effects, which was fine except that many classic objects still used OLDRAD numbers, meaning they'd completely annihilate you in seconds. Some of the numbers here are downright comical and I've applied slashing nerfs to rad output.

*However*, many things like the radgun, ebow, uranium floors, DNA injectors, nuclear mecha power upgrade, and others have remained unchanged because they are either *supposed* to be very strong (e.g.: radgun), reasonably small (uranium doors), or you have a lot of control over your interaction with the effect (DNA injector).

When you read the changelog below, keep in mind the following thresholds:
RADIATION
Minor: 1-49 (rad_tick will increase by 1 and 0.2 toxin per tick + random organ damage)
Medium: 50-74 (rad_tick will increase by 2 and 1 toxin per tick + chance to collapse + random organ damage)
Major: 75+ (rad_tick will increase by 3 and 3 toxin per tick + random organ damage)

RAD_TICK
Light: 100 - Hallucinations, vomiting
Minor: 200 - Internal bleeding
Advanced: 300 - Organ damage, brain damage, chance to become uncloneable
Critical: 400 - Clone damage, blindness, arm mutations **(players rarely reach this state without dying)**
Deadly: 500 - Body parts fall off and become meat

* rad_tick now increases at a rate of 1/2/3 based on radiation level rather than 2/3/4
* -3 rad_tick per second for having no radiation (buffed from -1)
* Radio transmitter radiation reduced by 75% down to 27/21/19 **per tick**.
* Jukebox radiation reduced by 75% to 18/14/12 **per wire pulse**.
* Singularity toxin pulse event no longer adds radiation (the singularity's pull effect still applies massive radiation per tick based on size, as high as 15-21 **per tick** while in containment and potentially 27-33 while LOOSE); Super-Singulo's insane fifteen thousand radiation pulses are untouched.
* Supermatter radiation reduced by 80%, to a minimum of 22 radiation **per tick**, maximum somewhere close to double that
* Hitting an object into the supermatter reduced by 66% to 50 per event.
* Throwing an object into the supermatter reduced by 85% to 53/43/38/34/31/28/26 per event based on distance. This should be substantially less of an instant room clear.
* Hive Pylons (away mission) reduced by about 33% to 6-20 (from 10-30) **per tick**

🆑 
* tweak: The radiation output of several high profile radiators has been lowered significantly, notably the radio transmitter, jukebox, singularity and supermatter.
* tweak: Radiation severity now increases less aggressively based on your radiation amount.
* tweak: Radiation severity level lowers more rapidly when you have no radiation at all.