### PR TITLE
Nerf Blink's smoke to not act like a free smoke bomb spam spell

### DIFF
--- a/code/modules/spells/aoe_turf/blink.dm
+++ b/code/modules/spells/aoe_turf/blink.dm
@@ -30,11 +30,7 @@
 
 /spell/aoe_turf/blink/proc/makeAnimation(var/turf/T, var/turf/starting)
 	var/datum/effect/effect/system/smoke_spread/smoke = new /datum/effect/effect/system/smoke_spread()
-	smoke.set_up(3, 0, starting)
-	smoke.start()
-
-	smoke = new()
-	smoke.set_up(3, 0, T)
+	smoke.set_up(1, 0, T)
 	smoke.start()
 
 /spell/aoe_turf/blink/vamp


### PR DESCRIPTION
It is to my understanding that Blink is a bit of an annoying spell currently. Granted, it's useful, obviously, and Wizard needs buffs on a ton of spells that are too gimmicky or too weak (*cough* Teleport 2 minutes cooldown and Ethereal Jaunt nerfed to hell and back), but Blink is just a bit too good

I've seen peeps suggest a cooldown nerf but it seems a bit too dramatic, instead I think that all that's needed is reduce the amount of smoke that is being thrown everywhere. An animation to replace the old smokescreen could be nice to make it more obvious when Wizards are blinking around, but physical, view-obstructing smoke allows Wizards to casually panic Blink to smoke up massive areas of the station

The spell should still be plenty useful. You can Blink fast, you don't risk being spaced, you're hard to hit, so on. But it won't be a free smoke spell anymore (there's a Smoke spell, isn't there ? Not like anyone would use it currently)

:cl:
 * rscdel: Blink spell (both Wizard and Vampire) no longer fills the origin and destination point with a huge plume of smoke. Instead, the origin of the warp will be clear of visual effects (pending a kickass animation or such) and the destination will have one-tile smoke to make the Wizard's destination more visible.