### PR TITLE
Fixed speech disabilities not working sometimes

### DIFF
--- a/code/game/dna/genes/gene.dm
+++ b/code/game/dna/genes/gene.dm
@@ -69,8 +69,7 @@
 /**
 * Called when the mob says shit
 */
-/datum/dna/gene/proc/OnSay(var/mob/M, var/message)
-	return message
+/datum/dna/gene/proc/OnSay(var/mob/M, var/datum/speech/message)
 
 /**
 * Called after the mob runs update_icons.

--- a/code/modules/mob/living/carbon/human/plasmaman/species.dm
+++ b/code/modules/mob/living/carbon/human/plasmaman/species.dm
@@ -35,6 +35,7 @@
 /datum/species/plasmaman/handle_speech(var/datum/speech/speech, mob/living/carbon/human/H)
 	speech.message = replacetext(speech.message, "s", "s-s") //not using stutter("s") because it likes adding more s's.
 	speech.message = replacetext(speech.message, "s-ss-s", "ss-ss") //asshole shows up as ass-sshole
+	..()
 
 /datum/species/plasmaman/equip(var/mob/living/carbon/human/H)
 	H.fire_sprite = "Plasmaman"


### PR DESCRIPTION
This was a bitch to figure out.
the base `OnSay()` would return a non-null value which made the loop return early.

:cl:
 * bugfix: Fixed speech disabilities not working if other genes were activated or the dude was a plasmaman.