### PR TITLE
Datums Readme (SBO47-54)

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic.dm
+++ b/code/datums/gamemode/dynamic/dynamic.dm
@@ -212,7 +212,7 @@ var/list/threat_by_job = list(
 			return pick_delay(starting_rule)
 
 		spend_threat(starting_rule.cost)
-		threat_log += "[worldtime2text()]: [starting_rule.name] spent [starting_rule.cost]"
+		threat_log += "[worldtime2text()]: Roundstart [starting_rule.name] spent [starting_rule.cost]"
 		if (starting_rule.execute())//this should never fail since ready() returned 1
 			executed_rules += starting_rule
 			if (starting_rule.persistent)
@@ -248,7 +248,7 @@ var/list/threat_by_job = list(
 		if (!latejoin_rule.repeatable)
 			latejoin_rules = remove_rule(latejoin_rules,latejoin_rule.type)
 		spend_threat(latejoin_rule.cost)
-		threat_log += "[worldtime2text()]: [latejoin_rule.name] spent [latejoin_rule.cost]"
+		threat_log += "[worldtime2text()]: Latejoin [latejoin_rule.name] spent [latejoin_rule.cost]"
 		dynamic_stats.measure_threat(threat)
 		if (latejoin_rule.execute())//this should never fail since ready() returned 1
 			var/mob/M = pick(latejoin_rule.assigned)
@@ -267,7 +267,7 @@ var/list/threat_by_job = list(
 		if (!midround_rule.repeatable)
 			midround_rules = remove_rule(midround_rules,midround_rule.type)
 		spend_threat(midround_rule.cost)
-		threat_log += "[worldtime2text()]: [midround_rule.name] spent [midround_rule.cost]"
+		threat_log += "[worldtime2text()]: Midround [midround_rule.name] spent [midround_rule.cost]"
 		dynamic_stats.measure_threat(threat)
 		if (midround_rule.execute())//this should never fail since ready() returned 1
 			message_admins("Injecting some threats...<font size='3'>[midround_rule.name]</font>!")
@@ -446,8 +446,8 @@ var/list/threat_by_job = list(
 
 	// -- No injection, we'll just update the threat
 	else
-		threat = min(threat + threat_by_job[newPlayer.mind.assigned_role], 100)
-		//threat_level = min(threat_level + threat_by_job[newPlayer.mind.assigned_role], 100)
+		refund_threat(threat_by_job[newPlayer.mind.assigned_role])
+		threat_log += "[worldtime2text()]: [newPlayer] refunded [threat_by_job[newPlayer.mind.assigned_role]] by joining as [newPlayer.mind.assigned_role]."
 
 /datum/gamemode/dynamic/mob_destroyed(var/mob/M)
 	for (var/datum/dynamic_ruleset/DR in midround_rules)

--- a/code/datums/gamemode/dynamic/dynamic_readme.dm
+++ b/code/datums/gamemode/dynamic/dynamic_readme.dm
@@ -1,0 +1,73 @@
+/*
+Dynamic flow looks like this:
+
+ROUNDSTART
+Dynamic rolls threat based on a special sauce formula rand(1,100)*0.6 + rand(1,100)*0.4
+LJ/MR injection timers set randomly between LJ(330,510)/MR(600,1050)
+
+https://docs.google.com/spreadsheets/d/1QLN_OBHqeL4cm9zTLEtxlnaJHHUu0IUPzPbsI-DFFmc/edit#gid=499381388
+
+rigged_roundstart() is called instead if there are forced rules (e.g.: an admin set the mode)
+
+can_start() -> Setup() -> roundstart() OR rigged_roundstart() -> picking_roundstart_rule(drafted_rules)
+
+PROCESS (about every 2 sec)
+Calls all rule, faction, and role process()
+Every sixty seconds, update_playercounts()
+Both Injection timers -1                                                 **NOTE this means a roll of 600 ticks means 1200 seconds, or 20 minutes)
+If latejoin reaches 0, it stays there  until someone joins.
+If midround reaches 0, it updates playercounts again, then tries to inject and resets its timer regardless of whether a rule is picked.
+
+ROLE process()
+Checks for RoleMobDestroyed()
+
+FACTION process()
+Calls process to each member role
+
+RULE process()
+Nothing at root level. As of 2/14 only ruleset to use this is roundstart autotraitor, which finds its own tots.
+
+LATEJOIN
+latespawn(newPlayer) -> injection_attempt() -> [For each latespawn rule...]
+-> acceptable(living players, threat_level) -> trim_candidates() -> ready(forced=FALSE) **If true, add to drafted rules
+**NOTE that acceptable uses threat_level not threat! 				 **NOTE Latejoin timer is ONLY reset if at least one rule was drafted.
+
+[After collecting all draftble rules...]
+-> picking_latejoin_ruleset(drafted_rules) -> spend threat -> ruleset.execute()
+
+
+MIDROUND
+process() -> injection_attempt() -> [For each midround rule...]
+-> acceptable(living players, threat_level) -> trim_candidates() -> ready(forced=FALSE)
+[After collecting all draftble rules...]
+-> picking_midround_ruleset(drafted_rules) -> spend threat -> ruleset.execute()
+
+
+FORCED
+For latejoin, it simply sets forced_latejoin_rule
+latespawn(newPlayer) -> trim_candidates() -> ready(forced=TRUE) **NOTE no acceptable() call
+
+For midround, calls the below proc with forced = TRUE
+picking_specific_rule(ruletype,forced) -> forced OR acceptable(living_players, threat_level) -> trim_candidates() -> ready(forced) -> spend threat -> execute()
+**NOTE specific rule can be called by RS traitor->MR autotraitor w/ forced=FALSE
+**NOTE that due to short circuiting acceptable() need not be called if forced.
+
+RULESET
+acceptable(population,threat) just checks if enough threat_level for population indice.
+**NOTE that we currently only send threat_level as the second arg, not threat.
+
+trim_candidates() varies significantly according to the ruleset type
+Roundstart: All candidates are new_player mobs. Check them for standard stuff: connected, desire role, not banned, etc.
+**NOTE Roundstart deals with both candidates (trimmed list of valid players) and mode.candidates (everyone readied up). Don't confuse them!
+Latejoin: Only one candidate, the latejoiner. Standard checks.
+Midround: Instead of building a single list candidates, candidates contains four lists: living, dead, observing, and living antags. Standard checks in trim_list(list).
+
+Midround - Rulesets have additional types
+/from_ghosts: execute() -> send_applications() -> review_applications() -> finish_setup(mob/newcharacter,index) -> setup_role(role)
+**NOTE: execute() here adds dead players and observers to candidates list
+
+/from_ghosts/faction_based: as above, but setup_role() -> faction.HandleRecruitedRole(role)
+** NOTE: setup_role normally calls OnPostSetup, faction_based calls the faction's OnPostSetup one time the first time the faction is made instead.
+** The main implication of this is that it's inuitive for factions like Nuke Ops where all ghosts spawn at once, and bad for Ragin' Mages where they come one/time.
+
+*/

--- a/code/datums/gamemode/dynamic/dynamic_readme.dm
+++ b/code/datums/gamemode/dynamic/dynamic_readme.dm
@@ -31,6 +31,7 @@ LATEJOIN
 latespawn(newPlayer) -> injection_attempt() -> [For each latespawn rule...]
 -> acceptable(living players, threat_level) -> trim_candidates() -> ready(forced=FALSE) **If true, add to drafted rules
 **NOTE that acceptable uses threat_level not threat! 				 **NOTE Latejoin timer is ONLY reset if at least one rule was drafted.
+**NOTE the new_player.dm AttemptLateSpawn() calls OnPostSetup for all roles (unless assigned role is MODE)
 
 [After collecting all draftble rules...]
 -> picking_latejoin_ruleset(drafted_rules) -> spend threat -> ruleset.execute()

--- a/code/datums/gamemode/dynamic/dynamic_rulesets.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets.dm
@@ -103,7 +103,7 @@
 			log_admin("DYNAMIC MODE: [name] received no applications.")
 			message_admins("DYNAMIC MODE: [name] received no applications.")
 			mode.refund_threat(cost)
-			mode.threat_log += "[worldtime2text()]: Forced rule [name] refunded [cost] (no applications)"
+			mode.threat_log += "[worldtime2text()]: Rule [name] refunded [cost] (no applications)"
 			mode.executed_rules -= src
 			return
 

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
@@ -52,7 +52,7 @@
 	requirements = list(90,90,70,40,30,20,10,10,10,10)
 	repeatable = TRUE
 
-/datum/dynamic_ruleset/latejoin/raginmages/acceptable(var/population=0,var/threat=0)
+/datum/dynamic_ruleset/latejoin/raginmages/ready(var/forced = 0)
 	if(wizardstart.len == 0)
 		log_admin("Cannot accept Wizard ruleset. Couldn't find any wizard spawn points.")
 		message_admins("Cannot accept Wizard ruleset. Couldn't find any wizard spawn points.")
@@ -113,7 +113,6 @@
 	newWeeaboo.AssignToRole(M.mind,1)
 	newWeeaboo.Greet(GREET_DEFAULT)
 	newWeeaboo.OnPostSetup()
-	newWeeaboo.ForgeObjectives()
 	newWeeaboo.AnnounceObjectives()
 	return 1
 

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -135,6 +135,7 @@
 	. = ..()
 	if (new_faction)
 		my_fac.OnPostSetup()
+	return new_faction
 
 /datum/dynamic_ruleset/midround/from_ghosts/faction_based/setup_role(var/datum/role/new_role)
 	my_fac.HandleRecruitedRole(new_role)
@@ -279,7 +280,6 @@
 
 /datum/dynamic_ruleset/midround/from_ghosts/faction_based/raginmages/setup_role(var/datum/role/new_role)
 	..()
-	new_role.OnPostSetup()
 	if(!locate(/datum/dynamic_ruleset/roundstart/wizard) in mode.executed_rules)
 		new_role.refund_value = BASE_SOLO_REFUND * 4
 		//If it's a spontaneous ragin' mage, it costs more, so refund more

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -83,13 +83,20 @@
 /datum/dynamic_ruleset/midround/from_ghosts/review_applications()
 	for (var/i = required_candidates, i > 0, i--)
 		if(applicants.len <= 0)
+			if(i == required_candidates)
+				//We have found no candidates so far and we are out of applicants.
+				mode.refund_threat(cost)
+				mode.threat_log += "[worldtime2text()]: Rule [name] refunded [cost] (all applications invalid)"
+				mode.executed_rules -= src
 			break
 		var/mob/applicant = pick(applicants)
 		applicants -= applicant
 		if(!isobserver(applicant))
-			//Making sure we don't recruit people who got back into the game since they applied
-			i++
-			continue
+			if(applicant.stat == DEAD) //Not an observer? If they're dead, make them one.
+				applicant = applicant.ghostize(FALSE) //
+			else //Not dead? Disregard them, pick a new applicant
+				i++
+				continue
 
 		var/mob/living/carbon/human/new_character = applicant
 
@@ -258,7 +265,9 @@
 	logo = "raginmages-logo"
 	repeatable = TRUE
 
-/datum/dynamic_ruleset/midround/from_ghosts/faction_based/raginmages/acceptable(var/population=0,var/threat=0)
+/datum/dynamic_ruleset/midround/from_ghosts/faction_based/raginmages/ready(var/forced = 0)
+	if (required_candidates > (dead_players.len + list_observers.len))
+		return 0
 	if(wizardstart.len == 0)
 		log_admin("Cannot accept Wizard ruleset. Couldn't find any wizard spawn points.")
 		message_admins("Cannot accept Wizard ruleset. Couldn't find any wizard spawn points.")
@@ -268,13 +277,9 @@
 		cost = 10
 	return ..()
 
-/datum/dynamic_ruleset/midround/from_ghosts/faction_based/raginmages/ready(var/forced = 0)
-	if (required_candidates > (dead_players.len + list_observers.len))
-		return 0
-	return ..()
-
 /datum/dynamic_ruleset/midround/from_ghosts/faction_based/raginmages/setup_role(var/datum/role/new_role)
 	..()
+	new_role.OnPostSetup()
 	if(!locate(/datum/dynamic_ruleset/roundstart/wizard) in mode.executed_rules)
 		new_role.refund_value = BASE_SOLO_REFUND * 4
 		//If it's a spontaneous ragin' mage, it costs more, so refund more

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -137,6 +137,8 @@
 			federation = ticker.mode.CreateFaction(/datum/faction/wizard, null, 1)
 		federation.HandleRecruitedRole(newWizard)//this will give the wizard their icon
 		newWizard.Greet(GREET_ROUNDSTART)
+		spawn(1)
+			newWizard.OnPostSetup()
 		return 1
 
 

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -137,9 +137,7 @@
 			federation = ticker.mode.CreateFaction(/datum/faction/wizard, null, 1)
 		federation.HandleRecruitedRole(newWizard)//this will give the wizard their icon
 		newWizard.Greet(GREET_ROUNDSTART)
-		spawn(1)
-			newWizard.OnPostSetup()
-		return 1
+	return 1
 
 
 //////////////////////////////////////////////

--- a/code/datums/gamemode/factions/faction.dm
+++ b/code/datums/gamemode/factions/faction.dm
@@ -365,7 +365,7 @@ var/list/factions_with_hud_icons = list()
 		log_admin("Failed to set-up a round of wizard. Couldn't find any wizard spawn points.")
 		message_admins("Failed to set-up a round of wizard. Couldn't find any wizard spawn points.")
 		return 0 //Critical failure.
-	..()
+	//Do not call parent OnPostSetup! Wizards get individual OnPostSetup.
 
 /datum/faction/wizard/forgeObjectives()
 	for(var/datum/role/R in members)

--- a/code/datums/gamemode/factions/faction.dm
+++ b/code/datums/gamemode/factions/faction.dm
@@ -365,7 +365,7 @@ var/list/factions_with_hud_icons = list()
 		log_admin("Failed to set-up a round of wizard. Couldn't find any wizard spawn points.")
 		message_admins("Failed to set-up a round of wizard. Couldn't find any wizard spawn points.")
 		return 0 //Critical failure.
-	//Do not call parent OnPostSetup! Wizards get individual OnPostSetup.
+	..()
 
 /datum/faction/wizard/forgeObjectives()
 	for(var/datum/role/R in members)

--- a/code/datums/gamemode/role/catbeast.dm
+++ b/code/datums/gamemode/role/catbeast.dm
@@ -55,6 +55,7 @@ var/list/catbeast_names = list("Meowth","Fluffy","Subject 246","Experiment 35a",
 #define DEFILE_THREAT 0.75
 
 /datum/role/catbeast/process()
+	..()
 	if(!iscatbeast(antag.current))
 		return
 	var/area/A = OnStation()

--- a/code/datums/gamemode/role/changeling.dm
+++ b/code/datums/gamemode/role/changeling.dm
@@ -90,6 +90,7 @@
 
 /datum/role/changeling/process()
 	changelingRegen()
+	..()
 
 // READ: Don't use the apostrophe in name or desc. Causes script errors.
 

--- a/code/datums/gamemode/role/cultist.dm
+++ b/code/datums/gamemode/role/cultist.dm
@@ -51,6 +51,7 @@
 		antag.current.add_spell(new /spell/cult/erase_rune, "cult_spell_ready", /obj/abstract/screen/movable/spell_master/bloodcult)
 
 /datum/role/cultist/process()
+	..()
 	if (holywarning_cooldown > 0)
 		holywarning_cooldown--
 

--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -244,9 +244,8 @@
 	var/mob/living/carbon/human/H = antag.current
 	if (!istype(H))
 		return FALSE // The life() procs only work on humans.
-	if(H.stat != DEAD)
-		handle_cloak(H)
-		handle_menace(H)
+	handle_cloak(H)
+	handle_menace(H)
 	handle_smite(H)
 	if(istype(H.loc, /turf/space))
 		H.check_sun()
@@ -268,6 +267,8 @@
 
 /datum/role/vampire/proc/handle_cloak(var/mob/living/carbon/human/H)
 	var/turf/T = get_turf(H)
+	if(H.stat != DEAD)
+		iscloaking = FALSE
 	if(!iscloaking)
 		H.alphas["vampire_cloak"] = 255
 		H.color = "#FFFFFF"
@@ -285,8 +286,9 @@
 			H.alphas["vampire_cloak"] = round((255 * 0.80))
 
 /datum/role/vampire/proc/handle_menace(var/mob/living/carbon/human/H)
+	if(H.stat != DEAD)
+		ismenacing = FALSE
 	if(!ismenacing)
-		ismenacing = 0 // ? Probably not necessary
 		return FALSE
 
 	var/turf/T = get_turf(H)

--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -240,11 +240,13 @@
 */
 
 /datum/role/vampire/process()
+	..()
 	var/mob/living/carbon/human/H = antag.current
 	if (!istype(H))
 		return FALSE // The life() procs only work on humans.
-	handle_cloak(H)
-	handle_menace(H)
+	if(H.stat != DEAD)
+		handle_cloak(H)
+		handle_menace(H)
 	handle_smite(H)
 	if(istype(H.loc, /turf/space))
 		H.check_sun()

--- a/code/datums/gamemode/role/weeaboo.dm
+++ b/code/datums/gamemode/role/weeaboo.dm
@@ -6,6 +6,7 @@
 	logo_state = "weeaboo-logo"
 	refund_value = BASE_SOLO_REFUND
 	wikiroute = WEEABOO
+	restricted_jobs = list("Trader") //Spawns in space
 
 /datum/role/weeaboo/OnPostSetup()
 	. =..()

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -110,9 +110,9 @@
 		var/cooldowncalculated = round((teleportcooldown - world.time)/10)
 		message += "Your steel has unleashed it's dark and unwholesome power, so it's tapped out right now. It'll be ready again in [cooldowncalculated] seconds."
 	if(active)
-		message += " Alt-click it to disable your teleport power!</span>"
+		message += " Alt-click it to stalk your prey without teleporting like a Hunter x Hunter!</span>"
 	else
-		message += " Alt-click it to teleport behind those who wish to Kill la Kill you!</span>"
+		message += " Alt-click it enable teleporting toward your Kill la Kill!</span>"
 	to_chat(user, "[message]")
 
 /obj/item/weapon/katana/hesfast/AltClick(mob/user)

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -108,11 +108,11 @@
 		message += "Oh yeah, the ancient power stirs. This is the katana that will pierce the heavens!"
 	else
 		var/cooldowncalculated = round((teleportcooldown - world.time)/10)
-		message += "Your steel has unleashed it's dark and unwholesome power, so it's tapped out right now. It'll be ready again in [cooldowncalculated] seconds."
+		message += "Your steel has unleashed its dark and unwholesome power, so it's tapped out right now. It'll be ready again in [cooldowncalculated] seconds."
 	if(active)
-		message += " Alt-click it to stalk your prey without teleporting like a Hunter x Hunter!</span>"
+		message += " Alt-click it to stop teleporting, just in case you enter a no-warp trap room like the ones in Aincrad.</span>"
 	else
-		message += " Alt-click it enable teleporting toward your Kill la Kill!</span>"
+		message += " Alt-click it to enable your teleportation, just like Goku's Shunkan Idou (Instant Transmission for Gaijin).</span>"
 	to_chat(user, "[message]")
 
 /obj/item/weapon/katana/hesfast/AltClick(mob/user)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -36,9 +36,6 @@
 		qdel(BrainContainer)
 		BrainContainer = null
 
-	if(mind && mind.antag_roles.len)
-		for(var/datum/role/R in mind.antag_roles)
-			R.RoleMobDestroyed()
 	. = ..()
 
 /mob/living/examine(var/mob/user, var/size = "", var/show_name = TRUE, var/show_icon = TRUE) //Show the mob's size and whether it's been butchered

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -302,6 +302,7 @@
 #include "code\datums\gamemode\vampire_gamemode.dm"
 #include "code\datums\gamemode\wizard.dm"
 #include "code\datums\gamemode\dynamic\dynamic.dm"
+#include "code\datums\gamemode\dynamic\dynamic_readme.dm"
 #include "code\datums\gamemode\dynamic\dynamic_rulesets.dm"
 #include "code\datums\gamemode\dynamic\dynamic_rulesets_latejoin.dm"
 #include "code\datums\gamemode\dynamic\dynamic_rulesets_midround.dm"


### PR DESCRIPTION
Adds a readme file for a basic overview of how datums work, and also

* Converted latejoin threat to refund_threat (from cap at 100) and added logging
* Latejoin weeaboo no longer forges objectives again (fixes #21288)
* Improves weeb sword examine text (fixes #21218)
* Traders cannot be weeb role (fixes #21612)
* Refactored RoleMobDestroyed to actually work
* Vampires no longer menace or cloak while dead (reported to me via ahelps)
* A mode can be refunded if no applications were valid, this is also logged
* Fixed a bug where a non-ghosted but dead applicant would get passed over for from-ghost antags
* Fixed a bug where wizards after the first would not be dressed, moved to the den, or named. fixes #21624
* Fixed a bug where a forced latejoin/midround ragin mages would not calculate threat cost properly.
* Threat log more verbose about what kind of rule spent threat

**Important note for transparency** the first change on the list has implications for overall threat generation, mostly in the case that officers latejoin immediately at the start of a round where little or no threat was spent right away. In the old functionality, this would allow threat to go above threat level (e.g.: 23 threat, none spent extended, 2 officers join raising it to 43 threat / 23 threat level). The new functionality uses refund_threat meaning it will not exceed the threat level via latejoins. We can change this and use create_threat() instead if you think it should raise the threat_level!

🆑 
* bugfix: Fixed a detection issue that prevented regaining threat when an antagonist was destroyed. Note that they need to be entirely destroyed, cremate that head!
* tweak: The weeaboo sword's examine text is now more clear about what alt clicking does (it toggles your teleport attack on/off)
* bugfix: Latejoin weeaboos should no longer get double objectives
* bugfix: When a latejoin role that refunds threat joins, it is now properly logged.
* tweak: Latejoin roles will not refund threat over the threat_level
* rscdel: Traders can no longer quality for the Crazed Weeaboo role, to prevent latejoining in space.
* bugfix: Vampires no longer cloak or menace while dead.
* rscadd: A mode can refund its threat now if none of the applicants were valid.
* bugfix: Fixed a bug where a dead but not ghosted player would be ignored for from_ghosts antag roles even after submitting an application.
* bugfix: Fixed a bug where later ragin' mages would not spawn in the wizard den, get a book, robes, name, etc.
* bugfix: Fixed a bug where forced ragin' mages would not calculate threat properly.