### PR TITLE
Fixing Latejoining

### DIFF
--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -15,8 +15,8 @@
 /obj/item/device/radio/intercom/supports_holomap()
 	return TRUE
 
-/obj/item/device/radio/intercom/universe/New()
-	return ..()
+/obj/item/device/radio/intercom/universe/GhostsAlwaysHear()
+	return TRUE
 
 /obj/item/device/radio/intercom/initialize()
 	..()

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -336,6 +336,9 @@
 	if(character.client.prefs.randomslot)
 		character.client.prefs.random_character_sqlite(character, character.ckey)
 
+	if(character.mind.assigned_role != "MODE")
+		job_master.EquipRank(character, rank, 1) //Must come before OnPostSetup for uplinks
+
 	var/turf/T = character.loc
 	for(var/role in character.mind.antag_roles)
 		var/datum/role/R = character.mind.antag_roles[role]
@@ -350,7 +353,7 @@
 		qdel(src)
 		return
 
-	job_master.EquipRank(character, rank, 1)					//equips the human
+
 	EquipCustomItems(character)
 
 	if(J.spawns_from_edge)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -393,30 +393,15 @@
 					if(istype(P.cartridge,/obj/item/weapon/cartridge/trader))
 						var/mob/living/L = get_holder_of_type(P,/mob/living)
 						if(L)
-							L.show_message("[bicon(P)] <b>Message from U���8�E1��Ћ (T�u1B��), </b>\"Caw. Cousin [character] detected in sector.\".", 2)
+							L.show_message("[bicon(P)] <b>Message from U���8�E1��Ћ (T�u1B��), </b>\"Caw. Cousin [character] detected in sector.\"", 2)
 				for(var/mob/dead/observer/M in player_list)
 					if(M.stat == DEAD && M.client)
 						handle_render(M,"<span class='game say'>PDA Message - <span class='name'>Trader [character] has arrived in the sector from space.</span></span>",character) //This should generate a Follow link
-
-	if(character.mind.assigned_role != "Cyborg")
-		data_core.manifest_inject(character)
-		ticker.minds += character.mind//Cyborgs and AIs handle this in the transform proc.	//TODO!!!!! ~Carn
-		if(character.mind.assigned_role == "Trader")
-			//If we're a trader, instead send a message to PDAs with the trader cartridge
-			for (var/obj/item/device/pda/P in PDAs)
-				if(istype(P.cartridge,/obj/item/weapon/cartridge/trader))
-					var/mob/living/L = get_holder_of_type(P,/mob/living)
-					if(L)
-						L.show_message("[bicon(P)] <b>Message from U¦É8¥E1ÀÓÐ (T¥u1B¤Õ), </b>\"Caw. Cousin [character] detected in sector.\".", 2)
-			for(var/mob/dead/observer/M in player_list)
-				if(M.stat == DEAD && M.client)
-					handle_render(M,"<span class='game say'>PDA Message - <span class='name'>Trader [character] has arrived in the sector from space.</span></span>",character) //This should generate a Follow link
-
+			else
+				AnnounceArrival(character, rank)
+			FuckUpGenes(character)
 		else
-			AnnounceArrival(character, rank)
-		FuckUpGenes(character)
-	else
-		character.Robotize()
+			character.Robotize()
 	qdel(src)
 
 /mob/living/carbon/human/proc/Meteortype_Latejoin(rank)

--- a/data/mode.txt
+++ b/data/mode.txt
@@ -1,1 +1,1 @@
-sandbox
+Dynamic Mode

--- a/data/mode.txt
+++ b/data/mode.txt
@@ -1,1 +1,1 @@
-Dynamic Mode
+sandbox


### PR DESCRIPTION
Looks like this was probably caused by improper merge conflict resolution based on the weirdly copied text.

Also removed an unnecessary New(). I tested this but I can easily imagine in cases like this there are weird cases that would be hard to think of in testing, as with all things that require multiple players present to test properly. Tried joining as a nonantag and antag.

fixes #19939 
fixes #19928 

🆑 
* bugfix: Fixed a typo in the trader latejoin PDA message
* bugfix:  You should no longer see twice the security records.
* bugfix: Latejoin traitors will now receive an uplink
* bugfix: If cyborg latejoin slots existed, they would work now.
* rscadd:  Ghosts should always hear the latejoin announcement even if they're not standing by a radio