### PR TITLE
Decreases deflection chance of gygax and phazon to 10%

### DIFF
--- a/code/game/mecha/combat/gygax.dm
+++ b/code/game/mecha/combat/gygax.dm
@@ -6,7 +6,6 @@
 	step_in = 3
 	dir_in = 1 //Facing North.
 	health = 300
-	deflect_chance = 15
 	damage_absorption = list("brute"=0.75,"fire"=1,"bullet"=0.8,"laser"=0.7,"energy"=0.85,"bomb"=1)
 	max_temperature = 25000
 	infra_luminosity = 6

--- a/code/game/mecha/combat/phazon.dm
+++ b/code/game/mecha/combat/phazon.dm
@@ -7,7 +7,6 @@
 	dir_in = 1 //Facing North.
 	step_energy_drain = 3
 	health = 200
-	deflect_chance = 30
 	damage_absorption = list("brute"=0.7,"fire"=0.7,"bullet"=0.7,"laser"=0.7,"energy"=0.7,"bomb"=0.7)
 	max_temperature = 25000
 	infra_luminosity = 3


### PR DESCRIPTION
Deflection is now 10% for gygax and phazon, the default for mechs
Science is DONE FOR
This was a branch I opened 2 weeks ago and only got around to working it about 10 minutes ago
Mechs are basically suits of armor that when destroyed you have to deal with the dude inside, and they also have like innate damage reduction or something
Every other mech untouched, durand is CHUNKY

:cl:
 * rscdel: Gygax and Phazon mechs now have the default 10% deflection chance instead of 15% and 30% respectively.