### PR TITLE
Adds the gas giant atmospheric scoop

### DIFF
--- a/code/controllers/subsystem/sun.dm
+++ b/code/controllers/subsystem/sun.dm
@@ -1,7 +1,7 @@
-var/datum/subsystem/sun/SSsun
+var/datum/subsystem/solar_system/SSsun
 
 
-/datum/subsystem/sun
+/datum/subsystem/solar_system
 	name          = "Sun"
 	init_order    = SS_INIT_SUN
 	display_order = SS_DISPLAY_SUN
@@ -10,15 +10,15 @@ var/datum/subsystem/sun/SSsun
 	flags         = SS_NO_TICK_CHECK
 
 
-/datum/subsystem/sun/New()
+/datum/subsystem/solar_system/New()
 	NEW_SS_GLOBAL(SSsun)
 
 
-/datum/subsystem/sun/Initialize(timeofday)
+/datum/subsystem/solar_system/Initialize(timeofday)
 	sun = new
-
+	gas_giant = new
 	..()
 
 
-/datum/subsystem/sun/fire(resumed = FALSE)
+/datum/subsystem/solar_system/fire(resumed = FALSE)
 	sun.calc_position()

--- a/code/datums/gas_giant.dm
+++ b/code/datums/gas_giant.dm
@@ -1,0 +1,19 @@
+var/global/datum/gas_giant/gas_giant
+/**
+	Gas giant datum
+	Mostly for atmospherics
+		Is composed of base elemental gases, such as oxygen, nitrogen, and plasma
+**/
+/datum/gas_giant
+	var/datum/gas_mixture/comp = new //What atmosphere is the gas giant composed of
+
+/datum/gas_giant/New()
+	var/temperature = T0C+rand(-50,150)
+	comp.adjust_multi_temp(
+		GAS_OXYGEN, rand(1,25)*10000/(R_IDEAL_GAS_EQUATION*temperature),temperature,
+		GAS_NITROGEN, rand(4, 25)*10000/(R_IDEAL_GAS_EQUATION*temperature),temperature,
+		GAS_PLASMA, rand(2, 10)*10000/(R_IDEAL_GAS_EQUATION*temperature),temperature,
+		)
+
+/datum/gas_giant/proc/return_air()
+	return comp

--- a/code/game/machinery/atmoalter/gas_mine.dm
+++ b/code/game/machinery/atmoalter/gas_mine.dm
@@ -173,3 +173,10 @@
 	air_contents.adjust_multi(
 		GAS_OXYGEN, O2STANDARD * internal_pressure * air_contents.volume / (R_IDEAL_GAS_EQUATION * air_contents.temperature),
 		GAS_NITROGEN, N2STANDARD * internal_pressure * air_contents.volume / (R_IDEAL_GAS_EQUATION * air_contents.temperature))
+
+/obj/machinery/atmospherics/miner/planet
+	name = "\improper Atmospheric Scoop"
+	overlay_color = "#8788FF" //135, 139, 255
+
+/obj/machinery/atmospherics/miner/planet/AddAir()
+	air_contents = gas_giant.return_air()

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -236,6 +236,7 @@
 #include "code\datums\emotes.dm"
 #include "code\datums\feedback.dm"
 #include "code\datums\fuzzy_rules.dm"
+#include "code\datums\gas_giant.dm"
 #include "code\datums\locking_category.dm"
 #include "code\datums\map_elements.dm"
 #include "code\datums\mind.dm"


### PR DESCRIPTION
An idea that's been on my mind for a while. Rather than atmospherics being hyper-perfect gas miners only drawing a fucking lot of a specific gas, this miner takes a sample from the gas giant, which is inconsistent in its composition.

An atmospheric technician would then have something to do regarding making containment for filtered gases from the samples drawn by the scoop. This would give more room for adding new gases, rather than being stuck with the mapped 5 miner containment zones + 2 mixing rooms.

There is currently a method of making CO2 (Burning plasma with oxygen) but no gas-specific method of making N2O, so will look into this in the future. One suggestion was having plasma react with nitrogen at higher temperatures, or could have an ammonia-based gas that can be decomposed in presence of oxygen under high pressure? who knows.

Adds a gas giant datum, currently just holds the atmospheric composition of the gas giant that the station is supposedly orbiting, which is copied by the atmospheric scoop. Could have more done with it in the future (holding a non-specific field of antimatter that can be drawn from, or have some effect on random events such as radiation storms)
