### PR TITLE
Wear_override icon variable

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -61,7 +61,7 @@
 	var/restraint_resist_time = 0	//When set, allows the item to be applied as restraints, which take this amount of time to resist out of
 	var/restraint_apply_time = 3 SECONDS
 	var/restraint_apply_sound = null
-	var/icon/wear_override = null
+	var/icon/wear_override = null //Worn state override used when wearing this object on your head/uniform/glasses/etc slot, for making a more procedurally generated icon
 
 /obj/item/proc/return_thermal_protection()
 	return return_cover_protection(body_parts_covered) * (1 - heat_conductivity)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -61,6 +61,7 @@
 	var/restraint_resist_time = 0	//When set, allows the item to be applied as restraints, which take this amount of time to resist out of
 	var/restraint_apply_time = 3 SECONDS
 	var/restraint_apply_sound = null
+	var/icon/wear_override = null
 
 /obj/item/proc/return_thermal_protection()
 	return return_cover_protection(body_parts_covered) * (1 - heat_conductivity)

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -171,8 +171,6 @@
 	desc = "A pair of kitty ears. Meow!"
 	icon_state = "kitty"
 	flags = FPRINT
-	var/icon/mob
-	var/icon/mob2
 	var/haircolored = 1
 	siemens_coefficient = 1.5
 
@@ -186,16 +184,11 @@
 /obj/item/clothing/head/kitty/update_icon(var/mob/living/carbon/human/user)
 	if(!istype(user) || !haircolored)
 		return
-	mob = new/icon("icon" = 'icons/mob/head.dmi', "icon_state" = "kitty")
-	mob2 = new/icon("icon" = 'icons/mob/head.dmi', "icon_state" = "kitty2")
-	mob.Blend(rgb(user.r_hair, user.g_hair, user.b_hair), ICON_ADD)
-	mob2.Blend(rgb(user.r_hair, user.g_hair, user.b_hair), ICON_ADD)
+	wear_override = new/icon("icon" = 'icons/mob/head.dmi', "icon_state" = "kitty")
+	wear_override.Blend(rgb(user.r_hair, user.g_hair, user.b_hair), ICON_ADD)
 
 	var/icon/earbit = new/icon("icon" = 'icons/mob/head.dmi', "icon_state" = "kittyinner")
-	var/icon/earbit2 = new/icon("icon" = 'icons/mob/head.dmi', "icon_state" = "kittyinner2")
-	mob.Blend(earbit, ICON_OVERLAY)
-	mob2.Blend(earbit2, ICON_OVERLAY)
-
+	wear_override.Blend(earbit, ICON_OVERLAY)
 
 /obj/item/clothing/head/butt
 	name = "butt"

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -518,24 +518,39 @@ var/global/list/damage_icon_parts = list()
 /mob/living/carbon/human/update_inv_w_uniform(var/update_icons=1)
 
 	overlays -= obj_overlays[UNIFORM_LAYER]
-	if(w_uniform && istype(w_uniform, /obj/item/clothing/under) && !check_hidden_body_flags(HIDEJUMPSUIT) && w_uniform.is_visible())
+	if(!w_uniform)
+		// Automatically drop anything in store / id / belt if you're not wearing a uniform.	//CHECK IF NECESARRY
+		for( var/obj/item/thing in list(r_store, l_store, wear_id, belt) )						//
+			if(thing)																			//
+				u_equip(thing,1)																//
+				if (client)																		//
+					client.screen -= thing														//
+																								//
+				if (thing)																		//
+					thing.forceMove(loc)																//
+					//thing.dropped(src)														//
+					thing.reset_plane_and_layer()
+
+	else if(w_uniform && !check_hidden_body_flags(HIDEJUMPSUIT) && w_uniform.is_visible())
 		w_uniform.screen_loc = ui_iclothing
 		var/obj/abstract/Overlays/O = obj_overlays[UNIFORM_LAYER]
 		O.overlays.len = 0
+		var/image/standing
 		var/t_color = w_uniform._color
-		if(!t_color)
-			t_color = icon_state
-		var/image/standing	= image("icon_state" = "[t_color]_s")
+		var/is_fat = ((M_FAT in mutations) && (species.anatomy_flags & CAN_BE_FAT)) || species.anatomy_flags & IS_BULKY
+		if(t_color)
+			standing = image("icon_state" = "[t_color]_s", "icon" = 'icons/mob/uniform.dmi')
 
-		if(((M_FAT in mutations) && (species.anatomy_flags & CAN_BE_FAT)) || species.anatomy_flags & IS_BULKY)
+		if(is_fat)
 			if(w_uniform.clothing_flags&ONESIZEFITSALL)
-				standing.icon	= 'icons/mob/uniform_fat.dmi'
+				standing.icon = 'icons/mob/uniform_fat.dmi'
 			else
 				to_chat(src, "<span class='warning'>You burst out of \the [w_uniform]!</span>")
 				drop_from_inventory(w_uniform)
 				return
-		else
-			standing.icon	= 'icons/mob/uniform.dmi'
+
+		if(w_uniform.wear_override)
+			standing = image("icon" = w_uniform.wear_override)
 
 		var/obj/item/clothing/under/under_uniform = w_uniform
 
@@ -565,19 +580,7 @@ var/global/list/damage_icon_parts = list()
 		O.pixel_y = species.inventory_offsets["[slot_w_uniform]"]["pixel_y"] * PIXEL_MULTIPLIER
 		obj_to_plane_overlay(O,UNIFORM_LAYER)
 		//overlays_standing[UNIFORM_LAYER]	= standing
-	else if (!check_hidden_body_flags(HIDEJUMPSUIT))
 		//overlays_standing[UNIFORM_LAYER]	= null
-		// Automatically drop anything in store / id / belt if you're not wearing a uniform.	//CHECK IF NECESARRY
-		for( var/obj/item/thing in list(r_store, l_store, wear_id, belt) )						//
-			if(thing)																			//
-				u_equip(thing,1)																//
-				if (client)																		//
-					client.screen -= thing														//
-																								//
-				if (thing)																		//
-					thing.forceMove(loc)																//
-					//thing.dropped(src)														//
-					thing.reset_plane_and_layer()
 	if(update_icons)
 		update_icons()
 
@@ -621,9 +624,11 @@ var/global/list/damage_icon_parts = list()
 		var/t_state = gloves.item_state
 		if(!t_state)
 			t_state = gloves.icon_state
-		var/image/standing	= image("icon" = ((gloves.icon_override) ? gloves.icon_override : 'icons/mob/hands.dmi'), "icon_state" = "[t_state]")
-
-		var/obj/item/I = gloves
+		var/image/standing
+		if(gloves.wear_override)
+			standing = image("icon" = gloves.wear_override)
+		else
+			standing = image("icon" = ((gloves.icon_override) ? gloves.icon_override : 'icons/mob/hands.dmi'), "icon_state" = "[t_state]")
 
 		var/datum/species/S = species
 		for(var/datum/organ/external/OE in get_organs_by_slot(slot_gloves, src)) //Display species-exclusive species correctly on attached limbs
@@ -631,7 +636,7 @@ var/global/list/damage_icon_parts = list()
 				S = OE.species
 				break
 
-		if(S.name in I.species_fit) //Allows clothes to display differently for multiple species
+		if(S.name in gloves.species_fit) //Allows clothes to display differently for multiple species
 			if(S.gloves_icons)
 				standing.icon = S.gloves_icons
 
@@ -675,9 +680,11 @@ var/global/list/damage_icon_parts = list()
 	overlays -= obj_overlays[GLASSES_LAYER]
 	overlays -= obj_overlays[GLASSES_OVER_HAIR_LAYER]
 	if(glasses && !check_hidden_head_flags(HIDEEYES) && glasses.is_visible())
-		var/image/standing = image("icon" = ((glasses.icon_override) ? glasses.icon_override : 'icons/mob/eyes.dmi'), "icon_state" = "[glasses.icon_state]")
-
-		var/obj/item/I = glasses
+		var/image/standing
+		if(glasses.wear_override)
+			standing = image("icon" = glasses.wear_override)
+		else
+			standing = image("icon" = ((glasses.icon_override) ? glasses.icon_override : 'icons/mob/eyes.dmi'), "icon_state" = "[glasses.icon_state]")
 
 		var/datum/species/S = species
 		for(var/datum/organ/external/OE in get_organs_by_slot(slot_head, src)) //Display species-exclusive species correctly on attached limbs
@@ -685,7 +692,7 @@ var/global/list/damage_icon_parts = list()
 				S = OE.species
 				break
 
-		if(S.name in I.species_fit) //Allows clothes to display differently for multiple species
+		if(S.name in glasses.species_fit) //Allows clothes to display differently for multiple species
 			if(S.glasses_icons)
 				standing.icon = S.glasses_icons
 
@@ -725,7 +732,11 @@ var/global/list/damage_icon_parts = list()
 
 	overlays -= obj_overlays[EARS_LAYER]
 	if(ears && !check_hidden_head_flags(HIDEEARS) && ears.is_visible())
-		var/image/standing = image("icon" = ((ears.icon_override) ? ears.icon_override : 'icons/mob/ears.dmi'), "icon_state" = "[ears.icon_state]")
+		var/image/standing
+		if(ears.wear_override)
+			standing = image("icon" = ears.wear_override)
+		else
+			standing = image("icon" = ((ears.icon_override) ? ears.icon_override : 'icons/mob/ears.dmi'), "icon_state" = "[ears.icon_state]")
 
 		var/obj/item/I = ears
 
@@ -761,11 +772,12 @@ var/global/list/damage_icon_parts = list()
 	overlays -= obj_overlays[SHOES_LAYER]
 	if(shoes && !check_hidden_body_flags(HIDESHOES) && shoes.is_visible())
 		var/obj/abstract/Overlays/O = obj_overlays[SHOES_LAYER]
-		O.icon = ((shoes.icon_override) ? shoes.icon_override : 'icons/mob/feet.dmi')
-		O.icon_state = shoes.icon_state
+		if(shoes.wear_override)
+			O.icon = icon("icon" = shoes.wear_override)
+		else
+			O.icon = ((shoes.icon_override) ? shoes.icon_override : 'icons/mob/feet.dmi')
+			O.icon_state = shoes.icon_state
 		//var/image/standing	= image("icon" = ((shoes.icon_override) ? shoes.icon_override : 'icons/mob/feet.dmi'), "icon_state" = "[shoes.icon_state]")
-
-		var/obj/item/I = shoes
 
 		var/datum/species/S = species
 		for(var/datum/organ/external/OE in get_organs_by_slot(slot_shoes, src)) //Display species-exclusive species correctly on attached limbs
@@ -773,7 +785,7 @@ var/global/list/damage_icon_parts = list()
 				S = OE.species
 				break
 
-		if(S.name in I.species_fit) //Allows clothes to display differently for multiple species
+		if(S.name in shoes.species_fit) //Allows clothes to display differently for multiple species
 			if(S.shoes_icons)
 				O.icon = S.shoes_icons
 
@@ -830,10 +842,10 @@ var/global/list/damage_icon_parts = list()
 		O.overlays.len = 0
 		head.screen_loc = ui_head		//TODO
 		var/image/standing
-		if(istype(head,/obj/item/clothing/head/kitty)) //AAAAUUUGH
-			standing	= image("icon" = head:mob)
+		if(head.wear_override)
+			standing = image("icon" = head.wear_override)
 		else
-			standing	= image("icon" = ((head.icon_override) ? head.icon_override : 'icons/mob/head.dmi'), "icon_state" = "[head.icon_state]")
+			standing = image("icon" = ((head.icon_override) ? head.icon_override : 'icons/mob/head.dmi'), "icon_state" = "[head.icon_state]")
 
 		var/obj/item/I = head
 


### PR DESCRIPTION
The wear_override variable is used when you want a more procedurally-generated icon to appear on the person when they wear the object.

Converts the kitty ears to use this variable. Removes some unused variables in kitty ears (mob2 was never used, and kitty2 and innerkitty2 were absent sprites)


Unfucks some of human/úpdate_icon code so it actually made sense (Removing a limiting check that would stop you from wearing things on your suit slot even if they were able to. Removed some redundant redefines.
