### PR TITLE
Fixed crew records ID generation

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -51,7 +51,7 @@
 		if(job && job.no_crew_manifest)
 			return
 
-		var/id = add_zero(num2hex(rand(1, 1.6777215E7)), 6)	//this was the best they could come up with? A large random number? *sigh*
+		var/id = num2hex(rand(1, 1.6777215E7), 6)	//this was the best they could come up with? A large random number? *sigh*
 
 
 		//General Record

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -402,7 +402,7 @@ What a mess.*/
 			if ("New Record (General)")
 				var/datum/data/record/G = new /datum/data/record()
 				G.fields["name"] = "New Record"
-				G.fields["id"] = text("[]", add_zero(num2hex(rand(1, 1.6777215E7)), 6))
+				G.fields["id"] = num2hex(rand(1, 1.6777215E7), 6)
 				G.fields["rank"] = "Unassigned"
 				G.fields["real_rank"] = "Unassigned"
 				G.fields["sex"] = "Male"


### PR DESCRIPTION
It relied on the old broken num2hex, resulting in all IDs being in the form 0000XX rather than XXXXXX.