### PR TITLE
Fixes runtime(s) related to miming

### DIFF
--- a/__DEFINES/_macros.dm
+++ b/__DEFINES/_macros.dm
@@ -198,7 +198,7 @@
 
 #define isfloor(A) (istype(A, /turf/simulated/floor) || istype(A, /turf/unsimulated/floor) || istype(A, /turf/simulated/shuttle/floor))
 
-#define issilent(A) (A.silent || (ishuman(A) && (A:mind.miming || A:species:flags & IS_SPECIES_MUTE))) //Remember that silent is not the same as miming. Miming you can emote, silent you can't gesticulate at all
+#define issilent(A) (A.silent || (ishuman(A) && (A.mind && A.mind.miming || A:species:flags & IS_SPECIES_MUTE))) //Remember that silent is not the same as miming. Miming you can emote, silent you can't gesticulate at all
 //Macros for antags
 
 #define isvampire(H) ((H.mind in ticker.mode.vampires) || H.mind && H.mind.vampire)


### PR DESCRIPTION
```
[14:54:22] Runtime in emote.dm, line 253: Cannot read null.miming
proc name: run emote (/datum/emote/living/carbon/scream/run_emote)
src: /datum/emote/living/carbon/scr... (/datum/emote/living/carbon/scream)
call stack:
/datum/emote/living/carbon/scr... (/datum/emote/living/carbon/scream): run emote(the unknown (/mob/living/carbon/human), 1, null, 0)
the unknown (/mob/living/carbon/human): emote("screams", null, 1, 0)
the unknown (/mob/living/carbon/human): audible scream()
chest (/datum/organ/external/chest): fracture()
chest (/datum/organ/external/chest): process()
the unknown (/mob/living/carbon/human): handle organs(1)
the unknown (/mob/living/carbon/human): handle regular status updates()
the unknown (/mob/living/carbon/human): Life()
Mob (/datum/subsystem/mob): fire(1)
Mob (/datum/subsystem/mob): ignite(1)
Master (/datum/controller/master): RunQueue()
Master (/datum/controller/master): Loop()
Master (/datum/controller/master): StartProcessing()
```
I forgot to put a null check for the mind in the macro.