### PR TITLE
Clowncart respects gravity (SBO19)

### DIFF
--- a/code/game/objects/structures/vehicles/clowncart.dm
+++ b/code/game/objects/structures/vehicles/clowncart.dm
@@ -259,6 +259,13 @@
 	if(user.incapacitated())
 		unlock_atom(user)
 		return
+	var/turf/T = get_turf(loc)
+	if(!T)
+		return 0
+	if(!T.has_gravity())
+		// Block relaymove() if needed.
+		if(!Process_Spacemove(0))
+			return 0
 	if(empstun > 0)
 		if(user && can_warn())
 			to_chat(user, "<span class='warning'>[src]'s banana essence battery has been shorted out.</span>")


### PR DESCRIPTION
fixes #21135

🆑 
* bugfix: The Clowncart now needs gravity and friction to handle properly, as all other vehicles.