### PR TITLE
Fixes emergency shuttle travel time being shortened to 10 seconds

### DIFF
--- a/code/game/machinery/computer/shuttle.dm
+++ b/code/game/machinery/computer/shuttle.dm
@@ -35,6 +35,8 @@
 				return 0
 			switch(choice)
 				if("Authorize")
+					if(!emergency_shuttle.location == 1)
+						return 
 					src.authorized -= W:registered_name
 					src.authorized += W:registered_name
 					if (src.auth_need - src.authorized.len > 0)


### PR DESCRIPTION
Fixes  #16221

:cl:
 * bugfix: You can no longer shorten emergency shuttle travel time to 10 seconds