### PR TITLE
Fixed examining invisible walls freezing clients

### DIFF
--- a/code/modules/spells/aoe_turf/conjure/forcewall.dm
+++ b/code/modules/spells/aoe_turf/conjure/forcewall.dm
@@ -53,7 +53,7 @@
 	invisibility = 0
 
 /obj/effect/forcefield/mime
-	icon_state = "empty"
+	icon_state = "fuel"
 	name = "invisible wall"
 	desc = "You have a bad feeling about this."
 	invisibility = 0


### PR DESCRIPTION
Fixes #15280
The icon state "empty" didn't exist, so BYOND was being BYOND and converting the entire DMI to base64 and sending it to the client. I think.

:cl:
* bugfix: Fixed mime walls having no sprite and freezing clients upon examination.