### PR TITLE
ACTUALLY Fixing Dynamic Mode

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic.dm
+++ b/code/datums/gamemode/dynamic/dynamic.dm
@@ -260,7 +260,7 @@ var/stacking_limit = 90
 	var/i = 0
 	for (var/datum/dynamic_ruleset/roundstart/rule in roundstart_rules)
 		if (rule.acceptable(roundstart_pop_ready,threat_level) && threat >= rule.cost)	//if we got the population and threat required
-			i++																			//we check whether we've got elligible players
+			i++																			//we check whether we've got eligible players
 			rule.candidates = candidates.Copy()
 			rule.trim_candidates()
 			if (rule.ready())
@@ -272,7 +272,11 @@ var/stacking_limit = 90
 	if (classic_secret) // Classic secret experience : one & only one roundstart ruleset
 		extra_rulesets_amount = 0
 	else
-		if (player_list.len > high_pop_limit)
+		var/rst_pop = 0
+		for(var/mob/new_player/player in player_list)
+			if(player.ready && player.mind)
+				rst_pop++
+		if (rst_pop > high_pop_limit)
 			if (threat_level > 50)
 				extra_rulesets_amount++
 				if (threat_level > 75)
@@ -283,19 +287,19 @@ var/stacking_limit = 90
 				if (threat_level >= third_rule_req[indice_pop])
 					extra_rulesets_amount++
 
-	message_admins("[i] rulesets qualify for the current pop and threat level, including [drafted_rules.len] with elligible candidates.")
+	message_admins("[i] rulesets qualify for the current pop and threat level, including [drafted_rules.len] with eligible candidates.")
 	if (drafted_rules.len > 0 && picking_roundstart_rule(drafted_rules))
 		if (extra_rulesets_amount > 0)//we've got enough population and threat for a second rulestart rule
 			for (var/datum/dynamic_ruleset/roundstart/rule in drafted_rules)
 				if (rule.cost > threat)
 					drafted_rules -= rule
-			message_admins("The current pop and threat level allow for a second round start ruleset, there remains [candidates.len] elligible candidates and [drafted_rules.len] elligible rulesets")
+			message_admins("The current pop and threat level allow for a second round start ruleset, there remains [candidates.len] eligible candidates and [drafted_rules.len] eligible rulesets")
 			if (drafted_rules.len > 0 && picking_roundstart_rule(drafted_rules))
 				if (extra_rulesets_amount > 1)//we've got enough population and threat for a third rulestart rule
 					for (var/datum/dynamic_ruleset/roundstart/rule in drafted_rules)
 						if (rule.cost > threat)
 							drafted_rules -= rule
-					message_admins("The current pop and threat level allow for a third round start ruleset, there remains [candidates.len] elligible candidates and [drafted_rules.len] elligible rulesets")
+					message_admins("The current pop and threat level allow for a third round start ruleset, there remains [candidates.len] eligible candidates and [drafted_rules.len] eligible rulesets")
 					if (!drafted_rules.len > 0 || !picking_roundstart_rule(drafted_rules))
 						message_admins("The mode failed to pick a third ruleset.")
 			else
@@ -341,7 +345,7 @@ var/stacking_limit = 90
 				for (var/datum/dynamic_ruleset/roundstart/rule in roundstart_rules)
 					rule.candidates -= M//removing the assigned players from the candidates for the other rules
 					if (!rule.ready())
-						drafted_rules -= rule//and removing rules that are no longer elligible
+						drafted_rules -= rule//and removing rules that are no longer eligible
 			return 1
 		else
 			message_admins("....except not because whomever coded that ruleset forgot some cases in ready() apparently! execute() returned 0.")
@@ -431,8 +435,8 @@ var/stacking_limit = 90
 					current_rules += new_rule
 				return 1
 		else if (forced)
-			message_admins("The ruleset couldn't be executed due to lack of elligible players.")
-			log_admin("The ruleset couldn't be executed due to lack of elligible players.")
+			message_admins("The ruleset couldn't be executed due to lack of eligible players.")
+			log_admin("The ruleset couldn't be executed due to lack of eligible players.")
 	return 0
 
 /datum/gamemode/dynamic/process()
@@ -494,12 +498,12 @@ var/stacking_limit = 90
 						drafted_rules[rule] = rule.get_weight()
 
 			if (drafted_rules.len > 0)
-				message_admins("DYNAMIC MODE: [drafted_rules.len] elligible rulesets.")
-				log_admin("DYNAMIC MODE: [drafted_rules.len] elligible rulesets.")
+				message_admins("DYNAMIC MODE: [drafted_rules.len] eligible rulesets.")
+				log_admin("DYNAMIC MODE: [drafted_rules.len] eligible rulesets.")
 				picking_midround_rule(drafted_rules)
 			else
-				message_admins("DYNAMIC MODE: Couldn't ready-up a single ruleset. Lack of elligible candidates, population, or threat.")
-				log_admin("DYNAMIC MODE: Couldn't ready-up a single ruleset. Lack of elligible candidates, population, or threat.")
+				message_admins("DYNAMIC MODE: Couldn't ready-up a single ruleset. Lack of eligible candidates, population, or threat.")
+				log_admin("DYNAMIC MODE: Couldn't ready-up a single ruleset. Lack of eligible candidates, population, or threat.")
 		else
 			midround_injection_cooldown = rand(600,1050)
 

--- a/code/datums/gamemode/dynamic/dynamic_rulesets.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets.dm
@@ -86,11 +86,16 @@
 		return TRUE
 
 	var/enemies_count = 0
-	for (var/mob/M in mode.living_players)
-		if (dead_dont_count && M.stat == DEAD)
-			continue//dead players cannot count as opponents
-		if (M.mind && M.mind.assigned_role && (M.mind.assigned_role in enemy_jobs) && (!(M in candidates) || (M.mind.assigned_role in restricted_from_jobs)))
-			enemies_count++//checking for "enemies" (such as sec officers). To be counters, they must either not be candidates to that rule, or have a job that restricts them from it
+	if (dead_dont_count)
+		for (var/mob/M in mode.living_players)
+			if (M.stat == DEAD)
+				continue//dead players cannot count as opponents
+			if (M.mind && M.mind.assigned_role && (M.mind.assigned_role in enemy_jobs) && (!(M in candidates) || (M.mind.assigned_role in restricted_from_jobs)))
+				enemies_count++//checking for "enemies" (such as sec officers). To be counters, they must either not be candidates to that rule, or have a job that restricts them from it
+	else
+		for (var/mob/M in mode.candidates)
+			if (M.mind && M.mind.assigned_role && (M.mind.assigned_role in enemy_jobs) && (!(M in candidates) || (M.mind.assigned_role in restricted_from_jobs)))
+				enemies_count++//checking for "enemies" (such as sec officers). To be counters, they must either not be candidates to that rule, or have a job that restricts them from it
 
 	var/threat = round(mode.threat_level/10)
 	if (enemies_count >= required_enemies[threat])


### PR DESCRIPTION
So we were on the right track, but also forgot that roundstart candidates are picked from mode.candidates, instead of mode.living_players, duh.

Also fixed a typo in debug logs.

And fixed high pop override also counting non-ready players when deciding for multiple roundstart  rulesets.

:cl:
* bugfix: ACTUALLY Fixed dynamic mode roundstart. I swear.