### PR TITLE
Buffs regeneration superpower by removing hunger penalty and giving more blood by default

### DIFF
--- a/code/game/dna/genes/powers.dm
+++ b/code/game/dna/genes/powers.dm
@@ -85,15 +85,6 @@
 /datum/dna/gene/basic/regenerate/New()
 	block=REGENERATEBLOCK
 
-/datum/dna/gene/basic/regenerate/activate(var/mob/living/carbon/human/H)
-	..()
-	H.calorie_burn_rate *= 2
-
-/datum/dna/gene/basic/regenerate/deactivate(var/mob/living/carbon/human/H)
-	if(..())
-		H.calorie_burn_rate /= 2
-
-
 /datum/dna/gene/basic/increaserun
 	name = "Super Speed"
 	activation_messages = list("Your leg muscles pulsate.")
@@ -206,9 +197,9 @@
 		return 1
 
 /datum/dna/gene/basic/heat_resist/OnDrawUnderlays(var/mob/M,var/g,var/fat)
-	if(isvox(M) || isskelevox(M))	
+	if(isvox(M) || isskelevox(M))
 		return "coldvox_s"
-	else	
+	else
 		return "cold[fat]_s"
 
 /datum/dna/gene/basic/cold_resist
@@ -303,7 +294,7 @@
 	block = TELEBLOCK
 
 /datum/dna/gene/basic/tk/OnDrawUnderlays(var/mob/M,var/g,var/fat)
-	if(isvox(M) || isskelevox(M))	
+	if(isvox(M) || isskelevox(M))
 		return "telekinesisheadvox_s"
-	else	
+	else
 		return "telekinesishead[fat]_s"

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -79,17 +79,19 @@ var/const/BLOOD_VOLUME_SURVIVE = 122
 							break
 
 				B.volume += 0.1 // regenerate blood VERY slowly
+				if(M_REGEN in mutations)
+					B.volume += 0.4 //A big chunky boost. If you have nutriment and iron you can regenerate 4.1 blood per tick
 				if (reagents.has_reagent(NUTRIMENT))	//Getting food speeds it up
 					if(M_REGEN in mutations)
 						B.volume += 1.2
-						reagents.remove_reagent(NUTRIMENT, 1.0)
+						reagents.remove_reagent(NUTRIMENT, 0.5)
 					else
 						B.volume += 0.6
 						reagents.remove_reagent(NUTRIMENT, 0.5)
 				if (reagents.has_reagent(IRON))	//Hematogen candy anyone?
 					if(M_REGEN in mutations)
 						B.volume += 2.4
-						reagents.remove_reagent(IRON, 1.0)
+						reagents.remove_reagent(IRON, 0.5)
 					else
 						B.volume += 1.2
 						reagents.remove_reagent(IRON, 0.5)

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -585,7 +585,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		// slow healing
 		var/heal_amt = 0
 
-		if(W.damage < 15) //This thing's edges are not in day's travel of each other, what healing?
+		if(W.damage < 15 || (M_REGEN in owner.mutations && W.damage <= 50)) //This thing's edges are not in day's travel of each other, what healing?
 			heal_amt += 0.2
 
 		if(W.is_treated() && W.damage < 50) //Whoa, not even magical band aid can hold it together


### PR DESCRIPTION
Healing doesn't happen much anyway unless wounds are treated
I should change how it works at some point in the future, making it regenerate limbs and stuff and with drawbacks or something
On the plus side the chef no longer goes bankrupt from not being able to provide the crew with enough food
:cl:
 * tweak: Regeneration superpower no longer makes you hungry faster, and now it gives a bit more blood by default when you don't have enough. It also no longer consumes more iron and nutriment, meaning you get more bang for your buck. You also start regenerating at a higher threshold (50 damage).