### PR TITLE
Fixes malf dying on Delta not triggering round end

### DIFF
--- a/code/datums/gamemode/factions/malf.dm
+++ b/code/datums/gamemode/factions/malf.dm
@@ -45,6 +45,10 @@
 	return FALSE
 
 /datum/faction/malf/check_win()
+	if (malf_mode_declared)
+		for (var/datum/role/R in members)
+			if (isAI(R.antag.current) && R.antag.current.isDead())
+				return 1
 	if(malf_win)
 		return 1
 	else

--- a/code/datums/gamemode/factions/malf.dm
+++ b/code/datums/gamemode/factions/malf.dm
@@ -47,8 +47,9 @@
 /datum/faction/malf/check_win()
 	if (malf_mode_declared)
 		for (var/datum/role/R in members)
-			if (isAI(R.antag.current) && R.antag.current.isDead())
-				return 1
+			if (R.antag.assigned_role == "AI")
+				if (!R.antag.current || R.antag.current.isDead())
+					return 1
 	if(malf_win)
 		return 1
 	else


### PR DESCRIPTION
Fixes #20902 

Malf dying on not delta does not trigger round-end.
Ideally, any antag defeat (malf, blob, revs) shouldn't trigger round-end but rather make an announcement and encourage people to call the shuttle, but that's for an other PR, let's keep things atomic.