### PR TITLE
Can now screwdriver emagged APCs

### DIFF
--- a/code/datums/wires/apc.dm
+++ b/code/datums/wires/apc.dm
@@ -37,6 +37,8 @@ var/const/APC_WIRE_AI_CONTROL = 8
 	switch(index)
 
 		if(APC_WIRE_IDSCAN)
+			if(A.emagged)
+				return
 			A.locked = 0
 
 			spawn(300)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -301,10 +301,10 @@
 			update_state |= UPSTATE_OPENED1
 		if(opened==2)
 			update_state |= UPSTATE_OPENED2
-	else if(wiresexposed)
-		update_state |= UPSTATE_WIREEXP
 	else if(emagged || malfai || spooky)
 		update_state |= UPSTATE_BLUESCREEN
+	else if(wiresexposed)
+		update_state |= UPSTATE_WIREEXP
 	if(update_state <= 1)
 		update_state |= UPSTATE_ALLGOOD
 

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -256,10 +256,10 @@
 				icon_state = "[basestate]-nocover"
 		else if(update_state & UPSTATE_BROKE)
 			icon_state = "apc-b"
-		else if(update_state & UPSTATE_WIREEXP)
-			icon_state = "apcewires"
 		else if(update_state & UPSTATE_BLUESCREEN)
 			icon_state = "apcemag"
+		else if(update_state & UPSTATE_WIREEXP)
+			icon_state = "apcewires"
 
 
 

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -256,10 +256,10 @@
 				icon_state = "[basestate]-nocover"
 		else if(update_state & UPSTATE_BROKE)
 			icon_state = "apc-b"
-		else if(update_state & UPSTATE_BLUESCREEN)
-			icon_state = "apcemag"
 		else if(update_state & UPSTATE_WIREEXP)
 			icon_state = "apcewires"
+		else if(update_state & UPSTATE_BLUESCREEN)
+			icon_state = "apcemag"
 
 
 
@@ -301,10 +301,10 @@
 			update_state |= UPSTATE_OPENED1
 		if(opened==2)
 			update_state |= UPSTATE_OPENED2
-	else if(emagged || malfai || spooky)
-		update_state |= UPSTATE_BLUESCREEN
 	else if(wiresexposed)
 		update_state |= UPSTATE_WIREEXP
+	else if(emagged || malfai || spooky)
+		update_state |= UPSTATE_BLUESCREEN
 	if(update_state <= 1)
 		update_state |= UPSTATE_ALLGOOD
 
@@ -458,8 +458,6 @@
 					to_chat(user, "<span class='warning'>There is nothing to secure.</span>")
 					return
 				update_icon()
-		else if(emagged)
-			to_chat(user, "The interface is broken.")
 		else if(has_electronics == 2)
 			wiresexposed = !wiresexposed
 			to_chat(user, "The wires have been [wiresexposed ? "exposed" : "unexposed"].")
@@ -470,7 +468,7 @@
 
 	else if (istype(W, /obj/item/weapon/card/id)||istype(W, /obj/item/device/pda))			// trying to unlock the interface with an ID card
 		if(emagged)
-			to_chat(user, "The interface is broken.")
+			to_chat(user, "The lock seems broken.")
 		else if(opened)
 			to_chat(user, "You must close the cover to swipe an ID card.")
 		else if(wiresexposed)


### PR DESCRIPTION
The 'toggle lock' wire on it doesn't do anything anymore when emagged
~~Also throws sprite lines around so emagged/hacked APCs actually change sprites when opened~~
tested

pros:
- Can't meta malf by screwdrivering blue APCs anymore
- Easier for syndies to set the AI up as rogue
- Easier for milf to pretend that it's just syndies fucking around

cons:
- Can't meta malf by screwdrivering blue APCs anymore
- ~~Malf borgs could screw open APCs to hide that they're blue~~

:cl:
- tweak: You can now use screwdrivers on emagged APCs to hack them