### PR TITLE
Attacking machines and airlocks with objects leaves fingerprints and fibers

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1264,7 +1264,7 @@ About the new airlock wires panel:
 			operating = -1
 	else
 		..(I, user)
-
+	add_fingerprint(user)
 	return
 
 /obj/machinery/door/airlock/proc/bashed_in(var/mob/user)

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -568,6 +568,9 @@ Class Procs:
 
 /obj/machinery/attackby(var/obj/item/O, var/mob/user)
 	..()
+
+	add_fingerprint(user)
+
 	if(istype(O, /obj/item/weapon/card/emag) && machine_flags & EMAGGABLE)
 		var/obj/item/weapon/card/emag/E = O
 		if(E.canUse(user,src))


### PR DESCRIPTION
tfw you scan the emagged airlock and come up with nothing

:cl:
 * tweak: Attacking machines and airlocks with objects leaves fingerprints and fibers.