### PR TITLE
Autolathe stethoscope

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -90,6 +90,7 @@
 		new /obj/item/weapon/retractor(),\
 		new /obj/item/weapon/cautery(),\
 		new /obj/item/weapon/hemostat(),\
+		new /obj/item/clothing/accessory/stethoscope(),\
 		),
 		"Ammunition"=list(
 		new /obj/item/ammo_casing/shotgun/blank(), \

--- a/code/modules/clothing/accessories/accessory.dm
+++ b/code/modules/clothing/accessories/accessory.dm
@@ -127,6 +127,7 @@
 	origin_tech = Tc_BIOTECH + "=1"
 	restraint_resist_time = 30 SECONDS
 	restraint_apply_sound = "rustle"
+	starting_materials = list(MAT_IRON = 5000, MAT_GLASS = 2500)
 
 /obj/item/clothing/accessory/stethoscope/attack(mob/living/carbon/human/M, mob/living/user)
 	if(ishuman(M) && isliving(user))
@@ -219,13 +220,13 @@
 /obj/item/clothing/accessory/medal/gold/heroism
 	name = "medal of exceptional heroism"
 	desc = "An extremely rare golden medal awarded only by CentComm. To recieve such a medal is the highest honor and as such, very few exist. This medal is almost never awarded to anybody but commanders."
-	
+
 /obj/item/clothing/accessory/medal/byond
 	name = "\improper BYOND support pin"
 	icon_state = "byond"
 	_color = "byond"
 	desc = "A cheap, but surprisingly rare, plastic pin. Sent to supporters by the BYOND corporation."
-	
+
 /obj/item/clothing/accessory/medal/byond/on_attached(obj/item/clothing/C)
 	..()
 	if(ismob(C.loc))


### PR DESCRIPTION
Adds the stethoscope to the autolathe among the medical equipment because it's not available from anywhere else and making it gunk market exclusive seems like a bad plan if its long-term availability is to be ensured.

:cl:
 * rscadd: stethoscopes can be printed from the autolathe