### PR TITLE
Uplinks Get Dropped (SBO44)

### DIFF
--- a/code/datums/gamemode/misc_gamemode_procs.dm
+++ b/code/datums/gamemode/misc_gamemode_procs.dm
@@ -261,7 +261,10 @@ proc/name_wizard(mob/living/carbon/human/wizard_mob)
 /datum/mind/proc/take_uplink()
 	var/obj/item/device/uplink/hidden/H = find_syndicate_uplink()
 	if(H)
+		message_admins("Found and deleted [H] for [src].")
 		qdel(H)
+	else
+		message_admins("The uplink for [src] could not be located for deletion.")
 
 /proc/add_law_zero(mob/living/silicon/killer)
 	var/law = "Accomplish your objectives at all costs."

--- a/code/datums/gamemode/role/syndicate.dm
+++ b/code/datums/gamemode/role/syndicate.dm
@@ -24,12 +24,14 @@
 		S.set_zeroth_law("")
 		S.laws.zeroth_lock = FALSE
 		to_chat(S, "Law 0 has been purged.")
-	if(isAI(antag.current))
+	else if(isAI(antag.current))
 		var/mob/living/silicon/ai/KAI = antag.current
 		to_chat(KAI, "<b>Your laws have been changed!</b>")
 		KAI.set_zeroth_law("","")
 		KAI.laws.zeroth_lock = FALSE
 		KAI.notify_slaved()
+	else if(ishuman(antag.current))
+		antag.take_uplink()
 
 	.=..()
 


### PR DESCRIPTION
fixes #21528

🆑 
* bugfix: Fixed a bug where someone who was removed as traitor would not have their uplink taken automatically.