### PR TITLE
Blob Fixes (SBO59-65)

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -332,9 +332,8 @@
 	var/blob_number = 1 + round(mode.roundstart_pop_ready/25) // + 1 Blob per 25 pop. ready.
 	for (var/i = 1 to min(blob_number, candidates.len))
 		var/mob/M = pick(candidates)
-		var/datum/role/blob_overmind/blob = new
-		blob.AssignToRole(M.mind, 1)
-		blob_fac.HandleRecruitedRole(blob)
+		blob_fac.HandleNewMind(M.mind)
+		var/datum/role/blob = M.mind.GetRole(BLOBOVERMIND)
 		blob.Greet(GREET_ROUNDSTART)
 	return 1
 

--- a/code/datums/gamemode/factions/blob.dm
+++ b/code/datums/gamemode/factions/blob.dm
@@ -182,33 +182,33 @@ Message ends."}
 // -- Scoreboard --
 
 /datum/faction/blob_conglomerate/GetScoreboard()
-	var/list/results = list()
-	results += ..()
-	results += "<br/>"
+	var/dat = ..()
+	dat += "<br/>"
 	switch (win)
 		if (STATION_TAKEOVER)
-			results += "<b>Blob victory!</b>"
+			dat += "<b>Blob victory!</b>"
 		if (STATION_WAS_NUKED)
-			results += "<b>Crew minor victory!</b>"
+			dat += "<b>Crew minor victory!</b>"
 		if (BLOB_IS_DED)
-			results += "<b>Crew victory!</b>"
-	results += "<br />"
+			dat += "<b>Crew victory!</b>"
+	dat += "<br />"
 	var/datum/station_state/end = new
 	end.count()
-	results += "<b>Percentage of station taken: [end.score(start)]</b>"
-	results += "<br/>"
-	results += "<b>Quarantaine status:</b><br/>"
+	dat += "<b>Total blobs: [blobs]</b>"
+	dat += "<b>Station Integrity: [end.score(start)]%</b>"
+	dat += "<br/>"
+	dat += "<b>Quarantaine status:</b><br/>"
 	var/list/result = check_quarantaine()
-	results += "Dead humans: <b>[result["numDead"]]</b><br/>"
-	results += "Alive humans still on board: <b>[result["numAlive"]]</b><br/>"
-	results += "Humans in space: <b>[result["numSpace"]]</b><br/>"
-	results += "Humans off-station: <b>[result["numOffStation"]]</b><br/>"
-	results += "Pre-escapes: <b>[pre_escapees.len]</b>"
+	dat += "Dead humans: <b>[result["numDead"]]</b><br/>"
+	dat += "Alive humans still on board: <b>[result["numAlive"]]</b><br/>"
+	dat += "Humans in space: <b>[result["numSpace"]]</b><br/>"
+	dat += "Humans off-station: <b>[result["numOffStation"]]</b><br/>"
+	dat += "Pre-escapes: <b>[pre_escapees.len]</b><br/>"
 	if (result["numOffStation"] + result["numSpace"])
-		results += "<span class='danger'>The AI has failed to enforce the quarantaine.</span>"
+		dat += "<span class='danger'>The AI has failed to enforce the quarantine.</span>"
 	else
-		results += "<span class='notice'>The AI has managed to enforce the quarantaine.</span>"
-	return jointext(result, "")
+		dat += "<span class='good'>The AI has managed to enforce the quarantine.</span><BR>"
+	return dat
 
 /datum/faction/blob_conglomerate/proc/check_quarantaine()
 	var/list/result = list()
@@ -290,15 +290,15 @@ Message ends."}
 	return
 
 
-/datum/station_state/proc/score(var/datum/station_state/result)
-	if(!result)
+/datum/station_state/proc/score(var/datum/station_state/start)
+	if(!start)
 		return 0
 	var/output = 0
-	output += (result.floor / max(floor,1))
-	output += (result.r_wall/ max(r_wall,1))
-	output += (result.wall / max(wall,1))
-	output += (result.window / max(window,1))
-	output += (result.door / max(door,1))
-	output += (result.grille / max(grille,1))
-	output += (result.mach / max(mach,1))
+	output += (floor / max(start.floor,1))
+	output += (r_wall/ max(start.r_wall,1))
+	output += (wall / max(start.wall,1))
+	output += (window / max(start.window,1))
+	output += (door / max(start.door,1))
+	output += (grille / max(start.grille,1))
+	output += (mach / max(start.mach,1))
 	return (output/7)

--- a/code/datums/gamemode/objectives/invade.dm
+++ b/code/datums/gamemode/objectives/invade.dm
@@ -15,4 +15,4 @@
     if (..())
         return TRUE
     else
-        return (target >= blobs)
+        return (blobs >= target)

--- a/code/datums/gamemode/role/role.dm
+++ b/code/datums/gamemode/role/role.dm
@@ -554,7 +554,8 @@
 
 /datum/role/blob_overmind
 	name = BLOBOVERMIND
-	id = ROLE_BLOB
+	id = BLOBOVERMIND
+	required_pref = ROLE_BLOB
 	logo_state = "blob-logo"
 	greets = list(GREET_DEFAULT,GREET_CUSTOM)
 	var/countdown = 60

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -402,8 +402,14 @@ var/list/blob_looks_player = list(//Options available to players
 				B.aftermove()
 				if(B.spawning > 1)
 					B.spawning = 1
+				if(istype(T,/turf/simulated/floor))
+					var/turf/simulated/floor/F = T
+					F.burn_tile()
 		else
 			B.forceMove(T)
+			if(istype(T,/turf/simulated/floor))
+				var/turf/simulated/floor/F = T
+				F.burn_tile()
 	else //If we cant move in hit the turf
 		if(!source || !source.restrain_blob)
 			T.blob_act(0,src) //Don't attack the turf if our source mind has that turned off.


### PR DESCRIPTION
fixes the non-balance parts of #21775

I tested this to made sure it works but then I made the changes to station integrity counting and tile burning so I want to test that before this merges

🆑 
* bugfix: Fixed a bug where station integrity was inverted on the blob score screen (e.g.: it would show 103% instead of 97%)
* bugfix: Fixed an oversight where blobs did not burn tiles, therefore scoring no station damage when expanding over floors.
* bugfix: Fixed the Blob scoreboard not displaying any data
* bugfix: Fixed a bug in which the Invade objective had an inverted check, causing instant victory
* bugfix: Fixed a bug where the Blob lacked a required_pref, meaning it could not fire
* bugfix: Fixed a bug where the blob was given a role, then recruited to its own faction, causing it to drop and regain its role.