### PR TITLE
Dynamic mode turndown

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -62,7 +62,7 @@
 	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
 	required_candidates = 1
 	weight = 3
-	cost = 10
+	cost = 30
 	requirements = list(90,90,70,40,30,20,10,10,10,10)
 	logo = "raginmages-logo"
 

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -12,7 +12,7 @@
 	required_candidates = 1
 	weight = 7
 	cost = 5
-	requirements = list(40,30,20,10,10,10,10,10,10,10)
+	requirements = list(50,40,30,20,10,10,10,10,10,10)
 
 /datum/dynamic_ruleset/midround/autotraitor/acceptable(var/population=0,var/threat=0)
 	var/player_count = mode.living_players.len

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -258,7 +258,7 @@
 	required_candidates = 0
 	weight = 3
 	cost = 0
-	requirements = list(0,0,0,0,0,0,0,0,0,0)
+	requirements = list(101,101,101,101,101,101,101,101,101,101) // So that's not possible to roll it naturally
 
 /datum/dynamic_ruleset/roundstart/extended/execute()
 	message_admins("Starting a round of extended.")

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -50,7 +50,7 @@
 	required_enemies = list(1,1,0,0,0,0,0,0,0,0)
 	required_candidates = 1
 	weight = 3
-	cost = 15
+	cost = 30
 	requirements = list(80,60,40,20,20,10,10,10,10,10)
 
 /datum/dynamic_ruleset/roundstart/changeling/execute()
@@ -108,7 +108,7 @@
 	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
 	required_candidates = 1
 	weight = 3
-	cost = 20
+	cost = 30
 	requirements = list(90,90,70,40,30,20,10,10,10,10)
 
 /datum/dynamic_ruleset/roundstart/wizard/acceptable(var/population=0,var/threat=0)
@@ -242,3 +242,25 @@
 	unction.HandleRecruitedRole(AI)
 	AI.Greet(GREET_ROUNDSTART)
 	return 1
+
+//////////////////////////////////////////////
+//                                          //
+//               EXTENDED                   ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//                                          //
+//////////////////////////////////////////////
+
+/datum/dynamic_ruleset/roundstart/extended
+	name = "Extended"
+	role_category = null
+	restricted_from_jobs = list()//just to be sure that a wizard getting picked won't ever imply a Captain or HoS not getting drafted
+	enemy_jobs = list()
+	required_enemies = list(0,0,0,0,0,0,0,0,0,0)
+	required_candidates = 0
+	weight = 3
+	cost = 0
+	requirements = list(0,0,0,0,0,0,0,0,0,0)
+
+/datum/dynamic_ruleset/roundstart/extended/execute()
+	message_admins("Starting a round of extended.")
+	log_admin("Starting a round of extended.")
+	return TRUE

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -252,7 +252,7 @@
 /datum/dynamic_ruleset/roundstart/extended
 	name = "Extended"
 	role_category = null
-	restricted_from_jobs = list()//just to be sure that a wizard getting picked won't ever imply a Captain or HoS not getting drafted
+	restricted_from_jobs = list()
 	enemy_jobs = list()
 	required_enemies = list(0,0,0,0,0,0,0,0,0,0)
 	required_candidates = 0


### PR DESCRIPTION
Dynamic is a wonderful piece of code, don't get me wrong, but I think it currently puts too much antags in the round too early.
This PR ups the threat cost of changelings, midround wiz, and make it slightly less likely to happen.

This also adds an "extended" roundstart ruleset, with a slightly low chance of getting picked.
The threat requirement and cost is null, so roundstart extended is more likely to turn into late nukies, for instance.

Tested

:cl:
- rscadd: Re-adds extended as a possible roundstart ruleset.
- rscadd: Ups the threat level of changelings & wizards. Effectively, you should see them slightly less often.