### PR TITLE
Fixes Disease Analyser Not Updating Icon on Power Loss

### DIFF
--- a/code/modules/virus2/analyser.dm
+++ b/code/modules/virus2/analyser.dm
@@ -76,6 +76,7 @@
 
 /obj/machinery/disease2/diseaseanalyser/process()
 	if(stat & (NOPOWER|BROKEN))
+		icon_state = "analyser"
 		return
 	use_power(500)
 


### PR DESCRIPTION
Fixes #12679.