### PR TITLE
ACTUALLY make secret mode dynamic mode

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -725,9 +725,11 @@
 				diary << "Unknown setting in configuration: '[name]'"
 
 /datum/configuration/proc/pick_mode(mode_name)
-	for (var/datum/gamemode/T in subtypesof(/datum/gamemode)-/datum/gamemode/cult)
+	for (var/t in subtypesof(/datum/gamemode)-/datum/gamemode/cult)
+		var/datum/gamemode/T = t
 		if (initial(T.name) && initial(T.name) == mode_name)
-			return T
+			world.log << "Returning [initial(T.name)]"
+			return new T
 	return new /datum/gamemode/extended()
 
 /datum/configuration/proc/get_runnable_modes()

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -728,7 +728,6 @@
 	for (var/t in subtypesof(/datum/gamemode)-/datum/gamemode/cult)
 		var/datum/gamemode/T = t
 		if (initial(T.name) && initial(T.name) == mode_name)
-			world.log << "Returning [initial(T.name)]"
 			return new T
 	return new /datum/gamemode/extended()
 

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -142,6 +142,7 @@ var/datum/controller/gameticker/ticker
 			var/mtype = src.mode.type
 			src.mode = new mtype
 	else if (master_mode=="secret")
+		world.log << "Picking dynamic mode"
 		mode = config.pick_mode("Dynamic Mode") //Huzzah
 	else
 		src.mode = config.pick_mode(master_mode)

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -142,7 +142,6 @@ var/datum/controller/gameticker/ticker
 			var/mtype = src.mode.type
 			src.mode = new mtype
 	else if (master_mode=="secret")
-		world.log << "Picking dynamic mode"
 		mode = config.pick_mode("Dynamic Mode") //Huzzah
 	else
 		src.mode = config.pick_mode(master_mode)


### PR DESCRIPTION
#19853 didn't work because `subtypesof()` returns a list of typepaths ; the loop looped over actual gamemode entities over a typelist
Additionally, it returned a typepath instead of an actual mode which would have caused the roundstart to runtime anyways, so it was actually a blessing in disguise

Tested
![image](https://user-images.githubusercontent.com/31417754/46239117-7e2fe400-c383-11e8-8ebb-a31fc35e36e3.png)
