### PR TITLE
further dab fixes

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -213,41 +213,49 @@
 /datum/emote/living/carbon/human/dab
 	key = "dab"
 	key_third_person = "*dab"
+	restraint_check = TRUE
 
 /datum/emote/living/carbon/human/dab/can_run_emote(mob/user)
+	..()
 	var/mob/living/carbon/human/H = user
 	if(H.has_organ(LIMB_LEFT_ARM) && H.has_organ(LIMB_RIGHT_ARM))
 		return TRUE
+	else
+		return FALSE
 
 /datum/emote/living/carbon/human/dab/run_emote(mob/user)
 	var/mob/living/carbon/human/H = user
 	if(!istype(H))
 		return
 	if(!(Holiday == APRIL_FOOLS_DAY))
-		if(!H.stunned && !H.restrained() && !iswizard(H))
-			H.visible_message("<span class = 'warning'><b>[H]</b> slaps themselves in the face.</span>")
-			H.apply_effects(10, 10, 10, 0, 10, 10, 0, 10, 0)
-		return
-	if(H.stunned || H.restrained())
-		return
-	if(world.time-H.lastDab >= 10 SECONDS)
-		for(var/mob/living/M in view(0))
-			if(M != H && M.loc == H.loc)
-				H.visible_message("<span class = 'warning'><b>[H]</b> dabs on <b>[M]</b>!</span>")
-		message = "<b>[H]</b> dabs."
-		emote_type = EMOTE_VISIBLE
-		H.visible_message(message)
-		H.lastDab=world.time
+		H.suiciding = 1
+		H.visible_message("<span class='danger'>[H] holds one arm up and slams \his other arm into \his face! It looks like \he's trying to commit suicide.</span>",)
+		for(var/datum/organ/external/breakthis in H.get_organs(LIMB_LEFT_ARM, LIMB_RIGHT_ARM, LIMB_HEAD))
+			H.apply_damage(50, BRUTE, breakthis)
+			if(!(H.species.anatomy_flags & NO_BONES))
+				breakthis.fracture()
+		H.adjustOxyLoss(max(175 - H.getToxLoss() - H.getFireLoss() - H.getBruteLoss() - H.getOxyLoss(), 0))
+		H.updatehealth()
 	else
-		var/armtobreak = pick(LIMB_LEFT_ARM, LIMB_RIGHT_ARM)
-		var/datum/organ/external/A = H.get_organ(armtobreak)
-		if(H.species.anatomy_flags & NO_BONES)
-			message = "<span class = 'warning'>smacks their head as they flail their arms to the side.</span>"
-			playsound(H, 'sound/weapons/punch1.ogg', 50, 1)
-			A = H.get_organ(LIMB_HEAD)
-			H.apply_damage(5, BRUTE, A)
+		if(world.time-H.lastDab >= 10 SECONDS)
+			for(var/mob/living/M in view(0))
+				if(M != H && M.loc == H.loc)
+					H.visible_message("<span class = 'warning'><b>[H]</b> dabs on <b>[M]</b>!</span>")
+			message = "<b>[H]</b> dabs."
+			emote_type = EMOTE_VISIBLE
+			H.visible_message(message)
+			H.lastDab=world.time
 		else
-			message = "<span class = 'warning'>dabs too hard!</span>"
-			H.apply_damage(5, BRUTE, A)
-		emote_type = EMOTE_VISIBLE
-		. = ..()
+			var/armtobreak = pick(LIMB_LEFT_ARM, LIMB_RIGHT_ARM)
+			var/datum/organ/external/A = H.get_organ(armtobreak)
+			if(H.species.anatomy_flags & NO_BONES)
+				message = "<span class = 'warning'>smacks their head as they flail their arms to the side.</span>"
+				playsound(H, 'sound/weapons/punch1.ogg', 50, 1)
+				A = H.get_organ(LIMB_HEAD)
+				H.apply_damage(50, BRUTE, A)
+			else
+				message = "<span class = 'warning'>dabs too hard!</span>"
+				H.apply_damage(50, BRUTE, A)
+				A.fracture()
+			emote_type = EMOTE_VISIBLE
+			. = ..()

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -238,13 +238,13 @@
 	var/mob/living/carbon/human/H = user
 	if(!istype(H))
 		return
-	//var/confirm = alert("Suffer for your sins.", "Confirm Suicide", "gladly", "ok")
-	//var/confirm = alert("Are you sure you want to do this? Nobody will want to revive you.", "Confirm Suicide", "Yes", "Yes")
-	//var/confirm = alert("Are you sure you want to [key]? This action will cause irreversable brain damage.", "Confirm Suicide", "Yes", "Yes")
-	var/confirm = alert("Are you sure you want to [key]? This action cannot be undone and you will not able to be revived.", "Confirm Suicide", "Yes", "No")
-	if(confirm != "Yes")
-		return
 	if(!(Holiday == APRIL_FOOLS_DAY))
+		//var/confirm = alert("Suffer for your sins.", "Confirm Suicide", "gladly", "ok")
+		//var/confirm = alert("Are you sure you want to do this? Nobody will want to revive you.", "Confirm Suicide", "Yes", "Yes")
+		//var/confirm = alert("Are you sure you want to [key]? This action will cause irreversable brain damage.", "Confirm Suicide", "Yes", "Yes")
+		var/confirm = alert("Are you sure you want to [key]? This action cannot be undone and you will not able to be revived.", "Confirm Suicide", "Yes", "No")
+		if(confirm != "Yes")
+			return
 		H.suiciding = 1
 		H.visible_message("<span class='danger'>[H] holds one arm up and slams \his other arm into \his face! It looks like \he's trying to commit suicide.</span>",)
 		for(var/datum/organ/external/breakthis in H.get_organs(LIMB_LEFT_ARM, LIMB_RIGHT_ARM, LIMB_HEAD))

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -238,6 +238,12 @@
 	var/mob/living/carbon/human/H = user
 	if(!istype(H))
 		return
+	//var/confirm = alert("Suffer for your sins.", "Confirm Suicide", "gladly", "ok")
+	//var/confirm = alert("Are you sure you want to do this? Nobody will want to revive you.", "Confirm Suicide", "Yes", "Yes")
+	//var/confirm = alert("Are you sure you want to [key]? This action will cause irreversable brain damage.", "Confirm Suicide", "Yes", "Yes")
+	var/confirm = alert("Are you sure you want to [key]? This action cannot be undone and you will not able to be revived.", "Confirm Suicide", "Yes", "No")
+	if(confirm != "Yes")
+		return
 	if(!(Holiday == APRIL_FOOLS_DAY))
 		H.suiciding = 1
 		H.visible_message("<span class='danger'>[H] holds one arm up and slams \his other arm into \his face! It looks like \he's trying to commit suicide.</span>",)

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -215,15 +215,26 @@
 	key_third_person = "*dab"
 	restraint_check = TRUE
 
-/datum/emote/living/carbon/human/dab/can_run_emote(mob/user)
-	..()
+/datum/emote/living/carbon/human/dab/can_run_emote(mob/user, var/status_check = TRUE)
 	var/mob/living/carbon/human/H = user
+	if (iswizard(H))
+		to_chat(user, "<span class='warning'>The Wizard Federation has banned usage of the [key].</span>")
+		return FALSE
 	if(H.has_organ(LIMB_LEFT_ARM) && H.has_organ(LIMB_RIGHT_ARM))
+		if(user.stat > stat_allowed)
+			to_chat(user, "<span class='warning'>You cannot [key] while unconscious.</span>")
+			return FALSE
+		if(restraint_check && (user.restrained() || user.locked_to))
+			to_chat(user, "<span class='warning'>You cannot [key] while restrained.</span>")
+			return FALSE
 		return TRUE
 	else
+		to_chat(user, "<span class='warning'>You cannot [key] without both your arms.</span>")
 		return FALSE
 
-/datum/emote/living/carbon/human/dab/run_emote(mob/user)
+/datum/emote/living/carbon/human/dab/run_emote(mob/user, params, ignore_status = FALSE)
+	if(!(can_run_emote(user, !ignore_status)))
+		return FALSE
 	var/mob/living/carbon/human/H = user
 	if(!istype(H))
 		return


### PR DESCRIPTION
- dabbing now has the intended desired effect on its emoter
- wizards can no longer dab
- `can_run_emote` wasn't being called resulting in limbless unconscious dabbing

tested

🆑 
 - tweak: fixes oversight where *dab would cause you minor damage, other minor fixes