### PR TITLE
Fixes Animal Holder Inconsistencies (FFF15)

### DIFF
--- a/code/modules/mob/living/holders.dm
+++ b/code/modules/mob/living/holders.dm
@@ -106,7 +106,7 @@
 
 		throw_range = 6 - w_class
 
-		if(w_class > W_CLASS_TINY)
+		if(w_class > W_CLASS_SMALL)
 			flags |= (TWOHANDABLE | MUSTTWOHAND)
 
 //MICE

--- a/code/modules/mob/living/simple_animal/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer.dm
@@ -28,7 +28,7 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 	icon_dead = "brainslug_dead"
 	speed = 6
 
-	size = SIZE_SMALL
+	size = W_CLASS_TINY
 
 	min_tox = 0
 	max_tox = 0


### PR DESCRIPTION
fixes #17924

If they're bigger than small their item form is HUGE anyway so you can't put them in bags, but if they're small it makes sense you can onehand them. On the other hand borers should have been tiny to begin with because you can only fit a tiny item in the head with cavity surgery.

🆑 
* bugfix: Animal holder rules are now more consistent. Notably, small animals do not need to be wielded and can be stored in containers.