### PR TITLE
Strike teams now get and display jecties

### DIFF
--- a/code/datums/gamemode/factions/faction.dm
+++ b/code/datums/gamemode/factions/faction.dm
@@ -404,7 +404,12 @@ var/list/factions_with_hud_icons = list()
 	roletype = /datum/role/emergency_responder
 	logo_state = "ert-logo"
 	hud_icons = list("ert-logo")
-
+	
+/datum/faction/strike_team/ert/forgeObjectives(var/mission)
+	var/datum/objective/custom/c = new /datum/objective/custom
+	c.explanation_text = mission
+	AppendObjective(c)
+	
 //________________________________________________
 
 /datum/faction/strike_team/deathsquad
@@ -414,6 +419,11 @@ var/list/factions_with_hud_icons = list()
 	roletype = /datum/role/death_commando
 	logo_state = "death-logo"
 	hud_icons = list("death-logo","creed-logo")
+	
+/datum/faction/strike_team/deathsquad/forgeObjectives(var/mission)
+	var/datum/objective/custom/c = new /datum/objective/custom
+	c.explanation_text = mission
+	AppendObjective(c)
 
 //________________________________________________
 
@@ -424,11 +434,23 @@ var/list/factions_with_hud_icons = list()
 	roletype = /datum/role/syndicate_elite_commando
 	logo_state = "elite-logo"
 
+/datum/faction/strike_team/syndiesquad/forgeObjectives(var/mission)
+	var/datum/objective/custom/c = new /datum/objective/custom
+	c.explanation_text = mission
+	AppendObjective(c)
+	
+//________________________________________________
+	
 /datum/faction/strike_team/custom
 	name = "Custom Strike Team"
 
 /datum/faction/strike_team/custom/New()
 	..()
 	ID = rand(1,999)
+	
+/datum/faction/strike_team/custom/forgeObjectives(var/mission)
+	var/datum/objective/custom/c = new /datum/objective/custom
+	c.explanation_text = mission
+	AppendObjective(c)
 
 //________________________________________________

--- a/code/datums/gamemode/factions/faction.dm
+++ b/code/datums/gamemode/factions/faction.dm
@@ -395,6 +395,11 @@ var/list/factions_with_hud_icons = list()
 	ID = CUSTOMSQUAD
 	logo_state = "nano-logo"
 
+/datum/faction/strike_team/forgeObjectives(var/mission)
+	var/datum/objective/custom/c = new /datum/objective/custom
+	c.explanation_text = mission
+	AppendObjective(c)
+	
 //________________________________________________
 
 /datum/faction/strike_team/ert
@@ -405,11 +410,6 @@ var/list/factions_with_hud_icons = list()
 	logo_state = "ert-logo"
 	hud_icons = list("ert-logo")
 	
-/datum/faction/strike_team/ert/forgeObjectives(var/mission)
-	var/datum/objective/custom/c = new /datum/objective/custom
-	c.explanation_text = mission
-	AppendObjective(c)
-	
 //________________________________________________
 
 /datum/faction/strike_team/deathsquad
@@ -419,11 +419,6 @@ var/list/factions_with_hud_icons = list()
 	roletype = /datum/role/death_commando
 	logo_state = "death-logo"
 	hud_icons = list("death-logo","creed-logo")
-	
-/datum/faction/strike_team/deathsquad/forgeObjectives(var/mission)
-	var/datum/objective/custom/c = new /datum/objective/custom
-	c.explanation_text = mission
-	AppendObjective(c)
 
 //________________________________________________
 
@@ -433,11 +428,6 @@ var/list/factions_with_hud_icons = list()
 	initroletype = /datum/role/syndicate_elite_commando
 	roletype = /datum/role/syndicate_elite_commando
 	logo_state = "elite-logo"
-
-/datum/faction/strike_team/syndiesquad/forgeObjectives(var/mission)
-	var/datum/objective/custom/c = new /datum/objective/custom
-	c.explanation_text = mission
-	AppendObjective(c)
 	
 //________________________________________________
 	
@@ -447,10 +437,5 @@ var/list/factions_with_hud_icons = list()
 /datum/faction/strike_team/custom/New()
 	..()
 	ID = rand(1,999)
-	
-/datum/faction/strike_team/custom/forgeObjectives(var/mission)
-	var/datum/objective/custom/c = new /datum/objective/custom
-	c.explanation_text = mission
-	AppendObjective(c)
 
 //________________________________________________

--- a/code/datums/gamemode/objectives/custom.dm
+++ b/code/datums/gamemode/objectives/custom.dm
@@ -1,6 +1,7 @@
 /datum/objective/custom
 	name = "Custom objective"
 	explanation_text = "Just be yourself"
+	force_success = TRUE
 
 /datum/objective/custom/New(var/text,var/auto_target = TRUE, var/mob/user)
 	if (!user)

--- a/code/game/striketeams/emergency_response_team.dm
+++ b/code/game/striketeams/emergency_response_team.dm
@@ -23,7 +23,9 @@ var/list/response_team_members = list()
 		to_chat(H, "<span class='notice'>You are [H.real_name], the Commander of the Emergency Response Team, in the service of Nanotrasen.</span>")
 	else
 		to_chat(H, "<span class='notice'>You are [H.real_name], an Emergency Responder, in the service of Nanotrasen.</span>")
-	to_chat(H, "<span class='notice'>Your mission is: <span class='danger'>[mission]</span></span>")
+	for (var/role in H.mind.antag_roles)
+		var/datum/role/R = H.mind.antag_roles[role]
+		R.AnnounceObjectives()
 
 /datum/striketeam/ert/create_commando(obj/spawn_location, leader_selected = 0, key = "")
 	var/mob/living/carbon/human/M = new(spawn_location)
@@ -131,6 +133,7 @@ var/list/response_team_members = list()
 		ert.HandleRecruitedMind(M.mind)
 	else
 		ert = ticker.mode.CreateFaction(/datum/faction/strike_team/ert)
+		ert.forgeObjectives(mission)
 		if(ert)
 			ert.HandleNewMind(M.mind) //First come, first served
 	M.equip_response_team(leader_selected)

--- a/code/game/striketeams/nanotrasen_deathsquad.dm
+++ b/code/game/striketeams/nanotrasen_deathsquad.dm
@@ -34,6 +34,7 @@
 		deathsquad.HandleRecruitedMind(new_commando.mind)
 	else
 		deathsquad = ticker.mode.CreateFaction(/datum/faction/strike_team/deathsquad)
+		deathsquad.forgeObjectives(mission)
 		if(deathsquad)
 			deathsquad.HandleNewMind(new_commando.mind) //First come, first served
 	if (leader_selected)
@@ -51,7 +52,10 @@
 		to_chat(H, "<span class='notice'>You are [H.real_name], a Death Squad commando, in the service of Nanotrasen.</span>")
 		if (leader_key != "")
 			to_chat(H, "<span class='notice'>Follow directions from your superior, Creed.</span>")
-	to_chat(H, "<span class='notice'>Your mission is: <span class='danger'>[mission]</span></span>")
+	//to_chat(H, "<span class='notice'>Your mission is: <span class='danger'>[mission]</span></span>")
+	for (var/role in H.mind.antag_roles)
+		var/datum/role/R = H.mind.antag_roles[role]
+		R.AnnounceObjectives()
 
 /mob/living/carbon/human/proc/equip_death_commando(leader = 0)
 	//Special radio setup

--- a/code/game/striketeams/striketeam_datums.dm
+++ b/code/game/striketeams/striketeam_datums.dm
@@ -142,7 +142,6 @@ var/list/sent_strike_teams = list()
 				new_commando.key = applicant.key
 
 				new_commando.update_action_buttons_icon()
-				new_commando.mind.store_memory("<B>Mission:</B> <span class='warning'>[mission].</span>")
 
 				greet_commando(new_commando)
 		extras()
@@ -153,7 +152,9 @@ var/list/sent_strike_teams = list()
 
 /datum/striketeam/proc/greet_commando(var/mob/living/carbon/human/H)
 	to_chat(H, "<span class='notice'>You are a [striketeam_name] commando, in the service of [faction_name].</span>")
-	to_chat(H, "<span class='notice'>Your current mission is: <span class='danger'>[mission]</span></span>")
+	for (var/role in H.mind.antag_roles)
+		var/datum/role/R = H.mind.antag_roles[role]
+		R.AnnounceObjectives()
 
 /datum/striketeam/Topic(var/href, var/list/href_list)
 	if(href_list["signup"])
@@ -342,6 +343,7 @@ var/list/sent_strike_teams = list()
 		customsquad.HandleRecruitedMind(new_commando.mind)
 	else
 		customsquad = ticker.mode.CreateFaction(/datum/faction/strike_team/custom)
+		customsquad.forgeObjectives(mission)
 		if(customsquad)
 			customsquad.HandleNewMind(new_commando.mind) //First come, first served
 	new_commando.equip_death_commando(leader_selected)

--- a/code/game/striketeams/syndicate_elite_squad.dm
+++ b/code/game/striketeams/syndicate_elite_squad.dm
@@ -40,6 +40,7 @@
 		syndiesquad.HandleRecruitedMind(new_syndicate_commando.mind)
 	else
 		syndiesquad = ticker.mode.CreateFaction(/datum/faction/strike_team/syndiesquad)
+		syndiesquad.forgeObjectives(mission)
 		if(syndiesquad)
 			syndiesquad.HandleNewMind(new_syndicate_commando.mind) //First come, first served
 	new_syndicate_commando.equip_syndicate_commando(syndicate_leader_selected)
@@ -48,7 +49,9 @@
 /datum/striketeam/syndicate/greet_commando(var/mob/living/carbon/human/H)
 	H << 'sound/music/elite_syndie_squad.ogg'
 	to_chat(H, "<span class='notice'>You are [H.real_name], an Elite commando, in the service of the Syndicate.</span>")
-	to_chat(H, "<span class='notice'>Your mission is: <span class='danger'>[mission]</span></span>")
+	for (var/role in H.mind.antag_roles)
+		var/datum/role/R = H.mind.antag_roles[role]
+		R.AnnounceObjectives()
 
 /mob/living/carbon/human/proc/equip_syndicate_commando(leader = 0)
 	//Special radio setup


### PR DESCRIPTION
yet another checkbox for #22477
Strike teams now get their passed mission as an actual objective.
They get shown their objective upon spawning.
By default, they succeed, but mins can fuck with it.

![image](https://user-images.githubusercontent.com/8468269/56871681-6277e380-6a21-11e9-9a05-6c227e36c616.png)
![image](https://user-images.githubusercontent.com/8468269/56871686-6ad01e80-6a21-11e9-9203-cc0bbf398067.png)
