### PR TITLE
Should stop spider queens from making mass trails of web in space

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/nurse.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/nurse.dm
@@ -56,6 +56,8 @@
 	return ..()
 
 /mob/living/simple_animal/hostile/giant_spider/nurse/proc/spin_web(var/turf/T)
+	if(isspace(T))
+		return 0
 	if(!locate(/obj/effect/spider/stickyweb) in T)
 		new /obj/effect/spider/stickyweb(T)
 	return 1


### PR DESCRIPTION
Thought it was an interesting feature that spiders could make space-spanning webs to catch things with, but if it's causing problems then it should be fixed.

closes #22363 

:cl:
 * bugfix: Spider queens now no longer make webs across space.