### PR TITLE
Can't Scan Supermatter (SBO7)

### DIFF
--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -19,6 +19,8 @@
 	density = 1
 	anchored = 0
 
+	mech_flags = MECH_SCAN_FAIL
+
 	var/max_luminosity = 8 // Now varies based on power.
 
 	light_color = LIGHT_COLOR_YELLOW


### PR DESCRIPTION
fixes #20768

🆑 
* bugfix: Supermatter can no longer be scanned with the device analyzer.