### PR TITLE
Merged disposal holders will prefer going to a destination, not disposals.

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -550,7 +550,7 @@
 	var/active = 0	// true if the holder is moving, otherwise inactive
 	dir = 0
 	var/count = 1000	//*** can travel 1000 steps before going inactive (in case of loops)
-	var/destinationTag = "DISPOSALS"// changes if contains a delivery container
+	var/destinationTag = DISP_DISPOSALS // changes if contains a delivery container
 	var/tomail = 0 //changes if contains wrapped package
 	var/hasmob = 0 //If it contains a mob
 
@@ -656,6 +656,10 @@
 // merge two holder objects
 // used when a a holder meets a stuck holder
 /obj/structure/disposalholder/proc/merge(var/obj/structure/disposalholder/other)
+	if(other.destinationTag != DISP_DISPOSALS && src.destinationTag == DISP_DISPOSALS)
+		// Lets make sure we don't accidentally dispose of stuff.
+		// Of course, if this happened before sorting this is a non-issue but if someone jammed the pipe after sorting, then it's a problem.
+		src.destinationTag = other.destinationTag
 	for(var/atom/movable/AM in other)
 		AM.forceMove(src)		// move everything in other holder to this one
 		if(ismob(AM))

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -656,9 +656,9 @@
 // merge two holder objects
 // used when a a holder meets a stuck holder
 /obj/structure/disposalholder/proc/merge(var/obj/structure/disposalholder/other)
-	if(other.destinationTag != DISP_DISPOSALS && src.destinationTag == DISP_DISPOSALS)
+	if(src.destinationTag == DISP_DISPOSALS && other.destinationTag != DISP_DISPOSALS)
 		// Lets make sure we don't accidentally dispose of stuff.
-		// Of course, if this happened before sorting this is a non-issue but if someone jammed the pipe after sorting, then it's a problem.
+		// Of course, if this happened before the cargo office this is a non-issue but if someone jammed the pipe after the office, then it's a problem.
 		src.destinationTag = other.destinationTag
 	for(var/atom/movable/AM in other)
 		AM.forceMove(src)		// move everything in other holder to this one


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl:
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
It should now make the passing holder assume the 'other' holder destination if it does not have one for itself, preventing items from being trashed because some fatass clogged the pipe _after_ the cargo office.

I didn't spy a logged issue, but looking over the merge code I could see a situation where it'd could happen.
:cl:
* tweak: If a disposal holder knocks another holder and merges with it, it will assume the merged holder if it's destination was the trash to prevent valuables from being trashed because of some fatass.