### PR TITLE
Renames iron powder back to iron

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -2020,9 +2020,9 @@
 		//We don't need to start up the system because we only want to smoke one tile.
 
 /datum/reagent/iron
-	name = "Iron powder"
+	name = "Iron"
 	id = IRON
-	description = "Pure iron is a metal."
+	description = "Pure iron in powdered form, a metal."
 	reagent_state = REAGENT_STATE_SOLID
 	color = "#666666" //rgb: 102, 102, 102
 	specheatcap = 0.45


### PR DESCRIPTION
Not gonna lie, this one is purely for aesthetic reasons because when you use a chem dispenser iron sticks out like a sore thumb, being the single element with its form described when practically all chemicals are magical fluids anyway. 
I know that a certain someone may not like this and I hope that the tweaked element description is enough of a compromise for them.