### PR TITLE
change_base_turf uses CHECK_TICK

### DIFF
--- a/maps/_map.dm
+++ b/maps/_map.dm
@@ -205,15 +205,13 @@ proc/get_base_turf(var/z)
 	return L.base_turf
 
 proc/change_base_turf(var/choice,var/new_base_path,var/update_old_base = 0)
-	if(update_old_base)
-		var/count = 0
-		for(var/turf/T in world)
-			count++
-			if(!(count % 50000))
-				sleep(world.tick_lag)
-			if(T.type == get_base_turf(choice) && T.z == choice)
-				T.ChangeTurf(new_base_path)
 	var/datum/zLevel/L = map.zLevels[choice]
+	if(update_old_base)
+		var/previous_base_turf = L.base_turf
+		for(var/turf/T in world)
+			CHECK_TICK
+			if(T.type == previous_base_turf && T.z == choice)
+				T.ChangeTurf(new_base_path)
 	L.base_turf = new_base_path
 	for(var/obj/docking_port/destination/D in all_docking_ports)
 		if(D.z == choice)


### PR DESCRIPTION
#20778 but better apparently

original:
![image](https://user-images.githubusercontent.com/6307265/48831250-bd245980-ed76-11e8-9e7f-1076330e4f7c.png)

this PR:
![image](https://user-images.githubusercontent.com/6307265/48831272-c6152b00-ed76-11e8-8db8-22ec1e239631.png)

#20778:
![image](https://user-images.githubusercontent.com/6307265/48831293-cf9e9300-ed76-11e8-8e12-71f47b54f0f4.png)

Notes:
I also explored the option of creating a list of turfs in the zLevel datum but it performed slightly worse than this.