### PR TITLE
Dynamic Threat Formula Lowered

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic.dm
+++ b/code/datums/gamemode/dynamic/dynamic.dm
@@ -112,7 +112,27 @@ var/list/threat_by_job = list(
 	send2maindiscord("Dynamic mode threat: **[threat_level]**, rulesets: [jointext(rules, ", ")]")
 
 /datum/gamemode/dynamic/can_start()
-	threat_level = rand(1,100)*0.6 + rand(1,100)*0.4//https://docs.google.com/spreadsheets/d/1QLN_OBHqeL4cm9zTLEtxlnaJHHUu0IUPzPbsI-DFFmc/edit#gid=499381388
+	//Old formula: rand(1,100)*0.6 + rand(1,100)*0.4//https://docs.google.com/spreadsheets/d/1QLN_OBHqeL4cm9zTLEtxlnaJHHUu0IUPzPbsI-DFFmc/edit#gid=499381388
+	threat_level = rand(1,20)
+	if(prob(50))
+		threat_level += rand(1,20)
+		if(prob(50))
+			threat_level += rand(1,20)
+			if(prob(50))
+				threat_level += rand(1,20)
+				if(prob(50))
+					threat_level += rand(1,40)
+	/*CHANCES
+	1-10 threat: 21.80%
+	11-20 threat: 34.97%
+	21-30 threat: 22.74%
+	31-35 threat: 7.80%
+	36-40 threat: 3.67%
+	41-45 threat: 2.64%
+	46-60 threat: 4.09%
+	61-88 threat: 0.96%
+	89-100 threat: not statistically significant
+	*/
 	threat = threat_level
 	starting_threat = threat_level
 	latejoin_injection_cooldown = rand(330,510)


### PR DESCRIPTION
I don't really have strong feelings about this one, so I don't care which way the emojiocracy goes. It seems there are rumblings about tuning down dynamic. Here you go, we can give it a try with a different formula. This is what the new odds look like: (value shown is odds the threat rolled will be *at least* that number. Starting threat will always be at least 1, so it is 100%)
![image](https://user-images.githubusercontent.com/9782036/55845606-321ae480-5b08-11e9-82c2-056db555081d.png)
Note: values 75-88 account for 0.11%. Higher values not statistically significant.

Cost references
_LJ Traitor: 5; MR Traitor: 10; RS Traitor: 10; LJ/MR Ninja: 10; Rambler: 5, Catbeast: 0_
_MR/LJ Wiz: 20; MR Blob: 15; LJ Revs: 20_
_Vampire: 25; Wizard: 30; Cult: 30_
_RS Revs: 35; MR Malf: 35; MR Nuke Ops_
_RS Nuke Ops: 40; RS Malf: 40_
_CWC: 45; RS Blob: 45; MR Revs: 45_

**Examples**
RS Wizard costs 30. The odds that there will be at least 30 threat, thus wizard will be eligible, are 22.36%. RS Cult costs 30 as well. The odds that there would be 60 threat, allowing both to fire, are 1.21%. RS Operatives costs 40. The odds that there will be enough threat to choose Operatives is 8.53%. RS Blob costs 45. The odds that there will be enough threat to choose blob at roundstart are 5.63%. Malf and Operatives would total to 95 threat. The odds of this happening are so low as to not matter.

🆑 
* experimental: The dynamic threat formula has been adjusted. Generally, it should be lower and very high threat rounds (75 or higher) should nearly never happen.