### PR TITLE
Firefighting equipment crate

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -335,10 +335,8 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/clothing/mask/gas,
 					/obj/item/clothing/head/hardhat/red,
 					/obj/item/clothing/head/hardhat/red,
-					// /obj/item/weapon/fireaxe,
 					/obj/item/weapon/extinguisher,
-					/obj/item/weapon/extinguisher,
-					/obj/item/weapon/extinguisher/foam)
+					/obj/item/weapon/extinguisher,)
 	cost = 20
 	containertype = /obj/structure/closet/crate/basic
 	containername = "firefighting equipment crate"
@@ -1558,6 +1556,17 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 15
 	containertype = /obj/structure/closet/crate/engi
 	containername = "inflatable structures crate"
+	group = "Engineering"
+
+/datum/supply_packs/firefighting_advanced
+	name = "Advanced firefighting equipment"
+	contains = list (/obj/item/weapon/fireaxe,
+					/obj/item/weapon/extinguisher/foam,
+					/obj/item/weapon/extinguisher/foam)
+	cost = 25
+	containertype = /obj/structure/closet/crate/secure/engisec
+	containername = "advanced firefighting equipment crate"
+	access = list(access_atmospherics)
 	group = "Engineering"
 
 /datum/supply_packs/radiation_suit

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -327,6 +327,23 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	access = list(access_mining)
 	group = "Supplies"
 
+/datum/supply_packs/firefighting
+	name = "Firefighting equipment"
+	contains = list(/obj/item/clothing/suit/fire/firefighter,
+					/obj/item/clothing/suit/fire/firefighter,
+					/obj/item/clothing/mask/gas,
+					/obj/item/clothing/mask/gas,
+					/obj/item/clothing/head/hardhat/red,
+					/obj/item/clothing/head/hardhat/red,
+					// /obj/item/weapon/fireaxe,
+					/obj/item/weapon/extinguisher,
+					/obj/item/weapon/extinguisher,
+					/obj/item/weapon/extinguisher/foam)
+	cost = 20
+	containertype = /obj/structure/closet/crate/basic
+	containername = "firefighting equipment crate"
+	group = "Supplies"
+
 /datum/supply_packs/artscrafts
 	name = "Arts and Crafts supplies"
 	contains = list(/obj/item/weapon/storage/fancy/crayons,


### PR DESCRIPTION
I don't think there was any way to get firesuits other than the ones that exist at roundstart, and none of the crates contained extinguishers either (should they go missing from extinguisher cabinets). This adds a crate to cargo under the Supplies tab that contains:

- Two firesuits
- Two gas masks
- Two firefighter helmets
- Two fire extinguishers

It costs $20, which is in line with similar supply crates (yes, they are really quite cheap). I decided against including the fire axe because that might make this too much of a powergay crate, even though there are multiple fire axes quite readily available on all stations. Roboticists rejoice.

Additionally, there is an **advanced firefighting equipment** crate under Engineering that contains the following:

- One fire axe
- Two foam fire extinguishers

It costs $25 and is locked to atmospherics access.

There's probably lots more minor stuff that could be added to the cargo terminal. I might take a more comprehensive look at some point, this and hardsuits (#22649) were just the ones off the top of my head.

:cl:
 * rscadd: Added a firefighting equipment crate to the cargo computer under Supplies. It contains firesuits, fire helmets, gas masks, and extinguishers. Also added an advanced firefighting equipment crate under Engineering that requires atmospherics access and contains a fire axe and two foam extinguishers.