### PR TITLE
Fixes Eat Power Not Allowing You to Eat Handcuffs

### DIFF
--- a/__DEFINES/spell_defines.dm
+++ b/__DEFINES/spell_defines.dm
@@ -18,6 +18,7 @@
 #define NO_BUTTON		1024	//spell won't show up in the HUD with this
 #define WAIT_FOR_CLICK	2048//spells wait for you to click on a target to cast
 #define TALKED_BEFORE	4096//spells require you to have heard the person you are casting it upon
+#define CAN_CHANNEL_RESTRAINED 8192 //channeled spells that you can cast despite having handcuffs on
 
 //invocation
 #define SpI_SHOUT	"shout"

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -237,7 +237,8 @@
 	Not currently used by anything but could easily be.
 */
 /mob/proc/RestrainedClickOn(var/atom/A)
-	return
+	if(INVOKE_EVENT(on_ruattack,list("atom"=A))) //This returns 1 when doing an action intercept
+		return
 
 /*
 	Middle click

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -77,7 +77,7 @@
 	return 0
 
 /mob/living/carbon/human/RestrainedClickOn(var/atom/A)
-	return
+	..()
 
 /mob/living/carbon/human/RangedAttack(var/atom/A)
 	if(!gloves && !mutations.len)
@@ -115,7 +115,7 @@
 /atom/proc/attack_animal(mob/user as mob)
 	return
 /mob/living/RestrainedClickOn(var/atom/A)
-	return
+	..()
 
 /*
 	Monkeys

--- a/code/game/dna/genes/goon_powers.dm
+++ b/code/game/dna/genes/goon_powers.dm
@@ -195,7 +195,7 @@
 	range = 1
 	max_targets = 1
 	selection_type = "view"
-	spell_flags = WAIT_FOR_CLICK
+	spell_flags = WAIT_FOR_CLICK | CAN_CHANNEL_RESTRAINED
 
 	override_base = "genetic"
 	hud_state = "gen_eat"

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -29,6 +29,8 @@
 		on_spellcast.holder = null
 	if(on_uattack)
 		on_uattack.holder = null
+	if(on_ruattack)
+		on_ruattack.holder = null
 	if(on_damaged)
 		on_damaged.holder = null
 	if(on_irradiate)
@@ -76,6 +78,7 @@
 	on_moved = null
 	qdel(on_spellcast)
 	qdel(on_uattack)
+	qdel(on_ruattack)
 	qdel(on_damaged)
 	qdel(on_clickon)
 	qdel(on_irradiate)
@@ -83,6 +86,7 @@
 
 	on_spellcast = null
 	on_uattack = null
+	on_ruattack = null
 	on_damaged = null
 	on_clickon = null
 	on_irradiate = null
@@ -298,6 +302,7 @@
 	store_position()
 	on_spellcast = new(owner = src)
 	on_uattack = new(owner = src)
+	on_ruattack = new(owner = src)
 	on_logout = new(owner = src)
 	on_damaged = new(owner = src)
 	on_clickon = new(owner = src)

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -277,6 +277,7 @@
 	var/list/languages[0]
 	var/event/on_spellcast
 	var/event/on_uattack
+	var/event/on_ruattack	//on restrained unarmed attack
 	var/event/on_logout
 	var/event/on_damaged
 	var/event/on_irradiate

--- a/code/modules/spells/spell_code.dm
+++ b/code/modules/spells/spell_code.dm
@@ -194,12 +194,17 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 			return 0
 		user.remove_spell_channeling() //In case we're swapping from an older spell to this new one
 		user.spell_channeling = user.on_uattack.Add(src, "channeled_spell")
+		if(spell_flags & CAN_CHANNEL_RESTRAINED)
+			user.spell_channeling = user.on_ruattack.Add(src, "channeled_spell")
 		connected_button.name = "(Ready) [name]"
 		currently_channeled = 1
 		connected_button.add_channeling()
 	else
 		var/event/E = user.on_uattack
 		E.handlers.Remove(user.spell_channeling)
+		var/event/ER = user.on_ruattack
+		if(ER)
+			ER.handlers.Remove(user.spell_channeling)
 		user.spell_channeling = null
 		currently_channeled = 0
 		connected_button.remove_channeling()


### PR DESCRIPTION
Handcuffs no longer impede usage of the Eat power, as it was before spell channeling.
Also adds a new spell flag, for channeled spells that are able to be cast while restrained.
At some point I think it'd be nice to have a system for assigning verbal/somatic/material components to spells, so we could have certain wizard spells that you can cast while gagged but not bound and vice versa, and potentially more powerful spells that require you to steal items to fuel them.
Fixes #11962.