### PR TITLE
fixed pointing at invisible things you can't see

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1060,7 +1060,6 @@ Use this proc preferably at the end of an equipment loadout
 	set name = "Point To"
 	set category = "Object"
 
-
 	if((usr.isUnconscious() && !isobserver(src)) || !(get_turf(src))|| attack_delayer.blocked())
 		return 0
 
@@ -1071,7 +1070,9 @@ Use this proc preferably at the end of an equipment loadout
 		I.showoff(src)
 		return 0
 
-	if(!(A in (view(get_turf(src)) + get_all_slots())))
+	if(!(A in (view(get_turf(src)) + get_all_slots())) || (usr.see_invisible < A.invisibility))
+		message_admins("<span class='warning'><B>WARNING: </B><A href='?src=\ref[usr];priv_msg=\ref[src]'>[key_name_admin(src)]</A> just pointed at something ([A]) they can't currently see. Are they using a macro to cheat?</span>", 1)
+		log_admin("[key_name_admin(src)] just pointed at something ([A]) they can't currently see. Are they using a macro to cheat?")
 		return 0
 
 	if(istype(A, /obj/effect/decal/point))


### PR DESCRIPTION
>People are abusing the macro point-to "thing" to point at wizards who are invisible.

>When you see the text "blizzard wizard fires a fireball at [src]" or "Butt-blaster mcGee says "AR'SE NATH"", simply make a macro of Point-To "[whatever the wizards name is]" then spam the command to constantly point towards the wizard if they're on screen, regardless of their visibility.

>This has prompted wizards such as Kavlax to name themselves "floor" so that, rather than being pointed at constantly through use of the aforementioned macro, it just points to the floor. Exploiters versus Exploiters.

#24029