### PR TITLE
Fixes Nano going nuclear if provided with infinite values

### DIFF
--- a/code/modules/nano/JSON Writer.dm
+++ b/code/modules/nano/JSON Writer.dm
@@ -15,7 +15,11 @@ json_writer
 
 		write(val)
 			if(isnum(val))
-				return num2text(val, 100)
+				var/n = num2text(val, 100)
+				if(abs(val) == INFINITY || val != val) //JSON doesn't support the infinities or NaN, so save those as strings instead of numbers. (NaN != NaN, by the way.)
+					return write_string(n)
+				else
+					return n
 			else if(isnull(val))
 				return "null"
 			else if(istype(val, /list))


### PR DESCRIPTION
Honestly I should have just done this along with #19366 
If you provide Nano with an infinite or NaN value, it will look weird, but no longer crash the UI

(Currently, this is only relevant to a particular CentComm request and infinite-capacity SMESes, neither of which appears in-game under normal circumstances)

Tested for displaying the numbers explicitly, as well as in percentage form with a progress bar. Looks weird in all cases, crashes in none.