### PR TITLE
Runtime hunting: labor console

### DIFF
--- a/code/game/machinery/computer/labor.dm
+++ b/code/game/machinery/computer/labor.dm
@@ -28,12 +28,14 @@ var/list/labor_console_categories = list(
 
 /obj/machinery/computer/labor/New()
 	..()
-	job_master.labor_consoles += src
+	if(job_master)
+		job_master.labor_consoles += src
 
 /obj/machinery/computer/labor/initialize()
 	. = ..()
 	verified_overlay = image(icon, "labor_verified")
 	awaiting_overlay = image(icon, "labor_awaiting")
+	job_master.labor_consoles += src
 
 
 /obj/machinery/computer/labor/Destroy()


### PR DESCRIPTION
Should fix the labor console runtiming because job master doesn't exist yet, as objects have New() called before the world has initialized the job_master
