### PR TITLE
Increases passive gate throughput

### DIFF
--- a/code/ATMOSPHERICS/components/binary_devices/passive_gate.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/passive_gate.dm
@@ -17,7 +17,6 @@
 /obj/machinery/atmospherics/binary/passive_gate/New()
 	..()
 	air1.volume = 1000
-	air2.volume = 1000
 
 /obj/machinery/atmospherics/binary/passive_gate/update_icon()
 	icon_state = "intact_[open?("on"):("off")]"

--- a/code/ATMOSPHERICS/components/binary_devices/passive_gate.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/passive_gate.dm
@@ -14,6 +14,11 @@
 	var/datum/radio_frequency/radio_connection
 	machine_flags = MULTITOOL_MENU
 
+/obj/machinery/atmospherics/binary/passive_gate/New()
+	..()
+	air1.volume = 1000
+	air2.volume = 1000
+
 /obj/machinery/atmospherics/binary/passive_gate/update_icon()
 	icon_state = "intact_[open?("on"):("off")]"
 	..()


### PR DESCRIPTION
[tweak]

Since I reworked these in #22879, I don't see any reason to limit them to a 200 l/tick throughput like pumps. This increases their throughput to 1000 l/tick. This will make them equalize large pressure gradients significantly faster, though it has the side effect of them having a greater footprint on the pipenet's total volume (which probably has no great effect in practice).

As a reminder, passive gates are now one-way check valves, but technical limitations in how pipecode and atmos machines work mean that they cannot facilitate "instantaneous" "flow" of gas like regular valves can. This means that from a technical standpoint they're more like pumps with no pressure limit that are only active when the input side has greater pressure than the output side.


:cl:
 * tweak: passive gates now have a dramatically greater flow rate.