### PR TITLE
Having your limbs damaged slows you down depending on the amount of damage

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -56,6 +56,7 @@
 				if(!find_held_item_by_type(/obj/item/weapon/cane))
 					. += 1*multiplier
 				. += 0.5*multiplier
+			. += ((E.brute_dam+E.burn_dam)/E.max_damage)*multiplier
 
 
 /mob/living/carbon/human/movement_tally_multiplier()


### PR DESCRIPTION
Requested by somebody in the discord

:cl:
 * rscadd: Damage to your navigational extremeties, be they legs and you are walking, or hands and are crawling, will slow your movement down.