### PR TITLE
Signaler sanity

### DIFF
--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -207,7 +207,7 @@
 	var/mob/M = src.loc
 
 	if(!M || !ismob(M))
-		if(prob(90))
+		if(prob(5))
 			signal()
 		deadman = 0
 		processing_objects.Remove(src)

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -207,7 +207,7 @@
 	var/mob/M = src.loc
 
 	if(!M || !ismob(M))
-		if(prob(5))
+		if(prob(90))
 			signal()
 		deadman = 0
 		processing_objects.Remove(src)
@@ -220,7 +220,7 @@
 	set name = "Threaten to push the button!"
 	set desc = "BOOOOM!"
 
-	if(usr)
+	if(usr && !usr.incapacitated())
 		var/mob/user = usr
 		deadman = 1
 		processing_objects.Add(src)


### PR DESCRIPTION
[powercreep] i guess

~raises the trigger chance for the threaten verb to 90% instead of 5%~
also adds some sanity to the verb so dead people cant trigger it

~my reasoning:
5% is fucking stupid for something like that, either remove it or buff it and i chose to do the second~

as barry pointed out correctly on discord, in [living_defense.dm#L72](https://github.com/vgstation-coders/vgstation13/blob/Bleeding-Edge/code/modules/mob/living/living_defense.dm#L72) it triggers the signaler on getting shot with a 80% chance, this was just for dropping it. thonk

still gonna keep this up cause sanitycheck

:cl:
* bugfix: dead people can no longer use the threaten verb of the signaler