### PR TITLE
Melting into a skeleton with that one genetic superpower is no longer charge-based

### DIFF
--- a/code/game/dna/genes/goon_disabilities.dm
+++ b/code/game/dna/genes/goon_disabilities.dm
@@ -366,7 +366,8 @@
 	panel = "Mutant Powers"
 	user_type = USER_TYPE_GENETIC
 
-	charge_type = Sp_CHARGES
+	charge_type = Sp_RECHARGE
+	charge_max = 200
 
 	spell_flags = INCLUDEUSER | STATALLOWED
 	invocation_type = SpI_NONE


### PR DESCRIPTION
Who did this and why
Charges also get consumed when the spell fails AKA you're a skeleton
Also untested
:cl:
 * tweak: The melting superpower (the one that turns you into a skeleton) now uses a cooldown of 20 seconds instead of 100 charges (that get consumed even when it fails because you are a skeleton).