### PR TITLE
Self click-dragging onto operating tables

### DIFF
--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -86,7 +86,7 @@
 	if(!ishigherbeing(user) && !isrobot(user)) //No ghosts or mice putting people into the sleeper
 		return
 	var/mob/living/L = O
-	if(!istype(L)|| L == user)
+	if(!istype(L))
 		return
 
 	L.unlock_from() //We checked above that they can ONLY be buckled to a rollerbed to allow this to happen!
@@ -135,16 +135,6 @@
 		visible_message("<span class='warning'>[C] has been laid on the operating table by [user].</span>")
 
 	add_fingerprint(user)
-
-/obj/machinery/optable/verb/climb_on()
-	set name = "Climb On Table"
-	set category = "Object"
-	set src in oview(1)
-
-	if(usr.isUnconscious() || !ishuman(usr) || usr.locked_to || usr.restrained())
-		return
-
-	take_victim(usr, usr)
 
 /obj/machinery/optable/attackby(obj/item/weapon/W as obj, mob/living/carbon/user as mob)
 	if(iswrench(W))

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -85,7 +85,7 @@
 		return
 	if(!ishigherbeing(user) && !isrobot(user)) //No ghosts or mice putting people into the sleeper
 		return
-	var/mob/living/L = O
+	var/mob/living/carbon/human/L = O
 	if(!istype(L))
 		return
 


### PR DESCRIPTION
[tweak][qol] Removes the climb-on verb on op tables, and moves its functionality to click-drag.

:cl:
 * tweak: You can now click-drag yourself onto an operating table. 