### PR TITLE
Halved the chance of being sick upon spawning, and slashed the infectability of those diseases

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -297,8 +297,8 @@
 			H.dna.GiveRandomSE(notflags = GENE_UNNATURAL,genetype = GENETYPE_GOOD)
 
 /mob/new_player/proc/DiseaseCarrierCheck(var/mob/living/carbon/human/H)
-	// 10% of players are joining the station with some minor disease
-	if(prob(10))
+	// 5% of players are joining the station with some minor disease
+	if(prob(5))
 		var/virus_choice = pick(subtypesof(/datum/disease2/disease))
 		var/datum/disease2/disease/D = new virus_choice
 

--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -144,6 +144,8 @@ var/global/list/disease2_list = list()
 	//slightly randomized infection chance
 	var/variance = initial(infectionchance)/10
 	infectionchance = rand(initial(infectionchance)-variance,initial(infectionchance)+variance)
+	if (origin == "New Player")
+		infectionchance = min(infectionchance,20)
 	infectionchance_base = infectionchance
 
 	//cosmetic petri dish stuff - if set beforehand, will not be randomized


### PR DESCRIPTION
:cl:
* tweak: Reduced the chance of being sick upon spawn from 10% to 5%
* tweak: Diseases that spawn in new players now have at most 20% infectability, highly reducing their contamination potential.
