### PR TITLE
Added functionality to buckle in closets

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/coffin.dm
+++ b/code/game/objects/structures/crates_lockers/closets/coffin.dm
@@ -7,6 +7,8 @@
 
 	starting_materials = list(MAT_WOOD = 5*CC_PER_SHEET_MISC)
 
+	mob_lock_type = /datum/locking_category/buckle/closet/coffin
+
 /obj/structure/closet/coffin/Destroy()
 	new /obj/item/stack/sheet/wood(loc,3) //This will result in 3 dropped if destroyed, or 5 if deconstructed
 	..()
@@ -16,3 +18,6 @@
 		icon_state = icon_closed
 	else
 		icon_state = icon_opened
+
+/datum/locking_category/buckle/closet/coffin
+	flags = LOCKED_SHOULD_LIE

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -103,6 +103,9 @@
 			togglelock(user)
 
 /obj/structure/closet/secure_closet/relaymove(mob/user as mob)
+	if (has_locked_mobs())
+		return
+
 	if(user.stat || !isturf(src.loc))
 		return
 
@@ -136,6 +139,7 @@
 
 	if(!src.toggle())
 		return src.attackby(null, user)
+	handle_user_visibility()
 
 /obj/structure/closet/secure_closet/attack_paw(mob/user as mob)
 	return src.attack_hand(user)


### PR DESCRIPTION
[general]

Added ability to buckle a player into a closet. Originally I started doing it only for #22826 coffins, but I figured I could implement it for all closets. The way it works without breaking the drag-and-drop functionality is that there is a separate option added in the context menu "Toggle Buckle".  It finds the player inside of the closet, and if there is one it buckles him. It works only if the closet is open, because if it's closed it "eats" the items and it doesn't find a player(if somebody has ideas for a fix for this it would be cool). While buckled, you cannot move and can't run outside. You can unbuckle yourself only if the door is open(due to earlier reasons). You can still drag items in the closet, because the buckle only works when you explicitly do from the right click menu. Tell me what you think.

Here are some gif examples I recorded:

https://imgur.com/a/K4doDc4

:cl:
 * rscadd: Added ability to buckle self/others into closets, right click the closet and select "Toggle Buckle".