### PR TITLE
Adds flavoured sweets

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -4448,8 +4448,8 @@
 	..()
 	reagents.add_reagent(NUTRIMENT, 3)
 	reagents.add_reagent(SUGAR, 2)
-	var/list/flavors = list("\improper strawberry","\improper lime","\improper blueberry","\improper lemon","\improper grape","\improper lemonade","\improper bubblegum","\improper raspberry","\improper orange","\improper liquorish","\improper apple","\improper cranberry")
-	var/variety = rand(1,12)
+	var/list/flavors = list("\improper strawberry","\improper lime","\improper blueberry","\improper banana","\improper grape","\improper lemonade","\improper bubblegum","\improper raspberry","\improper orange","\improper liquorish","\improper apple","\improper cranberry")
+	var/variety = rand(1,flavors.len) //MORE SWEETS MAYBE IF YOU SPRITE IT
 	icon_state = "sweet[variety]"
 	name = "[flavors[variety]] sweet"
 

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -4448,31 +4448,10 @@
 	..()
 	reagents.add_reagent(NUTRIMENT, 3)
 	reagents.add_reagent(SUGAR, 2)
-	icon_state = "sweet[rand(1,12)]"
-	if (icon_state == "sweet1")
-		name = "\improper Strawberry " + name
-	if (icon_state == "sweet2")
-		name = "\improper Lime " + name
-	if (icon_state == "sweet3")
-		name = "\improper Blueberry " + name
-	if (icon_state == "sweet4")
-		name = "\improper Lemon " + name
-	if (icon_state == "sweet5")
-		name = "\improper Grape " + name
-	if (icon_state == "sweet6")
-		name = "\improper Lemonade " + name
-	if (icon_state == "sweet7")
-		name = "\improper Bubblegum " + name
-	if (icon_state == "sweet8")
-		name = "\improper Raspberry " + name
-	if (icon_state == "sweet9")
-		name = "\improper Orange " + name
-	if (icon_state == "sweet10")
-		name = "\improper Liquorice " + name
-	if (icon_state == "sweet11")
-		name = "\improper Apple " + name
-	if (icon_state == "sweet12")
-		name = "\improper Cranberry " + name
+	var/list/flavors = list("\improper strawberry","\improper lime","\improper blueberry","\improper lemon","\improper grape","\improper lemonade","\improper bubblegum","\improper raspberry","\improper orange","\improper liquorish","\improper apple","\improper cranberry")
+	var/variety = rand(1,12)
+	icon_state = "sweet[variety]"
+	name = "[flavors[variety]] sweet"
 
 /obj/item/weapon/reagent_containers/food/snacks/sweet/strange
 	desc = "Something about this sweet doesn't seem right."

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -4450,29 +4450,29 @@
 	reagents.add_reagent(SUGAR, 2)
 	icon_state = "sweet[rand(1,12)]"
 	if (icon_state == "sweet1")
-		name = "Strawberry " + name
+		name = "\improper Strawberry " + name
 	if (icon_state == "sweet2")
-		name = "Lime " + name
+		name = "\improper Lime " + name
 	if (icon_state == "sweet3")
-		name = "Blueberry " + name
+		name = "\improper Blueberry " + name
 	if (icon_state == "sweet4")
-		name = "Lemon " + name
+		name = "\improper Lemon " + name
 	if (icon_state == "sweet5")
-		name = "Grape " + name
+		name = "\improper Grape " + name
 	if (icon_state == "sweet6")
-		name = "Lemonade " + name
+		name = "\improper Lemonade " + name
 	if (icon_state == "sweet7")
-		name = "Bubblegum " + name
+		name = "\improper Bubblegum " + name
 	if (icon_state == "sweet8")
-		name = "Raspberry " + name
+		name = "\improper Raspberry " + name
 	if (icon_state == "sweet9")
-		name = "Orange " + name
+		name = "\improper Orange " + name
 	if (icon_state == "sweet10")
-		name = "Liquorice " + name
+		name = "\improper Liquorice " + name
 	if (icon_state == "sweet11")
-		name = "Apple " + name
+		name = "\improper Apple " + name
 	if (icon_state == "sweet12")
-		name = "Cranberry " + name
+		name = "\improper Cranberry " + name
 
 /obj/item/weapon/reagent_containers/food/snacks/sweet/strange
 	desc = "Something about this sweet doesn't seem right."

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -4439,7 +4439,7 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/sweet
 	name = "\improper Sweet"
-	desc = "Comes in many different and unique flavours!"
+	desc = "Comes in many different and unique flavours! One of the flagship products of the Getmore Chocolate Corp. Not suitable for children aged 0-3. Do not consume around open flames or expose to radiation. Expiration date: 2921."
 	food_flags = FOOD_SWEET
 	icon = 'icons/obj/candymachine.dmi'
 	bitesize = 5
@@ -4449,6 +4449,30 @@
 	reagents.add_reagent(NUTRIMENT, 3)
 	reagents.add_reagent(SUGAR, 2)
 	icon_state = "sweet[rand(1,12)]"
+	if (icon_state == "sweet1")
+		name = "Strawberry " + name
+	if (icon_state == "sweet2")
+		name = "Lime " + name
+	if (icon_state == "sweet3")
+		name = "Blueberry " + name
+	if (icon_state == "sweet4")
+		name = "Lemon " + name
+	if (icon_state == "sweet5")
+		name = "Grape " + name
+	if (icon_state == "sweet6")
+		name = "Lemonade " + name
+	if (icon_state == "sweet7")
+		name = "Bubblegum " + name
+	if (icon_state == "sweet8")
+		name = "Raspberry " + name
+	if (icon_state == "sweet9")
+		name = "Orange " + name
+	if (icon_state == "sweet10")
+		name = "Liquorice " + name
+	if (icon_state == "sweet11")
+		name = "Apple " + name
+	if (icon_state == "sweet12")
+		name = "Cranberry " + name
 
 /obj/item/weapon/reagent_containers/food/snacks/sweet/strange
 	desc = "Something about this sweet doesn't seem right."


### PR DESCRIPTION
This adds sweet flavours based on the sweet icon, such that the flavour reflects the colour. The description has also been changed slight, shown below.

![image](https://user-images.githubusercontent.com/28162068/51547307-eb4d1500-1e5d-11e9-9364-53f3d31ae8d5.png)

There are 12 flavours to reflect the 12 colours: Strawberry, Lime, Blueberry, ~~Lemon~~ Banana, Grape, Lemonade, Bubblegum, Raspberry, Orange, Liquorice, Apple and Cranberry.

:cl:
 * rscadd: Adds flavours to sweet names to reflect their colour and also updates sweet descriptions.