### PR TITLE
Aghost Christmas

### DIFF
--- a/code/WorkInProgress/Mini/ATM.dm
+++ b/code/WorkInProgress/Mini/ATM.dm
@@ -129,13 +129,13 @@ log transactions
 		..()
 
 /obj/machinery/atm/attack_hand(mob/user as mob,var/fail_safe=0)
-	if(isobserver(user))
+	if(isobserver(user) && !isAdminGhost(user))
 		to_chat(user, "<span class='warning'>Your ghostly limb passes right through \the [src].</span>")
 		return
 	if(istype(user, /mob/living/silicon))
 		to_chat(user, "<span class='warning'>Artificial unit recognized. Artificial units do not currently receive monetary compensation, as per Nanotrasen regulation #1005.</span>")
 		return
-	if(get_dist(src,user) <= 1)
+	if(get_dist(src,user) <= 1 || isAdminGhost(user))
 		//check to see if the user has low security enabled
 		if(!fail_safe)
 			scan_user(user)

--- a/code/WorkInProgress/kilakk/fax.dm
+++ b/code/WorkInProgress/kilakk/fax.dm
@@ -50,10 +50,6 @@ var/list/alldepartments = list("Central Command")
 			scancount += SP.rating-1
 	cooldown_time = initial(cooldown_time) - 300*scancount
 
-/obj/machinery/faxmachine/attack_ghost(mob/user as mob)
-	to_chat(usr, "<span class='warning'>Nope.</span>")
-	return 0
-
 /obj/machinery/faxmachine/attack_ai(mob/user as mob)
 	return attack_hand(user)
 
@@ -80,7 +76,7 @@ var/list/alldepartments = list("Central Command")
 
 	dat += "<hr>"
 
-	if(authenticated)
+	if(authenticated || isAdminGhost(user))
 		dat += "<b>Logged in to:</b> Central Command Quantum Entanglement Network<br><br>"
 
 		if(tofax)

--- a/code/game/machinery/ai_slipper.dm
+++ b/code/game/machinery/ai_slipper.dm
@@ -30,7 +30,7 @@
 /obj/machinery/ai_slipper/attackby(obj/item/weapon/W, mob/user)
 	if(stat & (NOPOWER|BROKEN))
 		return
-	if(istype(user, /mob/living/silicon))
+	if(istype(user, /mob/living/silicon) || isAdminGhost(user))
 		src.add_hiddenprint(user)
 		return src.attack_hand(user)
 	else // trying to unlock the interface
@@ -58,7 +58,7 @@
 	var/area/this_area = get_area(src)
 	var/t = "<TT><B>Foam Dispenser</B> ([this_area.name])<HR>"
 
-	if(src.locked && (!istype(user, /mob/living/silicon)))
+	if(src.locked && !istype(user, /mob/living/silicon) && !isAdminGhost(user))
 		t += "<I>(Swipe ID card to unlock control panel.)</I><BR>"
 	else
 		t += text("Dispenser [src.disabled ? "unactive":"active"] - <A href='?src=\ref[src];toggleOn=1'>[src.disabled?"Enable":"Disable"]?</a><br>\n")
@@ -72,7 +72,7 @@
 	if(..())
 		return 1
 	if(src.locked)
-		if(!istype(usr, /mob/living/silicon))
+		if(!istype(usr, /mob/living/silicon) && !isAdminGhost(usr))
 			to_chat(usr, "<span class='warning'>Control panel is locked!</span>")
 			return
 	if(href_list["toggleOn"])

--- a/code/game/machinery/computer/cargo.dm
+++ b/code/game/machinery/computer/cargo.dm
@@ -15,6 +15,9 @@ For vending packs, see vending_packs.dm*/
 			return 0
 		acc_info["idname"] = usr_id.registered_name
 		acc_info["idrank"] = usr_id.GetJobName()
+	else if(isAdminGhost(user))
+		acc_info["idname"] = "Commander Green"
+		acc_info["idrank"] = "Central Commander"
 	else if(isAI(user))
 		acc_info["idname"] = user.real_name
 		acc_info["idrank"] = "AI"

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -135,7 +135,7 @@
 		src.active1 = null
 	if (!( data_core.medical.Find(src.active2) ))
 		src.active2 = null
-	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (istype(usr, /mob/living/silicon)))
+	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || isAdminGhost(usr) || (istype(usr, /mob/living/silicon)))
 		usr.set_machine(src)
 		if (href_list["temp"])
 			src.temp = null
@@ -166,6 +166,12 @@
 			src.active2 = null
 
 		else if (href_list["login"])
+			if(isAdminGhost(usr))
+				active1 = null
+				active2 = null
+				authenticated = "Commander Green"
+				rank = "Central Commander"
+				screen = 1
 
 			if (istype(usr, /mob/living/silicon/ai))
 				src.active1 = null

--- a/code/game/machinery/computer/message.dm
+++ b/code/game/machinery/computer/message.dm
@@ -82,7 +82,7 @@
 /obj/machinery/computer/message_monitor/attack_hand(var/mob/living/user as mob)
 	if(stat & (NOPOWER|BROKEN))
 		return
-	if(!istype(user))
+	if(!istype(user) && !isAdminGhost(user))
 		return
 	//If the computer is being hacked or is emagged, display the reboot message.
 	if(hacking || emagged)

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -201,7 +201,7 @@ What a mess.*/
 		active1 = null
 	if (!( data_core.security.Find(active2) ))
 		active2 = null
-	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(loc, /turf))) || (istype(usr, /mob/living/silicon)))
+	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(loc, /turf))) || isAdminGhost(usr) || (istype(usr, /mob/living/silicon)))
 		usr.set_machine(src)
 		switch(href_list["choice"])
 // SORTING!
@@ -245,6 +245,12 @@ What a mess.*/
 				active2 = null
 
 			if("Log In")
+				if(isAdminGhost(usr))
+					active1 = null
+					active2 = null
+					authenticated = "Commander Green"
+					rank = "Central Commander"
+					screen = 1
 				if (istype(usr, /mob/living/silicon))
 					active1 = null
 					active2 = null

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -201,7 +201,7 @@ var/global/list/alert_overlays_global = list()
 	return
 
 /obj/machinery/door/firedoor/attack_ai(mob/user)
-	if(isobserver(user) || user.stat)
+	if(!isAdminGhost(user) && (isobserver(user) || user.stat))
 		return
 	spawn()
 		var/area/A = get_area(src)

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -205,6 +205,9 @@
 			return 1
 		to_chat(user, "<span class='warning'>You aren't equipped to interface with technology this old!</span>")
 		return 0
+	if(isAdminGhost(user))
+		user.set_machine(src)
+		interact(user)
 
 /obj/machinery/microwave/attack_hand(mob/user as mob)
 	user.set_machine(src)
@@ -447,7 +450,7 @@
 	return ffuu
 
 /obj/machinery/microwave/CtrlClick(mob/user)
-	if(!user.incapacitated() && Adjacent(user) && user.dexterity_check() && anchored)
+	if(isAdminGhost(user) || (!user.incapacitated() && Adjacent(user) && user.dexterity_check() && anchored))
 		if(issilicon(user) && !attack_ai(user))
 			return ..()
 		cook() //Cook checks for power, brokenness, and contents internally
@@ -458,7 +461,7 @@
 	if(operating)
 		to_chat(user, "<span class='warning'>Too late, the microwave is already turned on!</span>")
 		return
-	if(!user.incapacitated() && Adjacent(user) && user.dexterity_check())
+	if(isAdminGhost(user) || (!user.incapacitated() && Adjacent(user) && user.dexterity_check()))
 		if(issilicon(user) && !attack_ai(user))
 			return ..()
 		dispose()

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -181,13 +181,12 @@ var/list/obj/machinery/requests_console/allConsoles = list()
 				dat += text("<A href='?src=\ref[src];setScreen=0'>Continue</A><BR>")
 
 			if(8)	//view messages
-				for (var/obj/machinery/requests_console/Console in allConsoles)
-					if (Console.department == department)
-						Console.newmessagepriority = 0
-						Console.icon_state = "req_comp0"
-						Console.set_light(1)
-				newmessagepriority = 0
-				icon_state = "req_comp0"
+				if(!isAdminGhost(user)) //Do not clear if admin
+					for (var/obj/machinery/requests_console/Console in allConsoles)
+						if (Console.department == department)
+							Console.newmessagepriority = 0
+							Console.icon_state = "req_comp0"
+							Console.set_light(1)
 				for(var/msg in messages)
 					dat += text("[msg]<BR>")
 				dat += text("<A href='?src=\ref[src];setScreen=0'>Back to main menu</A><BR>")

--- a/code/game/machinery/turrets.dm
+++ b/code/game/machinery/turrets.dm
@@ -383,14 +383,14 @@
 
 /obj/machinery/turretid/attack_ai(mob/user as mob)
 	src.add_hiddenprint(user)
-	if(!ailock)
+	if(!ailock || isAdminGhost(user))
 		return attack_hand(user)
 	else
 		to_chat(user, "<span class='notice'>There seems to be a firewall preventing you from accessing this device.</span>")
 
 /obj/machinery/turretid/attack_hand(mob/user as mob)
 	if ( get_dist(src, user) > 0 )
-		if ( !issilicon(user) )
+		if ( !issilicon(user) && !isAdminGhost(user))
 			to_chat(user, "<span class='notice'>You are too far away.</span>")
 			user.unset_machine()
 			user << browse(null, "window=turretid")
@@ -406,7 +406,7 @@
 	var/area/area = loc
 	var/t = "<TT><B>Turret Control Panel</B> ([area.name])<HR>"
 
-	if(src.locked && (!istype(user, /mob/living/silicon)))
+	if(!isAdminGhost(user) && src.locked && (!istype(user, /mob/living/silicon)))
 		t += "<I>(Swipe ID card to unlock control panel.)</I><BR>"
 	else
 		t += text("Turrets [] - <A href='?src=\ref[];toggleOn=1'>[]?</a><br>\n", src.enabled?"activated":"deactivated", src, src.enabled?"Disable":"Enable")
@@ -451,10 +451,10 @@
 	if(..())
 		return 1
 	if (src.locked)
-		if (!istype(usr, /mob/living/silicon))
+		if (!istype(usr, /mob/living/silicon) && !isAdminGhost(usr))
 			to_chat(usr, "Control panel is locked!")
 			return
-	if ( get_dist(src, usr) == 0 || issilicon(usr))
+	if ( get_dist(src, usr) == 0 || issilicon(usr) || isAdminGhost(usr))
 		if (href_list["toggleOn"])
 			src.enabled = !src.enabled
 			src.updateTurrets()

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -752,7 +752,7 @@ var/global/num_vending_terminals = 1
 		to_chat(user, "<span class='notice'>\The [src] is dark and unresponsive.</span>")
 		return
 
-	if(user.lying || user.incapacitated())
+	if(!isAdminGhost(usr) && (user.lying || user.incapacitated()))
 		return 0
 
 	if(M_TK in user.mutations && user.a_intent == "hurt" && iscarbon(user))
@@ -869,6 +869,8 @@ var/global/num_vending_terminals = 1
 	//testing("..(): [href]")
 
 	var/free_vend = 0
+	if(isAdminGhost(usr))
+		free_vend = 1
 	if(istype(usr,/mob/living/silicon))
 		var/can_vend = 1
 		if (href_list["vend"] && src.vend_ready && !currently_vending)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -133,10 +133,10 @@
 			return 1
 
 /obj/item/device/radio/Topic(href, href_list)
-	if (usr.stat || !on)
+	if (!isAdminGhost(usr) && (usr.stat || !on))
 		return
 
-	if (!(issilicon(usr) || (usr.contents.Find(src) || ( in_range(src, usr) && istype(loc, /turf) ))))
+	if (!isAdminGhost(usr) && (!issilicon(usr) || usr.contents.Find(src) || (in_range(src, usr) && istype(loc, /turf))))
 		usr << browse(null, "window=radio")
 		return
 	usr.set_machine(src)

--- a/code/modules/Economy/Accounts.dm
+++ b/code/modules/Economy/Accounts.dm
@@ -161,8 +161,6 @@ var/global/datum/money_account/trader_account
 	var/activated = 1
 
 	machine_flags = EMAGGABLE | WRENCHMOVE | FIXED2WORK | EJECTNOTDEL
-	ghost_read=0
-	ghost_write=0
 
 /obj/machinery/account_database/New(loc)
 	..(loc)
@@ -204,12 +202,12 @@ var/global/datum/money_account/trader_account
 	. = ..()
 	if(.)
 		return
-	if(ishuman(user) && !user.stat && get_dist(src,user) <= 1)
+	if(isAdminGhost(user) || (ishuman(user) && !user.stat && get_dist(src,user) <= 1))
 		var/dat = "<b>Accounts Database</b><br>"
 
 		dat += {"<i>[machine_id]</i><br>
 			Confirm identity: <a href='?src=\ref[src];choice=insert_card'>[held_card ? held_card : "-----"]</a><br>"}
-		if(access_level > 0)
+		if(access_level > 0 || isAdminGhost(user))
 
 			dat += {"<a href='?src=\ref[src];toggle_activated=1'>[activated ? "Disable" : "Enable"] remote access</a><br>
 				You may not edit accounts at this terminal, only create and view them.<br>"}

--- a/code/modules/Economy/utils.dm
+++ b/code/modules/Economy/utils.dm
@@ -48,7 +48,7 @@
 			if(D.remote_access_pin != attempt_pin)
 				return null
 		return D
-	else if(issilicon(src))
+	else if(issilicon(src) || isAdminGhost(src))
 		return station_account
 
 /datum/money_account/proc/fmtBalance()

--- a/code/modules/power/battery.dm
+++ b/code/modules/power/battery.dm
@@ -227,16 +227,16 @@ var/global/list/battery_online =	list(
 		if(usr.machine == src)
 			usr.unset_machine()
 		return 1
-	if (usr.stat || usr.restrained() )
+	if (!isAdminGhost(usr) && (usr.stat || usr.restrained()))
 		return
 	if (!(istype(usr, /mob/living/carbon/human) || ticker) && ticker.mode.name != "monkey")
-		if(!istype(usr, /mob/living/silicon/ai))
+		if(!istype(usr, /mob/living/silicon/ai) && !isAdminGhost(usr))
 			to_chat(usr, "<span class='warning'>You don't have the dexterity to do this!</span>")
 			return
 
 //to_chat(world, "[href] ; [href_list[href]]")
 
-	if (!isturf(src.loc) && !istype(usr, /mob/living/silicon/))
+	if (!isturf(src.loc) && !istype(usr, /mob/living/silicon/) && !isAdminGhost(usr))
 		return 0 // Do not update ui
 
 	if( href_list["cmode"] )

--- a/code/modules/research/fabricators.dm
+++ b/code/modules/research/fabricators.dm
@@ -490,7 +490,7 @@
 /obj/machinery/r_n_d/fabricator/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open=NANOUI_FOCUS)
 	if(stat & (BROKEN|NOPOWER))
 		return
-	if(user.stat || user.restrained())
+	if(!isAdminGhost(user) && (user.stat || user.restrained()))
 		return
 	if(!allowed(user) && !emagged)
 		return
@@ -630,7 +630,7 @@
 	build_part(new_design)
 
 /obj/machinery/r_n_d/fabricator/attack_hand(mob/user as mob)
-	if(user.stat || user.restrained()) //allowed is later on, so we don't check it
+	if(!isAdminGhost(user) && (user.stat || user.restrained())) //allowed is later on, so we don't check it
 		return
 
 	var/turf/exit = get_output()

--- a/code/modules/telesci/telesci_computer.dm
+++ b/code/modules/telesci/telesci_computer.dm
@@ -106,7 +106,7 @@
 /obj/machinery/computer/telescience/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = NANOUI_FOCUS)
 	if(stat & (BROKEN|NOPOWER))
 		return
-	if(user.stat || user.restrained())
+	if(!isAdminGhost(user) && (user.stat || user.restrained()))
 		return
 
 	var/list/cell_data=null


### PR DESCRIPTION
Aghosts can now interact with

- Vending machines
- Cargo console
- Telesci console
- Firelocks
- Microwave
- ATMs
- Accounts database
- Fax
- Turret Control
- Foam dispenser
- Message Monitor Console
- Fabricators
- SMES
- Intercoms
- Sec + Med Records

Additionally, viewing a request console as an aghost will **no longer clear the priority icon** so you can spy on messages without fucking with the round.

closes #17989
closes #14223

🆑 
* rscadd: Admin ghosts can now badmin a wider variety of things