### PR TITLE
Starscreen SGs can now be built with Micro Manipulators

### DIFF
--- a/code/WorkInProgress/Cael_Aislinn/ShieldGen/circuits.dm
+++ b/code/WorkInProgress/Cael_Aislinn/ShieldGen/circuits.dm
@@ -9,7 +9,7 @@
 	build_path = /obj/machinery/shield_gen/external
 	origin_tech = Tc_BLUESPACE + "=4;" + Tc_PLASMATECH + "=3"
 	req_components = list(
-							/obj/item/weapon/stock_parts/manipulator/nano/pico = 2,
+							/obj/item/weapon/stock_parts/manipulator = 2,
 							/obj/item/weapon/stock_parts/subspace/transmitter = 1,
 							/obj/item/weapon/stock_parts/subspace/crystal = 1,
 							/obj/item/weapon/stock_parts/subspace/amplifier = 1,
@@ -30,7 +30,7 @@
 	build_path = /obj/machinery/shield_gen
 	origin_tech = Tc_BLUESPACE + "=4;" + Tc_PLASMATECH + "=3"
 	req_components = list(
-							/obj/item/weapon/stock_parts/manipulator/nano/pico = 2,
+							/obj/item/weapon/stock_parts/manipulator = 2,
 							/obj/item/weapon/stock_parts/subspace/transmitter = 1,
 							/obj/item/weapon/stock_parts/subspace/crystal = 1,
 							/obj/item/weapon/stock_parts/subspace/amplifier = 1,

--- a/code/WorkInProgress/Cael_Aislinn/ShieldGen/shield_gen.dm
+++ b/code/WorkInProgress/Cael_Aislinn/ShieldGen/shield_gen.dm
@@ -49,8 +49,8 @@
 
 	component_parts = newlist(
 		board_path,
-		/obj/item/weapon/stock_parts/manipulator,
-		/obj/item/weapon/stock_parts/manipulator,
+		/obj/item/weapon/stock_parts/manipulator/nano/pico,
+		/obj/item/weapon/stock_parts/manipulator/nano/pico,
 		/obj/item/weapon/stock_parts/subspace/transmitter,
 		/obj/item/weapon/stock_parts/subspace/crystal,
 		/obj/item/weapon/stock_parts/subspace/amplifier,
@@ -63,9 +63,9 @@
 	var/T = 0
 	for(var/obj/item/weapon/stock_parts/manipulator/Ma in component_parts)
 		T += Ma.rating - 1
-		energy_conversion_rate = (initial(energy_conversion_rate)+(T * 0.01))	
-		max_strengthen_rate = (initial(max_strengthen_rate)+(T))	
-	
+		energy_conversion_rate = (initial(energy_conversion_rate)+(T * 0.01))
+		max_strengthen_rate = (initial(max_strengthen_rate)+(T))
+
 /obj/machinery/shield_gen/Destroy()
 	..()
 	owned_capacitor = null
@@ -265,7 +265,7 @@
 		return
 	if(prob(50))
 		active = !active
-	
+
 /obj/machinery/shield_gen/npc_tamper_act(var/mob/living/L)
 	field_radius = rand(MIN_FIELD_RADIUS, MAX_FIELD_RADIUS)
 	strengthen_rate = rand(MIN_STRENGTHEN_RATE, MAX_STRENGTHEN_RATE)

--- a/code/WorkInProgress/Cael_Aislinn/ShieldGen/shield_gen.dm
+++ b/code/WorkInProgress/Cael_Aislinn/ShieldGen/shield_gen.dm
@@ -49,8 +49,8 @@
 
 	component_parts = newlist(
 		board_path,
-		/obj/item/weapon/stock_parts/manipulator/nano/pico,
-		/obj/item/weapon/stock_parts/manipulator/nano/pico,
+		/obj/item/weapon/stock_parts/manipulator,
+		/obj/item/weapon/stock_parts/manipulator,
 		/obj/item/weapon/stock_parts/subspace/transmitter,
 		/obj/item/weapon/stock_parts/subspace/crystal,
 		/obj/item/weapon/stock_parts/subspace/amplifier,


### PR DESCRIPTION
[consistency]
Closes #23315.

As the title states, changes the manipulators required for Starscreen Shield Generators to match those spawned on New(), for consiiiisteeeency or something.

:cl:
 * tweak: Starscreen Shield Generators can now be built with Micro Manipulators rather than Pico Manipulators, as initially intended.