### PR TITLE
Emag not emagging living human limbs fix

### DIFF
--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -430,3 +430,17 @@
 	else
 		client.screen -= hud_used.hotkeybuttons
 		hud_used.hotkey_ui_hidden = 1
+
+//this method handles user getting attacked with an emag - the original logic was in human_defense.dm,
+//but it's better that it belongs to human.dm 
+/mob/living/carbon/human/emag_act(var/mob/attacker, var/datum/organ/external/affecting, var/obj/item/weapon/card/emag)
+	var/hit_area = affecting.display_name
+	if(!(affecting.status & ORGAN_ROBOT))
+		to_chat(attacker, "<span class='warning'>That limb isn't robotic.</span>")
+		return FALSE
+	if(affecting.sabotaged)
+		to_chat(attacker, "<span class='warning'>\The [src]'s [hit_area] is already sabotaged!</span>")
+	else
+		to_chat(attacker, "<span class='warning'>You sneakily slide [emag] into the dataport on \the [src]'s [hit_area] and short out the safeties.</span>")
+		affecting.sabotaged = TRUE
+	return FALSE

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -163,11 +163,21 @@
 	if(recharge_rate && recharge_ticks)
 		to_chat(user, "<span class=\"info\">A small label on a thermocouple notes that it recharges at a rate of [recharge_rate]MJ for every [recharge_ticks<=1?"":"[recharge_ticks] "]oscillator tick[recharge_ticks>1?"s":""].</span>")
 
-/obj/item/weapon/card/emag/attack()
+//only trigger if target is human thus having prosthetic limbs to sabotage
+//allowing this method to continue ensures attacked_by is called in human_defense.dm
+/obj/item/weapon/card/emag/attack(var/mob/living/target)
+	to_chat(world, "170 attack target: [target]")
 	return
+	if (!istype(target, /mob/living/carbon/human))
+		return
+	..()
 
+//this method gets called from held_item.afterattack as it should, but in the case of somebody with emag clicking on a human we don't want this method to trigger,
+//since the logic for emag attack on humans is handled in attacked_by in human_defense.dm
 /obj/item/weapon/card/emag/afterattack(atom/target, mob/user, proximity)
 	var/atom/A = target
+	if (istype(target, /mob/living/carbon/human)) 
+		return
 	if(!proximity)
 		return
 	A.emag_act(user)

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -163,11 +163,11 @@
 	if(recharge_rate && recharge_ticks)
 		to_chat(user, "<span class=\"info\">A small label on a thermocouple notes that it recharges at a rate of [recharge_rate]MJ for every [recharge_ticks<=1?"":"[recharge_ticks] "]oscillator tick[recharge_ticks>1?"s":""].</span>")
 
-//dont perform emag stuff in this method
+//don't perform emag_act() stuff in this method
 /obj/item/weapon/card/emag/attack()
 	return
 
-//perform individual emag_act stuff on children overriding the method here 
+//perform individual emag_act() stuff on children overriding the method here 
 /obj/item/weapon/card/emag/afterattack(var/atom/target, mob/user, proximity)
 	if(!proximity)
 		return

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -166,8 +166,6 @@
 //only trigger if target is human thus having prosthetic limbs to sabotage
 //allowing this method to continue ensures attacked_by is called in human_defense.dm
 /obj/item/weapon/card/emag/attack(var/mob/living/target)
-	to_chat(world, "170 attack target: [target]")
-	return
 	if (!istype(target, /mob/living/carbon/human))
 		return
 	..()

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -164,14 +164,17 @@
 		to_chat(user, "<span class=\"info\">A small label on a thermocouple notes that it recharges at a rate of [recharge_rate]MJ for every [recharge_ticks<=1?"":"[recharge_ticks] "]oscillator tick[recharge_ticks>1?"s":""].</span>")
 
 //only trigger if target is human thus having prosthetic limbs to sabotage
-//allowing this method to continue ensures attacked_by is called in human_defense.dm
-/obj/item/weapon/card/emag/attack(var/mob/living/target)
+/obj/item/weapon/card/emag/attack(var/mob/living/target, var/mob/living/attacker)
 	if (!istype(target, /mob/living/carbon/human))
 		return
-	..()
+	//get target zone with 0% chance of missing
+	var/zone = ran_zone(attacker.zone_sel.selecting, 100)
+	var/datum/organ/external/organ = target.get_organ(zone)
+	target.emag_act(attacker, organ, src)
+	return
 
 //this method gets called from held_item.afterattack as it should, but in the case of somebody with emag clicking on a human we don't want this method to trigger,
-//since the logic for emag attack on humans is handled in attacked_by in human_defense.dm
+//since the logic for emag attack is in emag/attack
 /obj/item/weapon/card/emag/afterattack(atom/target, mob/user, proximity)
 	var/atom/A = target
 	if (istype(target, /mob/living/carbon/human)) 

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -163,25 +163,22 @@
 	if(recharge_rate && recharge_ticks)
 		to_chat(user, "<span class=\"info\">A small label on a thermocouple notes that it recharges at a rate of [recharge_rate]MJ for every [recharge_ticks<=1?"":"[recharge_ticks] "]oscillator tick[recharge_ticks>1?"s":""].</span>")
 
-//only trigger if target is human thus having prosthetic limbs to sabotage
-/obj/item/weapon/card/emag/attack(var/mob/living/target, var/mob/living/attacker)
-	if (!istype(target, /mob/living/carbon/human))
-		return
-	//get target zone with 0% chance of missing
-	var/zone = ran_zone(attacker.zone_sel.selecting, 100)
-	var/datum/organ/external/organ = target.get_organ(zone)
-	target.emag_act(attacker, organ, src)
+//dont perform emag stuff in this method
+/obj/item/weapon/card/emag/attack()
 	return
 
-//this method gets called from held_item.afterattack as it should, but in the case of somebody with emag clicking on a human we don't want this method to trigger,
-//since the logic for emag attack is in emag/attack
-/obj/item/weapon/card/emag/afterattack(atom/target, mob/user, proximity)
-	var/atom/A = target
-	if (istype(target, /mob/living/carbon/human)) 
-		return
+//perform individual emag_act stuff on children overriding the method here 
+/obj/item/weapon/card/emag/afterattack(var/atom/target, mob/user, proximity)
 	if(!proximity)
 		return
-	A.emag_act(user)
+	if (istype(target, /mob/living/carbon/human)) 
+		var/mob/living/carbon/target_living = target
+		//get target zone with 0% chance of missing
+		var/zone = ran_zone(user.zone_sel.selecting, 100)
+		var/datum/organ/external/organ = target_living.get_organ(zone)
+		target_living.emag_act(user, organ, src)
+		return
+	target.emag_act(user)
 
 /obj/item/weapon/card/id
 	name = "identification card"

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -209,16 +209,7 @@ emp_act
 	var/hit_area = affecting.display_name
 
 	if(istype(I,/obj/item/weapon/card/emag))
-		if(!(affecting.status & ORGAN_ROBOT))
-			to_chat(user, "<span class='warning'>That limb isn't robotic.</span>")
-			return FALSE
-		if(affecting.sabotaged)
-			to_chat(user, "<span class='warning'>\The [src]'s [hit_area] is already sabotaged!</span>")
-		else
-			to_chat(user, "<span class='warning'>You sneakily slide [I] into the dataport on \the [src]'s [hit_area] and short out the safeties.</span>")
-			affecting.sabotaged = TRUE
-		return FALSE
-
+		return src.emag_act(user, affecting, I)
 
 	if(istype(I.attack_verb, /list) && I.attack_verb.len && !(I.flags & NO_ATTACK_MSG))
 		visible_message("<span class='danger'>\The [user] [pick(I.attack_verb)] \the [src] in \the [hit_area] with \the [I]!</span>", \

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -208,9 +208,6 @@ emp_act
 		return FALSE
 	var/hit_area = affecting.display_name
 
-	if(istype(I,/obj/item/weapon/card/emag))
-		return src.emag_act(user, affecting, I)
-
 	if(istype(I.attack_verb, /list) && I.attack_verb.len && !(I.flags & NO_ATTACK_MSG))
 		visible_message("<span class='danger'>\The [user] [pick(I.attack_verb)] \the [src] in \the [hit_area] with \the [I]!</span>", \
 			"<span class='userdanger'>\The [user] [pick(I.attack_verb)] you in \the [hit_area] with \the [I]!</span>")


### PR DESCRIPTION
[bugfix][oversight]

fixes bug we found with @SonixApache in #22955

The functionality to emag living people was there, but it didn't work, since the `attack()` method in the emag class returned void. Now the method properly checks if the target is human ~~allowing the logic to pass to `attacked_by` in `human_defense.dm`.~~ gets the organ target and passes it to `emag_act()`. I took the old logic that was hardcoded in `human_defense.dm` and made it override `emag_act()` in `human.dm`,  where it should have been in the first place. ~~Miss chance and all that still applies as the old logic was.~~

![emag_fix](https://user-images.githubusercontent.com/24612466/57982331-8e98ea00-7a4c-11e9-9182-49032401cec2.gif)

EDIT:

0% miss chance

![emag_fix](https://user-images.githubusercontent.com/24612466/57984725-57840200-7a67-11e9-9adb-8d8ac29141ce.gif)


:cl:
 * bugfix: Fixed a bug which prevented emagging prosthetic limbs on living people