### PR TITLE
Lowers Weight of RS Traitors

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -12,7 +12,7 @@
 	protected_from_jobs = list("Security Officer", "Merchant", "Warden", "Head of Personnel", "Cyborg", "Detective", "Head of Security", "Captain")
 	restricted_from_jobs = list("AI","Mobile MMI")
 	required_candidates = 1
-	weight = 7
+	weight = 3
 	cost = 10
 	requirements = list(10,10,10,10,10,10,10,10,10,10)
 	var/autotraitor_cooldown = 450//15 minutes (ticks once per 2 sec)
@@ -33,7 +33,7 @@
 	if (autotraitor_cooldown)
 		autotraitor_cooldown--
 	else
-		autotraitor_cooldown = 900//15 minutes
+		autotraitor_cooldown = 450//15 minutes
 		message_admins("Dynamic Mode: Checking if we can turn someone into a traitor...")
 		mode.picking_specific_rule(/datum/dynamic_ruleset/midround/autotraitor)
 


### PR DESCRIPTION
Some modes like Cult and Malf only exist as RS, while others like Blob and Revs play very differently if they fire at roundstart. We rarely see these because Traitor is always available as a ruleset and heavily weighted.

This makes its weight equal to Blob, Cult, Malf and Grinch, 50% stronger than vampires or revs. Please note that due to requiring only 1 candidate and no enemies (and I suspect having more people pref it), we will still see this ruleset more often by elimination

🆑 
* tweak: Tuned down the weight of roundstart traitors (which continually autotraitors more people every 15 minutes) from 7 to 3.