### PR TITLE
Re-adds revs to the rotation.

### DIFF
--- a/__DEFINES/role_datums_defines.dm
+++ b/__DEFINES/role_datums_defines.dm
@@ -152,3 +152,8 @@
 #define FROM_PLAYERS 2
 
 #define PROTECTED_TRAITOR_PROB 66 // Probability than a protected role is rejected from the candidate list
+
+#define ADD_REVOLUTIONARY_FAIL_IS_COMMAND -1
+#define ADD_REVOLUTIONARY_FAIL_IS_JOBBANNED -2
+#define ADD_REVOLUTIONARY_FAIL_IS_IMPLANTED -3
+#define ADD_REVOLUTIONARY_FAIL_IS_REV -4

--- a/code/_hooks/hooks.dm
+++ b/code/_hooks/hooks.dm
@@ -32,21 +32,21 @@ var/global/list/hooks = list()
 	for (var/hook_path in typesof(/hook))
 		var/hook/hook = new hook_path
 		hooks[hook.name] = hook
-		//world.log << "Found hook: " + hook.name
+		world.log << "Found hook: " + hook.name
 	for (var/hook_path in typesof(/hook_handler))
 		var/hook_handler/hook_handler = new hook_path
 		for (var/name in hooks)
 			if (hascall(hook_handler, "On" + name))
 				var/hook/hook = hooks[name]
 				hook.handlers += hook_handler
-				//world.log << "Found hook handler for: " + name
+				world.log << "Found hook handler for: " + name
 	for (var/hook/hook in hooks)
 		hook.Setup()
 
 /proc/CallHook(var/name as text, var/list/args)
 	var/hook/hook = hooks[name]
 	if (!hook)
-		//world.log << "WARNING: Hook with name " + name + " does not exist"
+		world.log << "WARNING: Hook with name " + name + " does not exist"
 		return
 	if (hook.Called(args))
 		return

--- a/code/_hooks/hooks.dm
+++ b/code/_hooks/hooks.dm
@@ -32,21 +32,21 @@ var/global/list/hooks = list()
 	for (var/hook_path in typesof(/hook))
 		var/hook/hook = new hook_path
 		hooks[hook.name] = hook
-		world.log << "Found hook: " + hook.name
+		//world.log << "Found hook: " + hook.name
 	for (var/hook_path in typesof(/hook_handler))
 		var/hook_handler/hook_handler = new hook_path
 		for (var/name in hooks)
 			if (hascall(hook_handler, "On" + name))
 				var/hook/hook = hooks[name]
 				hook.handlers += hook_handler
-				world.log << "Found hook handler for: " + name
+				//world.log << "Found hook handler for: " + name
 	for (var/hook/hook in hooks)
 		hook.Setup()
 
 /proc/CallHook(var/name as text, var/list/args)
 	var/hook/hook = hooks[name]
 	if (!hook)
-		world.log << "WARNING: Hook with name " + name + " does not exist"
+		//world.log << "WARNING: Hook with name " + name + " does not exist"
 		return
 	if (hook.Called(args))
 		return

--- a/code/_hooks/mob.dm
+++ b/code/_hooks/mob.dm
@@ -1,2 +1,5 @@
 /hook/login
 	name = "Login"
+
+/hook/arrival
+	name = "Arrival"

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -290,10 +290,11 @@
 	restricted_from_jobs = list("AI", "Cyborg", "Mobile MMI", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Chief Medical Officer", "Research Director", "Internal Affairs Agent")
 	enemy_jobs = list("AI", "Cyborg", "Security Officer","Detective","Head of Security", "Captain", "Warden")
 	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
-	required_candidates = 1
+	required_candidates = 3
 	weight = 3
 	cost = 25
 	requirements = list(90,90,70,40,30,20,10,10,10,10)
+	var/required_heads = 3
 
 /datum/dynamic_ruleset/roundstart/revs/ready(var/forced = 0)
 	if (!..())
@@ -302,8 +303,7 @@
 	for (var/mob/new_player/player in player_list)
 		if (player.mind.assigned_role in command_positions)
 			head_check++
-			break
-	return head_check
+	return (head_check >= required_heads)
 
 /datum/dynamic_ruleset/roundstart/revs/execute()
 	var/datum/faction/revolution/R = find_active_faction_by_type(/datum/faction/revolution)

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -287,8 +287,8 @@
 	name = "Revolution"
 	role_category = ROLE_REV
 	protected_from_jobs = list("Merchant")
-	restricted_from_jobs = list("AI", "Cyborg", "Mobile MMI", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Chaplain", "Head of Personnel", "Internal Affairs Agent", "Chaplain")
-	enemy_jobs = list("AI", "Cyborg", "Security Officer","Detective","Head of Security", "Captain", "Chaplain")
+	restricted_from_jobs = list("AI", "Cyborg", "Mobile MMI", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Internal Affairs Agent")
+	enemy_jobs = list("AI", "Cyborg", "Security Officer","Detective","Head of Security", "Captain", "Warden")
 	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
 	required_candidates = 4
 	weight = 3
@@ -300,7 +300,7 @@
 	if (!R)
 		R = ticker.mode.CreateFaction(/datum/faction/revolution, null, 1)
 	
-	for(var/cultists_number = 1 to required_candidates)
+	for(var/i = 1 to required_candidates)
 		if(candidates.len <= 0)
 			break
 		var/mob/M = pick(candidates)

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -276,3 +276,38 @@
 	message_admins("Starting a round of extended.")
 	log_admin("Starting a round of extended.")
 	return TRUE
+
+//////////////////////////////////////////////
+//                                          //
+//               REVS		                ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//                                          //
+//////////////////////////////////////////////
+
+/datum/dynamic_ruleset/roundstart/revs
+	name = "Revolution"
+	role_category = ROLE_REV
+	protected_from_jobs = list("Merchant")
+	restricted_from_jobs = list("AI", "Cyborg", "Mobile MMI", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Chaplain", "Head of Personnel", "Internal Affairs Agent", "Chaplain")
+	enemy_jobs = list("AI", "Cyborg", "Security Officer","Detective","Head of Security", "Captain", "Chaplain")
+	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
+	required_candidates = 4
+	weight = 3
+	cost = 25
+	requirements = list(90,90,70,40,30,20,10,10,10,10)
+
+/datum/dynamic_ruleset/roundstart/revs/execute()
+	var/datum/faction/revolution/R = find_active_faction_by_type(/datum/faction/revolution)
+	if (!R)
+		R = ticker.mode.CreateFaction(/datum/faction/revolution, null, 1)
+	
+	for(var/cultists_number = 1 to required_candidates)
+		if(candidates.len <= 0)
+			break
+		var/mob/M = pick(candidates)
+		assigned += M
+		candidates -= M
+		var/datum/role/revolutionary/leader/lenin = new
+		lenin.AssignToRole(M.mind,1)
+		R.HandleRecruitedRole(lenin)
+		lenin.Greet(GREET_ROUNDSTART)
+	return 1

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -287,20 +287,33 @@
 	name = "Revolution"
 	role_category = ROLE_REV
 	protected_from_jobs = list("Merchant")
-	restricted_from_jobs = list("AI", "Cyborg", "Mobile MMI", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Internal Affairs Agent")
+	restricted_from_jobs = list("AI", "Cyborg", "Mobile MMI", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Chief Medical Officer", "Research Director", "Internal Affairs Agent")
 	enemy_jobs = list("AI", "Cyborg", "Security Officer","Detective","Head of Security", "Captain", "Warden")
 	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
-	required_candidates = 4
+	required_candidates = 1
 	weight = 3
 	cost = 25
 	requirements = list(90,90,70,40,30,20,10,10,10,10)
+
+/datum/dynamic_ruleset/roundstart/revs/ready(var/forced = 0)
+	if (!..())
+		return FALSE
+	var/head_check = 0
+	for (var/mob/new_player/player in player_list)
+		if (player.mind.assigned_role in command_positions)
+			head_check++
+			break
+	return head_check
 
 /datum/dynamic_ruleset/roundstart/revs/execute()
 	var/datum/faction/revolution/R = find_active_faction_by_type(/datum/faction/revolution)
 	if (!R)
 		R = ticker.mode.CreateFaction(/datum/faction/revolution, null, 1)
 	
-	for(var/i = 1 to required_candidates)
+	R.OnPostSetup() // Forge our jecties
+
+	var/max_canditates = 4
+	for(var/i = 1 to max_canditates)
 		if(candidates.len <= 0)
 			break
 		var/mob/M = pick(candidates)
@@ -310,4 +323,6 @@
 		lenin.AssignToRole(M.mind,1)
 		R.HandleRecruitedRole(lenin)
 		lenin.Greet(GREET_ROUNDSTART)
+		lenin.OnPostSetup()
+	update_faction_icons()
 	return 1

--- a/code/datums/gamemode/factions/faction.dm
+++ b/code/datums/gamemode/factions/faction.dm
@@ -84,7 +84,7 @@ var/list/factions_with_hud_icons = list()
 	if(M.GetRole(late_role))
 		WARNING("Mind already had a role of [late_role]!")
 		return 0
-	var/datum/role/R = new roletype(null,src,initial_role) // Add him to our roles
+	var/datum/role/R = new roletype(null,src,late_role) // Add him to our roles
 	if(!R.AssignToRole(M, override))
 		R.Drop()
 		return 0
@@ -115,6 +115,7 @@ var/list/factions_with_hud_icons = list()
 	else
 		O = new objective_type
 	if(objective_holder.AddObjective(O, null, src))
+		to_chat(world, "We added [O.type].")
 		return TRUE
 	return FALSE
 

--- a/code/datums/gamemode/factions/faction.dm
+++ b/code/datums/gamemode/factions/faction.dm
@@ -115,7 +115,6 @@ var/list/factions_with_hud_icons = list()
 	else
 		O = new objective_type
 	if(objective_holder.AddObjective(O, null, src))
-		to_chat(world, "We added [O.type].")
 		return TRUE
 	return FALSE
 

--- a/code/datums/gamemode/factions/faction.dm
+++ b/code/datums/gamemode/factions/faction.dm
@@ -372,48 +372,8 @@ var/list/factions_with_hud_icons = list()
 /datum/faction/wizard/ragin/check_win()
 	if(members.len == max_roles)
 		return 1
+
 //________________________________________________
-
-#define ADD_REVOLUTIONARY_FAIL_IS_COMMAND -1
-#define ADD_REVOLUTIONARY_FAIL_IS_JOBBANNED -2
-#define ADD_REVOLUTIONARY_FAIL_IS_IMPLANTED -3
-#define ADD_REVOLUTIONARY_FAIL_IS_REV -4
-
-/datum/faction/revolution
-	name = "Revolutionaries"
-	ID = REVOLUTION
-	required_pref = ROLE_REV
-	initial_role = HEADREV
-	late_role = REV
-	desc = "Viva!"
-	logo_state = "rev-logo"
-	initroletype = /datum/role/revolutionary/leader
-	roletype = /datum/role/revolutionary
-
-/datum/faction/revolution/HandleRecruitedMind(var/datum/mind/M)
-	if(M.assigned_role in command_positions)
-		return ADD_REVOLUTIONARY_FAIL_IS_COMMAND
-
-	var/mob/living/carbon/human/H = M.current
-
-	if(jobban_isbanned(H, "revolutionary"))
-		return ADD_REVOLUTIONARY_FAIL_IS_JOBBANNED
-
-	for(var/obj/item/weapon/implant/loyalty/L in H) // check loyalty implant in the contents
-		if(L.imp_in == H) // a check if it's actually implanted
-			return ADD_REVOLUTIONARY_FAIL_IS_IMPLANTED
-
-	if(isrev(H)) //HOW DO YOU FUCK UP THIS BADLY.
-		return ADD_REVOLUTIONARY_FAIL_IS_REV
-
-	return ..()
-
-/datum/faction/revolution/forgeObjectives()
-	var/list/heads = get_living_heads()
-	for(var/datum/mind/head_mind in heads)
-		var/datum/objective/target/assassinate/A = new(auto_target = FALSE)
-		if(A.set_target(head_mind))
-			AppendObjective(A)
 
 /datum/faction/strike_team
 	name = "Custom Strike Team"//obviously this name is a placeholder getting replaced by the admin setting up the squad

--- a/code/datums/gamemode/factions/syndicate/rev.dm
+++ b/code/datums/gamemode/factions/syndicate/rev.dm
@@ -1,0 +1,62 @@
+//________________________________________________
+
+#define ADD_REVOLUTIONARY_FAIL_IS_COMMAND -1
+#define ADD_REVOLUTIONARY_FAIL_IS_JOBBANNED -2
+#define ADD_REVOLUTIONARY_FAIL_IS_IMPLANTED -3
+#define ADD_REVOLUTIONARY_FAIL_IS_REV -4
+
+/datum/faction/revolution
+	name = "Revolutionaries"
+	ID = REVOLUTION
+	required_pref = ROLE_REV
+	initial_role = HEADREV
+	late_role = REV
+	desc = "Viva!"
+	logo_state = "rev-logo"
+	initroletype = /datum/role/revolutionary/leader
+	roletype = /datum/role/revolutionary
+
+/datum/faction/revolution/HandleRecruitedMind(var/datum/mind/M)
+	if(M.assigned_role in command_positions)
+		return ADD_REVOLUTIONARY_FAIL_IS_COMMAND
+
+	var/mob/living/carbon/human/H = M.current
+
+	if(jobban_isbanned(H, "revolutionary"))
+		return ADD_REVOLUTIONARY_FAIL_IS_JOBBANNED
+
+	for(var/obj/item/weapon/implant/loyalty/L in H) // check loyalty implant in the contents
+		if(L.imp_in == H) // a check if it's actually implanted
+			return ADD_REVOLUTIONARY_FAIL_IS_IMPLANTED
+
+	if(isrev(H)) //HOW DO YOU FUCK UP THIS BADLY.
+		return ADD_REVOLUTIONARY_FAIL_IS_REV
+
+	return ..()
+
+/datum/faction/revolution/forgeObjectives()
+	var/list/heads = get_living_heads()
+	for(var/datum/mind/head_mind in heads)
+		var/datum/objective/target/assassinate/A = new(auto_target = FALSE)
+		if(A.set_target(head_mind))
+			AppendObjective(A)
+
+#define ALL_HEADS_DEAD 1
+#define ALL_REVS_DEAD 2
+
+/datum/faction/revolution/process()
+    // -- 1. Are all the heads dead ?
+    var/total_heads = 0
+    var/incapacitated_heads = 0
+
+    for (var/mob/living/carbon/human/H in player_list)
+        var/datum/mind/M = H.mind
+        if (!M)
+            continue
+        if (M.assigned_role in command_positions)
+            total_heads++
+            if (H.isDead() || H.z =! map.zMainStation)
+                incapacitated_heads++
+
+    if (incapacitated_heads >= total_heads)
+        return end(ALL_HEADS_DEAD)

--- a/code/datums/gamemode/factions/syndicate/rev.dm
+++ b/code/datums/gamemode/factions/syndicate/rev.dm
@@ -34,12 +34,9 @@
 
 /datum/faction/revolution/forgeObjectives()
 	var/list/heads = get_living_heads()
-	if (!heads.len)
-		to_chat(world, "No heads !")
 	for(var/datum/mind/head_mind in heads)
 		var/datum/objective/target/assassinate/A = new(auto_target = FALSE)
 		if(A.set_target(head_mind))
-			to_chat(world, "We want to kill [head_mind]")
 			AppendObjective(A, TRUE) // We will have more than one kill objective
 
 /datum/faction/revolution/OnPostSetup()
@@ -97,8 +94,6 @@
 		return FALSE			
 	ASSERT(args["character"])
 	ASSERT(args["rank"])
-	to_chat(world, "OnArrival called.")
-	to_chat(world, "[args["rank"]]")
 	var/mob/living/L = args["character"]
 	if (args["rank"] in command_positions)
 		var/datum/objective/target/assassinate/A = new(auto_target = FALSE)

--- a/code/datums/gamemode/factions/syndicate/rev.dm
+++ b/code/datums/gamemode/factions/syndicate/rev.dm
@@ -1,10 +1,5 @@
 //________________________________________________
 
-#define ADD_REVOLUTIONARY_FAIL_IS_COMMAND -1
-#define ADD_REVOLUTIONARY_FAIL_IS_JOBBANNED -2
-#define ADD_REVOLUTIONARY_FAIL_IS_IMPLANTED -3
-#define ADD_REVOLUTIONARY_FAIL_IS_REV -4
-
 /datum/faction/revolution
 	name = "Revolutionaries"
 	ID = REVOLUTION
@@ -15,6 +10,7 @@
 	logo_state = "rev-logo"
 	initroletype = /datum/role/revolutionary/leader
 	roletype = /datum/role/revolutionary
+	var/win_shuttle = FALSE
 
 /datum/faction/revolution/HandleRecruitedMind(var/datum/mind/M)
 	if(M.assigned_role in command_positions)
@@ -43,20 +39,64 @@
 
 #define ALL_HEADS_DEAD 1
 #define ALL_REVS_DEAD 2
+#define SHUTTLE_LEFT 3
 
-/datum/faction/revolution/process()
-    // -- 1. Are all the heads dead ?
-    var/total_heads = 0
-    var/incapacitated_heads = 0
+/datum/faction/revolution/check_win()
+	// -- 1. Did the shuttle left ?
+	if (win_shuttle)
+		return end(SHUTTLE_LEFT)
 
-    for (var/mob/living/carbon/human/H in player_list)
-        var/datum/mind/M = H.mind
-        if (!M)
-            continue
-        if (M.assigned_role in command_positions)
-            total_heads++
-            if (H.isDead() || H.z =! map.zMainStation)
-                incapacitated_heads++
+	// -- 2. Are all the heads dead ?
+	var/total_heads = 0
+	var/incapacitated_heads = 0
 
-    if (incapacitated_heads >= total_heads)
-        return end(ALL_HEADS_DEAD)
+	for (var/mob/living/carbon/human/H in player_list)
+		var/datum/mind/M = H.mind
+		if (!M)
+			continue
+		if (M.assigned_role in command_positions)
+			total_heads++
+			if (H.isDead() || H.z != map.zMainStation)
+				incapacitated_heads++
+
+	if (incapacitated_heads >= total_heads)
+		return end(ALL_HEADS_DEAD)
+
+	// -- 3. Are all the revs deads ?
+	for (var/datum/role/R in members)
+		if (R.antag && R.antag.current && !(R.antag.current.isDead() || R.antag.current.z != map.zMainStation))
+			return FALSE
+
+	return end(ALL_REVS_DEAD)
+
+// Called on arrivals and emergency shuttle departure.
+/hook_handler/revs
+
+/hook_handler/revs/proc/OnEmergencyShuttleDeparture(var/list/args)
+	var/datum/faction/revolution/R = find_active_faction_by_type(/datum/faction/revolution)
+	if (!istype(R))
+		return FALSE
+	R.win_shuttle = TRUE
+	return TRUE
+
+/hook_handler/revs/proc/OnArrival(var/list/args)
+	var/datum/faction/revolution/R = find_active_faction_by_type(/datum/faction/revolution)
+	if (!istype(R))
+		return FALSE			
+	ASSERT(args["character"])
+	ASSERT(args["rank"])
+	var/mob/living/L = args["character"]
+	if (args["rank"] in command_positions)
+		var/datum/objective/target/assassinate/A = new(auto_target = FALSE)
+		if(A.set_target(L.mind))
+			R.AppendObjective(A)
+
+/datum/faction/revolution/proc/end(var/result)
+	. = TRUE
+	switch (result)
+		if (ALL_HEADS_DEAD)
+			to_chat(world, "<b>The revolution has won!</b><br/>All heads are either dead or have fled the station!")
+		if (ALL_REVS_DEAD)
+			to_chat(world, "<b>The crew has won!</b><br/>All revolutionaries are either dead or have fled the station!")
+		if (SHUTTLE_LEFT)
+			to_chat(world, "<b>Revolution minor victory!</b><br/>The heads called the shuttle to leave the station!")

--- a/code/datums/gamemode/objectives/objective.dm
+++ b/code/datums/gamemode/objectives/objective.dm
@@ -7,10 +7,6 @@
 
 	var/flags = 0 // Objective flags.
 
-/datum/objective/target/New(var/text,var/auto_target = TRUE, var/mob/user = null)
-	if(text)
-		explanation_text = text
-
 /datum/objective/target/Destroy()
 	owner = null
 	faction = null

--- a/code/datums/gamemode/objectives/target/target.dm
+++ b/code/datums/gamemode/objectives/target/target.dm
@@ -5,6 +5,11 @@
 	var/auto_target = TRUE //Whether we pick a target automatically on PostAppend()
 	name = ""
 
+/datum/objective/target/New(var/text,var/auto_target = TRUE, var/mob/user = null)
+	src.auto_target = auto_target
+	if(text)
+		explanation_text = text
+
 /datum/objective/target/PostAppend()
 	if(auto_target)
 		return find_target()
@@ -33,6 +38,7 @@
 	return FALSE
 
 /datum/objective/target/proc/set_target(var/datum/mind/possible_target)
+	to_chat(world, "set target choosed [possible_target]")
 	if(possible_target != owner && ishuman(possible_target.current) && (possible_target.current.z != map.zCentcomm) && (possible_target.current.stat != DEAD) && !(possible_target.assigned_role in bad_assassinate_targets))
 		target = possible_target
 		explanation_text = format_explanation()

--- a/code/datums/gamemode/objectives/target/target.dm
+++ b/code/datums/gamemode/objectives/target/target.dm
@@ -38,7 +38,6 @@
 	return FALSE
 
 /datum/objective/target/proc/set_target(var/datum/mind/possible_target)
-	to_chat(world, "set target choosed [possible_target]")
 	if(possible_target != owner && ishuman(possible_target.current) && (possible_target.current.z != map.zCentcomm) && (possible_target.current.stat != DEAD) && !(possible_target.assigned_role in bad_assassinate_targets))
 		target = possible_target
 		explanation_text = format_explanation()

--- a/code/datums/gamemode/role/rev.dm
+++ b/code/datums/gamemode/role/rev.dm
@@ -5,13 +5,13 @@
 	logo_state = "rev-logo"
 	greets = list(GREET_DEFAULT,GREET_CUSTOM,GREET_ROUNDSTART,GREET_ADMINTOGGLE)
 
-/datum/role/revolutionary/Greet(var/greeting,var/custom)
+/datum/role/revolutionary/Greet(var/greeting, var/custom)
 	if(!greeting)
 		return
 
 	var/icon/logo = icon('icons/logos.dmi', logo_state)
 	switch(greeting)
-		if (GREET_ROUNDSTART)
+		if (GREET_ROUNDSTART, GREET_DEFAULT)
 			to_chat(antag.current, {"<img src='data:image/png;base64,[icon2base64(logo)]' style='position: relative; top: 10;'/><span class = 'notice'>You are a member of the revolutionaries' leadership!</span>"})
 		if (GREET_ADMINTOGGLE)
 			to_chat(antag.current, "<img src='data:image/png;base64,[icon2base64(logo)]' style='position: relative; top: 10;'/> <span class='warning'>You suddenly feel rather annoyed with this stations leadership!</span>")
@@ -19,6 +19,11 @@
 			to_chat(antag.current, "<img src='data:image/png;base64,[icon2base64(logo)]' style='position: relative; top: 10;'/> <span class='warning'>[custom]</span>")
 
 	to_chat(antag.current, "<span class='info'><a HREF='?src=\ref[antag.current];getwiki=[wikiroute]'>(Wiki Guide)</a></span>")
+
+/datum/role/revolutionary/OnPostSetup()
+	. = ..()
+	to_chat(antag.current, "<span class='warning'><FONT size = 3> You are now a revolutionary! Help your cause. Do not harm your fellow freedom fighters. You can identify your comrades by the red \"R\" icons, and your leaders by the blue \"R\" icons. Help them kill the heads to win the revolution!</FONT></span>")
+	AnnounceObjectives()
 
 /datum/role/revolutionary/New()
 	..()
@@ -50,3 +55,13 @@
 	else
 		T.forceMove(get_turf(mob))
 		to_chat(mob, "\The [faction.name] were able to get you \a [T], but could not find anywhere to slip it onto you, so it is now on the floor.")
+
+/datum/role/revolutionary/Drop(var/borged = FALSE)
+	if (borged)
+		antag.current.visible_message("<span class='big danger'>The frame beeps contentedly, purging the hostile memory engram from the MMI before initalizing it.</span>",
+				"<span class='big danger'>The frame's firmware detects and deletes your neural reprogramming! You remember nothing from the moment you were flashed until now.</span>")
+	else
+		antag.current.visible_message("<span class='big danger'>It looks like [antag.current] just remembered their real allegiance!</span>",
+			"<span class='big danger'>You have been brainwashed! You are no longer a revolutionary! Your memory is hazy from the time you were a rebel...the only thing you remember is the name of the one who brainwashed you...</span>")
+	update_faction_icons()
+	return ..()

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -119,6 +119,8 @@
 	if(!flashfail)
 		M.flash_eyes(affect_silicon = 1)
 
+	return !flashfail
+
 /obj/item/device/flash/attack_self(mob/living/carbon/user as mob, flag = 0, emp = 0)
 	if(!user || !clown_check(user))
 		return

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -151,6 +151,10 @@ obj/item/device/mmi/Destroy()
 		name = "[initial(name)]: [brainmob.real_name]"
 		icon_state = "mmi_full"
 
+		if (isrev(brainmob))
+			var/datum/role/revolutionary/R = brainmob.mind.GetRole(ROLE_REV)
+			R.Drop(TRUE)
+
 		locked = 1
 
 		feedback_inc("cyborg_mmis_filled",1)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -401,6 +401,7 @@
 						handle_render(M,"<span class='game say'>PDA Message - <span class='name'>Trader [character] has arrived in the sector from space.</span></span>",character) //This should generate a Follow link
 			else
 				AnnounceArrival(character, rank)
+				CallHook("OnArrival", list("character" = character, "rank" = rank))
 			FuckUpGenes(character)
 		else
 			character.Robotize()

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -401,7 +401,7 @@
 						handle_render(M,"<span class='game say'>PDA Message - <span class='name'>Trader [character] has arrived in the sector from space.</span></span>",character) //This should generate a Follow link
 			else
 				AnnounceArrival(character, rank)
-				CallHook("OnArrival", list("character" = character, "rank" = rank))
+				CallHook("Arrival", list("character" = character, "rank" = rank))
 			FuckUpGenes(character)
 		else
 			character.Robotize()

--- a/data/mode.txt
+++ b/data/mode.txt
@@ -1,1 +1,1 @@
-sandbox
+Dynamic Mode

--- a/data/mode.txt
+++ b/data/mode.txt
@@ -1,1 +1,1 @@
-Dynamic Mode
+sandbox

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -332,6 +332,7 @@
 #include "code\datums\gamemode\factions\legacy_cult\talisman.dm"
 #include "code\datums\gamemode\factions\legacy_cult\trash_machinery.dm"
 #include "code\datums\gamemode\factions\syndicate\nukeops.dm"
+#include "code\datums\gamemode\factions\syndicate\rev.dm"
 #include "code\datums\gamemode\factions\syndicate\traitor.dm"
 #include "code\datums\gamemode\objectives\absorb.dm"
 #include "code\datums\gamemode\objectives\acquire_blood.dm"


### PR DESCRIPTION
Should just be ready for testing.
We have the ~~luxury~~ misfortune of having several event handler systems and I choose the one which seemed the most fit to the task.

Needs to be live-tested of course.
Uses the same threat levels requirement as Cult right now.

:cl:
- rscadd: Re-adds revolution to the gamemode rotation, with the same threat requirements as cult.