### PR TITLE
Updates the chemistry manual link, adds it to chemist lockers

### DIFF
--- a/code/game/objects/items/weapons/manuals.dm
+++ b/code/game/objects/items/weapons/manuals.dm
@@ -156,7 +156,7 @@
 	icon_state ="bookChemistry"
 	author = "SpaceChem Inc."
 	title = "Chemistry 101"
-	wiki_page = "Chemistry_101"
+	wiki_page = "Guide_to_Chemistry"
 
 
 /obj/item/weapon/book/manual/ripley_build_and_repair

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -159,6 +159,7 @@
 /obj/structure/closet/secure_closet/chemical/atoms_to_spawn()
 	return list(
 		/obj/item/weapon/storage/box/pillbottles = 2,
+		/obj/item/weapon/book/manual/chemistry_manual,
 	)
 
 /obj/structure/closet/secure_closet/medical_wall


### PR DESCRIPTION
Found last shift that the chemistry manual links to a dead page. This PR updates the link, and adds the book to chemist lockers.