### PR TITLE
Adds default max length for utf8_sanitize

### DIFF
--- a/code/modules/Economy/debit_card.dm
+++ b/code/modules/Economy/debit_card.dm
@@ -33,7 +33,7 @@
 			to_chat(user, "<span class='notice'>The authorized user field on the card is blank.</span>")
 
 /obj/item/weapon/card/debit/proc/change_authorized_name(var/desired_authorized_name)
-	authorized_name = uppertext(sanitize_simple(utf8_sanitize(desired_authorized_name, DEBIT_MAX_AUTHORIZED_NAME_LENGTH)))
+	authorized_name = uppertext(sanitize_simple(utf8_sanitize(desired_authorized_name, length = DEBIT_MAX_AUTHORIZED_NAME_LENGTH)))
 
 /obj/item/weapon/card/debit/attack_self(var/mob/user)
 	if(user.attack_delayer.blocked())

--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -179,7 +179,7 @@ var/global/list/assembly_short_name_to_type = list() //Please, I beg you, don't 
 		if(!istext(new_value))  //Attempted to write a non-string to a string var - convert the non-string into a string and continue
 			new_value = "[new_value]"
 
-		new_value = utf8_sanitize(new_value, MAX_TEXT_VALUE_LEN)
+		new_value = utf8_sanitize(new_value, length = MAX_TEXT_VALUE_LEN)
 
 	//text values can accept either numbers or text, so don't check for that
 

--- a/code/modules/libvg/utf8.dm
+++ b/code/modules/libvg/utf8.dm
@@ -20,9 +20,7 @@
 	return LIBVG("to_utf8", _determine_encoding(mob_or_client), message)
 
 // Converts a byte string to a UTF-8 string, sanitizes it and caps the length.
-/proc/utf8_sanitize(var/message, var/mob_or_client, var/length)
-	if (!length)
-		length = min(length(message), MAX_MESSAGE_LEN)
+/proc/utf8_sanitize(var/message, var/mob_or_client, var/length = MAX_MESSAGE_LEN)
 	return LIBVG("utf8_sanitize", _determine_encoding(mob_or_client), message, num2text(length))
 
 // Get the length (Unicode Scalars) of a UTF-8 string.

--- a/code/modules/libvg/utf8.dm
+++ b/code/modules/libvg/utf8.dm
@@ -21,6 +21,8 @@
 
 // Converts a byte string to a UTF-8 string, sanitizes it and caps the length.
 /proc/utf8_sanitize(var/message, var/mob_or_client, var/length)
+	if (!length)
+		length = min(length(message), MAX_MESSAGE_LEN)
 	return LIBVG("utf8_sanitize", _determine_encoding(mob_or_client), message, num2text(length))
 
 // Get the length (Unicode Scalars) of a UTF-8 string.


### PR DESCRIPTION
[bugfix]
Fixes #20327
Fixes #20273

Adds a default max length for `utf8_sanitize` and fixes some bad proc calls to it.

:cl:
 * bugfix: Newcasters no longer truncate messages to one character.
 * bugfix: Flavour text is no longer truncated to one character.