### PR TITLE
marauders now spawn with super cells

### DIFF
--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -264,3 +264,6 @@
 					<b>Thrusters:</b> [thrusters?"on":"off"]
 					"}
 	return output
+
+/obj/mecha/combat/marauder/add_cell()
+	..(new /obj/item/weapon/cell/super)


### PR DESCRIPTION
closes  #23585

:cl:
 * tweak: Marauders, seraphs, and other derivative mechs now spawn with a super cell.