### PR TITLE
Nikita Fixes

### DIFF
--- a/code/modules/projectiles/projectile/rocket.dm
+++ b/code/modules/projectiles/projectile/rocket.dm
@@ -141,6 +141,8 @@
 			var/datum/control/new_control = new /datum/control/lock_move(mob, src)
 			mob.orient_object.Add(new_control)
 			new_control.take_control()
+			mob.drop_item(nikita)
+			nikita = null
 
 	dir = get_dir_cardinal(starting,original)
 	last_dir = dir
@@ -195,7 +197,7 @@
 			qdel(src)
 		src.Move(step)
 
-	if(mob)
+	if(mob && loc)
 		if(emagged)
 			mob.forceMove(loc)
 			mob.dir = dir


### PR DESCRIPTION
In prevision for #23690 I fixed a few Nikita bugs that appeared over the years somehow.

:cl:
* bugfix: Fixed players not dropping the emagged Nikita when firing it.
* bugfix: Fixed players getting nullspaced when attached to a detonating nikita missile.