### PR TITLE
Fabricators will now produce items immediately if they are next in queue

### DIFF
--- a/code/modules/research/fabricators.dm
+++ b/code/modules/research/fabricators.dm
@@ -347,8 +347,7 @@
 		if(queue.len) //If there is still a queue, it will immediately start working on a new item with no delay
 			var/datum/design/D = queue_pop()
 			src.build_part(D)
-			src.updateUsrDialog()
-			return 1
+			return 1 //Currently a bug where if item is unavailable to be built it disappears. Alternatives did not work. Please fix it yourself - B2MTTF
 	src.updateUsrDialog()
 	src.busy = 0
 	return 1

--- a/code/modules/research/fabricators.dm
+++ b/code/modules/research/fabricators.dm
@@ -299,6 +299,9 @@
 		src.visible_message("<font color='blue'>The [src.name] beeps, \"Not enough materials to complete item.\"</font>")
 		return
 
+	if(stopped)
+		return
+
 	src.being_built = new part.build_path(src)
 
 	src.busy = 1
@@ -340,6 +343,11 @@
 		src.being_built = null
 		last_made = part
 		wires.SignalIndex(RND_WIRE_JOBFINISHED)
+		if(queue.len) //If there is still a queue, it will immediately start working on a new item with no delay
+			var/datum/design/D = queue_pop()
+			src.build_part(D)
+			src.updateUsrDialog()
+			return 1
 	src.updateUsrDialog()
 	src.busy = 0
 	return 1

--- a/code/modules/research/fabricators.dm
+++ b/code/modules/research/fabricators.dm
@@ -343,6 +343,7 @@
 		src.being_built = null
 		last_made = part
 		wires.SignalIndex(RND_WIRE_JOBFINISHED)
+		sleep(2)
 		if(queue.len) //If there is still a queue, it will immediately start working on a new item with no delay
 			var/datum/design/D = queue_pop()
 			src.build_part(D)


### PR DESCRIPTION
You know that delay that makes building components be an unnecessary slog that nobody bothers to wait a few minutes for? This PR gets rid of it. Things will start being built immediately if they are next in queue, which means you can now print 50 components in about 10 seconds with a fully-upgraded Protolathe, which will make people start upgrading machineries.
Report any bugs that you can find, R&D code is a mess.
Current bugs:
If there are not enough materials for the next item in queue while the queue did not start with the item that cannot be produced, the item will be removed from the queue instead of being moved at the bottom.

:cl:
 * tweak: Drastically reduced the delay between objects being produced at fabricators, meaning that 50 stock parts will now take 10 seconds to build instead of approx. 2 minutes. Report any bugs you can find.