### PR TITLE
Secure briefcase big

### DIFF
--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -146,6 +146,9 @@
 	throw_speed = 1
 	throw_range = 4
 	w_class = W_CLASS_LARGE
+	fits_max_w_class = W_CLASS_MEDIUM
+	max_combined_w_class = 16
+	hitsound = "swing_hit"
 
 /obj/item/weapon/storage/secure/briefcase/paperpen/New()
 	..()


### PR DESCRIPTION
[qol][tweak]

Web editor but I tested it out locally first, doing it this way because ridiculously lazy

Basically just hands over some traits of the briefcase over to the secure briefcase, which is pretty useless right now. Unatomically gives it the same hitsound as well

:cl:
 * tweak: Secure briefcases can now contain medium-sized objects like their insecure counterparts.