### PR TITLE
Adds some armor penetration to the meat cleaver

### DIFF
--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -286,6 +286,7 @@
 	name = "meat cleaver"
 	icon_state = "mcleaver"
 	desc = "A huge thing used for chopping and chopping up meat. This includes clowns and clown-by-products."
+	armor_penetration = 50
 	force = 25.0
 	throwforce = 15.0
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -14,7 +14,7 @@
 	percent damage reduction
 */
 /mob/living/proc/run_armor_check(var/def_zone = null, var/attack_flag = "melee", var/absorb_text = null, var/soften_text = null, modifier = 1, var/quiet = 0, var/armor_penetration = 0)
-	var/armor = (getarmor(def_zone, attack_flag)-armor_penetration)*modifier
+	var/armor = max(0, (getarmor(def_zone, attack_flag)-armor_penetration)*modifier)
 
 	if(armor >= 100) //Absolutely no damage
 		if(!quiet)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -14,7 +14,7 @@
 	percent damage reduction
 */
 /mob/living/proc/run_armor_check(var/def_zone = null, var/attack_flag = "melee", var/absorb_text = null, var/soften_text = null, modifier = 1, var/quiet = 0, var/armor_penetration = 0)
-	var/armor = max(0, (getarmor(def_zone, attack_flag)-armor_penetration)*modifier)
+	var/armor = (getarmor(def_zone, attack_flag)-armor_penetration)*modifier
 
 	if(armor >= 100) //Absolutely no damage
 		if(!quiet)


### PR DESCRIPTION
Should make it a bit more viable
With the way armor mechanics work it shaves off 50% of reduction, meaning something with 30% reduction will count as if 0% reduction, something with 60% will have 10% reduction and so on.
:cl:
 * tweak: Meat cleaver ignores 50 armor