### PR TITLE
Fixing a potential exploit of the sacrifice target re-roll mechanic

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
@@ -600,7 +600,7 @@
 									return
 								else
 									var/turf/T = get_turf(O.sacrifice_target)
-									if ((T.z == CENTCOMM_Z) && (istype(T.loc, /area/shuttle/escape/centcom) || istype(T.loc, /area/shuttle/escape_pod1/centcom) || istype(T.loc, /area/shuttle/escape_pod2/centcom) || istype(T.loc, /area/shuttle/escape_pod3/centcom)|| istype(T.loc, /area/shuttle/escape_pod5/centcom)))
+									if ((T.z == CENTCOMM_Z) && (istype(T.loc, /area/shuttle/escape/centcom) || istype(T.loc, /area/shuttle/escape_pod1/transit) || istype(T.loc, /area/shuttle/escape_pod2/transit) || istype(T.loc, /area/shuttle/escape_pod3/transit)|| istype(T.loc, /area/shuttle/escape_pod5/transit)))
 										to_chat(user,"<b>\The [O.sacrifice_target] has fled the station along with the rest of the crew. Unless we can bring them back in time with a Path rune or sacrifice him where he stands, it's over.</b>")
 										return
 									else if (T.z != STATION_Z)//if the target fled the station, offer to reroll the target. May or not add penalties for that later.

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
@@ -600,7 +600,10 @@
 									return
 								else
 									var/turf/T = get_turf(O.sacrifice_target)
-									if (T.z != STATION_Z)//if the target fled the station, offer to reroll the target. May or not add penalties for that later.
+									if ((T.z == CENTCOMM_Z) && (istype(T.loc, /area/shuttle/escape/centcom) || istype(T.loc, /area/shuttle/escape_pod1/centcom) || istype(T.loc, /area/shuttle/escape_pod2/centcom) || istype(T.loc, /area/shuttle/escape_pod3/centcom)|| istype(T.loc, /area/shuttle/escape_pod5/centcom)))
+										to_chat(user,"<b>\The [O.sacrifice_target] has fled the station along with the rest of the crew. Unless we can bring them back in time with a Path rune or sacrifice him where he stands, it's over.</b>")
+										return
+									else if (T.z != STATION_Z)//if the target fled the station, offer to reroll the target. May or not add penalties for that later.
 										var/choice = alert(user,"The target has fled the station, do you wish for another sacrifice target to be selected?","[name]","Yes","No")
 										if (choice == "Yes")
 											replace_target(user)

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
@@ -600,7 +600,8 @@
 									return
 								else
 									var/turf/T = get_turf(O.sacrifice_target)
-									if ((T.z == CENTCOMM_Z) && (istype(T.loc, /area/shuttle/escape/centcom) || istype(T.loc, /area/shuttle/escape_pod1/transit) || istype(T.loc, /area/shuttle/escape_pod2/transit) || istype(T.loc, /area/shuttle/escape_pod3/transit)|| istype(T.loc, /area/shuttle/escape_pod5/transit)))
+									var/datum/shuttle/S = is_on_shuttle(T)
+									if ((T.z == CENTCOMM_Z) && (emergency_shuttle.shuttle == S || emergency_shuttle.escape_pods.Find(S)))
 										to_chat(user,"<b>\The [O.sacrifice_target] has fled the station along with the rest of the crew. Unless we can bring them back in time with a Path rune or sacrifice him where he stands, it's over.</b>")
 										return
 									else if (T.z != STATION_Z)//if the target fled the station, offer to reroll the target. May or not add penalties for that later.


### PR DESCRIPTION
:cl:
* bugfix: If the sacrifice target escape the station on the emergency shuttle or an escape pod, the cult won't be able to just reroll a new target at an altar.