### PR TITLE
Fixing a bunch of oversights

### DIFF
--- a/__DEFINES/global.dm
+++ b/__DEFINES/global.dm
@@ -234,7 +234,8 @@ var/list/score=list(
 	"mess"           = 0, //How much messes on the floor went uncleaned
 	"litter"		 = 0, //How much trash is laying on the station floor
 	"meals"          = 0, //How much food was actively cooked that day
-	"disease"        = 0, //How many disease vectors in the world (one disease on one person is one)
+	"disease_good"        = 0, //How many unique diseases currently affecting living mobs of cumulated danger <3
+	"disease_bad"        = 0, //How many unique diseases currently affecting living mobs of cumulated danger >= 3
 
 	//These ones are mainly for the stat panel
 	"powerbonus"    = 0, //If all APCs on the station are running optimally, big bonus

--- a/code/datums/gamemode/objectives/plague.dm
+++ b/code/datums/gamemode/objectives/plague.dm
@@ -7,9 +7,11 @@
 /datum/objective/plague/extraInfo()
 	var/current_infections = 0
 	for (var/mob/living/L in mob_list)
+		if (L.stat == DEAD)
+			continue
 		if (diseaseID in L.virus2)
 			current_infections++
-	explanation_text += " ([total_infections] infections caused in total. [current_infections] infected individuals remaining.)"
+	explanation_text += " ([total_infections] infections caused in total. [current_infections] infected individuals remaining alive.)"
 
 /datum/objective/plague/IsFulfilled()
 	if (..())
@@ -18,6 +20,8 @@
 	if (total_infections > 1)
 		for (var/mob/living/L in mob_list)
 			if (L.locked_to && istype(L.locked_to, /obj/item/critter_cage))//mice in cages are "safe"
+				continue
+			if (L.stat == DEAD)//dead mice don't count
 				continue
 			if (diseaseID in L.virus2)
 				return TRUE//if we infected at least one individual, and there is still an infected individual alive, that's good enough.

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -57,19 +57,19 @@ proc/process_med_hud(var/mob/M, var/mob/eye)
 				holder.icon_state = "huddead"
 			else if(patient.status_flags & XENO_HOST)
 				holder.icon_state = "hudxeno"
-			else if(has_any_recorded_disease(patient))
-				if (has_recorded_disease(patient))
-					holder.icon_state = "hudill_old"
-				else
-					holder.icon_state = "hudill"
-					var/dangerosity = has_recorded_virus2(patient)
-					switch (dangerosity)
-						if (2)
-							holder.icon_state = "hudill_safe"
-						if (3)
-							holder.icon_state = "hudill_danger"
+			else if(has_recorded_disease(patient))
+				holder.icon_state = "hudill_old"
 			else
-				holder.icon_state = "hudhealthy"
+				var/dangerosity = has_recorded_virus2(patient)
+				switch (dangerosity)
+					if (1)
+						holder.icon_state = "hudill"
+					if (2)
+						holder.icon_state = "hudill_safe"
+					if (3)
+						holder.icon_state = "hudill_danger"
+					else
+						holder.icon_state = "hudhealthy"
 			C.images += holder
 
 	for(var/mob/living/carbon/patient in range(T))
@@ -97,19 +97,19 @@ proc/process_med_hud(var/mob/M, var/mob/eye)
 				holder.icon_state = "huddead"
 			else if(patient.status_flags & XENO_HOST)
 				holder.icon_state = "hudxeno"
-			else if(has_any_recorded_disease(patient))
-				if (has_recorded_disease(patient))
-					holder.icon_state = "hudill_old"
-				else
-					holder.icon_state = "hudill"
-					var/dangerosity = has_recorded_virus2(patient)
-					switch (dangerosity)
-						if (2)
-							holder.icon_state = "hudill_safe"
-						if (3)
-							holder.icon_state = "hudill_danger"
+			else if(has_recorded_disease(patient))
+				holder.icon_state = "hudill_old"
 			else
-				holder.icon_state = "hudhealthy"
+				var/dangerosity = has_recorded_virus2(patient)
+				switch (dangerosity)
+					if (1)
+						holder.icon_state = "hudill"
+					if (2)
+						holder.icon_state = "hudill_safe"
+					if (3)
+						holder.icon_state = "hudill_danger"
+					else
+						holder.icon_state = "hudhealthy"
 			C.images += holder
 
 		holder = patient.hud_list[RECORD_HUD]

--- a/code/game/gamemodes/scoreboard.dm
+++ b/code/game/gamemodes/scoreboard.dm
@@ -65,11 +65,22 @@
 
 	//Score Calculation and Display
 
+	var/list/active_diseases = list()
+
+	for (var/mob/living/L in mob_list)//diseases only count if the mob is still alive
+		if (L.stat != DEAD)
+			for (var/ID in L.virus2)
+				active_diseases |= ID
+
+	score["disease"] = active_diseases.len
+
 	//Run through humans for diseases, also the Clown
 	for(var/mob/living/carbon/human/I in mob_list)
+		/*
 		if(I.viruses) //Do this guy have any viruses ?
 			for(var/datum/disease/D in I.viruses) //Alright, start looping through those viruses
 				score["disease"]++ //One point for every disease
+		*/
 
 		if(I.job == "Clown")
 			for(var/thing in I.attack_log)

--- a/code/game/gamemodes/scoreboard.dm
+++ b/code/game/gamemodes/scoreboard.dm
@@ -65,14 +65,24 @@
 
 	//Score Calculation and Display
 
-	var/list/active_diseases = list()
 
-	for (var/mob/living/L in mob_list)//diseases only count if the mob is still alive
-		if (L.stat != DEAD)
-			for (var/ID in L.virus2)
-				active_diseases |= ID
+	for (var/ID in disease2_list)
+		var/datum/disease2/disease/D = disease2_list[ID]
+		var/disease_score = 0
+		for (var/datum/disease2/effect/E in D.effects)
+			disease_score += text2num(E.badness)
 
-	score["disease"] = active_diseases.len
+		//diseases only count if the mob is still alive
+		if (disease_score <3)
+			for (var/mob/living/L in mob_list)
+				if (L.stat != DEAD)
+					if (ID in L.virus2)
+						score["disease_good"]++
+		else
+			for (var/mob/living/L in mob_list)
+				if (L.stat != DEAD)
+					if (ID in L.virus2)
+						score["disease_bad"]++
 
 	//Run through humans for diseases, also the Clown
 	for(var/mob/living/carbon/human/I in mob_list)
@@ -260,7 +270,8 @@
 		messpoints = score["mess"] //If there are any messes, let's count them
 	//if(score["airloss"] != 0)
 		//atmos = score["airloss"] * 20 //Air issues are bad, but since it's space, don't stress it too much
-	var/plaguepoints = score["disease"] * 50 //A diseased crewman is half-dead, as they say, and a double diseased is double half-dead
+	var/beneficialpoints = score["disease_good"] * 20
+	var/plaguepoints = score["disease_bad"] * 50 //A diseased crewman is half-dead, as they say, and a double diseased is double half-dead
 
 	/*//Mode Specific
 	if(ticker.mode.config_tag == "nuclear")
@@ -291,6 +302,7 @@
 	score["crewscore"] += escapoints
 	score["crewscore"] += meals
 	score["crewscore"] += time
+	score["crewscore"] += beneficialpoints
 
 	if(!power) //No APCs with bad power
 		score["crewscore"] += 2500 //Give the Engineers a pat on the back for bothering
@@ -467,6 +479,7 @@
 	<B>Random Events Endured:</B> [score["eventsendured"]] ([score["eventsendured"] * 200] Points)<BR>
 	<B>Whole Station Powered:</B> [score["powerbonus"] ? "Yes" : "No"] ([score["powerbonus"] * 2500] Points)<BR>
 	<B>Ultra-Clean Station:</B> [score["messbonus"] ? "Yes" : "No"] ([score["messbonus"] * 10000] Points)<BR><BR>
+	<B>Beneficial diseases in living mobs:</B> [score["disease_good"]] ([score["disease_good"] * 20] Points)<BR><BR>
 
 	<U>THE BAD:</U><BR>
 	<B>Dead Crewmen:</B> [score["deadcrew"]] (-[score["deadcrew"] * 250] Points)<BR>
@@ -475,7 +488,7 @@
 	<B>Uncleaned Messes:</B> [score["mess"]] (-[score["mess"]] Points)<BR>
 	<B>Trash on Station:</B> [score["litter"]] (-[score["litter"]] Points)<BR>
 	<B>Station Power Issues:</B> [score["powerloss"]] (-[score["powerloss"] * 50] Points)<BR>
-	<B>Unique Disease Vectors:</B> [score["disease"]] (-[score["disease"] * 50] Points)<BR><BR>
+	<B>Bad diseases in living mobs:</B> [score["disease_bad"]] (-[score["disease_bad"] * 50] Points)<BR><BR>
 
 	<U>THE WEIRD</U><BR>"}
 /*	<B>Final Station Budget:</B> $[num2text(totalfunds,50)]<BR>"}

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -80,7 +80,8 @@ var/list/admin_verbs_admin = list(
 	/client/proc/manage_religions,
 	/client/proc/set_veil_thickness,
 	/client/proc/credits_panel,			/*allows you to customize the roundend credits before they happen*/
-	/client/proc/persistence_panel			/*lets you check out the kind of shit that will persist to the next round and say "holy fuck no"*/
+	/client/proc/persistence_panel,			/*lets you check out the kind of shit that will persist to the next round and say "holy fuck no"*/
+	/client/proc/diseases_panel,
 )
 var/list/admin_verbs_ban = list(
 	/client/proc/unban_panel,
@@ -195,7 +196,6 @@ var/list/admin_verbs_debug = list(
 	/client/proc/cmd_mass_modify_object_variables,
 	/client/proc/emergency_shuttle_panel,
 	/client/proc/bee_count,
-	/client/proc/diseases_panel,
 #if UNIT_TESTS_ENABLED
 	/client/proc/unit_test_panel,
 #endif
@@ -700,7 +700,7 @@ var/list/admin_verbs_mod = list(
 	if (T.alphas["admin_invis"] == 0)
 		T.forced_density = 0
 		T.alphas -= "admin_invis"
-	else	
+	else
 		T.alphas["admin_invis"] = 0
 		T.density = 0
 		T.forced_density = 1

--- a/code/modules/admin/diseases_panel.dm
+++ b/code/modules/admin/diseases_panel.dm
@@ -50,8 +50,12 @@
 			if (dish.contained_virus)
 				if (ID == "[dish.contained_virus.uniqueID]-[dish.contained_virus.subID]")
 					dishes++
+		var/nickname = ""
+		if (ID in virusDB)
+			var/datum/data/record/v = virusDB[ID]
+			nickname = v.fields["nickname"] ? " \"[v.fields["nickname"]]\"" : ""
 		dat += {"<tr>
-			<td><a href='?src=\ref[src];diseasepanel_examine=\ref[D]'>[D.form] #[add_zero("[D.uniqueID]", 4)]-[add_zero("[D.subID]", 4)]</a></td>
+			<td><a href='?src=\ref[src];diseasepanel_examine=\ref[D]'>[D.form] #[add_zero("[D.uniqueID]", 4)]-[add_zero("[D.subID]", 4)][nickname]</a></td>
 			<td>[D.origin]</td>
 			<td><a href='?src=\ref[src];diseasepanel_toggledb=\ref[D]'>[(ID in virusDB) ? "Yes" : "No"]</a></td>
 			<td><a href='?src=\ref[src];diseasepanel_infectedmobs=\ref[D]'>[infctd_mobs][infctd_mobs_dead ? " (including [infctd_mobs_dead] dead)" : "" ]</a></td>

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -1336,7 +1336,7 @@ client/proc/check_convertables()
 
 /client/proc/diseases_panel()
 	set name = "Diseases Panel"
-	set category = "Debug"
+	set category = "Admin"
 	if(holder)
 		holder.diseases_panel()
 		log_admin("[key_name(usr)] checked the Diseases Panel.")

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -270,7 +270,7 @@ Works together with spawning an observer, noted above.
 /mob/dead/proc/process_medHUD(var/mob/M)
 	var/client/C = M.client
 	var/image/holder
-	for(var/mob/living/carbon/human/patient in oview(M))
+	for(var/mob/living/carbon/patient in oview(M))
 		var/foundVirus = 0//no disease
 		if(patient && patient.virus2 && patient.virus2.len)
 			foundVirus = 1//new diseases appear in priority

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -271,16 +271,13 @@ Works together with spawning an observer, noted above.
 	var/client/C = M.client
 	var/image/holder
 	for(var/mob/living/carbon/patient in oview(M))
-		var/foundVirus = 0//no disease
-		if(patient && patient.virus2 && patient.virus2.len)
-			foundVirus = 1//new diseases appear in priority
-		else if (patient && patient.viruses && patient.viruses.len)
-			foundVirus = 2//old disease
+		if(!check_HUD_visibility(patient, M))
+			continue
 		if(!C)
 			return
 		holder = patient.hud_list[HEALTH_HUD]
 		if(holder)
-			if(patient.stat == 2)
+			if(patient.isDead())
 				holder.icon_state = "hudhealth-100"
 			else
 				holder.icon_state = "hud[RoundHealth(patient.health)]"
@@ -288,15 +285,24 @@ Works together with spawning an observer, noted above.
 
 		holder = patient.hud_list[STATUS_HUD]
 		if(holder)
-			if(patient.stat == 2)
+			if(patient.isDead())
 				holder.icon_state = "huddead"
 			else if(patient.status_flags & XENO_HOST)
 				holder.icon_state = "hudxeno"
-			else if(foundVirus)
-				if (foundVirus > 1)
-					holder.icon_state = "hudill_old"
-				else
-					holder.icon_state = "hudill"
+			else if(has_recorded_disease(patient))
+				holder.icon_state = "hudill_old"
+			else
+				var/dangerosity = has_recorded_virus2(patient)
+				switch (dangerosity)
+					if (1)
+						holder.icon_state = "hudill"
+					if (2)
+						holder.icon_state = "hudill_safe"
+					if (3)
+						holder.icon_state = "hudill_danger"
+					else
+						holder.icon_state = "hudhealthy"
+			/*
 			else if(patient.has_brain_worms())
 				var/mob/living/simple_animal/borer/B = patient.has_brain_worms()
 				if(B.controlling)
@@ -305,7 +311,34 @@ Works together with spawning an observer, noted above.
 					holder.icon_state = "hudhealthy"
 			else
 				holder.icon_state = "hudhealthy"
+			*/
 
+			C.images += holder
+
+	for(var/mob/living/simple_animal/mouse/patient in oview(M))
+		if(!check_HUD_visibility(patient, M))
+			continue
+		if(!C)
+			continue
+		holder = patient.hud_list[STATUS_HUD]
+		if(holder)
+			if(patient.isDead())
+				holder.icon_state = "huddead"
+			else if(patient.status_flags & XENO_HOST)
+				holder.icon_state = "hudxeno"
+			else if(has_recorded_disease(patient))
+				holder.icon_state = "hudill_old"
+			else
+				var/dangerosity = has_recorded_virus2(patient)
+				switch (dangerosity)
+					if (1)
+						holder.icon_state = "hudill"
+					if (2)
+						holder.icon_state = "hudill_safe"
+					if (3)
+						holder.icon_state = "hudill_danger"
+					else
+						holder.icon_state = "hudhealthy"
 			C.images += holder
 
 /mob/dead/proc/assess_targets(list/target_list, mob/dead/observer/U)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1828,6 +1828,7 @@ mob/living/carbon/human/isincrit()
 
 /mob/living/carbon/human/proc/make_zombie(mob/master, var/retain_mind = TRUE)
 	var/mob/living/simple_animal/hostile/necro/zombie/turned/T = new(get_turf(src), master, (retain_mind ? src : null))
+	T.virus2 = virus_copylist(virus2)
 	T.get_clothes(src, T)
 	T.name = real_name
 	T.host = src

--- a/code/modules/mob/living/carbon/human/life/handle_hud_list.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_hud_list.dm
@@ -37,10 +37,16 @@
 			holder2.icon_state = "hudbrainworm"
 		else
 			holder.icon_state = "hudhealthy"
-			if(virus2.len)
-				holder2.icon_state = "hudill"
-			else
-				holder2.icon_state = "hudhealthy"
+			var/dangerosity = has_recorded_virus2(src)
+			switch (dangerosity)
+				if (1)
+					holder.icon_state = "hudill"
+				if (2)
+					holder.icon_state = "hudill_safe"
+				if (3)
+					holder.icon_state = "hudill_danger"
+				else
+					holder.icon_state = "hudhealthy"
 
 		hud_list[STATUS_HUD] = holder
 		hud_list[STATUS_HUD_OOC] = holder2

--- a/code/modules/virus2/effect/effect.dm
+++ b/code/modules/virus2/effect/effect.dm
@@ -11,14 +11,14 @@
 	var/stage = -1
 		// Diseases start at stage 1. They slowly and cumulatively proceed their way up.
 		// Try to keep more severe effects in the later stages.
-	var/badness = 1
+	var/badness = EFFECT_DANGER_ANNOYING
 		// How dangerous the symptom is.
-		// 0 = generally helpful (ex: full glass syndrome)
-		// 1 = neutral, just flavor text (ex: headache)
-		// 2 = minor inconvenience (ex: tourettes)
-		// 3 = severe inconvenience (ex: random tripping)
-		// 4 = likely to indirectly lead to death (ex: Harlequin Ichthyosis)
-		// 5 = will definitely kill you (ex: gibbingtons/necrosis)
+		// EFFECT_DANGER_HELPFUL = generally helpful (ex: full glass syndrome)
+		// EFFECT_DANGER_FLAVOR = neutral, just flavor text (ex: headache)
+		// EFFECT_DANGER_ANNOYING = minor inconvenience (ex: tourettes)
+		// EFFECT_DANGER_HINDRANCE = severe inconvenience (ex: random tripping)
+		// EFFECT_DANGER_HARMFUL = likely to indirectly lead to death (ex: Harlequin Ichthyosis)
+		// EFFECT_DANGER_DEADLY = will definitely kill you (ex: gibbingtons/necrosis)
 
 	var/chance = 3
 		// Under normal conditions, the percentage chance per tick to activate.

--- a/code/modules/virus2/immune_system.dm
+++ b/code/modules/virus2/immune_system.dm
@@ -111,6 +111,8 @@
 						tally += 2//if we're sleeping in a bed, we get up to 4
 			else if(istype(body.loc, /obj/machinery/atmospherics/unary/cryo_cell))
 				tally += 1.5
+			else if(body.locked_to && istype(body.locked_to, /obj/item/critter_cage))
+				tally += 2
 
 			if (antibodies[A] < threshold)
 				antibodies[A] = min(antibodies[A] + tally, threshold)//no overshooting here


### PR DESCRIPTION
[hotfix]

:cl:
* rscadd: The round end scoreboard will now add and remove points from the crew score based on how many beneficial or harmful diseases are loose in living mobs.
* tweak: Plague Mice Invasion event only considers mobs as "still infected" on the round end scoreboard if they're still alive.
* bugfix: maybe fixed a bug that caused medical HUDs to display the ill status even though the disease hasn't been added to the database.
* rscadd: humans turning into zombies upon death keep their diseases, which may then transmit to their meat. (zombies themselves can't spread their diseases for now, more to that later)
* rscadd: mice in small cages get a similar buff to antipathogenic efficiency that other mobs get when they rest in a bed.
* rscadd: Admin Diseases Panel now indicate the disease's nickname if there's one
* rscadd: Admin Diseases Panel is now accessible from the Admin tab instead of Debug.