### PR TITLE
Non-ninjas can no longer use energy katanas

### DIFF
--- a/code/datums/gamemode/role/ninja.dm
+++ b/code/datums/gamemode/role/ninja.dm
@@ -493,8 +493,8 @@ Helpers For Both Variants
 	if(isninja(user))
 		..()
 	else
-		to_chat(user,"<span class='warning'>You can't locate the off button.</span>")
-		..(user,"on")
+		to_chat(user,"<span class='warning'>There's no buttons on it.</span>")
+		return
 	if(active)
 		cant_drop = TRUE
 	else
@@ -516,6 +516,10 @@ Helpers For Both Variants
 		return 1
 	else
 		return ..()
+		
+/obj/item/weapon/melee/energy/sword/ninja/dropped(mob/user)
+	if(active)
+		toggleActive(user,togglestate = "off")
 
 /*******************************************
 ****          WEEABOO VARIANTS          ****


### PR DESCRIPTION
I did this because ninjas were starting to turn into pinatas, and every consecutive event or antag would have a harder time because now there was some crewman with a sword permanently stuck to his hand.

🆑 
 - rscdel: Non-ninjas can no longer use energy katanas.