### PR TITLE
Fixes Cluwnes Being Untouchable by Items

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/retaliate/cluwne.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/cluwne.dm
@@ -251,6 +251,10 @@
 	return ..()
 
 /mob/living/simple_animal/hostile/retaliate/cluwne/attackby(var/obj/item/O as obj, var/mob/user as mob)
+	var/currenthealth = health
+	..()
+	playsound(src, 'sound/items/bikehorn.ogg', 50, 1)
+	health = currenthealth
 	//only knowledge can kill a cluwne
 	if(istype(O,/obj/item/weapon/book))
 		gib()


### PR DESCRIPTION
Cluwnes can now be beat with items, and produce a honking sound when you do so. As a result, borgs can now interact with cluwnes by way of beatings. Cluwnes remain immune to damage from all melee weapons that are not books.
Fixes #7708.

:cl:
 * bugfix: Cluwnes can now be beat with items. It won't kill them, but it will hurt and shame them and produce a satisfying honk.