### PR TITLE
Cultists need to sacrifice implanted people

### DIFF
--- a/code/datums/gamemode/objectives/bloodcult.dm
+++ b/code/datums/gamemode/objectives/bloodcult.dm
@@ -90,6 +90,7 @@
 	var/list/possible_targets = list()
 	var/list/backup_targets = list()
 	for(var/mob/living/carbon/human/player in player_list)
+		//They may be dead, but we only need their flesh
 		var/turf/player_turf = get_turf(player)
 		if(player_turf.z != STATION_Z)//We only look for people currently aboard the station
 			continue
@@ -98,13 +99,12 @@
 			if(loyalty_implant.implanted)
 				is_implanted = TRUE
 				break
-		if (is_implanted) // If there are only non-implanted players left on the station, we'll have to sacrifice one of them
-			backup_targets += player
-		else
-			//They may be dead, but we only need their flesh
+		if(is_implanted || isReligiousLeader(user) || isantagbanned(user) || jobban_isbanned(user, CULTIST))
 			possible_targets += player
+		else
+			backup_targets += player
 
-	if(possible_targets.len <= 0)
+	if(possible_targets.len <= 0) // If there are only non-implanted players left on the station, we'll have to sacrifice one of them
 		if (backup_targets.len <= 0)
 			message_admins("Blood Cult: Could not find a suitable sacrifice target. Trying again in a minute.")
 			log_admin("Blood Cult: Could not find a suitable sacrifice target. Trying again in a minute.")

--- a/code/datums/gamemode/objectives/bloodcult.dm
+++ b/code/datums/gamemode/objectives/bloodcult.dm
@@ -93,7 +93,12 @@
 		var/turf/player_turf = get_turf(player)
 		if(player_turf.z != STATION_Z)//We only look for people currently aboard the station
 			continue
-		if (iscultist(player)) // If there are only cultists left on the station, we'll have to sacrifice one of them
+		var/is_implanted = FALSE
+		for(var/obj/item/weapon/implant/loyalty/loyalty_implant in player)
+			if(loyalty_implant.implanted)
+				is_implanted = TRUE
+				break
+		if (is_implanted) // If there are only non-implanted players left on the station, we'll have to sacrifice one of them
 			backup_targets += player
 		else
 			//They may be dead, but we only need their flesh

--- a/code/datums/gamemode/objectives/bloodcult.dm
+++ b/code/datums/gamemode/objectives/bloodcult.dm
@@ -99,7 +99,7 @@
 			if(loyalty_implant.implanted)
 				is_implanted = TRUE
 				break
-		if(is_implanted || isReligiousLeader(user) || isantagbanned(user) || jobban_isbanned(user, CULTIST))
+		if(is_implanted || isReligiousLeader(player) || isantagbanned(player) || jobban_isbanned(player, CULTIST))
 			possible_targets += player
 		else
 			backup_targets += player


### PR DESCRIPTION
closes #23367

:cl:
 * tweak: Cultists will have to sacrifice an implanted crew member. Only if there is no implanted personnel on the station they will be able to sacrifice a non-implanted crew member.