### PR TITLE
Runtime hunting: Assert sound loc

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -207,7 +207,7 @@ obj/item/proc/get_clamped_volume()
 				else
 					to_chat(user, "<span class='warning'>You attack [M] with [I]!</span>")
 
-
+	I.on_attack(M,user)
 	if(istype(M, /mob/living/carbon))
 		var/mob/living/carbon/C = M
 		if(originator)
@@ -239,7 +239,6 @@ obj/item/proc/get_clamped_volume()
 		. = TRUE //The attack always lands
 		M.updatehealth()
 	I.add_fingerprint(user)
-	I.on_attack(M,user)
 
 
 /obj/item/proc/on_attack(var/atom/attacked, var/mob/user)


### PR DESCRIPTION
Because of things that delete themselves on damage/death, such as spiderlings, the location of the attack playsound would be null by the time it would reach on_attack, as they would have deleted themselves and be nullspaced.

Now, on_attack is called before the damage is dealt rather than after.