### PR TITLE
Base Turf Override

### DIFF
--- a/code/game/objects/structures/docking_port.dm
+++ b/code/game/objects/structures/docking_port.dm
@@ -156,12 +156,15 @@ var/global/list/all_docking_ports = list()
 	var/base_turf_type			= /turf/space
 	var/base_turf_icon			= null
 	var/base_turf_icon_state	= null
+	var/base_turf_override		= FALSE
 
 /obj/docking_port/destination/New()
 	.=..()
 
 	origin_turf = get_turf(src)
 	//The following few lines exist to make shuttle corners and the syndicate base Less Shit :*
+	if(base_turf_override)
+		return //Allows mappers to manually set base_turf info
 	if(src.z in 1 to map.zLevels.len)
 		base_turf_type = get_base_turf(src.z)
 
@@ -262,7 +265,7 @@ var/global/list/dockinglights = list()
 /obj/machinery/docklight/New()
 	..()
 	dockinglights += src
-	
+
 /obj/machinery/docklight/Destroy()
 	dockinglights -= src
 	..()


### PR DESCRIPTION
This allows mappers to manually set base_turf_type, base_turf_icon, and base_turf_icon_state without them getting overwritten at runtime. Simply set base_turf_override to 1.

Basically, the code will normally grab the base_turf for that Z-level. But what if you want to have a Z-level that is partially space and partially not, with shuttles landing on the surface AND space? (think asteroid, if you could set down a shuttle at a destination in the middle). This would let you do that.