### PR TITLE
Adds *dab. (For real this time)

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -208,3 +208,36 @@
 						explosion(get_turf(H),-1,-1,1,5) //Tiny explosion with flash
 						H.dust()
 //Ayy lmao
+
+
+/datum/emote/living/carbon/human/dab
+	key = "dab"
+	key_third_person = "*dab"
+
+/datum/emote/living/carbon/human/dab/can_run_emote(mob/user)
+	var/mob/living/carbon/human/H = user
+	if(H.has_organ(LIMB_LEFT_ARM) && H.has_organ(LIMB_RIGHT_ARM))
+		return TRUE
+
+/datum/emote/living/carbon/human/dab/run_emote(mob/user)
+	var/mob/living/carbon/human/H = user
+	if(world.time-H.lastDab >= 10 SECONDS)
+		for(var/mob/living/M in view(0))
+			if(M != H && M.loc == H.loc)
+				H.visible_message("<span class = 'warning'><b>[H]</b> dabs on <b>[M]</b>!</span>")
+		message = "<b>[H]</b> dabs."
+		emote_type = EMOTE_VISIBLE
+		H.visible_message(message)
+		H.lastDab=world.time
+	else
+		var/armtobreak = pick(LIMB_LEFT_ARM, LIMB_RIGHT_ARM)
+		var/datum/organ/external/A = H.get_organ(armtobreak)
+		if(H.species.anatomy_flags & NO_BONES)
+			message = "<span class = 'warning'>smacks their head as they flail their arms to the side.</span>"
+			playsound(H, 'sound/weapons/punch1.ogg', 50, 1)
+		else
+			message = "<span class = 'warning'>dabs too hard!</span>"
+			H.apply_damage(50, BRUTE, A)
+			A.fracture()
+		emote_type = EMOTE_VISIBLE
+		. = ..()

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -235,6 +235,8 @@
 		if(H.species.anatomy_flags & NO_BONES)
 			message = "<span class = 'warning'>smacks their head as they flail their arms to the side.</span>"
 			playsound(H, 'sound/weapons/punch1.ogg', 50, 1)
+			A = H.get_organ(LIMB_HEAD)
+			H.apply_damage(50, BRUTE, A)
 		else
 			message = "<span class = 'warning'>dabs too hard!</span>"
 			H.apply_damage(50, BRUTE, A)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1753,6 +1753,7 @@ mob/living/carbon/human/isincrit()
 		"meatleft",
 		"check_mutations",
 		"lastFart",
+		"lastDab",
 		"last_shush",
 		"last_emote_sound",
 		"decapitated",

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -79,6 +79,7 @@
 
 	var/last_shush = 0 // disarm intent shushing cooldown
 	var/lastFart = 0 // Toxic fart cooldown.
+	var/lastDab = 0 //Dab cooldown.
 	var/last_emote_sound = 0 // Prevent scream spam in some situations
 
 	var/obj/item/organ/external/head/decapitated = null //to keep track of a decapitated head, for debug and soulstone purposes
@@ -91,4 +92,4 @@
 
 	var/become_zombie_after_death = FALSE
 	var/times_cloned = 0 //How many times this person has been cloned
-	var/talkcount = 0 // How many times a person has talked - used for determining who's been the "star" for the purposes of round end credits 
+	var/talkcount = 0 // How many times a person has talked - used for determining who's been the "star" for the purposes of round end credits


### PR DESCRIPTION
[qol][gameplay]
![memed-io-output](https://user-images.githubusercontent.com/28679186/51432173-4fbf6880-1c01-11e9-96d4-f77ab3ce3f21.png)
Back by popular demand after being suppressed by the c*der metaclub in #19843
Some notable changes since the first one.
- Dabbing no longer allows you to un-cuff yourself via bone breaking since that issue was fixed.
- You dab even harder now and it will kill you in two failed dabs. (50 brute now)
- The failed dab emote message is now short and to the point.

:cl:
 * rscadd: Added a *dab emote. Doing it too often will result in broken arms.