### PR TITLE
Protected roles tweaks and refactor

### DIFF
--- a/__DEFINES/role_datums_defines.dm
+++ b/__DEFINES/role_datums_defines.dm
@@ -162,9 +162,14 @@
 #define FROM_GHOSTS 1
 #define FROM_PLAYERS 2
 
-#define PROTECTED_TRAITOR_PROB 66 // Probability than a protected role is rejected from the candidate list
+// -- Revs
 
 #define ADD_REVOLUTIONARY_FAIL_IS_COMMAND -1
 #define ADD_REVOLUTIONARY_FAIL_IS_JOBBANNED -2
 #define ADD_REVOLUTIONARY_FAIL_IS_IMPLANTED -3
 #define ADD_REVOLUTIONARY_FAIL_IS_REV -4
+
+// -- Protected roles
+
+#define PROB_PROTECTED_REGULAR 50
+#define PROB_PROTECTED_RARE    80

--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -871,18 +871,6 @@ SEE_PIXELS	256
 #define ROLE_VOXRAIDER  	"vox raider"
 #define ROLE_WIZARD     	"wizard"
 
-// Role typepaths.
-
-#define ROLE_CULTIST_TYPE /datum/role/cultist
-#define ROLE_LEGACY_CULTIST_TYPE /datum/role/legacy_cultist
-#define ROLE_TRAITOR_TYPE /datum/role/traitor
-#define ROLE_MALF_TYPE /datum/role/malfAI
-#define ROLE_REV_TYPE /datum/role/revolutionary
-#define ROLE_VAMPIRE_TYPE /datum/role/vampire
-#define ROLE_CHANGELING_TYPE /datum/role/changeling
-#define ROLE_WIZARD_TYPE /datum/role/wizard
-#define ROLE_OPERATIVE_TYPE /datum/role/nuclear_operative
-
 #define AGE_MIN 17			//youngest a character can be
 #define AGE_MAX 85			//oldest a character can be
 

--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -871,6 +871,17 @@ SEE_PIXELS	256
 #define ROLE_VOXRAIDER  	"vox raider"
 #define ROLE_WIZARD     	"wizard"
 
+// Role typepaths.
+
+#define ROLE_CULTIST_TYPE /datum/role/cultist
+#define ROLE_LEGACY_CULTIST_TYPE /datum/role/legacy_cultist
+#define ROLE_TRAITOR_TYPE /datum/role/traitor
+#define ROLE_MALF_TYPE /datum/role/malfAI
+#define ROLE_REV_TYPE /datum/role/revolutionary
+#define ROLE_VAMPIRE_TYPE /datum/role/vampire
+#define ROLE_CHANGELING_TYPE /datum/role/changeling
+#define ROLE_WIZARD_TYPE /datum/role/wizard
+#define ROLE_OPERATIVE_TYPE /datum/role/nuclear_operative
 
 #define AGE_MIN 17			//youngest a character can be
 #define AGE_MAX 85			//oldest a character can be

--- a/code/datums/gamemode/dynamic/dynamic_rulesets.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets.dm
@@ -4,7 +4,7 @@
 	var/repeatable = 0//if set to 1, dynamic mode will be able to draft this ruleset again later on. (doesn't apply for roundstart rules)
 	var/list/candidates = list()//list of players that are being drafted for this rule
 	var/list/assigned = list()//list of players that were selected for this rule
-	var/datum/role/role_category = ROLE_TRAITOR_TYPE //rule will only accept candidates with "Yes" or "Always" in the preferences for this role
+	var/datum/role/role_category = /datum/role/traitor //rule will only accept candidates with "Yes" or "Always" in the preferences for this role
 	var/list/protected_from_jobs = list() // if set, and config.protect_roles_from_antagonist = 0, then the rule will have a much lower chance than usual to pick those roles.
 	var/list/restricted_from_jobs = list()//if set, rule will deny candidates from those jobs
 	var/list/exclusive_to_jobs = list()//if set, rule will only accept candidates from those jobs

--- a/code/datums/gamemode/dynamic/dynamic_rulesets.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets.dm
@@ -4,7 +4,7 @@
 	var/repeatable = 0//if set to 1, dynamic mode will be able to draft this ruleset again later on. (doesn't apply for roundstart rules)
 	var/list/candidates = list()//list of players that are being drafted for this rule
 	var/list/assigned = list()//list of players that were selected for this rule
-	var/role_category = ROLE_TRAITOR//rule will only accept candidates with "Yes" or "Always" in the preferences for this role
+	var/datum/role/role_category = ROLE_TRAITOR_TYPE //rule will only accept candidates with "Yes" or "Always" in the preferences for this role
 	var/list/protected_from_jobs = list() // if set, and config.protect_roles_from_antagonist = 0, then the rule will have a much lower chance than usual to pick those roles.
 	var/list/restricted_from_jobs = list()//if set, rule will deny candidates from those jobs
 	var/list/exclusive_to_jobs = list()//if set, rule will only accept candidates from those jobs
@@ -134,15 +134,17 @@
 //////////////////////////////////////////////Remember that roundstart objectives are automatically forged by /datum/gamemode/proc/PostSetup()
 
 /datum/dynamic_ruleset/roundstart/trim_candidates()
+	var/role_id = initial(role_category.id)
 	for(var/mob/new_player/P in candidates)
 		if (!P.client || !P.mind || !P.mind.assigned_role)//are they connected?
 			candidates.Remove(P)
 			continue
-		if (!P.client.desires_role(role_category) || jobban_isbanned(P, role_category) || (role_category_override && jobban_isbanned(P, role_category_override)))//are they willing and not antag-banned?
+		if (!P.client.desires_role(role_id) || jobban_isbanned(P, role_id) || (role_category_override && jobban_isbanned(P, role_category_override)))//are they willing and not antag-banned?
 			candidates.Remove(P)
 			continue
 		if (P.mind.assigned_role in protected_from_jobs)
-			if (prob(PROTECTED_TRAITOR_PROB)) // Only 1/3 chance to be in the candiates
+			var/probability = initial(role_category.protected_traitor_prob)
+			if (prob(probability))
 				candidates.Remove(P)
 			continue
 		if (P.mind.assigned_role in restricted_from_jobs)//does their job allow for it?
@@ -172,15 +174,17 @@
 //////////////////////////////////////////////
 
 /datum/dynamic_ruleset/latejoin/trim_candidates()
+	var/role_id = initial(role_category.id)
 	for(var/mob/new_player/P in candidates)
 		if (!P.client || !P.mind || !P.mind.assigned_role)//are they connected?
 			candidates.Remove(P)
 			continue
-		if (!P.client.desires_role(role_category) || jobban_isbanned(P, role_category)|| (role_category_override && jobban_isbanned(P, role_category_override)))//are they willing and not antag-banned?
+		if (!P.client.desires_role(role_id) || jobban_isbanned(P, role_id)|| (role_category_override && jobban_isbanned(P, role_category_override)))//are they willing and not antag-banned?
 			candidates.Remove(P)
 			continue
 		if (P.mind.assigned_role in protected_from_jobs)
-			if (prob(PROTECTED_TRAITOR_PROB)) // Only 1/3 chance to be in the candiates
+			var/probability = initial(role_category.protected_traitor_prob)
+			if (prob(probability))
 				candidates.Remove(P)
 			continue
 		if (P.mind.assigned_role in restricted_from_jobs)//does their job allow for it?
@@ -229,17 +233,22 @@
 
 /datum/dynamic_ruleset/midround/proc/trim_list(var/list/L = list())
 	var/list/trimmed_list = L.Copy()
+	var/role_id = initial(role_category.id)
 	for(var/mob/M in trimmed_list)
 		if (!M.client)//are they connected?
 			trimmed_list.Remove(M)
 			continue
-		if (!M.client.desires_role(role_category) || jobban_isbanned(M, role_category))//are they willing and not antag-banned?
+		if (!M.client.desires_role(role_id) || jobban_isbanned(M, role_id))//are they willing and not antag-banned?
 			trimmed_list.Remove(M)
 			continue
 		if (M.mind)
 			if (M.mind.assigned_role in restricted_from_jobs)//does their job allow for it?
 				trimmed_list.Remove(M)
 				continue
+			if (M.mind.assigned_role in protected_from_jobs)
+				var/probability = initial(role_category.protected_traitor_prob)
+				if (prob(probability))
+					candidates.Remove(M)
 			if ((exclusive_to_jobs.len > 0) && !(M.mind.assigned_role in exclusive_to_jobs))//is the rule exclusive to their job?
 				trimmed_list.Remove(M)
 				continue

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
@@ -7,7 +7,7 @@
 
 /datum/dynamic_ruleset/latejoin/infiltrator
 	name = "Syndicate Infiltrator"
-	role_category = ROLE_TRAITOR_TYPE
+	role_category = /datum/role/traitor
 	protected_from_jobs = list("Security Officer", "Warden", "Head of Personnel", "Detective", "Head of Security", "Captain", "Merchant")
 	restricted_from_jobs = list("AI","Cyborg","Mobile MMI")
 	required_candidates = 1
@@ -42,7 +42,7 @@
 
 /datum/dynamic_ruleset/latejoin/raginmages
 	name = "Ragin' Mages"
-	role_category = ROLE_WIZARD_TYPE
+	role_category = /datum/role/wizard
 	enemy_jobs = list("Security Officer","Detective", "Warden", "Head of Security", "Captain")
 	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
 	required_candidates = 1

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
@@ -7,7 +7,7 @@
 
 /datum/dynamic_ruleset/latejoin/infiltrator
 	name = "Syndicate Infiltrator"
-	role_category = ROLE_TRAITOR
+	role_category = ROLE_TRAITOR_TYPE
 	protected_from_jobs = list("Security Officer", "Warden", "Head of Personnel", "Detective", "Head of Security", "Captain", "Merchant")
 	restricted_from_jobs = list("AI","Cyborg","Mobile MMI")
 	required_candidates = 1
@@ -42,7 +42,7 @@
 
 /datum/dynamic_ruleset/latejoin/raginmages
 	name = "Ragin' Mages"
-	role_category = ROLE_WIZARD
+	role_category = ROLE_WIZARD_TYPE
 	enemy_jobs = list("Security Officer","Detective", "Warden", "Head of Security", "Captain")
 	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
 	required_candidates = 1

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -7,7 +7,7 @@
 
 /datum/dynamic_ruleset/midround/autotraitor
 	name = "Syndicate Sleeper Agent"
-	role_category = ROLE_TRAITOR
+	role_category = ROLE_TRAITOR_TYPE
 	protected_from_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Cyborg", "Merchant")
 	restricted_from_jobs = list("AI","Mobile MMI")
 	required_candidates = 1
@@ -58,7 +58,7 @@
 
 /datum/dynamic_ruleset/midround/raginmages
 	name = "Ragin' Mages"
-	role_category = ROLE_WIZARD
+	role_category = ROLE_WIZARD_TYPE
 	enemy_jobs = list("Security Officer","Detective","Head of Security", "Captain")
 	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
 	required_candidates = 1
@@ -132,7 +132,7 @@
 
 /datum/dynamic_ruleset/midround/nuclear
 	name = "Nuclear Assault"
-	role_category = ROLE_OPERATIVE
+	role_category = ROLE_OPERATIVE_TYPE
 	enemy_jobs = list("AI", "Cyborg", "Security Officer", "Warden","Detective","Head of Security", "Captain")
 	required_enemies = list(3,3,3,3,3,2,1,1,0,0)
 	required_candidates = 5

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -7,7 +7,7 @@
 
 /datum/dynamic_ruleset/midround/autotraitor
 	name = "Syndicate Sleeper Agent"
-	role_category = ROLE_TRAITOR_TYPE
+	role_category = /datum/role/traitor
 	protected_from_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Cyborg", "Merchant")
 	restricted_from_jobs = list("AI","Mobile MMI")
 	required_candidates = 1
@@ -58,7 +58,7 @@
 
 /datum/dynamic_ruleset/midround/raginmages
 	name = "Ragin' Mages"
-	role_category = ROLE_WIZARD_TYPE
+	role_category = /datum/role/wizard
 	enemy_jobs = list("Security Officer","Detective","Head of Security", "Captain")
 	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
 	required_candidates = 1
@@ -132,7 +132,7 @@
 
 /datum/dynamic_ruleset/midround/nuclear
 	name = "Nuclear Assault"
-	role_category = ROLE_OPERATIVE_TYPE
+	role_category = /datum/role/nuclear_operative
 	enemy_jobs = list("AI", "Cyborg", "Security Officer", "Warden","Detective","Head of Security", "Captain")
 	required_enemies = list(3,3,3,3,3,2,1,1,0,0)
 	required_candidates = 5

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -8,7 +8,7 @@
 /datum/dynamic_ruleset/roundstart/traitor
 	name = "Syndicate Traitors"
 	persistent = 1
-	role_category = ROLE_TRAITOR_TYPE
+	role_category = /datum/role/traitor
 	protected_from_jobs = list("Security Officer", "Merchant", "Warden", "Head of Personnel", "Cyborg", "Detective", "Head of Security", "Captain")
 	restricted_from_jobs = list("AI","Mobile MMI")
 	required_candidates = 1
@@ -75,7 +75,7 @@
 
 /datum/dynamic_ruleset/roundstart/vampire
 	name = "Vampires"
-	role_category = ROLE_VAMPIRE_TYPE
+	role_category = /datum/role/vampire
 	protected_from_jobs = list("Security Officer", "Warden","Merchant", "Head of Personnel", "Detective", "Head of Security", "Captain")
 	restricted_from_jobs = list("AI","Cyborg","Mobile MMI", "Chaplain")
 	enemy_jobs = list("Security Officer","Detective","Head of Security", "Captain")
@@ -107,7 +107,7 @@
 
 /datum/dynamic_ruleset/roundstart/wizard
 	name = "Wizard"
-	role_category = ROLE_WIZARD_TYPE
+	role_category = /datum/role/wizard
 	restricted_from_jobs = list("Head of Security", "Captain")//just to be sure that a wizard getting picked won't ever imply a Captain or HoS not getting drafted
 	enemy_jobs = list("Security Officer","Detective","Head of Security", "Captain")
 	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
@@ -148,7 +148,7 @@
 
 /datum/dynamic_ruleset/roundstart/bloodcult
 	name = "Blood Cult"
-	role_category = ROLE_CULTIST_TYPE
+	role_category = /datum/role/cultist
 	protected_from_jobs = list("Merchant")
 	restricted_from_jobs = list("AI", "Cyborg", "Mobile MMI", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Chaplain", "Head of Personnel", "Internal Affairs Agent")
 	enemy_jobs = list("AI", "Cyborg", "Security Officer","Warden", "Detective","Head of Security", "Captain", "Chaplain")
@@ -189,7 +189,7 @@
 /*
 /datum/dynamic_ruleset/roundstart/cult_legacy
 	name = "Cult (Legacy)"
-	role_category = ROLE_LEGACY_CULTIST_TYPE
+	role_category = /datum/role/legacy_cultist
 	role_category_override = ROLE_CULTIST // H-ha
 	protected_from_jobs = list("Merchant")
 	restricted_from_jobs = list("AI", "Cyborg", "Mobile MMI", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Chaplain", "Head of Personnel", "Internal Affairs Agent", "Chaplain")
@@ -227,7 +227,7 @@
 
 /datum/dynamic_ruleset/roundstart/nuclear
 	name = "Nuclear Emergency"
-	role_category = ROLE_OPERATIVE_TYPE
+	role_category = /datum/role/nuclear_operative
 	restricted_from_jobs = list("Head of Security", "Captain")//just to be sure that a nukie getting picked won't ever imply a Captain or HoS not getting drafted
 	enemy_jobs = list("AI", "Cyborg", "Security Officer", "Warden","Detective","Head of Security", "Captain")
 	required_enemies = list(3,3,3,3,3,2,1,1,0,0)
@@ -274,7 +274,7 @@
 
 /datum/dynamic_ruleset/roundstart/malf
 	name = "Malfunctioning AI"
-	role_category = ROLE_MALF_TYPE
+	role_category = /datum/role/malfAI
 	enemy_jobs = list("Security Officer", "Warden","Detective","Head of Security", "Captain", "Scientist", "Chemist", "Research Director", "Chief Engineer")
 	exclusive_to_jobs = list("AI")
 	required_enemies = list(4,4,4,4,4,4,2,2,2,0)
@@ -326,7 +326,7 @@
 
 /datum/dynamic_ruleset/roundstart/revs
 	name = "Revolution"
-	role_category = ROLE_REV_TYPE
+	role_category = /datum/role/revolutionary
 	protected_from_jobs = list("Merchant")
 	restricted_from_jobs = list("AI", "Cyborg", "Mobile MMI", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Chief Medical Officer", "Research Director", "Internal Affairs Agent")
 	enemy_jobs = list("AI", "Cyborg", "Security Officer","Detective","Head of Security", "Captain", "Warden")

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -8,7 +8,7 @@
 /datum/dynamic_ruleset/roundstart/traitor
 	name = "Syndicate Traitors"
 	persistent = 1
-	role_category = ROLE_TRAITOR
+	role_category = ROLE_TRAITOR_TYPE
 	protected_from_jobs = list("Security Officer", "Merchant", "Warden", "Head of Personnel", "Cyborg", "Detective", "Head of Security", "Captain")
 	restricted_from_jobs = list("AI","Mobile MMI")
 	required_candidates = 1
@@ -75,7 +75,7 @@
 
 /datum/dynamic_ruleset/roundstart/vampire
 	name = "Vampires"
-	role_category = ROLE_VAMPIRE
+	role_category = ROLE_VAMPIRE_TYPE
 	protected_from_jobs = list("Security Officer", "Warden","Merchant", "Head of Personnel", "Detective", "Head of Security", "Captain")
 	restricted_from_jobs = list("AI","Cyborg","Mobile MMI", "Chaplain")
 	enemy_jobs = list("Security Officer","Detective","Head of Security", "Captain")
@@ -107,7 +107,7 @@
 
 /datum/dynamic_ruleset/roundstart/wizard
 	name = "Wizard"
-	role_category = ROLE_WIZARD
+	role_category = ROLE_WIZARD_TYPE
 	restricted_from_jobs = list("Head of Security", "Captain")//just to be sure that a wizard getting picked won't ever imply a Captain or HoS not getting drafted
 	enemy_jobs = list("Security Officer","Detective","Head of Security", "Captain")
 	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
@@ -148,7 +148,7 @@
 
 /datum/dynamic_ruleset/roundstart/bloodcult
 	name = "Blood Cult"
-	role_category = ROLE_CULTIST
+	role_category = ROLE_CULTIST_TYPE
 	protected_from_jobs = list("Merchant")
 	restricted_from_jobs = list("AI", "Cyborg", "Mobile MMI", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Chaplain", "Head of Personnel", "Internal Affairs Agent")
 	enemy_jobs = list("AI", "Cyborg", "Security Officer","Warden", "Detective","Head of Security", "Captain", "Chaplain")
@@ -189,7 +189,7 @@
 /*
 /datum/dynamic_ruleset/roundstart/cult_legacy
 	name = "Cult (Legacy)"
-	role_category = ROLE_LEGACY_CULTIST
+	role_category = ROLE_LEGACY_CULTIST_TYPE
 	role_category_override = ROLE_CULTIST // H-ha
 	protected_from_jobs = list("Merchant")
 	restricted_from_jobs = list("AI", "Cyborg", "Mobile MMI", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Chaplain", "Head of Personnel", "Internal Affairs Agent", "Chaplain")
@@ -227,7 +227,7 @@
 
 /datum/dynamic_ruleset/roundstart/nuclear
 	name = "Nuclear Emergency"
-	role_category = ROLE_OPERATIVE
+	role_category = ROLE_OPERATIVE_TYPE
 	restricted_from_jobs = list("Head of Security", "Captain")//just to be sure that a nukie getting picked won't ever imply a Captain or HoS not getting drafted
 	enemy_jobs = list("AI", "Cyborg", "Security Officer", "Warden","Detective","Head of Security", "Captain")
 	required_enemies = list(3,3,3,3,3,2,1,1,0,0)
@@ -274,7 +274,7 @@
 
 /datum/dynamic_ruleset/roundstart/malf
 	name = "Malfunctioning AI"
-	role_category = ROLE_MALF
+	role_category = ROLE_MALF_TYPE
 	enemy_jobs = list("Security Officer", "Warden","Detective","Head of Security", "Captain", "Scientist", "Chemist", "Research Director", "Chief Engineer")
 	exclusive_to_jobs = list("AI")
 	required_enemies = list(4,4,4,4,4,4,2,2,2,0)
@@ -326,7 +326,7 @@
 
 /datum/dynamic_ruleset/roundstart/revs
 	name = "Revolution"
-	role_category = ROLE_REV
+	role_category = ROLE_REV_TYPE
 	protected_from_jobs = list("Merchant")
 	restricted_from_jobs = list("AI", "Cyborg", "Mobile MMI", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Chief Medical Officer", "Research Director", "Internal Affairs Agent")
 	enemy_jobs = list("AI", "Cyborg", "Security Officer","Detective","Head of Security", "Captain", "Warden")

--- a/code/datums/gamemode/role/changeling.dm
+++ b/code/datums/gamemode/role/changeling.dm
@@ -3,6 +3,7 @@
 	id = CHANGELING
 	required_pref = ROLE_CHANGELING
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain")
+	protected_traitor_prob = PROB_PROTECTED_RARE
 	logo_state = "change-logoa"
 	var/list/absorbed_dna = list()
 	var/list/absorbed_species = list()

--- a/code/datums/gamemode/role/rev.dm
+++ b/code/datums/gamemode/role/rev.dm
@@ -63,5 +63,3 @@
 	else
 		antag.current.visible_message("<span class='big danger'>It looks like [antag.current] just remembered their real allegiance!</span>",
 			"<span class='big danger'>You have been brainwashed! You are no longer a revolutionary! Your memory is hazy from the time you were a rebel...the only thing you remember is the name of the one who brainwashed you...</span>")
-	update_faction_icons()
-	return ..()

--- a/code/datums/gamemode/role/rev.dm
+++ b/code/datums/gamemode/role/rev.dm
@@ -63,3 +63,5 @@
 	else
 		antag.current.visible_message("<span class='big danger'>It looks like [antag.current] just remembered their real allegiance!</span>",
 			"<span class='big danger'>You have been brainwashed! You are no longer a revolutionary! Your memory is hazy from the time you were a rebel...the only thing you remember is the name of the one who brainwashed you...</span>")
+	update_faction_icons()
+	return ..()

--- a/code/datums/gamemode/role/role.dm
+++ b/code/datums/gamemode/role/role.dm
@@ -58,6 +58,7 @@
 
 	// Jobs that have a much lower chance to be this antag.
 	var/list/protected_jobs = list()
+	var/protected_traitor_prob = PROB_PROTECTED_REGULAR
 
 	// Jobs that can only be this antag
 	var/list/required_jobs=list()

--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -11,6 +11,7 @@
 	logo_state = "vampire-logo"
 	greets = list(GREET_DEFAULT,GREET_CUSTOM,GREET_ADMINTOGGLE, GREET_MASTER)
 	required_pref = ROLE_VAMPIRE
+	protected_traitor_prob = PROB_PROTECTED_RARE
 
 	var/list/powers = list()
 	var/ismenacing = FALSE


### PR DESCRIPTION
[system] [tweak] [role]

Rather than a single, universal probabilistic roll, rulesets will now look for a prob chance defined in the role.
Rulesets use a role type rather than an id to reduce the boilerplate.
In the ~~near~~ future, role ids should be avoided altogether and typepaths should be used, notably for the protected roles list itself.

Tested ; the probabilistic roll does take place, normal jobs still get their antag roll.

As an application, the probability for an officer to roll traitor successfully is 50%, but to roll vamp is 20%.
Meant as an alternative to #21034.
Can be further tweaked if needed.

:cl:
- tweak: NanoTrasen has changed their screening process for their security and command forces, resulting in less vampires being hired.