### PR TITLE
New rune effect - Unholy Threshold

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult_runes.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_runes.dm
@@ -494,7 +494,7 @@ var/list/uristrune_cache = list()//icon cache, so the whole blending process is 
 			if (src && loc)
 				conceal_cooldown = 0
 		return 1
-	return 
+	return 0
 
 // -- Warding runes, detect ennemies
 /obj/effect/rune/ward/

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_runes.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_runes.dm
@@ -494,4 +494,33 @@ var/list/uristrune_cache = list()//icon cache, so the whole blending process is 
 			if (src && loc)
 				conceal_cooldown = 0
 		return 1
-	return 0
+	return 
+
+// -- Warding runes, detect ennemies
+/obj/effect/rune/ward/
+
+/obj/effect/rune/ward/New()
+	conceal()
+	return ..()
+
+/obj/effect/rune/ward/Crossed(var/atom/movable/mover)
+	// Triggers if a living non-cultist mob crosses the rune.
+	if (!isliving(mover))
+		return
+	var/mob/living/L = mover
+	if (!iscultist(L))
+		for (var/mob/living/seer in range(7, src))
+			if (iscultist(seer) && seer.client && seer.client.screen)
+				seer.client.screen += mover // see the mover for a set period of time
+				seer.client.screen += anim(location = get_turf(seer), target = mover, a_icon = 'icons/effects/224x224.dmi', flick_anim = "rune_reveal", lay = NARSIE_GLOW, offX = -WORLD_ICON_SIZE, offY = -WORLD_ICON_SIZE, plane = LIGHTING_PLANE)		
+		var/count = 10
+
+		spawn()
+			do
+				sleep(1)
+				count--
+			while(!mover.gcDestroyed && count)
+
+			for (var/mob/M in player_list)
+				if (M.client)
+					M.client.screen -= mover

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_runes.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_runes.dm
@@ -543,7 +543,6 @@ var/list/uristrune_cache = list()//icon cache, so the whole blending process is 
 				var/delta_y = (L.y - seer.y)
 				image_intruder.pixel_x = delta_x*WORLD_ICON_SIZE
 				image_intruder.pixel_y = delta_y*WORLD_ICON_SIZE
-				ims += image_intruder
 				seer << image_intruder
 				spawn(3)
 					del image_intruder

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_runes.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_runes.dm
@@ -526,7 +526,6 @@ var/list/uristrune_cache = list()//icon cache, so the whole blending process is 
 				var/delta_y = (L.y - seer.y)
 				image_intruder.pixel_x = delta_x*WORLD_ICON_SIZE
 				image_intruder.pixel_y = delta_y*WORLD_ICON_SIZE
-				ims += image_intruder
 				seers += seer
 				seer << image_intruder // see the mover for a set period of time
 				anim(location = get_turf(seer), target = seer, a_icon = 'icons/effects/224x224.dmi', flick_anim = "rune_reveal", lay = NARSIE_GLOW, offX = 0, offY = 0, plane = LIGHTING_PLANE)		

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_runes.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_runes.dm
@@ -499,7 +499,7 @@ var/list/uristrune_cache = list()//icon cache, so the whole blending process is 
 // -- Warding runes, detect ennemies
 /obj/effect/rune/ward/
 	var/uses = 5
-	var/last_threeshold = -1
+	var/last_threshold = -1
 
 /obj/effect/rune/ward/New()
 	conceal()
@@ -513,11 +513,11 @@ var/list/uristrune_cache = list()//icon cache, so the whole blending process is 
 	if (uses < 0)
 		qdel(src)
 		return
-	if (last_threeshold + 10 SECONDS > world.time)
+	if (last_threshold + 10 SECONDS > world.time)
 		return
 	if (!iscultist(L))
 		uses--
-		last_threeshold = world.time
+		last_threshold = world.time
 		var/list/seers = list()
 		var/list/ims = list()
 		for (var/mob/living/seer in range(7, src))

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_runes.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_runes.dm
@@ -519,7 +519,6 @@ var/list/uristrune_cache = list()//icon cache, so the whole blending process is 
 		uses--
 		last_threshold = world.time
 		var/list/seers = list()
-		var/list/ims = list()
 		for (var/mob/living/seer in range(7, src))
 			if (iscultist(seer) && seer.client && seer.client.screen)
 				var/image/image_intruder = image(L, loc = seer, layer = ABOVE_LIGHTING_LAYER, dir = L.dir)
@@ -531,9 +530,8 @@ var/list/uristrune_cache = list()//icon cache, so the whole blending process is 
 				seers += seer
 				seer << image_intruder // see the mover for a set period of time
 				anim(location = get_turf(seer), target = seer, a_icon = 'icons/effects/224x224.dmi', flick_anim = "rune_reveal", lay = NARSIE_GLOW, offX = 0, offY = 0, plane = LIGHTING_PLANE)		
-		sleep(1)
-		for (var/image/I in ims)
-			del I
+				spawn(3)
+					del image_intruder
 		var/count = 60
 		do
 			for (var/mob/living/seer in seers)
@@ -547,8 +545,7 @@ var/list/uristrune_cache = list()//icon cache, so the whole blending process is 
 				image_intruder.pixel_y = delta_y*WORLD_ICON_SIZE
 				ims += image_intruder
 				seer << image_intruder
-			sleep(3)
-			for (var/image/I in ims)
-				del I
+				spawn(3)
+					del image_intruder
 			count--
 		while (count && seers.len)

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
@@ -2629,14 +2629,15 @@ var/list/bloodcult_exitportals = list()
 
 // RUNE XXI
 /datum/rune_spell/ward
-	name = "Warding"
+	name = "Unholy threeshold"
 	desc = "Create a rune that will alert you if someone tresspass."
 	Act_restriction = CULT_ACT_I
+	talisman_absorb = 0 // No absorbing.
 	invocation = "Wardiwch eich jyngl! Nid yw'n anodd."
 	word1 = /datum/cultword/see
 	word2 = /datum/cultword/other
 	word3 = /datum/cultword/join
-	page = "This rune will alert us if any unbeliever crosses it. It will also reveal his position for a short."
+	page = "This rune will alert us if any unbeliever crosses it. It will also reveal his position for a short duration."
 
 /datum/rune_spell/ward/cast()
 	var/obj/effect/rune/R = spell_holder

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
@@ -2627,6 +2627,21 @@ var/list/bloodcult_exitportals = list()
 	plane = ABOVE_HUMAN_PLANE
 	mouse_opacity = 0
 
+// RUNE XXI
+/datum/rune_spell/ward
+	name = "Warding"
+	desc = "Create a rune that will alert you if someone tresspass."
+	Act_restriction = CULT_ACT_I
+	invocation = "Wardiwch eich jyngl! Nid yw'n anodd."
+	word1 = /datum/cultword/see
+	word2 = /datum/cultword/other
+	word3 = /datum/cultword/join
+	page = "This rune will alert us if any unbeliever crosses it. It will also reveal his position for a short."
+
+/datum/rune_spell/ward/cast()
+	var/obj/effect/rune/R = spell_holder
+	new /obj/effect/rune/ward(R)
+	qdel(R)
 
 /*
 	if((word1 == cultwords["travel"] && word2 == cultwords["self"]))

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
@@ -2629,15 +2629,15 @@ var/list/bloodcult_exitportals = list()
 
 // RUNE XXI
 /datum/rune_spell/ward
-	name = "Unholy threeshold"
-	desc = "Create a rune that will alert you if someone tresspass."
+	name = "Unholy threshold"
+	desc = "Create a rune that will alert you if someone tresspasses."
 	Act_restriction = CULT_ACT_I
 	talisman_absorb = 0 // No absorbing.
 	invocation = "Wardiwch eich jyngl! Nid yw'n anodd."
 	word1 = /datum/cultword/see
 	word2 = /datum/cultword/other
 	word3 = /datum/cultword/join
-	page = "This rune will alert us if any unbeliever crosses it. It will also reveal his position for a short duration."
+	page = "This rune will alert us if any unbeliever crosses it. It will also reveal their position for a short duration."
 
 /datum/rune_spell/ward/cast()
 	var/obj/effect/rune/R = spell_holder

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
@@ -1516,6 +1516,9 @@ var/list/blind_victims = list()
 	word2 = /datum/cultword/see
 	word3 = /datum/cultword/hide
 	page = "This rune (whose words are the same as the Conceal rune in reverse) lets you reveal every rune and structures in a circular 7 tile range around it. Each revealed rune will stun non-cultists in a 3 tile range around them, stunning and muting them for 2 seconds, up to a total of 10 seconds. Affects through walls. The stun ends if the victims are moved away from where they stand, unless they get knockdown first, so you might want to follow up with a Stun talisman. "
+	
+	walk_effect = TRUE
+	
 	var/effect_range=7
 	var/shock_range=3
 	var/shock_per_obj=2
@@ -2678,7 +2681,7 @@ var/list/bloodcult_exitportals = list()
 	layer = SHADOW_LAYER
 	plane = ABOVE_HUMAN_PLANE
 	mouse_opacity = 0
-	
+
 /*
 	if((word1 == cultwords["travel"] && word2 == cultwords["self"]))
 		return "Travel Self"


### PR DESCRIPTION
[powercreep] [gameplay]

Basically, it wards your maint
Summon the rune, invoke it, it creates a threeshold that will alert nearby cultists with a little animation if a non-cultist crosses it.
It will also reveal the position of this enemy every 0.3 seconds for 6 seconds.
It works every 10 seconds.
Tested locally with two persons, it works and seems to be fluid/seamless for both players. However, I have no idea how wasteful it is to `del` images on the fly like that in a concrete case. So, might need to be live-tested with many players.

:cl:
- rscadd: Added a new rune effect. A "reveal" rune, concealed or not, will warn you if an enemy crosses it.