### PR TITLE
do_delay now checks if you are holding the item with any hand instead of active hand

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -709,7 +709,7 @@ proc/GaussRandRound(var/sigma,var/roundto)
 					if(progbar)
 						progbar.loc = null
 			return 0
-		if ( user.loc != user_loc || target.loc != target_loc || user.get_active_hand() != holding || user.isStunned())
+		if ( user.loc != user_loc || target.loc != target_loc || !user.is_holding_item(holding) || user.isStunned())
 			if(progbar)
 				progbar.icon_state = "prog_bar_stopped"
 				spawn(2)

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -710,7 +710,7 @@ proc/GaussRandRound(var/sigma,var/roundto)
 					if(progbar)
 						progbar.loc = null
 			return 0
-		if ( user.loc != user_loc || target.loc != target_loc || (!user.is_holding_item(holding) && needs_item) || user.isStunned())
+		if ( user.loc != user_loc || target.loc != target_loc || (needs_item && !user.is_holding_item(holding)) || user.isStunned())
 			if(progbar)
 				progbar.icon_state = "prog_bar_stopped"
 				spawn(2)

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -845,7 +845,7 @@ proc/GaussRandRound(var/sigma,var/roundto)
 					if(progbar)
 						progbar.loc = null
 			return 0
-		if(needhand && !user.is_holding_item(holding))	//Sometimes you don't want the user to have to keep their active hand
+		if(needhand && !user.is_holding_item(holding))	//Sometimes you don't want the user to have to use any hands
 			if(progbar)
 				progbar.icon_state = "prog_bar_stopped"
 				spawn(2)

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -676,7 +676,8 @@ proc/GaussRandRound(var/sigma,var/roundto)
 	else
 		return get_step(ref, base_dir)
 
-/proc/do_mob(var/mob/user , var/mob/target, var/delay = 30, var/numticks = 10) //This is quite an ugly solution but i refuse to use the old request system.
+//if needs_item is 0 it won't need any item that existed in "holding" to finish
+/proc/do_mob(var/mob/user , var/mob/target, var/delay = 30, var/numticks = 10, var/needs_item = 1) //This is quite an ugly solution but i refuse to use the old request system.
 	if(!user || !target)
 		return 0
 	var/user_loc = user.loc
@@ -709,7 +710,7 @@ proc/GaussRandRound(var/sigma,var/roundto)
 					if(progbar)
 						progbar.loc = null
 			return 0
-		if ( user.loc != user_loc || target.loc != target_loc || !user.is_holding_item(holding) || user.isStunned())
+		if ( user.loc != user_loc || target.loc != target_loc || (!user.is_holding_item(holding) && needs_item) || user.isStunned())
 			if(progbar)
 				progbar.icon_state = "prog_bar_stopped"
 				spawn(2)

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -845,7 +845,7 @@ proc/GaussRandRound(var/sigma,var/roundto)
 					if(progbar)
 						progbar.loc = null
 			return 0
-		if(needhand && !user.do_after_hand_check(holding))	//Sometimes you don't want the user to have to keep their active hand
+		if(needhand && !user.is_holding_item(holding))	//Sometimes you don't want the user to have to keep their active hand
 			if(progbar)
 				progbar.icon_state = "prog_bar_stopped"
 				spawn(2)

--- a/code/modules/mob/living/carbon/complex/martian/martian.dm
+++ b/code/modules/mob/living/carbon/complex/martian/martian.dm
@@ -1,5 +1,3 @@
-#define MARTIANS_AMBIDEXTROUS //Comment out to prevent martians from being able to do multiple do_afters at once
-
 //WORK IN PROGRESS - Martians (name may be changed)
 //Like octopuses but with 6 hands
 
@@ -67,13 +65,6 @@
 	head = null
 
 	..()
-
-#ifdef MARTIANS_AMBIDEXTROUS
-/mob/living/carbon/complex/martian/do_after_hand_check(held_item)
-	//Normally do_after breaks if you switch hands. With martians, it will only break if the used item is dropped
-	//This lets them do multiple things at once.
-	return (held_items.Find(held_item))
-#endif
 
 /mob/living/carbon/complex/martian/eyecheck()
 	var/obj/item/clothing/head/headwear = src.head

--- a/code/modules/mob/living/carbon/stripping.dm
+++ b/code/modules/mob/living/carbon/stripping.dm
@@ -16,7 +16,7 @@
 
 	target_item.add_fingerprint(user) //We don't need to be successful in order to get our prints on the thing
 
-	if(do_mob(user, src, strip_time())) //Fails if the user moves, changes held item, is incapacitated, etc.
+	if(do_mob(user, src, strip_time(), 10, 0)) //Fails if the user moves, changes held item, is incapacitated, etc.
 		if(temp_loc != target_item.loc) //This will also fail if the item to strip went anywhere, necessary because do_mob() doesn't keep track of it.
 			return
 


### PR DESCRIPTION
This means you can do things while doing other things, most noticeably swap hands. You can now weld a wall and fire a gun at the same time for example, regardless of active hand status. This now also works for stripping people for example, and anything that uses do_mob.
:cl:
 * tweak: You can now swap hands while doing things such as welding walls without interrupting the process.