### PR TITLE
Health deficiency doesn't immediately slow you down

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -649,6 +649,11 @@
 		if(. > 1 && reagents.has_any_reagents(list(HYPERZINE,COCAINE)))
 			. = max(1, .*0.4)//we don't hyperzine to make us move faster than the base speed, unless we were already faster.
 
+/mob/living/carbon/proc/health_deficiency_movement_tally()
+	var/health_deficiency = (maxHealth - health - halloss)
+	if(health_deficiency >= (maxHealth * 0.4))
+		return (health_deficiency / (maxHealth * 0.25))
+
 /mob/living/carbon/base_movement_tally()
 	. = ..()
 	if(flying)
@@ -659,9 +664,7 @@
 		return // Space ignores slowdown
 
 	if(feels_pain() && !has_painkillers())
-		var/health_deficiency = (maxHealth - health - halloss)
-		if(health_deficiency >= (maxHealth * 0.4))
-			. += (health_deficiency / (maxHealth * 0.25))
+		. += health_deficiency_movement_tally()
 
 
 /mob/living/carbon/proc/can_mind_interact(var/mob/M)

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -4,6 +4,9 @@
 			return min(..(), 1)
 	return ..()
 
+/mob/living/carbon/human/health_deficiency_movement_tally()
+
+
 /mob/living/carbon/human/base_movement_tally()
 	. = ..()
 
@@ -28,8 +31,7 @@
 		. += 2*undergoing_hypothermia()
 
 	if(feels_pain() && !has_painkillers())
-		if(pain_shock_stage >= 50)
-			. += 3
+		. += pain_shock_stage/50
 		var/list/limbs_to_check
 		var/multiplier = 1
 		if(!lying)


### PR DESCRIPTION
**Before:**
\>get shot with laser
\>instantly slowed down to a crawl, unable to react
**Now:**
\>get shot with laser
\>no noticeable slowdown is applied immediately
\>over time, you slow down according to how much pain you're feeling - painkillers can prevent this

:cl:
 * tweak: Humanoids are no longer instantly slowed down by damage. Instead, the amount of pain felt determines the amount of slowdown.
