### PR TITLE
Allows rulesets to bypass enemy job requirements at 80+ threat level

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets.dm
@@ -85,7 +85,7 @@
 	if (!enemy_jobs.len)
 		return TRUE
 
-	if (threat_level >= 80)
+	if (mode.threat_level >= 80)
 		return TRUE
 
 	var/enemies_count = 0

--- a/code/datums/gamemode/dynamic/dynamic_rulesets.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets.dm
@@ -85,6 +85,9 @@
 	if (!enemy_jobs.len)
 		return TRUE
 
+	if (threat_level >= 80)
+		return TRUE
+
 	var/enemies_count = 0
 	if (dead_dont_count)
 		for (var/mob/M in mode.living_players)


### PR DESCRIPTION
:cl:
* rscadd: Dynamic Mode: At very high threat level (80+), rulesets will bypass enemy job requirements.