### PR TITLE
Nukes point code, as it was being abused to point at invisible things.

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -269,7 +269,7 @@
 */
 
 /mob/proc/MiddleShiftClickOn(var/atom/A)
-	pointed(A)
+	point(A)
 
 /*
 	Shift click

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -1094,7 +1094,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 //this is a mob verb instead of atom for performance reasons
 //see /mob/verb/examinate() in mob.dm for more info
 //overriden here and in /mob/living for different point span classes and sanity checks
-/mob/dead/observer/pointed(atom/A as mob|obj|turf in view())
+/mob/dead/observer/point(atom/A as mob|obj|turf in view())
 	if(!..())
 		return 0
 	usr.visible_message("<span class='deadsay'><b>[src]</b> points to [A]</span>.")

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1274,7 +1274,7 @@ Thanks.
 	return
 
 //same as above
-/mob/living/pointed(atom/A as mob|obj|turf in view(get_turf(src)))
+/mob/living/point(atom/A as mob|obj|turf in view(get_turf(src)))
 	if(src.incapacitated())
 		return 0
 	if(!..())

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -699,9 +699,9 @@ var/list/slot_equipment_priority = list( \
 		slot_r_store\
 	)
 
-/*Equips accessories. 
+/*Equips accessories.
 A is the mob
-B is the accessory. 
+B is the accessory.
 C is what item the accessory will look to be attached to, important.
 D will look how many accessories the item already has, and will move on if its attachment would go above the amount of accessories
 E will stop the proc if a candidate had the accessory attached to it and it is toggled on
@@ -1056,7 +1056,7 @@ Use this proc preferably at the end of an equipment loadout
 //note: ghosts can point, this is intended
 //visible_message will handle invisibility properly
 //overriden here and in /mob/dead/observer for different point span classes and sanity checks
-/mob/verb/pointed(atom/A as turf | obj | mob in view(get_turf(src)))
+/mob/proc/point(atom/A in view(get_turf(src)))
 	set name = "Point To"
 	set category = "Object"
 


### PR DESCRIPTION
People are abusing the macro point_to "thing" to point at wizards who are invisible.

When you see the text "blizzard wizard fires a fireball at [src]" or "Butt-blaster mcGee says "AR'SE NATH"", simply make a macro of Point-To "[whatever the wizards name is]" then spam the command to constantly point towards the wizard if they're on screen, regardless of their visibility. 

This has prompted wizards such as Kavlax to name themselves "floor" so that, rather than being pointed at constantly through use of the aforementioned macro, it just points to the floor. Exploiters versus Exploiters.

Macros are honestly pretty bad due to how exploitable being able to call a verb on repeat is, but good luck getting the full thing removed.

Now, the only way to point is to Middle shift click on something. I currently don't know how to fix it so that you can't just pass the name of the thing you want to use in the macro, so I'd rather just nuke the verb.

:cl:
 * rscdel: The point verb has been removed. Use Middle shift click on a thing to point to it.