### PR TITLE
Fixed spiky skin syndrome causing infected people to get hurt when checking themselves for injuries

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -515,7 +515,7 @@
 /mob/living/carbon/CheckSlip(slip_on_walking = FALSE, overlay_type = TURF_WET_WATER, slip_on_magbooties = FALSE)
 	var/walking_factor = (!slip_on_walking && m_intent == M_INTENT_WALK)
 	return (on_foot()) && !locked_to && !lying && !unslippable && !walking_factor
-	
+
 /mob/living/carbon/teleport_to(var/atom/A)
 	var/last_slip_value = src.unslippable
 	src.unslippable = 1
@@ -604,6 +604,8 @@
 							return E
 
 /mob/living/carbon/proc/handle_symptom_on_touch(var/toucher, var/touched, var/touch_type)
+	if (toucher == touched)
+		return
 	if(virus2.len)
 		for(var/I in virus2)
 			var/datum/disease2/disease/D = virus2[I]


### PR DESCRIPTION
Fixes #23553

:cl:
* bugfix: Fixed spiky skin syndrome causing infected people to get hurt when checking themselves for injuries.