### PR TITLE
Radiation Storms PR #2 - Irradiated Boogaloo

### DIFF
--- a/code/modules/events/radiation_storm.dm
+++ b/code/modules/events/radiation_storm.dm
@@ -8,6 +8,7 @@
 		/area/security/perma,
 		/area/security/gas_chamber,
 		/area/security/brig,
+		/area/security/toilet,
 		/area/shuttle,
 		/area/vox_station,
 		/area/syndicate_station,
@@ -16,7 +17,8 @@
 		/area/prison,
 		/area/medical/patients_rooms,
 		/area/medical/patient_room1,
-		/area/medical/patient_room2
+		/area/medical/patient_room2,
+		/area/derelictparts,
 	)
 
 


### PR DESCRIPTION
[deff] [box] [qol]

Title. I added the Derelict Parts area in maintenance to shield most of maintenance. I also added the new Brig Dorms on Box so napping officers don't die in their sleep.

The current 'derelictparts' area and its subtypes on Deff covers most of the maintenance, but those areas are not powered so the flashing green lights do not work. This results in people fleeing into maintenance, or people already in maintenance, to die thinking that they are safe.

🆑 

 * tweak: Defficiency Maintenance should no longer be a total crapshoot on whether or not the radstorm gets ya.