### PR TITLE
Not-Obvious No-Slip Shoes + other syndigaloshes changes

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -170,8 +170,8 @@ var/list/uplink_items = list()
 	cost = 8
 
 /datum/uplink_item/nukeprice/syndigaloshes
-	name = "No-Slip Syndicate Shoes"
-	desc = "Allows you to run on wet floors. They do not work on lubricated surfaces and are distinguishable by their extra grip when examined closely."
+	name = "No-Slip Chameleon Shoes"
+	desc = "A pair of species-flexible shoes that can look, and in some cases sound, like any other piece of footgear. Protects against slipping on water, but cannot protect against lubricated surfaces. They can attract suspicion while off your person, and are explicitly identifiable as illegal tech when closely examined."
 	category = "Stealth and Camouflage Items"
 	item = /obj/item/clothing/shoes/syndigaloshes
 	cost = 4
@@ -317,8 +317,8 @@ var/list/uplink_items = list()
 	cost = 2
 
 /datum/uplink_item/stealthy_tools/syndigaloshes
-	name = "No-Slip Syndicate Shoes"
-	desc = "Allows you to run on wet floors. They do not work on lubricated surfaces and are distinguishable by their extra grip when examined closely."
+	name = "No-Slip Chameleon Shoes"
+	desc = "A pair of species-flexible shoes that can look, and in some cases sound, like any other piece of footgear. Protects against slipping on water, but cannot protect against lubricated surfaces. They can attract suspicion while off your person, and are explicitly identifiable as illegal tech when closely examined."
 	item = /obj/item/clothing/shoes/syndigaloshes
 	cost = 2
 	jobs_excluded = list("Nuclear Operative")

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -1,24 +1,38 @@
 /obj/item/clothing/shoes/syndigaloshes
-	desc = "A pair of brown shoes. They seem to have extra grip." //change line ~346 in code/datums/uplink_item.dm if you remove the second sentence
+	desc = "A pair of brown shoes." // the "extra grip" contraband id text is moved to examine()
 	name = "brown shoes"
 	icon_state = "brown"
 	item_state = "brown"
-	permeability_coefficient = 0.05
+	_color = "brown"
 	clothing_flags = NOSLIP
 	origin_tech = Tc_SYNDICATE + "=3"
 	var/list/clothing_choices = list()
 	actions_types = list(/datum/action/item_action/change_appearance_shoes)
 	siemens_coefficient = 0.8
-	species_fit = list(VOX_SHAPED)
+	permeability_coefficient = 0.90
+	species_fit = list(VOX_SHAPED, GREY_SHAPED, UNDEAD_SHAPED, MUSHROOM_SHAPED)
+
+// desc replacement block
+/obj/item/clothing/shoes/syndigaloshes/examine(mob/user) 
+	..()
+	if(is_holder_of(user, src)) // are the noslips on your person or on the floor? 
+		to_chat(user, "<span class='info'><b>When inspected hands-on,</b> they are apparently modified with complex electronics and extra-grip soles.</span>") // these are no-slips yes hello sir
+		to_chat(user, "<span class='info'>They are rated to fit all known species able to wear footgear.</span>") // catbeasts/unathi/golems btfo, how will they ever recover
+		return
+	if(isturf(loc) && user.Adjacent(src)) // so there's degrees of identification. above is blatant, this is less so 
+		to_chat(user, "Something's a little off...")
 
 /obj/item/clothing/shoes/syndigaloshes/New()
 	..()
+	verbs += /obj/item/clothing/shoes/syndigaloshes/verb/change_appearance_shoes
 	for(var/Type in typesof(/obj/item/clothing/shoes) - list(/obj/item/clothing/shoes, /obj/item/clothing/shoes/syndigaloshes))
 		clothing_choices += new Type
 	return
 
+/*	// the above 5 lines invalidate any purpose this block once had
 /obj/item/clothing/shoes/syndigaloshes/attackby(obj/item/I, mob/user)
 	..()
+
 	if(!istype(I, /obj/item/clothing/shoes) || istype(I, src.type))
 		return 0
 	else
@@ -30,9 +44,11 @@
 		to_chat(user, "<span class='notice'>[S.name]'s pattern absorbed by \the [src].</span>")
 		return 1
 	return 0
+*/
 
 /datum/action/item_action/change_appearance_shoes
-	name = "Change Shoes Appearance"
+	name = "Change Shoe Color"
+	desc = "Swap the appearance of your shoes."
 
 /datum/action/item_action/change_appearance_shoes/Trigger()
 	var/obj/item/clothing/shoes/syndigaloshes/T = target
@@ -40,23 +56,25 @@
 		return
 	T.change()
 
+/obj/item/clothing/shoes/syndigaloshes/verb/change_appearance_shoes()
+	set name = "Change Shoe Color"
+	set category = "Object"
+	set desc = "Swap the appearance of your shoes."
+	src.change()
+
 /obj/item/clothing/shoes/syndigaloshes/proc/change()
 	var/obj/item/clothing/shoes/A
-	A = input("Select Colour to change it to", "BOOYEA", A) as null|anything in clothing_choices
-	if(!A ||(usr.stat))
+	A = input("Pick a color:", "BOOYEA", A) as null|anything in clothing_choices 
+	if(!A || usr.incapacitated() || !Adjacent(usr) || isturf(src.loc))
 		return
 
-	desc = null
-	permeability_coefficient = 0.90
-
 	desc = A.desc
-	desc += " They seem to have extra grip."
 	name = A.name
 	icon_state = A.icon_state
 	item_state = A.item_state
 	_color = A._color
 	step_sound = A.step_sound
-	usr.update_inv_w_uniform()	//so our overlays update.
+	usr.update_inv_shoes()	
 
 /obj/item/clothing/shoes/mime
 	name = "mime shoes"


### PR DESCRIPTION
An update to the syndie no-slips, which have gone about 4 years since they got any attention.
I was mainly trying to fix the fact that no-slips easily reveal that they're contraband from a distance, and while they're being worn by someone else.
But while I was working on this, I saw that the noslips had some rather old code that hardly got touched. 
So that's in this PR as well.

This PR is very much open to change, as I don't think it's that polished.
Any input is appreciated.
Related to this PR, especially the `examine()` and `desc` changes, is issue #22659. 

**Examine changes**
 - Original "They seem to have extra grip." in `desc`/colorchange proc is removed
 - Description appears as normal when the `user` is 2+ tiles away
 - examine() gives unique but vague text while the user is Adjacent() and the shoes are in a turf
 - While the shoes are contained by the user, examination blatantly reveals the shoes' true nature
 - Hands-on examination also says that the shoes fit all species with a species_fit tag
 - All examination while the noslips are worn just gives the current color's desc

 **Usage**
 - The item_action (HUD button) for changing appearance has a short desc and a different name
 - A verb analog to the item_action was added to the Object tab (good for macros)
 - Sanity checks are improved (usr.stat replaced with usr.incapacitated, !Adjacent(usr) and isturf(src.loc)
 - Scanning other pairs of shoes is now commented out, as it's redundant when the no-slips can mimic any child of /item/clothing/shoes but itelf and the base type
 - Overlays now update properly and immediately upon switching colors
 
**Misc**
 - permeability_coefficient is now always 0.9
 - No-slips now initally have _color = "brown"
 - species_fit now has GREY_SHAPED, UNDEAD_SHAPED, MUSHROOM_SHAPED in addition to the already-existing VOX_SHAPED
 - In the Syndie uplink, no-slips are now "No-Slip Chameleon Shoes" and have a new, more specific description

<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation or the coding discord (you can find an invite link on the irc or the thread) to discuss your changes, or if you need help.

== SELF LABELLING PRs ==
You can now self-label your PR! The syntax is simple. Just put [<labeltag>] anywhere in your PR,
where <labeltag> is to be replaced by one of the following (allowing with the resultant tag)
just ctrl+f the list or something. I know it's long.

administration = "Logging / Administration"
away = "Mapping (Away Mission :earth_africa:)"
bagel = "Mapping (Bagel :o:)"
box = "Mapping (Box :baby:)"
bugfix = "Bug / Fix"
bus = "Mapping (Bus :bus:)"
byond = "T-Thanks BYOND"
consistency = "Consistency Issue"
controversial = "Controversial"
deff = "Mapping (Deff :wastebasket:)"
discussion = "Discussion"
dnm = "✋ Do Not Merge ✋"
easy = "Easy Fix"
exploitable = "Exploitable"
featureloss = "Feature Loss"
featurerequest = "Feature Request"
first = "good first issue"
formatting = "Grammar / Formatting"
gamemode = "Gameplay / Gamemode"
gameplay = "Gameplay / Gamemode"
general = "Mapping (General :world_map:)"
goonchat = "Goonchat"
grammar = "Grammar / Formatting"
help = "help wanted"
hotfix = "Hotfix"
libvg = "libvg"
logging = "Logging / Administration"
meta = "Mapping (Meta :no_mobile_phones:)"
needspritework = "Needs Spritework"
oversight = "Oversight"
packed = "Mapping (Packed :package:)"
parallax = "Parallax"
qol = "❤️ Quality of Life ❤️"
roid = "Mapping (Roidstation :pick:)"
role = "Role Datums"
roleissue = "Role Datums Issue"
runtime = "Runtime Log"
sanity = "Sanity / Ghosthands"
snowmap = "Mapping (Snowmap ❄)"
sound = "Sound"
sprites = "Sprites"
spriteworkdone = "Spritework Done Needs Coder"
system = "System"
taxi = "Mapping (Taxi :taxi:)"
tested = "100%  tested"
tweak = "Tweak"
ui = "UI"
vault = "Mapping (Vault :question:)"
vote = "⛔ Requires Server Vote ⛔"
wip = "WiP"

== CHANGELOGS ==
Changelogs can be attached either by following the instructions in html/changelogs/example.yml, or by attaching an in-body changelog like the one attached to your PR automatically.

For the keys you can use in an in-body changelog, they are the same as described in example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!

An example changelog is attached to this PR for your convenience:
-->

[consistency] [tweak] [qol]
:cl:
 * rscadd: The No-Slip Shoes can now use an Object verb to change color instead of just the HUD button.
 * tweak: No-Slips now only give distinctive examine text when held on your person, or next to you on the ground.
 * tweak: No-Slips are now consistently permeable.
 * spellcheck: The "No-Slip Syndicate Shoes" entry in the uplink has been renamed to "No-Slip Chameleon Shoes", along with a different description.