### PR TITLE
Network Alert: ALL SYSTEMS NOMINAL

### DIFF
--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -631,12 +631,6 @@ Target Machine: "}
 	if(M)
 		hacktarget = M
 	var/turf/T = get_turf(loc)
-	if(prob(10))
-		for(var/mob/living/silicon/ai/AI in player_list)
-			if(T.loc)
-				to_chat(AI, "<font color = red><b>Network Alert: Brute-force encryption crack in progress in [T.loc].</b></font>")
-			else
-				to_chat(AI, "<font color = red><b>Network Alert: Brute-force encryption crack in progress. Unable to pinpoint location.</b></font>")
 	while(hackprogress < 100)
 		if(hacktarget && get_dist(src, hacktarget) <= 1)
 			hackprogress += rand(10, 20)


### PR DESCRIPTION
Removes the "Network Alert: Brute-force encryption crack in progress in x" message when a pAI wirejack hacks a thing because HOLY SHIT that's annoying and useless

🆑 
 - rscdel: Removed the AI Network Alert for pAIs wirejacking into shit.