### PR TITLE
Ushanka no longer hides hair because it's a hat, not a full-face helmet

### DIFF
--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -114,7 +114,6 @@
 	desc = "Perfect for winter in Siberia, da?"
 	icon_state = "ushanka"
 	item_state = "ushanka"
-	flags = HIDEHAIRCOMPLETELY
 	body_parts_covered = EARS|HEAD
 	heat_conductivity = SNOWGEAR_HEAT_CONDUCTIVITY
 


### PR DESCRIPTION
I want my glorious beard to show with the ushanka, simple as that. I don't get why this behaviour was implemented in the first place