### PR TITLE
Cult actually requires enemies to fight

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -150,7 +150,7 @@
 	name = "Blood Cult"
 	role_category = /datum/role/cultist
 	restricted_from_jobs = list("Merchant","AI", "Cyborg", "Mobile MMI", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Chaplain", "Head of Personnel", "Internal Affairs Agent")
-	enemy_jobs = list("AI", "Cyborg", "Security Officer","Warden", "Detective","Head of Security", "Captain", "Chaplain")
+	enemy_jobs = list("Security Officer","Warden", "Detective","Head of Security", "Captain")
 	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
 	required_candidates = 4
 	weight = 3


### PR DESCRIPTION
Ie, removes cyborgs, AIs, and chaplains from the enemies list.
AIs are not an enemy of the cult, they're a passive observer. Same as cyborg.

A chaplain is nothing without implants or access. He is not a real threat.
Closes #21945.

"Victory without risk is triumph without glory." - Corneille, El Cid

:cl:
- tweak: Bloodcult now requires security members to start.