### PR TITLE
Tiered catbeast diseases

### DIFF
--- a/__DEFINES/subsystem.dm
+++ b/__DEFINES/subsystem.dm
@@ -53,6 +53,7 @@
 #define SS_WAIT_MACHINERY           2 SECONDS //TODO move the rest of these to defines
 #define SS_WAIT_FAST_MACHINERY      0.7 SECONDS
 #define SS_WAIT_FAST_OBJECTS        0.5 SECONDS
+#define SS_WAIT_TICKER              2 SECONDS
 
 #define SS_DISPLAY_GARBAGE        -100
 #define SS_DISPLAY_AIR            -90

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -4,7 +4,7 @@ var/datum/subsystem/ticker/SSticker
 /datum/subsystem/ticker
 	name          = "Ticker"
 	init_order    = SS_INIT_TICKER
-	wait          = 2 SECONDS
+	wait          = SS_WAIT_TICKER
 	flags         = SS_KEEP_TIMING
 	priority      = SS_PRIORITY_TICKER
 	display_order = SS_DISPLAY_TICKER

--- a/code/datums/gamemode/role/catbeast.dm
+++ b/code/datums/gamemode/role/catbeast.dm
@@ -9,6 +9,7 @@
 	var/threat_generated = 0
 	var/threat_level_inflated = 0
 	var/list/areas_defiled = list()
+	var/current_disease_tier = 1
 
 /datum/role/catbeast/Greet()
 	to_chat(antag.current, "<B><span class='warning'>You are a mangy catbeast!</span></B>")
@@ -22,7 +23,7 @@
 	H.my_appearance.s_tone = CATBEASTBLACK
 	H.dna.ResetUI()
 	equip_catbeast(H)
-	infect_catbeast(H)
+	infect_catbeast_tier1(H)
 	H.regenerate_icons()
 	var/datum/gamemode/dynamic/D = ticker.mode
 	if(istype(D))
@@ -37,7 +38,33 @@ var/list/catbeast_names = list("Meowth","Fluffy","Subject 246","Experiment 35a",
 						"Lurks-In-Shadows","Eartha Kitt","Target Practice","Fresh Meat","Ca'thulu","Furry Fury","Vore-Strikes-Back","Killing Machine","Uncle Tom",
 						"Nine Lives", "Bad Luck", "Siamese Sam", "Tom Tabby", "Hairball", "Throws-Dice-Poorly", "Wizard Apprentice", "Lynch Lynx", "Felix")
 
-/datum/role/catbeast/proc/infect_catbeast(var/mob/living/carbon/human/H)
+/datum/role/catbeast/proc/infect_catbeast(mob/living/carbon/human/H, str, rob, list/anti, list/bad)
+	var/virus_choice = pick(subtypesof(/datum/disease2/disease))
+	var/datum/disease2/disease/D1 = new virus_choice
+	D1.origin = "Loose Catbeast"
+	D1.makerandom(str, rob, anti, bad)
+	H.infect_disease2(D1, 1, "Loose Catbeast")
+	antag.store_memory(D1.get_info())
+	antag.store_memory("<hr>")
+
+/datum/role/catbeast/proc/infect_catbeast_tier1(mob/living/carbon/human/H)
+	var/list/anti = list(
+		ANTIGEN_BLOOD	= 1,
+		ANTIGEN_COMMON	= 1,
+		ANTIGEN_RARE	= 0,
+		ANTIGEN_ALIEN	= 0,
+		)
+	var/list/bad = list(
+		EFFECT_DANGER_HELPFUL	= 0,
+		EFFECT_DANGER_FLAVOR	= 1,
+		EFFECT_DANGER_ANNOYING	= 1,
+		EFFECT_DANGER_HINDRANCE	= 0,
+		EFFECT_DANGER_HARMFUL	= 0,
+		EFFECT_DANGER_DEADLY	= 0,
+		)
+	infect_catbeast(H, list(30,35), list(0,50), anti, bad)
+
+/datum/role/catbeast/proc/infect_catbeast_tier2(mob/living/carbon/human/H)
 	var/list/anti = list(
 		ANTIGEN_BLOOD	= 0,
 		ANTIGEN_COMMON	= 1,
@@ -46,28 +73,32 @@ var/list/catbeast_names = list("Meowth","Fluffy","Subject 246","Experiment 35a",
 		)
 	var/list/bad = list(
 		EFFECT_DANGER_HELPFUL	= 0,
-		EFFECT_DANGER_FLAVOR	= 2,
-		EFFECT_DANGER_ANNOYING	= 4,
-		EFFECT_DANGER_HINDRANCE	= 6,
-		EFFECT_DANGER_HARMFUL	= 6,
+		EFFECT_DANGER_FLAVOR	= 1,
+		EFFECT_DANGER_ANNOYING	= 2,
+		EFFECT_DANGER_HINDRANCE	= 3,
+		EFFECT_DANGER_HARMFUL	= 3,
+		EFFECT_DANGER_DEADLY	= 0,
+		)
+
+	infect_catbeast(H, list(40,60), list(40, 60), anti, bad)
+
+/datum/role/catbeast/proc/infect_catbeast_tier3(mob/living/carbon/human/H)
+	var/list/anti = list(
+		ANTIGEN_BLOOD	= 0,
+		ANTIGEN_COMMON	= 0,
+		ANTIGEN_RARE	= 1,
+		ANTIGEN_ALIEN	= 0,
+		)
+	var/list/bad = list(
+		EFFECT_DANGER_HELPFUL	= 0,
+		EFFECT_DANGER_FLAVOR	= 0,
+		EFFECT_DANGER_ANNOYING	= 1,
+		EFFECT_DANGER_HINDRANCE	= 2,
+		EFFECT_DANGER_HARMFUL	= 3,
 		EFFECT_DANGER_DEADLY	= 1,
 		)
 
-	var/first_virus_choice = pick(subtypesof(/datum/disease2/disease))
-	var/datum/disease2/disease/D1 = new first_virus_choice
-	D1.origin = "Loose Catbeast"
-	D1.makerandom(list(60,90),list(50,90),anti,bad,null)
-	H.infect_disease2(D1,1, "Loose Catbeast")
-	var/second_virus_choice = pick(subtypesof(/datum/disease2/disease))
-	var/datum/disease2/disease/D2 = new second_virus_choice
-	D2.origin = "Loose Catbeast"
-	D2.makerandom(list(60,90),list(50,90),anti,bad,null)
-	H.infect_disease2(D2,1, "Loose Catbeast")
-	antag.store_memory("<hr>")
-	antag.store_memory(D1.get_info())
-	antag.store_memory("<hr>")
-	antag.store_memory(D2.get_info())
-	antag.store_memory("<hr>")
+	infect_catbeast(H, list(60,90), list(50,90), anti, bad)
 
 /proc/equip_catbeast(var/mob/living/carbon/human/H)
 	var/list/shirts = list(/obj/item/clothing/under/overalls,/obj/item/clothing/under/schoolgirl,/obj/item/clothing/under/darkholme,/obj/item/clothing/under/maid,
@@ -93,19 +124,38 @@ var/list/catbeast_names = list("Meowth","Fluffy","Subject 246","Experiment 35a",
 #define SURVIVAL_THREAT 1
 #define DEFILE_THREAT 0.75
 
+#define AREAS_THRESHOLD_TIER2 20
+#define TICKS_THRESHOLD_TIER2 (5 MINUTES)/20
+
+#define AREAS_THRESHOLD_TIER3 30
+#define TICKS_THRESHOLD_TIER3 (10 MINUTES)/20
+
 /datum/role/catbeast/process()
 	..()
-	if(!iscatbeast(antag.current))
-		return
+	if(!iscatbeast(antag.current) || antag.current.gcDestroyed || antag.current.stat == DEAD)
+		return // dead or destroyed
 	var/area/A = OnStation()
-	if(antag.current.stat!=DEAD && A) //Not dead or unconscious or offstation
-		ticks_survived++
-		if(!(ticks_survived % 10) && ticks_survived < 150) //every 20 seconds, for 5 minutes
-			increment_threat(SURVIVAL_THREAT)
-		if(!(A in areas_defiled))
-			increment_threat(DEFILE_THREAT)
-			areas_defiled.Add(A)
-			to_chat(antag.current,"<span class='notice'>You have defiled [A.name] with your presence.")
+	if(!A)
+		return // offstation
+	ticks_survived++
+	if(!(ticks_survived % 10) && ticks_survived < 150) //every 20 seconds, for 5 minutes
+		increment_threat(SURVIVAL_THREAT)
+	if(!(A in areas_defiled))
+		increment_threat(DEFILE_THREAT)
+		areas_defiled.Add(A)
+		to_chat(antag.current,"<span class='notice'>You have defiled [A.name] with your presence.")
+	switch(current_disease_tier)
+		if(2)
+			if((areas_defiled.len >= AREAS_THRESHOLD_TIER3) && ticks_survived > TICKS_THRESHOLD_TIER3)
+				infect_catbeast_tier3(antag.current)
+				to_chat(antag.current, "<span class='danger'>You feel very sick!</span>")
+				current_disease_tier = 3
+		if(1)
+			if((areas_defiled.len >= AREAS_THRESHOLD_TIER2) && ticks_survived > TICKS_THRESHOLD_TIER2)
+				infect_catbeast_tier2(antag.current)
+				to_chat(antag.current, "<span class='danger'>You feel sick!</span>")
+				current_disease_tier = 2
+
 
 /datum/role/catbeast/proc/OnStation()
 	if(antag.current.z != STATION_Z)
@@ -131,3 +181,12 @@ var/list/catbeast_names = list("Meowth","Fluffy","Subject 246","Experiment 35a",
 /datum/role/catbeast/GetScoreboard()
 	. = ..()
 	. += "The catbeast survived on station for [ticks_survived*2] seconds, defiled [areas_defiled.len] rooms, and generated [threat_generated] threat!<BR>"
+
+#undef SURVIVAL_THREAT
+#undef DEFILE_THREAT
+
+#undef AREAS_THRESHOLD_TIER2
+#undef TICKS_THRESHOLD_TIER2
+
+#undef AREAS_THRESHOLD_TIER3
+#undef TICKS_THRESHOLD_TIER3

--- a/code/datums/gamemode/role/catbeast.dm
+++ b/code/datums/gamemode/role/catbeast.dm
@@ -146,12 +146,12 @@ var/list/catbeast_names = list("Meowth","Fluffy","Subject 246","Experiment 35a",
 		to_chat(antag.current,"<span class='notice'>You have defiled [A.name] with your presence.")
 	switch(current_disease_tier)
 		if(2)
-			if((areas_defiled.len >= AREAS_THRESHOLD_TIER3) && ticks_survived > (TICKS_THRESHOLD_TIER3)/2 SECONDS)) // 2 SECONDS is /datum/subsystem/ticker/wait
+			if((areas_defiled.len >= AREAS_THRESHOLD_TIER3) && ticks_survived > (TICKS_THRESHOLD_TIER3/SS_WAIT_TICKER))
 				infect_catbeast_tier3(antag.current)
 				to_chat(antag.current, "<span class='danger'>You feel very sick!</span>")
 				current_disease_tier = 3
 		if(1)
-			if((areas_defiled.len >= AREAS_THRESHOLD_TIER2) && ticks_survived > (TICKS_THRESHOLD_TIER2)/2 SECONDS)) // 2 SECONDS is /datum/subsystem/ticker/wait
+			if((areas_defiled.len >= AREAS_THRESHOLD_TIER2) && ticks_survived > (TICKS_THRESHOLD_TIER2/SS_WAIT_TICKER))
 				infect_catbeast_tier2(antag.current)
 				to_chat(antag.current, "<span class='danger'>You feel sick!</span>")
 				current_disease_tier = 2

--- a/code/datums/gamemode/role/catbeast.dm
+++ b/code/datums/gamemode/role/catbeast.dm
@@ -125,10 +125,10 @@ var/list/catbeast_names = list("Meowth","Fluffy","Subject 246","Experiment 35a",
 #define DEFILE_THREAT 0.75
 
 #define AREAS_THRESHOLD_TIER2 20
-#define TICKS_THRESHOLD_TIER2 (5 MINUTES)/20
+#define TICKS_THRESHOLD_TIER2 5 MINUTES
 
 #define AREAS_THRESHOLD_TIER3 30
-#define TICKS_THRESHOLD_TIER3 (10 MINUTES)/20
+#define TICKS_THRESHOLD_TIER3 10 MINUTES
 
 /datum/role/catbeast/process()
 	..()
@@ -146,12 +146,12 @@ var/list/catbeast_names = list("Meowth","Fluffy","Subject 246","Experiment 35a",
 		to_chat(antag.current,"<span class='notice'>You have defiled [A.name] with your presence.")
 	switch(current_disease_tier)
 		if(2)
-			if((areas_defiled.len >= AREAS_THRESHOLD_TIER3) && ticks_survived > TICKS_THRESHOLD_TIER3)
+			if((areas_defiled.len >= AREAS_THRESHOLD_TIER3) && ticks_survived > (TICKS_THRESHOLD_TIER3)/2 SECONDS)) // 2 SECONDS is /datum/subsystem/ticker/wait
 				infect_catbeast_tier3(antag.current)
 				to_chat(antag.current, "<span class='danger'>You feel very sick!</span>")
 				current_disease_tier = 3
 		if(1)
-			if((areas_defiled.len >= AREAS_THRESHOLD_TIER2) && ticks_survived > TICKS_THRESHOLD_TIER2)
+			if((areas_defiled.len >= AREAS_THRESHOLD_TIER2) && ticks_survived > (TICKS_THRESHOLD_TIER2)/2 SECONDS)) // 2 SECONDS is /datum/subsystem/ticker/wait
 				infect_catbeast_tier2(antag.current)
 				to_chat(antag.current, "<span class='danger'>You feel sick!</span>")
 				current_disease_tier = 2


### PR DESCRIPTION
The idea is that the crew should only be punished with GIGA AIDS if they let the catbeast live for too long, rather than being punished for interacting with it at all.

:cl:
 * tweak: Loose catbeasts only have mildly annoying diseases when they arrive. As they survive longer and defile more areas they get up to two more (increasingly deadly) diseases.