### PR TITLE
Chemistry Runtime Hunting (FFF26)

### DIFF
--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -539,6 +539,8 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 /datum/reagents/proc/add_reagent(var/reagent, var/amount, var/list/data=null, var/reagtemp = T0C+20)
 	if(!my_atom)
 		return 0
+	if(!amount)
+		return 0
 	if(!isnum(amount))
 		return 1
 	update_total()

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -3533,7 +3533,8 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/deepfryholder/New()
 	..()
-	reagents.add_reagent(NUTRIMENT,deepFriedNutriment)
+	if(deepFriedNutriment)
+		reagents.add_reagent(NUTRIMENT,deepFriedNutriment)
 
 ///////////////////////////////////////////
 // new old food stuff from bs12


### PR DESCRIPTION
Deepfriedholder will no longer try to add 0 nutriment to stuff

add_reagent will just abort if you're adding exactly 0 of anything

fixes #19493