### PR TITLE
GPS fixes

### DIFF
--- a/code/modules/telesci/gps.dm
+++ b/code/modules/telesci/gps.dm
@@ -55,7 +55,7 @@ var/list/SPS_list = list()
 /obj/item/device/gps/attack_self(mob/user)
 	if(emped)
 		return
-	if(transmitting)
+	if(transmitting || isobserver(user))
 		ui_interact(user)
 		return
 	var/choice = alert(user,"Would you like to turn on the GPS?",,"Yes","No")

--- a/code/modules/telesci/gps.dm
+++ b/code/modules/telesci/gps.dm
@@ -53,18 +53,18 @@ var/list/SPS_list = list()
 		update_icon()
 
 /obj/item/device/gps/attack_self(mob/user)
-	if (emped)
+	if(emped)
 		return
-	else if (!transmitting)
-		switch(alert(user,"Would you like to turn on the GPS?",,"Yes","No"))
-			if ("Yes")
-				if(!emped && !transmitting && Adjacent(user) && !user.incapacitated())
-					transmitting = TRUE
-					to_chat(user, "<span class = 'notice'>You activate \the [src].</span>")
-					update_icon()
-					ui_interact(user)
-	else
+	if(transmitting)
 		ui_interact(user)
+		return
+	var/choice = alert(user,"Would you like to turn on the GPS?",,"Yes","No")
+	if(choice != "Yes" || emped || transmitting || !Adjacent(user) || user.incapacitated())
+		return
+	transmitting = TRUE
+	to_chat(user, "<span class = 'notice'>You activate \the [src].</span>")
+	update_icon()
+	ui_interact(user)
 
 /obj/item/device/gps/examine(mob/user)
 	if(Adjacent(user) || isobserver(user))

--- a/code/modules/telesci/gps.dm
+++ b/code/modules/telesci/gps.dm
@@ -36,14 +36,21 @@ var/list/SPS_list = list()
 	gps_list -= src
 	..()
 
+/obj/item/device/gps/update_icon()
+	overlays.Cut()
+	if(emped)
+		overlays += image(icon, "emp")
+		return
+	if(transmitting)
+		overlays += image(icon, "working")
+
 /obj/item/device/gps/emp_act(severity)
 	emped = TRUE
 	transmitting = FALSE
-	overlays -= image(icon = icon, icon_state = "working")
-	overlays += image(icon = icon, icon_state = "emp")
+	update_icon()
 	spawn(30 SECONDS)
-		overlays -= image(icon = icon, icon_state = "emp")
 		emped = FALSE
+		update_icon()
 
 /obj/item/device/gps/attack_self(mob/user)
 	if (emped)
@@ -54,7 +61,7 @@ var/list/SPS_list = list()
 				if(!emped && !transmitting && Adjacent(user) && !user.incapacitated())
 					transmitting = TRUE
 					to_chat(user, "<span class = 'notice'>You activate \the [src].</span>")
-					overlays += image(icon = icon, icon_state = "working")
+					update_icon()
 					ui_interact(user)
 	else
 		ui_interact(user)

--- a/code/modules/telesci/gps.dm
+++ b/code/modules/telesci/gps.dm
@@ -21,7 +21,7 @@ var/list/SPS_list = list()
 /obj/item/device/gps/proc/gen_id()
 	return GPS_list.len
 
-/obj/item/device/gps/proc/get_list()
+/obj/item/device/gps/proc/get_gps_list()
 	return GPS_list
 
 /obj/item/device/gps/proc/update_name()

--- a/nano/templates/gps.tmpl
+++ b/nano/templates/gps.tmpl
@@ -10,29 +10,34 @@ Used In File(s): \code\modules\telesci\gps.dm
 	</div>
 {{/if}}
 <h3>Settings</h3>
-<div class="item">
-	<div class="itemLabel">Tag:</div>
-	<div class="itemContent">
-		{{:helper.link(data.gpstag, 'pencil', {'tag' : '1'}, null)}}
-	</div>
-</div>
-<div class="item">
-	<div class="itemLabel">Auto-refresh:</div>
-	<div class="itemContent">
-		{{:helper.link(data.autorefresh ? 'On' : 'Off', 'refresh', {'toggle_refresh' : '1'}, null)}}
-	</div>
-</div>
-
-<h3>Detected signals</h3>
-<div class="item">
-	<div class="itemLabelNarrow">{{:data.gpstag}}</div>
-	<div class="itemContentWide">{{:data.location_text}}</div>
-</div>
-{{for data.devices}}
+{{if !data.transmitting}}
+	This unit is currently <span class="bad">OFFLINE.</span>
+	{{:helper.link('Turn on', 'power', {'turn_on': '1'})}}
+{{else}}
 	<div class="item">
-		<div class="itemLabelNarrow">{{:value.tag}}</div>
-		<div class="itemContentWide">{{:value.location_text}}</div>
+		<div class="itemLabel">Tag:</div>
+		<div class="itemContent">
+			{{:helper.link(data.gpstag, 'pencil', {'tag' : '1'}, null)}}
+		</div>
 	</div>
-{{empty}}
-	<i>No signal detected.</i>
-{{/for}}
+	<div class="item">
+		<div class="itemLabel">Auto-refresh:</div>
+		<div class="itemContent">
+			{{:helper.link(data.autorefresh ? 'On' : 'Off', 'refresh', {'toggle_refresh' : '1'}, null)}}
+		</div>
+	</div>
+
+	<h3>Detected signals</h3>
+	<div class="item">
+		<div class="itemLabelNarrow">{{>data.gpstag}}</div>
+		<div class="itemContentWide">{{>data.location_text}}</div>
+	</div>
+	{{for data.devices}}
+		<div class="item">
+			<div class="itemLabelNarrow">{{>value.tag}}</div>
+			<div class="itemContentWide">{{>value.location_text}}</div>
+		</div>
+	{{empty}}
+		<i>No signal detected.</i>
+	{{/for}}
+{{/if}}


### PR DESCRIPTION
- Changed the way you turn on a GPS. Before it was an `alert()` on `attack_self()`, now it's all handled in the nano UI;
- Data to the UI is now properly encoded
- Added an `update_icon`, now called in all the right places
- Small refactoring

Fixed #19520

:cl:
 * tweak: GPS modules for pAIs and cyborgs don't have to be manually toggled on.
 * bugfix: Fixed pAI GPS not working at all.
