### PR TITLE
Literally just sets the default alternate option to RETURN TO LOBBY

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -152,7 +152,7 @@ var/const/MAX_SAVE_SLOTS = 8
 	var/job_engsec_low = 0
 
 	//Keeps track of preferrence for not getting any wanted jobs
-	var/alternate_option = 0
+	var/alternate_option = RETURN_TO_LOBBY
 
 	var/used_skillpoints = 0
 	var/skill_specialization = null


### PR DESCRIPTION
while a lot of people'll have this not as their default in preferences, this'll catch new players and send them back to lobby, rather than making then a job they may not be already familiar with.

:cl:
 * rscadd: Default alternate job option is now return to lobby, rather than get random job.