### PR TITLE
Farsight is now a toggle

### DIFF
--- a/code/game/dna/genes/goon_powers.dm
+++ b/code/game/dna/genes/goon_powers.dm
@@ -119,7 +119,7 @@
 /spell/targeted/cryokinesis
 	name = "Cryokinesis"
 	user_type = USER_TYPE_GENETIC
-	desc = "Drops the bodytemperature of another person."
+	desc = "Drops the body temperature of another person."
 	panel = "Mutant Powers"
 
 	charge_type = Sp_RECHARGE

--- a/code/game/dna/genes/powers.dm
+++ b/code/game/dna/genes/powers.dm
@@ -283,7 +283,7 @@
 	block = XRAYBLOCK
 
 /datum/dna/gene/basic/tk
-	name = "Telekenesis"
+	name = "Telekinesis"
 	activation_messages = list("You feel smarter.")
 	deactivation_messages = list("You feel less smart.")
 

--- a/code/game/dna/genes/vg_powers.dm
+++ b/code/game/dna/genes/vg_powers.dm
@@ -91,14 +91,17 @@ Obviously, requires DNA2.
 	desc = "Increases the subjects ability to see things from afar."
 	activation_messages = list("Your eyes focus.")
 	deactivation_messages = list("Your eyes return to normal.")
-	drug_activation_messages = list("The world becomes huge! You feel like an ant.")
-	drug_deactivation_messages = list("You no longer feel like an insect.")
-	spelltype = /spell/targeted/genetic/farsight
-	mutation = M_FARSIGHT
+	drug_activation_messages = list("You start feeling like an eagle, man!")
+	drug_deactivation_messages = list("You feel less like an eagle and more like the rabbit!")
+	spelltype = /spell/targeted/farsight
 
-/datum/dna/gene/basic/farsight/can_activate(var/mob/M,var/flags)
+/datum/dna/gene/basic/grant_spell/farsight/New()
+	block = FARSIGHTBLOCK
+	..()
+
+/datum/dna/gene/basic/grant_spell/farsight/can_activate(var/mob/M,var/flags)
 	// Can't be big AND small.
-	if((M.sdisabilities & BLIND) || (M.disabilities & NEARSIGHTED))
+	if((M.disabilities & BLIND) || (M.disabilities & NEARSIGHTED))
 		return 0
 	return ..(M,flags)
 
@@ -107,8 +110,8 @@ Obviously, requires DNA2.
 		if(M.client && M.client.view == world.view + 2)
 			M.client.changeView()
 
-/spell/targeted/genetic/farsight
-	name = "Enhanced Sight"
+/spell/targeted/farsight
+	name = "Far Sight"
 	desc = "Allows you to toggle farther vision at will."
 	user_type = USER_TYPE_GENETIC
 	panel = "Mutant Powers"
@@ -121,9 +124,9 @@ Obviously, requires DNA2.
 	hud_state = "wiz_sleepold"
 	var/active = 0
 
-/spell/targeted/genetic/farsight/cast(list/targets, mob/user)
+/spell/targeted/farsight/cast(list/targets, mob/user)
 	for(var/mob/living/carbon/human/F in targets)
-		if(active)
+		if(!active)
 			F.client.changeView(max(F.client.view, world.view+2))
 			to_chat(F, "<span class='notice'>You focus your eyes to see farther.</span>")
 			active = 1

--- a/code/game/dna/genes/vg_powers.dm
+++ b/code/game/dna/genes/vg_powers.dm
@@ -86,36 +86,51 @@ Obviously, requires DNA2.
 		message_admins("[key_name(M)] has hulked out! ([formatJumpTo(M)])")
 	return
 
-/datum/dna/gene/basic/farsight
+/datum/dna/gene/basic/grant_spell/farsight
 	name = "Farsight"
 	desc = "Increases the subjects ability to see things from afar."
 	activation_messages = list("Your eyes focus.")
 	deactivation_messages = list("Your eyes return to normal.")
-
 	drug_activation_messages = list("The world becomes huge! You feel like an ant.")
 	drug_deactivation_messages = list("You no longer feel like an insect.")
-
+	spelltype = /spell/targeted/genetic/farsight
 	mutation = M_FARSIGHT
-
-/datum/dna/gene/basic/farsight/New()
-	block = FARSIGHTBLOCK
-	..()
-
-/datum/dna/gene/basic/farsight/activate(var/mob/M)
-	..()
-	if(M.client)
-		M.client.changeView(max(M.client.view, world.view+2))
-
-/datum/dna/gene/basic/farsight/deactivate(var/mob/M,var/connected,var/flags)
-	if(..())
-		if(M.client && M.client.view == world.view + 2)
-			M.client.changeView()
 
 /datum/dna/gene/basic/farsight/can_activate(var/mob/M,var/flags)
 	// Can't be big AND small.
 	if((M.sdisabilities & BLIND) || (M.disabilities & NEARSIGHTED))
 		return 0
 	return ..(M,flags)
+
+/datum/dna/gene/basic/grant_spell/farsight/deactivate(var/mob/M,var/connected,var/flags)
+	if(..())
+		if(M.client && M.client.view == world.view + 2)
+			M.client.changeView()
+
+/spell/targeted/genetic/farsight
+	name = "Enhanced Sight"
+	desc = "Allows you to toggle farther vision at will."
+	user_type = USER_TYPE_GENETIC
+	panel = "Mutant Powers"
+	range = SELFCAST
+	charge_type = Sp_RECHARGE
+	charge_max = 50
+	invocation_type = SpI_NONE
+	spell_flags = INCLUDEUSER
+	override_base = "genetic"
+	hud_state = "wiz_sleepold"
+	var/active = 0
+
+/spell/targeted/genetic/farsight/cast(list/targets, mob/user)
+	for(var/mob/living/carbon/human/F in targets)
+		if(active)
+			F.client.changeView(max(F.client.view, world.view+2))
+			to_chat(F, "<span class='notice'>You focus your eyes to see farther.</span>")
+			active = 1
+		else
+			F.client.changeView()
+			to_chat(F, "<span class='notice'>You no longer focus your eyes.</span>")
+			active = 0
 
 // NOIR
 

--- a/code/game/dna/genes/vg_powers.dm
+++ b/code/game/dna/genes/vg_powers.dm
@@ -101,7 +101,7 @@ Obviously, requires DNA2.
 
 /datum/dna/gene/basic/grant_spell/farsight/can_activate(var/mob/M,var/flags)
 	// Can't be big AND small.
-	if((M.disabilities & BLIND) || (M.disabilities & NEARSIGHTED))
+	if((M.sdisabilities & BLIND) || (M.disabilities & NEARSIGHTED))
 		return 0
 	return ..(M,flags)
 


### PR DESCRIPTION
Also fixes random cryokinesis typo that was old for whoever knows long and telekinesis typo
:cl:
 * tweak: The farsight genetic power is now a toggle ability, in case you didn't want your overlays to be ruined indefinitely and the like.
 * spellcheck: Fixed a typo for the description of cryokinesis superpower.
 * spellcheck: Fixed a typo for the telekinesis superpower (not observable in-game).