### PR TITLE
New pinpointer

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -28,7 +28,6 @@
 		/obj/item/clothing/shoes/magboots/captain,
 		/obj/item/weapon/gun/energy/gun,
 		/obj/item/clothing/suit/armor/captain,
-		/obj/item/weapon/pinpointer/pinpointerpinpointer,
 		/obj/item/weapon/melee/telebaton,
 		/obj/item/clothing/under/dress/dress_cap,
 		/obj/item/device/gps/secure,

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -124,6 +124,7 @@
 		/obj/item/weapon/storage/lockbox/lawgiver/with_magazine,
 		/obj/item/clothing/accessory/holster/handgun/waist,
 		/obj/item/weapon/melee/telebaton,
+		/obj/item/weapon/pinpointer/pinpointerpinpointer
 		/obj/item/device/gps/secure,
 		/obj/item/clothing/suit/armor/hos,
 		/obj/item/taperoll/police,
@@ -132,7 +133,7 @@
 		/obj/item/weapon/grenade/flashbang,
 		/obj/item/weapon/gun/energy/taser,
 		/obj/item/weapon/card/debit/preferred/department/security,
-		/obj/item/weapon/pinpointer/pinpointerpinpointer
+		
 	)
 
 /obj/structure/closet/secure_closet/warden

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -133,7 +133,6 @@
 		/obj/item/weapon/grenade/flashbang,
 		/obj/item/weapon/gun/energy/taser,
 		/obj/item/weapon/card/debit/preferred/department/security,
-		
 	)
 
 /obj/structure/closet/secure_closet/warden

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -28,6 +28,7 @@
 		/obj/item/clothing/shoes/magboots/captain,
 		/obj/item/weapon/gun/energy/gun,
 		/obj/item/clothing/suit/armor/captain,
+		/obj/item/weapon/pinpointer/pinpointerpinpointer,
 		/obj/item/weapon/melee/telebaton,
 		/obj/item/clothing/under/dress/dress_cap,
 		/obj/item/device/gps/secure,

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -124,7 +124,7 @@
 		/obj/item/weapon/storage/lockbox/lawgiver/with_magazine,
 		/obj/item/clothing/accessory/holster/handgun/waist,
 		/obj/item/weapon/melee/telebaton,
-		/obj/item/weapon/pinpointer/pinpointerpinpointer
+		/obj/item/weapon/pinpointer/pinpointerpinpointer,
 		/obj/item/device/gps/secure,
 		/obj/item/clothing/suit/armor/hos,
 		/obj/item/taperoll/police,

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -132,6 +132,7 @@
 		/obj/item/weapon/grenade/flashbang,
 		/obj/item/weapon/gun/energy/taser,
 		/obj/item/weapon/card/debit/preferred/department/security,
+		/obj/item/weapon/pinpointer/pinpointerpinpointer
 	)
 
 /obj/structure/closet/secure_closet/warden


### PR DESCRIPTION
Adds a second pinpointer to the hos locker, It's too easy for the single pinpointer the station has to just go missing
Note that this is not a repeat of my previous PR why was an attempt to add a pinpointer pinpointer

:cl:
Adds a second pinpointer to the head of securities locker