### PR TITLE
Unlimited Clown Naming Time (FFF19)

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -258,8 +258,6 @@ Turf and target are seperate in case you want to teleport some distance from a t
 
 		for(var/i=1,i<=3,i++)	//we get 3 attempts to pick a suitable name.
 			newname = input(src,"You are a [role]. Would you like to change your name to something else?", "Name change",oldname) as text
-			if((world.time-time_passed)>300)
-				return	//took too long
 			newname = reject_bad_name(newname,allow_numbers)	//returns null if the name doesn't meet some basic requirements. Tidies up a few other things like bad-characters.
 
 			for(var/mob/living/M in player_list)


### PR DESCRIPTION
What's the worst that can happen? Roles like clown/mime are no longer limited to a mere 5 minutes to name themselves. Note that they don't get any bank account or ID access until they name themselves, so I think that's a fairly strong incentive to not remain un-named.

fixes #8488

🆑 
* bugfix: Clowns and mimes who fail to name themselves quickly will no longer be stuck as "unknown" without access or bank account.