### PR TITLE
Ninja energy katanas can't be hooked into eachother to make dual energy swords anymore

### DIFF
--- a/code/datums/gamemode/role/ninja.dm
+++ b/code/datums/gamemode/role/ninja.dm
@@ -501,7 +501,10 @@ Helpers For Both Variants
 		cant_drop = FALSE
 
 /obj/item/weapon/melee/energy/sword/ninja/attackby(obj/item/weapon/W, mob/living/user)
-	return
+	if(istype(W,/obj/item/weapon/melee/energy/sword))
+		return
+	else
+		return ..()
 		
 /obj/item/weapon/melee/energy/sword/ninja/examine(mob/user)
 	..()

--- a/code/datums/gamemode/role/ninja.dm
+++ b/code/datums/gamemode/role/ninja.dm
@@ -500,6 +500,9 @@ Helpers For Both Variants
 	else
 		cant_drop = FALSE
 
+/obj/item/weapon/melee/energy/sword/ninja/attackby(obj/item/weapon/W, mob/living/user)
+	return
+		
 /obj/item/weapon/melee/energy/sword/ninja/examine(mob/user)
 	..()
 	if(!isninja(user))


### PR DESCRIPTION
0% tested, shouldn't break anything but if it does whatever

🆑 
 - rscdel: You can't make dual energy swords out of e-katanas anymore