### PR TITLE
Trader 2

### DIFF
--- a/code/datums/wires/vending.dm
+++ b/code/datums/wires/vending.dm
@@ -44,6 +44,8 @@ var/const/VENDING_WIRE_IDSCAN = 8
 
 /datum/wires/vending/UpdatePulsed(var/index)
 	var/obj/machinery/vending/V = holder
+	if(V.unhackable)
+		return
 	switch(index)
 		if(VENDING_WIRE_THROW)
 			V.shoot_inventory = !V.shoot_inventory
@@ -56,6 +58,8 @@ var/const/VENDING_WIRE_IDSCAN = 8
 
 /datum/wires/vending/UpdateCut(var/index, var/mended)
 	var/obj/machinery/vending/V = holder
+	if(V.unhackable)
+		return
 	switch(index)
 		if(VENDING_WIRE_THROW)
 			V.shoot_inventory = !mended

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -61,6 +61,9 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 			if(player.assigned_role == job)
 				possible_changelings -= player
 
+		if(player.role_alt_title == "Merchant")
+			possible_changelings -= player
+
 	changeling_amount = 1 + round(num_players() / 10)
 
 // mixed mode scaling

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -61,8 +61,8 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 			if(player.assigned_role == job)
 				possible_changelings -= player
 
-		if(player.role_alt_title == "Merchant")
-			possible_changelings -= player
+		/*if(player.role_alt_title == "Merchant")
+			possible_changelings -= player*/
 
 	changeling_amount = 1 + round(num_players() / 10)
 

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -111,6 +111,9 @@
 			if(player.assigned_role == job)
 				cultists_possible -= player
 
+		if(player.role_alt_title == "Merchant")
+			cultists_possible -= player
+
 	for(var/cultists_number = 1 to max_cultists_to_start)
 		if(!cultists_possible.len)
 			break

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -20,7 +20,7 @@
 /datum/game_mode/revolution
 	name = "revolution"
 	config_tag = "revolution"
-	restricted_jobs = list("Security Officer", "Warden", "Detective", "AI", "Cyborg","Mobile MMI","Captain", "Head of Personnel", "Head of Security", "Chief Engineer", "Research Director", "Chief Medical Officer", "Internal Affairs Agent")
+	restricted_jobs = list("Security Officer", "Warden", "Detective", "AI", "Cyborg","Mobile MMI","Captain", "Head of Personnel", "Head of Security", "Chief Engineer", "Research Director", "Chief Medical Officer", "Internal Affairs Agent", "Trader")
 	required_players = 4
 	required_players_secret = 25
 	required_enemies = 3

--- a/code/game/gamemodes/traitor/doubleagent.dm
+++ b/code/game/gamemodes/traitor/doubleagent.dm
@@ -50,6 +50,9 @@
 			if(player.assigned_role == job)
 				possible_traitors -= player
 
+		if(player.role_alt_title == "Merchant")
+			possible_traitors -= player
+
 	if(possible_traitors.len < required_enemies) //fixes double agent starting with 1 traitor
 		log_admin("Failed to set-up a round of double agents. Couldn't find enough volunteers to be traitors.")
 		message_admins("Failed to set-up a round of double agents. Couldn't find enough volunteers to be traitors.")

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -52,8 +52,8 @@
 			if(player.assigned_role == job)
 				possible_traitors -= player
 
-		if(player.role_alt_title == "Merchant")
-			possible_traitors -= player
+		/*if(player.role_alt_title == "Merchant")
+			possible_traitors -= player*/
 
 	if(possible_traitors.len < required_enemies) //fixes double agent starting with 1 traitor
 		return 0

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -52,6 +52,9 @@
 			if(player.assigned_role == job)
 				possible_traitors -= player
 
+		if(player.role_alt_title == "Merchant")
+			possible_traitors -= player
+
 	if(possible_traitors.len < required_enemies) //fixes double agent starting with 1 traitor
 		return 0
 

--- a/code/game/gamemodes/vampire/vampire.dm
+++ b/code/game/gamemodes/vampire/vampire.dm
@@ -65,6 +65,9 @@
 			if(player.assigned_role == job)
 				possible_vampires -= player
 
+		if(player.role_alt_title == "Merchant")
+			possible_vampires -= player
+
 	vampire_amount = min(recommended_enemies, max(required_enemies,round(num_players() / 10))) //1 + round(num_players() / 10)
 
 	if(possible_vampires.len>0)

--- a/code/game/jobs/job/whitelisted.dm
+++ b/code/game/jobs/job/whitelisted.dm
@@ -28,7 +28,7 @@
 	no_headset = 1
 
 	//Both Restricted: Revolution, Revsquad
-	//Merchant Restricted: Traitor, Double Agent, Changeling, Vampire, Cult
+	//Merchant Restricted: Double Agent, Vampire, Cult
 
 /datum/job/trader/equip(var/mob/living/carbon/human/H)
 	if(!H)
@@ -48,13 +48,13 @@
 
 	H.equip_or_collect(new H.species.survival_gear(H.back), slot_in_backpack)
 	H.equip_or_collect(new /obj/item/weapon/storage/wallet/trader(H.back), slot_in_backpack)
-
+	H.equip_or_collect(new /obj/item/device/radio(H), slot_belt)
 	switch(H.mind.role_alt_title)
 		if("Trader") //Traders get snacks and a coin
 			H.equip_or_collect(new /obj/item/weapon/storage/box/donkpockets/random_amount(H.back), slot_in_backpack)
 			H.equip_or_collect(new /obj/item/weapon/reagent_containers/food/drinks/thermos/full(H.back), slot_in_backpack)
 			H.equip_or_collect(new /obj/item/weapon/coin/trader(H.back), slot_in_backpack)
-			H.equip_or_collect(new /obj/item/device/radio(H), slot_belt)
+
 		if("Merchant") //Merchants get an implant
 			var/obj/item/weapon/implant/loyalty/L = new/obj/item/weapon/implant/loyalty(H)
 			L.imp_in = H
@@ -101,7 +101,7 @@
 					</style>
 					<body>
 					<center><img src="http://ss13.moe/wiki/images/1/17/NanoTrasen_Logo.png"> <h1>ATTN: Internal Affairs</h1></center>
-					Nanotrasen\'s commercial arm has noted the presence of a registered merchant who holds a license for corporate commerce and a Nanotrasen loyalty implant in your sector. The registered trade partner\'s image is enclosed. Please continue to monitor trade on an ongoing basis such that Nanotrasen can maintain highest standard small business enterprise (SBE) partners.<BR>
+					Nanotrasen\'s commercial arm has noted the presence of a registered merchant who holds a license for corporate commerce, a process which includes a background check and Nanotrasen loyalty implant. The associate\'s image is enclosed. Please continue to monitor trade on an ongoing basis such that Nanotrasen can maintain highest standard small business enterprise (SBE) partners.<BR>
 					</body>
 					<fieldset>
   					<legend>Picture</legend>

--- a/code/game/jobs/job/whitelisted.dm
+++ b/code/game/jobs/job/whitelisted.dm
@@ -76,7 +76,7 @@
 
 	to_chat(M, "<B>You are a [job_title].</B>")
 
-	to_chat(M, "<b>You should do your best to sell what you can to fund new product sales. Ultimately, the mark of a good trader is profit -- but public relations are an important component of thatend goal.</b>")
+	to_chat(M, "<b>You should do your best to sell what you can to fund new product sales. Ultimately, the mark of a good trader is profit -- but public relations are an important component of that end goal.</b>")
 
 	if(M.mind.role_alt_title == "Merchant")
 		to_chat(M, "<B><span class='info'>Your merchant's license paperwork has just cleared with Nanotrasen HQ. You have a loyalty implant and the staff has been notified that you are active in this sector.</span></B>")
@@ -96,15 +96,19 @@
 	world << browse_rsc(preview_side, "previewicon2.png")
 	var/full_text = {"<html><style>
 					body {color: #000000; background: #ccffff;}
-					pbg {background: #000000}
 					h1 {color: #000000; font-size:30px;}
+					fieldset {width:140px;}
 					</style>
 					<body>
-					<img src="http://ss13.moe/wiki/images/1/17/NanoTrasen_Logo.png"> <h1>ATTN: Internal Affairs</h1>
-					Nanotrasen\'s commercial arm has noted the presence of a registered merchant who holds a license for corporate commerce and a Nanotrasen loyalty implant in your sector. The registered trade partner\'s image is enclosed. Please continue to monitor trade on an ongoing basis such that Nanotrasen can maintain highest standard small business enterprise (SBE) partners.<BR>Photo ID:<BR><BR>
-					</body><pbg><img src="previewicon.png"><img src="previewicon2.png"></pbg><BR>
-					<body>[merchant.name]<BR>
+					<center><img src="http://ss13.moe/wiki/images/1/17/NanoTrasen_Logo.png"> <h1>ATTN: Internal Affairs</h1></center>
+					Nanotrasen\'s commercial arm has noted the presence of a registered merchant who holds a license for corporate commerce and a Nanotrasen loyalty implant in your sector. The registered trade partner\'s image is enclosed. Please continue to monitor trade on an ongoing basis such that Nanotrasen can maintain highest standard small business enterprise (SBE) partners.<BR>
+					</body>
+					<fieldset>
+  					<legend>Picture</legend>
+					<center><img src="previewicon.png" width="64" height="64"><img src="previewicon2.png" width="64" height="64"></center>
+					</fieldset><BR>
+					<body>Name: [merchant.client.prefs.real_name]<BR>
 					Blood Type: [merchant.dna.b_type]<BR>
-					Fingerprint: [md5(merchant.dna.uni_identity)]</body>"}
+					Fingerprint: [md5(merchant.dna.uni_identity)]</body></html>"}
 
-	SendFax(full_text, "Licensed Merchant Report - [merchant]", centcomm = 1)
+	SendFax(full_text, "Licensed Merchant Report - [merchant.client.prefs.real_name]", centcomm = 1) //Wow this is really cumbersome but [name] hasn't been assigned yet

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -423,6 +423,7 @@ var/global/ports_open = TRUE
 		list("id"=SEC_LEVEL_BLUE,  "name"="Blue"),
 		//SEC_LEVEL_RED = list("name"="Red"),
 	)
+	data["portopen"] = ports_open
 	data["ert_sent"] = sentStrikeTeams(TEAM_ERT)
 
 	var/msg_data[0]
@@ -691,5 +692,5 @@ var/global/ports_open = TRUE
 		return ..()
 
 	shuttle_autocall()
-	
+
 	..()

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -53,6 +53,7 @@ var/global/num_vending_terminals = 1
 	var/shut_up = 0				//Stop spouting those godawful pitches!
 	var/extended_inventory = 0	//can we access the hidden inventory?
 	var/scan_id = 1
+	var/unhackable = 0
 	var/obj/item/weapon/coin
 	var/datum/wires/vending/wires = null
 	var/list/overlays_vending[2]//1 is the panel layer, 2 is the dangermode layer
@@ -2936,7 +2937,8 @@ var/global/num_vending_terminals = 1
 
 /obj/machinery/vending/trader	// Boxes are defined in trader.dm
 	name = "\improper Trader Supply"
-	desc = "Its coin groove has been modified."
+	desc = "Its wiring has been modified to prevent hacking."
+	unhackable = 1
 	product_slogans = list(
 		"Profits."
 	)
@@ -2952,36 +2954,40 @@ var/global/num_vending_terminals = 1
 		/obj/item/weapon/capsule = 60,
 		/obj/item/weapon/implantcase/peace = 5,
 		/obj/item/vaporizer = 1,
+		/obj/item/weapon/storage/trader_chemistry = 1,
+		/obj/structure/closet/secure_closet/wonderful = 1,
+		/obj/item/weapon/disk/shuttle_coords/vault/mecha_graveyard = 1,
+		/obj/item/weapon/reagent_containers/glass/beaker/bluespace = 1,
+		/obj/item/weapon/storage/bluespace_crystal = 1,
+		/obj/item/weapon/reagent_containers/food/snacks/borer_egg = 1,
+		/obj/item/clothing/shoes/clown_shoes/advanced = 1,
+		/obj/item/fish_eggs/seadevil = 1,
+		/obj/machinery/power/antiquesynth = 1,
 		)
 	prices = list(
 		/obj/item/clothing/suit/storage/trader = 100,
 		/obj/item/device/pda/trader = 100,
 		/obj/item/weapon/capsule = 10,
 		/obj/item/weapon/implantcase/peace = 100,
-		/obj/item/vaporizer = 100
+		/obj/item/vaporizer = 100,
+		/obj/item/weapon/storage/trader_chemistry = 200,
+		/obj/structure/closet/secure_closet/wonderful = 350,
+		/obj/item/weapon/disk/shuttle_coords/vault/mecha_graveyard = 100,
+		/obj/item/weapon/reagent_containers/glass/beaker/bluespace = 100,
+		/obj/item/weapon/storage/bluespace_crystal = 150,
+		/obj/item/weapon/reagent_containers/food/snacks/borer_egg = 100,
+		/obj/item/clothing/shoes/clown_shoes/advanced = 50,
+		/obj/item/fish_eggs/seadevil = 50,
+		/obj/machinery/power/antiquesynth = 350,
 		)
 
 	accepted_coins = list(/obj/item/weapon/coin/trader)
 
-	premium = list(
-		/obj/item/weapon/storage/trader_chemistry,
-		/obj/structure/closet/secure_closet/wonderful,
-		/obj/item/weapon/disk/shuttle_coords/vault/mecha_graveyard,
-		/obj/item/weapon/reagent_containers/glass/beaker/bluespace,
-		/obj/item/weapon/storage/bluespace_crystal,
-		/obj/item/weapon/reagent_containers/food/snacks/borer_egg,
-		/obj/item/clothing/shoes/clown_shoes/advanced,
-		/obj/item/fish_eggs/seadevil,
-		/obj/machinery/power/antiquesynth,
-		)
-
 /obj/machinery/vending/trader/New()
-
-	for(var/random_items = 1 to premium.len - 5)
-		premium.Remove(pick(premium))
-	if(premium.Find(/obj/item/weapon/disk/shuttle_coords/vault/mecha_graveyard))
-		load_dungeon(/datum/map_element/dungeon/mecha_graveyard)
-	premium.Add(pick(existing_typesof(/obj/item/borg/upgrade) - /obj/item/borg/upgrade/magnetic_gripper)) //A random borg upgrade minus the magnetic gripper. Time to jew the silicons!
+	load_dungeon(/datum/map_element/dungeon/mecha_graveyard)
+	var/list/upgrades = existing_typesof(/obj/item/borg/upgrade) - /obj/item/borg/upgrade/magnetic_gripper
+	for(var/i = 1 to 3)
+		premium.Add(pick_n_take(upgrades))
 
 	..()
 

--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -90,3 +90,7 @@
 			new item2_type(src)
 		if(item3_type)
 			new item3_type(src)
+
+/obj/item/weapon/storage/wallet/trader/New()
+	..()
+	dispense_cash(rand(150,250),src)

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -8,6 +8,7 @@
 	anchored = 1
 	circuit = "/obj/item/weapon/circuitboard/smeltcomp"
 	light_color = LIGHT_COLOR_GREEN
+	req_access = list(access_mining)
 
 	var/frequency = FREQ_DISPOSAL //Same as conveyors.
 	var/smelter_tag = null
@@ -83,7 +84,7 @@
 
 	else if(id)	//I don't care but the ID got in there in some way, allow them to eject it atleast.
 		dat += "<br><A href='?src=\ref[src];eject=1'>Eject ID.</A>"
-	
+
 	dat += {"</div>
 	<div style="float:left;" class="block">
 	<table>
@@ -182,6 +183,10 @@
 
 		if(id)
 			to_chat(usr, "<span class='notify'>There is already an ID in the console!</span>")
+			return 1
+
+		if(!allowed(usr))
+			to_chat(usr, "<span class='warning'>The machine rejects your access credentials.</span>")
 			return 1
 
 		var/obj/item/weapon/card/id/I = usr.get_active_hand()

--- a/nano/templates/comm_console.tmpl
+++ b/nano/templates/comm_console.tmpl
@@ -65,7 +65,11 @@ Used In File(s): /code/game/machinery/computers/communications.dm
 				{{:helper.link('Message List','comment',{'operation':'messagelist'})}}
 			</div>
 			<div class="line">
-				{{:helper.link('Toggle Port Status','key',{'operation':'SetPortRestriction'})}}
+				{{if data.portopen}}
+					{{:helper.link('Close Trader Port','key',{'operation':'SetPortRestriction'},null,'redBackground')}}
+				{{else}}
+					{{:helper.link('Open Trader Port','key',{'operation':'SetPortRestriction'},null,'linkOn')}}
+				{{/if}}
 			</div>
 			{{if data.str_security_level == "red" || data.str_security_level == "delta"}}
 				<div class="line">


### PR DESCRIPTION
I've actually had this mostly done for a while but I finished it now because I'm having laptop troubles and worried I could lose the code if I don't push it. I do so reluctantly because I think any trader PR is a battle to discuss due to certain metaclubs and I wanted to wait until the end of my FFF goal, but here we are. This is a substantial change to how traders operate.

**Wallets**

Standardized starting money to 150-250 credits and removed free coin. (Important, see alt title info). Previously wallets could have any of these values exactly and no other: 1, 2, 10, 11, 20, 100, 101, 110, 200, 1000, 1001, 1010, 1100, 2000. Total extremes. Now they can have any amount of money in the range of 150 to 250. On average this is probably a slight nerf but it's consistency.

**Alt Titles/Antagonism**

* Traders of any kind will never be starting revheads or revsquad heads. This seems obvious as they are not crew.
* Vagabond and Traveler alt titles removed. They seem to be the go-to shitbird titles and I think in general they encourage an image of raiding for loot.
* Trader is closest to legacy trader. Starts with the thermos, box of donk pockets, and trader coin.
* Merchant gives up the opportunity to start with a coin (important, see vendor changes) but instead gets a loyalty implant and can **never** start as a traitor, double agent, vampire, changeling, or cultist. The reasoning being to get the specially approved merchant status, you need to pass a difficult background check. Additionally, a fax with their information will be sent to the station immediately when they join. The idea is to give up some comforts in exchange for credibility. Note they could *become* an antagonist through autotator, thralling, deimplanting+rev/cult, etc.
![untitled](https://user-images.githubusercontent.com/9782036/45190723-1283ac80-b205-11e8-9bf0-ff9dfeb36746.png)



**Vendor Changes**
* Items are no longer removed from the vendor at roundstart by RNG
* Increased random borg modules from 1 to 3 (no repeats)
* Other than borg modules, everything costs money - hence, the only thing to use coins for are borg items
* The machine is unhackable (but not unemaggable) meaning you can not use it without a trader ID and you can not abuse the throw wire.
* I'm open to adjusting costs but I put them all over the map, and more trader items are on the way soon(TM). Some like the AMS and WW are rightfully expensive whereas niche toys like the Sea Devil are cheap.

_The hope in all of this is to give traders more incentive to trade and to behave. They can choose to signal they are 'NT supportive' by being Merchants or remain shady dealers as Traders. Similarly, now they have reason to acquire more money: to buy more products to sell. Tradeoffs include some lost start items, no longer a chance to start with 1k or even 2k credits, and ideally a curbing of bad behaviors through title reworks._

🆑 
* tweak: Traders have been overhauled. Merchants are now more officially recognized, but Traders get some small perks for remaining free agents. Vagabonds and travelers have been shooed off.
* tweak: Trader items now cost credits and are not randomized.
* tweak: The trader vendor can no longer be hacked.
* tweak: Merchants now spawn with NT loyalty implants and are barred from many antagonist roles. IAAs should keep their eyes on the fax machine for official documentation with photo ID and fingerprint any time a Merchant enters the sector.
* tweak: Mining access is required to claim money from the smelter (but not operate it)