### PR TITLE
Deathgasp fix

### DIFF
--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -72,7 +72,6 @@
 		return
 	if(healths)
 		healths.icon_state = "health7"
-	stat = DEAD
 	dizziness = 0
 	remove_jitter()
 
@@ -101,7 +100,7 @@
 		emote("deathgasp") //Let the world KNOW WE ARE DEAD
 
 		update_canmove()
-
+	stat = DEAD
 	tod = worldtime2text() //Weasellos time of death patch
 	if(mind)
 		mind.store_memory("Time of death: [tod]", 0)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -2708,7 +2708,7 @@
 	if(..())
 		return 1
 
-	if(prob(5))
+	if(prob(5) && M.stat == CONSCIOUS)
 		M.emote(pick("twitch","blink_r","shiver"))
 
 /datum/reagent/hypozine //syndie hyperzine


### PR DESCRIPTION
- Deathgasp would not work because you're setting the stat to DEAD too early in the proc
- Hyperzine would spam you with emotes even though you were unconscious 