### PR TITLE
removes the do_after from airlock attack_animal

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1054,8 +1054,8 @@ About the new airlock wires panel:
 		if(arePowerSystemsOn() && !(stat & NOPOWER))
 			if(level_of_door_opening < 2)
 				return
-			if(do_after(M, src, 100))
-				density ? open(1):close(1)
+			visible_message("<span class = 'warning'>\The [M] forces \the [src] [density?"open":"closed"]!</span>")
+			density ? open(1):close(1)
 		else
 			density ? open(1):close(1)
 


### PR DESCRIPTION
Who woulda thunked that life() isn't asynced. Wait that wouldn't help either. Regardless this kills the spider killing life() by making everyone wait their turn