### PR TITLE
Large cardboard boxes are no longer giant

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -37,7 +37,7 @@
 	desc = "You could build a fort with this."
 	icon_state = "largebox"
 	item_state = "largebox"
-	w_class = W_CLASS_GIANT // Big, bulky.
+	w_class = W_CLASS_LARGE // Big, bulky.
 	foldable = /obj/item/stack/sheet/cardboard
 	foldable_amount = 4 // Takes 4 to make. - N3X
 	starting_materials = list(MAT_CARDBOARD = 15000)


### PR DESCRIPTION
Resolves #10170
Resolves #18935 

https://github.com/vgstation-coders/vgstation13/commit/c42fe523e09f2239721653d7837f6ff28ed29cbf#diff-fa6357609192edfbc116b0bf58878b3aR34
https://github.com/vgstation-coders/vgstation13/commit/24e1c261b907da210eb492ad254d1347b5f69111#diff-fa6357609192edfbc116b0bf58878b3aR39

Yes, you're reading that right. They originally had w_class = 42.

:cl:
* tweak: Large cardboard boxes are now simply bulky instead of huge.