### PR TITLE
Heads of Staff Do Not Count As Fled While Inside Things (SBO55)

### DIFF
--- a/code/datums/gamemode/factions/syndicate/rev.dm
+++ b/code/datums/gamemode/factions/syndicate/rev.dm
@@ -112,7 +112,8 @@
 	var/incapacitated_heads = 0
 
 	for (var/datum/mind/M in total_heads)
-		if (M.current.isDead() || M.current.z != map.zMainStation)
+		var/turf/T = get_turf(M.current)
+		if (M.current.isDead() || T.z != STATION_Z)
 			incapacitated_heads++
 
 	if (incapacitated_heads >= total_heads.len)


### PR DESCRIPTION
Currently if a head of staff does any of these in revs they are considered fleeing the station
* In sleeper or cryo
* Riding disposals
* Hiding in a closet
* In a mecha
* Riding the transport tubes on metaclub
* Sitting in an inflatable shelter

That seems stupid to me. Now it's based on the Z of their turf instead.

🆑 
* bugfix: Heads of staff are no longer considered to have fled the station if they are inside something (e.g. a mecha, disposals)