### PR TITLE
Adds alt clicking to buckle into chair/allows dragging from adjacency.

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -49,6 +49,9 @@
 	else
 		return ..()
 
+/obj/structure/bed/AltClick(mob/user as mob)
+	buckle_mob(user, user)
+
 /obj/structure/bed/proc/manual_unbuckle(var/mob/user)
 	if(user.size <= SIZE_TINY)
 		to_chat(user, "<span class='warning'>You are too small to do that.</span>")
@@ -85,7 +88,8 @@
 	if(!Adjacent(user) || user.incapacitated() || istype(user, /mob/living/silicon/pai))
 		return
 
-	if(!ismob(M) || (M.loc != src.loc)  || M.locked_to)
+	//if(!ismob(M) || (M.loc != src.loc)  || M.locked_to)
+	if(!ismob(M) || M.locked_to)
 		return
 
 	for(var/mob/living/L in get_locked(mob_lock_type))

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -157,27 +157,31 @@
 			return
 	change_dir(direction)
 	return 1
+	
+/obj/structure/bed/chair/AltClick(mob/user as mob)
+	buckle_chair(user,user)	
 
 /obj/structure/bed/chair/MouseDropTo(mob/M as mob, mob/user as mob)
+	buckle_chair(M,user)
+
+/obj/structure/bed/chair/proc/buckle_chair(mob/M as mob, mob/user as mob)
 	if(!istype(M))
 		return ..()
+	
+	//if(M == user && M.loc != src.loc)
+		//return
+
 	var/mob/living/carbon/human/target = null
 	if(ishuman(M))
 		target = M
+
 	if(target && target.op_stage.butt == 4 && Adjacent(target) && user.Adjacent(src) && !user.incapacitated()) //Butt surgery is at stage 4
 		if(!M.knockdown)	//Spam prevention
-			if(M == usr)
-				M.visible_message(\
-					"<span class='notice'>[M.name] has no butt, and slides right out of [src]!</span>",\
-					"Having no butt, you slide right out of the [src]",\
-					"You hear metal clanking.")
-
-			else
-				M.visible_message(\
-					"<span class='notice'>[M.name] has no butt, and slides right out of [src]!</span>",\
-					"Having no butt, you slide right out of the [src]",\
-					"You hear metal clanking.")
-
+			M.visible_message(\
+				"<span class='notice'>[M.name] has no butt, and slides right out of [src]!</span>",\
+				"Having no butt, you slide right out of the [src]",\
+				"You hear metal clanking.")
+				
 			M.Knockdown(5)
 			M.Stun(5)
 		else
@@ -187,6 +191,7 @@
 		buckle_mob(M, user)
 	if(material_type)
 		material_type.on_use(src,M,user)
+
 
 // Chair types
 /obj/structure/bed/chair/wood


### PR DESCRIPTION
[qol]
This would mean that anybody not using the Fastline haircut can easily get into chairs too.
This removes the "is on same tile" check so you can either alt click or drag from adjacency, up to you.

![Annotation 2019-06-23 052920](https://user-images.githubusercontent.com/29109612/59974949-e4930d00-9577-11e9-916f-178b1636133a.png)

:cl:
 * tweak: Alt clicking a chair/bed now buckles you into it.
 * tweak: You can now buckle yourself into a chair/bed from an adjacent tile.