### PR TITLE
Stunbatons, telebatons, and classic batons no longer stun you for an exorbitant amount of time when you are brain-damaged or clumsy.

### DIFF
--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -125,7 +125,7 @@
 	if(status && clumsy_check(user) && prob(50))
 		user.simple_message("<span class='warning'>You grab the [src] on the wrong side.</span>",
 			"<span class='danger'>The [name] blasts you with its power!</span>")
-		user.Knockdown(stunforce*3)
+		user.Knockdown(stunforce)
 		playsound(loc, "sparks", 75, 1, -1)
 		deductcharge(hitcost)
 		return
@@ -150,7 +150,7 @@
 	if(status && clumsy_check(user) && prob(50))
 		user.simple_message("<span class='danger'>You accidentally hit yourself with [src]!</span>",
 			"<span class='danger'>The [name] goes mad!</span>")
-		user.Knockdown(stunforce*3)
+		user.Knockdown(stunforce)
 		deductcharge(hitcost)
 		return
 

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -35,7 +35,7 @@
 /obj/item/weapon/melee/classic_baton/attack(mob/M as mob, mob/living/user as mob)
 	if (clumsy_check(user) && prob(50))
 		to_chat(user, "<span class='warning'>You club yourself over the head.</span>")
-		user.Knockdown(3 * force)
+		user.Knockdown(8)
 		if(ishuman(user))
 			var/mob/living/carbon/human/H = user
 			H.apply_damage(2*force, BRUTE, LIMB_HEAD)
@@ -145,7 +145,7 @@
 			user.simple_message("<span class='warning'>You club yourself over the head.</span>",
 				"<span class='danger'>The fishing rod goes mad!</span>")
 
-			user.Knockdown(3 * force)
+			user.Knockdown(4)
 			if(ishuman(user))
 				var/mob/living/carbon/human/H = user
 				H.apply_damage(2*force, BRUTE, LIMB_HEAD)


### PR DESCRIPTION
90 seconds. Jesus Christ.
possibly fixes #21444 
Stunbatons now stun for as much as they stun (20 seconds), batons knock down for 16 seconds, and telebatons knock down for 8, from 60 seconds, 60 seconds, and 90 seconds respectively
:cl:
 * tweak: Stunbaton, telescopic baton, and classic batons now stun you for far less time when you hit yourself out of clumsiness or brain damage.