### PR TITLE
Fixes compile for 1447+

### DIFF
--- a/code/datums/statistics/stat_helpers.dm
+++ b/code/datums/statistics/stat_helpers.dm
@@ -115,16 +115,16 @@
 		BAD.purchaser_is_traitor = was_traitor
 		badass_bundles.Add(BAD)
 	else
-		var/datum/stat/uplink_purchase_stat/UP = new
+		var/datum/stat/uplink_purchase_stat/PUR = new
 		if(istype(bundle, /datum/uplink_item/badass/random))
-			UP.itemtype = resulting_item.type
+			PUR.itemtype = resulting_item.type
 		else
-			UP.itemtype = bundle.item
-		UP.bundle = bundle.type
-		UP.purchaser_key = ckey(user.mind.key)
-		UP.purchaser_name = STRIP_NEWLINE(user.mind.name)
-		UP.purchaser_is_traitor = was_traitor
-		uplink_purchases.Add(UP)
+			PUR.itemtype = bundle.item
+		PUR.bundle = bundle.type
+		PUR.purchaser_key = ckey(user.mind.key)
+		PUR.purchaser_name = STRIP_NEWLINE(user.mind.name)
+		PUR.purchaser_is_traitor = was_traitor
+		uplink_purchases.Add(PUR)
 
 /datum/stat_collector/proc/add_objectives(var/datum/mind/M)
 	if(M.objectives.len)

--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -170,7 +170,7 @@ var/global/list/blood_list = list()
 /obj/effect/decal/cleanable/mucus
 	name = "mucus"
 	desc = "Disgusting mucus."
-	setGender(PLURAL)
+	gender = PLURAL
 	density = 0
 	anchored = 1
 	icon = 'icons/effects/blood.dmi'

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -4,7 +4,7 @@
 /obj/item/weapon/handcuffs
 	name = "handcuffs"
 	desc = "Use this to keep prisoners in line."
-	setGender(PLURAL)
+	gender = PLURAL
 	icon = 'icons/obj/items.dmi'
 	icon_state = "handcuff"
 	flags = FPRINT

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -195,7 +195,7 @@
 	icon_broken = "medical_wall_spark"
 	icon_off = "medical_wall_off"
 	anchored = 1
-	setDensity(FALSE)
+	density = FALSE
 	wall_mounted = 1
 	req_access = list(access_medical)
 

--- a/code/game/objects/structures/lamarr_cage.dm
+++ b/code/game/objects/structures/lamarr_cage.dm
@@ -93,7 +93,7 @@
 	name = "Lamarr"
 	desc = "The worst she might do is attempt to... couple with your head."//hope we don't get sued over a harmless reference, rite?
 	sterile = 1
-	setGender(FEMALE)
+	gender = FEMALE
 
 /obj/item/clothing/mask/facehugger/lamarr/New()
 	..()


### PR DESCRIPTION
1. 1447 changed the internal constants from consts to defines. This caused variables sharing their names to fuck up. Luckily, we only had one.
2. Someone fucked up when regexing `gender = thing` to `setGender(thing)`, and the same for `density`, and changed the instances inside type definitions as well. Before 1447, this was interpreted as overriding those procs with empty ones with one arg. Starting with 1447, since defines don't obey scope rules, these lines of code were no longer valid. So also this probably fixes bugs with mucus, handcuffs, medical crates, and Lamarr.