### PR TITLE
Improves VV for lists

### DIFF
--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -1066,12 +1066,6 @@ function loadPage(list) {
 			message_admins("<span class='notice'>[key_name(usr)] dealt [amount] amount of [Text] damage to [L] </span>")
 			href_list["datumrefresh"] = href_list["mobToDamage"]
 
-	else if(href_list["datumrefresh"])
-		var/datum/DAT = locate(href_list["datumrefresh"])
-		if(!istype(DAT, /datum))
-			return
-		src.debug_variables(DAT)
-
 	else if(href_list["proc_call"])
 		if(!check_rights(R_DEBUG))
 			return
@@ -1137,3 +1131,11 @@ function loadPage(list) {
 		message_admins("[key_name(usr)] has deleted the value [L[index]] in the list [L][D ? ", belonging to the datum [D] of type [D.type]." : "."]")
 
 		L -= L[index]
+		href_list["datumrefresh"] = href_list["datum"]
+
+	// No else, as it must be checked separatly, and at the end.
+	if(href_list["datumrefresh"])
+		var/datum/DAT = locate(href_list["datumrefresh"])
+		if(!istype(DAT, /datum))
+			return
+		src.debug_variables(DAT)

--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -287,7 +287,7 @@ var/list/forbidden_varedit_object_types = list(
 		mod_list_add(L)
 		return L
 	else
-		L.Remove(variable)
+		L[variable] = variable_set(src, L)
 
 	return L
 


### PR DESCRIPTION
[qol] [administration]

- Editing a var in a list actually edits instead of deleting it without warning.
- Deleting a variable in a list refreshes the window. In fact, fixes a lot of things supposed to refresh the window but not actually refreshing it due to the presence of an `else` keyword.