### PR TITLE
Tweaked Melisso-Emeto Syndrome to basically allow the syndrome to make you cough up bees instead of just making you fat.

### DIFF
--- a/code/modules/virus2/effect/stage_1.dm
+++ b/code/modules/virus2/effect/stage_1.dm
@@ -157,16 +157,14 @@
 	if (mob.reagents.get_reagent_amount(HONEY) < 10+multiplier*2)
 		mob.reagents.add_reagent(HONEY, multiplier)
 
-	if((mob.reagents.get_reagent_amount(HONEY)> 10) && prob(multiplier*4))
+	if(prob(5))
 		to_chat(mob, "<span class='warning'>You feel a buzzing in your throat</span>")
-
 
 		spawn(5 SECONDS)
 			var/turf/simulated/T = get_turf(mob)
 			if(prob(50))
-				playsound(T, 'sound/effects/splat.ogg', 50, 1)
-				mob.visible_message("<span class='warning'>[mob] spits out a bee!</span>","<span class='danger'>You throw up a bee!</span>")
-				T.add_vomit_floor(mob, 1, 1, 1)
+				mob.audible_cough()
+				mob.visible_message("<span class='warning'>[mob] coughs out a bee!</span>","<span class='danger'>You cough up a bee!</span>")
 			for(var/i = 0 to multiplier)
 				var/bee_type = pick(
 					100;/mob/living/simple_animal/bee/adminSpawned,
@@ -228,7 +226,7 @@
 			continue
 		else
 			nearest_mob = other_mob
-	
+
 	if (!nearest_mob)
 		return 1
 

--- a/code/modules/virus2/effect/stage_1.dm
+++ b/code/modules/virus2/effect/stage_1.dm
@@ -157,7 +157,7 @@
 	if (mob.reagents.get_reagent_amount(HONEY) < 10+multiplier*2)
 		mob.reagents.add_reagent(HONEY, multiplier)
 
-	if(prob(5))
+	if(prob(4*multiplier))
 		to_chat(mob, "<span class='warning'>You feel a buzzing in your throat</span>")
 
 		spawn(5 SECONDS)

--- a/code/modules/virus2/effect/stage_1.dm
+++ b/code/modules/virus2/effect/stage_1.dm
@@ -147,8 +147,8 @@
 
 /datum/disease2/effect/bee_vomit
 	name = "Melisso-Emeto Syndrome"
-	desc = "Converts the lungs of the infected into a bee-hive, giving the infected a steady drip of honey in exchange of vomiting up a bee every so often."
-	encyclopedia = "The higher the symptom strength, the more honey can be accumulated. While Honey is a great healing reagent, it is also high on nutrients. Expect to become fat quickly.."
+	desc = "Converts the lungs of the infected into a bee-hive."
+	encyclopedia = "Giving the infected a steady drip of honey in exchange of coughing up a bee every so often. The higher the symptom strength, the more honey is generated, and the more bees will be coughed up and more often as well. While Honey is a great healing reagent, it is also high on nutrients. Expect to become fat quickly.."
 	stage = 1
 	badness = EFFECT_DANGER_ANNOYING
 	max_multiplier = 10


### PR DESCRIPTION
:cl:
* tweak: Melisso-Emeto Syndrome's chance of making you cough up bees no longer depends of how much honey you have in you. As it stood, the formula combined with the speed at which honey metabolizes made it so you never cough up any bees at all.