### PR TITLE
Evidence bag consistency fixes

### DIFF
--- a/code/modules/detectivework/evidence.dm
+++ b/code/modules/detectivework/evidence.dm
@@ -7,7 +7,10 @@
 	icon_state = "evidenceobj"
 	item_state = ""
 	use_to_pickup = TRUE
+	allow_quick_empty = TRUE
+	collection_mode = FALSE
 	w_class = W_CLASS_TINY
+	fits_max_w_class = W_CLASS_MEDIUM
 	storage_slots = 1
 
 /obj/item/weapon/storage/evidencebag/update_icon()


### PR DESCRIPTION
Fixes not being able to hold guns inside the evidence bag

Can now just DUMP IT all out on the floor with evidence bags

Evidence bags only try to pick up one thing at a time

:cl:
 * bugfix: Evidence bags are now swoller. They can now carry things a little larger, are also a little larger, and can now just be opened and dumped on the floor.