### PR TITLE
Cult buildings can't be summoned off the station's z-level anymore.

### DIFF
--- a/__DEFINES/role_datums_defines.dm
+++ b/__DEFINES/role_datums_defines.dm
@@ -112,6 +112,7 @@
 #define RITUALABORT_CONCEAL	"conceal"
 #define RITUALABORT_NEAR	"near"
 #define RITUALABORT_MISSING	"missing"
+#define RITUALABORT_OUTPOST "outpost"
 
 #define TATTOO_POOL		"Blood Communion"
 #define TATTOO_SILENT	"Silent Casting"

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
@@ -149,7 +149,9 @@
 		if (RITUALABORT_NEAR)
 			if (activator)
 				to_chat(activator, "<span class='warning'>You cannot perform this ritual that close from another similar structure.</span>")
-
+		if (RITUALABORT_OUTPOST)
+			if (activator)
+				to_chat(activator, "<span class='sinister'>This place is too remote to interest the Geometer of Blood. We must raise our structure in the heart of the station.</span>")
 
 
 	for(var/mob/living/L in contributors)
@@ -256,6 +258,11 @@
 		return
 
 	var/mob/living/user = activator
+
+	if (user.z != map.zMainStation)
+		abort(RITUALABORT_OUTPOST)
+		return FALSE
+
 	if (veil_thickness >= CULT_ACT_II)
 		var/spawnchoice = alert(user,"As the veil is getting thinner, new possibilities arise.","[name]","Altar","Forge","Spire")
 		switch (spawnchoice)


### PR DESCRIPTION
[balance]
Reasoning :

Because outpost cult is rather boring.
Given that building can be concealed I hope this doesn't impact the ability of making a cultist base too much.

:cl:
- tweaks: Cult buildings cannot be summoned off the station's z-level anymore.