### PR TITLE
re-adds the cult structure parent

### DIFF
--- a/code/datums/gamemode/factions/legacy_cult/cult_structures.dm
+++ b/code/datums/gamemode/factions/legacy_cult/cult_structures.dm
@@ -1,3 +1,8 @@
+/obj/structure/cult_legacy
+	icon = 'icons/obj/cult.dmi'
+	density = TRUE
+	anchored = TRUE
+
 
 /obj/structure/cult_legacy/talisman
 	name = "Altar"


### PR DESCRIPTION
They were inheriting the icon, density, and anchored from it. I guess somebody thought it redundant?

closes #19811
