### PR TITLE
Moves the captains spare to the safe

### DIFF
--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -215,3 +215,15 @@ obj/structure/safe/ex_act(severity)
 	..()
 	var/I = pick(loot_list)
 	new I(src)
+
+/obj/structure/safe/captain
+	name = "secure safe"
+	desc = "A wall-mounted secure safe"
+	icon = 'icons/obj/storage/storage.dmi'
+	icon_state = "safe"
+	density = 0
+
+/obj/structure/safe/captain/update_icon()
+	overlays.Cut()
+	if(open)
+		overlays.Add(image(icon = 'icons/obj/storage/storage.dmi', loc = src, icon_state = "safe0", "pixel_x" = pixel_x, "pixel_y" = pixel_y))


### PR DESCRIPTION
Also makes the safe not terrible by swapping it to the "ultra secure" version that's in the vault.

- [ ] Tell captains the tumbler positions required
- [ ] Tell other heads the tumbler positions, if a captain is not available at roundstart.
:cl:
 * balance: The captains spare is now located within the secure safe, located in the captains office. Captains will be informed of the tumbler positions required.