### PR TITLE
Hair and beard update on explode()

### DIFF
--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -1425,8 +1425,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 /datum/organ/external/head/explode()
 	owner.remove_internal_organ(owner, owner.internal_organs_by_name["brain"], src)
-
 	.=..()
+	owner.update_hair()
 
 /datum/organ/external/head/get_icon()
 	if(!owner)


### PR DESCRIPTION
Calling `explode()` on a head will no longer leave beard and hair floating above the newly-formed stump by calling `update_hair()`. The bug can be seen on the character in https://is3.4chan.org/vg/1533495576530.webm.