### PR TITLE
Brain Identities (FFF27)

### DIFF
--- a/code/modules/mob/living/carbon/brain/brain_item.dm
+++ b/code/modules/mob/living/carbon/brain/brain_item.dm
@@ -26,7 +26,7 @@
 			brainmob.client.screen.len = null //clear the hud
 
 /obj/item/organ/internal/brain/proc/transfer_identity(var/mob/living/carbon/H)
-	name = "[H]'s brain"
+	name = "[H.real_name]'s brain"
 	brainmob = new(src)
 	brainmob.name = H.real_name
 	brainmob.real_name = H.real_name


### PR DESCRIPTION
fixes #19655

🆑 
* bugfix: Brains will now have the real name of the person who was debrained, rather than whatever identity that person was using.