### PR TITLE
Fixed breaking any bones removing restraints.

### DIFF
--- a/__DEFINES/limb_defines.dm
+++ b/__DEFINES/limb_defines.dm
@@ -10,3 +10,7 @@
 #define LIMB_LEFT_FOOT		"l_foot"
 #define LIMB_RIGHT_FOOT		"r_foot"
 #define TARGET_MOUTH		"mouth"
+
+#define UNCUFF_LEGS			-1
+#define UNCUFF_BOTH			0
+#define UNCUFF_HANDS		1

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -872,8 +872,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 	return (species.default_mutations.Find(mutation))
 
 
-/datum/organ/external/proc/release_restraints(var/toporbottom = 0)// 0:both, -1: legcuffs, 1: handcuffs
-	if(toporbottom >= 0)
+/datum/organ/external/proc/release_restraints(var/uncuff = UNCUFF_BOTH)
+	if(uncuff >= UNCUFF_BOTH)
 		if(owner.handcuffed && body_part in list(ARM_LEFT, ARM_RIGHT, HAND_LEFT, HAND_RIGHT))
 			owner.visible_message(\
 				"\The [owner.handcuffed.name] falls off of [owner.name].",\
@@ -881,7 +881,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 			owner.drop_from_inventory(owner.handcuffed)
 
-	if(toporbottom <= 0)
+	if(uncuff <= UNCUFF_BOTH)
 		if(owner.legcuffed && body_part in list(FOOT_LEFT, FOOT_RIGHT, LEG_LEFT, LEG_RIGHT))
 			owner.visible_message("\The [owner.legcuffed.name] falls off of [owner].", \
 			"\The [owner.legcuffed.name] falls off you.")
@@ -946,10 +946,10 @@ Note that amputating the affected organ does in fact remove the infection from t
 	//Fractures have a chance of getting you out of restraints. All spacemen are all trained to be Houdini.
 	if(owner.handcuffed && body_part in list(HAND_LEFT, HAND_RIGHT))
 		if(prob(25))
-			release_restraints(1)//Handcuffs only.
+			release_restraints(UNCUFF_HANDS)//Handcuffs only.
 	if(owner.legcuffed && body_part in list(FOOT_LEFT, FOOT_RIGHT))
 		if(prob(25))
-			release_restraints(-1)//Legcuffs only.
+			release_restraints(UNCUFF_LEGS)//Legcuffs only.
 
 
 	if(isgolem(owner))

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -872,19 +872,21 @@ Note that amputating the affected organ does in fact remove the infection from t
 	return (species.default_mutations.Find(mutation))
 
 
-/datum/organ/external/proc/release_restraints()
-	if(owner.handcuffed && body_part in list(ARM_LEFT, ARM_RIGHT, HAND_LEFT, HAND_RIGHT))
-		owner.visible_message(\
-			"\The [owner.handcuffed.name] falls off of [owner.name].",\
-			"\The [owner.handcuffed.name] falls off you.")
+/datum/organ/external/proc/release_restraints(var/toporbottom = 0)// 0:both, -1: legcuffs, 1: handcuffs
+	if(toporbottom >= 0)
+		if(owner.handcuffed && body_part in list(ARM_LEFT, ARM_RIGHT, HAND_LEFT, HAND_RIGHT))
+			owner.visible_message(\
+				"\The [owner.handcuffed.name] falls off of [owner.name].",\
+				"\The [owner.handcuffed.name] falls off you.")
 
-		owner.drop_from_inventory(owner.handcuffed)
+			owner.drop_from_inventory(owner.handcuffed)
 
-	if(owner.legcuffed && body_part in list(FOOT_LEFT, FOOT_RIGHT, LEG_LEFT, LEG_RIGHT))
-		owner.visible_message("\The [owner.legcuffed.name] falls off of [owner].", \
-		"\The [owner.legcuffed.name] falls off you.")
+	if(toporbottom <= 0)
+		if(owner.legcuffed && body_part in list(FOOT_LEFT, FOOT_RIGHT, LEG_LEFT, LEG_RIGHT))
+			owner.visible_message("\The [owner.legcuffed.name] falls off of [owner].", \
+			"\The [owner.legcuffed.name] falls off you.")
 
-		owner.drop_from_inventory(owner.legcuffed)
+			owner.drop_from_inventory(owner.legcuffed)
 
 /datum/organ/external/proc/bandage()
 	var/rval = 0
@@ -941,9 +943,14 @@ Note that amputating the affected organ does in fact remove the infection from t
 	broken_description = pick("broken", "fracture", "hairline fracture")
 	perma_injury = brute_dam
 
-	//Fractures have a chance of getting you out of restraints
-	if(prob(25))
-		release_restraints()
+	//Fractures have a chance of getting you out of restraints. All spacemen are all trained to be Houdini.
+	if(owner.handcuffed && body_part in list(HAND_LEFT, HAND_RIGHT))
+		if(prob(25))
+			release_restraints(1)//Handcuffs only.
+	if(owner.legcuffed && body_part in list(FOOT_LEFT, FOOT_RIGHT))
+		if(prob(25))
+			release_restraints(-1)//Legcuffs only.
+
 
 	if(isgolem(owner))
 		droplimb(1)


### PR DESCRIPTION
[balance][bugfix]
Fixed being able to remove all of your restraints by breaking ANY bones. Now only if you break your hand/leg does it remove hand/leg cuffs. I'm open to playing with the RNG on this since you only have a 25% chance to remove them if you break 1 of 2 limbs for each cuff type. I was thinking about 50% since it greatly reduces the amount of spots.
:cl:
 * bugfix: Fixed all restraints falling off if you break any bones. Breaking a foot removes legcuffs; breaking a hand removes handcuffs. Its still only a chance to happen.
