### PR TITLE
Roidstation 2.5 - Goonsat, Bug Fixes, Labor Console - Attempt #2

### DIFF
--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -750,6 +750,33 @@
 	corpsemask = /obj/item/clothing/mask/breath
 	corpsehelmet = /obj/item/clothing/head/helmet/space/capspace
 
+/obj/effect/landmark/corpse/waifu
+	name = "Waifu"
+	corpseuniform = /obj/item/clothing/under/schoolgirl
+	corpseshoes = /obj/item/clothing/shoes/kneesocks
+	corpsehelmet = /obj/item/clothing/head/kitty
+	corpseradio = /obj/item/device/radio/headset
+	corpseid = 1
+	corpseidjob = "Waifu"
+	corpseidaccess = "Assistant"
+	corpsegender = G_FEMALE
+
+/obj/effect/landmark/corpse/waifu/secfu
+	corpseuniform = /obj/item/clothing/under/securityskirt/elite
+	corpsehelmet = /obj/item/clothing/head/beret/sec
+	corpseback = /obj/item/weapon/storage/backpack/security
+	corpseradio = /obj/item/device/radio/headset/headset_sec
+	corpseglasses = /obj/item/clothing/glasses/sunglasses/sechud
+	corpsebelt = /obj/item/weapon/storage/belt/security
+	corpsegloves = /obj/item/clothing/gloves/black
+	corpseshoes = /obj/item/clothing/shoes/jackboots
+	corpsepocket1 = /obj/item/weapon/handcuffs
+	corpsepocket2 = /obj/item/device/flash
+	corpseid = 1
+	corpseidjob = "Waifu"
+	corpseidaccess = "Security Officer"
+	corpsegender = G_FEMALE
+
 /////////////////Non-Crew (but still playable at roundstart)//////////////////////
 
 /obj/effect/landmark/corpse/trader

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -761,7 +761,7 @@
 	corpseidaccess = "Assistant"
 	corpsegender = G_FEMALE
 
-/obj/effect/landmark/corpse/waifu/secfu
+/obj/effect/landmark/corpse/waifu/secfu //bodybag sold separately.
 	corpseuniform = /obj/item/clothing/under/securityskirt/elite
 	corpsehelmet = /obj/item/clothing/head/beret/sec
 	corpseback = /obj/item/weapon/storage/backpack/security
@@ -773,6 +773,7 @@
 	corpsepocket1 = /obj/item/weapon/handcuffs
 	corpsepocket2 = /obj/item/device/flash
 	corpseid = 1
+	name = "Lucy Pinata"
 	corpseidjob = "Waifu"
 	corpseidaccess = "Security Officer"
 	corpsegender = G_FEMALE


### PR DESCRIPTION
[roid]

Pretty much what it says on the tin. New, custom Goonsat is the big change.

Picture: https://lambda.sx/QO7.JPG

Closes #21618 
Closes #21591 
Closes #21693 

:cl:
 * rscadd: Asteroid Station has been authorized to hire new crew and has accordingly been provided with a Labor Administration Console. Hopefully not all of the new crew will be clowns.
 * rscadd: Since most of the giant spiders were exterminated, carp have begun to nest more freely among the 'roids. Crew are advised to be more cautious of deep space.
 * bugfix: Some missing pipes and wiring were connected. A few doors in the Gateway and Science had their locks replaced as well.
 * rscadd: Dare you enter the Tomb of Azalin, the Wizard-King, to rescue the captive damsel in distress?
 * rscadd: Added waifu and secfu corpses which other mappers may find useful.