### PR TITLE
Feedback message when screwdrivering airlocks

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1139,6 +1139,7 @@ About the new airlock wires panel:
 	if(!operating)
 		panel_open = !panel_open
 		playsound(src, 'sound/items/Screwdriver.ogg', 25, 1, -6)
+		to_chat(user, "<span class='notice'>You [panel_open?"open":"close"] the panel.</span>")
 		update_icon()
 		return 1
 	return


### PR DESCRIPTION
![screwed](https://user-images.githubusercontent.com/8468269/60461095-d616b680-9c45-11e9-94c7-4d59c42caff7.png)

🆑 
 - tweak: You now get a feedback message when opening / closing airlock panels with a screwdriver