### PR TITLE
More Dynamic debug info

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets.dm
@@ -100,6 +100,9 @@
 	var/threat = round(mode.threat_level/10)
 	if (enemies_count >= required_enemies[threat])
 		return TRUE
+	if (!dead_dont_count)//roundstart check only
+		message_admins("Dynamic Mode: Despite [name] having enough candidates, there are not enough enemy jobs ready ([enemies_count] out of [required_enemies[threat]])")
+		log_admin("Dynamic Mode: Despite [name] having enough candidates, there are not enough enemy jobs ready ([enemies_count] out of [required_enemies[threat]])")
 	return FALSE
 
 /datum/dynamic_ruleset/proc/get_weight()


### PR DESCRIPTION
indicates in the logs/to admins how many enemy roles there were at round start for each ruleset.