### PR TITLE
Patient Rooms Made Radproof

### DIFF
--- a/code/modules/events/radiation_storm.dm
+++ b/code/modules/events/radiation_storm.dm
@@ -14,6 +14,9 @@
 		/area/medical/coldstorage,
 		/area/mine,
 		/area/prison,
+		/area/medical/patients_rooms,
+		/area/medical/patient_room1,
+		/area/medical/patient_room2
 	)
 
 


### PR DESCRIPTION
I know what you're thinking, and this has nothing to do with nerfing genetics gas chambers. Filling another thread request.

🆑 
* tweak: The patient rooms are now safe from radiation storms, making them a good place to store braindead crewmembers.