### PR TITLE
Xenos disarms actually take the target's armour into account

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/combat.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/combat.dm
@@ -6,7 +6,7 @@
 	if(prob(80/(disarm_chance_modifier == 0 ? 1 : disarm_chance_modifier)))
 		do_attack_animation(target, src)
 		playsound(loc, 'sound/weapons/pierce.ogg', 25, 1, -1)
-		target.apply_effect(4, WEAKEN, run_armor_check(affecting, "melee"))
+		target.apply_effect(4, WEAKEN, target.run_armor_check(affecting, "melee"))
 		visible_message("<span class='danger'>[src] has tackled down [target]!</span>")
 
 	else if (prob(80/(disarm_chance_modifier == 0 ? 1 : disarm_chance_modifier)))


### PR DESCRIPTION
Like #18864 fixing #18861 but for xenos

:cl:
- bugfix: Xeno disarms now actually take the target's armour into account