### PR TITLE
Fixes ancient bugs with fire

### DIFF
--- a/code/ZAS/Fire.dm
+++ b/code/ZAS/Fire.dm
@@ -313,7 +313,7 @@ datum/gas_mixture/proc/zburn(var/turf/T, force_burn)
 		adjust_multi(
 			GAS_OXYGEN, -min(src[GAS_OXYGEN], total_oxygen * used_reactants_ratio),
 			GAS_PLASMA, -min(src[GAS_PLASMA], (src[GAS_PLASMA] * used_fuel_ratio * used_reactants_ratio) * 3),
-			GAS_CARBON, max(2 * total_fuel, 0),
+			GAS_CARBON, max(2 * total_fuel * used_reactants_ratio, 0),
 			GAS_VOLATILE, -(src[GAS_VOLATILE] * used_fuel_ratio * used_reactants_ratio) * 5) //Fuel burns 5 times as quick
 
 		if(can_use_turf)
@@ -324,7 +324,7 @@ datum/gas_mixture/proc/zburn(var/turf/T, force_burn)
 					A.burnFireFuel(used_fuel_ratio, used_reactants_ratio)
 
 		//calculate the energy produced by the reaction and then set the new temperature of the mix
-		temperature = (starting_energy + zas_settings.Get(/datum/ZAS_Setting/fire_fuel_energy_release) * total_fuel) / heat_capacity()
+		temperature = (starting_energy + zas_settings.Get(/datum/ZAS_Setting/fire_fuel_energy_release) * total_fuel * used_reactants_ratio) / heat_capacity()
 
 		update_values()
 		value = total_reactants * used_reactants_ratio

--- a/code/ZAS/NewSettings.dm
+++ b/code/ZAS/NewSettings.dm
@@ -52,7 +52,7 @@ var/global/ZAS_Settings/zas_settings = new
 	valtype=ZAS_TYPE_NUMERIC
 
 /datum/ZAS_Setting/fire_fuel_energy_release
-	value = 550000
+	value = 1100000
 	name = "Fire - Fuel energy release"
 	desc = "The energy in joule released when burning one mol of a burnable substance"
 	valtype=ZAS_TYPE_NUMERIC

--- a/code/game/objects/effects/spawners/bombspawner.dm
+++ b/code/game/objects/effects/spawners/bombspawner.dm
@@ -43,16 +43,15 @@ var/list/syndicate_bomb_spawners = list()
 	V.tank_one = PT
 	V.tank_two = OT
 
-	PT.master = V
-	OT.master = V
+	//This is just an arbitrary mix that works fairly well.
+	PT.air_contents.temperature = T0C + 170
+	OT.air_contents.temperature = T0C - 100
 
-	PT.air_contents.temperature = PLASMA_FLASHPOINT
-	PT.air_contents.adjust_multi(
-		GAS_PLASMA, 15,
-		GAS_CARBON, 33)
-
-	OT.air_contents.temperature = PLASMA_FLASHPOINT
-	OT.air_contents.adjust_gas(GAS_OXYGEN, 48)
+	for(var/obj/item/weapon/tank/T in list(PT, OT))
+		T.master = V
+		var/datum/gas_mixture/G = T.air_contents
+		G.update_values()
+		G.multiply(1650 / G.pressure) //Sets each tank's pressure to 1650kPa. This was determined experimentally to result in a 7 dev explosion with this mix.
 
 	var/obj/item/device/assembly/S
 

--- a/config-example/ZAS.txt
+++ b/config-example/ZAS.txt
@@ -8,7 +8,7 @@
 
 # Fire - Fuel energy release
 #   The energy in joule released when burning one mol of a burnable substance
-/datum/ZAS_Setting/fire_fuel_energy_release 550000
+/datum/ZAS_Setting/fire_fuel_energy_release 1100000
 
 # Airflow - Small Movement Threshold %
 #   Percent of 1 Atm. at which items with the small weight classes will move.


### PR DESCRIPTION
I realized I was an idiot for even considering including this with the firecode rewrite. Looking forward to merge conflicting myself.

Carbon dioxide and thermal energy release were calculated based on the total usable fuel in the mixture, rather than the amount actually used. This resulted in fires producing much more thermal energy and carbon dioxide than they should. The exact differences depend on a lot of factors, but here are some before and after examples from burning one canister of plasma in the Thunderdome:
![image](https://user-images.githubusercontent.com/9827785/53112936-6877b280-350e-11e9-9f4a-df7f8b40d048.png)
![image](https://user-images.githubusercontent.com/9827785/53112957-72011a80-350e-11e9-89c9-5a2c3a0d0c0d.png)

DNM because I want to see how this affects bombs but have no experience with bombmaking
I specifically want to see if it's even possible to make a maxcap after this, so send me your best mix.

EDIT: Changed the mix of prespawned bombs so they still blow up at the bombcap. Also fixed #20287 while I was at it.


:cl:
* bugfix: Fixed two ancient bugs that caused fires to burn hotter and release more CO2 than intended. Fires in general are now much colder and produce much, much less pressure. This affects bombs as well. Since six years of balance happened since these bugs were introduced, some numbers are probably going to have to be tweaked.