### PR TITLE
Fixes Holidays.dm Runtime Error

### DIFF
--- a/code/game/gamemodes/events/holidays/Holidays.dm
+++ b/code/game/gamemodes/events/holidays/Holidays.dm
@@ -145,7 +145,8 @@ var/global/Holiday = null
 	if(MM == Easter_date["month"] && DD == Easter_date["day"])
 		current_holidays += EASTER
 
-	Holiday = pick(current_holidays)
+	if(current_holidays.len)
+		Holiday = pick(current_holidays)
 
 	if(!Holiday)
 		// Friday the 13th


### PR DESCRIPTION
I didn't know `pick()`ing from empty lists wasn't allowed.