### PR TITLE
you can now pull out the pilot of a mecha

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -245,26 +245,6 @@
 	pr_give_air = new /datum/global_iterator/mecha_tank_give_air(list(src))
 	pr_internal_damage = new /datum/global_iterator/mecha_internal_damage(list(src),0)
 
-/obj/mecha/proc/do_after(delay as num)
-	sleep(delay)
-	if(src)
-		return 1
-	return 0
-
-/obj/mecha/proc/enter_after(delay as num, var/mob/user as mob, var/numticks = 5)
-	var/delayfraction = delay/numticks
-
-	var/turf/T = user.loc
-
-	for(var/i = 0, i<numticks, i++)
-		sleep(delayfraction)
-		if(!src || !user || !user.canmove || !(user.loc == T))
-			return 0
-
-	return 1
-
-
-
 /obj/mecha/proc/check_for_support()
 	if(locate(/obj/structure/grille, orange(1, src)) || locate(/obj/structure/lattice, orange(1, src)) || locate(/turf/simulated, orange(1, src)) || locate(/turf/unsimulated, orange(1, src)))
 		return 1
@@ -422,8 +402,10 @@
 			if(!src.check_for_support())
 				src.pr_inertial_movement.start(list(src,direction))
 				src.log_message("Movement control lost. Inertial movement started.")
-		if(do_after(step_in))
-			can_move = 1
+		sleep(step_in)
+		if(!src)
+			return
+		can_move = 1
 		return 1
 	return 0
 
@@ -1193,7 +1175,7 @@
 	visible_message("<span class='notice'>[usr] starts to climb into \the [src].</span>")
 
 
-	if(enter_after(40,usr))
+	if(do_after(usr, src, 40))
 		if(!src.occupant)
 			moved_inside(usr)
 			refresh_spells()
@@ -1259,7 +1241,7 @@
 
 	visible_message("<span class='notice'>\The [user] starts to insert \the [mmi_as_oc] into \the [src].</span>")
 
-	if(enter_after(40,user))
+	if(do_after(user, src, 40))
 		if(!occupant)
 			return mmi_moved_inside(mmi_as_oc,user)
 		else
@@ -1355,9 +1337,10 @@
 	if(usr.incapacitated())
 		return
 	if(usr != occupant && occupant.isUnconscious())
-		visible_message("<span class='notice'>[usr] start pulling [occupant.name] out of \the [src].</span>")
-		if(do_after(30 SECONDS))
+		visible_message("<span class='notice'>[usr] starts pulling [occupant.name] out of \the [src].</span>")
+		if(do_after(usr, src, 30 SECONDS))
 			if(!occupant.isUnconscious())
+				visible_message("<span class='notice'>[occupant.name] woke up and pushed [usr] away.</span>")
 				return
 			go_out(over_location)
 			add_fingerprint(usr)
@@ -1956,14 +1939,16 @@
 		src.occupant_message("Recalibrating coordination system.")
 		src.log_message("Recalibration of coordination system started.")
 		var/T = src.loc
-		if(do_after(100))
-			if(T == src.loc)
-				src.clearInternalDamage(MECHA_INT_CONTROL_LOST)
-				src.occupant_message("<font color='blue'>Recalibration successful.</font>")
-				src.log_message("Recalibration of coordination system finished with 0 errors.")
-			else
-				src.occupant_message("<font color='red'>Recalibration failed.</font>")
-				src.log_message("Recalibration of coordination system failed with 1 error.",1)
+		sleep(100)
+		if(!src)
+			return
+		if(T == src.loc)
+			src.clearInternalDamage(MECHA_INT_CONTROL_LOST)
+			src.occupant_message("<font color='blue'>Recalibration successful.</font>")
+			src.log_message("Recalibration of coordination system finished with 0 errors.")
+		else
+			src.occupant_message("<font color='red'>Recalibration failed.</font>")
+			src.log_message("Recalibration of coordination system failed with 1 error.",1)
 
 	//debug
 	/*

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1356,7 +1356,7 @@
 		return
 	if(usr != occupant)
 		visible_message("<span class='notice'>[usr] start pulling [occupant.name] out of \the [src].</span>")
-		if(do_after(usr, src, 4 SECONDS))
+		if(do_after(usr, src, 10 SECONDS))
 			go_out(over_location)
 			add_fingerprint(usr)
 		return

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1354,9 +1354,11 @@
 		return
 	if(usr.incapacitated())
 		return
-	if(usr != occupant)
+	if(usr != occupant && occupant.isUnconscious())
 		visible_message("<span class='notice'>[usr] start pulling [occupant.name] out of \the [src].</span>")
-		if(do_after(usr, src, 30 SECONDS))
+		if(do_after(30 SECONDS))
+			if(!occupant.isUnconscious())
+				return
 			go_out(over_location)
 			add_fingerprint(usr)
 		return

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1356,7 +1356,7 @@
 		return
 	if(usr != occupant)
 		visible_message("<span class='notice'>[usr] start pulling [occupant.name] out of \the [src].</span>")
-		if(do_after(usr, src, 10 SECONDS))
+		if(do_after(usr, src, 30 SECONDS))
 			go_out(over_location)
 			add_fingerprint(usr)
 		return

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1346,13 +1346,19 @@
 	lock_dir = !lock_dir
 
 /obj/mecha/MouseDropFrom(over_object, src_location, var/turf/over_location, src_control, over_control, params)
-	if(usr != src.occupant || usr.incapacitated())
-		return
-	if(istype(occupant, /mob/living/carbon/brain))
+	if(!Adjacent(over_location))
 		return
 	if(!istype(over_location) || over_location.density)
 		return
-	if(!Adjacent(over_location))
+	if(istype(occupant, /mob/living/carbon/brain))
+		return
+	if(usr.incapacitated())
+		return
+	if(usr != occupant)
+		visible_message("<span class='notice'>[usr] start pulling [occupant.name] out of \the [src].</span>")
+		if(do_after(usr, src, 4 SECONDS))
+			go_out(over_location)
+			add_fingerprint(usr)
 		return
 	for(var/atom/movable/A in over_location.contents)
 		if(A.density)


### PR DESCRIPTION
[qol]
Basically what i did in #22645
@Blithering mentioned it would be neat to add this to mechas, so i did

What i did here:
- You can pull people out in 30 seconds if they are unconcious at start and end of the process
- removed that retarded do_after override from /obj/mecha and replaced all corresponding occurences with sleep()
- added the actual do_after to pullig out as well as entering, so you now get a progressbar when doing so

making mecha code a little less worse one day at a time

:cl:
 * rscadd: You can now pull the pilot out of a mech if he/she is unconscious
 * tweak: you will now get a progressbar when entering a mecha/inserting a mmi