### PR TITLE
Should fix changelings being prompted when they go lesser form

### DIFF
--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -53,7 +53,7 @@
 	qdel(src)
 
 
-/mob/proc/monkeyize(var/ignore_primitive = TRUE)
+/mob/proc/monkeyize(var/ignore_primitive = TRUE, var/choose_name = FALSE)
 	if(ismonkey(src)) //What's the point
 		return
 	if(!Premorph())
@@ -95,7 +95,7 @@
 		if (L.immune_system)
 			L.immune_system.transfer_to(Mo)
 	Mo.delayNextAttack(0)
-	Postmorph(Mo, TRUE, "You have been turned into a monkey! Pick a monkey name for your new monkey self.")
+	Postmorph(Mo, choose_name, "You have been turned into a monkey! Pick a monkey name for your new monkey self.")
 	return Mo
 
 /mob/living/carbon/human/monkeyize(ignore_primitive = FALSE)


### PR DESCRIPTION
Weird that that was added to monkeyize, can't see the reason why.

:cl:
 * tweak: Changelings are no longer prompted to choose a name for their lesser form when they monkeyize