### PR TITLE
fixes a few instances of showing antag on key_name() where it shouldn't

### DIFF
--- a/code/ZAS/NewSettings.dm
+++ b/code/ZAS/NewSettings.dm
@@ -313,7 +313,7 @@ var/global/ZAS_Settings/zas_settings = new
 		else
 			error("[id] has an invalid typeval.")
 			return
-	to_chat(world, "<span class='notice'><b>[key_name(user)] changed ZAS setting <i>[setting.name]</i> to <i>[displayedValue]</i>.</b></span>")
+	to_chat(world, "<span class='notice'><b>[key_name(user, showantag = FALSE)] changed ZAS setting <i>[setting.name]</i> to <i>[displayedValue]</i>.</b></span>")
 
 	ChangeSettingsDialog(user)
 
@@ -512,4 +512,4 @@ a { color: white; }
 			Set("/datum/ZAS_Setting/airflow_speed_decay",       1)
 			Set("/datum/ZAS_Setting/airflow_delay",             20)
 			Set("/datum/ZAS_Setting/airflow_mob_slowdown",      3)
-	to_chat(world, "<span class='notice'><b>[key_name(usr)] loaded ZAS preset <i>[def]</i></b></span>")
+	to_chat(world, "<span class='notice'><b>[key_name(usr, showantag = FALSE)] loaded ZAS preset <i>[def]</i></b></span>")

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -468,7 +468,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 	var/M = E/(SPEED_OF_LIGHT_SQ)
 	return M
 
-/proc/key_name(var/whom, var/include_link = null, var/include_name = TRUE, var/more_info = FALSE)
+/proc/key_name(var/whom, var/include_link = null, var/include_name = TRUE, var/more_info = FALSE, var/showantag = TRUE)
 	var/mob/M
 	var/client/C
 	var/key
@@ -519,7 +519,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 		else if(M.name)
 			. += "/([M.name])"
 
-	if(M && isanyantag(M))
+	if(showantag && M && isanyantag(M))
 		. += " <span title='[english_list(M.mind.antag_roles)]'>(A)</span>"
 
 	if(more_info && M)

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1971,7 +1971,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 									message_admins("[key_name_admin(U)] just attempted to blow up [P] with the Detomatix cartridge but failed, blowing themselves up", 1)
 								else
 									U.show_message("<span class='notice'>Success!</span>", 1)
-									log_admin("[key_name(U)] just attempted to blow up [P] with the Detomatix cartridge and succeded")
+									log_admin("[key_name(U)] just attempted to blow up [P] with the Detomatix cartridge and succeeded")
 									message_admins("[key_name_admin(U)] just attempted to blow up [P] with the Detomatix cartridge and succeded", 1)
 									P.explode()
 				else

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -60,7 +60,7 @@
 
 	//get message text, limit it's length.and clean/escape html
 	if(!msg)
-		msg = input(src, "Message:", "Private message to [key_name(C, 0, 0)]", "") as text | null
+		msg = input(src, "Message:", "Private message to [key_name(C, 0, 0, showantag = FALSE)]", "") as text | null
 
 		if(!msg)
 			return

--- a/code/modules/mob/logout.dm
+++ b/code/modules/mob/logout.dm
@@ -31,8 +31,8 @@
 
 			message_admins("Admin logout: [key_name(src)]")
 			if(available_admins == 0) // Apparently the admin logging out is no longer an admin at this point, so we have to check this towards 0 and not towards 1. Awell.
-				send2adminirc("[key_name(src)] logged out - no more admins online.")
-				send2admindiscord("[key_name(src)] logged out. **No more non-AFK admins online.** - **[admin_number_afk]** AFK", TRUE)
+				send2adminirc("[key_name(src, showantag = FALSE)] logged out - no more admins online.")
+				send2admindiscord("[key_name(src, showantag = FALSE)] logged out. **No more non-AFK admins online.** - **[admin_number_afk]** AFK", TRUE)
 
 	INVOKE_EVENT(on_logout, list())
 


### PR DESCRIPTION
fixes this:
![1](https://user-images.githubusercontent.com/4043940/51140366-341c2280-17fb-11e9-8f20-a368fd050e61.png)

doesn't change this:
![2](https://user-images.githubusercontent.com/4043940/51140373-38484000-17fb-11e9-8bd4-9de225e45615.png)