### PR TITLE
Fixes AAC Import/Export (FFF30)

### DIFF
--- a/code/modules/atmos_automation/implementation/scrubbers.dm
+++ b/code/modules/atmos_automation/implementation/scrubbers.dm
@@ -15,10 +15,6 @@
 	scrubber = json["scrubber"]
 	mode = text2num(json["mode"])
 
-/datum/automation/set_scrubber_mode/New(var/obj/machinery/computer/general_air_control/atmos_automation/aa)
-	..(aa)
-	children = list(null)
-
 /datum/automation/set_scrubber_mode/process()
 	if(scrubber)
 		parent.send_signal(list ("tag" = scrubber, "sigtype"="command", "scrubbing" = mode), RADIO_FROM_AIRALARM)

--- a/code/modules/atmos_automation/implementation/vent_pump.dm
+++ b/code/modules/atmos_automation/implementation/vent_pump.dm
@@ -19,10 +19,6 @@
 	mode = json["mode"]
 	vent_type = text2num(json["vent_type"])
 
-/datum/automation/set_vent_pump_mode/New(var/obj/machinery/computer/general_air_control/atmos_automation/aa)
-	..(aa)
-	children = list(null)
-
 /datum/automation/set_vent_pump_mode/process()
 	if(vent_pump)
 		parent.send_signal(list ("tag" = vent_pump, mode), filter = (vent_type ? RADIO_ATMOSIA : RADIO_FROM_AIRALARM))


### PR DESCRIPTION
fixes #8454

Truly ancient shitcode caused by copy/paste from the register automation, I suspect. Caused exported scripts for exactly the "vent mode" and "scrubber mode" automations to generate empty children lists that fucked up the JSON.

Tested.

🆑 
* bugfix: The Atmos Automations Computer no longer generates invalid JSON when exporting scripts that set vent mode or scrubber mode.