### PR TITLE
Finally fucking removes all explicit calls to Destroy() (except the necessary ones of course)

### DIFF
--- a/code/WorkInProgress/Cael_Aislinn/scp_173.dm
+++ b/code/WorkInProgress/Cael_Aislinn/scp_173.dm
@@ -131,7 +131,7 @@
 			if(!next_turf.Cross(src, next_turf)) //We can't pass through our planned path
 				break
 			for(var/obj/structure/window/W in next_turf)
-				W.Destroy(brokenup = 1)
+				W.shatter()
 				sleep(5)
 			for(var/obj/structure/table/O in next_turf)
 				O.ex_act(1)
@@ -182,7 +182,7 @@
 				if(!next_turf.Cross(src, next_turf)) //We can't pass through our planned path
 					break
 				for(var/obj/structure/window/W in next_turf)
-					W.Destroy(brokenup = 1)
+					W.shatter()
 					sleep(5)
 				for(var/obj/structure/table/O in next_turf)
 					O.ex_act(1)

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_mobs_and_constructs.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_mobs_and_constructs.dm
@@ -20,7 +20,8 @@
 	if(src.throwing)
 		var/breakthrough = 0
 		if(istype(obstacle, /obj/structure/window/))
-			obstacle.Destroy(brokenup = 1)
+			var/obj/structure/window/W = obstacle
+			W.shatter()
 			breakthrough = 1
 
 		else if(istype(obstacle, /obj/structure/grille/))

--- a/code/game/machinery/cell_charger.dm
+++ b/code/game/machinery/cell_charger.dm
@@ -106,7 +106,7 @@
 			spark(src, 5)
 			spawn(15)
 				explosion(src.loc, -1, 1, 3, adminlog = 0) //Overload
-				Destroy(src) //It exploded, rip
+				qdel(src) //It exploded, rip
 			return
 		usr.put_in_hands(charging)
 		charging.add_fingerprint(user)

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -132,7 +132,7 @@
 			A.state = 4
 			A.icon_state = "4"
 		circuit = null // Used by the busy check to avoid multiple 'You disconnect the monitor' messages
-		Destroy(src)
+		qdel(src)
 		return 1
 	else
 		return 1 // Needed, otherwise the computer UI will pop open

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1398,7 +1398,7 @@ About the new airlock wires panel:
 	for(var/turf/T in loc)
 		var/obj/structure/window/W = locate(/obj/structure/window) in T
 		if (W)
-			W.Destroy(brokenup = 1)
+			W.shatter()
 
 	..()
 	return

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -446,7 +446,8 @@
 	if(src.throwing)//high velocity mechas in your face!
 		var/breakthrough = 0
 		if(istype(obstacle, /obj/structure/window/))
-			obstacle.Destroy(brokenup = 1)
+			var/obj/structure/window/W = obstacle
+			W.shatter()
 			breakthrough = 1
 
 		else if(istype(obstacle, /obj/structure/grille/))
@@ -1668,12 +1669,12 @@
 						</head>
 						<body>
 						<h1>Following keycodes are present in this system:</h1>"}
-	
+
 	for(var/a in operation_req_access)
 		output += "[get_access_desc(a)] - <a href='?src=\ref[src];del_req_access=[a];user=\ref[user];id_card=\ref[id_card]'>Delete</a><br>"
-	
+
 	output += "<a href='?src=\ref[src];del_all_req_access=1;user=\ref[user];id_card=\ref[id_card]'><br><b>Delete All</b></a><br>"
-	
+
 	output += "<hr><h1>Following keycodes were detected on portable device:</h1>"
 	for(var/a in id_card.access)
 		if(a in operation_req_access)
@@ -1681,7 +1682,7 @@
 		if(!get_access_desc(a))
 			continue //there's some strange access without a name
 		output += "[get_access_desc(a)] - <a href='?src=\ref[src];add_req_access=[a];user=\ref[user];id_card=\ref[id_card]'>Add</a><br>"
-	
+
 	output += "<a href='?src=\ref[src];add_all_req_access=1;user=\ref[user];id_card=\ref[id_card]'><br><b>Add All</b></a><br>"
 
 	output += {"<hr><a href='?src=\ref[src];finish_req_access=1;user=\ref[user]'>Finish</a> <font color='red'>(Warning! The ID upload panel will be locked. It can be unlocked only through Exosuit Interface.)</font>
@@ -1905,7 +1906,7 @@
 		for(var/a in myaccess)
 			operation_req_access += a
 		output_access_dialog(topic_filter.getObj("id_card"),topic_filter.getMob("user"))
-		return	
+		return
 	if(href_list["del_req_access"] && add_req_access && topic_filter.getObj("id_card"))
 		if(!in_range(src, usr))
 			return
@@ -1917,7 +1918,7 @@
 			return
 		operation_req_access = list()
 		output_access_dialog(topic_filter.getObj("id_card"),topic_filter.getMob("user"))
-		return	
+		return
 	if(href_list["finish_req_access"])
 		if(!in_range(src, usr))
 			return

--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -166,7 +166,6 @@ var/list/infected_cleanables = list()
 //		user.verbs += /mob/living/carbon/human/proc/bloody_doodle
 //
 /obj/effect/decal/cleanable/resetVariables()
-	Destroy()
 	..("viruses","virus2", "blood_DNA", "random_icon_states", args)
 	viruses = list()
 	virus2 = list()

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -94,7 +94,7 @@
 				message_admins("[A] with pdiff [pdiff] fire-axed by [user.real_name] ([formatPlayerPanel(user,user.ckey)]) at [formatJumpTo(A.loc)]!")
 				log_admin("[A] with pdiff [pdiff] fire-axed by [user.real_name] ([user.ckey]) at [A.loc]!")
 			var/obj/structure/window/W = A
-			W.Destroy(brokenup = 1)
+			W.shatter()
 		else
 			qdel(A)
 			A = null

--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -39,7 +39,7 @@
 /obj/structure/window/barricade/healthcheck(var/mob/M, var/sound = 1)
 
 	if(health <= 0)
-		Destroy()
+		qdel(src)
 
 //Note : We don't want glass knocking sounds to play
 /obj/structure/window/barricade/attack_hand(mob/user as mob)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -109,7 +109,7 @@ var/list/one_way_windows
 				investigation_log(I_ATMOS, "with a pdiff of [pdiff] has been destroyed by [M.real_name] ([formatPlayerPanel(M, M.ckey)]) at [formatJumpTo(get_turf(src))]!")
 				if(M.ckey) //Only send an admin message if it's an actual players, admins don't need to know what the carps are doing
 					message_admins("\The [src] with a pdiff of [pdiff] has been destroyed by [M.real_name] ([formatPlayerPanel(M, M.ckey)]) at [formatJumpTo(get_turf(src))]!")
-		Destroy(brokenup = 1)
+		shatter()
 	else
 		if(sound)
 			playsound(loc, 'sound/effects/Glasshit.ogg', 100, 1)
@@ -505,7 +505,7 @@ var/list/one_way_windows
 				user.visible_message("<span class='warning'>[user] disassembles \the [src].</span>", \
 				"<span class='notice'>You disassemble \the [src].</span>")
 				drop_stack(sheet_type, get_turf(src), sheetamount, user)
-				Destroy()
+				qdel(src)
 				return
 
 	user.do_attack_animation(src, W)
@@ -562,19 +562,20 @@ var/list/one_way_windows
 	ini_dir = dir
 	return
 
-/obj/structure/window/Destroy(var/brokenup = 0)
-
+/obj/structure/window/Destroy()
 	setDensity(FALSE) //Sanity while we do the rest
 	update_nearby_tiles()
 	update_nearby_icons()
-	if(brokenup) //If the instruction we were sent clearly states we're breaking the window, not deleting it !
-		if(loc)
-			playsound(src, "shatter", 70, 1)
-		spawnBrokenPieces()
 	if(one_way)
 		one_way_windows.Remove(src)
 		update_oneway_nearby_clients()
 	..()
+
+/obj/structure/window/proc/shatter()
+	if(loc)
+		playsound(src, "shatter", 70, 1)
+	spawnBrokenPieces()
+	qdel(src)
 
 /obj/structure/window/proc/spawnBrokenPieces()
 	if(shardtype)

--- a/code/modules/mob/living/simple_animal/hostile/human/halloween.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/halloween.dm
@@ -256,7 +256,7 @@
 		C.Stun(8)
 		C.Jitter(150)
 	for(var/obj/structure/window/W in view(4, src))
-		W.Destroy(brokenup = 1)
+		W.shatter()
 	playsound(src.loc, 'sound/effects/creepyshriek.ogg', 100, 1)
 
 	anim(target = src, a_icon = 'icons/mob/mob.dmi', flick_anim = "dust-h", sleeptime = 15)

--- a/code/modules/spells/aoe_turf/screech.dm
+++ b/code/modules/spells/aoe_turf/screech.dm
@@ -63,7 +63,7 @@
 		C.Stun(8)
 		C.Jitter(150)
 	for(var/obj/structure/window/W in view(4))
-		W.Destroy(brokenup = 1)
+		W.shatter()
 
 	playsound(user, 'sound/effects/creepyshriek.ogg', 100, 1)
 


### PR DESCRIPTION
Windows are the main offender here, but there are three others. Emagged cell chargers and disassembled computers just called it instead of `qdel()`, presumably because someone got confused. Cleanables called it before the supercall in `resetVariables()`, which is completely pointless since it's called by `returnToPool()` right before `resetVariables()` is. This could potentially make a difference if `resetVariables()` were called from anywhere else or if any of this type's children did something before their supercall in `resetVariables()`, but neither of these is the case.

Merge before #24036.