### PR TITLE
fixes clownfools

### DIFF
--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -349,6 +349,8 @@
 	H.equip_or_collect(new /obj/item/weapon/coin/clown(H.back), slot_in_backpack)
 
 /datum/job/clown/reject_new_slots()
+	if(Holiday == APRIL_FOOLS_DAY)
+		return FALSE
 	if(!xtra_positions)
 		return FALSE
 	if(security_level == SEC_LEVEL_RAINBOW)
@@ -358,6 +360,7 @@
 
 /datum/job/clown/get_total_positions()
 	if(Holiday == APRIL_FOOLS_DAY)
+		spawn_positions = -1
 		return 99
 	else
 		..()


### PR DESCRIPTION
Maybe the problem is spawnpositions causing only one clown to be pooled due to only one available spawn position, so it was changed from 1 to -1 which was stolen from assistants which I recall spawning more than there were slots for during the prime of ssethtide
Also you can now tamper with the labor console stuff outside of rainbow alert