### PR TITLE
Fire Alarm Sanity

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -1130,7 +1130,8 @@ FIRE ALARM
 		else if (href_list["shelter"])
 			if(shelter)
 				var/obj/O = new /obj/item/inflatable/shelter(loc)
-				usr.put_in_hands(O)
+				if(Adjacent(usr)) //This way, silicons can still deploy it
+					usr.put_in_hands(O)
 				shelter = FALSE
 				update_icon()
 			else

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -378,7 +378,7 @@
 	user.reagents.add_reagent(PEPTOBISMOL,4)
 	user.reagents.add_reagent(TRAMADOL,3)
 	user.reagents.add_reagent(LEPORAZINE,1)
-	to_chat(user,"<span class='warning'>You feel calmed by the anesthetizing gasses inside the shelter.</span>")
+	to_chat(user,"<span class='warning'>You feel a prick upon entering \the [src] and your muscles relax.</span>")
 
 /obj/structure/inflatable/shelter/proc/laundry(var/mob/living/carbon/human/user)
 	if(user.loc != src)


### PR DESCRIPTION
closes #19114

Also slightly changes the enter shelter text for immersions

closes #19081

🆑 
* bugfix: When silicons remotely try to retrieve an inflatable shelter, it will fall to the ground at the fire alarm instead of teleporting to them.