### PR TITLE
Refactors Throw Impact

### DIFF
--- a/code/datums/gamemode/role/ninja.dm
+++ b/code/datums/gamemode/role/ninja.dm
@@ -95,7 +95,7 @@
 /obj/item/weapon/substitutionhologram/IsShield()
 	return TRUE
 
-/obj/item/weapon/substitutionhologram/on_block(damage, attack_text = "the_attack")
+/obj/item/weapon/substitutionhologram/on_block(damage, atom/blocked)
 	if(ishuman(loc))
 		var/mob/living/carbon/human/H = loc
 		if(H.mind.GetRole(NINJA))

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -486,6 +486,11 @@
 		return 1
 	return 0
 
+//Called below in hit_check to see if it can be hit
+//Return TRUE if not hit.
+/atom/proc/PreImpact(atom/movable/A, speed)
+	return TRUE
+
 /atom/movable/proc/hit_check(var/speed, mob/user)
 	. = 1
 
@@ -494,21 +499,10 @@
 			if(A == src)
 				continue
 
-			if(isliving(A))
-				var/mob/living/L = A
-				if(L.lying)
-					continue
-				src.throw_impact(L, speed, user)
-
-				if(src.throwing == 1) //If throwing == 1, the throw was weak and will stop when it hits a dude. If a hulk throws this item, throwing is set to 2 (so the item will pass through multiple mobs)
-					src.throwing = 0
-					. = 0
-
-			else if(isobj(A))
-				var/obj/O = A
-				if(O.density && !O.throwpass)	// **TODO: Better behaviour for windows which are dense, but shouldn't always stop movement
-					src.throw_impact(O, speed, user)
-					src.throwing = 0
+			if(!A.PreImpact(src,speed))
+				throw_impact(A,speed,user)
+				if(throwing==1)
+					throwing = 0
 					. = 0
 
 /atom/movable/proc/throw_at(atom/target, range, speed, override = 1, var/fly_speed = 0) //fly_speed parameter: if 0, does nothing. Otherwise, changes how fast the object flies WITHOUT affecting damage!

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -920,10 +920,13 @@
 	return FALSE
 
 //Called when the item blocks an attack. Return 1 to stop the hit, return 0 to let the hit go through
-/obj/item/proc/on_block(damage, attack_text = "the attack")
+/obj/item/proc/on_block(damage, atom/blocked)
 	if(ismob(loc))
 		if(prob(50 - round(damage / 3)))
-			visible_message("<span class='danger'>[loc] blocks [attack_text] with \the [src]!</span>")
+			visible_message("<span class='danger'>[loc] blocks \the [blocked] with \the [src]!</span>")
+			if(isatommovable(blocked))
+				var/atom/movable/M = blocked
+				M.throwing = FALSE
 			return TRUE
 
 	return FALSE

--- a/code/game/objects/items/weapons/lance.dm
+++ b/code/game/objects/items/weapons/lance.dm
@@ -168,7 +168,7 @@
 				var/mob/living/carbon/human/H = victim
 				var/datum/organ/external/affecting = H.get_organ(ran_zone(owner.zone_sel.selecting))
 
-				if(H.check_shields(base_damage, "the couched lance"))
+				if(H.check_shields(base_damage, L))
 					H.visible_message("<span class='danger'>[H] blocks \the [owner]'s [src.L.name] hit.</span>", "<span class='notice'>You block \the [owner]'s couched [src.L.name].</span>")
 					return
 

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -47,7 +47,7 @@
 /obj/item/weapon/shield/riot/buckler/IsShield()
 	return prob(33) //Only attempt to block 1/3 of attacks
 
-/obj/item/weapon/shield/riot/buckler/on_block(damage, attack_text = "the_attack")
+/obj/item/weapon/shield/riot/buckler/on_block(damage, atom/blocked)
 	if(damage > 10)
 		if(prob(min(10*(damage-10), 75))) //Bucklers are prone to breaking apart
 			var/turf/T = get_turf(src)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -698,3 +698,9 @@ a {
 
 /obj/proc/check_uplink_validity()
 	return TRUE
+
+//Return true if thrown object misses
+/obj/PreImpact(atom/movable/A, speed)
+	if(density && !throwpass)
+		return FALSE
+	return TRUE

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -233,7 +233,7 @@
 		src.add_fingerprint(user)
 	return
 
-/obj/item/clothing/suit/armor/reactive/on_block(damage, attack_text)
+/obj/item/clothing/suit/armor/reactive/on_block(damage, atom/blocked)
 	if(!prob(35))
 		return 0 //35% chance
 
@@ -261,7 +261,7 @@
 	if(!isturf(picked))
 		return
 
-	L.visible_message("<span class='danger'>The reactive teleport system flings [L] clear of [attack_text]!</span>", "<span class='notice'>The reactive teleport system flings you clear of [attack_text].</span>")
+	L.visible_message("<span class='danger'>The reactive teleport system flings [L] clear of \the [blocked]!</span>", "<span class='notice'>The reactive teleport system flings you clear of \the [blocked].</span>")
 
 	playsound(L, 'sound/effects/teleport.ogg', 30, 1)
 

--- a/code/modules/mob/living/carbon/combat.dm
+++ b/code/modules/mob/living/carbon/combat.dm
@@ -44,7 +44,7 @@
 		visible_message("<span class='danger'>[user] misses [src] with \the [I]!</span>")
 		return FALSE
 
-	if((user != src) && check_shields(I.force, "the [I.name]"))
+	if((user != src) && check_shields(I.force, I))
 		return FALSE
 
 	user.do_attack_animation(src, I)
@@ -62,3 +62,19 @@
 	apply_damage(damage, I.damtype, affecting, armor , I.is_sharp(), used_weapon = I)
 
 	return TRUE
+
+/mob/living/carbon/proc/check_shields(var/damage = 0, var/atom/A)
+	if(!incapacitated())
+		for(var/obj/item/weapon/I in held_items)
+			if(I.IsShield() && I.on_block(damage, A))
+				return 1
+
+	return 0
+
+/mob/living/carbon/PreImpact(atom/movable/A, speed)
+	if(isobj(A))
+		var/obj/O = A
+		if(check_shields(O.throwforce*(speed/5),O))
+			return TRUE
+	else
+		return ..()

--- a/code/modules/mob/living/carbon/complex/combat.dm
+++ b/code/modules/mob/living/carbon/complex/combat.dm
@@ -5,7 +5,7 @@
 	return 0 //Punches don't stun
 
 /mob/living/carbon/complex/bullet_act(var/obj/item/projectile/P, var/def_zone)
-	if(check_shields(P.damage, "the [P.name]"))
+	if(check_shields(P.damage, P))
 		P.on_hit(src, 2)
 		return 2
 	return (..(P , def_zone))

--- a/code/modules/mob/living/carbon/human/human_attackalien.dm
+++ b/code/modules/mob/living/carbon/human/human_attackalien.dm
@@ -1,6 +1,6 @@
 /mob/living/carbon/human/attack_alien(mob/living/carbon/alien/humanoid/M)
 	//M.delayNextAttack(10)
-	if(check_shields(0, M.name))
+	if(check_shields(0, M))
 		visible_message("<span class='danger'>[M] attempted to touch [src]!</span>")
 		return 0
 

--- a/code/modules/mob/living/carbon/human/human_attackanimal.dm
+++ b/code/modules/mob/living/carbon/human/human_attackanimal.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/human/attack_animal(mob/living/simple_animal/M)
-	if(check_shields(0, M.name))
+	if(check_shields(0, M))
 		return 0
 
 	M.unarmed_attack_mob(src)

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -177,7 +177,7 @@
 
 	..()
 
-	if((M != src) && check_shields(0, M.name))
+	if((M != src) && check_shields(0, M))
 		visible_message("<span class='danger'>[M] attempts to touch [src]!</span>")
 		return 0
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -23,7 +23,7 @@ emp_act
 
 				return -1 // complete projectile permutation
 
-	if(check_shields(P.damage, "the [P.name]"))
+	if(check_shields(P.damage, P))
 		P.on_hit(src, 2)
 		return 2
 	return (..(P , def_zone))
@@ -149,22 +149,13 @@ emp_act
 		body_coverage &= ~(C.body_parts_covered)
 	return body_coverage
 
-
-/mob/living/carbon/proc/check_shields(var/damage = 0, var/attack_text = "the attack")
-	if(!incapacitated())
-		for(var/obj/item/weapon/I in held_items)
-			if(I.IsShield() && I.on_block(damage, attack_text))
-				return 1
-
-	return 0
-
-/mob/living/carbon/human/check_shields(damage, attack_text = "the attack")
+/mob/living/carbon/human/check_shields(damage, atom/A)
 	if(..())
 		return 1
 
 	if(istype(wear_suit, /obj/item)) //Check armor
 		var/obj/item/I = wear_suit
-		if(I.IsShield() && I.on_block(damage, attack_text))
+		if(I.IsShield() && I.on_block(damage, A))
 			return 1
 
 /mob/living/carbon/human/emp_act(severity)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -318,3 +318,9 @@
 	IgniteMob()
 
 //Mobs on Fire end
+
+//Return true if thrown object misses
+/mob/living/PreImpact(atom/movable/A, speed)
+	if(lying)
+		return TRUE
+	return FALSE

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -254,7 +254,7 @@
 			return
 
 		var/hit_area = affecting.display_name
-		if((user != target) && H.check_shields(7, "the [src.name]"))
+		if((user != target) && H.check_shields(7, src))
 			return
 
 		// Check for protection on the targeted area and show messages


### PR DESCRIPTION
Checks to see if a thrown object impacts are now OOP

Most important consequence of this is that shields can block thrown items, fixes #22204

Also refactored on_block to take the thrown item and stop it, but objects that don't inherit base behavior don't use this (e.g.: if you block a toolbox with a katana it will stop on your tile, if you dodge it with the hologram projector it will fly through to the end of its throw course)

This also means that it is much easier to manipulate the blocked item in future PRs. For example, if someone wanted to add a behavior where blocking a thrown item with a katana reflects it back at the thrower, they could do that.

🆑 
* tweak: Shields and other blocking items (e.g.: katanas) now properly block thrown objects