### PR TITLE
Cult EMP rune buff

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
@@ -2387,7 +2387,7 @@ var/list/bloodcult_exitportals = list()
 	word1 = /datum/cultword/destroy
 	word2 = /datum/cultword/see
 	word3 = /datum/cultword/technology
-	page = "This rune triggers a short-range EMP that messes with electronic machinery, devices, and silicons. Affects things up to 3 tiles away, but only adjacent targets will take the full force of the EMP. Best used as a talisman. "
+	page = "This rune triggers a series of short-range EMPs that messes with electronic machinery, devices, and silicons. Affects things up to 3 tiles away, but only adjacent targets will take the full force of the EMP. Best used as a talisman. "
 
 /datum/rune_spell/pulse/cast()
 	var/turf/T = get_turf(spell_holder)

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
@@ -2393,7 +2393,10 @@ var/list/bloodcult_exitportals = list()
 	var/turf/T = get_turf(spell_holder)
 	playsound(T, 'sound/items/Welder2.ogg', 25, 1)
 	T.hotspot_expose(700,125,surfaces=1)
-	empulse(T, 1, 3)
+	spawn(0)
+		for(var/i = 0; i < 3; i++)
+			empulse(T, 1, 3)
+			sleep(20)
 	qdel(spell_holder)
 
 //RUNE XIX


### PR DESCRIPTION
It was suggested in #22576 that making the EMP talisman stronger would be preferable to letting cult stun mechs. I don't really think cult *needs* to be stronger against mechs, but I do think cult being able to stun mechs is a little silly, so here's an alternative solution.

The EMP talisman now does three EMPs in one use, spaced two seconds apart. There's room for tweaking here: it could eg. only be two EMPs, or the delay could be three seconds. Let me know what you think. As a reminder, cult EMPs have a heavy range of 1 tile (this is where the EMP deals full damage) and a light range of 3 tiles (this is where the EMP deals half damage).

The reason I went with a series of EMPs was that there's not really a good way to make a single EMP stronger, things tend to be somewhat balanced against ion rifles when it comes to EMPs (eg. a magdump of 10 shots from an ion rifle is enough to take out a Durand -- stun talismans currently are as strong as a single ion rifle shot, meaning it will take about 10 of them too), and this way there's some counterplay because eg. silicons may be able to avoid the second and third pulse if they run away, while slower mechs will have a more difficult time.

:cl:
 * tweak: Cult EMP rune (Pulse) now creates a series of 3 EMPs spaced two seconds apart.