### PR TITLE
Fixes surrender emote

### DIFF
--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -314,14 +314,14 @@
 /datum/emote/living/surrender
 	key = "surrender"
 	key_third_person = "surrenders"
-	message = "puts their hands on their head and falls to the ground, they surrender%s!"
+	message = "puts their hands on their head and falls to the ground, they surrender!"
 	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/surrender/run_emote(mob/user, params)
 	. = ..()
 	if(. && isliving(user))
 		var/mob/living/L = user
-		L.Knockdown(200)
+		L.Knockdown(10)
 
 /datum/emote/living/sway
 	key = "sway"


### PR DESCRIPTION
This number wasn't converted when it was ported over. It's supposed to knock you down for 200 deciseconds, not five minutes or whatever.

:cl:
* bugfix: The *surrender emote no longer renders you helpless for an insanely long time.