### PR TITLE
Remove need for carrier fluid from Fourier and Hyperspectral

### DIFF
--- a/code/modules/research/xenoarchaeology/machinery/analysis_fourier_transform.dm
+++ b/code/modules/research/xenoarchaeology/machinery/analysis_fourier_transform.dm
@@ -20,27 +20,19 @@
 	var/results = "The scan was inconclusive. Check sample integrity and carrier consistency."
 
 	var/datum/geosample/scanned_sample
-	var/carrier
-	var/num_reagents = 0
 
 	for(var/datum/reagent/A in held_container.reagents.reagent_list)
 		var/datum/reagent/R = A
 		if(istype(R, /datum/reagent/analysis_sample))
 			scanned_sample = R.data
-		else
-			carrier = R.id
-		num_reagents++
+			break
 
-	if(num_reagents == 2 && scanned_sample && carrier)
-		//all necessary components are present
-		var/specifity = GetResultSpecifity(scanned_sample, carrier)
+	if(scanned_sample)
 		var/distance = scanned_sample.artifact_distance
 		if(distance > 0)
 			distance += (2 * rand() - 1) * distance * 0.05
-			results = "Fourier transform analysis on anomalous energy absorption through carrier ([carrier]) indicates source located inside emission radius ([95 * specifity]% accuracy): [distance]."
+			results = "Fourier transform analysis on anomalous energy absorption indicates source located inside emission radius (95% accuracy): [distance]."
 		else
 			results = "Energy dispersion detected throughout sample consistent with background readings.<br>"
-		if(carrier == scanned_sample.source_mineral)
-			results += "Warning, analysis may be contaminated by high quantities of molecular carrier present throughout sample."
 
 	return results

--- a/code/modules/research/xenoarchaeology/machinery/analysis_hyperspectral.dm
+++ b/code/modules/research/xenoarchaeology/machinery/analysis_hyperspectral.dm
@@ -39,43 +39,21 @@
 	set_light(0)
 
 /obj/machinery/anomaly/hyperspectral/ScanResults()
-	var/results = "The scan was inconclusive. Check sample integrity and carrier consistency."
+	var/results = "The scan was inconclusive. Check sample integrity."
 
 	var/datum/geosample/scanned_sample
-	var/carrier
-	var/num_reagents = 0
 
 	for(var/datum/reagent/A in held_container.reagents.reagent_list)
 		var/datum/reagent/R = A
 		if(istype(R, /datum/reagent/analysis_sample))
 			scanned_sample = R.data
-		else
-			carrier = R.id
-		num_reagents++
+			break
 
-	if(num_reagents == 2 && scanned_sample && carrier)
-		//all necessary components are present
-		var/specifity = GetResultSpecifity(scanned_sample, carrier)
-		results = "Spectral signature over carrier ([carrier]):<br>"
-		if(specifity <= 0.25)
-			results += "<img src=\"http://i.imgur.com/TAQHn.jpg\"></img><br>"
-			//results += "<img src=chart1.jpg>"
-		else if(specifity <= 0.5)
-			results += "<img src=\"http://i.imgur.com/EwOZ7.jpg\"></img><br>"
-			//results += "<img src=chart2.jpg>"
-		else if(specifity <= 0.75)
-			results += "<img src=\"http://i.imgur.com/1qCae.jpg\"></img><br>"
-			//results += "<img src=chart3.jpg>"
-		else
-			results += "<img src=\"http://i.imgur.com/9T9nc.jpg\"></img><br>"
-			//results += "<img src=chart4.jpg>"
-
-		results += "<br>"
+	if(scanned_sample)
 		if(scanned_sample.artifact_id)
-			results += "Detected energy signatures [100 * (1 - specifity)]% consistent with standard background readings.<br>"
-			if(prob( (specifity + 0.5 * (1 - specifity)) * 100))
-				results += "Anomalous exotic energy signature isolated: <font color='red'><b>[scanned_sample.artifact_id].</b></font>"
+			results = {"Detected energy signatures 95% consistent with standard background readings.<br>
+			Anomalous exotic energy signature isolated: <font color='red'><b>[scanned_sample.artifact_id].</b></font>"}
 		else
-			results += "Detected energy signatures [95 + 5 * (2 * rand() - 1) * (1 - specifity)]% consistent with standard background readings."
+			results = "Detected energy signatures 100% consistent with standard background readings."
 
 	return results


### PR DESCRIPTION
AKA making Xenoarch slightly less newb trap.

:cl:

- tweak: Carrier fluids are no longer necessary for the xenoarchaeology Hyperspectral Imager and Fourier Transform spectroscope.

<!--
[qol]
-->