### PR TITLE
fixes wiki link for ninja

### DIFF
--- a/__DEFINES/role_datums_defines.dm
+++ b/__DEFINES/role_datums_defines.dm
@@ -38,7 +38,7 @@
 #define REV "revolutionary"
 #define WIZAPP "wizard's apprentice"
 #define MADMONKEY "monkey fever infected"
-#define NINJA "space ninja"
+#define NINJA "Space Ninja"
 #define WISHGRANTERAVATAR "avatar of the Wish Granter"
 #define HIGHLANDER "highlander"
 #define DEATHSQUADIE "death commando"


### PR DESCRIPTION
The ingame link to the wiki for ninja doesn't work because the page is `Space Ninja` but the link goes to `Space ninja` so this is a fix for that.
That or someone could do wiki magic to redirect 
http://ss13.moe/wiki/index.php/Space_ninja
to
http://ss13.moe/wiki/index.php/Space_Ninja
<!-- [hotfix] -->