### PR TITLE
Replaces mass specs in the protolathe with reagent scanners.

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -482,13 +482,14 @@ Subject's pulse: ??? BPM"})
 	var/details = 0
 	var/recent_fail = 0
 
-/obj/item/device/reagent_scanner/preattack(atom/O, mob/user)
-	if(!user.Adjacent(O))
+/obj/item/device/reagent_scanner/preattack(atom/O, mob/user, proximity_flag)
+	if(!proximity_flag)
 		return
 	if(!user.dexterity_check())
 		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
 		return
 	if(O.reagents)
+		playsound(user, 'sound/items/healthanalyzer.ogg', 50, 1)
 		var/dat = ""
 		if(O.reagents.reagent_list.len)
 			for(var/datum/reagent/R in O.reagents.reagent_list)

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -482,11 +482,8 @@ Subject's pulse: ??? BPM"})
 	var/details = 0
 	var/recent_fail = 0
 
-/obj/item/device/reagent_scanner/afterattack(obj/O, mob/user as mob)
-	. = ..()
-	if(.)
-		return
-	if(!istype(O)) //Wrong type sent
+/obj/item/device/reagent_scanner/preattack(atom/O, mob/user)
+	if(!O.Adjacent(user))
 		return
 	if(!user.dexterity_check())
 		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
@@ -501,8 +498,9 @@ Subject's pulse: ??? BPM"})
 			to_chat(user, "<span class='notice'>Chemicals found in \the [O]:[dat]</span>")
 		else
 			to_chat(user, "<span class='notice'>No active chemical agents found in \the [O].</span>")
-
-	return
+		return TRUE
+	else
+		..()
 
 /obj/item/device/reagent_scanner/adv
 	name = "advanced reagent scanner"

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -483,7 +483,7 @@ Subject's pulse: ??? BPM"})
 	var/recent_fail = 0
 
 /obj/item/device/reagent_scanner/preattack(atom/O, mob/user)
-	if(!O.Adjacent(user))
+	if(!user.Adjacent(O))
 		return
 	if(!user.dexterity_check())
 		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
@@ -500,7 +500,7 @@ Subject's pulse: ??? BPM"})
 			to_chat(user, "<span class='notice'>No active chemical agents found in \the [O].</span>")
 		return TRUE
 	else
-		..()
+		return ..()
 
 /obj/item/device/reagent_scanner/adv
 	name = "advanced reagent scanner"

--- a/code/modules/research/designs/medical.dm
+++ b/code/modules/research/designs/medical.dm
@@ -38,17 +38,16 @@
 	category = "Medical"
 	build_path = /obj/item/stack/medical/advanced/ointment
 
-/datum/design/mass_spectrometer
-	name = "Mass-Spectrometer"
-	desc = "A device for analyzing chemicals in the blood."
-	id = "mass_spectrometer"
-	req_tech = list(Tc_BIOTECH = 2, Tc_MAGNETS = 2)
+/datum/design/adv_reagent_scanner
+	name = "Advanced Reagent Scanner"
+	desc = "A hand-held reagent scanner which identifies chemical agents."
+	id = "adv_mass_spectrometer"
+	req_tech = list(Tc_BIOTECH = 2, Tc_MAGNETS = 4)
 	build_type = PROTOLATHE
 	materials = list(MAT_IRON = 30, MAT_GLASS = 20)
-	reliability_base = 76
 	category = "Medical"
-	build_path = /obj/item/device/mass_spectrometer
-
+	build_path = /obj/item/device/reagent_scanner/adv
+/*
 /datum/design/adv_mass_spectrometer
 	name = "Advanced Mass-Spectrometer"
 	desc = "A device for analyzing chemicals in the blood and their quantities."
@@ -59,7 +58,7 @@
 	reliability_base = 74
 	category = "Medical"
 	build_path = /obj/item/device/mass_spectrometer/adv
-
+*/
 /datum/design/defibrillator
 	name = "Defibrillator"
 	desc = "A handheld emergency defibrillator, used to bring people back from the brink of death or put them there."


### PR DESCRIPTION
[tweak]
Mostly does what the title says. The mass spec is pretty limited to what it can read from and several people who play medbay often said they wanted this. Also a small behavior change to reagent scanners so they don't smash carbons when you try to use one on someone. <h1>Here's a BIG IF TRUE. Carbons can hold reagents(WOW) and thus can be scanned with a reagent scanner.</h1>

:cl:
* tweak: Replaced mass spectrometers with general reagent scanners in the protolathe. They function the same but can scan more containers.
* bugfix: Reagent scanners can properly scan carbons now.