### PR TITLE
[Dynamic Mode] High Population Override

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -189,7 +189,7 @@
 	var/weighted_votes = 0
 
 	// Dynamic Mode
-	var/high_population_override = 0//If 1, what rulesets can or cannot be called depend on the threat level only
+	var/high_population_override = 1//If 1, what rulesets can or cannot be called depend on the threat level only
 
 /datum/configuration/New()
 	. = ..()

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -188,6 +188,9 @@
 	// Weighted Votes
 	var/weighted_votes = 0
 
+	// Dynamic Mode
+	var/high_population_override = 0//If 1, what rulesets can or cannot be called depend on the threat level only
+
 /datum/configuration/New()
 	. = ..()
 	var/list/L = subtypesof(/datum/gamemode)-/datum/gamemode/cult

--- a/code/datums/gamemode/dynamic/dynamic_rulesets.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets.dm
@@ -25,6 +25,9 @@
 	//0-4, 5-9, 10-14, 15-19, 20-24, 25-29, 30-34, 35-39, 40-54, 45+
 	//so with the above default values, The rule will never get drafted below 10 threat level (aka: "peaceful extended"), and it requires a higher threat level at lower pops.
 	//for reminder: the threat level is rolled at roundstart and tends to hover around 50 https://docs.google.com/spreadsheets/d/1QLN_OBHqeL4cm9zTLEtxlnaJHHUu0IUPzPbsI-DFFmc/edit#gid=499381388
+	var/high_population_requirement = 10
+	//an alternative, static requirement used instead when "high_population_override" is set to 1 in the config
+	//which it should be when even low pop rounds have over 30 players and high pop rounds have 90+.
 
 	var/datum/gamemode/dynamic/mode = null
 
@@ -49,13 +52,17 @@
 /datum/dynamic_ruleset/latejoin//Can be drafted when a player joins the server
 
 
-/datum/dynamic_ruleset/proc/acceptable(var/population=0,var/threat=0)
+/datum/dynamic_ruleset/proc/acceptable(var/population=0,var/threat_level=0)
 	//by default, a rule is acceptable if it satisfies the threat level/population requirements.
 	//If your rule has extra checks, such as counting security officers, do that in ready() instead
 	if (!map.map_ruleset(src))
 		return 0
-	var/indice_pop = min(10,round(population/5)+1)
-	return (threat >= requirements[indice_pop])
+
+	if (config.high_population_override)
+		return (threat_level >= high_population_requirement)
+	else
+		var/indice_pop = min(10,round(population/5)+1)
+		return (threat_level >= requirements[indice_pop])
 
 /datum/dynamic_ruleset/proc/process()
 	//write here your rule execution code, everything about faction/role spawning/populating.
@@ -184,7 +191,7 @@
 /datum/dynamic_ruleset/roundstart/delayed/trim_candidates()
 	if (ticker && ticker.current_state <  GAME_STATE_PLAYING)
 		return ..() // If the game didn't start, we'll use the parent's method to see if we have enough people desiring the role & what not.
-	var/role_id = initial(role_category.id) 
+	var/role_id = initial(role_category.id)
 	for (var/mob/P in candidates)
 		if (!istype(P, required_type))
 			candidates.Remove(P) // Can be a new_player, etc.

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
@@ -57,6 +57,7 @@
 	weight = 7
 	cost = 5
 	requirements = list(40,30,20,10,10,10,10,10,10,10)
+	high_population_requirement = 10
 	repeatable = TRUE
 
 /datum/dynamic_ruleset/latejoin/infiltrator/execute()
@@ -84,6 +85,7 @@
 	weight = 1
 	cost = 20
 	requirements = list(90,90,70,40,30,20,10,10,10,10)
+	high_population_requirement = 40
 	repeatable = TRUE
 
 /datum/dynamic_ruleset/latejoin/raginmages/ready(var/forced = 0)
@@ -123,6 +125,7 @@
 	weight = 4
 	cost = 10
 	requirements = list(90,90,60,20,10,10,10,10,10,10)
+	high_population_requirement = 20
 	logo = "ninja-logo"
 
 	repeatable = TRUE
@@ -155,6 +158,7 @@
 	cost = 20
 	var/required_heads = 3
 	requirements = list(101,101,70,40,30,20,20,20,20,20)
+	high_population_requirement = 50
 
 /datum/dynamic_ruleset/latejoin/provocateur/ready(var/forced=FALSE)
 	if (forced)

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -167,6 +167,7 @@
 	cost = 10
 	requirements = list(50,40,30,20,10,10,10,10,10,10)
 	repeatable = TRUE
+	high_population_requirement = 10
 
 /datum/dynamic_ruleset/midround/autotraitor/acceptable(var/population=0,var/threat=0)
 	var/player_count = mode.living_players.len
@@ -222,6 +223,7 @@
 	weight = 1
 	cost = 35
 	requirements = list(101,101,80,70,60,60,50,50,40,40)
+	high_population_requirement = 65
 
 /datum/dynamic_ruleset/midround/malf/trim_candidates()
 	..()
@@ -271,6 +273,7 @@
 	weight = 1
 	cost = 20
 	requirements = list(90,90,70,40,30,20,10,10,10,10)
+	high_population_requirement = 50
 	logo = "raginmages-logo"
 	repeatable = TRUE
 
@@ -312,6 +315,7 @@
 	weight = 5
 	cost = 35
 	requirements = list(90,90,90,80,60,40,30,20,10,10)
+	high_population_requirement = 60
 	var/operative_cap = list(2,2,3,3,4,5,5,5,5,5)
 	logo = "nuke-logo"
 
@@ -353,6 +357,7 @@
 	weight = 3
 	cost = 15
 	requirements = list(90,60,40,40,40,40,30,20,15,15)
+	high_population_requirement = 70
 	logo = "blob-logo"
 
 	makeBody = FALSE
@@ -387,6 +392,7 @@
 	weight = 5
 	cost = 45
 	requirements = list(101,101,90,60,45,45,45,45,45,45)
+	high_population_requirement = 50
 	my_fac = /datum/faction/revolution
 	logo = "rev-logo"
 	var/required_heads = 3
@@ -424,6 +430,7 @@
 	weight = 4
 	cost = 10
 	requirements = list(90,90,60,20,10,10,10,10,10,10)
+	high_population_requirement = 20
 	logo = "ninja-logo"
 	repeatable = TRUE
 
@@ -457,6 +464,7 @@
 	weight = 3
 	cost = 10
 	requirements = list(40,20,10,10,10,10,10,10,10,10) // So that's not possible to roll it naturally
+	high_population_requirement = 10
 
 /datum/dynamic_ruleset/midround/from_ghosts/grinch/acceptable(var/population=0, var/threat=0)
 	if(grinchstart.len == 0)
@@ -483,6 +491,7 @@
 	weight = 1
 	cost = 0
 	requirements = list(0,0,0,0,0,0,0,0,0,0)
+	high_population_requirement = 0
 	logo = "catbeast-logo"
 
 /datum/dynamic_ruleset/midround/from_ghosts/catbeast/acceptable(var/population=0,var/threat=0)

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -15,6 +15,7 @@
 	weight = 5
 	cost = 10
 	requirements = list(10,10,10,10,10,10,10,10,10,10)
+	high_population_requirement = 10
 	var/autotraitor_cooldown = 450//15 minutes (ticks once per 2 sec)
 
 /datum/dynamic_ruleset/roundstart/traitor/execute()
@@ -54,6 +55,7 @@
 	weight = 3
 	cost = 30
 	requirements = list(80,60,40,20,20,10,10,10,10,10)
+	high_population_requirement = 30
 
 /datum/dynamic_ruleset/roundstart/changeling/execute()
 	var/num_changelings = min(round(mode.candidates.len / 10) + 1, candidates.len)
@@ -84,6 +86,7 @@
 	weight = 2
 	cost = 25
 	requirements = list(80,60,50,30,20,10,10,10,10,10)
+	high_population_requirement = 30
 
 /datum/dynamic_ruleset/roundstart/vampire/execute()
 	var/num_vampires = min(round(mode.candidates.len / 10) + 1, candidates.len)
@@ -115,6 +118,7 @@
 	weight = 3
 	cost = 30
 	requirements = list(90,90,70,40,30,20,10,10,10,10)
+	high_population_requirement = 40
 	var/list/roundstart_wizards = list()
 
 /datum/dynamic_ruleset/roundstart/wizard/acceptable(var/population=0,var/threat=0)
@@ -155,6 +159,7 @@
 	weight = 2
 	cost = 45
 	requirements = list(90,90,70,40,30,20,10,10,10,10)
+	high_population_requirement = 40
 	persistent = 1
 	var/wizard_cd = 210 //7 minutes
 	var/total_wizards = 4
@@ -206,6 +211,7 @@
 	weight = 3
 	cost = 30
 	requirements = list(90,80,60,30,20,10,10,10,10,10)
+	high_population_requirement = 40
 	var/cultist_cap = list(2,2,3,4,4,4,4,4,4,4)
 
 /datum/dynamic_ruleset/roundstart/bloodcult/ready(var/forced = 0)
@@ -253,6 +259,7 @@
 	weight = 3
 	cost = 25
 	requirements = list(90,90,70,40,30,20,10,10,10,10)
+	high_population_requirement = 40
 
 /datum/dynamic_ruleset/roundstart/cult_legacy/execute()
 	//if ready() did its job, candidates should have 4 or more members in it
@@ -289,6 +296,7 @@
 	weight = 3
 	cost = 40
 	requirements = list(90,90,90,80,60,40,30,20,10,10)
+	high_population_requirement = 60
 	var/operative_cap = list(2,2,3,3,4,5,5,5,5,5)
 
 
@@ -345,6 +353,7 @@
 	weight = 2
 	cost = 40
 	requirements = list(90,90,90,90,80,70,50,30,20,10)
+	high_population_requirement = 65
 
 /datum/dynamic_ruleset/roundstart/malf/execute()
 	var/datum/faction/malf/unction = find_active_faction_by_type(/datum/faction/malf)
@@ -401,6 +410,7 @@
 	weight = 3
 	cost = 45
 	requirements = list(90,90,90,80,60,40,30,20,10,10)
+	high_population_requirement = 70
 
 /datum/dynamic_ruleset/roundstart/blob/execute()
 	var/datum/faction/blob_conglomerate/blob_fac = find_active_faction_by_type(/datum/faction/blob_conglomerate)
@@ -438,6 +448,7 @@
 	weight = 3
 	cost = 0
 	requirements = list(101,101,101,101,101,101,101,101,101,101) // So that's not possible to roll it naturally
+	high_population_requirement = 101
 
 /datum/dynamic_ruleset/roundstart/extended/execute()
 	message_admins("Starting a round of extended.")
@@ -460,6 +471,7 @@
 	weight = 2
 	cost = 35
 	requirements = list(101,101,70,40,30,20,10,10,10,10)
+	high_population_requirement = 50
 	delay = 5 MINUTES
 	var/required_heads = 3
 
@@ -511,6 +523,7 @@
 	weight = 3
 	cost = 10
 	requirements = list(40,20,10,10,10,10,10,10,10,10) // So that's not possible to roll it naturally
+	high_population_requirement = 10
 
 /datum/dynamic_ruleset/roundstart/grinch/acceptable(var/population=0, var/threat=0)
 	if(grinchstart.len == 0)


### PR DESCRIPTION
Adds a new config var, now set to 1. To summarize, this greatly simplifies ruleset picking/injection to deal with our now pretty high playerbase:
* having multiple roundstart rulesets now depends solely of the threat level. +1 at 50, +1 again at 75.
* halved the impact of the player population per antag on the ruleset injection chance
* all rulesets now have an override requirement that solely depends on the Threat Level, which will make high threat antags a slightly rarer occurence theoretically. Might or not add override weights as well later.

:cl:
* experiment: As our player numbers have soared in the past week, Dynamic Mode which had been designed to support populations oscillating between 5 and 50 players has basically kept picking mode as if we were being permanently at Threat Level 100, as far as roundstart rulesets are concerned at least. Therefore a new alternative configuration has been put in place that puts more weight on the Threat Level, and less on the player population, with the goal to bring back some variety to our rounds, and less Nuke+Malf+Blob at every or so roundstarts.