### PR TITLE
You can now resist from being cuffed inside a cage

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1082,6 +1082,11 @@ Thanks.
 						BD.attack_hand(usr)
 					C.open()
 
+	// Breaking out of a cage
+	if (src.locked_to && istype(src.locked_to, /obj/structure/cage))
+		locked_to.attack_hand(src)
+		return
+
 	if(src.loc && istype(src.loc, /obj/item/mecha_parts/mecha_equipment/tool/jail))
 		var/breakout_time = 30 SECONDS
 		var/obj/item/mecha_parts/mecha_equipment/tool/jail/jailcell = src.loc


### PR DESCRIPTION
Fixes #18264 

I consider it to be bug because else, no progress bar should show up
If people really want to have their cuck cages, you should probably remove the progress bar.
You come out of the cage still cuffed, and it takes 3 minutes to break out.
![proof](https://user-images.githubusercontent.com/31417754/43130712-8ab9fdf8-8f37-11e8-8bb8-9af745983969.png)

As a comment, comparison with common methods of restraining : 
- Bucklecuff : can be resisted out of it
- Tabling : resist out of the cuffs, and has access to backpack
- Walling : ditto
- Straight-jacket : can still move around