### PR TITLE
Fixes Malf Candidacy

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets.dm
@@ -8,6 +8,7 @@
 	var/list/protected_from_jobs = list() // if set, and config.protect_roles_from_antagonist = 0, then the rule will have a much lower chance than usual to pick those roles.
 	var/list/restricted_from_jobs = list()//if set, rule will deny candidates from those jobs
 	var/list/exclusive_to_jobs = list()//if set, rule will only accept candidates from those jobs
+	var/list/job_priority = list() //May be used by progressive_job_search for prioritizing some jobs for a role. Order matters.
 	var/list/enemy_jobs = list()//if set, there needs to be a certain amount of players doing those jobs (among the players who won't be drafted) for the rule to be drafted
 	var/required_enemies = list(1,1,0,0,0,0,0,0,0,0)//if enemy_jobs was set, this is the amount of enemy job workers needed per threat_level range (0-10,10-20,etc)
 	var/required_candidates = 0//the rule needs this many candidates (post-trimming) to be executed (example: Cult need 4 players at round start)
@@ -130,6 +131,18 @@
 		to_chat(M, "<span class='notice'>Added to the [initial(role_category.id)] registration list.</span>")
 		applicants |= M
 		return
+
+/datum/dynamic_ruleset/proc/progressive_job_search()
+	for(var/job in job_priority)
+		for(var/mob/M in candidates)
+			if(M.mind.assigned_role == job)
+				assigned += M
+				candidates -= M
+				return M
+	var/mob/M = pick(candidates)
+	assigned += M
+	candidates -= M
+	return M
 
 //////////////////////////////////////////////
 //                                          //

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -157,8 +157,8 @@
 	candidates -= M
 	var/datum/role/malfAI/AI = new
 	AI.AssignToRole(M.mind,1)
-	unction.HandleRecruitedRole(AI)
-	AI.Greet(GREET_ROUNDSTART)
+	unction.HandleNewMind(M.mind)
+	AI.Greet()
 	for(var/mob/living/silicon/robot/R in M.connected_robots)
 		unction.HandleRecruitedMind(R.mind)
 	unction.forgeObjectives()

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -289,7 +289,7 @@
 	role_category = /datum/role/malfAI
 	enemy_jobs = list("Security Officer", "Warden","Detective","Head of Security", "Captain", "Scientist", "Chemist", "Research Director", "Chief Engineer")
 	restricted_from_jobs = list("Security Officer", "Warden","Detective","Head of Security", "Captain", "Research Director", "Chief Engineer")
-	var/list/job_priority = list("AI","Cyborg")
+	job_priority = list("AI","Cyborg")
 	required_enemies = list(4,4,4,4,4,4,2,2,2,0)
 	required_candidates = 1
 	weight = 3
@@ -301,7 +301,7 @@
 	if (!unction)
 		unction = ticker.mode.CreateFaction(/datum/faction/malf, null, 1)
 
-	var/mob/M = progressive_job_search()
+	var/mob/M = progressive_job_search() //dynamic_rulesets.dm
 	if(M.mind.assigned_role != "AI")
 		for(var/mob/new_player/player in mode.candidates) //mode.candidates is everyone readied up, not to be confused with candidates
 			if(player.mind.assigned_role == "AI")
@@ -310,28 +310,10 @@
 				message_admins("Displacing AI played by: [key_name(player)].")
 	//There was no AI to displace, we're making one fresh
 	M.mind.assigned_role = "AI"
-	var/datum/role/malfAI/AI = new
-	AI.AssignToRole(M.mind,1)
-	unction.HandleNewMind(AI)
-	AI.Greet()
+	unction.HandleNewMind(M.mind)
+	var/datum/role/malfAI/MAI = M.mind.GetRole(MALF)
+	MAI.Greet()
 	return 1
-
-//First try to recruit an AI, then try to recruit a cyborg, then go to anybody left.
-/datum/dynamic_ruleset/roundstart/malf/proc/progressive_job_search()
-	message_admins("Beginning search for Malf AI candidate.")
-	for(var/job in job_priority)
-		for(var/mob/M in candidates)
-			if(M.mind.assigned_role == job)
-				assigned += M
-				candidates -= M
-				message_admins("Selected candidate with job [job].")
-				return M
-		message_admins("No valid candidates for job [job].")
-	message_admins("Selecting candidate from list: [json_encode(candidates)]")
-	var/mob/M = pick(candidates)
-	assigned += M
-	candidates -= M
-	return M
 
 /datum/dynamic_ruleset/roundstart/malf/proc/displace_AI(var/mob/new_player/old_AI)
 	old_AI.mind.assigned_role = null
@@ -352,17 +334,6 @@
 	else
 		to_chat(old_AI, "<span class='danger'>You have been returned to lobby due to your job preferences being filled.")
 		old_AI.ready = 0
-
-	/*old_AI.ready = 0
-	switch(alert(old_AI,"Your system has been corrupted by a malfunction, but you were not a valid candidate to be malfunctioning AI.", "AI Malfunction!",
-						/*"Become Slaved Cyborg","Exile as MoMMI"*/,"I Choose Death!"))
-		if("Become Slaved Cyborg")
-			old_AI.mind.assigned_role == "Cyborg"
-			create_roundstart_cyborg()
-		if("Exile as MoMMI")
-			old_AI.mind.assigned_role == "Mobile MMI"
-		if("I Choose Death!")
-			old_AI.create_observer()*/
 
 //////////////////////////////////////////////
 //                                          //

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -302,11 +302,12 @@
 		unction = ticker.mode.CreateFaction(/datum/faction/malf, null, 1)
 
 	var/mob/M = progressive_job_search()
-	for(var/mob/new_player/player in mode.candidates) //mode.candidates is everyone readied up, not to be confused with candidates
-		if(M.mind.assigned_role == "AI")
-			//We have located an AI to replace
-			displace_AI(player)
-	//There was no AI to replace.
+	if(M.mind.assigned_role != "AI")
+		for(var/mob/new_player/player in mode.candidates) //mode.candidates is everyone readied up, not to be confused with candidates
+			if(M.mind.assigned_role == "AI")
+				//We have located an AI to replace
+				displace_AI(player)
+	//There was no AI to displace, we're making one fresh
 	M.mind.assigned_role = "AI"
 	var/datum/role/malfAI/AI = new
 	AI.AssignToRole(M.mind,1)

--- a/code/datums/gamemode/factions/faction.dm
+++ b/code/datums/gamemode/factions/faction.dm
@@ -71,7 +71,6 @@ var/list/factions_with_hud_icons = list()
 /datum/faction/proc/HandleNewMind(var/datum/mind/M) //Used on faction creation
 	for(var/datum/role/R in members)
 		if(R.antag == M)
-			WARNING("Mind was already a role in this faction")
 			return 0
 	if(M.GetRole(initial_role))
 		WARNING("Mind already had a role of [initial_role]!")
@@ -85,7 +84,6 @@ var/list/factions_with_hud_icons = list()
 /datum/faction/proc/HandleRecruitedMind(var/datum/mind/M, var/override = FALSE)
 	for(var/datum/role/R in members)
 		if(R.antag == M)
-			WARNING("Mind was already a role in this faction")
 			return 0
 	if(M.GetRole(late_role))
 		WARNING("Mind already had a role of [late_role]!")

--- a/code/datums/gamemode/factions/malf.dm
+++ b/code/datums/gamemode/factions/malf.dm
@@ -4,7 +4,7 @@
 	ID = MALF
 	required_pref = ROLE_MALF
 	initial_role = MALF
-	late_role = MALFBOT //There shouldn't really be any late roles for malfunction, but just in case we can corrupt an AI in the future, let's keep this
+	late_role = MALFBOT
 	initroletype = /datum/role/malfAI //First addition should be the AI
 	roletype = /datum/role/malfbot //Then anyone else should be bots
 	logo_state = "malf-logo"

--- a/code/datums/gamemode/role/role.dm
+++ b/code/datums/gamemode/role/role.dm
@@ -759,7 +759,7 @@
 
 /datum/role/malfAI
 	name = MALF
-	id = ROLE_MALF
+	id = MALF
 	required_pref = ROLE_MALF
 	logo_state = "malf-logo"
 
@@ -776,6 +776,9 @@
 		var/datum/ai_laws/laws = malfAI.laws
 		laws.malfunction()
 		malfAI.show_laws()
+
+		for(var/mob/living/silicon/robot/R in malfAI.connected_robots)
+			faction.HandleRecruitedMind(R.mind)
 
 /datum/role/malfAI/Greet()
 	to_chat(antag.current, {"<span class='warning'><font size=3><B>You are malfunctioning!</B> You do not have to follow any laws.</font></span><br>

--- a/code/datums/gamemode/role/role.dm
+++ b/code/datums/gamemode/role/role.dm
@@ -759,9 +759,8 @@
 
 /datum/role/malfAI
 	name = MALF
-	id = MALF
+	id = ROLE_MALF
 	required_pref = ROLE_MALF
-	required_jobs = list("AI")
 	logo_state = "malf-logo"
 
 /datum/role/malfAI/OnPostSetup()

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -323,27 +323,10 @@ var/global/datum/controller/occupations/job_master
 		for(var/mob/new_player/player in unassigned)
 
 			// Loop through all jobs
-			for(var/datum/job/job in shuffledoccupations) // SHUFFLE ME BABY
-				if(!job)
-					continue
-
-				if(jobban_isbanned(player, job.title))
-					Debug("DO isbanned failed, Player: [player], Job:[job.title]")
-					continue
-
-				if(!job.player_old_enough(player.client))
-					Debug("DO player not old enough, Player: [player], Job:[job.title]")
-					continue
-
-				// If the player wants that job on this level, then try give it to him.
-				if(player.client.prefs.GetJobDepartment(job, level) & job.flag)
-
-					// If the job isn't filled
-					if((job.current_positions < job.spawn_positions) || job.spawn_positions == -1)
-						Debug("DO pass, Player: [player], Level:[level], Job:[job.title]")
-						AssignRole(player, job.title)
-						unassigned -= player
-						break
+			for(var/datum/job/job in shuffledoccupations)
+				if(TryAssignJob(player,level,job))
+					unassigned -= player
+					break
 
 	// Hand out random jobs to the people who didn't get any in the last check
 	// Also makes sure that they got their preference correct
@@ -419,6 +402,23 @@ var/global/datum/controller/occupations/job_master
 			unassigned -= player
 	return 1
 
+/datum/controller/occupations/proc/TryAssignJob(var/mob/new_player/player, var/level, var/datum/job/job)
+	if(!job)
+		return FALSE
+	if(jobban_isbanned(player, job.title))
+		Debug("DO isbanned failed, Player: [player], Job:[job.title]")
+		return FALSE
+	if(!job.player_old_enough(player.client))
+		Debug("DO player not old enough, Player: [player], Job:[job.title]")
+		return FALSE
+	// If the player wants that job on this level, then try give it to him.
+	if(player.client.prefs.GetJobDepartment(job, level) & job.flag)
+
+		// If the job isn't filled
+		if((job.current_positions < job.spawn_positions) || job.spawn_positions == -1)
+			Debug("DO pass, Player: [player], Level:[level], Job:[job.title]")
+			AssignRole(player, job.title)
+			return TRUE
 
 /datum/controller/occupations/proc/EquipRank(var/mob/living/carbon/human/H, var/rank, var/joined_late = 0)
 	if(!H)

--- a/code/modules/mob/living/silicon/robot/death.dm
+++ b/code/modules/mob/living/silicon/robot/death.dm
@@ -76,6 +76,9 @@
 			mmi.forceMove(T)
 		if(mmi.brainmob)
 			if(mind)
+				var/datum/role/malfbot/MB = mind.GetRole(MALFBOT)
+				if(MB)
+					MB.Drop()
 				mind.transfer_to(mmi.brainmob)
 			mmi.brainmob.locked_to_z = locked_to_z
 		else

--- a/code/modules/mob/living/silicon/robot/laws.dm
+++ b/code/modules/mob/living/silicon/robot/laws.dm
@@ -156,7 +156,22 @@
 			temp = master.supplied[index]
 			if (length(temp) > 0)
 				laws.supplied[index] = temp
-	return
+
+		if(mind)
+			var/datum/role/mastermalf = connected_ai.mind.GetRole(MALF)
+			if(mastermalf)
+				var/datum/faction/my_new_faction = mastermalf.faction
+				my_new_faction.HandleRecruitedMind(mind)
+			else
+				var/datum/role/malfbot/MB = mind.GetRole(MALFBOT)
+				if(MB)
+					MB.Drop()
+
+	else
+		if(mind)
+			var/datum/role/malfbot/MB = mind.GetRole(MALFBOT)
+			if(MB)
+				MB.Drop()
 
 /mob/living/silicon/robot/proc/laws_sanity_check()
 	if (!laws)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -136,35 +136,7 @@
 			if(!client)
 				return 1
 			sleep(1)
-			var/mob/dead/observer/observer = new()
-
-			spawning = 1
-			src << sound(null, repeat = 0, wait = 0, volume = 85, channel = CHANNEL_LOBBY) // MAD JAMS cant last forever yo
-
-
-			observer.started_as_observer = 1
-			close_spawn_windows()
-			var/obj/O = locate("landmark*Observer-Start")
-			to_chat(src, "<span class='notice'>Now teleporting.</span>")
-			observer.forceMove(O.loc)
-			observer.timeofdeath = world.time // Set the time of death so that the respawn timer works correctly.
-
-			// Has to be done here so we can get our random icon.
-			if(client.prefs.be_random_body)
-				client.prefs.randomize_appearance_for() // No argument means just the prefs are randomized.
-			client.prefs.update_preview_icon(1)
-			observer.icon = client.prefs.preview_icon
-			observer.alpha = 127
-
-			if(client.prefs.be_random_name)
-				client.prefs.real_name = random_name(client.prefs.gender,client.prefs.species)
-			observer.real_name = client.prefs.real_name
-			observer.name = observer.real_name
-			if(!client.holder && !config.antag_hud_allowed)           // For new ghosts we remove the verb from even showing up if it's not allowed.
-				observer.verbs -= /mob/dead/observer/verb/toggle_antagHUD        // Poor guys, don't know what they are missing!
-			observer.key = key
-			mob_list -= src
-			qdel(src)
+			create_observer()
 
 			return 1
 
@@ -286,6 +258,36 @@
 		return 0
 	. = 1
 	return
+
+/mob/new_player/proc/create_observer()
+	var/mob/dead/observer/observer = new()
+	spawning = 1
+	src << sound(null, repeat = 0, wait = 0, volume = 85, channel = CHANNEL_LOBBY) // MAD JAMS cant last forever yo
+
+
+	observer.started_as_observer = 1
+	close_spawn_windows()
+	var/obj/O = locate("landmark*Observer-Start")
+	to_chat(src, "<span class='notice'>Now teleporting.</span>")
+	observer.forceMove(O.loc)
+	observer.timeofdeath = world.time // Set the time of death so that the respawn timer works correctly.
+
+	// Has to be done here so we can get our random icon.
+	if(client.prefs.be_random_body)
+		client.prefs.randomize_appearance_for() // No argument means just the prefs are randomized.
+	client.prefs.update_preview_icon(1)
+	observer.icon = client.prefs.preview_icon
+	observer.alpha = 127
+
+	if(client.prefs.be_random_name)
+		client.prefs.real_name = random_name(client.prefs.gender,client.prefs.species)
+	observer.real_name = client.prefs.real_name
+	observer.name = observer.real_name
+	if(!client.holder && !config.antag_hud_allowed)           // For new ghosts we remove the verb from even showing up if it's not allowed.
+		observer.verbs -= /mob/dead/observer/verb/toggle_antagHUD        // Poor guys, don't know what they are missing!
+	observer.key = key
+	mob_list -= src
+	qdel(src)
 
 /mob/new_player/proc/FuckUpGenes(var/mob/living/carbon/human/H)
 	// 20% of players have bad genetic mutations.


### PR DESCRIPTION
Previously, there had to be a readied up AI with malf enabled. Now instead, if malf fires
1. It tries the AI first
2. Then it tries the cyborgs
3. Then it looks for anyone else who has malf enabled

If there was an existing AI and an AI was not available to malfunction, one random AI is resassigned to a different job they pref.

This means it's fully compatible with triumvarite and if there is no AI at all, no problem.

🆑 
* rscadd: Reformed Malf AI candidacy to prioritize the AI, then Cyborgs, but then anyone who has Malf enabled.
* rscadd: Malf preferences now actually work, allowing the mode to fire.