### PR TITLE
Seed Extractor No Longer Causes Dropping Items (FFF14)

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1709,9 +1709,6 @@ Game Mode config tags:
 
 	var/produce = rand(min_seeds,max_seeds)
 
-	if(user)
-		user.drop_item(O, force_drop = TRUE)
-
 	if(istype(O, /obj/item/weapon/grown))
 		var/obj/item/weapon/grown/F = O
 		if(F.plantname)
@@ -1727,6 +1724,8 @@ Game Mode config tags:
 				while(min_seeds <= produce)
 					new F.nonplant_seed_type(seedloc)
 					min_seeds++
+				if(user)
+					user.drop_item(F, force_drop = TRUE)
 				qdel(F)
 				return TRUE
 
@@ -1739,6 +1738,8 @@ Game Mode config tags:
 	else
 		return FALSE
 
+	if(user)
+		user.drop_item(O, force_drop = TRUE)
 	qdel(O)
 	return TRUE
 


### PR DESCRIPTION
fixes #18355

🆑 
* bugfix: You no longer will drop an item that cannot be seed extracted when using it on the seed extractor (e.g.: the wrench).