### PR TITLE
Make N2O no longer visible in the air

### DIFF
--- a/code/ZAS/XGM_gases.dm
+++ b/code/ZAS/XGM_gases.dm
@@ -78,8 +78,8 @@
 	specific_heat = 40	// J/(mol*K)
 	molar_mass = 0.044	// kg/mol. N₂O
 
-	tile_overlay = new /image/effect('icons/effects/tile_effects.dmi', "sleeping_agent", FLY_LAYER)
-	overlay_limit = 1 / CELL_VOLUME
+	//tile_overlay = new /image/effect('icons/effects/tile_effects.dmi', "sleeping_agent", FLY_LAYER)
+	//overlay_limit = 1 / CELL_VOLUME
 	flags = XGM_GAS_OXIDIZER | XGM_GAS_LOGGED // N₂O is a powerful oxidizer
 
 /datum/gas/sleeping_agent/is_human_safe(var/moles, var/datum/gas_mixture/mixture)


### PR DESCRIPTION
Based on a suggestion I've seen in the Ivory Tower, to make N2O less totally shit at sabotage. Now, just like CO2, it's invisible, so if you're not quick to notice its effects, you'll get tricked

It's important to remember that a FULL canister of N2O released into the air won't permastun people. It will stun them a lot, but one person with internals can break the cycle. Also the laughing is kinda telltale. What kind of sick fuck just -laughs- for non-intoxication reasons ?

Otherwise, well, leaving that one hanging around. Balance change means balance discussion

:cl:
 * rscdel: N2O in the air is no longer visible as white flakes. Remember to keep a close ye for laughing crewmmates. Extreme euphoria is the first sign of a laughing gas leak!