### PR TITLE
Adds composting with plants

### DIFF
--- a/code/modules/hydroponics/hydro_tray.dm
+++ b/code/modules/hydroponics/hydro_tray.dm
@@ -388,7 +388,7 @@
 		attack_hand(user)
 
 	else if(istype(O, /obj/item/weapon/reagent_containers/food/snacks/grown)) //composting
-		to_chat(user, "You use [O] as compost for [src].")
+		to_chat(user, "You use \the [O] as compost for \the [src].")
 		O.reagents.trans_to(src, O.reagents.total_volume, log_transfer = TRUE, whodunnit = user)
 		qdel(O)
 

--- a/code/modules/hydroponics/hydro_tray.dm
+++ b/code/modules/hydroponics/hydro_tray.dm
@@ -389,7 +389,7 @@
 
 	else if(istype(O, /obj/item/weapon/reagent_containers/food/snacks/grown)) //composting
 		to_chat(user, "You use [O] as compost for [src].")
-		W.reagents.trans_to(src, O.reagents.total_volume, log_transfer = TRUE, whodunnit = user)
+		O.reagents.trans_to(src, O.reagents.total_volume, log_transfer = TRUE, whodunnit = user)
 		qdel(O)
 
 	else

--- a/code/modules/hydroponics/hydro_tray.dm
+++ b/code/modules/hydroponics/hydro_tray.dm
@@ -387,11 +387,6 @@
 	else if((O.sharpness_flags & (SHARP_BLADE|SERRATED_BLADE)) && harvest)
 		attack_hand(user)
 
-	else if(istype(O, /obj/item/weapon/reagent_containers/food/snacks/grown)) //composting
-		to_chat(user, "You use [O] as compost for [src].")
-		O.reagents.trans_to(src, O.reagents.total_volume, log_transfer = TRUE, whodunnit = user)
-		qdel(O)
-
 	else
 		return ..()
 

--- a/code/modules/hydroponics/hydro_tray.dm
+++ b/code/modules/hydroponics/hydro_tray.dm
@@ -387,6 +387,11 @@
 	else if((O.sharpness_flags & (SHARP_BLADE|SERRATED_BLADE)) && harvest)
 		attack_hand(user)
 
+	else if(istype(O, /obj/item/weapon/reagent_containers/food/snacks/grown)) //composting
+		to_chat(user, "You use [O] as compost for [src].")
+		O.reagents.trans_to(src, O.reagents.total_volume, log_transfer = TRUE, whodunnit = user)
+		qdel(O)
+
 	else
 		return ..()
 

--- a/code/modules/hydroponics/hydro_tray.dm
+++ b/code/modules/hydroponics/hydro_tray.dm
@@ -387,6 +387,11 @@
 	else if((O.sharpness_flags & (SHARP_BLADE|SERRATED_BLADE)) && harvest)
 		attack_hand(user)
 
+	else if(istype(O, /obj/item/weapon/reagent_containers/food/snacks/grown)) //composting
+		to_chat(user, "You use [O] as compost for [src].")
+		W.reagents.trans_to(src, O.reagents.total_volume, log_transfer = TRUE, whodunnit = user)
+		qdel(O)
+
 	else
 		return ..()
 

--- a/code/modules/hydroponics/soil.dm
+++ b/code/modules/hydroponics/soil.dm
@@ -18,6 +18,12 @@
 			return 1
 		else
 			..()
+
+	else if(istype(W, /obj/item/weapon/reagent_containers/food/snacks/grown)) //composting
+		to_chat(user, "You use [W] as compost for [src].")
+		W.reagents.trans_to(src, W.reagents.total_volume, log_transfer = TRUE, whodunnit = user)
+		qdel(W)
+
 	else
 		return ..()
 

--- a/code/modules/hydroponics/soil.dm
+++ b/code/modules/hydroponics/soil.dm
@@ -18,12 +18,6 @@
 			return 1
 		else
 			..()
-
-	else if(istype(W, /obj/item/weapon/reagent_containers/food/snacks/grown)) //composting
-		to_chat(user, "You use [W] as compost for [src].")
-		W.reagents.trans_to(src, W.reagents.total_volume, log_transfer = TRUE, whodunnit = user)
-		qdel(W)
-
 	else
 		return ..()
 


### PR DESCRIPTION
You can now compost plant produce by using them on a tray. Composting transfers all reagents from the produce into the tray and deletes the produce.

[qol]

:cl:
 * rscadd: Plant produce can now be used as compost in trays