### PR TITLE
Borers can infest through armour/hardsuits

### DIFF
--- a/code/modules/mob/living/simple_animal/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer.dm
@@ -866,10 +866,6 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 		to_chat(src, "This host's [limb_to_name(region)] is already infested!")
 		return
 
-	if(limb_covered(M, region))
-		to_chat(src, "You cannot get through the protective gear on that host's [limb_to_name(region)].")
-		return
-
 	switch(region)
 		if(LIMB_HEAD)
 			to_chat(src, "You slither up [M] and begin probing at their ear canal...")


### PR DESCRIPTION
[tweak]

@HarseTheef [wrote:](https://github.com/vgstation-coders/vgstation13/pull/22698#issuecomment-488179072)
>Honestly, while you are at it, you should remove the need for a host to remove stuff for a borer to slip on in. The autistic "why aren't you getting in yet?" dance wastes a lot of time too and doesn't really have a good reason to exist. The big wait times and stuff like this are a relic of when they were antagonists.

I thought this was a good idea, so here it is.

:cl:
 * tweak: borers can now infest players through armour and hardsuits.