### PR TITLE
More Viro Oversights

### DIFF
--- a/__DEFINES/global.dm
+++ b/__DEFINES/global.dm
@@ -236,6 +236,8 @@ var/list/score=list(
 	"meals"          = 0, //How much food was actively cooked that day
 	"disease_good"        = 0, //How many unique diseases currently affecting living mobs of cumulated danger <3
 	"disease_bad"        = 0, //How many unique diseases currently affecting living mobs of cumulated danger >= 3
+	"disease_most"        = null, //Most spread disease
+	"disease_most_count"        = 0, //Most spread disease
 
 	//These ones are mainly for the stat panel
 	"powerbonus"    = 0, //If all APCs on the station are running optimally, big bonus

--- a/code/game/gamemodes/scoreboard.dm
+++ b/code/game/gamemodes/scoreboard.dm
@@ -532,7 +532,7 @@
 			var/datum/data/record/v = virusDB[score["disease_most"]]
 			nickname = v.fields["nickname"] ? " \"[v.fields["nickname"]]\"" : ""
 			dis_name = v.fields["name"]
-		dat += "<B>Most Spread Disease:</B> [dis_name ? "[dis_name]":"[D.form] #[add_zero("[D.uniqueID]", 4)]-[add_zero("[D.subID]", 4)]"][nickname] (Strength [D.strength], spread in [score["disease_most_count"]] mobs)<BR>"
+		dat += "<B>Most Spread Disease:</B> [dis_name ? "[dis_name]":"[D.form] #[add_zero("[D.uniqueID]", 4)]-[add_zero("[D.subID]", 4)]"][nickname] (Origin: [D.origin], Strength: [D.strength]%, spread among [score["disease_most_count"]] mobs)<BR>"
 		for(var/datum/disease2/effect/e in D.effects)
 			dat += "&#x25CF; Stage [e.stage] - <b>[e.name]</b><BR>"
 

--- a/code/game/gamemodes/scoreboard.dm
+++ b/code/game/gamemodes/scoreboard.dm
@@ -64,9 +64,8 @@
 		completions += "<HR>"
 
 	//Score Calculation and Display
-
-
 	for (var/ID in disease2_list)
+		var/disease_spread_count = 0
 		var/datum/disease2/disease/D = disease2_list[ID]
 		var/disease_score = 0
 		for (var/datum/disease2/effect/E in D.effects)
@@ -75,14 +74,20 @@
 		//diseases only count if the mob is still alive
 		if (disease_score <3)
 			for (var/mob/living/L in mob_list)
-				if (L.stat != DEAD)
-					if (ID in L.virus2)
+				if (ID in L.virus2)
+					disease_spread_count++
+					if (L.stat != DEAD)
 						score["disease_good"]++
 		else
 			for (var/mob/living/L in mob_list)
-				if (L.stat != DEAD)
-					if (ID in L.virus2)
+				if (ID in L.virus2)
+					disease_spread_count++
+					if (L.stat != DEAD)
 						score["disease_bad"]++
+
+		if (disease_spread_count > score["disease_most_count"])
+			score["disease_most_count"] = disease_spread_count
+			score["disease_most"] = ID
 
 	//Run through humans for diseases, also the Clown
 	for(var/mob/living/carbon/human/I in mob_list)
@@ -478,7 +483,7 @@
 	<B>Shuttle Escapees:</B> [score["escapees"]] ([score["escapees"] * 100] Points)<BR>
 	<B>Random Events Endured:</B> [score["eventsendured"]] ([score["eventsendured"] * 200] Points)<BR>
 	<B>Whole Station Powered:</B> [score["powerbonus"] ? "Yes" : "No"] ([score["powerbonus"] * 2500] Points)<BR>
-	<B>Ultra-Clean Station:</B> [score["messbonus"] ? "Yes" : "No"] ([score["messbonus"] * 10000] Points)<BR><BR>
+	<B>Ultra-Clean Station:</B> [score["messbonus"] ? "Yes" : "No"] ([score["messbonus"] * 10000] Points)<BR>
 	<B>Beneficial diseases in living mobs:</B> [score["disease_good"]] ([score["disease_good"] * 20] Points)<BR><BR>
 
 	<U>THE BAD:</U><BR>
@@ -519,6 +524,17 @@
 		dat += "<B>Guns Magically Spawned:</B> [score["gunsspawned"]]<BR>"
 	if(score["nukedefuse"] < 30)
 		dat += "<B>Seconds Left on the Nuke When It Was Defused:</B> [score["nukedefuse"]]<BR>"
+	if(score["disease_most"] != null)
+		var/datum/disease2/disease/D = disease2_list[score["disease_most"]]
+		var/nickname = ""
+		var/dis_name = ""
+		if (score["disease_most"] in virusDB)
+			var/datum/data/record/v = virusDB[score["disease_most"]]
+			nickname = v.fields["nickname"] ? " \"[v.fields["nickname"]]\"" : ""
+			dis_name = v.fields["name"]
+		dat += "<B>Most Spread Disease:</B> [dis_name ? "[dis_name]":"[D.form] #[add_zero("[D.uniqueID]", 4)]-[add_zero("[D.subID]", 4)]"][nickname] (Strength [D.strength], spread in [score["disease_most_count"]] mobs)<BR>"
+		for(var/datum/disease2/effect/e in D.effects)
+			dat += "&#x25CF; Stage [e.stage] - <b>[e.name]</b><BR>"
 
 	//Vault and away mission specific scoreboard elements
 	//The process_scoreboard() proc returns a list of strings associated with their score value (the number that's added to the total score)

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1578,6 +1578,7 @@ var/global/num_vending_terminals = 1
 		/obj/item/weapon/reagent_containers/glass/bottle/charcoal = 4,
 		/obj/item/weapon/reagent_containers/syringe/antiviral = 4,
 		/obj/item/weapon/reagent_containers/syringe = 12,
+		/obj/item/weapon/reagent_containers/glass/beaker/vial = 8,
 		/obj/item/device/healthanalyzer = 5,
 		/obj/item/device/antibody_scanner = 5,
 		/obj/item/weapon/reagent_containers/glass/beaker = 4,

--- a/code/game/objects/structures/mouse_cage.dm
+++ b/code/game/objects/structures/mouse_cage.dm
@@ -78,6 +78,7 @@
 /obj/item/critter_cage/unlock_atom(var/atom/movable/AM)
 	. = ..()
 	if (.)
+		AM.plane = initial(AM.plane)
 		AM.pixel_x = initial(AM.pixel_x)
 		AM.pixel_y = initial(AM.pixel_y)
 

--- a/code/game/objects/structures/mouse_cage.dm
+++ b/code/game/objects/structures/mouse_cage.dm
@@ -71,6 +71,7 @@
 /obj/item/critter_cage/lock_atom(var/atom/movable/AM)
 	. = ..()
 	if (.)
+		AM.plane = MOB_PLANE
 		AM.pixel_x = pixel_x
 		AM.pixel_y = pixel_y+5
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -40,6 +40,7 @@
 	incorporeal_move = INCORPOREAL_GHOST
 	var/movespeed = 0.75
 	var/lastchairspin
+	var/pathogenHUD = FALSE
 
 /mob/dead/observer/New(var/mob/body=null, var/flags=1)
 	change_sight(adding = SEE_TURFS | SEE_MOBS | SEE_OBJS | SEE_SELF)
@@ -577,6 +578,46 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	else
 		M.antagHUD = 1
 		to_chat(src, "<span class='notice'><B>AntagHUD Enabled</B></span>")
+
+
+
+/mob/dead/observer/verb/toggle_pathogenHUD()
+	set category = "Ghost"
+	set name = "Toggle PathogenHUD"
+	set desc = "Toggles Pathogen HUD allowing you to see airborne pathogenic clouds, and infected items and splatters"
+	if(!client)
+		return
+	if(pathogenHUD)
+		pathogenHUD = FALSE
+		to_chat(src, "<span class='notice'><B>Pathogen HUD disabled.</B></span>")
+		science_goggles_wearers.Remove(src)
+		if (client)
+			for (var/obj/item/I in infected_items)
+				client.images -= I.pathogen
+			for (var/mob/living/L in infected_contact_mobs)
+				client.images -= L.pathogen
+			for (var/obj/effect/effect/pathogen_cloud/C in pathogen_clouds)
+				client.images -= C.pathogen
+			for (var/obj/effect/decal/cleanable/C in infected_cleanables)
+				client.images -= C.pathogen
+	else
+		pathogenHUD = TRUE
+		to_chat(src, "<span class='notice'><B>Pathogen HUD enabled.</B></span>")
+		science_goggles_wearers.Add(src)
+		if (client)
+			for (var/obj/item/I in infected_items)
+				if (I.pathogen)
+					client.images |= I.pathogen
+			for (var/mob/living/L in infected_contact_mobs)
+				if (L.pathogen)
+					client.images |= L.pathogen
+			for (var/obj/effect/effect/pathogen_cloud/C in pathogen_clouds)
+				if (C.pathogen)
+					client.images |= C.pathogen
+			for (var/obj/effect/decal/cleanable/C in infected_cleanables)
+				if (C.pathogen)
+					client.images |= C.pathogen
+
 
 /mob/dead/observer/proc/dead_tele()
 	set category = "Ghost"

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -75,7 +75,7 @@
 
 	if (!isUnconscious())
 		//MICE!
-		if((src.loc) && isturf(src.loc))
+		if(isturf(loc))
 			if(!stat && !resting && !locked_to)
 				for(var/mob/living/simple_animal/mouse/M in view(1,src))
 					if(!M.stat && Adjacent(M) && !(M.locked_to && istype(M.locked_to, /obj/item/critter_cage)))

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -73,42 +73,44 @@
 	if(timestopped)
 		return 0 //under effects of time magick
 
-	//MICE!
-	if((src.loc) && isturf(src.loc))
-		if(!stat && !resting && !locked_to)
-			for(var/mob/living/simple_animal/mouse/M in view(1,src))
-				if(!M.stat && Adjacent(M) && !(M.locked_to && istype(M.locked_to, /obj/item/critter_cage)))
-					M.splat()
-					visible_message("<span class='warning'>\The [name] [pick(kill_verbs)] \the [M]!</span>")
-					movement_target = null
-					stop_automated_movement = 0
-					break
+	if (!isUnconscious())
+		//MICE!
+		if((src.loc) && isturf(src.loc))
+			if(!stat && !resting && !locked_to)
+				for(var/mob/living/simple_animal/mouse/M in view(1,src))
+					if(!M.stat && Adjacent(M) && !(M.locked_to && istype(M.locked_to, /obj/item/critter_cage)))
+						M.splat()
+						visible_message("<span class='warning'>\The [name] [pick(kill_verbs)] \the [M]!</span>")
+						movement_target = null
+						stop_automated_movement = 0
+						break
 
 	..()
 
-	for(var/mob/living/simple_animal/mouse/snack in oview(src, 3))
-		if(prob(15) && !snack.stat)
-			emote("me",, pick("[pick(growl_verbs)] at [snack]!", "eyes [snack] hungrily."))
-		break
+	if (!isUnconscious())
+		for(var/mob/living/simple_animal/mouse/snack in oview(src, 3))
+			if(prob(15) && !snack.stat)
+				emote("me",, pick("[pick(growl_verbs)] at [snack]!", "eyes [snack] hungrily."))
+			break
 
-	if(!stat && !resting && !locked_to)
-		turns_since_scan++
-		if(turns_since_scan > 5)
-			start_walk_to(0)
-			turns_since_scan = 0
-			if((movement_target) && !(isturf(movement_target.loc) || ishuman(movement_target.loc) ))
-				movement_target = null
-				stop_automated_movement = 0
-			if( !movement_target || !(movement_target.loc in oview(src, 3)) )
-				movement_target = null
-				stop_automated_movement = 0
-				for(var/mob/living/simple_animal/mouse/snack in oview(src,3))
-					if(isturf(snack.loc) && !snack.stat)
-						movement_target = snack
-						break
-			if(movement_target)
-				stop_automated_movement = 1
-				start_walk_to(movement_target,0,3)
+		if(!stat && !resting && !locked_to)
+			turns_since_scan++
+			if(turns_since_scan > 5)
+				start_walk_to(0)
+				turns_since_scan = 0
+				if((movement_target) && !(isturf(movement_target.loc) || ishuman(movement_target.loc) ))
+					movement_target = null
+					stop_automated_movement = 0
+				if( !movement_target || !(movement_target.loc in oview(src, 3)) )
+					movement_target = null
+					stop_automated_movement = 0
+					for(var/mob/living/simple_animal/mouse/snack in oview(src,3))
+						if(isturf(snack.loc) && !snack.stat)
+							movement_target = snack
+							break
+				if(movement_target)
+					stop_automated_movement = 1
+					start_walk_to(movement_target,0,3)
 
 /mob/living/simple_animal/cat/attack_hand(mob/living/carbon/human/M)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -329,6 +329,9 @@
 	if(isUnconscious())
 		return
 
+	if (locked_to && istype(locked_to, /obj/item/critter_cage))
+		return
+
 	if (plane != HIDING_MOB_PLANE)
 		plane = HIDING_MOB_PLANE
 		to_chat(src, text("<span class='notice'>You are now hiding.</span>"))

--- a/code/modules/mob/logout.dm
+++ b/code/modules/mob/logout.dm
@@ -19,6 +19,18 @@
 
 	remove_screen_objs() //Used to remove hud elements
 
+	if (src in science_goggles_wearers)
+		science_goggles_wearers.Remove(src)
+		if (client)
+			for (var/obj/item/I in infected_items)
+				client.images -= I.pathogen
+			for (var/mob/living/L in infected_contact_mobs)
+				client.images -= L.pathogen
+			for (var/obj/effect/effect/pathogen_cloud/C in pathogen_clouds)
+				client.images -= C.pathogen
+			for (var/obj/effect/decal/cleanable/C in infected_cleanables)
+				client.images -= C.pathogen
+
 	if(admin_datums[src.ckey])
 		if (ticker && ticker.current_state == GAME_STATE_PLAYING) //Only report this stuff if we are currently playing.
 			var/admins_number = admins.len

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -459,7 +459,7 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 					if(C.result)
 						feedback_add_details("chemical_reaction","[C.result][created_volume]")
 						multiplier = max(multiplier, 1) //this shouldnt happen ...
-						add_reagent(C.result, created_volume, C.data, chem_temp)
+						add_reagent(C.result, created_volume, null, chem_temp)
 						if (preserved_data)
 							set_data(C.result, preserved_data)
 
@@ -619,8 +619,13 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 					R.data["virus2"] |= virus_copylist(data["virus2"])
 				if(data["blood_colour"])
 					R.color = data["blood_colour"]
+			else if (reagent == VACCINE)
+				R.data = data.Copy()
 			else
 				R.data = data
+		else if (reagent == VACCINE)
+			R.data = list("antigen" = list())
+
 		R.on_introduced()
 
 		update_total()

--- a/code/modules/virus2/effect/stage_1.dm
+++ b/code/modules/virus2/effect/stage_1.dm
@@ -18,7 +18,7 @@
 
 /datum/disease2/effect/sneeze/activate(var/mob/living/mob)
 	mob.emote("sneeze")
-	if (prob(50))
+	if (prob(50) && isturf(mob.loc))
 		var/obj/effect/decal/cleanable/mucus/M= locate(/obj/effect/decal/cleanable/mucus) in get_turf(mob)
 		if(!M)
 			M = new(get_turf(mob))

--- a/code/modules/virus2/effect/stage_2.dm
+++ b/code/modules/virus2/effect/stage_2.dm
@@ -243,7 +243,7 @@
 	badness = EFFECT_DANGER_ANNOYING
 
 /datum/disease2/effect/viralsputum/activate(var/mob/living/mob)
-	if (prob(30))
+	if (prob(30) && isturf(mob.loc))
 		mob.emote("cough")
 		var/obj/effect/decal/cleanable/blood/viralsputum/D= locate(/obj/effect/decal/cleanable/blood/viralsputum) in get_turf(mob)
 		if(!D)

--- a/code/modules/virus2/items_devices.dm
+++ b/code/modules/virus2/items_devices.dm
@@ -285,10 +285,16 @@ var/list/virusdishes = list()
 	else
 		virusdishes.Remove(src)
 
+/obj/item/weapon/virusdish/open
+	icon_state = "virusdish1"
+
 /obj/item/weapon/virusdish/open/New(loc)
 	..()
 	open = TRUE
 	update_icon()
+
+/obj/item/weapon/virusdish/random/open
+	icon_state = "virusdish1"
 
 /obj/item/weapon/virusdish/random/open/New(loc)
 	..()

--- a/code/modules/virus2/items_devices.dm
+++ b/code/modules/virus2/items_devices.dm
@@ -285,6 +285,16 @@ var/list/virusdishes = list()
 	else
 		virusdishes.Remove(src)
 
+/obj/item/weapon/virusdish/open/New(loc)
+	..()
+	open = TRUE
+	update_icon()
+
+/obj/item/weapon/virusdish/random/open/New(loc)
+	..()
+	open = TRUE
+	update_icon()
+	processing_objects.Add(src)
 
 /obj/item/weapon/virusdish/throw_impact(atom/hit_atom, var/speed, mob/user)
 	..()


### PR DESCRIPTION
[hotfix]
:cl:
* bugfix: Fixed mobs like cockroach being invisible in cages because they appear bellow them. Mobs placed in cages have their plane changed to the default mob plane.
* bugfix: Mice can no longer use the Hide verb when in a cage.
* rscadd: Added some open growth dishes for mappers, both empty and containing a random disease
* rscadd: The round end scoreboard now indicates which disease was spread the most, as well as its symptoms.
* rscadd: Ghosts can now use the pathogen HUD
* rscadd: Cats no longer chase mice while dead or uncounscious. Let them rest in peace.
* rscadd: Mucus or Sputum caused by Coldingtons and Respiratory Putrefaction now only spawn if the mob is on top of a turf (so mice in vents won't spawn any). That should curb the amount of mucus spawning all around the station.
* rscadd: Nanomed plus now has 8 vials to dispense. With the 6 in virology and the 6 in Chemistry that's 20 vials in medbay.
* bugfix: Fixed blank vaccines sometimes mysteriously already containing antigen brewed in other vaccines someplace else.
