### PR TITLE
PAI sanity/balance

### DIFF
--- a/code/game/machinery/bots/cleanbot.dm
+++ b/code/game/machinery/bots/cleanbot.dm
@@ -442,7 +442,7 @@ text("<A href='?src=\ref[src];operation=oddbutton'>[src.oddbutton ? "Yes" : "No"
 */
 
 /obj/machinery/bot/cleanbot/getpAIMovementDelay()
-	return 1
+	return SS_WAIT_MACHINERY
 
 /obj/machinery/bot/cleanbot/pAImove(mob/living/silicon/pai/user, dir)
 	if(!on)

--- a/code/game/machinery/bots/medbot.dm
+++ b/code/game/machinery/bots/medbot.dm
@@ -724,7 +724,7 @@
 		overlays -= image('icons/obj/aibots.dmi', "medibot_pai_overlay")
 
 /obj/machinery/bot/medbot/getpAIMovementDelay()
-	return 1
+	return SS_WAIT_MACHINERY
 
 /obj/machinery/bot/medbot/pAImove(mob/living/silicon/pai/user, dir)
 	if(!on)

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -249,6 +249,9 @@
 /mob/living/silicon/pai/ClickOn(var/atom/A, var/params)
 	if(incapacitated())
 		return
+	if(click_delayer.blocked())
+		return
+	click_delayer.setDelay(1)
 	var/list/modifiers = params2list(params)
 	if(modifiers["middle"])
 		MiddleClickOn(A)
@@ -262,7 +265,8 @@
 	if(modifiers["ctrl"])
 		CtrlClickOn(A)
 		return
-
+	if(attack_delayer.blocked())
+		return
 	if(istype(card.loc, /obj))
 		var/obj/O = card.loc
 		if(O.integratedpai == card)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -401,6 +401,14 @@
 	if(get_holder_of_type(user, /obj/structure/disposalpipe) || get_holder_of_type(user, /obj/machinery/atmospherics/pipe))	//can't fire the gun from inside pipes or disposal pipes
 		to_chat(user, "<span class='warning'>You can't aim \the [src] properly from this location!</span>")
 		return FALSE
+	if(isliving(loc))
+		var/mob/living/L = loc
+		if(!L.held_items.Find(src))
+			to_chat(user, "<span class='warning'>Safety protocol prevents you from firing while situated upon a person, unless you are being held by said person.</span>")
+			return FALSE
+	else if(!isturf(loc))
+		to_chat(user, "<span class='warning'>Safety protocol prevents you from firing from within the confines of an object.</span>")
+		return FALSE
 	else if(!pai_safety)
 		to_chat(user, "<span class='warning'>You're not connected to \the [src]'s firing mechanism!</span>")
 		return FALSE


### PR DESCRIPTION
Actually adds click and attack delays to PAIs

Smartgun PAI sanity, can no longer fire from the confines of a box within a backpack within a bag of holding being worn by a monkey who is in a disposals bin, nor can you fire from in a weapons recharger and become a turret. Need to be either flat on the floor, or in a persons hand.

Medbots and cleanbot PAIs now have the same movement delay as the regular medbot/cleanbot, I'm really not feeling this change in particular however, but would prefer for it to be more sane than NANI-level movement.

TODO:
 - [x] #23790 
 - [ ] #23502 
 - [ ] #23203 
 - [ ] #23154 
 - [ ] Balance the PAI bot speed so it's above the normal bot movement speed, but not super fast
 - [ ] Have PAI guns be able to fire while being worn by a person (Pocket, belt, etc.) rather than being limited to hands

:cl:
 * tweak: PAIs now have click and attack delay
 * tweak: Smartgun PAI sanity now demands they are either in a persons hand or on the floor to fire.
 * tweak: PAIs now respect the movement delay of the bots they are placed within.