### PR TITLE
Changes a few parameters in dynamic distribution

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic.dm
+++ b/code/datums/gamemode/dynamic/dynamic.dm
@@ -10,8 +10,8 @@ var/list/threat_by_job = list(
 )
 
 // -- Distribution parameters chosen prior to roundstart --
-var/dynamic_curve_centre = 0
-var/dynamic_curve_width = 1.8
+var/dynamic_curve_centre = -3
+var/dynamic_curve_width = 1
 var/dynamic_chosen_mode = LORENTZ
 
 // -- Dynamic tweaks chosen prior to roundstart --


### PR DESCRIPTION
## Motivation

Rounds are too gunked. Even something like 50 threat is enough for a wizard + vampires + traitors.
This aims to make rounds more peaceful.

Keys numbers :
- 90% rounds between 10 and 60 threat
- 50% of rounds between 30 and 40. Enough for a single big antag.

Another way to look at it would be to just make it have less roundstart rulesets, with higher injection delays. It has the advantage of being more readable.

## Effective changes

This changes the two parameters in the distribution. The intent is to make rounds more peaceful.
Effectively, we have : 

![image](https://user-images.githubusercontent.com/31417754/57045276-5aac7f00-6c6d-11e9-800a-e0f409173250.png)

As a new distribution, compared to the old one.

![image](https://user-images.githubusercontent.com/31417754/57045368-a3fcce80-6c6d-11e9-9146-928f0346525a.png)

In short : 90% of the rounds will be between 10 and 60 threat.
Can be further tweaked if needed. Of course.
