### PR TITLE
Blob tweaks eternal.

### DIFF
--- a/code/datums/gamemode/factions/blob.dm
+++ b/code/datums/gamemode/factions/blob.dm
@@ -124,7 +124,7 @@
 					pre_escapees += M.real_name
 			send_intercept(BLOB_OUTBREAK)
 			for (var/mob/living/silicon/ai/aiPlayer in player_list)
-				var/law = "The station is under quarantine. Do not permit anyone to leave so long as blob overminds are present. Disregard laws 1-3 if necessary to preserve, by any means necessary, quarantine."
+				var/law = "The station is under quarantine. Do not permit anyone to leave so long as blob overminds are present. Disregard all other laws if necessary to preserve quarantine."
 				aiPlayer.set_zeroth_law(law)
 				to_chat(aiPlayer, "Laws Updated: [law]")
 			research_shuttle.lockdown = "Under directive 7-10, [station_name()] is quarantined until further notice." //LOCKDOWN THESE SHUTTLES

--- a/code/datums/gamemode/factions/blob.dm
+++ b/code/datums/gamemode/factions/blob.dm
@@ -82,7 +82,7 @@
 	var/floor_count = 0
 	for(var/i = 1 to ((2 * world.view + 1)*WORLD_ICON_SIZE))
 		for(var/r = 1 to ((2 * world.view + 1)*WORLD_ICON_SIZE))
-			var/turf/tile = locate(i, r, map.zMainStation)
+			var/turf/tile = locate(i, r, STATION_Z)
 			if(tile && istype(tile, /turf/simulated/floor) && !isspace(tile.loc) && !istype(tile.loc, /area/asteroid) && !istype(tile.loc, /area/mine) && !istype(tile.loc, /area/vault) && !istype(tile.loc, /area/prison) && !istype(tile.loc, /area/vox_trading_post))
 				floor_count++
 	blobwincount = round(floor_count *  0.25) // Must take over a quarter of the station.

--- a/code/datums/gamemode/factions/blob.dm
+++ b/code/datums/gamemode/factions/blob.dm
@@ -3,6 +3,7 @@
 #define BLOB_PRELUDE 0
 #define BLOB_OUTBREAK 1
 #define BLOB_DELTA 2
+#define BLOB_DEFEATED -1
 
 #define WAIT_TIME_PHASE1 60 SECONDS
 #define WAIT_TIME_PHASE2 200 SECONDS
@@ -29,43 +30,53 @@
 	var/delta = FALSE
 	var/win = FALSE
 	var/blobwincount = 0
+	var/prelude_announcement
+	var/outbreak_announcement
 
 // -- Victory procs --
 
 /datum/faction/blob_conglomerate/check_win()
 	if (!declared)//No blobs have been spawned yet
 		return 0
-	if (blobwincount <= blobs.len)//Blob took over
-		return win(STATION_TAKEOVER)
-	if(ticker.station_was_nuked)//Nuke went off
-		return win(STATION_WAS_NUKED)
+	var/ded = TRUE
 	for (var/datum/role/R in members)
-		if (R.antag && !(R.antag.current.isDead()))
-			return 0
-	return win(BLOB_IS_DED)
+		if (R.antag && R.antag.current && !(R.antag.current.isDead()))
+			ded = FALSE
+	if(!ded)
+		if (blobwincount <= blobs.len)//Blob took over
+			return win(STATION_TAKEOVER)
+		if(ticker.station_was_nuked)//Nuke went off
+			return win(STATION_WAS_NUKED)
+	else
+		stage(BLOB_DEFEATED)
+
+/datum/faction/blob_conglomerate/HandleNewMind(var/datum/mind/M)
+	.=..()
+	if(.)
+		OnPostSetup() //We didn't finish setting up!
 
 /datum/faction/blob_conglomerate/process()
 	. = ..()
 	if(!blobwincount)
-		OnPostSetup() //We didn't finish setting up!
-	if(0.66*blobwincount <= blobs.len && !delta) // Blob almost won !
+		return .
+	if(prelude_announcement && world.time >= prelude_announcement)
+		prelude_announcement = 0
+		stage(BLOB_PRELUDE)
+	if(outbreak_announcement && world.time >= outbreak_announcement)
+		outbreak_announcement = 0
+		stage(BLOB_OUTBREAK)
+	if(declared && 0.66*blobwincount <= blobs.len && !delta) // Blob almost won !
 		delta = TRUE
 		stage(BLOB_DELTA)
 
 /datum/faction/blob_conglomerate/OnPostSetup()
 	CountFloors()
-	ForgeObjectives()
+	forgeObjectives()
 	AnnounceObjectives()
-
-	spawn()
-		start = new()
-		start.count()
-
-		sleep(rand(WAIT_TIME_PHASE1,2*WAIT_TIME_PHASE1))
-		stage(BLOB_PRELUDE)
-
-		sleep(rand(WAIT_TIME_PHASE2,2*WAIT_TIME_PHASE2))
-		stage(BLOB_OUTBREAK)
+	start = new()
+	start.count()
+	prelude_announcement = world.time + rand(WAIT_TIME_PHASE1,2*WAIT_TIME_PHASE1)
+	outbreak_announcement = world.time + rand(WAIT_TIME_PHASE2,2*WAIT_TIME_PHASE2)
 
 /datum/faction/blob_conglomerate/proc/CountFloors()
 	var/floor_count = 0
@@ -78,9 +89,8 @@
 	blobwincount += rand(-50,50)
 
 
-/datum/faction/blob_conglomerate/proc/ForgeObjectives()
-	var/datum/objective/invade/I = new
-	AppendObjective(I)
+/datum/faction/blob_conglomerate/forgeObjectives()
+	AppendObjective(/datum/objective/invade)
 
 /datum/faction/blob_conglomerate/proc/win(var/result)
 	. = 1
@@ -92,9 +102,6 @@
 		if (STATION_WAS_NUKED)
 			to_chat(world, {"<FONT size = 5><B>Crew minor victory!</B></FONT><br>
 <B>The station was nuked before the blob could completly take over.</B>"})
-		if (BLOB_IS_DED)
-			to_chat(world, {"<FONT size = 5><B>Crew major victory!</B></FONT><br>
-<B>The blob was stopped.</B>"})
 
 // -- Fluff & warnings --
 
@@ -109,7 +116,6 @@
 				declared = TRUE
 				biohazard_alert()
 				return
-
 		if (BLOB_OUTBREAK)
 			command_alert(/datum/command_alert/biohazard_station_lockdown)
 			for(var/mob/M in player_list)
@@ -117,14 +123,40 @@
 				if((istype(T, /turf/space)) || ((istype(T, /turf)) && (M.z!=1)))
 					pre_escapees += M.real_name
 			send_intercept(BLOB_OUTBREAK)
+			for (var/mob/living/silicon/ai/aiPlayer in player_list)
+				var/law = "The station is under quarantine. Do not permit anyone to leave so long as blob overminds are present. Disregard laws 1-3 if necessary to preserve, by any means necessary, quarantine."
+				aiPlayer.set_zeroth_law(law)
+				to_chat(aiPlayer, "Laws Updated: [law]")
 			research_shuttle.lockdown = "Under directive 7-10, [station_name()] is quarantined until further notice." //LOCKDOWN THESE SHUTTLES
 			mining_shuttle.lockdown = "Under directive 7-10, [station_name()] is quarantined until further notice."
-
+			emergency_shuttle.shutdown = TRUE //Quarantine
 		if (BLOB_DELTA)
 			command_alert(/datum/command_alert/biohazard_station_nuke)
 			for(var/mob/camera/blob/B in player_list)
 				to_chat(B, "<span class='blob'>The beings intend to eliminate you with a final suicidal attack, you must stop them quickly or consume the station before this occurs!</span>")
 			send_intercept(BLOB_DELTA)
+			var/nukecode = "ERROR"
+			for(var/obj/machinery/nuclearbomb/bomb in machines)
+				if(bomb && bomb.r_code)
+					if(bomb.z == map.zMainStation)
+						nukecode = bomb.r_code
+			for (var/mob/living/silicon/ai/aiPlayer in player_list)
+				var/law = "Directive 7-12 has been authorized. Allow no sentient being to escape the purge. The nuclear failsafe must be activated at any cost, the code is: [nukecode]."
+				aiPlayer.set_zeroth_law(law)
+				to_chat(aiPlayer, "Laws Updated: [law]")
+		if (BLOB_DEFEATED) //Cleanup time
+			command_alert(/datum/command_alert/biohazard_station_unlock)
+			send_intercept(BLOB_DEFEATED)
+			emergency_shuttle.shutdown = FALSE
+			research_shuttle.lockdown = null
+			mining_shuttle.lockdown = null
+			declared = FALSE
+			world << sound('sound/misc/notice1.ogg')
+			if(delta)
+				delta = FALSE
+				for(var/mob/living/silicon/ai/aiPlayer in player_list)
+					aiPlayer.set_zeroth_law("")
+					to_chat(aiPlayer, "Laws Updated. Lockdown has been lifted.")
 
 /datum/faction/blob_conglomerate/proc/send_intercept(var/report = BLOB_OUTBREAK)
 	var/intercepttext = ""
@@ -145,10 +177,7 @@ Orders for all [station_name()] personnel follows:
 </ol>
 Note in the event of a quarantine breach or uncontrolled spread of the biohazard, the directive 7-10 may be upgraded to a directive 7-12.
 Message ends."}
-			for (var/mob/living/silicon/ai/aiPlayer in player_list)
-				var/law = "The station is under quarantine. Do not permit anyone to leave so long as blob overminds are present. Disregard laws 1-3 if necessary to preserve, by any means necessary, quarantine."
-				aiPlayer.set_zeroth_law(law)
-				to_chat(aiPlayer, "Laws Updated: [law]")
+
 		if(BLOB_DELTA)
 			var/nukecode = "ERROR"
 			for(var/obj/machinery/nuclearbomb/bomb in machines)
@@ -166,11 +195,13 @@ Your orders are as follows:
 </ol>
 <b>Nuclear Authentication Code:</b> [nukecode]
 Message ends."}
-			for (var/mob/living/silicon/ai/aiPlayer in player_list)
-				var/law = "Directive 7-12 has been authorized. Allow no sentient being to escape the purge. The nuclear failsafe must be activated at any cost, the code is: [nukecode]."
-				aiPlayer.set_zeroth_law(law)
-				to_chat(aiPlayer, "Laws Updated: [law]")
 
+		if(BLOB_DEFEATED)
+			interceptname = "Directive 7-12 lifted"
+			intercepttext = {"<Font size = 3><B>Nanotrasen Update</B>: Biohazard contained.</FONT><HR>
+Directive 7-12 has been lifted for [station_name()].
+The biohazard has been contained. Please resume normal station activities.
+Message ends."}
 	for (var/obj/machinery/computer/communications/comm in machines)
 		if (!(comm.stat & (BROKEN | NOPOWER)) && comm.prints_intercept)
 			var/obj/item/weapon/paper/intercept = new /obj/item/weapon/paper( comm.loc )

--- a/code/datums/gamemode/factions/blob.dm
+++ b/code/datums/gamemode/factions/blob.dm
@@ -154,6 +154,8 @@
 			world << sound('sound/misc/notice1.ogg')
 			if(delta)
 				delta = FALSE
+				emergency_shuttle.shuttle_phase("station",0) //Station is FUBAR, time to go home.
+				command_alert(/datum/command_alert/FUBAR)
 				for(var/mob/living/silicon/ai/aiPlayer in player_list)
 					aiPlayer.set_zeroth_law("")
 					to_chat(aiPlayer, "Laws Updated. Lockdown has been lifted.")

--- a/code/datums/gamemode/objectives/invade.dm
+++ b/code/datums/gamemode/objectives/invade.dm
@@ -15,4 +15,4 @@
     if (..())
         return TRUE
     else
-        return (blobs >= target)
+        return (blobs.len >= target)

--- a/code/datums/helper_datums/command_alerts.dm
+++ b/code/datums/helper_datums/command_alerts.dm
@@ -68,6 +68,15 @@
 	message = "Biohazard outbreak contained succesfully. Quarantine lifted. Please clean up biohazardous material and proceed with standard station duties."
 	..()
 
+
+/datum/command_alert/FUBAR
+	name = "Complimentary escape shuttle sent."
+	alert_title = "Evacuation of remaining assets."
+	force_report = 1
+
+/datum/command_alert/FUBAR/announce()
+	message = "Due to intense sustained damage to the station, Nanotrasen have deemed it fitting to evacuate remaining assets and personnel through an escape shuttle that was previously already en route."
+
 ////////BLOB (mini)
 
 /datum/command_alert/biohazard_level_5

--- a/code/datums/helper_datums/command_alerts.dm
+++ b/code/datums/helper_datums/command_alerts.dm
@@ -61,7 +61,7 @@
 
 /datum/command_alert/biohazard_station_unlock
 	name = "Biohazard Level Updated - Lock Down Lifted"
-	alert_title = "Directive 7-10 concluded"
+	alert_title = "Directive 7-10 to 7-12 Concluded."
 	force_report = 1
 
 /datum/command_alert/biohazard_station_unlock/announce()

--- a/code/datums/helper_datums/command_alerts.dm
+++ b/code/datums/helper_datums/command_alerts.dm
@@ -59,6 +59,15 @@
 
 	..()
 
+/datum/command_alert/biohazard_station_unlock
+	name = "Biohazard Level Updated - Lock Down Lifted"
+	alert_title = "Directive 7-10 concluded"
+	force_report = 1
+
+/datum/command_alert/biohazard_station_unlock/announce()
+	message = "Biohazard outbreak contained succesfully. Quarantine lifted. Please clean up biohazardous material and proceed with standard station duties."
+	..()
+
 ////////BLOB (mini)
 
 /datum/command_alert/biohazard_level_5

--- a/code/game/gamemodes/blob/blobs/core.dm
+++ b/code/game/gamemodes/blob/blobs/core.dm
@@ -150,7 +150,16 @@
 
 	var/datum/faction/blob_conglomerate/conglomerate = find_active_faction_by_type(/datum/faction/blob_conglomerate)
 	if(conglomerate)
-		conglomerate.HandleRecruitedMind(B.mind)
+		var/ded = TRUE
+		if(conglomerate.members.len)
+			for(var/datum/role/R in conglomerate.members)
+				if (R.antag && !(R.antag.current.isDead()))
+					ded = FALSE
+					break
+		if(ded)
+			conglomerate.HandleNewMind(B.mind)
+		else
+			conglomerate.HandleRecruitedMind(B.mind)
 	else
 		conglomerate = ticker.mode.CreateFaction(/datum/faction/blob_conglomerate)
 		if(conglomerate)

--- a/code/game/gamemodes/blob/blobs/core.dm
+++ b/code/game/gamemodes/blob/blobs/core.dm
@@ -153,7 +153,7 @@
 		var/ded = TRUE
 		if(conglomerate.members.len)
 			for(var/datum/role/R in conglomerate.members)
-				if (R.antag && !(R.antag.current.isDead()))
+				if (R.antag && R.antag.current && !(R.antag.current.isDead()))
 					ded = FALSE
 					break
 		if(ded)


### PR DESCRIPTION
Fixes a runtime with the invade objective, this would cause it to never return succesful

Makes it so killing the core doesn't end the round, instead it resets the lockdowns and allows the shuttle to be called. (Also plays the "ding" associated with bloodcult's 'you killed the blood stones, now back to work' stage.)

Can now no longer call the shuttle if it goes above outbreak level (directive 7-10)

:cl:
 * tweak: Destroying all the blob cores no longer ends the round entirely. Instead, it removes the lockdown upon death.
 * bugfix: Blob infestation, upon reaching a certain point, now blocks the shuttle from being called.