### PR TITLE
makes it more clear when cryo is empty

### DIFF
--- a/nano/templates/cryo.tmpl
+++ b/nano/templates/cryo.tmpl
@@ -96,7 +96,7 @@ Used In File(s): \code\game\machinery\cryo.dm
 				<span class="bad">Beaker is empty</span>
 			{{/if}}
 		{{else}}
-			<span class="average"><i>No beaker loaded</i></span>
+			<span class="bad"><i>No beaker loaded</i></span>
 		{{/if}}
 	</div>
 	<div class="itemContent" style="width: 26%;">


### PR DESCRIPTION
:cl:
* tweak: makes "no beaker loaded" red instead of orange on the cryo UI