### PR TITLE
Nerfs/Buffs to Starman

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_subtypes/starman.dm
+++ b/code/modules/mob/living/silicon/robot/robot_subtypes/starman.dm
@@ -76,13 +76,16 @@
 	invocation_type = SpI_NONE
 	charge_type = Sp_RECHARGE
 	charge_max = 10
+	var/list/starman_music = list('sound/music/battle_against_a_machine.ogg', 'sound/music/imbossible.ogg')
 
 /spell/aoe_turf/starman_play_music/cast(list/targets, mob/user = user)
 	stop_starman_music()
-	if(prob(50))
-		playsound(get_turf(user), 'sound/music/battle_against_a_machine.ogg', 20, channel = CHANNEL_STARMAN)
-	else
-		playsound(get_turf(user), 'sound/music/imbossible.ogg', 20, channel = CHANNEL_STARMAN)
+	if(user)
+		for(var/mob/M in oviewers(8,user))
+			if(M && M.client)
+				M << sound(pick(starman_music), repeat = 0, wait = 0, volume = 20, channel = CHANNEL_STARMAN)
+		user << sound(pick(starman_music), repeat = 0, wait = 0, volume = 20, channel = CHANNEL_STARMAN)
+		
 		
 /proc/stop_starman_music()
 	for(var/mob/M in mob_list)
@@ -245,12 +248,12 @@
 		playsound(user, 'sound/effects/psi/psi_starstorm_omega.ogg', 20, 0)
 		var/obj/item/projectile/meteor/new_meteor
 		var/turf/spawn_loc
-		spawn(6) //Slight delay
+		spawn(2) //Slight delay
 			for(var/i = 1 to meteor_count)
 				spawn_loc = pick(targets)
 				spawn(rand(0,2 SECONDS))
 					new_meteor = new /obj/item/projectile/meteor/mini(spawn_loc)
-					spawn(rand(1,4))
+					spawn(rand(3,5))
 						new_meteor.to_bump(get_turf(new_meteor))
 
 		user.visible_message("<span class='danger'>\The [user] summons a fearsome starstorm!</span>","<span class='notice'>*Click* Star-matrix realized.</span>")
@@ -327,6 +330,7 @@
 	icon_state = "voice0"
 	item_state = "flashbang"
 	var/list/possible_sounds = list('sound/effects/psi/other/enterbattle_normal.ogg','sound/effects/psi/other/boss_intro.ogg','sound/effects/psi/other/spooky.ogg')
+	var/list/sound_volumes = list(40,40,75)
 	var/nextuse
 	var/cooldown = 6 SECONDS
 	
@@ -340,7 +344,8 @@
 	if(world.time < nextuse)
 		return
 	if(user)
-		playsound(user, pick(possible_sounds), 60, 1, vary = 0)
+		var/index = rand(1,possible_sounds.len)
+		playsound(user, possible_sounds[index], sound_volumes[index], 1, vary = 0)
 		var/list/bystanders = get_hearers_in_view(world.view, user)
 		flick_overlay(image('icons/mob/talk.dmi', user, "hail", MOB_LAYER+1), clients_in_moblist(bystanders), 2 SECONDS)
 		user.visible_message("<span class='danger'>\The [user] [pick("emits","blares","performs")] a [pick("sickly","frightening","spooky","strange")] [pick("sound","tune","theme")]!</span>")

--- a/code/modules/mob/living/silicon/robot/robot_subtypes/starman.dm
+++ b/code/modules/mob/living/silicon/robot/robot_subtypes/starman.dm
@@ -2,6 +2,7 @@
 	cell_type = /obj/item/weapon/cell/ultra
 	deny_client_move = 1
 	anchored = 1
+	namepick_uses = 0
 	
 /mob/living/silicon/robot/starman/wearing_wiz_garb()
 	return 1
@@ -25,7 +26,7 @@
 	
 /mob/living/silicon/robot/starman/bullet_act(var/obj/item/projectile/P)
 	if(istype(P, /obj/item/projectile/bullet))
-		var/reflectchance = 80 - round(P.damage/3)
+		var/reflectchance = 70 - round(P.damage/3)
 		if(prob(reflectchance))
 			adjustBruteLoss(P.damage * 0.5)
 			visible_message("<span class='danger'>\The [P.name] gets reflected off \the [src]'s chrome!</span>", \
@@ -37,6 +38,11 @@
 			return -1 // complete projectile permutation
 
 	return (..(P))
+
+/mob/living/silicon/robot/starman/emp_act(severity)
+	..()
+	if(modulelock)
+		modulelock_time = min(modulelock_time, 4 SECONDS)
 
 /mob/living/silicon/robot/starman/getarmor()
 	return 30
@@ -133,23 +139,24 @@
 	var/heal_amount = 30
 
 /spell/aoe_turf/starman_heal/cast(list/targets, mob/living/user = user)
-	psi_precast(user)
-	if(user.getOxyLoss())
-		user.adjustOxyLoss(-heal_amount)
-	if(user.getBruteLoss())
-		user.heal_organ_damage(heal_amount, 0)
-	if(user.getFireLoss())
-		user.heal_organ_damage(0, heal_amount)
-	if(user.getToxLoss())
-		user.adjustToxLoss(-heal_amount)
-	var/mob/living/silicon/robot/robot = user
-	if(istype(robot))
-		for(var/name in robot.components)
-			var/datum/robot_component/component = robot.components[name]
-			component.heal_damage(30,30)
-	user.updatehealth()	
-	playsound(user, 'sound/effects/psi/psi_lifeup_alpha.ogg', 15, 0)
-	user.visible_message("<span class='danger'>\The [user] envelops himself in a bubble of healing magic!</span>","<span class='notice'>*Bzzt* Restoration successful.</span>")
+	spawn(0)
+		psi_precast(user)
+		if(user.getOxyLoss())
+			user.adjustOxyLoss(-heal_amount)
+		if(user.getBruteLoss())
+			user.heal_organ_damage(heal_amount, 0)
+		if(user.getFireLoss())
+			user.heal_organ_damage(0, heal_amount)
+		if(user.getToxLoss())
+			user.adjustToxLoss(-heal_amount)
+		var/mob/living/silicon/robot/robot = user
+		if(istype(robot))
+			for(var/name in robot.components)
+				var/datum/robot_component/component = robot.components[name]
+				component.heal_damage(30,30)
+		user.updatehealth()	
+		playsound(user, 'sound/effects/psi/psi_lifeup_alpha.ogg', 15, 0)
+		user.visible_message("<span class='danger'>\The [user] envelops himself in a bubble of healing magic!</span>","<span class='notice'>*Bzzt* Restoration successful.</span>")
 	
 
 	
@@ -170,17 +177,18 @@
 	selection_type = "range"
 	
 /spell/targeted/starman_shield/cast(list/targets, mob/user = user)
-	psi_precast(user)
-	for(var/atom/target in targets)
-		var/turf/floor = get_turf(target)
-		if(!floor.density)
-			playsound(user, 'sound/effects/psi/psi_shield_alpha.ogg', 35, 0)
-			var/obj/effect/forcefield/starman/barrier = new /obj/effect/forcefield/starman(floor)
-			barrier.spread_outward(user)
-			user.visible_message("<span class='danger'>\The [user] projects a psionic forcefield!</span>","<span class='notice'>*Whirrr* Projection successful.</span>")
-			return
-	playsound(user, 'sound/machines/buzz-sigh.ogg', 40, 0)
-	to_chat(user,"<span class='warning'>*Click* Projection failed.</span>")		
+	spawn(0)
+		psi_precast(user)
+		for(var/atom/target in targets)
+			var/turf/floor = get_turf(target)
+			if(!floor.density)
+				playsound(user, 'sound/effects/psi/psi_shield_alpha.ogg', 35, 0)
+				var/obj/effect/forcefield/starman/barrier = new /obj/effect/forcefield/starman(floor)
+				barrier.spread_outward(user)
+				user.visible_message("<span class='danger'>\The [user] projects a psionic forcefield!</span>","<span class='notice'>*Whirrr* Projection successful.</span>")
+				return
+		playsound(user, 'sound/machines/buzz-sigh.ogg', 40, 0)
+		to_chat(user,"<span class='warning'>*Click* Projection failed.</span>")		
 		
 
 /obj/effect/forcefield/starman
@@ -218,7 +226,7 @@
 	desc = "Conjures a psionic starstorm that impacts around you."
 	hud_state = "psi_starstorm_omega"
 	school = "conjuration"
-	charge_max = 1200
+	charge_max = 1800
 
 	charge_type = Sp_RECHARGE
 	invocation_type = SpI_NONE
@@ -226,25 +234,26 @@
 	duration = 100
 	range = 5
 	selection_type = "range"
-	var/meteor_count = 20
+	var/meteor_count = 12
 
 /spell/aoe_turf/starman_starstorm/choose_targets(mob/user = usr)
 	return trange(range, get_turf(user)) - trange(2, get_turf(user))
 
 /spell/aoe_turf/starman_starstorm/cast(list/targets, mob/user)
-	psi_precast(user)
-	playsound(user, 'sound/effects/psi/psi_starstorm_omega.ogg', 20, 0)
-	var/obj/item/projectile/meteor/new_meteor
-	var/turf/spawn_loc
-	spawn(6) //Slight delay
-		for(var/i = 1 to meteor_count)
-			spawn_loc = pick(targets)
-			spawn(rand(0,2 SECONDS))
-				new_meteor = new /obj/item/projectile/meteor/mini(spawn_loc)
-				spawn(rand(1,4))
-					new_meteor.to_bump(get_turf(new_meteor))
+	spawn(0)
+		psi_precast(user)
+		playsound(user, 'sound/effects/psi/psi_starstorm_omega.ogg', 20, 0)
+		var/obj/item/projectile/meteor/new_meteor
+		var/turf/spawn_loc
+		spawn(6) //Slight delay
+			for(var/i = 1 to meteor_count)
+				spawn_loc = pick(targets)
+				spawn(rand(0,2 SECONDS))
+					new_meteor = new /obj/item/projectile/meteor/mini(spawn_loc)
+					spawn(rand(1,4))
+						new_meteor.to_bump(get_turf(new_meteor))
 
-	user.visible_message("<span class='danger'>\The [user] summons a fearsome starstorm!</span>","<span class='notice'>*Click* Star-matrix realized.</span>")
+		user.visible_message("<span class='danger'>\The [user] summons a fearsome starstorm!</span>","<span class='notice'>*Click* Star-matrix realized.</span>")
 
 	..()
 	
@@ -282,20 +291,21 @@
 	return range(range, get_turf(user))
 
 /spell/aoe_turf/starman_brainshock/cast(list/targets, mob/user)
-	psi_precast(user)
-	playsound(user, 'sound/effects/psi/psi_brainshock_omega.ogg', 10, 0)
-	
-	spawn(6)
-		for(var/mob/living/carbon/target in targets)
-			target.stuttering += 5
-			target.ear_deaf += 1
-			target.dizziness += 5
-			target.confused +=  5
-			target.Jitter(5)		
-			target.Knockdown(1)
-			target.shakecamera += 1
+	spawn(0)
+		psi_precast(user)
+		playsound(user, 'sound/effects/psi/psi_brainshock_omega.ogg', 10, 0)
+		
+		spawn(6)
+			for(var/mob/living/carbon/target in targets)
+				target.stuttering += 5
+				target.ear_deaf += 1
+				target.dizziness += 5
+				target.confused +=  5
+				target.Jitter(5)		
+				target.Knockdown(1)
+				target.shakecamera += 1
 
-	user.visible_message("<span class='danger'>\The [user] bends reality in impossible ways!</span>","<span class='notice'>*Beep* Hostile consciousnesses twisted.</span>")
+		user.visible_message("<span class='danger'>\The [user] bends reality in impossible ways!</span>","<span class='notice'>*Beep* Hostile consciousnesses twisted.</span>")
 
 	..()
 	
@@ -318,7 +328,7 @@
 	item_state = "flashbang"
 	var/list/possible_sounds = list('sound/effects/psi/other/enterbattle_normal.ogg','sound/effects/psi/other/boss_intro.ogg','sound/effects/psi/other/spooky.ogg')
 	var/nextuse
-	var/cooldown = 4 SECONDS
+	var/cooldown = 6 SECONDS
 	
 /obj/item/device/starman_hailer/attack_self(mob/user)
 	activate(user)
@@ -330,7 +340,7 @@
 	if(world.time < nextuse)
 		return
 	if(user)
-		playsound(user, pick(possible_sounds), 70, 1, vary = 0)
+		playsound(user, pick(possible_sounds), 60, 1, vary = 0)
 		var/list/bystanders = get_hearers_in_view(world.view, user)
 		flick_overlay(image('icons/mob/talk.dmi', user, "hail", MOB_LAYER+1), clients_in_moblist(bystanders), 2 SECONDS)
 		user.visible_message("<span class='danger'>\The [user] [pick("emits","blares","performs")] a [pick("sickly","frightening","spooky","strange")] [pick("sound","tune","theme")]!</span>")


### PR DESCRIPTION
Based on the first round of starman antagonism, I've done the following:
>Slightly reduced bullet resistance
>Added emp resistance so that your lockdown timer will never be more than 4 seconds
>Fixed the spells being able to cast as many times as you can click before the precast sound plays
>Starstorm cd raised from 60 seconds to 90 seconds, meteor count lowered from 20 to 12. Timing changed slightly to be more aesthetic and match sfx.
>Raised CD of pulse rifle beam to 6 seconds
>Lowered volume of starman hailer slightly
>Made the music nondirectional

:cl:
 * rscadd: Starman nerfs/buffs.