### PR TITLE
Reactive Armor no longer has a slowdown

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -211,7 +211,6 @@
 	icon_state = "reactiveoff"
 	item_state = "reactiveoff"
 	blood_overlay_type = "armor"
-	slowdown = HARDSUIT_SLOWDOWN_LOW
 	clothing_flags = ONESIZEFITSALL
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0)
 


### PR DESCRIPTION
Everyone picked the ablative because the super pro strat combat meta in my deathmatch simulator is stuns and most common stuns are energy projectiles
This makes the reactive armor better, or as I like to call it, not ass
It's a cool item, I wish it was used more often, this will make it on par with the ablative
:cl:
 * tweak: The reactive armor from R&D no longer slows you down when worn.