### PR TITLE
Remove solo antag objectives part 55: electric boogaloo

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -6,7 +6,7 @@
                    // They did, tested in 508.1296 - N3X
 
 // If set to 0, replaces solo antags' objectives with an always-pass freeform
-#define SOLO_ANTAG_OBJECTIVES 1
+#define SOLO_ANTAG_OBJECTIVES 0
 
 // Defines for the shuttle
 #define SHUTTLE_ON_STANDBY 0


### PR DESCRIPTION
http://ss13.moe/index.php/poll/176

Only 20% in favour of keeping objectives as is.
Nobody changed objectives in a satisfactory fashion (and that's because you can't change something like that in a satisfactory fashion).

:cl:

- tweak: Solo antags no longer have defined objectives, and instead are just told to do what they want.