### PR TITLE
Fixes Doppelgangers Stunlocking Their Wizard

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/human/wizard.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/wizard.dm
@@ -59,7 +59,7 @@
 
 /mob/living/simple_animal/hostile/humanoid/wizard/doppelganger/New()
 	..()
-	var/spell/S = new /spell/targeted/projectile/magic_missile
+	var/spell/S = new /spell/targeted/projectile/magic_missile/spare_stunned
 	spell = S
 	add_spell(S, src)
 

--- a/code/modules/spells/targeted/projectile/magic_missile.dm
+++ b/code/modules/spells/targeted/projectile/magic_missile.dm
@@ -31,6 +31,13 @@
 		apply_spell_damage(M)
 	return
 
+/spell/targeted/projectile/magic_missile/spare_stunned/choose_prox_targets(mob/user = usr, var/atom/movable/spell_holder) //This version of magic missile doesn't hit stunned mobs.
+	var/list/targets = ..()
+	for(var/mob/living/M in targets)
+		if(M.stunned)
+			targets.Remove(M)
+	return targets
+
 //PROJECTILE
 
 /obj/item/projectile/spell_projectile/seeking/magic_missile


### PR DESCRIPTION
Fixes #16445.
The main problem was not that doppelgangers could hit their wizard, but that they never stopped firing due to the target opposite the wizard never being downed by a projectile. This resulted in the wizard being stunlocked to death.
The magic missile projectiles fired by doppelgangers have been changed to ignore stunned mobs, so the wizard should only be hit once before being able to get away if he happens to stray into the line of fire.

:cl:
 * bugfix: Magic missiles fired by doppelgangers no longer hit stunned mobs, so wizards can't get stunlocked by their clones if they end up between one and its target.