### PR TITLE
Adds a cooldown function for mob printers

### DIFF
--- a/code/game/machinery/martian_printer.dm
+++ b/code/game/machinery/martian_printer.dm
@@ -9,15 +9,15 @@
 	idle_power_usage = 20
 	active_power_usage = 5000
 	var/building = 0
-	var/cooldown_duration = 6000 // 10 minutes
+	var/cooldown_duration = 10 MINUTES
 	var/cooldown_time = 0
-	var/cooldown_state = 0
+	var/cooldown_active = 0
 	var/print_path = /mob/living/carbon/complex/martian
 
 /obj/machinery/mob_printer/attack_ghost(var/mob/dead/observer/O)
 	if(!canSpawn())
 		return
-	if(cooldown_state)
+	if(cooldown_active == 1)
 		to_chat(O, "<span class='warning'>Error: printer still recharging. Time left: [round((cooldown_time - world.time + 20)/10)] seconds.</span>")
 		return
 
@@ -35,17 +35,14 @@
 	make_mob(O)
 
 	// Activate the cooldown
+	cooldown_active = 1
 	cooldown_time = world.time + cooldown_duration
-	cooldown_state = 1
-	update_icon()
 
 /obj/machinery/mob_printer/process()
 	..()
-	var/old_cooldown_state=cooldown_state
-	cooldown_state = cooldown_time > world.time
-	if(cooldown_state!=old_cooldown_state)
-		update_icon()
-		if(!cooldown_state)
+	if(world.time >= cooldown_time)
+		if (cooldown_active == 1)
+			cooldown_active = 0
 			playsound(src, 'sound/machines/ping.ogg', 50, 0)
 
 /obj/machinery/mob_printer/power_change()

--- a/code/game/machinery/martian_printer.dm
+++ b/code/game/machinery/martian_printer.dm
@@ -17,7 +17,7 @@
 /obj/machinery/mob_printer/attack_ghost(var/mob/dead/observer/O)
 	if(!canSpawn())
 		return
-	if(cooldown_active == 1)
+	if(cooldown_active)
 		to_chat(O, "<span class='warning'>Error: printer still recharging. Time left: [round((cooldown_time - world.time + 20)/10)] seconds.</span>")
 		return
 
@@ -41,7 +41,7 @@
 /obj/machinery/mob_printer/process()
 	..()
 	if(world.time >= cooldown_time)
-		if (cooldown_active == 1)
+		if (cooldown_active)
 			cooldown_active = 0
 			playsound(src, 'sound/machines/ping.ogg', 50, 0)
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6062247/44615069-7eb5e780-a7e5-11e8-9234-f5f9054590e2.png)

Mob printers seem like a neat feature but they seem nonviable for bus or mapping since a ghost with a little bit of time on their hands can just spawn an arbitrary number of things. You can now still make a mob printer that does that, but a cooldown allows them to be actually placed on the map without immediate fuckery. Clicking on the printer as a ghost while the cooldown's still running will tell you how long you have to wait.

Maybe now you can bus in one of these things to really get ghosts excited!

Base cooldown is 10 minutes because that's about in the ballpark of as frequent you can spawn a living mob like a martian without it being an overpowered way of getting back into the round, especially when accounting for the fact that other ghosts might get it before you.

Code copied 99% from how the borgifier does things, probably far from the most elegant solution but it's the piece of machinery most similar to the mob printer so I figured it'd work fine. Only change I can imagine would be making it a lottery if multiple ghosts want it first, rather than a race.

:cl:
 * rscadd: Mob printers now have a cooldown, can be var edited to change duration