### PR TITLE
Spiders unscrewed

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/base_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/base_spider.dm
@@ -46,7 +46,6 @@
 	size = SIZE_SMALL //dog-sized spiders are still big!
 
 	var/icon_aggro = null // for swapping to when we get aggressive
-	var/busy = 0
 	var/poison_per_bite = 5
 	var/poison_type = TOXIN
 	var/delimbable_icon = TRUE
@@ -120,23 +119,6 @@
 				src.visible_message("<span class='warning'>\the [src] injects a powerful toxin!</span>")
 				L.reagents.add_reagent(poison_type, poison_per_bite)
 
-/mob/living/simple_animal/hostile/giant_spider/Life()
-	if(timestopped)
-		return 0 //under effects of time magick
-	..()
-	if(!stat)
-		if(stance == HOSTILE_STANCE_IDLE)
-			//1% chance to skitter madly away
-			if(!busy && !(life_tick % 100))// Every 100 life ticks or prob(1)
-				/*var/list/move_targets = list()
-				for(var/turf/T in orange(20, src))
-					move_targets.Add(T)*/
-				stop_automated_movement = 1
-				Goto(pick(orange(20, src)), move_to_delay)
-				spawn(50)
-					stop_automated_movement = 0
-					walk(src,0)
-				return 1
 
 /mob/living/simple_animal/hostile/giant_spider/Aggro()
 	..()

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/hunter.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/hunter.dm
@@ -20,13 +20,5 @@
 	ranged = 0
 	minimum_distance = 1
 
-/mob/living/simple_animal/hostile/giant_spider/hunter/proc/GiveUp(var/C)
-	spawn(100)
-		if(busy == MOVING_TO_TARGET)
-			if(target == C && get_dist(src,target) > 1)
-				target = null
-			busy = 0
-			stop_automated_movement = 0
-
 /mob/living/simple_animal/hostile/giant_spider/hunter/dead
 	health = 0

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/nurse.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/nurse.dm
@@ -14,16 +14,16 @@
 	poison_per_bite = 10
 	poison_type = STOXIN
 	species_type = /mob/living/simple_animal/hostile/giant_spider/nurse/queen_spider
+	search_objects = TRUE
+	stat_attack = 2
 	var/fed = 0
-	var/atom/cocoon_target
 
-/mob/living/simple_animal/hostile/giant_spider/nurse/proc/GiveUp(var/C)
-	spawn(100)
-		if(busy == MOVING_TO_TARGET)
-			if(cocoon_target == C && get_dist(src,cocoon_target) > 1)
-				cocoon_target = null
-			busy = 0
-			stop_automated_movement = 0
+/mob/living/simple_animal/hostile/giant_spider/nurse/initialize_rules()
+	target_rules.Add(new /datum/fuzzy_ruling/is_mob)
+	target_rules.Add(new /datum/fuzzy_ruling/is_obj{weighting = 0.01})
+	var/datum/fuzzy_ruling/distance/D = new /datum/fuzzy_ruling/distance
+	D.set_source(src)
+	target_rules.Add(D)
 
 /mob/living/simple_animal/hostile/giant_spider/nurse/proc/check_evolve()
 	if(animal_count[species_type] < MAX_SQUEENS && !key)	//don't evolve if there's a player inside
@@ -32,152 +32,83 @@
 	return 0
 
 /mob/living/simple_animal/hostile/giant_spider/nurse/Life()
-	if(timestopped)
-		return 0 //under effects of time magick
-	if(istype(loc,/obj/item/device/mobcapsule)) //Dont bother trying to do shit while inside of a capsule, stops self-web spinning
+	if(timestopped || istype(loc,/obj/item/device/mobcapsule))
 		return
 	..()
-	if(!stat)
-		if(stance == HOSTILE_STANCE_IDLE)
-			if(check_evolve())
-				return
+	if(!stat && stance == HOSTILE_STANCE_IDLE)
+		if(check_evolve())
+			return
+		if(spin_web(get_turf(src)) && fed > 0)
+			lay_eggs()
 
-			var/list/can_see = view(src, 10)
-			//30% chance to stop wandering and do something
-			if(!busy && prob(30))
-				//first, check for potential food nearby to cocoon
-				for(var/mob/living/C in can_see)
-					if(C.stat && !istype(C,/mob/living/simple_animal/hostile/giant_spider))
-						cocoon_target = C
-						busy = MOVING_TO_TARGET
-						Goto(C, move_to_delay)
-						//give up if we can't reach them after 10 seconds
-						GiveUp(C)
-						return
+/mob/living/simple_animal/hostile/giant_spider/nurse/CanAttack(var/atom/the_target)
+	if(isitem(the_target))
+		return TRUE
+	return ..()
 
-				//second, spin a sticky spiderweb on this tile
-				var/obj/effect/spider/stickyweb/W = locate() in get_turf(src)
-				if(!W)
-					busy = SPINNING_WEB
-					src.visible_message("<span class='notice'>\the [src] begins to secrete a sticky substance.</span>")
-					stop_automated_movement = 1
-					spawn(40)
-						if(busy == SPINNING_WEB)
-							W = locate() in get_turf(src)
-							if(!W)
-								new /obj/effect/spider/stickyweb(src.loc)
-							busy = 0
-							stop_automated_movement = 0
-				// If there IS web and we've been fed...
-				else if(fed > 0)
-					//third, lay an egg cluster there
-					var/obj/effect/spider/eggcluster/E = locate() in get_turf(src)
-					if(!E)
-						busy = LAYING_EGGS
-						src.visible_message("<span class='notice'>\the [src] begins to lay a cluster of eggs.</span>")
-						stop_automated_movement = 1
-						spawn(50)
-							if(busy == LAYING_EGGS)
-								E = locate() in get_turf(src)
-								if(!E)
-									new /obj/effect/spider/eggcluster(src.loc)
-									fed--
-								busy = 0
-								stop_automated_movement = 0
-				// If we've got eggs, don't do anything but attack and lay eggs.
-				if(fed>0)
-					return
-				//fourthly, cocoon any nearby items so those pesky pinkskins can't use them
-				for(var/obj/O in can_see)
+/mob/living/simple_animal/hostile/giant_spider/nurse/AttackingTarget()
+	if(isitem(target))
+		return spin_cocoon(target)
+	if(isliving(target))
+		var/mob/living/L = target
+		if(L.stat) //Unconscious, or dead
+			return spin_cocoon(target)
+	return ..()
 
-					if(istype(O,/obj/machinery/door))
-						var/obj/machinery/door/D=O
-						if(D.density)
-							continue
-						// Jammed? Skippit.
-						if(locate(/obj/effect/spider/stickyweb) in get_turf(O))
-							continue
-					else
-						if(O.anchored)
-							continue
+/mob/living/simple_animal/hostile/giant_spider/nurse/proc/spin_web(var/turf/T)
+	if(!locate(/obj/effect/spider/stickyweb) in T)
+		new /obj/effect/spider/stickyweb(T)
+	return 1
 
-					if(istype(O, /obj/item) || istype(O, /obj/structure) || istype(O, /obj/machinery))
-						// Quit breaking shit you can't break.
-						//if(istype(O,/obj/structure/window) && O:godmode==1)
-						//	continue
-						// Skip things we can't wrap
-						if(istype(O, /mob/living/simple_animal/hostile/giant_spider))
-							continue
-
-						//Don't cocoon the box we're stored in
-						if(loc == O || locked_to == O)
-							continue
-
-						cocoon_target = O
-						busy = MOVING_TO_TARGET
-						stop_automated_movement = 1
-						Goto(O, move_to_delay)
-						//give up if we can't reach them after 10 seconds
-						GiveUp(O)
-
-			else if(busy == MOVING_TO_TARGET && cocoon_target)
-				if(get_dist(src, cocoon_target) <= 1)
-					if(istype(cocoon_target, /mob/living/simple_animal/hostile/giant_spider))
-						busy=0
-						stop_automated_movement=0
-					busy = SPINNING_COCOON
-					src.visible_message("<span class='notice'>\the [src] begins to secrete a sticky substance around \the [cocoon_target].</span>")
-					stop_automated_movement = 1
-					walk(src,0)
-					spawn(50)
-						if(busy == SPINNING_COCOON)
-							if(cocoon_target && istype(cocoon_target.loc, /turf) && get_dist(src,cocoon_target) <= 1)
-								if(istype(cocoon_target,/obj/machinery/door))
-									var/obj/machinery/door/D=cocoon_target
-									var/obj/effect/spider/stickyweb/W = locate() in get_turf(cocoon_target)
-									if(!W)
-										src.visible_message("<span class='warning'>\the [src] jams \the [cocoon_target] open with web!</span>")
-										W=new /obj/effect/spider/stickyweb(cocoon_target.loc)
-										// Jam the door open with webs
-										D.jammed=W
-									busy = 0
-									stop_automated_movement = 0
-								else
-									var/obj/effect/spider/cocoon/C = new(cocoon_target.loc)
-									var/large_cocoon = 0
-									C.pixel_x = cocoon_target.pixel_x
-									C.pixel_y = cocoon_target.pixel_y
-									for(var/mob/living/M in C.loc)
-										if(istype(M, /mob/living/simple_animal/hostile/giant_spider))
-											continue
-										large_cocoon = 1
-										if(M.getCloneLoss() < 125)
-											fed++
-											src.visible_message("<span class='warning'>\the [src] sticks a proboscis into \the [cocoon_target] and sucks a viscous substance out.</span>")
-											M.adjustCloneLoss(30 * size)
-										M.forceMove(C)
-										C.pixel_x = M.pixel_x
-										C.pixel_y = M.pixel_y
-										break
-									for(var/obj/item/I in C.loc)
-										I.forceMove(C)
-									for(var/obj/structure/S in C.loc)
-										if(!S.anchored)
-											S.forceMove(C)
-											large_cocoon = 1
-									for(var/obj/machinery/M in C.loc)
-										if(!M.anchored)
-											M.forceMove(C)
-											large_cocoon = 1
-									if(large_cocoon)
-										C.icon_state = pick("cocoon_large1","cocoon_large2","cocoon_large3")
-										C.health = initial(C.health)*2
-							busy = 0
-							stop_automated_movement = 0
-
-		else
-			busy = 0
+/mob/living/simple_animal/hostile/giant_spider/nurse/proc/lay_eggs()
+	var/obj/effect/spider/eggcluster/E = locate() in get_turf(src)
+	if(!E)
+		src.visible_message("<span class='notice'>\the [src] begins to lay a cluster of eggs.</span>")
+		stop_automated_movement = 1
+		spawn(50)
+			E = locate() in get_turf(src)
+			if(!E)
+				new /obj/effect/spider/eggcluster(src.loc)
+				fed--
 			stop_automated_movement = 0
+
+/mob/living/simple_animal/hostile/giant_spider/nurse/proc/spin_cocoon(var/atom/cocoon_target)
+	if(locate(/obj/effect/spider/cocoon) in cocoon_target.loc)
+		return
+	src.visible_message("<span class='notice'>\the [src] begins to secrete a sticky substance around \the [cocoon_target].</span>")
+	spawn(50)
+		if(cocoon_target && istype(cocoon_target.loc, /turf) && get_dist(src,cocoon_target) <= 1)
+			var/obj/effect/spider/cocoon/C = new(cocoon_target.loc)
+			var/large_cocoon = 0
+			C.pixel_x = cocoon_target.pixel_x
+			C.pixel_y = cocoon_target.pixel_y
+			for(var/mob/living/M in C.loc)
+				if(istype(M, /mob/living/simple_animal/hostile/giant_spider))
+					continue
+				large_cocoon = 1
+				if(M.getCloneLoss() < 125)
+					fed++
+					src.visible_message("<span class='warning'>\the [src] sticks a proboscis into \the [cocoon_target] and sucks a viscous substance out.</span>")
+					M.adjustCloneLoss(30 * size)
+				M.forceMove(C)
+				C.pixel_x = M.pixel_x
+				C.pixel_y = M.pixel_y
+				break
+			for(var/obj/item/I in C.loc)
+				I.forceMove(C)
+			for(var/obj/structure/S in C.loc)
+				if(!S.anchored)
+					S.forceMove(C)
+					large_cocoon = 1
+			for(var/obj/machinery/M in C.loc)
+				if(!M.anchored)
+					M.forceMove(C)
+					large_cocoon = 1
+			if(large_cocoon)
+				C.icon_state = pick("cocoon_large1","cocoon_large2","cocoon_large3")
+				C.health = initial(C.health)*2
+		stop_automated_movement = 0
+
 
 /mob/living/simple_animal/hostile/giant_spider/nurse/queen_spider
 	name = "spider queen"


### PR DESCRIPTION
Nurse spiders no longer abuse life() as much, now using the targeting function that all hostile animals use.

Removes redundant functions that are already in use via said targeting functions

Removes pretty damn dumb random GoTo that I suppose was supposed to emulate the spiders running somewhere? but would just supersede any space checks

This, in all, should mean that spiders no longer screw up doors in their own unique way.

It does not, however, stop them from just jumping out of the window

![ork trade post fourteen 2019-01-07 182450](https://user-images.githubusercontent.com/30557196/50786579-db550300-12ab-11e9-93d1-4396695a8ffb.png)

closes #21130
closes #21091 
closes #20698
closes #17410

:cl:
 * bugfix: Fixes spiders being a greasy pile of spaghetticode