### PR TITLE
Buying the wizard hardsuit gives you the no-breathing superpower

### DIFF
--- a/code/game/gamemodes/wizard/artifacts.dm
+++ b/code/game/gamemodes/wizard/artifacts.dm
@@ -58,7 +58,7 @@
 	/obj/item/clothing/suit/space/rig/wizard,\
 	/obj/item/clothing/head/helmet/space/rig/wizard)
 
-/datum/spellbook_artifact/scrying/purchased(mob/living/carbon/human/H)
+/datum/spellbook_artifact/armor/purchased(mob/living/carbon/human/H)
 	..()
 	if(istype(H) && !H.mutations.Find(M_NO_BREATH))
 		H.mutations.Add(M_NO_BREATH)

--- a/code/game/gamemodes/wizard/artifacts.dm
+++ b/code/game/gamemodes/wizard/artifacts.dm
@@ -58,6 +58,12 @@
 	/obj/item/clothing/suit/space/rig/wizard,\
 	/obj/item/clothing/head/helmet/space/rig/wizard)
 
+/datum/spellbook_artifact/scrying/purchased(mob/living/carbon/human/H)
+	..()
+	if(istype(H) && !H.mutations.Find(M_NO_BREATH))
+		H.mutations.Add(M_NO_BREATH)
+		to_chat(H, "<span class='notice'>You feel no need to breathe.</span>")
+
 /datum/spellbook_artifact/staff_of_animation
 	name = "Staff of Animation"
 	desc = "An arcane staff capable of shooting bolts of eldritch energy which cause inanimate objects to come to life. This magic doesn't affect machines."


### PR DESCRIPTION
Wizards no longer have to get an oxygen tank!
You can call it a quality of life or terrible addition, but personally I think it's better with this
:cl:
 * tweak: Buying the wizard hardsuit removes your need to breathe.