### PR TITLE
Runtime hunting: Boulders

### DIFF
--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -318,6 +318,7 @@ turf/unsimulated/mineral/ChangeTurf(var/turf/N, var/tell_universe=1, var/force_l
 					if(excavation_level > 0)
 
 						B = getFromPool(/obj/structure/boulder, src)
+						B.geological_data = geologic_data
 						if(artifact_find)
 							B.artifact_find = artifact_find
 							B.investigation_log(I_ARTIFACT, "|| [artifact_find.artifact_find_type] - [artifact_find.artifact_id] found by [key_name(user)].")
@@ -326,7 +327,7 @@ turf/unsimulated/mineral/ChangeTurf(var/turf/N, var/tell_universe=1, var/force_l
 
 				else if(prob(15))
 					B = getFromPool(/obj/structure/boulder, src)
-
+					B.geological_data = geologic_data
 				if(B)
 					GetDrilled(0)
 				else

--- a/code/modules/research/xenoarchaeology/artifact/artifact.dm
+++ b/code/modules/research/xenoarchaeology/artifact/artifact.dm
@@ -57,7 +57,7 @@
 	excavation_level = rand(5,50)
 
 /obj/structure/boulder/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if (istype(W, /obj/item/device/core_sampler))
+	if (istype(W, /obj/item/device/core_sampler) && geological_data)
 		src.geological_data.artifact_distance = rand(-100,100) / 100
 		src.geological_data.artifact_id = artifact_find.artifact_id
 


### PR DESCRIPTION
Fixes a runtime when a boulder was interacted with using a core sampler, while lacking geological data
Actually has boulders inherit geological data

:cl:
 * bugfix: Boulders now inherit the geological data of their mined turf