### PR TITLE
AI holopad communication doesn't require .h prefix anymore

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -184,7 +184,8 @@ var/list/department_radio_keys = list(
 		message = copytext(message, 2)
 	else if(message_mode)
 		say_testing(src, "Message mode is [message_mode]")
-		message = copytext(message, 3)
+		if(message_mode != MODE_HOLOPAD)
+			message = copytext(message, 3)
 
 	// SAYCODE 90.0!
 	// We construct our speech object here.

--- a/code/modules/mob/living/silicon/ai/say.dm
+++ b/code/modules/mob/living/silicon/ai/say.dm
@@ -48,10 +48,9 @@
 	return !config.silent_ai
 
 /mob/living/silicon/ai/get_message_mode(message)
-	if(department_radio_keys[copytext(message, 1, 3)] == MODE_DEPARTMENT)
+	. = ..()
+	if(. != MODE_ROBOT && istype(current, /obj/machinery/hologram/holopad))
 		return MODE_HOLOPAD
-	else
-		return ..()
 
 /mob/living/silicon/ai/handle_inherent_channels(var/datum/speech/speech, var/message_mode)
 	say_testing(src, "[type]/handle_inherent_channels([message_mode])")


### PR DESCRIPTION
Closes #10297

:cl:
 * tweak: AIs don't need to prefix their messages with ".h" anymore to communicate via holopad. The message automatically goes through the holopad if it's not meant for radio.