### PR TITLE
Fixed deathnettle being consumed on failed attacks

### DIFF
--- a/code/modules/hydroponics/grown_inedible.dm
+++ b/code/modules/hydroponics/grown_inedible.dm
@@ -217,31 +217,25 @@
 /obj/item/weapon/grown/deathnettle/attack(mob/living/carbon/M as mob, mob/user as mob)
 	if(!..())
 		return
-	if(istype(M, /mob/living))
-		to_chat(M, "<span class='warning'>You are stunned by the powerful acid of the Deathnettle!</span>")
+	to_chat(M, "<span class='warning'>You are stunned by the powerful acid of the Deathnettle!</span>")
 
-		M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Had the [src.name] used on them by [user.name] ([user.ckey])</font>")
-		user.attack_log += text("\[[time_stamp()]\] <font color='red'>Used the [src.name] on [M.name] ([M.ckey])</font>")
-		msg_admin_attack("[user.name] ([user.ckey]) used the [src.name] on [M.name] ([M.ckey]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
+	M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Had the [src.name] used on them by [user.name] ([user.ckey])</font>")
+	user.attack_log += text("\[[time_stamp()]\] <font color='red'>Used the [src.name] on [M.name] ([M.ckey])</font>")
+	msg_admin_attack("[user.name] ([user.ckey]) used the [src.name] on [M.name] ([M.ckey]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
 
-		playsound(loc, 'sound/weapons/bladeslice.ogg', 50, 1, -1)
+	playsound(loc, 'sound/weapons/bladeslice.ogg', 50, 1, -1)
 
-		M.eye_blurry += force/7
-		if(prob(20))
-			M.Paralyse(force/6)
-			M.Knockdown(force/15)
-		M.drop_item()
+	M.eye_blurry += force/7
+	if(prob(20))
+		M.Paralyse(force/6)
+		M.Knockdown(force/15)
+	M.drop_item()
 
-/obj/item/weapon/grown/deathnettle/afterattack(atom/A as mob|obj, mob/user as mob, proximity)
-	if(!proximity)
-		return
 	user.delayNextAttack(8)
 	if (force > 0)
 		force -= rand(1,(force/3)+1) // When you whack someone with it, leaves fall off
-
 	else
 		to_chat(user, "All the leaves have fallen off the deathnettle from violent whacking.")
-		user.drop_item(src, force_drop = 1)
 		qdel(src)
 
 /obj/item/weapon/grown/deathnettle/changePotency(newValue) //-QualityVan


### PR DESCRIPTION
Fixes #19735

`afterattack` was not the place to do that.
Also turns out `..()` will return 0 if `M` is not `mob/living`, so got rid of that too.

:cl:
* bugfix: Fixed a bug that caused deathnettles to be consumed by unsuccessful attacks.