### PR TITLE
I accidentaly made dynamic cooldowns 10 times bigger than what they should be

### DIFF
--- a/__DEFINES/role_datums_defines.dm
+++ b/__DEFINES/role_datums_defines.dm
@@ -203,11 +203,11 @@
 
 // -- Injection delays (in ticks, ie, you need the /2 to get the real result)
 
-#define LATEJOIN_DELAY_MIN (5 MINUTES)/2
-#define LATEJOIN_DELAY_MAX (30 MINUTES)/2
+#define LATEJOIN_DELAY_MIN (5 MINUTES)/20
+#define LATEJOIN_DELAY_MAX (30 MINUTES)/20
 
-#define MIDROUND_DELAY_MIN (15 MINUTES)/2
-#define MIDROUND_DELAY_MAX (50 MINUTES)/2
+#define MIDROUND_DELAY_MIN (15 MINUTES)/20
+#define MIDROUND_DELAY_MAX (50 MINUTES)/20
 
 // -- Rulesets flags
 

--- a/__DEFINES/role_datums_defines.dm
+++ b/__DEFINES/role_datums_defines.dm
@@ -201,7 +201,7 @@
 #define INTERCEPT_TIME_LOW 10 MINUTES
 #define INTERCEPT_TIME_HIGH 18 MINUTES
 
-// -- Injection delays (in ticks, ie, you need the /2 to get the real result)
+// -- Injection delays (in ticks, ie, you need the /20 to get the real result)
 
 #define LATEJOIN_DELAY_MIN (5 MINUTES)/20
 #define LATEJOIN_DELAY_MAX (30 MINUTES)/20


### PR DESCRIPTION
Since dynamic uses game ticks and not deciseconds, `MINUTES` is 10 times too high
[hotfix]