### PR TITLE
Cult reminders

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult.dm
@@ -165,6 +165,8 @@ var/veil_thickness = CULT_PROLOGUE
 	var/cult_win = FALSE
 	var/warning = FALSE
 
+	var/list/cult_reminders = list()
+
 /datum/faction/bloodcult/check_win()
 	return cult_win
 
@@ -345,6 +347,13 @@ var/veil_thickness = CULT_PROLOGUE
 	for (var/obj/structure/cult/bloodstone/B in bloodstone_list)
 		B.update_icon()
 	bloody_floors -= T
+
+/datum/faction/bloodcult/HandleRecruitedRole(var/datum/role/R)
+	. = ..()
+	if (cult_reminders.len)
+		to_chat(R.antag.current, "<span class='notice'>The other cultists have left some useful reminders for you. They will be stored in your memory.</span>")
+	for (var/reminder in cult_reminders)
+		R.antag.store_memory("Cult reminder: [reminder].")
 
 /proc/is_convertable_to_cult(datum/mind/mind)
 	if(!istype(mind))
@@ -701,7 +710,6 @@ var/veil_thickness = CULT_PROLOGUE
 		data[BLOODCOST_TOTAL] = max(data[BLOODCOST_TOTAL], total_needed)
 	data["blood"] = blood
 	return data
-
 
 /obj/item/proc/get_cult_power()
 	return 0

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
@@ -393,7 +393,7 @@
 /datum/rune_spell/communication
 	name = "Communication"
 	desc = "Speak so that every cultists may hear your voice."
-	desc_talisman = "Use it to write and send a message to all followers of Nar-Sie. When in the middle of a ritual, use it to transmit a message that will be remembered at all."
+	desc_talisman = "Use it to write and send a message to all followers of Nar-Sie. When in the middle of a ritual, use it to transmit a message that will be remembered by all."
 	Act_restriction = CULT_PROLOGUE
 	invocation = "O bidai nabora se'sma!"
 	rune_flags = RUNE_STAND


### PR DESCRIPTION
[tweak]

Heavily inspired by the concept of Security records. I have no doubts cult players will be intelligent enough to make use of such a feature.

You can use again a "communicate" rune to write a cult reminder. This works similarly to cult message, except that it is also stored in your memory AND that it will be stored in the memory of all new converts.

You should use these to tell them where your base is, what your general plan of action is, etc, etc.

:cl:
- tweak: Using a communicate rune mid-cast will allow you to write a "Cult reminder", which will be engraved in the memory of all present cultists and all new converts.