### PR TITLE
changes the cost of the revolver from 13 tc to 12 tc

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -192,7 +192,7 @@ var/list/uplink_items = list()
 	name = "Fully Loaded Revolver"
 	desc = "A traditional handgun which fires .357 rounds. Has 7 chambers. Can down an unarmored target with two shots."
 	item = /obj/item/weapon/gun/projectile
-	cost = 13
+	cost = 12
 
 /datum/uplink_item/dangerous/ammo
 	name = "Ammo-357"


### PR DESCRIPTION
[powercreep] [balance]

An item that you can get seven of with a space suit, welding goggles, and patience? 13TC? This also solves the issue of not being able to buy that 4 TC item that you can print at any hacked autolathe, in case that was a thing you wanted to do. I'm also gonna write a PR that makes that a lot cheaper too (how I'd go about fixing it), but some retard wanted this so here it is.
fixes #22628
also see #22631

:cl:
 * tweak: lowers the cost of "fully loaded revolver" from 13 -> 12 TC