### PR TITLE
glass tiles now cost 1 sheet and are faster to make

### DIFF
--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -159,7 +159,7 @@ var/list/datum/stack_recipe/rglass_recipes = list (
 	new/datum/stack_recipe("window", /obj/structure/window/reinforced/loose, 1, time = 10, on_floor = TRUE),
 	new/datum/stack_recipe("full window", /obj/structure/window/full/reinforced/loose, 2, time = 10, on_floor = TRUE),
 	new/datum/stack_recipe("windoor", /obj/structure/windoor_assembly/, 5, time = 10, start_unanchored = TRUE, on_floor = TRUE),
-	new/datum/stack_recipe("glass tile", /obj/item/stack/glass_tile/rglass, 5, time = 10, on_floor = TRUE),
+	new/datum/stack_recipe("glass tile", /obj/item/stack/glass_tile/rglass, 1, time = 2, on_floor = TRUE),
 	)
 
 var/list/datum/stack_recipe/plasmaglass_recipes = list (
@@ -171,5 +171,5 @@ var/list/datum/stack_recipe/plasmarglass_recipes = list (
 	new/datum/stack_recipe("window", /obj/structure/window/reinforced/plasma/loose, 1, time = 10, on_floor = TRUE),
 	new/datum/stack_recipe("full window", /obj/structure/window/full/reinforced/plasma/loose, 2, time = 10, on_floor = TRUE),
 	new/datum/stack_recipe("windoor", /obj/structure/windoor_assembly/plasma, 5, time = 10, start_unanchored = TRUE, on_floor = TRUE),
-	new/datum/stack_recipe("glass tile", /obj/item/stack/glass_tile/rglass/plasma, 5, time = 10, on_floor = TRUE),
+	new/datum/stack_recipe("glass tile", /obj/item/stack/glass_tile/rglass/plasma, 1, time = 2, on_floor = TRUE),
 	)


### PR DESCRIPTION
<!-- [qol] [powercreep] -->
I was going to cut all the other build timers down to 2 as well but that'd be more unatomic.
Why the fuck are they even that slow?

🆑 
 - tweak: Glass floor tiles now cost 1 sheet to make, and are faster to make.