### PR TITLE
Chameleon Overlays fix

### DIFF
--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -51,7 +51,7 @@
 			saved_item = target.type
 			saved_icon = target.icon
 			saved_icon_state = target.icon_state
-			saved_overlays = target.overlays
+			saved_overlays = target.overlays.Copy()
 			return 1
 
 /obj/item/device/chameleon/proc/toggle()


### PR DESCRIPTION
So you're not holding the memory location of the overlays, but just copying the overlays at that time.

closes #19540
