### PR TITLE
Inflatable Shelters Don't Gas Vox

### DIFF
--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -380,7 +380,6 @@
 	user.reset_view()
 	if(!user.reagents.has_reagent(PRESLOMITE))
 		user.reagents.add_reagent(PRESLOMITE,3)
-		user.reagents.add_reagent(INAPROVALINE,12)
 		user.reagents.add_reagent(LEPORAZINE,1)
 		to_chat(user,"<span class='warning'>You feel a prick upon entering \the [src].</span>")
 	else

--- a/code/modules/mob/living/carbon/alien/humanoid/life.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/life.dm
@@ -320,7 +320,7 @@
 				if( health <= 20 && prob(1) )
 					spawn(0)
 						emote("gasp")
-				if(!reagents.has_reagent(INAPROVALINE))
+				if(!reagents.has_reagent(INAPROVALINE)&&!reagents.has_reagent(PRESLOMITE))
 					adjustOxyLoss(1)
 				Paralyse(3)
 

--- a/code/modules/mob/living/carbon/alien/humanoid/life.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/life.dm
@@ -320,7 +320,7 @@
 				if( health <= 20 && prob(1) )
 					spawn(0)
 						emote("gasp")
-				if(!reagents.has_reagent(INAPROVALINE)&&!reagents.has_reagent(PRESLOMITE))
+				if(!reagents.has_any_reagents(list(INAPROVALINE,PRESLOMITE)))
 					adjustOxyLoss(1)
 				Paralyse(3)
 

--- a/code/modules/mob/living/carbon/alien/larva/life.dm
+++ b/code/modules/mob/living/carbon/alien/larva/life.dm
@@ -244,7 +244,7 @@
 			//if( health <= 20 && prob(1) )
 			//	spawn(0)
 			//		emote("gasp")
-			if(!reagents.has_reagent(INAPROVALINE)&&!reagents.has_reagent(PRESLOMITE))
+			if(!reagents.has_any_reagents(list(INAPROVALINE,PRESLOMITE)))
 				adjustOxyLoss(1)
 			Paralyse(3)
 

--- a/code/modules/mob/living/carbon/alien/larva/life.dm
+++ b/code/modules/mob/living/carbon/alien/larva/life.dm
@@ -244,7 +244,7 @@
 			//if( health <= 20 && prob(1) )
 			//	spawn(0)
 			//		emote("gasp")
-			if(!reagents.has_reagent(INAPROVALINE))
+			if(!reagents.has_reagent(INAPROVALINE)&&!reagents.has_reagent(PRESLOMITE))
 				adjustOxyLoss(1)
 			Paralyse(3)
 

--- a/code/modules/mob/living/carbon/complex/life.dm
+++ b/code/modules/mob/living/carbon/complex/life.dm
@@ -285,7 +285,7 @@
 			if( health <= 20 && prob(1) )
 				spawn(0)
 					emote("gasp")
-			if(!reagents.has_reagent(INAPROVALINE))
+			if(!reagents.has_reagent(INAPROVALINE)&&!reagents.has_reagent(PRESLOMITE))
 				adjustOxyLoss(1)
 			Paralyse(3)
 		if(halloss > 100)

--- a/code/modules/mob/living/carbon/complex/life.dm
+++ b/code/modules/mob/living/carbon/complex/life.dm
@@ -285,7 +285,7 @@
 			if( health <= 20 && prob(1) )
 				spawn(0)
 					emote("gasp")
-			if(!reagents.has_reagent(INAPROVALINE)&&!reagents.has_reagent(PRESLOMITE))
+			if(!reagents.has_any_reagents(list(INAPROVALINE,PRESLOMITE)))
 				adjustOxyLoss(1)
 			Paralyse(3)
 		if(halloss > 100)

--- a/code/modules/mob/living/carbon/human/life/handle_breath.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_breath.dm
@@ -145,7 +145,7 @@
 		return 0
 	var/datum/organ/internal/lungs/L = internal_organs_by_name["lungs"]
 	if(!breath || (breath.total_moles() == 0) || suiciding || !L)
-		if(reagents.has_reagent(INAPROVALINE))
+		if(reagents.has_reagent(INAPROVALINE)||reagents.has_reagent(PRESLOMITE))
 			return 0
 		if(suiciding)
 			adjustOxyLoss(2) //If you are suiciding, you should die a little bit faster

--- a/code/modules/mob/living/carbon/human/life/handle_breath.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_breath.dm
@@ -145,7 +145,7 @@
 		return 0
 	var/datum/organ/internal/lungs/L = internal_organs_by_name["lungs"]
 	if(!breath || (breath.total_moles() == 0) || suiciding || !L)
-		if(reagents.has_reagent(INAPROVALINE)||reagents.has_reagent(PRESLOMITE))
+		if(reagents.has_any_reagents(list(INAPROVALINE,PRESLOMITE)))
 			return 0
 		if(suiciding)
 			adjustOxyLoss(2) //If you are suiciding, you should die a little bit faster

--- a/code/modules/mob/living/carbon/monkey/life.dm
+++ b/code/modules/mob/living/carbon/monkey/life.dm
@@ -572,7 +572,7 @@
 			if( health <= 20 && prob(1) )
 				spawn(0)
 					emote("gasp")
-			if(!reagents.has_reagent(INAPROVALINE)&&!reagents.has_reagent(PRESLOMITE))
+			if(!reagents.has_any_reagents(list(INAPROVALINE,PRESLOMITE)))
 				adjustOxyLoss(1)
 			Paralyse(3)
 		if(halloss > 100)

--- a/code/modules/mob/living/carbon/monkey/life.dm
+++ b/code/modules/mob/living/carbon/monkey/life.dm
@@ -572,7 +572,7 @@
 			if( health <= 20 && prob(1) )
 				spawn(0)
 					emote("gasp")
-			if(!reagents.has_reagent(INAPROVALINE))
+			if(!reagents.has_reagent(INAPROVALINE)&&!reagents.has_reagent(PRESLOMITE))
 				adjustOxyLoss(1)
 			Paralyse(3)
 		if(halloss > 100)

--- a/code/modules/mob/living/carbon/slime/life.dm
+++ b/code/modules/mob/living/carbon/slime/life.dm
@@ -271,7 +271,7 @@
 		// if(src.health <= 20 && prob(1)) spawn(0) emote("gasp")
 
 		//if(!src.rejuv) src.oxyloss++
-		if(!src.reagents.has_reagent(INAPROVALINE)&&!reagents.has_reagent(PRESLOMITE))
+		if(!reagents.has_any_reagents(list(INAPROVALINE,PRESLOMITE)))
 			src.adjustOxyLoss(10)
 
 		if(src.stat != DEAD)

--- a/code/modules/mob/living/carbon/slime/life.dm
+++ b/code/modules/mob/living/carbon/slime/life.dm
@@ -271,7 +271,7 @@
 		// if(src.health <= 20 && prob(1)) spawn(0) emote("gasp")
 
 		//if(!src.rejuv) src.oxyloss++
-		if(!src.reagents.has_reagent(INAPROVALINE))
+		if(!src.reagents.has_reagent(INAPROVALINE)&&!reagents.has_reagent(PRESLOMITE))
 			src.adjustOxyLoss(10)
 
 		if(src.stat != DEAD)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -3173,10 +3173,12 @@
 
 	if(..())
 		return 1
+	if(M.losebreath>10)
+		M.losebreath = max(10, M.losebreath - 5)
 	if(!iscarbon(M))
-		return //We can't do anything for you
+		return //We can't do anything else for you
 	var/mob/living/carbon/C = M
-	if(C.isInCrit())
+	if(C.health < config.health_threshold_crit + 10)
 		C.adjustToxLoss(-2 * REM)
 		C.heal_organ_damage(0, 2 * REM)
 


### PR DESCRIPTION
NT Scientists have uncovered wonderful new properties in Preslomite that let it imitate Inaprovaline, so there is no need for Inaprovaline in shelters where it will gas the Vox. Also, after some further testing I bumped up the working limit to 10% health so that people wouldn't keep hovering at 0.5% health.

Hopefully this will stop the VOX METACLUB from pinging me in Discord.

🆑 
* tweak: Inflatable shelters no longer gas the Vox.