### PR TITLE
Break cell lockers (FFF21)

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -326,6 +326,7 @@
 
 /obj/structure/closet/secure_closet/brig/Destroy()
 	brig_lockers.Remove(src)
+	..()
 
 
 


### PR DESCRIPTION
fixes #19414

🆑 
* bugfix: Cell lockers are no longer invulnerable to harm