### PR TITLE
renames security borgs to peacekeeper borgs

### DIFF
--- a/__DEFINES/silicon.dm
+++ b/__DEFINES/silicon.dm
@@ -3,7 +3,7 @@
 #define SERVICE_MODULE "Service"
 #define SUPPLY_MODULE "Supply"
 #define MEDICAL_MODULE "Medical"
-#define SECURITY_MODULE "Security"
+#define PEACEKEEPER_MODULE "Peacekeeper"
 #define ENGINEERING_MODULE "Engineering"
 #define JANITOR_MODULE "Janitor"
 #define COMBAT_MODULE "Combat"
@@ -22,7 +22,7 @@ var/global/list/default_nanotrasen_robot_modules = list(
 	SERVICE_MODULE			= /obj/item/weapon/robot_module/butler,
 	SUPPLY_MODULE 			= /obj/item/weapon/robot_module/miner,
 	MEDICAL_MODULE			= /obj/item/weapon/robot_module/medical,
-	SECURITY_MODULE			= /obj/item/weapon/robot_module/security,
+	PEACEKEEPER_MODULE		= /obj/item/weapon/robot_module/peacekeeper,
 	ENGINEERING_MODULE		= /obj/item/weapon/robot_module/engineering,
 	JANITOR_MODULE			= /obj/item/weapon/robot_module/janitor,
     )
@@ -100,7 +100,7 @@ var/global/list/all_robot_modules = default_nanotrasen_robot_modules + emergency
 #define CYBORG_COMBAT_SPEED_MODIFIER 1
 #define CYBORG_STANDARD_SPEED_MODIFIER 1
 #define CYBORG_SERVICE_SPEED_MODIFIER 1
-#define CYBORG_SECURITY_SPEED_MODIFIER 1
+#define CYBORG_PEACEKEEPER_SPEED_MODIFIER 1
 #define CYBORG_TG17355_SPEED_MODIFIER 1
 #define CYBORG_STARMAN_SPEED_MODIFIER 1
 

--- a/code/game/objects/items/robot/robot_items/robot_id.dm
+++ b/code/game/objects/items/robot/robot_items/robot_id.dm
@@ -3,10 +3,10 @@
 	icon_state = "id-robot"
 	desc = "A circuit grafted onto the bottom of an ID card."
 
-//Warden upgrade's security barrier ID
-/obj/item/weapon/card/robot/security
+//Warden upgrade's peacekeeper barrier ID
+/obj/item/weapon/card/robot/peacekeeper
 	name = "security code transmission device"
 
-/obj/item/weapon/card/robot/security/New()
+/obj/item/weapon/card/robot/peacekeeper/New()
 	..()
 	desc += " This one is used to transmit security codes into deployable barriers, allowing the user to lock and unlock them."

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -322,12 +322,12 @@
 
 	R.module.quirk_flags |= MODULE_IS_A_CLOWN
 
-//Security Stuff
+//Peacekeeper Stuff
 /obj/item/borg/upgrade/tasercooler
-	name = "security cyborg rapid taser cooling upgrade board"
+	name = "peacekeeper cyborg rapid taser cooling upgrade board"
 	desc = "Used to cool a mounted taser, increasing the potential current in it and thus its recharge rate."
 	icon_state = "cyborg_upgrade3"
-	required_modules = list(SECURITY_MODULE, HUG_MODULE)
+	required_modules = list(PEACEKEEPER_MODULE, HUG_MODULE)
 	multi_upgrades = TRUE
 
 
@@ -349,10 +349,10 @@
 
 
 /obj/item/borg/upgrade/noir
-	name = "security cyborg N.O.I.R. upgrade board"
+	name = "peacekeeper cyborg N.O.I.R. upgrade board"
 	desc = "So that's the way you scientific detectives work. My god! for a fat, middle-aged, hard-boiled, pig-headed guy, you've got the vaguest way of doing things I ever heard of."
 	icon_state = "mainboard"
-	required_modules = list(SECURITY_MODULE, HUG_MODULE)
+	required_modules = list(PEACEKEEPER_MODULE, HUG_MODULE)
 	modules_to_add = list(/obj/item/weapon/gripper/service/noir, /obj/item/weapon/storage/evidencebag, /obj/item/cyborglens, /obj/item/device/taperecorder, /obj/item/weapon/gun/projectile/detective, /obj/item/ammo_storage/speedloader/c38/cyborg)
 
 /obj/item/borg/upgrade/noir/attempt_action(var/mob/living/silicon/robot/R,var/mob/living/user)
@@ -375,11 +375,11 @@
 			C.Noirize()
 
 /obj/item/borg/upgrade/warden
-	name = "security cyborg W.A.T.C.H. upgrade board"
-	desc = "Used to give a security cyborg supervisory enforcement tools."
+	name = "peacekeeper cyborg W.A.T.C.H. upgrade board"
+	desc = "Used to give a peacekeeper cyborg supervisory enforcement tools."
 	icon_state = "mcontroller"
-	required_modules = list(SECURITY_MODULE, HUG_MODULE)
-	modules_to_add = list(/obj/item/weapon/batteringram, /obj/item/weapon/implanter/cyborg, /obj/item/weapon/card/robot/security, /obj/item/weapon/wrench, /obj/item/weapon/handcuffs/cyborg) //Secborgs have cuffs, but hugborgs can't do warden job properly without them.
+	required_modules = list(PEACEKEEPER_MODULE, HUG_MODULE)
+	modules_to_add = list(/obj/item/weapon/batteringram, /obj/item/weapon/implanter/cyborg, /obj/item/weapon/card/robot/peacekeeper, /obj/item/weapon/wrench, /obj/item/weapon/handcuffs/cyborg) //Secborgs have cuffs, but hugborgs can't do warden job properly without them.
 
 /obj/item/borg/upgrade/warden/attempt_action(var/mob/living/silicon/robot/R,var/mob/living/user)
 	if(..())
@@ -403,10 +403,10 @@
 	R.module.quirk_flags |= MODULE_HAS_FLASH_RES
 
 /obj/item/borg/upgrade/hos
-	name = "security cyborg H.O.S. upgrade board"
-	desc = "A special upgrade used to promote security cyborgs with both N.O.I.R. and W.A.T.C.H. upgrades installed to head of silicons."
+	name = "peacekeeper cyborg H.O.S. upgrade board"
+	desc = "A special upgrade used to promote peacekeeper cyborgs with both N.O.I.R. and W.A.T.C.H. upgrades installed to head of silicons."
 	icon_state = "mcontroller"
-	required_modules = list(SECURITY_MODULE, HUG_MODULE)
+	required_modules = list(PEACEKEEPER_MODULE, HUG_MODULE)
 	required_upgrades = list(/obj/item/borg/upgrade/noir, /obj/item/borg/upgrade/warden)
 	modules_to_add = list(/obj/item/weapon/gun/lawgiver, /obj/item/weapon/gun/grenadelauncher)
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -263,7 +263,7 @@ var/list/cyborg_list = list()
 	feedback_inc("cyborg_[lowertext(modtype)]",1)
 	updatename()
 
-	if(modtype == (SECURITY_MODULE || COMBAT_MODULE))
+	if(modtype == (PEACEKEEPER_MODULE || COMBAT_MODULE))
 		to_chat(src, "<span class='big warning'><b>Regardless of your module, your wishes, or the needs of the beings around you, absolutely nothing takes higher priority than following your silicon lawset.</b></span>")
 
 	set_module_sprites(module.sprites)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -347,9 +347,9 @@
 
 	fix_modules()
 
-/obj/item/weapon/robot_module/security
-	name = "security robot module"
-	module_holder = "security"
+/obj/item/weapon/robot_module/peacekeeper
+	name = "peacekeeper robot module"
+	module_holder = "peacekeeper"
 	quirk_flags = MODULE_IS_THE_LAW | MODULE_CAN_LIFT_SECTAPE
 	radio_key = /obj/item/device/encryptionkey/headset_sec
 	sprites = list(
@@ -364,9 +364,9 @@
 		"Noble" = "Noble-SEC",
 		"R34 - SEC10a 'Woody'" = "woody"
 		)
-	speed_modifier = CYBORG_SECURITY_SPEED_MODIFIER
+	speed_modifier = CYBORG_PEACEKEEPER_SPEED_MODIFIER
 
-/obj/item/weapon/robot_module/security/New()
+/obj/item/weapon/robot_module/peacekeeper/New()
 	..()
 
 	modules += new /obj/item/weapon/crowbar(src)


### PR DESCRIPTION
This is essentially a revert of #14762 and a redo of my old PR, #14203
It also goes against the relevant poll from `2017-07-16`, http://ss13.moe/index.php/poll/120

I think security borgs should be renamed to peacekeeper borgs because;

- they're not security when on any lawset but robocop or law custom
- they don't help security when on any lawset but robocop or law custom
- people that play them see 'security' and think they're security even when they're not onrobocop or law custom

Discuss.