### PR TITLE
Added null checks for some runtime errors.

### DIFF
--- a/code/_hooks/events.dm
+++ b/code/_hooks/events.dm
@@ -34,6 +34,8 @@
 	return handlers.Remove(key)
 
 /event/proc/Invoke(var/list/args)
+	if(handlers == null)
+		return
 	if(handlers.len==0)
 		return
 	for(var/key in handlers)

--- a/code/modules/mob/living/carbon/slime/life.dm
+++ b/code/modules/mob/living/carbon/slime/life.dm
@@ -387,6 +387,8 @@
 
 		else
 			if(!client)
+				if(adulttype == null)
+					return
 				var/mob/living/carbon/slime/adult/A = new adulttype(src.loc)
 				A.nutrition = nutrition
 //				A.nutrition += 100

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -371,7 +371,8 @@
 	return 0
 
 /datum/organ/external/process()
-
+	if(owner == null)
+		return
 	//Process wounds, doing healing etc. Only do this every few ticks to save processing power
 	if(owner.life_tick % wound_update_accuracy == 0)
 		update_wounds()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -792,6 +792,8 @@
 
 /obj/machinery/power/apc/proc/update()
 	var/area/this_area = get_area(src)
+	if(this_area == null)
+		return
 	if(operating && !shorted)
 		this_area.power_light = (lighting > 1)
 		this_area.power_equip = (equipment > 1)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -575,6 +575,8 @@ var/global/list/obj/machinery/light/alllights = list()
 /obj/machinery/light/power_change()
 	spawn(10)
 		var/area/this_area = get_area(src)
+		if(this_area == null)
+			return
 		seton(this_area.lightswitch && this_area.power_light)
 
 // called when on fire


### PR DESCRIPTION
I sampled the logs for August 17th, these were among 9601 runtime errors the worst offenders being the events, the slimes lifecode specifically rainbow slimes growing up (they don't) and external organs without an owner trying to process.
Even if the impact from the errors is negligible it's probably better they don't error in the first place right?

- x4840 events.dm,37: Cannot read null.len
- x2954 life.dm,390: Cannot create objects of type null.
- x1272 organ_external.dm,376: Cannot read null.life_tick
- x19   lighting.dm,578: Cannot read null.lightswitch
- x17   apc.dm,796: Cannot modify null.power_light.

