### PR TITLE
Mech recharge speed increase and upgrade bugfix

### DIFF
--- a/code/game/mecha/mech_bay.dm
+++ b/code/game/mecha/mech_bay.dm
@@ -105,7 +105,7 @@
 	for(var/obj/item/weapon/stock_parts/SP in component_parts)
 		if(istype(SP, /obj/item/weapon/stock_parts/micro_laser))
 			lasercount += SP.rating-1
-	set_voltage(45+lasercount*10)
+	set_voltage(450+lasercount*100)
 
 /obj/machinery/mech_bay_recharge_port/proc/start_charge(var/obj/mecha/recharging_mecha)
 	if(stat&(NOPOWER|BROKEN))
@@ -150,7 +150,7 @@
 
 /datum/global_iterator/mech_bay_recharger
 	delay = 20
-	var/max_charge = 45
+	var/max_charge = 450
 	check_for_null = 0 //since port.stop_charge() must be called. The checks are made in process()
 
 /datum/global_iterator/mech_bay_recharger/process(var/obj/machinery/mech_bay_recharge_port/port, var/obj/mecha/mecha)
@@ -194,7 +194,6 @@
 	if(recharge_port && autostart)
 		var/answer = recharge_port.start_charge(mecha)
 		if(answer)
-			recharge_port.set_voltage(voltage)
 			src.icon_state = initial(src.icon_state)+"_on"
 	return
 
@@ -251,15 +250,4 @@
 	output += "</ body></html>"
 	user << browse(output, "window=mech_bay_console")
 	onclose(user, "mech_bay_console")
-	return
-
-
-/obj/machinery/computer/mech_bay_power_console/Topic(href, href_list)
-	if(href_list["autostart"])
-		autostart = !autostart
-	if(href_list["voltage"])
-		voltage = text2num(href_list["voltage"])
-		if(recharge_port)
-			recharge_port.set_voltage(voltage)
-	updateUsrDialog()
 	return


### PR DESCRIPTION
The mech recharge stations are slooooow. Way slower than just taking out the battery and putting it in a regular recharger. In fact, this PR increases the mech recharge station speed by a factor of ten and they're *still* slower than a recharge station by about 5 seconds from 0% to 100% — and that's when the mech recharger is max upgraded for recharge speed and the regular recharge station is *completely unupgraded*.

Also, there was a bug that was causing the recharge speed upgrades on the recharge station to be ignored. I fixed that while I was at it. By the looks of it it was caused by legacy interface code for the mech power control console that no longer seemed to do anything except break the upgrades.

:cl:
* Bugfix: Exosuit charging stations now actually benefit from upgrades
* Tweak: Exosuit charging stations now charge exosuit batteries ten times faster

<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl:
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
