### PR TITLE
Adds a dot to the end of say and emote messages if they don't have dots, or have exclamation or question marks

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -327,7 +327,7 @@ proc/checkhtml(var/t)
 //Adds a dot at the end of the text unless there already is a dot, question mark, or exclamation point
 /proc/add_dot(var/t as text)
 	var/ending = copytext(t, length(t)) //Copies the last letter of the text
-	if((ending == "?") || (ending == "!") || (ending == "."))
+	if((ending == "?") || (ending == "!") || (ending == ".") || (ending == "-") || (ending == ";") || (ending == ","))
 		return t
 	else
 		return t + "."

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -325,8 +325,10 @@ proc/checkhtml(var/t)
 	return uppertext(copytext(t, 1, 2)) + copytext(t, 2)
 
 //Adds a dot at the end of the text unless there already is a dot, question mark, or exclamation point
-/proc/add_dot(var/t as text)
+/proc/add_dot(var/t)
 	var/ending = copytext(t, length(t)) //Copies the last letter of the text
+	if(!length(ending)) //Don't bother with text if the length is 0
+		return
 	if((ending == "?") || (ending == "!") || (ending == ".") || (ending == "-") || (ending == ";") || (ending == ","))
 		return t
 	else

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -324,6 +324,14 @@ proc/checkhtml(var/t)
 /proc/capitalize(var/t as text)
 	return uppertext(copytext(t, 1, 2)) + copytext(t, 2)
 
+//Adds a dot at the end of the text unless there already is a dot, question mark, or exclamation point
+/proc/add_dot(var/t as text)
+	var/ending = copytext(t, length(t)) //Copies the last letter of the text
+	if((ending == "?") || (ending == "!") || (ending == "."))
+		return t
+	else
+		return t + "."
+
 //Centers text by adding spaces to either side of the string.
 /proc/dd_centertext(message, length)
 	var/new_message = message

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -58,6 +58,7 @@
 		return
 
 	var/message = params
+	message = add_dot(message)
 
 	if(copytext(message,1,5) == "says")
 		to_chat(user, "<span class='danger'>Invalid emote.</span>")

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -103,6 +103,7 @@ var/list/department_radio_keys = list(
 		return //under the effects of time magick
 	message = trim(copytext(message, 1, MAX_MESSAGE_LEN))
 	message = capitalize(message)
+	message = add_dot(message)
 
 	say_testing(src, "Say start, message=[message]")
 	if(!message)


### PR DESCRIPTION
In hindsight I should add more things to that list
Where were you when I made a quality PR for once?
I think I saw this on Bee once like almost a month ago and it was a neat little feature that I coded it from scratch
:cl:
 * rscadd: You will now automatically add a dot at the end of whatever you say or emote if there is no dot, question mark, or exclamation mark.