### PR TITLE
Disables roundstart revs

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -473,8 +473,8 @@
 	required_candidates = 3
 	weight = 2
 	cost = 35
-	requirements = list(101,101,70,40,30,20,10,10,10,10)
-	high_population_requirement = 50
+	requirements = list(101,101,101,101,101,101,101,101,101,101) //won't roll naturally
+	high_population_requirement = 101
 	delay = 5 MINUTES
 	var/required_heads = 3
 	flags = HIGHLANDER_RULESET


### PR DESCRIPTION
[featureloss] [balance] [p\*wercreep] [all the bad tags]

Revs is a terrible gamemode and you can not convince me otherwise. You kill 5 out of 50-90 players and end the round with a ridicilously anticlimatic **"The revolution has won!"** boldtext in an average of 20 minutes. It's entirely possible for a crewmember to not even know there's a revolution going on before Rock suddenly starts cooking.

This disables roundstart revs by giving it a threat requirement too high to roll naturally. Presumably admins can still force it; I just copied what Extended was doing right above. Midround revs are untouched because those usually actually work somewhat alright and/or serve to end stagnant rounds.

:cl:
 * rscdel: Roundstart revolutionaries has been disabled.