### PR TITLE
[RFR] Powercreeper optimizations and fixes

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -17,7 +17,7 @@ var/area/space_area
 	var/shuttle_can_crush = TRUE
 	var/project_shadows = FALSE
 	var/obj/effect/narration/narrator = null
-
+	var/event/on_turf_density_change
 	flags = 0
 
 /area/New()
@@ -46,6 +46,8 @@ var/area/space_area
 		power_equip = 1
 		power_environ = 1
 
+	on_turf_density_change = new(owner = src)
+
 	..()
 
 //	spawn(15)
@@ -59,6 +61,8 @@ var/area/space_area
 /area/Destroy()
 	..()
 	areaapc = null
+	qdel(on_turf_density_change)
+	on_turf_density_change = null
 
 /*
  * Added to fix mech fabs 05/2013 ~Sayu.

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -159,6 +159,7 @@ var/global/list/ghdel_profiling = list()
 		qdel(reagents)
 		reagents = null
 
+	densityChanged()
 	// Idea by ChuckTheSheep to make the object even more unreferencable.
 	invisibility = 101
 	INVOKE_EVENT(on_destroyed, list("atom" = src)) // 1 argument - the object itself
@@ -217,9 +218,15 @@ var/global/list/ghdel_profiling = list()
 	if (density == src.density)
 		return FALSE // No need to invoke the event when we're not doing any actual change
 	src.density = density
+	densityChanged()
+
+/atom/proc/densityChanged()
 	INVOKE_EVENT(on_density_change, list("atom" = src)) // Invoke event for density change
 	if(beams && beams.len) // If beams is not a list something bad happened and we want to have a runtime to lynch whomever is responsible.
 		beams.len = 0
+	var/area/A = get_area(src)
+	if(A)
+		INVOKE_EVENT(A.on_turf_density_change, list("atom" = src))
 	for (var/obj/effect/beam/B in loc)
 		B.Crossed(src)
 

--- a/code/game/gamemodes/events/powercreeper.dm
+++ b/code/game/gamemodes/events/powercreeper.dm
@@ -179,10 +179,8 @@
 		if(Adir in cardinal)
 			var/result = isViableGrow(T)
 			if(result & CANGROW)
-				to_chat(world, "cangrow [dir2text(Adir)]")
 				growdirs |= Adir
 			if(result & CANZAP)
-				to_chat(world, "canzap [dir2text(Adir)]")
 				zapdirs |= Adir
 			if(!result)
 				growdirs &= ~Adir

--- a/code/game/gamemodes/events/powercreeper.dm
+++ b/code/game/gamemodes/events/powercreeper.dm
@@ -11,7 +11,6 @@
 	icon = 'icons/obj/structures/powercreeper.dmi'
 	icon_state = "neutral"
 	level = LEVEL_ABOVE_FLOOR
-	plane = ABOVE_HUMAN_PLANE
 	pass_flags = PASSTABLE | PASSGRILLE | PASSGIRDER | PASSMACHINE
 	slowdown_modifier = 2
 	autoignition_temperature = AUTOIGNITION_PAPER
@@ -78,13 +77,12 @@
 		if(growdirs)
 			var/grow_chance = Clamp(MIN_SPREAD_CHANCE + (powernet.avail / 1000), MIN_SPREAD_CHANCE, MAX_SPREAD_CHANCE)
 			if(prob(grow_chance))
-				for(var/chosen_dir in cardinal)
-					if(growdirs & chosen_dir)
-						var/turf/target_turf = get_step(src, chosen_dir)
-						if(isViableGrow(target_turf))
-							new /obj/structure/cable/powercreeper(target_turf, get_dir(src, target_turf))
-						else
-							growdirs &= ~chosen_dir
+				var/chosen_dir = pick(cardinal)
+				if(growdirs & chosen_dir)
+					var/turf/target_turf = get_step(src, chosen_dir)
+					if(isViableGrow(target_turf))
+						new /obj/structure/cable/powercreeper(target_turf, get_dir(src, target_turf))
+					growdirs &= ~chosen_dir
 
 /obj/structure/cable/powercreeper/Crossed(atom/movable/mover, turf/target, height = 1.5, air_group = 0)
 	.=..()
@@ -121,17 +119,13 @@
 
 /obj/structure/cable/powercreeper/proc/isViableGrow(var/turf/T)
 	if(!T.has_gravity())
-		to_chat(world, "[src] tried to cross into [T], but has no gravity")
 		return 0
 	if(!T.Adjacent(src))
-		to_chat(world, "[src] tried to cross into [T], but wasn't adjacent")
 		return 0
 	var/obj/structure/cable/powercreeper/PC = locate(/obj/structure/cable/powercreeper) in T
 	if(PC && PC != src)
-		to_chat(world, "[src] tried to cross into [T], but found a powercreeper there already")
 		return 0
 	if((T.density == 1) || T.has_dense_content())
-		to_chat(world, "[src] tried to cross into [T], but T was dense or had dense content [T.density] [T.has_dense_content()]")
 		return 0
 	return 1
 
@@ -154,16 +148,13 @@
 /obj/structure/cable/powercreeper/proc/proxDensityChange(var/list/args)
 	var/atom/A = args["atom"]
 	var/turf/T = get_turf(A)
-
-	if(get_dist(T, src) >= 1)
+	if(get_dist(T, src) <= 1)
 		var/Adir = get_dir(src, T)
 		if(Adir in cardinal)
 			if(!isViableGrow(T))
 				growdirs &= ~Adir
-				to_chat(world, "[Adir] removed from [src]")
 			else
 				growdirs |= Adir
-				to_chat(world, "[Adir] added to [src]")
 
 
 /obj/structure/cable/powercreeper/get_connections(powernetless_only = 0)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -250,7 +250,7 @@ var/list/all_doors = list()
 	door_animate("opening")
 	sleep(animation_delay)
 	layer = open_layer
-	density = 0
+	setDensity(FALSE)
 	explosion_resistance = 0
 	update_icon()
 	set_opacity(0)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -340,6 +340,7 @@
 	var/old_affecting_lights = affecting_lights
 	var/old_lighting_overlay = lighting_overlay
 	var/old_corners = corners
+	var/old_density = density
 
 	var/old_holomap = holomap_data
 //	to_chat(world, "Replacing [src.type] with [N]")
@@ -425,6 +426,8 @@
 
 	holomap_data = old_holomap // Holomap persists through everything...
 	update_holomap_planes() // But we might need to recalculate it.
+	if(density != old_density)
+		densityChanged()
 
 /turf/proc/AddDecal(const/image/decal)
 	if(!turfdecals)
@@ -477,7 +480,7 @@
 	holy = 1
 	..()
 	new /obj/effect/overlay/holywaterpuddle(src)
-	
+
 /////////////////////////////////////////////////////////////////////////
 // Navigation procs
 // Used for A-star pathfinding

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -67,7 +67,6 @@
 	var/image/viewblock
 
 	var/junction = 0
-
 /turf/examine(mob/user)
 	..()
 	if(bullet_marks)
@@ -119,6 +118,11 @@
 				return 0
 	return 1
 
+/turf/Exited(atom/movable/Obj, atom/newloc)
+	.=..()
+	if(Obj.density)
+		densityChanged()
+
 /turf/Enter(atom/movable/mover as mob|obj, atom/forget as mob|obj|turf|area)
 	if (!mover)
 		return 1
@@ -165,7 +169,6 @@
 		inertial_drift(A)
 	else
 		A.inertia_dir = 0
-
 	..()
 	var/objects = 0
 	if(A && A.flags & PROXMOVE)
@@ -181,6 +184,8 @@
 		return
 	if (!(src.can_border_transition))
 		return
+	if(A.density)
+		densityChanged()
 	if(ticker && ticker.mode)
 
 		// Okay, so let's make it so that people can travel z levels but not nuke disks!


### PR DESCRIPTION
Optimizes powercreeeper's growth. It now only tries to grow in the directions it knows are clear, and doesn't try to grow if there's no growth dirs remaining.

Destroying a powercreeper alerts its neighbours the area it was previously in is now clear.

Some misc fixes, such as powercreepers now actually becoming part of powernets, powercreepers no longer travel through space
