### PR TITLE
Custom shuttles fixes

### DIFF
--- a/code/datums/shuttle.dm
+++ b/code/datums/shuttle.dm
@@ -75,7 +75,7 @@
 	//When the shuttle moves, if stable is 0 then all unbuckled mobs will be stunned
 	var/stable = 0
 
-	var/password = 28011
+	var/password = null
 	var/can_link_to_computer = LINK_FORBIDDEN
 
 	//Whether the shuttle gibs or displaces stuff. Change this to COLLISION_DISPLACE to make all shuttles displace stuff by default
@@ -101,8 +101,8 @@
 
 	if(istype(linked_area) && linked_area.contents.len) //Only add the shuttle to the list if its area exists and it has something in it
 		shuttles |= src
-
-	password = rand(10000,99999)
+	if(password)
+		password = rand(10000,99999)
 
 //initialize() proc - called automatically in proc/setup_shuttles() below.
 //Returns INIT_SUCCESS, INIT_NO_AREA, INIT_NO_START or INIT_NO_PORT, depending on whether there were any errors
@@ -819,6 +819,7 @@
 //Custom shuttles
 /datum/shuttle/custom
 	name = "custom shuttle"
+	can_link_to_computer = LINK_FREE
 
 /datum/shuttle/proc/show_outline(var/mob/user, var/turf/centered_at)
 	if(!user)

--- a/code/game/machinery/computer/shuttle_computers.dm
+++ b/code/game/machinery/computer/shuttle_computers.dm
@@ -224,7 +224,7 @@
 		else if(shuttle.moving)
 			dat += "<center><h3>Currently moving [shuttle.destination_port.areaname ? "to [shuttle.destination_port.areaname]" : ""]</h3></center>"
 		else
-			dat += {"<a href='?src=\ref[src];link_to_port=1'>Scan for docking ports</a>"}
+			dat += {"<a href='?src=\ref[src];link_to_port=1'>Scan for docking ports</a><br>"}
 			if(shuttle.current_port)
 				dat += "Location: <b>[shuttle.current_port.areaname]</b><br>"
 			else

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -486,7 +486,7 @@ these cannot rename rooms that are in by default BUT can rename rooms that are c
 	var/area_size = A.area_turfs.len
 	var/active_engines = 0
 	for(var/obj/structure/shuttle/engine/propulsion/DIY/D in A)
-		if(D.heater && anchored)
+		if(D.heater && D.anchored)
 			active_engines++
 
 	if(active_engines < 2 || area_size/active_engines > 12.5) //2 engines per 25 tiles, with a minimum of 2 engines.
@@ -496,7 +496,7 @@ these cannot rename rooms that are in by default BUT can rename rooms that are c
 
 	var/turf/check_turf = get_step(user, user.dir)
 
-	if(!istype(check_turf, /turf/space))
+	if(get_area(check_turf) == A)
 		to_chat(user, "<span class = 'warning'>This area is not a viable shuttle. Reason: Unable to create docking port at current user location.</span>")
 		return
 
@@ -508,7 +508,7 @@ these cannot rename rooms that are in by default BUT can rename rooms that are c
 		to_chat(user, "Shuttlifying cancelled.")
 		return
 
-	var/obj/docking_port/shuttle/DP = new /obj/docking_port/shuttle(A.loc)
+	var/obj/docking_port/shuttle/DP = new /obj/docking_port/shuttle(get_turf(src))
 	DP.dir = user.dir
 
 

--- a/code/game/shuttle_engines.dm
+++ b/code/game/shuttle_engines.dm
@@ -48,7 +48,7 @@
 
 /obj/structure/shuttle/engine/heater/DIY/attackby(obj/item/I, mob/user)
 	if(iswrench(I) && wrenchAnchor(user, 5 SECONDS))
-		if(anchored)
+		if(!anchored)
 			if(connected_engine)
 				connected_engine.heater = null
 				connected_engine = null

--- a/code/game/shuttles/salvage.dm
+++ b/code/game/shuttles/salvage.dm
@@ -12,7 +12,7 @@ var/global/datum/shuttle/salvage/salvage_shuttle = new(starting_area=/area/shutt
 	pre_flight_delay = 30
 
 	can_link_to_computer = LINK_PASSWORD_ONLY
-
+	password = TRUE
 	stable = 1 //Don't stun everyone and don't throw anything when moving
 	can_rotate = 0 //Sleepers, body scanners and multi-tile airlocks aren't rotated properly
 


### PR DESCRIPTION
 - Fixes being unable to link the shuttle control console to the new shuttle, as it wouldn't come up on the shuttle link menu
 - Fixes being unable to link the heater to the engine
 - Fixes the custom shuttle not being able to do anything as it would have no initial docking port, which would cause issues.

closes #20914 

:cl:
 * bugfix: Fixes numerous issues with custom shuttle creation