### PR TITLE
Fixes Cult Gateways Being Layered Over Objects

### DIFF
--- a/code/datums/gamemode/factions/legacy_cult/cult_structures.dm
+++ b/code/datums/gamemode/factions/legacy_cult/cult_structures.dm
@@ -121,6 +121,7 @@
 	icon_state = "hole"
 	density = 1
 	anchored = 1.0
+	plane = ABOVE_TURF_PLANE
 	var/spawnable = null
 
 /obj/effect/gateway/Bumped(mob/M as mob|obj)


### PR DESCRIPTION
I'm not actually sure if gateways are still used with new cult, but I figured I'd do this anyway since it <s>was a simple fix</s> was going to be a simple fix before I spent half an hour making changes to an unincluded duplicate file and wondering why they weren't showing up in-game. Delete all unincluded files when?
Fixes #10091.