### PR TITLE
Bigger and thicker supply console UI

### DIFF
--- a/code/controllers/subsystem/supply_shuttle.dm
+++ b/code/controllers/subsystem/supply_shuttle.dm
@@ -5,8 +5,6 @@
 #define SUPPLY_DOCKZ 2          //Z-level of the Dock.
 #define SUPPLY_STATIONZ 1       //Z-level of the Station.
 
-#define SCREEN_WIDTH 480 // Dimensions of supply computer windows
-#define SCREEN_HEIGHT 590
 #define REASON_LEN 140 // max length for reason message, nanoui appears to not like long strings.
 
 var/datum/subsystem/supply_shuttle/SSsupply_shuttle

--- a/code/game/machinery/computer/cargo.dm
+++ b/code/game/machinery/computer/cargo.dm
@@ -279,7 +279,7 @@ For vending packs, see vending_packs.dm*/
 
 	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)
-		ui = new(user, src, ui_key, "supply_console.tmpl", name, SCREEN_WIDTH, SCREEN_HEIGHT)
+		ui = new(user, src, ui_key, "supply_console.tmpl", name, 600, 660)
 		ui.set_initial_data(data)
 		ui.open()
 
@@ -527,7 +527,7 @@ For vending packs, see vending_packs.dm*/
 
 	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if(!ui)
-		ui = new(user, src, ui_key, "order_console.tmpl", name, SCREEN_WIDTH, SCREEN_HEIGHT)
+		ui = new(user, src, ui_key, "order_console.tmpl", name, 600, 660)
 		ui.set_initial_data(data)
 		ui.open()
 

--- a/nano/templates/order_console.tmpl
+++ b/nano/templates/order_console.tmpl
@@ -1,5 +1,5 @@
-<!-- 
-Title: Supply Console UI 
+<!--
+Title: Supply Console UI
 Used In File(s): \code\game\supplyshuttle.dm
 -->
 
@@ -40,7 +40,7 @@ Used In File(s): \code\game\supplyshuttle.dm
 				{{for data.supply_packs}}
 					<div class="line">
 						<div class="statusValue">
-							{{:helper.link(value.name, null, value.command1, null, 'fixedLeftWide noOverflow')}}
+							{{:helper.link(value.name, null, value.command1, null, 'fixedLeftWidest noOverflow')}}
 							{{:helper.link('#', null, value.command2, null)}}${{:value.cost}}
 						</div>
 					</div>

--- a/nano/templates/supply_console.tmpl
+++ b/nano/templates/supply_console.tmpl
@@ -80,7 +80,7 @@ Used In File(s): \code\game\supplyshuttle.dm
 					{{for data.supply_packs}}
 						<div class="line">
 							<div class="statusValue">
-								{{:helper.link(value.name, null, value.command1, null, 'fixedLeftWide noOverflow')}}
+								{{:helper.link(value.name, null, value.command1, null, 'fixedLeftWidest noOverflow')}}
 								{{:helper.link('#', null, value.command2, null)}}${{:value.cost}}
 							</div>
 						</div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6307265/49701926-ba3cbc00-fbf2-11e8-80b4-c58e49017356.png)

The entries under "Supply Crates" have a larger box, the window itself is also bigger.