### PR TITLE
Makes supermatter chunks/splinters scanneable.

### DIFF
--- a/code/modules/research/designs/anomaly.dm
+++ b/code/modules/research/designs/anomaly.dm
@@ -48,6 +48,16 @@
 	category = "Anomaly"
 	build_path = /obj/item/clothing/accessory/glowstick/phazon
 
+/datum/design/supermatter_splinter //You shouldn't be able to normally print this from the protolathe
+	name = "Supermatter Splinter"
+	desc = "A superdense chunk of supermatter. It hums ever so slightly, with swirls of semi-absorbed matter orbiting it. <b>It doesn't look very safe to touch.</b>"
+	id = "supermatter_splinter"
+	req_tech = list(Tc_MATERIALS = 10, Tc_ANOMALY = 7, Tc_ENGINEERING =8) //Haha good luck getting these
+	build_type = PROTOLATHE
+	materials = list(MAT_PLASMA=40000, MAT_PHAZON=6000, MAT_DIAMOND=10000) //20 plasma sheets, 3 phazon sheets, 5 diamond sheets
+	category = "Anomaly"
+	build_path = /obj/item/supermatter_splinter
+
 /*
 /datum/design/ano_scanner
 	name = "Alden-Saraspova Counter"

--- a/code/modules/research/xenoarchaeology/finds/finds_splinter.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds_splinter.dm
@@ -12,6 +12,8 @@
 	name = "supermatter splinter"
 	desc = "A superdense chunk of supermatter. It hums ever so slightly, with swirls of semi-absorbed matter orbiting it. <b>It doesn't look very safe to touch.</b>"
 	icon = 'icons/obj/shards.dmi'
+	origin_tech = Tc_ENGINEERING + "=7;" + Tc_MATERIALS + "=10;" + Tc_ANOMALY + "=5" //It is impossible to pick up, so technically you can't put it inside the DA. I guess this will make it scannable
+
 
 /obj/item/supermatter_splinter/New()
 	..()


### PR DESCRIPTION
**Motive:**

Basically to have another work-around for getting/making supermatter crystals other than getting lucky with large artifacts or adminbus. In theory, it would require three different jobs to work together in order to get a crystal. The miners to get phazon/diamonds in order to print it, a xenoarchologist getting lucky finding a chunk while digging and the mechanics to actually scan them/print new ones (Engineering could be added to the mix since they have to fuse the chunks with the shard in order to make the crystal and then set up the supermatter engine with the crystal in it.

The item isn't that dangerous, only retards lose limbs if they try to pick it up even when the description says that is dangerous to do that.

[tweak]