### PR TITLE
Slip changes

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -683,6 +683,9 @@
 	if (!..())
 		return FALSE
 
+	if (src.unslippable) //if the user teleports in the middle of a slippable surface, he will not slip when he lands on the surface, rather than stepping, but not getting a knockdown
+		return false
+
 	switch(P.wet)
 		if(TURF_WET_WATER)
 			if (!Slip(stun_amount = 5, weaken_amount = 3, slip_on_walking = FALSE, overlay_type = TURF_WET_WATER))

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -683,7 +683,7 @@
 	if (!..())
 		return FALSE
 
-	if (src.unslippable) //if the user teleports in the middle of a slippable surface, he will not slip when he lands on the surface, rather than stepping, but not getting a knockdown
+	if (src.unslippable) //if unslippable, don't even bother making checks fam just don't slip me ok
 		return FALSE
 
 	switch(P.wet)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -683,7 +683,7 @@
 	if (!..())
 		return FALSE
 
-	if (src.unslippable) //if unslippable, don't even bother making checks fam just don't slip me ok
+	if (unslippable) //if unslippable, don't even bother making checks
 		return FALSE
 
 	switch(P.wet)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -684,7 +684,7 @@
 		return FALSE
 
 	if (src.unslippable) //if the user teleports in the middle of a slippable surface, he will not slip when he lands on the surface, rather than stepping, but not getting a knockdown
-		return false
+		return FALSE
 
 	switch(P.wet)
 		if(TURF_WET_WATER)


### PR DESCRIPTION
[hotfix]

Made it so you can blink/teleport inside of the lubed zone and you slip only after you move:

![wizard_fix](https://user-images.githubusercontent.com/24612466/57471194-47b03500-7293-11e9-9a32-4ae443e3059a.gif)


Before it was the case that the `Slip` method was not called if you blinked/teled on a lubed surface(i.e. you didn't get knocked down, but the 'sliding' still was in effect, as that is in another method called `ApplySlip`) I added another check there and now you don't slide and don't get knocked down.


:cl:
 * tweak: You can now end up inside of lubed zone with blink, but not slip until you move.