### PR TITLE
Click-dragging any equipped item to your hand

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1240,3 +1240,19 @@ var/global/list/image/blood_overlays = list()
 
 /obj/item/proc/recyclable() //Called by RnD machines, for added object-specific sanity.
 	return TRUE
+
+/obj/item/MouseDropFrom(var/obj/over_object)
+	if(!istype(over_object, /obj/abstract/screen/inventory))
+		return ..()
+	if(!ishuman(usr) && !ismonkey(usr))
+		return ..()
+	if(!usr.is_wearing_item(src) || !canremove)
+		return ..()
+	if(usr.incapacitated())
+		return ..()
+	var/obj/abstract/screen/inventory/OI = over_object
+
+	if(OI.hand_index && usr.put_in_hand_check(src, OI.hand_index))
+		usr.u_equip(src, TRUE)
+		usr.put_in_hand(OI.hand_index, src)
+		add_fingerprint(usr)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1241,6 +1241,9 @@ var/global/list/image/blood_overlays = list()
 /obj/item/proc/recyclable() //Called by RnD machines, for added object-specific sanity.
 	return TRUE
 
+/obj/item/proc/on_mousedrop_to_inventory_slot()
+	return
+
 /obj/item/MouseDropFrom(var/obj/over_object)
 	if(!istype(over_object, /obj/abstract/screen/inventory))
 		return ..()
@@ -1250,7 +1253,9 @@ var/global/list/image/blood_overlays = list()
 		return ..()
 	if(usr.incapacitated())
 		return ..()
+
 	var/obj/abstract/screen/inventory/OI = over_object
+	on_mousedrop_to_inventory_slot()
 
 	if(OI.hand_index && usr.put_in_hand_check(src, OI.hand_index))
 		usr.u_equip(src, TRUE)

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -159,28 +159,6 @@
 	colour_overlay = image('icons/obj/chemical.dmi',"bottle_colour")
 	overlays += colour_overlay
 
-
-/obj/item/weapon/storage/pill_bottle/MouseDropFrom(obj/over_object as obj) //Quick pillbottle fix. -Agouri
-	if (ishuman(usr) || ismonkey(usr)) //Can monkeys even place items in the pocket slots? Leaving this in just in case~
-		var/mob/M = usr //I don't see how this is necessary
-		if (!( istype(over_object, /obj/abstract/screen/inventory) ))
-			return ..()
-		if (!M.incapacitated() && Adjacent(M))
-			var/obj/abstract/screen/inventory/SI = over_object
-
-			if(SI.hand_index && M.put_in_hand_check(src, SI.hand_index))
-				M.u_equip(src, 0)
-				M.put_in_hand(SI.hand_index, src)
-				src.add_fingerprint(usr)
-
-			return
-		if(over_object == usr && in_range(src, usr) || usr.contents.Find(src))
-			if (usr.s_active)
-				usr.s_active.close(usr)
-			src.show_to(usr)
-			return
-	return ..()
-
 /obj/item/weapon/storage/pill_bottle/AltClick()
 	if(!usr.isUnconscious() && Adjacent(usr))
 		change()

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -34,6 +34,9 @@
 /obj/item/weapon/storage/proc/can_use()
 	return TRUE
 
+/obj/item/weapon/storage/on_mousedrop_to_inventory_slot()
+	playsound(src, "rustle", 50, 1, -5)
+
 /obj/item/weapon/storage/MouseDropFrom(obj/over_object as obj)
 	if(over_object == usr && (in_range(src, usr) || is_holder_of(usr, src)))
 		orient2hud(usr)
@@ -41,34 +44,14 @@
 			usr.s_active.close(usr)
 		src.show_to(usr)
 		return
-	if(ishuman(usr) || ismonkey(usr) || isrobot(usr) && is_holder_of(usr, src)) //so monkeys can take off their backpacks -- Urist
-		var/mob/M = usr
-		if(istype(over_object, /obj/structure/table) && M.Adjacent(over_object) && Adjacent(M))
+	if(ishuman(usr) || ismonkey(usr) || isrobot(usr) && is_holder_of(usr, src))
+		if(istype(over_object, /obj/structure/table) && usr.Adjacent(over_object) && Adjacent(usr))
 			var/mob/living/L = usr
 			if(istype(L) && !(L.incapacitated() || L.lying))
 				if(can_use())
 					empty_contents_to(over_object)
 					return
 
-		if(isrobot(usr))
-			return ..()
-
-		if(!( istype(over_object, /obj/abstract/screen/inventory) ))
-			return ..()
-
-		if(!(src.loc == usr) || (src.loc && src.loc.loc == usr))
-			return ..()
-
-		playsound(src, "rustle", 50, 1, -5)
-		if(!( M.restrained() ) && !( M.stat ))
-			var/obj/abstract/screen/inventory/OI = over_object
-
-			if(OI.hand_index && M.put_in_hand_check(src, OI.hand_index))
-				M.u_equip(src, 1)
-				M.put_in_hand(OI.hand_index, src)
-				src.add_fingerprint(usr)
-
-			return
 	return ..()
 
 /obj/item/weapon/storage/proc/empty_contents_to(var/atom/place)

--- a/code/game/objects/storage/coat.dm
+++ b/code/game/objects/storage/coat.dm
@@ -39,22 +39,12 @@
 	hold.emp_act(severity)
 	..()
 
-/obj/item/clothing/suit/storage/MouseDropFrom(atom/over_object)
-	if(ishuman(usr) || ismonkey(usr))
-		var/mob/M = usr
-		if(istype(over_object, /obj/abstract/screen/inventory)) //was clickdragged to an inventory slot, we want to be able to take our coat off
-			if(!M.incapacitated() && is_holder_of(M, src))
-				playsound(src, "rustle", 50, 1, -5)
-				var/obj/abstract/screen/inventory/OI = over_object
+/obj/item/clothing/suit/storage/on_mousedrop_to_inventory_slot()
+	playsound(src, "rustle", 50, 1, -5)
 
-				if(OI.hand_index && M.put_in_hand_check(src, OI.hand_index))
-					M.u_equip(src, 0)
-					M.put_in_hand(OI.hand_index, src)
-					M.update_inv_wear_suit()
-					src.add_fingerprint(usr)
-				return
-		else if(over_object == usr) //show container to user
-			return hold.MouseDropFrom(over_object)
-		else if(istype(over_object, /obj/structure/table)) //empty on table
-			return hold.MouseDropFrom(over_object)
-	return ..() //don't let us move the coat's abstract internal storage!
+/obj/item/clothing/suit/storage/MouseDropFrom(atom/over_object)
+	if(over_object == usr) //show container to user
+		return hold.MouseDropFrom(over_object)
+	else if(istype(over_object, /obj/structure/table)) //empty on table
+		return hold.MouseDropFrom(over_object)
+	return ..()


### PR DESCRIPTION
Know how you have to drag your backpack or belt into your hand instead of clicking it?
What if you could do that for any item in any slot?
Now you can.

Why? Because un-equipping items is annoying when you have a jumpsuit with 10 holobadges, a holster, and a bandolier on it. Or when you want to just take off your shoes but instead you have to remove the knife from the holster, then the holster itself, then FINALLY get the boots.

:cl:
 * rscadd: You can click-drag any equipped item into your hand to move it there.