### PR TITLE
Revert "humans are now naked by default + randombodies can roll no underwear"

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -17,7 +17,7 @@
 	var/age = 30		//Player's age (pure fluff)
 	//var/b_type = "A+"	//Player's bloodtype //NOW HANDLED IN THEIR DNA
 
-	var/underwear = 0	//Which underwear the player wants
+	var/underwear = 1	//Which underwear the player wants
 	var/backbag = 2		//Which backpack type the player has chosen. Nothing, Satchel or Backpack.
 
 	//Equipment slots

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -13,7 +13,7 @@
 	randomize_hair_color("hair")
 	randomize_hair_color("facial")
 	randomize_eyes_color()
-	underwear = rand(0,underwear_m.len)
+	underwear = rand(1,underwear_m.len)
 	backbag = 2
 	age = rand(AGE_MIN,AGE_MAX)
 	if(H)


### PR DESCRIPTION
Reverts vgstation-coders/vgstation13#24182

First of all, naked is at m_underwear.len or f_underwear.len, as that's the option for "None"

Secondly, the only reason this even worked was because of an indexoutofbounds exception meaning it would break when trying to retrieve underwar, which oddly enough is not a good thing, as that bricks peoples preference previews as is evident by #24337 

