### PR TITLE
Fixes/implements borg module lock

### DIFF
--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -80,6 +80,7 @@
 						dat += "<A href='?src=\ref[src];magbot=\ref[R]'>(<font color=blue><i>Hack</i></font>)</A> "
 
 				dat += {"<A href='?src=\ref[src];stopbot=\ref[R]'>(<font color=green><i>[R.canmove ? "Lockdown" : "Release"]</i></font>)</A>
+					<A href='?src=\ref[src];lockbot=\ref[R]'>(<font color=orange><i>[R.modulelock ? "Module-unlock" : "Module-lock"]</i></font>)</A>
 					<A href='?src=\ref[src];killbot=\ref[R]'>(<font color=red><i>Destroy</i></font>)</A>
 					<BR>"}
 			dat += "<A href='?src=\ref[src];screen=0'>(Return to Main Menu)</A><BR>"
@@ -169,7 +170,23 @@
 								log_game("<span class='notice'>[key_name_admin(usr)] detonated [R.name]!</span>")
 			else
 				to_chat(usr, "<span class='warning'>Access Denied.</span>")
+		else if (href_list["lockbot"])
+			if(src.allowed(usr))
+				var/mob/living/silicon/robot/R = locate(href_list["lockbot"])
+				if(R && istype(R))
+					var/choice = input("Are you certain you wish to [R.modulelock ? "module-unlock" : "module-lock"] [R.name]?") in list("Confirm", "Abort")
+					if(choice == "Confirm")
+						if(R && istype(R))
+							message_admins("<span class='notice'>[key_name_admin(usr)] [R.modulelock ? "module-unlocked" : "module-locked"] [R.name]!</span>")
+							log_game("[key_name(usr)] [R.modulelock ? "module-unlocked" : "module-locked"] [R.name]!")
+							R.toggle_modulelock()
+							if (R.modulelock)
+								to_chat(R, "<span class='info' style=\"font-family:Courier\">Your modules have been remotely locked!</span>")
+							else
+								to_chat(R, "<span class='info' style=\"font-family:Courier\">Your modules have been remotely unlocked!</span>")
 
+			else
+				to_chat(usr, "<span class='warning'>Access Denied.</span>")
 		else if (href_list["stopbot"])
 			if(src.allowed(usr))
 				var/mob/living/silicon/robot/R = locate(href_list["stopbot"])

--- a/code/modules/mob/living/silicon/mommi/mommi.dm
+++ b/code/modules/mob/living/silicon/mommi/mommi.dm
@@ -227,9 +227,6 @@ They can only use one tool at a time, they can't choose modules, and they have 1
 		picked_icon = TRUE
 
 /mob/living/silicon/robot/mommi/installed_modules()
-	if(weapon_lock)
-		to_chat(src, "<span class='warning'>Weapon lock active, unable to use modules! Count:[weaponlock_time]</span>")
-		return
 	if(!module)
 		pick_module()
 		return

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -69,6 +69,9 @@
 	hud_used.update_robot_modules_display()
 
 /mob/living/silicon/robot/proc/activate_module(var/obj/item/I)
+	if(modulelock)
+		to_chat(src, "<span class='alert' style=\"font-family:Courier\">Module lock active! Time remaining: [modulelock_time] seconds.</span>")
+		return
 	if(!(locate(I) in module.modules))
 		return
 	if(activated(I))
@@ -98,27 +101,32 @@
 
 /mob/living/silicon/robot/proc/uneq_all()
 	module_active = null
+	var/modulesdisabled = 0
 
 	if(module_state_1)
 		uneq_module(module_state_1)
 		module_state_1 = null
 		if(inv1)
 			inv1.icon_state = "inv1"
+		modulesdisabled += 1
 
 	if(module_state_2)
 		uneq_module(module_state_2)
 		module_state_2 = null
 		if(inv2)
 			inv2.icon_state = "inv2"
+		modulesdisabled += 1
 
 	if(module_state_3)
 		uneq_module(module_state_3)
 		module_state_3 = null
 		if(inv3)
 			inv3.icon_state = "inv3"
+		modulesdisabled += 1
 
 	unequip_sight()
 	updateicon()
+	return modulesdisabled
 
 /mob/living/silicon/robot/proc/activated(obj/item/O)
 	if(module_state_1 == O)

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -302,14 +302,15 @@
 				gib()
 
 /mob/living/silicon/robot/proc/process_locks()
-	if(weapon_lock)
-		uneq_all()
-		weaponlock_time --
-		if(weaponlock_time <= 0)
+	if(modulelock)
+		if(uneq_all())
+			to_chat(src, "<span class='alert' style=\"font-family:Courier\">Module unequipped.</span>")
+		modulelock_time --
+		if(modulelock_time <= 0)
 			if(client)
-				to_chat(src, "<span class='warning'><B>Weapon Lock Timed Out!</span>")
-			weapon_lock = 0
-			weaponlock_time = 120
+				to_chat(src, "<span class='info' style=\"font-family:Courier\"><B>Module lock timed out!</span>")
+			modulelock = FALSE
+			modulelock_time = 120
 
 /mob/living/silicon/robot/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	if(!module)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -78,8 +78,8 @@
 
 	var/killswitch = FALSE
 	var/killswitch_time = 60
-	var/weapon_lock = FALSE
-	var/weaponlock_time = 120
+	var/modulelock = FALSE
+	var/modulelock_time = 120
 	var/lawupdate = TRUE //Cyborgs will sync their laws with their AI by default
 	var/lockcharge //Used when locking down a borg to preserve cell charge
 	var/scrambledcodes = FALSE // Used to determine if a borg shows up on the robotics console.  Setting to one hides them.
@@ -462,6 +462,13 @@
 		spark(src, 5, FALSE)
 	return 2
 
+	
+/mob/living/silicon/robot/emp_act(severity)
+	..()
+	if(prob(50/severity))
+		modulelock_time = rand(10,60)
+		modulelock = TRUE
+	
 
 /mob/living/silicon/robot/triggerAlarm(var/class, area/A, var/O, var/alarmsource)
 	if(isDead())
@@ -985,10 +992,6 @@
 		overlays += target_locked
 
 /mob/living/silicon/robot/proc/installed_modules()
-	if(weapon_lock)
-		to_chat(src, "<span class='attack'>Weapon lock active, unable to use modules! Count:[weaponlock_time]</span>")
-		return
-
 	if(!module)
 		pick_module()
 		return
@@ -1307,3 +1310,7 @@
 
 /mob/living/silicon/robot/get_cell()
 	return cell
+	
+/mob/living/silicon/robot/proc/toggle_modulelock()
+	modulelock = !modulelock
+	return modulelock


### PR DESCRIPTION
Implements the half-finished 'weapon lock' system that was already present. 
Properly blocks borgs from using their equipment, de-equips anything equipped when the lock engages.
Module lock can be toggled from a robotics console, or randomly engaged by an EMP.

🆑 
 - rscadd: Borgs can now be temporarily 'module-locked', to prevent them from using their modules.
 - rscadd: EMPs can cause module-lock.