### PR TITLE
Disarm now ignores armour

### DIFF
--- a/code/modules/mob/living/carbon/human/combat.dm
+++ b/code/modules/mob/living/carbon/human/combat.dm
@@ -47,7 +47,6 @@
 	if(target.disarmed_by(src))
 		return
 
-	var/datum/organ/external/affecting = get_organ(ran_zone(zone_sel.selecting))
 	if(prob(40)) //40% miss chance
 		playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
 		visible_message("<span class='danger'>[src] has attempted to disarm [target]!</span>")
@@ -56,7 +55,7 @@
 	do_attack_animation(target, src)
 
 	if(prob(40)) //True chance of something happening per click is hit_chance*event_chance, so in this case the stun chance is actually 0.6*0.4=24%
-		target.apply_effect(4, WEAKEN, target.run_armor_check(affecting, "melee"))
+		target.apply_effect(4, WEAKEN)
 		playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 		visible_message("<span class='danger'>[src] has pushed [target]!</span>")
 		add_logs(src, target, "pushed", admin = (src.ckey && target.ckey) ? TRUE : FALSE) //Only add this to the server logs if both mobs were controlled by player


### PR DESCRIPTION
I personally found it funny that a greyshirt with nothing but his able hands was able to disarm-bully a nuke ops or a secman.
The rather high armour stats those have, combined to the fix of #18864, made disarm much less funny against those.
This reestablishes it, without it being a bug/oversight.

:cl:
- tweak: Melee resist no longer count against disarm/push chance.