### PR TITLE
SCP 294 balance

### DIFF
--- a/code/game/machinery/scp_294.dm
+++ b/code/game/machinery/scp_294.dm
@@ -18,7 +18,8 @@
 	dispensable_reagents = null
 	var/list/prohibited_reagents = list(ADMINORDRAZINE)
 
-	machine_flags = WRENCHMOVE | FIXED2WORK
+	machine_flags = FIXED2WORK
+	mech_flags = MECH_SCAN_FAIL
 
 /obj/machinery/chem_dispenser/scp_294/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open=NANOUI_FOCUS)
 	if(stat & (BROKEN|NOPOWER))


### PR DESCRIPTION
SCP 294 can no longer be moved with a simple wrench
Mechanics can no longer reproduce SCP 294
