### PR TITLE
Runtime hunting; barricade destroy

### DIFF
--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -104,7 +104,7 @@
 		return !density
 	return 1
 
-/obj/structure/window/barricade/Destroy()
+/obj/structure/window/barricade/Destroy(var/brokenup)
 
 	setDensity(FALSE) //Sanity while we do the rest
 	getFromPool(materialtype, loc, sheetamount)


### PR DESCRIPTION
Fixes a runtime involving a missing argument to destroy

Simple stuff, just a 'missing argument' runtime that bugs me