### PR TITLE
Yet more teleporter changes

### DIFF
--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -343,22 +343,26 @@
 /obj/machinery/teleport/station/proc/engage()
 	if(stat & (BROKEN|NOPOWER))
 		return
-	for(var/obj/machinery/teleport/hub/hub in orange(1))
+	var/count = 0
+	for(var/obj/machinery/teleport/hub/hub in orange(1, src))
 		if(hub.stat & (BROKEN|NOPOWER))
 			continue
+		count++
 		hub.engaged = 1
 		hub.update_icon()
 		use_power(5000)
-	visible_message("<span class='notice'>Teleporter engaged!</span>", range = 2)
+	visible_message("<span class='notice'>[count] teleporters engaged!</span>", range = 2)
 	src.add_fingerprint(usr)
 	src.engaged = 1
 	return
 
 /obj/machinery/teleport/station/proc/disengage(mob/user)
-	for(var/obj/machinery/teleport/hub/hub in orange(1))
+	var/count = 0
+	for(var/obj/machinery/teleport/hub/hub in orange(1, src))
+		count++
 		hub.engaged = 0
 		hub.update_icon()
-	visible_message("<span class='notice'>Teleporter disengaged!</span>", range = 2)
+	visible_message("<span class='notice'>[count] teleporters disengaged!</span>", range = 2)
 	if(user)
 		src.add_fingerprint(user)
 	src.engaged = 0

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -200,10 +200,8 @@
 	use_power = 1
 	idle_power_usage = 10
 	active_power_usage = 2000
-	density = 0
-
-/obj/machinery/teleport/hub/New()
-	. = ..()
+	var/teleport_power_usage = 5000
+	var/inprecision = 2
 	component_parts = newlist(
 		/obj/item/weapon/circuitboard/telehub,
 		/obj/item/weapon/stock_parts/scanning_module/adv/phasic,
@@ -223,7 +221,19 @@
 		/obj/item/weapon/stock_parts/subspace/transmitter,
 		/obj/item/weapon/stock_parts/subspace/transmitter
 	)
-	RefreshParts()
+	density = 0
+
+/obj/machinery/teleport/hub/RefreshParts()
+	var/T = 1
+	for(var/obj/item/weapon/stock_parts/capacitor/C in component_parts)
+		T += C.rating-3
+	teleport_power_usage = initial(teleport_power_usage)/T
+
+	T=0
+	for(var/obj/item/weapon/stock_parts/scanning_module/S in component_parts)
+		T+= S.rating-3
+
+	inprecision = max(0, inprecision-T)
 
 /obj/machinery/teleport/hub/power_change()
 	..()
@@ -249,7 +259,7 @@
 		return
 	spawn()
 		if (src.engaged && teleport(AM))
-			use_power(5000)
+			use_power(teleport_power_usage)
 
 /obj/machinery/teleport/hub/proc/teleport(atom/movable/M as mob|obj)
 	var/obj/machinery/teleport/station/st = locate(/obj/machinery/teleport/station, orange(1))
@@ -263,15 +273,11 @@
 	if(get_turf(com.locked) == get_turf(src))
 		to_chat(M, "<span class = 'notice'>The act of teleportation was so smooth, it feels like you didn't move at all.</span>")
 		return 0
-	var/list/contents_of_M = get_contents_in_object(M)
-	if(locate(com.locked) in contents_of_M)
-		visible_message("<span class = 'warning'>Infinite loop prevention: Attempted to teleport locked object to locked object.</span>")
-		return 0
 	if (istype(M, /atom/movable))
 		if(prob(5) && !accurate) //oh dear a problem, put em in deep space
 			do_teleport(M, locate(rand((2*TRANSITIONEDGE), world.maxx - (2*TRANSITIONEDGE)), rand((2*TRANSITIONEDGE), world.maxy - (2*TRANSITIONEDGE)), 3), 2)
 		else
-			do_teleport(M, com.locked) //dead-on precision
+			do_teleport(M, com.locked, inprecision)
 
 		if(com.one_time_use) //Make one-time-use cards only usable one time!
 			com.one_time_use = 0
@@ -289,10 +295,7 @@
 	use_power = 1
 	idle_power_usage = 10
 	active_power_usage = 2000
-
-/obj/machinery/teleport/station/New()
-	. = ..()
-
+	var/teleport_power_usage = 5000
 	component_parts = newlist(
 		/obj/item/weapon/circuitboard/telestation,
 		/obj/item/weapon/stock_parts/scanning_module/adv/phasic,
@@ -306,7 +309,12 @@
 		/obj/item/weapon/stock_parts/subspace/analyzer,
 		/obj/item/weapon/stock_parts/subspace/analyzer
 	)
-	RefreshParts()
+
+/obj/machinery/teleport/station/RefreshParts()
+	var/T = 1
+	for(var/obj/item/weapon/stock_parts/capacitor/C in component_parts)
+		T += C.rating-3
+	teleport_power_usage = initial(teleport_power_usage)/T
 
 /obj/machinery/teleport/station/power_change()
 	..()
@@ -350,7 +358,7 @@
 		count++
 		hub.engaged = 1
 		hub.update_icon()
-		use_power(5000)
+		use_power(teleport_power_usage)
 	visible_message("<span class='notice'>[count] teleporters engaged!</span>", range = 2)
 	src.add_fingerprint(usr)
 	src.engaged = 1
@@ -385,7 +393,7 @@
 		hub.update_icon()
 		visible_message("<span class='notice'>Test firing! Teleporter temporarily calibrated to be more accurate.</span>", range = 2)
 		hub.teleport()
-		use_power(5000)
+		use_power(teleport_power_usage)
 		spawn(30)
 			hub.accurate = wasaccurate
 			visible_message("<span class='notice'>Test fire completed.</span>", range = 2)

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -201,7 +201,6 @@
 	idle_power_usage = 10
 	active_power_usage = 2000
 	var/teleport_power_usage = 5000
-	var/inprecision = 2
 	component_parts = newlist(
 		/obj/item/weapon/circuitboard/telehub,
 		/obj/item/weapon/stock_parts/scanning_module/adv/phasic,
@@ -229,11 +228,6 @@
 		T += C.rating-3
 	teleport_power_usage = initial(teleport_power_usage)/T
 
-	T=0
-	for(var/obj/item/weapon/stock_parts/scanning_module/S in component_parts)
-		T+= S.rating-3
-
-	inprecision = max(0, inprecision-T)
 
 /obj/machinery/teleport/hub/power_change()
 	..()
@@ -277,7 +271,7 @@
 		if(prob(5) && !accurate) //oh dear a problem, put em in deep space
 			do_teleport(M, locate(rand((2*TRANSITIONEDGE), world.maxx - (2*TRANSITIONEDGE)), rand((2*TRANSITIONEDGE), world.maxy - (2*TRANSITIONEDGE)), 3), 2)
 		else
-			do_teleport(M, com.locked, inprecision)
+			do_teleport(M, com.locked) //dead-on precision
 
 		if(com.one_time_use) //Make one-time-use cards only usable one time!
 			com.one_time_use = 0

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -353,7 +353,7 @@
 		hub.engaged = 1
 		hub.update_icon()
 		use_power(teleport_power_usage)
-	visible_message("<span class='notice'>[count] teleporters engaged!</span>", range = 2)
+	visible_message("<span class='notice'>[count] teleporter[count>1?"s":""] engaged!</span>", range = 2)
 	src.add_fingerprint(usr)
 	src.engaged = 1
 	return
@@ -364,7 +364,7 @@
 		count++
 		hub.engaged = 0
 		hub.update_icon()
-	visible_message("<span class='notice'>[count] teleporters disengaged!</span>", range = 2)
+	visible_message("<span class='notice'>[count] teleporter[count>1?"s":""] disengaged!</span>", range = 2)
 	if(user)
 		src.add_fingerprint(user)
 	src.engaged = 0


### PR DESCRIPTION
removes a redundant check (Turns out just getting the turf and checking that is cheaper than getting the recursive contents of everything the person is holding)

Fixes the teleporter getting the usr as the center of the orange, rather than itself

Adds internal component upgrade uses to the teleporters 
 - Upgrading the capacitors makes it use less power

Was debating having the capacitors need to charge up before sending a person, with a larger capacitor holding more charge so can teleport more people before needing to enter a charge cycle again, but w/e

Was also debating a degree of imprecision inherant to the teleporter (Let's say 2 tiles of imprecision) and upgrading the scanning modules would reduce this, but it wasn't very fun in testing as you'd end up in walls and doors.

:cl:
 * tweak: Upgrading the capacitors in the teleporter now lets it use less power