### PR TITLE
Fixes lings creeping out of snowfort

### DIFF
--- a/maps/_map.dm
+++ b/maps/_map.dm
@@ -107,7 +107,7 @@
 			load_dungeon(T)
 
 /datum/map/proc/map_ruleset(var/datum/dynamic_ruleset/DR)
-	if(istype(DR.role_category,/datum/role/changeling))
+	if(DR.role_category == /datum/role/changeling)
 		return FALSE
 	
 	return TRUE //If false, fails Ready()

--- a/maps/_map.dm
+++ b/maps/_map.dm
@@ -107,7 +107,7 @@
 			load_dungeon(T)
 
 /datum/map/proc/map_ruleset(var/datum/dynamic_ruleset/DR)
-	if(DR.role_category == /datum/role/changeling)
+	if(ispath(DR.role_category,/datum/role/changeling))
 		return FALSE
 	
 	return TRUE //If false, fails Ready()

--- a/maps/roidstation.dm
+++ b/maps/roidstation.dm
@@ -37,7 +37,7 @@
 	center_y = 193
 
 /datum/map/active/map_ruleset(var/datum/dynamic_ruleset/DR)
-	if(istype(DR.role_category,/datum/role/blob_overmind))
+	if(ispath(DR.role_category,/datum/role/blob_overmind))
 		return FALSE
 	return TRUE
 

--- a/maps/snaxi.dm
+++ b/maps/snaxi.dm
@@ -42,9 +42,9 @@
     base_turf = /turf/unsimulated/floor/snow
 
 /datum/map/active/map_ruleset(var/datum/dynamic_ruleset/DR)
-	if(DR.role_category == /datum/role/blob_overmind)
+	if(ispath(DR.role_category,/datum/role/blob_overmind))
 		return FALSE
-	if(DR.role_category == /datum/role/changeling)
+	if(ispath(DR.role_category,/datum/role/changeling))
 		return TRUE
 		
 	return TRUE

--- a/maps/snaxi.dm
+++ b/maps/snaxi.dm
@@ -42,9 +42,9 @@
     base_turf = /turf/unsimulated/floor/snow
 
 /datum/map/active/map_ruleset(var/datum/dynamic_ruleset/DR)
-	if(istype(DR.role_category,/datum/role/blob_overmind))
+	if(DR.role_category == /datum/role/blob_overmind)
 		return FALSE
-	if(istype(DR.role_category,/datum/role/changeling))
+	if(DR.role_category == /datum/role/changeling)
 		return TRUE
 		
 	return TRUE


### PR DESCRIPTION
_The expedition was supposed to give us resources and science. Instead, only the cold death waited for us on the frozen asteroid. The cold death, and an old friend we would rather have forgotten._

This is also the reason why blob storms suddenly appear now.

closes #21914

:cl:
- tweak: Duet to improper containment procedures, changelings managed to escape the frozen asteroid to spread across the galaxy once again. This has been corrected.