### PR TITLE
Fixed the asteroid lair showing up on holomaps

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -1565,6 +1565,9 @@ var/proccalls = 1
 #define HOLOMAP_MARKER_CULT_EXIT		"path_exit"
 #define HOLOMAP_MARKER_CULT_RUNE		"rune"
 
+#define HOLOMAP_DRAW_NORMAL	0
+#define HOLOMAP_DRAW_FULL	1
+#define HOLOMAP_DRAW_EMPTY	2
 
 #define DEFAULT_BLOOD "#A10808"
 #define DEFAULT_FLESH "#FFC896"

--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -167,8 +167,8 @@ proc/process_adminbus_teleport_locs()
 	shuttle_can_crush = FALSE
 	flags = NO_PERSISTENCE
 
-/area/shuttle/holomapAlwaysDraw()
-	return 0
+/area/shuttle/holomapDrawOverride()
+	return HOLOMAP_DRAW_EMPTY
 
 /area/shuttle/arrival
 	name = "\improper Arrival Shuttle"
@@ -563,9 +563,15 @@ proc/process_adminbus_teleport_locs()
 	icon_state = "cave"
 	requires_power = 0
 
+/area/asteroid/cave/holomapDrawOverride()
+	return HOLOMAP_DRAW_FULL
+
 /area/asteroid/artifactroom
 	name = "\improper Asteroid - Artifact"
 	icon_state = "cave"
+
+/area/asteroid/artifactroom/holomapDrawOverride()
+	return HOLOMAP_DRAW_FULL
 
 /area/planet/clown
 	name = "\improper Clown Planet"
@@ -578,8 +584,8 @@ proc/process_adminbus_teleport_locs()
 	icon_state = "honk"
 	requires_power = 0
 
-/area/asteroid/clown/holomapAlwaysDraw()
-	return 0
+/area/asteroid/clown/holomapDrawOverride()
+	return HOLOMAP_DRAW_EMPTY
 
 /area/tdome
 	name = "\improper Thunderdome"
@@ -1898,8 +1904,8 @@ proc/process_adminbus_teleport_locs()
 	icon_state = "DJ"
 	shuttle_can_crush = FALSE
 
-/area/djstation/holomapAlwaysDraw()
-	return 0
+/area/djstation/holomapDrawOverride()
+	return HOLOMAP_DRAW_EMPTY
 
 /area/djstation/solars
 	name = "\improper DJ Station Solars"
@@ -1951,8 +1957,8 @@ proc/process_adminbus_teleport_locs()
 	name = "\improper Derelict Secret Room"
 	icon_state = "library"
 
-/area/derelict/secret/holomapAlwaysDraw()
-	return 0
+/area/derelict/secret/holomapDrawOverride()
+	return HOLOMAP_DRAW_EMPTY
 
 /area/derelict/bridge/access
 	name = "Derelict Control Room Access"
@@ -2011,8 +2017,8 @@ proc/process_adminbus_teleport_locs()
 	name = "\improper Abandoned Ship"
 	icon_state = "yellow"
 
-/area/derelict/ship/holomapAlwaysDraw()
-	return 0
+/area/derelict/ship/holomapDrawOverride()
+	return HOLOMAP_DRAW_EMPTY
 
 /area/solar/derelict_starboard
 	name = "\improper Derelict Starboard Solar Array"

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -884,8 +884,8 @@ its easier to just keep the beam vertical.
 /atom/proc/isacidhardened()
 	return FALSE
 
-/atom/proc/holomapAlwaysDraw()
-	return 1
+/atom/proc/holomapDrawOverride()
+	return HOLOMAP_DRAW_NORMAL
 
 /atom/proc/get_inaccuracy(var/atom/target, var/spread, var/obj/mecha/chassis)
 	var/turf/curloc = get_turf(src)

--- a/code/modules/html_interface/map/station_map.dm
+++ b/code/modules/html_interface/map/station_map.dm
@@ -98,8 +98,8 @@
 			for(var/i = 1 to ((2 * world.view + 1)*WORLD_ICON_SIZE))
 				for(var/r = 1 to ((2 * world.view + 1)*WORLD_ICON_SIZE))
 					var/turf/tile = locate(i, r, zLevel)
-					if(tile && tile.loc.holomapAlwaysDraw())
-						if((!istype(tile, get_base_turf(zLevel)) && istype(tile.loc, /area/mine/unexplored)) || istype(tile.loc, /area/asteroid/artifactroom) || istype(tile, /turf/simulated/wall) || istype(tile, /turf/unsimulated/mineral) || istype(tile, /turf/unsimulated/wall) || (locate(/obj/structure/grille) in tile) || (locate(/obj/structure/window/full) in tile))
+					if(tile && (tile.loc.holomapAlwaysDraw() != HOLOMAP_DRAW_EMPTY))
+						if((!istype(tile, get_base_turf(zLevel)) && istype(tile.loc, /area/mine/unexplored)) || (tile.loc.holomapAlwaysDraw() == HOLOMAP_DRAW_FULL) || istype(tile, /turf/simulated/wall) || istype(tile, /turf/unsimulated/mineral) || istype(tile, /turf/unsimulated/wall) || (locate(/obj/structure/grille) in tile) || (locate(/obj/structure/window/full) in tile))
 							if(map.holomap_offset_x.len >= zLevel)
 								canvas.DrawBox(HOLOMAP_OBSTACLE, min(i+map.holomap_offset_x[zLevel],((2 * world.view + 1)*WORLD_ICON_SIZE)), min(r+map.holomap_offset_y[zLevel],((2 * world.view + 1)*WORLD_ICON_SIZE)))
 							else

--- a/code/modules/html_interface/map/station_map.dm
+++ b/code/modules/html_interface/map/station_map.dm
@@ -98,8 +98,8 @@
 			for(var/i = 1 to ((2 * world.view + 1)*WORLD_ICON_SIZE))
 				for(var/r = 1 to ((2 * world.view + 1)*WORLD_ICON_SIZE))
 					var/turf/tile = locate(i, r, zLevel)
-					if(tile && (tile.loc.holomapAlwaysDraw() != HOLOMAP_DRAW_EMPTY))
-						if((!istype(tile, get_base_turf(zLevel)) && istype(tile.loc, /area/mine/unexplored)) || (tile.loc.holomapAlwaysDraw() == HOLOMAP_DRAW_FULL) || istype(tile, /turf/simulated/wall) || istype(tile, /turf/unsimulated/mineral) || istype(tile, /turf/unsimulated/wall) || (locate(/obj/structure/grille) in tile) || (locate(/obj/structure/window/full) in tile))
+					if(tile && (tile.loc.holomapDrawOverride() != HOLOMAP_DRAW_EMPTY))
+						if((!istype(tile, get_base_turf(zLevel)) && istype(tile.loc, /area/mine/unexplored)) || (tile.loc.holomapDrawOverride() == HOLOMAP_DRAW_FULL) || istype(tile, /turf/simulated/wall) || istype(tile, /turf/unsimulated/mineral) || istype(tile, /turf/unsimulated/wall) || (locate(/obj/structure/grille) in tile) || (locate(/obj/structure/window/full) in tile))
 							if(map.holomap_offset_x.len >= zLevel)
 								canvas.DrawBox(HOLOMAP_OBSTACLE, min(i+map.holomap_offset_x[zLevel],((2 * world.view + 1)*WORLD_ICON_SIZE)), min(r+map.holomap_offset_y[zLevel],((2 * world.view + 1)*WORLD_ICON_SIZE)))
 							else

--- a/maps/randomvaults/objects.dm
+++ b/maps/randomvaults/objects.dm
@@ -20,8 +20,8 @@
 		//Create a narrator object to play a sound to everybody who enters the area
 		narrator = new /obj/effect/narration/mystery_sound(null)
 
-/area/vault/holomapAlwaysDraw()
-	return 0
+/area/vault/holomapDrawOverride()
+	return HOLOMAP_DRAW_EMPTY
 
 //Special area that can be used in map elements. When loaded, it creates a new area object and transfers all of its contents into it.
 //This means that this area can be put into multiple map elements without any issues


### PR DESCRIPTION
Areas can now be set to either appear as "always full" or "always empty" on holomaps.

:cl:
* bugfix: The asteroid lair no longer appears on holomaps.