### PR TITLE
Security armor and hardsuit can fit bolas

### DIFF
--- a/code/modules/clothing/spacesuits/rig.dm
+++ b/code/modules/clothing/spacesuits/rig.dm
@@ -314,7 +314,9 @@
 		/obj/item/ammo_casing,
 		/obj/item/weapon/handcuffs,
 		/obj/item/weapon/bikehorn/baton,
-		/obj/item/weapon/blunderbuss)
+		/obj/item/weapon/blunderbuss,
+		/obj/item/weapon/legcuffs/bolas,
+	)
 	siemens_coefficient = 0.7
 	pressure_resistance = 40 * ONE_ATMOSPHERE
 

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -12,7 +12,8 @@
 		/obj/item/weapon/gun/mahoguny,
 		/obj/item/weapon/gun/grenadelauncher,
 		/obj/item/weapon/bikehorn/baton,
-		/obj/item/weapon/blunderbuss
+		/obj/item/weapon/blunderbuss,
+		/obj/item/weapon/legcuffs/bolas,
 		)
 	body_parts_covered = FULL_TORSO
 	flags = FPRINT


### PR DESCRIPTION
Closes #18281

:cl:
 * tweak: Security armor and security hardsuits can fit bolas in the suit storage slot.