### PR TITLE
Electropacks Can't Be Quickswapped Off (FFF20)

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1257,7 +1257,7 @@ var/global/list/image/blood_overlays = list()
 	var/obj/abstract/screen/inventory/OI = over_object
 	on_mousedrop_to_inventory_slot()
 
-	if(OI.hand_index && usr.put_in_hand_check(src, OI.hand_index))
+	if(OI.hand_index && usr.put_in_hand_check(src, OI.hand_index) && !src.prepickup(usr))
 		usr.u_equip(src, TRUE)
 		usr.put_in_hand(OI.hand_index, src)
 		add_fingerprint(usr)

--- a/code/game/objects/items/devices/radio/electropack.dm
+++ b/code/game/objects/items/devices/radio/electropack.dm
@@ -40,6 +40,9 @@
 		return
 	..()
 
+/obj/item/device/radio/electropack/prepickup(mob/user)
+	return src == user.back //Prevents picking the item up if it's the user's back slot item. e.g.: if they are quickswapping
+
 /obj/item/device/radio/electropack/Destroy()
 	if(istype(src.loc, /obj/item/assembly/shock_kit))
 		var/obj/item/assembly/shock_kit/S = src.loc


### PR DESCRIPTION
fixes #15326

also fixes an unreported bug where you could unequip electropacks by mousedragging them to your hand

🆑 
* bugfix: Electropacks are now much better at preventing removal by the victim