### PR TITLE
Fixes nuke ops theme failing to stop, despite it not having started?

### DIFF
--- a/code/datums/gamemode/factions/syndicate/nukeops.dm
+++ b/code/datums/gamemode/factions/syndicate/nukeops.dm
@@ -269,5 +269,5 @@
 				M = R.antag.current
 				if(M.stat != DEAD)
 					livingmembers++
-		if(ticker.theme.playing && !livingmembers && ticker.theme.playlist_id == "nukesquad")
+		if(!livingmembers && ticker.IsThematic(playlist))
 			ticker.StopThematic()

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -111,6 +111,14 @@ var/datum/controller/gameticker/ticker
 	while (!setup())
 #undef LOBBY_TICKING
 #undef LOBBY_TICKING_RESTARTED
+
+/datum/controller/gameticker/proc/IsThematic(var/playlist)
+	if(!theme)
+		return 0
+	if(theme.playlist_id == playlist)
+		return 1
+	return 0
+
 /datum/controller/gameticker/proc/StartThematic(var/playlist)
 	if(!theme)
 		theme = new(locate(1,1,CENTCOMM_Z))


### PR DESCRIPTION
A runtime I spotted, was caused by poor sanity.