### PR TITLE
Fixes Being Able to Use Lesser Form in Mechs

### DIFF
--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -445,12 +445,22 @@
 	if(!istype(M))
 		return
 
+	if(!M.changeling_can_lesser_form())
+		to_chat(M, "<span class='warning'>We cannot perform this ability in this location!</span>")
+		return
 	if(ishuman(M))
 		M.changeling_lesser_form()
 	else if(ismonkey(M))
 		M.changeling_lesser_transform()
 	else
 		to_chat(M, "<span class='warning'>We cannot perform this ability in this form!</span>")
+
+/mob/proc/changeling_can_lesser_form()
+	if(istype(loc, /obj/mecha))
+		return FALSE
+	if(istype(loc, /obj/machinery/atmospherics))
+		return FALSE
+	return TRUE
 
 //Transform into a monkey. 	//TODO replace with monkeyize proc
 /mob/proc/changeling_lesser_form()

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1199,6 +1199,8 @@
 		if(M.Victim == usr)
 			to_chat(usr, "You're too busy getting your life sucked out of you.")
 			return
+	if(ismonkey(usr))
+		return
 
 	visible_message("<span class='notice'>[usr] starts to climb into \the [src].</span>")
 

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1199,8 +1199,6 @@
 		if(M.Victim == usr)
 			to_chat(usr, "You're too busy getting your life sucked out of you.")
 			return
-	if(ismonkey(usr))
-		return
 
 	visible_message("<span class='notice'>[usr] starts to climb into \the [src].</span>")
 
@@ -1492,17 +1490,19 @@
 /////////////////////////
 
 /obj/mecha/proc/operation_allowed(mob/living/carbon/human/H)
-	for(var/ID in list(H.get_active_hand(), H.wear_id, H.belt))
-		if(src.check_access(ID,src.operation_req_access))
-			return 1
-	return 0
+	if(istype(H))
+		for(var/ID in list(H.get_active_hand(), H.wear_id, H.belt))
+			if(src.check_access(ID,src.operation_req_access))
+				return 1
+		return 0
 
 
 /obj/mecha/proc/internals_access_allowed(mob/living/carbon/human/H)
-	for(var/atom/ID in list(H.get_active_hand(), H.wear_id, H.belt))
-		if(src.check_access(ID,src.internals_req_access))
-			return 1
-	return 0
+	if(istype(H))
+		for(var/atom/ID in list(H.get_active_hand(), H.wear_id, H.belt))
+			if(src.check_access(ID,src.internals_req_access))
+				return 1
+		return 0
 
 
 /obj/mecha/check_access(obj/item/weapon/card/id/I, list/access_list)


### PR DESCRIPTION
Fixes all remaining bugs mentioned in #13149, as far as I can tell. Thanks to @SarahJohnson489 for bugtesting.
Changelings can no longer use lesser form while inside mechs or pipes. Also fixes a runtime related to monkeys hitting mechs with ID cards.

Fixes #13149.