### PR TITLE
Adds three circuits to the board printer

### DIFF
--- a/code/modules/research/designs/boards/machine_misc.dm
+++ b/code/modules/research/designs/boards/machine_misc.dm
@@ -150,3 +150,22 @@
 	materials = list(MAT_GLASS = 2000, SACID = 20)
 	category = "Machine Boards"
 	build_path = /obj/item/weapon/circuitboard/ammolathe
+
+/datum/design/chem_dispenser/brewer
+	name = "Circuit Design (Brewer)"
+	desc = "Allows for the construction of circuit boards used to build a brewer."
+	id = "brewer"
+	build_path = /obj/item/weapon/circuitboard/chem_dispenser/brewer
+
+/datum/design/chem_dispenser/soda_dispenser
+	name = "Circuit Design (Soda Dispenser)"
+	desc = "Allows for the construction of circuit boards used to build a soda dispenser."
+	id = "soda_dispenser"
+	build_path = /obj/item/weapon/circuitboard/chem_dispenser/soda_dispenser
+
+/datum/design/chem_dispenser/booze_dispenser
+	name = "Circuit Design (Booze Dispenser)"
+	desc = "Allows for the construction of circuit boards used to build a booze dispenser."
+	id = "booze_dispenser"
+	build_path = /obj/item/weapon/circuitboard/chem_dispenser/booze_dispenser
+


### PR DESCRIPTION
![tested](https://i.imgur.com/ieF5zdp.png "dispensers")

:cl:
 * rscadd: Brewer, soda dispenser, and booze dispenser circuits can be printed at the circuit imprinter.