### PR TITLE
Fixed genetics console not working

### DIFF
--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -391,7 +391,7 @@ var/global/list/facial_hair_styles_female_list	= list()
 	if(!isnum(value))
 		WARNING("Expected a number, got [value]")
 		return 0
-	return add_zero2(num2hex(value,1), 3)
+	return num2hex(value, 3)
 
 /datum/dna/proc/UpdateUI()
 	src.uni_identity=""


### PR DESCRIPTION
Looks like `EncodeDNABlock` relied on the old broken behavior of `num2hex`.
unironically 100% tested

Fixes #19932