### PR TITLE
better borg damage warnings

### DIFF
--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -28,7 +28,7 @@
 	else
 		msg += "Its cover is closed.\n"
 
-	if(cell && cell.charge <= 0)
+	if(!cell || (cell && cell.charge <= 0))
 		msg += "<span class='warning'>Its battery indicator is blinking red!</span>\n"
 
 	switch(stat)
@@ -38,7 +38,9 @@
 		if(UNCONSCIOUS)
 			msg += "<span class='warning'>It doesn't seem to be responding.</span>\n"
 		if(DEAD)
-			msg += "<span class='deadsay'>It looks completely unsalvageable.</span>\n"
+			msg += "<span class='warning'>It is broken beyond functioning.</span>\n"
+			if(!client)
+				msg += "<span class='deadsay'>It looks completely unsalvageable.</span>\n" //ghosted
 	msg += "*---------*</span>"
 
 	to_chat(user, msg)


### PR DESCRIPTION
again related to #21832 but not necessarily a close

🆑 
 - rscadd: Borgs now have slightly better examine text to indicate when they're really broken and when their cells are busted