### PR TITLE
Economy 2019 Part C Branch B

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -2,6 +2,7 @@
 #define CAT_HIDDEN 2
 #define CAT_COIN   3
 #define CAT_VOUCH  4
+#define CAT_LABOR  5
 
 //Maximum price you can assign to an item
 #define MAX_ITEM_PRICE 1000000000
@@ -35,6 +36,7 @@ var/global/num_vending_terminals = 1
 	var/list/premium 	= list()	// No specified amount = only one in stock
 	var/list/prices     = list()	// Prices for each item, list(/type/path = price), items not in the list don't have a price.
 	var/list/vouched     = list()	//For voucher-only items. These aren't available in any way without the appropriate voucher.
+	var/list/labor_rewards = list() //Just like products and contraband, but spends GBP from your ID.
 
 	var/list/custom_stock = list() 	//Custom items are stored inside our contents, but we keep track of them here so we don't vend our component parts or anything.
 
@@ -44,6 +46,7 @@ var/global/num_vending_terminals = 1
 	var/list/hidden_records = list()
 	var/list/coin_records = list()
 	var/list/voucher_records = list()
+	var/list/labor_records = list()
 	var/vend_reply				//Thank you for shopping!
 	var/last_reply = 0
 	var/last_slogan = 0			//When did we last pitch?
@@ -90,7 +93,7 @@ var/global/num_vending_terminals = 1
 	var/amount = 0
 	var/price = 0
 	var/display_color = "blue"
-	var/category = CAT_NORMAL //available by default, contraband, or premium (requires a coin)
+	var/category = CAT_NORMAL //available by default, contraband, premium (requires a coin), or labor (GBP)
 	var/subcategory = null
 	var/mini_icon = null
 
@@ -147,9 +150,10 @@ var/global/num_vending_terminals = 1
 /obj/machinery/vending/proc/build_inventories()
 	product_records = new/list()
 	build_inventory(products)
-	build_inventory(contraband, 1)
-	build_inventory(premium, 0, 1)
-	build_inventory(vouched, 0, 0, 1)
+	build_inventory(contraband, CAT_HIDDEN)
+	build_inventory(premium, CAT_COIN)
+	build_inventory(vouched, CAT_VOUCH)
+	build_inventory(labor_rewards, CAT_LABOR)
 
 /obj/machinery/vending/proc/link_to_account()
 	reconnect_database()
@@ -178,10 +182,14 @@ var/global/num_vending_terminals = 1
 			newpack.stock = products
 			newpack.secretstock = contraband
 			newpack.preciousstock = premium
-			newpack.targetvendomat = src.type
+			newpack.laborstock = labor_rewards
+
 			newpack.product_records = product_records
 			newpack.hidden_records = hidden_records
 			newpack.coin_records = coin_records
+			newpack.labor_records = labor_records
+
+			newpack.targetvendomat = src.type
 
 	if(coinbox)
 		coinbox.forceMove(get_turf(src))
@@ -239,9 +247,11 @@ var/global/num_vending_terminals = 1
 					newmachine.products = P.stock
 					newmachine.contraband = P.secretstock
 					newmachine.premium = P.preciousstock
+					newmachine.labor_rewards = P.laborstock
 					newmachine.product_records = P.product_records
 					newmachine.hidden_records = P.hidden_records
 					newmachine.coin_records = P.coin_records
+					newmachine.labor_records = P.labor_records
 				qdel(P)
 				if(user.machine==src)
 					newmachine.attack_hand(user)
@@ -326,7 +336,7 @@ var/global/num_vending_terminals = 1
 				malfunction()
 
 //This proc is not used by custom vending machines.
-/obj/machinery/vending/proc/build_inventory(var/list/productlist,hidden=0,req_coin=0,voucher_only=0)
+/obj/machinery/vending/proc/build_inventory(var/list/productlist,type=CAT_NORMAL)
 	for(var/typepath in productlist)
 		var/amount = productlist[typepath]
 		var/price = prices[typepath]
@@ -340,18 +350,18 @@ var/global/num_vending_terminals = 1
 		R.original_amount = amount
 		R.price = price
 		R.display_color = pick("red", "blue", "green")
-		if (hidden)
-			R.category=CAT_HIDDEN
-			hidden_records  += R
-		else if (req_coin)
-			R.category=CAT_COIN
-			coin_records    += R
-		else if (voucher_only)
-			voucher_records += R
-			R.category=CAT_VOUCH
-		else
-			R.category = CAT_NORMAL
-			product_records.Add(R)
+		R.category=type
+		switch(type)
+			if(CAT_HIDDEN)
+				hidden_records  += R
+			if(CAT_COIN)
+				coin_records    += R
+			if(CAT_VOUCH)
+				voucher_records += R
+			if(CAT_LABOR)
+				labor_records 	+= R
+			else
+				product_records.Add(R)
 
 		var/obj/item/initializer = typepath
 		if(!is_custom_machine)
@@ -569,6 +579,9 @@ var/global/num_vending_terminals = 1
 /obj/machinery/vending/proc/pay_with_cash(var/obj/item/weapon/spacecash/cashmoney, mob/user)
 	if(!currently_vending)
 		return
+	if(currently_vending.category == CAT_LABOR)
+		to_chat(user,"<span class='warning'>That product must be paid for in labor points!</span>")
+		return
 	visible_message("<span class='info'>[usr] inserts a credit chip into [src].</span>", "You hear a whirr.")
 	credits_held += cashmoney.get_total()
 	qdel(cashmoney)
@@ -605,6 +618,25 @@ var/global/num_vending_terminals = 1
 				playsound(src, 'sound/machines/alert.ogg', 50, 1)
 				visible_message("[bicon(src)] \The [src] buzzes.")
 
+/obj/machinery/vending/proc/pay_with_points(var/obj/item/weapon/card/C, mob/user)
+	if(!currently_vending)
+		return
+	if (istype(C, /obj/item/weapon/card/id))
+		var/obj/item/weapon/card/id/I = C
+		if(I.labor_points>=currently_vending.price)
+			playsound(src, 'sound/machines/chime.ogg', 50, 1)
+			visible_message("[bicon(src)] \The [src] chimes.")
+			I.labor_points -= currently_vending.price
+			vend(src.currently_vending, user)
+			currently_vending = null
+			updateUsrDialog()
+		else
+			playsound(src, 'sound/machines/alert.ogg', 50, 1)
+			visible_message("[bicon(src)] \The [src] buzzes.")
+			currently_vending = null
+			to_chat(user,"<span class='warning'>The scanned card did not have enough GBP!</span>")
+			updateUsrDialog()
+
 /obj/machinery/vending/attack_paw(mob/user as mob)
 	return attack_hand(user)
 
@@ -612,12 +644,15 @@ var/global/num_vending_terminals = 1
 	src.add_hiddenprint(user)
 	return attack_hand(user)
 
-/obj/machinery/vending/proc/GetProductLine(var/datum/data/vending_product/P)
+/obj/machinery/vending/proc/GetProductLine(var/datum/data/vending_product/P,var/labor = FALSE)
 	var/micon = !isnull(P.mini_icon) ? "<td class='fridgeIcon cropped'>[P.mini_icon]</td>" : ""
 	var/dat = {"[micon]<FONT color = '[P.display_color]'><B>[P.product_name]</B>:
 		<b>[P.amount]</b> </font>"}
 	if(P.price)
-		dat += " <b>($[P.price])</b>"
+		if(!labor)
+			dat += " <b>($[P.price])</b>"
+		else
+			dat += " <b>([P.price]GBP)</b>"
 	if (P.amount > 0)
 		var/idx=GetProductIndex(P)
 		dat += " <a href='byond://?src=\ref[src];vend=[idx];cat=[P.category]'>(Vend)</A>"
@@ -641,6 +676,8 @@ var/global/num_vending_terminals = 1
 			plist=hidden_records
 		if(CAT_COIN)
 			plist=coin_records
+		if(CAT_LABOR)
+			plist=labor_records
 		else
 			warning("UNKNOWN CATEGORY [P.category] IN TYPE [P.product_path] INSIDE [type]!")
 	return plist.Find(P)
@@ -653,6 +690,8 @@ var/global/num_vending_terminals = 1
 			return hidden_records[pid]
 		if(CAT_COIN)
 			return coin_records[pid]
+		if(CAT_LABOR)
+			return labor_records[pid]
 		else
 			warning("UNKNOWN PRODUCT: PID: [pid], CAT: [category] INSIDE [type]!")
 			return null
@@ -756,7 +795,7 @@ var/global/num_vending_terminals = 1
 	if (premium.len > 0)
 		dat += "<b>Coin slot:</b> [coin ? coin : "No coin inserted"] (<a href='byond://?src=\ref[src];remove_coin=1'>Remove</A>)<br><br>"
 
-	if (src.product_records.len == 0)
+	if (!product_records.len && !labor_records.len)
 		dat += "<font color = 'red'>No products loaded!</font><br><br></TT>"
 	else
 		var/list/display_records = src.product_records.Copy()
@@ -806,6 +845,12 @@ var/global/num_vending_terminals = 1
 			dat += {"<B>&nbsp;&nbsp;premium</B>:<br>"}
 			for (var/datum/data/vending_product/R in coin_records)
 				dat += GetProductLine(R)
+			dat += "<br>"
+
+		if(labor_records.len)
+			dat += {"<B>&nbsp;&nbsp;labor rewards</B>:<br>"}
+			for (var/datum/data/vending_product/R in labor_records)
+				dat += GetProductLine(R,TRUE)
 			dat += "<br>"
 
 		dat += "</TT>"
@@ -944,7 +989,10 @@ var/global/num_vending_terminals = 1
 	else if (href_list["buy"])
 		var/obj/item/weapon/card/card = usr.get_card()
 		if(card)
-			connect_account(usr, card)
+			if(currently_vending.category == CAT_LABOR)
+				pay_with_points(card, usr)
+			else
+				connect_account(usr, card)
 		else
 			to_chat(usr, "<span class='warning'>Please present a valid ID.</span>")
 
@@ -2696,7 +2744,7 @@ var/global/num_vending_terminals = 1
 		contraband[/obj/item/clothing/head/helmet/space/rig/nazi] = 3
 		contraband[/obj/item/clothing/suit/space/rig/nazi] = 3
 		contraband[/obj/item/weapon/gun/energy/plasma/MP40k] = 4
-		src.build_inventory(contraband, 1)
+		src.build_inventory(contraband, CAT_HIDDEN)
 		emagged = 1
 		overlays = 0
 		var/image/dangerlay = image(icon,"[icon_state]-dangermode", ABOVE_LIGHTING_LAYER)
@@ -2778,7 +2826,7 @@ var/global/num_vending_terminals = 1
 		contraband[/obj/item/clothing/head/helmet/space/rig/soviet] = 3
 		contraband[/obj/item/clothing/suit/space/rig/soviet] = 3
 		contraband[/obj/item/weapon/gun/energy/laser/LaserAK] = 4
-		src.build_inventory(contraband, 1)
+		src.build_inventory(contraband, CAT_HIDDEN)
 		emagged = 1
 		overlays = 0
 		var/image/dangerlay = image(icon,"[icon_state]-dangermode", ABOVE_LIGHTING_LAYER)
@@ -3217,7 +3265,7 @@ var/global/num_vending_terminals = 1
 	)
 	vend_reply = "What a glorious time to mine!"
 	icon_state = "mining"
-	products = list(
+	labor_rewards = list(
 		/obj/item/toy/canary = 10,
 		/obj/item/weapon/reagent_containers/food/snacks/hotchili = 10,
 		/obj/item/clothing/mask/cigarette/cigar/havana = 5,

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -36,7 +36,7 @@ var/global/num_vending_terminals = 1
 	var/list/premium 	= list()	// No specified amount = only one in stock
 	var/list/prices     = list()	// Prices for each item, list(/type/path = price), items not in the list don't have a price.
 	var/list/vouched     = list()	//For voucher-only items. These aren't available in any way without the appropriate voucher.
-	var/list/labor_rewards = list() //Just like products and contraband, but spends GBP from your ID.
+	var/list/labor_rewards = list() //Just like products and contraband, but spends labor points from your ID.
 
 	var/list/custom_stock = list() 	//Custom items are stored inside our contents, but we keep track of them here so we don't vend our component parts or anything.
 
@@ -93,7 +93,7 @@ var/global/num_vending_terminals = 1
 	var/amount = 0
 	var/price = 0
 	var/display_color = "blue"
-	var/category = CAT_NORMAL //available by default, contraband, premium (requires a coin), or labor (GBP)
+	var/category = CAT_NORMAL //available by default, contraband, premium (requires a coin), or labor (points)
 	var/subcategory = null
 	var/mini_icon = null
 
@@ -634,7 +634,7 @@ var/global/num_vending_terminals = 1
 			playsound(src, 'sound/machines/alert.ogg', 50, 1)
 			visible_message("[bicon(src)] \The [src] buzzes.")
 			currently_vending = null
-			to_chat(user,"<span class='warning'>The scanned card did not have enough GBP!</span>")
+			to_chat(user,"<span class='warning'>The scanned card did not have enough labor points!</span>")
 			updateUsrDialog()
 
 /obj/machinery/vending/attack_paw(mob/user as mob)
@@ -652,7 +652,7 @@ var/global/num_vending_terminals = 1
 		if(!labor)
 			dat += " <b>($[P.price])</b>"
 		else
-			dat += " <b>([P.price]GBP)</b>"
+			dat += " <b>([P.price] labor points)</b>"
 	if (P.amount > 0)
 		var/idx=GetProductIndex(P)
 		dat += " <a href='byond://?src=\ref[src];vend=[idx];cat=[P.category]'>(Vend)</A>"

--- a/code/game/machinery/vending_packs.dm
+++ b/code/game/machinery/vending_packs.dm
@@ -9,9 +9,11 @@
 	var/list/stock = list()
 	var/list/secretstock = list()
 	var/list/preciousstock = list()
+	var/list/laborstock = list()
 	var/list/product_records = list()
 	var/list/hidden_records = list()
 	var/list/coin_records = list()
+	var/list/labor_records = list()
 
 //////CUSTOM PACKS///////
 

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -194,6 +194,7 @@
 	var/dorm = 0		// determines if this ID has claimed a dorm already
 
 	var/datum/money_account/virtual_wallet = 1	//money! If 0, don't create a wallet. Otherwise create one!
+	var/labor_points = 0 //rewards to spend at some vendors
 
 /obj/item/weapon/card/id/New()
 	..()
@@ -214,6 +215,8 @@
 		user.show_message("The blood type on the card is [blood_type].",1)
 		user.show_message("The DNA hash on the card is [dna_hash].",1)
 		user.show_message("The fingerprint hash on the card is [fingerprint_hash].",1)
+	if(labor_points)
+		to_chat(user,"<span class='info'>It shines with the pride of [labor_points] labor points.</span>")
 
 /obj/item/weapon/card/id/attack_self(var/mob/user)
 	if(user.attack_delayer.blocked())

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -74,10 +74,10 @@
 	"}
 
 	if(smelter_data["credits"] != -1)
-		dat += "<br>Current unclaimed credits: $[num2septext(smelter_data["credits"])]<br>"
+		dat += "<br>Current unclaimed points: [num2septext(smelter_data["credits"])]<br>"
 
 		if(istype(id))
-			dat += "You have [id.GetBalance(format = 1)] credits in your bank account. <A href='?src=\ref[src];eject=1'>Eject ID.</A><br>"
+			dat += "You have [id.labor_points] points on your ID. <A href='?src=\ref[src];eject=1'>Eject ID.</A><br>"
 			dat += "<A href='?src=\ref[src];claim=1'>Claim points.</A><br>"
 		else
 			dat += text("No ID inserted. <A href='?src=\ref[src];insert=1'>Insert ID.</A><br>")
@@ -173,7 +173,7 @@
 		return 1
 
 	if(href_list["claim"])
-		send_signal(list("claimcredits" = get_card_account(id)))
+		send_signal(list("claimcredits" = id))
 		request_status()
 		return 1
 
@@ -473,9 +473,9 @@
 		if(credits < 1)	//Is there actual money to collect?
 			return 1
 
-		var/datum/money_account/acct = signal.data["claimcredits"]
-		if(istype(acct) && acct.charge(-credits, null, "Claimed mining credits.", src.name, dest_name = "Processing Machine"))
-			credits = 0
+		var/obj/item/weapon/card/id/ID = signal.data["claimcredits"]
+		ID.labor_points += credits
+		credits = 0
 
 	if(signal.data["inc_priority"])
 		var/idx = Clamp(signal.data["inc_priority"], 2, recipes.len)


### PR DESCRIPTION
The main economy reform was too vulnerable to blocking because it lacked atomicity. I'm going to split it in three to make it easier to push through. Part A is aimed at accounts issues, Part B will target vending machine improvements, and Part C will be where we take on the miner metaclub.

Branch B represents the "ideal timeline". I've removed the highly controversial previous name for points, now IDs can get _labor points_. You can still hold up your ID to show off labor points. There have been no changes to mining vend prices or mineral values, so miner progression is unaltered and no worries about people breaking into cargo for cheap stuff at the mining vend.

🆑 
* tweak: Miners now receive labor points on their ID from the smelter. Mining vendor items all cost labor points.