### PR TITLE
Threat Log (SBO47-48)

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic.dm
+++ b/code/datums/gamemode/dynamic/dynamic.dm
@@ -13,8 +13,13 @@ var/list/threat_by_job = list(
 
 /datum/gamemode/dynamic
 	name = "Dynamic Mode"
-	var/threat_level = 0//rolled at the beginning of the round.
+
+	//Threat logging vars
+	var/threat_level = 0//the "threat cap", threat shouldn't normally go above this and is used in ruleset calculations
+	var/starting_threat = 0 //threat_level's initially rolled value. Threat_level isn't changed by many things.
 	var/threat = 0//set at the beginning of the round. Spent by the mode to "purchase" rules.
+	var/list/threat_log = list() //Running information about the threat. Can store text or datum entries.
+
 	var/list/roundstart_rules = list()
 	var/list/latejoin_rules = list()
 	var/list/midround_rules = list()
@@ -42,7 +47,7 @@ var/list/threat_by_job = list(
 /datum/gamemode/dynamic/AdminPanelEntry()
 	var/dat = list()
 	dat += "Threat : <b>[threat_level]</b><br/>"
-	dat += "Threat availaible : <b>[threat]</b><br/>"
+	dat += "Threat availaible : <b>[threat]</b> <a href='?_src_=holder;threatlog=1'>\[View Log\]</a><br/>"
 	dat += "Executed rulesets : "
 	if (executed_rules.len > 0)
 		dat += "<br/>"
@@ -58,6 +63,27 @@ var/list/threat_by_job = list(
 	else
 		dat += "none."
 	return jointext(dat, "")
+
+/datum/gamemode/dynamic/proc/show_threatlog(mob/admin)
+	if(!ticker || !ticker.mode)
+		alert("Ticker and Game Mode aren't initialized yet!", "Alert")
+		return
+
+	if(!admin.check_rights(R_ADMIN))
+		return
+
+	var/out = "<TITLE>Threat Log</TITLE><B><font size='3'>Threat Log</font></B><br><B>Starting Threat:</B> [starting_threat]<BR>"
+
+	for(var/entry in threat_log)
+		if(istext(entry))
+			out += "[entry]<BR>"
+		if(istype(entry,/datum/role/catbeast))
+			var/datum/role/catbeast/C = entry
+			out += "Catbeast threat regenerated/threat_level inflated: [C.threat_generated]/[C.threat_level_inflated]<BR>"
+
+	out += "<B>Remaining threat/threat_level:</B> [threat]/[threat_level]"
+
+	usr << browse(out, "window=threatlog;size=700x500")
 
 /datum/gamemode/dynamic/GetScoreboard()
 	dat += "<h2>Dynamic Mode v1.0 - Threat Level = <font color='red'>[threat_level]%</font></h2>"
@@ -85,6 +111,7 @@ var/list/threat_by_job = list(
 /datum/gamemode/dynamic/can_start()
 	threat_level = rand(1,100)*0.6 + rand(1,100)*0.4//https://docs.google.com/spreadsheets/d/1QLN_OBHqeL4cm9zTLEtxlnaJHHUu0IUPzPbsI-DFFmc/edit#gid=499381388
 	threat = threat_level
+	starting_threat = threat_level
 	latejoin_injection_cooldown = rand(330,510)
 	midround_injection_cooldown = rand(600,1050)
 	message_admins("Dynamic Mode initialized with a Threat Level of... <font size='8'>[threat_level]</font>!")
@@ -180,8 +207,9 @@ var/list/threat_by_job = list(
 		roundstart_rules -= starting_rule
 		drafted_rules -= starting_rule
 
-		threat = max(0,threat-starting_rule.cost)
-		if (starting_rule.execute(starting_rule.cost))//this should never fail since ready() returned 1
+		spend_threat(starting_rule.cost)
+		threat_log += "[worldtime2text()]: [starting_rule.name] spent [starting_rule.cost]"
+		if (starting_rule.execute())//this should never fail since ready() returned 1
 			executed_rules += starting_rule
 			if (starting_rule.persistent)
 				current_rules += starting_rule
@@ -201,7 +229,8 @@ var/list/threat_by_job = list(
 	if (latejoin_rule)
 		if (!latejoin_rule.repeatable)
 			latejoin_rules -= latejoin_rule
-		threat = max(0,threat-latejoin_rule.cost)
+		spend_threat(latejoin_rule.cost)
+		threat_log += "[worldtime2text()]: [latejoin_rule.name] spent [latejoin_rule.cost]"
 		dynamic_stats.measure_threat(threat)
 		if (latejoin_rule.execute())//this should never fail since ready() returned 1
 			var/mob/M = pick(latejoin_rule.assigned)
@@ -219,7 +248,8 @@ var/list/threat_by_job = list(
 	if (midround_rule)
 		if (!midround_rule.repeatable)
 			midround_rules -= midround_rule
-		threat = max(0,threat-midround_rule.cost)
+		spend_threat(midround_rule.cost)
+		threat_log += "[worldtime2text()]: [midround_rule.name] spent [midround_rule.cost]"
 		dynamic_stats.measure_threat(threat)
 		if (midround_rule.execute())//this should never fail since ready() returned 1
 			message_admins("Injecting some threats...<font size='3'>[midround_rule.name]</font>!")
@@ -243,7 +273,8 @@ var/list/threat_by_job = list(
 		new_rule.candidates = current_players.Copy()
 		new_rule.trim_candidates()
 		if (new_rule.ready(forced))
-			threat = max(0,threat-new_rule.cost)
+			spend_threat(new_rule.cost)
+			threat_log += "[worldtime2text()]: Forced rule [new_rule.name] spent [new_rule.cost]"
 			dynamic_stats.measure_threat(threat)
 			if (new_rule.execute())//this should never fail since ready() returned 1
 				message_admins("Making a call to a specific ruleset...<font size='3'>[new_rule.name]</font>!")
@@ -397,6 +428,16 @@ var/list/threat_by_job = list(
 	for (var/datum/dynamic_ruleset/DR in midround_rules)
 		DR.applicants -= M
 
+//Regenerate threat, but no more than our original threat level.
 /datum/gamemode/dynamic/proc/refund_threat(var/regain)
 	threat = min(threat_level,threat+regain)
-	//Regenerate threat, but no more than our original threat level.
+
+//Generate threat and increase the threat_level if it goes beyond, capped at 100
+/datum/gamemode/dynamic/proc/create_threat(var/gain)
+	threat = min(100, threat+gain)
+	if(threat>threat_level)
+		threat_level = threat
+
+//Expend threat, but do not fall below 0.
+/datum/gamemode/dynamic/proc/spend_threat(var/cost)
+	threat = max(threat-cost,0)

--- a/code/datums/gamemode/dynamic/dynamic_rulesets.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets.dm
@@ -59,7 +59,7 @@
 	//write here your rule execution code, everything about faction/role spawning/populating.
 	return
 
-/datum/dynamic_ruleset/proc/execute(var/threat_cost)
+/datum/dynamic_ruleset/proc/execute()
 	//write here your rule execution code, everything about faction/role spawning/populating.
 	return 1
 
@@ -72,9 +72,9 @@
 	return
 
 
-/datum/dynamic_ruleset/proc/send_applications(var/list/possible_volunteers = list(),var/threat_cost)
+/datum/dynamic_ruleset/proc/send_applications(var/list/possible_volunteers = list())
 	if (possible_volunteers.len <= 0)//this shouldn't happen, as ready() should return 0 if there is not a single valid candidate
-		message_admins("Possible volunteers was 0. This shouldn't appear, because of ready().")
+		message_admins("Possible volunteers was 0. This shouldn't appear, because of ready(), unless you forced it!")
 		return
 	message_admins("DYNAMIC MODE: Polling [possible_volunteers.len] players to apply for the [name] ruleset.")
 	log_admin("DYNAMIC MODE: Polling [possible_volunteers.len] players to apply for the [name] ruleset.")
@@ -97,7 +97,9 @@
 		if(!applicants || applicants.len <= 0)
 			log_admin("DYNAMIC MODE: [name] received no applications.")
 			message_admins("DYNAMIC MODE: [name] received no applications.")
-			mode.threat = max(mode.threat_level,mode.threat+threat_cost) //Refund threat if no applications
+			mode.refund_threat(cost)
+			mode.threat_log += "[worldtime2text()]: Forced rule [name] refunded [cost] (no applications)"
+			mode.executed_rules -= src
 			return
 
 		log_admin("DYNAMIC MODE: [applicants.len] players volunteered for [name].")

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -3,11 +3,11 @@
 /datum/dynamic_ruleset/midround/from_ghosts/
 	weight = 0
 
-/datum/dynamic_ruleset/midround/from_ghosts/execute(var/threat_cost)
+/datum/dynamic_ruleset/midround/from_ghosts/execute()
 	var/list/possible_candidates = list()
 	possible_candidates.Add(dead_players)
 	possible_candidates.Add(list_observers)
-	send_applications(possible_candidates,threat_cost)
+	send_applications(possible_candidates)
 	return 1
 
 /datum/dynamic_ruleset/midround/from_ghosts/review_applications()

--- a/code/datums/gamemode/role/role.dm
+++ b/code/datums/gamemode/role/role.dm
@@ -480,8 +480,9 @@
 //Actions to be taken when antag.current is completely destroyed
 /datum/role/proc/RoleMobDestroyed()
 	if(refund_value && istype(ticker.mode, /datum/gamemode/dynamic)) //Mode check for sanity
-		var/datum/gamemode/dynamic/mode = ticker.mode
-		mode.refund_threat(refund_value)
+		var/datum/gamemode/dynamic/D = ticker.mode
+		D.refund_threat(refund_value)
+		D.threat_log += "[worldtime2text()]: [name] refunded [refund_value] upon destruction."
 
 /////////////////////////////THESE ROLES SHOULD GET MOVED TO THEIR OWN FILES ONCE THEY'RE GETTING ELABORATED/////////////////////////
 

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2632,6 +2632,20 @@
 			return
 		show_role_panel(M)
 
+	else if(href_list["threatlog"])
+		if(!check_rights(R_ADMIN))
+			return
+
+		if(!ticker || !ticker.mode)
+			alert("The game hasn't started yet!")
+			return
+
+		var/datum/gamemode/dynamic/D = ticker.mode
+		if(!istype(D))
+			alert("It's not dynamic!")
+			return
+		D.show_threatlog(usr)
+
 	// /vg/
 	else if(href_list["set_base_laws"])
 		if(!check_rights(R_FUN))


### PR DESCRIPTION
![threat log](https://user-images.githubusercontent.com/9782036/52702007-08e33b00-2f41-11e9-8463-d8a9e43a0320.png)

* Logging (spending, refunding, catbeast)
* Standardized threat gain/loss procs
* Remove from executed_rules if no apps fixes #21673
* Fixed bug where catbeast on scoreboard didn't have a linebreak fixes #21672
* Excised unnecessary threat_cost arg

*Just what all does this new panel log?*
* Starting threat: what was rolled originally
* -threat for rule executed
* +threat for antag destroyed (refund)
* +threat for no applicants (refund)
* +threat total tracking for catbeasts sent (cumulative totals instead of 1 entry for each +1 threat)

Could also be used for stuff like "latejoin jobs increase threat" as was proposed by @ShiftyRail 

🆑 
* bugfix: Fixed an issue with the loose catbeast on the scoreboard.
* bugfix: Fixed a bug where an admin-forced gamemode that did not execute due to lack of player apps would still be included on the scoreboard.