### PR TITLE
one_click_antag fixes

### DIFF
--- a/code/datums/gamemode/role/syndicate.dm
+++ b/code/datums/gamemode/role/syndicate.dm
@@ -1,6 +1,7 @@
 /datum/role/traitor
 	name = TRAITOR
 	id = TRAITOR
+	required_pref = ROLE_TRAITOR
 	logo_state = "synd-logo"
 	wikiroute = ROLE_TRAITOR
 

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -32,7 +32,7 @@
 				to_chat(usr, "<span class='notice'>[success] number of revolutionaries made.</span>")
 			if("4")
 				message_admins("[key_name(usr)] has attempted to spawn [count] cultists.")
-				var/success = makeAntag(null, /datum/faction/cult, count , FROM_PLAYERS)
+				var/success = makeAntag(null, /datum/faction/bloodcult, count , FROM_PLAYERS)
 				message_admins("[success] number of cultists made.")
 				to_chat(usr, "<span class='notice'>[success] number of cultists made..</span>")
 			if("5")

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -77,8 +77,9 @@ client/proc/one_click_antag()
 			var/datum/mind/M = H.mind
 			if(FF.HandleNewMind(M))
 				var/datum/role/RR = FF.get_member_by_mind(M)
-				RR.ForgeObjectives()
-				message_admins("[key_name(H)] has been recruited as leader of [F.name] via create antagonist verb.")
+				RR.OnPostSetup()
+				RR.Greet(GREET_LATEJOIN)
+				message_admins("[key_name(H)] has been recruited as leader of [FF.name] via create antagonist verb.")
 				recruit_count++
 				count--
 
@@ -92,7 +93,8 @@ client/proc/one_click_antag()
 			message_admins("polling if [key_name(H)] wants to become a member of [FF.name]")
 			if(FF.HandleRecruitedMind(M))
 				var/datum/role/RR = FF.get_member_by_mind(M)
-				RR.ForgeObjectives()
+				RR.OnPostSetup()
+				RR.Greet(GREET_LATEJOIN)
 				message_admins("[key_name(H)] has been recruited as recruit of [F.name] via create antagonist verb.")
 				recruit_count++
 
@@ -118,7 +120,7 @@ client/proc/one_click_antag()
 				newRole.Drop()
 				continue
 			newRole.OnPostSetup()
-			newRole.ForgeObjectives()
+			newRole.Greet(GREET_LATEJOIN)
 			message_admins("[key_name(H)] has been made into a [newRole.name] via create antagonist verb.")
 			recruit_count++
 


### PR DESCRIPTION
Doesn't give double objectives
Faction members are given post setup now. should closes #20753
Antags are greeted

Syndicate role now has the proper role requirement. closes #20748
Cult one-click now uses bloodcult. closes #20751
