### PR TITLE
Yet more mining turf tweaks for snowmap

### DIFF
--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -415,16 +415,7 @@ turf/unsimulated/mineral/ChangeTurf(var/turf/N, var/tell_universe=1, var/force_l
 /turf/unsimulated/mineral/proc/DropMineral()
 	if(!mineral)
 		return
-
-	var/obj/item/weapon/ore/O = new mineral.ore (src)
-	O.pixel_x = rand(-16,16) * PIXEL_MULTIPLIER
-	O.pixel_y = rand(-16,16) * PIXEL_MULTIPLIER
-	if(istype(O))
-		if(!geologic_data)
-			geologic_data = new/datum/geosample(src)
-		geologic_data.UpdateNearbyArtifactInfo(src)
-		O.geologic_data = geologic_data
-	return O
+	return mineral.DropMineral(src)
 
 /**
 * artifact_fail: If true, negative effects will be applied to mobs in range when artifacts inside
@@ -587,7 +578,7 @@ turf/unsimulated/mineral/ChangeTurf(var/turf/N, var/tell_universe=1, var/force_l
 
 	name = proper_name
 
-	if(prob(20))
+	if(prob(20) && icon_state == "asteroid")
 		icon_state = "asteroid[rand(0,12)]"
 
 
@@ -779,7 +770,6 @@ turf/unsimulated/mineral/ChangeTurf(var/turf/N, var/tell_universe=1, var/force_l
 	var/mineralChance = 10  //means 10% chance of this plot changing to a mineral deposit
 
 /turf/unsimulated/mineral/random/New()
-	icon_state = "rock"
 	if (prob(mineralChance) && !mineral)
 		var/mineral_name = pickweight(mineralSpawnChanceList) //temp mineral name
 
@@ -800,6 +790,18 @@ turf/unsimulated/mineral/ChangeTurf(var/turf/N, var/tell_universe=1, var/force_l
 	base_icon_state = "snow_rock"
 	mined_type = /turf/unsimulated/floor/snow/permafrost
 	overlay_state = "snow_rock_overlay"
+
+	mineralSpawnChanceList = list(
+		"Iron"      = 50,
+		"Plasma"    = 25,
+		"Ice"		= 10,
+		"Uranium"   = 5,
+		"Gold"      = 5,
+		"Silver"    = 5,
+		"Gibtonite" = 5,
+		"Diamond"   = 1,
+		"Ice Cave"  = 1,
+	)
 
 /turf/unsimulated/mineral/random/high_chance
 	icon_state = "rock(high)"
@@ -1112,6 +1114,29 @@ turf/unsimulated/mineral/ChangeTurf(var/turf/N, var/tell_universe=1, var/force_l
 		/mob/living/simple_animal/hostile/asteroid/pillow = 2
 	)
 	var/sanity = 1
+	var/turf/floor_type = /turf/unsimulated/floor/asteroid
+
+/turf/unsimulated/floor/asteroid/cave/permafrost
+	mob_spawn_list = list(
+		/mob/living/simple_animal/hostile/bear = 4,
+		/mob/living/simple_animal/hostile/asteroid/pillow = 3,
+		/mob/living/simple_animal/hostile/scarybat = 5,
+		/mob/living/simple_animal/hostile/giant_spider/hunter = 4,
+		/mob/living/simple_animal/hostile/giant_spider/nurse = 3,
+		/mob/living/simple_animal/hostile/wendigo = 1)
+
+	floor_type = /turf/unsimulated/floor/snow/permafrost
+
+	icon = 'icons/turf/new_snow.dmi'
+	icon_state = "permafrost_full"
+	temperature = T_ARCTIC
+	oxygen = MOLES_O2STANDARD_ARCTIC
+	nitrogen = MOLES_N2STANDARD_ARCTIC
+	light_color = "#e5ffff"
+	can_border_transition = 1
+	dynamic_lighting = 0
+	luminosity = 1
+	plane = PLATING_PLANE
 
 /turf/unsimulated/floor/asteroid/cave/New(loc, var/length, var/go_backwards = 1, var/exclude_dir = -1)
 
@@ -1182,7 +1207,7 @@ turf/unsimulated/mineral/ChangeTurf(var/turf/N, var/tell_universe=1, var/force_l
 
 	SpawnMonster(T)
 
-	new /turf/unsimulated/floor/asteroid(T) // TODO: FIX THIS
+	T.ChangeTurf(floor_type) // TODO: FIX THIS
 
 /turf/unsimulated/floor/asteroid/cave/proc/SpawnMonster(var/turf/T)
 	if(prob(2))

--- a/code/modules/mining/minerals.dm
+++ b/code/modules/mining/minerals.dm
@@ -31,6 +31,17 @@ mineral
 	proc/UpdateTurf(var/turf/unsimulated/mineral/T)
 		T.UpdateMineral()
 
+mineral/proc/DropMineral(var/turf/unsimulated/mineral/T)
+	var/obj/item/weapon/ore/O = new ore (T)
+	O.pixel_x = rand(-16,16) * PIXEL_MULTIPLIER
+	O.pixel_y = rand(-16,16) * PIXEL_MULTIPLIER
+	if(istype(O))
+		if(!T.geologic_data)
+			T.geologic_data = new/datum/geosample(T)
+		T.geologic_data.UpdateNearbyArtifactInfo(T)
+		O.geologic_data = T.geologic_data
+	return O
+
 mineral/uranium
 	name = "Uranium"
 	result_amount = 5
@@ -165,11 +176,15 @@ mineral/gibtonite
 	result_amount = 1
 	spread = 1
 	ore = /obj/item/weapon/gibtonite
-	UpdateTurf(var/turf/T)
-		if(!istype(T,/turf/unsimulated/mineral/gibtonite))
-			T.ChangeTurf(/turf/unsimulated/mineral/gibtonite)
-		else
-			..()
+
+mineral/gibtonite/UpdateTurf(var/turf/unsimulated/mineral/T)
+	if(!istype(T,/turf/unsimulated/mineral/gibtonite))
+		var/old_state = T.icon_state
+		var/turf/unsimulated/mineral/newturf = T.ChangeTurf(/turf/unsimulated/mineral/gibtonite)
+		newturf.base_icon_state = old_state
+		newturf.icon_state = old_state
+	else
+		..()
 
 
 mineral/ice
@@ -188,6 +203,15 @@ mineral/cave
 	UpdateTurf(var/turf/T)
 		if(!istype(T,/turf/unsimulated/floor/asteroid/cave))
 			T.ChangeTurf(/turf/unsimulated/floor/asteroid/cave)
+		else
+			..()
+
+mineral/cave/ice
+	display_name = "Ice Cave"
+	name = "Ice Cave"
+	UpdateTurf(var/turf/T)
+		if(!istype(T,/turf/unsimulated/floor/asteroid/cave/permafrost))
+			T.ChangeTurf(/turf/unsimulated/floor/asteroid/cave/permafrost)
 		else
 			..()
 


### PR DESCRIPTION
:cl:
 * rscadd: The mining caves on snowmap now contain snow-themed creatures, and are no longer asteroid atmosphere.
 * rscadd: gibtonite now inherits the icon state of the rock it's hiding in, rather than still appearing as mars red.