### PR TITLE
Restricts the use of 12ga and .357 mags in the vector. Also adds an unrestricted one.

### DIFF
--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -319,6 +319,9 @@
 		mag_type = null
 	update_icon()
 
+/obj/item/weapon/gun/projectile/automatic/vector/lockbox
+	spawn_mag = FALSE
+
 //Vector receivers.
 /obj/item/weapon/vectorreceiver
 	name = "vector receiver"
@@ -330,6 +333,8 @@
 	var/caliber = ".380AUTO" //Its not a list but IT WORKS ON MY MACHINE.
 	var/ammo_type = "/obj/item/ammo_casing/c380auto"
 	var/mag_type = "/obj/item/ammo_storage/magazine/m380auto"
+	var/list/mag_blacklist = list(/obj/item/ammo_storage/magazine/lawgiver, /obj/item/ammo_storage/magazine/a12ga, /obj/item/ammo_storage/magazine/a357)
+	//Insert unacceptable mags here ^^. The lawgiver makes error gas so always exclude it.
 
 /obj/item/weapon/vectorreceiver/New()
 	..()
@@ -341,7 +346,7 @@
 /obj/item/weapon/vectorreceiver/attackby(obj/item/used_item, mob/user)
 	..()
 	if(istype(used_item, /obj/item/ammo_storage/magazine) && !istype(used_item, text2path(mag_type)))
-		if(!istype(used_item, /obj/item/ammo_storage/magazine/lawgiver)) //Insert unacceptable mags here.
+		if(!is_type_in_list(used_item, mag_blacklist))
 			to_chat(user, "<span class='notice'>You insert \the [used_item] into \the [src] for a moment and it begins calibrating.</span>")
 			if (do_after(user, src, 10 SECONDS))
 				if(!src)
@@ -358,8 +363,17 @@
 		else
 			to_chat(user, "<span class='warning'>You're unable to insert \the [used_item] into \the [src]!</span>")
 
-/obj/item/weapon/gun/projectile/automatic/vector/lockbox
-	spawn_mag = FALSE
+//Unrestricted versions.
+/obj/item/weapon/gun/projectile/automatic/vector/unlimited
+
+/obj/item/weapon/gun/projectile/automatic/vector/unlimited/New()
+	..()
+	qdel(receiver)
+	receiver = new /obj/item/weapon/vectorreceiver/unlimited(src)
+	update_receiver()
+
+/obj/item/weapon/vectorreceiver/unlimited
+	mag_blacklist = list(/obj/item/ammo_storage/magazine/lawgiver)
 
 /* The thing I found with guns in ss13 is that they don't seem to simulate the rounds in the magazine in the gun.
    Afaik, since projectile.dm features a revolver, this would make sense since the magazine is part of the gun.


### PR DESCRIPTION
[balance]
This restricts the use of 12ga and .357 mags in the basic vector but also adds an unrestricted version that can only be spawned right now for admin bus or whatever.
The main reason for this change is because @SonixApache is a gay baby who hates fun and loves to ping me. Another minor reason is because those two calibers of ammo enabled the vector to [near] instantly kill people.
:cl:
 * rscdel: The vector can no longer accept magazines that are for 12 gauge and .357.
 * rscadd: A spawn only version has been added that has the old, nearly unlimited, capabilities. Try asking the admins nicely for one.