### PR TITLE
Liquid fuel tracks are now the color of fuel instead of blood-red

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/fuel.dm
+++ b/code/game/objects/effects/decals/Cleanable/fuel.dm
@@ -7,6 +7,8 @@
 
 	volatility = 0.02
 
+	basecolor = "#6D5757"
+
 /obj/effect/decal/cleanable/liquid_fuel/New(newLoc,amt=1)
 	src.amount = amt
 


### PR DESCRIPTION
Resolves #19302

They're still opaque but I don't feel like rewriting the tracks code to use alphas right now.

![fuel](https://user-images.githubusercontent.com/31839805/44011079-503d20ae-9e6b-11e8-9eb5-5a8e1066a79d.PNG)


:cl:
* tweak: Liquid fuel tracks are now the color of fuel instead of blood-red.