### PR TITLE
You can no longer drag yourself when hit with energy crossbow projectile

### DIFF
--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -82,6 +82,7 @@
 	icon_state = "cbbolt"
 	damage = 10
 	damage_type = TOX
+	stun = 10
 	nodamage = 0
 	weaken = 10
 	stutter = 10


### PR DESCRIPTION
They lacked the stun variable and ever since the crawl PR people have been able to drag themselves away from e-bow shots
Traitor powercreep
[easyfix]
fixes #21360 

:cl:
 * bugfix: You can no longer drag yourself from energy crossbow hits.