### PR TITLE
Replaces the seed requirement for a poppy pretzel

### DIFF
--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -325,7 +325,7 @@
 /datum/recipe/poppypretzel
 	reagents = list(FLOUR = 5)
 	items = list(
-		/obj/item/seeds/poppyseed,
+		/obj/item/weapon/reagent_containers/food/snacks/grown/poppy,
 		/obj/item/weapon/reagent_containers/food/snacks/egg,
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/poppypretzel


### PR DESCRIPTION
As currently every method of extracting seeds from the poppy results in just /obj/item/seeds with the poppy seed datum, whereas the recipe looks specifically for the poppyseed subtype.

Enjoy eating flower pretzels

closes #20445