### PR TITLE
Removes grue from the possible rolls of rambler

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -92,7 +92,7 @@
 	initialize_basic_NPC_components()
 
 /mob/living/carbon/human/frankenstein/New(var/new_loc, delay_ready_dna = 0) //Just fuck my shit up: the mob
-	var/list/valid_species = (all_species - list("Krampus", "Horror"))
+	var/list/valid_species = (all_species - list("Krampus", "Horror", "Grue"))
 
 	var/datum/species/new_species = all_species[pick(valid_species)]
 	..(new_loc, new_species.name)


### PR DESCRIPTION
hyperspeed 200 health obnoxiousness is no fun. Their spells need looking at too, as you can just spam the "whooooo" sound with their light-consumption spell for yet more ear-rape.

:cl:
 * tweak: Removes Grue from the possible frankenstein selection