### PR TITLE
Removes Insulated Pipes from the RPD

### DIFF
--- a/code/modules/RCD/RPD.dm
+++ b/code/modules/RCD/RPD.dm
@@ -49,12 +49,6 @@
 		/datum/rcd_schematic/pipe/he_manifold,
 		/datum/rcd_schematic/pipe/he_manifold4w,
 
-		/* Insulated Pipes */
-		/datum/rcd_schematic/pipe/insulated,
-		/datum/rcd_schematic/pipe/insulated_bent,
-		/datum/rcd_schematic/pipe/insulated_manifold,
-		/datum/rcd_schematic/pipe/insulated_4w_manifold,
-
 		/* Disposal Pipes */
 		/datum/rcd_schematic/pipe/disposal,
 		/datum/rcd_schematic/pipe/disposal/bent,


### PR DESCRIPTION
I was initially making this to fix #7252, but then I remembered that pipe painting is a thing, so I don't think the fact that insulated pipes are red by default really matters anymore.
However, since I'd already made the branch and everything, I thought I'd PR it anyway. As far as I know, insulated pipes have no practical differences from regular pipes since the removal of pipe bursting and pipe heat radiation, which means all their presence in the RPD does is confuse new players. I don't see any reason to keep them.

:cl:
 * rscdel: Insulated pipes have been removed from the RPD.