### PR TITLE
beepsky no longer arrests people that are invisible via alpha var

### DIFF
--- a/code/game/machinery/bots/secbot.dm
+++ b/code/game/machinery/bots/secbot.dm
@@ -724,6 +724,9 @@ Auto Patrol: []"},
 /obj/machinery/bot/secbot/proc/assess_perp(mob/living/carbon/human/perp as mob)
 	var/threatcount = 0 //If threat >= 4 at the end, they get arrested
 
+	if(perp.alpha <= 1) //perp is invisible, hence innocent
+		return 0
+
 	if(src.emagged == 2)
 		return PERP_LEVEL_ARREST + rand(PERP_LEVEL_ARREST, PERP_LEVEL_ARREST*5) //Everyone is a criminal!
 


### PR DESCRIPTION
fixes #15870

Previous reading:
#22400
#22405

I still have no strong opinions for or against this pull request, but it does have things that need to be changed like also not trying to arrest things with a high enough invisibility var

todo:
- [ ] fix the existing is_visible() proc to not be retarded (seperate PR)
- [ ] use is_visible() proc in this PR
- [ ] make secbots have an upgrade to go after invisible people

:cl:
 * tweak: Beepsky no longer arrests people that are invisible via alpha var