### PR TITLE
DEATH SQUAD gear tweaks & leader ID fix

### DIFF
--- a/code/game/striketeams/nanotrasen_deathsquad.dm
+++ b/code/game/striketeams/nanotrasen_deathsquad.dm
@@ -122,10 +122,15 @@
 
 	var/obj/item/weapon/card/id/W = new(src)
 	W.name = "[real_name]'s ID Card"
-	W.icon_state = "centcom"
-	W.access = get_centcom_access("Death Commando")
-	W.icon_state = "deathsquad"
-	W.assignment = "Death Commando"
+	if(leader)
+		W.access = get_centcom_access("Creed Commander")
+		W.icon_state = "creed"
+		W.assignment = "Creed Commander"
+	else
+		W.icon_state = "centcom"
+		W.access = get_centcom_access("Death Commando")
+		W.icon_state = "deathsquad"
+		W.assignment = "Death Commando"
 	W.registered_name = real_name
 	equip_to_slot_or_del(W, slot_wear_id)
 

--- a/code/game/striketeams/nanotrasen_deathsquad.dm
+++ b/code/game/striketeams/nanotrasen_deathsquad.dm
@@ -73,8 +73,6 @@
 		equip_to_slot_or_del(uni, slot_w_uniform)
 	else
 		equip_to_slot_or_del(new /obj/item/clothing/under/deathsquad(src), slot_w_uniform)
-	equip_to_slot_or_del(new /obj/item/weapon/melee/energy/sword(src), slot_l_store)
-	equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/mateba(src), slot_belt)
 
 	//Shoes & gloves
 	equip_to_slot_or_del(new /obj/item/clothing/shoes/magboots/deathsquad(src), slot_shoes)
@@ -92,7 +90,7 @@
 	//Backpack
 	equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/security(src), slot_back)
 	equip_to_slot_or_del(new /obj/item/weapon/storage/box(src), slot_in_backpack)
-	equip_to_slot_or_del(new /obj/item/ammo_storage/box/a357(src), slot_in_backpack)
+	equip_to_slot_or_del(new /obj/item/ammo_storage/speedloader/a357(src), slot_in_backpack)
 	equip_to_slot_or_del(new /obj/item/weapon/storage/firstaid/regular(src), slot_in_backpack)
 	equip_to_slot_or_del(new /obj/item/weapon/pinpointer(src), slot_in_backpack)
 	equip_to_slot_or_del(new /obj/item/weapon/shield/energy(src), slot_in_backpack)
@@ -101,7 +99,10 @@
 	else
 		equip_to_slot_or_del(new /obj/item/weapon/plastique(src), slot_in_backpack)
 
-	put_in_hands(new /obj/item/weapon/gun/energy/pulse_rifle(src))
+	//Other equipment and accessories
+	equip_to_slot_or_del(new /obj/item/weapon/gun/energy/pulse_rifle(src), slot_belt)
+	equip_accessory(src, /obj/item/clothing/accessory/holster/handgun/preloaded/mateba, /obj/item/clothing/under, 5)
+	equip_accessory(src, /obj/item/clothing/accessory/holster/knife/boot/preloaded/energysword, /obj/item/clothing/shoes, 5)
 
 
 	var/obj/item/weapon/implant/loyalty/L = new/obj/item/weapon/implant/loyalty(src)//Here you go Deuryn

--- a/code/game/striketeams/nanotrasen_deathsquad.dm
+++ b/code/game/striketeams/nanotrasen_deathsquad.dm
@@ -125,7 +125,7 @@
 	if(leader)
 		W.access = get_centcom_access("Creed Commander")
 		W.icon_state = "creed"
-		W.assignment = "Creed Commander"
+		W.assignment = "Death Commander"
 	else
 		W.access = get_centcom_access("Death Commando")
 		W.icon_state = "deathsquad"

--- a/code/game/striketeams/nanotrasen_deathsquad.dm
+++ b/code/game/striketeams/nanotrasen_deathsquad.dm
@@ -127,7 +127,6 @@
 		W.icon_state = "creed"
 		W.assignment = "Creed Commander"
 	else
-		W.icon_state = "centcom"
 		W.access = get_centcom_access("Death Commando")
 		W.icon_state = "deathsquad"
 		W.assignment = "Death Commando"

--- a/code/modules/clothing/accessories/holster.dm
+++ b/code/modules/clothing/accessories/holster.dm
@@ -146,6 +146,18 @@
 	name = "waistband holster"
 	desc = "A handgun holster that clips to a suit. Made of expensive leather."
 	_color = "holster_low"
+	
+/obj/item/clothing/accessory/holster/handgun/preloaded
+	var/gun_type
+
+/obj/item/clothing/accessory/holster/handgun/preloaded/New()
+	..()
+	if(!holstered)
+		holstered = new gun_type(src)
+		update_icon()
+		
+/obj/item/clothing/accessory/holster/handgun/preloaded/mateba
+	gun_type = /obj/item/weapon/gun/projectile/mateba
 
 //
 // Knives
@@ -218,3 +230,6 @@
 
 /obj/item/clothing/accessory/holster/knife/boot/preloaded/skinning
 	knife_type = /obj/item/weapon/kitchen/utensil/knife/skinning
+
+/obj/item/clothing/accessory/holster/knife/boot/preloaded/energysword
+	knife_type = /obj/item/weapon/melee/energy/sword


### PR DESCRIPTION
+ mateba now starts holstered in holster on uniform
+ pulse rifle spawns on belt instead of in-hand
+ esword spawns in boot knife holster
+ .357 speedloader instead of ammo box

🆑 
 - tweak: Certain striketeams that may or may not exist now come with gun and sword holsters