### PR TITLE
Increase Rambler Weight

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -473,9 +473,8 @@
 	if(!mode.executed_rules)
 		return FALSE
 		//We have nothing to investigate!
-	if(population>=20)
-		return FALSE
-		//We don't cotton to freaks in 20+pop
+	weight = Clamp(300/(population^2),1,10) //1-5: 10; 8.3, 6.1, 4.6, 3.7, 3, ... , 1.2 (15)
+	//We don't cotton to freaks in highpop
 	return ..()
 
 /datum/dynamic_ruleset/midround/from_ghosts/rambler/generate_ruleset_body(mob/applicant)


### PR DESCRIPTION
Soul Ramblers have been pretty popular, surprisingly so given how roleplay oriented they are. This allows them to show up in any population (even higher than 20), and makes their weight raise quadratically in ultra-lowpop. This functionally means they will still have weight 1 from 15+ pop, but the less players there are, the more likely a midround antag is to be a Rambler. When there are 5 or less players, the ruleset has 10 weight.

I think this is good, because Ramblers won't show up if there aren't already antags (they aren't "forcing" extended) but they don't add too much chaos for very chill rounds.

🆑 
* tweak: Soul Ramblers can now show up in any population, but prefer to ramble in lowpop shifts.