### PR TITLE
Fixed diskette boxes not appearing in the merch computer

### DIFF
--- a/code/game/machinery/computer/store.dm
+++ b/code/game/machinery/computer/store.dm
@@ -20,6 +20,8 @@
 			),
 		"Electronics" = list(
 			/datum/storeitem/boombox,
+			/datum/storeitem/diskettebox,
+			/datum/storeitem/diskettebox_large,
 			),
 		"Toys" = list(
 			/datum/storeitem/beachball,


### PR DESCRIPTION
:cl:
* bugfix: Diskette storage boxes now properly appear in the merch computer.