### PR TITLE
Blindness and deafness sanity for a bunch of effects

### DIFF
--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -295,18 +295,14 @@
 			C.Stun(8)
 			C.Knockdown(8)
 			C.stuttering += 20
-			if(!C.blinded)
-				C.blinded = 1
-			C.blinded += 5
+			C.flash_eyes(intensity = 4, visual = 1)
 		for(var/mob/living/carbon/C in dist_mobs)
 			var/distance_value = max(0, abs((get_dist(C, M.current)-3)) + 1)
 			C.Stun(distance_value)
 			if(distance_value > 1)
 				C.Knockdown(distance_value)
 			C.stuttering += 5+distance_value * ((VAMP_CHARISMA in M.vampire.powers) ? 2 : 1) //double stutter time with Charisma
-			if(!C.blinded)
-				C.blinded = 1
-			C.blinded += max(1, distance_value)
+			C.flash_eyes(intensity = 4, visual = 1)
 		to_chat((dist_mobs + close_mobs), "<span class='warning'>You are blinded by [M.current.name]'s glare</span>")
 
 

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -286,7 +286,7 @@
 			if(istype(C))
 				close_mobs |= C // using |= prevents adding 'large bounded' mobs twice with how the loop works
 		for(var/mob/living/carbon/C in view(3))
-			if(!C.vampire_affected(M))
+			if(!C.vampire_affected(M) || C.is_blind())
 				continue
 			if(istype(C))
 				dist_mobs |= C

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -183,7 +183,7 @@
 		to_chat(M, "<span class='warning'>You're not close enough to [C.name] to stare into \his eyes.</span>")
 		return
 
-	if(C.is_blind())
+	if(C.blinded)
 		to_chat(M, "<span class='warning'>[C.name]'s eyes are unresponsive! Hypnosis won't work if your victim can't see!</span>")
 		return
 
@@ -280,13 +280,13 @@
 		var/list/close_mobs = list()
 		var/list/dist_mobs = list()
 		for(var/mob/living/carbon/C in view(1))
-			if(!C.vampire_affected(M) || C.is_blind())
+			if(!C.vampire_affected(M) || C.blinded)
 				continue
 			//if(!M.current.vampire_can_reach(C, 1)) continue
 			if(istype(C))
 				close_mobs |= C // using |= prevents adding 'large bounded' mobs twice with how the loop works
 		for(var/mob/living/carbon/C in view(3))
-			if(!C.vampire_affected(M) || C.is_blind())
+			if(!C.vampire_affected(M) || C.blinded)
 				continue
 			if(istype(C))
 				dist_mobs |= C

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -182,6 +182,11 @@
 	if(!C in view(1))
 		to_chat(M, "<span class='warning'>You're not close enough to [C.name] to stare into \his eyes.</span>")
 		return
+
+	if(C.is_blind())
+		to_chat(M, "<span class='warning'>[C.name]'s eyes are unresponsive! Hypnosis won't work if your victim can't see!</span>")
+		return
+
 	M.current.visible_message("<span class='warning'>[M.current.name]'s eyes flash briefly as he stares into [C.name]'s eyes</span>")
 	M.current.verbs -= /client/proc/vampire_hypnotise
 	spawn(1800)
@@ -275,7 +280,7 @@
 		var/list/close_mobs = list()
 		var/list/dist_mobs = list()
 		for(var/mob/living/carbon/C in view(1))
-			if(!C.vampire_affected(M))
+			if(!C.vampire_affected(M) || C.is_blind())
 				continue
 			//if(!M.current.vampire_can_reach(C, 1)) continue
 			if(istype(C))
@@ -343,7 +348,7 @@
 				var/mob/living/carbon/human/H = C
 				if(H.earprot())
 					continue
-			if(!C.vampire_affected(M))
+			if(!C.vampire_affected(M) || C.is_deaf())
 				continue
 			to_chat(C, "<span class='danger'><font size='3'>You hear a ear piercing shriek and your senses dull!</font></span>")
 			C.Knockdown(8)
@@ -643,7 +648,7 @@
 	for(var/mob/living/carbon/C in oview(6))
 		if(prob(35))
 			continue //to prevent fearspam
-		if(!C.vampire_affected(mind.current))
+		if(!C.vampire_affected(mind.current) || C.is_blind())
 			continue
 		C.stuttering += 20
 		C.Jitter(20)

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -89,7 +89,8 @@ var/list/obj/machinery/flasher/flashers = list()
 			continue
 		if (get_dist(src, O) > src.range)
 			continue
-
+		if(O.is_blind())
+			continue
 		if (istype(O, /mob/living/carbon/alien))//So aliens don't get flashed (they have no external eyes)/N
 			continue
 		if(istype(O, /mob/living))

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -89,7 +89,7 @@ var/list/obj/machinery/flasher/flashers = list()
 			continue
 		if (get_dist(src, O) > src.range)
 			continue
-		if(O.is_blind())
+		if(O.blinded)
 			continue
 		if (istype(O, /mob/living/carbon/alien))//So aliens don't get flashed (they have no external eyes)/N
 			continue

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -126,6 +126,8 @@
 	playsound(chassis, 'sound/items/AirHorn.ogg', 100, 1)
 	chassis.occupant_message("<font color='red' size='5'>HONK</font>")
 	for(var/mob/living/carbon/M in ohearers(6, chassis))
+		if(M.is_deaf())
+			continue
 		if(istype(M, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = M
 			if(H.earprot())

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -90,7 +90,7 @@
 			sleep(5)
 			qdel(animation)
 
-	var/flashfail = (harm_labeled >= min_harm_label) || M.is_blind() //Flashfail is always true if the device has been successfully harm-labeled.
+	var/flashfail = (harm_labeled >= min_harm_label) || M.blinded //Flashfail is always true if the device has been successfully harm-labeled.
 
 	if(iscarbon(M))
 		var/mob/living/carbon/Subject = M
@@ -195,6 +195,8 @@
 								"<span class='warning'>You see a bright flash of light and are suddenly fully visible again.</span>")
 				spawn(50)
 					M.alpha = oldalpha
+		if(M.blinded)
+			continue
 		var/safety = M:eyecheck()
 		if(!safety)
 			M.flash_eyes(affect_silicon = 1)
@@ -216,7 +218,7 @@
 			if(istype(loc, /mob/living/carbon) && harm_labeled < min_harm_label)
 				var/mob/living/carbon/M = loc
 				var/safety = M.eyecheck()
-				if(safety <= 0 && !M.is_blind())
+				if(safety <= 0 && !M.blinded)
 					M.Knockdown(10)
 					M.flash_eyes(visual = 1)
 					for(var/mob/O in viewers(M, null))

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -90,12 +90,12 @@
 			sleep(5)
 			qdel(animation)
 
-	var/flashfail = (harm_labeled >= min_harm_label) //Flashfail is always true if the device has been successfully harm-labeled.
+	var/flashfail = (harm_labeled >= min_harm_label) || M.is_blind() //Flashfail is always true if the device has been successfully harm-labeled.
 
 	if(iscarbon(M))
 		var/mob/living/carbon/Subject = M
 
-		if(Subject.eyecheck() > 0)
+		if(Subject.eyecheck() > 0 || flashfail)
 			user.visible_message("<span class='notice'>[user] fails to blind [M] with the flash!</span>")
 		else
 			if(Subject.eyecheck() <= 0)
@@ -216,7 +216,7 @@
 			if(istype(loc, /mob/living/carbon) && harm_labeled < min_harm_label)
 				var/mob/living/carbon/M = loc
 				var/safety = M.eyecheck()
-				if(safety <= 0)
+				if(safety <= 0 && !M.is_blind())
 					M.Knockdown(10)
 					M.flash_eyes(visual = 1)
 					for(var/mob/O in viewers(M, null))

--- a/code/game/objects/items/robot/robot_items/robot_harm_alarm.dm
+++ b/code/game/objects/items/robot/robot_items/robot_harm_alarm.dm
@@ -31,7 +31,7 @@
 		playsound(src, alarm_sound, 70, 3, vary = src.vary)
 		add_gamelogs(user, "used \the [src]", admin = TRUE, tp_link = TRUE, tp_link_short = FALSE, span_class = "notice")
 		for(var/mob/living/carbon/M in hearers(9, user))
-			if(M.earprot())
+			if(M.earprot() || M.is_deaf())
 				continue
 			to_chat(M, "<span class='warning'>[user] blares out a near-deafening siren from its speakers!</span>")
 			to_chat(M, "<span class='danger'>The siren pierces your hearing!</span>")

--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -54,7 +54,7 @@
 			ear_safety += 1
 
 //Flashing everyone
-	if(eye_safety < 1 && !M.is_blind())
+	if(eye_safety < 1 && !M.blinded)
 		M.flash_eyes(visual = 1, affect_silicon = 1)
 		if (get_dist(M, T) <= 3)
 			M.Stun(8)

--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -54,7 +54,7 @@
 			ear_safety += 1
 
 //Flashing everyone
-	if(eye_safety < 1)
+	if(eye_safety < 1 && !M.is_blind())
 		M.flash_eyes(visual = 1, affect_silicon = 1)
 		if (get_dist(M, T) <= 3)
 			M.Stun(8)
@@ -69,20 +69,23 @@
 				M.Knockdown(1)
 
 //Now applying sound
-	if(!ear_safety)
-		to_chat(M, "<span class='userdanger'>BANG</span>")
-		playsound(src, 'sound/effects/bang.ogg', 60, 1)
-	else
-		to_chat(M, "<span class='danger'>BANG</span>")
-		playsound(src, 'sound/effects/bang.ogg', 25, 1)
+	if(!M.is_deaf())
+		if(!ear_safety)
+			to_chat(M, "<span class='userdanger'>BANG</span>")
+			playsound(src, 'sound/effects/bang.ogg', 60, 1)
+		else
+			to_chat(M, "<span class='danger'>BANG</span>")
+			playsound(src, 'sound/effects/bang.ogg', 25, 1)
 
 	if((get_dist(M, T) <= 2 || src.loc == M.loc || src.loc == M))
 		if(ear_safety > 0)
-			M.Stun(2)
-			M.Knockdown(2)
+			if(!M.is_deaf())
+				M.Stun(2)
+				M.Knockdown(2)
 		else
-			M.Stun(8)
-			M.Knockdown(8)
+			if(!M.is_deaf())
+				M.Stun(8)
+				M.Knockdown(8)
 			if ((prob(14) || (M == src.loc && prob(70))))
 				M.ear_damage += rand(1, 10)
 			else
@@ -91,22 +94,25 @@
 
 	else if(get_dist(M, T) <= 3)
 		if(!ear_safety)
-			M.Stun(6)
-			M.Knockdown(6)
+			if(!M.is_deaf())
+				M.Stun(6)
+				M.Knockdown(6)
 			M.ear_damage += rand(0, 3)
 			M.ear_deaf = max(M.ear_deaf,10)
 
 	else if(get_dist(M, T) <= 5)
 		if(!ear_safety)
-			M.Stun(4)
-			M.Knockdown(4)
+			if(!M.is_deaf())
+				M.Stun(4)
+				M.Knockdown(4)
 			M.ear_damage += rand(0, 3)
 			M.ear_deaf = max(M.ear_deaf,10)
 
 	else if(!ear_safety)
-		if (issilicon(M))
-			M.Stun(4)
-		M.Knockdown(1)
+		if(!M.is_deaf())
+			if (issilicon(M))
+				M.Stun(4)
+			M.Knockdown(1)
 		M.ear_damage += rand(0, 1)
 		M.ear_deaf = max(M.ear_deaf,5)
 

--- a/code/modules/mob/living/silicon/robot/robot_verbs.dm
+++ b/code/modules/mob/living/silicon/robot/robot_verbs.dm
@@ -89,6 +89,10 @@
 	if(!toggle)
 		return
 
+	if(toggle == "camera" && incapacitated())
+		to_chat(src, "<span class='warning'>You can't do that while you're incapacitated.</span>")
+		return
+
 	var/datum/robot_component/C = components[toggle]
 	if(C.toggled)
 		C.toggled = FALSE

--- a/code/modules/projectiles/guns/projectile/constructable/blinder.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/blinder.dm
@@ -87,6 +87,9 @@
 /obj/item/device/blinder/proc/flash(var/turf/T , var/mob/living/M)
 	playsound(src, 'sound/weapons/flash.ogg', 100, 1)
 
+	if(M.blinded)
+		return
+
 	M.flash_eyes(visual = 1)
 
 	if(issilicon(M))

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -505,6 +505,8 @@
 		playsound(src, 'sound/effects/phasein.ogg', 25, 1)
 
 		for(var/mob/living/M in viewers(get_turf(holder.my_atom), null))
+			if(M.is_blind())
+				continue
 			var/eye_safety = 0
 			if(iscarbon(M))
 				eye_safety = M.eyecheck()
@@ -1211,15 +1213,20 @@
 	playsound(holder.my_atom, 'sound/effects/phasein.ogg', 100, 1)
 
 	for(var/mob/O in viewers(get_turf(holder.my_atom), null))
-		if(ishuman(O))
+		if(O.is_blind())
+			if(O.is_deaf())
+				to_chat(O, "<span class='danger'>You feel a strange rumbling!</span>")
+			else
+				to_chat(O, "<span class='danger'>You hear a rumbling and terrifying noises!</span>")
+		else if(ishuman(O))
 			var/mob/living/carbon/human/H = O
 			if((H.eyecheck() <= 0) && (!istype(H.glasses, /obj/item/clothing/glasses/science)))
 				H.flash_eyes(visual = 1)
-				to_chat(O, "<span class='danger'>A flash blinds you while you start hearing terrifying noises!</span>")
+				to_chat(O, "<span class='danger'>A flash blinds you[O.is_deaf() ? "" : " while you start hearing terrifying noises"]!</span>")
 			else
-				to_chat(O, "<span class='danger'>You hear a rumbling as a troup of monsters phases into existence!</span>")
+				to_chat(O, "<span class='danger'>[O.is_deaf() ? "A" : "You hear a rumbling as a"] troup of monsters phases into existence!</span>")
 		else
-			to_chat(O, "<span class='danger'>You hear a rumbling as a troup of monsters phases into existence!</span>")
+			to_chat(O, "<span class='danger'>[O.is_deaf() ? "A" : "You hear a rumbling as a"] troup of monsters phases into existence!</span>")
 
 	for(var/i = 1, i <= 5, i++)
 		var/chosen = pick(critters)
@@ -1259,15 +1266,20 @@
 	playsound(holder.my_atom, 'sound/effects/phasein.ogg', 100, 1)
 
 	for(var/mob/O in viewers(get_turf(holder.my_atom), null))
-		if(ishuman(O))
+		if(O.is_blind())
+			if(O.is_deaf())
+				to_chat(O, "<span class='rose'>There's a sudden whiff of ozone in the air!</span>")
+			else
+				to_chat(O, "<span class='rose'>You hear an eerie crackling!</span>")
+		else if(ishuman(O))
 			var/mob/living/carbon/human/H = O
 			if((H.eyecheck() <= 0) && (!istype(H.glasses, /obj/item/clothing/glasses/science)))
 				H.flash_eyes(visual = 1)
 				to_chat(O, "<span class='rose'>A flash blinds and you can feel a new presence!</span>")
 			else
-				to_chat(O, "<span class='rose'>You hear a crackling as a creature manifests before you!</span>")
+				to_chat(O, "<span class='rose'>[O.is_deaf() ? "A" : "You hear a crackling as a"] creature manifests before you!</span>")
 		else
-			to_chat(O, "<span class='rose'>You hear a crackling as a creature manifests before you!</span>")
+			to_chat(O, "<span class='rose'>[O.is_deaf() ? "A" : "You hear a crackling as a"] creature manifests before you!</span>")
 
 	var/chosen = pick(critters)
 	var/mob/living/simple_animal/hostile/C = new chosen
@@ -1352,7 +1364,9 @@
 	playsound(holder.my_atom, 'sound/effects/phasein.ogg', 100, 1)
 
 	for(var/mob/O in viewers(get_turf(holder.my_atom), null))
-		if(ishuman(O))
+		if(O.is_blind())
+			to_chat(O,"<span class='notice'>you think you can smell some food nearby!</span>")
+		else if(ishuman(O))
 			var/mob/living/carbon/human/H = O
 			if((H.eyecheck() <= 0) && (!istype(H.glasses, /obj/item/clothing/glasses/science)))
 				H.flash_eyes(visual = 1)
@@ -1406,11 +1420,15 @@
 	playsound(holder.my_atom, 'sound/effects/phasein.ogg', 100, 1)
 
 	for(var/mob/O in viewers(get_turf(holder.my_atom), null))
+		if(O.is_blind())
+			if(O.is_deaf())
+				return
+			to_chat(O, "<span class='caution'>You think you can hear bottles rolling on the floor!</span>")
 		if(ishuman(O))
 			var/mob/living/carbon/human/H = O
 			if((H.eyecheck() <= 0) && (!istype(H.glasses, /obj/item/clothing/glasses/science)))
 				H.flash_eyes(visual = 1)
-				to_chat(O, "<span class='caution'>A white light blinds you and you think you can hear bottles rolling on the floor!</span>")
+				to_chat(O, "<span class='caution'>A white light blinds you[O.is_deaf() ? "" : " and you think you can hear bottles rolling on the floor"]!</span>")
 			else
 				to_chat(O, "<span class='notice'>A bunch of drinks appears before you!</span>")
 		else

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -1422,7 +1422,7 @@
 	for(var/mob/O in viewers(get_turf(holder.my_atom), null))
 		if(O.is_blind())
 			if(O.is_deaf())
-				return
+				continue
 			to_chat(O, "<span class='caution'>You think you can hear bottles rolling on the floor!</span>")
 		if(ishuman(O))
 			var/mob/living/carbon/human/H = O

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -505,7 +505,7 @@
 		playsound(src, 'sound/effects/phasein.ogg', 25, 1)
 
 		for(var/mob/living/M in viewers(get_turf(holder.my_atom), null))
-			if(M.is_blind())
+			if(M.blinded)
 				continue
 			var/eye_safety = 0
 			if(iscarbon(M))


### PR DESCRIPTION
Resolves #18057

This touches on sticky [Balance] stuff of course, but something needs to be done about all these sensory-based weapons working on people without said senses.

:cl:
* tweak: Added blindness and deafness checks to many light/sound-based effects, including flashes, flashers, flashbangs, flash powder, blinders, the Honker Blast 5000, harm alarms, vampire powers, and some slime reactions.