### PR TITLE
Easy Rig

### DIFF
--- a/code/controllers/mc/admin.dm
+++ b/code/controllers/mc/admin.dm
@@ -100,3 +100,30 @@
 			debug_variables(vote)
 			feedback_add_details("admin_verb","DprocessVote")
 	message_admins("Admin [key_name_admin(usr)] is debugging the [controller] controller.")
+
+/client/proc/rigvote()
+	set category = "Debug"
+	set name = "Rig Vote"
+	set desc = "easily rig an ongoing vote"
+
+	if(!vote)
+		return
+	var/winner
+	if(vote.choices.len && alert(usr,"Pick existing choice?", "Rig", "Preexisting", "Input New") == "Preexisting")
+		winner = input(usr,"Choose a result.","Choose a result.", vote.choices[1]) as null|anything in vote.choices
+		if(!winner)
+			return
+		vote.choices[winner] = ARBITRARILY_LARGE_NUMBER
+	else
+		winner = input(usr,"Add a result.","Add a result","") as text|null
+		if(!winner)
+			return
+		if(vote.ismapvote)
+			var/path = input(usr,"Add the map path.","Path","") as text|null
+			if(!path)
+				to_chat(usr,"<span class='warning'>You must specify a path to rig a mapvote!</span>")
+				return
+			vote.ismapvote[winner] = path
+			to_chat(usr,"<span class='info'>Set path as [path]. Hope that's right...</span>")
+		vote.choices[winner] = ARBITRARILY_LARGE_NUMBER
+	message_admins("Admin [key_name_admin(usr)] rigged the vote for [winner].")

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -363,6 +363,7 @@ var/list/admin_verbs_mod = list(
 		/client/proc/ticklag,
 		/client/proc/cmd_admin_grantfullaccess,
 		/client/proc/kaboom,
+		/client/proc/rigvote,
 		/client/proc/splash,
 		/client/proc/cmd_admin_areatest,
 		/client/proc/readmin,

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -145,6 +145,7 @@ var/intercom_range_display_status = 0
 	src.verbs += /client/proc/ticklag	//allows you to set the ticklag.
 	src.verbs += /client/proc/cmd_admin_grantfullaccess
 	src.verbs += /client/proc/kaboom
+	src.verbs += /client/proc/rigvote
 	src.verbs += /client/proc/splash
 	src.verbs += /client/proc/cmd_admin_areatest
 	src.verbs += /client/proc/cmd_admin_rejuvenate


### PR DESCRIPTION
Makes it very easy to rig a vote. Just select whether you want to use a pre-existing option or add your own, and this gives it +10000 votes. If you are rigging a mapvote AND adding a new option, it requires you to input a mapfile path.

Tested with non-mapvotes, it works.
Can't test with mapvotes because it requires the special files pomf has.

No 🆑 because admin backend. Admins, you can find the verb under Debug by enabling debug verbs.