### PR TITLE
Reset selected laws in State Laws when laws change

### DIFF
--- a/code/modules/mob/living/silicon/state_laws.dm
+++ b/code/modules/mob/living/silicon/state_laws.dm
@@ -121,10 +121,11 @@
 			state_laws_ui.has_linked_ai = TRUE
 		else
 			state_laws_ui.has_linked_ai = FALSE
+
 	var/hash = state_laws_ui.compute_hash(laws)
 	if(state_laws_ui.laws_hash != hash) //if our laws changed since last check
 		state_laws_ui.selected_laws = null
-		state_laws_ui.laws_hash = hash
+
 	if(state_laws_ui.selected_laws == null)
 		var/datum/ai_laws/temp_laws = laws //duplicate the laws so we don't edit them
 		if(isrobot(user) && state_laws_ui.has_linked_ai && state_laws_ui.use_laws_from_ai)
@@ -145,6 +146,7 @@
 			tmplist[++tmplist.len] = list("text" = "[lawnum]. [law]", "enabled" = TRUE)
 			lawnum++
 		state_laws_ui.selected_laws = tmplist
+		state_laws_ui.laws_hash = hash //update hash to match the reset laws
 
 	if(state_laws_ui.freeform == null)
 		state_laws_ui.freeform = FALSE

--- a/code/modules/mob/living/silicon/state_laws.dm
+++ b/code/modules/mob/living/silicon/state_laws.dm
@@ -132,6 +132,7 @@
 			var/mob/living/silicon/robot/R = user
 			temp_laws = R.connected_ai.laws
 			state_laws_ui.use_laws_from_ai = FALSE
+			hash = state_laws_ui.compute_hash(temp_laws) //use the AI's laws' hash instead
 		var/list/tmplist = new/list()
 		if(temp_laws.zeroth)
 			tmplist[++tmplist.len] = list("text" = "0. [temp_laws.zeroth]", "enabled" = TRUE) //oh dear this syntax


### PR DESCRIPTION
[bugfix]

If your laws change, the selected laws in the UI will stay the same. This can lead to accidentally stating your old laws.

The solution I went with here is a bit unorthodox: I hash the laws (using MD5, the only hashing algorithm byond seems to offer) when the defaults are formed, then compare the stored hash to that of the current laws when the UI updates. This is because there's a bazillion different ways the laws can change, and catching all of these and signalling to the UI that the laws need to be reset would lead to kinda messy code spread across many different places.

I thought about adding a hash var to `/datum/ai_laws` that gets updated whenever the law datum gets updated, but that would probably just lead to even more headscratching on some future coder's part than this. I also thought about storing a full deep copy of the laws datum, but I think that would be more expensive than just storing a hash, both CPU and memory-wise. Though obviously given the size of the data in question the difference will probably be imperceptible.

:cl:
 * bugfix: the State Laws interface now resets your laws when they are changed (by eg. someone uploading new laws)