### PR TITLE
mapping_idtag for shard box

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -200,11 +200,15 @@
 	name = "supermatter shard crate"
 	req_access = list(access_engine_equip)
 	var/payload = /obj/machinery/power/supermatter/shard
-	New()
-		..()
-		sleep(2)
-		if(payload)
-			new payload(src)
+	var/mapping_idtag
+
+/obj/structure/closet/crate/secure/large/reinforced/shard/New()
+	..()
+	sleep(2)
+	if(payload)
+		var/obj/machinery/power/supermatter/S = new payload(src)
+		if(mapping_idtag && istype(S))
+			S.id_tag = mapping_idtag
 
 /obj/structure/closet/crate/secure/large/reinforced/shard/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(istype(mover,/obj/machinery/power/supermatter))


### PR DESCRIPTION
does not affect players
tested to make sure it doesn't break boxes without tags just in case
shouldn't need a changelog since this is backend only

basically set the box's mapping_idtag to what you want the shard's id_tag to be