### PR TITLE
Stops items from being moved to the mob's turf when putting them in backpacks and whatever

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -317,14 +317,14 @@
 	if(!istype(W))
 		return 0
 	if(usr)
-		usr.u_equip(W,1)
-		usr.update_icons()	//update our overlays
+		usr.u_equip(W,0)
+		W.dropped(usr) // we're skipping u_equip's forcemove to turf but we still need the item to unset itself
+		usr.update_icons()
 	W.forceMove(src)
 	W.on_enter_storage(src)
 	if(usr)
 		if (usr.client && usr.s_active != src)
 			usr.client.screen -= W
-		//W.dropped(usr)
 		add_fingerprint(usr)
 
 		if(!prevent_warning && !istype(W, /obj/item/weapon/gun/energy/crossbow))


### PR DESCRIPTION
[bugfix]
Fixes #18613
Fixes #16373

This is functionally the same except it skips the `forcemove(turf)` proc in `u_equip`.

:cl:
 * bugfix: Items no longer get dropped and teleported away if you try to put it in a storage item while standing on a portal.