### PR TITLE
Add mushmen spores to black market

### DIFF
--- a/code/datums/black_market_item.dm
+++ b/code/datums/black_market_item.dm
@@ -290,7 +290,7 @@ for anyone but the person committing mass murder.
 	desc = "Sentient mushfriends for all your mushy needs"
 	item = /obj/item/seeds/walkingmushroommycelium
 	sps_chances = list(0, 10, 30)
-	delivery_available = list(0, 1, 1) //Would shatter on impact
+	delivery_available = list(0, 1, 1)
 	stock_min = 3
 	stock_max = 3
 	cost_min = 50

--- a/code/datums/black_market_item.dm
+++ b/code/datums/black_market_item.dm
@@ -281,6 +281,21 @@ for anyone but the person committing mass murder.
 /datum/black_market_item/arcane/health_potion/after_spawn(var/obj/spawned, var/mob/user)
 	if(prob(40))
 		spawned = /obj/item/potion/healing
+		
+/datum/black_market_item/plants
+	category = "Seeds" 
+
+/datum/black_market_item/plants/walkingmushroommycelium
+	name = "packet of walking mushroom seeds"
+	desc = "Sentient mushfriends for all your mushy needs"
+	item = /obj/item/potion/deception
+	sps_chances = list(0, 10, 30)
+	delivery_available = list(0, 1, 1) //Would shatter on impact
+	stock_min = 3
+	stock_max = 3
+	cost_min = 50
+	cost_max = 100
+	display_chance = 100	
 
 #undef CHEAP
 #undef NORMAL

--- a/code/datums/black_market_item.dm
+++ b/code/datums/black_market_item.dm
@@ -288,14 +288,14 @@ for anyone but the person committing mass murder.
 /datum/black_market_item/plants/walkingmushroommycelium
 	name = "packet of walking mushroom seeds"
 	desc = "Sentient mushfriends for all your mushy needs"
-	item = /obj/item/potion/deception
+	item = /obj/item/seeds/walkingmushroommycelium
 	sps_chances = list(0, 10, 30)
 	delivery_available = list(0, 1, 1) //Would shatter on impact
 	stock_min = 3
 	stock_max = 3
 	cost_min = 50
 	cost_max = 100
-	display_chance = 100	
+	display_chance = 99	
 
 #undef CHEAP
 #undef NORMAL


### PR DESCRIPTION
Seems harmless enough. Gives a way to access them without traders and without breaking into vox outpost. price may be off,. Dunno what a vox would charge for thse.

:cl:
* rscadd: The black market now sells mushman spores.