### PR TITLE
Fixes Getting Trapped Behind Transit Tubes

### DIFF
--- a/code/game/objects/structures/transit_tubes.dm
+++ b/code/game/objects/structures/transit_tubes.dm
@@ -92,7 +92,7 @@ obj/structure/transit_tube_pod/ex_act(severity)
 		init_dirs()
 
 /obj/structure/transit_tube/Cross(atom/movable/mover, turf/target, height = 1.5, air_group = 0)
-	if(get_exit(get_dir(src, mover)))
+	if(test_blocked(get_dir(src, mover)))
 		return ..() //If there's an opening on the side they're trying to enter, only let them do so if they can normally pass dense structures.
 	return TRUE //Otherwise, whatever.
 
@@ -316,6 +316,9 @@ obj/structure/transit_tube_pod/ex_act(severity)
 			near_dir = direction
 
 	return near_dir
+
+/obj/structure/transit_tube/proc/test_blocked(in_dir)	//You can now only squeeze under transit tubes if you can go out the same way you came in.
+	return (get_exit(in_dir) || get_exit(turn(in_dir, 180)))
 
 
 


### PR DESCRIPTION
You can now only slide under a transit tube if you would be able to slide back out from the other side, the same way you came in. This ensures that you can never be trapped behind a transit tube.
In practice, this essentially just disallows sliding under any transit tube sections that are not at 90 degree angles. I'm not sure sliding under diagonal tubes is terribly necessary, but if it is, then the existence of spots in which you can become trapped should be deemed a mapping issue, not a bug. Just put walls on those tiles.
Fixes #5532.
Fixes #16686.

:cl:
 * bugfix: You can no longer become trapped in corners behind transit tubes. As a side effect, you can no longer slide under diagonal sections of transit tube.
