### PR TITLE
Fixes odysseus sleepers being impossible to escape from

### DIFF
--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -210,6 +210,12 @@
 		update_equip_info()
 	return
 
+/obj/item/mecha_parts/mecha_equipment/tool/sleeper/relaymove(mob/user)
+	if(user.isStunned())
+		return
+	occupant_message("[occupant] is self ejecting at [(occupant.health/occupant.maxHealth)*100]% health.")
+	go_out()
+
 /obj/item/mecha_parts/mecha_equipment/tool/sleeper/update_equip_info()
 	if(..())
 		send_byjax(chassis.occupant,"msleeper.browser","lossinfo",get_occupant_dam())
@@ -226,6 +232,7 @@
 		S.set_ready_state(1)
 		S.log_message("Deactivated.")
 		S.occupant_message("[src] deactivated - no power.")
+		S.go_out()
 		return stop()
 	var/mob/living/carbon/M = S.occupant
 	if(!M)
@@ -235,10 +242,6 @@
 		M.updatehealth()
 	M.AdjustStunned(-4)
 	M.AdjustKnockdown(-4)
-	M.AdjustStunned(-4)
-	M.Paralyse(2)
-	M.Knockdown(2)
-	M.Stun(2)
 	if(M.reagents.get_reagent_amount(INAPROVALINE) < 5)
 		M.reagents.add_reagent(INAPROVALINE, 5)
 	S.chassis.use_power(S.energy_drain)

--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -76,6 +76,7 @@
 		occupant_message("<span class='notice'>[target] successfully loaded into [src]. Life support functions engaged.</span>")
 		chassis.visible_message("[chassis] loads [target] into [src].")
 		log_message("[target] loaded. Life support functions engaged.")
+		msg_admin_attack("[chassis.occupant] has loaded [target] into a mecha-sleeper. ([formatJumpTo(chassis)])")
 	return
 
 /obj/item/mecha_parts/mecha_equipment/tool/sleeper/proc/go_out()


### PR DESCRIPTION
For some strange reason it was constantly applying paralyze and stun and knockdown to whomever was inside, while also fixing the stun (twice) and knockdown for some reason. This has been changed so instead it is just fixing the stun and knockdown.

Now, you can move whilest inside the sleeper, and it will permit you exit from the mech. In addition, should the odysseus run out of power, it will auto-eject all sleeper occupants.

:cl:
 * bugfix: Odysseus sleepers now let the occupant out should the mech run out of power, or the occupant move.