### PR TITLE
Faction Antag Candidate Adjustment

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -212,11 +212,14 @@
 	weight = 5
 	cost = 35
 	requirements = list(90,90,90,80,60,40,30,20,10,10)
+	var/operative_cap = list(2,2,3,3,4,5,5,5,5,5)
 	logo = "nuke-logo"
 
 /datum/dynamic_ruleset/midround/from_ghosts/faction_based/nuclear/acceptable(var/population=0,var/threat=0)
 	if (locate(/datum/dynamic_ruleset/roundstart/nuclear) in mode.executed_rules)
 		return 0//unavailable if nuke ops were already sent at roundstart
+	var/indice_pop = min(10,round(living_players.len/5)+1)
+	required_candidates = operative_cap[indice_pop]
 	return ..()
 
 /datum/dynamic_ruleset/midround/from_ghosts/faction_based/nuclear/ready(var/forced = 0)

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -158,6 +158,11 @@
 	requirements = list(90,80,60,30,20,10,10,10,10,10)
 	var/cultist_cap = list(2,2,3,4,4,4,4,4,4,4)
 
+/datum/dynamic_ruleset/roundstart/bloodcult/ready(var/forced = 0)
+	var/indice_pop = min(10,round(mode.roundstart_pop_ready/5)+1)
+	required_candidates = cultist_cap[indice_pop]
+	..()
+
 /datum/dynamic_ruleset/roundstart/bloodcult/execute()
 	//if ready() did its job, candidates should have 4 or more members in it
 	var/datum/faction/bloodcult/cult = find_active_faction_by_type(/datum/faction/bloodcult)
@@ -235,6 +240,12 @@
 	cost = 30
 	requirements = list(90,90,90,80,60,40,30,20,10,10)
 	var/operative_cap = list(2,2,3,3,4,5,5,5,5,5)
+
+
+/datum/dynamic_ruleset/roundstart/nuclear/ready(var/forced = 0)
+	var/indice_pop = min(10,round(mode.roundstart_pop_ready/5)+1)
+	required_candidates = operative_cap[indice_pop]
+	..()
 
 /datum/dynamic_ruleset/roundstart/nuclear/execute()
 	//if ready() did its job, candidates should have 5 or more members in it


### PR DESCRIPTION
🆑 
* tweak: Nuke ops will no longer require more candidates than it actually needs (e.g.: if the pop only allows 3 ops, it will only require 3 instead of 5). Same with cult. Midround ops is now flexible to have lower op counts for lower pops just like roundstart ops.