### PR TITLE
Fixes Mechs Being Unable to Pass Through Portals

### DIFF
--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -147,7 +147,7 @@ var/list/portal_cache = list()
 /obj/effect/portal/proc/teleport(atom/movable/M as mob|obj)
 	if(istype(M, /obj/effect)) //sparks don't teleport
 		return
-	if (M.anchored&&istype(M, /obj/mecha))
+	if (M.anchored && !istype(M, /obj/mecha))
 		return
 	if (!target)
 		visible_message("<span class='warning'>The portal fails to find a destination and dissipates into thin air.</span>")


### PR DESCRIPTION
Fixes #8887.
As it turns out, mechs were not only unable to pass through wormholes, they were unable to pass through portals at all. This is because the commit which was originally supposed to add this feature, https://github.com/vgstation-coders/vgstation13/commit/ab87c76da187b80a0997af2aa343388c562d4fd5, did it incorrectly. *Seven years ago.*

The existence of the mech-mounted wormhole generator makes this even more strange, because as far as I can tell, mechs would have never been able to pass through their own wormholes at any point, even during the making of the item. Perhaps they used to create a different type of effect and they were changed into portals some time later.

:cl:
 * bugfix: Mechs can now pass through portals, including the wormholes created by the mech-mounted wormhole generator.