### PR TITLE
Compromise on ERT name length

### DIFF
--- a/code/game/striketeams/emergency_response_team.dm
+++ b/code/game/striketeams/emergency_response_team.dm
@@ -50,7 +50,7 @@ var/list/response_team_members = list()
 	to_chat(user, "<span class='notice'>Congratulations, you've been selected to be part of an ERT. You can customize your character, but don't take too long, time is of the essence!</span>")
 	user << 'sound/music/ERT.ogg'
 
-	var/commando_name = copytext(sanitize(input(user, "Pick a name","Name") as null|text), 1, MAX_NAME_LEN)
+	var/commando_name = copytext(sanitize(input(user, "Pick a name","Name") as null|text), 1, 2*MAX_NAME_LEN)
 
 	//todo: make it a panel, like in character creation
 	var/new_facial = input(user, "Please select facial hair color.", "Character Generation") as color


### PR DESCRIPTION
Twice the normal name length rather than over 25 times.
You can have names of the form : 
```
Cornelius McFuckstick the KICKIN RAD Wizardman = 46
The guy who is going to EI NATH every one of you = 48
```
Which is rather long already, isn't it ?