### PR TITLE
Removes Xenos from the SoC.

### DIFF
--- a/__DEFINES/global.dm
+++ b/__DEFINES/global.dm
@@ -378,7 +378,6 @@ var/list/available_staff_transforms = list(
 	SOC_MONKEY,SOC_MARTIAN,
 	SOC_CYBORG,
 	SOC_SLIME,
-	SOC_XENO,
 	SOC_HUMAN,
 	SOC_CATBEAST,
 	SOC_FRANKENSTEIN


### PR DESCRIPTION
[featureloss] [qol]
I don't mind the SoC being an antag tool nor do I want it removed. It makes things difficult for the crew or makes them easier targets and is interactive. The xeno option ends the same way every time where the wizard hits a few people and then can literally go braindead/scry orb with how un-interactive it is. This ruins the station for any possible future antags if the shuttle hasn't been called already due to xenos.
 * rscadd: Made life a little bit better.
:cl:
 * rscdel: Removed Xenos from the staff of change.