### PR TITLE
Fixing the Custom Strike Teams' dispensers

### DIFF
--- a/code/game/machinery/suit_dispenser.dm
+++ b/code/game/machinery/suit_dispenser.dm
@@ -207,23 +207,20 @@ var/list/dispenser_presets = list()
 						return
 					preset.name = preset_name
 					dispenser_presets[preset_name] = preset
-					one_suit = preset
-					icon_state = "suitdispenser"
-					flick("suitdispenser-fill",src)
-					one_suit.amount = promptfornum(user)
+					to_chat(user,"<span class='notice'>Preset saved!</span>")
 
 			if("Choose a Preset")
 				if (!dispenser_presets.len)
 					to_chat(user,"<span class='warning'>Error. No presets have been set. Place items on top of the dispenser to define them as presets.</span>")
 					return
-				var/datum/suit/custom/preset = input(user,"Choose a Preset.", "Suit Dispenser") in dispenser_presets
-				if (preset && !one_suit)
-					icon_state = "suitdispenser"
-					flick("suitdispenser-fill",src)
+				var/chosen = input(user,"Choose a Preset.", "Suit Dispenser") in dispenser_presets
+				var/datum/suit/custom/preset = dispenser_presets[chosen]
 				one_suit = new /datum/suit/custom
 				one_suit.name = preset.name
 				one_suit.to_spawn = preset.to_spawn
 				one_suit.amount = promptfornum(user)
+				icon_state = "suitdispenser"
+				flick("suitdispenser-fill",src)
 
 
 			if("Resupply")


### PR DESCRIPTION
* dispensers are no longer automatically loaded when making a preset
* setting a preset now properly loads the dispenser with the preset's items
* the dispenser no longer appears ready to use until the amount of items has been set