### PR TITLE
Fixes a runtime with attack delayers

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -135,7 +135,7 @@
 					resolved = M.attackby(held_item,src,def_zone = def_zone, params)
 				else
 					resolved = A.attackby(held_item, src, params)
-				if(ismob(A) || istype(A, /obj/mecha) || istype(held_item, /obj/item/weapon/grab))
+				if((ismob(A) || istype(A, /obj/mecha) || istype(held_item, /obj/item/weapon/grab)) && !A.gcDestroyed)
 					delayNextAttack(item_attack_delay)
 				if(!resolved && A && !A.gcDestroyed && held_item)
 					held_item.afterattack(A,src,1,params) // 1 indicates adjacency

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -243,8 +243,9 @@ obj/item/proc/get_clamped_volume()
 
 
 /obj/item/proc/on_attack(var/atom/attacked, var/mob/user)
-	user.do_attack_animation(attacked, src)
-	user.delayNextAttack(attack_delay)
+	if (!user.gcDestroyed)
+		user.do_attack_animation(attacked, src)
+		user.delayNextAttack(attack_delay)
 	if(hitsound)
 		playsound(attacked.loc, hitsound, 50, 1, -1)
 	if(material_type)

--- a/code/modules/mob/delays.dm
+++ b/code/modules/mob/delays.dm
@@ -47,9 +47,13 @@
 		client.move_delayer.delayNext(delay,additive)
 
 /mob/proc/delayNextAttack(var/delay, var/additive=0)
+	if (!attack_delayer)
+		return
 	attack_delayer.delayNext(delay,additive)
 
 /mob/proc/delayNextSpecial(var/delay, var/additive=0)
+	if (!special_delayer)
+		return
 	special_delayer.delayNext(delay,additive)
 
 /mob/proc/delayNext(var/types, var/delay, var/additive=0)

--- a/code/modules/mob/delays.dm
+++ b/code/modules/mob/delays.dm
@@ -47,13 +47,9 @@
 		client.move_delayer.delayNext(delay,additive)
 
 /mob/proc/delayNextAttack(var/delay, var/additive=0)
-	if (!attack_delayer)
-		return
 	attack_delayer.delayNext(delay,additive)
 
 /mob/proc/delayNextSpecial(var/delay, var/additive=0)
-	if (!special_delayer)
-		return
 	special_delayer.delayNext(delay,additive)
 
 /mob/proc/delayNext(var/types, var/delay, var/additive=0)


### PR DESCRIPTION
When trying to solve #19588, I wasn't able to reproduce the issue (`mob.death()` is called correctly),  but I did find this runtime

```
[19:12:23] Runtime in delays.dm,50: Cannot execute null.delayNext().
  proc name: delayNextAttack (/mob/proc/delayNextAttack)
  usr: Trinity () (/mob/living/simple_animal/hologram/advanced)
  usr.loc: (nullspace)
  src: Trinity (/mob/living/simple_animal/hologram/advanced)
  src.loc: null
  call stack:
  Trinity (/mob/living/simple_animal/hologram/advanced): delayNextAttack(10, 0)
  the energy axe (/obj/item/weapon/melee/energy/axe): on attack(Trinity (/mob/living/simple_animal/hologram/advanced), Trinity (/mob/living/simple_animal/hologram/advanced))
  the energy axe (/obj/item/weapon/melee/energy/axe): handle attack(the energy axe (/obj/item/weapon/melee/energy/axe), Trinity (/mob/living/simple_animal/hologram/advanced), Trinity (/mob/living/simple_animal/hologram/advanced), null, null)
```

Apparently, mobs that kill themseles with a weapon and whose body instantly gets qdel'd cause a runtime.
I'll see if this affects normal attacks but it shouldn't