### PR TITLE
Adds pre-warning to immovable rod event

### DIFF
--- a/code/datums/helper_datums/command_alerts.dm
+++ b/code/datums/helper_datums/command_alerts.dm
@@ -465,7 +465,7 @@ The access requirements on the Asteroid Shuttles' consoles have now been revoked
 /datum/command_alert/immovable_rod
 	name = "Immovable Rod (\"What The Fuck Was That?\")"
 	alert_title = "Local Bluespace Sensor Report"
-	message = "Alert: An anomalous object with extremely high relative velocity is on a collision course with this station. Heavy structural damage may result."
+	message = "Alert: The station appears to be on a collision course with an anomalous object perfectly suspended in space. Heavy structural damage may result."
 
 /datum/command_alert/rogue_drone
 	name = "Rogue Drones - Alert"

--- a/code/datums/helper_datums/command_alerts.dm
+++ b/code/datums/helper_datums/command_alerts.dm
@@ -464,8 +464,8 @@ The access requirements on the Asteroid Shuttles' consoles have now been revoked
 
 /datum/command_alert/immovable_rod
 	name = "Immovable Rod (\"What The Fuck Was That?\")"
-	alert_title = "General Alert"
-	message = "What the fuck was that?!"
+	alert_title = "Local Bluespace Sensor Report"
+	message = "Alert: An anomalous object with extremely high relative velocity is on a collision course with this station. Heavy structural damage may result."
 
 /datum/command_alert/rogue_drone
 	name = "Rogue Drones - Alert"

--- a/code/modules/events/immovablerod.dm
+++ b/code/modules/events/immovablerod.dm
@@ -5,7 +5,7 @@
 //Recoded as a projectile for better movement/appearance
 
 /datum/event/immovable_rod
-	announceWhen = 100
+	announceWhen = 1
 
 /datum/event/immovable_rod/announce()
 	command_alert(/datum/command_alert/immovable_rod)


### PR DESCRIPTION
Adds a pre-warning message to the immovable rod random event, alerting the crew a few seconds before disaster. The message has also changed.

:cl:
 * rscadd: Adds pre-warning to immovable rod random events with a new message reflecting the nature of the event.