### PR TITLE
Potassium Hydroxide and Bar Soap Production

### DIFF
--- a/__DEFINES/reagents.dm
+++ b/__DEFINES/reagents.dm
@@ -13,6 +13,7 @@
 #define TOXIN 			"toxin"
 #define PLASTICIDE 			"plasticide"
 #define CYANIDE "cyanide"
+#define POTASSIUM_HYDROXIDE 			"potassium_hydroxide"
 #define CHEFSPECIAL 			"chefspecial"
 #define MINTTOXIN 			"minttoxin"
 #define MUTATIONTOXIN 			"mutationtoxin"

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -603,7 +603,7 @@
 	if(holder.has_any_reagents(list(SACID, FORMIC_ACID)))
 		holder.remove_reagents(list(SACID, FORMIC_ACID), REM)
 	if(holder.has_reagent(POTASSIUM_HYDROXIDE))
-		holder.remove_reagents(POTASSIUM_HYDROXIDE, 2 * REM)
+		holder.remove_reagent(POTASSIUM_HYDROXIDE, 2 * REM)
 	if(holder.has_reagent(CYANIDE))
 		holder.remove_reagent(CYANIDE, REM)
 	if(holder.has_reagent(AMATOXIN))

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -602,6 +602,8 @@
 		holder.remove_reagent(PLASMA, REM)
 	if(holder.has_any_reagents(list(SACID, FORMIC_ACID)))
 		holder.remove_reagents(list(SACID, FORMIC_ACID), REM)
+	if(holder.has_reagent(POTASSIUM_HYDROXIDE))
+		holder.remove_reagents(POTASSIUM_HYDROXIDE, 2 * REM)
 	if(holder.has_reagent(CYANIDE))
 		holder.remove_reagent(CYANIDE, REM)
 	if(holder.has_reagent(AMATOXIN))
@@ -690,6 +692,24 @@
 	M.adjustToxLoss(4)
 	M.adjustOxyLoss(4)
 	M.sleeping += 1
+
+/datum/reagent/potassium_hydroxide
+	name = "Potassium Hydroxide"
+	id = POTASSIUM_HYDROXIDE
+	description = "A corrosive chemical used in making soap and batteries."
+	reagent_state = REAGENT_STATE_SOLID
+	overdose_am = REAGENTS_OVERDOSE
+	custom_metabolism = 0.1
+	color = "#ffffff" //rgb: 255, 255, 255
+	density = 2.12
+	specheatcap = 65.87 //how much energy in joules it takes to heat this thing up by 1 degree (J/g). round to 2dp
+
+/datum/reagent/potassium_hydroxide/on_mob_life(var/mob/living/M)
+
+	if(..())
+		return 1
+
+	M.adjustFireLoss(REM)
 
 //Quiet and lethal, needs at least 4 units in the person before they'll die
 /datum/reagent/chefspecial

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -94,7 +94,7 @@
 	name = "Soap"
 	id = "soap"
 	result = null
-	required_reagents = list(POTASSIUM_HYDROXIDE = 20, CORNOIL = 5)
+	required_reagents = list(POTASSIUM_HYDROXIDE = 20, NUTRIMENT = 5)
 	required_temp = T0C + 50
 	result_amount = 1
 

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -68,6 +68,7 @@
 	required_reagents = list(WATER = 1, POTASSIUM = 1)
 	result_amount = 2
 	alert_admins = ALERT_AMOUNT_ONLY
+	secondary = 1
 
 /datum/chemical_reaction/explosion_potassium/on_reaction(var/datum/reagents/holder, var/created_volume)
 	var/datum/effect/effect/system/reagents_explosion/e = new()
@@ -82,8 +83,24 @@
 	if(!holder.my_atom.is_open_container() || ismob(holder.my_atom))
 		holder.del_reagent(POTASSIUM)
 		holder.del_reagent(WATER)
+		holder.add_reagent(POTASSIUM_HYDROXIDE, created_volume)
+		holder.add_reagent(HYDROGEN, created_volume * REM)
 	else
 		holder.clear_reagents()
+		holder.add_reagent(POTASSIUM_HYDROXIDE, created_volume)
+		holder.add_reagent(HYDROGEN, created_volume * REM)
+
+/datum/chemical_reaction/soap //Potassium Hydroxide is used in making liquid soap not bar soap but that will not stop me
+	name = "Soap"
+	id = "soap"
+	result = null
+	required_reagents = list(POTASSIUM_HYDROXIDE = 20, CORNOIL = 5)
+	required_temp = T0C + 50
+	result_amount = 1
+
+/datum/chemical_reaction/soap/on_reaction(var/datum/reagents/holder, var/created_volume)
+	var/location = get_turf(holder.my_atom)
+	new /obj/item/weapon/soap(location)
 
 /datum/chemical_reaction/creatine
 	name = "Creatine"


### PR DESCRIPTION
This pull request adds potassium hydroxide.
To be clear, this is being done explicitly to reintroduce water potassium purging chemicals from closed containers, but that will be in a separate PR.  While this PR could exist on its own, I want to make it clear what my motivation is.

Potassium hydroxide is a chemical resultant from combining water and potassium.  It is corrosive, doing slight burn damage while inside the body.  It has a custom metabolism of 0.1 and is removed at a rate of (2 * REM) by anti-toxin.  Damage and metabolism numbers can be adjusted as needed for balance.  It is used in the making of soap.  Combined with corn oil and heated in a Bunsen burner will result in a bar of soap.  In real life, it is used in making liquid soap, but I made it make bar soap instead as people often find bar soap difficult to get a hold of, requiring spawn locations, the biogenerator, or an uplink.
The description mentions batteries, but it is not currently used in making batteries in game nor do I plan on making it.  That is just intended to be fun trivia/flavor.

Compiled and tested locally.

:cl:
 * rscadd: Added potassium hydroxide
 * rscadd: Soap can now be made at a Bunsen burner using potassium hydroxide and nutriment