### PR TITLE
Fixes RoidStation DNA computers

### DIFF
--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -488,10 +488,8 @@
 		qdel(src)
 
 /obj/machinery/computer/scan_consolenew/proc/findScanner()
-	for(dir in list(NORTH,EAST,SOUTH,WEST))
-		var/foundmachine = locate(/obj/machinery/dna_scannernew, get_step(src, dir))
-		if(foundmachine)
-			return foundmachine
+	for(var/obj/machinery/dna_scannernew/DN in oview(1, src)) // All 8 directions.
+		return DN
 
 /obj/machinery/computer/scan_consolenew/proc/all_dna_blocks(var/list/buffer)
 	var/list/arr = list()


### PR DESCRIPTION
Instead of looking for the 4 cardinals, it looks for all the Machinery in its view.
I find it weird that this is done in `New()`, behind a spawn(), rather than in `Initialize` but oh well.

I also tested this on Box, it still works.

![proof](https://user-images.githubusercontent.com/31417754/43804878-e9589646-9a9d-11e8-8d71-46c924fafa0a.png)

Addresses part of #19168 
>DNA modifiers aren't connected to scanners (can't make monkeymen or... do any genetics really)

:cl:
- bugfix: Roidstation : DNA computers are properly setup at roundstart.