### PR TITLE
Chameleon projector passes the explosion value on to you! (SBO4)

### DIFF
--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -148,6 +148,15 @@
 		ex_act(severity)
 	disrupt()
 
+/obj/effect/dummy/chameleon/emp_act(severity)
+	for(var/mob/M in src)
+		emp_act(severity)
+	disrupt()
+
+/obj/effect/dummy/chameleon/blob_act()
+	..()
+	disrupt()
+
 /obj/effect/dummy/chameleon/bullet_act()
 	disrupt()
 

--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -143,7 +143,9 @@
 /obj/effect/dummy/chameleon/attack_hand()
 	disrupt()
 
-/obj/effect/dummy/chameleon/ex_act()
+/obj/effect/dummy/chameleon/ex_act(severity)
+	for(var/mob/M in src)
+		ex_act(severity)
 	disrupt()
 
 /obj/effect/dummy/chameleon/bullet_act()


### PR DESCRIPTION
fixes #17362

🆑 
* rscadd: Chamelon projectors no longer protect you from explosions or emps. Blobs can also disrupt them but will not pass on damage the first time.