### PR TITLE
Fixed pooling bug (Now with 100% less lag)

### DIFF
--- a/code/__HELPERS/datumpool.dm
+++ b/code/__HELPERS/datumpool.dm
@@ -80,7 +80,7 @@
 		to_chat(world, text("DEBUG_DATUM_POOL: returnToPool([]) exceeds [] discarding...", D.type, MAINTAINING_OBJECT_POOL_COUNT))
 		#endif
 
-		qdel(D)
+		qdel(D, TRUE)
 		return
 
 	if(isnull(masterdatumPool[D.type]))

--- a/code/controllers/garbage.dm
+++ b/code/controllers/garbage.dm
@@ -145,7 +145,7 @@ world/loop_checks = 0
 		return
 
 	//We are object pooling this.
-	if(("[D.type]" in masterdatumPool) && !ignore_pooling)
+	if((D.type in masterdatumPool) && !ignore_pooling)
 		returnToPool(D)
 		return
 


### PR DESCRIPTION
#18994 but without killing the server
basically once you had more than 500 datums in a pool and tried to pool another one it would just qdel it, but it didn't pass the parameter to tell qdel to ignore attempting to pool. Infinite loop.

tested to the best of my abilities