### PR TITLE
Doubles borer chemical generation so it's one per second instead of one per two seconds

### DIFF
--- a/code/modules/mob/living/simple_animal/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer.dm
@@ -163,8 +163,7 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 			if(health < 20)
 				health += 0.5
 			if(chemicals < 250 && !channeling)
-				var/new_chemicals = chemicals + 2
-				chemicals = min(250, new_chemicals)
+				chemicals = min(250, chemicals + 2)
 			if(controlling)
 				if(prob(5))
 					host.adjustBrainLoss(rand(1,2))

--- a/code/modules/mob/living/simple_animal/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer.dm
@@ -163,7 +163,8 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 			if(health < 20)
 				health += 0.5
 			if(chemicals < 250 && !channeling)
-				chemicals++
+				var/new_chemicals = chemicals + 2
+				chemicals = min(250, new_chemicals)
 			if(controlling)
 				if(prob(5))
 					host.adjustBrainLoss(rand(1,2))


### PR DESCRIPTION
Chemical generation is attached to Byond ticks, which happen every 2 seconds and I blame whoever is responsible for the Byond tick.
:cl:
 * tweak: Doubled borer chemical generation, so it's now one chemical per second.