### PR TITLE
Mommers sends a message for when the game actually starts.

### DIFF
--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -211,6 +211,9 @@ var/datum/controller/gameticker/ticker
 					qdel(obj)
 
 		to_chat(world, "<FONT color='blue'><B>Enjoy the game!</B></FONT>")
+		
+		send2maindiscord("**The game has started**")
+		
 //		world << sound('sound/AI/welcome.ogg')// Skie //Out with the old, in with the new. - N3X15
 
 		if(!config.shut_up_automatic_diagnostic_and_announcement_system)


### PR DESCRIPTION
A simple QoL change - mommi now sends a message when the game starts. I have no idea how to test this. With this, you should be able to tell at a glance if you can still join the game in its lobby phase or if the game is already on.

:cl:
 * rscadd: Mommi now sends a message to the Discord's server-status channel when the game actually begins.