### PR TITLE
Manifested Ghosts are now actually immune to stuns

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -947,6 +947,7 @@ var/list/RESTRICTED_CAMERA_NETWORKS = list( //Those networks can only be accesse
 #define ELECTRIC_HEAL 2048
 #define IS_SPECIES_MUTE 4096
 #define REQUIRE_DARK 8192
+#define MOB_CANT_STUN 16384
 
 //Species anatomical flags.
 #define HAS_SKIN_TONE 1

--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -947,7 +947,6 @@ var/list/RESTRICTED_CAMERA_NETWORKS = list( //Those networks can only be accesse
 #define ELECTRIC_HEAL 2048
 #define IS_SPECIES_MUTE 4096
 #define REQUIRE_DARK 8192
-#define MOB_CANT_STUN 16384
 
 //Species anatomical flags.
 #define HAS_SKIN_TONE 1

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_tattoos.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_tattoos.dm
@@ -111,6 +111,10 @@ var/list/blood_communion = list()
 	H.b_eyes = 0
 	H.revive(0)
 	H.status_flags &= ~GODMODE
+	H.status_flags &= ~CANSTUN
+	H.status_flags &= ~CANKNOCKDOWN
+	H.status_flags &= ~CANPARALYSE
+	H.status_flags &= ~PACIFIABLE
 	H.regenerate_icons()
 
 /datum/cult_tattoo/memorize

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -113,14 +113,10 @@
 /mob/living/carbon/human/Stun(amount)
 	if(M_HULK in mutations)
 		return
-	if (species && species.flags & MOB_CANT_STUN)
-		return
 	..()
 
 /mob/living/carbon/human/Knockdown(amount)
 	if(M_HULK in mutations)
-		return
-	if (species && species.flags & MOB_CANT_STUN)
 		return
 	..()
 

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -113,10 +113,14 @@
 /mob/living/carbon/human/Stun(amount)
 	if(M_HULK in mutations)
 		return
+	if (species && species.flags & MOB_CANT_STUN)
+		return
 	..()
 
 /mob/living/carbon/human/Knockdown(amount)
 	if(M_HULK in mutations)
+		return
+	if (species && species.flags & MOB_CANT_STUN)
 		return
 	..()
 

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -315,7 +315,7 @@ var/global/list/whitelisted_species = list("Human")
 		"eyes" =     /datum/organ/internal/eyes
 		)
 
-	flags = NO_PAIN | MOB_CANT_STUN
+	flags = NO_PAIN
 	anatomy_flags = HAS_SKIN_TONE | HAS_LIPS | HAS_UNDERWEAR | CAN_BE_FAT | NO_BLOOD
 
 /datum/species/manifested/handle_death(var/mob/living/carbon/human/H)

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -315,7 +315,7 @@ var/global/list/whitelisted_species = list("Human")
 		"eyes" =     /datum/organ/internal/eyes
 		)
 
-	flags = NO_PAIN
+	flags = NO_PAIN | MOB_CANT_STUN
 	anatomy_flags = HAS_SKIN_TONE | HAS_LIPS | HAS_UNDERWEAR | CAN_BE_FAT | NO_BLOOD
 
 /datum/species/manifested/handle_death(var/mob/living/carbon/human/H)


### PR DESCRIPTION
[dnm] [balance] [bugfix]

Don't merge this, because I'm not actually sure if this is a bugfix or not.
The wiki page on manifested ghost tattoo (Pale Body) says that you'll no longer feel pain AND be immune to stun.
The in-game description just says that you're immune to pain.
So this would be a bugfix, if this was the intended change.

If it's not a bugfix, (ie, the wiki is wrong) then I would close this PR because I think that pale ghosts would be very, very strong with that advantage.

:cl:
- bugfix: Manifested Ghosts are now actually stun immune.