### PR TITLE
Fixes armor penetration and adds it to melee energy weapons

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -8,6 +8,7 @@
 	var/r_speed = 1.0
 	var/health = null
 	var/hitsound = null
+	var/armor_penetration = 0 // Chance from 0 to 100 to reduce absorb by one, and then rolls the same value. Check living_defense.dm
 
 	var/w_class = W_CLASS_MEDIUM
 	var/attack_delay = 10 //Delay between attacking with this item, in 1/10s of a second (default = 1 second)

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -35,6 +35,7 @@
 	siemens_coefficient = 1
 	origin_tech = Tc_COMBAT + "=3"
 	attack_verb = list("attacks", "chops", "cleaves", "tears", "cuts")
+	armor_penetration = 50
 
 
 /obj/item/weapon/melee/energy/axe/suicide_act(mob/user)
@@ -47,6 +48,7 @@
 	force = 3
 	active_force = 30
 	throwforce = 5
+	armor_penetration = 50
 
 /obj/item/weapon/melee/energy/sword
 	name = "energy sword"
@@ -72,6 +74,7 @@
 	w_class = W_CLASS_LARGE
 	sharpness = sharpness_on
 	sharpness_flags = SHARP_TIP | SHARP_BLADE | INSULATED_EDGE | HOT_EDGE | CHOPWOOD
+	armor_penetration = 100
 	hitsound = "sound/weapons/blade1.ogg"
 	update_icon()
 
@@ -110,6 +113,7 @@
 		w_class = W_CLASS_LARGE
 		sharpness = sharpness_on
 		sharpness_flags = SHARP_TIP | SHARP_BLADE | INSULATED_EDGE | HOT_EDGE | CHOPWOOD
+		armor_penetration = 100
 		hitsound = "sound/weapons/blade1.ogg"
 		playsound(user, 'sound/weapons/saberon.ogg', 50, 1)
 		to_chat(user, "<span class='notice'> [src] is now active.</span>")
@@ -118,6 +122,7 @@
 		w_class = W_CLASS_SMALL
 		sharpness = 0
 		sharpness_flags = 0
+		armor_penetration = initial(armor_penetration)
 		playsound(user, 'sound/weapons/saberoff.ogg', 50, 1)
 		hitsound = "sound/weapons/empty.ogg"
 		to_chat(user, "<span class='notice'> [src] can now be concealed.</span>")
@@ -146,15 +151,6 @@
 	base_state = "bsword0"
 	active_state = "bsword1"
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/swords_axes.dmi', "right_hand" = 'icons/mob/in-hand/right/swords_axes.dmi')
-	force = 3
-	throwforce = 5
-	throw_speed = 1
-	throw_range = 5
-	w_class = W_CLASS_SMALL
-	flags = FPRINT
-	origin_tech = Tc_MAGNETS + "=3;" + Tc_SYNDICATE + "=4"
-	attack_verb = list("attacks", "slashes", "stabs", "slices", "tears", "rips", "dices", "cuts")
-
 
 /obj/item/weapon/melee/energy/sword/bsword/update_icon()
 	if(active)
@@ -205,6 +201,7 @@
 	siemens_coefficient = 1
 	origin_tech = Tc_COMBAT + "=3" + Tc_SYNDICATE + "=3"
 	attack_verb = list("attacks", "dices", "cleaves", "tears", "cuts", "slashes",)
+	armor_penetration = 50
 	var/event_key
 
 /obj/item/weapon/melee/energy/hfmachete/update_icon()
@@ -228,6 +225,7 @@
 		throw_speed = 3
 		sharpness = 1.7
 		sharpness_flags += HOT_EDGE
+		armor_penetration = 100
 		to_chat(user, "<span class='warning'> [src] starts vibrating.</span>")
 		playsound(user, 'sound/weapons/hfmachete1.ogg', 40, 0)
 		event_key = user.on_moved.Add(src, "mob_moved")
@@ -237,6 +235,7 @@
 		throw_speed = initial(throw_speed)
 		sharpness = initial(sharpness)
 		sharpness_flags = initial(sharpness_flags)
+		armor_penetration = initial(armor_penetration)
 		to_chat(user, "<span class='notice'> [src] stops vibrating.</span>")
 		playsound(user, 'sound/weapons/hfmachete0.ogg', 40, 0)
 		user.on_moved.Remove(event_key)
@@ -299,5 +298,6 @@
 	sharpness = 1.7
 	w_class = W_CLASS_LARGE
 	sharpness_flags = SHARP_BLADE | SERRATED_BLADE | CHOPWOOD | HOT_EDGE
+	armor_penetration = 100
 	hitsound = get_sfx("machete_hit")
 	update_icon()

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -207,6 +207,7 @@
 		src.w_class = W_CLASS_HUGE
 		src.sharpness = 1.5
 		src.sharpness_flags = SHARP_BLADE | HOT_EDGE
+		src.armor_penetration = 100
 	else
 		to_chat(user, "<span class='notice'>\The [src] can now be concealed.</span>")
 		src.force = initial(src.force)
@@ -214,6 +215,7 @@
 		src.w_class = initial(src.w_class)
 		src.sharpness = initial(src.sharpness)
 		src.sharpness_flags = initial(src.sharpness_flags)
+		src.armor_penetration = initial(armor_penetration)
 	src.add_fingerprint(user)
 	return
 

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -126,6 +126,7 @@
 	w_class = wielded ? 5 : 2
 	sharpness_flags = wielded ? SHARP_TIP | SHARP_BLADE | INSULATED_EDGE | HOT_EDGE | CHOPWOOD : 0
 	sharpness = wielded ? 1.5 : 0
+	armor_penetration = wielded ? 100 : 0
 	hitsound = wielded ? "sound/weapons/blade1.ogg" : "sound/weapons/empty.ogg"
 	if(user)
 		user.update_inv_hands()
@@ -163,27 +164,11 @@
 	name = "banana bunch"
 	desc = "Potential for some serious chaos."
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/swords_axes.dmi', "right_hand" = 'icons/mob/in-hand/right/swords_axes.dmi')
-	force = 3
-	throwforce = 5.0
-	throw_speed = 1
-	throw_range = 5
-	w_class = W_CLASS_SMALL
-	flags = FPRINT | TWOHANDABLE
-	origin_tech = Tc_MAGNETS + "=3;" + Tc_SYNDICATE + "=4"
-	attack_verb = list("attacks", "slashes", "stabs", "slices", "tears", "rips", "dices", "cuts")
 
 /obj/item/weapon/dualsaber/bananabunch/update_wield(mob/user)
 	..()
 	icon_state = "bananabunch[wielded ? 1 : 0]"
 	item_state = "bananabunch[wielded ? 1 : 0]"
-	force = wielded ? 30 : 3
-	w_class = wielded ? 5 : 2
-	sharpness_flags = wielded ? SHARP_TIP | SHARP_BLADE | INSULATED_EDGE | HOT_EDGE | CHOPWOOD : 0
-	sharpness = wielded ? 1.5 : 0
-	hitsound = wielded ? "sound/weapons/blade1.ogg" : "sound/weapons/empty.ogg"
-	if(user)
-		user.update_inv_hands()
-	playsound(src, wielded ? 'sound/weapons/saberon.ogg' : 'sound/weapons/saberoff.ogg', 50, 1)
 	return
 
 /obj/item/weapon/dualsaber/bananabunch/attack(target as mob, mob/living/user as mob)
@@ -237,6 +222,7 @@
 	item_state = "hfrequency[wielded ? 1 : 0]"
 	force = wielded ? 200 : 50
 	sharpness = wielded ? 100 : 2
+	armor_penetration = wielded ? 100 : 50
 	if(user)
 		user.update_inv_hands()
 	return
@@ -358,6 +344,7 @@
 	force = wielded ? 34 : initial(force)
 	sharpness_flags = wielded ? SHARP_BLADE | SERRATED_BLADE | HOT_EDGE : initial(sharpness_flags)
 	sharpness = wielded ? 2 : initial(sharpness)
+	armor_penetration = wielded ? 100 : 50
 	to_chat(user, wielded ? "<span class='warning'> [src] starts vibrating.</span>" : "<span class='notice'> [src] stops vibrating.</span>")
 	playsound(user, wielded ? 'sound/weapons/hfmachete1.ogg' : 'sound/weapons/hfmachete0.ogg', 40, 0 )
 	if(user)

--- a/code/modules/mob/living/carbon/combat.dm
+++ b/code/modules/mob/living/carbon/combat.dm
@@ -53,7 +53,7 @@
 	var/armor
 	if(affecting)
 		var/hit_area = affecting.display_name
-		armor = run_armor_check(affecting, "melee", "Your armor protects your [hit_area].", "Your armor softens the hit to your [hit_area].")
+		armor = run_armor_check(affecting, "melee", "Your armor protects your [hit_area].", "Your armor softens the hit to your [hit_area].", armor_penetration = I.armor_penetration)
 		if(armor >= 2)
 			return TRUE //We still connected
 		if(!I.force)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -38,7 +38,6 @@ var/list/impact_master = list()
 
 	var/grillepasschance = 66
 	var/damage = 10
-	var/armor_penetration = 0 //Probability out of 100 whether this will penetrate the persons armor
 	var/damage_type = BRUTE //BRUTE, BURN, TOX, OXY, CLONE are the only things that should be in here
 	var/nodamage = 0 //Determines if the projectile will skip any damage inflictions
 	var/flag = "bullet" //Defines what armor to use when it hits things.  Must be set to bullet, laser, energy,or bomb	//Cael - bio and rad are also valid


### PR DESCRIPTION
This is more of a bugfix/balance stuff, but treat it as balance. If this doesn't pass I'm gonna just make the skinny armor penetration fix
Some weapons have 0 armor penetration when inactive, others have 50% armor penetration while inactive, while all of them have 100% armor penetration when active.
Melee energy weapons are weak against armor due to the way armor works: Roll the dice from 1 to 100 based on the armor value, and then roll it again. If it rolls at least once, the damage is halved. If it rolls both times, the damage is nullified. This works by adding 1 to the "absorb" value every time it succeeds. Armor penetration is the opposite, every time it rolls based on probability it reduces the "absorb" value by 1. Long story short armor penetration didn't even exist for melee items. It was projectile-only. This PR fixes that and also adds very solid armor penetration for the energy weapons that are literally extremely, extremely hot blades.
:cl:
 * bugfix: Armor penetration now works for melee weapons.
 * rscadd: Added armor penetration to melee energy weapons!