### PR TITLE
adds overflow to statusDisplay

### DIFF
--- a/nano/css/shared.css
+++ b/nano/css/shared.css
@@ -286,6 +286,7 @@ div.notice {
     border: 1px solid #40628a;
     padding: 4px;
     margin: 3px 0;
+    overflow:auto;
 }
 
 .statusDisplayRecords {


### PR DESCRIPTION
this should make it so everything utilizing the .statusDisplay class properly stays within the bounds as the height wasn't properly being scaled after a setting was changed.
[ui][nano][hotfix]