### PR TITLE
Closet refactor

### DIFF
--- a/code/game/objects/items/devices/uplinks.dm
+++ b/code/game/objects/items/devices/uplinks.dm
@@ -215,6 +215,10 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 	if(hidden_uplink)
 		hidden_uplink.trigger(user)
 
+/obj/item/device/radio/uplink/nukeops/New()
+	..()
+	hidden_uplink.uses = 80
+
 /obj/item/device/multitool/uplink/New()
 	hidden_uplink = new(src)
 

--- a/code/game/objects/items/trader.dm
+++ b/code/game/objects/items/trader.dm
@@ -76,7 +76,8 @@
 	list(/obj/item/clothing/shoes/clockwork_boots, /obj/item/clothing/head/clockwork_hood, /obj/item/clothing/suit/clockwork_robes),
 	/obj/item/clothing/mask/necklace/xeno_claw
 	)
-/obj/structure/closet/secure_closet/wonderful/New()
+
+/obj/structure/closet/secure_closet/wonderful/spawn_contents()
 	..()
 	for(var/amount = 1 to 10)
 		var/wonder_clothing = pick_n_take(wonder_whitelist)

--- a/code/game/objects/items/weapons/cash.dm
+++ b/code/game/objects/items/weapons/cash.dm
@@ -146,7 +146,7 @@ var/global/list/moneytypes = list(
 	worth = 1000
 	stack_color = "#333333"
 
-/obj/structure/closet/cash_closet/New()
+/obj/structure/closet/cash_closet/spawn_contents()
 	var/list/types = typesof(/obj/item/weapon/spacecash)
 	for(var/i = 1 to rand(3,10))
 		var/typepath = pick(types)

--- a/code/game/objects/items/weapons/implants/exile2.dm
+++ b/code/game/objects/items/weapons/implants/exile2.dm
@@ -51,13 +51,8 @@
 	name = "Exile Implants"
 	req_access = list(access_hos)
 
-/obj/structure/closet/secure_closet/exile/New()
-	..()
-	sleep(2)
-	new /obj/item/weapon/implanter/exile(src)
-	new /obj/item/weapon/implantcase/exile(src)
-	new /obj/item/weapon/implantcase/exile(src)
-	new /obj/item/weapon/implantcase/exile(src)
-	new /obj/item/weapon/implantcase/exile(src)
-	new /obj/item/weapon/implantcase/exile(src)
-	return
+/obj/structure/closet/secure_closet/exile/atoms_to_spawn()
+	return list(
+		/obj/item/weapon/implanter/exile,
+		/obj/item/weapon/implantcase/exile = 5,
+	)

--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -247,6 +247,10 @@
 	..()
 	new /obj/item/weapon/gun/lawgiver(src)
 
+/obj/item/weapon/storage/lockbox/lawgiver/with_magazine/New()
+	..()
+	new /obj/item/ammo_storage/magazine/lawgiver(src)
+
 /obj/item/weapon/storage/lockbox/oneuse
 	desc = "A locked box. When unlocked, the case will fall apart."
 	oneuse = 1

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -37,6 +37,21 @@
 		desc += " It has a slot for locking circuitry."
 	else if (has_lockless_type)
 		desc += " The locking circuitry could be unmounted if unlocked."
+	if(ticker && ticker.current_state >= GAME_STATE_PLAYING)
+		initialize()
+
+// Returns null or a list of items to spawn
+/obj/structure/closet/proc/atoms_to_spawn()
+	return null
+
+// Creates the items this closet is supposed to contain and places them inside
+// Override this if you need custom logic
+/obj/structure/closet/proc/spawn_contents()
+	var/list/to_spawn = atoms_to_spawn()
+	for(var/path in to_spawn)
+		var/amount = to_spawn[path] || 1
+		for(var/i in 1 to amount)
+			new path(src)
 
 /obj/structure/closet/basic
 	has_lock_type = /obj/structure/closet/secure_closet/basic
@@ -46,6 +61,7 @@
 
 /obj/structure/closet/initialize()
 	..()
+	spawn_contents()
 	if(!opened)		// if closed, any item at the crate's loc is put in the contents
 		take_contents()
 	else

--- a/code/game/objects/structures/crates_lockers/closets/fitness.dm
+++ b/code/game/objects/structures/crates_lockers/closets/fitness.dm
@@ -4,44 +4,43 @@
 	icon_state = "mixed"
 	icon_closed = "mixed"
 
-/obj/structure/closet/athletic_mixed/New()
-	..()
-	sleep(2)
-	new /obj/item/clothing/under/shorts/grey(src)
-	new /obj/item/clothing/under/shorts/black(src)
-	new /obj/item/clothing/under/shorts/red(src)
-	new /obj/item/clothing/under/shorts/blue(src)
-	new /obj/item/clothing/under/shorts/green(src)
-	new /obj/item/clothing/under/swimsuit/red(src)
-	new /obj/item/clothing/under/swimsuit/black(src)
-	new /obj/item/clothing/under/swimsuit/blue(src)
-	new /obj/item/clothing/under/swimsuit/green(src)
-	new /obj/item/clothing/under/swimsuit/purple(src)
-
+/obj/structure/closet/athletic_mixed/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/under/shorts/grey,
+		/obj/item/clothing/under/shorts/black,
+		/obj/item/clothing/under/shorts/red,
+		/obj/item/clothing/under/shorts/blue,
+		/obj/item/clothing/under/shorts/green,
+		/obj/item/clothing/under/swimsuit/red,
+		/obj/item/clothing/under/swimsuit/black,
+		/obj/item/clothing/under/swimsuit/blue,
+		/obj/item/clothing/under/swimsuit/green,
+		/obj/item/clothing/under/swimsuit/purple,
+	)
 
 /obj/structure/closet/boxinggloves
 	name = "boxing gloves"
 	desc = "It's a storage unit for gloves for use in the boxing ring."
 
-/obj/structure/closet/boxinggloves/New()
-	..()
-	sleep(2)
-	new /obj/item/clothing/gloves/boxing/blue(src)
-	new /obj/item/clothing/gloves/boxing/green(src)
-	new /obj/item/clothing/gloves/boxing/yellow(src)
-	new /obj/item/clothing/gloves/boxing(src)
+/obj/structure/closet/boxinggloves/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/gloves/boxing/blue,
+		/obj/item/clothing/gloves/boxing/green,
+		/obj/item/clothing/gloves/boxing/yellow,
+		/obj/item/clothing/gloves/boxing,
+	)
 
 
 /obj/structure/closet/masks
 	name = "mask closet"
 	desc = "IT'S A STORAGE UNIT FOR FIGHTER MASKS OLE!"
 
-/obj/structure/closet/masks/New()
-	..()
-	sleep(2)
-	new /obj/item/clothing/mask/luchador(src)
-	new /obj/item/clothing/mask/luchador/rudos(src)
-	new /obj/item/clothing/mask/luchador/tecnicos(src)
+/obj/structure/closet/masks/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/mask/luchador,
+		/obj/item/clothing/mask/luchador/rudos,
+		/obj/item/clothing/mask/luchador/tecnicos,
+	)
 
 
 /obj/structure/closet/lasertag/red
@@ -50,21 +49,11 @@
 	icon_state = "red"
 	icon_closed = "red"
 
-/obj/structure/closet/lasertag/red/New()
-	..()
-	sleep(2)
-	new /obj/item/weapon/gun/energy/tag/red(src)
-	new /obj/item/weapon/gun/energy/tag/red(src)
-	new /obj/item/weapon/gun/energy/tag/red(src)
-	new /obj/item/weapon/gun/energy/tag/red(src)
-	new /obj/item/weapon/gun/energy/tag/red(src)
-	new /obj/item/weapon/gun/energy/tag/red(src)
-	new /obj/item/clothing/suit/tag/redtag(src)
-	new /obj/item/clothing/suit/tag/redtag(src)
-	new /obj/item/clothing/suit/tag/redtag(src)
-	new /obj/item/clothing/suit/tag/redtag(src)
-	new /obj/item/clothing/suit/tag/redtag(src)
-	new /obj/item/clothing/suit/tag/redtag(src)
+/obj/structure/closet/lasertag/red/atoms_to_spawn()
+	return list(
+		/obj/item/weapon/gun/energy/tag/red = 6,
+		/obj/item/clothing/suit/tag/redtag = 6,
+	)
 
 
 /obj/structure/closet/lasertag/blue
@@ -73,18 +62,8 @@
 	icon_state = "blue"
 	icon_closed = "blue"
 
-/obj/structure/closet/lasertag/blue/New()
-	..()
-	sleep(2)
-	new /obj/item/weapon/gun/energy/tag/blue(src)
-	new /obj/item/weapon/gun/energy/tag/blue(src)
-	new /obj/item/weapon/gun/energy/tag/blue(src)
-	new /obj/item/weapon/gun/energy/tag/blue(src)
-	new /obj/item/weapon/gun/energy/tag/blue(src)
-	new /obj/item/weapon/gun/energy/tag/blue(src)
-	new /obj/item/clothing/suit/tag/bluetag(src)
-	new /obj/item/clothing/suit/tag/bluetag(src)
-	new /obj/item/clothing/suit/tag/bluetag(src)
-	new /obj/item/clothing/suit/tag/bluetag(src)
-	new /obj/item/clothing/suit/tag/bluetag(src)
-	new /obj/item/clothing/suit/tag/bluetag(src)
+/obj/structure/closet/lasertag/blue/atoms_to_spawn()
+	return list(
+		/obj/item/weapon/gun/energy/tag/blue = 6,
+		/obj/item/clothing/suit/tag/bluetag = 6,
+	)

--- a/code/game/objects/structures/crates_lockers/closets/gimmick.dm
+++ b/code/game/objects/structures/crates_lockers/closets/gimmick.dm
@@ -74,16 +74,16 @@
 	name = "old cabinet"
 	desc = "This cabinet has been gathering dust, and hasn't been disturbed in some years."
 
-/obj/structure/closet/cabinet/medivault/New()
-	..()
-	sleep(2)
-	new /obj/item/weapon/storage/box/masks(src)
-	new /obj/item/weapon/storage/backpack/satchel_med(src)
-	new /obj/item/clothing/under/rank/medical(src)
-	new /obj/item/clothing/head/bio_hood/virology(src)
-	new /obj/item/clothing/suit/bio_suit/virology(src)
-	new /obj/item/clothing/shoes/white(src)
-	new /obj/item/weapon/paper/pamphlet/medivault(src)
+/obj/structure/closet/cabinet/medivault/atoms_to_spawn()
+	return list(
+		/obj/item/weapon/storage/box/masks,
+		/obj/item/weapon/storage/backpack/satchel_med,
+		/obj/item/clothing/under/rank/medical,
+		/obj/item/clothing/head/bio_hood/virology,
+		/obj/item/clothing/suit/bio_suit/virology,
+		/obj/item/clothing/shoes/white,
+		/obj/item/weapon/paper/pamphlet/medivault,
+	)
 
 /obj/structure/closet/acloset
 	name = "strange closet"
@@ -108,19 +108,11 @@
 	icon_closed = "syndicate1"
 	icon_opened = "syndicate1open"
 
-/obj/structure/closet/gimmick/russian/New()
-	..()
-	sleep(2)
-	new /obj/item/clothing/head/ushanka(src)
-	new /obj/item/clothing/head/ushanka(src)
-	new /obj/item/clothing/head/ushanka(src)
-	new /obj/item/clothing/head/ushanka(src)
-	new /obj/item/clothing/head/ushanka(src)
-	new /obj/item/clothing/under/soviet(src)
-	new /obj/item/clothing/under/soviet(src)
-	new /obj/item/clothing/under/soviet(src)
-	new /obj/item/clothing/under/soviet(src)
-	new /obj/item/clothing/under/soviet(src)
+/obj/structure/closet/gimmick/russian/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/head/ushanka = 5,
+		/obj/item/clothing/under/soviet = 5,
+	)
 
 
 /obj/structure/closet/gimmick/tacticool
@@ -130,25 +122,18 @@
 	icon_closed = "syndicate1"
 	icon_opened = "syndicate1open"
 
-/obj/structure/closet/gimmick/tacticool/New()
-	..()
-	sleep(2)
-	new /obj/item/clothing/glasses/eyepatch(src)
-	new /obj/item/clothing/glasses/sunglasses(src)
-	new /obj/item/clothing/gloves/swat(src)
-	new /obj/item/clothing/gloves/swat(src)
-	new /obj/item/clothing/head/helmet/tactical/swat(src)
-	new /obj/item/clothing/head/helmet/tactical/swat(src)
-	new /obj/item/device/flashlight/tactical(src)
-	new /obj/item/device/flashlight/tactical(src)
-	new /obj/item/clothing/mask/gas(src)
-	new /obj/item/clothing/mask/gas(src)
-	new /obj/item/clothing/shoes/swat(src)
-	new /obj/item/clothing/shoes/swat(src)
-	new /obj/item/clothing/suit/armor/swat(src)
-	new /obj/item/clothing/suit/armor/swat(src)
-	new /obj/item/clothing/under/syndicate/tacticool(src)
-	new /obj/item/clothing/under/syndicate/tacticool(src)
+/obj/structure/closet/gimmick/tacticool/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/glasses/eyepatch,
+		/obj/item/clothing/glasses/sunglasses,
+		/obj/item/clothing/gloves/swat = 2,
+		/obj/item/clothing/head/helmet/tactical/swat = 2,
+		/obj/item/device/flashlight/tactical = 2,
+		/obj/item/clothing/mask/gas = 2,
+		/obj/item/clothing/shoes/swat = 2,
+		/obj/item/clothing/suit/armor/swat = 2,
+		/obj/item/clothing/under/syndicate/tacticool = 2,
+	)
 
 
 /obj/structure/closet/thunderdome
@@ -159,34 +144,18 @@
 	icon_opened = "syndicateopen"
 	anchored = 1
 
-/obj/structure/closet/thunderdome/New()
-	..()
-	sleep(2)
-
 /obj/structure/closet/thunderdome/tdred
 	name = "red-team Thunderdome closet"
 
-/obj/structure/closet/thunderdome/tdred/New()
-	..()
-	sleep(2)
-	new /obj/item/clothing/suit/armor/tdome/red(src)
-	new /obj/item/clothing/suit/armor/tdome/red(src)
-	new /obj/item/clothing/suit/armor/tdome/red(src)
-	new /obj/item/weapon/melee/energy/sword(src)
-	new /obj/item/weapon/melee/energy/sword(src)
-	new /obj/item/weapon/melee/energy/sword(src)
-	new /obj/item/weapon/gun/energy/laser(src)
-	new /obj/item/weapon/gun/energy/laser(src)
-	new /obj/item/weapon/gun/energy/laser(src)
-	new /obj/item/weapon/melee/baton/loaded(src)
-	new /obj/item/weapon/melee/baton/loaded(src)
-	new /obj/item/weapon/melee/baton/loaded(src)
-	new /obj/item/weapon/storage/box/flashbangs(src)
-	new /obj/item/weapon/storage/box/flashbangs(src)
-	new /obj/item/weapon/storage/box/flashbangs(src)
-	new /obj/item/clothing/head/helmet/thunderdome(src)
-	new /obj/item/clothing/head/helmet/thunderdome(src)
-	new /obj/item/clothing/head/helmet/thunderdome(src)
+/obj/structure/closet/thunderdome/tdred/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/suit/armor/tdome/red = 3,
+		/obj/item/weapon/melee/energy/sword = 3,
+		/obj/item/weapon/gun/energy/laser = 3,
+		/obj/item/weapon/melee/baton/loaded = 3,
+		/obj/item/weapon/storage/box/flashbangs = 3,
+		/obj/item/clothing/head/helmet/thunderdome = 3,
+	)
 
 /obj/structure/closet/thunderdome/tdgreen
 	name = "green-team Thunderdome closet"
@@ -194,24 +163,13 @@
 	icon_closed = "syndicate1"
 	icon_opened = "syndicate1open"
 
-/obj/structure/closet/thunderdome/tdgreen/New()
-	..()
-	sleep(2)
-	new /obj/item/clothing/suit/armor/tdome/green(src)
-	new /obj/item/clothing/suit/armor/tdome/green(src)
-	new /obj/item/clothing/suit/armor/tdome/green(src)
-	new /obj/item/weapon/melee/energy/sword(src)
-	new /obj/item/weapon/melee/energy/sword(src)
-	new /obj/item/weapon/melee/energy/sword(src)
-	new /obj/item/weapon/gun/energy/laser(src)
-	new /obj/item/weapon/gun/energy/laser(src)
-	new /obj/item/weapon/gun/energy/laser(src)
-	new /obj/item/weapon/melee/baton/loaded(src)
-	new /obj/item/weapon/melee/baton/loaded(src)
-	new /obj/item/weapon/melee/baton/loaded(src)
-	new /obj/item/weapon/storage/box/flashbangs(src)
-	new /obj/item/weapon/storage/box/flashbangs(src)
-	new /obj/item/weapon/storage/box/flashbangs(src)
-	new /obj/item/clothing/head/helmet/thunderdome(src)
-	new /obj/item/clothing/head/helmet/thunderdome(src)
-	new /obj/item/clothing/head/helmet/thunderdome(src)
+/obj/structure/closet/thunderdome/tdgreen/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/suit/armor/tdome/green = 3,
+		/obj/item/weapon/melee/energy/sword = 3,
+		/obj/item/weapon/gun/energy/laser = 3,
+		/obj/item/weapon/melee/baton/loaded = 3,
+		/obj/item/weapon/storage/box/flashbangs = 3,
+		/obj/item/clothing/head/helmet/thunderdome = 3,
+	)
+

--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -14,23 +14,18 @@
 	icon_state = "black"
 	icon_closed = "black"
 
-/obj/structure/closet/gmcloset/New()
-	..()
-	new /obj/item/clothing/head/that(src)
-	new /obj/item/clothing/head/that(src)
-	new /obj/item/clothing/head/hairflower
-	new /obj/item/clothing/under/sl_suit(src)
-	new /obj/item/clothing/under/sl_suit(src)
-	new /obj/item/clothing/under/rank/bartender(src)
-	new /obj/item/clothing/under/rank/bartender(src)
-	new /obj/item/clothing/under/dress/dress_saloon
-	new /obj/item/clothing/suit/wcoat(src)
-	new /obj/item/clothing/suit/wcoat(src)
-	new /obj/item/clothing/shoes/black(src)
-	new /obj/item/clothing/shoes/black(src)
-	new /obj/item/clothing/monkeyclothes(src)
-	new /obj/item/clothing/monkeyclothes(src)
-	new /obj/item/weapon/reagent_containers/food/drinks/coloring(src)
+/obj/structure/closet/gmcloset/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/head/that = 2,
+		/obj/item/clothing/head/hairflower,
+		/obj/item/clothing/under/sl_suit = 2,
+		/obj/item/clothing/under/rank/bartender = 2,
+		/obj/item/clothing/under/dress/dress_saloon,
+		/obj/item/clothing/suit/wcoat = 2,
+		/obj/item/clothing/shoes/black = 2,
+		/obj/item/clothing/monkeyclothes = 2,
+		/obj/item/weapon/reagent_containers/food/drinks/coloring,
+	)
 
 /*
  * Janitor
@@ -41,25 +36,20 @@
 	icon_state = "mixed"
 	icon_closed = "mixed"
 
-/obj/structure/closet/jcloset/New()
-	..()
-	new /obj/item/clothing/under/rank/janitor(src)
-	new /obj/item/weapon/cartridge/janitor(src)
-	new /obj/item/device/flashlight(src)
-	new /obj/item/clothing/shoes/galoshes(src)
-	new /obj/item/weapon/caution(src)
-	new /obj/item/weapon/caution(src)
-	new /obj/item/weapon/caution(src)
-	new /obj/item/weapon/caution(src)
-	new /obj/item/weapon/caution(src)
-	new /obj/item/weapon/caution(src)
-	new /obj/item/weapon/storage/bag/trash(src)
-	new /obj/item/device/lightreplacer/loaded/mixed(src)
-	new /obj/item/clothing/gloves/black(src)
-	new /obj/item/clothing/head/soft/purple(src)
-	new /obj/item/weapon/storage/box/lights/he(src)
-	new /obj/item/weapon/storage/box/lights/he(src)
-	new /obj/item/weapon/storage/belt/janitor(src)
+/obj/structure/closet/jcloset/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/under/rank/janitor,
+		/obj/item/weapon/cartridge/janitor,
+		/obj/item/device/flashlight,
+		/obj/item/clothing/shoes/galoshes,
+		/obj/item/weapon/caution = 6,
+		/obj/item/weapon/storage/bag/trash,
+		/obj/item/device/lightreplacer/loaded/mixed,
+		/obj/item/clothing/gloves/black,
+		/obj/item/clothing/head/soft/purple,
+		/obj/item/weapon/storage/box/lights/he = 2,
+		/obj/item/weapon/storage/belt/janitor,
+	)
 
 /*
  * Lawyer
@@ -70,20 +60,19 @@
 	icon_state = "blue"
 	icon_closed = "blue"
 
-/obj/structure/closet/lawcloset/New()
-	..()
-	new /obj/item/clothing/under/cia(src)
-	new /obj/item/clothing/under/lawyer/female(src)
-	new /obj/item/clothing/under/lawyer/black(src)
-	new /obj/item/clothing/under/lawyer/red(src)
-	new /obj/item/clothing/under/lawyer/bluesuit(src)
-	new /obj/item/clothing/suit/storage/lawyer/bluejacket(src)
-	new /obj/item/clothing/under/lawyer/purpsuit(src)
-	new /obj/item/clothing/suit/storage/lawyer/purpjacket(src)
-	new /obj/item/clothing/shoes/brown(src)
-	new /obj/item/clothing/shoes/black(src)
-
-	//Paramedic
+/obj/structure/closet/lawcloset/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/under/cia,
+		/obj/item/clothing/under/lawyer/female,
+		/obj/item/clothing/under/lawyer/black,
+		/obj/item/clothing/under/lawyer/red,
+		/obj/item/clothing/under/lawyer/bluesuit,
+		/obj/item/clothing/suit/storage/lawyer/bluejacket,
+		/obj/item/clothing/under/lawyer/purpsuit,
+		/obj/item/clothing/suit/storage/lawyer/purpjacket,
+		/obj/item/clothing/shoes/brown,
+		/obj/item/clothing/shoes/black,
+	)
 
 /obj/structure/closet/paramedic
 	name = "Paramedic Wardrobe"
@@ -92,23 +81,15 @@
 	icon_closed = "blue"
 
 
-/obj/structure/closet/paramedic/New()
-	..()
-	new /obj/item/clothing/under/rank/medical/paramedic(src)
-	new /obj/item/clothing/under/rank/medical/paramedic(src)
-	new /obj/item/device/radio/headset/headset_med(src)
-	new /obj/item/device/radio/headset/headset_med(src)
-	new /obj/item/clothing/head/soft/paramedic(src)
-	new /obj/item/clothing/head/soft/paramedic(src)
-	new /obj/item/clothing/gloves/latex(src)
-	new /obj/item/clothing/gloves/latex(src)
-	new /obj/item/clothing/shoes/black(src)
-	new /obj/item/clothing/shoes/black(src)
-	new /obj/item/clothing/suit/storage/paramedic(src)
-	new /obj/item/clothing/suit/storage/paramedic(src)
-	new /obj/item/weapon/storage/box/inflatables(src)
-	new /obj/item/weapon/storage/box/inflatables(src)
-	new /obj/item/weapon/tank/emergency_oxygen/engi(src)
-	new /obj/item/weapon/tank/emergency_oxygen/engi(src)
-	new /obj/item/device/gps/paramedic(src)
-	new /obj/item/device/gps/paramedic(src)
+/obj/structure/closet/paramedic/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/under/rank/medical/paramedic = 2,
+		/obj/item/device/radio/headset/headset_med = 2,
+		/obj/item/clothing/head/soft/paramedic = 2,
+		/obj/item/clothing/gloves/latex = 2,
+		/obj/item/clothing/shoes/black = 2,
+		/obj/item/clothing/suit/storage/paramedic = 2,
+		/obj/item/weapon/storage/box/inflatables = 2,
+		/obj/item/weapon/tank/emergency_oxygen/engi = 2,
+		/obj/item/device/gps/paramedic = 2,
+	)

--- a/code/game/objects/structures/crates_lockers/closets/l3closet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/l3closet.dm
@@ -5,11 +5,11 @@
 	icon_closed = "bio"
 	icon_opened = "bioopen"
 
-/obj/structure/closet/l3closet/New()
-	..()
-	sleep(2)
-	new /obj/item/clothing/suit/bio_suit/general( src )
-	new /obj/item/clothing/head/bio_hood/general( src )
+/obj/structure/closet/l3closet/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/suit/bio_suit/general,
+		/obj/item/clothing/head/bio_hood/general,
+	)
 
 
 /obj/structure/closet/l3closet/general
@@ -17,12 +17,11 @@
 	icon_closed = "bio_general"
 	icon_opened = "bio_generalopen"
 
-/obj/structure/closet/l3closet/general/New()
-	..()
-	sleep(2)
-	contents = list()
-	new /obj/item/clothing/suit/bio_suit/general( src )
-	new /obj/item/clothing/head/bio_hood/general( src )
+/obj/structure/closet/l3closet/general/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/suit/bio_suit/general,
+		/obj/item/clothing/head/bio_hood/general,
+	)
 
 
 /obj/structure/closet/l3closet/virology
@@ -30,12 +29,11 @@
 	icon_closed = "bio_virology"
 	icon_opened = "bio_virologyopen"
 
-/obj/structure/closet/l3closet/virology/New()
-	..()
-	sleep(2)
-	contents = list()
-	new /obj/item/clothing/suit/bio_suit/virology( src )
-	new /obj/item/clothing/head/bio_hood/virology( src )
+/obj/structure/closet/l3closet/virology/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/suit/bio_suit/virology,
+		/obj/item/clothing/head/bio_hood/virology,
+	)
 
 
 /obj/structure/closet/l3closet/security
@@ -43,12 +41,11 @@
 	icon_closed = "bio_security"
 	icon_opened = "bio_securityopen"
 
-/obj/structure/closet/l3closet/security/New()
-	..()
-	sleep(2)
-	contents = list()
-	new /obj/item/clothing/suit/bio_suit/security( src )
-	new /obj/item/clothing/head/bio_hood/security( src )
+/obj/structure/closet/l3closet/security/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/suit/bio_suit/security,
+		/obj/item/clothing/head/bio_hood/security,
+	)
 
 
 /obj/structure/closet/l3closet/janitor
@@ -56,12 +53,11 @@
 	icon_closed = "bio_janitor"
 	icon_opened = "bio_janitoropen"
 
-/obj/structure/closet/l3closet/janitor/New()
-	..()
-	sleep(2)
-	contents = list()
-	new /obj/item/clothing/suit/bio_suit/janitor( src )
-	new /obj/item/clothing/head/bio_hood/janitor( src )
+/obj/structure/closet/l3closet/janitor/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/suit/bio_suit/janitor,
+		/obj/item/clothing/head/bio_hood/janitor,
+	)
 
 
 /obj/structure/closet/l3closet/scientist
@@ -69,9 +65,8 @@
 	icon_closed = "bio_scientist"
 	icon_opened = "bio_scientistopen"
 
-/obj/structure/closet/l3closet/scientist/New()
-	..()
-	sleep(2)
-	contents = list()
-	new /obj/item/clothing/suit/bio_suit/scientist( src )
-	new /obj/item/clothing/head/bio_hood/scientist( src )
+/obj/structure/closet/l3closet/scientist/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/suit/bio_suit/scientist,
+		/obj/item/clothing/head/bio_hood/scientist,
+	)

--- a/code/game/objects/structures/crates_lockers/closets/malfunction.dm
+++ b/code/game/objects/structures/crates_lockers/closets/malfunction.dm
@@ -5,14 +5,14 @@
 	icon_closed = "syndicate"
 	icon_opened = "syndicateopen"
 
-/obj/structure/closet/malf/suits/New()
-	..()
-	sleep(2)
-	new /obj/item/weapon/tank/jetpack/void(src)
-	new /obj/item/clothing/mask/breath(src)
-	new /obj/item/clothing/head/helmet/space/nasavoid(src)
-	new /obj/item/clothing/suit/space/nasavoid(src)
-	new /obj/item/clothing/shoes/magboots/nasavoid(src)
-	new /obj/item/weapon/crowbar(src)
-	new /obj/item/weapon/cell(src)
-	new /obj/item/device/multitool(src)
+/obj/structure/closet/malf/suits/atoms_to_spawn()
+	return list(
+		/obj/item/weapon/tank/jetpack/void,
+		/obj/item/clothing/mask/breath,
+		/obj/item/clothing/head/helmet/space/nasavoid,
+		/obj/item/clothing/suit/space/nasavoid,
+		/obj/item/clothing/shoes/magboots/nasavoid,
+		/obj/item/weapon/crowbar,
+		/obj/item/weapon/cell,
+		/obj/item/device/multitool,
+	)

--- a/code/game/objects/structures/crates_lockers/closets/secure/bar.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/bar.dm
@@ -11,19 +11,9 @@
 
 
 /obj/structure/closet/secure_closet/bar/New()
-	..()
-	//sleep(2) // why
-	new /obj/item/weapon/reagent_containers/food/drinks/beer( src )
-	new /obj/item/weapon/reagent_containers/food/drinks/beer( src )
-	new /obj/item/weapon/reagent_containers/food/drinks/beer( src )
-	new /obj/item/weapon/reagent_containers/food/drinks/beer( src )
-	new /obj/item/weapon/reagent_containers/food/drinks/beer( src )
-	new /obj/item/weapon/reagent_containers/food/drinks/beer( src )
-	new /obj/item/weapon/reagent_containers/food/drinks/beer( src )
-	new /obj/item/weapon/reagent_containers/food/drinks/beer( src )
-	new /obj/item/weapon/reagent_containers/food/drinks/beer( src )
-	new /obj/item/weapon/reagent_containers/food/drinks/beer( src )
-	return
+	return list(
+		/obj/item/weapon/reagent_containers/food/drinks/beer = 10,
+	)
 
 /obj/structure/closet/secure_closet/bar/update_icon()
 	if(broken)

--- a/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
@@ -8,16 +8,14 @@
 	icon_broken = "securecargobroken"
 	icon_off = "securecargooff"
 
-	New()
-		..()
-		sleep(2)
-		new /obj/item/clothing/under/rank/cargotech(src)
-		new /obj/item/clothing/shoes/black(src)
-		new /obj/item/device/radio/headset/headset_cargo(src)
-		new /obj/item/clothing/gloves/black(src)
-		new /obj/item/clothing/head/soft(src)
-//		new /obj/item/weapon/cartridge/quartermaster(src)
-		return
+/obj/structure/closet/secure_closet/cargotech/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/under/rank/cargotech,
+		/obj/item/clothing/shoes/black,
+		/obj/item/device/radio/headset/headset_cargo,
+		/obj/item/clothing/gloves/black,
+		/obj/item/clothing/head/soft,
+	)
 
 /obj/structure/closet/secure_closet/quartermaster
 	name = "Quartermaster's Locker"
@@ -29,18 +27,16 @@
 	icon_broken = "secureqmbroken"
 	icon_off = "secureqmoff"
 
-	New()
-		..()
-		sleep(2)
-		new /obj/item/clothing/under/rank/cargo(src)
-		new /obj/item/clothing/shoes/brown(src)
-		new /obj/item/device/radio/headset/headset_cargo(src)
-		new /obj/item/clothing/gloves/black(src)
-//		new /obj/item/weapon/cartridge/quartermaster(src)
-		new /obj/item/clothing/suit/fire/firefighter(src)
-		new /obj/item/weapon/tank/emergency_oxygen(src)
-		new /obj/item/clothing/mask/gas(src)
-		new /obj/item/clothing/glasses/scanner/meson(src)
-		new /obj/item/clothing/head/soft(src)
-		new /obj/item/weapon/card/debit/preferred/department(src, "Cargo")
-		return
+/obj/structure/closet/secure_closet/quartermaster/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/under/rank/cargo,
+		/obj/item/clothing/shoes/brown,
+		/obj/item/device/radio/headset/headset_cargo,
+		/obj/item/clothing/gloves/black,
+		/obj/item/clothing/suit/fire/firefighter,
+		/obj/item/weapon/tank/emergency_oxygen,
+		/obj/item/clothing/mask/gas,
+		/obj/item/clothing/glasses/scanner/meson,
+		/obj/item/clothing/head/soft,
+		/obj/item/weapon/card/debit/preferred/department/cargo,
+	)

--- a/code/game/objects/structures/crates_lockers/closets/secure/chaplain.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/chaplain.dm
@@ -9,28 +9,24 @@
 	icon_broken = "chaplainsecurebroken"
 	icon_off = "chaplainsecureoff"
 
-/obj/structure/closet/secure_closet/chaplain/New()
-
-	..()
-
-	spawn()
-		new /obj/item/clothing/under/rank/chaplain(src)
-		new /obj/item/clothing/shoes/black(src)
-		new /obj/item/clothing/suit/nun(src)
-		new /obj/item/clothing/head/nun_hood(src)
-		new /obj/item/clothing/suit/chaplain_hoodie(src)
-		new /obj/item/clothing/head/chaplain_hood(src)
-		new /obj/item/clothing/suit/holidaypriest(src)
-		new /obj/item/clothing/under/wedding/bride_white(src)
-		new /obj/item/clothing/head/hasturhood(src)
-		new /obj/item/clothing/suit/hastur(src)
-		new /obj/item/clothing/suit/unathi/robe(src)
-		new /obj/item/clothing/head/wizard/amp(src) //This will need to be removed when/if psychic wizards are properly implemented
-		new /obj/item/clothing/suit/wizrobe/psypurple(src) //This will need to be removed when/if psychic wizards are properly implemented
-		new /obj/item/clothing/suit/imperium_monk(src)
-		new /obj/item/clothing/mask/chapmask(src)
-		new /obj/item/clothing/under/sl_suit(src)
-		new /obj/item/weapon/storage/backpack/cultpack(src)
-		new /obj/item/weapon/storage/fancy/candle_box(src)
-		new /obj/item/weapon/storage/fancy/candle_box(src)
-		return
+/obj/structure/closet/secure_closet/chaplain/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/under/rank/chaplain,
+		/obj/item/clothing/shoes/black,
+		/obj/item/clothing/suit/nun,
+		/obj/item/clothing/head/nun_hood,
+		/obj/item/clothing/suit/chaplain_hoodie,
+		/obj/item/clothing/head/chaplain_hood,
+		/obj/item/clothing/suit/holidaypriest,
+		/obj/item/clothing/under/wedding/bride_white,
+		/obj/item/clothing/head/hasturhood,
+		/obj/item/clothing/suit/hastur,
+		/obj/item/clothing/suit/unathi/robe,
+		/obj/item/clothing/head/wizard/amp, //This will need to be removed when/if psychic wizards are properly implemented
+		/obj/item/clothing/suit/wizrobe/psypurple, //This will need to be removed when/if psychic wizards are properly implemented
+		/obj/item/clothing/suit/imperium_monk,
+		/obj/item/clothing/mask/chapmask,
+		/obj/item/clothing/under/sl_suit,
+		/obj/item/weapon/storage/backpack/cultpack,
+		/obj/item/weapon/storage/fancy/candle_box = 2,
+	)

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -8,34 +8,33 @@
 	icon_broken = "securecebroken"
 	icon_off = "secureceoff"
 
-/obj/structure/closet/secure_closet/engineering_chief/New()
-	..()
-	sleep(2)
-	if(prob(50))
-		new /obj/item/weapon/storage/backpack/industrial(src)
-	else
-		new /obj/item/weapon/storage/backpack/satchel_eng(src)
-	new /obj/item/blueprints(src)
-	new /obj/item/clothing/under/rank/chief_engineer(src)
-	new /obj/item/clothing/head/hardhat/white(src)
-	new /obj/item/clothing/head/welding(src)
-	new /obj/item/clothing/gloves/yellow(src)
-	new /obj/item/clothing/shoes/workboots(src)
-	new /obj/item/weapon/cartridge/ce(src)
-	new /obj/item/device/radio/headset/heads/ce(src)
-	new /obj/item/weapon/storage/box/inflatables(src)
-	new /obj/item/weapon/inflatable_dispenser(src)
-	new /obj/item/weapon/storage/toolbox/mechanical(src)
-	new /obj/item/device/t_scanner/advanced(src)
-	new /obj/item/device/device_analyser/advanced(src)
-	new /obj/item/clothing/suit/storage/hazardvest(src)
-	new /obj/item/clothing/mask/gas(src)
-	new /obj/item/device/multitool(src)
-	new /obj/item/device/flash(src)
-	new /obj/item/device/gps/engineering(src)
-	new /obj/item/weapon/storage/belt/utility/chief(src)
-	new /obj/item/clothing/glasses/scanner/material(src)
-	new /obj/item/weapon/card/debit/preferred/department(src, "Engineering")
+/obj/structure/closet/secure_closet/engineering_chief/atoms_to_spawn()
+	return list(
+		pick(
+			/obj/item/weapon/storage/backpack/industrial,
+			/obj/item/weapon/storage/backpack/satchel_eng),
+		/obj/item/blueprints,
+		/obj/item/clothing/under/rank/chief_engineer,
+		/obj/item/clothing/head/hardhat/white,
+		/obj/item/clothing/head/welding,
+		/obj/item/clothing/gloves/yellow,
+		/obj/item/clothing/shoes/workboots,
+		/obj/item/weapon/cartridge/ce,
+		/obj/item/device/radio/headset/heads/ce,
+		/obj/item/weapon/storage/box/inflatables,
+		/obj/item/weapon/inflatable_dispenser,
+		/obj/item/weapon/storage/toolbox/mechanical,
+		/obj/item/device/t_scanner/advanced,
+		/obj/item/device/device_analyser/advanced,
+		/obj/item/clothing/suit/storage/hazardvest,
+		/obj/item/clothing/mask/gas,
+		/obj/item/device/multitool,
+		/obj/item/device/flash,
+		/obj/item/device/gps/engineering,
+		/obj/item/weapon/storage/belt/utility/chief,
+		/obj/item/clothing/glasses/scanner/material,
+		/obj/item/weapon/card/debit/preferred/department/engineering,
+	)
 
 /obj/structure/closet/secure_closet/engineering_electrical
 	name = "electrical supplies locker"
@@ -47,21 +46,14 @@
 	icon_broken = "secureengelecbroken"
 	icon_off = "secureengelecoff"
 
-/obj/structure/closet/secure_closet/engineering_electrical/New()
-	..()
-	sleep(2)
-	new /obj/item/weapon/storage/toolbox/electrical(src)
-	new /obj/item/weapon/storage/toolbox/electrical(src)
-	new /obj/item/weapon/storage/toolbox/electrical(src)
-	new /obj/item/weapon/rcl(src)
-	new /obj/item/weapon/circuitboard/power_control(src)
-	new /obj/item/weapon/circuitboard/power_control(src)
-	new /obj/item/weapon/circuitboard/power_control(src)
-	new /obj/item/clothing/gloves/yellow(src)
-	new /obj/item/clothing/gloves/yellow(src)
-	new /obj/item/device/multitool(src)
-	new /obj/item/device/multitool(src)
-	new /obj/item/device/multitool(src)
+/obj/structure/closet/secure_closet/engineering_electrical/atoms_to_spawn()
+	return list(
+		/obj/item/weapon/storage/toolbox/electrical = 3,
+		/obj/item/weapon/rcl,
+		/obj/item/weapon/circuitboard/power_control = 3,
+		/obj/item/clothing/gloves/yellow = 2,
+		/obj/item/device/multitool = 3,
+	)
 
 /obj/structure/closet/secure_closet/engineering_welding
 	name = "welding supplies locker"
@@ -74,14 +66,10 @@
 	icon_off = "secureengweldoff"
 
 /obj/structure/closet/secure_closet/engineering_welding/New()
-	..()
-	sleep(2)
-	new /obj/item/clothing/head/welding(src)
-	new /obj/item/clothing/head/welding(src)
-	new /obj/item/clothing/head/welding(src)
-	new /obj/item/weapon/weldingtool/largetank(src)
-	new /obj/item/weapon/weldingtool/largetank(src)
-	new /obj/item/weapon/weldingtool/largetank(src)
+	return list(
+		/obj/item/clothing/head/welding = 3,
+		/obj/item/weapon/weldingtool/largetank = 3,
+	)
 
 /obj/structure/closet/secure_closet/engineering_personal
 	name = "\improper Engineer's locker"
@@ -94,28 +82,25 @@
 	icon_off = "secureengoff"
 
 /obj/structure/closet/secure_closet/engineering_personal/New()
-	..()
-	sleep(2)
-	if(prob(50))
-		new /obj/item/weapon/storage/backpack/industrial(src)
-	else
-		new /obj/item/weapon/storage/backpack/satchel_eng(src)
-	new /obj/item/clothing/under/rank/engineer(src)
-	new /obj/item/clothing/shoes/workboots(src)
-	new /obj/item/weapon/storage/box/inflatables(src)
-	new /obj/item/weapon/storage/toolbox/mechanical(src)
-//		new /obj/item/weapon/cartridge/engineering(src)
-	new /obj/item/device/radio/headset/headset_eng(src)
-	new /obj/item/clothing/suit/storage/hazardvest(src)
-	new /obj/item/clothing/mask/gas(src)
-	if(prob(50))
-		new /obj/item/clothing/glasses/scanner/meson/prescription(src)
-	else
-		new /obj/item/clothing/glasses/scanner/meson(src)
-	new /obj/item/taperoll/engineering(src)
-	new /obj/item/taperoll/engineering(src)
-	new /obj/item/device/gps/engineering(src)
-	new /obj/item/clothing/glasses/scanner/material(src)
+	return list(
+		pick(
+			/obj/item/weapon/storage/backpack/industrial,
+			/obj/item/weapon/storage/backpack/satchel_eng),
+		/obj/item/clothing/under/rank/engineer,
+		/obj/item/clothing/shoes/workboots,
+		/obj/item/weapon/storage/box/inflatables,
+		/obj/item/weapon/storage/toolbox/mechanical,
+		/obj/item/device/radio/headset/headset_eng,
+		/obj/item/clothing/suit/storage/hazardvest,
+		/obj/item/clothing/mask/gas,
+		pick(
+			/obj/item/clothing/glasses/scanner/meson/prescription,
+			/obj/item/clothing/glasses/scanner/meson),
+		/obj/item/taperoll/engineering,
+		/obj/item/taperoll/engineering,
+		/obj/item/device/gps/engineering,
+		/obj/item/clothing/glasses/scanner/material,
+	)
 
 /obj/structure/closet/secure_closet/engineering_atmos
 	name = "\improper Atmospheric Technician's locker"
@@ -127,31 +112,29 @@
 	icon_broken = "secureatmosbroken"
 	icon_off = "secureatmosoff"
 
-/obj/structure/closet/secure_closet/engineering_atmos/New()
-	..()
-	sleep(2)
-	if(prob(50))
-		new /obj/item/weapon/storage/backpack(src)
-	else
-		new /obj/item/weapon/storage/backpack/satchel_norm(src)
-	new /obj/item/clothing/under/rank/atmospheric_technician(src)
-	new /obj/item/clothing/shoes/workboots(src)
-	new /obj/item/weapon/storage/box/inflatables(src)
-	new /obj/item/weapon/storage/toolbox/mechanical(src)
-	new /obj/item/weapon/extinguisher/foam(src)
-	// new /obj/item/weapon/cartridge/engineering(src)
-	new /obj/item/device/radio/headset/headset_eng(src)
-	new /obj/item/clothing/suit/storage/hazardvest(src)
-	new /obj/item/clothing/mask/gas(src)
-	new /obj/item/taperoll/atmos(src)
-	new /obj/item/pipe_planner(src)
-	new /obj/item/weapon/wrench/socket(src)
-	new /obj/item/weapon/gun/projectile/flare(src) //yay for emergency lighting
-	new /obj/item/ammo_storage/box/flare(src)
-	new /obj/item/device/rcd/rpd(src)
-	new /obj/item/device/analyzer(src)
-	new /obj/item/clothing/glasses/scanner/material(src)
-	new /obj/item/device/gps/engineering(src)
+/obj/structure/closet/secure_closet/engineering_atmos/atoms_to_spawn()
+	return list(
+		pick(
+			/obj/item/weapon/storage/backpack,
+			/obj/item/weapon/storage/backpack/satchel_norm),
+		/obj/item/clothing/under/rank/atmospheric_technician,
+		/obj/item/clothing/shoes/workboots,
+		/obj/item/weapon/storage/box/inflatables,
+		/obj/item/weapon/storage/toolbox/mechanical,
+		/obj/item/weapon/extinguisher/foam,
+		/obj/item/device/radio/headset/headset_eng,
+		/obj/item/clothing/suit/storage/hazardvest,
+		/obj/item/clothing/mask/gas,
+		/obj/item/taperoll/atmos,
+		/obj/item/pipe_planner,
+		/obj/item/weapon/wrench/socket,
+		/obj/item/weapon/gun/projectile/flare,
+		/obj/item/ammo_storage/box/flare,
+		/obj/item/device/rcd/rpd,
+		/obj/item/device/analyzer,
+		/obj/item/clothing/glasses/scanner/material,
+		/obj/item/device/gps/engineering,
+	)
 
 /obj/structure/closet/secure_closet/engineering_mechanic
 	name = "\improper Mechanic's locker"
@@ -164,28 +147,23 @@
 	icon_off = "securemechnioff"
 
 /obj/structure/closet/secure_closet/engineering_mechanic/New()
-	..()
-	sleep(2)
-	if(prob(50))
-		new /obj/item/weapon/storage/backpack/industrial(src)
-	else
-		new /obj/item/weapon/storage/backpack/satchel_eng(src)
-	new /obj/item/clothing/under/rank/mechanic(src)
-	new /obj/item/clothing/shoes/workboots(src)
-	new /obj/item/weapon/storage/toolbox/mechanical(src)
-	//new /obj/item/device/component_exchanger(src)
-	new /obj/item/device/radio/headset/headset_engsci(src)
-	new /obj/item/clothing/suit/storage/hazardvest(src)
-	new /obj/item/device/device_analyser(src)
-	new /obj/item/weapon/soap/nanotrasen(src)
-	new /obj/item/clothing/gloves/black(src)
-	new /obj/item/device/assembly_frame(src)
-	new /obj/item/device/assembly_frame(src)
-
-	if(prob(50))
-		new /obj/item/clothing/head/welding(src)
-	else
-		new /obj/item/clothing/glasses/welding(src)
+	return list(
+		pick(
+			/obj/item/weapon/storage/backpack/industrial,
+			/obj/item/weapon/storage/backpack/satchel_eng),
+		/obj/item/clothing/under/rank/mechanic,
+		/obj/item/clothing/shoes/workboots,
+		/obj/item/weapon/storage/toolbox/mechanical,
+		/obj/item/device/radio/headset/headset_engsci,
+		/obj/item/clothing/suit/storage/hazardvest,
+		/obj/item/device/device_analyser,
+		/obj/item/weapon/soap/nanotrasen,
+		/obj/item/clothing/gloves/black,
+		/obj/item/device/assembly_frame = 2,
+		pick(
+			/obj/item/clothing/head/welding,
+			/obj/item/clothing/glasses/welding),
+	)
 
 /obj/structure/closet/secure_closet/engineering_general
 	name = "engineering locker"
@@ -203,9 +181,7 @@
 	var/payload = /obj/machinery/power/supermatter/shard
 	var/mapping_idtag
 
-/obj/structure/closet/crate/secure/large/reinforced/shard/New()
-	..()
-	sleep(2)
+/obj/structure/closet/crate/secure/large/reinforced/shard/spawn_contents()
 	if(payload)
 		var/obj/machinery/power/supermatter/S = new payload(src)
 		if(mapping_idtag && istype(S))

--- a/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
@@ -78,14 +78,11 @@
 	name = "Kitchen Cabinet"
 	req_access = list(access_kitchen)
 
-	New()
-		..()
-		sleep(2)
-		for(var/i = 0, i < 3, i++)
-			new /obj/item/weapon/reagent_containers/food/drinks/flour(src)
-		new /obj/item/weapon/reagent_containers/food/condiment/sugar(src)
-		return
-
+/obj/structure/closet/secure_closet/freezer/kitchen/atoms_to_spawn()
+	return list(
+		/obj/item/weapon/reagent_containers/food/drinks/flour = 3,
+		/obj/item/weapon/reagent_containers/food/condiment/sugar,
+	)
 
 /obj/structure/closet/secure_closet/freezer/kitchen/mining
 	req_access = list()
@@ -102,13 +99,10 @@
 	icon_off = "fridge1"
 
 
-	New()
-		..()
-		sleep(2)
-		for(var/i = 0, i < 4, i++)
-			new /obj/item/weapon/reagent_containers/food/snacks/meat/animal/monkey(src)
-		return
-
+/obj/structure/closet/secure_closet/freezer/meat/atoms_to_spawn()
+	return list(
+		/obj/item/weapon/reagent_containers/food/snacks/meat/animal/monkey = 4,
+	)
 
 
 /obj/structure/closet/secure_closet/freezer/fridge
@@ -120,17 +114,12 @@
 	icon_broken = "fridgebroken"
 	icon_off = "fridge1"
 
-
-	New()
-		..()
-		sleep(2)
-		for(var/i = 0, i < 5, i++)
-			new /obj/item/weapon/reagent_containers/food/drinks/milk(src)
-		for(var/i = 0, i < 5, i++)
-			new /obj/item/weapon/reagent_containers/food/drinks/soymilk(src)
-		for(var/i = 0, i < 2, i++)
-			new /obj/item/weapon/storage/fancy/egg_box(src)
-		return
+/obj/structure/closet/secure_closet/freezer/fridge/atoms_to_spawn()
+	return list(
+		/obj/item/weapon/reagent_containers/food/drinks/milk = 5,
+		/obj/item/weapon/reagent_containers/food/drinks/soymilk = 5,
+		/obj/item/weapon/storage/fancy/egg_box = 2
+	)
 
 
 
@@ -145,11 +134,9 @@
 	req_access = list(access_heads_vault)
 
 
-	New()
-		..()
-		sleep(2)
-		dispense_cash(6700,src)
-		return
+/obj/structure/closet/secure_closet/freezer/money/spawn_contents()
+	dispense_cash(6700, src)
+
 
 
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/hydroponics.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/hydroponics.dm
@@ -9,23 +9,19 @@
 	icon_off = "hydrosecureoff"
 
 
-	New()
-		..()
-		sleep(2)
-		switch(rand(1,2))
-			if(1)
-				new /obj/item/clothing/suit/apron(src)
-			if(2)
-				new /obj/item/clothing/suit/apron/overalls(src)
-		new /obj/item/weapon/storage/bag/plants(src)
-		switch(rand(1,2))
-			if(1)
-				new /obj/item/clothing/under/rank/hydroponics(src)
-			if(2)
-				new /obj/item/clothing/under/rank/botany(src)
-		new /obj/item/device/analyzer/plant_analyzer(src)
-		new /obj/item/clothing/head/greenbandana(src)
-		new /obj/item/weapon/minihoe(src)
-		new /obj/item/weapon/hatchet(src)
-		new /obj/item/weapon/bee_net(src)
-		return
+/obj/structure/closet/secure_closet/hydroponics/atoms_to_spawn()
+	return list(
+		pick(
+			/obj/item/clothing/suit/apron,
+			/obj/item/clothing/suit/apron/overalls),
+		/obj/item/weapon/storage/bag/plants,
+		pick(
+			/obj/item/clothing/under/rank/hydroponics,
+			/obj/item/clothing/under/rank/botany,
+		),
+		/obj/item/device/analyzer/plant_analyzer,
+		/obj/item/clothing/head/greenbandana,
+		/obj/item/weapon/minihoe,
+		/obj/item/weapon/hatchet,
+		/obj/item/weapon/bee_net,
+	)

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -10,20 +10,14 @@
 	req_access = list(access_medical)
 
 
-	New()
-		..()
-		sleep(2)
-		new /obj/item/weapon/storage/box/syringes(src)
-		new /obj/item/weapon/reagent_containers/dropper(src)
-		new /obj/item/weapon/reagent_containers/dropper(src)
-		new /obj/item/weapon/reagent_containers/glass/beaker(src)
-		new /obj/item/weapon/reagent_containers/glass/beaker(src)
-		new /obj/item/weapon/reagent_containers/glass/bottle/inaprovaline(src)
-		new /obj/item/weapon/reagent_containers/glass/bottle/inaprovaline(src)
-		new /obj/item/weapon/reagent_containers/glass/bottle/antitoxin(src)
-		new /obj/item/weapon/reagent_containers/glass/bottle/antitoxin(src)
-		return
-
+/obj/structure/closet/secure_closet/medical1/atoms_to_spawn()
+	return list(
+		/obj/item/weapon/storage/box/syringes,
+		/obj/item/weapon/reagent_containers/dropper = 2,
+		/obj/item/weapon/reagent_containers/glass/beaker = 2,
+		/obj/item/weapon/reagent_containers/glass/bottle/inaprovaline = 2,
+		/obj/item/weapon/reagent_containers/glass/bottle/antitoxin = 2,
+	)
 
 
 /obj/structure/closet/secure_closet/medical2
@@ -38,16 +32,11 @@
 	req_access = list(access_surgery)
 
 
-	New()
-		..()
-		sleep(2)
-		new /obj/item/weapon/tank/anesthetic(src)
-		new /obj/item/weapon/tank/anesthetic(src)
-		new /obj/item/weapon/tank/anesthetic(src)
-		new /obj/item/clothing/mask/breath/medical(src)
-		new /obj/item/clothing/mask/breath/medical(src)
-		new /obj/item/clothing/mask/breath/medical(src)
-		return
+/obj/structure/closet/secure_closet/medical2/atoms_to_spawn()
+	return list(
+		/obj/item/weapon/tank/anesthetic = 3,
+		/obj/item/clothing/mask/breath/medical = 3,
+	)
 
 
 
@@ -61,49 +50,46 @@
 	icon_broken = "securemedbroken"
 	icon_off = "securemedoff"
 
-	New()
-		..()
-		sleep(2)
-		new /obj/item/clothing/monkeyclothes/doctor (src)
-		new /obj/item/clothing/monkeyclothes/doctor (src)
-		if(prob(50))
-			new /obj/item/weapon/storage/backpack/medic(src)
-		else
-			new /obj/item/weapon/storage/backpack/satchel_med(src)
-		new /obj/item/clothing/under/rank/nursesuit (src)
-		new /obj/item/clothing/head/nursehat (src)
-		switch(pick("blue", "green", "purple"))
-			if ("blue")
-				new /obj/item/clothing/under/rank/medical/blue(src)
-				new /obj/item/clothing/head/surgery/blue(src)
-			if ("green")
-				new /obj/item/clothing/under/rank/medical/green(src)
-				new /obj/item/clothing/head/surgery/green(src)
-			if ("purple")
-				new /obj/item/clothing/under/rank/medical/purple(src)
-				new /obj/item/clothing/head/surgery/purple(src)
-		switch(pick("blue", "green", "purple"))
-			if ("blue")
-				new /obj/item/clothing/under/rank/medical/blue(src)
-				new /obj/item/clothing/head/surgery/blue(src)
-			if ("green")
-				new /obj/item/clothing/under/rank/medical/green(src)
-				new /obj/item/clothing/head/surgery/green(src)
-			if ("purple")
-				new /obj/item/clothing/under/rank/medical/purple(src)
-				new /obj/item/clothing/head/surgery/purple(src)
-		new /obj/item/clothing/under/rank/medical(src)
-		new /obj/item/clothing/under/rank/nurse(src)
-		new /obj/item/clothing/under/rank/orderly(src)
-		new /obj/item/clothing/suit/storage/labcoat(src)
-		new /obj/item/clothing/suit/storage/fr_jacket(src)
-		new /obj/item/clothing/shoes/white(src)
-//		new /obj/item/weapon/cartridge/medical(src)
-		new /obj/item/device/radio/headset/headset_med(src)
-		new /obj/item/weapon/storage/belt/medical(src)
-		new /obj/item/clothing/glasses/hud/health/prescription(src)
-		return
-
+/obj/structure/closet/secure_closet/medical3/atoms_to_spawn()
+	. = list(
+		/obj/item/clothing/monkeyclothes/doctor = 2,
+		pick(
+			/obj/item/weapon/storage/backpack/medic,
+			/obj/item/weapon/storage/backpack/satchel_med),
+		/obj/item/clothing/under/rank/nursesuit,
+		/obj/item/clothing/head/nursehat,
+	)
+	switch(pick("blue", "green", "purple"))
+		if ("blue")
+			. += /obj/item/clothing/under/rank/medical/blue
+			. += /obj/item/clothing/head/surgery/blue
+		if ("green")
+			. += /obj/item/clothing/under/rank/medical/green
+			. += /obj/item/clothing/head/surgery/green
+		if ("purple")
+			. += /obj/item/clothing/under/rank/medical/purple
+			. += /obj/item/clothing/head/surgery/purple
+	switch(pick("blue", "green", "purple"))
+		if ("blue")
+			. += /obj/item/clothing/under/rank/medical/blue
+			. += /obj/item/clothing/head/surgery/blue
+		if ("green")
+			. += /obj/item/clothing/under/rank/medical/green
+			. += /obj/item/clothing/head/surgery/green
+		if ("purple")
+			. += /obj/item/clothing/under/rank/medical/purple
+			. += /obj/item/clothing/head/surgery/purple
+	. += list(
+		/obj/item/clothing/under/rank/medical,
+		/obj/item/clothing/under/rank/nurse,
+		/obj/item/clothing/under/rank/orderly,
+		/obj/item/clothing/suit/storage/labcoat,
+		/obj/item/clothing/suit/storage/fr_jacket,
+		/obj/item/clothing/shoes/white,
+		/obj/item/device/radio/headset/headset_med,
+		/obj/item/weapon/storage/belt/medical,
+		/obj/item/clothing/glasses/hud/health/prescription,
+	)
 
 
 /obj/structure/closet/secure_closet/CMO
@@ -116,54 +102,47 @@
 	icon_broken = "cmosecurebroken"
 	icon_off = "cmosecureoff"
 
-	New()
-		..()
-		sleep(2)
-		if(prob(50))
-			new /obj/item/weapon/storage/backpack/medic(src)
-		else
-			new /obj/item/weapon/storage/backpack/satchel_med(src)
-		new /obj/item/clothing/suit/bio_suit/cmo(src)
-		new /obj/item/clothing/head/bio_hood/cmo(src)
-		new /obj/item/clothing/shoes/white(src)
-		switch(pick("blue", "green", "purple"))
-			if ("blue")
-				new /obj/item/clothing/under/rank/medical/blue(src)
-				new /obj/item/clothing/head/surgery/blue(src)
-			if ("green")
-				new /obj/item/clothing/under/rank/medical/green(src)
-				new /obj/item/clothing/head/surgery/green(src)
-			if ("purple")
-				new /obj/item/clothing/under/rank/medical/purple(src)
-				new /obj/item/clothing/head/surgery/purple(src)
-		new /obj/item/clothing/under/rank/chief_medical_officer(src)
-		new /obj/item/clothing/suit/storage/labcoat/cmo(src)
-		new /obj/item/weapon/cartridge/cmo(src)
-		new /obj/item/clothing/gloves/latex(src)
-		new /obj/item/clothing/shoes/brown	(src)
-		new /obj/item/device/radio/headset/heads/cmo(src)
-		new /obj/item/weapon/storage/belt/medical(src)
-		new /obj/item/device/flash(src)
-		new /obj/item/weapon/reagent_containers/hypospray(src)
-		new /obj/item/weapon/card/debit/preferred/department(src, "Medical")
-		return
-
+/obj/structure/closet/secure_closet/CMO/atoms_to_spawn()
+	. = list(
+		pick(
+			/obj/item/weapon/storage/backpack/medic,
+			/obj/item/weapon/storage/backpack/satchel_med),
+		/obj/item/clothing/suit/bio_suit/cmo = 2,
+		/obj/item/clothing/shoes/white,
+	)
+	switch(pick("blue", "green", "purple"))
+		if ("blue")
+			. += /obj/item/clothing/under/rank/medical/blue
+			. += /obj/item/clothing/head/surgery/blue
+		if ("green")
+			. += /obj/item/clothing/under/rank/medical/green
+			. += /obj/item/clothing/head/surgery/green
+		if ("purple")
+			. += /obj/item/clothing/under/rank/medical/purple
+			. += /obj/item/clothing/head/surgery/purple
+	. += list(
+		/obj/item/clothing/under/rank/chief_medical_officer,
+		/obj/item/clothing/suit/storage/labcoat/cmo,
+		/obj/item/weapon/cartridge/cmo,
+		/obj/item/clothing/gloves/latex,
+		/obj/item/clothing/shoes/brown,
+		/obj/item/device/radio/headset/heads/cmo,
+		/obj/item/weapon/storage/belt/medical,
+		/obj/item/device/flash,
+		/obj/item/weapon/reagent_containers/hypospray,
+		/obj/item/weapon/card/debit/preferred/department/medical,
+	)
 
 
 /obj/structure/closet/secure_closet/animal
 	name = "Animal Control"
 	req_access = list(access_surgery)
 
-
-	New()
-		..()
-		sleep(2)
-		new /obj/item/device/assembly/signaler(src)
-		new /obj/item/device/radio/electropack(src)
-		new /obj/item/device/radio/electropack(src)
-		new /obj/item/device/radio/electropack(src)
-		return
-
+/obj/structure/closet/secure_closet/animal/atoms_to_spawn()
+	return list(
+		/obj/item/device/assembly/signaler,
+		/obj/item/device/radio/electropack = 3,
+	)
 
 
 /obj/structure/closet/secure_closet/chemical
@@ -177,13 +156,10 @@
 	icon_off = "medicaloff"
 	req_access = list(access_chemistry)
 
-
-	New()
-		..()
-		sleep(2)
-		new /obj/item/weapon/storage/box/pillbottles(src)
-		new /obj/item/weapon/storage/box/pillbottles(src)
-		return
+/obj/structure/closet/secure_closet/chemical/atoms_to_spawn()
+	return list(
+		/obj/item/weapon/storage/box/pillbottles = 2,
+	)
 
 /obj/structure/closet/secure_closet/medical_wall
 	name = "First Aid Closet"
@@ -222,14 +198,11 @@
 	icon_off = "medicaloff"
 	req_access = list(access_paramedic)
 
-
-	New()
-		..()
-		sleep(2)
-		new /obj/item/clothing/suit/space/paramedic(src)
-		new /obj/item/clothing/head/helmet/space/paramedic(src)
-		new /obj/item/clothing/shoes/magboots/para(src)
-		new /obj/item/clothing/accessory/storage/webbing/paramed(src)
-		new /obj/item/weapon/storage/firstaid/internalbleed(src)
-		new /obj/item/weapon/storage/firstaid/internalbleed(src)
-		return
+/obj/structure/closet/secure_closet/paramedic/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/suit/space/paramedic,
+		/obj/item/clothing/head/helmet/space/paramedic,
+		/obj/item/clothing/shoes/magboots/para,
+		/obj/item/clothing/accessory/storage/webbing/paramed,
+		/obj/item/weapon/storage/firstaid/internalbleed = 2,
+	)

--- a/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
@@ -4,26 +4,21 @@
 	req_access = list(access_all_personal_lockers)
 	var/registered_name = null
 
-/obj/structure/closet/secure_closet/personal/New()
-	..()
-	spawn(2)
-		var/B = pick(/obj/item/weapon/storage/backpack, /obj/item/weapon/storage/backpack/satchel_norm, /obj/item/weapon/storage/backpack/messenger)
-		new B(src)
-		new /obj/item/device/radio/headset( src )
-	return
+/obj/structure/closet/secure_closet/personal/atoms_to_spawn()
+	return list(
+		pick(/obj/item/weapon/storage/backpack, /obj/item/weapon/storage/backpack/satchel_norm, /obj/item/weapon/storage/backpack/messenger),
+		/obj/item/device/radio/headset,
+	)
 
 
 /obj/structure/closet/secure_closet/personal/patient
 	name = "patient's closet"
 
-/obj/structure/closet/secure_closet/personal/patient/New()
-	..()
-	spawn(4)
-		contents = list()
-		new /obj/item/clothing/under/color/white( src )
-		new /obj/item/clothing/shoes/white( src )
-	return
-
+/obj/structure/closet/secure_closet/personal/patient/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/under/color/white,
+		/obj/item/clothing/shoes/white,
+	)
 
 
 /obj/structure/closet/secure_closet/personal/cabinet
@@ -46,13 +41,11 @@
 		else
 			icon_state = icon_opened
 
-/obj/structure/closet/secure_closet/personal/cabinet/New()
-	..()
-	spawn(4)
-		contents = list()
-		new /obj/item/weapon/storage/backpack/satchel/withwallet( src )
-		new /obj/item/device/radio/headset( src )
-	return
+/obj/structure/closet/secure_closet/personal/cabinet/atoms_to_spawn()
+	return list(
+		/obj/item/weapon/storage/backpack/satchel/withwallet,
+		/obj/item/device/radio/headset,
+	)
 
 /obj/structure/closet/secure_closet/personal/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(istype(W, /obj/item/weapon/card/id))

--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -8,17 +8,15 @@
 	icon_broken = "secureresbroken"
 	icon_off = "secureresoff"
 
-/obj/structure/closet/secure_closet/scientist/New()
-	..()
-	sleep(2)
-	new /obj/item/clothing/under/rank/scientist(src)
-	new /obj/item/clothing/suit/storage/labcoat/science(src)
-	new /obj/item/clothing/shoes/white(src)
-//	new /obj/item/weapon/cartridge/signal/toxins(src)
-	new /obj/item/device/radio/headset/headset_sci(src)
-	new /obj/item/weapon/tank/air(src)
-	new /obj/item/clothing/mask/gas(src)
-
+/obj/structure/closet/secure_closet/scientist/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/under/rank/scientist,
+		/obj/item/clothing/suit/storage/labcoat/science,
+		/obj/item/clothing/shoes/white,
+		/obj/item/device/radio/headset/headset_sci,
+		/obj/item/weapon/tank/air,
+		/obj/item/clothing/mask/gas,
+	)
 
 
 /obj/structure/closet/secure_closet/RD
@@ -31,20 +29,19 @@
 	icon_broken = "rdsecurebroken"
 	icon_off = "rdsecureoff"
 
-/obj/structure/closet/secure_closet/RD/New()
-	..()
-	sleep(2)
-	new /obj/item/clothing/suit/bio_suit/scientist(src)
-	new /obj/item/clothing/head/bio_hood/scientist(src)
-	new /obj/item/clothing/under/rank/research_director(src)
-	new /obj/item/clothing/under/dress/dress_rd(src)
-	new /obj/item/clothing/suit/storage/labcoat/rd(src)
-	new /obj/item/weapon/cartridge/rd(src)
-	new /obj/item/clothing/shoes/white(src)
-	new /obj/item/clothing/gloves/latex(src)
-	new /obj/item/device/radio/headset/heads/rd(src)
-	new /obj/item/weapon/tank/air(src)
-	new /obj/item/clothing/mask/gas(src)
-	new /obj/item/device/flash(src)
-	new /obj/item/weapon/switchtool/holo(src)
-	new /obj/item/weapon/card/debit/preferred/department(src, "Science")
+/obj/structure/closet/secure_closet/RD/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/suit/bio_suit/scientist = 2,
+		/obj/item/clothing/under/rank/research_director,
+		/obj/item/clothing/under/dress/dress_rd,
+		/obj/item/clothing/suit/storage/labcoat/rd,
+		/obj/item/weapon/cartridge/rd,
+		/obj/item/clothing/shoes/white,
+		/obj/item/clothing/gloves/latex,
+		/obj/item/device/radio/headset/heads/rd,
+		/obj/item/weapon/tank/air,
+		/obj/item/clothing/mask/gas,
+		/obj/item/device/flash,
+		/obj/item/weapon/switchtool/holo,
+		/obj/item/weapon/card/debit/preferred/department/science,
+	)

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -8,33 +8,29 @@
 	icon_broken = "capsecurebroken"
 	icon_off = "capsecureoff"
 
-	New()
-		..()
-		sleep(2)
-		if(prob(50))
-			new /obj/item/weapon/storage/backpack/captain(src)
-		else
-			new /obj/item/weapon/storage/backpack/satchel_cap(src)
-		new /obj/item/clothing/suit/captunic(src)
-		new /obj/item/clothing/suit/storage/capjacket(src)
-		new /obj/item/clothing/head/helmet/cap(src)
-		new /obj/item/clothing/under/rank/captain(src)
-		new /obj/item/clothing/suit/armor/vest(src)
-		new /obj/item/weapon/cartridge/captain(src)
-		new /obj/item/clothing/head/helmet/tactical/swat(src)
-		new /obj/item/clothing/shoes/brown(src)
-		new /obj/item/device/radio/headset/heads/captain(src)
-		new /obj/item/clothing/gloves/captain(src)
-		new /obj/item/clothing/shoes/magboots/captain(src)
-		new /obj/item/weapon/gun/energy/gun(src)
-		new /obj/item/clothing/suit/armor/captain(src)
-		new /obj/item/weapon/melee/telebaton(src)
-		new /obj/item/clothing/under/dress/dress_cap(src)
-		new /obj/item/device/gps/secure(src)
-		new /obj/item/weapon/card/debit/preferred/department/elite(src, "Command")
-
-		return
-
+/obj/structure/closet/secure_closet/captains/atoms_to_spawn()
+	return list(
+		pick(
+			/obj/item/weapon/storage/backpack/captain,
+			/obj/item/weapon/storage/backpack/satchel_cap),
+		/obj/item/clothing/suit/captunic,
+		/obj/item/clothing/suit/storage/capjacket,
+		/obj/item/clothing/head/helmet/cap,
+		/obj/item/clothing/under/rank/captain,
+		/obj/item/clothing/suit/armor/vest,
+		/obj/item/weapon/cartridge/captain,
+		/obj/item/clothing/head/helmet/tactical/swat,
+		/obj/item/clothing/shoes/brown,
+		/obj/item/device/radio/headset/heads/captain,
+		/obj/item/clothing/gloves/captain,
+		/obj/item/clothing/shoes/magboots/captain,
+		/obj/item/weapon/gun/energy/gun,
+		/obj/item/clothing/suit/armor/captain,
+		/obj/item/weapon/melee/telebaton,
+		/obj/item/clothing/under/dress/dress_cap,
+		/obj/item/device/gps/secure,
+		/obj/item/weapon/card/debit/preferred/department/elite/command,
+	)
 
 
 /obj/structure/closet/secure_closet/hop
@@ -47,21 +43,19 @@
 	icon_broken = "hopsecurebroken"
 	icon_off = "hopsecureoff"
 
-	New()
-		..()
-		sleep(2)
-		new /obj/item/clothing/glasses/sunglasses(src)
-		new /obj/item/clothing/suit/storage/Hop_Coat(src)
-		new /obj/item/clothing/head/helmet/hopcap(src)
-		new /obj/item/weapon/cartridge/hop(src)
-		new /obj/item/device/radio/headset/heads/hop(src)
-		new /obj/item/weapon/storage/box/ids(src)
-		new /obj/item/weapon/storage/box/ids(src)
-		new /obj/item/weapon/gun/energy/gun(src)
-		new /obj/item/device/flash(src)
-		new /obj/item/device/gps/secure(src)
-		new /obj/item/weapon/card/debit/preferred/department(src, "Civilian")
-		return
+/obj/structure/closet/secure_closet/hop/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/glasses/sunglasses,
+		/obj/item/clothing/suit/storage/Hop_Coat,
+		/obj/item/clothing/head/helmet/hopcap,
+		/obj/item/weapon/cartridge/hop,
+		/obj/item/device/radio/headset/heads/hop,
+		/obj/item/weapon/storage/box/ids = 2,
+		/obj/item/weapon/gun/energy/gun,
+		/obj/item/device/flash,
+		/obj/item/device/gps/secure,
+		/obj/item/weapon/card/debit/preferred/department/civilian,
+	)
 
 /obj/structure/closet/secure_closet/hop2
 	name = "Head of Personnel's Attire"
@@ -73,22 +67,20 @@
 	icon_broken = "hopsecurebroken"
 	icon_off = "hopsecureoff"
 
-	New()
-		..()
-		sleep(2)
-		new /obj/item/clothing/under/rank/head_of_personnel(src)
-		new /obj/item/clothing/under/dress/dress_hop(src)
-		new /obj/item/clothing/under/dress/dress_hr(src)
-		new /obj/item/clothing/under/lawyer/female(src)
-		new /obj/item/clothing/under/lawyer/black(src)
-		new /obj/item/clothing/under/lawyer/red(src)
-		new /obj/item/clothing/under/lawyer/oldman(src)
-		new /obj/item/clothing/shoes/brown(src)
-		new /obj/item/clothing/shoes/black(src)
-		new /obj/item/clothing/shoes/leather(src)
-		new /obj/item/clothing/shoes/white(src)
-		return
-
+/obj/structure/closet/secure_closet/hop2/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/under/rank/head_of_personnel,
+		/obj/item/clothing/under/dress/dress_hop,
+		/obj/item/clothing/under/dress/dress_hr,
+		/obj/item/clothing/under/lawyer/female,
+		/obj/item/clothing/under/lawyer/black,
+		/obj/item/clothing/under/lawyer/red,
+		/obj/item/clothing/under/lawyer/oldman,
+		/obj/item/clothing/shoes/brown,
+		/obj/item/clothing/shoes/black,
+		/obj/item/clothing/shoes/leather,
+		/obj/item/clothing/shoes/white,
+	)
 
 
 /obj/structure/closet/secure_closet/hos
@@ -101,45 +93,43 @@
 	icon_broken = "hossecurebroken"
 	icon_off = "hossecureoff"
 
-/obj/structure/closet/secure_closet/hos/New()
-	..()
-	sleep(2)
-	if(prob(50))
-		new /obj/item/weapon/storage/backpack/security(src)
-	else
-		new /obj/item/weapon/storage/backpack/satchel_sec(src)
-	new /obj/item/clothing/head/helmet/tactical/HoS(src)
-	new /obj/item/device/flashlight/tactical(src)
-	new /obj/item/clothing/accessory/holster/knife/boot/preloaded/tactical(src)
-	new /obj/item/clothing/suit/armor/vest(src)
-	new /obj/item/clothing/under/rank/head_of_security/jensen(src)
-	if(prob(50))
-		new /obj/item/clothing/suit/armor/hos/jensen(src)
-	else
-		new /obj/item/clothing/suit/armor/hos/sundowner(src)
-	new /obj/item/clothing/head/helmet/tactical/HoS/dermal(src)
-	new /obj/item/weapon/cartridge/hos(src)
-	new /obj/item/device/detective_scanner(src)
-	new /obj/item/device/radio/headset/heads/hos(src)
-	new /obj/item/clothing/glasses/sunglasses/sechud(src)
-	new /obj/item/weapon/shield/riot(src)
-	new /obj/item/weapon/storage/lockbox/loyalty(src)
-	new /obj/item/weapon/storage/box/flashbangs(src)
-	new /obj/item/weapon/storage/belt/security(src)
-	new /obj/item/device/flash(src)
-	new /obj/item/weapon/melee/baton/loaded(src)
-	var/obj/lblg = new /obj/item/weapon/storage/lockbox/lawgiver(src)
-	new /obj/item/ammo_storage/magazine/lawgiver(lblg)
-	new /obj/item/clothing/accessory/holster/handgun/waist(src)
-	new /obj/item/weapon/melee/telebaton(src)
-	new /obj/item/device/gps/secure(src)
-	new /obj/item/clothing/suit/armor/hos(src)
-	new /obj/item/taperoll/police(src)
-	new /obj/item/device/hailer(src)
-	new /obj/item/weapon/reagent_containers/spray/pepper(src)
-	new /obj/item/weapon/grenade/flashbang(src)
-	new /obj/item/weapon/gun/energy/taser(src)
-	new /obj/item/weapon/card/debit/preferred/department(src, "Security")
+/obj/structure/closet/secure_closet/hos/atoms_to_spawn()
+	return list(
+		pick(
+			/obj/item/weapon/storage/backpack/security,
+			/obj/item/weapon/storage/backpack/satchel_sec,
+		),
+		/obj/item/clothing/head/helmet/tactical/HoS,
+		/obj/item/device/flashlight/tactical,
+		/obj/item/clothing/accessory/holster/knife/boot/preloaded/tactical,
+		/obj/item/clothing/suit/armor/vest,
+		/obj/item/clothing/under/rank/head_of_security/jensen,
+		pick(
+			/obj/item/clothing/suit/armor/hos/jensen,
+			/obj/item/clothing/suit/armor/hos/sundowner),
+		/obj/item/clothing/head/helmet/tactical/HoS/dermal,
+		/obj/item/weapon/cartridge/hos,
+		/obj/item/device/detective_scanner,
+		/obj/item/device/radio/headset/heads/hos,
+		/obj/item/clothing/glasses/sunglasses/sechud,
+		/obj/item/weapon/shield/riot,
+		/obj/item/weapon/storage/lockbox/loyalty,
+		/obj/item/weapon/storage/box/flashbangs,
+		/obj/item/weapon/storage/belt/security,
+		/obj/item/device/flash,
+		/obj/item/weapon/melee/baton/loaded,
+		/obj/item/weapon/storage/lockbox/lawgiver/with_magazine,
+		/obj/item/clothing/accessory/holster/handgun/waist,
+		/obj/item/weapon/melee/telebaton,
+		/obj/item/device/gps/secure,
+		/obj/item/clothing/suit/armor/hos,
+		/obj/item/taperoll/police,
+		/obj/item/device/hailer,
+		/obj/item/weapon/reagent_containers/spray/pepper,
+		/obj/item/weapon/grenade/flashbang,
+		/obj/item/weapon/gun/energy/taser,
+		/obj/item/weapon/card/debit/preferred/department/security,
+	)
 
 /obj/structure/closet/secure_closet/warden
 	name = "Warden's Locker"
@@ -152,35 +142,33 @@
 	icon_off = "wardensecureoff"
 
 
-/obj/structure/closet/secure_closet/warden/New()
-	..()
-	sleep(2)
-	if(prob(50))
-		new /obj/item/weapon/storage/backpack/security(src)
-	else
-		new /obj/item/weapon/storage/backpack/satchel_sec(src)
-	new /obj/item/clothing/suit/armor/vest/security(src)
-	new /obj/item/clothing/under/rank/warden(src)
-	new /obj/item/clothing/suit/armor/vest/warden(src)
-	new /obj/item/clothing/head/helmet/tactical/warden(src)
-	new /obj/item/device/flashlight/tactical(src)
-//	new /obj/item/weapon/cartridge/security(src)
-	new /obj/item/device/radio/headset/headset_sec(src)
-	new /obj/item/clothing/glasses/sunglasses/sechud(src)
-	new /obj/item/weapon/storage/box/flashbangs(src)
-	new /obj/item/weapon/storage/belt/security(src)
-	new /obj/item/weapon/reagent_containers/spray/pepper(src)
-	new /obj/item/weapon/melee/baton/loaded(src)
-	new /obj/item/weapon/gun/energy/taser(src)
-	new /obj/item/weapon/storage/box/bolas(src)
-	new /obj/item/weapon/batteringram(src)
-	new /obj/item/device/gps/secure(src)
-	new /obj/item/taperoll/police(src)
-	new /obj/item/device/hailer(src)
-	new /obj/item/weapon/reagent_containers/spray/pepper(src)
-	new /obj/item/weapon/grenade/flashbang(src)
-	new /obj/item/clothing/accessory/holster/knife/boot/preloaded/tactical(src)
-	new /obj/item/weapon/gun/energy/taser(src)
+/obj/structure/closet/secure_closet/warden/atoms_to_spawn()
+	return list(
+		pick(
+			/obj/item/weapon/storage/backpack/security,
+			/obj/item/weapon/storage/backpack/satchel_sec),
+		/obj/item/clothing/suit/armor/vest/security,
+		/obj/item/clothing/under/rank/warden,
+		/obj/item/clothing/suit/armor/vest/warden,
+		/obj/item/clothing/head/helmet/tactical/warden,
+		/obj/item/device/flashlight/tactical,
+		/obj/item/device/radio/headset/headset_sec,
+		/obj/item/clothing/glasses/sunglasses/sechud,
+		/obj/item/weapon/storage/box/flashbangs,
+		/obj/item/weapon/storage/belt/security,
+		/obj/item/weapon/reagent_containers/spray/pepper,
+		/obj/item/weapon/melee/baton/loaded,
+		/obj/item/weapon/gun/energy/taser,
+		/obj/item/weapon/storage/box/bolas,
+		/obj/item/weapon/batteringram,
+		/obj/item/device/gps/secure,
+		/obj/item/taperoll/police,
+		/obj/item/device/hailer,
+		/obj/item/weapon/reagent_containers/spray/pepper,
+		/obj/item/weapon/grenade/flashbang,
+		/obj/item/clothing/accessory/holster/knife/boot/preloaded/tactical,
+		/obj/item/weapon/gun/energy/taser,
+	)
 
 /obj/structure/closet/secure_closet/security
 	name = "Security Officer's Locker"
@@ -192,64 +180,62 @@
 	icon_broken = "secbroken"
 	icon_off = "secoff"
 
-/obj/structure/closet/secure_closet/security/New()
-	..()
-	sleep(2)
-	if(prob(50))
-		new /obj/item/weapon/storage/backpack/security(src)
-	else
-		new /obj/item/weapon/storage/backpack/satchel_sec(src)
-	new /obj/item/clothing/suit/armor/vest/security(src)
-	new /obj/item/clothing/head/helmet/tactical/sec/preattached(src)
-	new /obj/item/clothing/accessory/holster/knife/boot/preloaded/tactical(src)
-//	new /obj/item/weapon/cartridge/security(src)
-	new /obj/item/device/radio/headset/headset_sec(src)
-	new /obj/item/weapon/storage/belt/security(src)
-	new /obj/item/device/flash(src)
-	new /obj/item/weapon/reagent_containers/spray/pepper(src)
-	new /obj/item/weapon/grenade/flashbang(src)
-	new /obj/item/weapon/melee/baton/loaded(src)
-	new /obj/item/weapon/gun/energy/taser(src)
-	if(prob(50))
-		new /obj/item/clothing/glasses/sunglasses/sechud/prescription(src)
-	else
-		new /obj/item/clothing/glasses/sunglasses/sechud(src)
-	new /obj/item/taperoll/police(src)
-	new /obj/item/device/hailer(src) //wonder if vg would spam this
-	new /obj/item/clothing/gloves/black(src)
-	new /obj/item/device/gps/secure(src)
+/obj/structure/closet/secure_closet/security/atoms_to_spawn()
+	return list(
+		pick(
+			/obj/item/weapon/storage/backpack/security,
+			/obj/item/weapon/storage/backpack/satchel_sec),
+		/obj/item/clothing/suit/armor/vest/security,
+		/obj/item/clothing/head/helmet/tactical/sec/preattached,
+		/obj/item/clothing/accessory/holster/knife/boot/preloaded/tactical,
+		/obj/item/device/radio/headset/headset_sec,
+		/obj/item/weapon/storage/belt/security,
+		/obj/item/device/flash,
+		/obj/item/weapon/reagent_containers/spray/pepper,
+		/obj/item/weapon/grenade/flashbang,
+		/obj/item/weapon/melee/baton/loaded,
+		/obj/item/weapon/gun/energy/taser,
+		pick(
+			/obj/item/clothing/glasses/sunglasses/sechud/prescription,
+			/obj/item/clothing/glasses/sunglasses/sechud),
+		/obj/item/taperoll/police,
+		/obj/item/device/hailer,
+		/obj/item/clothing/gloves/black,
+		/obj/item/device/gps/secure,
+	)
+
 
 /obj/structure/closet/secure_closet/security/cargo
 
-	New()
-		..()
-		new /obj/item/clothing/accessory/armband/cargo(src)
-		new /obj/item/device/encryptionkey/headset_cargo(src)
-		return
+/obj/structure/closet/secure_closet/security/cargo/atoms_to_spawn()
+	return ..() + list(
+		/obj/item/clothing/accessory/armband/cargo,
+		/obj/item/device/encryptionkey/headset_cargo,
+	)
 
 /obj/structure/closet/secure_closet/security/engine
 
-	New()
-		..()
-		new /obj/item/clothing/accessory/armband/engine(src)
-		new /obj/item/device/encryptionkey/headset_eng(src)
-		return
+/obj/structure/closet/secure_closet/security/engine/atoms_to_spawn()
+	return ..() + list(
+		/obj/item/clothing/accessory/armband/engine,
+		/obj/item/device/encryptionkey/headset_eng,
+	)
 
 /obj/structure/closet/secure_closet/security/science
 
-	New()
-		..()
-		new /obj/item/clothing/accessory/armband/science(src)
-		new /obj/item/device/encryptionkey/headset_sci(src)
-		return
+/obj/structure/closet/secure_closet/security/science/atoms_to_spawn()
+	return ..() + list(
+		/obj/item/clothing/accessory/armband/science,
+		/obj/item/device/encryptionkey/headset_sci,
+	)
 
 /obj/structure/closet/secure_closet/security/med
 
-	New()
-		..()
-		new /obj/item/clothing/accessory/armband/medgreen(src)
-		new /obj/item/device/encryptionkey/headset_med(src)
-		return
+/obj/structure/closet/secure_closet/security/med/atoms_to_spawn()
+	return ..() + list(
+		/obj/item/clothing/accessory/armband/medgreen,
+		/obj/item/device/encryptionkey/headset_med,
+	)
 
 
 /obj/structure/closet/secure_closet/detective
@@ -262,30 +248,29 @@
 	icon_broken = "cabinetdetective_broken"
 	icon_off = "cabinetdetective_broken"
 
-	New()
-		..()
-		sleep(2)
-		new /obj/item/clothing/under/det(src)
-		new /obj/item/clothing/suit/storage/det_suit(src)
-		new /obj/item/clothing/suit/storage/forensics/blue(src)
-		new /obj/item/clothing/suit/storage/forensics/red(src)
-		new /obj/item/clothing/gloves/black(src)
-		new /obj/item/clothing/head/det_hat(src)
-		new /obj/item/clothing/shoes/brown(src)
-		new /obj/item/weapon/storage/box/evidence(src)
-		new /obj/item/device/radio/headset/headset_sec(src)
-		new /obj/item/device/detective_scanner(src)
-		new /obj/item/clothing/suit/armor/det_suit(src)
-		new /obj/item/ammo_storage/speedloader/c38(src)
-		new /obj/item/ammo_storage/box/c38(src)
-		new /obj/item/ammo_storage/box/c38(src)
-		new /obj/item/weapon/gun/projectile/detective(src)
-		new /obj/item/clothing/accessory/holster/handgun/wornout(src)
-		new /obj/item/device/gps/secure(src)
-		new /obj/item/binoculars(src)
-		new /obj/item/weapon/storage/box/surveillance(src)
-		new /obj/item/device/handtv(src)
-		return
+/obj/structure/closet/secure_closet/detective/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/under/det,
+		/obj/item/clothing/suit/storage/det_suit,
+		/obj/item/clothing/suit/storage/forensics/blue,
+		/obj/item/clothing/suit/storage/forensics/red,
+		/obj/item/clothing/gloves/black,
+		/obj/item/clothing/head/det_hat,
+		/obj/item/clothing/shoes/brown,
+		/obj/item/weapon/storage/box/evidence,
+		/obj/item/device/radio/headset/headset_sec,
+		/obj/item/device/detective_scanner,
+		/obj/item/clothing/suit/armor/det_suit,
+		/obj/item/ammo_storage/speedloader/c38,
+		/obj/item/ammo_storage/box/c38,
+		/obj/item/ammo_storage/box/c38,
+		/obj/item/weapon/gun/projectile/detective,
+		/obj/item/clothing/accessory/holster/handgun/wornout,
+		/obj/item/device/gps/secure,
+		/obj/item/binoculars,
+		/obj/item/weapon/storage/box/surveillance,
+		/obj/item/device/handtv,
+	)
 
 /obj/structure/closet/secure_closet/detective/update_icon()
 	if(broken)
@@ -303,14 +288,10 @@
 	name = "Lethal Injections"
 	req_access = list(access_captain)
 
-
-	New()
-		..()
-		sleep(2)
-		new /obj/item/weapon/reagent_containers/syringe/giant/chloral(src)
-		new /obj/item/weapon/reagent_containers/syringe/giant/chloral(src)
-		return
-
+/obj/structure/closet/secure_closet/injection/atoms_to_spawn()
+	return list(
+		/obj/item/weapon/reagent_containers/syringe/giant/chloral = 2,
+	)
 
 
 /obj/structure/closet/secure_closet/brig
@@ -319,10 +300,14 @@
 	anchored = 1
 	var/id_tag = null
 
+/obj/structure/closet/secure_closet/brig/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/under/color/prisoner,
+		/obj/item/clothing/shoes/orange,
+	)
+
 /obj/structure/closet/secure_closet/brig/New()
 	..()
-	new /obj/item/clothing/under/color/prisoner(src)
-	new /obj/item/clothing/shoes/orange(src)
 	brig_lockers.Add(src)
 
 /obj/structure/closet/secure_closet/brig/Destroy()
@@ -335,18 +320,16 @@
 	name = "Courtroom Locker"
 	req_access = list(access_court)
 
-	New()
-		..()
-		sleep(2)
-		new /obj/item/clothing/shoes/brown(src)
-		new /obj/item/weapon/paper/Court(src)
-		new /obj/item/weapon/paper/Court(src)
-		new /obj/item/weapon/paper/Court(src)
-		new /obj/item/weapon/pen (src)
-		new /obj/item/clothing/suit/judgerobe(src)
-		new /obj/item/clothing/head/powdered_wig(src)
-		new /obj/item/weapon/storage/briefcase(src)
-		return
+/obj/structure/closet/secure_closet/courtroom/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/shoes/brown,
+		/obj/item/weapon/paper/Court = 3,
+		/obj/item/weapon/pen,
+		/obj/item/clothing/suit/judgerobe,
+		/obj/item/clothing/head/powdered_wig,
+		/obj/item/weapon/storage/briefcase,
+	)
+
 
 /obj/structure/closet/secure_closet/wall
 	name = "wall locker"

--- a/code/game/objects/structures/crates_lockers/closets/syndicate.dm
+++ b/code/game/objects/structures/crates_lockers/closets/syndicate.dm
@@ -9,112 +9,96 @@
 /obj/structure/closet/syndicate/personal
 	desc = "It's a storage unit for operative gear."
 
-/obj/structure/closet/syndicate/personal/New()
-	..()
-	sleep(2)
-	new /obj/item/weapon/tank/jetpack/oxygen/nukeops(src)
-	new /obj/item/clothing/mask/gas/syndicate(src)
-	new /obj/item/clothing/under/syndicate(src)
-	new /obj/item/clothing/head/helmet/space/rig/syndi(src)
-	new /obj/item/clothing/suit/space/rig/syndi(src)
-	new /obj/item/weapon/crowbar/red(src)
-	new /obj/item/weapon/cell/high(src)
-	new /obj/item/device/pda/syndicate/door(src)
-	new /obj/item/device/multitool(src)
-	new /obj/item/weapon/pinpointer/nukeop(src)
-	new /obj/item/weapon/shield/energy(src)
-	new /obj/item/clothing/shoes/magboots/syndie(src)
-
+/obj/structure/closet/syndicate/personal/atoms_to_spawn()
+	return list(
+		/obj/item/weapon/tank/jetpack/oxygen/nukeops,
+		/obj/item/clothing/mask/gas/syndicate,
+		/obj/item/clothing/under/syndicate,
+		/obj/item/clothing/head/helmet/space/rig/syndi,
+		/obj/item/clothing/suit/space/rig/syndi,
+		/obj/item/weapon/crowbar/red,
+		/obj/item/weapon/cell/high,
+		/obj/item/device/pda/syndicate/door,
+		/obj/item/device/multitool,
+		/obj/item/weapon/pinpointer/nukeop,
+		/obj/item/weapon/shield/energy,
+		/obj/item/clothing/shoes/magboots/syndie,
+	)
 
 /obj/structure/closet/syndicate/nuclear
 	desc = "It's a storage unit for nuclear-operative gear."
 
-/obj/structure/closet/syndicate/nuclear/New()
-	..()
-	sleep(2)
-	new /obj/item/ammo_storage/magazine/a12mm/ops(src)
-	new /obj/item/ammo_storage/magazine/a12mm/ops(src)
-	new /obj/item/ammo_storage/magazine/a12mm/ops(src)
-	new /obj/item/ammo_storage/magazine/a12mm/ops(src)
-	new /obj/item/ammo_storage/magazine/a12mm/ops(src)
-	new /obj/item/weapon/storage/box/handcuffs(src)
-	new /obj/item/weapon/storage/box/flashbangs(src)
-	new /obj/item/weapon/storage/box/emps(src)
-	new /obj/item/weapon/gun/energy/gun(src)
-	new /obj/item/weapon/gun/energy/gun(src)
-	new /obj/item/weapon/gun/energy/gun(src)
-	new /obj/item/weapon/gun/energy/gun(src)
-	new /obj/item/weapon/gun/energy/gun(src)
-	new /obj/item/device/pda/syndicate(src)
-	var/obj/item/device/radio/uplink/U = new(src)
-	U.hidden_uplink.uses = 80
-	return
+/obj/structure/closet/syndicate/nuclear/atoms_to_spawn()
+	return list(
+		/obj/item/ammo_storage/magazine/a12mm/ops = 5,
+		/obj/item/weapon/storage/box/handcuffs,
+		/obj/item/weapon/storage/box/flashbangs,
+		/obj/item/weapon/storage/box/emps,
+		/obj/item/weapon/gun/energy/gun = 5,
+		/obj/item/device/pda/syndicate,
+		/obj/item/device/radio/uplink/nukeops,
+	)
 
-/obj/structure/closet/syndicate/resources/
+/obj/structure/closet/syndicate/resources
 	desc = "An old, dusty locker."
 
-	New()
-		..()
-		var/common_min = 30 //Minimum amount of minerals in the stack for common minerals
-		var/common_max = 50 //Maximum amount of HONK in the stack for HONK common minerals
-		var/rare_min = 5  //Minimum HONK of HONK in the stack HONK HONK rare minerals
-		var/rare_max = 20 //Maximum HONK HONK HONK in the HONK for HONK rare HONK
+/obj/structure/closet/syndicate/resources/spawn_contents()
+	..()
+	var/common_min = 30 //Minimum amount of minerals in the stack for common minerals
+	var/common_max = 50 //Maximum amount of HONK in the stack for HONK common minerals
+	var/rare_min = 5  //Minimum HONK of HONK in the stack HONK HONK rare minerals
+	var/rare_max = 20 //Maximum HONK HONK HONK in the HONK for HONK rare HONK
 
+	var/pickednum = rand(1, 50)
 
-		sleep(2)
+	//Sad trombone
+	if(pickednum == 1)
+		var/obj/item/weapon/paper/P = new /obj/item/weapon/paper(src)
+		P.name = "IOU"
+		P.info = "Sorry man, we needed the money so we sold your stash. It's ok, we'll double our money for sure this time!"
 
-		var/pickednum = rand(1, 50)
+	//Metal (common ore)
+	if(pickednum >= 2)
+		var/obj/item/stack/sheet/metal/M = getFromPool(/obj/item/stack/sheet/metal, get_turf(src))
+		M.amount = rand(common_min, common_max)
 
-		//Sad trombone
-		if(pickednum == 1)
-			var/obj/item/weapon/paper/P = new /obj/item/weapon/paper(src)
-			P.name = "IOU"
-			P.info = "Sorry man, we needed the money so we sold your stash. It's ok, we'll double our money for sure this time!"
+	//Glass (common ore)
+	if(pickednum >= 5)
+		new /obj/item/stack/sheet/glass/glass(src, rand(common_min, common_max))
 
-		//Metal (common ore)
-		if(pickednum >= 2)
-			var/obj/item/stack/sheet/metal/M = getFromPool(/obj/item/stack/sheet/metal, get_turf(src))
-			M.amount = rand(common_min, common_max)
+	//Plasteel (common ore) Because it has a million more uses then plasma
+	if(pickednum >= 10)
+		new /obj/item/stack/sheet/plasteel(src, rand(common_min, common_max))
 
-		//Glass (common ore)
-		if(pickednum >= 5)
-			new /obj/item/stack/sheet/glass/glass(src, rand(common_min, common_max))
+	//Plasma (rare ore)
+	if(pickednum >= 15)
+		new /obj/item/stack/sheet/mineral/plasma(src, rand(rare_min, rare_max))
 
-		//Plasteel (common ore) Because it has a million more uses then plasma
-		if(pickednum >= 10)
-			new /obj/item/stack/sheet/plasteel(src, rand(common_min, common_max))
+	//Silver (rare ore)
+	if(pickednum >= 20)
+		new /obj/item/stack/sheet/mineral/silver(src, rand(rare_min, rare_max))
 
-		//Plasma (rare ore)
-		if(pickednum >= 15)
-			new /obj/item/stack/sheet/mineral/plasma(src, rand(rare_min, rare_max))
+	//Gold (rare ore)
+	if(pickednum >= 30)
+		new /obj/item/stack/sheet/mineral/gold(src, rand(rare_min, rare_max))
 
-		//Silver (rare ore)
-		if(pickednum >= 20)
-			new /obj/item/stack/sheet/mineral/silver(src, rand(rare_min, rare_max))
+	//Uranium (rare ore)
+	if(pickednum >= 40)
+		new /obj/item/stack/sheet/mineral/uranium(src, rand(rare_min, rare_max))
 
-		//Gold (rare ore)
-		if(pickednum >= 30)
-			new /obj/item/stack/sheet/mineral/gold(src, rand(rare_min, rare_max))
+	//Diamond (rare HONK)
+	if(pickednum >= 45)
+		new /obj/item/stack/sheet/mineral/diamond(src, rand(rare_min, rare_max))
 
-		//Uranium (rare ore)
-		if(pickednum >= 40)
-			new /obj/item/stack/sheet/mineral/uranium(src, rand(rare_min, rare_max))
-
-		//Diamond (rare HONK)
-		if(pickednum >= 45)
-			new /obj/item/stack/sheet/mineral/diamond(src, rand(rare_min, rare_max))
-
-		//Jetpack (You hit the jackpot!)
-		if(pickednum == 50)
-			new /obj/item/weapon/tank/jetpack/carbondioxide(src)
-
-		return
+	//Jetpack (You hit the jackpot!)
+	if(pickednum == 50)
+		new /obj/item/weapon/tank/jetpack/carbondioxide(src)
 
 /obj/structure/closet/syndicate/resources/everything
 	desc = "It's an emergency storage closet for repairs."
 
-	New()
-		var/list/resources = list(
+/obj/structure/closet/syndicate/resources/everything/spawn_contents()
+	var/list/resources = list(
 		/obj/item/stack/sheet/metal,
 		/obj/item/stack/sheet/glass/glass,
 		/obj/item/stack/sheet/mineral/gold,
@@ -124,17 +108,13 @@
 		/obj/item/stack/sheet/mineral/diamond,
 		/obj/item/stack/sheet/mineral/clown,
 		/obj/item/stack/sheet/plasteel,
-		/obj/item/stack/rods
-		)
+		/obj/item/stack/rods,
+	)
 
-		sleep(2)
-
-		for(var/i = 0, i<2, i++)
-			for(var/res in resources)
-				var/obj/item/stack/R = new res(src)
-				R.amount = R.max_amount
-
-		return
+	for(var/i = 0, i<2, i++)
+		for(var/res in resources)
+			var/obj/item/stack/R = new res(src)
+			R.amount = R.max_amount
 
 /obj/structure/closet/vox_raiders
 	name = "vox armory closet"
@@ -143,14 +123,15 @@
 	icon_closed = "syndicate"
 	icon_opened = "syndicateopen"
 
-	New()
-		sleep(2)
-		new /obj/item/clothing/head/helmet/space/vox/pressure(src)
-		new /obj/item/clothing/mask/breath/vox(src)
-		new /obj/item/clothing/shoes/magboots/vox(src)
-		new /obj/item/clothing/suit/space/vox/pressure(src)
-		new /obj/item/clothing/under/vox/vox_casual(src)
-		new /obj/item/weapon/tank/jetpack/nitrogen(src)
+/obj/structure/closet/vox_raiders/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/head/helmet/space/vox/pressure,
+		/obj/item/clothing/mask/breath/vox,
+		/obj/item/clothing/shoes/magboots/vox,
+		/obj/item/clothing/suit/space/vox/pressure,
+		/obj/item/clothing/under/vox/vox_casual,
+		/obj/item/weapon/tank/jetpack/nitrogen,
+	)
 
 
 /obj/structure/closet/vox_raiders/trader
@@ -160,10 +141,11 @@
 	icon_closed = "syndicate"
 	icon_opened = "syndicateopen"
 
-	New()
-		sleep(2)
-		new /obj/abstract/map/spawner/space/vox/trader/spacesuit(src)
-		new /obj/item/clothing/mask/breath/vox(src)
-		new /obj/item/clothing/shoes/magboots/vox(src)
-		new /obj/item/clothing/under/vox/vox_casual(src)
-		new /obj/item/weapon/tank/jetpack/nitrogen(src)
+/obj/structure/closet/vox_raiders/trader/atoms_to_spawn()
+	return list(
+		/obj/abstract/map/spawner/space/vox/trader/spacesuit,
+		/obj/item/clothing/mask/breath/vox,
+		/obj/item/clothing/shoes/magboots/vox,
+		/obj/item/clothing/under/vox/vox_casual,
+		/obj/item/weapon/tank/jetpack/nitrogen,
+	)

--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -19,41 +19,44 @@
 	icon_closed = "emergency"
 	icon_opened = "emergencyopen"
 
-/obj/structure/closet/emcloset/New()
+/obj/structure/closet/emcloset/spawn_contents()
 	..()
-	switch (pickweight(list("small" = 55, "aid" = 25, "tank" = 10, "both" = 10, "nothing" = 0, "delete" = 0)))
-		if ("small")
-			new /obj/item/weapon/tank/emergency_oxygen(src)
-			new /obj/item/weapon/tank/emergency_oxygen(src)
-			new /obj/item/clothing/mask/breath(src)
-			new /obj/item/clothing/mask/breath(src)
-			new /obj/item/weapon/storage/toolbox/emergency(src)
-		if ("aid")
-			new /obj/item/weapon/tank/emergency_oxygen(src)
-			new /obj/item/weapon/storage/toolbox/emergency(src)
-			new /obj/item/clothing/mask/breath(src)
-			new /obj/item/weapon/storage/firstaid/o2(src)
-		if ("tank")
-			new /obj/item/weapon/tank/emergency_oxygen/engi(src)
-			new /obj/item/clothing/mask/breath(src)
-			new /obj/item/weapon/tank/emergency_oxygen/engi(src)
-			new /obj/item/clothing/mask/breath(src)
-			new /obj/item/weapon/storage/toolbox/emergency(src)
-		if ("both")
-			new /obj/item/weapon/storage/toolbox/emergency(src)
-			new /obj/item/weapon/tank/emergency_oxygen/engi(src)
-			new /obj/item/clothing/mask/breath(src)
-			new /obj/item/weapon/storage/firstaid/o2(src)
-		if ("nothing")
-			return
-		if ("delete")
-			qdel(src)
-			return
+	var/list/small = list(
+		/obj/item/weapon/tank/emergency_oxygen = 2,
+		/obj/item/clothing/mask/breath = 2,
+		/obj/item/weapon/storage/toolbox/emergency,
+	)
+	var/list/aid = list(
+		/obj/item/weapon/tank/emergency_oxygen,
+		/obj/item/weapon/storage/toolbox/emergency,
+		/obj/item/clothing/mask/breath,
+		/obj/item/weapon/storage/firstaid/o2,
+	)
+	var/list/tank = list(
+		/obj/item/weapon/tank/emergency_oxygen/engi,
+		/obj/item/clothing/mask/breath,
+		/obj/item/weapon/tank/emergency_oxygen/engi,
+		/obj/item/clothing/mask/breath,
+		/obj/item/weapon/storage/firstaid/o2,
+	)
+	var/list/both = list(
+		/obj/item/weapon/storage/toolbox/emergency,
+		/obj/item/weapon/tank/emergency_oxygen/engi,
+		/obj/item/clothing/mask/breath,
+		/obj/item/weapon/storage/firstaid/o2,
+	)
+	var/list/choices = list()
+	choices[small] = 55
+	choices[aid] = 25
+	choices[tank] = 10
+	choices[both] = 10
+	return pickweight(choices)
 
-/obj/structure/closet/emcloset/legacy/New()
-	..()
-	new /obj/item/weapon/tank/oxygen(src)
-	new /obj/item/clothing/mask/gas(src)
+/obj/structure/closet/emcloset/legacy/atoms_to_spawn()
+	return list(
+		/obj/item/weapon/tank/oxygen,
+		/obj/item/clothing/mask/gas,
+	)
 
 
 /obj/structure/closet/emcloset/vox
@@ -63,12 +66,11 @@
 	icon_closed = "emergencyvox"
 	icon_opened = "emergencyvoxopen"
 
-/obj/structure/closet/emcloset/vox/New()
-	AddToProfiler()
-	new /obj/item/weapon/tank/nitrogen(src)
-	new /obj/item/weapon/tank/nitrogen(src)
-	new /obj/item/clothing/mask/breath/vox(src)
-	new /obj/item/clothing/mask/breath/vox(src)
+/obj/structure/closet/emcloset/vox/atoms_to_spawn()
+	return list(
+		/obj/item/weapon/tank/nitrogen = 2,
+		/obj/item/clothing/mask/breath/vox = 2,
+	)
 
 /*
  * Fire Closet
@@ -80,18 +82,17 @@
 	icon_closed = "firecloset"
 	icon_opened = "fireclosetopen"
 
-/obj/structure/closet/firecloset/New()
-	..()
+/obj/structure/closet/firecloset/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/suit/fire/firefighter,
+		/obj/item/clothing/mask/gas,
+		/obj/item/weapon/tank/oxygen/red,
+		/obj/item/weapon/extinguisher,
+		/obj/item/clothing/head/hardhat/red,
+	)
 
-	new /obj/item/clothing/suit/fire/firefighter(src)
-	new /obj/item/clothing/mask/gas(src)
-	new /obj/item/weapon/tank/oxygen/red(src)
-	new /obj/item/weapon/extinguisher(src)
-	new /obj/item/clothing/head/hardhat/red(src)
-
-/obj/structure/closet/firecloset/full/New()
-	..()
-	new /obj/item/device/flashlight(src)
+/obj/structure/closet/firecloset/full/atoms_to_spawn()
+	return ..() + /obj/item/device/flashlight
 
 /obj/structure/closet/firecloset/update_icon()
 	if(!opened)
@@ -110,38 +111,38 @@
 	icon_closed = "toolcloset"
 	icon_opened = "toolclosetopen"
 
-/obj/structure/closet/toolcloset/New()
-	. = ..()
+/obj/structure/closet/toolcloset/atoms_to_spawn()
+	. = list()
 	if(prob(40))
-		new /obj/item/clothing/suit/storage/hazardvest(src)
+		. += /obj/item/clothing/suit/storage/hazardvest
 	if(prob(70))
-		new /obj/item/device/flashlight(src)
+		. += /obj/item/device/flashlight
 	if(prob(70))
-		new /obj/item/weapon/screwdriver(src)
+		. += /obj/item/weapon/screwdriver
 	if(prob(70))
-		new /obj/item/weapon/wrench(src)
+		. += /obj/item/weapon/wrench
 	if(prob(70))
-		new /obj/item/weapon/weldingtool(src)
+		. += /obj/item/weapon/weldingtool
 	if(prob(70))
-		new /obj/item/weapon/crowbar(src)
+		. += /obj/item/weapon/crowbar
 	if(prob(70))
-		new /obj/item/weapon/wirecutters(src)
+		. += /obj/item/weapon/wirecutters
 	if(prob(70))
-		new /obj/item/device/t_scanner(src)
+		. += /obj/item/device/t_scanner
 	if(prob(20))
-		new /obj/item/weapon/storage/belt/utility(src)
+		. += /obj/item/weapon/storage/belt/utility
 	if(prob(30))
-		new /obj/item/stack/cable_coil/random(src)
+		. += /obj/item/stack/cable_coil/random
 	if(prob(30))
-		new /obj/item/stack/cable_coil/random(src)
+		. += /obj/item/stack/cable_coil/random
 	if(prob(30))
-		new /obj/item/stack/cable_coil/random(src)
+		. += /obj/item/stack/cable_coil/random
 	if(prob(20))
-		new /obj/item/device/multitool(src)
+		. += /obj/item/device/multitool
 	if(prob(5))
-		new /obj/item/clothing/gloves/yellow(src)
+		. += /obj/item/clothing/gloves/yellow
 	if(prob(40))
-		new /obj/item/clothing/head/hardhat(src)
+		. += /obj/item/clothing/head/hardhat
 
 
 /*
@@ -154,11 +155,11 @@
 	icon_opened = "toolclosetopen"
 	icon_closed = "radsuitcloset"
 
-/obj/structure/closet/radiation/New()
-	..()
-	new /obj/item/clothing/suit/radiation(src)
-	new /obj/item/clothing/head/radiation(src)
-	new /obj/item/device/geiger_counter(src)
+/obj/structure/closet/radiation/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/suit/radiation = 2,
+		/obj/item/device/geiger_counter,
+	)
 
 /*
  * Bombsuit closet
@@ -170,12 +171,13 @@
 	icon_closed = "bombsuit"
 	icon_opened = "bombsuitopen"
 
-/obj/structure/closet/bombcloset/New()
-	..()
-	new /obj/item/clothing/suit/bomb_suit( src )
-	new /obj/item/clothing/under/color/black( src )
-	new /obj/item/clothing/shoes/black( src )
-	new /obj/item/clothing/head/bomb_hood( src )
+/obj/structure/closet/bombcloset/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/suit/bomb_suit,
+		/obj/item/clothing/under/color/black,
+		/obj/item/clothing/shoes/black,
+		/obj/item/clothing/head/bomb_hood,
+	)
 
 
 /obj/structure/closet/bombclosetsecurity
@@ -185,12 +187,13 @@
 	icon_closed = "bombsuitsec"
 	icon_opened = "bombsuitsecopen"
 
-/obj/structure/closet/bombclosetsecurity/New()
-	..()
-	new /obj/item/clothing/suit/bomb_suit/security( src )
-	new /obj/item/clothing/under/rank/security( src )
-	new /obj/item/clothing/shoes/brown( src )
-	new /obj/item/clothing/head/bomb_hood/security( src )
+/obj/structure/closet/bombclosetsecurity/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/suit/bomb_suit/security,
+		/obj/item/clothing/under/rank/security,
+		/obj/item/clothing/shoes/brown,
+		/obj/item/clothing/head/bomb_hood/security,
+	)
 
 /*
  * Hydrant
@@ -206,14 +209,14 @@
 	wall_mounted = 1
 	pick_up_stuff = 0 // #367 - Picks up stuff at src.loc, rather than the offset location.
 
-/obj/structure/closet/hydrant/New()
-	..()
-
-	new /obj/item/clothing/suit/fire/firefighter(src)
-	new /obj/item/clothing/mask/gas(src)
-	new /obj/item/weapon/tank/oxygen/red(src)
-	new /obj/item/weapon/extinguisher(src)
-	new /obj/item/clothing/head/hardhat/red(src)
+/obj/structure/closet/hydrant/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/suit/fire/firefighter,
+		/obj/item/clothing/mask/gas,
+		/obj/item/weapon/tank/oxygen/red,
+		/obj/item/weapon/extinguisher,
+		/obj/item/clothing/head/hardhat/red,
+	)
 
 /*
  * First Aid

--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -19,27 +19,26 @@
 	icon_closed = "emergency"
 	icon_opened = "emergencyopen"
 
-/obj/structure/closet/emcloset/spawn_contents()
-	..()
-	var/list/small = list(
+/obj/structure/closet/emcloset/atoms_to_spawn()
+	var/static/list/small = list(
 		/obj/item/weapon/tank/emergency_oxygen = 2,
 		/obj/item/clothing/mask/breath = 2,
 		/obj/item/weapon/storage/toolbox/emergency,
 	)
-	var/list/aid = list(
+	var/static/list/aid = list(
 		/obj/item/weapon/tank/emergency_oxygen,
 		/obj/item/weapon/storage/toolbox/emergency,
 		/obj/item/clothing/mask/breath,
 		/obj/item/weapon/storage/firstaid/o2,
 	)
-	var/list/tank = list(
+	var/static/list/tank = list(
 		/obj/item/weapon/tank/emergency_oxygen/engi,
 		/obj/item/clothing/mask/breath,
 		/obj/item/weapon/tank/emergency_oxygen/engi,
 		/obj/item/clothing/mask/breath,
 		/obj/item/weapon/storage/firstaid/o2,
 	)
-	var/list/both = list(
+	var/static/list/both = list(
 		/obj/item/weapon/storage/toolbox/emergency,
 		/obj/item/weapon/tank/emergency_oxygen/engi,
 		/obj/item/clothing/mask/breath,

--- a/code/game/objects/structures/crates_lockers/closets/wardrobe.dm
+++ b/code/game/objects/structures/crates_lockers/closets/wardrobe.dm
@@ -4,75 +4,49 @@
 	icon_state = "blue"
 	icon_closed = "blue"
 
-/obj/structure/closet/wardrobe/New()
-	. = ..()
-	new /obj/item/clothing/under/color/blue(src)
-	new /obj/item/clothing/under/color/blue(src)
-	new /obj/item/clothing/under/color/blue(src)
-	new /obj/item/clothing/shoes/brown(src)
-	new /obj/item/clothing/shoes/brown(src)
-	new /obj/item/clothing/shoes/brown(src)
+/obj/structure/closet/wardrobe/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/under/color/blue = 3,
+		/obj/item/clothing/shoes/brown = 3,
+	)
 
 /obj/structure/closet/wardrobe/red
 	name = "security wardrobe"
 	icon_state = "red"
 	icon_closed = "red"
 
-/obj/structure/closet/wardrobe/red/New()
-	new /obj/item/clothing/under/rank/security(src)
-	new /obj/item/clothing/under/rank/security(src)
-	new /obj/item/clothing/under/rank/security(src)
-	new /obj/item/clothing/under/rank/security2(src)
-	new /obj/item/clothing/under/rank/security2(src)
-	new /obj/item/clothing/under/rank/security2(src)
-	new /obj/item/clothing/shoes/jackboots(src)
-	new /obj/item/clothing/shoes/jackboots(src)
-	new /obj/item/clothing/shoes/jackboots(src)
-	new /obj/item/clothing/head/soft/sec(src)
-	new /obj/item/clothing/head/soft/sec(src)
-	new /obj/item/clothing/head/soft/sec(src)
-	new /obj/item/clothing/head/beret/sec(src)
-	new /obj/item/clothing/head/beret/sec(src)
-	new /obj/item/clothing/head/beret/sec(src)
-	new /obj/item/clothing/mask/bandana/red(src)
-	new /obj/item/clothing/mask/bandana/red(src)
-	new /obj/item/clothing/mask/bandana/red(src)
-	AddToProfiler()
-	return
-
+/obj/structure/closet/wardrobe/red/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/under/rank/security = 3,
+		/obj/item/clothing/under/rank/security2 = 3,
+		/obj/item/clothing/shoes/jackboots = 3,
+		/obj/item/clothing/head/soft/sec = 3,
+		/obj/item/clothing/head/beret/sec = 3,
+		/obj/item/clothing/mask/bandana/red = 3,
+	)
 
 /obj/structure/closet/wardrobe/pink
 	name = "pink wardrobe"
 	icon_state = "pink"
 	icon_closed = "pink"
 
-/obj/structure/closet/wardrobe/pink/New()
-	new /obj/item/clothing/under/color/pink(src)
-	new /obj/item/clothing/under/color/pink(src)
-	new /obj/item/clothing/under/color/pink(src)
-	new /obj/item/clothing/shoes/brown(src)
-	new /obj/item/clothing/shoes/brown(src)
-	new /obj/item/clothing/shoes/brown(src)
-	AddToProfiler()
-	return
+/obj/structure/closet/wardrobe/pink/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/under/color/pink = 3,
+		/obj/item/clothing/shoes/brown = 3,
+	)
 
 /obj/structure/closet/wardrobe/black
 	name = "black wardrobe"
 	icon_state = "black"
 	icon_closed = "black"
 
-/obj/structure/closet/wardrobe/black/New()
-	new /obj/item/clothing/under/color/black(src)
-	new /obj/item/clothing/under/color/black(src)
-	new /obj/item/clothing/under/color/black(src)
-	new /obj/item/clothing/shoes/black(src)
-	new /obj/item/clothing/shoes/black(src)
-	new /obj/item/clothing/shoes/black(src)
-	new /obj/item/clothing/head/that(src)
-	new /obj/item/clothing/head/that(src)
-	new /obj/item/clothing/head/that(src)
-	AddToProfiler()
-	return
+/obj/structure/closet/wardrobe/black/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/under/color/black = 3,
+		/obj/item/clothing/shoes/black = 3,
+		/obj/item/clothing/head/that = 3,
+	)
 
 
 /obj/structure/closet/wardrobe/chaplain_black
@@ -81,20 +55,19 @@
 	icon_state = "black"
 	icon_closed = "black"
 
-/obj/structure/closet/wardrobe/chaplain_black/New()
-	new /obj/item/clothing/under/rank/chaplain(src)
-	new /obj/item/clothing/shoes/black(src)
-	new /obj/item/clothing/suit/nun(src)
-	new /obj/item/clothing/head/nun_hood(src)
-	new /obj/item/clothing/suit/chaplain_hoodie(src)
-	new /obj/item/clothing/head/chaplain_hood(src)
-	new /obj/item/clothing/suit/holidaypriest(src)
-	new /obj/item/clothing/under/wedding/bride_white(src)
-	new /obj/item/weapon/storage/backpack/cultpack (src)
-	new /obj/item/weapon/storage/fancy/candle_box(src)
-	new /obj/item/weapon/storage/fancy/candle_box(src)
-	AddToProfiler()
-	return
+/obj/structure/closet/wardrobe/chaplain_black/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/under/rank/chaplain,
+		/obj/item/clothing/shoes/black,
+		/obj/item/clothing/suit/nun,
+		/obj/item/clothing/head/nun_hood,
+		/obj/item/clothing/suit/chaplain_hoodie,
+		/obj/item/clothing/head/chaplain_hood,
+		/obj/item/clothing/suit/holidaypriest,
+		/obj/item/clothing/under/wedding/bride_white,
+		/obj/item/weapon/storage/backpack/cultpack,
+		/obj/item/weapon/storage/fancy/candle_box = 2,
+	)
 
 
 /obj/structure/closet/wardrobe/green
@@ -102,29 +75,23 @@
 	icon_state = "green"
 	icon_closed = "green"
 
-/obj/structure/closet/wardrobe/green/New()
-	new /obj/item/clothing/under/color/green(src)
-	new /obj/item/clothing/under/color/green(src)
-	new /obj/item/clothing/under/color/green(src)
-	new /obj/item/clothing/shoes/black(src)
-	new /obj/item/clothing/shoes/black(src)
-	new /obj/item/clothing/shoes/black(src)
-	AddToProfiler()
-	return
+/obj/structure/closet/wardrobe/green/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/under/color/green = 3,
+		/obj/item/clothing/shoes/black = 3,
+	)
 
 /obj/structure/closet/wardrobe/xenos
 	name = "xenos wardrobe"
 	icon_state = "green"
 	icon_closed = "green"
 
-/obj/structure/closet/wardrobe/xenos/New()
-	new /obj/item/clothing/suit/unathi/mantle(src)
-	new /obj/item/clothing/suit/unathi/robe(src)
-	new /obj/item/clothing/shoes/sandal(src)
-	new /obj/item/clothing/shoes/sandal(src)
-	new /obj/item/clothing/shoes/sandal(src)
-	AddToProfiler()
-	return
+/obj/structure/closet/wardrobe/xenos/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/suit/unathi/mantle,
+		/obj/item/clothing/suit/unathi/robe,
+		/obj/item/clothing/shoes/sandal = 3,
+	)
 
 
 /obj/structure/closet/wardrobe/orange
@@ -133,18 +100,13 @@
 	icon_state = "orange"
 	icon_closed = "orange"
 
-/obj/structure/closet/wardrobe/orange/New()
-	new /obj/item/clothing/under/color/prisoner(src)
-	new /obj/item/clothing/under/color/prisoner(src)
-	new /obj/item/clothing/under/color/prisoner(src)
-	new /obj/item/clothing/shoes/orange(src)
-	new /obj/item/clothing/shoes/orange(src)
-	new /obj/item/clothing/shoes/orange(src)
-	new /obj/item/clothing/shoes/orange(src)
-	new /obj/item/clothing/suit/space/plasmaman/prisoner(src)
-	new /obj/item/clothing/head/helmet/space/plasmaman/prisoner(src)
-	AddToProfiler()
-	return
+/obj/structure/closet/wardrobe/orange/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/under/color/prisoner = 3,
+		/obj/item/clothing/shoes/orange = 4,
+		/obj/item/clothing/suit/space/plasmaman/prisoner,
+		/obj/item/clothing/head/helmet/space/plasmaman/prisoner,
+	)
 
 
 /obj/structure/closet/wardrobe/yellow
@@ -152,32 +114,22 @@
 	icon_state = "yellow"
 	icon_closed = "yellow"
 
-/obj/structure/closet/wardrobe/yellow/New()
-	new /obj/item/clothing/under/color/yellow(src)
-	new /obj/item/clothing/under/color/yellow(src)
-	new /obj/item/clothing/under/color/yellow(src)
-	new /obj/item/clothing/shoes/orange(src)
-	new /obj/item/clothing/shoes/orange(src)
-	new /obj/item/clothing/shoes/orange(src)
-	AddToProfiler()
-	return
-
+/obj/structure/closet/wardrobe/yellow/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/under/color/yellow = 3,
+		/obj/item/clothing/shoes/orange = 3,
+	)
 
 /obj/structure/closet/wardrobe/atmospherics_yellow
 	name = "atmospherics wardrobe"
 	icon_state = "yellow"
 	icon_closed = "yellow"
 
-/obj/structure/closet/wardrobe/atmospherics_yellow/New()
-	new /obj/item/clothing/under/rank/atmospheric_technician(src)
-	new /obj/item/clothing/under/rank/atmospheric_technician(src)
-	new /obj/item/clothing/under/rank/atmospheric_technician(src)
-	new /obj/item/clothing/shoes/workboots(src)
-	new /obj/item/clothing/shoes/workboots(src)
-	new /obj/item/clothing/shoes/workboots(src)
-	AddToProfiler()
-	return
-
+/obj/structure/closet/wardrobe/atmospherics_yellow/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/under/rank/atmospheric_technician = 3,
+		/obj/item/clothing/shoes/workboots = 3,
+	)
 
 
 /obj/structure/closet/wardrobe/engineering_yellow
@@ -185,20 +137,14 @@
 	icon_state = "yellow"
 	icon_closed = "yellow"
 
-/obj/structure/closet/wardrobe/engineering_yellow/New()
-	new /obj/item/clothing/under/rank/engineer(src)
-	new /obj/item/clothing/under/rank/engineer(src)
-	new /obj/item/clothing/under/rank/engine_tech(src)
-	new /obj/item/clothing/under/rank/engine_tech(src)
-	new /obj/item/clothing/under/rank/maintenance_tech(src)
-	new /obj/item/clothing/under/rank/maintenance_tech(src)
-	new /obj/item/clothing/under/rank/electrician(src)
-	new /obj/item/clothing/under/rank/electrician(src)
-	new /obj/item/clothing/shoes/workboots(src)
-	new /obj/item/clothing/shoes/workboots(src)
-	new /obj/item/clothing/shoes/workboots(src)
-	AddToProfiler()
-	return
+/obj/structure/closet/wardrobe/engineering_yellow/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/under/rank/engineer = 2,
+		/obj/item/clothing/under/rank/engine_tech = 2,
+		/obj/item/clothing/under/rank/maintenance_tech = 2,
+		/obj/item/clothing/under/rank/electrician = 2,
+		/obj/item/clothing/shoes/workboots = 3,
+	)
 
 
 /obj/structure/closet/wardrobe/white
@@ -206,15 +152,11 @@
 	icon_state = "white"
 	icon_closed = "white"
 
-/obj/structure/closet/wardrobe/white/New()
-	new /obj/item/clothing/under/color/white(src)
-	new /obj/item/clothing/under/color/white(src)
-	new /obj/item/clothing/under/color/white(src)
-	new /obj/item/clothing/shoes/white(src)
-	new /obj/item/clothing/shoes/white(src)
-	new /obj/item/clothing/shoes/white(src)
-	AddToProfiler()
-	return
+/obj/structure/closet/wardrobe/white/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/under/color/white = 3,
+		/obj/item/clothing/shoes/white = 3,
+	)
 
 
 /obj/structure/closet/wardrobe/pjs
@@ -222,21 +164,15 @@
 	icon_state = "white"
 	icon_closed = "white"
 
-/obj/structure/closet/wardrobe/pjs/New()
-	new /obj/item/clothing/under/pj/red(src)
-	new /obj/item/clothing/under/pj/red(src)
-	new /obj/item/clothing/under/pj/blue(src)
-	new /obj/item/clothing/under/pj/blue(src)
-	new /obj/item/clothing/shoes/white(src)
-	new /obj/item/clothing/shoes/white(src)
-	new /obj/item/clothing/shoes/slippers(src)
-	new /obj/item/clothing/shoes/slippers(src)
-	new /obj/item/clothing/head/pajamahat/blue(src)
-	new /obj/item/clothing/head/pajamahat/blue(src)
-	new /obj/item/clothing/head/pajamahat/red(src)
-	new /obj/item/clothing/head/pajamahat/red(src)
-	AddToProfiler()
-	return
+/obj/structure/closet/wardrobe/pjs/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/under/pj/red = 2,
+		/obj/item/clothing/under/pj/blue = 2,
+		/obj/item/clothing/shoes/white = 2,
+		/obj/item/clothing/shoes/slippers = 2,
+		/obj/item/clothing/head/pajamahat/blue = 2,
+		/obj/item/clothing/head/pajamahat/red = 2,
+	)
 
 
 /obj/structure/closet/wardrobe/toxins_white
@@ -244,24 +180,17 @@
 	icon_state = "white"
 	icon_closed = "white"
 
-/obj/structure/closet/wardrobe/toxins_white/New()
-	new /obj/item/clothing/under/rank/scientist(src)
-	new /obj/item/clothing/under/rank/scientist(src)
-	new /obj/item/clothing/under/rank/xenoarch(src)
-	new /obj/item/clothing/under/rank/plasmares(src)
-	new /obj/item/clothing/under/rank/xenobio(src)
-	new /obj/item/clothing/under/rank/anomalist(src)
-	new /obj/item/clothing/suit/storage/labcoat(src)
-	new /obj/item/clothing/suit/storage/labcoat(src)
-	new /obj/item/clothing/suit/storage/labcoat(src)
-	new /obj/item/clothing/shoes/white(src)
-	new /obj/item/clothing/shoes/white(src)
-	new /obj/item/clothing/shoes/white(src)
-	new /obj/item/clothing/shoes/slippers
-	new /obj/item/clothing/shoes/slippers
-	new /obj/item/clothing/shoes/slippers
-	AddToProfiler()
-	return
+/obj/structure/closet/wardrobe/toxins_white/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/under/rank/scientist,
+		/obj/item/clothing/under/rank/xenoarch,
+		/obj/item/clothing/under/rank/plasmares,
+		/obj/item/clothing/under/rank/xenobio,
+		/obj/item/clothing/under/rank/anomalist,
+		/obj/item/clothing/suit/storage/labcoat = 3,
+		/obj/item/clothing/shoes/white = 3,
+		/obj/item/clothing/shoes/slippers = 3,
+	)
 
 
 /obj/structure/closet/wardrobe/robotics_black
@@ -269,44 +198,32 @@
 	icon_state = "black"
 	icon_closed = "black"
 
-/obj/structure/closet/wardrobe/robotics_black/New()
-	new /obj/item/clothing/under/rank/roboticist(src)
-	new /obj/item/clothing/under/rank/roboticist(src)
-	new /obj/item/clothing/under/rank/mechatronic(src)
-	new /obj/item/clothing/under/rank/mechatronic(src)
-	new /obj/item/clothing/under/rank/biomechanical(src)
-	new /obj/item/clothing/under/rank/biomechanical(src)
-	new /obj/item/clothing/suit/storage/labcoat(src)
-	new /obj/item/clothing/suit/storage/labcoat(src)
-	new /obj/item/clothing/shoes/black(src)
-	new /obj/item/clothing/shoes/black(src)
-	new /obj/item/clothing/gloves/black(src)
-	new /obj/item/clothing/gloves/black(src)
-	if(prob(50))
-		new /obj/item/clothing/glasses/hud/diagnostic(src)
-	else
-		new /obj/item/clothing/glasses/hud/diagnostic/prescription(src)
-	new /obj/item/clothing/glasses/hud/diagnostic(src)
-	AddToProfiler()
-	return
-
+/obj/structure/closet/wardrobe/robotics_black/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/under/rank/roboticist = 2,
+		/obj/item/clothing/under/rank/mechatronic = 2,
+		/obj/item/clothing/under/rank/biomechanical = 2,
+		/obj/item/clothing/suit/storage/labcoat = 2,
+		/obj/item/clothing/shoes/black = 2,
+		/obj/item/clothing/gloves/black,
+		pick(
+			/obj/item/clothing/glasses/hud/diagnostic,
+			/obj/item/clothing/glasses/hud/diagnostic/prescription),
+		/obj/item/clothing/glasses/hud/diagnostic
+	)
 
 /obj/structure/closet/wardrobe/chemistry_white
 	name = "chemistry wardrobe"
 	icon_state = "white"
 	icon_closed = "white"
 
-/obj/structure/closet/wardrobe/chemistry_white/New()
-	new /obj/item/clothing/under/rank/chemist(src)
-	new /obj/item/clothing/under/rank/chemist(src)
-	new /obj/item/clothing/under/rank/pharma(src)
-	new /obj/item/clothing/under/rank/pharma(src)
-	new /obj/item/clothing/shoes/white(src)
-	new /obj/item/clothing/shoes/white(src)
-	new /obj/item/clothing/suit/storage/labcoat/chemist(src)
-	new /obj/item/clothing/suit/storage/labcoat/chemist(src)
-	AddToProfiler()
-	return
+/obj/structure/closet/wardrobe/chemistry_white/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/under/rank/chemist = 2,
+		/obj/item/clothing/under/rank/pharma = 2,
+		/obj/item/clothing/shoes/white = 2,
+		/obj/item/clothing/suit/storage/labcoat/chemist = 2,
+	)
 
 
 /obj/structure/closet/wardrobe/oncology_white
@@ -314,30 +231,24 @@
 	icon_state = "white"
 	icon_closed = "white"
 
-/obj/structure/closet/wardrobe/oncology_white/New()
-	new /obj/item/clothing/under/rank/medical(src)
-	new /obj/item/clothing/under/rank/medical(src)
-	new /obj/item/clothing/shoes/white(src)
-	new /obj/item/clothing/shoes/white(src)
-	new /obj/item/clothing/suit/storage/labcoat/oncologist(src)
-	new /obj/item/clothing/suit/storage/labcoat/oncologist(src)
-	AddToProfiler()
-	return
+/obj/structure/closet/wardrobe/oncology_white/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/under/rank/medical = 2,
+		/obj/item/clothing/shoes/white = 2,
+		/obj/item/clothing/suit/storage/labcoat/oncologist = 2,
+	)
 
 /obj/structure/closet/wardrobe/genetics_white
 	name = "genetics wardrobe"
 	icon_state = "white"
 	icon_closed = "white"
 
-/obj/structure/closet/wardrobe/genetics_white/New()
-	new /obj/item/clothing/under/rank/geneticist(src)
-	new /obj/item/clothing/under/rank/geneticist(src)
-	new /obj/item/clothing/shoes/white(src)
-	new /obj/item/clothing/shoes/white(src)
-	new /obj/item/clothing/suit/storage/labcoat/genetics(src)
-	new /obj/item/clothing/suit/storage/labcoat/genetics(src)
-	AddToProfiler()
-	return
+/obj/structure/closet/wardrobe/genetics_white/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/under/rank/geneticist = 2,
+		/obj/item/clothing/shoes/white = 2,
+		/obj/item/clothing/suit/storage/labcoat/genetics = 2,
+	)
 
 
 /obj/structure/closet/wardrobe/virology_white
@@ -345,17 +256,13 @@
 	icon_state = "white"
 	icon_closed = "white"
 
-/obj/structure/closet/wardrobe/virology_white/New()
-	new /obj/item/clothing/under/rank/virologist(src)
-	new /obj/item/clothing/under/rank/virologist(src)
-	new /obj/item/clothing/shoes/white(src)
-	new /obj/item/clothing/shoes/white(src)
-	new /obj/item/clothing/suit/storage/labcoat/virologist(src)
-	new /obj/item/clothing/suit/storage/labcoat/virologist(src)
-	new /obj/item/clothing/mask/surgical(src)
-	new /obj/item/clothing/mask/surgical(src)
-	AddToProfiler()
-	return
+/obj/structure/closet/wardrobe/virology_white/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/under/rank/virologist = 2,
+		/obj/item/clothing/shoes/white = 2,
+		/obj/item/clothing/suit/storage/labcoat/virologist = 2,
+		/obj/item/clothing/mask/surgical = 2,
+	)
 
 
 /obj/structure/closet/wardrobe/medic_white
@@ -363,20 +270,16 @@
 	icon_state = "white"
 	icon_closed = "white"
 
-/obj/structure/closet/wardrobe/medic_white/New()
-	new /obj/item/clothing/under/rank/medical(src)
-	new /obj/item/clothing/under/rank/medical(src)
-	new /obj/item/clothing/under/rank/medical/blue(src)
-	new /obj/item/clothing/under/rank/medical/green(src)
-	new /obj/item/clothing/under/rank/medical/purple(src)
-	new /obj/item/clothing/shoes/white(src)
-	new /obj/item/clothing/shoes/white(src)
-	new /obj/item/clothing/suit/storage/labcoat(src)
-	new /obj/item/clothing/suit/storage/labcoat(src)
-	new /obj/item/clothing/mask/surgical(src)
-	new /obj/item/clothing/mask/surgical(src)
-	AddToProfiler()
-	return
+/obj/structure/closet/wardrobe/medic_white/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/under/rank/medical = 2,
+		/obj/item/clothing/under/rank/medical/blue,
+		/obj/item/clothing/under/rank/medical/green,
+		/obj/item/clothing/under/rank/medical/purple,
+		/obj/item/clothing/shoes/white = 2,
+		/obj/item/clothing/suit/storage/labcoat = 2,
+		/obj/item/clothing/mask/surgical = 2,
+	)
 
 
 /obj/structure/closet/wardrobe/grey
@@ -384,18 +287,12 @@
 	icon_state = "grey"
 	icon_closed = "grey"
 
-/obj/structure/closet/wardrobe/grey/New()
-	new /obj/item/clothing/under/color/grey(src)
-	new /obj/item/clothing/under/color/grey(src)
-	new /obj/item/clothing/under/color/grey(src)
-	new /obj/item/clothing/shoes/black(src)
-	new /obj/item/clothing/shoes/black(src)
-	new /obj/item/clothing/shoes/black(src)
-	new /obj/item/clothing/head/soft/grey(src)
-	new /obj/item/clothing/head/soft/grey(src)
-	new /obj/item/clothing/head/soft/grey(src)
-	AddToProfiler()
-	return
+/obj/structure/closet/wardrobe/grey/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/under/color/grey = 3,
+		/obj/item/clothing/shoes/black = 3,
+		/obj/item/clothing/head/soft/grey = 3,
+	)
 
 
 /obj/structure/closet/wardrobe/mixed
@@ -403,21 +300,21 @@
 	icon_state = "mixed"
 	icon_closed = "mixed"
 
-/obj/structure/closet/wardrobe/mixed/New()
-	new /obj/item/clothing/under/color/blue(src)
-	new /obj/item/clothing/under/color/yellow(src)
-	new /obj/item/clothing/under/color/green(src)
-	new /obj/item/clothing/under/color/orange(src)
-	new /obj/item/clothing/under/color/pink(src)
-	new /obj/item/clothing/under/dress/plaid_blue(src)
-	new /obj/item/clothing/under/dress/plaid_red(src)
-	new /obj/item/clothing/under/dress/plaid_purple(src)
-	new /obj/item/clothing/shoes/blue(src)
-	new /obj/item/clothing/shoes/yellow(src)
-	new /obj/item/clothing/shoes/green(src)
-	new /obj/item/clothing/shoes/orange(src)
-	new /obj/item/clothing/shoes/purple(src)
-	new /obj/item/clothing/shoes/leather(src)
-	new /obj/item/clothing/under/casualwear(src)
-	AddToProfiler()
-	return
+/obj/structure/closet/wardrobe/mixed/atoms_to_spawn()
+	return list(
+		/obj/item/clothing/under/color/blue,
+		/obj/item/clothing/under/color/yellow,
+		/obj/item/clothing/under/color/green,
+		/obj/item/clothing/under/color/orange,
+		/obj/item/clothing/under/color/pink,
+		/obj/item/clothing/under/dress/plaid_blue,
+		/obj/item/clothing/under/dress/plaid_red,
+		/obj/item/clothing/under/dress/plaid_purple,
+		/obj/item/clothing/shoes/blue,
+		/obj/item/clothing/shoes/yellow,
+		/obj/item/clothing/shoes/green,
+		/obj/item/clothing/shoes/orange,
+		/obj/item/clothing/shoes/purple,
+		/obj/item/clothing/shoes/leather,
+		/obj/item/clothing/under/casualwear,
+	)

--- a/code/modules/Economy/debit_card.dm
+++ b/code/modules/Economy/debit_card.dm
@@ -129,4 +129,25 @@
 	to_cut = 1.5
 	examine_held = "<span class='notice'>You feel <b>incredibly</b> important just by holding it</span>"
 
+/obj/item/weapon/card/debit/preferred/department/cargo/New(var/new_loc, var/desired_department = "Cargo", var/desired_authorized_name)
+	..()
+
+/obj/item/weapon/card/debit/preferred/department/engineering/New(var/new_loc, var/desired_department = "Engineering", var/desired_authorized_name)
+	..()
+
+/obj/item/weapon/card/debit/preferred/department/medical/New(var/new_loc, var/desired_department = "Medical", var/desired_authorized_name)
+	..()
+
+/obj/item/weapon/card/debit/preferred/department/science/New(var/new_loc, var/desired_department = "Science", var/desired_authorized_name)
+	..()
+
+/obj/item/weapon/card/debit/preferred/department/elite/command/New(var/new_loc, var/desired_department = "Command", var/desired_authorized_name)
+	..()
+
+/obj/item/weapon/card/debit/preferred/department/civilian/New(var/new_loc, var/desired_department = "Civilian", var/desired_authorized_name)
+	..()
+
+/obj/item/weapon/card/debit/preferred/department/security/New(var/new_loc, var/desired_department = "Security", var/desired_authorized_name)
+	..()
+
 #undef DEBIT_MAX_AUTHORIZED_NAME_LENGTH


### PR DESCRIPTION
Fixes #12325 because we don't override `New()` without calling `..()` anymore

fuk u oldcoders

P.S. there are more closet subtypes that need to be given this treatment

:cl:
 * bugfix: Fixed a bug that prevented welding wardrobe lockers to deconstruct them.

