### PR TITLE
Preferences subsection datums, new organ menu

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -265,7 +265,7 @@ var/const/MAX_SAVE_SLOTS = 8
 	<b>Secondary Language:</b> <a href='byond://?src=\ref[user];preference=language;task=input'>[language]</a><br>
 	<b>Skin Tone:</b> <a href='?_src_=prefs;preference=s_tone;task=input'>[species == "Human" ? "[-s_tone + 35]/220" : "[s_tone]"]</a><br><BR>
 	<b>Handicaps:</b> <a href='byond://?src=\ref[user];task=input;preference=disabilities'>Set</a><br>
-	<b>Limbs:</b> <a href='byond://?src=\ref[user];preference=limbs;task=input'>Set</a><br>
+	<b>Limbs:</b> <a href='byond://?_src_=prefs;subsection=limbs;task=menu'>Set</a><br>
 	<b>Organs:</b> <a href='byond://?_src_=prefs;subsection=organs;task=menu'>Set</a><br>
 	<b>Underwear:</b> [gender == MALE ? "<a href ='?_src_=prefs;preference=underwear;task=input'>[underwear_m[underwear]]</a>" : "<a href ='?_src_=prefs;preference=underwear;task=input'>[underwear_f[underwear]]</a>"]<br>
 	<b>Backpack:</b> <a href ='?_src_=prefs;preference=bag;task=input'>[backbaglist[backbag]]</a><br>
@@ -1276,83 +1276,6 @@ NOTE:  The change will take effect AFTER any current recruiting periods."}
 
 				if("flavor_text")
 					flavor_text = input(user,"Set the flavor text in your 'examine' verb. This can also be used for OOC notes and preferences!","Flavor Text",html_decode(flavor_text)) as message
-
-				if("limbs")
-					var/list/limb_input = list(
-						"Left Leg [organ_data[LIMB_LEFT_LEG]]" = LIMB_LEFT_LEG,
-						"Right Leg [organ_data[LIMB_RIGHT_LEG]]" = LIMB_RIGHT_LEG,
-						"Left Arm [organ_data[LIMB_LEFT_ARM]]" = LIMB_LEFT_ARM,
-						"Right Arm [organ_data[LIMB_RIGHT_ARM]]" = LIMB_RIGHT_ARM,
-						"Left Foot [organ_data[LIMB_LEFT_FOOT]]" = LIMB_LEFT_FOOT,
-						"Right Foot [organ_data[LIMB_RIGHT_FOOT]]" = LIMB_RIGHT_FOOT,
-						"Left Hand [organ_data[LIMB_LEFT_HAND]]" = LIMB_LEFT_HAND,
-						"Right Hand [organ_data[LIMB_RIGHT_HAND]]" = LIMB_RIGHT_HAND
-						)
-
-					var/limb_name = input(user, "Which limb do you want to change?") as null|anything in limb_input
-					if(!limb_name)
-						return
-
-					var/limb = null
-					var/second_limb = null // if you try to change the arm, the hand should also change
-					var/third_limb = null  // if you try to unchange the hand, the arm should also change
-					var/valid_limb_states=list("Normal","Amputated","Prothesis")
-					switch(limb_input[limb_name])
-						if(LIMB_LEFT_LEG)
-							limb = LIMB_LEFT_LEG
-							second_limb = LIMB_LEFT_FOOT
-							valid_limb_states += "Peg Leg"
-						if(LIMB_RIGHT_LEG)
-							limb = LIMB_RIGHT_LEG
-							second_limb = LIMB_RIGHT_FOOT
-							valid_limb_states += "Peg Leg"
-						if(LIMB_LEFT_ARM)
-							limb = LIMB_LEFT_ARM
-							second_limb = LIMB_LEFT_HAND
-							valid_limb_states += "Wooden Prosthesis"
-						if(LIMB_RIGHT_ARM)
-							limb = LIMB_RIGHT_ARM
-							second_limb = LIMB_RIGHT_HAND
-							valid_limb_states += "Wooden Prosthesis"
-						if(LIMB_LEFT_FOOT)
-							limb = LIMB_LEFT_FOOT
-							third_limb = LIMB_LEFT_LEG
-						if(LIMB_RIGHT_FOOT)
-							limb = LIMB_RIGHT_FOOT
-							third_limb = LIMB_RIGHT_LEG
-						if(LIMB_LEFT_HAND)
-							limb = LIMB_LEFT_HAND
-							third_limb = LIMB_LEFT_ARM
-							valid_limb_states += "Hook Prosthesis"
-						if(LIMB_RIGHT_HAND)
-							limb = LIMB_RIGHT_HAND
-							third_limb = LIMB_RIGHT_ARM
-							valid_limb_states += "Hook Prosthesis"
-
-					var/new_state = input(user, "What state do you wish the limb to be in?") as null|anything in valid_limb_states
-					if(!new_state)
-						return
-
-					switch(new_state)
-						if("Normal")
-							organ_data[limb] = null
-							if(third_limb)
-								organ_data[third_limb] = null
-						if("Amputated")
-							organ_data[limb] = "amputated"
-							if(second_limb)
-								organ_data[second_limb] = "amputated"
-						if("Prothesis")
-							organ_data[limb] = "cyborg"
-							if(second_limb)
-								organ_data[second_limb] = "cyborg"
-						if("Peg Leg","Wooden Prosthesis","Hook Prosthesis")
-							organ_data[limb] = "peg"
-							if(second_limb)
-								if(limb == LIMB_LEFT_ARM || limb == LIMB_RIGHT_ARM)
-									organ_data[second_limb] = "peg"
-								else
-									organ_data[second_limb] = "amputated"
 
 				if("skin_style")
 					var/skin_style_name = input(user, "Select a new skin style") as null|anything in list("default1", "default2", "default3")

--- a/code/modules/client/preferences/subsections.dm
+++ b/code/modules/client/preferences/subsections.dm
@@ -1,0 +1,30 @@
+/*
+# What is this?
+Datums that handle specific sub-sections of the preferences menu.
+# How do I use it?
+Define a /datum/preferences_subsection.
+Specify the subsections your datum handles in `registered_paths`.
+Handle your links by overriding /process_link() - return TRUE if you handled the link successfully.
+*/
+
+/datum/preferences/proc/init_subsections()
+	subsections = list()
+	for(var/subsection_path in subtypesof(/datum/preferences_subsection))
+		var/datum/preferences_subsection/new_subsection = new subsection_path(src)
+		for(var/registered_path in new_subsection.registered_paths)
+			subsections[registered_path] = new_subsection
+
+/datum/preferences_subsection
+	var/datum/preferences/prefs
+	var/list/registered_paths
+
+/datum/preferences_subsection/New(var/datum/preferences/prefs)
+	..()
+	src.prefs = prefs
+
+/datum/preferences_subsection/Destroy()
+	prefs = null
+	..()
+
+/datum/preferences_subsection/proc/process_link(var/mob/user, var/list/href_list)
+	return FALSE

--- a/code/modules/client/preferences/subsections/limbs.dm
+++ b/code/modules/client/preferences/subsections/limbs.dm
@@ -1,0 +1,154 @@
+#define LIMB_MODE_AFFECT_CHILD 1
+#define LIMB_MODE_AFFECT_PARENT 2
+#define LIMB_MODE_SPECIAL_SNOWFLAKE 3
+
+/datum/preferences_subsection/limbs
+	registered_paths = list("limbs")
+	var/static/list/default_configurable_states = list(
+		"Normal" = list(
+			"internal_name" = null,
+			"mode" = LIMB_MODE_AFFECT_PARENT,
+		),
+		"Amputated" = list(
+			"internal_name" = "amputated",
+			"mode" = LIMB_MODE_AFFECT_CHILD,
+		),
+		"Prosthesis" = list(
+			"internal_name" = "cyborg",
+			"mode" = LIMB_MODE_AFFECT_CHILD,
+		)
+	)
+
+	var/static/list/peg_limb_data = list(
+		"internal_name" = "peg",
+		"mode" = LIMB_MODE_SPECIAL_SNOWFLAKE,
+	)
+
+	var/static/list/leg_configurable_states = list(
+		"Peg leg" = peg_limb_data,
+	)
+	var/static/list/arm_configurable_states = list(
+		"Wooden prosthesis" = peg_limb_data,
+	)
+	var/static/list/hand_configurable_states = list(
+		"Hook prosthesis" = peg_limb_data,
+	)
+	var/static/list/configurable_limbs = list(
+		"Left arm" = list(
+			"internal_name" = LIMB_LEFT_ARM,
+			"extra_states" = arm_configurable_states,
+			"child_limb" = LIMB_LEFT_HAND,
+		),
+		"Left hand" = list(
+			"internal_name" = LIMB_LEFT_HAND,
+			"extra_states" = hand_configurable_states,
+			"parent_limb" = LIMB_LEFT_ARM,
+		),
+		"Right arm" = list(
+			"internal_name" = LIMB_RIGHT_ARM,
+			"extra_states" = arm_configurable_states,
+			"child_limb" = LIMB_RIGHT_HAND,
+		),
+		"Right hand" = list(
+			"internal_name" = LIMB_RIGHT_HAND,
+			"extra_states" = hand_configurable_states,
+			"parent_limb" = LIMB_RIGHT_ARM,
+		),
+		"Left leg" = list(
+			"internal_name" = LIMB_LEFT_LEG,
+			"extra_states" = leg_configurable_states,
+			"child_limb" = LIMB_LEFT_FOOT,
+		),
+		"Left foot" = list(
+			"internal_name" = LIMB_LEFT_FOOT,
+			"parent_limb" = LIMB_LEFT_ARM,
+		),
+		"Right leg" = list(
+			"internal_name" = LIMB_RIGHT_LEG,
+			"extra_states" = leg_configurable_states,
+			"child_limb" = LIMB_RIGHT_FOOT,
+		),
+		"Right foot" = list(
+			"internal_name" = LIMB_RIGHT_FOOT,
+			"parent_limb" = LIMB_RIGHT_LEG,
+		),
+	)
+
+/datum/preferences_subsection/limbs/proc/show_menu(var/mob/user, var/list/href_list)
+	var/dat = list()
+	for(var/limb_english_name in configurable_limbs)
+		var/entry_data = configurable_limbs[limb_english_name]
+		var/limb_internal_name = entry_data["internal_name"]
+		var/list/extra_states = entry_data["extra_states"]
+		var/list/states = extra_states ? default_configurable_states + extra_states : default_configurable_states
+		dat += "<span style='display: inline-block; width: 100px;'>[limb_english_name]:</span>"
+		for(var/english_state_name in states)
+			dat += "&nbsp;"
+			var/internal_state_name = states[english_state_name]["internal_name"]
+			if(prefs.organ_data[limb_internal_name] == internal_state_name)
+				dat += "[english_state_name]"
+			else
+				dat += "<a href='?_src_=prefs;subsection=limbs;task=input;target_limb=[limb_english_name];target_state=[english_state_name]'>[english_state_name]</a>"
+		dat += "<br>"
+	dat = jointext(dat, null)
+
+	var/datum/browser/popup = new(user, "\ref[src]-limbs", "Limbs", 500, 220)
+	popup.set_content(dat)
+	popup.open(use_onclose = FALSE)
+	return TRUE
+
+/datum/preferences_subsection/limbs/proc/handle_input(var/mob/user, var/list/href_list)
+	var/target_limb = href_list["target_limb"]
+	ASSERT(target_limb)
+	var/target_state = href_list["target_state"]
+	ASSERT(target_state)
+
+	var/list/configurable_limb_data = configurable_limbs[target_limb]
+	ASSERT(configurable_limb_data)
+
+	var/limb_internal_name = configurable_limb_data["internal_name"]
+	ASSERT(limb_internal_name)
+
+	var/list/extra_states = configurable_limb_data["extra_states"]
+	var/list/valid_states = extra_states ? default_configurable_states + extra_states : default_configurable_states
+
+	var/state_data = valid_states[target_state]
+	ASSERT(state_data)
+
+	var/limb_internal_state = state_data["internal_name"]
+
+	prefs.organ_data[limb_internal_name] = limb_internal_state
+
+	switch(state_data["mode"])
+		if(LIMB_MODE_AFFECT_CHILD)
+			var/child_limb = configurable_limb_data["child_limb"]
+			if(child_limb)
+				prefs.organ_data[child_limb] = limb_internal_state
+		if(LIMB_MODE_AFFECT_PARENT)
+			var/parent_limb = configurable_limb_data["parent_limb"]
+			if(parent_limb)
+				prefs.organ_data[parent_limb] = limb_internal_state
+		if(LIMB_MODE_SPECIAL_SNOWFLAKE) // this is so sad
+			var/child_limb = configurable_limb_data["child_limb"]
+			if(child_limb)
+				if(limb_internal_name == LIMB_LEFT_ARM || limb_internal_name == LIMB_RIGHT_ARM)
+					prefs.organ_data[child_limb] = "peg"
+				else
+					prefs.organ_data[child_limb] = "amputated"
+
+	return TRUE
+
+/datum/preferences_subsection/limbs/process_link(var/mob/user, var/list/href_list)
+	var/task = href_list["task"]
+	switch(task)
+		if("menu")
+			return show_menu(arglist(args))
+		if("input")
+			. = handle_input(arglist(args))
+			show_menu(arglist(args))
+		else
+			CRASH("Unknown task: [task]")
+
+#undef LIMB_MODE_AFFECT_CHILD
+#undef LIMB_MODE_AFFECT_PARENT
+#undef LIMB_MODE_SPECIAL_SNOWFLAKE

--- a/code/modules/client/preferences/subsections/organs.dm
+++ b/code/modules/client/preferences/subsections/organs.dm
@@ -1,0 +1,73 @@
+/datum/preferences_subsection/organs
+	registered_paths = list("organs")
+	var/static/list/default_configurable_states = list(
+		"Normal" = null,
+		"Assisted" = "assisted",
+		"Mechanical" = "mechanical",
+	)
+	var/static/list/configurable_organs = list(
+		"Heart" = list(
+			"internal_name" = "heart",
+		),
+		"Eyes" = list(
+			"internal_name" = "eyes",
+		),
+		"Lungs" = list(
+			"internal_name" = "lungs",
+		),
+		"Liver" = list(
+			"internal_name" = "liver",
+		),
+		"Kidneys" = list(
+			"internal_name" = "kidneys",
+		)
+	)
+
+/datum/preferences_subsection/organs/proc/show_menu(var/mob/user, var/list/href_list)
+	var/dat = list()
+	for(var/english_organ_name in configurable_organs)
+		var/entry_data = configurable_organs[english_organ_name]
+		var/internal_organ_name = entry_data["internal_name"]
+		var/states = entry_data["states"] || default_configurable_states
+		dat += "<span style='display: inline-block; width: 100px;'>[english_organ_name]:</span>"
+		for(var/english_state_name in states)
+			dat += "&nbsp;"
+			var/internal_state_name = states[english_state_name]
+			if(prefs.organ_data[internal_organ_name] == internal_state_name)
+				dat += "[english_state_name]"
+			else
+				dat += "<a href='?_src_=prefs;subsection=organs;task=input;target_organ=[english_organ_name];target_state=[english_state_name]'>[english_state_name]</a>"
+		dat += "<br>"
+	dat = jointext(dat, null)
+
+	var/datum/browser/popup = new(user, "\ref[src]-organs", "Organs", 330, 200)
+	popup.set_content(dat)
+	popup.open(use_onclose = FALSE)
+	return TRUE
+
+/datum/preferences_subsection/organs/proc/handle_input(var/mob/user, var/list/href_list)
+	var/target_organ = href_list["target_organ"]
+	ASSERT(target_organ)
+	var/target_state = href_list["target_state"]
+	ASSERT(target_state)
+
+	var/list/configurable_organ_data = configurable_organs[target_organ]
+	ASSERT(configurable_organ_data)
+
+	var/organ_internal_name = configurable_organ_data["internal_name"]
+	ASSERT(organ_internal_name)
+
+	var/list/valid_states = configurable_organ_data["states"] || default_configurable_states
+	ASSERT(target_state in valid_states)
+	var/organ_internal_state = valid_states[target_state]
+
+	prefs.organ_data[organ_internal_name] = organ_internal_state
+	return TRUE
+
+/datum/preferences_subsection/organs/process_link(var/mob/user, var/list/href_list)
+	var/task = href_list["task"]
+	if(task == "menu")
+		. = show_menu(arglist(args))
+	else if(task == "input")
+		. = handle_input(arglist(args))
+		show_menu(arglist(args))

--- a/code/modules/client/preferences/subsections/organs.dm
+++ b/code/modules/client/preferences/subsections/organs.dm
@@ -66,8 +66,11 @@
 
 /datum/preferences_subsection/organs/process_link(var/mob/user, var/list/href_list)
 	var/task = href_list["task"]
-	if(task == "menu")
-		. = show_menu(arglist(args))
-	else if(task == "input")
-		. = handle_input(arglist(args))
-		show_menu(arglist(args))
+	switch(task)
+		if("menu")
+			return show_menu(arglist(args))
+		if("input")
+			. = handle_input(arglist(args))
+			show_menu(arglist(args))
+		else
+			CRASH("Unknown task: [task]")

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -1223,6 +1223,8 @@
 #include "code\modules\client\edge_sliding\keystate\1constants.dm"
 #include "code\modules\client\edge_sliding\keystate\1definitions.dm"
 #include "code\modules\client\edge_sliding\keystate\KeyState.dm"
+#include "code\modules\client\preferences\subsections.dm"
+#include "code\modules\client\preferences\subsections\organs.dm"
 #include "code\modules\clothing\clothing.dm"
 #include "code\modules\clothing\accessories\accessory.dm"
 #include "code\modules\clothing\accessories\armband.dm"


### PR DESCRIPTION
- Added a system to organize preferences without messing with a huge 2000-lines switch case
- Used said system to improve the organ configuration menu (it used to be a series of `input()`s that didn't even remember your current choices, yikes.)
![image](https://user-images.githubusercontent.com/6307265/48072909-da392400-e1dd-11e8-9243-4e0e770ba58b.png)
- Also remade the limbs menu
![image](https://user-images.githubusercontent.com/6307265/48081421-4de42c80-e1f0-11e8-8904-ed14959339e7.png)
The logic is still disgusting and so is the code, but hey, at least it's neatly separated in its own file.
