### PR TITLE
Yet Even More Cult Tweaks

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -154,7 +154,7 @@
 	enemy_jobs = list("AI", "Cyborg", "Security Officer","Detective","Head of Security", "Captain", "Chaplain")
 	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
 	required_candidates = 4
-	weight = 4
+	weight = 3
 	cost = 25
 	requirements = list(90,80,60,30,20,10,10,10,10,10)
 	var/cultist_cap = list(2,2,3,4,4,4,4,4,4,4)

--- a/code/datums/gamemode/factions/bloodcult/bloodcult.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult.dm
@@ -157,7 +157,10 @@ var/veil_thickness = CULT_PROLOGUE
 
 	if (new_act == CULT_MENDED)
 		veil_thickness = CULT_MENDED
-		emergency_shuttle.shutdown = 0//The shuttle can be called once again.
+		spawn (5 SECONDS)
+			emergency_shuttle.shutdown = 0//The shuttle docks to the station immediately afterwards.
+			emergency_shuttle.online = 1
+			emergency_shuttle.shuttle_phase("station",0)
 		set_security_level("blue")
 		ticker.StopThematic()
 		command_alert(/datum/command_alert/bloodstones_broken)

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
@@ -91,14 +91,16 @@
 			MouseDropTo(G.affecting,user)
 			returnToPool(W)
 	else if (istype(W))
-		if(user.a_intent == I_HURT)
+		if(user.a_intent == I_HELP || W.force == 0)
+			visible_message("<span class='warning'>\The [user] gently taps \the [src] with \the [W].</span>")
+			MouseDropTo(W,user)
+		else
 			user.delayNextAttack(8)
 			if (sound_damaged)
 				playsound(get_turf(src), sound_damaged, 75, 1)
 			takeDamage(W.force)
+			visible_message("<span class='warning'>\The [user] [pick(W.attack_verb)] \the [src] with \the [W].</span>")
 			..()
-		else
-			MouseDropTo(W,user)
 
 
 /obj/structure/cult/attack_paw(var/mob/user)


### PR DESCRIPTION
It never ends...

:cl:
* tweak: The emergency shuttle now automatically docks to the station after the cult loses.
* tweak: Slightly toned down the weight of the cult ruleset. There are a bit too many cult rounds occurring.
* tweak: Added some chat feedback when hitting cult structures with items. Remember that you need to be in harm intent.