### PR TITLE
Market Bugfix and Capitalization

### DIFF
--- a/code/datums/black_market_item.dm
+++ b/code/datums/black_market_item.dm
@@ -133,7 +133,7 @@ var/list/black_market_items = list()
 	radio.interact(user)
 
 	spawn(rand(15 SECONDS, 45 SECONDS))
-		var/obj/spawned_item = new item(get_turf(user),user)
+		var/obj/spawned_item = new item(get_turf(user))
 		if(!spawned_item)
 			if(radio)
 				radio.visible_message("The [radio.name] beeps: <span class='warning'>Okay, somehow we lost an item we were going to send to you. You've been refunded. Not really sure how that managed to happen.</span>")
@@ -181,7 +181,7 @@ var/locations_calculated = 0
 	radio.interact(user)
 
 	spawn(time_to_spawn)
-		var/obj/spawned_item = new item(spawnloc,user)
+		var/obj/spawned_item = new item(spawnloc)
 		after_spawn(spawned_item,NORMAL,user)
 		spawn(rand(30 SECONDS, 60 SECONDS))
 			if(!radio.nanotrasen_variant && prob(sps_chances[NORMAL]))
@@ -189,7 +189,7 @@ var/locations_calculated = 0
 
 /datum/black_market_item/proc/spawn_expensive(var/obj/item/device/illegalradio/radio, var/mob/user)
 	process_transaction(radio, EXPENSIVE)
-	var/obj/spawned_item = new item(get_turf(user),user)
+	var/obj/spawned_item = new item(get_turf(user))
 	if(!spawned_item)
 		if(radio)
 			radio.visible_message("The [radio.name] beeps: <span class='warning'>Okay, somehow we lost an item we were going to send to you. You've been refunded. Not really sure how that managed to happen.</span>")
@@ -315,7 +315,7 @@ for anyone but the person committing mass murder.
 	category = "Seeds"
 
 /datum/black_market_item/plants/mushroommanspore
-	name = "packet of walking mushroom seeds"
+	name = "Packet of Walking Mushroom Seeds"
 	desc = "Sentient mushfriends for all your mushy needs"
 	item = /obj/item/seeds/mushroommanspore
 	sps_chances = list(0, 10, 30)


### PR DESCRIPTION
This PR adds the same bugfix as in #23862 while also capitalizing the display name of mushroom seeds on the black market to make it consistent with other items on the market.
With the current code, any meat and hides would be named after the buyer. No current items suffer from this, and it only helps items that I am adding in another PR.  This is PR three of four.

Compiled and lightly tested locally

:cl:
 * rscadd: Capitalizes the name of mushroom seeds on the black market
 * bugfix: Black market spawns are no longer named based on the person buying them