### PR TITLE
vector does more damage

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -148,6 +148,12 @@
 	agony = 1
 	penetration = 2
 
+/obj/item/projectile/bullet/auto380/OnFired() //vector does more damage with regular ammo
+	..()
+	//ispath() is reversed and cuts offs any subclass, it just works
+	if(ispath(/obj/item/projectile/bullet/auto380, type) && istype(shot_from, /obj/item/weapon/gun/projectile/automatic/vector))
+		damage += 4
+
 /obj/item/projectile/bullet/auto380/practice
 	damage = 2
 	drowsy = 0


### PR DESCRIPTION
Vector does more damage with regular .380. That's all. Yes, I like it, the gun is cool but ammo issue for it has only become worse after removal of easy .357/shotgunshell alternative. A lot of people has expressed their discontent with it and it doesn't really see much use. Now along with being recoilless and better damage it will become a valid choice of a ballistic weapon.

[tweak]

:cl:
 * tweak: Vector now does more damage with regular .380 ammo.