### PR TITLE
Human health now only takes into account the vital external organs.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -7,7 +7,7 @@
 	var/total_burn	= 0
 	var/total_brute	= 0
 	for(var/datum/organ/external/O in organs)	//hardcoded to streamline things a bit
-		if(O.is_organic() && O.is_existing())
+		if(O.vital && O.is_organic() && O.is_existing())
 			total_brute	+= O.brute_dam
 			total_burn	+= O.burn_dam
 	health = maxHealth - getOxyLoss() - getToxLoss() - getCloneLoss() - total_burn - total_brute


### PR DESCRIPTION
This means cutting your feet to bloody shreds is no longer directly lethal, but the bloodloss attributed to said limbs getting cut to shreds will still be so.

If this were to get through, something would need to be done about burn damage, as it's not as disabling on a non-vital limb as brute damage is. Putting the PR up for suggestions regarding such.

:cl:
 * rscadd: For humans, their full health is now calculated based on damage to their vital external organs, being the head, chest, and groin.
