### PR TITLE
gives /datum/design/rad_cell its missing ID

### DIFF
--- a/code/modules/research/designs/engineering.dm
+++ b/code/modules/research/designs/engineering.dm
@@ -54,6 +54,7 @@
 /datum/design/rad_cell
 	name = "Radio-isotope thermoelectric cell"
 	desc = "A power cell that does not hold much charge, but recharges over time."
+	id = "rad_cell"
 	req_tech = list(Tc_POWERSTORAGE = 7, Tc_MATERIALS = 5)
 	reliability_base = 70
 	build_type = PROTOLATHE


### PR DESCRIPTION
0% tested, like the original