### PR TITLE
Fixes cyborgs getting stuck in limbo, part 2

### DIFF
--- a/code/modules/mob/living/silicon/robot/death.dm
+++ b/code/modules/mob/living/silicon/robot/death.dm
@@ -66,3 +66,18 @@
 	sql_report_cyborg_death(src)
 
 	return ..(gibbed)
+
+
+//If there's an MMI in the robot, have it ejected when the mob goes away. --NEO
+/mob/living/silicon/robot/Destroy()
+	if(mmi && mind)//Safety for when a cyborg gets dust()ed. Or there is no MMI inside.
+		var/turf/T = get_turf(loc)//To hopefully prevent run time errors.
+		if(T)
+			mmi.forceMove(T)
+		if(mmi.brainmob)
+			mind.transfer_to(mmi.brainmob)
+			mmi.brainmob.locked_to_z = locked_to_z
+		else
+			ghostize() //Somehow their MMI has no brainmob or something even worse happened. Let's just save their soul from this hell.
+		mmi = null
+	..()

--- a/code/modules/mob/living/silicon/robot/death.dm
+++ b/code/modules/mob/living/silicon/robot/death.dm
@@ -69,12 +69,13 @@
 
 //If there's an MMI in the robot, have it ejected when the mob goes away. --NEO
 /mob/living/silicon/robot/Destroy()
-	if(mmi && mind)//Safety for when a cyborg gets dust()ed. Or there is no MMI inside.
+	if(mmi)//Safety for when a cyborg gets dust()ed. Or there is no MMI inside.
 		var/turf/T = get_turf(loc)//To hopefully prevent run time errors.
 		if(T)
 			mmi.forceMove(T)
 		if(mmi.brainmob)
-			mind.transfer_to(mmi.brainmob)
+			if(mind)
+				mind.transfer_to(mmi.brainmob)
 			mmi.brainmob.locked_to_z = locked_to_z
 		else
 			ghostize() //Somehow their MMI has no brainmob or something even worse happened. Let's just save their soul from this hell.

--- a/code/modules/mob/living/silicon/robot/death.dm
+++ b/code/modules/mob/living/silicon/robot/death.dm
@@ -67,7 +67,6 @@
 
 	return ..(gibbed)
 
-
 //If there's an MMI in the robot, have it ejected when the mob goes away. --NEO
 /mob/living/silicon/robot/Destroy()
 	if(mmi && mind)//Safety for when a cyborg gets dust()ed. Or there is no MMI inside.

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -185,20 +185,6 @@
 				C.wrapped = I
 				C.vulnerability = I.vulnerability
 
-//If there's an MMI in the robot, have it ejected when the mob goes away. --NEO
-//Improved /N
-/mob/living/silicon/robot/Destroy()
-	if(mmi)//Safety for when a cyborg gets dust()ed. Or there is no MMI inside.
-		var/turf/T = get_turf(loc)//To hopefully prevent run time errors.
-		if(T)
-			mmi.forceMove(T)
-		if(mind)
-			mind.transfer_to(mmi.brainmob)
-		if(mmi.brainmob)
-			mmi.brainmob.locked_to_z = locked_to_z
-		mmi = null
-	..()
-
 /mob/living/silicon/robot/remove_screen_objs()
 	..()
 	if(cells)


### PR DESCRIPTION
```
[08:52:45] Runtime in mind.dm,92: Cannot read null.mind
  proc name: transfer to (/datum/mind/proc/transfer_to)
  src: Test Dummy (/datum/mind)
  call stack:
  Test Dummy (/datum/mind): transfer to(null)
  Medical Cyborg-282 (/mob/living/silicon/robot): Destroy()
  qdel(Medical Cyborg-282 (/mob/living/silicon/robot), 0, 0)
  Medical Cyborg-282 (/mob/living/silicon/robot): gib()
  Medical Cyborg-282 (/mob/living/silicon/robot): singularity act(1, the gravitational singularity (/obj/machinery/singularity))
  the gravitational singularity (/obj/machinery/singularity): consume(Medical Cyborg-282 (/mob/living/silicon/robot))
  the gravitational singularity (/obj/machinery/singularity): Crossed(Medical Cyborg-282 (/mob/living/silicon/robot))
  Medical Cyborg-282 (/mob/living/silicon/robot): Move(space (128,64,2) (/turf/space), 4, 0, 0, 0)
  Medical Cyborg-282 (/mob/living/silicon/robot): Move(space (128,64,2) (/turf/space), 4, 0, 0, 0)
  Medical Cyborg-282 (/mob/living/silicon/robot): Move(space (128,64,2) (/turf/space), 4, 0, 0, 0)
  Medical Cyborg-282 (/mob/living/silicon/robot): Move(space (128,64,2) (/turf/space), 4, 0, 0, 0)
  Medical Cyborg-282 (/mob/living/silicon/robot): singularity pull(the gravitational singularity (/obj/machinery/singularity), 1)
  the gravitational singularity (/obj/machinery/singularity): eat()
  the gravitational singularity (/obj/machinery/singularity): process()
  Power (/datum/subsystem/power): fire(0)
  Power (/datum/subsystem/power): ignite(0)
  Master (/datum/controller/master): RunQueue()
  Master (/datum/controller/master): Loop()
  Master (/datum/controller/master): StartProcessing()
```

Closes #18334

:cl:
 * bugfix: Cyborgs/MoMMIs with won't get stuck in limbo(after getting eaten by a singularity) anymore.

