### PR TITLE
Standardizes toxic and chemical waste

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -4216,7 +4216,7 @@
 /datum/reagent/toxicwaste
 	name = "Toxic Waste"
 	id = TOXICWASTE
-	description = "A type of sludge created from uranium."
+	description = "A type of sludge."
 	reagent_state = LIQUID
 	color = "#6F884F" //rgb: 255,255,255 //to-do
 	density = 5.59

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -4216,7 +4216,7 @@
 /datum/reagent/toxicwaste
 	name = "Toxic Waste"
 	id = TOXICWASTE
-	description = "A type of sludge created by heating space lubricant to extreme temperatures."
+	description = "A type of sludge created from uranium."
 	reagent_state = LIQUID
 	color = "#6F884F" //rgb: 255,255,255 //to-do
 	density = 5.59

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -259,10 +259,17 @@
 	required_reagents = list(SODIUM_POLYACRYLATE = 0.3, LUBE = 1)
 	result_amount = 0.3
 
-/datum/chemical_reaction/sludge
-	name = "Sludge"
+/datum/chemical_reaction/toxic_waste
+	name = "Toxic Waste"
 	id = TOXICWASTE
 	result = TOXICWASTE
+	required_reagents = list(URANIUM = 1, SODIUMCHLORIDE = 1)
+	result_amount = 2
+
+/datum/chemical_reaction/sludge
+	name = "Sludge"
+	id = CHEMICAL_WASTE
+	result = CHEMICAL_WASTE
 	required_reagents = list(LUBE = 1)
 	result_amount = 0.2
 	required_temp = 3500
@@ -273,7 +280,7 @@
 	name = "Degrease"
 	id = "degrease"
 	result = null
-	required_reagents = list(TOXICWASTE = 1, ETHANOL = 1) //Turns out it really WAS an engine degreaser
+	required_reagents = list(CHEMICAL_WASTE = 1, ETHANOL = 1) //Turns out it really WAS an engine degreaser
 	result_amount = 0
 
 /datum/chemical_reaction/pacid

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -259,13 +259,6 @@
 	required_reagents = list(SODIUM_POLYACRYLATE = 0.3, LUBE = 1)
 	result_amount = 0.3
 
-/datum/chemical_reaction/toxic_waste
-	name = "Toxic Waste"
-	id = TOXICWASTE
-	result = TOXICWASTE
-	required_reagents = list(URANIUM = 1, SODIUMCHLORIDE = 1)
-	result_amount = 2
-
 /datum/chemical_reaction/sludge
 	name = "Sludge"
 	id = CHEMICAL_WASTE


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl:
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
Standardizes lube from the TEG to create chemical waste from toxic waste, like it does when combined with sodium polyacrylate, while making toxic waste a result from uranium salt and table salt.  This adds a ghetto chemistry way of getting EMPs while not making chocolate bars radioactive compared to my other PR.  The main issues I can see with this is that it adds a lot more possible items to get EMPs compared to my other PR, it adds a way to get EMPs, the reagents making toxic waste is somewhat stupid, and this PR not be atomic.
While I consider the refactoring of toxic and chemical waste to be related book keeping to make toxic waste a chemical reaction and the two to be related items, it may need to be split into two different PRs.
Tested and compiled locally.
EDIT: after some testing, this removes a way of getting lube by electrolyzing toxic waste (lube turns into toxic waste at a rate of 0.2 from heat) so this may also be a balance pull, which I hope is not damning.

:cl:
 * rscadd: TEG now makes chemical waste from using lube
 * rscadd: Ethanol now removes chemical waste
 * rscdel: TEG no longer makes toxic waste from using lube
 * rscdel: Ethanol no longer removes toxic waste