### PR TITLE
Adds preloaded ethanol burners to maps

### DIFF
--- a/code/modules/research/xenoarchaeology/tools/bunsen_burner.dm
+++ b/code/modules/research/xenoarchaeology/tools/bunsen_burner.dm
@@ -45,6 +45,10 @@
 	processing_objects.Remove(src)
 	create_reagents(250)
 
+/obj/machinery/bunsen_burner/preloaded/New()
+	..()
+	reagents.add_reagent(ETHANOL, 250)
+
 /obj/machinery/bunsen_burner/Destroy()
 	if(held_container)
 		held_container.forceMove(get_turf(src))


### PR DESCRIPTION
:cl:
 * tweak: Roundstart bunsen burners in chemistry and xenoarchaeology should now start preloaded with ethanol