### PR TITLE
Alt-click functionality for full-tile windows and grilles

### DIFF
--- a/code/game/objects/structures/fullwindow.dm
+++ b/code/game/objects/structures/fullwindow.dm
@@ -95,8 +95,14 @@
 		ini_dir = dir
 
 /obj/structure/window/full/AltClick(var/mob/user)
-	var/turf/T = get_turf(src)
-	T.AltClick(user)
+	. = ..()
+	var/turf/T = loc
+	if (istype(T))
+		if (user.listed_turf == T)
+			user.listed_turf = null
+		else
+			user.listed_turf = T
+			user.client.statpanel = T.name
 
 /obj/structure/window/full/clockworkify()
 	GENERIC_CLOCKWORK_CONVERSION(src, /obj/structure/window/full/reinforced/clockwork, BRASS_FULL_WINDOW_GLOW)

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -228,6 +228,16 @@
 
 	reset_vars_after_duration(resettable_vars, duration)
 
+/obj/structure/grille/AltClick(var/mob/user)
+	. = ..()
+	var/turf/T = loc
+	if (istype(T))
+		if (user.listed_turf == T)
+			user.listed_turf = null
+		else
+			user.listed_turf = T
+			user.client.statpanel = T.name
+
 //Mapping entities and alternatives !
 
 /obj/structure/grille/broken //THIS IS ONLY TO BE USED FOR MAPPING, THANK YOU FOR YOUR UNDERSTANDING


### PR DESCRIPTION
See title, it lists the turf.
The code was here for full-tile windows already but didn't really work.
The code wasn't here for the grilles.
[qol]
:cl:
- tweak: Full-tile windows and grilles can now be alt-clicked to show the contents of the turf they're standing on.