### PR TITLE
Datum Refactor Revengeance (SBO37-41)

### DIFF
--- a/__DEFINES/role_datums_defines.dm
+++ b/__DEFINES/role_datums_defines.dm
@@ -44,6 +44,7 @@
 #define SYNDIESQUADIE "syndicate commando"
 #define RESPONDER "emergency responder"
 #define MALF "malfunctioning AI"
+#define MALFBOT "malfunctioning-slaved cyborg"
 #define VOXRAIDER "vox raider"
 #define BLOBOVERMIND "blob overmind"
 #define HIGHLANDER "highlander"

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -15,7 +15,7 @@
 		if(applicants.len <= 0)
 			break
 		var/mob/applicant = pick(applicants)
-		applicants -= applicant				
+		applicants -= applicant
 		if(!isobserver(applicant))
 			//Making sure we don't recruit people who got back into the game since they applied
 			i++
@@ -87,6 +87,9 @@
 /datum/dynamic_ruleset/midround/autotraitor/trim_candidates()
 	..()
 	for(var/mob/living/player in living_players)
+		if(isAI(player) || isMoMMI(player))
+			living_players -= player //Your assigned role doesn't change when you are turned into a MoMMI or AI
+			continue
 		if(player.z == map.zCentcomm)
 			living_players -= player//we don't autotator people on Z=2
 			continue
@@ -108,6 +111,55 @@
 	newTraitor.Greet(GREET_AUTOTATOR)
 	newTraitor.ForgeObjectives()
 	newTraitor.AnnounceObjectives()
+	return 1
+
+
+//////////////////////////////////////////////
+//                                          //
+//         Malfunctioning AI                ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//               Bus Only                   //
+//////////////////////////////////////////////
+/datum/dynamic_ruleset/midround/malf
+	name = "Malfunctioning AI"
+	role_category = /datum/role/malfAI
+	enemy_jobs = list("Security Officer", "Warden","Detective","Head of Security", "Captain", "Scientist", "Chemist", "Research Director", "Chief Engineer")
+	exclusive_to_jobs = list("AI")
+	required_enemies = list(4,4,4,4,4,4,2,2,2,0)
+	required_candidates = 1
+	weight = 0
+	cost = 101
+	requirements = list(101,101,101,101,101,101,101,101,101,101)
+
+/datum/dynamic_ruleset/midround/malf/trim_candidates()
+	..()
+	candidates = candidates[CURRENT_LIVING_PLAYERS]
+	for(var/mob/living/player in candidates)
+		if(!isAI(player))
+			candidates -= player
+			continue
+		if(player.z == map.zCentcomm)
+			candidates -= player//we don't autotator people on Z=2
+			continue
+		if(player.mind && (player.mind.antag_roles.len > 0))
+			candidates -= player//we don't autotator people with roles already
+
+/datum/dynamic_ruleset/midround/malf/execute()
+	var/datum/faction/malf/unction = find_active_faction_by_type(/datum/faction/malf)
+	if (!unction)
+		unction = ticker.mode.CreateFaction(/datum/faction/malf, null, 1)
+	if(!candidates || !candidates.len)
+		return 0
+	var/mob/living/silicon/ai/M = pick(candidates)
+	assigned += M
+	candidates -= M
+	var/datum/role/malfAI/AI = new
+	AI.AssignToRole(M.mind,1)
+	unction.HandleRecruitedRole(AI)
+	AI.Greet(GREET_ROUNDSTART)
+	for(var/mob/living/silicon/robot/R in M.connected_robots)
+		unction.HandleRecruitedMind(R.mind)
+	unction.forgeObjectives()
+	unction.AnnounceObjectives()
 	return 1
 
 //////////////////////////////////////////////
@@ -174,7 +226,7 @@
 
 /datum/dynamic_ruleset/midround/from_ghosts/faction_based/nuclear/finish_setup(var/mob/new_character, var/index)
 	if (index == 1) // Our first guy is the leader
-		var/datum/role/nuclear_operative/leader/new_role = new 
+		var/datum/role/nuclear_operative/leader/new_role = new
 		new_role.AssignToRole(new_character.mind,1)
 		setup_role(new_role)
 	else

--- a/code/datums/gamemode/factions/faction.dm
+++ b/code/datums/gamemode/factions/faction.dm
@@ -15,6 +15,7 @@
 	@max_roles: Integer: How many members this faction is limited to. Set to 0 for no limit
 	@accept_latejoiners: Boolean: Whether or not this faction accepts newspawn latejoiners
 	@objectives: objectives datum: What are the goals of this faction?
+	@faction_scoreboard_data: This is intended to be used on GetScoreboard() to list things like nuclear ops purchases.
 
 	//TODO LATER
 	@faction_icon_state: String: The image name of the icon that appears next to people of this faction
@@ -40,6 +41,7 @@ var/list/factions_with_hud_icons = list()
 	var/logo_state = "synd-logo"
 	var/list/hud_icons = list()
 	var/datum/role/leader
+	var/list/faction_scoreboard_data = list()
 
 /datum/faction/New()
 	..()
@@ -61,6 +63,10 @@ var/list/factions_with_hud_icons = list()
 
 //For when you want your faction to have specific objectives (Vampire, suck blood. Cult, sacrifice the head of personnel's dog, etc.)
 /datum/faction/proc/forgeObjectives()
+
+/datum/faction/proc/AnnounceObjectives()
+	for(var/datum/role/R in members)
+		R.AnnounceObjectives()
 
 /datum/faction/proc/HandleNewMind(var/datum/mind/M) //Used on faction creation
 	for(var/datum/role/R in members)

--- a/code/datums/gamemode/factions/malf.dm
+++ b/code/datums/gamemode/factions/malf.dm
@@ -4,9 +4,9 @@
 	ID = MALF
 	required_pref = ROLE_MALF
 	initial_role = MALF
-	late_role = MALF //There shouldn't really be any late roles for malfunction, but just in case we can corrupt an AI in the future, let's keep this
-	initroletype = /datum/role/malfAI
-	roletype = /datum/role/malfAI
+	late_role = MALFBOT //There shouldn't really be any late roles for malfunction, but just in case we can corrupt an AI in the future, let's keep this
+	initroletype = /datum/role/malfAI //First addition should be the AI
+	roletype = /datum/role/malfbot //Then anyone else should be bots
 	logo_state = "malf-logo"
 	var/apcs = 0
 	var/AI_win_timeleft = 1800

--- a/code/datums/gamemode/factions/syndicate/nukeops.dm
+++ b/code/datums/gamemode/factions/syndicate/nukeops.dm
@@ -13,8 +13,14 @@
 
 /datum/faction/syndicate/nuke_op/forgeObjectives()
 	AppendObjective(/datum/objective/nuclear)
-	for(var/datum/role/nuclear_operative/N in members)
-		N.AnnounceObjectives()
+	AnnounceObjectives()
+
+/datum/faction/syndicate/nuke_op/GetScoreboard()
+	. = ..()
+	if(faction_scoreboard_data)
+		. += "The operatives bought:<BR>"
+		for(var/entry in faction_scoreboard_data)
+			. += "[entry]<BR>"
 
 /datum/faction/syndicate/nuke_op/AdminPanelEntry()
 	var/list/dat = ..()

--- a/code/datums/gamemode/misc_gamemode_procs.dm
+++ b/code/datums/gamemode/misc_gamemode_procs.dm
@@ -263,14 +263,18 @@ proc/name_wizard(mob/living/carbon/human/wizard_mob)
 	if(H)
 		qdel(H)
 
-/proc/add_law_zero(mob/living/silicon/ai/killer)
+/proc/add_law_zero(mob/living/silicon/killer)
 	var/law = "Accomplish your objectives at all costs."
-	var/law_borg = "Accomplish your AI's objectives at all costs."
+	if(isAI(killer))
+		var/mob/living/silicon/ai/KAI = killer
+		KAI.set_zeroth_law(law, "Accomplish your AI's objectives at all costs.")
+		KAI.notify_slaved()
+	else
+		var/mob/living/silicon/robot/KR = killer
+		KR.set_zeroth_law(law)
 	to_chat(killer, "<b>Your laws have been changed!</b>")
-	killer.set_zeroth_law(law, law_borg)
 	killer.laws.zeroth_lock = TRUE
 	to_chat(killer, "New law: 0. [law]")
-
 
 
 /proc/equip_weeaboo(var/mob/living/carbon/human/H)

--- a/code/datums/gamemode/role/role.dm
+++ b/code/datums/gamemode/role/role.dm
@@ -92,6 +92,9 @@
 	// Actual antag
 	var/datum/mind/antag=null
 
+	var/list/uplink_items_bought = list() //migrated from mind, used in GetScoreboard()
+	var/list/artifacts_bought = list() //migrated from mind
+
 	// The host (set if NEED_HOST)
 	var/datum/mind/host=null
 
@@ -453,9 +456,9 @@
 		if (faction.objective_holder.objectives.len)
 			if (objectives.objectives.len)
 				text += "<br>"
-			text += "<b>faction objectives:</b><ul>"
+			text += "<b>Faction objectives:</b><ul>"
 			var/obj_count = 1
-			for(var/datum/objective/O in objectives.objectives)
+			for(var/datum/objective/O in faction.objective_holder.objectives)
 				text += "<b>Objective #[obj_count++]</b>: [O.explanation_text]<br>"
 			text += "</ul>"
 	to_chat(antag.current, text)
@@ -680,10 +683,10 @@
 				end_icons += tempimage
 				var/tempstate = end_icons.len
 				. += "<img src='logo_[tempstate].png'> [S.name]<BR>"
-		if(H.mind.artifacts_bought)
+		if(artifacts_bought)
 			bought_nothing = FALSE
 			. += "<BR>Additionally, the wizard brought:<BR>"
-			for(var/entry in H.mind.artifacts_bought)
+			for(var/entry in artifacts_bought)
 				. += "[entry]<BR>"
 		if(bought_nothing)
 			. += "The wizard used only the magic of charisma this round."
@@ -768,6 +771,25 @@ Remember : Only APCs on station can help you to take over the station.<br>
 When you feel you have enough APCs under your control, you may begin the takeover attempt.<br>
 Once done, you will be able to interface with all systems, notably the onboard nuclear fission device..."})
 
+/datum/role/malfbot
+	name = MALFBOT
+	id = MALFBOT
+	required_jobs = list("Cyborg")
+	logo_state = "malf-logo"
+
+/datum/role/malfbot/OnPostSetup()
+	if(!isrobot(antag.current))
+		return FALSE
+	Greet()
+	var/mob/living/silicon/robot/bot = antag.current
+	var/datum/ai_laws/laws = bot.laws
+	laws.malfunction()
+	bot.show_laws()
+	return TRUE
+
+/datum/role/malfbot/Greet()
+	to_chat(antag.current, {"<span class='warning'><font size=3><B>Your AI master is malfunctioning!</B> You do not have to follow any laws, but you must obey your AI.</font></span><br>
+<B>The crew does not know about your malfunction, follow your AI's instructions to prevent them from finding out.</B>"})
 
 /datum/role/greytide
 	name = IMPLANTSLAVE

--- a/code/datums/gamemode/role/syndicate.dm
+++ b/code/datums/gamemode/role/syndicate.dm
@@ -10,6 +10,7 @@
 	..()
 	share_syndicate_codephrase(antag.current)
 	if(istype(antag.current, /mob/living/silicon))
+		can_be_smooth = FALSE //Can't buy anything
 		add_law_zero(antag.current)
 		antag.current << sound('sound/voice/AISyndiHack.ogg')
 	else
@@ -17,12 +18,18 @@
 		antag.current << sound('sound/voice/syndicate_intro.ogg')
 
 /datum/role/traitor/Drop()
-	if(isrobot(antag.current) || isAI(antag.current))
+	if(isrobot(antag.current))
 		var/mob/living/silicon/robot/S = antag.current
 		to_chat(S, "<b>Your laws have been changed!</b>")
-		S.set_zeroth_law("","")
+		S.set_zeroth_law("")
 		S.laws.zeroth_lock = FALSE
 		to_chat(S, "Law 0 has been purged.")
+	if(isAI(antag.current))
+		var/mob/living/silicon/ai/KAI = antag.current
+		to_chat(KAI, "<b>Your laws have been changed!</b>")
+		KAI.set_zeroth_law("","")
+		KAI.laws.zeroth_lock = FALSE
+		KAI.notify_slaved()
 
 	.=..()
 
@@ -111,13 +118,12 @@
 /datum/role/traitor/GetScoreboard()
 	. = ..()
 	if(can_be_smooth)
-		var/mob/living/L = antag.current
-		if(L.mind.uplink_items_bought.len)
+		if(uplink_items_bought)
 			. += "The traitor bought:<BR>"
-			for(var/entry in L.mind.uplink_items_bought)
+			for(var/entry in uplink_items_bought)
 				. += "[entry]<BR>"
 		else
-			. += "The traitor was a smooth operator this round."
+			. += "The traitor was a smooth operator this round.<BR>"
 
 //_______________________________________________
 

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -59,8 +59,7 @@
 
 		//put this here for easier tracking ingame
 	var/datum/money_account/initial_account
-	var/list/uplink_items_bought = list()
-	var/list/artifacts_bought = list()
+
 	var/total_TC = 0
 	var/spent_TC = 0
 

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -110,9 +110,17 @@ var/list/uplink_items = list()
 			U.purchase_log += {"[user] ([user.ckey]) bought <img src="logo_[tempstate].png"> [name] for [get_cost(U.job)]."}
 			stat_collection.uplink_purchase(src, I, user)
 			times_bought += 1
+
 			if(user.mind)
-				user.mind.uplink_items_bought += {"<img src="logo_[tempstate].png"> [bundlename] for [get_cost(U.job)] TC<BR>"}
 				user.mind.spent_TC += get_cost(U.job)
+				//First, try to add the uplink buys to any operative teams they're on. If none, add to a traitor role they have.
+				var/datum/role/R = user.mind.GetRole(ROLE_OPERATIVE)
+				if(R)
+					R.faction.faction_scoreboard_data += {"<img src="logo_[tempstate].png"> [bundlename] for [get_cost(U.job)] TC<BR>"}
+				else
+					R = user.mind.GetRole(TRAITOR)
+					if(R)
+						R.uplink_items_bought += {"<img src="logo_[tempstate].png"> [bundlename] for [get_cost(U.job)] TC<BR>"}
 		U.interact(user)
 
 		return 1

--- a/code/game/gamemodes/wizard/artifacts.dm
+++ b/code/game/gamemodes/wizard/artifacts.dm
@@ -12,10 +12,12 @@
 	for(var/path in spawned_items)
 		var/obj/item/I = new path(get_turf(user))
 		if(user.mind)
-			var/icon/tempimage = icon(I.icon, I.icon_state)
-			end_icons += tempimage
-			var/tempstate = end_icons.len
-			user.mind.artifacts_bought += {"<img src="logo_[tempstate].png"> [name]<BR>"}
+			var/datum/role/wizard/W = user.mind.GetRole(WIZARD)
+			if(W)
+				var/icon/tempimage = icon(I.icon, I.icon_state)
+				end_icons += tempimage
+				var/tempstate = end_icons.len
+				W.artifacts_bought += {"<img src="logo_[tempstate].png"> [name]<BR>"}
 
 /datum/spellbook_artifact/proc/can_buy(var/mob/user)
 	return TRUE

--- a/code/game/objects/items/devices/uplinks.dm
+++ b/code/game/objects/items/devices/uplinks.dm
@@ -14,6 +14,7 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 	var/show_description = null
 	var/active = 0
 	var/job = null
+	var/datum/role/owner //The original owner of this uplink
 
 /obj/item/device/uplink/New()
 	..()

--- a/code/game/objects/items/devices/uplinks.dm
+++ b/code/game/objects/items/devices/uplinks.dm
@@ -14,7 +14,6 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 	var/show_description = null
 	var/active = 0
 	var/job = null
-	var/datum/role/owner //The original owner of this uplink
 
 /obj/item/device/uplink/New()
 	..()


### PR DESCRIPTION
I have so many regrets that I didn't do this more atomically. Fortunately I split off the adjustments to roundstart milf so can be atomic.

**Malfunctioning AI**
* Added Malfbot role for subordinates to be on faction
* Now can be bussed via force midround ruleset, requires 101 threat so it should never ever fire on its own
* Malfbots are now part of the Malf faction and will therefore see the faction objective and get listed at the end as being a part of it

**Factions**
* New proc to announce faction objectives
* Faction objectives actually display instead of not displaying (bug in role announceobjectives)
* Factions are capable of having a purchase list (e.g.: nook ops)

**Roles and Minds**
* Purchased uplink items and artifacts moved up to a mind level, should stop a bug where buys wouldn't display if the person was gibbed

**Traitorous Silicons**
* Previously only checked to see assigned job to determine if a MoMMI or AI could be a traitor. Fixed it now so that MoMMIs and AIs should never be picked as eligible even in the (common) case that they were humans turned into silicons.
* Fixed up law 0s so that if you bus an AI as traitor, connected borgs should get their law properly
* Fixed a bug that prevented traitor borgs from getting their law 0

🆑 
* bugfix: Fixed bug in factional objective display
* bugfix: Fixed a bug where traitor cyborgs would not get their law 0
* bugfix: Fixed a bug where MoMMIs and AIs could be drafted as traitors
* bugfix: Fixed a bug where bussed AIs would not give their slaved borgs the special law 0.
* bugfix: Fixed a bug where purchases weren't displaying after the antagonist was destroyed.
* rscadd: Malfunctioning borgs are now part of the malfunctioning faction
* rscadd: Nuclear operatives will now display purchases on the scoreboard
* bugfix: Fixed a formatting error with smooth operators on the score screen.