### PR TITLE
Fixing Merchant Fax

### DIFF
--- a/code/WorkInProgress/kilakk/fax.dm
+++ b/code/WorkInProgress/kilakk/fax.dm
@@ -238,13 +238,7 @@ proc/SendFax(var/sent, var/sentname, var/mob/Sender, var/dpt, var/centcomm, var/
 				playsound(F.loc, "sound/effects/fax.ogg", 50, 1)
 
 				if(centcomm)
-					var/image/stampoverlay = image('icons/obj/bureaucracy.dmi')
-					stampoverlay.icon_state = "paper_stamp-cent"
-					if(!P.stamped)
-						P.stamped = new
-					P.stamped += /obj/item/weapon/stamp
-					P.overlays += stampoverlay
-					P.stamps += "<HR><i>This paper has been stamped by the Central Command Quantum Relay.</i>"
+					CentcommStamp(P)
 
 				// give the sprite some time to flick
 				spawn(20)
@@ -252,3 +246,23 @@ proc/SendFax(var/sent, var/sentname, var/mob/Sender, var/dpt, var/centcomm, var/
 
 				faxed = P //doesn't return here in case there's multiple faxes in the department
 	return faxed
+
+/proc/CentcommStamp(var/obj/item/weapon/paper/P)
+	var/image/stampoverlay = image('icons/obj/bureaucracy.dmi')
+	stampoverlay.icon_state = "paper_stamp-cent"
+	if(!P.stamped)
+		P.stamped = new
+	P.stamped += /obj/item/weapon/stamp
+	P.overlays += stampoverlay
+	P.stamps += "<HR><i>This paper has been stamped by the Central Command Quantum Relay.</i>"
+
+/proc/SendMerchantFax(mob/living/carbon/human/merchant)
+	var/obj/item/weapon/paper/merchantreport/P
+	for(var/obj/machinery/faxmachine/F in allfaxes)
+		if(F.department == "Internal Affairs" && !F.stat)
+			flick("faxreceive", F)
+			playsound(F.loc, "sound/effects/fax.ogg", 50, 1)
+			P = new /obj/item/weapon/paper/merchantreport(F,merchant)
+			spawn(2 SECONDS)
+				P.forceMove(F.loc)
+	return P

--- a/code/game/jobs/job/whitelisted.dm
+++ b/code/game/jobs/job/whitelisted.dm
@@ -80,35 +80,9 @@
 
 	if(M.mind.role_alt_title == "Merchant")
 		to_chat(M, "<B><span class='info'>Your merchant's license paperwork has just cleared with Nanotrasen HQ. You have a loyalty implant and the staff has been notified that you are active in this sector.</span></B>")
-		notify_crew(M)
+		SendMerchantFax(M)
 
 	to_chat(M, "<b>Despite not being a member of the crew, by default you are <u>not</u> an antagonist. Cooperating with antagonists is allowed - within reason. Ask admins via adminhelp if you're not sure.</b>")
 
 	if(req_admin_notify)
 		to_chat(M, "<b>You are playing a job that is important for Game Progression. If you have to disconnect, please notify the admins via adminhelp.</b>")
-
-
-/datum/job/trader/proc/notify_crew(mob/living/carbon/human/merchant)
-	merchant.client.prefs.update_preview_icon(0) //This is necessary because if they don't check their character sheet it never generates!
-	var/preview_front = fcopy_rsc(merchant.client.prefs.preview_icon_front)
-	var/preview_side = fcopy_rsc(merchant.client.prefs.preview_icon_side)
-	world << browse_rsc(preview_front, "previewicon.png")
-	world << browse_rsc(preview_side, "previewicon2.png")
-	var/full_text = {"<html><style>
-					body {color: #000000; background: #ccffff;}
-					h1 {color: #000000; font-size:30px;}
-					fieldset {width:140px;}
-					</style>
-					<body>
-					<center><img src="http://ss13.moe/wiki/images/1/17/NanoTrasen_Logo.png"> <h1>ATTN: Internal Affairs</h1></center>
-					Nanotrasen\'s commercial arm has noted the presence of a registered merchant who holds a license for corporate commerce, a process which includes a background check and Nanotrasen loyalty implant. The associate\'s image is enclosed. Please continue to monitor trade on an ongoing basis such that Nanotrasen can maintain highest standard small business enterprise (SBE) partners.<BR>
-					</body>
-					<fieldset>
-  					<legend>Picture</legend>
-					<center><img src="previewicon.png" width="64" height="64"><img src="previewicon2.png" width="64" height="64"></center>
-					</fieldset><BR>
-					<body>Name: [merchant.client.prefs.real_name]<BR>
-					Blood Type: [merchant.dna.b_type]<BR>
-					Fingerprint: [md5(merchant.dna.uni_identity)]</body></html>"}
-
-	SendFax(full_text, "Licensed Merchant Report - [merchant.client.prefs.real_name]", centcomm = 1) //Wow this is really cumbersome but [name] hasn't been assigned yet

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -565,12 +565,11 @@ var/global/list/paper_folding_results = list ( \
 						<body>
 						<center><img src="http://ss13.moe/wiki/images/1/17/NanoTrasen_Logo.png"> <h1>ATTN: Internal Affairs</h1></center>
 						Nanotrasen\'s commercial arm has noted the presence of a registered merchant who holds a license for corporate commerce, a process which includes a background check and Nanotrasen loyalty implant. The associate\'s image is enclosed. Please continue to monitor trade on an ongoing basis such that Nanotrasen can maintain highest standard small business enterprise (SBE) partners.<BR>
-						</body>
 						<fieldset>
 	  					<legend>Picture</legend>
 						<center><img src="previewicon.png" width="64" height="64"><img src="previewicon2.png" width="64" height="64"></center>
 						</fieldset><BR>
-						<body>Name: [identity]<BR>
+						Name: [identity]<BR>
 						Blood Type: [merchant.dna.b_type]<BR>
 						Fingerprint: [md5(merchant.dna.uni_identity)]</body></html>"}
 		display_y = 700

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -545,3 +545,41 @@ var/global/list/paper_folding_results = list ( \
 
 /obj/item/weapon/paper/manifest
 	name = "Supply Manifest"
+
+/obj/item/weapon/paper/merchantreport
+	var/identity
+	var/list/mugshots = list()
+
+/obj/item/weapon/paper/merchantreport/New(loc,mob/living/carbon/human/merchant)
+	if(merchant)
+		identity = merchant.client.prefs.real_name
+		name = "Licensed Merchant Report - [identity]"
+		merchant.client.prefs.update_preview_icon(0) //This is necessary because if they don't check their character sheet it never generates!
+		mugshots += fcopy_rsc(merchant.client.prefs.preview_icon_front)
+		mugshots += fcopy_rsc(merchant.client.prefs.preview_icon_side)
+		info = {"<html><style>
+						body {color: #000000; background: #ccffff;}
+						h1 {color: #000000; font-size:30px;}
+						fieldset {width:140px;}
+						</style>
+						<body>
+						<center><img src="http://ss13.moe/wiki/images/1/17/NanoTrasen_Logo.png"> <h1>ATTN: Internal Affairs</h1></center>
+						Nanotrasen\'s commercial arm has noted the presence of a registered merchant who holds a license for corporate commerce, a process which includes a background check and Nanotrasen loyalty implant. The associate\'s image is enclosed. Please continue to monitor trade on an ongoing basis such that Nanotrasen can maintain highest standard small business enterprise (SBE) partners.<BR>
+						</body>
+						<fieldset>
+	  					<legend>Picture</legend>
+						<center><img src="previewicon.png" width="64" height="64"><img src="previewicon2.png" width="64" height="64"></center>
+						</fieldset><BR>
+						<body>Name: [identity]<BR>
+						Blood Type: [merchant.dna.b_type]<BR>
+						Fingerprint: [md5(merchant.dna.uni_identity)]</body></html>"}
+		display_y = 700
+		CentcommStamp(src)
+	..()
+
+/obj/item/weapon/paper/merchantreport/show_text(var/mob/user, var/links = FALSE, var/starred = FALSE)
+	var/index = 1
+	for(var/image in mugshots)
+		user << browse_rsc(image, "previewicon-[identity][index].png")
+		index++
+	..()


### PR DESCRIPTION
When I wrote Trader 2 it was mostly in ignorance of how browse rsc works, now I understand a bit better. These were bugs:
* All reports showed the pictures of the latest merchant to join
* If you joined after the merchant it would be blank (because it sent out the image to everyone who was logged in at the moment the merchant joined)
* Worse, if you joined after the merchant and had viewed your character preferences before spawning in, you'd see yourself in the fax!
* Every fax was spammed with reports mostly aimed at the IAA

New functionality
* Each image gets a unique ID, no overlap
* Image sent only to the paper's reader and in real time rather than just when the merchant spawns
* Only sends to the IAA office (in the case of Roidstation, both IAA offices)
* Changed the fax on Packedstation bridge to be an IAA fax (since there is no IAA Office)
* Made the Metaclub IAA fax an IAA fax

🆑 
* bugfix: Merchant reports now only go to Internal Affairs and should not have buggy pictures.