### PR TITLE
Fixed a runtime error for slime growth.

### DIFF
--- a/code/modules/mob/living/carbon/slime/life.dm
+++ b/code/modules/mob/living/carbon/slime/life.dm
@@ -387,6 +387,8 @@
 
 		else
 			if(!client)
+				if(adulttype == null)
+					return
 				var/mob/living/carbon/slime/adult/A = new adulttype(src.loc)
 				A.nutrition = nutrition
 //				A.nutrition += 100


### PR DESCRIPTION
Pygmy (rainbow) slimes do not have an adult form (subtypes.dm,444), this caused 2954 runtime errors on August 17th alone.