### PR TITLE
Fixes spiderling growth so they don't all turn into guards

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/spiderling.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/spiderling.dm
@@ -121,8 +121,7 @@
 	if(isturf(loc) && amount_grown > 0)
 		amount_grown += rand(0,2)
 		if(amount_grown >= 100)
-			if(!species_type)
-				species_type = pick(spider_types)
+			species_type = pick(spider_types)
 			grow_up()
 			return
 
@@ -151,4 +150,7 @@
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "jonas"
 	icon_living = "jonas"
-	amount_grown = -INFINITY
+
+/mob/living/simple_animal/hostile/giant_spider/spiderling/salk/New()
+	..()
+	amount_grown = 0


### PR DESCRIPTION
This has been a bug since #18014.

Also fixed Salk, the virologist's pet turning big when he's not supposed to. He's not mapped in anywhere but now he can be.

:cl:
* bugfix: Fixed spiderling growth so they don't all turn into guards.