### PR TITLE
Coldroom preset scrubs oxygen and maintains 1 ATM pressure

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -141,7 +141,7 @@
 	plasma = list(-1, -1, 0.2, 0.5)
 	n2o = list(-1, -1, 0.5, 1)
 	other = list(-1, -1, 0.5, 1)
-	pressure = list(-1, ONE_ATMOSPHERE*0.10, ONE_ATMOSPHERE*1.40, ONE_ATMOSPHERE*1.60)
+	pressure = list(ONE_ATMOSPHERE*0.80, ONE_ATMOSPHERE*0.90, ONE_ATMOSPHERE*1.10, ONE_ATMOSPHERE*1.20)
 	temperature = list(20, 40, 140, 160)
 	target_temperature = 90
 	scrubbers_gases = list("oxygen" = 1, "nitrogen" = 0, "carbon_dioxide" = 1, "plasma" = 1, "n2o" = 0)

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -141,7 +141,7 @@
 	plasma = list(-1, -1, 0.2, 0.5)
 	n2o = list(-1, -1, 0.5, 1)
 	other = list(-1, -1, 0.5, 1)
-	pressure = list(ONE_ATMOSPHERE*0.80, ONE_ATMOSPHERE*0.90, ONE_ATMOSPHERE*1.10, ONE_ATMOSPHERE*1.20)
+	pressure = list(-1, ONE_ATMOSPHERE*0.10, ONE_ATMOSPHERE*1.90, ONE_ATMOSPHERE*2.3)
 	temperature = list(20, 40, 140, 160)
 	target_temperature = 90
 	scrubbers_gases = list("oxygen" = 1, "nitrogen" = 0, "carbon_dioxide" = 1, "plasma" = 1, "n2o" = 0)

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -144,7 +144,7 @@
 	pressure = list(-1, ONE_ATMOSPHERE*0.10, ONE_ATMOSPHERE*1.40, ONE_ATMOSPHERE*1.60)
 	temperature = list(20, 40, 140, 160)
 	target_temperature = 90
-	scrubbers_gases = list("oxygen" = 0, "nitrogen" = 0, "carbon_dioxide" = 1, "plasma" = 1, "n2o" = 0)
+	scrubbers_gases = list("oxygen" = 1, "nitrogen" = 0, "carbon_dioxide" = 1, "plasma" = 1, "n2o" = 0)
 
 /datum/airalarm_preset/plasmaman //HONK
 	name = "Plasmaman"
@@ -244,7 +244,7 @@ var/global/list/airalarm_presets = list(
 	TLV["other"] =			presetdata.other.Copy()
 	TLV["pressure"] =		presetdata.pressure.Copy()
 	TLV["temperature"] =	presetdata.temperature.Copy()
-	target_temperature =	presetdata.target_temperature	
+	target_temperature =	presetdata.target_temperature
 	if(!no_cycle_after)
 		mode = AALARM_MODE_CYCLE
 	// Propagate settings.
@@ -599,7 +599,7 @@ var/global/list/airalarm_presets = list(
 			selected[2] = selected[4]
 		if(selected[3] > selected[4])
 			selected[3] = selected[4]
-	
+
 	//propagate to other air alarms in the area
 	if(propagate)
 		apply_mode()
@@ -966,7 +966,7 @@ var/global/list/airalarm_presets = list(
 			return 1
 		set_alarm(0)
 		return 1
-	
+
 	if(href_list["enable_override"])
 		if(locked && !issilicon(usr))
 			return 1
@@ -975,7 +975,7 @@ var/global/list/airalarm_presets = list(
 		this_area.UpdateFirelocks()
 		update_icon()
 		return 1
-	
+
 	if(href_list["disable_override"])
 		if(locked && !issilicon(usr))
 			return 1


### PR DESCRIPTION
I was mapping telecomms and noticed some things about the coldroom preset on air alarms (and coldrooms in general) that could do with improving. Coldrooms have a nitrogen atmosphere, but weren't scrubbing out oxygen. They also had a needlessly low pressure target. More pressure means more moles means more efficient cooling, *and* it minimizes gas loss if the chamber is breached (because hot gas doesn't get sucked in to a low pressure area), so I don't see why not.

:cl:
 * tweak: Server rooms now siphon out oxygen and maintain a 1 ATM pressure.