### PR TITLE
Ninja Blade and Skills

### DIFF
--- a/__DEFINES/obj_defines.dm
+++ b/__DEFINES/obj_defines.dm
@@ -20,3 +20,7 @@ var/list/qualityByString = list(
 		EXCELLENT = "Excellent",
 		MASTERWORK = "Masterwork",
 		LEGENDARY = "Legendary")
+
+//Daemons
+#define DAEMON_EXAMINE 	1
+#define DAEMON_AFTATT	2

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -37,6 +37,8 @@
 // Proximity_flag is 1 if this afterattack was called on something adjacent, in your square, or on your person.
 // Click parameters is the params string from byond Click() code, see that documentation.
 /obj/item/proc/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
+	if(daemon && daemon.flags & DAEMON_AFTATT)
+		daemon.afterattack(target, user, proximity_flag, click_parameters)
 	return
 
 // Overrides the weapon attack so it can attack any atoms like when we want to have an effect on an object independent of attackby

--- a/code/datums/daemon.dm
+++ b/code/datums/daemon.dm
@@ -1,0 +1,49 @@
+/*
+A daemon can be used to give behaviors to two items that are very different
+*/
+
+/datum/daemon
+	var/flags
+	var/cooldown = 0
+	var/active = FALSE
+	var/my_atom
+
+/datum/daemon/New(atom/holder)
+	my_atom = holder
+
+/datum/daemon/proc/examine(mob/user)
+
+/datum/daemon/proc/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
+
+/datum/daemon/proc/activate()
+
+/datum/daemon/teleport
+	flags = DAEMON_EXAMINE | DAEMON_AFTATT
+	cooldown = 1 MINUTES
+	var/message
+	var/telesound
+
+/datum/daemon/teleport/New(atom/holder,activate_message,sound)
+	..()
+	message = activate_message
+	telesound = sound
+
+/datum/daemon/teleport/afterattack(atom/A, mob/user, proximity_flag, click_parameters)
+	if(!active || !isninja(user) || !ismob(A) || (A == user)) //sanity
+		return
+	if(cooldown > world.time)//you're trying to teleport when it's on cooldown.
+		return
+	var/mob/living/L = A
+	var/turf/SHHHHIIIING = get_step(L.loc, turn(L.dir, 180))
+	if(!SHHHHIIIING) //sanity for avoiding banishing our weebs into the shadow realm
+		return
+	cooldown = initial(cooldown) + world.time
+	if(telesound)
+		playsound(src, telesound,50,1)
+	user.forceMove(SHHHHIIIING)
+	user.dir = L.dir
+	if(message)
+		user.say("[message]")
+
+/datum/daemon/teleport/activate()
+	active = !active

--- a/code/datums/gamemode/misc_gamemode_procs.dm
+++ b/code/datums/gamemode/misc_gamemode_procs.dm
@@ -369,9 +369,7 @@
 	if(!istype(H))
 		return 0
 	H.delete_all_equipped_items()
-	var/obj/item/weapon/katana/hesfast/hayai = new /obj/item/weapon/katana/hesfast
-	hayai.cant_drop = 1
-	H.put_in_hands(hayai)
+	H.put_in_hands(new /obj/item/weapon/melee/energy/sword/ninja)
 
 	H.equip_to_slot_or_del(new /obj/item/clothing/mask/balaclava, slot_wear_mask)
 	H.equip_to_slot_or_del(new /obj/item/clothing/suit/kimono/ronin, slot_wear_suit)
@@ -388,14 +386,14 @@
 	H.equip_to_slot_or_del(new /obj/item/mounted/poster/stealth, slot_in_backpack)
 	H.equip_to_slot_or_del(new /obj/item/stack/shuriken(H,10), slot_l_store)
 
+	H.see_in_dark_override = 8
+
 #define GREET_WEEB "weebgreet"
 /proc/equip_weeaboo(var/mob/living/carbon/human/H)
 	if(!istype(H))
 		return 0
 	H.delete_all_equipped_items()
-	var/obj/item/weapon/katana/hesfast/hayai = new /obj/item/weapon/katana/hesfast
-	hayai.cant_drop = 1
-	H.put_in_hands(hayai)
+	H.put_in_hands(new /obj/item/weapon/katana/hesfast)
 
 	H.equip_to_slot_or_del(new /obj/item/clothing/head/rice_hat, slot_head)
 	H.equip_to_slot_or_del(new /obj/item/clothing/mask/balaclava, slot_wear_mask)
@@ -412,6 +410,8 @@
 	H.equip_to_slot_or_del(new /obj/item/weapon/substitutionhologram/dakimakura, slot_in_backpack)
 	H.equip_to_slot_or_del(new /obj/item/mounted/poster/stealth/anime, slot_in_backpack)
 	H.equip_to_slot_or_del(new /obj/item/stack/shuriken/pizza(H,10), slot_l_store)
+
+	H.see_in_dark_override = 8
 
 	var/datum/role/R = H.mind.GetRole(NINJA)
 	if(R)

--- a/code/datums/gamemode/role/ninja.dm
+++ b/code/datums/gamemode/role/ninja.dm
@@ -91,7 +91,7 @@
 	var/obj/item/stack/shuriken/S = locate(/obj/item/stack/shuriken) in H.held_items
 	if(S)
 		to_chat(H,"<span class='notice'>You add the shuriken to the stack.</span>")
-		S.amount++
+		S.amount += amount
 		qdel(src)
 
 	else
@@ -536,7 +536,7 @@ Helpers For Both Variants
 	to_chat(user, "[message]")
 
 /obj/item/weapon/katana/hesfast/suicide_act(mob/user)
-	to_chat(viewers(user), "<span class='danger'>[user] is slicing \his chest open with the [src.name]! It looks like \he's trying to commit sudoku.</span>")
+	visible_message("<span class='danger'>[user] is slicing \his chest open with the [src.name]! It looks like \he's trying to commit sudoku.</span>")
 	return(SUICIDE_ACT_BRUTELOSS)
 
 /obj/item/weapon/katana/hesfast/preattack(atom/target, mob/user, proximity_flag, click_parameters)

--- a/code/datums/gamemode/role/ninja.dm
+++ b/code/datums/gamemode/role/ninja.dm
@@ -82,6 +82,22 @@
 			to_chat(usr,"<span class='warning'>You fumble with \the [src]!</span>")
 		//Sometimes things are thrown by objects like vending machines or pneumatic cannons
 
+/obj/item/stack/shuriken/Crossed(atom/movable/A)
+	if(!ishuman(A))
+		return
+	var/mob/living/carbon/human/H = A
+	if(!isninja(H))
+		return
+	var/obj/item/stack/shuriken/S = locate(/obj/item/stack/shuriken) in H.held_items
+	if(S)
+		to_chat(H,"<span class='notice'>You add the shuriken to the stack.</span>")
+		S.amount++
+		qdel(src)
+
+	else
+		to_chat(H,"<span class='notice'>You pick up the shuriken!</span>")
+		H.put_in_hands(src)
+
 //Shield
 /obj/item/weapon/substitutionhologram
 	name = "hologram projector"
@@ -270,19 +286,25 @@
 		to_chat(user,"<span class='warning'>You need [MAKE_SHURIKEN_COST] to make that!</span>")
 
 /obj/item/clothing/gloves/ninja/proc/charge_sword(mob/user)
-	var/obj/item/weapon/katana/hesfast/oursword = locate(/obj/item/weapon/katana/hesfast) in user.held_items
-	if(oursword)
-		var/difference = (oursword.teleportcooldown-world.time)*CHARGE_COST_MULTIPLIER
-		if(difference<=0)
-			to_chat(user,"<span class='warning'>Your blade is already fully charged!</span>")
-			return
-		var/to_subtract = min(difference,reservoir) //Take the least between: how much we need, how much we have
-		oursword.teleportcooldown -= to_subtract
-		reservoir -= to_subtract
-		if(oursword.teleportcooldown < world.time)
-			to_chat(user,"<span class='good'>The glove's power flows into your weapon. Your blade is ready to be unleashed!</span>")
-		else
-			to_chat(user,"<span class='notice'>The glove's power flows into your weapon. It will be ready in [round((oursword.teleportcooldown - world.time)/10)] seconds.</span>")
+	var/obj/item/weapon/oursword = GetNinjaWeapon(user)
+	if(!oursword)
+		to_chat(user,"<span class='warning'>You need to hold the sword to channel power into it!</span>")
+		return
+	var/datum/daemon/teleport/T = oursword.daemon
+	if(!istype(T))
+		to_chat(user,"<span class='warning'>No power dwells within that blade!</span>")
+		return
+	var/difference = (T.cooldown-world.time)*CHARGE_COST_MULTIPLIER
+	if(difference<=0)
+		to_chat(user,"<span class='warning'>Your blade is already fully charged!</span>")
+		return
+	var/to_subtract = min(difference,reservoir) //Take the least between: how much we need, how much we have
+	T.cooldown -= to_subtract/CHARGE_COST_MULTIPLIER
+	reservoir -= to_subtract
+	if(T.cooldown < world.time)
+		to_chat(user,"<span class='good'>The glove's power flows into your weapon. Your blade is ready to be unleashed!</span>")
+	else
+		to_chat(user,"<span class='notice'>The glove's power flows into your weapon. It will be ready in [round((T.cooldown - world.time)/10)] seconds.</span>")
 
 /obj/item/mounted/poster/stealth
 	name = "rolled-up stealth poster"
@@ -355,63 +377,73 @@
 		new poster_path(get_turf(src), serial_number)
 	qdel(src)
 
-
-//Special Katana. Main katana in weaponry.dm
-/obj/item/weapon/katana/hesfast //it's a normal katana, except alt clicking lets you teleport behind someone for epic slice and dice time
-	var/teleportcooldown = 600 //one minute cooldown
-	var/active = FALSE
-	var/activate_message = "Weakness."
-	siemens_coefficient = 0
-
-/obj/item/weapon/katana/hesfast/IsShield()
-	return TRUE
-
-/obj/item/weapon/katana/hesfast/examine(mob/user)
-	..()
-	if(!isninja(user))
+/*=======
+Ninja Esword
+&
+Helpers For Both Variants
+=======*/
+/proc/GetNinjaWeapon(mob/M)
+	if(!istype(M))
 		return
-	to_chat(user, "<span class='notice'>This katana has an ancient power dwelling inside of it!</span>")
-	var/message = "<span class='notice'>"
-	if(teleportcooldown < world.time)
-		message += "Oh yeah, the ancient power stirs. This is the katana that will pierce the heavens!"
 	else
-		var/cooldowncalculated = round((teleportcooldown - world.time)/10)
-		message += "Your steel has unleashed its dark and unwholesome power, so it's tapped out right now. It'll be ready again in [cooldowncalculated] seconds."
+		var/obj/item/weapon/W = locate(/obj/item/weapon/melee/energy/sword/ninja) in M.held_items
+		if(W)
+			return W
+		else
+			return locate(/obj/item/weapon/katana/hesfast) in M.held_items
+
+/datum/action/item_action/toggle_teleport
+	name = "Toggle Teleport"
+
+/datum/action/item_action/toggle_teleport/Trigger()
+	var/obj/item/weapon/W = GetNinjaWeapon(owner)
+	if(!istype(W))
+		return
+	if(!ismob(owner) || !isninja(owner))
+		return
+	if(W.daemon && istype(W.daemon,/datum/daemon/teleport))
+		W.daemon.activate()
+		to_chat(owner,"<span class='notice'>Teleportation is now [W.daemon.active ? "active" : "inactive"].</span>")
+		if(!W.daemon.active && istype(W,/obj/item/weapon/katana/hesfast))
+			owner.whisper("Not today, katana-san.")
+
+/obj/item/weapon/melee/energy/sword/ninja
+	name = "energy katana"
+	desc = "It makes you a little nervous even when it's off."
+	activeforce = 40
+	onsound = null
+	actions_types = list(/datum/action/item_action/toggle_teleport)
+
+/obj/item/weapon/melee/energy/sword/ninja/New()
+	..()
+	daemon = new /datum/daemon/teleport(src,"Weakness",null)
+
+/obj/item/weapon/melee/energy/sword/ninja/toggleActive(mob/user, var/togglestate = "")
+	if(isninja(user))
+		..()
+	else
+		..(user,"on")
 	if(active)
-		message += " Alt-click it to stop teleporting, just in case you enter a no-warp trap room like the ones in Aincrad.</span>"
+		cant_drop = TRUE
 	else
-		message += " Alt-click it to enable your teleportation, just like Goku's Shunkan Idou (Instant Transmission for Gaijin).</span>"
-	to_chat(user, "[message]")
+		cant_drop = FALSE
 
-/obj/item/weapon/katana/hesfast/AltClick(mob/user)
+/obj/item/weapon/melee/energy/sword/ninja/examine(mob/user)
+	..()
 	if(!isninja(user))
 		return
-	if(!active)
-		active = TRUE
-		to_chat(user, "<span class='notice'>You will teleport on attacks if you can.</span>")
-	else//i could return on the above but this is much more readable or something
-		to_chat(user, "<span class='notice'>You will not teleport for now. \"Not today, katana-san.\"</span>")
-		active = FALSE
+	if(!daemon)
+		return
+	var/cc = max(round((daemon.cooldown - world.time)/10),0)
+	to_chat(user,"<span class='notice'>The hilt displays its status in the form of a cryptic readout.</span>")
+	to_chat(user,"<span class='notice'>TP: </span>[daemon.active ? "<span class='good'>I":"<span class='warning'>O"]</span><span class='notice'>; CD: [cc ? "[cc]s ([cc*10*CHARGE_COST_MULTIPLIER]J)</span>" : "</span><span class='warning'><B>X</B></span>"]")
 
-/obj/item/weapon/katana/hesfast/preattack(var/atom/A, mob/user)
-	if(!active || !isninja(user) || !ismob(A) || (A == user)) //sanity
-		return
-	if(teleportcooldown > world.time)//you're trying to teleport when it's on cooldown.
-		return
-	var/mob/living/L = A
-	var/turf/SHHHHIIIING = get_step(L.loc, turn(L.dir, 180))
-	if(!SHHHHIIIING) //sanity for avoiding banishing our weebs into the shadow realm
-		return
-	teleportcooldown = initial(teleportcooldown) + world.time
-	playsound(src, "sound/weapons/shing.ogg",50,1)
-	user.forceMove(SHHHHIIIING)
-	user.dir = L.dir
-	user.say("[activate_message]")
-	..()
-
-/obj/item/weapon/katana/hesfast/suicide_act(mob/user)
-	to_chat(viewers(user), "<span class='danger'>[user] is slicing \his chest open with the [src.name]! It looks like \he's trying to commit sudoku.</span>")
-	return(SUICIDE_ACT_BRUTELOSS)
+/obj/item/weapon/melee/energy/sword/ninja/preattack(atom/target, mob/user, proximity_flag, click_parameters)
+	if(target == user)
+		examine(user)
+		return 1
+	else
+		..()
 
 /*******************************************
 ****          WEEABOO VARIANTS          ****
@@ -447,9 +479,6 @@
 	activate_message = "Substitution no jutsu!"
 	reject_message = "You really, really don't want to pick that up."
 
-/obj/item/weapon/katana/hesfast/weeb
-	activate_message = "Pshh... nothing personnel... kid..."
-
 /obj/item/mounted/poster/stealth/anime
 	name = "rolled-up anime poster"
 	path = /obj/structure/sign/poster/stealth/anime
@@ -475,3 +504,43 @@
 			name = "EVA poster"
 		if("animeposter6")
 			name = "Mob Psycho poster"
+
+//Special Katana. Main katana in weaponry.dm
+/obj/item/weapon/katana/hesfast
+	siemens_coefficient = 0
+	cant_drop = TRUE
+	actions_types = list(/datum/action/item_action/toggle_teleport)
+
+/obj/item/weapon/katana/hesfast/New()
+	..()
+	daemon = new /datum/daemon/teleport(src,"sound/weapons/shing.ogg", "Pshh... nothing personnel... kid...")
+
+/obj/item/weapon/katana/hesfast/examine(mob/user)
+	..()
+	if(!isninja(user))
+		return
+	if(!daemon)
+		return
+	to_chat(user, "<span class='notice'>This katana has an ancient power dwelling inside of it!</span>")
+	var/message = "<span class='notice'>"
+	if(daemon.cooldown < world.time)
+		message += "Oh yeah, the ancient power stirs. This is the katana that will pierce the heavens!"
+	else
+		var/cooldowncalculated = round((daemon.cooldown - world.time)/10)
+		message += "Your steel has unleashed its dark and unwholesome power, so it's tapped out right now. It'll be ready again in [cooldowncalculated] seconds."
+	if(daemon.active)
+		message += " Your teleport is active, just like Goku's Shunkan Idou (Instant Transmission for Gaijin).</span>"
+	else
+		message += " Your teleport is inactive, just like a no-warp trap room in Aincrad.</span>"
+	to_chat(user, "[message]")
+
+/obj/item/weapon/katana/hesfast/suicide_act(mob/user)
+	to_chat(viewers(user), "<span class='danger'>[user] is slicing \his chest open with the [src.name]! It looks like \he's trying to commit sudoku.</span>")
+	return(SUICIDE_ACT_BRUTELOSS)
+
+/obj/item/weapon/katana/hesfast/preattack(atom/target, mob/user, proximity_flag, click_parameters)
+	if(target == user)
+		examine(user)
+		return 1
+	else
+		..()

--- a/code/datums/gamemode/role/ninja.dm
+++ b/code/datums/gamemode/role/ninja.dm
@@ -411,6 +411,7 @@ Helpers For Both Variants
 	name = "energy katana"
 	desc = "It makes you a little nervous even when it's off."
 	activeforce = 40
+	siemens_coefficient = 0
 	onsound = null
 	actions_types = list(/datum/action/item_action/toggle_teleport)
 
@@ -443,7 +444,7 @@ Helpers For Both Variants
 		examine(user)
 		return 1
 	else
-		..()
+		return ..()
 
 /*******************************************
 ****          WEEABOO VARIANTS          ****
@@ -543,4 +544,4 @@ Helpers For Both Variants
 		examine(user)
 		return 1
 	else
-		..()
+		return ..()

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -64,6 +64,8 @@
 	var/restraint_apply_sound = null
 	var/icon/wear_override = null //Worn state override used when wearing this object on your head/uniform/glasses/etc slot, for making a more procedurally generated icon
 	var/hides_identity = HIDES_IDENTITY_DEFAULT
+	var/datum/daemon/daemon
+
 /obj/item/proc/return_thermal_protection()
 	return return_cover_protection(body_parts_covered) * (1 - heat_conductivity)
 
@@ -193,6 +195,8 @@
 		to_chat(user, "You read '[price] space bucks' on the tag.")
 	if((cant_drop != FALSE) && user.is_holding_item(src)) //Item can't be dropped, and is either in left or right hand!
 		to_chat(user, "<span class='danger'>It's stuck to your hands!</span>")
+	if(daemon && daemon.flags & DAEMON_EXAMINE)
+		daemon.examine(user)
 
 
 /obj/item/attack_ai(mob/user as mob)

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -58,6 +58,8 @@
 	var/active_state = ""
 	sharpness_flags = 0 //starts inactive
 	force = 3
+	var/activeforce = 30
+	var/onsound = 'sound/weapons/saberon.ogg'
 	throwforce = 5
 	throw_speed = 1
 	throw_range = 5
@@ -109,13 +111,14 @@
 		else
 			active = !active
 	if (active)
-		force = 30
+		force = activeforce
 		w_class = W_CLASS_LARGE
 		sharpness = sharpness_on
 		sharpness_flags = SHARP_TIP | SHARP_BLADE | INSULATED_EDGE | HOT_EDGE | CHOPWOOD | CUT_WALL | CUT_AIRLOCK
 		armor_penetration = 100
 		hitsound = "sound/weapons/blade1.ogg"
-		playsound(user, 'sound/weapons/saberon.ogg', 50, 1)
+		if(onsound)
+			playsound(user, onsound, 50, 1)
 		to_chat(user, "<span class='notice'> [src] is now active.</span>")
 	else
 		force = 3
@@ -123,7 +126,8 @@
 		sharpness = 0
 		sharpness_flags = 0
 		armor_penetration = initial(armor_penetration)
-		playsound(user, 'sound/weapons/saberoff.ogg', 50, 1)
+		if(onsound)
+			playsound(user, 'sound/weapons/saberoff.ogg', 50, 1)
 		hitsound = "sound/weapons/empty.ogg"
 		to_chat(user, "<span class='notice'> [src] can now be concealed.</span>")
 	update_icon()

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -229,6 +229,7 @@
 #include "code\datums\browser.dm"
 #include "code\datums\circuits.dm"
 #include "code\datums\computerfiles.dm"
+#include "code\datums\daemon.dm"
 #include "code\datums\datacore.dm"
 #include "code\datums\datumvars.dm"
 #include "code\datums\disease.dm"


### PR DESCRIPTION
This is the last ninja buff for a while. We need to see how people adapt to these new abilities.

**Energy Katana** - Replaces the Katana
* Only stuck to your hand while it is deployed. Anyone can turn it on but only a ninja can turn it off.
* If you attack yourself with the Katana it conveniently examines for you, because its thin sprite is hard to shift click in the moment.
* Examine readout is much better than the weeb version. It shows you if teleport is active, remaining cooldown seconds, and cost in joules to refresh. Color coded.
* Toggle teleport is now an action button
* All the perks of an esword - notably hotness, wall/airlock cutting, and armor penetration.

**Darkvision** - Think Grey, not Vampire. It's only dim vision instead of pitch black.

**Under the Hood**
New daemon datums can flexibly add behaviors to two very different items.

🆑 
* rscadd: Ninjas are now equipped with the Energy Katana.
* rscadd: Ninjas will now automatically pick shuriken up by walking over them. If you have a stack of shurikens in hand it will add to the stack.
* rscadd: Ninjas can now see in the dark.