### PR TITLE
reverts #17987 (actually limits borg names)

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_verbs.dm
+++ b/code/modules/mob/living/silicon/robot/robot_verbs.dm
@@ -11,7 +11,7 @@
 
 	var/newname
 	for(var/i = 1 to 3)
-		newname = reject_bad_name(stripped_input(src,"You are a [braintype]. Enter a name, or leave blank for the default name.", "Name change [4-i] [0-i != 1 ? "tries":"try"] left",""),1,MAX_NAME_LEN)
+		newname = trimcenter(trim(stripped_input(src,"You are a [braintype]. Enter a name, or leave blank for the default name.", "Name change [4-i] [0-i != 1 ? "tries":"try"] left",""),1,MAX_NAME_LEN))
 		if(newname == null)
 			if(alert(src,"Are you sure you want the default name?",,"Yes","No") == "Yes")
 				break


### PR DESCRIPTION
![validator](https://user-images.githubusercontent.com/8468269/43440661-6bb2b844-9498-11e8-8bc5-27716057edda.png)
resolves #18684 
@MadmanMartian  if you still think absurdly long borg names are an issue trim them in a way that doesn't force capitalize and lock out other shit 

🆑 
 - tweak: borg names once again have less restrictions