### PR TITLE
Fixes Getting Stunned off Vehicles Breaking Your Offset

### DIFF
--- a/code/game/objects/structures/vehicles/cargo_tractor.dm
+++ b/code/game/objects/structures/vehicles/cargo_tractor.dm
@@ -10,23 +10,13 @@
 	keytype = /obj/item/key/tractor
 	wreckage_type = /obj/effect/decal/mecha_wreckage/vehicle/tractor
 
-/obj/structure/bed/chair/vehicle/tractor/update_mob()
-	if(!occupant)
-		return
-
-	switch(dir)
-		if(SOUTH)
-			occupant.pixel_x = 0
-			occupant.pixel_y = 7 * PIXEL_MULTIPLIER
-		if(WEST)
-			occupant.pixel_x = 5 * PIXEL_MULTIPLIER
-			occupant.pixel_y = 4 * PIXEL_MULTIPLIER
-		if(NORTH)
-			occupant.pixel_x = 0
-			occupant.pixel_y = 4 * PIXEL_MULTIPLIER
-		if(EAST)
-			occupant.pixel_x = -5 * PIXEL_MULTIPLIER
-			occupant.pixel_y = 4 * PIXEL_MULTIPLIER
+/obj/structure/bed/chair/vehicle/tractor/make_offsets()
+	offsets = list(
+		"[SOUTH]" = list("x" = 0, "y" = 7 * PIXEL_MULTIPLIER),
+		"[WEST]" = list("x" = 5 * PIXEL_MULTIPLIER, "y" = 4 * PIXEL_MULTIPLIER),
+		"[NORTH]" = list("x" = 0, "y" = 4 * PIXEL_MULTIPLIER),
+		"[EAST]" = list("x" = -5 * PIXEL_MULTIPLIER, "y" = 4 * PIXEL_MULTIPLIER)
+		)
 
 /obj/structure/bed/chair/vehicle/tractor/handle_layer()
 	if(dir == NORTH)

--- a/code/game/objects/structures/vehicles/gigadrill.dm
+++ b/code/game/objects/structures/vehicles/gigadrill.dm
@@ -35,19 +35,13 @@
 		plane = ABOVE_HUMAN_PLANE
 		layer = VEHICLE_LAYER
 
-/obj/structure/bed/chair/vehicle/gigadrill/update_mob()
-	if(occupant && dir == SOUTH)
-		occupant.pixel_x = 0
-		occupant.pixel_y = 18 * PIXEL_MULTIPLIER
-	else if(occupant && dir == NORTH)
-		occupant.pixel_x = 0
-		occupant.pixel_y = 7 * PIXEL_MULTIPLIER
-	else if(occupant && dir == WEST)
-		occupant.pixel_x = 18 * PIXEL_MULTIPLIER
-		occupant.pixel_y = 9 * PIXEL_MULTIPLIER
-	else if(occupant && dir == EAST)
-		occupant.pixel_x = -18 * PIXEL_MULTIPLIER
-		occupant.pixel_y = 9 * PIXEL_MULTIPLIER
+/obj/structure/bed/chair/vehicle/gigadrill/make_offsets()
+	offsets = list(
+		"[SOUTH]" = list("x" = 0, "y" = 18 * PIXEL_MULTIPLIER),
+		"[WEST]" = list("x" = 18 * PIXEL_MULTIPLIER, "y" = 9 * PIXEL_MULTIPLIER),
+		"[NORTH]" = list("x" = 0, "y" = 7 * PIXEL_MULTIPLIER),
+		"[EAST]" = list("x" = -18 * PIXEL_MULTIPLIER, "y" = 9 * PIXEL_MULTIPLIER)
+		)
 
 /obj/structure/bed/chair/vehicle/gigadrill/update_icon()
   if(occupant)

--- a/code/game/objects/structures/vehicles/gokart.dm
+++ b/code/game/objects/structures/vehicles/gokart.dm
@@ -24,25 +24,13 @@
 /obj/structure/bed/chair/vehicle/gokart/update_icon()
 	icon_state="gokart[!occupant]"
 
-/obj/structure/bed/chair/vehicle/gokart/update_mob()
-	if(!occupant)
-		return
-
-	switch(dir)
-		if(SOUTH)
-			occupant.pixel_x = 0
-			occupant.pixel_y = 7 * PIXEL_MULTIPLIER
-		if(WEST)
-			occupant.pixel_x = 4 * PIXEL_MULTIPLIER
-			occupant.pixel_y = 7 * PIXEL_MULTIPLIER
-		if(NORTH)
-			occupant.pixel_x = 0
-			occupant.pixel_y = 4 * PIXEL_MULTIPLIER
-		if(EAST)
-			occupant.pixel_x = -4 * PIXEL_MULTIPLIER
-			occupant.pixel_y = 7 * PIXEL_MULTIPLIER
-
-
+/obj/structure/bed/chair/vehicle/gokart/make_offsets()
+	offsets = list(
+		"[SOUTH]" = list("x" = 0, "y" = 7 * PIXEL_MULTIPLIER),
+		"[WEST]" = list("x" = 4 * PIXEL_MULTIPLIER, "y" = 7 * PIXEL_MULTIPLIER),
+		"[NORTH]" = list("x" = 0, "y" = 4 * PIXEL_MULTIPLIER),
+		"[EAST]" = list("x" = -4 * PIXEL_MULTIPLIER, "y" = 7 * PIXEL_MULTIPLIER)
+		)
 
 /obj/effect/decal/mecha_wreckage/vehicle/gokart
 	// TODO: SPRITE PLS

--- a/code/game/objects/structures/vehicles/lightcycle.dm
+++ b/code/game/objects/structures/vehicles/lightcycle.dm
@@ -199,11 +199,13 @@
 /obj/structure/bed/chair/vehicle/lightcycle/handle_layer()
 	return
 
-/obj/structure/bed/chair/vehicle/lightcycle/update_mob()
-	if(!occupant)
-		return
-
-	occupant.pixel_y = 2 * PIXEL_MULTIPLIER
+/obj/structure/bed/chair/vehicle/lightcycle/make_offsets()
+	offsets = list(
+		"[SOUTH]" = list("x" = 0, "y" = 2 * PIXEL_MULTIPLIER),
+		"[WEST]" = list("x" = 0, "y" = 2 * PIXEL_MULTIPLIER),
+		"[NORTH]" = list("x" = 0, "y" = 2 * PIXEL_MULTIPLIER),
+		"[EAST]" = list("x" = 0, "y" = 2 * PIXEL_MULTIPLIER)
+		)
 
 /obj/effect/lightribbon
 	name = "light ribbon"

--- a/code/game/objects/structures/vehicles/secway.dm
+++ b/code/game/objects/structures/vehicles/secway.dm
@@ -14,24 +14,13 @@
 
 /obj/structure/bed/chair/vehicle/secway/set_keys() //doesn't spawn with keys, mapped in
 
-/obj/structure/bed/chair/vehicle/secway/update_mob()
-	if(!occupant)
-		return
-
-	switch(dir)
-		if(SOUTH)
-			occupant.pixel_x = 0
-			occupant.pixel_y = 3
-		if(WEST)
-			occupant.pixel_x = 2
-			occupant.pixel_y = 3
-		if(NORTH)
-			occupant.pixel_x = 0
-			occupant.pixel_y = 3
-		if(EAST)
-			occupant.pixel_x = -2
-			occupant.pixel_y = 3
-
+/obj/structure/bed/chair/vehicle/secway/make_offsets()
+	offsets = list(
+		"[SOUTH]" = list("x" = 0, "y" = 3 * PIXEL_MULTIPLIER),
+		"[WEST]" = list("x" = 2 * PIXEL_MULTIPLIER, "y" = 3 * PIXEL_MULTIPLIER),
+		"[NORTH]" = list("x" = 0, "y" = 3 * PIXEL_MULTIPLIER),
+		"[EAST]" = list("x" = -2 * PIXEL_MULTIPLIER, "y" = 3 * PIXEL_MULTIPLIER)
+		)
 
 /obj/structure/bed/chair/vehicle/secway/handle_layer()
 	if(dir == WEST || dir == EAST || dir == SOUTH)

--- a/code/game/objects/structures/vehicles/vehicle.dm
+++ b/code/game/objects/structures/vehicles/vehicle.dm
@@ -49,6 +49,9 @@
 	var/wreckage_type = /obj/effect/decal/mecha_wreckage/vehicle
 	var/last_warn
 
+	var/list/offsets = list()
+	var/last_dir
+
 /obj/structure/bed/chair/vehicle/proc/getMovementDelay()
 	return movement_delay
 
@@ -72,6 +75,7 @@
 	if(!nick)
 		nick=name
 	set_keys()
+	make_offsets()
 
 /obj/structure/bed/chair/vehicle/Destroy()
 	vehicle_list.Remove(src)
@@ -269,23 +273,26 @@
 
 	update_mob()
 
+/obj/structure/bed/chair/vehicle/proc/make_offsets()
+	offsets = list(
+		"[SOUTH]" = list("x" = 0, "y" = 7 * PIXEL_MULTIPLIER),
+		"[WEST]" = list("x" = 13 * PIXEL_MULTIPLIER, "y" = 7 * PIXEL_MULTIPLIER),
+		"[NORTH]" = list("x" = 0, "y" = 4 * PIXEL_MULTIPLIER),
+		"[EAST]" = list("x" = -13 * PIXEL_MULTIPLIER, "y" = 7 * PIXEL_MULTIPLIER)
+		)
+
 /obj/structure/bed/chair/vehicle/proc/update_mob()
 	if(!occupant)
 		return
 
-	switch(dir)
-		if(SOUTH)
-			occupant.pixel_x = 0
-			occupant.pixel_y = 7 * PIXEL_MULTIPLIER
-		if(WEST)
-			occupant.pixel_x = 13 * PIXEL_MULTIPLIER
-			occupant.pixel_y = 7 * PIXEL_MULTIPLIER
-		if(NORTH)
-			occupant.pixel_x = 0
-			occupant.pixel_y = 4 * PIXEL_MULTIPLIER
-		if(EAST)
-			occupant.pixel_x = -13 * PIXEL_MULTIPLIER
-			occupant.pixel_y = 7 * PIXEL_MULTIPLIER
+	if(last_dir)
+		occupant.pixel_x -= offsets["[last_dir]"]["x"]
+		occupant.pixel_y -= offsets["[last_dir]"]["y"]
+
+	occupant.pixel_x += offsets["[dir]"]["x"]
+	occupant.pixel_y += offsets["[dir]"]["y"]
+
+	last_dir = dir
 
 /obj/structure/bed/chair/vehicle/emp_act(severity)
 	switch(severity)
@@ -372,8 +379,10 @@
 	if(!.)
 		return
 
-	AM.pixel_x = 0
-	AM.pixel_y = 0
+	AM.pixel_x -= offsets["[dir]"]["x"]
+	AM.pixel_y -= offsets["[dir]"]["y"]
+
+	last_dir = null
 
 	if(occupant == AM)
 		occupant = null

--- a/code/game/objects/structures/vehicles/wheelchair.dm
+++ b/code/game/objects/structures/vehicles/wheelchair.dm
@@ -153,10 +153,13 @@
 /obj/structure/bed/chair/vehicle/wheelchair/emp_act(severity)
 	return
 
-/obj/structure/bed/chair/vehicle/wheelchair/update_mob()
-	if(occupant)
-		occupant.pixel_x = 0
-		occupant.pixel_y = 3 * PIXEL_MULTIPLIER
+/obj/structure/bed/chair/vehicle/wheelchair/make_offsets()
+	offsets = list(
+		"[SOUTH]" = list("x" = 0, "y" = 3 * PIXEL_MULTIPLIER),
+		"[WEST]" = list("x" = 0, "y" = 3 * PIXEL_MULTIPLIER),
+		"[NORTH]" = list("x" = 0, "y" = 3 * PIXEL_MULTIPLIER),
+		"[EAST]" = list("x" = 0, "y" = 3 * PIXEL_MULTIPLIER)
+		)
 
 /obj/structure/bed/chair/vehicle/wheelchair/die()
 	getFromPool(/obj/item/stack/sheet/metal, get_turf(src), 4)

--- a/code/game/objects/structures/vehicles/wizmobile.dm
+++ b/code/game/objects/structures/vehicles/wizmobile.dm
@@ -50,23 +50,13 @@
 	return 1
 */
 
-/obj/structure/bed/chair/vehicle/wizmobile/update_mob()
-	if(!occupant)
-		return
-
-	switch(dir)
-		if(SOUTH)
-			occupant.pixel_x = 0
-			occupant.pixel_y = 7 * PIXEL_MULTIPLIER
-		if(WEST)
-			occupant.pixel_x = 3 * PIXEL_MULTIPLIER// 13
-			occupant.pixel_y = 7 * PIXEL_MULTIPLIER
-		if(NORTH)
-			occupant.pixel_x = 0
-			occupant.pixel_y = 4 * PIXEL_MULTIPLIER
-		if(EAST)
-			occupant.pixel_x = -3 * PIXEL_MULTIPLIER// -13
-			occupant.pixel_y = 7 * PIXEL_MULTIPLIER
+/obj/structure/bed/chair/vehicle/wizmobile/make_offsets()
+	offsets = list(
+		"[SOUTH]" = list("x" = 0, "y" = 7 * PIXEL_MULTIPLIER),
+		"[WEST]" = list("x" = 3 * PIXEL_MULTIPLIER, "y" = 7 * PIXEL_MULTIPLIER),//13
+		"[NORTH]" = list("x" = 0, "y" = 4 * PIXEL_MULTIPLIER),
+		"[EAST]" = list("x" = -3 * PIXEL_MULTIPLIER, "y" = 7 * PIXEL_MULTIPLIER)//-13
+		)
 
 /obj/structure/bed/chair/vehicle/wizmobile/handle_layer()
 	return


### PR DESCRIPTION
Vehicle offsets are now stored in a variable, and are added and subtracted rather than directly set, so dismounting a vehicle as a result of getting stunned should no longer leave you permanently elevated.
Fixes #6809.

:cl:
 * bugfix: Getting stunned off a vehicle will no longer break your offset.