### PR TITLE
null rod revamp qB^)

### DIFF
--- a/code/game/objects/items/weapons/null_rod.dm
+++ b/code/game/objects/items/weapons/null_rod.dm
@@ -52,13 +52,8 @@
 			if(VAMP_MATURE in V.powers)
 				to_chat(H, "<span class='warning'>\The [src]'s power violently interferes with your own!</span>")
 				if(V.nullified < 5) //Don't actually reduce their debuff if it's over 5
-					V.nullified = max(5, V.nullified + 2)
-
-				/* undead smite abilities moved to thurible (and silver weapons in general).
-
-				V.smitecounter += 30 //Smithe the shit out of him. Four strikes and he's out
-
-				*/
+					V.nullified = min(5, V.nullified + 2)
+				V.smitecounter += 30 //Smite the shit out of him. Four strikes and he's out
 
 	//A 25% chance to de-cult per hit that bypasses all protections? Is this some kind of joke? The last thing cult needs right now is that kind of nerfs. Jesus dylan.
 	/*
@@ -97,8 +92,6 @@
 			to_chat(user, "<span class='warning'>A structure suddenly emerges from the ground!</span>")
 		call(/obj/effect/rune_legacy/proc/revealrunes)(src)//revealing legacy runes as well because why not
 
-/* undead smite abilities moved to thurible. (and silver weapons in general)
-
 /obj/item/weapon/nullrod/pickup(mob/living/user as mob)
 	if(user.mind)
 		if(user.mind.assigned_role == "Chaplain")
@@ -108,7 +101,6 @@
 			if(V && !(VAMP_UNDYING in V.powers))
 				V.smitecounter += 60
 				to_chat(user, "<span class='danger'>You feel an unwanted presence as you pick up the rod. Your body feels like it is burning from the inside!</span>")
-*/
 
 /obj/item/weapon/nullrod/attack_self(mob/user)
 	if(reskinned)


### PR DESCRIPTION
why was this removed in the first place
thuribles still work
if the null rod protects the holder why cant it smite bitches too
i dun geddit
(for those who didn't know, only the chaplain can use it in this way)
(fuck sec)

:cl: 
* tweak: null rod fucks up vampires once more
* tweak: also fixes a bug with the old code
* tweak: fixes a typo in a comment