### PR TITLE
Tasing and shooting borgs temporarily slows them down: episode 2

### DIFF
--- a/__DEFINES/silicon.dm
+++ b/__DEFINES/silicon.dm
@@ -105,3 +105,9 @@ var/global/list/all_robot_modules = default_nanotrasen_robot_modules + emergency
 #define SILICON_MOBILITY_MODULE_SPEED_MODIFIER 0.75 //Silicon's speed var is multiplied by the mobility module modifier
 #define SILICON_VTEC_SPEED_BONUS 0.25 //But the VTEC Bonus is ADDED to their movement_speed_modifier
 
+#define SILICON_TASER_SLOWDOWN_DURATION 18 SECONDS
+#define SILICON_TASER_SLOWDOWN_MULTIPLIER 4
+
+#define SILICON_HIGH_DAMAGE_SLOWDOWN_THRESHOLD 30
+#define SILICON_HIGH_DAMAGE_SLOWDOWN_DURATION 3 SECONDS
+#define SILICON_HIGH_DAMAGE_SLOWDOWN_MULTIPLIER SILICON_TASER_SLOWDOWN_MULTIPLIER

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -99,6 +99,9 @@
 	var/list/req_access = list(access_robotics) //Access needed to open cover
 	var/list/robot_access = list(access_ai_upload, access_robotics, access_maint_tunnels, access_external_airlocks) //Our current access
 
+	var/last_tase_timeofday
+	var/last_high_damage_taken_timeofday
+
 /mob/living/silicon/robot/New(loc, var/unfinished = FALSE)
 	ident = rand(1, 999)
 	updatename(modtype)
@@ -459,17 +462,21 @@
 /mob/living/silicon/robot/bullet_act(var/obj/item/projectile/Proj)
 	..(Proj)
 	updatehealth()
+	if(istype(Proj, /obj/item/projectile/energy/electrode))
+		last_tase_timeofday = world.timeofday
+		if(can_diagnose())
+			to_chat(src, "<span class='alert' style=\"font-family:Courier\">Warning: Actuators overloaded.</span>")
+	if(Proj.damage >= SILICON_HIGH_DAMAGE_SLOWDOWN_THRESHOLD)
+		last_high_damage_taken_timeofday = world.timeofday
 	if(prob(75) && Proj.damage > 0)
 		spark(src, 5, FALSE)
 	return 2
 
-	
 /mob/living/silicon/robot/emp_act(severity)
 	..()
 	if(prob(50/severity))
 		modulelock_time = rand(10,60)
 		modulelock = TRUE
-	
 
 /mob/living/silicon/robot/triggerAlarm(var/class, area/A, var/O, var/alarmsource)
 	if(isDead())
@@ -1311,7 +1318,7 @@
 
 /mob/living/silicon/robot/get_cell()
 	return cell
-	
+
 /mob/living/silicon/robot/proc/toggle_modulelock()
 	modulelock = !modulelock
 	return modulelock

--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -22,6 +22,11 @@
 /mob/living/silicon/robot/movement_tally_multiplier()
 	. = ..()
 	if(is_component_functioning("power cell") && cell)
+		var/timeofday = world.timeofday
+		if((timeofday - last_tase_timeofday) < SILICON_TASER_SLOWDOWN_DURATION)
+			. *= SILICON_TASER_SLOWDOWN_MULTIPLIER
+		if((timeofday - last_high_damage_taken_timeofday) < SILICON_HIGH_DAMAGE_SLOWDOWN_DURATION)
+			. *= SILICON_HIGH_DAMAGE_SLOWDOWN_MULTIPLIER
 		if(module_active && istype(module_active,/obj/item/borg/combat/mobility))
 			. *= SILICON_MOBILITY_MODULE_SPEED_MODIFIER
 		if(cell.charge <= 0)


### PR DESCRIPTION
#20035 but:
- less magic numbers
- no spawn()
- more defines
- multiple hits refresh the duration (but still don't stack)

:cl:
 * rscadd: Shooting a silicon with a taser now slows them down for ~18 seconds.
 * rscadd: Shooting a silicon with a high-powered weapon slows them down for ~3 seconds.