### PR TITLE
Starts working on reworking xenos - Disarm tweaks

### DIFF
--- a/__DEFINES/xenomorphs.dm
+++ b/__DEFINES/xenomorphs.dm
@@ -1,0 +1,2 @@
+#define STUNMOB 1
+#define STUNROBOT 2

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
@@ -7,6 +7,8 @@
 	max_plasma = 150
 	icon_state = "alienh_s"
 	plasma_rate = 5
+	disarm_chance = 80
+	combat_flags = STUNMOB
 
 /mob/living/carbon/alien/humanoid/hunter/movement_tally_multiplier()
 	return ..() * 0.9 // Hunters are fast.

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/sentinel.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/sentinel.dm
@@ -7,6 +7,8 @@
 	max_plasma = 250
 	icon_state = "aliens_s"
 	plasma_rate = 10
+	disarm_chance = 60
+	combat_flags = STUNROBOT|STUNMOB
 
 //As far as movement goes, Sentinels are average
 

--- a/code/modules/mob/living/carbon/alien/humanoid/combat.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/combat.dm
@@ -3,13 +3,13 @@
 		return
 	var/datum/organ/external/affecting = get_organ(ran_zone(zone_sel.selecting))
 	var/disarm_chance_modifier = target.run_armor_check(affecting, "melee", quiet = 1)
-	if(prob(80/(disarm_chance_modifier == 0 ? 1 : disarm_chance_modifier)))
+	if((combat_flags & STUNMOB) && prob(disarm_chance/max(1,disarm_chance_modifier)))
 		do_attack_animation(target, src)
 		playsound(loc, 'sound/weapons/pierce.ogg', 25, 1, -1)
 		target.apply_effect(4, WEAKEN, target.run_armor_check(affecting, "melee"))
 		visible_message("<span class='danger'>[src] has tackled down [target]!</span>")
 
-	else if (prob(80/(disarm_chance_modifier == 0 ? 1 : disarm_chance_modifier)))
+	else if (prob(disarm_chance/max(1,disarm_chance_modifier)))
 		do_attack_animation(target, src)
 		playsound(loc, get_unarmed_hit_sound(), 25, 1, -1)
 		target.drop_item()

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -6,7 +6,8 @@
 	var/obj/item/weapon/l_store = null
 	var/caste = ""
 	update_icon = TRUE
-
+	var/combat_flags = 0
+	var/disarm_chance = 50
 	species_type = /mob/living/carbon/alien/humanoid
 
 //This is fine right now, if we're adding organ specific damage this needs to be updated

--- a/code/modules/mob/living/carbon/alien/humanoid/queen.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/queen.dm
@@ -7,11 +7,13 @@
 	status_flags = CANPARALYSE
 	heal_rate = 5
 	plasma_rate = 20
+	disarm_chance = 80
+	combat_flags = STUNROBOT|STUNMOB
 
 /mob/living/carbon/alien/humanoid/queen/movement_tally_multiplier()
 	. = ..()
 	. *= 5 // Queens are slow as fuck
-	
+
 /mob/living/carbon/alien/humanoid/queen/feels_pain()
 	return FALSE // Queens are slow enough as they are
 
@@ -78,7 +80,8 @@
 	if(lying)
 		if(resting)
 			icon_state = "queen_sleep"
-		else						icon_state = "queen_l"
+		else
+			icon_state = "queen_l"
 		for(var/image/I in overlays_lying)
 			overlays += I
 	else

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -836,7 +836,7 @@ var/list/cyborg_list = list()
 
 		if(I_DISARM)
 			if(!(lying))
-				if(prob(85))
+				if((M.combat_flags & STUNROBOT) && prob(M.disarm_chance))
 					Stun(7)
 					step(src,get_dir(M,src))
 					spawn(5) step(src,get_dir(M,src))

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -66,6 +66,7 @@
 #include "__DEFINES\unit_tests.dm"
 #include "__DEFINES\weapons.dm"
 #include "__DEFINES\world.dm"
+#include "__DEFINES\xenomorphs.dm"
 #include "__DEFINES\ZAS.dm"
 #include "code\_secrets.dm"
 #include "code\hub.dm"


### PR DESCRIPTION
Starts removing some of the magic numbers regarding xeno stuns around the code, and moving them to the object in question (being the xenos). Also changes the stun chance for the different caste members.

Adds two flags, STUNMOB and STUNROBOT, used for stunning mobs and stunning robots, respectively.


Previously:
 - All xenos: 80% chance to knock somebody over for 4 BYOND seconds (stackable), 85% chance to stun a silicon for 7 BYOND seconds

Now:
 - Base: 50% to stun/disarm.
 - Hunter: 80% to stun/disarm, mobs only.
 - Sentinel: 60% to stun/disarm, mobs and robots.
 - Queen: 80% to stun/disarm, mobs and robots.

:cl:
 * tweak: Xeno disarm chance now caste specific.