### PR TITLE
Tator codewords now appear in red when seen by other tators/nukeops

### DIFF
--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -196,7 +196,6 @@ var/list/syndicate_code_response //Code response for traitors.
 		names += t.fields["name"]
 
 	var/maxwords = words//Extra var to check for duplicates.
-	code_phrase.len = words
 
 	for(words,words>0,words--)//Randomly picks from one of the choices below.
 
@@ -210,27 +209,27 @@ var/list/syndicate_code_response //Code response for traitors.
 				switch(rand(1,2))//Mainly to add more options later.
 					if(1)
 						if(names.len&&prob(70))
-							code_phrase += pick(names)
+							code_phrase.Insert(0, pick(names))
 						else
-							code_phrase += pick(pick(first_names_male,first_names_female))+" "+pick(last_names)
+							code_phrase.Insert(0, pick(pick(first_names_male,first_names_female))+" "+pick(last_names))
 					if(2)
-						code_phrase += pick(get_all_jobs())//Returns a job.
+						code_phrase.Insert(0, pick(get_all_jobs()))
 				safety -= 1
 			if(2)
 				switch(rand(1,2))//Places or things.
 					if(1)
-						code_phrase += pick(drinks)
+						code_phrase.Insert(0, pick(drinks))
 					if(2)
-						code_phrase += pick(locations)
+						code_phrase.Insert(0, pick(locations))
 				safety -= 2
 			if(3)
 				switch(rand(1,3))//Nouns, adjectives, verbs. Can be selected more than once.
 					if(1)
-						code_phrase += pick(nouns)
+						code_phrase.Insert(0, pick(nouns))
 					if(2)
-						code_phrase += pick(adjectives)
+						code_phrase.Insert(0, pick(adjectives))
 					if(3)
-						code_phrase += pick(verbs)
+						code_phrase.Insert(0, pick(verbs))
 
 	return code_phrase
 

--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -159,8 +159,8 @@ var/syndicate_name = null
 
 
 //Traitors and traitor silicons will get these. Revs will not.
-var/syndicate_code_phrase//Code phrase for traitors.
-var/syndicate_code_response//Code response for traitors.
+var/list/syndicate_code_phrase //Code phrase for traitors.
+var/list/syndicate_code_response //Code response for traitors.
 
 	/*
 	Should be expanded.

--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -189,7 +189,6 @@ var/list/syndicate_code_response //Code response for traitors.
 	var/safety[] = list(1,2,3)//Tells the proc which options to remove later on.
 	var/nouns[] = list("love","hate","anger","peace","pride","sympathy","bravery","loyalty","honesty","integrity","compassion","charity","success","courage","deceit","skill","beauty","brilliance","pain","misery","beliefs","dreams","justice","truth","faith","liberty","knowledge","thought","information","culture","trust","dedication","progress","education","hospitality","leisure","trouble","friendships", "relaxation")
 	var/drinks[] = list("vodka and tonic","gin fizz","bahama mama","manhattan","black Russian","whiskey soda","long island tea","margarita","Irish coffee"," manly dwarf","Irish cream","doctor's delight","Beepksy Smash","tequila sunrise","brave bull","gargle blaster","bloody mary","whiskey cola","white Russian","vodka martini","martini","Cuba libre","kahlua","vodka","wine","moonshine")
-	var/locations[] = teleportlocs.len ? teleportlocs : drinks//if null, defaults to drinks instead.
 
 	var/names[] = list()
 	for(var/datum/data/record/t in data_core.general)//Picks from crew manifest.
@@ -216,11 +215,7 @@ var/list/syndicate_code_response //Code response for traitors.
 						code_phrase.Insert(0, pick(get_all_jobs()))
 				safety -= 1
 			if(2)
-				switch(rand(1,2))//Places or things.
-					if(1)
-						code_phrase.Insert(0, pick(drinks))
-					if(2)
-						code_phrase.Insert(0, pick(locations))
+				code_phrase.Insert(0, pick(drinks))
 				safety -= 2
 			if(3)
 				switch(rand(1,3))//Nouns, adjectives, verbs. Can be selected more than once.

--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -178,8 +178,7 @@ var/list/syndicate_code_response //Code response for traitors.
 
 /proc/generate_code_phrase()//Proc is used for phrase and response in master_controller.dm
 
-
-	var/code_phrase = ""//What is returned when the proc finishes.
+	var/list/code_phrase = list()//What is returned when the proc finishes.
 	var/words = pick(//How many words there will be. Minimum of two. 2, 4 and 5 have a lesser chance of being selected. 3 is the most likely.
 		50; 2,
 		200; 3,
@@ -197,6 +196,7 @@ var/list/syndicate_code_response //Code response for traitors.
 		names += t.fields["name"]
 
 	var/maxwords = words//Extra var to check for duplicates.
+	code_phrase.len = words
 
 	for(words,words>0,words--)//Randomly picks from one of the choices below.
 
@@ -212,9 +212,7 @@ var/list/syndicate_code_response //Code response for traitors.
 						if(names.len&&prob(70))
 							code_phrase += pick(names)
 						else
-							code_phrase += pick(pick(first_names_male,first_names_female))
-							code_phrase += " "
-							code_phrase += pick(last_names)
+							code_phrase += pick(pick(first_names_male,first_names_female))+" "+pick(last_names)
 					if(2)
 						code_phrase += pick(get_all_jobs())//Returns a job.
 				safety -= 1
@@ -233,10 +231,6 @@ var/list/syndicate_code_response //Code response for traitors.
 						code_phrase += pick(adjectives)
 					if(3)
 						code_phrase += pick(verbs)
-		if(words==1)
-			code_phrase += "."
-		else
-			code_phrase += ", "
 
 	return code_phrase
 

--- a/code/datums/gamemode/misc_gamemode_procs.dm
+++ b/code/datums/gamemode/misc_gamemode_procs.dm
@@ -445,7 +445,7 @@
 	else
 		words += "Unfortunately, the Syndicate did not provide you with a code phrase.<br>"
 	if (syndicate_code_response)
-		var/response = syndicate_code_phrase.Join(", ")
+		var/response = syndicate_code_response.Join(", ")
 		words += "<span class='warning'>Code Response: </span>[response].<br>"
 		agent.mind.store_memory("<b>Code Response</b>: [response].")
 	else

--- a/code/datums/gamemode/misc_gamemode_procs.dm
+++ b/code/datums/gamemode/misc_gamemode_procs.dm
@@ -439,13 +439,15 @@
 		return 0
 	var/words = "The Syndicate provided you with the following information on how to identify their agents:<br>"
 	if (syndicate_code_phrase)
-		words += "<span class='warning'>Code Phrase: </span>[syndicate_code_phrase]<br>"
-		agent.mind.store_memory("<b>Code Phrase</b>: [syndicate_code_phrase]")
+		var/phrases = syndicate_code_phrase.Join(", ")
+		words += "<span class='warning'>Code Phrases: </span>[phrases].<br>"
+		agent.mind.store_memory("<b>Code Phrases</b>: [phrases].")
 	else
 		words += "Unfortunately, the Syndicate did not provide you with a code phrase.<br>"
 	if (syndicate_code_response)
-		words += "<span class='warning'>Code Response: </span>[syndicate_code_response]<br>"
-		agent.mind.store_memory("<b>Code Response</b>: [syndicate_code_response]")
+		var/response = syndicate_code_phrase.Join(", ")
+		words += "<span class='warning'>Code Response: </span>[response].<br>"
+		agent.mind.store_memory("<b>Code Response</b>: [response].")
 	else
 		words += "Unfortunately, the Syndicate did not provide you with a code response.<br>"
 

--- a/code/datums/saycode/speech.dm
+++ b/code/datums/saycode/speech.dm
@@ -68,17 +68,25 @@
 /datum/speech/proc/render_message_classes(var/sep=" ")
 	return jointext(message_classes, sep)
 
-/datum/speech/proc/render_message()
+/datum/speech/proc/render_message(var/istraitor = 0)
 #ifdef SAY_DEBUG
 	to_chat(speaker, "[type]/render_message(): message_classes = {[jointext(message_classes, ", ")]}")
 #endif
-	var/rendered=message
+	var/rendered=html_encode(message)
 	// Sanity
 	if(!lquote)
 		lquote="\""
 	if(!rquote)
 		rquote="\""
-	rendered="<span class='[jointext(message_classes, " ")]'>[lquote][html_encode(rendered)][rquote]</span>"
+
+	if(istraitor)
+		for(var/T in syndicate_code_phrase)
+			rendered = replacetext(rendered, T, "<b style='color: red;'>[T]</b>")
+
+		for(var/T in syndicate_code_response)
+			rendered = replacetext(rendered, T, "<i style='color: red;'>[T]</i>")
+
+	rendered="<span class='[jointext(message_classes, " ")]'>[lquote][rendered][rquote]</span>"
 	if(language)
 		rendered=language.render_speech(src, rendered)
 	else
@@ -87,7 +95,7 @@
 		else
 			warning("Speaker not set! (message=\"[message]\")")
 #ifdef SAY_DEBUG
-	to_chat(speaker, "[type]/render_message(): message = \"[html_encode(rendered)]\"")
+	to_chat(speaker, "[type]/render_message(): message = \"[rendered]\"")
 #endif
 	return rendered
 

--- a/code/datums/saycode/speech.dm
+++ b/code/datums/saycode/speech.dm
@@ -68,7 +68,7 @@
 /datum/speech/proc/render_message_classes(var/sep=" ")
 	return jointext(message_classes, sep)
 
-/datum/speech/proc/render_message(var/istraitor = 0)
+/datum/speech/proc/render_message()
 #ifdef SAY_DEBUG
 	to_chat(speaker, "[type]/render_message(): message_classes = {[jointext(message_classes, ", ")]}")
 #endif
@@ -78,13 +78,6 @@
 		lquote="\""
 	if(!rquote)
 		rquote="\""
-
-	if(istraitor)
-		for(var/T in syndicate_code_phrase)
-			rendered = replacetext(rendered, T, "<b style='color: red;'>[T]</b>")
-
-		for(var/T in syndicate_code_response)
-			rendered = replacetext(rendered, T, "<i style='color: red;'>[T]</i>")
 
 	rendered="<span class='[jointext(message_classes, " ")]'>[lquote][rendered][rquote]</span>"
 	if(language)

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -119,6 +119,7 @@ var/list/freqtoname = list(
 		filtered_speech = speech
 
 	var/atom/movable/source = speech.speaker.GetSource()
+	var/istraitor = 0
 	say_testing(speech.speaker, "Checking if [src]([type]) understands [source]([source.type])")
 	if(!say_understands(source, speech.language))
 		say_testing(speech.speaker," We don't understand this fuck, adding stars().")
@@ -131,12 +132,7 @@ var/list/freqtoname = list(
 			var/mob/M = src
 			if(M.mind.GetRole(TRAITOR) || M.mind.GetRole(NUKE_OP))
 				//is tator
-				for(var/T in syndicate_code_phrase)
-					filtered_speech.message = replacetext(filtered_speech.message, T, "<b style='color: red;'>[T]</b>")
-
-				for(var/T in syndicate_code_response)
-					filtered_speech.message = replacetext(filtered_speech.message, T, "<i style='color: red;'>[T]</i>")
-
+				istraitor = 1
 
 #ifdef SAY_DEBUG
 	var/enc_wrapclass=jointext(filtered_speech.wrapper_classes, ", ")
@@ -154,7 +150,7 @@ var/list/freqtoname = list(
 			[filtered_speech.render_message()]
 		</span>"}
 	*/
-	. = "<span class='[filtered_speech.render_wrapper_classes()]'><span class='name'>[render_speaker_track_start(filtered_speech)][render_speech_name(filtered_speech)][render_speaker_track_end(filtered_speech)][freqpart][render_job(filtered_speech)]</span> [filtered_speech.render_message()]</span>"
+	. = "<span class='[filtered_speech.render_wrapper_classes()]'><span class='name'>[render_speaker_track_start(filtered_speech)][render_speech_name(filtered_speech)][render_speaker_track_end(filtered_speech)][freqpart][render_job(filtered_speech)]</span> [filtered_speech.render_message(istraitor)]</span>"
 	say_testing(src, html_encode(.))
 	if(pooled)
 		returnToPool(filtered_speech)

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -127,11 +127,13 @@ var/list/freqtoname = list(
 	else
 		say_testing(speech.speaker," We <i>do</i> understand this gentle\[wo\]man.")
 		//checking for syndie codephrases if person is a tator
-		if(istype(src, /mob/living) && (src.mind.special_role == TRAITOR || src.mind.special_role == NUKE_OP)) //will this cause runtimes?
-			//is tator
-			var/list/thingsToCheck = syndicate_code_phrase + syndicate_code_response
-			for(var/T in thingsToCheck)
-				speech.message = replacetext(speech.message, T, "<span style='color: red;'>[T]</span>")
+		if(istype(src, /mob/living))
+			var/mob/M = src
+			if(M.mind.special_role == TRAITOR || M.mind.special_role == NUKE_OP)
+				//is tator
+				var/list/thingsToCheck = syndicate_code_phrase + syndicate_code_response
+				for(var/T in thingsToCheck)
+					speech.message = replacetext(speech.message, T, "<span style='color: red;'>[T]</span>")
 
 
 #ifdef SAY_DEBUG

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -126,6 +126,13 @@ var/list/freqtoname = list(
 		pooled=1
 	else
 		say_testing(speech.speaker," We <i>do</i> understand this gentle\[wo\]man.")
+		//checking for syndie codephrases if person is a tator
+		if(istype(src, /mob/living) && (src.mind.special_role == TRAITOR || src.mind.special_role == NUKE_OP)) //will this cause runtimes?
+			//is tator
+			var/list/thingsToCheck = syndicate_code_phrase + syndicate_code_response
+			for(var/T in thingsToCheck)
+			speech.message = replacetext(speech.message, T, "<span style='color: red;'>[T]</span>")
+
 
 #ifdef SAY_DEBUG
 	var/enc_wrapclass=jointext(filtered_speech.wrapper_classes, ", ")

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -127,12 +127,6 @@ var/list/freqtoname = list(
 		pooled=1
 	else
 		say_testing(speech.speaker," We <i>do</i> understand this gentle\[wo\]man.")
-		//checking for syndie codephrases if person is a tator
-		if(istype(src, /mob/living))
-			var/mob/M = src
-			if(M.mind.GetRole(TRAITOR) || M.mind.GetRole(NUKE_OP))
-				//is tator
-				istraitor = 1
 
 #ifdef SAY_DEBUG
 	var/enc_wrapclass=jointext(filtered_speech.wrapper_classes, ", ")
@@ -150,7 +144,7 @@ var/list/freqtoname = list(
 			[filtered_speech.render_message()]
 		</span>"}
 	*/
-	. = "<span class='[filtered_speech.render_wrapper_classes()]'><span class='name'>[render_speaker_track_start(filtered_speech)][render_speech_name(filtered_speech)][render_speaker_track_end(filtered_speech)][freqpart][render_job(filtered_speech)]</span> [filtered_speech.render_message(istraitor)]</span>"
+	. = "<span class='[filtered_speech.render_wrapper_classes()]'><span class='name'>[render_speaker_track_start(filtered_speech)][render_speech_name(filtered_speech)][render_speaker_track_end(filtered_speech)][freqpart][render_job(filtered_speech)]</span> [filtered_speech.render_message()]</span>"
 	say_testing(src, html_encode(.))
 	if(pooled)
 		returnToPool(filtered_speech)

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -132,10 +132,10 @@ var/list/freqtoname = list(
 			if(M.mind.GetRole(TRAITOR) || M.mind.GetRole(NUKE_OP))
 				//is tator
 				for(var/T in syndicate_code_phrase)
-					speech.message = replacetext(speech.message, T, "<span style='color: red;'><b>[T]</b></span>")
+					filtered_speech.message = replacetext(filtered_speech.message, T, "<b style='color: red;'>[T]</b>")
 
-				for(var/T in syndicate_code_phrase)
-					speech.message = replacetext(speech.message, T, "<span style='color: red;'><i>[T]</i></span>")
+				for(var/T in syndicate_code_response)
+					filtered_speech.message = replacetext(filtered_speech.message, T, "<i style='color: red;'>[T]</i>")
 
 
 #ifdef SAY_DEBUG

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -131,7 +131,7 @@ var/list/freqtoname = list(
 			//is tator
 			var/list/thingsToCheck = syndicate_code_phrase + syndicate_code_response
 			for(var/T in thingsToCheck)
-			speech.message = replacetext(speech.message, T, "<span style='color: red;'>[T]</span>")
+				speech.message = replacetext(speech.message, T, "<span style='color: red;'>[T]</span>")
 
 
 #ifdef SAY_DEBUG

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -119,7 +119,6 @@ var/list/freqtoname = list(
 		filtered_speech = speech
 
 	var/atom/movable/source = speech.speaker.GetSource()
-	var/istraitor = 0
 	say_testing(speech.speaker, "Checking if [src]([type]) understands [source]([source.type])")
 	if(!say_understands(source, speech.language))
 		say_testing(speech.speaker," We don't understand this fuck, adding stars().")

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -129,7 +129,7 @@ var/list/freqtoname = list(
 		//checking for syndie codephrases if person is a tator
 		if(istype(src, /mob/living))
 			var/mob/M = src
-			if(M.mind.special_role == TRAITOR || M.mind.special_role == NUKE_OP)
+			if(M.mind.GetRole(TRAITOR) || M.mind.GetRole(NUKE_OP))
 				//is tator
 				var/list/thingsToCheck = syndicate_code_phrase + syndicate_code_response
 				for(var/T in thingsToCheck)

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -131,9 +131,11 @@ var/list/freqtoname = list(
 			var/mob/M = src
 			if(M.mind.GetRole(TRAITOR) || M.mind.GetRole(NUKE_OP))
 				//is tator
-				var/list/thingsToCheck = syndicate_code_phrase + syndicate_code_response
-				for(var/T in thingsToCheck)
-					speech.message = replacetext(speech.message, T, "<span style='color: red;'>[T]</span>")
+				for(var/T in syndicate_code_phrase)
+					speech.message = replacetext(speech.message, T, "<span style='color: red;'><b>[T]</b></span>")
+
+				for(var/T in syndicate_code_phrase)
+					speech.message = replacetext(speech.message, T, "<span style='color: red;'><i>[T]</i></span>")
 
 
 #ifdef SAY_DEBUG

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -222,6 +222,16 @@ var/list/department_radio_keys = list(
 	var/atom/movable/AM = speech.speaker.GetSource()
 	if(!say_understands((istype(AM) ? AM : speech.speaker),speech.language)|| force_compose) //force_compose is so AIs don't end up without their hrefs.
 		rendered_message = render_speech(speech)
+	
+	//checking for syndie codephrases if person is a tator
+	if(src.mind.GetRole(TRAITOR) || src.mind.GetRole(NUKE_OP))
+		//is tator
+		for(var/T in syndicate_code_phrase)
+			rendered_message = replacetext(rendered_message, T, "<b style='color: red;'>[T]</b>")
+
+		for(var/T in syndicate_code_response)
+			rendered_message = replacetext(rendered_message, T, "<i style='color: red;'>[T]</i>")
+
 	show_message(rendered_message, type, deaf_message, deaf_type)
 	return rendered_message
 


### PR DESCRIPTION
[qol]

This will be some major qol for the tator metaclub ~altough i'm still not quite happy with my current markup, i tough about making it a little bolder~

Closes #22613

Codephrases are red and **bold**
Coderesponses are red and _italic_

Roles which get their text highlighted: Traitor, Nukeops

![image](https://user-images.githubusercontent.com/16618384/56855106-7b10cc80-6941-11e9-8ac9-df9bf92f761a.png)


:cl:
 * rscadd: Syndicate Codephrases/responses now get highlighted for other syndicates when spoken