### PR TITLE
Makes sandstone crafting faster

### DIFF
--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -75,8 +75,8 @@
 /obj/item/stack/ore/glass/attack_self(mob/living/user as mob) //It's magic I ain't gonna explain how instant conversion with no tool works. -- Urist
 	var/location = get_turf(user)
 	for(var/obj/item/stack/ore/glass/sandToConvert in location)
-		drop_stack(/obj/item/stack/sheet/mineral/sandstone, location, 1, user)
-		sandToConvert.use(1)
+		drop_stack(/obj/item/stack/sheet/mineral/sandstone, location, sandToConvert.amount, user)
+		sandToConvert.use(sandToConvert.amount)
 
 	drop_stack(/obj/item/stack/sheet/mineral/sandstone, location, 1, user)
 	use(1)


### PR DESCRIPTION
Fixes #24080
:cl:
 * bugfix: Clicking a piece of sand now converts all the sand on the tile you're standing on to sandstone.