### PR TITLE
Adds anarcho-communism as a religion for the chaplain

### DIFF
--- a/code/datums/religions.dm
+++ b/code/datums/religions.dm
@@ -1168,6 +1168,18 @@
 /datum/religion/ancap/equip_chaplain(var/mob/living/carbon/human/H)
 	H.equip_or_collect(new /obj/item/toy/gun(H), slot_l_store) //concealed carry
 
+/datum/religion/ancom
+	name = "Anarcho-Communism"
+	deity_name = "Peter Kropotkin"
+	bible_name = "The Conquest of Bread"
+	bible_type = /obj/item/weapon/storage/bible/booze
+	male_adept = "Activist" 
+	female_adept = "Activist"
+	keys = list("anarcho-communism", "communalism", "mutualism")
+	
+/datum/religion/ancom/equip_chaplain(var/mob/living/carbon/human/H)
+	H.equip_or_collect(new /obj/item/clothing/mask/balaclava(H), slot_l_store) // Black Bloc
+
 /datum/religion/samurai
 	name = "Bushido" // The way of the warrior
 	deity_name = "The Way of the Warrior"


### PR DESCRIPTION
:cl:
 * rscadd: Adds anarcho-communism as a religion for the chaplain, keys are anarcho-communism, communalism, and mutualism.

This brings the server one step closer to my dream of an ancap chaplain giving a free pod ride to the ancom chaplain for violating the NAP.