### PR TITLE
APC wires can only be accessed with proper tools

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -679,6 +679,24 @@
 	return
 
 
+/obj/machinery/power/apc/updateDialog()
+	if(in_use)
+		var/list/nearby = viewers(1, src)
+		var/is_in_use = 0
+		for(var/mob/M in _using) 
+			if (!M || !M.client || M.machine != src)
+				_using.Remove(M)
+				continue
+			if(!isAI(M) && !isrobot(M) && !(M in nearby))
+				_using.Remove(M)
+				continue
+			is_in_use = 1
+			if (wiresexposed)
+				wires.Interact(M)
+			else
+				interact(M)
+		in_use = is_in_use
+	
 /obj/machinery/power/apc/interact(mob/user)
 	if (!user)
 		return
@@ -825,8 +843,13 @@
 				to_chat(user, "<span class='warning'>\The [src] have AI control disabled!</span>")
 				nanomanager.close_user_uis(user, src)
 			return 0
+	
 	else
 		if ((!in_range(src, user) || !istype(src.loc, /turf)))
+			nanomanager.close_user_uis(user, src)
+			
+		if (wiresexposed)
+			to_chat(user, "<span class='warning'>Unexpose the wires first!</span>")
 			nanomanager.close_user_uis(user, src)
 
 			return 0

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -675,6 +675,8 @@
 
 	if (wiresexposed)
 		wires.Interact(user)
+		if (issilicon(user))
+			ui_interact(user)
 		return
 
 	if (stat & (BROKEN | MAINT | EMPED))

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -380,9 +380,16 @@
 
 //attack with an item - open/close cover, insert cell, or (un)lock interface
 /obj/machinery/power/apc/attackby(obj/item/W, mob/living/user)
+
+	src.add_fingerprint(user)
+	
+	if (iswiretool(W) && wiresexposed)
+		wires.Interact(user)
+		return
+		
 	if (istype(user, /mob/living/silicon) && get_dist(src,user)>1)
 		return src.attack_hand(user)
-	src.add_fingerprint(user)
+		
 	if (iscrowbar(W) && opened)
 		if (has_electronics==1)
 			if (terminal)
@@ -672,16 +679,10 @@
 /obj/machinery/power/apc/interact(mob/user)
 	if (!user)
 		return
-
-	if (wiresexposed)
-		wires.Interact(user)
-		if (issilicon(user))
-			ui_interact(user)
-		return
-
+	
 	if (stat & (BROKEN | MAINT | EMPED))
 		return
-
+		
 	ui_interact(user)
 
 /obj/machinery/power/apc/proc/get_malf_status(mob/user)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -626,6 +626,9 @@
 //		return
 	if(!user)
 		return
+	if(wiresexposed && !issilicon(user))
+		to_chat(user, "Unexpose the wires first!")
+		return
 	if(!isobserver(user))
 		src.add_fingerprint(user)
 		if(usr == user && opened)


### PR DESCRIPTION
~~Silicons interacting with APCs with their wires exposed will now get both the wire UI and the normal operations UI.~~

 
~~tweak~~ ~~AIs and cyborgs that interact with APCs that have their wires exposed will now see both the wire menu and the normal operations menu.~~

Interacting with an APC that has it's wires exposed will only work with proper wire tools, much like with airlocks.
Silicons can still interact with the APC program directly.

🆑 
- Tweak: You can no longer interact with APCs that have their wires exposed without proper tools. 
- Tweak: Silicons attempting to interact with APCs without tools will load up the APC control menu.