### PR TITLE
Telescience machines can now be linked via multitool, should fix the bug where the game would crash if there were multiple telepads.

### DIFF
--- a/code/modules/telesci/telepad.dm
+++ b/code/modules/telesci/telepad.dm
@@ -8,12 +8,17 @@
 	use_power = 1
 	idle_power_usage = 200
 	active_power_usage = 5000
+	machine_flags = MULTITOOL_MENU
+	var/id_tag = "telepad"
 
 	var/obj/machinery/computer/telescience/linked
 
 	// Bluespace crystal!
 	var/obj/item/bluespace_crystal/amplifier=null
 	var/opened=0
+
+/obj/machinery/telepad/multitool_menu(var/mob/user, var/obj/item/device/multitool/P)
+	return ""
 
 /obj/machinery/telepad/Destroy()
 	if (linked)
@@ -22,6 +27,7 @@
 	..()
 
 /obj/machinery/telepad/attackby(obj/item/weapon/W as obj, mob/user as mob)
+	..()
 	if(W.is_screwdriver(user))
 		if(opened)
 			playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)

--- a/code/modules/telesci/telepad.dm
+++ b/code/modules/telesci/telepad.dm
@@ -32,6 +32,13 @@
 		linked.telepad = src
 		return 1
 
+/obj/machinery/telepad/unlinkFrom(mob/user, obj/buffer)
+	if(linked.telepad)
+		linked.telepad = null
+	if(linked)
+		linked = null
+	return 1
+
 /obj/machinery/telepad/canClone(var/obj/machinery/T)
 	return (istype(T, /obj/machinery/computer/telescience) && get_dist(src, T) < 7)
 

--- a/code/modules/telesci/telepad.dm
+++ b/code/modules/telesci/telepad.dm
@@ -20,6 +20,27 @@
 /obj/machinery/telepad/multitool_menu(var/mob/user, var/obj/item/device/multitool/P)
 	return ""
 
+/obj/machinery/telepad/canLink(var/obj/T)
+	return (istype(T,/obj/machinery/computer/telescience) && get_dist(src,T) < 7)
+
+/obj/machinery/telepad/isLinkedWith(var/obj/T)
+	return (linked == T)
+
+/obj/machinery/telepad/linkWith(var/mob/user, var/obj/T, var/list/context)
+	if(istype(T, /obj/machinery/computer/telescience))
+		linked = T
+		linked.telepad = src
+		return 1
+
+/obj/machinery/telepad/canClone(var/obj/machinery/T)
+	return (istype(T, /obj/machinery/computer/telescience) && get_dist(src, T) < 7)
+
+/obj/machinery/telepad/clone(var/obj/machinery/T)
+	if(istype(T, /obj/machinery/computer/telescience))
+		linked = T
+		linked.telepad = src
+		return 1
+
 /obj/machinery/telepad/Destroy()
 	if (linked)
 		linked.telepad = null

--- a/code/modules/telesci/telesci_computer.dm
+++ b/code/modules/telesci/telesci_computer.dm
@@ -75,9 +75,19 @@
 	return (istype(T,/obj/machinery/telepad) && get_dist(src,T) < 7)
 
 /obj/machinery/computer/telescience/isLinkedWith(var/obj/T)
-	return T != null && T == telepad
+	return (telepad == T)
 
 /obj/machinery/computer/telescience/linkWith(var/mob/user, var/obj/T, var/list/context)
+	if(istype(T, /obj/machinery/telepad))
+		telepad = T
+		telepad.linked = src
+		return 1
+
+//Plagiarized conveyor belt multi-tool code
+/obj/machinery/computer/telescience/canClone(var/obj/machinery/T)
+	return (istype(T, /obj/machinery/telepad) && get_dist(src, T) < 7)
+
+/obj/machinery/computer/telescience/clone(var/obj/machinery/T)
 	if(istype(T, /obj/machinery/telepad))
 		telepad = T
 		telepad.linked = src
@@ -325,6 +335,10 @@ var/list/telesci_warnings = list(
 
 	if(cell.charge < teleport_cell_usage)
 		to_chat(user, "<span class='caution'>Error: not enough buffer energy.</span>")
+		return
+
+	if(telepad && (!telepad.linked == src))
+		to_chat(user, "<span class='caution'>Error: No telepad linked.</span>")
 		return
 
 	cell.use(teleport_cell_usage)

--- a/code/modules/telesci/telesci_computer.dm
+++ b/code/modules/telesci/telesci_computer.dm
@@ -83,6 +83,13 @@
 		telepad.linked = src
 		return 1
 
+/obj/machinery/computer/telescience/unlinkFrom(mob/user, obj/buffer)
+	if(telepad.linked)
+		telepad.linked = null
+	if(telepad)
+		telepad = null
+	return 1
+
 //Plagiarized conveyor belt multi-tool code
 /obj/machinery/computer/telescience/canClone(var/obj/machinery/T)
 	return (istype(T, /obj/machinery/telepad) && get_dist(src, T) < 7)

--- a/code/modules/telesci/telesci_computer.dm
+++ b/code/modules/telesci/telesci_computer.dm
@@ -33,6 +33,8 @@
 	var/obj/item/weapon/cell/cell
 	var/teleport_cell_usage=1000 // 100% of a standard cell
 	processing=1
+	var/id_tag = "teleconsole"
+
 
 	light_color = LIGHT_COLOR_BLUE
 
@@ -46,13 +48,10 @@
 	y_off = rand(-10,10)
 	x_player_off = 0
 	y_player_off = 0
+	cell = new/obj/item/weapon/cell(src)
 
 /obj/machinery/computer/telescience/initialize()
 	..()
-	if (!ticker || ticker.current_state != GAME_STATE_PLAYING)
-		cell = new/obj/item/weapon/cell(src)
-		cell.charge = 0
-
 	for(var/obj/machinery/telepad/possible_telepad in range(src, 7))
 		if(telepad)
 			return //Stop checking if we are linked
@@ -66,6 +65,23 @@
 		telepad = null
 
 	..()
+
+
+//Plagiarized cloning console multi-tool code
+/obj/machinery/computer/telescience/multitool_menu(var/mob/user, var/obj/item/device/multitool/P)
+	return ""
+
+/obj/machinery/computer/telescience/canLink(var/obj/T)
+	return (istype(T,/obj/machinery/telepad) && get_dist(src,T) < 7)
+
+/obj/machinery/computer/telescience/isLinkedWith(var/obj/T)
+	return T != null && T == telepad
+
+/obj/machinery/computer/telescience/linkWith(var/mob/user, var/obj/T, var/list/context)
+	if(istype(T, /obj/machinery/telepad))
+		telepad = T
+		telepad.linked = src
+		return 1
 
 /obj/machinery/computer/telescience/process()
 	if(!cell || (stat & (BROKEN|NOPOWER)) || !anchored)

--- a/code/modules/telesci/telesci_computer.dm
+++ b/code/modules/telesci/telesci_computer.dm
@@ -46,8 +46,6 @@
 	y_off = rand(-10,10)
 	x_player_off = 0
 	y_player_off = 0
-	if (ticker && ticker.mode == GAME_STATE_PLAYING)
-		initialize()
 
 /obj/machinery/computer/telescience/initialize()
 	..()
@@ -55,10 +53,12 @@
 		cell = new/obj/item/weapon/cell(src)
 		cell.charge = 0
 
-	var/obj/machinery/telepad/possible_telepad = locate() in range(src, 7)
-	if (!possible_telepad.linked)
-		telepad = possible_telepad
-		telepad.linked = src
+	for(var/obj/machinery/telepad/possible_telepad in range(src, 7))
+		if(telepad)
+			return //Stop checking if we are linked
+		if (!possible_telepad.linked) //Check if the telepad is linked to something else
+			telepad = possible_telepad
+			telepad.linked = src
 
 /obj/machinery/computer/telescience/Destroy()
 	if (telepad)


### PR DESCRIPTION
No idea how to unlink without deconstructing though, if anyone who actually knows multitool menu code could tell me that'd be great, no way of adding telescience console or telepad yet.
Cloning also doesn't work because I think cloning is a separate thing from linking, I'll plagiarize conveyor belt code
:cl:
 * tweak: You are now able to link telescience consoles and telepads between each other.
 * bugfix: Fixed a bug where the game would crash if multiple telescience consoles or telepads were added to the game before the start of the round.