### PR TITLE
Medical supply crate stethoscope

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1648,7 +1648,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/storage/box/syringes,
 					/obj/item/weapon/storage/bag/chem,
 					/obj/item/weapon/storage/box/autoinjectors,
-					/obj/item/clothing/accessory/stethsocope)
+					/obj/item/clothing/accessory/stethoscope)
 	cost = 10
 	containertype = /obj/structure/closet/crate/medical
 	containername = "medical crate"

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1647,7 +1647,8 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/reagent_containers/glass/bottle/stoxin,
 					/obj/item/weapon/storage/box/syringes,
 					/obj/item/weapon/storage/bag/chem,
-					/obj/item/weapon/storage/box/autoinjectors)
+					/obj/item/weapon/storage/box/autoinjectors,
+					/obj/item/clothing/accessory/stethsocope)
 	cost = 10
 	containertype = /obj/structure/closet/crate/medical
 	containername = "medical crate"


### PR DESCRIPTION
I think this is better than #23917 because it's much slower to order a crate than to just print the thing from the autolathe. This way safe cracking shouldn't become *too* convenient, because there's roughly the same amount of effort involved in getting one of these from the medbay (which I maintain the doctors won't mind you doing, since it really is pretty much useless to them as an item) as there is in ordering a crate from cargo.

:cl:
 * rscadd: The medical supplies crate from cargo now contains a stethoscope.