### PR TITLE
Adds XGM panel

### DIFF
--- a/code/ZAS/XGM.dm
+++ b/code/ZAS/XGM.dm
@@ -22,19 +22,32 @@
 	for(var/p in subtypesof(/datum/gas))
 		var/datum/gas/gas = new p()
 
-		if(gas.id in gases)
+		if(!add(gas))
 			stack_trace("Duplicate gas id '[gas.id]' in from typepath '[p]'")
-			continue
 
-		gases[gas.id] = gas
-		name[gas.id] = gas.name
-		short_name[gas.id] = gas.short_name || gas.name
-		specific_heat[gas.id] = gas.specific_heat
-		molar_mass[gas.id] = gas.molar_mass
-		flags[gas.id] = gas.flags
-		if(gas.tile_overlay)
-			tile_overlay[gas.id] = image('icons/effects/tile_effects.dmi', gas.tile_overlay, FLY_LAYER)
-		if(gas.overlay_limit)
-			overlay_limit[gas.id] = gas.overlay_limit
+/datum/xgm_data/proc/add(var/datum/gas/gas)
+	if(gases[gas.id])
+		return FALSE
+	return update(gas)
 
-	return 1
+/datum/xgm_data/proc/update(var/datum/gas/gas)
+	gases[gas.id] = gas
+	name[gas.id] = gas.name
+	short_name[gas.id] = gas.short_name || gas.name
+	specific_heat[gas.id] = gas.specific_heat
+	molar_mass[gas.id] = gas.molar_mass
+	flags[gas.id] = gas.flags
+	if(gas.tile_overlay)
+		tile_overlay[gas.id] = image('icons/effects/tile_effects.dmi', gas.tile_overlay, FLY_LAYER)
+	if(gas.overlay_limit)
+		overlay_limit[gas.id] = gas.overlay_limit
+	return TRUE
+
+/datum/xgm_data/proc/update_id(var/id)
+	if(gases[id])
+		return update(gases[id])
+	return FALSE
+
+/datum/xgm_data/proc/update_all()
+	for(var/id in gases)
+		update_id(id)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -713,6 +713,8 @@ var/global/floorIsLava = 0
 		<hr />
 		<A href='?src=\ref[src];vsc=airflow'>Edit ZAS Settings</A><br>
 		<A href='?src=\ref[src];vsc=default'>Choose a default ZAS setting</A><br>
+		<A href='?src=\ref[src];xgm_panel=1'>XGM Panel</A><br>
+		<hr />
 		"}
 
 	if(wages_enabled)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -4099,6 +4099,9 @@
 			if(href_list["vsc"] == "default")
 				zas_settings.SetDefault(usr)
 
+	else if(href_list["xgm_panel"])
+		XGM.ui_interact(usr)
+
 	else if(href_list["toglang"])
 		if(check_rights(R_SPAWN))
 			var/mob/M = locate(href_list["toglang"])

--- a/nano/templates/XGM_data.tmpl
+++ b/nano/templates/XGM_data.tmpl
@@ -1,0 +1,49 @@
+<div class="statusDisplay">
+	<div class="line">
+		After editing a gas, press its update button to apply the changes.
+	</div>
+	<br>
+	<div class="line">
+		<span class="bad">DO NOT</span> change the <span class="blue">id</span> var on any gas. It will fuck everything up.
+	</div>
+	<br>
+	<div class="line">
+		When you create a new gas, it will be initialized with default values for all vars except <span class="blue">id</span>. Edit and update it as usual to set the values you want.
+	</div>
+	<br>
+	<div class="line">
+		To add your new gas (or any other gas, for that matter) to a gas_mixture:
+	</div>
+	<div class="line">
+		<div class="statusLabel">
+			1.
+		</div>
+		<div class="statusValue">
+			VV the gas_mixture.
+		</div>
+	</div>
+	<div class="line">
+		<div class="statusLabel">
+			2.
+		</div>
+		<div class="statusValue">
+			Add a string equal to the gas's <span class="blue">id</span> to the gas_mixture's <span class="blue">gas</span> list, and associate it with the desired number of moles.
+		</div>
+	</div>
+</div>
+<div class="itemGroup">
+	{{for data.gases}}
+		<div class="item">
+			<div class="itemLabel">
+				{{>value.name}}
+			</div>
+			<div class="itemContent">
+				{{:helper.link('Edit', 'edit', {'edit' : value.id})}}
+				{{:helper.link('Update', 'refresh', {'update' : value.id})}}
+			</div>
+		</div>
+	{{/for}}
+	<div class="item">
+		{{:helper.link('Create New', 'plus', {'create' : 1})}}
+	</div>
+</div>

--- a/nano/templates/XGM_data.tmpl
+++ b/nano/templates/XGM_data.tmpl
@@ -38,7 +38,7 @@
 				{{>value.name}}
 			</div>
 			<div class="itemContent">
-				{{:helper.link('Edit', 'edit', {'edit' : value.id})}}
+				{{:helper.link('Edit', 'pencil', {'edit' : value.id})}}
 				{{:helper.link('Update', 'refresh', {'update' : value.id})}}
 			</div>
 		</div>


### PR DESCRIPTION
This panel contains some general instructions on how to use it, and lets you edit the properties of gases and create new ones.
At the moment, it just opens the gas datum in VV when you click edit. In the future, it might be changed to have an actual UI for editing them, both to prevent accidentally editing `id` and to allow easier use of `flags`.
Any admin can open the panel, but the buttons won't do anything unless you have +VAREDIT.

Also refactors how gases are added to XGM to accommodate gases created at runtime

![image](https://user-images.githubusercontent.com/9827785/46652304-aaf8ae00-cb70-11e8-9445-65f3a3dd2503.png)

I hate HTML too much to take the time to make it look better
It's in Nano because I wanted to learn Nano, and there's no reason for it not to be

The lack of a delete button is intentional. XGM absolutely does not expect a valid `gasid` to suddenly become invalid. This is also why you should **never ever** edit the `id` var of a gas.
Luckily, there's no performance impact from unused gases. If you create a gas by accident or make a typo in its `id` or something, just leave it.

:cl:
* rscadd: Added an admin button under the Game Panel allowing admins to edit the properties of gases, and to create new ones. The useful properties are currently limited pretty much to name, specific heat, and appearance, but in the future will include other details such as flammability.