### PR TITLE
Pick up verb sanity

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -845,21 +845,24 @@
 		return CANNOT_EQUIP //Unsupported slot
 		//END GRINCH
 
-/obj/item/can_pickup(mob/living/user)
+/obj/item/can_pickup(mob/living/user, var/actually_picking_up = TRUE, var/silent = FALSE)
 	if(!(user) || !isliving(user)) //BS12 EDIT
 		return FALSE
-	if(prepickup(user))
+	if(actually_picking_up && prepickup(user))
 		return FALSE
 	if(user.incapacitated() || !Adjacent(user))
 		return FALSE
 	if((!iscarbon(user) && !isMoMMI(user)) && !ishologram(user) && !isgrinch(user) || isbrain(user)) //Is not a carbon being, MoMMI, advanced hologram, or is a brain
-		to_chat(user, "You can't pick things up!")
+		if(!silent)
+			to_chat(user, "You can't pick things up!")
 		return FALSE
 	if(anchored) //Object isn't anchored
-		to_chat(user, "<span class='warning'>You can't pick that up!</span>")
+		if(!silent)
+			to_chat(user, "<span class='warning'>You can't pick that up!</span>")
 		return FALSE
 	if(!istype(loc, /turf) && !is_holder_of(user, src)) //Object is not on a turf
-		to_chat(user, "<span class='warning'>You can't pick that up!</span>")
+		if(!silent)
+			to_chat(user, "<span class='warning'>You can't pick that up!</span>")
 		return FALSE
 	return TRUE
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1252,18 +1252,10 @@ Use this proc preferably at the end of an equipment loadout
 	A.examine(src)
 
 
-/mob/living/verb/verb_pickup() //Removed the arguments due to macro abuse
+/mob/living/verb/verb_pickup(obj/I in acquirable_objects_in_view(usr, 1))
 	set name = "Pick up"
 	set category = "Object"
 
-	var/list/L = acquirable_objects_in_view(usr, 1)
-	var/obj/I
-	if(L.len == 1)
-		I = L[1]
-	else
-		I = input("Select an object", null, null, null) as null|anything in L
-		if(!I)
-			return
 	face_atom(I)
 	I.verb_pickup(src)
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1252,12 +1252,20 @@ Use this proc preferably at the end of an equipment loadout
 	A.examine(src)
 
 
-/mob/living/verb/verb_pickup(obj/I in view(1))
+/mob/living/verb/verb_pickup(obj/I in objects_in_view(usr, 1))
 	set name = "Pick up"
 	set category = "Object"
 
 	face_atom(I)
 	I.verb_pickup(src)
+
+/proc/objects_in_view(var/mob/living/L, var/range)
+	var/list/obj_list = list()
+	for(var/turf/T in view(L, range))
+		for(var/obj/I in T)
+			if(I.can_pickup(L, FALSE, TRUE))
+				obj_list.Add(I)
+	return obj_list
 
 // See carbon/human
 /mob/proc/can_show_flavor_text()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1252,14 +1252,22 @@ Use this proc preferably at the end of an equipment loadout
 	A.examine(src)
 
 
-/mob/living/verb/verb_pickup(obj/I in objects_in_view(usr, 1))
+/mob/living/verb/verb_pickup() //Removed the arguments due to macro abuse
 	set name = "Pick up"
 	set category = "Object"
 
+	var/list/L = acquirable_objects_in_view(usr, 1)
+	var/obj/I
+	if(L.len == 1)
+		I = L[1]
+	else
+		I = input("Select an object", null, null, null) as null|anything in L
+		if(!I)
+			return
 	face_atom(I)
 	I.verb_pickup(src)
 
-/proc/objects_in_view(var/mob/living/L, var/range)
+/proc/acquirable_objects_in_view(var/mob/living/L, var/range)
 	var/list/obj_list = list()
 	for(var/turf/T in view(L, range))
 		for(var/obj/I in T)


### PR DESCRIPTION
The pick up verb now only takes into account objects in your surroundngs, rather than an object inside yourself

Also only shows objects that you can actually pick up

closes #24307 

![image](https://user-images.githubusercontent.com/30557196/65840458-6336dd80-e311-11e9-8726-cf2b8d5f6d9a.png)


:cl:
 * bugfix: Fixed the pick up verb being able to pull an implant out of yourself