### PR TITLE
Adds tractor and carts to cargo

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -173,7 +173,6 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 /datum/supply_packs/tractor
 	name = "Tractor"
 	contains = list(/obj/structure/bed/chair/vehicle/tractor,
-					/obj/item/key/tractor,
 					/obj/machinery/cart/cargo)
 	cost = 40
 	containertype = /obj/structure/largecrate

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -176,16 +176,16 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/key/tractor,
 					/obj/machinery/cart/cargo)
 	cost = 40
-	containertype = /obj/structure/largecrate/mule
+	containertype = /obj/structure/largecrate
 	containername = "tractor crate"
 	group = "Supplies"
 
 /datum/supply_packs/carts
 	name = "Carts"
-	contains = list(/obj/machinery/cart/cargo)
-	amount = 5
-	cost = 40
-	containertype = /obj/structure/largecrate/mule
+	contains = list(/obj/machinery/cart/cargo,
+                    /obj/machinery/cart/cargo)
+	cost = 15
+	containertype = /obj/structure/largecrate
 	containername = "carts crate"
 	group = "Supplies"
 

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -170,6 +170,25 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	containername = "\improper MULEbot crate"
 	group = "Supplies"
 
+/datum/supply_packs/tractor
+	name = "Tractor"
+	contains = list(/obj/structure/bed/chair/vehicle/tractor,
+					/obj/item/key/tractor,
+					/obj/machinery/cart/cargo)
+	cost = 40
+	containertype = /obj/structure/largecrate/mule
+	containername = "tractor crate"
+	group = "Supplies"
+
+/datum/supply_packs/carts
+	name = "Carts"
+	contains = list(/obj/machinery/cart/cargo)
+	amount = 5
+	cost = 40
+	containertype = /obj/structure/largecrate/mule
+	containername = "carts crate"
+	group = "Supplies"
+
 /datum/supply_packs/porcelain
 	name = "Porcelain furniture"
 	contains = list()


### PR DESCRIPTION
Made by me 2 years ago, fixed by @ProfanedBane (thank you) in 2018. I'd like to see how people interact with them before tweaking.
I played with them and it worked pretty good, but I'm also sure the crew will find ways to break it or exploit it. Let's see how it goes.

EDIT: Also, let me note that for some reason I can't order stuff at my test server, so I can't test if the tractor key properly spawns.

video for those who don't know what a tractor/cart is https://video.datsemultimedia.com/videos/watch/ce92e27a-746b-450c-acb7-bc2a5599d5ea

:cl:
 * rscadd: Tractors and carts added to cargo.