### PR TITLE
#warning -> #warn

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -1259,7 +1259,7 @@ var/default_colour_matrix = list(1,0,0,0,\
 
 //#define SAY_DEBUG 1
 #ifdef SAY_DEBUG
-	#warning SOME ASSHOLE FORGOT TO COMMENT SAY_DEBUG BEFORE COMMITTING
+	#warn SOME ASSHOLE FORGOT TO COMMENT SAY_DEBUG BEFORE COMMITTING
 	#define say_testing(a,x) to_chat(a, ("([__FILE__]:[__LINE__] say_testing) [x]"))
 #else
 	#define say_testing(a,x)
@@ -1269,7 +1269,7 @@ var/default_colour_matrix = list(1,0,0,0,\
 //#define JUSTFUCKMYSHITUP 1
 #ifdef JUSTFUCKMYSHITUP
 #define writepanic(a) if(ticker && ticker.current_state >= 3 && world.cpu > 100) write_panic(a)
-#warning IMA FUCK YOUR SHIT UP
+#warn IMA FUCK YOUR SHIT UP
 var/proccalls = 1
 //keep a list of last 10 proccalls maybe?
 /proc/write_panic(a)

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -279,8 +279,8 @@ var/list/DummyCache = list()
 //#define DEBUG_ROLESELECT
 
 #ifdef DEBUG_ROLESELECT
-# define roleselect_debug(x) testing(x)
-# warning DEBUG_ROLESELECT is defined!
+#define roleselect_debug(x) testing(x)
+#warn DEBUG_ROLESELECT is defined!
 #else
 # define roleselect_debug(x)
 #endif

--- a/code/game/machinery/computer/slot_machine.dm
+++ b/code/game/machinery/computer/slot_machine.dm
@@ -1,6 +1,6 @@
 //#define DEBUG_SLOT_MACHINES
 #ifdef DEBUG_SLOT_MACHINES
-	#warning Slot machines are being debugged! Turn this off in code/game/machinery/computer/slot_machine.dm
+	#warn Slot machines are being debugged! Turn this off in code/game/machinery/computer/slot_machine.dm
 #endif
 
 #define SEVEN		1

--- a/code/game/objects/effects/beam.dm
+++ b/code/game/objects/effects/beam.dm
@@ -19,7 +19,7 @@
 #define BEAM_DEL(x) del(x)
 
 #ifdef BEAM_DEBUG
-# warning SOME ASSHOLE FORGOT TO COMMENT BEAM_DEBUG BEFORE COMMITTING
+# warn SOME ASSHOLE FORGOT TO COMMENT BEAM_DEBUG BEFORE COMMITTING
 # define beam_testing(x) to_chat(world, "(Line: [__LINE__]) [x]")
 #else
 # define beam_testing(x)

--- a/code/modules/media/mediamanager.dm
+++ b/code/modules/media/mediamanager.dm
@@ -128,7 +128,7 @@ function SetMusic(url, time, volume) {
 
 #ifdef DEBUG_MEDIAPLAYER
 to_chat(#define MP_DEBUG(x) owner, x)
-#warning Please comment out #define DEBUG_MEDIAPLAYER before committing.
+#warn Please comment out #define DEBUG_MEDIAPLAYER before committing.
 #else
 #define MP_DEBUG(x)
 #endif


### PR DESCRIPTION
Apparently `#warning` is not a real preprocessor directive, but BYOND is okay with it, because it begins with `#warn`, which is a real preprocessor directive.