### PR TITLE
Fixes Inability to Splash Monkey Cubes

### DIFF
--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -252,7 +252,7 @@ var/list/LOGGED_SPLASH_REAGENTS = list(FUEL, THERMITE)
 	// Transfer to container
 	else if (can_send /*&& target.reagents**/)
 		var/obj/container = target
-		if (!container.is_open_container() && istype(container,/obj/item/weapon/reagent_containers))
+		if (!container.is_open_container() && istype(container,/obj/item/weapon/reagent_containers) && !istype(container,/obj/item/weapon/reagent_containers/food/snacks))
 			return -1
 
 		if(target.is_open_container())


### PR DESCRIPTION
Food items can now be splashed with reagents. Specifically `/food/snacks`. Among these are monkey cubes.
Fixes #6575.

:cl:
 * bugfix: You can now splash monkey cubes with water from reagent containers. In fact, you can now splash any food with any reagent.