### PR TITLE
Fixes being able to send yourself to the ghost realm through kicking off of a wall diagonally

### DIFF
--- a/code/game/objects/structures/vehicles/vehicle.dm
+++ b/code/game/objects/structures/vehicles/vehicle.dm
@@ -285,6 +285,8 @@
 /obj/structure/bed/chair/vehicle/proc/update_mob()
 	if(!occupant)
 		return
+	if(!(dir in cardinal))
+		return
 
 	if(last_dir)
 		occupant.pixel_x -= offsets["[last_dir]"]["x"]


### PR DESCRIPTION
The reason this was happening was because offsets is a list of 1,2,4,8, but kicking off of a wall would try to access the offset list at 5, or 9, or 3, which runtimes. This would not restore your previous y value, so you would eventually drift off of the screen if you abuse it too much.

closes #21881