### PR TITLE
Security camera name improvement for mappers

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -87,7 +87,6 @@ var/list/camera_names=list()
 	..()
 	if(adv_camera && adv_camera.initialized && !(src in adv_camera.camerasbyzlevel["[z]"]))
 		adv_camera.update(z, TRUE, list(src))
-	name = initial(name) //reset the name for mapping convenience
 	update_hear()
 
 /obj/machinery/camera/proc/name_camera()

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -82,7 +82,7 @@ var/list/camera_names=list()
 	..()
 	if(adv_camera && adv_camera.initialized && !(src in adv_camera.camerasbyzlevel["[z]"]))
 		adv_camera.update(z, TRUE, list(src))
-
+	name = initial(name) //reset the name for mapping convenience
 	update_hear()
 
 /obj/machinery/camera/proc/name_camera()

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -77,6 +77,11 @@ var/list/camera_names=list()
 		ASSERT(src.network)
 		ASSERT(src.network.len > 0)
 
+	//allow mappers to use the name field for the camera instead of c_tag
+	//this helps organize the camera object list in DreamMaker
+	if(name != initial(name) && !c_tag)
+		c_tag = name
+		name = initial(name)
 	if(!c_tag)
 		name_camera()
 	..()


### PR DESCRIPTION
~~Virtually all security cameras are called just "security camera". When mapping, you have a list of hundreds of cameras with identical names but different c_tags (the name the camera uses on the camera network), which is a pain to organize. This change allows mappers to rename their cameras whatever they want to help organize the camera object list, and the name should get reset when the game loads so they'll show up as just plain "security camera" (or eg. arena camera, if it's the floor cam found in centcomm arena) for players.~~

**Updated:**

Mappers can now use the `name` field instead of the `c_tag` field to define the name of security cameras. When the camera is created, if `name` has been defined but `c_tag` hasn't, the camera's `c_tag` will become its `name`, and `name` will be reset to its default value (usually "security camera").

In practise this means the object list for security cameras will now look like this: ![after](https://i.imgur.com/T4dg8TV.png) rather than this: ![before](https://i.imgur.com/IgSVoGv.png)

which makes organizing things that little bit easier. There are no visible effects in-game, and this entire feature can be ignored entirely by just defining the `c_tag` of the camera manually (so it should not have any impact on existing maps).

~~I also modified all the existing maps to use this naming scheme by using regex to replace the `c_tag` of all cameras with `name` (and then fixing some fringe cases where the camera was supposed to have a non-default name). This is why the PR includes lots of changes to all five main maps.~~ **I'll just put those in a different PR if/when this one gets accepted**

:cl:
* tweak: Mappers can now use the name field rather than the c_tag field to define the name of security cameras. All cameras still appear as their plain default name in-game. If the c_tag is defined manually, neither it or the name are touched.

<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl:
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
