### PR TITLE
Scrubber siphoning fix

### DIFF
--- a/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
@@ -211,7 +211,7 @@
 		if (air_contents.return_pressure()>=MAX_PRESSURE)
 			return
 
-		var/transfer_moles = environment.total_moles()*(volume_rate/environment.volume)
+		var/transfer_moles = min(1, volume_rate / environment.volume) * environment.total_moles
 
 		var/datum/gas_mixture/removed = loc.remove_air(transfer_moles)
 

--- a/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
@@ -166,7 +166,7 @@
 			(scrub_N2 && environment[GAS_NITROGEN] > 0))
 			if (air_contents.return_pressure()>=MAX_PRESSURE)
 				return
-			var/transfer_moles = min(1, volume_rate / environment.volume) * environment.total_moles()
+			var/transfer_moles = min(1, volume_rate / environment.volume) * environment.total_moles
 
 			//Take a gas sample
 			var/datum/gas_mixture/removed = loc.remove_air(transfer_moles)

--- a/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
@@ -166,7 +166,7 @@
 			(scrub_N2 && environment[GAS_NITROGEN] > 0))
 			if (air_contents.return_pressure()>=MAX_PRESSURE)
 				return
-			var/transfer_moles = min(1, volume_rate / environment.volume) * environment.total_moles
+			var/transfer_moles = min(1, volume_rate / environment.volume) * environment.total_moles()
 
 			//Take a gas sample
 			var/datum/gas_mixture/removed = loc.remove_air(transfer_moles)


### PR DESCRIPTION
[consistency]

There was a minor consistency issue here where scrubbers could siphon too fast if `environment.volume` was less than 1000. I don't think this could ever happen in practice, because `CELL_VOLUME` is 2500, but sanity never hurt anyone. And I guess it could bite us in the ass if we add an extra large scrubber subtype some day that has a higher `volume_rate`.