### PR TITLE
Recursive cyber horror works

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/monster.dm
+++ b/code/modules/mob/living/simple_animal/hostile/monster.dm
@@ -120,7 +120,7 @@
 /mob/living/simple_animal/hostile/monster/cyber_horror/monster/New(loc, var/mob/living/who_we_were)
 	name = who_we_were.name+" cyber horror"
 	desc = "What was once \a [who_we_were], twisted by machine."
-	var/multiplier = who_we_were.reagents.has_reagent(MEDNANOBOTS)?who_we_were.reagents.get_reagent_amount(MEDNANOBOTS)/10:1
+	var/multiplier = min(3,who_we_were.reagents.has_reagent(MEDNANOBOTS)?who_we_were.reagents.get_reagent_amount(MEDNANOBOTS)/10:1)
 	var/has_robo_icon = FALSE
 	if(isanimal(who_we_were))
 		var/mob/living/simple_animal/S = who_we_were

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -3494,18 +3494,20 @@
 		if(5 to 20)	//Processing above 5 units runs the risk of getting a big enough dose of nanobots to turn you into a cyberhorror.
 			percent_machine += 0.5 //The longer it metabolizes at this stage the more likely.
 			if(prob(20))
-				to_chat(M, pick("<span class='warning'>Something shifts inside you...</span>", 
+				to_chat(M, pick("<span class='warning'>Something shifts inside you...</span>",
 								"<span class='warning'>You feel different, somehow...</span>"))
 			if(prob(percent_machine))
 				holder.add_reagent("mednanobots", 20)
 				to_chat(M, pick("<b><span class='warning'>Your body lurches!</b></span>"))
 		if(20 to INFINITY) //Now you've done it.
+			if(istype(M, /mob/living/simple_animal/hostile/monster/cyber_horror))
+				return
 			spawning_horror = 1
 			to_chat(M, pick("<b><span class='warning'>Something doesn't feel right...</span></b>", "<b><span class='warning'>Something is growing inside you!</span></b>", "<b><span class='warning'>You feel your insides rearrange!</span></b>"))
 			spawn(60)
 				if(spawning_horror == 1)
 					to_chat(M, "<b><span class='warning'>Something bursts out from inside you!</span></b>")
-					message_admins("[key_name(M)] has gibbed and spawned a new cyber horror due to nanobots. ([formatJumpTo(M)])")
+					message_admins("[key_name(M)] [M] has gibbed and spawned a new cyber horror due to nanobots. ([formatJumpTo(M)])")
 					if(ishuman(M))
 						var/mob/living/carbon/human/H = M
 						var/typepath

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -3497,7 +3497,7 @@
 				to_chat(M, pick("<span class='warning'>Something shifts inside you...</span>",
 								"<span class='warning'>You feel different, somehow...</span>"))
 			if(prob(percent_machine))
-				holder.add_reagent("mednanobots", 20)
+				holder.add_reagent(MEDNANOBOTS, 20)
 				to_chat(M, pick("<b><span class='warning'>Your body lurches!</b></span>"))
 		if(20 to INFINITY) //Now you've done it.
 			if(istype(M, /mob/living/simple_animal/hostile/monster/cyber_horror))


### PR DESCRIPTION
closes #23874 

>throw an antag belt cyber horror at a perfectly normal monkey
>wait 10~ minutes
>receive two recursive cyber-horror levels later, who have 400k health and punch for upwards of 1000