### PR TITLE
Advanced lungs adjust their settings when inserted like they're supposed to

### DIFF
--- a/code/modules/organs/internal/lungs/filter.dm
+++ b/code/modules/organs/internal/lungs/filter.dm
@@ -30,7 +30,7 @@
 /datum/organ/internal/lungs/filter/CanInsert(var/mob/living/carbon/human/H, var/mob/surgeon=null, var/quiet=0)
 	if(!(H.species.breath_type in intake_settings))
 		if(surgeon)
-			surgeon << "<span class='warning'>You read the compatibility list on the back of the lung and find that it won't work on this species.</span>"
+			to_chat(surgeon, "<span class='warning'>You read the compatibility list on the back of the lung and find that it won't work on this species.</span>")
 		return 0
 	return 1
 

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -469,6 +469,9 @@
 		else
 			to_chat(user, "<span class='warning'>\The [O.organ_tag] [o_do] normally go in \the [affected.display_name].</span>")
 			return 0
+
+		if(!O.organ_data.CanInsert(target, user))
+			return 0
 	else
 		to_chat(user, "<span class='warning'>\A [target.species.name] doesn't normally have [o_a][O.organ_tag].</span>")
 		return 0
@@ -509,6 +512,7 @@
 		affected.internal_organs |= O.organ_data
 		target.internal_organs_by_name[O.organ_tag] = O.organ_data
 		O.organ_data.status |= ORGAN_CUT_AWAY
+		O.organ_data.Insert(target, user)
 		O.replaced(target)
 	var/datum/organ/internal/I = target.internal_organs_by_name[O.organ_tag]
 	I.removed_type = O


### PR DESCRIPTION
Resolves #14766
Resolves part of #18499
:cl:
* bugfix: Fixed advanced lungs not setting up properly when inserted, which resulted in buggy behavior.