### PR TITLE
Fixes vehicles and everything

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -167,15 +167,12 @@
 /obj/structure/bed/chair/proc/buckle_chair(mob/M as mob, mob/user as mob)
 	if(!istype(M))
 		return ..()
-	
-	if(M == user && M.loc != src.loc)
-		return
 
 	var/mob/living/carbon/human/target = null
 	if(ishuman(M))
 		target = M
 		
-	if(!user.Adjacent(M))
+	if(!user.Adjacent(M) || !user.Adjacent(src))
 		return
 
 	if(target && target.op_stage.butt == 4 && Adjacent(target) && user.Adjacent(src) && !user.incapacitated()) //Butt surgery is at stage 4


### PR DESCRIPTION
Fixes #23933 

Tested ; can climb on Janicart, can buckle self on chairs, can buckle other on chairs
Sanity with respect to adjacency when buckling self or others
Can *not* buckle someone else, or self, to a chair, a bed or a vehicle from a distance. The other person must be on the same tile as the chair.
Can't also buckle self to a chair from a distance.

[hotfix]