### PR TITLE
Reverts evidence bag changes

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -66,7 +66,7 @@
 	if(!("Security" in R.module.sensor_augs)) //If they don't have a SECHUD, give them one.
 		pop(R.module.sensor_augs)
 		R.module.sensor_augs.Add("Security", "Disable")
-
+	
 	if(!HAS_MODULE_QUIRK(R, MODULE_IS_THE_LAW)) //Make them able to *law and *halt
 		R.module.quirk_flags |= MODULE_IS_THE_LAW
 
@@ -147,7 +147,7 @@
 	playsound(R, "sound/voice/liveagain.ogg", 75, 1)
 	R.stat = CONSCIOUS
 	R.resurrect()
-
+ 
 	if(R.can_diagnose())
 		to_chat(R, "<span style=\"font-family:Courier\">System reboot finished successfully.</span>")
 
@@ -334,7 +334,7 @@
 	desc = "So that's the way you scientific detectives work. My god! for a fat, middle-aged, hard-boiled, pig-headed guy, you've got the vaguest way of doing things I ever heard of."
 	icon_state = "mainboard"
 	required_modules = list(SECURITY_MODULE, HUG_MODULE)
-	modules_to_add = list(/obj/item/weapon/gripper/service/noir, /obj/item/weapon/storage/evidencebag, /obj/item/cyborglens, /obj/item/device/taperecorder, /obj/item/weapon/gun/projectile/detective, /obj/item/ammo_storage/speedloader/c38/cyborg)
+	modules_to_add = list(/obj/item/weapon/gripper/service/noir, /obj/item/weapon/evidencebag, /obj/item/cyborglens, /obj/item/device/taperecorder, /obj/item/weapon/gun/projectile/detective, /obj/item/ammo_storage/speedloader/c38/cyborg)
 
 /obj/item/borg/upgrade/noir/attempt_action(var/mob/living/silicon/robot/R,var/mob/living/user)
 	if(..())

--- a/code/game/objects/items/stacks/packagewrap.dm
+++ b/code/game/objects/items/stacks/packagewrap.dm
@@ -20,7 +20,7 @@
 		/obj/item/delivery,
 		/obj/item/weapon/gift,
 		/obj/item/weapon/winter_gift,
-		/obj/item/weapon/storage/evidencebag,
+		/obj/item/weapon/evidencebag,
 		/obj/item/weapon/legcuffs/bolas,
 		/obj/item/weapon/storage
 		)

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -100,7 +100,7 @@
 				flags &= ~OPENCONTAINER
 		return
 
-	if (istype(W, /obj/item) && !is_open_container() && !istype(src, /obj/item/weapon/extinguisher/foam) && !istype(W, /obj/item/weapon/storage/evidencebag))
+	if (istype(W, /obj/item) && !is_open_container() && !istype(src, /obj/item/weapon/extinguisher/foam) && !istype(W, /obj/item/weapon/evidencebag))
 		if(W.is_open_container())
 			return //We're probably trying to fill it
 		if(W.w_class > W_CLASS_TINY)

--- a/code/modules/detectivework/detective_work.dm
+++ b/code/modules/detectivework/detective_work.dm
@@ -171,11 +171,12 @@ var/const/FINGERPRINT_COMPLETE = 6	//This is the output of the stringpercent(pri
 					if(G.wrapped)
 						scanning = G.wrapped //We add it as scanned object first because we'll lose the wrapped reference once we drop it.
 						G.drop_item(G.wrapped, src)
-				else
-					if(istype(I, /obj/item/weapon/storage/evidencebag) && I.contents.len)
-						var/obj/item/weapon/storage/evidencebag/EVB = I
-						scanning = EVB.contents[1]
-						EVB.remove_from_storage(scanning, src, TRUE, TRUE)
+				else 
+					if(istype(I, /obj/item/weapon/evidencebag))
+						scanning = I.contents[1]
+						scanning.forceMove(src)
+						I.overlays.len = 0
+						I.icon_state = "evidenceobj"		
 					else
 						if(M.drop_item(I, src))
 							scanning = I

--- a/code/modules/detectivework/evidence.dm
+++ b/code/modules/detectivework/evidence.dm
@@ -1,45 +1,98 @@
 //CONTAINS: Evidence bags and fingerprint cards
 
-/obj/item/weapon/storage/evidencebag
+/obj/item/weapon/evidencebag
 	name = "evidence bag"
 	desc = "An empty evidence bag."
 	icon = 'icons/obj/storage/storage.dmi'
 	icon_state = "evidenceobj"
 	item_state = ""
-	use_to_pickup = TRUE
 	w_class = W_CLASS_TINY
-	storage_slots = 1
 
-/obj/item/weapon/storage/evidencebag/update_icon()
-	var/obj/item/I = locate() in contents
-	if(I)
-		var/xx = I.pixel_x	//save the offset of the item
-		var/yy = I.pixel_y
-		I.pixel_x = 0		//then remove it so it'll stay within the evidence bag
-		I.pixel_y = 0
-		var/image/img = image("icon"=I, "layer"=FLOAT_LAYER)	//take a snapshot. (necessary to stop the underlays appearing under our inventory-HUD slots ~Carn
-		img.plane = FLOAT_PLANE
-		I.pixel_x = xx		//and then return it
-		I.pixel_y = yy
-		overlays += img
-		overlays += image(icon = icon, icon_state = "evidence")	//should look nicer for transparent stuff. not really that important, but hey.
+/obj/item/weapon/evidencebag/preattack(obj/item/I, mob/user, proximity_flag, click_parameters)
+	if(proximity_flag == 0) // not adjacent
+		return
 
-		desc = "An evidence bag containing [I]. [I.desc]"
-		w_class = I.w_class
+	if(!istype(I) || I.anchored == 1)
+		return ..()
+
+	if(istype(I, /obj/item/weapon/storage))
+		return ..()
+
+	if(istype(I, /obj/item/weapon/evidencebag))
+		to_chat(user, "<span class='notice'>You find putting an evidence bag in another evidence bag to be slightly absurd.</span>")
+		return
+
+	if(I.w_class > W_CLASS_MEDIUM)
+		to_chat(user, "<span class='notice'>[I] won't fit in [src].</span>")
+		return
+
+	if(contents.len)
+		to_chat(user, "<span class='notice'>[src] already has something inside it.</span>")
+		return ..()
+
+	if(!isturf(I.loc)) //If it isn't on the floor. Do some checks to see if it's in our hands or a box. Otherwise give up.
+		if(istype(I.loc,/obj/item/weapon/storage))	//in a container.
+			var/obj/item/weapon/storage/U = I.loc
+			user.client.screen -= I
+			U.contents.Remove(I)
+		user.drop_item(I, force_drop = 1)
+
+	user.visible_message("[user] puts [I] into [src]", "You put [I] inside [src].",\
+	"You hear a rustle as someone puts something into a plastic bag.")
+
+	icon_state = "evidence"
+
+	var/xx = I.pixel_x	//save the offset of the item
+	var/yy = I.pixel_y
+	I.pixel_x = 0		//then remove it so it'll stay within the evidence bag
+	I.pixel_y = 0
+	var/image/img = image("icon"=I, "layer"=FLOAT_LAYER)	//take a snapshot. (necessary to stop the underlays appearing under our inventory-HUD slots ~Carn
+	img.plane = FLOAT_PLANE
+	I.pixel_x = xx		//and then return it
+	I.pixel_y = yy
+	overlays += img
+	overlays += image(icon = icon, icon_state = "evidence")	//should look nicer for transparent stuff. not really that important, but hey.
+
+	desc = "An evidence bag containing [I]. [I.desc]"
+	I.forceMove(src)
+	w_class = I.w_class
+	return TRUE
+
+
+/obj/item/weapon/evidencebag/attack_self(mob/user as mob)
+	if(contents.len)
+		var/obj/item/I = contents[1]
+		user.visible_message("[user] takes [I] out of [src]", "You take [I] out of [src].",\
+		"You hear someone rustle around in a plastic bag, and remove something.")
+		overlays.len = 0	//remove the overlays
+		underlays.len = 0	//and the underlays (due to xenoarch's core sampler)
+		user.put_in_hands(I)
+		w_class = W_CLASS_TINY
+		icon_state = "evidenceobj"
+		desc = "An empty evidence bag."
+
 	else
-		overlays.Cut()
+		to_chat(user, "[src] is empty.")
+		icon_state = "evidenceobj"
+	return
+
+obj/item/weapon/evidencebag/attackby(obj/item/weapon/W as obj, mob/living/user as mob)
+	if(istype(W, /obj/item/weapon/pen))
+		set_tiny_label(user)
+	else
+		..(W, user)
 
 /obj/item/weapon/storage/box/evidence
 	name = "evidence bag box"
 	desc = "A box containing evidence bags."
 	icon_state = "evidencebox"
 	New()
-		new /obj/item/weapon/storage/evidencebag(src)
-		new /obj/item/weapon/storage/evidencebag(src)
-		new /obj/item/weapon/storage/evidencebag(src)
-		new /obj/item/weapon/storage/evidencebag(src)
-		new /obj/item/weapon/storage/evidencebag(src)
-		new /obj/item/weapon/storage/evidencebag(src)
+		new /obj/item/weapon/evidencebag(src)
+		new /obj/item/weapon/evidencebag(src)
+		new /obj/item/weapon/evidencebag(src)
+		new /obj/item/weapon/evidencebag(src)
+		new /obj/item/weapon/evidencebag(src)
+		new /obj/item/weapon/evidencebag(src)
 		..()
 		return
 

--- a/code/modules/research/xenoarchaeology/tools/tools_coresampler.dm
+++ b/code/modules/research/xenoarchaeology/tools/tools_coresampler.dm
@@ -6,7 +6,7 @@
 
 /obj/item/weapon/storage/box/samplebags/New()
 	for(var/i=0, i<7, i++)
-		var/obj/item/weapon/storage/evidencebag/S = new(src)
+		var/obj/item/weapon/evidencebag/S = new(src)
 		S.name = "sample bag"
 		S.desc = "a bag for holding research samples."
 	..()
@@ -25,7 +25,7 @@
 	//slot_flags = SLOT_BELT
 	var/sampled_turf = ""
 	var/num_stored_bags = 10
-	var/obj/item/weapon/storage/evidencebag/filled_bag
+	var/obj/item/weapon/evidencebag/filled_bag
 
 /obj/item/device/core_sampler/examine(mob/user)
 	..()
@@ -33,7 +33,7 @@
 		to_chat(user, "<span class='info'>This one is [sampled_turf ? "full" : "empty"], and has [num_stored_bags] bag[num_stored_bags != 1 ? "s" : ""] remaining.</span>")
 
 /obj/item/device/core_sampler/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if(istype(W,/obj/item/weapon/storage/evidencebag))
+	if(istype(W,/obj/item/weapon/evidencebag))
 		if(num_stored_bags < 10)
 			to_chat(user, "<span class='notice'>You insert the [W] into the core sampler.</span>")
 			qdel(W)
@@ -62,7 +62,7 @@
 			to_chat(user, "<span class='warning'>The core sampler is out of sample bags!</span>")
 		else
 			//create a new sample bag which we'll fill with rock samples
-			filled_bag = new /obj/item/weapon/storage/evidencebag(src)
+			filled_bag = new /obj/item/weapon/evidencebag(src)
 			filled_bag.name = "sample bag"
 			filled_bag.desc = "a bag for holding research samples."
 


### PR DESCRIPTION
The change made them annoying and unwieldy to use in every thinkable way.
The nuclear option clearly wasn't the right option.

before:
click bag on thing (that is anywhere) to place it in bag
use bag in hand to remove thing from bag
drag bag onto table or similar to put thing on table or similar

now:
click bag on thing to maybe place it in the bag (but not if it's in a box, bag, etc) (and if it's on the floor you just randomly pick something off the floor, not the item you want)
use bag in hand to open the bag like a box
drag bag to table to remove thing from bag OR dirty it with your hands

:cl:
 - tweak: Reverted the new evidence bag behavior