### PR TITLE
Fixes unlit welding tools repairing robotic limbs for free

### DIFF
--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -661,10 +661,10 @@
 			return
 		if(!(S.status & ORGAN_ROBOT) || user.a_intent != I_HELP)
 			return ..()
-		if (!src.welding)
-			to_chat(user, "You press \the unlit [src] against [user == M ? "your" : "[M]'s"] [S.display_name], but nothing happens.")
-			return
 		if(S.brute_dam)
+			if (!src.welding)
+				to_chat(user, "You press \the unlit [src] against [user == M ? "your" : "[M]'s"] [S.display_name], but nothing happens.")
+				return
 			S.heal_damage(15,0,0,1)
 			if(user != M)
 				user.visible_message("<span class='attack'>\The [user] patches some dents on \the [M]'s [S.display_name] with \the [src]</span>",\

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -663,7 +663,7 @@
 			return ..()
 		if(S.brute_dam)
 			if (!src.welding)
-				to_chat(user, "You press \the unlit [src] against [user == M ? "your" : "[M]'s"] [S.display_name], but nothing happens.")
+				to_chat(user, "<span class='notice'>You press \the unlit [src] against [user == M ? "your" : "[M]'s"] [S.display_name], but nothing happens.</span>")
 				return
 			if(remove_fuel(1, user))
 				S.heal_damage(15,0,0,1)

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -665,15 +665,16 @@
 			if (!src.welding)
 				to_chat(user, "You press \the unlit [src] against [user == M ? "your" : "[M]'s"] [S.display_name], but nothing happens.")
 				return
-			S.heal_damage(15,0,0,1)
-			if(user != M)
-				user.visible_message("<span class='attack'>\The [user] patches some dents on \the [M]'s [S.display_name] with \the [src]</span>",\
-				"<span class='attack'>You patch some dents on \the [M]'s [S.display_name]</span>",\
-				"You hear a welder.")
-			else
-				user.visible_message("<span class='attack'>\The [user] patches some dents on their [S.display_name] with \the [src]</span>",\
-				"<span class='attack'>You patch some dents on your [S.display_name]</span>",\
-				"You hear a welder.")
+			if(remove_fuel(1, user))
+				S.heal_damage(15,0,0,1)
+				if(user != M)
+					user.visible_message("<span class='attack'>\The [user] patches some dents on \the [M]'s [S.display_name] with \the [src]</span>",\
+					"<span class='attack'>You patch some dents on \the [M]'s [S.display_name]</span>",\
+					"You hear a welder.")
+				else
+					user.visible_message("<span class='attack'>\The [user] patches some dents on their [S.display_name] with \the [src]</span>",\
+					"<span class='attack'>You patch some dents on your [S.display_name]</span>",\
+					"You hear a welder.")
 		else
 			to_chat(user, "Nothing to fix!")
 	else

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -661,6 +661,9 @@
 			return
 		if(!(S.status & ORGAN_ROBOT) || user.a_intent != I_HELP)
 			return ..()
+		if (!src.welding)
+			to_chat(user, "You press \the unlit [src] against [user == M ? "your" : "[M]'s"] [S.display_name], but nothing happens.")
+			return
 		if(S.brute_dam)
 			S.heal_damage(15,0,0,1)
 			if(user != M)


### PR DESCRIPTION
Fixes #23776

:cl:
 * bugfix: Welding tools now have to be turned on to fix robotic limbs