### PR TITLE
Improved combat text readability

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -931,7 +931,7 @@
 /obj/item/proc/on_block(damage, atom/blocked)
 	if(ismob(loc))
 		if(prob(50 - round(damage / 3)))
-			visible_message("<span class='bnotice'>[loc] blocks \the [blocked] with \the [src]!</span>")
+			visible_message("<span class='borange'>[loc] blocks \the [blocked] with \the [src]!</span>")
 			if(isatommovable(blocked))
 				var/atom/movable/M = blocked
 				M.throwing = FALSE

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -931,7 +931,7 @@
 /obj/item/proc/on_block(damage, atom/blocked)
 	if(ismob(loc))
 		if(prob(50 - round(damage / 3)))
-			visible_message("<span class='danger'>[loc] blocks \the [blocked] with \the [src]!</span>")
+			visible_message("<span class='bnotice'>[loc] blocks \the [blocked] with \the [src]!</span>")
 			if(isatommovable(blocked))
 				var/atom/movable/M = blocked
 				M.throwing = FALSE

--- a/code/game/objects/items/weapons/lance.dm
+++ b/code/game/objects/items/weapons/lance.dm
@@ -169,7 +169,7 @@
 				var/datum/organ/external/affecting = H.get_organ(ran_zone(owner.zone_sel.selecting))
 
 				if(H.check_shields(base_damage, L))
-					H.visible_message("<span class='bnotice'>[H] blocks \the [owner]'s [src.L.name] hit.</span>", "<span class='notice'>You block \the [owner]'s couched [src.L.name].</span>")
+					H.visible_message("<span class='borange'>[H] blocks \the [owner]'s [src.L.name] hit.</span>", "<span class='notice'>You block \the [owner]'s couched [src.L.name].</span>")
 					return
 
 				victim.apply_damage(base_damage, BRUTE, affecting)

--- a/code/game/objects/items/weapons/lance.dm
+++ b/code/game/objects/items/weapons/lance.dm
@@ -169,7 +169,7 @@
 				var/datum/organ/external/affecting = H.get_organ(ran_zone(owner.zone_sel.selecting))
 
 				if(H.check_shields(base_damage, L))
-					H.visible_message("<span class='danger'>[H] blocks \the [owner]'s [src.L.name] hit.</span>", "<span class='notice'>You block \the [owner]'s couched [src.L.name].</span>")
+					H.visible_message("<span class='bnotice'>[H] blocks \the [owner]'s [src.L.name] hit.</span>", "<span class='notice'>You block \the [owner]'s couched [src.L.name].</span>")
 					return
 
 				victim.apply_damage(base_damage, BRUTE, affecting)

--- a/code/modules/mob/living/carbon/combat.dm
+++ b/code/modules/mob/living/carbon/combat.dm
@@ -41,7 +41,7 @@
 	if(user == src) // Attacking yourself can't miss
 		target_zone = user.zone_sel.selecting
 	if(!target_zone && !src.stat)
-		visible_message("<span class='bnotice'>[user] misses [src] with \the [I]!</span>")
+		visible_message("<span class='borange'>[user] misses [src] with \the [I]!</span>")
 		return FALSE
 
 	if((user != src) && check_shields(I.force, I))

--- a/code/modules/mob/living/carbon/combat.dm
+++ b/code/modules/mob/living/carbon/combat.dm
@@ -41,7 +41,7 @@
 	if(user == src) // Attacking yourself can't miss
 		target_zone = user.zone_sel.selecting
 	if(!target_zone && !src.stat)
-		visible_message("<span class='danger'>[user] misses [src] with \the [I]!</span>")
+		visible_message("<span class='notice'>[user] misses [src] with \the [I]!</span>")
 		return FALSE
 
 	if((user != src) && check_shields(I.force, I))

--- a/code/modules/mob/living/carbon/combat.dm
+++ b/code/modules/mob/living/carbon/combat.dm
@@ -41,7 +41,7 @@
 	if(user == src) // Attacking yourself can't miss
 		target_zone = user.zone_sel.selecting
 	if(!target_zone && !src.stat)
-		visible_message("<span class='notice'>[user] misses [src] with \the [I]!</span>")
+		visible_message("<span class='bnotice'>[user] misses [src] with \the [I]!</span>")
 		return FALSE
 
 	if((user != src) && check_shields(I.force, I))

--- a/code/modules/mob/living/carbon/human/human_attackalien.dm
+++ b/code/modules/mob/living/carbon/human/human_attackalien.dm
@@ -1,7 +1,7 @@
 /mob/living/carbon/human/attack_alien(mob/living/carbon/alien/humanoid/M)
 	//M.delayNextAttack(10)
 	if(check_shields(0, M))
-		visible_message("<span class='bnotice'>[M] attempted to touch [src]!</span>")
+		visible_message("<span class='borange'>[M] attempted to touch [src]!</span>")
 		return 0
 
 	switch(M.a_intent)

--- a/code/modules/mob/living/carbon/human/human_attackalien.dm
+++ b/code/modules/mob/living/carbon/human/human_attackalien.dm
@@ -1,7 +1,7 @@
 /mob/living/carbon/human/attack_alien(mob/living/carbon/alien/humanoid/M)
 	//M.delayNextAttack(10)
 	if(check_shields(0, M))
-		visible_message("<span class='danger'>[M] attempted to touch [src]!</span>")
+		visible_message("<span class='bnotice'>[M] attempted to touch [src]!</span>")
 		return 0
 
 	switch(M.a_intent)

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -183,7 +183,7 @@
 	..()
 
 	if((M != src) && check_shields(0, M))
-		visible_message("<span class='bnotice'>[M] attempts to touch [src]!</span>")
+		visible_message("<span class='borange'>[M] attempts to touch [src]!</span>")
 		return 0
 
 

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -183,7 +183,7 @@
 	..()
 
 	if((M != src) && check_shields(0, M))
-		visible_message("<span class='danger'>[M] attempts to touch [src]!</span>")
+		visible_message("<span class='bnotice'>[M] attempts to touch [src]!</span>")
 		return 0
 
 

--- a/code/modules/mob/living/combat.dm
+++ b/code/modules/mob/living/combat.dm
@@ -82,7 +82,7 @@
 	if(miss_sound)
 		playsound(loc, miss_sound, 25, 1, -1)
 
-	visible_message("<span class='bnotice'>[src] misses [target]!</span>")
+	visible_message("<span class='borange'>[src] misses [target]!</span>")
 	return TRUE
 
 /mob/living/proc/get_attack_message(mob/living/target, attack_verb)

--- a/code/modules/mob/living/combat.dm
+++ b/code/modules/mob/living/combat.dm
@@ -82,7 +82,7 @@
 	if(miss_sound)
 		playsound(loc, miss_sound, 25, 1, -1)
 
-	visible_message("<span class='danger'>[src] misses [target]!</span>")
+	visible_message("<span class='notice'>[src] misses [target]!</span>")
 	return TRUE
 
 /mob/living/proc/get_attack_message(mob/living/target, attack_verb)

--- a/code/modules/mob/living/combat.dm
+++ b/code/modules/mob/living/combat.dm
@@ -82,7 +82,7 @@
 	if(miss_sound)
 		playsound(loc, miss_sound, 25, 1, -1)
 
-	visible_message("<span class='notice'>[src] misses [target]!</span>")
+	visible_message("<span class='bnotice'>[src] misses [target]!</span>")
 	return TRUE
 
 /mob/living/proc/get_attack_message(mob/living/target, attack_verb)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -29,14 +29,14 @@
 			if(absorb_text)
 				show_message("[absorb_text]")
 			else
-				show_message("<span class='bnotice'>Your armor ABSORBS the blow!</span>")
+				show_message("<span class='borange'>Your armor ABSORBS the blow!</span>")
 		return 2
 	if(absorb == 1)
 		if(!quiet)
 			if(absorb_text)
 				show_message("[soften_text]",4)
 			else
-				show_message("<span class='bnotice'>Your armor SOFTENS the blow!</span>")
+				show_message("<span class='borange'>Your armor SOFTENS the blow!</span>")
 		return 1
 	return 0
 
@@ -193,7 +193,7 @@
 
 	if(!damage)
 		playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
-		visible_message("<span class='bnotice'>\The [M] has attempted to bite \the [src]!</span>")
+		visible_message("<span class='borange'>\The [M] has attempted to bite \the [src]!</span>")
 		return 0
 
 	playsound(loc, 'sound/weapons/bite.ogg', 50, 1, -1)
@@ -233,7 +233,7 @@
 
 	if(!damage)
 		playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
-		visible_message("<span class='bnotice'>\The [M] attempts to kick \the [src]!</span>")
+		visible_message("<span class='borange'>\The [M] attempts to kick \the [src]!</span>")
 		return 0
 
 	//Handle shoes

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -193,7 +193,7 @@
 
 	if(!damage)
 		playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
-		visible_message("<span class='danger'>\The [M] has attempted to bite \the [src]!</span>")
+		visible_message("<span class='bnotice'>\The [M] has attempted to bite \the [src]!</span>")
 		return 0
 
 	playsound(loc, 'sound/weapons/bite.ogg', 50, 1, -1)
@@ -233,7 +233,7 @@
 
 	if(!damage)
 		playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
-		visible_message("<span class='danger'>\The [M] attempts to kick \the [src]!</span>")
+		visible_message("<span class='bnotice'>\The [M] attempts to kick \the [src]!</span>")
 		return 0
 
 	//Handle shoes

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -29,14 +29,14 @@
 			if(absorb_text)
 				show_message("[absorb_text]")
 			else
-				show_message("<span class='warning'>Your armor absorbs the blow!</span>")
+				show_message("<span class='notice'>Your armor ABSORBS the blow!</span>")
 		return 2
 	if(absorb == 1)
 		if(!quiet)
 			if(absorb_text)
 				show_message("[soften_text]",4)
 			else
-				show_message("<span class='warning'>Your armor softens the blow!</span>")
+				show_message("<span class='notice'>Your armor SOFTENS the blow!</span>")
 		return 1
 	return 0
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -29,14 +29,14 @@
 			if(absorb_text)
 				show_message("[absorb_text]")
 			else
-				show_message("<span class='notice'>Your armor ABSORBS the blow!</span>")
+				show_message("<span class='bnotice'>Your armor ABSORBS the blow!</span>")
 		return 2
 	if(absorb == 1)
 		if(!quiet)
 			if(absorb_text)
 				show_message("[soften_text]",4)
 			else
-				show_message("<span class='notice'>Your armor SOFTENS the blow!</span>")
+				show_message("<span class='bnotice'>Your armor SOFTENS the blow!</span>")
 		return 1
 	return 0
 

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -1,4 +1,4 @@
-
+f
 /*
  * Use: Caches beam state images and holds turfs that had these images overlaid.
  * Structure:

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -1,4 +1,4 @@
-f
+
 /*
  * Use: Caches beam state images and holds turfs that had these images overlaid.
  * Structure:

--- a/goon/browserassets/css/browserOutput.css
+++ b/goon/browserassets/css/browserOutput.css
@@ -296,6 +296,7 @@ h1.alert, h2.alert		{color: #000000;}
 .golem					{color: #B4DBCB; font-weight: bold;}
 .slime					{color: #34A7Af;}
 .orange					{color: #ffa500;}
+.borange				{color: #ffa500; font-weight: bold;}
 .maroon					{color: #800000;}
 
 /* /vg/ */


### PR DESCRIPTION
Combat messages now show up in bold orange if the hit was softened, absorbed, or missed. That way, you'll know better.
:cl:
 * tweak: Hits that have been absorbed (nullified), softened (halved), missed, or blocked, will show up with orange bold text instead of red for improved readability.