### PR TITLE
Removes one possibility of medal spawns in the safe as well as the Siren

### DIFF
--- a/code/modules/maps/spawners/spawners.dm
+++ b/code/modules/maps/spawners/spawners.dm
@@ -1114,7 +1114,7 @@
 		/obj/item/weapon/bikehorn,
 		/obj/item/weapon/storage/box/emps,
 		/obj/item/weapon/card/id/captains_spare,
-		/obj/item/clothing/accessory/medal,
+/*		/obj/item/clothing/accessory/medal,
 		/obj/item/clothing/accessory/medal/conduct,
 		/obj/item/clothing/accessory/medal/bronze_heart,
 		/obj/item/clothing/accessory/medal/nobel_science,
@@ -1123,7 +1123,7 @@
 		/obj/item/clothing/accessory/medal/silver/security,
 		/obj/item/clothing/accessory/medal/gold,
 		/obj/item/clothing/accessory/medal/gold/captain,
-		/obj/item/clothing/accessory/medal/gold/heroism,
+		/obj/item/clothing/accessory/medal/gold/heroism,*/ //Medals will still be spawned by the medal spawner
 		/obj/item/clothing/accessory/storage/webbing,
 		/obj/item/clothing/suit/armor/laserproof,
 		/obj/item/clothing/accessory/holster,
@@ -1190,8 +1190,8 @@
 	/obj/item/weapon/melee/energy/axe/rusty,
 	/obj/item/weapon/gun/projectile/russian,
 	/obj/item/weapon/gun/mahoguny,
-	/obj/item/weapon/gun/stickybomb,
-	/obj/item/weapon/gun/siren
+	/obj/item/weapon/gun/stickybomb
+//	/obj/item/weapon/gun/siren // If you want to uncomment this don't forget to add a , at the end of stickybomb
 )
 
 /obj/abstract/map/spawner/safe/clothing


### PR DESCRIPTION
Why?
Turns out the safe usually has junk far more often than necessary, and I'm pretty sure there's also something wrong because less items spawn than there should be (at least six items on most maps, five on Defficiency due to lack of medal spawner) and I witnessed three items once. Until then, safes will now have at least one item that would have been a medal replaced with a more useful item. Medals will still spawn from medal spawner, however.
Siren is broken, as in basically non-functional because it tries to apply permeability and chems applied via permeability don't work if I recall.
:cl:
 * tweak: Safes had the possibility for multiple medals cut off to make room for more useful items. At least one medal will still spawn most of the time however.
 * tweak: Siren has been removed from possible safe contents due to being broken.