### PR TITLE
Fixes Akimbo dropping

### DIFF
--- a/code/modules/mob/living/simple_animal/hologram/hologram.dm
+++ b/code/modules/mob/living/simple_animal/hologram/hologram.dm
@@ -97,6 +97,10 @@
 	head = null
 	w_uniform = null
 	wear_suit = null
+	for (var/i = 1 to held_items.len)
+		var/obj/item/O = held_items[i]
+		if (O)
+			O.dropped(src)
 	if(connected_holoconsole)
 		connected_holoconsole.connected_holopeople.Remove(src)
 		connected_holoconsole = null
@@ -118,7 +122,6 @@
 		dissipate()
 
 /mob/living/simple_animal/hologram/proc/dissipate()
-	transmogrify()
 	qdel(src)
 
 /mob/living/simple_animal/hologram/advanced/can_wield()

--- a/code/modules/mob/living/simple_animal/hologram/hologram.dm
+++ b/code/modules/mob/living/simple_animal/hologram/hologram.dm
@@ -97,10 +97,8 @@
 	head = null
 	w_uniform = null
 	wear_suit = null
-	for (var/i = 1 to held_items.len)
-		var/obj/item/O = held_items[i]
-		if (O)
-			O.dropped(src)
+	for (var/obj/item/O in held_items)
+		O.dropped(src)
 	if(connected_holoconsole)
 		connected_holoconsole.connected_holopeople.Remove(src)
 		connected_holoconsole = null

--- a/code/modules/projectiles/guns/akimbo.dm
+++ b/code/modules/projectiles/guns/akimbo.dm
@@ -16,6 +16,11 @@
 	if(!broken)
 		Break(user)
 
+/obj/item/weapon/gun/akimbo/stripped(mob/wearer, mob/stripper)
+	if(!broken)
+		Break()
+	..()
+
 /obj/item/weapon/gun/akinbo/pickup(mob/user)
 	update_icon(user)
 
@@ -43,8 +48,9 @@
 /obj/item/weapon/gun/akimbo/proc/Break(mob/living/user)
 	broken = TRUE
 	if(left && right)
-		left.forceMove(get_turf(src))
-		right.forceMove(get_turf(src))
+		var/turf/T = get_turf(src)
+		left.forceMove(T)
+		right.forceMove(T)
 		if(user)
 			user.drop_item(src, force_drop = TRUE)
 			user.put_in_hands(left)
@@ -52,6 +58,7 @@
 		left = null
 		right = null
 	qdel(src)
+
 /obj/item/weapon/gun/akimbo/update_icon(mob/user)
 	//right over left
 	icon = left.icon

--- a/code/modules/projectiles/targeting.dm
+++ b/code/modules/projectiles/targeting.dm
@@ -24,14 +24,14 @@
 //Removing the lock and the buttons.
 /obj/item/weapon/gun/dropped(mob/user as mob)
 	stop_aim()
-	if (user.client)
+	if (user && user.client)
 		user.client.remove_gun_icons()
 	return ..()
 
 /obj/item/weapon/gun/equipped(var/mob/user, var/slot, hand_index)
 	if(!hand_index)
 		stop_aim()
-		if (user.client)
+		if (user && user.client)
 			user.client.remove_gun_icons()
 	return ..()
 


### PR DESCRIPTION
`Transmangorify()` was called twice, this resulted in erratic behaviour.
Also, now the holodudes call the proper `dropped()` procedure.

Fixes #19205 