### PR TITLE
Androids -> Droids

### DIFF
--- a/code/game/objects/items/robot/robot_items/robot_mobility.dm
+++ b/code/game/objects/items/robot/robot_items/robot_mobility.dm
@@ -1,5 +1,5 @@
 /obj/item/borg/combat/mobility
 	name = "mobility module"
-	desc = "By retracting limbs and tucking in its head, a combat android can roll at high speeds."
+	desc = "By retracting limbs and tucking in its head, a combat model can move at high speeds."
 	icon = 'icons/obj/decals.dmi'
 	icon_state = "shock"

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -290,7 +290,7 @@ var/list/cyborg_list = list()
 		braintype = "Robot"
 	else
 		if(istype(mmi, /obj/item/device/mmi/posibrain))
-			braintype = "Android"
+			braintype = "Droid"
 		else
 			braintype = "Cyborg"
 

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -599,7 +599,7 @@
 	modules += new /obj/item/weapon/pickaxe/jackhammer/combat(src)
 	modules += new /obj/item/borg/combat/shield(src)
 	modules += new /obj/item/borg/combat/mobility(src)
-	modules += new /obj/item/weapon/wrench(src) //Is a combat android really going to be stopped by a chair?
+	modules += new /obj/item/weapon/wrench(src) //Is a combat machine really going to be stopped by a chair?
 	emag = new /obj/item/weapon/gun/energy/laser/cannon/cyborg(src)
 
 	sensor_augs = list("Security", "Medical", "Mesons", "Thermal", "Light Amplification", "Disable")


### PR DESCRIPTION
Androids are machines made to look like humans. Calling a posibrain-powered robot "human-like" is plain wrong. Let's drop the "andr"(Greek root ἀνδρ- man-) and use just "Droid" instead. #20644 when?

:cl:
 * tweak: Androids are now called Droids.