### PR TITLE
Fixes robot construction

### DIFF
--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -218,7 +218,7 @@
 			if(!user.drop_item(W))
 				return
 
-			var/mob/living/silicon/robot/O = new /mob/living/silicon/robot(get_turf(loc), unfinished = 1)
+			var/mob/living/silicon/robot/O = new /mob/living/silicon/robot(get_turf(loc))
 
 			for(var/P in M.mommi_assembly_parts) //Let's give back all those mommi creation components
 				for(var/obj/item/L in M.contents)


### PR DESCRIPTION
Some old code was looking for a specific argument in robot/New() that was removed. This caused robot/New() to runtime,  meaning components were never initialized, causing the robot to become immortal but non-functional.

closes #21425

:cl:
 * bugfix: Fixes not being able to build robots.