### PR TITLE
Adds burning swirlies and BURN/BRUTE damage corrections for greys

### DIFF
--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -14,10 +14,12 @@
 	var/cistern = 0			//if the cistern bit is open
 	var/w_items = 0			//the combined w_class of all the items in the cistern
 	var/mob/living/swirlie = null	//the mob being given a swirlie
+	var/obj/item/weapon/reagent_containers/glass/beaker/water/watersource = null
 
 /obj/structure/toilet/New()
 	. = ..()
 	open = round(rand(0, 1))
+	watersource = new /obj/item/weapon/reagent_containers/glass/beaker/water()
 	update_icon()
 
 /obj/structure/toilet/verb/empty_container_into()
@@ -118,12 +120,10 @@
 						GM.visible_message("<span class='danger'>[user] gives [GM.name] a swirlie!</span>", "<span class='userdanger'>[user] gives you a swirlie!</span>", "You hear a toilet flushing.")
 						add_fingerprint(user)
 						add_fingerprint(GM)
-						if(isgrey(GM))
-							GM.adjustFireLoss(10)
-							if(!GM.internal && GM.losebreath <= 30)
-								GM.losebreath += 5
-							add_attacklogs(user, GM, "gave a burning swirlie to")
-						else if(!GM.internal && GM.losebreath <= 30)
+
+						watersource.reagents.reaction(GM, TOUCH)
+
+						if(!GM.internal && GM.losebreath <= 30)
 							GM.losebreath += 5
 							add_attacklogs(user, GM, "gave a swirlie to")
 						else

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -118,7 +118,12 @@
 						GM.visible_message("<span class='danger'>[user] gives [GM.name] a swirlie!</span>", "<span class='userdanger'>[user] gives you a swirlie!</span>", "You hear a toilet flushing.")
 						add_fingerprint(user)
 						add_fingerprint(GM)
-						if(!GM.internal && GM.losebreath <= 30)
+						if(isgrey(GM))
+							GM.adjustFireLoss(10)
+							if(!GM.internal && GM.losebreath <= 30)
+								GM.losebreath += 5
+							add_attacklogs(user, GM, "gave a burning swirlie to")
+						else if(!GM.internal && GM.losebreath <= 30)
 							GM.losebreath += 5
 							add_attacklogs(user, GM, "gave a swirlie to")
 						else

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -561,15 +561,15 @@
 					if(prob(15) && volume >= 30)
 						var/datum/organ/external/head/head_organ = H.get_organ(LIMB_HEAD)
 						if(head_organ)
-							if(head_organ.take_damage(25, 0))
+							if(head_organ.take_damage(0, 25))
 								H.UpdateDamageIcon(1)
 							head_organ.disfigure("burn")
 							H.audible_scream()
 					else
-						M.take_organ_damage(min(15, volume * 2)) //Uses min() and volume to make sure they aren't being sprayed in trace amounts (1 unit != insta rape) -- Doohl
+						M.take_organ_damage(0, min(15, volume * 2)) //Uses min() and volume to make sure they aren't being sprayed in trace amounts (1 unit != insta rape) -- Doohl
 			else
 				if(M.acidable())
-					M.take_organ_damage(min(15, volume * 2))
+					M.take_organ_damage(0, min(15, volume * 2))
 
 		else if(isslimeperson(H))
 


### PR DESCRIPTION
Currently, if you give a grey a swirlie in the toilet they just take the oxyloss and nothing else. If you put a grey under a shower they take a fuckton of damage. I think that shower damage is brute damage too and it should be burn damage. I'll probably correct that too.

Anyways, now when you swirlie a grey they get a BURNING SWIRLIE which applies 10 burn damage along with the current oxygen damage (max 30) and if you didn't know you can slam the toilet seat down too while you do it.

Update: Greys now take BURN instead of BRUTE when dealing with water. Swirlie now uses the permeability and splash related code instead of just istype.
-->
:cl:
 * rscadd: Greys now take extra burn damage when swirlied in a toilet. Greys also take burn and not brute damage when dealing with water.