### PR TITLE
Increasing the danger rating of Toxin Sublimation

### DIFF
--- a/code/modules/virus2/effect/stage_4.dm
+++ b/code/modules/virus2/effect/stage_4.dm
@@ -412,7 +412,7 @@
 	name = "Toxin Sublimation"
 	desc = "Converts the infected's pores and respiratory organs to synthesize Plasma gas."
 	stage = 4
-	badness = EFFECT_DANGER_HARMFUL
+	badness = EFFECT_DANGER_DEADLY
 
 /datum/disease2/effect/plasma/activate(var/mob/living/mob)
 	//var/src = mob


### PR DESCRIPTION
:cl:
* tweak: Toxin Sublimation, the disease symptom that causes you to emit plasma, has had its danger rating upped from 4 to 5, due to its high station-ruining potential. This makes it much less likely to appear in loose catbeasts, and won't let it appear at all in maintenance mice.