### PR TITLE
Fixes Phazon Mutation Allowing Mobs with No Fat Sprites to Be Fat

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1707,7 +1707,7 @@ mob/living/carbon/human/isincrit()
 		species.chem_flags = rand(0,65535)
 
 	if(!can_be_fat)
-		species.anatomy_flags ^= CAN_BE_FAT
+		species.anatomy_flags &= ~CAN_BE_FAT
 
 /mob/living/carbon/human/send_to_past(var/duration)
 	..()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1697,12 +1697,17 @@ mob/living/carbon/human/isincrit()
 	species.burn_mod *= rand(5,20)/10
 	species.tox_mod *= rand(5,20)/10
 
+	var/can_be_fat = species.anatomy_flags & CAN_BE_FAT	//removing this flag causes gamebreaking things like invisible fat aliens to happen
+
 	if(prob(5))
 		species.flags = rand(0,65535)
 	if(prob(5))
 		species.anatomy_flags = rand(0,65535)
 	if(prob(5))
 		species.chem_flags = rand(0,65535)
+
+	if(!can_be_fat)
+		species.anatomy_flags ^= CAN_BE_FAT
 
 /mob/living/carbon/human/send_to_past(var/duration)
 	..()


### PR DESCRIPTION
Prevents mobs from gaining the `CAN_BE_FAT` flag via phazon mutation if they did not already have it.
Did not actually test this one, but I don't see any reason why it wouldn't work.
Fixes #16725.

:cl:
 * bugfix: Phazon mutation will no longer allow species to become fat if they can't already, to prevent icon errors.
