### PR TITLE
adds holiday-specific items to vending machines

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -359,7 +359,7 @@ var/global/num_vending_terminals = 1
 		if (R.assignedholiday == Holiday)
 			holiday_records += R
 			R.category=CAT_HOLIDAY
-			R.display_color = pick("orange")
+			R.display_color = pick("orange", "purple", "navy")
 		else
 			R.category = CAT_NORMAL
 			product_records.Add(R)
@@ -799,7 +799,8 @@ var/global/num_vending_terminals = 1
 				categories["default"] += R
 
 		if(Holiday && holiday_records.len)
-			dat += {"<FONT color = "pink"><B>&nbsp;&nbsp;holiday specials</B></font>:<br>"}
+			var/col = pick("orange", "purple", "navy")
+			dat += {"<FONT color = [col]><B>&nbsp;&nbsp;[Holiday] specials</B></font>:<br>"}
 			for (var/datum/data/vending_product/R in holiday_records)
 				dat += GetProductLine(R)
 			dat += "<br>"
@@ -1336,6 +1337,7 @@ var/global/num_vending_terminals = 1
 		/obj/item/weapon/reagent_containers/food/drinks/coffee = 25,
 		/obj/item/weapon/reagent_containers/food/drinks/tea = 25,
 		/obj/item/weapon/reagent_containers/food/drinks/h_chocolate = 25,
+		/obj/item/weapon/reagent_containers/food/drinks/drinkingglass/irishcoffee/ = 25,
 		)
 	premium = list(
 		/obj/item/weapon/reagent_containers/food/drinks/tomatosoup = 3,
@@ -1347,7 +1349,11 @@ var/global/num_vending_terminals = 1
 		/obj/item/weapon/reagent_containers/food/drinks/coffee = 25,
 		/obj/item/weapon/reagent_containers/food/drinks/tea = 25,
 		/obj/item/weapon/reagent_containers/food/drinks/h_chocolate = 25,
+		/obj/item/weapon/reagent_containers/food/drinks/drinkingglass/irishcoffee/ = 40,
 		)
+	specials = list(
+		/obj/item/weapon/reagent_containers/food/drinks/drinkingglass/irishcoffee/ = ST_PATRICKS_DAY,
+	)
 
 	pack = /obj/structure/vendomatpack/coffee
 
@@ -1386,6 +1392,7 @@ var/global/num_vending_terminals = 1
 		/obj/item/weapon/reagent_containers/food/snacks/cheesiehonkers = 6,
 		/obj/item/weapon/reagent_containers/food/snacks/chococoin/wrapped = 2,
 		/obj/item/weapon/storage/fancy/cigarettes/gum = 10,
+		/obj/item/weapon/reagent_containers/food/snacks/grown/potato = 100,
 		/obj/item/weapon/reagent_containers/food/snacks/chocolatebar/wrapped/valentine = 2,
 		)
 	contraband = list(
@@ -1405,13 +1412,15 @@ var/global/num_vending_terminals = 1
 		/obj/item/weapon/reagent_containers/food/snacks/chococoin/wrapped = 75,
 		/obj/item/weapon/reagent_containers/food/snacks/magbites = 110,
 		/obj/item/weapon/storage/fancy/cigarettes/gum = 10,
+		/obj/item/weapon/reagent_containers/food/snacks/grown/potato = 1,
 		/obj/item/weapon/reagent_containers/food/snacks/chocolatebar/wrapped/valentine = 100,
 		)
 	vouched = list(
 		/obj/item/weapon/reagent_containers/food/snacks/donkpocket/self_heating = 2
 		)
 	specials = list(
-		/obj/item/weapon/reagent_containers/food/snacks/chocolatebar/wrapped/valentine = VALENTINES_DAY
+		/obj/item/weapon/reagent_containers/food/snacks/grown/potato = ST_PATRICKS_DAY,
+		/obj/item/weapon/reagent_containers/food/snacks/chocolatebar/wrapped/valentine = VALENTINES_DAY,
 		)
 
 	pack = /obj/structure/vendomatpack/snack

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1,7 +1,8 @@
-#define CAT_NORMAL 1
-#define CAT_HIDDEN 2
-#define CAT_COIN   3
-#define CAT_VOUCH  4
+#define CAT_NORMAL 	1
+#define CAT_HIDDEN 	2
+#define CAT_COIN   	3
+#define CAT_VOUCH  	4
+#define CAT_HOLIDAY	5
 
 //Maximum price you can assign to an item
 #define MAX_ITEM_PRICE 1000000000
@@ -34,7 +35,8 @@ var/global/num_vending_terminals = 1
 	var/list/contraband	= list()	// list(/type/path = amount,/type/path2 = amount2)
 	var/list/premium 	= list()	// No specified amount = only one in stock
 	var/list/prices     = list()	// Prices for each item, list(/type/path = price), items not in the list don't have a price.
-	var/list/vouched     = list()	//For voucher-only items. These aren't available in any way without the appropriate voucher.
+	var/list/vouched    = list()	//For voucher-only items. These aren't available in any way without the appropriate voucher.
+	var/list/specials    = list()	//Allows you to lock items to certain holidays, otherwise they don't show up
 
 	var/list/custom_stock = list() 	//Custom items are stored inside our contents, but we keep track of them here so we don't vend our component parts or anything.
 
@@ -44,6 +46,7 @@ var/global/num_vending_terminals = 1
 	var/list/hidden_records = list()
 	var/list/coin_records = list()
 	var/list/voucher_records = list()
+	var/list/holiday_records = list()
 	var/vend_reply				//Thank you for shopping!
 	var/last_reply = 0
 	var/last_slogan = 0			//When did we last pitch?
@@ -89,10 +92,11 @@ var/global/num_vending_terminals = 1
 	var/original_amount = 0 //NON-CUSTOM ONLY - How many items of this product the recharge pack starts with
 	var/amount = 0
 	var/price = 0
-	var/display_color = "blue"
-	var/category = CAT_NORMAL //available by default, contraband, or premium (requires a coin)
+	var/display_color = null //string, "red", "green", "blue", etc
+	var/category = CAT_NORMAL //available on holidays, by default, contraband, or premium (requires a coin)
 	var/subcategory = null
 	var/mini_icon = null
+	var/assignedholiday = null //Add an item to the 'specials' list to make it only show up on a certain holiday
 
 /* TODO: Add this to deconstruction for vending machines
 /obj/item/compressed_vend
@@ -330,6 +334,7 @@ var/global/num_vending_terminals = 1
 	for(var/typepath in productlist)
 		var/amount = productlist[typepath]
 		var/price = prices[typepath]
+		var/special = specials[typepath]
 
 		if (isnull(amount))
 			amount = 1
@@ -339,7 +344,9 @@ var/global/num_vending_terminals = 1
 		R.amount = amount
 		R.original_amount = amount
 		R.price = price
-		R.display_color = pick("red", "blue", "green")
+		R.assignedholiday = special
+		if (!R.display_color)
+			R.display_color = pick("red", "blue", "green")
 		if (hidden)
 			R.category=CAT_HIDDEN
 			hidden_records  += R
@@ -349,6 +356,10 @@ var/global/num_vending_terminals = 1
 		else if (voucher_only)
 			voucher_records += R
 			R.category=CAT_VOUCH
+		if (R.assignedholiday == Holiday)
+			holiday_records += R
+			R.category=CAT_HOLIDAY
+			R.display_color = pick("orange")
 		else
 			R.category = CAT_NORMAL
 			product_records.Add(R)
@@ -363,6 +374,7 @@ var/global/num_vending_terminals = 1
 	datum_products |= hidden_records
 	datum_products |= coin_records
 	datum_products |= voucher_records
+	datum_products |= holiday_records
 	datum_products |= product_records
 	for(var/datum/data/vending_product/product in datum_products)
 		if(product.product_path == this_type)
@@ -635,6 +647,8 @@ var/global/num_vending_terminals = 1
 /obj/machinery/vending/proc/GetProductIndex(var/datum/data/vending_product/P)
 	var/list/plist
 	switch(P.category)
+		if(CAT_HOLIDAY)
+			plist=holiday_records
 		if(CAT_NORMAL)
 			plist=product_records
 		if(CAT_HIDDEN)
@@ -647,6 +661,8 @@ var/global/num_vending_terminals = 1
 
 /obj/machinery/vending/proc/GetProductByID(var/pid, var/category)
 	switch(category)
+		if(CAT_HOLIDAY)
+			return holiday_records[pid]
 		if(CAT_NORMAL)
 			return product_records[pid]
 		if(CAT_HIDDEN)
@@ -761,6 +777,8 @@ var/global/num_vending_terminals = 1
 	else
 		var/list/display_records = src.product_records.Copy()
 
+		if(Holiday)
+			display_records += src.holiday_records
 		if(src.extended_inventory)
 			display_records += src.hidden_records
 		if(src.coin)
@@ -779,6 +797,12 @@ var/global/num_vending_terminals = 1
 				categories[R.subcategory] += R
 			else
 				categories["default"] += R
+
+		if(Holiday && holiday_records.len)
+			dat += {"<FONT color = "pink"><B>&nbsp;&nbsp;holiday specials</B></font>:<br>"}
+			for (var/datum/data/vending_product/R in holiday_records)
+				dat += GetProductLine(R)
+			dat += "<br>"
 
 		if(is_custom_machine)
 			for(var/datum/data/vending_product/VP in product_records)
@@ -1362,6 +1386,7 @@ var/global/num_vending_terminals = 1
 		/obj/item/weapon/reagent_containers/food/snacks/cheesiehonkers = 6,
 		/obj/item/weapon/reagent_containers/food/snacks/chococoin/wrapped = 2,
 		/obj/item/weapon/storage/fancy/cigarettes/gum = 10,
+		/obj/item/weapon/reagent_containers/food/snacks/chocolatebar/wrapped/valentine = 2,
 		)
 	contraband = list(
 		/obj/item/weapon/reagent_containers/food/snacks/syndicake = 4,
@@ -1380,9 +1405,13 @@ var/global/num_vending_terminals = 1
 		/obj/item/weapon/reagent_containers/food/snacks/chococoin/wrapped = 75,
 		/obj/item/weapon/reagent_containers/food/snacks/magbites = 110,
 		/obj/item/weapon/storage/fancy/cigarettes/gum = 10,
+		/obj/item/weapon/reagent_containers/food/snacks/chocolatebar/wrapped/valentine = 100,
 		)
 	vouched = list(
 		/obj/item/weapon/reagent_containers/food/snacks/donkpocket/self_heating = 2
+		)
+	specials = list(
+		/obj/item/weapon/reagent_containers/food/snacks/chocolatebar/wrapped/valentine = VALENTINES_DAY
 		)
 
 	pack = /obj/structure/vendomatpack/snack
@@ -2116,13 +2145,19 @@ var/global/num_vending_terminals = 1
 		/obj/item/weapon/staff/broom = 5,
 		/obj/item/clothing/glasses/monocle = 5,
 		/obj/item/weapon/storage/bag/wiz_cards/full = 1,
-		/obj/item/weapon/storage/bag/potion = 5
+		/obj/item/weapon/storage/bag/potion = 5,
+		/obj/item/clothing/suit/wizrobe/hallowiz = 5,
+		/obj/item/clothing/head/wizard/hallowiz = 5,
 		)
 	contraband = list(
 		/obj/item/weapon/reagent_containers/glass/bottle/wizarditis = 1,
 		)	//No one can get to the machine to hack it anyways; for the lulz - Microwave
 	premium = list(
 		/obj/item/clothing/back/magiccape = 1,
+		)
+	specials = list(
+		/obj/item/clothing/suit/wizrobe/hallowiz = HALLOWEEN,
+		/obj/item/clothing/head/wizard/hallowiz = HALLOWEEN,
 		)
 
 	pack = /obj/structure/vendomatpack/magivend	//Who's laughing now? wizarditis doesn't do shit anyway. - Deity Link of 2014

--- a/code/modules/reagents/reagent_containers/food/drinks/drinkingglass.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/drinkingglass.dm
@@ -665,6 +665,14 @@
 	..()
 	reagents.add_reagent(TOXINSSPECIAL, 30)
 	on_reagent_change()
+	
+/obj/item/weapon/reagent_containers/food/drinks/drinkingglass/irishcoffee
+	name = "irish coffee"
+	
+/obj/item/weapon/reagent_containers/food/drinks/drinkingglass/irishcoffee/New()
+	..()
+	reagents.add_reagent(IRISHCOFFEE, 50)
+	on_reagent_change()
 
 // Cafe Stuff. Mugs act the same as drinking glasses, but they don't break when thrown.
 


### PR DESCRIPTION
Proof-of-concept items; halloween wizard robes for halloween, valentine's day chocolate on valentine's day, potatoes and irish coffee for st patricks day
Tested, seems to work as intended. Category doesn't show up when there's no relevant items, items only show up on the proper holiday, prices work, etcetera.

![holiday specials](https://user-images.githubusercontent.com/8468269/65586085-d643fb00-df83-11e9-8d08-5a0ad6a68c86.png)

Ideas for discussion:
- colors of the holiday section
- ~~should it say "HOLIDAY_NAME specials!" ?~~
 - ~~other items that I can add in real quick~~

🆑 
 - rscadd: Vending machines can now have holiday-specific items in them.