### PR TITLE
Shadowstep removes restrains

### DIFF
--- a/code/modules/spells/aoe_turf/blink.dm
+++ b/code/modules/spells/aoe_turf/blink.dm
@@ -51,6 +51,9 @@
 	. = ..()
 	if (!.) // No need to go further.
 		return FALSE
+	if (user.locked_to)
+		to_chat(user, "<span class='warning'>We are restrained!</span>")
+		return FALSE
 	if (!user.vampire_power(blood_cost, CONSCIOUS))
 		return FALSE
 
@@ -62,6 +65,10 @@
 	return turfs
 
 /spell/aoe_turf/blink/vamp/cast(var/list/targets, var/mob/user)
+	if (ishuman(user))
+		var/mob/living/carbon/human/H = user
+		for (var/datum/organ/external/O in H.organs)
+			O.release_restraints()
 	. = ..()
 	var/datum/role/vampire/V = isvampire(user)
 	if (V)


### PR DESCRIPTION
[balance]
However, if you're locked to an object (ie, if you're bucked to anything), it won't work.
Reasoning : this makes vampire more mobile and a bit more engaging to fight (in my opinion). 
At the least, it encourages slightly risky playstyles because you have (even more) margin for error.
The cuffs get dropped on the turf you exit, so you can't just get free cuffs.

The fact that you can't, however, just yank away whilst being cuffed to a chair makes restraining vampires still possible.

:cl:
- tweak: Shadowstep now uncuffs you when you use it.