### PR TITLE
Radiation artifact tweaks

### DIFF
--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_radiate.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_radiate.dm
@@ -13,19 +13,18 @@
 /datum/artifact_effect/radiate/DoEffectTouch(var/mob/living/user)
 	if(user)
 		user.apply_radiation(radiation_amount * 5,RAD_INTERNAL)
-		user.updatehealth()
 		return 1
 
 /datum/artifact_effect/radiate/DoEffectAura()
 	if(holder)
-		for (var/mob/living/M in range(src.effectrange,holder))
-			M.apply_radiation(radiation_amount,RAD_INTERNAL)
-			M.updatehealth()
+		emitted_harvestable_radiation(get_turf(holder), radiation_amount, range = effectrange)
+		for(var/mob/living/M in range(effectrange,holder))
+			M.apply_radiation(radiation_amount,RAD_EXTERNAL)
 		return 1
 
 /datum/artifact_effect/radiate/DoEffectPulse()
 	if(holder)
-		for (var/mob/living/M in range(src.effectrange,holder))
-			M.apply_radiation(radiation_amount * 25,RAD_INTERNAL)
-			M.updatehealth()
+		emitted_harvestable_radiation(get_turf(holder), radiation_amount * 25, range = effectrange)
+		for(var/mob/living/M in range(effectrange,holder))
+			M.apply_radiation(radiation_amount * 25,RAD_EXTERNAL)
 		return 1


### PR DESCRIPTION
More sources of meme power are always fun. Also reasons why you don't want RAD_INTERNAL on something that can have half of the station worth of range:
![image](https://user-images.githubusercontent.com/17928298/57773484-7d6b7880-76ee-11e9-8686-2db8351d3817.png)

:cl:
 * rscadd: Radiation large artifacts now emit a small(really small) amount of harvestable radiation
 * rscdel: Pulse and aura large artifacts now emit external radiation instead of internal(so you can actually protect yourself by using a radiation suit).