### PR TITLE
Fixes Constructed Lantern Hook Direction

### DIFF
--- a/code/modules/mining/mine_structures.dm
+++ b/code/modules/mining/mine_structures.dm
@@ -25,9 +25,10 @@
 	var/start_with_lantern = /obj/item/device/flashlight/lantern/on
 	var/busy = 0
 
-/obj/structure/hanging_lantern/New()
+/obj/structure/hanging_lantern/New(turf/T, var/build_dir)
 
 	..()
+	dir = build_dir
 
 	if(start_with_lantern)
 		lantern = new start_with_lantern(src)


### PR DESCRIPTION
Fixes #9189.

:cl:
 * bugfix: Wall-mounted lantern hooks now appear on the wall on which they were placed instead of always facing south when constructed.