### PR TITLE
Burn damage can cause ashing in high amounts

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -113,6 +113,7 @@
 	var/health_threshold_softcrit = 0
 	var/health_threshold_crit = 0
 	var/health_threshold_dead = -100
+	var/burn_damage_ash = 0
 
 	var/organ_health_multiplier = 1
 	var/organ_regeneration_multiplier = 1
@@ -606,6 +607,8 @@
 					config.health_threshold_softcrit = value
 				if("health_threshold_dead")
 					config.health_threshold_dead = value
+				if("burn_damage_ash")
+					config.burn_damage_ash = value
 				if("revival_pod_plants")
 					config.revival_pod_plants = value
 				if("revival_cloning")

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -21,7 +21,7 @@
 	hgibs(loc, viruses, dna, species.flesh_color, species.blood_color, gib_radius)
 	qdel(src)
 
-/mob/living/carbon/human/dust()
+/mob/living/carbon/human/dust(var/drop_everything = FALSE)
 	death(1)
 	monkeyizing = 1
 	canmove = 0
@@ -40,6 +40,8 @@
 		new /obj/effect/decal/remains/human/noskull(loc)
 	else
 		new /obj/effect/decal/remains/human(loc)
+	if(drop_everything)
+		drop_all()
 	qdel(src)
 
 /mob/living/carbon/human/Destroy()

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -73,7 +73,7 @@
 	if(amount > 0)
 		take_overall_damage(0, amount)
 		if(config.burn_damage_ash && amount >= config.burn_damage_ash)
-			dust()
+			dust(TRUE)
 			return
 	else
 		heal_overall_damage(0, -amount)

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -72,6 +72,9 @@
 
 	if(amount > 0)
 		take_overall_damage(0, amount)
+		if(config.burn_damage_ash && amount >= config.burn_damage_ash)
+			dust()
+			return
 	else
 		heal_overall_damage(0, -amount)
 	hud_updateflag |= 1 << HEALTH_HUD


### PR DESCRIPTION
Adds a (currently disabled) config option for, should a human take enough instant burn damage, they just dust.

Adds an argument for human dust for it to drop everything that the person has equipped

:cl:
 * rscadd: If enabled by the host. If somebody takes enough instantaneous burn damage, they will turn to dust, leaving their belongings behind.