### PR TITLE
Turning internal organs robotic or organic actually works now (bugfix)

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1429,16 +1429,16 @@
 
 // Makes all robotic limbs organic.
 /mob/living/carbon/human/proc/make_robot_limbs_organic()
-	for(var/datum/organ/external/O in src.organs)
+	for(var/datum/organ/external/O in organs)
 		if(O.is_robotic())
-			O.status &= ~ORGAN_ROBOT
+			O.fleshify()
 	update_icons()
+	update_body()
 
 // Makes all robot internal organs organic.
 /mob/living/carbon/human/proc/make_robot_internals_organic()
-	for(var/datum/organ/internal/O in src.organs)
-		if(O.robotic)
-			O.robotic = 0
+	for(var/datum/organ/internal/O in internal_organs)
+		O.robotic = 0
 
 // Makes all robot organs, internal and external, organic.
 /mob/living/carbon/human/proc/make_all_robot_parts_organic()
@@ -1448,13 +1448,15 @@
 // Makes all limbs robotic.
 /mob/living/carbon/human/proc/make_organic_limbs_robotic()
 	for(var/datum/organ/external/O in organs)
-		O.robotize()
+		if(!O.is_robotic())
+			O.robotize()
 	update_icons()
+	update_body()
 
 // Makes all internal organs robotic.
 /mob/living/carbon/human/proc/make_organic_internals_robotic()
-	for(var/datum/organ/internal/O in organs)
-		O.robotic = TRUE
+	for(var/datum/organ/internal/O in internal_organs)
+		O.robotic = 2
 
 // Makes all organs, internal and external, robotic.
 /mob/living/carbon/human/proc/make_all_organic_parts_robotic()


### PR DESCRIPTION
Turns out there's a difference between organs (limbs, basically the stuff you can select in zone targeting) and internal_organs
Fixes #21437 
This was tested by joining the game with every organ and internal organ being robotic and turning into a wizard and then using EMP spell, as well as checking vars
:cl:
 * bugfix: Fixed turning internal organs between organic and robotic process not working. For instance, wizard will no longer spawn with robotic internal organs, causing the wizard to immediately die when they use the "Disable Technology" spell.