### PR TITLE
Fixes an href exploit with the holodeck

### DIFF
--- a/code/game/machinery/computer/HolodeckControl.dm
+++ b/code/game/machinery/computer/HolodeckControl.dm
@@ -26,6 +26,8 @@
 	return
 
 /obj/machinery/computer/HolodeckControl/proc/spawn_holoperson(mob/dead/observer/user)
+	if (!istype(user) || user.stat != DEAD )
+		return
 	if(stat & (NOPOWER|BROKEN|MAINT))
 		return
 	if(!ticker || ticker.current_state != GAME_STATE_PLAYING)
@@ -118,6 +120,7 @@
 	else
 		if(issilicon(user))
 			dat += "<A href='?src=\ref[src];AIoverride=1'>(<font color=red>Override Safety Protocols?</font>)</A><BR>"
+
 
 		dat += {"<BR>
 			Safety Protocols are <font color=green> ENABLED </font><BR>"}


### PR DESCRIPTION
Closes #20237 

This is less bad as I thought it would be (I feared mouses/dionae could use it) but the machinery in-built sanities prevent this, to an extent (Connection failed/you don't have the dexterity to do this).
However, they could still become holopersons whilst alive, and cyborgs/mommis/shuted AIs with careful href skills could teleport to the holodeck, and abuse the transmogorify proc.