### PR TITLE
Removed doppeldanger spell

### DIFF
--- a/code/modules/spells/aoe_turf/conjure/doppelganger.dm
+++ b/code/modules/spells/aoe_turf/conjure/doppelganger.dm
@@ -1,7 +1,6 @@
 /spell/aoe_turf/conjure/doppelganger
 	name = "Doppelganger"
 	desc = "This spell summons a construct with your appearance."
-	user_type = USER_TYPE_WIZARD
 
 	summon_type = list(/mob/living/simple_animal/hostile/humanoid/wizard/doppelganger/melee)
 


### PR DESCRIPTION
Every wizard round one's taken this spell has been gunked beyond belief.

[featureloss]

:cl:
 * rscdel: remove doppelganger because it's broken as fuck, fix it