### PR TITLE
Change roundstart camera failure into a camera failure random event

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -22,7 +22,7 @@ var/list/camera_names=list()
 	anchored = 1.0
 	var/invuln = null
 	var/bugged = 0
-	var/failure_chance = 10
+	var/failure_chance = 15
 	var/obj/item/weapon/camera_assembly/assembly = null
 	var/light_on = 0
 
@@ -44,11 +44,6 @@ var/list/camera_names=list()
 
 /obj/machinery/camera/flawless
 	failure_chance = 0
-
-/obj/machinery/camera/initialize()
-	..()
-	if(prob(failure_chance))
-		deactivate()
 
 /obj/machinery/camera/update_icon()
 	var/EMPd = stat & EMPED

--- a/code/modules/events/camera_failure.dm
+++ b/code/modules/events/camera_failure.dm
@@ -1,0 +1,18 @@
+//This file was auto-corrected by findeclaration.exe on 29/05/2012 15:03:04
+
+/datum/event/camera_failure
+	announceWhen = 500
+
+/datum/event/camera_failure/setup()
+	announceWhen = rand(250, 750)
+
+/datum/event/camera_failure/announce()
+
+	command_alert(/datum/command_alert/ion_storm_large) //Same as ion storm. It is AI-controlled equipment that failed, afterall
+
+/datum/event/camera_failure/start()
+
+	for(var/obj/machinery/camera/camera in cameranet.cameras)
+		if(prob(camera.failure_chance))
+			camera.triggerCameraAlarm()
+			camera.deactivate()

--- a/code/modules/events/event_dynamic.dm
+++ b/code/modules/events/event_dynamic.dm
@@ -49,6 +49,7 @@ var/list/event_last_fired = list()
 
 	if(active_with_role["AI"] > 0 || active_with_role["Cyborg"] > 0)
 		possibleEvents[/datum/event/ionstorm] = 30
+	possibleEvents[/datum/event/camera_failure] = 40
 	possibleEvents[/datum/event/grid_check] = 20 //May cause lag
 	possibleEvents[/datum/event/electrical_storm] = 10
 	possibleEvents[/datum/event/wallrot] = 30

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -1415,6 +1415,7 @@
 #include "code\modules\events\alien_infestation.dm"
 #include "code\modules\events\bluespaceanomaly.dm"
 #include "code\modules\events\brand_intelligence.dm"
+#include "code\modules\events\camera_failure.dm"
 #include "code\modules\events\carp_migration.dm"
 #include "code\modules\events\centcomm_order.dm"
 #include "code\modules\events\comms_blackout.dm"


### PR DESCRIPTION
As suggested by Pomf. The roundstart camera failures were way too harsh on AIs since it basically created a lot of blindspots (320-ish cameras on Box, hence 32 failures). Also, it didn't proc any alerts, and it didn't seem possible to do so as long as it was an init proc

Instead, random event that busts 15 % of the station's cameras. Can always happen, relatively high chance. It will trigger alerts but the AI will not be directly pinged about it, allowing the maintenance crew to actually track down the breakdowns

:cl:
 * rscadd: Added a random event that breaks 15 % of the station's cameras (minus flawless cam, aka critical ones)
 * rscdel: Removed the roundstart chance for cameras to break