### PR TITLE
Blob Spores tweak and fix

### DIFF
--- a/code/game/gamemodes/blob/blobs/factory.dm
+++ b/code/game/gamemodes/blob/blobs/factory.dm
@@ -143,11 +143,5 @@
 			CreateBlobDisease(looks)
 		var/datum/disease2/disease/D = blob_diseases[looks]
 
-		var/chance_to_infect = 100
-		if (target.check_contact_sterility(FULL_TORSO))//For simplicity's sake (for once), let's just assume that the blob strikes the torso.
-			chance_to_infect = 10//Even with perfect protection, those spores might get to you.
-		if (target.check_bodypart_bleeding(FULL_TORSO))
-			chance_to_infect = min(100, chance_to_infect + 10)
-
-		if (prob(chance_to_infect))
-			target.infect_disease2(D, notes="(Blob, from [src])")//still 5% chance to fail infection
+		if (!target.check_contact_sterility(FULL_TORSO))//For simplicity's sake (for once), let's just assume that the blob strikes the torso.
+			target.infect_disease2(D, notes="(Blob, from [src])")

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -270,6 +270,12 @@ var/list/blob_overminds = list()
 			layer = OBJ_LAYER
 			overlays.len = 0
 
+	blob_looks(looks)
+
+	if(right_now)
+		update_icon()
+
+/atom/proc/blob_looks(var/looks = "new")
 	switch(looks)
 		if("new")
 			icon = 'icons/mob/blob/blob_64x64.dmi'
@@ -293,8 +299,6 @@ var/list/blob_overminds = list()
 			icon = 'icons/mob/blob_machine.dmi'
 		*/
 
-	if(right_now)
-		update_icon()
 
 var/list/blob_looks_admin = list(//Options available to admins
 	"new" = 64,

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -2040,14 +2040,8 @@ Thanks.
 			CreateBlobDisease(source.looks)
 		var/datum/disease2/disease/D = blob_diseases[source.looks]
 
-		var/chance_to_infect = 100
-		if (check_contact_sterility(FULL_TORSO))//For simplicity's sake (for once), let's just assume that the blob strikes the torso.
-			chance_to_infect = 10//Even with perfect protection, those spores might get to you.
-		if (check_bodypart_bleeding(FULL_TORSO))
-			chance_to_infect = min(100, chance_to_infect + 10)
-
-		if (prob(chance_to_infect))
-			infect_disease2(D, notes="(Blob, from [source])")//still 5% chance to fail infection
+		if (!check_contact_sterility(FULL_TORSO))//For simplicity's sake (for once), let's just assume that the blob strikes the torso.
+			infect_disease2(D, notes="(Blob, from [source])")
 
 	..()
 

--- a/code/modules/virus2/effect/stage_special.dm
+++ b/code/modules/virus2/effect/stage_special.dm
@@ -60,6 +60,6 @@
 
 
 /datum/disease2/effect/blob_spores/getcopy(var/datum/disease2/disease/disease)
-	var/datum/disease2/effect/monkey/new_e = ..(disease)
+	var/datum/disease2/effect/blob_spores/new_e = ..(disease)
 	new_e.looks = looks
 	return new_e

--- a/code/modules/virus2/effect/stage_special.dm
+++ b/code/modules/virus2/effect/stage_special.dm
@@ -30,7 +30,7 @@
 /datum/disease2/effect/blob_spores
 	name = "Blob Spores"
 	desc = "They seem inert for the most part, but appear to randomly pulsate once in a while."
-	encyclopedia = "They will cause their carrier to spawn blob upon their death. Potentially more the longer the pathogen persists in the host's body. At some point it may even spawn a Node."
+	encyclopedia = "They will cause their carrier to spawn blob upon their death, potentially more the longer the pathogen matured in the host's body. Some additional blob spores may even emanate from their body."
 	stage = 1
 	badness = EFFECT_DANGER_HINDRANCE
 	restricted = 1//symptoms won't randomly mutate into this one
@@ -44,25 +44,14 @@
 	var/obj/effect/blob/B = locate() in T
 
 	if (!B)//if not, let's just spawn one.
-		if (count > 150)
-			B = new /obj/effect/blob/node (T,looks,1)
-		else
-			B = new /obj/effect/blob/normal(T,looks,1)
-	else if (istype(B,/obj/effect/blob/normal) && (count > 150))//if yes, maybe we can upgrade it
-		var/overmind = null
-		if (B.overmind)
-			overmind = B.overmind
-		B.change_to(/obj/effect/blob/node)
-		var/obj/effect/blob/node/N = locate() in T
-		if(N && overmind)//in which case, let's reward its overmind
-			N.overmind = overmind
-			N.overmind.special_blobs += N
-			N.overmind.update_specialblobs()
-			N.overmind.max_blob_points += BLOBNDPOINTINC
+		B = new /obj/effect/blob/normal(T,looks,1)
 
 	if (B)//then let's just pulse him as many times as we activated on a row (up to 10 times)
 		spawn()
 			for(var/j = 1 to min(30,round(count/10)))//max number of pulses reached after about 10 minutes (300 activations, 1 every 2 second in BYOND time)
+				if ((j%5) == 0)//up to 6 spores spawned
+					var/mob/living/simple_animal/hostile/blobspore/S = new (T)
+					S.blob_looks(looks)
 				for(var/i = 1; i < 8; i += i)
 					B.Pulse(0, i, null)
 				sleep(2)

--- a/code/modules/virus2/effect/stage_special.dm
+++ b/code/modules/virus2/effect/stage_special.dm
@@ -69,3 +69,8 @@
 
 	virus.cure(mob)//finally let's remove the spores now that they've matured
 
+
+/datum/disease2/effect/blob_spores/getcopy(var/datum/disease2/disease/disease)
+	var/datum/disease2/effect/monkey/new_e = ..(disease)
+	new_e.looks = looks
+	return new_e


### PR DESCRIPTION
:cl:
* tweak: Removed the 10% chance for blob spores to bypass protections and infect you through sterile clothing, such as spacesuits or biosuits.
* tweak: Blob Spores no longer creates a node if incubated for over 5 minutes. Instead, it spawns a few spore enemies. More the longer the disease was incubated, up to 6.
* bugfix: Fixed Blob Spores-created blob tiles that always featured the default blob looks, even when the infection came from a different type of blob.