### PR TITLE
Disorient spell now has an empowered variant

### DIFF
--- a/code/modules/spells/targeted/disorient.dm
+++ b/code/modules/spells/targeted/disorient.dm
@@ -21,11 +21,10 @@
 	spell_flags = WAIT_FOR_CLICK
 
 	hud_state = "wiz_disorient"
-	var/empowered = 0
 
 /spell/targeted/disorient/cast(var/list/targets)
 	..()
-	if(empowered)
+	if(spell_levels[Sp_POWER] >= 1)
 		for(var/mob/target in targets)
 			var/angle = pick(90, 180, 270)
 			var/client/C = target.client
@@ -37,7 +36,6 @@
 
 /spell/targeted/disorient/empower_spell()
 	spell_levels[Sp_POWER]++
-	empowered++
 	name = "Empowered Disorient"
 	desc = "This spell will very thoroughly disorient a target for 30 seconds."
 	return "You have upgraded the spell to turn the target's perception in another direction, further debilitating them."

--- a/code/modules/spells/targeted/disorient.dm
+++ b/code/modules/spells/targeted/disorient.dm
@@ -44,7 +44,7 @@
 	desc = "This spell will very thoroughly disorient a target for 30 seconds."
 	return "You have upgraded the spell to turn the target's perception in another direction, further debilitating them."
 
-/spell/targeted/buttbots_revenge/get_upgrade_info(upgrade_type, level)
+/spell/targeted/buttbots_revenge/get_upgrade_info(upgrade_type, level) //I don't know what this does, and it doesn't seem to do anything, just copypasted
 	if(upgrade_type == Sp_POWER)
 		return "Gives an additional effect to the spell that turns the target's view of reality in a direction, debilitating them a lot."
 	return ..()

--- a/code/modules/spells/targeted/disorient.dm
+++ b/code/modules/spells/targeted/disorient.dm
@@ -1,3 +1,5 @@
+//Note, the spell could permanently ruin someone's viewport if combined with the hallucination that turns client direction. Fixed by reconnecting.
+
 /spell/targeted/disorient
 	name = "Disorient"
 	desc = "This spell temporarily disorients a target."
@@ -9,6 +11,7 @@
 	invocation = "DII ODA BAJI"
 	invocation_type = SpI_WHISPER
 	message = "<span class='danger'>You suddenly feel completely overwhelmed!<span>"
+	level_max = list(Sp_TOTAL = 5, Sp_SPEED = 4, Sp_POWER = 1)
 
 	max_targets = 1
 
@@ -20,3 +23,28 @@
 	spell_flags = WAIT_FOR_CLICK
 
 	hud_state = "wiz_disorient"
+	var/empowered = 0
+
+/spell/targeted/disorient/cast(var/list/targets)
+	..()
+	if(empowered)
+		for(var/mob/target in targets)
+			var/angle = pick(90, 180, 270)
+			var/client/C = target.client
+			if(C)
+				C.dir = turn(C.dir, angle)
+				spawn(30 SECONDS) //This will confuse someone for a while and end up very annoying
+				if(C)
+					C.dir = turn(C.dir, -angle)
+
+/spell/targeted/disorient/empower_spell()
+	spell_levels[Sp_POWER]++
+	empowered++
+	name = "Empowered Disorient"
+	desc = "This spell will very thoroughly disorient a target for 30 seconds."
+	return "You have upgraded the spell to turn the target's perception in another direction, further debilitating them."
+
+/spell/targeted/buttbots_revenge/get_upgrade_info(upgrade_type, level)
+	if(upgrade_type == Sp_POWER)
+		return "Gives an additional effect to the spell that turns the target's view of reality in a direction, debilitating them a lot."
+	return ..()

--- a/code/modules/spells/targeted/disorient.dm
+++ b/code/modules/spells/targeted/disorient.dm
@@ -32,8 +32,8 @@
 			if(C)
 				C.dir = turn(C.dir, angle)
 				spawn(30 SECONDS) //This will confuse someone for a while and end up very annoying
-				if(C)
-					C.dir = turn(C.dir, -angle)
+					if(C)
+						C.dir = turn(C.dir, -angle)
 
 /spell/targeted/disorient/empower_spell()
 	spell_levels[Sp_POWER]++

--- a/code/modules/spells/targeted/disorient.dm
+++ b/code/modules/spells/targeted/disorient.dm
@@ -1,5 +1,3 @@
-//Note, the spell could permanently ruin someone's viewport if combined with the hallucination that turns client direction. Fixed by reconnecting.
-
 /spell/targeted/disorient
 	name = "Disorient"
 	desc = "This spell temporarily disorients a target."
@@ -44,7 +42,7 @@
 	desc = "This spell will very thoroughly disorient a target for 30 seconds."
 	return "You have upgraded the spell to turn the target's perception in another direction, further debilitating them."
 
-/spell/targeted/buttbots_revenge/get_upgrade_info(upgrade_type, level) //I don't know what this does, and it doesn't seem to do anything, just copypasted
+/spell/targeted/disorient/get_upgrade_info(upgrade_type, level)
 	if(upgrade_type == Sp_POWER)
 		return "Gives an additional effect to the spell that turns the target's view of reality in a direction, debilitating them a lot."
 	return ..()


### PR DESCRIPTION
It flips the target's viewport like that one hallucination, goes away after 30 seconds (compared to the 3 minutes of stuttering and drunk-walking and dizziness the spell gives by default)
Why? It's funny (for the wizard) and it's still harmless

:cl:
 * tweak: The Disorient spell now has an empowered variant that flips the target's view of reality for 30 seconds, for further debilitation.