### PR TITLE
Removes Wizard Nar-Sie

### DIFF
--- a/code/datums/gamemode/factions/legacy_cult/narsie.dm
+++ b/code/datums/gamemode/factions/legacy_cult/narsie.dm
@@ -395,19 +395,6 @@ var/global/list/narsie_list = list()
 	overlays += image(icon,"glow-[icon_state]",overlay_layer)
 */
 
-
-/**
- * Wizard narsie.
- */
-/obj/machinery/singularity/narsie/wizard
-	grav_pull = 0
-
-/obj/machinery/singularity/narsie/wizard/eat()
-	set background = BACKGROUND_ENABLED
-
-	for (var/turf/T in trange(consume_range, src))
-		consume(T)
-
 /**
  * MR. CLEAN
  */

--- a/code/game/gamemodes/sandbox/h_sandbox.dm
+++ b/code/game/gamemodes/sandbox/h_sandbox.dm
@@ -41,7 +41,7 @@ var/global/list/banned_sandbox_types=list(
 	// /obj/item/weapon/cloaking_device,
 	// /obj/item/weapon/dummy,
 	// /obj/item/weapon/melee/energy/sword,
-	/obj/item/weapon/veilrender,
+	// /obj/item/weapon/veilrender,
 	/obj/item/weapon/reagent_containers/glass/bottle/wizarditis,
 	// /obj/item/weapon/spellbook,
 	/obj/machinery/singularity,

--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -28,7 +28,6 @@
 
 /obj/effect/rend/New()
 	processing_objects.Add(src)
-	return
 
 /obj/effect/rend/Destroy()
 	processing_objects.Remove(src)

--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -14,6 +14,7 @@
 	w_class = W_CLASS_MEDIUM
 	var/charged = 1
 	hitsound = 'sound/weapons/bladeslice.ogg'
+	var/rendtype = /obj/effect/rend
 
 /obj/effect/rend
 	name = "tear in the fabric of reality"
@@ -22,60 +23,56 @@
 	icon_state = "rift"
 	density = 1
 	anchored = 1.0
+	var/mobsleft = 20
+	var/mobtype = /mob/living/simple_animal/hostile/creature
 
 /obj/effect/rend/New()
-	spawn(50)
-		new /obj/machinery/singularity/narsie/wizard(get_turf(src))
-		qdel(src)
-		return
+	processing_objects.Add(src)
 	return
 
-/obj/item/weapon/veilrender/attack_self(mob/user as mob)
-	if(charged == 1)
-		new /obj/effect/rend(get_turf(usr))
-		charged = 0
-		visible_message("<span class='danger'>[src] hums with power as [usr] deals a blow to reality itself!</span>")
+/obj/effect/rend/Destroy()
+	processing_objects.Remove(src)
+	..()
+
+/obj/effect/rend/process()
+	for(var/mob/M in loc)
+		if(M.stat != DEAD)
+		return
+	new mobtype(loc)
+	mobsleft--
+	if(mobsleft <= 0)
+		qdel(src)
+
+/obj/effect/rend/attackby(obj/item/I, mob/user)
+	if(istype(I, /obj/item/weapon/nullrod))
+		visible_message("<span class='danger'>[I] strikes a blow against \the [src], banishing it!</span>")
+		qdel(src)
+		return
+	..()
+
+/obj/item/weapon/veilrender/attack_self(mob/user)
+	if(charged > 0)
+		create_rend(user)
+		charged--
 	else
 		to_chat(user, "<span class='warning'>The unearthly energies that powered the blade are now dormant.</span>")
 
-
+/obj/item/weapon/veilrender/proc/create_rend(mob/user)
+	new rendtype(get_turf(user))
+	visible_message("<span class='danger'>[src] hums with power as \the [user] deals a blow to reality itself!</span>")
 
 /obj/item/weapon/veilrender/vealrender
 	name = "veal render"
 	desc = "A wicked curved blade of alien origin, recovered from the ruins of a vast farm."
+	rendtype = /obj/effect/rend/cow
 
-/obj/item/weapon/veilrender/vealrender/attack_self(mob/user as mob)
-	if(charged)
-		new /obj/effect/rend/cow(get_turf(usr))
-		charged = 0
-		visible_message("<span class='danger'>[src] hums with power as [usr] deals a blow to hunger itself!</span>")
-	else
-		to_chat(user, "<span class='warning'>The unearthly energies that powered the blade are now dormant.</span>")
+/obj/item/weapon/veilrender/vealrender/create_rend(mob/user)
+	new rendtype(get_turf(user))
+	visible_message("<span class='danger'>[src] hums with power as \the [user] deals a blow to hunger itself!</span>")
 
 /obj/effect/rend/cow
 	desc = "Reverberates with the sound of ten thousand moos."
-	var/cowsleft = 20
-
-/obj/effect/rend/cow/New()
-	processing_objects.Add(src)
-	return
-
-/obj/effect/rend/cow/process()
-	if(locate(/mob) in loc)
-		return
-	new /mob/living/simple_animal/cow(loc)
-	cowsleft--
-	if(cowsleft <= 0)
-		qdel (src)
-
-/obj/effect/rend/cow/attackby(obj/item/I as obj, mob/user as mob)
-	if(istype(I, /obj/item/weapon/nullrod))
-		visible_message("<span class='danger'>[I] strikes a blow against \the [src], banishing it!</span>")
-		spawn(1)
-			qdel (src)
-		return
-	..()
-
+	mobtype = /mob/living/simple_animal/cow
 
 /////////////////////////////////////////Scrying///////////////////
 


### PR DESCRIPTION
Even after fixing the runtime errors, the old wizard Nar-Sie did nothing when spawned except delete a chunk of tiles and then disappear. Neither the veil render nor wizard Nar-Sie have been used for years, so I just got rid of it.

The veil render now spawns a portal, veal render style, that creates 20 creatures instead of cows. Maybe it could now be made into an actual wizard artifact.

Fixes #13191.