### PR TITLE
Toxic fart is no longer considered a superpower

### DIFF
--- a/code/game/gamemodes/setupgame.dm
+++ b/code/game/gamemodes/setupgame.dm
@@ -148,7 +148,7 @@ var/LACTOSEBLOCK = 0
 	CHAVBLOCK      = getAssignedBlock("CHAV",       numsToAssign)
 	SWEDEBLOCK     = getAssignedBlock("SWEDE",      numsToAssign)
 	SCRAMBLEBLOCK  = getAssignedBlock("SCRAMBLE",   numsToAssign)
-	TOXICFARTBLOCK = getAssignedBlock("TOXICFART",  numsToAssign, DNA_HARD_BOUNDS, good=1) //Why the hell does this have "good" if it's a disability?
+	TOXICFARTBLOCK = getAssignedBlock("TOXICFART",  numsToAssign)
 	HORNSBLOCK     = getAssignedBlock("HORNS",      numsToAssign)
 	SMILEBLOCK     = getAssignedBlock("SMILE",      numsToAssign)
 	ELVISBLOCK     = getAssignedBlock("ELVIS",      numsToAssign)


### PR DESCRIPTION
Less because it gasses you and more because I can't be bothered to change the font to have its activation message be blue. And also because it gasses you, and it's overwritten by superfart anyway
:cl:
 * tweak: The toxic fart gene is no longer considered a superpower.