### PR TITLE
Unatomic spell tweaks

### DIFF
--- a/__DEFINES/spell_defines.dm
+++ b/__DEFINES/spell_defines.dm
@@ -19,6 +19,7 @@
 #define WAIT_FOR_CLICK	2048//spells wait for you to click on a target to cast
 #define TALKED_BEFORE	4096//spells require you to have heard the person you are casting it upon
 #define CAN_CHANNEL_RESTRAINED 8192 //channeled spells that you can cast despite having handcuffs on
+#define LOSE_IN_TRANSFER 16384 //If your mind is transferred, you'll lose this spell.
 
 //invocation
 #define SpI_SHOUT	"shout"

--- a/code/datums/gamemode/role/role.dm
+++ b/code/datums/gamemode/role/role.dm
@@ -660,7 +660,7 @@
 /datum/role/wizard/PostMindTransfer(var/mob/living/new_character, var/mob/living/old_character)
 	. = ..()
 	for (var/spell/S in old_character.spell_list)
-		if (S.user_type == USER_TYPE_WIZARD)
+		if (S.user_type == USER_TYPE_WIZARD && !(S.spell_flags & LOSE_IN_TRANSFER))
 			new_character.add_spell(S)
 
 /datum/role/wizard/summon_magic

--- a/code/modules/mob/spells.dm
+++ b/code/modules/mob/spells.dm
@@ -5,7 +5,7 @@
 	if(!spell_masters)
 		spell_masters = list()
 
-	spell_to_add.holder = src
+	spell_to_add.set_holder(src)
 	if(spell_masters.len)
 		for(var/obj/abstract/screen/movable/spell_master/spell_master in spell_masters)
 			if(spell_master.type == master_type)

--- a/code/modules/projectiles/projectile/change.dm
+++ b/code/modules/projectiles/projectile/change.dm
@@ -48,9 +48,6 @@
 			else
 				return
 		if(new_mob)
-			if(new_mob.mind && new_mob.mind.wizard_spells && new_mob.mind.wizard_spells.len)
-				for (var/spell/S in new_mob.mind.wizard_spells)
-					new_mob.add_spell(S)
 			var/mob/living/carbon/human/H = new_mob
 			to_chat(new_mob, "<B>Your form morphs into that of a [(istype(H) && H.species && H.species.name) ? H.species.name : randomize].</B>")
 			return new_mob

--- a/code/modules/spells/aoe_turf/fall.dm
+++ b/code/modules/spells/aoe_turf/fall.dm
@@ -74,7 +74,7 @@ var/global/list/falltempoverlays = list()
 
 /spell/aoe_turf/fall/perform(mob/user = usr, skipcharge = 0, var/ignore_timeless = FALSE) //if recharge is started is important for the trigger spells
 	if(!holder)
-		holder = user //just in case
+		set_holder(user) //just in case
 	if(!cast_check(skipcharge, user))
 		return
 	if(cast_delay && !spell_do_after(user, cast_delay))

--- a/code/modules/spells/spell_code.dm
+++ b/code/modules/spells/spell_code.dm
@@ -109,6 +109,11 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 	//still_recharging_msg = "<span class='notice'>[name] is still recharging.</span>"
 	charge_counter = charge_max
 
+/spell/proc/set_holder(var/new_holder)
+	if(holder == new_holder)
+		world.log << "[src] is trying to set its holder to the same holder!"
+	holder = new_holder
+
 /spell/proc/process()
 	spawn while(charge_counter < charge_max)
 		if(holder && !holder.timestopped)
@@ -141,7 +146,7 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 
 /spell/proc/perform(mob/user = usr, skipcharge = 0, list/target_override) //if recharge is started is important for the trigger spells
 	if(!holder)
-		holder = user //just in case
+		set_holder(user) //just in case
 
 	var/list/targets = target_override
 
@@ -195,7 +200,7 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 //This is used with the wait_for_click spell flag to prepare spells to be cast on your next click
 /spell/proc/channel_spell(mob/user = usr, skipcharge = 0, force_remove = 0)
 	if(!holder)
-		holder = user //just in case
+		set_holder(user) //just in case
 	if(!force_remove && !currently_channeled)
 		if(!cast_check(skipcharge, user))
 			return 0

--- a/code/modules/spells/targeted/fist.dm
+++ b/code/modules/spells/targeted/fist.dm
@@ -10,6 +10,7 @@
 	invocation = "I CAST FIST"
 	invocation_type = SpI_SHOUT
 	max_targets = 3
+	spell_flags = NEEDSCLOTHES|LOSE_IN_TRANSFER
 
 	compatible_mobs = list(/mob/living)
 


### PR DESCRIPTION
Adds a new flag for spells for whether they are preserved on mindswap.
Fist spell is no longer preserved on Mind Transfer.
Spell code now uses a setter for setting the holder.
Staff of change no longer preserves spells in its own way, so now it defaults down to Role/PostMindTransfer

Should really be on mind/TransferTo IMO

closes #20760

:cl:
 * tweak: Shooting yoursel fin the face with a staff of change no long preserves certain spells.
