### PR TITLE
Coefficiency changes for fabricators

### DIFF
--- a/code/modules/research/fabricators.dm
+++ b/code/modules/research/fabricators.dm
@@ -67,13 +67,13 @@
 	var/datum/tech/Tech = files.known_tech["materials"]
 	for(var/obj/item/weapon/stock_parts/manipulator/Ma in component_parts)
 		T += Ma.rating - 1
-	resource_coeff = max(round(initial(resource_coeff) - (initial(resource_coeff)*(Tech.level+(T * 3)))/25,0.01), min_cap_C)
+	resource_coeff = max(round(initial(resource_coeff) - (initial(resource_coeff)*((Tech.level - 1)+(T * 2)))/25,0.01), min_cap_C)
 
 	T = 0
 	Tech = files.known_tech["programming"]
 	for(var/obj/item/weapon/stock_parts/micro_laser/Ml in component_parts)
 		T += Ml.rating - 1
-	time_coeff = max(round(initial(time_coeff) - (initial(time_coeff)*(Tech.level+(T * 5)))/25,0.01), min_cap_T)
+	time_coeff = max(round(initial(time_coeff) - (initial(time_coeff)*((Tech.level - 1)+(T * 3)))/25,0.01), min_cap_T)
 
 /obj/machinery/r_n_d/fabricator/emag()
 	sleep()
@@ -433,7 +433,7 @@
 		var/pmat = 0//Calculations to make up for the fact that these parts and tech modify the same thing
 		for(var/obj/item/weapon/stock_parts/manipulator/Ma in component_parts)
 			pmat += Ma.rating - 1
-		diff = max(round(initial(resource_coeff) - (initial(resource_coeff)*(T.level+(pmat*3)))/25,0.01), min_cap_C)
+		diff = max(round(initial(resource_coeff) - (initial(resource_coeff)*((T.level - 1)+(pmat*2)))/25,0.01), min_cap_C)
 		if(resource_coeff!=diff)
 			resource_coeff = diff
 			output+="Production efficiency increased.<br>"
@@ -442,7 +442,7 @@
 		var/ptime = 0
 		for(var/obj/item/weapon/stock_parts/micro_laser/Ml in component_parts)
 			ptime += Ml.rating - 1
-		diff = max(round(initial(time_coeff) - (initial(time_coeff)*(T.level+(ptime*5)))/25,0.1), min_cap_T)
+		diff = max(round(initial(time_coeff) - (initial(time_coeff)*((T.level - 1)+(ptime*3)))/25,0.1), min_cap_T)
 		if(time_coeff!=diff)
 			time_coeff = diff
 			output+="Production routines updated.<br>"

--- a/code/modules/research/fabricators.dm
+++ b/code/modules/research/fabricators.dm
@@ -12,8 +12,8 @@
 	idle_power_usage = 20
 	active_power_usage = 5000
 
-	var/time_coeff = 1.5 //can be upgraded with research
-	var/resource_coeff = 1.5 //can be upgraded with research
+	var/time_coeff = 1 //can be upgraded with research
+	var/resource_coeff = 1 //can be upgraded with research
 	max_material_storage = 562500 //All this could probably be done better with a list but meh.
 
 	var/datum/research/files
@@ -31,6 +31,8 @@
 	var/list/part_sets = list()
 	var/datum/design/last_made
 	var/start_end_anims = 0
+	var/min_cap_C = 0.1 //The minimum cap used to how much cost coeff can be improved
+	var/min_cap_T = 0.1 //The minimum cap used to how much time coeff can be improved
 
 	machine_flags	= SCREWTOGGLE | CROWDESTROY | WRENCHMOVE | FIXED2WORK | EMAGGABLE
 	research_flags = TAKESMATIN | HASOUTPUT | HASMAT_OVER | NANOTOUCH
@@ -65,13 +67,13 @@
 	var/datum/tech/Tech = files.known_tech["materials"]
 	for(var/obj/item/weapon/stock_parts/manipulator/Ma in component_parts)
 		T += Ma.rating - 1
-	resource_coeff = round(initial(resource_coeff) - (initial(resource_coeff)*(Tech.level+(T * 3)))/25,0.01)
+	resource_coeff = max(round(initial(resource_coeff) - (initial(resource_coeff)*(Tech.level+(T * 3)))/25,0.01), min_cap_C)
 
 	T = 0
 	Tech = files.known_tech["programming"]
 	for(var/obj/item/weapon/stock_parts/micro_laser/Ml in component_parts)
 		T += Ml.rating - 1
-	time_coeff = round(initial(time_coeff) - (initial(time_coeff)*(Tech.level+(T * 5)))/25,0.01)
+	time_coeff = max(round(initial(time_coeff) - (initial(time_coeff)*(Tech.level+(T * 5)))/25,0.01), min_cap_T)
 
 /obj/machinery/r_n_d/fabricator/emag()
 	sleep()
@@ -431,7 +433,7 @@
 		var/pmat = 0//Calculations to make up for the fact that these parts and tech modify the same thing
 		for(var/obj/item/weapon/stock_parts/manipulator/Ma in component_parts)
 			pmat += Ma.rating - 1
-		diff = round(initial(resource_coeff) - (initial(resource_coeff)*(T.level+(pmat*3)))/25,0.01)
+		diff = max(round(initial(resource_coeff) - (initial(resource_coeff)*(T.level+(pmat*3)))/25,0.01), min_cap_C)
 		if(resource_coeff!=diff)
 			resource_coeff = diff
 			output+="Production efficiency increased.<br>"
@@ -440,7 +442,7 @@
 		var/ptime = 0
 		for(var/obj/item/weapon/stock_parts/micro_laser/Ml in component_parts)
 			ptime += Ml.rating - 1
-		diff = round(initial(time_coeff) - (initial(time_coeff)*(T.level+(ptime*5)))/25,0.1)
+		diff = max(round(initial(time_coeff) - (initial(time_coeff)*(T.level+(ptime*5)))/25,0.1), min_cap_T)
 		if(time_coeff!=diff)
 			time_coeff = diff
 			output+="Production routines updated.<br>"


### PR DESCRIPTION
Truly fixes #7083
The previous multiplier was 1.5. This entire thing started as looking into why the circuit boards costed 29 acid despite saying they need 20 in the code.
The minimum coefficiency is a tenth of the price or time it takes to build now, previously you could have things like instantly-building exosuit fabricator items due to two microlaser ratings and research stacking hard enough to set the time coefficiency to 0. Components have lower impact on coefficiency to allow for higher-rated components to be added later on
Anyway things are generally cheaper and now everything looks neat as fuck, now that they actually show the actual price now that a tech level has been accounted for
![You try to tell me this isn't the neatest shit ever](https://i.imgur.com/LN9qHkF.png)
Technical list of changes:
- Coefficiency values (for both resource coefficiency and time coefficiency) have been reduced to a solid 1 from 1.5, which means items will have their default price for a non-upgraded research 1 machinery instead of 1.5x the price in both materials and time
- The impact components have on coefficiency has been reduced, from the (rating minus 1) being multiplied by 3 for resource coefficiency to being multiplied by 2; from 5 for time coefficiency to 3
- Added a minimum limit to how much coefficiency can be reduced, whose vars can be tweaked. By default the minimum coefficiency cap is 0.1, a tenth of the price or time it takes to build.
- A bugfix that will be made separate if this PR receives negative feedback and gets closed, but tech level in the calculation is now reduced by 1 so that a default research 1 machinery will not have a slightly reduced coefficiency by default, messing with the writing (bugfix represented in the above image). The impact is minuscule, it's more of an aesthetic fix.


:cl:
 * balance: The time and cost multipliers for fabricators have been changed! The most noticeable change is that things are cheaper by default, as they now have their base price instead of 1.5x (for example, circuit imprinter boards now cost the default 20 sulphuric acid instead of 29). To compensate, components have a slightly lower impact on how much they change the multiplier.
* balance: The multiplier now has a minimum limit of 0.1 (a tenth of the material cost and/or time it takes to build something), that can be tweaked using variables, which leads to...
* bugfix: Exosuit fabricators can no longer print instantly when fully upgraded due to the multiplier for the time it takes to build objects being 0.
* bugfix: Sacrificed a negligible amount of potential impact research has on the multiplier in order to have clean-looking costs due to unintended interaction of level 1 default research in the multiplier calculation.