### PR TITLE
Bloodcult sacrifice target can't be a cultist anymore

### DIFF
--- a/code/datums/gamemode/objectives/bloodcult.dm
+++ b/code/datums/gamemode/objectives/bloodcult.dm
@@ -79,6 +79,8 @@
 	for(var/mob/living/carbon/human/player in player_list)
 		if(player.z != map.zMainStation)//We only look for people currently aboard the station
 			continue
+		if (iscultist(player)) // Edit of 08/01/19 : no longer able to sacrifice cultists
+			continue
 		//They may be dead, but we only need their flesh
 		possible_targets += player
 


### PR DESCRIPTION
[tweak] [balance]

### Reasoning :

>Be cultist
>Advance to the sac objective, the most tense moment, not yet at my full power and having to take the most risks
>But still have a few lads with me and the ability to conjure constructs
>Truly it's time for a kinographique experience
>... expect that the sac target is just a cultist near me that will gladly become a memesword anyway

:cl:
- tweak: Bloodcult sacrifice target can no longer be a cultist.