### PR TITLE
Openning and flicking cult tome pages now does somes low volume short-range noise

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult_items.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_items.dm
@@ -113,6 +113,7 @@ var/list/arcane_tomes = list()
 	if(href_list["page"])
 		current_page = text2num(href_list["page"])
 		flick("tome-flick",src)
+		playsound(usr, "pageturn", 50, 1, -5)
 
 	if(href_list["talisman"])
 		var/obj/item/weapon/talisman/T = locate(href_list["talisman"])
@@ -195,6 +196,7 @@ var/list/arcane_tomes = list()
 			icon_state = "tome-open"
 			item_state = "tome-open"
 			flick("tome-flickopen",src)
+			playsound(user, "pageturn", 50, 1, -5)
 			state = TOME_OPEN
 			usr << browse_rsc('icons/tomebg.png', "tomebg.png")
 			usr << browse(tome_text(), "window=arcanetome;size=537x375")
@@ -215,6 +217,7 @@ var/list/arcane_tomes = list()
 		if (Adjacent(user))
 			to_chat(user, "You flick a page.")
 			flick("tome-flick",src)
+			playsound(user, "pageturn", 50, 1, -3)
 			can_flick = 0
 			spawn(5)
 				can_flick = 1
@@ -251,6 +254,7 @@ var/list/arcane_tomes = list()
 		icon_state = "tome-open"
 		item_state = "tome-open"
 		flick("tome-flickopen",src)
+		playsound(user, "pageturn", 50, 1, -5)
 		state = TOME_OPEN
 	var/choice = show_radial_menu(user,loc,choices,'icons/obj/cult_radial3.dmi', "radial-cult2")
 	if(!choice_to_talisman[choice])

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_spells.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_spells.dm
@@ -88,6 +88,7 @@
 				tome.icon_state = "tome-open"
 				tome.item_state = "tome-open"
 				flick("tome-flickopen",tome)
+				playsound(user, "pageturn", 50, 1, -5)
 				tome.state = TOME_OPEN
 			var/spell_name = input(user,"Draw a rune with the help of the Arcane Tome.", "Trace Complete Rune", null) as null|anything in available_runes
 			spell = available_runes[spell_name]

--- a/code/game/objects/items/weapons/storage/bible.dm
+++ b/code/game/objects/items/weapons/storage/bible.dm
@@ -14,6 +14,7 @@
 	var/mob/affecting = null
 	var/datum/religion/my_rel = new /datum/religion
 	actions_types = list(/datum/action/item_action/convert)
+	rustle_sound = "pageturn"
 
 	autoignition_temperature = 522 // Kelvin
 	fire_fuel = 2

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -30,12 +30,13 @@
 	var/foldable_amount = 1 // Number of foldables to produce, if any - N3X
 	var/internal_store = 0
 	var/list/no_storage_slot = new/list()//if the item is equipped in a slot that is contained in this list, the item will act purely as a clothing item and not a storage item (ie plastic bags over head)
+	var/rustle_sound = "rustle"
 
 /obj/item/weapon/storage/proc/can_use()
 	return TRUE
 
 /obj/item/weapon/storage/on_mousedrop_to_inventory_slot()
-	playsound(src, "rustle", 50, 1, -5)
+	playsound(src, rustle_sound, 50, 1, -5)
 
 /obj/item/weapon/storage/MouseDropFrom(obj/over_object as obj)
 	if(over_object == usr && (in_range(src, usr) || is_holder_of(usr, src)))
@@ -438,7 +439,7 @@
 	..()
 
 /obj/item/weapon/storage/attack_hand(mob/user as mob)
-	playsound(src, "rustle", 50, 1, -5)
+	playsound(src, rustle_sound, 50, 1, -5)
 
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -225,6 +225,8 @@
 	if(carved)
 		to_chat(user, "<span class='notice'>The pages of [title] have been cut out!</span>")
 		return
+	if (!isobserver(user))
+		playsound(user, "pageturn", 50, 1, -5)
 	if(src.dat)
 		user << browse("<TT><I>Penned by [author].</I></TT> <BR>" + "[dat]", "window=book")
 		if(!isobserver(user))


### PR DESCRIPTION
Because we've had those sound files in the game since forever but they're only used by newspaper that nobody ever prints.

:cl:
* rscadd: Added some page turning sounds when flicking the pages of arcane tomes. Can be heard up to 2 tiles away. 3 tiles if the tome was on the ground and a ghost did the flicking.