### PR TITLE
Heads can't be gibbed anymore.

### DIFF
--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -1438,10 +1438,10 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 	return B
 
+
+// Spessmen have very thick skulls. Made it solely so that permanent round removal is more difficult.
 /datum/organ/external/head/explode()
-	owner.remove_internal_organ(owner, owner.internal_organs_by_name["brain"], src)
-	.=..()
-	owner.update_hair()
+	return FALSE
 
 /datum/organ/external/head/get_icon(gender = "", isFat = 0)
 	if(!owner)


### PR DESCRIPTION
I suffer from a chronic allergy to permanent round removal.
There are three ways for me to cure this.

The first one is to not play anymore. I rather like this game and this server, so I would prefer try the other options.
The second one is to do something is to talk to the admins about it. Unfortunately, a number of factors - inertia, cowardice, ideological sympathy for murderboners ? Hard to tell. - prevent any real discussion about it. I do believe it is however a topic worth talking about and worth changing.

The last option is to do something about it via the code.
One thing depopulators like to do is to gib the heads of the people they slain and polyacid their brain, ensuring that they can never be found again. I for one find it a bit distasteful. It is also what I can consider a perversion of a cool mechanic (limb gimbing) to do something not so cool (permanent removal).

This PR aims to change that by simply making it so you can't gib heads anymore, requiring slightly more effort for our hard-working depopulators that make ss13 a better game for everyone.

One might argue this is code-grudging. And one would be entirely right. However, codegrudging is widely accepted if the party being grudged are people the readers don't like.
I don't like depopulators. Do you? 

The canon explanation for this being that spessmen have an abnormally thick skull which makes their head more resistant than usual.

:cl:
- tweak: Can no longer gib heads.