### PR TITLE
Mech clusterbang launcher can now be rearmed

### DIFF
--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -400,13 +400,13 @@
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/flashbang/clusterbang//Because I am a heartless bastard -Sieve
 	name = "\improper SOP-6 Grenade Launcher"
 	projectile = /obj/item/weapon/grenade/flashbang/clusterbang
-
+/* These two lines of code have been commented out by an even more heartless bastard
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/flashbang/clusterbang/limited/get_equip_info()//Limited version of the clusterbang launcher that can't reload
 	return "<span style=\"color:[equip_ready?"#0f0":"#f00"];\">*</span>&nbsp;[chassis.selected==src?"<b>":"<a href='?src=\ref[chassis];select_equip=\ref[src]'>"][src.name][chassis.selected==src?"</b>":"</a>"]\[[src.projectiles]\]"
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/flashbang/clusterbang/limited/rearm()
 	return//Extra bit of security
-
+*/
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/flashbang/metalfoam
 	name = "\improper Metal Foam Grenade Launcher"
 	desc = "An exosuit-mounted Metal Foam Grenade Launcher. (Can be attached to: Engineering exosuits)"

--- a/code/modules/research/designs/mecha/weapons.dm
+++ b/code/modules/research/designs/mecha/weapons.dm
@@ -140,7 +140,7 @@
 	id = "clusterbang_launcher"
 	build_type = MECHFAB
 	req_tech = list(Tc_COMBAT = 5, Tc_MATERIALS = 5, Tc_SYNDICATE = 3)
-	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/flashbang/clusterbang/limited
+	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/flashbang/clusterbang
 	category = "Exosuit_Weapons"
 	locked = 1
 	req_lock_access = list(access_armory)


### PR DESCRIPTION
It was an intentional choice but all it did was just make people print new clusterbang launchers to recharge it, basically an unneeded step that doesn't end up doing anything
There is far worse stuff that mechs can get, I'm sure

:cl:
 * tweak: Clusterbang launchers from mechs can now be rearmed.