### PR TITLE
Adds Z-6 back to CMC

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -1023,6 +1023,7 @@ var/default_colour_matrix = list(1,0,0,0,\
 #define TELECOMM_Z 3
 #define DERELICT_Z 4
 #define ASTEROID_Z 5
+#define SPACEPIRATE_Z 6
 
 // canGhost(Read|Write) flags
 #define PERMIT_ALL 1

--- a/code/modules/cmc/crew.dm
+++ b/code/modules/cmc/crew.dm
@@ -43,7 +43,7 @@ Crew Monitor by Paul, based on the holomaps by Deity
 	var/list/textview_updatequeued = list() //list of _using set textviewupdate setting
 	var/list/holomap = list() //list of _using set holomap-enable setting
 	var/list/holomap_z_levels_mapped = list(STATION_Z, ASTEROID_Z, DERELICT_Z) //all z-level which should be mapped
-	var/list/holomap_z_levels_unmapped = list(TELECOMM_Z) //all z-levels which should not be mapped but should still be scanned for people
+	var/list/holomap_z_levels_unmapped = list(TELECOMM_Z, SPACEPIRATE_Z) //all z-levels which should not be mapped but should still be scanned for people
 	var/list/jobs = list( //needed for formatting, stolen from the old cmc
 		"Captain" = 00,
 		"Head of Personnel" = 50,


### PR DESCRIPTION
[oversight]

For whatever reason this wasn't on the new CMC while it apparently was on the old one. If it was deliberately removed, I think it should be deliberately removed in a separate PR that people can vote on. Or I guess you can just downtoot this one if you don't want to see it return, that works too.

:cl:
 * bugfix: Z6 is back on the CMC.