### PR TITLE
Adds regular and security biosuit crates.

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1025,9 +1025,9 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/clothing/head/bio_hood/security,
 					/obj/item/clothing/suit/bio_suit/security,
 					/obj/item/clothing/suit/bio_suit/security,
-					/obj/item/clothing/suit/bio_suit/security,
+					/obj/item/clothing/suit/bio_suit/security)
 	cost = 35
-	containertype = /obj/structure/closet/crate/secure/basic
+	containertype = /obj/structure/closet/crate/secure/gear
 	containername = "Security Biosuits"
 	group = "Security"
 
@@ -1733,7 +1733,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/clothing/head/bio_hood,
 					/obj/item/clothing/suit/bio_suit,
 					/obj/item/clothing/suit/bio_suit,
-					/obj/item/clothing/suit/bio_suit,
+					/obj/item/clothing/suit/bio_suit)
 	cost = 35
 	containertype = /obj/structure/closet/crate/medical
 	containername = "Regular Biosuits"

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1018,6 +1018,19 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	access = list(access_security)
 	group = "Security"
 
+/datum/supply_packs/secbiosuits
+	name = "Biohazard Emergency Biosuits"
+	contains = list(/obj/item/clothing/head/bio_hood/security,
+					/obj/item/clothing/head/bio_hood/security,
+					/obj/item/clothing/head/bio_hood/security,
+					/obj/item/clothing/suit/bio_suit/security,
+					/obj/item/clothing/suit/bio_suit/security,
+					/obj/item/clothing/suit/bio_suit/security,
+	cost = 35
+	containertype = /obj/structure/closet/crate/secure/basic
+	containername = "Security Biosuits"
+	group = "Security"
+
 //////HOSPITALITY//////
 
 /datum/supply_packs/food
@@ -1711,6 +1724,19 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 30
 	containertype = /obj/structure/largecrate/skele_stand
 	containername = "hanging skeleton model crate"
+	group = "Medical"
+
+/datum/supply_packs/biosuits
+	name = "Biosuits"
+	contains = list(/obj/item/clothing/head/bio_hood,
+					/obj/item/clothing/head/bio_hood,
+					/obj/item/clothing/head/bio_hood,
+					/obj/item/clothing/suit/bio_suit,
+					/obj/item/clothing/suit/bio_suit,
+					/obj/item/clothing/suit/bio_suit,
+	cost = 35
+	containertype = /obj/structure/closet/crate/medical
+	containername = "Regular Biosuits"
 	group = "Medical"
 
 //////SCIENCE//////

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1026,7 +1026,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/clothing/suit/bio_suit/security,
 					/obj/item/clothing/suit/bio_suit/security,
 					/obj/item/clothing/suit/bio_suit/security)
-	cost = 35
+	cost = 85
 	containertype = /obj/structure/closet/crate/secure/gear
 	containername = "Security Biosuits"
 	group = "Security"
@@ -1734,7 +1734,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/clothing/suit/bio_suit,
 					/obj/item/clothing/suit/bio_suit,
 					/obj/item/clothing/suit/bio_suit)
-	cost = 35
+	cost = 85
 	containertype = /obj/structure/closet/crate/medical
 	containername = "Regular Biosuits"
 	group = "Medical"


### PR DESCRIPTION
Not sure if the price is cheap or not for something that can let you walk in a plasma flood as long as you have internals and someone hasn't set the room on fire. Both regular and security biosuits are the same which means they don't have bullet/fire/laser protection.

:cl:

- You can now order regular and security biosuits from cargo.