### PR TITLE
Crawling touchup

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1888,9 +1888,17 @@ mob/living/carbon/human/isincrit()
 		return FALSE
 	if(isUnconscious() || stunned || paralysis || !check_crawl_ability() || pulledby || locked_to || client.move_delayer.blocked())
 		return FALSE
-	var/crawldelay = round(1 + base_movement_tally()/5) * 1 SECONDS
+	var/crawldelay = 0.2 SECONDS
+	if (crawlcounter >= max_crawls_before_fatigue)
+		if (prob(10))
+			to_chat(src, "<span class='warning'>You get tired from all this crawling around.</span>")
+		crawldelay = round(1 + base_movement_tally()/10) * 3 SECONDS
+		crawlcounter = 1
+	else
+		crawlcounter++
 	. = Move(target, get_dir(src, target), glide_size_override = crawldelay)
-	delayNextMove(crawldelay, additive=1)
+	delayNextMove(crawldelay, additive = 1)
+
 
 /mob/living/carbon/human/Hear(var/datum/speech/speech, var/rendered_speech="")
 	..()

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -1,3 +1,7 @@
+/mob/living/carbon/human
+	var/crawlcounter = 1
+	var/max_crawls_before_fatigue = 6
+
 /mob/living/carbon/human/movement_delay()
 	if(isslimeperson(src))
 		if (bodytemperature >= 330.23) // 135 F

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -124,6 +124,8 @@ var/global/list/organ_damage_overlays = list(
 	//TODO: seperate this out
 	//Update the current life tick, can be used to e.g. only do something every 4 ticks
 	life_tick++
+	if (life_tick % 2)
+		crawlcounter = 1
 
 	var/datum/gas_mixture/environment = loc.return_air()
 	in_stasis = istype(loc, /obj/structure/closet/body_bag/cryobag) && loc:opened == 0 //Nice runtime operator


### PR DESCRIPTION
Before you ask, no, there was no possibility to fully revert it

## Foreword

I think crawling can be an interesting mechanic to get in & out of fights. It can be a way to silently sneak up on someone, to go out of a fight while you were faking death, to advance on someone while dodging their taser shots, etc, etc.

In other words, it can be a fun mechanic and I believe when we are asking ourselves "how to fix stun based combat", maybe rather than blindly touching numbers or lethality of weapons, we can look at alternative paths such as this one.

Even though I got lobbied to fully revert it, I don't believe this would have been very reasonable nor had a chance to pass.

## What

Rather than a static movement delay of 1 second after crawling from one tile to an other, this gives the ability to crawl extremely fast (0.2 seconds) in short bursts (6 crawls) and then you have a slight cooldown (3 seconds). 
This number get reset every two life ticks, so if you pace yourself and don't use all your burst in a single go, you will most likely never get tired from crawling.
All of those numbers are subject to change.

The reasoning is to make this more useful in a combat or combat-related situation without making it as busted as it used to be.

Feel free to discuss it.

:cl:
- tweak: Changes to crawling. You can now crawl fast for a short duration, with a short cooldown if you do it too fast and too often.