### PR TITLE
added vox farmbot on maps

### DIFF
--- a/code/game/machinery/bots/farmbot.dm
+++ b/code/game/machinery/bots/farmbot.dm
@@ -56,7 +56,7 @@
 	var/frustration
 
 /obj/machinery/bot/farmbot/vox_garden_farmbot
-	name = "Special vox trader farmbot"
+	name = "Special Vox Trader Farmbot"
 	req_access = list()
 	req_one_access =  list(access_hydroponics, access_trade)
 

--- a/code/game/machinery/bots/farmbot.dm
+++ b/code/game/machinery/bots/farmbot.dm
@@ -55,6 +55,11 @@
 	var/path[] = new() // used for pathing
 	var/frustration
 
+/obj/machinery/bot/farmbot/vox_garden_farmbot
+	name = "Special vox trader farmbot"
+	req_access = list()
+	req_one_access =  list(access_hydroponics, access_trade)
+
 /obj/machinery/bot/farmbot/New()
 	..()
 	src.icon_state = "[src.icon_initial][src.on]"


### PR DESCRIPTION
[tested][box][bugfix]

Voxbros can now graden in peace on trader outpost with their new special vox farmbot which they can unlock with their ids. Also added on the snowmap and sec version and packed.

closes #22745

🆑

* rscadd: Added vox farmbot on trader outpost which traders can now unlock with their id.