### PR TITLE
Role datums objective fixes

### DIFF
--- a/code/datums/gamemode/objectives/absorb.dm
+++ b/code/datums/gamemode/objectives/absorb.dm
@@ -2,10 +2,11 @@
 	explanation_text = "Absorb a number of genomes."
 	name = "(changeling) Absorb genomes"
 	var/genomes_to_absorb
-/datum/objective/absorb/New()
-	..()
+
+/datum/objective/absorb/PostAppend()
 	genomes_to_absorb = rand(2,3)
 	explanation_text = "Absorb [genomes_to_absorb] genomes."
+	return TRUE
 
 /datum/objective/absorb/IsFulfilled()
 	if (..())

--- a/code/datums/gamemode/objectives/acquire_blood.dm
+++ b/code/datums/gamemode/objectives/acquire_blood.dm
@@ -3,10 +3,11 @@
 	explanation_text = "Acquire 150 units of blood."
 	name = "(vampire) Acquire blood"
 
-/datum/objective/acquire_blood/New()
+/datum/objective/acquire_blood/PostAppend()
 	blood_objective = round(rand(3, 8)) * 50 // Between 150 and 400.
 	explanation_text = "Acquire [blood_objective] units of blood."
-	
+	return TRUE
+
 /datum/objective/acquire_blood/IsFulfilled()
 	if (..())
 		return TRUE

--- a/code/datums/gamemode/objectives/convert_people.dm
+++ b/code/datums/gamemode/objectives/convert_people.dm
@@ -25,10 +25,11 @@
 			return FALSE
 		return total
 
-/datum/objective/convert_people/New(var/text, var/auto_target = TRUE)
+/datum/objective/convert_people/PostAppend()
 	faction = find_active_faction(LEGACY_CULT)
 	cultists_target = get_number()
 	explanation_text = "We must increase our influence before we can summon Nar-Sie. Convert [cultists_target] crew members. Take it slowly to avoid raising suspicions."
+	return TRUE
 
 /datum/objective/convert_people/IsFulfilled()
 	return (faction.members.len >= cultists_target)

--- a/code/datums/gamemode/objectives/harvest.dm
+++ b/code/datums/gamemode/objectives/harvest.dm
@@ -7,16 +7,16 @@
 
     flags =  FACTION_OBJECTIVE
 
-/datum/objective/harvest/New()
-    ..()
-    var/targets = 0
-    for (var/mob/living/L in player_list)
-        if (ishuman(L) || issilicon(L))
-            targets++
-    targets -= faction.members.len
-    harvest_target = min(10, targets)
-    explanation_text = "The Geometer of Blood hungers for his first meal of this never-ending day. Offer him [harvest_target] unbelievers in sacrifice."
+/datum/objective/harvest/PostAppend()
+	var/targets = 0
+	for (var/mob/living/L in player_list)
+		if (ishuman(L) || issilicon(L))
+			targets++
+	targets -= faction.members.len
+	harvest_target = min(10, targets)
+	explanation_text = "The Geometer of Blood hungers for his first meal of this never-ending day. Offer him [harvest_target] unbelievers in sacrifice."
+	return TRUE
 
 /datum/objective/harvest/IsFulfilled()
-    var/datum/faction/cult/narsie/my_cult = faction
-    return (my_cult.harvested >= harvest_target)
+	var/datum/faction/cult/narsie/my_cult = faction
+	return (my_cult.harvested >= harvest_target)

--- a/code/datums/gamemode/objectives/objective.dm
+++ b/code/datums/gamemode/objectives/objective.dm
@@ -11,6 +11,16 @@
 	if(text)
 		explanation_text = text
 
+/datum/objective/target/Destroy()
+	owner = null
+	faction = null
+	..()
+
+/**
+	Used for post-adding things, such as objective/target finding a target that isn't the owner of this objective.
+	Return: TRUE if succesful, FALSE otherwise
+*/
+
 /datum/objective/proc/PostAppend()
 	return TRUE
 
@@ -31,6 +41,12 @@
 	objectives.Add(O)
 	if(M)
 		O.owner = M
+	if(O.PostAppend())
+		return TRUE
+	else
+		objectives.Remove(O)
+		qdel(O)
+		return FALSE
 
 /datum/objective_holder/proc/GetObjectives()
 	return objectives

--- a/code/datums/gamemode/objectives/spray_blood.dm
+++ b/code/datums/gamemode/objectives/spray_blood.dm
@@ -1,19 +1,20 @@
 // Legacy cult
 
 /datum/objective/spray_blood
-    explanation_text = "We must prepare this place for the Geometer of Blood's coming. Spread blood and gibs over X of the Station's floor tiles."
-    name = "Spray blood on the station."
-    var/floor_limit = 15 // Abritary, to fix later
+	explanation_text = "We must prepare this place for the Geometer of Blood's coming. Spread blood and gibs over X of the Station's floor tiles."
+	name = "Spray blood on the station."
+	var/floor_limit = 15 // Abritary, to fix later
 
-    flags =  FACTION_OBJECTIVE
+	flags =  FACTION_OBJECTIVE
 
-/datum/objective/spray_blood/New()
-    floor_limit = round(rand(1,5))*50
-    explanation_text = "We must prepare this place for the Geometer of Blood's coming. Spread blood and gibs over [floor_limit] of the Station's floor tiles."
+/datum/objective/spray_blood/PostAppend()
+	floor_limit = round(rand(1,5))*50
+	explanation_text = "We must prepare this place for the Geometer of Blood's coming. Spread blood and gibs over [floor_limit] of the Station's floor tiles."
+	return TRUE
 
 /datum/objective/spray_blood/IsFulfilled()
-    var/datum/faction/cult/narsie/cult_fac = faction
-    return (cult_fac.bloody_floors.len >= floor_limit)
+	var/datum/faction/cult/narsie/cult_fac = faction
+	return (cult_fac.bloody_floors.len >= floor_limit)
 
 /datum/objective/summon_narsie/feedbackText()
-    return "<span class = 'sinister'>You succesfully defiled the floors of this station. The veil between this world and Nar'Sie grows thinner.</span>"
+	return "<span class = 'sinister'>You succesfully defiled the floors of this station. The veil between this world and Nar'Sie grows thinner.</span>"

--- a/code/datums/gamemode/objectives/target/sacrifice.dm
+++ b/code/datums/gamemode/objectives/target/sacrifice.dm
@@ -4,13 +4,15 @@
 	name = "Sacrifice <target>"
 	flags = FACTION_OBJECTIVE
 
-/datum/objective/target/assassinate/sacrifice/New()
+/datum/objective/target/assassinate/sacrifice/PostAppend()
 	faction = find_active_faction(LEGACY_CULT)
 	if (!find_target())
 		message_admins("Could not find a target to sacrifice, rerolling objectives the hard way.")
 		var/datum/faction/cult/narsie/cult = faction
 		cult.getNewObjective()
 		CRASH("Could not find a target to sacrifice, rereolling objectives the hard way.") // Crash, so that it doesn't try to pass the bugged objective to the rest of the proc.
+		return FALSE
+	return TRUE
 
 /datum/objective/target/assassinate/sacrifice/find_target()
 	target = pick(get_targets())

--- a/code/datums/gamemode/objectives/target/syndicate/steal.dm
+++ b/code/datums/gamemode/objectives/target/syndicate/steal.dm
@@ -3,10 +3,10 @@
 	name = "\[Syndicate\] Steal <target>"
 
 var/list/potential_theft_objectives=list(
-	"traitor" = typesof(/datum/theft_objective/traitor) - /datum/theft_objective/traitor,
-	"special" = typesof(/datum/theft_objective/special) - /datum/theft_objective/special,
-	"heist_easy"   = typesof(/datum/theft_objective/number/heist_easy) - /datum/theft_objective/number/heist_easy,
-	"heist_hard"   = typesof(/datum/theft_objective/number/heist_hard) - /datum/theft_objective/number/heist_hard,
+	"traitor" = subtypesof(/datum/theft_objective/traitor),
+	"special" = subtypesof(/datum/theft_objective/special),
+	"heist_easy"   = subtypesof(/datum/theft_objective/number/heist_easy),
+	"heist_hard"   = subtypesof(/datum/theft_objective/number/heist_hard)
 )
 
 /datum/objective/target/steal

--- a/code/datums/gamemode/objectives/target/target.dm
+++ b/code/datums/gamemode/objectives/target/target.dm
@@ -2,12 +2,13 @@
 	var/datum/mind/target = null	//If they are focused on a particular person.
 	var/target_amount = 0	//If they are focused on a particular number. Steal objectives have their own counter.
 	var/list/bad_assassinate_targets = list("AI","Cyborg","Mobile MMI","Trader")
+	var/auto_target = TRUE //Whether we pick a target automatically on PostAppend()
 	name = ""
 
-/datum/objective/target/New(var/text,var/auto_target = TRUE)
-	..()
-	if (auto_target)
-		find_target()
+/datum/objective/target/PostAppend()
+	if(auto_target)
+		return find_target()
+	return TRUE
 
 /datum/objective/target/proc/find_target()
 	var/list/possible_targets = list()
@@ -36,9 +37,3 @@
 
 /datum/objective/target/proc/select_target()
 	return 0
-
-/datum/objective/target/IsFulfilled()
-	if (..())
-		return TRUE
-	if(!target) //BE YOURSELF
-		return TRUE

--- a/code/datums/gamemode/role/role.dm
+++ b/code/datums/gamemode/role/role.dm
@@ -223,8 +223,7 @@
 		O = objective_type
 	else
 		O = new objective_type
-	if(O.PostAppend())
-		objectives.AddObjective(O, antag)
+	if(objectives.AddObjective(O, antag))
 		return TRUE
 	return FALSE
 

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -4614,10 +4614,11 @@
 		var/setup = TRUE
 		if (istype(new_objective,/datum/objective/target))
 			var/datum/objective/target/new_O = new_objective
-			if (alert("Do you want to specify a target?", "New Objective", "Yes", "No") == "No")
-				setup = new_O.find_target()
-			else
+			if (alert("Do you want to specify a target?", "New Objective", "Yes", "No") == "Yes")
 				setup = new_O.select_target()
+				new_O.auto_target = FALSE
+			else
+				setup = TRUE //Let it sort itself out
 
 		if(!setup)
 			alert("Couldn't set-up a proper target.", "New Objective")
@@ -4638,7 +4639,7 @@
 		if (obj_holder.faction)
 			log_admin("[usr.key]/([usr.name]) removed \the [obj_holder.faction.ID]'s objective ([objective.explanation_text])")
 			objective.faction.handleRemovedObjective(objective)
-	
+
 		obj_holder.objectives.Remove(objective)
 
 	if(href_list["obj_completed"])


### PR DESCRIPTION
Fixes objectives not functioning properly. This was due to them looking for a mind that had not been assigned at that point.

Also fixes steal objectives always showing as successful by removing a just be yourself joke that was being inherited.

Fixes the vampire objective whitespace, switching it from spaces to tabs.
