### PR TITLE
Fixes revs spawning on the wrong z-level

### DIFF
--- a/code/datums/gamemode/role/rev.dm
+++ b/code/datums/gamemode/role/rev.dm
@@ -5,6 +5,12 @@
 	logo_state = "rev-logo"
 	greets = list(GREET_DEFAULT,GREET_CUSTOM,GREET_ROUNDSTART,GREET_ADMINTOGGLE)
 
+/datum/role/revolutionary/AssignToRole(var/datum/mind/M, var/override = 0)
+	if (!(M.current) || M.current.z != map.zMainStation)
+		message_admins("Error: cannot create a revolutionary off the main z-level.")
+		return FALSE
+	return ..()
+
 /datum/role/revolutionary/Greet(var/greeting, var/custom)
 	if(!greeting)
 		return
@@ -57,6 +63,8 @@
 		to_chat(mob, "\The [faction.name] were able to get you \a [T], but could not find anywhere to slip it onto you, so it is now on the floor.")
 
 /datum/role/revolutionary/Drop(var/borged = FALSE)
+	if (!antag)
+		return ..()
 	if (borged)
 		antag.current.visible_message("<span class='big danger'>The frame beeps contentedly, purging the hostile memory engram from the MMI before initalizing it.</span>",
 				"<span class='big danger'>The frame's firmware detects and deletes your neural reprogramming! You remember nothing from the moment you were flashed until now.</span>")

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -234,6 +234,7 @@
 
 		if(!newRole.AssignToRole(src,1))//it shouldn't fail since we're using our admin powers to force the role
 			newRole.Drop()//but just in case
+			return
 
 		if (joined_faction && joined_faction != "-----")
 			if (joined_faction == "NEW CUSTOM FACTION")


### PR DESCRIPTION
[roleissue] [bug] [administation]

Now if admins are dumb they don't accidentally brick the round.
I have to do it in `AssignToRole` rather than `CanBeAssigned` because the later is more for job restrictions which can be overturned by admins.

Fixes #20916