### PR TITLE
Reduces attack delay on Bloodlust

### DIFF
--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -342,7 +342,7 @@
 	throwforce = 3
 	throw_speed = 1
 	throw_range = 5
-	attack_delay = 25 // Heavy.
+	attack_delay = 15 // Heavy.//Come on man that makes it useless (reduced it)
 	w_class = W_CLASS_LARGE
 	flags = FPRINT | TWOHANDABLE
 	mech_flags = MECH_SCAN_ILLEGAL


### PR DESCRIPTION
Turns out it's actually kind of terrible because it has as much damage as roughly a dual energy sword and if I recall doesn't really have 100% energy deflection rate
:cl:
 * balance: The Bloodlust dual-handed weapon had the attack delay reduced by 1 second (from 2.5 seconds).