### PR TITLE
Format units helper proc

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -416,27 +416,6 @@ var/list/unit_suffixes = list("", "k", "M", "G", "T", "P", "E", "Z", "Y")
 
 	return "[format_num(number)] [unit_suffixes[i]]"
 
-/**
- * Old unit formatter, the TEG used to use this
- */
-/*
-var/list/watt_suffixes = list("W", "KW", "MW", "GW", "TW", "PW", "EW", "ZW", "YW")
-/proc/format_watts(var/number)
-	if (number<0)
-		return "-[format_watts(abs(number))]"
-	if (number==0)
-		return "0 W"
-
-	var/max_watt_suffix = watt_suffixes.len
-	var/i=1
-	while (round(number/1000) >= 1)
-		number/=1000
-		i++
-		if (i == max_watt_suffix)
-			break
-
-	return "[format_num(number)] [watt_suffixes[i]]"
-*/
 
 //Returns 1 if [text] ends with [suffix]
 //Example: text_ends_with("Woody got wood", "dy got wood") returns 1

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -398,7 +398,7 @@ proc/checkhtml(var/t)
  * Formats unites with their suffixes
  * Should be good for J, W, and stuff
  */
-var/list/unit_suffixes = list("K", "M", "G", "T", "P", "E", "Z", "Y")
+var/list/unit_suffixes = list("", "K", "M", "G", "T", "P", "E", "Z", "Y")
 
 /proc/format_units(var/number)
 	if (number<0)

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -398,7 +398,7 @@ proc/checkhtml(var/t)
  * Formats unites with their suffixes
  * Should be good for J, W, and stuff
  */
-var/list/unit_suffixes = list("", "K", "M", "G", "T", "P", "E", "Z", "Y")
+var/list/unit_suffixes = list("", "k", "M", "G", "T", "P", "E", "Z", "Y")
 
 /proc/format_units(var/number)
 	if (number<0)

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -419,7 +419,7 @@ var/list/unit_suffixes = list("K", "M", "G", "T", "P", "E", "Z", "Y")
 /**
  * Old unit formatter, the TEG used to use this
  */
-
+/*
 var/list/watt_suffixes = list("W", "KW", "MW", "GW", "TW", "PW", "EW", "ZW", "YW")
 /proc/format_watts(var/number)
 	if (number<0)
@@ -436,7 +436,7 @@ var/list/watt_suffixes = list("W", "KW", "MW", "GW", "TW", "PW", "EW", "ZW", "YW
 			break
 
 	return "[format_num(number)] [watt_suffixes[i]]"
-
+*/
 
 //Returns 1 if [text] ends with [suffix]
 //Example: text_ends_with("Woody got wood", "dy got wood") returns 1

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -421,7 +421,7 @@ var/list/unit_suffixes = list("", "k", "M", "G", "T", "P", "E", "Z", "Y")
  * Old unit formatter, the TEG used to use this
  */
 /proc/format_watts(var/number)
-	return "[unit_suffixes(number)]W"
+	return "[format_units(number)]W"
 
 
 //Returns 1 if [text] ends with [suffix]

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -393,6 +393,33 @@ proc/checkhtml(var/t)
 	if(parts.len==2)
 		. += ".[parts[2]]"
 
+
+/**
+ * Formats unites with their suffixes
+ * Should be good for J, W, and stuff
+ */
+var/list/unit_suffixes = list("K", "M", "G", "T", "P", "E", "Z", "Y")
+
+/proc/format_units(var/number)
+	if (number<0)
+		return "-[format_units(abs(number))]"
+	if (number==0)
+		return "0 "
+
+	var/max_unit_suffix = unit_suffixes.len
+	var/i=1
+	while (round(number/1000) >= 1)
+		number/=1000
+		i++
+		if (i == max_unit_suffix)
+			break
+
+	return "[format_num(number)] [unit_suffixes[i]]"
+
+/**
+ * Old unit formatter, the TEG used to use this
+ */
+
 var/list/watt_suffixes = list("W", "KW", "MW", "GW", "TW", "PW", "EW", "ZW", "YW")
 /proc/format_watts(var/number)
 	if (number<0)
@@ -409,6 +436,7 @@ var/list/watt_suffixes = list("W", "KW", "MW", "GW", "TW", "PW", "EW", "ZW", "YW
 			break
 
 	return "[format_num(number)] [watt_suffixes[i]]"
+
 
 //Returns 1 if [text] ends with [suffix]
 //Example: text_ends_with("Woody got wood", "dy got wood") returns 1

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -417,6 +417,13 @@ var/list/unit_suffixes = list("", "k", "M", "G", "T", "P", "E", "Z", "Y")
 	return "[format_num(number)] [unit_suffixes[i]]"
 
 
+/**
+ * Old unit formatter, the TEG used to use this
+ */
+/proc/format_watts(var/number)
+	return "[unit_suffixes(number)]W"
+
+
 //Returns 1 if [text] ends with [suffix]
 //Example: text_ends_with("Woody got wood", "dy got wood") returns 1
 //         text_ends_with("Woody got wood", "d") returns 1

--- a/code/modules/optics/photocollector.dm
+++ b/code/modules/optics/photocollector.dm
@@ -57,7 +57,7 @@ var/list/obj/machinery/power/photocollector/photocollector_list = list()
 		return 1
 	else if(istype(W, /obj/item/device/analyzer) || istype(W, /obj/item/device/multitool))
 		if(last_power)
-			to_chat(user, "<span class='notice'>\The [W] registers that [format_units(last_power)]W is being produced every cycle.</span>")
+			to_chat(user, "<span class='notice'>\The [W] registers that [format_watts(last_power)] is being produced every cycle.</span>")
 		else
 			to_chat(user, "<span class='notice'>\The [W] registers that the unit is currently not producing power.</span>")
 		return 1

--- a/code/modules/optics/photocollector.dm
+++ b/code/modules/optics/photocollector.dm
@@ -57,7 +57,7 @@ var/list/obj/machinery/power/photocollector/photocollector_list = list()
 		return 1
 	else if(istype(W, /obj/item/device/analyzer) || istype(W, /obj/item/device/multitool))
 		if(last_power)
-			to_chat(user, "<span class='notice'>\The [W] registers that [format_watts(last_power)] is being produced every cycle.</span>")
+			to_chat(user, "<span class='notice'>\The [W] registers that [format_units(last_power)]W is being produced every cycle.</span>")
 		else
 			to_chat(user, "<span class='notice'>\The [W] registers that the unit is currently not producing power.</span>")
 		return 1

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -347,7 +347,7 @@
 	interface.updateContent("circ1", "Primary circulator ([vertical ? "top"		: "right"])")
 	interface.updateContent("circ2", "Primary circulator ([vertical ? "bottom"	: "left"])")
 
-	interface.updateContent("total_out", "[format_units(last_gen)]W")
+	interface.updateContent("total_out", format_watts(last_gen))
 
 	if(!circ1 || !circ2)	//From this point on it's circulator data.
 		return

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -347,7 +347,7 @@
 	interface.updateContent("circ1", "Primary circulator ([vertical ? "top"		: "right"])")
 	interface.updateContent("circ2", "Primary circulator ([vertical ? "bottom"	: "left"])")
 
-	interface.updateContent("total_out", format_watts(last_gen))
+	interface.updateContent("total_out", "[format_units(last_gen)]W")
 
 	if(!circ1 || !circ2)	//From this point on it's circulator data.
 		return

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -55,7 +55,7 @@ var/global/list/rad_collectors = list()
 		return 1
 	else if(istype(W, /obj/item/device/analyzer) || istype(W, /obj/item/device/multitool))
 		if(active)
-			to_chat(user, "<span class='notice'>\The [W] registers that [format_watts(last_power)] is being produced every cycle.</span>")
+			to_chat(user, "<span class='notice'>\The [W] registers that [format_units(last_power)]W is being produced every cycle.</span>")
 		else
 			to_chat(user, "<span class='notice'>\The [W] registers that the unit is currently not producing power.</span>")
 		return 1

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -55,7 +55,7 @@ var/global/list/rad_collectors = list()
 		return 1
 	else if(istype(W, /obj/item/device/analyzer) || istype(W, /obj/item/device/multitool))
 		if(active)
-			to_chat(user, "<span class='notice'>\The [W] registers that [format_units(last_power)]W is being produced every cycle.</span>")
+			to_chat(user, "<span class='notice'>\The [W] registers that [format_watts(last_power)] is being produced every cycle.</span>")
 		else
 			to_chat(user, "<span class='notice'>\The [W] registers that the unit is currently not producing power.</span>")
 		return 1


### PR DESCRIPTION
Converts the "format_watts" helper proc into a "format_units" helper proc so you can use it on units that aren't watts.
Did CTRL+F to replace all (three) uses of it with the new proc, seems to be working fine. The old "format_watts" is kept around as a wrapper