### PR TITLE
Runtime hunting: Storage

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -196,9 +196,10 @@
 
 //This proc return 1 if the item can be picked up and 0 if it can't.
 //Set the stop_messages to stop it from printing messages
-/obj/item/weapon/storage/proc/can_be_inserted(obj/item/W as obj, stop_messages = 0,mob/M, slot)
+/obj/item/weapon/storage/proc/can_be_inserted(obj/item/W as obj, stop_messages = 0)
 	if(W == src)
-		to_chat(M, "<span class = 'notice'>No matter how hard you try, you can't seem to manage to fit \the [src] inside of itself.</span>")
+		if(!stop_messages)
+			to_chat(usr, "<span class = 'notice'>No matter how hard you try, you can't seem to manage to fit \the [src] inside of itself.</span>")
 		return //No putting ourselves into ourselves
 	if(!istype(W))
 		return //Not an item
@@ -218,7 +219,7 @@
 		return 0 //Storage item is full
 	if(usr && (W.cant_drop > 0))
 		if(!stop_messages)
-			usr << "<span class='notice'>You can't let go of \the [W]!</span>"
+			to_chat(usr,"<span class='notice'>You can't let go of \the [W]!</span>")
 		return 0 //Item is stuck to our hands
 
 	if(W.wielded || istype(W, /obj/item/offhand))


### PR DESCRIPTION
Removes arguments for can_be_inserted that weren't used. Fixes runtime that was looking for mob/M that was never given.
