### PR TITLE
Makes Observing Tolerable Again

### DIFF
--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -51,6 +51,9 @@ var/const/HOLOPAD_MODE = 0
 		/obj/item/weapon/stock_parts/micro_laser
 	)
 
+/obj/machinery/hologram/holopad/GhostsAlwaysHear()
+	return TRUE
+
 /obj/machinery/hologram/holopad/attack_hand(var/mob/living/carbon/human/user) //Carn: Hologram requests.
 	if(!istype(user))
 		return

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -77,8 +77,14 @@ var/list/freqtoname = list(
 	if(isnull(range))
 		range = 7
 	var/rendered = render_speech(speech)
-	for(var/atom/movable/AM in get_hearers_in_view(range, src) | observers)
+	var/list/listeners = get_hearers_in_view(range, src)
+	if(speech.speaker.GhostsAlwaysHear())
+		listeners += observers
+	for(var/atom/movable/AM in listeners)
 		AM.Hear(speech, rendered)
+
+/atom/movable/proc/GhostsAlwaysHear()
+	return FALSE
 
 /atom/movable/proc/create_speech(var/message, var/frequency=0, var/atom/movable/transmitter=null)
 	if(!transmitter)

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -79,7 +79,7 @@ var/list/freqtoname = list(
 	var/rendered = render_speech(speech)
 	var/list/listeners = get_hearers_in_view(range, src)
 	if(speech.speaker.GhostsAlwaysHear())
-		listeners += observers
+		listeners |= observers
 	for(var/atom/movable/AM in listeners)
 		AM.Hear(speech, rendered)
 


### PR DESCRIPTION
Tested with machinery, normal human speech, and the holopad

Fixes #19278

🆑 
* bugfix: Observers will no longer hear machinery out of their view talking (unless explicitly intended, e.g.: AI holopad)