### PR TITLE
Vampire buffs 2: Halved the cost of enthralling

### DIFF
--- a/code/modules/spells/targeted/enthrall.dm
+++ b/code/modules/spells/targeted/enthrall.dm
@@ -18,7 +18,7 @@
 	override_base = "vamp"
 	hud_state = "vampire_enthrall"
 
-	var/blood_cost = 150
+	var/blood_cost = 75
 
 /spell/targeted/enthrall/cast_check(skipcharge = 0,mob/user = usr)
 	. = ..()
@@ -43,14 +43,14 @@
 /spell/targeted/enthrall/cast(var/list/targets, var/mob/user)
 	if (targets.len > 1)
 		return FALSE
-		
+
 	var/mob/living/target = targets[1]
 
 	var/datum/role/vampire/V = isvampire(user)
 
 	if (!V)
 		return FALSE
-	
+
 	user.visible_message("<span class='warning'>[user] bites \the [target]'s neck!</span>", "<span class='warning'>You bite \the [target]'s neck and begin the flow of power.</span>")
 	to_chat(target, "<span class='sinister'>You feel the tendrils of evil [(VAMP_CHARISMA in V.powers) ? "aggressively" : "slowly"] invade your mind.</span>")
 


### PR DESCRIPTION
Why?
Turns out you need 150 blood to thrall someone, but that takes about 2 victims for one thrall (considering that one victim will die and you can no longer acquire active blood) or 1.5x (one victim doesn't have to die) if you want to be technical. Thralling is stupid easy to remove, all you need to deconvert a thrall is to feed them holy water which means 150 blood goes down the drain and they recall who their master is. Also encourages vampires to keep more people into the round (albeit antag-like).
:cl:
 * tweak: Halved the cost of vampire enthralling (from 150 to 75)