### PR TITLE
New Disease and Spread Types

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -980,6 +980,9 @@ var/default_colour_matrix = list(1,0,0,0,\
 #define	SPREAD_BLOOD	1//can be extracted from the carrier's blood, all diseases have this by default.
 #define	SPREAD_CONTACT	2//touching or bumping into someone may transmit the virus, virus can survive on items for a while. gloves lower the chance of transmission.
 #define	SPREAD_AIRBORNE	4//carrier mobs will periodically release invisible clouds that carry the virus to adjacent mobs that can breath it.
+#define SPREAD_COLONY 8 //like contact, but only spreads to suited individuals or pressure-resistant clothing.
+#define SPREAD_MEMETIC 16 //spreads on hearing, doesn't appear on goggles
+
 
 #define EFFECT_DANGER_HELPFUL	"0"
 #define EFFECT_DANGER_FLAVOR	"1"

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -954,6 +954,9 @@ its easier to just keep the beam vertical.
 /atom/proc/thermal_energy_transfer()
 	return
 
+/atom/proc/suitable_colony()
+	return FALSE
+
 //Used for map persistence. Returns an associative list with some of our most pertinent variables. This list will be used ad-hoc by our relevant map_persistence_type datum to reconstruct this atom from scratch.
 /atom/proc/atom2mapsave()
 	. = list()

--- a/code/game/objects/effects/decals/Cleanable/misc.dm
+++ b/code/game/objects/effects/decals/Cleanable/misc.dm
@@ -290,6 +290,8 @@
 	//Now if your feet aren't well protected, or are bleeding, you might get infected.
 	var/block = 0
 	var/bleeding = 0
+	if(attempt_colony(perp,contained_virus,"from exposure to a broken virus dish."))
+		return
 	if (perp.lying)
 		block = perp.check_contact_sterility(FULL_TORSO)
 		bleeding = perp.check_bodypart_bleeding(FULL_TORSO)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1899,10 +1899,22 @@ mob/living/carbon/human/isincrit()
 
 /mob/living/carbon/human/Hear(var/datum/speech/speech, var/rendered_speech="")
 	..()
-	if(!mind.faith || speech.frequency || speech.speaker == src || !ishuman(speech.speaker) || length(speech.message) < 20)
-		return
+	if(speech.frequency || speech.speaker == src || !ishuman(speech.speaker))
+		return //First, eliminate radio chatter, speech from us, or speech from nonhumans
+	var/mob/living/carbon/human/H = speech.speaker
+	var/list/diseases = H.virus2
+	if(istype(diseases) && diseases.len)
+		//do not use check_contact_sterility because other things cover ears, like helmets
+		if(ears && prob(ears.sterility))
+			return //If wearing sterile earpiece, block the meme
+		for(var/ID in diseases)
+			var/datum/disease2/disease/V = diseases[ID]
+			if(V.spread & SPREAD_MEMETIC)
+				infect_disease2(V, notes="(Memed, from [speech.speaker])")
+
+	if(!mind.faith || length(speech.message) < 20)
+		return //If we aren't religious or hearing a long message, don't check further
 	if(dizziness || stuttering || jitteriness || hallucination || confused || drowsyness || pain_shock_stage)
-		var/mob/living/carbon/human/H = speech.speaker
 		if(H.mind == mind.faith.religiousLeader)
 			AdjustDizzy(rand(-8,-10))
 			stuttering = max(0,stuttering-rand(8,10))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1896,24 +1896,20 @@ mob/living/carbon/human/isincrit()
 	. = Move(target, get_dir(src, target), glide_size_override = crawldelay)
 	delayNextMove(crawldelay, additive = 1)
 
+/mob/living/carbon/human/resist_memes(var/datum/speech/speech)
+	//do not use check_contact_sterility because other things cover ears, like helmets
+	if(ears && prob(ears.sterility))
+		return TRUE //If wearing sterile earpiece, block the meme
+	else
+		return ..()
 
 /mob/living/carbon/human/Hear(var/datum/speech/speech, var/rendered_speech="")
 	..()
-	if(speech.frequency || speech.speaker == src || !ishuman(speech.speaker))
-		return //First, eliminate radio chatter, speech from us, or speech from nonhumans
-	var/mob/living/carbon/human/H = speech.speaker
-	var/list/diseases = H.virus2
-	if(istype(diseases) && diseases.len)
-		//do not use check_contact_sterility because other things cover ears, like helmets
-		if(ears && prob(ears.sterility))
-			return //If wearing sterile earpiece, block the meme
-		for(var/ID in diseases)
-			var/datum/disease2/disease/V = diseases[ID]
-			if(V.spread & SPREAD_MEMETIC)
-				infect_disease2(V, notes="(Memed, from [speech.speaker])")
-
-	if(!mind.faith || length(speech.message) < 20)
+	if(ear_deaf || speech.frequency || speech.speaker == src)
+		return //First, eliminate radio chatter, speech from us, or wearing earmuffs/deafened
+	if(!mind || !mind.faith || length(speech.message) < 20)
 		return //If we aren't religious or hearing a long message, don't check further
+	var/mob/living/H = speech.speaker
 	if(dizziness || stuttering || jitteriness || hallucination || confused || drowsyness || pain_shock_stage)
 		if(H.mind == mind.faith.religiousLeader)
 			AdjustDizzy(rand(-8,-10))

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -12,6 +12,8 @@
 	mob_push_flags = ALLMOBS
 	mob_swap_flags = ALLMOBS
 
+	flags = HEAR_ALWAYS | PROXMOVE
+
 	var/age = 30		//Player's age (pure fluff)
 	//var/b_type = "A+"	//Player's bloodtype //NOW HANDLED IN THEIR DNA
 

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -19,6 +19,8 @@
 	mob_swap_flags = MONKEY|SLIME|SIMPLE_ANIMAL
 	mob_push_flags = MONKEY|SLIME|SIMPLE_ANIMAL|ALIEN
 
+	flags = HEAR_ALWAYS | PROXMOVE
+
 	size = SIZE_SMALL
 
 	var/canWearClothes = 1

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1898,16 +1898,17 @@ Thanks.
 
 ///////////////////////DISEASE STUFF///////////////////////////////////////////////////////////////////
 
-//For when we've already gone through clothing protections
-/mob/living/proc/assume_contact_diseases(var/list/disease_list,var/atom/source,var/bleeding=0)
+//Blocked is whether clothing prevented the spread of contact/blood
+/mob/living/proc/assume_contact_diseases(var/list/disease_list,var/atom/source,var/blocked=0,var/bleeding=0)
 	if (istype(disease_list) && disease_list.len > 0)
 		for(var/ID in disease_list)
 			var/datum/disease2/disease/V = disease_list[ID]
-			if (V.spread & SPREAD_CONTACT)
+			if(!blocked && V.spread & SPREAD_CONTACT)
 				infect_disease2(V, notes="(Contact, from [source])")
-			else if (bleeding && (V.spread & SPREAD_BLOOD))
+			else if(suitable_colony() && V.spread & SPREAD_COLONY)
+				infect_disease2(V, notes="(Colonized, from [source])")
+			else if(!blocked && bleeding && (V.spread & SPREAD_BLOOD))
 				infect_disease2(V, notes="(Blood, from [source])")
-
 
 //Called in Life() by humans (in handle_virus_updates.dm), monkeys and mice
 /mob/living/proc/find_nearby_disease()//only tries to find Contact and Blood spread diseases. Airborne ones are handled by breath_airborne_diseases()
@@ -1938,31 +1939,28 @@ Thanks.
 		block = check_contact_sterility(FEET)
 		bleeding = check_bodypart_bleeding(FEET)
 
-	if (!block)
-		var/list/viral_cleanable_types = list(
-			/obj/effect/decal/cleanable/blood,
-			/obj/effect/decal/cleanable/mucus,
-			/obj/effect/decal/cleanable/vomit,
-			)
+	var/list/viral_cleanable_types = list(
+		/obj/effect/decal/cleanable/blood,
+		/obj/effect/decal/cleanable/mucus,
+		/obj/effect/decal/cleanable/vomit,
+		)
 
-		for(var/obj/effect/decal/cleanable/C in T)
-			if (is_type_in_list(C,viral_cleanable_types))
-				assume_contact_diseases(C.virus2,C,bleeding)
+	for(var/obj/effect/decal/cleanable/C in T)
+		if (is_type_in_list(C,viral_cleanable_types))
+			assume_contact_diseases(C.virus2,C,block,bleeding)
 
-		for(var/obj/effect/rune/R in T)
-			assume_contact_diseases(R.virus2,R,bleeding)
+	for(var/obj/effect/rune/R in T)
+		assume_contact_diseases(R.virus2,R,block,bleeding)
 	return 0
 
 //This one is used for one-way infections, such as getting splashed with someone's blood due to clobbering them to death
 /mob/living/proc/oneway_contact_diseases(var/mob/living/L,var/block=0,var/bleeding=0)
-	if (!block)
-		assume_contact_diseases(L.virus2,L,bleeding)
+	assume_contact_diseases(L.virus2,L,block,bleeding)
 
 //This one is used for two-ways infections, such as hand-shakes, hugs, punches, people bumping into each others, etc
 /mob/living/proc/share_contact_diseases(var/mob/living/L,var/block=0,var/bleeding=0)
-	if (!block)
-		L.assume_contact_diseases(virus2,src,bleeding)
-		assume_contact_diseases(L.virus2,L,bleeding)
+	L.assume_contact_diseases(virus2,src,block,bleeding)
+	assume_contact_diseases(L.virus2,L,block,bleeding)
 
 //Called in Life() by humans (in handle_breath.dm), monkeys and mice
 /mob/living/proc/breath_airborne_diseases()//only tries to find Airborne spread diseases. Blood and Contact ones are handled by find_nearby_disease()

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -203,10 +203,26 @@ var/list/department_radio_keys = list(
 	returnToPool(speech)
 	return 1
 
+/mob/living/proc/resist_memes(var/datum/speech/speech)
+	if(ear_deaf || speech.frequency || speech.speaker == src || !isliving(speech.speaker))
+		return TRUE
+	return FALSE
 
 /mob/living/Hear(var/datum/speech/speech, var/rendered_message = null)
 	if(!rendered_message)
 		rendered_message = speech.message
+
+	//Meme disease code. Needs to come before client so that NPCs/catatonic can be infected.
+	//We don't concern ourselves with: radio chatter, our own speech, or if we're deaf.
+	if(!resist_memes(speech))
+		var/mob/living/L = speech.speaker
+		var/list/diseases = L.virus2
+		if(istype(diseases) && diseases.len)
+			for(var/ID in diseases)
+				var/datum/disease2/disease/V = diseases[ID]
+				if(V.spread & SPREAD_MEMETIC)
+					infect_disease2(V, notes="(Memed, from [L])")
+
 	if(!client)
 		return
 	say_testing(src, "[src] ([src.type]) has heard a message (lang=[speech.language ? speech.language.name : "null"])")
@@ -226,7 +242,7 @@ var/list/department_radio_keys = list(
 	var/atom/movable/AM = speech.speaker.GetSource()
 	if(!say_understands((istype(AM) ? AM : speech.speaker),speech.language)|| force_compose) //force_compose is so AIs don't end up without their hrefs.
 		rendered_message = render_speech(speech)
-	
+
 	//checking for syndie codephrases if person is a tator
 	if(src.mind.GetRole(TRAITOR) || src.mind.GetRole(NUKE_OP))
 		//is tator
@@ -379,7 +395,7 @@ var/list/department_radio_keys = list(
 				var/message = text("<span class='cortical'>Cortical link, <b>[]</b>: []</span>",B.truename, html_encode(speech.message))
 				var/turf/T = get_turf(src)
 				log_say("[key_name(src)] (@[T.x],[T.y],[T.z]) Borer chat: [html_encode(speech.message)]")
-				
+
 				for(var/mob/M in mob_list)
 					if(isborer(M) || ((M in dead_mob_list) && !istype(M, /mob/new_player)))
 						if(isborer (M)) //for borers that are IN CONTROL

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -21,6 +21,7 @@
 	emote_hear = list("squeeks","squeaks","squiks")
 	emote_see = list("runs in a circle", "shakes", "scritches at something")
 	pass_flags = PASSTABLE
+	flags = HEAR_ALWAYS | PROXMOVE
 	speak_chance = 1
 	turns_per_move = 5
 	see_in_dark = 6

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -699,9 +699,9 @@ var/list/slot_equipment_priority = list( \
 		slot_r_store\
 	)
 
-/*Equips accessories. 
+/*Equips accessories.
 A is the mob
-B is the accessory. 
+B is the accessory.
 C is what item the accessory will look to be attached to, important.
 D will look how many accessories the item already has, and will move on if its attachment would go above the amount of accessories
 E will stop the proc if a candidate had the accessory attached to it and it is toggled on
@@ -1987,7 +1987,7 @@ mob/proc/on_foot()
 	return
 
 /mob/living/carbon/heard(var/mob/living/carbon/human/M)
-	if(M == src || !istype(M))
+	if(M == src || !istype(M) || !mind)
 		return
 	if(!ear_deaf && !stat)
 		if(!(mind.heard_before[M.name]))

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -392,7 +392,8 @@
 					if(method == TOUCH)
 						var/block = L.check_contact_sterility(FULL_TORSO)
 						var/bleeding = L.check_bodypart_bleeding(FULL_TORSO)
-						if (!block)
+						if(attempt_colony(L,D,"splashed with infected blood"))
+						else if (!block)
 							if (D.spread & SPREAD_CONTACT)
 								L.infect_disease2(D, notes="(Contact, splashed with infected blood)")
 							else if (bleeding && (D.spread & SPREAD_BLOOD))
@@ -3494,7 +3495,7 @@
 		if(5 to 20)	//Processing above 5 units runs the risk of getting a big enough dose of nanobots to turn you into a cyberhorror.
 			percent_machine += 0.5 //The longer it metabolizes at this stage the more likely.
 			if(prob(20))
-				to_chat(M, pick("<span class='warning'>Something shifts inside you...</span>", 
+				to_chat(M, pick("<span class='warning'>Something shifts inside you...</span>",
 								"<span class='warning'>You feel different, somehow...</span>"))
 			if(prob(percent_machine))
 				holder.add_reagent("mednanobots", 20)

--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -108,6 +108,7 @@ var/global/list/disease2_list = list()
 	stageprob = 30
 	stage_variance = -1
 	allowed_transmission = SPREAD_BLOOD | SPREAD_MEMETIC
+	//Note: if more types of creatures become infectable than humans/monkeys/mice, give them HEAR_ALWAYS
 
 /datum/disease2/disease/proc/update_global_log()
 	if ("[uniqueID]-[subID]" in disease2_list)
@@ -242,11 +243,15 @@ var/global/list/disease2_list = list()
 
 /datum/disease2/disease/fungus/randomize_spread()
 	spread = SPREAD_BLOOD
-	if(prob(50)) //50% colonizing
+	if(prob(50)) //40% just colonizing
 		spread |= SPREAD_COLONY
-	else if(prob(40)) //20% airborne
+		if(prob(20)) //10% colonizing + air OR contact
+			spread |= pick(SPREAD_AIRBORNE,SPREAD_CONTACT)
+	else if(prob(40)) //14% just airborne
 		spread |= SPREAD_AIRBORNE
-	else if(prob(60)) //18% contact
+		if(prob(30))
+			spread |= SPREAD_CONTACT //6% air+contact
+	else if(prob(60)) //18% just contact
 		spread |= SPREAD_CONTACT
 			//12% blood only
 

--- a/code/modules/virus2/helpers.dm
+++ b/code/modules/virus2/helpers.dm
@@ -45,7 +45,6 @@ proc/airborne_can_reach(turf/source, turf/target, var/radius=5)
 	return 0
 
 /mob/living/carbon/human/check_contact_sterility(var/body_part)
-	var/block = 0
 	var/list/clothing_to_check = list(
 		wear_mask,
 		w_uniform,
@@ -64,11 +63,10 @@ proc/airborne_can_reach(turf/source, turf/target, var/radius=5)
 	for (var/thing in clothing_to_check)
 		var/obj/item/cloth = thing
 		if(istype(cloth) && (cloth.body_parts_covered & body_part) && prob(cloth.sterility))
-			block = 1
-	return block
+			return TRUE
+	return FALSE
 
 /mob/living/carbon/monkey/check_contact_sterility(var/body_part)
-	var/block = 0
 	var/list/clothing_to_check = list(
 		wear_mask,
 		uniform,
@@ -80,8 +78,33 @@ proc/airborne_can_reach(turf/source, turf/target, var/radius=5)
 	for (var/thing in clothing_to_check)
 		var/obj/item/cloth = thing
 		if(istype(cloth) && (cloth.body_parts_covered & body_part) && prob(cloth.sterility))
-			block = 1
-	return block
+			return TRUE
+	return FALSE
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//VALID COLONY (spread SPREAD_COLONY)
+/mob/living/carbon/suitable_colony()
+	return FALSE
+
+/mob/living/carbon/human/suitable_colony()
+	var/obj/item/clothing = wear_suit
+	if(clothing && clothing.pressure_resistance > ONE_ATMOSPHERE)
+		return TRUE
+	return FALSE
+
+/mob/living/carbon/monkey/suitable_colony()
+	var/obj/item/clothing = uniform
+	if(istype(clothing,/obj/item/clothing/monkeyclothes/space)) //Also covers sanity if null
+		return TRUE
+	return FALSE
+
+/proc/attempt_colony(var/atom/A, var/datum/disease2/disease/D,var/info)
+	if(!(D.spread & SPREAD_COLONY))
+		return FALSE
+	if(A.suitable_colony())
+		A.infect_disease2(D, notes="(Colonized[info ? ", [info]" : ""])")
+		return TRUE
+	return FALSE
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //BLEEDING (bleeding body parts allow SPREAD_BLOOD to infect)

--- a/code/modules/virus2/items_devices.dm
+++ b/code/modules/virus2/items_devices.dm
@@ -393,7 +393,9 @@ var/list/virusdishes = list()
 	if (open)//If the dish is open, we may get infected by the disease inside on top of those that might be stuck on it.
 		var/block = 0
 		var/bleeding = 0
-		if (src in perp.held_items)
+		if(attempt_colony(perp,contained_virus, "from exposure to \a [src]."))
+			//Spacesuits cover feet, torso, and hands, but are ideal for a colony.
+		else if (src in perp.held_items)
 			block = perp.check_contact_sterility(HANDS)
 			bleeding = perp.check_bodypart_bleeding(HANDS)
 			if (!block)


### PR DESCRIPTION
I've been kicking this one around a while. It was inspired because I wished our feathered friends the Vox could get to enjoy diseases like we do.

Backend:
* Diseases are now allowed to be limited to certain spread types. Previously all diseases could have any spread type.

Todo:
- [x] Deafness, earmuffs, etc. protect you from memetic diseases

Fairly robustly tested.
![image](https://user-images.githubusercontent.com/9782036/64101734-1b359280-cd34-11e9-830e-8d5b69b601d2.png)

🆑 
* rscadd: New disease type: Fungus. It can have blood, contact, air, and colony spread types. Fungi have the highest infection chance and slightly faster speed, but revert 2 stages upon spreading.
* rscadd: New disease type: Meme. It can have blood and memetic spread types. Memes have a very high infection rate and a fast progression rate, but can only have 2 symptoms.
* rscadd: New spread type: Colony. It works like contact, but only likes to spread to spacesuits and those wearing them. Ignores the suit's normal blocks.
* rscadd: New spread type: Memetic. Spread when you hear someone infected speak in person, unless you are wearing a sterile earpiece.