### PR TITLE
Manifast Replaces Manislow (SFO13)

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -2,14 +2,6 @@
 	data_core = new /obj/effect/datacore()
 	return 1
 
-/obj/effect/datacore/proc/manifest(var/nosleep = 0)
-	spawn()
-		if(!nosleep)
-			sleep(40)
-		for(var/mob/living/carbon/human/H in player_list)
-			manifest_inject(H)
-		return
-
 /obj/effect/datacore/proc/manifest_modify(var/name, var/assignment)
 	if(PDA_Manifest.len)
 		PDA_Manifest.len = 0

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -182,7 +182,7 @@ var/datum/controller/gameticker/ticker
 	create_characters() //Create player characters and transfer them
 	collect_minds()
 	equip_characters()
-	data_core.manifest()
+	//data_core.manifest() Now handled in create_characters()
 	current_state = GAME_STATE_PLAYING
 	// Update new player panels so they say join instead of ready up.
 	for(var/mob/new_player/player in player_list)
@@ -373,7 +373,11 @@ var/datum/controller/gameticker/ticker
 			else if(!player.mind.assigned_role)
 				continue
 			else
-				player.FuckUpGenes(player.create_character())
+
+				var/mob/living/carbon/human/new_character = player.create_character()
+				if(new_character.mind.assigned_role!="MODE"&&new_character.mind.assigned_role!="Cyborg")//MODE is something like a wizard, not announced.
+					data_core.manifest_inject(new_character)
+				player.FuckUpGenes(new_character)
 				qdel(player)
 
 

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -182,7 +182,6 @@ var/datum/controller/gameticker/ticker
 	create_characters() //Create player characters and transfer them
 	collect_minds()
 	equip_characters()
-	//data_core.manifest() Now handled in create_characters()
 	current_state = GAME_STATE_PLAYING
 	// Update new player panels so they say join instead of ready up.
 	for(var/mob/new_player/player in player_list)
@@ -375,7 +374,7 @@ var/datum/controller/gameticker/ticker
 			else
 
 				var/mob/living/carbon/human/new_character = player.create_character()
-				if(new_character.mind.assigned_role!="MODE"&&new_character.mind.assigned_role!="Cyborg")//MODE is something like a wizard, not announced.
+				if(new_character.mind.assigned_role!="MODE"&&new_character.mind.assigned_role!="Cyborg"&&new_character.mind.assigned_role!="Mobile MMI")//MODE is something like a wizard, not announced.
 					data_core.manifest_inject(new_character)
 				player.FuckUpGenes(new_character)
 				qdel(player)


### PR DESCRIPTION
fixes #16144

🆑 
* bugfix: Fixed an obscure bug that allowed people to avoid appearing in records and manifest by logging out at roundstart.