### PR TITLE
Fixed cargo computers hygiene

### DIFF
--- a/code/game/machinery/computer/cargo.dm
+++ b/code/game/machinery/computer/cargo.dm
@@ -359,7 +359,7 @@ For vending packs, see vending_packs.dm*/
 			to_chat(usr, "<span class='warning'>You can only afford [max_crates] crates.</span>")
 			return
 		var/timeout = world.time + 600
-		var/reason = copytext(sanitize(strict_ascii(input(usr, "Reason:", "Why do you require this item?", "") as null|text)), 1, REASON_LEN)
+		var/reason = utf8_sanitize(input(usr,"Reason:","Why do you require this item?","") as null|text, usr, REASON_LEN)
 		if(world.time > timeout)
 			return
 		if(!reason)
@@ -584,7 +584,7 @@ For vending packs, see vending_packs.dm*/
 			var/max_crates = round((account.money - total_money_req) / P.cost)
 			to_chat(usr, "<span class='warning'>You can only afford [max_crates] crates.</span>")
 			return
-		var/reason = copytext(sanitize(strict_ascii(input(usr,"Reason:","Why do you require this item?","") as null|text)),1,REASON_LEN)
+		var/reason = utf8_sanitize(input(usr,"Reason:","Why do you require this item?","") as null|text, usr, REASON_LEN)
 		if(world.time > timeout)
 			return
 		if(!reason)


### PR DESCRIPTION
Fixes #16473

:cl:
 * bugfix: Entering quotation marks in the reason field for a cargo order shouldn't break the console anymore.
