### PR TITLE
Fix runtime on nullspaced brains on CMC

### DIFF
--- a/code/modules/cmc/crew.dm
+++ b/code/modules/cmc/crew.dm
@@ -245,7 +245,11 @@ GENERAL PROCS
 
 	for(var/mob/living/carbon/brain/B in mob_list)
 		var/obj/item/device/mmi/M = B.loc
-		var/parea = format_text(get_area(B).name)
+		var/parea = "ERROR"
+		// area can be null in the case of nullspacing
+		var/area/A = get_area(B)
+		if(A)
+			parea = format_text(A.name)
 
 		if(istype(M.loc,/obj/item/weapon/storage/belt/silicon))
 			continue

--- a/code/modules/cmc/crew.dm
+++ b/code/modules/cmc/crew.dm
@@ -248,14 +248,14 @@ GENERAL PROCS
 		var/parea = "ERROR"
 		// area can be null in the case of nullspacing
 		var/area/A = get_area(B)
-		if(A)
+		if(!isnull(A))
 			parea = format_text(A.name)
 
 		if(istype(M.loc,/obj/item/weapon/storage/belt/silicon))
 			continue
 
 		var/turf/pos = get_turf(B)
-		if((pos.z in all_tracked_z_levels) && istype(M) && M.brainmob == B && !isrobot(M.loc))
+		if(!isnull(pos) && (pos.z in all_tracked_z_levels) && istype(M) && M.brainmob == B && !isrobot(M.loc))
 			var/see_x = pos.x - WORLD_X_OFFSET[pos.z]
 			var/see_y = pos.y - WORLD_Y_OFFSET[pos.z]
 			entries[pos.z][++entries[pos.z].len] = list(see_x, see_y, B, "[B]", "MMI", null, null, parea, 60, pos)


### PR DESCRIPTION
[hotfix]
Relevant runtime:
```
[03:30:00] Runtime in crew.dm,248: Cannot read null.name
  proc name: scanCrew (/obj/machinery/computer/crew/proc/scanCrew)
  usr: Orlando T. Allen (mastercasual) (/mob/living/carbon/human)
  usr.loc: The floor (247, 244, 1) (/turf/simulated/floor)
  src: Crew monitoring computer (/obj/machinery/computer/crew)
  src.loc: the floor (246,243,1) (/turf/simulated/floor)
  call stack:
  Crew monitoring computer (/obj/machinery/computer/crew): scanCrew()
  Crew monitoring computer (/obj/machinery/computer/crew): initializeUser(Orlando T. Allen (/mob/living/carbon/human))
  Crew monitoring computer (/obj/machinery/computer/crew): attack hand(Orlando T. Allen (/mob/living/carbon/human), "icon-x=12;icon-y=19;left=1;scr...", 1)
  Orlando T. Allen (/mob/living/carbon/human): UnarmedAttack(Crew monitoring computer (/obj/machinery/computer/crew), 1, "icon-x=12;icon-y=19;left=1;scr...")
  Orlando T. Allen (/mob/living/carbon/human): ClickOn(Crew monitoring computer (/obj/machinery/computer/crew), "icon-x=12;icon-y=19;left=1;scr...")
  Crew monitoring computer (/obj/machinery/computer/crew): Click(the floor (246,243,1) (/turf/simulated/floor), "mapwindow.map", "icon-x=12;icon-y=19;left=1;scr...")
  Mastercasual (/client): Click(Crew monitoring computer (/obj/machinery/computer/crew), the floor (246,243,1) (/turf/simulated/floor), "mapwindow.map", "icon-x=12;icon-y=19;left=1;scr...")
```
A few notes:
 - Yes, brains should probably not being hanging out in nullspace
 - No, this does not affect anything other than brains
 - Yes, it's silly to have to fix this when it isn't the source of the problem, but it makes up the majority of runtime logs at present, and has for months
 - I think someone said it was probably related to MoMMIs