### PR TITLE
Created datums can now take arguments for their new()

### DIFF
--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -1251,8 +1251,7 @@ client/proc/check_convertables()
 
 	lst.len = argnum // Expand to right length
 
-	var/i
-	for(i = 1, i < argnum + 1, i++) // Lists indexed from 1 forwards in byond
+	for(var/i = 1 to argnum) // Lists indexed from 1 forwards in byond
 		lst[i] = variable_set(src)
 
 	holder.marked_datum = new chosen(arglist(lst))

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -1244,7 +1244,18 @@ client/proc/check_convertables()
 		if(!chosen)
 			return
 
-	holder.marked_datum = new chosen
+	var/list/lst = list()
+	var/argnum = input("Number of arguments","Number:",0) as num|null
+	if(!argnum && (argnum!=0))
+		return
+
+	lst.len = argnum // Expand to right length
+
+	var/i
+	for(i = 1, i < argnum + 1, i++) // Lists indexed from 1 forwards in byond
+		lst[i] = variable_set(src)
+
+	holder.marked_datum = new chosen(arglist(lst))
 
 	to_chat(usr, "<span class='notify'>A reference to the new [chosen] has been stored in your marked datum. <a href='?_src_=vars;Vars=\ref[holder.marked_datum]'>Click here to access it</a></span>")
 	log_admin("[key_name(usr)] spawned the datum [chosen] to his marked datum.")


### PR DESCRIPTION
[system]
pi% tested

I need this for reasons