### PR TITLE
Powercreep scything fix

### DIFF
--- a/code/game/mecha/equipment/tools/tools.dm
+++ b/code/game/mecha/equipment/tools/tools.dm
@@ -269,7 +269,7 @@
 			var/obj/machinery/portable_atmospherics/hydroponics/tray = target
 			playsound(target, 'sound/mecha/mechsmash.ogg', 50, 1)
 			tray.smashDestroy(50) //Just to really drive it home
-	else if(istype(target, /obj/effect/plantsegment) || istype(target, /obj/effect/alien/weeds) || istype(target, /obj/effect/biomass)|| istype(target, /turf/simulated/floor))
+	else if(istype(target, /obj/effect/plantsegment) || istype(target, /obj/effect/alien/weeds) || istype(target, /obj/effect/biomass)|| istype(target, /turf/simulated/floor) || istype(target, /obj/structure/cable/powercreeper))
 		set_ready_state(0)
 		var/olddir = chassis.dir
 		var/eradicated = 0
@@ -283,6 +283,11 @@
 						eradicated++
 					else if(istype(E, /obj/effect/alien/weeds) || istype(E, /obj/effect/biomass))
 						qdel(E)
+						eradicated++
+			for(var/obj/structure/cable/powercreeper/C in range(chassis,i == 4 ? 2 : 1))
+				if(get_dir(chassis,C)&chassis.dir || C.loc == get_turf(chassis))
+					if(istype(C, /obj/structure/cable/powercreeper))
+						C.die()
 						eradicated++
 			sleep(3)
 		if(eradicated)

--- a/code/modules/hydroponics/hydro_tools.dm
+++ b/code/modules/hydroponics/hydro_tools.dm
@@ -419,11 +419,13 @@
 /obj/item/weapon/scythe/afterattack(atom/A, mob/user as mob, proximity)
 	if(!proximity)
 		return
-	if(istype(A, /obj/effect/plantsegment) || istype(A, /turf/simulated/floor) || istype(A, /obj/effect/biomass))
+	if(istype(A, /obj/effect/plantsegment) || istype(A, /turf/simulated/floor) || istype(A, /obj/effect/biomass) || istype(A, /obj/structure/cable/powercreeper))
 		for(var/obj/effect/plantsegment/B in range(user,1))
 			B.take_damage(src)
 		for(var/obj/effect/biomass/BM in range(user,1))
 			BM.adjust_health(rand(15,45))
+		for(var/obj/structure/cable/powercreeper/C in range(user,1))
+			C.die()
 		user.delayNextAttack(10)
 		/*var/olddir = user.dir
 		spawn for(var/i=-2, i<=2, i++) //hheeeehehe i'm so dumb


### PR DESCRIPTION
Fixes #24106
Also fixes normal scythes while I'm at it.
This solution has a ~~bug~~ feature that forces the scythe to wait for the death animation of a section of the plant to finish, before killing off the next section.
Fixing it seemed like a balance change, so I decided to keep it in for now. Let me know if I should change it.

:cl:
 * bugfix: Scythes now work properly against powercreep vines