### PR TITLE
Fixes Ghosts Getting Nullspaced By The Teleporter

### DIFF
--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -268,7 +268,8 @@
 	var/obj/machinery/computer/teleporter/com = locate(/obj/machinery/computer/teleporter, locate(l.x - 2, l.y, l.z))
 	if (!com)
 		return
-	if (!com.locked)
+	if (!com.locked || com.locked.gcDestroyed)
+		com.locked = null
 		for(var/mob/O in hearers(src, null))
 			O.show_message("<span class='warning'>Failure: Cannot authenticate locked on coordinates. Please reinstate coordinate matrix.</span>")
 		return


### PR DESCRIPTION
Fixes #12175.
It turns out that the reason they were getting nullspaced is because once the beacon is deleted, the destination is in nullspace. The teleporter never checked that the beacon still existed so it would continue to function until it was finally deleted for real by the garbage collector.
The only reason it wasn't nullspacing humans is that the lack of a Z-level for the destination caused a runtime error in `teleportChecks()`, otherwise I'm sure it would have.