### PR TITLE
Newcops Music Button

### DIFF
--- a/__DEFINES/role_datums_defines.dm
+++ b/__DEFINES/role_datums_defines.dm
@@ -34,6 +34,7 @@
 #define CULTIST "cultist"
 #define LEGACY_CULTIST "legacy cultist"
 #define NUKE_OP "nuclear operative"
+#define NUKE_OP_LEADER "nuclear operative leader"
 #define HEADREV "head revolutionary"
 #define REV "revolutionary"
 #define WIZAPP "wizard's apprentice"

--- a/code/datums/gamemode/factions/syndicate/nukeops.dm
+++ b/code/datums/gamemode/factions/syndicate/nukeops.dm
@@ -208,14 +208,15 @@
 /datum/faction/syndicate/nuke_op/process()
 	var/livingmembers
 	var/mob/living/M
-	for (var/datum/role/R in members)
-		if(R.antag.current)
-			M = R.antag.current
-			if(M.stat != DEAD)
-				livingmembers++
-	if(livingmembers > 0)
-		return
-	else
-		if (src.stage != FACTION_DORMANT)
-			stage(FACTION_DORMANT)
-			ticker.StopThematic()
+	if(members)
+		for (var/datum/role/R in members)
+			if(R.antag.current)
+				M = R.antag.current
+				if(M.stat != DEAD)
+					livingmembers++
+		if(livingmembers > 0)
+			return
+		else
+			if (src.stage != FACTION_DORMANT)
+				stage(FACTION_DORMANT)
+				ticker.StopThematic()

--- a/code/datums/gamemode/factions/syndicate/nukeops.dm
+++ b/code/datums/gamemode/factions/syndicate/nukeops.dm
@@ -214,8 +214,5 @@
 				M = R.antag.current
 				if(M.stat != DEAD)
 					livingmembers++
-		if(livingmembers > 0)
-			return
-		else
-			if (src.stage != FACTION_DEFEATED)
-				stage(FACTION_DEFEATED)
+		if(ticker.theme.playing && !livingmembers && ticker.theme.playlist_id == "nukesquad")
+			ticker.StopThematic()

--- a/code/datums/gamemode/factions/syndicate/nukeops.dm
+++ b/code/datums/gamemode/factions/syndicate/nukeops.dm
@@ -211,10 +211,11 @@
 	for (var/datum/role/R in members)
 		if(R.antag.current)
 			M = R.antag.current
-		if(M.stat != DEAD)
-			livingmembers++
+			if(M.stat != DEAD)
+				livingmembers++
 	if(livingmembers > 0)
 		return
 	else
-		stage(FACTION_DORMANT)
-		ticker.StopThematic()
+		if (src.stage != FACTION_DORMANT)
+			stage(FACTION_DORMANT)
+			ticker.StopThematic()

--- a/code/datums/gamemode/factions/syndicate/nukeops.dm
+++ b/code/datums/gamemode/factions/syndicate/nukeops.dm
@@ -204,3 +204,15 @@
 	else
 		nuke_code = "code will be provided later"
 	return
+
+/datum/faction/syndicate/nuke_op/process()
+	var/livingmembers
+	var/mob/M
+	for (var/datum/role/R in members)
+		M = R.antag.current
+		if(M.stat != DEAD)
+			livingmembers++
+	if(livingmembers > 0)
+		return
+	else
+		stage(FACTION_DEFEATED)

--- a/code/datums/gamemode/factions/syndicate/nukeops.dm
+++ b/code/datums/gamemode/factions/syndicate/nukeops.dm
@@ -207,12 +207,14 @@
 
 /datum/faction/syndicate/nuke_op/process()
 	var/livingmembers
-	var/mob/M
+	var/mob/living/M
 	for (var/datum/role/R in members)
-		M = R.antag.current
+		if(R.antag.current)
+			M = R.antag.current
 		if(M.stat != DEAD)
 			livingmembers++
 	if(livingmembers > 0)
 		return
 	else
-		stage(FACTION_DEFEATED)
+		stage(FACTION_DORMANT)
+		ticker.StopThematic()

--- a/code/datums/gamemode/factions/syndicate/nukeops.dm
+++ b/code/datums/gamemode/factions/syndicate/nukeops.dm
@@ -217,5 +217,5 @@
 		if(livingmembers > 0)
 			return
 		else
-			if (src.stage != (FACTION_DORMANT || FACTION_DEFEATED))
+			if (src.stage != FACTION_DEFEATED)
 				stage(FACTION_DEFEATED)

--- a/code/datums/gamemode/factions/syndicate/nukeops.dm
+++ b/code/datums/gamemode/factions/syndicate/nukeops.dm
@@ -217,6 +217,5 @@
 		if(livingmembers > 0)
 			return
 		else
-			if (src.stage != FACTION_DORMANT)
-				stage(FACTION_DORMANT)
-				ticker.StopThematic()
+			if (src.stage != (FACTION_DORMANT || FACTION_DEFEATED))
+				stage(FACTION_DEFEATED)

--- a/code/datums/gamemode/factions/syndicate/nukeops.dm
+++ b/code/datums/gamemode/factions/syndicate/nukeops.dm
@@ -208,7 +208,7 @@
 /datum/faction/syndicate/nuke_op/process()
 	var/livingmembers
 	var/mob/living/M
-	if(members)
+	if(members.len > 0)
 		for (var/datum/role/R in members)
 			if(R.antag.current)
 				M = R.antag.current

--- a/code/datums/gamemode/role/syndicate.dm
+++ b/code/datums/gamemode/role/syndicate.dm
@@ -197,4 +197,32 @@
 	logo_state = "nuke-logo"
 
 /datum/role/nuclear_operative/leader
+	name = NUKE_OP_LEADER
+	id = NUKE_OP_LEADER
+	required_pref = NUKE_OP
+	disallow_job = TRUE
 	logo_state = "nuke-logo-leader"
+
+/datum/role/nuclear_operative/leader/OnPostSetup()
+	if(antag)
+		var/datum/action/play_ops_music/go_loud = new /datum/action/play_ops_music(antag)
+		go_loud.Grant(antag.current)
+	..()
+	
+/datum/action/play_ops_music
+	name = "Go Loud"
+	desc = "For the operative who prefers style over subtlety."
+	icon_icon = 'icons/obj/device.dmi'
+	button_icon_state = "megaphone"
+
+/datum/action/play_ops_music/Trigger()
+	var/mob/living/M = owner
+	var/datum/faction/F
+	var/confirm = alert(M, "Are you sure you want to announce your presence? Doing so will display a command announcement and start the Nuclear Assault playlist.", "Are you sure?", "No", "Yes")
+	if (confirm == "Yes")
+		command_alert(/datum/command_alert/nuclear_operatives)
+		F = find_active_faction_by_type(/datum/faction/syndicate/nuke_op)
+		F.stage(FACTION_ENDGAME)
+		Destroy()
+	else
+		return

--- a/code/datums/gamemode/role/syndicate.dm
+++ b/code/datums/gamemode/role/syndicate.dm
@@ -206,6 +206,7 @@
 /datum/role/nuclear_operative/leader/OnPostSetup()
 	if(antag && src.faction.stage != FACTION_ENDGAME)
 		var/datum/action/play_ops_music/go_loud = new /datum/action/play_ops_music(antag)
+		go_loud.linkedfaction = faction
 		go_loud.Grant(antag.current)
 	..()
 	
@@ -214,13 +215,15 @@
 	desc = "For the operative who prefers style over subtlety."
 	icon_icon = 'icons/obj/device.dmi'
 	button_icon_state = "megaphone"
+	var/datum/faction/linkedfaction
 
 /datum/action/play_ops_music/Trigger()
 	var/mob/living/M = owner
-	var/datum/role/R = new /datum/role/nuclear_operative/leader
-	var/datum/faction/F = find_active_faction_by_member(R, owner.mind)
+	if(!linkedfaction)
+		qdel(src)
+		return
 	var/confirm = alert(M, "Are you sure you want to announce your presence? Doing so will display a command announcement and start the Nuclear Assault playlist.", "Are you sure?", "No", "Yes")
-	if (confirm == "Yes" && F.stage != FACTION_ENDGAME && M.stat == CONSCIOUS)
+	if (confirm == "Yes" && linkedfaction.stage != FACTION_ENDGAME && M.stat == CONSCIOUS)
+		linkedfaction.stage(FACTION_ENDGAME)
 		command_alert(/datum/command_alert/nuclear_operatives)
-		F.stage(FACTION_ENDGAME)
 		qdel(src)

--- a/code/datums/gamemode/role/syndicate.dm
+++ b/code/datums/gamemode/role/syndicate.dm
@@ -223,7 +223,7 @@
 		qdel(src)
 		return
 	var/confirm = alert(M, "Are you sure you want to announce your presence? Doing so will display a command announcement and start the Nuclear Assault playlist.", "Are you sure?", "No", "Yes")
-	if (confirm == "Yes" && linkedfaction.stage != FACTION_ENDGAME && M.stat == CONSCIOUS)
-		linkedfaction.stage(FACTION_ENDGAME)
+	if (confirm == "Yes" && !ticker.theme.playing && M.stat == CONSCIOUS)
+		ticker.StartThematic(linkedfaction.playlist)
 		command_alert(/datum/command_alert/nuclear_operatives)
 		qdel(src)

--- a/code/datums/gamemode/role/syndicate.dm
+++ b/code/datums/gamemode/role/syndicate.dm
@@ -204,7 +204,7 @@
 	logo_state = "nuke-logo-leader"
 
 /datum/role/nuclear_operative/leader/OnPostSetup()
-	if(antag)
+	if(antag && src.faction.stage != FACTION_ENDGAME)
 		var/datum/action/play_ops_music/go_loud = new /datum/action/play_ops_music(antag)
 		go_loud.Grant(antag.current)
 	..()
@@ -219,10 +219,8 @@
 	var/mob/living/M = owner
 	var/datum/faction/F
 	var/confirm = alert(M, "Are you sure you want to announce your presence? Doing so will display a command announcement and start the Nuclear Assault playlist.", "Are you sure?", "No", "Yes")
-	if (confirm == "Yes")
+	if (confirm == "Yes" && M.stat == CONSCIOUS)
 		command_alert(/datum/command_alert/nuclear_operatives)
 		F = find_active_faction_by_type(/datum/faction/syndicate/nuke_op)
 		F.stage(FACTION_ENDGAME)
-		Destroy()
-	else
-		return
+		qdel(src)

--- a/code/datums/gamemode/role/syndicate.dm
+++ b/code/datums/gamemode/role/syndicate.dm
@@ -219,7 +219,7 @@
 	var/mob/living/M = owner
 	var/datum/faction/F
 	var/confirm = alert(M, "Are you sure you want to announce your presence? Doing so will display a command announcement and start the Nuclear Assault playlist.", "Are you sure?", "No", "Yes")
-	if (confirm == "Yes" && M.stat == CONSCIOUS)
+	if (confirm == "Yes" && stage != FACTION_ENDGAME && M.stat == CONSCIOUS)
 		command_alert(/datum/command_alert/nuclear_operatives)
 		F = find_active_faction_by_type(/datum/faction/syndicate/nuke_op)
 		F.stage(FACTION_ENDGAME)

--- a/code/datums/gamemode/role/syndicate.dm
+++ b/code/datums/gamemode/role/syndicate.dm
@@ -217,10 +217,10 @@
 
 /datum/action/play_ops_music/Trigger()
 	var/mob/living/M = owner
-	var/datum/faction/F
+	var/datum/role/R = new /datum/role/nuclear_operative/leader
+	var/datum/faction/F = find_active_faction_by_member(R, owner.mind)
 	var/confirm = alert(M, "Are you sure you want to announce your presence? Doing so will display a command announcement and start the Nuclear Assault playlist.", "Are you sure?", "No", "Yes")
-	if (confirm == "Yes" && stage != FACTION_ENDGAME && M.stat == CONSCIOUS)
+	if (confirm == "Yes" && F.stage != FACTION_ENDGAME && M.stat == CONSCIOUS)
 		command_alert(/datum/command_alert/nuclear_operatives)
-		F = find_active_faction_by_type(/datum/faction/syndicate/nuke_op)
 		F.stage(FACTION_ENDGAME)
 		qdel(src)

--- a/code/datums/helper_datums/command_alerts.dm
+++ b/code/datums/helper_datums/command_alerts.dm
@@ -563,3 +563,11 @@ The access requirements on the Asteroid Shuttles' consoles have now been revoked
 	name = "Wall Fungi"
 	alert_title = "Biohazard Alert"
 	message = "Harmful fungi detected on station. Station structures may be contaminated."
+
+/datum/command_alert/nuclear_operatives
+	name = "Nuclear Operatives"
+	alert_title = "Imminent Assault"
+
+/datum/command_alert/nuclear_operatives/announce()
+	message = "Presence of hostile Syndicate operatives has been confirmed in the vicinity of [station_name()]. Command staff is advised to monitor the status of all high-value assets, and security staff should co-operate with all crew members in securing the station from infiltration."
+	..()


### PR DESCRIPTION
Adds a UI button accessible to newcops team leaders that triggers an announcement and initiates their endgame, which causes the nukesquad playlist to stream globally.

[sound] [gamemode]

:cl:
 * rscadd: Nuclear Assault team leaders can now choose to declare their presence and trigger the nukesquad playlist.