### PR TITLE
Increases farsight range by one tile

### DIFF
--- a/code/game/dna/genes/vg_powers.dm
+++ b/code/game/dna/genes/vg_powers.dm
@@ -104,11 +104,11 @@ Obviously, requires DNA2.
 /datum/dna/gene/basic/farsight/activate(var/mob/M)
 	..()
 	if(M.client)
-		M.client.changeView(max(M.client.view, world.view+1))
+		M.client.changeView(max(M.client.view, world.view+2))
 
 /datum/dna/gene/basic/farsight/deactivate(var/mob/M,var/connected,var/flags)
 	if(..())
-		if(M.client && M.client.view == world.view + 1)
+		if(M.client && M.client.view == world.view + 2)
 			M.client.changeView()
 
 /datum/dna/gene/basic/farsight/can_activate(var/mob/M,var/flags)


### PR DESCRIPTION
[tested]
According to a comment apparently farsight was supposed to increase vision range by 2 tiles. Personally I think this has more impact for the gene, I guess.
Genetics powercreep, anyone?
![Clown](https://i.imgur.com/JtoBixS.png)
:cl:
 * tweak: Increases vision range addition of far-sight superpower from one tile to two tiles.