### PR TITLE
Hardsuits from cargo

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -632,7 +632,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	name = "Space suit"
 	contains = list(/obj/item/clothing/suit/space,
 					/obj/item/clothing/head/helmet/space)
-	cost = 150
+	cost = 200
 	containertype = /obj/structure/closet/crate/basic
 	containername = "space suit crate"
 	group = "Clothing"
@@ -719,7 +719,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	contains = list(/obj/item/clothing/suit/space/rig,
 					/obj/item/clothing/shoes/magboots,
 					/obj/item/clothing/mask/breath)
-	cost = 250
+	cost = 350
 	access = list(access_engine)
 	containertype = /obj/structure/closet/crate/secure/basic
 	containername = "engineering hardsuit crate"
@@ -730,7 +730,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	contains = list(/obj/item/clothing/suit/space/rig/atmos,
 					/obj/item/clothing/shoes/magboots/atmos,
 					/obj/item/clothing/mask/breath)
-	cost = 250
+	cost = 400
 	access = list(access_atmospherics)
 	containertype = /obj/structure/closet/crate/secure/basic
 	containername = "atmospherics hardsuit crate"
@@ -741,7 +741,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	contains = list(/obj/item/clothing/suit/space/rig/mining,
 					/obj/item/clothing/shoes/magboots,
 					/obj/item/clothing/mask/breath)
-	cost = 250
+	cost = 350
 	access = list(access_mining)
 	containertype = /obj/structure/closet/crate/secure/basic
 	containername = "mining hardsuit crate"
@@ -752,7 +752,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	contains = list(/obj/item/clothing/suit/space/rig/medical,
 					/obj/item/clothing/shoes/magboots,
 					/obj/item/clothing/mask/breath)
-	cost = 250
+	cost = 350
 	access = list(access_medical)
 	containertype = /obj/structure/closet/crate/secure/basic
 	containername = "medical hardsuit crate"
@@ -763,7 +763,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	contains = list(/obj/item/clothing/suit/space/rig/security,
 					/obj/item/clothing/shoes/magboots,
 					/obj/item/clothing/mask/breath)
-	cost = 250
+	cost = 350
 	access = list(access_armory)
 	containertype = /obj/structure/closet/crate/secure/basic
 	containername = "security hardsuit crate"
@@ -775,7 +775,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/clothing/suit/space/paramedic,
 					/obj/item/clothing/shoes/magboots/para,
 					/obj/item/clothing/mask/breath)
-	cost = 200
+	cost = 300
 	access = list(access_paramedic)
 	containertype = /obj/structure/closet/crate/secure/basic
 	containername = "paramedic space suit crate"

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -632,7 +632,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	name = "Space suit"
 	contains = list(/obj/item/clothing/suit/space,
 					/obj/item/clothing/head/helmet/space)
-	cost = 200
+	cost = 150
 	containertype = /obj/structure/closet/crate/basic
 	containername = "space suit crate"
 	group = "Clothing"
@@ -712,6 +712,73 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 150
 	containertype = /obj/structure/closet/crate/basic
 	containername = "contacts crate"
+	group = "Clothing"
+
+/datum/supply_packs/hardsuit_engineering
+	name = "Hardsuit (engineering)"
+	contains = list(/obj/item/clothing/suit/space/rig,
+					/obj/item/clothing/shoes/magboots,
+					/obj/item/clothing/mask/breath)
+	cost = 250
+	access = list(access_engine)
+	containertype = /obj/structure/closet/crate/secure/basic
+	containername = "engineering hardsuit crate"
+	group = "Clothing"
+
+/datum/supply_packs/hardsuit_atmos
+	name = "Hardsuit (atmospherics)"
+	contains = list(/obj/item/clothing/suit/space/rig/atmos,
+					/obj/item/clothing/shoes/magboots/atmos,
+					/obj/item/clothing/mask/breath)
+	cost = 250
+	access = list(access_atmospherics)
+	containertype = /obj/structure/closet/crate/secure/basic
+	containername = "atmospherics hardsuit crate"
+	group = "Clothing"
+
+/datum/supply_packs/hardsuit_mining
+	name = "Hardsuit (mining)"
+	contains = list(/obj/item/clothing/suit/space/rig/mining,
+					/obj/item/clothing/shoes/magboots,
+					/obj/item/clothing/mask/breath)
+	cost = 250
+	access = list(access_mining)
+	containertype = /obj/structure/closet/crate/secure/basic
+	containername = "mining hardsuit crate"
+	group = "Clothing"
+
+/datum/supply_packs/hardsuit_medical
+	name = "Hardsuit (medical)"
+	contains = list(/obj/item/clothing/suit/space/rig/medical,
+					/obj/item/clothing/shoes/magboots,
+					/obj/item/clothing/mask/breath)
+	cost = 250
+	access = list(access_medical)
+	containertype = /obj/structure/closet/crate/secure/basic
+	containername = "medical hardsuit crate"
+	group = "Clothing"
+
+/datum/supply_packs/hardsuit_security
+	name = "Hardsuit (security)"
+	contains = list(/obj/item/clothing/suit/space/rig/security,
+					/obj/item/clothing/shoes/magboots,
+					/obj/item/clothing/mask/breath)
+	cost = 250
+	access = list(access_armory)
+	containertype = /obj/structure/closet/crate/secure/basic
+	containername = "security hardsuit crate"
+	group = "Clothing"
+
+/datum/supply_packs/paramedicsuit
+	name = "Space suit (paramedic)"
+	contains = list(/obj/item/clothing/head/helmet/space/paramedic,
+					/obj/item/clothing/suit/space/paramedic,
+					/obj/item/clothing/shoes/magboots/para,
+					/obj/item/clothing/mask/breath)
+	cost = 200
+	access = list(access_paramedic)
+	containertype = /obj/structure/closet/crate/secure/basic
+	containername = "paramedic space suit crate"
 	group = "Clothing"
 
 //////SECURITY//////


### PR DESCRIPTION
[content] [powercreep]

As things stand if all the roundstart hardsuits go missing, as they often do, you're shit out of luck. However there's still enough of them on station accessible with sufficient ease for antags and powergayers to almost never have trouble getting them, so this lack of hardsuits usually just ends up shafting latejoiners in long-running rounds. So why not allow them to be ordered from cargo?

This adds engineering, atmos, mining, medical and security hardsuits to the cargo console under Clothing for ~~$250~~ $350 a pop, except the atmos hardsuit which is $400. Each crate comes with the hardsuit (which includes the helmet), appropriate magboots and a breathing mask, to match the roundstart suit storage units. There's also the paramedic's EVA suit at ~~$200~~ $300, it's cheaper because it's apparently not a proper hardsuit but I can make it cost the same if this sounds silly. Every crate requires appropriate access to the department the hardsuit belongs to in order to unlock.

~~I also made the existing civilian space suit only $150, because at $200 it felt a bit too expensive compared to the real hardsuits, and making it cheaper might make breaking into EVA or engineering for a hardsuit a bit less appealing in comparison (though who am I kidding, breaking in is free).~~

~~Untested because apparently the fucking cargo shuttle console doesn't work under Wine (or at least doesn't work under my Wine installation). It compiles fine, and really, how could I *possibly* fuck up adding a bunch of items into a list? Hah hah... I'll test this when I get back to my desktop tomorrow.~~ Turns out I just forgot to compile libvg, now officially 100% tested.

:cl:
 * rscadd: Hardsuits can now be ordered from cargo. The following hardsuit crates are available under the Clothing tab for $350 per crate: engineering, mining, medical, security. The atmospherics suit is available for $400. Additionally, the paramedic softsuit is available for $200. Each crate contains the hardsuit and its helmet, magboots, and a breath mask. Each crate requires appropriate access to unlock.