### PR TITLE
Vampire buffs 1: Vampire sucks twice as much blood

### DIFF
--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -191,17 +191,17 @@
 			to_chat(assailant, "<span class='warning'>They've got no blood left to give.</span>")
 			break
 		if(target.stat < DEAD) //alive
-			blood = min(10, target.vessel.get_reagent_amount(BLOOD)) // if they have less than 10 blood, give them the remnant else they get 10 blood
+			blood = min(20, target.vessel.get_reagent_amount(BLOOD)) // if they have less than 20 blood, give them the remnant else they get 20 blood
 			blood_total += blood
 			blood_usable += blood
 			target.adjustCloneLoss(10) // beep boop 10 damage
 		else
-			blood = min(5, target.vessel.get_reagent_amount(BLOOD)) // The dead only give 5 bloods
+			blood = min(10, target.vessel.get_reagent_amount(BLOOD)) // The dead only give 10 blood
 			blood_total += blood
 		if(blood_total_before != blood_total)
 			to_chat(assailant, "<span class='notice'>You have accumulated [blood_total] [blood_total > 1 ? "units" : "unit"] of blood[blood_usable_before != blood_usable ?", and have [blood_usable] left to use." : "."]</span>")
 		check_vampire_upgrade()
-		target.vessel.remove_reagent(BLOOD,25)
+		target.vessel.remove_reagent(BLOOD,50)
 		update_vamp_hud()
 
 	draining = null


### PR DESCRIPTION
Why?
Vampire gameplay is clunky as hell and all it takes is one failure in any part to be discovered as a vampire. Person had a bounced radio (in the case you didn't find it) and they yell for help. Person had suit sensors (in case you didn't set them, what the hell are you doing as a vampire?) and the doctors notice, he was near an intercom (super special trick, you can use :i to talk into a nearby intercom, no it didn't happen to me) and they yell for help, and then you have to hide the body because if it is recovered they will tell your identity and vampires get discovered if they weren't. The worst part of vampire gameplay is standing still in a corner of the room much like changelings while your blood pool fills up, and this change aims to make that part shorter.
Also because it's more fun this way (for the vampire, victim ends up dead either way)
The worst thing I can see happening is people being able to be sucked on the spot after being slapped with hypnotise before they can even get up, but gameplay will dictate that. If that happens and enough people dislike that change, I'll reduce the blood sucked to 1.5x instead
:cl:
 * tweak: Vampire sucks blood twice as fast.