### PR TITLE
Unpowered Air Alarm (De)construction Fix

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -505,7 +505,10 @@
 /obj/machinery/alarm/attack_hand(mob/user)
 	. = ..()
 
-	if (.)
+	if(wiresexposed)
+		wires.Interact(user)
+		return
+	else if (.)
 		return
 
 	interact(user)
@@ -672,9 +675,6 @@
 
 /obj/machinery/alarm/interact(mob/user)
 	if(buildstage!=2)
-		return
-	if(wiresexposed)
-		wires.Interact(user)
 		return
 	if(!shorted)
 		ui_interact(user)


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl:
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->

Fixes #18761 by moving the wire interface pop up before the power check. This allows you to construct and deconstruct an air alarm without power.