### PR TITLE
Adds light floortile crate to order from cargo.

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -257,6 +257,15 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	containername = "wooden planks crate"
 	group = "Supplies"
 
+/datum/supply_packs/lightile
+	name = "50 light tiles"
+	contains = list(/obj/item/stack/tile/light)
+	amount = 50
+	cost = 20
+	containertype = /obj/structure/closet/crate/basic
+	containername = "light tiles crate"
+	group = "Supplies"
+
 /datum/supply_packs/carpet
 	name = "30 carpet tiles"
 	contains = list(/obj/item/stack/tile/carpet)


### PR DESCRIPTION
This should help speed up bar makeovers. Price is 20 since you do need metal and glass to make floor tiles.

100% Tested
![tiles](https://user-images.githubusercontent.com/38330373/65440085-9273b900-ddfe-11e9-9d24-f38d6d756c85.png)

:cl: 

- tweak: You can now order stacks of floor lights from cargo.