### PR TITLE
Ok this time I think we got him for realsies

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
@@ -735,9 +735,6 @@
 		newCultist.conversion.Add("altar")
 		cult_risk()//risk of exposing the cult early if too many soul blades created
 
-		spawn(1)
-			shadeMob.ckey = M_ckey
-
 
 /obj/structure/cult/altar/dance_start()//This is executed at the end of the sacrifice ritual
 	//var/datum/faction/bloodcult/cult = find_active_faction_by_type(/datum/faction/bloodcult)

--- a/code/datums/gamemode/factions/faction.dm
+++ b/code/datums/gamemode/factions/faction.dm
@@ -100,10 +100,10 @@ var/list/factions_with_hud_icons = list()
 /datum/faction/proc/HandleRecruitedMind(var/datum/mind/M, var/override = FALSE)
 	for(var/datum/role/R in members)
 		if(R.antag == M)
-			return 0
+			return R
 	if(M.GetRole(late_role))
 		WARNING("Mind already had a role of [late_role]!")
-		return 0
+		return (M.GetRole(late_role))
 	var/datum/role/R = new roletype(null,src,late_role) // Add him to our roles
 	if(!R.AssignToRole(M, override))
 		R.Drop()


### PR DESCRIPTION
Turns out that HandleRecruitedMind() returned 0 if the mind was already a member of the faction. It now returns the role properly. 0 is now only returned if the role didn't exist and failed to be assigned (such as because of a ban).

:cl:
* bugfix: Ok this time I swear the Altar shades should no longer be braindead.