### PR TITLE
Fixes being able to givebomb somebody

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -20,7 +20,7 @@
 	var/pulse = PULSE_NORM	//current pulse level
 
 	var/hasmouth = 1 // Used for food, etc.
-
+	var/give_check = FALSE
 	var/event/on_emote = new ()
 	var/base_insulation = 0
 	var/unslippable = 0 //Whether the mob can be slipped
@@ -33,4 +33,3 @@
 	if (mutual_handcuffs && mutual_handcuffed_to)
 		mutual_handcuffs.remove_mutual_cuff_events(mutual_handcuffed_to)
 	. = ..()
-	

--- a/code/modules/mob/living/carbon/give.dm
+++ b/code/modules/mob/living/carbon/give.dm
@@ -1,16 +1,12 @@
-/mob/living/carbon/verb/give()
-	set category = "IC"
-	set name = "Give"
-	set src in oview(1) //Cannot handle giving shit to mobs on your own tile, but it's a small, small loss
-
-	give_item(usr)
-
 /mob/living/carbon/proc/give_item(mob/living/carbon/user)
 
 
 	if(!istype(user))
 		return
 	if(src.stat == 2 || user.stat == 2 || src.client == null)
+		return
+	if(give_check)
+		to_chat(user, "<span class='warning'>\The [src] is currently being passed something by somebody else.</span>")
 		return
 	if(src.handcuffed)
 		to_chat(user, "<span class='warning'>Those hands are cuffed right now.</span>")
@@ -26,8 +22,10 @@
 		to_chat(user, "<span class='warning'>You tried to give yourself \the [I], but you didn't want it.</span>")
 		return
 	if(find_empty_hand_index())
+		give_check = TRUE
 		switch(alert(src, "[user] wants to give you \a [I]?", , "Yes", "No"))
 			if("Yes")
+				give_check = FALSE
 				if(!I)
 					return
 				if(!Adjacent(user))
@@ -51,6 +49,8 @@
 				src.put_in_hands(I)
 				src.visible_message("<span class='notice'>[user] handed \the [I] to [src].</span>")
 			if("No")
+				give_check = FALSE
 				src.visible_message("<span class='warning'>[user] tried to hand \the [I] to [src] but \he didn't want it.</span>")
+
 	else
 		to_chat(user, "<span class='warning'>[src]'s hands are full.</span>")


### PR DESCRIPTION
The act of givebombing is to spam a person with the give command. This will open a prompt to them and remove focus from the game screen, and could be repeated ad infinitum, creating a new prompt each time, with no way to clear all prompts.

This adds a lock, so that if somebody has received a prompt, they can't receive stacking prompts of give.

Also removes the verb, as @boy2mantwicethefam stated they were specifically using a repeat-macro to lock somebody up incredibly quickly.

:cl:
 * bugfix: Fixes being able to spam the give command to somebody to lock up their game.
