### PR TITLE
nullspace hf

### DIFF
--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -358,10 +358,10 @@
 
 /obj/structure/inflatable/shelter/Destroy()
 	for(var/atom/movable/AM in src)
-		AM.forceMove(src.loc)
-	..()
+		AM.forceMove(loc)
 	qdel(cabin_air)
 	cabin_air = null
+	..()
 
 /obj/structure/inflatable/shelter/remove_air(amount)
 	return cabin_air.remove(amount)
@@ -424,5 +424,7 @@
 	user.delayNext(DELAY_ALL,10 SECONDS)
 	visible_message("<span class='warning'>[user] begins to climb free of the \the [src]!</span>")
 	spawn(10 SECONDS)
-		user.forceMove(loc)
-		update_icon()
+		if(loc)
+			user.forceMove(loc)
+			update_icon()
+		//If not loc, it was probably deflated

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1104,8 +1104,8 @@ Thanks.
 				jailcell.break_out(L)
 		return
 
-	if(src.loc && istype(src.loc, /obj/structure/inflatable/shelter))
-		var/obj/O = src.loc
+	if(L.loc && istype(L.loc, /obj/structure/inflatable/shelter))
+		var/obj/O = L.loc
 		O.container_resist(L)
 
 


### PR DESCRIPTION
almost certainly

closes  #19060

Could not reproduce the bug as he described it HOWEVER I realized that COULD happen if someone else deflated the shelter while you were trying to resist out (after being freed you would then be forced to its null location). If his report meant to say this, then this fixes that.