### PR TITLE
Space Is Quiet (FFF18)

### DIFF
--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -76,12 +76,34 @@ var/list/freqtoname = list(
 	say_testing(src, "/atom/movable/proc/send_speech() start, msg = [speech.message]; message_range = [range]; language = [speech.language ? speech.language.name : "None"];")
 	if(isnull(range))
 		range = 7
+	range = atmospheric_speech(speech,range)
 	var/rendered = render_speech(speech)
 	var/list/listeners = get_hearers_in_view(range, src)
 	if(speech.speaker.GhostsAlwaysHear())
 		listeners |= observers
 	for(var/atom/movable/AM in listeners)
 		AM.Hear(speech, rendered)
+
+/atom/movable/proc/atmospheric_speech(var/datum/speech/speech, var/range=7)
+	var/turf/T = get_turf(speech.speaker)
+	if(T && !T.c_airblock(T)) //we are on an airflowing tile
+		var/atmos = 0
+		var/datum/gas_mixture/current_air = T.return_air()
+		if(current_air)
+			atmos = round(current_air.return_pressure()/ONE_ATMOSPHERE, 0.1)
+		else
+			atmos = 0 //no air
+		range = min(round(range * sqrt(atmos)), range) //Range technically falls off with the root of pressure (see Newtonian sound)
+		/*Rough range breakpoints for default 7-range speech
+		10kpa: 0 (round 0.09 down to 0 for atmos value)
+		11kpa: 2
+		21kpa: 3
+		51kpa: 4
+		61kpa: 5
+		81kpa: 6
+		101kpa: 7 (normal)
+		*/
+	return range
 
 /atom/movable/proc/GhostsAlwaysHear()
 	return FALSE

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -233,6 +233,8 @@ var/list/department_radio_keys = list(
 	if(isnull(message_range))
 		message_range = 7
 
+	message_range = atmospheric_speech(speech,message_range)
+
 	var/list/listeners = get_hearers_in_view(message_range, speech.speaker) | observers
 
 	var/rendered = render_speech(speech)


### PR DESCRIPTION
fixes  #6124
fixes #14385

One of our oldest bugs
Tested this one pretty thoroughly I think, the only thing I notice that we may want to change is to play with the scaling numbers and maybe you should get the speech bubble overlay even when you aren't heard? That way people can see you're *trying* to talk even though the words don't make it out. Or some other kind of feedback like "X moves \his lips, but the sound is too faint."
This is also prone to causing a problem where you don't realize the other person can't hear you.

Either way, I present to you speech distance scaling based on air pressure. Radio comms are not affected at all by this. Here are some distance breakpoints I commented in the code (and yes I tested these on local with a space room and air pumps).

		10kpa: 0 (round 0.09 down to 0 for atmos value)
		11kpa: 2
		21kpa: 3
		51kpa: 4
		61kpa: 5
		81kpa: 6
		101kpa: 7 (normal)

🆑 
* rscadd: In space no one can hear you scream unless you use the radio.  Local speech distance now scales with air pressure.