### PR TITLE
Stomach given its own reagent_container

### DIFF
--- a/code/modules/organs/internal/stomach/stomach.dm
+++ b/code/modules/organs/internal/stomach/stomach.dm
@@ -12,6 +12,7 @@
 	removed_type = /obj/item/organ/internal/stomach
 	var/base_intake_rate = 1	// rate at which reagents enter the system
 	var/obj/item/organ/internal/stomach/reagents_holder = null // need this since /datum/reagents needs an atom
+	var/current_volume = 0 // used for determining the amount of each reagent to transfer to body
 
 /datum/organ/internal/stomach/New()
 	..()
@@ -26,21 +27,20 @@
 /datum/organ/internal/stomach/process()
 	..()
 	if(is_bruised()) // damage should also tie into hunger calculations
-		var/chance = min(50, (damage-min_bruised_damage)/min_broken_damage*50)
+		var/chance = min(2, (damage-min_bruised_damage)/min_broken_damage*5)
 		if(prob(chance) && owner.feels_pain())
-			to_chat(owner, "<spawn class='warning'>You feel a sharp pain in your gut!</span>")
+			to_chat(owner, "<span class='danger'>You feel a sharp pain in your gut!</span>")
 
-	var/current_volume = reagents_holder.reagents.total_volume
+	current_volume = reagents_holder.reagents.total_volume
 
 	if(current_volume >= 0.9 * reagent_size)
 		damage += 0.1 // damage from being too full
 
 	// process contents of stomach, slowly moving reagents to bloodstream
 	for(var/datum/reagent/R in reagents_holder.reagents.reagent_list)
-		// transfer reagents as a weighted average of the current contents times a basic intake rate
-		R.digest(owner, current_volume)
+		R.digest(owner)
 
-	damage = Clamp(damage - 0.02, 0, INFINITY) // natural healing - clamps to be minimum of zero, will account for any healing reagents in the stomach
+	damage = Clamp(damage - 0.02, 0, INFINITY) // natural healing - ensures that damage is non-negative
 
 /datum/organ/internal/stomach/remove(var/mob/user, var/quiet=0)
 	var/obj/item/organ/internal/stomach/S = ..()

--- a/code/modules/organs/internal/stomach/stomach.dm
+++ b/code/modules/organs/internal/stomach/stomach.dm
@@ -1,29 +1,58 @@
 /**
 	Stomach organ
 
-	Literally just a pseudo-organ used for handling the mass removal of reagents from a person.
+	An organ used for handling the transfer of consumed reagents to the human body.
 **/
 
 /datum/organ/internal/stomach
 	name = "stomach"
 	parent_organ = LIMB_CHEST
 	organ_type = "stomach"
-	var/reagent_size = 1000
+	var/reagent_size = 200
 	removed_type = /obj/item/organ/internal/stomach
+	var/base_intake_rate = 1	// rate at which reagents enter the system
+	var/obj/item/organ/internal/stomach/reagents_holder = null // need this since /datum/reagents needs an atom
+
+/datum/organ/internal/stomach/New()
+	..()
+	reagents_holder = new()
+	reagents_holder.create_reagents(reagent_size)
 
 /datum/organ/internal/stomach/Copy()
 	var/datum/organ/internal/stomach/S = ..()
 	S.reagent_size = reagent_size
 	return S
 
+/datum/organ/internal/stomach/process()
+	..()
+	if(is_bruised()) // damage should also tie into hunger calculations
+		var/chance = min(50, (damage-min_bruised_damage)/min_broken_damage*50)
+		if(prob(chance) && owner.feels_pain())
+			to_chat(owner, "<spawn class='warning'>You feel a sharp pain in your gut!</span>")
+
+	var/current_volume = reagents_holder.reagents.total_volume
+
+	if(current_volume >= 0.9 * reagent_size)
+		damage += 0.1 // damage from being too full
+
+	// process contents of stomach, slowly moving reagents to bloodstream
+	for(var/datum/reagent/R in reagents_holder.reagents.reagent_list)
+		// transfer reagents as a weighted average of the current contents times a basic intake rate
+		R.digest(owner, current_volume)
+
+	damage = Clamp(damage - 0.02, 0, INFINITY) // natural healing - clamps to be minimum of zero, will account for any healing reagents in the stomach
+
 /datum/organ/internal/stomach/remove(var/mob/user, var/quiet=0)
 	var/obj/item/organ/internal/stomach/S = ..()
-	owner.reagents.trans_to(S, owner.reagents.total_volume)
-	owner.reagents.maximum_volume = 25
+	reagents_holder.reagents.trans_to(S, reagents_holder.reagents.total_volume)
 	return S
 
-/datum/organ/internal/stomach/Insert(var/mob/living/carbon/human/H, var/mob/surgeon=null, var/quiet=0)
-	.=..()
-	if(H.reagents)
-		H.reagents.clear_reagents()
-		H.reagents.maximum_volume = reagent_size
+/datum/organ/internal/stomach/proc/get_reagents()
+	return reagents_holder.reagents
+
+// return volume of a given reagent
+/datum/organ/internal/stomach/proc/get_reagent_volume(var/id)
+	var/datum/reagent/R = reagents_holder.reagents.get_reagent(id)
+	if(R)
+		return R.volume
+	return 0

--- a/code/modules/organs/internal/stomach/stomach.dm
+++ b/code/modules/organs/internal/stomach/stomach.dm
@@ -49,10 +49,3 @@
 
 /datum/organ/internal/stomach/proc/get_reagents()
 	return reagents_holder.reagents
-
-// return volume of a given reagent
-/datum/organ/internal/stomach/proc/get_reagent_volume(var/id)
-	var/datum/reagent/R = reagents_holder.reagents.get_reagent(id)
-	if(R)
-		return R.volume
-	return 0

--- a/code/modules/organs/organ_objects.dm
+++ b/code/modules/organs/organ_objects.dm
@@ -277,7 +277,7 @@
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
 		var/datum/organ/internal/stomach/S = H.get_stomach()
-		if(H.get_stomach())
+		if(S)
 			reagents.trans_to(S.get_reagents(), reagents.maximum_volume)
 
 /obj/item/organ/internal/proc/removed(var/mob/living/target,var/mob/living/user)

--- a/code/modules/organs/organ_objects.dm
+++ b/code/modules/organs/organ_objects.dm
@@ -266,7 +266,6 @@
 	icon_state = "stomach"
 	organ_tag = "stomach"
 
-
 /obj/item/organ/internal/stomach/update()
 	.=..()
 	if(istype(organ_data, /datum/organ/internal/stomach))
@@ -277,7 +276,9 @@
 /obj/item/organ/internal/stomach/replaced(var/mob/living/target)
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
-		reagents.trans_to(H.reagents, reagents.maximum_volume)
+		var/datum/organ/internal/stomach/S = H.get_stomach()
+		if(H.get_stomach())
+			reagents.trans_to(S.get_reagents(), reagents.maximum_volume)
 
 /obj/item/organ/internal/proc/removed(var/mob/living/target,var/mob/living/user)
 	if(!target || !user)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -50,6 +50,7 @@
 	var/density = 1 //(g/cm^3) Everything is water unless specified otherwise. round to 2dp
 	var/specheatcap = 1 //how much energy in joules it takes to heat this thing up by 1 degree (J/g). round to 2dp
 	var/digestion_rate = 1 // multiplier that affects reagents transfer from stomach to body. Higher means faster, lower means slower, 0 means the reagent stays in the stomach
+	var/overdose_includes_stomach = FALSE // if true, the volume of reagent in the stomach will count for overdose quantity
 
 /datum/reagent/proc/reaction_mob(var/mob/living/M, var/method = TOUCH, var/volume)
 	set waitfor = 0
@@ -164,8 +165,8 @@
 
 	var/datum/organ/internal/stomach/S = M.get_stomach()
 	var/volume_in_stomach = 0 // volume in stomach counts for overdose amounts
-	if(S)
-		volume_in_stomach = S.get_reagent_volume(id)
+	if(S && overdose_includes_stomach)
+		volume_in_stomach = S.get_reagents().get_reagent_amount(id)
 
 	if((overdose_am && (volume + volume_in_stomach) >= overdose_am) || (overdose_tick && tick >= overdose_tick)) //Too much chems, or been in your system too long
 		on_overdose(M)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -132,11 +132,11 @@
 	holder.remove_reagent(src.id, custom_metabolism) // If we aren't human, we don't have a liver, so just metabolize it the old fashioned way.
 
 // process the chemicals within the stomach, called by /datum/organ/internal/stomach in process() on all stomach contents
-// takes the mob and the stomach reagent volume at the start of process() as mandatory arguments
+// takes the mob as a mandatory argument
 // reagent damage to the stomach and threshold for stomach damage are optional arguments
 // if volume >= amount_for_damage then the stomach will take the specified amount of damage every time process() is called on the stomach (about once a second)
 // damage < 0 will heal the stomach
-/datum/reagent/proc/digest(var/mob/living/carbon/human/M, var/current_stomach_volume, var/damage = 0, var/amount_for_damage = 0)
+/datum/reagent/proc/digest(var/mob/living/carbon/human/M, var/damage = 0, var/amount_for_damage = 0)
 	var/datum/organ/internal/stomach/S = M.get_stomach()
 	if(!S)
 		return // can't digest without a stomach
@@ -146,7 +146,7 @@
 		S.damage += damage
 
 	// move part of the stomach contents to the body
-	S.get_reagents().trans_id_to(M, id, (volume / current_stomach_volume) * digestion_rate * S.base_intake_rate)
+	S.get_reagents().trans_id_to(M, id, (volume / S.current_volume) * digestion_rate * S.base_intake_rate)
 
 /datum/reagent/proc/on_mob_life(var/mob/living/M, var/alien)
 	set waitfor = 0
@@ -602,8 +602,8 @@
 	density = 1.49033
 	specheatcap = 0.55536
 
-/datum/reagent/anti_toxin/digest(var/mob/living/carbon/human/M, var/current_stomach_volume)
-	..(M, current_stomach_volume, damage = 0.1, amount_for_damage = 15)
+/datum/reagent/anti_toxin/digest(var/mob/living/carbon/human/M)
+	..(M, damage = 0.1, amount_for_damage = 15)
 
 /datum/reagent/anti_toxin/on_mob_life(var/mob/living/M)
 
@@ -2053,8 +2053,8 @@
 					H.update_inv_shoes(0)
 		M.clean_blood()
 
-/datum/reagent/space_cleaner/digest(var/mob/living/carbon/human/M, var/current_stomach_volume)
-	..(M, current_stomach_volume, damage = 1)
+/datum/reagent/space_cleaner/digest(var/mob/living/carbon/human/M)
+	..(M, damage = 1)
 
 /datum/reagent/space_cleaner/bleach
 	name = "Bleach"
@@ -2623,8 +2623,8 @@
 	density = 1.92
 	specheatcap = 5.45
 
-/datum/reagent/imidazoline/digest(var/mob/living/carbon/human/M, var/current_stomach_volume)
-	..(M, current_stomach_volume, damage = -0.5)
+/datum/reagent/imidazoline/digest(var/mob/living/carbon/human/M)
+	..(M, damage = -0.5)
 
 /datum/reagent/imidazoline/on_mob_life(var/mob/living/M)
 
@@ -4913,8 +4913,8 @@
 	var/pass_out = 450 //Amount absorbed after which mob starts passing out
 	var/common_data = 1 //Needed to add all ethanol subtype's datas
 
-/datum/reagent/ethanol/digest(var/mob/living/carbon/human/M, var/current_stomach_volume)
-	..(M, current_stomach_volume, damage = 0.08)
+/datum/reagent/ethanol/digest(var/mob/living/carbon/human/M)
+	..(M, damage = 0.08)
 
 /datum/reagent/ethanol/on_mob_life(var/mob/living/M)
 
@@ -6229,8 +6229,8 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 	reagent_state = LIQUID
 	color = "#12A7C9"
 
-/datum/reagent/fishbleach/digest(var/mob/living/carbon/human/M, var/current_stomach_volume)
-	..(M, current_stomach_volume, damage = 1)
+/datum/reagent/fishbleach/digest(var/mob/living/carbon/human/M)
+	..(M, damage = 1)
 
 /datum/reagent/fishbleach/on_mob_life(var/mob/living/carbon/human/H)
 	if(..())

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -141,8 +141,6 @@
 	if(!S)
 		return // can't digest without a stomach
 
-	on_mob_life(M)
-
 	// deal damage - damage < 0 means it will heal the stomach
 	if(volume >= amount_for_damage)
 		S.damage += damage

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -3059,7 +3059,7 @@
 		return
 	H.vomit()
 	S.take_damage(created_volume/10)
-	holder.remove_reagents(created_volume*25)
+	S.get_reagents().remove_reagents(created_volume*25)
 
 /datum/chemical_reaction/albuterol
 	name = "Albuterol"

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -349,8 +349,13 @@ var/list/LOGGED_SPLASH_REAGENTS = list(FUEL, THERMITE)
 			reagents.reaction(user, INGEST)
 			spawn(5)
 				if(reagents)
-					reagents.trans_to(user, amount_per_imbibe)
-
+					if(user.get_stomach())
+						var/datum/organ/internal/stomach/S = user.get_stomach()
+						reagents.trans_to(S.get_reagents(), amount_per_imbibe) // transfer to stomach
+					else if(istype(user, /mob/living/carbon/human))
+						reagents.trans_to(user, amount_per_imbibe / 4) // greatly reduced reagent absorption without a stomach
+					else
+						reagents.trans_to(user, amount_per_imbibe)
 	return 1
 
 /obj/item/weapon/reagent_containers/proc/can_drink(mob/user)

--- a/code/modules/reagents/reagents/vg.dm
+++ b/code/modules/reagents/reagents/vg.dm
@@ -13,16 +13,15 @@ var/global/list/charcoal_doesnt_remove=list(
 	reagent_state = LIQUID
 	color = "#333333" // rgb: 51, 51, 51
 	custom_metabolism = 0.06
+	digestion_rate = 0 // will not transfer from stomach to body
 
-/datum/reagent/charcoal/on_mob_life(var/mob/living/M)
-	if(!M)
-		M = holder.my_atom
-
-	if(ishuman(M) && prob(5))
-		var/mob/living/carbon/human/H=M
-		H.vomit()
+/datum/reagent/charcoal/digest(var/mob/living/carbon/human/M, var/current_stomach_volume)
+	var/datum/organ/internal/stomach/S = M.get_stomach()
+	if(!S)
 		return
 
+	if(prob(5))
+		M.vomit()
 	var/found_any = FALSE
 	for(var/datum/reagent/reagent in holder.reagent_list)
 		if(reagent.id in charcoal_doesnt_remove)

--- a/code/modules/reagents/reagents/vg.dm
+++ b/code/modules/reagents/reagents/vg.dm
@@ -15,7 +15,7 @@ var/global/list/charcoal_doesnt_remove=list(
 	custom_metabolism = 0.06
 	digestion_rate = 0 // will not transfer from stomach to body
 
-/datum/reagent/charcoal/digest(var/mob/living/carbon/human/M, var/current_stomach_volume)
+/datum/reagent/charcoal/digest(var/mob/living/carbon/human/M)
 	var/datum/organ/internal/stomach/S = M.get_stomach()
 	if(!S)
 		return


### PR DESCRIPTION
Gives the stomach its own reagent_container that slowly "digests" reagents within it and transfers them to the body. Having the stomach interact with the body's whole reagent_container seemed odd, especially since removing the stomach effectively limited the body's whole reagent capacity to 25 or so unit.

This digestion rate is generally 1u per `process()` call (about once a second) split across all of the different reagents in the stomach. Individual reagents can have different digestion rates and more room is given for upgraded stomachs that could be given different reagent capacity, digestion rate, and possibly filters for reducing the amount of toxic reagents that make their way to the body, etc..

Also adds a proc for reagents called `digest()` that lets reagents do things in the stomach. Charcoal has been updated to use this. For the purposes of overdose calculations, the volume of a reagent in the body can be added to the volume of the same reagent in the stomach if a var for the reagent if `overdose_includes_stomach = TRUE`. ~~None~~ All of the current reagents have this var set to `TRUE` but it may come in handy in the future.

Any feedback or ideas are welcome.

Reagents that cause damage to or heal the stomach:

| Reagent | Damage (per second) | Stomach damage threshold (u) |
| --- | --- | --- |
| ~~Anti-Toxin~~ | ~~0.1~~| ~~15~~ |
| Bleach/spacecleaner/fishbleach | 1 | >0 |
| Ethanol | 0.08 | >0 |
| Imidazoline | -0.5 (heals) | >0 |

Other potential ideas/expansions:
* Give the stomach a number of bites variable that tracks how much food is in it. This value, and maybe even stomach damage, feeds into fullness calculations.
* Robotic/advanced stomach
* food/reagent temp causing damage
* stomach damage causing blood to be transferred to the stomach which leads to bloody puke

:cl:
* rscadd: The stomach holds reagents separately from the body and slowly transfers its contents to the body's reagent container. Individual reagents can interact with the stomach. THIS ONLY HAPPENS WITH DRINKING CURRENTLY.
* tweak: Some chemicals now damage or heal the stomach. Imidazoline heals it. Ethanol, Bleach, and Antitoxin damage it.