### PR TITLE
Add the first purely Chaplain traitor item

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -262,7 +262,7 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/stealthy_weapons/detomatix
 	name = "Detomatix PDA Cartridge"
-	desc = "When inserted into a Personal Data Assistant, this cartridge gives you five opportunities to detonate PDAs of crewmembers who have their message feature enabled. The concussive effect from the explosion will knock the recipient out for a short period, and deafen them for longer. It has a chance to detonate your PDA."
+	desc = "When inserted into a Personal Data Assistant, this cartridge gives you four opportunities to detonate PDAs of crewmembers who have their message feature enabled. The concussive effect from the explosion will knock the recipient out for a short period, and deafen them for longer. It has a chance to detonate your PDA."
 	item = /obj/item/weapon/cartridge/syndicate
 	cost = 6
 

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -262,7 +262,7 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/stealthy_weapons/detomatix
 	name = "Detomatix PDA Cartridge"
-	desc = "When inserted into a Personal Data Assistant, this cartridge gives you four opportunities to detonate PDAs of crewmembers who have their message feature enabled. The concussive effect from the explosion will knock the recipient out for a short period, and deafen them for longer. It has a chance to detonate your PDA."
+	desc = "When inserted into a Personal Data Assistant, this cartridge gives you five opportunities to detonate PDAs of crewmembers who have their message feature enabled. The concussive effect from the explosion will knock the recipient out for a short period, and deafen them for longer. It has a chance to detonate your PDA."
 	item = /obj/item/weapon/cartridge/syndicate
 	cost = 6
 
@@ -870,3 +870,16 @@ var/list/uplink_items = list()
 	cost = 16
 	discounted_cost = 6
 	jobs_with_discount = list("Librarian")
+
+/datum/uplink_item/jobspecific/traitor_bible
+	name = "Feldbischof's Bible"
+	desc = "A copy of the station's holy book of choice, with a little ballistic discount on conversions. 88 rapid, eight in the gun, eight in the extra mag."
+	item = /obj/item/weapon/storage/bible/traitor_gun
+	cost = 14
+	discounted_cost = 10
+	jobs_with_discount = list("Chaplain")
+
+/datum/uplink_item/jobspecific/traitor_bible/spawn_item(var/turf/loc, var/obj/item/device/uplink/U, mob/user)
+	U.uses -= max(cost, 0)
+	feedback_add_details("traitor_uplink_items_bought", name)
+	return new item(loc) //Fix for amount ref

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -878,8 +878,3 @@ var/list/uplink_items = list()
 	cost = 14
 	discounted_cost = 10
 	jobs_with_discount = list("Chaplain")
-
-/datum/uplink_item/jobspecific/traitor_bible/spawn_item(var/turf/loc, var/obj/item/device/uplink/U, mob/user)
-	U.uses -= max(cost, 0)
-	feedback_add_details("traitor_uplink_items_bought", name)
-	return new item(loc) //Fix for amount ref

--- a/code/game/objects/items/weapons/storage/bible.dm
+++ b/code/game/objects/items/weapons/storage/bible.dm
@@ -19,6 +19,14 @@
 	autoignition_temperature = 522 // Kelvin
 	fire_fuel = 2
 
+/obj/item/weapon/storage/bible/New()
+	. = ..()
+	if(ticker && (ticker.Bible_icon_state && ticker.Bible_item_state && ticker.Bible_name && ticker.chap_rel))
+		icon_state = ticker.Bible_icon_state
+		item_state = ticker.Bible_item_state
+		name = ticker.Bible_name
+		my_rel = ticker.chap_rel
+
 /obj/item/weapon/storage/bible/suicide_act(mob/living/user)
 	user.visible_message("<span class='danger'>[user] is farting on \the [src]! It looks like \he's trying to commit suicide!</span>")
 	user.emote("fart")
@@ -41,6 +49,17 @@
 	new /obj/item/weapon/spacecash(src)
 	new /obj/item/weapon/spacecash(src)
 	new /obj/item/weapon/spacecash(src)
+
+//Even more "Special" Bible with a nicer gift on introduction
+/obj/item/weapon/storage/bible/traitor_gun
+
+	autoignition_temperature = 0 //Not actually paper
+	fire_fuel = 0
+
+/obj/item/weapon/storage/bible/traitor_gun/New()
+	. = ..()
+	new /obj/item/weapon/gun/projectile/luger/small(src)
+	new /obj/item/ammo_storage/magazine/mc9mm(src)
 
 //What happens when you slap things with the Bible in general
 /obj/item/weapon/storage/bible/attack(mob/living/M as mob, mob/living/user as mob)

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -188,6 +188,10 @@
 	..()
 	icon_state = "[initial(icon_state)][stored_magazine ? "" : "empty"]"
 
+/obj/item/weapon/gun/projectile/luger/small
+	desc = "The wrath of the SS. Now in extra-concealed size for civilian uses!"
+	w_class = W_CLASS_SMALL
+
 /obj/item/weapon/gun/projectile/beretta
 	name = "\improper Beretta 92FS"
 	desc = "The classic wonder nine and favorite of the undercover cop. Kong whiskey not included."


### PR DESCRIPTION
I figured it was a shame that the Chaplain had no Traitor items. While it is not the most imaginative gimmick in the world, pulling a gun from your Bible tends to do nicely for conversions, does it not ? It's also a pretty neat way to disguise the thing. Could have added a knife in here or something too but I think 16 rounds with a delivery system is good enough.

* Added the first purely Chaplain traitor item, the Feldbischof's Bible. This bible handily disguised AND functioning as your holy book of choice comes with an extra bonus in the form of an authentic (made in China) loaded Luger P08 and an extra magazine. 16 rounds of pure converting power, like back in the day. It costs 14 points to buy, discounted at 10 for practicing people.
* Manually spawned in Bibles, booze bibles and Traitor bibles will now automatically print for the Chaplain's religion.

![new_traitor_item](https://user-images.githubusercontent.com/6137403/52526492-ae847900-2cb9-11e9-895c-45f534fe1452.png)


:cl:
 * rscadd: Added the first purely Chaplain traitor item, the Feldbischof's Bible. This bible handily disguised AND functioning as your holy book of choice comes with an extra bonus in the form of an authentic (made in China) loaded Luger P08 and an extra magazine. 16 rounds of pure converting power, like back in the day. It costs 14 points to buy, discounted at 10 for practicing people.
 * rscadd: Manually spawned in Bibles, booze bibles and Traitor bibles will now automatically print for the Chaplain's religion.