### PR TITLE
Eswords can now slice open firelocks

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -282,6 +282,31 @@ var/global/list/alert_overlays_global = list()
 	if( iscrowbar(C) || ( istype(C,/obj/item/weapon/fireaxe) && C.wielded ) )
 		force_open(user, C)
 		return
+	
+	if((C.sharpness_flags & (CUT_AIRLOCK)) && user.a_intent == I_HURT)
+		if(!density)
+			return
+		if(blocked)
+			user.visible_message("<span class='warning'>[user] begins slicing through \the [src]!</span>", \
+								"<span class='notice'>You begin slicing through \the [src].</span>", \
+								"<span class='warning'>You hear slicing noises.</span>")
+			playsound(src, 'sound/items/Welder2.ogg', 100, 1)
+			if(do_after(user, src, 50))
+				if(!istype(src))
+					return
+				user.visible_message("<span class='warning'>[user] slices through \the [src]!</span>", \
+									"<span class='notice'>You slice through \the [src].</span>", \
+									"<span class='warning'>You hear slicing noises.</span>")
+				playsound(src, 'sound/items/Welder2.ogg', 100, 1)
+				blocked = !blocked
+				open()
+			return
+		else
+			user.visible_message("<span class='warning'>[user] swiftly slices \the [src] open!</span>",\
+								"You slice \the [src] open in one clean cut!",\
+								"You hear the sound of a swift, sharp slice.")
+			open()
+			return
 
 	if(istype(C, /obj/item/weapon/wrench))
 		if(blocked)


### PR DESCRIPTION
Eswords could cut open airlocks, bolted or welded or not, but were useless against puny firelocks? Ridicilous. End the firelock menace.

Harm intent eswords open firelocks, even if they're alarming. If they're welded, it takes five seconds to slice through. Compared to the 20 seconds of airlocks this may sound low, but there are potentially lots of firelocks and firelocks are fucking gay.

I'm not even going to admit this is powercreep because honestly fuck firelocks.

<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation or the coding discord (you can find an invite link on the irc or the thread) to discuss your changes, or if you need help.

== SELF LABELLING PRs ==
You can now self-label your PR! The syntax is simple. Just put [<labeltag>] anywhere in your PR,
where <labeltag> is to be replaced by one of the following (allowing with the resultant tag)
just ctrl+f the list or something. I know it's long.

administration = "Logging / Administration"
away = "Mapping (Away Mission :earth_africa:)"
bagel = "Mapping (Bagel :o:)"
box = "Mapping (Box :baby:)"
bugfix = "Bug / Fix"
bus = "Mapping (Bus :bus:)"
byond = "T-Thanks BYOND"
consistency = "Consistency Issue"
controversial = "Controversial"
deff = "Mapping (Deff :wastebasket:)"
discussion = "Discussion"
dnm = "✋ Do Not Merge ✋"
easy = "Easy Fix"
exploitable = "Exploitable"
featureloss = "Feature Loss"
featurerequest = "Feature Request"
first = "good first issue"
formatting = "Grammar / Formatting"
gamemode = "Gameplay / Gamemode"
gameplay = "Gameplay / Gamemode"
general = "Mapping (General :world_map:)"
goonchat = "Goonchat"
grammar = "Grammar / Formatting"
help = "help wanted"
hotfix = "Hotfix"
libvg = "libvg"
logging = "Logging / Administration"
meta = "Mapping (Meta :no_mobile_phones:)"
needspritework = "Needs Spritework"
oversight = "Oversight"
packed = "Mapping (Packed :package:)"
parallax = "Parallax"
qol = "❤️ Quality of Life ❤️"
roid = "Mapping (Roidstation :pick:)"
role = "Role Datums"
roleissue = "Role Datums Issue"
runtime = "Runtime Log"
sanity = "Sanity / Ghosthands"
snowmap = "Mapping (Snowmap ❄)"
sound = "Sound"
sprites = "Sprites"
spriteworkdone = "Spritework Done Needs Coder"
system = "System"
taxi = "Mapping (Taxi :taxi:)"
tested = "100%  tested"
tweak = "Tweak"
ui = "UI"
vault = "Mapping (Vault :question:)"
vote = "⛔ Requires Server Vote ⛔"
wip = "WiP"

== CHANGELOGS ==
Changelogs can be attached either by following the instructions in html/changelogs/example.yml, or by attaching an in-body changelog like the one attached to your PR automatically.

For the keys you can use in an in-body changelog, they are the same as described in example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!

An example changelog is attached to this PR for your convenience:
-->
:cl:
 * tweak: eswords can now open firelocks when on Harm intent.