### PR TITLE
Fixes Cloning Pods Having Their Sprite Reset When Their Panel Is Opened

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -492,12 +492,12 @@ Class Procs:
 
 /obj/machinery/proc/togglePanelOpen(var/obj/toggleitem, var/mob/user)
 	panel_open = !panel_open
-	if(!icon_state_open)
-		icon_state_open = icon_state
 	if(panel_open)
-		icon_state = icon_state_open
+		if(icon_state_open)
+			icon_state = icon_state_open
 	else
-		icon_state = initial(icon_state)
+		if(icon_state_open)	//don't need to reset the icon_state if it was never changed
+			icon_state = initial(icon_state)
 	to_chat(user, "<span class='notice'>[bicon(src)] You [panel_open ? "open" : "close"] the maintenance hatch of \the [src].</span>")
 	if(isscrewdriver(toggleitem))
 		playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)


### PR DESCRIPTION
Fixes #8053.