### PR TITLE
Cultist shades made by non-cultists will now drop their HuD, and have a warning message.

### DIFF
--- a/code/datums/gamemode/factions/legacy_cult/soulstone.dm
+++ b/code/datums/gamemode/factions/legacy_cult/soulstone.dm
@@ -329,7 +329,7 @@
 		dir = NORTH
 		update_icon()
 	user.update_inv_hands()
-	to_chat(shadeMob, "<span class='notice'>Your soul has been captured! You are now bound to [user.name]'s will, help them suceed in their goals at all costs.</span>")
+	to_chat(shadeMob, "<span class='notice'>Your soul has been captured! You are now bound to [user.name]'s will, help them succeed in their goals at all costs.</span>")
 	to_chat(user, "<span class='notice'>[true_name]'s soul has been ripped from their body and stored within the soul stone.</span>")
 
 	//Is our user a cultist? Then you're a cultist too now!

--- a/code/datums/gamemode/factions/legacy_cult/soulstone.dm
+++ b/code/datums/gamemode/factions/legacy_cult/soulstone.dm
@@ -307,8 +307,8 @@
 			qdel(add_target)
 		return
 
-	message_admins("BLOODCULT: [key_name(body)] has been soul-stoned by [key_name(user)].")
-	log_admin("BLOODCULT: [key_name(body)] has been soul-stoned by [key_name(user)].")
+	message_admins("BLOODCULT: [key_name(body)] has been soul-stoned by [key_name(user)][iscultist(user) ? ", a cultist." : "a NON-cultist."].")
+	log_admin("BLOODCULT: [key_name(body)] has been soul-stoned by [key_name(user)][iscultist(user) ? ", a cultist." : "a NON-cultist."].")
 
 	//Creating a shade inside the stone and putting the victim in control
 	var/mob/living/simple_animal/shade/shadeMob = new(src)//put shade in stone
@@ -329,9 +329,8 @@
 		dir = NORTH
 		update_icon()
 	user.update_inv_hands()
-	to_chat(shadeMob, "Your soul has been captured! You are now bound to [user.name]'s will, help them suceed in their goals at all costs.")
+	to_chat(shadeMob, "<span class='notice'>Your soul has been captured! You are now bound to [user.name]'s will, help them suceed in their goals at all costs.</span>")
 	to_chat(user, "<span class='notice'>[true_name]'s soul has been ripped from their body and stored within the soul stone.</span>")
-
 
 	//Is our user a cultist? Then you're a cultist too now!
 	if (iscultist(user))
@@ -346,6 +345,12 @@
 		newCultist.conversion["soulstone"] = user
 		cult_risk(user)//risk of exposing the cult early if too many soul trappings
 
+	else
+		if (iscultist(shadeMob))
+			to_chat(shadeMob, "<span class='userdanger'>Your master is NOT a cultist, but you are. You are still to follow their commands and help them in their goal.</span>")
+			to_chat(shadeMob, "<span class='sinister'>Your loyalty to Nar-Sie temporarily wanes, but the God takes his toll on your treacherous mind. You only remember of who converted you.</span>")
+			shadeMob.mind.decult()
+	
 	//Pretty particles
 	var/turf/T1 = get_turf(target)
 	var/turf/T2 = null

--- a/code/datums/gamemode/role/cultist.dm
+++ b/code/datums/gamemode/role/cultist.dm
@@ -36,19 +36,22 @@
 /datum/role/cultist/PostMindTransfer(var/mob/living/new_character)
 	. = ..()
 	if (issilicon(new_character))
-		antag.antag_roles -= CULTIST
-		antag.current.remove_language(LANGUAGE_CULT)
-		for(var/spell/cult/spell_to_remove in antag.current.spell_list)
-			antag.current.remove_spell(spell_to_remove)
-		if (src in blood_communion)
-			blood_communion.Remove(src)
-		update_faction_icons()
-		return
+		antag.decult()
 	update_cult_hud()
 	antag.current.add_language(LANGUAGE_CULT)
 	if((ishuman(antag.current) || ismonkey(antag.current)) && !(locate(/spell/cult) in antag.current.spell_list))
 		antag.current.add_spell(new /spell/cult/trace_rune, "cult_spell_ready", /obj/abstract/screen/movable/spell_master/bloodcult)
 		antag.current.add_spell(new /spell/cult/erase_rune, "cult_spell_ready", /obj/abstract/screen/movable/spell_master/bloodcult)
+
+/datum/mind/proc/decult()
+	antag_roles -= CULTIST
+	current.remove_language(LANGUAGE_CULT)
+	for(var/spell/cult/spell_to_remove in current.spell_list)
+		current.remove_spell(spell_to_remove)
+	var/datum/role/cultist/C = GetRole(CULTIST)
+	if (C in blood_communion)
+		blood_communion.Remove(C)
+	update_faction_icons()
 
 /datum/role/cultist/process()
 	if (holywarning_cooldown > 0)


### PR DESCRIPTION
[role] [balance] [discussion]

This essentially was how it was in Cult II. Minus of course the ability to make security-aligned constructs.
Waiting for an headmin ruling (haha) I feel this is the mos reasonable course of action.

The current course of action with the rule that the shade remains a cultist would
1) Penalise security for trying to spare a cultist
2) Be very confusing for the poor culted person

Forbidding non-cultists to use stones would
1) Be gay
2) Remove a wizard feature

Closes #21805 