### PR TITLE
Fixes evidence bags not resetting their weight class or description

### DIFF
--- a/code/modules/detectivework/evidence.dm
+++ b/code/modules/detectivework/evidence.dm
@@ -30,6 +30,8 @@
 		desc = "An evidence bag containing [I]. [I.desc]"
 		w_class = I.w_class
 	else
+		desc = initial(desc)
+		w_class = initial(w_class)
 		overlays.Cut()
 
 /obj/item/weapon/storage/box/evidence


### PR DESCRIPTION
closes #24033

:cl:
 * bugfix: Fixes evidence bags not having their description or weight class reset upon an inserted object being removed.