### PR TITLE
Spider sanity eternal

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/base_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/base_spider.dm
@@ -72,33 +72,28 @@
 			icon_state = "[icon_dead][(our_legs.amount<8) ? our_legs.amount : ""]"
 
 // Checks pressure here vs. around us. Intended to make sure the spider doesn't breach to space while comfortable, or breach into a high pressure area
-/mob/living/simple_animal/hostile/giant_spider/proc/performPressureCheck(var/turf/loc)
-	var/turf/simulated/lT=loc
-	if(!istype(lT) || !lT.zone)
+/mob/living/simple_animal/hostile/giant_spider/proc/performPressureCheck(var/turf/curturf)
+	if(!istype(curturf))
 		return 0
-	var/datum/gas_mixture/myenv=lT.return_air()
+	var/datum/gas_mixture/myenv=curturf.return_air()
 	var/pressure=myenv.return_pressure()
 
 	for(var/checkdir in cardinal)
-		var/turf/simulated/T = get_step(loc, checkdir)
-		if(T && istype(T) && T.zone)
+		var/turf/T = get_step(curturf, checkdir)
+		if(T && istype(T))
 			var/datum/gas_mixture/environment = T.return_air()
 			var/pdiff = abs(pressure - environment.return_pressure())
 			if(pdiff > SPIDER_MAX_PRESSURE_DIFF)
 				return pdiff
 	return 0
 
-/mob/living/simple_animal/hostile/giant_spider/UnarmedAttack(var/atom/A)
-	if(istype(A,/obj/structure/window) && (!target || !ismob(target)) && performPressureCheck(get_turf(A)))
-		return 0
+/mob/living/simple_animal/hostile/giant_spider/UnarmedAttack(var/atom/A, var/proximity_flag, var/params)
+	if(istype(A,/obj/structure/window) && proximity_flag && (!target || !ismob(target)) && performPressureCheck(get_turf(A)))
+		return
 	.=..()
 
 //Can we actually attack a possible target?
 /mob/living/simple_animal/hostile/giant_spider/CanAttack(var/atom/the_target)
-	if(istype(the_target,/mob/living/simple_animal/hostile/giant_spider))
-		return 0
-	if(istype(the_target,/obj/effect))
-		return 0
 	if(istype(the_target,/obj/machinery/light))
 		var/obj/machinery/light/L = the_target
 		// Not empty or broken
@@ -106,16 +101,6 @@
 	return ..(the_target)
 
 /mob/living/simple_animal/hostile/giant_spider/AttackingTarget()
-	if(istype(target,/obj/structure/window))
-		var/obj/structure/window/W=target
-		if(get_dist(src, target) > 1)
-			return // keep movin'.
-
-		var/turf/T = get_turf(W)
-
-		// Don't kill ourselves
-		if(performPressureCheck(T))
-			return
 	..()
 	if(isliving(target))
 		var/mob/living/L = target

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/base_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/base_spider.dm
@@ -71,7 +71,7 @@
 		if(istype(our_legs))
 			icon_state = "[icon_dead][(our_legs.amount<8) ? our_legs.amount : ""]"
 
-// Checks pressure here vs. around us.
+// Checks pressure here vs. around us. Intended to make sure the spider doesn't breach to space while comfortable, or breach into a high pressure area
 /mob/living/simple_animal/hostile/giant_spider/proc/performPressureCheck(var/turf/loc)
 	var/turf/simulated/lT=loc
 	if(!istype(lT) || !lT.zone)
@@ -79,14 +79,19 @@
 	var/datum/gas_mixture/myenv=lT.return_air()
 	var/pressure=myenv.return_pressure()
 
-	for(var/dir in cardinal)
-		var/turf/simulated/T = get_step(loc, dir)
+	for(var/checkdir in cardinal)
+		var/turf/simulated/T = get_step(loc, checkdir)
 		if(T && istype(T) && T.zone)
 			var/datum/gas_mixture/environment = T.return_air()
 			var/pdiff = abs(pressure - environment.return_pressure())
 			if(pdiff > SPIDER_MAX_PRESSURE_DIFF)
 				return pdiff
 	return 0
+
+/mob/living/simple_animal/hostile/giant_spider/UnarmedAttack(var/atom/A)
+	if(istype(A,/obj/structure/window) && (!target || !ismob(target)) && performPressureCheck(get_turf(A)))
+		return 0
+	.=..()
 
 //Can we actually attack a possible target?
 /mob/living/simple_animal/hostile/giant_spider/CanAttack(var/atom/the_target)

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/nurse.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/nurse.dm
@@ -56,7 +56,7 @@
 	return ..()
 
 /mob/living/simple_animal/hostile/giant_spider/nurse/proc/spin_web(var/turf/T)
-	if(isspace(T))
+	if(!T.has_gravity(src))
 		return 0
 	if(!locate(/obj/effect/spider/stickyweb) in T)
 		new /obj/effect/spider/stickyweb(T)

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -224,7 +224,7 @@
 			if(canmove && space_check())
 				Goto(A,move_to_delay,minimum_distance)
 			if(A.Adjacent(src))
-				UnarmedAttack(A)
+				UnarmedAttack(A, Adjacent(A))
 			return
 		else
 			LostTarget()
@@ -265,7 +265,7 @@
 		return 1
 
 /mob/living/simple_animal/hostile/proc/AttackingTarget()
-	UnarmedAttack(target)
+	UnarmedAttack(target, Adjacent(target))
 
 /mob/living/simple_animal/hostile/proc/Aggro()
 	vision_range = aggro_vision_range
@@ -392,7 +392,7 @@
 		for(var/dir in smash_dirs)
 			var/turf/T = get_step(src, dir)
 			if(istype(T, /turf/simulated/wall) && Adjacent(T))
-				UnarmedAttack(T)
+				UnarmedAttack(T, Adjacent(T))
 			for(var/atom/A in T)
 				var/static/list/destructible_objects = list(/obj/structure/window,
 					 /obj/structure/closet,
@@ -408,15 +408,15 @@
 						var/obj/machinery/door/airlock/AIR = A
 						if(!AIR.density || AIR.locked || AIR.welded || AIR.operating)
 							continue
-					UnarmedAttack(A)
+					UnarmedAttack(A, Adjacent(A))
 	return
 
 /mob/living/simple_animal/hostile/proc/EscapeConfinement()
 	if(locked_to)
-		UnarmedAttack(locked_to)
+		UnarmedAttack(locked_to, Adjacent(locked_to))
 	if(!isturf(src.loc) && src.loc != null)//Did someone put us in something?
 		var/atom/A = src.loc
-		UnarmedAttack(A) //Bang on it till we get out
+		UnarmedAttack(A, Adjacent(A)) //Bang on it till we get out
 	if(environment_smash_flags & SMASH_ASTEROID)
 		for(var/turf/unsimulated/mineral/M in range(src, 1))
 			UnarmedAttack(M, Adjacent(M))


### PR DESCRIPTION
Fixes spiders STILL making webs, as isspace is an area check macro, not a turf check macro.

Revisits an ancient function in spider code, that was supposed to check if the pressure in a direction was dangerous. Problem is it was so riddled with needless istype checks, it failed to check for if it was next to space and such. This has been remedied.

:cl:
 * rscadd: Spiders should no longer try to break windows that have a high pressure difference, unless there is something living that it is hunting.