### PR TITLE
Smartglass revision

### DIFF
--- a/code/game/machinery/door_control.dm
+++ b/code/game/machinery/door_control.dm
@@ -204,6 +204,7 @@
 	icon_state = "launcherbtt"
 	active = 0
 
+// TODO: Remove this snowflake stuff.
 /obj/machinery/door_control/mapped/interogation_room
 	name = "smartglass control"
 	desc = "Toogle smartglass"

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -22,8 +22,9 @@
 	penetration_dampening = 2
 	animation_delay = 7
 	var/obj/machinery/smartglass_electronics/smartwindow
-	var/window_is_opaque = TRUE //The var that helps darken the glass when the door opens/closes
+	var/window_is_opaque = FALSE //The var that helps darken the glass when the door opens/closes
 	var/assembly_type = /obj/structure/windoor_assembly
+	var/id_tag = null
 
 /obj/machinery/door/window/New()
 	..()
@@ -31,21 +32,27 @@
 		icon_state = "[icon_state]"
 		base_state = icon_state
 	set_electronics()
+	if(smartwindow && window_is_opaque)
+		set_opacity(1)
+		update_nearby_tiles()
 
 /obj/machinery/door/window/Destroy()
 	setDensity(FALSE)
 	..()
 
 /obj/machinery/door/window/proc/smart_toggle() //For "smart" windows
-	animate(src, color="[window_is_opaque ? "#FFFFFF":"#222222"]", time=5) //Start with coloring the windoor. Always.
+	// var/color = window_is_opaque ? "#FFFFFF" : "#222222" //these are backwards because we're changing window_is_opaque later
+	// animate(src, color=color, time=5)
 
 	if(density) //window is CLOSED
 		if(window_is_opaque) //Is it dark?
 			set_opacity(0) //Make it light.
-			window_is_opaque = TRUE
+			window_is_opaque = FALSE
+			animate(src, color="#FFFFFF", time=5)
 		else
 			set_opacity(1) // Else, make it dark.
-			window_is_opaque = FALSE
+			window_is_opaque = TRUE
+			animate(src, color="#222222", time=5)
 	else //Window is OPEN!
 		window_is_opaque = !window_is_opaque //We pass on that we've been toggled.
 	return opacity
@@ -53,9 +60,9 @@
 /obj/machinery/door/window/examine(mob/user)
 	..()
 	if(smartwindow)
-		to_chat(user, "It's NT-15925 SmartGlass™ compliant.")
+		to_chat(user, "It is NT-15925 SmartGlass™ compliant.")
 	if(secure)
-		to_chat(user, "It is a secure windoor, it is stronger and closes more quickly.")
+		to_chat(user, "It is a secure windoor. It's stronger and closes more quickly.")
 
 /obj/machinery/door/window/Bumped(atom/movable/AM)
 	if(!ismob(AM))
@@ -133,6 +140,11 @@
 		return FALSE
 	if(!operating) //in case of emag
 		operating = 1
+
+	// Dark windows look silly when open
+	if(smartwindow && window_is_opaque)
+		animate(src, color="#FFFFFF", time=10)
+
 	door_animate("opening")
 	playsound(src, soundeffect, 100, 1)
 	icon_state = "[base_state]open"
@@ -140,8 +152,7 @@
 
 	explosion_resistance = 0
 	setDensity(FALSE)
-	if(smartwindow && window_is_opaque)
-		set_opacity(0) //You can see through open windows
+	set_opacity(0) //You can see through open windoors even if the glass is opaque
 	update_nearby_tiles()
 
 	if(operating == 1) //emag again
@@ -152,17 +163,22 @@
 	if(operating)
 		return FALSE
 	operating = 1
+
+	// Re-darken the window when closed
+	if(smartwindow && window_is_opaque)
+		animate(src, color="#222222", time=10)
+
 	door_animate("closing")
 	playsound(src, soundeffect, 100, 1)
 	icon_state = base_state
 
 	setDensity(TRUE)
 	explosion_resistance = initial(explosion_resistance)
-	if(smartwindow && window_is_opaque)
-		set_opacity(1)
 	update_nearby_tiles()
 
 	sleep(animation_delay)
+	if(window_is_opaque) //you can't see through closed opaque windoors
+		set_opacity(1)
 
 	operating = 0
 	return TRUE
@@ -355,7 +371,6 @@
 	base_state = "leftsecure"
 	req_access = list(access_security)
 	secure = TRUE
-	var/id_tag = null
 	health = 100
 	assembly_type = /obj/structure/windoor_assembly/secure
 	penetration_dampening = 4
@@ -379,6 +394,7 @@
 	penetration_dampening = 8
 
 // Used on Packed ; smartglassified roundstart
+// TODO: Remove this snowflake stuff.
 /obj/machinery/door/window/plasma/secure/interogation_room/initialize()
 	smartwindow = new(src)
 	smartwindow.id_tag = "InterogationRoomIDTag"
@@ -398,3 +414,38 @@
 
 /obj/machinery/door/window/clockwork/clockworkify()
 	return
+
+// Smartglass for mappers, smartglassified on roundstart.
+// the frequency and id_tag (shared by the windoor itself) get passed on to the smartglass electronics
+// sharing the id_tag is alright because airlocks don't use radio frequency mechanics like smartglass
+/obj/machinery/door/window/smartglass
+	var/frequency = 1449
+
+/obj/machinery/door/window/smartglass/initialize()
+	smartwindow = new(src)
+	smartwindow.id_tag = id_tag
+	smartwindow.frequency = frequency
+
+/obj/machinery/door/window/brigdoor/smartglass
+	var/frequency = 1449
+
+/obj/machinery/door/window/brigdoor/smartglass/initialize()
+	smartwindow = new(src)
+	smartwindow.id_tag = id_tag
+	smartwindow.frequency = frequency
+
+/obj/machinery/door/window/plasma/smartglass
+	var/frequency = 1449
+
+/obj/machinery/door/window/plasma/smartglass/initialize()
+	smartwindow = new(src)
+	smartwindow.id_tag = id_tag
+	smartwindow.frequency = frequency
+
+/obj/machinery/door/window/plasma/secure/smartglass
+	var/frequency = 1449
+
+/obj/machinery/door/window/plasma/secure/smartglass/initialize()
+	smartwindow = new(src)
+	smartwindow.id_tag = id_tag
+	smartwindow.frequency = frequency

--- a/code/game/machinery/smartglass.dm
+++ b/code/game/machinery/smartglass.dm
@@ -36,7 +36,6 @@
 	..()
 	radio_connection = radio_controller.add_object(src, frequency, RADIO_AIRLOCK)
 	Ourwindow = loc
-	Ourwindow.smart_toggle()
 
 /obj/machinery/smartglass_electronics/Destroy()
 	radio_controller.remove_object(src, frequency)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -694,6 +694,7 @@ var/list/one_way_windows
 
 
 // Used on Packed ; smartglassified roundstart
+// TODO: Remove this snowflake stuff.
 /obj/structure/window/reinforced/plasma/interogation_room/initialize()
 	smartwindow = new(src)
 	smartwindow.id_tag = "InterogationRoomIDTag"
@@ -736,6 +737,80 @@ var/list/one_way_windows
 /obj/structure/window/reinforced/clockwork/loose
 	anchored = 0
 	d_state = 0
+
+// Smartglass for mappers, smartglassified on roundstart.
+//the id_tag of the actual pane itself is passed to the smartglass electronics on initialization, it's not used for anything else
+/obj/structure/window/smart
+	var/id_tag = null
+	var/frequency = 1449
+
+/obj/structure/window/smart/initialize()
+	smartwindow = new(src)
+	smartwindow.id_tag = id_tag
+	smartwindow.frequency = frequency
+
+/obj/structure/window/full/smart
+	var/id_tag = null
+	var/frequency = 1449
+
+/obj/structure/window/full/smart/initialize()
+	smartwindow = new(src)
+	smartwindow.id_tag = id_tag
+	smartwindow.frequency = frequency
+
+/obj/structure/window/reinforced/smart
+	var/id_tag = null
+	var/frequency = 1449
+
+/obj/structure/window/reinforced/smart/initialize()
+	smartwindow = new(src)
+	smartwindow.id_tag = id_tag
+	smartwindow.frequency = frequency
+
+/obj/structure/window/full/reinforced/smart
+	var/id_tag = null
+	var/frequency = 1449
+
+/obj/structure/window/full/reinforced/smart/initialize()
+	smartwindow = new(src)
+	smartwindow.id_tag = id_tag
+	smartwindow.frequency = frequency
+
+/obj/structure/window/plasma/smart
+	var/id_tag = null
+	var/frequency = 1449
+
+/obj/structure/window/plasma/smart/initialize()
+	smartwindow = new(src)
+	smartwindow.id_tag = id_tag
+	smartwindow.frequency = frequency
+
+/obj/structure/window/full/plasma/smart
+	var/id_tag = null
+	var/frequency = 1449
+
+/obj/structure/window/full/plasma/smart/initialize()
+	smartwindow = new(src)
+	smartwindow.id_tag = id_tag
+	smartwindow.frequency = frequency
+
+/obj/structure/window/reinforced/plasma/smart
+	var/id_tag = null
+	var/frequency = 1449
+
+/obj/structure/window/reinforced/plasma/smart/initialize()
+	smartwindow = new(src)
+	smartwindow.id_tag = id_tag
+	smartwindow.frequency = frequency
+
+/obj/structure/window/full/reinforced/plasma/smart
+	var/id_tag = null
+	var/frequency = 1449
+
+/obj/structure/window/full/reinforced/plasma/smart/initialize()
+	smartwindow = new(src)
+	smartwindow.id_tag = id_tag
+	smartwindow.frequency = frequency
 
 /obj/structure/window/send_to_past(var/duration)
 	..()


### PR DESCRIPTION
Smartglass (glass that turns dark when you press a button) was a bit janky, so I tried to fix it.

This adds mappable types for all windows and windoors that have smartglass functionality in them. To use them, create a new instance based on the type and set the `id_tag`. Then create a button (`/obj/machinery/access_button`, or some other device that uses this type of remote signalling might work too), set the `master_tag` to match the smartglass (and make sure the frequency matches too; it will by default, since it uses the standard 1449 frequency), and set the `command` to `"toggle-transparency"`.

Yes, this means that the standard airlock controlling buttons used for most other things (`/obj/machinery/door_control`) will not work with the smartglass. I did not design this (SonixApache did), but trust me and him, this is the better solution.

There's some leftover stuff used on Packed and Roid that uses a bunch of snowflake stuff, including special `obj/machinery/door_control` buttons to control the glass instead of the correct kind of button. I'm not touching that because it requires map changes to fix, and there are several map PRs up, and the map merger is beyond the collabs' understanding, and I don't want to deal with map merge conflicts right now because I should be working on a deadline due next week. I marked this with a TODO comment so that it'll stay unfixed until we move on to a fancy build system in 3 years that warns about TODO comments, which is when someone will come by and remove the comment.

Webum of the smartglass in action: https://streamable.com/520aa

<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation or the coding discord (you can find an invite link on the irc or the thread) to discuss your changes, or if you need help.

== SELF LABELLING PRs ==
You can now self-label your PR! The syntax is simple. Just put [<labeltag>] anywhere in your PR,
where <labeltag> is to be replaced by one of the following (allowing with the resultant tag)
just ctrl+f the list or something. I know it's long.

administration = "Logging / Administration"
away = "Mapping (Away Mission :earth_africa:)"
bagel = "Mapping (Bagel :o:)"
box = "Mapping (Box :baby:)"
bugfix = "Bug / Fix"
bus = "Mapping (Bus :bus:)"
byond = "T-Thanks BYOND"
consistency = "Consistency Issue"
controversial = "Controversial"
deff = "Mapping (Deff :wastebasket:)"
discussion = "Discussion"
dnm = "✋ Do Not Merge ✋"
easy = "Easy Fix"
exploitable = "Exploitable"
featureloss = "Feature Loss"
featurerequest = "Feature Request"
first = "good first issue"
formatting = "Grammar / Formatting"
gamemode = "Gameplay / Gamemode"
gameplay = "Gameplay / Gamemode"
general = "Mapping (General :world_map:)"
goonchat = "Goonchat"
grammar = "Grammar / Formatting"
help = "help wanted"
hotfix = "Hotfix"
libvg = "libvg"
logging = "Logging / Administration"
meta = "Mapping (Meta :no_mobile_phones:)"
needspritework = "Needs Spritework"
oversight = "Oversight"
packed = "Mapping (Packed :package:)"
parallax = "Parallax"
qol = "❤️ Quality of Life ❤️"
roid = "Mapping (Roidstation :pick:)"
role = "Role Datums"
roleissue = "Role Datums Issue"
runtime = "Runtime Log"
sanity = "Sanity / Ghosthands"
snowmap = "Mapping (Snowmap ❄)"
sound = "Sound"
sprites = "Sprites"
spriteworkdone = "Spritework Done Needs Coder"
system = "System"
taxi = "Mapping (Taxi :taxi:)"
tested = "100%  tested"
tweak = "Tweak"
ui = "UI"
vault = "Mapping (Vault :question:)"
vote = "⛔ Requires Server Vote ⛔"
wip = "WiP"

== CHANGELOGS ==
Changelogs can be attached either by following the instructions in html/changelogs/example.yml, or by attaching an in-body changelog like the one attached to your PR automatically.

For the keys you can use in an in-body changelog, they are the same as described in example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!

An example changelog is attached to this PR for your convenience:
-->

:cl:
 * bugfix: smartglass on windoors now works as intended