### PR TITLE
You can't empower doppelganger spell to have magic missile anymore

### DIFF
--- a/code/modules/spells/aoe_turf/conjure/doppelganger.dm
+++ b/code/modules/spells/aoe_turf/conjure/doppelganger.dm
@@ -6,7 +6,7 @@
 	summon_type = list(/mob/living/simple_animal/hostile/humanoid/wizard/doppelganger/melee)
 
 	price = Sp_BASE_PRICE / 2
-	level_max = list(Sp_TOTAL = 3, Sp_SPEED = 2, Sp_POWER = 1)
+	level_max = list(Sp_TOTAL = 2, Sp_SPEED = 2)
 	charge_max = 300
 	cooldown_reduc = 100
 	cooldown_min = 100
@@ -51,20 +51,3 @@ var/list/doppelgangers = list()
 			if(doppelgangers[M] == user)
 				doppelgangers[M] = null
 				doppelgangers -= M
-
-/spell/aoe_turf/conjure/doppelganger/empower_spell()
-	spell_levels[Sp_POWER]++
-
-	var/description = ""
-	switch(spell_levels[Sp_POWER])
-		if(0)
-			name = "Doppelganger"
-			description = "It will now summon a construct with your appearance."
-		if(1)
-			name = "Empowered Doppelganger"
-			description = "The summoned construct is now capable of casting magic missile."
-			summon_type = list(/mob/living/simple_animal/hostile/humanoid/wizard/doppelganger)
-		else
-			return
-
-	return "You have improved Doppelganger into [name]. [description]"


### PR DESCRIPTION
Disregard the other 2 PRs that try to kneecap doppelganger, THIS is the PR you want
All they can do is punch, no more stuns from empowered variant because the empowered interaction is removed.
:cl:
 * tweak: To avoid a flame war, you can no longer upgrade doppelgangers to cast magic missile.