### PR TITLE
Removes the encouragement for admins to recall the shuttle.

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -544,7 +544,7 @@ var/global/ports_open = TRUE
 	if(!justification)
 		justification = "#??!7E/_1$*/ARR-CON�FAIL!!*$^?" //Can happen for reasons, let's deal with it IC
 	log_game("[key_name(user)] has called the shuttle. Justification given : '[justification]'")
-	message_admins("[key_name_admin(user)] has called the shuttle. Justification given : '[justification]'. You are encouraged to act if that justification is shit", 1)
+	message_admins("[key_name_admin(user)] has called the shuttle. Justification given : '[justification]'.", 1)
 	captain_announce("The emergency shuttle has been called. It will arrive in [round(emergency_shuttle.timeleft()/60)] minutes. Justification : '[justification]'")
 	world << sound('sound/AI/shuttlecalled.ogg')
 


### PR DESCRIPTION
Controversial as it may, I believe this only encourages unwanted extended because someone vaguely worded their shuttle call despite the fact that there is a plasma flood/a murderboning antag/etc, etc.

Admins can still do it if they feel like it so it's purely symbolic anyways.