### PR TITLE
Wizards no longer spawn with robotic organs.

### DIFF
--- a/code/datums/gamemode/misc_gamemode_procs.dm
+++ b/code/datums/gamemode/misc_gamemode_procs.dm
@@ -103,7 +103,7 @@ proc/equip_wizard(mob/living/carbon/human/wizard_mob)
 	to_chat(wizard_mob, "You will find a list of available spells in your spell book. Choose your magic arsenal carefully.")
 	to_chat(wizard_mob, "In your pockets you will find a teleport scroll. Use it as needed.")
 	wizard_mob.mind.store_memory("<B>Remember:</B> do not forget to prepare your spells.")
-	wizard_mob.revive(0)
+	wizard_mob.revive(0) //Used to properly refresh limb icons and make prosthetic internal organs organic
 	wizard_mob.update_icons()
 	return 1
 

--- a/code/datums/gamemode/misc_gamemode_procs.dm
+++ b/code/datums/gamemode/misc_gamemode_procs.dm
@@ -103,6 +103,7 @@ proc/equip_wizard(mob/living/carbon/human/wizard_mob)
 	to_chat(wizard_mob, "You will find a list of available spells in your spell book. Choose your magic arsenal carefully.")
 	to_chat(wizard_mob, "In your pockets you will find a teleport scroll. Use it as needed.")
 	wizard_mob.mind.store_memory("<B>Remember:</B> do not forget to prepare your spells.")
+	wizard_mob.revive(0)
 	wizard_mob.update_icons()
 	return 1
 


### PR DESCRIPTION
Something's wrong with handling internal mob organs when it comes to the proc, but this is not the PR for it. Instead this fixes wizards spawning with prosthetic organs, meaning they can't take EMP or else they'll kill themselves.
fixes #21437 
:cl:
 * bugfix: Wizards no longer spawn with prosthetic organs. Now you can take EMP again.