### PR TITLE
Fixes being able to see if a crate is a mimic through an oversight

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -136,7 +136,8 @@ var/global/list/crate_mimic_disguises = list(\
 
 	..()
 
-	drop_meat(src) //Fill the mimic up with its own meat
+	drop_meat(src)
+	meat_taken--
 	initialize() //Collect all items from its turf!
 
 /mob/living/simple_animal/hostile/mimic/crate/Life()


### PR DESCRIPTION
It calls drop_meat to put at least some loot inside the mimic. Problem is; this would change meat_taken down, so it would say 'It is partially butchered' upon examine.

Simplest solution: Bring meat_taken back to 0

closes #21261 