### PR TITLE
Fixes num2words Runtime

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -503,6 +503,8 @@ var/quote = ascii2text(34)
 		if(hundreds)
 			out += num2words(hundreds, zero, minus, hundred, digits, tens, units, recursion+1) + list(hundred)
 			number %= 100
+			if(number == 0)
+				return out
 
 	if(number < 100)
 		// Teens


### PR DESCRIPTION
`num2words` can now properly count multiples of 100 without runtiming. In testing it counted all the way to 10,000 without any issue.
Fixes #8713.