### PR TITLE
Eimplants didn't go off if you died without succumbing

### DIFF
--- a/code/modules/mob/living/carbon/human/life/handle_regular_status_updates.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_regular_status_updates.dm
@@ -16,6 +16,7 @@
 			handle_blood()
 
 		if(health <= config.health_threshold_dead || !has_brain())
+			emote("deathgasp", message = TRUE)
 			death()
 			blinded = 1
 			silent = 0


### PR DESCRIPTION
What I did test when I made the whisper thingy : 
- Whisper 
- Emoting *deathgasp

What I didn't : 
- Dying normally

:cl:
- bugfix: E-implants will explode again if you die without manually typing *deathgasp.