### PR TITLE
Refactors Cyborg Roundstart Spawn (SBO42)

### DIFF
--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -369,13 +369,16 @@ var/datum/controller/gameticker/ticker
 			if(player.mind.assigned_role=="AI")
 				player.close_spawn_windows()
 				player.AIize()
+			else if(player.mind.assigned_role=="Cyborg")
+				player.create_roundstart_cyborg()
+
 			else if(!player.mind.assigned_role)
 				continue
 			else
 
 				var/mob/living/carbon/human/new_character = player.create_character()
 				switch(new_character.mind.assigned_role)
-					if("MODE","Cyborg","Mobile MMI","Trader")
+					if("MODE","Mobile MMI","Trader")
 						//No injection
 					else
 						data_core.manifest_inject(new_character)

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -438,14 +438,10 @@ var/global/datum/controller/occupations/job_master
 		alt_title = H.mind.role_alt_title
 
 		switch(rank)
-			if("Cyborg")
-				spawn(20)//We need to be absolutely certain the borg is made after AI for law sync reasons.
-					H.Robotize()
-				return 1
 			if("Mobile MMI")
 				H.MoMMIfy()
 				return 1
-			if("AI","Clown")	//don't need bag preference stuff!
+			if("AI","Clown","Cyborg")	//don't need bag preference stuff!
 				if(rank=="Clown") // Clowns DO need to breathe, though - N3X
 					H.species.equip(H)
 			else

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -202,6 +202,18 @@ obj/item/device/mmi/Destroy()
 	locked = 1
 	return
 
+/obj/item/device/mmi/proc/create_identity(var/datum/preferences/P)
+	brainmob = new(src)
+	brainmob.dna = new()
+	brainmob.dna.ResetUI()
+	brainmob.dna.ResetSE()
+	brainmob.name = P.real_name
+	brainmob.real_name = P.real_name
+	brainmob.container = src
+	name = "Man-Machine Interface: [brainmob.real_name]"
+	icon_state = "mmi_full"
+	locked = 1
+
 /obj/item/device/mmi/radio_enabled
 	name = "Radio-enabled Man-Machine Interface"
 	desc = "The Warrior's bland acronym, MMI, obscures the true horror of this monstrosity. This one comes with a built-in radio."

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -564,8 +564,8 @@ Round Duration: [round(hours)]h [round(mins)]m<br>"}
 		spawn_loc = sloc.loc
 		break
 	if(!spawn_loc)
-		spawn_loc = loc //If we absolutely can't find spawns
-		message_admins("WARNING! Couldn't find a spawn location for a cyborg. They will spawn in the new player cube.")
+		spawn_loc = pick(latejoin) //If we absolutely can't find spawns
+		message_admins("WARNING! Couldn't find a spawn location for a cyborg. They will spawn at the arrival shuttle.")
 
 	//Create the robot and move over prefs
 	var/mob/living/silicon/robot/new_character = new(spawn_loc)


### PR DESCRIPTION
Previously we made a human and then borgified it after 2 seconds, which sucked for many reasons, and with datums it actually caused the bug it was supposed to fix.

This new refactor not only fixes the bug but reduces complexity and load by removing the need to go through all kinds of preferences and initializations for a human that we won't even be using.

🆑 
* tweak: Roundstart cyborgs will now be cyborgs right away, instead of humans for 2 seconds.
* bugfix: Roundstart traitor cyborgs will be properly assigned silicon friendly traitor objectives and hear the proper syndicate intro ogg.