### PR TITLE
Extinguisher cabinets can be closed with alt-click

### DIFF
--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -60,8 +60,8 @@
 	return
 
 /obj/structure/extinguisher_cabinet/AltClick(var/mob/user)
-	..()
 	if(user.incapacitated() || !Adjacent(user))
+		..()
 		return
 	opened = !opened
 	update_icon()

--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -59,6 +59,13 @@
 	attack_hand(user)
 	return
 
+/obj/structure/extinguisher_cabinet/AltClick(var/mob/user)
+	..()
+	if(user.incapacitated() || !Adjacent(user))
+		return
+	opened = !opened
+	update_icon()
+
 
 /obj/structure/extinguisher_cabinet/update_icon()
 	if(!opened)


### PR DESCRIPTION
A pet peeve of mine is that once you put a fire extinguisher back in its cabinet, you can't close it by clicking on it with an empty hand because you'll take the extinguisher right back out. Now you can alt-click them to toggle the open/close state.

:cl:
 * rscadd: Extinguisher cabinets can now be alt-clicked to open or close them.