### PR TITLE
Fixed Nar-Sie rising in nullspace if the anchor blood stone got destroyed during Act IV

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
@@ -1379,7 +1379,7 @@ var/list/bloodstone_list = list()
 			new /obj/effect/cult_ritual/backup_spawn(T)
 
 /obj/structure/cult/bloodstone/dance_start()
-	while(src && loc && anchor)
+	while(!gcDestroyed && loc && anchor)
 		for (var/mob/M in contributors)
 			if (!iscultist(M) || get_dist(src,M) > 1 || (M.stat != CONSCIOUS))
 				if (M.client)
@@ -1407,7 +1407,7 @@ var/list/bloodstone_list = list()
 	anchor = FALSE
 	for (var/obj/structure/teleportwarp/TW in src.loc)
 		qdel(TW)
-	if (src && loc)
+	if (!gcDestroyed && loc)
 		new /obj/machinery/singularity/narsie/large(src.loc)
 		stat_collection.cult_narsie_summoned = TRUE
 	return 1

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
@@ -1407,8 +1407,9 @@ var/list/bloodstone_list = list()
 	anchor = FALSE
 	for (var/obj/structure/teleportwarp/TW in src.loc)
 		qdel(TW)
-	new /obj/machinery/singularity/narsie/large(src.loc)
-	stat_collection.cult_narsie_summoned = TRUE
+	if (src && loc)
+		new /obj/machinery/singularity/narsie/large(src.loc)
+		stat_collection.cult_narsie_summoned = TRUE
 	return 1
 
 /obj/structure/cult/bloodstone/ex_act(var/severity)

--- a/code/datums/gamemode/objectives/bloodcult.dm
+++ b/code/datums/gamemode/objectives/bloodcult.dm
@@ -170,7 +170,7 @@
 			qdel(B)
 
 	spawn()
-		anchor.dance_start()
+		anchor.dance_start()//the dance starts once, and only ends for good when Nar-Sie rises or the anchor is destroyed first.
 
 	message_admins("Blood Cult: ACT IV has begun.")
 	return TRUE


### PR DESCRIPTION
Fixed #21330

:cl:
* bugfix: Fixed Nar-Sie rising in nullspace if the anchor blood stone got destroyed during Act IV.