### PR TITLE
borg cover pops open on cell damage

### DIFF
--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -27,6 +27,12 @@
 	var/obj/item/broken_device/G = new/obj/item/broken_device
 	G.component = wrapped.type // the broken component now "remembers" the component it used to be, now it's scrap. This is used to fix the scrap into the component it was.
 	var/brokenpartname = wrapped.name
+	if(ispowercell(wrapped)) //dead cell unlocks the cover
+		if(owner.locked)
+			owner.locked = FALSE 
+			owner.visible_message("A click sounds from <span class='name'>[owner]</span>, indicating the automatic cover release failsafe.")
+			if(owner.can_diagnose())
+				to_chat(owner, "<span class='notice' style=\"font-family:Courier\">Cover auto-unlocked.</span>")
 	wrapped = G
 
 	// The thing itself isn't there anymore, but some fried remains are.

--- a/code/modules/mob/living/silicon/robot/death.dm
+++ b/code/modules/mob/living/silicon/robot/death.dm
@@ -42,7 +42,9 @@
 	update_canmove()
 	if(!gibbed)
 		updateicon() //Don't call updateicon if you're already null.
-		locked = FALSE //Cover unlocks.
+		if (locked)
+			locked = FALSE //Cover unlocks.
+			visible_message("A click sounds from <span class='name'>[src]</span>, indicating the automatic cover release failsafe.")
 	if(camera)
 		camera.status = FALSE
 	if(station_holomap)


### PR DESCRIPTION
closes #21832

🆑 
 - rscadd: Borgs covers now automatically unlock when their cells are destroyed. This was already the case for when they died.
 - tweak: There's now a message when a borg's cover automatically unlocks (ie when their cell is destroyed or when they die)