### PR TITLE
Fixes Some Listening Stuff

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1908,6 +1908,8 @@ mob/living/carbon/human/isincrit()
 
 /mob/living/carbon/human/Hear(var/datum/speech/speech, var/rendered_speech="")
 	..()
+	if(stat)
+		return //Don't bother if we're dead or unconscious
 	if(ear_deaf || speech.frequency || speech.speaker == src)
 		return //First, eliminate radio chatter, speech from us, or wearing earmuffs/deafened
 	if(!mind || !mind.faith || length(speech.message) < 20)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -204,7 +204,7 @@ var/list/department_radio_keys = list(
 	return 1
 
 /mob/living/proc/resist_memes(var/datum/speech/speech)
-	if(ear_deaf || speech.frequency || speech.speaker == src || !isliving(speech.speaker))
+	if(stat || ear_deaf || speech.frequency || speech.speaker == src || !isliving(speech.speaker))
 		return TRUE
 	return FALSE
 


### PR DESCRIPTION
I heard pomf say that he caught a meme as a ghost. This shouldn't be possible since observers aren't a subtype of living but this just adds some extra sanity.

🆑 
* bugfix: Memes and spooks are now kept separate.
* bugfix: You can no longer benefit from the comforting words of your chaplain if you are unconscious, or dead.