### PR TITLE
Fixes Bombermen Not Being Able to Breathe in Space

### DIFF
--- a/code/modules/bomberman/bomberman.dm
+++ b/code/modules/bomberman/bomberman.dm
@@ -698,6 +698,10 @@ obj/structure/bomberflame/Destroy()
 	clothing_flags = CONTAINPLASMAMAN
 	var/never_removed = 1
 
+/obj/item/clothing/head/helmet/space/bomberman/equipped(mob/living/carbon/human/H, head)
+	if(istype(H) && H.get_item_by_slot(head) == src)
+		H.mutations.Add(M_NO_BREATH)
+
 /obj/item/clothing/head/helmet/space/bomberman/New()
 	..()
 	bombermangear += src

--- a/code/modules/bomberman/bomberman.dm
+++ b/code/modules/bomberman/bomberman.dm
@@ -704,7 +704,7 @@ obj/structure/bomberflame/Destroy()
 
 /obj/item/clothing/head/helmet/space/bomberman/unequipped(mob/living/carbon/human/user, var/from_slot = null)
 	if(from_slot == slot_head && istype(user))
-		H.mutations.Remove(M_NO_BREATH)
+		user.mutations.Remove(M_NO_BREATH)
 
 /obj/item/clothing/head/helmet/space/bomberman/New()
 	..()

--- a/code/modules/bomberman/bomberman.dm
+++ b/code/modules/bomberman/bomberman.dm
@@ -702,6 +702,10 @@ obj/structure/bomberflame/Destroy()
 	if(istype(H) && H.get_item_by_slot(head) == src)
 		H.mutations.Add(M_NO_BREATH)
 
+/obj/item/clothing/head/helmet/space/bomberman/unequipped(mob/living/carbon/human/user, var/from_slot = null)
+	if(from_slot == slot_head && istype(user))
+		H.mutations.Remove(M_NO_BREATH)
+
 /obj/item/clothing/head/helmet/space/bomberman/New()
 	..()
 	bombermangear += src


### PR DESCRIPTION
The bomberman helmet now confers the no-breathe mutation when equipped.
Fixes #9922.