### PR TITLE
Roidstation gulag and mining areas are now radshielded

### DIFF
--- a/code/modules/events/radiation_storm.dm
+++ b/code/modules/events/radiation_storm.dm
@@ -12,6 +12,8 @@
 		/area/vox_station,
 		/area/syndicate_station,
 		/area/medical/coldstorage,
+		/area/mine,
+		/area/prison,
 	)
 
 


### PR DESCRIPTION
Fixes #19207

/area/mine/ and /area/prison/ are now radshielded to keep miners and enemies of the Party from getting cool superpowers. This shouldn't affect any of the non-roid maps, because these areas aren't used on Z-1 on them (except on Metaclub, but it only uses prison solars on the AI minisat in the ass end of nowhere, which is pretty much a maintenance area anyway).

:cl:
- tweak: The Gulag and the asteroid areas on Roidstation are now shielded against radiation storms.

<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl:
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
