### PR TITLE
Adds unsimulated gas_mixtures

### DIFF
--- a/code/ZAS/Turf.dm
+++ b/code/ZAS/Turf.dm
@@ -207,7 +207,7 @@
 
 /turf/return_air()
 	//Create gas mixture to hold data for passing
-	var/datum/gas_mixture/GM = new
+	var/datum/gas_mixture/unsimulated/GM = new
 
 	GM.oxygen = oxygen
 	GM.carbon_dioxide = carbon_dioxide
@@ -258,8 +258,8 @@
 /turf/proc/make_air()
 	air = new/datum/gas_mixture
 	air.temperature = temperature
-	air.adjust(oxygen, carbon_dioxide, nitrogen, toxins)
 	air.volume = CELL_VOLUME
+	air.adjust(oxygen, carbon_dioxide, nitrogen, toxins)
 
 /turf/simulated/proc/c_copy_air()
 	if(!air)

--- a/code/ZAS/_gas_mixture.dm
+++ b/code/ZAS/_gas_mixture.dm
@@ -661,3 +661,113 @@ var/static/list/sharing_lookup_table = list(0.30, 0.40, 0.48, 0.54, 0.60, 0.66)
 	if(locate(/datum/gas/sleeping_agent) in trace_gases)
 		naughty_stuff += "<b><font color='red'>N<sub>2</sub>O</font>"
 	return english_list(naughty_stuff, nothing_text = "")
+
+
+
+//Unsimulated gas_mixture
+//Acts like a gas_mixture, except none of the procs actually change it.
+
+/datum/gas_mixture/unsimulated/adjust(o2 = 0, co2 = 0, n2 = 0, tx = 0, list/datum/gas/traces)
+	return
+
+
+/datum/gas_mixture/unsimulated/adjust_gas(gasid, moles, update = TRUE)
+	return
+
+
+/datum/gas_mixture/unsimulated/adjust_gas_temp(gasid, moles, temp, update = TRUE)
+	return
+
+
+/datum/gas_mixture/unsimulated/adjust_multi()
+	ASSERT(!(args.len % 2))
+
+
+/datum/gas_mixture/unsimulated/adjust_multi_temp()
+	ASSERT(!(args.len % 3))
+
+
+/datum/gas_mixture/unsimulated/merge(datum/gas_mixture/giver)
+	return !isnull(giver)
+
+
+/datum/gas_mixture/unsimulated/equalize(datum/gas_mixture/sharer)
+	return sharer.equalize(src) //Won't actually equalize the two mixtures, but will affect sharer the same way it would have if src weren't unsimulated.
+
+
+/datum/gas_mixture/unsimulated/add_thermal_energy(var/thermal_energy)
+	return 0
+
+
+/datum/gas_mixture/unsimulated/get_thermal_energy_change(var/new_temperature)
+	return 0 //Real answer would be infinity, but that would be virtually guaranteed to cause problems.
+
+
+/datum/gas_mixture/unsimulated/remove(amount)
+	var/sum = total_moles()
+	amount = min(amount, sum) //Can not take more air than tile has!
+	if(amount <= 0)
+		return null
+
+	var/datum/gas_mixture/removed = new
+
+	removed.oxygen = QUANTIZE((oxygen / sum) * amount)
+	removed.nitrogen = QUANTIZE((nitrogen / sum) * amount)
+	removed.carbon_dioxide = QUANTIZE((carbon_dioxide / sum) * amount)
+	removed.toxins = QUANTIZE((toxins / sum) * amount)
+
+	if(trace_gases.len)
+		for(var/datum/gas/trace_gas in trace_gases)
+			var/datum/gas/corresponding = new trace_gas.type()
+			removed.trace_gases += corresponding
+			corresponding.moles = (trace_gas.moles / sum) * amount
+
+	removed.temperature = temperature
+	removed.update_values()
+
+	return removed
+
+
+/datum/gas_mixture/unsimulated/remove_ratio(ratio)
+	if(ratio <= 0 || total_moles <= 0)
+		return null
+
+	ratio = min(ratio, 1)
+
+	var/datum/gas_mixture/removed = new
+
+	removed.oxygen = QUANTIZE(oxygen * ratio)
+	removed.nitrogen = QUANTIZE(nitrogen * ratio)
+	removed.carbon_dioxide = QUANTIZE(carbon_dioxide * ratio)
+	removed.toxins = QUANTIZE(toxins * ratio)
+
+	if(trace_gases.len)
+		for(var/datum/gas/trace_gas in trace_gases)
+			var/datum/gas/corresponding = new trace_gas.type()
+			removed.trace_gases += corresponding
+			corresponding.moles = trace_gas.moles * ratio
+
+	removed.temperature = temperature
+	removed.update_values()
+
+	return removed
+
+
+/datum/gas_mixture/unsimulated/copy_from(datum/gas_mixture/sample)
+	return FALSE
+
+
+/datum/gas_mixture/unsimulated/add(datum/gas_mixture/right_side)
+	return FALSE
+
+
+/datum/gas_mixture/unsimulated/subtract(datum/gas_mixture/right_side)
+	return FALSE
+
+
+/datum/gas_mixture/unsimulated/multiply(factor)
+	return FALSE
+
+
+/datum/gas_mixture/unsimulated/divide(factor)
+	return FALSE


### PR DESCRIPTION
These behave exactly like normal `gas_mixture`s, except none of their procs actually change them. Assuming I didn't fuck up, they should produce exactly the same effects as normal `gas_mixture`s on everything except themselves when used in the same places.
Unsimulated turfs now return unsimulated `gas_mixture`s in `return_air()`. This should start paving the way to removing checks for unsimulated turfs in ZAS, and unifying some of its systems.