### PR TITLE
Fixes responsive reagent for stock parts

### DIFF
--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -511,7 +511,7 @@ turf/unsimulated/mineral/ChangeTurf(var/turf/N, var/tell_universe=1, var/force_l
 	//many finds are ancient and thus very delicate - luckily there is a specialised energy suspension field which protects them when they're being extracted
 	if(prob(F.prob_delicate))
 		var/obj/effect/suspension_field/S = locate() in src
-		if(!S || S.field_type != get_responsive_reagent(F.find_ID))
+		if(!S || S.field_type != F.responsive_reagent)
 			if(X)
 				visible_message("<span class='danger'>[pick("[display_name] crumbles away into dust","[display_name] breaks apart")].</span>")
 				qdel(X)

--- a/code/modules/research/xenoarchaeology/finds/finds.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds.dm
@@ -11,7 +11,7 @@
 									//if excavation hits var/excavation_required exactly, it's contained find is extracted cleanly without the ore
 	var/prob_delicate = 90			//probability it requires an active suspension field to not insta-crumble
 	var/dissonance_spread = 1		//proportion of the tile that is affected by this find
-	var/responsive_reagent
+	var/responsive_reagent = PLASMA
 	var/apply_material_decorations = FALSE
 	var/apply_image_decorations = FALSE
 	var/material_descriptor = ""
@@ -503,6 +503,7 @@
 /datum/find/stock_parts //Tier 4 parts
 	find_ID = ARCHAEO_STOCKPARTS
 	apply_material_decorations = FALSE
+	responsive_reagent = IRON
 	anomaly_factor = 2
 
 /datum/find/stock_parts/spawn_item()

--- a/code/modules/research/xenoarchaeology/finds/finds_defines.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds_defines.dm
@@ -1,12 +1,5 @@
 var/list/digsite_types = list()
 var/list/archaeo_types = list()
-
-/proc/get_responsive_reagent(var/find_type)
-	var/datum/find/F = archaeo_types[find_type]
-	if(F)
-		return initial(F.responsive_reagent)
-	return PLASMA
-
 /proc/get_random_digsite_type()
 	var/value = pick(100;DIGSITE_GARDEN,95;DIGSITE_ANIMAL,90;DIGSITE_HOUSE,85;DIGSITE_TECHNICAL,80;DIGSITE_TEMPLE,75;DIGSITE_WAR)
 	return digsite_types[value]

--- a/code/modules/research/xenoarchaeology/tools/tools_depthscanner.dm
+++ b/code/modules/research/xenoarchaeology/tools/tools_depthscanner.dm
@@ -42,7 +42,7 @@
 				var/datum/find/F = M.finds[1]
 				D.depth = F.excavation_required * 2		//0-100% and 0-200cm
 				D.clearance = F.clearance_range * 2
-				D.material = get_responsive_reagent(F.find_ID)
+				D.material = F.responsive_reagent
 			/*
 			if(M.excavation_minerals.len)
 				if(M.excavation_minerals[1] < D.depth)

--- a/code/modules/research/xenoarchaeology/tools/tools_depthscanner.dm
+++ b/code/modules/research/xenoarchaeology/tools/tools_depthscanner.dm
@@ -171,7 +171,7 @@
 				var/new_color
 				if(adv)
 					new_icon_state = "find_overlay"
-					new_color = color_from_find_reagent[get_responsive_reagent(F.find_ID)]
+					new_color = color_from_find_reagent[F.responsive_reagent]
 				else
 					new_icon_state = pick("archaeo1","archaeo2","archaeo3")
 				var/image/I = image('icons/turf/mine_overlays.dmi', loc = M, icon_state = new_icon_state, layer = UNDER_HUD_LAYER)


### PR DESCRIPTION
and prevents the error from ever happening again

So, for some reason, rather than using the finds responsive_reagent that it could just access, instead it went to a find_responsive_reagent proc, that goes to a series of pre-stored types of finds, to get their responsive reagent.

A bit dumb, now it just gets the find that you have's responsive_reagent, which now defaults to PLASMA rather than being null.