### PR TITLE
Adds access requirements to edit info from sec and med huds.

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -508,6 +508,10 @@
 		if(!sec_record)
 			to_chat(usr, "<span class='warning'>Unable to locate a data core entry for this person.</span>")
 			return
+		var/req_access = list(access_security)
+		if(!can_access(usr.GetAccess(),req_access))
+			to_chat(usr, "<span class='warning'>Access denied.</span>")
+			return
 		var/setcriminal = input(usr, "Specify a new criminal status for this person.", "Security HUD", sec_record.fields["criminal"]) as null|anything in list("None", "*High Threat*", "*Arrest*", "Incarcerated", "Parolled", "Released")
 		if(!setcriminal || (usr.incapacitated() && !isAdminGhost(usr)) || !usr.hasHUD(HUD_SECURITY))
 			return
@@ -534,6 +538,10 @@
 	else if (href_list["secrecordadd"])
 		if(!usr.hasHUD(HUD_SECURITY) || isjustobserver(usr))
 			return
+		var/req_access = list(access_security)
+		if(!can_access(usr.GetAccess(),req_access))
+			to_chat(usr, "<span class='warning'>Access denied.</span>")
+			return
 		var/perpname = get_identification_name(get_face_name())
 		var/datum/data/record/sec_record = data_core.find_security_record_by_name(perpname)
 		if(!sec_record)
@@ -550,6 +558,10 @@
 		var/datum/data/record/gen_record = data_core.find_general_record_by_name(perpname)
 		if(!gen_record)
 			to_chat(usr, "<span class='warning'>Unable to locate a data core entry for this person.</span>")
+			return
+		var/req_access = list(access_medical)
+		if(!can_access(usr.GetAccess(),req_access))
+			to_chat(usr, "<span class='warning'>Access denied.</span>")
 			return
 		var/setmedical = input(usr, "Specify a new medical status for this person.", "Medical HUD", gen_record.fields["p_stat"]) as null|anything in list("*SSD*", "*Deceased*", "Physically Unfit", "Active", "Disabled")
 		if(!setmedical|| (usr.incapacitated() && !isAdminGhost(usr)) || !usr.hasHUD(HUD_MEDICAL))
@@ -596,6 +608,10 @@
 		var/datum/data/record/med_record = data_core.find_medical_record_by_name(perpname)
 		if(!med_record)
 			to_chat(usr, "<span class='warning'>Unable to locate a data core entry for this person.</span>")
+			return
+		var/req_access = list(access_medical)
+		if(!can_access(usr.GetAccess(),req_access))
+			to_chat(usr, "<span class='warning'>Access denied.</span>")
 			return
 		var/t1 = copytext(sanitize(input(usr, "Add comment:", "Medical records") as message|null),1,MAX_MESSAGE_LEN)
 		if (!t1 || (usr.incapacitated() && !isAdminGhost(usr)) || !usr.hasHUD(HUD_MEDICAL))


### PR DESCRIPTION
[bugfix] [oversight]
Medical and security records are normally behind a console that requires the user to log in with an ID with the respective access and then they can view and edit the info. Med/sec huds completely bypass these requirements due to the lack of an access check. This adds a similar access requirement to huds so you can no longer bypass it. I have made it as painless as possible by just having it check if the user has the access rather than having to fumble around with an ID swipe or insert.
**Med/sec huds still allow anyone to VIEW info from them but to EDIT the info you need the basic med/sec access. Silicon huds are unchanged.**
Some possible game play changes are you can no longer mess with arrest status if you don't have access. This means clowns can no longer set everyone to arrest with a hidden pair of sec huds and have beepsky claim valids on the entire crew but they can see when sec has set them to arrest for slipping the HoS for those shades.

:cl:
 * bugfix: Med/sec huds now require their respective access to EDIT info but said info can still be VIEWed. This change doesn't affect silicon huds.