### PR TITLE
Make Bolas great again

### DIFF
--- a/__DEFINES/obj_defines.dm
+++ b/__DEFINES/obj_defines.dm
@@ -24,3 +24,10 @@ var/list/qualityByString = list(
 //Daemons
 #define DAEMON_EXAMINE 	1
 #define DAEMON_AFTATT	2
+
+// Shields
+// SHIELD_xxx is to be given to shields
+// IGNORE_xxx is to be given to thrown items
+// If "IGNORE" is higher than "SHIELD", then the thrown item will always pass.
+#define IGNORE_SOME_SHIELDS 1
+#define SHIELD_ADVANCED 2

--- a/code/datums/gamemode/role/ninja.dm
+++ b/code/datums/gamemode/role/ninja.dm
@@ -151,7 +151,7 @@
 	var/activate_message = "Too slow."
 
 /obj/item/weapon/substitutionhologram/IsShield()
-	return TRUE
+	return SHIELD_ADVANCED
 
 /obj/item/weapon/substitutionhologram/on_block(damage, atom/blocked)
 	if(ishuman(loc))

--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -197,10 +197,10 @@
 	breakouttime = 50 //10 seconds
 	throw_speed = 1
 	throw_range = 10
-	alwayspass = TRUE // Hit or miss? I guess they never miss
 	var/dispenser = 0
 	var/throw_sound = 'sound/weapons/whip.ogg'
 	var/trip_prob = 90
+	ignore_blocking = IGNORE_SOME_SHIELDS
 
 /obj/item/weapon/legcuffs/bolas/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	user.throw_item(target)

--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -197,6 +197,7 @@
 	breakouttime = 50 //10 seconds
 	throw_speed = 1
 	throw_range = 10
+	alwayspass = TRUE // Hit or miss? I guess they never miss
 	var/dispenser = 0
 	var/throw_sound = 'sound/weapons/whip.ogg'
 	var/trip_prob = 90

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -43,7 +43,6 @@ var/global/list/ghdel_profiling = list()
 	var/list/last_beamchecks // timings for beam checks.
 	var/ignoreinvert = 0
 	var/timestopped
-	var/alwayspass = FALSE
 
 	appearance_flags = TILE_BOUND|LONG_GLIDE
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -43,6 +43,7 @@ var/global/list/ghdel_profiling = list()
 	var/list/last_beamchecks // timings for beam checks.
 	var/ignoreinvert = 0
 	var/timestopped
+	var/alwayspass = FALSE
 
 	appearance_flags = TILE_BOUND|LONG_GLIDE
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -53,6 +53,8 @@
 	var/list/current_tethers
 	var/obj/shadow/shadow
 
+	var/ignore_blocking = 0
+
 /atom/movable/New()
 	. = ..()
 	if((flags & HEAR) && !ismob(src))

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -930,6 +930,7 @@
 //Called when the item blocks an attack. Return 1 to stop the hit, return 0 to let the hit go through
 /obj/item/proc/on_block(damage, atom/blocked)
 	if(ismob(loc))
+	
 		if(prob(50 - round(damage / 3)))
 			visible_message("<span class='borange'>[loc] blocks \the [blocked] with \the [src]!</span>")
 			if(isatommovable(blocked))

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -928,10 +928,11 @@
 	return FALSE
 
 //Called when the item blocks an attack. Return 1 to stop the hit, return 0 to let the hit go through
-/obj/item/proc/on_block(damage, atom/blocked)
+/obj/item/proc/on_block(damage, atom/movable/blocked)
 	if(ismob(loc))
-	
-		if(prob(50 - round(damage / 3)))
+		if (IsShield() < blocked.ignore_blocking)
+			return FALSE
+		if (prob(50 - round(damage / 3)))
 			visible_message("<span class='borange'>[loc] blocks \the [blocked] with \the [src]!</span>")
 			if(isatommovable(blocked))
 				var/atom/movable/M = blocked

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -234,8 +234,8 @@
 	return
 
 /obj/item/clothing/suit/armor/reactive/on_block(damage, atom/blocked)
-	if (blocked.alwayspass)
-		return TRUE
+	if (blocked.ignore_blocking) // They have a "blocking rating" of 1
+		return FALSE
 	if(!prob(35))
 		return 0 //35% chance
 

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -234,6 +234,8 @@
 	return
 
 /obj/item/clothing/suit/armor/reactive/on_block(damage, atom/blocked)
+	if (blocked.alwayspass)
+		return TRUE
 	if(!prob(35))
 		return 0 //35% chance
 

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -233,7 +233,7 @@
 		src.add_fingerprint(user)
 	return
 
-/obj/item/clothing/suit/armor/reactive/on_block(damage, atom/blocked)
+/obj/item/clothing/suit/armor/reactive/on_block(damage, atom/movable/blocked)
 	if (blocked.ignore_blocking) // They have a "blocking rating" of 1
 		return FALSE
 	if(!prob(35))


### PR DESCRIPTION
[balance]
#22207 killed Bolas by making any shield (at all) having a 50% chance to deflect them, and by making the science powergame armours having 35% chance to deflect them.

This fixes that.

Bolas are a high-risk, high-reward item, compared to tasers, they're faster but have only one charge and can give your opponent a weapon to stun you from a distance if you miss.
The ghetto variant is also a very useful self-defence tool.

I don't believe their main selling point (going through shields and armour) needed to be nerfed.

:cl:
- tweak: Shields, reactive teleport armor, and eswords, will no longer protect you from thrown bolas.