### PR TITLE
Properly fixes the fabricator problem

### DIFF
--- a/code/datums/statistics/stat_helpers.dm
+++ b/code/datums/statistics/stat_helpers.dm
@@ -13,10 +13,11 @@
 			break
 	if(!server)
 		return
-	for(var/datum/tech/T in tech_list)
+	for(var/ID in tech_list)
+		var/datum/tech/T = tech_list[ID]
 		if(T.goal_level==0) // Ignore illegal tech, etc
 			continue
-		var/datum/tech/KT  = locate(T.type, server.files.known_tech)
+		var/datum/tech/KT = server.files.GetKTechByID(ID)
 		tech_level_total += KT.level
 	return tech_level_total
 

--- a/code/game/jobs/job_objectives/science.dm
+++ b/code/game/jobs/job_objectives/science.dm
@@ -19,7 +19,8 @@
 		// This was just used for testing.
 //		to_chat(world, "UNABLE TO FIND A GODDAMN RND SERVER. FUCK.")
 		return
-	for(var/datum/tech/T in tech_list)
+	for(var/ID in tech_list)
+		var/datum/tech/T = tech_list[ID]
 		if(T.goal_level==0) // Ignore illegal tech, etc
 			continue
 		var/datum/tech/KT  = locate(T.type, server.files.known_tech)

--- a/code/modules/research/fabricators.dm
+++ b/code/modules/research/fabricators.dm
@@ -429,8 +429,8 @@
 	var/datum/tech/T = files.known_tech["materials"]
 	if(T && T.level > 1)
 		var/pmat = 0//Calculations to make up for the fact that these parts and tech modify the same thing
-		for(var/obj/item/weapon/stock_parts/micro_laser/Ml in component_parts)
-			pmat += Ml.rating - 1
+		for(var/obj/item/weapon/stock_parts/manipulator/Ma in component_parts)
+			pmat += Ma.rating - 1
 		diff = round(initial(resource_coeff) - (initial(resource_coeff)*(T.level+(pmat*3)))/25,0.01)
 		if(resource_coeff!=diff)
 			resource_coeff = diff
@@ -438,8 +438,8 @@
 	T = files.known_tech["programming"]
 	if(T && T.level > 1)
 		var/ptime = 0
-		for(var/obj/item/weapon/stock_parts/manipulator/Ma in component_parts)
-			ptime += Ma.rating - 1
+		for(var/obj/item/weapon/stock_parts/micro_laser/Ml in component_parts)
+			ptime += Ml.rating - 1
 		diff = round(initial(time_coeff) - (initial(time_coeff)*(T.level+(ptime*5)))/25,0.1)
 		if(time_coeff!=diff)
 			time_coeff = diff
@@ -468,7 +468,7 @@
 				files.AddDesign2Known(D)
 		files.RefreshResearch()
 		var/i = src.convert_designs()
-		var/tech_output = update_tech() //apparently this has never worked
+		var/tech_output = update_tech()
 		if(!silent)
 			temp = "Processed [i] equipment designs.<br>"
 			temp += tech_output

--- a/code/modules/research/fabricators.dm
+++ b/code/modules/research/fabricators.dm
@@ -62,14 +62,16 @@
 	max_material_storage = (initial(max_material_storage)+(T * 187500))
 
 	T = 0
+	var/datum/tech/Tech = files.known_tech["materials"]
 	for(var/obj/item/weapon/stock_parts/manipulator/Ma in component_parts)
 		T += Ma.rating - 1
-	resource_coeff = round(initial(resource_coeff) - (initial(resource_coeff)*(T * 3))/25,0.01)
+	resource_coeff = round(initial(resource_coeff) - (initial(resource_coeff)*(Tech.level+(T * 3)))/25,0.01)
 
 	T = 0
+	Tech = files.known_tech["programming"]
 	for(var/obj/item/weapon/stock_parts/micro_laser/Ml in component_parts)
 		T += Ml.rating - 1
-	time_coeff = round(initial(time_coeff) - (initial(time_coeff)*(T * 5))/25,0.01)
+	time_coeff = round(initial(time_coeff) - (initial(time_coeff)*(Tech.level+(T * 5)))/25,0.01)
 
 /obj/machinery/r_n_d/fabricator/emag()
 	sleep()
@@ -242,7 +244,7 @@
 			update_buffer_size()
 
 	return 1
-	
+
 /obj/machinery/r_n_d/fabricator/proc/has_bluespace_bin()
 	var/I = /obj/item/weapon/stock_parts/matter_bin/adv/super/bluespace/
 	//return (I in component_parts)
@@ -252,10 +254,10 @@
 /obj/machinery/r_n_d/fabricator/proc/bluespace_materials(var/datum/design/part)
 	if(!has_bluespace_bin())
 		return 0
-		
+
 	for (var/obj/machinery/r_n_d/fabricator/gibmats in machines)
 		if(gibmats.has_bluespace_bin())
-			for(var/gib in part.materials)	
+			for(var/gib in part.materials)
 				if (gibmats.check_mat(part,gib) && !src.check_mat(part,gib))//they have what we need && we don't need more
 					if(copytext(gib,1,2) == "$" && !(research_flags & IGNORE_MATS))
 						var/bluespaceamount = src.get_resource_cost_w_coeff(part, gib)
@@ -263,7 +265,7 @@
 						src.materials.addAmount(gib,bluespaceamount)
 	return remove_materials(part)
 
-	
+
 /obj/machinery/r_n_d/fabricator/proc/check_mat(var/datum/design/being_built, var/M)
 	if(copytext(M,1,2) == "$")
 		if(src.research_flags & IGNORE_MATS)
@@ -423,30 +425,25 @@
 	if(!files)
 		return
 	var/output
-	for(var/datum/tech/T in files.known_tech)
-		if(T && T.level > 1)
-			var/diff
-			switch(T.id) //bad, bad formulas
-				if("materials")
-					var/pmat = 0//Calculations to make up for the fact that these parts and tech modify the same thing
-					for(var/obj/item/weapon/stock_parts/micro_laser/Ml in component_parts)
-						pmat += Ml.rating
-					if(pmat >= 1)
-						pmat -= 1//So the equations don't have to be reworked, upgrading a single part from T1 to T2 is == to 1 tech level
-					diff = round(initial(resource_coeff) - (initial(resource_coeff)*(T.level+pmat))/25,0.01)
-					if(resource_coeff!=diff)
-						resource_coeff = diff
-						output+="Production efficiency increased.<br>"
-				if("programming")
-					var/ptime = 0
-					for(var/obj/item/weapon/stock_parts/manipulator/Ma in component_parts)
-						ptime += Ma.rating
-					if(ptime >= 2)
-						ptime -= 2
-					diff = round(initial(time_coeff) - (initial(time_coeff)*(T.level+ptime))/25,0.1)
-					if(time_coeff!=diff)
-						time_coeff = diff
-						output+="Production routines updated.<br>"
+	var/diff
+	var/datum/tech/T = files.known_tech["materials"]
+	if(T && T.level > 1)
+		var/pmat = 0//Calculations to make up for the fact that these parts and tech modify the same thing
+		for(var/obj/item/weapon/stock_parts/micro_laser/Ml in component_parts)
+			pmat += Ml.rating - 1
+		diff = round(initial(resource_coeff) - (initial(resource_coeff)*(T.level+(pmat*3)))/25,0.01)
+		if(resource_coeff!=diff)
+			resource_coeff = diff
+			output+="Production efficiency increased.<br>"
+	T = files.known_tech["programming"]
+	if(T && T.level > 1)
+		var/ptime = 0
+		for(var/obj/item/weapon/stock_parts/manipulator/Ma in component_parts)
+			ptime += Ma.rating - 1
+		diff = round(initial(time_coeff) - (initial(time_coeff)*(T.level+(ptime*5)))/25,0.1)
+		if(time_coeff!=diff)
+			time_coeff = diff
+			output+="Production routines updated.<br>"
 	return output
 
 
@@ -462,7 +459,8 @@
 	else
 		src.visible_message("[bicon(src)] <b>[src]</b> beeps, \"Not connected to a server. Please connect from a local console first.\"")
 	if(console)
-		for(var/datum/tech/T in console.files.known_tech)
+		for(var/ID in console.files.known_tech)
+			var/datum/tech/T = console.files.known_tech[ID]
 			if(T)
 				files.AddTech2Known(T)
 		for(var/datum/design/D in console.files.known_designs)
@@ -470,13 +468,13 @@
 				files.AddDesign2Known(D)
 		files.RefreshResearch()
 		var/i = src.convert_designs()
-		//var/tech_output = update_tech() //apparently this has never worked
+		var/tech_output = update_tech() //apparently this has never worked
 		if(!silent)
 			temp = "Processed [i] equipment designs.<br>"
-			//temp += tech_output
+			temp += tech_output
 			temp += "<a href='?src=\ref[src];clear_temp=1'>Return</a>"
 			src.updateUsrDialog()
-		if(i)
+		if(i || tech_output)
 			new_data=1
 	if(new_data)
 		src.visible_message("[bicon(src)] <b>[src]</b> beeps, \"Successfully synchronized with R&D server. New data processed.\"")

--- a/code/modules/research/mechanic/reverse_engine.dm
+++ b/code/modules/research/mechanic/reverse_engine.dm
@@ -120,7 +120,8 @@
 		//message_admins("We have a techlist and a linked_console")
 		for(var/checktech in techlist)
 			//message_admins("Looking at [checktech] with value of [techlist[checktech]]")
-			for(var/datum/tech/pointed_tech in tech_list) //if we find that technology
+			for(var/ID in tech_list) //if we find that technology
+				var/datum/tech/pointed_tech = tech_list[ID]
 				if(pointed_tech.id == checktech)
 					if(techlist[checktech] > pointed_tech.level) //if the machine board's research level is higher than the one on the console
 						//message_admins("Found a difference of [techlist[checktech] - pointed_tech.level]")

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -110,7 +110,8 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 
 /obj/machinery/computer/rdconsole/proc/Maximize()
 	files.known_tech = tech_list.Copy()
-	for(var/datum/tech/KT in files.known_tech)
+	for(var/ID in files.known_tech)
+		var/datum/tech/KT = files.known_tech[ID]
 		if(KT.level < KT.max_level)
 			KT.level=KT.max_level
 
@@ -175,7 +176,8 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 //Have it automatically push research to the centcomm server so wild griffins can't fuck up R&D's work --NEO
 /obj/machinery/computer/rdconsole/proc/griefProtection()
 	for(var/obj/machinery/r_n_d/server/centcom/C in machines)
-		for(var/datum/tech/T in files.known_tech)
+		for(var/ID in files.known_tech)
+			var/datum/tech/T = files.known_tech[ID]
 			C.files.AddTech2Known(T)
 		for(var/datum/design/D in files.known_designs)
 			C.files.AddDesign2Known(D)
@@ -332,7 +334,8 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 		screen = 1.0
 
 	else if(href_list["copy_tech"]) //Copys some technology data from the research holder to the disk.
-		for(var/datum/tech/T in files.known_tech)
+		for(var/ID in files.known_tech)
+			var/datum/tech/T = files.known_tech[ID]
 			if(href_list["copy_tech_ID"] == T.id)
 				t_disk.stored = T
 				break
@@ -402,14 +405,16 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 						if(S.disabled)
 							continue
 						if((id in S.id_with_upload) || istype(S, /obj/machinery/r_n_d/server/centcom))
-							for(var/datum/tech/T in files.known_tech)
+							for(var/ID in files.known_tech)
+								var/datum/tech/T = files.known_tech[ID]
 								S.files.AddTech2Known(T)
 							for(var/datum/design/D in files.known_designs)
 								S.files.AddDesign2Known(D)
 							S.files.RefreshResearch()
 							server_processed = 1
 						if(((id in S.id_with_download) && !istype(S, /obj/machinery/r_n_d/server/centcom)) || S.hacked)
-							for(var/datum/tech/T in S.files.known_tech)
+							for(var/ID in S.files.known_tech)
+								var/datum/tech/T = S.files.known_tech[ID]
 								files.AddTech2Known(T)
 							for(var/datum/design/D in S.files.known_designs)
 								files.AddDesign2Known(D)
@@ -718,8 +723,8 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 
 		if(1.1) //Research viewer
 			dat += "Current Research Levels:<BR><BR>"
-			for(var/datum/tech/T in files.known_tech)
-
+			for(var/ID in files.known_tech)
+				var/datum/tech/T = files.known_tech[ID]
 				dat += {"[T.name]<BR>
 					* Level: [T.level]<BR>
 					* Summary: [T.desc]<HR>"}
@@ -750,8 +755,8 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			dat += {"<BR><A href='?src=\ref[src];menu=1.0'>Main Menu</A> ||
 				<A href='?src=\ref[src];menu=1.2'>Return to Disk Operations</A><HR>
 				Load Technology to Disk:<BR><BR>"}
-			for(var/datum/tech/T in files.known_tech)
-
+			for(var/ID in files.known_tech)
+				var/datum/tech/T = files.known_tech[ID]
 				dat += {"[T.name]
 					<A href='?src=\ref[src];copy_tech=1;copy_tech_ID=[T.id]'>(Copy to Disk)</A><BR>"}
 		if(1.4) //Design Disk menu.

--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -10,7 +10,7 @@ but it is possible to add tech to the game that DON'T start in it (example: Xeno
 with these since they should be the default version of the datums. They're actually stored in a list rather then using typesof to
 refer to them since it makes it a bit easier to search through them for specific information.
 - know_tech is the companion list to possible_tech. It's the tech you can actually research and improve. Until it's added to this
-list, it can't be improved. All the tech in this list are visible to the player.
+list, it can't be improved. All the tech in this list are visible to the player. Formatted as known_tech[tech.id] = tech
 - possible_designs is functionally identical to possbile_tech except it's for /datum/design.
 - known_designs is functionally identical to known_tech except it's for /datum/design
 
@@ -58,8 +58,9 @@ var/global/list/hidden_tech = list(
 
 /datum/research/New()		//Insert techs into possible_tech here. Known_tech automatically updated.
 	if(!tech_list.len)
-		for(var/T in typesof(/datum/tech) - hidden_tech)
-			tech_list += new T()
+		for(var/inst in typesof(/datum/tech) - hidden_tech)
+			var/datum/tech/T = new inst()
+			tech_list[T.id] = T
 	if(!design_list.len)
 		for(var/D in typesof(/datum/design) - /datum/design)
 			design_list += new D()
@@ -74,14 +75,20 @@ var/global/list/hidden_tech = list(
 		return 1
 	var/matches = 0
 	for(var/req in T.req_tech)
-		for(var/datum/tech/known in known_tech)
-			if((req == known.id) && (known.level >= T.req_tech[req]))
-				matches++
-				break
+		var/datum/tech/known = GetKTechByID(req)
+		if(known && (known.level >= T.req_tech[req]))
+			matches++
+			break
 	if(matches == T.req_tech.len)
 		return 1
 	else
 		return 0
+
+
+/datum/research/proc/GetKTechByID(var/id)
+	if(known_tech[id])
+		return known_tech[id]
+
 
 //Checks to see if design has all the required pre-reqs.
 //Input: datum/design; Output: 0/1 (false/true)
@@ -90,7 +97,8 @@ var/global/list/hidden_tech = list(
 		return 1
 	var/matches = 0
 	var/list/k_tech = list()
-	for(var/datum/tech/known in known_tech)
+	for(var/ID in known_tech)
+		var/datum/tech/known = known_tech[ID]
 		k_tech[known.id] = known.level
 	for(var/req in D.req_tech)
 		if(!isnull(k_tech[req]) && k_tech[req] >= D.req_tech[req])
@@ -99,32 +107,16 @@ var/global/list/hidden_tech = list(
 		return 1
 	else
 		return 0
-/*
-//Checks to see if design has all the required pre-reqs.
-//Input: datum/design; Output: 0/1 (false/true)
-/datum/research/proc/DesignHasReqs(var/datum/design/D)
-	if(D.req_tech.len == 0)
-		return 1
-	var/matches = 0
-	for(var/req in D.req_tech)
-		for(var/datum/tech/known in known_tech)
-			if((req == known.id) && (known.level >= D.req_tech[req]))
-				matches++
-				break
-	if(matches == D.req_tech.len)
-		return 1
-	else
-		return 0
-*/
+
 //Adds a tech to known_tech list. Checks to make sure there aren't duplicates and updates existing tech's levels if needed.
 //Input: datum/tech; Output: Null
 /datum/research/proc/AddTech2Known(var/datum/tech/T)
-	for(var/datum/tech/known in known_tech)
-		if(T.id == known.id)
-			if(T.level > known.level)
-				known.level = T.level
-			return 1
-	known_tech += T
+	var/datum/tech/known = GetKTechByID(T.id)
+	if(known)
+		if(T.level > known.level)
+			known.level = T.level
+		return 1
+	known_tech[T.id] = T
 	return 2
 
 /datum/research/proc/AddDesign2Known(var/datum/design/D)
@@ -140,14 +132,16 @@ var/global/list/hidden_tech = list(
 //Refreshes known_tech and known_designs list. Then updates the reliability vars of the designs in the known_designs list.
 //Input/Output: n/a
 /datum/research/proc/RefreshResearch()
-	for(var/datum/tech/PT in tech_list)
+	for(var/ID in tech_list)
+		var/datum/tech/PT = tech_list[ID]
 		if(TechHasReqs(PT))
 			AddTech2Known(PT)
 	for(var/datum/design/PD in design_list)
 		if(DesignHasReqs(PD))
 			AddDesign2Known(PD)
-	for(var/datum/tech/T in known_tech)
-		T = Clamp(T.level, 1, 20)
+	for(var/ID in known_tech)
+		var/datum/tech/T = known_tech[ID]
+		T.level = Clamp(T.level, 1, 20)
 	for(var/datum/design/D in known_designs)
 		D.CalcReliability(known_tech)
 	return
@@ -155,10 +149,9 @@ var/global/list/hidden_tech = list(
 //Refreshes the levels of a given tech.
 //Input: Tech's ID and Level; Output: null
 /datum/research/proc/UpdateTech(var/ID, var/level)
-	for(var/datum/tech/KT in known_tech)
-		if(KT.id == ID)
-			if(KT.level <= level)
-				KT.level = max((KT.level + 1), (level - 1))
+	var/datum/tech/KT = GetKTechByID(ID)
+	if(KT && KT.level <= level)
+		KT.level = max((KT.level + 1), (level - 1))
 	return
 
 /datum/research/proc/UpdateDesign(var/path)

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -67,7 +67,8 @@
 		griefProtection() //I dont like putting this in process() but it's the best I can do without re-writing a chunk of rd servers.
 		files.known_designs = list()
 		var/changed=0
-		for(var/datum/tech/T in files.known_tech)
+		for(var/ID in files.known_tech)
+			var/datum/tech/T = files.known_tech[ID]
 			if(prob(1))
 				T.level = 0 // This never happens, so make it dramatic. T.level--
 				changed=1
@@ -101,7 +102,8 @@
 //Backup files to centcomm to help admins recover data after greifer attacks
 /obj/machinery/r_n_d/server/proc/griefProtection()
 	for(var/obj/machinery/r_n_d/server/centcom/C in machines)
-		for(var/datum/tech/T in files.known_tech)
+		for(var/ID in files.known_tech)
+			var/datum/tech/T = files.known_tech[ID]
 			C.files.AddTech2Known(T)
 		for(var/datum/design/D in files.known_designs)
 			C.files.AddDesign2Known(D)
@@ -215,10 +217,8 @@
 	else if(href_list["reset_tech"])
 		var/choice = alert("Technology Data Rest", "Are you sure you want to reset this technology to its default data? Data lost cannot be recovered.", "Continue", "Cancel")
 		if(choice == "Continue")
-			for(var/datum/tech/T in temp_server.files.known_tech)
-				if(T.id == href_list["reset_tech"])
-					T.level = 1
-					break
+			var/datum/tech/T = temp_server.files.GetKTechByID(href_list["reset_tech"])
+			T.level = 1
 		temp_server.files.RefreshResearch()
 
 	else if(href_list["reset_design"])
@@ -280,8 +280,8 @@
 
 			dat += {"[temp_server.name] Data Management<BR><BR>
 				Known Technologies<BR>"}
-			for(var/datum/tech/T in temp_server.files.known_tech)
-
+			for(var/ID in temp_server.files.known_tech)
+				var/datum/tech/T = temp_server.files.known_tech[ID]
 				dat += {"* [T.name]
 					<A href='?src=\ref[src];reset_tech=[T.id]'>(Reset)</A><BR>"} //FYI, these are all strings
 			dat += "Known Designs<BR>"


### PR DESCRIPTION
Rips the bandaid off that is #20302 and properly sutures the wounds of #18356, #20087

closes #18356
closes #20087

 - Moves research's tech level stuff to a list by reference. Reference being the ID. All this so you don't need to loop through EVERY.FREAKING.RESEARCH.OBJECT to find the one you want.
 - Actually fixes the issue where syncing research and updating the internal components were using different math.

:cl:
 * bugfix: Fabricators now take research into account when refreshing internal components