### PR TITLE
Adds appendix to list of valid target organs for the organics extractor

### DIFF
--- a/code/game/gamemodes/heist/tools.dm
+++ b/code/game/gamemodes/heist/tools.dm
@@ -28,7 +28,8 @@
 		"heart",
 		"kidneys",
 		"liver",
-		"lungs"
+		"lungs",
+		"appendix"
 	)
 	var/target_type="eyes"
 


### PR DESCRIPTION
Resolves #19110

#15002 had the bright idea of adding appendixes to the possible Heist objectives. What they didn't count on was that the organ remover had a whitelist that didn't include them.

:cl:
* tweak: Organics extractors can now target appendixes.