### PR TITLE
Insulated gloves crate requires engineering access

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1235,7 +1235,8 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/cell/high,
 					/obj/item/weapon/cell/high)
 	cost = 15
-	containertype = /obj/structure/closet/crate/engi
+	containertype = /obj/structure/closet/crate/secure/engisec
+	access = list(access_engine)
 	containername = "electrical maintenance crate"
 	group = "Engineering"
 


### PR DESCRIPTION
The station-wide greyshirt all access must end. Crate access requirements don't deter anyone anyway.

:cl:
 * rscdel: the electrical maintenance crate, which contains insulated gloves, now requires engineering access to open.