### PR TITLE
Deathsting now uses chef's sauce

### DIFF
--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -1167,7 +1167,7 @@ var/list/datum/dna/hivemind_bank = list()
 /obj/item/verbs/changeling/proc/changeling_DEATHsting()
 	set category = "Changeling"
 	set name = "Death Sting (40)"
-	set desc = "Causes spasms onto death."
+	set desc = "Causes a delayed death."
 
 	var/mob/M = loc
 	if(!istype(M))
@@ -1177,12 +1177,8 @@ var/list/datum/dna/hivemind_bank = list()
 	if(!target)
 		return
 
-	to_chat(target, "<span class='userdanger'>You feel a tiny prick. Your chest starts tightening.</span>")
-	target.silent = 10
-	target.Paralyse(10)
-	target.Jitter(1000)
 	if(target.reagents)
-		target.reagents.add_reagent(CYANIDE, 20)
+		target.reagents.add_reagent(CHEFSPECIAL, 5)
 
 	feedback_add_details("changeling_powers", "DTHS")
 	return 1

--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -1177,6 +1177,8 @@ var/list/datum/dna/hivemind_bank = list()
 	if(!target)
 		return
 
+	to_chat(target, "<span class='userdanger'>You feel a tiny prick.</span>")
+
 	if(target.reagents)
 		target.reagents.add_reagent(CHEFSPECIAL, 5)
 


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl:
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
Changes changling deathsting to inject 5u Chef's special instead of an instant death + cyanide.  I believe this is a nerf to changlings to make it so the gamemode isn't two succs -> deathsting everyone while keeping the deathsting very powerful.
Inspired by: ![d*scord](https://cdn.discordapp.com/attachments/239823497365422091/472953548750192640/temp5.PNG)
EDIT: Compiled and tested locally
:cl:
 * rscadd: Deathsting now injects 5u special sauce
 * rscdel: Deathsting is no longer instant