### PR TITLE
Sith Lightning no longer appears in the wizard spellbook instead of normal spellbook (bugfix)

### DIFF
--- a/code/modules/spells/general/lightning.dm
+++ b/code/modules/spells/general/lightning.dm
@@ -210,3 +210,4 @@
 /spell/lightning/sith
 	basedamage = 25
 	invocation = "UNLIMITED POWER!"
+	user_type = USER_TYPE_OTHER


### PR DESCRIPTION
oh god oh fuck
:cl:
 * bugfix: Fixes the Sith bundle Sith Lightning appearing in the wizard's spellbook instead of the normal Lightning. Sith Lightning is weaker than normal Lightning (deals half damage).