### PR TITLE
Role datums RoleTopic unfuck

### DIFF
--- a/code/datums/gamemode/role/changeling.dm
+++ b/code/datums/gamemode/role/changeling.dm
@@ -16,11 +16,12 @@
 	var/geneticdamage = 0
 	var/isabsorbing = 0
 	var/geneticpoints = 5
-	var/purchasedpowers = list()
+	var/datum/power_holder/power_holder
 	var/mimicing = ""
 
 /datum/role/changeling/OnPostSetup()
 	. = ..()
+	power_holder = new(src)
 	antag.current.make_changeling()
 	var/honorific
 	if(antag.current.gender == FEMALE)
@@ -294,19 +295,22 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 	genomecost = 5
 	verbpath = /obj/item/verbs/changeling/proc/changeling_armblade
 
+/datum/power_holder
+	var/datum/role/R
+	var/list/purchasedpowers = list()
 
-/datum/role/changeling/proc/EvolutionMenu()
-	set category = "Changeling"
-	set desc = "Level up!"
+/datum/power_holder/New(var/datum/role/newRole)
+	R = newRole
 
-	if(!usr || !usr.mind)
-		return
-
-	src = usr.mind.GetRole(CHANGELING)
-
+/datum/power_holder/proc/EvolutionMenu()
 	if(!powerinstances.len)
 		for(var/P in powers)
 			powerinstances += new P()
+
+	var/geneticpoints
+	if(istype(R, /datum/role/changeling))
+		var/datum/role/changeling/C = R
+		geneticpoints = C.geneticpoints
 
 	var/dat = "<html><head><title>Changling Evolution Menu</title></head>"
 
@@ -384,7 +388,7 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 
 					if(!ownsthis)
 					{
-						body += "<a href='?src=\ref[src];P="+power+";mind=\ref[antag];'>Evolve</a>"
+						body += "<a href='?src=\ref[src];P="+power+";mind=\ref[R.antag];'>Evolve</a>"
 					}
 
 
@@ -568,25 +572,34 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 	usr << browse(dat, "window=powers;size=900x480")
 
 
-/datum/role/changeling/RoleTopic(href, href_list, var/datum/mind/M, var/admin_auth)
-	..()
+/datum/role/changeling/proc/EvolutionMenu()
+	set category = "Changeling"
+	set desc = "Level up!"
+
+	if(!usr || !usr.mind)
+		return
+
+	src = usr.mind.GetRole(CHANGELING)
+
+	power_holder.EvolutionMenu()
+
+/datum/power_holder/Topic(href, href_list)
 	if(href_list["P"])
+		var/datum/mind/M = locate(href_list["mind"])
+		if(!M.GetRole(CHANGELING))
+			return
 		if(!istype(M))
 			return
 		purchasePower(M, href_list["P"])
-		call(/datum/role/changeling/proc/EvolutionMenu)()
+		EvolutionMenu()
 
-
-
-
-
-/datum/role/changeling/proc/purchasePower(var/datum/mind/M, var/Pname, var/remake_verbs = 1)
+/datum/power_holder/proc/purchasePower(var/datum/mind/M, var/Pname, var/remake_verbs = 1)
 	if(!M || !M.GetRole(CHANGELING))
 		to_chat(M.current, "Either you have no mind, or you're not a changeling!")
 		return
 
 	var/datum/power/changeling/Thepower = Pname
-
+	var/datum/role/changeling/C = M.GetRole(CHANGELING)
 
 	for (var/datum/power/changeling/P in powerinstances)
 //		to_chat(world, "[P] - [Pname] = [P.name == Pname ? "True" : "False"]")
@@ -604,11 +617,11 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 		return
 
 
-	if(geneticpoints < Thepower.genomecost)
+	if(C.geneticpoints < Thepower.genomecost)
 		to_chat(M.current, "We cannot evolve this... yet.  We must acquire more DNA.")
 		return
 
-	geneticpoints -= Thepower.genomecost
+	C.geneticpoints -= Thepower.genomecost
 
 	purchasedpowers += Thepower
 

--- a/code/datums/gamemode/role/changeling.dm
+++ b/code/datums/gamemode/role/changeling.dm
@@ -388,7 +388,7 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 
 					if(!ownsthis)
 					{
-						body += "<a href='?src=\ref[src];P="+power+";mind=\ref[R.antag];'>Evolve</a>"
+						body += "<a href='?src=\ref[src];P="+power+"'>Evolve</a>"
 					}
 
 
@@ -585,19 +585,11 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 
 /datum/power_holder/Topic(href, href_list)
 	if(href_list["P"])
-		var/datum/mind/M = locate(href_list["mind"])
-		if(!M.GetRole(CHANGELING))
-			return
-		if(!istype(M))
-			return
-		purchasePower(M, href_list["P"])
+		purchasePower(href_list["P"])
 		EvolutionMenu()
 
-/datum/power_holder/proc/purchasePower(var/datum/mind/M, var/Pname, var/remake_verbs = 1)
-	if(!M || !M.GetRole(CHANGELING))
-		to_chat(M.current, "Either you have no mind, or you're not a changeling!")
-		return
-
+/datum/power_holder/proc/purchasePower(var/Pname, var/remake_verbs = 1)
+	var/datum/mind/M = R.antag
 	var/datum/power/changeling/Thepower = Pname
 	var/datum/role/changeling/C = M.GetRole(CHANGELING)
 

--- a/code/datums/gamemode/role/role.dm
+++ b/code/datums/gamemode/role/role.dm
@@ -385,6 +385,8 @@
 
 // DO NOT OVERRIDE
 /datum/role/Topic(href, href_list)
+	if(!check_rights(R_ADMIN))
+		return 0
 
 	if(!href_list["mind"])
 		to_chat(usr, "<span class='warning'>BUG: mind variable not specified in Topic([href])!</span>")
@@ -397,15 +399,6 @@
 
 // USE THIS INSTEAD (global)
 /datum/role/proc/RoleTopic(href, href_list, var/datum/mind/M, var/admin_auth)
-	if(admin_auth && !check_rights(R_ADMIN))
-		message_admins("<span class='warning'>Something fucky is going on. [usr] has admin_auth 1 on their RoleTopic, but failed actual check_rights(R_ADMIN)!</span>")
-		return 1
-
-	else if(href_list["auto_objectives"])//what's that even for actually? Might want to get rid of it later
-		var/datum/role/R = M.GetRole(href_list["auto_objectives"])
-		R.ForgeObjectives()
-		to_chat(usr, "<span class='info'>The objectives for [M.key] have been generated. You can edit them. Remember to announce their objectives.</span>")
-		return
 
 
 /datum/role/proc/AnnounceObjectives()

--- a/code/datums/gamemode/role/syndicate.dm
+++ b/code/datums/gamemode/role/syndicate.dm
@@ -61,10 +61,9 @@
 	return dat
 
 /datum/role/traitor/RoleTopic(href, href_list, var/datum/mind/M, var/admin_auth)
-	.=..()
-	if(href_list["giveuplink"] && admin_auth)
+	if(href_list["giveuplink"])
 		equip_traitor(antag.current, 20)
-	if(href_list["removeuplink"] && admin_auth)
+	if(href_list["removeuplink"])
 		M.take_uplink()
 		to_chat(M.current, "<span class='warning'>You have been stripped of your uplink.</span>")
 

--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -87,8 +87,7 @@
  - <a href='?_src_=holder;traitor=\ref[M]'>(role panel)</a> - <a href='?src=\ref[src]&mind=\ref[antag]&giveblood=1'>Give blood</a>"}
 	return text
 
-/datum/role/vampire/RoleTopic(href, href_list)
-	. = ..()
+/datum/role/vampire/RoleTopic(href, href_list, var/datum/mind/M, var/admin_auth)
 	if (!usr.client.holder)
 		return FALSE
 	if (href_list["giveblood"])
@@ -224,7 +223,7 @@
 
 	else if (VAMP_VISION in powers)
 		H.change_sight(adding = SEE_MOBS)
-	
+
 
 /datum/role/vampire/proc/handle_enthrall(var/datum/mind/M)
 	if (!istype(M))

--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -22,7 +22,7 @@
 	for(var/datum/power/changeling/P in powerinstances)
 		if(!P.genomecost) // Is it free?
 			if(!(P in C.power_holder.purchasedpowers)) // Do we not have it already?
-				C.power_holder.purchasePower(mind, P.name, 0)// Purchase it. Don't remake our verbs, we're doing it after this.
+				C.power_holder.purchasePower(P.name, 0)// Purchase it. Don't remake our verbs, we're doing it after this.
 
 	for(var/datum/power/changeling/P in C.power_holder.purchasedpowers)
 		if(P.isVerb)

--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -21,10 +21,10 @@
 	// Code to auto-purchase free powers.
 	for(var/datum/power/changeling/P in powerinstances)
 		if(!P.genomecost) // Is it free?
-			if(!(P in C.purchasedpowers)) // Do we not have it already?
-				C.purchasePower(mind, P.name, 0)// Purchase it. Don't remake our verbs, we're doing it after this.
+			if(!(P in C.power_holder.purchasedpowers)) // Do we not have it already?
+				C.power_holder.purchasePower(mind, P.name, 0)// Purchase it. Don't remake our verbs, we're doing it after this.
 
-	for(var/datum/power/changeling/P in C.purchasedpowers)
+	for(var/datum/power/changeling/P in C.power_holder.purchasedpowers)
 		if(P.isVerb)
 			if(lesser_form && !P.allowduringlesserform)
 				continue
@@ -203,7 +203,7 @@
 	if(!verb_holder)
 		return
 
-	for(var/datum/power/changeling/P in changeling.purchasedpowers)
+	for(var/datum/power/changeling/P in changeling.power_holder.purchasedpowers)
 		if(P.isVerb)
 			verb_holder.verbs -= P.verbpath
 
@@ -362,12 +362,12 @@
 					changeling.absorbedcount++
 				Tchangeling.absorbed_dna.len = 1
 
-			if(Tchangeling.purchasedpowers)
-				for(var/datum/power/changeling/Tp in Tchangeling.purchasedpowers)
-					if(Tp in changeling.purchasedpowers)
+			if(Tchangeling.power_holder.purchasedpowers.len)
+				for(var/datum/power/changeling/Tp in Tchangeling.power_holder.purchasedpowers)
+					if(Tp in changeling.power_holder.purchasedpowers)
 						continue
 					else
-						changeling.purchasedpowers += Tp
+						changeling.power_holder.purchasedpowers += Tp
 
 						if(!Tp.isVerb)
 							call(Tp.verbpath)()


### PR DESCRIPTION
MSO pointed out a potential security issue should somebody find a juicy role ref through illicit means, so reintroducing the isadmin check to before topic is called on roles.

This does mean that only admin-related things will be available through role-related HTML UIs, so be wary.
