### PR TITLE
runtime hunting: ores

### DIFF
--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -313,7 +313,7 @@
 
 
 
-/obj/item/stack/ore/New()
+/obj/item/stack/ore/New(var/loc, var/amount=null)
 	. = ..()
 	pixel_x = rand(-8, 8) * PIXEL_MULTIPLIER
 	pixel_y = rand(-8, 0) * PIXEL_MULTIPLIER


### PR DESCRIPTION
Fixes ores runtiming because of missing named arguments in ore/New()