### PR TITLE
Ups a bit the 'max blood per victim' number.

### DIFF
--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -2,7 +2,7 @@
  -- Vampires --
  */
 
-#define MAX_BLOOD_PER_TARGET 400
+#define MAX_BLOOD_PER_TARGET 200
 
 /datum/role/vampire
 	id = VAMPIRE

--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -2,6 +2,8 @@
  -- Vampires --
  */
 
+#define MAX_BLOOD_PER_TARGET 400
+
 /datum/role/vampire
 	id = VAMPIRE
 	name = VAMPIRE
@@ -203,7 +205,7 @@
 			feeders[targetref] = 0
 		if(target.stat < DEAD) //alive
 			blood = min(20, target.vessel.get_reagent_amount(BLOOD)) // if they have less than 20 blood, give them the remnant else they get 20 blood
-			if (feeders[targetref] < 100)
+			if (feeders[targetref] < MAX_BLOOD_PER_TARGET)
 				blood_total += blood
 			else
 				to_chat(assailant, "<span class='warning'>Their blood quenches your thirst but won't let you become any stronger. You need to find new prey.</span>")
@@ -213,7 +215,7 @@
 			head_organ.add_autopsy_data("sharp teeth", 1)
 		else
 			blood = min(10, target.vessel.get_reagent_amount(BLOOD)) // The dead only give 10 blood
-			if (feeders[targetref] < 100)
+			if (feeders[targetref] < MAX_BLOOD_PER_TARGET)
 				blood_total += blood
 			else
 				to_chat(assailant, "<span class='warning'>Their blood quenches your thirst but won't let you become any stronger. You need to find new prey.</span>")


### PR DESCRIPTION
#22666 removed clone damage from vamp bites, which was fairly popular (14/1) but it also sneakily added a max blood count that was MUCH lower than what you could get with a single person. (100 vs about 180 if they didn't ghost.)

I don't believe this part of the change was given enough time (and was, frankly, plugged in at the last moment without any discussion or transparency on the numbers).

This PR aims to fix that. It is of course open for further discussion.

:cl:
- tweak: The max blood you can get per vampire victim has been upped a bit.