### PR TITLE
Safe spawners are more modular

### DIFF
--- a/code/modules/maps/spawners/spawners.dm
+++ b/code/modules/maps/spawners/spawners.dm
@@ -1096,9 +1096,16 @@
 
 // Safe /////////////////////////////////////////////////////
 //Does not come with a safe.
-/obj/abstract/map/spawner/safe/any
-	name = "safe any spawner "
+
+/obj/abstract/map/spawner/safe
+	name = "safe template spawner"
 	icon_state = "safe"
+	amount = 1
+	chance = 100
+	jiggle = 0
+
+/obj/abstract/map/spawner/safe/any
+	name = "safe any spawner"
 	to_spawn = list(
 		/obj/item/weapon/storage/pill_bottle/creatine,
 		/obj/item/weapon/storage/pill_bottle/nanobot,
@@ -1145,10 +1152,26 @@
 		/obj/item/mounted/frame/painting
 )
 
+/obj/abstract/map/spawner/safe/any/box
+	name = "safe any spawner (boxstation)"
+
+/obj/abstract/map/spawner/safe/any/packed
+	name = "safe any spawner (packed)"
+
+/obj/abstract/map/spawner/safe/any/deff
+	name = "safe any spawner (defficiency)"
+
+/obj/abstract/map/spawner/safe/any/meta
+	name = "safe any spawner (metaclub)"
+
+/obj/abstract/map/spawner/safe/any/roid
+	name = "safe any spawner (asteroid)"
+
+/obj/abstract/map/spawner/safe/any/bagel
+	name = "safe any spawner (bagel)"
 
 /obj/abstract/map/spawner/safe/medical
 	name = "safe medical spawner"
-	icon_state = "safe"
 	to_spawn = list(/obj/item/weapon/storage/pill_bottle/creatine,
 	/obj/item/weapon/storage/pill_bottle/nanobot,
 	/obj/item/weapon/storage/firstaid/adv,
@@ -1160,10 +1183,31 @@
 	/obj/item/voucher/free_item/medical_safe
 )
 
+/obj/abstract/map/spawner/safe/medical/box
+	name = "safe medical spawner (boxstation)"
+	chance = 75
+
+/obj/abstract/map/spawner/safe/medical/packed
+	name = "safe medical spawner (packed)"
+	chance = 75
+
+/obj/abstract/map/spawner/safe/medical/deff
+	name = "safe medical spawner (defficiency)"
+	chance = 75
+
+/obj/abstract/map/spawner/safe/medical/meta
+	name = "safe medical spawner (metaclub)"
+	chance = 75
+
+/obj/abstract/map/spawner/safe/medical/roid
+	name = "safe medical spawner (asteroid)"
+
+/obj/abstract/map/spawner/safe/medical/bagel
+	name = "safe medical spawner (bagel)"
+
 
 /obj/abstract/map/spawner/safe/food
 	name = "safe food spawner"
-	icon_state = "safe"
 	to_spawn = list(/obj/item/weapon/reagent_containers/food/drinks/bottle/vodka,
 	/obj/item/voucher/free_item/snack,
 	/obj/item/voucher/free_item/hot_drink,
@@ -1177,9 +1221,27 @@
 	/obj/item/weapon/reagent_containers/food/snacks/potentham
 )
 
+/obj/abstract/map/spawner/safe/food/box
+	name = "safe food spawner (boxstation)"
+
+/obj/abstract/map/spawner/safe/food/packed
+	name = "safe food spawner (packed)"
+
+/obj/abstract/map/spawner/safe/food/deff
+	name = "safe food spawner (defficiency)"
+
+/obj/abstract/map/spawner/safe/food/meta
+	name = "safe food spawner (metaclub)"
+
+/obj/abstract/map/spawner/safe/food/roid
+	name = "safe food spawner (asteroid)"
+
+/obj/abstract/map/spawner/safe/food/bagel
+	name = "safe food spawner (bagel)"
+
+
 /obj/abstract/map/spawner/safe/weapon
 	name = "safe weapon spawner"
-	icon_state = "safe"
 	to_spawn = list(/obj/item/weapon/shield/energy,
 	/obj/item/weapon/gun/energy/gun/nuclear,
 	/obj/item/weapon/gun/projectile/mateba,
@@ -1194,9 +1256,31 @@
 	/obj/item/weapon/gun/siren
 )
 
+/obj/abstract/map/spawner/safe/weapon/box
+	name = "safe weapon spawner (boxstation)"
+	chance = 50
+
+/obj/abstract/map/spawner/safe/weapon/packed
+	name = "safe weapon spawner (packed)"
+	chance = 50
+
+/obj/abstract/map/spawner/safe/weapon/deff
+	name = "safe weapon spawner (defficiency)"
+	chance = 50
+
+/obj/abstract/map/spawner/safe/weapon/meta
+	name = "safe weapon spawner (metaclub)"
+	chance = 50
+
+/obj/abstract/map/spawner/safe/weapon/roid
+	name = "safe weapon spawner (asteroid)"
+
+/obj/abstract/map/spawner/safe/weapon/bagel
+	name = "safe weapon spawner (bagel)"
+
+
 /obj/abstract/map/spawner/safe/clothing
 	name = "safe clothing spawner"
-	icon_state = "safe"
 	to_spawn = list(/obj/item/weapon/shield/energy,
 	/obj/item/clothing/accessory/storage/webbing,
 	/obj/item/clothing/under/sexyclown,
@@ -1213,9 +1297,27 @@
 	/obj/abstract/loadout/dredd_gear
 )
 
+/obj/abstract/map/spawner/safe/clothing/box
+	name = "safe clothing spawner (boxstation)"
+
+/obj/abstract/map/spawner/safe/clothing/packed
+	name = "safe clothing spawner (packed)"
+
+/obj/abstract/map/spawner/safe/clothing/deff
+	name = "safe clothing spawner (defficiency)"
+
+/obj/abstract/map/spawner/safe/clothing/meta
+	name = "safe clothing spawner (metaclub)"
+
+/obj/abstract/map/spawner/safe/clothing/roid
+	name = "safe clothing spawner (asteroid)"
+
+/obj/abstract/map/spawner/safe/clothing/bagel
+	name = "safe clothing spawner (bagel)"
+
+
 /obj/abstract/map/spawner/safe/medal
 	name = "safe medal spawner"
-	icon_state = "safe"
 	to_spawn = list(/obj/item/clothing/accessory/medal,
 	/obj/item/clothing/accessory/medal/conduct,
 	/obj/item/clothing/accessory/medal/bronze_heart,
@@ -1227,6 +1329,26 @@
 	/obj/item/clothing/accessory/medal/gold/captain,
 	/obj/item/clothing/accessory/medal/gold/heroism
 )
+
+/obj/abstract/map/spawner/safe/medal/box
+	name = "safe medal spawner (boxstation)"
+
+/obj/abstract/map/spawner/safe/medal/packed
+	name = "safe medal spawner (packed)"
+
+/obj/abstract/map/spawner/safe/medal/deff
+	name = "safe medal spawner (defficiency)"
+
+/obj/abstract/map/spawner/safe/medal/meta
+	name = "safe medal spawner (metaclub)"
+
+/obj/abstract/map/spawner/safe/medal/roid
+	name = "safe medal spawner (asteroid)"
+
+/obj/abstract/map/spawner/safe/medal/bagel
+	name = "safe medal spawner (bagel)"
+
+
 //Food spawners////////////////////////////////////
 /obj/abstract/map/spawner/food/voxfood //spawns food for the vox raiders
 	name = "vox food spawner"

--- a/code/modules/maps/spawners/spawners.dm
+++ b/code/modules/maps/spawners/spawners.dm
@@ -1170,6 +1170,13 @@
 /obj/abstract/map/spawner/safe/any/bagel
 	name = "safe any spawner (bagel)"
 
+/obj/abstract/map/spawner/safe/any/castle
+	name = "safe any spawner (castle)"
+
+/obj/abstract/map/spawner/safe/any/snow
+	name = "safe any spawner (snow)"
+
+
 /obj/abstract/map/spawner/safe/medical
 	name = "safe medical spawner"
 	to_spawn = list(/obj/item/weapon/storage/pill_bottle/creatine,
@@ -1205,6 +1212,14 @@
 /obj/abstract/map/spawner/safe/medical/bagel
 	name = "safe medical spawner (bagel)"
 
+/obj/abstract/map/spawner/safe/medical/castle
+	name = "safe medical spawner (castle)"
+	chance = 75
+
+/obj/abstract/map/spawner/safe/medical/snow
+	name = "safe medical spawner (snow)"
+	chance = 75
+
 
 /obj/abstract/map/spawner/safe/food
 	name = "safe food spawner"
@@ -1238,6 +1253,12 @@
 
 /obj/abstract/map/spawner/safe/food/bagel
 	name = "safe food spawner (bagel)"
+
+/obj/abstract/map/spawner/safe/food/castle
+	name = "safe food spawner (castle)"
+
+/obj/abstract/map/spawner/safe/food/snow
+	name = "safe food spawner (snow)"
 
 
 /obj/abstract/map/spawner/safe/weapon
@@ -1278,6 +1299,14 @@
 /obj/abstract/map/spawner/safe/weapon/bagel
 	name = "safe weapon spawner (bagel)"
 
+/obj/abstract/map/spawner/safe/weapon/castle
+	name = "safe weapon spawner (castle)"
+	chance = 50
+
+/obj/abstract/map/spawner/safe/weapon/snow
+	name = "safe weapon spawner (snow)"
+	chance = 50
+
 
 /obj/abstract/map/spawner/safe/clothing
 	name = "safe clothing spawner"
@@ -1315,6 +1344,12 @@
 /obj/abstract/map/spawner/safe/clothing/bagel
 	name = "safe clothing spawner (bagel)"
 
+/obj/abstract/map/spawner/safe/clothing/castle
+	name = "safe clothing spawner (castle)"
+
+/obj/abstract/map/spawner/safe/clothing/snow
+	name = "safe clothing spawner (snow)"
+
 
 /obj/abstract/map/spawner/safe/medal
 	name = "safe medal spawner"
@@ -1347,6 +1382,12 @@
 
 /obj/abstract/map/spawner/safe/medal/bagel
 	name = "safe medal spawner (bagel)"
+
+/obj/abstract/map/spawner/safe/medal/castle
+	name = "safe medal spawner (castle)"
+
+/obj/abstract/map/spawner/safe/medal/snow
+	name = "safe medal spawner (snow)"
 
 
 //Food spawners////////////////////////////////////


### PR DESCRIPTION
There are now safe spawners for every map
They have been mapped in.
Mapping sucks.
Mapping change includes Bagel but not Snowmap and Castle Station because I forgot about those before I made the commit and I can't be half-arsed to make the changes there too
Turns out spawners were hardmapped on most stations so that there was a 75% chance of medical to spawn and 50% for weapon to spawn
This is good
This is better
I'm making a PR after this to make medical and weapon spawn 100% for a minimum of 6 items (if all spawners are present), no balance change sneaked in (hopefully) because i'm not shifty yes you've been dabbed on shifty. Christ this change was tedious and boring
Closes #22763 
No changelog because I'm a sneaky coder with thigh-high programmer socks and the """plebeians""" don't deserve a changelog
jk
Again, fuck mapping
Also the point of the PR is that it will now be easier to change values directly for every map (except Snowmap and Castlestation) regarding what spawns in the safe contents
Half an hour or more of my life wasted for a fucking m*pper's design choices for safes and then more time wasted adding the map variants
Also all the unrelated shit with the maps, fuck mapping, but I think it fixes itself
:cl: 
  tweak: Changed some values that you will never see by making some vault safe item spawners easier to change on a per-map basis