### PR TITLE
Fixes wiz double spellbook

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -136,18 +136,18 @@
 /datum/dynamic_ruleset/midround/from_ghosts/faction_based
 	weight = 0
 	var/datum/faction/my_fac = null // If the midround lawset will try to add our antag to a faction
+	var/created_a_faction = 0
 
 /datum/dynamic_ruleset/midround/from_ghosts/faction_based/review_applications()
 	var/datum/faction/active_fac = find_active_faction_by_type(my_fac)
-	var/new_faction = 0
 	if (!active_fac)
-		new_faction = 1
 		active_fac = ticker.mode.CreateFaction(my_fac, null, 1)
+		created_a_faction = 1
 	my_fac = active_fac
 	. = ..()
-	if (new_faction)
-		my_fac.OnPostSetup()
-	return new_faction
+	if (created_a_faction)
+		active_fac.OnPostSetup()
+	return my_fac
 
 /datum/dynamic_ruleset/midround/from_ghosts/faction_based/setup_role(var/datum/role/new_role)
 	my_fac.HandleRecruitedRole(new_role)
@@ -301,7 +301,8 @@
 	return ..()
 
 /datum/dynamic_ruleset/midround/from_ghosts/faction_based/raginmages/setup_role(var/datum/role/new_role)
-	new_role.OnPostSetup() //Each individual role to show up gets a postsetup
+	if (!created_a_faction)
+		new_role.OnPostSetup() //Each individual role to show up gets a postsetup
 	..()
 
 


### PR DESCRIPTION
See title
Closes #22968 (the diagnosis on the issue is incorrect, it's just that the wizard role is intialised twice if there was no early wizard)