### PR TITLE
Adds forks for deweeding hydrotrays and soil

### DIFF
--- a/__DEFINES/_macros.dm
+++ b/__DEFINES/_macros.dm
@@ -214,6 +214,8 @@
 
 #define hasanvil(H) (isturf(H) && (locate(/obj/item/anvil) in H))
 
+#define ishoe(O) (is_type_in_list(O, list(/obj/item/weapon/minihoe, /obj/item/weapon/kitchen/utensil/fork)))
+
 //Macros for roles/antags
 #define isfaction(A) (istype(A, /datum/faction))
 

--- a/code/modules/hydroponics/hydro_tray.dm
+++ b/code/modules/hydroponics/hydro_tray.dm
@@ -327,7 +327,7 @@
 
 		return
 
-	else if (istype(O, /obj/item/weapon/minihoe))
+	else if (is_type_in_list(O, list(/obj/item/weapon/minihoe, /obj/item/weapon/kitchen/utensil/fork)))
 
 		if(weedlevel > 0)
 			user.visible_message("<span class='alert'>[user] starts uprooting the weeds.</span>", "<span class='alert'>You remove the weeds from the [src].</span>")

--- a/code/modules/hydroponics/hydro_tray.dm
+++ b/code/modules/hydroponics/hydro_tray.dm
@@ -327,7 +327,7 @@
 
 		return
 
-	else if (is_type_in_list(O, list(/obj/item/weapon/minihoe, /obj/item/weapon/kitchen/utensil/fork)))
+	else if (ishoe(O))
 
 		if(weedlevel > 0)
 			user.visible_message("<span class='alert'>[user] starts uprooting the weeds.</span>", "<span class='alert'>You remove the weeds from the [src].</span>")


### PR DESCRIPTION
Instead of needing a minihoe for ghetto botany deweeding, you can now just use a fork. This should compliment the fact that wirecutters are ghetto plant cutters.
:cl:
 * rscadd: You can now use forks for removing weeds from soil and hydrotrays.