### PR TITLE
starscreens now come in flatpacks

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1474,22 +1474,34 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	access = list(access_engine)
 
 /datum/supply_packs/shield_gen
-	contains = list(/obj/item/weapon/circuitboard/shield_gen)
-	name = "Starscreen generator board"
-	cost = 30
-	containertype = /obj/structure/closet/crate/secure/engisec
+	contains = list(/obj/structure/closet/crate/flatpack/starscreen_generator,
+					/obj/structure/closet/crate/flatpack/starscreen_capacitor)
+	name = "Starscreen shield generator"
+	cost = 200
+	containertype = /obj/structure/closet/crate/secure/large/reinforced
 	containername = "Starscreen shield generator crate"
 	group = "Engineering"
 	access = list(access_engine)
-
-/datum/supply_packs/shield_cap
-	contains = list(/obj/item/weapon/circuitboard/shield_cap)
-	name = "Starscreen capacitor board"
-	cost = 30
-	containertype = /obj/structure/closet/crate/secure/engisec
-	containername = "Starscreen shield capacitor crate"
+	
+/datum/supply_packs/shield_gen/post_creation(var/atom/movable/container)
+	var/obj/structure/closet/crate/flatpack/flatpack1 = locate(/obj/structure/closet/crate/flatpack/starscreen_generator/) in container
+	var/obj/structure/closet/crate/flatpack/flatpack2 = locate(/obj/structure/closet/crate/flatpack/starscreen_capacitor/) in container
+	flatpack1.add_stack(flatpack2)
+	
+/datum/supply_packs/shield_gen_ex
+	contains = list(/obj/structure/closet/crate/flatpack/starscreen_ex_generator,
+					/obj/structure/closet/crate/flatpack/starscreen_capacitor)
+	name = "Starscreen-EX shield generator"
+	cost = 200
+	containertype = /obj/structure/closet/crate/secure/large/reinforced
+	containername = "Starscreen-EX shield generator crate"
 	group = "Engineering"
 	access = list(access_engine)
+	
+/datum/supply_packs/shield_gen_ex/post_creation(var/atom/movable/container)
+	var/obj/structure/closet/crate/flatpack/flatpack1 = locate(/obj/structure/closet/crate/flatpack/starscreen_ex_generator/) in container
+	var/obj/structure/closet/crate/flatpack/flatpack2 = locate(/obj/structure/closet/crate/flatpack/starscreen_capacitor/) in container
+	flatpack1.add_stack(flatpack2)
 
 /datum/supply_packs/teg
 	contains = list(/obj/machinery/power/generator)

--- a/code/modules/research/mechanic/flatpack.dm
+++ b/code/modules/research/mechanic/flatpack.dm
@@ -282,3 +282,15 @@
 /obj/structure/closet/crate/flatpack/brewer/New()
 	..()
 	machine = new /obj/machinery/chem_dispenser/brewer(src)
+	
+/obj/structure/closet/crate/flatpack/starscreen_generator/New()
+	..()
+	machine = new /obj/machinery/shield_gen(src)
+	
+/obj/structure/closet/crate/flatpack/starscreen_ex_generator/New()
+	..()
+	machine = new /obj/machinery/shield_gen/external(src)
+	
+/obj/structure/closet/crate/flatpack/starscreen_capacitor/New()
+	..()
+	machine = new /obj/machinery/shield_capacitor(src)


### PR DESCRIPTION
- starscreen crate now comes with a flatpacked machine rather than a fucking circuitboard
- also comes with a flatpacked capacitor
- added a starscreen EX crate
- removed the capacitor crate
- raised the price by a lot to compensate(60 -> 200)
- updated the wiki in advance


:cl:
 - tweak: Starscreens crates from cargo now contain a fully functional shield generator flatpack and shield capacitor flatpack