### PR TITLE
Yet more blacksmithing tweaks

### DIFF
--- a/code/WorkInProgress/MadmanMartian/blacksmithing/misc_components.dm
+++ b/code/WorkInProgress/MadmanMartian/blacksmithing/misc_components.dm
@@ -17,6 +17,7 @@
 		if(do_after(user, src, 4 SECONDS))
 			user.drop_item(I)
 			finishing_requirements.Remove(I.type)
+			gen_quality(quality-I.quality, quality, I.material_type)
 			qdel(I)
 
 			if(!finishing_requirements.len) //We're done

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -634,8 +634,8 @@ a {
 				var/mob/M = loc
 				M.regenerate_icons()
 
-/obj/proc/gen_quality(var/modifier = 0, var/min_quality = 0)
-	var/material_mod = material_type ? material_type.quality_mod : 1
+/obj/proc/gen_quality(var/modifier = 0, var/min_quality = 0, var/datum/material/mat)
+	var/material_mod = mat ? mat.quality_mod : material_type ? material_type.quality_mod : 1
 	var/surrounding_mod = 1
 	/* - Probably better we find a better way of checking the quality of a room, like an area-level variable for room quality, and cleanliness
 	var/turf/T = get_turf(src)

--- a/code/modules/mining/materials.dm
+++ b/code/modules/mining/materials.dm
@@ -294,7 +294,7 @@ var/global/list/initial_materials	//Stores all the matids = 0 in helping New
 /datum/material/clown/on_use(obj/source) //May [ticker.deity] have mercy
 	if(!..())
 		return
-	if(prob(2*source.quality))
+	if(prob(10*source.quality))
 		playsound(get_turf(source), 'sound/items/bikehorn.ogg', 100, 1)
 
 /datum/material/phazon
@@ -314,7 +314,7 @@ var/global/list/initial_materials	//Stores all the matids = 0 in helping New
 /datum/material/phazon/on_use(obj/source, atom/target, mob/user)
 	if(!..())
 		return
-	if(prob(0.5*source.quality))
+	if(prob(5*source.quality))
 		switch(rand(1,2))
 			if(1) //EMP
 				empulse(get_turf(pick(source,target,user)), 0.25*source.quality, 0.5*source.quality, 1)


### PR DESCRIPTION
Each object you apply helps with quality.

Phazon and bananium effects now more likely to trigge

:cl:
 * tweak: Phazon and bananium material effects now more likely to trigger
 * rscadd: Each object used to create a blacksmithing object contribute to the quality