### PR TITLE
Nullrods now blocks vamp spells, unless vamp is young

### DIFF
--- a/code/modules/spells/vampire_helpers.dm
+++ b/code/modules/spells/vampire_helpers.dm
@@ -87,6 +87,11 @@
 		if(mind && mind.assigned_role == "Chaplain")
 			to_chat(M.current, "<span class='warning'>[src] resists our powers!</span>")
 			return 0
+		// Null rod nullifies vampire powers
+		var/obj/item/weapon/nullrod/N = locate(/obj/item/weapon/nullrod) in get_contents_in_object(src)
+		if (N)
+			to_chat(M.current, "<span class='warning'>An holy artifact protects [src]!</span>")
+			return 0
 		return 1
 
 // If the target is weakened, the spells take less time to complete.

--- a/code/modules/spells/vampire_helpers.dm
+++ b/code/modules/spells/vampire_helpers.dm
@@ -78,10 +78,10 @@
 	if(mind && mind.GetRole(VAMPIRE))
 		return 0
 
-	//Vampires who have reached their full potential can affect nearly everything
+	// Non-mature vampires are not stopped by holy things.
 	if(M)
 		var/datum/role/vampire/vamp = M.GetRole(VAMPIRE)
-		if (vamp && (VAMP_MATURE in vamp.powers))
+		if (vamp && !(VAMP_MATURE in vamp.powers))
 			return 1
 		//Chaplains are resistant to vampire powers
 		if(mind && mind.assigned_role == "Chaplain")


### PR DESCRIPTION
[balance]
Technically a balance thing.

_Why_ : because it gives people a way around shitty vamps ; your spell is not used if it can be blocked, so you don't waste your cooldown. (can be changed if needed).

:cl:
- tweak: To bring vampire counters more in-line with each other, the chaplain is now immune to spells from mature vampires instead of from young vampires. His holy weapon also now provides the same protection to whoever carries it.