### PR TITLE
Fixing reported bugs: Catechizer and katana reproduction

### DIFF
--- a/code/modules/randomMaps/vault_definitions.dm
+++ b/code/modules/randomMaps/vault_definitions.dm
@@ -38,6 +38,22 @@ var/list/existing_vaults = list()
 /datum/map_element/vault/asteroid_temple
 	file_path = "maps/randomvaults/asteroid_temple.dmm"
 
+/datum/map_element/vault/asteroid_temple/initialize(list/objects)
+	..(objects)
+
+	var/list/all_spawns = list()
+	for(var/obj/effect/landmark/catechizer_spawn/S in objects)
+		all_spawns.Add(S)
+
+	var/obj/effect/true_spawn = pick(all_spawns)
+	all_spawns.Remove(true_spawn)
+
+	var/obj/item/weapon/melee/morningstar/catechizer/original = new(get_turf(true_spawn))
+	qdel(true_spawn)
+	for(var/obj/effect/S in all_spawns)
+		new /mob/living/simple_animal/hostile/mimic/crate/item(get_turf(S), original) //Make copies
+		qdel(S)
+
 /datum/map_element/vault/tommyboyasteroid
 	file_path = "maps/randomvaults/tommyboyasteroid.dmm"
 

--- a/code/modules/research/xenoarchaeology/finds/finds.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds.dm
@@ -521,6 +521,7 @@
 	find_ID = ARCHAEO_KATANA
 	apply_prefix = FALSE
 	responsive_reagent = IRON
+	anomaly_factor = 0
 
 /datum/find/katana/spawn_item()
 	var/obj/item/weapon/new_item = new /obj/item/weapon/katana

--- a/maps/randomvaults/objects.dm
+++ b/maps/randomvaults/objects.dm
@@ -350,7 +350,7 @@
 /obj/item/weapon/melee/morningstar/catechizer
 	name = "The Catechizer"
 	desc = "An unholy weapon forged eons ago by a servant of Nar-Sie."
-
+	origin_tech = null
 	force = 37
 	throwforce = 30
 	throw_speed = 3
@@ -358,26 +358,6 @@
 
 /obj/effect/landmark/catechizer_spawn //Multiple of these are put in a single area. One of these landmark will contain a true catachizer, others only mimics
 	name = "catechizer spawn"
-
-/obj/effect/landmark/catechizer_spawn/New()
-	spawn()
-		if(!isturf(loc))
-			return
-
-		var/list/all_spawns = list()
-		for(var/obj/effect/landmark/catechizer_spawn/S in get_area(src))
-			all_spawns.Add(S)
-
-		var/obj/effect/true_spawn = pick(all_spawns)
-		all_spawns.Remove(true_spawn)
-
-		var/obj/item/weapon/melee/morningstar/catechizer/original = new(get_turf(true_spawn))
-
-		for(var/obj/effect/S in all_spawns)
-			new /mob/living/simple_animal/hostile/mimic/crate/item(get_turf(S), original) //Make copies
-			qdel(S)
-
-		qdel(src)
 
 /obj/machinery/door/poddoor/vault_rust
 	id_tag = "tokamak_yadro_ventilyatsionnyy" // Russian for "tokamak_core_vent"


### PR DESCRIPTION
Catechizer now shows above altars, rather than below

Catechizer spawns now work, rather than making 4 catechizers

Can no longer reproduce the katana and the catechizer

