### PR TITLE
Hiding the count of players ready in the lobby

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -86,11 +86,16 @@
 			stat("Time To Start:", "LOADING...")
 
 		if(SSticker.initialized && ticker.current_state == GAME_STATE_PREGAME)
-			stat("Players: [totalPlayers]", "Players Ready: [totalPlayersReady]")
+			stat("Players: [totalPlayers]")
+			if (check_rights(R_ADMIN))
+				stat("Players Ready: [totalPlayersReady]")
 			totalPlayers = 0
 			totalPlayersReady = 0
 			for(var/mob/new_player/player in player_list)
-				stat("[player.key]", (player.ready)?("(Playing)"):(null))
+				if (check_rights(R_ADMIN))
+					stat("[player.key]", (player.ready)?("(Playing)"):(null))
+				else
+					stat("[player.key]")
 				totalPlayers++
 				if(player.ready)
 					totalPlayersReady++


### PR DESCRIPTION
Now that Dynamic Mode is in, giving another shot at #18813 except this time people can still see the total player count, and the list of players (which they could see by doing /who anyway)

![image](https://user-images.githubusercontent.com/7573912/46906547-75075100-cf05-11e8-8f06-a4729aff12c2.png)

This makes sense to me considering that modes aren't locked by pop alone now.

:cl:
* tweak: The count of players ready in the lobby is now only visible to admins, to help prevent players guessing roundstart antagonists by checking the crew manifest.