### PR TITLE
[Cult Balance - March 2019] All Constructs may now dance, not just artificers (shades still can't)

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
@@ -1351,6 +1351,12 @@ var/list/bloodstone_list = list()
 			cult.fail()
 	..()
 
+/obj/structure/cult/bloodstone/attack_construct(var/mob/user)
+	if (!Adjacent(user))
+		return 0
+	cultist_act(user)
+	return 1
+
 /obj/structure/cult/bloodstone/cultist_act(var/mob/user)
 	.=..()
 	if (!.)


### PR DESCRIPTION
:cl:
* rscadd: Juggernauts and Wraiths may now join Artificers as part of the Constructs Dance Club.