### PR TITLE
return of brain damage; Bundle Edition

### DIFF
--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -889,7 +889,7 @@
 ///// ANCIENT SPELLBOOK /////
 
 /obj/item/weapon/spellbook/oneuse/ancient //the ancient spellbook contains weird and dangerous spells that aren't otherwise available to purchase, only available via the spellbook bundle
-	var/list/possible_spells = list(/spell/targeted/disintegrate, /spell/targeted/parrotmorph, /spell/aoe_turf/conjure/spares, /spell/targeted/balefulmutate)
+	var/list/possible_spells = list(/spell/targeted/disintegrate, /spell/targeted/parrotmorph, /spell/aoe_turf/conjure/spares, /spell/targeted/balefulmutate, /spell/targeted/retard)
 	spell = null
 	icon_state = "book"
 	desc = "A book of lost and forgotten knowledge"

--- a/code/modules/spells/targeted/retard.dm
+++ b/code/modules/spells/targeted/retard.dm
@@ -1,0 +1,18 @@
+//Brain damage spell. This unholy spell was removed but it returns with a vengence.
+/spell/targeted/retard
+	name = "Brain Damage"
+	desc = "Give an unlucky person brain damage."
+	abbreviation = "BD"
+	user_type = USER_TYPE_SPELLBOOK //Whereas previously this was a normal spell, it is now found only in the ancient spellbook.
+	school = "evocation"
+	charge_max = 200 // 20 seconds
+	//Invocation is noted below
+	invocation_type = SpI_WHISPER //Wizard will whisper what they say instead of shouting
+	range = 3 // Target anyone within 3 tiles of you
+	amt_dam_brain = 30 //30 brain damage
+	max_targets = 1 // Can only target one person
+	compatible_mobs = list(/mob/living/carbon/human, /mob/living/carbon/monkey) // Only works on humans and monkeys
+	spell_flags = WAIT_FOR_CLICK //Click on whoever you want to get brain damaged
+	message = "<span class='danger'>You feel dumber!<span>" //What the victim sees when affected
+	mind_affecting = 1 //Blocked by tinfoil hat
+	hud_state = "wiz_retard" //Icon is from screen_spells.dmi

--- a/code/modules/spells/targeted/targeted.dm
+++ b/code/modules/spells/targeted/targeted.dm
@@ -24,6 +24,7 @@ Targeted spells have two useful flags: INCLUDEUSER and SELECTABLE. These are exp
 	var/amt_dam_brute = 0
 	var/amt_dam_oxy = 0
 	var/amt_dam_tox = 0
+	var/amt_dam_brain = 0
 
 	var/amt_eye_blind = 0
 	var/amt_eye_blurry = 0
@@ -158,6 +159,7 @@ Targeted spells have two useful flags: INCLUDEUSER and SELECTABLE. These are exp
 	target.adjustFireLoss(amt_dam_fire)
 	target.adjustToxLoss(amt_dam_tox)
 	target.adjustOxyLoss(amt_dam_oxy)
+	target.adjustBrainLoss(amt_dam_brain)
 	//disabling
 	target.Knockdown(amt_knockdown)
 	target.Paralyse(amt_paralysis)

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -2386,6 +2386,7 @@
 #include "code\modules\spells\targeted\pumpkinhead.dm"
 #include "code\modules\spells\targeted\push.dm"
 #include "code\modules\spells\targeted\recall.dm"
+#include "code\modules\spells\targeted\retard.dm"
 #include "code\modules\spells\targeted\shoesnatch.dm"
 #include "code\modules\spells\targeted\targeted.dm"
 #include "code\modules\spells\targeted\wrap.dm"


### PR DESCRIPTION
This PR re-adds the removed Brain Damage spell. The spell is now restricted to the ancient spellbook so the only way to get it is to roll the bundle and get lucky. This also means the spell can no longer be upgraded, so I removed all the code relating to that.


:cl:
 * rscadd: Re-added the previously removed brain damage spell and made it Bundle exclusive.