### PR TITLE
Bring back the worms

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1231,7 +1231,7 @@ Thanks.
 
 	if(client.move_delayer.blocked())
 		return
-	delayNextMove(10)
+	delayNextMove(3)
 	resting = !resting
 	update_canmove()
 	to_chat(src, "<span class='notice'>You are now [resting ? "resting" : "getting up"]</span>")

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1231,7 +1231,7 @@ Thanks.
 
 	if(client.move_delayer.blocked())
 		return
-	delayNextMove(3)
+	delayNextMove(1)
 	resting = !resting
 	update_canmove()
 	to_chat(src, "<span class='notice'>You are now [resting ? "resting" : "getting up"]</span>")


### PR DESCRIPTION
## What

"Worms" also known as Rest Spam, was a technique to dodge projectiles by using the rest command.
One possible abuse of it was to completely negate the AI Upload's turrets as they couldn't target resting people. To counter it, a long delay (1 second) was added to the rest command.
This apparently got fixed, and AI will no longer be fooled by rest spam.

Rather than completely suppressing the delay (which could cause other issues, such as crashing the server by using a macro to call "Rest" 10 000 times in a single click), I simply adjusted it to 0.1 second so that elaborate rest spam can still be performed.

## Why

I find this funny and it's a good way to dodge projectiles.

Open to discussion if you see any balance or potential exploit.
I don't think there can be any foolery with "pretending to lie down to fool sec into cuffing you and then getting up", since the animation to get up takes 0.4 seconds and it is enough for the officer to react.
You could also already do this because the time the officer took to cuff you was much higher than 1 second.

:cl:
- tweak: Reduced the delay to rest from 1 second to 0.1 second.