### PR TITLE
Artifact Cost Adjustment 2: Transmutational Boogaloo

### DIFF
--- a/code/game/gamemodes/wizard/artifacts.dm
+++ b/code/game/gamemodes/wizard/artifacts.dm
@@ -19,6 +19,7 @@
 	name = "Staff of Change"
 	desc = "An artefact that spits bolts of coruscating energy which cause the target's very form to reshape itself."
 	abbreviation = "ST"
+	price = 2 * Sp_BASE_PRICE
 	spawned_items = list(/obj/item/weapon/gun/energy/staff/change)
 
 /datum/spellbook_artifact/mental_focus
@@ -84,7 +85,7 @@
 	abbreviation = "PB"
 	price = 5 * Sp_BASE_PRICE
 	spawned_items = list(/obj/item/weapon/storage/bag/potion/bundle)
-	
+
 /datum/spellbook_artifact/lesser_potion_bundle
 	name = "Lesser potion bundle"
 	desc = "Contains 10 unknown potions. For wizards that are unwilling to go all-in."
@@ -239,7 +240,6 @@
 /datum/spellbook_artifact/phylactery
 	name = "phylactery"
 	desc = "Creates a soulbinding artifact that, upon the death of the user, resurrects them as best it can. You must bind yourself to this through making an incision on your palm, holding the phylactery in that hand, and squeezing it."
-	price = 2 * Sp_BASE_PRICE
 	spawned_items = list(/obj/item/phylactery)
 
 


### PR DESCRIPTION
Wow, it's #20068 again? But hopefully sane this time.

Exactly what it says on the tin. The Staff of Change now costs 40 points to buy, and the Phylactery's price has been reduced to 20. Now that the Summon spells have been reworked and restricted to roundstart Wizards only, I don't think that their price needs to be changed until we get more feedback.

However, the SoC remains the most chaotic and disruptive artifact in the game. We are fresh off a round where a Wizard used it to turn literally everyone on the station into Xenos, which completely gunked the round. Because he had Blink, Jaunt, and Magic Missile in addition to the Staff of Change, he was effectively unstoppable and only died after every other Head of Staff and crew member had been turned into Xenos, which meant that the round could only end through admeme intervention.

I also reduced the price of the Phylactery because it only rarely gets used. Sure, it's a free respawn, but it's still fairly limited and you have to plan around it. Besides, some of the healing potions give you tons of regeneration anyway so this isn't really a big buff.

[balance]

:cl:
 * tweak: The Staff of Change now costs 40 points to buy. The phylactery now costs 20.
