### PR TITLE
Reduces time it takes to unbuckle from bucklecuff to 1 minute from 2 minutes

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -980,7 +980,7 @@ Thanks.
 						                  "<span class='warning'>You attempt to unbuckle yourself (this will take around two minutes, and you need to stay still).</span>",
 						                   self_drugged_message="<span class='warning'>You attempt to regain control of your legs (this will take a while).</span>")
 						spawn(0)
-							if(do_after(usr, usr, 1200))
+							if(do_after(usr, usr, 600))
 								if(!C.locked_to)
 									return
 								C.visible_message("<span class='danger'>[C] manages to unbuckle themself!</span>",\

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -980,7 +980,7 @@ Thanks.
 						                  "<span class='warning'>You attempt to unbuckle yourself (this will take around two minutes, and you need to stay still).</span>",
 						                   self_drugged_message="<span class='warning'>You attempt to regain control of your legs (this will take a while).</span>")
 						spawn(0)
-							if(do_after(usr, usr, 600))
+							if(do_after(usr, usr, 1 MINUTES))
 								if(!C.locked_to)
 									return
 								C.visible_message("<span class='danger'>[C] manages to unbuckle themself!</span>",\


### PR DESCRIPTION
A bit excessive to have 4 minutes when the process can be interrupted at any time and outright reset if you get buckled after unbuckling. Or something.
Hard to defend against this change mostly because it's not that important if you still got 3 minutes during which a person can't do anything, 2 minutes of which they can only move.
:cl:
 * tweak: It now takes 1 minute to unbuckle while cuffed instead of 2 minutes.