### PR TITLE
Attempt to rehabilitate bot attackby() code somewhat

### DIFF
--- a/code/game/machinery/bots/bots.dm
+++ b/code/game/machinery/bots/bots.dm
@@ -139,8 +139,10 @@
 	else if(iswelder(W) && user.a_intent != I_HURT)
 		if(health < maxhealth)
 			if(open)
-				health = min(maxhealth, health+10)
-				user.visible_message("<span class='danger'>[user] repairs [src]!</span>","<span class='notice'>You repair [src]!</span>")
+				var/obj/item/weapon/weldingtool/WT = W
+				if(WT.remove_fuel(0))
+					health = min(maxhealth, health+10)
+					user.visible_message("<span class='danger'>[user] repairs [src]!</span>","<span class='notice'>You repair [src]!</span>")
 			else
 				to_chat(user, "<span class='notice'>Unable to repair with the maintenance panel closed.</span>")
 		else

--- a/code/game/machinery/bots/bots.dm
+++ b/code/game/machinery/bots/bots.dm
@@ -125,13 +125,18 @@
 			huduser.show_message(declare_message,1)
 
 
-/obj/machinery/bot/attackby(obj/item/weapon/W as obj, mob/living/user as mob)
+/obj/machinery/bot/attackby(obj/item/weapon/W, mob/living/user)
 	if(flags & INVULNERABLE)
 		return
-	if(!locked && (isscrewdriver(W) || iscrowbar(W)))
-		open = !open
-		to_chat(user, "<span class='notice'>Maintenance panel is now [src.open ? "opened" : "closed"].</span>")
-	else if(iswelder(W))
+	user.delayNextAttack(W.attack_delay)
+	if((isscrewdriver(W) || iscrowbar(W)) && user.a_intent != I_HURT)
+		if(locked)
+			to_chat(user, "<span class='notice'>[src]'s maintenance panel is locked tight.</span>")
+		else
+			open = !open
+			to_chat(user, "<span class='notice'>Maintenance panel is now [open ? "opened" : "closed"].</span>")
+			updateUsrDialog()
+	else if(iswelder(W) && user.a_intent != I_HURT)
 		if(health < maxhealth)
 			if(open)
 				health = min(maxhealth, health+10)
@@ -144,7 +149,8 @@
 		Emag(user)
 	else
 		if(hasvar(W,"force") && hasvar(W,"damtype"))
-			user.do_attack_animation(src, W)
+			W.on_attack(src, user)
+			visible_message("<span class='danger'>[src] has been hit by [user] with [W].</span>")
 			switch(W.damtype)
 				if("fire")
 					src.health -= W.force * fire_dam_coeff
@@ -152,6 +158,7 @@
 					src.health -= W.force * brute_dam_coeff
 			..()
 			healthcheck()
+			return W.force
 		else
 			..()
 

--- a/code/game/machinery/bots/cleanbot.dm
+++ b/code/game/machinery/bots/cleanbot.dm
@@ -151,18 +151,19 @@ text("<A href='?src=\ref[src];operation=oddbutton'>[src.oddbutton ? "Yes" : "No"
 			to_chat(usr, "<span class='notice'>You press the weird button.</span>")
 			src.updateUsrDialog()
 
-/obj/machinery/bot/cleanbot/attackby(obj/item/weapon/W, mob/user as mob)
+/obj/machinery/bot/cleanbot/attackby(obj/item/weapon/W, mob/user)
 	if (istype(W, /obj/item/weapon/card/id)||istype(W, /obj/item/device/pda))
-		if(src.allowed(usr) && !open && !emagged)
-			src.locked = !src.locked
-			to_chat(user, "<span class='notice'>You [ src.locked ? "lock" : "unlock"] the [src] behaviour controls.</span>")
+		if(allowed(usr) && !open && !emagged)
+			locked = !locked
+			to_chat(user, "<span class='notice'>You [locked ? "lock" : "unlock"] [src]'s behaviour controls.</span>")
+			updateUsrDialog()
 		else
 			if(emagged)
 				to_chat(user, "<span class='warning'>ERROR</span>")
-			if(open)
+			else if(open)
 				to_chat(user, "<span class='warning'>Please close the access panel before locking it.</span>")
 			else
-				to_chat(user, "<span class='notice'>This [src] doesn't seem to respect your authority.</span>")
+				to_chat(user, "<span class='notice'>[src] doesn't seem to respect your authority.</span>")
 	else
 		return ..()
 
@@ -354,19 +355,20 @@ text("<A href='?src=\ref[src];operation=oddbutton'>[src.oddbutton ? "Yes" : "No"
 	var/armed = 0
 
 /obj/machinery/bot/cleanbot/roomba/attackby(var/obj/item/W, mob/user)
-	..()
-	if(istype(W,/obj/item/weapon/kitchen/utensil/fork) && !armed)
+	if(istype(W,/obj/item/weapon/kitchen/utensil/fork) && !armed && user.a_intent != I_HURT)
 		if(user.drop_item(W))
 			qdel(W)
 			to_chat(user, "<span class='notice'>You attach \the [W] to \the [src]. It looks increasingly concerned about its current situation.</span>")
 			armed++
-	else if(istype(W, /obj/item/weapon/lighter) && armed == 1)
+	else if(istype(W, /obj/item/weapon/lighter) && armed == 1 && user.a_intent != I_HURT)
 		if(user.drop_item(W))
 			qdel(W)
 			to_chat(user, "<span class='notice'>You attach \the [W] to \the [src]. It appears to roll its sensor in disappointment before carrying on with its work.</span>")
 			armed++
 			icon_state = "roombot_battle[on]"
 			icon_initial = "roombot_battle"
+	else
+		. = ..()
 
 /obj/machinery/bot/cleanbot/roomba/Crossed(atom/A)
 	if(isliving(A))

--- a/code/game/machinery/bots/draculabot.dm
+++ b/code/game/machinery/bots/draculabot.dm
@@ -145,6 +145,7 @@
 				to_chat(user, "<span class='warning'>ERROR</span>")
 			else
 				to_chat(user, "<span class='warning'>Access denied.</span>")
+		return
 
 	if(istype(W,/obj/item/weapon/reagent_containers/blood))
 		var/obj/item/weapon/reagent_containers/blood/B = W
@@ -157,9 +158,10 @@
 			speak("Thanks, nurse! Now I've got [contained_bags.len]!")
 			update_icon()
 			updateUsrDialog()
-	if(health < maxhealth && !isscrewdriver(W) && W.force && !emagged) //Retreat if we're not hostile and we're under attack
-		step_to(src, get_step_away(src,user))
-	..()
+		return
+	. = ..()
+	if(. && !emagged) //Retreat if we're not hostile and we're under attack
+		step_away(src,user)
 
 /obj/machinery/bot/bloodbot/Emag(mob/user as mob)
 	if(!locked)

--- a/code/game/machinery/bots/ed209bot.dm
+++ b/code/game/machinery/bots/ed209bot.dm
@@ -219,28 +219,28 @@ Auto Patrol: []"},
 			src.declare_arrests = !src.declare_arrests
 			src.updateUsrDialog()
 
-/obj/machinery/bot/ed209/attackby(obj/item/weapon/W as obj, mob/user as mob)
+/obj/machinery/bot/ed209/attackby(obj/item/weapon/W, mob/user)
 	if (istype(W, /obj/item/weapon/card/id)||istype(W, /obj/item/device/pda))
-		if (src.allowed(user) && !open && !emagged)
-			src.locked = !src.locked
+		if (allowed(user) && !open && !emagged)
+			locked = !locked
 			to_chat(user, "<span class='notice'>Controls are now [src.locked ? "locked" : "unlocked"].</span>")
+			updateUsrDialog()
 		else
 			if(emagged)
 				to_chat(user, "<span class='warning'>ERROR</span>")
-			if(open)
+			else if(open)
 				to_chat(user, "<span class='warning'>Please close the access panel before locking it.</span>")
 			else
 				to_chat(user, "<span class='notice'>Access denied.</span>")
 	else
-		..()
-		if (!isscrewdriver(W) && (!src.target))
-			if(hasvar(W,"force") && W.force)//If force is defined and non-zero
-				threatlevel = user.assess_threat(src)
-				threatlevel += PERP_LEVEL_ARREST_MORE
-				if(threatlevel > 0)
-					src.target = user
-					src.shootAt(user)
-					src.mode = SECBOT_HUNT
+		. = ..()
+		if (. && !target)
+			threatlevel = user.assess_threat(src)
+			threatlevel += PERP_LEVEL_ARREST_MORE
+			if(threatlevel > 0)
+				target = user
+				shootAt(user)
+				mode = SECBOT_HUNT
 
 /obj/machinery/bot/ed209/kick_act(mob/living/H)
 	..()

--- a/code/game/machinery/bots/floorbot.dm
+++ b/code/game/machinery/bots/floorbot.dm
@@ -129,30 +129,31 @@ var/global/list/floorbot_targets=list()
 		O.show_message("<span class='game say'><span class='name'>[src]</span> beeps, \"[message]\"",2)
 	return
 
-/obj/machinery/bot/floorbot/attackby(var/obj/item/W , mob/user as mob)
+/obj/machinery/bot/floorbot/attackby(var/obj/item/W , mob/user)
 	if(istype(W, /obj/item/stack/tile/plasteel))
 		var/obj/item/stack/tile/plasteel/T = W
-		if(src.amount >= 50)
+		if(amount >= 50)
 			return
 		var/loaded = min(50-src.amount, T.amount)
 		T.use(loaded)
-		src.amount += loaded
-		to_chat(user, "<span class='notice'>You load [loaded] tiles into the floorbot. He now contains [src.amount] tiles.</span>")
-		src.updateicon()
+		amount += loaded
+		to_chat(user, "<span class='notice'>You load [loaded] tiles into the floorbot. He now contains [amount] tiles.</span>")
+		updateicon()
+		updateUsrDialog()
 	else if(istype(W, /obj/item/weapon/card/id)||istype(W, /obj/item/device/pda))
-		if(src.allowed(usr) && !open && !emagged)
-			src.locked = !src.locked
-			to_chat(user, "<span class='notice'>You [src.locked ? "lock" : "unlock"] the [src] behaviour controls.</span>")
+		if(allowed(usr) && !open && !emagged)
+			locked = !locked
+			to_chat(user, "<span class='notice'>You [locked ? "lock" : "unlock"] \the [src]'s behaviour controls.</span>")
+			updateUsrDialog()
 		else
 			if(emagged)
 				to_chat(user, "<span class='warning'>ERROR</span>")
-			if(open)
+			else if(open)
 				to_chat(user, "<span class='warning'>Please close the access panel before locking it.</span>")
 			else
 				to_chat(user, "<span class='warning'>Access denied.</span>")
-		src.updateUsrDialog()
 	else
-		..()
+		. = ..()
 
 /obj/machinery/bot/floorbot/Emag(mob/user as mob)
 	..()

--- a/code/game/machinery/bots/medbot.dm
+++ b/code/game/machinery/bots/medbot.dm
@@ -223,7 +223,7 @@
 	updateUsrDialog()
 	return
 
-/obj/machinery/bot/medbot/attackby(obj/item/weapon/W as obj, mob/user as mob)
+/obj/machinery/bot/medbot/attackby(obj/item/weapon/W, mob/user)
 	if (istype(W, /obj/item/weapon/card/id)||istype(W, /obj/item/device/pda))
 		if (allowed(user) && !open && !emagged)
 			locked = !locked
@@ -232,7 +232,7 @@
 		else
 			if(emagged)
 				to_chat(user, "<span class='warning'>ERROR</span>")
-			if(open)
+			else if(open)
 				to_chat(user, "<span class='warning'>Please close the access panel before locking it.</span>")
 			else
 				to_chat(user, "<span class='warning'>Access denied.</span>")
@@ -256,9 +256,9 @@
 			return
 
 	else
-		..()
-		if (health < maxhealth && !isscrewdriver(W) && W.force)
-			step_to(src, (get_step_away(src,user)))
+		. = ..()
+		if (.)
+			step_away(src,user)
 
 /obj/machinery/bot/medbot/Emag(mob/user as mob)
 	..()

--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -122,24 +122,25 @@ var/global/mulebot_count = 0
 // screwdriver: open/close hatch
 // cell: insert it
 // other: chance to knock rider off bot
-/obj/machinery/bot/mulebot/attackby(var/obj/item/I, var/mob/user)
+/obj/machinery/bot/mulebot/attackby(obj/item/I, mob/user)
+	user.delayNextAttack(I.attack_delay)
 	if(istype(I,/obj/item/weapon/card/emag))
-		locked = !locked
-		to_chat(user, "<span class='notice'>You [locked ? "lock" : "unlock"] the mulebot's controls!</span>")
+		toggle_lock(user, TRUE)
+		to_chat(user, "<span class='notice'>You [locked ? "lock" : "unlock"] [src]'s controls!</span>")
 		flick("[icon_initial]-emagged", src)
 		playsound(src, 'sound/effects/sparks1.ogg', 100, 0)
 	else if(istype(I, /obj/item/weapon/card/id))
 		if(toggle_lock(user))
 			to_chat(user, "<span class='notice'>Controls [(locked ? "locked" : "unlocked")].</span>")
 
-	else if(istype(I,/obj/item/weapon/cell) && open && !cell)
+	else if(istype(I,/obj/item/weapon/cell) && open && !cell && user.a_intent != I_HURT)
 		var/obj/item/weapon/cell/C = I
 		if(user.drop_item(C, src))
 			cell = C
 			updateDialog()
-	else if(istype(I,/obj/item/weapon/wirecutters)||istype(I,/obj/item/device/multitool))
+	else if((istype(I,/obj/item/weapon/wirecutters)||istype(I,/obj/item/device/multitool)) && user.a_intent != I_HURT)
 		attack_hand(user)
-	else if(istype(I,/obj/item/weapon/screwdriver))
+	else if(istype(I,/obj/item/weapon/screwdriver) && user.a_intent != I_HURT)
 		if(locked)
 			to_chat(user, "<span class='notice'>The maintenance hatch cannot be opened or closed while the controls are locked.</span>")
 			return
@@ -154,7 +155,7 @@ var/global/mulebot_count = 0
 			icon_state = "[icon_initial]0"
 
 		updateDialog()
-	else if (iswrench(I))
+	else if (iswrench(I) && user.a_intent != I_HURT)
 		if (src.health < maxhealth)
 			src.health = min(maxhealth, src.health+25)
 			user.visible_message(
@@ -166,12 +167,13 @@ var/global/mulebot_count = 0
 	else if(load && ismob(load))  // chance to knock off rider
 		if(prob(1+I.force * 2))
 			unload(0)
+			var/mob/living/rider = load
+			rider.Knockdown(2)
+			playsound(rider, "sound/effects/bodyfall.ogg", 50, 1)
 			user.visible_message("<span class='warning'>[user] knocks [load] off [src] with \the [I]!</span>", "<span class='warning'>You knock [load] off [src] with \the [I]!</span>")
-		else
-			to_chat(user, "You hit [src] with \the [I] but to no effect.")
+		. = ..()
 	else
-		..()
-	return
+		. = ..()
 
 
 /obj/machinery/bot/mulebot/ex_act(var/severity)
@@ -394,8 +396,8 @@ var/global/mulebot_count = 0
 /obj/machinery/bot/mulebot/proc/has_power()
 	return !open && cell && cell.charge > 0 && wires.HasPower()
 
-/obj/machinery/bot/mulebot/proc/toggle_lock(var/mob/user)
-	if(src.allowed(user))
+/obj/machinery/bot/mulebot/proc/toggle_lock(mob/user, ignore_access = FALSE)
+	if(allowed(user) || ignore_access)
 		locked = !locked
 		updateDialog()
 		return 1

--- a/code/game/machinery/bots/secbot.dm
+++ b/code/game/machinery/bots/secbot.dm
@@ -188,28 +188,27 @@ Auto Patrol: []"},
 			src.declare_arrests = !src.declare_arrests
 			src.updateUsrDialog()
 
-/obj/machinery/bot/secbot/attackby(obj/item/weapon/W as obj, mob/user as mob)
+/obj/machinery/bot/secbot/attackby(obj/item/weapon/W, mob/user)
 	if(istype(W, /obj/item/weapon/card/id)||istype(W, /obj/item/device/pda))
-		if(src.allowed(user) && !open && !emagged)
-			src.locked = !src.locked
-			to_chat(user, "Controls are now [src.locked ? "locked." : "unlocked."]")
+		if(allowed(user) && !open && !emagged)
+			locked = !locked
+			to_chat(user, "Controls are now [locked ? "locked." : "unlocked."]")
+			updateUsrDialog()
 		else
 			if(emagged)
 				to_chat(user, "<span class='warning'>ERROR</span>")
-			if(open)
+			else if(open)
 				to_chat(user, "<span class='warning'>Please close the access panel before locking it.</span>")
 			else
 				to_chat(user, "<span class='warning'>Access denied.</span>")
 	else
-		..()
-	if(iswelder(W) && user.a_intent != "harm") // Any intent but harm will heal, so we shouldn't get angry.
-		return
-	if(!isscrewdriver(W) && (W.force) && (!target) ) // Added check for welding tool to fix #2432. Welding tool behavior is handled in superclass.
-		threatlevel = user.assess_threat(src)
-		threatlevel += PERP_LEVEL_ARREST_MORE
-		if(threatlevel > 0)
-			target = user
-			mode = SECBOT_HUNT
+		. = ..()
+		if(. && !target)
+			threatlevel = user.assess_threat(src)
+			threatlevel += PERP_LEVEL_ARREST_MORE
+			if(threatlevel > 0)
+				target = user
+				mode = SECBOT_HUNT
 
 /obj/machinery/bot/secbot/kick_act(mob/living/H)
 	..()


### PR DESCRIPTION
Resolves #16863

:cl:
* tweak: There are now attack delays, attack sounds and attack messages for hitting bots. Having harm intent on while holding a tool will now generally cause you to attack a bot instead of manipulating/repairing it.
* bugfix: Bots no longer ignore being stabbed with screwdrivers. The retaliate/retreat logic now tied to actions that actually do damage.
* bugfix: You can no longer weld a bot with an unlit welder.
* tweak: Getting knocked off a MULE now floors you briefly. MULEs with riders are no longer immune to melee attacks.
