### PR TITLE
Shelter fixes + QoL

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -981,6 +981,15 @@ FIRE ALARM
 		alarm()
 	..()
 
+/obj/machinery/firealarm/MouseDropTo(atom/movable/AM, mob/user)
+	if(user.incapacitated() || user.lying || !Adjacent(user) || !user.Adjacent(src))
+		return
+	if(istype(AM,/obj/structure/inflatable/shelter))
+		var/obj/structure/inflatable/shelter/S = AM
+		S.deflate()
+	if(istype(AM,/obj/item/inflatable/shelter))
+		attackby(AM,user)
+
 /obj/machinery/firealarm/attackby(obj/item/W as obj, mob/user as mob)
 	src.add_fingerprint(user)
 
@@ -988,7 +997,6 @@ FIRE ALARM
 		qdel(W)
 		shelter = TRUE
 		update_icon()
-		attack_hand(user)
 		return
 
 	if (isscrewdriver(W) && buildstage == 2)
@@ -1057,7 +1065,7 @@ FIRE ALARM
 	var/turf/simulated/location = loc
 	if(shelter && istype(location)) //If simulated turf and we have a shelter to drop
 		var/datum/gas_mixture/environment = location.return_air()
-		if(environment.toxins>1) //The simpler sensors aren't elaborate as air alarms to sense partial pressure or other threats
+		if(environment.toxins*(R_IDEAL_GAS_EQUATION*environment.temperature/environment.volume)>0.5) //Partial Pressure of 0.5%
 			var/obj/item/inflatable/shelter/S = new /obj/item/inflatable/shelter(loc)
 			S.inflate()
 			shelter = FALSE

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -291,7 +291,7 @@
 
 /obj/structure/inflatable/shelter
 	name = "inflatable shelter"
-	desc = "A shelter designed to protect from extreme heat and pressure, but vulnerable to popping by other forms of trauma. Filled with soporific gasses that promote health."
+	desc = "A shelter designed to protect from extreme heat and pressure, but vulnerable to popping by other forms of trauma. The entrance is fitted with a medical autoinjector."
 	icon_state = "shelter_base"
 	anchored = 0
 	undeploy_path = /obj/item/inflatable/shelter
@@ -311,7 +311,7 @@
 /obj/structure/inflatable/shelter/examine(mob/user)
 	..()
 	if(!(user.loc == src))
-		to_chat(user, "<span class='notice'>Click to enter. Use grab on shelter to force target inside.</span>")
+		to_chat(user, "<span class='notice'>Click to enter. Use grab on shelter to force target inside. Click-drag onto firealarm or right click to deflate.</span>")
 	else
 		to_chat(user, "<span class='notice'>Click to package contaminated clothes. Resist to exit/cancel exit.</span>")
 	var/list/living_contents = list()
@@ -356,7 +356,7 @@
 		var/obj/item/weapon/grab/G = W
 		var/mob/living/target = G.affecting
 		visible_message(user,"<span class='danger'>[user] begins to drag [target] into the shelter!</span>")
-		if(do_after(target,src,20)) //Twice the normal time
+		if(do_after_many(user,list(target,src),20)) //Twice the normal time
 			enter_shelter(target)
 	else
 		..()


### PR DESCRIPTION

🆑 
* bugfix: Shelter desc no longer implies it is soporific
* tweak: Fire alarm interface no longer pops open after shoving a shelter in
* tweak: Changed the threshold for shelters popping out of walls. It now requires 0.5% plasma instead of a flat 1 mol of plasma.
* rscadd: Shelters now show a progress bar when sticking someone else inside the shelter.
* rscadd: You can clickdrag a shelter onto a fire alarm to deflate it (clickdrag the item onto the fire alarm to put it away without picking it up)