### PR TITLE
Adds honking for the honk serum, recipe included

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -2288,7 +2288,7 @@
 
 	if(..())
 		return 1
-		
+
 	var/mob/living/carbon/human/H = M
 	if(isplasmaman(H))
 		return 1
@@ -2296,7 +2296,7 @@
 		M.adjustToxLoss(3 * REM)
 	if(holder.has_reagent("inaprovaline"))
 		holder.remove_reagent("inaprovaline", 2 * REM)
-	
+
 
 /datum/reagent/leporazine
 	name = "Leporazine"
@@ -4635,7 +4635,7 @@
 	id = NOTHING
 	description = "Absolutely nothing."
 	nutriment_factor = 0
-	
+
 /datum/reagent/drink/nothing/on_mob_life(var/mob/living/M)
 
     if(ishuman(M))
@@ -6169,15 +6169,16 @@
 	description = "Concentrated honking"
 	reagent_state = REAGENT_STATE_LIQUID
 	color = "#F2C900" //rgb: 242, 201, 0
-	custom_metabolism = 0.01
+	custom_metabolism = 0.05
 
 /datum/reagent/honkserum/on_mob_life(var/mob/living/M)
 
 	if(..())
 		return 1
 
-	if(prob(0.9))
+	if(prob(5))
 		M.say(pick("Honk", "HONK", "Hoooonk", "Honk?", "Henk", "Hunke?", "Honk!"))
+		playsound(get_turf(M), 'sound/items/bikehorn.ogg', 50, -1)
 
 /datum/reagent/hamserum
 	name = "Ham Serum"

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -2884,7 +2884,7 @@
 	name = "Honk Serum"
 	id = HONKSERUM
 	result = HONKSERUM
-	required_reagents = list(BANANA = 1, ETHYLREDOXRAZINE = 1, ALKYSINE = 1)
+	required_reagents = list(BANANA = 1, INACUSIATE = 1, ALKYSINE = 1)
 	result_amount = 3
 
 /datum/chemical_reaction/silencer

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -2880,6 +2880,13 @@
 	required_reagents = list(BANANA = 1, CREAM = 1, SUGAR = 1)
 	result_amount = 3
 
+/datum/chemical_reaction/honkserum
+	name = "Honk Serum"
+	id = HONKSERUM
+	result = HONKSERUM
+	required_reagents = list(BANANA = 1, ETHYLREDOXRAZINE = 1, ALKYSINE = 1)
+	result_amount = 3
+
 /datum/chemical_reaction/silencer
 	name = "Silencer"
 	id = SILENCER


### PR DESCRIPTION
I thought this would be funny.

You used to need to get clown burgers to make the honk serum by grinding them, but now you can make it with banana juice, ear medicine and brain medicine. It metabolises at 0.05 per cycle with a 5% chance of making the honk occur, so eating a clown burger makes you do it 1-3 times before it wears off (5.5 units). Bananas grind for 1 banana juice so there's quite a bit of effort required to make enough of the chem.

I made a webm of putting the probability to 30 and metabolism to 0.01 and jesus christ it was the honking apocalypse.

THIS COULDNT POSSIBLY GO WRONG COULD IT HAHA NO NEVER

-->
:cl:
 * rscadd: Honk serum now makes you audibly honk. Honk serum can also be made from 1 part banana juice, 1 part inacusiate and 1 part alkysine.