### PR TITLE
Changes the shapeshift spell to be more flexible.

### DIFF
--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -21,6 +21,9 @@
 	var/nullified = 0
 	var/smitecounter = 0
 
+	var/list/saved_appearances = list()
+	var/datum/human_appearance/initial_appearance
+
 	var/reviving = FALSE
 	var/draining = FALSE
 	var/blood_usable = STARTING_BLOOD
@@ -68,6 +71,10 @@
 	if(faction && istype(faction, /datum/faction/vampire) && faction.leader == src)
 		var/datum/faction/vampire/V = faction
 		V.name_clan(src)
+
+	var/mob/living/carbon/human/H = antag.current
+	initial_appearance = H.my_appearance.Copy()
+	initial_appearance.name = H.real_name
 
 /datum/role/vampire/RemoveFromRole(var/datum/mind/M)
 	var/list/vamp_spells = getAllVampSpells()
@@ -342,6 +349,11 @@
 		smitetemp = -1
 
 	smitecounter = max(0, (smitecounter + smitetemp))
+
+	// At any rate 
+	if (smitecounter && H.real_name != initial_appearance.name)
+		H.switch_appearance(initial_appearance) // Reveal us as who we are
+		H.real_name = initial_appearance.name
 
 	switch(smitecounter)
 		if(1 to 30) //just dizziness

--- a/code/modules/mob/living/carbon/human/appearance.dm
+++ b/code/modules/mob/living/carbon/human/appearance.dm
@@ -33,6 +33,23 @@
 	my_appearance = new_looks
 	regenerate_icons()
 
+/datum/human_appearance/proc/Copy()
+	var/datum/human_appearance/new_looks = new
+	new_looks.name = name
+	new_looks.gender = gender
+	new_looks.s_tone = s_tone
+	new_looks.h_style = h_style
+	new_looks.r_hair = r_hair
+	new_looks.g_hair = g_hair
+	new_looks.f_style = f_style
+	new_looks.r_facial = r_facial
+	new_looks.g_facial = g_facial
+	new_looks.b_facial = b_facial
+	new_looks.r_eyes = r_eyes
+	new_looks.g_eyes = g_eyes
+	new_looks.b_eyes = b_eyes
+	return new_looks
+
 /mob/living/carbon/human/proc/randomise_appearance_for(var/new_gender)
 	var/datum/human_appearance/appearance = new
 

--- a/code/modules/mob/living/carbon/human/appearance.dm
+++ b/code/modules/mob/living/carbon/human/appearance.dm
@@ -50,40 +50,44 @@
 	new_looks.b_eyes = b_eyes
 	return new_looks
 
-/mob/living/carbon/human/proc/randomise_appearance_for(var/new_gender)
-	var/datum/human_appearance/appearance = new
-
+/datum/human_appearance/proc/randomise(var/new_gender, var/species)
 	if (new_gender)
-		appearance.gender = new_gender
+		gender = new_gender
 	else
-		appearance.gender = pick(MALE, FEMALE)
+		gender = pick(MALE, FEMALE)
 	
-	appearance.s_tone = random_skin_tone(species)
-	appearance.h_style = random_hair_style(gender, species)
-	appearance.f_style = random_facial_hair_style(gender, species)
+	s_tone = random_skin_tone(species)
+	h_style = random_hair_style(gender, species)
+	f_style = random_facial_hair_style(gender, species)
 
 	var/list/hair_colour = randomize_hair_color("hair")
 	var/list/facial_hair_colour = randomize_hair_color("facial")
 	var/list/eye_colour = randomize_eyes_color()
 
-	appearance.r_hair = hair_colour[INDEX_RED]
-	appearance.g_hair = hair_colour[INDEX_GREEN]
-	appearance.b_hair = hair_colour[INDEX_BLUE]
+	r_hair = hair_colour[INDEX_RED]
+	g_hair = hair_colour[INDEX_GREEN]
+	b_hair = hair_colour[INDEX_BLUE]
 
-	appearance.r_facial = facial_hair_colour[INDEX_RED]
-	appearance.g_facial = facial_hair_colour[INDEX_GREEN]
-	appearance.b_facial = facial_hair_colour[INDEX_BLUE]
+	r_facial = facial_hair_colour[INDEX_RED]
+	g_facial = facial_hair_colour[INDEX_GREEN]
+	b_facial = facial_hair_colour[INDEX_BLUE]
 
-	appearance.r_eyes = eye_colour[INDEX_RED]
-	appearance.g_eyes = eye_colour[INDEX_GREEN]
-	appearance.b_eyes = eye_colour[INDEX_BLUE]
-	gender = appearance.gender
+	r_eyes = eye_colour[INDEX_RED]
+	g_eyes = eye_colour[INDEX_GREEN]
+	b_eyes = eye_colour[INDEX_BLUE]
+
+/mob/living/carbon/human/proc/randomise_appearance_for(var/new_gender)
+	var/datum/human_appearance/new_looks = new
+
+	new_looks.randomise(new_gender, species.name)
+	my_appearance = new_looks
 	regenerate_icons()
-	return appearance
 
-/mob/living/carbon/human/proc/randomize_hair_color(var/target = "hair")
+	return new_looks
+
+/datum/human_appearance/proc/randomize_hair_color(var/target = "hair")
 	if(prob (75) && target == "facial") // Chance to inherit hair color
-		return list(my_appearance.r_hair, my_appearance.g_hair, my_appearance.b_hair)
+		return list(r_hair, g_hair, b_hair)
 
 	var/red
 	var/green
@@ -130,7 +134,7 @@
 
 	return list(red, green, blue)
 
-/mob/living/carbon/human/proc/randomize_eyes_color()
+/datum/human_appearance/proc/randomize_eyes_color()
 	var/red
 	var/green
 	var/blue

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -190,7 +190,7 @@
 	prev_gender = gender // Debug for plural genders
 	make_blood()
 	init_butchering_list() // While animals only generate list of their teeth/skins on death, humans generate it when they're born.
-
+	my_appearance.name = real_name
 	// Set up DNA.
 	if(!delay_ready_dna)
 		dna.ready_dna(src)

--- a/code/modules/spells/general/shapeshift.dm
+++ b/code/modules/spells/general/shapeshift.dm
@@ -31,9 +31,27 @@
 /spell/shapeshift/cast(var/list/targets, var/mob/living/carbon/human/user)
 	if (!istype(user))
 		return FALSE
-	user.visible_message("<span class='sinister'>\The [user] transforms!</span>")
-	user.real_name = user.generate_name() //random_name(M.current.gender)
-	user.randomise_appearance_for(user.gender)
+	var/list/choices = list()
 	var/datum/role/vampire/V = isvampire(user)
-	if (V)
-		V.remove_blood(blood_cost)
+	choices[V.initial_appearance.name] = V.initial_appearance
+	for (var/mob/living/carbon/human/H in view(user) - user)
+		choices[H.real_name] = H.my_appearance.Copy()
+	for (var/datum/human_appearance/looks in V.saved_appearances)
+		choices[looks.name] = looks
+	choices["Random"] = ""
+
+	var/choice = input(user, "Which appearance shall we adopt?", "Shapeshift", "Random") as null|anything in choices
+
+	if (!choice)
+		return
+	else if (choice == "Random")
+		var/name = user.generate_name() //random_name(M.current.gender)
+		var/datum/human_appearance/new_looks = user.randomise_appearance_for(user.gender)
+		new_looks.name = name
+		user.switch_appearance(new_looks)
+		V.saved_appearances += new_looks
+	else
+		user.switch_appearance(choices[choice])
+		user.real_name = choice
+
+	V.remove_blood(blood_cost)

--- a/code/modules/spells/general/shapeshift.dm
+++ b/code/modules/spells/general/shapeshift.dm
@@ -1,6 +1,6 @@
 /spell/shapeshift
 	name = "Shapeshift (1)"
-	desc = "Changes your name and appearance and has a cooldown of 3 minutes."
+	desc = "Changes your name and appearance, either to someone in view or randomly. Has a cooldown of 3 minutes."
 	abbreviation = "SS"
 
 	school = "vampire"
@@ -48,7 +48,6 @@
 		var/name = user.generate_name() //random_name(M.current.gender)
 		var/datum/human_appearance/new_looks = user.randomise_appearance_for(user.gender)
 		new_looks.name = name
-		user.switch_appearance(new_looks)
 		V.saved_appearances += new_looks
 	else
 		user.switch_appearance(choices[choice])


### PR DESCRIPTION
[balance] [powercreep]

See changelog for content.
Reasoning : this spell is pretty much only used to make the AI lose you now, and it permanently fucks up your appearance.

With this new spell, you can be more creative in impersonating people (in a less reliable fashion than changeling, because once you lose your disguise, you need to see the victim again to mimic them), you can go back at your glorious original form, and you can create the own secondary characters of your adventure by morphing back into the random dudes you rolled, either to confuse people or to create new, interesting narratives.

:cl:
- tweak: Vampire shapeshift spell can now make you mimic a person nearby, or going back to your original body, as well as shapeshifting into a random body. Entering the chapel or being hit by a holy artifact instantly breaks your disguise. 