### PR TITLE
Secret mode will be rolled sometimes

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic.dm
+++ b/code/datums/gamemode/dynamic/dynamic.dm
@@ -19,6 +19,7 @@ var/dynamic_no_stacking = 1 // NO STACKING : only one "round-ender", except if w
 var/dynamic_classic_secret = 0 // Only one roundstart ruleset, and only autotraitor + minor rules allowed
 var/dynamic_high_pop_limit = 45 // Will switch to "high pop override" if the roundstart population is above this
 var/dynamic_forced_extended = 0 // No rulesets will be drated, ever
+var/dynamic_prob_secret = 50
 
 var/stacking_limit = 90
 
@@ -60,6 +61,7 @@ var/stacking_limit = 90
 	var/relative_threat = 0 // Relative threat, Lorentz-distributed.
 	var/curve_centre_of_round = 0
 	var/curve_width_of_round = 1.8
+	var/prob_secret = 50
 
 	var/peaceful_percentage = 50
 
@@ -141,6 +143,8 @@ var/stacking_limit = 90
 
 /datum/gamemode/dynamic/GetScoreboard()
 	dat += "<h2>Dynamic Mode v1.0 - Threat Level = <span class='red'>[threat_level]%</span></h2>"
+	if (classic_secret)
+		dat += "<b>Classic secret</b> mode was picked.<br/>"
 	var/rules = list()
 	if (executed_rules.len > 0)
 		for (var/datum/dynamic_ruleset/DR in executed_rules)
@@ -174,7 +178,7 @@ var/stacking_limit = 90
 	no_stacking = dynamic_no_stacking
 	if (no_stacking)
 		message_admins("Round-ending rulesets won't stack, unless the threat is above stacking_limit ([stacking_limit]).")
-	classic_secret = dynamic_classic_secret
+	classic_secret = dynamic_classic_secret || (prob(prob_secret))
 	if (classic_secret)
 		message_admins("Classic secret mode active: only autotraitors will spawn, and we will only have one roundstart ruleset.")
 	log_admin("Dynamic mode parameters for the round: distrib mode = [distribution_mode], centre = [curve_centre_of_round], width is [curve_width_of_round]. Extended : [forced_extended], no stacking : [no_stacking], classic secret: [classic_secret].")

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -752,6 +752,9 @@ var/global/floorIsLava = 0
 		<br/>
 		<b>Stacking threeshold:</b> Current value : <a href='?src=\ref[src];stacking_limit=1'><b>[stacking_limit]</b></a>.
 		<br/>The threshold at which "round-ender" rulesets will stack. A value higher than 100 ensure this never happens. <br/>
+		<br/>
+		<b>"Classic secret probability":</b> Current value : <a href='?src=\ref[src];classic_secret_prob=1'><b>[dynamic_prob_secret]</b></a>.
+		<br/>The probability of the game to roll the "classic secret" mode.<br/>
 		<h3>Advanced parameters</h3>
 		The distribution mode is currently : <b>[dynamic_chosen_mode]</b> <br/>
 		Glossary : <br/>

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1646,6 +1646,23 @@
 		message_admins("[key_name(usr)] set 'classic_secret' to [dynamic_classic_secret].")
 		dynamic_mode_options(usr)
 
+	else if(href_list["classic_secret_prob"])
+		if(!check_rights(R_ADMIN))
+			return
+
+		if(master_mode != "Dynamic Mode")
+			return alert(usr, "The game mode has to be Dynamic Mode!", null, null, null, null)
+
+		var/temp_prob = input(usr,"Change the probability of having the mode roll 'classic secret'.", "Change 'secret' mode probability", null) as num
+		if (temp_prob < 0)
+			to_chat(usr, "<span class='warning'>Negative values not allowed.</span>")
+			return
+		dynamic_prob_secret = temp_prob
+		log_admin("[key_name(usr)] set 'dynamic_prob_secret' to [dynamic_prob_secret].")
+		message_admins("[key_name(usr)] set 'dynamic_prob_secret' to [dynamic_prob_secret].")
+		dynamic_mode_options(usr)
+
+
 	else if(href_list["stacking_limit"])
 		if(!check_rights(R_ADMIN))
 			return


### PR DESCRIPTION
One of the easiest options put forward in #23153.

50% chance to roll secret at roundstart ; whether or not it did get secret will be displayed on round-end report

Admins can of course override it if they so desire in Dynamic Mode Options