### PR TITLE
Re-introducing Borer brain control...exclusively for monkeys!

### DIFF
--- a/code/game/dna/genes/monkey.dm
+++ b/code/game/dna/genes/monkey.dm
@@ -46,6 +46,10 @@
 		animation.master = null
 		qdel(animation)
 
+	for (var/mob/living/simple_animal/borer/borer in Mo)
+		if (borer.controlling)
+			Mo.do_release_control(0)
+
 	var/mob/living/carbon/human/O = new(src)
 	if(Mo.greaterform)
 		O.set_species(Mo.greaterform)
@@ -74,14 +78,13 @@
 	//	del(T)
 
 	O.forceMove(M.loc)
-
+	Mo.transferBorers(O)
 	if(M.mind)
 		M.mind.transfer_to(O)	//transfer our mind to the human
 
 
 	for(var/obj/item/W in (Mo.contents))
 		Mo.drop_from_inventory(W)
-	Mo.transferBorers(O)
 	if (connected) //inside dna thing
 		var/obj/machinery/dna_scannernew/C = connected
 		O.forceMove(C)

--- a/code/modules/mob/living/simple_animal/borer/chems.dm
+++ b/code/modules/mob/living/simple_animal/borer/chems.dm
@@ -31,6 +31,9 @@
 /datum/borer_chem/head/ryetalyn
 	id = RYETALYN
 
+/datum/borer_chem/head/methylin
+	id = METHYLIN
+
 /datum/borer_chem/chest/blood
 	id = BLOOD
 


### PR DESCRIPTION
It's my birthday, please let me have my playable monkeys at long last!
More seriously though, I often get the "borer egg about to hatch" prompt but never click it because I don't want to become another player's ~~parasite~~ symbiote, while other players who actually like to play borer may not find a willing player to host them. Being able to take control of a monkey should offer a nice compromise for both of those types.
Of course if the monkey was being controlled by the player, they can still resist to take back control, and I'm not giving borers back their power to harm them.

:cl:
* rscadd: Borers can now use the Assume Control verb when inside a monkey. If the monkey becomes a human afterwards, they lose control.
* rscadd: Borers can now secrete Methylin.