### PR TITLE
Welding without protection blinds you (again)

### DIFF
--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -490,7 +490,7 @@
 		if(E.welding_proof)
 			user.simple_message("<span class='notice'>Your eyelenses darken to accommodate for the welder's glow.</span>")
 			return
-		if(safety && eye_damaging && !(user.sdisabilities & BLIND))
+		if(safety < 2 && eye_damaging && !(user.sdisabilities & BLIND))
 			switch(safety)
 				if(1)
 					user.simple_message("<span class='warning'>Your eyes sting a little.</span>",\


### PR DESCRIPTION
One of the little changes in #21028 made it so that, if your eyeprot is 0, you don't take damage from welding, full stop. No messages or anything! -1 and 1 still work just fine, though.

This is just reverting said little change.
[bugfix]
