### PR TITLE
aghost with matter synth

### DIFF
--- a/code/game/machinery/antiquemattersynth.dm
+++ b/code/game/machinery/antiquemattersynth.dm
@@ -79,7 +79,10 @@ list("category" = "machinery", "name" = "MSGS", "path" = /obj/machinery/atmosphe
 		nanomanager.update_uis(src)
 
 /obj/machinery/power/antiquesynth/attack_ai(mob/user)
-	to_chat(user, "<span class='warning'>You aren't equipped to interface with technology this old!</span>")
+	if(isAdminGhost(user))
+		attack_hand(user)
+	else
+		to_chat(user, "<span class='warning'>You aren't equipped to interface with technology this old!</span>")
 
 /obj/machinery/power/antiquesynth/attack_hand(mob/user)
 	return ui_interact(user)
@@ -120,7 +123,7 @@ list("category" = "machinery", "name" = "MSGS", "path" = /obj/machinery/atmosphe
 /obj/machinery/power/antiquesynth/Topic(href, href_list)
 	if(..())
 		return
-	if(usr.incapacitated() || !Adjacent(usr) || !usr.dexterity_check())
+	if(usr.incapacitated() || (!Adjacent(usr)&&!isAdminGhost(usr)) || !usr.dexterity_check())
 		return
 	if(!allowed(usr) && !emagged)
 		to_chat(usr,"<span class='warning'>Access denied.</span>")


### PR DESCRIPTION
Not counting this as a bug fix since its QOL (mostly for me)

🆑 
* rscadd: Adminghosts can now use the antique matter synth