### PR TITLE
Fix monkeyhumans crying out into the void causing runtimes

### DIFF
--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -72,9 +72,10 @@
 				return "Unknown"
 		else
 			return real_name
-	var/datum/role/changeling/changeling = mind.GetRole(CHANGELING)
-	if(changeling && changeling.mimicing)
-		return changeling.mimicing
+	if(mind) // monkeyhumans exist, don't descriminate
+		var/datum/role/changeling/changeling = mind.GetRole(CHANGELING)
+		if(changeling && changeling.mimicing)
+			return changeling.mimicing
 	if(GetSpecialVoice())
 		return GetSpecialVoice()
 	return real_name


### PR DESCRIPTION
No associated issue to close
```
[07:48:23] Runtime in say.dm,75: Cannot execute null.GetRole().
  proc name: GetVoice (/mob/living/carbon/human/GetVoice)
  src: Kaelea Stough (/mob/living/carbon/human)
  src.loc: the DNA modifier (/obj/machinery/dna_scannernew)
  call stack:
  Kaelea Stough (/mob/living/carbon/human): GetVoice()
  Kaelea Stough (/mob/living/carbon/human): create speech("FUCK", 0, null)
  Kaelea Stough (/mob/living/carbon/human): say("FUCK", null)
  Kaelea Stough (/mob/living/carbon/human): handle disabilities()
  Kaelea Stough (/mob/living/carbon/human): Life()
  Mob (/datum/subsystem/mob): fire(0)
  Mob (/datum/subsystem/mob): ignite(0)
  Master (/datum/controller/master): RunQueue()
  Master (/datum/controller/master): Loop()
  Master (/datum/controller/master): StartProcessing()
```