### PR TITLE
Fixed syndie shoes getting the ninja shoe message.

### DIFF
--- a/code/datums/gamemode/misc_gamemode_procs.dm
+++ b/code/datums/gamemode/misc_gamemode_procs.dm
@@ -381,6 +381,7 @@
 	spaceninja.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/voice/ninja, slot_wear_mask)
 	spaceninja.equip_to_slot_or_del(new /obj/item/clothing/suit/space/ninja/apprentice, slot_wear_suit)
 	spaceninja.equip_to_slot_or_del(new /obj/item/clothing/shoes/ninja/apprentice, slot_shoes)
+	spaceninja.get_item_by_slot(slot_shoes).activateMagnets()
 	spaceninja.equip_to_slot_or_del(new /obj/item/clothing/gloves/ninja, slot_gloves)
 	spaceninja.equip_to_slot_or_del(new /obj/item/weapon/melee/energy/sword/ninja(), slot_s_store)
 	spaceninja.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/silicon, slot_belt)

--- a/code/datums/gamemode/role/ninja.dm
+++ b/code/datums/gamemode/role/ninja.dm
@@ -617,9 +617,10 @@ Suit and assorted
 	
 /obj/item/clothing/shoes/ninja/apprentice
 	desc = "A pair of ninja apprentice shoes, excellent for running and even better for smashing skulls."
+	clothing_flags = NOSLIP
 	
-/obj/item/clothing/shoes/ninja/apprentice/New()
-	..()
+/obj/item/clothing/shoes/ninja/apprentice/proc/activateMagnets()
+	togglemagpulse(override = TRUE)
 	spawn(130 SECONDS)
 		togglemagpulse(override = TRUE)
 		visible_message("<span class='danger'>The magnetic charge on \the [src] disappates!</span>")


### PR DESCRIPTION
Title says it all, since the addition of ninja space suit the New() for the ninja magboots would send a visible message after 130 seconds. I moved it to a new proc, activateMagnets, and added activateMagnets to the ninja spawn.

