### PR TITLE
Emote Restriction Tweaks

### DIFF
--- a/code/WorkInProgress/Ported/policetape.dm
+++ b/code/WorkInProgress/Ported/policetape.dm
@@ -372,7 +372,7 @@
 				L.get_active_hand_organ().droplimb(1)
 			else
 				to_chat(L, "<span class='danger'>You cut yourself on the tape!")
-			L.emote("scream", , , 1)
+			L.emote("scream")
 			L.adjustBruteLoss(10)
 		return FALSE
 	if (!W.is_sharp() || !(W.force >= 10))

--- a/code/datums/diseases/brainrot.dm
+++ b/code/datums/diseases/brainrot.dm
@@ -29,7 +29,7 @@
 			if(prob(2))
 				affected_mob.emote("stare")
 			if(prob(2))
-				affected_mob.emote("drool")
+				affected_mob.emote("drool", null, null, TRUE)
 			if(prob(10) && affected_mob.getBrainLoss()<=98)//shouldn't retard you to death now
 				affected_mob.adjustBrainLoss(2)
 				affected_mob.updatehealth()
@@ -44,7 +44,7 @@
 			if(prob(2))
 				affected_mob.emote("stare")
 			if(prob(2))
-				affected_mob.emote("drool")
+				affected_mob.emote("drool", null, null, TRUE)
 /*			if(prob(15))
 				affected_mob.adjustToxLoss(4)
 				affected_mob.updatehealth()
@@ -61,7 +61,7 @@
 					O.show_message("[affected_mob] suddenly collapses", 1)
 				affected_mob.Paralyse(rand(5,10))
 				if(prob(1))
-					affected_mob.emote("snore")
+					affected_mob.emote("snore", null, null, TRUE)
 			if(prob(15))
 				affected_mob.stuttering += 3
 	return

--- a/code/datums/diseases/fake_gbs.dm
+++ b/code/datums/diseases/fake_gbs.dm
@@ -20,7 +20,7 @@
 			if(prob(5))
 				affected_mob.audible_cough()
 			else if(prob(5))
-				affected_mob.emote("gasp")
+				affected_mob.emote("gasp", null, null, TRUE)
 			if(prob(10))
 				to_chat(affected_mob, "<span class='warning'>You're starting to feel very weak...</span>")
 		if(4)

--- a/code/datums/diseases/gbs.dm
+++ b/code/datums/diseases/gbs.dm
@@ -24,7 +24,7 @@
 			if(prob(5))
 				affected_mob.audible_cough()
 			else if(prob(5))
-				affected_mob.emote("gasp")
+				affected_mob.emote("gasp", null, null, TRUE)
 			if(prob(10))
 				to_chat(affected_mob, "<span class='warning'>You're starting to feel very weak...</span>")
 		if(4)

--- a/code/datums/diseases/rhumba_beat.dm
+++ b/code/datums/diseases/rhumba_beat.dm
@@ -29,7 +29,7 @@
 			if(prob(5))
 				to_chat(affected_mob, "<span class='warning'>You feel the urge to dance...</span>")
 			else if(prob(5))
-				affected_mob.emote("gasp")
+				affected_mob.emote("gasp", null, null, TRUE)
 			else if(prob(10))
 				to_chat(affected_mob, "<span class='warning'>You feel the need to chick chicky boom...</span>")
 		if(4)

--- a/code/datums/diseases/rhumba_beat.dm
+++ b/code/datums/diseases/rhumba_beat.dm
@@ -36,7 +36,7 @@
 			if(affected_mob.ckey == "rosham")
 				src.cure()
 			if(prob(10))
-				affected_mob.emote("gasp")
+				affected_mob.emote("gasp", null, null, TRUE)
 				to_chat(affected_mob, "<span class='warning'>You feel a burning beat inside...</span>")
 			if(prob(20))
 				affected_mob.adjustToxLoss(5)

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -33,7 +33,7 @@
 
 /datum/emote/proc/run_emote(mob/user, params, type_override, ignore_status = FALSE)
 	. = TRUE
-	if(!can_run_emote(user) || (ignore_status && !can_run_emote(user, FALSE)))
+	if(!can_run_emote(user, !ignore_status)) // ignore_status == TRUE means that status_check should be FALSE and vise-versa
 		return FALSE
 	var/msg = select_message_type(user)
 	if(params && message_param)

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -31,9 +31,9 @@
 	if(!message_mommi)
 		message_mommi = message_robot
 
-/datum/emote/proc/run_emote(mob/user, params, type_override)
+/datum/emote/proc/run_emote(mob/user, params, type_override, ignore_status = FALSE)
 	. = TRUE
-	if(!can_run_emote(user))
+	if(!can_run_emote(user) || (ignore_status && !can_run_emote(user, FALSE)))
 		return FALSE
 	var/msg = select_message_type(user)
 	if(params && message_param)

--- a/code/datums/religions.dm
+++ b/code/datums/religions.dm
@@ -50,7 +50,7 @@
 		to_chat(preacher, "<span class='warning'>You are a heathen to this God. You feel [B.my_rel.deity_name]'s wrath strike you for this blasphemy.</span>")
 		preacher.fire_stacks += 5
 		preacher.IgniteMob()
-		preacher.emote("scream",,, 1)
+		preacher.emote("scream")
 		return FALSE
 	if (preacher != religiousLeader.current)
 		to_chat(preacher, "<span class='warning'>You fail to muster enough mental strength to begin the conversion. Only the Spiritual Guide of [name] can perfom this.</span>")

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1270,7 +1270,7 @@ About the new airlock wires panel:
 					qdel(S)
 					S = null
 
-				L.emote("scream",,, 1)
+				L.emote("scream")
 
 				if (istype(loc, /turf/simulated))
 					T.add_blood(L)

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -441,11 +441,11 @@
 			if(src.issuperUV)
 				var/burndamage = rand(28,35)
 				occupant.take_organ_damage(0,burndamage)
-				occupant.emote("scream",,, 1)
+				occupant.emote("scream", null, null, TRUE)
 			else
 				var/burndamage = rand(6,10)
 				occupant.take_organ_damage(0,burndamage)
-				occupant.emote("scream",,, 1)
+				occupant.emote("scream", null, null, TRUE)
 		if(i==3) //End of the cycle
 			if(!src.issuperUV)
 				if(helmet)

--- a/code/game/machinery/transformer.dm
+++ b/code/game/machinery/transformer.dm
@@ -73,7 +73,7 @@
 		return
 
 	playsound(src, 'sound/items/Welder.ogg', 50, 1)
-	H.emote("scream",,, 1) // It is painful
+	H.emote("scream") // It is painful
 	H.adjustBruteLoss(max(0, 80 - H.getBruteLoss())) // Hurt the human, don't try to kill them though.
 	H.handle_regular_hud_updates() // Make sure they see the pain.
 

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -340,7 +340,7 @@ steam.start() -- spawns the effect
 	R.burn_skin(0.75)
 	if (R.coughedtime != 1)
 		R.coughedtime = 1
-		R.emote("gasp")
+		R.emote("gasp", null, null, TRUE)
 		spawn (20)
 			R.coughedtime = 0
 	R.updatehealth()

--- a/code/game/objects/items/weapons/cosmetics.dm
+++ b/code/game/objects/items/weapons/cosmetics.dm
@@ -455,7 +455,7 @@
 					return
 				if (21 to 40)
 					to_chat(H, "<span class='sinister'>There's [pick("somebody","a monster","a little girl","a zombie","a ghost","a catbeast","a demon")] standing behind you!</span>")
-					H.emote("scream", auto=1)
+					H.emote("scream")
 					H.dir = turn(H.dir, 180)
 					return
 				if (41 to 50)

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -110,7 +110,7 @@
 	target.visible_message("<span class='danger'>[target] has been shocked in the chest with the [src] by [user]!</span>")
 	target.Knockdown(rand(6,12))
 	target.apply_damage(rand(30,60),BURN,LIMB_CHEST)
-	target.emote("scream",,, 1) //If we're going this route, it kinda hurts
+	target.emote("scream") //If we're going this route, it kinda hurts
 	target.updatehealth()
 	spawn() //Logging
 		user.attack_log += "\[[time_stamp()]\]<font color='red'> Shocked [target.name] ([target.ckey]) with an emagged [src.name]</font>"

--- a/code/game/objects/items/weapons/storage/bible.dm
+++ b/code/game/objects/items/weapons/storage/bible.dm
@@ -23,7 +23,7 @@
 	spawn(10) //Wait for it
 		user.fire_stacks += 5
 		user.IgniteMob()
-		user.emote("scream",,, 1)
+		user.emote("scream")
 		return FIRELOSS //Set ablaze and burned to crisps
 
 //"Special" Bible with a little gift on introduction
@@ -59,13 +59,13 @@
 			to_chat(user, "<span class='danger'>[my_rel.deity_name] channels through \the [src] and sets you ablaze for your blasphemy!</span>")
 			user.fire_stacks += 5
 			user.IgniteMob()
-			user.emote("scream",,, 1)
+			user.emote("scream")
 			M.mind.vampire.smitecounter += 50 //Once we are extinguished, we will be quite vulnerable regardless
 		else if(iscult(user)) //Cultist trying to use it
 			to_chat(user, "<span class='danger'>[my_rel.deity_name] channels through \the [src] and sets you ablaze for your blasphemy!</span>")
 			user.fire_stacks += 5
 			user.IgniteMob()
-			user.emote("scream",,, 1)
+			user.emote("scream")
 		else //Literally anyone else than a Cultist using it, at this point it's just a big book
 			..() //WHACK
 		return 1 //Non-chaplains can't use the holy book, at least not properly

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -27,7 +27,7 @@
 					return
 				if(21 to 40)
 					to_chat(H, "<span class='sinister'>There's [pick("somebody","a monster","a little girl","a zombie","a ghost","a catbeast","a demon")] standing behind you!</span>")
-					H.emote("scream",,, 1)
+					H.emote("scream")
 					H.dir = turn(H.dir, 180)
 					return
 				if(41 to 50)

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -357,7 +357,7 @@
 
 		for (var/mob/living/M in inside)
 			if (M.stat!=2)
-				M.emote("scream",,, 1)
+				M.emote("scream")
 			//Logging for this causes runtimes resulting in the cremator locking up. Commenting it out until that's figured out.
 			//M.attack_log += "\[[time_stamp()]\] Has been cremated by <b>[user]/[user.ckey]</b>" //No point in this when the mob's about to be qdeleted
 			//user.attack_log +="\[[time_stamp()]\] Cremated <b>[M]/[M.ckey]</b>"

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -1,5 +1,5 @@
 //The code execution of the emote datum is located at code/datums/emotes.dm
-/mob/proc/emote(act, m_type = null, message = null)
+/mob/proc/emote(act, m_type = null, message = null, ignore_status = FALSE)
 	act = lowertext(act)
 	var/param = message
 	var/custom_param = findtext(act, " ") // Someone was given as a parameter
@@ -12,7 +12,7 @@
 	if(!E)
 		to_chat(src, "<span class='notice'>Unusable emote '[act]'. Say *help for a list.</span>")
 		return
-	E.run_emote(src, param, m_type)
+	E.run_emote(src, param, m_type, ignore_status)
 
 /datum/emote/flip
 	key = "flip"
@@ -45,7 +45,7 @@
 			user.dir = i
 			sleep(1)
 		user.dir = prev_dir
-	
+
 /datum/emote/me
 	key = "me"
 	restraint_check = FALSE
@@ -69,7 +69,7 @@
 				O.show_message(msg, m_type)
 			if (!(user in viewers(broadcast)))
 				user.show_message(msg, emote_type)
-	
+
 	var/location = T ? "[T.x],[T.y],[T.z]" : "nullspace"
 	log_emote("[user.name]/[user.key] (@[location]): [message]")
 

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -199,7 +199,7 @@
 				for(var/datum/organ/external/arm in M.organs)
 					if(istype(arm, /datum/organ/external/r_arm) || istype(arm, /datum/organ/external/l_arm))
 						arm.droplimb(1)
-				M.emote("scream", auto=TRUE)
+				M.emote("scream")
 				visible_message("<span class='sinister'>[M] tried to [bad_behavior] [src]! [ticker.Bible_deity_name] has frowned upon the disgrace!</span>")
 				punishment = "disarmed"
 		if(M.mind.special_role == BOMBERMAN)

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -94,7 +94,12 @@
 	key_third_person = "drools"
 	message = "drools."
 	mob_type_blacklist_typelist = list(/mob/living/silicon, /mob/living/simple_animal/slime, /mob/living/carbon/brain)
-	stat_allowed = UNCONSCIOUS
+
+/datum/emote/living/drool/can_run_emote(mob/living/user, var/status_check = FALSE)
+	. = ..()
+	if(. && iscarbon(user))
+		var/mob/living/carbon/C = user
+		return !C.silent
 
 /datum/emote/living/faint
 	key = "faint"
@@ -339,12 +344,10 @@
 	key = "twitch"
 	key_third_person = "twitches"
 	message = "twitches violently."
-	stat_allowed = UNCONSCIOUS
 
 /datum/emote/living/twitch_s
 	key = "twitch_s"
 	message = "twitches."
-	stat_allowed = UNCONSCIOUS
 
 /datum/emote/living/wave
 	key = "wave"

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -95,12 +95,6 @@
 	message = "drools."
 	mob_type_blacklist_typelist = list(/mob/living/silicon, /mob/living/simple_animal/slime, /mob/living/carbon/brain)
 
-/datum/emote/living/drool/can_run_emote(mob/living/user, var/status_check = FALSE)
-	. = ..()
-	if(. && iscarbon(user))
-		var/mob/living/carbon/C = user
-		return !C.silent
-
 /datum/emote/living/faint
 	key = "faint"
 	key_third_person = "faints"

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -94,6 +94,7 @@
 	key_third_person = "drools"
 	message = "drools."
 	mob_type_blacklist_typelist = list(/mob/living/silicon, /mob/living/simple_animal/slime, /mob/living/carbon/brain)
+	stat_allowed = UNCONSCIOUS
 
 /datum/emote/living/faint
 	key = "faint"
@@ -338,10 +339,12 @@
 	key = "twitch"
 	key_third_person = "twitches"
 	message = "twitches violently."
+	stat_allowed = UNCONSCIOUS
 
 /datum/emote/living/twitch_s
 	key = "twitch_s"
 	message = "twitches."
+	stat_allowed = UNCONSCIOUS
 
 /datum/emote/living/wave
 	key = "wave"

--- a/code/modules/mob/living/simple_animal/hostile/human/cult.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/cult.dm
@@ -69,7 +69,7 @@
 		if(0) //damage
 			var/dmg = rand(10,20)
 			to_chat(L, "<span class='userdanger'>Pain surges through your body and horrible visions flash through your mind!</span>")
-			L.emote("scream", , , 1)
+			L.emote("scream")
 			L.adjustBruteLoss(dmg)
 		if(1) //deaf
 			var/mob/living/carbon/human/H = L

--- a/code/modules/mob/living/simple_animal/hostile/human/mummy.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/mummy.dm
@@ -107,7 +107,7 @@
 		if(0) //damage
 			var/dmg = rand(10,20)
 			to_chat(L, "<span class='userdanger'>Pain surges through your body!</span>")
-			L.emote("scream", , , 1)
+			L.emote("scream")
 			L.adjustBruteLoss(dmg)
 		if(1) //deaf
 			var/mob/living/carbon/human/H = L
@@ -202,7 +202,7 @@
 		if(0) //damage
 			var/dmg = rand(10,20)
 			to_chat(L, "<span class='userdanger'>You writhe in agony!</span>")
-			L.emote("scream", , , 1)
+			L.emote("scream")
 			L.adjustBruteLoss(dmg)
 		if(1) //deaf
 			var/mob/living/carbon/human/H = L

--- a/code/modules/organs/internal/lungs/lung.dm
+++ b/code/modules/organs/internal/lungs/lung.dm
@@ -26,7 +26,7 @@
 	var/exhale_moles = 0
 
 /datum/organ/internal/lungs/proc/gasp()
-	owner.emote("gasp")
+	owner.emote("gasp", null, null, TRUE)
 
 /datum/organ/internal/lungs/proc/handle_breath(var/datum/gas_mixture/breath, var/mob/living/carbon/human/H)
 

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -179,7 +179,7 @@
 				brute -= brute / 2
 
 	if(is_broken() && prob(40) && brute)
-		owner.emote("scream", , , 1) //Getting hit on broken and unsplinted limbs hurts
+		owner.emote("scream") //Getting hit on broken and unsplinted limbs hurts
 
 	if(used_weapon)
 		add_autopsy_data("[used_weapon]", brute + burn)
@@ -925,7 +925,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	"<span class='danger'>You hear a sickening crack.</span>")
 
 	if(owner.feels_pain())
-		owner.emote("scream", , , 1)
+		owner.emote("scream")
 
 	playsound(owner.loc, "fracture", 100, 1, -2)
 	status |= ORGAN_BROKEN

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -103,7 +103,7 @@
 				if(prob(50)) //50/50 of becoming unrecoverable
 					user.visible_message("<span class = 'danger'>\The [user] screams as they are consumed from within!</span>")
 					if(prob(50))
-						user.emote("scream",auto=1)
+						user.emote("scream")
 						var/matrix/M = matrix()
 						M.Scale(0)
 						animate(user, alpha = 0, transform = M, time = 3 SECONDS, easing = SINE_EASING)

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -275,7 +275,7 @@
 		return 1
 	if(prob(5))
 		M.drop_item()
-		M.emote("scream",,, 1)
+		M.emote("scream")
 		M.adjustFireLossByPart(rand(5, 10), LIMB_LEFT_HAND, src)
 		M.adjustFireLossByPart(rand(5, 10), LIMB_RIGHT_HAND, src)
 		to_chat(M, "<span class='danger'>\The [src] burns your hands!.</span>")

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -465,7 +465,7 @@
 							if(head_organ.take_damage(25, 0))
 								H.UpdateDamageIcon(1)
 							head_organ.disfigure("burn")
-							H.emote("scream", , , 1)
+							H.emote("scream")
 					else
 						M.take_organ_damage(min(15, volume * 2)) //Uses min() and volume to make sure they aren't being sprayed in trace amounts (1 unit != insta rape) -- Doohl
 			else
@@ -897,7 +897,7 @@
 				step(M, pick(cardinal))
 
 	if(prob(7))
-		M.emote(pick("twitch", "drool", "moan", "giggle"))
+		M.emote(pick("twitch", "drool", "moan", "giggle"), null, null, TRUE)
 
 /datum/reagent/holywater
 	name = "Holy Water"
@@ -974,7 +974,7 @@
 									if(head_organ.take_damage(30, 0))
 										H.UpdateDamageIcon(1)
 									head_organ.disfigure("burn")
-									H.emote("scream",,, 1)
+									H.emote("scream", TRUE)
 								else
 									to_chat(H, "<span class='warning'>A freezing liquid covers your face. Your vampiric powers protect you!</span>")
 									H.mind.vampire.smitecounter += 12 //Ditto above
@@ -1016,7 +1016,7 @@
 		return 1
 
 	if(prob(7))
-		M.emote(pick("twitch", "drool", "moan", "gasp"))
+		M.emote(pick("twitch", "drool", "moan", "gasp"), null, null, TRUE)
 
 	M.druggy = max(M.druggy, 50)
 
@@ -1119,7 +1119,7 @@
 		step(M, pick(cardinal))
 
 	if(prob(5))
-		M.emote(pick("twitch","drool","moan"))
+		M.emote(pick("twitch","drool","moan"), null, null, TRUE)
 
 	M.adjustBrainLoss(2)
 
@@ -1247,7 +1247,7 @@
 	if(M.canmove && !M.restrained() && istype(M.loc, /turf/space))
 		step(M, pick(cardinal))
 	if(prob(5))
-		M.emote(pick("twitch","drool","moan"))
+		M.emote(pick("twitch","drool","moan"), null, null, TRUE)
 
 /datum/reagent/sugar
 	name = "Sugar"
@@ -1398,7 +1398,7 @@
 					if(head_organ.take_damage(25, 0))
 						H.UpdateDamageIcon(1)
 					head_organ.disfigure("burn")
-					H.emote("scream", , , 1)
+					H.emote("scream", TRUE)
 			else
 				M.take_organ_damage(min(15, volume * 2)) //uses min() and volume to make sure they aren't being sprayed in trace amounts (1 unit != insta rape) -- Doohl
 	else
@@ -1475,7 +1475,7 @@
 				var/datum/organ/external/head/head_organ = H.get_organ(LIMB_HEAD)
 				if(head_organ.take_damage(15, 0))
 					H.UpdateDamageIcon(1)
-				H.emote("scream", , , 1)
+				H.emote("scream", TRUE)
 
 		else if(ismonkey(M))
 			var/mob/living/carbon/monkey/MK = M
@@ -1498,7 +1498,7 @@
 				var/datum/organ/external/head/head_organ = H.get_organ(LIMB_HEAD)
 				if(head_organ.take_damage(15, 0))
 					H.UpdateDamageIcon(1)
-				H.emote("scream", , , 1)
+				H.emote("scream", TRUE)
 				head_organ.disfigure("burn")
 			else
 				M.take_organ_damage(min(15, volume * 4))
@@ -2088,7 +2088,7 @@
 				to_chat(H,"<span class='warning'>Your [eyes_covered] protects your eyes from the bleach!</span>")
 				return
 			else //This stuff is a little more corrosive but less irritative than pepperspray
-				H.emote("scream", , , 1)
+				H.emote("scream", TRUE)
 				to_chat(H,"<span class='danger'>You are sprayed directly in the eyes with bleach!</span>")
 				H.eye_blurry = max(M.eye_blurry, 15)
 				H.eye_blind = max(M.eye_blind, 5)
@@ -2301,7 +2301,7 @@
 		M.take_organ_damage(REM, 0, ignore_inorganics = TRUE)
 	M.adjustOxyLoss(3)
 	if(prob(20))
-		M.emote("gasp")
+		M.emote("gasp", TRUE)
 
 /datum/reagent/kelotane
 	name = "Kelotane"
@@ -2514,7 +2514,7 @@
 	if(prob(50))
 		M.drowsyness = max(M.drowsyness, 3)
 	if(prob(10))
-		M.emote("drool")
+		M.emote("drool", TRUE)
 
 /datum/reagent/hyronalin
 	name = "Hyronalin"
@@ -3607,11 +3607,11 @@
 				return
 			else if(eyes_covered) //Eye cover is better than mouth cover
 				H << "<span class='warning'>Your [eyes_covered] protects your eyes from the pepperspray!</span>"
-				H.emote("scream", , , 1)
+				H.emote("scream")
 				H.eye_blurry = max(M.eye_blurry, 5)
 				return
 			else //Oh dear
-				H.emote("scream", , , 1)
+				H.emote("scream")
 				H << "<span class='danger'>You are sprayed directly in the eyes with pepperspray!</span>"
 				H.eye_blurry = max(M.eye_blurry, 25)
 				H.eye_blind = max(M.eye_blind, 10)
@@ -6486,7 +6486,7 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 		if(M_ASTHMA in H.mutations)
 			H.adjustOxyLoss(2)
 			if(prob(30))
-				H.emote("gasp")
+				H.emote("gasp", null, null, TRUE)
 
 /datum/reagent/albuterol
 	name = "Albuterol"

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -974,7 +974,7 @@
 									if(head_organ.take_damage(30, 0))
 										H.UpdateDamageIcon(1)
 									head_organ.disfigure("burn")
-									H.emote("scream", TRUE)
+									H.emote("scream")
 								else
 									to_chat(H, "<span class='warning'>A freezing liquid covers your face. Your vampiric powers protect you!</span>")
 									H.mind.vampire.smitecounter += 12 //Ditto above
@@ -1398,7 +1398,7 @@
 					if(head_organ.take_damage(25, 0))
 						H.UpdateDamageIcon(1)
 					head_organ.disfigure("burn")
-					H.emote("scream", TRUE)
+					H.emote("scream")
 			else
 				M.take_organ_damage(min(15, volume * 2)) //uses min() and volume to make sure they aren't being sprayed in trace amounts (1 unit != insta rape) -- Doohl
 	else
@@ -1475,7 +1475,7 @@
 				var/datum/organ/external/head/head_organ = H.get_organ(LIMB_HEAD)
 				if(head_organ.take_damage(15, 0))
 					H.UpdateDamageIcon(1)
-				H.emote("scream", TRUE)
+				H.emote("scream")
 
 		else if(ismonkey(M))
 			var/mob/living/carbon/monkey/MK = M
@@ -1498,7 +1498,7 @@
 				var/datum/organ/external/head/head_organ = H.get_organ(LIMB_HEAD)
 				if(head_organ.take_damage(15, 0))
 					H.UpdateDamageIcon(1)
-				H.emote("scream", TRUE)
+				H.emote("scream")
 				head_organ.disfigure("burn")
 			else
 				M.take_organ_damage(min(15, volume * 4))
@@ -2088,7 +2088,7 @@
 				to_chat(H,"<span class='warning'>Your [eyes_covered] protects your eyes from the bleach!</span>")
 				return
 			else //This stuff is a little more corrosive but less irritative than pepperspray
-				H.emote("scream", TRUE)
+				H.emote("scream")
 				to_chat(H,"<span class='danger'>You are sprayed directly in the eyes with bleach!</span>")
 				H.eye_blurry = max(M.eye_blurry, 15)
 				H.eye_blind = max(M.eye_blind, 5)
@@ -2301,7 +2301,7 @@
 		M.take_organ_damage(REM, 0, ignore_inorganics = TRUE)
 	M.adjustOxyLoss(3)
 	if(prob(20))
-		M.emote("gasp", TRUE)
+		M.emote("gasp", null, null, TRUE)
 
 /datum/reagent/kelotane
 	name = "Kelotane"
@@ -2514,7 +2514,7 @@
 	if(prob(50))
 		M.drowsyness = max(M.drowsyness, 3)
 	if(prob(10))
-		M.emote("drool", TRUE)
+		M.emote("drool", null, null, TRUE)
 
 /datum/reagent/hyronalin
 	name = "Hyronalin"

--- a/code/modules/surgery/genderchange.dm
+++ b/code/modules/surgery/genderchange.dm
@@ -78,7 +78,7 @@
 	//H.gender_ambiguous = 1
 	user.visible_message("<span class='warning'>[user] mutilates [target]'s genitals beyond recognition!</span>")
 	target.apply_damage(50, BRUTE, LIMB_GROIN, 1)
-	target.emote("scream", , , 1)
+	target.emote("scream")
 	target.setGender(pick(MALE, FEMALE))
 	target.regenerate_icons()
 	return 1

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -135,7 +135,7 @@ proc/do_surgery(mob/living/M, mob/living/user, obj/item/tool)
 				else
 					if(sleep_fail)
 						to_chat(user, "<span class='warning'>The patient is squirming around in pain!</span>")
-						M.emote("scream",,, 1)
+						M.emote("scream")
 					M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has had surgery [S.type] with \the [tool] failed by [user.name] ([user.ckey])</font>")
 					user.attack_log += text("\[[time_stamp()]\] <font color='red'>Failed surgery [S.type] with \the [tool] on [M.name] ([M.ckey])</font>")
 					log_attack("<font color='red'>[user.name] ([user.ckey]) used \the [tool] to fail the surgery type [S.type] on [M.name] ([M.ckey])</font>")

--- a/code/modules/virus2/effect/effect.dm
+++ b/code/modules/virus2/effect/effect.dm
@@ -218,7 +218,7 @@
 	stage = 2
 
 /datum/disease2/effect/scream/activate(var/mob/living/carbon/mob)
-	mob.emote("scream",,, 1)
+	mob.emote("scream")
 
 
 /datum/disease2/effect/drowsness


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl:
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
Creates a new optional argument in the emote() and run_emote() proc called ignore_status. By default it is FALSE.

emote():

https://github.com/flagzzzz/vgstation13/blob/a5a6e760daf1da4e904e343b2db77d51c8e819e9/code/modules/mob/emote.dm#L2-L15

run_emote():

https://github.com/flagzzzz/vgstation13/blob/a5a6e760daf1da4e904e343b2db77d51c8e819e9/code/datums/emotes.dm#L34-L38

If it is ignore_status == TRUE, run_emote() will call can_run_emote(..., FALSE) instead of can_run_emote(...) whereby it ignores status effects.

An example of this can be seen in the Chemistry-Reagants.dm for space_drugs:

https://github.com/flagzzzz/vgstation13/blob/a5a6e760daf1da4e904e343b2db77d51c8e819e9/code/modules/reagents/Chemistry-Reagents.dm#L900

This ensures that the emotes will fire even if the mob in unconscious, fixing #18959. I've went ahead and updated Chemistry-Reagents with the new emote() proc (there were some .emote("scream",,, 1) from before but I have no clue why they were like that so I removed them so they read .emote("scream")). Not every emote() was updated, only the ones that could feasibly happen while you are unconscious. If this implementation is satisfactory, I can try to update every emote().