### PR TITLE
Fixes cloning disk backups runtiming and disks getting qdel'd

### DIFF
--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -38,6 +38,21 @@
 			ser["type"] = "se"
 	return ser
 
+/datum/dna2/record/proc/Clone()
+	var/datum/dna2/record/new_copy = new
+	if(dna)
+		new_copy.dna = dna.Clone()
+	new_copy.types = types
+	new_copy.name = name
+	new_copy.id = id
+	new_copy.implant = implant
+	new_copy.ckey = ckey
+	new_copy.mind = mind
+	new_copy.languages = languages.Copy()
+	new_copy.times_cloned = times_cloned
+
+	return new_copy
+
 /////////////////////////// DNA MACHINES
 /obj/machinery/dna_scannernew
 	name = "\improper DNA modifier"

--- a/code/modules/medical/computer/cloning.dm
+++ b/code/modules/medical/computer/cloning.dm
@@ -35,7 +35,10 @@
 		scanner.connected = null
 		scanner = null
 	if(diskette)
-		qdel(diskette)
+		if(loc)
+			diskette.forceMove(loc)
+		else
+			qdel(diskette)
 		diskette = null
 	records.Cut()
 	active_record = null
@@ -321,7 +324,7 @@
 			return
 
 		// DNA2 makes things a little simpler.
-		src.diskette.buf=src.active_record
+		src.diskette.buf=src.active_record.Clone() //Copy the record, not just the reference to it
 		src.diskette.buf.types=0
 		switch(href_list["save_disk"]) //Save as Ui/Ui+Ue/Se
 			if("ui")


### PR DESCRIPTION
Resolves #19042 

:cl:
* bugfix: Deconstructing a cloning computer with a disk inside no longer poofs the disk into nothing.
* bugfix: Attempting to clone somebody from a disk record who was already cloned before from that same scan no longer bricks the console.