### PR TITLE
Deathgasp roundup

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/death.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/death.dm
@@ -3,12 +3,11 @@
 		return
 	if(healths)
 		healths.icon_state = "health6"
+	if(!gibbed)
+		emote("deathgasp")
 	stat = DEAD
 
 	if(!gibbed)
-		playsound(loc, 'sound/voice/hiss6.ogg', 80, 1, 1)
-		for(var/mob/O in viewers(src, null))
-			O.show_message("<B>[src]</B> lets out a waning guttural screech, green blood bubbling from its maw...", 1)
 		update_canmove()
 		update_icons()
 

--- a/code/modules/mob/living/carbon/alien/larva/death.dm
+++ b/code/modules/mob/living/carbon/alien/larva/death.dm
@@ -3,12 +3,14 @@
 		return
 	if(healths)
 		healths.icon_state = "health6"
+	if(!gibbed)
+		emote("deathgasp")
 	stat = DEAD
 	icon_state = "larva_dead"
 
 	if(!gibbed)
 		update_canmove()
-		
+
 	tod = worldtime2text() //weasellos time of death patch
 	if(mind)
 		mind.store_memory("Time of death: [tod]", 0)

--- a/code/modules/mob/living/carbon/monkey/death.dm
+++ b/code/modules/mob/living/carbon/monkey/death.dm
@@ -30,11 +30,9 @@
 		return
 	if(healths)
 		healths.icon_state = "health5"
-	stat = DEAD
-
 	if(!gibbed)
-		for(var/mob/O in viewers(src, null))
-			O.show_message("<b>\The [name]</b> lets out a faint chimper as it collapses and stops moving...", 1) //ded -- Urist
+		emote("deathgasp")
+	stat = DEAD
 
 	update_canmove()
 	update_icons()

--- a/code/modules/mob/living/silicon/ai/death.dm
+++ b/code/modules/mob/living/silicon/ai/death.dm
@@ -1,6 +1,8 @@
 /mob/living/silicon/ai/death(gibbed)
 	if(stat == DEAD)
 		return
+	if(!gibbed)
+		emote("deathgasp")
 	stat = DEAD
 	if("[icon_state]-crash" in icon_states(src.icon,1))
 		icon_state = "[icon_state]-crash"

--- a/code/modules/mob/living/silicon/robot/death.dm
+++ b/code/modules/mob/living/silicon/robot/death.dm
@@ -36,10 +36,11 @@
 /mob/living/silicon/robot/death(gibbed)
 	if(stat == DEAD)
 		return
+	if(!gibbed)
+		emote("deathgasp")
 	stat = DEAD
 	update_canmove()
 	if(!gibbed)
-		emote("deathgasp")
 		updateicon() //Don't call updateicon if you're already null.
 		locked = FALSE //Cover unlocks.
 	if(camera)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -509,7 +509,7 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 		return
 
 	if(!gibbed)
-		visible_message("<span class='danger'>\the [src] stops moving...</span>")
+		emote("deathgasp")
 
 	health = 0 // so /mob/living/simple_animal/Life() doesn't magically revive them
 	living_mob_list -= src


### PR DESCRIPTION
Fixes borgs not deathgasping when they die, implements a couple deathgasps that were ported with emote datums but not implemented, and gets rid of some copypaste.

:cl:
* bugfix: Fixed cyborgs not making a deathgasp on death.
* rscadd: Implemented deathgasps on death for AIs and alien larvae.