### PR TITLE
Lowers the Lawgiver's laser damage back to 40

### DIFF
--- a/code/modules/projectiles/guns/lawgiver.dm
+++ b/code/modules/projectiles/guns/lawgiver.dm
@@ -32,7 +32,7 @@
 	voice_triggers = list("laser", "lethal", "beam")
 	firing_mode = LAWGIVER_LASER
 	fire_sound = 'sound/weapons/lasercannonfire.ogg'
-	projectile_type = /obj/item/projectile/beam/heavylaser
+	projectile_type = /obj/item/projectile/beam/heavylaser/lawgiver
 	fire_delay = 5
 	activation_message = "LASER."
 	ammo_per_shot = 20

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -575,6 +575,9 @@ var/list/beam_master = list()
 	damage = 60
 	fire_sound = 'sound/weapons/lasercannonfire.ogg'
 
+/obj/item/projectile/beam/heavylaser/lawgiver
+	damage = 40
+
 /obj/item/projectile/beam/xray
 	name = "xray beam"
 	icon_state = "xray"


### PR DESCRIPTION
Seeing #21209 reminded me that #20564 also buffed the Lawgiver; it wasn't mentioned in the description, so I presume it was unintentional. This just changes the damage back to how it used to be, which is still 10 higher than a default laser.

[balance]