### PR TITLE
Fixes duplicating RnD machines

### DIFF
--- a/code/modules/mining/materials.dm
+++ b/code/modules/mining/materials.dm
@@ -11,10 +11,12 @@
 */
 
 proc/initialize_materials()
-	for(var/matdata in typesof(/datum/material) - /datum/material)
+	for(var/matdata in subtypesof(/datum/material))
 		var/datum/material/mat = new matdata
 		material_list += list(mat.id = mat)
-		initial_materials += list(mat.id = 0)
+		if (!mat.sheettype)
+			continue
+		initial_materials += list(mat.id = 0) // This is for machines in r&d who have a material holder. If you can't make sheets of the material, you can't put in an r_n_d machine to begin with.
 
 var/global/list/material_list		//Stores an instance of all the datums as an assoc with their matids
 var/global/list/initial_materials	//Stores all the matids = 0 in helping New

--- a/code/modules/research/rdmachines.dm
+++ b/code/modules/research/rdmachines.dm
@@ -127,7 +127,6 @@ var/global/list/rnd_machines = list()
 	if(..() == 1)
 		if (materials)
 			for(var/matID in materials.storage)
-				to_chat(world, "[matID] : [materials.storage[matID]]")
 				if (materials.storage[matID] == 0) // No materials of this type
 					continue
 				var/datum/material/M = materials.getMaterial(matID)

--- a/code/modules/research/rdmachines.dm
+++ b/code/modules/research/rdmachines.dm
@@ -127,6 +127,9 @@ var/global/list/rnd_machines = list()
 	if(..() == 1)
 		if (materials)
 			for(var/matID in materials.storage)
+				to_chat(world, "[matID] : [materials.storage[matID]]")
+				if (materials.storage[matID] == 0) // No materials of this type
+					continue
 				var/datum/material/M = materials.getMaterial(matID)
 				var/obj/item/stack/sheet/sheet = new M.sheettype(src.loc)
 				if(sheet)


### PR DESCRIPTION
Closes #20155 

Basically, this does two things : 
1/ When deconstructed the RnD machine will check it actually has the material in storage instead of creating a blank stack and deleting it as it realise it's empty
2/ Initialisation of materials will not initialise in the list made for material holders things that cannot be put into material holders (currently, only ice crystal ; they don't have any interaction will material holder whatsoever, there is not even an ice ore, you end up getting the finished product straight away.)

Also the runtime was due to (1) the RnD machine creating a stack of everything and (2) ice having no sheettype.