### PR TITLE
Unmakes far sight

### DIFF
--- a/__DEFINES/global.dm
+++ b/__DEFINES/global.dm
@@ -4,7 +4,7 @@
 /proc/readglobal(var/which)
 	return global.vars[which]
 
-#define DNA_SE_LENGTH 58
+#define DNA_SE_LENGTH 57
 
 #define VOX_SHAPED "Vox","Skeletal Vox"
 

--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -452,7 +452,7 @@ var/global/list/BODY_COVER_VALUE_LIST=list("[HEAD]" = COVER_PROTECTION_HEAD,"[EY
 #define M_WHISPER	209		// causes quiet whispering
 #define M_DIZZY		210		// Trippy.
 #define M_SANS		211		// IF YOU SEE THIS WHILST BROWSING CODE, YOU HAVE BEEN VISITED BY: THE FONT OF SHITPOSTING. GREAT LUCK AND WEALTH WILL COME TO YOU, BUT ONLY IF YOU SAY 'fuck comic sans' IN YOUR PR.
-#define M_FARSIGHT	212		// Increases mob's view range by 2
+//#define M_FARSIGHT 212	// Increases mob's view range by 2, removed because most things weren't made for a higher clientview
 #define M_NOIR		213		// aww yis detective noir
 #define M_VEGAN		214
 #define M_ASTHMA	215

--- a/code/game/dna/genes/vg_powers.dm
+++ b/code/game/dna/genes/vg_powers.dm
@@ -87,55 +87,6 @@ Obviously, requires DNA2.
 		message_admins("[key_name(M)] has hulked out! ([formatJumpTo(M)])")
 	return
 
-/datum/dna/gene/basic/grant_spell/farsight
-	name = "Farsight"
-	desc = "Increases the subjects ability to see things from afar."
-	activation_messages = list("Your eyes focus.")
-	deactivation_messages = list("Your eyes return to normal.")
-	drug_activation_messages = list("You start feeling like an eagle, man!")
-	drug_deactivation_messages = list("You feel less like an eagle and more like the rabbit!")
-	spelltype = /spell/targeted/farsight
-
-/datum/dna/gene/basic/grant_spell/farsight/New()
-	block = FARSIGHTBLOCK
-	..()
-
-/datum/dna/gene/basic/grant_spell/farsight/can_activate(var/mob/M,var/flags)
-	// Can't be big AND small.
-	if((M.sdisabilities & BLIND) || (M.disabilities & NEARSIGHTED))
-		return 0
-	return ..(M,flags)
-
-/datum/dna/gene/basic/grant_spell/farsight/deactivate(var/mob/M,var/connected,var/flags)
-	if(..())
-		if(M.client && M.client.view == world.view + 2)
-			M.client.changeView()
-
-/spell/targeted/farsight
-	name = "Far Sight"
-	desc = "Allows you to toggle farther vision at will."
-	user_type = USER_TYPE_GENETIC
-	panel = "Mutant Powers"
-	range = SELFCAST
-	charge_type = Sp_RECHARGE
-	charge_max = 50
-	invocation_type = SpI_NONE
-	spell_flags = INCLUDEUSER
-	override_base = "genetic"
-	hud_state = "wiz_sleepold"
-	var/active = 0
-
-/spell/targeted/farsight/cast(list/targets, mob/user)
-	for(var/mob/living/carbon/human/F in targets)
-		if(!active)
-			F.client.changeView(max(F.client.view, world.view+2))
-			to_chat(F, "<span class='notice'>You focus your eyes to see farther.</span>")
-			active = 1
-		else
-			F.client.changeView()
-			to_chat(F, "<span class='notice'>You no longer focus your eyes.</span>")
-			active = 0
-
 // NOIR
 
 #define NOIR_ANIM_TIME 170

--- a/code/game/gamemodes/setupgame.dm
+++ b/code/game/gamemodes/setupgame.dm
@@ -50,7 +50,6 @@ var/SOBERBLOCK = 0
 var/PSYRESISTBLOCK = 0
 var/STRONGBLOCK = 0
 //var/SHADOWBLOCK = 0
-var/FARSIGHTBLOCK = 0
 var/CHAMELEONBLOCK = 0
 var/CRYOBLOCK = 0
 var/EATBLOCK = 0
@@ -157,7 +156,6 @@ var/LACTOSEBLOCK = 0
 	SOBERBLOCK     = getAssignedBlock("SOBER",      numsToAssign, DNA_HARD_BOUNDS, good=1)
 	PSYRESISTBLOCK = getAssignedBlock("PSYRESIST",  numsToAssign, DNA_HARD_BOUNDS, good=1)
 	//SHADOWBLOCK  = getAssignedBlock("SHADOW",     numsToAssign, DNA_HARDER_BOUNDS, good=1)
-	FARSIGHTBLOCK  = getAssignedBlock("FARSIGHT",   numsToAssign, DNA_HARDER_BOUNDS, good=1)
 	CHAMELEONBLOCK = getAssignedBlock("CHAMELEON",  numsToAssign, DNA_HARDER_BOUNDS, good=1)
 	CRYOBLOCK      = getAssignedBlock("CRYO",       numsToAssign, DNA_HARD_BOUNDS, good=1)
 	EATBLOCK       = getAssignedBlock("EAT",        numsToAssign, DNA_HARD_BOUNDS, good=1)

--- a/code/game/objects/items/weapons/dna_injector.dm
+++ b/code/game/objects/items/weapons/dna_injector.dm
@@ -1307,28 +1307,6 @@
 	block = SANSBLOCK
 	..()
 
-/obj/item/weapon/dnainjector/nofail/farsightmut
-	name = "DNA-Injector (Farsight)"
-	desc = "This will allow you to focus your eyes better."
-	datatype = DNA2_BUF_SE
-	value = 0xFFF
-	//block = 2
-
-/obj/item/weapon/dnainjector/nofail/farsightmut/initialize()
-	block = FARSIGHTBLOCK
-	..()
-
-/obj/item/weapon/dnainjector/nofail/antifarsight
-	name = "DNA-Injector (Anti-Farsight)"
-	desc = "No fun allowed"
-	datatype = DNA2_BUF_SE
-	value = 0x001
-	//block = 2
-
-/obj/item/weapon/dnainjector/nofail/antifarsight/initialize()
-	block = FARSIGHTBLOCK
-	..()
-
 /obj/item/weapon/dnainjector/nofail/remotesay
 	name = "DNA-Injector (Remote Say)"
 	desc = "Share it with the world."
@@ -1376,7 +1354,6 @@
         /obj/item/weapon/dnainjector/nofail/strong,
         /obj/item/weapon/dnainjector/nofail/immolate,
         /obj/item/weapon/dnainjector/nofail/melt,
-        /obj/item/weapon/dnainjector/nofail/farsightmut,
         /obj/item/weapon/dnainjector/nofail/remotesay)
     new type(loc)
     qdel(src)

--- a/code/modules/mob/living/simple_animal/borer/unlocks.dm
+++ b/code/modules/mob/living/simple_animal/borer/unlocks.dm
@@ -281,15 +281,6 @@
 				host.update_mutations()
 				break
 
-// Vision tree
-/datum/unlockable/borer/head/gene_unlock/farsight
-	id = "farsight"
-	name = "Telephoto Vision"
-	desc = "Adjusts your host's eyes to see farther."
-	cost = 200
-	time = 1 MINUTES
-	gene_name = "FARSIGHT"
-
 //////////////Chest Unlocks/////////////////
 
 /datum/unlockable/borer/chest/gene_unlock
@@ -512,7 +503,6 @@
 	time = 2 MINUTES
 	verb_type = /obj/item/verbs/borer/attached_head/night_vision
 	give_when_attached=1
-	prerequisites=list("farsight")
 
 //////////Chest Verbs///////////////////
 

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -96,9 +96,6 @@
 	if(client)
 		if(ckey in deadmins)
 			client.verbs += /client/proc/readmin
-
-		if(M_FARSIGHT in mutations)
-			client.changeView(max(client.view, world.view+1))
 	CallHook("Login", list("client" = src.client, "mob" = src))
 
 	if(spell_masters)


### PR DESCRIPTION
Clearing up the genetics gunk one superpower at a time

Why:
- Nothing was made with a higher clientview than the current one, even when you are in crit you will see past the plenty of black with small circle of visibility, because it was made for the current world.view
- It looked ugly when you were sighted out

The direct consequence is that borers lost an ability (giving their host farsight)

As a g*neticist main, I can say with 100% certainty that this is one of the superpowers that makes everything look ugly (even with the toggle I added!), and things that change the world.view (currently only the binoculars and the hecate) should be used sparingly
If the change is ready in the case people like the change, do not merge any other superpower removal until DNA_SE_LENGTH is changed too

:cl:
 * rscdel: The farsight genetic superpower is no longer in the game.