### PR TITLE
Economy 2019 Part A

### DIFF
--- a/__DEFINES/_macros.dm
+++ b/__DEFINES/_macros.dm
@@ -377,4 +377,5 @@ proc/get_space_area()
 #define LOWEST_DENOMINATION 1
 #define round_to_lowest_denomination(A) (round(A, LOWEST_DENOMINATION))
 
-#define create_trader_account create_account("Trader Shoal", 0, null, 0) //Starts 0 credits, not sourced from any database, earns 0 credits
+#define create_trader_account create_account("Trader Shoal", 0, null, 0, 1, TRUE)
+//Starts 0 credits, not sourced from any database, earns 0 credits, hidden

--- a/__DEFINES/global.dm
+++ b/__DEFINES/global.dm
@@ -349,8 +349,8 @@ var/adminblob_beat = 'sound/effects/blob_pulse.ogg'
 
 // ECONOMY
 // Account default values
-#define DEPARTMENT_START_FUNDS 5000
-#define DEPARTMENT_START_WAGE 500
+#define DEPARTMENT_START_FUNDS 500
+#define DEPARTMENT_START_WAGE 50
 #define PLAYER_START_WAGE 50
 
 //HUD MINIMAPS

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -754,7 +754,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 /datum/supply_packs/secway
 	name = "Secway"
 	contains = list(/obj/structure/bed/chair/vehicle/secway)
-	cost = 500
+	cost = 150
 	containertype = /obj/structure/closet/crate/secure/large
 	containername = "secway crate"
 	access = list(access_security)
@@ -1546,7 +1546,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 /datum/supply_packs/radiation_suit
 	name = "Radiation suit"
 	contains = list()
-	cost = 500
+	cost = 150
 	containertype = /obj/structure/closet/crate/radiation
 	containername = "radiation suit crate"
 	group = "Engineering"
@@ -1555,7 +1555,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	name = "DIY Shuttle Engine kit"
 	contains = list(/obj/structure/shuttle/engine/propulsion/DIY,
 					/obj/structure/shuttle/engine/heater/DIY)
-	cost = 650
+	cost = 250
 	containertype = /obj/structure/closet/crate/secure/engisec
 	containername = "\improper Shuttle engines crate"
 	group = "Engineering"
@@ -1565,7 +1565,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	contains = list(/obj/item/shuttle_license,
 					/obj/item/weapon/book/manual/ship_building)
 
-	cost = 3000
+	cost = 750
 	containertype = /obj/structure/closet/crate/secure/engisec
 	containername = "secure shuttle permit crate"
 	group = "Engineering"
@@ -1573,7 +1573,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 /datum/supply_packs/suit_modification_station
 	name = "suit modification station"
 	contains = list()
-	cost = 400
+	cost = 200
 	containertype = /obj/structure/closet/crate/flatpack/suit_modifier
 	group = "Engineering"
 
@@ -1661,7 +1661,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/reagent_containers/food/snacks/ijzerkoekje,
 					/obj/item/weapon/reagent_containers/food/snacks/ijzerkoekje,
 					/obj/item/weapon/reagent_containers/food/snacks/ijzerkoekje)
-	cost = 1000
+	cost = 50
 	containertype = /obj/structure/largecrate
 	containername = "blood donation drive crate"
 	group = "Medical"

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -312,6 +312,9 @@
 				if ((modify == t2 && (in_range(src, usr) || (istype(usr, /mob/living/silicon))) && istype(loc, /turf)))
 					var/account_num = text2num(href_list["account"])
 					var/datum/money_account/MA = get_money_account(account_num)
+					if(!MA)
+						to_chat(usr, "<span class='warning'>That account number was invalid.</span>")
+						return
 					if(MA.hidden)
 						to_chat(usr, "<span class='warning'>That account number is reserved.</span>")
 						return

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -311,6 +311,10 @@
 				var/t2 = modify
 				if ((modify == t2 && (in_range(src, usr) || (istype(usr, /mob/living/silicon))) && istype(loc, /turf)))
 					var/account_num = text2num(href_list["account"])
+					var/datum/money_account/MA = get_money_account(account_num)
+					if(MA.hidden)
+						to_chat(usr, "<span class='warning'>That account number is reserved.</span>")
+						return
 					modify.associated_account_number = account_num
 			nanomanager.update_uis(src)
 

--- a/code/game/machinery/computer/slot_machine.dm
+++ b/code/game/machinery/computer/slot_machine.dm
@@ -53,7 +53,7 @@
 
 	id = rand(1,99999)
 
-	our_money_account = create_account("slot machine ([id])", rand(30000,50000))
+	our_money_account = create_account("slot machine ([id])", rand(30000,50000), null, 0, 1, TRUE)
 	radio = new(src)
 
 	update_icon()

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -153,7 +153,7 @@ var/global/num_vending_terminals = 1
 
 /obj/machinery/vending/proc/link_to_account()
 	reconnect_database()
-	linked_account = department_accounts["Cargo"]
+	linked_account = vendor_account
 
 /obj/machinery/vending/RefreshParts()
 	var/manipcount = 0

--- a/code/modules/Economy/Accounts.dm
+++ b/code/modules/Economy/Accounts.dm
@@ -26,7 +26,7 @@ var/global/datum/money_account/trader_account
 		var/datum/transaction/T = new()
 		T.target_name = station_account.owner_name
 		T.purpose = "Account creation"
-		T.amount = 5000
+		T.amount = 750
 		T.date = "2nd April, [game_year]"
 		T.time = "11:24"
 		T.source_terminal = "Biesel GalaxyNet Terminal #277"
@@ -64,7 +64,7 @@ var/global/datum/money_account/trader_account
 //the current ingame time (hh:mm) can be obtained by calling:
 //worldtime2text()
 
-/proc/create_account(var/new_owner_name = "Default user", var/starting_funds = 0, var/obj/machinery/account_database/source_db, var/wage_payout = 0, var/security_pref = 1)
+/proc/create_account(var/new_owner_name = "Default user", var/starting_funds = 0, var/obj/machinery/account_database/source_db, var/wage_payout = 0, var/security_pref = 1, var/makehidden = FALSE)
 
 	//create a new account
 	var/datum/money_account/M = new()
@@ -73,6 +73,7 @@ var/global/datum/money_account/trader_account
 	M.money = starting_funds
 	M.wage_gain = wage_payout
 	M.security_level = security_pref
+	M.hidden = makehidden
 
 	//create an entry in the account transaction log for when it was created
 	var/datum/transaction/T = new()
@@ -136,6 +137,7 @@ var/global/datum/money_account/trader_account
 	var/virtual = 0
 	var/wage_gain = 0 // How much an account gains per 'wage' tick.
 	var/disabled = 0
+	var/hidden = FALSE
 	// 0 Unlocked
 	// 1 User locked
 	// 2 Admin locked
@@ -176,8 +178,7 @@ var/global/datum/money_account/trader_account
 		for(var/department in station_departments)
 			create_department_account(department, recieves_wage = 1)
 	if(!vendor_account)
-		create_department_account("Vendor")
-		vendor_account = department_accounts["Vendor"]
+		vendor_account = create_account("Vendor", 0, null, 0, 1, TRUE)
 
 	if(!current_date_string)
 		current_date_string = "[time2text(world.timeofday, "DD")] [time2text(world.timeofday, "Month")], [game_year]"
@@ -275,6 +276,8 @@ var/global/datum/money_account/trader_account
 						<table border=1 style='width:100%'>"}
 					for(var/i=1, i<=all_money_accounts.len, i++)
 						var/datum/money_account/D = all_money_accounts[i]
+						if(D.hidden)
+							continue
 
 						dat += {"<tr>
 							<td>#[D.account_number]</td>

--- a/code/modules/Economy/utils.dm
+++ b/code/modules/Economy/utils.dm
@@ -125,7 +125,7 @@ var/global/no_pin_for_debit = TRUE
 				return CARD_CAPTURE_FAILURE_NO_CONNECTION
 			account = linked_db.get_account(card.associated_account_number)
 			if(!account)
-				to_chat(user, "[bicon(src)] <span class='warning'>Bad account/pin combination.</span>")
+				to_chat(user, "[bicon(src)] <span class='warning'>Bad account/pin combination or ID is not registered with Nanotrasen accounts database.</span>")
 				return CARD_CAPTURE_FAILURE_BAD_ACCOUNT_PIN_COMBO
 		else
 			to_chat(user, "[bicon(src)] <span class='warning'>Internal Error.</span>")


### PR DESCRIPTION
The main economy reform was too vulnerable to blocking because it lacked atomicity. I'm going to split it in three to make it easier to push through.

Part A is aimed at accounts issues, Part B will target vending machine improvements, and Part C will be where we take on the miner metaclub.

Personally I think these changes to setting an account at the ID computer are a bandaid. Longterm, we should make it so that you can only set an ID's account at an ATM, and it requires the pin number.

🆑 
* tweak: Department accounts lowered to 500 (750 for station account)
* rscdel: Some accounts can be hidden from accounts database (shoal, slot machines, vendors). Attempting to set an ID to use these accounts will cause an error, as will trying to set a wrong account number.
* tweak: Lowered the prices of the most expensive things in cargo that were balanced around department accounts
* bugfix: Fixed a bug where Cargo was the department attached to public vending machines instead of the (unused) vendor account. This means Cargo can't set prices or be 100% reimbursed for buying things anymore.
* bugfix: Improved error message for payment when your card does not have a linked bank account (mostly trader relevant)