### PR TITLE
fixes ninja sword teleport item_action not being granted to the user

### DIFF
--- a/code/datums/gamemode/role/ninja.dm
+++ b/code/datums/gamemode/role/ninja.dm
@@ -532,12 +532,15 @@ Helpers For Both Variants
 /obj/item/weapon/melee/energy/sword/ninja/dropped(mob/user)
 	if(active)
 		toggleActive(user,togglestate = "off")
+	..()
 		
 /obj/item/weapon/melee/energy/sword/ninja/equipped(mob/user)
 	if(!isninja(user) && active)
 		toggleActive(user,togglestate = "off")
 		to_chat(user,"<span class='warning'>The [src] shuts off.</span>")
+		..()
 		return
+	..()
 		
 /*=======
 Suit and assorted

--- a/code/datums/gamemode/role/ninja.dm
+++ b/code/datums/gamemode/role/ninja.dm
@@ -538,8 +538,6 @@ Helpers For Both Variants
 	if(!isninja(user) && active)
 		toggleActive(user,togglestate = "off")
 		to_chat(user,"<span class='warning'>The [src] shuts off.</span>")
-		..()
-		return
 	..()
 		
 /*=======


### PR DESCRIPTION
fixes #23454 

🆑 
 - bugfix: Ninjas can now teleport again