### PR TITLE
Solarboards

### DIFF
--- a/code/modules/research/designs/boards/machine_engie.dm
+++ b/code/modules/research/designs/boards/machine_engie.dm
@@ -54,7 +54,6 @@
 	category = "Machine Boards"
 	build_path = /obj/item/weapon/circuitboard/cell_charger
 
-/*
 /datum/design/tracker_electronics
 	name = "Circuit Design (Tracker Electronics)"
 	desc = "Allows for the construction of circuit boards used to build a Solar Tracker."
@@ -64,7 +63,6 @@
 	materials = list(MAT_GLASS = 2000, SACID = 20)
 	category = "Machine Boards"
 	build_path = /obj/item/weapon/tracker_electronics
-*/
 
 //
 //P.A.C.M.A.N

--- a/code/modules/research/designs/boards/machine_engie.dm
+++ b/code/modules/research/designs/boards/machine_engie.dm
@@ -46,13 +46,25 @@
 
 /datum/design/cell_charger
 	name = "Circuit Design (Cell Charger)"
-	desc = "Allows for the construction of circuit boards used to build a cell charger"
+	desc = "Allows for the construction of circuit boards used to build a Cell Charger."
 	id = "cellcharger"
 	req_tech = list(Tc_MATERIALS = 2, Tc_ENGINEERING = 2, Tc_POWERSTORAGE = 3)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 2000, SACID = 20)
 	category = "Machine Boards"
 	build_path = /obj/item/weapon/circuitboard/cell_charger
+
+/*
+/datum/design/tracker_electronics
+	name = "Circuit Design (Tracker Electronics)"
+	desc = "Allows for the construction of circuit boards used to build a Solar Tracker."
+	id = "trackerelectronics"
+	req_tech = list(Tc_ENGINEERING = 2, Tc_POWERSTORAGE = 2)
+	build_type = IMPRINTER
+	materials = list(MAT_GLASS = 2000, SACID = 20)
+	category = "Machine Boards"
+	build_path = /obj/item/weapon/tracker_electronics
+*/
 
 //
 //P.A.C.M.A.N


### PR DESCRIPTION
Tracker Electronics are currently only available via cargo's solar panel supply pack, so I've added them to the imprinter's engineering boards.

Also minor grammar tweak just because I spotted it.

Tested, works fine.

:cl:
 * rscadd: Added Tracker Electronics to the Circuit Imprinter