### PR TITLE
Fixes simple_animal Regeneration

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -726,6 +726,7 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 	src.resurrect()
 	src.revive()
 	visible_message("<span class='warning'>[src] appears to wake from the dead, having healed all wounds.</span>")
+	isRegenerating = 0
 
 /mob/living/simple_animal/proc/pointed_at(var/mob/pointer)
 	return


### PR DESCRIPTION
`simple_animal`s with the ability to regenerate will no longer be permanently killed if you kill them again before the next `Life()` tick.
Fixes #10776.