### PR TITLE
replace callOnLife with a new on_life event

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -92,15 +92,7 @@
 			to_chat(src, "<span class='notice'>You feel like a pleb.</span>")
 	handle_beams()
 
-	//handles "call on life", allowing external life-related things to be processed
-	for(var/toCall in src.callOnLife)
-		if(locate(toCall) && callOnLife[toCall])
-			try
-				call(locate(toCall),callOnLife[toCall])()
-			catch(var/exception/e)
-				stack_trace(e)
-		else
-			callOnLife -= toCall
+	INVOKE_EVENT(on_life, list())
 
 	/*if(mind)
 		if(mind in ticker.mode.implanted)
@@ -779,16 +771,19 @@ Thanks.
 				hook.override_target_X--
 
 /mob/living
-    var/event/on_resist
+	var/event/on_resist
 
 /mob/living/New()
-    . = ..()
-    on_resist = new(owner = src)
+	. = ..()
+	on_resist = new(owner = src)
+	on_life = new(owner = src)
 
 /mob/living/Destroy()
-    . = ..()
-    qdel(on_resist)
-    on_resist = null
+	. = ..()
+	qdel(on_resist)
+	on_resist = null
+	qdel(on_life)
+	on_life = null
 
 /mob/living/verb/resist()
 	set name = "Resist"

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -68,8 +68,8 @@
 	var/species_type
 	var/holder_type = /obj/item/weapon/holder/animal	//When picked up, put us into a holder of this type. Dionae use /obj/item/weapon/holder/diona, others - the default one
 														//Set to null to prevent people from picking this mob up!
-	//
-	var/list/callOnLife = list() //
+
+	var/event/on_life
 	var/obj/abstract/screen/schematics_background
 	var/shown_schematics_background = 0
 
@@ -80,7 +80,3 @@
 	var/thermal_loss_multiplier = 1				//The heat the mob loses to the environment is multiplied by this value.
 
 	var/datum/component_container/BrainContainer
-
-/mob/living/proc/unsubLife(datum/sub)
-	while("\ref[sub]" in callOnLife)
-		callOnLife -= "\ref[sub]"


### PR DESCRIPTION
- It was only used by vampire.dm (no longer ticked)
- when it WAS used, it used to cause runtimes.
- Replaced it with a new `on_life` event
- SOMEONE USED SPACES INSTEAD OF TABS