### PR TITLE
Fixing a bunch of cult related runtimes

### DIFF
--- a/__DEFINES/role_datums_defines.dm
+++ b/__DEFINES/role_datums_defines.dm
@@ -121,6 +121,8 @@
 #define BLOODCOST_TOTAL		"total"
 #define BLOODCOST_RESULT	"result"
 #define BLOODCOST_FAILURE	"failure"
+#define BLOODCOST_TRIBUTE	"tribute"
+#define BLOODCOST_USER	"user"
 
 #define RITUALABORT_ERASED	"erased"
 #define RITUALABORT_STAND	"too far"

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
@@ -1434,6 +1434,7 @@ var/list/bloodstone_list = list()
 						user.say("Tok-lyr rqa'nap g'lt-ulotf!","C")
 				contributors.Add(user)
 				if (user.client)
+					update_progbar()
 					user.client.images |= progbar
 			else if(user.hud_used && user.hud_used.holomap_obj)
 				if(!("\ref[user]" in watcher_maps))

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_items.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_items.dm
@@ -743,7 +743,7 @@ var/list/arcane_tomes = list()
 					blood = min(100,blood+5)
 					to_chat(user, "<span class='warning'>You steal a bit of their blood, but not much.</span>")
 
-			if (shade)
+			if (shade && shade.hud_used && shade.gui_icons && shade.gui_icons.soulblade_bloodbar)
 				var/matrix/MAT = matrix()
 				MAT.Scale(1,blood/maxblood)
 				var/total_offset = (60 + (100*(blood/maxblood))) * PIXEL_MULTIPLIER

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
@@ -1521,9 +1521,9 @@ var/list/blind_victims = list()
 	word2 = /datum/cultword/see
 	word3 = /datum/cultword/hide
 	page = "This rune (whose words are the same as the Conceal rune in reverse) lets you reveal every rune and structures in a circular 7 tile range around it. Each revealed rune will stun non-cultists in a 3 tile range around them, stunning and muting them for 2 seconds, up to a total of 10 seconds. Affects through walls. The stun ends if the victims are moved away from where they stand, unless they get knockdown first, so you might want to follow up with a Stun talisman. "
-	
+
 	walk_effect = TRUE
-	
+
 	var/effect_range=7
 	var/shock_range=3
 	var/shock_per_obj=2
@@ -1926,8 +1926,9 @@ var/list/blind_victims = list()
 					H.pain_shock_stage = 0
 				L.update_canmove()
 				L.stat = CONSCIOUS
-				L.reagents.del_reagent(HOLYWATER)
-				L.reagents.add_reagent(HYPERZINE,1)
+				if (L.reagents)
+					L.reagents.del_reagent(HOLYWATER)
+					L.reagents.add_reagent(HYPERZINE,1)
 		qdel(spell_holder)
 	qdel(src)
 


### PR DESCRIPTION
as a side effect, when using the blood communion tattoo, and an ally pays an 1u blood cost, the data from the blood they used to pay is now properly carried over. So let's say you've got a human and a vox cultist, both in Blood Communion. If the human writes runes, the rune will appear blue, and the vox's runes will appear red, because they're using each other's blood. Note that this only applies to 1u blood costs, since higher costs will still have the main cultist pay some of it.