### PR TITLE
Can deconvert cultists

### DIFF
--- a/code/datums/gamemode/role/legacy_cultist.dm
+++ b/code/datums/gamemode/role/legacy_cultist.dm
@@ -84,8 +84,8 @@
 	dat += "<a href='?src=\ref[faction];cult_mindspeak=\ref[src]'>Voice of [C.deity_name]</a><br/>"
 	return dat
 
-/datum/role/legacy_cultist/handle_reagent(var/reagent_id)
-	switch (reagent_id)
+/datum/role/legacy_cultist/handle_reagent(var/datum/reagent/agent)
+	switch (agent.id)
 		if (HOLYWATER)
 			var/mob/living/carbon/human/H = antag.current
 			if (!istype(H))

--- a/code/datums/gamemode/role/role.dm
+++ b/code/datums/gamemode/role/role.dm
@@ -478,7 +478,7 @@
 
 // -- Custom reagent reaction for your antag - now in a (somewhat) maintable fashion
 
-/datum/role/proc/handle_reagent(var/reagent_id)
+/datum/role/proc/handle_reagent(var/datum/reagent/agent)
 	return
 
 /datum/role/proc/handle_splashed_reagent(var/reagent_id)

--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -428,8 +428,8 @@
 		logo_state = initial(logo_state)
 		check_vampire_upgrade()
 
-/datum/role/vampire/handle_reagent(var/reagent_id)
-	switch(reagent_id)
+/datum/role/vampire/handle_reagent(var/datum/reagent/agent)
+	switch(agent.id)
 		if (HOLYWATER,INCENSE_HAREBELLS)
 			var/mob/living/carbon/human/H = antag.current
 			if (!istype(H))
@@ -596,8 +596,8 @@
 	update_faction_icons()
 	return ..()
 
-/datum/role/thrall/handle_reagent(var/reagent_id)
-	switch (reagent_id)
+/datum/role/thrall/handle_reagent(var/datum/reagent/agent)
+	switch (agent.id)
 		if (HOLYWATER)
 			var/mob/living/carbon/human/H = antag.current
 			if (!istype(H))

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -160,7 +160,7 @@
 	if (M.mind)
 		for (var/role in M.mind.antag_roles)
 			var/datum/role/R = M.mind.antag_roles[role]
-			R.handle_reagent(id)
+			R.handle_reagent(src)
 
 /datum/reagent/proc/is_overdosing() //Too much chems, or been in your system too long
 	return (overdose_am && volume >= overdose_am) || (overdose_tick && tick >= overdose_tick)


### PR DESCRIPTION
Requires
- 15u of holy water in the body
- The holy water MUST metabolises 5 ticks so you need a BIG sip of it
- Doesn't work on cultists with more than 3 tattoos or if you have the "holy water immunity" tattoo

(ie, it will be really hard to perform deconversions on the run)

When deconverted, you're stunned for 8 seconds and jitter a lot.

[balance] [powercreep] [etc]

0% tested for now because there's a non-negligible chance it will just downboated to hell and back with no explanations

:cl:
- tweak: Can deconvert cultists again with a hefty dose of holy water