### PR TITLE
R&D QoL - Destructive Analyzer

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -853,11 +853,12 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			dat += {"<A href='?src=\ref[src];menu=1.0'>Main Menu</A><HR>
 				Deconstruction Menu<HR>
 				Name: [linked_destroy.loaded_item.name]<BR>
-				Origin Tech:<BR>"}
+				Origin Tech:<UL>"}
 			var/list/temp_tech = linked_destroy.ConvertReqString2List(linked_destroy.loaded_item.origin_tech)
 			for(var/T in temp_tech)
 				var/datum/tech/TT = files.GetKTechByID(T)
-				dat += "* [CallTechName(T)] [temp_tech[T]] \[Current research level: [TT.level]\]<BR>"
+				dat += "<LI>[CallTechName(T)] [temp_tech[T]] \[Current research level: [TT.level]\]</LI>"
+			dat += "</UL>"
 			if(linked_destroy.loaded_item.materials)
 				dat += "Material Composition:<UL>"
 				for(var/matID in linked_destroy.loaded_item.materials.storage)

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -856,8 +856,15 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 				Origin Tech:<BR>"}
 			var/list/temp_tech = linked_destroy.ConvertReqString2List(linked_destroy.loaded_item.origin_tech)
 			for(var/T in temp_tech)
-				dat += "* [CallTechName(T)] [temp_tech[T]]<BR>"
-
+				var/datum/tech/TT = files.GetKTechByID(T)
+				dat += "* [CallTechName(T)] [temp_tech[T]] \[Current research level: [TT.level]\]<BR>"
+			if(linked_destroy.loaded_item.materials)
+				dat += "Material Composition:<UL>"
+				for(var/matID in linked_destroy.loaded_item.materials.storage)
+					if(linked_destroy.loaded_item.materials.storage[matID])
+						var/datum/material/M = linked_destroy.loaded_item.materials.getMaterial(matID)
+						dat += "<LI>[M.processed_name] : [linked_destroy.loaded_item.materials.storage[matID]]</LI>"
+				dat += "</UL><BR>"
 			dat += {"<HR><A href='?src=\ref[src];deconstruct=1'>Deconstruct Item</A> ||
 				<A href='?src=\ref[src];eject_item=1'>Eject Item</A> || "}
 		/////////////////////PROTOLATHE SCREENS/////////////////////////

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -864,7 +864,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 				for(var/matID in linked_destroy.loaded_item.materials.storage)
 					if(linked_destroy.loaded_item.materials.storage[matID])
 						var/datum/material/M = linked_destroy.loaded_item.materials.getMaterial(matID)
-						dat += "<LI>[M.processed_name] : [linked_destroy.loaded_item.materials.storage[matID]]</LI>"
+						dat += "<LI>[M.processed_name]: [linked_destroy.loaded_item.materials.storage[matID]]</LI>"
 				dat += "</UL><BR>"
 			dat += {"<HR><A href='?src=\ref[src];deconstruct=1'>Deconstruct Item</A> ||
 				<A href='?src=\ref[src];eject_item=1'>Eject Item</A> || "}


### PR DESCRIPTION
The destruction tab now tells you the current research level, and however much material you would receive from deconstructing the object

:cl:
 * rscadd: The destructive analyzer now tells you the current research level in comparison to the items research level, as well as what resources would be reclaimed should the item be deconstructed.