### PR TITLE
Add single greytide implant item to uplink

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -796,11 +796,19 @@ var/list/uplink_items = list()
 	jobs_with_discount = list("Assistant")
 
 /datum/uplink_item/jobspecific/greytide
-	name = "Greytide Implant"
+	name = "Greytide Implants"
 	desc = "A box containing two greytide implanters that when injected into another person makes them loyal to the greytide and your cause, unless they're already implanted by someone else. Loyalty ends if he or she no longer has the implant. CAUTION: WILL NOT WORK ON SUBJECTS WITH NT LOYALTY IMPLANTS. Now with disguised sechud sunglasses. These will have limited access until you can get your hands on some containing security codes."
 	item = /obj/item/weapon/storage/box/syndie_kit/greytide
 	cost = 20
 	discounted_cost = 14
+	jobs_with_discount = list("Assistant")
+
+/datum/uplink_item/jobspecific/cheaptide
+	name = "Cheaptide Implant"
+	desc = "A box containing one greytide implanter that when injected into another person makes them loyal to the greytide and your cause, unless they're already implanted by someone else. Loyalty ends if he or she no longer has the implant. CAUTION: WILL NOT WORK ON SUBJECTS WITH NT LOYALTY IMPLANTS. Now with disguised sechud sunglasses. These will have limited access until you can get your hands on some containing security codes."
+	item = /obj/item/weapon/storage/box/syndie_kit/cheaptide
+	cost = 12
+	discounted_cost = 8
 	jobs_with_discount = list("Assistant")
 
 /datum/uplink_item/jobspecific/drunkbullets

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -273,8 +273,7 @@ obj/item/weapon/storage/box/syndie_kit/cheaptide
 	..()
 	new /obj/item/weapon/implanter/traitor(src)
 	new /obj/item/clothing/glasses/sunglasses/sechud/syndishades(src)
-	return
-
+	
 /obj/item/weapon/storage/box/syndie_kit/flaregun
 	name = "box (modified flare gun)"
 

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -266,6 +266,15 @@
 	new /obj/item/ammo_storage/speedloader/a357(src)
 	return
 
+obj/item/weapon/storage/box/syndie_kit/cheaptide
+	name = "box (CT)"
+
+/obj/item/weapon/storage/box/syndie_kit/cheaptide/New()
+	..()
+	new /obj/item/weapon/implanter/traitor(src)
+	new /obj/item/clothing/glasses/sunglasses/sechud/syndishades(src)
+	return
+
 /obj/item/weapon/storage/box/syndie_kit/flaregun
 	name = "box (modified flare gun)"
 


### PR DESCRIPTION
Sometimes you don't want to spend all your tc/all your TC except enough for an emag for two allies, but just a lot for one. Gives more freedom in things you can do while using this item. Buying this twice would cost more than 1 2 implant item. Also has no bullets since its supposed to be cheap option and I honestly don't get why greytide has bullets to begin with.  They're just there with no mention.

:cl:
- rscadd: Added single-use greytide implant
