### PR TITLE
Fixes a runtime in soul ramblers

### DIFF
--- a/code/datums/gamemode/role/rambler.dm
+++ b/code/datums/gamemode/role/rambler.dm
@@ -59,7 +59,7 @@
 		..()
 
 /obj/item/device/instrument/recorder/shakashuri/OnPlayed(mob/user,mob/M)
-	if(user!=M && !M.reagents.has_reagent(CHILLWAX,1))
+	if(user!=M && M.reagents && !M.reagents.has_reagent(CHILLWAX,1))
 		M.reagents.add_reagent(CHILLWAX,0.3)
 
 /obj/item/weapon/reagent_containers/food/snacks/quiche/frittata/New()


### PR DESCRIPTION
They were trying to give chillwax to mobs which didn't have reagents (such as presumably simple animals)
I think `reagents` got moved to a more general level recently, there surely must be a good reason for it.