### PR TITLE
Mushmen pressure suits were called mushmen helmets

### DIFF
--- a/code/modules/clothing/spacesuits/alien.dm
+++ b/code/modules/clothing/spacesuits/alien.dm
@@ -209,7 +209,7 @@
 // -- Mushroom,traders --
 
 /obj/item/clothing/suit/space/vox/civ/mushmen
-	name = "mushmen helmet"
+	name = "mushmen pressure suit"
 	icon_state = "mushroom-pressure"
 	item_state = "mushroom-pressure"
 	desc = "It looks like a deformed vox pressure suit, fit for mushroom people."


### PR DESCRIPTION
[bugfix]

:cl:
 * bugfix: mushmen pressure suits are now called pressure suits rather than helmets