### PR TITLE
Disables slimeperson decapitation

### DIFF
--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -159,7 +159,7 @@
 			if(isslimeperson(owner))
 				var/chance_multiplier = 1
 				if(istype(src, /datum/organ/external/head))
-					chance_multiplier = 0.5
+					chance_multiplier = 0
 				if(prob(brute * sharp * chance_multiplier))
 					droplimb(1)
 					return

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -418,6 +418,8 @@
 		return 0
 	if (affected.status & ORGAN_DESTROYED)
 		return 0
+	if(isslimeperson(target) && istype(affected, /datum/organ/external/head))
+		return 0
 	return target_zone != LIMB_CHEST && target_zone != LIMB_GROIN && target_zone != LIMB_HEAD
 
 /datum/surgery_step/generic/cut_limb/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)


### PR DESCRIPTION
You can no longer decapitate slimepeople, to avoid the fuckery that is their unique functionality of dropping their brain.

closes #21134

There's probably weird edge-cases that'll still decapitate the slime.

:cl:
 * tweak: Slime people can no longer be decapitated.