### PR TITLE
Glass floors QoL + powercreep

### DIFF
--- a/code/game/turfs/simulated/floor_glass.dm
+++ b/code/game/turfs/simulated/floor_glass.dm
@@ -11,7 +11,7 @@
 	luminosity = 1
 	intact = 0 // make pipes appear above space
 
-	var/health=40 // same as rwindow.
+	var/health=80 // 2x that of an rwindow
 	var/sheetamount = 1 //Number of sheets needed to build this floor (determines how much shit is spawned via Destroy())
 	var/cracked_base = "fcrack"
 	var/shardtype = /obj/item/weapon/shard
@@ -74,31 +74,10 @@
 	if(loc)
 		playsound(src, "shatter", 70, 1)
 	//ReplaceWithLattice()
-	// TODO: Break all pipes/wires?
-	// FIXME: Animations are fucked, controversial, I want to move on to other shit.
-	/*
-	if(!no_teleport && src.has_gravity())
-		for(var/atom/movable/A in src)
-			if(!istype(A))
-				continue
-			fall_into_background(A) // 3 seconds, NONBLOCKING.
-			spawn(30)
-				throw_that_fucker(A)
-	*/
+	// TODO: Break all pipes/wires? //Maybe not, N3X.
 
-	// Yes, this leaves shit left when other things are flung into space, but it gives engineering something to work with.
 	spawnBrokenPieces(src)
 	ChangeTurf(/turf/space)
-
-/turf/simulated/floor/glass/proc/throw_that_fucker(var/atom/movable/A)
-	if(!istype(A))
-		return
-
-	var/new_x = rand(25, world.maxx-25)
-	var/new_y = rand(25, world.maxx-25)
-	var/new_z = map.zDeepSpace
-	var/turf/T = locate(new_x,new_y,new_z)
-	A.forceMove(T)
 
 /turf/simulated/floor/glass/proc/spawnBrokenPieces(var/turf/T)
 	getFromPool(shardtype, T, sheetamount)
@@ -114,7 +93,7 @@
 			if (pressure > 0)
 				message_admins("Glass floor with pressure [pressure]kPa broken (method=[method]) by [M.real_name] ([formatPlayerPanel(M,M.ckey)]) at [formatJumpTo(src)]!")
 				log_admin("Window with pressure [pressure]kPa broken (method=[method]) by [M.real_name] ([M.ckey]) at [src]!")
-			M.visible_message("<span class='danger'>[M] falls through the glass!</span>", "<span style='font-size:largest' class='danger'>OH FUCK, YOU FELL THROUGH!</span>", "You hear breaking glass.")
+			M.visible_message("<span class='danger'>[M] falls through the glass!</span>", "<span style='font-size:largest' class='danger'>\The [src] breaks!</span>", "You hear breaking glass.")
 		break_turf(no_teleport)
 	else
 		if(sound)
@@ -149,50 +128,13 @@
 			return
 
 /turf/simulated/floor/glass/Entered(var/atom/movable/mover)
-	if(!reinforced && ishuman(mover))
-		var/mob/living/carbon/human/H = mover
-		// Fatties damage glass.
-		if(M_FAT in H.mutations && prob(25)) // I REALLY don't like sampling noise this often...
-			H.visible_message("<span class='warning'>[H] damages \the [src] with \his[H] sheer weight!</span>",
-			"<span class='warning'>You damage \the [src] with your sheer weight!</span>",
-			"<span class='italics'>You hear glass cracking!</span>")
-			health -= rand(5, 20)
-			healthcheck(H, FALSE, "body weight")
-	if(istype(mover,/obj/mecha))
+	if(!reinforced  && istype(mover,/obj/mecha)) //OSHA spec glass flooring, woohoo
 		var/obj/mecha/M = mover
 		M.visible_message("<span class='warning'>\The [M] damages \the [src] with its sheer weight!</span>",
 		"<span class='warning'>You damage \the [src] with your sheer weight!</span>",
 		"<span class='italics'>You hear glass cracking!</span>")
 		health -= rand(20, 40)
 		healthcheck(M.occupant, FALSE, "mech weight")
-	if(isvehicle(mover))
-		var/obj/structure/bed/chair/vehicle/V = mover
-		if(V.is_too_heavy(src))
-			V.visible_message("<span class='warning'>\The [V] damages \the [src] with its sheer weight!</span>",
-			"<span class='warning'>You damage \the [src] with your sheer weight!</span>",
-			"<span class='italics'>You hear glass cracking!</span>")
-			health -= rand(10, 20)
-			healthcheck(V.occupant, FALSE, "vehicle weight")
-	/* Unimplemented
-	if(istype(mover, /obj/vehicle))
-		var/obj/vehicle/V = mover
-		if(V.is_too_heavy(src))
-			V.visible_message("<span class='warning'>\The [V] damages \the [src] with its sheer weight!</span>",
-			"<span class='warning'>You damage \the [src] with your sheer weight!</span>",
-			"<span class='italics'>You hear glass cracking!</span>")
-			health -= rand(10, 20)
-			healthcheck(V.occupant, FALSE, "vehicle weight")
-	*/
-	/* I'm really iffy about players being punished over dumb AI decisions.
-	if(istype(mover, /obj/machinery/bot/mulebot))
-		var/obj/machinery/bot/mulebot/MB = mover
-		V.visible_message("<span class='warning'>\The [MB] damages \the [src] with its sheer weight!</span>",
-		"<span class='warning'>You damage \the [src] with your sheer weight!</span>",
-		"<span class='italics'>You hear glass cracking!</span>")
-		health -= rand(1, 5)
-		healthcheck(MB.integratedpai, FALSE, "mulebot weight")
-	*/
-
 	return 1
 
 //Someone threw something at us, please advise
@@ -215,16 +157,16 @@
 		healthcheck(null, TRUE, "hitby obj")
 
 /turf/simulated/floor/glass/attack_hand(mob/living/user as mob)
-	if(M_HULK in user.mutations)
-		user.do_attack_animation(src, user)
-		user.say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!"))
-		user.visible_message("<span class='danger'>[user] smashes \the [src]!</span>")
-		health -= 25
-		healthcheck(user, TRUE, "attack_hand hulk")
-		user.delayNextAttack(8)
-
 	//Bang against the window
-	else if(usr.a_intent == I_HURT)
+	if(usr.a_intent == I_HURT)
+		if(M_HULK in user.mutations)
+			user.do_attack_animation(src, user)
+			user.say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!"))
+			user.visible_message("<span class='danger'>[user] smashes \the [src]!</span>")
+			health -= 25
+			healthcheck(user, TRUE, "attack_hand hulk")
+			user.delayNextAttack(8)
+			return
 		user.do_attack_animation(src, user)
 		user.delayNextAttack(10)
 		playsound(src, 'sound/effects/glassknock.ogg', 100, 1)
@@ -232,14 +174,6 @@
 		"<span class='warning'>You bang against \the [src]!</span>", \
 		"You hear banging.")
 		healthcheck(user, TRUE, "attack_hand hurt")
-
-	//Knock against it
-	else
-		user.delayNextAttack(10)
-		playsound(src, 'sound/effects/glassknock.ogg', 50, 1)
-		user.visible_message("<span class='notice'>[user] knocks on \the [src].</span>", \
-		"<span class='notice'>You knock on \the [src].</span>", \
-		"You hear knocking.")
 
 	return
 
@@ -372,7 +306,6 @@
 
 /turf/simulated/floor/glass/airless
 	icon_state = "floor"
-	name = "airless glass floor"
 	oxygen = 0.01
 	nitrogen = 0.01
 	temperature = TCMB
@@ -388,7 +321,6 @@
 
 /turf/simulated/floor/glass/plasma/airless
 	icon_state = "floor"
-	name = "airless plasma glass floor"
 	oxygen = 0.01
 	nitrogen = 0.01
 	temperature = TCMB

--- a/code/game/turfs/simulated/floor_glass.dm
+++ b/code/game/turfs/simulated/floor_glass.dm
@@ -260,6 +260,8 @@
 
 					getFromPool(sheettype, src, sheetamount)
 					src.ReplaceWithLattice()
+	if(ishuman(user) && user.a_intent != I_HURT)
+		return
 	unhandled_attackby(W, user)
 
 /turf/simulated/floor/glass/proc/unhandled_attackby(var/obj/item/W, var/mob/user)


### PR DESCRIPTION
<!-- [qol] [powercreep] -->
Doubled health for starters
Fat people and normal vehicles no longer crash through.
Removed some oldcode
Removed the crashing through code and messages
removed knocking so you don't waste time with the cooldown when you misclick
only hit the glass on red intent now
even hulks have manners when it comes to touching glass floors now

changelog later