### PR TITLE
Door HF

### DIFF
--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -66,6 +66,13 @@ var/list/poddoors = list()
 	else
 		return 0
 
+/obj/machinery/door/poddoor/hitby(atom/movable/AM)
+	if(!density)
+		return ..()
+	else
+		denied()
+		return FALSE
+
 /obj/machinery/door/poddoor/attackby(obj/item/weapon/C as obj, mob/user as mob)
 	src.add_fingerprint(user)
 	if (!( iscrowbar(C) || (istype(C, /obj/item/weapon/fireaxe) && C.wielded == 1) ))


### PR DESCRIPTION
fixes #23160

Caused by #22311

Tested

🆑 
* bugfix: Fixed a bug where any blast door could be opened by throwing any item at it (including, for example, the borer pen with borer eggs)