### PR TITLE
Fixed goof with WACKY disability

### DIFF
--- a/code/game/dna/genes/vg_disabilities.dm
+++ b/code/game/dna/genes/vg_disabilities.dm
@@ -62,11 +62,11 @@
 	activation_message = "You feel an off sensation in your voicebox.."
 	deactivation_message = "The off sensation passes.."
 
-/datum/dna/gene/disability/speech/sans/New()
+/datum/dna/gene/disability/sans/New()
 	..()
 	block = SANSBLOCK
 
-/datum/dna/gene/disability/speech/sans/OnSay(var/mob/M, var/datum/speech/speech)
+/datum/dna/gene/disability/sans/OnSay(var/mob/M, var/datum/speech/speech)
 	speech.message_classes.Add("sans") // SPEECH 2.0!!!1
 
 /datum/dna/gene/disability/veganism


### PR DESCRIPTION
```
UNIT TEST FAIL: /datum/unit_test/dna_and_disabilities 0s
	REASON #1: /datum/dna/gene/disability/speech/sans does not specify an activation message.
	REASON #2: /datum/dna/gene/disability/speech/sans does not specify a deactivation message.
	REASON #3: /datum/dna/gene/disability/speech does not specify an activation message.
	REASON #4: /datum/dna/gene/disability/speech does not specify a deactivation message.
```