### PR TITLE
Recruitment runtime removal

### DIFF
--- a/code/datums/recruiter.dm
+++ b/code/datums/recruiter.dm
@@ -63,7 +63,8 @@
 		O = pick(currently_querying)
 		while(currently_querying.len && !check_observer(O)) //While we the list has something and
 			currently_querying -= O				//Remove them from the list if they don't get checked properly
-			O = pick(currently_querying)
+			if(currently_querying.len)
+				O = pick(currently_querying)
 
 		if(!check_observer(O))
 			INVOKE_EVENT(recruited, list("player"=null))


### PR DESCRIPTION
Objects were being removed from a list, and then a pick was being called without checking if the list still had contents.