### PR TITLE
Fishtanks now drop circuit boards when deconstructed [READY]

### DIFF
--- a/code/modules/fish/fish_tank.dm
+++ b/code/modules/fish/fish_tank.dm
@@ -33,6 +33,7 @@
 	density = FALSE
 	anchored = FALSE
 	throwpass = FALSE
+	var/circuitboard = null		// The circuitboard to eject when deconstructed
 
 	var/tank_type = ""			// Type of aquarium, used for icon updating
 	var/water_capacity = 0		// Number of units the tank holds (varies with tank type)
@@ -77,6 +78,7 @@
 	density = TRUE
 	anchored = TRUE
 	throwpass = TRUE				// You can throw objects over this, despite it's density, because it's short enough.
+	circuitboard = /obj/item/weapon/circuitboard/fishtank
 
 	tank_type = "tank"
 	water_capacity = 200		// Decent sized, holds 2 full large beakers worth
@@ -95,6 +97,7 @@
 	density = TRUE
 	anchored = TRUE
 	throwpass = FALSE				// This thing is the size of a wall, you can't throw past it.
+	circuitboard = /obj/machinery/fishtank/wall
 
 	tank_type = "wall"
 	water_capacity = 500		// This thing fills an entire tile,5 large beakers worth
@@ -425,7 +428,10 @@
 			spill_water()
 	else																//We are deconstructing, make glass sheets instead of shards
 		var/sheets = shard_count + 1									//Deconstructing it salvages all the glass used to build the tank
-		new /obj/item/stack/sheet/glass/glass(get_turf(src), sheets)	//Produce the appropriate number of glass sheets, in a single stack (/glass/glass)
+		var/cur_turf = get_turf(src)
+		new /obj/item/stack/sheet/glass/glass(cur_turf, sheets)			//Produce the appropriate number of glass sheets, in a single stack (/glass/glass)
+		if(circuitboard)
+			new circuitboard(cur_turf)									//Eject the circuitboard
 	qdel(src)															//qdel the tank and it's contents
 
 

--- a/code/modules/fish/fish_tank.dm
+++ b/code/modules/fish/fish_tank.dm
@@ -97,7 +97,7 @@
 	density = TRUE
 	anchored = TRUE
 	throwpass = FALSE				// This thing is the size of a wall, you can't throw past it.
-	circuitboard = /obj/machinery/fishtank/wall
+	circuitboard = /obj/item/weapon/circuitboard/fishwall
 
 	tank_type = "wall"
 	water_capacity = 500		// This thing fills an entire tile,5 large beakers worth


### PR DESCRIPTION
Fixes #19475 
Fixes #19476
![2018-08-25_02-41-46](https://user-images.githubusercontent.com/3196371/44615783-7a52f400-a810-11e8-9ab5-1ce2bbd63f04.gif)
:cl:
* tweak: Fishtanks now drop their circuit board when deconstructed.