### PR TITLE
Lattices now smooth properly

### DIFF
--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -20,11 +20,10 @@
 
 /obj/structure/lattice/New(loc)
 	..(loc)
-
 	icon = 'icons/obj/smoothlattice.dmi'
 
+/obj/structure/lattice/initialize()
 	relativewall()
-
 	relativewall_neighbours()
 
 /obj/structure/lattice/relativewall()

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -21,6 +21,8 @@
 /obj/structure/lattice/New(loc)
 	..(loc)
 	icon = 'icons/obj/smoothlattice.dmi'
+	if(ticker && ticker.current_state >= GAME_STATE_PLAYING)
+		initialize()
 
 /obj/structure/lattice/initialize()
 	relativewall()


### PR DESCRIPTION
Fixes #18744

I don't know if this meaningfully slows initializations down (almost certainly not) or if there are other things that call these procs in `New()` and are not smoothing properly (almost certainly yes), and frankly I don't really care. But let me know if you know better than I anyway.

:cl:
 * bugfix: lattices now smooth properly with catwalks to their north