### PR TITLE
Kill or Exile Objective for Revs

### DIFF
--- a/code/datums/gamemode/factions/syndicate/rev.dm
+++ b/code/datums/gamemode/factions/syndicate/rev.dm
@@ -44,7 +44,7 @@
 /datum/faction/revolution/forgeObjectives()
 	var/list/heads = get_living_heads()
 	for(var/datum/mind/head_mind in heads)
-		var/datum/objective/target/assassinate/A = new(auto_target = FALSE)
+		var/datum/objective/target/assassinate/orexile/A = new(auto_target = FALSE)
 		if(A.set_target(head_mind))
 			AppendObjective(A, TRUE) // We will have more than one kill objective
 
@@ -83,13 +83,14 @@
 	for(var/datum/mind/head_mind in heads)
 		var/mob/M = head_mind.current
 		if (M)
-			return {"[name] <a href='?_src_=holder;adminplayeropts=\ref[M]'>[M.real_name]/[M.key]</a>[M.client ? "" : " <i> - (logged out)</i>"][M.stat == DEAD ? " <b><font color=red> - (DEAD)</font></b>" : ""]
+			dat += {"[name] <a href='?_src_=holder;adminplayeropts=\ref[M]'>[M.real_name]/[M.key]</a>[M.client ? "" : " <i> - (logged out)</i>"][M.stat == DEAD ? " <b><font color=red> - (DEAD)</font></b>" : ""]
 				 - <a href='?src=\ref[usr];priv_msg=\ref[M]'>(priv msg)</a>
 				 - <a href='?_src_=holder;traitor=\ref[M]'>(role panel)</a>"}
 		else
-			return {"[name] [head_mind.name]/[M.key]<b><font color=red> - (DESTROYED)</font></b>
+			dat += {"[name] [head_mind.name]/[M.key]<b><font color=red> - (DESTROYED)</font></b>
 				 - <a href='?src=\ref[usr];priv_msg=\ref[M]'>(priv msg)</a>
 				 - <a href='?_src_=holder;traitor=\ref[M]'>(role panel)</a>"}
+	return dat
 
 #define ALL_HEADS_DEAD 1
 #define ALL_REVS_DEAD 2
@@ -104,21 +105,20 @@
 		return
 
 	// -- 2. Are all the heads dead ?
-	var/list/total_heads = get_living_heads()
-	var/incapacitated_heads = 0
+	var/remaining_targets = objective_holder.objectives.len
+	for(var/datum/objective/objective in objective_holder.GetObjectives())
+		if(objective.IsFulfilled())
+			remaining_targets--
 
-	for (var/datum/mind/M in total_heads)
-		var/turf/T = get_turf(M.current)
-		if (M.current.isDead() || T.z != STATION_Z)
-			incapacitated_heads++
-
-	if (incapacitated_heads >= total_heads.len)
-		return end(ALL_HEADS_DEAD)
-	if(stage < FACTION_ENDGAME)
-		if(incapacitated_heads == total_heads.len-1)
-			stage(FACTION_ENDGAME)
-			command_alert(/datum/command_alert/revolution)
-			//Only one head left!
+	switch(remaining_targets)
+		if(0)
+			if(stage < FACTION_VICTORY)
+				stage(FACTION_VICTORY)
+				return end(ALL_HEADS_DEAD)
+		if(1)
+			if(stage < FACTION_ENDGAME)
+				stage(FACTION_ENDGAME)
+				command_alert(/datum/command_alert/revolution)
 
 /datum/faction/revolution/process()
 	..()
@@ -142,7 +142,7 @@
 	ASSERT(args["rank"])
 	var/mob/living/L = args["character"]
 	if (args["rank"] in command_positions)
-		var/datum/objective/target/assassinate/A = new(auto_target = FALSE)
+		var/datum/objective/target/assassinate/orexile/A = new(auto_target = FALSE)
 		if(A.set_target(L.mind))
 			R.AppendObjective(A, TRUE) // We will have more than one kill objective
 

--- a/code/datums/gamemode/objectives/target/killorexile.dm
+++ b/code/datums/gamemode/objectives/target/killorexile.dm
@@ -1,0 +1,18 @@
+/datum/objective/target/assassinate/orexile
+	name = "Assassinate or exile <target>"
+
+/datum/objective/target/assassinate/orexile/format_explanation()
+	return "Assassinate or exile [target.current.real_name], the [target.assigned_role=="MODE" ? (target.special_role) : (target.assigned_role)]."
+
+/datum/objective/target/assassinate/orexile/IsFulfilled()
+	if(..())
+		return TRUE //Covers dead, cyborgified, MMI'd, on away mission, no target, manual toggle
+	if(target.current.z != STATION_Z)
+		var/turf/T = get_turf(target.current)
+		if(istype(T.loc, /area/shuttle/escape/centcom))
+			return FALSE
+		else if(istype(T.loc, /area/shuttle/escape_pod1/centcom) || istype(T.loc, /area/shuttle/escape_pod2/centcom) || istype(T.loc, /area/shuttle/escape_pod3/centcom) || istype(T.loc, /area/shuttle/escape_pod5/centcom))
+			return FALSE
+		else
+			return TRUE
+	return FALSE

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -376,6 +376,7 @@
 #include "code\datums\gamemode\objectives\target\assassinate.dm"
 #include "code\datums\gamemode\objectives\target\debrain.dm"
 #include "code\datums\gamemode\objectives\target\harm.dm"
+#include "code\datums\gamemode\objectives\target\killorexile.dm"
 #include "code\datums\gamemode\objectives\target\protection.dm"
 #include "code\datums\gamemode\objectives\target\sacrifice.dm"
 #include "code\datums\gamemode\objectives\target\target.dm"


### PR DESCRIPTION
closes #22105

🆑 
* tweak: Revs will no longer win if Heads flee on the emergency shuttle or pods, though they can still secure victory by killing the heads before the shuttle lands.
* tweak: Rev objectives are now more clear that you can exile heads instead of killing them.