### PR TITLE
Adds an alt+click toggle to the Field Suspension Generator

### DIFF
--- a/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
+++ b/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
@@ -363,12 +363,13 @@
 	..()
 
 /obj/machinery/suspension_gen/AltClick(mob/user)
-	if(!user.incapacitated() && user.Adjacent(get_turf(src)))
-		if(!suspension_field)
-			if(cell.charge > 0)
-				if(anchored)
-					activate()
-				else
-					to_chat(usr, "<span class='warning'>You are unable to activate [src] until it is properly secured on the ground.</span>")
-		else
-			deactivate()
+	if(user.incapacitated() || !user.Adjacent(get_turf(src)) || locked)
+		return
+	if(!suspension_field)
+		if(cell.charge > 0)
+			if(anchored)
+				activate()
+			else
+				to_chat(usr, "<span class='warning'>You are unable to activate [src] until it is properly secured on the ground.</span>")
+	else
+		deactivate()

--- a/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
+++ b/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
@@ -361,3 +361,14 @@
 	for(var/obj/I in src)
 		I.forceMove(src.loc)
 	..()
+
+/obj/machinery/suspension_gen/AltClick(mob/user)
+	if(!user.incapacitated() && user.Adjacent(get_turf(src)))
+		if(!suspension_field)
+			if(cell.charge > 0)
+				if(anchored)
+					activate()
+				else
+					to_chat(usr, "<span class='warning'>You are unable to activate [src] until it is properly secured on the ground.</span>")
+		else
+			deactivate()

--- a/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
+++ b/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
@@ -363,6 +363,9 @@
 	..()
 
 /obj/machinery/suspension_gen/AltClick(mob/user)
+	toggle(user)
+	
+/obj/machinery/suspension_gen/proc/toggle(mob/user)
 	if(user.incapacitated() || !user.Adjacent(get_turf(src)) || locked)
 		return
 	if(!suspension_field)

--- a/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
+++ b/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
@@ -122,14 +122,7 @@
 	usr.set_machine(src)
 
 	if(href_list["toggle_field"])
-		if(!suspension_field)
-			if(cell.charge > 0)
-				if(anchored)
-					activate()
-				else
-					to_chat(usr, "<span class='warning'>You are unable to activate \the [src] until it is properly secured on the ground.</span>")
-		else
-			deactivate()
+		toggle(usr)
 	if(href_list["select_field"])
 		field_type = href_list["select_field"]
 	else if(href_list["insertcard"])

--- a/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
+++ b/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
@@ -119,7 +119,7 @@
 /obj/machinery/suspension_gen/Topic(href, href_list)
 	if(..())
 		return
-	usr.set_machine(src)
+	user.set_machine(src)
 
 	if(href_list["toggle_field"])
 		if(!suspension_field)
@@ -127,26 +127,26 @@
 				if(anchored)
 					activate()
 				else
-					to_chat(usr, "<span class='warning'>You are unable to activate [src] until it is properly secured on the ground.</span>")
+					to_chat(user, "<span class='warning'>You are unable to activate [src] until it is properly secured on the ground.</span>")
 		else
 			deactivate()
 	if(href_list["select_field"])
 		field_type = href_list["select_field"]
 	else if(href_list["insertcard"])
-		var/obj/item/I = usr.get_active_hand()
+		var/obj/item/I = user.get_active_hand()
 		if (istype(I, /obj/item/weapon/card))
-			if(usr.drop_item(I, src))
+			if(user.drop_item(I, src))
 				auth_card = I
 				if(attempt_unlock(I))
-					to_chat(usr, "<span class='info'>You insert [I], the console flashes \'<i>Access granted.</a>\'</span>")
+					to_chat(user, "<span class='info'>You insert [I], the console flashes \'<i>Access granted.</a>\'</span>")
 				else
-					to_chat(usr, "<span class='warning'>You insert [I], the console flashes \'<i>Access denied.</a>\'</span>")
+					to_chat(user, "<span class='warning'>You insert [I], the console flashes \'<i>Access denied.</a>\'</span>")
 	else if(href_list["ejectcard"])
 		if(auth_card)
-			if(ishuman(usr))
-				auth_card.forceMove(usr.loc)
-				if(!usr.get_active_hand())
-					usr.put_in_hands(auth_card)
+			if(ishuman(user))
+				auth_card.forceMove(user.loc)
+				if(!user.get_active_hand())
+					user.put_in_hands(auth_card)
 				auth_card = null
 			else
 				auth_card.forceMove(loc)
@@ -154,8 +154,8 @@
 	else if(href_list["lock"])
 		locked = 1
 	else if(href_list["close"])
-		usr.unset_machine()
-		usr << browse(null, "window=suspension")
+		user.unset_machine()
+		user << browse(null, "window=suspension")
 
 	updateUsrDialog()
 
@@ -335,7 +335,7 @@
 	set category = "Object"
 
 	if(anchored)
-		to_chat(usr, "<span class='warning'>You cannot rotate [src], it has been firmly fixed to the floor.</span>")
+		to_chat(user, "<span class='warning'>You cannot rotate [src], it has been firmly fixed to the floor.</span>")
 	else
 		dir = turn(dir, -90)
 
@@ -345,7 +345,7 @@
 	set category = "Object"
 
 	if(anchored)
-		to_chat(usr, "<span class='warning'>You cannot rotate [src], it has been firmly fixed to the floor.</span>")
+		to_chat(user, "<span class='warning'>You cannot rotate [src], it has been firmly fixed to the floor.</span>")
 	else
 		dir = turn(dir, 90)
 
@@ -370,6 +370,6 @@
 			if(anchored)
 				activate()
 			else
-				to_chat(usr, "<span class='warning'>You are unable to activate [src] until it is properly secured on the ground.</span>")
+				to_chat(user, "<span class='warning'>You are unable to activate [src] until it is properly secured on the ground.</span>")
 	else
 		deactivate()

--- a/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
+++ b/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
@@ -119,7 +119,7 @@
 /obj/machinery/suspension_gen/Topic(href, href_list)
 	if(..())
 		return
-	user.set_machine(src)
+	usr.set_machine(src)
 
 	if(href_list["toggle_field"])
 		if(!suspension_field)
@@ -127,26 +127,26 @@
 				if(anchored)
 					activate()
 				else
-					to_chat(user, "<span class='warning'>You are unable to activate [src] until it is properly secured on the ground.</span>")
+					to_chat(usr, "<span class='warning'>You are unable to activate [src] until it is properly secured on the ground.</span>")
 		else
 			deactivate()
 	if(href_list["select_field"])
 		field_type = href_list["select_field"]
 	else if(href_list["insertcard"])
-		var/obj/item/I = user.get_active_hand()
+		var/obj/item/I = usr.get_active_hand()
 		if (istype(I, /obj/item/weapon/card))
-			if(user.drop_item(I, src))
+			if(usr.drop_item(I, src))
 				auth_card = I
 				if(attempt_unlock(I))
-					to_chat(user, "<span class='info'>You insert [I], the console flashes \'<i>Access granted.</a>\'</span>")
+					to_chat(usr, "<span class='info'>You insert [I], the console flashes \'<i>Access granted.</a>\'</span>")
 				else
-					to_chat(user, "<span class='warning'>You insert [I], the console flashes \'<i>Access denied.</a>\'</span>")
+					to_chat(usr, "<span class='warning'>You insert [I], the console flashes \'<i>Access denied.</a>\'</span>")
 	else if(href_list["ejectcard"])
 		if(auth_card)
-			if(ishuman(user))
-				auth_card.forceMove(user.loc)
-				if(!user.get_active_hand())
-					user.put_in_hands(auth_card)
+			if(ishuman(usr))
+				auth_card.forceMove(usr.loc)
+				if(!usr.get_active_hand())
+					usr.put_in_hands(auth_card)
 				auth_card = null
 			else
 				auth_card.forceMove(loc)
@@ -154,8 +154,8 @@
 	else if(href_list["lock"])
 		locked = 1
 	else if(href_list["close"])
-		user.unset_machine()
-		user << browse(null, "window=suspension")
+		usr.unset_machine()
+		usr << browse(null, "window=suspension")
 
 	updateUsrDialog()
 
@@ -335,7 +335,7 @@
 	set category = "Object"
 
 	if(anchored)
-		to_chat(user, "<span class='warning'>You cannot rotate [src], it has been firmly fixed to the floor.</span>")
+		to_chat(usr, "<span class='warning'>You cannot rotate [src], it has been firmly fixed to the floor.</span>")
 	else
 		dir = turn(dir, -90)
 
@@ -345,7 +345,7 @@
 	set category = "Object"
 
 	if(anchored)
-		to_chat(user, "<span class='warning'>You cannot rotate [src], it has been firmly fixed to the floor.</span>")
+		to_chat(usr, "<span class='warning'>You cannot rotate [src], it has been firmly fixed to the floor.</span>")
 	else
 		dir = turn(dir, 90)
 

--- a/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
+++ b/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
@@ -127,7 +127,7 @@
 				if(anchored)
 					activate()
 				else
-					to_chat(usr, "<span class='warning'>You are unable to activate [src] until it is properly secured on the ground.</span>")
+					to_chat(usr, "<span class='warning'>You are unable to activate \the [src] until it is properly secured on the ground.</span>")
 		else
 			deactivate()
 	if(href_list["select_field"])
@@ -195,11 +195,11 @@
 					to_chat(user, "<span class='info'>You crowbar the battery panel [open ? "open" : "in place"].</span>")
 					icon_state = "suspension[anchored ? (open ? (cell ? "1" : "0") : "2") : (open ? (cell ? "1-b" : "0-b") : "2-b")]"
 				else
-					to_chat(user, "<span class='warning'>[src]'s safety locks are engaged, shut it down first.</span>")
+					to_chat(user, "<span class='warning'>\the [src]'s safety locks are engaged, shut it down first.</span>")
 			else
-				to_chat(user, "<span class='warning'>Unscrew [src]'s battery panel first.</span>")
+				to_chat(user, "<span class='warning'>Unscrew \the [src]'s battery panel first.</span>")
 		else
-			to_chat(user, "<span class='warning'>[src]'s security locks are engaged.</span>")
+			to_chat(user, "<span class='warning'>\the [src]'s security locks are engaged.</span>")
 	else if (iswrench(W))
 		if(!suspension_field)
 			if(anchored)
@@ -213,7 +213,7 @@
 			else
 				desc = "It has stubby legs bolted up against it's body for stabilising."
 		else
-			to_chat(user, "<span class='warning'>You are unable to secure [src] while it is active!</span>")
+			to_chat(user, "<span class='warning'>You are unable to secure \the [src] while it is active!</span>")
 	else if (istype(W, /obj/item/weapon/cell))
 		if(open)
 			if(cell)
@@ -294,7 +294,7 @@
 
 	suspension_field = new(T)
 	suspension_field.field_type = field_type
-	src.visible_message("<span class='notice'>[bicon(src)] [src] activates with a low hum.</span>")
+	src.visible_message("<span class='notice'>[bicon(src)] \the [src] activates with a low hum.</span>")
 	icon_state = "suspension3"
 
 	for(var/obj/item/I in T)
@@ -319,7 +319,7 @@
 		to_chat(M, "<span class='info'>You no longer feel like floating.</span>")
 		M.SetKnockdown(min(M.knockdown, 3))
 
-	src.visible_message("<span class='notice'>[bicon(src)] [src] deactivates with a gentle shudder.</span>")
+	src.visible_message("<span class='notice'>[bicon(src)] \the [src] deactivates with a gentle shudder.</span>")
 	qdel(suspension_field)
 	suspension_field = null
 	icon_state = "suspension2"
@@ -335,7 +335,7 @@
 	set category = "Object"
 
 	if(anchored)
-		to_chat(usr, "<span class='warning'>You cannot rotate [src], it has been firmly fixed to the floor.</span>")
+		to_chat(usr, "<span class='warning'>You cannot rotate \the [src], it has been firmly fixed to the floor.</span>")
 	else
 		dir = turn(dir, -90)
 
@@ -345,7 +345,7 @@
 	set category = "Object"
 
 	if(anchored)
-		to_chat(usr, "<span class='warning'>You cannot rotate [src], it has been firmly fixed to the floor.</span>")
+		to_chat(usr, "<span class='warning'>You cannot rotate \the [src], it has been firmly fixed to the floor.</span>")
 	else
 		dir = turn(dir, 90)
 
@@ -370,6 +370,6 @@
 			if(anchored)
 				activate()
 			else
-				to_chat(user, "<span class='warning'>You are unable to activate [src] until it is properly secured on the ground.</span>")
+				to_chat(user, "<span class='warning'>You are unable to activate \the [src] until it is properly secured on the ground.</span>")
 	else
 		deactivate()


### PR DESCRIPTION
It feels like there's a better way to do this seeing as it's just awkward copypasta, so recommendations are welcome. Otherwise, does what it says on the can, and is tested for the basics (e.g., actually works, ghosthands, etc)

Closes #21222 
[qol]

🆑

- rscadd: The Xenoarchaeologist's Field Suspension Generator can now be toggled with Alt+Click.