### PR TITLE
striketeams now show mission when polling

### DIFF
--- a/code/game/striketeams/striketeam_datums.dm
+++ b/code/game/striketeams/striketeam_datums.dm
@@ -73,6 +73,7 @@ var/list/sent_strike_teams = list()
 			continue
 
 		to_chat(O, "[bicon(team_logo)]<span class='recruit'>[faction_name] needs YOU to become part of its upcoming [striketeam_name]. (<a href='?src=\ref[src];signup=\ref[O]'>Apply now!</a>)</span>[bicon(team_logo)]")
+		to_chat(O, "[bicon(team_logo)]<span class='recruit'>Their mission: [mission]</span>")
 
 	spawn(1 MINUTES)
 		searching = FALSE

--- a/code/game/striketeams/striketeam_datums.dm
+++ b/code/game/striketeams/striketeam_datums.dm
@@ -73,7 +73,7 @@ var/list/sent_strike_teams = list()
 			continue
 
 		to_chat(O, "[bicon(team_logo)]<span class='recruit'>[faction_name] needs YOU to become part of its upcoming [striketeam_name]. (<a href='?src=\ref[src];signup=\ref[O]'>Apply now!</a>)</span>[bicon(team_logo)]")
-		to_chat(O, "[bicon(team_logo)]<span class='recruit'>Their mission: [mission]</span>")
+		to_chat(O, "[bicon(team_logo)]<span class='recruit'>Their mission: [mission]</span>[bicon(team_logo)]")
 
 	spawn(1 MINUTES)
 		searching = FALSE


### PR DESCRIPTION
and another checkbox for #22477
Works for all striketeams, including the standard ERT.
![image](https://user-images.githubusercontent.com/8468269/56870421-63077e80-6a0f-11e9-8240-31d6750ad3b5.png)
