### PR TITLE
glowshroom / grass weeds

### DIFF
--- a/code/modules/hydroponics/hydro_tray.dm
+++ b/code/modules/hydroponics/hydro_tray.dm
@@ -179,7 +179,7 @@
 	//Remove the seed if something is already planted.
 	if(seed)
 		remove_plant()
-	seed = SSplant.seeds[pick(list("reishi","nettles","amanita","mushrooms","plumphelmet","towercap","harebells","weeds"))]
+	seed = SSplant.seeds[pick(list("reishi","nettles","amanita","mushrooms","plumphelmet","towercap","harebells","weeds","glowshroom","grass"))]
 	if(!seed)
 		return //Weed does not exist, someone fucked up.
 


### PR DESCRIPTION
Hydro trays that get overgrown by weeds can now sprout glowshrooms and grass.
This was requested so people without access to seeds can do advanced botany or something.
Also something about mommis. [tweak] 

🆑 
 - tweak: Hydro trays that get overgrown by weeds can now sprout glowshrooms and grass.