### PR TITLE
OOC will now automatically turn back on at the end of rounds

### DIFF
--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -530,6 +530,9 @@ var/datum/controller/gameticker/ticker
 	minesweeper_best_players["expert"] = "none"
 
 /datum/controller/gameticker/proc/declare_completion()
+	if(!ooc_allowed)
+		to_chat(world, "<B>The OOC channel has been automatically re-enabled!</B>")
+		ooc_allowed = TRUE
 	scoreboard()
 	return 1
 


### PR DESCRIPTION
:cl:
 * rscadd: OOC will now be automatically re-enabled at the round end in the case of it being disabled by admins and never re-enabled.