### PR TITLE
Fixes Bugs Related to Operator Precedence

### DIFF
--- a/code/game/gamemodes/newobjective.dm
+++ b/code/game/gamemodes/newobjective.dm
@@ -596,7 +596,7 @@ datum
 				weight = 20
 
 				get_points(var/job)
-					if(job in science_positions || job in command_positions)
+					if((job in science_positions) || (job in command_positions))
 						return 20
 					return 40
 

--- a/code/modules/Economy/Accounts.dm
+++ b/code/modules/Economy/Accounts.dm
@@ -300,7 +300,7 @@ var/global/datum/money_account/trader_account
 
 				if(access_cent_captain in idcard.access)
 					access_level = 2
-				else if(access_hop in idcard.access || access_captain in idcard.access)
+				else if((access_hop in idcard.access) || (access_captain in idcard.access))
 					access_level = 1
 
 /obj/machinery/account_database/emag(mob/user)
@@ -311,7 +311,7 @@ var/global/datum/money_account/trader_account
 			var/obj/item/weapon/card/id/C = held_card
 			if(access_cent_captain in C.access)
 				access_level = 2
-			else if(access_hop in C.access || access_captain in C.access)
+			else if((access_hop in C.access) || (access_captain in C.access))
 				access_level = 1
 		attack_hand(user)
 		to_chat(user, "<span class='notice'>You re-enable the security checks of [src].</span>")
@@ -368,7 +368,7 @@ var/global/datum/money_account/trader_account
 							if(access_level < 3)
 								if(access_cent_captain in C.access)
 									access_level = 2
-								else if(access_hop in C.access || access_captain in C.access)
+								else if((access_hop in C.access) || (access_captain in C.access))
 									access_level = 1
 			if("view_account_detail")
 				var/index = text2num(href_list["account_index"])

--- a/code/modules/Economy/EFTPOS.dm
+++ b/code/modules/Economy/EFTPOS.dm
@@ -164,7 +164,7 @@
 				var/obj/item/I = usr.get_active_hand()
 				if (istype(I, /obj/item/weapon/card))
 					var/obj/item/weapon/card/id/C = I
-					if(access_cent_captain in C.access || access_hop in C.access || access_captain in C.access)
+					if((access_cent_captain in C.access) || (access_hop in C.access) || (access_captain in C.access))
 						access_code = 0
 						to_chat(usr, "[bicon(src)] <span class='info'>Access code reset to 0.</span>")
 				else if (istype(I, /obj/item/weapon/card/emag))


### PR DESCRIPTION
The only included files that had these errors were economy-related files, stuff with the accounts database and EFTPOS system.
I'm actually not sure what the effects of fixing these will be, but they were definitely causing unintended behavior, whatever it was.

Thanks to @Exxion for the regex string to find these.