### PR TITLE
Deathsting Rework

### DIFF
--- a/code/datums/gamemode/role/changeling.dm
+++ b/code/datums/gamemode/role/changeling.dm
@@ -217,7 +217,7 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 
 /datum/power/changeling/DeathSting
 	name = "Death Sting"
-	desc = "We silently sting a human, filling him with potent chemicals. His rapid death is all but assured."
+	desc = "We silently sting a human, filling him with potent chemicals. His death is all but assured."
 	genomecost = 8
 	verbpath = /obj/item/verbs/changeling/proc/changeling_DEATHsting
 

--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -1197,23 +1197,20 @@ var/list/datum/dna/hivemind_bank = list()
 
 /obj/item/verbs/changeling/proc/changeling_DEATHsting()
 	set category = "Changeling"
-	set name = "Death Sting (40)"
+	set name = "Death Sting (50)"
 	set desc = "Causes spasms onto death."
 
 	var/mob/M = loc
 	if(!istype(M))
 		return
 
-	var/mob/living/carbon/target = M.changeling_sting(40, /obj/item/verbs/changeling/proc/changeling_DEATHsting)
+	var/mob/living/carbon/target = M.changeling_sting(50, /obj/item/verbs/changeling/proc/changeling_DEATHsting)
 	if(!target)
 		return
 
-	to_chat(target, "<span class='userdanger'>You feel a tiny prick. Your chest starts tightening.</span>")
-	target.silent = 10
-	target.Paralyse(10)
 	target.Jitter(1000)
 	if(target.reagents)
-		target.reagents.add_reagent(CYANIDE, 20)
+		target.reagents.add_reagent(CHEFSPECIAL, 5)
 
 	feedback_add_details("changeling_powers", "DTHS")
 	return 1


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl:
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!

SELF LABELLING PRs:
You can now self-label your PR! The syntax is simple. Just put [<labeltag>] anywhere in your PR,
where <labeltag> is to be replaced by one of the following (allowing with the resultant tag)
just ctrl+f the list or something. I know it's long.

administration = "Logging / Administration"
away = "Mapping (Away Mission :earth_africa:)"
bagel = "Mapping (Bagel :o:)"
box = "Mapping (Box :baby:)"
bugfix = "Bug / Fix"
bus = "Mapping (Bus :bus:)"
byond = "T-Thanks BYOND"
consistency = "Consistency Issue"
controversial = "Controversial"
deff = "Mapping (Deff :wastebasket:)"
discussion = "Discussion"
dnm = "✋ Do Not Merge ✋"
easy = "Easy Fix"
exploitable = "Exploitable"
featureloss = "Feature Loss"
featurerequest = "Feature Request"
first = "good first issue"
formatting = "Grammar / Formatting"
gamemode = "Gameplay / Gamemode"
gameplay = "Gameplay / Gamemode"
general = "Mapping (General :world_map:)"
goonchat = "Goonchat"
grammar = "Grammar / Formatting"
help = "help wanted"
hotfix = "Hotfix"
libvg = "libvg"
logging = "Logging / Administration"
meta = "Mapping (Meta :no_mobile_phones:)"
needspritework = "Needs Spritework"
oversight = "Oversight"
packed = "Mapping (Packed :package:)"
parallax = "Parallax"
qol = "❤️ Quality of Life ❤️"
roid = "Mapping (Roidstation :pick:)"
role = "Role Datums"
roleissue = "Role Datums Issue"
runtime = "Runtime Log"
sanity = "Sanity / Ghosthands"
snowmap = "Mapping (Snowmap ❄)"
sound = "Sound"
sprites = "Sprites"
spriteworkdone = "Spritework Done Needs Coder"
system = "System"
taxi = "Mapping (Taxi :taxi:)"
tested = "100%  tested"
tweak = "Tweak"
ui = "UI"
vault = "Mapping (Vault :question:)"
vote = "⛔ Requires Server Vote ⛔"
wip = "WiP"

-->
This changes deathstings to use chef sauce instead of cyanide.  It increases the price to 50 chemicals, the maximum amount a changeling can hold normally.  This PR also removes the message about being stung to the user, the silence, and the paralyze.  It does leave the jitters, giving the person stung some subtle feedback.  I hope this is a good blend of stealth, cooldown, and feedback to give the changeling and the target more engaging gameplay before the death kicks in.  Or at least more than current deathsting and more than no deathsting.  Alternate to #20318
Compiled and tested locally.
[balance] [updatewiki] [wiki]

:cl:
 * rscadd: Deathsting now uses chef's special sauce
 * rscadd: Deathsting now costs 50 chemicals instead of 40
 * rscdel: Deathsting no long silences and paralyzes (still causes jitters) 