### PR TITLE
Cult Balance of the Month - February

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult.dm
@@ -92,7 +92,7 @@ var/veil_thickness = CULT_PROLOGUE
 	var/living_cultists = 0
 	var/living_noncultists = 0
 	for (var/mob/living/L in player_list)
-		if (issilicon(L))
+		if (issilicon(L)||isborer(L))
 			continue
 		if (L.stat != DEAD)
 			if (iscultist(L))

--- a/code/datums/gamemode/factions/bloodcult/bloodcult.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult.dm
@@ -92,6 +92,8 @@ var/veil_thickness = CULT_PROLOGUE
 	var/living_cultists = 0
 	var/living_noncultists = 0
 	for (var/mob/living/L in player_list)
+		if (issilicon(L))
+			continue
 		if (L.stat != DEAD)
 			if (iscultist(L))
 				living_cultists++

--- a/code/datums/gamemode/factions/bloodcult/bloodcult.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult.dm
@@ -78,6 +78,7 @@ var/veil_thickness = CULT_PROLOGUE
 		else
 			qdel(B)
 			message_admins("Blood Cult: A blood stone was somehow spawned in nullspace. It has been destroyed.")
+			log_admin("Blood Cult: A blood stone was somehow spawned in nullspace. It has been destroyed.")
 
 /proc/cult_risk(var/mob/M)//too many conversions/soul-stoning might bring the cult to the attention of Nanotrasen prematurely
 	var/datum/faction/bloodcult/cult = find_active_faction_by_type(/datum/faction/bloodcult)
@@ -102,13 +103,15 @@ var/veil_thickness = CULT_PROLOGUE
 
 	if (risk > 0)
 		if(prob(risk))
-			message_admins("With a chance of [risk]%, the cult's activities have been prematurely exposed.")
+			message_admins("With a chance of [risk]% ([living_cultists] Cultists vs [living_noncultists] non-cultists), the cult's activities have been prematurely exposed.")
+			log_admin("With a chance of [risk]% ([living_cultists] Cultists vs [living_noncultists] non-cultists), the cult's activities have been prematurely exposed.")
 			cult.warning = TRUE
 			command_alert(/datum/command_alert/cult_detected)
 		else
-			message_admins("With a chance of [risk]%, the cult's activities have avoided raising suspicion for now...")
+			message_admins("With a chance of [risk]% ([living_cultists] Cultists vs [living_noncultists] non-cultists), the cult's activities have avoided raising suspicion for now...")
+			log_admin("With a chance of [risk]% ([living_cultists] Cultists vs [living_noncultists] non-cultists), the cult's activities have avoided raising suspicion for now...")
 			if (M)
-				to_chat(M,"<span class='warning'>Be mindful, overzealous conversions and soul trapping will bring attention to us unwanted attention. You should focus on the objective with your current force.</span>")
+				to_chat(M,"<span class='warning'>Be mindful, overzealous conversions and soul trapping will bring us unwanted attention. You should focus on the objective with your current force.</span>")
 
 
 //CULT_PROLOGUE		Default thickness, only communication and raise structure runes enabled
@@ -140,7 +143,7 @@ var/veil_thickness = CULT_PROLOGUE
 	return cult_win
 
 /datum/faction/bloodcult/proc/fail()
-	if (cult_win || veil_thickness == CULT_MENDED)
+	if (veil_thickness == CULT_MENDED || veil_thickness == CULT_EPILOGUE)
 		return
 	progress(CULT_MENDED)
 

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
@@ -1354,6 +1354,8 @@ var/list/bloodstone_list = list()
 	return
 
 /obj/structure/cult/bloodstone/takeDamage(var/damage)
+	if(veil_thickness == CULT_EPILOGUE)
+		return
 	var/backup = (health > (2*maxHealth/3)) + (health > (maxHealth/3))
 	health -= damage
 	if (health <= 0)

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
@@ -325,6 +325,8 @@
 /obj/structure/cult/altar/MouseDropTo(var/atom/movable/O, var/mob/user)
 	if (altar_task)
 		return
+	if (!istype(O))
+		return
 	if (!O.anchored && (istype(O, /obj/item) || user.get_active_hand() == O))
 		if(!user.drop_item(O))
 			return

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
@@ -735,6 +735,8 @@
 
 /datum/rune_spell/conversion/cast()
 	var/obj/effect/rune/R = spell_holder
+	var/mob/converter = activator//trying to fix logs showing the converter as *null*
+
 	R.one_pulse()
 	var/turf/T = R.loc
 	var/list/targets = list()
@@ -948,8 +950,8 @@
 				conversion.icon_state = ""
 				flick("rune_convert_success",conversion)
 				abort(RITUALABORT_CONVERT)
-				message_admins("BLOODCULT: [key_name(victim)] has been converted by [key_name(activator)].")
-				log_admin("BLOODCULT: [key_name(victim)] has been converted by [key_name(activator)].")
+				message_admins("BLOODCULT: [key_name(victim)] has been converted by [key_name(converter)].")
+				log_admin("BLOODCULT: [key_name(victim)] has been converted by [key_name(converter)].")
 				return
 			if (CONVERSION_NOCHOICE)
 				to_chat(victim, "<span class='danger'>As you stood there, unable to make a choice for yourself, the Geometer of Blood ran out of patience and chose for you.</span>")
@@ -961,8 +963,8 @@
 					if ("Banned")
 						to_chat(victim, "The conversion automatically failed due to your account being banned from the cultist role.")
 
-		message_admins("BLOODCULT: [key_name(victim)] refused conversion by [key_name(activator)], and died.")
-		log_admin("BLOODCULT: [key_name(victim)] refused conversion by [key_name(activator)], and died.")
+		message_admins("BLOODCULT: [key_name(victim)] refused conversion by [key_name(converter)], and died.")
+		log_admin("BLOODCULT: [key_name(victim)] refused conversion by [key_name(converter)], and died.")
 
 		playsound(R, 'sound/effects/convert_failure.ogg', 75, 0, -4)
 		conversion.icon_state = ""

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_tattoos.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_tattoos.dm
@@ -115,6 +115,7 @@ var/list/blood_communion = list()
 	H.status_flags &= ~CANKNOCKDOWN
 	H.status_flags &= ~CANPARALYSE
 	H.status_flags &= ~PACIFIABLE
+	H.fixblood()
 	H.regenerate_icons()
 
 /datum/cult_tattoo/memorize

--- a/code/datums/gamemode/objectives/bloodcult.dm
+++ b/code/datums/gamemode/objectives/bloodcult.dm
@@ -80,18 +80,24 @@
 
 /datum/objective/bloodcult_sacrifice/proc/find_target()
 	var/list/possible_targets = list()
+	var/list/backup_targets = list()
 	for(var/mob/living/carbon/human/player in player_list)
-		if(player.z != map.zMainStation)//We only look for people currently aboard the station
+		var/turf/player_turf = get_turf(player)
+		if(player_turf.z != STATION_Z)//We only look for people currently aboard the station
 			continue
-		if (iscultist(player)) // Edit of 08/01/19 : no longer able to sacrifice cultists
-			continue
-		//They may be dead, but we only need their flesh
-		possible_targets += player
+		if (iscultist(player)) // If there are only cultists left on the station, we'll have to sacrifice one of them
+			backup_targets += player
+		else
+			//They may be dead, but we only need their flesh
+			possible_targets += player
 
-	if(!possible_targets.len)
-		message_admins("Blood Cult: Could not find a suitable sacrifice target. Trying again in a minute.")
-		log_admin("Blood Cult: Could not find a suitable sacrifice target. Trying again in a minute.")
-		return null
+	if(possible_targets.len <= 0)
+		if (backup_targets.len <= 0)
+			message_admins("Blood Cult: Could not find a suitable sacrifice target. Trying again in a minute.")
+			log_admin("Blood Cult: Could not find a suitable sacrifice target. Trying again in a minute.")
+			return null
+		else
+			return pick(backup_targets)
 
 	return pick(possible_targets - failed_targets)
 
@@ -193,7 +199,7 @@
 /datum/objective/bloodcult_feast
 	explanation_text = "The Feast: This is your victory, you may take part in the celebrations of a work well done."
 	name = "Blood Cult: Epilogue"
-	var/timer = 300 SECONDS
+	var/timer = 200 SECONDS
 
 /datum/objective/bloodcult_feast/PostAppend()
 	message_admins("Blood Cult: The cult has won.")

--- a/code/datums/gamemode/objectives/bloodcult.dm
+++ b/code/datums/gamemode/objectives/bloodcult.dm
@@ -6,6 +6,7 @@
 
 /datum/objective/bloodcult_reunion/PostAppend()
 	message_admins("Blood Cult: A cult dedicated to Nar-Sie has formed aboard the station.")
+	log_admin("Blood Cult: A cult dedicated to Nar-Sie has formed aboard the station.")
 	return TRUE
 
 /datum/objective/bloodcult_reunion/IsFulfilled()
@@ -24,6 +25,7 @@
 /datum/objective/bloodcult_followers/PostAppend()
 	explanation_text = "The Followers: Perform the conversion ritual on [convert_target] crew members."
 	message_admins("Blood Cult: ACT I has begun.")
+	log_admin("Blood Cult: ACT I has begun.")
 	return TRUE
 
 /datum/objective/bloodcult_followers/IsFulfilled()
@@ -50,6 +52,7 @@
 			target_role = ", the cultist,"
 		explanation_text = "The Sacrifice: Nar-Sie requires the flesh of [sacrifice_target.real_name][target_role] to breach reality. Sacrifice them at an altar using a cult blade."
 		message_admins("Blood Cult: ACT II has begun, the sacrifice target is [sacrifice_target.real_name][target_role].")
+		log_admin("Blood Cult: ACT II has begun, the sacrifice target is [sacrifice_target.real_name][target_role].")
 		var/datum/faction/bloodcult/cult = faction
 		cult.target_change = TRUE
 		return TRUE
@@ -67,6 +70,7 @@
 			target_role = ", the cultist,"
 		explanation_text = "The Sacrifice: Nar-Sie requires the flesh of [sacrifice_target.real_name][target_role] to breach reality. Sacrifice them at an altar using a cult blade."
 		message_admins("Blood Cult: The cult didn't sacrifice their target in time, a new target has been assigned, the new sacrifice target is [sacrifice_target.real_name][target_role].")
+		log_admin("Blood Cult: The cult didn't sacrifice their target in time, a new target has been assigned, the new sacrifice target is [sacrifice_target.real_name][target_role].")
 		var/datum/faction/bloodcult/cult = faction
 		cult.target_change = TRUE
 		return TRUE
@@ -86,6 +90,7 @@
 
 	if(!possible_targets.len)
 		message_admins("Blood Cult: Could not find a suitable sacrifice target. Trying again in a minute.")
+		log_admin("Blood Cult: Could not find a suitable sacrifice target. Trying again in a minute.")
 		return null
 
 	return pick(possible_targets - failed_targets)
@@ -115,6 +120,7 @@
 	target_bloodspill += rand(-20,20)
 	explanation_text = "The Blood Bath: The blood stones have risen. Spill blood accross [target_bloodspill] of the station's floors to fill them up before the crew destroys them all."
 	message_admins("Blood Cult: ACT III has begun. The cult has to spill blood over [target_bloodspill] floor tiles, out of the station's [floor_count] floor tiles.")
+	log_admin("Blood Cult: ACT III has begun. The cult has to spill blood over [target_bloodspill] floor tiles, out of the station's [floor_count] floor tiles.")
 	return TRUE
 
 /datum/objective/bloodcult_bloodbath/IsFulfilled()
@@ -167,12 +173,14 @@
 			B.holomap_datum.initialize_holomap(B.loc)
 		else
 			message_admins("Blood Cult: A blood stone was somehow spawned in nullspace. It has been destroyed.")
+			log_admin("Blood Cult: A blood stone was somehow spawned in nullspace. It has been destroyed.")
 			qdel(B)
 
 	spawn()
 		anchor.dance_start()//the dance starts once, and only ends for good when Nar-Sie rises or the anchor is destroyed first.
 
 	message_admins("Blood Cult: ACT IV has begun.")
+	log_admin("Blood Cult: ACT IV has begun.")
 	return TRUE
 
 /datum/objective/bloodcult_tearinreality/IsFulfilled()
@@ -189,6 +197,7 @@
 
 /datum/objective/bloodcult_feast/PostAppend()
 	message_admins("Blood Cult: The cult has won.")
+	log_admin("Blood Cult: The cult has won.")
 	spawn (timer)
 		var/datum/faction/bloodcult/cult = faction
 		cult.cult_win = TRUE

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -315,8 +315,19 @@ var/global/list/whitelisted_species = list("Human")
 		"eyes" =     /datum/organ/internal/eyes
 		)
 
+	cold_level_1 = 210 //Default 220 - Lower is better
+	cold_level_2 = 190 //Default 200
+	cold_level_3 = 110 //Default 120
+
+	heat_level_1 = 380 //Default 360 - Higher is better
+	heat_level_2 = 420 //Default 400
+	heat_level_3 = 1200 //Default 1000
+
 	flags = NO_PAIN
-	anatomy_flags = HAS_SKIN_TONE | HAS_LIPS | HAS_UNDERWEAR | CAN_BE_FAT | NO_BLOOD
+	anatomy_flags = HAS_SKIN_TONE | HAS_LIPS | HAS_UNDERWEAR | CAN_BE_FAT | HAS_SWEAT_GLANDS
+
+	blood_color = "#272727"
+	flesh_color = "#C3C1BE"
 
 /datum/species/manifested/handle_death(var/mob/living/carbon/human/H)
 	H.dust()


### PR DESCRIPTION
Surely I can afford to spend an hour every month to take care of bugs and shit. Right?

Fixes #21149

:cl:
* experiment: Cult Balance of the Month! - February
* bugfix: The cult can no longer lose AFTER Nar-Sie has risen by having the remaining bloodstones smashed down. Bloodstones can no longer take damage after that point either.
* tweak: Pale beings, aka manifested ghosts, can now sweat! (they can finally regulate their body temperature and will no longer die from standing too long near a space heater (or after getting away from a forge))
* tweak: They can also tolerate temperatures up to 20 degrees higher or lower than regular humans.
* tweak: Lastly they now have black blood flowing in their veins, fixing the inconsistency where those made from tattoos had blood while those resurrected by a rune had none. (This also means they can die of blood loss now, be careful)
* tweak: Fixed a few harmless runtimes and added some additional admin logs.
* tweak: Silicons no longer count as either living cultists or non-cultists as far as early cult announcements are concerned (and neither do borers, because organic pAIs lmao).
* bugfix: Players in mechas, closets, disposals, etc, are no longer exempt from getting chosen as sacrifice targets.
* tweak: Cultists may again be sacrifice targets IF there are no other eligible non-cultists targets aboard the station.
* tweak: Reduced the duration of the Epilogue by a third.