### PR TITLE
No Blob on Roidstation

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_readme.dm
+++ b/code/datums/gamemode/dynamic/dynamic_readme.dm
@@ -56,6 +56,7 @@ picking_specific_rule(ruletype,forced) -> forced OR acceptable(living_players, t
 RULESET
 acceptable(population,threat) just checks if enough threat_level for population indice.
 **NOTE that we currently only send threat_level as the second arg, not threat.
+ready(forced) checks if enough candidates and calls the map's map_ruleset(dynamic_ruleset) at the parent level
 logo_state: if creating a non-faction role, name should be the same for both the role (for role_HUD_icons.dmi) and the ruleset (for logos.dmi) to prevent scoreboard bugs
 
 trim_candidates() varies significantly according to the ruleset type

--- a/code/datums/gamemode/dynamic/dynamic_rulesets.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets.dm
@@ -65,6 +65,8 @@
 /datum/dynamic_ruleset/proc/ready(var/forced = 0)	//Here you can perform any additional checks you want. (such as checking the map, the amount of certain jobs, etc)
 	if (required_candidates > candidates.len)		//IMPORTANT: If ready() returns 1, that means execute() should never fail!
 		return 0
+	if (!map.map_ruleset(src))
+		return 0
 	return 1
 
 /datum/dynamic_ruleset/proc/get_weight()

--- a/maps/_map.dm
+++ b/maps/_map.dm
@@ -103,6 +103,9 @@
 		for(var/T in load_map_elements)
 			load_dungeon(T)
 
+/datum/map/proc/map_ruleset(var/datum/dynamic_ruleset/DR)
+	return TRUE //If false, fails Ready()
+
 /datum/map/proc/loadZLevels(list/levelPaths)
 
 

--- a/maps/roidstation.dm
+++ b/maps/roidstation.dm
@@ -36,6 +36,11 @@
 	center_x = 177
 	center_y = 193
 
+/datum/map/active/map_ruleset(var/datum/dynamic_ruleset/DR)
+	if(istype(DR.role_category,/datum/role/blob_overmind))
+		return FALSE
+	return TRUE
+
 ////////////////////////////////////////////////////////////////
 #include "roidstation/areas.dm"
 #include "roidstation.dmm"


### PR DESCRIPTION
Reports from players are that Blob feels irreconcilably bad on Roid.

If this gets merged, it will forever shut off Blob from Roid. Also adds a new function where the mapfile gets to yes/no a ruleset, so we could have map specific antags. The possibilities: player-controlled megaroidmonster for Roid? Maintenance Clowns for Deff? Box Baby's Day Out on Box?

🆑 
* tweak: Blob (RS/MR) will not happen on Roid.