### PR TITLE
Fixes blocked Check

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -24,7 +24,7 @@ emp_act
 				return -1 // complete projectile permutation
 
 	if(check_shields(P.damage, P))
-		P.on_hit(src, 2)
+		P.on_hit(src, 100)
 		return 2
 	return (..(P , def_zone))
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -115,7 +115,7 @@ var/list/impact_master = list()
 	X.apply_effects(stun, weaken, paralyze, irradiate, stutter, eyeblur, drowsy, agony, blocked)
 
 /obj/item/projectile/proc/on_hit(var/atom/atarget, var/blocked = 0)
-	if(blocked >= 2)
+	if(blocked >= 100)
 		return 0//Full block
 	if(!isliving(atarget))
 		return 0

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -115,7 +115,7 @@ var/list/impact_master = list()
 	X.apply_effects(stun, weaken, paralyze, irradiate, stutter, eyeblur, drowsy, agony, blocked)
 
 /obj/item/projectile/proc/on_hit(var/atom/atarget, var/blocked = 0)
-	if(blocked >= 100)
+	if(blocked >= 2)
 		return 0//Full block
 	if(!isliving(atarget))
 		return 0


### PR DESCRIPTION
caused by an undocumented extra change in #23380 ; fixes #24179

why was this done? we may never know.

tested

🆑 
* bugfix: Effects which should normally fully block projectile collision, like the ninja projector, work again.