### PR TITLE
Increases fire_fuel_energy_release again

### DIFF
--- a/code/ZAS/NewSettings.dm
+++ b/code/ZAS/NewSettings.dm
@@ -52,7 +52,7 @@ var/global/ZAS_Settings/zas_settings = new
 	valtype=ZAS_TYPE_NUMERIC
 
 /datum/ZAS_Setting/fire_fuel_energy_release
-	value = 1100000
+	value = 2000000
 	name = "Fire - Fuel energy release"
 	desc = "The energy in joule released when burning one mol of a burnable substance"
 	valtype=ZAS_TYPE_NUMERIC

--- a/code/game/objects/effects/spawners/bombspawner.dm
+++ b/code/game/objects/effects/spawners/bombspawner.dm
@@ -51,7 +51,7 @@ var/list/syndicate_bomb_spawners = list()
 		T.master = V
 		var/datum/gas_mixture/G = T.air_contents
 		G.update_values()
-		G.multiply(1650 / G.pressure) //Sets each tank's pressure to 1650kPa. This was determined experimentally to result in a 7 dev explosion with this mix.
+		G.multiply(10 * ONE_ATMOSPHERE / G.pressure) //Sets each tank's pressure to ten atmospheres, which incidentally results in an explosion of exactly 7 dev with default settings.
 
 	var/obj/item/device/assembly/S
 

--- a/config-example/ZAS.txt
+++ b/config-example/ZAS.txt
@@ -8,7 +8,7 @@
 
 # Fire - Fuel energy release
 #   The energy in joule released when burning one mol of a burnable substance
-/datum/ZAS_Setting/fire_fuel_energy_release 1100000
+/datum/ZAS_Setting/fire_fuel_energy_release 2000000
 
 # Airflow - Small Movement Threshold %
 #   Percent of 1 Atm. at which items with the small weight classes will move.


### PR DESCRIPTION
Except it actually doesn't, because it's really governed by a settings file on the secret repo, but close enough

This brings the easy mix I was given back to *exactly* the bombcap. Which I wouldn't do except every single explosion in the toxins range since the change has been exactly the same size as the one resulting from this mix on the same settings. Apparently there's not much variation in high-power bombmixes anymore.

I didn't really bother testing the effects this has on fires because they'll still be way weaker than they were before #21782, with the possible exception of burn chambers, which will probably be only slightly weaker (if they're filtered properly)
I did test a molotov to the bar, though, which resulted in about 300C. To the bar only, because the firelocks closed almost immediately.

🆑 
* tweak: Almost doubled energy released per mole of reactant in fires, again. This should bring bombs and burn chambers back to roughly where they were before, or only slightly lower. This also affects all other fires, but any time the ratio of reactants to total gas is low, they'll still be far weaker than before. (If you see this message but don't observe the effects in-game, blame whoever merged the PR)