### PR TITLE
Forgot something crucial about altar holomaps

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
@@ -429,6 +429,9 @@
 	.=..()
 	if (!.)
 		return
+	if(user in watching_mobs)
+		stopWatching(user)
+		return
 	if (altar_task)
 		if (altar_task == ALTARTASK_SACRIFICE)
 			if (user in contributors)


### PR DESCRIPTION
Right now you can only discard them by moving away from the altar, which sucks if you're in a small room.

:cl:
* tweak: Cult: You can now discard the altar holomap by clicking the altar again.