### PR TITLE
Added standard/freeform objective toggle

### DIFF
--- a/SQL/players2.sql
+++ b/SQL/players2.sql
@@ -119,7 +119,8 @@ CREATE TABLE client (
     hear_voicesound INTEGER,
     hear_instruments INTEGER,
     ambience_volume INTEGER,
-    credits_volume INTEGER
+    credits_volume INTEGER,
+    antag_objectives INTEGER
 );
 
 

--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -5,9 +5,6 @@
 #define RUNWARNING // disable if they re-enable run() in 507 or newer.
                    // They did, tested in 508.1296 - N3X
 
-// If set to 0, replaces solo antags' objectives with an always-pass freeform
-#define SOLO_ANTAG_OBJECTIVES 0
-
 // Defines for the shuttle
 #define SHUTTLE_ON_STANDBY 0
 #define SHUTTLE_ON_STATION 1

--- a/code/datums/gamemode/role/changeling.dm
+++ b/code/datums/gamemode/role/changeling.dm
@@ -52,7 +52,7 @@
 	antag.current << sound('sound/effects/ling_intro.ogg')
 
 /datum/role/changeling/ForgeObjectives()
-	if(!SOLO_ANTAG_OBJECTIVES)
+	if(!antag.current.client.prefs.antag_objectives)
 		AppendObjective(/datum/objective/freeform/changeling)
 		return
 	AppendObjective(/datum/objective/absorb)

--- a/code/datums/gamemode/role/syndicate.dm
+++ b/code/datums/gamemode/role/syndicate.dm
@@ -36,7 +36,7 @@
 	.=..()
 
 /datum/role/traitor/ForgeObjectives()
-	if(!SOLO_ANTAG_OBJECTIVES)
+	if(!antag.current.client.prefs.antag_objectives)
 		AppendObjective(/datum/objective/freeform/syndicate)
 		return
 	if(istype(antag.current, /mob/living/silicon))

--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -129,7 +129,7 @@
 	. += ..() // Who he was, his objectives...
 
 /datum/role/vampire/ForgeObjectives()
-	if(!SOLO_ANTAG_OBJECTIVES)
+	if(!antag.current.client.prefs.antag_objectives)
 		AppendObjective(/datum/objective/freeform/vampire)
 		return
 

--- a/code/datums/gamemode/role/wizard.dm
+++ b/code/datums/gamemode/role/wizard.dm
@@ -10,7 +10,7 @@
 	stat_datum_type = /datum/stat/role/wizard
 
 /datum/role/wizard/ForgeObjectives()
-	if(!SOLO_ANTAG_OBJECTIVES)
+	if(!antag.current.client.prefs.antag_objectives)
 		AppendObjective(/datum/objective/freeform/wizard)
 		return
 	switch(rand(1,100))

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -141,6 +141,7 @@ var/const/MAX_SAVE_SLOTS = 8
 	var/ambience_volume = 25
 	var/credits_volume = 75
 	var/window_flashing = 1
+	var/antag_objectives = 1 //If set to 1, solo antag roles will get the standard objectives. If set to 0, will give them a freeform objective instead.
 
 		//Mob preview
 	var/icon/preview_icon = null
@@ -374,6 +375,8 @@ var/const/MAX_SAVE_SLOTS = 8
 	<a href='?_src_=prefs;preference=stumble'><b>[(stumble) ? "Yes" : "No"]</b></a><br>
 	<b>Pulling action:</b>
 	<a href='?_src_=prefs;preference=pulltoggle'><b>[(pulltoggle) ? "Toggle Pulling" : "Always Pull"]</b></a><br>
+	<b>Solo Antag Objectives:</b>
+	<a href='?_src_=prefs;preference=antag_objectives'><b>[(antag_objectives) ? "Standard" : "Freeform"]</b></a><br>
   </div>
   <div id="rightDiv" style="width:50%;height:100%;float:right;">
 	<b>Randomized Character Slot:</b>
@@ -1490,7 +1493,10 @@ NOTE:  The change will take effect AFTER any current recruiting periods."}
 
 				if("window_flashing")
 					window_flashing = !window_flashing
-
+				
+				if("antag_objectives")
+					antag_objectives = !antag_objectives
+				
 			if(user.client.holder)
 				switch(href_list["preference"])
 					if("hear_ahelp")

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -141,7 +141,7 @@ var/const/MAX_SAVE_SLOTS = 8
 	var/ambience_volume = 25
 	var/credits_volume = 75
 	var/window_flashing = 1
-	var/antag_objectives = 1 //If set to 1, solo antag roles will get the standard objectives. If set to 0, will give them a freeform objective instead.
+	var/antag_objectives = 0 //If set to 1, solo antag roles will get the standard objectives. If set to 0, will give them a freeform objective instead.
 
 		//Mob preview
 	var/icon/preview_icon = null

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -105,6 +105,7 @@
 	credits 		=	preference_list_client["credits"]
 	jingle	 		=	preference_list_client["jingle"]
 	window_flashing  =	text2num(preference_list_client["window_flashing"])
+	antag_objectives =  text2num(preference_list_client["antag_objectives"])
 
 	ooccolor		= 	sanitize_hexcolor(ooccolor, initial(ooccolor))
 	lastchangelog	= 	sanitize_text(lastchangelog, initial(lastchangelog))
@@ -133,6 +134,7 @@
 	ambience_volume = sanitize_integer(ambience_volume, 0, 100, initial(ambience_volume))
 	credits_volume  = sanitize_integer(credits_volume, 0, 100, initial(credits_volume))
 	window_flashing = sanitize_integer(window_flashing, 0, 1, initial(window_flashing))
+	antag_objectives =  sanitize_integer(antag_objectives, 0, 1, initial(antag_objectives))
 	initialize_preferences()
 	return 1
 
@@ -214,15 +216,15 @@
 	check.Add("SELECT ckey FROM client WHERE ckey = ?", ckey)
 	if(check.Execute(db))
 		if(!check.NextRow())
-			q.Add("INSERT into client (ckey, ooc_color, lastchangelog, UI_style, default_slot, toggles, UI_style_color, UI_style_alpha, warns, warnbans, randomslot, volume, usewmp, special, usenanoui, tooltips, progress_bars, space_parallax, space_dust, parallax_speed, stumble, attack_animation, pulltoggle, credits, jingle, hear_voicesound, hear_instruments, ambience_volume, credits_volume, window_flashing) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",\
-			ckey, ooccolor, lastchangelog, UI_style, default_slot, toggles, UI_style_color, UI_style_alpha, warns, warnbans, randomslot, volume, usewmp, special_popup, usenanoui, tooltips, progress_bars, space_parallax, space_dust, parallax_speed, stumble, attack_animation, pulltoggle, credits, jingle, hear_voicesound, hear_instruments, ambience_volume, credits_volume, window_flashing)
+			q.Add("INSERT into client (ckey, ooc_color, lastchangelog, UI_style, default_slot, toggles, UI_style_color, UI_style_alpha, warns, warnbans, randomslot, volume, usewmp, special, usenanoui, tooltips, progress_bars, space_parallax, space_dust, parallax_speed, stumble, attack_animation, pulltoggle, credits, jingle, hear_voicesound, hear_instruments, ambience_volume, credits_volume, window_flashing, antag_objectives) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",\
+			ckey, ooccolor, lastchangelog, UI_style, default_slot, toggles, UI_style_color, UI_style_alpha, warns, warnbans, randomslot, volume, usewmp, special_popup, usenanoui, tooltips, progress_bars, space_parallax, space_dust, parallax_speed, stumble, attack_animation, pulltoggle, credits, jingle, hear_voicesound, hear_instruments, ambience_volume, credits_volume, window_flashing, antag_objectives)
 			if(!q.Execute(db))
 				message_admins("Error in save_preferences_sqlite [__FILE__] ln:[__LINE__] #: [q.Error()] - [q.ErrorMsg()]")
 				WARNING("Error in save_preferences_sqlite [__FILE__] ln:[__LINE__] #:[q.Error()] - [q.ErrorMsg()]")
 				return 0
 		else
-			q.Add("UPDATE client SET ooc_color=?,lastchangelog=?,UI_style=?,default_slot=?,toggles=?,UI_style_color=?,UI_style_alpha=?,warns=?,warnbans=?,randomslot=?,volume=?,usewmp=?,special=?,usenanoui=?,tooltips=?,progress_bars=?,space_parallax=?,space_dust=?,parallax_speed=?, stumble=?, attack_animation=?, pulltoggle=?, credits=?, jingle=?, hear_voicesound=?, hear_instruments=?, ambience_volume=?, credits_volume=?, window_flashing=? WHERE ckey = ?",\
-			ooccolor, lastchangelog, UI_style, default_slot, toggles, UI_style_color, UI_style_alpha, warns, warnbans, randomslot, volume, usewmp, special_popup, usenanoui, tooltips, progress_bars, space_parallax, space_dust, parallax_speed, stumble, attack_animation, pulltoggle, credits, jingle, hear_voicesound, hear_instruments, ambience_volume, credits_volume, window_flashing, ckey)
+			q.Add("UPDATE client SET ooc_color=?,lastchangelog=?,UI_style=?,default_slot=?,toggles=?,UI_style_color=?,UI_style_alpha=?,warns=?,warnbans=?,randomslot=?,volume=?,usewmp=?,special=?,usenanoui=?,tooltips=?,progress_bars=?,space_parallax=?,space_dust=?,parallax_speed=?, stumble=?, attack_animation=?, pulltoggle=?, credits=?, jingle=?, hear_voicesound=?, hear_instruments=?, ambience_volume=?, credits_volume=?, window_flashing=?, antag_objectives=? WHERE ckey = ?",\
+			ooccolor, lastchangelog, UI_style, default_slot, toggles, UI_style_color, UI_style_alpha, warns, warnbans, randomslot, volume, usewmp, special_popup, usenanoui, tooltips, progress_bars, space_parallax, space_dust, parallax_speed, stumble, attack_animation, pulltoggle, credits, jingle, hear_voicesound, hear_instruments, ambience_volume, credits_volume, window_flashing, antag_objectives, ckey)
 			if(!q.Execute(db))
 				message_admins("Error in save_preferences_sqlite [__FILE__] ln:[__LINE__] #: [q.Error()] - [q.ErrorMsg()]")
 				WARNING("Error in save_preferences_sqlite [__FILE__] ln:[__LINE__] #:[q.Error()] - [q.ErrorMsg()]")
@@ -270,6 +272,7 @@
 	S["ambience_volume"]<< ambience_volume
 	S["credits_volume"]<< credits_volume
 	S["window_flashing"]<< window_flashing
+	S["antag_objectives"]<< antag_objectives
 	return 1
 
 //saving volume changes

--- a/code/modules/migrations/SS13_Prefs/021-antag_objectives.dm
+++ b/code/modules/migrations/SS13_Prefs/021-antag_objectives.dm
@@ -1,0 +1,13 @@
+/datum/migration/sqlite/ss13_prefs/_021
+	id = 21
+	name = "Toggle Solo Antag Objectives"
+
+/datum/migration/sqlite/ss13_prefs/_021/up()
+	if(!hasColumn("client","antag_objectives"))
+		return execute("ALTER TABLE `client` ADD COLUMN antag_objectives INTEGER DEFAULT 1")
+	return TRUE
+
+/datum/migration/sqlite/ss13_prefs/_021/down()
+	if(hasColumn("client","antag_objectives"))
+		return execute("ALTER TABLE `client` DROP COLUMN antag_objectives")
+	return TRUE

--- a/code/modules/migrations/SS13_Prefs/021-antag_objectives.dm
+++ b/code/modules/migrations/SS13_Prefs/021-antag_objectives.dm
@@ -4,7 +4,7 @@
 
 /datum/migration/sqlite/ss13_prefs/_021/up()
 	if(!hasColumn("client","antag_objectives"))
-		return execute("ALTER TABLE `client` ADD COLUMN antag_objectives INTEGER DEFAULT 1")
+		return execute("ALTER TABLE `client` ADD COLUMN antag_objectives INTEGER DEFAULT 0")
 	return TRUE
 
 /datum/migration/sqlite/ss13_prefs/_021/down()

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -1579,6 +1579,7 @@
 #include "code\modules\migrations\SS13_Prefs\018-add-ambience_vol.dm"
 #include "code\modules\migrations\SS13_Prefs\019-add-credits_vol.dm"
 #include "code\modules\migrations\SS13_Prefs\020-window_flashing.dm"
+#include "code\modules\migrations\SS13_Prefs\021-antag_objectives.dm"
 #include "code\modules\migrations\SS13_Prefs\_base.dm"
 #include "code\modules\mining\abandonedcrates.dm"
 #include "code\modules\mining\debug_shit.dm"


### PR DESCRIPTION
Does exactly what it says on the tin.
Allows people to choose whether they get the standard antag objectives or the new freeform objectives when they're a solo antage role.

:cl:
 * rscadd: You can now choose between standard and freeform objectives in the general settings menu