### PR TITLE
Makes HE pipe radiation capacity equal to thermal plates

### DIFF
--- a/code/ATMOSPHERICS/components/unary/thermal_plate.dm
+++ b/code/ATMOSPHERICS/components/unary/thermal_plate.dm
@@ -1,6 +1,5 @@
 #define NO_GAS 0.01
 #define SOME_GAS 1
-#define RADIATION_CAPACITY 30000 //Radiation isn't particularly effective (TODO BALANCE)
 #define ENERGY_MULT 6.4
 
 
@@ -11,7 +10,7 @@
 	icon = 'icons/obj/atmospherics/cold_sink.dmi'
 	icon_state = "off"
 	level = 1
-
+	var/radiation_capacity = 30000 //Radiation isn't particularly effective (TODO BALANCE)
 	name = "Thermal Transfer Plate"
 	desc = "Transfers heat to and from an area."
 
@@ -73,8 +72,8 @@
 	if (!internal_removed)
 		return
 
-	var/combined_heat_capacity = internal_removed.heat_capacity() + RADIATION_CAPACITY
-	var/combined_energy = internal_removed.thermal_energy() + (RADIATION_CAPACITY * ENERGY_MULT)
+	var/combined_heat_capacity = internal_removed.heat_capacity() + radiation_capacity
+	var/combined_energy = internal_removed.thermal_energy() + (radiation_capacity * ENERGY_MULT)
 
 	var/final_temperature = combined_energy / combined_heat_capacity
 
@@ -92,5 +91,4 @@
 
 #undef NO_GAS
 #undef SOME_GAS
-#undef RADIATION_CAPACITY
 #undef ENERGY_MULT

--- a/code/ATMOSPHERICS/components/unary/thermal_plate.dm
+++ b/code/ATMOSPHERICS/components/unary/thermal_plate.dm
@@ -1,4 +1,5 @@
 #define RADIATION_CAPACITY 30000 //Radiation isn't particularly effective (TODO BALANCE)
+#define ENERGY_MULT 6.4
 
 
 /obj/machinery/atmospherics/unary/thermal_plate
@@ -71,7 +72,7 @@
 		return
 
 	var/combined_heat_capacity = internal_removed.heat_capacity() + RADIATION_CAPACITY
-	var/combined_energy = internal_removed.thermal_energy() + (RADIATION_CAPACITY * 6.4)
+	var/combined_energy = internal_removed.thermal_energy() + (RADIATION_CAPACITY * ENERGY_MULT)
 
 	var/final_temperature = combined_energy / combined_heat_capacity
 
@@ -86,3 +87,6 @@
 
 /obj/machinery/atmospherics/unary/thermal_plate/hide(var/i) //to make the little pipe section invisible, the icon changes.
 	update_icon()
+
+#undef RADIATION_CAPACITY
+#undef ENERGY_MULT

--- a/code/ATMOSPHERICS/components/unary/thermal_plate.dm
+++ b/code/ATMOSPHERICS/components/unary/thermal_plate.dm
@@ -1,4 +1,5 @@
-#define RADIATION_CAPACITY 30000 //Radiation isn't particularly effective (TODO BALANCE)
+#define RADIATION_CAPACITY 35000 //Radiation isn't particularly effective (TODO BALANCE)
+								 //H/E pipe value is 32000. This is higher because otherwise these are useless.
 
 
 /obj/machinery/atmospherics/unary/thermal_plate

--- a/code/ATMOSPHERICS/components/unary/thermal_plate.dm
+++ b/code/ATMOSPHERICS/components/unary/thermal_plate.dm
@@ -1,5 +1,4 @@
-#define RADIATION_CAPACITY 32000 //Radiation isn't particularly effective (TODO BALANCE)
-								 //H/E pipe value is 32000 so this is the same now. Textbook powercreep.
+#define RADIATION_CAPACITY 30000 //Radiation isn't particularly effective (TODO BALANCE)
 
 
 /obj/machinery/atmospherics/unary/thermal_plate

--- a/code/ATMOSPHERICS/components/unary/thermal_plate.dm
+++ b/code/ATMOSPHERICS/components/unary/thermal_plate.dm
@@ -1,5 +1,5 @@
-#define RADIATION_CAPACITY 35000 //Radiation isn't particularly effective (TODO BALANCE)
-								 //H/E pipe value is 32000. This is higher because otherwise these are useless.
+#define RADIATION_CAPACITY 32000 //Radiation isn't particularly effective (TODO BALANCE)
+								 //H/E pipe value is 32000 so this is the same now. Textbook powercreep.
 
 
 /obj/machinery/atmospherics/unary/thermal_plate

--- a/code/ATMOSPHERICS/components/unary/thermal_plate.dm
+++ b/code/ATMOSPHERICS/components/unary/thermal_plate.dm
@@ -1,3 +1,5 @@
+#define NO_GAS 0.01
+#define SOME_GAS 1
 #define RADIATION_CAPACITY 30000 //Radiation isn't particularly effective (TODO BALANCE)
 #define ENERGY_MULT 6.4
 
@@ -88,5 +90,7 @@
 /obj/machinery/atmospherics/unary/thermal_plate/hide(var/i) //to make the little pipe section invisible, the icon changes.
 	update_icon()
 
+#undef NO_GAS
+#undef SOME_GAS
 #undef RADIATION_CAPACITY
 #undef ENERGY_MULT

--- a/code/ATMOSPHERICS/he_pipes.dm
+++ b/code/ATMOSPHERICS/he_pipes.dm
@@ -9,8 +9,9 @@
 	minimum_temperature_difference = 20
 	thermal_conductivity = OPEN_HEAT_TRANSFER_COEFFICIENT
 
-	var/RADIATION_CAPACITY = 32000       // Radiation isn't particularly effective (TODO BALANCE)
+	var/RADIATION_CAPACITY = 30000       // Radiation isn't particularly effective (TODO BALANCE)
 	                                     //  Plate value is 30000, increased it a bit because of additional surface area. - N3X
+										 // Screw you N3X15, 30000 is a perfectly fine number. - bur
 	var/const/ENERGY_MULT        = 6.4   // Not sure what this is, keeping it the same as plates.
 
 	burst_type = /obj/machinery/atmospherics/unary/vent/burstpipe/heat_exchanging

--- a/code/ATMOSPHERICS/he_pipes.dm
+++ b/code/ATMOSPHERICS/he_pipes.dm
@@ -1,5 +1,9 @@
 #define NO_GAS 0.01
 #define SOME_GAS 1
+#define RADIATION_CAPACITY 30000// Radiation isn't particularly effective (TODO BALANCE)
+								//  Plate value is 30000, increased it a bit because of additional surface area. - N3X
+								// Screw you N3X15, 30000 is a perfectly fine number. - bur
+#define ENERGY_MULT 6.4   // Not sure what this is, keeping it the same as plates.
 
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging
 	icon = 'icons/obj/pipes/heat.dmi'
@@ -8,11 +12,6 @@
 
 	minimum_temperature_difference = 20
 	thermal_conductivity = OPEN_HEAT_TRANSFER_COEFFICIENT
-
-	var/RADIATION_CAPACITY = 30000       // Radiation isn't particularly effective (TODO BALANCE)
-	                                     //  Plate value is 30000, increased it a bit because of additional surface area. - N3X
-										 // Screw you N3X15, 30000 is a perfectly fine number. - bur
-	var/const/ENERGY_MULT        = 6.4   // Not sure what this is, keeping it the same as plates.
 
 	burst_type = /obj/machinery/atmospherics/unary/vent/burstpipe/heat_exchanging
 
@@ -300,3 +299,8 @@
 
 	if(!suppress_icon_check)
 		update_icon()
+
+#undef NO_GAS
+#undef SOME_GAS
+#undef RADIATION_CAPACITY
+#undef ENERGY_MULT

--- a/code/ATMOSPHERICS/he_pipes.dm
+++ b/code/ATMOSPHERICS/he_pipes.dm
@@ -1,8 +1,5 @@
 #define NO_GAS 0.01
 #define SOME_GAS 1
-#define RADIATION_CAPACITY 30000// Radiation isn't particularly effective (TODO BALANCE)
-								//  Plate value is 30000, increased it a bit because of additional surface area. - N3X
-								// Screw you N3X15, 30000 is a perfectly fine number. - bur
 #define ENERGY_MULT 6.4   // Not sure what this is, keeping it the same as plates.
 
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging
@@ -12,6 +9,9 @@
 
 	minimum_temperature_difference = 20
 	thermal_conductivity = OPEN_HEAT_TRANSFER_COEFFICIENT
+	var/radiation_capacity = 30000  // Radiation isn't particularly effective (TODO BALANCE)
+									//  Plate value is 30000, increased it a bit because of additional surface area. - N3X
+									// Screw you N3X15, 30000 is a perfectly fine number. - bur
 
 	burst_type = /obj/machinery/atmospherics/unary/vent/burstpipe/heat_exchanging
 
@@ -112,8 +112,8 @@
 	if (!internal_removed)
 		return
 
-	var/combined_heat_capacity = internal_removed.heat_capacity() + RADIATION_CAPACITY
-	var/combined_energy = internal_removed.thermal_energy() + (RADIATION_CAPACITY * ENERGY_MULT)
+	var/combined_heat_capacity = internal_removed.heat_capacity() + radiation_capacity
+	var/combined_energy = internal_removed.thermal_energy() + (radiation_capacity * ENERGY_MULT)
 
 	var/final_temperature = combined_energy / combined_heat_capacity
 
@@ -204,7 +204,7 @@
 	icon = 'icons/obj/pipe-item.dmi'
 	icon_state = "he_manifold"
 	var/obj/machinery/atmospherics/node3
-	RADIATION_CAPACITY = 24000
+	radiation_capacity = 24000
 
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/he_manifold/New()
 	.. ()
@@ -258,7 +258,7 @@
 	icon_state = "he_manifold4w"
 	var/obj/machinery/atmospherics/node3
 	var/obj/machinery/atmospherics/node4
-	RADIATION_CAPACITY = 24000
+	radiation_capacity = 24000
 
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/he_manifold4w/New()
 	.. ()
@@ -302,5 +302,4 @@
 
 #undef NO_GAS
 #undef SOME_GAS
-#undef RADIATION_CAPACITY
 #undef ENERGY_MULT


### PR DESCRIPTION
[consistency]

he_pipes.dm:
```
var/RADIATION_CAPACITY = 32000       // Radiation isn't particularly effective (TODO BALANCE)
                                     // Plate value is 30000, increased it a bit because of additional surface area. - N3X
```

This difference basically means that thermal plates are strictly inferior to H/E pipes. They can't be chained together en masse and radiate less heat.

As you can see in the commit history I was going to buff thermal plates at first, but then I decided to nerf H/E pipes to match instead because powercreep is the devil etc. The 2000 unit (~~like half a percent~~ ok, like five percent) difference here probably has next to no effect in practice and 30000 is a much nicer number than 32000.

Completely untested, but what could *possibly* go wrong?

:cl:
 * tweak: HE pipes and thermal plates are now equally effective in radiating heat.