### PR TITLE
Removes ling general stings, adds ling chemsting and chemspit

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1659,27 +1659,29 @@ Game Mode config tags:
 	var/turf/U = get_turf(target)
 	if (!T || !U)
 		return
-	var/obj/item/projectile/A
-	A = new projectile(T)
+	if(ispath(projectile))
+		projectile = new(T)
+	else
+		projectile.forceMove(T)
 	var/fire_sound
 	if(shot_sound)
 		fire_sound = shot_sound
 	else
-		fire_sound = A.fire_sound
+		fire_sound = projectile.fire_sound
 
-	A.original = target
-	A.target = U
-	A.shot_from = source
+	projectile.original = target
+	projectile.target = U
+	projectile.shot_from = source
 	if(istype(source, /mob))
-		A.firer = source
-	A.current = T
-	A.starting = T
-	A.yo = U.y - T.y
-	A.xo = U.x - T.x
+		projectile.firer = source
+	projectile.current = T
+	projectile.starting = T
+	projectile.yo = U.y - T.y
+	projectile.xo = U.x - T.x
 	playsound(T, fire_sound, 75, 1)
 	spawn()
-		A.OnFired()
-		A.process()
+		projectile.OnFired()
+		projectile.process()
 
 
 //Increases delay as the server gets more overloaded,

--- a/code/datums/gamemode/objectives/sample.dm
+++ b/code/datums/gamemode/objectives/sample.dm
@@ -1,0 +1,18 @@
+/datum/objective/chem_sample
+	explanation_text = "Learn a number of chemicals"
+	name = "(Changeling) Learn chemicals"
+	var/number_of_chems_to_learn
+
+/datum/objective/chem_sample/PostAppend()
+	number_of_chems_to_learn = rand(5,30)
+	explanation_text = "Learn [number_of_chems_to_learn] different chemicals."
+	return TRUE
+
+/datum/objective/chem_sample/IsFulfilled()
+	if (..())
+		return TRUE
+	if(owner)
+		var/datum/role/changeling/C = owner.GetRole(CHANGELING)
+		if(C && C.absorbed_chems.len >= number_of_chems_to_learn)
+			return TRUE
+	return FALSE

--- a/code/datums/gamemode/role/changeling.dm
+++ b/code/datums/gamemode/role/changeling.dm
@@ -7,6 +7,7 @@
 	var/list/absorbed_dna = list()
 	var/list/absorbed_species = list()
 	var/list/absorbed_languages = list()
+	var/list/absorbed_chems = list()
 	var/absorbedcount = 0
 	var/chem_charges = 20
 	var/chem_recharge_rate = 0.5
@@ -53,6 +54,8 @@
 	AppendObjective(/datum/objective/absorb)
 	AppendObjective(/datum/objective/target/assassinate)
 	AppendObjective(/datum/objective/target/steal)
+	if(prob(50))
+		AppendObjective(/datum/objective/chem_sample)
 	if(prob(50))
 		AppendObjective(/datum/objective/escape)
 	else
@@ -158,28 +161,6 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 	genomecost = 15
 	verbpath = /obj/item/verbs/changeling/proc/changeling_horror_form
 
-/datum/power/changeling/deaf_sting
-	name = "Deaf Sting"
-	desc = "We silently sting a human, completely deafening them for a short time."
-	genomecost = 1
-	allowduringlesserform = 1
-	verbpath = /obj/item/verbs/changeling/proc/changeling_deaf_sting
-
-/datum/power/changeling/blind_sting
-	name = "Blind Sting"
-	desc = "We silently sting a human, completely blinding them for a short time."
-	genomecost = 2
-	allowduringlesserform = 1
-	verbpath = /obj/item/verbs/changeling/proc/changeling_blind_sting
-
-/datum/power/changeling/silence_sting
-	name = "Silence Sting"
-	desc = "We silently sting a human, completely silencing them for a short time."
-	helptext = "Does not provide a warning to a victim that they have been stung, until they try to speak and cannot."
-	genomecost = 2
-	allowduringlesserform = 1
-	verbpath = /obj/item/verbs/changeling/proc/changeling_silence_sting
-
 /datum/power/changeling/mimicvoice
 	name = "Mimic Voice"
 	desc = "We shape our vocal glands to sound like a desired voice."
@@ -201,33 +182,6 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 	helptext = "Does not provide a warning to others. The victim will transform much like a changeling would."
 	genomecost = 3
 	verbpath = /obj/item/verbs/changeling/proc/changeling_transformation_sting
-
-/datum/power/changeling/paralysis_sting
-	name = "Paralysis Sting"
-	desc = "We silently sting a human, paralyzing them for a short time."
-	genomecost = 4
-	verbpath = /obj/item/verbs/changeling/proc/changeling_paralysis_sting
-
-/datum/power/changeling/LSDSting
-	name = "Hallucination Sting"
-	desc = "We evolve the ability to sting a target with a powerful hallunicationary chemical."
-	helptext = "The target does not notice they have been stung.  The effect occurs after 30 to 60 seconds."
-	genomecost = 3
-	verbpath = /obj/item/verbs/changeling/proc/changeling_lsdsting
-
-/datum/power/changeling/unfat_sting
-	name = "Unfat Sting"
-	desc = "We silently sting a human or ourselves, forcing them to rapidly metabolize their fat."
-	helptext = "Caution: This can also target you!"
-	genomecost = 0
-	verbpath = /obj/item/verbs/changeling/proc/changeling_unfat_sting
-
-/datum/power/changeling/fat_sting
-	name = "Fat Sting"
-	desc = "We silently sting a human or ourselves, forcing them to rapidly accumulate fat."
-	helptext = "Caution: This can also target you!"
-	genomecost = 0
-	verbpath = /obj/item/verbs/changeling/proc/changeling_fat_sting
 
 /datum/power/changeling/boost_range
 	name = "Boost Range"
@@ -288,6 +242,21 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 	helptext = "The blade can be retracted by using the same verb used to manifest it. It has a chance to deflect projectiles."
 	genomecost = 5
 	verbpath = /obj/item/verbs/changeling/proc/changeling_armblade
+
+/datum/power/changeling/chemsting
+	name = "Chemical Sting"
+	desc = "We repurpose our internal organs to process and recreate any chemicals we have learned, ready to inject into another lifeform or ourselves if needs be."
+	helptext = "This can be used to hinder others, or help ourselves, through the application of medicines or poisons."
+	genomecost = 1
+	verbpath = /obj/item/verbs/changeling/proc/changeling_chemsting
+
+/datum/power/changeling/chemspit
+	name = "Chemical Spit"
+	desc = "We repurpose our internal organs to process and recreate any chemicals we have learned, ready to fire like projectile venom in our facing direction."
+	helptext = "Handy for firing acid at enemies, providing we have learned such chemicals."
+	genomecost = 1
+	allowduringlesserform = 1
+	verbpath = /obj/item/verbs/changeling/proc/changeling_chemspit
 
 /datum/power_holder
 	var/datum/role/R

--- a/code/modules/mob/living/simple_animal/hostile/necromorph.dm
+++ b/code/modules/mob/living/simple_animal/hostile/necromorph.dm
@@ -208,6 +208,9 @@
 /obj/item/projectile/puke/New()
 	..()
 	create_reagents(500)
+	make_reagents()
+
+/obj/item/projectile/puke/proc/make_reagents()
 	var/room_remaining = 500
 	var/poly_to_add = rand(100,200)
 	reagents.add_reagent(PACID, poly_to_add)
@@ -216,6 +219,9 @@
 	reagents.add_reagent(SACID, sulph_to_add)
 	room_remaining -= sulph_to_add
 	reagents.add_reagent(VOMIT, room_remaining)
+
+/obj/item/projectile/puke/clear/make_reagents()
+	return
 
 
 /obj/item/projectile/puke/on_hit(var/atom/atarget, var/blocked = 0)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -143,6 +143,11 @@
 		if((M.mind.special_role == HIGHLANDER || M.mind.special_role == BOMBERMAN) && src.flags & CHEMFLAG_DISHONORABLE)
 			// TODO: HONORABLE_* checks.
 			return 1
+		if(dupeable && reagent_state == REAGENT_STATE_LIQUID && volume>=5 && ischangeling(M))
+			var/datum/role/changeling/C = M.mind.GetRole(CHANGELING)
+			if(!C.absorbed_chems.Find(id))
+				C.absorbed_chems.Add(id)
+				to_chat(M, "<span class = 'notice'>We have learned [src]</span>")
 
 	if((overdose_am && volume >= overdose_am) || (overdose_tick && tick >= overdose_tick)) //Too much chems, or been in your system too long
 		on_overdose(M)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -147,7 +147,7 @@
 			var/datum/role/changeling/C = M.mind.GetRole(CHANGELING)
 			if(!C.absorbed_chems.Find(id))
 				C.absorbed_chems.Add(id)
-				to_chat(M, "<span class = 'notice'>We have learned [src]</span>")
+				to_chat(M, "<span class = 'notice'>We have learned [src].</span>")
 
 	if((overdose_am && volume >= overdose_am) || (overdose_tick && tick >= overdose_tick)) //Too much chems, or been in your system too long
 		on_overdose(M)

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -346,6 +346,7 @@
 #include "code\datums\gamemode\objectives\minimize_casualties.dm"
 #include "code\datums\gamemode\objectives\nuclear.dm"
 #include "code\datums\gamemode\objectives\objective.dm"
+#include "code\datums\gamemode\objectives\sample.dm"
 #include "code\datums\gamemode\objectives\silence.dm"
 #include "code\datums\gamemode\objectives\spray_blood.dm"
 #include "code\datums\gamemode\objectives\summon_narsie.dm"


### PR DESCRIPTION
My version of #20318 and #20357

:cl:
 * rscdel: Removes old changeling stings such as fat sting, unfat sting, deaf sting, death sting, paralysis sting, hallucination sting, blind sting, silence sting
* rscadd: Adds changeling chemical learning. Consume a chemical that is dupeable and is a liquid to be able to duplicate it.
* rscadd: Adds chemical sting, where you attempt to recreate then inject a chemical you have learned
* rscadd: Adds chemical spit, where you spit a chemical you have learned like a projectile in the direction you are facing.