### PR TITLE
potentially maybe perhaps possibly actually fix the nanoui bug

### DIFF
--- a/code/modules/nano/nanoui.dm
+++ b/code/modules/nano/nanoui.dm
@@ -485,7 +485,8 @@ nanoui is used to open and update nano browser uis
 		if(user && winexists(user, window_id))
 			var/params = "\ref[src]"
 			winset(user, window_id, "on-close=\"nanoclose [params]\"")
-			break
+			return
+	close()
 
  /**
   * Push data to an already open UI window


### PR DESCRIPTION
The assumption here is that if you managed to somehow
1. Open a nanoUI window
2. Fail 10 winexists checks
then it just means you closed the window before we could winset, so we'll just close the nanoui datum