### PR TITLE
Yet more head reattachment fixes

### DIFF
--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -1026,6 +1026,13 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 			OE.attach(attached)
 
+		if(organ.organ_data && !owner.internal_organs_by_name[organ.organ_data.organ_type])
+			owner.internal_organs_by_name[organ.organ_data.organ_type] = organ.organ_data.Copy()
+			owner.internal_organs += owner.internal_organs_by_name[organ.organ_data.organ_type]
+			internal_organs += owner.internal_organs_by_name[organ.organ_data.organ_type]
+			owner.internal_organs_by_name[organ.organ_data.organ_type].owner = owner
+
+
 	else if(istype(I, /obj/item/weapon/peglimb)) //Attaching a peg limb
 		src.peggify()
 

--- a/code/modules/surgery/headreattach.dm
+++ b/code/modules/surgery/headreattach.dm
@@ -197,40 +197,14 @@
 	affected.amputated = 0
 	affected.destspawn = 0
 
-	var/obj/item/organ/external/O = tool
-	if(istype(O))
-		affected.attach(O)
-
 	var/obj/item/organ/external/head/B = tool
 	if (B.brainmob.mind)
 		B.brainmob.mind.transfer_to(target)
 	target.languages = B.brainmob.languages
 	target.default_language = B.brainmob.default_language
 
-	if (B.butchering_drops.len) //Transferring teeth and other stuff
-		for(var/datum/butchering_product/BP in B.butchering_drops) //First, search for all "stuff" inside the head
-
-			var/datum/butchering_product/match = locate(BP.type) in target.butchering_drops //See if our guy already has the same thing in him (shouldn't happen, but who knows)
-			if(istype(match)) //If he does have a duplicate
-				target.butchering_drops -= match //Remove it!
-				qdel(match)
-
-			target.butchering_drops.Add(BP) //Transfer
-			B.butchering_drops.Remove(BP)
-
-
-	if(B.organ_data) //There is a brain in this head
-		var/datum/organ/internal/brain/copied
-		var/datum/organ/internal/I = B.organ_data
-		copied = I.Copy()
-		copied.owner = target
-		target.internal_organs_by_name["brain"] = copied
-		target.internal_organs += copied
-		affected.internal_organs += copied
-
+	affected.attach(B)
 	target.decapitated = null
-
-	qdel(B)
 
 
 /datum/surgery_step/head/attach/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -262,7 +236,6 @@
 	var/datum/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'>[user] has attached \the [tool] to the body.</span>",	\
 	"<span class='notice'>You have attached \the [tool] to the bodies reshaped neck.</span>")
-	affected.status = 0
 	affected.amputated = 0
 	affected.destspawn = 0
 	affected.attach(tool)


### PR DESCRIPTION
Now that I can finally see my screen, this should sort it. The problem was, now that the function is using attach(), it would get qdel'd and lose the brain before passing it over to the new body.

Removes the snowflake "Remove this brain datum, and put it there" from head reattachment, and moves it to the attach() function

Removes the redundant passing of butchering drops, as that's also handled by attach()

moves attach() to further down, and removes the redundant qdel(), as attach() calls qdel()