### PR TITLE
Emagged airlocks will now open when bolted

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1256,6 +1256,7 @@ About the new airlock wires panel:
 		src.busy = 0
 	else if (istype(I, /obj/item/weapon/card/emag))
 		if (!operating)
+			locked = 0
 			operating = -1
 			if(density)
 				door_animate("spark")


### PR DESCRIPTION
This does not affect welded airlocks, that still can't be opened.
:cl:
 * tweak: Using a cryptographic sequencer (emag) on a door will now open it when it is bolted instead of bolting it shut.