### PR TITLE
Girders are easier to destroy with explosions

### DIFF
--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -322,7 +322,7 @@
 				qdel(src) //No scraps
 			return
 		if(2.0)
-			if(prob(30))
+			if(prob(50))
 				if(state == 2)
 					state = 1
 					update_icon()


### PR DESCRIPTION
\>pulse beam a wall
\>instantly destroyed
\>pulse beam a girder 5 times
\>nothing happens

:cl:
 * tweak: Girders are now more easily destroyed by explosions and pulse lasers.