### PR TITLE
Makes drilling mechs automatically defuse gibtonite

### DIFF
--- a/code/game/mecha/equipment/tools/tools.dm
+++ b/code/game/mecha/equipment/tools/tools.dm
@@ -169,7 +169,7 @@
 		if(do_after_cooldown(target, 1/MECHDRILL_ROCK_SPEED) && C == chassis.loc && src == chassis.selected)
 			for(var/turf/unsimulated/mineral/M in range(chassis,1))
 				if(get_dir(chassis,M)&chassis.dir)
-					M.GetDrilled()
+					M.GetDrilled(safety_override = TRUE, driller = src)
 			log_message("Drilled through [target]")
 			if(istype(chassis, /obj/mecha/working))
 				var/obj/mecha/working/W = chassis


### PR DESCRIPTION
Closes #7765

Effectively solves every issue listed there.  Ripleys and whatever uses the exosuit drill will now drill the gibtonite like normal, except it will be instantly defused when the turf is mined.

Note that if you want to collect gibtonite ore with a mech, you'll need to get out and pick it up manually because gibtonite isn't actually a child of ore.

[qol]
:cl:
 * tweak: Mining mechs will now automatically defuse gibtonite when mining gibtonite deposits.