### PR TITLE
Salvage Broker Alt-Title

### DIFF
--- a/code/game/jobs/job/whitelisted.dm
+++ b/code/game/jobs/job/whitelisted.dm
@@ -9,7 +9,7 @@
 	selection_color = "#dddddd"
 	access = list(access_trade)
 	minimal_access = list(access_trade)
-	alt_titles = list("Merchant")
+	alt_titles = list("Merchant","Salvage Broker")
 
 	species_whitelist = list("Vox")
 	must_be_map_enabled = 1
@@ -63,6 +63,9 @@
 			affected.implants += L
 			L.part = affected
 
+		if("Salvage Broker")
+			H.equip_or_collect(new /obj/item/device/telepad_beacon(H.back), slot_in_backpack)
+			H.equip_or_collect(new /obj/item/weapon/rcs/salvage(H.back), slot_in_backpack)
 
 	return 1
 

--- a/code/modules/telesci/rcs.dm
+++ b/code/modules/telesci/rcs.dm
@@ -119,6 +119,10 @@
 	if (!istype(target) || target.opened || !proximity_flag || !cell || teleporting)
 		return
 
+	if (send_note && z == STATION_Z)
+		to_chat(user, "<span class='warning'>The safety prevents the sending of crates from the viscinity of Nanotrasen Station.</span>")
+		return
+
 	if (cell.charge < send_cost)
 		to_chat(user, "<span class='warning'>Out of charges.</span>")
 		return 1

--- a/code/modules/telesci/rcs.dm
+++ b/code/modules/telesci/rcs.dm
@@ -119,7 +119,7 @@
 	if (!istype(target) || target.opened || !proximity_flag || !cell || teleporting)
 		return
 
-	if (send_note && z == STATION_Z)
+	if (send_note && user.z == STATION_Z)
 		to_chat(user, "<span class='warning'>The safety prevents the sending of crates from the viscinity of Nanotrasen Station.</span>")
 		return
 

--- a/code/modules/telesci/rcs.dm
+++ b/code/modules/telesci/rcs.dm
@@ -78,6 +78,7 @@
 	var/mode    = MODE_NORMAL
 	var/emagged = FALSE
 	var/send_cost = 1500
+	var/send_note = FALSE
 	var/tmp/teleporting = FALSE
 	starting_materials	= list(MAT_IRON = 50000)
 
@@ -153,19 +154,40 @@
 	else if (mode == MODE_RANDOM)
 		teleport_target = locate(rand(50, 450), rand(50, 450), 6)
 
+	var/obj/item/weapon/paper/P
+
+	if(send_note)
+		var/note = input("Would you like to attach a note?", "Autoletter") as null|text
+		if(note)
+			P = new(null) //This will be deleted if the teleport doesn't complete. Avoids generating extra notes.
+			P.name = "letter from [user]"
+			P.info = note
+
 	playsound(src, 'sound/machines/click.ogg', 50, 1)
 	to_chat(user, "<span class='notic'>Teleporting \the [target]...</span>")
 	teleporting = TRUE
 	if (!do_after(user, target, 50))
 		teleporting = FALSE
+		if(P)
+			qdel(P)
 		return 1
 
 	teleporting = FALSE
 	do_teleport(target, teleport_target)
+	if(P)
+		P.forceMove(target)
 	/*spark(src, 5)*/
 	cell.use(send_cost)
-	to_chat(user, "<span class='notice'>Teleport successful. [round(cell.charge / send_cost)] charge\s left.</span>")
+	to_chat(user, "<span class='notice'>Teleport successful. [send_cost ? "[round(cell.charge / send_cost)] charge\s left." : "Caw."]</span>")
 	return 1
+
+/obj/item/weapon/rcs/salvage
+	name = "salvage-crate-sender (SCS)"
+	desc = "An old RCS model that has been modified for longterm use."
+	icon = 'icons/obj/device.dmi'
+	icon_state = "dest_tagger_p"
+	send_cost = 0
+	send_note = TRUE
 
 #undef MODE_NORMAL
 #undef MODE_RANDOM


### PR DESCRIPTION
People requested a Trader alt-title that conveys the idea of space exploring without being a shitbird hobo.

* Instead of getting the extra coin/donks/thermos, starts with a single telepad beacon and a special RCS
* Modified RCS has a unique sprite and no send cost, also allows you to send letters home with the crate

This should help brokers who spend an hour in space "participate" because they can send their salvage home crated up and ready to be sold by other merchants/traders.

This telepad is on the same list as the other cargo beacons, which means cargo can prank birds by sending them crates with facehuggers or whatever. Be careful about that!

🆑 
* rscadd: Salvage Broker added as a new alternate title for Traders.