### PR TITLE
Anvil force increased (SBO27)

### DIFF
--- a/code/WorkInProgress/MadmanMartian/blacksmithing/anvil.dm
+++ b/code/WorkInProgress/MadmanMartian/blacksmithing/anvil.dm
@@ -13,6 +13,7 @@
 	layer = TABLE_LAYER
 	flags = FPRINT | TWOHANDABLE | MUSTTWOHAND
 	density = 1
+	force = 40 //as much as a wielded fireaxe
 	throwforce = 40
 
 /obj/item/anvil/can_pickup(mob/living/M)


### PR DESCRIPTION
Since these are theoretically harder to get than a fireaxe and must be twohanded like them AND require hulk to pick up, it seems fine to have them be 40 force like the fireaxe.

fixes #21146

🆑 
* bugfix: The anvil now properly has melee damage. (If you are strong enough to lift it)