### PR TITLE
Limbs and organs preferences menu QoL

### DIFF
--- a/code/modules/client/preferences/subsections/limbs.dm
+++ b/code/modules/client/preferences/subsections/limbs.dm
@@ -92,9 +92,9 @@
 		dat += "<br>"
 	dat = jointext(dat, null)
 
-	var/datum/browser/popup = new(user, "\ref[src]-limbs", "Limbs", 500, 220)
+	var/datum/browser/popup = new(user, "\ref[src]-limbs", "Limbs", 500, 220, src)
 	popup.set_content(dat)
-	popup.open(use_onclose = FALSE)
+	popup.open()
 	return TRUE
 
 /datum/preferences_subsection/limbs/proc/handle_input(var/mob/user, var/list/href_list)
@@ -142,12 +142,19 @@
 	var/task = href_list["task"]
 	switch(task)
 		if("menu")
+			user << browse(null, "window=preferences")
 			return show_menu(arglist(args))
 		if("input")
 			. = handle_input(arglist(args))
 			show_menu(arglist(args))
 		else
 			CRASH("Unknown task: [task]")
+
+/datum/preferences_subsection/limbs/Topic(href, list/href_list)
+	. = ..()
+	if(href_list["close"])
+		usr << browse(null, "window=\ref[src]-limbs")
+		prefs.ShowChoices(usr)
 
 #undef LIMB_MODE_AFFECT_CHILD
 #undef LIMB_MODE_AFFECT_PARENT

--- a/code/modules/client/preferences/subsections/organs.dm
+++ b/code/modules/client/preferences/subsections/organs.dm
@@ -40,9 +40,9 @@
 		dat += "<br>"
 	dat = jointext(dat, null)
 
-	var/datum/browser/popup = new(user, "\ref[src]-organs", "Organs", 330, 200)
+	var/datum/browser/popup = new(user, "\ref[src]-organs", "Organs", 330, 200, src)
 	popup.set_content(dat)
-	popup.open(use_onclose = FALSE)
+	popup.open()
 	return TRUE
 
 /datum/preferences_subsection/organs/proc/handle_input(var/mob/user, var/list/href_list)
@@ -68,9 +68,16 @@
 	var/task = href_list["task"]
 	switch(task)
 		if("menu")
+			user << browse(null, "window=preferences")
 			return show_menu(arglist(args))
 		if("input")
 			. = handle_input(arglist(args))
 			show_menu(arglist(args))
 		else
 			CRASH("Unknown task: [task]")
+
+/datum/preferences_subsection/organs/Topic(href, list/href_list)
+	. = ..()
+	if(href_list["close"])
+		usr << browse(null, "window=\ref[src]-organs")
+		prefs.ShowChoices(usr)


### PR DESCRIPTION
- Opening the new limbs and organ windows will close the general preferences window
- Closing those windows will re-open and update the general preferences window

This is consistent with how the disability and occupation windows (are supposed to) work, and it sort of matters because before this the preview wouldn't update unless you manually closed/reopened the preferences window or click something else.