### PR TITLE
Fax machine bug fixes and QoL

### DIFF
--- a/code/WorkInProgress/kilakk/fax.dm
+++ b/code/WorkInProgress/kilakk/fax.dm
@@ -220,6 +220,17 @@ var/list/alldepartments = list("Central Command")
 		to_chat(user, "<span class='notice'>You [anchored ? "wrench" : "unwrench"] \the [src].</span>")
 	return
 
+/obj/machinery/faxmachine/kick_act()
+	..()
+	if(tofax)
+		tofax.forceMove(loc)
+		tofax = null
+		return
+	if(scan)
+		scan.forceMove(loc)
+		scan = null
+		return
+
 /proc/Centcomm_fax(var/obj/item/weapon/paper/sent, var/sentname, var/mob/Sender)
 
 //why the fuck doesnt the thing show as orange

--- a/code/WorkInProgress/kilakk/fax.dm
+++ b/code/WorkInProgress/kilakk/fax.dm
@@ -56,6 +56,20 @@ var/list/alldepartments = list("Central Command")
 /obj/machinery/faxmachine/attack_paw(mob/user as mob)
 	return attack_hand(user)
 
+/obj/machinery/faxmachine/verb/remove_id()
+	set name = "Remove ID from the fax machine"
+	set src in view(1)
+	if(scan && ishuman(usr))
+		usr.put_in_hands(scan)
+		scan = null
+
+/obj/machinery/faxmachine/verb/remove_paper()
+	set name = "Remove fax material from the fax machine"
+	set src in view(1)
+	if(tofax && ishuman(usr))
+		usr.put_in_hands(tofax)
+		tofax = null
+
 /obj/machinery/faxmachine/attack_hand(mob/user as mob)
 	user.set_machine(src)
 
@@ -82,8 +96,8 @@ var/list/alldepartments = list("Central Command")
 		if(tofax)
 			dat += "<a href='byond://?src=\ref[src];remove=1'>Remove Paper</a><br><br>"
 
-			if(faxtime>world.timeofday)
-				dat += "<b>Transmitter arrays realigning. Please stand by for [(faxtime - world.timeofday) / 10] second\s.</b><br>"
+			if(faxtime>world.time)
+				dat += "<b>Transmitter arrays realigning. Please stand by for [(faxtime - world.time) / 10] second\s.</b><br>"
 
 			else
 				dat += "<a href='byond://?src=\ref[src];send=1'>Send</a><br>"
@@ -94,9 +108,9 @@ var/list/alldepartments = list("Central Command")
 				dat += "<b>Sending to:</b> <a href='byond://?src=\ref[src];dept=1'>[dpt]</a><br>"
 
 		else
-			if(faxtime>world.timeofday)
+			if(faxtime>world.time)
 				dat += "Please insert paper to send via secure connection.<br><br>"
-				dat += "<b>Transmitter arrays realigning. Please stand by for [(faxtime - world.timeofday) / 10] second\s.</b><br>"
+				dat += "<b>Transmitter arrays realigning. Please stand by for [(faxtime - world.time) / 10] second\s.</b><br>"
 			else
 				dat += "Please insert paper to send via secure connection.<br><br>"
 
@@ -132,7 +146,7 @@ var/list/alldepartments = list("Central Command")
 				SendFax(tofax.info, tofax.name, usr, dpt, 0, tofax.display_x, tofax.display_y)
 			log_game("([usr]/([usr.ckey]) sent a fax titled [tofax] to [dpt] - contents: [tofax.info]")
 			to_chat(usr, "Message transmitted successfully.")
-			faxtime = world.timeofday + cooldown_time
+			faxtime = world.time + cooldown_time
 
 	if(href_list["remove"])
 		if(tofax)
@@ -177,7 +191,12 @@ var/list/alldepartments = list("Central Command")
 	updateUsrDialog()
 
 /obj/machinery/faxmachine/attackby(obj/item/O as obj, mob/user as mob)
-
+	if(stat & NOPOWER)
+		to_chat(user, "<span class = 'warning'>\The [src] has no power.</span>")
+		return
+	if(stat & BROKEN)
+		to_chat(user, "<span class = 'warning'>\The [src] is broken!</span>")
+		return
 	if(istype(O, /obj/item/weapon/paper))
 		if(!tofax)
 			if(user.drop_item(O, src))


### PR DESCRIPTION
Adds verbs for removing IDs and removing papers from fax machines

Fax machines use world.time rather than world.timeofday. Closes #19972

Can no longer place your IDs and papers in fax machines that are not powered.

:cl:
 * rscadd: Fax machines no longer claim your ID for themselves should the equipment power be offline.