### PR TITLE
Fix powersink Destroy() failing due to bad assumption

### DIFF
--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -23,116 +23,116 @@
 
 	var/obj/structure/cable/attached		// the attached cable
 
-	attackby(var/obj/item/I, var/mob/user)
-		if(I.is_screwdriver(user))
-			if(mode == 0)
-				var/turf/T = loc
-				if(isturf(T) && !T.intact)
-					attached = locate() in T
-					if(!attached)
-						to_chat(user, "No exposed cable here to attach to.")
-						return
-					else
-						attached.attached = src
-						anchored = 1
-						mode = 1
-						to_chat(user, "You attach the device to the cable.")
-						for(var/mob/M in viewers(user))
-							if(M == user)
-								continue
-							to_chat(M, "[user] attaches the power sink to the cable.")
-						return
+/obj/item/device/powersink/attackby(var/obj/item/I, var/mob/user)
+	if(I.is_screwdriver(user))
+		if(mode == 0)
+			var/turf/T = loc
+			if(isturf(T) && !T.intact)
+				attached = locate() in T
+				if(!attached)
+					to_chat(user, "No exposed cable here to attach to.")
+					return
 				else
-					to_chat(user, "Device must be placed over an exposed cable to attach to it.")
+					attached.attached = src
+					anchored = 1
+					mode = 1
+					to_chat(user, "You attach the device to the cable.")
+					for(var/mob/M in viewers(user))
+						if(M == user)
+							continue
+						to_chat(M, "[user] attaches the power sink to the cable.")
 					return
 			else
-				if (mode == 2)
-					processing_objects.Remove(src) // Now the power sink actually stops draining the station's power if you unhook it. --NeoFite
-				anchored = 0
-				mode = 0
-				to_chat(user, "You detach the device from the cable.")
-				attached.attached = null
-				attached = null
-				for(var/mob/M in viewers(user))
-					if(M == user)
-						continue
-					to_chat(M, "[user] detaches the power sink from the cable.")
-				set_light(0)
-				icon_state = "powersink0"
-
+				to_chat(user, "Device must be placed over an exposed cable to attach to it.")
 				return
 		else
-			..()
+			if (mode == 2)
+				processing_objects.Remove(src) // Now the power sink actually stops draining the station's power if you unhook it. --NeoFite
+			anchored = 0
+			mode = 0
+			to_chat(user, "You detach the device from the cable.")
+			attached.attached = null
+			attached = null
+			for(var/mob/M in viewers(user))
+				if(M == user)
+					continue
+				to_chat(M, "[user] detaches the power sink from the cable.")
+			set_light(0)
+			icon_state = "powersink0"
 
-	Destroy()
-		set_light(0)
-		processing_objects.Remove(src)
-		attached.attached = null
-		attached = null
+			return
+	else
 		..()
 
-	attack_paw()
-		return
+/obj/item/device/powersink/Destroy()
+	set_light(0)
+	processing_objects.Remove(src)
+	attached?.attached = null
+	attached = null
+	..()
 
-	attack_ai()
-		return
+/obj/item/device/powersink/attack_paw()
+	return
 
-	attack_hand(var/mob/user)
-		switch(mode)
-			if(0)
-				..()
+/obj/item/device/powersink/attack_ai()
+	return
 
-			if(1)
-				to_chat(user, "You activate the device!")
-				for(var/mob/M in viewers(user))
-					if(M == user)
-						continue
-					to_chat(M, "[user] activates the power sink!")
-				mode = 2
-				icon_state = "powersink1"
-				playsound(src, 'sound/effects/phasein.ogg', 30, 1)
-				processing_objects.Add(src)
+/obj/item/device/powersink/attack_hand(var/mob/user)
+	switch(mode)
+		if(0)
+			..()
 
-			if(2)  //This switch option wasn't originally included. It exists now. --NeoFite
-				to_chat(user, "You deactivate the device!")
-				for(var/mob/M in viewers(user))
-					if(M == user)
-						continue
-					to_chat(M, "[user] deactivates the power sink!")
-				mode = 1
-				set_light(0)
-				icon_state = "powersink0"
-				playsound(src, 'sound/effects/teleport.ogg', 50, 1)
-				processing_objects.Remove(src)
+		if(1)
+			to_chat(user, "You activate the device!")
+			for(var/mob/M in viewers(user))
+				if(M == user)
+					continue
+				to_chat(M, "[user] activates the power sink!")
+			mode = 2
+			icon_state = "powersink1"
+			playsound(src, 'sound/effects/phasein.ogg', 30, 1)
+			processing_objects.Add(src)
 
-	process()
-		if(attached)
-			var/datum/powernet/PN = attached.get_powernet()
-			if(PN)
-				set_light(12)
+		if(2)  //This switch option wasn't originally included. It exists now. --NeoFite
+			to_chat(user, "You deactivate the device!")
+			for(var/mob/M in viewers(user))
+				if(M == user)
+					continue
+				to_chat(M, "[user] deactivates the power sink!")
+			mode = 1
+			set_light(0)
+			icon_state = "powersink0"
+			playsound(src, 'sound/effects/teleport.ogg', 50, 1)
+			processing_objects.Remove(src)
 
-				// found a powernet, so drain up to max power from it
+/obj/item/device/powersink/process()
+	if(attached)
+		var/datum/powernet/PN = attached.get_powernet()
+		if(PN)
+			set_light(12)
 
-				var/drained = min ( drain_rate, PN.avail )
-				PN.load += drained
-				power_drained += drained
+			// found a powernet, so drain up to max power from it
 
-				// if tried to drain more than available on powernet
-				// now look for APCs and drain their cells
-				if(drained < drain_rate)
-					for(var/obj/machinery/power/terminal/T in PN.nodes)
-						if(istype(T.master, /obj/machinery/power/apc))
-							var/obj/machinery/power/apc/A = T.master
-							if(A.operating && A.cell)
-								A.cell.charge = max(0, A.cell.charge - 50)
-								power_drained += 50
-								if(A.charging == 2)
-									A.charging = 1
+			var/drained = min ( drain_rate, PN.avail )
+			PN.load += drained
+			power_drained += drained
+
+			// if tried to drain more than available on powernet
+			// now look for APCs and drain their cells
+			if(drained < drain_rate)
+				for(var/obj/machinery/power/terminal/T in PN.nodes)
+					if(istype(T.master, /obj/machinery/power/apc))
+						var/obj/machinery/power/apc/A = T.master
+						if(A.operating && A.cell)
+							A.cell.charge = max(0, A.cell.charge - 50)
+							power_drained += 50
+							if(A.charging == 2)
+								A.charging = 1
 
 
-			if(power_drained > max_power * 0.95)
-				playsound(src, 'sound/effects/screech.ogg', 100, 1, 1)
-			if(power_drained >= max_power)
-				processing_objects.Remove(src)
-				explosion(src.loc, 3,6,9,12)
-				qdel(src)
+		if(power_drained > max_power * 0.95)
+			playsound(src, 'sound/effects/screech.ogg', 100, 1, 1)
+		if(power_drained >= max_power)
+			processing_objects.Remove(src)
+			explosion(src.loc, 3,6,9,12)
+			qdel(src)


### PR DESCRIPTION
[hotfix]
This fixes powersinks runtiming on `Destroy` when they were not attached to a cable, which would cause it to survive destruction indefinitely, since the error would also prevent the parent call to `Destroy`

Since I'm apparently the first person to touch this file since absolute pathing, and I updated it to use abs pathing, it's got a lot of whitespace changes.

Fixes #22502