### PR TITLE
Blinder now confuses borgs, rather than stunning them

### DIFF
--- a/code/modules/mob/living/silicon/mommi/life.dm
+++ b/code/modules/mob/living/silicon/mommi/life.dm
@@ -88,6 +88,8 @@
 		gib()
 
 	if (src.stat != 2) //Alive.
+		if(confused)
+			confused = max(0, confused - 1)
 		if (src.paralysis || src.stunned || src.knockdown) //Stunned etc.
 			src.stat = 1
 			if (src.stunned > 0)

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -84,6 +84,8 @@
 		death()
 
 	if(!isDead()) //Alive.
+		if(confused)
+			confused = max(0, confused - 1)
 		if(paralysis || stunned || knockdown) //Stunned etc.
 			stat = UNCONSCIOUS
 			if(stunned > 0)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -378,7 +378,10 @@
 							return
 
 		else if(mob.confused)
-			step_rand(mob)
+			if(issilicon(mob))
+				step(mob, pick(NORTH,SOUTH,EAST,WEST))
+			else
+				step_rand(mob)
 			mob.last_movement=world.time
 		else
 			if (prefs.stumble && ((world.time - mob.last_movement) > 5 && move_delay < 2))

--- a/code/modules/projectiles/guns/projectile/constructable/blinder.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/blinder.dm
@@ -95,7 +95,7 @@
 	M.flash_eyes(visual = 1, affect_silicon = 1)
 
 	if(issilicon(M))
-		M.Knockdown(rand(5, 10))
+		M.confused = rand(5, 10)
 		M.visible_message("<span class='warning'>[M]'s sensors are overloaded by the flash of light!</span>","<span class='warning'>Your sensors are overloaded by the flash of light!</span>")
 
 	if(ishuman(M))


### PR DESCRIPTION
A second attempt at rebalancing the blinder, following the discussion in #24103, which makes the borg move around randomly instead of stunning them entirely.
This change brings it much closer to the original intent for the blinder, which was to have it serve as a defensive weapon against borgs, allowing the user enough time to run away and hide from it, but without it being so powerful that it can effectively be used in open combat as an alternative to ion rifles.

:cl:
 * tweak: Blinders now confuse borgs, instead of stunning them.