### PR TITLE
Fixes an href exploit with uplinks.

### DIFF
--- a/code/game/objects/items/devices/uplinks.dm
+++ b/code/game/objects/items/devices/uplinks.dm
@@ -111,6 +111,11 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 
 /obj/item/device/uplink/Topic(href, href_list)
 	..()
+
+	if (!is_holder_of(usr, src))
+		message_admins("[usr] tried to access [src], an unlocked PDA, despite not being its holder.")
+		return FALSE
+
 	if(!active)
 		return
 


### PR DESCRIPTION
[exploitable][byond]
You needed to copypaste `byond:///?src=[HREF_OF_UPLINK_HERE];buy_item=Stealthy+and+Inconspicuous+Weapons:1;` to use the other guy's PDA through a distance.
Thanks, Topic(), and @HarseTheef for bringing this up

