### PR TITLE
Role datums bugfixes

### DIFF
--- a/code/datums/gamemode/factions/faction.dm
+++ b/code/datums/gamemode/factions/faction.dm
@@ -74,7 +74,6 @@ var/list/factions_with_hud_icons = list()
 	if(!newRole.AssignToRole(M))
 		newRole.Drop()
 		return 0
-	members.Add(newRole)
 	return 1
 
 /datum/faction/proc/HandleRecruitedMind(var/datum/mind/M)
@@ -85,11 +84,10 @@ var/list/factions_with_hud_icons = list()
 	if(M.GetRole(late_role))
 		WARNING("Mind already had a role of [late_role]!")
 		return 0
-	var/datum/role/R = new roletype(null,src, initial_role)
+	var/datum/role/R = new roletype(null,src, initial_role) // Add him to our roles
 	if(!R.AssignToRole(M))
 		R.Drop()
 		return 0
-	members.Add(R)
 	R.OnPostSetup()
 	return 1
 

--- a/code/datums/gamemode/factions/legacy_cult/cult.dm
+++ b/code/datums/gamemode/factions/legacy_cult/cult.dm
@@ -287,6 +287,7 @@ var/global/list/rnwords = list("ire","ego","nahlizet","certum","veri","jatkaa","
 		message_admins("Trying to force completion of objective [O] to [src], but the faction has no current objective.")
 		return FALSE
 	if (!(O in objective_holder.objectives) || current_objective != O) // Same as previous
+		message_admins("Trying to force completion of objective [O] to [src], but this isn't the faction's current objective.")
 		return FALSE
 	getNewObjective()
 

--- a/code/datums/gamemode/objectives/convert_people.dm
+++ b/code/datums/gamemode/objectives/convert_people.dm
@@ -31,6 +31,8 @@
 	return TRUE
 
 /datum/objective/convert_people/IsFulfilled()
+	if (..())
+		return TRUE
 	return (faction.members.len >= cultists_target)
 
 /datum/objective/summon_narsie/feedbackText()

--- a/code/datums/gamemode/objectives/spray_blood.dm
+++ b/code/datums/gamemode/objectives/spray_blood.dm
@@ -8,7 +8,7 @@
 	flags =  FACTION_OBJECTIVE
 
 /datum/objective/spray_blood/PostAppend()
-	floor_limit = round(rand(1,5))*1
+	floor_limit = round(rand(1,5))*50
 	explanation_text = "We must prepare this place for the Geometer of Blood's coming. Spread blood and gibs over [floor_limit] of the Station's floor tiles."
 	return TRUE
 

--- a/code/datums/gamemode/objectives/spray_blood.dm
+++ b/code/datums/gamemode/objectives/spray_blood.dm
@@ -8,11 +8,13 @@
 	flags =  FACTION_OBJECTIVE
 
 /datum/objective/spray_blood/PostAppend()
-	floor_limit = round(rand(1,5))*50
+	floor_limit = round(rand(1,5))*1
 	explanation_text = "We must prepare this place for the Geometer of Blood's coming. Spread blood and gibs over [floor_limit] of the Station's floor tiles."
 	return TRUE
 
 /datum/objective/spray_blood/IsFulfilled()
+	if (..())
+		return TRUE
 	var/datum/faction/cult/narsie/cult_fac = faction
 	return (cult_fac.bloody_floors.len >= floor_limit)
 

--- a/code/datums/gamemode/role/legacy_cultist.dm
+++ b/code/datums/gamemode/role/legacy_cultist.dm
@@ -57,15 +57,19 @@
 	antag.current << sound('sound/effects/vampire_intro.ogg')
 
 /datum/role/legacy_cultist/Drop()
+	stat_collection.cult_deconverted++
+	. = ..()
+	if (!antag)
+		return .
 	antag.current.remove_language(LANGUAGE_CULT)
 	to_chat(antag.current, "<span class='danger'><FONT size = 3>An unfamiliar white light flashes through your mind, cleansing the taint of the dark-one and removing all of the memories of your time as his servant, except the one who converted you, with it.</FONT></span>")
 	to_chat(antag.current, "<span class='danger'>You find yourself unable to mouth the words of the forgotten...</span>")
 	antag.current.visible_message("<span class='big danger'>It looks like [antag.current] just reverted to their old faith!</span>")
 	log_admin("[key_name(antag.current)] has been deconverted from the cult.")
-	stat_collection.cult_deconverted++
-	. = ..()
 
 /datum/role/legacy_cultist/AnnounceObjectives()
+	if (!antag)
+		return
 	if (!istype(faction, /datum/faction/cult/narsie))
 		WARNING("Wrong faction type for [src.antag.current], faction is [faction.type]")
 		return FALSE
@@ -77,5 +81,5 @@
 /datum/role/legacy_cultist/AdminPanelEntry()
 	var/list/dat = ..()
 	var/datum/faction/cult/narsie/C = faction
-	dat += "<a href='?src=\ref[faction];cult_mindspeak=\ref[src]'>Voice of [C.eldergod]</a><br/>"
+	dat += "<a href='?src=\ref[faction];cult_mindspeak=\ref[src]'>Voice of [C.deity_name]</a><br/>"
 	return dat


### PR DESCRIPTION
This fixes two things.

1/ Roles were doubled in some cases. It was my fault with a previous PR. It didn't have too much of a serious impact, except clogging the scoreboard and causing some runtimes (because one role didn't have a mind to link with.)

2/ Cult's objectives would default to failed if they didn't happen to be completed when an admin checked them. This could result in some troubles if you tried to debug them, such as making them completed manually, it would mess with the cult state and could possible bug summoning.