### PR TITLE
Moves a check in borer.dm

### DIFF
--- a/code/modules/mob/living/simple_animal/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer.dm
@@ -419,7 +419,7 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 				break
 	if(newname)
 		host.name = newname
-	if(controlling == 0)
+	if(!controlling)
 		host_brain.ckey = host.ckey
 		host_brain.name = host.real_name
 		host.ckey = src.ckey

--- a/code/modules/mob/living/simple_animal/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer.dm
@@ -407,7 +407,11 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 		to_chat(src, "<span class='danger'>You plunge your probosci deep into the cortex of the host brain, interfacing directly with their nervous system.</span>")
 		to_chat(host, "<span class='danger'>You feel a strange shifting sensation behind your eyes as an alien consciousness displaces yours.</span>")
 
-	//Let borers namepick when assuming control
+	if(!controlling)
+		host_brain.ckey = host.ckey
+		host_brain.name = host.real_name
+		host.ckey = src.ckey
+		controlling = 1
 	var/newname
 	for(var/i = 1 to 3)
 		newname = reject_bad_name(stripped_input(src,"You may assume a new identity for the host you've infested. Enter a name, or cancel to keep your host's original name.", "Name change [4-i] [0-i != 1 ? "tries":"try"] left",""),1,MAX_NAME_LEN)
@@ -419,12 +423,6 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 				break
 	if(newname)
 		host.name = newname
-	if(!controlling)
-		host_brain.ckey = host.ckey
-		host_brain.name = host.real_name
-		host.ckey = src.ckey
-		controlling = 1
-
 	host.verbs += /mob/living/carbon/proc/release_control
 	/* Broken
 	host.verbs += /mob/living/carbon/proc/punish_host

--- a/code/modules/mob/living/simple_animal/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer.dm
@@ -11,7 +11,7 @@ var/global/borer_chem_types_chest = typesof(/datum/borer_chem/chest) - /datum/bo
 var/global/borer_chem_types_arm = typesof(/datum/borer_chem/arm) - /datum/borer_chem - /datum/borer_chem/arm
 var/global/borer_chem_types_leg = typesof(/datum/borer_chem/leg) - /datum/borer_chem - /datum/borer_chem/leg
 var/global/borer_unlock_types_head = typesof(/datum/unlockable/borer/head) - /datum/unlockable/borer - /datum/unlockable/borer/head - /datum/unlockable/borer/head/chem_unlock - /datum/unlockable/borer/head/verb_unlock
-var/global/borer_unlock_types_chest = typesof(/datum/unlockable/borer/chest) "- /datum/unlockable/borer - /datum/unlockable/borer/chest - /datum/unlockable/borer/chest/chem_unlock - /datum/unlockable/borer/chest/verb_unlock
+var/global/borer_unlock_types_chest = typesof(/datum/unlockable/borer/chest) - /datum/unlockable/borer - /datum/unlockable/borer/chest - /datum/unlockable/borer/chest/chem_unlock - /datum/unlockable/borer/chest/verb_unlock
 var/global/borer_unlock_types_arm = typesof(/datum/unlockable/borer/arm) - /datum/unlockable/borer - /datum/unlockable/borer/arm - /datum/unlockable/borer/arm/chem_unlock - /datum/unlockable/borer/arm/verb_unlock
 var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datum/unlockable/borer - /datum/unlockable/borer/leg - /datum/unlockable/borer/leg/chem_unlock - /datum/unlockable/borer/leg/verb_unlock
 
@@ -364,7 +364,7 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 	set category = "Alien"
 	set name = "Assume Control"
 	set desc = "Fully connect to the brain of your host."
-	
+
 	var/mob/living/simple_animal/borer/B=loc
 	if(!istype(B))
 		return
@@ -387,7 +387,7 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 		return
 
 	to_chat(src, "You begin delicately adjusting your connection to the host brain...")
-	
+
 	var/mod = max(300 - host.brainloss, 0) //braindamaged hosts are overwhelmed faster
 	spawn(mod)
 		if(!host || !src || controlling)

--- a/code/modules/mob/living/simple_animal/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer.dm
@@ -364,7 +364,6 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 	set category = "Alien"
 	set name = "Assume Control"
 	set desc = "Fully connect to the brain of your host."
-
 	var/mob/living/simple_animal/borer/B=loc
 	if(!istype(B))
 		return
@@ -387,7 +386,6 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 		return
 
 	to_chat(src, "You begin delicately adjusting your connection to the host brain...")
-
 	var/mod = max(300 - host.brainloss, 0) //braindamaged hosts are overwhelmed faster
 	spawn(mod)
 		if(!host || !src || controlling)
@@ -396,7 +394,7 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 			do_bonding(rptext=1)
 
 /mob/living/simple_animal/borer/proc/do_bonding(var/rptext=0)
-	if(!host || host.stat==DEAD || !src || controlling || research.unlocking)
+	if(!host || host.stat==DEAD || !src || research.unlocking)
 		return
 	
 	if(host.ckey || !istype(host, /mob/living/carbon/monkey)) //check again just to be sure
@@ -419,11 +417,11 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 				break
 	if(newname)
 		host.name = newname
-
-	host_brain.ckey = host.ckey
-	host_brain.name = host.real_name
-	host.ckey = src.ckey
-	controlling = 1
+	if(controlling == 0)
+		host_brain.ckey = host.ckey
+		host_brain.name = host.real_name
+		host.ckey = src.ckey
+		controlling = 1
 
 	host.verbs += /mob/living/carbon/proc/release_control
 	/* Broken

--- a/code/modules/mob/living/simple_animal/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer.dm
@@ -11,7 +11,7 @@ var/global/borer_chem_types_chest = typesof(/datum/borer_chem/chest) - /datum/bo
 var/global/borer_chem_types_arm = typesof(/datum/borer_chem/arm) - /datum/borer_chem - /datum/borer_chem/arm
 var/global/borer_chem_types_leg = typesof(/datum/borer_chem/leg) - /datum/borer_chem - /datum/borer_chem/leg
 var/global/borer_unlock_types_head = typesof(/datum/unlockable/borer/head) - /datum/unlockable/borer - /datum/unlockable/borer/head - /datum/unlockable/borer/head/chem_unlock - /datum/unlockable/borer/head/verb_unlock
-var/global/borer_unlock_types_chest = typesof(/datum/unlockable/borer/chest) - /datum/unlockable/borer - /datum/unlockable/borer/chest - /datum/unlockable/borer/chest/chem_unlock - /datum/unlockable/borer/chest/verb_unlock
+var/global/borer_unlock_types_chest = typesof(/datum/unlockable/borer/chest) "- /datum/unlockable/borer - /datum/unlockable/borer/chest - /datum/unlockable/borer/chest/chem_unlock - /datum/unlockable/borer/chest/verb_unlock
 var/global/borer_unlock_types_arm = typesof(/datum/unlockable/borer/arm) - /datum/unlockable/borer - /datum/unlockable/borer/arm - /datum/unlockable/borer/arm/chem_unlock - /datum/unlockable/borer/arm/verb_unlock
 var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datum/unlockable/borer - /datum/unlockable/borer/leg - /datum/unlockable/borer/leg/chem_unlock - /datum/unlockable/borer/leg/verb_unlock
 
@@ -364,6 +364,7 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 	set category = "Alien"
 	set name = "Assume Control"
 	set desc = "Fully connect to the brain of your host."
+	
 	var/mob/living/simple_animal/borer/B=loc
 	if(!istype(B))
 		return
@@ -386,6 +387,7 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 		return
 
 	to_chat(src, "You begin delicately adjusting your connection to the host brain...")
+	
 	var/mod = max(300 - host.brainloss, 0) //braindamaged hosts are overwhelmed faster
 	spawn(mod)
 		if(!host || !src || controlling)


### PR DESCRIPTION
This should prevent situations where someone double-clicks on Assume Control and gets put in a limbo with no verbs.
[bugfix]
:cl:
 * bugfix: Adds a check to see if someone already has control within Assume Control for borers.