### PR TITLE
[Role Datums] Tweaks, Bugfixes and other stuff

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
@@ -55,7 +55,7 @@
 		message_admins("Cannot accept Wizard ruleset. Couldn't find any wizard spawn points.")
 		return 0
 	if (locate(/datum/dynamic_ruleset/roundstart/wizard) in mode.executed_rules)
-		weight = initial(weight) * 2//double chance to happen when there was a roundstart wizard
+		weight = initial(weight) * 5
 
 	return ..()
 

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -184,7 +184,5 @@
 		var/datum/role/nuclear_operative/newCop = new
 		newCop.AssignToRole(new_character.mind,1)
 		nuclear.HandleRecruitedRole(newCop)
-		newCop.OnPostSetup()
 		newCop.Greet(GREET_MIDROUND)
-		newCop.ForgeObjectives()
-		newCop.AnnounceObjectives()
+	nuclear.OnPostSetup()

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -198,7 +198,7 @@
 		var/mob/M = pick(candidates)
 		assigned += M
 		candidates -= M
-		var/datum/role/legacy_cultist/newCop = new
+		var/datum/role/nuclear_operative/newCop = new
 		newCop.AssignToRole(M.mind,1)
 		nuclear.HandleRecruitedRole(newCop)
 		newCop.Greet(GREET_ROUNDSTART)

--- a/code/datums/gamemode/factions/faction.dm
+++ b/code/datums/gamemode/factions/faction.dm
@@ -334,6 +334,11 @@ var/list/factions_with_hud_icons = list()
 		return 0 //Critical failure.
 	..()
 
+/datum/faction/wizard/forgeObjectives()
+	for(var/datum/role/R in members)
+		R.ForgeObjectives()
+		R.AnnounceObjectives()
+
 /datum/faction/wizard/ragin
 	accept_latejoiners = TRUE
 	var/max_wizards

--- a/code/datums/gamemode/factions/syndicate/nukeops.dm
+++ b/code/datums/gamemode/factions/syndicate/nukeops.dm
@@ -13,6 +13,8 @@
 
 /datum/faction/syndicate/nuke_op/forgeObjectives()
 	AppendObjective(/datum/objective/nuclear)
+	for(var/datum/role/nuclear_operative/N in members)
+		N.AnnounceObjectives()
 
 /datum/faction/syndicate/nuke_op/AdminPanelEntry()
 	var/list/dat = ..()

--- a/code/datums/gamemode/gamemode.dm
+++ b/code/datums/gamemode/gamemode.dm
@@ -193,7 +193,7 @@
 		F.OnPostSetup()
 	for(var/datum/role/R in orphaned_roles)
 		R.ForgeObjectives()
-		R.MemorizeObjectives()
+		R.AnnounceObjectives()
 		R.OnPostSetup()
 	return 1
 

--- a/code/datums/gamemode/role/legacy_cultist.dm
+++ b/code/datums/gamemode/role/legacy_cultist.dm
@@ -65,9 +65,6 @@
 	stat_collection.cult_deconverted++
 	. = ..()
 
-/datum/role/legacy_cultist/MemorizeObjectives()
-	AnnounceObjectives()
-
 /datum/role/legacy_cultist/AnnounceObjectives()
 	if (!istype(faction, /datum/faction/cult/narsie))
 		WARNING("Wrong faction type for [src.antag.current], faction is [faction.type]")
@@ -76,5 +73,4 @@
 	to_chat(antag.current, "<span class = 'warning'>Our new objective is:</span>")
 	to_chat(antag.current, "Objective #[faction.objective_holder.objectives.len]: <span class='danger'>[our_cult.current_objective.name]</span>")
 	to_chat(antag.current, "<span class='warning'>[our_cult.current_objective.explanation_text]</span><br/>")
-	antag.memory += "Objective #[faction.objective_holder.objectives.len]: <span class='danger'>[our_cult.current_objective.name]</span>"
-	antag.memory += "<span class='warning'>[our_cult.current_objective.explanation_text]</span><br/>"
+

--- a/code/datums/gamemode/role/role.dm
+++ b/code/datums/gamemode/role/role.dm
@@ -258,9 +258,6 @@
 		else
 			to_chat(antag.current, "<img src='data:image/png;base64,[icon2base64(logo)]' style='position: relative; top: 10;'/> <B>You are \a [name][faction ? ", a member of the [faction.GetObjectivesMenuHeader()]":"."]</B>")
 
-/datum/role/proc/AnnounceObjectives()
-	to_chat(antag.current, "[ReturnObjectivesString(check_name = FALSE)]")
-
 /datum/role/proc/PreMindTransfer(var/datum/mind/M)
 	return
 
@@ -329,14 +326,19 @@
 			text += "<a href='?src=\ref[M];role_edit=\ref[src];add_to_faction=1'>(add)</a>"
 	text += "<br>"
 	if (objectives.objectives.len)
-		text += "<b>personnal objectives</b><br>"
+		text += "<b>personnal objectives</b><ul>"
 	text += objectives.GetObjectiveString(0,admin_edit,M, src)
-	text += "<br>"
+	if (objectives.objectives.len)
+		text += "</ul>"
 	if (faction && faction.objective_holder)
 		if (faction.objective_holder.objectives.len)
-			text += "<b>faction objectives</b><br>"
+			if (objectives.objectives.len)
+				text += "<br>"
+			text += "<b>faction objectives</b><ul>"
 		text += faction.objective_holder.GetObjectiveString(0,admin_edit,M)
-	text += "<br><br>"
+		if (faction.objective_holder.objectives.len)
+			text += "</ul>"
+	text += "<br>"
 	return text
 /*
 /datum/role_controls
@@ -406,14 +408,24 @@
 		return
 
 
-/datum/role/proc/MemorizeObjectives()
-	var/text="<b>[name] objectives:</b><ul>"
-	var/list/current_objectives = objectives.GetObjectives()
-	for(var/obj_count = 1 to current_objectives.len)
-		var/datum/objective/O = current_objectives[obj_count]
-		text +=  "<B>Objective #[obj_count]</B>: [O.explanation_text] <br/>"
+/datum/role/proc/AnnounceObjectives()
+	var/text = ""
+	if (objectives.objectives.len)
+		text += "<b>[name] objectives:</b><ul>"
+		var/obj_count = 1
+		for(var/datum/objective/O in objectives.objectives)
+			text += "<b>Objective #[obj_count++]</b>: [O.explanation_text]<br>"
+		text += "</ul>"
+	if (faction && faction.objective_holder)
+		if (faction.objective_holder.objectives.len)
+			if (objectives.objectives.len)
+				text += "<br>"
+			text += "<b>faction objectives:</b><ul>"
+			var/obj_count = 1
+			for(var/datum/objective/O in objectives.objectives)
+				text += "<b>Objective #[obj_count++]</b>: [O.explanation_text]<br>"
+			text += "</ul>"
 	to_chat(antag.current, text)
-	antag.memory += "[text]<BR>"
 
 /datum/role/proc/GetMemoryHeader()
 	return name

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -93,7 +93,8 @@
 		new_character.key = key		//now transfer the key to link the client to our new body
 
 /datum/mind/proc/store_memory(new_text)
-	memory += "[new_text]<BR>"
+	if(new_text)
+		memory += "[new_text]<BR>"
 
 
 /datum/mind/proc/hasFactionsWithHUDIcons()

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -334,6 +334,8 @@
 	for(var/role in character.mind.antag_roles)
 		var/datum/role/R = character.mind.antag_roles[role]
 		R.OnPostSetup()
+		R.ForgeObjectives()
+		R.AnnounceObjectives()
 
 	var/datum/job/J = job_master.GetJob(rank)
 	if (character.loc != T)//uh oh, we're spawning as an off-station antag, better not be announced, show up on the manifest, or take up a job slot


### PR DESCRIPTION
* Roundstart Wizards and latejoin/midround antags now properly spawn with objectives
* Fixed the Notes panel having screwed up formatting, such as some objectives being displayed twice.
* Added a midround Nuke Ops ruleset, can only trigger nuke ops weren't drafted at roundstart.