### PR TITLE
Adds two micro-lasers to protolathe required components

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1725,6 +1725,8 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/reagent_containers/glass/beaker,
 					/obj/item/weapon/reagent_containers/glass/beaker,
 					/obj/item/weapon/stock_parts/scanning_module,
+					/obj/item/weapon/stock_parts/micro_laser,
+					/obj/item/weapon/stock_parts/micro_laser,
 					/obj/item/weapon/stock_parts/micro_laser)
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure/scisec

--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -53,6 +53,8 @@ it creates. All the menus and other manipulation commands are in the R&D console
 		/obj/item/weapon/stock_parts/matter_bin,
 		/obj/item/weapon/stock_parts/manipulator,
 		/obj/item/weapon/stock_parts/manipulator,
+		/obj/item/weapon/stock_parts/micro_laser,
+		/obj/item/weapon/stock_parts/micro_laser,
 	)
 
 	RefreshParts()


### PR DESCRIPTION
This is an excuse so that they can be upgraded to print things faster, not that it matters much because a lot of things have reasonable printing times.
They have the same printing speed as fabricators now.
:cl:
 * tweak: The Protolathe now requires two micro-lasers to build, but now it can be upgraded to fabricate things faster.