### PR TITLE
Layer adapters now only adapt the layer they are supposed to

### DIFF
--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -211,7 +211,7 @@ Pipelines + Other Objects -> Pipe network
 //Called when checking connectability in findConnecting()
 //This is checked for both pipes in establishing a connection - the base behaviour will work fine nearly every time
 /obj/machinery/atmospherics/proc/isConnectable(var/obj/machinery/atmospherics/target, var/direction, var/given_layer)
-	return (target.piping_layer == given_layer || target.pipe_flags & ALL_LAYER)
+	return (target.get_layer_of_dir(turn(direction, 180)) == given_layer || target.pipe_flags & ALL_LAYER)
 
 /obj/machinery/atmospherics/proc/getNodeType(var/node_id)
 	return PIPE_TYPE_STANDARD
@@ -396,3 +396,8 @@ Pipelines + Other Objects -> Pipe network
 
 	var/turf/T = loc
 	return !T.intact
+
+// Returns the layer of a pipe connection in the specified direction
+// Only needs to be overridden if a pipe can connect on different layers
+/obj/machinery/atmospherics/proc/get_layer_of_dir(var/direction)
+	return piping_layer

--- a/code/ATMOSPHERICS/burstpipe.dm
+++ b/code/ATMOSPHERICS/burstpipe.dm
@@ -20,7 +20,7 @@
 
 /obj/machinery/atmospherics/unary/vent/burstpipe/update_icon()
 	alpha = invisibility ? 128 : 255
-	if(!node || istype(node,type)) // No connection, or the connection is another burst pipe
+	if(!node1 || istype(node1,type)) // No connection, or the connection is another burst pipe
 		qdel(src) //TODO: silent deleting looks weird
 
 /obj/machinery/atmospherics/unary/vent/burstpipe/ex_act(var/severity)
@@ -34,9 +34,9 @@
 	level = T.intact ? 2 : 1
 	initialize()
 	build_network()
-	if (node)
-		node.initialize()
-		node.build_network()
+	if (node1)
+		node1.initialize()
+		node1.build_network()
 
 /obj/machinery/atmospherics/unary/vent/burstpipe/attackby(var/obj/item/weapon/W, var/mob/user)
 	if (!iswrench(W))

--- a/code/ATMOSPHERICS/components/binary_devices/binary_atmos_base.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/binary_atmos_base.dm
@@ -120,6 +120,9 @@
 	if(node1 && node2)
 		return
 
+	// While other pipes/atmos machinery can use whatever node for any other pipe,
+	// most binary pumps must specifically have the succ end on node1, and the blow
+	// end on node2.
 	node1 = findConnecting(turn(dir, 180))
 	node2 = findConnecting(dir)
 

--- a/code/ATMOSPHERICS/components/unary/outlet_injector.dm
+++ b/code/ATMOSPHERICS/components/unary/outlet_injector.dm
@@ -28,7 +28,7 @@
 	return 0
 
 /obj/machinery/atmospherics/unary/outlet_injector/update_icon()
-	if(node)
+	if(node1)
 		if(on && !(stat & NOPOWER))
 			icon_state = "hon"
 		else
@@ -145,7 +145,7 @@
 	update_icon()
 
 /obj/machinery/atmospherics/unary/outlet_injector/hide(var/i) //to make the little pipe section invisible, the icon changes.
-	if(node)
+	if(node1)
 		if(on)
 			icon_state = "[i == 1 && istype(loc, /turf/simulated) ? "h" : "" ]on"
 		else

--- a/code/ATMOSPHERICS/components/unary/oxygen_generator.dm
+++ b/code/ATMOSPHERICS/components/unary/oxygen_generator.dm
@@ -14,7 +14,7 @@ obj/machinery/atmospherics/unary/oxygen_generator
 	var/oxygen_content = 10
 
 obj/machinery/atmospherics/unary/oxygen_generator/update_icon()
-	if(node)
+	if(node1)
 		icon_state = "intact_[on?("on"):("off")]"
 	else
 		icon_state = "exposed_off"

--- a/code/ATMOSPHERICS/components/unary/portables_connector.dm
+++ b/code/ATMOSPHERICS/components/unary/portables_connector.dm
@@ -34,12 +34,12 @@
 	if(connected_device)
 		connected_device.disconnect()
 
-	if(node)
-		node.disconnect(src)
+	if(node1)
+		node1.disconnect(src)
 		if(network)
 			returnToPool(network)
 
-	node = null
+	node1 = null
 
 	..()
 
@@ -52,7 +52,7 @@
 /obj/machinery/atmospherics/unary/portables_connector/return_network(obj/machinery/atmospherics/reference)
 	build_network()
 
-	if(reference==node)
+	if(reference==node1)
 		return network
 
 	if(reference==connected_device)

--- a/code/ATMOSPHERICS/components/unary/unary_base.dm
+++ b/code/ATMOSPHERICS/components/unary/unary_base.dm
@@ -4,7 +4,7 @@
 	layer = UNARY_PIPE_LAYER
 
 	var/datum/gas_mixture/air_contents
-	var/obj/machinery/atmospherics/node
+	var/obj/machinery/atmospherics/node1
 	var/datum/pipe_network/network
 
 /obj/machinery/atmospherics/unary/New()
@@ -24,7 +24,7 @@
 	layer = PIPING_LAYER(layer, piping_layer)
 
 /obj/machinery/atmospherics/unary/update_icon(var/adjacent_procd,node_list)
-	node_list = list(node)
+	node_list = list(node1)
 	..(adjacent_procd,node_list)
 
 
@@ -38,14 +38,14 @@
 	update_planes_and_layers()
 	initialize()
 	build_network()
-	if (node)
-		node.initialize()
-		node.build_network()
+	if (node1)
+		node1.initialize()
+		node1.build_network()
 	return 1
 
 // Housekeeping and pipe network stuff below
 /obj/machinery/atmospherics/unary/network_expand(datum/pipe_network/new_network, obj/machinery/atmospherics/pipe/reference)
-	if(reference == node)
+	if(reference == node1)
 		network = new_network
 	if(new_network.normal_members.Find(src))
 		return 0
@@ -53,35 +53,30 @@
 	return null
 
 /obj/machinery/atmospherics/unary/Destroy()
-	if(node)
-		node.disconnect(src)
+	if(node1)
+		node1.disconnect(src)
 		if(network)
 			returnToPool(network)
-	node = null
+	node1 = null
 	..()
 
 /obj/machinery/atmospherics/unary/initialize()
-	if(node)
+	if(node1)
 		return
-	var/node_connect = dir
-	for(var/obj/machinery/atmospherics/target in get_step(src,node_connect))
-		if(target.initialize_directions & get_dir(target,src))
-			if(target.piping_layer == piping_layer || target.pipe_flags & ALL_LAYER)
-				node = target
-				break
+	findAllConnections(initialize_directions)
 	update_icon()
 	add_self_to_holomap()
 
 /obj/machinery/atmospherics/unary/build_network()
-	if(!network && node)
+	if(!network && node1)
 		network = getFromPool(/datum/pipe_network)
 		network.normal_members += src
-		network.build_network(node, src)
+		network.build_network(node1, src)
 
 
 /obj/machinery/atmospherics/unary/return_network(obj/machinery/atmospherics/reference)
 	build_network()
-	if(reference == node || reference == src)
+	if(reference == node1 || reference == src)
 		return network
 	return null
 
@@ -97,10 +92,10 @@
 	return results
 
 /obj/machinery/atmospherics/unary/disconnect(obj/machinery/atmospherics/reference)
-	if(reference==node)
+	if(reference==node1)
 		if(network)
 			returnToPool(network)
-		node = null
+		node1 = null
 	return ..()
 
 /obj/machinery/atmospherics/unary/unassign_network(datum/pipe_network/reference)

--- a/code/ATMOSPHERICS/components/unary/vent.dm
+++ b/code/ATMOSPHERICS/components/unary/vent.dm
@@ -24,7 +24,7 @@
 	. = ..()
 
 	CHECK_DISABLED(vents)
-	if (!node)
+	if (!node1)
 		return// Turning off the vent is a PITA. - N3X
 
 	// New GC does this sometimes

--- a/code/ATMOSPHERICS/components/unary/vent_pump.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_pump.dm
@@ -91,7 +91,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/process()
 	. = ..()
 	CHECK_DISABLED(vents)
-	if (!node)
+	if (!node1)
 		return // Turning off the vent is a PITA. - N3X
 	if(stat & (NOPOWER|BROKEN))
 		return

--- a/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
@@ -63,7 +63,7 @@
 
 	icon_state = prefix + "off"
 
-	if (node && on && !(stat & (NOPOWER|BROKEN)))
+	if (node1 && on && !(stat & (NOPOWER|BROKEN)))
 		var/state = ""
 		if (scrubbing)
 			state = "on"
@@ -140,7 +140,7 @@
 	CHECK_DISABLED(scrubbers)
 	if(stat & (NOPOWER|BROKEN))
 		return
-	if (!node)
+	if (!node1)
 		return // Let's not shut it off, for now.
 	if(welded)
 		return

--- a/code/ATMOSPHERICS/pipes.dm
+++ b/code/ATMOSPHERICS/pipes.dm
@@ -1149,8 +1149,6 @@
 
 	volume = 260 //6 averaged pipe segments
 
-	pipe_flags = ALL_LAYER
-
 	var/obj/machinery/atmospherics/layer_node = null
 	var/obj/machinery/atmospherics/mid_node = null
 
@@ -1279,11 +1277,6 @@
 					continue
 				layer_node = found
 
-/obj/machinery/atmospherics/pipe/layer_adapter/isConnectable(var/obj/machinery/atmospherics/target, var/direction, var/given_layer)
-	if(direction == dir)
-		return (given_layer == PIPING_LAYER_DEFAULT)
-	return ..()
-
 /obj/machinery/atmospherics/pipe/layer_adapter/getNodeType()
 	return PIPE_TYPE_STANDARD
 
@@ -1297,3 +1290,9 @@
 		user.ventcrawl_layer = (direction == dir) ? PIPING_LAYER_DEFAULT : piping_layer
 		to_chat(user, "You are redirected into the [user.ventcrawl_layer]\th piping layer.")
 		return ..()
+
+/obj/machinery/atmospherics/pipe/layer_adapter/get_layer_of_dir(var/direction)
+	if (direction == dir)
+		return PIPING_LAYER_DEFAULT // requested direction is our mid_node
+	else if (turn(direction, 180) == dir)
+		return piping_layer // requested direction is our layer_node

--- a/code/game/machinery/Freezer.dm
+++ b/code/game/machinery/Freezer.dm
@@ -45,8 +45,8 @@
 	temp_offset = initial(temp_offset) - 5*lasercount
 
 /obj/machinery/atmospherics/unary/cold_sink/freezer/update_icon()
-	if(src.node)
-		if(src.on)
+	if(node1)
+		if(on)
 			icon_state = "freezer_1"
 		else
 			icon_state = "freezer"
@@ -78,14 +78,14 @@
 		initialize_directions = dir
 		initialize()
 		build_network()
-		if (node)
-			node.initialize()
-			node.build_network()
+		if (node1)
+			node1.initialize()
+			node1.build_network()
 	else
 		verbs += rotate_verbs
-		if(node)
-			node.disconnect(src)
-			node = null
+		if(node1)
+			node1.disconnect(src)
+			node1 = null
 		if(network)
 			qdel(network)
 			network = null
@@ -217,8 +217,8 @@
 	temp_offset = initial(temp_offset) + 5*lasercount
 
 /obj/machinery/atmospherics/unary/heat_reservoir/heater/update_icon()
-	if(src.node)
-		if(src.on)
+	if(node1)
+		if(on)
 			icon_state = "heater_1"
 		else
 			icon_state = "heater"
@@ -251,14 +251,14 @@
 		initialize_directions = dir
 		initialize()
 		build_network()
-		if (node)
-			node.initialize()
-			node.build_network()
+		if (node1)
+			node1.initialize()
+			node1.build_network()
 	else
 		verbs += rotate_verbs
-		if(node)
-			node.disconnect(src)
-			node = null
+		if(node1)
+			node1.disconnect(src)
+			node1 = null
 		if(network)
 			qdel(network)
 			network = null

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -52,16 +52,16 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 	initialize_directions = dir
 	initialize()
 	build_network()
-	if (node)
-		node.initialize()
-		node.build_network()
+	if (node1)
+		node1.initialize()
+		node1.build_network()
 
 /obj/machinery/atmospherics/unary/cryo_cell/initialize()
-	if(node)
+	if(node1)
 		return
 	for(var/cdir in cardinal)
-		node = findConnecting(cdir)
-		if(node)
+		node1 = findConnecting(cdir)
+		if(node1)
 			break
 	update_icon()
 
@@ -152,7 +152,7 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 	if(stat & NOPOWER)
 		on = 0
 
-	if(!node)
+	if(!node1)
 		return
 	if(!on)
 		updateUsrDialog()
@@ -585,7 +585,7 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 		return*/
 	if(M.locked_to)
 		M.unlock_from()
-	if(!node)
+	if(!node1)
 		to_chat(usr, "<span class='warning'>The cell is not correctly connected to its pipe network!</span>")
 		return
 	if(usr.pulling == M)


### PR DESCRIPTION
Fixes #19409

There were multiple issues with the layer adapters:
- Layer adapters had the ALL_LAYERS flag, meaning their layered side could connect to ANY of the five layers, rather than the one they were specifically meant to.
- Pipe connections didn't bother to check if the actual end they were connecting to was on the same layer.  You could do some funky stuff if you dodged the checks correctly.
- Unary devices had copy pasted code for initialization which didn't use `isConnectable()`.  I had to rename the `node` var so that unary devices could use the `findAllConnections()` proc that most other pipes use.

Because I touched a bunch of files doing this, these are the things I tested:
- Layer adapters connecting to a single pipe, connecting to a pipe sharing a tile with multiple pipes, and connecting to unary, binary and ternary devices.
- Layer manifolds also work properly.
- Distro devices (scrubbers, vents, pumps) as a part of distro and on their own.  All working as before.
- Tested cryo to make sure it was working as before.

:cl:
 * bugfix: Fixes layer adapters being able to connect to any pipe on any layer.  They can now only connect to the pipe layers they are spawned with.