### PR TITLE
Washing machine code cleanup

### DIFF
--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -23,20 +23,50 @@
 	var/speed_coefficient = 1
 	var/size_coefficient = 1
 	//Lists for each bin tier in order T1, T2, T3, T4. Whitelist doesn't change but its there for future proofing.
+	//The lists are organized as type = size_coeff minimum to process
 	var/list/whitelist_list = list(
-		list(/obj/item/stack/sheet/hairlesshide, /obj/item/clothing/under, /obj/item/clothing/mask, /obj/item/clothing/head, /obj/item/clothing/gloves, /obj/item/clothing/shoes, /obj/item/clothing/suit, /obj/item/stack/cable_coil, /obj/item/weapon/bedsheet),\
-		list(/obj/item/stack/sheet/hairlesshide, /obj/item/clothing/under, /obj/item/clothing/mask, /obj/item/clothing/head, /obj/item/clothing/gloves, /obj/item/clothing/shoes, /obj/item/clothing/suit, /obj/item/stack/cable_coil, /obj/item/weapon/bedsheet),\
-		list(/obj/item/stack/sheet/hairlesshide, /obj/item/clothing/under, /obj/item/clothing/mask, /obj/item/clothing/head, /obj/item/clothing/gloves, /obj/item/clothing/shoes, /obj/item/clothing/suit, /obj/item/stack/cable_coil, /obj/item/weapon/bedsheet),\
-		list(/obj/item/stack/sheet/hairlesshide, /obj/item/clothing/under, /obj/item/clothing/mask, /obj/item/clothing/head, /obj/item/clothing/gloves, /obj/item/clothing/shoes, /obj/item/clothing/suit, /obj/item/stack/cable_coil, /obj/item/weapon/bedsheet)\
+		//Tier 1 and above
+		/obj/item/stack/sheet/hairlesshide = 1,
+		/obj/item/clothing/under = 1,
+		/obj/item/clothing/mask = 1,
+		/obj/item/clothing/head = 1,
+		/obj/item/clothing/gloves = 1,
+		/obj/item/clothing/shoes = 1,
+		/obj/item/clothing/suit = 1,
+		/obj/item/stack/cable_coil = 1,
+		/obj/item/weapon/bedsheet = 1
 		)
 	var/list/blacklist_list = list(
-		list(/mob/living/carbon, /obj/item/clothing/head/helmet, /obj/item/clothing/suit/space, /obj/item/clothing/head/syndicatefake, /obj/item/clothing/suit/syndicatefake, /obj/item/clothing/suit/cyborg_suit, /obj/item/clothing/head/bomb_hood, /obj/item/clothing/suit/bomb_suit, /obj/item/clothing/suit/armor, /obj/item/clothing/mask/cigarette),\
-		list(/mob/living/carbon, /obj/item/clothing/suit/space, /obj/item/clothing/suit/syndicatefake, /obj/item/clothing/suit/cyborg_suit, /obj/item/clothing/suit/bomb_suit, /obj/item/clothing/suit/armor, /obj/item/clothing/mask/cigarette),\
-		list(/mob/living/carbon/human, /obj/item/clothing/mask/cigarette),\
-		list(/obj/item/clothing/mask/cigarette)\
+		//Tier 1 and above
+		//Nothing
+		//Tier 2 and above
+		/obj/item/clothing/head/helmet = 2,
+		/obj/item/clothing/head/bomb_hood = 2,
+		//Tier 3 and above
+		/obj/item/clothing/suit/space = 3,
+		/obj/item/clothing/suit/syndicatefake = 3,
+		/obj/item/clothing/suit/cyborg_suit = 3,
+		/obj/item/clothing/suit/bomb_suit = 3,
+		/obj/item/clothing/suit/armor = 3,
+		//Tier 4 and above
+		/mob/living/carbon/human = 4,
+		//Tier 5 and above
+		/obj/item/clothing/mask/cigarette = 5,
 		)
 
 	machine_flags = SCREWTOGGLE | WRENCHMOVE
+
+/obj/machinery/washing_machine/proc/is_in_blacklist(atom/A)
+	for(var/type in blacklist_list)
+		if(istype(A, type) && size_coefficient < blacklist_list[type])
+			return TRUE
+	return FALSE
+
+/obj/machinery/washing_machine/proc/is_in_whitelist(atom/A)
+	for(var/type in whitelist_list)
+		if(istype(A, type) && size_coefficient >= whitelist_list[type])
+			return TRUE
+	return FALSE
 
 /obj/machinery/washing_machine/New()
 	..()
@@ -247,7 +277,7 @@
 	if(..())
 		update_icon()
 		return 1
-	else if(is_type_in_list(W, blacklist_list[size_coefficient]))
+	else if(is_in_blacklist(W))
 		to_chat(user, "This item does not fit.")
 		return
 	else if(istype(W,/obj/item/toy/crayon) ||istype(W,/obj/item/weapon/stamp))
@@ -259,7 +289,7 @@
 		if(contents.len < (5 * size_coefficient))
 			if((wash_state == 1) && hacked)
 				var/obj/item/weapon/grab/G = W
-				if(ishuman(G.assailant) && isliving(G.affecting) && !is_type_in_list(G.affecting, blacklist_list[size_coefficient]))
+				if(ishuman(G.assailant) && isliving(G.affecting) && !is_in_blacklist(G.affecting))
 					G.affecting.forceMove(src)
 					qdel(G)
 					G = null
@@ -276,7 +306,7 @@
 					qdel(locate(contents,/obj/item/weapon/holder/animal))
 		else
 			to_chat(user, "<span class='notice'>\The [src] is full.</span>")
-	else if(is_type_in_list(W, whitelist_list[size_coefficient]))
+	else if(is_in_whitelist(W))
 		if(contents.len < (5 * size_coefficient))
 			if(wash_state in list(1, 3))
 				if(user.drop_item(W, src))


### PR DESCRIPTION
Implements the suggestion I made to DrSnips, to reduce on list abuse.

Rather than a list of lists for each potential tier, instead it's a list of types that point to the minimum size coefficient required for them to fit in the washing machine.

So, rather than 10 lists per washing machine, it has been reduced to 2