### PR TITLE
Species has icon checks and more

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -564,7 +564,7 @@ var/global/list/damage_icon_parts = list()
 		var/obj/item/clothing/under/under_uniform = w_uniform
 
 		if(species.name in under_uniform.species_fit) //Allows clothes to display differently for multiple species
-			if(species.uniform_icons)
+			if(species.wear_suit_icons && has_icon(species.wear_suit_icons, w_uniform.icon_state))
 				standing.icon = species.uniform_icons
 
 		if(w_uniform.icon_override)
@@ -602,6 +602,10 @@ var/global/list/damage_icon_parts = list()
 			var/obj/item/weapon/card/ID_worn = wear_id
 			O.icon = 'icons/mob/ids.dmi'
 			O.icon_state = ID_worn.icon_state
+			if(species.name in ID_worn.species_fit) //Allows clothes to display differently for multiple species
+				if(species.id_icons && has_icon(species.id_icons, ID_worn.icon_state))
+					O.icon = species.uniform_icons
+
 			O.overlays.len = 0
 			if(wear_id.dynamic_overlay)
 				if(wear_id.dynamic_overlay["[ID_LAYER]"])
@@ -646,7 +650,7 @@ var/global/list/damage_icon_parts = list()
 				break
 
 		if(S.name in gloves.species_fit) //Allows clothes to display differently for multiple species
-			if(S.gloves_icons)
+			if(S.gloves_icons && has_icon(S.gloves_icons, t_state))
 				standing.icon = S.gloves_icons
 
 
@@ -702,7 +706,7 @@ var/global/list/damage_icon_parts = list()
 				break
 
 		if(S.name in glasses.species_fit) //Allows clothes to display differently for multiple species
-			if(S.glasses_icons)
+			if(S.glasses_icons && has_icon(S.glasses_icons, glasses.icon_state))
 				standing.icon = S.glasses_icons
 
 		if(glasses.cover_hair)
@@ -756,7 +760,7 @@ var/global/list/damage_icon_parts = list()
 				break
 
 		if(S.name in I.species_fit) //Allows clothes to display differently for multiple species
-			if(S.ears_icons)
+			if(S.ears_icons && has_icon(S.ears_icons, ears.icon_state))
 				standing.icon = S.ears_icons
 
 		var/obj/abstract/Overlays/O = obj_overlays[EARS_LAYER]
@@ -795,7 +799,7 @@ var/global/list/damage_icon_parts = list()
 				break
 
 		if(S.name in shoes.species_fit) //Allows clothes to display differently for multiple species
-			if(S.shoes_icons)
+			if(S.shoes_icons && has_icon(S.shoes_icons, shoes.icon_state))
 				O.icon = S.shoes_icons
 
 		O.overlays.len = 0
@@ -865,7 +869,7 @@ var/global/list/damage_icon_parts = list()
 				break
 
 		if(S.name in I.species_fit) //Allows clothes to display differently for multiple species
-			if(S.head_icons)
+			if(S.head_icons && has_icon(S.head_icons, head.icon_state))
 				standing.icon = S.head_icons
 
 		if(head.dynamic_overlay)
@@ -911,7 +915,7 @@ var/global/list/damage_icon_parts = list()
 				break
 
 		if(S.name in I.species_fit) //Allows clothes to display differently for multiple species
-			if(S.belt_icons)
+			if(S.belt_icons && has_icon(S.belt_icons, t_state))
 				standing.icon = S.belt_icons
 
 		var/obj/abstract/Overlays/O = obj_overlays[BELT_LAYER]
@@ -939,31 +943,36 @@ var/global/list/damage_icon_parts = list()
 		var/obj/abstract/Overlays/O = obj_overlays[SUIT_LAYER]
 		O.overlays.len = 0
 		var/image/standing	= image("icon" = ((wear_suit.icon_override) ? wear_suit.icon_override : 'icons/mob/suit.dmi'), "icon_state" = "[wear_suit.icon_state]")
-		if((((M_FAT in mutations) && (species.anatomy_flags & CAN_BE_FAT)) || (species.anatomy_flags & IS_BULKY)) && !(wear_suit.icon_override))
-			if(wear_suit.clothing_flags&ONESIZEFITSALL)
-				standing.icon	= 'icons/mob/suit_fat.dmi'
-			else
-				to_chat(src, "<span class='warning'>You burst out of \the [wear_suit]!</span>")
-				drop_from_inventory(wear_suit)
-
-		if( istype(wear_suit, /obj/item/clothing/suit/straight_jacket) )
-			drop_from_inventory(handcuffed)
-			drop_hands()
-
 		var/datum/species/SP = species
 		for(var/datum/organ/external/OE in get_organs_by_slot(slot_wear_suit, src)) //Display species-exclusive species correctly on attached limbs
 			if(OE.species)
 				SP = OE.species
 				break
+		if((((M_FAT in mutations) && (species.anatomy_flags & CAN_BE_FAT)) || (species.anatomy_flags & IS_BULKY)) && !(wear_suit.icon_override))
+			if(wear_suit.clothing_flags&ONESIZEFITSALL)
+				standing.icon	= 'icons/mob/suit_fat.dmi'
+				if(SP.name in wear_suit.species_fit) //Allows clothes to display differently for multiple species
+					if(SP.fat_wear_suit_icons && has_icon(SP.fat_wear_suit_icons, wear_suit.icon_state))
+						standing.icon = SP.wear_suit_icons
+			else
+				to_chat(src, "<span class='warning'>You burst out of \the [wear_suit]!</span>")
+				drop_from_inventory(wear_suit)
+		else
+			if(SP.name in wear_suit.species_fit) //Allows clothes to display differently for multiple species
+				if(SP.wear_suit_icons && has_icon(SP.wear_suit_icons, wear_suit.icon_state))
+					standing.icon = SP.wear_suit_icons
 
-		if(SP.name in wear_suit.species_fit) //Allows clothes to display differently for multiple species
-			if(SP.wear_suit_icons)
-				standing.icon = SP.wear_suit_icons
+
+
 
 		if(wear_suit.dynamic_overlay)
 			if(wear_suit.dynamic_overlay["[SUIT_LAYER]"])
 				var/image/dyn_overlay = wear_suit.dynamic_overlay["[SUIT_LAYER]"]
 				O.overlays += dyn_overlay
+
+		if(istype(wear_suit, /obj/item/clothing/suit/straight_jacket) )
+			drop_from_inventory(handcuffed)
+			drop_hands()
 
 		if(istype(wear_suit, /obj/item/clothing/suit))
 			var/obj/item/clothing/suit/C = wear_suit
@@ -1016,7 +1025,7 @@ var/global/list/damage_icon_parts = list()
 				break
 
 		if(S.name in I.species_fit) //Allows clothes to display differently for multiple species
-			if(S.wear_mask_icons)
+			if(S.wear_mask_icons && has_icon(S.wear_mask_icons, wear_mask.icon_state))
 				standing.icon = S.wear_mask_icons
 
 		if(wear_mask.dynamic_overlay)
@@ -1059,7 +1068,7 @@ var/global/list/damage_icon_parts = list()
 				break
 
 		if(S.name in I.species_fit) //Allows clothes to display differently for multiple species
-			if(S.back_icons)
+			if(S.back_icons && has_icon(S.back_icons, back.icon_state))
 				standing.icon = S.back_icons
 
 		var/obj/abstract/Overlays/O = obj_overlays[BACK_LAYER]


### PR DESCRIPTION
Adds has icon checks to where there are species-specific sprite overrides. Now you'll just look human rather than NAKED

closes #22048 
closes #22047 
closes #10812

Actually uses the id override

Actually uses the fat icon override

🆑 
 * bugfix: Fixes some worn items not appearing on some species. Now it will use the normal human sprites, so there will be irregularities, but it beats the icon not showing at all.