### PR TITLE
Welding down shuttle seats now only gives 2 plasteel back down from 5

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -624,7 +624,7 @@
 				return
 			var/obj/structure/bed/chair/C = new (loc)
 			C.dir = dir
-			drop_stack(/obj/item/stack/sheet/plasteel, loc, 5, user)
+			drop_stack(/obj/item/stack/sheet/plasteel, loc, 2, user)
 			user.visible_message(\
 				"<span class='warning'>\The [src] has been welded apart, leaving \a [C] behind.</span>",\
 				"You finish removing the seat components from the chair frame.",\


### PR DESCRIPTION
Fixes #19865
:cl:
* tweak: Welding down shuttle seats now only gives 2 plasteel back down from 5.