### PR TITLE
Can slide drinks across tables

### DIFF
--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -1513,15 +1513,14 @@
 // Sliding from one table to another
 /obj/item/weapon/reagent_containers/food/drinks/MouseDropFrom(atom/over_object,atom/src_location,over_location,src_control,over_control,params)
 	var/mob/user = usr
-	to_chat(world, "[user]")
 	if (!istype(src_location))
 		return
 	if (!user || user.incapacitated())
 		return
 	if (!user.Adjacent(src) || !src_location.Adjacent(over_location))
 		return
-	if (istype(src_location, /obj/structure/table) && istype(over_location, /obj/structure/table))
-		user.visible_message("<span class='notice'>\The [user] slides \the [src] down the tables.</span>", "<span class='notice'>You slide \the [src] down the tables!</span>")
+	if ((locate(/obj/structure/table) in src_location) && (locate(/obj/structure/table) in over_location))
+		user.visible_message("<span class='notice'>\The [user] slides \the [src] down the table.</span>", "<span class='notice'>You slide \the [src] down the table!</span>")
 		forceMove(over_location, glide_size_override = DELAY2GLIDESIZE(2))
 		return
 	return ..()

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -1510,6 +1510,21 @@
 		loca.hotspot_expose(700, 1000,surfaces=istype(loc,/turf))
 	return
 
+// Sliding from one table to another
+/obj/item/weapon/reagent_containers/food/drinks/MouseDropFrom(atom/over_object,atom/src_location,over_location,src_control,over_control,params)
+	var/mob/user = usr
+	to_chat(world, "[user]")
+	if (!istype(src_location))
+		return
+	if (!user || user.incapacitated())
+		return
+	if (!user.Adjacent(src) || !src_location.Adjacent(over_location))
+		return
+	if (istype(src_location, /obj/structure/table) && istype(over_location, /obj/structure/table))
+		user.visible_message("<span class='notice'>\The [user] slides \the [src] down the tables.</span>", "<span class='notice'>You slide \the [src] down the tables!</span>")
+		forceMove(over_location, glide_size_override = DELAY2GLIDESIZE(2))
+		return
+	return ..()
 
 //todo: can light cigarettes with
 //todo: is force = 15 overwriting the force? //Yes, of broken bottles, but that's been fixed now

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -2537,7 +2537,7 @@
 #include "maprendering\maprendering.dm"
 #include "maps\_map.dm"
 #include "maps\_map_override.dm"
-#include "maps\snaxi.dm"
+#include "maps\tgstation.dm"
 #include "maps\defficiency\areas.dm"
 #include "maps\packedstation\telecomms.dm"
 #include "maps\randomvaults\dance_revolution.dm"

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -2537,7 +2537,7 @@
 #include "maprendering\maprendering.dm"
 #include "maps\_map.dm"
 #include "maps\_map_override.dm"
-#include "maps\tgstation.dm"
+#include "maps\snaxi.dm"
 #include "maps\defficiency\areas.dm"
 #include "maps\packedstation\telecomms.dm"
 #include "maps\randomvaults\dance_revolution.dm"


### PR DESCRIPTION
Suggested by Vega on d*scord.

This lets people drag and drop drinks across tables, with a small flavour text describing it.
The animation of the slide tries to be as smooth as possible.

Compiled & tested locally.
[content]

:cl:
- rscadd: You can now drag drinks from one table surface to another, but only up to 1 tile away.