### PR TITLE
Probably fixes breaches not draining

### DIFF
--- a/code/ZAS/Zone.dm
+++ b/code/ZAS/Zone.dm
@@ -99,6 +99,13 @@ Class Procs:
 		T.dbg(merged)
 		#endif
 
+	//Rebuild the old zone's edges so that they will be possessed by the new zone
+	for(var/connection_edge/E in edges)
+		if(E.contains_zone(into))
+			E.erase() //Don't need to connect the new zone to itself
+		for(var/turf/T in E.connecting_turfs)
+			SSair.mark_for_update(T)
+
 /zone/proc/c_invalidate()
 	invalid = 1
 	SSair.remove_zone(src)


### PR DESCRIPTION
I still have no idea why this only became relevant after the ZAS update, as I can see no evidence edges were ever transferred when zones merged
But whatever

Unless demonstrated otherwise, fixes #15216, fixes #14141, fixes #16965

Unclear whether or not this is the same bug that was observed at least as early as 2015, which had the same effect but was extremely rare

Also, does not affect #19258 because that's a shitty feature, not a bug
So if you think you see this issue again, make sure the air isn't just draining very slowly before you report it