### PR TITLE
[DNM] Noir greyscale colours are now properly set and unset

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -453,7 +453,6 @@ var/global/list/NOIRMATRIX = list(0.33,0.33,0.33,0,\
 								  0.33,0.33,0.33,0,\
 								  0.00,0.00,0.00,1,\
 								  0.00,0.00,0.00,0)
-var/global/list/bad_changing_colour_ckeys = list()
 
 // Bustanuts
 #define M_HARDCORE      300

--- a/code/game/dna/genes/vg_powers.dm
+++ b/code/game/dna/genes/vg_powers.dm
@@ -135,13 +135,13 @@ Obviously, requires DNA2.
 
 /datum/dna/gene/basic/noir/activate(var/mob/M)
 	..()
-	M.update_colour(time = NOIR_ANIM_TIME)
+	M.update_colour(NOIR_ANIM_TIME)
 	if(M.client) // wow it's almost like non-client mobs can get mutations!
 		M.client.screen += noir_master
 		M << sound('sound/misc/noirdarkcoffee.ogg')
 
 /datum/dna/gene/basic/noir/deactivate(var/mob/M,var/connected,var/flags)
 	if(..())
-		M.update_colour(time = NOIR_ANIM_TIME)
+		M.update_colour(NOIR_ANIM_TIME)
 		if(M.client)
 			M.client.screen -= noir_master

--- a/code/game/dna/genes/vg_powers.dm
+++ b/code/game/dna/genes/vg_powers.dm
@@ -119,6 +119,8 @@ Obviously, requires DNA2.
 
 // NOIR
 
+#define NOIR_ANIM_TIME 170
+
 /datum/dna/gene/basic/noir
 	name = "Noir"
 	desc = "In recent years, there's been a real push towards 'Detective Noir' movies, but since the last black and white camera was lost many centuries ago, Scientists had to develop a way to turn any movie noir."
@@ -133,12 +135,13 @@ Obviously, requires DNA2.
 
 /datum/dna/gene/basic/noir/activate(var/mob/M)
 	..()
-	M.update_colour()
+	M.update_colour(time = NOIR_ANIM_TIME)
 	if(M.client) // wow it's almost like non-client mobs can get mutations!
 		M.client.screen += noir_master
+		M << sound('sound/misc/noirdarkcoffee.ogg')
 
 /datum/dna/gene/basic/noir/deactivate(var/mob/M,var/connected,var/flags)
 	if(..())
-		M.update_colour()
+		M.update_colour(time = NOIR_ANIM_TIME)
 		if(M.client)
 			M.client.screen -= noir_master

--- a/code/modules/client/client defines.dm
+++ b/code/modules/client/client defines.dm
@@ -59,7 +59,6 @@
 
 	var/filling = 0 //SOME STUPID SHIT POMF IS DOING
 	var/haszoomed = 0
-	var/updating_colour = 0
 
 	// Their chat window, sort of important.
 	// See /goon/code/datums/browserOutput.dm

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -201,7 +201,7 @@
 				to_chat(src, "<b>You must eat to survive. Starvation for extended periods of time will kill you!</b>")
 				to_chat(src, "<b>Keep an eye out on the hunger indicator on the right of your screen; it will start flashing red and black when you're close to starvation.</b>")
 
-	update_colour(0,1)
+	update_colour(0)
 
 	spawn()
 		update_mutantrace()

--- a/code/modules/mob/living/carbon/species_powers.dm
+++ b/code/modules/mob/living/carbon/species_powers.dm
@@ -1,3 +1,5 @@
+#define INVERT_ANIM_TIME 50
+
 /spell/targeted/genetic/invert_eyes
 	name = "Invert eyesight"
 	desc = "Inverts the colour spectrum you see, letting you see clearly in the dark, but not in the light."
@@ -26,5 +28,6 @@
 	else
 		colourmatrix = default_colour_matrix
 	for(var/mob/living/carbon/human/M in targets)
-		M.update_colour(50,0,colourmatrix)
+		M.update_colour(INVERT_ANIM_TIME, colourmatrix)
 	toggle = !toggle
+#undef INVERT_ANIM_TIME

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -112,9 +112,6 @@
 		client.changeView()
 		client.haszoomed = 0
 
-	if(bad_changing_colour_ckeys["[client.ckey]"] == 1)
-		client.updating_colour = 0
-		bad_changing_colour_ckeys["[client.ckey]"] = 0
 	update_colour()
 
 	if(client)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -309,7 +309,7 @@
 	if(flags & HEAR_ALWAYS)
 		getFromPool(/mob/virtualhearer, src)
 
-	update_colour(0,1)
+	update_colour(0)
 
 /mob/Del()
 	if(flags & HEAR_ALWAYS)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -86,9 +86,7 @@ mob/proc/remove_internal_organ()
 	// We can't compare client.color directly because Byond will force set client.color to null
 	// when assigning the default_colour_matrix to it
 	var/list/colour_initial = (client.color ? client.color : default_colour_matrix)
-	var/list/difference = list()
-	difference = difflist(colour_initial, colour_to_apply)
-	if(difference && difference.len)
+	if(colour_initial ~! colour_to_apply)
 		client.colour_transition(colour_to_apply,time = time)
 /*
 /proc/RemoveAllFactionIcons(var/datum/mind/M)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -67,8 +67,6 @@ mob/proc/remove_internal_organ()
 	. = ..()
 	if(.)
 		return .
-	else if(has_reagent_in_blood(DETCOFFEE))
-		return NOIRMATRIX
 	var/obj/item/clothing/glasses/scanner/S = is_wearing_item(/obj/item/clothing/glasses/scanner, slot_glasses)
 	if(S && S.on && S.color_matrix)
 		return S.color_matrix

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -78,36 +78,18 @@ mob/proc/remove_internal_organ()
 	else
 		return default_colour_matrix
 
-/mob/proc/update_colour(var/time = 50,var/forceupdate = 0, var/list/colour_to_apply)
-	if(!client || (client.updating_colour && !forceupdate))
+/mob/proc/update_colour(var/time = 50, var/list/colour_to_apply)
+	if(!client)
 		return
 	if(!colour_to_apply)
 		colour_to_apply = get_screen_colour()
+	// We can't compare client.color directly because Byond will force set client.color to null
+	// when assigning the default_colour_matrix to it
+	var/list/colour_initial = (client.color ? client.color : default_colour_matrix)
 	var/list/difference = list()
-	if(client.color)
-		difference = difflist(client.color,colour_to_apply)
-	if(!difference) // otherwise !difference.len throws a runtime since null.len isn't a thing
-		return
-	else if(!difference.len)
-		client.updating_colour = 1
-		var/cached_ckey = client.ckey
-		if(forceupdate)
-			time = 0
-		else if(colour_to_apply == NOIRMATRIX)
-			time = 170
-			src << sound('sound/misc/noirdarkcoffee.ogg')
+	difference = difflist(colour_initial, colour_to_apply)
+	if(difference && difference.len)
 		client.colour_transition(colour_to_apply,time = time)
-		spawn(time)
-			if(client && client.mob != src)
-				return
-			if(client)
-				client.color = colour_to_apply
-				client.updating_colour = 0
-				difference = difflist(client.color,get_screen_colour())
-				if((difference || !(client.color) || !istype(difference) || !difference.len) && !forceupdate) // panic panic panic
-					src.update_colour(0,1,colour_to_apply)
-			else
-				bad_changing_colour_ckeys["[cached_ckey]"] = 1
 /*
 /proc/RemoveAllFactionIcons(var/datum/mind/M)
 	ticker.mode.update_cult_icons_removed(M)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -6401,24 +6401,31 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 	description = "Bitter, black, and tasteless. It's the way I've always had my joe, and the way I was having it when one of the officers came running toward me. The chief medical officer got axed, and no one knew who did it. I reluctantly took one last drink before putting on my coat and heading out. I knew that by the time I was finished, my joe would have fallen to a dreadfully low temperature, but I had work to do."
 	causes_jitteriness = 0
 	var/activated = 0
+	var/noir_set_by_us = 0
 
 /datum/reagent/drink/coffee/detcoffee/on_mob_life(var/mob/living/M)
 	if(..())
 		return 1
 	if(!activated)
-		M.update_colour()
+		if (M_NOIR in M.mutations)
+			noir_set_by_us = 0
+		else
+			noir_set_by_us = 1
+			M.dna.SetSEState(NOIRBLOCK, 1)
+			genemutcheck(M, NOIRBLOCK)
+			M.update_mutations()
 		activated = 1
 
 /datum/reagent/drink/coffee/detcoffee/reagent_deleted()
 	if(..())
 		return 1
-
 	if(!holder)
 		return
 	var/mob/M =  holder.my_atom
-
-	if(ishuman(M))
-		M.update_colour()
+	if (istype(M) && activated && noir_set_by_us)
+		M.dna.SetSEState(NOIRBLOCK, 0)
+		genemutcheck(M, NOIRBLOCK)
+		M.update_mutations()
 
 /datum/reagent/drink/coffee/etank
 	name = "Recharger"


### PR DESCRIPTION
MERGE WHEN WE ARE ON `512.1454`.

Fixes #19613
Fixes #19280
Fixes #18491
Fixes #12080

* Removed unused `bad_changing_colour_ckeys` global var.  No idea what this was meant to do, but it was doing nothing.
* Removed the `updating_colour` var from client.  There's no need to track whether the client is going through a colour change animation or not because all the colour transition stuff is nicely handled by the `animate()` proc.
* Moved the noir specific stuff from the `update_colour()` proc to the appropriate noir file.
* Oh and the colour transitions have been fixed.

:cl:
 * bugfix: Losing colour visions (noir, shroom invert, etc) will now properly set colour overlays back to normal.  Update your client to the latest beta if you get weird colours after your vision resets.