### PR TITLE
remove_reagents() no longer ignores reagents in volumes less than the amount to be removed

### DIFF
--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -607,7 +607,7 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 		return 1
 
 	for(var/id in reagent_list)
-		if(has_reagent(id, amount))
+		if(has_reagent(id))
 			remove_reagent(id, amount, safety)
 	return 1
 


### PR DESCRIPTION
This proc is only used for one thing and that's anti-toxin.

:cl:
* bugfix: Anti-toxin no longer stops removing certain toxic reagents when they're under a certain threshold.