### PR TITLE
Fix runtimes with beams trying to draw while being fed null locs; runtime with projectile resetting

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -547,6 +547,8 @@ var/list/impact_master = list()
 
 /obj/item/projectile/proc/reset()
 	starting = get_turf(src)
+	if(isnull(starting))
+		return
 	override_starting_X = starting.x
 	override_starting_Y = starting.y
 	override_target_X = override_starting_X+dist_x

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -715,9 +715,8 @@ var/list/beam_master = list()
 				error -= dist_y
 
 			if(isnull(loc))
-				if(isnull(lastposition))
-					return
-				draw_ray(lastposition)
+				if(!isnull(lastposition))
+					draw_ray(lastposition)
 				return
 			if(lastposition == loc)
 				kill_count = 0
@@ -753,9 +752,8 @@ var/list/beam_master = list()
 				error -= dist_x
 
 			if(isnull(loc))
-				if(isnull(lastposition))
-					return
-				draw_ray(lastposition)
+				if(!isnull(lastposition))
+					draw_ray(lastposition)
 				return
 			if(lastposition == loc)
 				kill_count = 0

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -715,6 +715,8 @@ var/list/beam_master = list()
 				error -= dist_y
 
 			if(isnull(loc))
+				if(isnull(lastposition))
+					return
 				draw_ray(lastposition)
 				return
 			if(lastposition == loc)
@@ -751,6 +753,8 @@ var/list/beam_master = list()
 				error -= dist_x
 
 			if(isnull(loc))
+				if(isnull(lastposition))
+					return
 				draw_ray(lastposition)
 				return
 			if(lastposition == loc)


### PR DESCRIPTION
Relevant runtimes:
```dm
[18:30:22] Runtime in beams.dm,790: Cannot read null.x
  proc name: draw ray (/obj/item/projectile/beam/bison/proc/draw_ray)
  usr: Nan Keener (charmstruck) (/mob/living/carbon/human)
  usr.loc: Carpet (339, 350, 6) (/turf/simulated/floor/carpet)
  src: the heat ray (/obj/item/projectile/beam/bison)
  src.loc: null
  call stack:
  the heat ray (/obj/item/projectile/beam/bison): draw ray(Carpet (339,350,6) (/turf/simulated/floor/carpet))
  the heat ray (/obj/item/projectile/beam/bison): process()
```
```dm
[02:05:08] Runtime in projectile.dm,550: Cannot read null.x
  proc name: reset (/obj/item/projectile/proc/reset)
  src: the projectile (/obj/item/projectile/friendlyCheck)
  src.loc: null
  call stack:
  the projectile (/obj/item/projectile/friendlyCheck): reset()
  space (7,125,3) (/turf/space): Entered(the projectile (/obj/item/projectile/friendlyCheck), space (8,125,3) (/turf/space))
```

I am a bit unsure about the bison fix. It's kind of a mess, but I found that the lines I changed were the ones calling draw_ray and providing a null loc.
`Firer` inside `draw_ray` would also be null, but seemingly, only when lastposition was also null.
Is there another fix? Maybe, but this proc is kind of a mess and rather than try to fix what works (except the runtime) I'd rather just do this instead to suppress the runtime.