### PR TITLE
Fixed Arachnogenesis Effect being rated as Danger 3 instead of 4

### DIFF
--- a/code/modules/virus2/effect/stage_4.dm
+++ b/code/modules/virus2/effect/stage_4.dm
@@ -377,7 +377,7 @@
 	name = "Arachnogenesis Effect"
 	desc = "Converts the infected's stomach to begin producing creatures of the arachnid variety."
 	stage = 4
-	badness = EFFECT_DANGER_HINDRANCE
+	badness = EFFECT_DANGER_HARMFUL
 	var/spawn_type=/mob/living/simple_animal/hostile/giant_spider/spiderling
 	var/spawn_name="spiderling"
 


### PR DESCRIPTION
:cl:
* bugfix: Fixed Arachnogenesis Effect being rated as Danger 3 instead of 4. This change means it can never appear in maintenance mice again.