### PR TITLE
Fixes vampire issues

### DIFF
--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -59,7 +59,6 @@
 
 /datum/role/vampire/OnPostSetup()
 	. = ..()
-
 	update_vamp_hud()
 	ForgeObjectives()
 	for(var/type_VP in roundstart_powers)
@@ -161,7 +160,7 @@
 	log_attack("[key_name(assailant)] bit [key_name(target)] in the neck")
 
 	to_chat(antag.current, "<span class='danger'>You latch on firmly to \the [target]'s neck.</span>")
-	to_chat(target, "<span class='userdanger'>\The [assailant] latches on to your neck!</span>")
+	target.show_message("<span class='userdanger'>\The [assailant] latches on to your neck!</span>")
 
 	if(!iscarbon(assailant))
 		target.LAssailant = null

--- a/code/datums/gamemode/vampire_gamemode.dm
+++ b/code/datums/gamemode/vampire_gamemode.dm
@@ -22,7 +22,7 @@
 		message_admins("Error: trying to give a vampire power to a non-vampire.")
 		return FALSE
 
-	if (spell_path)
+	if (spell_path && !(locate(spell_path) in V.antag.current.spell_list))
 		var/spell/S = new spell_path
 		V.antag.current.add_spell(S)
 


### PR DESCRIPTION
[bugfix] [roleissues]

Fixes #20280 
"Lazily" fixes #20108

For the second thing, I tried to track down how it could possibly happen by having a message pop out when `OnPostSetup` is called and/or when `Give` is called for the vampire ; they're called only once so I don't know why this happen

Both are tested.

:cl:
- bugfix: Vampires shouldn't have duplicated spells anymore.
- bugfix: Vampire bite is no longer seen by unconscious people.