### PR TITLE
Vampire buffs 3: Reduced cooldowns for five abilities

### DIFF
--- a/code/modules/spells/aoe_turf/glare.dm
+++ b/code/modules/spells/aoe_turf/glare.dm
@@ -7,11 +7,11 @@
 	user_type = USER_TYPE_VAMPIRE
 
 	charge_type = Sp_RECHARGE
-	charge_max = 3 MINUTES
+	charge_max = 2 MINUTES
 	invocation_type = SpI_NONE
 	range = 3
 	spell_flags = NEEDSHUMAN
-	cooldown_min = 3 MINUTES
+	cooldown_min = 2 MINUTES
 
 	override_base = "vamp"
 	hud_state = "vampire_glare"

--- a/code/modules/spells/aoe_turf/screech.dm
+++ b/code/modules/spells/aoe_turf/screech.dm
@@ -7,11 +7,11 @@
 	user_type = USER_TYPE_VAMPIRE
 
 	charge_type = Sp_RECHARGE
-	charge_max = 5 MINUTES
+	charge_max = 3 MINUTES
 	invocation_type = SpI_NONE
 	range = 4
 	spell_flags = STATALLOWED | NEEDSHUMAN
-	cooldown_min = 5 MINUTES
+	cooldown_min = 3 MINUTES
 
 	override_base = "vamp"
 	hud_state = "vampire_screech"
@@ -26,7 +26,7 @@
 		return FALSE
 
 /spell/aoe_turf/screech/choose_targets(var/mob/user = usr)
-	
+
 	var/list/targets = list()
 
 	for(var/mob/living/carbon/C in hearers(user, 4))
@@ -39,7 +39,7 @@
 			if(!C.vampire_affected(user.mind))
 				continue
 			targets += C
-	
+
 	if (!targets.len)
 		to_chat(user, "<span class='warning'>There are no targets.</span>")
 		return FALSE

--- a/code/modules/spells/general/rejuvenate.dm
+++ b/code/modules/spells/general/rejuvenate.dm
@@ -7,11 +7,11 @@
 	user_type = USER_TYPE_VAMPIRE
 
 	charge_type = Sp_RECHARGE
-	charge_max = 30 SECONDS
+	charge_max = 1 MINUTES
 	invocation_type = SpI_NONE
 	range = 0
 	spell_flags = STATALLOWED | NEEDSHUMAN
-	cooldown_min = 30 SECONDS
+	cooldown_min = 1 MINUTES
 
 	override_base = "vamp"
 	hud_state = "vampire_rejuv"

--- a/code/modules/spells/general/rejuvenate.dm
+++ b/code/modules/spells/general/rejuvenate.dm
@@ -7,11 +7,11 @@
 	user_type = USER_TYPE_VAMPIRE
 
 	charge_type = Sp_RECHARGE
-	charge_max = 3 MINUTES
+	charge_max = 30 SECONDS
 	invocation_type = SpI_NONE
 	range = 0
 	spell_flags = STATALLOWED | NEEDSHUMAN
-	cooldown_min = 3 MINUTES
+	cooldown_min = 30 SECONDS
 
 	override_base = "vamp"
 	hud_state = "vampire_rejuv"

--- a/code/modules/spells/targeted/enthrall.dm
+++ b/code/modules/spells/targeted/enthrall.dm
@@ -7,12 +7,12 @@
 	user_type = USER_TYPE_VAMPIRE
 
 	charge_type = Sp_RECHARGE
-	charge_max = 3 MINUTES
+	charge_max = 2 MINUTES
 	invocation_type = SpI_NONE
 	range = 1
 	max_targets = 1
 	spell_flags = WAIT_FOR_CLICK | NEEDSHUMAN
-	cooldown_min = 3 MINUTES
+	cooldown_min = 2 MINUTES
 	selection_type = "range"
 
 	override_base = "vamp"
@@ -43,14 +43,14 @@
 /spell/targeted/enthrall/cast(var/list/targets, var/mob/user)
 	if (targets.len > 1)
 		return FALSE
-		
+
 	var/mob/living/target = targets[1]
 
 	var/datum/role/vampire/V = isvampire(user)
 
 	if (!V)
 		return FALSE
-	
+
 	user.visible_message("<span class='warning'>[user] bites \the [target]'s neck!</span>", "<span class='warning'>You bite \the [target]'s neck and begin the flow of power.</span>")
 	to_chat(target, "<span class='sinister'>You feel the tendrils of evil [(VAMP_CHARISMA in V.powers) ? "aggressively" : "slowly"] invade your mind.</span>")
 

--- a/code/modules/spells/targeted/hypnotise.dm
+++ b/code/modules/spells/targeted/hypnotise.dm
@@ -7,12 +7,12 @@
 	user_type = USER_TYPE_VAMPIRE
 
 	charge_type = Sp_RECHARGE
-	charge_max = 3 MINUTES
+	charge_max = 2 MINUTES
 	invocation_type = SpI_NONE
 	range = 1
 	max_targets = 1
 	spell_flags = WAIT_FOR_CLICK | NEEDSHUMAN
-	cooldown_min = 3 MINUTES
+	cooldown_min = 2 MINUTES
 	selection_type = "range"
 
 	amt_paralysis = 20


### PR DESCRIPTION
Why?
Cooldowns are too much, that's all.
The most this change will do is make vampires pounce on people a bit more often, for God's sake even the wizard's teleport spell has a shorter cooldown than these.
The more powerful spells like summon bats, mist form, and diseased touch haven't been reduced in cooldown
Glare: 180 -> 120 seconds
Screech: 300 -> 180 seconds
Rejuvenation 180 -> 60 seconds: It's a very good tool but three minutes is too much.
Enthrall: 180 -> 120 seconds
Hypnotise: 180 -> 120 seconds
Also they cost blood except for glare
:cl:
 * tweak: The following vampire spells had their cooldowns reduced: Glare, Chiropteran Screech, Rejuvenation, Enthrall, and Hypnotise.