### PR TITLE
take_overall_damage() now returns the amount of damage taken

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -248,7 +248,10 @@ In most cases it makes more sense to use apply_damage() instead! And make sure t
 		brute = brute*species.brute_mod
 
 	if(status_flags & GODMODE)
-		return	//godmode
+		return 0	//godmode
+
+	. = brute + burn
+
 	var/list/datum/organ/external/parts = get_damageable_organs()
 	var/update = 0
 	while(parts.len && (brute>0 || burn>0) )
@@ -266,7 +269,6 @@ In most cases it makes more sense to use apply_damage() instead! And make sure t
 	hud_updateflag |= 1 << HEALTH_HUD
 	if(update)
 		UpdateDamageIcon()
-
 
 ////////////////////////////////////////////
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -509,6 +509,9 @@
 	adjustFireLoss(burn)
 	src.updatehealth()
 
+	return brute + burn
+
+
 /mob/living/proc/restore_all_organs()
 	return
 

--- a/code/modules/mob/living/silicon/robot/robot_damage.dm
+++ b/code/modules/mob/living/silicon/robot/robot_damage.dm
@@ -139,6 +139,8 @@
 			burn -= absorb_burn
 			to_chat(src, "<span class='warning'>Your shield absorbs some of the impact!</span>")
 
+	. = brute + burn
+
 	var/datum/robot_component/armour/A = get_armour()
 	if(A)
 		A.take_damage(brute,burn,sharp)


### PR DESCRIPTION
Resolves #17969

Only implication of this I know of:

https://github.com/vgstation-coders/vgstation13/blob/f7a62386921f9b39e7f9b896f41841587b629715/code/modules/mob/living/carbon/carbon.dm#L114-L115

Currently this statement can never be true, since the proc always returns null. Meaning that you get shocked and stunned even if it would do zero damage. Grilles with wires under them shock even if they're not connected to anything (for zero damage). Using an item with a siemens_coefficient of 0 on a machine that's electrified shocks you. Only reason hitting an electrified grille with a glass shard doesn't shock you is due to the INSULATED_EDGE flag which I'm not sure needs to exist after this.

:cl:
* bugfix: You no longer get shocked by the powergrid if it would inflict zero damage. (Note: This doesn't apply to slimepeople healing. That will be done separately.)