### PR TITLE
Gives solo antagonists the opportunity to get custom objectives

### DIFF
--- a/__DEFINES/global.dm
+++ b/__DEFINES/global.dm
@@ -168,6 +168,7 @@ var/datum/nanomanager/nanomanager = new()
 #define MAX_BOOK_MESSAGE_LEN 9216
 #define MAX_NAME_LEN 26
 #define MAX_BROADCAST_LEN		512
+#define MAX_OBJECTIVE_LEN	256
 
 #define shuttle_time_in_station 1800 // 3 minutes in the station
 #define shuttle_time_to_arrive 6000 // 10 minutes to arrive

--- a/__DEFINES/role_datums_defines.dm
+++ b/__DEFINES/role_datums_defines.dm
@@ -175,6 +175,7 @@
 // -- Objectives flags
 
 #define FACTION_OBJECTIVE 1
+#define DONT_CHECK_OBJ 2
 
 // -- Cult 2.0 states
 #define CULT_PRELUDE 		0 // First objective
@@ -230,3 +231,7 @@
 #define DIRAC "Rigged threat number"
 #define EXPONENTIAL "Peaceful bias"
 #define UNIFORM "Uniform distribution"
+
+// -- Roles flags
+
+#define SOLO_ANTAG 1

--- a/code/datums/gamemode/objectives/custom.dm
+++ b/code/datums/gamemode/objectives/custom.dm
@@ -3,23 +3,22 @@
 	explanation_text = "Just be yourself"
 	force_success = TRUE
 
-var/list/predefined_custom_objectives = list(
-	// Open ended ; low chance of being picked
-	10;"Go on a date with the station's AI.",
-	10;"Rename all rooms in the station to something silly.",
-	10;"Accelerate.",
-	10;"Steal every last pen on the station. Every single one of them.",
-	10;"Get your revenge.",
-	10;"Do as you wish.",
+var/list/predefined_custom_objectives = list(	
+	// Open ended ; low chance of being picked10; "Go on a date with the station's AI.",
+	"Rename all rooms in the station to something silly." = 10,
+	"Accelerate." = 10,
+	"Steal every last pen on the station. Every single one of them." = 10,
+	"Get your revenge." = 10,
+	"Do as you wish." = 10,
 
 	// Slightly more directed. Higher chance of being picked.
-	50;"Steal one of the key items to NanoTrasen's organisation. This includes a pinpointer, a nuclear authentification disk, and a hand teleporter.",
-	50;"Disrupt the station's command structure.",
-	50;"Sabotage the station's power net and atmospheric regulation system.",
-	50;"Sabotage the station's medical facilities.",
-	50;"Sabotage the station's research activities.",
-	50;"Cripple the station's mining activities.",
-)
+	"Steal one of the key items to NanoTrasen's organisation. This includes a pinpointer, a nuclear authentification disk, and a hand teleporter." = 50,
+	"Disrupt the station's command structure." = 50,
+	"Sabotage the station's power net and atmospheric regulation system." = 50,
+	"Sabotage the station's medical facilities." = 50,
+	"Sabotage the station's research activities." = 50,
+	"Cripple the station's mining activities." = 50,
+	)
 
 //if user passed - means that this will be called as an explicit custom objective and will require user input
 /datum/objective/custom/New(var/mob/user, var/datum/faction/faction)
@@ -27,7 +26,10 @@ var/list/predefined_custom_objectives = list(
 		return
 	if (faction)
 		src.faction = faction
-	var/txt = stripped_input(user, "What should be the text of this objective?","Custom objective", pick(predefined_custom_objectives), MAX_OBJECTIVE_LEN)
+
+	var/default_objective = pickweight(predefined_custom_objectives)
+
+	var/txt = stripped_input(user, "What should be the text of this objective?","Custom objective", default_objective, MAX_OBJECTIVE_LEN)
 	explanation_text = txt
 
 // Fullfilled as per admin wishes

--- a/code/datums/gamemode/objectives/custom.dm
+++ b/code/datums/gamemode/objectives/custom.dm
@@ -4,12 +4,21 @@
 	force_success = TRUE
 
 var/list/predefined_custom_objectives = list(
-	"Go on a date with the station's AI.",
-	"Rename all rooms in the station to something silly.",
-	"Accelerate.",
-	"Steal every last pen on the station. Every single one of them.",
-	"Get your revenge.",
-	"Do as you wish.",
+	// Open ended ; low chance of being picked
+	10;"Go on a date with the station's AI.",
+	10;"Rename all rooms in the station to something silly.",
+	10;"Accelerate.",
+	10;"Steal every last pen on the station. Every single one of them.",
+	10;"Get your revenge.",
+	10;"Do as you wish.",
+
+	// Slightly more directed. Higher chance of being picked.
+	50;"Steal one of the key items to NanoTrasen's organisation. This includes a pinpointer, a nuclear authentification disk, and a hand teleporter.",
+	50;"Disrupt the station's command structure.",
+	50;"Sabotage the station's power net and atmospheric regulation system.",
+	50;"Sabotage the station's medical facilities.",
+	50;"Sabotage the station's research activities.",
+	50;"Cripple the station's mining activities.",
 )
 
 //if user passed - means that this will be called as an explicit custom objective and will require user input

--- a/code/datums/gamemode/objectives/custom.dm
+++ b/code/datums/gamemode/objectives/custom.dm
@@ -3,13 +3,22 @@
 	explanation_text = "Just be yourself"
 	force_success = TRUE
 
+var/list/predefined_custom_objectives = list(
+	"Go on a date with the station's AI.",
+	"Rename all rooms in the station to something silly.",
+	"Accelerate.",
+	"Steal every last pen on the station. Every single one of them.",
+	"Get your revenge.",
+	"Do as you wish.",
+)
+
 //if user passed - means that this will be called as an explicit custom objective and will require user input
 /datum/objective/custom/New(var/mob/user, var/datum/faction/faction)
 	if (!user)
 		return
 	if (faction)
 		src.faction = faction
-	var/txt = input(user, "What should be the text of this objective?","Custom objective", "Just be yourself")
+	var/txt = stripped_input(user, "What should be the text of this objective?","Custom objective", pick(predefined_custom_objectives))
 	explanation_text = txt
 
 // Fullfilled as per admin wishes

--- a/code/datums/gamemode/objectives/custom.dm
+++ b/code/datums/gamemode/objectives/custom.dm
@@ -18,7 +18,7 @@ var/list/predefined_custom_objectives = list(
 		return
 	if (faction)
 		src.faction = faction
-	var/txt = stripped_input(user, "What should be the text of this objective?","Custom objective", pick(predefined_custom_objectives))
+	var/txt = stripped_input(user, "What should be the text of this objective?","Custom objective", pick(predefined_custom_objectives), MAX_OBJECTIVE_LEN)
 	explanation_text = txt
 
 // Fullfilled as per admin wishes

--- a/code/datums/gamemode/objectives/freeform.dm
+++ b/code/datums/gamemode/objectives/freeform.dm
@@ -2,3 +2,4 @@
 	explanation_text = "Do as you like."
 	name = "Freeform"
 	force_success = TRUE
+	flags = DONT_CHECK_OBJ

--- a/code/datums/gamemode/role/changeling.dm
+++ b/code/datums/gamemode/role/changeling.dm
@@ -54,6 +54,7 @@
 /datum/role/changeling/ForgeObjectives()
 	if(!SOLO_ANTAG_OBJECTIVES)
 		AppendObjective(/datum/objective/freeform/changeling)
+		GiveCustomObjective()
 		return
 	AppendObjective(/datum/objective/absorb)
 	AppendObjective(/datum/objective/target/assassinate)

--- a/code/datums/gamemode/role/role.dm
+++ b/code/datums/gamemode/role/role.dm
@@ -101,6 +101,7 @@
 
 	// Objectives
 	var/datum/objective_holder/objectives=new
+	var/last_requested_objective_time = -30 MINUTES
 
 	var/icon/logo_state = "synd-logo"
 
@@ -240,6 +241,10 @@
 /datum/role/proc/ForgeObjectives()
 	return
 
+/datum/role/proc/GiveCustomObjective()
+	to_chat(antag.current, "<span class='notice'>You can assign yourself a customised objective if you want. It will not be checked on roundend. To do so, type 'Notes' on your chat bar.</span>")
+	antag.store_memory("<a href='?src=\ref[antag];give_custom_objective=\ref[src]'>Give yourself a custom objective.</a>")
+
 /datum/role/proc/AppendObjective(var/objective_type,var/duplicates=0)
 	if(!duplicates && locate(objective_type) in objectives)
 		return FALSE
@@ -338,7 +343,10 @@
 		text += "<ul>"
 		for(var/datum/objective/objective in objectives.GetObjectives())
 			var/successful = objective.IsFulfilled()
-			text += "<B>Objective #[count]</B>: [objective.explanation_text] [successful ? "<font color='green'><B>Success!</B></font>" : "<font color='red'>Fail.</font>"]"
+			var/success = ""
+			if (SOLO_ANTAG_OBJECTIVES && !(objective.flags & DONT_CHECK_OBJ)) // Only display red/green text to objectives that can actually fail.
+				success = successful ? "<font color='green'><B>Success!</B></font>" : "<font color='red'>Fail.</font>"
+			text += "<B>Objective #[count]</B>: [objective.explanation_text] [success]"
 			feedback_add_details("[id]_objective","[objective.type]|[successful ? "SUCCESS" : "FAIL"]")
 			if(!successful) //If one objective fails, then you did not win.
 				win = 0

--- a/code/datums/gamemode/role/syndicate.dm
+++ b/code/datums/gamemode/role/syndicate.dm
@@ -4,6 +4,7 @@
 	required_pref = TRAITOR
 	logo_state = "synd-logo"
 	wikiroute = TRAITOR
+	flags = SOLO_ANTAG
 	var/can_be_smooth = TRUE //Survivors can't be smooth because they get nothing.
 
 /datum/role/traitor/OnPostSetup()
@@ -38,6 +39,7 @@
 /datum/role/traitor/ForgeObjectives()
 	if(!SOLO_ANTAG_OBJECTIVES)
 		AppendObjective(/datum/objective/freeform/syndicate)
+		GiveCustomObjective()
 		return
 	if(istype(antag.current, /mob/living/silicon))
 		AppendObjective(/datum/objective/target/delayed/assassinate)

--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -37,6 +37,7 @@
 	var/list/image/cached_images = list()
 
 	stat_datum_type = /datum/stat/role/vampire
+	flags = SOLO_ANTAG
 
 /datum/role/vampire/New(var/datum/mind/M, var/datum/faction/fac=null, var/new_id, var/override = FALSE)
 	..()
@@ -131,6 +132,7 @@
 /datum/role/vampire/ForgeObjectives()
 	if(!SOLO_ANTAG_OBJECTIVES)
 		AppendObjective(/datum/objective/freeform/vampire)
+		GiveCustomObjective()
 		return
 
 	AppendObjective(/datum/objective/acquire_blood)

--- a/code/datums/gamemode/role/wizard.dm
+++ b/code/datums/gamemode/role/wizard.dm
@@ -8,10 +8,12 @@
 	greets = list(GREET_CUSTOM,GREET_ROUNDSTART,GREET_MIDROUND)
 
 	stat_datum_type = /datum/stat/role/wizard
+	flags = SOLO_ANTAG
 
 /datum/role/wizard/ForgeObjectives()
 	if(!SOLO_ANTAG_OBJECTIVES)
 		AppendObjective(/datum/objective/freeform/wizard)
+		GiveCustomObjective()
 		return
 	switch(rand(1,100))
 		if(1 to 30)

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -2537,7 +2537,7 @@
 #include "maprendering\maprendering.dm"
 #include "maps\_map.dm"
 #include "maps\_map_override.dm"
-#include "maps\snaxi.dm"
+#include "maps\tgstation.dm"
 #include "maps\defficiency\areas.dm"
 #include "maps\packedstation\telecomms.dm"
 #include "maps\randomvaults\dance_revolution.dm"


### PR DESCRIPTION
I said that if we got rid of the broken and downright awful greentext objectives, I would do this.

This gives antagonists the ability to give themselves a custom objective every 25 minutes. Admins are notified of this, they can of course remove it, and the input is sanitised so that you can't just break the end game screen.

![image](https://user-images.githubusercontent.com/31417754/63584414-31598b00-c59d-11e9-9dc3-83fa0688be35.png)

Those custom objectives aren't checked and don't display a green/red text upon round end ; admin given objectives are STILL checked and can be toggled as success or failure as admins see fit.

:cl:
- rscadd: Solo antagonists can now give themselves custom objectives. Those are not checked upon round end.