### PR TITLE
Ports Dreamseeker window flashing from TG

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1783,6 +1783,6 @@ Game Mode config tags:
         var/mob/M = C
         if(M.client)
             C = M.client
-    if(!C || (!C.prefs.window_flashing && !ignorepref))
+    if(!istype(C) || (!C.prefs.window_flashing && !ignorepref))
         return
     winset(C, "mainwindow", "flash=5")

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1776,3 +1776,13 @@ Game Mode config tags:
 		return M.mind.key
 	else
 		return null
+
+//Ported from TG
+/proc/window_flash(client/C, ignorepref = FALSE)
+    if(ismob(C))
+        var/mob/M = C
+        if(M.client)
+            C = M.client
+    if(!C || (!C.prefs.window_flashing && !ignorepref))
+        return
+    winset(C, "mainwindow", "flash=5")

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -134,6 +134,7 @@ var/const/MAX_SAVE_SLOTS = 8
 	var/hear_instruments = 1
 	var/ambience_volume = 25
 	var/credits_volume = 75
+	var/window_flashing = 1
 
 		//Mob preview
 	var/icon/preview_icon = null
@@ -397,6 +398,8 @@ var/const/MAX_SAVE_SLOTS = 8
 	<a href='?_src_=prefs;preference=jingle'><b>[jingle]</b></a><br>
 	<b>Credits/Jingle Volume:</b>
 	<a href='?_src_=prefs;preference=credits_volume'><b>[credits_volume]</b></a><br>
+	<b>Window Flashing</b>
+	<a href='?_src_=prefs;preference=window_flashing'><b>[(window_flashing) ? "Yes":"No"]</b></a><br>
   </div>
 </div>"}
 
@@ -1472,6 +1475,9 @@ NOTE:  The change will take effect AFTER any current recruiting periods."}
 
 				if("credits_volume")
 					credits_volume = min(max(input(user, "Enter the new volume you wish to use. (0-100, default is 75)","Credits/Jingle Volume", credits_volume), 0), 100)
+
+				if("window_flashing")
+					window_flashing = !window_flashing
 
 			if(user.client.holder)
 				switch(href_list["preference"])

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -104,6 +104,7 @@
 	credits_volume	=	text2num(preference_list_client["credits_volume"])
 	credits 		=	preference_list_client["credits"]
 	jingle	 		=	preference_list_client["jingle"]
+	window_flashing  =	text2num(preference_list_client["window_flashing"])
 
 	ooccolor		= 	sanitize_hexcolor(ooccolor, initial(ooccolor))
 	lastchangelog	= 	sanitize_text(lastchangelog, initial(lastchangelog))
@@ -131,6 +132,7 @@
 	hear_instruments =	sanitize_integer(hear_instruments, 0, 1, initial(hear_instruments))
 	ambience_volume = sanitize_integer(ambience_volume, 0, 100, initial(ambience_volume))
 	credits_volume  = sanitize_integer(credits_volume, 0, 100, initial(credits_volume))
+	window_flashing = sanitize_integer(window_flashing, 0, 1, initial(window_flashing))
 	initialize_preferences()
 	return 1
 
@@ -212,15 +214,15 @@
 	check.Add("SELECT ckey FROM client WHERE ckey = ?", ckey)
 	if(check.Execute(db))
 		if(!check.NextRow())
-			q.Add("INSERT into client (ckey, ooc_color, lastchangelog, UI_style, default_slot, toggles, UI_style_color, UI_style_alpha, warns, warnbans, randomslot, volume, usewmp, special, usenanoui, tooltips, progress_bars, space_parallax, space_dust, parallax_speed, stumble, attack_animation, pulltoggle, credits, jingle, hear_voicesound, hear_instruments, ambience_volume, credits_volume) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",\
-			ckey, ooccolor, lastchangelog, UI_style, default_slot, toggles, UI_style_color, UI_style_alpha, warns, warnbans, randomslot, volume, usewmp, special_popup, usenanoui, tooltips, progress_bars, space_parallax, space_dust, parallax_speed, stumble, attack_animation, pulltoggle, credits, jingle, hear_voicesound, hear_instruments, ambience_volume, credits_volume)
+			q.Add("INSERT into client (ckey, ooc_color, lastchangelog, UI_style, default_slot, toggles, UI_style_color, UI_style_alpha, warns, warnbans, randomslot, volume, usewmp, special, usenanoui, tooltips, progress_bars, space_parallax, space_dust, parallax_speed, stumble, attack_animation, pulltoggle, credits, jingle, hear_voicesound, hear_instruments, ambience_volume, credits_volume, window_flashing) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",\
+			ckey, ooccolor, lastchangelog, UI_style, default_slot, toggles, UI_style_color, UI_style_alpha, warns, warnbans, randomslot, volume, usewmp, special_popup, usenanoui, tooltips, progress_bars, space_parallax, space_dust, parallax_speed, stumble, attack_animation, pulltoggle, credits, jingle, hear_voicesound, hear_instruments, ambience_volume, credits_volume, window_flashing)
 			if(!q.Execute(db))
 				message_admins("Error in save_preferences_sqlite [__FILE__] ln:[__LINE__] #: [q.Error()] - [q.ErrorMsg()]")
 				WARNING("Error in save_preferences_sqlite [__FILE__] ln:[__LINE__] #:[q.Error()] - [q.ErrorMsg()]")
 				return 0
 		else
-			q.Add("UPDATE client SET ooc_color=?,lastchangelog=?,UI_style=?,default_slot=?,toggles=?,UI_style_color=?,UI_style_alpha=?,warns=?,warnbans=?,randomslot=?,volume=?,usewmp=?,special=?,usenanoui=?,tooltips=?,progress_bars=?,space_parallax=?,space_dust=?,parallax_speed=?, stumble=?, attack_animation=?, pulltoggle=?, credits=?, jingle=?, hear_voicesound=?, hear_instruments=?, ambience_volume=?, credits_volume=? WHERE ckey = ?",\
-			ooccolor, lastchangelog, UI_style, default_slot, toggles, UI_style_color, UI_style_alpha, warns, warnbans, randomslot, volume, usewmp, special_popup, usenanoui, tooltips, progress_bars, space_parallax, space_dust, parallax_speed, stumble, attack_animation, pulltoggle, credits, jingle, hear_voicesound, hear_instruments, ambience_volume, credits_volume, ckey)
+			q.Add("UPDATE client SET ooc_color=?,lastchangelog=?,UI_style=?,default_slot=?,toggles=?,UI_style_color=?,UI_style_alpha=?,warns=?,warnbans=?,randomslot=?,volume=?,usewmp=?,special=?,usenanoui=?,tooltips=?,progress_bars=?,space_parallax=?,space_dust=?,parallax_speed=?, stumble=?, attack_animation=?, pulltoggle=?, credits=?, jingle=?, hear_voicesound=?, hear_instruments=?, ambience_volume=?, credits_volume=?, window_flashing=? WHERE ckey = ?",\
+			ooccolor, lastchangelog, UI_style, default_slot, toggles, UI_style_color, UI_style_alpha, warns, warnbans, randomslot, volume, usewmp, special_popup, usenanoui, tooltips, progress_bars, space_parallax, space_dust, parallax_speed, stumble, attack_animation, pulltoggle, credits, jingle, hear_voicesound, hear_instruments, ambience_volume, credits_volume, window_flashing, ckey)
 			if(!q.Execute(db))
 				message_admins("Error in save_preferences_sqlite [__FILE__] ln:[__LINE__] #: [q.Error()] - [q.ErrorMsg()]")
 				WARNING("Error in save_preferences_sqlite [__FILE__] ln:[__LINE__] #:[q.Error()] - [q.ErrorMsg()]")
@@ -267,6 +269,7 @@
 	S["hear_instruments"]<< hear_instruments
 	S["ambience_volume"]<< ambience_volume
 	S["credits_volume"]<< credits_volume
+	S["window_flashing"]<< window_flashing
 	return 1
 
 //saving volume changes

--- a/code/modules/migrations/SS13_Prefs/020-window_flashing.dm
+++ b/code/modules/migrations/SS13_Prefs/020-window_flashing.dm
@@ -1,0 +1,13 @@
+/datum/migration/sqlite/ss13_prefs/_020
+	id = 20
+	name = "Toggle Window Flashing"
+
+/datum/migration/sqlite/ss13_prefs/_020/up()
+	if(!hasColumn("client","window_flashing"))
+		return execute("ALTER TABLE `client` ADD COLUMN window_flashing INTEGER DEFAULT 1")
+	return TRUE
+
+/datum/migration/sqlite/ss13_prefs/_020/down()
+	if(hasColumn("client","window_flashing"))
+		return execute("ALTER TABLE `client` DROP COLUMN window_flashing")
+	return TRUE

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -1547,6 +1547,7 @@
 #include "code\modules\migrations\SS13_Prefs\017-add-instrument.dm"
 #include "code\modules\migrations\SS13_Prefs\018-add-ambience_vol.dm"
 #include "code\modules\migrations\SS13_Prefs\019-add-credits_vol.dm"
+#include "code\modules\migrations\SS13_Prefs\020-window_flashing.dm"
 #include "code\modules\migrations\SS13_Prefs\_base.dm"
 #include "code\modules\mining\abandonedcrates.dm"
 #include "code\modules\mining\debug_shit.dm"


### PR DESCRIPTION
Untested but probably works
This ports window flashing from TG
What the hell is with preferences though? I had to copypaste the whole thing from start to finish, why is it so much spaghetti and will anyone explain what each thing does?
The subsequent PR related to this will be having midround roles make your Dreamseeker window flash orange, preferably with options to have it off, for special/antag roles only, and for all roles.
:cl:
 * rscadd: Added a new function to the game that makes your Dreamseeker window flash orange. Currently not used by anything.