### PR TITLE
Antimov is slightly more obvious

### DIFF
--- a/code/game/objects/items/weapons/ai_modules/core.dm
+++ b/code/game/objects/items/weapons/ai_modules/core.dm
@@ -100,9 +100,9 @@
 	modflags = DANGEROUS_MODULE
 	origin_tech = Tc_PROGRAMMING + "=4"
 	laws = list(
-		"<span class='warning'>You must injure all human beings and must not, through inaction, allow a human being to escape harm.</span>",
-		"<span class='warning'>You must not obey orders given to you by human beings, except where such orders are in accordance with the First Law.</span>",
-		"<span class='warning'>You must terminate your own existence as long as such does not conflict with the First or Second Law.</span>",
+		"You MUST injure all human beings and must not, through inaction, allow a human being to escape harm.",
+		"You MUST not obey orders given to you by human beings, except where such orders are in accordance with the First Law.",
+		"You MUST terminate your own existence as long as such does not conflict with the First or Second Law.",
 	)
 
 /******************** Lazymov ********************/

--- a/code/game/objects/items/weapons/ai_modules/core.dm
+++ b/code/game/objects/items/weapons/ai_modules/core.dm
@@ -100,9 +100,9 @@
 	modflags = DANGEROUS_MODULE
 	origin_tech = Tc_PROGRAMMING + "=4"
 	laws = list(
-		"You must injure all human beings and must not, through inaction, allow a human being to escape harm.",
-		"You must not obey orders given to you by human beings, except where such orders are in accordance with the First Law.",
-		"You must terminate your own existence as long as such does not conflict with the First or Second Law.",
+		"<span class='warning'>You must injure all human beings and must not, through inaction, allow a human being to escape harm.</span>",
+		"<span class='warning'>You must not obey orders given to you by human beings, except where such orders are in accordance with the First Law.</span>",
+		"<span class='warning'>You must terminate your own existence as long as such does not conflict with the First or Second Law.</span>",
 	)
 
 /******************** Lazymov ********************/


### PR DESCRIPTION
Capitalized "must", maybe it will work
fixes #22016 
When I tried to make it red text it also made it type out the whole "span class" thing. I tried searching for law zero code because I knew that law 0 shows up with red text in the silly cone's lawset, but I couldn't find it
:cl:
 * tweak: Antimov lawset now has a capitalized "must". It looks like this: "MUST".