### PR TITLE
Target stake overlay sanity

### DIFF
--- a/code/game/objects/items/shooting_range.dm
+++ b/code/game/objects/items/shooting_range.dm
@@ -81,6 +81,9 @@
 		hp = 2350 // alium onest too kinda
 
 /obj/item/target/bullet_act(var/obj/item/projectile/Proj)
+	if(overlays.len >= 10) //Too many overlays
+		overlays.Remove(overlays[1]) //Cut the first overlay
+
 	var/p_x = Proj.p_x + pick(0,0,0,0,0,-1,1) // really ugly way of coding "sometimes offset Proj.p_x!"
 	var/p_y = Proj.p_y + pick(0,0,0,0,0,-1,1)
 	var/decaltype = 1 // 1 - scorch, 2 - bullet


### PR DESCRIPTION
Pretty simple fix, just has the first overlay removed if you go over the limit (being 10)

:cl:
 * bugfix: The target stake should no longer cause clients to crash when shot over 50 times