### PR TITLE
Re-adds eject sanity, makes the href eject work properly.

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1330,6 +1330,8 @@
 	set src = usr.loc
 	set popup_menu = 0
 
+	if(usr != occupant)
+		return
 	src.go_out()
 	add_fingerprint(usr)
 	return
@@ -1789,7 +1791,7 @@
 	if(href_list["eject"])
 		if(usr != src.occupant && (get_dist(usr, src) > 1 || state != STATE_BOLTSEXPOSED))
 			return
-		eject()
+		go_out()
 	if(href_list["toggle_lights"])
 		if(usr != src.occupant)
 			return


### PR DESCRIPTION
Big whoops

closes #21614 

:cl:
 * bugfix: Fixes ghosts being able to eject mecha pilots