### PR TITLE
Additional sanity checks for ventcrawling

### DIFF
--- a/code/_onclick/ventcrawl.dm
+++ b/code/_onclick/ventcrawl.dm
@@ -181,6 +181,18 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 							if(!ventcrawl_carry())
 								return
 
+							if(stat)
+								to_chat(src, "<span class='danger'>You must be conscious to do this!</span>")
+								return
+
+							if(locked_to)
+								to_chat(src, "<span class='warning'>You can't vent crawl while you're restrained!</span>")
+								return
+
+							if(lying)
+								to_chat(src, "<span class='warning'>You can't vent crawl while you're stunned!</span>")
+								return
+
 							visible_message("<B>[src] scrambles into the ventilation ducts!</B>", "You climb into the ventilation system.")
 
 							forceMove(vent_found)


### PR DESCRIPTION

<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl:
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
https://github.com/vgstation-coders/vgstation13/pull/15723 didn't finish the job and forgot to do checks again once the wait timer was up, allowing you to buckle between the initial click and the ventcrawl beginning.

Fixes(again) https://github.com/vgstation-coders/vgstation13/issues/14015 https://github.com/vgstation-coders/vgstation13/issues/15229 etc

:cl:
 * bugfix: Ventcrawling when you are buckled, stunned and such now fails rather than trapping you forever.
