### PR TITLE
Fixes Subspace Tunneler Object Ejection

### DIFF
--- a/code/modules/projectiles/guns/projectile/constructable/subspacetunneler.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/subspacetunneler.dm
@@ -71,8 +71,10 @@
 		qdel(loaded_matter_bin)
 		loaded_matter_bin = null
 	if(stored_items.len)
-		spawn(0)
-			src.visible_message("<span class='warning'>\The [src]'s stored [stored_items.len > 1 ? "items are" : "item is"] forcibly ejected as \the [src] is destroyed!</span>")
+		for(var/atom/movable/AM in stored_items)
+			AM.forceMove(null)
+		src.visible_message("<span class='warning'>\The [src]'s stored [stored_items.len > 1 ? "items are" : "item is"] forcibly ejected as \the [src] is destroyed!</span>")
+		spawn()
 			for(var/I in stored_items)
 				var/offset_x = rand(-3,3)
 				var/offset_y = rand(-3,3)


### PR DESCRIPTION
The parent was being called and the items were being deleted before they actually got ejected. Now the items are stored in nullspace before being ejected one-by-one, so they don't get deleted due to not being in the tunneler's contents when it is deleted.
Fixes #11961.

:cl:
 * bugfix: The subspace tunneler will now properly eject its stored objects when deleted rather than taking them to the grave with it.