### PR TITLE
No Locker Exile (again)

### DIFF
--- a/code/datums/gamemode/objectives/target/killorexile.dm
+++ b/code/datums/gamemode/objectives/target/killorexile.dm
@@ -7,8 +7,8 @@
 /datum/objective/target/assassinate/orexile/IsFulfilled()
 	if(..())
 		return TRUE //Covers dead, cyborgified, MMI'd, on away mission, no target, manual toggle
-	if(target.current.z != STATION_Z)
-		var/turf/T = get_turf(target.current)
+	var/turf/T = get_turf(target.current)
+	if(T.z != STATION_Z)
 		if(istype(T.loc, /area/shuttle/escape/centcom))
 			return FALSE
 		else if(istype(T.loc, /area/shuttle/escape_pod1/centcom) || istype(T.loc, /area/shuttle/escape_pod2/centcom) || istype(T.loc, /area/shuttle/escape_pod3/centcom) || istype(T.loc, /area/shuttle/escape_pod5/centcom))

--- a/code/datums/gamemode/objectives/target/killorexile.dm
+++ b/code/datums/gamemode/objectives/target/killorexile.dm
@@ -8,6 +8,8 @@
 	if(..())
 		return TRUE //Covers dead, cyborgified, MMI'd, on away mission, no target, manual toggle
 	var/turf/T = get_turf(target.current)
+	if(!T)
+		return TRUE
 	if(T.z != STATION_Z)
 		if(istype(T.loc, /area/shuttle/escape/centcom))
 			return FALSE


### PR DESCRIPTION
@SonixApache 

This was my fault

fixes #22209

🆑 
* bugfix: Once again fixes the bug where heads would be "exiled" during revs by getting inside a mech, locker, sleeper, etc.