### PR TITLE
adds coin flipping

### DIFF
--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -370,7 +370,7 @@
 /obj/item/weapon/coin/is_screwdriver(var/mob/user)
 	return user.a_intent == I_HURT
 
-/obj/item/weapon/coin/proc/coinflip(var/mob/user, thrown, rigged = FALSE)
+/obj/item/weapon/coin/proc/coinflip(mob/user as mob, thrown, rigged = FALSE)
 	var/matrix/flipit = matrix()
 	flipit.Scale(0.2,1)
 	animate(src, transform = flipit, time = 2, easing = QUAD_EASING)
@@ -391,7 +391,7 @@
 		flipit.Invert()
 		flipit.Turn(rand(1,359))
 		animate(src, transform = flipit, time = 2, easing = QUAD_EASING)
-	if (rand(1000) == 1000 || rigged)
+	if (prob(0.1) || rigged)
 		flipit.Scale(0.2,1)
 		animate(src, transform = flipit, time = 2, easing = QUAD_EASING)
 		sideup = "on the side!"

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -370,7 +370,7 @@
 /obj/item/weapon/coin/is_screwdriver(var/mob/user)
 	return user.a_intent == I_HURT
 
-/obj/item/weapon/coin/proc/coinflip(mob/user as mob, thrown, rigged = FALSE)
+/obj/item/weapon/coin/proc/coinflip(var/mob/user, thrown, rigged = FALSE)
 	var/matrix/flipit = matrix()
 	flipit.Scale(0.2,1)
 	animate(src, transform = flipit, time = 2, easing = QUAD_EASING)
@@ -391,7 +391,7 @@
 		flipit.Invert()
 		flipit.Turn(rand(1,359))
 		animate(src, transform = flipit, time = 2, easing = QUAD_EASING)
-	if (prob(0.1) || rigged)
+	if (rand(1000) == 1000 || rigged)
 		flipit.Scale(0.2,1)
 		animate(src, transform = flipit, time = 2, easing = QUAD_EASING)
 		sideup = "on the side!"

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -370,7 +370,7 @@
 /obj/item/weapon/coin/is_screwdriver(var/mob/user)
 	return user.a_intent == I_HURT
 
-/obj/item/weapon/coin/proc/coinflip(mob/user as mob, thrown, rigged = FALSE)
+/obj/item/weapon/coin/proc/coinflip(mob/user, thrown, rigged = FALSE)
 	var/matrix/flipit = matrix()
 	flipit.Scale(0.2,1)
 	animate(src, transform = flipit, time = 2, easing = QUAD_EASING)

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -412,7 +412,7 @@
 	sideup = "heads-up."
 	transform = null
 	
-/obj/item/weapon/coin/attack_self(mob/user as mob)
+/obj/item/weapon/coin/attack_self(var/mob/user)
 	coinflip(user, 0)
 
 /obj/item/weapon/coin/throw_impact(atom/hit_atom, speed, user)

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -370,7 +370,7 @@
 /obj/item/weapon/coin/is_screwdriver(var/mob/user)
 	return user.a_intent == I_HURT
 
-/obj/item/weapon/coin/proc/coinflip(mob/user, thrown, rigged = FALSE)
+/obj/item/weapon/coin/proc/coinflip(var/mob/user, thrown, rigged = FALSE)
 	var/matrix/flipit = matrix()
 	flipit.Scale(0.2,1)
 	animate(src, transform = flipit, time = 2, easing = QUAD_EASING)

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -354,6 +354,7 @@
 	var/string_attached
 	var/material=MAT_IRON // Ore ID, used with coinbags.
 	var/credits = 0 // How many credits is this coin worth?
+	var/sideup = "heads." //heads, tails or on its side?
 
 /obj/item/weapon/coin/New()
 	. = ..()
@@ -368,6 +369,55 @@
 
 /obj/item/weapon/coin/is_screwdriver(var/mob/user)
 	return user.a_intent == I_HURT
+
+/obj/item/weapon/coin/proc/coinflip(mob/user as mob, thrown, rigged = FALSE)
+	var/matrix/flipit = matrix()
+	flipit.Scale(0.2,1)
+	animate(src, transform = flipit, time = 2, easing = QUAD_EASING)
+	flipit.Scale(5,1)
+	flipit.Invert()
+	flipit.Turn(rand(1,359))
+	animate(src, transform = flipit, time = 2, easing = QUAD_EASING)
+	flipit.Scale(0.2,1)
+	animate(src, transform = flipit, time = 2, easing = QUAD_EASING)
+	if (pick(0,1))
+		sideup = "heads-up."
+		flipit.Scale(5,1)
+		flipit.Turn(rand(1,359))
+		animate(src, transform = flipit, time = 2, easing = QUAD_EASING)
+	else
+		sideup = "tails-up."
+		flipit.Scale(5,1)
+		flipit.Invert()
+		flipit.Turn(rand(1,359))
+		animate(src, transform = flipit, time = 2, easing = QUAD_EASING)
+	if (prob(0.1) || rigged)
+		flipit.Scale(0.2,1)
+		animate(src, transform = flipit, time = 2, easing = QUAD_EASING)
+		sideup = "on the side!"
+	if(!thrown)
+		user.visible_message("<span class='notice'>[user] flips [src]. It lands [sideup]</span>", \
+							 "<span class='notice'>You flip [src]. It lands [sideup]</span>", \
+							 "<span class='notice'>You hear [src] landing.</span>")
+	else 
+		if(!throwing) //coin was thrown and is coming to rest
+			visible_message("<span class='notice'>[src] stops spinning, landing [sideup]</span>")
+	
+/obj/item/weapon/coin/examine(var/mob/user)
+	..()
+	to_chat(user, "<span class='notice'>[src] is [sideup]</span>")
+	
+/obj/item/weapon/coin/equipped(var/mob/user)
+	..()
+	sideup = "heads-up."
+	transform = null
+	
+/obj/item/weapon/coin/attack_self(mob/user as mob)
+	coinflip(user, 0)
+
+/obj/item/weapon/coin/throw_impact(atom/hit_atom, speed, user)
+	..()
+	coinflip(user, 1)
 
 /obj/item/weapon/coin/gold
 	material=MAT_GOLD


### PR DESCRIPTION
With a little animation and a tiny chance to land on the side. Picking up the coin resets it to heads.
![coinflip](https://user-images.githubusercontent.com/8468269/58764496-00525700-8568-11e9-83b2-564d212a2a13.gif)
tested as far as I could imagine

closes #23097

🆑 
 - rscadd: After many years of development, coins can now be flipped.