### PR TITLE
Fixes being able to open the ui of unpowered or open air alarms

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -676,7 +676,7 @@
 /obj/machinery/alarm/interact(mob/user)
 	if(buildstage!=2)
 		return
-	if(!shorted)
+	if(!shorted && !(stat & (NOPOWER|BROKEN)))
 		ui_interact(user)
 
 /obj/machinery/alarm/Topic(href, href_list)


### PR DESCRIPTION
It didn't let you change anything, but it shouldn't be showing up at all, or popping up while you're pulsing wires.

:cl:
* bugfix: Fixed being able to open the interface of unpowered or open air alarms.