### PR TITLE
Fix bats trying to check if they're biting their dads when they never had a father to begin with

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/bat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bat.dm
@@ -50,7 +50,7 @@
 	if (!istype(the_target, /mob/living))
 		return ..()
 	var/mob/living/L = the_target
-	if (L.mind)
+	if (L.mind && vamp_fac)
 		for (var/R in L.mind.antag_roles)
 			if (L.mind.antag_roles[R] in vamp_fac.members)
 				return FALSE
@@ -65,7 +65,7 @@
 	if(!istype(A, /mob/living))
 		return FALSE
 	var/mob/living/L = A
-	if (L.mind)
+	if (L.mind && vamp_fac)
 		for (var/R in L.mind.antag_roles)
 			if (L.mind.antag_roles[R] in vamp_fac.members)
 				return FALSE


### PR DESCRIPTION
runtime fix:
```dm
[22:31:46] Runtime in bat.dm,70: Cannot read null.members
  proc name: Found (/mob/living/simple_animal/hostile/scarybat/Found)
  src: the space bats (/mob/living/simple_animal/hostile/scarybat)
  src.loc: Carpet (68,49,7) (/turf/simulated/floor/carpet)
  call stack:
  the space bats (/mob/living/simple_animal/hostile/scarybat): Found(Joel Nash (/mob/living/carbon/human/lich))
  the space bats (/mob/living/simple_animal/hostile/scarybat): FindTarget()
  the space bats (/mob/living/simple_animal/hostile/scarybat): FindTarget()
  the space bats (/mob/living/simple_animal/hostile/scarybat): Life()
  Mob (/datum/subsystem/mob): fire(0)
  Mob (/datum/subsystem/mob): ignite(0)
  Master (/datum/controller/master): RunQueue()
  Master (/datum/controller/master): Loop()
  Master (/datum/controller/master): StartProcessing()
```

:cl:
 - bugfix: Bats no longer try to figure out if you're their father before biting you if their father was never there for them anyways