### PR TITLE
Fixes a bunch of Destroy() stuff

### DIFF
--- a/code/ATMOSPHERICS/datum_pipe_network.dm
+++ b/code/ATMOSPHERICS/datum_pipe_network.dm
@@ -16,15 +16,13 @@
 
 	..()
 
-/datum/pipeline/Del()
-	pipe_networks -= src
-	..()
-
 /datum/pipe_network/Destroy()
 	for(var/datum/pipeline/pipeline in line_members) //This will remove the pipeline references for us
 		pipeline.network = null
 	for(var/obj/machinery/atmospherics/objects in normal_members) //Procs for the different bases will remove the references
 		objects.unassign_network(src)
+	pipe_networks -= src
+	..()
 
 /datum/pipe_network/resetVariables()
 	..("gases", "normal_members", "line_members")

--- a/code/_hooks/events.dm
+++ b/code/_hooks/events.dm
@@ -24,6 +24,7 @@
 /event/Destroy()
 	holder = null
 	handlers = null
+	..()
 
 /event/proc/Add(var/objectRef,var/procName)
 	var/key="\ref[objectRef]:[procName]"

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -170,22 +170,19 @@ var/global/list/whitelisted_species = list("Human")
 
 /datum/species/proc/clear_organs(var/mob/living/carbon/human/H)
 	if(H.organs)
+		for(var/datum/organ/I in H.organs)
+			qdel(I)
 		H.organs.len=0
 	if(H.internal_organs)
 		for(var/datum/organ/I in H.internal_organs)
 			qdel(I)
 		H.internal_organs.len=0
+	//The rest SHOULD only refer to organs that were already deleted by the above loops, so we can just clear the lists.
 	if(H.organs_by_name)
-		for(var/datum/organ/I in H.organs_by_name)
-			qdel(I)
 		H.organs_by_name.len=0
 	if(H.internal_organs_by_name)
-		for(var/datum/organ/I in H.internal_organs_by_name)
-			qdel(I)
 		H.internal_organs_by_name.len=0
 	if(H.grasp_organs)
-		for(var/datum/organ/I in H.grasp_organs)
-			qdel(I)
 		H.grasp_organs.len = 0
 
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -38,6 +38,10 @@
 		qdel(BrainContainer)
 		BrainContainer = null
 
+	if(immune_system)
+		qdel(immune_system)
+		immune_system = null
+
 	. = ..()
 
 /mob/living/examine(var/mob/user, var/size = "", var/show_name = TRUE, var/show_icon = TRUE) //Show the mob's size and whether it's been butchered

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -36,6 +36,12 @@
 	..()
 	initialize_rules()
 
+/mob/living/simple_animal/hostile/Destroy()
+	for(var/datum/fuzzy_ruling/D in target_rules)
+		qdel(D)
+	target_rules = null
+	..()
+
 /mob/living/simple_animal/hostile/proc/initialize_rules()
 	target_rules.Add(new /datum/fuzzy_ruling/is_mob)
 	target_rules.Add(new /datum/fuzzy_ruling/is_obj{weighting = 0.5})

--- a/code/modules/organs/internal/lungs/lung.dm
+++ b/code/modules/organs/internal/lungs/lung.dm
@@ -25,6 +25,11 @@
 	var/inhale_volume = BREATH_VOLUME
 	var/exhale_moles = 0
 
+/datum/organ/internal/lungs/Destroy()
+	for(var/datum/lung_gas/G in gasses)
+		qdel(G)
+	..()
+
 /datum/organ/internal/lungs/proc/gasp()
 	owner.emote("gasp", null, null, TRUE)
 

--- a/code/modules/organs/internal/lungs/lung_gasses.dm
+++ b/code/modules/organs/internal/lungs/lung_gasses.dm
@@ -11,6 +11,15 @@
 /datum/lung_gas/New(var/gas_id) //If you came here looking for what the second arg is, it was removed and no longer matters
 	src.id = gas_id
 
+/datum/lung_gas/Destroy()
+	if(lungs)
+		lungs.gasses -= src
+		lungs = null
+
+	qdel(breath)
+	breath = null
+	..()
+
 /datum/lung_gas/proc/get_pp()
 	return breath.partial_pressure(id)
 

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -65,6 +65,42 @@
 		parent.children.Add(src)
 	return ..()
 
+/datum/organ/external/Destroy()
+	if(parent?.children)
+		parent.children -= src
+		parent = null
+
+	if(children)
+		for(var/datum/organ/external/O in children)
+			qdel(O)
+		children = null
+
+	if(internal_organs)
+		for(var/datum/organ/internal/O in internal_organs)
+			qdel(O)
+		internal_organs = null
+
+	if(implants)
+		for(var/obj/O in implants)
+			qdel(O)
+		implants = null
+
+	if(wounds)
+		for(var/datum/wound/W in wounds)
+			qdel(W)
+		wounds = null
+
+	if(owner)
+		owner.organs -= src
+		for(var/organ_name in owner.organs_by_name) //I hate that this is the only way
+			if(owner.organs_by_name[organ_name] == src)
+				owner.organs_by_name -= src
+				break //Assume there's only one because if not we have much bigger problems than a hard del
+		owner = null
+
+	organ_item = null //I honestly cannot tell if anything else should be done with this
+	..()
+
 /****************************************************
 			   DAMAGE PROCS
 ****************************************************/

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -92,6 +92,8 @@
 
 	if(owner)
 		owner.organs -= src
+		if(grasp_id)
+			owner.grasp_organs -= src
 		for(var/organ_name in owner.organs_by_name) //I hate that this is the only way
 			if(owner.organs_by_name[organ_name] == src)
 				owner.organs_by_name -= src

--- a/code/modules/organs/organ_internal.dm
+++ b/code/modules/organs/organ_internal.dm
@@ -18,6 +18,18 @@
 	var/datum/dna/owner_dna
 
 
+/datum/organ/internal/Destroy()
+	if(owner) //Just going to assume these lists are here because we have bigger problems than a runtime if they aren't
+		owner.internal_organs -= src
+		owner.internal_organs_by_name -= organ_type
+		var/datum/organ/external/E = owner.organs_by_name[parent_organ] //Fuck this setup
+		E.internal_organs -= src
+		owner = null
+	if(organ_holder)
+		organ_holder.organ_data = null
+		organ_holder = null
+	..()
+
 /datum/organ/internal/Copy()
 	var/datum/organ/internal/I = ..()
 	I.damage = damage

--- a/code/modules/organs/organ_objects.dm
+++ b/code/modules/organs/organ_objects.dm
@@ -33,9 +33,11 @@
 	spawn(1)
 		update()
 
-/obj/item/organ/internal/Del()
+/obj/item/organ/internal/Destroy()
 	if(!robotic)
 		processing_objects -= src
+	qdel(organ_data)
+	organ_data = null
 	..()
 
 /obj/item/organ/internal/examine(var/mob/user, var/size = "")

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -836,7 +836,9 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 	reagent_list.Cut()
 
 	if(my_atom)
+		my_atom.reagents = null
 		my_atom = null
+	..()
 
 /**
  * Helper proc to retrieve the 'bad' reagents in the holder. Used for logging.

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -211,6 +211,7 @@
 	if(istype(holder))
 		holder.reagent_list -= src
 		holder = null
+	..()
 
 /datum/reagent/piccolyn
 	name = "Piccolyn"
@@ -6621,7 +6622,7 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 	name = "Wake-Up Call"
 	id = SECCOFFEE
 	description = "All the essentials."
-	
+
 /datum/reagent/drink/coffee/seccoffee/on_mob_life(var/mob/living/M)
 	..()
 	if(ishuman(M))

--- a/code/modules/virus2/immune_system.dm
+++ b/code/modules/virus2/immune_system.dm
@@ -47,6 +47,12 @@
 				if (antibody == ANTIGEN_RH && findtext(body.dna.b_type,"+"))
 					antibodies[antibody] += rand(12,15)
 
+/datum/immune_system/Destroy()
+	if(body)
+		body.immune_system = null
+		body = null
+	..()
+
 /datum/immune_system/proc/transfer_to(var/mob/living/L)
 	if (!L.immune_system)
 		L.immune_system = new (L)


### PR DESCRIPTION
1. Fixes a bunch of types failing to fully dereference themselves in `Destroy()`, and thus failing to GC
2. Fixes a couple types of datum lacking supercalls in `Destroy()`. This doesn't really do anything right now, but is necessary to keep #24036 from nuking the runtime log with tens of thousands of runtimes per round.