### PR TITLE
Some Medical Borg QoL

### DIFF
--- a/code/game/objects/items/robot/robot_items/robot_gripper.dm
+++ b/code/game/objects/items/robot/robot_items/robot_gripper.dm
@@ -4,6 +4,7 @@
 	var/obj/item/wrapped = null // Item currently being held.
 	var/list/can_hold = list() //Has a list of items that it can hold.
 	var/list/blacklist = list() //This is a list of items that can't be held even if their parent is whitelisted.
+	var/list/valid_containers = list()
 	var/force_holder = null
 
 /obj/item/weapon/gripper/proc/grip_item(obj/item/I as obj, mob/user, var/feedback = TRUE)
@@ -165,9 +166,8 @@
 
 	else if(isitem(target))//Check that we're not pocketing a mob.
 		var/obj/item/I = target
-		if(!isturf(target.loc))//That the item is not in a container.
-			return
-		grip_item(I, user, 1)//And finally.
+		if(isturf(target.loc) || is_type_in_list(target.loc,valid_containers))//That the item is not in a non-valid container.
+			grip_item(I, user, 1)//And finally.
 
 	else if(isrobot(target))//Robots repairing themselves? What can go wrong.
 		var/mob/living/silicon/robot/A = target
@@ -187,6 +187,11 @@
 	can_hold = list(
 		/obj/item/weapon/reagent_containers/glass,
 		/obj/item/weapon/reagent_containers/blood,
+		)
+
+	valid_containers = list(
+		/obj/item/weapon/storage/fancy/vials,
+		/obj/item/weapon/storage/lockbox/vials,
 		)
 
 /obj/item/weapon/gripper/organ //Used to handle organs.

--- a/code/game/objects/items/robot/robot_items/robot_gripper.dm
+++ b/code/game/objects/items/robot/robot_items/robot_gripper.dm
@@ -166,8 +166,12 @@
 
 	else if(isitem(target))//Check that we're not pocketing a mob.
 		var/obj/item/I = target
-		if(isturf(target.loc) || is_type_in_list(target.loc,valid_containers))//That the item is not in a non-valid container.
-			grip_item(I, user, 1)//And finally.
+		if(isturf(target.loc))
+			grip_item(I, user, 1)
+		else if(is_type_in_list(target.loc,valid_containers))
+			var/obj/O = target.loc
+			grip_item(I, user, 1)
+			O.update_icon()//updating fancy containers
 
 	else if(isrobot(target))//Robots repairing themselves? What can go wrong.
 		var/mob/living/silicon/robot/A = target

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -254,6 +254,7 @@
 	modules += new /obj/item/weapon/crowbar(src)
 	modules += new /obj/item/weapon/extinguisher/mini(src)
 	modules += new /obj/item/device/healthanalyzer(src)
+	modules += new /obj/item/device/antibody_scanner(src)
 	modules += new /obj/item/weapon/reagent_containers/borghypo(src)
 	modules += new /obj/item/weapon/gripper/chemistry(src)
 	modules += new /obj/item/weapon/reagent_containers/dropper/robodropper(src)

--- a/code/modules/virus2/items_devices.dm
+++ b/code/modules/virus2/items_devices.dm
@@ -15,6 +15,10 @@
 		//to_chat(user, "<span class='notice'>Incompatible object, scan aborted.</span>")
 		return
 
+	if (issilicon(L))
+		to_chat(user, "<span class='warning'>Incompatible with silicon lifeforms, scan aborted.</span>")
+		return
+
 	playsound(user, 'sound/items/detscan.ogg', 50, 1)
 	var/info = ""
 	var/icon/scan = icon('icons/virology.dmi',"immunitybg")


### PR DESCRIPTION
Fixes #23659

:cl:
* rscadd: Medical Borg grippers can now pick up vials from vial storage boxes, you can open the container by drag and dropping it onto yourself while adjacent.
* rscadd: Medical Borgs now have an immunity scanner among their modules.
* bugfix: You may no longer use immunity scanners on silicons, DUH.