### PR TITLE
longevity syndrome tweaks

### DIFF
--- a/code/modules/virus2/effect/stage_4.dm
+++ b/code/modules/virus2/effect/stage_4.dm
@@ -166,15 +166,16 @@
 		var/mob/living/carbon/human/H = mob
 		for (var/datum/organ/external/E in H.organs)
 			if (E.status & ORGAN_BROKEN && prob(30))
-				E.status ^= ORGAN_BROKEN
+				to_chat(user, "<span class = 'notice'>You feel the bones in your [E.display_name] set back into place.</span>")
+				E.status &= ~ORGAN_BROKEN
 	var/heal_amt = -5*multiplier
 	mob.apply_damages(heal_amt,heal_amt,heal_amt,heal_amt)
 
 /datum/disease2/effect/immortal/deactivate(var/mob/living/carbon/mob)
 	if(istype(mob, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = mob
-		to_chat(H, "<span class='notice'>You suddenly feel hurt and old...</span>")
-		H.age += 8
+		to_chat(H, "<span class='warning'>You suddenly feel hurt and old...</span>")
+		H.age += 4*multiplier
 	var/backlash_amt = 5*multiplier
 	mob.apply_damages(backlash_amt,backlash_amt,backlash_amt,backlash_amt)
 

--- a/code/modules/virus2/effect/stage_4.dm
+++ b/code/modules/virus2/effect/stage_4.dm
@@ -166,7 +166,7 @@
 		var/mob/living/carbon/human/H = mob
 		for (var/datum/organ/external/E in H.organs)
 			if (E.status & ORGAN_BROKEN && prob(30))
-				to_chat(user, "<span class = 'notice'>You feel the bones in your [E.display_name] set back into place.</span>")
+				to_chat(H, "<span class = 'notice'>You feel the bones in your [E.display_name] set back into place.</span>")
 				E.status &= ~ORGAN_BROKEN
 	var/heal_amt = -5*multiplier
 	mob.apply_damages(heal_amt,heal_amt,heal_amt,heal_amt)


### PR DESCRIPTION
Gives a bit of feedback to longevity syndrome

Can't say for sure if switching from ^= bit to &= ~bit is any different, but it's consistent with the rest of the codebase.

Also, why was the feedback of the deactivation backlash a notice and not a warning?

Sorry for messing with virology stuff during the rework

:cl:
 * tweak: The longevity symptom now backlash-ages you according to the multiplier, rather than you gaining an arbitrary 8 years of age. Age currently does not affect anything ingame.