### PR TITLE
Increases maximum queue limit for Protolathe and Circuit Imprinter to 50

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -30,7 +30,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 
 
 */
-#define RESEARCH_MAX_Q_LEN 30
+#define RESEARCH_MAX_Q_LEN 50
 /obj/machinery/computer/rdconsole
 	name = "R&D Console"
 	icon_state = "rdcomp"


### PR DESCRIPTION
[tweak]
Now you can build 10 of every component type (5 types) and fill up the RPED this way. No way this can go wrong.
:cl:
 * tweak: The protolathe and circuit imprinter can now fit 50 objects in their queues instead of 30.