### PR TITLE
Pipes can be seen even in darkness when ventcrawling

### DIFF
--- a/code/_onclick/ventcrawl.dm
+++ b/code/_onclick/ventcrawl.dm
@@ -211,8 +211,8 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 	for(var/datum/pipeline/pipeline in network.line_members)
 		for(var/obj/machinery/atmospherics/A in (pipeline.members || pipeline.edges))
 			if(!A.pipe_image)
-				A.pipe_image = image(A, A.loc, layer = BELOW_PROJECTILE_LAYER, dir = A.dir) //the 20 puts it above Byond's darkness (not its opacity view)
-				A.pipe_image.plane = EFFECTS_PLANE
+				A.pipe_image = image(A, A.loc, layer = ABOVE_LIGHTING_LAYER, dir = A.dir)
+				A.pipe_image.plane = LIGHTING_PLANE
 			pipes_shown += A.pipe_image
 			client.images += A.pipe_image
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6307265/47710326-d2eca600-dc32-11e8-9f0a-5e5806137d72.png)

Intended as a QoL thing. I'm not sure if there's any other implication to doing this.

:cl:
 * tweak: When vent-crawling, pipes that are part of the network you're inside of can now be seen even in darkness.