### PR TITLE
Atmos machines now actually use power

### DIFF
--- a/code/controllers/subsystem/pipenet.dm
+++ b/code/controllers/subsystem/pipenet.dm
@@ -54,6 +54,9 @@ var/event/on_pipenet_tick = new
 		if (atmosmachinery.process() && MC_TICK_CHECK)
 			return
 
+		if (atmosmachinery.use_power)
+			atmosmachinery.auto_use_power()
+
 	while (currentrun_pipenets.len)
 		var/datum/pipe_network/pipeNetwork = currentrun_pipenets[currentrun_pipenets.len]
 		currentrun_pipenets.len--


### PR DESCRIPTION
I can understand moving them to their own sub, but in doing so removing them actually using power seems like quite the oversight

:cl:
 * rscadd: Atmospherics machinery should now actually consume power. Not many atmospheric machines have power consumption enabled individually, so this shouldn't affect anything right now.