### PR TITLE
Color Describer

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -427,6 +427,37 @@ var/list/DummyCache = list()
 		GetBluePart(hexa),
 		)
 
+//Converts hex to RGB, then describes it.
+proc/hex2eng(var/hexa)
+	var/output = "white"
+	var/list/rgb_list = list("red" = getr(hexa), "green" = getg(hexa), "blue" = getb(hexa))
+	var/list/rgb_sorted = sortTim(rgb_list,/proc/cmp_numeric_dsc,TRUE)
+	//First, describe the hue
+	if(rgb_sorted[1]>168)
+		output = "bright"
+	else if(rgb_sorted[1]>86)
+		output = "murky"
+	else
+		output = "dark"
+
+	//Next, describe the color
+	if(rgb_sorted[1]-rgb_sorted[2]>80)
+		//One distinct color stands out
+		//Since we know [1] has a different value than [2], we can use this helper
+		output += " [get_key_by_element(rgb_sorted,rgb_sorted[1])]ish"
+	else
+		//In this case, the master color is no more than a third dominant.
+		//Is the last color that weak?
+		if(rgb_sorted[1]-rgb_sorted[3]>80)
+			//Just two colors dominate, let's combine the keys
+			pop(rgb_sorted)
+			for(var/key in rgb_sorted)
+				output += " [key]ish" //e.g.: reddish blueish
+
+		else
+			//They're all about the same
+			output += " grayish"
+
 /proc/rgb2hsl(var/red, var/grn, var/blu)
 
 	red /= 255

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -427,47 +427,51 @@ var/list/DummyCache = list()
 		GetBluePart(hexa),
 		)
 
-/*(1,0,0, "red"), "Ideal" colors
-(1,0.6,0, "orange"),
-(1,1,0, "yellow"),
-(0,0.3,0, "green"),
-(0,0,1, "blue"),
-(0.9,0.5,0.9, "violet"),
-(0.6,0.15,0.15, "brown",
-(0,0,0, "black"),
-(0.3,0.3,0.3, "grey"),
-(1,1,1, "white"))*/
-proc/rgb2eng(var/red, var/grn, var/blu) //Describes RGB
-	red /= 255
-	grn /= 255
-	blu /= 255
-	var/list/all = list(red,grn,blu)
-	var/lo = min(red, grn, blu)
-	var/hi = max(red, grn, blu)
+/*Colors that we use a lot that might be worth describing:
+- Orange
+- Brown*/
+proc/rgb2eng(var/list/all) //Describes RGB
+	//message_admins(json_encode(all)) DEBUG
+	var/red = all[1]
+	var/grn = all[2]
+	var/blu = all[3]
+	var/lo = min(all)
+	var/hi = max(all)
 	all -= list(hi,lo)
 	var/med = all[1]
-	if(hi-lo<0.25) //All of the colors are within 25% of each other. It's grayish.
-		if(hi<0.1)
+	var/modifier
+	if(hi<110)
+		modifier += "dark "
+	else if(hi>200)
+		modifier += "bright "
+	if(hi/2<=lo) //No color is twice another
+		if(hi<30)
 			return "black"
-		if(lo>0.9)
+		if(lo>220)
 			return "white"
-		return "gray" //US pride worldwide
+		return "[modifier]gray" //US pride worldwide
 	else
-		if(hi-med<0.5) //Two colors dominate with a forgiving margin
+		if(med/hi>0.80) //Two colors dominate with a tight margin
 			if(lo==red)
-				return "cyan"
+				return "[modifier]cyan"
 			else if(lo==grn)
-				return "violet"
-			else(blu)
-				return "orange"
+				return "[modifier]purple"
+			else
+				return "[modifier]yellow"
 
 		else //One color is dominant
 			if(hi==red)
-				return "red"
+				if(grn/red>=0.3) //We are on the orange-brown spectrum
+					if(hi>=110) //It's mostly bright
+						return "[modifier]orange" //Bright red with between 30% and 87% green
+					else
+						return "brown" //A dark orange
+				else
+					return "[modifier]red"
 			if(hi==blu)
-				return "blue"
+				return "[modifier]blue"
 			else
-				return "green"
+				return "[modifier]green"
 
 
 

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -427,36 +427,50 @@ var/list/DummyCache = list()
 		GetBluePart(hexa),
 		)
 
-//Converts hex to RGB, then describes it.
-proc/hex2eng(var/hexa)
-	var/output = "white"
-	var/list/rgb_list = list("red" = getr(hexa), "green" = getg(hexa), "blue" = getb(hexa))
-	var/list/rgb_sorted = sortTim(rgb_list,/proc/cmp_numeric_dsc,TRUE)
-	//First, describe the hue
-	if(rgb_sorted[1]>168)
-		output = "bright"
-	else if(rgb_sorted[1]>86)
-		output = "murky"
+/*(1,0,0, "red"), "Ideal" colors
+(1,0.6,0, "orange"),
+(1,1,0, "yellow"),
+(0,0.3,0, "green"),
+(0,0,1, "blue"),
+(0.9,0.5,0.9, "violet"),
+(0.6,0.15,0.15, "brown",
+(0,0,0, "black"),
+(0.3,0.3,0.3, "grey"),
+(1,1,1, "white"))*/
+proc/rgb2eng(var/red, var/grn, var/blu) //Describes RGB
+	red /= 255
+	grn /= 255
+	blu /= 255
+	var/list/all = list(red,grn,blu)
+	var/lo = min(red, grn, blu)
+	var/hi = max(red, grn, blu)
+	all -= list(hi,lo)
+	var/med = all[1]
+	if(hi-lo<0.25) //All of the colors are within 25% of each other. It's grayish.
+		if(hi<0.1)
+			return "black"
+		if(lo>0.9)
+			return "white"
+		return "gray" //US pride worldwide
 	else
-		output = "dark"
+		if(hi-med<0.5) //Two colors dominate with a forgiving margin
+			if(lo==red)
+				return "cyan"
+			else if(lo==grn)
+				return "violet"
+			else(blu)
+				return "orange"
 
-	//Next, describe the color
-	if(rgb_sorted[1]-rgb_sorted[2]>80)
-		//One distinct color stands out
-		//Since we know [1] has a different value than [2], we can use this helper
-		output += " [get_key_by_element(rgb_sorted,rgb_sorted[1])]ish"
-	else
-		//In this case, the master color is no more than a third dominant.
-		//Is the last color that weak?
-		if(rgb_sorted[1]-rgb_sorted[3]>80)
-			//Just two colors dominate, let's combine the keys
-			pop(rgb_sorted)
-			for(var/key in rgb_sorted)
-				output += " [key]ish" //e.g.: reddish blueish
+		else //One color is dominant
+			if(hi==red)
+				return "red"
+			if(hi==blu)
+				return "blue"
+			else
+				return "green"
 
-		else
-			//They're all about the same
-			output += " grayish"
+
+
 
 /proc/rgb2hsl(var/red, var/grn, var/blu)
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -449,8 +449,8 @@ its easier to just keep the beam vertical.
 							to_chat(user, "<span class='info'>[R.volume] units of [R.name]</span>")
 					else
 						//Let's try to figure out what's in there!
-						var/hex = mix_color_from_reagents(reagents.reagent_list)
-						to_chat(user,  "<span class='info'>It seems to be about [round(reagents.total_volume/maximum_volume*100,10)]% full with [hex2eng(hex)] reagent.</span>")
+						var/rgb = GetHexColors(mix_color_from_reagents(reagents.reagent_list))
+						to_chat(user,  "<span class='info'>It seems to be about [round(reagents.total_volume/reagents.maximum_volume*100,10)]% full with [rgb2eng(rgb)] reagent.</span>")
 
 
 				else

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -120,6 +120,9 @@
 	ghostMulti = null
 	observers.Remove(src)
 
+/mob/dead/observer/can_see_reagents()
+	return TRUE
+
 /mob/dead/observer/hasFullAccess()
 	return isAdminGhost(src)
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -690,9 +690,6 @@
 				return 0
 	return 1
 
-/mob/living/carbon/can_see_reagents()
-	return head && istype(head,/obj/item/clothing/glasses/science)
-
 /mob/living/carbon/make_invisible(var/source_define, var/time, var/include_clothing)
 	if(invisibility || alpha <= 1 || !source_define)
 		return

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -691,7 +691,7 @@
 	return 1
 
 /mob/living/carbon/can_see_reagents()
-	return H.head && istype(H.head,/obj/item/clothing/glasses/science)
+	return head && istype(head,/obj/item/clothing/glasses/science)
 
 /mob/living/carbon/make_invisible(var/source_define, var/time, var/include_clothing)
 	if(invisibility || alpha <= 1 || !source_define)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -690,6 +690,9 @@
 				return 0
 	return 1
 
+/mob/living/carbon/can_see_reagents()
+	return H.head && istype(H.head,/obj/item/clothing/glasses/science)
+
 /mob/living/carbon/make_invisible(var/source_define, var/time, var/include_clothing)
 	if(invisibility || alpha <= 1 || !source_define)
 		return

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -497,3 +497,6 @@
 	if(active_only && istype(get_inactive_hand(),/obj/item/device/multitool))
 		return get_inactive_hand()
 	return null
+
+/mob/living/carbon/human/can_see_reagents()
+	return glasses && istype(glasses,/obj/item/clothing/glasses/science)

--- a/code/modules/mob/living/carbon/monkey/inventory.dm
+++ b/code/modules/mob/living/carbon/monkey/inventory.dm
@@ -125,3 +125,6 @@
 
 /mob/living/carbon/monkey/reversestrip_time()
 	return MONKEY_REVERSESTRIP_DELAY
+
+/mob/living/carbon/monkey/can_see_reagents()
+	return glasses && istype(glasses,/obj/item/clothing/glasses/science)

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -28,6 +28,9 @@
 /mob/living/silicon/GetAccess()
 	return get_all_accesses()
 
+/mob/living/silicon/can_see_reagents()
+	return TRUE //Is this creep?
+
 /mob/living/silicon/feels_pain()
 	return FALSE
 

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -53,6 +53,9 @@ mob/proc/remove_internal_organ()
 /mob/proc/get_bleeding_organs()
 	return list()
 
+/mob/proc/can_see_reagents()
+	return FALSE
+
 //Helper proc for do_after. Checks if the user is holding 'held_item' in his active arm. Return 0 to stop the do_after
 /mob/proc/do_after_hand_check(held_item)
 	return (get_active_hand() == held_item)

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -867,6 +867,9 @@
 	amount_per_transfer_from_this = 10
 	volume = 100
 
+/obj/item/weapon/reagent_containers/food/drinks/shaker/is_smart_container()
+	return TRUE
+
 /obj/item/weapon/reagent_containers/food/drinks/thermos
 	name = "\improper Thermos"
 	desc = "A metal flask which insulates its contents from temperature - keeping hot beverages hot, and cold ones cold."


### PR DESCRIPTION
Instead of being able to identify exactly what is in a container, when you look at it you will instead see a description of the color mixed within. This means that you can hide reagents.
* Wearing science goggles will let you examine reagents like you used to
* Smart containers (like the bartender shaker) still allow you to examine reagents
* (TODO) Silicons can see reagents with an upgrade
* (TODO) Ghosts can see reagents

![untitled](https://user-images.githubusercontent.com/9782036/43666426-6f103a18-9739-11e8-9130-62babf7c5478.png)

Buggy behavior:
* Dispensers (like fuel tanks) seem to override examine or something because they are not affected as of yet.

🆑 
* rscadd: Spacemen can no longer identify exactly which reagents are in a container unless they have scientific goggles.