### PR TITLE
Fixes Posibrain emotes.

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -33,7 +33,7 @@
 
 /datum/emote/proc/run_emote(mob/user, params, type_override, ignore_status = FALSE)
 	. = TRUE
-	if(!can_run_emote(user, !ignore_status)) // ignore_status == TRUE means that status_check should be FALSE and vise-versa
+	if(!(type_override) && !(can_run_emote(user, !ignore_status))) // ignore_status == TRUE means that status_check should be FALSE and vise-versa
 		return FALSE
 	var/msg = select_message_type(user)
 	if(params && message_param)

--- a/code/modules/mob/living/carbon/brain/emote.dm
+++ b/code/modules/mob/living/carbon/brain/emote.dm
@@ -1,4 +1,3 @@
-
 /datum/emote/brain
 	mob_type_allowed_typelist = list(/mob/living/carbon/brain)
 	mob_type_blacklist_typelist = list()
@@ -8,6 +7,13 @@
 	var/mob/living/carbon/brain/B = user
 	if(!istype(B) || (!(B.container && istype(B.container, /obj/item/device/mmi))))
 		return FALSE
+
+/datum/emote/brain/run_emote(mob/user, params, type_override, ignore_status = FALSE)
+	var/mob/living/carbon/brain/B = user
+	if (istype(B) && isrobot(B.container.loc))
+		var/mob/living/silicon/robot/R = B.container.loc
+		return run_emote(R, params, TRUE, ignore_status)
+	return ..()
 
 /datum/emote/brain/alarm
 	key = "alarm"


### PR DESCRIPTION
[tested][oversight]

Fixes #20037.
This was the intended behaviour ; prior to emote datums, brain had a snowflake way to handle emotes when within a container.
