### PR TITLE
Mice colour fix+ hunger tweaks

### DIFF
--- a/code/modules/maps/nests.dm
+++ b/code/modules/maps/nests.dm
@@ -42,7 +42,7 @@
 /obj/abstract/map/nest/mouse
 	name = "mouse breeding ground"
 	icon_state = "mouse"
-	mob_type = /mob/living/simple_animal/mouse/common
+	mob_type = /mob/living/simple_animal/mouse/common/gray //Ideally we'd have a chance for the 3 main common mice but nests don't support lists
 	breed_time = 1200
 
 /obj/abstract/map/nest/mouse/limited

--- a/code/modules/maps/nests.dm
+++ b/code/modules/maps/nests.dm
@@ -42,7 +42,7 @@
 /obj/abstract/map/nest/mouse
 	name = "mouse breeding ground"
 	icon_state = "mouse"
-	mob_type = /mob/living/simple_animal/mouse/common/gray //Ideally we'd have a chance for the 3 main common mice but nests don't support lists
+	mob_type = /mob/living/simple_animal/mouse/common
 	breed_time = 1200
 
 /obj/abstract/map/nest/mouse/limited

--- a/code/modules/maps/spawners/spawners.dm
+++ b/code/modules/maps/spawners/spawners.dm
@@ -894,11 +894,7 @@
 	icon_state = "mob_mouse"
 	amount = 2
 	chance = 50
-	to_spawn = list(
-		/mob/living/simple_animal/mouse/common/brown,
-		/mob/living/simple_animal/mouse/common/gray,
-		/mob/living/simple_animal/mouse/common/white,
-		)
+	to_spawn = list(/mob/living/simple_animal/mouse/common)
 
 /obj/abstract/map/spawner/mobs/bear
 	name = "bear spawner"

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -839,7 +839,14 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			found_vents.Add(v)
 	if(found_vents.len)
 		vent_found = pick(found_vents)
-		host = new /mob/living/simple_animal/mouse/common(vent_found.loc)
+
+		var/mouse_type = pick(list(
+		/mob/living/simple_animal/mouse/common/brown,
+		/mob/living/simple_animal/mouse/common/gray,
+		/mob/living/simple_animal/mouse/common/white
+		))
+
+		host = new mouse_type(vent_found.loc)
 	else
 		to_chat(src, "<span class='warning'>Unable to find any unwelded vents to spawn mice at.</span>")
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -840,13 +840,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(found_vents.len)
 		vent_found = pick(found_vents)
 
-		var/mouse_type = pick(list(
-		/mob/living/simple_animal/mouse/common/brown,
-		/mob/living/simple_animal/mouse/common/gray,
-		/mob/living/simple_animal/mouse/common/white
-		))
-
-		host = new mouse_type(vent_found.loc)
+		host = new /mob/living/simple_animal/mouse/common(vent_found.loc)
 	else
 		to_chat(src, "<span class='warning'>Unable to find any unwelded vents to spawn mice at.</span>")
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -839,7 +839,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			found_vents.Add(v)
 	if(found_vents.len)
 		vent_found = pick(found_vents)
-
 		host = new /mob/living/simple_animal/mouse/common(vent_found.loc)
 	else
 		to_chat(src, "<span class='warning'>Unable to find any unwelded vents to spawn mice at.</span>")

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -454,7 +454,7 @@
 	// Mice IDs
 	if(namenumbers)
 		name = "[name] ([rand(1, 1000)])"
-	if(!_color)
+	if(!_color) // due to shitcode this never actually happens, but it's best to leave it here just incase we get a mystery uncoloured mouse
 		_color = pick( list("brown","gray","white") )
 		initIcons()
 	desc = "It's a small [_color] rodent, often seen hiding in maintenance areas and making a nuisance of itself."

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -1,5 +1,5 @@
 #define MOUSETFAT 1000
-#define MOUSEFAT 600
+#define MOUSEFAT 700
 #define MOUSESTARVE 25
 #define MOUSEHUNGRY 100
 #define MOUSEMOVECOST 0.5
@@ -46,6 +46,7 @@
 	var/can_chew_wires = 0
 	var/splat = 0
 	var/infectable = 0
+	var/nutrition_loss_mod = 1
 
 /mob/living/simple_animal/mouse/New()
 	..()
@@ -98,9 +99,10 @@
 		is_fat = 0
 		speed = initial(speed)
 		meat_amount = size //What it is on living/New(),
-	if(nutrition <= MOUSESTARVE && prob(5) && client)
-		to_chat(src, "<span class = 'warning'>You are starving!</span>")
-		health -= 1
+	if(nutrition <= MOUSESTARVE && client)
+		speed = 10
+		if(prob(1))
+			to_chat(src, "<span class = 'warning'>You are starving!</span>")
 	if(nutrition <= MOUSEHUNGRY && nutrition > MOUSESTARVE)
 		speed = 3
 		if(prob(5))
@@ -140,7 +142,7 @@
 			else if (prob(25))
 				dir = pick(cardinal - dir)
 
-		if(!food_target && (!client || nutrition <= MOUSEHUNGRY)) //Regular mice will be moved towards food, mice with a client won't be moved unless they're desperate
+		if(!food_target && !client) //Regular mice will be moved towards food, mice with a client won't be
 			for(var/obj/item/weapon/reagent_containers/food/snacks/C in can_see)
 				food_target = C
 				break
@@ -184,7 +186,7 @@
 					//spread_disease_to(src,M, "Airborne") //Spreads it to humans, mice, and monkeys
 
 */
-		nutrition = max(0, nutrition - MOUSESTANDCOST)
+		nutrition = max(0, nutrition - (MOUSESTANDCOST * nutrition_loss_mod))
 
 
 
@@ -218,7 +220,7 @@
 	var/multiplier = 1
 	if(nutrition >= MOUSEFAT) //Fat mice lose nutrition faster through movement
 		multiplier = 2.5
-	nutrition = max(0, nutrition - MOUSEMOVECOST*multiplier)
+	nutrition = max(0, nutrition - (MOUSEMOVECOST*multiplier*nutrition_loss_mod))
 
 
 /mob/living/simple_animal/mouse/proc/initIcons()

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -451,12 +451,16 @@
 	_color = "black"
 	icon_state = "mouse_black"
 
+//Selects a 1 of 3 random colours.
+/mob/living/simple_animal/mouse/common
+	_color = null
+
 /mob/living/simple_animal/mouse/common/New()
 	..()
 	// Mice IDs
 	if(namenumbers)
 		name = "[name] ([rand(1, 1000)])"
-	if(!_color) // due to shitcode this never actually happens, but it's best to leave it here just incase we get a mystery uncoloured mouse
+	if(!_color)
 		_color = pick( list("brown","gray","white") )
 		initIcons()
 	desc = "It's a small [_color] rodent, often seen hiding in maintenance areas and making a nuisance of itself."

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -3371,12 +3371,7 @@
 		H.vomit(instant = TRUE) //mouse spawning continues below
 	var/location = get_turf(holder.my_atom)
 	for(var/i=1 to created_volume)
-		var/mouse_type = pick(list(
-		/mob/living/simple_animal/mouse/common/brown,
-		/mob/living/simple_animal/mouse/common/gray,
-		/mob/living/simple_animal/mouse/common/white
-		))
-		new mouse_type(location)
+		new /mob/living/simple_animal/mouse/common(location)
 
 /datum/chemical_reaction/aminocyprinidol
 	name = "Aminocyprinidol"

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -3371,7 +3371,12 @@
 		H.vomit(instant = TRUE) //mouse spawning continues below
 	var/location = get_turf(holder.my_atom)
 	for(var/i=1 to created_volume)
-		new /mob/living/simple_animal/mouse/common(location)
+		var/mouse_type = pick(list(
+		/mob/living/simple_animal/mouse/common/brown,
+		/mob/living/simple_animal/mouse/common/gray,
+		/mob/living/simple_animal/mouse/common/white
+		))
+		new mouse_type(location)
 
 /datum/chemical_reaction/aminocyprinidol
 	name = "Aminocyprinidol"

--- a/code/modules/research/xenoarchaeology/artifact/artifact_autocloner.dm
+++ b/code/modules/research/xenoarchaeology/artifact/artifact_autocloner.dm
@@ -41,7 +41,7 @@
 			/mob/living/simple_animal/parrot,
 			/mob/living/simple_animal/slime,
 			/mob/living/simple_animal/crab,
-			/mob/living/simple_animal/mouse/common,
+			/mob/living/simple_animal/mouse/common/black,
 			/mob/living/simple_animal/hostile/retaliate/goat,
 			/mob/living/carbon/monkey,
 			)

--- a/code/modules/research/xenoarchaeology/artifact/artifact_autocloner.dm
+++ b/code/modules/research/xenoarchaeology/artifact/artifact_autocloner.dm
@@ -41,7 +41,7 @@
 			/mob/living/simple_animal/parrot,
 			/mob/living/simple_animal/slime,
 			/mob/living/simple_animal/crab,
-			/mob/living/simple_animal/mouse/common/black,
+			/mob/living/simple_animal/mouse/common,
 			/mob/living/simple_animal/hostile/retaliate/goat,
 			/mob/living/carbon/monkey,
 			)


### PR DESCRIPTION
Allows players to once again spawn as any of the 3 main mouse colours, generally consolidating mouse spawning to use the same method.

Sets the nutriment needed to get fat to 700, up from 600. Defatting still takes 25 less nutriment than the fat value.

Starving is no longer deadly, instead it gives you an insane speed penalty and the occasional message. Additionally you no longer automatically move to eat food while starving.

Adds a nutriment loss modifier so admins can make mice that don't ever get hungry, or otherwise starve uber quick.

[bugfix] [qol]
 
:cl:
 * bugfix: Player mice can now spawn as 1 of 3 colours once again
 * tweak: Player mice no longer take damage when starving, and instead take a huge speed penalty
 * tweak: Player mice no longer automatically move to eat food when starving
 * experiment: Player mice now have a "nutrition_loss_mod" variable for admins to tweak how fast a mouse loses nutrition



<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation or the coding discord (you can find an invite link on the irc or the thread) to discuss your changes, or if you need help.

== SELF LABELLING PRs ==
You can now self-label your PR! The syntax is simple. Just put [<labeltag>] anywhere in your PR,
where <labeltag> is to be replaced by one of the following (allowing with the resultant tag)
just ctrl+f the list or something. I know it's long.

administration = "Logging / Administration"
away = "Mapping (Away Mission :earth_africa:)"
bagel = "Mapping (Bagel :o:)"
box = "Mapping (Box :baby:)"
bugfix = "Bug / Fix"
bus = "Mapping (Bus :bus:)"
byond = "T-Thanks BYOND"
consistency = "Consistency Issue"
controversial = "Controversial"
deff = "Mapping (Deff :wastebasket:)"
discussion = "Discussion"
dnm = "✋ Do Not Merge ✋"
easy = "Easy Fix"
exploitable = "Exploitable"
featureloss = "Feature Loss"
featurerequest = "Feature Request"
first = "good first issue"
formatting = "Grammar / Formatting"
gamemode = "Gameplay / Gamemode"
gameplay = "Gameplay / Gamemode"
general = "Mapping (General :world_map:)"
goonchat = "Goonchat"
grammar = "Grammar / Formatting"
help = "help wanted"
hotfix = "Hotfix"
libvg = "libvg"
logging = "Logging / Administration"
meta = "Mapping (Meta :no_mobile_phones:)"
needspritework = "Needs Spritework"
oversight = "Oversight"
packed = "Mapping (Packed :package:)"
parallax = "Parallax"
qol = "❤️ Quality of Life ❤️"
roid = "Mapping (Roidstation :pick:)"
role = "Role Datums"
roleissue = "Role Datums Issue"
runtime = "Runtime Log"
sanity = "Sanity / Ghosthands"
snowmap = "Mapping (Snowmap ❄)"
sound = "Sound"
sprites = "Sprites"
spriteworkdone = "Spritework Done Needs Coder"
system = "System"
taxi = "Mapping (Taxi :taxi:)"
tested = "100%  tested"
tweak = "Tweak"
ui = "UI"
vault = "Mapping (Vault :question:)"
vote = "⛔ Requires Server Vote ⛔"
wip = "WiP"

== CHANGELOGS ==
Changelogs can be attached either by following the instructions in html/changelogs/example.yml, or by attaching an in-body changelog like the one attached to your PR automatically.

For the keys you can use in an in-body changelog, they are the same as described in example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!

Valid Prefixes:
bugfix
wip (For works in progress)
tweak
soundadd
sounddel
rscdel (general deleting of nice things)
rscadd (general adding of nice things)
imageadd
imagedel
spellcheck (typo fixes)
experiment
tgs (TG-ported fixes?)

An example changelog is attached to this PR for your convenience:
-->