### PR TITLE
Removes reversible bug handling + message because it doesn't describe a bug

### DIFF
--- a/code/datums/helper_datums/construction_datum.dm
+++ b/code/datums/helper_datums/construction_datum.dm
@@ -375,10 +375,6 @@
 	else
 		var/list/spawn_step
 		var/new_index = (diff == FORWARD ? index - 1 : index + 1)
-		if(new_index == 0)
-			spawn_result(user)
-			return 1
-			//CRASH("Holy shit [src]/([src.type]) is trying to set its new index to 0! how the fuck did this happen? I don't know, our direction is [diff==FORWARD?"forward":"backward"] old index was [index]. User is [user], itemused [used_atom], step [given_step]")
 		if(diff == FORWARD)
 			spawn_step = get_backward_step(new_index)
 		else if(diff == BACKWARD)

--- a/code/datums/helper_datums/construction_datum.dm
+++ b/code/datums/helper_datums/construction_datum.dm
@@ -376,7 +376,6 @@
 		var/list/spawn_step
 		var/new_index = (diff == FORWARD ? index - 1 : index + 1)
 		if(new_index == 0)
-			message_admins("Holy shit [src]/([src.type]) is trying to set its new index to 0! how the fuck did this happen? I don't know, our direction is [diff==FORWARD?"forward":"backward"] old index was [index]. User is [formatPlayerPanel(user,user.ckey)], itemused [used_atom], step [given_step]")
 			spawn_result(user)
 			return 1
 			//CRASH("Holy shit [src]/([src.type]) is trying to set its new index to 0! how the fuck did this happen? I don't know, our direction is [diff==FORWARD?"forward":"backward"] old index was [index]. User is [user], itemused [used_atom], step [given_step]")


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5942183/45221109-bd9d7000-b2b0-11e8-97bc-38fddb5ba760.png)
^ It's literally not a bug
Far as I can remember from the last time I looked this over and what I could skim just before, it happens because:
- check_step() keeps setting diff = -1 during forward construction (backward is deconstruction) through is_right_key()
- update_index() keeps setting index += diff which means index keeps decrementing by 1 until it reaches 1 (the final step)
- try_consume() sees index is 1 and gives the error because it then sets `new_index = (diff == FORWARD ? index - 1 : index + 1)` which means `1 - 1`

I don't think this would ever be a bug. You can also see in update_index() that `if(index==0) spawn_result(user)`
See [construction_datum.dm](https://github.com/vgstation-coders/vgstation13/blob/7d3124ce91f6fc3bacadfcbcbacb057f30d638b4/code/datums/helper_datums/construction_datum.dm) for the procs called and [cell_charger.dm](https://github.com/vgstation-coders/vgstation13/blob/d9e848094b6925abf2f76e05e25d483a69edf908/code/game/machinery/cell_charger.dm) for the crank charger construction steps list

I ended up removing the entire statement because it still spawns the result properly through spawn_result() and it just seemed to be a failsafe that did nothing
Construction of crank charger and holomap with it removed:
![image](https://user-images.githubusercontent.com/5942183/45222002-83819d80-b2b3-11e8-86b5-d31a09040a87.png)
And pod:
![image](https://user-images.githubusercontent.com/5942183/45222025-9005f600-b2b3-11e8-83d2-66e8f13f659c.png)

<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl:
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
