### PR TITLE
Fixes Book of Dimensional Push

### DIFF
--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -803,8 +803,17 @@
 	desc = "This book seems like it moves away as you get closer to it."
 
 /obj/item/weapon/spellbook/oneuse/push/recoil(mob/living/carbon/user)
+	user.drop_item(src, force_drop = 1)	//no taking the transportation device with you
 	to_chat(user, "<span class = 'warning'>You are pushed away by \the [src]!</span>")
-	var/area/thearea = pick(areas)
+	var/area/thearea
+	var/area/prospective = pick(areas)
+	while(!thearea)
+		if(prospective.type != /area)
+			var/turf/T = pick(get_area_turfs(prospective.type))
+			if(T.z != 2)
+				thearea = prospective
+				break
+		prospective = pick(areas)
 	var/list/L = list()
 	for(var/turf/T in get_area_turfs(thearea.type))
 		if(!T.density)


### PR DESCRIPTION
The dimensional push book's recoil can no longer send you to Z2, though it can send you to all other Z-levels.
The dimensional push book recoil now causes you to drop the book, so it isn't just a free travel device.
Fixes #18283.

:cl:
 * bugfix: The recoil of the one-use spellbook for dimensional push will no longer be capable of sending you to Z2, and will force you to drop the book so it doesn't just act as a free travel device.