### PR TITLE
Should prevent traders abusing the RCS to steal from spacemart

### DIFF
--- a/code/modules/telesci/rcs.dm
+++ b/code/modules/telesci/rcs.dm
@@ -169,7 +169,7 @@
 
 	//After inputs to prevent process-pause exploitation
 	var/area/A = get_area(target)
-	if(A.teleblocked || A.flags & (NO_TELEPORT|NO_PORTALS))
+	if(A.jammed || A.flags & (NO_TELEPORT|NO_PORTALS))
 		to_chat(user, "<span class='warning'>You can not teleport \the [target] from here, due to bluespace interference.</span>")
 		return
 

--- a/code/modules/telesci/rcs.dm
+++ b/code/modules/telesci/rcs.dm
@@ -167,8 +167,14 @@
 			P.name = "letter from [user]"
 			P.info = note
 
+	//After inputs to prevent process-pause exploitation
+	var/area/A = get_area(target)
+	if(A.teleblocked || A.flags & (NO_TELEPORT|NO_PORTALS))
+		to_chat(user, "<span class='warning'>You can not teleport \the [target] from here, due to bluespace interference.</span>")
+		return
+
 	playsound(src, 'sound/machines/click.ogg', 50, 1)
-	to_chat(user, "<span class='notic'>Teleporting \the [target]...</span>")
+	to_chat(user, "<span class='notice'>Teleporting \the [target]...</span>")
 	teleporting = TRUE
 	if (!do_after(user, target, 50))
 		teleporting = FALSE


### PR DESCRIPTION
RCS now checks for teleblock, or the NO_TELEPORT or NO_PORTALS flag

Also, fixes a bad class, 1 letter, shouldn't hurt.