### PR TITLE
Fixes blueprint lag

### DIFF
--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -183,7 +183,8 @@ these cannot rename rooms that are in by default BUT can rename rooms that are c
 /obj/item/blueprints/process()
 	//Blueprints must be in hands to be usable
 	//Editor must be in the edited area
-	if(!istype(editor) || !editor.client || !currently_edited || (loc != editor) || (!currently_edited.contents.Find(get_turf(editor))) )
+	var/turf/turf_loc = get_turf(editor)
+	if(!istype(editor) || !editor.client || !currently_edited || (loc != editor) || turf_loc.loc != currently_edited )
 		if(editor)
 			to_chat(editor, "<span class='info'>You finish modifying \the [src].</span>")
 


### PR DESCRIPTION
Fixes #23177

Tested it, no longer lags

:cl:
 * bugfix: Blueprints should no longer lag the server when used on large areas (e.g. asteroid)
