### PR TITLE
Mops and crematoriums now call parent on Destroy

### DIFF
--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -19,6 +19,7 @@
 
 /obj/item/weapon/mop/Destroy()
 	mop_list.Remove(src)
+	..()
 
 /obj/item/weapon/mop/proc/clean(turf/simulated/A as turf)
 	reagents.reaction(A,1,10) //Mops magically make chems ten times more efficient than usual, aka equivalent of 50 units of whatever you're using

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -162,6 +162,8 @@
 	update()
 
 /obj/structure/morgue/Destroy()
+	if(connected)
+		qdel(connected)
 	. = ..()
 
 /*

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -163,8 +163,6 @@
 
 /obj/structure/morgue/Destroy()
 	. = ..()
-	if(connected)
-		qdel(connected) //references get cleared in the tray's Destroy()
 
 /*
  * Morgue tray
@@ -236,6 +234,7 @@
 
 /obj/structure/crematorium/Destroy()
 	crematorium_list.Remove(src)
+	..()
 
 /obj/structure/crematorium/proc/update()
 	if (cremating)


### PR DESCRIPTION
After watching an indestructable mop and crematorium orbit the singularity, it sadly had to be done