### PR TITLE
Allow the HoP to give custom titles their own categories

### DIFF
--- a/code/defines/obj.dm
+++ b/code/defines/obj.dm
@@ -117,28 +117,27 @@
 			isactive[name] = (SSD ? "SSD" : (active ? "Active" : "Inactive"))
 		else
 			isactive[name] = t.fields["p_stat"]
-//			to_chat(world, "[name]: [rank]")
 			//cael - to prevent multiple appearances of a player/job combination, add a continue after each line
 		var/department = 0
-		if(real_rank in command_positions)
+		if((real_rank in command_positions) || (t.fields["override_dept"] == "Command"))
 			heads[name] = rank
 			department = 1
-		if(real_rank in security_positions)
+		if((real_rank in security_positions) || (t.fields["override_dept"] == "Security"))
 			sec[name] = rank
 			department = 1
-		if(real_rank in engineering_positions)
+		if((real_rank in engineering_positions) || (t.fields["override_dept"] == "Engineering"))
 			eng[name] = rank
 			department = 1
-		if(real_rank in medical_positions)
+		if((real_rank in medical_positions) || (t.fields["override_dept"] == "Medical"))
 			med[name] = rank
 			department = 1
-		if(real_rank in science_positions)
+		if((real_rank in science_positions) || (t.fields["override_dept"] == "Science"))
 			sci[name] = rank
 			department = 1
-		if(real_rank in cargo_positions)
+		if((real_rank in cargo_positions) || (t.fields["override_dept"] == "Cargo"))
 			cgo[name] = rank
 			department = 1
-		if(real_rank in civilian_positions)
+		if((real_rank in civilian_positions) || (t.fields["override_dept"] == "Civilian"))
 			civ[name] = rank
 			department = 1
 		if(real_rank in nonhuman_positions)

--- a/code/game/jobs/jobs.dm
+++ b/code/game/jobs/jobs.dm
@@ -128,6 +128,53 @@ var/list/misc_positions = list(
 	"Trader",
 )
 
+var/list/all_jobs_txt = list(
+	"Captain",
+	"Head of Personnel",
+	"Head of Security",
+	"Chief Engineer",
+	"Research Director",
+	"Chief Medical Officer",
+	"Station Engineer",
+	"Atmospheric Technician",
+	"Mechanic",
+	"Medical Doctor",
+	"Geneticist",
+	"Virologist",
+//	"Psychiatrist",
+	"Paramedic",
+	"Chemist",
+	"Research Director",
+	"Scientist",
+	"Roboticist",
+	"Bartender",
+	"Botanist",
+	"Chef",
+	"Janitor",
+	"Librarian",
+	"Internal Affairs Agent",
+	"Chaplain",
+	"Clown",
+	"Mime",
+	"Assistant",
+	"Quartermaster",
+	"Cargo Technician",
+	"Shaft Miner",
+	"Warden",
+	"Detective",
+	"Security Officer",
+)
+
+var/list/departement_list = list(
+	"Command",
+	"Security",
+	"Cargo",
+	"Engineering",
+	"Medical",
+	"Science",
+	"Civilian",
+)
+
 /proc/guest_jobbans(var/job)
 	return ((job in command_positions) || (job in nonhuman_positions) || (job in security_positions))
 

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -264,6 +264,15 @@
 						//let custom jobs function as an impromptu alt title, mainly for sechuds
 						if(temp_t && modify)
 							modify.assignment = temp_t
+					if (!(temp_t in all_jobs_txt))
+						var/new_dept = input("Choose the departement this job belongs to.") as null|anything in departement_list
+						if (new_dept)
+							for (var/list/L in list(data_core.general, data_core.medical, data_core.security,data_core.locked))
+								if (L)
+									var/datum/data/record/R = find_record("name", modify.registered_name, L)
+									if (R)
+										R.fields["override_dept"] = new_dept
+
 				else
 					var/list/access = list()
 					if(is_centcom())

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -47,33 +47,33 @@
 
 	light_color = LIGHT_COLOR_BLUE
 
-	proc/is_centcom()
-		return istype(src, /obj/machinery/computer/card/centcom)
+/obj/machinery/computer/card/proc/is_centcom()
+	return istype(src, /obj/machinery/computer/card/centcom)
 
-	proc/is_authenticated()
-		return scan ? check_access(scan) : 0
+/obj/machinery/computer/card/proc/is_authenticated()
+	return scan ? check_access(scan) : 0
 
-	proc/get_target_rank()
-		return modify && modify.assignment ? modify.assignment : "Unassigned"
+/obj/machinery/computer/card/proc/get_target_rank()
+	return modify && modify.assignment ? modify.assignment : "Unassigned"
 
-	proc/format_jobs(list/jobs)
-		var/list/formatted = list()
-		for(var/job in jobs)
-			formatted.Add(list(list(
-				"display_name" = replacetext(job, " ", "&nbsp;"),
-				"target_rank" = get_target_rank(),
-				"job" = job)))
+/obj/machinery/computer/card/proc/format_jobs(list/jobs)
+	var/list/formatted = list()
+	for(var/job in jobs)
+		formatted.Add(list(list(
+			"display_name" = replacetext(job, " ", "&nbsp;"),
+			"target_rank" = get_target_rank(),
+			"job" = job)))
 
-		return formatted
+	return formatted
 
-	proc/format_card_skins(list/card_skins)
-		var/list/formatted = list()
-		for(var/skin in card_skins)
-			formatted.Add(list(list(
-				"display_name" = replacetext(skin, " ", "&nbsp;"),
-				"skin" = skin)))
+/obj/machinery/computer/card/proc/format_card_skins(list/card_skins)
+	var/list/formatted = list()
+	for(var/skin in card_skins)
+		formatted.Add(list(list(
+			"display_name" = replacetext(skin, " ", "&nbsp;"),
+			"skin" = skin)))
 
-		return formatted
+	return formatted
 
 /obj/machinery/computer/card/verb/eject_id()
 	set category = "Object"

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -268,7 +268,7 @@
 						var/new_dept = input("Choose the departement this job belongs to.") as null|anything in departement_list
 						if (new_dept)
 							for (var/list/L in list(data_core.general, data_core.medical, data_core.security,data_core.locked))
-								if (L)
+								if (L.len)
 									var/datum/data/record/R = find_record("name", modify.registered_name, L)
 									if (R)
 										R.fields["override_dept"] = new_dept


### PR DESCRIPTION
[content]
<s>It *should* work but when I tried to test it the Identification Computer UI bugged out on me, just not displaying anything
Which I fail to understand why as the only change I did before and after the UI bugged was to add an extra pair of parenthesis around the conditions in `obj.dm`

It's not even the Crew Manifest(s) in general that are breaking because the PDA one and the verb work properly </s>

Tested.

:cl:
- tweak: Allow the HoP to give custom titles their own categories