### PR TITLE
Sec Shuttle SDC Compatibility

### DIFF
--- a/code/game/machinery/computer/shuttle_computers.dm
+++ b/code/game/machinery/computer/shuttle_computers.dm
@@ -20,7 +20,7 @@
 	header = "station arrivals"
 
 /obj/item/weapon/disk/shuttle_coords/vault
-	allowed_shuttles = list(/datum/shuttle/mining, /datum/shuttle/research)
+	allowed_shuttles = list(/datum/shuttle/mining, /datum/shuttle/research, /datum/shuttle/security)
 
 ///obj/item/weapon/disk/shuttle_coords/vault/random -> leads to a random vault with a docking port!
 /obj/item/weapon/disk/shuttle_coords/vault/random/initialize()


### PR DESCRIPTION
The gulag ferry can now use vault disks, including the mecha graveyard coordinates, or even the prison vault which has some serious potential.

🆑 
* rscadd: The gulag ferry (Bagel, Roid) can now use most destination disks.