### PR TITLE
converted circuit boards `build_path` to use typepaths

### DIFF
--- a/code/WorkInProgress/Cael_Aislinn/Rust/circuits.dm
+++ b/code/WorkInProgress/Cael_Aislinn/Rust/circuits.dm
@@ -4,7 +4,7 @@
 /obj/item/weapon/circuitboard/rust_core_control
 	name = "Circuit board (R-UST Mk. 7 core controller)"
 	desc = "A circuit board used to run the core controller computer of a R-UST Mk. 7 engine."
-	build_path = "/obj/machinery/computer/rust_core_control"
+	build_path = /obj/machinery/computer/rust_core_control
 	origin_tech = Tc_PROGRAMMING + "=4;" + Tc_ENGINEERING + "=4"
 
 //////////////////////////////////////
@@ -13,7 +13,7 @@
 /obj/item/weapon/circuitboard/rust_core_monitor
 	name = "Circuit board (R-UST Mk. 7 core monitor)"
 	desc = "A circuit board used to run the core monitoring computer of a R-UST Mk. 7 engine."
-	build_path = "/obj/machinery/computer/rust_core_monitor"
+	build_path = /obj/machinery/computer/rust_core_monitor
 	origin_tech = Tc_PROGRAMMING + "=4;" + Tc_ENGINEERING + "=4"
 
 //////////////////////////////////////
@@ -22,7 +22,7 @@
 /obj/item/weapon/circuitboard/rust_fuel_control
 	name = "Circuit board (R-UST Mk. 7 fuel controller)"
 	desc = "A circuit board used to run the fuel injection computer of a R-UST Mk. 7 engine."
-	build_path = "/obj/machinery/computer/rust_fuel_control"
+	build_path = /obj/machinery/computer/rust_fuel_control
 	origin_tech = Tc_PROGRAMMING + "=4;" + Tc_ENGINEERING + "=4"
 
 //////////////////////////////////////
@@ -49,7 +49,7 @@
 /obj/item/weapon/circuitboard/rust_core
 	name = "Internal circuitry (R-UST Mk. 7 tokamak core)"
 	desc = "A circuit board used to run the core machine of a R-UST Mk. 7 engine."
-	build_path = "/obj/machinery/power/rust_core"
+	build_path = /obj/machinery/power/rust_core
 	board_type = MACHINE
 	origin_tech = Tc_BLUESPACE + "=3;" + Tc_PLASMATECH + "=4;" + Tc_MAGNETS + "=5;" + Tc_POWERSTORAGE + "=6"
 	req_components = list(
@@ -64,7 +64,7 @@
 /obj/item/weapon/circuitboard/rust_injector
 	name = "Internal circuitry (R-UST Mk. 7 fuel injector)"
 	desc = "A circuit board used to run the fuel injection machine of a R-UST Mk. 7 engine."
-	build_path = "/obj/machinery/power/rust_fuel_injector"
+	build_path = /obj/machinery/power/rust_fuel_injector
 	board_type = MACHINE
 	origin_tech = Tc_POWERSTORAGE + "=3;" + Tc_ENGINEERING + "=4;" + Tc_PLASMATECH + "=4;" + Tc_MATERIALS + "=6"
 	req_components = list(
@@ -77,5 +77,5 @@
 /obj/item/weapon/circuitboard/rust_gyrotron_control
 	name = "Circuit board (R-UST Mk. 7 gyrotron controller)"
 	desc = "A circuit board used to run the gyrotron controller computer of a R-UST Mk. 7 engine."
-	build_path = "/obj/machinery/computer/rust_gyrotron_controller"
+	build_path = /obj/machinery/computer/rust_gyrotron_controller
 	origin_tech = Tc_PROGRAMMING + "=4;" + Tc_ENGINEERING + "=4"

--- a/code/WorkInProgress/Cael_Aislinn/ShieldGen/circuits.dm
+++ b/code/WorkInProgress/Cael_Aislinn/ShieldGen/circuits.dm
@@ -6,7 +6,7 @@
 	name = "Circuit board (Starscreen-EX external shield generator)"
 	desc = "A circuit board used to run a Starscreen-EX external shield generator. There's a plate soldered just over one of the identifying chips."
 	board_type = MACHINE
-	build_path = "/obj/machinery/shield_gen/external"
+	build_path = /obj/machinery/shield_gen/external
 	origin_tech = Tc_BLUESPACE + "=4;" + Tc_PLASMATECH + "=3"
 	req_components = list(
 							"/obj/item/weapon/stock_parts/manipulator/nano/pico" = 2,
@@ -27,7 +27,7 @@
 	name = "Circuit board (Starscreen shield generator)"
 	desc = "A circuit board used to run a Starscreen shield generator. There's a plate soldered just under one of the identifying chips."
 	board_type = MACHINE
-	build_path = "/obj/machinery/shield_gen"
+	build_path = /obj/machinery/shield_gen
 	origin_tech = Tc_BLUESPACE + "=4;" + Tc_PLASMATECH + "=3"
 	req_components = list(
 							"/obj/item/weapon/stock_parts/manipulator/nano/pico" = 2,
@@ -48,7 +48,7 @@
 	name = "Circuit board (Starscreen shield capacitor)"
 	desc = "A circuit board used to run a Starscreen shield capacitor."
 	board_type = MACHINE
-	build_path = "/obj/machinery/shield_capacitor"
+	build_path = /obj/machinery/shield_capacitor
 	origin_tech = Tc_MAGNETS + "=3;" + Tc_POWERSTORAGE + "=4"
 	req_components = list(
 							"/obj/item/weapon/stock_parts/capacitor" = 2,

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -41,16 +41,16 @@
 /obj/item/weapon/circuitboard/message_monitor
 	name = "Circuit board (Message Monitor)"
 	desc = "A circuit board for running a computer used for telecommunications monitoring."
-	build_path = "/obj/machinery/computer/message_monitor"
+	build_path = /obj/machinery/computer/message_monitor
 	origin_tech = Tc_PROGRAMMING + "=3"
 /obj/item/weapon/circuitboard/security
 	name = "Circuit board (Security Cameras)"
 	desc = "A circuit board for running a computer used for viewing security cameras."
-	build_path = "/obj/machinery/computer/security"
+	build_path = /obj/machinery/computer/security
 /obj/item/weapon/circuitboard/security/engineering
 	name = "Circuit board (Engineering Cameras)"
 	desc = "A circuit board for running a computer used for viewing engineering cameras."
-	build_path = "/obj/machinery/computer/security/engineering"
+	build_path = /obj/machinery/computer/security/engineering
 /obj/item/weapon/circuitboard/aicore
 	name = "Circuit board (AI core)"
 	desc = "A circuit board that allows the intelligence in an AI core to interface with the world around it."
@@ -59,281 +59,277 @@
 /obj/item/weapon/circuitboard/aiupload
 	name = "Circuit board (AI Upload)"
 	desc = "A circuit board for running a computer used for modifying AI laws."
-	build_path = "/obj/machinery/computer/aiupload"
+	build_path = /obj/machinery/computer/aiupload
 	origin_tech = Tc_PROGRAMMING + "=4"
 /obj/item/weapon/circuitboard/aiupload/longrange
 	name = "Circuit board (Long Range AI Upload)"
 	desc = "A circuit board for running a computer used for modifying AI laws."
-	build_path = "/obj/machinery/computer/aiupload/longrange"
+	build_path = /obj/machinery/computer/aiupload/longrange
 	origin_tech = Tc_PROGRAMMING + "=4" + Tc_MATERIALS + "=9" + Tc_BLUESPACE + "=3" + Tc_MAGNETS + "=5"
 /obj/item/weapon/circuitboard/borgupload
 	name = "Circuit board (Cyborg Upload)"
 	desc = "A circuit board for running a computer used for modifying cyborg laws."
-	build_path = "/obj/machinery/computer/borgupload"
+	build_path = /obj/machinery/computer/borgupload
 	origin_tech = Tc_PROGRAMMING + "=4"
 /obj/item/weapon/circuitboard/med_data
 	name = "Circuit board (Medical Records)"
 	desc = "A circuit board for running a computer used for viewing medical records."
-	build_path = "/obj/machinery/computer/med_data"
+	build_path = /obj/machinery/computer/med_data
 /obj/item/weapon/circuitboard/pandemic
 	name = "Circuit board (PanD.E.M.I.C. 2200)"
 	desc = "A circuit board for running a computer used in Virology."
-	build_path = "/obj/machinery/computer/pandemic"
+	build_path = /obj/machinery/computer/pandemic
 	origin_tech = Tc_PROGRAMMING + "=2;" + Tc_BIOTECH + "=2"
 /obj/item/weapon/circuitboard/scan_consolenew
 	name = "Circuit board (DNA Machine)"
 	desc = "A circuit board for running a computer used in Genetics."
-	build_path = "/obj/machinery/computer/scan_consolenew"
+	build_path = /obj/machinery/computer/scan_consolenew
 	origin_tech = Tc_PROGRAMMING + "=2;" + Tc_BIOTECH + "=2"
 /obj/item/weapon/circuitboard/communications
 	name = "Circuit board (Communications)"
 	desc = "A circuit board for running a computer used to communicate with Central Command."
-	build_path = "/obj/machinery/computer/communications"
+	build_path = /obj/machinery/computer/communications
 	origin_tech = Tc_PROGRAMMING + "=2;" + Tc_MAGNETS + "=2"
 /obj/item/weapon/circuitboard/card
 	name = "Circuit board (ID Computer)"
 	desc = "A circuit board for running a computer used for modifying access on ID cards."
-	build_path = "/obj/machinery/computer/card"
+	build_path = /obj/machinery/computer/card
 /obj/item/weapon/circuitboard/card/centcom
 	name = "Circuit board (CentCom ID Computer)"
 	desc = "A circuit board for running a computer used for granting access to areas at Central Command.."
-	build_path = "/obj/machinery/computer/card/centcom"
+	build_path = /obj/machinery/computer/card/centcom
 //obj/item/weapon/circuitboard/shield
 //	name = "Circuit board (Shield Control)"
-//	build_path = "/obj/machinery/computer/stationshield"
+//	build_path = /obj/machinery/computer/stationshield
 /obj/item/weapon/circuitboard/teleporter
 	name = "Circuit board (Teleporter)"
-	build_path = "/obj/machinery/computer/teleporter"
+	build_path = /obj/machinery/computer/teleporter
 	desc = "A circuit board for running a computer used for selecting teleporter locations."
 	origin_tech = Tc_PROGRAMMING + "=2;" + Tc_BLUESPACE + "=2"
 /obj/item/weapon/circuitboard/secure_data
 	name = "Circuit board (Security Records)"
 	desc = "A circuit board for running a computer used for viewing security records."
-	build_path = "/obj/machinery/computer/secure_data"
+	build_path = /obj/machinery/computer/secure_data
 /obj/item/weapon/circuitboard/stationalert
 	name = "Circuit board (Station Alerts)"
 	desc = "A circuit board for running a computer used for viewing station alerts."
-	build_path = "/obj/machinery/computer/station_alert"
+	build_path = /obj/machinery/computer/station_alert
 /*/obj/item/weapon/circuitboard/atmospheresiphonswitch
 	name = "Circuit board (Atmosphere siphon control)"
-	build_path = "/obj/machinery/computer/atmosphere/siphonswitch"*/
+	build_path = /obj/machinery/computer/atmosphere/siphonswitch*/
 /obj/item/weapon/circuitboard/air_management
 	name = "Circuit board (Atmospheric General Monitor)"
 	desc = "A circuit board for running a computer used for monitoring amospherical sensor inputs."
-	build_path = "/obj/machinery/computer/general_air_control"
+	build_path = /obj/machinery/computer/general_air_control
 /obj/item/weapon/circuitboard/atmos_automation
 	name = "Circuit board (Atmospherics Automation)"
 	desc = "A circuit board for running a computer used for automating atmospherical devices, such as valves."
-	build_path = "/obj/machinery/computer/general_air_control/atmos_automation"
+	build_path = /obj/machinery/computer/general_air_control/atmos_automation
 /obj/item/weapon/circuitboard/large_tank_control
 	name = "Circuit board (Atmospheric Tank Control)"
 	desc = "A circuit board for running a computer used for monitoring atmosphere in the gas tank chambers."
-	build_path = "/obj/machinery/computer/general_air_control/large_tank_control"
+	build_path = /obj/machinery/computer/general_air_control/large_tank_control
 /obj/item/weapon/circuitboard/injector_control
 	name = "Circuit board (Injector control)"
 	desc = "A circuit board for running an obsolete computer used for injecting fuel."
-	build_path = "/obj/machinery/computer/general_air_control/fuel_injection"
+	build_path = /obj/machinery/computer/general_air_control/fuel_injection
 /obj/item/weapon/circuitboard/atmos_alert
 	name = "Circuit board (Atmospheric Alert)"
 	desc = "A circuit board for running a computer used for viewing air alarm alerts."
-	build_path = "/obj/machinery/computer/atmos_alert"
+	build_path = /obj/machinery/computer/atmos_alert
 /obj/item/weapon/circuitboard/pod
 	name = "Circuit board (Massdriver control)"
 	desc = "A circuit board for running a computer used for controlling mass drivers and blast doors."
-	build_path = "/obj/machinery/computer/pod"
-/obj/item/weapon/circuitboard/pod/deathsquad
-	name = "Circuit board (Deathsquad Massdriver control)"
-	desc = "A circuit board for running a computer used for controlling mass drivers and blast doors. This one is pre-configured for Central Command usage.?"
-	build_path = "/obj/machinery/computer/pod/deathsquad"
+	build_path = /obj/machinery/computer/pod
 /obj/item/weapon/circuitboard/robotics
 	name = "Circuit board (Robotics Control)"
 	desc = "A circuit board for running a computer used for monitoring and locking or destroying cyborgs."
-	build_path = "/obj/machinery/computer/robotics"
+	build_path = /obj/machinery/computer/robotics
 	origin_tech = Tc_PROGRAMMING + "=3"
 /obj/item/weapon/circuitboard/cloning
 	name = "Circuit board (Cloning Console)"
 	desc = "A circuit board for running a computer used for saving and applying cloning records."
-	build_path = "/obj/machinery/computer/cloning"
+	build_path = /obj/machinery/computer/cloning
 	origin_tech = Tc_PROGRAMMING + "=3;" + Tc_BIOTECH + "=3"
 /obj/item/weapon/circuitboard/arcade
 	name = "Circuit board (Arcade)"
 	desc = "A circuit board for running a computer used for the popular 'Random Encounter!' series videogames."
-	build_path = "/obj/machinery/computer/arcade"
+	build_path = /obj/machinery/computer/arcade
 	origin_tech = Tc_PROGRAMMING + "=1"
 	var/list/game_data = list()
 /obj/item/weapon/circuitboard/turbine_control
 	name = "Circuit board (Turbine control)"
 	desc = "A circuit board for running an obsolete computer used for controlling a gas turbine."
-	build_path = "/obj/machinery/computer/turbine_computer"
+	build_path = /obj/machinery/computer/turbine_computer
 /obj/item/weapon/circuitboard/solar_control
 	name = "Circuit board (Solar Control)"  //name fixed 250810
 	desc = "A circuit board for running a computer used for monitoring solar panel rotation and output."
-	build_path = "/obj/machinery/power/solar/control"
+	build_path = /obj/machinery/power/solar/control
 	origin_tech = Tc_PROGRAMMING + "=2;" + Tc_POWERSTORAGE + "=2"
 /obj/item/weapon/circuitboard/powermonitor
 	name = "Circuit board (Power Monitor)"  //name fixed 250810
 	desc = "A circuit board for running a computer used for monitoring power generation, load and demand."
-	build_path = "/obj/machinery/power/monitor"
+	build_path = /obj/machinery/power/monitor
 /obj/item/weapon/circuitboard/olddoor
 	name = "Circuit board (DoorMex)"
 	desc = "A circuit board for running a very outdated computer used for opening doors."
-	build_path = "/obj/machinery/computer/pod/old"
+	build_path = /obj/machinery/computer/pod/old
 /obj/item/weapon/circuitboard/syndicatedoor
 	name = "Circuit board (ProComp Executive)"
 	desc = "A circuit board for running a very outdated computer used for opening doors. A tag on it says \"Property of Cybersun Industries\"."
-	build_path = "/obj/machinery/computer/pod/old/syndicate"
+	build_path = /obj/machinery/computer/pod/old/syndicate
 /obj/item/weapon/circuitboard/swfdoor
 	name = "Circuit board (Magix)"
 	desc = "A circuit board for running a very outdated computer used for opening doors. A tag on it says \"Federation Use Only\"."
-	build_path = "/obj/machinery/computer/pod/old/swf"
+	build_path = /obj/machinery/computer/pod/old/swf
 /obj/item/weapon/circuitboard/prisoner
 	name = "Circuit board (Prisoner Management)"
 	desc = "A circuit board for running a computer used for monitoring and manipulating prisoner implants."
-	build_path = "/obj/machinery/computer/prisoner"
+	build_path = /obj/machinery/computer/prisoner
 
 /obj/item/weapon/circuitboard/rdconsole
 	name = "Circuit Board (R&D Console)"
 	desc = "A circuit board for running the core computer used in Research and Development."
-	build_path = "/obj/machinery/computer/rdconsole/core"
+	build_path = /obj/machinery/computer/rdconsole/core
 /obj/item/weapon/circuitboard/rdconsole/mommi
 	name = "Circuit Board (MoMMI R&D Console)"
 	desc = "A circuit board for running a R&D console for Mobile MMIs."
-	build_path = "/obj/machinery/computer/rdconsole/mommi"
+	build_path = /obj/machinery/computer/rdconsole/mommi
 /obj/item/weapon/circuitboard/rdconsole/robotics
 	name = "Circuit Board (Robotics R&D Console)"
 	desc = "A circuit board for running a R&D console for Robotics."
-	build_path = "/obj/machinery/computer/rdconsole/robotics"
+	build_path = /obj/machinery/computer/rdconsole/robotics
 /obj/item/weapon/circuitboard/rdconsole/mechanic
 	name = "Circuit Board (Mechanic R&D Console)"
 	desc = "A circuit board for running a R&D console for Mechanics."
-	build_path = "/obj/machinery/computer/rdconsole/mechanic"
+	build_path = /obj/machinery/computer/rdconsole/mechanic
 /obj/item/weapon/circuitboard/rdconsole/pod
 	name = "Circuit Board (Pod Bay R&D Console)"
 	desc = "A circuit board for running a R&D console for the Pod Bay."
-	build_path = "/obj/machinery/computer/rdconsole/pod"
+	build_path = /obj/machinery/computer/rdconsole/pod
 
 /obj/item/weapon/circuitboard/mecha_control
 	name = "Circuit Board (Exosuit Control Console)"
 	desc = "A circuit board for running a computer used to monitor and remotely lock exosuits."
-	build_path = "/obj/machinery/computer/mecha"
+	build_path = /obj/machinery/computer/mecha
 /obj/item/weapon/circuitboard/rdservercontrol
 	name = "Circuit Board (R&D Server Control)"
 	desc = "A circuit board for running a computer used to monitor and delete research data."
-	build_path = "/obj/machinery/computer/rdservercontrol"
+	build_path = /obj/machinery/computer/rdservercontrol
 /obj/item/weapon/circuitboard/crew
 	name = "Circuit board (Crew monitoring computer)"
 	desc = "A circuit board for running a computer used to monitor suit sensor data."
-	build_path = "/obj/machinery/computer/crew"
+	build_path = /obj/machinery/computer/crew
 	origin_tech = Tc_PROGRAMMING + "=3;" + Tc_BIOTECH + "=2;" + Tc_MAGNETS + "=2"
 /obj/item/weapon/circuitboard/mech_bay_power_console
 	name = "Circuit board (Mech Bay Power Control Console)"
 	desc = "A circuit board for running a computer used to monitor exosuit cell charging."
-	build_path = "/obj/machinery/computer/mech_bay_power_console"
+	build_path = /obj/machinery/computer/mech_bay_power_console
 	origin_tech = Tc_PROGRAMMING + "=2;" + Tc_POWERSTORAGE + "=3"
 /obj/item/weapon/circuitboard/ordercomp
 	name = "Circuit board (Supply ordering console)"
 	desc = "A circuit board for running a computer used to order items from Cargo."
-	build_path = "/obj/machinery/computer/ordercomp"
+	build_path = /obj/machinery/computer/ordercomp
 	origin_tech = Tc_PROGRAMMING + "=2"
 /obj/item/weapon/circuitboard/supplycomp
 	name = "Circuit board (Supply shuttle console)"
 	desc = "A circuit board for running a computer used by Cargo to order items and call the Supply Shuttle."
-	build_path = "/obj/machinery/computer/supplycomp"
+	build_path = /obj/machinery/computer/supplycomp
 	origin_tech = Tc_PROGRAMMING + "=3"
 	var/contraband_enabled = 0
 /obj/item/weapon/circuitboard/operating
 	name = "Circuit board (Operating Computer)"
 	desc = "A circuit board for running a computer used to monitor patients during surgery."
-	build_path = "/obj/machinery/computer/operating"
+	build_path = /obj/machinery/computer/operating
 	origin_tech = Tc_PROGRAMMING + "=2;" + Tc_BIOTECH + "=2"
 /obj/item/weapon/circuitboard/mining
 	name = "Circuit board (Mining Outpost Cameras)"
 	desc = "A circuit board for running a computer used to view Mining Outpost cameras."
-	build_path = "/obj/machinery/computer/security/mining"
+	build_path = /obj/machinery/computer/security/mining
 	origin_tech = Tc_PROGRAMMING + "=2"
 /obj/item/weapon/circuitboard/comm_monitor
 	name = "Circuit board (Telecommunications Monitor)"
 	desc = "A circuit board for running a computer used to view the entities and links between entities in a telecommunications network."
-	build_path = "/obj/machinery/computer/telecomms/monitor"
+	build_path = /obj/machinery/computer/telecomms/monitor
 	origin_tech = Tc_PROGRAMMING + "=3"
 /obj/item/weapon/circuitboard/comm_server
 	name = "Circuit board (Telecommunications Server Monitor)"
 	desc = "A circuit board for running a computer used to view active telecommunications servers and their message logs."
-	build_path = "/obj/machinery/computer/telecomms/server"
+	build_path = /obj/machinery/computer/telecomms/server
 	origin_tech = Tc_PROGRAMMING + "=3"
 /obj/item/weapon/circuitboard/comm_traffic
 	name = "Circuitboard (Telecommunications Traffic Control)"
 	desc = "A circuit board for running a computer used to manipulate telecommunications traffic."
-	build_path = "/obj/machinery/computer/telecomms/traffic"
+	build_path = /obj/machinery/computer/telecomms/traffic
 	origin_tech = Tc_PROGRAMMING + "=3"
 
 /obj/item/weapon/circuitboard/curefab
 	name = "Circuit board (Cure fab)"
 	desc = "A circuit board for running a computer used to fabricate cures for virusses."
-	build_path = "/obj/machinery/computer/curer"
+	build_path = /obj/machinery/computer/curer
 /obj/item/weapon/circuitboard/splicer
 	name = "Circuit board (Disease Splicer)"
 	desc = "A circuit board for running a computer used to splice DNA strands in virusses."
-	build_path = "/obj/machinery/computer/diseasesplicer"
+	build_path = /obj/machinery/computer/diseasesplicer
 	origin_tech = Tc_PROGRAMMING + "=3;" + Tc_BIOTECH + "=4"
 
 /obj/item/weapon/circuitboard/shuttle_control
 	name = "Circuit board (Shuttle Control)"
 	desc = "A circuit board for running a computer used to control space shuttles."
-	build_path = "/obj/machinery/computer/shuttle_control"
+	build_path = /obj/machinery/computer/shuttle_control
 	origin_tech = Tc_PROGRAMMING + "=3;" + Tc_ENGINEERING + "=2"
 
 /obj/item/weapon/circuitboard/HolodeckControl // Not going to let people get this, but it's just here for future
 	name = "Circuit board (Holodeck Control)"
 	desc = "A circuit board for running a computer used to control the holodeck."
-	build_path = "/obj/machinery/computer/HolodeckControl"
+	build_path = /obj/machinery/computer/HolodeckControl
 	origin_tech = Tc_PROGRAMMING + "=4"
 /obj/item/weapon/circuitboard/aifixer
 	name = "Circuit board (AI Integrity Restorer)"
 	desc = "A circuit board for running a computer used to restore the integrity of a destroyed AI."
-	build_path = "/obj/machinery/computer/aifixer"
+	build_path = /obj/machinery/computer/aifixer
 	origin_tech = Tc_PROGRAMMING + "=3;" + Tc_BIOTECH + "=2"
 /obj/item/weapon/circuitboard/area_atmos
 	name = "Circuit board (Area Air Control)"
 	desc = "A circuit board for running a computer used to operate large scrubbers in the vicinity."
-	build_path = "/obj/machinery/computer/area_atmos"
+	build_path = /obj/machinery/computer/area_atmos
 	origin_tech = Tc_PROGRAMMING + "=2"
 /obj/item/weapon/circuitboard/prison_shuttle
 	name = "Circuit board (Prison Shuttle)"
 	desc = "A circuit board for running an obsolete computer used to control the prison shuttle on an ancient station."
-	build_path = "/obj/machinery/computer/prison_shuttle"
+	build_path = /obj/machinery/computer/prison_shuttle
 	origin_tech = Tc_PROGRAMMING + "=2"
 /obj/item/weapon/circuitboard/bhangmeter
 	name = "Circuit board (Bhangmeter)"
 	desc = "A circuit board for running a computer used to monitor the locations and intensity of explosions."
-	build_path = "/obj/machinery/computer/bhangmeter"
+	build_path = /obj/machinery/computer/bhangmeter
 	origin_tech = Tc_PROGRAMMING + "=2"
 /obj/item/weapon/circuitboard/telesci_computer
 	name = "Circuit board (Telepad Control Console)"
 	desc = "A circuit board for running a computer used to operate the Telescience Telepad."
-	build_path = "/obj/machinery/computer/telescience"
+	build_path = /obj/machinery/computer/telescience
 	origin_tech = Tc_PROGRAMMING + "=3;" + Tc_BLUESPACE + "=2"
 /obj/item/weapon/circuitboard/forensic_computer
 	name = "Circuit board (Forensics Console)"
 	desc = "A circuit board for running a computer used to scan objects and view data from portable scanners."
-	build_path = "/obj/machinery/computer/forensic_scanning"
+	build_path = /obj/machinery/computer/forensic_scanning
 	origin_tech = Tc_PROGRAMMING + "=2"
 /obj/item/weapon/circuitboard/pda_terminal
 	name = "Circuit board (PDA Terminal)"
 	desc = "A circuit board for running a computer used to download applications to PDAs."
-	build_path = "/obj/machinery/computer/pda_terminal"
+	build_path = /obj/machinery/computer/pda_terminal
 	origin_tech = Tc_PROGRAMMING + "=2"
 
 /obj/item/weapon/circuitboard/smeltcomp
 	name = "Circuit board (Ore Processing Console)"
 	desc = "A circuit board for running a computer used to operate ore smelting machines."
-	build_path = "/obj/machinery/computer/smelting"
+	build_path = /obj/machinery/computer/smelting
 	origin_tech = Tc_PROGRAMMING + "=2;" + Tc_MATERIALS + "=2"
 
 /obj/item/weapon/circuitboard/stacking_machine_console
 	name = "Circuit board (Stacking Machine Console)"
 	desc = "A circuit board for running a computer used to operate stacking machines."
-	build_path = "/obj/machinery/computer/stacking_unit"
+	build_path = /obj/machinery/computer/stacking_unit
 	origin_tech = Tc_PROGRAMMING + "=2;" + Tc_MATERIALS + "=2"
 
 /obj/item/weapon/circuitboard/attackby(obj/item/I as obj, mob/user as mob)

--- a/code/game/machinery/computer/camera_circuit.dm
+++ b/code/game/machinery/computer/camera_circuit.dm
@@ -7,7 +7,6 @@
 	var/authorised = 0
 	var/possibleNets[0]
 	var/network = ""
-	build_path = 0
 
 //when adding a new camera network, you should only need to update these two procs
 	New()
@@ -19,21 +18,21 @@
 		possibleNets[CAMERANET_MEDBAY] = access_cmo
 
 	proc/updateBuildPath()
-		build_path = ""
+		build_path = null
 		if(authorised && secured)
 			switch(network)
 				if(CAMERANET_SS13)
-					build_path = "/obj/machinery/computer/security"
+					build_path = /obj/machinery/computer/security
 				if(CAMERANET_ENGI)
-					build_path = "/obj/machinery/computer/security/engineering"
+					build_path = /obj/machinery/computer/security/engineering
 				if(CAMERANET_MINE)
-					build_path = "/obj/machinery/computer/security/mining"
+					build_path = /obj/machinery/computer/security/mining
 				if(CAMERANET_SCIENCE)
-					build_path = "/obj/machinery/computer/security/research"
+					build_path = /obj/machinery/computer/security/research
 				if(CAMERANET_MEDBAY)
-					build_path = "/obj/machinery/computer/security/medbay"
+					build_path = /obj/machinery/computer/security/medbay
 				if(CAMERANET_CARGO)
-					build_path = "/obj/machinery/computer/security/cargo"
+					build_path = /obj/machinery/computer/security/cargo
 
 	attackby(var/obj/item/I, var/mob/user)//if(health > 50)
 		..()

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -354,7 +354,7 @@ to destroy them and players will be able to make replacements.
 /obj/item/weapon/circuitboard/destructive_analyzer
 	name = "Circuit board (Destructive Analyzer)"
 	desc = "A circuit board used to run a machine that destroys objects to extract structural information for research."
-	build_path = "/obj/machinery/r_n_d/destructive_analyzer"
+	build_path = /obj/machinery/r_n_d/destructive_analyzer
 	board_type = MACHINE
 	origin_tech = Tc_MAGNETS + "=2;" + Tc_ENGINEERING + "=2;" + Tc_PROGRAMMING + "=3"
 	req_components = list(
@@ -365,7 +365,7 @@ to destroy them and players will be able to make replacements.
 /obj/item/weapon/circuitboard/autolathe
 	name = "Circuit board (Autolathe)"
 	desc = "A circuit board used to run a machine that fabricates various general-purpose gadgets and tools."
-	build_path = "/obj/machinery/r_n_d/fabricator/mechanic_fab/autolathe"
+	build_path = /obj/machinery/r_n_d/fabricator/mechanic_fab/autolathe
 	board_type = MACHINE
 	origin_tech = Tc_ENGINEERING + "=2;" + Tc_PROGRAMMING + "=2"
 	req_components = list(
@@ -376,7 +376,7 @@ to destroy them and players will be able to make replacements.
 /obj/item/weapon/circuitboard/protolathe
 	name = "Circuit board (Protolathe)"
 	desc = "A circuit board used to run a machine that fabricates various cutting-edge gadgets and tools."
-	build_path = "/obj/machinery/r_n_d/fabricator/protolathe"
+	build_path = /obj/machinery/r_n_d/fabricator/protolathe
 	board_type = MACHINE
 	origin_tech = Tc_ENGINEERING + "=2;" + Tc_PROGRAMMING + "=3"
 	req_components = list(
@@ -386,7 +386,7 @@ to destroy them and players will be able to make replacements.
 /obj/item/weapon/circuitboard/circuit_imprinter
 	name = "Circuit board (Circuit Imprinter)"
 	desc = "A circuit board used to run a machine that fabricates circuit boards. How recursive."
-	build_path = "/obj/machinery/r_n_d/fabricator/circuit_imprinter"
+	build_path = /obj/machinery/r_n_d/fabricator/circuit_imprinter
 	board_type = MACHINE
 	origin_tech = Tc_ENGINEERING + "=2;" + Tc_PROGRAMMING + "=2"
 	req_components = list(
@@ -397,7 +397,7 @@ to destroy them and players will be able to make replacements.
 /obj/item/weapon/circuitboard/pacman
 	name = "Circuit Board (PACMAN-type Generator)"
 	desc = "A circuit board used to run a machine that converts plasma into electricity."
-	build_path = "/obj/machinery/power/port_gen/pacman"
+	build_path = /obj/machinery/power/port_gen/pacman
 	board_type = MACHINE
 	origin_tech = Tc_PROGRAMMING + "=3;" + Tc_POWERSTORAGE + "=3;" + Tc_PLASMATECH + "=3;" + Tc_ENGINEERING + "=3"
 	req_components = list(
@@ -408,13 +408,13 @@ to destroy them and players will be able to make replacements.
 /obj/item/weapon/circuitboard/pacman/super
 	name = "Circuit Board (SUPERPACMAN-type Generator)"
 	desc = "A circuit board used to run a machine that converts uranium into electricity."
-	build_path = "/obj/machinery/power/port_gen/pacman/super"
+	build_path = /obj/machinery/power/port_gen/pacman/super
 	origin_tech = Tc_PROGRAMMING + "=3;" + Tc_POWERSTORAGE + "=4;" + Tc_ENGINEERING + "=4"
 
 /obj/item/weapon/circuitboard/pacman/mrs
 	name = "Circuit Board (MRSPACMAN-type Generator)"
 	desc = "A circuit board used to run a machine that converts diamonds into electricity."
-	build_path = "/obj/machinery/power/port_gen/pacman/mrs"
+	build_path = /obj/machinery/power/port_gen/pacman/mrs
 	origin_tech = Tc_PROGRAMMING + "=3;" + Tc_POWERSTORAGE + "=5;" + Tc_ENGINEERING + "=5"
 
 /obj/item/weapon/circuitboard/air_alarm
@@ -444,7 +444,7 @@ to destroy them and players will be able to make replacements.
 obj/item/weapon/circuitboard/rdserver
 	name = "Circuit Board (R&D Server)"
 	desc = "A circuit board used to run a R&D server."
-	build_path = "/obj/machinery/r_n_d/server"
+	build_path = /obj/machinery/r_n_d/server
 	board_type = MACHINE
 	origin_tech = Tc_PROGRAMMING + "=3"
 	req_components = list(
@@ -454,7 +454,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/mechfab
 	name = "Circuit board (Exosuit Fabricator)"
 	desc = "A circuit board used to run a robotics fabricator."
-	build_path = "/obj/machinery/r_n_d/fabricator/mech"
+	build_path = /obj/machinery/r_n_d/fabricator/mech
 	board_type = MACHINE
 	origin_tech = Tc_PROGRAMMING + "=3;" + Tc_ENGINEERING + "=3"
 	req_components = list(
@@ -466,7 +466,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/podfab
 	name = "Circuit board (Spacepod Fabricator)"
 	desc = "A circuit board used to run a spacepod fabricator."
-	build_path = "/obj/machinery/r_n_d/fabricator/pod"
+	build_path = /obj/machinery/r_n_d/fabricator/pod
 	board_type = MACHINE
 	origin_tech = Tc_PROGRAMMING + "=3;" + Tc_ENGINEERING + "=3"
 	req_components = list(
@@ -477,7 +477,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/defib_recharger
 	name = "Circuit Board (Defib Recharger)"
 	desc = "A circuit board used to run a defibrillator recharger."
-	build_path = "/obj/machinery/recharger/defibcharger/wallcharger"
+	build_path = /obj/machinery/recharger/defibcharger/wallcharger
 	board_type = MACHINE
 	origin_tech = Tc_PROGRAMMING + "=3;" + Tc_BIOTECH + "=4;" + Tc_ENGINEERING + "=2;" + Tc_POWERSTORAGE + "=2"
 	req_components = list(
@@ -489,7 +489,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/smes
 	name = "Circuit Board (SMES)"
 	desc = "A circuit board used to run a giant battery."
-	build_path = "/obj/machinery/power/battery/smes/pristine"
+	build_path = /obj/machinery/power/battery/smes/pristine
 	board_type = MACHINE
 	origin_tech = Tc_POWERSTORAGE + "=4;" + Tc_ENGINEERING + "=4;" + Tc_PROGRAMMING + "=4"
 	req_components = list(
@@ -500,7 +500,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/port_smes
 	name = "Circuit Board (Portable SMES)"
 	desc = "A circuit board used to run a giant portable battery."
-	build_path = "/obj/machinery/power/battery/portable"
+	build_path = /obj/machinery/power/battery/portable
 	board_type = MACHINE
 	origin_tech = Tc_POWERSTORAGE + "=5;" + Tc_ENGINEERING + "=4;" + Tc_PROGRAMMING + "=4"
 	req_components = list(
@@ -511,7 +511,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/battery_port
 	name = "Circuit Board (SMES Port)"
 	desc = "A circuit board used to run the base station for a giant portable battery."
-	build_path = "/obj/machinery/power/battery_port"
+	build_path = /obj/machinery/power/battery_port
 	board_type = MACHINE
 	origin_tech = Tc_POWERSTORAGE + "=5;" + Tc_ENGINEERING + "=4;" + Tc_PROGRAMMING + "=4"
 	req_components = list(
@@ -521,7 +521,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/treadmill
 	name = "Circuit Board (Treadmill Generator)"
 	desc = "A circuit board used to run a machine that converts kinetic energy into power."
-	build_path = "/obj/machinery/power/treadmill"
+	build_path = /obj/machinery/power/treadmill
 	board_type = MACHINE
 	origin_tech = Tc_ENGINEERING + "=2;" + Tc_POWERSTORAGE + "=4"
 	req_components = list (
@@ -531,7 +531,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/chemheater
 	name = "Circuit Board (Directed Laser Heater)"
 	desc = "A circuit board used to run a container heating device."
-	build_path = "/obj/machinery/chemheater"
+	build_path = /obj/machinery/chemheater
 	board_type = MACHINE
 	origin_tech = Tc_BIOTECH + "=4;" + Tc_ENGINEERING + "=3;" + Tc_POWERSTORAGE + "=4"
 	req_components = list (
@@ -541,7 +541,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/chemcooler
 	name = "Circuit Board (Cryonic Wave Projector)"
 	desc = "A circuit board used to run a container cooling device."
-	build_path = "/obj/machinery/chemcooler"
+	build_path = /obj/machinery/chemcooler
 	board_type = MACHINE
 	origin_tech = Tc_BIOTECH + "=4;" + Tc_ENGINEERING + "=3;" + Tc_POWERSTORAGE + "=4"
 	req_components = list (
@@ -551,7 +551,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/chem_dispenser
 	name = "Circuit Board (Chemistry Dispenser)"
 	desc = "A circuit board used to run a reagent dispensing machine."
-	build_path = "/obj/machinery/chem_dispenser"
+	build_path = /obj/machinery/chem_dispenser
 	board_type = MACHINE
 	origin_tech = Tc_PROGRAMMING + "=3;" + Tc_BIOTECH + "=5;" + Tc_ENGINEERING + "=4"
 	req_components = list (
@@ -563,22 +563,22 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/chem_dispenser/brewer
 	name = "Circuit Board (Brewer)"
 	desc = "A circuit board used to run a coffee and tea dispensing machine."
-	build_path = "/obj/machinery/chem_dispenser/brewer"
+	build_path = /obj/machinery/chem_dispenser/brewer
 
 /obj/item/weapon/circuitboard/chem_dispenser/soda_dispenser
 	name = "Circuit Board (Soda Dispenser)"
 	desc = "A circuit board used to run a soda dispensing machine."
-	build_path = "/obj/machinery/chem_dispenser/soda_dispenser"
+	build_path = /obj/machinery/chem_dispenser/soda_dispenser
 
 /obj/item/weapon/circuitboard/chem_dispenser/booze_dispenser
 	name = "Circuit Board (Booze Dispenser)"
 	desc = "A circuit board used to run an advanced bartending machine."
-	build_path = "/obj/machinery/chem_dispenser/booze_dispenser"
+	build_path = /obj/machinery/chem_dispenser/booze_dispenser
 
 /obj/item/weapon/circuitboard/chemmaster3000
 	name = "Circuit Board (ChemMaster 3000)"
 	desc = "A circuit board used to run a reagent pill and bottle making machine."
-	build_path = "/obj/machinery/chem_master"
+	build_path = /obj/machinery/chem_master
 	board_type = MACHINE
 	origin_tech = Tc_ENGINEERING + "=3;" + Tc_BIOTECH + "=4"
 	req_components = list (
@@ -590,7 +590,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/condimaster
 	name = "Circuit Board (CondiMaster)"
 	desc = "A circuit board used to run a condiment bottle making machine."
-	build_path = "/obj/machinery/chem_master/condimaster"
+	build_path = /obj/machinery/chem_master/condimaster
 	board_type = MACHINE
 	origin_tech = Tc_ENGINEERING + "=3;" + Tc_BIOTECH + "=4"
 	req_components = list (
@@ -602,7 +602,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/snackbar_machine
 	name = "Circuit Board (SnackBar Machine)"
 	desc = "A circuit board used to run a snackbar making machine."
-	build_path = "/obj/machinery/chem_master/snackbar_machine"
+	build_path = /obj/machinery/chem_master/snackbar_machine
 	board_type = MACHINE
 	origin_tech = Tc_ENGINEERING + "=3;" + Tc_BIOTECH + "=4"
 	req_components = list (
@@ -614,7 +614,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/recharge_station
 	name = "Circuit Board (Cyborg Recharging Station)"
 	desc = "A circuit board used to run a cyborg recharging station."
-	build_path = "/obj/machinery/recharge_station"
+	build_path = /obj/machinery/recharge_station
 	board_type = MACHINE
 	origin_tech = Tc_POWERSTORAGE + "=4;" + Tc_PROGRAMMING + "=3"
 	req_components = list (
@@ -625,7 +625,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/heater
 	name = "Circuit Board (Heater)"
 	desc = "A circuit board used to run a gas heater."
-	build_path = "/obj/machinery/atmospherics/unary/heat_reservoir/heater"
+	build_path = /obj/machinery/atmospherics/unary/heat_reservoir/heater
 	board_type = MACHINE
 	origin_tech = Tc_POWERSTORAGE + "=3;" + Tc_ENGINEERING + "=5;" + Tc_BIOTECH + "=4"
 	req_components = list (
@@ -635,7 +635,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/freezer
 	name = "Circuit Board (Freezer)"
 	desc = "A circuit board used to run a gas freezer."
-	build_path = "/obj/machinery/atmospherics/unary/cold_sink/freezer"
+	build_path = /obj/machinery/atmospherics/unary/cold_sink/freezer
 	board_type = MACHINE
 	origin_tech = Tc_POWERSTORAGE + "=3;" + Tc_ENGINEERING + "=4;" + Tc_BIOTECH + "=4"
 	req_components = list (
@@ -645,7 +645,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/photocopier
 	name = "Circuit Board (Photocopier)"
 	desc = "A circuit board used to run a photocopier."
-	build_path = "/obj/machinery/photocopier"
+	build_path = /obj/machinery/photocopier
 	board_type = MACHINE
 	origin_tech = Tc_ENGINEERING + "=2;" + Tc_PROGRAMMING + "=2"
 	req_components = list (
@@ -657,7 +657,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/cryo
 	name = "Circuit Board (Cryo)"
 	desc = "A circuit board used to run a medical cryogenics cell."
-	build_path = "/obj/machinery/atmospherics/unary/cryo_cell"
+	build_path = /obj/machinery/atmospherics/unary/cryo_cell
 	board_type = MACHINE
 	origin_tech = Tc_PROGRAMMING + "=3;" + Tc_BIOTECH + "=3;" + Tc_ENGINEERING + "=2"
 	req_components = list (
@@ -668,7 +668,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/clonepod
 	name = "Circuit board (Clone Pod)"
 	desc = "A circuit board used to run a medical cloning pod."
-	build_path = "/obj/machinery/cloning/clonepod"
+	build_path = /obj/machinery/cloning/clonepod
 	board_type = MACHINE
 	origin_tech = Tc_PROGRAMMING + "=3;" + Tc_BIOTECH + "=3"
 	req_components = list(
@@ -679,7 +679,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/clonescanner
 	name = "Circuit board (Cloning Scanner)"
 	desc = "A circuit board used to run a medical cloning scanner."
-	build_path = "/obj/machinery/dna_scannernew"
+	build_path = /obj/machinery/dna_scannernew
 	board_type = MACHINE
 	origin_tech = Tc_PROGRAMMING + "=3;" + Tc_BIOTECH + "=2"
 	req_components = list(
@@ -690,7 +690,7 @@ obj/item/weapon/circuitboard/rdserver
 
 /obj/item/weapon/circuitboard/fullbodyscanner
 	name = "Circuit board (Full Body Scanner)"
-	build_path = "/obj/machinery/bodyscanner"
+	build_path = /obj/machinery/bodyscanner
 	desc = "A circuit board used to run a medical bodyscanner."
 	board_type = MACHINE
 	origin_tech = Tc_BIOTECH + "=2"
@@ -700,7 +700,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/sleeper
 	name = "Circuit board (Sleeper)"
 	desc = "A circuit board used to run a medical sleeper."
-	build_path = "/obj/machinery/sleeper"
+	build_path = /obj/machinery/sleeper
 	board_type = MACHINE
 	origin_tech = Tc_BIOTECH + "=2"
 	req_components = list(
@@ -710,12 +710,12 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/sleeper/mancrowave
 	name = "Circuit board (Thermal Homeostasis Regulator)"
 	desc = "A circuit board used to run a general purpose kit- err, a medical re-heating apparatus."
-	build_path = "/obj/machinery/sleeper/mancrowave"
+	build_path = /obj/machinery/sleeper/mancrowave
 
 /obj/item/weapon/circuitboard/biogenerator
 	name = "Circuit Board (Biogenerator)"
 	desc = "A circuit board used to run a machine that converts biomatter into various useful items."
-	build_path = "/obj/machinery/biogenerator"
+	build_path = /obj/machinery/biogenerator
 	board_type = MACHINE
 	origin_tech = Tc_PROGRAMMING + "=3;" + Tc_ENGINEERING + "=2;" + Tc_BIOTECH + "=3"
 	req_components = list(
@@ -729,7 +729,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/seed_extractor
 	name = "Circuit Board (Seed Extractor)"
 	desc = "A circuit board used to run a machine that extracts and packets seeds from plants."
-	build_path = "/obj/machinery/seed_extractor"
+	build_path = /obj/machinery/seed_extractor
 	board_type = MACHINE
 	origin_tech = Tc_PROGRAMMING + "=2;" + Tc_BIOTECH + "=2"
 	req_components = list(
@@ -742,7 +742,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/microwave
 	name = "Circuit Board (Microwave)"
 	desc = "A circuit board used to run a general purpose kitchen appliance."
-	build_path = "/obj/machinery/microwave"
+	build_path = /obj/machinery/microwave
 	board_type = MACHINE
 	origin_tech = Tc_PROGRAMMING + "=2;" + Tc_ENGINEERING + "=2;" + Tc_MAGNETS + "=3"
 	req_components = list(
@@ -753,7 +753,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/reagentgrinder
 	name = "Circuit Board (All-In-One Grinder)"
 	desc = "A circuit board used to run a machine that grinds or juices solid items.."
-	build_path = "/obj/machinery/reagentgrinder"
+	build_path = /obj/machinery/reagentgrinder
 	board_type = MACHINE
 	origin_tech = Tc_PROGRAMMING + "=3;" + Tc_ENGINEERING + "=2"
 	req_components = list(
@@ -765,7 +765,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/smartfridge
 	name = "Circuit Board (SmartFridge)"
 	desc = "A circuit board used to run a machine that will hold grown plants, seeds, meat, and eggs."
-	build_path = "/obj/machinery/smartfridge"
+	build_path = /obj/machinery/smartfridge
 	board_type = MACHINE
 	origin_tech = Tc_PROGRAMMING + "=3;" + Tc_ENGINEERING + "=2"
 	req_components = list(
@@ -801,37 +801,37 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/smartfridge/medbay
 	name = "Circuit Board (Medbay SmartFridge)"
 	desc = "A circuit board used to run a machine that will hold beakers, pills and pill bottles."
-	build_path = "/obj/machinery/smartfridge/secure/medbay"
+	build_path = /obj/machinery/smartfridge/secure/medbay
 
 /obj/item/weapon/circuitboard/smartfridge/chemistry
 	name = "Circuit Board (Chemical SmartFridge)"
 	desc = "A circuit board used to run a machine that will hold beakers and pill bottles."
-	build_path = "/obj/machinery/smartfridge/chemistry"
+	build_path = /obj/machinery/smartfridge/chemistry
 
 /obj/item/weapon/circuitboard/smartfridge/extract
 	name = "Circuit Board (Extract SmartFridge)"
 	desc = "A circuit board used to run a machine that will hold slime extracts."
-	build_path = "/obj/machinery/smartfridge/extract"
+	build_path = /obj/machinery/smartfridge/extract
 
 /obj/item/weapon/circuitboard/smartfridge/seeds
 	name = "Circuit Board (Megaseed Servitor)"
 	desc = "A circuit board used to run a machine that will hold seed packets."
-	build_path = "/obj/machinery/smartfridge/seeds"
+	build_path = /obj/machinery/smartfridge/seeds
 
 /obj/item/weapon/circuitboard/smartfridge/drinks
 	name = "Circuit Board (Drinks Showcase)"
 	desc = "A circuit board used to run a machine that will hold glasses, drinks and condiments."
-	build_path = "/obj/machinery/smartfridge/drinks"
+	build_path = /obj/machinery/smartfridge/drinks
 
 /obj/item/weapon/circuitboard/smartfridge/bloodbank
 	name = "Circuit Board (Refrigerated Blood Bank)"
 	desc = "A circuit board used to run a machine that will hold blood packs."
-	build_path = "/obj/machinery/smartfridge/bloodbank"
+	build_path = /obj/machinery/smartfridge/bloodbank
 
 /obj/item/weapon/circuitboard/hydroponics
 	name = "Circuit Board (Hydroponics Tray)"
 	desc = "A circuit board used to run a machine that holds and nurtures plants."
-	build_path = "/obj/machinery/portable_atmospherics/hydroponics"
+	build_path = /obj/machinery/portable_atmospherics/hydroponics
 	board_type = MACHINE
 	origin_tech = Tc_PROGRAMMING + "=3;" + Tc_ENGINEERING + "=2;" + Tc_BIOTECH + "=3;" + Tc_POWERSTORAGE + "=2"
 	req_components = list(
@@ -844,7 +844,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/gibber
 	name = "Circuit Board (Gibber)"
 	desc = "A circuit board used to run a machine that turns live humanoids into pieces of meat."
-	build_path = "/obj/machinery/gibber"
+	build_path = /obj/machinery/gibber
 	board_type = MACHINE
 	origin_tech = Tc_PROGRAMMING + "=3;" + Tc_ENGINEERING + "=2;" + Tc_BIOTECH + "=3;" + Tc_POWERSTORAGE + "=2"
 	req_components = list(
@@ -857,7 +857,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/processor
 	name = "Circuit Board (Food Processor)"
 	desc = "A circuit board used to run a machine that improves and converts food ingredients."
-	build_path = "/obj/machinery/processor"
+	build_path = /obj/machinery/processor
 	board_type = MACHINE
 	origin_tech = Tc_PROGRAMMING + "=3;" + Tc_ENGINEERING + "=2;" + Tc_BIOTECH + "=3;" + Tc_POWERSTORAGE + "=2"
 	req_components = list(
@@ -867,7 +867,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/egg_incubator
 	name = "Circuit Board (Egg Incubator)"
 	desc = "A circuit board used to run a machine that incubates eggs."
-	build_path = "/obj/machinery/egg_incubator"
+	build_path = /obj/machinery/egg_incubator
 	board_type = MACHINE
 	origin_tech = Tc_BIOTECH + "=3"
 	req_components = list(
@@ -876,7 +876,7 @@ obj/item/weapon/circuitboard/rdserver
 
 /obj/item/weapon/circuitboard/box_cloner
 	name = "Circuit Board (Box Cloner)"
-	build_path = "/obj/machinery/egg_incubator/box_cloner"
+	build_path = /obj/machinery/egg_incubator/box_cloner
 	desc = "A circuit board used to run a machine that clones Boxen for meat and pet use."
 	origin_tech = Tc_SYNDICATE + "=3"
 	board_type = MACHINE
@@ -887,7 +887,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/monkey_recycler
 	name = "Circuit Board (Monkey Recycler)"
 	desc = "A circuit board used to run a machine that turns dead monkeys into monkey cubes."
-	build_path = "/obj/machinery/monkey_recycler"
+	build_path = /obj/machinery/monkey_recycler
 	board_type = MACHINE
 	origin_tech = Tc_PROGRAMMING + "=3;" + Tc_ENGINEERING + "=2;" + Tc_BIOTECH + "=3;" + Tc_POWERSTORAGE + "=2"
 	req_components = list(
@@ -898,7 +898,7 @@ obj/item/weapon/circuitboard/rdserver
 /*
 /obj/item/weapon/circuitboard/hydroseeds
 	name = "Circuit Board (MegaSeed Servitor)"
-	build_path = "/obj/machinery/vending/hydroseeds"
+	build_path = /obj/machinery/vending/hydroseeds
 	board_type = MACHINE
 	origin_tech = Tc_PROGRAMMING + "=3;" + Tc_ENGINEERING + "=2;" + Tc_BIOTECH + "=3;" + Tc_POWERSTORAGE + "=2"
 	req_components = list(
@@ -909,7 +909,7 @@ obj/item/weapon/circuitboard/rdserver
 
 /obj/item/weapon/circuitboard/hydronutrients
 	name = "Circuit Board (Nutrimax)"
-	build_path = "/obj/machinery/vending/hydronutrients"
+	build_path = /obj/machinery/vending/hydronutrients
 	board_type = MACHINE
 	origin_tech = Tc_PROGRAMMING + "=3;" + Tc_ENGINEERING + "=2;" + Tc_BIOTECH + "=3;" + Tc_POWERSTORAGE + "=2"
 	req_components = list(
@@ -922,7 +922,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/pipedispenser
 	name = "Circuit Board (Pipe Dispenser)"
 	desc = "A circuit board used to run a machine that fabricates atmospherical pipes and devices."
-	build_path = "/obj/machinery/pipedispenser"
+	build_path = /obj/machinery/pipedispenser
 	board_type = MACHINE
 	origin_tech = Tc_PROGRAMMING + "=3;" + Tc_ENGINEERING + "=2;" + Tc_BIOTECH + "=3;" + Tc_POWERSTORAGE + "=2"
 	req_components = list(
@@ -934,7 +934,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/pipedispenser/disposal
 	name = "Circuit Board (Disposal Pipe Dispenser)"
 	desc = "A circuit board used to run a machine that fabricates disposals pipes and devices."
-	build_path = "/obj/machinery/pipedispenser/disposal"
+	build_path = /obj/machinery/pipedispenser/disposal
 	board_type = MACHINE
 	origin_tech = Tc_PROGRAMMING + "=3;" + Tc_ENGINEERING + "=2;" + Tc_BIOTECH + "=3;" + Tc_POWERSTORAGE + "=2"
 	req_components = list(
@@ -950,7 +950,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/telehub
 	name = "Circuit Board (Teleporter Hub)"
 	desc = "A circuit board used to run a machine that works as the base for a teleporter."
-	build_path = "/obj/machinery/teleport/hub"
+	build_path = /obj/machinery/teleport/hub
 	board_type = MACHINE
 	origin_tech = Tc_PROGRAMMING + "=4;" + Tc_ENGINEERING + "=3;" + Tc_BLUESPACE + "=3"
 	req_components = list(
@@ -965,7 +965,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/telestation
 	name = "Circuit Board (Teleporter Station)"
 	desc = "A circuit board used to run a machine that generates an active teleportation field."
-	build_path = "/obj/machinery/teleport/station"
+	build_path = /obj/machinery/teleport/station
 	board_type = MACHINE
 	origin_tech = Tc_PROGRAMMING + "=4;" + Tc_ENGINEERING + "=3;" + Tc_BLUESPACE + "=3"
 	req_components = list(
@@ -979,7 +979,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/pda_multicaster
 	name = "Circuit Board (PDA multicaster)"
 	desc = "A circuit board used to run a machine that resends messages."
-	build_path = "/obj/machinery/pda_multicaster"
+	build_path = /obj/machinery/pda_multicaster
 	board_type = MACHINE
 	origin_tech = Tc_PROGRAMMING + "=4;" + Tc_ENGINEERING + "=3;" + Tc_BLUESPACE + "=2"
 	req_components = list(
@@ -989,7 +989,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/telecomms/receiver
 	name = "Circuit Board (telecommunications subspace receiver)"
 	desc = "A circuit board used to run a machine that receives subspace transmissions in telecommunications systems."
-	build_path = "/obj/machinery/telecomms/receiver"
+	build_path = /obj/machinery/telecomms/receiver
 	board_type = MACHINE
 	origin_tech = Tc_PROGRAMMING + "=4;" + Tc_ENGINEERING + "=3;" + Tc_BLUESPACE + "=2"
 	req_components = list(
@@ -1001,7 +1001,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/telecomms/hub
 	name = "Circuit Board (telecommunications hub)"
 	desc = "A circuit board used to run a machine that works as a hub for a telecommunications system."
-	build_path = "/obj/machinery/telecomms/hub"
+	build_path = /obj/machinery/telecomms/hub
 	board_type = MACHINE
 	origin_tech = Tc_PROGRAMMING + "=4;" + Tc_ENGINEERING + "=4"
 	req_components = list(
@@ -1011,7 +1011,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/telecomms/relay
 	name = "Circuit Board (telecommunications relay)"
 	desc = "A circuit board used to run a machine that works as a relay for a telecommunications system."
-	build_path = "/obj/machinery/telecomms/relay"
+	build_path = /obj/machinery/telecomms/relay
 	board_type = MACHINE
 	origin_tech = Tc_PROGRAMMING + "=3;" + Tc_ENGINEERING + "=4;" + Tc_BLUESPACE + "=3"
 	req_components = list(
@@ -1021,7 +1021,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/telecomms/bus
 	name = "Circuit Board (telecommunications bus)"
 	desc = "A circuit board used to run a machine that works as a bus for a telecommunications system."
-	build_path = "/obj/machinery/telecomms/bus"
+	build_path = /obj/machinery/telecomms/bus
 	board_type = MACHINE
 	origin_tech = Tc_PROGRAMMING + "=4;" + Tc_ENGINEERING + "=4"
 	req_components = list(
@@ -1031,7 +1031,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/telecomms/processor
 	name = "Circuit Board (telecommunications processor)"
 	desc = "A circuit board used to run a machine that works as a processing unit for a telecommunications system."
-	build_path = "/obj/machinery/telecomms/processor"
+	build_path = /obj/machinery/telecomms/processor
 	board_type = MACHINE
 	origin_tech = Tc_PROGRAMMING + "=4;" + Tc_ENGINEERING + "=4"
 	req_components = list(
@@ -1044,7 +1044,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/telecomms/server
 	name = "Circuit Board (telecommunications server)"
 	desc = "A circuit board used to run a machine that works as a frequency server for a telecommunications system."
-	build_path = "/obj/machinery/telecomms/server"
+	build_path = /obj/machinery/telecomms/server
 	board_type = MACHINE
 	origin_tech = Tc_PROGRAMMING + "=4;" + Tc_ENGINEERING + "=4"
 	req_components = list(
@@ -1054,7 +1054,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/telecomms/broadcaster
 	name = "Circuit Board (telecommunications subspace broadcaster)"
 	desc = "A circuit board used to run a machine that sends subspace transmissions in telecommunications systems."
-	build_path = "/obj/machinery/telecomms/broadcaster"
+	build_path = /obj/machinery/telecomms/broadcaster
 	board_type = MACHINE
 	origin_tech = Tc_PROGRAMMING + "=4;" + Tc_ENGINEERING + "=4;" + Tc_BLUESPACE + "=2"
 	req_components = list(
@@ -1066,7 +1066,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/bioprinter
 	name = "Circuit Board (Bioprinter)"
 	desc = "A circuit board used to run a machine that fabricates live organs."
-	build_path = "/obj/machinery/bioprinter"
+	build_path = /obj/machinery/bioprinter
 	board_type = MACHINE
 	origin_tech = Tc_PROGRAMMING + "=3;" + Tc_ENGINEERING + "=2;" + Tc_BIOTECH + "=3"
 	req_components = list(
@@ -1079,7 +1079,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/reverse_engine
 	name = "Circuit Board (Reverse Engine)"
 	desc = "A circuit board used to run a machine that analyzes designs from a device analyzer."
-	build_path = "/obj/machinery/r_n_d/reverse_engine"
+	build_path = /obj/machinery/r_n_d/reverse_engine
 	board_type = MACHINE
 	origin_tech = Tc_MATERIALS + "=6;" + Tc_PROGRAMMING + "=4;" + Tc_ENGINEERING + "=3;" + Tc_BLUESPACE + "=3;" + Tc_POWERSTORAGE + "=4"
 	req_components = list(
@@ -1091,7 +1091,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/generalfab
 	name = "Circuit Board (General Fabricator)"
 	desc = "A circuit board used to run a machine that loads blueprints to fabricate items."
-	build_path = "/obj/machinery/r_n_d/fabricator/mechanic_fab"
+	build_path = /obj/machinery/r_n_d/fabricator/mechanic_fab
 	board_type = MACHINE
 	origin_tech = Tc_MATERIALS + "=3;" + Tc_ENGINEERING + "=2;" + Tc_PROGRAMMING + "=3"
 	req_components = list(
@@ -1102,7 +1102,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/flatpacker
 	name = "Circuit Board (Flatpack Fabricator)"
 	desc = "A circuit board used to run a machine that loads blueprints to fabricate machines."
-	build_path = "/obj/machinery/r_n_d/fabricator/mechanic_fab/flatpacker"
+	build_path = /obj/machinery/r_n_d/fabricator/mechanic_fab/flatpacker
 	board_type = MACHINE
 	origin_tech = Tc_MATERIALS + "=5;" + Tc_ENGINEERING + "=4;" + Tc_POWERSTORAGE + "=3;" + Tc_PROGRAMMING + "=3"
 	req_components = list(
@@ -1115,7 +1115,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/blueprinter
 	name = "Circuit Board (Blueprint Printer)"
 	desc = "A circuit board used to run a machine that prints blueprints for the general and flatpack fabricators."
-	build_path = "/obj/machinery/r_n_d/blueprinter"
+	build_path = /obj/machinery/r_n_d/blueprinter
 	board_type = MACHINE
 	origin_tech = Tc_ENGINEERING + "=3;" + Tc_PROGRAMMING + "=3"
 	req_components = list(
@@ -1126,7 +1126,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/vendomat
 	name = "Circuit Board (Vending Machine)"
 	desc = "A circuit board used to run a machine that vends items."
-	build_path = "/obj/machinery/vending"
+	build_path = /obj/machinery/vending
 	board_type = MACHINE
 	origin_tech = Tc_MATERIALS + "=1;" + Tc_ENGINEERING + "=1;" + Tc_POWERSTORAGE + "=1"
 	req_components = list(
@@ -1137,7 +1137,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/pdapainter
 	name = "Circuit Board (PDA Painter)"
 	desc = "A circuit board used to run a machine that fabricates and re-colors PDAs."
-	build_path = "/obj/machinery/pdapainter"
+	build_path = /obj/machinery/pdapainter
 	board_type = MACHINE
 	origin_tech = Tc_PROGRAMMING + "=2;" + Tc_ENGINEERING + "=2"
 	req_components = list(
@@ -1149,7 +1149,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/incubator
 	name = "Circuit Board (Pathogenic Incubator)"
 	desc = "A circuit board used to run a machine that incubates viruses."
-	build_path = "/obj/machinery/disease2/incubator"
+	build_path = /obj/machinery/disease2/incubator
 	board_type = MACHINE
 	origin_tech = Tc_MATERIALS + "=4;" + Tc_BIOTECH + "=5;" + Tc_MAGNETS + "=3"
 	req_components = list(
@@ -1161,7 +1161,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/diseaseanalyser
 	name = "Circuit Board (Disease Analyser)"
 	desc = "A circuit board used to run a machine that analyzes diseases."
-	build_path = "/obj/machinery/disease2/diseaseanalyser"
+	build_path = /obj/machinery/disease2/diseaseanalyser
 	board_type = MACHINE
 	origin_tech = Tc_ENGINEERING + "=3;" + Tc_BIOTECH + "=3;" + Tc_PROGRAMMING + "=3"
 	req_components = list(
@@ -1172,7 +1172,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/centrifuge
 	name = "Circuit Board (Isolation Centrifuge)"
 	desc = "A circuit board used to run a machine that isolates pathogens and antibodies."
-	build_path = "/obj/machinery/centrifuge"
+	build_path = /obj/machinery/centrifuge
 	board_type = MACHINE
 	origin_tech = Tc_BIOTECH + "=3"
 	req_components = list(
@@ -1181,7 +1181,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/mech_bay_power_port
 	name = "Circuit Board (Power Port)"
 	desc = "A circuit board used to run a machine that supplies power to a recharge station."
-	build_path = "/obj/machinery/mech_bay_recharge_port"
+	build_path = /obj/machinery/mech_bay_recharge_port
 	board_type = MACHINE
 	origin_tech = Tc_ENGINEERING + "=2;" + Tc_POWERSTORAGE + "=3"
 	req_components = list(
@@ -1191,7 +1191,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/mech_bay_recharge_station
 	name = "Circuit Board (Recharge Station)"
 	desc = "A circuit board used to run a machine that charges exosuit power cells."
-	build_path = "/obj/machinery/mech_bay_recharge_floor"
+	build_path = /obj/machinery/mech_bay_recharge_floor
 	board_type = MACHINE
 	origin_tech = Tc_MATERIALS + "=2;" + Tc_POWERSTORAGE + "=3"
 	req_components = list(
@@ -1201,7 +1201,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/prism
 	name = "Circuit Board (Prism)"
 	desc = "A circuit board used to run a piece of glass."
-	build_path = "/obj/machinery/prism"
+	build_path = /obj/machinery/prism
 	board_type = MACHINE
 	origin_tech = Tc_PROGRAMMING + "=3;" + Tc_ENGINEERING + "=3;" + Tc_POWERSTORAGE + "=3"
 	req_components = list(
@@ -1211,7 +1211,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/cell_charger
 	name = "Circuit Board (Cell Charger)"
 	desc = "A circuit board used to run a small device that recharges power cells."
-	build_path = "/obj/machinery/cell_charger"
+	build_path = /obj/machinery/cell_charger
 	board_type = MACHINE
 	origin_tech = Tc_MATERIALS + "=2;" + Tc_ENGINEERING + "=2;" + Tc_POWERSTORAGE + "=3"
 	req_components = list(
@@ -1222,7 +1222,7 @@ obj/item/weapon/circuitboard/rdserver
 	name = "Circuit Board (Recharger)"
 	desc = "A circuit board used to run a machine that replenishes energy weapon charge"
 	board_type = MACHINE
-	build_path = "/obj/machinery/recharger"
+	build_path = /obj/machinery/recharger
 	origin_tech = Tc_POWERSTORAGE + "=2;" + Tc_COMBAT + "=2"
 	req_components = list(
 						"/obj/item/weapon/stock_parts/scanning_module" = 1,
@@ -1231,7 +1231,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/washing_machine
 	name = "Circuit Board (Washing Machine)"
 	desc = "A circuit board used to run a machine that cleans clothing and kills pets."
-	build_path = "/obj/machinery/washing_machine"
+	build_path = /obj/machinery/washing_machine
 	board_type = MACHINE
 	origin_tech = Tc_MATERIALS + "=1"
 	req_components = list(
@@ -1250,17 +1250,17 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/sorting_machine/recycling
 	name = "Circuit Board (Recycling Sorting Machine)"
 	desc = "A circuit board used to run a machine that sorts input into two outputs from pre-programmed settings. This one is programmed for recycling."
-	build_path = "/obj/machinery/sorting_machine/recycling"
+	build_path = /obj/machinery/sorting_machine/recycling
 
 /obj/item/weapon/circuitboard/sorting_machine/destination
 	name = "Circuit Board (Destinations Sorting Machine)"
 	desc = "A circuit board used to run a machine that sorts input into two outputs from pre-programmed settings. This one is programmed for mail."
-	build_path = "/obj/machinery/sorting_machine/destination"
+	build_path = /obj/machinery/sorting_machine/destination
 
 /obj/item/weapon/circuitboard/processing_unit
 	name = "Circuit Board (Ore Processor)"
 	desc = "A circuit board used to run a machine that smelts mineral ores into sheets."
-	build_path = "/obj/machinery/mineral/processing_unit"
+	build_path = /obj/machinery/mineral/processing_unit
 	board_type = MACHINE
 	origin_tech = Tc_MATERIALS + "=3;" + Tc_ENGINEERING + "=2;" + Tc_PROGRAMMING + "=2"
 	req_components = list(
@@ -1270,12 +1270,12 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/processing_unit/recycling
 	name = "Circuit Board (Recycling Furnace)"
 	desc = "A circuit board used to run a machine that smelts items into mineral sheets."
-	build_path = "/obj/machinery/mineral/processing_unit/recycle"
+	build_path = /obj/machinery/mineral/processing_unit/recycle
 
 /obj/item/weapon/circuitboard/stacking_unit
 	name = "Circuit Board (Stacking Machine)"
 	desc = "A circuit board used to run a machine that stacks mineral sheets."
-	build_path = "/obj/machinery/mineral/stacking_machine"
+	build_path = /obj/machinery/mineral/stacking_machine
 	board_type = MACHINE
 	origin_tech = Tc_MATERIALS + "=3;" + Tc_ENGINEERING + "=2;" + Tc_PROGRAMMING + "=2"
 	req_components = list(  //Matter bins because it's moving matter, I guess, and a capacitor because else the recipe is boring.
@@ -1285,7 +1285,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/fax
 	name = "Circuit Board (Fax Machine)"
 	desc = "A circuit board used to run a machine that sends pieces of paper through bluespace."
-	build_path = "/obj/machinery/faxmachine"
+	build_path = /obj/machinery/faxmachine
 	board_type = MACHINE
 	origin_tech = Tc_MATERIALS + "=2;" + Tc_BLUESPACE + "=2"
 	req_components = list(
@@ -1299,7 +1299,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/botany_centrifuge
 	name = "Circuit Board (Lysis-Isolation Centrifuge)"
 	desc = "A circuit board used to run a machine that isolates aspects of plants."
-	build_path = "/obj/machinery/botany/extractor"
+	build_path = /obj/machinery/botany/extractor
 	board_type = MACHINE
 	origin_tech = Tc_ENGINEERING + "=3;" + Tc_BIOTECH + "=3"
 	req_components = list (
@@ -1312,7 +1312,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/botany_bioballistic
 	name = "Circuit Board (Bioballistic Delivery System)"
 	desc = "A circuit board used to run a machine that can modify plants."
-	build_path = "/obj/machinery/botany/editor"
+	build_path = /obj/machinery/botany/editor
 	board_type = MACHINE
 	origin_tech = Tc_ENGINEERING + "=3;" + Tc_BIOTECH + "=3"
 	req_components = list (
@@ -1325,7 +1325,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/dialysis
 	name = "Circuit Board (Dialysis Machine)"
 	desc = "A circuit board used to co-ordinate a machine to remove chemicals from a persons blood."
-	build_path = "/obj/machinery/dialysis"
+	build_path = /obj/machinery/dialysis
 	board_type = MACHINE
 	origin_tech = Tc_BIOTECH + "=3" + Tc_MAGNETS + "=2"
 	req_components = list(
@@ -1340,7 +1340,7 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/anom
 	name = "Circuit Board (Fourier Transform Spectroscope)"
 	desc = "A circuit board used to run a machine used in xenoarcheology."
-	build_path = "/obj/machinery/anomaly/fourier_transform"
+	build_path = /obj/machinery/anomaly/fourier_transform
 	board_type = MACHINE
 	origin_tech = Tc_PROGRAMMING + "=4"
 	req_components = list (
@@ -1349,34 +1349,34 @@ obj/item/weapon/circuitboard/rdserver
 /obj/item/weapon/circuitboard/anom/accelerator
 	name = "Circuit Board (Accelerator Spectrometer)"
 	desc = "A circuit board used to run a machine used in xenoarcheology."
-	build_path = "/obj/machinery/anomaly/accelerator"
+	build_path = /obj/machinery/anomaly/accelerator
 
 /obj/item/weapon/circuitboard/anom/gas
 	name = "Circuit Board (Gas Chromatography Spectrometer)"
 	desc = "A circuit board used to run a machine used in xenoarcheology."
-	build_path = "/obj/machinery/anomaly/gas_chromatography"
+	build_path = /obj/machinery/anomaly/gas_chromatography
 
 /obj/item/weapon/circuitboard/anom/hyper
 	name = "Circuit Board (Hyperspectral Imager)"
 	desc = "A circuit board used to run a machine used in xenoarcheology."
-	build_path = "/obj/machinery/anomaly/hyperspectral"
+	build_path = /obj/machinery/anomaly/hyperspectral
 
 /obj/item/weapon/circuitboard/anom/ion
 	name = "Circuit Board (Ion Mobility Spectrometer)"
 	desc = "A circuit board used to run a machine used in xenoarcheology."
-	build_path = "/obj/machinery/anomaly/ion_mobility"
+	build_path = /obj/machinery/anomaly/ion_mobility
 
 /obj/item/weapon/circuitboard/anom/iso
 	name = "Circuit Board (Isotope Ratio Spectrometer)"
 	desc = "A circuit board used to run a machine used in xenoarcheology."
-	build_path = "/obj/machinery/anomaly/isotope_ratio"
+	build_path = /obj/machinery/anomaly/isotope_ratio
 
 /obj/item/weapon/circuitboard/confectionator
 
 	name = "circuit board (confectionator)"
 	desc = "A circuit board used to run a kitchen appliance."
 	board_type = MACHINE
-	build_path = "/obj/machinery/cooking/deepfryer/confectionator"
+	build_path = /obj/machinery/cooking/deepfryer/confectionator
 	req_components = list(
 						"/obj/item/weapon/stock_parts/matter_bin" = 1,
 						"/obj/item/weapon/stock_parts/scanning_module" = 1,
@@ -1390,7 +1390,7 @@ obj/item/weapon/circuitboard/rdserver
 
 /obj/item/weapon/circuitboard/fishtank
 	name = "Circuit Board (Fishtank Filter)"
-	build_path = "/obj/machinery/fishtank/tank"
+	build_path = /obj/machinery/fishtank/tank
 	board_type = MACHINE
 	origin_tech = Tc_PROGRAMMING + "=1"
 	req_components = list (
@@ -1398,7 +1398,7 @@ obj/item/weapon/circuitboard/rdserver
 
 /obj/item/weapon/circuitboard/fishwall
 	name = "Circuit Board (Large Fishtank Filter)"
-	build_path = "/obj/machinery/fishtank/wall"
+	build_path = /obj/machinery/fishtank/wall
 	board_type = MACHINE
 	origin_tech = Tc_PROGRAMMING + "=1"
 	req_components = list (
@@ -1406,7 +1406,7 @@ obj/item/weapon/circuitboard/rdserver
 
 /obj/item/weapon/circuitboard/conduction_plate
 	name = "Circuit Board (Conduction Plate)"
-	build_path = "/obj/machinery/power/conduction_plate"
+	build_path = /obj/machinery/power/conduction_plate
 	board_type = MACHINE
 	origin_tech = Tc_PROGRAMMING + "=1;" + Tc_ENGINEERING + "=4"
 	req_components = list(

--- a/code/modules/research/designs/boards/computer_engie.dm
+++ b/code/modules/research/designs/boards/computer_engie.dm
@@ -123,7 +123,7 @@
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 2000, SACID = 20)
 	category = "Misc"
-	build_path = "/obj/item/weapon/circuitboard/rust_gyrotron_control"
+	build_path = /obj/item/weapon/circuitboard/rust_gyrotron_control
 
 /datum/design/rust_fuel_control
 	name = "Circuit Design (R-UST Mk. 7 fuel controller)"
@@ -133,7 +133,7 @@
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 2000, SACID = 20)
 	category = "Misc"
-	build_path = "/obj/item/weapon/circuitboard/rust_fuel_control"
+	build_path = /obj/item/weapon/circuitboard/rust_fuel_control
 
 /datum/design/rust_core_monitor
 	name = "Circuit Design (R-UST Mk. 7 core monitor)"
@@ -143,7 +143,7 @@
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 2000, SACID = 20)
 	category = "Misc"
-	build_path = "/obj/item/weapon/circuitboard/rust_core_monitor"
+	build_path = /obj/item/weapon/circuitboard/rust_core_monitor
 
 /datum/design/rust_core_control
 	name = "Circuit Design (R-UST Mk. 7 core controller)"
@@ -153,4 +153,4 @@
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 2000, SACID = 20)
 	category = "Misc"
-	build_path = "/obj/item/weapon/circuitboard/rust_core_control"
+	build_path = /obj/item/weapon/circuitboard/rust_core_control

--- a/code/modules/research/designs/boards/machine_engie.dm
+++ b/code/modules/research/designs/boards/machine_engie.dm
@@ -201,7 +201,7 @@
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 2000, SACID = 20, MAT_URANIUM = 3000)
 	category = "Misc"
-	build_path = "/obj/item/weapon/module/rust_fuel_port"
+	build_path = /obj/item/weapon/module/rust_fuel_port
 
 /datum/design/rust_fuel_compressor
 	name = "Circuit Design (R-UST Mk. 7 fuel compressor)"
@@ -211,7 +211,7 @@
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 2000, SACID = 20, MAT_PLASMA = 3000, MAT_DIAMOND = 1000)
 	category = "Misc"
-	build_path = "/obj/item/weapon/module/rust_fuel_compressor"
+	build_path = /obj/item/weapon/module/rust_fuel_compressor
 
 /datum/design/rust_core
 	name = "Internal circuitry (R-UST Mk. 7 tokamak core)"
@@ -222,7 +222,7 @@
 	reliability_base = 79
 	materials = list(MAT_GLASS = 2000, SACID = 20, MAT_PLASMA = 3000, MAT_DIAMOND = 2000)
 	category = "Misc"
-	build_path = "/obj/item/weapon/circuitboard/rust_core"
+	build_path = /obj/item/weapon/circuitboard/rust_core
 
 /datum/design/rust_injector
 	name = "Internal circuitry (R-UST Mk. 7 fuel injector)"
@@ -233,7 +233,7 @@
 	reliability_base = 79
 	materials = list(MAT_GLASS = 2000, SACID = 20, MAT_PLASMA = 3000, MAT_URANIUM = 2000)
 	category = "Misc"
-	build_path = "/obj/item/weapon/circuitboard/rust_injector"
+	build_path = /obj/item/weapon/circuitboard/rust_injector
 
 //Cael shield gen designs.
 
@@ -244,7 +244,7 @@
 	req_tech = list(Tc_BLUESPACE = 4, Tc_PLASMATECH = 3)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 2000, SACID = 20, MAT_DIAMOND = 2000, MAT_GOLD = 2000)
-	build_path = "/obj/item/weapon/circuitboard/shield_gen_ex"
+	build_path = /obj/item/weapon/circuitboard/shield_gen_ex
 
 /datum/design/shield_gen
 	name = "Circuit Design (Starscreen shield generator)"
@@ -253,7 +253,7 @@
 	req_tech = list(Tc_BLUESPACE = 4, Tc_PLASMATECH = 3)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 2000, SACID = 20, MAT_DIAMOND = 2000, MAT_GOLD = 2000)
-	build_path = "/obj/machinery/shield_gen"
+	build_path = /obj/machinery/shield_gen
 
 /datum/design/shield_cap
 	name = "Circuit Design (Starscreen shield capacitor)"
@@ -262,4 +262,4 @@
 	req_tech = list(Tc_MAGNETS = 3, Tc_POWERSTORAGE = 4)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 2000, SACID = 20, MAT_GOLD = 2000)
-	build_path = "/obj/item/weapon/circuitboard/shield_cap"
+	build_path = /obj/item/weapon/circuitboard/shield_cap


### PR DESCRIPTION
Incidentally reveals one circuit board that was pointing to a non-existent path. It has been removed.
Done by searching for `build_path = "(.*?)"`