### PR TITLE
Fixes Hearing Cameras Runtime

### DIFF
--- a/code/game/machinery/telecomms/broadcaster.dm
+++ b/code/game/machinery/telecomms/broadcaster.dm
@@ -74,6 +74,7 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 		if(signal.data["type"] == 0)
 			var/datum/speech/speech = getFromPool(/datum/speech)
 			speech.from_signal(signal)
+			speech.speaker = signal.data["mob"]
 			/* ###### Broadcast a message using signal.data ###### */
 			Broadcast_Message(speech, signal.data["vmask"], 0, signal.data["compression"], signal.data["level"])
 
@@ -90,6 +91,7 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 			*/
 			var/datum/speech/speech = getFromPool(/datum/speech)
 			speech.from_signal(signal)
+			speech.speaker = signal.data["mob"]
 			/* ###### Broadcast a message using signal.data ###### */
 			Broadcast_Message(speech, signal.data["vmask"], null, signal.data["compression"], signal.data["level"])
 
@@ -104,6 +106,7 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 				// Parameter "data" as 4: AI can't track this person/mob
 			var/datum/speech/speech = getFromPool(/datum/speech)
 			speech.from_signal(signal)
+			speech.speaker = signal.data["mob"]
 			/* ###### Broadcast a message using signal.data ###### */
 			Broadcast_Message(speech, signal.data["vmask"], 4, signal.data["compression"], signal.data["level"])
 

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -219,7 +219,9 @@ var/list/department_radio_keys = list(
 	else
 		deaf_message = "<span class='notice'>You can't hear yourself!</span>"
 		deaf_type = 2 // Since you should be able to hear yourself without looking
-	var/atom/movable/AM = speech.speaker.GetSource()
+	var/atom/movable/AM
+	if(speech.speaker)
+		AM = speech.speaker.GetSource()
 	if(!say_understands((istype(AM) ? AM : speech.speaker),speech.language)|| force_compose) //force_compose is so AIs don't end up without their hrefs.
 		rendered_message = render_speech(speech)
 	show_message(rendered_message, type, deaf_message, deaf_type)


### PR DESCRIPTION
It should, anyway. I'm not sure exactly what circumstances trigger the runtime, but this should ensure both that the speech datum passed to the camera's hearer has a `speaker`, as well as having the camera check whether its speech datum has a `speaker` instead of assuming it does.
Fixes #8158.