### PR TITLE
longer morgue / bodybag nametags

### DIFF
--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -50,7 +50,7 @@
 		new /obj/structure/morgue(src.loc)
 		qdel(src)
 	else if(istype(W, /obj/item/weapon/pen) || istype(W, /obj/item/device/flashlight/pen))
-		set_tiny_label(user)
+		set_tiny_label(user, maxlength=32)
 	else if(iswirecutter(W))
 		remove_label()
 		to_chat(user, "<span class='notice'>You cut the tag off the bodybag.</span>")

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -140,7 +140,7 @@
 		else
 			dir=4
 	if (istype(P, /obj/item/weapon/pen))
-		set_tiny_label(user, " - '", "'")
+		set_tiny_label(user, " - '", "'", maxlength=32)
 	src.add_fingerprint(user)
 
 /obj/structure/morgue/relaymove(mob/user as mob)
@@ -310,7 +310,7 @@
 
 /obj/structure/crematorium/attackby(P as obj, mob/user as mob)
 	if (istype(P, /obj/item/weapon/pen))
-		set_tiny_label(user, " - '", "'")
+		set_tiny_label(user, " - '", "'", maxlength=32)
 	src.add_fingerprint(user)
 
 /obj/structure/crematorium/relaymove(mob/user as mob)

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -164,12 +164,12 @@
 
 // Not really sure where to put this. This is a verb that lets you add a tiny label to the item without consuming label rolls or anything.
 // Used for pen-labeling pill bottles, beakers and whatnot.
-/atom/proc/set_tiny_label(var/mob/user, var/start_text = " (", var/end_text = ")")
+/atom/proc/set_tiny_label(var/mob/user, var/start_text = " (", var/end_text = ")", var/maxlength=16)
 	var/tmp_label = sanitize(input(user, "Enter a label for \the [src]","Label",copytext(labeled, length(start_text)+1, length(labeled)-length(end_text)+1)) as text|null)
 	if (!Adjacent(user) || user.incapacitated() || !tmp_label || !length(tmp_label))
 		return FALSE
-	if(length(tmp_label) > 16)
-		to_chat(user, "<span class='warning'>The label can be at most 16 characters long.</span>")
+	if(length(tmp_label) > maxlength)
+		to_chat(user, "<span class='warning'>The label can be at most [maxlength] characters long.</span>")
 		return FALSE
 	to_chat(user, "<span class='notice'>You set the label to \"[tmp_label]\".</span>")
 	set_labeled(tmp_label, start_text, end_text)


### PR DESCRIPTION
This adds a maxlength var to the proc that governs morgue/bodybag labels, allowing for double length bag tags.
closes #21918

🆑 
 - tweak: Doubled allowed tag length for morgues and bodybags