### PR TITLE
giant syringes are now giant

### DIFF
--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -296,8 +296,9 @@
 
 /obj/item/weapon/reagent_containers/syringe/giant/New()
 	..()
+	appearance_flags |= PIXEL_SCALE
 	var/matrix/gisy = matrix()
-	gisy.Scale(1.5,1.5)
+	gisy.Scale(1.2,1.2)
 	transform = gisy
 
 /obj/item/weapon/reagent_containers/syringe/giant/get_injection_time(var/mob/target)

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -294,6 +294,12 @@
 	can_draw_blood = FALSE
 	can_stab = FALSE
 
+/obj/item/weapon/reagent_containers/syringe/giant/New()
+	..()
+	var/matrix/gisy = matrix()
+	gisy.Scale(1.5,1.5)
+	transform = gisy
+
 /obj/item/weapon/reagent_containers/syringe/giant/get_injection_time(var/mob/target)
 	if (istype(target, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = target


### PR DESCRIPTION
[sprites]
![effort](https://user-images.githubusercontent.com/8468269/48657200-54fc0d80-ea2e-11e8-8827-045ecbcf5437.png)


🆑 
 - tweak: giant syringes are now visually distinguishable from normal syringes