### PR TITLE
Yet more hostile mob door opening fixes

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1074,7 +1074,6 @@ About the new airlock wires panel:
 		if(arePowerSystemsOn() && !(stat & NOPOWER))
 			if(level_of_door_opening < 2)
 				return
-			visible_message("<span class = 'warning'>\The [M] forces \the [src] [density?"open":"closed"]!</span>")
 			if(M.client)
 				density ? open(1):close(1)
 			else if(density)
@@ -1084,6 +1083,7 @@ About the new airlock wires panel:
 				density ? open(1):close(1)
 			else if(density)
 				open(1)
+		visible_message("<span class = 'warning'>\The [M] forces \the [src] [density?"closed":"open"]!</span>")
 
 
 //You can ALWAYS screwdriver a door. Period. Well, at least you can even if it's open

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -168,7 +168,7 @@
 					return 1
 		if((environment_smash_flags & OPEN_DOOR_STRONG) && istype(the_target, /obj/machinery/door/airlock))
 			var/obj/machinery/door/airlock/A = the_target
-			if(!A.density || A.operating)
+			if(!A.density || A.operating || A.locked || A.welded)
 				return 0
 			return 1
 	return 0
@@ -389,7 +389,7 @@
 				if(is_type_in_list(A, destructible_objects) && Adjacent(A))
 					if(istype(A, /obj/machinery/door/airlock))
 						var/obj/machinery/door/airlock/AIR = A
-						if(AIR.density)
+						if(!AIR.density || AIR.locked || AIR.welded || AIR.operating)
 							continue
 					UnarmedAttack(A)
 	return


### PR DESCRIPTION
Fixes a bug where mobs would get stuck trying to open bolted doors

Fixes a bug where, after having opened a door, they would try to close it again straight after thanks to DestroySurroundings

Fixes a bug where it says you opened a door, despite not being succesful

closes #20540
