### PR TITLE
can holster bananas, isgun macro, isbanana macro

### DIFF
--- a/__DEFINES/_macros.dm
+++ b/__DEFINES/_macros.dm
@@ -154,6 +154,10 @@
 
 #define isbikehorn(A) istype(A, /obj/item/weapon/bikehorn)
 
+#define isbanana(A) istype(A, /obj/item/weapon/reagent_containers/food/snacks/grown/banana)
+
+#define isgun(A) istype(A, /obj/item/weapon/gun)
+
 #define ispowercell(A) istype(A, /obj/item/weapon/cell)
 
 #define ismultitool(A) istype(A, /obj/item/device/multitool)

--- a/code/modules/clothing/accessories/holster.dm
+++ b/code/modules/clothing/accessories/holster.dm
@@ -124,7 +124,7 @@
 	holster_verb_name = "Holster (Handgun)"
 
 /obj/item/clothing/accessory/holster/handgun/can_holster(obj/item/weapon/W)
-	if(!isgun(W) && !isbanana(W))
+	if(!isgun(W) && !isbanana(W) && !istype(W, /obj/item/weapon/reagent_containers/food/snacks/grown/bluespacebanana))
 		return
 	return W.isHandgun()
 

--- a/code/modules/clothing/accessories/holster.dm
+++ b/code/modules/clothing/accessories/holster.dm
@@ -123,8 +123,8 @@
 	desc = "A handgun holster that clips to a suit. Perfect for concealed carry."
 	holster_verb_name = "Holster (Handgun)"
 
-/obj/item/clothing/accessory/holster/handgun/can_holster(obj/item/weapon/gun/W)
-	if(!istype(W))
+/obj/item/clothing/accessory/holster/handgun/can_holster(obj/item/weapon/W)
+	if(!isgun(W) && !isbanana(W))
 		return
 	return W.isHandgun()
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -101,7 +101,7 @@
 	else
 		Fire(A,user,params, "struggle" = struggle) //Otherwise, fire normally.
 
-/obj/item/weapon/gun/proc/isHandgun()
+/obj/item/weapon/proc/isHandgun()
 	return FALSE //Make this proc return TRUE for handgun-shaped weapons (or in general, small enough weapons I guess)
 
 /obj/item/weapon/gun/proc/play_firesound(mob/user, var/reflex)

--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -564,6 +564,9 @@ var/list/special_fruits = list()
 	plantname = "banana"
 	fragrance = INCENSE_BANANA
 
+/obj/item/weapon/reagent_containers/food/snacks/grown/banana/isHandgun()
+	return TRUE
+
 /obj/item/weapon/reagent_containers/food/snacks/grown/bluespacebanana
 	name = "bluespace banana"
 	desc = "It's an excellent prop for a comedy."

--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -576,6 +576,9 @@ var/list/special_fruits = list()
 	filling_color = "#FCF695"
 	plantname = "bluespacebanana"
 
+/obj/item/weapon/reagent_containers/food/snacks/grown/bluespacebanana/isHandgun()
+	return TRUE
+
 /obj/item/weapon/reagent_containers/food/snacks/grown/bluespacebanana/after_consume(var/mob/user, var/datum/reagents/reagentreference)
 	var/obj/item/weapon/bananapeel/bluespace/peel = new
 	peel.potency = potency


### PR DESCRIPTION
![bananaholster](https://user-images.githubusercontent.com/8468269/60464661-7b825800-9c4f-11e9-9722-f034fc566282.png)
also adds a `isgun()` and `isbanana()` macro, for your profit
does *not* support bluespace bananas, because those aren't subtypes of bananas for some reason

🆑 
 - tweak: Handgun holsters can now hold bananas.
