### PR TITLE
teleport/blink slip bug fix/announce faction objectives/generate faction objectives/add custom objective fix

### DIFF
--- a/code/datums/gamemode/objectives/objective.dm
+++ b/code/datums/gamemode/objectives/objective.dm
@@ -73,7 +73,8 @@
 		if (owner)
 			dat += "<a href='?src=\ref[M];obj_add=1;obj_holder=\ref[src]'>(add personal objective)</a> <br/>"
 		else if (faction)
+			dat += "<b> Manage faction: </b> <br/>"
 			dat += "<a href='?src=\ref[M];obj_add=1;obj_holder=\ref[src]'>(add faction objective)</a> <br/>"
 		dat += "<a href='?src=\ref[M];obj_gen=1;obj_holder=\ref[src];[faction?"obj_owner=\ref[faction]":"obj_owner=\ref[R]"]'>(generate objectives)</a> <br/>"
-		dat += "<a href='?src=\ref[M];obj_announce=1'>(annouce objectives)</a><br/>"
+		dat += "<a href='?src=\ref[M];obj_announce=1;[faction?"obj_owner=\ref[faction]":"obj_owner=\ref[R]"]'>(annouce objectives)</a><br/>"
 	return dat

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -4942,7 +4942,7 @@
 		var/new_obj = input("Select a new objective", "New Objective", null) as null|anything in available_objectives
 		var/obj_type = available_objectives[new_obj]
 
-		var/datum/objective/new_objective = new obj_type(null,FALSE)
+		var/datum/objective/new_objective = new obj_type(null,FALSE, usr)
 
 		if (new_objective.flags & FACTION_OBJECTIVE)
 			var/datum/faction/fac = input("To which faction shall we give this?", "Faction-wide objective", null) as null|anything in ticker.mode.factions
@@ -4995,6 +4995,27 @@
 		objective.force_success = !objective.force_success
 		check_antagonists()
 		log_admin("[usr.key]/([usr.name]) toggled [obj_holder.faction.ID] [objective.explanation_text] to [objective.force_success ? "completed" : "incomplete"]")
+
+	if (href_list["obj_announce"])
+		var/text = ""
+		var/owner = locate(href_list["obj_owner"])
+		if (istype(owner, /datum/faction))
+			var/datum/faction/F = owner
+			for (var/datum/role/member in F.members)
+				to_chat(member.antag.current, "<span class='notice'>Your faction objectives are:</span>")
+				if (member.faction.objective_holder.objectives.len)
+					text += "<b>Faction objectives are:</b><ul>"
+					var/obj_count = 1
+					for(var/datum/objective/O in member.faction.objective_holder.objectives)
+						text += "<b>Objective #[obj_count++]</b>: [O.explanation_text]<br>"
+					text += "</ul>"
+				to_chat(member.antag.current, text)
+						
+	if(href_list["obj_gen"])
+		var/owner = locate(href_list["obj_owner"])
+		var/datum/faction/F = owner
+		F.forgeObjectives()
+		check_antagonists()
 
 	if(href_list["wages_enabled"])
 		if(check_rights(R_ADMIN))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1832,6 +1832,8 @@ Thanks.
 	return on_foot() // Check if we have legs, gravity, etc. Checked by the children.
 
 /mob/living/proc/Slip(stun_amount, weaken_amount, slip_on_walking = 0, overlay_type, slip_with_magbooties = 0)
+	if (!src.can_slip)
+		return 0
 	stop_pulling()
 	Stun(stun_amount)
 	Knockdown(weaken_amount)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -4,6 +4,7 @@
 /mob
 	plane = MOB_PLANE
 	var/said_last_words = 0 // All mobs can now whisper as they die
+	var/can_slip = TRUE
 
 /mob/variable_edited(var_name, old_value, new_value)
 	.=..()
@@ -1929,7 +1930,10 @@ mob/proc/on_foot()
 		alpha = lowest_alpha
 
 /mob/proc/teleport_to(var/atom/A)
+	can_slip = FALSE
+	unlock_from()
 	forceMove(get_turf(A))
+	can_slip = TRUE
 
 /mob/proc/nuke_act() //Called when caught in a nuclear blast
 	return

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1931,7 +1931,6 @@ mob/proc/on_foot()
 
 /mob/proc/teleport_to(var/atom/A)
 	var/last_slip_value = can_slip
-	unlock_from()
 	can_slip = FALSE
 	forceMove(get_turf(A))
 	can_slip = last_slip_value

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1930,10 +1930,11 @@ mob/proc/on_foot()
 		alpha = lowest_alpha
 
 /mob/proc/teleport_to(var/atom/A)
-	can_slip = FALSE
+	var/last_slip_value = can_slip
 	unlock_from()
+	can_slip = FALSE
 	forceMove(get_turf(A))
-	can_slip = TRUE
+	can_slip = last_slip_value
 
 /mob/proc/nuke_act() //Called when caught in a nuclear blast
 	return

--- a/code/modules/spells/aoe_turf/blink.dm
+++ b/code/modules/spells/aoe_turf/blink.dm
@@ -22,9 +22,7 @@
 	var/turf/T = pick(targets)
 	var/turf/starting = get_turf(user)
 	if(T)
-		user.unlock_from()
-		user.forceMove(T)
-
+		user.teleport_to(T)
 		makeAnimation(T, starting)
 	return
 

--- a/code/modules/spells/aoe_turf/blink.dm
+++ b/code/modules/spells/aoe_turf/blink.dm
@@ -22,6 +22,7 @@
 	var/turf/T = pick(targets)
 	var/turf/starting = get_turf(user)
 	if(T)
+		unlock_from()
 		user.teleport_to(T)
 		makeAnimation(T, starting)
 	return

--- a/code/modules/spells/aoe_turf/blink.dm
+++ b/code/modules/spells/aoe_turf/blink.dm
@@ -22,7 +22,7 @@
 	var/turf/T = pick(targets)
 	var/turf/starting = get_turf(user)
 	if(T)
-		unlock_from()
+		user.unlock_from()
 		user.teleport_to(T)
 		makeAnimation(T, starting)
 	return


### PR DESCRIPTION
[hotfix]
closes #22708

:cl:
 * tweak: Added flag which prevents mob from slipping when teleporting
 * bugfix: fixed announce faction objectives/generate faction objectives/add custom objective in check antagonist window
 * bugfix: adding custom objective now works for factions as well
 * rscadd: text "Manage faction" to the factions managing section. If user clicks "announce" from the Manage factions window, everyone in the faction will get notified of the faction objective.
* tweak:  If user clicks generate for the faction managing section, then if the method forgeObjectives is overriden in the given faction, an objective is added to the faction. Also the window now refreshes when user clicks on generate.
