### PR TITLE
Removed new statelaws from pAIs

### DIFF
--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -75,6 +75,7 @@
 	add_language(LANGUAGE_TRADEBAND, 1)
 	add_language(LANGUAGE_GUTTER, 1)
 
+	src.verbs.Remove(/mob/living/silicon/verb/state_laws)
 	..()
 
 /mob/living/silicon/pai/Login()


### PR DESCRIPTION
Forgot to disable the verb for these guys. They use nontraditional laws and would cause runtimes with it.
