### PR TITLE
Fixes an oopsie in chem dispenser overlays

### DIFF
--- a/code/game/machinery/scp_294.dm
+++ b/code/game/machinery/scp_294.dm
@@ -92,3 +92,6 @@
 
 	add_fingerprint(usr)
 	return 1 // update UIs attached to this object
+
+/obj/machinery/chem_dispenser/scp_294/update_icon()
+	return

--- a/code/modules/reagents/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/machinery/chem_dispenser.dm
@@ -13,6 +13,7 @@
 	var/rechargerate = 2
 	var/amount = 30
 	var/obj/item/weapon/reagent_containers/container = null
+	var/beaker_height
 	var/recharged = 0
 	var/custom = 0
 	var/useramount = 30 // Last used amount
@@ -332,6 +333,7 @@ USE THIS CHEMISTRY DISPENSER FOR MAPS SO THEY START AT 100 ENERGY
 		else
 			overlay = image('icons/obj/chemical.dmi', src, "dispenser_overlay1")
 
+		overlay.pixel_y = beaker_height * PIXEL_MULTIPLIER //used for children
 		overlay.pixel_x = pick(-7,-3, 1, 5, 8) * PIXEL_MULTIPLIER //puts the beaker under a random nozzle
 		overlays += overlay
 
@@ -377,6 +379,7 @@ USE THIS CHEMISTRY DISPENSER FOR MAPS SO THEY START AT 100 ENERGY
 /obj/machinery/chem_dispenser/soda_dispenser/
 	name = "Soda Dispenser"
 	icon_state = "soda_dispenser"
+	beaker_height = -5
 	required_quirk = MODULE_CAN_HANDLE_FOOD
 	dispensable_reagents = list(SPACEMOUNTAINWIND, SODAWATER, LEMON_LIME, DR_GIBB, COLA, ICE = T0C, TONIC)
 
@@ -402,6 +405,7 @@ USE THIS CHEMISTRY DISPENSER FOR MAPS SO THEY START AT 100 ENERGY
 /obj/machinery/chem_dispenser/booze_dispenser/
 	name = "Booze Dispenser"
 	icon_state = "booze_dispenser"
+	beaker_height = -6
 	required_quirk = MODULE_CAN_HANDLE_FOOD
 	dispensable_reagents = list(
 		BEER,


### PR DESCRIPTION
[bugfix]
:cl:
- bugfix: The beaker overlay now appears at the proper height on the brewer, soda dispenser, and booze dispenser; additionally it does not show up on SCP_294. 