### PR TITLE
Adds clown curse empowerment

### DIFF
--- a/code/modules/spells/targeted/equip/clowncurse.dm
+++ b/code/modules/spells/targeted/equip/clowncurse.dm
@@ -10,7 +10,7 @@
 	invocation_type = SpI_SHOUT
 	range = 1
 	spell_flags = WAIT_FOR_CLICK //SELECTABLE hinders you here, since the spell has a range of 1 and only works on adjacent guys. Having the TARGETTED flag here makes it easy for your target to run away from you!
-
+	level_max = list(Sp_TOTAL = 5, Sp_SPEED = 4, Sp_POWER = 1)
 	cooldown_min = 50
 
 	sparks_spread = 1
@@ -45,13 +45,23 @@
 		M.wizard_garb = 1  // This means that wizards who are clown cursed can still cast robed spells.
 	return new_item
 
+/spell/targeted/equip_item/clowncurse/empower_spell()
+	spell_levels[Sp_POWER]++
+	equipped_summons"[slot_shoes]" = /obj/item/clothing/shoes/clown_shoes/slippy
+	name = "Empowered Clown Curse"
+	desc = "A curse that will turn a victim into a miserable clown that spills lube there and there."
+
+/spell/targeted/equip_item/clowncurse/get_upgrade_info(upgrade_type, level)
+	if(upgrade_type == Sp_POWER)
+		return "Makes the shoes of clowns periodically produce lube when moving."
+	return ..()
 
 /spell/targeted/equip_item/clowncurse/christmas //elves for santa's workshop
 	name = "The Elf Curse"
 	desc = "A curse that will turn its victim into a miserable christmas elf."
 	abbreviation = "EC"
 	holiday_required = list(XMAS)
-
+	level_max = list(Sp_TOTAL = 4, Sp_SPEED = 4, Sp_POWER = 0)
 	hud_state = "wiz_elf"
 
 	invocation = "MAK'N T'YS!"
@@ -61,3 +71,6 @@
 	equipped_summons = list("[slot_head]" = /obj/item/clothing/head/elfhat/stickymagic,
 							"[slot_w_uniform]" = /obj/item/clothing/under/elf/stickymagic,
 							"[slot_shoes]" = /obj/item/clothing/shoes/clown_shoes/elf/stickymagic)
+
+/spell/targeted/equip_item/clowncurse/christmas/get_upgrade_info(upgrade_type, level)
+	return ..()

--- a/code/modules/spells/targeted/equip/clowncurse.dm
+++ b/code/modules/spells/targeted/equip/clowncurse.dm
@@ -47,7 +47,10 @@
 
 /spell/targeted/equip_item/clowncurse/empower_spell()
 	spell_levels[Sp_POWER]++
-	equipped_summons[slot_shoes] = /obj/item/clothing/shoes/clown_shoes/slippy
+	//equipped_summons[slot_shoes] didn't work, copypasting is the only option.
+	equipped_summons = list("[slot_wear_mask]" = /obj/item/clothing/mask/gas/clown_hat/stickymagic,
+	"[slot_w_uniform]" = /obj/item/clothing/under/rank/clown,
+	"[slot_shoes]" = /obj/item/clothing/shoes/clown_shoes/slippy)
 	name = "Empowered Clown Curse"
 	desc = "A curse that will turn a victim into a miserable clown that spills lube there and there."
 

--- a/code/modules/spells/targeted/equip/clowncurse.dm
+++ b/code/modules/spells/targeted/equip/clowncurse.dm
@@ -47,7 +47,7 @@
 
 /spell/targeted/equip_item/clowncurse/empower_spell()
 	spell_levels[Sp_POWER]++
-	equipped_summons"[slot_shoes]" = /obj/item/clothing/shoes/clown_shoes/slippy
+	equipped_summons[slot_shoes] = /obj/item/clothing/shoes/clown_shoes/slippy
 	name = "Empowered Clown Curse"
 	desc = "A curse that will turn a victim into a miserable clown that spills lube there and there."
 


### PR DESCRIPTION
This empowerment will make the shoes the slippy ones that have a 10% chance of lubing the floor per step from pierrot.
You are blowing 40 points on one of the most antagonizing spells in the game
These shoes can be acidable unlike normal clown curse shoes
Watch your step!
:cl:
 * rscadd: Added a new wizard empowerment for clown curse!