### PR TITLE
Mimes don't scream audibly

### DIFF
--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -250,7 +250,7 @@
 		return ..()
 	if (H.stat == DEAD)
 		return
-	if (!H.is_muzzled())
+	if (!H.is_muzzled() && !issilent(H)) // Silent = mime, mute species.
 		if (params == TRUE) // Forced scream
 			if(world.time-H.last_emote_sound >= 30)//prevent scream spam with things like poly spray
 				message = "screams in agony!"


### PR DESCRIPTION
Closes #19310 

![proof 1](https://user-images.githubusercontent.com/31417754/44299338-29b13780-a2f4-11e8-9e6d-c7471894814a.png)

The audio was not played.

:cl:

* bugfix: Mimes have been given strength training, they no longer scream in agony when being bullied, staying true to their oath of silence.