### PR TITLE
Adds the door onopen signal wire

### DIFF
--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -13,13 +13,14 @@ var/const/AIRLOCK_WIRE_ELECTRIFY = 256
 var/const/AIRLOCK_WIRE_SAFETY = 512
 var/const/AIRLOCK_WIRE_SPEED = 1024
 var/const/AIRLOCK_WIRE_LIGHT = 2048
+var/const/AIRLOCK_WIRE_ONOPEN = 4096
 
 /datum/wires/airlock/secure
 	random = 1
 
 /datum/wires/airlock
 	holder_type = /obj/machinery/door/airlock
-	wire_count = 12
+	wire_count = 13
 	window_y = 570
 
 /datum/wires/airlock/New()
@@ -36,6 +37,7 @@ var/const/AIRLOCK_WIRE_LIGHT = 2048
 		"[AIRLOCK_WIRE_SAFETY]"        = "Safety",
 		"[AIRLOCK_WIRE_SPEED]"         = "Speed",
 		"[AIRLOCK_WIRE_LIGHT]"         = "Lights",
+		"[AIRLOCK_WIRE_ONOPEN]"        = "On Open"
 	)
 	..()
 
@@ -212,3 +214,6 @@ var/const/AIRLOCK_WIRE_LIGHT = 2048
 		if(AIRLOCK_WIRE_LIGHT)
 			A.lights = !A.lights
 			A.update_icon()
+
+		if(AIRLOCK_WIRE_ONOPEN)
+			A.visible_message("<span class = 'notice'>\The [A]'s motors whirr.</span>")

--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -6,15 +6,15 @@
 #define MAX_FLAG 65535
 
 var/list/same_wires = list()
-// 12 colours, if you're adding more than 12 wires then add more colours here
-var/list/wireColours = list("red", "blue", "green", "black", "orange", "brown", "gold", "gray", "cyan", "navy", "purple", "pink")
+// 14 colours, if you're adding more than 14 wires then add more colours here
+var/list/wireColours = list("red", "blue", "green", "black", "orange", "brown", "gold", "gray", "cyan", "navy", "purple", "pink", "fuchsia", "aqua")
 
 /datum/wires
 
 	var/random = 0 // Will the wires be different for every single instance.
 	var/atom/holder = null // The holder
 	var/holder_type = null // The holder type; used to make sure that the holder is the correct type.
-	var/wire_count = 0 // Max is 16
+	var/wire_count = 0 // Max is 16, but display is limited by the amount of different wire colours
 	var/wires_status = 0 // BITFLAG OF WIRES
 	var/check_wires = 0
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1289,7 +1289,10 @@ About the new airlock wires panel:
 			spawn(20)
 				autoclose()
 	// </worry>
-	return ..()
+
+	.=..()
+	if(.)
+		wires.SignalIndex(AIRLOCK_WIRE_ONOPEN)
 
 /obj/machinery/door/airlock/Uncross(atom/movable/mover)
 	if(density && ismob(mover) && !(mover.checkpass(PASSGLASS) && !opacity) && !(mover.checkpass(PASSDOOR)) && !(istype(mover,/mob/living/simple_animal/shade)))//REEEEEEE

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1291,7 +1291,7 @@ About the new airlock wires panel:
 	// </worry>
 
 	.=..()
-	if(.)
+	if(. && !(stat & (NOPOWER) || !src.arePowerSystemsOn())) //It opened, and there's power
 		wires.SignalIndex(AIRLOCK_WIRE_ONOPEN)
 
 /obj/machinery/door/airlock/Uncross(atom/movable/mover)


### PR DESCRIPTION
When an airlock opens, it sends a signal via any attached devices to this wire.

Useful for 'open up the door, room explodes' traps

Misc changes:
 - Adds two new colours of wire, fuchsia and aqua.

:cl:
 * rscadd: Adds a new wire to airlocks, that when the airlock is opened, triggers any signalers attached to that wire.