### PR TITLE
No ninja fun allowed

### DIFF
--- a/code/datums/gamemode/role/ninja.dm
+++ b/code/datums/gamemode/role/ninja.dm
@@ -505,11 +505,7 @@ Helpers For Both Variants
 		return
 
 /obj/item/weapon/melee/energy/sword/ninja/proc/checkdroppable()
-	if(active)
-		cant_drop = TRUE
-	else
-		cant_drop = FALSE
-	return cant_drop
+	return cant_drop = active //they should be the same value every time
 
 /obj/item/weapon/melee/energy/sword/ninja/attackby(obj/item/weapon/W, mob/living/user)
 	if(istype(W,/obj/item/weapon/melee/energy/sword))

--- a/code/datums/gamemode/role/ninja.dm
+++ b/code/datums/gamemode/role/ninja.dm
@@ -530,6 +530,12 @@ Helpers For Both Variants
 	if(active)
 		toggleActive(user,togglestate = "off")
 
+/obj/item/weapon/melee/energy/sword/ninja/equipped(mob/user)
+	if(!isninja(user) && active)
+		toggleActive(user,togglestate = "off")
+		to_chat(user,"<span class='warning'>The [src] shuts off.</span>")
+		return
+
 		
 /*=======
 Suit and assorted

--- a/code/datums/gamemode/role/ninja.dm
+++ b/code/datums/gamemode/role/ninja.dm
@@ -493,15 +493,23 @@ Helpers For Both Variants
 	daemon = new /datum/daemon/teleport(src,"Weakness",null)
 
 /obj/item/weapon/melee/energy/sword/ninja/toggleActive(mob/user, var/togglestate = "")
+	if(togglestate) //override
+		..()
+		checkdroppable()
+		return
 	if(isninja(user))
 		..()
+		checkdroppable()
 	else
 		to_chat(user,"<span class='warning'>There's no buttons on it.</span>")
 		return
+
+/obj/item/weapon/melee/energy/sword/ninja/proc/checkdroppable()
 	if(active)
 		cant_drop = TRUE
 	else
 		cant_drop = FALSE
+	return cant_drop
 
 /obj/item/weapon/melee/energy/sword/ninja/attackby(obj/item/weapon/W, mob/living/user)
 	if(istype(W,/obj/item/weapon/melee/energy/sword))
@@ -529,13 +537,12 @@ Helpers For Both Variants
 /obj/item/weapon/melee/energy/sword/ninja/dropped(mob/user)
 	if(active)
 		toggleActive(user,togglestate = "off")
-
+		
 /obj/item/weapon/melee/energy/sword/ninja/equipped(mob/user)
 	if(!isninja(user) && active)
 		toggleActive(user,togglestate = "off")
 		to_chat(user,"<span class='warning'>The [src] shuts off.</span>")
 		return
-
 		
 /*=======
 Suit and assorted


### PR DESCRIPTION
The former is more of a contingency thing for if the latter somehow doesn't work again.
The latter should make it so the former is never needed.

:cl:
 - tweak: Active E-katanas turn themselves off if picked up by non-ninjas
 - bugfix: Active E-katanas should no longer fail to turn themselves off when dropped