### PR TITLE
Cult tattoos tweaks

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
@@ -674,7 +674,7 @@ var/list/cult_spires = list()
 	..()
 	cult_spires.Add(src)
 	set_light(1)
-	stage = min(3,max(1,veil_thickness-1))
+	stage = Clamp(veil_thickness, 1, 3)
 	flick("spire[stage]-spawn",src)
 	spawn(10)
 		update_stage()
@@ -684,7 +684,7 @@ var/list/cult_spires = list()
 	..()
 
 /obj/structure/cult/spire/proc/upgrade()
-	var/new_stage = min(3,max(1,veil_thickness-1))
+	var/new_stage = Clamp(1, veil_thickness, 3)
 	if (new_stage>stage)
 		stage = new_stage
 		alpha = 255

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
@@ -263,7 +263,12 @@
 		abort(RITUALABORT_OUTPOST)
 		return FALSE
 
-	if (veil_thickness >= CULT_ACT_II)
+	if (veil_thickness >= CULT_ACT_I)
+		var/spawnchoice = alert(user,"As the veil is getting thinner, new possibilities arise.","[name]","Altar","Spire")
+		if (spawnchoice == "Spire")
+			spawntype = /obj/structure/cult/spire
+
+	else if (veil_thickness >= CULT_ACT_II)
 		var/spawnchoice = alert(user,"As the veil is getting thinner, new possibilities arise.","[name]","Altar","Forge","Spire")
 		switch (spawnchoice)
 			if ("Forge")


### PR DESCRIPTION
[balance]

## What

- Spire can now be built on act I, rather than act II.
- All tattoos can now be used an act earlier.

## Why

- While I find a lot of tools and design choices of Cult III questionable, tattoos are (mostly) underused. Besides, a few of them aren't really useful at later acts (why have the tome memorised if you can summon one ?), and having some tattoos available at Act IV is a bit of a waste since you'll most likely be busy trying to rush the bloodstone (and since the spill blood objective has been completed, most likely the resistance will be vestigial). 
- To make tattoos more relevant, to give cultists a few more options, and to make rounds more interesting.

I personally think that this should be accompanied with a reduction of the cult swords devastating potential but I'm not sure how to do it yet.
Fully tested.

:cl:
- tweak: All tattoos can now be used one act earlier than before.