### PR TITLE
Meteors will now target the general center of the station like rods, massively increasing the amount that will cross the station

### DIFF
--- a/code/game/gamemodes/meteor/meteor_universe.dm
+++ b/code/game/gamemodes/meteor/meteor_universe.dm
@@ -67,5 +67,5 @@
 	spawn()
 		while(meteors_allowed && src == global.universe)
 			var/meteors_in_wave = rand(meteor_wave_size_l, meteor_wave_size_h)
-			meteor_wave(meteors_in_wave, 3)
+			meteor_wave(meteors_in_wave, 3, offset_origin = 150, offset_dest = 230)
 			sleep(10)

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -7,7 +7,7 @@
 /var/chosen_dir = 1
 
 //Call above constants to change
-/proc/meteor_wave(var/number = meteors_in_wave, var/max_size = 0, var/list/types = null, var/offset_origin = 0, var/offset_dest = 0)
+/proc/meteor_wave(var/number = meteors_in_wave, var/max_size = 0, var/list/types = null, var/offset_origin = 150, var/offset_dest = 230)
 
 	if(!ticker || meteor_wave_active)
 		return
@@ -78,25 +78,29 @@
 		switch(chosen_dir)
 
 			if(1) //North, along the y = max edge
-				starty = world.maxy - (TRANSITIONEDGE + 5)
-				startx = rand((TRANSITIONEDGE + 5 + offset_origin), world.maxx - (TRANSITIONEDGE + 5 + offset_origin))
+				starty = world.maxy - (TRANSITIONEDGE + 2)
+				startx = rand((TRANSITIONEDGE + 2 + offset_origin), world.maxx - (TRANSITIONEDGE + 2 + offset_origin))
+				endy = TRANSITIONEDGE
+				endx = rand(TRANSITIONEDGE + offset_dest, world.maxx - TRANSITIONEDGE - offset_dest)
 
 			if(2) //South, along the y = 0 edge
-				starty = (TRANSITIONEDGE + 5)
-				startx = rand((TRANSITIONEDGE + 5 + offset_origin), world.maxx - (TRANSITIONEDGE + 5 + offset_origin))
+				starty = (TRANSITIONEDGE + 2)
+				startx = rand((TRANSITIONEDGE + 2 + offset_origin), world.maxx - (TRANSITIONEDGE + 2 + offset_origin))
+				endy = world.maxy - (TRANSITIONEDGE + 2)
+				endx = rand(TRANSITIONEDGE + offset_dest, world.maxx - TRANSITIONEDGE - offset_dest)
 
 			if(4) //East, along the x = max edge
-				starty = rand((TRANSITIONEDGE + 5 + offset_origin), world.maxy - (TRANSITIONEDGE + 5 + offset_origin))
-				startx = world.maxx - (TRANSITIONEDGE + 5)
+				starty = rand((TRANSITIONEDGE + 2 + offset_origin), world.maxy - (TRANSITIONEDGE + 2 + offset_origin))
+				startx = world.maxx - (TRANSITIONEDGE + 2)
+				endy = rand(TRANSITIONEDGE + offset_dest, world.maxy - TRANSITIONEDGE - offset_dest)
+				endx = (TRANSITIONEDGE + 2)
 
 			if(8) //West, along the x = 0 edge
-				starty = rand((TRANSITIONEDGE + 5 + offset_origin), world.maxy - (TRANSITIONEDGE + 5 + offset_origin))
-				startx = (TRANSITIONEDGE + 5)
+				starty = rand((TRANSITIONEDGE + 2 + offset_origin), world.maxy - (TRANSITIONEDGE + 2 + offset_origin))
+				startx = (TRANSITIONEDGE + 2)
+				endy = rand(TRANSITIONEDGE + offset_dest, world.maxy - TRANSITIONEDGE - offset_dest)
+				endx = world.maxx - (TRANSITIONEDGE + 2)
 
-		//Grabs a turf in the center of the z-level
-		//Offset by 50 in every direction, bit more innacurate than a rod but won't miss wide like current
-		endx = rand((world.maxx/2) - 50,(world.maxx/2) + 50)
-		endy = rand((world.maxy/2) - 50,(world.maxy/2) + 50)
 		pickedstart = locate(startx, starty, 1)
 		pickedgoal = locate(endx, endy, 1)
 		max_i--

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -78,29 +78,25 @@
 		switch(chosen_dir)
 
 			if(1) //North, along the y = max edge
-				starty = world.maxy - (TRANSITIONEDGE + 2)
-				startx = rand((TRANSITIONEDGE + 2 + offset_origin), world.maxx - (TRANSITIONEDGE + 2 + offset_origin))
-				endy = TRANSITIONEDGE
-				endx = rand(TRANSITIONEDGE + offset_dest, world.maxx - TRANSITIONEDGE - offset_dest)
+				starty = world.maxy - (TRANSITIONEDGE + 5)
+				startx = rand((TRANSITIONEDGE + 5 + offset_origin), world.maxx - (TRANSITIONEDGE + 5 + offset_origin))
 
 			if(2) //South, along the y = 0 edge
-				starty = (TRANSITIONEDGE + 2)
-				startx = rand((TRANSITIONEDGE + 2 + offset_origin), world.maxx - (TRANSITIONEDGE + 2 + offset_origin))
-				endy = world.maxy - (TRANSITIONEDGE + 2)
-				endx = rand(TRANSITIONEDGE + offset_dest, world.maxx - TRANSITIONEDGE - offset_dest)
+				starty = (TRANSITIONEDGE + 5)
+				startx = rand((TRANSITIONEDGE + 5 + offset_origin), world.maxx - (TRANSITIONEDGE + 5 + offset_origin))
 
 			if(4) //East, along the x = max edge
-				starty = rand((TRANSITIONEDGE + 2 + offset_origin), world.maxy - (TRANSITIONEDGE + 2 + offset_origin))
-				startx = world.maxx - (TRANSITIONEDGE + 2)
-				endy = rand(TRANSITIONEDGE + offset_dest, world.maxy - TRANSITIONEDGE - offset_dest)
-				endx = (TRANSITIONEDGE + 2)
+				starty = rand((TRANSITIONEDGE + 5 + offset_origin), world.maxy - (TRANSITIONEDGE + 5 + offset_origin))
+				startx = world.maxx - (TRANSITIONEDGE + 5)
 
 			if(8) //West, along the x = 0 edge
-				starty = rand((TRANSITIONEDGE + 2 + offset_origin), world.maxy - (TRANSITIONEDGE + 2 + offset_origin))
-				startx = (TRANSITIONEDGE + 2)
-				endy = rand(TRANSITIONEDGE + offset_dest, world.maxy - TRANSITIONEDGE - offset_dest)
-				endx = world.maxx - (TRANSITIONEDGE + 2)
+				starty = rand((TRANSITIONEDGE + 5 + offset_origin), world.maxy - (TRANSITIONEDGE + 5 + offset_origin))
+				startx = (TRANSITIONEDGE + 5)
 
+		//Grabs a turf in the center of the z-level
+		//Offset by 50 in every direction, bit more innacurate than a rod but won't miss wide like current
+		endx = rand((world.maxx/2) - 50,(world.maxx/2) + 50)
+		endy = rand((world.maxy/2) - 50,(world.maxy/2) + 50)
 		pickedstart = locate(startx, starty, 1)
 		pickedgoal = locate(endx, endy, 1)
 		max_i--

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -7,7 +7,7 @@
 /var/chosen_dir = 1
 
 //Call above constants to change
-/proc/meteor_wave(var/number = meteors_in_wave, var/max_size = 0, var/list/types = null, var/offset_origin = 150, var/offset_dest = 230)
+/proc/meteor_wave(var/number = meteors_in_wave, var/max_size = 0, var/list/types = null, var/offset_origin = 0, var/offset_dest = 0)
 
 	if(!ticker || meteor_wave_active)
 		return

--- a/code/modules/events/meteors.dm
+++ b/code/modules/events/meteors.dm
@@ -16,7 +16,7 @@
 
 //Two to three waves. So 40 to 120
 /datum/event/meteor_wave/tick()
-	meteor_wave(rand(20, 40), max_size = 2) //Large waves, panic is mandatory
+	meteor_wave(rand(20, 40), max_size = 2, offset_origin = 150, offset_dest = 230) //Large waves, panic is mandatory
 
 /datum/event/meteor_wave/end()
 	command_alert(/datum/command_alert/meteor_wave_end)
@@ -35,7 +35,7 @@
 //Meteor showers are lighter and more common
 //Sometimes a single wave, most likely two, so anywhere from 10 to 30 small meteors
 /datum/event/meteor_shower/tick()
-	meteor_wave(rand(10, 15), max_size = 1) //Much more clement
+	meteor_wave(rand(10, 15), max_size = 1, offset_origin = 150, offset_dest = 230) //Much more clement
 
 /datum/event/meteor_shower/end()
 	command_alert(/datum/command_alert/meteor_wave_end)
@@ -48,7 +48,7 @@
 /datum/event/meteor_shower/meteor_quiet/announce()
 
 /datum/event/meteor_shower/meteor_quiet/tick()
-	meteor_wave(rand(7, 10), max_size = 2) //Good balance of sizes and abundance between shower and storm
+	meteor_wave(rand(7, 10), max_size = 2, offset_origin = 150, offset_dest = 230) //Good balance of sizes and abundance between shower and storm
 
 /datum/event/meteor_shower/meteor_quiet/end()
 
@@ -150,7 +150,7 @@ var/global/list/thing_storm_types = list(
 //Meteor showers are lighter and more common
 //Since this isn't rocks of pure pain and explosion, we have more, anywhere from 10 to 40 items
 /datum/event/thing_storm/tick()
-	meteor_wave(rand(10, 20), types = thing_storm_types[storm_name]) //Much more clement
+	meteor_wave(rand(10, 20), types = thing_storm_types[storm_name], offset_origin = 150, offset_dest = 230) //Much more clement
 
 /datum/event/thing_storm/end()
 	command_alert("The station has cleared the [storm_name].", "Meteor Alert")
@@ -162,7 +162,7 @@ var/global/list/thing_storm_types = list(
 	storm_name="meaty gore storm"
 
 /datum/event/thing_storm/meaty_gore/tick()
-	meteor_wave(rand(45, 60), types = thing_storm_types[storm_name])
+	meteor_wave(rand(45, 60), types = thing_storm_types[storm_name], offset_origin = 150, offset_dest = 230)
 
 /datum/event/thing_storm/meaty_gore/announce()
 	command_alert("The station is about to pass through an unknown organic debris field. No hull breaches are likely.", "Organic Debris Field")
@@ -177,7 +177,7 @@ var/global/list/thing_storm_types = list(
 	storm_name="blob shower"
 
 /datum/event/thing_storm/blob_shower/tick()
-	meteor_wave(rand(12, 24), types = thing_storm_types[storm_name])
+	meteor_wave(rand(12, 24), types = thing_storm_types[storm_name], offset_origin = 150, offset_dest = 230)
 
 /datum/event/thing_storm/blob_shower/announce()
 	command_alert(/datum/command_alert/blob_storm)
@@ -195,7 +195,7 @@ var/global/list/thing_storm_types = list(
 	storm_name="blob storm"
 
 /datum/event/thing_storm/blob_storm/tick()
-	var/chosen_dir = meteor_wave(rand(20, 40), types = thing_storm_types[storm_name])
+	var/chosen_dir = meteor_wave(rand(20, 40), types = thing_storm_types[storm_name], offset_origin = 150, offset_dest = 230)
 	if(!cores_spawned)
 		var/living = 0
 		for(var/mob/living/M in player_list)
@@ -226,7 +226,7 @@ var/global/list/thing_storm_types = list(
 	storm_name="fireworks"
 
 /datum/event/thing_storm/fireworks/tick()
-	meteor_wave(rand(45, 60), types = thing_storm_types[storm_name])
+	meteor_wave(rand(45, 60), types = thing_storm_types[storm_name], offset_origin = 150, offset_dest = 230)
 
 /datum/event/thing_storm/fireworks/announce()
 	command_alert("The station is about to be bombarded by light-based distraction projectiles. Source unknown. No hull breaches are likely.", "Firework Fiasco")


### PR DESCRIPTION
Yep, same code as immovable rods. Dearly needed, but I guess no-one but me is ever going to touch Meteors and meteor-related code, right ?

This still means meteors will spread out when hitting the station due to spawning across the entire edge of space, but they will no longer graze or go wide, or just never hit anything

:cl:
 * rscadd: Meteors will now head for the general center of the station, instead of some random location which previously meant that a good half to two thirds will miss wide. You can thank me later for the Meteors rounds.