### PR TITLE
Glare no longer costs 1u blood

### DIFF
--- a/code/modules/spells/aoe_turf/glare.dm
+++ b/code/modules/spells/aoe_turf/glare.dm
@@ -18,7 +18,7 @@
 
 	inner_radius = 3
 
-	var/blood_cost = 1
+	var/blood_cost = 0
 
 /spell/aoe_turf/glare/cast_check(var/skipcharge = 0, var/mob/user = usr)
 	. = ..()


### PR DESCRIPTION
Probably a change from after I started to port this.
Or I am just retarded works too

:cl:
- tweak: Glare no longer costs 1u blood.
