### PR TITLE
Cleans up welder code

### DIFF
--- a/code/ATMOSPHERICS/components/unary/tank.dm
+++ b/code/ATMOSPHERICS/components/unary/tank.dm
@@ -182,7 +182,6 @@
 	if(iswelder(W) && !anchored)
 		var/obj/item/weapon/weldingtool/WT = W
 		if(!WT.remove_fuel(0,user))
-			to_chat(user, "<span class='notice'>You need more welding fuel to complete this task.</span>")
 			return
 		playsound(src, 'sound/items/Welder2.ogg', 100, 1)
 		user.visible_message("<span class='notice'>[user] starts disassembling \the [src].</span>", \

--- a/code/ATMOSPHERICS/components/unary/tank.dm
+++ b/code/ATMOSPHERICS/components/unary/tank.dm
@@ -181,7 +181,7 @@
 	//deconstruction
 	if(iswelder(W) && !anchored)
 		var/obj/item/weapon/weldingtool/WT = W
-		if(!WT.remove_fuel(0,user))
+		if(!WT.remove_fuel(1,user))
 			return
 		playsound(src, 'sound/items/Welder2.ogg', 100, 1)
 		user.visible_message("<span class='notice'>[user] starts disassembling \the [src].</span>", \

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -552,7 +552,6 @@ Class Procs:
 							)
 		return 1
 	else
-		to_chat(user, "<span class='rose'>You need more welding fuel to complete this task.</span>")
 		return -1
 
 /**

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -536,7 +536,7 @@ Class Procs:
 	user.visible_message("[user.name] starts to [state - 1 ? "unweld": "weld" ] the [src] [state - 1 ? "from" : "to"] the floor.", \
 		"You start to [state - 1 ? "unweld": "weld" ] the [src] [state - 1 ? "from" : "to"] the floor.", \
 		"You hear welding.")
-	if (WT.do_weld(user, src,20, 0))
+	if (WT.do_weld(user, src,20, 1))
 		if(gcDestroyed)
 			return -1
 		switch(state)

--- a/code/game/mecha/mecha_wreckage.dm
+++ b/code/game/mecha/mecha_wreckage.dm
@@ -87,7 +87,7 @@
 		if(isemptylist(welder_salvage))
 			to_chat(user, "You don't see anything that can be cut with [W].")
 			return
-		if (WT.remove_fuel(0,user))
+		if (WT.remove_fuel(1,user))
 			var/type = prob(70)?pick(welder_salvage):null
 			if(type)
 				var/N = new type(get_turf(user))

--- a/code/game/mecha/mecha_wreckage.dm
+++ b/code/game/mecha/mecha_wreckage.dm
@@ -97,7 +97,6 @@
 			else
 				to_chat(user, "You failed to salvage anything valuable from [src].")
 		else
-			to_chat(user, "<span class='notice'>You need more welding fuel to complete this task.</span>")
 			return
 	if(iswirecutter(W))
 		if(isemptylist(wirecutters_salvage))

--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -244,7 +244,7 @@
 				new /obj/item/weapon/metal_blade(get_turf(src.loc))
 			qdel(src)
 		else
-			to_chat(user, "<span class='notice'>You need more welding fuel to complete this task.</span>")
+			return
 
 /obj/item/weapon/kitchen/utensil/knife/large/suicide_act(mob/user)
 	to_chat(viewers(user), pick("<span class='danger'>[user] is slitting \his wrists with the [src.name]! It looks like \he's trying to commit suicide.</span>", \

--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -233,7 +233,7 @@
 		return
 	if(iswelder(W))
 		var/obj/item/weapon/weldingtool/WT = W
-		if(WT.remove_fuel(0, user))
+		if(WT.remove_fuel(1, user))
 			to_chat(user, "You slice the handle off of \the [src].")
 			playsound(user, 'sound/items/Welder.ogg', 50, 1)
 			if(src.loc == user)
@@ -243,7 +243,6 @@
 			else
 				new /obj/item/weapon/metal_blade(get_turf(src.loc))
 			qdel(src)
-		else
 			return
 
 /obj/item/weapon/kitchen/utensil/knife/large/suicide_act(mob/user)

--- a/code/game/objects/items/weapons/table_rack_parts.dm
+++ b/code/game/objects/items/weapons/table_rack_parts.dm
@@ -36,7 +36,7 @@
 		return
 	if (iswelder(W))
 		var/obj/item/weapon/weldingtool/WT = W
-		if(WT.remove_fuel(0, user))
+		if(WT.remove_fuel(1, user))
 			to_chat(user, "You begin the delicate process of heating and moulding \the [src].")
 			playsound(user, 'sound/items/Welder.ogg', 50, 1)
 			if(do_after(user, src, 180))
@@ -49,7 +49,6 @@
 				else
 					new /obj/item/weapon/ghetto_ansible(loc)
 					qdel(src)
-		else
 			return
 	if (istype(W, /obj/item/stack/rods))
 		var/obj/item/stack/rods/rods = W
@@ -214,7 +213,7 @@
 		return
 	if(iswelder(W))
 		var/obj/item/weapon/weldingtool/WT = W
-		if(WT.remove_fuel(0, user))
+		if(WT.remove_fuel(1, user))
 			to_chat(user, "You begin slicing through \the [src].")
 			playsound(user, 'sound/items/Welder.ogg', 50, 1)
 			if(do_after(user, src, 60))
@@ -227,7 +226,6 @@
 				else
 					new /obj/item/weapon/metal_gun_stock(loc)
 					qdel(src)
-		else
 			return
 
 /obj/item/weapon/rack_parts/attack_self(mob/user)

--- a/code/game/objects/items/weapons/table_rack_parts.dm
+++ b/code/game/objects/items/weapons/table_rack_parts.dm
@@ -50,7 +50,7 @@
 					new /obj/item/weapon/ghetto_ansible(loc)
 					qdel(src)
 		else
-			to_chat(user, "<span class='notice'>You need more welding fuel to complete this task.</span>")
+			return
 	if (istype(W, /obj/item/stack/rods))
 		var/obj/item/stack/rods/rods = W
 		if (rods.amount >= 4)
@@ -228,7 +228,7 @@
 					new /obj/item/weapon/metal_gun_stock(loc)
 					qdel(src)
 		else
-			to_chat(user, "<span class='notice'>You need more welding fuel to complete this task.</span>")
+			return
 
 /obj/item/weapon/rack_parts/attack_self(mob/user)
 	var/obj/structure/rack/R = new /obj/structure/rack(user.loc)

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -353,8 +353,10 @@
 		if(A.reagents.trans_to(src, max_fuel))
 			to_chat(user, "<span class='notice'>Welder refueled.</span>")
 			playsound(src, 'sound/effects/refill.ogg', 50, 1, -6)
+		else if(!A.reagents)
+			to_chat(user, "<span class='notice'>\The [A] is empty.</span>")
 		else
-			to_chat(user, "<span class='notice'>The welder is already full.")
+			to_chat(user, "<span class='notice'>\The [src] is already full.</span>")
 		return
 	else if (istype(A, /obj/structure/reagent_dispensers/fueltank) && get_dist(src,A) <= 1 && src.welding)
 		message_admins("[key_name_admin(user)] triggered a fueltank explosion.")

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -337,8 +337,6 @@
 			if(prob(5))
 				remove_fuel(1)
 
-	//I'm not sure what this does. I assume it has to do with starting fires...
-	//...but it doesnt check to see if the welder is on or not.
 	var/turf/location = src.loc
 	if(istype(location, /mob/))
 		var/mob/M = location
@@ -352,9 +350,11 @@
 	if(!proximity)
 		return
 	if (istype(A, /obj/structure/reagent_dispensers/fueltank) && get_dist(src,A) <= 1 && !src.welding)
-		A.reagents.trans_to(src, max_fuel)
-		to_chat(user, "<span class='notice'>Welder refueled</span>")
-		playsound(src, 'sound/effects/refill.ogg', 50, 1, -6)
+		if(A.reagents.trans_to(src, max_fuel))
+			to_chat(user, "<span class='notice'>Welder refueled.</span>")
+			playsound(src, 'sound/effects/refill.ogg', 50, 1, -6)
+		else
+			to_chat(user, "<span class='notice'>The welder is already full.")
 		return
 	else if (istype(A, /obj/structure/reagent_dispensers/fueltank) && get_dist(src,A) <= 1 && src.welding)
 		message_admins("[key_name_admin(user)] triggered a fueltank explosion.")
@@ -364,14 +364,10 @@
 		tank.explode()
 		return
 	if (src.welding)
-		remove_fuel(1)
-		var/turf/location = get_turf(user)
-		if (istype(location, /turf))
-			location.hotspot_expose(source_temperature, 50, 1,surfaces=1)
-			if(isliving(A))
-				var/mob/living/L = A
-				L.IgniteMob()
-
+		if(isliving(A))
+			var/mob/living/L = A
+			L.IgniteMob()
+			remove_fuel(1)
 
 /obj/item/weapon/weldingtool/attack_self(mob/user as mob)
 	toggle(user)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -449,7 +449,7 @@
 
 		if(iswelder(W) && canweld())
 			var/obj/item/weapon/weldingtool/WT = W
-			if(!WT.remove_fuel(0,user))
+			if(!WT.remove_fuel(1,user))
 				return
 			materials.makeSheets(src)
 			for(var/mob/M in viewers(src))
@@ -465,7 +465,7 @@
 		return
 	else if(iswelder(W) && canweld())
 		var/obj/item/weapon/weldingtool/WT = W
-		if(!WT.remove_fuel(0,user))
+		if(!WT.remove_fuel(1,user))
 			return
 		src.welded =! src.welded
 		src.update_icon()

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -450,7 +450,6 @@
 		if(iswelder(W) && canweld())
 			var/obj/item/weapon/weldingtool/WT = W
 			if(!WT.remove_fuel(0,user))
-				to_chat(user, "<span class='notice'>You need more welding fuel to complete this task.</span>")
 				return
 			materials.makeSheets(src)
 			for(var/mob/M in viewers(src))
@@ -467,7 +466,6 @@
 	else if(iswelder(W) && canweld())
 		var/obj/item/weapon/weldingtool/WT = W
 		if(!WT.remove_fuel(0,user))
-			to_chat(user, "<span class='notice'>You need more welding fuel to complete this task.</span>")
 			return
 		src.welded =! src.welded
 		src.update_icon()

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -89,7 +89,7 @@
 	else
 		if(iswelder(W))
 			var/obj/item/weapon/weldingtool/WT = W
-			if(!WT.remove_fuel(0,user))
+			if(!WT.remove_fuel(1,user))
 				return
 			src.welded =! src.welded
 			src.update_icon()

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -90,7 +90,6 @@
 		if(iswelder(W))
 			var/obj/item/weapon/weldingtool/WT = W
 			if(!WT.remove_fuel(0,user))
-				to_chat(user, "<span class='notice'>You need more welding fuel to complete this task.</span>")
 				return
 			src.welded =! src.welded
 			src.update_icon()

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -473,7 +473,7 @@ var/list/one_way_windows
 					var/obj/item/weapon/weldingtool/WT = W
 					user.visible_message("<span class='warning'>[user] starts disassembling \the [src].</span>", \
 						"<span class='notice'>You start disassembling \the [src].</span>")
-					if(WT.do_weld(user, src, 40, 0) && d_state == WINDOWLOOSE) //Extra condition needed to avoid cheesing
+					if(WT.do_weld(user, src, 40, 1) && d_state == WINDOWLOOSE) //Extra condition needed to avoid cheesing
 						playsound(src, 'sound/items/Welder.ogg', 100, 1)
 						user.visible_message("<span class='warning'>[user] disassembles \the [src].</span>", \
 						"<span class='notice'>You disassemble \the [src].</span>")

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -481,7 +481,6 @@ var/list/one_way_windows
 						qdel(src)
 						return
 					else
-						to_chat(user, "<span class='warning'>You need more welding fuel to complete this task.</span>")
 						return
 
 	else if(!reinforced) //Normal window steps

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -627,7 +627,7 @@ turf/simulated/floor/update_icon()
 		var/obj/item/weapon/weldingtool/welder = C
 		if(welder.isOn() && (is_plating()))
 			if(broken || burnt)
-				if(welder.remove_fuel(0,user))
+				if(welder.remove_fuel(1,user))
 					to_chat(user, "<span class='warning'>You fix some dents on the broken plating.</span>")
 					playsound(src, 'sound/items/Welder.ogg', 80, 1)
 					icon_state = "plating"

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -634,7 +634,7 @@ turf/simulated/floor/update_icon()
 					burnt = 0
 					broken = 0
 				else
-					to_chat(user, "<span class='notice'>You need more welding fuel to complete this task.</span>")
+					return
 
 /turf/simulated/floor/Entered(var/atom/movable/AM)
 	.=..()

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -218,7 +218,7 @@
 	//Deconstruction
 	if(iswelder(W))
 		var/obj/item/weapon/weldingtool/WT = W
-		if(WT.remove_fuel(0, user))
+		if(WT.remove_fuel(1, user))
 			if(engraving)
 				to_chat(user, "<span class='notice'>You deform the wall back into its original shape")
 				engraving = null

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -244,7 +244,6 @@
 					message_admins("\The [src] with a pdiff of [pdiff] has been dismantled by [user.real_name] ([formatPlayerPanel(user, user.ckey)]) at [formatJumpTo(get_turf(src))]!")
 				dismantle_wall()
 		else
-			to_chat(user, "<span class='notice'>You need more welding fuel to complete this task.</span>")
 			return
 
     //CUT_WALL will dismantle the wall

--- a/code/game/turfs/simulated/walls_reinforced.dm
+++ b/code/game/turfs/simulated/walls_reinforced.dm
@@ -304,7 +304,7 @@
 			else if(iswelder(W))
 
 				var/obj/item/weapon/weldingtool/WT = W
-				if(WT.remove_fuel(0,user))
+				if(WT.remove_fuel(1,user))
 					user.visible_message("<span class='notice'>[user] begins mending \the [src]'s external support rods.</span>", \
 					"<span class='notice'>You begin mending \the [src]'s external support rods.</span>")
 					playsound(src, 'sound/items/Welder.ogg', 100, 1)

--- a/code/game/turfs/simulated/walls_reinforced.dm
+++ b/code/game/turfs/simulated/walls_reinforced.dm
@@ -316,8 +316,7 @@
 						user.visible_message("<span class='warning'>[user] mends \the [src]'s external support rods.</span>", \
 						"<span class='notice'>You mend \the [src]'s external support rods.</span>")
 				else
-					to_chat(user, "<span class='notice'>You need more welding fuel to complete this task.</span>")
-				return
+					return
 
 //This is where we perform actions that aren't deconstructing, constructing or thermiting the reinforced wall
 


### PR DESCRIPTION
Some things had redundant messages if you didn't have enough fuel, their messages have been removed.
Will now tell you to lit the welder if it isn't lit when you do something, but if you have no fuel it will tell you to refuel.
Exposing the local location to the welder temperature now checks if the welder is lit in the first place.
Restored a forgotten functionality that set someone on fire, but it still doesn't do anything because the mob is already set on fire if he has any fire stacks, and the functionality only works if the mob already has fire stacks, which means he is on fire.
Removed the third state of a welder (welding) because it wasn't used anywhere.
You no longer get a message that you refueled the welding tool if the tool is full. Instead it will tell you it's already full. However, if the welding tank is empty it will say it's empty.
Removed welder fuel consumption if it was used on any obj (or atom now), instead things that can be interacted with the welder will consume it.

:cl:
 * tweak: Welders will now tell you when they have to be lit instead of saying "you require more fuel" when you use the welder and it isn't lit.
 * tweak: Welders will no longer refill themselves if they are already full, and welding tanks will tell you if they are empty.