### PR TITLE
Attempts to add Castle to rotation when conditions are met (formerly Lamprey too)

### DIFF
--- a/code/__HELPERS/files.dm
+++ b/code/__HELPERS/files.dm
@@ -15,6 +15,13 @@
 /proc/get_maps(root="maps/voting/")
 	var/list/maps = list()
 	var/recursion_limit = 20 //lots of maps waiting to be played, feels like TF2
+	//Check if we can add the special maps
+	var/Lamprey = root + "Lamprey/vgstation13.dmb"
+	if(Lamprey && (score["crewscore"] <= -15000))
+		maps += Lamprey
+	var/Castle = root + "tgstation-sec/vgstation13.dmb"
+	if(ticker.revolutionaries_won)
+		maps += Castle
 	//Get our potential maps
 	testing("starting in [root]")
 	for(var/potential in flist(root))

--- a/code/datums/gamemode/factions/syndicate/rev.dm
+++ b/code/datums/gamemode/factions/syndicate/rev.dm
@@ -171,5 +171,6 @@
 	switch (result)
 		if (ALL_HEADS_DEAD)
 			to_chat(world, "<font size = 3><b>The revolution has won!</b></font><br/><font size = 2>All heads are either dead or have fled the station!</font>")
+			ticker.revolutionaries_won = 1
 		if (ALL_REVS_DEAD)
 			to_chat(world, "<font size = 3><b>The crew has won!</b></h1><br/><font size = 2>All revolutionaries are either dead or have fled the station!</font>")

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -38,6 +38,8 @@ var/datum/controller/gameticker/ticker
 	var/explosion_in_progress
 	var/station_was_nuked
 
+	var/revolutionaries_won
+
 	var/list/datum/role/antag_types = list() // Associative list of all the antag types in the round (List[id] = roleNumber1) //Seems to be totally unused?
 
 	// Hack


### PR DESCRIPTION
The time has come and so have I
It's untested, if it breaks map voting revert ASAP, could add it to the test server first though and see if it works
The conditions are as such
Lamprey: Crew score must be at or less than -15000 in order to unlock Lamprey to be voted (currently not worked, apparently Lamprey's broken)
Castle: Revolutionaries must win, added a check for when revolutionaries win to the ticker.
:cl:
 * tweak: New map options are available if the station is a complete disaster or revolutionaries succeed, respectively.