### PR TITLE
Faint is now a temporary knockdown

### DIFF
--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -75,7 +75,7 @@
 	. = ..()
 	if(. && isliving(user))
 		var/mob/living/L = user
-		L.Knockdown(3)
+		L.sleeping += 10 // You can't faint when you're asleep.
 
 /datum/emote/living/flap
 	key = "flap"

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -75,7 +75,7 @@
 	. = ..()
 	if(. && isliving(user))
 		var/mob/living/L = user
-		L.SetSleeping(200)
+		L.Knockdown(3)
 
 /datum/emote/living/flap
 	key = "flap"


### PR DESCRIPTION
I've had people complaining than emoting *faint put them to sleep.

:cl:
- tweak: Faint is now a temporary knockdown instead of a 200 seconds sleep.