### PR TITLE
Adds auto-searching/installing pai for ninja suits

### DIFF
--- a/code/datums/gamemode/role/ninja.dm
+++ b/code/datums/gamemode/role/ninja.dm
@@ -80,6 +80,7 @@
 			to_chat(antag.current, "<span class='danger'>You are currently on a direct course to the station.</span>")
 			to_chat(antag.current, "<span class='userdanger'>Your suit will lose pressure in approximately two minutes.</span>")
 			to_chat(antag.current, "<span class='danger'>Find a way inside before your suit's life support systems give out!</span>")
+			to_chat(antag.current, "<span class='notice'>Your suit's AI card is searching for a personality. You can manually re-start the search with the \"configure pAI\" verb.</span>")
 
 	to_chat(antag.current, "<span class='info'><a HREF='?src=\ref[antag.current];getwiki=[wikiroute]'>(Wiki Guide)</a></span>")
 
@@ -580,6 +581,25 @@ Suit and assorted
 	species_fit = list("Human")
 	species_restricted = list("Human") //only have human sprites :/
 	can_take_pai = 1
+	
+/obj/item/clothing/suit/space/ninja/New()
+	..()
+	
+	var/obj/item/device/paicard/mypai = new /obj/item/device/paicard(src)
+	mypai.name = "SpiderAI device"
+	mypai.overridedownload = TRUE
+	mypai.silent = TRUE
+	mypai.forceMove(src)
+	src.integratedpai = mypai
+	src.verbs += /obj/proc/configure_pai
+	mypai.looking_for_personality = 1
+	paiController.findPAI(mypai)
+	
+/*/obj/item/clothing/suit/space/ninja/Destroy()
+	..()
+	if(integratedpai)
+		remove_pai(integratedpai)
+	integratedpai = null*/
 	
 /obj/item/clothing/suit/space/ninja/apprentice
 	name = "ninja suit"

--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -11,6 +11,8 @@
 	var/mob/living/silicon/pai/pai
 	var/last_ping_time = 0
 	var/ping_cooldown = 5 SECONDS
+	var/overridedownload = FALSE //first-come first-serve cards
+	var/silent = FALSE //doesn't ping for new personalities
 
 /obj/item/device/paicard/New()
 	..()
@@ -176,7 +178,8 @@
 	var/turf/T = get_turf(src.loc)
 	for (var/mob/M in viewers(T))
 		M.show_message("<span class='notice'>[src] flashes a message across its screen, \"Additional personalities available for download.\"</span>", 1, "<span class='notice'>[src] bleeps electronically.</span>", 2)
-		playsound(loc, 'sound/machines/paistartup.ogg', 50, 1)
+		if (!silent)
+			playsound(loc, 'sound/machines/paistartup.ogg', 50, 1)
 		src.overlays += image(icon=icon, icon_state = "pai-off-notify")
 
 /obj/item/device/paicard/proc/removeNotification()

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -85,6 +85,7 @@ var/global/list/reagents_to_log = list(FUEL, PLASMA, PACID, SACID, AMUTATIONTOXI
 	P.forceMove(src)
 	integratedpai = P
 	verbs += /obj/proc/remove_pai
+	verbs += /obj/proc/configure_pai
 
 /obj/attackby(obj/item/weapon/W, mob/user)
 	if(can_take_pai && istype(W, /obj/item/device/paicard))
@@ -179,6 +180,23 @@ var/global/list/reagents_to_log = list(FUEL, PLASMA, PACID, SACID, AMUTATIONTOXI
 	to_chat(M, "You eject \the [integratedpai] from \the [src].")
 	M.put_in_hands(eject_integratedpai_if_present())
 	playsound(src, 'sound/misc/cartridge_out.ogg', 25)
+	
+/obj/proc/configure_pai()
+	set name = "Configure pAI"
+	set category = "Object"
+	set src in range(1)
+
+	var/mob/M = usr
+	if(!M.Adjacent(src))
+		return
+	if(!M.dexterity_check())
+		to_chat(usr, "You don't have the dexterity to do this!")
+		return
+	if(M.incapacitated())
+		to_chat(M, "You can't do that while you're incapacitated!")
+		return
+
+	integratedpai.attack_self(M)
 
 /obj/proc/eject_integratedpai_if_present()
 	if(integratedpai)

--- a/code/modules/mob/living/silicon/pai/recruit.dm
+++ b/code/modules/mob/living/silicon/pai/recruit.dm
@@ -18,6 +18,28 @@ var/datum/paiController/paiController			// Global handler for pAI candidates
 
 	var/askDelay = 10 * 60 * 1	// One minute [ms * sec * min]
 
+/datum/paiController/proc/installpersonality(var/datum/paiCandidate/candidate,var/obj/item/device/paicard/card)
+	if(card.pai)
+		return
+	if(istype(card,/obj/item/device/paicard) && istype(candidate,/datum/paiCandidate))
+		var/mob/living/silicon/pai/pai = new(card)
+		if(!candidate.name)
+			pai.name = pick(ninja_names)
+		else
+			pai.name = candidate.name
+		pai.real_name = pai.name
+		pai.key = candidate.key
+
+		card.setPersonality(pai)
+		card.looking_for_personality = 0
+
+		//RemoveAllFactionIcons(card.pai.mind)
+
+		pai_candidates -= candidate
+		for(var/obj/item/device/paicard/p in paicard_list)
+			if(!p.pai && !pai_candidates.len)
+				p.removeNotification()
+
 /datum/paiController/Topic(href, href_list[])
 	if("signup" in href_list)
 		var/mob/dead/observer/O = usr
@@ -31,27 +53,8 @@ var/datum/paiController/paiController			// Global handler for pAI candidates
 	if(href_list["download"])
 		var/datum/paiCandidate/candidate = locate(href_list["candidate"])
 		var/obj/item/device/paicard/card = locate(href_list["device"])
-		if(card.pai)
-			return
-		if(istype(card,/obj/item/device/paicard) && istype(candidate,/datum/paiCandidate))
-			var/mob/living/silicon/pai/pai = new(card)
-			if(!candidate.name)
-				pai.name = pick(ninja_names)
-			else
-				pai.name = candidate.name
-			pai.real_name = pai.name
-			pai.key = candidate.key
-
-			card.setPersonality(pai)
-			card.looking_for_personality = 0
-
-			//RemoveAllFactionIcons(card.pai.mind)
-
-			pai_candidates -= candidate
-			for(var/obj/item/device/paicard/p in paicard_list)
-				if(!p.pai && !pai_candidates.len)
-					p.removeNotification()
-			usr << browse(null, "window=findPai")
+		installpersonality(candidate,card)
+		usr << browse(null, "window=findPai")
 
 	if(href_list["new"])
 		var/datum/paiCandidate/candidate = locate(href_list["candidate"])
@@ -94,7 +97,11 @@ var/datum/paiController/paiController			// Global handler for pAI candidates
 					candidate.ready = 1
 					for(var/obj/item/device/paicard/p in paicard_list)
 						if(!p.pai)
-							p.alertUpdate()
+							if(p.overridedownload)
+								installpersonality(candidate,p)
+								p.overridedownload = FALSE
+							else
+								p.alertUpdate()
 				usr << browse(null, "window=paiRecruit")
 				return
 		recruitWindow(usr)
@@ -197,7 +204,10 @@ var/datum/paiController/paiController			// Global handler for pAI candidates
 	for(var/mob/dead/observer/O in player_list) // We handle polling ourselves.
 		if(O.client && get_role_desire_str(O.client.prefs.roles[ROLE_PAI]) != "Never")
 			if(check_recruit(O))
-				to_chat(O, "<span class='recruit'>A pAI card is looking for personalities. (<a href='?src=\ref[src];signup=1'>Sign Up</a> | <a href='?src=\ref[O];jump=\ref[p]'>Teleport</a>)</span>")
+				if(p.overridedownload)
+					to_chat(O, "<span class='recruit'>A special pAI card is looking for an auto-installation personality. (<a href='?src=\ref[src];signup=1'>Claim</a> | <a href='?src=\ref[O];jump=\ref[p]'>Teleport</a>)</span>")
+				else
+					to_chat(O, "<span class='recruit'>A pAI card is looking for personalities. (<a href='?src=\ref[src];signup=1'>Sign Up</a> | <a href='?src=\ref[O];jump=\ref[p]'>Teleport</a>)</span>")
 				//question(O.client)
 
 /datum/paiController/proc/check_recruit(var/mob/dead/observer/O)


### PR DESCRIPTION
system:
- pAI cards now have a `overridedownload` var that instantly takes whoever signs up first.
- Doing so toggles the var. Am considering to just turn it into a UI option for the card.
- Does NOT insta-pull personalities that already signed up.
- *Does* insta-pull the first personality that signs up for *any* pAI card once the ninja card starts recruiting
- Integrated pAIs can now be configured with a seperate verb **that is added alongside the 'remove pai' verb**, not sure if that should always be available since it would allow people to ninja-wipe slotted pAIs
- New `silent` var to make cards not ping when there's a new personality available if their old one dies (muh stelth)

ninja:
 - Ninjas now spawn with a pAI card installed in their suit that is both `overridedownload` and `silent`
 - Card will poll ghosts as soon as the ninja spawns
 - Card can be configured by verb, but not removed (the pAI is bound to the suit)

related issues:
 - All pAI cards only poll *once* as far as I can tell. Even though there's a poll cooldown var. Meaning that if a ninja spawns and there's no ghosts at the time, literally nobody will ever see the sign-up prompt.
 - Role datum recruitment system isn't used for these? Why do they have their own snowflake recruitment system?

I think a better implementation of this would be to add a pAI poll to the initial ninja spawn, a sort of dual role selection thing, but that's outside the scope of this PR.
If this passes I'm probably going to work on card-specific software suites.

🆑 
 - rscadd: Space ninjas now spawn with active pAI cards in their suits