### PR TITLE
Cleans Up Rev Modes

### DIFF
--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -128,7 +128,7 @@
 		result = first ^ second
 	return result
 
-//Pretends to pick an element based on its weight but really just seems to pick a random element.
+//Picks an element based on its weight
 /proc/pickweight(list/L)
 	if(!L || !L.len)
 		return

--- a/code/datums/gamemode/dynamic/dynamic.dm
+++ b/code/datums/gamemode/dynamic/dynamic.dm
@@ -459,7 +459,7 @@ var/list/threat_by_job = list(
 				rule.candidates = list(newPlayer)
 				rule.trim_candidates()
 				if (rule.ready())
-					drafted_rules[rule] = rule.weight
+					drafted_rules[rule] = rule.get_weight()
 
 		if (drafted_rules.len > 0 && picking_latejoin_rule(drafted_rules))
 			latejoin_injection_cooldown = rand(330,510)//11 to 17 minutes inbetween antag latejoiner rolls

--- a/code/datums/gamemode/dynamic/dynamic_rulesets.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets.dm
@@ -74,6 +74,7 @@
 		for(var/datum/dynamic_ruleset/DR in mode.executed_rules)
 			if(istype(DR,src.type))
 				weight = max(weight-2,1)
+	message_admins("[name] had [weight] weight (-[initial(weight) - weight]).")
 	return weight
 
 /datum/dynamic_ruleset/proc/trim_candidates()
@@ -207,49 +208,6 @@
 		var/job_check = 0
 		if (enemy_jobs.len > 0)
 			for (var/mob/M in mode.candidates)
-				if (M.mind && M.mind.assigned_role && (M.mind.assigned_role in enemy_jobs) && (!(M in candidates) || (M.mind.assigned_role in restricted_from_jobs)))
-					job_check++//checking for "enemies" (such as sec officers). To be counters, they must either not be candidates to that rule, or have a job that restricts them from it
-
-		var/threat = round(mode.threat_level/10)
-		if (job_check < required_enemies[threat])
-			return 0
-	return ..()
-
-//////////////////////////////////////////////
-//                                          //
-//            LATEJOIN RULESETS             ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-//                                          //
-//////////////////////////////////////////////
-
-/datum/dynamic_ruleset/latejoin/trim_candidates()
-	var/role_id = initial(role_category.id)
-	var/role_pref = initial(role_category.required_pref)
-	for(var/mob/new_player/P in candidates)
-		if (!P.client || !P.mind || !P.mind.assigned_role)//are they connected?
-			candidates.Remove(P)
-			continue
-		if (!P.client.desires_role(role_pref) || jobban_isbanned(P, role_id) || isantagbanned(P) || (role_category_override && jobban_isbanned(P, role_category_override)))//are they willing and not antag-banned?
-			candidates.Remove(P)
-			continue
-		if (P.mind.assigned_role in protected_from_jobs)
-			var/probability = initial(role_category.protected_traitor_prob)
-			if (prob(probability))
-				candidates.Remove(P)
-			continue
-		if (P.mind.assigned_role in restricted_from_jobs)//does their job allow for it?
-			candidates.Remove(P)
-			continue
-		if ((exclusive_to_jobs.len > 0) && !(P.mind.assigned_role in exclusive_to_jobs))//is the rule exclusive to their job?
-			candidates.Remove(P)
-			continue
-
-/datum/dynamic_ruleset/latejoin/ready(var/forced = 0)
-	if (!forced)
-		var/job_check = 0
-		if (enemy_jobs.len > 0)
-			for (var/mob/M in mode.living_players)
-				if (M.stat == DEAD)
-					continue//dead players cannot count as opponents
 				if (M.mind && M.mind.assigned_role && (M.mind.assigned_role in enemy_jobs) && (!(M in candidates) || (M.mind.assigned_role in restricted_from_jobs)))
 					job_check++//checking for "enemies" (such as sec officers). To be counters, they must either not be candidates to that rule, or have a job that restricts them from it
 

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
@@ -1,3 +1,46 @@
+//////////////////////////////////////////////
+//                                          //
+//            LATEJOIN RULESETS             ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//                                          //
+//////////////////////////////////////////////
+
+/datum/dynamic_ruleset/latejoin/trim_candidates()
+	var/role_id = initial(role_category.id)
+	var/role_pref = initial(role_category.required_pref)
+	for(var/mob/new_player/P in candidates)
+		if (!P.client || !P.mind || !P.mind.assigned_role)//are they connected?
+			candidates.Remove(P)
+			continue
+		if (!P.client.desires_role(role_pref) || jobban_isbanned(P, role_id) || isantagbanned(P) || (role_category_override && jobban_isbanned(P, role_category_override)))//are they willing and not antag-banned?
+			candidates.Remove(P)
+			continue
+		if (P.mind.assigned_role in protected_from_jobs)
+			var/probability = initial(role_category.protected_traitor_prob)
+			if (prob(probability))
+				candidates.Remove(P)
+			continue
+		if (P.mind.assigned_role in restricted_from_jobs)//does their job allow for it?
+			candidates.Remove(P)
+			continue
+		if ((exclusive_to_jobs.len > 0) && !(P.mind.assigned_role in exclusive_to_jobs))//is the rule exclusive to their job?
+			candidates.Remove(P)
+			continue
+
+/datum/dynamic_ruleset/latejoin/ready(var/forced = 0)
+	if (!forced)
+		var/job_check = 0
+		if (enemy_jobs.len > 0)
+			for (var/mob/M in mode.living_players)
+				if (M.stat == DEAD)
+					continue//dead players cannot count as opponents
+				if (M.mind && M.mind.assigned_role && (M.mind.assigned_role in enemy_jobs) && (!(M in candidates) || (M.mind.assigned_role in restricted_from_jobs)))
+					job_check++//checking for "enemies" (such as sec officers). To be counters, they must either not be candidates to that rule, or have a job that restricts them from it
+
+		var/threat = round(mode.threat_level/10)
+		if (job_check < required_enemies[threat])
+			return 0
+	return ..()
+
 
 //////////////////////////////////////////////
 //                                          //
@@ -131,7 +174,6 @@
 	var/required_heads = 3
 	requirements = list(101,101,70,40,30,20,20,20,20,20)
 
-
 /datum/dynamic_ruleset/latejoin/provocateur/ready(var/forced=FALSE)
 	if (forced)
 		required_heads = 1
@@ -140,7 +182,7 @@
 	if(!..())
 		return FALSE
 	var/head_check = 0
-	for (var/mob/new_player/player in mode.living_players)
+	for(var/mob/player in mode.living_players)
 		if (player.mind.assigned_role in command_positions)
 			head_check++
 	return (head_check >= required_heads)
@@ -150,12 +192,10 @@
 	assigned += M
 	var/antagmind = M.mind
 	var/datum/faction/F = ticker.mode.CreateFaction(/datum/faction/revolution, null, 1)
-	var/datum/role/revolutionary/leader/L = new(null,F,HEADREV)
+	F.forgeObjectives()
 	spawn(1 SECONDS)
-		L.AssignToRole(antagmind,1)
+		var/datum/role/revolutionary/leader/L = new(antagmind,F,HEADREV)
 		L.Greet(GREET_LATEJOIN)
-		update_faction_icons()
 		L.OnPostSetup()
-		F.forgeObjectives()
-		L.AnnounceObjectives()
+		update_faction_icons()
 	return 1

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -392,6 +392,8 @@
 	var/required_heads = 3
 
 /datum/dynamic_ruleset/midround/from_ghosts/faction_based/revsquad/ready(var/forced = 0)
+	if(forced)
+		required_heads = 1
 	if (find_active_faction_by_type(/datum/faction/revolution))
 		return FALSE //Never send 2 rev types
 	if (required_candidates > (dead_players.len + list_observers.len))
@@ -399,7 +401,7 @@
 	if(!..())
 		return FALSE
 	var/head_check = 0
-	for (var/mob/player in mode.living_players)
+	for(var/mob/player in mode.living_players)
 		if(!player.mind)
 			continue
 		if(player.mind.assigned_role in command_positions)

--- a/code/datums/gamemode/factions/syndicate/rev.dm
+++ b/code/datums/gamemode/factions/syndicate/rev.dm
@@ -100,6 +100,8 @@
 		if(!(gameactivetime % 60))
 			message_admins("The revolution faction exists. [round(((5 MINUTES) - gameactivetime)/60)] minutes until win conditions begin checking.")
 		return //Don't bother checking for win before 5min
+	if(stage <= FACTION_DEFEATED)
+		return
 
 	// -- 2. Are all the heads dead ?
 	var/list/total_heads = get_living_heads()


### PR DESCRIPTION
* Forced RevSquad only requires one head like other forced Rev modes (only applies to admins)
* Forced Provocateur, same
* Added an admin message with weight reporting for each drafted rule. This should help admins track with greater clarity why something is being chosen.

🆑 
* bugfix: Fixed a bug where Provocateur (Latejoin Revs) would not fire.
* bugfix: Fixed a bug where latejoin rules would not take the penalty for being a repeated rule.
* bugfix: Fixed a bug where a defeated revolution with only one head remaining could spam the station.