### PR TITLE
Cyborg modules with MODULE_CAN_HANDLE_MEDICAL can use morgue trays

### DIFF
--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -76,6 +76,10 @@
 /obj/structure/morgue/attack_paw(mob/user as mob)
 	return src.attack_hand(user)
 
+/obj/structure/morgue/attack_robot(mob/living/silicon/robot/user)
+	if(HAS_MODULE_QUIRK(user, MODULE_CAN_HANDLE_MEDICAL))
+		attack_hand(user)
+
 /obj/structure/morgue/attack_hand(mob/user as mob)
 	if (connected)
 		close_up()

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -194,6 +194,10 @@
 	else
 		qdel(src) //this should not happen but if it does happen we should not be here
 
+/obj/structure/m_tray/attack_robot(mob/living/silicon/robot/user)
+	if(HAS_MODULE_QUIRK(user, MODULE_CAN_HANDLE_MEDICAL))
+		attack_hand(user)
+
 /obj/structure/m_tray/MouseDropTo(atom/movable/O as mob|obj, mob/user as mob)
 	if (!istype(O) || O.anchored || !user.Adjacent(O) || !user.Adjacent(src) || user.contents.Find(O))
 		return


### PR DESCRIPTION
:cl:
 * rscadd: Medical/Syndicate Crisis cyborgs can now use morgue trays
