### PR TITLE
Fixes being able to dupe FULL STACKS of any item if it's small enough using the blunderbuss.

### DIFF
--- a/code/modules/projectiles/guns/projectile/constructable/blunderbuss.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/blunderbuss.dm
@@ -101,7 +101,7 @@
 		if(istype(W, /obj/item/stack))
 			var/obj/item/stack/S = W
 			S.use(1)
-			var/Y = new W.type(src)
+			var/Y = new W.type(src, 1)
 			loaded_item = Y
 		else
 			if(!user.drop_item(W, src))


### PR DESCRIPTION
closes #21834 