### PR TITLE
Removes the default 7-item limit in a storage such as backpacks

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -18,7 +18,7 @@
 	var/list/is_seeing = new/list() //List of mobs which are currently seeing the contents of this item's storage
 	var/fits_max_w_class = W_CLASS_SMALL //Max size of objects that this object can store (in effect even if can_only_hold is set)
 	var/max_combined_w_class = 14 //The sum of the w_classes of all the items in this storage item.
-	var/storage_slots = 7 //The number of storage slots in this container.
+	var/storage_slots = 0 //The number of storage slots in this container. Set this to 0 to disable the limit.
 	var/obj/abstract/screen/storage/boxes = null
 	var/obj/abstract/screen/close/closer = null
 	var/use_to_pickup	//Set this to make it possible to use this item in an inverse way, so you can have the item in your hand and click items on the floor to pick them up.
@@ -218,7 +218,7 @@
 
 	if(src.loc == W)
 		return 0 //Means the item is already in the storage item
-	if(contents.len >= storage_slots)
+	if(storage_slots && (contents.len >= storage_slots))
 		if(!stop_messages)
 			to_chat(usr, "<span class='notice'>\The [src] is full, make some space.</span>")
 		return 0 //Storage item is full


### PR DESCRIPTION
This means that as long as the weight class is small enough you can fit a lot of smaller items into storages.
I've wondered why this wasn't done earlier, so let's give it a try
There are unintended consequences, I feel that weight classes or weight limits should be tweaked as to balance that you've got more inventory space now. Worst thing I can think of is fitting 21 talismans in your bag, with the cult hate going around and all, but that by itself isn't a reason to reject the entire change.

Regular storages fit 14 weight in items, backpacks fit 21, bags of holding fit 28.
Weight classes for documentation:
Tiny - 1
Small - 2
Medium - 3
Large - 4
Huge - 5
Giant - 20
:cl:
 * tweak: Your backpacks and boxes can now fit more items.