### PR TITLE
Maturity minimum (SBO29)

### DIFF
--- a/code/modules/hydroponics/hydroponics_mutations.dm
+++ b/code/modules/hydroponics/hydroponics_mutations.dm
@@ -226,7 +226,7 @@
 			hardcap_values = list(5,  3.5, 2,  1,   0.75, 0)
 			deviation = severity * (rand(8, 12)/100) * get_ratio(severity, softcap_values, hardcap_values, seed.maturation)
 			//Deviation per 10u Mutagen before cap: 0.8-1.2
-			seed.maturation = Clamp(seed.maturation - deviation, 1, 30)
+			seed.maturation = Clamp(seed.maturation - deviation, 2, 30)
 			generic_mutation_message("quivers!")
 
 		if("plusstat_heat&pressure_tolerance")

--- a/code/modules/hydroponics/hydroponics_mutations.dm
+++ b/code/modules/hydroponics/hydroponics_mutations.dm
@@ -226,7 +226,7 @@
 			hardcap_values = list(5,  3.5, 2,  1,   0.75, 0)
 			deviation = severity * (rand(8, 12)/100) * get_ratio(severity, softcap_values, hardcap_values, seed.maturation)
 			//Deviation per 10u Mutagen before cap: 0.8-1.2
-			seed.maturation = Clamp(seed.maturation - deviation, 2, 30)
+			seed.maturation = Clamp(seed.maturation - deviation, 1.1, 30)
 			generic_mutation_message("quivers!")
 
 		if("plusstat_heat&pressure_tolerance")


### PR DESCRIPTION
fixes #21032 

🆑 
* bugfix: Plants now have a hardcap minimum maturation time of 1.1, preventing them from bugging by being instantly mature.