### PR TITLE
Beepsky now cuffs with cable restraints instead of real deal handcuffs

### DIFF
--- a/code/game/machinery/bots/secbot.dm
+++ b/code/game/machinery/bots/secbot.dm
@@ -366,7 +366,7 @@ Auto Patrol: []"},
 							if(istype(src.target,/mob/living/carbon) && !isalien(target))
 								C = target
 								if(!C.handcuffed)
-									C.handcuffed = new /obj/item/weapon/handcuffs(target)
+									C.handcuffed = new /obj/item/weapon/handcuffs/cable(target)
 									C.update_inv_handcuffed()	//update the handcuffs overlay
 
 							mode = SECBOT_IDLE


### PR DESCRIPTION
Beepsky needs some fixing but that can't happen until Astar is made (Beepsky can do things such as hitting people through firelocks or chasing invisible people)
Besides cuffs take 120 seconds to break out of, cable restraints are 30 seconds, and this won't make people caught by Beepsky feel like dying
No this is not grudgecode from recent rounds
:cl:
 * tweak: Beepsky now cuffs with cable restraints instead of handcuffs, meaning it takes 30 seconds to break out of cuffs instead of 120 seconds.