### PR TITLE
Foam Can't Cause 0K Gas (FFF31)

### DIFF
--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -749,7 +749,7 @@ steam.start() -- spawns the effect
 		savedtemp = old_air.temperature
 		if(istype(T) && savedtemp > lowest_temperature)
 			var/datum/gas_mixture/lowertemp = old_air.remove_volume(CELL_VOLUME)
-			lowertemp.temperature = max(min(lowertemp.temperature - 500, lowertemp.temperature / 2), 0)
+			lowertemp.temperature = max(min(lowertemp.temperature - 500, lowertemp.temperature / 2), 1) //Reaching exactly 0K causes problems
 			lowertemp.react()
 			T.assume_air(lowertemp)
 	spawn(3)


### PR DESCRIPTION
fixes #17909

It can still go to 1K (which is questionable, but I'd rather just keep this a bugfix than make it an "important balance matter"). Tested with a basic inflatable cuck cube.

Basically gas gets really fucky if it reaches exactly 0K because it messes with equations and as a result it's even possible to get below 0K. As far as I could tell from my testing, that won't happen anymore but you can still get blasma very cold

🆑 
* bugfix: Foam extinguishers can now only reach the minimum temperature instead of BYOND