### PR TITLE
Small percentage of roundstart cameras deactivated

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -41,6 +41,10 @@ var/list/camera_names=list()
 	var/vision_flags = SEE_SELF //Only applies when viewing the camera through a console.
 	var/health = CAMERA_MAX_HEALTH
 
+/obj/machinery/camera/initialize()
+	if(prob(15))
+		deactivate()
+
 /obj/machinery/camera/update_icon()
 	var/EMPd = stat & EMPED
 	var/deactivated = !status

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -22,6 +22,7 @@ var/list/camera_names=list()
 	anchored = 1.0
 	var/invuln = null
 	var/bugged = 0
+	var/failure_chance = 10
 	var/obj/item/weapon/camera_assembly/assembly = null
 	var/light_on = 0
 
@@ -41,8 +42,12 @@ var/list/camera_names=list()
 	var/vision_flags = SEE_SELF //Only applies when viewing the camera through a console.
 	var/health = CAMERA_MAX_HEALTH
 
+/obj/machinery/camera/flawless
+	failure_chance = 0
+
 /obj/machinery/camera/initialize()
-	if(prob(15))
+	..()
+	if(prob(failure_chance))
 		deactivate()
 
 /obj/machinery/camera/update_icon()


### PR DESCRIPTION
[tweak][balance]
Makes a random ~~fifteen~~ ten percent of roundstart cameras deactivated. I'm not dead set on ~~fifteen~~ ten percent so feel free to suggest higher/lower percentages as you see fit. 
Additionally adds a flawless camera subtype with a zero percent deactivation chance.

The intent of this is to discourage meta knowledge that cut cams = antag activity, in the same vein as randomized suit sensors. 

:cl:
 * tweak: Ten percent of roundstart cameras are now randomly deactivated.