### PR TITLE
Makes code compile on 512.1445+

### DIFF
--- a/code/ZAS/Atom.dm
+++ b/code/ZAS/Atom.dm
@@ -1,7 +1,14 @@
 /atom/movable/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	return (!density || !height || air_group)
 
+#ifdef DM_BUILD //Checking the actual value of this macro is unnecessary, since the required build is 1438 and the macro was first added in 1443.
+                //This means that the code can't compile in builds 1438-1442, but there's not a way around that.
+                //(Not a good way, at least.)
+/turf/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+#else
 /turf/proc/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+#endif
+
 	if(!target)
 		return 0
 


### PR DESCRIPTION
You may note that 512.1445 is not out yet. 512.1444 has a bug with macros that causes the code to not compile even with this change. This bug has already been fixed for 1445.

I didn't bother downgrading to see if this works on the current version, but if it doesn't, Travis will tell us