### PR TITLE
Teleport cooldown changed to 45 sec, minus 10 per upgrade, 5 sec min

### DIFF
--- a/code/modules/spells/general/area_teleport.dm
+++ b/code/modules/spells/general/area_teleport.dm
@@ -5,12 +5,14 @@
 	user_type = USER_TYPE_WIZARD
 
 	school = "abjuration"
-	charge_max = 600
 	spell_flags = NEEDSCLOTHES
 	autocast_flags = AUTOCAST_NOTARGET
 	invocation = "SCYAR NILA"
 	invocation_type = SpI_SHOUT
-	cooldown_min = 200 //100 deciseconds reduction per rank
+
+	charge_max = 45 SECONDS
+	cooldown_min = 5 SECONDS
+	cooldown_reduc = 10 SECONDS
 
 	smoke_spread = 1
 	smoke_amt = 5


### PR DESCRIPTION
Simple and straightforward. Base spell is 25 % faster, upgrades are sane. If you blow all your points into Teleport you can Teleport really fast... yay ?

:cl:
 * rscadd: Teleport spell cooldowns changed. Starts at 45 seconds (was 1 minute), reduces by 10 seconds per upgrade (was 15 seconds per), minimum time is now 5 seconds (was 20 seconds). A bit faster teleport, maybe -someone- will pick the spell now