### PR TITLE
Heir to the Throne

### DIFF
--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -182,6 +182,7 @@ var/datum/controller/gameticker/ticker
 	create_characters() //Create player characters and transfer them
 	collect_minds()
 	equip_characters()
+	job_master.succession()
 	current_state = GAME_STATE_PLAYING
 	// Update new player panels so they say join instead of ready up.
 	for(var/mob/new_player/player in player_list)
@@ -389,18 +390,11 @@ var/datum/controller/gameticker/ticker
 			ticker.minds += player.mind
 
 /datum/controller/gameticker/proc/equip_characters()
-	var/captainless=1
 	for(var/mob/living/carbon/human/player in player_list)
 		if(player && player.mind && player.mind.assigned_role)
-			if(player.mind.assigned_role == "Captain")
-				captainless=0
 			if(player.mind.assigned_role != "MODE")
 				job_master.EquipRank(player, player.mind.assigned_role, 0)
 				EquipCustomItems(player)
-	if(captainless)
-		for(var/mob/M in player_list)
-			if(!istype(M,/mob/new_player))
-				to_chat(M, "Captainship not forced on anyone.")
 
 	for(var/mob/M in player_list)
 		if(!istype(M,/mob/new_player))

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -10,9 +10,9 @@ var/global/datum/controller/occupations/job_master
 
 	var/list/crystal_ball = list() //This should be an assoc. list. Job = # of players ready. Configured by predict_manifest() in obj.dm
 
-	var/list/order_of_succession = list(list("Head of Personnel","Head of Security"),
+	var/list/order_of_succession = list("Head of Personnel","Head of Security",
 										list("Chief Engineer","Research Director","Chief Medical Officer"),
-										"Internal Affairs Agent","Warden","Security Officer","Quartermaster","Chef","Chaplain","Clown")
+										"Warden","Security Officer")
 
 
 /datum/controller/occupations/proc/SetupOccupations(var/faction = "Station")


### PR DESCRIPTION
![htt](https://user-images.githubusercontent.com/9782036/51959858-f7b40d80-241b-11e9-8add-6cfe2a2fd88e.png)

At roundstart, if there is no captain, one player is moved to the captain spawnpoint.

This order is entirely negotiable. Here's the current succession order
* Head of Personnel
* Head of Security
* Randomly From: Unimplanted Heads of Staff (CE, CMO, RD)
* Warden
* Security Officer

If there are multiples of the same role (e.g.: two officers), it picks one at random.
If there is absolutely no job from that list (e.g.: deadpop with some engineering, science, and a bridge officer), no one is made acting captain.

🆑 
* rscadd: An acting captain will now be moved to the captain's office at roundstart.