### PR TITLE
Shotgun stun shells deal no damage, sound like tasers, make people scream

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -182,10 +182,17 @@
 /obj/item/projectile/bullet/stunshot
 	name = "stunshot"
 	icon_state = "sshell"
-	damage = 5
+	nodamage = 1
 	stun = 10
 	weaken = 10
 	stutter = 10
+	jittery = 10
+	agony = 10
+	hitsound = 'sound/weapons/taserhit.ogg'
+
+/obj/item/projectile/bullet/stunshot/hit_apply(mob/living/X, blocked)
+	. = ..()
+	X.audible_scream()
 
 /obj/item/projectile/bullet/a762
 	damage = 25


### PR DESCRIPTION
Alternative to #23328 since apparently the stunshellmetaclub really likes their shotgun tasers that are never used

:cl:
 * tweak: Shotgun stun shells now deal no damage, sound like tasers and make people scream.