### PR TITLE
Adds a mind.miming check to Remote Talk

### DIFF
--- a/code/game/dna/genes/powers.dm
+++ b/code/game/dna/genes/powers.dm
@@ -143,6 +143,10 @@
 	if(!user || !istype(user))
 		return
 
+	if(user.mind.miming)
+		to_chat(user, "<span class = 'warning'>You find yourself unable to project your mind outward.</span>")
+		return
+
 	var/say = stripped_input(user, "What do you wish to say?", "Project Mind")
 
 	if(!say)
@@ -206,9 +210,9 @@
 		return 1
 
 /datum/dna/gene/basic/heat_resist/OnDrawUnderlays(var/mob/M,var/g,var/fat)
-	if(isvox(M) || isskelevox(M))	
+	if(isvox(M) || isskelevox(M))
 		return "coldvox_s"
-	else	
+	else
 		return "cold[fat]_s"
 
 /datum/dna/gene/basic/cold_resist
@@ -303,7 +307,7 @@
 	block = TELEBLOCK
 
 /datum/dna/gene/basic/tk/OnDrawUnderlays(var/mob/M,var/g,var/fat)
-	if(isvox(M) || isskelevox(M))	
+	if(isvox(M) || isskelevox(M))
 		return "telekinesisheadvox_s"
-	else	
+	else
 		return "telekinesishead[fat]_s"

--- a/code/game/dna/genes/powers.dm
+++ b/code/game/dna/genes/powers.dm
@@ -144,7 +144,7 @@
 		return
 
 	if(user.mind.miming)
-		to_chat(user, "<span class = 'warning'>You find yourself unable to project your mind outward.</span>")
+		to_chat(user, "<span class = 'warning'>You find yourself unable to convey your thoughts outside of gestures.</span>")
 		return
 
 	var/say = stripped_input(user, "What do you wish to say?", "Project Mind")


### PR DESCRIPTION
[tweak]

As the title says. 87.7% tested and probably fine as far as I can see. Initially intended as an alternative to #23155, but I feel like it's a fair change regardless of how that goes.

Considerations include whether or not it would be preferable to just forgo the feedback and lump the check in with the target checks, as well as whether or not it should apply to cursed individuals.

:cl:
 * tweak: Mimes who have not broken their Vow of Silence and victims of the French Curse can no longer use the Project Mind power.