### PR TITLE
Woody Plants Need Sharp Object To Harvest (FFF4)

### DIFF
--- a/code/modules/hydroponics/seed_datums.dm
+++ b/code/modules/hydroponics/seed_datums.dm
@@ -626,6 +626,7 @@ var/global/list/gene_tag_masks = list()   // Gene obfuscation for delicious tria
 										H.vessel.remove_reagent(BLOOD, drawing)
 										tray.reagents.add_reagent(BLOOD, drawing)
 	if(ligneous && success)
+		success = 0
 		if(istype(user, /mob/living/carbon))
 			var/mob/living/carbon/M = user
 			for(var/obj/item/I in M.held_items)


### PR DESCRIPTION
fixes #11225

Only took 2 years to add 1 line of code! Fully tested on lemon tree (not woody) and towercap (woody).

🆑 
* bugfix: You once again need a sharp object, such as a hatchet, to harvest some plants.