### PR TITLE
Better Layering (SBO22-23)

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -16,6 +16,7 @@ var/global/num_vending_terminals = 1
 	var/obj/structure/vendomatpack/pack = null
 	anchored = 1
 	density = 1
+	layer = OPEN_DOOR_LAYER //This is below BELOW_OBJ_LAYER because vendors can contain crates/closets
 	var/health = 100
 	var/maxhealth = 100 //Kicking feature
 	var/active = 1		//No sales pitches if off!

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -7,7 +7,7 @@
 	density = 0
 	icon = 'icons/obj/lighting.dmi'
 	icon_state = "glowshroomf"
-	layer = BELOW_OBJ_LAYER
+	layer = BELOW_TABLE_LAYER
 	var/endurance = 30
 	var/potency = 30
 	var/delay = 1200


### PR DESCRIPTION
closes #17941

🆑 
* bugfix: Glowshrooms will now grow below tables and crates, no longer blocking them.
* bugfix: Vending machines are now layered below container structures like crates and closets (mostly relevant to trader vendor)