### PR TITLE
Plasma cutter tweaks

### DIFF
--- a/code/game/objects/items/devices/modkit.dm
+++ b/code/game/objects/items/devices/modkit.dm
@@ -163,6 +163,10 @@
 	finished[1] = /obj/item/weapon/pickaxe/plasmacutter/accelerator
 
 /obj/item/device/modkit/plasmacutter/attackby(atom/target, mob/user, proximity_flag)
-	if(proximity_flag && istype(target, /obj/item/weapon/gun/energy/kinetic_accelerator))
+	if(proximity_flag && parts[1] == 1 && istype(target, /obj/item/weapon/gun/energy/kinetic_accelerator))
+		to_chat(user, "<span class='warning'>\The [src] is already loaded!</span>")
+		return
+
+	else if(proximity_flag && istype(target, /obj/item/weapon/gun/energy/kinetic_accelerator))
 		parts[1] = 1
 		qdel(target)

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -270,7 +270,7 @@ proc/move_mining_shuttle()
 
 /obj/item/weapon/pickaxe/plasmacutter/accelerator
 	name = "plasma cutter"
-	desc = "A rock cutter that, ingeniously, is powered directly by putting plasma into it. It's even powerful enough that you could use it to cut limbs off of xenos! Or, you know, mine stuff."
+	desc = "A rock cutter that, ingeniously, is powered by putting plasma directly into it. It's even powerful enough that you could use it to cut limbs off of xenos! Or, you know, mine stuff."
 	digspeed = 5
 	diggables = DIG_ROCKS | DIG_SOIL | DIG_WALLS | DIG_RWALLS
 	var/max_ammo = 15

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -287,7 +287,7 @@ proc/move_mining_shuttle()
 		var/turf/target = get_turf(A)
 		var/obj/item/projectile/kinetic/cutter/BS = new (starting)
 		BS.firer = user
-		BS.original = target
+		BS.original = A
 		BS.target = target
 		BS.current = starting
 		BS.starting = starting

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -270,7 +270,7 @@ proc/move_mining_shuttle()
 
 /obj/item/weapon/pickaxe/plasmacutter/accelerator
 	name = "plasma cutter"
-	desc = "A rock cutter that, ingeniously, is powered by inserting solid plasma directly into it. It's powerful enough to cut through rocks and xenos with ease."
+	desc = "A rock cutter that's powerful enough to cut through rocks and xenos with ease. Ingeniously, it's powered by putting plasma directly into it, for those miners on the go."
 	digspeed = 5
 	diggables = DIG_ROCKS | DIG_SOIL | DIG_WALLS | DIG_RWALLS
 	var/max_ammo = 15

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -283,24 +283,8 @@ proc/move_mining_shuttle()
 		return
 	if(current_ammo >0)
 		current_ammo--
-		var/turf/starting = get_turf(user)
-		var/turf/target = get_turf(A)
-		var/obj/item/projectile/kinetic/cutter/BS = new (starting)
-		BS.firer = user
-		BS.original = A
-		BS.target = target
-		BS.current = starting
-		BS.starting = starting
-		BS.yo = target.y - starting.y
-		BS.xo = target.x - starting.x
+		generic_projectile_fire(A, src, /obj/item/projectile/kinetic/cutter/, 'sound/weapons/Taser.ogg')
 		user.delayNextAttack(4)
-		if(user.zone_sel)
-			BS.def_zone = user.zone_sel.selecting
-		else
-			BS.def_zone = LIMB_CHEST
-		BS.OnFired()
-		playsound(starting, 'sound/weapons/Taser.ogg', 50, 1)
-		BS.process()
 	else
 		src.visible_message("*click click*")
 		playsound(src, 'sound/weapons/empty.ogg', 100, 1)

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -270,7 +270,7 @@ proc/move_mining_shuttle()
 
 /obj/item/weapon/pickaxe/plasmacutter/accelerator
 	name = "plasma cutter"
-	desc = "A rock cutter that, ingeniously, is powered by putting plasma directly into it. It's even powerful enough that you could use it to cut limbs off of xenos! Or, you know, mine stuff."
+	desc = "A rock cutter that, ingeniously, is powered by inserting solid plasma directly into it. It's powerful enough to cut through rocks and xenos with ease."
 	digspeed = 5
 	diggables = DIG_ROCKS | DIG_SOIL | DIG_WALLS | DIG_RWALLS
 	var/max_ammo = 15

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -270,7 +270,7 @@ proc/move_mining_shuttle()
 
 /obj/item/weapon/pickaxe/plasmacutter/accelerator
 	name = "plasma cutter"
-	desc = "A rock cutter that's powerful enough to cut through rocks and xenos with ease. Ingeniously, it's powered by putting plasma directly into it, for those miners on the go."
+	desc = "A rock cutter that's powerful enough to cut through rocks and xenos with ease. Ingeniously, it's powered by putting solid plasma directly into it, for those miners on the go."
 	digspeed = 5
 	diggables = DIG_ROCKS | DIG_SOIL | DIG_WALLS | DIG_RWALLS
 	var/max_ammo = 15

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -296,7 +296,7 @@ proc/move_mining_shuttle()
 			var/loading_ammo = min(max_ammo - current_ammo, A.amount)
 			A.use(loading_ammo)
 			current_ammo += loading_ammo
-			to_chat(user, "<span class='notice'>You load [src].</span>")
+			to_chat(user, "<span class='notice'>You load \the [src].</span>")
 		else
 			to_chat(user, "<span class='notice'>[src] is already loaded.</span>")
 
@@ -306,7 +306,7 @@ proc/move_mining_shuttle()
 			var/loading_ammo = min(max_ammo - current_ammo, A.amount)
 			A.use(loading_ammo)
 			current_ammo += loading_ammo
-			to_chat(user, "<span class='notice'>You load [src].</span>")
+			to_chat(user, "<span class='notice'>You load \the [src].</span>")
 		else
 			to_chat(user, "<span class='notice'>[src] is already loaded.</span>")
 

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -298,7 +298,7 @@ proc/move_mining_shuttle()
 			current_ammo += loading_ammo
 			to_chat(user, "<span class='notice'>You load \the [src].</span>")
 		else
-			to_chat(user, "<span class='notice'>[src] is already loaded.</span>")
+			to_chat(user, "<span class='notice'>\The [src] is already loaded.</span>")
 
 	if(proximity_flag && istype(target, /obj/item/stack/sheet/mineral/plasma))
 		var/obj/item/stack/sheet/mineral/plasma/A = target
@@ -308,7 +308,7 @@ proc/move_mining_shuttle()
 			current_ammo += loading_ammo
 			to_chat(user, "<span class='notice'>You load \the [src].</span>")
 		else
-			to_chat(user, "<span class='notice'>[src] is already loaded.</span>")
+			to_chat(user, "<span class='notice'>\The [src] is already loaded.</span>")
 
 /obj/item/weapon/pickaxe/diamond
 	name = "diamond pickaxe"

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -310,6 +310,10 @@ proc/move_mining_shuttle()
 		else
 			to_chat(user, "<span class='notice'>\The [src] is already loaded.</span>")
 
+/obj/item/weapon/pickaxe/plasmacutter/accelerator/examine(mob/user)
+	..()
+	to_chat(user, "<span class='info'>Has [current_ammo] round\s remaining.</span>")
+
 /obj/item/weapon/pickaxe/diamond
 	name = "diamond pickaxe"
 	icon_state = "dpickaxe"

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -270,7 +270,7 @@ proc/move_mining_shuttle()
 
 /obj/item/weapon/pickaxe/plasmacutter/accelerator
 	name = "plasma cutter"
-	desc = "A rock cutter that's powerful enough to cut through rocks and xenos with ease. Ingeniously, it's powered by putting solid plasma directly into it, for those miners on the go."
+	desc = "A rock cutter that's powerful enough to cut through rocks and xenos with ease. Ingeniously, it's powered by putting solid plasma directly into it - even plasma ore, for those miners on the go."
 	digspeed = 5
 	diggables = DIG_ROCKS | DIG_SOIL | DIG_WALLS | DIG_RWALLS
 	var/max_ammo = 15
@@ -290,16 +290,25 @@ proc/move_mining_shuttle()
 		playsound(src, 'sound/weapons/empty.ogg', 100, 1)
 
 /obj/item/weapon/pickaxe/plasmacutter/accelerator/attackby(atom/target, mob/user, proximity_flag)
-	if(proximity_flag && istype(target, /obj/item/stack/sheet))
-		var/obj/item/stack/sheet/A = target
-		if(A.mat_type == MAT_PLASMA)
-			if(current_ammo < max_ammo)
-				var/loading_ammo = min(max_ammo - current_ammo, A.amount)
-				A.use(loading_ammo)
-				current_ammo += loading_ammo
-				to_chat(user, "<span class='notice'>You load [src].</span>")
-			else
-				to_chat(user, "<span class='notice'>[src] is already loaded.</span>")
+	if(proximity_flag && istype(target, /obj/item/stack/ore/plasma))
+		var/obj/item/stack/ore/plasma/A = target
+		if(current_ammo < max_ammo)
+			var/loading_ammo = min(max_ammo - current_ammo, A.amount)
+			A.use(loading_ammo)
+			current_ammo += loading_ammo
+			to_chat(user, "<span class='notice'>You load [src].</span>")
+		else
+			to_chat(user, "<span class='notice'>[src] is already loaded.</span>")
+
+	if(proximity_flag && istype(target, /obj/item/stack/sheet/mineral/plasma))
+		var/obj/item/stack/sheet/mineral/plasma/A = target
+		if(current_ammo < max_ammo)
+			var/loading_ammo = min(max_ammo - current_ammo, A.amount)
+			A.use(loading_ammo)
+			current_ammo += loading_ammo
+			to_chat(user, "<span class='notice'>You load [src].</span>")
+		else
+			to_chat(user, "<span class='notice'>[src] is already loaded.</span>")
 
 /obj/item/weapon/pickaxe/diamond
 	name = "diamond pickaxe"

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -277,6 +277,9 @@ proc/move_mining_shuttle()
 	var/current_ammo = 15
 
 /obj/item/weapon/pickaxe/plasmacutter/accelerator/afterattack(var/atom/A, var/mob/living/user, var/proximity_flag, var/click_parameters)
+	if (!user.IsAdvancedToolUser() || isMoMMI(user) || istype(user, /mob/living/carbon/monkey/diona))
+		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
+		return
 	if(proximity_flag)
 		return
 	if(user.is_pacified(VIOLENCE_SILENT,A,src))

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -270,7 +270,7 @@ proc/move_mining_shuttle()
 
 /obj/item/weapon/pickaxe/plasmacutter/accelerator
 	name = "plasma cutter"
-	desc = "A rock cutter that fires bolts of hot plasma. You could use it to cut limbs off of xenos! Or, you know, mine stuff."
+	desc = "A rock cutter that, ingeniously, is powered directly by putting plasma into it. It's even powerful enough that you could use it to cut limbs off of xenos! Or, you know, mine stuff."
 	digspeed = 5
 	diggables = DIG_ROCKS | DIG_SOIL | DIG_WALLS | DIG_RWALLS
 	var/max_ammo = 15


### PR DESCRIPTION
Really though why did it say nowhere on it that it reloads by slapping plasma into it FUCK
also I'm going to throw in the same fix as #23286 because this has the same problem
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation or the coding discord (you can find an invite link on the irc or the thread) to discuss your changes, or if you need help.

== SELF LABELLING PRs ==
You can now self-label your PR! The syntax is simple. Just put [<labeltag>] anywhere in your PR,
where <labeltag> is to be replaced by one of the following (allowing with the resultant tag)
just ctrl+f the list or something. I know it's long.

administration = "Logging / Administration"
away = "Mapping (Away Mission :earth_africa:)"
bagel = "Mapping (Bagel :o:)"
box = "Mapping (Box :baby:)"
bugfix = "Bug / Fix"
bus = "Mapping (Bus :bus:)"
byond = "T-Thanks BYOND"
consistency = "Consistency Issue"
controversial = "Controversial"
deff = "Mapping (Deff :wastebasket:)"
discussion = "Discussion"
dnm = "✋ Do Not Merge ✋"
easy = "Easy Fix"
exploitable = "Exploitable"
featureloss = "Feature Loss"
featurerequest = "Feature Request"
first = "good first issue"
formatting = "Grammar / Formatting"
gamemode = "Gameplay / Gamemode"
gameplay = "Gameplay / Gamemode"
general = "Mapping (General :world_map:)"
goonchat = "Goonchat"
grammar = "Grammar / Formatting"
help = "help wanted"
hotfix = "Hotfix"
libvg = "libvg"
logging = "Logging / Administration"
meta = "Mapping (Meta :no_mobile_phones:)"
needspritework = "Needs Spritework"
oversight = "Oversight"
packed = "Mapping (Packed :package:)"
parallax = "Parallax"
qol = "❤️ Quality of Life ❤️"
roid = "Mapping (Roidstation :pick:)"
role = "Role Datums"
roleissue = "Role Datums Issue"
runtime = "Runtime Log"
sanity = "Sanity / Ghosthands"
snowmap = "Mapping (Snowmap ❄)"
sound = "Sound"
sprites = "Sprites"
spriteworkdone = "Spritework Done Needs Coder"
system = "System"
taxi = "Mapping (Taxi :taxi:)"
tested = "100%  tested"
tweak = "Tweak"
ui = "UI"
vault = "Mapping (Vault :question:)"
vote = "⛔ Requires Server Vote ⛔"
wip = "WiP"

== CHANGELOGS ==
Changelogs can be attached either by following the instructions in html/changelogs/example.yml, or by attaching an in-body changelog like the one attached to your PR automatically.

For the keys you can use in an in-body changelog, they are the same as described in example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!

Valid Prefixes:
bugfix
wip (For works in progress)
tweak
soundadd
sounddel
rscdel (general deleting of nice things)
rscadd (general adding of nice things)
imageadd
imagedel
spellcheck (typo fixes)
experiment
tgs (TG-ported fixes?)

An example changelog is attached to this PR for your convenience:
-->
:cl:
 * rscadd: Plasma Cutter description now says how to load it, and displays remaining ammo
 * bugfix: Plasma Cutters can now hit people lying down, and the conversion kit will no longer eat multiple accelerators
 * rscadd: Plasma Cutters can now be loaded with plasma ore
 * bugfix: Plasma Cutters now go through the normal weapon checks (Looking at you, mommis)