### PR TITLE
GC Fixes

### DIFF
--- a/code/controllers/garbage.dm
+++ b/code/controllers/garbage.dm
@@ -1,6 +1,6 @@
 #define GC_COLLECTIONS_PER_TICK 300 // Was 100.
 #define GC_COLLECTION_TIMEOUT (30 SECONDS)
-#define GC_FORCE_DEL_PER_TICK 5 //Was 60, but even 5 is enough to notice the lag. Holy fuck these are slow.
+#define GC_FORCE_DEL_PER_TICK 2 //Was 60, but even 5 is enough to notice the lag. Holy fuck these are slow.
 
 //#define GC_DEBUG
 //#define GC_FINDREF

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -19,6 +19,7 @@
 	var/pass_flags = 0
 
 	var/sound_override = 0 //Do we make a sound when bumping into something?
+	var/hard_deleted
 	var/pressure_resistance = ONE_ATMOSPHERE
 	var/obj/effect/overlay/chain/tether = null
 	var/tether_pull = 0
@@ -104,6 +105,19 @@
 
 	for(var/atom/movable/AM in src)
 		qdel(AM)
+
+	..()
+
+/atom/movable/Del()
+	if (gcDestroyed)
+		if (hard_deleted)
+			delete_profile("[type]", 1)
+		else
+			delete_profile("[type]", 2)
+
+	else // direct del calls or nulled explicitly.
+		delete_profile("[type]", 0)
+		Destroy()
 
 	..()
 


### PR DESCRIPTION
* Undefines `/datum/Del()` because it's slow
  * This also breaks del profiling for datums (except hard del profiling), but there's no way around that
* Makes what was the failsafe into the only method by which things are removed from the queue, at Clusterfack's recommendation
* Makes what was the failsafe actually work
  * Whoops
* Reduces the cap on hard dels per tick from 60 to ~~5~~ 2 because they are so incredibly slow you can even feel the game hiccup when 5 happen at once