### PR TITLE
Removed #undef for macros that were never defined

### DIFF
--- a/code/WorkInProgress/buildmode.dm
+++ b/code/WorkInProgress/buildmode.dm
@@ -199,10 +199,10 @@ obj/effect/bmode/buildholder/New()
 				var/partial_type = input(usr, "Enter type, or leave blank to see all types", "Typepath", "/obj/structure/closet") as text|null
 				if(isnull(partial_type))
 					return
-				
+
 				var/list/matches = get_matching_types(partial_type, /atom)
 				objholder = input("Select type", "Typepath") as null|anything in matches
-				
+
 				if(!ispath(objholder))
 					objholder = /obj/structure/closet
 					alert("That path is not allowed.")
@@ -735,8 +735,6 @@ obj/effect/bmode/buildholder/New()
 
 		variable_set(usr, A, varname, value_override = init_value, logging = log)
 
-#undef BOTTOM_LEFT
-#undef TOP_RIGHT
 #undef MASS_FILL
 #undef MASS_DELETE
 #undef SELECTIVE_DELETE

--- a/code/game/objects/structures/curtains.dm
+++ b/code/game/objects/structures/curtains.dm
@@ -102,6 +102,3 @@
 
 /obj/structure/curtain/open/shower/security
 	color = "#AA0000"
-
-#undef SHOWER_OPEN_LAYER
-#undef SHOWER_CLOSED_LAYER

--- a/code/modules/admin/verbs/diagnostics.dm
+++ b/code/modules/admin/verbs/diagnostics.dm
@@ -95,8 +95,6 @@
 	feedback_add_details("admin_verb","UFE") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	return
 
-#undef GATHER_DELAYER_LOCKUPS
-
 /client/proc/radio_report()
 	set category = "Debug"
 	set name = "Radio report"

--- a/code/modules/admin/verbs/massmodvar.dm
+++ b/code/modules/admin/verbs/massmodvar.dm
@@ -118,4 +118,3 @@
 			CHECK_TICK
 
 	#undef is_valid_atom
-	#undef perform

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -464,5 +464,5 @@
 	if(istype(user))
 		user.heard(src)
 
-#undef Jitter_Medium
-#undef Jitter_High
+#undef JITTER_MEDIUM
+#undef JITTER_HIGH

--- a/code/modules/mob/living/simple_animal/hostile/necro.dm
+++ b/code/modules/mob/living/simple_animal/hostile/necro.dm
@@ -716,10 +716,10 @@
 			spawn(3 SECONDS)
 				set_light(1, 2, "#5dca31")
 
-#undef EVOLVING
-#undef MOVING_TO_TARGET
-#undef EATING
-#undef OPENING_DOOR
+//#undef EVOLVING
+//#undef MOVING_TO_TARGET
+//#undef EATING
+//#undef OPENING_DOOR
 #undef CAN
 #undef CANT
 #undef CANPLUS


### PR DESCRIPTION
These were all `#undef`'d without a corresponding `#define`, probably because of refactors