### PR TITLE
New Nuke OP uplink items, uplink refunding.

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -244,16 +244,6 @@ var/list/uplink_items = list()
 	cost = 40
 	jobs_exclusive = list("Nuclear Operative")
 
-/datum/uplink_item/dangerous/robot
-	name = "Syndicate Robot Teleporter"
-	desc = "A single-use teleporter used to deploy a syndicate robot that will help with your mission. Keep in mind that unlike NT silicons these don't have access to most of the station's machinery."
-	item = /obj/item/weapon/robot_spawner/syndicate
-	refund_path = /obj/item/weapon/robot_spawner //Any spawner is fine. They are super rare and need to be unused to pass the refund check anyways.
-	cost = 50
-	refund_amount = 25
-	jobs_exclusive = list("Nuclear Operative")
-	refundable = TRUE
-
 /datum/uplink_item/dangerous/dude_bombs_lmao
 	name = "Modified Tank Transfer Valve"
 	desc = "A small, expensive and powerful plasma-oxygen explosive. Handle very carefully."
@@ -261,6 +251,14 @@ var/list/uplink_items = list()
 	refund_path = /obj/item/device/transfer_valve/mediumsize
 	cost = 100
 	refund_amount = 15
+	jobs_exclusive = list("Nuclear Operative")
+	refundable = TRUE
+
+/datum/uplink_item/dangerous/robot
+	name = "Syndicate-modded Combat Robot Teleporter"
+	desc = "A single-use teleporter used to deploy a syndicate robot that will help with your mission. Keep in mind that unlike NT silicons these don't have access to most of the station's machinery."
+	item = /obj/item/weapon/robot_spawner/syndicate
+	cost = 100
 	jobs_exclusive = list("Nuclear Operative")
 	refundable = TRUE
 

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -46,6 +46,7 @@ var/list/uplink_items = list()
 	var/num_in_stock = 0	// Number of times this can be bought, globally. 0 is infinite
 	var/static/times_bought = 0
 	var/refundable = FALSE
+	var/refund_path = null // Alternative path for refunds, in case the item purchased isn't what is actually refunded (Bombs and such).
 	var/refund_amount // specified refund amount in case there needs to be a TC penalty for refunds.
 
 /datum/uplink_item/proc/get_cost(var/user_job, var/cost_modifier = 1)
@@ -241,6 +242,33 @@ var/list/uplink_items = list()
 	desc = "A huge minigun. Makes up for its lack of mobility and discretion with sheer firepower. Has 200 bullets."
 	item = /obj/item/weapon/gun/gatling
 	cost = 40
+	jobs_exclusive = list("Nuclear Operative")
+
+/datum/uplink_item/dangerous/robot
+	name = "Syndicate Robot Teleporter"
+	desc = "A single-use teleporter used to deploy a syndicate robot that will help with your mission. Keep in mind that unlike NT silicons these don't have access to most of the station's machinery."
+	item = /obj/item/weapon/robot_spawner/syndicate
+	refund_path = /obj/item/weapon/robot_spawner //Any spawner is fine. They are super rare and need to be unused to pass the refund check anyways.
+	cost = 50
+	refund_amount = 25
+	jobs_exclusive = list("Nuclear Operative")
+	refundable = TRUE
+
+/datum/uplink_item/dangerous/dude_bombs_lmao
+	name = "Modified Tank Transfer Valve"
+	desc = "A small, expensive and powerful plasma-oxygen explosive. Handle very carefully."
+	item = /obj/effect/spawner/newbomb
+	refund_path = /obj/item/device/transfer_valve/mediumsize
+	cost = 100
+	refund_amount = 15
+	jobs_exclusive = list("Nuclear Operative")
+	refundable = TRUE
+
+/datum/uplink_item/dangerous/mecha
+	name = "Syndicate Mass-Produced Assault Mecha - 'Mauler'"
+	desc = "A Heavy-duty combat unit. Not usually used by nuclear operatives, for its ridiculous pricetag and lack of stealth. Yet, against heavily-guarded stations, it might be just the thing." //Implying bombs aren't better.
+	item = /obj/effect/spawner/mecha/mauler
+	cost = 140
 	jobs_exclusive = list("Nuclear Operative")
 
 // STEALTHY WEAPONS
@@ -457,14 +485,6 @@ var/list/uplink_items = list()
 	item = /obj/item/device/does_not_tip_backdoor
 	num_in_stock = 1
 	cost = 10
-
-//datum/uplink_item/dangerous/robot
-//	name = "Syndicate Robot Teleporter"
-//	desc = "A single-use teleporter used to deploy a syndicate robot that will help with your mission. Keep in mind that unlike NT cyborgs/androids these don't have access to most of the station's machinery."
-//	item = /obj/item/weapon/robot_spawner/syndicate
-//	cost = 40
-//	jobs_exclusive = list("Nuclear Operative")
-//	refundable = TRUE
 
 // IMPLANTS
 

--- a/code/game/mecha/mecha_spawner.dm
+++ b/code/game/mecha/mecha_spawner.dm
@@ -1,0 +1,18 @@
+/obj/effect/spawner/mecha
+	name = "mecha teleport beacon"
+	var/mecha_type = null
+
+/obj/effect/spawner/mecha/New()
+	..()
+	spawn_mecha()
+
+/obj/effect/spawner/mecha/proc/spawn_mecha()
+	var/turf/T = get_turf(src)
+	var/obj/mecha = null
+	if(mecha_type && T)
+		mecha = new mecha_type(T)
+		spark(mecha, 4)
+	qdel(src)
+
+/obj/effect/spawner/mecha/mauler
+	mecha_type = /obj/mecha/combat/marauder/mauler

--- a/code/game/objects/items/robot/robot_items/robot_spawner.dm
+++ b/code/game/objects/items/robot/robot_items/robot_spawner.dm
@@ -24,6 +24,9 @@
 /obj/item/weapon/robot_spawner/attack_self(mob/user)
 	request_borg(user)
 
+/obj/item/weapon/robot_spawner/check_uplink_validity()
+	return charge > 0 ? TRUE : FALSE
+
 /obj/item/weapon/robot_spawner/attack_ghost(var/mob/dead/observer/O)
 	if(last_ping_time + ping_cooldown <= world.time)
 		last_ping_time = world.time
@@ -99,9 +102,6 @@
 	role = ROLE_OPERATIVE
 	jobban_roles = list("Syndicate", "AI", "Cyborg", "Mobile MMI")
 	faction = "syndicate"
-
-/obj/item/weapon/robot_spawner/syndicate/check_uplink_validity()
-	return charge
 
 /obj/item/weapon/robot_spawner/syndicate/post_recruited(mob/living/silicon/robot/R)
 	..()

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -692,6 +692,7 @@
 #include "code\game\mecha\mecha_construction_paths.dm"
 #include "code\game\mecha\mecha_control_console.dm"
 #include "code\game\mecha\mecha_parts.dm"
+#include "code\game\mecha\mecha_spawner.dm"
 #include "code\game\mecha\mecha_wreckage.dm"
 #include "code\game\mecha\combat\combat.dm"
 #include "code\game\mecha\combat\durand.dm"


### PR DESCRIPTION
:cl:
 * rscadd: The nuclear operative boombox uplink can now refund uplink items that are refundable.
 * rscadd: Adds the "Modified Tank Transfer Valve" to the uplink, for 100 TC, exclusive for nuclear operatives.
 * rscadd: Nuclear operatives can now refund modified TTVs to get 15 TCs for each of them.
 * rscadd: Adds the "Syndicate-modded Combat Robot Teleporter" to the uplink, for 100 TC, exclusive for nuclear operatives.
 * rscadd: Nuclear operatives can refund their unused teleporter to get their TCs back.
 * rscadd: Adds the "Syndicate Assault Mecha - 'Mauler'" to the uplink, for 140 TC, exclusive for nuclear operatives.
