### PR TITLE
Medbelt Buffs

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -142,6 +142,11 @@
 	desc = "Can hold various medical equipment."
 	icon_state = "medicalbelt"
 	item_state = "medical"
+	storage_slots = 21
+	max_combined_w_class = 21
+	allow_quick_gather = TRUE
+	allow_quick_empty = TRUE
+	use_to_pickup = TRUE
 	can_only_hold = list(
 		"/obj/item/device/healthanalyzer",
 		"/obj/item/weapon/dnainjector",
@@ -162,7 +167,9 @@
 		"/obj/item/device/mass_spectrometer",
 		"/obj/item/device/gps/paramedic",
 		"/obj/item/device/antibody_scanner",
-		"/obj/item/weapon/switchtool/surgery"
+		"/obj/item/weapon/switchtool/surgery",
+		"/obj/item/weapon/grenade/chem_grenade",
+		"/obj/item/weapon/electrolyzer"
 	)
 
 /obj/item/weapon/storage/belt/slim


### PR DESCRIPTION
@I-VAPE-VOX-CLOACA-EVERY-DAY-OF-MY-LIFE 

🆑 
* tweak: Medical belts can now hold up to 21 size worth of items (most compatible items, such as pills, syringes, health analyzers, etc. are tiny/size 1).
* tweak: Medical belts can now hold chemical grenades, grenade casings, and electrolyzers.
* tweak: Medical belts can now quickgather/quickdrop like plastic bags