### PR TITLE
Mob printers no longer care if you can re-enter corpse

### DIFF
--- a/code/game/machinery/martian_printer.dm
+++ b/code/game/machinery/martian_printer.dm
@@ -12,6 +12,7 @@
 	var/cooldown_duration = 10 MINUTES
 	var/cooldown_time = 0
 	var/cooldown_active = 0
+	var/corpse_check = 0 // if set to 1, you can't enter it after ghosting or otherwise being unable to enter corpse (being sharded or deleted)
 	var/print_path = /mob/living/carbon/complex/martian
 
 /obj/machinery/mob_printer/attack_ghost(var/mob/dead/observer/O)
@@ -21,11 +22,15 @@
 		to_chat(O, "<span class='warning'>Error: printer still recharging. Time left: [round((cooldown_time - world.time + 20)/10)] seconds.</span>")
 		return
 
-	if(alert(O,"Do you want to enter a corporeal form?","Inset Disk","Yes","No")== "Yes")
-		if(building)
-			to_chat(O, "<span class='notice'>\The [src] is already processing another. Try again later.</span>")
+	if(O.can_reenter_corpse || !corpse_check)
+		if(alert(O,"Do you want to enter a corporeal form?","Inset Disk","Yes","No")== "Yes")
+			if(building)
+				to_chat(O, "<span class='notice'>\The [src] is already processing another. Try again later.</span>")
+				return
+		else
 			return
-	else
+	else if(!(O.can_reenter_corpse))
+		to_chat(O,"<span class='notice'>You have recently ghosted or have no corpse, and cannot use the [src].</span>")
 		return
 
 	make_mob(O)

--- a/code/game/machinery/martian_printer.dm
+++ b/code/game/machinery/martian_printer.dm
@@ -21,15 +21,11 @@
 		to_chat(O, "<span class='warning'>Error: printer still recharging. Time left: [round((cooldown_time - world.time + 20)/10)] seconds.</span>")
 		return
 
-	if(O.can_reenter_corpse)
-		if(alert(O,"Do you want to enter a corporeal form?","Inset Disk","Yes","No")== "Yes")
-			if(building)
-				to_chat(O, "<span class='notice'>\The [src] is already processing another. Try again later.</span>")
-				return
-		else
+	if(alert(O,"Do you want to enter a corporeal form?","Inset Disk","Yes","No")== "Yes")
+		if(building)
+			to_chat(O, "<span class='notice'>\The [src] is already processing another. Try again later.</span>")
 			return
-	else if(!(O.can_reenter_corpse))
-		to_chat(O,"<span class='notice'>You have recently ghosted and can not enter right now. Try again later.</span>")
+	else
 		return
 
 	make_mob(O)

--- a/code/game/machinery/martian_printer.dm
+++ b/code/game/machinery/martian_printer.dm
@@ -22,7 +22,7 @@
 		to_chat(O, "<span class='warning'>Error: printer still recharging. Time left: [round((cooldown_time - world.time + 20)/10)] seconds.</span>")
 		return
 
-	if(O.can_reenter_corpse || !corpse_check)
+	if(!corpse_check || O.can_reenter_corpse)
 		if(alert(O,"Do you want to enter a corporeal form?","Inset Disk","Yes","No")== "Yes")
 			if(building)
 				to_chat(O, "<span class='notice'>\The [src] is already processing another. Try again later.</span>")


### PR DESCRIPTION
By default, mob printers no longer check to see if you can re-enter corpse. This is probably sensible sanity but since it's an adminbus piece of machinery, and it breaks under some very annoying circumstances (for instance, if you run into the bluespace in Lamprey Hell) then it's preferable to just let people respawn as something more often than not.

Now with a var that controls this-- off by default, but if you're bussing something in and ghosts make your life hell, you can easily throttle them by making ghosting lock you out of the printer. The message has been updated to be more explanatory.

Tested locally but web editor used on git because I am more lazy than responsible. Sue me at my home address

:cl:
 * bugfix: You can now fall into the pits of Hell and become a lawyer again!