### PR TITLE
[Simply epic] Fixes splashed holy water not working correctly on cultists

### DIFF
--- a/code/datums/gamemode/role/cultist.dm
+++ b/code/datums/gamemode/role/cultist.dm
@@ -293,7 +293,7 @@
 	switch (reagent_id)
 		if (HOLYWATER)
 			var/mob/living/carbon/human/H = antag.current
-			if (istype(H))
+			if (!istype(H))
 				return
 			H.Dizzy(12)
 			H.Jitter(24)


### PR DESCRIPTION
:100: :100:
[tested] [bugfix]

Will probably put a balance PR as a companion to this because I think it's bullshit