### PR TITLE
Appearance bans now also forbid you from changing your name as a silicon.

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_verbs.dm
+++ b/code/modules/mob/living/silicon/robot/robot_verbs.dm
@@ -1,6 +1,11 @@
 /mob/living/silicon/robot/verb/Namepick()
 	set category = "Robot Commands"
 
+	if (appearance_isbanned(src))
+		var/banreason = appearance_isbanned(M)
+		to_chat(src, "<span class='warning'>You have been apperance banned for the reason: [banreason]. You cannot change your name.</span>")
+		return
+
 	if(incapacitated())
 		return
 


### PR DESCRIPTION
See tittle. No changelog as players aren't concerned by this.