### PR TITLE
Increased regular bruise packs' chance of succeeding surgery

### DIFF
--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -58,8 +58,8 @@
 /datum/surgery_step/internal/fix_organ
 	allowed_tools = list(
 		/obj/item/stack/medical/advanced/bruise_pack= 100,
-		/obj/item/stack/medical/bruise_pack = 50,
-		/obj/item/stack/medical/bruise_pack/tajaran = 75,
+		/obj/item/stack/medical/bruise_pack = 75,
+		/obj/item/stack/medical/bruise_pack/tajaran = 100,
 		)
 
 	min_duration = 70


### PR DESCRIPTION
Performing surgery to fix internal organs using a common roll of gauze used to have 50% chance of succeeding. Increased that to 75%.
A more advanced type of gauze (afaik only obtainable by growing seeds that are themselves only obtainable by ordering a cargo "exotic seeds crate" (the contents of which are random)) used to have 75% chance of succeeding. Increased that to 100%.

:cl:
 * tweak: Increased the chance of succeeding organ repair surgery with rolls of gauze.