### PR TITLE
fixes WATCH ram (SBO36)

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1120,8 +1120,11 @@ About the new airlock wires panel:
 				user.delayNextAttack(10)
 
 	if(istype(I, /obj/item/weapon/batteringram))
-		if(!I.wielded)
+		if(!I.wielded && ishuman(user))
 			to_chat(user,"<span class='warning'>\The [I] must be wielded!</span>")
+			return
+		if(isMoMMI(user))
+			to_chat(user,"<span class='warning'>\The [I] is too bulky for your gripper!</span>")
 			return
 		user.delayNextAttack(30)
 		var/breaktime = 60 //Same amount of time as drilling a wall, then a girder

--- a/code/game/objects/items/robot/robot_items/robot_implanter.dm
+++ b/code/game/objects/items/robot/robot_items/robot_implanter.dm
@@ -3,9 +3,10 @@
 //Warden upgrade's implanter
 /obj/item/weapon/implanter/cyborg
 	name = "cyborg implanter"
+	desc = "Can be refilled in about sixty seconds at any cyborg recharging station."
 	imp_type = /obj/item/weapon/implant/loyalty
 	var/charge = 0
-	
+
 /obj/item/weapon/implanter/cyborg/update()
 	..()
 	name = "[initial(name)][imp? " - [imp.name]":""]"


### PR DESCRIPTION
fixes #21352

unatomic: makes the cyborg implanter slightly more clear in its description

🆑 
* bugfix: The WATCH upgraded wardenborg can once again use its battering ram.