### PR TITLE
reworked heard_by and heard_before

### DIFF
--- a/code/datums/gamemode/role/rambler.dm
+++ b/code/datums/gamemode/role/rambler.dm
@@ -77,15 +77,16 @@
 /obj/item/clothing/mask/necklace/crystal/attack_self(mob/user)
 	if(!isrambler(user))
 		return
-	var/mob/potential = input(user, "Choose your suspect, from those whose voices you've heard before.", "Soul Inspiration") as null|mob in get_list_of_elements(user.mind.heard_before)
+	var/target_name = input(user, "Choose your suspect, from those whose voices you've heard before.", "Soul Inspiration") in user.mind.heard_before
+	var/datum/mind/M = user.mind.heard_before[target_name]
+	if(!M.current)
+		return
+	var/mob/living/potential = M.current
 	if(!isliving(potential))
 		to_chat(user,"<span class='warning'>That is some kind of ghost or something!</span>")
 		return
 	if(potential == suspect)
 		to_chat(user,"<span class='warning'>It is just as you suspected. The suspect is the suspicious suspect you have already suspected!</span>")
-		return
-	if(!potential.mind)
-		to_chat(user,"<span class='warning'>To accuse the mindless? The scrawling of a madman!</span>")
 		return
 	if(potential == user)
 		to_chat(user,"<span class='warning'>You already know the crime was arson!</span>")

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -78,7 +78,10 @@
 
 /datum/mind/Destroy()
 	for(var/M in heard_by){
-		heard_by[M].heard_before[M] = null
+		for(var/N in heard_by[M].heard_before)
+			if(heard_by[M].heard_before[N] == src)
+				heard_by[M].heard_before[N] = null
+		heard_by = null
 	}
 	. = ..()
 

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -65,7 +65,8 @@
 
 	//fix scrying raging mages issue.
 	var/isScrying = 0
-	var/list/heard_before = list()
+	var/list/heard_before = list() //list of mind we have heard before in some way or the other, indexed by the mobs name we heard it from
+	var/list/heard_by = list() //list of minds that we have been heard by, also indexed by mob names
 
 	var/nospells = 0 //Can't cast spells.
 	var/hasbeensacrificed = FALSE
@@ -74,6 +75,12 @@
 
 /datum/mind/New(var/key)
 	src.key = key
+
+/datum/mind/Destroy()
+	for(var/M in heard_by){
+		heard_by[M].heard_before[M] = null
+	}
+	. = ..()
 
 /datum/mind/proc/transfer_to(mob/living/new_character)
 	if(!istype(new_character))

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -661,7 +661,7 @@ a {
 				var/atom/AM = pick(existing_typesof(/mob/living/simple_animal))
 				characters |= initial(AM.name)
 			else
-				var/strangething = pick("captain","clown","mime","\improper CMO","cargo technician","medical doctor","[user ? user : "stranger"]","octopus","changeling","\improper Nuclear Operative", "[pick("greyshirt", "greytide", "assistant")]", "xenomorph","catbeast","[user && user.mind && user.mind.heard_before.len ? pick(user.mind.heard_before) : "strange thing"]","Central Command","\improper Ian","[ticker.Bible_deity_name]","Nar-Sie","\improper Poly the Parrot","\improper Wizard","vox")
+				var/strangething = pick("captain","clown","mime","\improper CMO","cargo technician","medical doctor","[user ? user : "stranger"]","octopus","changeling","\improper Nuclear Operative", "[pick("greyshirt", "greytide", "assistant")]", "xenomorph","catbeast","[user && user.mind && user.mind.heard_before.len ? pick(user.mind.heard_before).name : "strange thing"]","Central Command","\improper Ian","[ticker.Bible_deity_name]","Nar-Sie","\improper Poly the Parrot","\improper Wizard","vox")
 				characters |= strangething
 			additional_description += "[i == material_mod ? " & a " : "[i > 1 ? ", a ": " A "]"][characters[i]]"
 		additional_description += ". They are in \the [pick("captains office","Space","mining outpost","vox outpost","a space station","[station_name()]","bar","kitchen","library","Science","void","Bluespace","Hell","Central Command")]"

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -22,10 +22,6 @@
 /mob/burnFireFuel(var/used_fuel_ratio,var/used_reactants_ratio)
 
 /mob/Destroy() // This makes sure that mobs with clients/keys are not just deleted from the game.
-	for(var/datum/mind/mind in heard_by)
-		for(var/M in mind.heard_before)
-			if(mind.heard_before[M] == src)
-				mind.heard_before[M] = null
 	if(on_spellcast)
 		on_spellcast.holder = null
 	if(on_uattack)
@@ -1969,13 +1965,13 @@ mob/proc/on_foot()
 /mob/proc/AdjustPlasma()
 	return
 
-/mob/living/carbon/heard(var/mob/living/carbon/human/M)
+/mob/heard(var/mob/M)
 	if(M == src || !istype(M))
 		return
 	if(!ear_deaf && !stat)
-		if(!(mind.heard_before[M.name]))
-			mind.heard_before[M.name] = M
-			M.heard_by |= mind
+		if(M.mind)
+			mind.heard_before[M.name] = M.mind
+			M.mind.heard_by |= mind
 
 /mob/acidable()
 	return 1

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -198,7 +198,6 @@
 
 	var/movement_speed_modifier = 1 //To allow on-the-fly editing of a human mob's base move speed
 	var/has_penalized_speed = 0 //does nothing, merely for checking
-	var/list/heard_by = list()
 
 //Generic list for proc holders. Only way I can see to enable certain verbs/procs. Should be modified if needed.
 	var/proc_holder_list[] = list()//Right now unused.
@@ -296,7 +295,7 @@
 
 /mob/resetVariables()
 	..("callOnFace", "pinned", "embedded", "abilities", "grabbed_by", "requests", "mapobjs", "mutations", "spell_list", "viruses", "resistances", "radar_blips", "active_genes", \
-	"attack_log", "speak_emote", "alphas", "heard_by", "control_object", "orient_object", "actions", "held_items", "click_delayer", "attack_delayer", "throw_delayer", "special_delayer", \
+	"attack_log", "speak_emote", "alphas", "control_object", "orient_object", "actions", "held_items", "click_delayer", "attack_delayer", "throw_delayer", "special_delayer", \
 	"clong_delayer", args)
 
 	callOnFace = list()
@@ -315,7 +314,6 @@
 	attack_log = list()
 	speak_emote = list()
 	alphas = list()
-	heard_by = list()
 	control_object = list()
 	orient_object = list()
 	actions = list()

--- a/code/modules/spells/targeted/targeted.dm
+++ b/code/modules/spells/targeted/targeted.dm
@@ -58,7 +58,7 @@ Targeted spells have two useful flags: INCLUDEUSER and SELECTABLE. These are exp
 			if(!user || !user.mind || !user.mind.heard_before.len)
 				return
 			var/target_name = input(user, "Choose the target, from those whose voices you've heard before.", "Targeting") in user.mind.heard_before
-			var/mob/temp_target = user.mind.heard_before[target_name]
+			var/datum/mind/temp_target = user.mind.heard_before[target_name]
 			believed_name = target_name
 			targets += temp_target
 		else if((range == 0 || range == SELFCAST) && (spell_flags & INCLUDEUSER))


### PR DESCRIPTION
[oversight]
fixes #10723

- based the heard_by list in the mind
- indexed both heard_by and heard_before with mob names
- both list now hold minds and not indexes
- reworked all occurences to work with this

:cl:
 * bugfix: monkifying no longer prevents being tracked by remote view
 * experiment: people you've heard before are no longer saved as mobs, but saved as brains, while still indexed with their mob name