### PR TITLE
Analysis now appends the type of pathogen as its name, rather than stamm

### DIFF
--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -234,13 +234,13 @@ var/global/list/disease2_list = list()
 var/global/list/virusDB = list()
 
 /datum/disease2/disease/proc/name()
-	.= "stamm #[add_zero("[uniqueID]", 4)]"
+	.= "[form] #[add_zero("[uniqueID]", 4)]"
 	if ("[uniqueID]" in virusDB)
 		var/datum/data/record/V = virusDB["[uniqueID]"]
 		.= V.fields["name"]
 
 /datum/disease2/disease/proc/get_info()
-	var/r = "GNAv2 [form] [name()]"
+	var/r = "GNAv2 [name()]"
 	r += "<BR>Infection rate : [infectionchance]"
 	r += "<BR>Spread form : [spreadtype]"
 	r += "<BR>Progress Speed : [stageprob]"


### PR DESCRIPTION
Not entirely sure what stamm even stands for, so this seems like a better use of it.

:cl:
 * rscadd: Analysis of the pathogen now yields whether it is a parasite, bacterium, or virus, rather than just stamm then random numbers for its name.