### PR TITLE
Raises the number of enemies required for cult to fire

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -218,7 +218,7 @@
 	role_category = /datum/role/cultist
 	restricted_from_jobs = list("Merchant","AI", "Cyborg", "Mobile MMI", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Chaplain", "Head of Personnel", "Internal Affairs Agent")
 	enemy_jobs = list("Security Officer","Warden", "Detective","Head of Security", "Captain")
-	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
+	required_enemies = list(3,3,2,2,2,2,2,1,1,0)
 	required_candidates = 4
 	weight = 3
 	cost = 30


### PR DESCRIPTION
As explained in #23142 

:cl:
- tweak: Cult now requires at least two enemies to fire.