### PR TITLE
Adjust Midround Blob Costs

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -338,12 +338,12 @@
 	name = "Blob Overmind Storm"
 	role_category = /datum/role/blob_overmind/
 	my_fac = /datum/faction/blob_conglomerate/
-	enemy_jobs = list("AI", "Cyborg", "Security Officer", "Warden","Detective","Head of Security", "Captain")
-	required_enemies = list(3,3,3,3,3,2,1,1,0,0)
+	enemy_jobs = list("AI", "Cyborg", "Security Officer", "Station Engineer","Chief Engineer", "Roboticist","Head of Security", "Captain")
+	required_enemies = list(3,2,2,1,1,1,0,0,0,0)
 	required_candidates = 1
 	weight = 5
-	cost = 35
-	requirements = list(90,90,90,80,60,40,30,20,10,10)
+	cost = 15
+	requirements = list(90,60,40,40,40,40,30,20,15,15)
 	logo = "blob-logo"
 
 	makeBody = FALSE
@@ -358,9 +358,9 @@
 
 
 /datum/dynamic_ruleset/midround/from_ghosts/faction_based/blob_storm/review_applications()
-	command_alert(/datum/command_alert/blob_storm/overminds)
+	command_alert(/datum/command_alert/meteor_storm)
 	. = ..()
-	spawn (60 SECONDS)
+	spawn (120 SECONDS)
 		command_alert(/datum/command_alert/blob_storm/overminds/end)
 
 //////////////////////////////////////////////

--- a/code/datums/helper_datums/command_alerts.dm
+++ b/code/datums/helper_datums/command_alerts.dm
@@ -289,7 +289,7 @@ The access requirements on the Asteroid Shuttles' consoles have now been revoked
 
 /datum/command_alert/blob_storm/overminds/end
 	name = "Meteor Blob Cluster Ended (Overminds!)"
-	message = "The station has cleared the Blob conglomerate. Investigate the hit areas at once and clear the blob. Beware for possible Overmind presence."
+	message = "The station has passed through a Blob conglomerate. Investigate the hit areas at once and clear the blob. Beware for possible Overmind presence."
 
 /////////////GRAVITY
 


### PR DESCRIPTION
* Detective and Warden no longer enemies of blobstorm
* Station Engineer, Chief Engineer, and Roboticist are enemies of blobstorm
* Lowered number of enemies required at all threat levels
* Slashed threat_level requirements to fire
* Threat cost reduced 35->15
* Now when it starts, a fake meteor alert plays. After 120 seconds, the crew is warned it was a blobstorm.

🆑 
* tweak: Blobstorms are now much cheaper, require less extreme conditions to fire, and get a fake meteor warning at first (as well as more delay before announcing it was a blobstorm after all); roundstart blobs remain the same