### PR TITLE
Fixes Hulk Inverting Throw Damage

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1688,7 +1688,7 @@ Thanks.
 		if(istype(src,/mob/living/carbon/human))
 			var/mob/living/carbon/human/H=src
 			throw_mult = H.species.throw_mult
-			if(M_HULK in H.mutations || M_STRONG in H.mutations)
+			if((M_HULK in H.mutations) || (M_STRONG in H.mutations))
 				throw_mult+=0.5
 		item.throw_at(target, item.throw_range*throw_mult, item.throw_speed*throw_mult)
 		return THREW_SOMETHING


### PR DESCRIPTION
Hulk no longer passively increases throw damage, and now does increase throw damage when hulked out.
Fixes #7092.

:cl:
 * bugfix: Hulk no longer passively increases throw damage while you have the gene. Hulk now properly increases throw damage while hulked out.