### PR TITLE
Fixes DNA Consoles Labeling DNA of Disfigured People "Unknown"

### DIFF
--- a/code/defines/obj.dm
+++ b/code/defines/obj.dm
@@ -53,6 +53,12 @@
 					return R
 	return null
 
+/obj/effect/datacore/proc/find_record_by_dna(var/target_dna, var/list/which)
+	for (var/datum/data/record/E in which)
+		if (E.fields["b_dna"] == target_dna)
+			return E
+	return null
+
 /obj/effect/datacore/proc/find_general_record_by_name(var/target_name)
 	for(var/datum/data/record/E in general)
 		if(E.fields["name"] == target_name)
@@ -61,6 +67,9 @@
 
 /obj/effect/datacore/proc/find_medical_record_by_name(var/target_name)
 	return find_record_by_name(target_name, medical)
+
+/obj/effect/datacore/proc/find_medical_record_by_dna(var/target_dna)
+	return find_record_by_dna(target_dna, medical)
 
 /obj/effect/datacore/proc/find_security_record_by_name(var/target_name)
 	return find_record_by_name(target_name, security)

--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -970,7 +970,11 @@
 				databuf.types = DNA2_BUF_UI // DNA2_BUF_UE
 				databuf.dna = src.connected.occupant.dna.Clone()
 				if(ishuman(connected.occupant))
-					databuf.dna.real_name=connected.occupant.real_name
+					var/datum/data/record/med_record = data_core.find_medical_record_by_dna(connected.occupant.dna.unique_enzymes)
+					if(med_record)
+						databuf.dna.real_name = med_record.fields["name"]
+					else
+						databuf.dna.real_name=connected.occupant.name
 					databuf.dna.flavor_text=connected.occupant.flavor_text
 				databuf.name = "Unique Identifier"
 				src.buffers[bufferId] = databuf
@@ -985,7 +989,11 @@
 				databuf.types = DNA2_BUF_UI|DNA2_BUF_UE
 				databuf.dna = src.connected.occupant.dna.Clone()
 				if(ishuman(connected.occupant))
-					databuf.dna.real_name=connected.occupant.real_name
+					var/datum/data/record/med_record = data_core.find_medical_record_by_dna(connected.occupant.dna.unique_enzymes)
+					if(med_record)
+						databuf.dna.real_name = med_record.fields["name"]
+					else
+						databuf.dna.real_name=connected.occupant.name
 					databuf.dna.flavor_text=connected.occupant.flavor_text
 				databuf.name = "Unique Identifier + Unique Enzymes"
 				src.buffers[bufferId] = databuf
@@ -1000,7 +1008,11 @@
 				databuf.types = DNA2_BUF_SE
 				databuf.dna = src.connected.occupant.dna.Clone()
 				if(ishuman(connected.occupant))
-					databuf.dna.real_name=connected.occupant.real_name
+					var/datum/data/record/med_record = data_core.find_medical_record_by_dna(connected.occupant.dna.unique_enzymes)
+					if(med_record)
+						databuf.dna.real_name = med_record.fields["name"]
+					else
+						databuf.dna.real_name=connected.occupant.name
 				databuf.name = "Structural Enzymes"
 				src.buffers[bufferId] = databuf
 			return 1

--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -970,7 +970,7 @@
 				databuf.types = DNA2_BUF_UI // DNA2_BUF_UE
 				databuf.dna = src.connected.occupant.dna.Clone()
 				if(ishuman(connected.occupant))
-					databuf.dna.real_name=connected.occupant.name
+					databuf.dna.real_name=connected.occupant.real_name
 					databuf.dna.flavor_text=connected.occupant.flavor_text
 				databuf.name = "Unique Identifier"
 				src.buffers[bufferId] = databuf
@@ -985,7 +985,7 @@
 				databuf.types = DNA2_BUF_UI|DNA2_BUF_UE
 				databuf.dna = src.connected.occupant.dna.Clone()
 				if(ishuman(connected.occupant))
-					databuf.dna.real_name=connected.occupant.name
+					databuf.dna.real_name=connected.occupant.real_name
 					databuf.dna.flavor_text=connected.occupant.flavor_text
 				databuf.name = "Unique Identifier + Unique Enzymes"
 				src.buffers[bufferId] = databuf
@@ -1000,7 +1000,7 @@
 				databuf.types = DNA2_BUF_SE
 				databuf.dna = src.connected.occupant.dna.Clone()
 				if(ishuman(connected.occupant))
-					databuf.dna.real_name=connected.occupant.name
+					databuf.dna.real_name=connected.occupant.real_name
 				databuf.name = "Structural Enzymes"
 				src.buffers[bufferId] = databuf
 			return 1


### PR DESCRIPTION
DNA consoles now check the medical records for the subject's DNA first, and use the name associated with the DNA if found. Otherwise, the subject's display name is used.
Technically a balance change, I think, since you can now reveal anyone's true identity through use of a genetics console if they're in the medical records.
Fixes #4387.

:cl:
 * bugfix: The DNA of disfigured people will no longer be labeled "Unknown" by DNA consoles if the person is in the medical records.
