### PR TITLE
Mapping pipes QoL

### DIFF
--- a/code/ATMOSPHERICS/components/unary/vent_pump.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_pump.dm
@@ -41,15 +41,12 @@
 
 /obj/machinery/atmospherics/unary/vent_pump/on
 	on = 1
-	icon_state = "hout"
 
 /obj/machinery/atmospherics/unary/vent_pump/siphon
 	pump_direction = 0
-	icon_state = "hoff"
 
 /obj/machinery/atmospherics/unary/vent_pump/siphon/on
 	on = 1
-	icon_state = "hin"
 
 /obj/machinery/atmospherics/unary/vent_pump/New()
 	..()

--- a/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
@@ -35,7 +35,6 @@
 
 /obj/machinery/atmospherics/unary/vent_scrubber/on
 	on					= 1
-	icon_state			= "on"
 
 /obj/machinery/atmospherics/unary/vent_scrubber/on/burn_chamber
 	name				= "\improper Burn Chamber Scrubber"
@@ -44,6 +43,12 @@
 	id_tag				= "inc_out"
 
 	scrub_Toxins		= 0
+
+/obj/machinery/atmospherics/unary/vent_scrubber/vox
+	scrub_O2 = 1
+
+/obj/machinery/atmospherics/unary/vent_scrubber/on/vox
+	scrub_O2 = 1
 
 /obj/machinery/atmospherics/unary/vent_scrubber/New()
 	..()

--- a/code/ATMOSPHERICS/pipe_defines_for_mapping.dm
+++ b/code/ATMOSPHERICS/pipe_defines_for_mapping.dm
@@ -34,6 +34,14 @@
 	piping_layer=DEF_PIPELAYER_SCRUBBERS
 	pixel_x=DEF_PIXELX_SCRUBBERS
 	pixel_y=DEF_PIXELY_SCRUBBERS
+/obj/machinery/atmospherics/unary/vent_scrubber/on/layered
+	piping_layer=DEF_PIPELAYER_SCRUBBERS
+	pixel_x=DEF_PIXELX_SCRUBBERS
+	pixel_y=DEF_PIXELY_SCRUBBERS
+/obj/machinery/atmospherics/unary/vent_scrubber/on/vox/layered
+	piping_layer=DEF_PIPELAYER_SCRUBBERS
+	pixel_x=DEF_PIXELX_SCRUBBERS
+	pixel_y=DEF_PIXELY_SCRUBBERS
 /obj/machinery/atmospherics/pipe/layer_adapter/scrubbers
 	piping_layer=DEF_PIPELAYER_SCRUBBERS
 	icon_state="adapter_4"
@@ -66,6 +74,14 @@
 	pixel_x=DEF_PIXELX_SUPPLY
 	pixel_y=DEF_PIXELY_SUPPLY
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layered
+	piping_layer=DEF_PIPELAYER_SUPPLY
+	pixel_x=DEF_PIXELX_SUPPLY
+	pixel_y=DEF_PIXELY_SUPPLY
+/obj/machinery/atmospherics/unary/vent_pump/layered
+	piping_layer=DEF_PIPELAYER_SUPPLY
+	pixel_x=DEF_PIXELX_SUPPLY
+	pixel_y=DEF_PIXELY_SUPPLY
+/obj/machinery/atmospherics/unary/vent_pump/on/layered
 	piping_layer=DEF_PIPELAYER_SUPPLY
 	pixel_x=DEF_PIXELX_SUPPLY
 	pixel_y=DEF_PIXELY_SUPPLY


### PR DESCRIPTION
This changes the default icon_states on vents and scrubbers so that instead of looking like this in the mapper:

![1565844383744](https://user-images.githubusercontent.com/5822375/63073471-9f64d900-bf31-11e9-84fc-b4aa9fdf7721.png)

they look like this:

![1565844333333](https://user-images.githubusercontent.com/5822375/63073474-a390f680-bf31-11e9-816c-afb320c6cb7c.png)

It also adds a couple of subtypes such as vox-preset scrubbers (scrubbing O2) and layered scrubbers that are turned on.

Should have no in-game effects (the icons get set in `New()` or somewhere else during init anyway)