### PR TITLE
Fixes trader goof (SBO26)

### DIFF
--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -374,8 +374,11 @@ var/datum/controller/gameticker/ticker
 			else
 
 				var/mob/living/carbon/human/new_character = player.create_character()
-				if(new_character.mind.assigned_role!="MODE"&&new_character.mind.assigned_role!="Cyborg"&&new_character.mind.assigned_role!="Mobile MMI")//MODE is something like a wizard, not announced.
-					data_core.manifest_inject(new_character)
+				switch(new_character.mind.assigned_role)
+					if("MODE","Cyborg","Mobile MMI","Trader")
+						//No injection
+					else
+						data_core.manifest_inject(new_character)
 				player.FuckUpGenes(new_character)
 				qdel(player)
 


### PR DESCRIPTION
🆑 
* bugfix: Traders will no longer appear on the roundstart manifest