### PR TITLE
Runtime hunting - Mortem farting

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -169,7 +169,7 @@
 		"farts [pick("lightly", "tenderly", "softly", "with care")].",
 	)
 
-	if(H.mind.miming)
+	if(H.mind && H.mind.miming)
 		farts = list("silently farts.", "acts out a fart.", "lets out a silent fart.")
 
 	message = pick(farts)

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -169,7 +169,7 @@
 		"farts [pick("lightly", "tenderly", "softly", "with care")].",
 	)
 
-	if(H.mind && H.mind.miming)
+	if(H.mind?.miming)
 		farts = list("silently farts.", "acts out a fart.", "lets out a silent fart.")
 
 	message = pick(farts)


### PR DESCRIPTION
Fixes an odd bug where (brace for this) a runtime would occur on deathgasp, where you would fart upon death if you had elvisism. This would runtime because a monkeyperson (no mind) would try to fart on deathgasp, assumedly due to being a genetics monkey.