### PR TITLE
Fixes not being able to flip windoors when constructing them

### DIFF
--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -73,6 +73,8 @@ obj/structure/windoor_assembly/Destroy()
 	var/spawn_type = secure ? secure_type : windoor_type
 	var/obj/machinery/door/window/windoor = new spawn_type(loc)
 	windoor.dir = dir
+	windoor.base_state = (facing == "l" ? "left" : "right")
+	windoor.icon_state = windoor.base_state
 	transfer_fingerprints_to(windoor)
 	set_windoor_electronics(windoor)
 	return windoor


### PR DESCRIPTION
You could flip them before but it did nothing