### PR TITLE
Tweaks robot access, again.

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -67,7 +67,6 @@
 	var/illegal_weapons = FALSE
 	var/wiresexposed = FALSE
 	var/locked = TRUE
-	var/list/req_access = list(access_robotics)
 	var/ident = FALSE
 	var/hasbutt = TRUE //Needed for bootyborgs... and buckling too.
 	var/alarms = list("Motion"=list(), "Fire"=list(), "Atmosphere"=list(), "Power"=list(), "Camera"=list())
@@ -96,12 +95,17 @@
 	var/toner = CYBORG_STARTING_TONER
 	var/tonermax = CYBORG_MAX_TONER
 
+//Access
+	var/list/req_access = list(access_robotics) //Access needed to open cover
+	var/list/robot_access = list(access_ai_upload, access_robotics, access_maint_tunnels, access_external_airlocks) //Our current access
+
 /mob/living/silicon/robot/New(loc, var/unfinished = FALSE)
 	ident = rand(1, 999)
 	updatename(modtype)
 	updateicon()
 
 	laws = getLawset(src)
+	robot_access = GetRobotAccess()
 	wires = new wiring_type(src)
 	station_holomap = new(src)
 	radio = new /obj/item/device/radio/borg(src)
@@ -1305,8 +1309,10 @@
 /mob/living/silicon/robot/GetAccess()
 	if(isDead()) //Dead cyborgs need no access.
 		return
-	if(module) //Pick a module you lil shit.
-		return module.access
+	return robot_access
+
+/mob/living/silicon/robot/proc/GetRobotAccess()
+	return get_all_accesses()
 
 /mob/living/silicon/robot/hasFullAccess()
 	return FALSE

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -23,7 +23,7 @@
 
 	//Languages
 	var/list/languages = list()
-	var/list/added_languages //Bookkeeping
+	var/list/added_languages = list() //Bookkeeping
 
 	//Radio
 	var/radio_key = null
@@ -36,9 +36,6 @@
 	var/recharge_tick = 0
 	var/list/respawnables
 	var/respawnables_max_amount = 0
-
-	//Access
-	var/list/access = list()
 
 /obj/item/weapon/robot_module/Destroy()
 	if(istype(loc, /mob/living/silicon/robot))
@@ -82,7 +79,6 @@
 
 /obj/item/weapon/robot_module/New(var/mob/living/silicon/robot/R)
 	..()
-	added_languages = list()
 	add_languages(R)
 	AddToProfiler()
 	if(default_modules)
@@ -91,7 +87,6 @@
 	AddCameraNetworks(R)
 	AddEncryptionKey(R)
 	ApplyStatusFlags(R)
-	access = GetModuleAccess()
 
 /obj/item/weapon/robot_module/proc/AddDefaultModules()
 	modules += new /obj/item/device/flashlight(src)
@@ -178,9 +173,6 @@
 	for(var/language_name in added_languages)
 		R.remove_language(language_name, TRUE) //We remove the ability to speak but keep the ability to understand.
 	added_languages.Cut()
-
-/obj/item/weapon/robot_module/proc/GetModuleAccess()
-	return get_all_accesses()
 
 //Modules
 /obj/item/weapon/robot_module/standard
@@ -525,9 +517,6 @@
 	networks = list(CAMERANET_NUKE)
 	radio_key = /obj/item/device/encryptionkey/syndicate
 	speed_modifier = CYBORG_SYNDICATE_SPEED_MODIFIER
-
-/obj/item/weapon/robot_module/syndicate/GetModuleAccess()
-	return get_all_syndicate_access()
 
 /obj/item/weapon/robot_module/syndicate/blitzkrieg/New()
 	..()

--- a/code/modules/mob/living/silicon/robot/robot_subtypes/syndicate.dm
+++ b/code/modules/mob/living/silicon/robot/robot_subtypes/syndicate.dm
@@ -11,6 +11,9 @@
 /mob/living/silicon/robot/syndie/getModules()
 	return syndicate_robot_modules
 
+/mob/living/silicon/robot/syndie/GetRobotAccess()
+	return get_all_syndicate_access()
+
 /mob/living/silicon/robot/syndie/New()
 	..()
 	UnlinkSelf()


### PR DESCRIPTION
Moving the crap back to robot code without messing with syndicate cyborgs.

Fixes #18984

:cl:
 * tweak: Cyborgs starts with access again.
 * rscdel: Dead cyborgs now lose their access.

