### PR TITLE
Space Christianity Converts Everyone

### DIFF
--- a/code/datums/religions.dm
+++ b/code/datums/religions.dm
@@ -18,7 +18,8 @@
 	var/list/deity_names = list()
 
 	var/datum/action/renounce/action_renounce
-	var/list/keys = list("christianity") // What you need to type to get this particular relgion.
+	var/list/keys = list("abstractbasetype") // What you need to type to get this particular relgion.
+	var/converts_everyone = FALSE
 
 /datum/religion/New() // For religions with several bibles/deities
 	if (bible_names.len)
@@ -128,10 +129,13 @@
 		preacher.put_in_hands(holy_book)
 	religiousLeader = preacher.mind
 	convert(preacher, null)
-	if(keys[1]=="christianity")
-		message_admins("[key_name(preacher)] has selected Christianity and converted the entire crew.")
+	OnPostActivation()
+
+/datum/religion/proc/OnPostActivation()
+	if(converts_everyone)
+		message_admins("[key_name(religiousLeader)] has selected [name] and converted the entire crew.")
 		for(var/mob/living/carbon/human/H in player_list)
-			if(H==preacher)
+			if(isReligiousLeader(H))
 				continue
 			convert(H,null,TRUE,TRUE)
 
@@ -246,6 +250,10 @@
 			R.holy_book.item_state = "bible"
 
 // The list of all religions spacemen have designed, so far.
+/datum/religion/default
+	keys = list("christianity")
+	converts_everyone = TRUE
+
 /datum/religion/catholic
 	name = "Catholicism"
 	deity_name = "Jesus Christ"

--- a/code/datums/religions.dm
+++ b/code/datums/religions.dm
@@ -94,27 +94,30 @@
 	return choice == "Yes"
 
 // Here is the proc to welcome a new soul in our religion.
-/datum/religion/proc/convert(var/mob/living/subject, var/mob/living/preacher, var/can_renounce = TRUE)
+/datum/religion/proc/convert(var/mob/living/subject, var/mob/living/preacher, var/can_renounce = TRUE, var/default = FALSE)
 	// If he already had one
 	if (subject.mind.faith)
 		subject.mind.faith.renounce(subject) // We remove him from that one
 
 	subject.mind.faith = src
-	to_chat(subject, "You feel your mind become clear and focused as you discover your newfound faith. You are now a follower of [name].")
 	adepts += subject.mind
 	if(can_renounce)
 		action_renounce.Grant(subject)
-	if (!preacher)
-		var/msg = "\The [key_name(subject)] has been converted to [name] without a preacher."
-		message_admins(msg)
+	if(!default)
+		to_chat(subject, "<span class='good'>You feel your mind become clear and focused as you discover your newfound faith. You are now a follower of [name].</span>")
+		if (!preacher)
+			var/msg = "\The [key_name(subject)] has been converted to [name] without a preacher."
+			message_admins(msg)
+		else
+			var/msg = "[key_name(subject)] has been converted to [name] by \The [key_name(preacher)]."
+			message_admins(msg)
 	else
-		var/msg = "[key_name(subject)] has been converted to [name] by \The [key_name(preacher)]."
-		message_admins(msg)
+		to_chat(subject, "<span class='good'>You are reminded you were christened into [name] long ago.</span>")
 
 // Activivating a religion with admin interventions.
 /datum/religion/proc/activate(var/mob/living/preacher)
 	equip_chaplain(preacher) // We do the misc things related to the religion
-	to_chat(preacher, "A great, intense revelation go through your spirit. You are now the religious leader of [name]. Convert people by [convert_method]")
+	to_chat(preacher, "A great, intense revelation goes through your spirit. You are now the religious leader of [name]. Convert people by [convert_method]")
 	if (holy_book)
 		preacher.put_in_hands(holy_book)
 	else
@@ -125,6 +128,12 @@
 		preacher.put_in_hands(holy_book)
 	religiousLeader = preacher.mind
 	convert(preacher, null)
+	if(keys[1]=="christianity")
+		message_admins("[key_name(preacher)] has selected Christianity and converted the entire crew.")
+		for(var/mob/living/carbon/human/H in player_list)
+			if(H==preacher)
+				continue
+			convert(H,null,TRUE,TRUE)
 
 /datum/religion/proc/renounce(var/mob/living/subject)
 	to_chat(subject, "<span class='notice'>You renounce [name].</span>")

--- a/code/game/jobs/job/civilian_chaplain.dm
+++ b/code/game/jobs/job/civilian_chaplain.dm
@@ -56,6 +56,10 @@
 					rel.religiousLeader = H.mind
 					J = (H.gender == FEMALE ? rel.female_adept : rel.male_adept)
 					rel.convert(H, null, can_renounce = FALSE)
+					if(key == "christianity")
+						message_admins("[key_name(H)] has selected Christianity and converted the entire crew.")
+						for(var/mob/living/carbon/human/P in player_list)
+							rel.convert(P,null,TRUE,TRUE)
 					to_chat(H, "A great, intense revelation goes through your spirit. You are now the religious leader of [rel.name]. Convert people by [rel.convert_method]")
 					chap_religion = rel
 					choice = TRUE

--- a/code/game/jobs/job/civilian_chaplain.dm
+++ b/code/game/jobs/job/civilian_chaplain.dm
@@ -12,7 +12,7 @@
 	minimal_access = list(access_morgue, access_chapel_office, access_crematorium)
 	pdaslot = slot_belt
 	pdatype = /obj/item/device/pda/chaplain
-	var/datum/religion/chap_religion = new /datum/religion // He gets the default one
+	var/datum/religion/chap_religion = new /datum/religion/default // default = space christianity
 
 /datum/job/chaplain/equip(var/mob/living/carbon/human/H)
 	switch(H.backbag)
@@ -56,10 +56,7 @@
 					rel.religiousLeader = H.mind
 					J = (H.gender == FEMALE ? rel.female_adept : rel.male_adept)
 					rel.convert(H, null, can_renounce = FALSE)
-					if(key == "christianity")
-						message_admins("[key_name(H)] has selected Christianity and converted the entire crew.")
-						for(var/mob/living/carbon/human/P in player_list)
-							rel.convert(P,null,TRUE,TRUE)
+					rel.OnPostActivation()
 					to_chat(H, "A great, intense revelation goes through your spirit. You are now the religious leader of [rel.name]. Convert people by [rel.convert_method]")
 					chap_religion = rel
 					choice = TRUE

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -544,7 +544,7 @@ Round Duration: [round(hours)]h [round(mins)]m<br>"}
 	new_character.key = key		//Manually transfer the key to log them in
 
 	var/datum/religion/R = ticker.chap_rel
-	if(R && R.keys[1]=="christianity")
+	if(R && R.converts_everyone && !R.isReligiousLeader(new_character))
 		R.convert(new_character,null,TRUE,TRUE)
 
 	return new_character

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -543,6 +543,10 @@ Round Duration: [round(hours)]h [round(mins)]m<br>"}
 
 	new_character.key = key		//Manually transfer the key to log them in
 
+	var/datum/religion/R = ticker.chap_rel
+	if(R && R.keys[1]=="christianity")
+		R.convert(new_character,null,TRUE,TRUE)
+
 	return new_character
 
 /mob/new_player/proc/ViewManifest()


### PR DESCRIPTION
Had this idea after discussing in the coder discord why no one takes the default religion. Basically you're opting out of additional toys when you choose the base religion. There's no incentive to not at least get yourself a fun practice laser or special conversion ceremony.

This change makes it so that if you select the default Christianity as your religion, it automatically converts everyone (and any future latejoiners). They are still free to renounce religion at any time.

🆑 
* rscadd: The chaplain's default religion (Christianity) now has the added perk of having everyone else converted by default, though they may still choose to renounce it.