### PR TITLE
links autoborger to summoner

### DIFF
--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -138,6 +138,9 @@ rcd light flash thingy on matter drain
 	summon_type = list(/obj/machinery/transformer/conveyor)
 	hud_state = "autoborger"
 	override_base = "grey"
+	
+/spell/aoe_turf/conjure/place_transformer/New()
+	..()
 
 /spell/aoe_turf/conjure/place_transformer/before_target(mob/user)
 	var/mob/living/silicon/ai/A = user
@@ -168,6 +171,7 @@ rcd light flash thingy on matter drain
 	if(!C.visibleTurfs[middle])
 		alert(holder, "We cannot get camera vision of this location.")
 		return 0
+	newVars = list("belongstomalf" = holder)
 	return 1
 
 /spell/aoe_turf/conjure/place_transformer/cast(var/list/targets,mob/user)
@@ -177,7 +181,7 @@ rcd light flash thingy on matter drain
 	var/mob/living/silicon/ai/A = user
 	A.can_shunt = 0
 	to_chat(user, "You cannot shunt anymore.")
-
+	
 /datum/AI_Module/large/highrescams
 	module_name = "High Resolution Cameras"
 	mod_pick_name = "High Res Cameras"

--- a/code/game/machinery/transformer.dm
+++ b/code/game/machinery/transformer.dm
@@ -23,6 +23,7 @@
 	var/force_borg_module=null
 	var/name_type=NAMETYPE_NORMAL
 	var/enable_namepick=TRUE
+	var/belongstomalf=null //malf AI that owns autoborger
 
 /obj/machinery/transformer/New()
 	// On us
@@ -82,7 +83,7 @@
 
 	// Delete the items or they'll all pile up in a single tile and lag
 	// skipnaming disables namepick on New(). It's annoying as fuck on malf.  Later on, we enable or disable namepick.
-	var/mob/living/silicon/robot/R = H.Robotize(1, skipnaming=TRUE)
+	var/mob/living/silicon/robot/R = H.Robotize(1, skipnaming=TRUE, malfAI=belongstomalf)
 	if(R)
 		R.cell.maxcharge = robot_cell_charge
 		R.cell.charge = robot_cell_charge

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -102,7 +102,7 @@
 	var/last_tase_timeofday
 	var/last_high_damage_taken_timeofday
 
-/mob/living/silicon/robot/New(loc, var/unfinished = FALSE)
+/mob/living/silicon/robot/New(loc, var/malfAI = null)
 	ident = rand(1, 999)
 	updatename(modtype)
 
@@ -114,7 +114,10 @@
 	aicamera = new/obj/item/device/camera/silicon/robot_camera(src)
 
 	if(AIlink)
-		connected_ai = select_active_ai_with_fewest_borgs()
+		if(malfAI)
+			connected_ai = malfAI
+		else
+			connected_ai = select_active_ai_with_fewest_borgs()
 
 	if(connected_ai)
 		connected_ai.connected_robots += src

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -145,10 +145,10 @@
 	if(del_mob)
 		qdel(src)
 
-/mob/proc/Robotize(var/delete_items = FALSE, var/skipnaming=FALSE)
+/mob/proc/Robotize(var/delete_items = FALSE, var/skipnaming=FALSE, var/malfAI=null)
 	if(!Premorph(delete_items))
 		return
-	var/mob/living/silicon/robot/O = new /mob/living/silicon/robot(get_turf(src))
+	var/mob/living/silicon/robot/O = new /mob/living/silicon/robot(get_turf(src), malfAI)
 	. = O
 	if(mind)		//TODO
 		mind.transfer_to(O)


### PR DESCRIPTION
This links the autoborger to whatever AI summoned it, causing all borgs created by that autoborger to be slaved to aforementioned AI
fixes #19776
![tested](https://user-images.githubusercontent.com/8468269/51220221-a04e7180-1934-11e9-9f76-708beebc7dd3.png)

🆑 
 - bugfix: Malf-spawned autoborgers will now slave its borgs to the malf that spawned the borger