### PR TITLE
Antitoxin no hurt tummy + smokyroom reagent line fixed

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -603,9 +603,6 @@
 	density = 1.49033
 	specheatcap = 0.55536
 
-/datum/reagent/anti_toxin/digest(var/mob/living/carbon/human/M)
-	..(M, damage = 0.1, amount_for_damage = 15)
-
 /datum/reagent/anti_toxin/on_mob_life(var/mob/living/M)
 
 	if(..())
@@ -5271,7 +5268,7 @@
 		M.say(pick("The streets were heartless and cold, like the fickle 'love' of some hysterical dame.",
 			"The lights, the smoke, the grime... the city itself seemed alive that day. Was it the pulse that made me think so? Or just all the blood?",
 			"I caressed my .44 magnum. Ever since Jimmy bit it against the Two Bit Gang, the gun and its six rounds were the only partner I could trust.",
-			"The whole reason I took the case to begin with was trouble, in the shape of a pinup blonde with shanks that’d make you dizzy. Wouldn’t give her name, said she was related to the captain",
+			"The whole reason I took the case to begin with was trouble, in the shape of a pinup blonde with shanks that'd make you dizzy. Wouldn't give her name, said she was related to the captain",
 			"Judging by the boys at the lab, the perp took a sander to the tooth profiles, but did a sloppy job. Lab report came in early this morning. Guess my vacation is on pause.",
 			"The blacktop was baking that day, and the broads working 19th and Main were wearing even less than usual.",
 			"The young dame was pride and joy of the station. Little did she know that looks can breed envy... or worse.",


### PR DESCRIPTION
The PR which added this (#19121) said it didn't but it did. This changes it so that it doesn't.
![image](https://user-images.githubusercontent.com/5942183/44943476-312e1180-adc7-11e8-9deb-2bac0d1a7e1e.png)
is it technically a bugfix whoooo knooows but that PR had several things that he said he'd change/fix but then didn't and then it got merged so I consider it to be close enough

I don't know what happened to the smokyroom lines, but "that'd" and "wouldn't" were written with right single quotation marks ("that’d" and "wouldn’t" - ’ versus ') and apparently some editor at some point couldn't read that. I disqualify my own because I tested the reagent on the live server and it said:
`[23:49:16]SAY: unknown/kammerjunk (@128,62,2) As Galactic Common : The whole reason I took the case to begin with was trouble, in the shape of a pinup blonde with shanks thatӤ make you dizzy. WouldnӴ give her name, said she was related to the captain`
or:
![image](https://user-images.githubusercontent.com/5942183/44943456-d8f70f80-adc6-11e8-9b9c-e2a5dd95d1b0.png)

🆑 
- bugfix: Anti-toxin no longer hurts your stomach in doses of 15u or more, following the description of the PR that added reagents damaging stomachs.
- bugfix: Fixed broken character in smoky room reagent.