### PR TITLE
Fixed Dynamic ruleset injection cooldowns still using the original delays after the first injection

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic.dm
+++ b/code/datums/gamemode/dynamic/dynamic.dm
@@ -468,7 +468,8 @@ var/stacking_limit = 90
 		update_playercounts()
 
 		if (injection_attempt())
-			midround_injection_cooldown = rand(600,1050)//20 to 35 minutes inbetween midround threat injections attempts
+			var/midround_injection_cooldown_middle = 0.5*(MIDROUND_DELAY_MAX + MIDROUND_DELAY_MIN)
+			midround_injection_cooldown = round(Clamp(exp_distribution(midround_injection_cooldown_middle), MIDROUND_DELAY_MIN, MIDROUND_DELAY_MAX))
 			var/list/drafted_rules = list()
 			var/list/current_players = list(CURRENT_LIVING_PLAYERS, CURRENT_LIVING_ANTAGS, CURRENT_DEAD_PLAYERS, CURRENT_OBSERVERS)
 			current_players[CURRENT_LIVING_PLAYERS] = living_players.Copy()
@@ -612,7 +613,8 @@ var/stacking_limit = 90
 					drafted_rules[rule] = rule.get_weight()
 
 		if (drafted_rules.len > 0 && picking_latejoin_rule(drafted_rules))
-			latejoin_injection_cooldown = rand(330,510)//11 to 17 minutes inbetween antag latejoiner rolls
+			var/latejoin_injection_cooldown_middle = 0.5*(LATEJOIN_DELAY_MAX + LATEJOIN_DELAY_MIN)
+			latejoin_injection_cooldown = round(Clamp(exp_distribution(latejoin_injection_cooldown_middle), LATEJOIN_DELAY_MIN, LATEJOIN_DELAY_MAX))
 
 /datum/gamemode/dynamic/mob_destroyed(var/mob/M)
 	for (var/datum/dynamic_ruleset/DR in midround_rules)


### PR DESCRIPTION
#22574 added new defines for latejoin and midround rulesets injections, with larger values, however those are currently only applied at roundstart, and now when the cooldowns get reset, so until now injections would use the original cooldowns again after the first injection.

This should slow down the rate of injection for Dynamic somewhat.

:cl:
* bugfix: Fixed Dynamic Mode ruleset injections cooldowns being shorter than intended after the first injection.