### PR TITLE
armor fixes

### DIFF
--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -68,7 +68,7 @@
 			altered = effect
 			halloss += altered // Useful for objects that cause "subdual" damage. PAIN!
 		if(IRRADIATE)
-			altered = max((((effect - (effect*(getarmor(null, "rad")/100))))/(blocked+1)),0)//Rads auto check armor
+			altered = max(0, (effect/100)*(100-getarmor(null, "rad"))) //Get overall radiation protection, rather than point-exposure
 			radiation += altered
 		if(STUTTER)
 			if(status_flags & CANSTUN) // stun is usually associated with stutter

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -116,7 +116,7 @@ var/list/impact_master = list()
 	X.apply_effects(stun, weaken, paralyze, irradiate, stutter, eyeblur, drowsy, agony, blocked)
 
 /obj/item/projectile/proc/on_hit(var/atom/atarget, var/blocked = 0)
-	if(blocked >= 2)
+	if(blocked >= 100)
 		return 0//Full block
 	if(!isliving(atarget))
 		return 0


### PR DESCRIPTION
Fixes projectiles not doing anything, at all.

:cl:
 * tweak: Armor is now a straight divider of damage, rather than the double diceroll it was previously.