### PR TITLE
MoMMI blueprints and construction permits can now delete blueprint-defined areas

### DIFF
--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -46,7 +46,7 @@
 	desc = "Blueprints of the station, designed for the passive aggressive spider bots aboard."
 
 	can_rename_areas = list(AREA_BLUEPRINTS)
-	can_delete_areas = list()
+	can_delete_areas = list(AREA_BLUEPRINTS)
 
 	header = "<small>These blueprints are for the creation of new rooms only; you cannot change existing rooms.</small>"
 
@@ -61,7 +61,7 @@ these cannot rename rooms that are in by default BUT can rename rooms that are c
 	w_class = W_CLASS_TINY
 
 	can_rename_areas = list(AREA_BLUEPRINTS)
-	can_delete_areas = list()
+	can_delete_areas = list(AREA_BLUEPRINTS)
 
 	header = "<small>This permit is for the creation of new rooms only; you cannot change existing rooms.</small>"
 


### PR DESCRIPTION
[qol]

I don't think these things are used all that often, especially for anything mission critical, so I think the griff potential of anyone being able to delete the areas you create with these is overshadowed by the QoL of being able to undo your mistakes.

:cl:
 * tweak: MoMMI blueprints and construction permits can now delete the areas they create (but not any pre-existing areas on the station)