### PR TITLE
Hailers can now be held in an armors storage slot

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -14,6 +14,7 @@
 		/obj/item/weapon/bikehorn/baton,
 		/obj/item/weapon/blunderbuss,
 		/obj/item/weapon/legcuffs/bolas,
+		/obj/item/device/hailer,
 		)
 	body_parts_covered = FULL_TORSO
 	flags = FPRINT


### PR DESCRIPTION
closes #20348 

:cl:
* rscadd: Can now store hailers in armor storage slots.