### PR TITLE
Aghost Airlocks Made Silky Smooth (SBO35)

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -102,23 +102,8 @@
 /atom/proc/AIShiftClick()
 	return
 
-/obj/machinery/door/airlock/AIShiftClick()  // Opens and closes doors!
-	if(allowed(usr))
-		if(density)
-			Topic("aiEnable=7", list("aiEnable"="7"), 1)
-		else
-			Topic("aiDisable=7", list("aiDisable"="7"), 1)
-
-
 /atom/proc/AICtrlClick()
 	return
-
-/obj/machinery/door/airlock/AICtrlClick() // Bolts doors
-	if(allowed(usr))
-		if(locked)
-			Topic("aiEnable=4", list("aiEnable"="4"), 1)
-		else
-			Topic("aiDisable=4", list("aiDisable"="4"), 1)
 
 /obj/machinery/power/apc/AICtrlClick() // turns off APCs.
 	if(allowed(usr))
@@ -128,15 +113,6 @@
 /atom/proc/AIAltClick(var/mob/living/silicon/ai/user)
 	AltClick(user)
 	return
-
-/obj/machinery/door/airlock/AIAltClick() // Eletrifies doors.
-	if(allowed(usr))
-		if(!secondsElectrified)
-			// permenant shock
-			Topic("aiEnable=6", list("aiEnable"="6"), 1) // 1 meaning no window (consistency!)
-		else
-			// disable/6 is not in Topic; disable/5 disables both temporary and permenant shock
-			Topic("aiDisable=5", list("aiDisable"="5"), 1)
 
 /obj/machinery/door/firedoor/AIShiftClick(var/mob/living/silicon/ai/user) // Allows examining firelocks
 	examine(user)

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -145,20 +145,6 @@
 	A.RobotAltClick(src)
 	return
 
-/mob/living/silicon/robot/ShiftClickOn(var/atom/A)
-	//Borgs can into doors as well
-	if(istype(A, /obj/machinery/door/airlock))
-		A.AIShiftClick(src)
-		return
-	..()
-
-/mob/living/silicon/robot/CtrlClickOn(var/atom/A)
-	//Borgs can into doors as well
-	if(istype(A, /obj/machinery/door/airlock))
-		A.AICtrlClick(src)
-		return
-	..()
-
 /*
 	As with AI, these are not used in click code,
 	because the code for robots is specific, not generic.

--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -67,6 +67,9 @@
 
 // We don't need a fucking toggle.
 /mob/dead/observer/ShiftClickOn(var/atom/A)
+	if(isAdminGhost(src))
+		A.ShiftClick(src)
+		return
 	examination(A)
 
 /atom/proc/attack_ghost(mob/user as mob)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -643,6 +643,42 @@ About the new airlock wires panel:
 //aiEnable - 1 idscan, 4 raise door bolts, 5 electrify door for 30 seconds, 6 electrify door indefinitely, 7 open door
 
 
+//Migrated from onclick
+/obj/machinery/door/airlock/AIAltClick() // Eletrifies doors.
+	if(allowed(usr))
+		if(!secondsElectrified)
+			// permenant shock
+			Topic("aiEnable=6", list("aiEnable"="6"), 1) // 1 meaning no window (consistency!)
+		else
+			// disable/6 is not in Topic; disable/5 disables both temporary and permenant shock
+			Topic("aiDisable=5", list("aiDisable"="5"), 1)
+
+/obj/machinery/door/airlock/AICtrlClick() // Bolts doors
+	if(allowed(usr))
+		if(locked)
+			Topic("aiEnable=4", list("aiEnable"="4"), 1)
+		else
+			Topic("aiDisable=4", list("aiDisable"="4"), 1)
+
+/obj/machinery/door/airlock/AIShiftClick()  // Opens and closes doors!
+	if(allowed(usr))
+		if(density)
+			Topic("aiEnable=7", list("aiEnable"="7"), 1)
+		else
+			Topic("aiDisable=7", list("aiDisable"="7"), 1)
+
+/obj/machinery/door/airlock/CtrlClick(mob/user)
+	if(isrobot(user) || isAdminGhost(user))
+		AICtrlClick()
+	else
+		..()
+
+/obj/machinery/door/airlock/ShiftClick(mob/user)
+	if(isrobot(user) || isAdminGhost(user))
+		AIShiftClick()
+	else
+		..()
+
 /obj/machinery/door/airlock/proc/attempt_hack(mob/user)
 	if (!isAI(user))
 		return FALSE

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1011,9 +1011,7 @@ About the new airlock wires panel:
 
 	add_fingerprint(usr)
 	update_icon()
-	if(!nowindow)
-		updateUsrDialog()
-	return
+	updateUsrDialog()
 
 /obj/machinery/door/airlock/multitool_menu(var/mob/user,var/obj/item/device/multitool/P)
 	var/dat=""
@@ -1032,6 +1030,9 @@ About the new airlock wires panel:
 	return dat
 
 /obj/machinery/door/airlock/attack_hand(mob/user as mob)
+	if(isAdminGhost(user))
+		attack_ai(user)
+		return
 	if (!istype(user, /mob/living/silicon) && !isobserver(user) && Adjacent(user))
 		if (isElectrified())
 			// TODO: analyze the called proc
@@ -1040,11 +1041,6 @@ About the new airlock wires panel:
 	//Basically no open panel, not opening already, door has power, area has power, door isn't bolted
 	if (!panel_open && !operating && arePowerSystemsOn() && !(stat & (NOPOWER|BROKEN)) && !locked)
 		..(user)
-	//else
-	//	// TODO: logic for adding fingerprints when interacting with wires
-	//	wires.Interact(user)
-
-	return
 
 /obj/machinery/door/airlock/attack_alien(mob/living/carbon/alien/humanoid/user)
 	if(isElectrified())

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -136,7 +136,7 @@ var/list/all_doors = list()
 			return
 
 
-	if(isobserver(user) && !isAdminGhost(user))
+	if(isobserver(user)) //Adminghosts don't want to toggle the door open, they want to see the AI interface
 		return
 
 	add_fingerprint(user)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -271,7 +271,7 @@ var/global/list/reagents_to_log = list(FUEL, PLASMA, PACID, SACID, AMUTATIONTOXI
 					continue
 
 				// AIs/Robots can do shit from afar.
-				if (isAI(M) || isrobot(M))
+				if (isAI(M) || isrobot(M) || isAdminGhost(M))
 					is_in_use = 1
 					src.attack_ai(M)
 


### PR DESCRIPTION
fixes #21173

No changelog since it's backend

Airlock topic will now
* Update for aghost even if they are not adjacent
* Not try to toggle the door open/closed regardless of the command sent (e.g.: a door will not try to close after being opened, will not automatically open after being unbolted, etc.)