### PR TITLE
R&D QoL - Material costs preview

### DIFF
--- a/code/modules/research/fabricators.dm
+++ b/code/modules/research/fabricators.dm
@@ -267,6 +267,27 @@
 						src.materials.addAmount(gib,bluespaceamount)
 	return remove_materials(part)
 
+//Returns however much of that material we have
+/obj/machinery/r_n_d/fabricator/proc/check_mats(var/material)
+	if(copytext(material,1,2) == "$")//It's iron/gold/glass
+		return materials.getAmount(material)
+	else
+		var/reagent_total = 0
+		for(var/obj/item/weapon/reagent_containers/RC in component_parts)
+			reagent_total += RC.reagents.get_reagent_amount(material)
+		return reagent_total
+
+//Returns however much of that material is in the bluespace network
+/obj/machinery/r_n_d/fabricator/proc/check_mats_bluespace(var/material)
+	if(!has_bluespace_bin()) //We can't access that
+		return 0
+
+	var/amount
+	for(var/obj/machinery/r_n_d/fabricator/gibmats in machines)
+		if(gibmats.has_bluespace_bin())
+			amount += gibmats.materials.getAmount(material)
+	return amount
+
 
 /obj/machinery/r_n_d/fabricator/proc/check_mat(var/datum/design/being_built, var/M)
 	if(copytext(M,1,2) == "$")

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -932,12 +932,28 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 
 		if(3.4) //Protolathe Queue Management
 			dat += protolathe_header()+"Production Queue<BR><HR><ul>"
+			var/list/required_materials = list()
 			for(var/i=1;i<=linked_lathe.queue.len;i++)
 				var/datum/design/I=linked_lathe.queue[i]
 				dat += "<li>Name: [I.name]"
+				for(var/material in I.materials)
+					required_materials[material] += I.materials[material]*linked_lathe.resource_coeff
 				if(linked_lathe.stopped)
 					dat += "<A href='?src=\ref[src];removeQItem=[i];device=protolathe'>(Remove)</A></li>"
-			dat += "</ul><A href='?src=\ref[src];clearQ=1;device=protolathe'>Remove All Queued Items</A><br />"
+			dat += "</ul>"
+			if(required_materials.len) //Do we have the materials required? Green if so, blue if it requires bluespace, red otherwise.
+				dat += "<BR>Required Materials: "
+				for(var/I in required_materials)
+					var/datum/material/M=linked_lathe.materials.getMaterial(I)
+					var/success = "red"
+					var/success_amount = linked_lathe.check_mats(I)
+					if(linked_lathe.check_mats(I) >= required_materials[I])
+						success = "green"
+					else if(linked_lathe.check_mats_bluespace(I) >= required_materials[I])
+						success_amount = linked_lathe.check_mats_bluespace(I)
+						success = "blue"
+					dat += "<span style='color:[success]'>[required_materials[I]] ([success_amount]) [M.processed_name]. </span>"
+			dat += "<br><A href='?src=\ref[src];clearQ=1;device=protolathe'>Remove All Queued Items</A><br />"
 			if(linked_lathe.stopped)
 				dat += "<A href='?src=\ref[src];setProtolatheStopped=0' style='color:green'>Start Production</A>"
 			else
@@ -1030,12 +1046,34 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 
 		if(4.4) //Imprinter Queue Management
 			dat += CircuitImprinterHeader()+"Production Queue<BR><HR><ul>"
+			var/list/required_materials = list()
 			for(var/i=1;i<=linked_imprinter.queue.len;i++)
 				var/datum/design/I=linked_imprinter.queue[i]
 				dat += "<li>Name: [I.name]"
+				for(var/material in I.materials)
+					required_materials[material] += I.materials[material]*linked_imprinter.resource_coeff
 				if(linked_imprinter.stopped)
 					dat += "<A href='?src=\ref[src];removeQItem=[i];device=imprinter'>(Remove)</A></li>"
-			dat += "</ul><A href='?src=\ref[src];clearQ=1;device=imprinter'>Remove All Queued Items</A><br />"
+			dat += "</ul>"
+			if(required_materials.len) //Do we have the materials required? Green if so, blue if it requires bluespace, red otherwise.
+				dat += "<BR>Required Materials: "
+				for(var/I in required_materials)
+					if(copytext(I,1,2) == "$")
+						var/datum/material/M=linked_imprinter.materials.getMaterial(I)
+						if(M)
+							var/success = "red"
+							var/success_amount = linked_imprinter.check_mats(I)
+							if(linked_imprinter.check_mats(I) >= required_materials[I])
+								success = "green"
+							else if(linked_imprinter.check_mats_bluespace(I) >= required_materials[I])
+								success_amount = linked_imprinter.check_mats_bluespace(I)
+								success = "blue"
+							dat += "<span style='color:[success]'>[required_materials[I]] ([success_amount]) [M.processed_name]. </span>"
+					else
+						var/success = linked_imprinter.check_mats(I)
+						dat += "<span style='color:[success?"green":"red"]'>[required_materials[I]] ([success]) [reagent_name(I)]. </span>"
+
+			dat += "<br><A href='?src=\ref[src];clearQ=1;device=imprinter'>Remove All Queued Items</A><br />"
 			if(linked_imprinter.stopped)
 				dat += "<A href='?src=\ref[src];setImprinterStopped=0' style='color:green'>Start Production</A>"
 			else


### PR DESCRIPTION
Adds total required material costs to the production pages of both the protolathe and the circuit imprinter

:cl:
 * rscadd: The R&D console now shows you the total material cost of whatever you're making. If it has enough by itself, the material cost will be shown in green. If it requires the bluespace network to help, it will be shown in blue. If it does not have enough, it will be shown in red.