### PR TITLE
delay assassination jectie now shows name in chat after delay

### DIFF
--- a/code/datums/gamemode/objectives/target/delayedassassinate.dm
+++ b/code/datums/gamemode/objectives/target/delayedassassinate.dm
@@ -11,7 +11,7 @@
 			explanation_text = format_explanation()
 			if(owner)
 				to_chat(owner.current,"<span class='warning'><BIG>We have identified our objective!</BIG></span>")
-				to_chat(owner.current,"<span class='warning'>The target is [target.current.real_name], the [target.assigned_role=="MODE" ? (target.special_role) : (target.assigned_role)]. Commit it to memory.</span>")
+				to_chat(owner.current,"<span class='warning'>The target is [target.current.real_name], the [target.assigned_role=="MODE" ? (target.special_role) : (target.assigned_role)]. Commit that name to memory.</span>")
 		else
 			if(owner)
 				to_chat(owner.current,"<span class='warning'><BIG>We have determined the target is not on this station. Redact assassination order.</BIG></warning>")

--- a/code/datums/gamemode/objectives/target/delayedassassinate.dm
+++ b/code/datums/gamemode/objectives/target/delayedassassinate.dm
@@ -10,7 +10,8 @@
 		if(find_target())
 			explanation_text = format_explanation()
 			if(owner)
-				to_chat(owner.current,"<span class='warning'><BIG>We have identified our objective target!</BIG></span>")
+				to_chat(owner.current,"<span class='warning'><BIG>We have identified our objective!</BIG></span>")
+				to_chat(owner.current,"<span class='warning'>The target is [target.current.real_name], the [target.assigned_role=="MODE" ? (target.special_role) : (target.assigned_role)]. Commit it to memory.</span>")
 		else
 			if(owner)
 				to_chat(owner.current,"<span class='warning'><BIG>We have determined the target is not on this station. Redact assassination order.</BIG></warning>")


### PR DESCRIPTION
i'm sick of telling people to check their notes
did what kurf told me to do in #22153
0% tested

🆑 
 - tweak: The names of assassination targets are now printed in the chat after their identity is confirmed. You can check your notes if you miss or forget it.