### PR TITLE
Fixes a religion runtime

### DIFF
--- a/code/datums/religions.dm
+++ b/code/datums/religions.dm
@@ -3,7 +3,7 @@
 		return "a voice"
 	if(H.mind.GetRole(CULTIST))
 		return "Nar-Sie"
-	else if(usr.mind.faith) // The user has a faith
+	else if(usr.mind && usr.mind.faith) // The user has a faith
 		var/datum/religion/R = usr.mind.faith
 		return R.deity_name
 	else if(usr.mind.assigned_role == "Clown")

--- a/code/datums/religions.dm
+++ b/code/datums/religions.dm
@@ -3,12 +3,12 @@
 		return "a voice"
 	if(H.mind.GetRole(CULTIST))
 		return "Nar-Sie"
-	else if(usr.mind && usr.mind.faith) // The user has a faith
-		var/datum/religion/R = usr.mind.faith
+	else if(H.mind.faith) // The user has a faith
+		var/datum/religion/R = H.mind.faith
 		return R.deity_name
-	else if(usr.mind.assigned_role == "Clown")
+	else if(H.mind.assigned_role == "Clown")
 		return "Honkmother"
-	else if(usr.mind.assigned_role == "Trader")
+	else if(H.mind.assigned_role == "Trader")
 		return "Shoalmother"
 	else if(!ishuman(H))
 		return "Animal Jesus"


### PR DESCRIPTION
When an admin, as a ghost, would try to reply to a prayer, it would cause a runtime as they have no mind, when it should be checking the mind of the person they're replying to

Also returns some dead functionality, for things like the clown praying directly to the honkmother, traders getting the "shoalmother", etc.