### PR TITLE
Fixing an issue that prevents multiple of the same area marker icon from appearing

### DIFF
--- a/code/modules/html_interface/map/station_map.dm
+++ b/code/modules/html_interface/map/station_map.dm
@@ -86,7 +86,7 @@
 				newMarker.x = T.x
 				newMarker.y = T.y
 				newMarker.z = ZLevel
-				holomap_markers[newMarker.id+"_\ref[src]"] = newMarker
+				holomap_markers[newMarker.id+"_\ref[A]"] = newMarker
 
 
 /proc/generateHoloMinimap(var/zLevel=1)

--- a/code/modules/html_interface/map/station_map.dm
+++ b/code/modules/html_interface/map/station_map.dm
@@ -86,7 +86,7 @@
 				newMarker.x = T.x
 				newMarker.y = T.y
 				newMarker.z = ZLevel
-				holomap_markers[newMarker.id] = newMarker
+				holomap_markers[newMarker.id+"_\ref[src]"] = newMarker
 
 
 /proc/generateHoloMinimap(var/zLevel=1)


### PR DESCRIPTION
This fix having the Vox outpost bar showing up, but not the station bar showing up on the Station Map (on RoidStation)