### PR TITLE
Crtl-clicking clothing with accessories now removes it

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -21,7 +21,7 @@
 	..()
 	
 /obj/item/clothing/CtrlClick(var/mob/user)
-	if(accessories.len)
+	if(isliving(user) && user.incapacitated() && user.Adjacent(src) && accessories.len)
 		remove_accessory(user, pick(accessories))
 
 /obj/item/clothing/examine(mob/user)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -21,7 +21,7 @@
 	..()
 	
 /obj/item/clothing/CtrlClick(var/mob/user)
-	if(isliving(user) && user.incapacitated() && user.Adjacent(src) && accessories.lenw)
+	if(isliving(user) && !user.incapacitated() && user.Adjacent(src) && accessories.lenw)
 		remove_accessory(user, pick(accessories))
 
 /obj/item/clothing/examine(mob/user)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -19,12 +19,17 @@
 		accessories.Remove(A)
 		qdel(A)
 	..()
+	
+/obj/item/clothing/CtrlClick(var/mob/user)
+	if(accessories.len)
+		remove_accessory(user, pick(accessories))
 
 /obj/item/clothing/examine(mob/user)
 	..()
 	for(var/obj/item/clothing/accessory/A in accessories)
 		to_chat(user, "<span class='info'>\A [A] is clipped to it.</span>")
 
+		
 /obj/item/clothing/emp_act(severity)
 	for(var/obj/item/clothing/accessory/accessory in accessories)
 		accessory.emp_act(severity)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -21,7 +21,7 @@
 	..()
 	
 /obj/item/clothing/CtrlClick(var/mob/user)
-	if(isliving(user) && user.incapacitated() && user.Adjacent(src) && accessories.len)
+	if(isliving(user) && user.incapacitated() && user.Adjacent(src) && accessories.lenw)
 		remove_accessory(user, pick(accessories))
 
 /obj/item/clothing/examine(mob/user)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -21,7 +21,7 @@
 	..()
 	
 /obj/item/clothing/CtrlClick(var/mob/user)
-	if(isliving(user) && !user.incapacitated() && user.Adjacent(src) && accessories.lenw)
+	if(isliving(user) && !user.incapacitated() && user.Adjacent(src) && accessories.len)
 		remove_accessory(user, pick(accessories))
 
 /obj/item/clothing/examine(mob/user)


### PR DESCRIPTION
Very complex change, took me 4 weeks with a full development team to figure this one out but I managed. 4 pomfcoins please, thank you.

:cl:
 * rscadd: Crtl-clicking clothing with accessories will remove a random accessory.