### PR TITLE
Viro Dispenser Nondense

### DIFF
--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -303,7 +303,8 @@
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "virusfoodtank"
 	amount_per_transfer_from_this = 10
-	anchored = 1
+	anchored = TRUE
+	density = FALSE
 
 /obj/structure/reagent_dispensers/virusfood/New()
 	. = ..()


### PR DESCRIPTION
closes #24285

🆑 
* tweak: The virus food wall dispenser doesn't take up floor space anymore.