### PR TITLE
Gives Unathi claws

### DIFF
--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -331,7 +331,7 @@ var/global/list/whitelisted_species = list("Human")
 	known_languages = list(LANGUAGE_UNATHI)
 	tail = "sogtail"
 	attack_verb = "scratches"
-	punch_damage = 5
+	punch_damage = 2
 	primitive = /mob/living/carbon/monkey/unathi
 	darksight = 3
 
@@ -345,6 +345,8 @@ var/global/list/whitelisted_species = list("Human")
 
 	flags = IS_WHITELISTED
 	anatomy_flags = HAS_LIPS | HAS_UNDERWEAR | HAS_TAIL
+
+	default_mutations=list(M_CLAWS)
 
 	flesh_color = "#34AF10"
 


### PR DESCRIPTION
Because they didn't have them before, for some reason. Adjusts their punch_damage, too, because having claws is +3 anyway. _Muh consistency._

[consistency]
:cl:
 * bugfix: Unathi (lizards) now actually have claws for use in butchering and other horrible things.