### PR TITLE
Made it a bit less trivial for Virologist to essentially create panacea

### DIFF
--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -645,7 +645,13 @@ var/global/list/disease2_list = list()
 	clean_global_log()
 	subID = rand(0,9999)
 	var/old_dat = get_antigen_string()
-	roll_antigen()
+	var/list/anti = list(
+		ANTIGEN_BLOOD	= 2,
+		ANTIGEN_COMMON	= 2,
+		ANTIGEN_RARE	= 1,
+		ANTIGEN_ALIEN	= 0,
+		)
+	roll_antigen(anti)
 	log_debug("[form] [uniqueID]-[subID] has mutated its antigen from [old_dat] to [get_antigen_string()].")
 	log += "<br />[timestamp()] Mutated antigen [old_dat] into [get_antigen_string()]."
 	update_global_log()

--- a/code/modules/virus2/items_devices.dm
+++ b/code/modules/virus2/items_devices.dm
@@ -265,9 +265,9 @@ var/list/virusdishes = list()
 		var/virus_choice = pick(subtypesof(/datum/disease2/disease))
 		contained_virus = new virus_choice
 		var/list/anti = list(
-			ANTIGEN_BLOOD	= 2,
-			ANTIGEN_COMMON	= 2,
-			ANTIGEN_RARE	= 1,
+			ANTIGEN_BLOOD	= 1,
+			ANTIGEN_COMMON	= 1,
+			ANTIGEN_RARE	= 0,
 			ANTIGEN_ALIEN	= 0,
 			)
 		var/list/bad = list(


### PR DESCRIPTION
:cl:
* tweak: Growth dishes from Virology or Cargo can now only spawn with the blood (OABRh) and common (QUV) antibodies.
* tweak: When mutating a disease's antigen by incubating it with radium, the new antigen will be picked among a weighted list that no longer includes the X, Y and Z antigen.