### PR TITLE
Can now load an orebox onto the gigadrill

### DIFF
--- a/code/game/objects/structures/vehicles/gigadrill.dm
+++ b/code/game/objects/structures/vehicles/gigadrill.dm
@@ -11,6 +11,13 @@
 	keytype = /obj/item/key/gigadrill
 	wreckage_type = /obj/effect/decal/mecha_wreckage/vehicle/gigadrill
 	var/turf/drilling_turf
+	var/obj/structure/ore_box/OB //The orebox contained within
+
+/obj/structure/bed/chair/vehicle/gigadrill/destroy()
+	if(OB)
+		OB.forceMove(get_turf(src))
+		OB = null
+	..()
 
 /obj/structure/bed/chair/vehicle/gigadrill/buckle_mob(mob/M, mob/user)
   ..()
@@ -63,6 +70,51 @@
 				if(prob(50))
 					M.artifact_debris()
 		M.GetDrilled()
+		if(OB)
+			var/count = 0
+			for(var/obj/item/weapon/ore/ore in range(src,1))
+				if(get_dir(src,ore)&dir && ore.material)
+					OB.materials.addAmount(ore.material,1)
+					returnToPool(ore)
+					count++
+			if(count)
+				to_chat(occupant,"<font color='blue'>[count] ore successfully loaded into cargo compartment.</font>")
+
+/obj/structure/bed/chair/vehicle/gigadrill/MouseDropTo(atom/movable/O as mob|obj, mob/user as mob)
+	..()
+	if(OB || !istype(O, /obj/structure/ore_box))
+		return
+	if(O.loc == user || !isturf(O.loc) || !isturf(user.loc) || !user.Adjacent(O)) //no you can't pull things out of your ass
+		return
+	if(user.incapacitated() || user.lying) //are you cuffed, dying, lying, stunned or other
+		return
+	if(!Adjacent(user) || !user.Adjacent(src) || user.contents.Find(src)) // is the mob too far away from you, or are you too far away from the source
+		return
+
+	to_chat(user, "<span class = 'notice'>You load \the [O] onto \the [src].</span>")
+	O.forceMove(src)
+	OB = O
+
+/obj/structure/bed/chair/vehicle/gigadrill/MouseDropFrom(over_object, src_location, var/turf/over_location, src_control, over_control, params)
+	..()
+	if(!OB)
+		return
+	if(!ishigherbeing(usr) && !isrobot(usr) || usr.incapacitated() || usr.lying)
+		return
+	if(!istype(over_location) || over_location.density)
+		return
+	if(!Adjacent(over_location))
+		return
+	if((!Adjacent(usr) || !usr.Adjacent(over_location)))
+		return
+	for(var/atom/movable/A in over_location.contents)
+		if(A.density)
+			if((A == src) || istype(A, /mob))
+				continue
+			return
+	to_chat(usr, "<span class = 'notice'>You offload \the [OB]</span>")
+	OB.forceMove(over_location)
+	OB = null
 
 /obj/effect/decal/mecha_wreckage/vehicle/gigadrill
 	// TODO: SPRITE PLS

--- a/code/game/objects/structures/vehicles/gigadrill.dm
+++ b/code/game/objects/structures/vehicles/gigadrill.dm
@@ -13,7 +13,7 @@
 	var/turf/drilling_turf
 	var/obj/structure/ore_box/OB //The orebox contained within
 
-/obj/structure/bed/chair/vehicle/gigadrill/destroy()
+/obj/structure/bed/chair/vehicle/gigadrill/Destroy()
 	if(OB)
 		OB.forceMove(get_turf(src))
 		OB = null


### PR DESCRIPTION
Suggested by a random miner when I asked if they wanted anything added to mining.

Can now drag an ore box onto the gigadrill, where when you mine it autoloads resources into the ore box.

Drag off to offload the ore box.

🆑 
 * rscadd: You can now load an orebox onto the gigadrill so it collects resources as you mine with it. Offload the orebox by clickdragging to a nearby turf.