### PR TITLE
Fixes cameras crashing the serb (sometimes)

### DIFF
--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -169,13 +169,13 @@ var/list/obj/machinery/camera/cyborg_cams = list(
 	var/obj/machinery/camera/D
 
 	while (!found && (place != place_0))
-		if (place > net.len)
-			place = 1
 		D = net[place]
 		var/list/tempnetwork = (D.network & network)
 		if (tempnetwork.len && D.can_use()) // D.can_use() is false if the camera is EMP or whatever
 			found = TRUE
 		++place
+		if (place > net.len)
+			place = 1
 	set_camera(user, D)
 
 /obj/machinery/computer/security/proc/previous(var/mob/living/user)

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -160,6 +160,9 @@ var/list/obj/machinery/camera/cyborg_cams = list(
 	var/list/net = cameranet.cameras
 
 	var/place = net.Find(current)
+	if (!place) // Couldn't find the camera in the net ; it may have been destroyed
+		user.cancel_camera()
+		return FALSE
 	var/place_0 = place // Prevent infinite loops if there is litteraly no next camera usuable.
 	++place
 	var/found = FALSE
@@ -180,19 +183,22 @@ var/list/obj/machinery/camera/cyborg_cams = list(
 	var/list/net = cameranet.cameras
 
 	var/place = net.Find(current)
+	if (!place) // Couldn't find the camera in the net ; it may have been destroyed
+		user.cancel_camera()
+		return FALSE
 	var/place_0 = place // Prevent infinite loops if there is litteraly no next camera usuable.
 	place--
 	var/found = FALSE
 	var/obj/machinery/camera/D
 
 	while (!found  && (place != place_0))
-		if (place <= 0)
-			place = net.len
 		D = net[place]
 		var/list/tempnetwork = (D.network & network)
 		if (tempnetwork.len && D.can_use())
 			found = TRUE
 		place--
+		if (place <= 0)
+			place = net.len
 	set_camera(user, D)
 
 


### PR DESCRIPTION
[tested]
Cameras did a bad thing last round.
An infinite loop can happen with new, fancy sec cameras in two occasions : 

1) The computer has no current camera. It goes through the whole list of cameras without finding a stopping point, again and again ; `place_0 = 0` and `place >= 1` for all cameras, so the check doesn't work.

2) The computer has a current camera, but without the good network assigned to it, and this camera is the first in the list. Then, the "safety checks" skips the first camera because I suck at logic. (the compter is set to 1 AND incremented after, so `place_0 == 1` is never checked).

Both cases are reproducible and both cases crash the server. This PR fixes both cases.
I truly am sorry.