### PR TITLE
Fixes being unable to grind ice in the reagentgrinder

### DIFF
--- a/code/modules/reagents/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/machinery/reagentgrinder.dm
@@ -60,7 +60,7 @@ var/global/list/juice_items = list (
 		//All types that you can put into the grinder to transfer the reagents to the beaker. !Put all recipes above this.!
 		/obj/item/weapon/reagent_containers/pill = list(),
 		/obj/item/weapon/reagent_containers/food = list(),
-		/obj/item/ice_crystal                = list(ICE, 10),
+		/obj/item/ice_crystal                = list(ICE = 10),
 	)
 
 


### PR DESCRIPTION
Formatting inconsistency between the mortar and the reagent grinder meant that, where one worked, the other would runtime.

Naicu

:cl:
 * bugfix: Can now grind ice crystals in the all in one grinder