### PR TITLE
Adds Drinking Glasses to the Autolathe

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -55,7 +55,7 @@
 		new /obj/item/weapon/reagent_containers/glass/bucket(), \
 		new /obj/item/weapon/reagent_containers/glass/beaker/vial(), \
 		new /obj/item/weapon/reagent_containers/food/drinks/mug(), \
-		new /obj/item/weapon/reagent_containers/food/drinks/drinkingglass, \
+		new /obj/item/weapon/reagent_containers/food/drinks/drinkingglass(), \
 		new /obj/item/weapon/storage/toolbox(), \
 		new /obj/item/weapon/reagent_containers/glass/jar(), \
 		),

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -55,6 +55,7 @@
 		new /obj/item/weapon/reagent_containers/glass/bucket(), \
 		new /obj/item/weapon/reagent_containers/glass/beaker/vial(), \
 		new /obj/item/weapon/reagent_containers/food/drinks/mug(), \
+		new /obj/item/weapon/reagent_containers/food/drinks/drinkingglass, \
 		new /obj/item/weapon/storage/toolbox(), \
 		new /obj/item/weapon/reagent_containers/glass/jar(), \
 		),


### PR DESCRIPTION
Currently, the only way to get drinking glasses are cargo or dumping thousands of mats into an RSD and matter cartridges. This makes it a little easier.

:cl:
 * Autholathes can now produce drinking glasses