### PR TITLE
More blocks are now marked as superpowers

### DIFF
--- a/code/game/gamemodes/setupgame.dm
+++ b/code/game/gamemodes/setupgame.dm
@@ -130,10 +130,10 @@ var/LACTOSEBLOCK = 0
 	INCREASERUNBLOCK   = getAssignedBlock("INCREASERUN",   numsToAssign, DNA_HARDER_BOUNDS, good=1)
 	REMOTETALKBLOCK    = getAssignedBlock("REMOTETALK",    numsToAssign, DNA_HARDER_BOUNDS, good=1)
 	MORPHBLOCK         = getAssignedBlock("MORPH",         numsToAssign, DNA_HARDER_BOUNDS, good=1)
-	COLDBLOCK          = getAssignedBlock("COLD",          numsToAssign, good=1)
+	COLDBLOCK          = getAssignedBlock("COLD",          numsToAssign, DNA_HARDER_BOUNDS, good=1)
 	HALLUCINATIONBLOCK = getAssignedBlock("HALLUCINATION", numsToAssign)
 	NOPRINTSBLOCK      = getAssignedBlock("NOPRINTS",      numsToAssign, DNA_HARD_BOUNDS, good=1)
-	SHOCKIMMUNITYBLOCK = getAssignedBlock("SHOCKIMMUNITY", numsToAssign, good=1)
+	SHOCKIMMUNITYBLOCK = getAssignedBlock("SHOCKIMMUNITY", numsToAssign, DNA_HARD_BOUNDS, good=1)
 	SMALLSIZEBLOCK     = getAssignedBlock("SMALLSIZE",     numsToAssign, DNA_HARD_BOUNDS, good=1)
 
 	//
@@ -148,13 +148,13 @@ var/LACTOSEBLOCK = 0
 	CHAVBLOCK      = getAssignedBlock("CHAV",       numsToAssign)
 	SWEDEBLOCK     = getAssignedBlock("SWEDE",      numsToAssign)
 	SCRAMBLEBLOCK  = getAssignedBlock("SCRAMBLE",   numsToAssign)
-	TOXICFARTBLOCK = getAssignedBlock("TOXICFART",  numsToAssign, good=1)
+	TOXICFARTBLOCK = getAssignedBlock("TOXICFART",  numsToAssign, DNA_HARD_BOUNDS, good=1) //Why the hell does this have "good" if it's a disability?
 	HORNSBLOCK     = getAssignedBlock("HORNS",      numsToAssign)
 	SMILEBLOCK     = getAssignedBlock("SMILE",      numsToAssign)
 	ELVISBLOCK     = getAssignedBlock("ELVIS",      numsToAssign)
 
 	// Powers
-	SOBERBLOCK     = getAssignedBlock("SOBER",      numsToAssign, good=1)
+	SOBERBLOCK     = getAssignedBlock("SOBER",      numsToAssign, DNA_HARD_BOUNDS, good=1)
 	PSYRESISTBLOCK = getAssignedBlock("PSYRESIST",  numsToAssign, DNA_HARD_BOUNDS, good=1)
 	//SHADOWBLOCK  = getAssignedBlock("SHADOW",     numsToAssign, DNA_HARDER_BOUNDS, good=1)
 	FARSIGHTBLOCK  = getAssignedBlock("FARSIGHT",   numsToAssign, DNA_HARDER_BOUNDS, good=1)
@@ -163,8 +163,8 @@ var/LACTOSEBLOCK = 0
 	EATBLOCK       = getAssignedBlock("EAT",        numsToAssign, DNA_HARD_BOUNDS, good=1)
 	JUMPBLOCK      = getAssignedBlock("JUMP",       numsToAssign, DNA_HARD_BOUNDS, good=1)
 	STRONGBLOCK    = getAssignedBlock("STRONG",     numsToAssign, DNA_HARD_BOUNDS, good=1)
-	MELTBLOCK      = getAssignedBlock("MELT",       numsToAssign, good=1)
-	IMMOLATEBLOCK  = getAssignedBlock("IMMOLATE",   numsToAssign)
+	MELTBLOCK      = getAssignedBlock("MELT",       numsToAssign, DNA_HARD_BOUNDS, good=1)
+	IMMOLATEBLOCK  = getAssignedBlock("IMMOLATE",   numsToAssign, DNA_HARD_BOUNDS, good=1)
 	EMPATHBLOCK    = getAssignedBlock("EMPATH",     numsToAssign, DNA_HARD_BOUNDS, good=1)
 	SUPERFARTBLOCK = getAssignedBlock("SUPERFART",  numsToAssign, DNA_HARDER_BOUNDS, good=1)
 	POLYMORPHBLOCK = getAssignedBlock("POLYMORPH",  numsToAssign, DNA_HARDER_BOUNDS, good=1)


### PR DESCRIPTION
Some superpowers have the same activation threshold as disabilities, this PR fixes it
:cl:
 * tweak: "Several genetics superpowers (Resistance against heat, shock immunity, toxic farts, resistance to alcohol, turning into a skeleton, and setting yourself on fire) have been properly labeled as superpowers, even if immolate still sets you on fire, but at least you can do it intentionally!"