### PR TITLE
Delay Improvements

### DIFF
--- a/code/datums/gamemode/objectives/objective.dm
+++ b/code/datums/gamemode/objectives/objective.dm
@@ -20,6 +20,9 @@
 /datum/objective/proc/PostAppend()
 	return TRUE
 
+//1 is station, 2 is centcom
+/datum/objective/proc/ShuttleDocked(state)
+
 /datum/objective/proc/IsFulfilled()
 	if(force_success)
 		return TRUE

--- a/code/datums/gamemode/objectives/target/delayedassassinate.dm
+++ b/code/datums/gamemode/objectives/target/delayedassassinate.dm
@@ -6,7 +6,7 @@
 	explanation_text = "Assassinate the [pick("data leaker","critical personnel","loved one of our enemy","mole","Nanotrasen asset","brilliant mind")]. We will have their identity in [delay/600] minutes."
 
 /datum/objective/target/delayed/assassinate/PostDelay()
-	if(auto_target)
+	if(auto_target && !target)
 		if(find_target())
 			explanation_text = format_explanation()
 			if(owner)

--- a/code/datums/gamemode/objectives/target/target.dm
+++ b/code/datums/gamemode/objectives/target/target.dm
@@ -10,6 +10,10 @@
 
 /datum/objective/target/delayed/proc/PostDelay()
 
+/datum/objective/target/delayed/ShuttleDocked(state)
+	if(state == 1)
+		PostDelay()
+
 /datum/objective/target/New(var/text,var/auto_target = TRUE, var/mob/user = null)
 	src.auto_target = auto_target
 	if(text)
@@ -21,6 +25,9 @@
 	return TRUE
 
 /datum/objective/target/delayed/PostAppend()
+	if(emergency_shuttle.location || emergency_shuttle.direction == 2)
+		PostDelay() //If the shuttle is docked or en route to centcomm, no delay
+		return TRUE
 	spawn(delay)
 		PostDelay()
 	return TRUE

--- a/code/datums/gamemode/role/role.dm
+++ b/code/datums/gamemode/role/role.dm
@@ -465,6 +465,9 @@
 /datum/role/proc/RoleTopic(href, href_list, var/datum/mind/M, var/admin_auth)
 
 /datum/role/proc/ShuttleDocked(state)
+	if(objectives.objectives.len)
+		for(var/datum/objective/O in objectives.objectives)
+			O.ShuttleDocked(state)
 
 /datum/role/proc/AnnounceObjectives()
 	var/text = ""


### PR DESCRIPTION
fixes #22188

I dedicate this reference PR to @DamianX 

Tested, works

🆑 
* tweak: Delayed assassinate will now immediately identify target if the shuttle docks, or if it was already docked/traveling to centcom when it was given to you.