### PR TITLE
staffs and scrying orbs are now restricted to spellcasters

### DIFF
--- a/__DEFINES/_macros.dm
+++ b/__DEFINES/_macros.dm
@@ -283,6 +283,8 @@
 
 #define isERT(H) (H.mind && H.mind.GetRole(RESPONDER))
 
+#define isspellcaster(H) (ismagician(H) || iswizard(H) || isapprentice(H))
+
 //Banning someone from the Syndicate role bans them from all antagonist roles
 #define isantagbanned(H) (jobban_isbanned(H, "Syndicate"))
 

--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -88,6 +88,9 @@
 	hitsound = 'sound/items/welder2.ogg'
 
 /obj/item/weapon/scrying/attack_self(mob/user as mob)
+	if(!isspellcaster(user))
+		to_chat(user, "<span class='notice'>You have no idea how to use this.</span>")
+		return
 	to_chat(user, "<span class='notice'>You can see...everything!</span>")
 	visible_message("<span class='danger'>[usr] stares into [src], their eyes glazing over.</span>")
 	user.ghostize(1)

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -93,6 +93,10 @@
 	processing_objects.Remove(src)
 	..()
 
+/obj/item/weapon/gun/energy/staff/preattack(atom/target, mob/living/user, proximity_flag, click_parameters)
+	if(!isspellcaster(user))
+		to_chat(user, "<span class='notice'>You have no idea how to use this.</span>")
+		return 1
 
 /obj/item/weapon/gun/energy/staff/process()
 	charge_tick++
@@ -120,6 +124,9 @@
 	return 1
 
 /obj/item/weapon/gun/energy/staff/change/attack_self(var/mob/living/user)
+	if(!isspellcaster(user))
+		to_chat(user, "<span class='notice'>You have no idea how to use this.</span>")
+		return
 	if(world.time < next_changetype)
 		to_chat(user, "<span class='warning'>[src] is still recharging.</span>")
 		return
@@ -181,6 +188,9 @@
 	return 1
 
 /obj/item/weapon/gun/energy/staff/necro/attack_self(mob/user)
+	if(!isspellcaster(user))
+		to_chat(user, "<span class='notice'>You have no idea how to use this.</span>")
+		return
 	if(next_change > world.timeofday)
 		to_chat(user, "<span class='warning'>You must wait longer to decide on a minion type.</span>")
 		return
@@ -349,6 +359,9 @@
 	flags = FPRINT | TWOHANDABLE
 
 /obj/item/weapon/gun/energy/staff/swapper/update_wield(mob/user)
+	if(!isspellcaster(user))
+		to_chat(user, "<span class='notice'>You have no idea how to use this.</span>")
+		return
 	..()
 	to_chat(user, "<span class = 'notice'>[wielded?"Holding \the [src] in both hands grants it more power!":"As you hold \the [src] in one hand, it sighs."]</span>")
 	if(wielded)
@@ -517,6 +530,9 @@ obj/item/weapon/gun/energy/staff/focus
 	charge_cost = 100
 
 obj/item/weapon/gun/energy/staff/focus/attack_self(mob/living/user as mob)
+	if(!isspellcaster(user))
+		to_chat(user, "<span class='notice'>You have no idea how to use this.</span>")
+		return
 	if(projectile_type == "/obj/item/projectile/forcebolt")
 		charge_cost = 250
 		to_chat(user, "<span class='warning'>The [src.name] will now strike a small area.</span>")


### PR DESCRIPTION
<!-- [featureloss] -->

Something something "staff of change permagunks the round" and "scrying orb makes sec delete all antags".

🆑 
 - rscdel: Magical staffs and scrying orbs can now only be used by antagonist spellcasters. (Wizards, apprentices, magicians)