### PR TITLE
Tweaked starting requirements and cost for revs

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -468,11 +468,11 @@
 	name = "Revolution"
 	role_category = /datum/role/revolutionary
 	restricted_from_jobs = list("Merchant","AI", "Cyborg", "Mobile MMI", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Chief Medical Officer", "Research Director", "Internal Affairs Agent")
-	enemy_jobs = list("AI", "Cyborg", "Security Officer","Detective","Head of Security", "Captain", "Warden")
-	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
+	enemy_jobs = list("Security Officer","Detective","Head of Security", "Captain", "Warden")
+	required_enemies = list(3,3,3,3,3,2,2,1,0,0)
 	required_candidates = 3
 	weight = 2
-	cost = 35
+	cost = 40
 	requirements = list(101,101,70,40,30,20,10,10,10,10)
 	high_population_requirement = 50
 	delay = 5 MINUTES


### PR DESCRIPTION
- AIs and cyborgs no longer count as enemies for the revolution (because they're often subverted)
- Adjusted the curve of required enemies, from 1 to "3 or 2" (for the sane threat levels, that is)
- Increased the cost from 35 to 40 to slightly reduce the amount of additional antags in the same round (the reasoning here is that the revs really don't need 3 traitors in their ranks to be successful)

Obviously up for discussion but I'm not wrong

:cl:
- tweak: Revolution is more likely to have opposition when it triggers and less other antags will spawn concurrently with it.