### PR TITLE
Nerfs the chronically overused Wizard Artifacts (SoC, Summon Guns/Swords/Magic) by slightly increasing their prices.

### DIFF
--- a/code/game/gamemodes/wizard/artifacts.dm
+++ b/code/game/gamemodes/wizard/artifacts.dm
@@ -123,7 +123,7 @@
 /datum/spellbook_artifact/summon_magic
 	name = "Summon Magic"
 	desc = "Share the power of magic with the crew and turn them against each other. Or just empower them against you."
-	price = 3 * Sp_BASE_PRICE
+	price = 2 * Sp_BASE_PRICE
 	abbreviation = "SM"
 
 /* WIZARDS, NO SENSE OF RIGHT OR WRONG

--- a/code/game/gamemodes/wizard/artifacts.dm
+++ b/code/game/gamemodes/wizard/artifacts.dm
@@ -19,6 +19,7 @@
 	name = "Staff of Change"
 	desc = "An artefact that spits bolts of coruscating energy which cause the target's very form to reshape itself."
 	abbreviation = "ST"
+	price = 3 * Sp_BASE_PRICE
 	spawned_items = list(/obj/item/weapon/gun/energy/staff/change)
 
 /datum/spellbook_artifact/mental_focus
@@ -104,6 +105,7 @@
 /datum/spellbook_artifact/summon_guns
 	name = "Summon Guns"
 	desc = "Nothing could possibly go wrong with arming a crew of lunatics just itching for an excuse to kill eachother. Just be careful not to get hit in the crossfire!"
+	price = 2 * Sp_BASE_PRICE
 	abbreviation = "SG"
 
 /* WIZARDS, NO SENSE OF RIGHT OR WRONG
@@ -121,6 +123,7 @@
 /datum/spellbook_artifact/summon_magic
 	name = "Summon Magic"
 	desc = "Share the power of magic with the crew and turn them against each other. Or just empower them against you."
+	price = 3 * Sp_BASE_PRICE
 	abbreviation = "SM"
 
 /* WIZARDS, NO SENSE OF RIGHT OR WRONG
@@ -138,6 +141,7 @@
 /datum/spellbook_artifact/summon_swords
 	name = "Summon Swords"
 	desc = "Launch a crusade or just spark a blood bath. Either way there will be limbs flying and blood spraying."
+	price = 2 * Sp_BASE_PRICE
 	abbreviation = "SS"
 
 /datum/spellbook_artifact/summon_magic/can_buy()


### PR DESCRIPTION
Because of the frequency with which Wizards can spawn in the middle of rounds, even on 'Raging Mages' and summon guns, swords, and magic then roam around and fuck everyone up with their Staff of Change, completely gunking every round, I have slightly increased their prices.

- The Staff of Change now costs 60 points to buy, due to its sheer destructive potential.

- Summon Swords, Guns, and Magic each now cost 40 points to buy.

:cl:
 * rscdel: Increases the price on the Staff of Change, Summon Guns, Summon Swords, and Summon Magic.
