### PR TITLE
Fixes Blinder Not Blinding Silicons

### DIFF
--- a/code/modules/projectiles/guns/projectile/constructable/blinder.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/blinder.dm
@@ -92,7 +92,7 @@
 	if(M.blinded)
 		return
 
-	M.flash_eyes(visual = 1)
+	M.flash_eyes(visual = 1, affect_silicon = 1)
 
 	if(issilicon(M))
 		M.Knockdown(rand(5, 10))


### PR DESCRIPTION
It was stunning them before, just not blinding them.

:cl:
 * bugfix: Blinders will now properly blind borgs as well as stun them.