### PR TITLE
Allows the dorms buttons to toggle bolts sounds too

### DIFF
--- a/code/game/machinery/airlock_control.dm
+++ b/code/game/machinery/airlock_control.dm
@@ -42,12 +42,7 @@
 			if(!density)
 				close(1)
 				sleep(2)
-			locked = !locked
-			if (locked == 1)
-				playsound(loc, "sound/machines/door_bolt.ogg", 50, 1, -1)
-			if (locked == 0)
-				playsound(loc, "sound/machines/door_unbolt.ogg", 50, 1, -1)
-
+			toggle_bolts()
 			update_icon()
 
 		if("secure_open")

--- a/code/game/machinery/door_control.dm
+++ b/code/game/machinery/door_control.dm
@@ -99,7 +99,7 @@
 					D.aiDisabledIdScanner = !D.aiDisabledIdScanner
 				if(specialfunctions & BOLTS)
 					if(!D.isWireCut(4) && D.arePowerSystemsOn())
-						D.locked = !D.locked
+						D.toggle_bolts()
 						D.update_icon()
 				if(specialfunctions & SHOCK)
 					D.secondsElectrified = D.secondsElectrified ? 0 : -1

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1403,6 +1403,14 @@ About the new airlock wires panel:
 	playsound(loc, "sound/machines/door_bolt.ogg", 50, 1, -1)
 	return
 
+/obj/machinery/door/airlock/proc/toggle_bolts()
+	locked = !locked
+	if (locked == 1)
+		playsound(loc, "sound/machines/door_bolt.ogg", 50, 1, -1)
+	if (locked == 0)
+		playsound(loc, "sound/machines/door_unbolt.ogg", 50, 1, -1)
+	return
+
 /obj/machinery/door/airlock/wirejack(var/mob/living/silicon/pai/P)
 	if(..())
 		density ? open(TRUE) : close(TRUE)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1409,7 +1409,6 @@ About the new airlock wires panel:
 		playsound(loc, "sound/machines/door_bolt.ogg", 50, 1, -1)
 	if (locked == FALSE)
 		playsound(loc, "sound/machines/door_unbolt.ogg", 50, 1, -1)
-	return
 
 /obj/machinery/door/airlock/wirejack(var/mob/living/silicon/pai/P)
 	if(..())

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1405,9 +1405,9 @@ About the new airlock wires panel:
 
 /obj/machinery/door/airlock/proc/toggle_bolts()
 	locked = !locked
-	if (locked == 1)
+	if (locked == TRUE)
 		playsound(loc, "sound/machines/door_bolt.ogg", 50, 1, -1)
-	if (locked == 0)
+	if (locked == FALSE)
 		playsound(loc, "sound/machines/door_unbolt.ogg", 50, 1, -1)
 	return
 


### PR DESCRIPTION
An oversight from the door bolts addition. This should fix it. Works for dorms, virology, prison break events, cyborgs, signallers and other misc airlocks like mining.
:cl:
 * rscadd: Fixes the door bolts sounds for various buttons, such as dorms.