### PR TITLE
Deconstruction Improvements (SBO20-21)

### DIFF
--- a/code/WorkInProgress/MadmanMartian/blacksmithing/forge.dm
+++ b/code/WorkInProgress/MadmanMartian/blacksmithing/forge.dm
@@ -28,7 +28,7 @@
 		heating.forceMove(get_turf(src))
 		heating = null
 	for(var/obj/I in contents)
-		qdel(I)
+		I.forceMove(get_turf(src))
 	..()
 
 /obj/structure/forge/attackby(obj/item/I, mob/user)
@@ -71,13 +71,17 @@
 				to_chat(user, "<span class = 'warning'>\The [src] does not light.</span>")
 				return
 			toggle_lit()
+	else if(iscrowbar(I))
+		to_chat(user, "<span class = 'notice'>You begin to disassemble \the [src].</span>")
+		playsound(loc, 'sound/effects/stonedoor_openclose.ogg', 50, 1)
+		if(do_after(user, src, 5 SECONDS))
+			drop_stack(/obj/item/stack/sheet/mineral/sandstone, get_turf(src), rand(5, 20))
+			qdel(src)
 	else if(!heating)
 		if(user.drop_item(I, src))
 			to_chat(user, "<span class = 'notice'>You place \the [I] into \the [src].</span>")
 			heating = I
 			return
-	else if(iscrowbar(I) && do_after(user, src, 5 SECONDS))
-		drop_stack(/obj/item/stack/sheet/mineral/sandstone, get_turf(src), rand(5, 20))
 	..()
 
 /obj/structure/forge/proc/toggle_lit()

--- a/code/game/objects/structures/crates_lockers/closets/coffin.dm
+++ b/code/game/objects/structures/crates_lockers/closets/coffin.dm
@@ -5,6 +5,12 @@
 	icon_closed = "coffin"
 	icon_opened = "coffin_open"
 
+	starting_materials = list(MAT_WOOD = 5*CC_PER_SHEET_MISC)
+
+/obj/structure/closet/coffin/Destroy()
+	new /obj/item/stack/sheet/wood(loc,3) //This will result in 3 dropped if destroyed, or 5 if deconstructed
+	..()
+
 /obj/structure/closet/coffin/update_icon()
 	if(!opened)
 		icon_state = icon_closed

--- a/code/game/objects/structures/vehicles/clowncart.dm
+++ b/code/game/objects/structures/vehicles/clowncart.dm
@@ -259,6 +259,13 @@
 	if(user.incapacitated())
 		unlock_atom(user)
 		return
+	var/turf/T = get_turf(loc)
+	if(!T)
+		return 0
+	if(!T.has_gravity())
+		// Block relaymove() if needed.
+		if(!Process_Spacemove(0))
+			return 0
 	if(empstun > 0)
 		if(user && can_warn())
 			to_chat(user, "<span class='warning'>[src]'s banana essence battery has been shorted out.</span>")


### PR DESCRIPTION
closes #21155 
closes #21145 

🆑 
* bugfix: Destroying coffins now returns 3 wood, deconstructing them returns the full 5.
* bugfix: Deconstruction of forges is all around better. Deconstruction is prioritized above inserting a crowbar, you get a feedback message when you begin, it plays a sound, and it doesn't delete whatever was inserted inside (drops instead). Oh, and it actually deconstructs.