### PR TITLE
Fixes gun suicide setting stat improperly

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -338,7 +338,6 @@
 			in_chamber.on_hit(M)
 			if (!in_chamber.nodamage)
 				user.apply_damage(in_chamber.damage*2.5, in_chamber.damage_type, LIMB_HEAD, used_weapon = "Point blank shot in the mouth with \a [in_chamber]")
-				user.stat=2 // Just to be sure
 				user.death()
 				var/suicidesound = pick('sound/misc/suicide/suicide1.ogg','sound/misc/suicide/suicide2.ogg','sound/misc/suicide/suicide3.ogg','sound/misc/suicide/suicide4.ogg','sound/misc/suicide/suicide5.ogg','sound/misc/suicide/suicide6.ogg')
 				playsound(src, pick(suicidesound), 10, channel = 125)


### PR DESCRIPTION
https://github.com/vgstation-coders/vgstation13/blob/2541ce49d0c12c47b52a43c876b57689db3eba54/code/modules/mob/living/carbon/human/death.dm#L70-L72

As you can see, death() does nothing if their stat is already DEAD. This "to be sure" line actively made death() useless. Consequently gun suicides didn't do all the death stuff they're supposed to do, such as setting the time of death, raising as zombies, deathgasping, etc.

Oh and most importantly it means it wasn't checking the win state for modes like Revs if the last head or revhead suicided by gun.