### PR TITLE
Changes snow tiles to standard atmospheric pressure

### DIFF
--- a/__DEFINES/atmos.dm
+++ b/__DEFINES/atmos.dm
@@ -79,8 +79,7 @@
 #define BASE_ZAS_FUEL_REQ	0.1
 
 //Snowmap when?
-#define ARCTIC_ATMOSPHERE 90.13
 #define T_ARCTIC 223.65 //- 49.5 Celcius, taken from South Pole averages
-#define MOLES_ARCTICSTANDARD (ARCTIC_ATMOSPHERE*CELL_VOLUME/(T_ARCTIC*R_IDEAL_GAS_EQUATION)) //Note : Open air tiles obviously aren't 2.5 meters in height, but abstracted for now with infinite atmos
+#define MOLES_ARCTICSTANDARD (ONE_ATMOSPHERE*CELL_VOLUME/(T_ARCTIC*R_IDEAL_GAS_EQUATION)) //Note : Open air tiles obviously aren't 2.5 meters in height, but abstracted for now with infinite atmos
 #define MOLES_O2STANDARD_ARCTIC MOLES_ARCTICSTANDARD*O2STANDARD	//O2 standard value (21%)
 #define MOLES_N2STANDARD_ARCTIC MOLES_ARCTICSTANDARD*N2STANDARD	//N2 standard value (79%)


### PR DESCRIPTION
[tweak]
Snow tiles used to be about 90 kPa because that's the atmospheric pressure on Antarctica which is about 2 kilometres above sea level due to the thickness of the ice cap. This is not the case for the places these tiles are used for in spess, so making them standard atmospheric pressure makes more sense to me.
