### PR TITLE
better proc call results

### DIFF
--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -415,22 +415,17 @@ function loadPage(list) {
 
 		if (L.len > 0 && !(name == "underlays" || name == "overlays" || name == "vars" || L.len > 500))
 			// not sure if this is completely right...
-			if(0)   //(L.vars.len > 0)
-
-				html += {"<ol>
-					</ol>"}
-			else
-				html += "<ul>"
-				var/index = 1
-				for (var/entry in L)
-					if(istext(entry))
-						html += debug_variable(entry, L[entry], level + 1)
-					//html += debug_variable("[index]", L[index], level + 1)
-					else
-						html += debug_variable(index, L[index], level + 1)
-					html += " <a href='?_src_=vars;delValueFromList=1;list=\ref[L];index=[index];datum=\ref[DA]'>(Delete)</a>"
-					index++
-				html += "</ul>"
+			html += "<ul>"
+			var/index = 1
+			for (var/entry in L)
+				if(istext(entry))
+					html += debug_variable(entry, L[entry], level + 1)
+				//html += debug_variable("[index]", L[index], level + 1)
+				else
+					html += debug_variable(index, L[index], level + 1)
+				html += " <a href='?_src_=vars;delValueFromList=1;list=\ref[L];index=[index];datum=\ref[DA]'>(Delete)</a>"
+				index++
+			html += "</ul>"
 
 	else
 		html += "[name] = <span class='value'>[value]</span>"
@@ -455,12 +450,20 @@ function loadPage(list) {
 
 	return html
 
+/client/proc/debug_list(var/L)
+	if(!istype(L, /list))
+		return
+
+	usr << browse(debug_variable("LIST", L, 0, L), "window=listedit\ref[L];size=475x650")
+
 /client/proc/view_var_Topic(href, href_list, hsrc)
 	//This should all be moved over to datum/admins/Topic() or something ~Carn
 	if( (usr.client != src) || !src.holder )
 		return
 	if(href_list["Vars"])
 		debug_variables(locate(href_list["Vars"]))
+	else if(href_list["List"])
+		debug_list(locate(href_list["List"]))
 
 	//~CARN: for renaming mobs (updates their name, real_name, mind.name, their ID/PDA and datacore records).
 	else if(href_list["rename"])

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -1,3 +1,6 @@
+//how long we keep proc call results (datums and lists)
+#define PROC_RESULT_KEEP_TIME 5 MINUTES
+
 /client/proc/Debug2()
 	set category = "Debug"
 	set name = "Debug-Game"
@@ -143,9 +146,19 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 			returnval = "null"
 		else if(returnval == "")
 			returnval = "\"\" (empty string)"
-		to_chat(usr, "<span class='notice'>[procname] returned: [returnval]</span>")
-		feedback_add_details("admin_verb","APC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
+		var/returntext = returnval
+		if(istype(returnval, /datum))
+			returntext = "[returnval] <a href='?_src_=vars;Vars=\ref[returnval]'>\[VV\]</A>"
+			spawn(PROC_RESULT_KEEP_TIME)
+				returnval = null
+		else if(istype(returnval, /list))
+			returntext = "<a href='?_src_=vars;List=\ref[returnval]'>\[List\]</A>"
+			spawn(PROC_RESULT_KEEP_TIME)
+				returnval = null
+
+		to_chat(usr, "<span class='notice'>[procname] returned: [returntext]</span>")
+		feedback_add_details("admin_verb","APC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/Cell()
 	set category = "Debug"


### PR DESCRIPTION
Adds the possiblity to VV a returned datum or to view a returned list when proc calling

to stop shit like this from happening when testing:
> get_connections returned: /list

![image](https://user-images.githubusercontent.com/16618384/64346693-d9863f80-cff2-11e9-8751-43ba88e8426e.png)

[administration] [qol]
:cl:
 * rscadd: admins and coders can now actually look at proc call results when debugging