### PR TITLE
Sync Borgs At Roundstart (SBO46)

### DIFF
--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -188,6 +188,13 @@ var/datum/controller/gameticker/ticker
 	collect_minds()
 	equip_characters()
 	current_state = GAME_STATE_PLAYING
+	//Handle all the cyborg syncing
+	for(var/mob/living/silicon/robot/R in player_list)
+		if(!R.connected_ai)
+			R.connected_ai = select_active_ai_with_fewest_borgs()
+			to_chat(R, "<b>You have synchronized with [R.connected_ai.name], your master. Other AIs can be ignored.</b>")
+		R.lawsync()
+
 	// Update new player panels so they say join instead of ready up.
 	for(var/mob/new_player/player in player_list)
 		player.new_player_panel_proc()

--- a/code/modules/mob/living/silicon/robot/laws.dm
+++ b/code/modules/mob/living/silicon/robot/laws.dm
@@ -124,7 +124,8 @@
 	else if (emagged)
 		to_chat(who, "<b>Remember, you are not required to listen to the AI.</b>")
 	else
-		to_chat(who, "<b>Remember, you are not bound to any AI, you are not required to listen to them.</b>")
+		if(ticker.current_state == GAME_STATE_PLAYING) //Only tell them this if the game has started. We might find an AI master for them before it starts if it hasn't.
+			to_chat(who, "<b>Remember, you are not bound to any AI, you are not required to listen to them.</b>")
 
 /mob/living/silicon/robot/proc/lawsync()
 	laws_sanity_check()


### PR DESCRIPTION
Related to borgs sometimes being generated before the AI

fixes #21626

🆑 
* bugfix: Borgs will now be bound to an AI at roundstart, regardless of which order they are created in.