### PR TITLE
Hopefully fixes spiders opening and closing doors forever

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1073,9 +1073,15 @@ About the new airlock wires panel:
 			if(level_of_door_opening < 2)
 				return
 			visible_message("<span class = 'warning'>\The [M] forces \the [src] [density?"open":"closed"]!</span>")
-			density ? open(1):close(1)
+			if(M.client)
+				density ? open(1):close(1)
+			else if(density)
+				open(1)
 		else
-			density ? open(1):close(1)
+			if(M.client)
+				density ? open(1):close(1)
+			else if(density)
+				open(1)
 
 
 //You can ALWAYS screwdriver a door. Period. Well, at least you can even if it's open

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/hunter.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/hunter.dm
@@ -10,9 +10,7 @@
 	melee_damage_lower = 10
 	melee_damage_upper = 20
 	poison_per_bite = 5
-	// Hunters attack doors (jam them open)
 	wanted_objects = list(
-		/obj/machinery/door/airlock,
 		/obj/machinery/bot,          // Beepsky and friends
 		/obj/machinery/light,        // Bust out lights
 	)

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -168,7 +168,7 @@
 					return 1
 		if((environment_smash_flags & OPEN_DOOR_STRONG) && istype(the_target, /obj/machinery/door/airlock))
 			var/obj/machinery/door/airlock/A = the_target
-			if(!A.density)
+			if(!A.density || A.operating)
 				return 0
 			return 1
 	return 0


### PR DESCRIPTION
 - Adds an operating check, to see if the door is mid-open or mid-close
 - Removes airlocks from hunter wanted oblcts
 - Makes it so only a mob with a client can close a door, everything else just opens.

:cl:
 * bugfix: Fixes spiders opening and closing doors 5ever


