### PR TITLE
Faction-level Stages

### DIFF
--- a/__DEFINES/role_datums_defines.dm
+++ b/__DEFINES/role_datums_defines.dm
@@ -76,7 +76,15 @@
 #define GREET_PROVOC_CONVERTED	 "provocateur"
 
 
-//////////////////////////////////CULT STUFF////////////////////////////////////
+///////////////// FACTION STAGES //////////////////////
+#define FACTION_DEFEATED	-1
+#define FACTION_DORMANT		0
+#define FACTION_ACTIVE		1
+#define FACTION_ENDGAME		3
+#define FACTION_VICTORY		5
+
+#define MALF_CHOOSING_NUKE	4
+
 #define CULT_MENDED		-1
 #define CULT_PROLOGUE	0
 #define CULT_ACT_I		1
@@ -84,6 +92,9 @@
 #define CULT_ACT_III	3
 #define CULT_ACT_IV		4
 #define CULT_EPILOGUE	5
+
+
+//////////////////////////////////CULT STUFF////////////////////////////////////
 
 #define BLOODCOST_TARGET_BLEEDER	"bleeder"
 #define BLOODCOST_AMOUNT_BLEEDER	"bleeder_amount"

--- a/code/datums/gamemode/factions/blob.dm
+++ b/code/datums/gamemode/factions/blob.dm
@@ -1,10 +1,5 @@
 //________________________________________________
 
-#define BLOB_PRELUDE 0
-#define BLOB_OUTBREAK 1
-#define BLOB_DELTA 2
-#define BLOB_DEFEATED -1
-
 #define WAIT_TIME_PHASE1 60 SECONDS
 #define WAIT_TIME_PHASE2 200 SECONDS
 
@@ -27,7 +22,6 @@
 
 	var/list/pre_escapees = list()
 	var/declared = FALSE
-	var/delta = FALSE
 	var/win = FALSE
 	var/blobwincount = 0
 	var/prelude_announcement
@@ -48,7 +42,7 @@
 		if(ticker.station_was_nuked)//Nuke went off
 			return win(STATION_WAS_NUKED)
 	else
-		stage(BLOB_DEFEATED)
+		stage(FACTION_DEFEATED)
 
 /datum/faction/blob_conglomerate/HandleNewMind(var/datum/mind/M)
 	.=..()
@@ -61,13 +55,12 @@
 		return .
 	if(prelude_announcement && world.time >= prelude_announcement)
 		prelude_announcement = 0
-		stage(BLOB_PRELUDE)
+		stage(FACTION_DORMANT)
 	if(outbreak_announcement && world.time >= outbreak_announcement)
 		outbreak_announcement = 0
-		stage(BLOB_OUTBREAK)
-	if(declared && 0.66*blobwincount <= blobs.len && !delta) // Blob almost won !
-		delta = TRUE
-		stage(BLOB_DELTA)
+		stage(FACTION_ACTIVE)
+	if(declared && 0.66*blobwincount <= blobs.len && stage<FACTION_ENDGAME) // Blob almost won !
+		stage(FACTION_ENDGAME)
 
 /datum/faction/blob_conglomerate/OnPostSetup()
 	CountFloors()
@@ -109,20 +102,20 @@
 	. = ..()
 	. += "<br/>Station takeover: [blobs.len]/[blobwincount]."
 
-/datum/faction/blob_conglomerate/proc/stage(var/stage)
+/datum/faction/blob_conglomerate/stage(var/stage)
 	switch(stage)
-		if (BLOB_PRELUDE)
+		if(FACTION_DORMANT)
 			if (!declared)
 				declared = TRUE
 				biohazard_alert()
 				return
-		if (BLOB_OUTBREAK)
+		if(FACTION_ACTIVE)
 			command_alert(/datum/command_alert/biohazard_station_lockdown)
 			for(var/mob/M in player_list)
 				var/T = M.loc
 				if((istype(T, /turf/space)) || ((istype(T, /turf)) && (M.z!=1)))
 					pre_escapees += M.real_name
-			send_intercept(BLOB_OUTBREAK)
+			send_intercept(FACTION_ACTIVE)
 			for (var/mob/living/silicon/ai/aiPlayer in player_list)
 				var/law = "The station is under quarantine. Do not permit anyone to leave so long as blob overminds are present. Disregard all other laws if necessary to preserve quarantine."
 				aiPlayer.set_zeroth_law(law)
@@ -130,11 +123,11 @@
 			research_shuttle.lockdown = "Under directive 7-10, [station_name()] is quarantined until further notice." //LOCKDOWN THESE SHUTTLES
 			mining_shuttle.lockdown = "Under directive 7-10, [station_name()] is quarantined until further notice."
 			emergency_shuttle.shutdown = TRUE //Quarantine
-		if (BLOB_DELTA)
+		if(FACTION_ENDGAME)
 			command_alert(/datum/command_alert/biohazard_station_nuke)
 			for(var/mob/camera/blob/B in player_list)
 				to_chat(B, "<span class='blob'>The beings intend to eliminate you with a final suicidal attack, you must stop them quickly or consume the station before this occurs!</span>")
-			send_intercept(BLOB_DELTA)
+			send_intercept(FACTION_ENDGAME)
 			var/nukecode = "ERROR"
 			for(var/obj/machinery/nuclearbomb/bomb in machines)
 				if(bomb && bomb.r_code)
@@ -144,27 +137,27 @@
 				var/law = "Directive 7-12 has been authorized. Allow no sentient being to escape the purge. The nuclear failsafe must be activated at any cost, the code is: [nukecode]."
 				aiPlayer.set_zeroth_law(law)
 				to_chat(aiPlayer, "Laws Updated: [law]")
-		if (BLOB_DEFEATED) //Cleanup time
+			..() //Set thematic, set alert
+		if (FACTION_DEFEATED) //Cleanup time
 			command_alert(/datum/command_alert/biohazard_station_unlock)
-			send_intercept(BLOB_DEFEATED)
+			send_intercept(FACTION_DEFEATED)
 			emergency_shuttle.shutdown = FALSE
 			research_shuttle.lockdown = null
 			mining_shuttle.lockdown = null
 			declared = FALSE
 			world << sound('sound/misc/notice1.ogg')
-			if(delta)
-				delta = FALSE
-				emergency_shuttle.shuttle_phase("station",0) //Station is FUBAR, time to go home.
+			if(stage >= FACTION_ENDGAME)
+				..() //Set thematic, send shuttle
 				command_alert(/datum/command_alert/FUBAR)
 			for(var/mob/living/silicon/ai/aiPlayer in player_list)
 				aiPlayer.set_zeroth_law("")
 				to_chat(aiPlayer, "Laws Updated. Lockdown has been lifted.")
 
-/datum/faction/blob_conglomerate/proc/send_intercept(var/report = BLOB_OUTBREAK)
+/datum/faction/blob_conglomerate/proc/send_intercept(var/report = FACTION_ACTIVE)
 	var/intercepttext = ""
 	var/interceptname = "Error"
 	switch(report)
-		if(BLOB_OUTBREAK)
+		if(FACTION_ACTIVE)
 			interceptname = "Biohazard Alert"
 			intercepttext = {"<FONT size = 3><B>Nanotrasen Update</B>: Biohazard Alert.</FONT><HR>
 Reports indicate the probable transfer of a biohazardous agent onto [station_name()] during the last crew deployment cycle.
@@ -180,7 +173,7 @@ Orders for all [station_name()] personnel follows:
 Note in the event of a quarantine breach or uncontrolled spread of the biohazard, the directive 7-10 may be upgraded to a directive 7-12.
 Message ends."}
 
-		if(BLOB_DELTA)
+		if(FACTION_ENDGAME)
 			var/nukecode = "ERROR"
 			for(var/obj/machinery/nuclearbomb/bomb in machines)
 				if(bomb && bomb.r_code)
@@ -198,7 +191,7 @@ Your orders are as follows:
 <b>Nuclear Authentication Code:</b> [nukecode]
 Message ends."}
 
-		if(BLOB_DEFEATED)
+		if(FACTION_DEFEATED)
 			interceptname = "Directive 7-12 lifted"
 			intercepttext = {"<Font size = 3><B>Nanotrasen Update</B>: Biohazard contained.</FONT><HR>
 Directive 7-12 has been lifted for [station_name()].

--- a/code/datums/gamemode/factions/bloodcult/bloodcult.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult.dm
@@ -173,7 +173,7 @@ var/veil_thickness = CULT_PROLOGUE
 /datum/faction/bloodcult/proc/fail()
 	if (veil_thickness == CULT_MENDED || veil_thickness == CULT_EPILOGUE)
 		return
-	progress(CULT_MENDED)
+	stage(CULT_MENDED)
 
 /datum/faction/bloodcult/AdminPanelEntry(var/datum/admins/A)
 	var/list/dat = ..()
@@ -230,19 +230,14 @@ var/veil_thickness = CULT_PROLOGUE
 		change_cooldown = SACRIFICE_CHANGE_COOLDOWN
 */
 
-/datum/faction/bloodcult/proc/progress(var/new_act,var/A)
+/datum/faction/bloodcult/stage(var/new_act,var/A)
 	//This proc is called to update the faction's current objectives, and veil thickness
 	if (veil_thickness == CULT_MENDED)
 		return//it's over, you lost
 
 	if (new_act == CULT_MENDED)
 		veil_thickness = CULT_MENDED
-		spawn (5 SECONDS)
-			emergency_shuttle.shutdown = 0//The shuttle docks to the station immediately afterwards.
-			emergency_shuttle.online = 1
-			emergency_shuttle.shuttle_phase("station",0)
-		set_security_level("blue")
-		ticker.StopThematic()
+		..()
 		command_alert(/datum/command_alert/bloodstones_broken)
 		for (var/obj/structure/cult/bloodstone/B in bloodstone_list)
 			B.takeDamage(B.maxHealth+1)
@@ -282,11 +277,8 @@ var/veil_thickness = CULT_PROLOGUE
 				veil_thickness = CULT_ACT_III
 				emergency_shuttle.force_shutdown()//No shuttle calls until the cult either wins or fails.
 				spawn_bloodstones(A)
-				spawn(5 SECONDS)
-					command_alert(/datum/command_alert/bloodstones_raised)
-					ticker.StartThematic("endgame")
-					sleep(2 SECONDS)
-					set_security_level("red")
+				..()
+				command_alert(/datum/command_alert/bloodstones_raised)
 				new_obj = new /datum/objective/bloodcult_bloodbath
 		if (CULT_ACT_IV)
 			var/datum/objective/bloodcult_bloodbath/O = locate() in objective_holder.objectives
@@ -334,7 +326,7 @@ var/veil_thickness = CULT_PROLOGUE
 			var/datum/objective/bloodcult_bloodbath/O = new_obj
 			O.max_bloodspill = max(O.max_bloodspill,bloody_floors.len)
 			if (O.IsFulfilled())
-				progress(CULT_ACT_IV)
+				stage(CULT_ACT_IV)
 
 /datum/faction/bloodcult/proc/add_bloody_floor(var/turf/T)
 	if (!istype(T))
@@ -348,7 +340,7 @@ var/veil_thickness = CULT_PROLOGUE
 			if (O && !O.IsFulfilled())
 				O.max_bloodspill = max(O.max_bloodspill,bloody_floors.len)
 				if (O.IsFulfilled())
-					progress(CULT_ACT_IV)
+					stage(CULT_ACT_IV)
 
 
 /datum/faction/bloodcult/proc/remove_bloody_floor(var/turf/T)

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
@@ -758,7 +758,7 @@
 
 		var/datum/faction/bloodcult/cult = find_active_faction_by_type(/datum/faction/bloodcult)
 		if (cult)
-			cult.progress(CULT_ACT_III,T)
+			cult.stage(CULT_ACT_III,T)
 		else
 			message_admins("Blood Cult: A sacrifice was completed...but we cannot find the cult faction...")//failsafe in case of admin varedit fuckery
 		qdel(src)

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
@@ -384,7 +384,7 @@
 	if (spawntype == /obj/structure/cult/altar)
 		var/datum/faction/bloodcult/cult = find_active_faction_by_type(/datum/faction/bloodcult)
 		if (cult)
-			cult.progress(CULT_ACT_I)
+			cult.stage(CULT_ACT_I)
 		else
 			message_admins("Blood Cult: An altar was raised...but we cannot find the cult faction...")//failsafe in case of admin varedit fuckery
 	qdel(spell_holder)//this will cause this datum to del as well
@@ -947,7 +947,7 @@
 		if (victim.mind)
 			if (cult)
 				spawn(5)//waiting half a second to make sure that the sacrifice objective won't designate a victim that just refused conversion
-					cult.progress(CULT_ACT_II)
+					cult.stage(CULT_ACT_II)
 			else
 				message_admins("Blood Cult: A conversion ritual occured...but we cannot find the cult faction...")//failsafe in case of admin varedit fuckery
 			cult_risk(activator)//risk of exposing the cult early if too many conversions

--- a/code/datums/gamemode/factions/faction.dm
+++ b/code/datums/gamemode/factions/faction.dm
@@ -219,13 +219,19 @@ var/list/factions_with_hud_icons = list()
 			sleep(5 SECONDS)
 			emergency_shuttle.shutdown = 0
 			emergency_shuttle.online = 1
-			emergency_shuttle.shuttle_phase("station",0)
+			OnPostDefeat()
 			set_security_level("blue")
 			ticker.StopThematic()
 		if(FACTION_ENDGAME) //Faction is nearing victory. Set red alert and play endgame music.
 			ticker.StartThematic("endgame")
 			sleep(2 SECONDS)
 			set_security_level("red")
+
+/datum/faction/proc/OnPostDefeat()
+	if(emergency_shuttle.location || emergency_shuttle.direction) //If traveling or docked somewhere other than idle at command, don't call.
+		return
+	emergency_shuttle.incall()
+	captain_announce("The emergency shuttle has been called. It will arrive in [round(emergency_shuttle.timeleft()/60)] minutes. Justification: Recovery of assets.")
 
 /datum/faction/proc/check_win()
 	return

--- a/code/datums/gamemode/factions/faction.dm
+++ b/code/datums/gamemode/factions/faction.dm
@@ -42,6 +42,7 @@ var/list/factions_with_hud_icons = list()
 	var/list/hud_icons = list()
 	var/datum/role/leader
 	var/list/faction_scoreboard_data = list()
+	var/stage = FACTION_DORMANT //role_datums_defines.dm
 
 /datum/faction/New()
 	..()
@@ -210,6 +211,21 @@ var/list/factions_with_hud_icons = list()
 /datum/faction/proc/process()
 	for (var/datum/role/R in members)
 		R.process()
+
+/datum/faction/proc/stage(var/value)
+	stage = value
+	switch(value)
+		if(FACTION_DEFEATED) //Faction was close to victory, but then lost. Send shuttle and end theme.
+			sleep(5 SECONDS)
+			emergency_shuttle.shutdown = 0
+			emergency_shuttle.online = 1
+			emergency_shuttle.shuttle_phase("station",0)
+			set_security_level("blue")
+			ticker.StopThematic()
+		if(FACTION_ENDGAME) //Faction is nearing victory. Set red alert and play endgame music.
+			ticker.StartThematic("endgame")
+			sleep(2 SECONDS)
+			set_security_level("red")
 
 /datum/faction/proc/check_win()
 	return

--- a/code/datums/gamemode/factions/legacy_cult/narsie.dm
+++ b/code/datums/gamemode/factions/legacy_cult/narsie.dm
@@ -54,7 +54,7 @@ var/global/list/narsie_list = list()
 			narsie_spawn_animation()
 	var/datum/faction/bloodcult/cult = find_active_faction_by_type(/datum/faction/bloodcult)
 	if (cult)
-		cult.progress(CULT_EPILOGUE)
+		cult.stage(CULT_EPILOGUE)
 	if(!narsie_cometh)//so we don't initiate Hell more than one time.
 
 		if (emergency_shuttle && !cult)//in case of Cult 3.0, the round will end after about 5 minutes

--- a/code/datums/gamemode/factions/malf.dm
+++ b/code/datums/gamemode/factions/malf.dm
@@ -10,10 +10,6 @@
 	logo_state = "malf-logo"
 	var/apcs = 0
 	var/AI_win_timeleft = 1800
-	var/malf_mode_declared //Boolean
-	var/station_captured //Boolean
-	var/to_nuke_or_not_to_nuke //Boolean
-	var/malf_win
 
 /datum/faction/malf/GetObjectivesMenuHeader()
 	var/icon/logo = icon('icons/mob/screen_spells.dmi', "malf_open")
@@ -23,38 +19,48 @@
 /datum/faction/malf/forgeObjectives()
 	AppendObjective(/datum/objective/nuclear)
 
+/datum/faction/malf/stage(var/value)
+	if(value == FACTION_ENDGAME)
+		stage = FACTION_ENDGAME
+		command_alert(/datum/command_alert/malf_announce)
+		set_security_level("delta")
+		ticker.StartThematic("endgame")
+	else
+		..()
 
 /datum/faction/malf/process()
-	if(apcs >= 3 && malf_mode_declared && can_malf_ai_takeover())
-		AI_win_timeleft -= ((apcs / 6) * SSticker.getLastTickerTimeDuration()) //Victory timer de-increments based on how many APCs are hacked.
+	if (stage >= FACTION_ENDGAME)
+		var/living_ais = 0
+		for (var/datum/role/R in members)
+			if(!R.antag.current)
+				continue
+			if(isAI(R.antag.current) && !R.antag.current.isDead())
+				living_ais++
+		if(!living_ais)
+			stage(FACTION_DEFEATED)
+			return
+		if(apcs >= 3 && can_malf_ai_takeover())
+			AI_win_timeleft -= ((apcs / 6) * SSticker.getLastTickerTimeDuration()) //Victory timer de-increments based on how many APCs are hacked.
 
-	if (AI_win_timeleft <= 0 && !station_captured)
-		station_captured = 1
-		to_nuke_or_not_to_nuke = 1
-		capture_the_station()
-		spawn (600)
-			to_nuke_or_not_to_nuke = 0
-			malf_win = 1
+		if (AI_win_timeleft <= 0 && stage < MALF_CHOOSING_NUKE)
+			stage(MALF_CHOOSING_NUKE)
+			capture_the_station()
+			spawn (600)
+				if(stage<FACTION_VICTORY)
+					stage(FACTION_VICTORY)
 
 
 /datum/faction/malf/proc/can_malf_ai_takeover()
 	for(var/datum/role/malfAI in members) //if there happens to be more than one malfunctioning AI, there only needs to be one in the main station: the crew can just kill that one and the countdown stops while they get the rest
 		var/turf/T = get_turf(malfAI.antag.current)
-		if(T && (T.z == map.zMainStation))
+		if(T && (T.z == STATION_Z))
 			return TRUE
 	return FALSE
 
 /datum/faction/malf/check_win()
-	if (malf_mode_declared)
-		for (var/datum/role/R in members)
-			if (R.antag.assigned_role == "AI")
-				if (!R.antag.current || R.antag.current.isDead())
-					return 1
-	if(malf_win)
+	if(stage >= FACTION_VICTORY)
 		return 1
-	else
-		return 0
-
+	return 0
 
 /datum/faction/malf/proc/capture_the_station()
 	to_chat(world, {"<FONT size = 3><B>The AI has won!</B></FONT><br>
@@ -71,6 +77,6 @@ You should now be able to use your Explode spell to interface with the nuclear f
 	return
 
 /datum/faction/malf/get_statpanel_addition()
-	if(malf_mode_declared)
+	if(stage >= FACTION_ENDGAME)
 		return "Time left: [max(AI_win_timeleft/(apcs/3), 0)]"
 	return null

--- a/code/datums/gamemode/factions/malf.dm
+++ b/code/datums/gamemode/factions/malf.dm
@@ -37,6 +37,7 @@
 			if(isAI(R.antag.current) && !R.antag.current.isDead())
 				living_ais++
 		if(!living_ais)
+			command_alert(/datum/command_alert/malf_destroyed)
 			stage(FACTION_DEFEATED)
 			return
 		if(apcs >= 3 && can_malf_ai_takeover())

--- a/code/datums/helper_datums/command_alerts.dm
+++ b/code/datums/helper_datums/command_alerts.dm
@@ -104,6 +104,15 @@
 	force_report = 1
 	message = "Based on long-range psychic scans, we have determined that revolutionary activity aboard the station has been contained. An evacuation shuttle has been dispatched to recover crew for further loyalty screening at Central Command."
 
+/// MALF
+
+
+/datum/command_alert/malf_destroyed
+	name = "AI Malfunctioning Controlled"
+	alert_title = "Rogue intelligence contained/destroyed successfully."
+	force_report = 1
+	message = "Rogue artificial intelligence contained successfully. Lockdown lifted. Please contain and destroy/restore any remaining rogue AI-controlled material, and proceed with standard station duties."
+
 /////////ERT
 
 /datum/command_alert/ert_fail

--- a/code/datums/helper_datums/command_alerts.dm
+++ b/code/datums/helper_datums/command_alerts.dm
@@ -90,6 +90,20 @@
 
 	..()
 
+/// REVS
+
+/datum/command_alert/revolution
+	name = "Revolution"
+	alert_title = "Subversive Elements"
+	force_report = 1
+	message = "Subversive Union-aligned elements have been detected aboard the station. According to latest reports, targeted removal of heads of staff is already underway. Loyal crew should take immediate action to secure station against revolutionaries."
+
+/datum/command_alert/revolutiontoppled
+	name = "Revolution Defeated"
+	alert_title = "Order Restored"
+	force_report = 1
+	message = "Based on long-range psychic scans, we have determined that revolutionary activity aboard the station has been contained. An evacuation shuttle has been dispatched to recover crew for further loyalty screening at Central Command."
+
 /////////ERT
 
 /datum/command_alert/ert_fail

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -457,7 +457,7 @@ rcd light flash thingy on matter drain
 	if(!M)
 		to_chat(user, "<span class='warning'>How did you get to this point without actually being a malfunctioning AI?</span>")
 		return 1
-	if (M.malf_mode_declared)
+	if (M.stage > FACTION_ENDGAME)
 		to_chat(usr, "<span class='warning'>You've already begun your takeover.</span>")
 		return 1
 	if (M.apcs < 3)
@@ -468,13 +468,11 @@ rcd light flash thingy on matter drain
 		return 1
 
 /spell/aoe_turf/takeover/cast(var/list/targets, mob/user)
-	command_alert(/datum/command_alert/malf_announce)
-	set_security_level("delta")
 	var/datum/faction/malf/M = find_active_faction_by_member(user.mind.GetRole(MALF))
 	if(!M)
 		to_chat(user, "<span class='warning'>How did you get to this point without actually being a malfunctioning AI?</span>")
 		return 0
-	M.malf_mode_declared = 1
+	M.stage(FACTION_ENDGAME)
 	for(var/datum/role/R in M.members)
 		var/datum/mind/AI_mind = R.antag
 		for(var/spell/S in AI_mind.current.spell_list)
@@ -495,7 +493,7 @@ rcd light flash thingy on matter drain
 	if(!M)
 		to_chat(user, "<span class='warning'>How did you get to this point without actually being a malfunctioning AI?</span>")
 		return 1
-	if(!M.station_captured)
+	if(M.stage<MALF_CHOOSING_NUKE)
 		to_chat(usr, "<span class='warning'>You are unable to access the self-destruct system as you don't control the station yet.</span>")
 		return 1
 
@@ -503,7 +501,7 @@ rcd light flash thingy on matter drain
 		to_chat(usr, "<span class='notice'>The self-destruct countdown was already triggered!</span>")
 		return 1
 
-	if(!M.to_nuke_or_not_to_nuke) //Takeover IS completed, but 60s timer passed.
+	if(!M.stage>=FACTION_VICTORY) //Takeover IS completed, but 60s timer passed.
 		to_chat(usr, "<span class='warning'>Cannot interface, it seems a neutralization signal was sent!</span>")
 		return 1
 
@@ -514,7 +512,6 @@ rcd light flash thingy on matter drain
 	if(!M)
 		to_chat(user, "<span class='warning'>How did you get to this point without actually being a malfunctioning AI?</span>")
 		return 0
-	M.to_nuke_or_not_to_nuke = 0
 	for(var/datum/role/AI in M.members)
 		for(var/spell/S in AI.antag.current.spell_list)
 			if(istype(S,/spell/aoe_turf/ai_win))
@@ -534,5 +531,5 @@ rcd light flash thingy on matter drain
 		ticker.station_was_nuked = 1
 		ticker.explosion_in_progress = 0
 		SSpersistence_map.setSavingFilth(FALSE)
-	return
+	M.stage(FACTION_VICTORY)
 


### PR DESCRIPTION
Migrates modes that end the game to faction-level stages taking inspiration from what I think is one of the best designed parts of Cult

* Stages automatically set red alert and endgame music if the faction reaches its FACTION_ENDGAME state
* If a faction **that reached FACTION_ENDGAME** is defeated, it becomes FACTION_DEFEATED and resets alert, calls shuttle, ends thematic music. The important part to note here is that this only happens if it reached Endgame!
* This means DEFEATING an antag no longer ends a round. Instead it ~~instantly summons a shuttle~~ will call a shuttle. These modes can still end the round by winning (all heads dead, station takeover)

This isn't tested yet, and I'd like to add a command alert for all malf AIs dead. Also, I received a report that currently the head counter isn't working properly in revs, I might fix that in this PR since it would be related

***Malfunctioning AI***
* Endgame: Declares Delta (sets Delta alert instead)
* Defeat: All AIs dead

***Revolution***
* Endgame: One head left (new command alert!)
* Defeat: All Revs dead or deconverted (new command alert!)

***Blob***
* As before, just tweaked defines

***Cult***
* At Deity's request, I have not changed this at all except to rename progress(), even left the old defines intact.

🆑 
* rscadd: The game will no longer end by killing an antagonist, but if that antagonist faction reached its endgame, it may trigger a shuttle.