### PR TITLE
Fixes locker, etc. air, for super extra realz this time

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -253,13 +253,10 @@ var/global/list/reagents_to_log = list(FUEL, PLASMA, PACID, SACID, AMUTATIONTOXI
 	else
 		return null
 
-/obj/proc/handle_internal_lifeform(mob/lifeform_inside_me, breath_request)
-	//Return: (NONSTANDARD)
-	//		null if object handles breathing logic for lifeform
-	//		datum/air_group to tell lifeform to process using that breath return
-	//DEFAULT: Take air from turf to give to have mob process
-	if(breath_request>0)
-		return remove_air(breath_request)
+/obj/proc/handle_internal_lifeform(mob/lifeform_inside_me, breath_vol)
+	if(breath_vol > 0)
+		var/datum/gas_mixture/G = return_air()
+		return G.remove_volume(breath_vol)
 	else
 		return null
 

--- a/code/modules/mob/living/carbon/human/life/handle_breath.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_breath.dm
@@ -47,7 +47,7 @@
 				//
 			else if(isobj(loc))
 				var/obj/location_as_object = loc
-				breath = location_as_object.handle_internal_lifeform(src, BREATH_MOLES)
+				breath = location_as_object.handle_internal_lifeform(src, BREATH_VOLUME)
 			else if(isturf(loc))
 				/*if(environment.return_pressure() > ONE_ATMOSPHERE)
 					//Loads of air around (pressure effect will be handled elsewhere), so lets just take a enough to fill our lungs at normal atmos pressure (using n = Pv/RT)


### PR DESCRIPTION
Fixes #20427 
Also fixes an unreported and very old issue where every breathing mob except humans would always use almost 25 times as much air as they were supposed to, as long as they were inside anything

This one has more significance (but still not all that much):
Also fixes lockers (and all other objects) being magical air bastions which would vacuum up gas from the entire zone to give you a full breath (or ~25 full breaths in the case of anything except humans), regardless of the zone's pressure
As it is when not in an object, the air is now given based on volume, rather than moles.

:cl:
* bugfix: Being inside an object (such as a locker) no longer allows you to suck up air from an arbitrary volume while breathing. Breathing while inside an object is now the same as breathing while not inside an object (other than objects that are supposed to let you breathe, of course). (This affects only breathing, not pressure damage.)