### PR TITLE
Fixed bees never coming out of their apiary on some maps

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -101,6 +101,7 @@ var/savefile/panicfile
 
 	initialize_runesets()
 
+	initialize_beespecies()
 
 	//sun = new /datum/sun()
 	radio_controller = new /datum/controller/radio()


### PR DESCRIPTION
Shouldn't have removed it from world.dm in #23283 R0B0

Fixes #23493

:cl:
* bugfix: Fixed bees never coming out of their apiary on some maps.