### PR TITLE
Say logs QoL

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -98,7 +98,6 @@ var/list/department_radio_keys = list(
 
 // /vg/edit: Added forced_by for handling braindamage messages and meme stuff
 /mob/living/say(var/message, bubble_type, forced = TRUE)
-	var/original_message = message
 	say_testing(src, "/mob/living/say(\"[message]\", [bubble_type]")
 	if(timestopped)
 		return //under the effects of time magick
@@ -200,7 +199,7 @@ var/list/department_radio_keys = list(
 		send_speech(speech, message_range, bubble_type)
 	radio(speech, message_mode) //Sends the radio signal
 	var/turf/T = get_turf(src)
-	log_say("[name]/[key] [T?"(@[T.x],[T.y],[T.z])":"(@[x],[y],[z])"] [speech.language ? "As [speech.language.name] ":""]: [message] [forced ? "(F)" : ""] [(original_message =! message) ? "(Original message: [original_message]" : ""]")
+	log_say("[name]/[key] [T?"(@[T.x],[T.y],[T.z])":"(@[x],[y],[z])"] [speech.language ? "As [speech.language.name] ":""]: [message] [forced ? "(F)" : ""] [(message != speech.message) ? "(Rendred as : [speech.message])" : ""]")
 	returnToPool(speech)
 	return 1
 

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -199,7 +199,7 @@ var/list/department_radio_keys = list(
 		send_speech(speech, message_range, bubble_type)
 	radio(speech, message_mode) //Sends the radio signal
 	var/turf/T = get_turf(src)
-	log_say("[name]/[key] [T?"(@[T.x],[T.y],[T.z])":"(@[x],[y],[z])"] [speech.language ? "As [speech.language.name] ":""]: [message] [forced ? "(F)" : ""] [(message != speech.message) ? "(Rendred as : [speech.message])" : ""]")
+	log_say("[name]/[key] [T?"(@[T.x],[T.y],[T.z])":"(@[x],[y],[z])"] [speech.language ? "As [speech.language.name] ":""]: [message] [forced ? "(F)" : ""] [(message != speech.message) ? "(Rendered as : [speech.message])" : ""]")
 	returnToPool(speech)
 	return 1
 

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -97,7 +97,8 @@ var/list/department_radio_keys = list(
 
 
 // /vg/edit: Added forced_by for handling braindamage messages and meme stuff
-/mob/living/say(var/message, bubble_type)
+/mob/living/say(var/message, bubble_type, forced = TRUE)
+	var/original_message = message
 	say_testing(src, "/mob/living/say(\"[message]\", [bubble_type]")
 	if(timestopped)
 		return //under the effects of time magick
@@ -199,7 +200,7 @@ var/list/department_radio_keys = list(
 		send_speech(speech, message_range, bubble_type)
 	radio(speech, message_mode) //Sends the radio signal
 	var/turf/T = get_turf(src)
-	log_say("[name]/[key] [T?"(@[T.x],[T.y],[T.z])":"(@[x],[y],[z])"] [speech.language ? "As [speech.language.name] ":""]: [message]")
+	log_say("[name]/[key] [T?"(@[T.x],[T.y],[T.z])":"(@[x],[y],[z])"] [speech.language ? "As [speech.language.name] ":""]: [message] [forced ? "(F)" : ""] [(original_message =! message) ? "(Original message: [original_message]" : ""]")
 	returnToPool(speech)
 	return 1
 

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -5,7 +5,7 @@
 	if(say_disabled)
 		to_chat(usr, "<span class='danger'>Speech is currently admin-disabled.</span>")
 		return
-	usr.say(to_utf8(message, usr))
+	usr.say(to_utf8(message, usr), forced = FALSE)
 
 /mob/verb/whisper(message as text)
 	set name = "Whisper"


### PR DESCRIPTION
Logs will now show if a "say" message was forced, or was said using the verb.
Logs will also show the original message if the content of the message has been modified by any status effect the mob had (slurred speech, virus that switched words, vowels, etc...)

This might raise the size of the logs by quite a bit, but I think it's worth it for ease of investigation and transparency.