### PR TITLE
Fixes viro incubator getting toxins incorrectly

### DIFF
--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -635,13 +635,13 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 
 /datum/reagents/proc/remove_any_reagents(var/list/reagent_list, var/amount, var/safety)
 	if(!isnum(amount))
-		return 0
+		return 1
 	for(var/id in reagent_list)
 		if(has_reagent(id))
 			amount -= remove_reagent(id, amount, safety)
 			if(amount <= 0)
-				return 1
-	return 0
+				return 0
+	return 1
 
 /datum/reagents/proc/remove_reagent_by_type(var/reagent_type, var/amount, var/safety)
 	if(!isnum(amount))

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -635,13 +635,13 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 
 /datum/reagents/proc/remove_any_reagents(var/list/reagent_list, var/amount, var/safety)
 	if(!isnum(amount))
-		return 1
+		return 0
 	for(var/id in reagent_list)
 		if(has_reagent(id))
 			amount -= remove_reagent(id, amount, safety)
 			if(amount <= 0)
-				return 0
-	return 1
+				return 1
+	return 0
 
 /datum/reagents/proc/remove_reagent_by_type(var/reagent_type, var/amount, var/safety)
 	if(!isnum(amount))

--- a/code/modules/virus2/dishincubator.dm
+++ b/code/modules/virus2/dishincubator.dm
@@ -208,7 +208,7 @@
 	if(beaker)
 		if(!beaker.reagents.remove_reagent(VIRUSFOOD,5))
 			foodsupply += 10
-		if(!beaker.reagents.remove_any_reagents(TOXINS,1))
+		if(beaker.reagents.remove_any_reagents(TOXINS,1))
 			toxins += 1
 
 	src.updateUsrDialog()


### PR DESCRIPTION
Fixes
![235659889](https://user-images.githubusercontent.com/31839805/49047639-eedd5c00-f18c-11e8-9804-01dcd1c8bb91.PNG)

https://github.com/vgstation-coders/vgstation13/blob/9352e082dceadc3bcc0c92e21ab293ce4f505f47/code/modules/virus2/dishincubator.dm#L211-L212
Only thing that uses ``remove_any_reagents()`` right now is this. ~~Returning 1 for a negative result is consistent with the other chemistry holder procs, which is why I did it on this end.~~

:cl:
* bugfix: Fixed pathogenic incubator accumulating toxins for no reason.