### PR TITLE
rocket explosion vars and cleanup

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1885,7 +1885,7 @@ mob/proc/on_foot()
 /mob/proc/isTeleViewing(var/client_eye)
 	if(istype(client_eye,/obj/machinery/camera))
 		return 1
-	if(istype(client_eye,/obj/item/projectile/nikita))
+	if(istype(client_eye,/obj/item/projectile/rocket/nikita))
 		return 1
 	return 0
 

--- a/code/modules/projectiles/ammunition/rocket.dm
+++ b/code/modules/projectiles/ammunition/rocket.dm
@@ -8,62 +8,35 @@
 	w_type = RECYK_METAL
 	w_class = W_CLASS_MEDIUM // Rockets don't exactly fit in pockets and cardboard boxes last I heard, try your backpack
 	shrapnel_amount = 0
-
+	
 /obj/item/ammo_casing/rocket_rpg/update_icon()
 	return
 
 /obj/item/ammo_casing/rocket_rpg/lowyield
 	name = "low yield rocket"
 	desc = "Explosive supplement to Nanotrasen's rocket launchers."
-	icon_state = "rpground"
-	caliber = ROCKETGRENADE
 	projectile_type = "/obj/item/projectile/rocket/lowyield"
 	starting_materials = list(MAT_IRON = 20000)
-	w_type = RECYK_METAL
-	w_class = W_CLASS_MEDIUM // Rockets don't exactly fit in pockets and cardboard boxes last I heard, try your backpack
-	shrapnel_amount = 0
-
-/obj/item/ammo_casing/rocket_rpg/lowyield/update_icon()
-	return
 
 /obj/item/ammo_casing/rocket_rpg/blank
 	name = "blank rocket"
 	desc = "This rocket left intentionally blank."
-	icon_state = "rpground"
-	caliber = ROCKETGRENADE
 	projectile_type = "/obj/item/projectile/rocket/blank"
 	starting_materials = list(MAT_IRON = 100)
-	w_type = RECYK_METAL
-	w_class = W_CLASS_MEDIUM // Rockets don't exactly fit in pockets and cardboard boxes last I heard, try your backpack
-	shrapnel_amount = 0
-
-/obj/item/ammo_casing/rocket_rpg/blank/update_icon()
-	return
 
 /obj/item/ammo_casing/rocket_rpg/emp
 	name = "EMP rocket"
 	desc = "EMP rocket for the Nanotrasen rocket launcher."
-	icon_state = "rpground"
-	caliber = ROCKETGRENADE
-	projectile_type = "/obj/item/projectile/rocket/emp"
+	projectile_type = "/obj/item/projectile/rocket/blank/emp"
 	starting_materials = list(MAT_IRON = 20000, MAT_URANIUM = 500)
-	w_type = RECYK_METAL
-	w_class = W_CLASS_MEDIUM // Rockets don't exactly fit in pockets and cardboard boxes last I heard, try your backpack
-	shrapnel_amount = 0
-
-/obj/item/ammo_casing/rocket_rpg/stun/update_icon()
-	return
 
 /obj/item/ammo_casing/rocket_rpg/stun
 	name = "stun rocket"
 	desc = "Stun rocket for the Nanotrasen rocket launcher. Not a flashbang."
-	icon_state = "rpground"
-	caliber = ROCKETGRENADE
-	projectile_type = "/obj/item/projectile/rocket/stun"
+	projectile_type = "/obj/item/projectile/rocket/blank/stun"
 	starting_materials = list(MAT_IRON = 50000, MAT_SILVER = 1000)
-	w_type = RECYK_METAL
-	w_class = W_CLASS_MEDIUM // Rockets don't exactly fit in pockets and cardboard boxes last I heard, try your backpack
-	shrapnel_amount = 0
-
-/obj/item/ammo_casing/rocket_rpg/stun/update_icon()
-	return
+	
+/obj/item/ammo_casing/rocket_rpg/extreme
+	name = "extreme rocket" //don't even map or spawn this in or you'll be very sad
+	desc = "Extreme-yield rocket. Fire from very very far away."
+	projectile_type = "/obj/item/projectile/rocket/lowyield/extreme"

--- a/code/modules/projectiles/guns/projectile/rocketlauncher.dm
+++ b/code/modules/projectiles/guns/projectile/rocketlauncher.dm
@@ -106,7 +106,7 @@
 	origin_tech = null
 	fire_sound = 'sound/weapons/rocket.ogg'
 	ammo_type = "/obj/item/ammo_casing/rocket_rpg/nikita"
-	var/obj/item/projectile/nikita/fired = null
+	var/obj/item/projectile/rocket/nikita/fired = null
 	var/emagged = 0
 
 /obj/item/weapon/gun/projectile/rocketlauncher/nikita/update_icon()
@@ -148,7 +148,7 @@
 	icon = 'icons/obj/ammo.dmi'
 	icon_state = "nikita"
 	caliber = GUIDEDROCKET
-	projectile_type = "/obj/item/projectile/nikita"
+	projectile_type = "/obj/item/projectile/rocket/nikita"
 
 /obj/item/ammo_casing/rocket_rpg/nikita/New()
 	..()

--- a/code/modules/projectiles/guns/projectile/roulette.dm
+++ b/code/modules/projectiles/guns/projectile/roulette.dm
@@ -26,7 +26,7 @@
 		/obj/item/projectile/bullet/blastwave,
 		/obj/item/projectile/beam/lightning,
 		/obj/item/projectile/beam/lightning/spell,
-		/obj/item/projectile/nikita,
+		/obj/item/projectile/rocket/nikita,
 		/obj/item/projectile/test,
 		/obj/item/projectile/beam/emitter,
 		/obj/item/projectile/meteor,

--- a/code/modules/projectiles/projectile/rocket.dm
+++ b/code/modules/projectiles/projectile/rocket.dm
@@ -11,6 +11,12 @@
 	var/explosive = 1
 	var/picked_up_speed = 0.66 //This is basically projectile speed, so
 	fire_sound = 'sound/weapons/rocket.ogg'
+	var/exdev 	= 1 //RPGs pack a serious punch and will cause massive structural damage in your average room, 
+	var/exheavy = 3 //but won't punch through reinforced walls
+	var/exlight = 5
+	var/exflash = 8
+	var/emheavy = -1
+	var/emlight = -1
 
 /obj/item/projectile/rocket/process_step()
 	if(src.loc)
@@ -28,7 +34,7 @@
 
 /obj/item/projectile/rocket/to_bump(var/atom/A)
 	if(explosive == 1)
-		explosion(A, 1, 3, 5, 8) //RPGs pack a serious punch and will cause massive structural damage in your average room, but won't punch through reinforced walls
+		explosion(A, exdev, exheavy, exlight, exflash) 
 		if(!gcDestroyed)
 			qdel(src)
 	else
@@ -39,77 +45,57 @@
 /obj/item/projectile/rocket/lowyield
 	name = "low yield rocket"
 	icon_state = "rpground"
-	explosive = 0
 	damage = 45
 	stun = 10
 	weaken = 10
-	damage_type = BRUTE
-	nodamage = 0
-	flag = "bullet"
-
-/obj/item/projectile/rocket/lowyield/to_bump(var/atom/A)
-	explosion(A, -1, 0, 3, 5) //RPGs pack a serious punch and will cause massive structural damage in your average room, but won't punch through reinforced walls
-	..()
-	if(!gcDestroyed)
-		qdel(src)
+	exdev 	= -1
+	exheavy = 0
+	exlight = 3
+	exflash = 5
 
 /obj/item/projectile/rocket/blank
 	name = "blank rocket"
-	icon_state = "rpground"
-	explosive = 0
 	damage = 5
-	stun = 5
 	weaken = 10
 	agony = 10
-	damage_type = BRUTE
-	nodamage = 0
-	flag = "bullet"
+	exdev 	= -1
+	exheavy = 0
+	exlight = 0
+	exflash = 0
 
-/obj/item/projectile/rocket/blank/to_bump(var/atom/A)
-	explosion(A, -1, 0, 0, 0)
-	..()
-	if(!gcDestroyed)
-		qdel(src)
-
-/obj/item/projectile/rocket/emp
+/obj/item/projectile/rocket/blank/emp
 	name = "EMP rocket"
-	icon_state = "rpground"
-	explosive = 0
 	damage = 10
-	stun = 5
-	weaken = 10
 	agony = 30
-	damage_type = BRUTE
-	nodamage = 0
-	flag = "bullet"
+	emheavy = 3
+	emlight = 5
 
 /obj/item/projectile/rocket/emp/to_bump(var/atom/A)
-	explosion(A, -1, 0, 0, 0)
 	empulse(A, 3, 5)
 	..()
-	if(!gcDestroyed)
-		qdel(src)
-
-/obj/item/projectile/rocket/stun
+	
+/obj/item/projectile/rocket/blank/stun
 	name = "stun rocket"
-	icon_state = "rpground"
-	explosive = 0
 	damage = 15
 	stun = 20
 	weaken = 20
 	agony = 30
-	damage_type = BRUTE
-	nodamage = 0
-	flag = "bullet"
 
 /obj/item/projectile/rocket/stun/to_bump(var/atom/A)
-	explosion(A, -1, 0, 0, 0)
 	flashbangprime(TRUE, FALSE, FALSE)
 	..()
-	if(!gcDestroyed)
-		qdel(src)
+		
+/obj/item/projectile/rocket/lowyield/extreme
+	name = "extreme yield rocket"
+	icon_state = "rpground"
+	explosive = 1
+	damage = 200
+	exdev 	= 7
+	exheavy = 14
+	exlight = 28
+	exflash = 32
 
-/obj/item/projectile/nikita
+/obj/item/projectile/rocket/nikita
 	name = "\improper Nikita missile"
 	desc = "One does not simply dodge a nikita missile."
 	icon = 'icons/obj/projectiles_experimental.dmi'
@@ -130,7 +116,7 @@
 	var/last_dir = null
 	var/emagged = 0//the value is set by the Nikita when it fires it
 
-/obj/item/projectile/nikita/OnFired()
+/obj/item/projectile/rocket/nikita/OnFired()
 	nikita = shot_from
 	emagged = nikita.emagged
 
@@ -151,24 +137,24 @@
 		for(var/obj/item/W in mob.get_all_slots())
 			mob.drop_from_inventory(W)//were you're going you won't need those!
 
-/obj/item/projectile/nikita/emp_act(severity)
+/obj/item/projectile/rocket/nikita/emp_act(severity)
 	new/obj/item/ammo_casing/rocket_rpg/nikita(get_turf(src))
 	if(nikita)
 		nikita.fired = null
 	qdel(src)
 
-/obj/item/projectile/nikita/bullet_act(var/obj/item/projectile/Proj)
+/obj/item/projectile/rocket/nikita/bullet_act(var/obj/item/projectile/Proj)
 	if(istype(Proj ,/obj/item/projectile/beam)||istype(Proj,/obj/item/projectile/bullet)||istype(Proj,/obj/item/projectile/ricochet))
 		if(!istype(Proj ,/obj/item/projectile/beam/lasertag) && !istype(Proj ,/obj/item/projectile/beam/practice) )
 			detonate()
 
-/obj/item/projectile/nikita/Destroy()
+/obj/item/projectile/rocket/nikita/Destroy()
 	reset_view()
 	if(nikita)
 		nikita.fired = null
 	..()
 
-/obj/item/projectile/nikita/to_bump(var/atom/A)
+/obj/item/projectile/rocket/nikita/to_bump(var/atom/A)
 	if(bumped)
 		return
 	if(emagged && (A == mob))
@@ -176,12 +162,12 @@
 	bumped = 1
 	detonate(get_turf(A))
 
-/obj/item/projectile/nikita/Bumped(var/atom/A)
+/obj/item/projectile/rocket/nikita/Bumped(var/atom/A)
 	if(emagged && (A == mob))
 		return
 	detonate(A)
 
-/obj/item/projectile/nikita/process_step()
+/obj/item/projectile/rocket/nikita/process_step()
 	if(!emagged && !check_user())//if the original user dropped the Nikita and the missile is still in the air, we check if someone picked it up.
 		if(nikita && istype(nikita.loc,/mob/living/carbon))
 			var/mob/living/carbon/C = nikita.loc
@@ -222,10 +208,10 @@
 
 	sleep(sleeptime)
 
-/obj/item/projectile/nikita/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+/obj/item/projectile/rocket/nikita/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	return (!density || !height || air_group)
 
-/obj/item/projectile/nikita/proc/check_user()
+/obj/item/projectile/rocket/nikita/proc/check_user()
 	if(!mob || !mob.client)
 		return 0
 	if(mob.stat || (mob.get_active_hand() != nikita))
@@ -233,12 +219,12 @@
 		return 0
 	return 1
 
-/obj/item/projectile/nikita/proc/detonate(var/atom/A)
-	explosion(A, 1, 3, 5, 8) //Nikita rockets pack a serious punch and will cause massive structural damage in your average room, but won't punch through reinforced walls
+/obj/item/projectile/rocket/nikita/proc/detonate(var/atom/A)
+	explosion(A, exdev, exheavy, exlight, exflash)
 	if(!gcDestroyed)
 		qdel(src)
 
-/obj/item/projectile/nikita/proc/reset_view()
+/obj/item/projectile/rocket/nikita/proc/reset_view()
 	var/datum/control/C = mob.orient_object[src]
 	if(C)
 		C.break_control()

--- a/code/modules/projectiles/projectile/rocket.dm
+++ b/code/modules/projectiles/projectile/rocket.dm
@@ -87,8 +87,6 @@
 		
 /obj/item/projectile/rocket/lowyield/extreme
 	name = "extreme yield rocket"
-	icon_state = "rpground"
-	explosive = 1
 	damage = 200
 	exdev 	= 7
 	exheavy = 14


### PR DESCRIPTION
- Rockets now have vars to determine their EMP/explosion size, so admins can fuck with them if they want.
- Did some cleanup, removed most of the copypaste. Woohoo, OOP.
- Nikitas are now a subtype of rockets.
- Added a maxcap meme rocket.

Did you know that if you fire any RPG at a reinforced wall, there's a pretty high chance it won't even pierce the wall? Hitting walls with RPGs is completely fucked, man. I'm not gonna be the one to fix it, though.