### PR TITLE
Rev fixes, 105% tested edition

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -331,7 +331,7 @@
 	restricted_from_jobs = list("AI", "Cyborg", "Mobile MMI", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Chief Medical Officer", "Research Director", "Internal Affairs Agent")
 	enemy_jobs = list("AI", "Cyborg", "Security Officer","Detective","Head of Security", "Captain", "Warden")
 	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
-	required_candidates = 3
+	required_candidates = 1
 	weight = 2
 	cost = 45
 	requirements = list(101,101,70,40,30,20,10,10,10,10)
@@ -344,26 +344,27 @@
 	for (var/mob/new_player/player in player_list)
 		if (player.mind.assigned_role in command_positions)
 			head_check++
+	if (forced)
+		required_heads = 1
 	return (head_check >= required_heads)
 
 /datum/dynamic_ruleset/roundstart/revs/execute()
 	var/datum/faction/revolution/R = find_active_faction_by_type(/datum/faction/revolution)
 	if (!R)
 		R = ticker.mode.CreateFaction(/datum/faction/revolution, null, 1)
-	
-	R.OnPostSetup() // Forge our jecties
 
 	var/max_canditates = 4
 	for(var/i = 1 to max_canditates)
 		if(candidates.len <= 0)
 			break
 		var/mob/M = pick(candidates)
+		if (!M.mind)
+			WARNING("Shit, [M] has a no mind! [M.type]")
 		assigned += M
 		candidates -= M
 		var/datum/role/revolutionary/leader/lenin = new
-		lenin.AssignToRole(M.mind,1)
+		lenin.AssignToRole(M.mind, 1, 1)
 		R.HandleRecruitedRole(lenin)
 		lenin.Greet(GREET_ROUNDSTART)
-		lenin.OnPostSetup()
 	update_faction_icons()
 	return 1

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -358,8 +358,6 @@
 		if(candidates.len <= 0)
 			break
 		var/mob/M = pick(candidates)
-		if (!M.mind)
-			WARNING("Shit, [M] has a no mind! [M.type]")
 		assigned += M
 		candidates -= M
 		var/datum/role/revolutionary/leader/lenin = new

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -331,7 +331,7 @@
 	restricted_from_jobs = list("AI", "Cyborg", "Mobile MMI", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Chief Medical Officer", "Research Director", "Internal Affairs Agent")
 	enemy_jobs = list("AI", "Cyborg", "Security Officer","Detective","Head of Security", "Captain", "Warden")
 	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
-	required_candidates = 1
+	required_candidates = 3
 	weight = 2
 	cost = 45
 	requirements = list(101,101,70,40,30,20,10,10,10,10)

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -346,6 +346,7 @@
 			head_check++
 	if (forced)
 		required_heads = 1
+		required_candidates = 1
 	return (head_check >= required_heads)
 
 /datum/dynamic_ruleset/roundstart/revs/execute()

--- a/code/datums/gamemode/factions/syndicate/rev.dm
+++ b/code/datums/gamemode/factions/syndicate/rev.dm
@@ -39,10 +39,6 @@
 		if(A.set_target(head_mind))
 			AppendObjective(A, TRUE) // We will have more than one kill objective
 
-/datum/faction/revolution/OnPostSetup()
-	. = ..()
-	forgeObjectives()
-
 #define ALL_HEADS_DEAD 1
 #define ALL_REVS_DEAD 2
 #define SHUTTLE_LEFT 3

--- a/code/datums/gamemode/role/rev.dm
+++ b/code/datums/gamemode/role/rev.dm
@@ -5,8 +5,11 @@
 	logo_state = "rev-logo"
 	greets = list(GREET_DEFAULT,GREET_CUSTOM,GREET_ROUNDSTART,GREET_ADMINTOGGLE)
 
-/datum/role/revolutionary/AssignToRole(var/datum/mind/M, var/override = 0)
-	if (!(M.current) || M.current.z != map.zMainStation)
+// The ticker current state check is because revs are created, at roundstart, in the cuck cube.
+// Which is outside the z-level of the main station.
+
+/datum/role/revolutionary/AssignToRole(var/datum/mind/M, var/override = 0, var/roundstart = 0)
+	if (!(M.current) || (M.current.z != map.zMainStation && !roundstart))
 		message_admins("Error: cannot create a revolutionary off the main z-level.")
 		return FALSE
 	return ..()


### PR DESCRIPTION
[role] [bug]

- Fixes double objectives generation (because `OnPostSetup` is called elsewhere)
- Fixes revheads not spawning at all (because the cuck cube is on z = 2, and rev heads check if they're on station before spawning)

:100: 