### PR TITLE
Enables pointing shortcut for robots

### DIFF
--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -19,6 +19,9 @@
 		return
 
 	var/list/modifiers = params2list(params)
+	if(modifiers["middle"] && modifiers["shift"])
+		MiddleShiftClickOn(A)
+		return
 	if(modifiers["middle"])
 		MiddleClickOn(A)
 		return


### PR DESCRIPTION
:cl:
* rscadd: Cyborgs and MoMMIs can now use the pointing shortcut (shift + middleclick).