### PR TITLE
Runtime hunting: bucket heating

### DIFF
--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -355,6 +355,7 @@
 		user.put_in_hands(new /obj/item/weapon/bucket_sensor)
 		user.drop_from_inventory(src)
 		qdel(src)
+		return
 	attempt_heating(D, user)
 
 /obj/item/weapon/reagent_containers/glass/bucket/water_filled/New()


### PR DESCRIPTION
When attempting to build a roomba/cleanbot, it would runtime when it came to attempt heating, as the item had been deleted.