### PR TITLE
"Grandmaster" Wiz/Cult Concept

### DIFF
--- a/__DEFINES/spell_defines.dm
+++ b/__DEFINES/spell_defines.dm
@@ -5,6 +5,7 @@
 #define Z2NOCAST		8	//if this is added, the spell can't be cast at centcomm
 #define STATALLOWED		16	//if set, the user doesn't have to be conscious to cast. Required for ghost spells
 #define IGNOREPREV		32	//if set, each new target does not overlap with the previous one
+#define GRANDMASTER		64  //is the cult grandmaster allowed to learn this?
 //The following flags only affect different types of spell, and therefore overlap
 //Targeted spells
 #define INCLUDEUSER		64	//does the spell include the caster in its target selection?

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
@@ -112,3 +112,41 @@
 	newWeeaboo.ForgeObjectives()
 	newWeeaboo.AnnounceObjectives()
 	return 1
+
+//////////////////////////////////////////////
+//                                          //
+//      CULT GRANDMASTER (SOLOCULT)         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//                                          //
+//////////////////////////////////////////////
+
+/datum/dynamic_ruleset/latejoin/grandmaster
+	name = "Cult Grandmaster"
+	role_category = /datum/role/cultist
+	enemy_jobs = list("Security Officer","Detective", "Warden", "Head of Security", "Captain")
+	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
+	required_candidates = 1
+	weight = 1
+	cost = 50
+	requirements = list(90,90,70,40,30,20,10,10,10,10)
+
+/datum/dynamic_ruleset/latejoin/grandmaster/acceptable(var/population=0,var/threat=0)
+	if(wizardstart.len == 0)
+		log_admin("Cannot accept Grandmaster ruleset. Couldn't find any wizard spawn points.")
+		message_admins("Cannot accept Grandmaster ruleset. Couldn't find any wizard spawn points.")
+		return 0
+	if (find_active_faction_by_type(/datum/faction/bloodcult))
+		message_admins("Rejected Grandmaster ruleset. There was already a blood cult.")
+		return 0
+
+	return ..()
+
+/datum/dynamic_ruleset/latejoin/grandmaster/execute()
+	var/datum/faction/bloodcult/cult = ticker.mode.CreateFaction(/datum/faction/bloodcult, null, 1)
+	var/mob/M = pick(candidates)
+	assigned += M
+	candidates -= M
+	var/datum/role/cultist/gm = new
+	gm.AssignToRole(M.mind,1)
+	cult.HandleRecruitedRole(gm)
+	gm.Greet(GREET_LATEJOIN)
+	return 1

--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -310,3 +310,31 @@
 			T = get_turf(src)
 			if(user.z != T.z || is_holder_of(user, src))
 				user.dust()
+
+/obj/item/clothing/suit/cultrobes/grandmaster
+	name = "grandmaster robes"
+	desc = "A set of robes for a cult kingpin."
+	icon_state = "magusred"
+	item_state = "magusred"
+	wizard_garb = TRUE
+
+/obj/item/clothing/suit/cultrobes/get_cult_power()
+	return 60
+
+/obj/item/clothing/shoes/cult/grandmaster
+	name = "grandmaster sandals"
+	icon_state = "wizard"
+	wizard_garb = TRUE
+
+/obj/item/clothing/shoes/cult/grandmaster/get_cult_power()
+	return 10
+
+/obj/item/clothing/head/culthood/grandmaster
+	name = "grandmaster hood"
+	desc = "This is an unusual grandmaster hood, because it is not pointy."
+	icon_state = "magus"
+	item_state = "magus"
+	wizard_garb = TRUE
+
+/obj/item/clothing/head/culthood/grandmaster/get_cult_power()
+	return 20

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -44,17 +44,15 @@
 	var/uses = STARTING_USES
 	var/max_uses = STARTING_USES
 
-	var/op = 1
-
-/obj/item/weapon/spellbook/admin
-	uses = 30 * Sp_BASE_PRICE
-	op = 0
-
 /obj/item/weapon/spellbook/New()
 	..()
 
 	available_artifacts = typesof(/datum/spellbook_artifact) - /datum/spellbook_artifact
 
+	populate_spells()
+	populate_artifacts()
+
+/obj/item/weapon/spellbook/proc/populate_spells()
 	for(var/type_S in getAllWizSpells())
 		var/spell/S = new type_S // Because initial doesn't work with lists
 		if (!S.holiday_required.len)
@@ -62,10 +60,28 @@
 		else if (Holiday in S.holiday_required) // Either no holiday or a very special spell for a very special day
 			available_spells += type_S // We're giving types
 
+/obj/item/weapon/spellbook/proc/populate_artifacts()
 	for(var/T in available_artifacts)
 		available_artifacts.Add(new T) //Create a new object with the path T
 		available_artifacts.Remove(T) //Remove the path from the list
-	//Result is a list full of /datum/spellbook_artifact objects
+
+/obj/item/weapon/spellbook/admin
+	uses = 30 * Sp_BASE_PRICE
+
+/obj/item/weapon/spellbook/admin/populate_spells()
+	for(var/type_S in getAllWizSpells())
+		var/spell/S = new type_S
+		available_spells += type_S //Admins don't need holiday restrictions
+
+/obj/item/weapon/spellbook/cult
+	uses = 3 * Sp_BASE_PRICE
+	max_uses = 3 * Sp_BASE_PRICE
+
+/obj/item/weapon/spellbook/cult/populate_spells()
+	for(var/type_S in getAllWizSpells())
+		var/spell/S = new type_S
+		if(S.spell_flags & GRANDMASTER)
+			available_spells += type_S
 
 /obj/item/weapon/spellbook/proc/get_available_spells()
 	return available_spells.Copy()

--- a/code/modules/spells/aoe_turf/charge.dm
+++ b/code/modules/spells/aoe_turf/charge.dm
@@ -5,7 +5,7 @@
 
 	school = "transmutation"
 	charge_max = 600
-	spell_flags = 0
+	spell_flags = GRANDMASTER
 	invocation = "DIRI CEL"
 	invocation_type = SpI_WHISPER
 	range = 0

--- a/code/modules/spells/aoe_turf/conjure/doppelganger.dm
+++ b/code/modules/spells/aoe_turf/conjure/doppelganger.dm
@@ -12,7 +12,7 @@
 	cooldown_min = 100
 	invocation = "MY O'N CLO'N"
 	invocation_type = SpI_SHOUT
-	spell_flags = NEEDSCLOTHES
+	spell_flags = NEEDSCLOTHES|GRANDMASTER
 	hud_state = "wiz_doppelganger"
 	var/spell_duration = 8 MINUTES
 

--- a/code/modules/spells/aoe_turf/conjure/forcewall.dm
+++ b/code/modules/spells/aoe_turf/conjure/forcewall.dm
@@ -7,7 +7,7 @@
 	duration = 300
 	charge_max = 10 SECONDS
 	cooldown_min = 2 SECONDS
-	spell_flags = 0
+	spell_flags = GRANDMASTER
 	range = 0
 	cast_sound = null
 

--- a/code/modules/spells/aoe_turf/conjure/snakes.dm
+++ b/code/modules/spells/aoe_turf/conjure/snakes.dm
@@ -2,6 +2,7 @@
 	name = "Become Snakes"
 	desc = "This spell transforms your body into a den of snakes."
 	user_type = USER_TYPE_WIZARD
+	spell_flags = GRANDMASTER
 
 	summon_type = list(/mob/living/simple_animal/cat/snek/wizard)
 

--- a/code/modules/spells/aoe_turf/lightbulb.dm
+++ b/code/modules/spells/aoe_turf/lightbulb.dm
@@ -5,7 +5,7 @@
 	abbreviation = "LB"
 
 	charge_max = 150
-	spell_flags = null
+	spell_flags = GRANDMASTER
 	invocation = "EAIS' RAUG"
 	invocation_type = SpI_WHISPER
 	selection_type = "range"

--- a/code/modules/spells/aoe_turf/smoke.dm
+++ b/code/modules/spells/aoe_turf/smoke.dm
@@ -6,7 +6,7 @@
 
 	school = "conjuration"
 	charge_max = 120
-	spell_flags = 0
+	spell_flags = GRANDMASTER
 	invocation = "none"
 	invocation_type = SpI_NONE
 	range = 1

--- a/code/modules/spells/general/area_teleport.dm
+++ b/code/modules/spells/general/area_teleport.dm
@@ -6,7 +6,7 @@
 
 	school = "abjuration"
 	charge_max = 600
-	spell_flags = NEEDSCLOTHES
+	spell_flags = NEEDSCLOTHES|GRANDMASTER
 	autocast_flags = AUTOCAST_NOTARGET
 	invocation = "SCYAR NILA"
 	invocation_type = SpI_SHOUT

--- a/code/modules/spells/general/lightning.dm
+++ b/code/modules/spells/general/lightning.dm
@@ -10,7 +10,7 @@
 	spell_levels = list(Sp_SPEED = 0, Sp_POWER = 0)
 	level_max = list(Sp_TOTAL = 3, Sp_SPEED = 3, Sp_POWER = 3) //each level of power grants 1 additional target.
 
-	spell_flags = NEEDSCLOTHES|WAIT_FOR_CLICK
+	spell_flags = NEEDSCLOTHES|WAIT_FOR_CLICK|GRANDMASTER
 	charge_type = Sp_RECHARGE
 	invocation = "ZAP MUTHA FUH KA"
 	invocation_type = SpI_SHOUT

--- a/code/modules/spells/general/reflect_pain.dm
+++ b/code/modules/spells/general/reflect_pain.dm
@@ -6,7 +6,7 @@
 
 	school = "necromancy"
 	charge_max = 90 SECONDS
-	spell_flags = NEEDSCLOTHES
+	spell_flags = NEEDSCLOTHES|GRANDMASTER
 
 	invocation = "KON TEAH STOV"
 	invocation_type = SpI_SHOUT

--- a/code/modules/spells/no_clothes.dm
+++ b/code/modules/spells/no_clothes.dm
@@ -4,6 +4,7 @@
 	user_type = USER_TYPE_WIZARD
 	desc = "Removes the need of wizard robes to cast powerful spells."
 	charge_max = 0
+	spell_flags = GRANDMASTER
 	level_max = list(Sp_TOTAL = 0) //Can't upgrade
 	hud_state = "wiz_noclothes"
 

--- a/code/modules/spells/targeted/feint.dm
+++ b/code/modules/spells/targeted/feint.dm
@@ -6,7 +6,7 @@
 
 	school = "transmutation"
 	charge_max = 300
-	spell_flags = NEEDSCLOTHES
+	spell_flags = NEEDSCLOTHES|GRANDMASTER
 	invocation_type = SpI_NONE
 	cooldown_min = 100 //50 deciseconds reduction per rank
 	duration = 30 //in deciseconds

--- a/code/modules/spells/targeted/projectile/firebreath.dm
+++ b/code/modules/spells/targeted/projectile/firebreath.dm
@@ -11,6 +11,7 @@
 
 	spell_flags = WAIT_FOR_CLICK
 	spell_aspect_flags = SPELL_FIRE
+	spell_flags = GRANDMASTER
 	dumbfire = 0
 
 	amt_dam_brute = 0

--- a/code/modules/spells/targeted/recall.dm
+++ b/code/modules/spells/targeted/recall.dm
@@ -6,7 +6,7 @@
 
 	school = "abjuration"
 	charge_max = 100
-	spell_flags = SELECTABLE | WAIT_FOR_CLICK
+	spell_flags = SELECTABLE | WAIT_FOR_CLICK | GRANDMASTER
 	hud_state = "wiz_bound"
 	level_max = list(Sp_TOTAL = 3, Sp_SPEED = 2, Sp_POWER = 1)
 


### PR DESCRIPTION
I talked about this idea with Deity a bit. I had some downtime so I threw about half of it together. I'll finish it if people like the idea. It could be a bus option or a normal ruleset, but either way it should cost a good chunk of threat. **So feel free to emojiocracy this up or down, I'm not gonna work on it further until I see what people think.**

tl;dnr: Latejoin ruleset sends someone to the wizard den. They only get 60 spell points (3 slots "traditional" wizard) and a very limited spell list (see below). They also get cult robes and are told to solo-raise an altar on station (easily done with robes) and raise their own cult from scratch. The true solocult experience.

Freebies: Full cult robe outfit, tesseract, tome, maybe a couple starter talismans

**Available Spells**
**Robeless:** Smoke, Break Lightbulbs, Charge, Become Snakes, Forcewall, Bound Object, Fire Breath
**Robed:** Pain Mirror, ~~Doppelganger~~, Feint, Teleport, Lightning (I am the Senate)
**Artifacts:** Mental Focus, Soul Stone Bundle, Lesser Predicted Potions, Glow Orbs, Phylactery, Prestidigitation Bundle, Summon Identity, Grandmaster's Robes

The idea behind these spells is, to quote Deity
>"If a solocultist joins late, I want him to be stealthy, not like a wizard"

These are the spells I viewed as conceivably stealthy enough. Without blink and jaunt, a wizard-cultist would have to be much more careful about how he engages.

**New Artifacts**
**Summon Identity:** Available for wizards on LABOR DAY and grandmasters all year. Summons a dead man (lootable job specific clothes) from a random non-unique maintenance-access job (e.g.: cargo tech, engineer), a syndicate ID, and injects your identity into the manifest. Vacation by laboring, it's Labor Day!
**Grandmaster's Robes:** Slightly higher cult power than normal robes (90 total) and count as wizard garb for spells. These are enough to reduce forge heat to half and count as +3 cultists when raising a structure. Altars should be a breeze.

**Also Featuring** Admin spellbook can always buy any artifact or spell no matter the holiday or round status, meaning you can now pray for summon guns as a ragin' mage.