### PR TITLE
Z levels only process if there's a player on that zlevel

### DIFF
--- a/code/WorkInProgress/Cael_Aislinn/scp_173.dm
+++ b/code/WorkInProgress/Cael_Aislinn/scp_173.dm
@@ -228,7 +228,7 @@
 			var/obj/machinery/atmospherics/unary/vent_pump/exit_vent = pick(vents)
 			spawn()
 				visible_message("<span class='danger'>\The [src] suddenly disappears into the vent!</span>")
-				loc = exit_vent
+				forceMove(exit_vent)
 				var/travel_time = round(get_dist(loc, exit_vent.loc)/2)
 				spawn(travel_time)
 					if(!exit_vent || exit_vent.welded)

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -183,6 +183,8 @@
 
 	// Weighted Votes
 	var/weighted_votes = 0
+	//If there are no players on a zlevel, things will stop processing on it
+	var/disable_zlevel_processing_if_no_players
 
 /datum/configuration/New()
 	. = ..()
@@ -577,6 +579,8 @@
 					discord_password = value
 				if("weighted_votes")
 					weighted_votes = TRUE
+				if("disable_zlevel_processing_if_no_players")
+					disable_zlevel_processing_if_no_players = TRUE
 
 				else
 					diary << "Unknown setting in configuration: '[name]'"

--- a/code/controllers/subsystem/init/map.dm
+++ b/code/controllers/subsystem/init/map.dm
@@ -2,21 +2,33 @@
 
 var/datum/subsystem/map/SSmap
 
+/**
+List of players by z level
+	list(1 = list(mind1, mind2, mind3...)
+		2 = list())
+
+fleshed out in map init
+populated during player spawning.
+
+**/
+var/list/players_by_z_level = list()
+
+
+
+proc/handle_z_level_transition(var/datum/mind/M, var/from_z, var/to_z)
+	if(players_by_z_level.len && from_z && to_z && M) //If it's initialized
+		for(var/i = 1 to players_by_z_level.len) //Find them in the list currently
+			if(islist(players_by_z_level[i]))
+				var/list/L = players_by_z_level[i]
+				if(i != to_z && L.Find(M)) //They are in this list, and shouldn't be
+					L.Remove(M)
+				if(i == to_z && !L.Find(M)) //They aren't in this list and should be
+					L.Add(M)
 
 /datum/subsystem/map
 	name       = "Map"
 	init_order = SS_INIT_MAP
 	flags      = SS_NO_FIRE
-	/**
-	List of players by z level
-		list(1 = list(mind1, mind2, mind3...)
-			2 = list())
-
-	fleshed out in map init
-	populated during player spawning.
-
-	**/
-	var/list/players_by_z_level = list()
 
 
 /datum/subsystem/map/New()
@@ -47,13 +59,3 @@ var/datum/subsystem/map/SSmap
 			players_by_z_level[Z.z] = list()
 		log_startup_progress("List initialized. number of zLevels [players_by_z_level.len].")
 	..()
-
-/datum/subsystem/map/proc/handle_z_level_transition(var/datum/mind/M, var/from_z, var/to_z)
-	if(players_by_z_level.len) //If it's initialized
-		for(var/i = 1 to players_by_z_level.len) //Find them in the list currently
-			if(islist(players_by_z_level[i]))
-				var/list/L = players_by_z_level[i]
-				if(i != to_z && L.Find(M)) //They are in this list, and shouldn't be
-					L.Remove(M)
-				if(i == to_z && !L.Find(M)) //They aren't in this list and should be
-					L.Add(M)

--- a/code/controllers/subsystem/machinery.dm
+++ b/code/controllers/subsystem/machinery.dm
@@ -40,9 +40,9 @@ var/list/machines = list()
 		if (!M || M.gcDestroyed || M.disposed || M.timestopped)
 			continue
 
-		if(SSmap.players_by_z_level.len && M.z)
-			var/list/L = SSmap.players_by_z_level[M.z]
-			if(!L.len) //Nobody here
+		if(players_by_z_level.len && M.z)
+			var/list/L = players_by_z_level[M.z]
+			if(!L.len)
 				continue
 
 		if (M.process() == PROCESS_KILL)

--- a/code/controllers/subsystem/machinery.dm
+++ b/code/controllers/subsystem/machinery.dm
@@ -40,6 +40,11 @@ var/list/machines = list()
 		if (!M || M.gcDestroyed || M.disposed || M.timestopped)
 			continue
 
+		if(SSmap.players_by_z_level.len && M.z)
+			var/list/L = SSmap.players_by_z_level[M.z]
+			if(!L.len) //Nobody here
+				continue
+
 		if (M.process() == PROCESS_KILL)
 			M.inMachineList = 0
 			machines.Remove(M)

--- a/code/controllers/subsystem/mob.dm
+++ b/code/controllers/subsystem/mob.dm
@@ -30,8 +30,8 @@ var/datum/subsystem/mob/SSmob
 		if (!M || M.disposed || M.gcDestroyed || M.timestopped)
 			continue
 
-		if(SSmap.players_by_z_level.len && M.z)
-			var/list/L = SSmap.players_by_z_level[M.z]
+		if(players_by_z_level.len && M.z)
+			var/list/L = players_by_z_level[M.z]
 			if(!L.len) //Nobody here
 				continue
 

--- a/code/controllers/subsystem/mob.dm
+++ b/code/controllers/subsystem/mob.dm
@@ -30,6 +30,11 @@ var/datum/subsystem/mob/SSmob
 		if (!M || M.disposed || M.gcDestroyed || M.timestopped)
 			continue
 
+		if(SSmap.players_by_z_level.len && M.z)
+			var/list/L = SSmap.players_by_z_level[M.z]
+			if(!L.len) //Nobody here
+				continue
+
 		M.Life()
 
 		if (MC_TICK_CHECK)

--- a/code/controllers/subsystem/objects.dm
+++ b/code/controllers/subsystem/objects.dm
@@ -43,6 +43,11 @@ var/list/processing_objects = list()
 		if (!o || o.gcDestroyed || o.disposed || o.timestopped)
 			continue
 
+		if(SSmap.players_by_z_level.len && o.z)
+			var/list/L = SSmap.players_by_z_level[o.z]
+			if(!L.len) //Nobody here
+				continue
+
 		// > this fucking proc isn't defined on a global level.
 		// > Which means I can't fucking set waitfor on all of them.
 		o:process()

--- a/code/controllers/subsystem/objects.dm
+++ b/code/controllers/subsystem/objects.dm
@@ -43,8 +43,8 @@ var/list/processing_objects = list()
 		if (!o || o.gcDestroyed || o.disposed || o.timestopped)
 			continue
 
-		if(SSmap.players_by_z_level.len && o.z)
-			var/list/L = SSmap.players_by_z_level[o.z]
+		if(players_by_z_level.len && o.z)
+			var/list/L = players_by_z_level[o.z]
 			if(!L.len) //Nobody here
 				continue
 

--- a/code/controllers/subsystem/pipenet.dm
+++ b/code/controllers/subsystem/pipenet.dm
@@ -51,6 +51,11 @@ var/event/on_pipenet_tick = new
 		if (!atmosmachinery || atmosmachinery.gcDestroyed || atmosmachinery.disposed || atmosmachinery.timestopped)
 			continue
 
+		if(SSmap.players_by_z_level.len && atmosmachinery.z)
+			var/list/L = SSmap.players_by_z_level[atmosmachinery.z]
+			if(!L.len) //Nobody here
+				continue
+
 		if (atmosmachinery.process() && MC_TICK_CHECK)
 			return
 

--- a/code/controllers/subsystem/pipenet.dm
+++ b/code/controllers/subsystem/pipenet.dm
@@ -51,8 +51,8 @@ var/event/on_pipenet_tick = new
 		if (!atmosmachinery || atmosmachinery.gcDestroyed || atmosmachinery.disposed || atmosmachinery.timestopped)
 			continue
 
-		if(SSmap.players_by_z_level.len && atmosmachinery.z)
-			var/list/L = SSmap.players_by_z_level[atmosmachinery.z]
+		if(players_by_z_level.len && atmosmachinery.z)
+			var/list/L = players_by_z_level[atmosmachinery.z]
 			if(!L.len) //Nobody here
 				continue
 

--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -135,11 +135,6 @@
 		P.override_target_Y += Ychange
 		P.reflected = TRUE//you can now get hit by the projectile you just fired. Careful with portals!
 
-	if(curturf.z != destturf.z)
-		INVOKE_EVENT(teleatom.on_z_transition, list("user" = teleatom, "from_z" = curturf.z, "to_z" = destturf.z))
-		for(var/atom/AA in recursive_type_check(teleatom))
-			INVOKE_EVENT(AA.on_z_transition, list("user" = AA, "from_z" = curturf.z, "to_z" = destturf.z))
-
 	if(force_teleport)
 		teleatom.forceMove(destturf,TRUE)
 		playSpecials(destturf,effectout,soundout)

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -97,7 +97,7 @@
 	current = new_character		//link ourself to our new body
 	new_character.mind = src	//and link our new body to ourself
 
-	SSmap.handle_z_level_transition(src, old_character.z, current.z)
+	handle_z_level_transition(src, old_character.z, current.z)
 	for (var/role in antag_roles)
 		var/datum/role/R = antag_roles[role]
 		R.PostMindTransfer(new_character, old_character)
@@ -464,7 +464,7 @@
 	if(!mind.name)
 		mind.name = real_name
 	mind.current = src
-	SSmap.handle_z_level_transition(mind, z, z) //Puts them on the players_in_zlevel list
+	handle_z_level_transition(mind, z, z) //Puts them on the players_in_zlevel list
 
 //HUMAN
 /mob/living/carbon/human/mind_initialize()

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -96,7 +96,8 @@
 	var/mob/old_character = current
 	current = new_character		//link ourself to our new body
 	new_character.mind = src	//and link our new body to ourself
-	
+
+	SSmap.handle_z_level_transition(src, old_character.z, current.z)
 	for (var/role in antag_roles)
 		var/datum/role/R = antag_roles[role]
 		R.PostMindTransfer(new_character, old_character)
@@ -463,6 +464,7 @@
 	if(!mind.name)
 		mind.name = real_name
 	mind.current = src
+	SSmap.handle_z_level_transition(mind, z, z) //Puts them on the players_in_zlevel list
 
 //HUMAN
 /mob/living/carbon/human/mind_initialize()

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -944,3 +944,8 @@ its easier to just keep the beam vertical.
 
 /atom/proc/thermal_energy_transfer()
 	return
+
+/atom/proc/on_z_transition(var/old_z, var/new_z)
+	INVOKE_EVENT(on_z_transition, list("user" = src, "from_z" = old_z, "to_z" = new_z))
+	for(var/atom/AA in recursive_type_check(src))
+		INVOKE_EVENT(AA.on_z_transition, list("user" = AA, "from_z" = old_z, "to_z" = new_z))

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -256,6 +256,8 @@
 	src.l_move_time = world.timeofday
 	// Update on_moved listeners.
 	INVOKE_EVENT(on_moved,list("loc"=NewLoc))
+	if(oldloc.z != z)
+		on_z_transition(oldloc.z, z)
 
 /atom/movable/search_contents_for(path,list/filter_path=null) // For vehicles
 	var/list/found = ..()
@@ -449,7 +451,7 @@
 	INVOKE_EVENT(on_moved,list("loc"=loc))
 	var/turf/T = get_turf(destination)
 	if(old_loc && T && old_loc.z != T.z)
-		INVOKE_EVENT(on_z_transition, list("user" = src, "from_z" = old_loc.z, "to_z" = T.z))
+		on_z_transition(old_loc.z, T.z)
 	return 1
 
 /atom/movable/proc/update_client_hook(atom/destination)

--- a/code/game/objects/items/weapons/scrolls.dm
+++ b/code/game/objects/items/weapons/scrolls.dm
@@ -85,19 +85,16 @@
 	var/list/tempL = L
 	var/attempt = null
 	var/success = 0
-	var/prev_z = user.z
 	while(tempL.len)
 		attempt = pick(tempL)
 		success = user.Move(attempt)
 		if(!success)
 			tempL.Remove(attempt)
 		else
-			INVOKE_EVENT(user.on_z_transition, list("user" = user, "to_z" = user.z, "from_z" = prev_z))
 			break
 
 	if(!success)
 		user.forceMove(pick(L))
-		INVOKE_EVENT(user.on_z_transition, list("user" = user, "to_z" = user.z, "from_z" = prev_z))
 
 	smoke.start()
 	src.uses -= 1

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -236,9 +236,6 @@
 			if(!move_to_z)
 				return
 
-			INVOKE_EVENT(A.on_z_transition, list("user" = A, "from_z" = A.z, "to_z" = move_to_z))
-			for(var/atom/AA in contents_brought)
-				INVOKE_EVENT(AA.on_z_transition, list("user" = AA, "from_z" = AA.z, "to_z" = move_to_z))
 			A.z = move_to_z
 
 			if(src.x <= TRANSITIONEDGE)

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -123,4 +123,4 @@
 		client.CAN_MOVE_DIAGONALLY = 0
 
 	if(mind)
-		SSmap.handle_z_level_transition(mind, z, z)
+		handle_z_level_transition(mind, z, z)

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -121,3 +121,6 @@
 
 	if(client)
 		client.CAN_MOVE_DIAGONALLY = 0
+
+	if(mind)
+		SSmap.handle_z_level_transition(mind, z, z)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -2198,7 +2198,7 @@ mob/proc/on_foot()
 /mob/on_z_transition(var/old_z, var/new_z)
 	..()
 	if(mind)
-		SSmap.handle_z_level_transition(mind, old_z, new_z)
+		handle_z_level_transition(mind, old_z, new_z)
 
 #undef MOB_SPACEDRUGS_HALLUCINATING
 #undef MOB_MINDBREAKER_HALLUCINATING

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -2195,5 +2195,10 @@ mob/proc/on_foot()
 			var/datum/role/R = mind.antag_roles[role]
 			R.update_antag_hud()
 
+/mob/on_z_transition(var/old_z, var/new_z)
+	..()
+	if(mind)
+		SSmap.handle_z_level_transition(mind, old_z, new_z)
+
 #undef MOB_SPACEDRUGS_HALLUCINATING
 #undef MOB_MINDBREAKER_HALLUCINATING

--- a/maps/_map.dm
+++ b/maps/_map.dm
@@ -119,10 +119,12 @@
 		level.base_turf = /turf/space
 	if(z_to_use > zLevels.len)
 		zLevels.len = z_to_use
+		if(SSmap.players_by_z_level.len && z_to_use > SSmap.players_by_z_level.len)
+			SSmap.players_by_z_level.Add(z_to_use)
+			SSmap.players_by_z_level[z_to_use] = list()
 	zLevels[z_to_use] = level
 	if(!level.movementJammed)
 		accessable_z_levels += list("[z_to_use]" = level.movementChance)
-
 	level.z = z_to_use
 
 var/global/list/accessable_z_levels = list()

--- a/maps/_map.dm
+++ b/maps/_map.dm
@@ -119,9 +119,9 @@
 		level.base_turf = /turf/space
 	if(z_to_use > zLevels.len)
 		zLevels.len = z_to_use
-		if(SSmap.players_by_z_level.len && z_to_use > SSmap.players_by_z_level.len)
-			SSmap.players_by_z_level.Add(z_to_use)
-			SSmap.players_by_z_level[z_to_use] = list()
+		if(players_by_z_level.len && z_to_use > players_by_z_level.len)
+			players_by_z_level.Add(z_to_use)
+			players_by_z_level[z_to_use] = list()
 	zLevels[z_to_use] = level
 	if(!level.movementJammed)
 		accessable_z_levels += list("[z_to_use]" = level.movementChance)


### PR DESCRIPTION
Just a silly idea I had, when I heard that TG or somewhere had processing only happen when a player was on it.

Needs to be enabled in config, and when it is, creates a list in the map subsystem that holds however many zlevels there are amount of lists.

Each list holds a reference to a mind datum, which is moved around during z level transition.

Currently object, machinery, mob, and some atmospheric machine processing require there to be a mob on the zlevel, should the list of lists be initialized.

Also, moves the on_z_transition event to on_z_transition proc (atom level), which is called by a players move and forceMove, rather than everywhere.
