### PR TITLE
No TTVs for Midround Nuke Ops

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -273,6 +273,8 @@
 			newCop.AssignToRole(M.mind,1)
 			nuclear.HandleRecruitedRole(newCop)
 			newCop.Greet(GREET_ROUNDSTART)
+	for (var/obj/effect/spawner/newbomb/timer/syndicate/bomb in syndicate_bomb_spawners)
+		bomb.spawnbomb()
 	return 1
 
 

--- a/code/game/objects/effects/spawners/bombspawner.dm
+++ b/code/game/objects/effects/spawners/bombspawner.dm
@@ -1,131 +1,41 @@
-/* The old single tank bombs that dont really work anymore
-/obj/effect/spawner/bomb
-	name = "bomb"
-	icon = 'icons/mob/screen1.dmi'
-	icon_state = "x"
-	var/btype = 0  //0 = radio, 1= prox, 2=time
-	var/explosive = 1	// 0= firebomb
-	var/btemp = 500	// bomb temperature (degC)
-	var/active = 0
-
-/obj/effect/spawner/bomb/radio
-	btype = 0
-
-/obj/effect/spawner/bomb/proximity
-	btype = 1
-
-/obj/effect/spawner/bomb/timer
-	btype = 2
-
-/obj/effect/spawner/bomb/timer/syndicate
-	btemp = 450
-
-/obj/effect/spawner/bomb/suicide
-	btype = 3
-
-/obj/effect/spawner/bomb/New()
-	..()
-
-	switch (src.btype)
-		// radio
-		if (0)
-			var/obj/item/assembly/r_i_ptank/R = new /obj/item/assembly/r_i_ptank(src.loc)
-			var/obj/item/weapon/tank/plasma/p3 = new /obj/item/weapon/tank/plasma(R)
-			var/obj/item/device/radio/signaler/p1 = new /obj/item/device/radio/signaler(R)
-			var/obj/item/device/igniter/p2 = new /obj/item/device/igniter(R)
-			R.part1 = p1
-			R.part2 = p2
-			R.part3 = p3
-			p1.master = R
-			p2.master = R
-			p3.master = R
-			R.status = explosive
-			p1.b_stat = 0
-			p2.secured = 1
-			p3.air_contents.temperature = btemp + T0C
-
-		// proximity
-		if (1)
-			var/obj/item/assembly/m_i_ptank/R = new /obj/item/assembly/m_i_ptank(src.loc)
-			var/obj/item/weapon/tank/plasma/p3 = new /obj/item/weapon/tank/plasma(R)
-			var/obj/item/device/prox_sensor/p1 = new /obj/item/device/prox_sensor(R)
-			var/obj/item/device/igniter/p2 = new /obj/item/device/igniter(R)
-			R.part1 = p1
-			R.part2 = p2
-			R.part3 = p3
-			p1.master = R
-			p2.master = R
-			p3.master = R
-			R.status = explosive
-
-			p3.air_contents.temperature = btemp + T0C
-			p2.secured = 1
-
-			if(src.active)
-				R.part1.secured = 1
-				R.part1.icon_state = text("motion[]", 1)
-				R.c_state(1, src)
-
-		// timer
-		if (2)
-			var/obj/item/assembly/t_i_ptank/R = new /obj/item/assembly/t_i_ptank(src.loc)
-			var/obj/item/weapon/tank/plasma/p3 = new /obj/item/weapon/tank/plasma(R)
-			var/obj/item/device/timer/p1 = new /obj/item/device/timer(R)
-			var/obj/item/device/igniter/p2 = new /obj/item/device/igniter(R)
-			R.part1 = p1
-			R.part2 = p2
-			R.part3 = p3
-			p1.master = R
-			p2.master = R
-			p3.master = R
-			R.status = explosive
-
-			p3.air_contents.temperature = btemp + T0C
-			p2.secured = 1
-		//bombvest
-		if(3)
-			var/obj/item/clothing/suit/armor/a_i_a_ptank/R = new /obj/item/clothing/suit/armor/a_i_a_ptank(src.loc)
-			var/obj/item/weapon/tank/plasma/p4 = new /obj/item/weapon/tank/plasma(R)
-			var/obj/item/device/healthanalyzer/p1 = new /obj/item/device/healthanalyzer(R)
-			var/obj/item/device/igniter/p2 = new /obj/item/device/igniter(R)
-			var/obj/item/clothing/suit/armor/vest/p3 = new /obj/item/clothing/suit/armor/vest(R)
-			R.part1 = p1
-			R.part2 = p2
-			R.part3 = p3
-			R.part4 = p4
-			p1.master = R
-			p2.master = R
-			p3.master = R
-			p4.master = R
-			R.status = explosive
-
-			p4.air_contents.temperature = btemp + T0C
-			p2.secured = 1
-
-	del(src)
-*/
 
 /obj/effect/spawner/newbomb
 	name = "bomb"
 	icon = 'icons/mob/screen1.dmi'
 	icon_state = "x"
 	var/btype = 0 // 0=radio, 1=prox, 2=time
+	var/delayedspawn = 0
 
-	timer
-		btype = 2
+/obj/effect/spawner/newbomb/radio
+	btype = 0
 
-		syndicate
+/obj/effect/spawner/newbomb/proximity
+	btype = 1
 
-	proximity
-		btype = 1
+/obj/effect/spawner/newbomb/timer
+	btype = 2
 
-	radio
-		btype = 0
+var/list/syndicate_bomb_spawners = list()
 
+/obj/effect/spawner/newbomb/timer/syndicate
+	delayedspawn = 1
+
+/obj/effect/spawner/newbomb/timer/syndicate/New()
+	..()
+	syndicate_bomb_spawners += src
+
+/obj/effect/spawner/newbomb/timer/syndicate/Destroy()
+	syndicate_bomb_spawners -= src
+	..()
 
 /obj/effect/spawner/newbomb/New()
 	..()
+	if (delayedspawn)
+		return
 
+	spawnbomb()
+
+/obj/effect/spawner/newbomb/proc/spawnbomb()
 	var/obj/item/device/transfer_valve/mediumsize/V = new(src.loc)
 	var/obj/item/weapon/tank/plasma/PT = new(V)
 	var/obj/item/weapon/tank/oxygen/OT = new(V)


### PR DESCRIPTION
Because this is ridiculous. Please come discuss.

Also I took this opportunity to absolute-path `bombspawner.dm`

:cl:
* tweak: Nuclear Assault (mid-round Nuke Ops) no longer have tank transfer valve bombs in their ship, only Nuclear Emergency (roundstart Nuke Ops) do.