### PR TITLE
Improves Weeb QoL (SBO69-72)

### DIFF
--- a/code/datums/gamemode/role/weeaboo.dm
+++ b/code/datums/gamemode/role/weeaboo.dm
@@ -6,6 +6,7 @@
 	logo_state = "weeaboo-logo"
 	refund_value = BASE_SOLO_REFUND
 	wikiroute = WEEABOO
+	disallow_job = TRUE
 	restricted_jobs = list("Trader") //Spawns in space
 
 /datum/role/weeaboo/OnPostSetup()
@@ -33,7 +34,7 @@
 			to_chat(antag.current, "<img src='data:image/png;base64,[icon2base64(logo)]' style='position: relative; top: 10;'/> <span class='danger'>You are a Space Weeaboo.<br>The crew has insulted glorious Space Nippon. Equipped with your authentic Space Kimono, your Space Katana that was folded over a million times, and your honobru bushido code, you must implore them to reconsider!</span>")
 
 	to_chat(antag.current, "<span class='danger'>Remember that guns are not honobru, and that your katana has an ancient power imbued within it. Take a closer look at it if you've forgotten how it works.</span>")
-
+	to_chat(antag.current, "<span class='info'><a HREF='?src=\ref[antag.current];getwiki=[wikiroute]'>(Wiki Guide)</a></span>")
 
 //Weeb Items
 
@@ -201,8 +202,8 @@
 		if(H.mind.GetRole(WEEABOO))
 
 			var/list/choices = list(
-				list("Make Shuriken", "radial_cook"),
-				list("Charge Sword", "radial_zap"),
+				list("Make Shuriken", "radial_cook", "Fabricate a new shuriken. Cost: 1000."),
+				list("Charge Sword", "radial_zap", "Reset the cooldown on your blade's teleport. Cost: 40 per second."),
 			)
 			var/event/menu_event = new(owner = user)
 			menu_event.Add(src, "radial_check_handler")

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -75,6 +75,7 @@ var/list/role_wiki=list(
 	ROLE_VOXRAIDER		= "Vox_Raider",
 	ROLE_WIZARD			= "Wizard",
 	ROLE_GRINCH			= "Grinch",
+	WEEABOO				= "Crazed_Weeaboo",
 	ROLE_MINOR			= "Minor_Roles",
 )
 


### PR DESCRIPTION
fixes #21894
fixes #21752
fixes #21903 

🆑 
* bugfix: Fixed a bug where the special roles panel did not link to Crazed Weeaboo page.
* tweak: Also added a link to the greet for weeaboo
* bugfix: Weeaboos no longer get job equipment calls when latejoining (e.g.: choosing a chaplain religion)
* bugfix: Weeaboos no longer get a fake name announced or injected when they join
* rscadd: Added tooltips with costs to the NinTendie Glove