### PR TITLE
Fixes steal blueprints objective

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -13,7 +13,7 @@
 		pick(
 			/obj/item/weapon/storage/backpack/industrial,
 			/obj/item/weapon/storage/backpack/satchel_eng),
-		/obj/item/blueprints,
+		/obj/item/blueprints/primary,
 		/obj/item/clothing/under/rank/chief_engineer,
 		/obj/item/clothing/head/hardhat/white,
 		/obj/item/clothing/head/welding,


### PR DESCRIPTION
Seems that when somebody added custom blueprints, they didn't add the new chief engineer only subtype to his closet.
