### PR TITLE
These are (what I believe) to be causing server crashes

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult_mobs_and_constructs.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_mobs_and_constructs.dm
@@ -6,7 +6,7 @@
 	icon_dead = "juggernaut2"
 	construct_spells = list(
 		/spell/aoe_turf/conjure/forcewall/greater,
-		/spell/juggerdash,
+		//spell/juggerdash,
 		)
 	see_in_dark = 7
 	var/dash_dir = null

--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -63,7 +63,7 @@
 	rockets.pixel_y = -64 * PIXEL_MULTIPLIER
 	intrinsic_spells = list(
 							new /spell/mech/marauder/thrusters(src),
-							new /spell/mech/marauder/dash(src),
+							//new /spell/mech/marauder/dash(src),
 							new /spell/mech/marauder/smoke(src),
 							new /spell/mech/marauder/zoom(src)
 						)


### PR DESCRIPTION
They both were pretty high in the CPU usage, and have both been attributed to server crashes, and they both use the same function (throw the thing in a direction)

Until the issue is further diagnosed and treated, we'll see how we do without these spells.
