### PR TITLE
Removed teleporters sending you to deep space and accuracy stuff.

### DIFF
--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -196,7 +196,7 @@
 	name = "teleporter horizon generator"
 	desc = "This generates the portal through which you step through to teleport elsewhere."
 	icon_state = "tele0"
-	//var/accurate = 0
+	var/accurate = 0 //Doesn't compile without it due to legacy stuff. Unused otherwise.
 	use_power = 1
 	idle_power_usage = 10
 	active_power_usage = 2000

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -196,7 +196,7 @@
 	name = "teleporter horizon generator"
 	desc = "This generates the portal through which you step through to teleport elsewhere."
 	icon_state = "tele0"
-	var/accurate = 0 //Accuracy is no longer used.
+	//var/accurate = 0
 	use_power = 1
 	idle_power_usage = 10
 	active_power_usage = 2000
@@ -268,12 +268,10 @@
 		to_chat(M, "<span class = 'notice'>The act of teleportation was so smooth, it feels like you didn't move at all.</span>")
 		return 0
 	if (istype(M, /atom/movable))
-		/*
-		if(prob(5) && !accurate) //oh dear a problem, put em in deep space
-			do_teleport(M, locate(rand((2*TRANSITIONEDGE), world.maxx - (2*TRANSITIONEDGE)), rand((2*TRANSITIONEDGE), world.maxy - (2*TRANSITIONEDGE)), 3), 2)
-		else
-			do_teleport(M, com.locked) //dead-on precision
-		*/
+		//if(prob(5) && !accurate) //oh dear a problem, put em in deep space
+		//	do_teleport(M, locate(rand((2*TRANSITIONEDGE), world.maxx - (2*TRANSITIONEDGE)), rand((2*TRANSITIONEDGE), world.maxy - (2*TRANSITIONEDGE)), 3), 2)
+		//else
+		//	do_teleport(M, com.locked) //dead-on precision
 		do_teleport(M, com.locked)
 
 		if(com.one_time_use) //Make one-time-use cards only usable one time!
@@ -325,8 +323,6 @@
 	else
 		icon_state = "controller"
 
-
-
 /obj/machinery/teleport/station/attackby(var/obj/item/weapon/W, var/mob/user as mob)
 	if (..())
 		return 1
@@ -373,29 +369,24 @@
 	src.engaged = 0
 	return
 
-/*
-/obj/machinery/teleport/station/verb/testfire()
-	set name = "Test Fire Teleporter"
-	set category = "Object"
-	set src in oview(1)
+///obj/machinery/teleport/station/verb/testfire()
+	//set name = "Test Fire Teleporter"
+	//set category = "Object"
+	//set src in oview(1)
 
-	if(stat & (BROKEN|NOPOWER) || !istype(usr,/mob/living))
-		return
-
-
-	for(var/obj/machinery/teleport/hub/hub in orange(1))
-		engaged = 1
-		var/wasaccurate = hub.accurate //let's make sure if you have a mapped in accurate tele that it stays that way
-		hub.accurate = 1
-		hub.engaged = 1
-		hub.update_icon()
-		visible_message("<span class='notice'>Test firing! Teleporter temporarily calibrated to be more accurate.</span>", range = 2)
-		hub.teleport()
-		use_power(teleport_power_usage)
-		spawn(30)
-			hub.accurate = wasaccurate
-			visible_message("<span class='notice'>Test fire completed.</span>", range = 2)
-
-	src.add_fingerprint(usr)
-	return
-*/
+	//if(stat & (BROKEN|NOPOWER) || !istype(usr,/mob/living))
+	//	return
+	//for(var/obj/machinery/teleport/hub/hub in orange(1))
+	//	engaged = 1
+	//	var/wasaccurate = hub.accurate //let's make sure if you have a mapped in accurate tele that it stays that way
+	//	hub.accurate = 1
+	//	hub.engaged = 1
+	//	hub.update_icon()
+	//	visible_message("<span class='notice'>Test firing! Teleporter temporarily calibrated to be more accurate.</span>", range = 2)
+	//	hub.teleport()
+	//	use_power(teleport_power_usage)
+	//	spawn(30)
+	//		hub.accurate = wasaccurate
+	//		visible_message("<span class='notice'>Test fire completed.</span>", range = 2)
+	//src.add_fingerprint(usr)
+	//return

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -196,7 +196,7 @@
 	name = "teleporter horizon generator"
 	desc = "This generates the portal through which you step through to teleport elsewhere."
 	icon_state = "tele0"
-	var/accurate = 0 //Doesn't compile without it due to legacy stuff. Unused otherwise.
+	//var/accurate = 0
 	use_power = 1
 	idle_power_usage = 10
 	active_power_usage = 2000

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -196,7 +196,7 @@
 	name = "teleporter horizon generator"
 	desc = "This generates the portal through which you step through to teleport elsewhere."
 	icon_state = "tele0"
-	var/accurate = 0
+	var/accurate = 0 //Accuracy is no longer used.
 	use_power = 1
 	idle_power_usage = 10
 	active_power_usage = 2000
@@ -268,10 +268,13 @@
 		to_chat(M, "<span class = 'notice'>The act of teleportation was so smooth, it feels like you didn't move at all.</span>")
 		return 0
 	if (istype(M, /atom/movable))
+		/*
 		if(prob(5) && !accurate) //oh dear a problem, put em in deep space
 			do_teleport(M, locate(rand((2*TRANSITIONEDGE), world.maxx - (2*TRANSITIONEDGE)), rand((2*TRANSITIONEDGE), world.maxy - (2*TRANSITIONEDGE)), 3), 2)
 		else
 			do_teleport(M, com.locked) //dead-on precision
+		*/
+		do_teleport(M, com.locked)
 
 		if(com.one_time_use) //Make one-time-use cards only usable one time!
 			com.one_time_use = 0
@@ -370,6 +373,7 @@
 	src.engaged = 0
 	return
 
+/*
 /obj/machinery/teleport/station/verb/testfire()
 	set name = "Test Fire Teleporter"
 	set category = "Object"
@@ -394,3 +398,4 @@
 
 	src.add_fingerprint(usr)
 	return
+*/


### PR DESCRIPTION
[featureloss] [featurerequest]
Resolves #24136 
Getting sent to deep space without warning is pretty bad. The only way to mitigate this is to do a right click / player tabs verb which gives you 30 seconds and even then you have a 5% chance to be sent to deep space with no warning.
I've seen it happen here and there where someone sets the teleporter and jumps in without test firing it or not even knowing you had to test fire it and ending up dead in space with no way back. So I think this should be fixed.
:cl:
* rscdel: The 3 part teleporter no longer has a test fire and accuracy requirement that sends you to deep space by chance if you didn't do so.