### PR TITLE
Looc will now show mob name instead of ckey

### DIFF
--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -143,7 +143,7 @@
 	log_ooc("(LOCAL) [mob.name]/[key] (@[mob.x],[mob.y],[mob.z]): [msg]")
 	var/list/heard
 	var/mob/living/silicon/ai/AI
-	var/mob/name = src.mob.name
+	var/name = src.mob.name
 	if(!isAI(src.mob))
 		heard = get_hearers_in_view(7, src.mob)
 	else

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -143,6 +143,7 @@
 	log_ooc("(LOCAL) [mob.name]/[key] (@[mob.x],[mob.y],[mob.z]): [msg]")
 	var/list/heard
 	var/mob/living/silicon/ai/AI
+	var/mob/name = src.mob.name
 	if(!isAI(src.mob))
 		heard = get_hearers_in_view(7, src.mob)
 	else
@@ -161,32 +162,17 @@
 			if(E.ai)
 				C = E.ai.client
 		if(C.prefs.toggles & CHAT_LOOC)
-			var/display_name = src.key
-			if(holder)
-				if(holder.fakekey)
-					if(C.holder)
-						display_name = "[holder.fakekey]/([src.key])"
-					else
-						display_name = holder.fakekey
-			to_chat(C, "<font color='#6699CC'><span class='ooc'><span class='prefix'>LOOC:</span> <EM>[display_name]:</EM> <span class='message'>[msg]</span></span></font>")
+			to_chat(C, "<font color='#6699CC'><span class='ooc'><span class='prefix'>LOOC:</span> <EM>[name]:</EM> <span class='message'>[msg]</span></span></font>")
 
 	for(var/client/C in admins)
 		if(C.prefs.toggles & CHAT_LOOC)
 			var/prefix = "(R)LOOC"
 			if (C.mob in heard)
 				prefix = "LOOC"
-			to_chat(C, "<font color='#6699CC'><span class='ooc'><span class='prefix'>[prefix]:</span> <EM>[src.key]:</EM> <span class='message'>[msg]</span></span></font>")
+			to_chat(C, "<font color='#6699CC'><span class='ooc'><span class='prefix'>[prefix]:</span> <EM>[name]/[src.key]:</EM> <span class='message'>[msg]</span></span></font>")
 	if(istype(AI))
 		var/client/C = AI.client
 		if (C in admins)
 			return //already been handled
-
 		if(C.prefs.toggles & CHAT_LOOC)
-			var/display_name = src.key
-			if(holder)
-				if(holder.fakekey)
-					if(C.holder)
-						display_name = "[holder.fakekey]/([src.key])"
-					else
-						display_name = holder.fakekey
-			to_chat(C, "<font color='#6699CC'><span class='ooc'><span class='prefix'>LOOC:</span> <EM>[display_name]:</EM> <span class='message'>[msg]</span></span></font>")
+			to_chat(C, "<font color='#6699CC'><span class='ooc'><span class='prefix'>LOOC:</span> <EM>[name]:</EM> <span class='message'>[msg]</span></span></font>")


### PR DESCRIPTION
Hell yeah I fixed the server
Admins will see player name and then ckey instead
:cl:
 * tweak: LOOC will now show your in-game name instead of ckey.