### PR TITLE
Fixed and rebalanced tables blocking projectiles

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -320,16 +320,18 @@
 
 //checks if projectile 'P' from turf 'from' can hit whatever is behind the table. Returns 1 if it can, 0 if bullet stops.
 /obj/structure/table/proc/check_cover(obj/item/projectile/P, turf/from)
-	if(!flipped || get_dir(loc, from) != dir) // It needs to be flipped and the direction needs to be right
-		return 1
-	if(get_dist(P.starting, loc) <= 1) //Tables won't help you if people are THIS close
-		return 1
+	var/shooting_at_the_table_directly = P.original == src
 	var/chance = 60
-	if(ismob(P.original))
-		var/mob/M = P.original
-		if(M.lying)
-			chance += 20 //Lying down lets you catch less bullets
-	if(P.original == src || prob(chance))
+	if(!shooting_at_the_table_directly)
+		if(!flipped || get_dir(loc, from) != dir) // It needs to be flipped and the direction needs to be right
+			return 1
+		if(get_dist(P.starting, loc) <= 1) //Tables won't help you if people are THIS close
+			return 1
+		if(ismob(P.original))
+			var/mob/M = P.original
+			if(M.lying)
+				chance += 20 //Lying down lets you catch less bullets
+	if(shooting_at_the_table_directly || prob(chance))
 		health -= P.damage/2
 		if (health > 0)
 			visible_message("<span class='warning'>[P] hits \the [src]!</span>")

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -320,29 +320,24 @@
 
 //checks if projectile 'P' from turf 'from' can hit whatever is behind the table. Returns 1 if it can, 0 if bullet stops.
 /obj/structure/table/proc/check_cover(obj/item/projectile/P, turf/from)
-	var/turf/cover = flipped ? get_turf(src) : get_step(loc, get_dir(from, loc))
-	if (get_dist(P.starting, loc) <= 1) //Tables won't help you if people are THIS close
+	if(!flipped || get_dir(loc, from) != dir) // It needs to be flipped and the direction needs to be right
 		return 1
-	if (get_turf(P.original) == cover)
-		var/chance = 20
-		if (ismob(P.original))
-			var/mob/M = P.original
-			if (M.lying)
-				chance += 20				//Lying down lets you catch less bullets
-		if(flipped)
-			if(get_dir(loc, from) == dir)	//Flipped tables catch mroe bullets
-				chance += 20
-			else
-				return 1					//But only from one side
-		if(prob(chance))
-			health -= P.damage/2
-			if (health > 0)
-				visible_message("<span class='warning'>[P] hits \the [src]!</span>")
-				return 0
-			else
-				visible_message("<span class='warning'>[src] breaks down!</span>")
-				destroy()
-				return 1
+	if(get_dist(P.starting, loc) <= 1) //Tables won't help you if people are THIS close
+		return 1
+	var/chance = 60
+	if(ismob(P.original))
+		var/mob/M = P.original
+		if(M.lying)
+			chance += 20 //Lying down lets you catch less bullets
+	if(P.original == src || prob(chance))
+		health -= P.damage/2
+		if (health > 0)
+			visible_message("<span class='warning'>[P] hits \the [src]!</span>")
+			return 0
+		else
+			visible_message("<span class='warning'>[src] breaks down!</span>")
+			destroy()
+			return 1
 	return 1
 
 /obj/structure/table/Uncross(atom/movable/mover as mob|obj, target as turf)


### PR DESCRIPTION
closes #16466
- Removed chance for non-flipped tables to block projectiles

Before:
- Tables literally only block projectiles if you're standing on its tile and the shooter clicks you instead of any tile behind you

Now:
- Tables block projectiles if you're firing against the direction the table got flipped
- 60% chance to block by default (a 40% for the projectile to go over the table to your target)
- 80% chance to miss the target if you manage to click a spessman resting behind a flipped table (a 20% chance to hit him instead of the table)

As a reminder, they start with 100 health and take half the damage the projectiles would do normally.

:cl:
 * tweak: Flipped tables are now highly effective at blocking projectiles.