### PR TITLE
Fixes Midround Weeb (SBO43)

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -188,7 +188,7 @@
 //                                          //
 //////////////////////////////////////////////
 
-/datum/dynamic_ruleset/midround/from_ghosts/weeabo
+/datum/dynamic_ruleset/midround/from_ghosts/weeaboo
 	name = "crazed weeaboo attack"
 	role_category = /datum/role/weeaboo
 	enemy_jobs = list("Security Officer","Detective", "Warden", "Head of Security", "Captain")


### PR DESCRIPTION
This was done entirely in the web editor!

🆑 
* bugfix: Fixes a bug where midround crazed weeaboo was undefined due to a typo.