### PR TITLE
Fixes NPC Wizards Speaking in Deadchat

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/human/wizard.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/wizard.dm
@@ -38,11 +38,6 @@
 	src.say("SCYAR NILA [pick("AI UPLOAD", "SECURE ARMORY", "BAR", "PRIMARY TOOL STORAGE", "INCINERATOR", "CHAPEL", "FORE STARBOARD MAINTENANCE", "WIZARD FEDERATION")]")
 	var/obj/effect/effect/smoke/S = new /obj/effect/effect/smoke(get_turf(src))
 	S.time_to_live = 20 //2 seconds instead of full 10
-	invisibility = 101
-	density = 0
-	timestopped = TRUE
-	sleep(10)	//Wizards were somehow dying before executing their say() despite the position of the procs, so let's give them a little extra time.
-	timestopped = FALSE
 
 	..(TRUE)
 	qdel(src)

--- a/code/modules/mob/living/simple_animal/hostile/human/wizard.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/wizard.dm
@@ -38,7 +38,7 @@
 	src.say("SCYAR NILA [pick("AI UPLOAD", "SECURE ARMORY", "BAR", "PRIMARY TOOL STORAGE", "INCINERATOR", "CHAPEL", "FORE STARBOARD MAINTENANCE", "WIZARD FEDERATION")]")
 	var/obj/effect/effect/smoke/S = new /obj/effect/effect/smoke(get_turf(src))
 	S.time_to_live = 20 //2 seconds instead of full 10
-	alpha = 0
+	invisibility = 101
 	density = 0
 	timestopped = TRUE
 	sleep(10)	//Wizards were somehow dying before executing their say() despite the position of the procs, so let's give them a little extra time.

--- a/code/modules/mob/living/simple_animal/hostile/human/wizard.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/wizard.dm
@@ -38,6 +38,11 @@
 	src.say("SCYAR NILA [pick("AI UPLOAD", "SECURE ARMORY", "BAR", "PRIMARY TOOL STORAGE", "INCINERATOR", "CHAPEL", "FORE STARBOARD MAINTENANCE", "WIZARD FEDERATION")]")
 	var/obj/effect/effect/smoke/S = new /obj/effect/effect/smoke(get_turf(src))
 	S.time_to_live = 20 //2 seconds instead of full 10
+	alpha = 0
+	density = 0
+	timestopped = TRUE
+	sleep(10)	//Wizards were somehow dying before executing their say() despite the position of the procs, so let's give them a little extra time.
+	timestopped = FALSE
 
 	..(TRUE)
 	qdel(src)

--- a/code/modules/spells/aoe_turf/conjure/doppelganger.dm
+++ b/code/modules/spells/aoe_turf/conjure/doppelganger.dm
@@ -40,7 +40,8 @@ var/list/doppelgangers = list()
 	D.alpha = OPAQUE // No more invisible doppels
 	doppelgangers_count_by_wizards[holder]++ // Update the counts of doppels we summoned
 	spawn (spell_duration)
-		D.death()
+		if(D.stat != DEAD)
+			D.death()
 
 /spell/aoe_turf/conjure/doppelganger/on_holder_death(mob/user)
 	if(!user)


### PR DESCRIPTION
The `say()` comes before the NPC wizard dies in the same proc, and BYOND is single-threaded, so I have absolutely no idea how they could be dying before speaking. It's like how the Lawgiver sometimes repeats what the user says *before* the user says it.
In any case, this gives them a second where it just looks like they died, before they *actually* die, so they should now have time to say their death phrase and stop saying it in deadchat.
Fixes #19954.

:cl:
 * bugfix: Dead NPC wizards such as doppelgangers no longer speak in deadchat.