### PR TITLE
Cargo Is NEVER Late (FFF22)

### DIFF
--- a/code/controllers/subsystem/supply_shuttle.dm
+++ b/code/controllers/subsystem/supply_shuttle.dm
@@ -15,7 +15,7 @@ var/datum/subsystem/supply_shuttle/SSsupply_shuttle
 	name       = "Supply Shuttle"
 	init_order = SS_INIT_SUPPLY_SHUTTLE
 	flags      = SS_NO_TICK_CHECK
-	wait       = 30 SECONDS
+	wait       = 1 SECONDS
 	//supply points have been replaced with MONEY MONEY MONEY - N3X
 	var/credits_per_slip = 2
 	var/credits_per_crate = 5


### PR DESCRIPTION
Should it be late? Should it sometimes be early? Who can say, but that seems more like a feature request to add variance. This does away with the uncertain waiting time. Basically what was happening is that if you "miss the bus" when the SS controller checks in every 30 seconds, you need to wait until the next cycle for the shuttle to arrive. That means all cargo shuttles come late, and it can be anywhere from 1 to 30 seconds late.

Not anymore.
fixes  #11344

🆑 
* bugfix: The cargo shuttle will not be late.