### PR TITLE
some small Cult fixes, QoL, and Sacrifice reroll rework

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult.dm
@@ -300,8 +300,12 @@ var/veil_thickness = CULT_PROLOGUE
 		AppendObjective(new_obj)
 		for(var/datum/role/cultist/C in members)
 			var/mob/M = C.antag.current
-			if (M)
+			if (M && iscultist(M))
 				to_chat(M,"<span class='danger'>[new_obj.name]</span><b>: [new_obj.explanation_text]</b>")
+				//ACT 1
+				if (istype(new_obj,/datum/objective/bloodcult_followers))
+					to_chat(M,"<b>As our ritual progresses through its Acts, the veil gets thinner, and dormant runes awaken. Summon a tome (<span class='danger'>See Blood Hell</span>) to see the available runes and learn their uses.</b>")
+				//ACT 2
 				if (istype(new_obj,/datum/objective/bloodcult_sacrifice))
 					var/datum/objective/bloodcult_sacrifice/O = new_obj
 					if (M == O.sacrifice_target)
@@ -312,10 +316,10 @@ var/veil_thickness = CULT_PROLOGUE
 		for (var/datum/role/cultist/C in members)
 			C.update_cult_hud()
 
-		for (var/obj/structure/cult/spire/S in cult_spires)
+		for (var/obj/structure/cult/spire/S in cult_spires)//spires update their appearance on Act 2 and 3, signaling new available tattoos.
 			S.upgrade()
 
-		for (var/obj/effect/rune/R in rune_list)
+		for (var/obj/effect/rune/R in rune_list)//runes now available will start pulsing
 			R.update_icon()
 
 		if (istype(new_obj,/datum/objective/bloodcult_bloodbath))

--- a/code/datums/gamemode/factions/bloodcult/bloodcult.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult.dm
@@ -160,8 +160,8 @@ var/veil_thickness = CULT_PROLOGUE
 	logo_state = "cult-logo"
 	hud_icons = list("cult-logo")
 	var/list/bloody_floors = list()
-	var/target_change = FALSE
-	var/change_cooldown = 0
+	//var/target_change = FALSE
+	//var/change_cooldown = 0
 	var/cult_win = FALSE
 	var/warning = FALSE
 
@@ -203,8 +203,10 @@ var/veil_thickness = CULT_PROLOGUE
 	initialize_cultwords()
 	AppendObjective(/datum/objective/bloodcult_reunion)
 
+/*
 /datum/faction/bloodcult/process()
 	..()
+
 	if (change_cooldown > 0)
 		change_cooldown -= 1 SECONDS
 		if (change_cooldown <= 0)
@@ -224,6 +226,7 @@ var/veil_thickness = CULT_PROLOGUE
 	if (target_change)
 		target_change = FALSE
 		change_cooldown = SACRIFICE_CHANGE_COOLDOWN
+*/
 
 /datum/faction/bloodcult/proc/progress(var/new_act,var/A)
 	//This proc is called to update the faction's current objectives, and veil thickness
@@ -308,10 +311,13 @@ var/veil_thickness = CULT_PROLOGUE
 				//ACT 2
 				if (istype(new_obj,/datum/objective/bloodcult_sacrifice))
 					var/datum/objective/bloodcult_sacrifice/O = new_obj
-					if (M == O.sacrifice_target)
-						to_chat(M,"<b>There is no greater honor than purposefuly relinquishing your body for the coming of Nar-Sie, but you may wait for another target to be selected should you be afraid of death.</b>")
-					else if (iscultist(O.sacrifice_target))
-						to_chat(M,"<b>Chance has rolled its dice, and one of ours was selected. If for whatever reasons you do not want to take their life, you will have to wait for a new selection.</b>")
+					if (O.sacrifice_target)
+						if (M == O.sacrifice_target)
+							to_chat(M,"<b>There is no greater honor than purposefuly relinquishing your body for the coming of Nar-Sie.</b>")
+						to_chat(M,"<b>Should the target's body be annihilated, or should they flee the station, you may commune with Nar-Sie at an altar to have him designate a new target.</b>")
+					else
+						to_chat(M,"<b>There are no elligible targets aboard the station, how did you guys even manage that one?</b>")//if there's literally no humans aboard the station
+						to_chat(M,"<b>Commune with Nar-Sie at an altar to have him designate a new target.</b>")
 
 		for (var/datum/role/cultist/C in members)
 			C.update_cult_hud()

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
@@ -933,7 +933,8 @@
 		if (victim.mind)
 			var/datum/faction/bloodcult/cult = find_active_faction_by_type(/datum/faction/bloodcult)
 			if (cult)
-				cult.progress(CULT_ACT_II)
+				spawn(5)//waiting half a second to make sure that the sacrifice objective won't designate a victim that just refused conversion
+					cult.progress(CULT_ACT_II)
 			else
 				message_admins("Blood Cult: A conversion ritual occured...but we cannot find the cult faction...")//failsafe in case of admin varedit fuckery
 			cult_risk(activator)//risk of exposing the cult early if too many conversions
@@ -973,6 +974,7 @@
 
 		message_admins("BLOODCULT: [key_name(victim)] refused conversion by [key_name(converter)], and died.")
 		log_admin("BLOODCULT: [key_name(victim)] refused conversion by [key_name(converter)], and died.")
+		to_chat(converter, "<span class='sinister'>\The [victim] was pulled through the veil, their body was devoured by Nar-Sie and their possession stored inside this coffer.</span>")
 
 		playsound(R, 'sound/effects/convert_failure.ogg', 75, 0, -4)
 		conversion.icon_state = ""
@@ -985,10 +987,13 @@
 			victim.take_blood(cup, cup.volume)//Up to 60u
 			cup.on_reagent_change()//so we get the reagentsfillings overlay
 			new/obj/item/weapon/skull(coffer)
+			to_chat(converter, "<span class='sinister'>Inside you may also find a cup filled with a portion of the blood left in their body, along with their skull to potentially use in a resurrection ritual.</span>")
 		if (isslime(victim))
 			cup.reagents.add_reagent(SLIMEJELLY, 50)
+			to_chat(converter, "<span class='sinister'>Inside you may also find a cup filled with a slimy substance.</span>")
 		if (isalien(victim))//w/e
 			cup.reagents.add_reagent(RADIUM, 50)
+			to_chat(converter, "<span class='sinister'>Inside you may also find a cup filled with a green radioactive liquid.</span>")
 
 		for(var/obj/item/weapon/implant/loyalty/I in victim)
 			I.implanted = 0

--- a/code/datums/gamemode/objectives/bloodcult.dm
+++ b/code/datums/gamemode/objectives/bloodcult.dm
@@ -50,15 +50,15 @@
 			target_role = (sacrifice_target.mind.assigned_role=="MODE") ? "" : ", the ([sacrifice_target.mind.assigned_role]),"
 		if (iscultist(sacrifice_target))
 			target_role = ", the cultist,"
-		explanation_text = "The Sacrifice: Nar-Sie requires the flesh of [sacrifice_target.real_name][target_role] to breach reality. Sacrifice them at an altar using a cult blade. If you feel merciful for their soul, you may use an empty soul blade instead."
+		explanation_text = "The Sacrifice: Nar-Sie requires the flesh of [sacrifice_target.real_name][target_role] to breach reality. Sacrifice them at an altar using a cult blade. If you feel merciful for their soul, you may use an empty soul blade."
 		message_admins("Blood Cult: ACT II has begun, the sacrifice target is [sacrifice_target.real_name][target_role].")
 		log_admin("Blood Cult: ACT II has begun, the sacrifice target is [sacrifice_target.real_name][target_role].")
-		var/datum/faction/bloodcult/cult = faction
-		cult.target_change = TRUE
+		//var/datum/faction/bloodcult/cult = faction
+		//cult.target_change = TRUE
 		return TRUE
-	else
-		sleep(60 SECONDS)//kind of a failsafe should the entire server cooperate to cause this to occur, but that shouldn't logically ever happen anyway.
-		return PostAppend()
+//	else
+//		sleep(60 SECONDS)//kind of a failsafe should the entire server cooperate to cause this to occur, but that shouldn't logically ever happen anyway.
+//		return PostAppend()
 
 /datum/objective/bloodcult_sacrifice/proc/replace_target()
 	sacrifice_target = find_target()
@@ -68,15 +68,16 @@
 			target_role = (sacrifice_target.mind.assigned_role=="MODE") ? "" : ", the ([sacrifice_target.mind.assigned_role]),"
 		if (iscultist(sacrifice_target))
 			target_role = ", the cultist,"
-		explanation_text = "The Sacrifice: Nar-Sie requires the flesh of [sacrifice_target.real_name][target_role] to breach reality. Sacrifice them at an altar using a cult blade. If you feel merciful for their soul, you may use an empty soul blade instead."
+		explanation_text = "The Sacrifice: Nar-Sie requires the flesh of [sacrifice_target.real_name][target_role] to breach reality. Sacrifice them at an altar using a cult blade. If you feel merciful for their soul, you may use an empty soul blade."
 		message_admins("Blood Cult: The cult didn't sacrifice their target in time, a new target has been assigned, the new sacrifice target is [sacrifice_target.real_name][target_role].")
 		log_admin("Blood Cult: The cult didn't sacrifice their target in time, a new target has been assigned, the new sacrifice target is [sacrifice_target.real_name][target_role].")
-		var/datum/faction/bloodcult/cult = faction
-		cult.target_change = TRUE
+		//var/datum/faction/bloodcult/cult = faction
+		//cult.target_change = TRUE
 		return TRUE
-	else
-		sleep(60 SECONDS)//kind of a failsafe should the entire server cooperate to cause this to occur, but that shouldn't logically ever happen anyway.
-		return replace_target()
+	return FALSE
+//	else
+//		sleep(60 SECONDS)//kind of a failsafe should the entire server cooperate to cause this to occur, but that shouldn't logically ever happen anyway.
+//		return replace_target()
 
 /datum/objective/bloodcult_sacrifice/proc/find_target()
 	var/list/possible_targets = list()

--- a/code/datums/gamemode/role/cultist.dm
+++ b/code/datums/gamemode/role/cultist.dm
@@ -117,7 +117,8 @@
 			to_chat(antag.current, "<img src='data:image/png;base64,[icon2base64(logo)]' style='position: relative; top: 10;'/> <span class='sinister'>[custom]</span>")
 		if (GREET_CONVERTED)
 			to_chat(antag.current, "<span class='sinister'>You feel like you've broken past the veil of reality, your mind has seen worlds from beyond this plane, you've listened to the words of the Geometer of Blood for what felt like both an instant and ages, and now share both his knowledge and his ambition.</span>")
-			to_chat(antag.current, "<span class='sinister'>The Cult of Nar-Sie now counts you as its newest member. Your fellow cultists will guide you. You remember the last three words that Nar-Sie spoke to you: <span class='danger'>See Blood Hell</span></span>")
+			to_chat(antag.current, "<span class='sinister'>The Cult of Nar-Sie now counts you as its newest member. Your fellow cultists will guide you.</span>")
+			to_chat(antag.current,"<b>The first thing you might want to do is to summon a tome (<span class='danger'>See Blood Hell</span>) to see the available runes and learn their uses.</b>")
 		if (GREET_PAMPHLET)
 			to_chat(antag.current, "<span class='sinister'>Wow, that pamphlet was very convincing, in fact you're like totally a cultist now, hail Nar-Sie!</span>")//remember, debug item
 		if (GREET_SOULSTONE)


### PR DESCRIPTION
Fixes #21935
Also took @Kurfursten 's idea of sacrifice re-rolling. We'll see how it goes.

:cl:
* bugfix: Fixed a bug that let a crew-member that refused conversion be designed as sacrifice target the instant before they get devoured.
* tweak: Removed the cooldown on sacrifice target re-roll, instead, any cultist may now force a re-roll at an altar by communing with Nar-Sie if the target either had their body destroyed, or fled the station's Z level. This means that the cult may now confirm that their target is still around the station.
* tweak: Added a bunch of flavor text when progressing to Act 1 or getting converted to remind cultists how to summon their own Arcane Tome.
* tweak: Added a bunch of flavor text when a conversion failed so cultists understand the coffer's purpose.
