### PR TITLE
Fixes fire alarms not being able to be ctrl-clicked by AIs

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -973,13 +973,19 @@ FIRE ALARM
 	return src.alarm()
 
 /obj/machinery/firealarm/CtrlClick(var/mob/user)
-	if(user.incapacitated() || (!Adjacent(user) && !issilicon(user) && !isAI(user) && !(M_TK in usr.mutations)))
+	if(user.incapacitated() || (!in_range(src, user) && !issilicon(user)))
 		return
 	else
 		if(alarm == 1)
 			reset()
 		else
 			alarm()
+
+/obj/machinery/firealarm/AICtrlClick()
+	if(alarm == 1)
+		reset()
+	else
+		alarm()
 
 /obj/machinery/firealarm/attack_paw(mob/user as mob)
 	return src.attack_hand(user)

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -973,7 +973,7 @@ FIRE ALARM
 	return src.alarm()
 
 /obj/machinery/firealarm/CtrlClick(var/mob/user)
-	if(user.incapacitated() || (!Adjacent(user) && !issilicon(user) && !(M_TK in usr.mutations)))
+	if(user.incapacitated() || (!Adjacent(user) && !issilicon(user) && !isAI(user) && !(M_TK in usr.mutations)))
 		return
 	else
 		if(alarm == 1)


### PR DESCRIPTION
Turns out silicons and AIs are different things.
:cl:
 * bugfix: AI can now ctrl+click the fire alarms.