### PR TITLE
Dynamic Mode (v1.01) - Balance Update

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic.dm
+++ b/code/datums/gamemode/dynamic/dynamic.dm
@@ -330,9 +330,9 @@ var/list/forced_roundstart_ruleset = list()
 	if (dead_players.len > living_players.len)
 		chance -= 30//more than half the crew died? ew, let's calm down on antags
 	if (threat > 70)
-		chance += 20
+		chance += 15
 	if (threat < 30)
-		chance -= 20
+		chance -= 15
 	chance = round(max(0,chance))
 	message_admins("DYNAMIC MODE: Chance of injection with the current player numbers and threat level is...[chance]%.")
 	log_admin("DYNAMIC MODE: Chance of injection with the current player numbers and threat level is...[chance]%.")

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
@@ -38,7 +38,7 @@
 //                                          //
 //        RAGIN' MAGES (LATEJOIN)           ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //                                          //
-//////////////////////////////////////////////
+//////////////////////////////////////////////1.01 - Lowered weight from 3 to 2
 
 /datum/dynamic_ruleset/latejoin/raginmages
 	name = "Ragin' Mages"
@@ -46,8 +46,8 @@
 	enemy_jobs = list("Security Officer","Detective", "Warden", "Head of Security", "Captain")
 	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
 	required_candidates = 1
-	weight = 3
-	cost = 10
+	weight = 2
+	cost = 30
 	requirements = list(90,90,70,40,30,20,10,10,10,10)
 
 /datum/dynamic_ruleset/latejoin/raginmages/acceptable(var/population=0,var/threat=0)

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
@@ -46,8 +46,8 @@
 	enemy_jobs = list("Security Officer","Detective", "Warden", "Head of Security", "Captain")
 	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
 	required_candidates = 1
-	weight = 2
-	cost = 30
+	weight = 1
+	cost = 20
 	requirements = list(90,90,70,40,30,20,10,10,10,10)
 
 /datum/dynamic_ruleset/latejoin/raginmages/acceptable(var/population=0,var/threat=0)
@@ -56,7 +56,7 @@
 		message_admins("Cannot accept Wizard ruleset. Couldn't find any wizard spawn points.")
 		return 0
 	if (locate(/datum/dynamic_ruleset/roundstart/wizard) in mode.executed_rules)
-		weight = initial(weight) * 5
+		weight = 10
 
 	return ..()
 

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -55,7 +55,7 @@
 //              RAGIN' MAGES                ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //                                          //
 //////////////////////////////////////////////1.01 - Disabled because it caused a bit too many wizards in rounds
-/*
+
 /datum/dynamic_ruleset/midround/raginmages
 	name = "Ragin' Mages"
 	role_category = ROLE_WIZARD
@@ -63,7 +63,7 @@
 	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
 	required_candidates = 1
 	weight = 3
-	cost = 30
+	cost = 20
 	requirements = list(90,90,70,40,30,20,10,10,10,10)
 	logo = "raginmages-logo"
 
@@ -72,8 +72,8 @@
 		log_admin("Cannot accept Wizard ruleset. Couldn't find any wizard spawn points.")
 		message_admins("Cannot accept Wizard ruleset. Couldn't find any wizard spawn points.")
 		return 0
-	if (locate(/datum/dynamic_ruleset/roundstart/wizard) in mode.executed_rules)
-		weight = initial(weight) * 5
+	if (!(locate(/datum/dynamic_ruleset/roundstart/wizard) in mode.executed_rules))
+		cost = ARBITRARILY_LARGE_NUMBER
 
 	return ..()
 
@@ -121,7 +121,7 @@
 		newWizard.Greet(GREET_MIDROUND)
 		newWizard.ForgeObjectives()
 		newWizard.AnnounceObjectives()
-*/
+
 
 //////////////////////////////////////////////
 //                                          //

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -54,8 +54,8 @@
 //                                          //
 //              RAGIN' MAGES                ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //                                          //
-//////////////////////////////////////////////
-
+//////////////////////////////////////////////1.01 - Disabled because it caused a bit too many wizards in rounds
+/*
 /datum/dynamic_ruleset/midround/raginmages
 	name = "Ragin' Mages"
 	role_category = ROLE_WIZARD
@@ -121,7 +121,7 @@
 		newWizard.Greet(GREET_MIDROUND)
 		newWizard.ForgeObjectives()
 		newWizard.AnnounceObjectives()
-
+*/
 
 //////////////////////////////////////////////
 //                                          //


### PR DESCRIPTION
The main point of this update is to deal with the influx of wizards in almost every single highpop/threat rounds.

:cl:
* tweak: Midround polling of observers for Wizard may now only happen if there were wizards at roundstart.
* tweak: Slightly lowered the weight chance of latejoiners becoming Wizards instead of Traitors if the mode decided to make them an antag.
* tweak: Increased the cost of latejoining Wizards, which lowers drastically their chances to appear on low threat levels, or after many other rulesets have been called.