### PR TITLE
No Longer Scan Fossils (SBO18)

### DIFF
--- a/code/modules/research/xenoarchaeology/finds/finds_fossils.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds_fossils.dm
@@ -7,6 +7,7 @@
 	icon = 'icons/obj/xenoarchaeology.dmi'
 	icon_state = "bone"
 	desc = "It's a fossil."
+	mech_flags = MECH_SCAN_FAIL
 
 /obj/item/weapon/fossil/base/New()
 	var/list/l = list("/obj/item/weapon/fossil/bone"=9,"/obj/item/weapon/fossil/skull"=3,


### PR DESCRIPTION
fixes #21043

🆑 
* bugfix: Fossils can no longer be mass produced at the general fabricator. Another win for young space creationists!