### PR TITLE
Removes the PDA from Syndicate Cyborgs

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_subtypes/syndicate.dm
+++ b/code/modules/mob/living/silicon/robot/robot_subtypes/syndicate.dm
@@ -23,6 +23,9 @@
 		holochip = new /obj/item/clothing/accessory/holomap_chip/syndicate_robot(src)
 		holochip.equipped(src)
 
+/mob/living/silicon/robot/syndie/setup_PDA()
+	return
+
 /mob/living/silicon/robot/syndie/blitz/New()
 	..()
 	pick_module(SYNDIE_BLITZ_MODULE)


### PR DESCRIPTION
Can you IMAGINE grabbing yoru PDA to prank the mime and then noticing a **Syndicate Blitzkrieg Cyborg** in the list?