### PR TITLE
Buffs portable air scrubbers

### DIFF
--- a/code/game/machinery/atmoalter/scrubber.dm
+++ b/code/game/machinery/atmoalter/scrubber.dm
@@ -266,4 +266,24 @@
 		return TRUE
 	return FALSE
 
+//Have to override this to let it connect from the mech
+/obj/machinery/portable_atmospherics/connect(obj/machinery/atmospherics/unary/portables_connector/new_port)
+	//Make sure not already connected to something else
+	if(connected_port || !new_port || new_port.connected_device)
+		return 0
+
+	//Perform the connection
+	connected_port = new_port
+	connected_port.connected_device = src
+
+	anchored = 1 //Prevent movement
+
+	//Actually enforce the air sharing
+	var/datum/pipe_network/network = connected_port.return_network(src)
+	if(network && !network.gases.Find(air_contents))
+		network.gases += air_contents
+		network.update = 1
+	update_icon()
+	return 1
+
 #undef MAX_PRESSURE

--- a/code/game/machinery/atmoalter/scrubber.dm
+++ b/code/game/machinery/atmoalter/scrubber.dm
@@ -237,6 +237,11 @@
 /obj/machinery/portable_atmospherics/scrubber/mech
 	volume = 50000
 	volume_rate = 20000
+	var/obj/mecha/mech //the mech associated with this scrubber
+
+/obj/machinery/portable_atmospherics/scrubber/mech/New(var/location)
+	..()
+	src.mech = location
 
 /obj/machinery/portable_atmospherics/scrubber/mech/get_environment()
 	var/turf/T = get_turf(src)
@@ -249,5 +254,16 @@
 /obj/machinery/portable_atmospherics/scrubber/mech/return_sample(var/environment, var/removed)
 	var/turf/T = get_turf(src)
 	T.assume_air(removed)
+
+//required to allow the pilot to use the scrubber UI
+/obj/machinery/portable_atmospherics/scrubber/mech/is_on_same_z(var/mob/user)
+	if(user == mech.occupant)
+		return TRUE
+	return FALSE
+
+/obj/machinery/portable_atmospherics/scrubber/mech/is_in_range(var/mob/user)
+	if(user == mech.occupant)
+		return TRUE
+	return FALSE
 
 #undef MAX_PRESSURE

--- a/code/game/machinery/atmoalter/scrubber.dm
+++ b/code/game/machinery/atmoalter/scrubber.dm
@@ -150,7 +150,7 @@
 			//calculate the amount of moles in scrubbing_rate litres of gas in removed and apply the scrubbing rate limit
 			var/filter_moles = min(1, scrubbing_rate / volume_rate) * removed.total_moles()
 			var/datum/gas_mixture/filtered_out = total_to_filter.remove(filter_moles)
-			visible_message("DEBUG: Filtered [filtered_out.total_moles()] moles.")
+
 			removed.subtract(filtered_out)
 
 			//Remix the resulting gases

--- a/code/game/machinery/atmoalter/scrubber.dm
+++ b/code/game/machinery/atmoalter/scrubber.dm
@@ -1,4 +1,4 @@
-#define MAX_PRESSURE 9000
+#define MAX_PRESSURE 50*ONE_ATMOSPHERE
 
 /obj/machinery/portable_atmospherics/scrubber
 	name = "Portable Air Scrubber"
@@ -17,7 +17,7 @@
 	var/scrub_co2 = TRUE
 	var/scrub_plasma = TRUE
 
-	volume = 1000
+	volume = 2000
 
 /obj/machinery/portable_atmospherics/scrubber/emp_act(severity)
 	if(stat & (BROKEN|NOPOWER))

--- a/code/game/machinery/atmoalter/scrubber.dm
+++ b/code/game/machinery/atmoalter/scrubber.dm
@@ -1,4 +1,4 @@
-#define MAX_PRESSURE 50*ONE_ATMOSPHERE
+#define MAX_PRESSURE 9000
 
 /obj/machinery/portable_atmospherics/scrubber
 	name = "Portable Air Scrubber"

--- a/code/game/machinery/atmoalter/scrubber.dm
+++ b/code/game/machinery/atmoalter/scrubber.dm
@@ -1,3 +1,5 @@
+#define MAX_PRESSURE 50*ONE_ATMOSPHERE
+
 /obj/machinery/portable_atmospherics/scrubber
 	name = "Portable Air Scrubber"
 
@@ -111,7 +113,7 @@
 /obj/machinery/portable_atmospherics/scrubber/process()
 	..()
 
-	if(on)
+	if(on && air_contents.return_pressure() < MAX_PRESSURE)
 		var/datum/gas_mixture/environment = get_environment()
 		var/transfer_moles = min(1, volume_rate / environment.volume) * environment.total_moles()
 
@@ -212,3 +214,5 @@
 /obj/machinery/portable_atmospherics/scrubber/mech/return_sample(var/environment, var/removed)
 	var/turf/T = get_turf(src)
 	T.assume_air(removed)
+
+#undef MAX_PRESSURE

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -370,8 +370,8 @@ Class Procs:
 
 /obj/machinery/proc/is_in_range(var/mob/user)
 	if((!in_range(src, usr) || !istype(src.loc, /turf)) && !istype(usr, /mob/living/silicon))
-		return TRUE
-	return FALSE
+		return FALSE
+	return TRUE
 
 /obj/machinery/Topic(href, href_list)
 	..()

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -362,6 +362,17 @@ Class Procs:
 			update_multitool_menu(usr)
 			return 1
 
+/obj/machinery/proc/is_on_same_z(var/mob/user)
+	var/turf/T = get_turf(user)
+	if(!isAI(user) && T.z != z && user.z != map.zCentcomm)
+		return FALSE
+	return TRUE
+
+/obj/machinery/proc/is_in_range(var/mob/user)
+	if((!in_range(src, usr) || !istype(src.loc, /turf)) && !istype(usr, /mob/living/silicon))
+		return TRUE
+	return FALSE
+
 /obj/machinery/Topic(href, href_list)
 	..()
 	if(stat & (NOPOWER|BROKEN))
@@ -377,12 +388,10 @@ Class Procs:
 		if (!usr.dexterity_check())
 			to_chat(usr, "<span class='warning'>You don't have the dexterity to do this!</span>")
 			return 1
-		var/turf/T = get_turf(usr)
-		if(!isAI(usr) && T.z != z)
-			if(usr.z != map.zCentcomm)
-				to_chat(usr, "<span class='warning'>WARNING: Unable to interface with \the [src.name].</span>")
-				return 1
-		if ((!in_range(src, usr) || !istype(src.loc, /turf)) && !istype(usr, /mob/living/silicon))
+		if(!is_on_same_z(usr))
+			to_chat(usr, "<span class='warning'>WARNING: Unable to interface with \the [src.name].</span>")
+			return 1
+		if(!is_in_range(usr))
 			to_chat(usr, "<span class='warning'>WARNING: Connection failure. Reduce range.</span>")
 			return 1
 	else if(!custom_aghost_alerts)

--- a/code/game/mecha/working/clarke.dm
+++ b/code/game/mecha/working/clarke.dm
@@ -63,7 +63,7 @@
 /obj/mecha/working/clarke/connect()
 	if(scrubber_port)
 		return 0
-	..()
+	return ..()
 
 /obj/mecha/working/clarke/proc/connect_scrubber(obj/machinery/atmospherics/unary/portables_connector/new_port)
 	//Make sure not already connected to something else
@@ -97,7 +97,7 @@
 						<div class='links'>
 						<a href='?src=\ref[src];scrubber_interface=1'>Scrubber interface</a>
 						<br>
-						[src.scrubber_port ? "<a href='?src=\ref[src];scrubber_disconnect=1'>Disconnect Scrubber to Port</a>" : "<a href='?src=\ref[src];scrubber_connect=1'>Connect Scrubber to Port</a>"]
+						<span id="scrubbing_port">[src.scrubber_port ? "<a href='?src=\ref[src];scrubber_disconnect=1'>Disconnect Scrubber to Port</a>" : "<a href='?src=\ref[src];scrubber_connect=1'>Connect Scrubber to Port</a>"]</span>
 						</div>
 						</div>
 						"}
@@ -118,6 +118,7 @@
 		if(possible_port)
 			if(connect_scrubber(possible_port))
 				src.occupant_message("<span class='notice'>[name] connects to the port.</span>")
+				send_byjax(src.occupant, "exosuit.browser", "scrubbing_port", src.scrubber_port ? "<a href='?src=\ref[src];scrubber_disconnect=1'>Disconnect Scrubber from Port</a>" : "<a href='?src=\ref[src];scrubber_connect=1'>Connect Scrubber to Port</a>")
 			else
 				src.occupant_message("<span class='warning'>[name] failed to connect to the port.</span>")
 		else
@@ -128,6 +129,7 @@
 			return
 		if(disconnect_scrubber())
 			src.occupant_message("<span class='notice'>[name] disconnects from the port.</span>")
+			send_byjax(src.occupant, "exosuit.browser", "scrubbing_port", src.scrubber_port ? "<a href='?src=\ref[src];scrubber_disconnect=1'>Disconnect Scrubber from Port</a>" : "<a href='?src=\ref[src];scrubber_connect=1'>Connect Scrubber to Port</a>")
 		else
 			src.occupant_message("<span class='warning'>[name] is not connected to the port at the moment.</span>")
 		return

--- a/code/game/mecha/working/clarke.dm
+++ b/code/game/mecha/working/clarke.dm
@@ -14,6 +14,7 @@
 	var/image/thruster_overlay
 	var/overlay_applied = FALSE
 	var/obj/machinery/portable_atmospherics/scrubber/mech/scrubber
+	var/obj/machinery/atmospherics/unary/portables_connector/scrubber_port = null
 
 /obj/mecha/working/clarke/New()
 	..()
@@ -27,6 +28,12 @@
 
 /obj/mecha/working/clarke/check_for_support()
 	return 1
+
+/obj/mecha/working/clarke/relaymove()
+	if(scrubber_port)
+		occupant_message("Unable to move while connected to the air system port.", TRUE)
+		return 0
+	..()
 
 /obj/mecha/working/clarke/mechturn(direction)
 	dir = direction
@@ -53,11 +60,44 @@
 /obj/mecha/working/clarke/startMechWalking()
 	icon_state = initial_icon + "-move"
 
+/obj/mecha/working/clarke/connect()
+	if(scrubber_port)
+		return 0
+	..()
+
+/obj/mecha/working/clarke/proc/connect_scrubber(obj/machinery/atmospherics/unary/portables_connector/new_port)
+	//Make sure not already connected to something else
+	if(connected_port || scrubber_port || !new_port || new_port.connected_device)
+		return 0
+
+	//Make sure are close enough for a valid connection
+	if(new_port.loc != src.loc)
+		return 0
+
+	//Perform the connection
+	scrubber_port = new_port
+	scrubber.connect(new_port)
+
+	log_message("Connected to gas port.")
+	return 1
+
+/obj/mecha/working/clarke/proc/disconnect_scrubber()
+	if(!scrubber_port)
+		return 0
+
+	scrubber.disconnect()
+
+	scrubber_port = null
+	src.log_message("Disconnected from gas port.")
+	return 1
+
 /obj/mecha/working/clarke/get_commands()
 	var/output = {"<div class='wr'>
 						<div class='header'>Special</div>
 						<div class='links'>
 						<a href='?src=\ref[src];scrubber_interface=1'>Scrubber interface</a>
+						<br>
+						[src.scrubber_port ? "<a href='?src=\ref[src];scrubber_disconnect=1'>Disconnect Scrubber to Port</a>" : "<a href='?src=\ref[src];scrubber_connect=1'>Connect Scrubber to Port</a>"]
 						</div>
 						</div>
 						"}
@@ -65,7 +105,30 @@
 	return output
 
 /obj/mecha/working/clarke/Topic(href, href_list)
-	..()
+	. = ..()
 	if (href_list["scrubber_interface"])
+		if(usr != src.occupant)
+			return
 		scrubber.ui_interact(occupant)
+		return
+	if (href_list["scrubber_connect"])
+		if(usr != src.occupant)
+			return
+		var/obj/machinery/atmospherics/unary/portables_connector/possible_port = locate(/obj/machinery/atmospherics/unary/portables_connector/) in loc
+		if(possible_port)
+			if(connect_scrubber(possible_port))
+				src.occupant_message("<span class='notice'>[name] connects to the port.</span>")
+			else
+				src.occupant_message("<span class='warning'>[name] failed to connect to the port.</span>")
+		else
+			src.occupant_message("Nothing happens")
+		return
+	if (href_list["scrubber_disconnect"])
+		if(usr != src.occupant)
+			return
+		if(disconnect_scrubber())
+			src.occupant_message("<span class='notice'>[name] disconnects from the port.</span>")
+		else
+			src.occupant_message("<span class='warning'>[name] is not connected to the port at the moment.</span>")
+		return
 	return

--- a/code/game/mecha/working/clarke.dm
+++ b/code/game/mecha/working/clarke.dm
@@ -57,7 +57,7 @@
 	var/output = {"<div class='wr'>
 						<div class='header'>Special</div>
 						<div class='links'>
-						<a href='?src=\ref[src];scrubbing=1'><span id="scrubbing_command">[scrubber.on?"Deactivate":"Activate"] scrubber</span></a>
+						<a href='?src=\ref[src];scrubber_interface=1'>Scrubber interface</a>
 						</div>
 						</div>
 						"}
@@ -66,8 +66,6 @@
 
 /obj/mecha/working/clarke/Topic(href, href_list)
 	..()
-	if (href_list["scrubbing"])
-		scrubber.on = !scrubber.on
-		send_byjax(src.occupant,"exosuit.browser","scrubbing_command","[scrubber.on?"Deactivate":"Activate"] scrubber")
-		src.occupant_message("<font color=\"[scrubber.on?"#00f\">Activated":"#f00\">Deactivated"] scrubber.</font>")
+	if (href_list["scrubber_interface"])
+		scrubber.ui_interact(occupant)
 	return

--- a/nano/templates/portscrubber.tmpl
+++ b/nano/templates/portscrubber.tmpl
@@ -41,8 +41,21 @@
 	<div class="item">&nbsp;</div>
 {{/if}}
 
-
 <h3>Power Regulator Status</h3>
+
+<div class="item">
+	<div class="itemLabel">
+		Scrubbing Gases:
+	</div>
+	<div class="itemContent">
+		{{:helper.link('CO<sub>2</sub>', null, {'scrub_toggle': 'co2'}, null, data.scrub_co2 ? 'greenBackground' : null)}}
+		{{:helper.link('Plasma', null, {'scrub_toggle': 'plasma'}, null, data.scrub_plasma ? 'greenBackground' : null)}}
+		{{:helper.link('N<sub>2</sub>O', null, {'scrub_toggle': 'n2o'}, null, data.scrub_n2o ? 'greenBackground' : null)}}
+		{{:helper.link('N<sub>2</sub>', null, {'scrub_toggle': 'n2'}, null, data.scrub_n2 ? 'greenBackground' : null)}}
+		{{:helper.link('O<sub>2</sub>', null, {'scrub_toggle': 'o2'}, null, data.scrub_o2 ? 'greenBackground' : null)}}
+	</div>
+</div>
+
 <div class="item">
 	<div class="itemLabel">
 		Power Switch:

--- a/nano/templates/portscrubber.tmpl
+++ b/nano/templates/portscrubber.tmpl
@@ -45,26 +45,6 @@
 <h3>Power Regulator Status</h3>
 <div class="item">
 	<div class="itemLabel">
-		Volume Rate:
-	</div>
-	<div class="itemContent">
-		{{:helper.displayBar(data.rate, data.minrate, data.maxrate)}}
-		<div style="clear: both; padding-top: 4px;">
-			{{:helper.link('-', null, {'volume_adj' : -1000}, (data.rate > data.minrate) ? null : 'disabled')}}
-			{{:helper.link('-', null, {'volume_adj' : -100}, (data.rate > data.minrate) ? null : 'disabled')}}
-			{{:helper.link('-', null, {'volume_adj' : -10}, (data.rate > data.minrate) ? null : 'disabled')}}
-			{{:helper.link('-', null, {'volume_adj' : -1}, (data.rate > data.minrate) ? null : 'disabled')}}
-			<div style="float: left; width: 80px; text-align: center;">&nbsp;{{:data.rate}} kPa&nbsp;</div>
-			{{:helper.link('+', null, {'volume_adj' : 1}, (data.rate < data.maxrate) ? null : 'disabled')}}
-			{{:helper.link('+', null, {'volume_adj' : 10}, (data.rate < data.maxrate) ? null : 'disabled')}}
-			{{:helper.link('+', null, {'volume_adj' : 100}, (data.rate < data.maxrate) ? null : 'disabled')}}
-			{{:helper.link('+', null, {'volume_adj' : 1000}, (data.rate < data.maxrate) ? null : 'disabled')}}
-		</div>
-	</div>
-</div>
-
-<div class="item">
-	<div class="itemLabel">
 		Power Switch:
 	</div>
 	<div class="itemContent">


### PR DESCRIPTION
[featureloss] [tweak]

These things are very bad. They're about as effective as the regular scrubbers that passively scrub into the waste loop, which is IMO unacceptable for an active solution. In practice this translates to taking about 10-15 minutes, depending on room size, to clear a single plasma canister leak.

This PR makes these much faster. The details are a little complicated (keep reading if you're interested), but in practice it now takes about 3-5 minutes to clear a single plasma canister leak from a medium sized room. I also added the option to change which gases they scrub, which involved removing the speed setting to keep the UI from being cluttered (not a big loss, because there's never a reason to run these at anything but max power).

I also imposed a 50 ATM (5066.25 kPa) pressure limit on these and increased their tank volume to 2000 litres from 750 litres. In practice this means that they can hold about 40 tiles worth of standard pressure air.

![1558214174812](https://user-images.githubusercontent.com/5822375/57985318-aa14ec80-7a6e-11e9-8bdd-d04c2413fd64.png)

## The details

These now take a 5000 litre sample of air from the room. From that sample, they remove up to 300 litres of the gases they're set to scrub, and return the rest back into the room. Before this PR they took a sample of 1013 litres and removed all contaminants from it.

In practice this means that compared to their current behaviour, the new behaviour is slower at gas concentrations of 30% or more, but faster at gas concentrations below that. When gas concentrations get very low, the new behaviour is substantially (up to about 5 times) faster.

The reason it works this way is that the scrubber can now be set to scrub anything, including oxygen and nitrogen, and without this limit it could be used to drain rooms of their air very rapidly.

The Clarke scrubber and the Huge Air Scrubber have a sample size of 20000 (this number is unchanged by me) and remove up to 1200 litres per tick. This may sound like a lot, but it's only 20% more than a single scrubber set to syphon.

:cl:
 * tweak: Portable air scrubbers now scrub up to 5 times faster than they used to and have a larger tank (2000 litres). They now have a pressure limit of 5066.25 kPa.
 * rscadd: Portable scrubbers now have a gas selection.
 * rscadd: The Clarke scrubber now has an accessible interface and can be connected to a connector port to drain its contents.