### PR TITLE
Removes chillwax making you fall asleep at random

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1441,9 +1441,6 @@
 			H.emote(pick("stare", "giggle"), null, null, TRUE)
 		if(prob(5))
 			to_chat(H, "<span class='notice'>[pick("You feel at peace with the world.","Everyone is nice, everything is awesome.","You feel high and ecstatic.")]</span>")
-		if(prob(2))
-			to_chat(H, "<span class='notice'>You doze off for a second.</span>")
-			H.sleeping += 1
 		..()
 
 /datum/reagent/sacid


### PR DESCRIPTION
For a prob(2), it sure fires a lot, and considering the amount of ways this enters your system seemingly by magic (The incense that seems to ignore masks, and the rambler instrument that DOES ignore masks) it becomes very obnoxious, and detracts from the point of the chem (to pacify)

:cl:
 * tweak: Chillwax no longer makes you fall asleep randomly.