### PR TITLE
Conveyors insert things into Machinery

### DIFF
--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -111,6 +111,7 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 			return
 
 	L.unlock_from() //We checked above that they can ONLY be buckled to a rollerbed to allow this to happen!
+	message_admins("huh")
 	if(put_mob(L))
 		if(L == user)
 			visible_message("[user] climbs into \the [src].")

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -111,7 +111,6 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 			return
 
 	L.unlock_from() //We checked above that they can ONLY be buckled to a rollerbed to allow this to happen!
-	message_admins("huh")
 	if(put_mob(L))
 		if(L == user)
 			visible_message("[user] climbs into \the [src].")

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -78,15 +78,11 @@
 /obj/item/weapon/reagent_containers/glass/afterattack(var/atom/target, var/mob/user, var/adjacency_flag, var/click_params)
 	if (!adjacency_flag)
 		return
-
 	if (is_type_in_list(target, can_be_placed_into))
 		return
-
 	if(ishuman(target)) //Splashing handled in attack now
 		return
-
 	var/transfer_result = transfer(target, user, splashable_units = -1) // Potentially splash with everything inside
-
 	if((transfer_result > 10) && (isturf(target) || istype(target, /obj/machinery/portable_atmospherics/hydroponics)))	//if we're splashing a decent amount of reagent on the floor
 		playsound(target, 'sound/effects/slosh.ogg', 25, 1)													//or in an hydro tray, then we make some noise.
 

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -113,7 +113,10 @@ var/mob/living/carbon/human/conveyor_overmind
 	update_nearby_conveyors() //smooth with diagonals
 	if(!conveyor_overmind)
 		conveyor_overmind = new /mob/living/carbon/human/conveyor_overmind(get_turf(src))
-		conveyor_overmind.invisibility = 0
+		conveyor_overmind.invisibility = 100
+		conveyor_overmind.x = 10 //Get it back to a place where nothing can fuck with it.
+		conveyor_overmind.y = 10
+		conveyor_overmind.z = 2
 	fakeMob = conveyor_overmind
 
 /obj/machinery/conveyor/Destroy()
@@ -254,10 +257,13 @@ var/mob/living/carbon/human/conveyor_overmind
 			if(!A.anchored)
 				if(A.loc == src.loc)
 					A.set_glide_size(DELAY2GLIDESIZE(SS_WAIT_FAST_MACHINERY))
-					if(!step(A,movedir))
+					if(!step(A,movedir) && A != fakeMob)
 						var/obj/machinery/next_tile = locate() in get_step(A, movedir)
 						if(istype(next_tile) && !istype(next_tile, /obj/machinery/conveyor))
-							attemptInsert(next_tile,A)
+							for(var/obj/machinery/machine in get_step(A, movedir))
+								if(A.loc != src.loc)
+									break
+								attemptInsert(machine,A)
 					items_moved++
 			if(items_moved >= max_moved)
 				break
@@ -268,9 +274,9 @@ var/mob/living/carbon/human/conveyor_overmind
 	if(!conveyor_overmind)
 		conveyor_overmind = new /mob/living/carbon/human/conveyor_overmind(get_turf(src))
 		fakeMob = conveyor_overmind
-	conveyor_overmind.forceMove(get_turf(src),TRUE)
+	fakeMob.forceMove(get_turf(src),TRUE)
+	usr = fakeMob
 	if(istype(input,/obj/item))
-		message_admins("A")
 		var/obj/item/itemInput = input
 		target.attackby(itemInput,fakeMob)
 		if(itemInput.loc == src.loc)
@@ -278,14 +284,15 @@ var/mob/living/carbon/human/conveyor_overmind
 			if(itemInput.loc == src.loc)
 				target.MouseDropTo(itemInput,fakeMob)
 	else if(istype(input,/obj))
-		message_admins("B")
 		var/obj/objInput = input
 		target.attackby(objInput,fakeMob)
 		if(objInput.loc == src.loc)
 			target.MouseDropTo(objInput,fakeMob)
 	else
-		message_admins("C")
 		target.MouseDropTo(input,fakeMob)
+	fakeMob.x = 10 //Get it back to a place where nothing can fuck with it.
+	fakeMob.y = 10
+	fakeMob.z = 2
 	
 /obj/machinery/conveyor/togglePanelOpen(var/obj/item/toggle_item, mob/user)
 	return
@@ -612,6 +619,7 @@ var/mob/living/carbon/human/conveyor_overmind
 /mob/living/carbon/human/conveyor_overmind
 	status_flags = GODMODE|CANPUSH|UNPACIFIABLE
 	invisibility = INVISIBILITY_MAXIMUM
+	name = "conveyor belt"
 
 /mob/living/carbon/human/conveyor_overmind/Adjacent(var/atom/neighbor)
 	return 1


### PR DESCRIPTION
[wip]

The feature of this PR is simple - conveyors will now attempt to use any given item into the machine in front of it. How it works:
>1. If there is a machine blocking the thing on the conveyor, attempt to use it by going to part 2.
>2. If the thing is an /obj/item, attempt to do attackby, attackafter, and mousedragto
>3. If the thing is an /obj/, attempt to do attackby and mousedragto
>4. Otherwise, just do mousedragto.

This basically means that the conveyor will click objects onto the machine and, if that fails, then attempt to drag the item into the machine. Imagine what you could do with this simple-yet-powerful feature:
>Cryo cell memes
>Spare on a conveyor around the station, opening airlocks like a train that goes around
>Automatic biogenerator loader
>Infinite autolathe loop of creating multitools (hack the production wire) and recycling it
>Money donation conveyor belt
It works with any objects of type /obj/machinery. 

As for the coding side of things, the way it works is quite simple. There is an invisible godmode human named "conveyor belt" that serves as the human inputting all of these things. As a singleton, all conveyor belts will check for it on creation and if it does not exist, it will create it. Otherwise, it will store a reference to it. 

Whenever the move event fails and the conveyor belt detects machines in the next tile, it will then teleport the conveyor overmind to its location and call attackby, attackafter, and mousedropto where appropriate. It will then teleport the overmind back to the shadow realm of z-level 2 so it hopefully won't die by a supermatter shard or something like that. If it does die somehow, then the conveyors will make a new one.

While somewhat hacky, this solution is good performance-wise and only adds code to the conveyor belt dm. Diety recommended that instead of this I create a new proc in machinery and whitelist every machine for usage to make it cleaner, but I don't think this way will have any issues. Optimally, we would have a proc/machine_interact that attackby and conveyor_attackby would call, but I'm not going to rework every machine and if statement interaction in the game to do that. Sorry.

I still need to test it out to make sure the inevitable bugs don't break the game, but I don't expect it to do anything worse than break a conveyor thanks to dynamic typing(tm). 

:cl:
 * rscadd: Conveyors now insert items into machinery directly in front of it.