### PR TITLE
[RFR] Powercreeper 2 electric boogaloo

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1400,7 +1400,7 @@ proc/rotate_icon(file, state, step = 1, aa = FALSE)
 /turf/proc/has_dense_content()
 	for(var/atom/turf_contents in contents)
 		if(turf_contents.density)
-			return 1
+			return turf_contents
 	return 0
 
 //Checks if there are any atoms in the turf that aren't system-only (currently only lighting overlays count)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -159,6 +159,8 @@ var/global/list/ghdel_profiling = list()
 		qdel(reagents)
 		reagents = null
 
+	if(density)
+		densityChanged()
 	// Idea by ChuckTheSheep to make the object even more unreferencable.
 	invisibility = 101
 	INVOKE_EVENT(on_destroyed, list("atom" = src)) // 1 argument - the object itself
@@ -217,11 +219,18 @@ var/global/list/ghdel_profiling = list()
 	if (density == src.density)
 		return FALSE // No need to invoke the event when we're not doing any actual change
 	src.density = density
+	densityChanged()
+
+/atom/proc/densityChanged()
 	INVOKE_EVENT(on_density_change, list("atom" = src)) // Invoke event for density change
 	if(beams && beams.len) // If beams is not a list something bad happened and we want to have a runtime to lynch whomever is responsible.
 		beams.len = 0
 	for (var/obj/effect/beam/B in loc)
 		B.Crossed(src)
+	if(!isturf(src))
+		var/turf/T = get_turf(src)
+		if(T && T.on_density_change)
+			T.densityChanged()
 
 /atom/proc/bumped_by_firebird(var/obj/structure/bed/chair/vehicle/firebird/F)
 	return Bumped(F)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -225,8 +225,6 @@ var/global/list/ghdel_profiling = list()
 	INVOKE_EVENT(on_density_change, list("atom" = src)) // Invoke event for density change
 	if(beams && beams.len) // If beams is not a list something bad happened and we want to have a runtime to lynch whomever is responsible.
 		beams.len = 0
-	for (var/obj/effect/beam/B in loc)
-		B.Crossed(src)
 	if(!isturf(src))
 		var/turf/T = get_turf(src)
 		if(T && T.on_density_change)

--- a/code/game/gamemodes/events/powercreeper.dm
+++ b/code/game/gamemodes/events/powercreeper.dm
@@ -4,6 +4,9 @@
 #define ATTACK_CHANCE 35
 #define LEAVES_CHANCE 20
 
+#define CANGROW 2
+#define CANZAP 4
+
 //the actual powercreeper obj
 /obj/structure/cable/powercreeper
 	name = "powercreeper"
@@ -11,12 +14,14 @@
 	icon = 'icons/obj/structures/powercreeper.dmi'
 	icon_state = "neutral"
 	level = LEVEL_ABOVE_FLOOR
-	plane = ABOVE_HUMAN_PLANE
+	plane = ABOVE_TURF_PLANE
 	pass_flags = PASSTABLE | PASSGRILLE | PASSGIRDER | PASSMACHINE
 	slowdown_modifier = 2
 	autoignition_temperature = AUTOIGNITION_PAPER
 	var/add_state = "_bare"
 	var/grown = 0
+	var/growdirs = 0
+	var/zapdirs = 0
 
 /obj/structure/cable/powercreeper/New(loc, growdir, packet_override)
 	//did we get created by a packet?
@@ -48,20 +53,16 @@
 	for(var/dir in cardinal)
 		mergeConnectedNetworks(dir)   //Merge the powernet with adjacents powernets
 	mergeConnectedNetworksOnTurf() //Merge the powernet with on turf powernets
-
-	//we are processing
-	processing_objects += src
-
-	//lighting
-	spawn
-		set_light(1, 15, LIGHT_COLOR_RED)
-
+	getViableNeighbours()
+	updateNeighbours()
 	. = ..()
+	//we are processing
+	processing_objects.Add(src)
+	set_light(1, 15, LIGHT_COLOR_RED)
 
 /obj/structure/cable/powercreeper/Destroy()
-	//no longer processing
-	processing_objects -= src
-
+	processing_objects.Remove(src)
+	updateNeighbours(TRUE)
 	..()
 
 /obj/structure/cable/powercreeper/process()
@@ -78,25 +79,26 @@
 		//add power to powernet
 		add_avail(POWER_PER_FRUIT)
 
-		//spread - copypasta from spreading_growth.dm
-		var/chance = MIN_SPREAD_CHANCE + (powernet.avail / 1000) //two powercreeper plants raise chance by 1
-		chance = chance > MAX_SPREAD_CHANCE ? MAX_SPREAD_CHANCE : chance
-		if(prob(chance))
-			sleep(rand(3,5))
-			if(!gcDestroyed)
-				var/list/neighbours = getViableNeighbours()
-				if(neighbours.len)
-					var/turf/target_turf = pick(neighbours)
-					new /obj/structure/cable/powercreeper(get_turf(target_turf), get_dir(src, target_turf))
+		if(growdirs)
+			var/grow_chance = Clamp(MIN_SPREAD_CHANCE + (powernet.avail/1000), MIN_SPREAD_CHANCE, MAX_SPREAD_CHANCE)
+			if(prob(grow_chance))
+				var/chosen_dir = pick(cardinal)
+				if(growdirs & chosen_dir)
+					var/turf/target_turf = get_step(src, chosen_dir)
+					if(isViableGrow(target_turf) & CANGROW)
+						new /obj/structure/cable/powercreeper(target_turf, get_dir(src, target_turf))
+					growdirs &= ~chosen_dir
 
-		//if there is a person caught in the vines, burn em a bit
-		//electrocute people who aren't insulated
-		if(prob(ATTACK_CHANCE))
-			flick("attacking[add_state]",src)
-			for(var/mob/living/M in range(1, get_turf(src)))
-				spawn
-					Beam(M, "lightning", 'icons/obj/zap.dmi', 5, 2)
-				try_electrocution(M)
+		if(zapdirs && prob(ATTACK_CHANCE))
+			for(var/chosen_dir in cardinal)
+				if(zapdirs & chosen_dir)
+					var/turf/T = get_step(src, chosen_dir)
+					try_electrocution_turf(T, chosen_dir)
+
+/obj/structure/cable/powercreeper/Crossed(atom/movable/mover, turf/target, height = 1.5, air_group = 0)
+	.=..()
+	if(isliving(mover))
+		try_electrocution(mover)
 
 /obj/structure/cable/powercreeper/update_icon()
 	return
@@ -112,26 +114,74 @@
 	do_flick(src, "death[add_state]", 13)
 	qdel(src)
 
+/obj/structure/cable/powercreeper/proc/try_electrocution_turf(var/turf/T, var/checkdir)
+	var/success = 0
+	flick("attacking[add_state]",src)
+	for(var/mob/living/M in T)
+		success = 1
+		try_electrocution(M)
+	if(!success)
+		zapdirs &= ~checkdir
+		return 0
+
 /obj/structure/cable/powercreeper/proc/try_electrocution(var/mob/living/M)
-	if(!istype(M))
+	if(!istype(M) || M.isDead())
 		return 0
+	Beam(M, "lighting", 'icons/obj/zap.dmi', 5, 2)
 	playsound(src,'sound/weapons/electriczap.ogg',50, 1) //we still want a sound
-	if(!electrocute_mob(M, powernet, src))
-		M.apply_damage((powernet.avail / 3000), BURN) //one burn damage per 6 plants (keep in mind, this will also take the power from any connected powernet)
-		return 0
-	return 1
+	return electrocute_mob(M, powernet, src)
 
 /obj/structure/cable/powercreeper/proc/getViableNeighbours()
-	. = list()
-	var/turf/T
 	for(var/dir in cardinal)
-		T = get_step(src, dir)
-		if(locate(/obj/structure/cable/powercreeper) in T)
-			continue
-		if((T.density == 1) || T.has_dense_content())
-			continue
-	
-		. += T
+		var/turf/T = get_step(src, dir)
+		var/result = isViableGrow(T)
+		if(result & CANGROW)
+			growdirs |= dir
+		if(result & CANZAP)
+			zapdirs |= dir
+
+/obj/structure/cable/powercreeper/proc/isViableGrow(var/turf/T)
+	if(!T.has_gravity())
+		return CANZAP
+	if(!T.Adjacent(src))
+		return 0
+	var/obj/structure/cable/powercreeper/PC = locate(/obj/structure/cable/powercreeper) in T
+	if(PC && PC != src)
+		return CANZAP
+	if(T.density == 1)
+		return 0
+	if(T.has_dense_content())
+		return CANZAP
+	return CANGROW|CANZAP
+
+
+/obj/structure/cable/powercreeper/proc/updateNeighbours(var/dying = FALSE)
+	for(var/dir in cardinal)
+		var/turf/T = get_step(src, dir)
+		var/obj/structure/cable/powercreeper/P = locate() in T
+		if(P)
+			if(dying)
+				P.growdirs |= get_dir(P, src)
+			else
+				P.growdirs &= ~get_dir(P, src)
+		if(dying)
+			T.on_density_change.Remove(src)
+		else
+			T.on_density_change.Add(src, "proxDensityChange")
+
+/obj/structure/cable/powercreeper/proc/proxDensityChange(var/list/args)
+	var/turf/T = args["atom"]
+	if(get_dist(T, src) <= 1)
+		var/Adir = get_dir(src, T)
+		if(Adir in cardinal)
+			var/result = isViableGrow(T)
+			if(result & CANGROW)
+				growdirs |= Adir
+			if(result & CANZAP)
+				zapdirs |= Adir
+			if(!result)
+				growdirs &= ~Adir
+				zapdirs &= ~Adir
 
 /obj/structure/cable/powercreeper/get_connections(powernetless_only = 0)
 	. = list()
@@ -141,6 +191,23 @@
 		T = get_step(src, dir)
 		if(T)
 			. += power_list(T, src, turn(dir, 180), powernetless_only)
+
+obj/structure/cable/powercreeper/mergeConnectedNetworks(var/direction)
+	var/turf/TB = get_step(src, direction)
+
+	for(var/obj/structure/cable/C in TB)
+		if(!C)
+			continue
+		if(src == C)
+			continue
+		if(!C.powernet) // if the matching cable somehow got no powernet, make him one (should not happen for cables)
+			var/datum/powernet/newPN = getFromPool(/datum/powernet/)
+			newPN.add_cable(C)
+		if(powernet) // if we already have a powernet, then merge the two powernets
+			merge_powernets(powernet,C.powernet)
+		else
+			C.powernet.add_cable(src) // else, we simply connect to the matching cable powernet
+
 
 /obj/structure/cable/powercreeper/hasDir(var/dir)
 	return (dir in cardinal)

--- a/code/game/gamemodes/events/powercreeper.dm
+++ b/code/game/gamemodes/events/powercreeper.dm
@@ -76,9 +76,12 @@
 
 	//we only want to interact with stuff as soon as our growing animation finishes
 	if(grown)
-		//add power to powernet
-		add_avail(POWER_PER_FRUIT)
-
+		var/datum/gas_mixture/environment
+		if(isturf(loc))
+			var/turf/T = loc
+			environment = T.return_air()
+		//add power to powernet through converting atmospheric heat to power
+		add_avail(-(environment.add_thermal_energy(max(environment.get_thermal_energy_change(T0C),-POWER_PER_FRUIT*50)/50)))
 		if(growdirs)
 			var/grow_chance = Clamp(MIN_SPREAD_CHANCE + (powernet.avail/1000), MIN_SPREAD_CHANCE, MAX_SPREAD_CHANCE)
 			if(prob(grow_chance))
@@ -99,6 +102,11 @@
 	.=..()
 	if(isliving(mover))
 		try_electrocution(mover)
+
+/obj/structure/cable/powercreeper/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+	if(istype(mover, /obj/item/projectile/ion))
+		return 0
+	return ..()
 
 /obj/structure/cable/powercreeper/update_icon()
 	return

--- a/code/game/gamemodes/events/powercreeper.dm
+++ b/code/game/gamemodes/events/powercreeper.dm
@@ -81,7 +81,7 @@
 			var/turf/T = loc
 			environment = T.return_air()
 		//add power to powernet through converting atmospheric heat to power
-		add_avail(-(environment.add_thermal_energy(max(environment.get_thermal_energy_change(T0C),-POWER_PER_FRUIT*50)/50)))
+		add_avail(-(environment.add_thermal_energy(max(environment.get_thermal_energy_change(T0C),-POWER_PER_FRUIT*10)/10)))
 		if(growdirs)
 			var/grow_chance = Clamp(MIN_SPREAD_CHANCE + (powernet.avail/1000), MIN_SPREAD_CHANCE, MAX_SPREAD_CHANCE)
 			if(prob(grow_chance))

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -250,7 +250,7 @@ var/list/all_doors = list()
 	door_animate("opening")
 	sleep(animation_delay)
 	layer = open_layer
-	density = 0
+	setDensity(FALSE)
 	explosion_resistance = 0
 	update_icon()
 	set_opacity(0)

--- a/code/game/objects/effects/beam.dm
+++ b/code/game/objects/effects/beam.dm
@@ -95,7 +95,6 @@
 /obj/effect/beam/proc/turf_density_change(var/list/args)
 	var/turf/T = args["atom"]
 	var/atom/A = T.has_dense_content()
-	to_chat(world, "beam TDC called. [T] [A]")
 	if(A)
 		Crossed(A)
 

--- a/code/game/objects/effects/beam.dm
+++ b/code/game/objects/effects/beam.dm
@@ -95,7 +95,7 @@
 /obj/effect/beam/proc/turf_density_change(var/list/args)
 	var/turf/T = args["atom"]
 	var/atom/A = T.has_dense_content()
-	if(A)
+	if(A && !(A in sources))
 		Crossed(A)
 
 // Listener for /atom/on_density_change
@@ -143,7 +143,7 @@
 /obj/effect/beam/Bumped(var/atom/movable/AM)
 	if(!master || !AM)
 		return
-	if(istype(AM, /obj/effect/beam) || !AM.density)
+	if(istype(AM, /obj/effect/beam) || !AM.density || Cross(AM))
 		return
 	beam_testing("Bumped by [AM]")
 	am_connector=1

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -16,6 +16,7 @@
 	var/static/list/parallax_appearances
 
 /turf/space/New()
+	..()
 	if(loc)
 		var/area/A = loc
 		A.area_turfs += src

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -15,6 +15,11 @@
 	can_border_transition = 1
 	var/static/list/parallax_appearances
 
+/turf/space/New()
+	if(loc)
+		var/area/A = loc
+		A.area_turfs += src
+
 /turf/space/initialize()
 	if(!parallax_appearances)
 		parallax_appearances = list()
@@ -198,3 +203,10 @@
 
 /turf/space/has_gravity()
 	return 0
+
+/turf/space/densityChanged()
+	..()
+	var/atom/A = has_dense_content()
+	if(A)
+		for(var/obj/effect/beam/B in src)
+			B.Crossed(A)

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -15,12 +15,6 @@
 	can_border_transition = 1
 	var/static/list/parallax_appearances
 
-/turf/space/New()
-	..()
-	if(loc)
-		var/area/A = loc
-		A.area_turfs += src
-
 /turf/space/initialize()
 	if(!parallax_appearances)
 		parallax_appearances = list()

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -85,7 +85,6 @@
 	for(var/atom/movable/AM as mob|obj in src)
 		spawn( 0 )
 			src.Entered(AM)
-			return
 
 /turf/ex_act(severity)
 	return 0
@@ -340,6 +339,7 @@
 	var/old_affecting_lights = affecting_lights
 	var/old_lighting_overlay = lighting_overlay
 	var/old_corners = corners
+	var/old_density = density
 
 	var/old_holomap = holomap_data
 //	to_chat(world, "Replacing [src.type] with [N]")
@@ -425,6 +425,8 @@
 
 	holomap_data = old_holomap // Holomap persists through everything...
 	update_holomap_planes() // But we might need to recalculate it.
+	if(density != old_density)
+		densityChanged()
 
 /turf/proc/AddDecal(const/image/decal)
 	if(!turfdecals)
@@ -477,7 +479,7 @@
 	holy = 1
 	..()
 	new /obj/effect/overlay/holywaterpuddle(src)
-	
+
 /////////////////////////////////////////////////////////////////////////
 // Navigation procs
 // Used for A-star pathfinding

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -23,7 +23,7 @@
 	w_class = W_CLASS_MEDIUM
 	slot_flags = SLOT_BELT
 	cell_type = "/obj/item/weapon/cell/crap/better"
-	projectile_type = "/obj/item/projectile/ionsmall"
+	projectile_type = "/obj/item/projectile/ion/small"
 
 /obj/item/weapon/gun/energy/ionrifle/ioncarbine/ionpistol
 	name = "ion pistol"

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -11,21 +11,15 @@
 /obj/item/projectile/ion/to_bump(atom/A as mob|obj|turf|area)
 	if(!bumped && ((A != firer) || reflected))
 		empulse(get_turf(A), 1, 1)
+		qdel(src)
+		return
 	..()
 
-/obj/item/projectile/ionsmall
-	name = "ion bolt"
-	icon_state = "ion"
-	damage = 0
-	damage_type = BURN
-	nodamage = 1
-	layer = PROJECTILE_LAYER
-	flag = "energy"
-	fire_sound = 'sound/weapons/ion.ogg'
-
-/obj/item/projectile/ionsmall/to_bump(atom/A as mob|obj|turf|area)
+/obj/item/projectile/ion/small/to_bump(atom/A as mob|obj|turf|area)
 	if(!bumped && ((A != firer) || reflected))
-		empulse(src, 0, 1)
+		empulse(get_turf(A), 0, 1)
+		qdel(src)
+		return
 	..()
 
 /obj/item/projectile/bullet/gyro

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -2305,6 +2305,10 @@
 		tray.weedlevel -= 3
 		tray.toxins += 15
 		tray.check_level_sanity()
+	else if(istype(O, /obj/structure/cable/powercreeper))
+		var/obj/structure/cable/powercreeper/PC = O
+		if(prob(1*(PC.powernet.avail/1000))) //The less there is, the hardier it gets
+			PC.die()
 
 /datum/reagent/toxin/plantbgone/reaction_mob(var/mob/living/M, var/method = TOUCH, var/volume)
 


### PR DESCRIPTION
Now with less lag, more event hooks, and by golly is it all a little crazy.

Ended up having to touch beams and space, because DensityChanged was too expensive with the loop through itself for checking if it had any beams that needed updating, so changed those to turf density changes. Because space wasn't inheriting from the base atoms for reasons like not wanting a million tiles to make 4 more events, beams weren't working properly.

Still working on changeturf, as it seems the changed turf isn't inheriting its old events

:cl:
 * tweak: Powercreeper spread logic tweaked, so it isn't as laggy as before
 * tweak: Powercreepers no longer zap the dead
 * tweak: Powercreepers are now affected by plantbgone, the more power in the grid, the more likely they are to die from it
 * tweak: Powercreepers now draw their energy from the environment, so any area with powercreepers in will tend towards 0 celsius
 * tweak: Powercreepers now don't shock you through gloves
 * tweak: For those of you who can't aim, powercreepers now intercept ion bolts