### PR TITLE
Changes slime split results.

### DIFF
--- a/code/modules/mob/living/carbon/slime/life.dm
+++ b/code/modules/mob/living/carbon/slime/life.dm
@@ -368,14 +368,16 @@
 	if(amount_grown >= 10 && !Victim && !Target)
 		if(istype(src, /mob/living/carbon/slime/adult))
 			if(!client)
-				for(var/i=1,i<=4,i++)
+				for(var/i = 1 to 4)
 					var/newslime
-					if(prob(70))
-						newslime = primarytype
-					else
-						newslime = slime_mutation[rand(1,4)]
-					if(i == 4)
-						newslime = slime_mutation[rand(1,4)]
+					switch(i)
+						if(1 to 2)
+							newslime = slime_mutation[rand(1,maxcolorcount)]
+						if(3)
+							newslime = primarytype
+						if(4)
+							newslime = slime_mutation[rand(1,(maxcolorcount-1))]
+//For an explination on how and why this is what it is go to 'code\modules\mob\living\carbon\slime\subtypes.dm' and see the READ ME at the top.
 
 					var/mob/living/carbon/slime/M = new newslime(loc)
 					M.powerlevel = round(powerlevel/4)

--- a/code/modules/mob/living/carbon/slime/powers.dm
+++ b/code/modules/mob/living/carbon/slime/powers.dm
@@ -243,14 +243,15 @@
 			var/list/babies = list()
 			var/new_nutrition = round(nutrition * 0.9)
 			var/new_powerlevel = round(powerlevel / 4)
-			for(var/i=1,i<=4,i++)
+			for(var/i = 1 to 4)
 				var/newslime
-				if(prob(70))
-					newslime = primarytype
-				else
-					newslime = slime_mutation[rand(1,4)]
-				if(i == 4)
-					newslime = slime_mutation[rand(1,4)]
+				switch(i)
+					if(1 to 2)
+						newslime = slime_mutation[rand(1,maxcolorcount)]
+					if(3)
+						newslime = primarytype
+					if(4)
+						newslime = slime_mutation[rand(1,(maxcolorcount-1))]
 
 				var/mob/living/carbon/slime/M = new newslime(loc)
 				M.nutrition = new_nutrition

--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -50,7 +50,8 @@
 	var/primarytype = /mob/living/carbon/slime
 	var/adulttype = /mob/living/carbon/slime/adult
 	var/coretype = /obj/item/slime_extract/grey
-	var/list/slime_mutation[4]
+	var/list/slime_mutation[5]
+	var/maxcolorcount = 5
 
 	var/core_removal_stage = 0 //For removing cores
 	universal_speak = 1
@@ -69,6 +70,7 @@
 
 	update_icon = 0
 	nutrition = 800 // 1200 = max
+	maxcolorcount = 5 //Based on how many different colors they can split into.
 
 /mob/living/carbon/slime/Destroy()
 	..()
@@ -101,6 +103,8 @@
 	slime_mutation[2] = /mob/living/carbon/slime/metal
 	slime_mutation[3] = /mob/living/carbon/slime/blue
 	slime_mutation[4] = /mob/living/carbon/slime/purple
+	slime_mutation[5] = /mob/living/carbon/slime
+	//For an explination on how and why this list is what it is go to 'code\modules\mob\living\carbon\slime\subtypes.dm' and see the READ ME at the top.
 
 /mob/living/carbon/slime/movement_delay()
 	if (bodytemperature >= 330.23) // 135 F

--- a/code/modules/mob/living/carbon/slime/subtypes.dm
+++ b/code/modules/mob/living/carbon/slime/subtypes.dm
@@ -1,5 +1,13 @@
+/*
+READ ME
+The "slime_mutation[X]" list should include all of the possible colors it can split into and it's own color as the LAST color. This is for when it generates it's mutations on split.
+The "maxcolorcount" var should be set to the greatest number in "slime_mutation[X]". This number must be less than or equal to 5 however.
+Upon splitting it will generate 4 offspring in the following order:
+1st and 2nd ones are a random chance between all of the "slime_mutation[X]"s, 3rd is made from the "primarytype", and the 4th is made from "slime_mutation[X]"s but from 1 to ("maxcolorcount"-1).
+This allows two random colors of slimes, one of it's own color for sure, and finally one different color for sure. Tier 5 and up breaks this rule kind of since they split into their own color always.
+*/
 
-////////////////Tier 2
+//Tier 2
 
 /mob/living/carbon/slime/purple
 	colour = "purple"
@@ -8,20 +16,21 @@
 	adulttype = /mob/living/carbon/slime/adult/purple
 	coretype = /obj/item/slime_extract/purple
 
-
 /mob/living/carbon/slime/adult/purple
 	icon_state = "purple adult slime"
 	colour = "purple"
 	primarytype = /mob/living/carbon/slime/purple
 	adulttype = /mob/living/carbon/slime/adult/purple
 	coretype = /obj/item/slime_extract/purple
+	maxcolorcount = 4
 
 	New()
 		..()
 		slime_mutation[1] = /mob/living/carbon/slime/darkpurple
 		slime_mutation[2] = /mob/living/carbon/slime/darkblue
 		slime_mutation[3] = /mob/living/carbon/slime/green
-		slime_mutation[4] = /mob/living/carbon/slime/green
+		slime_mutation[4] = /mob/living/carbon/slime/purple
+
 
 /mob/living/carbon/slime/metal
 	colour = "metal"
@@ -36,13 +45,15 @@
 	primarytype = /mob/living/carbon/slime/metal
 	adulttype = /mob/living/carbon/slime/adult/metal
 	coretype = /obj/item/slime_extract/metal
+	maxcolorcount = 4
 
 	New()
 		..()
 		slime_mutation[1] = /mob/living/carbon/slime/silver
 		slime_mutation[2] = /mob/living/carbon/slime/yellow
 		slime_mutation[3] = /mob/living/carbon/slime/gold
-		slime_mutation[4] = /mob/living/carbon/slime/gold
+		slime_mutation[4] = /mob/living/carbon/slime/metal
+
 
 /mob/living/carbon/slime/orange
 	colour = "orange"
@@ -57,13 +68,15 @@
 	primarytype = /mob/living/carbon/slime/orange
 	adulttype = /mob/living/carbon/slime/adult/orange
 	coretype = /obj/item/slime_extract/orange
+	maxcolorcount = 4
 
 	New()
 		..()
 		slime_mutation[1] = /mob/living/carbon/slime/red
-		slime_mutation[2] = /mob/living/carbon/slime/red
-		slime_mutation[3] = /mob/living/carbon/slime/darkpurple
-		slime_mutation[4] = /mob/living/carbon/slime/yellow
+		slime_mutation[2] = /mob/living/carbon/slime/darkpurple
+		slime_mutation[3] = /mob/living/carbon/slime/yellow
+		slime_mutation[4] = /mob/living/carbon/slime/orange
+
 
 /mob/living/carbon/slime/blue
 	colour = "blue"
@@ -78,14 +91,14 @@
 	primarytype = /mob/living/carbon/slime/blue
 	adulttype = /mob/living/carbon/slime/adult/blue
 	coretype = /obj/item/slime_extract/blue
+	maxcolorcount = 4
 
 	New()
 		..()
 		slime_mutation[1] = /mob/living/carbon/slime/darkblue
 		slime_mutation[2] = /mob/living/carbon/slime/pink
-		slime_mutation[3] = /mob/living/carbon/slime/pink
-		slime_mutation[4] = /mob/living/carbon/slime/silver
-
+		slime_mutation[3] = /mob/living/carbon/slime/silver
+		slime_mutation[4] = /mob/living/carbon/slime/blue
 
 //Tier 3
 
@@ -102,13 +115,15 @@
 	primarytype = /mob/living/carbon/slime/darkblue
 	adulttype = /mob/living/carbon/slime/adult/darkblue
 	coretype = /obj/item/slime_extract/darkblue
+	maxcolorcount = 4
 
 	New()
 		..()
 		slime_mutation[1] = /mob/living/carbon/slime/purple
 		slime_mutation[2] = /mob/living/carbon/slime/cerulean
 		slime_mutation[3] = /mob/living/carbon/slime/blue
-		slime_mutation[4] = /mob/living/carbon/slime/cerulean
+		slime_mutation[4] = /mob/living/carbon/slime/darkblue
+
 
 /mob/living/carbon/slime/darkpurple
 	colour = "dark purple"
@@ -123,13 +138,14 @@
 	primarytype = /mob/living/carbon/slime/darkpurple
 	adulttype = /mob/living/carbon/slime/adult/darkpurple
 	coretype = /obj/item/slime_extract/darkpurple
+	maxcolorcount = 4
 
 	New()
 		..()
 		slime_mutation[1] = /mob/living/carbon/slime/purple
 		slime_mutation[2] = /mob/living/carbon/slime/sepia
 		slime_mutation[3] = /mob/living/carbon/slime/orange
-		slime_mutation[4] = /mob/living/carbon/slime/sepia
+		slime_mutation[4] = /mob/living/carbon/slime/darkpurple
 
 
 /mob/living/carbon/slime/yellow
@@ -145,13 +161,14 @@
 	primarytype = /mob/living/carbon/slime/yellow
 	adulttype = /mob/living/carbon/slime/adult/yellow
 	coretype = /obj/item/slime_extract/yellow
+	maxcolorcount = 4
 
 	New()
 		..()
 		slime_mutation[1] = /mob/living/carbon/slime/metal
 		slime_mutation[2] = /mob/living/carbon/slime/bluespace
 		slime_mutation[3] = /mob/living/carbon/slime/orange
-		slime_mutation[4] = /mob/living/carbon/slime/bluespace
+		slime_mutation[4] = /mob/living/carbon/slime/yellow
 
 
 /mob/living/carbon/slime/silver
@@ -167,16 +184,14 @@
 	primarytype = /mob/living/carbon/slime/silver
 	adulttype = /mob/living/carbon/slime/adult/silver
 	coretype = /obj/item/slime_extract/silver
+	maxcolorcount = 4
 
 	New()
 		..()
 		slime_mutation[1] = /mob/living/carbon/slime/metal
 		slime_mutation[2] = /mob/living/carbon/slime/pyrite
 		slime_mutation[3] = /mob/living/carbon/slime/blue
-		slime_mutation[4] = /mob/living/carbon/slime/pyrite
-
-
-/////////////Tier 4
+		slime_mutation[4] = /mob/living/carbon/slime/silver
 
 
 /mob/living/carbon/slime/pink
@@ -192,13 +207,13 @@
 	primarytype = /mob/living/carbon/slime/pink
 	adulttype = /mob/living/carbon/slime/adult/pink
 	coretype = /obj/item/slime_extract/pink
+	maxcolorcount = 2
 
 	New()
 		..()
-		slime_mutation[1] = /mob/living/carbon/slime/pink
+		slime_mutation[1] = /mob/living/carbon/slime/lightpink
 		slime_mutation[2] = /mob/living/carbon/slime/pink
-		slime_mutation[3] = /mob/living/carbon/slime/lightpink
-		slime_mutation[4] = /mob/living/carbon/slime/lightpink
+
 
 /mob/living/carbon/slime/red
 	colour = "red"
@@ -213,13 +228,13 @@
 	primarytype = /mob/living/carbon/slime/red
 	adulttype = /mob/living/carbon/slime/adult/red
 	coretype = /obj/item/slime_extract/red
+	maxcolorcount = 2
 
 	New()
 		..()
-		slime_mutation[1] = /mob/living/carbon/slime/red
+		slime_mutation[1] = /mob/living/carbon/slime/oil
 		slime_mutation[2] = /mob/living/carbon/slime/red
-		slime_mutation[3] = /mob/living/carbon/slime/oil
-		slime_mutation[4] = /mob/living/carbon/slime/oil
+
 
 /mob/living/carbon/slime/gold
 	colour = "gold"
@@ -234,13 +249,13 @@
 	primarytype = /mob/living/carbon/slime/gold
 	adulttype = /mob/living/carbon/slime/adult/gold
 	coretype = /obj/item/slime_extract/gold
+	maxcolorcount = 2
 
 	New()
 		..()
-		slime_mutation[1] = /mob/living/carbon/slime/gold
+		slime_mutation[1] = /mob/living/carbon/slime/adamantine
 		slime_mutation[2] = /mob/living/carbon/slime/gold
-		slime_mutation[3] = /mob/living/carbon/slime/adamantine
-		slime_mutation[4] = /mob/living/carbon/slime/adamantine
+
 
 /mob/living/carbon/slime/green
 	colour = "green"
@@ -255,15 +270,14 @@
 	primarytype = /mob/living/carbon/slime/green
 	adulttype = /mob/living/carbon/slime/adult/green
 	coretype = /obj/item/slime_extract/green
+	maxcolorcount = 2
 
 	New()
 		..()
-		slime_mutation[1] = /mob/living/carbon/slime/green
+		slime_mutation[1] = /mob/living/carbon/slime/black
 		slime_mutation[2] = /mob/living/carbon/slime/green
-		slime_mutation[3] = /mob/living/carbon/slime/black
-		slime_mutation[4] = /mob/living/carbon/slime/black
 
-// Tier 5
+// Tier 4
 
 /mob/living/carbon/slime/lightpink
 	colour = "light pink"
@@ -278,13 +292,13 @@
 	primarytype = /mob/living/carbon/slime/lightpink
 	adulttype = /mob/living/carbon/slime/adult/lightpink
 	coretype = /obj/item/slime_extract/lightpink
+	maxcolorcount = 2
 
 	New()
 		..()
 		slime_mutation[1] = /mob/living/carbon/slime/lightpink
 		slime_mutation[2] = /mob/living/carbon/slime/lightpink
-		slime_mutation[3] = /mob/living/carbon/slime/lightpink
-		slime_mutation[4] = /mob/living/carbon/slime/lightpink
+
 
 /mob/living/carbon/slime/oil
 	icon_state = "oil baby slime"
@@ -299,13 +313,13 @@
 	primarytype = /mob/living/carbon/slime/oil
 	adulttype = /mob/living/carbon/slime/adult/oil
 	coretype = /obj/item/slime_extract/oil
+	maxcolorcount = 2
 
 	New()
 		..()
 		slime_mutation[1] = /mob/living/carbon/slime/oil
 		slime_mutation[2] = /mob/living/carbon/slime/oil
-		slime_mutation[3] = /mob/living/carbon/slime/oil
-		slime_mutation[4] = /mob/living/carbon/slime/oil
+
 
 /mob/living/carbon/slime/black
 	icon_state = "black baby slime"
@@ -320,13 +334,13 @@
 	primarytype = /mob/living/carbon/slime/black
 	adulttype = /mob/living/carbon/slime/adult/black
 	coretype = /obj/item/slime_extract/black
+	maxcolorcount = 2
 
 	New()
 		..()
 		slime_mutation[1] = /mob/living/carbon/slime/black
 		slime_mutation[2] = /mob/living/carbon/slime/black
-		slime_mutation[3] = /mob/living/carbon/slime/black
-		slime_mutation[4] = /mob/living/carbon/slime/black
+
 
 /mob/living/carbon/slime/adamantine
 	icon_state = "adamantine baby slime"
@@ -341,15 +355,13 @@
 	primarytype = /mob/living/carbon/slime/adamantine
 	adulttype = /mob/living/carbon/slime/adult/adamantine
 	coretype = /obj/item/slime_extract/adamantine
+	maxcolorcount = 2
 
 	New()
 		..()
 		slime_mutation[1] = /mob/living/carbon/slime/adamantine
 		slime_mutation[2] = /mob/living/carbon/slime/adamantine
-		slime_mutation[3] = /mob/living/carbon/slime/adamantine
-		slime_mutation[4] = /mob/living/carbon/slime/adamantine
 
-////////// Even in death I still code Tier //////////////
 
 /mob/living/carbon/slime/bluespace
 	icon_state = "bluespace baby slime"
@@ -364,13 +376,13 @@
 	primarytype = /mob/living/carbon/slime/bluespace
 	adulttype = /mob/living/carbon/slime/adult/bluespace
 	coretype = /obj/item/slime_extract/bluespace
+	maxcolorcount = 2
 
 	New()
 		..()
 		slime_mutation[1] = /mob/living/carbon/slime/bluespace
 		slime_mutation[2] = /mob/living/carbon/slime/bluespace
-		slime_mutation[3] = /mob/living/carbon/slime/bluespace
-		slime_mutation[4] = /mob/living/carbon/slime/bluespace
+
 
 /mob/living/carbon/slime/pyrite
 	icon_state = "pyrite baby slime"
@@ -385,13 +397,13 @@
 	primarytype = /mob/living/carbon/slime/pyrite
 	adulttype = /mob/living/carbon/slime/adult/pyrite
 	coretype = /obj/item/slime_extract/pyrite
+	maxcolorcount = 2
 
 	New()
 		..()
 		slime_mutation[1] = /mob/living/carbon/slime/pyrite
 		slime_mutation[2] = /mob/living/carbon/slime/pyrite
-		slime_mutation[3] = /mob/living/carbon/slime/pyrite
-		slime_mutation[4] = /mob/living/carbon/slime/pyrite
+
 
 /mob/living/carbon/slime/cerulean
 	icon_state = "cerulean baby slime"
@@ -406,13 +418,13 @@
 	primarytype = /mob/living/carbon/slime/cerulean
 	adulttype = /mob/living/carbon/slime/adult/cerulean
 	coretype = /obj/item/slime_extract/cerulean
+	maxcolorcount = 2
 
 	New()
 		..()
 		slime_mutation[1] = /mob/living/carbon/slime/cerulean
 		slime_mutation[2] = /mob/living/carbon/slime/cerulean
-		slime_mutation[3] = /mob/living/carbon/slime/cerulean
-		slime_mutation[4] = /mob/living/carbon/slime/cerulean
+
 
 /mob/living/carbon/slime/sepia
 	icon_state = "sepia baby slime"
@@ -427,13 +439,12 @@
 	primarytype = /mob/living/carbon/slime/sepia
 	adulttype = /mob/living/carbon/slime/adult/sepia
 	coretype = /obj/item/slime_extract/sepia
+	maxcolorcount = 2
 
 	New()
 		..()
 		slime_mutation[1] = /mob/living/carbon/slime/sepia
 		slime_mutation[2] = /mob/living/carbon/slime/sepia
-		slime_mutation[3] = /mob/living/carbon/slime/sepia
-		slime_mutation[4] = /mob/living/carbon/slime/sepia
 
 ////////////////Other
 


### PR DESCRIPTION
[tweak][featurerequest] (filled request from #21195)
This PR changes the results of slime splits in the following way:
- 1st slime and 2nd slime are random chance based on their usual pool of possible mutations and their own color. This is nearly the same way as the old way for resulting slimes 1st to 3rd. Old way slightly favored the starting colors over an even chance for all of their possible results.
- 3rd slime is based off of it's starting color. You are guaranteed at least one the same color as your start. (split a blue, get a blue)
- 4th slime is unchanged. A guaranteed new color.
This change could technically be seen as buff or a nerf depending on what you want. If you want to grow the same color over and over it's a buff. If you want to see a lot of new colors this could be seen as a nerf.

:cl:
* tweak: Changed slime split results slightly as follows.
* rscdel: Old way was 3 random colors but a slightly higher chance to get same color and 1 different color for sure. 
* rscadd: New way is 2 random colors with an even chance for all possible mutations, 1 same color(split a blue, get a blue) for sure, and 1 different color for sure.