### PR TITLE
Adds the atmospherics rack to the engineering MK-2 upgrade

### DIFF
--- a/code/game/objects/items/robot/robot_items/robot_rack.dm
+++ b/code/game/objects/items/robot/robot_items/robot_rack.dm
@@ -4,7 +4,7 @@
 /obj/item/robot_rack
 	name = "generic robot rack"
 	desc = "A rack for carrying objects as a robot."
-	var/obj/object_type = null //The types of object the rack holds (subtypes are allowed).
+	var/obj/object_type = null //The type of object the rack holds (subtypes are allowed).
 	var/obj/initial_type = null //What type we start with. Useful if we start with a subtype of the type we can held.
 	var/starting_objects = 0 //How many things we start with.
 	var/capacity = 1 //How many things can be held.
@@ -128,3 +128,21 @@
 	icon_state = "ammopack_[length(held)]"
 
 #undef NEEDED_CHARGE_TO_RESTOCK_MAG
+
+/obj/item/robot_rack/atmos
+	name = "portable atmospherics rack"
+	desc = "Used by engineering cyborgs for convenient transport of portable atmospherics machinery."
+	icon = 'icons/obj/rollerbed.dmi'
+	icon_state = "borgbed_deployed"
+	object_type = "/obj/machinery/portable_atmospherics" //WHAT CAN GO WRONG
+	initial_type = "/obj/machinery/portable_atmospherics/scrubber"
+	starting_objects = 1
+
+/obj/item/robot_rack/bed/update_icon()
+	icon = "[held ? held.icon : initial(icon)]"
+	icon_state = "[held ? held.icon_state : initial(icon_state)]"
+
+/obj/item/robot_rack/preattack(obj/O, mob/user, proximity, params)
+	if(O.anchored || O.locked_to) //We don't want no trouble.
+		return
+	..()

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -250,12 +250,12 @@
 	R.illegal_weapons = TRUE
 	R.SetEmagged()
 
-/obj/item/borg/upgrade/engineering/
+/obj/item/borg/upgrade/engineering
 	name = "engineering cyborg MK-2 upgrade board"
 	desc = "Adds several tools and materials for the robot to use."
 	icon_state = "cyborg_upgrade3"
 	required_module = list(/obj/item/weapon/robot_module/engineering)
-	modules_to_add = list(/obj/item/weapon/wrench/socket)
+	modules_to_add = list(/obj/item/weapon/wrench/socket, /obj/item/robot_rack/atmos)
 
 /obj/item/borg/upgrade/engineering/attempt_action(var/mob/living/silicon/robot/R,var/mob/living/user)
 	if(..())


### PR DESCRIPTION
The MK-2 upgrade is a huge "wow it's fucking nothing" upgrade, i want to change that. Works like a bed rack, but for portable atmos crap(scrubbers, air pumps). 0% tested.

:cl:
 * rscadd: Adds the atmospherics rack to the engineering MK-2 upgrade