### PR TITLE
Fixes Eternal Fire Safety

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1065,7 +1065,7 @@ Thanks.
 	else if(iscarbon(L))
 		var/mob/living/carbon/CM = L
 	//putting out a fire
-		if(CM.on_fire && CM.canmove)
+		if(CM.on_fire && CM.canmove && ((!locate(/obj/effect/fire) in loc) || !CM.handcuffed))	//No point in putting ourselves out if we'd just get set on fire again. Unless there's nothing more pressing to resist out of, in which case go nuts.
 			CM.fire_stacks -= 5
 			CM.SetKnockdown(3)
 			playsound(CM.loc, 'sound/effects/bodyfall.ogg', 50, 1)


### PR DESCRIPTION
If you are handcuffed and also on fire, Resist will now prioritize uncuffing yourself if the tile you are on is still on fire, and therefore extinguishing yourself would do no good. Otherwise, you extinguish yourself first as per usual.
Fixes #4681.
Fixes #10037.

:cl:
 * bugfix: Being cuffed while inside a fire will no longer make you unable to uncuff yourself.
