### PR TITLE
Fixing some unintended Holy Water/Incense behaviours

### DIFF
--- a/code/datums/gamemode/role/cultist.dm
+++ b/code/datums/gamemode/role/cultist.dm
@@ -227,7 +227,7 @@
 	if (!istype(H))
 		return
 	var/unholy = H.checkTattoo(TATTOO_HOLY)
-	var/current_act = max(-1,min(5,veil_thickness))
+	var/current_act = Clamp(veil_thickness,CULT_MENDED,CULT_EPILOGUE)
 	if (reagent_id == INCENSE_HAREBELLS)
 		if (unholy)
 			H.eye_blurry = max(H.eye_blurry, 3)

--- a/code/datums/gamemode/role/cultist.dm
+++ b/code/datums/gamemode/role/cultist.dm
@@ -228,6 +228,66 @@
 		return
 	var/unholy = H.checkTattoo(TATTOO_HOLY)
 	var/current_act = max(-1,min(5,veil_thickness))
+	if (reagent_id == INCENSE_HAREBELLS)
+		if (unholy)
+			H.eye_blurry = max(H.eye_blurry, 3)
+			return
+		else
+			switch (current_act)
+				if (CULT_MENDED)
+					H.dust()
+					return
+				if (CULT_PROLOGUE)
+					H.eye_blurry = max(H.eye_blurry, 3)
+					H.Dizzy(3)
+				if (CULT_ACT_I)
+					H.eye_blurry = max(H.eye_blurry, 6)
+					H.Dizzy(6)
+					H.stuttering = max(H.stuttering, 6)
+				if (CULT_ACT_II)
+					H.eye_blurry = max(H.eye_blurry, 12)
+					H.Dizzy(12)
+					H.stuttering = max(H.stuttering, 12)
+					H.Jitter(12)
+				if (CULT_ACT_III)
+					H.eye_blurry = max(H.eye_blurry, 16)
+					H.Dizzy(16)
+					H.stuttering = max(H.stuttering, 16)
+					H.Jitter(16)
+					if (prob(50))
+						H.Knockdown(1)
+					else if (prob(50))
+						H.confused = 2
+					H.adjustOxyLoss(5)
+				if (CULT_ACT_IV)
+					H.eye_blurry = max(H.eye_blurry, 20)
+					H.Dizzy(20)
+					H.stuttering = max(H.stuttering, 20)
+					H.Jitter(20)
+					if (prob(60))
+						H.Knockdown(2)
+					else if (prob(60))
+						H.confused = 4
+					H.adjustOxyLoss(10)
+					H.adjustToxLoss(5)
+				if (CULT_EPILOGUE)
+					H.eye_blurry = max(H.eye_blurry, 30)
+					H.Dizzy(30)
+					H.stuttering = max(H.stuttering, 30)
+					H.Jitter(30)
+					if (prob(70))
+						H.Knockdown(4)
+					else if (prob(70))
+						H.confused = 6
+					H.adjustOxyLoss(20)
+					H.adjustToxLoss(10)
+
+/datum/role/cultist/handle_splashed_reagent(var/reagent_id)//also proc'd when holy water is drinked or ingested in any way
+	var/mob/living/carbon/human/H = antag.current
+	if (!istype(H))
+		return
+	var/unholy = H.checkTattoo(TATTOO_HOLY)
+	var/current_act = max(-1,min(5,veil_thickness))
 	if (reagent_id == HOLYWATER)
 		if (holywarning_cooldown <= 0)
 			holywarning_cooldown = 5
@@ -303,32 +363,6 @@
 						H.confused = 6
 					H.adjustOxyLoss(20)
 					H.adjustToxLoss(10)
-
-/datum/role/cultist/handle_splashed_reagent(var/reagent_id)
-	switch (reagent_id)
-		if (HOLYWATER)
-			var/mob/living/carbon/human/H = antag.current
-			if (!istype(H))
-				return
-			var/current_act = max(-1,min(5,veil_thickness))
-			switch (current_act)
-				if (CULT_PROLOGUE)
-					return
-				if (CULT_ACT_I)
-					H.Dizzy(4)
-					H.Jitter(8)
-					H.eye_blurry = max(H.eye_blurry, 6)
-				if (CULT_ACT_II)
-					H.Dizzy(8)
-					H.Jitter(16)
-					H.confused = 1
-					H.eye_blurry = max(H.eye_blurry, 12)
-				else // Other acts, mended, etc...
-					H.Dizzy(16)
-					H.Jitter(24)
-					H.Knockdown(3)
-					H.eye_blurry = max(H.eye_blurry, 12)
-					H.confused = 3
 
 /datum/role/cultist/RoleTopic(href, href_list, var/datum/mind/M, var/admin_auth)
 	if (href_list["cult_privatespeak"])

--- a/code/game/objects/items/incense.dm
+++ b/code/game/objects/items/incense.dm
@@ -184,9 +184,16 @@
 									var/mob/living/carbon/human/H = C
 									if(H.species && H.species.flags & NO_BREATHE)//can they breath?
 										continue
+									if(H.wear_mask && H.wear_mask.clothing_flags & BLOCK_GAS_SMOKE_EFFECT)
+										continue
+									if(H.glasses && H.glasses.clothing_flags & BLOCK_GAS_SMOKE_EFFECT)
+										continue
+									if(H.head && H.head.clothing_flags & BLOCK_GAS_SMOKE_EFFECT)
+										continue
 									if(H.internal)//are their internals off?
 										continue
 									potential_breathers += C
+
 					var/datum/reagent/incense/D = chemical_reagents_list[fragrance]
 					if(D)
 						D.OnDisperse(location)


### PR DESCRIPTION

:cl:
* bugfix: Fixed Holy Water behaving on cultists as if it had been splashed on then as well as ingested when they drink it. Mostly, this means that drinking holy water won't cause cultists to visibly jitter before Act 2, as intended (they still stutter from Act 1 onwards).
* bugfix: Fixed the Unholy Protection tattoo not protecting you at all from holy water being splashed upon you.
* bugfix: Stuff that protects you from chemical smokes (aka, plastic bags on head and lit cigarettes) now protects cultists as well from holy incense.