### PR TITLE
Stop malformed monkeys from growing inside of you when you fork a monkey cube

### DIFF
--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -115,6 +115,10 @@
 		to_chat(user, "<span class='notice'>It wouldn't make sense to put \the [snack.name] on a fork.</span>")
 		return
 
+	if(snack.food_flags & FOOD_LIQUID)
+		to_chat(user, "<span class='notice'>You can't eat that with a fork.</span>")
+		return
+
 	if(loaded_food)
 		to_chat(user, "<span class='notice'>You already have food on \the [src].</span>")
 		return

--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -111,6 +111,10 @@
 	if(!snack || !user || !istype(snack) || !istype(user))
 		return
 
+	if(!snack.edible_by_utensil)
+		to_chat(user, "<span class='notice'>It wouldn't make sense to put \the [snack.name] on a fork.</span>")
+		return
+
 	if(loaded_food)
 		to_chat(user, "<span class='notice'>You already have food on \the [src].</span>")
 		return

--- a/code/modules/reagents/reagent_containers/food/mobcube.dm
+++ b/code/modules/reagents/reagent_containers/food/mobcube.dm
@@ -4,6 +4,7 @@
 	icon_state = "monkeycube"
 	bitesize = 12
 	food_flags = FOOD_MEAT
+	edible_by_utensil = FALSE
 	var/contained_mob = /mob/living/carbon/monkey
 
 /obj/item/weapon/reagent_containers/food/snacks/monkeycube/New()

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -29,6 +29,7 @@
 	var/dried_type = null //What can we dry the food into
 	var/deepfried = 0 //Is the food deep-fried ?
 	var/filling_color = "#FFFFFF" //What color would a filling of this item be ?
+	var/edible_by_utensil = TRUE //Can this snack be put on a fork?
 	volume = 100 //Double amount snacks can carry, so that food prepared from excellent items can contain all the nutriments it deserves
 
 /obj/item/weapon/reagent_containers/food/snacks/Destroy()


### PR DESCRIPTION
Closes #23871
I added a boolean to `/obj/item/weapon/reagent_containers/food/snacks` that is used to allow or deny the forking of a snack. The way forks handle the last bite of a snack is kind of fucky and doesn't work well with how the monkey cube determines when it is eaten.
This is just a workaround, I'm open to suggestions on how this should be handled.
