### PR TITLE
Removes a big unintended buff to rad_tick

### DIFF
--- a/code/modules/mob/living/carbon/human/life/handle_mutations_and_radiation.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_mutations_and_radiation.dm
@@ -22,8 +22,6 @@
 		gene.OnMobLife(src)
 
 	if(radiation)
-		rad_tick += round(radiation/50)
-
 		if(radiation < 0)
 			radiation = 0
 


### PR DESCRIPTION
Looking at the description of #18881, it doesn't seem like this line was supposed to be here. Removing it makes the following accurate:

>rad_tick now increases at a rate of 1/2/3 based on radiation level rather than 2/3/4

:cl:
* bugfix: Fixed radiation sickness progressing much faster than intended.