### PR TITLE
Lighting overlays don't show up in turf alt-click menu

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1486,6 +1486,8 @@ var/list/slot_equipment_priority = list( \
 			else if(statpanel(listed_turf.name))
 				statpanel(listed_turf.name, null, listed_turf)
 				for(var/atom/A in listed_turf)
+					if(!A.mouse_opacity)
+						continue
 					if(A.invisibility > see_invisible)
 						continue
 					statpanel(listed_turf.name, null, A)


### PR DESCRIPTION
Fixes #17699

Can't think of any reason you'd want a mouse_opacity=0 atom to show up there