### PR TITLE
Some runtime fixes

### DIFF
--- a/code/datums/gamemode/role/role.dm
+++ b/code/datums/gamemode/role/role.dm
@@ -125,7 +125,7 @@
 		stack_trace("M is [M.type]!")
 		return 0
 	if(!CanBeAssigned(M) && !override)
-		stack_trace("[M] was to be assigned to [name] but failed CanBeAssigned!")
+		stack_trace("[M.name] was to be assigned to [name] but failed CanBeAssigned!")
 		return 0
 
 	antag = M

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -580,6 +580,9 @@
 			available_objectives[initial(O.name)] = O
 
 		var/new_obj = input("Select a new objective", "New Objective", null) as null|anything in available_objectives
+
+		if(new_obj == null)
+			return
 		var/obj_type = available_objectives[new_obj]
 
 		var/datum/objective/new_objective = new obj_type(null,FALSE)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -373,6 +373,8 @@
 /mob/living/silicon/robot/show_malf_ai()
 	..()
 	var/datum/faction/malf/malf = find_active_faction(MALF)
+	if(!malf)
+		return FALSE
 	for (var/datum/mind/malfai in malf.members)
 		if(connected_ai)
 			if(connected_ai.mind == malfai)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -442,7 +442,7 @@
 				to_chat(mob, "<span class='sinister'>A dark forcefield prevents you from entering the area.</span>")
 			else
 				var/datum/faction/cult = find_active_faction(BLOODCULT)
-				if((T && T.holy) && isobserver(mob) && ((mob.invisibility == 0) || mob.mind in cult.members))
+				if((T && T.holy) && isobserver(mob) && ((mob.invisibility == 0) || (cult && mob.mind in cult.members)))
 					to_chat(mob, "<span class='warning'>You cannot get past holy grounds while you are in this plane of existence!</span>")
 				else
 					mob.forceEnter(get_step(mob, direct))


### PR DESCRIPTION
Fixes a runtime in robots in show_malf_ai when there was no malf AI

Fixes the stack trace of canbeassigned so it shows a name. That should be changed to a commented out debug log tbf.

fixes a mob_movement runtime for ghosts

fixes a runtime in objective adding by admins.