### PR TITLE
Adds an end-game usage of money for vox

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -2966,6 +2966,7 @@ var/global/num_vending_terminals = 1
 		/obj/item/clothing/shoes/clown_shoes/advanced = 1,
 		/obj/item/fish_eggs/seadevil = 1,
 		/obj/machinery/power/antiquesynth = 1,
+		/obj/item/crackerbox = 1,
 		)
 	prices = list(
 		/obj/item/clothing/suit/storage/trader = 100,
@@ -2982,6 +2983,7 @@ var/global/num_vending_terminals = 1
 		/obj/item/clothing/shoes/clown_shoes/advanced = 50,
 		/obj/item/fish_eggs/seadevil = 50,
 		/obj/machinery/power/antiquesynth = 350,
+		/obj/item/crackerbox = 200,
 		)
 
 	accepted_coins = list(/obj/item/weapon/coin/trader)

--- a/code/game/objects/items/trader.dm
+++ b/code/game/objects/items/trader.dm
@@ -154,24 +154,35 @@
 	desc = "The greatest invention known to birdkind. Converts unwanted, unneeded cash, into useful, beautiful crackers!"
 	icon = 'icons/obj/toy.dmi'
 	icon_state = "fingerbox"
+	var/status //if true, is in use.
 
 /obj/item/crackerbox/examine(mob/user)
 	..()
-	to_chat(user, "<span class = 'notice'>Currently the conversion rate reads at [get_cash2cracker_rate()]</span>")
+	to_chat(user, "<span class = 'notice'>Currently the conversion rate reads at [get_cash2cracker_rate()] per cracker.</span>")
 
 /obj/item/crackerbox/proc/get_cash2cracker_rate()
 	return round(10, nanocoins_rates)
 
 /obj/item/crackerbox/attackby(obj/item/I, mob/user)
-	if(istype(I, /obj/item/weapon/spacecash) && user.drop_item(I, src))
+	if(!status && istype(I, /obj/item/weapon/spacecash) && user.drop_item(I, src))
+		status = TRUE
 		var/obj/item/weapon/spacecash/S = I
 		var/crackers_to_dispense = round((S.worth*S.amount)/get_cash2cracker_rate())
+		playsound(loc, 'sound/items/polaroid2.ogg', 50, 1)
 		if(!crackers_to_dispense)
 			say("Not enough! Never enough!")
 		spawn(3 SECONDS)
 			say("That is enough for [crackers_to_dispense] crackers!")
+			if(crackers_to_dispense > 100)
+				visible_message("<span class = 'warning'>\The [src]'s matter fabrication unit overloads!</span>")
+				explosion(loc, 0, prob(15), 2, 0)
+				qdel(src)
+				return
 			for(var/x = 1 to crackers_to_dispense)
 				var/obj/II = new /obj/item/weapon/reagent_containers/food/snacks/cracker(get_turf(src))
-				II.throw_at(get_turf(pick(oview(7,user))), 1*crackers_to_dispense, 1*crackers_to_dispense)
+				II.throw_at(get_turf(pick(orange(7,src))), 1*crackers_to_dispense, 1*crackers_to_dispense)
 				sleep(1)
+			status = FALSE
 		qdel(S)
+		return
+	..()

--- a/code/game/objects/items/trader.dm
+++ b/code/game/objects/items/trader.dm
@@ -148,3 +148,30 @@
 	add_salvagable_equipment(new /obj/item/mecha_parts/mecha_equipment/tool/collector,100)
 	add_salvagable_equipment(new /obj/item/mecha_parts/mecha_equipment/tool/tiler,100)
 	add_salvagable_equipment(new /obj/item/mecha_parts/mecha_equipment/tool/switchtool,100)
+
+/obj/item/crackerbox
+	name = "crackerbox"
+	desc = "The greatest invention known to birdkind. Converts unwanted, unneeded cash, into useful, beautiful crackers!"
+	icon = 'icons/obj/toy.dmi'
+	icon_state = "fingerbox"
+
+/obj/item/crackerbox/examine(mob/user)
+	..()
+	to_chat(user, "<span class = 'notice'>Currently the conversion rate reads at [get_cash2cracker_rate()]</span>")
+
+/obj/item/crackerbox/proc/get_cash2cracker_rate()
+	return round(10, nanocoins_rates)
+
+/obj/item/crackerbox/attackby(obj/item/I, mob/user)
+	if(istype(I, /obj/item/weapon/spacecash) && user.drop_item(I, src))
+		var/obj/item/weapon/spacecash/S = I
+		var/crackers_to_dispense = round((S.worth*S.amount)/get_cash2cracker_rate())
+		if(!crackers_to_dispense)
+			say("Not enough! Never enough!")
+		spawn(3 SECONDS)
+			say("That is enough for [crackers_to_dispense] crackers!")
+			for(var/x = 1 to crackers_to_dispense)
+				var/obj/II = new /obj/item/weapon/reagent_containers/food/snacks/cracker(get_turf(src))
+				II.throw_at(get_turf(pick(oview(7,user))), 1*crackers_to_dispense, 1*crackers_to_dispense)
+				sleep(1)
+		qdel(S)


### PR DESCRIPTION
Adds yet more vox powercreep. In this case, an item that converts the cash that traders get and have no use for into crackers.

The crackers are thrown at turfs in range, rather than dropping them all on the floor. 

After testing 
![crackerjack](https://user-images.githubusercontent.com/30557196/46879949-47f06b00-ce3f-11e8-9230-9d51093ae53b.PNG)
I added a hard limit of 100 crackers a time. Any more and it explodes.
