### PR TITLE
Fixing false walls not smoothing with their neighbors

### DIFF
--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -252,11 +252,12 @@
 		/obj/structure/falsewall,
 		/obj/structure/falserwall,
 	)
+	return smoothables
 
 /obj/structure/falserwall/New()
+	..()
 	relativewall()
 	relativewall_neighbours()
-	..()
 
 
 /obj/structure/falserwall/attack_ai(mob/user as mob)


### PR DESCRIPTION
Fixes #19981 

this is stupid.

:cl:
* bugfix: False Reinforced Walls properly smooth with their neighbors at last.