### PR TITLE
Economy Reform 2019

### DIFF
--- a/__DEFINES/_macros.dm
+++ b/__DEFINES/_macros.dm
@@ -375,4 +375,5 @@ proc/get_space_area()
 #define LOWEST_DENOMINATION 1
 #define round_to_lowest_denomination(A) (round(A, LOWEST_DENOMINATION))
 
-#define create_trader_account create_account("Trader Shoal", 0, null, 0) //Starts 0 credits, not sourced from any database, earns 0 credits
+#define create_trader_account create_account("Trader Shoal", 0, null, 0, 1, TRUE)
+//Starts 0 credits, not sourced from any database, earns 0 credits, default secpref 1, hidden

--- a/__DEFINES/global.dm
+++ b/__DEFINES/global.dm
@@ -349,8 +349,8 @@ var/adminblob_beat = 'sound/effects/blob_pulse.ogg'
 
 // ECONOMY
 // Account default values
-#define DEPARTMENT_START_FUNDS 5000
-#define DEPARTMENT_START_WAGE 500
+#define DEPARTMENT_START_FUNDS 500
+#define DEPARTMENT_START_WAGE 50
 #define PLAYER_START_WAGE 50
 
 //HUD MINIMAPS

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -754,7 +754,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 /datum/supply_packs/secway
 	name = "Secway"
 	contains = list(/obj/structure/bed/chair/vehicle/secway)
-	cost = 500
+	cost = 150
 	containertype = /obj/structure/closet/crate/secure/large
 	containername = "secway crate"
 	access = list(access_security)
@@ -1546,7 +1546,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 /datum/supply_packs/radiation_suit
 	name = "Radiation suit"
 	contains = list()
-	cost = 500
+	cost = 150
 	containertype = /obj/structure/closet/crate/radiation
 	containername = "radiation suit crate"
 	group = "Engineering"
@@ -1555,7 +1555,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	name = "DIY Shuttle Engine kit"
 	contains = list(/obj/structure/shuttle/engine/propulsion/DIY,
 					/obj/structure/shuttle/engine/heater/DIY)
-	cost = 650
+	cost = 250
 	containertype = /obj/structure/closet/crate/secure/engisec
 	containername = "\improper Shuttle engines crate"
 	group = "Engineering"
@@ -1565,7 +1565,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	contains = list(/obj/item/shuttle_license,
 					/obj/item/weapon/book/manual/ship_building)
 
-	cost = 3000
+	cost = 750
 	containertype = /obj/structure/closet/crate/secure/engisec
 	containername = "secure shuttle permit crate"
 	group = "Engineering"
@@ -1573,7 +1573,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 /datum/supply_packs/suit_modification_station
 	name = "suit modification station"
 	contains = list()
-	cost = 400
+	cost = 200
 	containertype = /obj/structure/closet/crate/flatpack/suit_modifier
 	group = "Engineering"
 
@@ -1661,7 +1661,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/reagent_containers/food/snacks/ijzerkoekje,
 					/obj/item/weapon/reagent_containers/food/snacks/ijzerkoekje,
 					/obj/item/weapon/reagent_containers/food/snacks/ijzerkoekje)
-	cost = 1000
+	cost = 50
 	containertype = /obj/structure/largecrate
 	containername = "blood donation drive crate"
 	group = "Medical"

--- a/code/datums/wires/vending.dm
+++ b/code/datums/wires/vending.dm
@@ -4,14 +4,14 @@
 
 /datum/wires/vending/New()
 	wire_names=list(
-		"[VENDING_WIRE_THROW]" 		= "Firing",
+		"[VENDING_WIRE_MALF]" 		= "Actuator",
 		"[VENDING_WIRE_CONTRABAND]" = "Contraband",
 		"[VENDING_WIRE_ELECTRIFY]" 	= "Shock",
 		"[VENDING_WIRE_IDSCAN]" 	= "ID Scan"
 	)
 	..()
 
-var/const/VENDING_WIRE_THROW = 1
+var/const/VENDING_WIRE_MALF = 1
 var/const/VENDING_WIRE_CONTRABAND = 2
 var/const/VENDING_WIRE_ELECTRIFY = 4
 var/const/VENDING_WIRE_IDSCAN = 8
@@ -47,8 +47,9 @@ var/const/VENDING_WIRE_IDSCAN = 8
 	if(V.unhackable)
 		return
 	switch(index)
-		if(VENDING_WIRE_THROW)
-			V.shoot_inventory = !V.shoot_inventory
+		if(VENDING_WIRE_MALF)
+			V.visible_message("<span class='warning'>\The [src] [pick("sputters","whirs","buzzes")]!</span>")
+			V.damaged()
 		if(VENDING_WIRE_CONTRABAND)
 			V.extended_inventory = !V.extended_inventory
 		if(VENDING_WIRE_ELECTRIFY)
@@ -61,8 +62,6 @@ var/const/VENDING_WIRE_IDSCAN = 8
 	if(V.unhackable)
 		return
 	switch(index)
-		if(VENDING_WIRE_THROW)
-			V.shoot_inventory = !mended
 		if(VENDING_WIRE_CONTRABAND)
 			V.extended_inventory = 0
 		if(VENDING_WIRE_ELECTRIFY)

--- a/code/game/machinery/computer/slot_machine.dm
+++ b/code/game/machinery/computer/slot_machine.dm
@@ -53,7 +53,7 @@
 
 	id = rand(1,99999)
 
-	our_money_account = create_account("slot machine ([id])", rand(30000,50000))
+	our_money_account = create_account("slot machine ([id])", rand(30000,50000), null, 0, 1, TRUE)
 	radio = new(src)
 
 	update_icon()

--- a/code/game/machinery/vending_packs.dm
+++ b/code/game/machinery/vending_packs.dm
@@ -9,9 +9,11 @@
 	var/list/stock = list()
 	var/list/secretstock = list()
 	var/list/preciousstock = list()
+	var/list/laborstock = list()
 	var/list/product_records = list()
 	var/list/hidden_records = list()
 	var/list/coin_records = list()
+	var/list/labor_records = list()
 
 //////CUSTOM PACKS///////
 

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -194,6 +194,7 @@
 	var/dorm = 0		// determines if this ID has claimed a dorm already
 
 	var/datum/money_account/virtual_wallet = 1	//money! If 0, don't create a wallet. Otherwise create one!
+	var/gbp = 0 //Great Britain Pound. Rewarded for labor.
 
 /obj/item/weapon/card/id/New()
 	..()
@@ -214,6 +215,8 @@
 		user.show_message("The blood type on the card is [blood_type].",1)
 		user.show_message("The DNA hash on the card is [dna_hash].",1)
 		user.show_message("The fingerprint hash on the card is [fingerprint_hash].",1)
+		if(gbp)
+			to_chat(user,"<span class='info'>It shines with the pride of [gbp] GBP.</span>")
 
 /obj/item/weapon/card/id/attack_self(var/mob/user)
 	if(user.attack_delayer.blocked())

--- a/code/modules/Economy/Accounts.dm
+++ b/code/modules/Economy/Accounts.dm
@@ -26,7 +26,7 @@ var/global/datum/money_account/trader_account
 		var/datum/transaction/T = new()
 		T.target_name = station_account.owner_name
 		T.purpose = "Account creation"
-		T.amount = 5000
+		T.amount = 750
 		T.date = "2nd April, [game_year]"
 		T.time = "11:24"
 		T.source_terminal = "Biesel GalaxyNet Terminal #277"
@@ -64,7 +64,7 @@ var/global/datum/money_account/trader_account
 //the current ingame time (hh:mm) can be obtained by calling:
 //worldtime2text()
 
-/proc/create_account(var/new_owner_name = "Default user", var/starting_funds = 0, var/obj/machinery/account_database/source_db, var/wage_payout = 0, var/security_pref = 1)
+/proc/create_account(var/new_owner_name = "Default user", var/starting_funds = 0, var/obj/machinery/account_database/source_db, var/wage_payout = 0, var/security_pref = 1, var/makehidden = FALSE)
 
 	//create a new account
 	var/datum/money_account/M = new()
@@ -73,6 +73,7 @@ var/global/datum/money_account/trader_account
 	M.money = starting_funds
 	M.wage_gain = wage_payout
 	M.security_level = security_pref
+	M.hidden = makehidden
 
 	//create an entry in the account transaction log for when it was created
 	var/datum/transaction/T = new()
@@ -136,6 +137,7 @@ var/global/datum/money_account/trader_account
 	var/virtual = 0
 	var/wage_gain = 0 // How much an account gains per 'wage' tick.
 	var/disabled = 0
+	var/hidden = FALSE //Do not list in accounts database (shoal, slot machines)
 	// 0 Unlocked
 	// 1 User locked
 	// 2 Admin locked
@@ -275,6 +277,8 @@ var/global/datum/money_account/trader_account
 						<table border=1 style='width:100%'>"}
 					for(var/i=1, i<=all_money_accounts.len, i++)
 						var/datum/money_account/D = all_money_accounts[i]
+						if(D.hidden)
+							continue
 
 						dat += {"<tr>
 							<td>#[D.account_number]</td>

--- a/code/modules/Economy/Accounts.dm
+++ b/code/modules/Economy/Accounts.dm
@@ -178,8 +178,7 @@ var/global/datum/money_account/trader_account
 		for(var/department in station_departments)
 			create_department_account(department, recieves_wage = 1)
 	if(!vendor_account)
-		create_department_account("Vendor")
-		vendor_account = department_accounts["Vendor"]
+		vendor_account = create_account("Vendor", 0, null, 0, 1, TRUE)
 
 	if(!current_date_string)
 		current_date_string = "[time2text(world.timeofday, "DD")] [time2text(world.timeofday, "Month")], [game_year]"

--- a/code/modules/Economy/utils.dm
+++ b/code/modules/Economy/utils.dm
@@ -125,7 +125,7 @@ var/global/no_pin_for_debit = TRUE
 				return CARD_CAPTURE_FAILURE_NO_CONNECTION
 			account = linked_db.get_account(card.associated_account_number)
 			if(!account)
-				to_chat(user, "[bicon(src)] <span class='warning'>Bad account/pin combination.</span>")
+				to_chat(user, "[bicon(src)] <span class='warning'>Bad account/pin combination or ID is not registered with Nanotrasen accounts database..</span>")
 				return CARD_CAPTURE_FAILURE_BAD_ACCOUNT_PIN_COMBO
 		else
 			to_chat(user, "[bicon(src)] <span class='warning'>Internal Error.</span>")

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -77,7 +77,7 @@
 		dat += "<br>Current unclaimed GBP: [num2septext(smelter_data["credits"])]<br>"
 
 		if(istype(id))
-			dat += "You have [id.GetBalance(format = 1)] credits in your bank account. <A href='?src=\ref[src];eject=1'>Eject ID.</A><br>"
+			dat += "You have [id.gbp] GBP on your ID. <A href='?src=\ref[src];eject=1'>Eject ID.</A><br>"
 			dat += "<A href='?src=\ref[src];claim=1'>Claim points.</A><br>"
 		else
 			dat += text("No ID inserted. <A href='?src=\ref[src];insert=1'>Insert ID.</A><br>")
@@ -477,7 +477,7 @@
 		if(istype(acct) && acct.charge(-credits, null, "Claimed mining credits.", src.name, dest_name = "Processing Machine"))
 			credits = 0*/
 		var/obj/item/weapon/card/id/ID = signal.data["claimcredits"]
-		ID.gpb += credits
+		ID.gbp += credits
 		credits = 0
 
 	if(signal.data["inc_priority"])

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -74,7 +74,7 @@
 	"}
 
 	if(smelter_data["credits"] != -1)
-		dat += "<br>Current unclaimed credits: $[num2septext(smelter_data["credits"])]<br>"
+		dat += "<br>Current unclaimed GBP: [num2septext(smelter_data["credits"])]<br>"
 
 		if(istype(id))
 			dat += "You have [id.GetBalance(format = 1)] credits in your bank account. <A href='?src=\ref[src];eject=1'>Eject ID.</A><br>"
@@ -173,7 +173,7 @@
 		return 1
 
 	if(href_list["claim"])
-		send_signal(list("claimcredits" = get_card_account(id)))
+		send_signal(list("claimcredits" = id))
 		request_status()
 		return 1
 
@@ -473,9 +473,12 @@
 		if(credits < 1)	//Is there actual money to collect?
 			return 1
 
-		var/datum/money_account/acct = signal.data["claimcredits"]
+		/*var/datum/money_account/acct = signal.data["claimcredits"]
 		if(istype(acct) && acct.charge(-credits, null, "Claimed mining credits.", src.name, dest_name = "Processing Machine"))
-			credits = 0
+			credits = 0*/
+		var/obj/item/weapon/card/id/ID = signal.data["claimcredits"]
+		ID.gpb += credits
+		credits = 0
 
 	if(signal.data["inc_priority"])
 		var/idx = Clamp(signal.data["inc_priority"], 2, recipes.len)


### PR DESCRIPTION
**TL;DNR**: If you were none of these this PR only affected you by making things cheaper: _miner, person who used cargo department card to set vendor prices to 0, person who duped items with partial vending packs, person who used department account money_
**Miners**: Your progression is identical but you earn labor points instead of credits to spend at the mining vendor. You still get the same number of points and same costs at smelter/vendor.
**Department Accounts**: Now not loadsamoney but still twice your starting dosh
**Bugs**: Fixed

Long ago in 2300, Nanotrasen bought out the UK, so now the Great Britain Pound is used as company scrip. As a cost cutting measure, NT now pays miners in GBP. Additionally, they're cutting the department allocated funds to less ridiculous levels, but making the most expensive items at cargo more reasonable.

* Shuttle License 3000->750
* DIY Engine Kit 650->250
* Radiation Suits 500->150
* Secway 500->150
* Suit Modification Station 400->200
* Blood Drive Crate 1000->50

Most significant bug fixes were removing duping using partial packs and removing the ability of cargo to get stuff for free with the cargo account card. To this very day I curse WhiteHusky for giving us such a broken accounts system I have had to fix like 8 times already.

fixes #19025

🆑 
* rscadd: IDs can now have Great Britain Pounds (can be examined on card if you have any at all) used to buy labor rewards from vending machines. So far the only way to acquire them is from the smelter and only use is the mining vendor.
* tweak: Vending machine throw wire changed to malfunction wire. Instead of a trickle of free goods you will damage the machine for a 2% chance of dumping several goodies.
* tweak: Changed malfunction rates somewhat. Additionally, hurt leg effect can only be caused by kicking the machine, not any other kind of malfunction.
* tweak: Department accounts lowered to 500 (750 for station account)
* rscdel: Some accounts can be hidden from accounts database (shoal, slot machines, vendors)
* tweak: Lowered the prices of the most expensive things in cargo that were balanced around department accounts
* bugfix: Fixed a bug where Cargo was the department attached to public vending machines instead of the (unused) vendor account. This means Cargo can't set prices or be 100% reimbursed for buying things anymore.
* bugfix: Improved error message for payment when your card does not have a linked bank account (mostly trader relevant)
* bugfix: Fixed a bug where partial packs could be used on anything
* bugfix: Fixed a bug where vending machines would not be turned off by their turnoff effect