### PR TITLE
Fixes the advanced xenoarch scanner not being listed in the protolathe list.

### DIFF
--- a/code/modules/research/designs/anomaly.dm
+++ b/code/modules/research/designs/anomaly.dm
@@ -51,7 +51,7 @@
 /datum/design/xenoarch_scanner_adv
 	name = "Advanced xenoarchaeology digsite locator"
 	desc = "Shows digsites in vicinity, whether they're hidden or not. Shows you their reagent via highlighting them a specific colour"
-	id = "xenoarch_scanner"
+	id = "xenoarch_scanner_adv"
 	req_tech  =list(Tc_MAGNETS = 3, Tc_ANOMALY = 3)
 	build_type = PROTOLATHE
 	materials = list(MAT_GLASS=2500, MAT_IRON = 2500, MAT_PLASMA = 300)


### PR DESCRIPTION
100% Tested
It works
![works](https://user-images.githubusercontent.com/38330373/63644956-04a39180-c6cb-11e9-8fbf-f78506e8b5fc.png)

Fixes #23980

:cl: 
- bugfix: Advanced xenoarch scanners should now appear in the protolathe once you get the research level requirements.
