### PR TITLE
Virology Rewrite/Virus3 - Part 2.99 of 3 : lots of small tweaks, mostly effect changes, and other stuff I had postponed

### DIFF
--- a/code/datums/gamemode/role/catbeast.dm
+++ b/code/datums/gamemode/role/catbeast.dm
@@ -13,6 +13,9 @@
 /datum/role/catbeast/Greet()
 	to_chat(antag.current, "<B><span class='warning'>You are a mangy catbeast!</span></B>")
 	to_chat(antag.current, "The longer you avoid the crew, the greater danger the station will attract! You will generate threat for each new room you enter and for being alive (up to 5 minutes).")
+	to_chat(antag.current, "<span class='warning'>You are also carrying some nasty diseases. Check your notes to see their specs.</span>")
+	to_chat(antag.current, "<span class='notice'>You can accelerate their progression by drinking some milk along with some water, so go find some.</span>")
+
 
 /datum/role/catbeast/OnPostSetup()
 	var/mob/living/carbon/human/H = antag.current
@@ -61,11 +64,6 @@ var/list/catbeast_names = list("Meowth","Fluffy","Subject 246","Experiment 35a",
 	D2.origin = "Loose Catbeast"
 	D2.makerandom(list(60,90),list(50,90),anti,bad,null)
 	H.infect_disease2(D2,1, "Loose Catbeast")
-
-	to_chat(H, "<span class='warning'>You are also carrying some diseases. Check your notes to see their specs.</span>")
-
-	to_chat(H, "<span class='warning'>You can accelerate their progression by drinking some milk along with some water, so go find some.</span>")
-
 	antag.store_memory("<hr>")
 	antag.store_memory(D1.get_info())
 	antag.store_memory("<hr>")

--- a/code/game/machinery/kitchen/gibber.dm
+++ b/code/game/machinery/kitchen/gibber.dm
@@ -217,6 +217,12 @@ obj/machinery/gibber/New()
 		if(src.occupant.reagents)
 			src.occupant.reagents.trans_to (newmeat, round (sourcetotalreagents / totalslabs, 1)) // Transfer all the reagents from the
 
+		if (occupant.virus2?.len)
+			for (var/ID in occupant.virus2)
+				var/datum/disease2/disease/D = occupant.virus2[ID]
+				if (D.spread & SPREAD_BLOOD)
+					newmeat.infect_disease2(D,1,"(Gibber, from [occupant], and activated by [user])")
+
 		allmeat[i] = newmeat
 
 	src.occupant.attack_log += "\[[time_stamp()]\] Was gibbed by <B>[key_name(user)]</B>" //One shall not simply gib a mob unnoticed!

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1422,7 +1422,10 @@ Thanks.
 	meat_taken++
 
 	if (virus2?.len)
-		M.virus2 = filter_disease_by_spread(virus_copylist(virus2),required = SPREAD_BLOOD)
+		for (var/ID in virus2)
+			var/datum/disease2/disease/D = virus2[ID]
+			if (D.spread & SPREAD_BLOOD)
+				M.infect_disease2(D,1,"(Butchered, from [src])")
 
 	var/obj/item/weapon/reagent_containers/food/snacks/meat/animal/A = M
 

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -3146,7 +3146,7 @@
 	id = VACCINE
 	reagent_state = REAGENT_STATE_LIQUID
 	color = "#A6A6A6" //rgb: 166, 166, 166
-	alpha = 128
+	alpha = 200
 	density = 1.05
 	specheatcap = 3.49
 	custom_metabolism = 1

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -395,6 +395,10 @@
 				to_chat(N, ("<span class='notice'>You nibble away at \the [src].</span>"))
 			N.health = min(N.health + 1, N.maxHealth)
 			N.nutrition += 5
+			if (virus2?.len)
+				for (var/ID in virus2)
+					var/datum/disease2/disease/D = virus2[ID]
+					N.infect_disease2(D, 1, notes="(Ate an infected [src])")//eating infected food means 100% chance of infection.
 			reagents.trans_to(N, 0.25)
 			bitecount+= 0.25
 			after_consume(M,src.reagents)

--- a/code/modules/virus2/analyser.dm
+++ b/code/modules/virus2/analyser.dm
@@ -235,6 +235,9 @@
 	scanner = null
 	..()
 
+
+//////////////////////////////////////////////////////GENERAL DISEASE2 MACHINE PROCS/////////////////////////////////
+
 /obj/machinery/disease2/power_change()
 	..()
 	update_icon()
@@ -287,13 +290,16 @@
 	if (prob(5))
 		breakdown()
 
-/obj/machinery/disease2/attack_paw(var/mob/living/carbon/alien/humanoid/user)
-	if(!istype(user))
-		return
-	if(stat & (BROKEN))
-		return
-	breakdown()
-	user.do_attack_animation(src, user)
-	visible_message("<span class='warning'>\The [user] slashes at \the [src]!</span>")
-	playsound(src, 'sound/weapons/slash.ogg', 100, 1)
-	add_hiddenprint(user)
+/obj/machinery/disease2/attack_paw(var/mob/user)
+	if(istype(user,/mob/living/carbon/alien/humanoid))
+		if(stat & (BROKEN))
+			return
+		breakdown()
+		user.do_attack_animation(src, user)
+		visible_message("<span class='warning'>\The [user] slashes at \the [src]!</span>")
+		playsound(src, 'sound/weapons/slash.ogg', 100, 1)
+		add_hiddenprint(user)
+	else if (!usr.dexterity_check())
+		to_chat(usr, "<span class='warning'>You don't have the dexterity to do this!</span>")
+	else
+		attack_hand(user)

--- a/code/modules/virus2/effect/stage_1.dm
+++ b/code/modules/virus2/effect/stage_1.dm
@@ -5,7 +5,7 @@
 	stage = 1
 	badness = EFFECT_DANGER_HELPFUL
 
-/datum/disease2/effect/invisible/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/invisible/activate(var/mob/living/mob)
 	return
 
 
@@ -16,7 +16,7 @@
 	stage = 1
 	badness = EFFECT_DANGER_ANNOYING
 
-/datum/disease2/effect/sneeze/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/sneeze/activate(var/mob/living/mob)
 	mob.say("*sneeze")
 	if (prob(50))
 		var/obj/effect/decal/cleanable/mucus/M= locate(/obj/effect/decal/cleanable/mucus) in get_turf(mob)
@@ -35,7 +35,7 @@
 	stage = 1
 	badness = EFFECT_DANGER_FLAVOR
 
-/datum/disease2/effect/gunck/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/gunck/activate(var/mob/living/mob)
 	to_chat(mob, "<span class = 'notice'> Mucous runs down the back of your throat.</span>")
 
 
@@ -46,7 +46,7 @@
 	stage = 1
 	badness = EFFECT_DANGER_FLAVOR
 
-/datum/disease2/effect/drool/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/drool/activate(var/mob/living/mob)
 	mob.say("*drool")
 
 
@@ -57,7 +57,7 @@
 	stage = 1
 	badness = EFFECT_DANGER_FLAVOR
 
-/datum/disease2/effect/twitch/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/twitch/activate(var/mob/living/mob)
 	mob.say("*twitch")
 
 
@@ -68,7 +68,7 @@
 	stage = 1
 	badness = EFFECT_DANGER_FLAVOR
 
-/datum/disease2/effect/headache/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/headache/activate(var/mob/living/mob)
 	to_chat(mob, "<span class = 'notice'>Your head hurts a bit</span>")
 
 
@@ -79,7 +79,7 @@
 	stage = 1
 	badness = EFFECT_DANGER_FLAVOR
 
-/datum/disease2/effect/itching/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/itching/activate(var/mob/living/mob)
 	var/mob/living/carbon/human/H = mob
 	if (istype(H) && H.species && H.species.anatomy_flags & NO_SKIN)
 		to_chat(mob, "<span class='warning'>Your bones itch!</span>")
@@ -94,7 +94,7 @@
 	stage = 1
 	badness = EFFECT_DANGER_FLAVOR
 
-/datum/disease2/effect/drained/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/drained/activate(var/mob/living/mob)
 	to_chat(mob, "<span class='warning'>You feel drained.</span>")
 
 
@@ -105,7 +105,7 @@
 	stage = 1
 	badness = EFFECT_DANGER_FLAVOR
 
-/datum/disease2/effect/eyewater/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/eyewater/activate(var/mob/living/mob)
 	to_chat(mob, "<SPAN CLASS='warning'>Your eyes sting and water!</SPAN>")
 
 
@@ -116,7 +116,7 @@
 	stage = 1
 	badness = EFFECT_DANGER_FLAVOR
 
-/datum/disease2/effect/wheeze/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/wheeze/activate(var/mob/living/mob)
 	mob.emote("me",1,"wheezes.")
 
 
@@ -127,7 +127,7 @@
 	stage = 1
 	badness = EFFECT_DANGER_HELPFUL
 
-/datum/disease2/effect/optimistic/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/optimistic/activate(var/mob/living/mob)
 	to_chat(mob, "<span class = 'notice'>You feel optimistic!</span>")
 	if (mob.reagents.get_reagent_amount(TRICORDRAZINE) < 1)
 		mob.reagents.add_reagent(TRICORDRAZINE, 1)
@@ -138,35 +138,44 @@
 	desc = "Makes the infected spin at random."
 	encyclopedia = "Although it impaires movement, it appears to favor healing in the infected's legs."
 	stage = 1
-	badness = EFFECT_DANGER_HINDRANCE
+	badness = EFFECT_DANGER_ANNOYING
+	max_multiplier = 4
 
-/datum/disease2/effect/spyndrome/activate(var/mob/living/carbon/mob)
-	if (mob.reagents.get_reagent_amount(GYRO) < 1)
-		mob.reagents.add_reagent(GYRO, 1)
+/datum/disease2/effect/spyndrome/activate(var/mob/living/mob)
+	if (mob.reagents.get_reagent_amount(GYRO) < 3*multiplier)
+		mob.reagents.add_reagent(GYRO, 3*multiplier)
 
 /datum/disease2/effect/bee_vomit
 	name = "Melisso-Emeto Syndrome"
 	desc = "Converts the lungs of the infected into a bee-hive, giving the infected a steady drip of honey in exchange of vomiting up a bee every so often."
-	encyclopedia = "The higher the symptom strength, the more honey can be accumulated before risking vomiting bees. While Honey is a great healing reagent, it is also high on nutrients. Expect to become fat quickly.."
+	encyclopedia = "The higher the symptom strength, the more honey can be accumulated. While Honey is a great healing reagent, it is also high on nutrients. Expect to become fat quickly.."
 	stage = 1
 	badness = EFFECT_DANGER_ANNOYING
 	max_multiplier = 10
 
-/datum/disease2/effect/bee_vomit/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/bee_vomit/activate(var/mob/living/mob)
 	if (mob.reagents.get_reagent_amount(HONEY) < 10+multiplier*2)
-		mob.reagents.add_reagent(HONEY, 1)
+		mob.reagents.add_reagent(HONEY, multiplier)
 
-	if((mob.reagents.get_reagent_amount(HONEY)>= 10+multiplier*2) && prob(10))
-		if(prob(25))
-			to_chat(mob, "<span class='warning'>You feel a buzzing in your throat</span>")
+	if((mob.reagents.get_reagent_amount(HONEY)> 10) && prob(multiplier*4))
+		to_chat(mob, "<span class='warning'>You feel a buzzing in your throat</span>")
+
+
 		spawn(5 SECONDS)
 			var/turf/simulated/T = get_turf(mob)
-			if(prob(30))
+			if(prob(50))
 				playsound(T, 'sound/effects/splat.ogg', 50, 1)
 				mob.visible_message("<span class='warning'>[mob] spits out a bee!</span>","<span class='danger'>You throw up a bee!</span>")
 				T.add_vomit_floor(mob, 1, 1, 1)
 			for(var/i = 0 to multiplier)
-				new/mob/living/simple_animal/bee(get_turf(mob))
+				var/bee_type = pick(
+					100;/mob/living/simple_animal/bee/adminSpawned,
+					10;/mob/living/simple_animal/bee/adminSpawnedQueen,
+					5;/mob/living/simple_animal/bee/angry,
+					1;/mob/living/simple_animal/bee/swarm,
+					1;/mob/living/simple_animal/bee/adminSpawned_hornet,
+					)
+				new bee_type(get_turf(mob))
 
 
 /datum/disease2/effect/radresist
@@ -176,13 +185,13 @@
 	stage = 1
 	chance = 10
 	max_chance = 40
-	max_count = 10
 	badness = EFFECT_DANGER_HELPFUL
+	max_multiplier = 5
 
-/datum/disease2/effect/radresist/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/radresist/activate(var/mob/living/mob)
 	if(mob.radiation && mob.reagents.get_reagent_amount(HYRONALIN) < 15)
-		mob.reagents.add_reagent(HYRONALIN, 1)
-		to_chat(mob, "<span class = 'notice'>Your body feels more resistant to radiation.</span>")
+		mob.reagents.add_reagent(HYRONALIN, multiplier)
+		to_chat(mob,"<span class='notice'>You feel your skin is thicker.</span>")
 
 
 /datum/disease2/effect/soreness
@@ -194,7 +203,7 @@
 	max_chance = 60
 	badness = EFFECT_DANGER_FLAVOR
 
-/datum/disease2/effect/soreness/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/soreness/activate(var/mob/living/mob)
 	to_chat(mob, "<span class='notice'>You feel a little sore.</span>")
 
 
@@ -207,7 +216,7 @@
 	max_chance = 25
 	badness = EFFECT_DANGER_FLAVOR
 
-/datum/disease2/effect/socialconfusion/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/socialconfusion/activate(var/mob/living/mob)
 	if(mob.isUnconscious() || mob.getBrainLoss() >= 10)
 		return 1
 
@@ -225,6 +234,7 @@
 								"Greetings, [other_mob_name].",
 								"Good day to you, [other_mob_name]",
 								"'Sup, [other_mob_name]?'",
+								"Bonsoir, [other_mob_name]?",
 								"What it do, [other_mob_name]?",
 								"What's good, [other_mob_name]?",
 								"Yo, [other_mob_name].",
@@ -237,6 +247,8 @@
 								"Goodbye, [other_mob_name].",
 								"Sayonara, [other_mob_name].",
 								"Peace out, [other_mob_name].",
+								"Ciao, [other_mob_name].",
+								"Au revoir, [other_mob_name].",
 								"Later, [other_mob_name]."
 								)
 	mob.say(pick(greets_farewells))

--- a/code/modules/virus2/effect/stage_2.dm
+++ b/code/modules/virus2/effect/stage_2.dm
@@ -5,7 +5,7 @@
 	stage = 2
 	badness = EFFECT_DANGER_ANNOYING
 
-/datum/disease2/effect/scream/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/scream/activate(var/mob/living/mob)
 	mob.audible_scream()
 
 
@@ -15,9 +15,11 @@
 	encyclopedia = "This may cause the infected to randomly fall asleep at times."
 	stage = 2
 	badness = EFFECT_DANGER_ANNOYING
+	multiplier = 5
+	max_multiplier = 10
 
-/datum/disease2/effect/drowsness/activate(var/mob/living/carbon/mob)
-	mob.drowsyness += 10
+/datum/disease2/effect/drowsness/activate(var/mob/living/mob)
+	mob.drowsyness += multiplier
 
 
 /datum/disease2/effect/sleepy
@@ -27,19 +29,22 @@
 	stage = 2
 	badness = EFFECT_DANGER_HINDRANCE
 
-/datum/disease2/effect/sleepy/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/sleepy/activate(var/mob/living/mob)
 	mob.say("*collapse")
 
 
 /datum/disease2/effect/blind
 	name = "Blackout Syndrome"
 	desc = "Inhibits the infected's ability to see."
-	encyclopedia = "Turning them blind for about 5 seconds."
+	encyclopedia = "Turning them blind for a few seconds."
 	stage = 2
 	badness = EFFECT_DANGER_HINDRANCE
+	multiplier = 4
+	max_multiplier = 10
+	max_chance = 8
 
-/datum/disease2/effect/blind/activate(var/mob/living/carbon/mob)
-	mob.eye_blind = max(mob.eye_blind, 4)
+/datum/disease2/effect/blind/activate(var/mob/living/mob)
+	mob.eye_blind = max(mob.eye_blind, multiplier)
 
 
 /datum/disease2/effect/cough//creates pathogenic clouds that may contain even non-airborne viruses.
@@ -48,8 +53,9 @@
 	encyclopedia = "This symptom enables even diseases that lack the Airborne vector to spread through the air."
 	stage = 2
 	badness = EFFECT_DANGER_ANNOYING
+	max_chance = 10
 
-/datum/disease2/effect/cough/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/cough/activate(var/mob/living/mob)
 	mob.say("*cough")
 
 	var/datum/gas_mixture/breath
@@ -99,20 +105,24 @@
 /datum/disease2/effect/hungry
 	name = "Appetiser Effect"
 	desc = "Starves the infected."
+	encyclopedia = "Symptom strength determines how quickly one becomes hungry."
 	stage = 2
 	badness = EFFECT_DANGER_ANNOYING
+	multiplier = 10
+	max_multiplier = 20
 
-/datum/disease2/effect/hungry/activate(var/mob/living/carbon/mob)
-	mob.nutrition = max(0, mob.nutrition - 200)
+/datum/disease2/effect/hungry/activate(var/mob/living/mob)
+	mob.nutrition = max(0, mob.nutrition - 20*multiplier)
 
 
 /datum/disease2/effect/fridge
 	name = "Refridgerator Syndrome"
 	desc = "Causes the infected to shiver at random."
+	encyclopedia = "No matter whether the room is cold or hot. This has no effect on their body temperature."
 	stage = 2
 	badness = EFFECT_DANGER_FLAVOR
 
-/datum/disease2/effect/fridge/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/fridge/activate(var/mob/living/mob)
 	mob.say("*shiver")
 
 
@@ -122,15 +132,23 @@
 	encyclopedia = "Nothing that a trip in front of a mirror can't fix."
 	stage = 2
 	badness = EFFECT_DANGER_FLAVOR
+	multiplier = 1
+	max_multiplier = 5
 
-/datum/disease2/effect/hair/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/hair/activate(var/mob/living/mob)
 	if(istype(mob, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = mob
-		if(H.species.name == "Human" && !(H.my_appearance.h_style == "Bald") && !(H.my_appearance.h_style == "Balding Hair"))
-			to_chat(H, "<span class='danger'>Your hair starts to fall out in clumps...</span>")
-			spawn(50)
-				H.my_appearance.h_style = "Balding Hair"
-				H.update_hair()
+		if(H.species.name == "Human" && H.my_appearance.h_style != "Bald")
+			if (H.my_appearance.h_style != "Balding Hair")
+				to_chat(H, "<span class='danger'>Your hair starts to fall out in clumps...</span>")
+				if (prob(multiplier*20))
+					H.my_appearance.h_style = "Balding Hair"
+					H.update_hair()
+			else
+				to_chat(H, "<span class='danger'>You have almost no hair left...</span>")
+				if (prob(multiplier*20))
+					H.my_appearance.h_style = "Bald"
+					H.update_hair()
 
 
 /datum/disease2/effect/stimulant
@@ -140,7 +158,7 @@
 	stage = 2
 	badness = EFFECT_DANGER_HELPFUL
 
-/datum/disease2/effect/stimulant/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/stimulant/activate(var/mob/living/mob)
 	to_chat(mob, "<span class='notice'>You feel a rush of energy inside you!</span>")
 	if (mob.reagents.get_reagent_amount(HYPERZINE) < 10)
 		mob.reagents.add_reagent(HYPERZINE, 4)
@@ -154,11 +172,13 @@
 	encyclopedia = "Without a cure, the infected's liver is sure to die, also effect strength increases the rate at which ethanol is synthesized."
 	stage = 2
 	badness = EFFECT_DANGER_HARMFUL
+	multiplier = 3
+	max_multiplier = 7
 
-/datum/disease2/effect/drunk/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/drunk/activate(var/mob/living/mob)
 	to_chat(mob, "<span class='notice'>You feel like you had one hell of a party!</span>")
 	if (mob.reagents.get_reagent_amount(ETHANOL) < 325)
-		mob.reagents.add_reagent(ETHANOL, 5*multiplier)
+		mob.reagents.add_reagent(ETHANOL, multiplier)
 
 
 /datum/disease2/effect/gaben
@@ -167,7 +187,7 @@
 	stage = 2
 	badness = EFFECT_DANGER_HINDRANCE
 
-/datum/disease2/effect/gaben/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/gaben/activate(var/mob/living/mob)
 	to_chat(mob, "<span class='notice'>Your clothing fits a little tighter!!</span>")
 	if (prob(10))
 		mob.reagents.add_reagent(NUTRIMENT, 1000)
@@ -180,7 +200,7 @@
 	stage = 2
 	badness = EFFECT_DANGER_FLAVOR
 
-/datum/disease2/effect/beard/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/beard/activate(var/mob/living/mob)
 	if(istype(mob, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = mob
 		if(H.species.name == "Human" && !(H.my_appearance.f_style == "Full Beard"))
@@ -197,7 +217,7 @@
 	stage = 2
 	badness = EFFECT_DANGER_ANNOYING
 
-/datum/disease2/effect/bloodynose/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/bloodynose/activate(var/mob/living/mob)
 	if (prob(30))
 		if (ishuman(mob))
 			var/mob/living/carbon/human/H = mob
@@ -217,7 +237,7 @@
 	stage = 2
 	badness = EFFECT_DANGER_ANNOYING
 
-/datum/disease2/effect/viralsputum/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/viralsputum/activate(var/mob/living/mob)
 	if (prob(30))
 		mob.say("*cough")
 		var/obj/effect/decal/cleanable/blood/viralsputum/D= locate(/obj/effect/decal/cleanable/blood/viralsputum) in get_turf(mob)
@@ -233,9 +253,11 @@
 	encyclopedia = "While useful at first glance, this also hinders the infected's capacity at hiding."
 	stage = 2
 	badness = EFFECT_DANGER_HELPFUL
+	multiplier = 4
+	max_multiplier = 10
 
-/datum/disease2/effect/lantern/activate(var/mob/living/carbon/mob)
-	mob.set_light(4)
+/datum/disease2/effect/lantern/activate(var/mob/living/mob)
+	mob.set_light(multiplier)
 	to_chat(mob, "<span class = 'notice'>You are glowing!</span>")
 
 
@@ -248,7 +270,7 @@
 	affect_voice = 1
 	badness = EFFECT_DANGER_HINDRANCE
 
-/datum/disease2/effect/hangman/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/hangman/activate(var/mob/living/mob)
 //Add filters to change a,A,e,E,i,I,o,O,u,U to _
 	if(!triggered)
 		to_chat(mob, "<span class='warning'>Y__ f__l _ b_t str_ng _p.</span>")
@@ -314,7 +336,7 @@
 	badness = EFFECT_DANGER_HINDRANCE
 	var/list/virus_opposite_word_list
 
-/datum/disease2/effect/opposite/activate(var/mob/living/carbon/mob,var/multiplier)
+/datum/disease2/effect/opposite/activate(var/mob/living/mob,var/multiplier)
 	to_chat(mob, "<span class='warning'>You feel completely fine.</span>")
 	affect_voice_active = 1
 	if(!virus_opposite_word_list)
@@ -353,7 +375,7 @@
 
 	speech.message = message
 
-/datum/disease2/effect/opposite/deactivate(var/mob/living/carbon/mob)
+/datum/disease2/effect/opposite/deactivate(var/mob/living/mob)
 	to_chat(mob, "<span class='warning'>You feel terrible.</span>")
 	affect_voice_active = 0
 	..()
@@ -367,8 +389,10 @@
 	max_count = 1
 	badness = EFFECT_DANGER_HINDRANCE
 	var/skip = FALSE
+	multiplier = 4
+	max_multiplier = 8
 
-/datum/disease2/effect/spiky_skin/activate(var/mob/living/carbon/mob,var/multiplier)
+/datum/disease2/effect/spiky_skin/activate(var/mob/living/mob,var/multiplier)
 	if(ishuman(mob))
 		var/mob/living/carbon/human/H = mob
 		if(H.species && (H.species.anatomy_flags & NO_SKIN))	//Can't have spiky skin if you don't have skin at all.
@@ -376,12 +400,12 @@
 			return
 	to_chat(mob, "<span class='warning'>Your skin feels a little prickly.</span>")
 
-/datum/disease2/effect/spiky_skin/deactivate(var/mob/living/carbon/mob)
+/datum/disease2/effect/spiky_skin/deactivate(var/mob/living/mob)
 	if(!skip)
 		to_chat(mob, "<span class='notice'>Your skin feels nice and smooth again!</span>")
 	..()
 
-/datum/disease2/effect/spiky_skin/on_touch(var/mob/living/carbon/mob, var/toucher, var/touched, var/touch_type)
+/datum/disease2/effect/spiky_skin/on_touch(var/mob/living/mob, var/toucher, var/touched, var/touch_type)
 	if(!count || skip)
 		return
 	if(!istype(toucher, /mob) || !istype(touched, /mob))
@@ -406,25 +430,25 @@
 	if(toucher == mob)
 		if(E)
 			to_chat(mob, "<span class='warning'>As you bump into \the [touched], your spines dig into \his [E.display_name]!</span>")
-			E.take_damage(5)
+			E.take_damage(multiplier)
 		else
 			to_chat(mob, "<span class='warning'>As you bump into \the [touched], your spines dig into \him!</span>")
 			var/mob/living/L = touched
 			if(istype(L) && !istype(L, /mob/living/silicon))
-				L.apply_damage(5)
+				L.apply_damage(multiplier)
 		var/mob/M = touched
 		add_attacklogs(mob, M, "damaged with keratin spikes",addition = "([mob] bumped into [M])", admin_warn = FALSE)
 	else
 		if(E)
 			to_chat(mob, "<span class='warning'>As \the [toucher] [touch_type == BUMP ? "bumps into" : "touches"] you, your spines dig into \his [E.display_name]!</span>")
 			to_chat(toucher, "<span class='danger'>As you [touch_type == BUMP ? "bump into" : "touch"] \the [mob], \his spines dig into your [E.display_name]!</span>")
-			E.take_damage(5)
+			E.take_damage(multiplier)
 		else
 			to_chat(mob, "<span class='warning'>As \the [toucher] [touch_type == BUMP ? "bumps into" : "touches"] you, your spines dig into \him!</span>")
 			to_chat(toucher, "<span class='danger'>As you [touch_type == BUMP ? "bump into" : "touch"] \the [mob], \his spines dig into you!</span>")
 			var/mob/living/L = toucher
 			if(istype(L) && !istype(L, /mob/living/silicon))
-				L.apply_damage(5)
+				L.apply_damage(multiplier)
 		var/mob/M = touched
 		add_attacklogs(mob, M, "damaged with keratin spikes",addition = "([M] bumped into [mob])", admin_warn = FALSE)
 
@@ -435,10 +459,11 @@
 	stage = 2
 	badness = EFFECT_DANGER_HINDRANCE
 
-/datum/disease2/effect/vegan/activate(var/mob/living/carbon/mob)
-	mob.dna.check_integrity()
-	mob.dna.SetSEState(VEGANBLOCK,1)
-	domutcheck(mob, null)
+/datum/disease2/effect/vegan/activate(var/mob/living/mob)
+	if (mob.dna)
+		mob.dna.check_integrity()
+		mob.dna.SetSEState(VEGANBLOCK,1)
+		domutcheck(mob, null)
 
 /datum/disease2/effect/famine
 	name = "Faminous Potation"
@@ -448,7 +473,7 @@
 	max_multiplier = 3
 	badness = EFFECT_DANGER_HINDRANCE
 
-/datum/disease2/effect/famine/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/famine/activate(var/mob/living/mob)
 	if(ishuman(mob))
 		var/mob/living/carbon/human/H = mob
 		if(H.dna)
@@ -491,14 +516,14 @@
 	var/activated = FALSE
 	badness = EFFECT_DANGER_HINDRANCE
 
-/datum/disease2/effect/calorieburn/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/calorieburn/activate(var/mob/living/mob)
 	if(!activated)
 		if(ishuman(mob))
 			var/mob/living/carbon/human/H
 			H.calorie_burn_rate *= multiplier
 		activated = TRUE
 
-/datum/disease2/effect/calorieburn/deactivate(var/mob/living/carbon/mob)
+/datum/disease2/effect/calorieburn/deactivate(var/mob/living/mob)
 	if(activated)
 		if(ishuman(mob))
 			var/mob/living/carbon/human/H
@@ -514,14 +539,14 @@
 	badness = EFFECT_DANGER_HINDRANCE
 	var/activated = FALSE
 
-/datum/disease2/effect/calorieconserve/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/calorieconserve/activate(var/mob/living/mob)
 	if(!activated)
 		if(ishuman(mob))
 			var/mob/living/carbon/human/H
 			H.calorie_burn_rate /= multiplier
 		activated = TRUE
 
-/datum/disease2/effect/calorieconserve/deactivate(var/mob/living/carbon/mob)
+/datum/disease2/effect/calorieconserve/deactivate(var/mob/living/mob)
 	if(activated)
 		if(ishuman(mob))
 			var/mob/living/carbon/human/H
@@ -536,7 +561,7 @@
 	affect_voice = 1
 	badness = EFFECT_DANGER_ANNOYING
 
-/datum/disease2/effect/yelling/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/yelling/activate(var/mob/living/mob)
 	if(!triggered)
 		to_chat(mob, "<span class='notice'>You feel like what you have to say is more important.</span>")
 		affect_voice_active = 1

--- a/code/modules/virus2/effect/stage_3.dm
+++ b/code/modules/virus2/effect/stage_3.dm
@@ -5,7 +5,7 @@
 	max_multiplier = 3
 	badness = EFFECT_DANGER_HARMFUL
 
-/datum/disease2/effect/toxins/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/toxins/activate(var/mob/living/mob)
 	mob.adjustToxLoss((2*multiplier))
 
 
@@ -16,7 +16,7 @@
 	max_multiplier = 3
 	badness = EFFECT_DANGER_HINDRANCE
 
-/datum/disease2/effect/shakey/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/shakey/activate(var/mob/living/mob)
 	shake_camera(mob,5*multiplier)
 
 
@@ -26,7 +26,7 @@
 	stage = 3
 	badness = EFFECT_DANGER_HELPFUL
 
-/datum/disease2/effect/telepathic/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/telepathic/activate(var/mob/living/mob)
 	mob.dna.check_integrity()
 	mob.dna.SetSEState(REMOTETALKBLOCK,1)
 	domutcheck(mob, null)
@@ -37,7 +37,7 @@
 	stage = 3
 	badness = EFFECT_DANGER_HARMFUL
 
-/datum/disease2/effect/mind/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/mind/activate(var/mob/living/mob)
 	if(istype(mob, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = mob
 		var/datum/organ/internal/brain/B = H.internal_organs_by_name["brain"]
@@ -53,7 +53,7 @@
 	stage = 3
 	badness = EFFECT_DANGER_HINDRANCE
 
-/datum/disease2/effect/hallucinations/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/hallucinations/activate(var/mob/living/mob)
 	mob.hallucination += 25
 
 
@@ -63,7 +63,7 @@
 	stage = 3
 	badness = EFFECT_DANGER_HINDRANCE
 
-/datum/disease2/effect/deaf/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/deaf/activate(var/mob/living/mob)
 	mob.ear_deaf = 5
 
 
@@ -73,7 +73,7 @@
 	stage = 3
 	badness = EFFECT_DANGER_FLAVOR
 
-/datum/disease2/effect/giggle/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/giggle/activate(var/mob/living/mob)
 	mob.say("*giggle")
 
 
@@ -83,7 +83,7 @@
 	stage = 3
 	badness = EFFECT_DANGER_ANNOYING
 
-/datum/disease2/effect/chickenpox/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/chickenpox/activate(var/mob/living/mob)
 	if (prob(30))
 		mob.say(pick("BAWWWK!", "BAAAWWK!", "CLUCK!", "CLUUUCK!", "BAAAAWWWK!"))
 	if (prob(15))
@@ -98,7 +98,7 @@
 	stage = 3
 	badness = EFFECT_DANGER_HINDRANCE
 
-/datum/disease2/effect/confusion/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/confusion/activate(var/mob/living/mob)
 	to_chat(mob, "<span class='notice'>You have trouble telling right and left apart all of a sudden.</span>")
 	mob.confused += 10
 
@@ -109,7 +109,7 @@
 	stage = 3
 	badness = EFFECT_DANGER_DEADLY
 
-/datum/disease2/effect/mutation/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/mutation/activate(var/mob/living/mob)
 	mob.apply_damage(2, CLONE)
 
 
@@ -119,7 +119,7 @@
 	stage = 3
 	badness = EFFECT_DANGER_FLAVOR
 
-/datum/disease2/effect/groan/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/groan/activate(var/mob/living/mob)
 	mob.say("*groan")
 
 
@@ -129,7 +129,7 @@
 	stage = 3
 	badness = EFFECT_DANGER_HINDRANCE
 
-/datum/disease2/effect/sweat/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/sweat/activate(var/mob/living/mob)
 	if(prob(30))
 		mob.emote("me",1,"is sweating profusely!")
 
@@ -144,7 +144,7 @@
 	stage = 3
 	badness = EFFECT_DANGER_HINDRANCE
 
-/datum/disease2/effect/elvis/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/elvis/activate(var/mob/living/mob)
 	if(!istype(mob))
 		return
 
@@ -174,7 +174,7 @@
 				H.my_appearance.f_style = "Elvis Sideburns"
 				H.update_hair()
 
-/datum/disease2/effect/elvis/deactivate(var/mob/living/carbon/mob)
+/datum/disease2/effect/elvis/deactivate(var/mob/living/mob)
 	if(ishuman(mob))
 		var/mob/living/carbon/human/dude = mob
 		if(istype(dude.glasses, /obj/item/clothing/glasses/sunglasses/virus))
@@ -188,7 +188,7 @@
 	stage = 3
 	badness = EFFECT_DANGER_HINDRANCE
 
-/datum/disease2/effect/pthroat/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/pthroat/activate(var/mob/living/mob)
 	//
 	var/obj/item/clothing/mask/gas/clown_hat/virus/virusclown_hat = new /obj/item/clothing/mask/gas/clown_hat/virus
 	if(mob.wear_mask && !istype(mob.wear_mask, /obj/item/clothing/mask/gas/clown_hat/virus))
@@ -208,7 +208,7 @@ var/list/compatible_mobs = list(/mob/living/carbon/human, /mob/living/carbon/mon
 	stage = 3
 	badness = EFFECT_DANGER_HINDRANCE
 
-/datum/disease2/effect/horsethroat/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/horsethroat/activate(var/mob/living/mob)
 
 
 	if(!(mob.type in compatible_mobs))
@@ -233,13 +233,20 @@ var/list/compatible_mobs = list(/mob/living/carbon/human, /mob/living/carbon/mon
 	affect_voice = 1
 	max_multiplier = 4
 	badness = EFFECT_DANGER_ANNOYING
+	var/old_r = 0
+	var/old_g = 0
+	var/old_b = 0
 
-/datum/disease2/effect/anime_hair/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/anime_hair/activate(var/mob/living/mob)
 	if(ishuman(mob))
 		var/mob/living/carbon/human/affected = mob
 		if(!triggered)
 			var/list/hair_colors = list("pink","red","green","blue","purple")
 			var/hair_color = pick(hair_colors)
+
+			old_r = affected.my_appearance.b_hair
+			old_g = affected.my_appearance.g_hair
+			old_b = affected.my_appearance.r_hair
 
 			switch(hair_color)
 				if("pink")
@@ -315,13 +322,18 @@ var/list/compatible_mobs = list(/mob/living/carbon/human, /mob/living/carbon/mon
 					affected.put_in_hands(fake_katana)
 				given_katana = 1
 
-datum/disease2/effect/anime_hair/deactivate(var/mob/living/carbon/mob)
+datum/disease2/effect/anime_hair/deactivate(var/mob/living/mob)
 	to_chat(mob, "<span class = 'notice'>You no longer feel quite like the main character. </span>")
-	var/mob/living/carbon/human/affected = mob
-	if(affected.shoes && istype(affected.shoes, /obj/item/clothing/shoes/kneesocks))
-		affected.shoes.canremove = 1
-	if(affected.w_uniform && istype(affected.w_uniform, /obj/item/clothing/under/schoolgirl))
-		affected.w_uniform.canremove = 1
+	if (ishuman(mob))
+		var/mob/living/carbon/human/affected = mob
+		if(affected.shoes && istype(affected.shoes, /obj/item/clothing/shoes/kneesocks))
+			affected.shoes.canremove = 1
+		if(affected.w_uniform && istype(affected.w_uniform, /obj/item/clothing/under/schoolgirl))
+			affected.w_uniform.canremove = 1
+
+		affected.my_appearance.b_hair = old_r
+		affected.my_appearance.g_hair = old_g
+		affected.my_appearance.r_hair = old_b
 
 /datum/disease2/effect/anime_hair/affect_mob_voice(var/datum/speech/speech)
 	var/message=speech.message
@@ -340,7 +352,7 @@ datum/disease2/effect/anime_hair/deactivate(var/mob/living/carbon/mob)
 	badness = EFFECT_DANGER_HARMFUL
 	var/triggered
 
-/datum/disease2/effect/lubefoot/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/lubefoot/activate(var/mob/living/mob)
 	if(ishuman(mob))
 		var/mob/living/carbon/human/affected = mob
 		if(multiplier > 1.5 && !triggered)
@@ -364,7 +376,7 @@ datum/disease2/effect/anime_hair/deactivate(var/mob/living/carbon/mob)
 	if(prob(15))
 		to_chat(mob, "Your feet feel slippy!")
 
-datum/disease2/effect/lubefoot/deactivate(var/mob/living/carbon/mob)
+datum/disease2/effect/lubefoot/deactivate(var/mob/living/mob)
 	if(ishuman(mob))
 		var/mob/living/carbon/human/affected = mob
 
@@ -383,7 +395,7 @@ datum/disease2/effect/lubefoot/deactivate(var/mob/living/carbon/mob)
 	badness = EFFECT_DANGER_HARMFUL
 	var/skip = FALSE
 
-/datum/disease2/effect/butterfly_skin/activate(var/mob/living/carbon/mob,var/multiplier)
+/datum/disease2/effect/butterfly_skin/activate(var/mob/living/mob)
 	if(ishuman(mob))
 		var/mob/living/carbon/human/H = mob
 		if(H.species && (H.species.anatomy_flags & NO_SKIN))	//Can't have fragile skin if you don't have skin at all.
@@ -391,12 +403,12 @@ datum/disease2/effect/lubefoot/deactivate(var/mob/living/carbon/mob)
 			return
 	to_chat(mob, "<span class='warning'>Your skin feels a little fragile.</span>")
 
-/datum/disease2/effect/butterfly_skin/deactivate(var/mob/living/carbon/mob)
+/datum/disease2/effect/butterfly_skin/deactivate(var/mob/living/mob)
 	if(!skip)
 		to_chat(mob, "<span class='notice'>Your skin feels nice and durable again!</span>")
 	..()
 
-/datum/disease2/effect/butterfly_skin/on_touch(var/mob/living/carbon/mob, var/toucher, var/touched, var/touch_type)
+/datum/disease2/effect/butterfly_skin/on_touch(var/mob/living/mob, var/toucher, var/touched, var/touch_type)
 	if(count && !skip)
 		var/datum/organ/external/E
 		if(ishuman(mob))
@@ -428,7 +440,7 @@ datum/disease2/effect/lubefoot/deactivate(var/mob/living/carbon/mob)
 	badness = EFFECT_DANGER_HELPFUL
 	var/skip = FALSE
 
-/datum/disease2/effect/thick_blood/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/thick_blood/activate(var/mob/living/mob)
 	if(skip)
 		return
 	var/mob/living/carbon/human/H = mob
@@ -451,7 +463,7 @@ datum/disease2/effect/lubefoot/deactivate(var/mob/living/carbon/mob)
 	stage = 3
 	badness = EFFECT_DANGER_FLAVOR
 
-/datum/disease2/effect/teratoma/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/teratoma/activate(var/mob/living/mob)
 	var/organ_type = pick(existing_typesof(/obj/item/organ/internal) + /obj/item/stack/teeth)
 	var/obj/item/spawned_organ = new organ_type(get_turf(mob))
 	mob.visible_message("<span class='warning'>\A [spawned_organ.name] is extruded from \the [mob]'s body and falls to the ground!</span>","<span class='warning'>\A [spawned_organ.name] is extruded from your body and falls to the ground!</span>")
@@ -464,7 +476,7 @@ datum/disease2/effect/lubefoot/deactivate(var/mob/living/carbon/mob)
 	badness = EFFECT_DANGER_HELPFUL
 	var/activated = FALSE
 
-/datum/disease2/effect/multiarm/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/multiarm/activate(var/mob/living/mob)
 	if(activated)
 		return
 	var/hand_amount = round(multiplier)
@@ -473,7 +485,7 @@ datum/disease2/effect/lubefoot/deactivate(var/mob/living/carbon/mob)
 	blood_splatter(mob.loc,mob,TRUE)
 	activated = TRUE
 
-/datum/disease2/effect/multiarm/deactivate(var/mob/living/carbon/mob)
+/datum/disease2/effect/multiarm/deactivate(var/mob/living/mob)
 	if(!activated)
 		return
 	var/hand_amount = round(multiplier)
@@ -504,7 +516,7 @@ datum/disease2/effect/lubefoot/deactivate(var/mob/living/carbon/mob)
 	badness = EFFECT_DANGER_HELPFUL
 	var/night_vision_strength = 0
 
-/datum/disease2/effect/catvision/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/catvision/activate(var/mob/living/mob)
 	night_vision_strength = mob.see_in_dark
 
 	if (mob.see_in_dark_override < 9)

--- a/code/modules/virus2/effect/stage_4.dm
+++ b/code/modules/virus2/effect/stage_4.dm
@@ -6,7 +6,7 @@
 	chance = 10
 	max_chance = 25
 
-/datum/disease2/effect/spaceadapt/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/spaceadapt/activate(var/mob/living/mob)
 	var/datum/gas_mixture/environment = mob.loc.return_air()
 	var/pressure = environment.return_pressure()
 	var/adjusted_pressure = mob.calculate_affecting_pressure(pressure)
@@ -32,7 +32,7 @@
 	stage = 4
 	badness = EFFECT_DANGER_HARMFUL
 
-/datum/disease2/effect/minttoxin/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/minttoxin/activate(var/mob/living/mob)
 	if(istype(mob) && mob.reagents.get_reagent_amount(MINTTOXIN) < 5)
 		to_chat(mob, "<span class='notice'>You feel a minty freshness</span>")
 		mob.reagents.add_reagent(MINTTOXIN, 5)
@@ -41,11 +41,18 @@
 /datum/disease2/effect/gibbingtons
 	name = "Gibbingtons Syndrome"
 	desc = "Causes the infected to spontaneously explode in a shower of gore."
+	encyclopedia = "The individual will feel more and more bloated as the limits of his body are reached."
 	stage = 4
 	badness = EFFECT_DANGER_DEADLY
+	var/gibchance = 20
 
-/datum/disease2/effect/gibbingtons/activate(var/mob/living/carbon/mob)
-	mob.gib()
+/datum/disease2/effect/gibbingtons/activate(var/mob/living/mob)
+	if (prob(gibchance))
+		to_chat(mob, "<span class = 'danger'>You explode in a shower of gore.</span>")
+		mob.gib()
+	else
+		to_chat(mob, "<span class = 'danger'>You get a foreboding feeling as your limbs and chest feel more and more bloated.</span>")
+		gibchance += rand(9,15)
 
 
 /datum/disease2/effect/radian
@@ -55,7 +62,7 @@
 	max_multiplier = 3
 	badness = EFFECT_DANGER_DEADLY
 
-/datum/disease2/effect/radian/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/radian/activate(var/mob/living/mob)
 	mob.radiation += (2*multiplier)
 
 
@@ -65,7 +72,7 @@
 	stage = 4
 	badness = EFFECT_DANGER_HINDRANCE
 
-/datum/disease2/effect/deaf/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/deaf/activate(var/mob/living/mob)
 	mob.ear_deaf += 20
 
 
@@ -74,11 +81,23 @@
 	desc = "Causes the infected to rapidly devolve to a lower form of life."
 	stage = 4
 	badness = EFFECT_DANGER_DEADLY
+	var/transformed = FALSE
 
-/datum/disease2/effect/monkey/activate(var/mob/living/carbon/mob)
-	if(istype(mob,/mob/living/carbon/human))
-		var/mob/living/carbon/human/h = mob
-		h.monkeyize()
+/datum/disease2/effect/monkey/getcopy(var/datum/disease2/disease/disease)
+	var/datum/disease2/effect/monkey/new_e = ..(disease)
+	new_e.transformed = transformed
+	return new_e
+
+/datum/disease2/effect/monkey/activate(var/mob/living/carbon/human/mob)
+	if(istype(mob))
+		transformed = TRUE
+		var/datum/dna/gene/gene = dna_genes[/datum/dna/gene/monkey]
+		gene.activate(mob, null, null)
+
+/datum/disease2/effect/monkey/deactivate(var/mob/living/carbon/monkey/mob)
+	if(istype(mob) && transformed)
+		var/datum/dna/gene/gene = dna_genes[/datum/dna/gene/monkey]
+		gene.deactivate(mob, null, null)
 
 
 /datum/disease2/effect/catbeast
@@ -86,12 +105,21 @@
 	desc = "A previously experimental syndrome that found its way into the wild. Causes the infected to mutate into a Tajaran."
 	stage = 4
 	badness = EFFECT_DANGER_DEADLY
+	var/old_species = "Human"
 
-/datum/disease2/effect/catbeast/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/catbeast/activate(var/mob/living/mob)
 	if(istype(mob,/mob/living/carbon/human))
 		var/mob/living/carbon/human/h = mob
-		if(h.species.name != "Tajaran")
+		old_species = h.species.name
+		if(old_species != "Tajaran")
 			if(h.set_species("Tajaran"))
+				h.regenerate_icons()
+
+/datum/disease2/effect/catbeast/deactivate(var/mob/living/mob)
+	if(istype(mob,/mob/living/carbon/human))
+		var/mob/living/carbon/human/h = mob
+		if(h.species.name == "Tajaran" && old_species != "Tajaran")
+			if(h.set_species(old_species))
 				h.regenerate_icons()
 
 /datum/disease2/effect/zombie
@@ -100,7 +128,7 @@
 	stage = 4
 	badness = EFFECT_DANGER_ANNOYING
 
-/datum/disease2/effect/zombie/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/zombie/activate(var/mob/living/mob)
 	if(ishuman(mob))
 		var/mob/living/carbon/human/h = mob
 		h.become_zombie_after_death = 1
@@ -111,12 +139,21 @@
 	desc = "A previously experimental syndrome that found its way into the wild. Causes the infected to mutate into a Vox."
 	stage = 4
 	badness = EFFECT_DANGER_DEADLY
+	var/old_species = "Human"
 
-/datum/disease2/effect/voxpox/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/voxpox/activate(var/mob/living/mob)
 	if(istype(mob,/mob/living/carbon/human))
 		var/mob/living/carbon/human/h = mob
-		if(h.species.name != "Vox")
+		old_species = h.species.name
+		if(old_species != "Vox")
 			if(h.set_species("Vox"))
+				h.regenerate_icons()
+
+/datum/disease2/effect/voxpox/deactivate(var/mob/living/mob)
+	if(istype(mob,/mob/living/carbon/human))
+		var/mob/living/carbon/human/h = mob
+		if(h.species.name == "Vox" && old_species != "Vox")
+			if(h.set_species(old_species))
 				h.regenerate_icons()
 
 
@@ -126,7 +163,7 @@
 	stage = 4
 	badness = EFFECT_DANGER_DEADLY
 
-/datum/disease2/effect/suicide/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/suicide/activate(var/mob/living/mob)
 
 	if(mob.stat != CONSCIOUS || !mob.canmove || mob.restrained()) //Try as we might, we still can't snap our neck when we are KO or restrained, even if forced.
 		return
@@ -138,9 +175,11 @@
 	desc = "A more advanced version of Hyperacidity, causing the infected to rapidly generate toxins."
 	stage = 4
 	badness = EFFECT_DANGER_DEADLY
+	multiplier = 3
+	max_multiplier = 5
 
-/datum/disease2/effect/killertoxins/activate(var/mob/living/carbon/mob)
-	mob.adjustToxLoss(15*multiplier)
+/datum/disease2/effect/killertoxins/activate(var/mob/living/mob)
+	mob.adjustToxLoss(5*multiplier)
 
 
 /datum/disease2/effect/dna
@@ -149,7 +188,7 @@
 	stage = 4
 	badness = EFFECT_DANGER_DEADLY
 
-/datum/disease2/effect/dna/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/dna/activate(var/mob/living/mob)
 	mob.bodytemperature = max(mob.bodytemperature, 350)
 	scramble(0,mob,10)
 	mob.apply_damage(10, CLONE)
@@ -161,7 +200,7 @@
 	stage = 4
 	badness = EFFECT_DANGER_DEADLY
 
-/datum/disease2/effect/organs/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/organs/activate(var/mob/living/mob)
 	if(istype(mob, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = mob
 		var/organ = pick(list(LIMB_RIGHT_ARM,LIMB_LEFT_ARM,LIMB_RIGHT_LEG,LIMB_RIGHT_LEG))
@@ -176,7 +215,7 @@
 			multiplier = 1
 		H.adjustToxLoss(15*multiplier)
 
-/datum/disease2/effect/organs/deactivate(var/mob/living/carbon/mob)
+/datum/disease2/effect/organs/deactivate(var/mob/living/mob)
 	if(istype(mob, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = mob
 		for (var/datum/organ/external/E in H.organs)
@@ -192,7 +231,7 @@
 	stage = 4
 	badness = EFFECT_DANGER_HELPFUL
 
-/datum/disease2/effect/immortal/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/immortal/activate(var/mob/living/mob)
 	if(istype(mob, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = mob
 		for (var/datum/organ/external/E in H.organs)
@@ -202,7 +241,7 @@
 	var/heal_amt = -5*multiplier
 	mob.apply_damages(heal_amt,heal_amt,heal_amt,heal_amt)
 
-/datum/disease2/effect/immortal/deactivate(var/mob/living/carbon/mob)
+/datum/disease2/effect/immortal/deactivate(var/mob/living/mob)
 	if(istype(mob, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = mob
 		to_chat(H, "<span class='warning'>You suddenly feel hurt and old...</span>")
@@ -217,13 +256,13 @@
 	stage = 4
 	badness = EFFECT_DANGER_HINDRANCE
 
-/datum/disease2/effect/bones/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/bones/activate(var/mob/living/mob)
 	if(istype(mob, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = mob
 		for (var/datum/organ/external/E in H.organs)
 			E.min_broken_damage = max(5, E.min_broken_damage - 30)
 
-/datum/disease2/effect/bones/deactivate(var/mob/living/carbon/mob)
+/datum/disease2/effect/bones/deactivate(var/mob/living/mob)
 	if(istype(mob, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = mob
 		for (var/datum/organ/external/E in H.organs)
@@ -234,9 +273,9 @@
 	name = "Spontaneous Cellular Collapse"
 	desc = "Converts the infected's internal toxin treatment to synthesize Polyacid, as well as cause the infected's skin to break, and their bones to fracture."
 	stage = 4
-	badness = EFFECT_DANGER_HARMFUL
+	badness = EFFECT_DANGER_DEADLY
 
-/datum/disease2/effect/scc/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/scc/activate(var/mob/living/mob)
 	//
 	if(!ishuman(mob))
 		return 0
@@ -258,7 +297,7 @@
 	stage = 4
 	badness = EFFECT_DANGER_DEADLY
 
-/datum/disease2/effect/necrosis/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/necrosis/activate(var/mob/living/mob)
 
 	if(ishuman(mob)) //Only works on humans properly since it needs to do organ work
 		var/mob/living/carbon/human/H = mob
@@ -321,7 +360,7 @@
 	stage = 4
 	badness = EFFECT_DANGER_HELPFUL
 
-/datum/disease2/effect/fizzle/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/fizzle/activate(var/mob/living/mob)
 	mob.emote("me",1,pick("sniffles...", "clears their throat..."))
 
 
@@ -331,7 +370,7 @@
 	stage = 4
 	badness = EFFECT_DANGER_HINDRANCE
 
-/datum/disease2/effect/delightful/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/delightful/activate(var/mob/living/mob)
 	to_chat(mob, "<span class = 'notice'>You feel delightful!</span>")
 	if (mob.reagents.get_reagent_amount(DOCTORSDELIGHT) < 1)
 		mob.reagents.add_reagent(DOCTORSDELIGHT, 1)
@@ -345,7 +384,7 @@
 	var/spawn_type=/mob/living/simple_animal/hostile/giant_spider/spiderling
 	var/spawn_name="spiderling"
 
-/datum/disease2/effect/spawn/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/spawn/activate(var/mob/living/mob)
 	playsound(mob.loc, 'sound/effects/splat.ogg', 50, 1)
 
 	new spawn_type(get_turf(mob))
@@ -366,7 +405,7 @@
 	stage = 4
 	badness = EFFECT_DANGER_HELPFUL
 
-/datum/disease2/effect/orbweapon/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/orbweapon/activate(var/mob/living/mob)
 	var/obj/item/toy/snappop/virus/virus = new /obj/item/toy/snappop/virus
 	virus.virus2 = virus_copylist(mob.virus2)
 	mob.put_in_hands(virus)
@@ -378,7 +417,7 @@
 	stage = 4
 	badness = EFFECT_DANGER_HARMFUL
 
-/datum/disease2/effect/plasma/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/plasma/activate(var/mob/living/mob)
 	//var/src = mob
 	var/hack = mob.loc
 	var/turf/simulated/T = get_turf(hack)
@@ -406,7 +445,7 @@
 
 	var/list/original_languages = list()
 
-/datum/disease2/effect/babel/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/babel/activate(var/mob/living/mob)
 	if(mob.languages.len <= 1)
 		to_chat(mob, "Your knowledge of language is just fine.")
 		return
@@ -427,7 +466,7 @@
 
 	to_chat(mob, "You can't seem to remember any language but [picked_lang]. Odd.")
 
-/datum/disease2/effect/babel/deactivate(var/mob/living/carbon/mob)
+/datum/disease2/effect/babel/deactivate(var/mob/living/mob)
 	if(original_languages.len)
 		for(var/forgotten in original_languages)
 			mob.add_language(forgotten)
@@ -443,7 +482,7 @@
 	max_chance = 25
 	max_multiplier = 4
 
-/datum/disease2/effect/gregarious/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/gregarious/activate(var/mob/living/mob)
 	var/others_count = 0
 	for(var/mob/living/carbon/m in oview(5, mob))
 		if (airborne_can_reach(mob.loc, m.loc, 9)) // Apparently mobs physically block airborne viruses
@@ -476,7 +515,7 @@
 	var/therm_loss_mod_subtracted = 0
 	var/cal_heat_mod_added = 0
 
-/datum/disease2/effect/thick_skin/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/thick_skin/activate(var/mob/living/mob)
 	if(ishuman(mob))
 		var/mob/living/carbon/human/H = mob
 		if(H.species && (H.species.anatomy_flags & NO_SKIN))	//Can't have thick skin if you don't have skin at all.
@@ -554,7 +593,7 @@
 	mob.cap_calorie_burning_bodytemp = FALSE
 	multiplier = min(multiplier + 10, max_multiplier)
 
-/datum/disease2/effect/thick_skin/deactivate(var/mob/living/carbon/mob)
+/datum/disease2/effect/thick_skin/deactivate(var/mob/living/mob)
 	if(!skip)
 		mob.brute_damage_modifier += brute_mod_subtracted
 		mob.thermal_loss_multiplier += therm_loss_mod_subtracted
@@ -574,7 +613,7 @@
 	badness = EFFECT_DANGER_DEADLY
 	max_count = 1
 
-/datum/disease2/effect/heart_attack/activate(var/mob/living/carbon/mob)
+/datum/disease2/effect/heart_attack/activate(var/mob/living/mob)
 	if(ishuman(mob))
 		var/mob/living/carbon/human/H = mob
 		if(H.get_heart())

--- a/code/modules/virus2/items_devices.dm
+++ b/code/modules/virus2/items_devices.dm
@@ -83,8 +83,10 @@
 	popup.set_content(info)
 	popup.open()
 
-/obj/item/device/antibody_scanner/afterattack(var/atom/A, var/mob/user)
-	if (A.Adjacent(user) && isitem(A))
+/obj/item/device/antibody_scanner/preattack(var/atom/A, var/mob/user, proximity_flag)
+	if(proximity_flag != 1)
+		return
+	if (isitem(A))
 		var/obj/item/I = A
 		playsound(user, 'sound/items/detscan.ogg', 50, 1)
 		var/span = "warning"


### PR DESCRIPTION
* you can now use the immunity scanner on containers/labcoats
* tons of effects were tweaked, namely to have modular strength and occurence, and take those into account in their effects.
* Monkeyism, Vox Pox, and Kingston syndrome will automatically turn their infected back into their original form/species when the disease is cured.
* Kitchen's gibber produced meat properly carries diseases.
* Mice properly get diseases from eating infected food.
* Anime hair symptom gives you back your original hair color when cured.

With that taken care of, all that's left is doing a bunch of map changes.

But I'll probably do it when I get back home in 3 days. Next PR will have the map changes and all of the viro branch, directed at Bleeding-Edge. it's gonna be pretty massive.