### PR TITLE
Removes need for harm intent when cutting walls with CUT_WALL flag weapons

### DIFF
--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -248,7 +248,7 @@
 			return
 
     //CUT_WALL will dismantle the wall
-	else if(W.sharpness_flags & (CUT_WALL) && user.a_intent == I_HURT)
+	else if(W.sharpness_flags & (CUT_WALL))
 		user.visible_message("<span class='warning'>[user] begins slicing through \the [src]'s outer plating.</span>", \
 		"<span class='notice'>You begin slicing through \the [src]'s outer plating.</span>", \
 		"<span class='warning'>You hear slicing noises.</span>")


### PR DESCRIPTION
Asked to by @Kurfursten . You still need to have harm intent for airlocks!
:cl:
 * tweak: You no longer need harm intent to cut walls with weapons that allow you to cut walls (currently melee energy weapons) because the feature was too obscure. You still need harm intent for cutting airlocks!