### PR TITLE
Re-Liberates Bagel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
   global:
   - BYOND_MAJOR="512"
   - BYOND_MINOR="1453"
-  - ALL_MAPS="tgstation metaclub defficiency packedstation roidstation test_box test_tiny"
+  - ALL_MAPS="tgstation metaclub defficiency packedstation roidstation bagelstation test_box test_tiny"
   - PROJECT_NAME="vgstation13"
   - RUST_BACKTRACE="1"
   - RUST_TEST_THREADS=1


### PR DESCRIPTION
It turns out Travis doesn't check Bagel. In fact, Travis has *never* checked Bagel. Nobody noticed this.
Bagel wasn't compiling because #20021 accidentally undid #19807 

In addition to fixing compile, this adds Bagel to Travis.