### PR TITLE
Ghetto screwdriver

### DIFF
--- a/__DEFINES/_macros.dm
+++ b/__DEFINES/_macros.dm
@@ -150,8 +150,6 @@
 
 #define iswiretool(A) (iswirecutter(A) || ismultitool(A) || issignaler(A))
 
-#define isscrewdriver(A) istype(A, /obj/item/weapon/screwdriver)
-
 #define isbikehorn(A) istype(A, /obj/item/weapon/bikehorn)
 
 #define ispowercell(A) istype(A, /obj/item/weapon/cell)

--- a/code/datums/helper_datums/construction_datum.dm
+++ b/code/datums/helper_datums/construction_datum.dm
@@ -71,14 +71,14 @@
 		return steps.len
 	return 0
 
-/datum/construction/proc/custom_action(step, used_atom, user)
+/datum/construction/proc/custom_action(step, obj/item/used_atom, mob/user)
 	if(iswelder(used_atom))
 		playsound(holder, 'sound/items/Welder2.ogg', 50, 1)
 
 	else if(iswrench(used_atom))
 		playsound(holder, 'sound/items/Ratchet.ogg', 50, 1)
 
-	else if(isscrewdriver(used_atom))
+	else if(used_atom.can_be_used_as_screwdriver(user))
 		playsound(holder, 'sound/items/Screwdriver.ogg', 50, 1)
 
 	else if(iswirecutter(used_atom))
@@ -251,7 +251,7 @@
 		assembling = 0
 	return 0
 
-/datum/construction/reversible/custom_action(index, diff, used_atom, user)
+/datum/construction/reversible/custom_action(index, diff, obj/item/used_atom, mob/user)
 	. = ..(index,used_atom,user)
 
 	if(.)

--- a/code/datums/helper_datums/construction_datum.dm
+++ b/code/datums/helper_datums/construction_datum.dm
@@ -78,7 +78,7 @@
 	else if(iswrench(used_atom))
 		playsound(holder, 'sound/items/Ratchet.ogg', 50, 1)
 
-	else if(used_atom.can_be_used_as_screwdriver(user))
+	else if(used_atom.is_screwdriver(user))
 		playsound(holder, 'sound/items/Screwdriver.ogg', 50, 1)
 
 	else if(iswirecutter(used_atom))

--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -457,7 +457,7 @@
 				to_chat(user, "<span class='danger'>You shouldn't be reading this message! Contact a coder or someone, something broke!</span>")
 				IED = null
 				return
-	if(I.can_be_used_as_screwdriver(user))
+	if(I.is_screwdriver(user))
 		if(IED)
 			IED.forceMove(get_turf(src.loc))
 			IED = null

--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -457,7 +457,7 @@
 				to_chat(user, "<span class='danger'>You shouldn't be reading this message! Contact a coder or someone, something broke!</span>")
 				IED = null
 				return
-	if(isscrewdriver(I))
+	if(I.can_be_used_as_screwdriver(user))
 		if(IED)
 			IED.forceMove(get_turf(src.loc))
 			IED = null

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -817,7 +817,7 @@
 
 	switch(buildstage)
 		if(2)
-			if(W.can_be_used_as_screwdriver(user))  // Opening that Air Alarm up.
+			if(W.is_screwdriver(user))  // Opening that Air Alarm up.
 				wiresexposed = !wiresexposed
 				to_chat(user, "The wires have been [wiresexposed ? "exposed" : "unexposed"].")
 				playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
@@ -1013,7 +1013,7 @@ FIRE ALARM
 		update_icon()
 		return
 
-	if (W.can_be_used_as_screwdriver(user) && buildstage == 2)
+	if (W.is_screwdriver(user) && buildstage == 2)
 		wiresexposed = !wiresexposed
 		to_chat(user, "The wires have been [wiresexposed ? "exposed" : "unexposed"].")
 		playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -817,7 +817,7 @@
 
 	switch(buildstage)
 		if(2)
-			if(isscrewdriver(W))  // Opening that Air Alarm up.
+			if(W.can_be_used_as_screwdriver(user))  // Opening that Air Alarm up.
 				wiresexposed = !wiresexposed
 				to_chat(user, "The wires have been [wiresexposed ? "exposed" : "unexposed"].")
 				playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
@@ -1013,7 +1013,7 @@ FIRE ALARM
 		update_icon()
 		return
 
-	if (isscrewdriver(W) && buildstage == 2)
+	if (W.can_be_used_as_screwdriver(user) && buildstage == 2)
 		wiresexposed = !wiresexposed
 		to_chat(user, "The wires have been [wiresexposed ? "exposed" : "unexposed"].")
 		playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)

--- a/code/game/machinery/bots/bots.dm
+++ b/code/game/machinery/bots/bots.dm
@@ -131,7 +131,7 @@
 	if(flags & INVULNERABLE)
 		return
 	user.delayNextAttack(W.attack_delay)
-	if((W.can_be_used_as_screwdriver(user) || iscrowbar(W)) && user.a_intent != I_HURT)
+	if((W.is_screwdriver(user) || iscrowbar(W)) && user.a_intent != I_HURT)
 		if(locked)
 			to_chat(user, "<span class='notice'>[src]'s maintenance panel is locked tight.</span>")
 		else

--- a/code/game/machinery/bots/bots.dm
+++ b/code/game/machinery/bots/bots.dm
@@ -131,7 +131,7 @@
 	if(flags & INVULNERABLE)
 		return
 	user.delayNextAttack(W.attack_delay)
-	if((isscrewdriver(W) || iscrowbar(W)) && user.a_intent != I_HURT)
+	if((W.can_be_used_as_screwdriver(user) || iscrowbar(W)) && user.a_intent != I_HURT)
 		if(locked)
 			to_chat(user, "<span class='notice'>[src]'s maintenance panel is locked tight.</span>")
 		else

--- a/code/game/machinery/bots/ed209bot.dm
+++ b/code/game/machinery/bots/ed209bot.dm
@@ -1051,7 +1051,7 @@ Auto Patrol: []"},
 			qdel(W)
 
 		if(8)
-			if( W.can_be_used_as_screwdriver(user) )
+			if( W.is_screwdriver(user) )
 				playsound(src, 'sound/items/Screwdriver.ogg', 100, 1)
 				var/turf/T = get_turf(user)
 				to_chat(user, "<span class='notice'>Now attaching the gun to the frame...</span>")

--- a/code/game/machinery/bots/ed209bot.dm
+++ b/code/game/machinery/bots/ed209bot.dm
@@ -1051,7 +1051,7 @@ Auto Patrol: []"},
 			qdel(W)
 
 		if(8)
-			if( isscrewdriver(W) )
+			if( W.can_be_used_as_screwdriver(user) )
 				playsound(src, 'sound/items/Screwdriver.ogg', 100, 1)
 				var/turf/T = get_turf(user)
 				to_chat(user, "<span class='notice'>Now attaching the gun to the frame...</span>")

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -210,7 +210,7 @@ var/list/camera_messages = list()
 /obj/machinery/camera/attackby(obj/item/W, mob/living/user)
 
 	// DECONSTRUCTION
-	if(isscrewdriver(W))
+	if(W.can_be_used_as_screwdriver(user))
 //		to_chat(user, "<span class='notice'>You start to [panel_open ? "close" : "open"] the camera's panel.</span>")
 		//if(toggle_panel(user)) // No delay because no one likes screwdrivers trying to be hip and have a duration cooldown
 		togglePanelOpen(W, user, icon_state, icon_state)
@@ -502,8 +502,8 @@ var/list/camera_messages = list()
 	upgradeXRay()
 	upgradeHearing()
 
-/obj/machinery/camera/arena/attackby(W as obj, mob/living/user as mob)
-	if(isscrewdriver(W))
+/obj/machinery/camera/arena/attackby(obj/item/W as obj, mob/living/user as mob)
+	if(W.can_be_used_as_screwdriver(user))
 		to_chat(user, "<span class='warning'>There aren't any visible screws to unscrew.</span>")
 	else
 		user.visible_message("<span class='warning'>\The [user] hits \the [src] with \the [W] but it doesn't seem to affect it in the least.</span>","<span class='warning'>You hit \the [src] with \the [W] but it doesn't seem to affect it in the least</span>")

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -210,7 +210,7 @@ var/list/camera_messages = list()
 /obj/machinery/camera/attackby(obj/item/W, mob/living/user)
 
 	// DECONSTRUCTION
-	if(W.can_be_used_as_screwdriver(user))
+	if(W.is_screwdriver(user))
 //		to_chat(user, "<span class='notice'>You start to [panel_open ? "close" : "open"] the camera's panel.</span>")
 		//if(toggle_panel(user)) // No delay because no one likes screwdrivers trying to be hip and have a duration cooldown
 		togglePanelOpen(W, user, icon_state, icon_state)
@@ -503,7 +503,7 @@ var/list/camera_messages = list()
 	upgradeHearing()
 
 /obj/machinery/camera/arena/attackby(obj/item/W as obj, mob/living/user as mob)
-	if(W.can_be_used_as_screwdriver(user))
+	if(W.is_screwdriver(user))
 		to_chat(user, "<span class='warning'>There aren't any visible screws to unscrew.</span>")
 	else
 		user.visible_message("<span class='warning'>\The [user] hits \the [src] with \the [W] but it doesn't seem to affect it in the least.</span>","<span class='warning'>You hit \the [src] with \the [W] but it doesn't seem to affect it in the least</span>")

--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -81,7 +81,7 @@
 
 		if(3)
 			// State 3
-			if(W.can_be_used_as_screwdriver(user))
+			if(W.is_screwdriver(user))
 				playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 
 				var/input = stripped_input(usr, "Which networks would you like to connect this camera to? seperate networks with a comma. No Spaces!\nFor example: SS13,Security,Secret ", "Set Network", CAMERANET_SS13)

--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -81,7 +81,7 @@
 
 		if(3)
 			// State 3
-			if(isscrewdriver(W))
+			if(W.can_be_used_as_screwdriver(user))
 				playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 
 				var/input = stripped_input(usr, "Which networks would you like to connect this camera to? seperate networks with a comma. No Spaces!\nFor example: SS13,Security,Secret ", "Set Network", CAMERANET_SS13)

--- a/code/game/machinery/computer/HolodeckControl.dm
+++ b/code/game/machinery/computer/HolodeckControl.dm
@@ -518,7 +518,7 @@
 	return
 
 /obj/structure/window/reinforced/holo/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if(W.can_be_used_as_screwdriver(user))
+	if(W.is_screwdriver(user))
 		to_chat(user, "It's a holowindow! It has no frame!")
 		return
 
@@ -531,7 +531,7 @@
 	return
 
 /obj/structure/window/holo/attackby(obj/item/weapon/W, mob/user)
-	if(W.can_be_used_as_screwdriver(user))
+	if(W.is_screwdriver(user))
 		to_chat(user, "It's a holowindow! It has no frame!")
 		return
 

--- a/code/game/machinery/computer/HolodeckControl.dm
+++ b/code/game/machinery/computer/HolodeckControl.dm
@@ -518,7 +518,7 @@
 	return
 
 /obj/structure/window/reinforced/holo/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if(isscrewdriver(W))
+	if(W.can_be_used_as_screwdriver(user))
 		to_chat(user, "It's a holowindow! It has no frame!")
 		return
 
@@ -531,7 +531,7 @@
 	return
 
 /obj/structure/window/holo/attackby(obj/item/weapon/W, mob/user)
-	if(isscrewdriver(W))
+	if(W.can_be_used_as_screwdriver(user))
 		to_chat(user, "It's a holowindow! It has no frame!")
 		return
 

--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -53,7 +53,7 @@
 					circuit = P
 					state = UNSECURED_CIRCUITBOARD
 		if(UNSECURED_CIRCUITBOARD)
-			if(P.can_be_used_as_screwdriver(user) && circuit)
+			if(P.is_screwdriver(user) && circuit)
 				playsound(loc, 'sound/items/Screwdriver.ogg', 50, 1)
 				to_chat(user, "<span class='notice'>You screw the circuit board into place.</span>")
 				state = SECURED_CIRCUITBOARD
@@ -64,7 +64,7 @@
 				circuit.forceMove(loc)
 				circuit = null
 		if(SECURED_CIRCUITBOARD)
-			if(P.can_be_used_as_screwdriver(user) && circuit)
+			if(P.is_screwdriver(user) && circuit)
 				playsound(loc, 'sound/items/Screwdriver.ogg', 50, 1)
 				to_chat(user, "<span class='notice'>You unfasten the circuit board.</span>")
 				state = UNSECURED_CIRCUITBOARD
@@ -133,7 +133,7 @@
 				to_chat(user, "<span class='notice'>You remove the glass panel.</span>")
 				state = WIREDFRAME
 				drop_stack(/obj/item/stack/sheet/glass/rglass, loc, 2, user)
-			else if(P.can_be_used_as_screwdriver(user))
+			else if(P.is_screwdriver(user))
 				playsound(loc, 'sound/items/Screwdriver.ogg', 50, 1)
 				to_chat(user, "<span class='notice'>You connect the monitor.</span>")
 				var/mob/living/silicon/ai/A = new /mob/living/silicon/ai ( loc, laws, brain )

--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -53,7 +53,7 @@
 					circuit = P
 					state = UNSECURED_CIRCUITBOARD
 		if(UNSECURED_CIRCUITBOARD)
-			if(isscrewdriver(P) && circuit)
+			if(P.can_be_used_as_screwdriver(user) && circuit)
 				playsound(loc, 'sound/items/Screwdriver.ogg', 50, 1)
 				to_chat(user, "<span class='notice'>You screw the circuit board into place.</span>")
 				state = SECURED_CIRCUITBOARD
@@ -64,7 +64,7 @@
 				circuit.forceMove(loc)
 				circuit = null
 		if(SECURED_CIRCUITBOARD)
-			if(isscrewdriver(P) && circuit)
+			if(P.can_be_used_as_screwdriver(user) && circuit)
 				playsound(loc, 'sound/items/Screwdriver.ogg', 50, 1)
 				to_chat(user, "<span class='notice'>You unfasten the circuit board.</span>")
 				state = UNSECURED_CIRCUITBOARD
@@ -133,7 +133,7 @@
 				to_chat(user, "<span class='notice'>You remove the glass panel.</span>")
 				state = WIREDFRAME
 				drop_stack(/obj/item/stack/sheet/glass/rglass, loc, 2, user)
-			else if(isscrewdriver(P))
+			else if(P.can_be_used_as_screwdriver(user))
 				playsound(loc, 'sound/items/Screwdriver.ogg', 50, 1)
 				to_chat(user, "<span class='notice'>You connect the monitor.</span>")
 				var/mob/living/silicon/ai/A = new /mob/living/silicon/ai ( loc, laws, brain )

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -414,7 +414,7 @@
 				else
 					to_chat(user, "<span class='warning'>This frame does not accept circuit boards of this type!</span>")
 				return 1
-			if(isscrewdriver(P) && circuit)
+			if(P.can_be_used_as_screwdriver(user) && circuit)
 				playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 				user.visible_message("[user] screws the circuit board into place.", "You screw the circuit board into place.", "You hear metallic sounds.")
 				src.state = 2
@@ -429,7 +429,7 @@
 				src.circuit = null
 				return 1
 		if(2)
-			if(isscrewdriver(P) && circuit)
+			if(P.can_be_used_as_screwdriver(user) && circuit)
 				playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 				user.visible_message("[user] unfastens the circuit board.", "You unfasten the circuit board.", "You hear metallic sounds.")
 				src.state = 1
@@ -480,7 +480,7 @@
 				src.icon_state = "3"
 				new /obj/item/stack/sheet/glass/glass( src.loc, 2 )
 				return 1
-			if(isscrewdriver(P))
+			if(P.can_be_used_as_screwdriver(user))
 				playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 				if(!circuit.build_path) // the board has been soldered away!
 					to_chat(user, "<span class='warning'>You connect the monitor, but nothing turns on!</span>")

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -414,7 +414,7 @@
 				else
 					to_chat(user, "<span class='warning'>This frame does not accept circuit boards of this type!</span>")
 				return 1
-			if(P.can_be_used_as_screwdriver(user) && circuit)
+			if(P.is_screwdriver(user) && circuit)
 				playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 				user.visible_message("[user] screws the circuit board into place.", "You screw the circuit board into place.", "You hear metallic sounds.")
 				src.state = 2
@@ -429,7 +429,7 @@
 				src.circuit = null
 				return 1
 		if(2)
-			if(P.can_be_used_as_screwdriver(user) && circuit)
+			if(P.is_screwdriver(user) && circuit)
 				playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 				user.visible_message("[user] unfastens the circuit board.", "You unfasten the circuit board.", "You hear metallic sounds.")
 				src.state = 1
@@ -480,7 +480,7 @@
 				src.icon_state = "3"
 				new /obj/item/stack/sheet/glass/glass( src.loc, 2 )
 				return 1
-			if(P.can_be_used_as_screwdriver(user))
+			if(P.is_screwdriver(user))
 				playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 				if(!circuit.build_path) // the board has been soldered away!
 					to_chat(user, "<span class='warning'>You connect the monitor, but nothing turns on!</span>")

--- a/code/game/machinery/computer/cargo.dm
+++ b/code/game/machinery/computer/cargo.dm
@@ -184,12 +184,12 @@ For vending packs, see vending_packs.dm*/
 
 	onclose(user, "computer")
 
-/obj/machinery/computer/supplycomp/attackby(I as obj, user as mob)
+/obj/machinery/computer/supplycomp/attackby(obj/item/I as obj, user as mob)
 	if(istype(I,/obj/item/weapon/card/emag) && !hacked)
 		to_chat(user, "<span class='notice'>Special supplies unlocked.</span>")
 		hacked = 1
 		return
-	if(isscrewdriver(I))
+	if(I.can_be_used_as_screwdriver(user))
 		playsound(loc, 'sound/items/Screwdriver.ogg', 50, 1)
 		if(do_after(user, src, 20))
 			if (stat & BROKEN)

--- a/code/game/machinery/computer/cargo.dm
+++ b/code/game/machinery/computer/cargo.dm
@@ -189,7 +189,7 @@ For vending packs, see vending_packs.dm*/
 		to_chat(user, "<span class='notice'>Special supplies unlocked.</span>")
 		hacked = 1
 		return
-	if(I.can_be_used_as_screwdriver(user))
+	if(I.is_screwdriver(user))
 		playsound(loc, 'sound/items/Screwdriver.ogg', 50, 1)
 		if(do_after(user, src, 20))
 			if (stat & BROKEN)

--- a/code/game/machinery/computer/message.dm
+++ b/code/game/machinery/computer/message.dm
@@ -37,7 +37,7 @@
 /obj/machinery/computer/message_monitor/attackby(obj/item/weapon/O as obj, mob/living/user as mob)
 	if(!istype(user))
 		return
-	if(isscrewdriver(O) && emagged)
+	if(O.can_be_used_as_screwdriver(user) && emagged)
 		//Stops people from just unscrewing the monitor and putting it back to get the console working again.
 		to_chat(user, "<span class='warning'>It is too hot to mess with!</span>")
 		return

--- a/code/game/machinery/computer/message.dm
+++ b/code/game/machinery/computer/message.dm
@@ -37,7 +37,7 @@
 /obj/machinery/computer/message_monitor/attackby(obj/item/weapon/O as obj, mob/living/user as mob)
 	if(!istype(user))
 		return
-	if(O.can_be_used_as_screwdriver(user) && emagged)
+	if(O.is_screwdriver(user) && emagged)
 		//Stops people from just unscrewing the monitor and putting it back to get the console working again.
 		to_chat(user, "<span class='warning'>It is too hot to mess with!</span>")
 		return

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -81,7 +81,7 @@
 					build_state--
 					icon_state = "box_glass"
 					playsound(src, 'sound/items/Crowbar.ogg', 50, 1)
-				if(isscrewdriver(P) && C)
+				if(P.can_be_used_as_screwdriver(user) && C)
 					var/obj/structure/displaycase/new_display_case = new(get_turf(src))
 					new_display_case.circuit = C
 					C.forceMove(new_display_case)
@@ -171,7 +171,7 @@
 					req_components = null
 					components = null
 				else
-					if(isscrewdriver(P))
+					if(P.can_be_used_as_screwdriver(user))
 						if(istype(get_turf(src), /turf/simulated/shuttle))
 							to_chat(user, "<span class='warning'>You must move \the [src] to a more stable location, such as a space station, before you can finish constructing it.</span>")
 							return

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -81,7 +81,7 @@
 					build_state--
 					icon_state = "box_glass"
 					playsound(src, 'sound/items/Crowbar.ogg', 50, 1)
-				if(P.can_be_used_as_screwdriver(user) && C)
+				if(P.is_screwdriver(user) && C)
 					var/obj/structure/displaycase/new_display_case = new(get_turf(src))
 					new_display_case.circuit = C
 					C.forceMove(new_display_case)
@@ -171,7 +171,7 @@
 					req_components = null
 					components = null
 				else
-					if(P.can_be_used_as_screwdriver(user))
+					if(P.is_screwdriver(user))
 						if(istype(get_turf(src), /turf/simulated/shuttle))
 							to_chat(user, "<span class='warning'>You must move \the [src] to a more stable location, such as a space station, before you can finish constructing it.</span>")
 							return

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -362,7 +362,7 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 			investigation_log(I_CHEMS, "was loaded with \a [G] by [key_name(user)], containing [G.reagents.get_reagent_ids(1)]")
 	if(iswrench(G))//FUCK YOU PARENT, YOU AREN'T MY REAL DAD
 		return
-	if(G.can_be_used_as_screwdriver(user))
+	if(G.is_screwdriver(user))
 		if(occupant || on)
 			to_chat(user, "<span class='notice'>The maintenance panel is locked.</span>")
 			return

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -362,7 +362,7 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 			investigation_log(I_CHEMS, "was loaded with \a [G] by [key_name(user)], containing [G.reagents.get_reagent_ids(1)]")
 	if(iswrench(G))//FUCK YOU PARENT, YOU AREN'T MY REAL DAD
 		return
-	if(isscrewdriver(G))
+	if(G.can_be_used_as_screwdriver(user))
 		if(occupant || on)
 			to_chat(user, "<span class='notice'>The maintenance panel is locked.</span>")
 			return

--- a/code/game/machinery/defibcharger.dm
+++ b/code/game/machinery/defibcharger.dm
@@ -99,7 +99,7 @@ obj/machinery/recharger/defibcharger/wallcharger/attackby(obj/item/weapon/G as o
 			charging = G
 			use_power = 2
 			update_icon()
-	else if (G.can_be_used_as_screwdriver(user) || iscrowbar(G))
+	else if (G.is_screwdriver(user) || iscrowbar(G))
 		..()
 	else
 		to_chat(user, "<span class='warning'>\The [G] isn't a defibrillator, it won't fit!</span>")

--- a/code/game/machinery/defibcharger.dm
+++ b/code/game/machinery/defibcharger.dm
@@ -99,7 +99,7 @@ obj/machinery/recharger/defibcharger/wallcharger/attackby(obj/item/weapon/G as o
 			charging = G
 			use_power = 2
 			update_icon()
-	else if (isscrewdriver(G) || iscrowbar(G))
+	else if (G.can_be_used_as_screwdriver(user) || iscrowbar(G))
 		..()
 	else
 		to_chat(user, "<span class='warning'>\The [G] isn't a defibrillator, it won't fit!</span>")

--- a/code/game/machinery/door_control.dm
+++ b/code/game/machinery/door_control.dm
@@ -54,7 +54,7 @@
 	..()
 	..()
 	/* For later implementation
-	if (isscrewdriver(W))
+	if (W.can_be_used_as_screwdriver(user))
 	{
 		if(wiresexposed)
 			icon_state = "doorctrl0"

--- a/code/game/machinery/door_control.dm
+++ b/code/game/machinery/door_control.dm
@@ -54,7 +54,7 @@
 	..()
 	..()
 	/* For later implementation
-	if (W.can_be_used_as_screwdriver(user))
+	if (W.is_screwdriver(user))
 	{
 		if(wiresexposed)
 			icon_state = "doorctrl0"

--- a/code/game/machinery/embedded_controller/embedded_controller_base.dm
+++ b/code/game/machinery/embedded_controller/embedded_controller_base.dm
@@ -37,7 +37,7 @@
 	if(type==/obj/machinery/embedded_controller)
 		switch(build)
 			if(0) // Empty hull
-				if(isscrewdriver(W))
+				if(W.can_be_used_as_screwdriver(user))
 					to_chat(usr, "You begin removing screws from \the [src] backplate...")
 					if(do_after(user, src, 50))
 						to_chat(usr, "<span class='notice'>You unscrew \the [src] from the wall.</span>")
@@ -99,7 +99,7 @@
 						build--
 						update_icon()
 					return 1
-				if(isscrewdriver(W))
+				if(W.can_be_used_as_screwdriver(user))
 					to_chat(user, "You begin to complete \the [src]...")
 					playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 					if(do_after(user, src, 20))

--- a/code/game/machinery/embedded_controller/embedded_controller_base.dm
+++ b/code/game/machinery/embedded_controller/embedded_controller_base.dm
@@ -37,7 +37,7 @@
 	if(type==/obj/machinery/embedded_controller)
 		switch(build)
 			if(0) // Empty hull
-				if(W.can_be_used_as_screwdriver(user))
+				if(W.is_screwdriver(user))
 					to_chat(usr, "You begin removing screws from \the [src] backplate...")
 					if(do_after(user, src, 50))
 						to_chat(usr, "<span class='notice'>You unscrew \the [src] from the wall.</span>")
@@ -99,7 +99,7 @@
 						build--
 						update_icon()
 					return 1
-				if(W.can_be_used_as_screwdriver(user))
+				if(W.is_screwdriver(user))
 					to_chat(user, "You begin to complete \the [src]...")
 					playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 					if(do_after(user, src, 20))

--- a/code/game/machinery/igniter.dm
+++ b/code/game/machinery/igniter.dm
@@ -116,7 +116,7 @@ var/global/list/igniters = list()
 /obj/machinery/sparker/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(istype(W, /obj/item/device/detective_scanner))
 		return
-	if (W.can_be_used_as_screwdriver(user))
+	if (W.is_screwdriver(user))
 		add_fingerprint(user)
 		src.disable = !src.disable
 		if (src.disable)

--- a/code/game/machinery/igniter.dm
+++ b/code/game/machinery/igniter.dm
@@ -116,7 +116,7 @@ var/global/list/igniters = list()
 /obj/machinery/sparker/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(istype(W, /obj/item/device/detective_scanner))
 		return
-	if (isscrewdriver(W))
+	if (W.can_be_used_as_screwdriver(user))
 		add_fingerprint(user)
 		src.disable = !src.disable
 		if (src.disable)

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -85,7 +85,7 @@
 ********************/
 /obj/machinery/microwave/attackby(var/obj/item/O as obj, var/mob/user as mob)
 	if(src.broken > 0)
-		if(src.broken == 2 && O.can_be_used_as_screwdriver(user)) // If it's broken and they're using a screwdriver
+		if(src.broken == 2 && O.is_screwdriver(user)) // If it's broken and they're using a screwdriver
 			user.visible_message( \
 				"<span class='notice'>[user] starts to fix part of the microwave.</span>", \
 				"<span class='notice'>You start to fix part of the microwave.</span>" \

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -85,7 +85,7 @@
 ********************/
 /obj/machinery/microwave/attackby(var/obj/item/O as obj, var/mob/user as mob)
 	if(src.broken > 0)
-		if(src.broken == 2 && isscrewdriver(O)) // If it's broken and they're using a screwdriver
+		if(src.broken == 2 && O.can_be_used_as_screwdriver(user)) // If it's broken and they're using a screwdriver
 			user.visible_message( \
 				"<span class='notice'>[user] starts to fix part of the microwave.</span>", \
 				"<span class='notice'>You start to fix part of the microwave.</span>" \

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -55,7 +55,7 @@
 /obj/machinery/light_switch/attackby(obj/item/W as obj, mob/user as mob)
 	switch(buildstage)
 		if(2)
-			if(W.can_be_used_as_screwdriver(user))
+			if(W.is_screwdriver(user))
 				to_chat(user, "You begin unscrewing \the [src].")
 				playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 				if(do_after(user, src,10) && buildstage == 2)
@@ -65,7 +65,7 @@
 					on = this_area.lightswitch
 			return
 		if(1)
-			if(W.can_be_used_as_screwdriver(user))
+			if(W.is_screwdriver(user))
 				to_chat(user, "You begin screwing closed \the [src].")
 				playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 				if(do_after(user, src,10) && buildstage == 1)

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -55,7 +55,7 @@
 /obj/machinery/light_switch/attackby(obj/item/W as obj, mob/user as mob)
 	switch(buildstage)
 		if(2)
-			if(isscrewdriver(W))
+			if(W.can_be_used_as_screwdriver(user))
 				to_chat(user, "You begin unscrewing \the [src].")
 				playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 				if(do_after(user, src,10) && buildstage == 2)
@@ -65,7 +65,7 @@
 					on = this_area.lightswitch
 			return
 		if(1)
-			if(isscrewdriver(W))
+			if(W.can_be_used_as_screwdriver(user))
 				to_chat(user, "You begin screwing closed \the [src].")
 				playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 				if(do_after(user, src,10) && buildstage == 1)

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -490,7 +490,7 @@ Class Procs:
 	spillContents(destroy_chance)
 	qdel(src)
 
-/obj/machinery/proc/togglePanelOpen(var/obj/toggleitem, var/mob/user)
+/obj/machinery/proc/togglePanelOpen(var/obj/item/toggleitem, var/mob/user)
 	panel_open = !panel_open
 	if(panel_open)
 		if(icon_state_open)
@@ -499,7 +499,7 @@ Class Procs:
 		if(icon_state_open)	//don't need to reset the icon_state if it was never changed
 			icon_state = initial(icon_state)
 	to_chat(user, "<span class='notice'>[bicon(src)] You [panel_open ? "open" : "close"] the maintenance hatch of \the [src].</span>")
-	if(isscrewdriver(toggleitem))
+	if(toggleitem.can_be_used_as_screwdriver(user))
 		playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
 	update_icon()
 	return 1
@@ -566,7 +566,7 @@ Class Procs:
 /obj/machinery/proc/getEmagCost(var/mob/user, var/obj/item/weapon/card/emag/emag)
 	return emag_cost
 
-/obj/machinery/attackby(var/obj/O, var/mob/user)
+/obj/machinery/attackby(var/obj/item/O, var/mob/user)
 	..()
 	if(istype(O, /obj/item/weapon/card/emag) && machine_flags & EMAGGABLE)
 		var/obj/item/weapon/card/emag/E = O
@@ -588,7 +588,7 @@ Class Procs:
 			to_chat(user, "<span class='warning'>\The [src]'s maintenance panel must be closed first!</span>")
 			return -1 //we return -1 rather than 0 for the if(..()) checks
 
-	if(isscrewdriver(O) && machine_flags & SCREWTOGGLE)
+	if(O.can_be_used_as_screwdriver(user) && machine_flags & SCREWTOGGLE)
 		if(machine_flags & SECUREDPANEL)
 			return toggleSecuredPanelOpen(O, user)
 		return togglePanelOpen(O, user)

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -499,7 +499,7 @@ Class Procs:
 		if(icon_state_open)	//don't need to reset the icon_state if it was never changed
 			icon_state = initial(icon_state)
 	to_chat(user, "<span class='notice'>[bicon(src)] You [panel_open ? "open" : "close"] the maintenance hatch of \the [src].</span>")
-	if(toggleitem.can_be_used_as_screwdriver(user))
+	if(toggleitem.is_screwdriver(user))
 		playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
 	update_icon()
 	return 1
@@ -588,7 +588,7 @@ Class Procs:
 			to_chat(user, "<span class='warning'>\The [src]'s maintenance panel must be closed first!</span>")
 			return -1 //we return -1 rather than 0 for the if(..()) checks
 
-	if(O.can_be_used_as_screwdriver(user) && machine_flags & SCREWTOGGLE)
+	if(O.is_screwdriver(user) && machine_flags & SCREWTOGGLE)
 		if(machine_flags & SECUREDPANEL)
 			return toggleSecuredPanelOpen(O, user)
 		return togglePanelOpen(O, user)

--- a/code/game/machinery/mass_driver.dm
+++ b/code/game/machinery/mass_driver.dm
@@ -40,7 +40,7 @@ var/list/mass_drivers = list()
 	if(.)
 		return .
 
-	if(isscrewdriver(W))
+	if(W.can_be_used_as_screwdriver(user))
 		to_chat(user, "You begin to unscrew the bolts off the [src]...")
 		playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 		if(do_after(user, src, 30))
@@ -220,7 +220,7 @@ var/list/mass_drivers = list()
 					build--
 					update_icon()
 				return 1
-			if(isscrewdriver(W))
+			if(W.can_be_used_as_screwdriver(user))
 				to_chat(user, "You finalize the Mass Driver...")
 				playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 				var/obj/machinery/mass_driver/M = new(get_turf(src))

--- a/code/game/machinery/mass_driver.dm
+++ b/code/game/machinery/mass_driver.dm
@@ -40,7 +40,7 @@ var/list/mass_drivers = list()
 	if(.)
 		return .
 
-	if(W.can_be_used_as_screwdriver(user))
+	if(W.is_screwdriver(user))
 		to_chat(user, "You begin to unscrew the bolts off the [src]...")
 		playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 		if(do_after(user, src, 30))
@@ -220,7 +220,7 @@ var/list/mass_drivers = list()
 					build--
 					update_icon()
 				return 1
-			if(W.can_be_used_as_screwdriver(user))
+			if(W.is_screwdriver(user))
 				to_chat(user, "You finalize the Mass Driver...")
 				playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 				var/obj/machinery/mass_driver/M = new(get_turf(src))

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -891,13 +891,13 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 					qdel(src)
 					return
 
-			if(I.can_be_used_as_screwdriver(user) && !(stat & BROKEN))
+			if(I.is_screwdriver(user) && !(stat & BROKEN))
 				user.visible_message("<span class='notice'>[user] screws in the [src]!</span>", "<span class='notice'>You screw in the [src]</span>")
 				playsound(src, 'sound/items/Screwdriver.ogg', 100, 1)
 				buildstage = 1
 
 		if(1)
-			if(I.can_be_used_as_screwdriver(user) && !(stat & BROKEN))
+			if(I.is_screwdriver(user) && !(stat & BROKEN))
 				user.visible_message("<span class='notice'>[user] unscrews the [src]!</span>", "<span class='notice'>You unscrew the [src]</span>")
 				playsound(src, 'sound/items/Screwdriver.ogg', 100, 1)
 				buildstage = 0

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -891,13 +891,13 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 					qdel(src)
 					return
 
-			if(isscrewdriver(I) && !(stat & BROKEN))
+			if(I.can_be_used_as_screwdriver(user) && !(stat & BROKEN))
 				user.visible_message("<span class='notice'>[user] screws in the [src]!</span>", "<span class='notice'>You screw in the [src]</span>")
 				playsound(src, 'sound/items/Screwdriver.ogg', 100, 1)
 				buildstage = 1
 
 		if(1)
-			if(isscrewdriver(I) && !(stat & BROKEN))
+			if(I.can_be_used_as_screwdriver(user) && !(stat & BROKEN))
 				user.visible_message("<span class='notice'>[user] unscrews the [src]!</span>", "<span class='notice'>You unscrew the [src]</span>")
 				playsound(src, 'sound/items/Screwdriver.ogg', 100, 1)
 				buildstage = 0

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -734,7 +734,7 @@ Status: []<BR>"},
 			// attack_hand() removes the gun
 
 		if(5)
-			if(W.can_be_used_as_screwdriver(user))
+			if(W.is_screwdriver(user))
 				playsound(src, 'sound/items/Screwdriver.ogg', 100, 1)
 				build_step = 6
 				to_chat(user, "<span class='notice'>You close the internal access hatch.</span>")
@@ -753,7 +753,7 @@ Status: []<BR>"},
 					to_chat(user, "<span class='warning'>You need at least 2 [stack] to add external armor.</span>")
 					return
 
-			else if(W.can_be_used_as_screwdriver(user))
+			else if(W.is_screwdriver(user))
 				playsound(src, 'sound/items/Screwdriver.ogg', 100, 1)
 				build_step = 5
 				to_chat(user, "You open the internal access hatch.")

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -734,7 +734,7 @@ Status: []<BR>"},
 			// attack_hand() removes the gun
 
 		if(5)
-			if(isscrewdriver(W))
+			if(W.can_be_used_as_screwdriver(user))
 				playsound(src, 'sound/items/Screwdriver.ogg', 100, 1)
 				build_step = 6
 				to_chat(user, "<span class='notice'>You close the internal access hatch.</span>")
@@ -753,7 +753,7 @@ Status: []<BR>"},
 					to_chat(user, "<span class='warning'>You need at least 2 [stack] to add external armor.</span>")
 					return
 
-			else if(isscrewdriver(W))
+			else if(W.can_be_used_as_screwdriver(user))
 				playsound(src, 'sound/items/Screwdriver.ogg', 100, 1)
 				build_step = 5
 				to_chat(user, "You open the internal access hatch.")

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -431,7 +431,7 @@ var/list/obj/machinery/requests_console/allConsoles = list()
 				icon_state="req_comp_open"
 			else
 				icon_state="req_comp_rewired"
-	if (isscrewdriver(O))
+	if (O.can_be_used_as_screwdriver(user))
 		if(open)
 			if(!hackState)
 				hackState = 1

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -431,7 +431,7 @@ var/list/obj/machinery/requests_console/allConsoles = list()
 				icon_state="req_comp_open"
 			else
 				icon_state="req_comp_rewired"
-	if (O.can_be_used_as_screwdriver(user))
+	if (O.is_screwdriver(user))
 		if(open)
 			if(!hackState)
 				hackState = 1

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1739,7 +1739,7 @@ var/global/num_vending_terminals = 1
 /obj/machinery/wallmed_frame/attackby(var/obj/item/W as obj, var/mob/user as mob)
 	switch(build)
 		if(0) // Empty hull
-			if(isscrewdriver(W))
+			if(W.can_be_used_as_screwdriver(user))
 				to_chat(usr, "You begin removing screws from \the [src] backplate...")
 				if(do_after(user, src, 50))
 					to_chat(usr, "<span class='notice'>You unscrew \the [src] from the wall.</span>")
@@ -1801,7 +1801,7 @@ var/global/num_vending_terminals = 1
 					build--
 					update_icon()
 				return 1
-			if(isscrewdriver(W))
+			if(W.can_be_used_as_screwdriver(user))
 				to_chat(user, "You begin to complete \the [src]...")
 				playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 				if(do_after(user, src, 20))
@@ -1814,7 +1814,7 @@ var/global/num_vending_terminals = 1
 						"You finish \the [src].")
 				return 1
 		if(3) // Waiting for a recharge pack
-			if(isscrewdriver(W))
+			if(W.can_be_used_as_screwdriver(user))
 				to_chat(user, "You begin to unscrew \the [src]...")
 				playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 				if(do_after(user, src, 30))

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1739,7 +1739,7 @@ var/global/num_vending_terminals = 1
 /obj/machinery/wallmed_frame/attackby(var/obj/item/W as obj, var/mob/user as mob)
 	switch(build)
 		if(0) // Empty hull
-			if(W.can_be_used_as_screwdriver(user))
+			if(W.is_screwdriver(user))
 				to_chat(usr, "You begin removing screws from \the [src] backplate...")
 				if(do_after(user, src, 50))
 					to_chat(usr, "<span class='notice'>You unscrew \the [src] from the wall.</span>")
@@ -1801,7 +1801,7 @@ var/global/num_vending_terminals = 1
 					build--
 					update_icon()
 				return 1
-			if(W.can_be_used_as_screwdriver(user))
+			if(W.is_screwdriver(user))
 				to_chat(user, "You begin to complete \the [src]...")
 				playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 				if(do_after(user, src, 20))
@@ -1814,7 +1814,7 @@ var/global/num_vending_terminals = 1
 						"You finish \the [src].")
 				return 1
 		if(3) // Waiting for a recharge pack
-			if(W.can_be_used_as_screwdriver(user))
+			if(W.is_screwdriver(user))
 				to_chat(user, "You begin to unscrew \the [src]...")
 				playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 				if(do_after(user, src, 30))

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -892,7 +892,7 @@
 			else
 				to_chat(user, "There's not enough wire to finish the task.")
 		return
-	else if(isscrewdriver(W))
+	else if(W.can_be_used_as_screwdriver(user))
 		if(hasInternalDamage(MECHA_INT_TEMP_CONTROL))
 			clearInternalDamage(MECHA_INT_TEMP_CONTROL)
 			to_chat(user, "You repair the damaged temperature controller.")

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -892,7 +892,7 @@
 			else
 				to_chat(user, "There's not enough wire to finish the task.")
 		return
-	else if(W.can_be_used_as_screwdriver(user))
+	else if(W.is_screwdriver(user))
 		if(hasInternalDamage(MECHA_INT_TEMP_CONTROL))
 			clearInternalDamage(MECHA_INT_TEMP_CONTROL)
 			to_chat(user, "You repair the damaged temperature controller.")

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1343,3 +1343,6 @@ var/global/list/image/blood_overlays = list()
 
 /obj/item/proc/recharger_process(var/obj/machinery/recharger/charger)
 	return
+
+/obj/item/proc/can_be_used_as_screwdriver(var/mob/user)
+	return FALSE

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1344,5 +1344,5 @@ var/global/list/image/blood_overlays = list()
 /obj/item/proc/recharger_process(var/obj/machinery/recharger/charger)
 	return
 
-/obj/item/proc/can_be_used_as_screwdriver(var/mob/user)
+/obj/item/proc/is_screwdriver(var/mob/user)
 	return FALSE

--- a/code/game/objects/items/devices/holomap.dm
+++ b/code/game/objects/items/devices/holomap.dm
@@ -80,7 +80,7 @@
 	to_chat(user, "You reset the holomap data.")
 
 /obj/item/device/holomap/attackby(obj/item/W, mob/user)
-	if (W.can_be_used_as_screwdriver(user))
+	if (W.is_screwdriver(user))
 		panel = !panel
 		to_chat(user, "<span class='notify'>You [panel ? "open" : "close"] the panel on \the [src].</span>")
 		playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)

--- a/code/game/objects/items/devices/holomap.dm
+++ b/code/game/objects/items/devices/holomap.dm
@@ -80,7 +80,7 @@
 	to_chat(user, "You reset the holomap data.")
 
 /obj/item/device/holomap/attackby(obj/item/W, mob/user)
-	if (isscrewdriver(W))
+	if (W.can_be_used_as_screwdriver(user))
 		panel = !panel
 		to_chat(user, "<span class='notify'>You [panel ? "open" : "close"] the panel on \the [src].</span>")
 		playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)

--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -24,7 +24,7 @@
 	var/obj/structure/cable/attached		// the attached cable
 
 	attackby(var/obj/item/I, var/mob/user)
-		if(isscrewdriver(I))
+		if(I.can_be_used_as_screwdriver(user))
 			if(mode == 0)
 				var/turf/T = loc
 				if(isturf(T) && !T.intact)

--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -24,7 +24,7 @@
 	var/obj/structure/cable/attached		// the attached cable
 
 	attackby(var/obj/item/I, var/mob/user)
-		if(I.can_be_used_as_screwdriver(user))
+		if(I.is_screwdriver(user))
 			if(mode == 0)
 				var/turf/T = loc
 				if(isturf(T) && !T.intact)

--- a/code/game/objects/items/devices/radio/cyborg.dm
+++ b/code/game/objects/items/devices/radio/cyborg.dm
@@ -18,10 +18,10 @@
 /obj/item/device/radio/borg/attackby(obj/item/weapon/W as obj, mob/user as mob)
 //	..()
 	user.set_machine(src)
-	if (!( isscrewdriver(W) || (istype(W, /obj/item/device/encryptionkey/ ))))
+	if (!( W.can_be_used_as_screwdriver(user) || (istype(W, /obj/item/device/encryptionkey/ ))))
 		return
 
-	if(isscrewdriver(W))
+	if(W.can_be_used_as_screwdriver(user))
 		if(keyslot)
 
 

--- a/code/game/objects/items/devices/radio/cyborg.dm
+++ b/code/game/objects/items/devices/radio/cyborg.dm
@@ -18,10 +18,10 @@
 /obj/item/device/radio/borg/attackby(obj/item/weapon/W as obj, mob/user as mob)
 //	..()
 	user.set_machine(src)
-	if (!( W.can_be_used_as_screwdriver(user) || (istype(W, /obj/item/device/encryptionkey/ ))))
+	if (!( W.is_screwdriver(user) || (istype(W, /obj/item/device/encryptionkey/ ))))
 		return
 
-	if(W.can_be_used_as_screwdriver(user))
+	if(W.is_screwdriver(user))
 		if(keyslot)
 
 

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -287,10 +287,10 @@
 /obj/item/device/radio/headset/attackby(obj/item/weapon/W as obj, mob/user as mob)
 //	..()
 	user.set_machine(src)
-	if (!( W.can_be_used_as_screwdriver(user) || (istype(W, /obj/item/device/encryptionkey/ ))))
+	if (!( W.is_screwdriver(user) || (istype(W, /obj/item/device/encryptionkey/ ))))
 		return
 
-	if(W.can_be_used_as_screwdriver(user))
+	if(W.is_screwdriver(user))
 		if(keyslot1 || keyslot2)
 
 

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -287,10 +287,10 @@
 /obj/item/device/radio/headset/attackby(obj/item/weapon/W as obj, mob/user as mob)
 //	..()
 	user.set_machine(src)
-	if (!( isscrewdriver(W) || (istype(W, /obj/item/device/encryptionkey/ ))))
+	if (!( W.can_be_used_as_screwdriver(user) || (istype(W, /obj/item/device/encryptionkey/ ))))
 		return
 
-	if(isscrewdriver(W))
+	if(W.can_be_used_as_screwdriver(user))
 		if(keyslot1 || keyslot2)
 
 

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -95,7 +95,7 @@
 			else
 				return ..()
 		if(2)
-			if(isscrewdriver(W))
+			if(W.can_be_used_as_screwdriver(user))
 				playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 				if(do_after(user, src, 10))
 					update_icon()

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -95,7 +95,7 @@
 			else
 				return ..()
 		if(2)
-			if(W.can_be_used_as_screwdriver(user))
+			if(W.is_screwdriver(user))
 				playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 				if(do_after(user, src, 10))
 					update_icon()

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -529,7 +529,7 @@
 /obj/item/device/radio/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	..()
 	user.set_machine(src)
-	if (!( W.can_be_used_as_screwdriver(user) ))
+	if (!( W.is_screwdriver(user) ))
 		return
 	b_stat = !( b_stat )
 	if (b_stat)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -529,7 +529,7 @@
 /obj/item/device/radio/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	..()
 	user.set_machine(src)
-	if (!( isscrewdriver(W) ))
+	if (!( W.can_be_used_as_screwdriver(user) ))
 		return
 	b_stat = !( b_stat )
 	if (b_stat)

--- a/code/game/objects/items/weapons/RCL.dm
+++ b/code/game/objects/items/weapons/RCL.dm
@@ -32,7 +32,7 @@
 			loaded.preattack(W,user,1)
 		update_icon()
 		to_chat(user, "<span class='notice'>You add the cables to the [src]. It now contains [loaded.amount].</span>")
-	else if(isscrewdriver(W))
+	else if(W.can_be_used_as_screwdriver(user))
 		if(!loaded)
 			return
 		to_chat(user, "<span class='notice'>You loosen the securing screws on the side, allowing you to lower the guiding edge and retrieve the wires.</span>")

--- a/code/game/objects/items/weapons/RCL.dm
+++ b/code/game/objects/items/weapons/RCL.dm
@@ -32,7 +32,7 @@
 			loaded.preattack(W,user,1)
 		update_icon()
 		to_chat(user, "<span class='notice'>You add the cables to the [src]. It now contains [loaded.amount].</span>")
-	else if(W.can_be_used_as_screwdriver(user))
+	else if(W.is_screwdriver(user))
 		if(!loaded)
 			return
 		to_chat(user, "<span class='notice'>You loosen the securing screws on the side, allowing you to lower the guiding edge and retrieve the wires.</span>")

--- a/code/game/objects/items/weapons/explosives.dm
+++ b/code/game/objects/items/weapons/explosives.dm
@@ -44,7 +44,7 @@
 	return .
 
 /obj/item/weapon/plastique/attackby(var/obj/item/I, var/mob/user)
-	if(I.can_be_used_as_screwdriver(user))
+	if(I.is_screwdriver(user))
 		open_panel = !open_panel
 		to_chat(user, "<span class='notice'>You [open_panel ? "open" : "close"] the wire panel.</span>")
 	else if(iswiretool(I))

--- a/code/game/objects/items/weapons/explosives.dm
+++ b/code/game/objects/items/weapons/explosives.dm
@@ -44,7 +44,7 @@
 	return .
 
 /obj/item/weapon/plastique/attackby(var/obj/item/I, var/mob/user)
-	if(isscrewdriver(I))
+	if(I.can_be_used_as_screwdriver(user))
 		open_panel = !open_panel
 		to_chat(user, "<span class='notice'>You [open_panel ? "open" : "close"] the wire panel.</span>")
 	else if(iswiretool(I))

--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -99,7 +99,7 @@
 
 
 /obj/item/weapon/grenade/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if(isscrewdriver(W))
+	if(W.can_be_used_as_screwdriver(user))
 		if(active)
 			to_chat(user, "<span class = 'warning'>It's already primed!</span>")
 			return

--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -99,7 +99,7 @@
 
 
 /obj/item/weapon/grenade/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if(W.can_be_used_as_screwdriver(user))
+	if(W.is_screwdriver(user))
 		if(active)
 			to_chat(user, "<span class = 'warning'>It's already primed!</span>")
 			return

--- a/code/game/objects/items/weapons/storage/briefcase.dm
+++ b/code/game/objects/items/weapons/storage/briefcase.dm
@@ -92,7 +92,7 @@
 	return
 
 /obj/item/weapon/storage/briefcase/false_bottomed/attackby(var/obj/item/item, mob/user)
-	if(isscrewdriver(item))
+	if(item.can_be_used_as_screwdriver(user))
 		if(!bottom_open && !busy_hunting)
 			to_chat(user, "You begin to hunt around the rim of \the [src]...")
 			busy_hunting = 1

--- a/code/game/objects/items/weapons/storage/briefcase.dm
+++ b/code/game/objects/items/weapons/storage/briefcase.dm
@@ -92,7 +92,7 @@
 	return
 
 /obj/item/weapon/storage/briefcase/false_bottomed/attackby(var/obj/item/item, mob/user)
-	if(item.can_be_used_as_screwdriver(user))
+	if(item.is_screwdriver(user))
 		if(!bottom_open && !busy_hunting)
 			to_chat(user, "You begin to hunt around the rim of \the [src]...")
 			busy_hunting = 1

--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -47,7 +47,7 @@
 			to_chat(user, "You short out the lock on [src].")
 			return
 
-		if (isscrewdriver(W))
+		if (W.can_be_used_as_screwdriver(user))
 			if (do_after(user, src, 20))
 				src.open =! src.open
 				user.show_message(text("<span class='notice'>You [] the service panel.</span>", (src.open ? "open" : "close")))

--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -47,7 +47,7 @@
 			to_chat(user, "You short out the lock on [src].")
 			return
 
-		if (W.can_be_used_as_screwdriver(user))
+		if (W.is_screwdriver(user))
 			if (do_after(user, src, 20))
 				src.open =! src.open
 				user.show_message(text("<span class='notice'>You [] the service panel.</span>", (src.open ? "open" : "close")))

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -89,7 +89,7 @@
 		else
 			to_chat(user, "<span class='notice'>[src] already has a cell.</span>")
 
-	else if(isscrewdriver(W))
+	else if(W.can_be_used_as_screwdriver(user))
 		if(bcell)
 			bcell.updateicon()
 			bcell.forceMove(get_turf(src.loc))

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -89,7 +89,7 @@
 		else
 			to_chat(user, "<span class='notice'>[src] already has a cell.</span>")
 
-	else if(W.can_be_used_as_screwdriver(user))
+	else if(W.is_screwdriver(user))
 		if(bcell)
 			bcell.updateicon()
 			bcell.forceMove(get_turf(src.loc))

--- a/code/game/objects/items/weapons/surgery_tools.dm
+++ b/code/game/objects/items/weapons/surgery_tools.dm
@@ -217,7 +217,7 @@
 		to_chat(user, "\The [src] is in cautery mode.")
 
 /obj/item/weapon/scalpel/laser/attackby(var/obj/item/used_item, mob/user)
-	if(isscrewdriver(used_item) && cauterymode)
+	if(used_item.can_be_used_as_screwdriver(user) && cauterymode)
 		if(held)
 			to_chat(user, "<span class='notice'>You detach \the [held] and \the [src] switches to cutting mode.</span>")
 			playsound(src, "sound/items/screwdriver.ogg", 10, 1)

--- a/code/game/objects/items/weapons/surgery_tools.dm
+++ b/code/game/objects/items/weapons/surgery_tools.dm
@@ -217,7 +217,7 @@
 		to_chat(user, "\The [src] is in cautery mode.")
 
 /obj/item/weapon/scalpel/laser/attackby(var/obj/item/used_item, mob/user)
-	if(used_item.can_be_used_as_screwdriver(user) && cauterymode)
+	if(used_item.is_screwdriver(user) && cauterymode)
 		if(held)
 			to_chat(user, "<span class='notice'>You detach \the [held] and \the [src] switches to cutting mode.</span>")
 			playsound(src, "sound/items/screwdriver.ogg", 10, 1)

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -161,6 +161,9 @@
 			to_chat(usr, "<span class='warning'>You cannot do that.</span>")
 	else
 		..()
+
+/obj/item/weapon/screwdriver/can_be_used_as_screwdriver(var/mob/user)
+	return TRUE
 /*
  * Wirecutters
  */

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -162,7 +162,7 @@
 	else
 		..()
 
-/obj/item/weapon/screwdriver/can_be_used_as_screwdriver(var/mob/user)
+/obj/item/weapon/screwdriver/is_screwdriver(var/mob/user)
 	return TRUE
 /*
  * Wirecutters

--- a/code/game/objects/structures/catwalk.dm
+++ b/code/game/objects/structures/catwalk.dm
@@ -48,7 +48,7 @@
 /obj/structure/catwalk/attackby(obj/item/C as obj, mob/user as mob)
 	if(!C || !user)
 		return 0
-	if(C.can_be_used_as_screwdriver(user))
+	if(C.is_screwdriver(user))
 		to_chat(user, "<span class='notice'>You begin undoing the screws holding the catwalk together.</span>")
 		playsound(src, 'sound/items/Screwdriver.ogg', 80, 1)
 		if(do_after(user, src, 30) && src)

--- a/code/game/objects/structures/catwalk.dm
+++ b/code/game/objects/structures/catwalk.dm
@@ -48,7 +48,7 @@
 /obj/structure/catwalk/attackby(obj/item/C as obj, mob/user as mob)
 	if(!C || !user)
 		return 0
-	if(isscrewdriver(C))
+	if(C.can_be_used_as_screwdriver(user))
 		to_chat(user, "<span class='notice'>You begin undoing the screws holding the catwalk together.</span>")
 		playsound(src, 'sound/items/Screwdriver.ogg', 80, 1)
 		if(do_after(user, src, 30) && src)

--- a/code/game/objects/structures/curtains.dm
+++ b/code/game/objects/structures/curtains.dm
@@ -58,7 +58,7 @@
 				getFromPool(/obj/item/stack/sheet/mineral/plastic, get_turf(src), 4)
 			qdel(src)
 		return 1
-	if(isscrewdriver(W))
+	if(W.can_be_used_as_screwdriver(user))
 		playsound(loc, 'sound/items/Screwdriver.ogg', 50, 1)
 		user.visible_message("[user] [anchored? "unsecures" : "secures"] \the [src].", "You [anchored? "unsecure" : "secure"] \the [src].")
 		anchored = !anchored

--- a/code/game/objects/structures/curtains.dm
+++ b/code/game/objects/structures/curtains.dm
@@ -58,7 +58,7 @@
 				getFromPool(/obj/item/stack/sheet/mineral/plastic, get_turf(src), 4)
 			qdel(src)
 		return 1
-	if(W.can_be_used_as_screwdriver(user))
+	if(W.is_screwdriver(user))
 		playsound(loc, 'sound/items/Screwdriver.ogg', 50, 1)
 		user.visible_message("[user] [anchored? "unsecures" : "secures"] \the [src].", "You [anchored? "unsecure" : "secure"] \the [src].")
 		anchored = !anchored

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -323,7 +323,7 @@
 							glass = "[M]"
 				busy = 0
 
-	else if(isscrewdriver(W) && state == 2 )
+	else if(W.can_be_used_as_screwdriver(user) && state == 2 )
 		busy = 1
 		playsound(src, 'sound/items/Screwdriver.ogg', 100, 1)
 		to_chat(user, "<span class='notice'>Now finishing the airlock.</span>")

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -323,7 +323,7 @@
 							glass = "[M]"
 				busy = 0
 
-	else if(W.can_be_used_as_screwdriver(user) && state == 2 )
+	else if(W.is_screwdriver(user) && state == 2 )
 		busy = 1
 		playsound(src, 'sound/items/Screwdriver.ogg', 100, 1)
 		to_chat(user, "<span class='notice'>Now finishing the airlock.</span>")

--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -187,7 +187,7 @@
 		if(T.density)
 			to_chat(user, "<span class='warning'>The wall is blocked!</span>")
 			return
-		if(isscrewdriver(W))
+		if(W.can_be_used_as_screwdriver(user))
 			user.visible_message("[user] tightens some bolts on the wall.", "You tighten the bolts on the wall.")
 			if(!mineral || mineral == "metal")
 				T.ChangeTurf(/turf/simulated/wall)
@@ -301,7 +301,7 @@
 		to_chat(user, "<span class='warning'>You must wait until the door has stopped moving.</span>")
 		return
 
-	if(isscrewdriver(W))
+	if(W.can_be_used_as_screwdriver(user))
 		var/turf/T = get_turf(src)
 		user.visible_message("[user] tightens some bolts on the r wall.", "You tighten the bolts on the wall.")
 		T.ChangeTurf(/turf/simulated/wall/r_wall) //Why not make rwall?

--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -187,7 +187,7 @@
 		if(T.density)
 			to_chat(user, "<span class='warning'>The wall is blocked!</span>")
 			return
-		if(W.can_be_used_as_screwdriver(user))
+		if(W.is_screwdriver(user))
 			user.visible_message("[user] tightens some bolts on the wall.", "You tighten the bolts on the wall.")
 			if(!mineral || mineral == "metal")
 				T.ChangeTurf(/turf/simulated/wall)
@@ -301,7 +301,7 @@
 		to_chat(user, "<span class='warning'>You must wait until the door has stopped moving.</span>")
 		return
 
-	if(W.can_be_used_as_screwdriver(user))
+	if(W.is_screwdriver(user))
 		var/turf/T = get_turf(src)
 		user.visible_message("[user] tightens some bolts on the r wall.", "You tighten the bolts on the wall.")
 		T.ChangeTurf(/turf/simulated/wall/r_wall) //Why not make rwall?

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -89,7 +89,7 @@
 			getFromPool(material, get_turf(src))
 			qdel(src)
 
-	else if(W.can_be_used_as_screwdriver(user) && state == 2) //Unsecuring support struts, stage 2 to 1
+	else if(W.is_screwdriver(user) && state == 2) //Unsecuring support struts, stage 2 to 1
 		playsound(src, 'sound/items/Screwdriver.ogg', 100, 1)
 		user.visible_message("<span class='warning'>[user] starts unsecuring \the [src]'s internal support struts.</span>", \
 		"<span class='notice'>You start unsecuring \the [src]'s internal support struts.</span>")
@@ -101,7 +101,7 @@
 			state = 1
 			update_icon()
 
-	else if(W.can_be_used_as_screwdriver(user) && state == 1) //Securing support struts, stage 1 to 2
+	else if(W.is_screwdriver(user) && state == 1) //Securing support struts, stage 1 to 2
 		playsound(src, 'sound/items/Screwdriver.ogg', 100, 1)
 		user.visible_message("<span class='notice'>[user] starts securing \the [src]'s internal support struts.</span>", \
 		"<span class='notice'>You start securing \the [src]'s internal support struts.</span>")

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -89,7 +89,7 @@
 			getFromPool(material, get_turf(src))
 			qdel(src)
 
-	else if(isscrewdriver(W) && state == 2) //Unsecuring support struts, stage 2 to 1
+	else if(W.can_be_used_as_screwdriver(user) && state == 2) //Unsecuring support struts, stage 2 to 1
 		playsound(src, 'sound/items/Screwdriver.ogg', 100, 1)
 		user.visible_message("<span class='warning'>[user] starts unsecuring \the [src]'s internal support struts.</span>", \
 		"<span class='notice'>You start unsecuring \the [src]'s internal support struts.</span>")
@@ -101,7 +101,7 @@
 			state = 1
 			update_icon()
 
-	else if(isscrewdriver(W) && state == 1) //Securing support struts, stage 1 to 2
+	else if(W.can_be_used_as_screwdriver(user) && state == 1) //Securing support struts, stage 1 to 2
 		playsound(src, 'sound/items/Screwdriver.ogg', 100, 1)
 		user.visible_message("<span class='notice'>[user] starts securing \the [src]'s internal support struts.</span>", \
 		"<span class='notice'>You start securing \the [src]'s internal support struts.</span>")

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -177,7 +177,7 @@
 			qdel(src)
 			return
 		return //Return in case the user starts cutting and gets shocked, so that it doesn't continue downwards !
-	else if((isscrewdriver(W)) && (istype(loc, /turf/simulated) || anchored))
+	else if((W.can_be_used_as_screwdriver(user)) && (istype(loc, /turf/simulated) || anchored))
 		if(!shock(user, 90, W.siemens_coefficient))
 			playsound(loc, 'sound/items/Screwdriver.ogg', 100, 1)
 			anchored = !anchored

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -177,7 +177,7 @@
 			qdel(src)
 			return
 		return //Return in case the user starts cutting and gets shocked, so that it doesn't continue downwards !
-	else if((W.can_be_used_as_screwdriver(user)) && (istype(loc, /turf/simulated) || anchored))
+	else if((W.is_screwdriver(user)) && (istype(loc, /turf/simulated) || anchored))
 		if(!shock(user, 90, W.siemens_coefficient))
 			playsound(loc, 'sound/items/Screwdriver.ogg', 100, 1)
 			anchored = !anchored

--- a/code/game/objects/structures/signs.dm
+++ b/code/game/objects/structures/signs.dm
@@ -37,7 +37,7 @@
 	return
 
 /obj/structure/sign/attackby(obj/item/tool as obj, mob/user as mob)	//deconstruction
-	if(isscrewdriver(tool) && !istype(src, /obj/structure/sign/double))
+	if(tool.can_be_used_as_screwdriver(user) && !istype(src, /obj/structure/sign/double))
 		to_chat(user, "You unfasten the sign with your [tool].")
 		var/obj/item/sign/S = new(src.loc)
 		S.name = name
@@ -59,7 +59,7 @@
 	var/sign_state = ""
 
 /obj/item/sign/attackby(obj/item/tool as obj, mob/user as mob)	//construction
-	if(isscrewdriver(tool) && isturf(user.loc))
+	if(tool.can_be_used_as_screwdriver(user) && isturf(user.loc))
 		var/direction = input("In which direction?", "Select direction.") in list("North", "East", "South", "West", "Cancel")
 		if(direction == "Cancel" || src.loc == null)
 			return // We can get qdel'd if someone spams screwdrivers on signs before responding to the prompt.

--- a/code/game/objects/structures/signs.dm
+++ b/code/game/objects/structures/signs.dm
@@ -37,7 +37,7 @@
 	return
 
 /obj/structure/sign/attackby(obj/item/tool as obj, mob/user as mob)	//deconstruction
-	if(tool.can_be_used_as_screwdriver(user) && !istype(src, /obj/structure/sign/double))
+	if(tool.is_screwdriver(user) && !istype(src, /obj/structure/sign/double))
 		to_chat(user, "You unfasten the sign with your [tool].")
 		var/obj/item/sign/S = new(src.loc)
 		S.name = name
@@ -59,7 +59,7 @@
 	var/sign_state = ""
 
 /obj/item/sign/attackby(obj/item/tool as obj, mob/user as mob)	//construction
-	if(tool.can_be_used_as_screwdriver(user) && isturf(user.loc))
+	if(tool.is_screwdriver(user) && isturf(user.loc))
 		var/direction = input("In which direction?", "Select direction.") in list("North", "East", "South", "West", "Cancel")
 		if(direction == "Cancel" || src.loc == null)
 			return // We can get qdel'd if someone spams screwdrivers on signs before responding to the prompt.

--- a/code/game/objects/structures/vehicles/vehicle.dm
+++ b/code/game/objects/structures/vehicles/vehicle.dm
@@ -126,7 +126,7 @@
 					to_chat(user, "<span class='notice'>You don't need a key.</span>")
 		else
 			to_chat(user, "<span class='notice'>\The [src] already has \the [heldkey] in it.</span>")
-	else if(W.can_be_used_as_screwdriver(user) && !heldkey)
+	else if(W.is_screwdriver(user) && !heldkey)
 		var/mob/living/carbon/human/H = user
 		to_chat(user, "<span class='warning'>You jam \the [W] into \the [src]'s ignition and feel like a genius as you try turning it!</span>")
 		playsound(src, "sound/items/screwdriver.ogg", 10, 1)

--- a/code/game/objects/structures/vehicles/vehicle.dm
+++ b/code/game/objects/structures/vehicles/vehicle.dm
@@ -126,7 +126,7 @@
 					to_chat(user, "<span class='notice'>You don't need a key.</span>")
 		else
 			to_chat(user, "<span class='notice'>\The [src] already has \the [heldkey] in it.</span>")
-	else if(isscrewdriver(W) && !heldkey)
+	else if(W.can_be_used_as_screwdriver(user) && !heldkey)
 		var/mob/living/carbon/human/H = user
 		to_chat(user, "<span class='warning'>You jam \the [W] into \the [src]'s ignition and feel like a genius as you try turning it!</span>")
 		playsound(src, "sound/items/screwdriver.ogg", 10, 1)

--- a/code/game/objects/structures/vehicles/wheelchair.dm
+++ b/code/game/objects/structures/vehicles/wheelchair.dm
@@ -235,7 +235,7 @@
 		return ..()
 
 /obj/structure/bed/chair/vehicle/wheelchair/motorized/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if(isscrewdriver(W))
+	if(W.can_be_used_as_screwdriver(user))
 		user.visible_message("<span class='notice'>[user] screws [maintenance ? "closed" : "open"] \the [src]'s battery compartment.</span>", "<span class='notice'>You screw [maintenance ? "closed" : "open"] the battery compartment.</span>", "You hear screws being loosened.")
 		maintenance = !maintenance
 	else if(iscrowbar(W)&&maintenance)

--- a/code/game/objects/structures/vehicles/wheelchair.dm
+++ b/code/game/objects/structures/vehicles/wheelchair.dm
@@ -235,7 +235,7 @@
 		return ..()
 
 /obj/structure/bed/chair/vehicle/wheelchair/motorized/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if(W.can_be_used_as_screwdriver(user))
+	if(W.is_screwdriver(user))
 		user.visible_message("<span class='notice'>[user] screws [maintenance ? "closed" : "open"] \the [src]'s battery compartment.</span>", "<span class='notice'>You screw [maintenance ? "closed" : "open"] the battery compartment.</span>", "You hear screws being loosened.")
 		maintenance = !maintenance
 	else if(iscrowbar(W)&&maintenance)

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -186,7 +186,7 @@ obj/structure/windoor_assembly/Destroy()
 			user.drop_item(AE, src, force_drop = 1)
 
 	//Screwdriver to remove airlock electronics. Step 6 undone.
-	if(W.can_be_used_as_screwdriver(user) && (anchored && electronics))
+	if(W.is_screwdriver(user) && (anchored && electronics))
 		playsound(src, 'sound/items/Screwdriver.ogg', 100, 1)
 		user.visible_message("[user] removes the [electronics] from [src].", "You start to uninstall [electronics] from [src].")
 

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -186,7 +186,7 @@ obj/structure/windoor_assembly/Destroy()
 			user.drop_item(AE, src, force_drop = 1)
 
 	//Screwdriver to remove airlock electronics. Step 6 undone.
-	if(isscrewdriver(W) && (anchored && electronics))
+	if(W.can_be_used_as_screwdriver(user) && (anchored && electronics))
 		playsound(src, 'sound/items/Screwdriver.ogg', 100, 1)
 		user.visible_message("[user] removes the [electronics] from [src].", "You start to uninstall [electronics] from [src].")
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -396,7 +396,7 @@ var/list/one_way_windows
 
 			if(WINDOWSECURE) //Reinforced, fully secured
 
-				if(isscrewdriver(W))
+				if(W.can_be_used_as_screwdriver(user))
 					playsound(loc, 'sound/items/Screwdriver.ogg', 75, 1)
 					user.visible_message("<span class='warning'>[user] unfastens \the [src] from its frame.</span>", \
 					"<span class='notice'>You unfasten \the [src] from its frame.</span>")
@@ -405,7 +405,7 @@ var/list/one_way_windows
 
 			if(WINDOWUNSECUREFRAME)
 
-				if(isscrewdriver(W))
+				if(W.can_be_used_as_screwdriver(user))
 					playsound(loc, 'sound/items/Screwdriver.ogg', 75, 1)
 					user.visible_message("<span class='notice'>[user] fastens \the [src] to its frame.</span>", \
 					"<span class='notice'>You fasten \the [src] to its frame.</span>")
@@ -428,7 +428,7 @@ var/list/one_way_windows
 					d_state = WINDOWUNSECUREFRAME
 					return
 
-				if(isscrewdriver(W))
+				if(W.can_be_used_as_screwdriver(user))
 					playsound(loc, 'sound/items/Screwdriver.ogg', 75, 1)
 					user.visible_message("<span class='warning'>[user] unfastens \the [src]'s frame from the floor.</span>", \
 					"<span class='notice'>You unfasten \the [src]'s frame from the floor.</span>")
@@ -452,7 +452,7 @@ var/list/one_way_windows
 
 			if(WINDOWLOOSE)
 
-				if(isscrewdriver(W))
+				if(W.can_be_used_as_screwdriver(user))
 					playsound(loc, 'sound/items/Screwdriver.ogg', 75, 1)
 					user.visible_message("<span class='notice'>[user] fastens \the [src]'s frame to the floor.</span>", \
 					"<span class='notice'>You fasten \the [src]'s frame to the floor.</span>")
@@ -486,7 +486,7 @@ var/list/one_way_windows
 
 	else if(!reinforced) //Normal window steps
 
-		if(isscrewdriver(W))
+		if(W.can_be_used_as_screwdriver(user))
 			playsound(loc, 'sound/items/Screwdriver.ogg', 75, 1)
 			user.visible_message("<span class='[d_state ? "warning":"notice"]'>[user] [d_state ? "un":""]fastens \the [src].</span>", \
 			"<span class='notice'>You [d_state ? "un":""]fasten \the [src].</span>")

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -396,7 +396,7 @@ var/list/one_way_windows
 
 			if(WINDOWSECURE) //Reinforced, fully secured
 
-				if(W.can_be_used_as_screwdriver(user))
+				if(W.is_screwdriver(user))
 					playsound(loc, 'sound/items/Screwdriver.ogg', 75, 1)
 					user.visible_message("<span class='warning'>[user] unfastens \the [src] from its frame.</span>", \
 					"<span class='notice'>You unfasten \the [src] from its frame.</span>")
@@ -405,7 +405,7 @@ var/list/one_way_windows
 
 			if(WINDOWUNSECUREFRAME)
 
-				if(W.can_be_used_as_screwdriver(user))
+				if(W.is_screwdriver(user))
 					playsound(loc, 'sound/items/Screwdriver.ogg', 75, 1)
 					user.visible_message("<span class='notice'>[user] fastens \the [src] to its frame.</span>", \
 					"<span class='notice'>You fasten \the [src] to its frame.</span>")
@@ -428,7 +428,7 @@ var/list/one_way_windows
 					d_state = WINDOWUNSECUREFRAME
 					return
 
-				if(W.can_be_used_as_screwdriver(user))
+				if(W.is_screwdriver(user))
 					playsound(loc, 'sound/items/Screwdriver.ogg', 75, 1)
 					user.visible_message("<span class='warning'>[user] unfastens \the [src]'s frame from the floor.</span>", \
 					"<span class='notice'>You unfasten \the [src]'s frame from the floor.</span>")
@@ -452,7 +452,7 @@ var/list/one_way_windows
 
 			if(WINDOWLOOSE)
 
-				if(W.can_be_used_as_screwdriver(user))
+				if(W.is_screwdriver(user))
 					playsound(loc, 'sound/items/Screwdriver.ogg', 75, 1)
 					user.visible_message("<span class='notice'>[user] fastens \the [src]'s frame to the floor.</span>", \
 					"<span class='notice'>You fasten \the [src]'s frame to the floor.</span>")
@@ -486,7 +486,7 @@ var/list/one_way_windows
 
 	else if(!reinforced) //Normal window steps
 
-		if(W.can_be_used_as_screwdriver(user))
+		if(W.is_screwdriver(user))
 			playsound(loc, 'sound/items/Screwdriver.ogg', 75, 1)
 			user.visible_message("<span class='[d_state ? "warning":"notice"]'>[user] [d_state ? "un":""]fastens \the [src].</span>", \
 			"<span class='notice'>You [d_state ? "un":""]fasten \the [src].</span>")

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -540,7 +540,7 @@ turf/simulated/floor/update_icon()
 		playsound(src, 'sound/items/Crowbar.ogg', 80, 1)
 
 		return
-	else if(C.can_be_used_as_screwdriver(user))
+	else if(C.is_screwdriver(user))
 		if(is_wood_floor())
 			if(broken || burnt)
 				return

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -540,7 +540,7 @@ turf/simulated/floor/update_icon()
 		playsound(src, 'sound/items/Crowbar.ogg', 80, 1)
 
 		return
-	else if(isscrewdriver(C))
+	else if(C.can_be_used_as_screwdriver(user))
 		if(is_wood_floor())
 			if(broken || burnt)
 				return

--- a/code/game/turfs/simulated/floor_glass.dm
+++ b/code/game/turfs/simulated/floor_glass.dm
@@ -280,14 +280,14 @@
 		return // Do nothing. (preattack based)
 	switch(construction_state)
 		if(2) // intact
-			if(isscrewdriver(W))
+			if(W.can_be_used_as_screwdriver(user))
 				playsound(src, 'sound/items/Screwdriver.ogg', 75, 1)
 				user.visible_message("<span class='warning'>[user] unfastens \the [src] from its frame.</span>", \
 				"<span class='notice'>You unfasten \the [src] from its frame.</span>")
 				construction_state -= 1
 				return
 		if(1)
-			if(isscrewdriver(W))
+			if(W.can_be_used_as_screwdriver(user))
 				playsound(src, 'sound/items/Screwdriver.ogg', 75, 1)
 				user.visible_message("<span class='notice'>[user] fastens \the [src] to its frame.</span>", \
 				"<span class='notice'>You fasten \the [src] to its frame.</span>")

--- a/code/game/turfs/simulated/floor_glass.dm
+++ b/code/game/turfs/simulated/floor_glass.dm
@@ -280,14 +280,14 @@
 		return // Do nothing. (preattack based)
 	switch(construction_state)
 		if(2) // intact
-			if(W.can_be_used_as_screwdriver(user))
+			if(W.is_screwdriver(user))
 				playsound(src, 'sound/items/Screwdriver.ogg', 75, 1)
 				user.visible_message("<span class='warning'>[user] unfastens \the [src] from its frame.</span>", \
 				"<span class='notice'>You unfasten \the [src] from its frame.</span>")
 				construction_state -= 1
 				return
 		if(1)
-			if(W.can_be_used_as_screwdriver(user))
+			if(W.is_screwdriver(user))
 				playsound(src, 'sound/items/Screwdriver.ogg', 75, 1)
 				user.visible_message("<span class='notice'>[user] fastens \the [src] to its frame.</span>", \
 				"<span class='notice'>You fasten \the [src] to its frame.</span>")

--- a/code/game/turfs/simulated/walls_reinforced.dm
+++ b/code/game/turfs/simulated/walls_reinforced.dm
@@ -120,7 +120,7 @@
 				return
 
 		if(WALLCOVEREXPOSED)
-			if(isscrewdriver(W))
+			if(W.can_be_used_as_screwdriver(user))
 				user.visible_message("<span class='warning'>[user] begins unsecuring \the [src]'s external cover.</span>", \
 				"<span class='notice'>You begin unsecuring \the [src]'s external cover.</span>")
 				playsound(src, 'sound/items/Screwdriver.ogg', 100, 1)
@@ -161,7 +161,7 @@
 
 				return
 			//Re-secure external cover, unsurprisingly exact same step as above
-			else if(isscrewdriver(W))
+			else if(W.can_be_used_as_screwdriver(user))
 				user.visible_message("<span class='notice'>[user] begins securing \the [src]'s external cover.</span>", \
 				"<span class='notice'>You begin securing \the [src]'s external cover.</span>")
 				playsound(src, 'sound/items/Screwdriver.ogg', 100, 1)

--- a/code/game/turfs/simulated/walls_reinforced.dm
+++ b/code/game/turfs/simulated/walls_reinforced.dm
@@ -120,7 +120,7 @@
 				return
 
 		if(WALLCOVEREXPOSED)
-			if(W.can_be_used_as_screwdriver(user))
+			if(W.is_screwdriver(user))
 				user.visible_message("<span class='warning'>[user] begins unsecuring \the [src]'s external cover.</span>", \
 				"<span class='notice'>You begin unsecuring \the [src]'s external cover.</span>")
 				playsound(src, 'sound/items/Screwdriver.ogg', 100, 1)
@@ -161,7 +161,7 @@
 
 				return
 			//Re-secure external cover, unsurprisingly exact same step as above
-			else if(W.can_be_used_as_screwdriver(user))
+			else if(W.is_screwdriver(user))
 				user.visible_message("<span class='notice'>[user] begins securing \the [src]'s external cover.</span>", \
 				"<span class='notice'>You begin securing \the [src]'s external cover.</span>")
 				playsound(src, 'sound/items/Screwdriver.ogg', 100, 1)

--- a/code/modules/RCD/RCD.dm
+++ b/code/modules/RCD/RCD.dm
@@ -322,7 +322,7 @@
 		to_chat(user, "<span class='notice'>\the [src] now holds [matter]/[max_matter] matter-units.</span>")
 		return 1
 
-	if(isscrewdriver(W))
+	if(W.can_be_used_as_screwdriver(user))
 		to_chat(user, "<span class='notice'>You unscrew the access panel and release the cartridge chamber.</span>")
 		while(matter >= 10)
 			new /obj/item/weapon/rcd_ammo(user.loc)

--- a/code/modules/RCD/RCD.dm
+++ b/code/modules/RCD/RCD.dm
@@ -322,7 +322,7 @@
 		to_chat(user, "<span class='notice'>\the [src] now holds [matter]/[max_matter] matter-units.</span>")
 		return 1
 
-	if(W.can_be_used_as_screwdriver(user))
+	if(W.is_screwdriver(user))
 		to_chat(user, "<span class='notice'>You unscrew the access panel and release the cartridge chamber.</span>")
 		while(matter >= 10)
 			new /obj/item/weapon/rcd_ammo(user.loc)

--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -275,7 +275,7 @@ var/global/list/assembly_short_name_to_type = list() //Please, I beg you, don't 
 		if((!A.secured) && (!secured))
 			attach_assembly(A,user)
 			return
-	if(W.can_be_used_as_screwdriver(user))
+	if(W.is_screwdriver(user))
 		if(toggle_secure())
 			to_chat(user, "<span class='notice'>\The [src] is ready!</span>")
 		else

--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -275,7 +275,7 @@ var/global/list/assembly_short_name_to_type = list() //Please, I beg you, don't 
 		if((!A.secured) && (!secured))
 			attach_assembly(A,user)
 			return
-	if(isscrewdriver(W))
+	if(W.can_be_used_as_screwdriver(user))
 		if(toggle_secure())
 			to_chat(user, "<span class='notice'>\The [src] is ready!</span>")
 		else

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -159,7 +159,7 @@
 
 
 /obj/item/device/assembly_holder/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if(W.can_be_used_as_screwdriver(user))
+	if(W.is_screwdriver(user))
 		if(!a_left || !a_right)
 			to_chat(user, "<span class='warning'>BUG:Assembly part missing, please report this!</span>")
 			return

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -159,7 +159,7 @@
 
 
 /obj/item/device/assembly_holder/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if(isscrewdriver(W))
+	if(W.can_be_used_as_screwdriver(user))
 		if(!a_left || !a_right)
 			to_chat(user, "<span class='warning'>BUG:Assembly part missing, please report this!</span>")
 			return

--- a/code/modules/clothing/head/tactical.dm
+++ b/code/modules/clothing/head/tactical.dm
@@ -25,7 +25,7 @@
 		user.update_action_buttons_icon()
 		user.update_inv_head()
 		return
-	if(isscrewdriver(I) && src.flashlight)
+	if(I.can_be_used_as_screwdriver(user) && src.flashlight)
 		flashlight.forceMove(get_turf(src))
 		flashlight.update_brightness(user, playsound = FALSE)
 		flashlight = null

--- a/code/modules/clothing/head/tactical.dm
+++ b/code/modules/clothing/head/tactical.dm
@@ -25,7 +25,7 @@
 		user.update_action_buttons_icon()
 		user.update_inv_head()
 		return
-	if(I.can_be_used_as_screwdriver(user) && src.flashlight)
+	if(I.is_screwdriver(user) && src.flashlight)
 		flashlight.forceMove(get_turf(src))
 		flashlight.update_brightness(user, playsound = FALSE)
 		flashlight = null

--- a/code/modules/context_click/remote.dm
+++ b/code/modules/context_click/remote.dm
@@ -70,7 +70,7 @@ Remotes have procs for when attack_self() is called to handle which button is pr
 /datum/context_click/remote_control/action(obj/item/used_item, mob/user, params)
 	if(used_item)
 
-		if(isscrewdriver(used_item)) //Button removal - click a valid button with a screwdriver to pop it out
+		if(used_item.can_be_used_as_screwdriver(user)) //Button removal - click a valid button with a screwdriver to pop it out
 			var/button_id = return_clicked_id_by_params(params)
 			if(get_button_by_id(button_id))
 				var/obj/item/device/remote_button/removed = remove_button(button_id)

--- a/code/modules/context_click/remote.dm
+++ b/code/modules/context_click/remote.dm
@@ -70,7 +70,7 @@ Remotes have procs for when attack_self() is called to handle which button is pr
 /datum/context_click/remote_control/action(obj/item/used_item, mob/user, params)
 	if(used_item)
 
-		if(used_item.can_be_used_as_screwdriver(user)) //Button removal - click a valid button with a screwdriver to pop it out
+		if(used_item.is_screwdriver(user)) //Button removal - click a valid button with a screwdriver to pop it out
 			var/button_id = return_clicked_id_by_params(params)
 			if(get_button_by_id(button_id))
 				var/obj/item/device/remote_button/removed = remove_button(button_id)

--- a/code/modules/food/customizables.dm
+++ b/code/modules/food/customizables.dm
@@ -396,8 +396,8 @@
 	name = "flavored chocolate coin"
 	icon_state = "coincustom"
 
-/obj/item/weapon/reagent_containers/food/snacks/customizable/candy/coin/is_screwdriver(mob/user)
-	return user.a_intent = I_HURT
+/obj/item/weapon/reagent_containers/food/snacks/customizable/candy/coin/is_screwdriver(var/mob/user)
+	return user.a_intent == I_HURT
 
 // Customizable Drinks /////////////////////////////////////////
 

--- a/code/modules/food/customizables.dm
+++ b/code/modules/food/customizables.dm
@@ -396,9 +396,6 @@
 	name = "flavored chocolate coin"
 	icon_state = "coincustom"
 
-/obj/item/weapon/reagent_containers/food/snacks/customizable/candy/coin/is_screwdriver(var/mob/user)
-	return user.a_intent == I_HURT
-
 // Customizable Drinks /////////////////////////////////////////
 
 /obj/item/weapon/reagent_containers/food/drinks/bottle/customizable

--- a/code/modules/food/customizables.dm
+++ b/code/modules/food/customizables.dm
@@ -396,6 +396,9 @@
 	name = "flavored chocolate coin"
 	icon_state = "coincustom"
 
+/obj/item/weapon/reagent_containers/food/snacks/customizable/candy/coin/is_screwdriver(mob/user)
+	return user.a_intent = I_HURT
+
 // Customizable Drinks /////////////////////////////////////////
 
 /obj/item/weapon/reagent_containers/food/drinks/bottle/customizable

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -45,13 +45,13 @@
 		getFromPool(/obj/item/stack/sheet/wood, get_turf(src), 3)
 		qdel(src)
 
-/obj/structure/bookcase/attackby(obj/O as obj, mob/user as mob)
+/obj/structure/bookcase/attackby(obj/item/O as obj, mob/user as mob)
 	if(busy) //So that you can't mess with it while deconstructing
 		return
 	if(is_type_in_list(O, valid_types))
 		user.drop_item(O, src)
 		update_icon()
-	else if(isscrewdriver(O) && user.a_intent == I_HELP) //They're probably trying to open the "maintenance panel" to deconstruct it. Let them know what's wrong.
+	else if(O.can_be_used_as_screwdriver(user) && user.a_intent == I_HELP) //They're probably trying to open the "maintenance panel" to deconstruct it. Let them know what's wrong.
 		to_chat(user, "<span class='notice'>There are no screws on \the [src], it appears to be nailed together. You could probably disassemble it with just a crowbar.</span>")
 		return
 	else if(iscrowbar(O) && user.a_intent == I_HELP) //Only way to deconstruct, needs help intent

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -51,7 +51,7 @@
 	if(is_type_in_list(O, valid_types))
 		user.drop_item(O, src)
 		update_icon()
-	else if(O.can_be_used_as_screwdriver(user) && user.a_intent == I_HELP) //They're probably trying to open the "maintenance panel" to deconstruct it. Let them know what's wrong.
+	else if(O.is_screwdriver(user) && user.a_intent == I_HELP) //They're probably trying to open the "maintenance panel" to deconstruct it. Let them know what's wrong.
 		to_chat(user, "<span class='notice'>There are no screws on \the [src], it appears to be nailed together. You could probably disassemble it with just a crowbar.</span>")
 		return
 	else if(iscrowbar(O) && user.a_intent == I_HELP) //Only way to deconstruct, needs help intent

--- a/code/modules/media/broadcast/receivers/radio.dm
+++ b/code/modules/media/broadcast/receivers/radio.dm
@@ -152,7 +152,7 @@
 			else
 				return ..()
 		if(SYSTEMISKINDADONE)
-			if(W.can_be_used_as_screwdriver(user))
+			if(W.is_screwdriver(user))
 				playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 				if(do_after(user, src, 10) && buildstage==SYSTEMISKINDADONE)
 					on = 1

--- a/code/modules/media/broadcast/receivers/radio.dm
+++ b/code/modules/media/broadcast/receivers/radio.dm
@@ -152,7 +152,7 @@
 			else
 				return ..()
 		if(SYSTEMISKINDADONE)
-			if(isscrewdriver(W))
+			if(W.can_be_used_as_screwdriver(user))
 				playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 				if(do_after(user, src, 10) && buildstage==SYSTEMISKINDADONE)
 					on = 1

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -354,6 +354,9 @@
 	rec.addAmount(material, 0.2) // 5 coins per sheet.
 	return w_type
 
+/obj/item/weapon/coin/can_be_used_as_screwdriver(var/mob/user)
+	return TRUE
+
 /obj/item/weapon/coin/gold
 	material=MAT_GOLD
 	name = "Gold coin"

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -354,7 +354,7 @@
 	rec.addAmount(material, 0.2) // 5 coins per sheet.
 	return w_type
 
-/obj/item/weapon/coin/can_be_used_as_screwdriver(var/mob/user)
+/obj/item/weapon/coin/is_screwdriver(var/mob/user)
 	return user.a_intent == I_HURT
 
 /obj/item/weapon/coin/gold

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -355,7 +355,7 @@
 	return w_type
 
 /obj/item/weapon/coin/can_be_used_as_screwdriver(var/mob/user)
-	return TRUE
+	return user.a_intent == I_HURT
 
 /obj/item/weapon/coin/gold
 	material=MAT_GOLD

--- a/code/modules/mob/living/silicon/mommi/mommi.dm
+++ b/code/modules/mob/living/silicon/mommi/mommi.dm
@@ -151,12 +151,12 @@ They can only use one tool at a time, they can't choose modules, and they have 1
 		else
 			to_chat(user, "You can't reach the wiring.")
 
-	else if(W.can_be_used_as_screwdriver(user) && opened && !cell)	// haxing
+	else if(W.is_screwdriver(user) && opened && !cell)	// haxing
 		wiresexposed = !wiresexposed
 		to_chat(user, "The wires have been [wiresexposed ? "exposed" : "unexposed"].")
 		updateicon()
 
-	else if(W.can_be_used_as_screwdriver(user) && opened && cell)	// radio
+	else if(W.is_screwdriver(user) && opened && cell)	// radio
 		if(radio)
 			radio.attackby(W,user)//Push it to the radio to let it handle everything
 		else

--- a/code/modules/mob/living/silicon/mommi/mommi.dm
+++ b/code/modules/mob/living/silicon/mommi/mommi.dm
@@ -151,12 +151,12 @@ They can only use one tool at a time, they can't choose modules, and they have 1
 		else
 			to_chat(user, "You can't reach the wiring.")
 
-	else if(isscrewdriver(W) && opened && !cell)	// haxing
+	else if(W.can_be_used_as_screwdriver(user) && opened && !cell)	// haxing
 		wiresexposed = !wiresexposed
 		to_chat(user, "The wires have been [wiresexposed ? "exposed" : "unexposed"].")
 		updateicon()
 
-	else if(isscrewdriver(W) && opened && cell)	// radio
+	else if(W.can_be_used_as_screwdriver(user) && opened && cell)	// radio
 		if(radio)
 			radio.attackby(W,user)//Push it to the radio to let it handle everything
 		else

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -757,14 +757,14 @@ var/list/cyborg_list = list()
 		else
 			to_chat(user, "You can't reach the wiring.")
 
-	else if(W.can_be_used_as_screwdriver(user) && opened && !cell)	// haxing
+	else if(W.is_screwdriver(user) && opened && !cell)	// haxing
 		wiresexposed = !wiresexposed
 		to_chat(user, "The wires have been [wiresexposed ? "exposed" : "unexposed"].")
 		if(can_diagnose())
 			to_chat(src, "<span class='info' style=\"font-family:Courier\">Internal wiring [wiresexposed ? "exposed" : "unexposed"].</span>")
 		updateicon()
 
-	else if(W.can_be_used_as_screwdriver(user) && opened && cell)	// radio
+	else if(W.is_screwdriver(user) && opened && cell)	// radio
 		if(radio)
 			radio.attackby(W,user)//Push it to the radio to let it handle everything
 			if(can_diagnose())

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -757,14 +757,14 @@ var/list/cyborg_list = list()
 		else
 			to_chat(user, "You can't reach the wiring.")
 
-	else if(isscrewdriver(W) && opened && !cell)	// haxing
+	else if(W.can_be_used_as_screwdriver(user) && opened && !cell)	// haxing
 		wiresexposed = !wiresexposed
 		to_chat(user, "The wires have been [wiresexposed ? "exposed" : "unexposed"].")
 		if(can_diagnose())
 			to_chat(src, "<span class='info' style=\"font-family:Courier\">Internal wiring [wiresexposed ? "exposed" : "unexposed"].</span>")
 		updateicon()
 
-	else if(isscrewdriver(W) && opened && cell)	// radio
+	else if(W.can_be_used_as_screwdriver(user) && opened && cell)	// radio
 		if(radio)
 			radio.attackby(W,user)//Push it to the radio to let it handle everything
 			if(can_diagnose())

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -343,7 +343,7 @@
 				copy.forceMove(src.loc)
 				copy = null
 			updateUsrDialog()
-	else if(O.can_be_used_as_screwdriver(user))
+	else if(O.is_screwdriver(user))
 		if(anchored)
 			to_chat(user, "[src] needs to be unanchored.")
 			return

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -343,7 +343,7 @@
 				copy.forceMove(src.loc)
 				copy = null
 			updateUsrDialog()
-	else if(isscrewdriver(O))
+	else if(O.can_be_used_as_screwdriver(user))
 		if(anchored)
 			to_chat(user, "[src] needs to be unanchored.")
 			return

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -239,7 +239,7 @@
 	borgprint()
 
 /obj/item/device/camera/attackby(obj/item/I, mob/user)
-	if(isscrewdriver(I))
+	if(I.can_be_used_as_screwdriver(user))
 		to_chat(user, "You [panelopen ? "close" : "open"] the panel on the side of \the [src].")
 		panelopen = !panelopen
 		playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -239,7 +239,7 @@
 	borgprint()
 
 /obj/item/device/camera/attackby(obj/item/I, mob/user)
-	if(I.can_be_used_as_screwdriver(user))
+	if(I.is_screwdriver(user))
 		to_chat(user, "You [panelopen ? "close" : "open"] the panel on the side of \the [src].")
 		panelopen = !panelopen
 		playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -450,7 +450,7 @@
 					"You insert the power cell.")
 				chargecount = 0
 				update_icon()
-	else if	(W.can_be_used_as_screwdriver(user))	// haxing
+	else if	(W.is_screwdriver(user))	// haxing
 		if(opened)
 			if (cell)
 				to_chat(user, "<span class='warning'>Close the APC first.</span>")//Less hints more mystery!

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -450,7 +450,7 @@
 					"You insert the power cell.")
 				chargecount = 0
 				update_icon()
-	else if	(isscrewdriver(W))	// haxing
+	else if	(W.can_be_used_as_screwdriver(user))	// haxing
 		if(opened)
 			if (cell)
 				to_chat(user, "<span class='warning'>Close the APC first.</span>")//Less hints more mystery!

--- a/code/modules/power/monitor.dm
+++ b/code/modules/power/monitor.dm
@@ -140,8 +140,8 @@
 			icon_state = initial(icon_state)
 
 //copied from computer.dm
-/obj/machinery/power/monitor/attackby(I as obj, mob/user as mob)
-	if(isscrewdriver(I) && circuit)
+/obj/machinery/power/monitor/attackby(obj/item/I as obj, mob/user as mob)
+	if(I.can_be_used_as_screwdriver(user) && circuit)
 		playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
 		if(do_after(user,src,20))
 			var/obj/structure/computerframe/A = new /obj/structure/computerframe( src.loc )

--- a/code/modules/power/monitor.dm
+++ b/code/modules/power/monitor.dm
@@ -141,7 +141,7 @@
 
 //copied from computer.dm
 /obj/machinery/power/monitor/attackby(obj/item/I as obj, mob/user as mob)
-	if(I.can_be_used_as_screwdriver(user) && circuit)
+	if(I.is_screwdriver(user) && circuit)
 		playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
 		if(do_after(user,src,20))
 			var/obj/structure/computerframe/A = new /obj/structure/computerframe( src.loc )

--- a/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
@@ -201,7 +201,7 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 	return 0
 
 
-/obj/structure/particle_accelerator/proc/process_tool_hit(var/obj/O, var/mob/user)
+/obj/structure/particle_accelerator/proc/process_tool_hit(var/obj/item/O, var/mob/user)
 	if(!(O) || !(user))
 		return 0
 	if(!ismob(user) || !isobj(O))
@@ -233,12 +233,12 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 				user.visible_message("[user.name] removes some wires from the [src.name].", \
 					"You remove some wires.")
 				temp_state--
-			else if(isscrewdriver(O))
+			else if(O.can_be_used_as_screwdriver(user))
 				user.visible_message("[user.name] closes the [src.name]'s access panel.", \
 					"You close the access panel.")
 				temp_state++
 		if(3)
-			if(isscrewdriver(O))
+			if(O.can_be_used_as_screwdriver(user))
 				user.visible_message("[user.name] opens the [src.name]'s access panel.", \
 					"You open the access panel.")
 				temp_state--
@@ -345,7 +345,7 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 	return 0
 
 
-/obj/machinery/particle_accelerator/proc/process_tool_hit(var/obj/O, var/mob/user)
+/obj/machinery/particle_accelerator/proc/process_tool_hit(var/obj/item/O, var/mob/user)
 	if(!(O) || !(user))
 		return 0
 	if(!ismob(user) || !isobj(O))
@@ -376,12 +376,12 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 				user.visible_message("[user.name] removes some wires from the [src.name].", \
 					"You remove some wires.")
 				temp_state--
-			else if(isscrewdriver(O))
+			else if(O.can_be_used_as_screwdriver(user))
 				user.visible_message("[user.name] closes the [src.name]'s access panel.", \
 					"You close the access panel.")
 				temp_state++
 		if(3)
-			if(isscrewdriver(O))
+			if(O.can_be_used_as_screwdriver(user))
 				user.visible_message("[user.name] opens the [src.name]'s access panel.", \
 					"You open the access panel.")
 				temp_state--

--- a/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
@@ -233,12 +233,12 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 				user.visible_message("[user.name] removes some wires from the [src.name].", \
 					"You remove some wires.")
 				temp_state--
-			else if(O.can_be_used_as_screwdriver(user))
+			else if(O.is_screwdriver(user))
 				user.visible_message("[user.name] closes the [src.name]'s access panel.", \
 					"You close the access panel.")
 				temp_state++
 		if(3)
-			if(O.can_be_used_as_screwdriver(user))
+			if(O.is_screwdriver(user))
 				user.visible_message("[user.name] opens the [src.name]'s access panel.", \
 					"You open the access panel.")
 				temp_state--
@@ -376,12 +376,12 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 				user.visible_message("[user.name] removes some wires from the [src.name].", \
 					"You remove some wires.")
 				temp_state--
-			else if(O.can_be_used_as_screwdriver(user))
+			else if(O.is_screwdriver(user))
 				user.visible_message("[user.name] closes the [src.name]'s access panel.", \
 					"You close the access panel.")
 				temp_state++
 		if(3)
-			if(O.can_be_used_as_screwdriver(user))
+			if(O.is_screwdriver(user))
 				user.visible_message("[user.name] opens the [src.name]'s access panel.", \
 					"You open the access panel.")
 				temp_state--

--- a/code/modules/power/solars/control.dm
+++ b/code/modules/power/solars/control.dm
@@ -82,7 +82,7 @@
 	updateDialog()
 
 /obj/machinery/power/solar/control/attackby(obj/item/I as obj, mob/user as mob)
-	if(I.can_be_used_as_screwdriver(user))
+	if(I.is_screwdriver(user))
 		playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 		if(do_after(user, src, 20))
 			if(src.stat & BROKEN)

--- a/code/modules/power/solars/control.dm
+++ b/code/modules/power/solars/control.dm
@@ -81,8 +81,8 @@
 
 	updateDialog()
 
-/obj/machinery/power/solar/control/attackby(I as obj, user as mob)
-	if(isscrewdriver(I))
+/obj/machinery/power/solar/control/attackby(obj/item/I as obj, mob/user as mob)
+	if(I.can_be_used_as_screwdriver(user))
 		playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 		if(do_after(user, src, 20))
 			if(src.stat & BROKEN)

--- a/code/modules/power/turbine.dm
+++ b/code/modules/power/turbine.dm
@@ -217,8 +217,8 @@
 			if(P.id_tag == id_tag)
 				doors += P
 
-/obj/machinery/computer/turbine_computer/attackby(I as obj, user as mob)
-	if(isscrewdriver(I))
+/obj/machinery/computer/turbine_computer/attackby(obj/item/I as obj, mob/user as mob)
+	if(I.can_be_used_as_screwdriver(user))
 		playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 		if(do_after(user, src, 20))
 			if (src.stat & BROKEN)

--- a/code/modules/power/turbine.dm
+++ b/code/modules/power/turbine.dm
@@ -218,7 +218,7 @@
 				doors += P
 
 /obj/machinery/computer/turbine_computer/attackby(obj/item/I as obj, mob/user as mob)
-	if(I.can_be_used_as_screwdriver(user))
+	if(I.is_screwdriver(user))
 		playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 		if(do_after(user, src, 20))
 			if (src.stat & BROKEN)

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -278,7 +278,7 @@
 		return FALSE
 
 /obj/item/weapon/gun/projectile/automatic/vector/attackby(obj/item/used_item, mob/user)
-	if(used_item.can_be_used_as_screwdriver(user) && receiver)
+	if(used_item.is_screwdriver(user) && receiver)
 		if(stored_magazine)
 			to_chat(user, "<span class='warning'>You need to remove the magazine first!</span>")
 		else

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -278,7 +278,7 @@
 		return FALSE
 
 /obj/item/weapon/gun/projectile/automatic/vector/attackby(obj/item/used_item, mob/user)
-	if(isscrewdriver(used_item) && receiver)
+	if(used_item.can_be_used_as_screwdriver(user) && receiver)
 		if(stored_magazine)
 			to_chat(user, "<span class='warning'>You need to remove the magazine first!</span>")
 		else

--- a/code/modules/projectiles/guns/projectile/bow.dm
+++ b/code/modules/projectiles/guns/projectile/bow.dm
@@ -104,7 +104,7 @@
 		else
 			to_chat(user, "<span class='notice'>[src] already has a cell installed.</span>")
 
-	else if(isscrewdriver(W))
+	else if(W.can_be_used_as_screwdriver(user))
 		if(cell)
 			var/obj/item/C = cell
 			C.forceMove(get_turf(user))

--- a/code/modules/projectiles/guns/projectile/bow.dm
+++ b/code/modules/projectiles/guns/projectile/bow.dm
@@ -104,7 +104,7 @@
 		else
 			to_chat(user, "<span class='notice'>[src] already has a cell installed.</span>")
 
-	else if(W.can_be_used_as_screwdriver(user))
+	else if(W.is_screwdriver(user))
 		if(cell)
 			var/obj/item/C = cell
 			C.forceMove(get_turf(user))

--- a/code/modules/projectiles/guns/projectile/constructable/flamethrower.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/flamethrower.dm
@@ -153,7 +153,7 @@
 		qdel(src)
 		return
 
-	if(isscrewdriver(W) && igniter && !lit)
+	if(W.can_be_used_as_screwdriver(user) && igniter && !lit)
 		status = !status
 		to_chat(user, "<span class='notice'>[igniter] is now [status ? "secured" : "unsecured"]!</span>")
 		update_icon()

--- a/code/modules/projectiles/guns/projectile/constructable/flamethrower.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/flamethrower.dm
@@ -153,7 +153,7 @@
 		qdel(src)
 		return
 
-	if(W.can_be_used_as_screwdriver(user) && igniter && !lit)
+	if(W.is_screwdriver(user) && igniter && !lit)
 		status = !status
 		to_chat(user, "<span class='notice'>[igniter] is now [status ? "secured" : "unsecured"]!</span>")
 		update_icon()

--- a/code/modules/projectiles/guns/projectile/constructable/gunsmithing.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/gunsmithing.dm
@@ -459,7 +459,7 @@
 				update_assembly()
 				qdel(W)
 		if("blunderbuss_assembly")
-			if(isscrewdriver(W))
+			if(W.can_be_used_as_screwdriver(user))
 				to_chat(user, "You tighten the igniter to \the [src].")
 				playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 				if(src.loc == user)
@@ -473,7 +473,7 @@
 
 //RAILGUN BEGIN////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 		if("stock_capacitorbank_assembly")
-			if(isscrewdriver(W))
+			if(W.can_be_used_as_screwdriver(user))
 				to_chat(user, "You tighten the wires in \the [src]'s capacitor bank.")
 				playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 				state = "stock_capacitorbank"
@@ -491,7 +491,7 @@
 				state = "stock_capacitorbank_barrel_assembly"
 				update_assembly()
 				qdel(W)
-			if(isscrewdriver(W))
+			if(W.can_be_used_as_screwdriver(user))
 				to_chat(user, "You loosen the wires in \the [src]'s capacitor bank.")
 				playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 				state = "stock_capacitorbank_assembly"
@@ -511,7 +511,7 @@
 				update_assembly()
 				qdel(W)
 		if("railgun_assembly")
-			if(isscrewdriver(W))
+			if(W.can_be_used_as_screwdriver(user))
 				to_chat(user, "You secure \the [src]'s triggering mechanism.")
 				playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 				if(src.loc == user)
@@ -581,7 +581,7 @@
 				update_assembly()
 				qdel(W)
 		if("stock_ansible_amplifier_assembly")
-			if(isscrewdriver(W))
+			if(W.can_be_used_as_screwdriver(user))
 				to_chat(user, "You secure \the [src]'s subspace amplifier.")
 				playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 				state = "stock_ansible_amplifier"
@@ -593,7 +593,7 @@
 				update_assembly()
 				qdel(W)
 		if("stock_ansible_amplifier_transmitter_assembly")
-			if(isscrewdriver(W))
+			if(W.can_be_used_as_screwdriver(user))
 				to_chat(user, "You secure \the [src]'s subspace transmitter.")
 				playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 				state = "subspacetunneler_assembly"

--- a/code/modules/projectiles/guns/projectile/constructable/gunsmithing.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/gunsmithing.dm
@@ -459,7 +459,7 @@
 				update_assembly()
 				qdel(W)
 		if("blunderbuss_assembly")
-			if(W.can_be_used_as_screwdriver(user))
+			if(W.is_screwdriver(user))
 				to_chat(user, "You tighten the igniter to \the [src].")
 				playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 				if(src.loc == user)
@@ -473,7 +473,7 @@
 
 //RAILGUN BEGIN////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 		if("stock_capacitorbank_assembly")
-			if(W.can_be_used_as_screwdriver(user))
+			if(W.is_screwdriver(user))
 				to_chat(user, "You tighten the wires in \the [src]'s capacitor bank.")
 				playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 				state = "stock_capacitorbank"
@@ -491,7 +491,7 @@
 				state = "stock_capacitorbank_barrel_assembly"
 				update_assembly()
 				qdel(W)
-			if(W.can_be_used_as_screwdriver(user))
+			if(W.is_screwdriver(user))
 				to_chat(user, "You loosen the wires in \the [src]'s capacitor bank.")
 				playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 				state = "stock_capacitorbank_assembly"
@@ -511,7 +511,7 @@
 				update_assembly()
 				qdel(W)
 		if("railgun_assembly")
-			if(W.can_be_used_as_screwdriver(user))
+			if(W.is_screwdriver(user))
 				to_chat(user, "You secure \the [src]'s triggering mechanism.")
 				playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 				if(src.loc == user)
@@ -581,7 +581,7 @@
 				update_assembly()
 				qdel(W)
 		if("stock_ansible_amplifier_assembly")
-			if(W.can_be_used_as_screwdriver(user))
+			if(W.is_screwdriver(user))
 				to_chat(user, "You secure \the [src]'s subspace amplifier.")
 				playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 				state = "stock_ansible_amplifier"
@@ -593,7 +593,7 @@
 				update_assembly()
 				qdel(W)
 		if("stock_ansible_amplifier_transmitter_assembly")
-			if(W.can_be_used_as_screwdriver(user))
+			if(W.is_screwdriver(user))
 				to_chat(user, "You secure \the [src]'s subspace transmitter.")
 				playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 				state = "subspacetunneler_assembly"

--- a/code/modules/projectiles/guns/projectile/constructable/railgun.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/railgun.dm
@@ -156,7 +156,7 @@
 		to_chat(user, "You insert \the [W] into the barrel of \the [src].")
 		rails = W
 
-	else if(W.can_be_used_as_screwdriver(user))
+	else if(W.is_screwdriver(user))
 		if(rails)
 			if(rails_secure)
 				to_chat(user, "You loosen the rail assembly within \the [src].")

--- a/code/modules/projectiles/guns/projectile/constructable/railgun.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/railgun.dm
@@ -156,7 +156,7 @@
 		to_chat(user, "You insert \the [W] into the barrel of \the [src].")
 		rails = W
 
-	else if(isscrewdriver(W))
+	else if(W.can_be_used_as_screwdriver(user))
 		if(rails)
 			if(rails_secure)
 				to_chat(user, "You loosen the rail assembly within \the [src].")

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -42,7 +42,7 @@
 
 	attackby(var/obj/item/A as obj, mob/user as mob)
 		..()
-		if(A.can_be_used_as_screwdriver(user) || istype(A, /obj/item/weapon/conversion_kit))
+		if(A.is_screwdriver(user) || istype(A, /obj/item/weapon/conversion_kit))
 			var/obj/item/weapon/conversion_kit/CK
 			if(istype(A, /obj/item/weapon/conversion_kit))
 				CK = A

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -42,7 +42,7 @@
 
 	attackby(var/obj/item/A as obj, mob/user as mob)
 		..()
-		if(isscrewdriver(A) || istype(A, /obj/item/weapon/conversion_kit))
+		if(A.can_be_used_as_screwdriver(user) || istype(A, /obj/item/weapon/conversion_kit))
 			var/obj/item/weapon/conversion_kit/CK
 			if(istype(A, /obj/item/weapon/conversion_kit))
 				CK = A

--- a/code/modules/reagents/machinery/mortar.dm
+++ b/code/modules/reagents/machinery/mortar.dm
@@ -47,7 +47,7 @@
 	. = ..()
 
 /obj/item/weapon/reagent_containers/glass/mortar/attackby(var/obj/item/O as obj, var/mob/user as mob)
-	if (isscrewdriver(O))
+	if (O.can_be_used_as_screwdriver(user))
 		if(crushable)
 			crushable.forceMove(user.loc)
 		new /obj/item/stack/sheet/metal(user.loc)

--- a/code/modules/reagents/machinery/mortar.dm
+++ b/code/modules/reagents/machinery/mortar.dm
@@ -47,7 +47,7 @@
 	. = ..()
 
 /obj/item/weapon/reagent_containers/glass/mortar/attackby(var/obj/item/O as obj, var/mob/user as mob)
-	if (O.can_be_used_as_screwdriver(user))
+	if (O.is_screwdriver(user))
 		if(crushable)
 			crushable.forceMove(user.loc)
 		new /obj/item/stack/sheet/metal(user.loc)

--- a/code/modules/reagents/reagent_containers/chempack.dm
+++ b/code/modules/reagents/reagent_containers/chempack.dm
@@ -219,7 +219,7 @@ obj/item/weapon/reagent_containers/chempack/verb/set_fill()
 
 	switch(stage) //Handles the different stages of overriding the chemical pack's safeties. This can be done completely with a standard set of tools.
 		if(0)
-			if(W.can_be_used_as_screwdriver(user) && user.back == src)
+			if(W.is_screwdriver(user) && user.back == src)
 				to_chat(user, "<span class='warning'>You can't perform maintenance on \the [src] while you're wearing it!</span>")
 				return
 			else
@@ -238,10 +238,10 @@ obj/item/weapon/reagent_containers/chempack/verb/set_fill()
 				else if (iscrowbar(W) && src.beaker && !auxiliary)
 					to_chat(user, "<span class='warning'>The beaker is held tight by the bolts of the auxiliary chamber!</span>")
 					return
-				if (W.can_be_used_as_screwdriver(user) && src.beaker)
+				if (W.is_screwdriver(user) && src.beaker)
 					to_chat(user, "<span class='warning'>You can't reach the maintenance panel with the beaker in the way!</span>")
 					return
-				else if (W.can_be_used_as_screwdriver(user))
+				else if (W.is_screwdriver(user))
 					stage = 1
 					slot_flags = null
 					to_chat(user, "<span class='notice'>You unscrew the maintenance panel of \the [src].</span>")
@@ -258,7 +258,7 @@ obj/item/weapon/reagent_containers/chempack/verb/set_fill()
 				icon_state = "[initial(icon_state)]2"
 				user.update_inv_hands()
 				return
-			else if (W.can_be_used_as_screwdriver(user))
+			else if (W.is_screwdriver(user))
 				stage = 0
 				slot_flags = SLOT_BACK
 				to_chat(user, "<span class='notice'>You secure the maintenance panel of \the [src].</span>")

--- a/code/modules/reagents/reagent_containers/chempack.dm
+++ b/code/modules/reagents/reagent_containers/chempack.dm
@@ -219,7 +219,7 @@ obj/item/weapon/reagent_containers/chempack/verb/set_fill()
 
 	switch(stage) //Handles the different stages of overriding the chemical pack's safeties. This can be done completely with a standard set of tools.
 		if(0)
-			if(isscrewdriver(W) && user.back == src)
+			if(W.can_be_used_as_screwdriver(user) && user.back == src)
 				to_chat(user, "<span class='warning'>You can't perform maintenance on \the [src] while you're wearing it!</span>")
 				return
 			else
@@ -238,10 +238,10 @@ obj/item/weapon/reagent_containers/chempack/verb/set_fill()
 				else if (iscrowbar(W) && src.beaker && !auxiliary)
 					to_chat(user, "<span class='warning'>The beaker is held tight by the bolts of the auxiliary chamber!</span>")
 					return
-				if (isscrewdriver(W) && src.beaker)
+				if (W.can_be_used_as_screwdriver(user) && src.beaker)
 					to_chat(user, "<span class='warning'>You can't reach the maintenance panel with the beaker in the way!</span>")
 					return
-				else if (isscrewdriver(W))
+				else if (W.can_be_used_as_screwdriver(user))
 					stage = 1
 					slot_flags = null
 					to_chat(user, "<span class='notice'>You unscrew the maintenance panel of \the [src].</span>")
@@ -258,7 +258,7 @@ obj/item/weapon/reagent_containers/chempack/verb/set_fill()
 				icon_state = "[initial(icon_state)]2"
 				user.update_inv_hands()
 				return
-			else if (isscrewdriver(W))
+			else if (W.can_be_used_as_screwdriver(user))
 				stage = 0
 				slot_flags = SLOT_BACK
 				to_chat(user, "<span class='notice'>You secure the maintenance panel of \the [src].</span>")

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -4512,6 +4512,9 @@
 	icon_state = "chococoin_wrapped"
 	wrapped = 1
 
+/obj/item/weapon/reagent_containers/food/snacks/chococoin/wrapped/is_screwdriver(var/mob/user)
+	return user.a_intent == I_HURT
+
 /obj/item/weapon/reagent_containers/food/snacks/chococoin/New()
 	..()
 	reagents.add_reagent(NUTRIMENT, 2)
@@ -4529,6 +4532,9 @@
 	desc = "A thin wafer of milky, chocolatey, melt-in-your-mouth goodness. That alone is already worth a hoard."
 	to_chat(user, "<span class='notice'>You remove the golden foil from \the [src].</span>")
 	wrapped = 0
+
+/obj/item/weapon/reagent_containers/food/snacks/chococoin/is_screwdriver(var/mob/user)
+	return user.a_intent == I_HURT
 
 /obj/item/weapon/reagent_containers/food/snacks/eucharist
 	name = "\improper Eucharist Wafer"

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -100,7 +100,7 @@
 
 	src.add_fingerprint(user)
 	if(mode<=0) // It's off
-		if(isscrewdriver(I))
+		if(I.can_be_used_as_screwdriver(user))
 			if(contents.len > 0)
 				to_chat(user, "Eject the items first!")
 				return
@@ -1595,7 +1595,7 @@
 	if(!I || !user || !deconstructable)
 		return
 	src.add_fingerprint(user)
-	if(isscrewdriver(I))
+	if(I.can_be_used_as_screwdriver(user))
 		if(mode==0)
 			mode=1
 			playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -100,7 +100,7 @@
 
 	src.add_fingerprint(user)
 	if(mode<=0) // It's off
-		if(I.can_be_used_as_screwdriver(user))
+		if(I.is_screwdriver(user))
 			if(contents.len > 0)
 				to_chat(user, "Eject the items first!")
 				return
@@ -1595,7 +1595,7 @@
 	if(!I || !user || !deconstructable)
 		return
 	src.add_fingerprint(user)
-	if(I.can_be_used_as_screwdriver(user))
+	if(I.is_screwdriver(user))
 		if(mode==0)
 			mode=1
 			playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -58,7 +58,7 @@
 	interact(user)
 
 /obj/item/device/destTagger/attackby(obj/item/W, mob/user)
-	if(W.can_be_used_as_screwdriver(user))
+	if(W.is_screwdriver(user))
 		panel = !panel
 		to_chat(user, "<span class='notify'>You [panel ? "open" : "close"] the panel on \the [src].</span>")
 		playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
@@ -199,7 +199,7 @@
 	if(!I || !user)
 		return
 
-	if(I.can_be_used_as_screwdriver(user))
+	if(I.is_screwdriver(user))
 		if(c_mode==0)
 			c_mode=1
 			playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -58,7 +58,7 @@
 	interact(user)
 
 /obj/item/device/destTagger/attackby(obj/item/W, mob/user)
-	if(isscrewdriver(W))
+	if(W.can_be_used_as_screwdriver(user))
 		panel = !panel
 		to_chat(user, "<span class='notify'>You [panel ? "open" : "close"] the panel on \the [src].</span>")
 		playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
@@ -199,7 +199,7 @@
 	if(!I || !user)
 		return
 
-	if(isscrewdriver(I))
+	if(I.can_be_used_as_screwdriver(user))
 		if(c_mode==0)
 			c_mode=1
 			playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -303,7 +303,7 @@
 	return
 
 /obj/machinery/computer/rdservercontrol/attackby(var/obj/item/weapon/D as obj, var/mob/user as mob)
-	if(D.can_be_used_as_screwdriver(user))
+	if(D.is_screwdriver(user))
 		playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 		if(do_after(user, src, 20))
 			if (src.stat & BROKEN)

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -303,7 +303,7 @@
 	return
 
 /obj/machinery/computer/rdservercontrol/attackby(var/obj/item/weapon/D as obj, var/mob/user as mob)
-	if(isscrewdriver(D))
+	if(D.can_be_used_as_screwdriver(user))
 		playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 		if(do_after(user, src, 20))
 			if (src.stat & BROKEN)

--- a/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
+++ b/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
@@ -173,7 +173,7 @@
 		to_chat(user, "<span class='info'>You remove the power cell</span>")
 
 /obj/machinery/suspension_gen/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if (W.can_be_used_as_screwdriver(user))
+	if (W.is_screwdriver(user))
 		if(!open)
 			if(screwed)
 				screwed = 0

--- a/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
+++ b/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
@@ -173,7 +173,7 @@
 		to_chat(user, "<span class='info'>You remove the power cell</span>")
 
 /obj/machinery/suspension_gen/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if (isscrewdriver(W))
+	if (W.can_be_used_as_screwdriver(user))
 		if(!open)
 			if(screwed)
 				screwed = 0

--- a/code/modules/telesci/rcs.dm
+++ b/code/modules/telesci/rcs.dm
@@ -25,7 +25,7 @@
 		playsound(src, 'sound/items/Ratchet.ogg', 50, 1)
 		anchored = !anchored
 		to_chat(user, "<span class='caution'>\the [src] [anchored ? "is now secured" : "can now be moved"] .</span>")
-	if(W.can_be_used_as_screwdriver(user))
+	if(W.is_screwdriver(user))
 		if(stage == 0)
 			playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 			to_chat(user, "<span class = 'caution'>You unscrew the telepad's tracking beacon.</span>")

--- a/code/modules/telesci/rcs.dm
+++ b/code/modules/telesci/rcs.dm
@@ -25,7 +25,7 @@
 		playsound(src, 'sound/items/Ratchet.ogg', 50, 1)
 		anchored = !anchored
 		to_chat(user, "<span class='caution'>\the [src] [anchored ? "is now secured" : "can now be moved"] .</span>")
-	if(isscrewdriver(W))
+	if(W.can_be_used_as_screwdriver(user))
 		if(stage == 0)
 			playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 			to_chat(user, "<span class = 'caution'>You unscrew the telepad's tracking beacon.</span>")

--- a/code/modules/telesci/telepad.dm
+++ b/code/modules/telesci/telepad.dm
@@ -22,7 +22,7 @@
 	..()
 
 /obj/machinery/telepad/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if(isscrewdriver(W))
+	if(W.can_be_used_as_screwdriver(user))
 		if(opened)
 			playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 			to_chat(user, "<span class = 'caution'>You secure the access port on \the [src].</span>")

--- a/code/modules/telesci/telepad.dm
+++ b/code/modules/telesci/telepad.dm
@@ -22,7 +22,7 @@
 	..()
 
 /obj/machinery/telepad/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if(W.can_be_used_as_screwdriver(user))
+	if(W.is_screwdriver(user))
 		if(opened)
 			playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 			to_chat(user, "<span class = 'caution'>You secure the access port on \the [src].</span>")

--- a/code/modules/virus2/curer.dm
+++ b/code/modules/virus2/curer.dm
@@ -7,8 +7,8 @@
 
 	var/obj/item/weapon/reagent_containers/container = null
 
-/obj/machinery/computer/curer/attackby(var/obj/I as obj, var/mob/user as mob)
-	if(isscrewdriver(I))
+/obj/machinery/computer/curer/attackby(var/obj/item/I as obj, var/mob/user as mob)
+	if(I.can_be_used_as_screwdriver(user))
 		return ..(I,user)
 	if(istype(I,/obj/item/weapon/reagent_containers))
 		var/mob/living/carbon/C = user

--- a/code/modules/virus2/curer.dm
+++ b/code/modules/virus2/curer.dm
@@ -8,7 +8,7 @@
 	var/obj/item/weapon/reagent_containers/container = null
 
 /obj/machinery/computer/curer/attackby(var/obj/item/I as obj, var/mob/user as mob)
-	if(I.can_be_used_as_screwdriver(user))
+	if(I.is_screwdriver(user))
 		return ..(I,user)
 	if(istype(I,/obj/item/weapon/reagent_containers))
 		var/mob/living/carbon/C = user


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation or the coding discord (you can find an invite link on the irc or the thread) to discuss your changes, or if you need help.

== SELF LABELLING PRs ==
You can now self-label your PR! The syntax is simple. Just put [<labeltag>] anywhere in your PR,
where <labeltag> is to be replaced by one of the following (allowing with the resultant tag)
just ctrl+f the list or something. I know it's long.

administration = "Logging / Administration"
away = "Mapping (Away Mission :earth_africa:)"
bagel = "Mapping (Bagel :o:)"
box = "Mapping (Box :baby:)"
bugfix = "Bug / Fix"
bus = "Mapping (Bus :bus:)"
byond = "T-Thanks BYOND"
consistency = "Consistency Issue"
controversial = "Controversial"
deff = "Mapping (Deff :wastebasket:)"
discussion = "Discussion"
dnm = "✋ Do Not Merge ✋"
easy = "Easy Fix"
exploitable = "Exploitable"
featureloss = "Feature Loss"
featurerequest = "Feature Request"
first = "good first issue"
formatting = "Grammar / Formatting"
gamemode = "Gameplay / Gamemode"
gameplay = "Gameplay / Gamemode"
general = "Mapping (General :world_map:)"
goonchat = "Goonchat"
grammar = "Grammar / Formatting"
help = "help wanted"
hotfix = "Hotfix"
libvg = "libvg"
logging = "Logging / Administration"
meta = "Mapping (Meta :no_mobile_phones:)"
needspritework = "Needs Spritework"
oversight = "Oversight"
packed = "Mapping (Packed :package:)"
parallax = "Parallax"
qol = "❤️ Quality of Life ❤️"
roid = "Mapping (Roidstation :pick:)"
role = "Role Datums"
roleissue = "Role Datums Issue"
runtime = "Runtime Log"
sanity = "Sanity / Ghosthands"
snowmap = "Mapping (Snowmap ❄)"
sound = "Sound"
sprites = "Sprites"
spriteworkdone = "Spritework Done Needs Coder"
system = "System"
taxi = "Mapping (Taxi :taxi:)"
tested = "100%  tested"
tweak = "Tweak"
ui = "UI"
vault = "Mapping (Vault :question:)"
vote = "⛔ Requires Server Vote ⛔"
wip = "WiP"

== CHANGELOGS ==
Changelogs can be attached either by following the instructions in html/changelogs/example.yml, or by attaching an in-body changelog like the one attached to your PR automatically.

For the keys you can use in an in-body changelog, they are the same as described in example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!

An example changelog is attached to this PR for your convenience:
-->
[gameplay][system][tested]

i replaced the macro isscrewdriver with a /obj/item/proc/~can_be_used_as_screwdriver~is_screwdriver(mob/user) with return FALSE

overrid ~can_be_used_as_screwdriver~ is_screwdriver for /obj/item/weapon/screwdriver and /obj/item/weapon/coin, but coin only returns true if on harm intent

fixes #22172

:cl:
 * rscadd: coins can now be used as ghetto screwdrivers
 * rscadd: chocolate coins can now be used as ghetto screwdrivers