### PR TITLE
PDA Stops Jumping To Hand (SBO17)

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -2326,7 +2326,7 @@ obj/item/device/pda/AltClick()
 		id.virtual_wallet.transaction_log.Add(T)
 		to_chat(user, "<span class='info'>You insert [T.amount] credit\s into the PDA.</span>")
 		qdel(dosh)
-		updateUsrDialog()
+		updateDialog()
 
 	return
 


### PR DESCRIPTION
fixes #19930

🆑 
* bugfix: Your PDA will no longer jump to your hand if you insert space cash while the interface is open.