### PR TITLE
Emagging the clone pod now turns the occupant into gibs

### DIFF
--- a/code/modules/medical/cloning.dm
+++ b/code/modules/medical/cloning.dm
@@ -356,9 +356,8 @@
 	if(isnull(occupant))
 		return
 	if(user)
-		to_chat(user, "You force an emergency ejection.")
-	locked = FALSE
-	go_out()
+		to_chat(user, "You scramble the cloning pod's genetic data, turning the occupant into mush.")
+	malfunction()
 	return
 
 /obj/machinery/cloning/clonepod/crowbarDestroy(mob/user)


### PR DESCRIPTION
Emagging the clone pod used to eject the occupant, same as what kicking does. "Wooooooooow" - Some anon last night
Also untested, because no way I can make a clone to test things with
:cl:
 * tweak: Emagging the cloning pod now turns the occupant into gibs instead of ejecting the occupant early.