### PR TITLE
Updates Cell Drain/Charge Effects to use get_cell()

### DIFF
--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -335,4 +335,5 @@
 	return
 
 /obj/machinery/recharge_station/get_cell()
-	return occupant.get_cell()
+	if(occupant)
+		return occupant.get_cell()

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -333,3 +333,6 @@
 	var/mob/living/silicon/robot/R = AM
 	mob_enter(R)
 	return
+
+/obj/machinery/recharge_station/get_cell()
+	return occupant.get_cell()

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_cellcharge.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_cellcharge.dm
@@ -5,43 +5,45 @@
 	var/next_message
 
 /datum/artifact_effect/cellcharge/DoEffectTouch(var/mob/user)
-	if(isrobot(user))
-		var/mob/living/silicon/robot/R = user
-		if(R.cell)
-			R.cell.charge += rand() * 100
-			to_chat(R, "<span class='notice'>SYSTEM ALERT: Large energy boost detected!</span>")
+	var/obj/item/weapon/cell/target_cell = user.get_cell()
+	if(target_cell)
+		if(isrobot(user) && (world.time >= next_message))
+			to_chat(user, "<span class='notice'>SYSTEM ALERT: Large energy boost detected!</span>")
+		target_cell.charge += rand() * 100
+		if(target_cell.charge > target_cell.maxcharge)
+			target_cell.charge = target_cell.maxcharge
 		if(world.time >= next_message)
 			next_message = world.time + 50
-		return 1
+		return TRUE
 
 /datum/artifact_effect/cellcharge/DoEffectAura()
 	if(holder)
-		for(var/obj/machinery/power/apc/C in range(effectrange, holder))
-			if(C.cell)
-				C.cell.charge += 25
+		for(var/atom/movable/C in range(effectrange, holder))
+			var/obj/item/weapon/cell/target_cell = C.get_cell()
+			if(target_cell)	
+				if(isrobot(C) && (world.time >= next_message))
+					to_chat(C, "<span class='notice'>SYSTEM ALERT: Energy boost detected!</span>")
+				target_cell.charge += 25
+				if(target_cell.charge > target_cell.maxcharge)
+					target_cell.charge = target_cell.maxcharge
 		for(var/obj/machinery/power/battery/S in range(effectrange, holder))
 			S.charge += 25
-		for(var/mob/living/silicon/robot/M in mob_list)
-			if(M.cell)
-				M.cell.charge += 25
-				if(world.time >= next_message)
-					to_chat(M, "<span class='notice'>SYSTEM ALERT: Energy boost detected!</span>")
 		if(world.time >= next_message)
 			next_message = world.time + 300
-		return 1
+		return TRUE
 
 /datum/artifact_effect/cellcharge/DoEffectPulse()
 	if(holder)
-		for(var/obj/machinery/power/apc/C in range(effectrange, holder))
-			if(C.cell)
-				C.cell.charge += rand() * 100
+		for(var/atom/movable/C in range(effectrange, holder))
+			var/obj/item/weapon/cell/target_cell = C.get_cell()
+			if(target_cell)	
+				if(isrobot(C) && (world.time >= next_message))
+					to_chat(C, "<span class='notice'>SYSTEM ALERT: Large energy boost detected!</span>")
+				target_cell.charge += rand() * 100
+				if(target_cell.charge > target_cell.maxcharge)
+					target_cell.charge = target_cell.maxcharge
 		for(var/obj/machinery/power/battery/S in range(effectrange, holder))
 			S.charge += rand() * 100
-		for(var/mob/living/silicon/robot/M in mob_list)
-			if(M.cell)
-				M.cell.charge += rand() * 100
-				if(world.time >= next_message)
-					to_chat(M, "<span class='notice'>SYSTEM ALERT: Large energy boost detected!</span>")
 		if(world.time >= next_message)
 			next_message = world.time + 300
-		return 1
+		return TRUE

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_celldrain.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_celldrain.dm
@@ -7,43 +7,39 @@
 	var/next_message
 
 /datum/artifact_effect/celldrain/DoEffectTouch(var/mob/user)
-	if(isrobot(user))
-		var/mob/living/silicon/robot/R = user
-		if(R.cell)
-			R.cell.charge = max(R.cell.charge - rand() * 100, 0)
-			to_chat(R, "<span class='danger'>SYSTEM ALERT: Large energy drain detected!</span>")
+	var/obj/item/weapon/cell/target_cell = user.get_cell()
+	if(target_cell)
+		if(isrobot(user) && (world.time >= next_message))
+			to_chat(user, "<span class='notice'>SYSTEM ALERT: Large energy drain detected!</span>")
+		target_cell.charge = max(target_cell.charge - rand() * 100, 0)
 		if(world.time >= next_message)
 			next_message = world.time + 50
-		return 1
+		return TRUE
 
 /datum/artifact_effect/celldrain/DoEffectAura()
 	if(holder)
-		for(var/obj/machinery/power/apc/C in range(effectrange, holder))
-			if(C.cell)
-				C.cell.charge = max(C.cell.charge - 50, 0)
+		for(var/atom/movable/C in range(effectrange, holder))
+			var/obj/item/weapon/cell/target_cell = C.get_cell()
+			if(target_cell)	
+				if(isrobot(C) && (world.time >= next_message))
+					to_chat(C, "<span class='notice'>SYSTEM ALERT: Energy drain detected!</span>")
+				target_cell.charge = max(target_cell.charge - 50, 0)
 		for(var/obj/machinery/power/battery/S in range(effectrange, holder))
 			S.charge = max(S.charge - 50, 0)
-		for(var/mob/living/silicon/robot/M in mob_list)
-			if(M.cell)
-				M.cell.charge = max(M.cell.charge - 50, 0)
-				if(world.time >= next_message)
-					to_chat(M, "<span class='warning'>SYSTEM ALERT: Energy drain detected!</span>")
 		if(world.time >= next_message)
 			next_message = world.time + 300
-		return 1
+		return TRUE
 
 /datum/artifact_effect/celldrain/DoEffectPulse()
 	if(holder)
-		for(var/obj/machinery/power/apc/C in range(effectrange, holder))
-			if(C.cell)
-				C.cell.charge = max(C.cell.charge - rand() * 100, 0)
+		for(var/atom/movable/C in range(effectrange, holder))
+			var/obj/item/weapon/cell/target_cell = C.get_cell()
+			if(target_cell)	
+				if(isrobot(C) && (world.time >= next_message))
+					to_chat(C, "<span class='notice'>SYSTEM ALERT: Large energy drain detected!</span>")
+				target_cell.charge = max(target_cell.charge - rand() * 100, 0)
 		for(var/obj/machinery/power/battery/S in range(effectrange, holder))
 			S.charge = max(S.charge - rand() * 100, 0)
-		for(var/mob/living/silicon/robot/M in mob_list)
-			if(M.cell)
-				M.cell.charge = max(M.cell.charge - rand() * 100, 0)
-				if(world.time >= next_message)
-					to_chat(M, "<span class='danger'>SYSTEM ALERT: Large energy drain detected!</span>")
 		if(world.time >= next_message)
 			next_message = world.time + 300
-		return 1
+		return TRUE


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/17928298/47620599-969e3600-daca-11e8-8a27-fb09cababa0c.png)

:cl:
 * tweak: Cell drain/charge artifacts now work with almost everything cell-powered as long it's on their range and not inside containers/mobs(unless it's the mob's internal cell).
 * bugfix: Fixed cell drain/charge artifacts working on all cyborgs in the world.
 * bugfix: Fixed cell drain/charge artifacts charging things beyond the max charge.