### PR TITLE
Mystery of the LJ Antag Solved

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
@@ -59,15 +59,6 @@
 	requirements = list(40,30,20,10,10,10,10,10,10,10)
 	repeatable = TRUE
 
-/datum/dynamic_ruleset/latejoin/infiltrator/acceptable(var/population=0,var/threat=0)
-	var/player_count = mode.living_players.len
-	var/antag_count = mode.living_antags.len
-	var/max_traitors = round(player_count / 10) + 1
-	if ((antag_count < max_traitors) && prob(mode.threat_level))//adding traitors if the antag population is getting low
-		return ..()
-	else
-		return 0
-
 /datum/dynamic_ruleset/latejoin/infiltrator/execute()
 	var/mob/M = pick(candidates)
 	assigned += M
@@ -135,15 +126,6 @@
 	logo = "ninja-logo"
 
 	repeatable = TRUE
-
-/datum/dynamic_ruleset/latejoin/ninja/acceptable(var/population=0,var/threat=0)
-	var/player_count = mode.living_players.len
-	var/antag_count = mode.living_antags.len
-	var/max_traitors = round(player_count / 10) + 1
-	if ((antag_count < max_traitors) && prob(mode.threat_level))
-		return ..()
-	else
-		return 0
 
 /datum/dynamic_ruleset/latejoin/ninja/execute()
 	var/mob/M = pick(candidates)


### PR DESCRIPTION
@Sooose 

Basically, Dynamic already decides if it's a good idea to inject antags based on population. Ninja and Traitor were doing it a *second* time *with* an extra RNG check too. This removes it like Mages and Provocateur. In general this means we should see ++++Latejoin Traitors, ++Latejoin Ninjas, and ----Latejoin Wizards.

🆑 
* rscdel: Removed an RNG check that made latejoin traitors and ninjas less common.