### PR TITLE
Adding libvg.so to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,6 @@ cfg
 
 # Thumbs.db (windows image caching)
 Thumbs.db
+
+# Linux users can compile this themselves
+libvg.so


### PR DESCRIPTION
We don't keep this in the repo for one reason or another, but it's not in .gitignore either. Considering Linux users tend to think precompiled binaries are the devil, .gitignore seems like the better option.