### PR TITLE
Fixes a bad oversight

### DIFF
--- a/code/datums/gamemode/factions/legacy_cult/talisman.dm
+++ b/code/datums/gamemode/factions/legacy_cult/talisman.dm
@@ -98,6 +98,7 @@
 				return
 			if("supply")
 				supply()
+		qdel(R)
 		user.take_organ_damage(5, 0)
 		if(use_charge)
 			uses--


### PR DESCRIPTION
Instead of manually calling procs, runes are now `New`d in a talisman.
However, a new rune causes it to be references in the global rune list ; preventing its deletion at the end of talisman usage.

This would result in tons of runes in nullspace clogging the rune list.
This is probably what caused #20009 
