### PR TITLE
Teleporter TLC

### DIFF
--- a/code/defines/obj.dm
+++ b/code/defines/obj.dm
@@ -370,16 +370,6 @@ var/global/list/PDA_Manifest = list()
 		)
 	return PDA_Manifest
 
-
-
-/obj/effect/laser
-	name = "laser"
-	desc = "IT BURNS!!!"
-	icon = 'icons/obj/projectiles.dmi'
-	var/damage = 0.0
-	var/range = 10.0
-
-
 /obj/effect/list_container
 	name = "list container"
 

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -956,8 +956,8 @@ obj/item/weapon/circuitboard/rdserver
 
 //Teleporter
 /obj/item/weapon/circuitboard/telehub
-	name = "Circuit Board (Teleporter Hub)"
-	desc = "A circuit board used to run a machine that works as the base for a teleporter."
+	name = "Circuit Board (Teleporter Generator)"
+	desc = "A circuit board used to run a machine that generates a teleporter horizon."
 	build_path = /obj/machinery/teleport/hub
 	board_type = MACHINE
 	origin_tech = Tc_PROGRAMMING + "=4;" + Tc_ENGINEERING + "=3;" + Tc_BLUESPACE + "=3"
@@ -971,8 +971,8 @@ obj/item/weapon/circuitboard/rdserver
 							/obj/item/weapon/stock_parts/subspace/transmitter = 4)
 
 /obj/item/weapon/circuitboard/telestation
-	name = "Circuit Board (Teleporter Station)"
-	desc = "A circuit board used to run a machine that generates an active teleportation field."
+	name = "Circuit Board (Teleporter Controller)"
+	desc = "A circuit board used to co-ordinate teleporter generators."
 	build_path = /obj/machinery/teleport/station
 	board_type = MACHINE
 	origin_tech = Tc_PROGRAMMING + "=4;" + Tc_ENGINEERING + "=3;" + Tc_BLUESPACE + "=3"

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -193,11 +193,10 @@
 	machine_flags = SCREWTOGGLE | CROWDESTROY | WRENCHMOVE | FIXED2WORK
 
 /obj/machinery/teleport/hub
-	name = "teleporter hub"
-	desc = "It's the hub of a teleporting machine."
+	name = "teleporter horizon generator"
+	desc = "This generates the portal through which you step through to teleport elsewhere."
 	icon_state = "tele0"
 	var/accurate = 0
-	var/opened = 0.0
 	use_power = 1
 	idle_power_usage = 10
 	active_power_usage = 2000
@@ -284,10 +283,9 @@
 
 
 /obj/machinery/teleport/station
-	name = "station"
-	desc = "It's the station thingy of a teleport thingy." //seriously, wtf.
+	name = "teleporter controller"
+	desc = "This co-ordinates nearby teleporter horizon generators."
 	icon_state = "controller"
-	var/opened = 0.0
 	use_power = 1
 	idle_power_usage = 10
 	active_power_usage = 2000

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -156,7 +156,7 @@
 				if (M.timeofdeath + 6000 < world.time)
 					continue
 			var/turf/T = get_turf(M)
-			if(T)
+			if(!T)
 				continue
 			if(T.z == map.zCentcomm)
 				continue
@@ -190,8 +190,7 @@
 	var/engaged = 0
 	ghost_read=0 // #519
 	ghost_write=0
-
-
+	machine_flags = SCREWTOGGLE | CROWDESTROY | WRENCHMOVE | FIXED2WORK
 
 /obj/machinery/teleport/hub
 	name = "teleporter hub"
@@ -204,29 +203,8 @@
 	active_power_usage = 2000
 	density = 0
 
-	machine_flags = SCREWTOGGLE | CROWDESTROY
-
-/obj/machinery/teleport/hub/power_change()
-	..()
-	if(stat & (BROKEN|NOPOWER))
-		engaged = 0
-	update_icon()
-
-/obj/machinery/teleport/hub/update_icon()
-	if(stat & (BROKEN|NOPOWER) || !engaged)
-		icon_state = "tele0"
-	else
-		icon_state = "tele1"
-
-/obj/machinery/teleport/hub/attackby(obj/item/weapon/O as obj, mob/user as mob)
-	return(..())
-
-/********************************************************************
-**   Adding Stock Parts to VV so preconstructed shit has its candy **
-********************************************************************/
 /obj/machinery/teleport/hub/New()
 	. = ..()
-
 	component_parts = newlist(
 		/obj/item/weapon/circuitboard/telehub,
 		/obj/item/weapon/stock_parts/scanning_module/adv/phasic,
@@ -246,8 +224,20 @@
 		/obj/item/weapon/stock_parts/subspace/transmitter,
 		/obj/item/weapon/stock_parts/subspace/transmitter
 	)
-
 	RefreshParts()
+
+/obj/machinery/teleport/hub/power_change()
+	..()
+	if(stat & (BROKEN|NOPOWER))
+		engaged = 0
+	update_icon()
+
+/obj/machinery/teleport/hub/update_icon()
+	if(stat & (BROKEN|NOPOWER) || !engaged)
+		icon_state = "tele0"
+	else
+		icon_state = "tele1"
+
 
 /obj/machinery/teleport/hub/Crossed(AM as mob|obj)
 	if(AM == src)
@@ -259,23 +249,25 @@
 		src.to_bump(AM)
 		return
 	spawn()
-		if (src.engaged)
-			teleport(AM)
+		if (src.engaged && teleport(AM))
 			use_power(5000)
 
 /obj/machinery/teleport/hub/proc/teleport(atom/movable/M as mob|obj)
-	var/atom/l = src.loc
-	var/obj/machinery/computer/teleporter/com = locate(/obj/machinery/computer/teleporter, locate(l.x - 2, l.y, l.z))
+	var/obj/machinery/teleport/station/st = locate(/obj/machinery/teleport/station, orange(1))
+	var/obj/machinery/computer/teleporter/com = locate(/obj/machinery/computer/teleporter, orange(1, st))
 	if (!com)
-		return
+		return 0
 	if (!com.locked || com.locked.gcDestroyed)
 		com.locked = null
 		visible_message("<span class='warning'>Failure: Cannot authenticate locked on coordinates. Please reinstate coordinate matrix.</span>")
-		return
+		return 0
+	if(get_turf(com.locked) == get_turf(src))
+		to_chat(M, "<span class = 'notice'>The act of teleportation was so smooth, it feels like you didn't move at all.</span>")
+		return 0
 	var/list/contents_of_M = get_contents_in_object(M)
 	if(locate(com.locked) in contents_of_M)
 		visible_message("<span class = 'warning'>Infinite loop prevention: Attempted to teleport locked object to locked object.</span>")
-		return
+		return 0
 	if (istype(M, /atom/movable))
 		if(prob(5) && !accurate) //oh dear a problem, put em in deep space
 			do_teleport(M, locate(rand((2*TRANSITIONEDGE), world.maxx - (2*TRANSITIONEDGE)), rand((2*TRANSITIONEDGE), world.maxy - (2*TRANSITIONEDGE)), 3), 2)
@@ -288,6 +280,8 @@
 	else
 		spark(src, 5)
 
+	return 1
+
 
 /obj/machinery/teleport/station
 	name = "station"
@@ -298,24 +292,7 @@
 	idle_power_usage = 10
 	active_power_usage = 2000
 
-	machine_flags = SCREWTOGGLE | CROWDESTROY
-
-/obj/machinery/teleport/station/power_change()
-	..()
-	if(stat & (BROKEN|NOPOWER))
-		disengage()
-	update_icon()
-
-/obj/machinery/teleport/station/update_icon()
-	if(stat & NOPOWER)
-		icon_state = "controller-p"
-	else
-		icon_state = "controller"
-
-/********************************************************************
-**   Adding Stock Parts to VV so preconstructed shit has its candy **
-********************************************************************/
-obj/machinery/teleport/station/New()
+/obj/machinery/teleport/station/New()
 	. = ..()
 
 	component_parts = newlist(
@@ -331,8 +308,21 @@ obj/machinery/teleport/station/New()
 		/obj/item/weapon/stock_parts/subspace/analyzer,
 		/obj/item/weapon/stock_parts/subspace/analyzer
 	)
-
 	RefreshParts()
+
+/obj/machinery/teleport/station/power_change()
+	..()
+	if(stat & (BROKEN|NOPOWER))
+		disengage()
+	update_icon()
+
+/obj/machinery/teleport/station/update_icon()
+	if(stat & NOPOWER)
+		icon_state = "controller-p"
+	else
+		icon_state = "controller"
+
+
 
 /obj/machinery/teleport/station/attackby(var/obj/item/weapon/W, var/mob/user as mob)
 	if (..())
@@ -355,27 +345,22 @@ obj/machinery/teleport/station/New()
 /obj/machinery/teleport/station/proc/engage()
 	if(stat & (BROKEN|NOPOWER))
 		return
-
-	var/atom/l = src.loc
-	var/obj/machinery/teleport/hub/hub = locate(/obj/machinery/teleport/hub, locate(l.x + 1, l.y, l.z))
-	if (hub)
+	for(var/obj/machinery/teleport/hub/hub in orange(1))
+		if(hub.stat & (BROKEN|NOPOWER))
+			continue
 		hub.engaged = 1
 		hub.update_icon()
 		use_power(5000)
-		for(var/mob/O in hearers(src, null))
-			O.show_message("<span class='notice'>Teleporter engaged!</span>", 2)
+	visible_message("<span class='notice'>Teleporter engaged!</span>", range = 2)
 	src.add_fingerprint(usr)
 	src.engaged = 1
 	return
 
 /obj/machinery/teleport/station/proc/disengage(mob/user)
-	var/atom/l = src.loc
-	var/obj/machinery/teleport/hub/hub = locate(/obj/machinery/teleport/hub, locate(l.x + 1, l.y, l.z))
-	if (hub)
+	for(var/obj/machinery/teleport/hub/hub in orange(1))
 		hub.engaged = 0
 		hub.update_icon()
-		for(var/mob/O in hearers(src, null))
-			O.show_message("<span class='notice'>Teleporter disengaged!</span>", 2)
+	visible_message("<span class='notice'>Teleporter disengaged!</span>", range = 2)
 	if(user)
 		src.add_fingerprint(user)
 	src.engaged = 0
@@ -389,35 +374,19 @@ obj/machinery/teleport/station/New()
 	if(stat & (BROKEN|NOPOWER) || !istype(usr,/mob/living))
 		return
 
-	var/atom/l = src.loc
-	var/obj/machinery/teleport/hub/hub = locate(/obj/machinery/teleport/hub, locate(l.x + 1, l.y, l.z))
-	if (hub)
+
+	for(var/obj/machinery/teleport/hub/hub in orange(1))
 		engaged = 1
 		var/wasaccurate = hub.accurate //let's make sure if you have a mapped in accurate tele that it stays that way
 		hub.accurate = 1
 		hub.engaged = 1
 		hub.update_icon()
-		for(var/mob/O in hearers(src, null))
-			O.show_message("<span class='notice'>Test firing! Teleporter temporarily calibrated to be more accurate.</span>", 2)
+		visible_message("<span class='notice'>Test firing! Teleporter temporarily calibrated to be more accurate.</span>", range = 2)
 		hub.teleport()
 		use_power(5000)
-
 		spawn(30)
 			hub.accurate = wasaccurate
-			for(var/mob/B in hearers(src, null))
-				B.show_message("<span class='notice'>Test fire completed.</span>", 2)
+			visible_message("<span class='notice'>Test fire completed.</span>", range = 2)
 
 	src.add_fingerprint(usr)
 	return
-
-
-/obj/effect/laser/to_bump()
-	src.range--
-	return
-
-/obj/effect/laser/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
-	src.range--
-	return
-
-/atom/proc/laserhit(L as obj)
-	return 1

--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -169,6 +169,7 @@ Frequency:
 /obj/item/weapon/hand_tele/examine(var/mob/user)
 	..()
 	to_chat(user, "<span class='notice'>Alt-Click the hand tele to set portal destination. Defaults to your last choice.</span>")
+	to_chat(user, "<span class='notice'>Charge: [charge]/[HANDTELE_MAX_CHARGE] ([charge/HANDTELE_PORTAL_COST]/[HANDTELE_MAX_CHARGE/HANDTELE_PORTAL_COST])</span>")
 
 /obj/item/weapon/hand_tele/attack_self(mob/user as mob)
 	var/turf/current_location = get_turf(user)//What turf is the user on?
@@ -213,12 +214,13 @@ Frequency:
 /obj/item/weapon/hand_tele/proc/choose_destination(var/mob/user)
 	var/list/L = list(  )
 	for(var/obj/machinery/computer/teleporter/R in machines)
-		for(var/obj/machinery/teleport/hub/com in locate(R.x + 2, R.y, R.z))
-			if(R.locked && !R.one_time_use)
-				if(com.engaged)
-					L["[R.id] (Active)"] = R.locked
-				else
-					L["[R.id] (Inactive)"] = R.locked
+		for(var/obj/machinery/teleport/station/S in orange(1,R))
+			for(var/obj/machinery/teleport/hub/com in orange(1,S))
+				if(R.locked && !R.one_time_use)
+					if(com.engaged)
+						L["[R.id] (Active)"] = R.locked
+					else
+						L["[R.id] (Inactive)"] = R.locked
 
 	var/list/turfs = new/list()
 

--- a/code/modules/research/designs/boards/machine_command.dm
+++ b/code/modules/research/designs/boards/machine_command.dm
@@ -23,8 +23,8 @@
 	build_path = /obj/item/weapon/circuitboard/pdapainter
 
 /datum/design/telehub
-	name = "Circuit Design (Teleporter Hub)"
-	desc = "Allows for the construction of circuit boards used to build a Teleporter Hub"
+	name = "Circuit Design (Teleporter Generator)"
+	desc = "Allows for the construction of circuit boards used to build a Teleporter Generator"
 	id = "telehub"
 	req_tech = list(Tc_PROGRAMMING = 4, Tc_ENGINEERING = 3, Tc_BLUESPACE = 3)
 	build_type = IMPRINTER
@@ -33,8 +33,8 @@
 	build_path = /obj/item/weapon/circuitboard/telehub
 
 /datum/design/telestation
-	name = "Circuit Design (Teleporter Station)"
-	desc = "Allows for the construction of circuit boards used to build a Teleporter Station."
+	name = "Circuit Design (Teleporter Controller)"
+	desc = "Allows for the construction of circuit boards used to build a Teleporter Controller."
 	id = "telestation"
 	req_tech = list(Tc_PROGRAMMING = 4, Tc_ENGINEERING = 3, Tc_BLUESPACE = 3)
 	build_type = IMPRINTER


### PR DESCRIPTION
 - Removed a redundant laser object
 - Fixed a bug where tracking implants weren't showing as targets on the teleporter console
 - Renamed the Hub and Station to Controller and Generator because holy fuck is it annoying to keep getting the two mixed up
 - Made it possible to hook up multiple TeleGenerators to a TeleController, and multiple TeleControllers to the same teleporter console
 - Made telegenerators and telecontrollers WRENCHMOVE and FIXED2WORK

:cl:
 * tweak: The two teleporter machines are now renamed from Station and Hub, to Controller and Generator.
 * tweak: Teleporters will not consume power on an unsuccessful teleport.
 * tweak: Examining a hand teleporter now tells you its current charge, and a summary of how many portals that remaining charge can make.
 * bugfix: Fixed a bug where you could teleport infinitely onto the teleporter generator, lagging the server.
 * rscadd: A teleporter controller can now manage multiple teleporter generators.
 * rscadd: A teleporter console can now manage multiple teleporter controllers.
 * rscadd: Teleporter generators and teleporter controllers can now be wrenched to move them around.
 * bugfix: Fixes an unreported bug where tracking implants would not show up as a potential teleport location on teleporters.