### PR TITLE
Mimes stay mimes after cloning

### DIFF
--- a/__DEFINES/_macros.dm
+++ b/__DEFINES/_macros.dm
@@ -198,7 +198,7 @@
 
 #define isfloor(A) (istype(A, /turf/simulated/floor) || istype(A, /turf/unsimulated/floor) || istype(A, /turf/simulated/shuttle/floor))
 
-#define issilent(A) (A.silent || (ishuman(A) && (A:miming || A:species:flags & IS_SPECIES_MUTE))) //Remember that silent is not the same as miming. Miming you can emote, silent you can't gesticulate at all
+#define issilent(A) (A.silent || (ishuman(A) && (A:mind.miming || A:species:flags & IS_SPECIES_MUTE))) //Remember that silent is not the same as miming. Miming you can emote, silent you can't gesticulate at all
 //Macros for antags
 
 #define isvampire(H) ((H.mind in ticker.mode.vampires) || H.mind && H.mind.vampire)

--- a/__DEFINES/human.dm
+++ b/__DEFINES/human.dm
@@ -1,3 +1,6 @@
 // Amount of nutrition at which point overeatduration starts to tick up.
 // AKA from this point on you get fat.
 #define OVEREAT_THRESHOLD 450
+
+#define MIMING_OUT_OF_CHOICE 1
+#define MIMING_OUT_OF_CURSE  2

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -114,7 +114,7 @@
 	. = message
 	if(!muzzle_ignore && user.is_muzzled() && emote_type == EMOTE_AUDIBLE)
 		return "makes a [pick("strong ", "weak ", "")]noise."
-	if(user.mind && ishuman(user) && user:miming && message_mime)
+	if(user.mind && ishuman(user) && user.mind.miming && message_mime)
 		. = message_mime
 	if(isalienadult(user) && message_alien)
 		. = message_alien

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -73,7 +73,7 @@
 	var/list/heard_before = list()
 
 	var/nospells = 0 //Can't cast spells.
-
+	var/miming = null //Toggle for the mime's abilities.
 
 /datum/mind/New(var/key)
 	src.key = key

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -373,7 +373,7 @@
 			H.equip_or_collect(new /obj/item/weapon/reagent_containers/food/drinks/bottle/bottleofnothing(H), slot_in_backpack)
 		H.add_spell(new /spell/aoe_turf/conjure/forcewall/mime, "grey_spell_ready")
 		H.add_spell(new /spell/targeted/oathbreak/)
-		H.miming = 1
+		H.mind.miming = MIMING_OUT_OF_CHOICE
 		H.rename_self("mime")
 		return 1
 
@@ -397,7 +397,7 @@
 		var/response = alert(M, "Are you -sure- you want to break your oath of silence?\n(This removes your ability to create invisible walls and cannot be undone!)","Are you sure you want to break your oath?","Yes","No")
 		if(response != "Yes")
 			return
-		M.miming=0
+		M.mind.miming=0
 		for(var/spell/aoe_turf/conjure/forcewall/mime/spell in M.spell_list)
 			M.remove_spell(spell)
 		for(var/spell/targeted/oathbreak/spell in M.spell_list)

--- a/code/modules/medical/cloning.dm
+++ b/code/modules/medical/cloning.dm
@@ -282,6 +282,11 @@
 
 	// -- End mode specific stuff
 
+	if (H.mind.miming)
+		H.add_spell(new /spell/aoe_turf/conjure/forcewall/mime, "grey_spell_ready")
+		if (H.mind.miming == MIMING_OUT_OF_CHOICE)
+			H.add_spell(new /spell/targeted/oathbreak/)
+
 	H.UpdateAppearance()
 	H.set_species(R.dna.species)
 	randmutb(H) // sometimes the clones come out wrong.

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -78,7 +78,7 @@
 		if(world.time-H.lastFart >= 400)
 			for(var/mob/living/M in view(0))
 				if(M != H && M.loc == H.loc)
-					if(!H.miming)
+					if(!H.mind.miming)
 						H.visible_message("<span class = 'warning'><b>[H]</b> farts in <b>[M]</b>'s face!</span>")
 					else
 						H.visible_message("<span class = 'warning'><b>[H]</b> silently farts in <b>[M]</b>'s face!</span>")
@@ -92,12 +92,12 @@
 				"farts [pick("lightly", "tenderly", "softly", "with care")]",
 			)
 
-			if(H.miming)
+			if(H.mind.miming)
 				farts = list("silently farts.", "acts out a fart.", "lets out a silent fart.")
 
 			var/fart = pick(farts)
 
-			if(!H.miming)
+			if(!H.mind.miming)
 				message = "<b>[H]</b> [fart]."
 				if(H.mind && H.mind.assigned_role == "Clown")
 					playsound(H, pick('sound/items/bikehorn.ogg','sound/items/AirHorn.ogg'), 50, 1)

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -60,7 +60,6 @@
 	var/icon/stand_icon = null
 	var/icon/lying_icon = null
 
-	var/miming = null //Toggle for the mime's abilities.
 	var/special_voice = "" // For changing our voice. Used by a symptom.
 	var/said_last_words=0
 

--- a/code/modules/spells/targeted/equip/frenchcurse.dm
+++ b/code/modules/spells/targeted/equip/frenchcurse.dm
@@ -28,7 +28,7 @@
 	..()
 	for(var/mob/living/carbon/human/target in targets)
 		target.flash_eyes(visual = 1)
-		target.miming = 1
+		target.mind.miming = MIMING_OUT_OF_CURSE
 		var/spell = /spell/aoe_turf/conjure/forcewall/mime
 		if(!(locate(spell) in target.spell_list))
 			target.add_spell(new /spell/aoe_turf/conjure/forcewall/mime)//They can't even acid the mime mask off, if they're going to be permanently muted they may as well get the benefits of the mime. Also they can't oathbreak.


### PR DESCRIPTION
This moves miming from the torso to the mind.
Two things : 
- Encourages cloning Mimes as there is no less consequences of doing so
- French curse becomes much more difficult to remove

Tested to the best of my ability, I emoted things Mimes emote differently (worked), I tried to talk (silent), used both spells, and when I cloned myself I stayed a Mime.
Proof : 
![proof](https://user-images.githubusercontent.com/31417754/43361126-7873f8ae-92c7-11e8-84f7-cd7a616c0332.png)

:cl:
- tweak: Mimes stay mimes after being cloned.