### PR TITLE
Cryogenics rework

### DIFF
--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -33,6 +33,7 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 	var/scan_level = 0 //Current scanner level
 	var/auto_eject = FALSE
 	var/dump_loc = 0 //1 is to the beaker, 0 is to the floor
+	var/controls = TRUE
 	component_parts = newlist(
 		/obj/item/weapon/circuitboard/cryo,
 		/obj/item/weapon/stock_parts/scanning_module,
@@ -298,6 +299,7 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 	data["injection_rate"] = inject_rate
 	data["injecting"] = injecting
 	data["auto_eject"] = auto_eject
+	data["controls"] = controls
 	data["dump_loc"] = dump_loc
 	data["scan_level"] = scan_level
 	// update the ui if it exists, returns null if no ui is passed/found
@@ -374,6 +376,9 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 		if(scan_level < 4)
 			return 0
 		auto_eject = !auto_eject
+
+	if(href_list["toggle_controls"])
+		controls = !controls
 
 	add_fingerprint(usr)
 	return 1 // update UIs attached to this object

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -168,7 +168,6 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 	if(air_contents)
 		temperature_archived = air_contents.temperature
 		heat_gas_contents()
-		expel_gas()
 
 	if(abs(temperature_archived-air_contents.temperature) > 1)
 		network.update = 1
@@ -279,7 +278,7 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 	var/list/cryo_contents = list()
 	if(reagents.total_volume)
 		for(var/datum/reagent/R in reagents.reagent_list)
-			cryo_contents.Add(list(list("name" = R.name, "volume" = R.volume))) //UI decomposes the top layer list, so has to be a list in a list
+			cryo_contents.Add(list(list("name" = R.name, "volume" = R.volume))) //List.Add merges lists, so to have a list in the list, the donor list needs to be list(list)
 	data["cryo_contents"] = cryo_contents
 	data["cryo_volume"] = reagents.total_volume
 	data["injection_rate"] = inject_rate
@@ -508,17 +507,6 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 	if(combined_heat_capacity > 0)
 		var/combined_energy = T20C*current_heat_capacity + air_heat_capacity*air_contents.temperature
 		air_contents.temperature = combined_energy/combined_heat_capacity
-
-/obj/machinery/atmospherics/unary/cryo_cell/proc/expel_gas()
-	if(air_contents.total_moles() < 1)
-		return
-//	var/datum/gas_mixture/expel_gas = new
-//	var/remove_amount = air_contents.total_moles()/50
-//	expel_gas = air_contents.remove(remove_amount)
-
-	// Just have the gas disappear to nowhere.
-	//expel_gas.temperature = T20C // Lets expel hot gas and see if that helps people not die as they are removed
-	//loc.assume_air(expel_gas)
 
 /obj/machinery/atmospherics/unary/cryo_cell/proc/go_out(var/exit = src.loc, var/ejector)
 	if(!occupant || ejecting)

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -32,6 +32,7 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 	var/running_bob_animation = FALSE // This is used to prevent threads from building up if update_icons is called multiple times
 	var/scan_level = 0 //Current scanner level
 	var/auto_eject = FALSE
+	var/dump_loc = 0 //1 is to the beaker, 0 is to the floor
 	component_parts = newlist(
 		/obj/item/weapon/circuitboard/cryo,
 		/obj/item/weapon/stock_parts/scanning_module,
@@ -297,6 +298,7 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 	data["injection_rate"] = inject_rate
 	data["injecting"] = injecting
 	data["auto_eject"] = auto_eject
+	data["dump_loc"] = dump_loc
 	data["scan_level"] = scan_level
 	// update the ui if it exists, returns null if no ui is passed/found
 	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)
@@ -357,10 +359,16 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 	if(href_list["toggle_inject"])
 		injecting = !injecting
 
+	if(href_list["toggle_dump"])
+		dump_loc = !dump_loc
+
 	if(href_list["dump_reagents"])
-		visible_message("<span class = 'warning'>\The [src] begins venting its chemical contents!</span>")
-		var/turf/T = get_step(loc, SOUTH)
-		splash_sub(reagents, T, reagents.total_volume)
+		if(dump_loc && beaker) //To the beaker
+			reagents.trans_to(beaker, reagents.total_volume)
+		else
+			visible_message("<span class = 'warning'>\The [src] begins venting its chemical contents!</span>")
+			var/turf/T = get_step(loc, SOUTH)
+			splash_sub(reagents, T, reagents.total_volume)
 
 	if(href_list["toggle_autoeject"])
 		if(scan_level < 4)

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -17,7 +17,8 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 	anchored = 1.0
 	layer = ABOVE_WINDOW_LAYER
 	plane = OBJ_PLANE
-
+	active_power_usage = 350
+	idle_power_usage = 0
 	var/on = 0
 	var/ejecting = 0
 	var/temperature_archived
@@ -58,13 +59,16 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 	create_reagents(1000)
 
 /obj/machinery/atmospherics/unary/cryo_cell/RefreshParts()
+	active_power_usage = initial(active_power_usage)
 	var/T = 0
 	for(var/obj/item/weapon/stock_parts/manipulator/MP in component_parts)
 		T += MP.rating-1
+		active_power_usage += 50 * (MP.rating-1)
 	inject_rate_max = initial(inject_rate_max) + (5*T)
 	T = 0
 	for(var/obj/item/weapon/stock_parts/scanning_module/SM in component_parts)
 		T += SM.rating-1
+		active_power_usage += 100 * (SM.rating-1)
 	scan_level = T
 
 /obj/machinery/atmospherics/unary/cryo_cell/initialize()
@@ -162,7 +166,7 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 
 	if(stat & NOPOWER)
 		on = 0
-
+		use_power = 0
 	if(!node1)
 		return
 	if(!on)
@@ -322,10 +326,12 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 			to_chat(usr, "<span class='bnotice'>Close the maintenance panel first.</span>")
 			return
 		on = 1
+		use_power = 2
 		update_icon()
 
 	if(href_list["switchOff"])
 		on = 0
+		use_power = 0
 		update_icon()
 
 	if(href_list["ejectBeaker"])
@@ -640,8 +646,10 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 	if(prob(50)) //Turn on/off
 		if(on)
 			on = 0
+			use_power = 0
 		else
 			on = 1
+			use_power = 2
 		update_icon()
 
 		message_admins("[key_name(L)] has turned \the [src] [on?"on":"off"]! [formatJumpTo(src)]")

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -347,6 +347,11 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 	if(href_list["toggle_inject"])
 		injecting = !injecting
 
+	if(href_list["dump_reagents"])
+		visible_message("<span class = 'warning'>\The [src] begins venting its chemical contents!</span>")
+		var/turf/T = get_step(loc, SOUTH)
+		splash_sub(reagents, T, reagents.total_volume)
+
 	add_fingerprint(usr)
 	return 1 // update UIs attached to this object
 

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -550,7 +550,7 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 		my_atom.on_reagent_change()
 	return 0
 
-/datum/reagents/proc/reaction(var/atom/A, var/method=TOUCH, var/volume_modifier=0)
+/datum/reagents/proc/reaction(var/atom/A, var/method=TOUCH, var/volume_modifier=0, var/remove_reagents = FALSE)
 
 	switch(method)
 		if(TOUCH)
@@ -559,7 +559,7 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 					if(isanimal(A))
 						R.reaction_animal(A, TOUCH, R.volume+volume_modifier)
 					else
-						R.reaction_mob(A, TOUCH, R.volume+volume_modifier)
+						R.reaction_mob(A, TOUCH, R.volume+volume_modifier, remove_reagents)
 				if(isturf(A))
 					R.reaction_turf(A, R.volume+volume_modifier)
 				if(istype(A, /obj))

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -40,7 +40,7 @@
 	var/density = 1 //(g/cm^3) Everything is water unless specified otherwise. round to 2dp
 	var/specheatcap = 1 //how much energy in joules it takes to heat this thing up by 1 degree (J/g). round to 2dp
 
-/datum/reagent/proc/reaction_mob(var/mob/living/M, var/method = TOUCH, var/volume)
+/datum/reagent/proc/reaction_mob(var/mob/living/M, var/method = TOUCH, var/volume, var/remove_reagents = FALSE)
 	set waitfor = 0
 
 	if(!holder)
@@ -76,7 +76,8 @@
 			if(prob(chance) && !block)
 				if(M.reagents)
 					M.reagents.add_reagent(self.id, self.volume/2) //Hardcoded, transfer half of volume
-					self.holder.remove_reagent(self.id, self.volume/2) //Hardcoded, removes half of volume
+					if(remove_reagents)
+						self.holder.remove_reagent(self.id, self.volume/2) //Hardcoded, removes half of volume
 
 	if (M.mind)
 		for (var/role in M.mind.antag_roles)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -76,6 +76,7 @@
 			if(prob(chance) && !block)
 				if(M.reagents)
 					M.reagents.add_reagent(self.id, self.volume/2) //Hardcoded, transfer half of volume
+					self.holder.remove_reagent(self.id, self.volume/2) //Hardcoded, removes half of volume
 
 	if (M.mind)
 		for (var/role in M.mind.antag_roles)
@@ -6621,7 +6622,7 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 	name = "Wake-Up Call"
 	id = SECCOFFEE
 	description = "All the essentials."
-	
+
 /datum/reagent/drink/coffee/seccoffee/on_mob_life(var/mob/living/M)
 	..()
 	if(ishuman(M))

--- a/nano/templates/cryo.tmpl
+++ b/nano/templates/cryo.tmpl
@@ -82,7 +82,7 @@ Used In File(s): \code\game\machinery\cryo.dm
 		{{:helper.link('Eject Occupant', 'arrowreturnthick-1-s', {'ejectOccupant' : 1}, data.hasOccupant ? null : 'disabled')}}
 	</div>
 </div>
-<div class="item">&nbsp;</div>
+<br>
 <div class="item">
 	<div class="itemLabel">
 		Beaker:
@@ -102,25 +102,22 @@ Used In File(s): \code\game\machinery\cryo.dm
 	<div class="itemContent" style="width: 26%;">
 		{{:helper.link('Eject Beaker', 'eject', {'ejectBeaker' : 1}, data.isBeakerLoaded ? null : 'disabled')}}
 	</div>
+</div>
+<br>
 <div class="item">
-	<div class="itemlabel">
-	 Cell contents:
-  </div>
+	<div class="itemLabel">
+		Cell contents:
+	</div>
 	<div class="itemContent" style="width: 40%;">
 		{{for data.cryo_contents}}
-		<div class="item">
-			<div class="itemLabelNarrow">
-				{{value.name}}:{{value.volume}}
-			</div>
-			<div class="itemContent">
-				{{:helper.link('Extract '+value.name, 'shuffle', {'dish_effect_to_buffer': value.stage})}}
-			</div>
-		</div>
+		<span class="highlight">{{value.name}}:{{value.volume}}</span><br>
 		{{empty}}
-			Cell is empty.
+			<span class="bad">Cell is empty.</span>
 		{{/for}}
 	</div>
-</div>
+	<div class="itemContent" style="width: auto;">
+		{{:helper.link("injection rate:"+data.injection_rate+" units", 'carat-2-n-s', {'set_inject_rate': 1})}}
+	</div>
 </div>
 {{if data.ejecting}}
 	<div class="mask">

--- a/nano/templates/cryo.tmpl
+++ b/nano/templates/cryo.tmpl
@@ -117,6 +117,9 @@ Used In File(s): \code\game\machinery\cryo.dm
 		{{/for}}
 		</tbody></table>
 	</div>
+	<div class="itemContent" style="width: 26%;">
+		{{:helper.link("Dump cell contents", null, {'dump_reagents': 1}, data.cryo_volume ? null : 'disabled')}}
+	</div>
 </div>
 <br>
 <div class="item">
@@ -124,20 +127,34 @@ Used In File(s): \code\game\machinery\cryo.dm
 		Controls:
 	</div>
 	<div class="itemContent" style = "width: 40%;">
-		<div class="statusValue average">Injection status:</div>
-		{{:helper.link(data.injecting==1?"Active":"Inactive", null, {'toggle_inject': 1})}}
+		<div class="statusValue average">
+			Injection status:
+			<div class="floatRight">
+				{{:helper.link(data.injecting==1?"Active":"Inactive", null, {'toggle_inject': 1})}}
+			</div>
 		<br>
 		{{if data.scan_level >= 2}}
-			<div class="statusValue average">Injection rate (units):
-			{{:helper.link(data.injection_rate, 'carat-2-n-s', {'set_inject_rate': 1})}}
-			</div><br>
+					Injection rate (units):
+				<div class="floatRight">
+					{{:helper.link(data.injection_rate, 'carat-2-n-s', {'set_inject_rate': 1})}}
+				</div>
+				<br>
 		{{/if}}
-		{{:helper.link("Dump cell contents", null, {'dump_reagents': 1}, data.cryo_volume ? null : 'disabled')}}
+				Current dump location:
+			<div class="floatRight">
+				{{:helper.link(data.dump_loc==1?"Beaker":"Vicinity", null, {'toggle_dump': 1})}}
+		  </div>
+			<br>
 		{{if data.scan_level >= 4}}
-			<div class="statusValue average">Auto ejection:</div>
-			{{:helper.link(data.auto_eject?"Active":"Inactive", null, {'toggle_autoeject': 1})}}
+					Auto ejection:
+				<div class="floatRight">
+					{{:helper.link(data.auto_eject?"Active":"Inactive", null, {'toggle_autoeject': 1})}}
+				</div>
+			<br>
 		{{/if}}
+		</div>
 	</div>
+</div>
 {{if data.ejecting}}
 	<div class="mask">
 		<div class="maskContent" style="margin: 160px 0">

--- a/nano/templates/cryo.tmpl
+++ b/nano/templates/cryo.tmpl
@@ -111,7 +111,7 @@ Used In File(s): \code\game\machinery\cryo.dm
 	<div class="itemContent" style="width: 40%;">
 		<table width="100%"><tbody>
 		{{for data.cryo_contents}}
-			<tr><td><span class="highlight">{{:value.name}} - {{:value.volume}} units</span>
+			<tr><td><span class="highlight">{{:value.name}}{{if data.scan_level > 1}} - {{:value.volume}} units{{/if}}</span>
 		{{empty}}
 			<span class="bad">Cell is empty</span>
 		{{/for}}

--- a/nano/templates/cryo.tmpl
+++ b/nano/templates/cryo.tmpl
@@ -102,6 +102,25 @@ Used In File(s): \code\game\machinery\cryo.dm
 	<div class="itemContent" style="width: 26%;">
 		{{:helper.link('Eject Beaker', 'eject', {'ejectBeaker' : 1}, data.isBeakerLoaded ? null : 'disabled')}}
 	</div>
+<div class="item">
+	<div class="itemlabel">
+	 Cell contents:
+  </div>
+	<div class="itemContent" style="width: 40%;">
+		{{for data.cryo_contents}}
+		<div class="item">
+			<div class="itemLabelNarrow">
+				{{value.name}}:{{value.volume}}
+			</div>
+			<div class="itemContent">
+				{{:helper.link('Extract '+value.name, 'shuffle', {'dish_effect_to_buffer': value.stage})}}
+			</div>
+		</div>
+		{{empty}}
+			Cell is empty.
+		{{/for}}
+	</div>
+</div>
 </div>
 {{if data.ejecting}}
 	<div class="mask">

--- a/nano/templates/cryo.tmpl
+++ b/nano/templates/cryo.tmpl
@@ -124,37 +124,39 @@ Used In File(s): \code\game\machinery\cryo.dm
 <br>
 <div class="item">
 	<div class="itemLabel">
-		Controls:
+		Controls: {{:helper.link(data.controls==1?"Hide":"Show", null, {'toggle_controls': 1})}}
 	</div>
-	<div class="itemContent" style = "width: 40%;">
-		<div class="statusValue average">
-			Injection status:
-			<div class="floatRight">
+{{if data.controls}}
+		<div class="itemContent" style = "width: 40%;">
+			<div class="statusValue average">
+				Injection status:
+				<div class="floatRight">
 				{{:helper.link(data.injecting==1?"Active":"Inactive", null, {'toggle_inject': 1})}}
-			</div>
-		<br>
-		{{if data.scan_level >= 2}}
+				</div>
+			<br>
+			{{if data.scan_level >= 2}}
 					Injection rate (units):
-				<div class="floatRight">
+					<div class="floatRight">
 					{{:helper.link(data.injection_rate, 'carat-2-n-s', {'set_inject_rate': 1})}}
-				</div>
-				<br>
-		{{/if}}
+					</div>
+					<br>
+			{{/if}}
 				Current dump location:
-			<div class="floatRight">
-				{{:helper.link(data.dump_loc==1?"Beaker":"Vicinity", null, {'toggle_dump': 1})}}
-		  </div>
-			<br>
-		{{if data.scan_level >= 4}}
-					Auto ejection:
 				<div class="floatRight">
+				{{:helper.link(data.dump_loc==1?"Beaker":"Vicinity", null, {'toggle_dump': 1})}}
+			  </div>
+				<br>
+			{{if data.scan_level >= 4}}
+					Auto ejection:
+					<div class="floatRight">
 					{{:helper.link(data.auto_eject?"Active":"Inactive", null, {'toggle_autoeject': 1})}}
-				</div>
-			<br>
-		{{/if}}
+					</div>
+				<br>
+			{{/if}}
+			</div>
 		</div>
 	</div>
-</div>
+{{/if}}
 {{if data.ejecting}}
 	<div class="mask">
 		<div class="maskContent" style="margin: 160px 0">

--- a/nano/templates/cryo.tmpl
+++ b/nano/templates/cryo.tmpl
@@ -109,21 +109,13 @@ Used In File(s): \code\game\machinery\cryo.dm
 		Cell contents:
 	</div>
 	<div class="itemContent" style="width: 40%;">
-		{{if data.scan_level > 1}}
-			{{if data.cryo_volume > 0}}
-				<span class="highlight">{{:data.cryo_volume}} units remaining.</span><br>
-			{{else}}
-				<span class="bad">Cell is empty</span>
-			{{/if}}
-		{{else}}
-			<table width="100%"><tbody>
-			{{for data.cryo_contents}}
-				<tr><td><span class="highlight">{{:value.name}} - {{:value.volume}} units</span>
-			{{empty}}
-				<span class="bad">Cell is empty</span>
-			{{/for}}
-			</tbody></table>
-		{{/if}}
+		<table width="100%"><tbody>
+		{{for data.cryo_contents}}
+			<tr><td><span class="highlight">{{:value.name}} - {{:value.volume}} units</span>
+		{{empty}}
+			<span class="bad">Cell is empty</span>
+		{{/for}}
+		</tbody></table>
 	</div>
 </div>
 <br>
@@ -140,6 +132,7 @@ Used In File(s): \code\game\machinery\cryo.dm
 			{{:helper.link(data.injection_rate, 'carat-2-n-s', {'set_inject_rate': 1})}}
 			</div><br>
 		{{/if}}
+		{{:helper.link("Dump cell contents", null, {'dump_reagents': 1}, data.cryo_volume ? null : 'disabled')}}
 	</div>
 {{if data.ejecting}}
 	<div class="mask">

--- a/nano/templates/cryo.tmpl
+++ b/nano/templates/cryo.tmpl
@@ -127,12 +127,16 @@ Used In File(s): \code\game\machinery\cryo.dm
 		<div class="statusValue average">Injection status:</div>
 		{{:helper.link(data.injecting==1?"Active":"Inactive", null, {'toggle_inject': 1})}}
 		<br>
-		{{if data.scan_level > 1}}
+		{{if data.scan_level >= 2}}
 			<div class="statusValue average">Injection rate (units):
 			{{:helper.link(data.injection_rate, 'carat-2-n-s', {'set_inject_rate': 1})}}
 			</div><br>
 		{{/if}}
 		{{:helper.link("Dump cell contents", null, {'dump_reagents': 1}, data.cryo_volume ? null : 'disabled')}}
+		{{if data.scan_level >= 4}}
+			<div class="statusValue average">Auto ejection:</div>
+			{{:helper.link(data.auto_eject?"Active":"Inactive", null, {'toggle_autoeject': 1})}}
+		{{/if}}
 	</div>
 {{if data.ejecting}}
 	<div class="mask">

--- a/nano/templates/cryo.tmpl
+++ b/nano/templates/cryo.tmpl
@@ -109,11 +109,13 @@ Used In File(s): \code\game\machinery\cryo.dm
 		Cell contents:
 	</div>
 	<div class="itemContent" style="width: 40%;">
+		<table width="100%"><tbody>
 		{{for data.cryo_contents}}
-		<span class="highlight">{{value.name}}:{{value.volume}}</span><br>
+			<tr><td><span class="highlight">{{:value.name} - :{{:value.volume}} units</span>
 		{{empty}}
-			<span class="bad">Cell is empty.</span>
+			<span class="bad">Beaker is empty</span>
 		{{/for}}
+		</tbody></table>
 	</div>
 	<div class="itemContent" style="width: auto;">
 		{{:helper.link("injection rate:"+data.injection_rate+" units", 'carat-2-n-s', {'set_inject_rate': 1})}}

--- a/nano/templates/cryo.tmpl
+++ b/nano/templates/cryo.tmpl
@@ -109,18 +109,38 @@ Used In File(s): \code\game\machinery\cryo.dm
 		Cell contents:
 	</div>
 	<div class="itemContent" style="width: 40%;">
-		<table width="100%"><tbody>
-		{{for data.cryo_contents}}
-			<tr><td><span class="highlight">{{:value.name} - :{{:value.volume}} units</span>
-		{{empty}}
-			<span class="bad">Beaker is empty</span>
-		{{/for}}
-		</tbody></table>
-	</div>
-	<div class="itemContent" style="width: auto;">
-		{{:helper.link("injection rate:"+data.injection_rate+" units", 'carat-2-n-s', {'set_inject_rate': 1})}}
+		{{if data.scan_level > 1}}
+			{{if data.cryo_volume > 0}}
+				<span class="highlight">{{:data.cryo_volume}} units remaining.</span><br>
+			{{else}}
+				<span class="bad">Cell is empty</span>
+			{{/if}}
+		{{else}}
+			<table width="100%"><tbody>
+			{{for data.cryo_contents}}
+				<tr><td><span class="highlight">{{:value.name}} - {{:value.volume}} units</span>
+			{{empty}}
+				<span class="bad">Cell is empty</span>
+			{{/for}}
+			</tbody></table>
+		{{/if}}
 	</div>
 </div>
+<br>
+<div class="item">
+	<div class="itemLabel">
+		Controls:
+	</div>
+	<div class="itemContent" style = "width: 40%;">
+		<div class="statusValue average">Injection status:</div>
+		{{:helper.link(data.injecting==1?"Active":"Inactive", null, {'toggle_inject': 1})}}
+		<br>
+		{{if data.scan_level > 1}}
+			<div class="statusValue average">Injection rate (units):
+			{{:helper.link(data.injection_rate, 'carat-2-n-s', {'set_inject_rate': 1})}}
+			</div><br>
+		{{/if}}
+	</div>
 {{if data.ejecting}}
 	<div class="mask">
 		<div class="maskContent" style="margin: 160px 0">


### PR DESCRIPTION
Fixes cryo duping reagents, courtesy of reagents.reaction(mob, TOUCH) just adding more reagents without removing the reagents it is adding to the person. Closes #17345 

Because of this, Cryo would run through all of its chemicals within seconds, so now it has its own buffer reagents that the person is affected by. The beaker you place within cryo steadily injects reagents into cryo itself. Injection can be toggled, and the rate of injection can be controlled at a higher level of scanning module.

Reagents are not consumed from this buffer unless they can actively get to the user (Clothing with reagent permeability prevention will prevent consumption of the reagent.) so putting somebody in a hardsuit into cryo will do nothing to the buffer. The buffer itself, due to how touch reagents works, transfers half of itself every time it processes the occupant.

Cryo no longer passively heals brute, burn, oxygen deprivation, and toxin damage for free. 

:cl:
 * rscadd: Cryogenic tubes have now been reworked.
 * tweak: Cryogenics no longer passively heal brute, burn, oxygen deprivation, and toxin damage for free.
 * tweak: Cryogenics no longer duplicate chems put within them.
 * rscadd: The beaker placed within the cryo tube now steadily injects reagents into the tube itself, which are transferred to the occupant through touch. If the occupant is wearing impermeable clothing, they will not be consumed.
 * tweak: Cryo now consumes power.
 * rscadd: Upgrading the internal components of cryo now enables different abilities and increases active power consumption. Tier 2 scanning modules enables the ability to tweak injection rate, maximum injection rate depending on manipulator tier, Tier 3 scanning modules enables the cryo being able to auto-eject occupants at full health. Tier 4 scanning modules means cryo no longer stuns the occupant.