### PR TITLE
Makes catbeast sandals leave catbeast footprints

### DIFF
--- a/code/datums/gamemode/role/catbeast.dm
+++ b/code/datums/gamemode/role/catbeast.dm
@@ -49,6 +49,7 @@ var/list/catbeast_names = list("Meowth","Fluffy","Subject 246","Experiment 35a",
 /obj/item/clothing/shoes/sandal/catbeast
 	desc = "Strange sandals designed with claws in mind. They look uncomfortable if you're not a cat."
 	species_restricted = list("Tajaran")
+	footprint_type = /obj/effect/decal/cleanable/blood/tracks/footprints/catbeast
 
 /datum/role/catbeast/ForgeObjectives()
 	AppendObjective(/datum/objective/catbeast/survive5)


### PR DESCRIPTION
Catbeast footprints were primarily added to aid in hunting down catbeasts, helped by the fact they couldn't wear shoes. Now there are shoes they can wear, and most catbeasts that appear on the station spawn with them, so that doesn't work. This changes that.
I attempted to run an impromptu vote in deadchat but only one person responded so vote here I guess

🆑 
* tweak: Catbeast sandals now leave catbeast footprints.