### PR TITLE
Fixes glass tile creation

### DIFF
--- a/code/game/objects/items/stacks/tiles/tiles.dm
+++ b/code/game/objects/items/stacks/tiles/tiles.dm
@@ -133,6 +133,7 @@
 	name = "glass tile"
 	desc = "A relatively clear reinforced glass tile."
 	icon_state = "tile_rglass"
+	max_amount = 60
 
 /obj/item/stack/glass_tile/rglass/proc/build(turf/S as turf)
 	var/obj/structure/lattice/L = S.canBuildCatwalk(src)


### PR DESCRIPTION
Fixes #22471

It was runtiming due to the type having no defined `max_amount`, so I gave them a `max_amount` equal to all other floortiles