### PR TITLE
Allow crawling when knocked down

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -83,6 +83,9 @@
 		CtrlClickOn(A)
 		return
 
+	if(attempt_crawling(A))
+		return
+
 	if(isStunned())
 		return
 

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -52,11 +52,6 @@
 	else
 		A.attack_stump(src, params)
 
-	if(src.lying && !(isUnconscious() || stunned || paralysis) && check_crawl_ability() && isfloor(A) && isfloor(get_turf(src)) && proximity && !pulledby && !locked_to && !client.move_delayer.blocked())
-		var/crawldelay = round(1 + base_movement_tally()/5) * 1 SECONDS
-		Move(A, get_dir(src,A), glide_size_override = crawldelay)
-		delayNextMove(crawldelay, additive=1)
-
 	if(proximity && isobj(A))
 		var/obj/O = A
 		if(O.material_type)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1863,3 +1863,14 @@ mob/living/carbon/human/isincrit()
 	donkey.transfer_buttdentity(src)
 	op_stage.butt = SURGERY_NO_BUTT
 	return donkey
+
+/mob/living/carbon/human/attempt_crawling(var/turf/target)
+	if(!lying)
+		return FALSE
+	if(!isfloor(target) || !isfloor(get_turf(src)) || !Adjacent(target))
+		return FALSE
+	if(isUnconscious() || stunned || paralysis || !check_crawl_ability() || pulledby || locked_to || client.move_delayer.blocked())
+		return FALSE
+	var/crawldelay = round(1 + base_movement_tally()/5) * 1 SECONDS
+	. = Move(target, get_dir(src, target), glide_size_override = crawldelay)
+	delayNextMove(crawldelay, additive=1)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -2205,5 +2205,9 @@ mob/proc/on_foot()
 			var/datum/role/R = mind.antag_roles[role]
 			R.update_antag_hud()
 
+// Returns TRUE on success
+/mob/proc/attempt_crawling(var/turf/target)
+	return FALSE
+
 #undef MOB_SPACEDRUGS_HALLUCINATING
 #undef MOB_MINDBREAKER_HALLUCINATING


### PR DESCRIPTION
Non-exhaustive list of things that knock down without stunning:
- Pain
- Shuttle movement
- Flashes and flashers
- Mecha Honker (70% chance to not stun when knocking down)
- Chemical reagents explosions
- Stun mines
- Slipping on puddles
- Electropack (also from within a mech)
- toy crossbow memes
- flashbangs from more than 4 tiles away
- several failed clumsy checks (baton, defib)

And possibly more.
I personally only care about pain, which I think shouldn't prevent crawling (it's the whole point of this), and flashes, which I think SHOULD prevent crawling. [I'll address those in a separate PR.](https://github.com/vgstation-coders/vgstation13/pull/20995)

:cl:
 * tweak: Being knocked down no longer prevents you from crawling. Stuns and paralysis still do.