### PR TITLE
Fixes vampires not burning in the chapel (as well as other things.)

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic.dm
+++ b/code/datums/gamemode/dynamic/dynamic.dm
@@ -115,7 +115,7 @@ var/list/forced_roundstart_ruleset = list()
 						drafted_rules -= rule//and removing rules from those that are no longer elligible
 			return 1
 		else
-			message_admins("....except not because whoever coded that ruleset forgot some cases in ready() apparently! execute() returned 0.")
+			message_admins("....except not because whomever coded that ruleset forgot some cases in ready() apparently! execute() returned 0.")
 	return 0
 
 /datum/gamemode/dynamic/proc/picking_latejoin_rule(var/list/drafted_rules = list())
@@ -172,6 +172,7 @@ var/list/forced_roundstart_ruleset = list()
 	return 0
 
 /datum/gamemode/dynamic/process()
+	. = ..() // Making the factions & roles process.
 	if (latejoin_injection_cooldown)
 		latejoin_injection_cooldown--
 

--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -306,12 +306,11 @@
 	var/smitetemp = 0
 	var/vampcoat = istype(H.wear_suit, /obj/item/clothing/suit/storage/draculacoat) //coat reduces smiting
 	if(check_holy(H)) //if you're on a holy tile get ready for pain
-		to_chat(world, "Ouch, it's holy")
 		smitetemp += (vampcoat ? 1 : 5)
 		if(prob(35))
 			to_chat(H, "<span class='danger'>This ground is blessed. Get away, or splatter it with blood to make it safe for you.</span>")
 
-	if(!(VAMP_MATURE in powers) && (istype(get_area(H), /area/chapel)) //stay out of the chapel unless you want to turn into a pile of ashes
+	if(!(VAMP_MATURE in powers) && (istype(get_area(H), /area/chapel))) //stay out of the chapel unless you want to turn into a pile of ashes
 		nullified = max(5, nullified + 2)
 		if(prob(35))
 			to_chat(H, "<span class='sinister'>You feel yourself growing weaker.</span>")

--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -306,11 +306,12 @@
 	var/smitetemp = 0
 	var/vampcoat = istype(H.wear_suit, /obj/item/clothing/suit/storage/draculacoat) //coat reduces smiting
 	if(check_holy(H)) //if you're on a holy tile get ready for pain
+		to_chat(world, "Ouch, it's holy")
 		smitetemp += (vampcoat ? 1 : 5)
 		if(prob(35))
 			to_chat(H, "<span class='danger'>This ground is blessed. Get away, or splatter it with blood to make it safe for you.</span>")
 
-	if(!(VAMP_MATURE in powers) && get_area(H) == /area/chapel) //stay out of the chapel unless you want to turn into a pile of ashes
+	if(!(VAMP_MATURE in powers) && (istype(get_area(H), /area/chapel)) //stay out of the chapel unless you want to turn into a pile of ashes
 		nullified = max(5, nullified + 2)
 		if(prob(35))
 			to_chat(H, "<span class='sinister'>You feel yourself growing weaker.</span>")
@@ -383,7 +384,6 @@
 -- Helpers --
 */
 
-// ! - need to handle thrall removing
 /datum/role/vampire/proc/update_vamp_hud()
 	var/mob/M = antag.current
 	if(M.hud_used)


### PR DESCRIPTION
Two things

1) Restore original chapel burning (the dynmaical gamemode `process` proc didn't call the parent)
2) Fixes a years-old bug about the vampire not being _nullified_ in the chapel ; that means, still being able to use spells in it.

The check was checking against a type, while `get_area` returns an actual area.

closes #19644 