### PR TITLE
Yet More Yet More blacksmithing tweaks tweaks

### DIFF
--- a/code/WorkInProgress/MadmanMartian/blacksmithing/blacksmithing.dm
+++ b/code/WorkInProgress/MadmanMartian/blacksmithing/blacksmithing.dm
@@ -83,14 +83,18 @@
 		return
 	if(user)
 		to_chat(user, "<span class = 'notice'>You heat \the [src].</span>")
-	if(user && !do_after(user, A, 4 SECONDS/(temperature/material_type.melt_temperature)))
+	if(iswelder(A) && user)
+		var/obj/item/weapon/weldingtool/W = A
+		if(!W.do_weld(user, src, 4 SECONDS/(temperature/material_type.melt_temperature), 5))
+			return
+	else if(user && !do_after(user, A, 4 SECONDS/(temperature/material_type.melt_temperature)))
 		return
 	malleable = TRUE
 	spawn(2 MINUTES)
 		malleable = FALSE
 
 
-/obj/item/smithing_placeholder/proc/strike(atom/A, mob/user)
+/obj/item/smithing_placeholder/proc/strike(var/obj/A, mob/user)
 	if(!malleable)
 		to_chat(user, "<span class = 'warning'>\The [src] has gone cool. It can not be manipulated in this state.</span>")
 		return
@@ -99,7 +103,7 @@
 		return
 	playsound(loc, 'sound/items/hammer_strike.ogg', 50, 1)
 	if(istype(A,/obj/item/weapon/hammer))
-		strikes++
+		strikes+=min(1,round(A.quality/2))
 	else if(istype(A,/obj/item/weapon/storage/toolbox))
 		strikes+=0.25
 	if(strikes == strikes_required)
@@ -108,10 +112,8 @@
 		if(prob(5*(strikes/strikes_required)))
 			to_chat(user, "<span class = 'warning'>\The [src] becomes brittle and unmalleable.</span>")
 			var/obj/item/weapon/ore/slag/S = new /obj/item/weapon/ore/slag(get_turf(src))
-			recycle(S.mats)
-			result.recycle(S.mats)
+			recycle(S.materials)
 			qdel(result)
-			qdel(src)
 
 
 /obj/item/smithing_placeholder/proc/quench(obj/O, mob/user)

--- a/code/WorkInProgress/MadmanMartian/blacksmithing/misc_components.dm
+++ b/code/WorkInProgress/MadmanMartian/blacksmithing/misc_components.dm
@@ -18,8 +18,10 @@
 			user.drop_item(I)
 			finishing_requirements.Remove(I.type)
 			gen_quality(quality-I.quality, quality, I.material_type)
+			if(!materials)
+				materials = getFromPool(/datum/materials, src)
+			I.recycle(materials)
 			qdel(I)
-
 			if(!finishing_requirements.len) //We're done
 				user.drop_item(src)
 				result = new result
@@ -27,6 +29,9 @@
 				if(mat)
 					result.dorfify(mat, 0, quality)
 				user.put_in_hands(result)
+				if(!result.materials)
+					result.materials = getFromPool(/datum/materials, result)
+				recycle(result.materials)
 				qdel(src)
 		return
 	..()


### PR DESCRIPTION
Material value is inherited all the way down, so you can recycle objects such as the slag that's produced when you mess up.

Welding tool now does its whole 'do weld' thing I added, that got ignored in other peoples PRs but there we go.

Hammer quality now helps, as each two stages of quality increases the amount of strikes you deal per hit.

:cl:
 * tweak: Recipe created items inherit the materials from their stack, so you can recycle them.
 * tweak: The higher the quality of your hammer, the more strikes it deals to a blacksmithing item
 * tweak: Welding tool now uses its associated helper when heating a blacksmithing item, so wear goggles