### PR TITLE
Fixes pAIs still displaying a !!! after their ghost becomes another ghost role

### DIFF
--- a/code/datums/recruiter.dm
+++ b/code/datums/recruiter.dm
@@ -68,6 +68,7 @@
 		if(!check_observer(O))
 			INVOKE_EVENT(recruited, list("player"=null))
 		else
+			paiController.was_recruited(O)
 			INVOKE_EVENT(recruited, list("player"=O))
 
 /datum/recruiter/Topic(var/href, var/list/href_list)

--- a/code/modules/mob/living/silicon/pai/recruit.dm
+++ b/code/modules/mob/living/silicon/pai/recruit.dm
@@ -226,3 +226,17 @@ var/datum/paiController/paiController			// Global handler for pAI candidates
 				asked[C.key] = INFINITY
 			else
 				question(C)
+
+
+/datum/paiController/proc/was_recruited(var/mob/dead/observer/O)
+	if (!istype(O))
+		return
+
+	for(var/datum/paiCandidate/c in pai_candidates)
+		if(c.key == O.key)
+			pai_candidates -= c // We remove them from the list
+			break
+
+	for(var/obj/item/device/paicard/p in paicard_list)
+		if(!p.pai && !pai_candidates.len)
+			p.removeNotification()


### PR DESCRIPTION
Fixes #19654 

Ideally you'd use another event, or rewrite the pAI controller to be a subtype of the recruiter datum, but this works fairly well and for any kind of recruiter (ragin' mages, dionae, posibrain...)