### PR TITLE
Confusion rune disguises humans and silicons now

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -106,7 +106,7 @@
 /mob/living/carbon/human/generate_static_overlay()
 	if(!istype(static_overlays,/list))
 		static_overlays = list()
-	static_overlays.Add(list("static", "blank", "letter"))
+	static_overlays.Add(list("static", "blank", "letter", "cult"))
 	var/image/static_overlay = image(icon('icons/effects/effects.dmi', "static"), loc = src)
 	static_overlay.override = 1
 	static_overlays["static"] = static_overlay
@@ -118,6 +118,12 @@
 	static_overlay = getLetterImage(src, "H", 1)
 	static_overlay.override = 1
 	static_overlays["letter"] = static_overlay
+
+	static_overlay = image(icon = 'icons/mob/animal.dmi', loc = src, icon_state = pick("faithless","forgotten","otherthing",))
+
+	static_overlay.override = 1
+
+	static_overlays["cult"] = static_overlay
 
 /mob/living/carbon/human/New(var/new_loc, var/new_species_name = null, var/delay_ready_dna=0)
 	if(new_species_name)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -120,9 +120,7 @@
 	static_overlays["letter"] = static_overlay
 
 	static_overlay = image(icon = 'icons/mob/animal.dmi', loc = src, icon_state = pick("faithless","forgotten","otherthing",))
-
 	static_overlay.override = 1
-
 	static_overlays["cult"] = static_overlay
 
 /mob/living/carbon/human/New(var/new_loc, var/new_species_name = null, var/delay_ready_dna=0)

--- a/code/modules/mob/living/silicon/mommi/login.dm
+++ b/code/modules/mob/living/silicon/mommi/login.dm
@@ -9,10 +9,6 @@
 /mob/living/silicon/robot/mommi/proc/can_see_static()
 	return (keeper && !emagged && !syndicate && (config && config.mommi_static))
 
-/mob/living/silicon/robot/mommi/generate_static_overlay()
-	if(!islist(static_overlays))
-		static_overlays = list()
-
 /mob/living/silicon/robot/mommi/proc/add_static_overlays()
 	remove_static_overlays()
 	for(var/mob/living/living in mob_list)

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -122,7 +122,13 @@
 	return 1
 
 /mob/living/silicon/generate_static_overlay()
-	return
+	if(!istype(static_overlays,/list))
+		static_overlays = list()
+	static_overlays.Add(list("cult"))
+
+	var/image/static_overlay = image(icon = 'icons/mob/animal.dmi', loc = src, icon_state = pick("faithless","forgotten","otherthing",))
+	static_overlay.override = 1
+	static_overlays["cult"] = static_overlay
 
 /mob/living/silicon/emp_act(severity)
 	for(var/obj/item/stickybomb/B in src)


### PR DESCRIPTION
[bugfix] [gamemode] [tested]

:cl:
* bugfix: Confusion rune now affects the appearance of all mobs, not just non-human non-silicons.