### PR TITLE
fixes ghetto splints not consuming cablecuffs

### DIFF
--- a/code/modules/projectiles/guns/projectile/constructable/gunsmithing.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/gunsmithing.dm
@@ -189,7 +189,7 @@
 			user.put_in_hands(I)
 		else
 			new /obj/item/stack/medical/splint/ghetto(get_turf(src.loc))
-		qdel(src)
+		qdel(W)
 
 /obj/item/weapon/cylinder
 	name = "beaker"


### PR DESCRIPTION
[easy]

🆑 
 - bugfix: Ghetto splints now consume the cablecuffs used in their creation.