### PR TITLE
Fixing roundstart clowns having their slot name on the manifest instead of their chosen name

### DIFF
--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -321,7 +321,7 @@
 				else
 					H.equip_or_collect(new /obj/item/clothing/under/rank/clown(H), slot_w_uniform)
 					H.equip_or_collect(new /obj/item/clothing/shoes/clown_shoes(H), slot_shoes)
-		fully_replace_character_name(H.real_name,pick(clown_names))
+		H.fully_replace_character_name(H.real_name,pick(clown_names))
 		H.dna.real_name = H.real_name
 		H.rename_self("clown")
 		return 1

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -321,7 +321,7 @@
 				else
 					H.equip_or_collect(new /obj/item/clothing/under/rank/clown(H), slot_w_uniform)
 					H.equip_or_collect(new /obj/item/clothing/shoes/clown_shoes(H), slot_shoes)
-		H.real_name = pick(clown_names)
+		fully_replace_character_name(H.real_name,pick(clown_names))
 		H.dna.real_name = H.real_name
 		H.rename_self("clown")
 		return 1


### PR DESCRIPTION
Fixes #21462

:cl:
* bugfix: Roundstart clowns have their name properly updated on the manifest when they choose it, instead of it being their character slot name.