### PR TITLE
Swap display of TEG circulators

### DIFF
--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -215,16 +215,16 @@
 		return
 
 	if(src.dir & (EAST|WEST))
-		circ1 = locate(/obj/machinery/atmospherics/binary/circulator) in get_step(src,EAST)
+		circ1 = locate(/obj/machinery/atmospherics/binary/circulator) in get_step(src,WEST)
 		if(circ1 && !circ1.anchored)
 			circ1 = null
 
-		circ2 = locate(/obj/machinery/atmospherics/binary/circulator) in get_step(src,WEST)
+		circ2 = locate(/obj/machinery/atmospherics/binary/circulator) in get_step(src,EAST)
 		if(circ2 && !circ2.anchored)
 			circ2 = null
 
 		if(circ1 && circ2)
-			if(circ1.dir != SOUTH || circ2.dir != NORTH)
+			if(circ1.dir != NORTH || circ2.dir != SOUTH)
 				circ1 = null
 				circ2 = null
 
@@ -344,8 +344,8 @@
 	if(dir & (NORTH | SOUTH))
 		vertical = 1
 
-	interface.updateContent("circ1", "Primary circulator ([vertical ? "top"		: "right"])")
-	interface.updateContent("circ2", "Primary circulator ([vertical ? "bottom"	: "left"])")
+	interface.updateContent("circ1", "Primary circulator ([vertical ? "top"		: "left"])")
+	interface.updateContent("circ2", "Primary circulator ([vertical ? "bottom"	: "right"])")
 
 	interface.updateContent("total_out", format_watts(last_gen))
 


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl:
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
Swaps the display of the TEG so that it matches the sides the circulators are actually on.

![](http://i.imgur.com/k71v61F.png)