### PR TITLE
Runtime webhook

### DIFF
--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -447,6 +447,7 @@ var/datum/controller/gameticker/ticker
 	var/mode_finished = mode.check_finished() || (emergency_shuttle.location == 2 && emergency_shuttle.alert == 1) || force_round_end
 	if(!explosion_in_progress && mode_finished)
 		current_state = GAME_STATE_FINISHED
+		error_cache.send_to_webhook()
 
 		spawn
 			declare_completion()

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -1312,6 +1312,7 @@ client/proc/check_convertables()
 		return
 
 	error_cache.show_to(src)
+	error_cache.send_to_webhook();
 
 /client/proc/emergency_shuttle_panel()
 	set name = "Emergency Shuttle Panel"

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -1312,7 +1312,6 @@ client/proc/check_convertables()
 		return
 
 	error_cache.show_to(src)
-	error_cache.send_to_webhook();
 
 /client/proc/emergency_shuttle_panel()
 	set name = "Emergency Shuttle Panel"

--- a/code/modules/error_handler/error_viewer.dm
+++ b/code/modules/error_handler/error_viewer.dm
@@ -190,7 +190,7 @@
 		html += " <a href='?_src_=holder;adminplayerobservefollow=[usr_ref]'>Follow</a>"
 		if (istype(usr_loc))
 			html += "<br><b>usr.loc</b>: <a href='?_src_=vars;Vars=\ref[usr_loc]'>VV</a>"
-			html += " <a href='?_src_=holder;adminplayerobservecoodjump=;X=[usr_loc.x];Y=[usr_loc.y];Z=[usr_loc.z]'>JMP</a>"
+			html += " <a href='?_src_=holder;adminplayerobservecoodjump=1;X=[usr_loc.x];Y=[usr_loc.y];Z=[usr_loc.z]'>JMP</a>"
 
 	browse_to(user, html)
 

--- a/code/modules/error_handler/error_viewer.dm
+++ b/code/modules/error_handler/error_viewer.dm
@@ -125,10 +125,8 @@
 		error_source.next_message_at = world.time + err_msg_delay
 
 /datum/error_viewer/error_cache/proc/send_to_webhook()
-	var/list/data = list()
 	for (var/datum/error_viewer/error_entry/error_entry in errors)
-		data += error_entry.name;
-	world.Export("WEBHOOK URL", text2file("{ \"username\":\"Runtime Cache\", \"content\":\"[data.Join("\\n")]\" }","test"));
+		send2runtimediscord(error_entry.name)
 
 /datum/error_viewer/error_source
 	var/list/errors = list()

--- a/code/modules/error_handler/error_viewer.dm
+++ b/code/modules/error_handler/error_viewer.dm
@@ -124,6 +124,12 @@
 			err_msg_delay = initial(config.error_msg_delay)
 		error_source.next_message_at = world.time + err_msg_delay
 
+/datum/error_viewer/error_cache/proc/send_to_webhook()
+	var/list/data = list()
+	for (var/datum/error_viewer/error_entry/error_entry in errors)
+		data += error_entry.name;
+	world.Export("WEBHOOK URL", text2file("{ \"username\":\"Runtime Cache\", \"content\":\"[data.Join("\\n")]\" }","test"));
+
 /datum/error_viewer/error_source
 	var/list/errors = list()
 	var/next_message_at = 0
@@ -186,7 +192,7 @@
 		html += " <a href='?_src_=holder;adminplayerobservefollow=[usr_ref]'>Follow</a>"
 		if (istype(usr_loc))
 			html += "<br><b>usr.loc</b>: <a href='?_src_=vars;Vars=\ref[usr_loc]'>VV</a>"
-			html += " <a href='?_src_=holder;adminplayerobservecoodjump=1;X=[usr_loc.x];Y=[usr_loc.y];Z=[usr_loc.z]'>JMP</a>"
+			html += " <a href='?_src_=holder;adminplayerobservecoodjump=;X=[usr_loc.x];Y=[usr_loc.y];Z=[usr_loc.z]'>JMP</a>"
 
 	browse_to(user, html)
 

--- a/code/modules/ext_scripts/discord.dm
+++ b/code/modules/ext_scripts/discord.dm
@@ -8,6 +8,11 @@
 /proc/send2admindiscord(var/msg, var/ping = FALSE)
 	send2discord(msg, "adminhelp", ping)
 
+// Sends to the runtime channel
+// This sends to the "runtime" gamenudge route.
+/proc/send2runtimediscord(var/msg)
+	send2discord(msg, "runtime")
+
 // Meta argument here is the MoMMI meta argument to send to the gamenudge route.
 // AKA the MoMMI config file chooses where to send it based on this key.
 /proc/send2discord(var/msg, var/meta, var/ping = FALSE)

--- a/test
+++ b/test
@@ -1,1 +1,0 @@
-{ "username":"Runtime Cache", "content":"" }

--- a/test
+++ b/test
@@ -1,0 +1,1 @@
+{ "username":"Runtime Cache", "content":"" }


### PR DESCRIPTION
To avoid us needing to logdive to find issues.
Triggeres at roundend and sends all runtimes to MoMMI, which then posts them into a #runtimes channel in the coderdiscord
**this needs @PJB3005 to edit the MoMMI config as well as the channel to be created**
also 0% tested cause im not setting up MoMMI myself for such a small chance
[qol]

:cl:
 * rscadd: MoMMI will now post all runtimes at roundend in the coderdiscord