### PR TITLE
Fixes silicon interaction when adjacent to airlocks (and possibly other machines)

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -270,14 +270,14 @@ var/global/list/reagents_to_log = list(FUEL, PLASMA, PACID, SACID, AMUTATIONTOXI
 					_using.Remove(M)
 					continue
 
-				if(!(M in nearby)) // NOT NEARBY
-					// AIs/Robots can do shit from afar.
-					if (isAI(M) || isrobot(M))
-						is_in_use = 1
-						src.attack_ai(M)
+				// AIs/Robots can do shit from afar.
+				if (isAI(M) || isrobot(M))
+					is_in_use = 1
+					src.attack_ai(M)
 
+				else if(!(M in nearby)) // NOT NEARBY
 					// check for TK users
-					else if(M.mutations && M.mutations.len)
+					if(M.mutations && M.mutations.len)
 						if(M_TK in M.mutations)
 							is_in_use = 1
 							src.attack_hand(M, TRUE) // The second param is to make sure brain damage on the user doesn't cause the UI to not update but the action to still happen.


### PR DESCRIPTION
Fixes #18899

:cl:
* bugfix: Fixed silicon interaction with airlocks being buggy when adjacent to them.