### PR TITLE
Doorcrushing No Longer Creates a Forcefield Around You

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1275,8 +1275,8 @@ About the new airlock wires panel:
 	return ..()
 
 /obj/machinery/door/airlock/Uncross(atom/movable/mover)
-	if(density)
-		to_chat(mover, "You are pinned inside the closed airlock, you can't move!")
+	if(density && ismob(mover) && !(mover.checkpass(PASSGLASS) && !opacity) && !(mover.checkpass(PASSDOOR)))
+		to_chat(mover, "You are pinned inside the closed airlock; you can't move!")
 		return 0
 	return ..()
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -353,6 +353,8 @@ About the new airlock wires panel:
 		..()
 
 /obj/machinery/door/airlock/bump_open(mob/living/user as mob) //Airlocks now zap you when you 'bump' them open when they're electrified. --NeoFite
+	if(user.loc == loc)	//no bumping an airlock from within the airlock
+		return
 	if(!istype(user))
 		return
 	if(!issilicon(usr))
@@ -1272,6 +1274,12 @@ About the new airlock wires panel:
 	// </worry>
 	return ..()
 
+/obj/machinery/door/airlock/Uncross(atom/movable/mover)
+	if(density)
+		to_chat(mover, "You are pinned inside the closed airlock, you can't move!")
+		return 0
+	return ..()
+
 /obj/machinery/door/airlock/close(var/forced = 0 as num)
 	if (operating || locked || welded)
 		return
@@ -1307,13 +1315,6 @@ About the new airlock wires panel:
 
 				L.SetStunned(5)
 				L.SetKnockdown(5)
-				var/obj/effect/stop/S = new()
-				S.forceMove(loc)
-				S.victim = L
-
-				spawn (20)
-					qdel(S)
-					S = null
 
 				L.audible_scream()
 


### PR DESCRIPTION
However, it is also no longer possible to leave an airlock's tile after you have been crushed inside it, unless you open it again first. This gives AIs the new ability of trapping someone inside an airlock if they lack the access to open it themselves, though the AI risks them escaping or being pulled out if it opens the airlock again to continue crushing them to death.

Fixes #13576.

:cl:
 * bugfix: Being doorcrushed no longer creates a forcefield that prevents you from moving or being dragged out of the door for two seconds.
 * tweak: It is no longer possible to leave an airlock's tile if it closes while you're inside it. The airlock will have to be opened first.