### PR TITLE
Scrubber pressure check consistency 2: Eternal Scrubaloo

### DIFF
--- a/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
@@ -204,9 +204,6 @@
 				network.update = 1
 
 	else //Just siphoning all air
-		if (air_contents.return_pressure()>=50*ONE_ATMOSPHERE)
-			return
-
 		var/transfer_moles = environment.total_moles()*(volume_rate/environment.volume)
 
 		var/datum/gas_mixture/removed = loc.remove_air(transfer_moles)


### PR DESCRIPTION
[consistency] [bugfix]

Scrubbers didn't suck air in when they were already at 50 ATM pressure or more, but this was only checked when they were siphoning, not when they were scrubbing. Now they properly siphon.

:cl:
 * bugfix: Scrubbers now properly siphon without limit.