### PR TITLE
Delay Assassinate

### DIFF
--- a/code/datums/gamemode/objectives/target/assassinate.dm
+++ b/code/datums/gamemode/objectives/target/assassinate.dm
@@ -1,7 +1,6 @@
 /datum/objective/target/assassinate
 	name = "Assassinate <target>"
 
-
 /datum/objective/target/assassinate/find_target()
 	..()
 	if(target && target.current)
@@ -39,8 +38,6 @@
 		if(possible_target != owner && (possible_target.current.z != map.zCentcomm) && (possible_target.current.stat != DEAD) && !(possible_target.assigned_role in bad_assassinate_targets))
 			possible_targets += possible_target
 	return possible_targets
-
-
 
 /datum/objective/target/assassinate/IsFulfilled()
 	if (..())

--- a/code/datums/gamemode/objectives/target/delayedassassinate.dm
+++ b/code/datums/gamemode/objectives/target/delayedassassinate.dm
@@ -1,0 +1,53 @@
+/datum/objective/target/delayed/assassinate
+	name = "Assassinate Unknown Target"
+
+/datum/objective/target/delayed/assassinate/New()
+	..()
+	explanation_text = "Assassinate the [pick("data leaker","critical personnel","loved one of our enemy","mole","Nanotrasen asset","brilliant mind")]. We will have their identity in [delay/600] minutes."
+
+/datum/objective/target/delayed/assassinate/PostDelay()
+	if(auto_target)
+		if(find_target())
+			explanation_text = format_explanation()
+			if(owner)
+				to_chat(owner.current,"<span class='warning'><BIG>We have identified our objective target!</BIG></span>")
+		else
+			if(owner)
+				to_chat(owner.current,"<span class='warning'><BIG>We have determined the target is not on this station. Redact assassination order.</BIG></warning>")
+			qdel(src)
+
+/datum/objective/target/delayed/assassinate/find_target()
+	..()
+	if(target && target.current)
+		return TRUE
+	return FALSE
+
+/datum/objective/target/delayed/assassinate/select_target()
+	//Not designed for manual selection
+	return FALSE
+
+/datum/objective/target/delayed/assassinate/format_explanation()
+	if(target)
+		return "Assassinate [target.current.real_name], the [target.assigned_role=="MODE" ? (target.special_role) : (target.assigned_role)]."
+	else
+		return "Assassinate the [pick("data leaker","critical personnel","loved one of our enemy","mole","potential threat to the Syndicate","Nanotrasen asset","brilliant mind")]."
+
+/datum/objective/target/delayed/assassinate/get_targets()
+	var/list/possible_targets = list()
+	for(var/mob/living/carbon/human/H in player_list)
+		if(!H.mind || H.gcDestroyed)
+			continue
+		var/datum/mind/possible_target = H.mind
+		if(possible_target != owner && (possible_target.current.z != map.zCentcomm) && (possible_target.current.stat != DEAD) && !(possible_target.assigned_role in bad_assassinate_targets))
+			possible_targets += possible_target
+	return possible_targets
+
+/datum/objective/target/delayed/assassinate/IsFulfilled()
+	if (..())
+		return TRUE
+	//Same conditionals as normal assassinate
+	if(target && target.current)
+		if(target.current.stat == DEAD || issilicon(target.current) || isbrain(target.current) || target.current.z > 6 || !target.current.ckey || isborer(target.current))
+			return TRUE
+		return FALSE
+	return TRUE

--- a/code/datums/gamemode/objectives/target/target.dm
+++ b/code/datums/gamemode/objectives/target/target.dm
@@ -5,6 +5,11 @@
 	var/auto_target = TRUE //Whether we pick a target automatically on PostAppend()
 	name = ""
 
+/datum/objective/target/delayed
+	var/delay = 10 MINUTES
+
+/datum/objective/target/delayed/proc/PostDelay()
+
 /datum/objective/target/New(var/text,var/auto_target = TRUE, var/mob/user = null)
 	src.auto_target = auto_target
 	if(text)
@@ -13,6 +18,11 @@
 /datum/objective/target/PostAppend()
 	if(auto_target)
 		return find_target()
+	return TRUE
+
+/datum/objective/target/delayed/PostAppend()
+	spawn(delay)
+		PostDelay()
 	return TRUE
 
 /datum/objective/target/proc/find_target()

--- a/code/datums/gamemode/role/ninja.dm
+++ b/code/datums/gamemode/role/ninja.dm
@@ -19,7 +19,7 @@
 
 /datum/role/ninja/ForgeObjectives()
 	AppendObjective(/datum/objective/target/steal)
-	AppendObjective(/datum/objective/target/assassinate)
+	AppendObjective(/datum/objective/target/delayed/assassinate)
 	AppendObjective(/datum/objective/target/skulls)
 	AppendObjective(/datum/objective/escape)
 

--- a/code/datums/gamemode/role/syndicate.dm
+++ b/code/datums/gamemode/role/syndicate.dm
@@ -41,7 +41,7 @@
 		AppendObjective(/datum/objective/freeform/syndicate)
 		return
 	if(istype(antag.current, /mob/living/silicon))
-		AppendObjective(/datum/objective/target/assassinate)
+		AppendObjective(/datum/objective/target/delayed/assassinate)
 
 		AppendObjective(/datum/objective/survive)
 
@@ -49,7 +49,7 @@
 			AppendObjective(/datum/objective/block)
 
 	else
-		AppendObjective(/datum/objective/target/assassinate)
+		AppendObjective(/datum/objective/target/delayed/assassinate)
 		AppendObjective(/datum/objective/target/steal)
 		switch(rand(1,100))
 			if(1 to 30) // Die glorious death

--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -120,7 +120,7 @@
 
 	AppendObjective(/datum/objective/acquire_blood)
 
-	AppendObjective(/datum/objective/target/assassinate)
+	AppendObjective(/datum/objective/target/delayed/assassinate)
 
 	AppendObjective(/datum/objective/target/steal)
 

--- a/code/datums/gamemode/role/wizard.dm
+++ b/code/datums/gamemode/role/wizard.dm
@@ -14,13 +14,13 @@
 		return
 	switch(rand(1,100))
 		if(1 to 30)
-			AppendObjective(/datum/objective/target/assassinate)
+			AppendObjective(/datum/objective/target/delayed/assassinate)
 			AppendObjective(/datum/objective/escape, 1)
 		if(31 to 60)
 			AppendObjective(/datum/objective/target/steal)
 			AppendObjective(/datum/objective/escape, 1)
 		if(61 to 100)
-			AppendObjective(/datum/objective/target/assassinate)
+			AppendObjective(/datum/objective/target/delayed/assassinate)
 			AppendObjective(/datum/objective/target/steal)
 			AppendObjective(/datum/objective/survive, 1)
 		else

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -375,6 +375,7 @@
 #include "code\datums\gamemode\objectives\freeform\wizard.dm"
 #include "code\datums\gamemode\objectives\target\assassinate.dm"
 #include "code\datums\gamemode\objectives\target\debrain.dm"
+#include "code\datums\gamemode\objectives\target\delayedassassinate.dm"
 #include "code\datums\gamemode\objectives\target\harm.dm"
 #include "code\datums\gamemode\objectives\target\killorexile.dm"
 #include "code\datums\gamemode\objectives\target\protection.dm"


### PR DESCRIPTION
You will now receive your assassinate objective after 10 minutes.

![Untitled](https://user-images.githubusercontent.com/9782036/54830943-77759000-4c87-11e9-8b0d-27cb35e66d44.png)

Before you know the target's name they are called something from this list: data leaker, critical personnel, loved one of our enemy, mole, Nanotrasen asset, brilliant mind

I for one welcome assassinating Grug Unga, brilliant mind.

🆑 
* rscadd: Objectives can now exist as a delayed type where the target is chosen later. Assassinate is delayed 10 minutes for most antags (but not for revolutionaries). This means that latejoining within the first 10 minutes is functionally equal to being ready at start for roundstart assassinations.