### PR TITLE
Paper Formatting

### DIFF
--- a/code/WorkInProgress/kilakk/fax.dm
+++ b/code/WorkInProgress/kilakk/fax.dm
@@ -129,7 +129,7 @@ var/list/alldepartments = list("Central Command")
 							new /obj/item/mounted/poster(src.loc,-1)
 
 			else
-				SendFax(tofax.info, tofax.name, usr, dpt)
+				SendFax(tofax.info, tofax.name, usr, dpt, 0, tofax.display_x, tofax.display_y)
 			log_game("([usr]/([usr.ckey]) sent a fax titled [tofax] to [dpt] - contents: [tofax.info]")
 			to_chat(usr, "Message transmitted successfully.")
 			faxtime = world.timeofday + cooldown_time
@@ -212,7 +212,7 @@ var/list/alldepartments = list("Central Command")
 			to_chat(C, msg)
 		C << 'sound/effects/fax.ogg'
 
-proc/SendFax(var/sent, var/sentname, var/mob/Sender, var/dpt, var/centcomm)
+proc/SendFax(var/sent, var/sentname, var/mob/Sender, var/dpt, var/centcomm, var/xdim, var/ydim)
 
 	var/faxed = null
 	for(var/obj/machinery/faxmachine/F in allfaxes)
@@ -229,6 +229,10 @@ proc/SendFax(var/sent, var/sentname, var/mob/Sender, var/dpt, var/centcomm)
 				else//probably a
 					P.name = "[sentname]"
 				P.info = "[sent]"
+				if(xdim)
+					P.display_x = xdim
+				if(ydim)
+					P.display_y = ydim
 				P.update_icon()
 
 				playsound(F.loc, "sound/effects/fax.ogg", 50, 1)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -26,6 +26,8 @@
 	var/list/stamped
 	var/rigged = 0
 	var/spam_flag = 0
+	var/display_x = 400
+	var/display_y = 400
 
 	var/log=""
 	var/obj/item/weapon/photo/img
@@ -54,7 +56,7 @@
 	if(img)
 		user << browse_rsc(img.img, "tmp_photo.png")
 		info_image = "<img src='tmp_photo.png' width='192' style='-ms-interpolation-mode:nearest-neighbor' /><br><a href='?src=\ref[src];picture=1'>Remove</a><br>"
-	user << browse("<HTML><HEAD><TITLE>[name]</TITLE></HEAD><BODY[color ? " bgcolor=[src.color]":""]>[info_image][info_text][stamps]</BODY></HTML>", "window=[name]")
+	user << browse("<HTML><HEAD><TITLE>[name]</TITLE></HEAD><BODY[color ? " bgcolor=[src.color]":""]>[info_image][info_text][stamps]</BODY></HTML>", "window=[name];size=[display_x]x[display_y]")
 	onclose(user, "[name]")
 
 /obj/item/weapon/paper/update_icon()

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -72,6 +72,8 @@
 					c.info += "</font>"
 					c.name = copy.name
 					c.fields = copy.fields
+					c.display_x = copy.display_x
+					c.display_y = copy.display_y
 					c.updateinfolinks()
 					toner--
 					sleep(15)
@@ -167,7 +169,9 @@
 			dat += "Printing: [copies] copies."
 			dat += "<a href='byond://?src=\ref[src];min=1'>-</a> "
 			dat += "<a href='byond://?src=\ref[src];add=1'>+</a><BR><BR>"
-			if(photocopy)
+			if(copy)
+				dat += "<a href='byond://?src=\ref[src];windowsize=1'>Format Paper</a><BR>"
+			else if(photocopy)
 				dat += "Printing in <a href='byond://?src=\ref[src];colortoggle=1'>[greytoggle]</a><BR><BR>"
 	else if(toner)
 		dat += "Please insert paper to copy.<BR><BR>"
@@ -269,6 +273,21 @@
 			greytoggle = "Color"
 		else
 			greytoggle = "Greyscale"
+		updateUsrDialog()
+	else if(href_list["windowsize"])
+		if(!copy)
+			return
+		var/xdim = input(usr, "Default paper width", "Formatting", 400) as num|null
+		if(!xdim)
+			return
+		xdim = Clamp(xdim,100,800)
+		var/ydim = input(usr, "Default paper height", "Formatting", 400) as num|null
+		if(!ydim)
+			return
+		ydim = Clamp(ydim,100,900)
+		copy.display_x = xdim
+		copy.display_y = ydim
+		to_chat(usr, "<span class='notice'>The machine hums a moment as it configures your document.</span>")
 		updateUsrDialog()
 
 /obj/machinery/photocopier/attackby(obj/item/O, mob/user)


### PR DESCRIPTION
I added this because I wanted to be able to format the size of the fax for Merchants.

🆑 
* rscadd: You can now use a photocopier to set the default view window dimensions of any paper (100x100 to 800x900, default 400x400)
* rscadd: These dimensions are preserved across copies and faxes