### PR TITLE
Fixes multirev

### DIFF
--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -87,6 +87,9 @@ client/proc/one_click_antag()
 			count--
 			var/mob/living/carbon/human/H = pick(candidates)
 			candidates.Remove(H)
+			var/initRoleID = initial(F.initroletype.id)
+			if (locate(initRoleID) in H.mind.antag_roles) // Ex: a head rev being made a revolutionary.
+				return FALSE
 			if(isobserver(H))
 				H = makeBody(H)
 			var/datum/mind/M = H.mind

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -87,8 +87,8 @@ client/proc/one_click_antag()
 			count--
 			var/mob/living/carbon/human/H = pick(candidates)
 			candidates.Remove(H)
-			var/initRoleID = initial(F.initroletype.id)
-			if (locate(initRoleID) in H.mind.antag_roles) // Ex: a head rev being made a revolutionary.
+			var/initRoleID = initial(F.initroletype.id) // A string.
+			if (initRoleID in H.mind.antag_roles) // Ex: a head rev being made a revolutionary.
 				return FALSE
 			if(isobserver(H))
 				H = makeBody(H)

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -87,8 +87,7 @@ client/proc/one_click_antag()
 			count--
 			var/mob/living/carbon/human/H = pick(candidates)
 			candidates.Remove(H)
-			var/initRoleID = initial(F.initroletype.id) // A string.
-			if (initRoleID in H.mind.antag_roles) // Ex: a head rev being made a revolutionary.
+			if (F.initial_role in H.mind.antag_roles) // Ex: a head rev being made a revolutionary.
 				continue
 			if(isobserver(H))
 				H = makeBody(H)

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -89,7 +89,7 @@ client/proc/one_click_antag()
 			candidates.Remove(H)
 			var/initRoleID = initial(F.initroletype.id) // A string.
 			if (initRoleID in H.mind.antag_roles) // Ex: a head rev being made a revolutionary.
-				return FALSE
+				continue
 			if(isobserver(H))
 				H = makeBody(H)
 			var/datum/mind/M = H.mind


### PR DESCRIPTION
Closes #20934 

The first part of the report isn't actually a bug, if there is a rev faction active, it will try to add the latejoiner role, which is in such a case a normal (red) rev.

Tested.