### PR TITLE
Scrubber pressure targets/bounds/limits

### DIFF
--- a/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
@@ -25,6 +25,14 @@
 	var/panic			= 0 //is this scrubber panicked?
 	var/welded			= 0
 
+	var/external_pressure_bound = ONE_ATMOSPHERE
+	var/internal_pressure_bound = 0
+	var/pressure_checks = 1
+	//1: Do not pass external_pressure_bound
+	//2: Do not pass internal_pressure_bound
+	//3: Do not pass either
+	var/reducing_pressure = 0 //1 if external_pressure_bound is exceeded and we're sucking out gas to reduce pressure
+
 	var/area_uid
 	var/radio_filter_out
 	var/radio_filter_in
@@ -71,6 +79,8 @@
 			state = "on"
 			if (scrub_O2)
 				state += "1"
+			else if(reducing_pressure)
+				state += "1"
 		else
 			state = "in"
 
@@ -116,6 +126,9 @@
 		"filter_n2o" = scrub_N2O,
 		"filter_o2" = scrub_O2,
 		"filter_n2" = scrub_N2,
+		"internal" = internal_pressure_bound,
+		"external" = external_pressure_bound,
+		"checks" = pressure_checks,
 		"sigtype" = "status"
 	)
 	if(frequency == 1439)
@@ -156,16 +169,23 @@
 
 	var/datum/gas_mixture/environment = loc.return_air()
 
+	//scrubbing mode
 	if(scrubbing)
-		// Are we scrubbing gasses that are present?
-		if(\
-			(scrub_Toxins && environment[GAS_PLASMA] > 0) ||\
-			(scrub_CO2 && environment[GAS_CARBON] > 0) ||\
-			(scrub_N2O && environment[GAS_SLEEPING] > 0) ||\
-			(scrub_O2 && environment[GAS_OXYGEN] > 0) ||\
-			(scrub_N2 && environment[GAS_NITROGEN] > 0))
-			if (air_contents.return_pressure()>=MAX_PRESSURE)
-				return
+		//if internal pressure limit is enabled and met, we don't do anything
+		if((pressure_checks & 2) && (internal_pressure_bound - air_contents.return_pressure()) < 0.05)
+			return
+		//if we're at max pressure we also don't do anything
+		if(air_contents.return_pressure() >= MAX_PRESSURE)
+			return
+
+		//I'm sorry you have to see this
+		//tl;dr: if we're scrubbing some gas that's in the environment, or if the external pressure bound is exceeded
+		var/external_pressure_delta = environment.return_pressure() - external_pressure_bound
+		if((scrub_Toxins && environment[GAS_PLASMA] > 0) || (scrub_CO2 && environment[GAS_CARBON] > 0) ||\
+			(scrub_N2O && environment[GAS_SLEEPING] > 0) ||	(scrub_O2 && environment[GAS_OXYGEN] > 0) ||\
+			(scrub_N2 && environment[GAS_NITROGEN] > 0) || ((pressure_checks & 1) &&\
+			external_pressure_delta > 0.05))
+
 			var/transfer_moles = min(1, volume_rate / environment.volume) * environment.total_moles
 
 			//Take a gas sample
@@ -175,7 +195,8 @@
 
 			//Filter it
 			var/datum/gas_mixture/filtered_out = new
-			filtered_out.temperature = removed.temperature
+			var/air_temperature = (removed.temperature > 0) ? removed.temperature : air_contents.temperature
+			filtered_out.temperature = air_temperature
 
 			#define FILTER(g) filtered_out.adjust_gas((g), removed[g], FALSE)
 			if(scrub_Toxins)
@@ -198,6 +219,19 @@
 			filtered_out.update_values()
 			removed.subtract(filtered_out)
 			#undef FILTER
+
+			//if external pressure bound is exceeded, remove extra gas to bring the external pressure down
+			if((pressure_checks & 1) && external_pressure_delta > 0.05)
+				var/output_volume = air_contents.volume + (network ? network.volume : 0)
+				var/extra_moles = (external_pressure_delta * output_volume) / (air_temperature * R_IDEAL_GAS_EQUATION)
+				var/datum/gas_mixture/extra_removed = removed.remove(extra_moles)
+				filtered_out.merge(extra_removed)
+				if(!reducing_pressure)
+					reducing_pressure = 1
+					update_icon()
+			else if(reducing_pressure)
+				reducing_pressure = 0
+				update_icon()
 
 			//Remix the resulting gases
 			air_contents.merge(filtered_out)
@@ -286,6 +320,24 @@
 		scrub_N2 = text2num(signal.data["n2_scrub"])
 	if(signal.data["toggle_n2_scrub"])
 		scrub_N2 = !scrub_N2
+
+	if("checks" in signal.data)
+		pressure_checks = text2num(signal.data["checks"])
+
+	if("checks_toggle" in signal.data)
+		pressure_checks = (pressure_checks?0:3)
+
+	if("set_internal_pressure" in signal.data)
+		internal_pressure_bound = Clamp(text2num(signal.data["set_internal_pressure"]), 0, ONE_ATMOSPHERE * 50)
+
+	if("set_external_pressure" in signal.data)
+		external_pressure_bound = Clamp(text2num(signal.data["set_external_pressure"]), 0, ONE_ATMOSPHERE * 50)
+
+	if("adjust_internal_pressure" in signal.data)
+		internal_pressure_bound = Clamp(internal_pressure_bound + text2num(signal.data["adjust_internal_pressure"]), 0, ONE_ATMOSPHERE * 50)
+
+	if("adjust_external_pressure" in signal.data)
+		external_pressure_bound = Clamp(external_pressure_bound + text2num(signal.data["adjust_external_pressure"]), 0, ONE_ATMOSPHERE * 50)
 
 	if(signal.data["init"] != null)
 		name = signal.data["init"]

--- a/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
@@ -173,9 +173,15 @@
 	if(scrubbing)
 		//if internal pressure limit is enabled and met, we don't do anything
 		if((pressure_checks & 2) && (internal_pressure_bound - air_contents.return_pressure()) < 0.05)
+			if(reducing_pressure)
+				reducing_pressure = 0
+				update_icon()
 			return
 		//if we're at max pressure we also don't do anything
 		if(air_contents.return_pressure() >= MAX_PRESSURE)
+			if(reducing_pressure)
+				reducing_pressure = 0
+				update_icon()
 			return
 
 		//I'm sorry you have to see this
@@ -242,6 +248,9 @@
 				network.update = 1
 
 	else //Just siphoning all air
+		if(reducing_pressure)
+			reducing_pressure = 0
+			update_icon()
 		if (air_contents.return_pressure()>=MAX_PRESSURE)
 			return
 

--- a/code/modules/atmos_automation/implementation/scrubbers.dm
+++ b/code/modules/atmos_automation/implementation/scrubbers.dm
@@ -154,3 +154,113 @@ var/global/list/gas_labels=list(
 		scrubber = input("Select a scrubber:", "Scrubbers", scrubber) as null | anything in injector_names
 		parent.updateUsrDialog()
 		return 1
+
+/datum/automation/set_scrubber_pressure
+	name = "Scrubber: Pressure Settings"
+	var/scrubber = null
+	var/intpressure = 0
+	var/extpressure = 0
+
+/datum/automation/set_scrubber_pressure/Export()
+	var/list/json = ..()
+	json["scrubber"] = scrubber
+	json["intpressure"] = intpressure
+	json["extpressure"] = extpressure
+	return json
+
+/datum/automation/set_scrubber_pressure/Import(var/list/json)
+	..(json)
+	scrubber = json["scrubber"]
+	intpressure = json["intpressure"]
+	extpressure = json["extpressure"]
+
+/datum/automation/set_scrubber_pressure/process()
+	if(scrubber)
+		var/list/data = list("tag" = scrubber)
+		if(intpressure)
+			data.Add(list("set_internal_pressure" = intpressure))
+		if(extpressure)
+			data.Add(list("set_external_pressure" = extpressure))
+		parent.send_signal(data, RADIO_FROM_AIRALARM)
+
+/datum/automation/set_scrubber_pressure/GetText()
+	return {"Set scrubber <a href=\"?src=\ref[src];set_scrubber=1\">[fmtString(scrubber)]</a> pressure bounds:
+			internal: <a href=\"?src=\ref[src];set_intpressure=1">[fmtString(intpressure)]</a>
+			external: <a href=\"?src=\ref[src];set_extpressure=1">[fmtString(extpressure)]</a>"}
+
+/datum/automation/set_scrubber_pressure/Topic(href, href_list)
+	if(..())
+		return 1
+	if(href_list["set_scrubber"])
+		var/list/injector_names = list()
+		for(var/obj/machinery/atmospherics/unary/vent_scrubber/S in atmos_machines)
+			if(!isnull(S.id_tag) && S.frequency == parent.frequency)
+				injector_names |= S.id_tag
+
+		scrubber = input("Select a scrubber:", "Scrubbers", scrubber) as null | anything in injector_names
+		parent.updateUsrDialog()
+		return 1
+
+	if(href_list["set_intpressure"])
+		var/response = input("Set new pressure in kPa. \[0-[50*ONE_ATMOSPHERE]\]") as num
+		intpressure = text2num(response)
+		intpressure = Clamp(intpressure, 0, 50*ONE_ATMOSPHERE)
+		parent.updateUsrDialog()
+		return 1
+
+	if(href_list["set_extpressure"])
+		var/response = input(usr,"Set new pressure in kPa. \[0-[50*ONE_ATMOSPHERE]\]") as num
+		extpressure = text2num(response)
+		extpressure = Clamp(extpressure, 0, 50*ONE_ATMOSPHERE)
+		parent.updateUsrDialog()
+		return 1
+
+/datum/automation/set_scrubber_pressure_checks
+	name = "Scrubber: Pressure Checks"
+	var/scrubber = null
+	var/checks = 1
+
+/datum/automation/set_scrubber_pressure_checks/Export()
+	var/list/json = ..()
+	json["scrubber"] = scrubber
+	json["checks"] = checks
+
+/datum/automation/set_scrubber_pressure_checks/Import(var/list/json)
+	..(json)
+	scrubber = json["scrubber"]
+	checks = json["checks"]
+
+/datum/automation/set_scrubber_pressure_checks/process()
+	if(scrubber)
+		parent.send_signal(list("tag" = scrubber, "checks" = checks), RADIO_FROM_AIRALARM)
+
+/datum/automation/set_scrubber_pressure_checks/GetText()
+	return {"Set scrubber <a href=\"?src=\ref[src];set_scrubber=1\">[fmtString(scrubber)]</a> pressure checks to:
+			external: <a href=\"?src=\ref[src];togglecheck=1\">[checks&1 ? "Enabled" : "Disabled"]</a>,
+			internal: <a href=\"?src=\ref[src];togglecheck=2\">[checks&2 ? "Enabled" : "Disabled"]</a>"}
+
+/datum/automation/set_scrubber_pressure_checks/Topic(href, href_list)
+	if(..())
+		return 1
+
+	if(href_list["set_scrubber"])
+		var/list/injector_names = list()
+		for(var/obj/machinery/atmospherics/unary/vent_scrubber/S in atmos_machines)
+			if(!isnull(S.id_tag) && S.frequency == parent.frequency)
+				injector_names |= S.id_tag
+
+		scrubber = input("Select a scrubber:", "Scrubbers", scrubber) as null | anything in injector_names
+		parent.updateUsrDialog()
+		return 1
+
+	if(href_list["togglecheck"])
+		var/bitflagvalue = text2num(href_list["togglecheck"])
+		if(!(bitflagvalue in list(1, 2)))
+			return 0
+
+		if(checks&bitflagvalue)//the bitflag is on ATM
+			checks &= ~bitflagvalue
+		else//can't not be off
+			checks |= bitflagvalue
+		parent.updateUsrDialog()
+		return 1

--- a/nano/templates/air_alarm.tmpl
+++ b/nano/templates/air_alarm.tmpl
@@ -215,6 +215,29 @@ Used In File(s): /code/game/machinery/alarm.dm
 					</div>
 				</div>
 				{{/if}}
+				<div class="line">
+					<div class="statusLabelWide">Pressure checks:</div>
+					<div class="statusValue">
+						{{:helper.link('External','power',{'id_tag':value.id_tag,'command':'checks','val':helper.xor(value.checks,1)},null,(value.checks & 1 ?'linkOn':'red'))}}
+						{{:helper.link('Internal','power',{'id_tag':value.id_tag,'command':'checks','val':helper.xor(value.checks,2)},null,(value.checks & 2 ?'linkOn':'red'))}}
+					</div>
+				</div>
+				<div class="line">
+					<div class="statusLabelWide">External pressure target:</div>
+					<div class="statusValue">
+						{{:helper.precisionRound(value.external,4)}} kPa
+					</div>
+					{{:helper.link('Set','gear',{'id_tag':value.id_tag,'command':'set_external_pressure'})}}
+					{{:helper.link('Reset','arrowrefresh-1-n',{'id_tag':value.id_tag,'command':'set_external_pressure','val':101.325},null,'linkOn')}}
+				</div>
+				<div class="line">
+					<div class="statusLabelWide">Internal pressure target:</div>
+					<div class="statusValue">
+						{{:helper.precisionRound(value.internal,4)}} kPa
+					</div>
+					{{:helper.link('Set','gear',{'id_tag':value.id_tag,'command':'set_internal_pressure'})}}
+					{{:helper.link('Reset','arrowrefresh-1-n',{'id_tag':value.id_tag,'command':'set_internal_pressure','val':0},null,'linkOn')}}
+				</div>
 			</div>
 		{{empty}}
 			<i>No scrubbers located in this area.</i>
@@ -234,7 +257,7 @@ Used In File(s): /code/game/machinery/alarm.dm
 		</div>
 		<h3>System Preset</h3>
 		<div class="line">
-			Cycle after changing preset 
+			Cycle after changing preset
 			{{if data.cycle_after_preset}}
 				{{:helper.link('Yes', null, {'toggle_cycle_after_preset':1}, null, 'greenBackground')}}
 			{{else}}

--- a/nano/templates/atmos_control.tmpl
+++ b/nano/templates/atmos_control.tmpl
@@ -19,7 +19,7 @@ Used In File(s): /code/game/machinery/alarm.dm
 {{if !data.logged_in}}
 	<div class="line">
 		{{:helper.link('Log in', 'unlocked', {'login': 1})}}
-	</div>	
+	</div>
 {{else}}
 	<div class="line">
 		Logged in as: <b>{{:data.login_name}}</b> {{:helper.link('Log out', 'locked', {'logout': 1}, (data.emagged) ? 'disabled' : null)}}
@@ -30,7 +30,7 @@ Used In File(s): /code/game/machinery/alarm.dm
 			{{:helper.link('Show Tracker Map', 'pin-s', {'reset': 1, 'showMap' : 1})}}
 			{{:helper.link('Show Detail List', 'script', {'set_screen': 1})}}
 		</div>
-		
+
 		<div class="line">
 			<h3>System Presets</h3>
 		</div>
@@ -364,6 +364,29 @@ Used In File(s): /code/game/machinery/alarm.dm
 								</div>
 							</div>
 							{{/if}}
+							<div class="line">
+								<div class="statusLabelWide">Pressure checks:</div>
+								<div class="statusValue">
+									{{:helper.link('External','power',{'id_tag':value.id_tag,'command':'checks','val':helper.xor(value.checks,1)},null,(value.checks & 1 ?'linkOn':'red'))}}
+									{{:helper.link('Internal','power',{'id_tag':value.id_tag,'command':'checks','val':helper.xor(value.checks,2)},null,(value.checks & 2 ?'linkOn':'red'))}}
+								</div>
+							</div>
+							<div class="line">
+								<div class="statusLabelWide">External pressure target:</div>
+								<div class="statusValue">
+									{{:helper.precisionRound(value.external,4)}} kPa
+								</div>
+								{{:helper.link('Set','gear',{'id_tag':value.id_tag,'command':'set_external_pressure'})}}
+								{{:helper.link('Reset','arrowrefresh-1-n',{'id_tag':value.id_tag,'command':'set_external_pressure','val':101.325},null,'linkOn')}}
+							</div>
+							<div class="line">
+								<div class="statusLabelWide">Internal pressure target:</div>
+								<div class="statusValue">
+									{{:helper.precisionRound(value.internal,4)}} kPa
+								</div>
+								{{:helper.link('Set','gear',{'id_tag':value.id_tag,'command':'set_internal_pressure'})}}
+								{{:helper.link('Reset','arrowrefresh-1-n',{'id_tag':value.id_tag,'command':'set_internal_pressure','val':0},null,'linkOn')}}
+							</div>
 						</div>
 					{{empty}}
 						<i>No scrubbers located in this area.</i>
@@ -383,7 +406,7 @@ Used In File(s): /code/game/machinery/alarm.dm
 					</div>
 					<h3>System Preset</h3>
 					<div class="line">
-						Cycle after changing preset 
+						Cycle after changing preset
 						{{if data.cycle_after_preset}}
 							{{:helper.link('Yes', null, {'toggle_cycle_after_preset':1}, null, 'greenBackground')}}
 						{{else}}


### PR DESCRIPTION
burneddi: scrubbers switching to siphon if there's excess pressure in the room when
Exxion: There definitely needs to be some kind of overflow collector, even if it's a separate device
Exxion: Without it, there are problems like disposal pipes gradually pressurizing rooms and the vox trading floor

This is that. 👆

Scrubbers now have an external pressure target and an internal pressure target, similar to vent pumps. They aim to maintain the room at the external pressure target, siphoning gas if it is exceeded. The internal pressure target is the maximum pressure in their output pipe: in normal scrubbing mode they will not exceed this if it is enabled. It's disabled by default, and ignored in siphoning mode (it is, after all, a panic siphon). I don't know why you would want to use it (maybe to avoid clogging waste or something), but it's there.

The scrubber icon turns green when it's sucking out gas this way.

![scrub](https://user-images.githubusercontent.com/5822375/62753357-fcfdaf00-ba73-11e9-8629-b5ede50facbe.gif)

There are controls to adjust this in air alarms, as well as atmospheric automation consoles.

![1565318202177](https://user-images.githubusercontent.com/5822375/62753370-10a91580-ba74-11e9-8140-0f4b086e2671.png)

This probably isn't the most elegant solution of them all but it does the job and works intuitively enough (to my brain).

:cl:
 * rscadd: Scrubbers now have external pressure bounds. They will aim to keep the room at or below this pressure, siphoning gas if it is exceeded. It's set to 1 ATM by default.
 * rscadd: Scrubbers now have internal pressure bounds. They will not exceed this pressure when scrubbing gas into their output. It's disabled by default and is ignored when siphoning all gas.