### PR TITLE
Drinking Glass Examine Nerf

### DIFF
--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -906,6 +906,9 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 	if(obscured && !vis_override)
 		to_chat(user, "<span class='info'>You can't quite make out the contents.</span>")
 		return
+	if (istype(my_atom,/obj/item/weapon/reagent_containers/food/drinks/drinkingglass) && reagent_list.len)
+		to_chat(user, "<span class='info'>It contains [total_volume] units of what looks like [get_master_reagent_name()].</span>")
+		return
 	to_chat(user, "It contains:")
 	if(!user.hallucinating())
 		if(reagent_list.len)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7573912/62840177-6bba5280-bc96-11e9-8a8d-23be6bc11811.png)

Closes #23762

> Issue: Right now the only way to "poison" or trick people into ingesting suspicious reagents is with badly named pills. That's also why floor pills are a popular meme I guess. Anyway, I don't know how far back have we been able to just examine glasses to get their content, but I think it's kinda detrimental to the bartender experience (traitor and otherwise).
> 
> I mean sure there's the "black color" reagent you can hide to a glass to turn it into an "international drink of mystery" but that's kinda on the nose and not subtle at all.
> 
> So here I thought, hey maybe we could go back to only beakers and other chemistry containers having detailed readings. Paranoid people could still carry a beaker to get the exact contents out of a bar drink, but that'd still require to go an extra step beyond shift+click.


:cl:
* tweak: When examining a drinking glass (and only drinking glasses specifically), you no longer get the list of every reagent in it. Instead you get the total volume, as well as the identity of the reagent that's with the largest quantity.