### PR TITLE
Electrified airlocks don't prevent interaction with them

### DIFF
--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -46,8 +46,7 @@ var/const/AIRLOCK_WIRE_LIGHT = 2048
 	if(!istype(L, /mob/living/silicon))
 		if(A.isElectrified())
 			var/obj/I = L.get_active_hand()
-			if(A.shock(L, 100, get_conductivity(I)))
-				return 0
+			A.shock(L, 100, get_conductivity(I))
 	if(A.panel_open)
 		return 1
 	return 0

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -367,7 +367,6 @@ About the new airlock wires panel:
 			to_chat(user, "<span class='danger'>You feel a powerful shock course through your body!</span>")
 			user.halloss += 10
 			user.stunned += 10
-			return
 	..(user)
 
 /obj/machinery/door/Bumped(atom/AM)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -363,9 +363,6 @@ About the new airlock wires panel:
 					user.delayNextMove(10)
 					spawn (10)
 						src.justzap = 0
-					return
-			else /*if(src.justzap)*/
-				return
 		else if(user.hallucination > 50 && prob(10) && src.operating == 0)
 			to_chat(user, "<span class='danger'>You feel a powerful shock course through your body!</span>")
 			user.halloss += 10
@@ -1005,7 +1002,6 @@ About the new airlock wires panel:
 			// TODO: analyze the called proc
 			if (shock(user, 100))
 				user.delayNextAttack(10)
-				return
 	//Basically no open panel, not opening already, door has power, area has power, door isn't bolted
 	if (!panel_open && !operating && arePowerSystemsOn() && !(stat & (NOPOWER|BROKEN)) && !locked)
 		..(user)
@@ -1056,7 +1052,6 @@ About the new airlock wires panel:
 			// TODO: analyze the called proc
 			if (shock(user, 75, I.siemens_coefficient))
 				user.delayNextAttack(10)
-				return
 
 	if(istype(I, /obj/item/weapon/batteringram))
 		user.delayNextAttack(30)


### PR DESCRIPTION
Resolves #17267

Currently a non-silicon can't do much of anything to an electrified airlock without those yellow gloves, be it making it open or manipulating the wires. (Maybe there's more of a case to be made for keeping just the wires part but we'll see.) Electrification is a defacto bolting, plus a lockout on doing much about it against non-glove-havers (this is unless they can cut the APC power, which don't require gloves.) If this PR is merged it will be possible to take the shocks, but still use the door otherwise.

Why is this important? 
* It makes insulateds less of an all-or-nothing proposition, and the partial protection other kinds of gloves have will matter more. Although how much more will depend on how much power is in the grid. If it's in the instakill range then at the very least now there will be the possibility of somebody sacrificing themselves to open the airlock for the greater good.
* It means that a hostile silicon or saboteur will have to take the time to make use of the other wires on the door to keep non-glove-havers from doing anything.

:cl:
* tweak: Getting shocked by an electrified airlock no longer nullifies whatever action you were taking that caused you to get shocked.