### PR TITLE
Yet Even Again More Cult Changes

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult.dm
@@ -197,7 +197,7 @@ var/veil_thickness = CULT_PROLOGUE
 						for(var/obj/item/weapon/implant/loyalty/I in M)
 							I.forceMove(get_turf(M))
 							I.implanted = 0
-							spell_holder.visible_message("<span class='warning'>\The [I] pops out of \the [M]'s head.</span>")
+							M.visible_message("<span class='warning'>\The [I] pops out of \the [M]'s head.</span>")
 		if (CULT_ACT_III)
 			var/datum/objective/bloodcult_sacrifice/O = locate() in objective_holder.objectives
 			if (O)

--- a/code/datums/gamemode/factions/bloodcult/bloodcult.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult.dm
@@ -192,6 +192,12 @@ var/veil_thickness = CULT_PROLOGUE
 				if (O.conversions >= O.convert_target)
 					veil_thickness = CULT_ACT_II
 					new_obj = new /datum/objective/bloodcult_sacrifice
+					for(var/datum/role/cultist/C in members)
+						var/mob/M = C.antag.current
+						for(var/obj/item/weapon/implant/loyalty/I in M)
+							I.forceMove(get_turf(M))
+							I.implanted = 0
+							spell_holder.visible_message("<span class='warning'>\The [I] pops out of \the [M]'s head.</span>")
 		if (CULT_ACT_III)
 			var/datum/objective/bloodcult_sacrifice/O = locate() in objective_holder.objectives
 			if (O)

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
@@ -207,7 +207,7 @@
 				user.visible_message("<span class='danger'>\The [user] holds \the [I] above \the [C]'s stomach and impales them on \the [src]!</span>","<span class='danger'>You hold \the [I] above \the [C]'s stomach and impale them on \the [src]!</span>")
 		else
 			to_chat(user, "You plant \the [blade] on top of \the [src]</span>")
-			if (istype(blade))
+			if (istype(blade) && !blade.shade)
 				var/icon/logo_icon = icon('icons/logos.dmi', "shade-blade")
 				for(var/mob/M in observers)
 					if(!M.client || jobban_isbanned(M, ROLE_CULTIST) || M.client.is_afk())

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
@@ -1311,9 +1311,8 @@ var/list/bloodstone_list = list()
 
 /obj/structure/cult/bloodstone/proc/summon_backup()
 	var/list/possible_floors = list()
-	for (var/turf/simulated/floor/F in range(1,src))
-		if (F != loc)//orange ain't working for some reason
-			possible_floors.Add(F)
+	for (var/turf/simulated/floor/F in orange(1,get_turf(src)))
+		possible_floors.Add(F)
 	var/monsters_to_spawn = 1
 	if (health < (maxHealth / 2))
 		monsters_to_spawn++

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
@@ -207,12 +207,12 @@
 				user.visible_message("<span class='danger'>\The [user] holds \the [I] above \the [C]'s stomach and impales them on \the [src]!</span>","<span class='danger'>You hold \the [I] above \the [C]'s stomach and impale them on \the [src]!</span>")
 		else
 			to_chat(user, "You plant \the [blade] on top of \the [src]</span>")
-		if (istype(blade))
-			var/icon/logo_icon = icon('icons/logos.dmi', "shade-blade")
-			for(var/mob/M in observers)
-				if(!M.client || jobban_isbanned(M, ROLE_CULTIST) || M.client.is_afk())
-					continue
-				to_chat(M, "[bicon(logo_icon)]<span class='recruit'>\The [user] has planted a Soul Blade on an altar, opening a small crack in the veil that allows you to become the blade's resident shade. (<a href='?src=\ref[src];signup=\ref[M]'>Possess now!</a>)</span>[bicon(logo_icon)]")
+			if (istype(blade))
+				var/icon/logo_icon = icon('icons/logos.dmi', "shade-blade")
+				for(var/mob/M in observers)
+					if(!M.client || jobban_isbanned(M, ROLE_CULTIST) || M.client.is_afk())
+						continue
+					to_chat(M, "[bicon(logo_icon)]<span class='recruit'>\The [user] has planted a Soul Blade on an altar, opening a small crack in the veil that allows you to become the blade's resident shade. (<a href='?src=\ref[src];signup=\ref[M]'>Possess now!</a>)</span>[bicon(logo_icon)]")
 		return 1
 	if (istype(I, /obj/item/weapon/grab))
 		if (blade)
@@ -1311,12 +1311,15 @@ var/list/bloodstone_list = list()
 
 /obj/structure/cult/bloodstone/proc/summon_backup()
 	var/list/possible_floors = list()
-	for (var/turf/simulated/floor/F in orange(1,src))
-		possible_floors.Add(F)
+	for (var/turf/simulated/floor/F in range(1,src))
+		if (F != loc)//orange ain't working for some reason
+			possible_floors.Add(F)
 	var/monsters_to_spawn = 1
 	if (health < (maxHealth / 2))
 		monsters_to_spawn++
 	for (var/i = 1 to monsters_to_spawn)
+		if (possible_floors.len <= 0)
+			break
 		var/turf/T = pick(possible_floors)
 		if (T)
 			possible_floors.Remove(T)

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_effects.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_effects.dm
@@ -414,7 +414,7 @@ var/list/bloodstone_backup = 0
 					1;/mob/living/simple_animal/hostile/scarybat/cult,
 					)
 			if (7 to INFINITY)
-				var/mobtype = pick(
+				mobtype = pick(
 					2;/mob/living/simple_animal/hostile/creature/cult,
 					1;/mob/living/simple_animal/hostile/faithless/cult,
 					)

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_effects.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_effects.dm
@@ -380,6 +380,8 @@
 
 ///////////////////////////////////////BLOODSTONE DEFENSES////////////////////////////////////////////////
 
+var/list/bloodstone_backup = 0
+
 /obj/effect/cult_ritual/backup_spawn
 	name = "gateway"
 	desc = "Something is coming through!"
@@ -391,10 +393,30 @@
 /obj/effect/cult_ritual/backup_spawn/New()
 	..()
 	spawn (30)
-		var/mobtype = pick(
-			1;/mob/living/simple_animal/hostile/creature/cult,
-			2;/mob/living/simple_animal/hostile/faithless/cult,
-			3;/mob/living/simple_animal/hostile/scarybat/cult,
-			)
+		bloodstone_backup++
+		var/mobtype
+		switch (bloodstone_backup)
+			if (0,1,2)
+				mobtype = pick(
+					1;/mob/living/simple_animal/hostile/faithless/cult,
+					2;/mob/living/simple_animal/hostile/scarybat/cult,
+					)
+			if (3,4)
+				mobtype = pick(
+					1;/mob/living/simple_animal/hostile/creature/cult,
+					3;/mob/living/simple_animal/hostile/faithless/cult,
+					2;/mob/living/simple_animal/hostile/scarybat/cult,
+					)
+			if (5,6)
+				mobtype = pick(
+					2;/mob/living/simple_animal/hostile/creature/cult,
+					2;/mob/living/simple_animal/hostile/faithless/cult,
+					1;/mob/living/simple_animal/hostile/scarybat/cult,
+					)
+			if (7 to INFINITY)
+				var/mobtype = pick(
+					2;/mob/living/simple_animal/hostile/creature/cult,
+					1;/mob/living/simple_animal/hostile/faithless/cult,
+					)
 		new mobtype(get_turf(src))
 		qdel(src)

--- a/code/datums/gamemode/factions/faction.dm
+++ b/code/datums/gamemode/factions/faction.dm
@@ -219,7 +219,7 @@ var/list/factions_with_hud_icons = list()
 
 	//then re-add them
 	for(var/datum/role/R in members)
-		if(R.antag && R.antag.current && R.antag.current.client && antag.GetRole(R.id))//if the mind doesn't have access to the role, they shouldn't see the icons
+		if(R.antag && R.antag.current && R.antag.current.client && R.antag.GetRole(R.id))//if the mind doesn't have access to the role, they shouldn't see the icons
 			for(var/datum/role/R_target in members)
 				if(R_target.antag && R_target.antag.current)
 					var/imageloc = R_target.antag.current

--- a/code/datums/gamemode/factions/faction.dm
+++ b/code/datums/gamemode/factions/faction.dm
@@ -219,7 +219,7 @@ var/list/factions_with_hud_icons = list()
 
 	//then re-add them
 	for(var/datum/role/R in members)
-		if(R.antag && R.antag.current && R.antag.current.client)
+		if(R.antag && R.antag.current && R.antag.current.client && antag.GetRole(R.id))//if the mind doesn't have access to the role, they shouldn't see the icons
 			for(var/datum/role/R_target in members)
 				if(R_target.antag && R_target.antag.current)
 					var/imageloc = R_target.antag.current

--- a/code/datums/gamemode/role/role.dm
+++ b/code/datums/gamemode/role/role.dm
@@ -299,7 +299,9 @@
 	var/icon/logo = icon('icons/logos.dmi', logo_state)
 	text += "<img src='data:image/png;base64,[icon2base64(logo)]' style='position: relative;top:10px;'/><b>[antag.key]</b> was <b>[antag.name]</b> ("
 	if(M)
-		if(M.stat == DEAD)
+		if(!antag.GetRole(id))
+			text += "removed"
+		else if(M.stat == DEAD)
 			text += "died"
 		else
 			text += "survived"

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -294,7 +294,10 @@ the implant may become unstable and either pre-maturely inject the subject or si
 	if(!iscarbon(M))
 		return 0
 	var/mob/living/carbon/H = M
-	if(isrevhead(H) || iscultist(H))
+	if(isrevhead(H))
+		H.visible_message("<span class='big danger'>[H] seems to resist the implant!</span>", "<span class='danger'>You feel the corporate tendrils of Nanotrasen try to invade your mind!</span>")
+		return 0
+	if(iscultist(H) && veil_thickness >= CULT_ACT_II)
 		H.visible_message("<span class='big danger'>[H] seems to resist the implant!</span>", "<span class='danger'>You feel the corporate tendrils of Nanotrasen try to invade your mind!</span>")
 		return 0
 	else if(isrevnothead(H))

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -294,10 +294,7 @@ the implant may become unstable and either pre-maturely inject the subject or si
 	if(!iscarbon(M))
 		return 0
 	var/mob/living/carbon/H = M
-	if(isrevhead(H))
-		H.visible_message("<span class='big danger'>[H] seems to resist the implant!</span>", "<span class='danger'>You feel the corporate tendrils of Nanotrasen try to invade your mind!</span>")
-		return 0
-	if(iscultist(H) && veil_thickness >= CULT_ACT_II)
+	if(isrevhead(H) || (iscultist(H) && veil_thickness >= CULT_ACT_II))
 		H.visible_message("<span class='big danger'>[H] seems to resist the implant!</span>", "<span class='danger'>You feel the corporate tendrils of Nanotrasen try to invade your mind!</span>")
 		return 0
 	else if(isrevnothead(H))

--- a/code/modules/library/computers/checkout.dm
+++ b/code/modules/library/computers/checkout.dm
@@ -49,7 +49,7 @@
 			dat += "</ol>"
 
 			if(src.arcanecheckout)
-				new /obj/item/weapon/tome_legacy(src.loc)
+				new /obj/item/weapon/tome(src.loc)
 				to_chat(user, "<span class='warning'>Your sanity barely endures the seconds spent in the vault's browsing window. The only thing to remind you of this when you stop browsing is a dusty old tome sitting on the desk. You don't really remember printing it.</span>")
 				user.visible_message("[user] stares at the blank screen for a few moments, his expression frozen in fear. When he finally awakens from it, he looks a lot older.", 2)
 				src.arcanecheckout = 0


### PR DESCRIPTION
Fixed #20743
:cl:
* bugfix: Another tentative attempt at preventing borged cultists from seeing cult antag HUD icons.
* tweak: Cultists now only reject loyalty implants from ACT II onwards. Implants will pop out from already implanted cultists when they reach that point.
* tweak: The library computer's Forbidden Lore Vault now provides the newest edition of the Arcane Tome.
* tweak: Planting an empty Soul Blade on an Altar will now only prompt observers if the blade isn't planted on a mob, such as the sacrifice. Sacrifice targets can now have their souls reliably saved this way (as they become the blade's shade upon Sacrifice)
