### PR TITLE
Removes space slipping

### DIFF
--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -197,9 +197,6 @@ In all, this is a lot like the monkey code. /N
 /mob/living/carbon/alien/IsAdvancedToolUser()
 	return has_fine_manipulation
 
-/mob/living/carbon/alien/Process_Spaceslipping()
-	return 0 // Don't slip in space.
-
 /mob/living/carbon/alien/Stat()
 
 	if(statpanel("Status"))

--- a/code/modules/mob/living/carbon/complex/martian/martian.dm
+++ b/code/modules/mob/living/carbon/complex/martian/martian.dm
@@ -95,9 +95,6 @@
 /mob/living/carbon/complex/martian/IsAdvancedToolUser()
 	return TRUE
 
-/mob/living/carbon/complex/martian/Process_Spaceslipping()
-	return 0 //No slipping
-
 /mob/living/carbon/complex/martian/has_eyes()
 	return FALSE
 

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -109,27 +109,6 @@
 	return ..()
 
 
-/mob/living/carbon/human/Process_Spaceslipping(var/prob_slip = 5)
-	//If knocked out we might just hit it and stop.  This makes it possible to get dead bodies and such.
-	if(stat)
-		prob_slip = 0 // Changing this to zero to make it line up with the comment, and also, make more sense.
-
-	//Do we have magboots or such on if so no slip
-	if(CheckSlip() == SLIP_HAS_MAGBOOTS)
-		prob_slip = 0
-
-	//Check hands and mod slip
-	for(var/i = 1 to held_items.len)
-		var/obj/item/I = held_items[i]
-
-		if(!I)
-			prob_slip -= 2
-		else if(I.w_class <= W_CLASS_SMALL)
-			prob_slip -= 1
-
-	prob_slip = round(prob_slip)
-	return(prob_slip)
-
 /mob/living/carbon/human/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	. = ..()
 

--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -1,8 +1,3 @@
-/mob/living/silicon/robot/Process_Spaceslipping(var/prob_slip = 5)
-	if(HAS_MODULE_QUIRK(src, MODULE_HAS_MAGPULSE)) //	The magic of magnets.
-		return FALSE
-	..()
-
 /mob/living/silicon/robot/CheckSlip(slip_on_walking = FALSE, overlay_type = TURF_WET_WATER, slip_on_magbooties = FALSE)
 	return ((HAS_MODULE_QUIRK(src, MODULE_HAS_MAGPULSE))? SLIP_HAS_MAGBOOTS : FALSE)
 

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -488,22 +488,7 @@
 		return 1
 
 	if(..())
-		//Check to see if we slipped
-		if(!ignore_slip && on_foot() && prob(Process_Spaceslipping(5)))
-			to_chat(src, "<span class='notice'><B>You slipped!</B></span>")
-			src.inertia_dir = src.last_move
-			step(src, src.inertia_dir)
-			return 0
 		return 1
-
-/mob/proc/Process_Spaceslipping(var/prob_slip = 5)
-	//Setup slipage
-	//If knocked out we might just hit it and stop.  This makes it possible to get dead bodies and such.
-	if(stat)
-		prob_slip = 0  // Changing this to zero to make it line up with the comment.
-
-	prob_slip = round(prob_slip)
-	return(prob_slip)
 
 
 /mob/proc/Move_Pulled(var/atom/dest, var/atom/movable/target = pulling)


### PR DESCRIPTION
![shout-out to iflashyou for not committing war crimes against me](https://i.imgur.com/UQbXFhY.png)
Removes that "you slip!" thing that happens when you walk without activated magboots in space
"Wait, why?"
I've been asked to, I don't like it but I don't really have any strong objective arguments for its removal because it's going to make magboots have one less advantage, even if they are currently just upgraded boots. Besides, how do you slip in space? Is it something like "you don't have a good grasp on the nearby wall or floor so you slip in the direction you're walking"? How does it work if you're near walls and just have magboots enabled?
:cl:
 * rscdel: You can no longer slip in space.