### PR TITLE
Mech cursor toggle option

### DIFF
--- a/code/game/mecha/combat/combat.dm
+++ b/code/game/mecha/combat/combat.dm
@@ -4,6 +4,7 @@
 	var/melee_can_hit = 1
 	var/list/destroyable_obj = list(/obj/mecha, /obj/structure/window, /obj/structure/grille, /turf/simulated/wall)
 	internal_damage_threshold = 50
+	cursor_enabled = 1 //cursor is enabled by default for combat mechs
 	maint_access = 0
 	//add_req_access = 0
 	//operation_req_access = list(access_hos)
@@ -249,28 +250,6 @@
 		onclose(occupant, "sam", src)
 	return
 */
-/obj/mecha/combat/moved_inside(var/mob/living/carbon/human/H as mob)
-	if(..())
-		if(H.client)
-			H.client.mouse_pointer_icon = file("icons/mouse/mecha_mouse.dmi")
-		return 1
-	else
-		return 0
-
-/obj/mecha/combat/mmi_moved_inside(var/obj/item/device/mmi/mmi_as_oc as obj,mob/user as mob)
-	if(..())
-		if(occupant.client)
-			occupant.client.mouse_pointer_icon = file("icons/mouse/mecha_mouse.dmi")
-		return 1
-	else
-		return 0
-
-
-/obj/mecha/combat/go_out()
-	if(src.occupant && src.occupant.client)
-		src.occupant.client.mouse_pointer_icon = initial(src.occupant.client.mouse_pointer_icon)
-	..()
-	return
 
 /obj/mecha/combat/Topic(href,href_list)
 	..()

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -50,7 +50,9 @@
 	var/obj/machinery/portable_atmospherics/canister/internal_tank
 	var/datum/gas_mixture/cabin_air
 	var/obj/machinery/atmospherics/unary/portables_connector/connected_port = null
-
+	
+	/var/cursor_enabled = 0 //whether to display the mecha cursor	
+	
 	var/obj/item/device/radio/radio = null
 	var/obj/item/device/radio/electropack/electropack = null
 	var/obj/item/mecha_parts/mecha_tracking/tracking = null
@@ -1113,6 +1115,24 @@
 	src.occupant_message("Toggled lights [lights?"on":"off"].")
 	log_message("Toggled lights [lights?"on":"off"].")
 	return
+	
+/obj/mecha/verb/toggle_cursor()
+	set name = "Toggle Cursor"
+	set category = "Exosuit Interface"
+	set src = usr.loc
+	set popup_menu = 0
+	if(usr!=src.occupant)
+		return
+	cursor_enabled = !cursor_enabled
+	if(cursor_enabled)
+		if(src.occupant && src.occupant.client)
+			src.occupant.client.mouse_pointer_icon = file("icons/mouse/mecha_mouse.dmi")
+	else
+		if(src.occupant && src.occupant.client)
+			src.occupant.client.mouse_pointer_icon = initial(src.occupant.client.mouse_pointer_icon)
+	src.occupant_message("Toggled cursor [cursor_enabled?"on":"off"].")
+	log_message("Toggled cursor [cursor_enabled?"on":"off"].")
+	return
 
 
 /obj/mecha/verb/toggle_internal_tank()
@@ -1200,6 +1220,10 @@
 		if(!hasInternalDamage())
 			src.occupant << sound('sound/mecha/nominalsyndi.ogg',volume=50)
 
+		//change the cursor
+		if(H.client && cursor_enabled)
+			H.client.mouse_pointer_icon = file("icons/mouse/mecha_mouse.dmi")
+			
 		// -- Mode/mind specific stuff goes here
 		if(H.mind)
 			if(isrev(H) || isrevhead(H))
@@ -1271,6 +1295,11 @@
 		src.log_message("[mmi_as_oc] moved in as pilot.")
 		if(!hasInternalDamage())
 			src.occupant << sound('sound/mecha/nominalsyndi.ogg',volume=50)
+			
+		//change the cursor
+		if(occupant.client && cursor_enabled)
+			occupant.client.mouse_pointer_icon = file("icons/mouse/mecha_mouse.dmi")
+			
 		return 1
 	else
 		return 0
@@ -1399,7 +1428,11 @@
 			mmi.mecha = null
 			src.occupant.canmove = 0
 			src.verbs += /obj/mecha/verb/eject
-
+			
+		//change the cursor
+		if(src.occupant && src.occupant.client)
+			src.occupant.client.mouse_pointer_icon = initial(src.occupant.client.mouse_pointer_icon)
+			
 		// -- Mode/mind specific stuff goes here
 		if(src.occupant.mind)
 			if(isrev(src.occupant) || isrevhead(src.occupant))
@@ -1570,6 +1603,7 @@
 						<div class='header'>Electronics</div>
 						<div class='links'>
 						<a href='?src=\ref[src];toggle_lights=1'>Toggle Lights</a><br>
+						<a href='?src=\ref[src];toggle_cursor=1'>Toggle Cursor</a><br>
 						<b>Radio settings:</b><br>
 						Microphone: <a href='?src=\ref[src];rmictoggle=1'><span id="rmicstate">[radio.broadcasting?"Engaged":"Disengaged"]</span></a><br>
 						Speaker: <a href='?src=\ref[src];rspktoggle=1'><span id="rspkstate">[radio.listening?"Engaged":"Disengaged"]</span></a><br>
@@ -1754,6 +1788,11 @@
 		if(usr != src.occupant)
 			return
 		src.toggle_lights()
+		return
+	if (href_list["toggle_cursor"])
+		if(usr != src.occupant)
+			return
+		src.toggle_cursor()
 		return
 	if(href_list["toggle_airtank"])
 		if(usr != src.occupant)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -51,7 +51,7 @@
 	var/datum/gas_mixture/cabin_air
 	var/obj/machinery/atmospherics/unary/portables_connector/connected_port = null
 	
-	/var/cursor_enabled = 0 //whether to display the mecha cursor	
+	var/cursor_enabled = 0 //whether to display the mecha cursor	
 	
 	var/obj/item/device/radio/radio = null
 	var/obj/item/device/radio/electropack/electropack = null


### PR DESCRIPTION
(split off from #19049)

Adds a toggle option for the mech cursor because I think it's annoying. As a side effect of this, it's also now available on non-combat mechs such as the Ripley, because doing separate interface code for the combat mechs would be a pain in the ass.

The cursor defaults to on for combat mechs and off for non-combat mechs, so there are no changes except for the addition of the toggle option in that regard.

:cl:
* tweak: added a toggle option for the special mech cursor.

<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl:
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
