### PR TITLE
Layering tweaks

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -5,6 +5,7 @@
 	icon_state = "closed"
 	density = 1
 	flags = FPRINT
+	layer = BELOW_OBJ_LAYER
 	var/icon_closed = "closed"
 	var/icon_opened = "open"
 	var/opened = 0

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -10,6 +10,7 @@
 	name = "conveyor belt"
 	desc = "A conveyor belt.\
 	<br><span class='info'>It can be pried into a different direction using a crowbar, but cannot be moved without welding it apart.</span>"
+	layer = BELOW_TABLE_LAYER
 	anchored = 1
 
 	var/operating = 0	// 1 if running forward, -1 if backwards, 0 if off


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6307265/43528796-17fe4a7a-95aa-11e8-8900-e5437547de91.png)

Closes #18372

:cl:
 * bugfix: Items are now rendered on top of lockers and crates. Lockers and crates are now rendered on top of conveyors belts.