### PR TITLE
Fixes Projectiles Not Being Able to Go Through Portals

### DIFF
--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -147,6 +147,8 @@ var/list/portal_cache = list()
 /obj/effect/portal/proc/teleport(atom/movable/M as mob|obj)
 	if(istype(M, /obj/effect)) //sparks don't teleport
 		return
+	if (M.anchored && !istype(M, /obj/mecha) && !istype(M, /obj/item/projectile))
+		return
 	if (!target)
 		visible_message("<span class='warning'>The portal fails to find a destination and dissipates into thin air.</span>")
 		qdel(src)

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -147,8 +147,6 @@ var/list/portal_cache = list()
 /obj/effect/portal/proc/teleport(atom/movable/M as mob|obj)
 	if(istype(M, /obj/effect)) //sparks don't teleport
 		return
-	if (M.anchored && !istype(M, /obj/mecha))
-		return
 	if (!target)
 		visible_message("<span class='warning'>The portal fails to find a destination and dissipates into thin air.</span>")
 		qdel(src)


### PR DESCRIPTION
<s>This allows all anchored objects which are capable of entering a portal, and therefore can move, to go through portals. I don't see any reason why not.</s>
I suppose the number of movable anchored objects is small enough anyway that not everything needs to be allowed by default.
Perhaps a `PASS_PORTAL` flag could be useful in the future if the list ends up growing.
Fixes #20141.