### PR TITLE
Dense atmos machines actually get cultified

### DIFF
--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -291,7 +291,7 @@ Pipelines + Other Objects -> Pipe network
 /obj/machinery/atmospherics/cultify()
 	if(density)
 		..()
-	else if(src.invisibility != INVISIBILITY_MAXIMUM)
+	else
 		src.invisibility = INVISIBILITY_MAXIMUM
 
 

--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -289,7 +289,9 @@ Pipelines + Other Objects -> Pipe network
 	return FALSE
 
 /obj/machinery/atmospherics/cultify()
-	if(src.invisibility != INVISIBILITY_MAXIMUM)
+	if(density)
+		..()
+	else if(src.invisibility != INVISIBILITY_MAXIMUM)
 		src.invisibility = INVISIBILITY_MAXIMUM
 
 


### PR DESCRIPTION
Resolves #19373

This optimization was for pipes and vents so Nar-Sie would lag less. Clearly wasn't meant to affect something like a cryo pod.

:cl:
* bugfix: Minor change to Nar-Sie's cultify logic regarding machines, so you won't get stuck in limbo if you're in a cryo tube when it gets cultified.