### PR TITLE
MAGPULSE clothing flag instead of hard magboot checks

### DIFF
--- a/__DEFINES/clothing.dm
+++ b/__DEFINES/clothing.dm
@@ -4,7 +4,7 @@
 
 //clothing flags
 #define MASKINTERNALS		1 // mask allows internals
-#define NOSLIP				2 //prevents from slipping on wet floors, in space etc
+#define NOSLIP				2 //prevents from slipping on wet floors, etc
 #define BLOCK_GAS_SMOKE_EFFECT 4 //blocks the effect that chemical clouds would have on a mob
 #define ONESIZEFITSALL		8
 #define PLASMAGUARD 		16 //Does not get contaminated by plasma.
@@ -13,3 +13,4 @@
 #define CANEXTINGUISH 		128
 #define CONTAINPLASMAMAN 	256
 #define IGNORE_LUBE			512
+#define MAGPULSE			1024 //prevents slipping in space, singulo pulling, etc

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -448,6 +448,7 @@
 	var/chaintype = null // Type of chain.
 	var/bonus_kick_damage = 0
 	var/footprint_type = /obj/effect/decal/cleanable/blood/tracks/footprints //The type of footprint left by someone wearing these
+	var/mag_slow = MAGBOOTS_SLOWDOWN_HIGH //how slow are they when the magpulse is on?
 
 	siemens_coefficient = 0.9
 	body_parts_covered = FEET
@@ -477,6 +478,18 @@
 	. = ..()
 	track_blood = 0
 
+/obj/item/clothing/shoes/proc/togglemagpulse(var/mob/user = usr)
+	if(user.isUnconscious())
+		return
+	if((clothing_flags & MAGPULSE))
+		clothing_flags &= ~(NOSLIP | MAGPULSE)
+		slowdown = NO_SLOWDOWN
+		return 0
+	else
+		clothing_flags |= (NOSLIP | MAGPULSE)
+		slowdown = mag_slow
+		return 1
+	
 //Suit
 /obj/item/clothing/suit
 	icon = 'icons/obj/clothing/suits.dmi'

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -3,8 +3,6 @@
 	name = "magboots"
 	icon_state = "magboots0"
 	var/base_state = "magboots"
-	var/magpulse = 0
-	var/mag_slow = MAGBOOTS_SLOWDOWN_HIGH
 //	clothing_flags = NOSLIP //disabled by default
 	actions_types = list(/datum/action/item_action/toggle_magboots)
 	species_fit = list(VOX_SHAPED)
@@ -22,7 +20,7 @@
 	set category = "Object"
 	if (!usr || loc != usr)
 		return
-	return toggle(usr) // Sanity is handled there.
+	return togglemagpulse(usr) // Sanity is handled there.
 
 /obj/item/clothing/shoes/magboots/on_kick(mob/living/carbon/human/user, mob/living/victim)
 	if(!stomp_attack_power)
@@ -31,14 +29,14 @@
 	var/turf/T = get_turf(src)
 	var/datum/organ/external/affecting = victim.get_organ(user.get_unarmed_damage_zone(victim))
 
-	if(magpulse && victim.lying && T == victim.loc && !istype(T, /turf/space)) //To stomp on somebody, you have to be on the same tile as them. You can't be in space, and they have to be lying
+	if((clothing_flags & MAGPULSE) && victim.lying && T == victim.loc && !istype(T, /turf/space)) //To stomp on somebody, you have to be on the same tile as them. You can't be in space, and they have to be lying
 		//NUCLEAR MAGBOOT STUMP INCOMING (it takes 3 seconds)
 
 		user.visible_message("<span class='danger'>\The [user] slowly raises \his [stomp_boot] above the lying [victim.name], preparing to stomp on \him.</span>")
-		toggle(user)
+		togglemagpulse(user)
 
 		if(do_after(user, src, stomp_delay))
-			if(magpulse)
+			if((clothing_flags & MAGPULSE))
 				return //Magboots enabled
 			if(!victim.lying || (victim.loc != T))
 				return //Victim moved
@@ -52,35 +50,33 @@
 		else
 			return
 
-		toggle(user)
+		togglemagpulse(user)
 		playsound(victim, 'sound/mecha/mechstep.ogg', 100, 1)
 
-/obj/item/clothing/shoes/magboots/proc/toggle(var/mob/user = usr)
-	if(user.isUnconscious())
-		return
-	if(src.magpulse)
-		src.clothing_flags &= ~NOSLIP
-		src.slowdown = NO_SLOWDOWN
-		src.magpulse = 0
-		icon_state = "[base_state]0"
-		to_chat(user, "You disable the mag-pulse traction system.")
-	else
-		src.clothing_flags |= NOSLIP
-		src.slowdown = mag_slow
-		src.magpulse = 1
-		icon_state = "[base_state]1"
-		to_chat(user, "You enable the mag-pulse traction system.")
-	user.update_inv_shoes()	//so our mob-overlays update
-
 /obj/item/clothing/shoes/magboots/attack_self()
-	src.toggle()
+	src.togglemagpulse()
 	..()
 	return
 
+/obj/item/clothing/shoes/magboots/togglemagpulse(var/mob/user = usr)
+	if(user.isUnconscious())
+		return
+	if(clothing_flags & MAGPULSE)
+		clothing_flags &= ~(NOSLIP | MAGPULSE)
+		slowdown = NO_SLOWDOWN
+		icon_state = "[base_state]0"
+		to_chat(user, "You disable the mag-pulse traction system.")
+	else
+		clothing_flags |= (NOSLIP | MAGPULSE)
+		slowdown = mag_slow
+		icon_state = "[base_state]1"
+		to_chat(user, "You enable the mag-pulse traction system.")
+	user.update_inv_shoes()	//so our mob-overlays update
+	
 /obj/item/clothing/shoes/magboots/examine(mob/user)
 	..()
 	var/state = " disabled."
-	if(src.clothing_flags&NOSLIP)
+	if(src.clothing_flags&MAGPULSE)
 		state = " enabled."
 	to_chat(user, "<span class='info'>[anchoring_system_examine][state]</span>")
 
@@ -136,22 +132,22 @@
 	icon_state = "MAGNIFICENTboots0"
 	base_state = "MAGNIFICENTboots"
 
-/obj/item/clothing/shoes/magboots/captain/toggle(var/mob/user = usr)
+/obj/item/clothing/shoes/magboots/captain/togglemagpulse(var/mob/user = usr)
 	//set name = "Toggle Floor Grip"
 	if(user.isUnconscious())
 		return
-	if(src.magpulse)
-		src.clothing_flags &= ~NOSLIP
-		src.slowdown = NO_SLOWDOWN
-		src.magpulse = 0
+	if((clothing_flags & MAGPULSE))
+		clothing_flags &= ~(NOSLIP | MAGPULSE)
+		slowdown = NO_SLOWDOWN
 		icon_state = "[base_state]0"
 		to_chat(user, "You stop ruining the carpet.")
+		return 0
 	else
-		src.clothing_flags |= NOSLIP
-		src.slowdown = mag_slow
-		src.magpulse = 1
+		clothing_flags |= (NOSLIP | MAGPULSE)
+		slowdown = mag_slow
 		icon_state = "[base_state]1"
 		to_chat(user, "Small spikes shoot from your shoes and dig into the flooring, bracing you.")
+		return 1
 
 
 /obj/item/clothing/shoes/magboots/funk
@@ -162,7 +158,7 @@
 	var/funk_level = 0
 	canremove = 0
 
-/obj/item/clothing/shoes/magboots/funk/toggle(var/mob/user = usr)
+/obj/item/clothing/shoes/magboots/funk/togglemagpulse(var/mob/user = usr)
 	if(user.isUnconscious())
 		return
 	if(funk_level >= 11) //WE HAVE GONE TOO FAR, COMRADE
@@ -170,8 +166,7 @@
 	user.visible_message("<span class = 'warning'>[usr] dials up \the [src]'s funk level to [funk_level+1]</span>")
 	funk_level++
 	if(funk_level >= 2)
-		clothing_flags |= NOSLIP
-		magpulse = 1
+		clothing_flags |= (NOSLIP | MAGPULSE)
 
 /obj/item/clothing/shoes/magboots/funk/step_action()
 	..()
@@ -214,12 +209,11 @@
 		explosion(get_turf(src), round(((1*funk_level)+russian)*0.25), round(((1*funk_level)+russian)*0.5), round((1*funk_level)+russian))
 
 	if(prob((funk_level/russian)*2)) //IT WAS ALWAYS TOO LATE
-		toggle(H)
+		togglemagpulse(H)
 
 /obj/item/clothing/shoes/magboots/funk/OnMobDeath(var/mob/living/carbon/human/wearer)
 	var/mob/living/carbon/human/W = wearer
 	W.drop_from_inventory(src)
 	funk_level = 0
 	canremove = 1
-	clothing_flags &= ~NOSLIP
-	magpulse = 0
+	clothing_flags &= ~(NOSLIP | MAGPULSE)

--- a/code/modules/clothing/spacesuits/alien.dm
+++ b/code/modules/clothing/spacesuits/alien.dm
@@ -138,20 +138,20 @@
 
 	footprint_type = /obj/effect/decal/cleanable/blood/tracks/footprints/vox //They're like those five-toed shoes except for vox and with only three toes
 
-/obj/item/clothing/shoes/magboots/vox/toggle()
+/obj/item/clothing/shoes/magboots/vox/togglemagpulse()
 	//set name = "Toggle Floor Grip"
 	if(usr.isUnconscious())
 		return
-	if(src.magpulse)
-		src.clothing_flags &= ~NOSLIP
-		src.magpulse = 0
-		src.slowdown = NO_SLOWDOWN
+	if(clothing_flags & MAGPULSE)
+		clothing_flags &= ~(NOSLIP | MAGPULSE)
+		slowdown = NO_SLOWDOWN
 		to_chat(usr, "You retract the razor-sharp talons of your boots.")
+		return 0
 	else
-		src.clothing_flags |= NOSLIP
-		src.magpulse = 1
-		src.slowdown = mag_slow
+		clothing_flags |= (NOSLIP | MAGPULSE)
+		slowdown = mag_slow
 		to_chat(usr, "You extend the razor-sharp talons of your boots.")
+		return 1
 
 
 // Vox Trader -- Same stats as civ gear, but looks like raiders. ///////////////////////////////

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1271,9 +1271,7 @@
 /mob/living/carbon/human/canSingulothPull(var/obj/machinery/singularity/singulo)
 	if(!..())
 		return 0
-	if(istype(shoes,/obj/item/clothing/shoes/magboots))
-		var/obj/item/clothing/shoes/magboots/M = shoes
-		if(M.magpulse && singulo.current_size <= STAGE_FOUR)
+		if((shoes.clothing_flags & MAGPULSE) && singulo.current_size <= STAGE_FOUR)
 			return 0
 	return 1
 // Get ALL accesses available.

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -155,7 +155,7 @@
 		else
 			shoes_slip_factor = TRUE // Shoes are of no interest for this.
 
-	var/magboots_slip_factor = (!slip_on_magbooties && shoes_slip_factor && istype(shoes, /obj/item/clothing/shoes/magboots))
+	var/magboots_slip_factor = (!slip_on_magbooties && shoes_slip_factor && (shoes.clothing_flags & MAGPULSE))
 	. = ..()
 
 	// We have magboots, and magboots can protect us

--- a/code/modules/unit_tests/slipping.dm
+++ b/code/modules/unit_tests/slipping.dm
@@ -50,7 +50,7 @@
 				if (RESULT_MAGBOOTS)
 					var/obj/item/clothing/shoes/magboots/M = new
 					H.equip_or_collect(M, slot_shoes)
-					M.toggle(H)
+					M.togglemagpulse(H)
 			H.Move(T_test, NORTH)
 			if (H.isStunned() != items_and_result_humans[type][i])
 				fail("Slipping test failed at [type], step [i] ; expected [items_and_result_humans[type][i]], got [H.isStunned()]")
@@ -74,7 +74,7 @@
 				if (RESULT_MAGBOOTS)
 					var/obj/item/clothing/shoes/magboots/M = new
 					H.equip_or_collect(M, slot_shoes)
-					M.toggle(H)
+					M.togglemagpulse(H)
 			H.Move(T_test, NORTH)
 			if (H.isStunned() != overlays_and_results[wetness][j])
 				fail("Slipping test failed at [wetness], step [j] ; expected [overlays_and_results[wetness][j]], got [H.isStunned()]")


### PR DESCRIPTION
Moves all this shit up a bit so you can make any ~~clothing~~ shoes work like magboots.
Checks are still locked to shoes, so keep that in mind.
Saves me some headaches down the line.
Tested:
 - normal magboots, wet floors
 - workshoes, wet floors, togglemagpulse proc call
 - normal magboots, singulo pull