### PR TITLE
Removed duplicated pipe defines

### DIFF
--- a/code/ATMOSPHERICS/utils.dm
+++ b/code/ATMOSPHERICS/utils.dm
@@ -2,14 +2,6 @@
  * Atmospherics-related utilities
  */
 
-// Shapes
-#define PIPE_BINARY   0
-#define PIPE_STRAIGHT 1 // Like binary, but rotates differently.
-#define PIPE_BENT     2
-#define PIPE_TRINARY  3
-#define PIPE_UNARY    4
-#define PIPE_4W       5
-
 // For straight pipes
 /proc/rotate_pipe_straight(var/newdir)
 	switch(newdir)


### PR DESCRIPTION
These are defined in https://github.com/vgstation-coders/vgstation13/blob/fdd6efab30db73a9f18b197a1075d274a36e652a/code/modules/RCD/schematics/pipe.dm#L1
where they're actually used