### PR TITLE
Cyborg health nerf/rework

### DIFF
--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -77,7 +77,7 @@
 	name = "armour plating"
 	external_type = /obj/item/robot_parts/robot_component/armour
 	energy_consumption = 0
-	max_damage = 110
+	max_damage = 120
 
 /datum/robot_component/actuator
 	name = "actuator"

--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -8,7 +8,7 @@
 /datum/robot_component/var/electronics_damage = 0
 /datum/robot_component/var/vulnerability = 1
 /datum/robot_component/var/energy_consumption = 0
-/datum/robot_component/var/max_damage = 30 //WHY THE FUCK IS THE DEFAULT MAX DAMAGE 30 ARE YOU STUPID
+/datum/robot_component/var/max_damage = 15
 /datum/robot_component/var/mob/living/silicon/robot/owner
 
 // The actual device object that has to be installed for this.
@@ -77,18 +77,16 @@
 	name = "armour plating"
 	external_type = /obj/item/robot_parts/robot_component/armour
 	energy_consumption = 0
-	max_damage = 60
+	max_damage = 110
 
 /datum/robot_component/actuator
 	name = "actuator"
 	external_type = /obj/item/robot_parts/robot_component/actuator
 	energy_consumption = 0 // seeing as we can move without any charge...
-	max_damage = 50
 
 /datum/robot_component/cell
 	name = "power cell"
-	max_damage = 50
-
+	
 /datum/robot_component/cell/destroy()
 	..()
 	owner.cell = null
@@ -98,25 +96,21 @@
 	name = "radio"
 	external_type = /obj/item/robot_parts/robot_component/radio
 	energy_consumption = 1
-	max_damage = 40
 
 /datum/robot_component/binary_communication
 	name = "binary communication device"
 	external_type = /obj/item/robot_parts/robot_component/binary_communication_device
 	energy_consumption = 0
-	max_damage = 30
 
 /datum/robot_component/camera
 	name = "camera"
 	external_type = /obj/item/robot_parts/robot_component/camera
 	energy_consumption = 1
-	max_damage = 40
 
 /datum/robot_component/diagnosis_unit
 	name = "self-diagnosis unit"
 	external_type = /obj/item/robot_parts/robot_component/diagnosis_unit
 	energy_consumption = 0
-	max_damage = 30
 
 /mob/living/silicon/robot/proc/initialize_components()
 	// This only initializes the components, it doesn't set them to installed.

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -5,8 +5,8 @@ var/list/cyborg_list = list()
 	real_name = "Cyborg"
 	icon = 'icons/mob/robots.dmi'
 	icon_state = "robot"
-	maxHealth = 300
-	health = 300
+	maxHealth = 200
+	health = 200
 	flashed = FALSE
 
 	var/sight_mode = 0


### PR DESCRIPTION
this pr changes the overall health of cyborgs down from 300 to 200
the armor component, however, goes from 60 health to 110, meaning that they can tank damage for longer without the risk of losing functionality
however, once their armor fails, components will start dropping fast.
[controversial] [tweak]
:cl:
 * rscadd: made cyborg armor more than twice as strong
 * rscdel: made all the other components much weaker