### PR TITLE
fix ninja throw and species runtime

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
@@ -140,7 +140,11 @@
 	newninja.Greet(GREET_DEFAULT)
 	newninja.OnPostSetup()
 	newninja.AnnounceObjectives()
+	spawn(5)
+		newninja.antag.current.ThrowAtStation()
 	return 1
+	
+
 
 //////////////////////////////////////////////
 //                                          //

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -457,7 +457,16 @@
 	if (required_candidates > (dead_players.len + list_observers.len))
 		return 0
 	return ..()
-
+	
+/datum/dynamic_ruleset/midround/from_ghosts/ninja/setup_role(var/datum/role/newninja)
+	newninja.OnPostSetup()
+	newninja.Greet(GREET_MIDROUND)
+	newninja.ForgeObjectives()
+	newninja.AnnounceObjectives()
+	spawn(5)
+		newninja.antag.current.ThrowAtStation()
+	return 1
+	
 //////////////////////////////////////////////
 //                                          //
 //         RAMBLER       (MIDROUND)         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/code/datums/gamemode/misc_gamemode_procs.dm
+++ b/code/datums/gamemode/misc_gamemode_procs.dm
@@ -368,6 +368,7 @@
 /proc/equip_ninja(var/mob/living/carbon/human/spaceninja)
 	if(!istype(spaceninja))
 		return 0
+	sleep(1) //so non-humans don't runtime
 	if(!isjusthuman(spaceninja))
 		spaceninja = spaceninja.Humanize("Human")
 	spaceninja.delete_all_equipped_items()

--- a/code/datums/gamemode/role/ninja.dm
+++ b/code/datums/gamemode/role/ninja.dm
@@ -79,7 +79,6 @@
 		else
 			to_chat(antag.current, "<img src='data:image/png;base64,[icon2base64(logo)]' style='position: relative; top: 10;'/> <span class='danger'>You are a Space Ninja.<br>The Spider Clan has been insulted for the last time. Send Nanotrasen a message. You are forbidden by your code to use guns, do not forget!</span>")
 			to_chat(antag.current, "<span class='danger'>You are currently on a direct course to the station. Find a way inside before your suit's life support systems give out.</span>")
-			antag.current.ThrowAtStation()
 
 	to_chat(antag.current, "<span class='info'><a HREF='?src=\ref[antag.current];getwiki=[wikiroute]'>(Wiki Guide)</a></span>")
 


### PR DESCRIPTION
closes #23001

+ fixed the runtimes by adding a small sleep, might just use generate_ruleset_body later
+ fixed the throw, it was just an order of operations issue

This was tested a lot more than the initial and I'm relatively sure it actually all works as intended now.
