### PR TITLE
Buffs portable air pumps

### DIFF
--- a/code/game/machinery/atmoalter/pump.dm
+++ b/code/game/machinery/atmoalter/pump.dm
@@ -63,7 +63,7 @@
 
 			if(air_contents.temperature > 0)
 				var/required_moles = pressure_delta * environment.volume / (air_contents.temperature * R_IDEAL_GAS_EQUATION)
-				//cap flow rate at 200 litres (at our internal air pressure) per tick
+				//cap flow rate at our throughput litres (at our internal air pressure) per tick
 				var/max_transferred_moles = air_contents.pressure * throughput / (air_contents.temperature * R_IDEAL_GAS_EQUATION)
 				var/transfer_moles = min(required_moles, max_transferred_moles)
 

--- a/code/game/machinery/atmoalter/pump.dm
+++ b/code/game/machinery/atmoalter/pump.dm
@@ -12,7 +12,8 @@
 	var/pressuremax = 10 * ONE_ATMOSPHERE
 	var/pressuremin = 0
 
-	volume = 1000
+	volume = 2000
+	var/throughput = 300 //litres / process() tick
 
 /obj/machinery/portable_atmospherics/pump/update_icon()
 	src.overlays = 0
@@ -51,21 +52,20 @@
 	..()
 	if(on)
 		var/datum/gas_mixture/environment
-		var/transfer_vol //A band-aid fix for the fact the equation used below doesn't work as intended
 		if(holding)
 			environment = holding.air_contents
-			transfer_vol = holding.volume
 		else
 			environment = loc.return_air()
-			transfer_vol = CELL_VOLUME
 
 		if(direction_out)
 			var/pressure_delta = target_pressure - environment.return_pressure()
 			//Can not have a pressure delta that would cause environment pressure > tank pressure
 
-			var/transfer_moles = 0
 			if(air_contents.temperature > 0)
-				transfer_moles = pressure_delta * transfer_vol / (air_contents.temperature * R_IDEAL_GAS_EQUATION)
+				var/required_moles = pressure_delta * environment.volume / (air_contents.temperature * R_IDEAL_GAS_EQUATION)
+				//cap flow rate at 200 litres (at our internal air pressure) per tick
+				var/max_transferred_moles = air_contents.pressure * throughput / (air_contents.temperature * R_IDEAL_GAS_EQUATION)
+				var/transfer_moles = min(required_moles, max_transferred_moles)
 
 				//Actually transfer the gas
 				var/datum/gas_mixture/removed = air_contents.remove(transfer_moles)
@@ -78,9 +78,8 @@
 			var/pressure_delta = target_pressure - air_contents.return_pressure()
 			//Can not have a pressure delta that would cause environment pressure > tank pressure
 
-			var/transfer_moles = 0
 			if(environment.temperature > 0)
-				transfer_moles = pressure_delta * air_contents.volume / (environment.temperature * R_IDEAL_GAS_EQUATION)
+				var/transfer_moles = pressure_delta * air_contents.volume / (environment.temperature * R_IDEAL_GAS_EQUATION)
 
 				//Actually transfer the gas
 				var/datum/gas_mixture/removed


### PR DESCRIPTION
[tweak] [powercreep]

These things are fucking terrible for actually repressurizing rooms. Fill them to 4500 kPa and they hold enough air to pressurize 18 turfs to 100 kPa, and will take literally 15 minutes to do so. Absolutely laughable.

I doubled their capacity (1000 litres -> 2000 litres, for comparison canisters are 1000) and made them pump much faster (300 litres per tick, injectors are 200). This does mean that they're basically canisters with more capacity and extra features now. I don't know if that's a bad thing, because they're less available than canisters. If you think it's bad, there are two options: not buffing the volume on these (remember, 18 turfs), or buffing the volume on canisters (objectively powercreep and bad).

I'll be taking a look at portable scrubbers next because those are also laughably bad for actually scrubbing anything.

:cl:
 * tweak: Portable air pumps now pump faster (300 litres per tick) and have twice the volume.