### PR TITLE
ATM QoL and bug fixes

### DIFF
--- a/code/WorkInProgress/Mini/ATM.dm
+++ b/code/WorkInProgress/Mini/ATM.dm
@@ -124,7 +124,7 @@ log transactions
 			T.time = worldtime2text()
 			authenticated_account.transaction_log.Add(T)
 
-			to_chat(user, "<span class='info'>You insert [T.amount] credit/s into \the [src].</span>")
+			to_chat(user, "<span class='info'>You insert [T.amount] credit\s into \the [src].</span>")
 			src.attack_hand(user)
 			qdel(I)
 	else

--- a/code/WorkInProgress/Mini/ATM.dm
+++ b/code/WorkInProgress/Mini/ATM.dm
@@ -32,6 +32,7 @@ log transactions
 	var/machine_id = ""
 	var/view_screen = NO_SCREEN
 	var/lastprint = 0 // Printer needs time to cooldown
+	var/take_from_turf = TRUE
 	var/obj/item/weapon/card/atm_card = null // Since there's debit cards now, scan doesn't work for us.
 
 	machine_flags = PURCHASER //not strictly true, but it connects it to the account
@@ -68,7 +69,7 @@ log transactions
 		if(ticks_left_locked_down <= 0)
 			number_incorrect_tries = 0
 
-	if(CAN_INTERACT_WITH_ACCOUNT)
+	if(CAN_INTERACT_WITH_ACCOUNT && take_from_turf)
 		var/turf/T = get_turf(src)
 		if(istype(T) && locate(/obj/item/weapon/spacecash) in T)
 			var/list/cash_found = list()
@@ -123,7 +124,7 @@ log transactions
 			T.time = worldtime2text()
 			authenticated_account.transaction_log.Add(T)
 
-			to_chat(user, "<span class='info'>You insert [I] into [src].</span>")
+			to_chat(user, "<span class='info'>You insert [T.amount] credit/s into \the [src].</span>")
 			src.attack_hand(user)
 			qdel(I)
 	else
@@ -160,7 +161,8 @@ log transactions
 		var/dat = {"<h1>Nanotrasen Automatic Teller Machine</h1>
 			For all your monetary needs!<br>
 			<i>This terminal is</i> [machine_id]. <i>Report this code when contacting Nanotrasen IT Support</i><br/>
-			Card: <a href='?src=\ref[src];choice=insert_card'>[get_card_name_or_account()]</a><br><br><hr>"}
+			Card: <a href='?src=\ref[src];choice=insert_card'>[get_card_name_or_account()]</a><br>
+			Cash-magnet status: <a href='?src=\ref[src];choice=toggle_take'>[take_from_turf?"active":"inactive"]</a><br><br><hr>"}
 
 		if(ticks_left_locked_down > 0)
 			dat += "<span class='alert'>Maximum number of pin attempts exceeded! Access to this ATM has been temporarily disabled.</span>"
@@ -416,7 +418,7 @@ log transactions
 					if(!istype(atm_card, /obj/item/weapon/card/id))
 						to_chat(usr, "<span class='notice'>You must insert your ID card before you can transfer funds to it.</span>")
 						return
-					
+
 					var/obj/item/weapon/card/id/card_id = atm_card
 					if(amount <= 0)
 						alert("That is not a valid amount.")
@@ -538,6 +540,8 @@ log transactions
 			if("logout")
 				authenticated_account = null
 				failsafe = 1
+			if("toggle_take")
+				take_from_turf = !take_from_turf
 				//usr << browse(null,"window=atm")
 
 	src.attack_hand(usr,failsafe)
@@ -550,7 +554,21 @@ log transactions
 			dispense_cash(arbitrary_sum,H.wear_id)
 			to_chat(usr, "[bicon(src)]<span class='notice'>Funds were transferred into your physical wallet!</span>")
 			return
-	dispense_cash(arbitrary_sum,get_step(get_turf(src),turn(dir,180))) // Spawn on the ATM.
+		if(istype(H.wear_id, /obj/item/device/pda))
+			var/obj/item/device/pda/P = H.wear_id
+			to_chat(usr, "[bicon(src)]<span class='notice'>Funds were transferred into your virtual wallet!</span>")
+			P.add_to_virtual_wallet(arbitrary_sum, user)
+			return
+	var/turf/our_turf = get_turf(src)
+	var/turf/destination_turf = get_step(our_turf, turn(dir, 180))
+	var/just_throw_it = FALSE
+	if(!destination_turf.Adjacent(src) || destination_turf == our_turf) //Can we get to this turf being where the user is facing?
+		destination_turf = our_turf //We'll handle it another way
+		just_throw_it = TRUE
+	var/list/cash = dispense_cash(arbitrary_sum,destination_turf)
+	if(just_throw_it) //Just throw it at them
+		for(var/obj/I in cash)
+			I.throw_at(pick(trange(3, src)), rand(2,5), rand(1,4))
 
 //stolen wholesale and then edited a bit from newscasters, which are awesome and by Agouri
 /obj/machinery/atm/proc/scan_user(mob/living/carbon/human/human_user as mob)

--- a/code/WorkInProgress/Mini/ATM.dm
+++ b/code/WorkInProgress/Mini/ATM.dm
@@ -562,7 +562,7 @@ log transactions
 	var/turf/our_turf = get_turf(src)
 	var/turf/destination_turf = get_step(our_turf, turn(dir, 180))
 	var/just_throw_it = FALSE
-	if(!destination_turf.Adjacent(src) || destination_turf == our_turf) //Can we get to this turf being where the user is facing?
+	if(!destination_turf.Adjacent(src) || destination_turf == our_turf) //Can we get to this turf being where the ATM is facing?
 		destination_turf = our_turf //We'll handle it another way
 		just_throw_it = TRUE
 	var/list/cash = dispense_cash(arbitrary_sum,destination_turf)

--- a/code/WorkInProgress/Mini/ATM.dm
+++ b/code/WorkInProgress/Mini/ATM.dm
@@ -534,9 +534,14 @@ log transactions
 			return
 		if(istype(H.wear_id, /obj/item/device/pda))
 			var/obj/item/device/pda/P = H.wear_id
-			to_chat(usr, "[bicon(src)]<span class='notice'>Funds were transferred into your virtual wallet!</span>")
-			P.add_to_virtual_wallet(arbitrary_sum, user)
-			return
+			if(P.add_to_virtual_wallet(arbitrary_sum, user, src))
+				to_chat(usr, "[bicon(src)]<span class='notice'>Funds were transferred into your virtual wallet!</span>")
+				return
+		if(istype(H.wear_id, /obj/item/weapon/card/id))
+			var/obj/item/weapon/card/id/ID = H.wear_id
+			if(ID.add_to_virtual_wallet(arbitrary_sum, user, src))
+				to_chat(usr, "[bicon(src)]<span class='notice'>Funds were transferred into your virtual wallet!</span>")
+				return
 	var/turf/our_turf = get_turf(src)
 	var/turf/destination_turf = get_step(our_turf, turn(dir, 180))
 	var/just_throw_it = FALSE

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -2341,25 +2341,21 @@ obj/item/device/pda/AltClick()
 			to_chat(user, "[bicon(src)]<span class='warning'>There is no ID in the PDA!</span>")
 			return
 		var/obj/item/weapon/spacecash/dosh = C
-		add_to_virtual_wallet(dosh.worth * dosh.amount, user)
-		to_chat(user, "<span class='info'>You insert [dosh.worth * dosh.amount] credit\s into the PDA.</span>")
-		qdel(dosh)
+		if(add_to_virtual_wallet(dosh.worth * dosh.amount, user))
+			to_chat(user, "<span class='info'>You insert [dosh.worth * dosh.amount] credit\s into the PDA.</span>")
+			qdel(dosh)
 		updateDialog()
 
-/obj/item/device/pda/proc/add_to_virtual_wallet(var/amount, var/mob/user)
-	id.virtual_wallet.money += amount
-	if(prob(50))
-		playsound(loc, 'sound/items/polaroid1.ogg', 50, 1)
-	else
-		playsound(loc, 'sound/items/polaroid2.ogg', 50, 1)
-	var/datum/transaction/T = new()
-	T.target_name = user.name
-	T.purpose = "Currency deposit"
-	T.amount = amount
-	T.source_terminal = src.name
-	T.date = current_date_string
-	T.time = worldtime2text()
-	id.virtual_wallet.transaction_log.Add(T)
+/obj/item/device/pda/proc/add_to_virtual_wallet(var/amount, var/mob/user, var/atom/giver)
+	if(!id)
+		return 0
+	if(id.add_to_virtual_wallet(amount, user, giver))
+		if(prob(50))
+			playsound(loc, 'sound/items/polaroid1.ogg', 50, 1)
+		else
+			playsound(loc, 'sound/items/polaroid2.ogg', 50, 1)
+		return 1
+	return 0
 
 /obj/item/device/pda/attack(mob/living/carbon/C, mob/living/user as mob)
 	if(istype(C))

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -2058,7 +2058,9 @@ var/global/list/obj/item/device/pda/PDAs = list()
 			dispense_cash(arbitrary_sum,H.wear_id)
 			to_chat(usr, "[bicon(src)]<span class='notice'>Funds were transferred into your physical wallet!</span>")
 			return 1
-	dispense_cash(arbitrary_sum,get_turf(src))
+	var/list/L = dispense_cash(arbitrary_sum,get_turf(src))
+	for(var/obj/I in L)
+		user.put_in_hands(I)
 	return 1
 
 //Receive money transferred from another PDA

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -2339,25 +2339,25 @@ obj/item/device/pda/AltClick()
 			to_chat(user, "[bicon(src)]<span class='warning'>There is no ID in the PDA!</span>")
 			return
 		var/obj/item/weapon/spacecash/dosh = C
-		id.virtual_wallet.money += dosh.worth * dosh.amount
-		if(prob(50))
-			playsound(loc, 'sound/items/polaroid1.ogg', 50, 1)
-		else
-			playsound(loc, 'sound/items/polaroid2.ogg', 50, 1)
-
-		var/datum/transaction/T = new()
-		T.target_name = user.name
-		T.purpose = "Currency deposit"
-		T.amount = dosh.worth * dosh.amount
-		T.source_terminal = src.name
-		T.date = current_date_string
-		T.time = worldtime2text()
-		id.virtual_wallet.transaction_log.Add(T)
-		to_chat(user, "<span class='info'>You insert [T.amount] credit\s into the PDA.</span>")
+		add_to_virtual_wallet(dosh.worth * dosh.amount, user)
+		to_chat(user, "<span class='info'>You insert [dosh.worth * dosh.amount] credit\s into the PDA.</span>")
 		qdel(dosh)
 		updateDialog()
 
-	return
+/obj/item/device/pda/proc/add_to_virtual_wallet(var/amount, var/mob/user)
+	id.virtual_wallet.money += amount
+	if(prob(50))
+		playsound(loc, 'sound/items/polaroid1.ogg', 50, 1)
+	else
+		playsound(loc, 'sound/items/polaroid2.ogg', 50, 1)
+	var/datum/transaction/T = new()
+	T.target_name = user.name
+	T.purpose = "Currency deposit"
+	T.amount = amount
+	T.source_terminal = src.name
+	T.date = current_date_string
+	T.time = worldtime2text()
+	id.virtual_wallet.transaction_log.Add(T)
 
 /obj/item/device/pda/attack(mob/living/carbon/C, mob/living/user as mob)
 	if(istype(C))

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -167,11 +167,11 @@
 /obj/item/weapon/card/emag/attack()
 	return
 
-//perform individual emag_act() stuff on children overriding the method here 
+//perform individual emag_act() stuff on children overriding the method here
 /obj/item/weapon/card/emag/afterattack(var/atom/target, mob/user, proximity)
 	if(!proximity)
 		return
-	if (istype(target, /mob/living/carbon/human)) 
+	if (istype(target, /mob/living/carbon/human))
 		var/mob/living/carbon/target_living = target
 		//get target zone with 0% chance of missing
 		var/zone = ran_zone(user.zone_sel.selecting, 100)
@@ -256,6 +256,22 @@
 	if(!virtual_wallet.account_number)
 		virtual_wallet.account_number = next_account_number
 		next_account_number += rand(1,25)
+
+/obj/item/weapon/card/id/proc/add_to_virtual_wallet(var/added_funds=0, var/mob/user, var/atom/source)
+	if(!virtual_wallet)
+		return 0
+	virtual_wallet.money += added_funds
+	var/datum/transaction/T = new()
+	if(user)
+		T.target_name = user.name
+	T.purpose = "Currency deposit"
+	T.amount = added_funds
+	if(source)
+		T.source_terminal = source.name
+	T.date = current_date_string
+	T.time = worldtime2text()
+	virtual_wallet.transaction_log.Add(T)
+	return 1
 
 /obj/item/weapon/card/id/proc/UpdateName()
 	name = "[src.registered_name]'s ID Card ([src.assignment])"

--- a/code/game/objects/items/weapons/cash.dm
+++ b/code/game/objects/items/weapons/cash.dm
@@ -163,11 +163,13 @@ var/global/list/moneytypes = list(
 
 // TODO: Allow denominations below $1
 /proc/dispense_cash(var/amount, var/loc)
+	var/list/cash_spawned = list()
 	if(amount > 100000)
 		var/obj/item/weapon/spacecash/SC = new /obj/item/weapon/spacecash/cN(loc, 1)
 		SC.worth = amount
 		SC.name = "[SC.worth] credit chip"
-		return
+		cash_spawned.Add(SC)
+		return cash_spawned
 	for(var/cashtype in moneytypes)
 		var/slice = moneytypes[cashtype]
 		var/dispense_count = Floor(amount/slice)
@@ -175,8 +177,10 @@ var/global/list/moneytypes = list(
 		while(dispense_count>0)
 			var/dispense_this_time = min(dispense_count,10)
 			if(dispense_this_time > 0)
-				new cashtype(loc,dispense_this_time)
+				cash_spawned.Add(new cashtype(loc,dispense_this_time))
 				dispense_count -= dispense_this_time
+
+	return cash_spawned
 
 /proc/count_cash(var/list/cash)
 	. = 0


### PR DESCRIPTION
After seeing 
![image](https://user-images.githubusercontent.com/30557196/63981676-e87f6600-cab7-11e9-84e5-69235d3d8481.png) in the thread, I thought I'd take a shot at fixing this.

 - If you're wearing a PDA, cash from the ATM is put into your virtual wallet (Might disable this, as there's the "transfer to virtual wallet" option)
 - It will then try to put the money on the turf "behind" itself
 - If it can not reach said turf, it'll just eject the money with force.

 - ~~Also adds a button for toggling the ATMs ability to take money from the floor~~ Removes ATMs taking money from the floor, as that was a bodge-job fix for PDAs printing money and putting it right on the floor.

 - Makes adding money to your virtual wallet into a function, currently used by applying cash to your PDA, and by the ATM placing money in your virtual wallet

:cl:
 * rscadd: ATMs now check if the user can actually reach the turf they are going to place the money they are removing from their account onto, otherwise it'll just throw the money at them.
 * rscadd: ATMs no longer steal money from the floor
 * tweak: Rather than printing money from your PDA putting the money on the floor, instead it attempts to put the money in your hands whenever possible.

