### PR TITLE
Vox raider day 0 fixes

### DIFF
--- a/code/datums/gamemode/factions/vox_shoal.dm
+++ b/code/datums/gamemode/factions/vox_shoal.dm
@@ -10,7 +10,7 @@
 	logo_state = "vox-logo"
 	hud_icons = list("vox-logo")
 
-	var/time_left = 30 MINUTES
+	var/time_left = (30 MINUTES)/10
 	var/completed = FALSE
 
 	var/results = "The Shoal didn't return yet."
@@ -110,7 +110,7 @@ var/list/potential_bonus_items = list(
 
 /datum/faction/vox_shoal/GetScoreboard()
 	. = ..()
-	. += "<br/> Time left: <b>[(time_left / 2*60) % 60]:[add_zero(num2text(time_left/2 % 60), 2)]</b>"
+	. += "<br/> Time left: <b>[num2text((time_left /(2*60)))]:[add_zero(num2text(time_left/2 % 60), 2)]</b>"
 	if (time_left < 0)
 		. += "<br/> <span class='danger'>The raid took too long.</span>"
 	. += "<br/> The raiders took <b>[got_personnel]</b> people to the Shoal."
@@ -120,7 +120,7 @@ var/list/potential_bonus_items = list(
 
 /datum/faction/vox_shoal/AdminPanelEntry()
 	. = ..()
-	. += "<br/> Time left: <b>[(time_left / 2*60) % 60]:[add_zero(num2text(time_left/2 % 60), 2)]</b>"
+	. += "<br/> Time left: <b>[num2text((time_left /(2*60)))]:[add_zero(num2text(time_left/2 % 60), 2)]</b>"
 
 /datum/faction/vox_shoal/OnPostSetup()
 	..()
@@ -202,7 +202,6 @@ var/list/potential_bonus_items = list(
 				else
 					to_chat(H, "<span class='notice'>The raid has been concluded, and you returned safe. This will greatly helps us.</span>")
 					total_points += 500
-				qdel(H) // They get deleted and go back as ghosts.
 			else
 				count_score(H)
 				to_chat(H, "<span class='warning'>You can't really remember the details, but somehow, you managed to escape. Your situation is still far from ideal, however.")
@@ -223,6 +222,10 @@ var/list/potential_bonus_items = list(
 		else
 			results = "The vox raiders didn't beat the previous record of [score_to_beat]."
 
+		for (var/datum/role/R in members)
+			to_chat(R.antag.current, "<span class='notice'>The raid is over. You'll go back to the shoal in a few minutes...</span>")
+			spawn (1 MINUTES)
+				qdel(R.antag.current)
 
 /datum/faction/vox_shoal/proc/count_score(var/atom/O)
 	if (ishuman(O))

--- a/code/datums/gamemode/objectives/abduct.dm
+++ b/code/datums/gamemode/objectives/abduct.dm
@@ -5,7 +5,7 @@
 
 /datum/objective/abduct/New(var/dept)
 	. = ..()
-	num = rand(2, 5)
+	num = rand(1, 3)
 	explanation_text = "Abduct [num] qualified personnel from the [dept] departement."
 
 /datum/objective/abduct/IsFulfilled()

--- a/code/datums/gamemode/objectives/steal_priority_items.dm
+++ b/code/datums/gamemode/objectives/steal_priority_items.dm
@@ -5,8 +5,8 @@
 
 /datum/objective/steal_priority/PostAppend()
 	. = ..()
-	num = rand(2, 5)
-	explanation_text = "Abduct [num] priority items."
+	num = rand(1, 3)
+	explanation_text = "Acquire [num] priority items."
 
 /datum/objective/steal_priority/IsFulfilled()
 	var/datum/faction/vox_shoal/VS = faction

--- a/code/datums/gamemode/role/vox_raider.dm
+++ b/code/datums/gamemode/role/vox_raider.dm
@@ -13,5 +13,5 @@
 	var/datum/faction/vox_shoal/vox = faction
 	if (!istype(vox))
 		return
-	var/dat = "Vox raid time left: [(vox.time_left / 2*60) % 60]:[add_zero(num2text(vox.time_left/2 % 60), 2)]"
+	var/dat = "Raid time left: <b>[num2text((vox.time_left /(2*60)))]:[add_zero(num2text(vox.time_left/2 % 60), 2)]</b>"
 	return dat

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -656,6 +656,8 @@
 // -- Vox raiders.
 
 /obj/structure/closet/loot
+	name = "Loot closet"
+	desc = "Store the valuables here for a direct transfer to the shoal. We make much bluespace."
 
 /obj/structure/closet/loot/Destroy()
 	for (var/datum/faction/vox_shoal/VS in ticker.mode.factions)


### PR DESCRIPTION
Made a goof in the timer display.
Made the raiders not delete themselves, but stay in the shuttle for a time before they go back as ghosts.

More to come, of course, those were just the easiest problems to identify.