### PR TITLE
Removes highly classified exploit

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -3,6 +3,13 @@
 	~Sayu
 */
 
+//A workaround for a BYOND bug (or at least weird behavior). It's classified.
+/client/Click(object, location, control, params)
+	var/list/p = params2list(params)
+	if(p["drag"])
+		return
+	..()
+
 /*
 	Before anything else, defer these calls to a per-mobtype handler.  This allows us to
 	remove istype() spaghetti code, but requires the addition of other handler procs to simplify it.


### PR DESCRIPTION
This is a shitty workaround for a BYOND bug, which is too exploitable to let Lummox take his time in fixing
Hopefully it will be fixed at some point, in which case this should be reverted