### PR TITLE
Converting 40% of the crew to revs triggers the 'subversive elements' announcement

### DIFF
--- a/code/datums/gamemode/factions/syndicate/rev.dm
+++ b/code/datums/gamemode/factions/syndicate/rev.dm
@@ -110,6 +110,24 @@
 		if(objective.IsFulfilled())
 			remaining_targets--
 
+	if(stage < FACTION_ENDGAME)
+		var/living_revs = 0
+		var/total_valid_living = 0
+		for (var/mob/living/L in player_list)
+			if (issilicon(L)||isborer(L))
+				continue
+			if (L.stat == DEAD)
+				continue
+			if (isrev(L))
+				living_revs++
+			total_valid_living++
+		var/threshold = 40 //the percentage of living revs at which point the announcement is triggered
+		if(living_revs > 0 && total_valid_living > 0)
+			var/revs_percentage = round((living_revs * 100)/total_valid_living)
+			if(revs_percentage >= threshold)
+				stage(FACTION_ENDGAME)
+				command_alert(/datum/command_alert/revolution)
+
 	switch(remaining_targets)
 		if(0)
 			if(stage < FACTION_VICTORY)


### PR DESCRIPTION
closes #22799
0% tested

:cl:
 * tweak: Converting 40% of the crew to the revolution triggers the 'subversive elements' announcement.