### PR TITLE
Fixes Gender Hair Randomization in Character Preferences

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1381,8 +1381,8 @@ NOTE:  The change will take effect AFTER any current recruiting periods."}
 						gender = FEMALE
 					else
 						gender = MALE
-					f_style = random_facial_hair_style(gender)
-					h_style = random_hair_style(gender)
+					f_style = random_facial_hair_style(gender, species)
+					h_style = random_hair_style(gender, species)
 
 				if("hear_adminhelps")
 					toggles ^= SOUND_ADMINHELP


### PR DESCRIPTION
Switching gender in the character creation menu no longer causes your character to receive random hair incompatible with its species.
Fixes #4052.
