### PR TITLE
Corrects Reactivate Camera plane and layer

### DIFF
--- a/__DEFINES/planes+layers.dm
+++ b/__DEFINES/planes+layers.dm
@@ -216,6 +216,9 @@ What is the naming convention for planes or layers?
 
 #define STATIC_PLANE 			22		// For AI's static.
 
+	#define STATIC_LAYER			1
+	#define REACTIVATE_CAMERA_LAYER	2
+
 #define FULLSCREEN_PLANE		23		// for fullscreen overlays that do not cover the hud.
 
 	#define FULLSCREEN_LAYER	 	0

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -283,7 +283,8 @@ rcd light flash thingy on matter drain
 			continue
 		var/image/I = image(C.icon, C.icon_state)
 		I.appearance = C.appearance
-		I.plane = ABOVE_LIGHTING_LAYER
+		I.plane = STATIC_PLANE
+		I.layer = REACTIVATE_CAMERA_LAYER
 		I.alpha = 128
 		I.loc = C
 		camera_images += I

--- a/code/modules/mob/living/silicon/ai/freelook/chunk.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/chunk.dm
@@ -114,7 +114,7 @@
 		var/turf/t = turf
 		if(obscuredTurfs[t])
 			if(!t.obscured)
-				var/image/obscured_static = image('icons/effects/cameravis.dmi', t, null, 15)
+				var/image/obscured_static = image('icons/effects/cameravis.dmi', t, null, STATIC_LAYER)
 				obscured_static.plane = STATIC_PLANE
 				t.obscured = obscured_static
 			obscured += t.obscured
@@ -169,7 +169,7 @@
 	for(var/turf in obscuredTurfs)
 		var/turf/t = turf
 		if(!t.obscured)
-			var/image/obscured_static = image('icons/effects/cameravis.dmi', t, null, 15)
+			var/image/obscured_static = image('icons/effects/cameravis.dmi', t, null, STATIC_LAYER)
 			obscured_static.plane = STATIC_PLANE
 			t.obscured = obscured_static
 		obscured += t.obscured


### PR DESCRIPTION
:cl:
* bugfix: The long-broken Malf spell, Reactivate Camera, actually functions now. The overlays for targeting deactivated cameras were being covered up by the static.