### PR TITLE
Runtime hunting: portable pumps altclick

### DIFF
--- a/code/game/machinery/atmoalter/portable_atmospherics.dm
+++ b/code/game/machinery/atmoalter/portable_atmospherics.dm
@@ -86,8 +86,9 @@
 	return 1
 
 /obj/machinery/portable_atmospherics/proc/eject_holding()
-	holding.forceMove(loc)
-	holding = null
+	if(holding)
+		holding.forceMove(loc)
+		holding = null
 
 /obj/machinery/portable_atmospherics/attackby(var/obj/item/weapon/W as obj, var/mob/user as mob)
 


### PR DESCRIPTION
```
x1 portable_atmospherics.dm,89: Cannot execute null.forceMove().
  proc name: eject holding (/obj/machinery/portable_atmospherics/proc/eject_holding)
  usr: Gary Soup (subs455) (/mob/living/carbon/human)
  usr.loc: Holodeck Projector Floor (263, 266, 1) (/turf/simulated/floor/engine)
  src: Portable Air Pump (/obj/machinery/portable_atmospherics/pump)
  src.loc: Holodeck Projector Floor (264,266,1) (/turf/simulated/floor/engine)
  call stack:
  Portable Air Pump (/obj/machinery/portable_atmospherics/pump): eject holding()
  Portable Air Pump (/obj/machinery/portable_atmospherics/pump): AltClick(Gary Soup (/mob/living/carbon/human))
  Gary Soup (/mob/living/carbon/human): AltClickOn(Portable Air Pump (/obj/machinery/portable_atmospherics/pump))
  Gary Soup (/mob/living/carbon/human): AltClickOn(Portable Air Pump (/obj/machinery/portable_atmospherics/pump))
  Gary Soup (/mob/living/carbon/human): ClickOn(Portable Air Pump (/obj/machinery/portable_atmospherics/pump), "icon-x=19;icon-y=11;left=1;alt...")
  Portable Air Pump (/obj/machinery/portable_atmospherics/pump): Click(Holodeck Projector Floor (264,266,1) (/turf/simulated/floor/engine), "mapwindow.map", "icon-x=19;icon-y=11;left=1;alt...")
  Subs455 (/client): Click(Portable Air Pump (/obj/machinery/portable_atmospherics/pump), Holodeck Projector Floor (264,266,1) (/turf/simulated/floor/engine), "mapwindow.map", "icon-x=19;icon-y=11;left=1;alt...")
```