### PR TITLE
Basic and advanced xenoarch scanners now fit inside excavation belts.

### DIFF
--- a/code/modules/research/xenoarchaeology/tools/gearbelt.dm
+++ b/code/modules/research/xenoarchaeology/tools/gearbelt.dm
@@ -29,4 +29,5 @@
 		"/obj/item/weapon/wrench",
 		"/obj/item/weapon/storage/box/excavation",
 		"/obj/item/weapon/anobattery",
-		"/obj/item/weapon/weldingtool")
+		"/obj/item/weapon/weldingtool",
+		"/obj/item/device/xenoarch_scanner")


### PR DESCRIPTION
100% Tested

![works](https://user-images.githubusercontent.com/38330373/63783082-c1137800-c8c2-11e9-9647-7d32eb31846c.png)

:cl: 

- tweak: Basic and Advanced xenoarch scanners now fit inside excavation belts.