### PR TITLE
[Hotfix] Fixes Who Advanced

### DIFF
--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -59,13 +59,13 @@
 					dead++
 			else
 				living++
-		/*if(is_special_character(C.mob))
-			entry += " - <b><span class='red'>Antagonist</span></b>"
+		if (C.mob.mind && C.mob.mind.antag_roles.len > 0)
+			for(var/datum/role/R in C.mob.mind.antag_roles)
+				entry += " - <b><span class='red'>[uppertext(R.name)]</span></b>"
 			if(!(C.mob.isDead()))
 				living_antags++
 			else
 				dead_antags++
-		*/
 		entry += " (<A HREF='?_src_=holder;adminmoreinfo=\ref[C.mob]'>?</A>)"
 		Lines += entry
 


### PR DESCRIPTION
Who Advanced now displays each roles instead of just saying ANTAGONIST.

Fixes #19796