### PR TITLE
Offhands Delete Self If Nullspaced or on Turf (FFF16)

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -72,6 +72,8 @@
 		new path(src)
 
 /obj/item/Destroy()
+	if(wielded)
+		unwield()
 	if(istype(loc, /mob))
 		var/mob/H = loc
 		H.drop_from_inventory(src) // items at the very least get unequipped from their mob before being deleted
@@ -883,15 +885,17 @@
 		return
 
 /obj/item/proc/unwield(mob/user)
-	if(flags & MUSTTWOHAND && src in user)
+	if(flags & MUSTTWOHAND && user && src in user)
 		user.drop_from_inventory(src)
 	if(istype(wielded))
 		wielded.wielding = null
-		user.u_equip(wielded,1)
+		if(user)
+			user.u_equip(wielded,1)
 		if(wielded)
 			returnToPool(wielded)
 			wielded = null
-	update_wield(user)
+	if(user)
+		update_wield(user)
 
 /obj/item/proc/update_wield(mob/user)
 

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -26,10 +26,8 @@
 	..()
 
 /obj/item/offhand/process()
-	if(!loc)
-		return returnToPool(src)
-	else if(istype(loc,/turf) || !(contents.len))
-		return returnToPool(src)
+	if(!loc || istype(loc,/turf))
+		unwield()
 
 /obj/item/offhand/dropped(user)
 	if(!wielding)

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -17,6 +17,20 @@
 	abstract = 1
 	var/obj/item/wielding = null
 
+/obj/item/offhand/New()
+	..()
+	processing_objects.Add(src)
+
+/obj/item/offhand/Destroy()
+	processing_objects.Remove(src)
+	..()
+
+/obj/item/offhand/process()
+	if(!loc)
+		return returnToPool(src)
+	else if(istype(loc,/turf) || !(contents.len))
+		return returnToPool(src)
+
 /obj/item/offhand/dropped(user)
 	if(!wielding)
 		returnToPool(src)


### PR DESCRIPTION
This is the system animal holders use, which I thought was good enough. Handles all the nice edge cases where somehow the offhand is forced onto the turf. This also catches an unreported bug regarding walking out of the holodeck with a wielded item which would previously leave you with an unbound offhand item.

fixes #19398

🆑 
* bugfix: Becoming deleted while holding a wielded object no longer gives you a 'bound object' offhand item.