### PR TITLE
Phazon mechs can phase through telejammed areas (except turbo-telejammed) again

### DIFF
--- a/code/game/mecha/combat/phazon.dm
+++ b/code/game/mecha/combat/phazon.dm
@@ -37,7 +37,7 @@
 		if (L.teleJammed)
 			return
 		var/area/A = get_area(new_turf)
-		if (A.flags & NO_TELEPORT || A.jammed)
+		if (A.flags & NO_TELEPORT || (A.jammed == 2))
 			return
 		if(can_move)
 			can_move = 0


### PR DESCRIPTION
Now that the dust has settled, can we all agree phazon mech needs a buff?
Anyway, telejammed areas include areas like the cap's office, AI core and so on. However, turbo-telejammed areas like the russian satellite's gooncode room will still block phazon mechs.
:cl:
 * tweak: Phazon mech can now phase through telejammed areas again.