### PR TITLE
really nasty bug

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -565,6 +565,7 @@ Thanks.
 	ear_deaf = 0
 	ear_damage = 0
 	say_mute = 0
+	said_last_words = 0
 	mutations &= ~M_HUSK
 	if(!reagents)
 		create_reagents(1000)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -232,7 +232,7 @@ var/list/department_radio_keys = list(
 		for(var/T in syndicate_code_response)
 			rendered_message = replacetext(rendered_message, T, "<i style='color: red;'>[T]</i>")
 
-	show_message(rendered_message, type, deaf_message, deaf_type)
+	show_message(rendered_message, type, deaf_message, deaf_type, src)
 	return rendered_message
 
 /mob/living/proc/hear_radio_only()
@@ -542,12 +542,10 @@ var/list/department_radio_keys = list(
 		said_last_words = src.stat
 	treat_speech(speech)
 
-
 	var/listeners = get_hearers_in_view(1, src) | observers
 	var/eavesdroppers = get_hearers_in_view(2, src) - listeners
 	var/watchers = hearers(5, src) - listeners - eavesdroppers
 	var/rendered = render_speech(speech)
-
 	for (var/atom/movable/listener in listeners)
 		listener.Hear(speech, rendered)
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -371,9 +371,7 @@
 	else
 		to_chat(src, msg)
 
-/mob/proc/show_message(msg, type, alt, alt_type)//Message, type of message (1=visible or 2=hearable), alternative message, alt message type (1=if blind or 2=if deaf)
-
-
+/mob/proc/show_message(msg, type, alt, alt_type, var/mob/speaker)//Message, type of message (1=visible or 2=hearable), alternative message, alt message type (1=if blind or 2=if deaf), and optionally the speaker
 	//Because the person who made this is a fucking idiot, let's clarify. 1 is sight-related messages (aka emotes in general), 2 is hearing-related (aka HEY DUMBFUCK I'M TALKING TO YOU)
 
 	if(!client) //We dun goof
@@ -408,8 +406,10 @@
 
 				return //And we're good
 		else //This is not an emote
-			to_chat(src, "<span class='notice'>You can almost hear someone talking.</span>")//The sweet silence of death
-
+			if (speaker && (src.ckey == speaker.ckey) && speaker.isincrit() && speaker.said_last_words) //if user is in crit, if user has said_last_words, and whisperer of the final words IS the user himself)
+				to_chat(src, msg)//Send it
+			else
+				to_chat(src, "<span class='notice'>You can almost hear someone talking.</span>")//The sweet silence of death
 			return //All we ever needed to hear
 	else //We're fine
 		to_chat(src, msg)//Send it


### PR DESCRIPTION
[bugfix][featureloss][oversight]

closes #22607 😌👌

The way whisper works - is that it sends all the nearby listeners(including the player) the message. The nasty bug - was that all listeners(including the user) were notified of the message, but the check in `show_message` thought the user was unconscious and didn't show him the message. The solution was to pass an additional argument to the `show_message` method - the speaker - to assert if the listener is the same as the person sending the message(checking ckey) and if he is in crit and has said his dying words. This way we are sure that the person sending the final whisper(to the list of listeners) will see his message even if he is unconscious AND that other people who are in unconscious/incrit/have said last words won't see it due to the ckey check. Also rejuvenating the user with the admin command resets the `said_last_words` flag as this was bugged before.
:cl:
 * bugfix: The user can hear his last whisper words before dying, instead of getting the "You can almost hear someone talking." message.
 * bugfix: Rejuvenating from the admin panel now resets the ability to whisper last words again. 