### PR TITLE
Borg Smashing

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -818,6 +818,25 @@ var/list/cyborg_list = list()
 	else
 		if(W.force > 0)
 			spark(src, 5, FALSE)
+		if(stat == DEAD && W.force >= 15)
+			visible_message("<span class='danger'>[user] begins ripping [src] apart with \the [W]!")
+			if(do_after(user, src, 3 SECONDS))
+				playsound(src, 'sound/mecha/mechsmash.ogg', 50, 1)
+				if(prob(max((W.force/7.5)**3,25))) //15-21f - 25% chance, 22f - 27%, 30f - 64%, 35f - 99%
+					visible_message("<span class='danger'>[user] tore [src] apart with \the [W]!")
+					if(prob(25))
+						new /obj/item/robot_parts/l_leg(loc)
+					if(prob(25))
+						new /obj/item/robot_parts/r_leg(loc)
+					if(prob(25))
+						new /obj/item/robot_parts/l_arm(loc)
+					if(prob(25))
+						new /obj/item/robot_parts/r_arm(loc)
+					gib()
+				else
+					visible_message("<span class='danger'>[src] groans under the force of \the [W]!")
+					shake(1, 3)
+				return
 		return ..()
 
 /mob/living/silicon/robot/attack_alien(mob/living/carbon/alien/humanoid/M as mob)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -818,7 +818,7 @@ var/list/cyborg_list = list()
 	else
 		if(W.force > 0)
 			spark(src, 5, FALSE)
-		if(stat == DEAD && W.force >= 15)
+		if(stat == DEAD && W.force > 15)
 			visible_message("<span class='danger'>[user] begins ripping [src] apart with \the [W]!")
 			if(do_after(user, src, 3 SECONDS))
 				playsound(src, 'sound/mecha/mechsmash.ogg', 50, 1)


### PR DESCRIPTION
Inspiration taken from both magboot stomping and limb gibbing. When you hit a dead borg with a weapon of 15 force or more, you have a chance to rip it apart after 3 seconds. This process can be interrupted.

The formula is max((force/7.5)^3,25), or put more legibly, here are some percentage chances:
16-21 force: 25%
22 force: 27%
30 force: 64%
35 force: 99%
This formula was based off of the formula for human limbgibbing. There is a 25% chance for each robolimb to drop with the gibs.

🆑 
* rscadd: You can now smash borgs to get out the MMI/posibrain and some limbs. It requires a weapon of >15 force.