### PR TITLE
Vampire ruleset tweaks

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -87,12 +87,12 @@
 	role_category = /datum/role/vampire
 	protected_from_jobs = list("Security Officer", "Warden","Merchant", "Head of Personnel", "Detective", "Head of Security", "Captain")
 	restricted_from_jobs = list("AI","Cyborg","Mobile MMI", "Chaplain")
-	enemy_jobs = list("Security Officer","Detective","Head of Security", "Captain")
-	required_enemies = list(1,1,0,0,0,0,0,0,0,0)
+	enemy_jobs = list("Security Officer","Detective", "Warden", "Head of Security", "Captain", "Chaplain")
+	required_enemies = list(2,2,2,1,1,1,1,0,0,0)
 	required_candidates = 1
 	weight = 2
 	cost = 15
-	requirements = list(80,60,50,30,20,10,10,10,10,10)
+	requirements = list(80,70,60,60,30,20,10,10,10,10)
 	high_population_requirement = 30
 
 /datum/dynamic_ruleset/roundstart/vampire/execute()


### PR DESCRIPTION
Now requires more enemies and more threat to fire on average.
However, **two new roles** now register as enemy jobs eligible for vampires to start spawning (**warden and chaplain**)
Now needs 2 enemies at threat level ranging 0-30, 1 enemy at 30-70, and no enemies at 70-100
Previously required 1 enemy at threat level ranging 0-20, and no enemies at 20-100
Now needs 80 threat level at 0-4 players, 70 at 5-9, 60 at 10-19, 30 at 20-24, 20 at 25-29, and 10 at 30 and onwards
Previously required 80 threat level at 0-4 players, 60 at 5-9, 50 at 10-14, 30 at 15-19, 20 at 20-24, and 10 at 25 and onwards.
:cl:
 * tweak: Raised some limits for threat levels required and enemies required in order for vampires to appear. However, wardens and chaplains are now considered enemies of vampires, and eligible to allow them to spawn.