### PR TITLE
Fixes striketeam infinite loop

### DIFF
--- a/code/game/striketeams/striketeam_datums.dm
+++ b/code/game/striketeams/striketeam_datums.dm
@@ -117,12 +117,7 @@ var/list/sent_strike_teams = list()
 				if(M.key == selected_key)
 					applicant = M
 
-			if(!applicant)
-				i++
-				applicants -= selected_key
-				continue
-
-			applicants -= applicant.key
+			applicants -= selected_key
 
 			if(!isobserver(applicant))
 				//Making sure we don't recruit people who got back into the game since they applied

--- a/code/game/striketeams/striketeam_datums.dm
+++ b/code/game/striketeams/striketeam_datums.dm
@@ -117,8 +117,9 @@ var/list/sent_strike_teams = list()
 				if(M.key == selected_key)
 					applicant = M
 
-			if(!applicant || !applicant.key)
+			if(!applicant)
 				i++
+				applicants -= selected_key
 				continue
 
 			applicants -= applicant.key


### PR DESCRIPTION
This proc is still bad and should be rewritten, but this should at least remove the possibility of an infinite loop
0% tested but the effects are pretty obvious
(It was impossible for `applicant.key` to be `null` if `applicant` was not null. It was impossible for `applicant.key` to differ from `selected_key` if `applicant` existed. `isobserver()` returns false when given `null`, so this `if()` wasn't necessary.)