### PR TITLE
Hotfix changed snow tiles staying in global snow list, blizzard holders acting on non-snowtiles

### DIFF
--- a/code/game/turfs/unsimulated/snow.dm
+++ b/code/game/turfs/unsimulated/snow.dm
@@ -26,7 +26,7 @@
 	var/list/snowsound = list('sound/misc/snow1.ogg', 'sound/misc/snow2.ogg', 'sound/misc/snow3.ogg', 'sound/misc/snow4.ogg', 'sound/misc/snow5.ogg', 'sound/misc/snow6.ogg')
 
 /turf/unsimulated/floor/snow/ChangeTurf(var/turf/N, var/tell_universe=1, var/force_lighting_update = 0, var/allow = 1)
-	global_snowtiles = null
+	global_snowtiles -= src
 	if(snowprint_parent)
 		qdel(snowprint_parent)
 	if(blizzard_parent)

--- a/code/game/turfs/unsimulated/snow.dm
+++ b/code/game/turfs/unsimulated/snow.dm
@@ -26,6 +26,7 @@
 	var/list/snowsound = list('sound/misc/snow1.ogg', 'sound/misc/snow2.ogg', 'sound/misc/snow3.ogg', 'sound/misc/snow4.ogg', 'sound/misc/snow5.ogg', 'sound/misc/snow6.ogg')
 
 /turf/unsimulated/floor/snow/ChangeTurf(var/turf/N, var/tell_universe=1, var/force_lighting_update = 0, var/allow = 1)
+	global_snowtiles = null
 	if(snowprint_parent)
 		qdel(snowprint_parent)
 	if(blizzard_parent)
@@ -136,6 +137,10 @@
 	plane = ABOVE_TURF_PLANE
 	mouse_opacity = 0
 	var/turf/unsimulated/floor/snow/parent
+
+/obj/effect/blizzard_holder/Destroy()
+	parent = null
+	..()
 
 /obj/effect/blizzard_holder/proc/UpdateSnowfall()
 	if(!snow_state_to_texture["[parent.snow_state]"])


### PR DESCRIPTION
[hotfix]
Should fix two runtimes related to snow tiles.
`[01:23:18] Runtime in snow.dm,141: undefined variable /turf/space/var/snow_state`
This one is because `ChangeTurf` did not remove the tile from `global_snowtiles`.
`[01:29:17] Runtime in snow.dm,70: Cannot execute null.UpdateSnowfall().`
This one, as far as I can tell, involves blizzard_holders keeping a ref to their parent when it shouldn't. I'm really not sure, but I included a possible fix regardless.

Side note, this code is an uncommented mess and it's gross.