### PR TITLE
Ups the total chef, bartender, and librarian count.

### DIFF
--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -4,7 +4,7 @@
 	flag = BARTENDER
 	department_flag = CIVILIAN
 	faction = "Station"
-	total_positions = 1
+	total_positions = 3
 	spawn_positions = 1
 	supervisors = "the head of personnel"
 	selection_color = "#dddddd"
@@ -60,7 +60,7 @@
 	flag = CHEF
 	department_flag = CIVILIAN
 	faction = "Station"
-	total_positions = 1
+	total_positions = 2
 	spawn_positions = 1
 	supervisors = "the head of personnel"
 	selection_color = "#dddddd"
@@ -452,7 +452,7 @@
 	flag = LIBRARIAN
 	department_flag = CIVILIAN
 	faction = "Station"
-	total_positions = 1
+	total_positions = 3
 	spawn_positions = 1
 	supervisors = "the head of personnel"
 	selection_color = "#dddddd"


### PR DESCRIPTION
![deity idea](https://cdn.discordapp.com/attachments/239823497365422091/471654295201382400/unknown.png)

Just to test, upping the total count rather than the spawn count. This means only one of these jobs can spawn at roundstart, but more can join later in the round.