### PR TITLE
Fixes the crayon decal runtime

### DIFF
--- a/code/game/objects/effects/decals/crayon.dm
+++ b/code/game/objects/effects/decals/crayon.dm
@@ -5,14 +5,13 @@
 
 	persistence_type = null //todo
 
-/obj/effect/decal/cleanable/crayon/New(location,main = "#FFFFFF",shade = "#000000",var/type = "rune")
+/obj/effect/decal/cleanable/crayon/New(loc,age,icon_state,color,dir,pixel_x,pixel_y,main = "#FFFFFF",shade = "#000000",var/type = "rune")
 	..()
-	loc = location
 
 	name = type
 	desc = "A [type] drawn in crayon."
 
-	switch(type)
+	switch(type) //For generics
 		if("rune")
 			type = "rune[rand(1,6)]"
 		if("graffiti")
@@ -34,5 +33,5 @@
 /obj/effect/decal/cleanable/crayon/fuckyou
 	icon_state = "fuckyou"
 
-/obj/effect/decal/cleanable/crayon/fuckyou/New(location, main = "#007F0E", shade = "#02560B", type = "fuckyou")
-	..()
+/obj/effect/decal/cleanable/crayon/fuckyou/New()
+	..(main = "#007F0E", shade = "#02560B", type = "fuckyou")

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -66,7 +66,7 @@ var/global/list/all_graffitis = list(
 	colour = "#DA00FF"
 	shadeColour = "#810CFF"
 	colourName = "purple"
-	
+
 /obj/item/toy/crayon/black
 	icon_state = "crayonblack"
 	colour = "#222222"
@@ -192,7 +192,7 @@ var/global/list/all_graffitis = list(
 				C.maptext = "[maptext_start][preference][maptext_end]"
 
 			else
-				C = new /obj/effect/decal/cleanable/crayon(target,colour,shadeColour,drawtype)
+				C = new /obj/effect/decal/cleanable/crayon(target, main = colour, shade = shadeColour, type = drawtype)
 
 			if(target.density && (C.loc != get_turf(user))) //Drawn on a wall (while standing on a floor)
 				C.forceMove(get_turf(user))

--- a/code/game/objects/structures/vehicles/clowncart.dm
+++ b/code/game/objects/structures/vehicles/clowncart.dm
@@ -324,7 +324,7 @@
 		return
 	reagents.remove_reagent(BANANA, BANANA_FOR_DRAWING)//"graffiti" and "rune" will draw graffiti and runes
 	if(printing_text == "graffiti" || printing_text == "rune") //"paint" will paint floor tiles with selected colour
-		new /obj/effect/decal/cleanable/crayon(pos, colour1, colour2, printing_text)
+		new /obj/effect/decal/cleanable/crayon(pos, main = colour1, shade = colour2, type = printing_text)
 	else
 		if(printing_text == "paint")
 			var/tmp/turf/T = pos
@@ -343,7 +343,7 @@
 				if(printing_pos >= 0)
 					printing_pos = -length(printing_text)-1 //indian code magic
 			printing_pos++
-			new /obj/effect/decal/cleanable/crayon(pos, colour1, colour2, copytext(printing_text, abs(printing_pos), 1+abs(printing_pos)))
+			new /obj/effect/decal/cleanable/crayon(pos, main = colour1, shade = colour2, type = copytext(printing_text, abs(printing_pos), 1+abs(printing_pos)))
 			if(printing_pos > length(printing_text) - 1 || printing_pos == - 1)
 				printing_text = ""
 				printing_pos = 0


### PR DESCRIPTION
decal/cleanable had different new args than the crayon, so it was doing weird things like comparing a string to 1

This may cause unintended consequences, like unlimited crayon works.

closes #22263