### PR TITLE
Humanoid Mobs Spawned by Traitor Lazarus Belt No Longer Drop Weapons

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -351,6 +351,9 @@
 		var/chosen = pick(critters)
 		critters -= chosen
 		var/mob/living/simple_animal/hostile/NM = new chosen(MC)
+		if(istype(NM, /mob/living/simple_animal/hostile/humanoid))
+			var/mob/living/simple_animal/hostile/humanoid/H = NM
+			H.items_to_drop = list()
 		NM.faction = "lazarus \ref[user]"
 		NM.friends += user
 		MC.contained_mob = NM


### PR DESCRIPTION
I'm actually not sure if the original report should be classified a bug, an oversight, or a feature request.
Regardless,
Fixes #8294.

:cl:
 * tweak: Humanoid mobs spawned by the traitor lazarus belt will no longer drop their weapons when they die.