### PR TITLE
Setting a controlled singulo's cooldown to 0 no longer crashes serb

### DIFF
--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -765,6 +765,8 @@ var/list/global_singularity_pool
 			
 			
 /obj/machinery/singularity/deadchat_controlled/proc/begin_democracy_loop()
+	if(democracy_cooldown <= 10)
+		democracy_cooldown = 10
 	spawn(democracy_cooldown)
 		if(src)
 			var/result = count_democracy_votes()

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -765,7 +765,7 @@ var/list/global_singularity_pool
 			
 			
 /obj/machinery/singularity/deadchat_controlled/proc/begin_democracy_loop()
-	if(democracy_cooldown <= 10)
+	if(democracy_cooldown < 10)
 		democracy_cooldown = 10
 	spawn(democracy_cooldown)
 		if(src)


### PR DESCRIPTION
[sanity]

T-thanks GlassEclipse.

:cl:
* bugfix: Admins can no longer crash the server by setting a controlled singulo's vote cooldown to 0.