### PR TITLE
Adds rule weighting

### DIFF
--- a/code/datums/fuzzy_rules.dm
+++ b/code/datums/fuzzy_rules.dm
@@ -1,0 +1,68 @@
+/** Fuzzy rule datums
+	Pass it an object, and it will evaluate it
+	Will return the membership value (a value between 1 and 0), this is 'how true' this object is to this ruling
+**/
+
+/datum/fuzzy_ruling
+	var/weighting = 1 //Value between 1 and 0, how much the evaluation value will be timesd by
+	var/list/args //Generic list of arguments
+
+/datum/fuzzy_ruling/proc/evaluate(var/datum/D)
+	return 1
+
+/datum/fuzzy_ruling/is_mob/evaluate(var/datum/D)
+	if(ismob(D))
+		return 1
+	return 0
+
+/datum/fuzzy_ruling/is_obj/evaluate(var/datum/D)
+	if(isobj(D))
+		return 1
+	return 0
+
+/datum/fuzzy_ruling/distance
+	var/atom/source
+
+/datum/fuzzy_ruling/distance/proc/set_source(var/atom/A)
+	source = A
+
+/datum/fuzzy_ruling/distance/evaluate(var/datum/D)
+	return 1/get_dist(source,D)
+
+/**
+	Evaluate_list
+		Orders the list in highest priority first, according to the ruleset provided to it
+	@params:
+		L: List: The list of objects/datums/atoms to evalute.
+		ruleS: List: The list of rules to evaluate these objects by
+
+	@return:
+		List: L, re-ordered with the most relevant objects (according to the rules given) to the least relevant objects
+**/
+/proc/evaluate_list(var/list/L, var/list/rules)
+	if(!L.len || L.len < 2 || !rules.len) //List is empty, or only has one element so can't compare, or no rules to compare with
+		return L
+	var/list/comparison = L.Copy()
+	var/evaluating = TRUE
+	//First, we associate a value with each object in the comparison list
+	for(var/datum/D in comparison)
+		var/relevance
+		for(var/datum/fuzzy_ruling/FR in rules)
+			relevance += FR.evaluate(D)*FR.weighting
+		comparison[D] = relevance
+	//Then, bubblesort
+	while(evaluating)
+		evaluating = FALSE
+		for(var/i = 2 to comparison.len)
+			var/obj = comparison[i]
+			var/obj2 = comparison[i-1]
+			if(comparison[obj] > comparison[obj2])
+				comparison[i-1] = obj
+				comparison[i] = obj2
+				evaluating = TRUE
+				continue
+
+	for(var/datum/D in L)
+		comparison[D] = L[D] //So we don't lose assoc values, should there be any
+
+	return comparison

--- a/code/datums/fuzzy_rules.dm
+++ b/code/datums/fuzzy_rules.dm
@@ -37,30 +37,20 @@
 		ruleS: List: The list of rules to evaluate these objects by
 
 	@return:
-		List: L, re-ordered with the most relevant objects (according to the rules given) to the least relevant objects
+		List: comparison, ordered with the most relevant objects (according to the rules given) to the least relevant objects
 **/
 /proc/evaluate_list(var/list/L, var/list/rules)
 	if(!L.len || L.len < 2 || !rules.len) //List is empty, or only has one element so can't compare, or no rules to compare with
 		return L
 	var/list/comparison = L.Copy()
-	var/evaluating = TRUE
 	//First, we associate a value with each object in the comparison list
 	for(var/datum/D in comparison)
 		var/relevance
 		for(var/datum/fuzzy_ruling/FR in rules)
 			relevance += FR.evaluate(D)*FR.weighting
 		comparison[D] = relevance
-	//Then, bubblesort
-	while(evaluating)
-		evaluating = FALSE
-		for(var/i = 2 to comparison.len)
-			var/obj = comparison[i]
-			var/obj2 = comparison[i-1]
-			if(comparison[obj] > comparison[obj2])
-				comparison[i-1] = obj
-				comparison[i] = obj2
-				evaluating = TRUE
-				continue
+	//Then, we use sortTim with descending numeric arg, so we get them from highest to lowest
+	sortTim(comparison, /proc/cmp_numeric_dsc,TRUE)
 
 	for(var/datum/D in L)
 		comparison[D] = L[D] //So we don't lose assoc values, should there be any

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -30,6 +30,19 @@
 	var/friendly_fire = 0 //If set to 1, they won't hesitate to shoot their target even if a friendly is in the way.
 	var/armor_modifier = 1 //The higher this is, the more effect armor has on melee attacks
 
+	var/list/target_rules = list()
+
+/mob/living/simple_animal/hostile/New()
+	..()
+	initialize_rules()
+
+/mob/living/simple_animal/hostile/proc/initialize_rules()
+	target_rules.Add(new /datum/fuzzy_ruling/is_mob)
+	target_rules.Add(new /datum/fuzzy_ruling/is_obj{weighting = 0.5})
+	var/datum/fuzzy_ruling/distance/D = new /datum/fuzzy_ruling/distance
+	D.set_source(src)
+	target_rules.Add(D)
+
 /mob/living/simple_animal/hostile/resetVariables()
 	..("wanted_objects", "friends", args)
 	wanted_objects = list()
@@ -82,36 +95,32 @@
 //////////////HOSTILE MOB TARGETTING AND AGGRESSION////////////
 
 
-/mob/living/simple_animal/hostile/proc/ListTargets(var/range)//Step 1, find out what we can see
+/mob/living/simple_animal/hostile/proc/ListTargets()//Step 1, find out what we can see
 	var/list/L = new()
-
 	if (!search_objects)
-		L.Add(ohearers(range, src)-ohearers(range-1, src))
-
+		L.Add(ohearers(vision_range, src))
 		for (var/obj/mecha/M in mechas_list)
 			if (get_dist(M, src) <= vision_range && can_see(src, M, vision_range))
 				L.Add(M)
 	else
-		L.Add(oview(range, src)-oview(range-1, src))
-
+		L.Add(oview(vision_range, src))
 	return L
 
 /mob/living/simple_animal/hostile/proc/FindTarget()//Step 2, filter down possible targets to things we actually care about
 	var/list/Targets = list()
 	var/Target
-	for(var/i = 1 to vision_range)
-		for(var/atom/A in ListTargets(i))
-			if(Found(A))//Just in case people want to override targetting
-				var/list/FoundTarget = list()
-				FoundTarget += A
-				Targets = FoundTarget
-				break
-			if(CanAttack(A))//Can we attack it?
-				Targets += A
-				continue
-		Target = PickTarget(Targets)
-		if(Target)
-			return Target //We now have a target
+	for(var/atom/A in ListTargets())
+		if(Found(A))//Just in case people want to override targetting
+			var/list/FoundTarget = list()
+			FoundTarget += A
+			Targets = FoundTarget
+			break
+		if(CanAttack(A))//Can we attack it?
+			Targets += A
+			continue
+	Target = PickTarget(Targets)
+	if(Target)
+		return Target //We now have a target
 
 /mob/living/simple_animal/hostile/proc/Found(var/atom/A)//This is here as a potential override to pick a specific target if available
 	return
@@ -125,7 +134,8 @@
 				Targets -= A
 	if(!Targets.len)//We didnt find nothin!
 		return
-	var/chosen_target = pick(Targets)//Pick the remaining targets (if any) at random
+	Targets = evaluate_list(Targets, target_rules)
+	var/chosen_target = Targets[1]//Pick the top target, as it would be highest priority
 	return chosen_target
 
 /mob/living/simple_animal/hostile/CanAttack(var/atom/the_target)//Can we actually attack a possible target?

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -230,6 +230,7 @@
 #include "code\datums\disease.dm"
 #include "code\datums\emotes.dm"
 #include "code\datums\feedback.dm"
+#include "code\datums\fuzzy_rules.dm"
 #include "code\datums\locking_category.dm"
 #include "code\datums\map_elements.dm"
 #include "code\datums\mind.dm"


### PR DESCRIPTION
Current PoC is simple animal mobs, where they take into account if the target is an object or a mob, and the distance.

Pass it a list of objects and a list of rules, and it'll return the list re-ordered with highest priority first

May drop the weighting of the object rule some more, just so mobs have total priority.

:cl:
 * tweak: Overhauled simple animal logic. This should improve target decision making and fix some behaviours like getting caught trying to move to an object through a crowd of potential targets.