### PR TITLE
Can now set radio filter on buttons

### DIFF
--- a/code/game/machinery/airlock_control.dm
+++ b/code/game/machinery/airlock_control.dm
@@ -390,7 +390,11 @@ obj/machinery/access_button/Topic(href,href_list)
 	var/obj/item/device/multitool/P = get_multitool(usr)
 	if(P)
 		if("set_filter" in href_list)
-			var/newfilter = input(usr, "Select radio filter.", "Radio Filter", customfilter) as null|anything in radiofilters
+			var/explanation = {"Set the radio filter.
+3 is for signalers
+4 is for airlocks (default)
+6 is for machinery (emitters, etc)"}
+			var/newfilter = input(usr, explanation, "Radio Filter", customfilter) as null|anything in radiofilters
 			if (newfilter)
 				customfilter = newfilter
 			

--- a/code/game/machinery/airlock_control.dm
+++ b/code/game/machinery/airlock_control.dm
@@ -1,8 +1,8 @@
 #define AIRLOCK_CONTROL_RANGE 8
 #define RADIO_FILTER_EXPLANATION {"Set the radio filter.
 3 is for signalers
-4 is for airlocks (default)
-6 is for machinery (emitters, etc)"}
+4 is for machinery (emitters, etc)
+6 is for airlocks (default)"}
 
 
 // This code allows for airlocks to be controlled externally by setting an id_tag and comm frequency (disables ID access)

--- a/code/game/machinery/airlock_control.dm
+++ b/code/game/machinery/airlock_control.dm
@@ -1,5 +1,7 @@
 #define AIRLOCK_CONTROL_RANGE 8
 
+
+
 // This code allows for airlocks to be controlled externally by setting an id_tag and comm frequency (disables ID access)
 /obj/machinery/door/airlock
 	var/id_tag
@@ -268,13 +270,18 @@ obj/machinery/access_button
 	icon = 'icons/obj/airlock_machines.dmi'
 	icon_state = "access_button_standby"
 	name = "access button"
-
 	anchored = 1
 	power_channel = ENVIRON
 
 	var/master_tag
 	var/frequency = 1449
 	var/command = "cycle"
+	var/customfilter = RADIO_AIRLOCK
+	var/radiofilters = list(
+							RADIO_CHAT,
+							RADIO_ATMOSIA,
+							RADIO_AIRLOCK
+							)
 
 	var/datum/radio_frequency/radio_connection
 
@@ -321,7 +328,7 @@ obj/machinery/access_button/attack_hand(mob/user)
 		signal.data["tag"] = master_tag
 		signal.data["command"] = command
 
-		radio_connection.post_signal(src, signal, range = AIRLOCK_CONTROL_RANGE, filter = RADIO_AIRLOCK)
+		radio_connection.post_signal(src, signal, range = AIRLOCK_CONTROL_RANGE, filter = customfilter)
 	flick("access_button_cycle", src)
 
 
@@ -339,7 +346,7 @@ obj/machinery/access_button/attackby(var/obj/item/W, var/mob/user)
 obj/machinery/access_button/proc/set_frequency(new_frequency)
 	radio_controller.remove_object(src, frequency)
 	frequency = new_frequency
-	radio_connection = radio_controller.add_object(src, frequency, RADIO_AIRLOCK)
+	radio_connection = radio_controller.add_object(src, frequency, customfilter)
 
 
 obj/machinery/access_button/initialize()
@@ -366,8 +373,9 @@ obj/machinery/access_button/multitool_menu(var/mob/user,var/obj/item/device/mult
 	return {"
 		<ul>
 			<li><b>Frequency:</b> <a href="?src=\ref[src];set_freq=-1">[format_frequency(frequency)] GHz</a> (<a href="?src=\ref[src];set_freq=[0]">Reset</a>)</li>
-			[format_tag("Master ID Tag","master_tag")]
-			[format_tag("Command","command")]
+			<li>[format_tag("Master ID Tag","master_tag")]</li>
+			<li>[format_tag("Command","command")]</li>
+			<li><b>Filter:</b> <a href="?src=\ref[src];set_filter=-1">[customfilter]</a></li>
 		</ul>"}
 
 obj/machinery/access_button/Topic(href,href_list)
@@ -381,6 +389,11 @@ obj/machinery/access_button/Topic(href,href_list)
 
 	var/obj/item/device/multitool/P = get_multitool(usr)
 	if(P)
+		if("set_filter" in href_list)
+			var/newfilter = input(usr, "Select radio filter.", "Radio Filter", customfilter) as null|anything in radiofilters
+			if (newfilter)
+				customfilter = newfilter
+			
 		if("set_freq" in href_list)
 			var/newfreq=frequency
 			if(href_list["set_freq"]!="-1")

--- a/code/game/machinery/airlock_control.dm
+++ b/code/game/machinery/airlock_control.dm
@@ -1,5 +1,8 @@
 #define AIRLOCK_CONTROL_RANGE 8
-
+#define RADIO_FILTER_EXPLANATION {"Set the radio filter.
+3 is for signalers
+4 is for airlocks (default)
+6 is for machinery (emitters, etc)"}
 
 
 // This code allows for airlocks to be controlled externally by setting an id_tag and comm frequency (disables ID access)
@@ -390,12 +393,10 @@ obj/machinery/access_button/Topic(href,href_list)
 	var/obj/item/device/multitool/P = get_multitool(usr)
 	if(P)
 		if("set_filter" in href_list)
-			var/explanation = {"Set the radio filter.
-3 is for signalers
-4 is for airlocks (default)
-6 is for machinery (emitters, etc)"}
-			var/newfilter = input(usr, explanation, "Radio Filter", customfilter) as null|anything in radiofilters
+			var/newfilter = input(usr, RADIO_FILTER_EXPLANATION, "Radio Filter", customfilter) as null|anything in radiofilters
 			if (newfilter)
+				if(usr.incapacitated() || (!issilicon(usr) && !Adjacent(usr)))
+					return	
 				customfilter = newfilter
 			
 		if("set_freq" in href_list)
@@ -412,3 +413,5 @@ obj/machinery/access_button/Topic(href,href_list)
 					initialize()
 
 		update_multitool_menu(usr)
+		
+#undef RADIO_FILTER_EXPLANATION


### PR DESCRIPTION
Adds the ability to set the radio filter on access buttons, which lets the button interact with signalers(maybe?), airlocks (like they already did), and atmos/engineering equipment
![filters](https://user-images.githubusercontent.com/8468269/45600333-5774c380-b9fb-11e8-94ca-771cd59707bb.png)
https://streamable.com/f3l1m
closes #19684
tested

🆑 
 - rscadd: You can now set the radio filter on access buttons.