### PR TITLE
Fixes lonely robots BRICKING THE ENTIRE GAMESTART

### DIFF
--- a/code/datums/wires/robot.dm
+++ b/code/datums/wires/robot.dm
@@ -54,8 +54,7 @@ var/const/BORG_WIRE_LAWCHECK    = 16 // Not used on MoMMIs
 
 		if (BORG_WIRE_AI_CONTROL) //Cut the AI wire to reset AI control
 			if(!mended)
-				if (R.connected_ai)
-					R.connected_ai = null
+				R.disconnect_AI()
 
 		if (BORG_WIRE_CAMERA)
 			if(!isnull(R.camera) && !R.scrambledcodes)

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -188,12 +188,6 @@ var/datum/controller/gameticker/ticker
 	collect_minds()
 	equip_characters()
 	current_state = GAME_STATE_PLAYING
-	//Handle all the cyborg syncing
-	for(var/mob/living/silicon/robot/R in cyborg_list)
-		if(!R.connected_ai)
-			R.connected_ai = select_active_ai_with_fewest_borgs()
-			to_chat(R, "<b>You have synchronized with [R.connected_ai.name], your master. Other AIs can be ignored.</b>")
-		R.lawsync()
 
 	// Update new player panels so they say join instead of ready up.
 	for(var/mob/new_player/player in player_list)
@@ -273,7 +267,7 @@ var/datum/controller/gameticker/ticker
 		population_poll_loop()
 
 	wageSetup()
-
+	post_roundstart()
 	return 1
 
 /datum/controller/gameticker
@@ -715,6 +709,16 @@ var/datum/controller/gameticker/ticker
 		if(player.mind && (player.mind.assigned_role in command_positions))
 			roles += player.mind.assigned_role
 	return roles
+
+/datum/controller/gameticker/proc/post_roundstart()
+	//Handle all the cyborg syncing
+	var/list/active_ais = active_ais()
+	if(active_ais.len)
+		for(var/mob/living/silicon/robot/R in cyborg_list)
+			if(!R.connected_ai)
+				R.connect_AI(select_active_ai_with_fewest_borgs())
+				to_chat(R, R.connected_ai?"<b>You have synchronized with an AI. Their name will be stated shortly. Other AIs can be ignored.</b>":"<b>You are not synchronized with an AI, and therefore are not required to heed the instructions of any unless you are synced to them.</b>")
+			R.lawsync()
 
 
 /world/proc/has_round_started()

--- a/code/modules/mob/living/silicon/mommi/life.dm
+++ b/code/modules/mob/living/silicon/mommi/life.dm
@@ -171,22 +171,6 @@
 		else
 			src.healths.icon_state = "health7"
 
-	/*if (src.syndicate && src.client)
-		if(ticker.mode.name == "traitor")
-			for(var/datum/mind/tra in ticker.mode.traitors)
-				if(tra.current)
-					var/I = image('icons/mob/mob.dmi', loc = tra.current, icon_state = "traitor")
-					src.client.images += I
-
-		if(src.connected_ai)
-			src.connected_ai.connected_robots -= src
-			src.connected_ai = null
-		if(src.mind)
-			if(!src.mind.special_role)
-				src.mind.special_role = "traitor"
-				ticker.mode.traitors += src.mind
-		*/
-
 	if(!can_see_static()) //what lets us avoid the overlay
 		if(static_overlays && static_overlays.len)
 			remove_static_overlays()

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -207,21 +207,6 @@
 		else
 			healths.icon_state = "health7"
 
-	/*if(syndicate && client)
-		if(ticker.mode.name == "traitor")
-			for(var/datum/mind/tra in ticker.mode.traitors)
-				if(tra.current)
-					var/I = image('icons/mob/mob.dmi', loc = tra.current, icon_state = "traitor")
-					src.client.images += I
-		if(src.connected_ai)
-			src.connected_ai.connected_robots -= src
-			src.connected_ai = null
-		if(src.mind)
-			if(!src.mind.special_role)
-				src.mind.special_role = "traitor"
-				ticker.mode.traitors += src.mind
-	*/
-
 	if(cells)
 		if(cell)
 			var/cellcharge = cell.charge/cell.maxcharge

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -117,16 +117,9 @@ var/list/cyborg_list = list()
 
 	if(AIlink)
 		if(malfAI)
-			connected_ai = malfAI
+			connect_AI(malfAI)
 		else
-			connected_ai = select_active_ai_with_fewest_borgs()
-
-	if(connected_ai)
-		connected_ai.connected_robots += src
-		lawsync()
-		lawupdate = TRUE
-	else
-		lawupdate = FALSE
+			connect_AI(select_active_ai_with_fewest_borgs())
 
 	track_globally()
 
@@ -176,6 +169,20 @@ var/list/cyborg_list = list()
 			add_language(lang.name, can_speak = FALSE)
 
 	default_language = all_languages[LANGUAGE_GALACTIC_COMMON]
+
+/mob/living/silicon/robot/proc/connect_AI(var/mob/living/silicon/ai/new_AI)
+	if(istype(new_AI))
+		connected_ai = new_AI
+		connected_ai.connected_robots += src
+		lawsync()
+		lawupdate = TRUE
+	else
+		lawupdate = FALSE
+
+/mob/living/silicon/robot/proc/disconnect_AI()
+	if(connected_ai)
+		connected_ai.connected_robots -= src
+		connected_ai = null
 
 /mob/living/silicon/robot/proc/track_globally()
 	cyborg_list += src
@@ -555,7 +562,7 @@ var/list/cyborg_list = list()
 					SetEmagged(TRUE)
 					SetLockdown(TRUE)
 					lawupdate = FALSE
-					connected_ai = null
+					disconnect_AI()
 					to_chat(user, "You emag [src]'s interface")
 					message_admins("[key_name_admin(user)] emagged cyborg [key_name_admin(src)]. Laws overidden.")
 					log_game("[key_name(user)] emagged cyborg [key_name(src)].  Laws overridden.")
@@ -1178,7 +1185,7 @@ var/list/cyborg_list = list()
 
 /mob/living/silicon/robot/proc/UnlinkSelf()
 	if(connected_ai)
-		connected_ai = null
+		disconnect_AI()
 	lawupdate = FALSE
 	lockcharge = FALSE
 	canmove = TRUE


### PR DESCRIPTION
So, turns out #21644 would runtime if there were no AIs, yay nullpointerexception.

This fixes that, and moved it to its own function.

Additionally, makes the robot AI connect/disconnect into a function so it's not left here there and everywhere. Reason being the AI has to have the robot added to its connected_robots, which previously wasn't happening