### PR TITLE
drag damage 3.8 remix hd

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -735,7 +735,7 @@ Thanks.
 
 								if (damaged_organs.len)
 									for(var/datum/organ/external/damagedorgan in damaged_organs)
-										if((damagedorgan.brute_dam) < (damagedorgan.max_damage - 1)) //To prevent organs from accruing thousands of damage or exploding
+										if((damagedorgan.brute_dam) < (damagedorgan.max_damage - 3)) //To prevent organs from accruing thousands of damage or exploding
 											if(prob(damagedorgan.brute_dam / 5)) //Chance for damage based on current damage
 												HM.apply_damage(2, BRUTE, damagedorgan)
 												HM.visible_message("<span class='warning'>The wounds on \the [HM]'s [damagedorgan.display_name] worsen from being dragged!</span>")

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -734,9 +734,9 @@ Thanks.
 							if (T.has_gravity() && HM.lying && m_intent != "walk")
 
 								if (damaged_organs.len)
-									if(prob(HM.getBruteLoss() / 8)) //Chance for damage based on current damage
-										for(var/datum/organ/external/damagedorgan in damaged_organs)
-											if((damagedorgan.brute_dam) < (damagedorgan.max_damage - 1)) //To prevent organs from accruing thousands of damage or exploding
+									for(var/datum/organ/external/damagedorgan in damaged_organs)
+										if((damagedorgan.brute_dam) < (damagedorgan.max_damage - 1)) //To prevent organs from accruing thousands of damage or exploding
+											if(prob(damagedorgan.brute_dam / 5)) //Chance for damage based on current damage
 												HM.apply_damage(2, BRUTE, damagedorgan)
 												HM.visible_message("<span class='warning'>The wounds on \the [HM]'s [damagedorgan.display_name] worsen from being dragged!</span>")
 												HM.UpdateDamageIcon()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -731,7 +731,7 @@ Thanks.
 							var/mob/living/carbon/human/HM = M
 							var/list/damaged_organs = HM.get_broken_organs()
 							var/list/bleeding_organs = HM.get_bleeding_organs()
-							if (T.has_gravity() && HM.lying)
+							if (T.has_gravity() && HM.lying && m_intent != "walk")
 
 								if (damaged_organs.len)
 									if(prob(HM.getBruteLoss() / 8)) //Chance for damage based on current damage

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -725,45 +725,30 @@ Thanks.
 							if(M && secondarypull)
 								M.start_pulling(secondarypull)
 
-							/* Drag damage is here!*/
+							/* Drag damage is here! */
+							/* Dragging folk with broken bones hurts their broken organ */
+							/* Dragging folk that are bleeding without bandaging them makes them lose blood */
 							var/mob/living/carbon/human/HM = M
 							var/list/damaged_organs = HM.get_broken_organs()
 							var/list/bleeding_organs = HM.get_bleeding_organs()
 							if (T.has_gravity() && HM.lying)
 
 								if (damaged_organs.len)
-									if(!HM.isincrit())
-										if(prob(HM.getBruteLoss() / 5)) //Chance for damage based on current damage
-											for(var/datum/organ/external/damagedorgan in damaged_organs)
-												if((damagedorgan.brute_dam) < damagedorgan.max_damage) //To prevent organs from accruing thousands of damage
-													HM.apply_damage(2, BRUTE, damagedorgan)
-													HM.visible_message("<span class='warning'>The wounds on \the [HM]'s [damagedorgan.display_name] worsen from being dragged!</span>")
-													HM.UpdateDamageIcon()
-									else
-										if(prob(15))
-											for(var/datum/organ/external/damagedorgan in damaged_organs)
-												if((damagedorgan.brute_dam) < damagedorgan.max_damage)
-													HM.apply_damage(4, BRUTE, damagedorgan)
-													HM.visible_message("<span class='warning'>The wounds on \the [HM]'s [damagedorgan.display_name] worsen terribly from being dragged!</span>")
-													add_logs(src, HM, "caused drag damage to", admin = (M.ckey))
-													HM.UpdateDamageIcon()
+									if(prob(HM.getBruteLoss() / 8)) //Chance for damage based on current damage
+										for(var/datum/organ/external/damagedorgan in damaged_organs)
+											if((damagedorgan.brute_dam) < (damagedorgan.max_damage - 1)) //To prevent organs from accruing thousands of damage or exploding
+												HM.apply_damage(2, BRUTE, damagedorgan)
+												HM.visible_message("<span class='warning'>The wounds on \the [HM]'s [damagedorgan.display_name] worsen from being dragged!</span>")
+												HM.UpdateDamageIcon()
 
 								if (bleeding_organs.len && !(HM.species.anatomy_flags & NO_BLOOD))
 									var/blood_volume = round(HM:vessel.get_reagent_amount("blood"))
-									/*Sometimes species with NO_BLOOD get blood, hence weird check*/
 									if(blood_volume > 0)
 										if(isturf(HM.loc))
-											if(!HM.isincrit())
-												if(prob(blood_volume / 89.6)) //Chance to bleed based on blood remaining
-													blood_splatter(HM.loc,HM)
-													HM.vessel.remove_reagent("blood",4)
-													HM.visible_message("<span class='warning'>\The [HM] loses some blood from being dragged!</span>")
-											else
-												if(prob(blood_volume / 44.8)) //Crit mode means double chance of blood loss
-													blood_splatter(HM.loc,HM,1)
-													HM.vessel.remove_reagent("blood",8)
-													HM.visible_message("<span class='danger'>\The [HM] loses a lot of blood from being dragged!</span>")
-													add_logs(src, HM, "caused drag damage bloodloss to", admin = (HM.ckey))
+											if(prob(blood_volume / 89.6)) //Chance to bleed based on blood remaining
+												blood_splatter(HM.loc,HM,0)
+												HM.vessel.remove_reagent("blood",2)
+												HM.visible_message("<span class='warning'>\The [HM] loses some blood from being dragged!</span>")
 					else
 						if (pulling)
 							pulling.Move(T, get_dir(pulling, T), glide_size_override = src.glide_size)


### PR DESCRIPTION
no longer applies while walking
damage chance based on organ damage rather than global damage
removed crit multipliers
lowered chances
closes #19330

🆑 
 - tweak: Drag damage now only applies when you are running while dragging someone with broken, unsplinted organs. Walk, splint them, or carry them on a bed/locker/bag/etc to prevent it.
 - tweak: Drag bloodloss now only applies while you are running while dragging someone with open wounds. BANDAGE THEM, walk, or carry them on a bed/locker/bag/etc to prevent it.
 - tweak: Drag damage numbers dropped across the board. It's just fluff now.