### PR TITLE
Fixes empty snacks not dropping properly

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -109,7 +109,6 @@
 	if(!reagents.total_volume)	//Are we done eating (determined by the amount of reagents left, here 0)
 		//This is mostly caused either by "persistent" food items or spamming
 		to_chat(user, "<span class='notice'>There's nothing left of \the [src]!</span>")
-		M.drop_from_inventory(src)	//Drop our item before we delete it
 		qdel(src)
 		return 0
 


### PR DESCRIPTION
Empty snacks, when fed to other mobs, will no longer incorrectly try to drop from the target mob. Item dropping is already handled in `item/Destroy`.

[bugfix]