### PR TITLE
Un-removes Juggernaut/Marauder dash, and "properly" fixes server-crashing bug, and also several related minor bugs

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult_mobs_and_constructs.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_mobs_and_constructs.dm
@@ -6,7 +6,7 @@
 	icon_dead = "juggernaut2"
 	construct_spells = list(
 		/spell/aoe_turf/conjure/forcewall/greater,
-		//spell/juggerdash,
+		/spell/juggerdash,
 		)
 	see_in_dark = 7
 	var/dash_dir = null

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_mobs_and_constructs.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_mobs_and_constructs.dm
@@ -26,10 +26,7 @@
 		else if(istype(obstacle, /obj/structure/grille/))
 			var/obj/structure/grille/G = obstacle
 			G.health = (0.25*initial(G.health))
-			G.broken = 1
-			G.icon_state = "[initial(G.icon_state)]-b"
-			G.setDensity(FALSE)
-			getFromPool(/obj/item/stack/rods, get_turf(G.loc))
+			G.healthcheck()
 			breakthrough = 1
 
 		else if(istype(obstacle, /obj/structure/table))

--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -63,7 +63,7 @@
 	rockets.pixel_y = -64 * PIXEL_MULTIPLIER
 	intrinsic_spells = list(
 							new /spell/mech/marauder/thrusters(src),
-							//new /spell/mech/marauder/dash(src),
+							new /spell/mech/marauder/dash(src),
 							new /spell/mech/marauder/smoke(src),
 							new /spell/mech/marauder/zoom(src)
 						)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -432,10 +432,7 @@
 		else if(istype(obstacle, /obj/structure/grille/))
 			var/obj/structure/grille/G = obstacle
 			G.health = (0.25*initial(G.health))
-			G.broken = 1
-			G.icon_state = "[initial(G.icon_state)]-b"
-			G.setDensity(FALSE)
-			getFromPool(/obj/item/stack/rods, get_turf(G.loc))
+			G.healthcheck()
 			breakthrough = 1
 
 		else if(istype(obstacle, /obj/structure/table))

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -34,7 +34,7 @@
 		icon_state = "[initial(icon_state)]-b"
 		setDensity(FALSE) //Not blocking anything anymore
 		new grille_material(get_turf(src)) //One rod set
-	else if(health >= (0.25*initial(health)) && broken) //Repair the damage to this bitch
+	else if(health > (0.25*initial(health)) && broken) //Repair the damage to this bitch
 		broken = 0
 		icon_state = initial(icon_state)
 		setDensity(TRUE)

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -295,7 +295,7 @@
 /obj/structure/grille/cult/Cross(atom/movable/mover, turf/target, height = 1.5, air_group = 0)
 	if(air_group || !broken)
 		return 0 //Make sure air doesn't drain
-	..()
+	return ..()
 
 
 /obj/structure/grille/invulnerable


### PR DESCRIPTION
* Reverts #20672
* Fixes all grilles dropping *rods* when hit by thrown mechs/big juggernauts as opposed to whatever they're supposed to drop
* Fixes grilles flipping back and forth between damaged and undamaged states every time `healthcheck()` was called if they were at exactly 1/4 of their starting health (in which case they now stay damaged)
* Fixes cult grilles being impassable even when broken
  * This was what was causing the server crash, so also fixes that