### PR TITLE
Deconstructing partially-constructed machine frames gives back all item-type objects

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -174,8 +174,8 @@
 						to_chat(user, "<span class='notice'>You remove the circuit board.</span>")
 					else
 						to_chat(user, "<span class='notice'>You remove the circuit board and other components.</span>")
-						for(var/obj/item/weapon/W in components)
-							W.forceMove(src.loc)
+						for(var/obj/item/I in components)
+							I.forceMove(src.loc)
 					desc = initial(desc)
 					req_components = null
 					components = null

--- a/code/modules/fish/fish_tank.dm
+++ b/code/modules/fish/fish_tank.dm
@@ -85,7 +85,7 @@
 	has_lid = TRUE
 	max_health = 50				// Average strength, will take a couple hits from a toolbox.
 	cur_health = 50
-	shard_count = 2
+	shard_count = 4
 
 
 /obj/machinery/fishtank/wall
@@ -103,7 +103,7 @@
 	has_lid = TRUE
 	max_health = 100			// This thing is a freaking wall, it can handle abuse.
 	cur_health = 100
-	shard_count = 3
+	shard_count = 9
 
 /obj/machinery/fishtank/wall/full
 	water_level = 500


### PR DESCRIPTION
Fixes #19015 by letting partially constructed machine frames return all `/obj/item` components. Previously only allowed for components of type `/obj/item/weapon` to be returned. This currently only affects fish tanks but any future machines that require items like sheets of glass or metal will spit out those components.

Also corrects the `shard_count` of two fish tanks so the proper number of glass shards/sheets are dropped, which according to notes in the code should be `number of glass sheets needed - 1`.

Tests show that deconstructing a nearly-complete wall fish tank gives back the 10 sheets that were inserted.
![untitled](https://user-images.githubusercontent.com/18647741/43373676-3899caee-9379-11e8-9d34-90ea0c13ad7f.png)


:cl:
* tweak: All item components are dropped when partially-completed machine frames are crowbarred.