### PR TITLE
Shelter Tweaks

### DIFF
--- a/__DEFINES/reagents.dm
+++ b/__DEFINES/reagents.dm
@@ -98,6 +98,7 @@
 #define METHYLIN 			"methylin"
 #define BICARODYNE 			"bicarodyne"
 #define STABILIZINE 			"stabilizine"
+#define PRESLOMITE			"preslomite"
 #define NANITES 			"nanites"
 #define AUTISTNANITES 			"autistnanites"
 #define XENOMICROBES 			"xenomicrobes"

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -1050,9 +1050,19 @@ FIRE ALARM
 
 	src.alarm()
 
-/obj/machinery/firealarm/process()//Note: this processing was mostly phased out due to other code, and only runs when needed
+/obj/machinery/firealarm/process()
 	if(stat & (NOPOWER|BROKEN))
 		return
+
+	var/turf/simulated/location = loc
+	if(shelter && istype(location)) //If simulated turf and we have a shelter to drop
+		var/datum/gas_mixture/environment = location.return_air()
+		if(environment.toxins>1) //The simpler sensors aren't elaborate as air alarms to sense partial pressure or other threats
+			var/obj/item/inflatable/shelter/S = new /obj/item/inflatable/shelter(loc)
+			S.inflate()
+			shelter = FALSE
+			update_icon()
+			visible_message("<span class='warning'>\The [S] springs free of the fire alarm autonomously and inflates!</span>")
 
 	if(src.timing)
 		if(src.time > 0)
@@ -1061,7 +1071,6 @@ FIRE ALARM
 			src.alarm()
 			src.time = 0
 			src.timing = 0
-			processing_objects.Remove(src)
 		src.updateDialog()
 	last_process = world.timeofday
 
@@ -1122,7 +1131,6 @@ FIRE ALARM
 		else if (href_list["time"])
 			timing = !timing
 			last_process = world.timeofday
-			processing_objects.Add(src)
 		else if (href_list["tp"])
 			var/tp = text2num(href_list["tp"])
 			time += tp
@@ -1130,7 +1138,7 @@ FIRE ALARM
 		else if (href_list["shelter"])
 			if(shelter)
 				var/obj/O = new /obj/item/inflatable/shelter(loc)
-				if(Adjacent(usr)) //This way, silicons can still deploy it
+				if(Adjacent(usr)&&!isAdminGhost(usr)) //Silicons AND adminghosts drop it to the floor
 					usr.put_in_hands(O)
 				shelter = FALSE
 				update_icon()
@@ -1184,6 +1192,7 @@ var/global/list/firealarms = list() //shrug
 
 	machines.Remove(src)
 	firealarms |= src
+	processing_objects += src
 	update_icon()
 
 /obj/machinery/firealarm/Destroy()

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -296,6 +296,7 @@
 	anchored = 0
 	undeploy_path = /obj/item/inflatable/shelter
 	ctrl_deflate = FALSE
+	var/list/exiting = list()
 	var/datum/gas_mixture/cabin_air
 
 /obj/structure/inflatable/shelter/New()
@@ -309,6 +310,10 @@
 
 /obj/structure/inflatable/shelter/examine(mob/user)
 	..()
+	if(!(user.loc == src))
+		to_chat(user, "<span class='notice'>Click to enter. Use grab on shelter to force target inside.</span>")
+	else
+		to_chat(user, "<span class='notice'>Click to package contaminated clothes. Resist to exit/cancel exit.</span>")
 	var/list/living_contents = list()
 	for(var/mob/living/L in contents)
 		living_contents += L.name //Shelters can frequently end up with dropped items because people fall asleep.
@@ -373,12 +378,13 @@
 	user.forceMove(src)
 	update_icon()
 	user.reset_view()
-	user.reagents.add_reagent(STOXIN,3)
-	user.reagents.add_reagent(KELOTANE,4)
-	user.reagents.add_reagent(PEPTOBISMOL,4)
-	user.reagents.add_reagent(TRAMADOL,3)
-	user.reagents.add_reagent(LEPORAZINE,1)
-	to_chat(user,"<span class='warning'>You feel a prick upon entering \the [src] and your muscles relax.</span>")
+	if(!user.reagents.has_reagent(PRESLOMITE))
+		user.reagents.add_reagent(PRESLOMITE,3)
+		user.reagents.add_reagent(INAPROVALINE,12)
+		user.reagents.add_reagent(LEPORAZINE,1)
+		to_chat(user,"<span class='warning'>You feel a prick upon entering \the [src].</span>")
+	else
+		to_chat(user,"<span class='notice'>You enter \the [src].</span>")
 
 /obj/structure/inflatable/shelter/proc/laundry(var/mob/living/carbon/human/user)
 	if(user.loc != src)
@@ -421,10 +427,16 @@
 	..()
 
 /obj/structure/inflatable/shelter/container_resist(mob/user)
-	user.delayNext(DELAY_ALL,10 SECONDS)
+	if(exiting.Find(user))
+		exiting -= user
+		to_chat(user,"<span class='warning'>You stop climbing free of \the [src].</span>")
+		return
 	visible_message("<span class='warning'>[user] begins to climb free of the \the [src]!</span>")
-	spawn(10 SECONDS)
-		if(loc)
+	exiting += user
+	spawn(6 SECONDS)
+		if(loc && exiting.Find(user)) //If not loc, it was probably deflated
 			user.forceMove(loc)
+			exiting -= user
 			update_icon()
-		//If not loc, it was probably deflated
+			to_chat(user,"<span class='notice'>You climb free of the shelter.</span>")
+

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -3092,6 +3092,26 @@
 	else if(M.bodytemperature < 311)
 		M.bodytemperature = min(310, M.bodytemperature + (40 * TEMPERATURE_DAMAGE_COEFFICIENT))
 
+/datum/reagent/preslomite
+	name = "Preslomite"
+	id = PRESLOMITE
+	description = "A stabilizing chemical used in industrial relief efforts."
+	reagent_state = LIQUID
+	color = "#FFFFFF" //rgb: 255, 255, 255
+	custom_metabolism = 0.05
+
+/datum/reagent/preslomite/on_mob_life(var/mob/living/M, var/alien)
+
+	if(..())
+		return 1
+	if(!iscarbon(M))
+		return //We can't do anything for you
+	var/mob/living/carbon/C = M
+	if(C.isInCrit())
+		C.adjustToxLoss(-2 * REM)
+		C.heal_organ_damage(0, 2 * REM)
+
+
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 


### PR DESCRIPTION
Over the past week I have been very closely monitoring the use of shelters in emergencies and I believe these changes will increase their usefulness to the crew.

Undocumented change: admins will no longer "eat" inflatable shelters by hitting retrieve while close to the alarm.

closes #19300

🆑 
* tweak: Shelters provide inaprovaline and preslomite instead of sleep toxin, kelotane, tramadol, and peptobismol.
* rscadd: Added Preslomite for shelters, which heals toxin and burn damage, but only to those in critical condition. It has a fairly slow metabolism time.
* rscadd: Shelters will automatically deploy from the wall if plasma is detected in the air.
* rscadd: Shelters now have more verbose examine text regarding how to use them.
* rscadd: Entering and exiting shelters has more description, and you can now cancel exiting a shelter.