### PR TITLE
Taser/Egun projectile nerf

### DIFF
--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -104,6 +104,7 @@
 	var/lying_prev = 0
 	var/canmove = 1
 	var/candrop = 1
+	var/tazed = 0
 
 	var/size = SIZE_NORMAL
 	//SIZE_TINY for tiny animals like mice and borers

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -112,6 +112,9 @@ var/list/impact_master = list()
 	initial_pixel_x = pixel_x
 	initial_pixel_y = pixel_y
 
+/obj/item/projectile/proc/hit_apply(var/mob/living/X, var/blocked) // this is relevant because of projectile/energy/electrode
+	X.apply_effects(stun, weaken, paralyze, irradiate, stutter, eyeblur, drowsy, agony, blocked)
+
 /obj/item/projectile/proc/on_hit(var/atom/atarget, var/blocked = 0)
 	if(blocked >= 2)
 		return 0//Full block
@@ -128,7 +131,7 @@ var/list/impact_master = list()
 	var/mob/living/L = atarget
 	if(L.flags & INVULNERABLE)
 		return 0
-	L.apply_effects(stun, weaken, paralyze, irradiate, stutter, eyeblur, drowsy, agony, blocked) // add in AGONY!
+	hit_apply(L)
 	if(jittery)
 		L.Jitter(jittery)
 	if(!isnull(hitsound))

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -25,9 +25,13 @@
 		X.apply_effects(stun, weaken, blocked = blocked)
 	X.apply_effects(stutter = stutter, blocked = blocked, agony = agony)
 	X.audible_scream()
-	X.movement_speed_modifier -= 0.75
+	if(X.tazed == 0)
+		X.movement_speed_modifier -= 0.75
+		spawn(30)
+			X.movement_speed_modifier += 0.75
+	X.tazed = 1
 	spawn(30)
-		X.movement_speed_modifier += 0.75
+		X.tazed = 0
 
 
 /*/vg/ EDIT

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -16,7 +16,19 @@
 	stun = 10
 	weaken = 10
 	stutter = 10
+	jittery = 20
+	agony = 10
 	hitsound = 'sound/weapons/taserhit.ogg'
+
+/obj/item/projectile/energy/electrode/hit_apply(var/mob/living/X, var/blocked)
+	spawn(13)
+		X.apply_effects(stun, weaken, blocked = blocked)
+	X.apply_effects(stutter = stutter, blocked = blocked, agony = agony)
+	X.audible_scream()
+	X.movement_speed_modifier -= 0.75
+	spawn(30)
+		X.movement_speed_modifier += 0.75
+
 
 /*/vg/ EDIT
 	agony = 40


### PR DESCRIPTION
This creates a 1,3 second delay between being hit by a taser bolt and actually getting stunned.
It also applies 75% movement slowdown immediately on hit.
This could hopefully change the meta of gunfights being immediately decided by landing the first taserbolt.

![nweh](https://user-images.githubusercontent.com/29950771/47383447-0005f980-d705-11e8-9966-3adaeea90e13.gif)

Basically you can retaliate with lasers(I think you can fire at least 2 or 3) or a taserbolt of your own within the 1 second of being hit.

🆑 
experiment: Getting hit by taser or egun projectiles now stuns after a 1.3 second delay instead of immediately. It slows you down between being hit and being stunned.
wip: The above is in as a trial of the change and will be reverted on November 3, at which point it will be polled on. t. Intigracy