### PR TITLE
Disabling the ID wire on a door will now allow the door to be accessed by anyone

### DIFF
--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -137,15 +137,25 @@ var/const/AIRLOCK_WIRE_LIGHT = 2048
 			A.lights = mended
 			A.update_icon()
 
+		if (AIRLOCK_WIRE_IDSCAN)
+			if(!mended)
+				A.AccessEnabled = 0 //So you can't multi-tool it before bricking
+				to_chat(usr, "<span class='notice'>The ID slot turns off.</span>")
+
 
 /datum/wires/airlock/UpdatePulsed(var/index, mob/user)
 
 	var/obj/machinery/door/airlock/A = holder
 	switch(index)
 		if(AIRLOCK_WIRE_IDSCAN)
-			//Sending a pulse through this flashes the red light on the door (if the door has power).
-			if((A.arePowerSystemsOn()) && (!(A.stat & NOPOWER)) && A.density)
-				A.door_animate("deny")
+			//Sending a pulse through this disables the airlock's access requirement for 10 ticks
+			if((A.arePowerSystemsOn()) && (!(A.stat & NOPOWER)))
+				A.AccessEnabled = 1
+				to_chat(usr, "<span class='notice'>The ID slot flashes yellow.</span>")
+				spawn(100)
+					if(A)
+						if(A.AccessEnabled == 1)
+							A.AccessEnabled = 0
 		if(AIRLOCK_WIRE_MAIN_POWER1, AIRLOCK_WIRE_MAIN_POWER2)
 			//Sending a pulse through either one causes a breaker to trip, disabling the door for 10 seconds if backup power is connected, or 1 minute if not (or until backup power comes back on, whichever is shorter).
 			A.loseMainPower()

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -158,16 +158,6 @@ var/list/all_doors = list()
 			else
 				return open()
 
-	if(AccessEnabled || allowed(user))
-		if(!requiresID())
-			user = null
-		if(requiresID())
-			if (isshade(user))
-				user.forceMove(loc)//They're basically slightly tangible ghosts, they can fit through doors as soon as they begin openning.
-			open()
-		else if(!operating)
-			denied()
-
 	if(horror_force(user))
 		return
 

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -104,10 +104,7 @@ var/list/all_doors = list()
 
 	add_fingerprint(user)
 
-	if(!requiresID())
-		user = null
-
-	if(allowed(user))
+	if(!requiresID() || allowed(user))
 		if (isshade(user))
 			user.forceMove(loc)//They're basically slightly tangible ghosts, they can fit through doors as soon as they begin openning.
 		open()
@@ -141,10 +138,7 @@ var/list/all_doors = list()
 
 	add_fingerprint(user)
 
-	if (!requiresID())
-		user = null
-
-	if (allowed(user))
+	if (!requiresID() || allowed(user))
 		if (!density)
 			return close()
 		else
@@ -162,7 +156,7 @@ var/list/all_doors = list()
 	if(istype(I, /obj/item/device/detective_scanner))
 		return //It does its own thing on attack
 
-	if (allowed(user))
+	if (!requiresID() || allowed(user))
 		if (!density)
 			return close()
 		else


### PR DESCRIPTION
Thanks to @Kammerjunk and @MadmanMartian for literally doing this PR
Give the PR the OH GOD IT'S LOOSE tag
[gameplay] [tweak] [vote]
could possibly be a bug fix who knows

:cl:
 * tweak: Pulsing the ID scanner wire on an airlock allows anyone for 10 seconds to access it.
 * tweak: Cutting the ID scanner wire on an airlock has the same function; Not allowing anyone to use it.
 * rcadd: Added new messages when tampering with wires and when examining from a distance that show whether the ID scanner has been pulsed or cut.