### PR TITLE
Ion Rifles from R&D

### DIFF
--- a/code/modules/research/designs/weapons.dm
+++ b/code/modules/research/designs/weapons.dm
@@ -94,6 +94,18 @@
 	locked = TRUE
 	req_lock_access = list(access_armory, access_weapons)
 
+/datum/design/ionrifle
+	name = "Ion Rifle"
+	desc = "A man portable anti-armor weapon designed to disable mechanical threats."
+	id = "ionrifle"
+	req_tech = list(Tc_COMBAT = 4, Tc_MATERIALS = 3, Tc_POWERSTORAGE = 3, Tc_MAGNETS = 2)
+	build_type = PROTOLATHE
+	materials = list(MAT_IRON = 10000, MAT_GLASS = 1000, MAT_DIAMOND = 2000)
+	category = "Weapons"
+	build_path = /obj/item/weapon/gun/energy/ionrifle
+	locked = TRUE
+	req_lock_access = list(access_armory, access_weapons)
+
 /datum/design/xcomar
 	name = "Assault Rifle"
 	desc = "An Assault Rifle."

--- a/code/modules/research/designs/weapons.dm
+++ b/code/modules/research/designs/weapons.dm
@@ -98,9 +98,9 @@
 	name = "Ion Rifle"
 	desc = "A man portable anti-armor weapon designed to disable mechanical threats."
 	id = "ionrifle"
-	req_tech = list(Tc_COMBAT = 4, Tc_MATERIALS = 3, Tc_POWERSTORAGE = 3, Tc_MAGNETS = 2)
+	req_tech = list(Tc_COMBAT = 4, Tc_MATERIALS = 3, Tc_POWERSTORAGE = 3, Tc_MAGNETS = 5)
 	build_type = PROTOLATHE
-	materials = list(MAT_IRON = 10000, MAT_GLASS = 1000, MAT_DIAMOND = 2000)
+	materials = list(MAT_IRON = 10000, MAT_GLASS = 1000, MAT_DIAMOND = 1000, MAT_URANIUM = 8000)
 	category = "Weapons"
 	build_path = /obj/item/weapon/gun/energy/ionrifle
 	locked = TRUE


### PR DESCRIPTION
Ion rifles can't be acquired from anywhere currently. This adds them to R&D, which is where you also get laser rifles (so I think it makes more sense than cargo). They require the same materials as laser rifles (iron, glass and diamonds) and similar research, with some extra electromagnetic research—but it's not like research requirements really matter considering how easy they are to max out. They come in a locked box, like all other guns.

:cl:
 * rscadd: Ion rifles can now be created in R&D with similar material and research requirements as laser rifles, but with added electromagnetics research. As with other guns, they come in a locked box.