### PR TITLE
Component processing subsystem

### DIFF
--- a/__DEFINES/subsystem.dm
+++ b/__DEFINES/subsystem.dm
@@ -10,6 +10,7 @@
 #define SS_INIT_PLANT              21.5
 #define SS_INIT_HUMANS             21
 #define SS_INIT_MAP                20
+#define SS_INIT_COMPONENT          19.5
 #define SS_INIT_POWER              19
 #define SS_INIT_OBJECT             18
 #define SS_INIT_PIPENET            17.5
@@ -27,6 +28,7 @@
 
 #define SS_PRIORITY_TICKER         200
 #define SS_PRIORITY_MOB            150
+#define SS_PRIORITY_COMPONENT      125
 #define SS_PRIORITY_NANOUI         120
 #define SS_PRIORITY_VOTE           110
 #define SS_PRIORITY_FAST_OBJECTS   105
@@ -53,6 +55,7 @@
 #define SS_DISPLAY_AIR            -90
 #define SS_DISPLAY_LIGHTING       -80
 #define SS_DISPLAY_MOB            -70
+#define SS_DISPLAY_COMPONENT      -69
 #define SS_DISPLAY_FAST_OBJECTS   -65
 #define SS_DISPLAY_OBJECTS        -60
 #define SS_DISPLAY_MACHINERY      -50

--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -13,6 +13,7 @@ var/global/list/living_mob_list = list()			//List of all alive mobs, including c
 var/global/list/dead_mob_list = list()				//List of all dead mobs, including clientless. Excludes /mob/new_player
 var/list/observers = new/list()
 var/global/list/areas = list()
+var/global/list/active_component_containers = list() 	//List of all component containers that have registered for updating
 
 var/global/list/chemical_reactions_list				//list of all /datum/chemical_reaction datums. Used during chemical reactions
 var/global/list/chemical_reagents_list				//list of all /datum/reagent datums indexed by reagent id. Used by chemistry stuff

--- a/code/controllers/subsystem/component.dm
+++ b/code/controllers/subsystem/component.dm
@@ -1,0 +1,41 @@
+var/datum/subsystem/component/SScomp
+
+/datum/subsystem/component
+	name          = "Component"
+	wait          = 0.5 SECONDS
+	flags         = SS_NO_INIT | SS_KEEP_TIMING
+	priority      = SS_PRIORITY_COMPONENT
+	display_order = SS_DISPLAY_COMPONENT
+
+	var/list/currentrun
+
+
+/datum/subsystem/component/New()
+	NEW_SS_GLOBAL(SScomp)
+
+
+/datum/subsystem/component/stat_entry()
+	..("P:[active_component_containers.len]")
+
+
+/datum/subsystem/component/fire(resumed = FALSE)
+	if (!resumed)
+		currentrun = active_component_containers.Copy()
+
+	while (currentrun.len)
+		var/datum/component_container/C = currentrun[currentrun.len]
+		currentrun.len--
+
+		if(!C || C.gcDestroyed || !C.holder || !C.components.len)
+			continue
+
+		if(isliving(C.holder))
+			var/mob/living/M = C.holder
+			if (!M || M.disposed || M.gcDestroyed || M.timestopped || M.monkeyizing || M.stat == DEAD)
+				continue
+
+
+		C.SendSignal(COMSIG_LIFE, list())
+
+		if(MC_TICK_CHECK)
+			return

--- a/code/modules/components/ai/controllers/movement.dm
+++ b/code/modules/components/ai/controllers/movement.dm
@@ -25,10 +25,10 @@
 				target = args["loc"]
 				movement_nodes = AStar(M, target, /turf/proc/AdjacentTurfsSpace, /turf/proc/Distance, 0, 30, id=M.get_visible_id())
 			if("dir" in args)
-				movement_nodes.Cut()
+				movement_nodes = list()
 				walk(M, args["dir"], walk_delay)
 		if(message_type == COMSIG_LIFE)
-			if(movement_nodes.len && target && (target != null))
+			if(movement_nodes && movement_nodes.len && target && (target != null))
 				if(movement_nodes.len > 0)
 					step_to(M, movement_nodes[1])
 					movement_nodes -= movement_nodes[1]

--- a/code/modules/components/ai/mobs/component_mob.dm
+++ b/code/modules/components/ai/mobs/component_mob.dm
@@ -9,6 +9,7 @@
 	..()
 	BrainContainer = new (src)
 	InitializeComponents()
+	BrainContainer.register_for_updates()
 
 /mob/living/component/proc/InitializeComponents()
 	// Set up components here

--- a/code/modules/components/component_container.dm
+++ b/code/modules/components/component_container.dm
@@ -15,6 +15,15 @@
 /datum/component_container/New(var/atom/holder_atom)
 	holder=holder_atom
 
+/datum/component_container/Destroy()
+	for(var/i in components)
+		qdel(i)
+	components.Cut()
+
+	holder = null
+	unregister_for_updates()
+	..()
+
 /datum/component_container/proc/AddComponentsByType(var/list/new_types)
 	var/list/newtypes=list()
 	for(var/new_type in new_types)
@@ -109,3 +118,10 @@
 		if(istype(C, desired_type))
 			. += C
 	return .
+
+
+/datum/component_container/proc/register_for_updates()
+	active_component_containers.Add(src)
+
+/datum/component_container/proc/unregister_for_updates()
+	active_component_containers.Remove(src)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1774,6 +1774,7 @@ mob/living/carbon/human/isincrit()
 	BrainContainer.AddComponent(/datum/component/controller/mob)
 	BrainContainer.AddComponent(/datum/component/ai/hand_control)
 	BrainContainer.AddComponent(/datum/component/controller/movement/astar)
+	BrainContainer.register_for_updates()
 
 /mob/living/carbon/human/proc/initialize_basic_NPC_components()	//will wander around
 	initialize_barebones_NPC_components()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -121,8 +121,6 @@
 					special_role = null
 					to_chat(current, "<span class='danger'><FONT size = 3>The fog clouding your mind clears. You remember nothing from the moment you were implanted until now..(You don't remember who enslaved you)</FONT></span>")
 				*/
-	if(BrainContainer)
-		BrainContainer.SendSignal(COMSIG_LIFE,list())
 	return 1
 
 // Apply connect damage

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -175,6 +175,7 @@
 #include "code\controllers\mc\master.dm"
 #include "code\controllers\mc\subsystem.dm"
 #include "code\controllers\subsystem\air.dm"
+#include "code\controllers\subsystem\component.dm"
 #include "code\controllers\subsystem\disease.dm"
 #include "code\controllers\subsystem\emergency_shuttle.dm"
 #include "code\controllers\subsystem\event.dm"


### PR DESCRIPTION
Moves component processing to a subsystem, rather than have to trawl through life and add something to fire it each time in every override that doesn't call the parent.

Likely either needs more sanity, or nuking from orbit

Also fixes some weirdness with movement erroring the fuck out because Astar said no