### PR TITLE
Adds luminol.

### DIFF
--- a/__DEFINES/reagents.dm
+++ b/__DEFINES/reagents.dm
@@ -401,6 +401,7 @@
 #define AMINOMICIN		"aminomicin"
 #define AMINOCYPRINIDOL	"aminocyprinidol"
 #define TOMATO_SOUP		"tomato_soup"
+#define LUMINOL			"luminol"
 
 // How many units of reagent are consumed per tick, by default.
 #define REAGENTS_METABOLISM 0.2

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -753,16 +753,11 @@ its easier to just keep the beam vertical.
 
 //Atomic level procs to be used elsewhere.
 /atom/proc/apply_luminol(var/atom/A)
-	if(had_blood)
-		return TRUE
-	else
-		return FALSE
+	return had_blood
 
 /atom/proc/clear_luminol(var/atom/A)
-	if(had_blood)
-		return TRUE
-	else
-		return FALSE
+	return had_blood
+
 
 //returns 1 if made bloody, returns 0 otherwise
 /atom/proc/add_blood(mob/living/carbon/human/M as mob)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -14,6 +14,7 @@ var/global/list/ghdel_profiling = list()
 	var/fingerprintslast = null
 	var/list/blood_DNA
 	var/blood_color
+	var/had_blood //Something was bloody at some point.
 	var/germ_level = 0 // The higher the germ level, the more germ on the atom.
 	var/penetration_dampening = 5 //drains some of a projectile's penetration power whenever it goes through the atom
 
@@ -750,6 +751,18 @@ its easier to just keep the beam vertical.
 	if(fingerprintshidden && istype(fingerprintshidden))
 		A.fingerprintshidden |= fingerprintshidden.Copy()    //admin	A.fingerprintslast = fingerprintslast
 
+//Atomic level procs to be used elsewhere.
+/atom/proc/apply_luminol(var/atom/A)
+	if(had_blood)
+		return TRUE
+	else
+		return FALSE
+
+/atom/proc/clear_luminol(var/atom/A)
+	if(had_blood)
+		return TRUE
+	else
+		return FALSE
 
 //returns 1 if made bloody, returns 0 otherwise
 /atom/proc/add_blood(mob/living/carbon/human/M as mob)
@@ -758,15 +771,16 @@ its easier to just keep the beam vertical.
 		if(!blood_DNA || !istype(blood_DNA, /list))
 			blood_DNA = list()
 		blood_color = DEFAULT_BLOOD
-		return 1
+		had_blood = TRUE
+		return TRUE
 	if (!( istype(M, /mob/living/carbon/human) ))
-		return 0
+		return FALSE
 	if (!istype(M.dna, /datum/dna))
 		M.dna = new /datum/dna(null)
 		M.dna.real_name = M.real_name
 	M.check_dna()
 	if (!( src.flags ) & FPRINT)
-		return 0
+		return FALSE
 	if(!blood_DNA || !istype(blood_DNA, /list))	//if our list of DNA doesn't exist yet (or isn't a list) initialise it.
 		blood_DNA = list()
 	blood_color = DEFAULT_BLOOD
@@ -777,10 +791,11 @@ its easier to just keep the beam vertical.
 		var/mob/living/carbon/human/H = src
 		//if this blood isn't already in the list, add it
 		if(blood_DNA[H.dna.unique_enzymes])
-			return 0 //already bloodied with this blood. Cannot add more.
+			return FALSE //already bloodied with this blood. Cannot add more.
 		blood_DNA[H.dna.unique_enzymes] = H.dna.b_type
 		H.update_inv_gloves()	//handles bloody hands overlays and updating
-		return 1 //we applied blood to the item
+		had_blood = TRUE
+		return TRUE //we applied blood to the item
 	return
 
 /atom/proc/add_vomit_floor(mob/living/carbon/M, toxvomit = 0, active = 0, steal_reagents_from_mob = 1)
@@ -805,6 +820,8 @@ its easier to just keep the beam vertical.
 		//del(blood_DNA)
 		blood_DNA.len = 0
 		return 1
+	if(istype(had_blood,/obj/effect/decal/cleanable/blueglow))
+		clear_luminol()
 
 
 /atom/proc/get_global_map_pos()

--- a/code/game/objects/effects/decals/Cleanable/misc.dm
+++ b/code/game/objects/effects/decals/Cleanable/misc.dm
@@ -42,10 +42,32 @@
 	desc = "Jeez. I hope that's not for lunch."
 	gender = PLURAL
 	density = 0
-	anchored = 1
-	luminosity = 1
+	anchored = TRUE
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "greenglow"
+
+/obj/effect/decal/cleanable/greenglow/New()
+	..()
+	set_light(1,2,LIGHT_COLOR_GREEN)
+
+/obj/effect/decal/cleanable/blueglow
+	name = "glowing luminol"
+	desc = "A smear of activated luminol."
+	gender = PLURAL
+	density = 0
+	anchored = TRUE
+	icon = 'icons/effects/blood.dmi'
+	icon_state = "mfloor1"
+	//icon = 'icons/effects/tomatodecal.dmi'
+	//icon_state = "fruit_smudge1"
+	color = LIGHT_COLOR_CYAN
+
+/obj/effect/decal/cleanable/blueglow/New()
+	..()
+	icon_state = "mfloor[rand(1,7)]"
+	////icon_state = "[pick("m","")]floor[rand(1,3)]"
+	//icon_state = "fruit_smudge[rand(1,3)]"
+	set_light(1,2,LIGHT_COLOR_BLUE)
 
 /obj/effect/decal/cleanable/cobweb
 	name = "cobweb"

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1060,7 +1060,7 @@ var/global/list/image/blood_overlays = list()
 		return FALSE
 	if(!blood_overlays[type]) //Blood overlay generation if it lacks one.
 		generate_blood_overlay()
-	if(blood_overlay != null)
+	if(blood_overlay)
 		overlays.Remove(blood_overlay)
 	else
 		blood_overlay = blood_overlays[type]

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1010,6 +1010,8 @@
 	. = ..()
 	if(blood_overlay)
 		overlays.Remove(blood_overlay)
+	if(had_blood)
+		clear_luminol()
 	if(istype(src, /obj/item/clothing/gloves))
 		var/obj/item/clothing/gloves/G = src
 		G.transfer_blood = 0
@@ -1033,14 +1035,13 @@
 	//apply the blood-splatter overlay if it isn't already in there, else it updates it.
 	blood_overlay.color = blood_color
 	overlays += blood_overlay
-
 	//if this blood isn't already in the list, add it
-
 	if(!M)
 		return
 	if(blood_DNA[M.dna.unique_enzymes])
 		return FALSE //already bloodied with this blood. Cannot add more.
 	blood_DNA[M.dna.unique_enzymes] = M.dna.b_type
+	had_blood = TRUE
 	return TRUE //we applied blood to the item
 
 var/global/list/image/blood_overlays = list()
@@ -1054,6 +1055,34 @@ var/global/list/image/blood_overlays = list()
 
 	blood_overlays[type] = image(I)
 
+/obj/item/apply_luminol()
+	if(!..())
+		return FALSE
+	if(!blood_overlays[type]) //Blood overlay generation if it lacks one.
+		generate_blood_overlay()
+	if(blood_overlay != null)
+		overlays.Remove(blood_overlay)
+	else
+		blood_overlay = blood_overlays[type]
+	var/image/luminol_overlay = blood_overlay
+	luminol_overlay.color = LIGHT_COLOR_CYAN
+	overlays += luminol_overlay
+	var/obj/effect/decal/cleanable/blueglow/BG
+	if(istype(had_blood,/obj/effect/decal/cleanable/blueglow))
+		BG = had_blood
+		BG.set_light(1,2,LIGHT_COLOR_BLUE)
+	else
+		had_blood = null
+		BG = new /obj/effect/decal/cleanable/blueglow(src)
+		had_blood = BG
+
+/obj/item/clear_luminol()
+	if(!..())
+		return FALSE
+	if(istype(had_blood,/obj/effect/decal/cleanable/blueglow))
+		var/obj/effect/decal/cleanable/blueglow/BG
+		BG = had_blood
+		BG.set_light(0)
 
 /obj/item/proc/showoff(mob/user)
 	if(abstract)

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -73,17 +73,18 @@
 //returns 1 if made bloody, returns 0 otherwise
 /turf/simulated/add_blood(mob/living/carbon/human/M as mob)
 	if (!..())
-		return 0
+		return FALSE
 
 	for(var/obj/effect/decal/cleanable/blood/B in contents)
 		if(!B.blood_DNA[M.dna.unique_enzymes])
 			B.blood_DNA[M.dna.unique_enzymes] = M.dna.b_type
 			B.virus2 = virus_copylist(M.virus2)
-		return 1 //we bloodied the floor
+		had_blood = TRUE
+		return TRUE //we bloodied the floor
 
 	blood_splatter(src,M,1)
-	return 1 //we bloodied the floor
-
+	had_blood = TRUE
+	return TRUE //we bloodied the floor
 
 // Only adds blood on the floor -- Skie
 /turf/simulated/proc/add_blood_floor(mob/living/carbon/M as mob)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -442,6 +442,12 @@
 
 	turfdecals.len = 0
 
+/turf/apply_luminol()
+	if(!..())
+		return FALSE
+	if(!(locate(/obj/effect/decal/cleanable/blueglow) in src))
+		new /obj/effect/decal/cleanable/blueglow(src)
+
 /turf/proc/get_underlying_turf()
 	var/area/A = loc
 	if(A.base_turf_type)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -353,7 +353,7 @@ emp_act
 		w_uniform.add_blood(source)
 		update_inv_w_uniform(update)
 
-/mob/living/carbon/human/apply_luminol(var/update = FALSE) //Dispite what you might think with FALSE this will update things as normal.
+/mob/living/carbon/human/apply_luminol(var/update = FALSE) //Despite what you might think with FALSE this will update things as normal.
 	if(wear_suit)
 		wear_suit.apply_luminol()
 		update_inv_wear_suit(update)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -353,6 +353,14 @@ emp_act
 		w_uniform.add_blood(source)
 		update_inv_w_uniform(update)
 
+/mob/living/carbon/human/apply_luminol(var/update = FALSE) //Dispite what you might think with FALSE this will update things as normal.
+	if(wear_suit)
+		wear_suit.apply_luminol()
+		update_inv_wear_suit(update)
+	if(w_uniform)
+		w_uniform.apply_luminol()
+		update_inv_w_uniform(update)
+
 /mob/living/carbon/human/ex_act(var/severity, var/noblind = FALSE)
 	if(flags & INVULNERABLE)
 		return FALSE

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -7152,12 +7152,9 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 /datum/reagent/luminol
 	name = "Luminol"
 	id = LUMINOL
-	description = "Luminol."
+	description = "A chmical that exhibits chemiluminescence in the presence of blood due to the iron and copper in the hemoglobin."
 	reagent_state = REAGENT_STATE_LIQUID
 	color = "#FFFFFF" //rgb: 255, 255, 255
-//	var/light_intensity = 4
-	density = 3.46
-	specheatcap = 512.3
 
 /datum/reagent/luminol/reaction_mob(var/mob/living/M, var/method = TOUCH)
 	if(ishuman(M) && (method == TOUCH))

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -7152,7 +7152,7 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 /datum/reagent/luminol
 	name = "Luminol"
 	id = LUMINOL
-	description = "A chmical that exhibits chemiluminescence in the presence of blood due to the iron and copper in the hemoglobin."
+	description = "A chemical that exhibits chemiluminescence in the presence of blood due to the iron and copper in the hemoglobin."
 	reagent_state = REAGENT_STATE_LIQUID
 	color = "#FFFFFF" //rgb: 255, 255, 255
 

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -424,7 +424,7 @@
 
 	var/datum/reagent/self = src
 	if(..())
-		return 1
+		return TRUE
 
 	if(volume < 3) //Hardcoded
 		return
@@ -453,7 +453,7 @@
 		var/obj/effect/decal/cleanable/blood/B = blood_splatter(T, self, 1)
 		if(B)
 			B.blood_DNA["UNKNOWN DNA STRUCTURE"] = "X*"
-
+	T.had_blood = TRUE
 	if(volume >= 5 && !istype(T.loc, /area/chapel)) //Blood desanctifies non-chapel tiles
 		T.holy = 0
 	return
@@ -7149,6 +7149,30 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 	specheatcap = ARBITRARILY_LARGE_NUMBER //Is partly made out of leporazine, so you're not heating this up.
 	custom_metabolism = 0.01 //oh shit what are you doin
 
+/datum/reagent/luminol
+	name = "Luminol"
+	id = LUMINOL
+	description = "Luminol."
+	reagent_state = REAGENT_STATE_LIQUID
+	color = "#FFFFFF" //rgb: 255, 255, 255
+//	var/light_intensity = 4
+	density = 3.46
+	specheatcap = 512.3
+
+/datum/reagent/luminol/reaction_mob(var/mob/living/M, var/method = TOUCH)
+	if(ishuman(M) && (method == TOUCH))
+		var/mob/living/carbon/human/H = M
+		H.apply_luminol()
+
+/datum/reagent/luminol/reaction_turf(var/turf/simulated/T)
+	if(..())
+		return TRUE
+	T.apply_luminol()
+
+/datum/reagent/luminol/reaction_obj(var/obj/O, var/volume)
+	if(..())
+		return TRUE
+	O.apply_luminol()
 
 //////////////////////
 //					//

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -960,7 +960,7 @@
 	required_reagents = list(LITHIUM = 1, HYDROGEN = 1)
 	result_amount = 1
 
-//Synthesizing these three chemicals is pretty complex in real life, but fuck it, it's just a game!
+//Synthesizing these three(+) chemicals is pretty complex in real life, but fuck it, it's just a game!
 /datum/chemical_reaction/ammonia
 	name = "Ammonia"
 	id = AMMONIA
@@ -988,6 +988,15 @@
 	result = BLEACH
 	required_reagents = list(SODIUMCHLORIDE = 2, CLEANER = 2, OXYGEN = 1)
 	result_amount = 1
+
+//This one isn't even close the the real life reaction but will have to do to avoid conflicts with the above reactions.
+/datum/chemical_reaction/luminol
+	name = "Luminol"
+	id = LUMINOL
+	result = LUMINOL
+	required_reagents = list(CLEANER = 3, CARBON = 8)
+	result_amount = 3
+	secondary_results = list(WATER = 1, HYDROGEN = 6)
 
 //Botany chemicals
 

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -995,8 +995,10 @@
 	id = LUMINOL
 	result = LUMINOL
 	required_reagents = list(CLEANER = 3, CARBON = 8)
-	result_amount = 3
-	secondary_results = list(WATER = 1, HYDROGEN = 6)
+	result_amount = 10
+	//"Realistic" results.
+	//result_amount = 3
+	//secondary_results = list(WATER = 1, HYDROGEN = 6)
 
 //Botany chemicals
 


### PR DESCRIPTION
[content]
Requested by @otatoh 
This is a part of an update to detectives. Luminol will glow a bright blue color when applied to items that have had blood on them at some point even if it was washed off. How useful this information can be is up to the user. The best way to apply it is by spraying it and I plan to add a spray bottle of it in the before mentioned detective update. Luminol itself can be washed away like any other form of blood or mess.
It can be made with 3 parts space cleaner and 8 parts carbon resulting in 3 parts luminol, 1 part water, and 6 parts hydrogen. It has this silly recipe due the the conflicts with other recipes like space cleaner.
**I've likely missed a few interactions and I encourage people to report them as they pop up. This also has not been live tested with perma-gunk (due to not having any way of testing it) so I have no idea how that will go.**
![luminol](https://user-images.githubusercontent.com/28679186/55272125-29b3e580-528e-11e9-968a-047d60249c1d.png)

:cl:
 * rscadd: Added Luminol. You can spray, apply, etc. it to stuff to make it glow blue to indicate if something had blood on it. i.e. floors and items. It can be made with 3 parts space cleaner and 8 parts carbon resulting in 10 parts luminol.
* experiment: Some interactions with luminol might be unaccounted for. Please report any issues in it's behavior that seem incorrect.