### PR TITLE
Changes shoes a bit so that clown shoes make a sound every step (except advanced ones)

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -466,7 +466,8 @@
 		var/mob/living/carbon/human/H = loc
 		switch(H.m_intent)
 			if("run")
-				playsound(H, step_sound, 50, 1) // this will NEVER GET ANNOYING!
+				if(stepstaken % 2 == 1)
+					playsound(H, step_sound, 50, 1) // this will NEVER GET ANNOYING!
 			if("walk")
 				playsound(H, step_sound, 20, 1)
 

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -467,7 +467,7 @@
 		switch(H.m_intent)
 			if("run")
 				step_sound_counter++
-				if(step_sound_counter == step_sound_threshold)
+				if(step_sound_counter >= step_sound_threshold)
 					playsound(H, step_sound, 50, 1) // this will NEVER GET ANNOYING!
 					step_sound_counter = 0
 			if("walk")

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -466,8 +466,7 @@
 		var/mob/living/carbon/human/H = loc
 		switch(H.m_intent)
 			if("run")
-				if(stepstaken % 2 == 1)
-					playsound(H, step_sound, 50, 1) // this will NEVER GET ANNOYING!
+				playsound(H, step_sound, 50, 1) // this will NEVER GET ANNOYING!
 			if("walk")
 				playsound(H, step_sound, 20, 1)
 
@@ -489,7 +488,7 @@
 		clothing_flags |= (NOSLIP | MAGPULSE)
 		slowdown = mag_slow
 		return 1
-	
+
 //Suit
 /obj/item/clothing/suit
 	icon = 'icons/obj/clothing/suits.dmi'

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -458,16 +458,18 @@
 
 	species_restricted = list("exclude","Unathi","Tajaran","Muton")
 	var/step_sound = ""
-	var/stepstaken = 1
+	var/step_sound_counter = 0 //Used to determine how many steps left until a sound is played
+	var/step_sound_threshold = 2 //Doesn't work if it's 0 or negative
 
 /obj/item/clothing/shoes/proc/step_action()
-	stepstaken++
 	if(step_sound != "" && ishuman(loc))
 		var/mob/living/carbon/human/H = loc
 		switch(H.m_intent)
 			if("run")
-				if(stepstaken % 2 == 1)
+				step_sound_counter++
+				if(step_sound_counter == step_sound_threshold)
 					playsound(H, step_sound, 50, 1) // this will NEVER GET ANNOYING!
+					step_sound_counter = 0
 			if("walk")
 				playsound(H, step_sound, 20, 1)
 

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -153,7 +153,7 @@
 	footprint_type = /obj/effect/decal/cleanable/blood/tracks/footprints/clown
 
 	step_sound = "clownstep"
-	step_sound_cooldown = 0.5
+	step_sound_threshold = 1
 
 /obj/item/clothing/shoes/clown_shoes/attackby(obj/item/weapon/W, mob/user)
 	..()
@@ -180,6 +180,7 @@
 	icon_state = "superclown"
 	item_state = "superclown"
 	clothing_flags = NOSLIP
+	step_sound_threshold = 2
 	var/list/sound_list = list(
 		"Clown squeak" = "clownstep",
 		"Bike horn" = 'sound/items/bikehorn.ogg',

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -13,13 +13,13 @@
 	species_fit = list(VOX_SHAPED, GREY_SHAPED, UNDEAD_SHAPED, MUSHROOM_SHAPED)
 
 // desc replacement block
-/obj/item/clothing/shoes/syndigaloshes/examine(mob/user) 
+/obj/item/clothing/shoes/syndigaloshes/examine(mob/user)
 	..()
-	if(is_holder_of(user, src)) // are the noslips on your person or on the floor? 
+	if(is_holder_of(user, src)) // are the noslips on your person or on the floor?
 		to_chat(user, "<span class='info'><b>When inspected hands-on,</b> they are apparently modified with complex electronics and extra-grip soles.</span>") // these are no-slips yes hello sir
 		to_chat(user, "<span class='info'>They are rated to fit all known species able to wear footgear.</span>") // catbeasts/unathi/golems btfo, how will they ever recover
 		return
-	if(isturf(loc) && user.Adjacent(src)) // so there's degrees of identification. above is blatant, this is less so 
+	if(isturf(loc) && user.Adjacent(src)) // so there's degrees of identification. above is blatant, this is less so
 		to_chat(user, "Something's a little off...")
 
 /obj/item/clothing/shoes/syndigaloshes/New()
@@ -64,7 +64,7 @@
 
 /obj/item/clothing/shoes/syndigaloshes/proc/change()
 	var/obj/item/clothing/shoes/A
-	A = input("Pick a color:", "BOOYEA", A) as null|anything in clothing_choices 
+	A = input("Pick a color:", "BOOYEA", A) as null|anything in clothing_choices
 	if(!A || usr.incapacitated() || !Adjacent(usr) || isturf(src.loc))
 		return
 
@@ -74,7 +74,7 @@
 	item_state = A.item_state
 	_color = A._color
 	step_sound = A.step_sound
-	usr.update_inv_shoes()	
+	usr.update_inv_shoes()
 
 /obj/item/clothing/shoes/mime
 	name = "mime shoes"
@@ -153,6 +153,7 @@
 	footprint_type = /obj/effect/decal/cleanable/blood/tracks/footprints/clown
 
 	step_sound = "clownstep"
+	step_sound_cooldown = 0.5
 
 /obj/item/clothing/shoes/clown_shoes/attackby(obj/item/weapon/W, mob/user)
 	..()


### PR DESCRIPTION
Stepstaken is removed because it's not used by anything
Replaced with step_sound_counter and step_sound_threshold, the former keeps track of the steps made and gets reset when a sound happens and the latter is how many steps required until sound is played
Clown shoes now make a noise every step except for the advanced ones, but you can var-edit the advanced ones to 1 if you're insidious
:cl:
 * tweak: Clown shoes now make a noise every step. This does not apply to the advanced clown shoes.