### PR TITLE
fixed runtime when logging pills being put in containers

### DIFF
--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -162,6 +162,8 @@ var/const/INGEST = 2
 
 	if(log_transfer && logged_message.len)
 		var/turf/T = get_turf(my_atom)
+		if(!T) //we got removed, duh
+			T = get_turf(R.my_atom)
 		minimal_investigation_log(I_CHEMS, "[whodunnit ? "[key_name(whodunnit)]" : "(N/A, last user processed: [usr.ckey])"] \
 		transferred [english_list(logged_message)] from \a [my_atom] \ref[my_atom] to \a [R.my_atom] \ref[R.my_atom].", prefix=" ([T.x],[T.y],[T.z])")
 		if(adminwarn_message.len)

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -300,9 +300,13 @@ var/list/LOGGED_SPLASH_REAGENTS = list(FUEL, THERMITE)
 	return 0
 
 /obj/item/weapon/reagent_containers/proc/is_empty()
+	if(!reagents)
+		return 1
 	return reagents.total_volume <= 0
 
 /obj/item/weapon/reagent_containers/proc/is_full()
+	if(!reagents)
+		return 0
 	return reagents.total_volume >= reagents.maximum_volume
 
 /obj/item/weapon/reagent_containers/proc/can_transfer_an_APTFT()

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -301,7 +301,7 @@ var/list/LOGGED_SPLASH_REAGENTS = list(FUEL, THERMITE)
 
 /obj/item/weapon/reagent_containers/proc/is_empty()
 	if(!reagents)
-		return 1
+		return TRUE
 	return reagents.total_volume <= 0
 
 /obj/item/weapon/reagent_containers/proc/is_full()

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -306,7 +306,7 @@ var/list/LOGGED_SPLASH_REAGENTS = list(FUEL, THERMITE)
 
 /obj/item/weapon/reagent_containers/proc/is_full()
 	if(!reagents)
-		return 0
+		return FALSE
 	return reagents.total_volume >= reagents.maximum_volume
 
 /obj/item/weapon/reagent_containers/proc/can_transfer_an_APTFT()

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -36,11 +36,7 @@
 	// Show messages
 	if (tx_amount > 0)
 		user.visible_message("<span class='warning'>[user] puts something into \the [target], filling it.</span>")
-		if (src.is_empty())
-			to_chat(user, "<span class='notice'>You [target_was_empty ? "crush" : "dissolve"] the pill into \the [target].</span>")
-			qdel(src)
-		else
-			to_chat(user, "<span class='notice'>You [target_was_empty ? "crush partially" : "partially dissolve"] the pill into \the [target], filling it.</span>")
+		to_chat(user, "<span class='notice'>You [target_was_empty ? "crush" : "dissolve"] the pill into \the [target], filling it.</span>")
 	else
 		to_chat(user, "<span class='notice'>\The [target] is full!</span>")
 


### PR DESCRIPTION
fixed the awful flavourtext while im at it ew
[hotfix]

~DONT MERGE YET, WAS HAVING MORE RUNTIMES~ good to go boys

the log was causing a runtime, so the pill thought it failed to insert, prompting it to never produce any notice that someones drink got drugged.

I ran around putting chloral in the beers at bar and got confused that the barkeep didn't mind, turns out he didn't get any messages.

Also the flavourtext was broken and it always defaulted to the else statement, so i just removed that if statement alltogether