### PR TITLE
[Cult Balance - March 2019] Pulling stuff through cult doors

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
@@ -1274,7 +1274,7 @@ var/list/bloodstone_list = list()
 
 	bloodstone_list.Add(src)
 	for (var/obj/O in loc)
-		if (O != src)
+		if (O != src && !istype(O,/obj/item/weapon/melee/soulblade))
 			O.ex_act(2)
 	safe_space()
 	set_light(3)

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_effects.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_effects.dm
@@ -434,14 +434,14 @@ var/list/bloodstone_backup = 0
 /obj/effect/stun_indicator/New()
 	..()
 	if (!ismob(loc))
-		qdel()
+		qdel(src)
 		return
 
 	victim = loc
 	current_dots = Clamp(round(victim.knockdown/2.5),0,5)
 
 	if (!current_dots)
-		qdel()
+		qdel(src)
 		return
 
 	current_dots++//so we get integers from 1 to 6

--- a/code/datums/gamemode/objectives/bloodcult.dm
+++ b/code/datums/gamemode/objectives/bloodcult.dm
@@ -50,7 +50,7 @@
 			target_role = (sacrifice_target.mind.assigned_role=="MODE") ? "" : ", the ([sacrifice_target.mind.assigned_role]),"
 		if (iscultist(sacrifice_target))
 			target_role = ", the cultist,"
-		explanation_text = "The Sacrifice: Nar-Sie requires the flesh of [sacrifice_target.real_name][target_role] to breach reality. Sacrifice them at an altar using a cult blade."
+		explanation_text = "The Sacrifice: Nar-Sie requires the flesh of [sacrifice_target.real_name][target_role] to breach reality. Sacrifice them at an altar using a cult blade. If you feel merciful for their soul, you may use an empty soul blade instead."
 		message_admins("Blood Cult: ACT II has begun, the sacrifice target is [sacrifice_target.real_name][target_role].")
 		log_admin("Blood Cult: ACT II has begun, the sacrifice target is [sacrifice_target.real_name][target_role].")
 		var/datum/faction/bloodcult/cult = faction
@@ -68,7 +68,7 @@
 			target_role = (sacrifice_target.mind.assigned_role=="MODE") ? "" : ", the ([sacrifice_target.mind.assigned_role]),"
 		if (iscultist(sacrifice_target))
 			target_role = ", the cultist,"
-		explanation_text = "The Sacrifice: Nar-Sie requires the flesh of [sacrifice_target.real_name][target_role] to breach reality. Sacrifice them at an altar using a cult blade."
+		explanation_text = "The Sacrifice: Nar-Sie requires the flesh of [sacrifice_target.real_name][target_role] to breach reality. Sacrifice them at an altar using a cult blade. If you feel merciful for their soul, you may use an empty soul blade instead."
 		message_admins("Blood Cult: The cult didn't sacrifice their target in time, a new target has been assigned, the new sacrifice target is [sacrifice_target.real_name][target_role].")
 		log_admin("Blood Cult: The cult didn't sacrifice their target in time, a new target has been assigned, the new sacrifice target is [sacrifice_target.real_name][target_role].")
 		var/datum/faction/bloodcult/cult = faction

--- a/code/game/machinery/doors/mineral.dm
+++ b/code/game/machinery/doors/mineral.dm
@@ -307,6 +307,10 @@
 
 /obj/machinery/door/mineral/cult/Uncrossed(var/atom/movable/mover)
 	if (!density && !operating && !(locate(/mob/living) in loc))
+		if (ismob(mover))
+			var/mob/M = mover
+			if (M.pulling && loc)
+				M.pulling.forceMove(loc)//so we don't stop pulling stuff when moving through cult doors
 		close()
 
 /obj/machinery/door/mineral/cult/TryToSwitchState(atom/user)
@@ -331,7 +335,8 @@
 
 /obj/machinery/door/mineral/cult/attackby(var/obj/item/weapon/W, var/mob/user)
 	if(istype(W, /obj/item/weapon/card))
-		to_chat(user, "You swipe your card at \the [src], petulantly expecting a result.")
+		user.visible_message("\The [user] swipes their card at \the [src], petulantly expecting a result.</span>",
+							"You swipe your card at \the [src], petulantly expecting a result.")
 	else
 		health -= W.force
 		to_chat(user, "You hit \the [src] with your [W.name]!")


### PR DESCRIPTION
* You can now pull stuff through cult doors (they previously closed immediately, preventing you from dragging stuff through, which is pretty irritating)
* Updated the sacrifice objective's explanation text to remind cultists that they can soulstone the people they sacrifice by using an empty soul blade.
* Bloodstones spawning will no longer harm soul blades (especially those that got used during a sacrifice)