### PR TITLE
Fixes Clown Latejoining

### DIFF
--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -363,7 +363,7 @@
 		spawn_positions = -1
 		return 99
 	else
-		..()
+		return ..()
 
 /datum/job/mime
 	title = "Mime"


### PR DESCRIPTION
fixes #22598

Tested and confirmed that this does indeed allow clowns to latejoin again, also it does indeed fix the broken display on the labor console.

The clown metaclub better remember this kindness.

🆑 
* bugfix: Clowns can once again latejoin.