### PR TITLE
MODE Takes No Job (SBO55)

### DIFF
--- a/code/datums/gamemode/role/role.dm
+++ b/code/datums/gamemode/role/role.dm
@@ -216,7 +216,8 @@
 		antag.special_role=special_role
 	if(disallow_job)
 		var/datum/job/job = job_master.GetJob(antag.assigned_role)
-		job.current_positions--
+		if(job)
+			job.current_positions--
 		antag.assigned_role="MODE"
 	return 1
 

--- a/code/datums/gamemode/role/role.dm
+++ b/code/datums/gamemode/role/role.dm
@@ -215,6 +215,8 @@
 	if(special_role)
 		antag.special_role=special_role
 	if(disallow_job)
+		var/datum/job/job = job_master.GetJob(antag.assigned_role)
+		job.current_positions--
 		antag.assigned_role="MODE"
 	return 1
 

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -332,9 +332,8 @@
 		R.ForgeObjectives()
 		R.AnnounceObjectives()
 
-	var/datum/job/J = job_master.GetJob(rank)
-	if (character.loc != T)//uh oh, we're spawning as an off-station antag, better not be announced, show up on the manifest, or take up a job slot
-		J.current_positions--
+	if (character.loc != T) //Offstation antag. Continue no further, as there will be no announcement or manifest injection.
+		//Removal of job slot is in role/role.dm
 		character.store_position()
 		qdel(src)
 		return
@@ -344,6 +343,7 @@
 
 	var/atom/movable/what_to_move = character.locked_to || character
 
+	var/datum/job/J = job_master.GetJob(rank)
 	if(J.spawns_from_edge)
 		Meteortype_Latejoin(what_to_move, rank)
 	else


### PR DESCRIPTION
fixes #21711 

Tested

🆑 
* bugfix: Offstation antags (e.g.: nuke ops, wiz) will no longer steal a roundstart job slot.