### PR TITLE
Fixes seedify helper proc dropping items

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1707,9 +1707,6 @@ Game Mode config tags:
 
 	var/produce = rand(min_seeds,max_seeds)
 
-	if(user)
-		user.drop_item(O, force_drop = TRUE)
-
 	if(istype(O, /obj/item/weapon/grown))
 		var/obj/item/weapon/grown/F = O
 		if(F.plantname)
@@ -1725,8 +1722,6 @@ Game Mode config tags:
 				while(min_seeds <= produce)
 					new F.nonplant_seed_type(seedloc)
 					min_seeds++
-				if(user)
-					user.drop_item(F, force_drop = TRUE)
 				qdel(F)
 				return TRUE
 
@@ -1739,8 +1734,6 @@ Game Mode config tags:
 	else
 		return FALSE
 
-	if(user)
-		user.drop_item(O, force_drop = TRUE)
 	qdel(O)
 	return TRUE
 


### PR DESCRIPTION
[bugfix]

`seedify` helper proc no longer drops items before `qdel`. Item dropping is already handled in `item/Destroy`

This fixes seed extractor dropping items such as tools when they are used on it.