### PR TITLE
Runtime hunting: storage 2

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -81,6 +81,10 @@
 	return L
 
 /obj/item/weapon/storage/proc/show_to(mob/user as mob)
+	if(!user.client)
+		is_seeing -= user
+		return
+
 	if(!user.incapacitated())
 		if(user.s_active != src)
 			for(var/obj/item/I in src)


### PR DESCRIPTION
Fixes a runtime where refresh_all would try to show somebody who's logged out the contents of a storage container.