### PR TITLE
Fixes POS products view, Prevents charging below the lowest denomination, and other tweaks/fixes

### DIFF
--- a/__DEFINES/_macros.dm
+++ b/__DEFINES/_macros.dm
@@ -295,3 +295,7 @@ proc/get_space_area()
 //Swaps the contents of the variables A and B. The if(TRUE) is there simply to restrict the scope of _.
 //Yes, _ is a shitty variable name. Hopefully so shitty it won't ever be used anywhere it could conflict with this.
 #define swap_vars(A, B) if(TRUE){var/_ = A; A = B; B = _}
+
+// To prevent situations of trying to take funds that are factions of our lowest denomination
+#define LOWEST_DENOMINATION 1
+#define round_to_lowest_denomination(A) (round(A, LOWEST_DENOMINATION))

--- a/code/game/objects/items/weapons/cash.dm
+++ b/code/game/objects/items/weapons/cash.dm
@@ -1,3 +1,5 @@
+// Remember to update the LOWEST_DENOMINATION define if you add a smaller denomination
+// WARNING: Update cash.dm's dispense_cash proc to permit denominations below $1, else it'll runtime. - CW
 var/global/list/moneytypes = list(
 	/obj/item/weapon/spacecash/c1000 = 1000,
 	/obj/item/weapon/spacecash/c100  = 100,
@@ -151,6 +153,7 @@ var/global/list/moneytypes = list(
 		new typepath(src)
 	..()
 
+// TODO: Allow denominations below $1
 /proc/dispense_cash(var/amount, var/loc)
 	for(var/cashtype in moneytypes)
 		var/slice = moneytypes[cashtype]

--- a/code/modules/Economy/POS.dm
+++ b/code/modules/Economy/POS.dm
@@ -369,6 +369,13 @@ var/const/POS_HEADER = {"<html>
 				<b>Tax Rate:</b> <input type="textbox" name="taxes" value="[POS_TAX_RATE*100]" disabled="disabled" />% (LOCKED)
 			</div>
 		</fieldset>
+		<fieldset>
+			<legend>Denomination Settings</legend>
+			<div>
+				<b>Lowest Denomination:</b> $<input type="textbox" name="lowestdenomination" value="[LOWEST_DENOMINATION]" disabled="disabled" /> (LOCKED)<br />
+				<i>Subtotals and Taxes are rounded to the nearest, lowest denomination</i>
+			</div>
+		</fieldset>
 		<input type="submit" name="act" value="Save Settings" />
 		</form>"}
 	return dat

--- a/code/modules/Economy/POS.dm
+++ b/code/modules/Economy/POS.dm
@@ -391,7 +391,7 @@ var/const/POS_HEADER = {"<html>
 	user.set_machine(src)
 	var/logindata=""
 	if(logged_in)
-		logindata={"<a href="?src=\ref[src];logout=1">[logged_in.name]</a>"}
+		logindata={"<a href="?src=\ref[src];logout=1">[logged_in.name]</a> |"}
 	var/dat = POS_HEADER + {"
 	<div class="navbar">
 		[worldtime2text()], [current_date_string]<br />

--- a/code/modules/Economy/POS.dm
+++ b/code/modules/Economy/POS.dm
@@ -165,6 +165,12 @@ var/const/POS_HEADER = {"<html>
 	else
 		linked_account = station_account
 
+/obj/machinery/pos/proc/dispense_change(var/amount)
+	var/obj/item/weapon/storage/box/B = new(loc)
+	dispense_cash(amount,B)
+	B.name="change"
+	B.desc="A box of change."
+
 /obj/machinery/pos/proc/AddToOrder(var/name, var/units)
 	if(!(name in products))
 		return 0
@@ -446,6 +452,11 @@ var/const/POS_HEADER = {"<html>
 	if("act" in href_list)
 		switch(href_list["act"])
 			if("Reset")
+				if(credits_held > 0){
+					visible_message("<span class='notice'>The machine buzzes.</span>","<span class='warning'>You hear a buzz.</span>")
+					dispense_change(credits_held)
+					credits_held=0
+				}
 				NewOrder()
 				screen=POS_SCREEN_ORDER
 			if("Finalize Sale")
@@ -572,14 +583,12 @@ var/const/POS_HEADER = {"<html>
 			visible_message("<span class='notice'>The machine beeps, and begins printing a receipt</span>","You hear a beep and the sound of paper being shredded.")
 			PrintReceipt()
 			NewOrder()
+			linked_account.charge(-credits_needed, null, "Purchase at POS #[id].", dest_name = linked_account.owner_name)
 			credits_held -= credits_needed
 			credits_needed=0
 			screen=POS_SCREEN_ORDER
 			if(credits_held>0)
-				var/obj/item/weapon/storage/box/B = new(loc)
-				dispense_cash(credits_held,B)
-				B.name="change"
-				B.desc="A box of change."
+				dispense_change(credits_held)
 			credits_held=0
 	..()
 

--- a/code/modules/Economy/POS.dm
+++ b/code/modules/Economy/POS.dm
@@ -4,6 +4,11 @@
 * Takes cash or credit.
 *************************/
 
+/*
+	For anyone confused why products["[products.len+1]"] = LI is used, it's so there's no type conversion required since href_list[] always produces a string.
+	Of course, this is what I've observed and assumed - CW
+*/
+
 /line_item
 	parent_type = /datum
 
@@ -296,7 +301,8 @@ var/const/POS_HEADER = {"<html>
 			</tr>"}
 	for(var/i in products)
 		var/line_item/LI = products[i]
-		dat += {"<tr class=\"[(i%2)?"even":"odd"]\">
+		var/pid = text2num(i)
+		dat += {"<tr class="[(pid%2)?"even":"odd"]">
 			<th><a href="?src=\ref[src];setpname=[i]">[LI.name]</a></th>
 			<td><a href="?src=\ref[src];setprice=[i]">$[num2septext(LI.price)]</a></td>
 			<td>[LI.units]</td>


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl:
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
Fixes POS' since all products use strings as their key and not numbers, causing the mod operation to not work.
![2018-08-07_00-41-37](https://user-images.githubusercontent.com/3196371/43754960-87aa00c8-99db-11e8-9d2f-0eb53081094f.gif)
Also prevents charging below the lowest denomination
![image](https://user-images.githubusercontent.com/3196371/43760949-94cff0da-99f1-11e8-8c00-45d49a1a555d.png)
And adds ingame explanation on how the subtotal and taxes are calculated.
![2018-08-07_03-43-49](https://user-images.githubusercontent.com/3196371/43764942-c21fc56e-99fc-11e8-89c4-a45d0fb5cd03.png)

There's now a define going by `LOWEST_DENOMINATION` for the lowest denomination we have in the game along with `round_to_lowest_denomination` to help make sure other machines don't use factions of our lowest denomination.

:cl:
* bugfix: POS' product views now work.
* bugfix: POS' no longer charge below the lowest denomination
* bugfix: POS' now prompt if you want to log out.
* bugfix: POS' now charge the linked account if spacecash is used instead of blackholing the spacecash.
* tweak: POS' now separate the login name like the rest of the other screens.
* rscadd: POS' now make change if the order was canceled
