### PR TITLE
Removes a compile warning

### DIFF
--- a/code/WorkInProgress/pomf/spacepods/equipment.dm
+++ b/code/WorkInProgress/pomf/spacepods/equipment.dm
@@ -191,7 +191,6 @@
 			var/correct_positions = 0
 			for(var/i=1 to our_code.len)
 				var/char = our_code[i]
-				var/their_char = their_code[i]
 				if(their_code.Find(char))
 					found_values++
 				if(i < their_code.len && char == their_code[i])


### PR DESCRIPTION
```
code\WorkInProgress\pomf\spacepods\equipment.dm:194:warning: their_char: variable defined but not used
```