### PR TITLE
Supply display subtype

### DIFF
--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -50,6 +50,9 @@ var/global/list/status_displays = list() //This list contains both normal status
 	maptext_width = WORLD_ICON_SIZE
 	layer = ABOVE_WINDOW_LAYER
 
+/obj/machinery/status_display/supply
+	supply_display = 1
+
 // new display
 // register for radio system
 /obj/machinery/status_display/New()


### PR DESCRIPTION
Back in the day when mapping roid, this being a var led to no end of confusion and half the status displays on the station showed the cargo shuttle ETA. Better make it a subtype.