### PR TITLE
Removing clone damage from vampire succ

### DIFF
--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -201,7 +201,6 @@
 			blood = min(20, target.vessel.get_reagent_amount(BLOOD)) // if they have less than 20 blood, give them the remnant else they get 20 blood
 			blood_total += blood
 			blood_usable += blood
-			target.adjustCloneLoss(10) // beep boop 10 damage
 		else
 			blood = min(10, target.vessel.get_reagent_amount(BLOOD)) // The dead only give 10 blood
 			blood_total += blood

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -1128,7 +1128,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 //Is the limb robotic and malfunctioning
 /datum/organ/external/proc/is_malfunctioning()
 	return (is_robotic() && (status & (ORGAN_MALFUNCTIONING) || (brute_dam + burn_dam > min_broken_damage/2 && prob(brute_dam + burn_dam))))
-	
+
 //Can we use advanced tools (no pegs or hook-hands)
 /datum/organ/external/proc/can_use_advanced_tools()
 	return !(status & (ORGAN_DESTROYED|ORGAN_MUTATED|ORGAN_DEAD|ORGAN_PEG|ORGAN_CUT_AWAY))


### PR DESCRIPTION
This thing singlehandedly removes any possibility of vampires keeping their victims alive or even the possibility of thralls willingly giving their blood.

If you're against this I'd be curious to read why.

:cl:
* tweak: Vampires no longer deal 10 genetic damage per tick when sucking blood, instead they deal 1 brute damage that will be identified during autopsy as coming from sharp teeth.
* tweak: Vampires may now only drink up to 100 "total" blood from a single victim. If the victim is still alive, they may continue to drink to get some "usable" blood back, but they will need at least 7 different victims to reach full powers.