### PR TITLE
Your Dreamseeker window will now flash when you receive an adminhelp or when you are dead and a gamemode is looking for candidates

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets.dm
@@ -107,8 +107,7 @@
 			continue
 
 		to_chat(M, "[logo ? "[bicon(logo_icon)]" : ""]<span class='recruit'>The mode is looking for volunteers to become [initial(role_category.id)]. (<a href='?src=\ref[src];signup=\ref[M]'>Apply now!</a>)</span>[logo ? "[bicon(logo_icon)]" : ""]")
-		var/client/C = M.client
-		window_flash(C)
+		window_flash(M.client)
 
 	spawn(1 MINUTES)
 		searching = 0

--- a/code/datums/gamemode/dynamic/dynamic_rulesets.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets.dm
@@ -107,6 +107,8 @@
 			continue
 
 		to_chat(M, "[logo ? "[bicon(logo_icon)]" : ""]<span class='recruit'>The mode is looking for volunteers to become [initial(role_category.id)]. (<a href='?src=\ref[src];signup=\ref[M]'>Apply now!</a>)</span>[logo ? "[bicon(logo_icon)]" : ""]")
+		var/client/C = M.client
+		window_flash(C)
 
 	spawn(1 MINUTES)
 		searching = 0

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -148,6 +148,9 @@
 		C.last_pm_received = world.time
 		C.ckey_last_pm = ckey*/
 
+	//Makes Dreamseeker flash on Windows, regardless of window flashing preference.
+	window_flash(C, 1)
+
 	//play the recieving admin the adminhelp sound (if they have them enabled)
 	//non-admins shouldn't be able to disable this
 	if(C.prefs.toggles & SOUND_ADMINHELP)


### PR DESCRIPTION
All of you people out there can now alt-tab and rest easily knowing you won't miss out on midround shenanigans
Not even sure if this will work but I really want a live test, nothing should break.
:cl:
 * tweak: Your Dreamseeker window will now flash orange if you are given an admin PM or if a gamemode is looking for candidates.