### PR TITLE
Adds a basic chemistry supply pack

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1612,6 +1612,24 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	containername = "blood donation drive crate"
 	group = "Medical"
 
+/datum/supply_packs/chemkit
+	name = "Basic chemistry kit"
+	contains = list(/obj/item/weapon/reagent_containers/glass/beaker,
+					/obj/item/weapon/reagent_containers/glass/beaker,
+					/obj/item/weapon/reagent_containers/glass/bottle/carbon,
+					/obj/item/weapon/reagent_containers/glass/bottle/silicon,
+					/obj/item/weapon/reagent_containers/glass/bottle/sugar,
+					/obj/item/weapon/reagent_containers/glass/bottle/oxygen,
+					/obj/item/weapon/reagent_containers/glass/bottle/hydrogen,
+					/obj/item/weapon/reagent_containers/glass/bottle/nitrogen,
+					/obj/item/weapon/reagent_containers/glass/bottle/potassium,
+					/obj/item/weapon/reagent_containers/dropper)
+	cost = 80
+	containertype = /obj/structure/closet/crate/medical
+	containername = "basic chemistry kit"
+	group = "Medical"
+
+
 /datum/supply_packs/wheelchair
 	name = "Wheelchair"
 	contains = list(/obj/structure/bed/chair/vehicle/wheelchair)

--- a/code/modules/reagents/reagent_containers/glass/bottle.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle.dm
@@ -407,9 +407,9 @@
 	New()
 		..()
 		reagents.add_reagent(BICARODYNE, 30)
-		
+
 /obj/item/weapon/reagent_containers/glass/bottle/hypozine
-	
+
 
 /obj/item/weapon/reagent_containers/glass/bottle/hypozine/New()
 	..()
@@ -487,3 +487,31 @@
 /obj/item/weapon/reagent_containers/glass/bottle/bleach/New()
 	..()
 	reagents.add_reagent(BLEACH, 15)
+
+/obj/item/weapon/reagent_containers/glass/bottle/carbon/New()
+	..()
+	reagents.add_reagent(CARBON, 30)
+
+/obj/item/weapon/reagent_containers/glass/bottle/silicon/New()
+	..()
+	reagents.add_reagent(SILICON, 30)
+
+/obj/item/weapon/reagent_containers/glass/bottle/sugar/New()
+	..()
+	reagents.add_reagent(SUGAR, 30)
+
+/obj/item/weapon/reagent_containers/glass/bottle/oxygen/New()
+	..()
+	reagents.add_reagent(OXYGEN, 30)
+
+/obj/item/weapon/reagent_containers/glass/bottle/hydrogen/New()
+	..()
+	reagents.add_reagent(HYDROGEN, 30)
+
+/obj/item/weapon/reagent_containers/glass/bottle/nitrogen/New()
+	..()
+	reagents.add_reagent(NITROGEN, 30)
+
+/obj/item/weapon/reagent_containers/glass/bottle/potassium/New()
+	..()
+	reagents.add_reagent(POTASSIUM, 30)


### PR DESCRIPTION
For when chemistry dispensers are not available

:cl:
 * rscadd: You can now purchase a basic chemistry kit from cargo. Containing basic elements, some beakers, and a dropper.