### PR TITLE
Check antag menu fixes

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1621,6 +1621,18 @@ Game Mode config tags:
 	var/list/found_factions = find_active_factions_by_member(R, M)
 	return locate(fac_type) in found_factions
 
+/proc/find_unique_objectives(list/new_objectives, list/old_objectives)
+	var/list/uniques = list()
+	for (var/datum/objective/new_objective in new_objectives)
+		var/is_unique = TRUE
+		for (var/datum/objective/old_objective in old_objectives)
+			if (old_objective.name == new_objective.name)
+				is_unique = FALSE
+		if (is_unique)
+			uniques.Add(new_objective)
+	return uniques
+
+
 /proc/clients_in_moblist(var/list/mob/mobs)
 	. = list()
 	for(var/mob/M in mobs)

--- a/code/datums/gamemode/objectives/custom.dm
+++ b/code/datums/gamemode/objectives/custom.dm
@@ -3,10 +3,13 @@
 	explanation_text = "Just be yourself"
 	force_success = TRUE
 
-/datum/objective/custom/New(var/text,var/auto_target = TRUE, var/mob/user)
-	if (!user)
+//if not auto generated - means that this will be called as an explicit custom objective and will require user input
+/datum/objective/custom/New(var/text, var/auto_target = TRUE, var/is_auto_generated = TRUE, var/datum/faction/faction)
+	if (is_auto_generated)
 		return
-	var/txt = input(user,"What should be the text of this objective?","Custom objective", "Just be yourself")
+	if (faction)
+		src.faction = faction
+	var/txt = input(owner, "What should be the text of this objective?","Custom objective", "Just be yourself")
 	explanation_text = txt
 
 // Fullfilled as per admin wishes

--- a/code/datums/gamemode/objectives/custom.dm
+++ b/code/datums/gamemode/objectives/custom.dm
@@ -3,13 +3,13 @@
 	explanation_text = "Just be yourself"
 	force_success = TRUE
 
-//if not auto generated - means that this will be called as an explicit custom objective and will require user input
-/datum/objective/custom/New(var/text, var/auto_target = TRUE, var/is_auto_generated = TRUE, var/datum/faction/faction)
-	if (is_auto_generated)
+//if user passed - means that this will be called as an explicit custom objective and will require user input
+/datum/objective/custom/New(var/mob/user, var/datum/faction/faction)
+	if (!user)
 		return
 	if (faction)
 		src.faction = faction
-	var/txt = input(owner, "What should be the text of this objective?","Custom objective", "Just be yourself")
+	var/txt = input(user, "What should be the text of this objective?","Custom objective", "Just be yourself")
 	explanation_text = txt
 
 // Fullfilled as per admin wishes

--- a/code/datums/gamemode/objectives/objective.dm
+++ b/code/datums/gamemode/objectives/objective.dm
@@ -75,6 +75,6 @@
 		else if (faction)
 			dat += "<b> Manage faction: </b> <br/>"
 			dat += "<a href='?src=\ref[M];obj_add=1;obj_holder=\ref[src]'>(add faction objective)</a> <br/>"
-		dat += "<a href='?src=\ref[M];obj_gen=1;obj_holder=\ref[src];[faction?"obj_owner=\ref[faction]":"obj_owner=\ref[R]"]'>(generate objectives)</a> <br/>"
-		dat += "<a href='?src=\ref[M];obj_announce=1;[faction?"obj_owner=\ref[faction]":"obj_owner=\ref[R]"]'>(annouce objectives)</a><br/>"
+		dat += "<a href='?src=\ref[M];obj_gen=1;obj_holder=\ref[src];obj_owner=[faction?"\ref[faction]":"\ref[R]"]'>(generate objectives)</a> <br/>"
+		dat += "<a href='?src=\ref[M];obj_announce=1;obj_owner=[faction?"\ref[faction]":"\ref[R]"]'>(annouce objectives)</a><br/>"
 	return dat

--- a/code/datums/gamemode/objectives/objective.dm
+++ b/code/datums/gamemode/objectives/objective.dm
@@ -73,7 +73,8 @@
 		if (owner)
 			dat += "<a href='?src=\ref[M];obj_add=1;obj_holder=\ref[src]'>(add personal objective)</a> <br/>"
 		else if (faction)
+			dat += "<b> Manage faction: </b> <br/>"
 			dat += "<a href='?src=\ref[M];obj_add=1;obj_holder=\ref[src]'>(add faction objective)</a> <br/>"
 		dat += "<a href='?src=\ref[M];obj_gen=1;obj_holder=\ref[src];[faction?"obj_owner=\ref[faction]":"obj_owner=\ref[R]"]'>(generate objectives)</a> <br/>"
-		dat += "<a href='?src=\ref[M];obj_announce=1'>(annouce objectives)</a><br/>"
+		dat += "<a href='?src=\ref[M];obj_announce=1;[faction?"obj_owner=\ref[faction]":"obj_owner=\ref[R]"]'>(annouce objectives)</a><br/>"
 	return dat

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -304,7 +304,7 @@
 			return
 		var/obj_type = available_objectives[new_obj]
 
-		var/datum/objective/new_objective = new obj_type(null,FALSE, usr)
+		var/datum/objective/new_objective = new obj_type(null, FALSE, FALSE, obj_holder.faction)
 
 		if (new_objective.flags & FACTION_OBJECTIVE)
 			var/datum/faction/fac = input("To which faction shall we give this?", "Faction-wide objective", null) as null|anything in ticker.mode.factions
@@ -366,6 +366,8 @@
 		else if(istype(owner, /datum/faction))
 			var/datum/faction/F = owner
 			F.forgeObjectives()
+			for (var/datum/objective/objective in F.objective_holder.objectives)
+				log_admin("[usr.key]/([usr.name]) gave \the [F.ID] the objective: [objective.explanation_text]")
 
 	else if(href_list["role"]) //Something role specific
 		var/datum/role/R = locate(href_list["role"])

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -331,7 +331,11 @@
 			obj_holder.AddObjective(new_objective, src)
 			message_admins("[usr.key]/([usr.name]) gave [key]/([name]) the objective: [new_objective.explanation_text]")
 			log_admin("[usr.key]/([usr.name]) gave [key]/([name]) the objective: [new_objective.explanation_text]")
-		else if (obj_holder.faction || (istype(new_objective, /datum/objective/custom) && new_objective.faction)) //if its an explicit faction obj OR a custom objective with a faction modifier
+		else if (new_objective.faction && istype(new_objective, /datum/objective/custom)) //is it a custom objective with a faction modifier?
+			new_objective.faction.AppendObjective(new_objective)
+			message_admins("[usr.key]/([usr.name]) gave \the [new_objective.faction.ID] the objective: [new_objective.explanation_text]")
+			log_admin("[usr.key]/([usr.name]) gave \the [new_objective.faction.ID] the objective: [new_objective.explanation_text]")
+		else if (obj_holder.faction) //or is it just an explicit faction obj? 
 			obj_holder.faction.AppendObjective(new_objective)
 			message_admins("[usr.key]/([usr.name]) gave \the [obj_holder.faction.ID] the objective: [new_objective.explanation_text]")
 			log_admin("[usr.key]/([usr.name]) gave \the [obj_holder.faction.ID] the objective: [new_objective.explanation_text]")
@@ -370,16 +374,22 @@
 			var/list/prev_objectives = R.objectives.objectives.Copy()
 			R.ForgeObjectives()
 			var/list/unique_objectives_role = find_unique_objectives(R.objectives.objectives, prev_objectives)
-			for (var/datum/objective/objective in unique_objectives_role)
-				log_admin("[usr.key]/([usr.name]) gave [key]/([name]) the objective: [objective.explanation_text]")
+			if (!unique_objectives_role.len)
+				alert(usr, "No new objectives generated.", "Alert", "OK")
+			else
+				for (var/datum/objective/objective in unique_objectives_role)
+					log_admin("[usr.key]/([usr.name]) gave [key]/([name]) the objective: [objective.explanation_text]")
 		else if(istype(owner, /datum/faction))
 			var/datum/faction/F = owner
 			var/list/prev_objectives = F.GetObjectives().Copy()
 			F.forgeObjectives()
 			var/list/unique_objectives_faction = find_unique_objectives(F.GetObjectives(), prev_objectives)
-			for (var/datum/objective/objective in unique_objectives_faction)
-				message_admins("[usr.key]/([usr.name]) gave \the [F.ID] the objective: [objective.explanation_text]")
-				log_admin("[usr.key]/([usr.name]) gave \the [F.ID] the objective: [objective.explanation_text]")
+			if (!unique_objectives_faction.len)
+				alert(usr, "No new objectives generated.", "Alert", "OK")
+			else 
+				for (var/datum/objective/objective in unique_objectives_faction)
+					message_admins("[usr.key]/([usr.name]) gave \the [F.ID] the objective: [objective.explanation_text]")
+					log_admin("[usr.key]/([usr.name]) gave \the [F.ID] the objective: [objective.explanation_text]")
 
 	else if(href_list["role"]) //Something role specific
 		var/datum/role/R = locate(href_list["role"])

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -4942,7 +4942,7 @@
 		var/new_obj = input("Select a new objective", "New Objective", null) as null|anything in available_objectives
 		var/obj_type = available_objectives[new_obj]
 
-		var/datum/objective/new_objective = new obj_type(null,FALSE)
+		var/datum/objective/new_objective = new obj_type(null, FALSE, FALSE, obj_holder.faction)
 
 		if (new_objective.flags & FACTION_OBJECTIVE)
 			var/datum/faction/fac = input("To which faction shall we give this?", "Faction-wide objective", null) as null|anything in ticker.mode.factions
@@ -4995,6 +4995,31 @@
 		objective.force_success = !objective.force_success
 		check_antagonists()
 		log_admin("[usr.key]/([usr.name]) toggled [obj_holder.faction.ID] [objective.explanation_text] to [objective.force_success ? "completed" : "incomplete"]")
+
+	if (href_list["obj_announce"])
+		var/text = ""
+		var/owner = locate(href_list["obj_owner"])
+		if (istype(owner, /datum/faction))
+			var/datum/faction/F = owner
+			for (var/datum/role/member in F.members)
+				to_chat(member.antag.current, "<span class='notice'>Your faction objectives are:</span>")
+				if (member.faction.objective_holder.objectives.len)
+					text += "<b>Faction objectives are:</b><ul>"
+					var/obj_count = 1
+					for(var/datum/objective/O in member.faction.objective_holder.objectives)
+						text += "<b>Objective #[obj_count++]</b>: [O.explanation_text]<br>"
+					text += "</ul>"
+				to_chat(member.antag.current, text)
+
+
+	if(href_list["obj_gen"])
+		var/owner = locate(href_list["obj_owner"])
+		var/datum/faction/F = owner
+		F.forgeObjectives()
+		for (var/datum/objective/objective in F.objective_holder.objectives)
+			// message_admins("[key_name_admin(usr)] gave \the [F.ID] the objective: [objective.explanation_text]")
+			log_admin("[key_name(usr)] gave \the [F.ID] the objective: [objective.explanation_text]")
+		check_antagonists()	
 
 	if(href_list["wages_enabled"])
 		if(check_rights(R_ADMIN))

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -4968,7 +4968,11 @@
 			alert("Couldn't set-up a proper target.", "New Objective")
 			return
 
-		if (obj_holder.faction || (istype(new_objective, /datum/objective/custom) && new_objective.faction)) //if its an explicit faction obj OR a custom objective with a faction modifier
+		if (new_objective.faction && istype(new_objective, /datum/objective/custom)) //is it a custom objective with a faction modifier?
+			new_objective.faction.AppendObjective(new_objective)
+			message_admins("[key_name_admin(usr)] gave \the [new_objective.faction.ID] the objective: [new_objective.explanation_text]")
+			log_admin("[key_name(usr)] gave \the [new_objective.faction.ID] the objective: [new_objective.explanation_text]")
+		else if (obj_holder.faction) //or is it just an explicit faction obj? 
 			obj_holder.faction.AppendObjective(new_objective)
 			message_admins("[key_name_admin(usr)] gave \the [obj_holder.faction.ID] the objective: [new_objective.explanation_text]")
 			log_admin("[key_name(usr)] gave \the [obj_holder.faction.ID] the objective: [new_objective.explanation_text]")
@@ -5021,9 +5025,12 @@
 		var/list/prev_objectives = F.GetObjectives().Copy()
 		F.forgeObjectives()
 		var/list/unique_objectives = find_unique_objectives(F.GetObjectives(), prev_objectives)
-		for (var/datum/objective/objective in unique_objectives)
-			message_admins("[key_name_admin(usr)] gave \the [F.ID] the objective: [objective.explanation_text]")
-			log_admin("[key_name(usr)] gave \the [F.ID] the objective: [objective.explanation_text]")
+		if (!unique_objectives.len)
+			alert(usr, "No new objectives generated.", "", "OK")
+		else 
+			for (var/datum/objective/objective in unique_objectives)
+				message_admins("[key_name_admin(usr)] gave \the [F.ID] the objective: [objective.explanation_text]")
+				log_admin("[key_name(usr)] gave \the [F.ID] the objective: [objective.explanation_text]")
 		check_antagonists()	
 
 	if(href_list["wages_enabled"])


### PR DESCRIPTION
[bugfix] [qol] [logging] [featurerequest]

Made a lot of fixes to the check antags and player role panels because most of the stuff like announcing and generating objectives and custom objectives didn't seem to work. Added a neat method to announce/log only the distinct objectives after generating factions/role objectives method has been called. If generate objectives yields no new objectives an alert pops up. Was not sure where to use log_admin and message_admins so I kinda followed the logic in the classes respectively:
If it's a faction related thing, aside from logging, it also messages the admins, if it's a player role change(non-faction related) it only logs.

closes #22708 

:cl:

* bugfix: Adding custom faction objectives now works for factions as well
* bugfix: Announcing custom faction objectives from check antags panel announces the faction objectives to the faction members, announcing objectives from the player panel announces the objectives only to the player
* rscadd: Added logging/admin messages when user is given roles and/or is given faction objectives
* rscadd: Added "manage factions" label to distinct the faction objectives edit section from the player role section in the Player Role panel
* tweak: Generating role objectives logs the generated objective/objectives in the server log, generating faction objectives logs the new objectives and messages the admins about it.
* rscadd: If no new objectives are generated an alert shows up notifying the user.
* bugfix: Generating objectives/deleting objectives from the check antags panel now refreshes the window, same applies for player role panel when adding faction objective from there