### PR TITLE
Repeatable Gamemodes

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic.dm
+++ b/code/datums/gamemode/dynamic/dynamic.dm
@@ -328,7 +328,7 @@ var/list/threat_by_job = list(
 					rule.candidates = current_players.Copy()
 					rule.trim_candidates()
 					if (rule.ready())
-						drafted_rules[rule] = rule.weight
+						drafted_rules[rule] = rule.get_weight()
 
 			if (drafted_rules.len > 0)
 				message_admins("DYNAMIC MODE: [drafted_rules.len] elligible rulesets.")

--- a/code/datums/gamemode/dynamic/dynamic.dm
+++ b/code/datums/gamemode/dynamic/dynamic.dm
@@ -228,7 +228,7 @@ var/list/threat_by_job = list(
 	var/datum/dynamic_ruleset/latejoin/latejoin_rule = pickweight(drafted_rules)
 	if (latejoin_rule)
 		if (!latejoin_rule.repeatable)
-			latejoin_rules -= latejoin_rule
+			latejoin_rules = remove_rule(latejoin_rules,latejoin_rule.type)
 		spend_threat(latejoin_rule.cost)
 		threat_log += "[worldtime2text()]: [latejoin_rule.name] spent [latejoin_rule.cost]"
 		dynamic_stats.measure_threat(threat)
@@ -247,7 +247,7 @@ var/list/threat_by_job = list(
 	var/datum/dynamic_ruleset/midround/midround_rule = pickweight(drafted_rules)
 	if (midround_rule)
 		if (!midround_rule.repeatable)
-			midround_rules -= midround_rule
+			midround_rules = remove_rule(midround_rules,midround_rule.type)
 		spend_threat(midround_rule.cost)
 		threat_log += "[worldtime2text()]: [midround_rule.name] spent [midround_rule.cost]"
 		dynamic_stats.measure_threat(threat)
@@ -393,6 +393,12 @@ var/list/threat_by_job = list(
 	message_admins("DYNAMIC MODE: Check failed!")
 	log_admin("DYNAMIC MODE: Check failed!")
 	return 0
+
+/datum/gamemode/dynamic/proc/remove_rule(var/list/rule_list,var/rule_type)
+	for(var/datum/dynamic_ruleset/DR in rule_list)
+		if(istype(DR,rule_type))
+			rule_list -= DR
+	return rule_list
 
 /datum/gamemode/dynamic/latespawn(var/mob/living/newPlayer)
 	if(emergency_shuttle.departed)//no more rules after the shuttle has left

--- a/code/datums/gamemode/dynamic/dynamic_rulesets.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets.dm
@@ -68,6 +68,13 @@
 		return 0
 	return 1
 
+/datum/dynamic_ruleset/proc/get_weight()
+	if(repeatable && weight > 1)
+		for(var/datum/dynamic_ruleset/DR in mode.executed_rules)
+			if(istype(DR,src.type))
+				weight = max(weight-2,1)
+	return weight
+
 /datum/dynamic_ruleset/proc/trim_candidates()
 	return
 

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
@@ -14,6 +14,7 @@
 	weight = 7
 	cost = 5
 	requirements = list(40,30,20,10,10,10,10,10,10,10)
+	repeatable = TRUE
 
 /datum/dynamic_ruleset/latejoin/infiltrator/acceptable(var/population=0,var/threat=0)
 	var/player_count = mode.living_players.len
@@ -49,6 +50,7 @@
 	weight = 1
 	cost = 50
 	requirements = list(90,90,70,40,30,20,10,10,10,10)
+	repeatable = TRUE
 
 /datum/dynamic_ruleset/latejoin/raginmages/acceptable(var/population=0,var/threat=0)
 	if(wizardstart.len == 0)
@@ -91,6 +93,8 @@
 	cost = 10
 	requirements = list(90,90,60,20,10,10,10,10,10,10)
 	logo = "weeaboo-logo"
+
+	repeatable = TRUE
 
 /datum/dynamic_ruleset/latejoin/weeaboo/acceptable(var/population=0,var/threat=0)
 	var/player_count = mode.living_players.len

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -77,6 +77,7 @@
 	weight = 7
 	cost = 10
 	requirements = list(50,40,30,20,10,10,10,10,10,10)
+	repeatable = TRUE
 
 /datum/dynamic_ruleset/midround/autotraitor/acceptable(var/population=0,var/threat=0)
 	var/player_count = mode.living_players.len
@@ -182,6 +183,7 @@
 	cost = 50
 	requirements = list(90,90,70,40,30,20,10,10,10,10)
 	logo = "raginmages-logo"
+	repeatable = TRUE
 
 /datum/dynamic_ruleset/midround/from_ghosts/faction_based/raginmages/acceptable(var/population=0,var/threat=0)
 	if(wizardstart.len == 0)
@@ -266,6 +268,7 @@
 	cost = 10
 	requirements = list(90,90,60,20,10,10,10,10,10,10)
 	logo = "weeaboo-logo"
+	repeatable = TRUE
 
 /datum/dynamic_ruleset/midround/from_ghosts/weeaboo/acceptable(var/population=0,var/threat=0)
 	var/player_count = mode.living_players.len


### PR DESCRIPTION
New get_weight() proc. If a repeatable ruleset has executed already, by default it loses 2 weight for each time it previously fired.

🆑 
* rscadd: Syndicate Infiltrator, Syndicate Sleeper Agent, Ragin' Mages, and Crazed Weeaboo can now occur as repeatable rulesets (but take a penalty to weight each time).
* bugfix: Fixed a bug where non-repeatable rulesets would reoccur.