### PR TITLE
Scorescreen once again lists purchases (SBO32)

### DIFF
--- a/code/datums/gamemode/role/role.dm
+++ b/code/datums/gamemode/role/role.dm
@@ -667,10 +667,33 @@
 		if (S.user_type == USER_TYPE_WIZARD && !(S.spell_flags & LOSE_IN_TRANSFER))
 			new_character.add_spell(S)
 
+/datum/role/wizard/GetScoreboard()
+	. = ..()
+	if(disallow_job) //Not a survivor wizzie
+		var/mob/living/carbon/human/H = antag.current
+		var/bought_nothing = TRUE
+		if(H.spell_list)
+			bought_nothing = FALSE
+			. += "<BR>The wizard knew:<BR>"
+			for(var/spell/S in H.spell_list)
+				var/icon/tempimage = icon('icons/mob/screen_spells.dmi', S.hud_state)
+				end_icons += tempimage
+				var/tempstate = end_icons.len
+				. += "<img src='logo_[tempstate].png'> [S.name]<BR>"
+		if(H.mind.artifacts_bought)
+			bought_nothing = FALSE
+			. += "<BR>Additionally, the wizard brought:<BR>"
+			for(var/entry in H.mind.artifacts_bought)
+				. += "[entry]<BR>"
+		if(bought_nothing)
+			. += "The wizard used only the magic of charisma this round."
+
 /datum/role/wizard/summon_magic
 	disallow_job = FALSE
+	name = MAGICIAN
 	id = MAGICIAN
 	logo_state = "magik-logo"
+	var/summons_received
 
 /datum/role/wizard/summon_magic/ForgeObjectives()
 	var/datum/objective/survive/S = new
@@ -681,6 +704,11 @@
 
 /datum/role/wizard/summon_magic/OnPostSetup()
 	return TRUE
+
+/datum/role/wizard/summon_magic/GetScoreboard()
+	. = ..()
+	. += "The [name] received the following as a result of a summoning spell: [summons_received]"
+
 //________________________________________________
 
 /datum/role/wish_granter_avatar

--- a/code/datums/gamemode/role/syndicate.dm
+++ b/code/datums/gamemode/role/syndicate.dm
@@ -4,7 +4,7 @@
 	required_pref = ROLE_TRAITOR
 	logo_state = "synd-logo"
 	wikiroute = ROLE_TRAITOR
-
+	var/can_be_smooth = TRUE //Survivors can't be smooth because they get nothing.
 
 /datum/role/traitor/OnPostSetup()
 	..()
@@ -108,6 +108,17 @@
 
 	to_chat(antag.current, "<span class='info'><a HREF='?src=\ref[antag.current];getwiki=[wikiroute]'>(Wiki Guide)</a></span>")
 
+/datum/role/traitor/GetScoreboard()
+	. = ..()
+	if(can_be_smooth)
+		var/mob/living/L = antag.current
+		if(L.mind.uplink_items_bought.len)
+			. += "The traitor bought:<BR>"
+			for(var/entry in L.mind.uplink_items_bought)
+				. += "[entry]<BR>"
+		else
+			. += "The traitor was a smooth operator this round."
+
 //_______________________________________________
 
 /*
@@ -118,7 +129,9 @@
 	id = SURVIVOR
 	name = SURVIVOR
 	logo_state = "gun-logo"
+	can_be_smooth = FALSE
 	var/survivor_type = "survivor"
+	var/summons_received
 
 /datum/role/traitor/survivor/crusader
 	id = CRUSADER
@@ -135,6 +148,11 @@
 
 /datum/role/traitor/survivor/OnPostSetup()
 	return TRUE
+
+/datum/role/traitor/survivor/GetScoreboard()
+	. = ..()
+	. += "The [name] received the following as a result of a summoning spell: [summons_received]"
+
 //________________________________________________
 
 

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -60,6 +60,7 @@
 		//put this here for easier tracking ingame
 	var/datum/money_account/initial_account
 	var/list/uplink_items_bought = list()
+	var/list/artifacts_bought = list()
 	var/total_TC = 0
 	var/spent_TC = 0
 
@@ -96,7 +97,7 @@
 	var/mob/old_character = current
 	current = new_character		//link ourself to our new body
 	new_character.mind = src	//and link our new body to ourself
-	
+
 	for (var/role in antag_roles)
 		var/datum/role/R = antag_roles[role]
 		R.PostMindTransfer(new_character, old_character)

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -111,7 +111,7 @@ var/list/uplink_items = list()
 			stat_collection.uplink_purchase(src, I, user)
 			times_bought += 1
 			if(user.mind)
-				user.mind.uplink_items_bought += {"<img src="logo_[tempstate].png"> [bundlename]"}
+				user.mind.uplink_items_bought += {"<img src="logo_[tempstate].png"> [bundlename] for [get_cost(U.job)] TC<BR>"}
 				user.mind.spent_TC += get_cost(U.job)
 		U.interact(user)
 

--- a/code/game/gamemodes/wizard/artifacts.dm
+++ b/code/game/gamemodes/wizard/artifacts.dm
@@ -9,8 +9,13 @@
 
 /datum/spellbook_artifact/proc/purchased(mob/living/user)
 	to_chat(user, "<span class='info'>You have purchased [name].</span>")
-	for(var/T in spawned_items)
-		new T(get_turf(user))
+	for(var/path in spawned_items)
+		var/obj/item/I = new path(get_turf(user))
+		if(user.mind)
+			var/icon/tempimage = icon(I.icon, I.icon_state)
+			end_icons += tempimage
+			var/tempstate = end_icons.len
+			user.mind.artifacts_bought += {"<img src="logo_[tempstate].png"> [name]<BR>"}
 
 /datum/spellbook_artifact/proc/can_buy(var/mob/user)
 	return TRUE

--- a/code/game/gamemodes/wizard/rightandwrong.dm
+++ b/code/game/gamemodes/wizard/rightandwrong.dm
@@ -37,9 +37,9 @@
 /mob/living/carbon/human/proc/equip_survivor(var/datum/role/R)
 	var/summon_type = R.type
 	switch (summon_type)
-		if ("swords")
+		if (/datum/role/traitor/survivor/crusader)
 			return equip_swords(R)
-		if ("magic")
+		if (/datum/role/wizard/summon_magic)
 			return equip_magician(R)
 		else
 			return equip_guns(R)

--- a/code/game/gamemodes/wizard/rightandwrong.dm
+++ b/code/game/gamemodes/wizard/rightandwrong.dm
@@ -16,13 +16,14 @@
 			survivor_type = /datum/role/traitor/survivor/
 
 	for(var/mob/living/carbon/human/H in player_list)
-		H.equip_survivor(summon_type)
+
 		if (prob(65) || iswizard(H))
 			continue
 		if(H.stat == DEAD || !(H.client))
 			continue
 
 		var/datum/role/R = new survivor_type()
+		H.equip_survivor(R)
 
 		if (!(isrole(R.id, H)))
 			R.AssignToRole(H.mind)
@@ -33,16 +34,17 @@
 
 
 
-/mob/living/carbon/human/proc/equip_survivor(var/summon_type)
+/mob/living/carbon/human/proc/equip_survivor(var/datum/role/R)
+	var/summon_type = R.type
 	switch (summon_type)
 		if ("swords")
-			return equip_swords()
+			return equip_swords(R)
 		if ("magic")
-			return equip_magician()
+			return equip_magician(R)
 		else
-			return equip_guns()
+			return equip_guns(R)
 
-/mob/living/carbon/human/proc/equip_guns()
+/mob/living/carbon/human/proc/equip_guns(var/datum/role/R)
 	var/randomizeguns = pick("taser","stunrevolver","egun","laser","retro","laserak","revolver","detective","c20r","nuclear","deagle","gyrojet","pulse","silenced","cannon","doublebarrel","shotgun","combatshotgun","mateba","smg","uzi","microuzi","crossbow","saw","hecate","osipr","gatling","bison","ricochet","spur","nagant","obrez","beegun","beretta","usp","glock","luger","colt","plasmapistol","plasmarifle", "ion", "bulletstorm", "combustioncannon", "laserpistol", "siren", "lawgiver", "nt12", "automag")
 	switch (randomizeguns)
 		if("taser")
@@ -145,10 +147,13 @@
 			new /obj/item/weapon/gun/projectile/shotgun/nt12(get_turf(src))
 		if ("automag")
 			new /obj/item/weapon/gun/projectile/automag/prestige(get_turf(src))
+	var/datum/role/traitor/survivor/S = R
+	if(S)
+		S.summons_received = randomizeguns
 	playsound(src,'sound/effects/summon_guns.ogg', 50, 1)
 	score["gunsspawned"]++
 
-/mob/living/carbon/human/proc/equip_swords()
+/mob/living/carbon/human/proc/equip_swords(var/datum/role/R)
 	var/randomizeswords = pick("unlucky", "misc", "throw", "armblade", "pickaxe", "pcutter", "esword", "alt-esword", "machete", "kitchen", "medieval", "katana", "axe", "boot", "saw", "scalpel", "switchtool", "shitcurity")
 	var/randomizeknightcolor = pick("green", "yellow", "blue", "red", "templar", "roman")
 	switch (randomizeknightcolor) //everyone gets some armor as well
@@ -283,9 +288,12 @@
 		if("shitcurity") //Might as well give the Redtide a taste of their own medicine.
 			var/shitcurity = pick(/obj/item/weapon/melee/telebaton, /obj/item/weapon/melee/classic_baton, /obj/item/weapon/melee/baton/loaded/New, /obj/item/weapon/melee/baton/cattleprod,/obj/item/weapon/melee/chainofcommand)
 			new shitcurity(get_turf(src))
+	var/datum/role/traitor/survivor/crusader/S = R
+	if(S)
+		S.summons_received = randomizeswords
 	playsound(src,'sound/items/zippo_open.ogg', 50, 1)
 
-/mob/living/carbon/human/proc/equip_magician()
+/mob/living/carbon/human/proc/equip_magician(var/datum/role/R)
 	var/randomizemagic = pick("fireball","smoke","blind","mindswap","forcewall","knock","horsemask","blink","disorient","clowncurse", "mimecurse", "shoesnatch","emp", "magicmissile", "mutate", "teleport", "jaunt", "buttbot", "lightning", "timestop", "ringoffire", "painmirror", "bound_object", "firebreath", "snakes", "push", "pie")
 	var/randomizemagecolor = pick("magician", "magusred", "magusblue", "blue", "red", "necromancer", "clown", "purple", "lich", "skelelich", "marisa", "fake")
 	switch (randomizemagecolor) //everyone can put on their robes and their wizard hat
@@ -394,3 +402,6 @@
 			new /obj/item/weapon/spellbook/oneuse/push(get_turf(src))
 		if("pie")
 			new /obj/item/weapon/spellbook/oneuse/pie(get_turf(src))
+	var/datum/role/wizard/summon_magic/S = R
+	if(S)
+		S.summons_received = randomizemagic


### PR DESCRIPTION
fixes #21120 

🆑 
* rscadd: Traitors and wizards will now once again list their purchases on the score screen.
* rscadd: Survivors now also get a listing of what was summoned for them.