### PR TITLE
Chrono-carbon Grenades

### DIFF
--- a/code/defines/obj.dm
+++ b/code/defines/obj.dm
@@ -447,38 +447,42 @@ var/global/list/PDA_Manifest = list()
 	icon_state = "empty"
 	name = "Sleepy time"
 	var/datum/mind/owner
+	var/ignored_type
 	var/spell/aoe_turf/fall/ourspell
 	invisibility = 100
 	var/theworld
 	ignoreinvert = 1
 
-/obj/effect/stop/sleeping/New(loc, ourtime, mind, var/spell/aoe_turf/fall/F, theworld)
+/obj/effect/stop/sleeping/New(loc, ourtime, mind, var/spell/aoe_turf/fall/F, theworld, var/ignored)
 	..()
 	sleeptime = ourtime
 	owner = mind
 	ourspell = F
 	src.theworld = theworld
+	if(ignored)
+		ignored_type = ignored
 
 /obj/effect/stop/sleeping/Crossed(atom/movable/A)
 	if(!(A.flags & TIMELESS) && sleeptime > world.time)
-		if(ismob(A))
-			var/mob/living/L = A
-			if(L.mind != owner)
-				if(L.client)
-					L.client.move_delayer.next_allowed = sleeptime //So we don't need to check timestopped in client/move
-				if(!L.stat)
-					L.playsound_local(src, theworld == 1 ? 'sound/effects/theworld2.ogg' : 'sound/effects/fall2.ogg', 100, 0, 0, 0, 0)
-				//L.Paralyse(round(((sleeptime - world.time)/10)/2, 1))
-				//L.update_canmove()
-				if(!(L in ourspell.affected))
-					invertcolor(L)
-					ourspell.affected += L
-					ourspell.recursive_timestop(L)
-		else
-			if(!(A in ourspell.affected))
-				invertcolor(A)
-				ourspell.affected += A
-				ourspell.recursive_timestop(A)
+		if(!ignored_type || !istype(A,ignored_type))
+			if(ismob(A))
+				var/mob/living/L = A
+				if(L.mind != owner)
+					if(L.client)
+						L.client.move_delayer.next_allowed = sleeptime //So we don't need to check timestopped in client/move
+					if(!L.stat)
+						L.playsound_local(src, theworld == 1 ? 'sound/effects/theworld2.ogg' : 'sound/effects/fall2.ogg', 100, 0, 0, 0, 0)
+					//L.Paralyse(round(((sleeptime - world.time)/10)/2, 1))
+					//L.update_canmove()
+					if(!(L in ourspell.affected))
+						invertcolor(L)
+						ourspell.affected += L
+						ourspell.recursive_timestop(L)
+			else
+				if(!(A in ourspell.affected))
+					invertcolor(A)
+					ourspell.affected += A
+					ourspell.recursive_timestop(A)
 
 
 /obj/effect/spawner

--- a/code/game/objects/items/weapons/grenades/chronogrenade.dm
+++ b/code/game/objects/items/weapons/grenades/chronogrenade.dm
@@ -12,7 +12,17 @@
 /obj/item/weapon/grenade/chronogrenade/prime()
 	timestop(src, duration, radius)
 	qdel(src)
+	
+/obj/item/weapon/grenade/chronogrenade/carbon
+	name = "chrono-carbon grenade"
+	desc = "This experimental weapon will halt the progression of time in the local area for ten seconds. Carbon lifeforms are not unaffected by the field."
+	icon_state = "past_grenade"
+	duration = 15 SECONDS
 
+/obj/item/weapon/grenade/chronogrenade/carbon/prime()
+	timestop(src, duration, radius, 0, /mob/living/carbon/)
+	qdel(src)	
+	
 /obj/item/weapon/grenade/chronogrenade/future
 	desc = "This experimental weapon will send all entities in the local area ten seconds into the future."
 	icon_state = "future_grenade"

--- a/code/game/objects/items/weapons/grenades/chronogrenade.dm
+++ b/code/game/objects/items/weapons/grenades/chronogrenade.dm
@@ -15,7 +15,7 @@
 	
 /obj/item/weapon/grenade/chronogrenade/carbon
 	name = "chrono-carbon grenade"
-	desc = "This experimental weapon will halt the progression of time in the local area for ten seconds. Carbon lifeforms are not unaffected by the field."
+	desc = "This experimental weapon will halt the progression of time in the local area for ten seconds. Carbon lifeforms are not affected by the field."
 	icon_state = "past_grenade"
 	duration = 15 SECONDS
 

--- a/code/modules/spells/aoe_turf/fall.dm
+++ b/code/modules/spells/aoe_turf/fall.dm
@@ -69,7 +69,7 @@ var/global/list/falltempoverlays = list()
 		for(i = -x, i <= x, i++)
 			. += "[x],[y]"
 
-/spell/aoe_turf/fall/perform(mob/user = usr, skipcharge = 0, var/ignore_timeless = FALSE) //if recharge is started is important for the trigger spells
+/spell/aoe_turf/fall/perform(mob/user = usr, skipcharge = 0, var/ignore_timeless = FALSE, var/ignore_path = null) //if recharge is started is important for the trigger spells
 	if(!holder)
 		set_holder(user) //just in case
 	if(!cast_check(skipcharge, user))
@@ -90,11 +90,11 @@ var/global/list/falltempoverlays = list()
 		if(prob(critfailchance))
 			critfail(targets, user)
 		else
-			cast(targets, user, ignore_timeless)
+			cast(targets, user, ignore_timeless, ignore_path)
 		after_cast(targets) //generates the sparks, smoke, target messages etc.
 		invocation = initial(invocation)
 
-/spell/aoe_turf/fall/cast(list/targets, mob/user, var/ignore_timeless = FALSE)
+/spell/aoe_turf/fall/cast(list/targets, mob/user, var/ignore_timeless = FALSE, var/ignore_path)
 	var/turf/ourturf = get_turf(user)
 
 	var/list/potentials = circlerangeturfs(user, range)
@@ -120,10 +120,13 @@ var/global/list/falltempoverlays = list()
 
 	sleepfor = world.time + sleeptime
 	for(var/turf/T in targets)
-		oureffects += getFromPool(/obj/effect/stop/sleeping, T, sleepfor, user.mind, src, invocation == "ZA WARUDO")
+		
+		oureffects += getFromPool(/obj/effect/stop/sleeping, T, sleepfor, user.mind, src, invocation == "ZA WARUDO", ignore_path)
 		for(var/atom/movable/everything in T)
 			if(isliving(everything))
 				var/mob/living/L = everything
+				if(ignore_path && istype(everything,ignore_path))
+					continue
 				if(L == holder)
 					continue
 				if(!ignore_timeless && L.flags & TIMELESS)
@@ -133,6 +136,8 @@ var/global/list/falltempoverlays = list()
 				spawn() recursive_timestop(L)
 				L.playsound_local(L, invocation == "ZA WARUDO" ? 'sound/effects/theworld2.ogg' : 'sound/effects/fall2.ogg', 100, 0, 0, 0, 0)
 			else
+				if(ignore_path && istype(everything,ignore_path))
+					continue
 				if(!ignore_timeless && everything.flags & TIMELESS)
 					continue
 				spawn() recursive_timestop(everything)
@@ -146,6 +151,7 @@ var/global/list/falltempoverlays = list()
 
 		affected += T
 	return
+	
 /spell/aoe_turf/fall/proc/recursive_timestop(var/atom/O, var/ignore_timeless = FALSE)
 	var/list/processing_list = list(O)
 	var/list/processed_list = new/list()
@@ -219,7 +225,7 @@ var/global/list/falltempoverlays = list()
 						0,0,-1,
 						1,1,1)
 
-/proc/timestop(atom/A, var/duration, var/range, var/ignore_timeless = FALSE)
+/proc/timestop(atom/A, var/duration, var/range, var/ignore_timeless = FALSE, var/ignore_path = null)
 	if(!A || !duration)
 		return
 	var/mob/caster = new
@@ -236,5 +242,8 @@ var/global/list/falltempoverlays = list()
 	fall.sleeptime = duration			//for how long
 	caster.forceMove(get_turf(A))
 	spawn()
-		fall.perform(caster, skipcharge = 1, ignore_timeless = ignore_timeless)
-		qdel(caster)
+		if(ignore_path)
+			fall.perform(caster, skipcharge = 1, ignore_timeless = ignore_timeless, ignore_path = ignore_path)
+		else
+			fall.perform(caster, skipcharge = 1, ignore_timeless = ignore_timeless)
+		


### PR DESCRIPTION
This PR simply adds a chrono-carbon grenade, chrono grenades that do not affect /mob/living/carbon type mobs. An extra optional variable is added to the time stop spell to add an ignore path that will ignore all items of that type.

There is currently no way to obtain the item outside of adminbus. It is meant to be put in the black market if the PR goes through. Useful for creating "no fire" zones, as all projectiles will be stopped. Lasts 15 seconds currently.