### PR TITLE
Fixes Handheld Flashes Not Showing White Screen Overlay

### DIFF
--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -96,6 +96,7 @@
 
 		if(Subject.eyecheck() > 0 || flashfail)
 			user.visible_message("<span class='notice'>[user] fails to blind [M] with the flash!</span>")
+			flashfail = TRUE
 		else
 			if(Subject.eyecheck() <= 0)
 				Subject.Knockdown(Subject.eyecheck() * 5 * -1 +10)
@@ -108,13 +109,15 @@
 			length = rand(5,10)
 			R.Knockdown(length)
 			R.flashed = 1
-			R.flash_eyes(affect_silicon = 1)
 			user.visible_message("<span class='warning'>[user] overloads [R]'s sensors with the flash!</span>")
 			spawn(length SECONDS)
 				if (R.flashed)
 					R.flashed = 0
 	else //simple_animal maybe?
 		user.visible_message("<span class='notice'>[user] fails to blind [M] with the flash!</span>")
+		return
+	if(!flashfail)
+		M.flash_eyes(affect_silicon = 1)
 
 /obj/item/device/flash/attack_self(mob/living/carbon/user as mob, flag = 0, emp = 0)
 	if(!user || !clown_check(user))


### PR DESCRIPTION
All this time it's been working for borgs, but not humans.
Fixes #13889.

:cl:
 * bugfix: Handheld flashes will now show the white "flash"  overlay on someone's screen when you flash them.