### PR TITLE
More phylactery fixes.

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -436,6 +436,9 @@
 
 	// Update on_moved listeners.
 	INVOKE_EVENT(on_moved,list("loc"=loc))
+	var/turf/T = get_turf(destination)
+	if(old_loc && T && old_loc.z != T.z)
+		INVOKE_EVENT(on_z_transition, list("user" = src, "from_z" = old_loc.z, "to_z" = T.z))
 	return 1
 
 /atom/movable/proc/update_client_hook(atom/destination)

--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -304,12 +304,14 @@
 	if(user != bound_soul)
 		unbind()
 		return
-	if(recursive_in_contents_of(user))
+	if(is_holder_of(user, src))
 		return //We're in their pocket, you ash-happy bottle of soul!
 	var/turf/T = get_turf(src)
 	if(arguments["to_z"] != T.z)
 		to_chat(user, "<span class = 'warning'><b>As you stray further and further away from \the [src], you feel your form unravel!</b></span>")
 		spawn(rand(5 SECONDS, 15 SECONDS)) //Mr. Wizman, I don't feel so good
+			if(user.gcDestroyed)
+				return
 			T = get_turf(src)
-			if(arguments["to_z"] != T.z)
+			if(user.z != T.z || is_holder_of(user, src))
 				user.dust()


### PR DESCRIPTION
forceMove now calls on_z_level_change. 

Phylactery now uses is_holder_of instead of recursive_in_contents. 

Phylactery now checks if the user was destroyed after the 15 seconds of ohfuck time when you move away from your phylactery.
