### PR TITLE
An attempt at trying to fix or at least debug #24418 by preloading.

### DIFF
--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -381,6 +381,21 @@
 	spawn()
 		if(src in clients) //Did we log out before we reached this part of the function?
 			nanomanager.send_resources(src)
+	// Hahaha your suffering is not yet over, as we still must waterboard you with ten thousand oggs! (4500 at last count)
+	spawn()
+		if(src)
+			to_chat(src, "<span class='notice'>Receiving VOX words.  This will take time, and until it is complete, you may receive words out of order.</span>")
+		var/n = 0
+		if(src in clients)
+			for(var/voice in vox_sounds)
+				for(var/word in vox_sounds[voice])
+					// Yay for undocumented BYOND things.
+					Export("##action=preload_rsc", vox_sounds[voice][word])
+					n++
+					// This may make it too slow.
+					stoplag()
+		if(src)
+			to_chat(src, "<span class='notice'>[n] VOX words received!</span>")
 
 
 /client/proc/send_html_resources()

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -393,9 +393,7 @@
 					Export("##action=preload_rsc", vox_sounds[voice][word])
 					n++
 					// This may make it too slow.
-					stoplag()
-		if(src)
-			to_chat(src, "<span class='notice'>[n] VOX words received!</span>")
+					//stoplag()
 
 
 /client/proc/send_html_resources()

--- a/code/modules/mob/living/silicon/ai/say.dm
+++ b/code/modules/mob/living/silicon/ai/say.dm
@@ -195,6 +195,8 @@ var/VOX_AVAILABLE_VOICES = list(
 	if(!message || announcing_vox > world.time)
 		return
 
+	to_chat(src, "<span class='notice'>VOX DEBUG: Received message as \"[message]\". Please file a bug report if this is incorrect.</span>")
+
 	var/list/words = splittext(trim(message), " ")
 	var/list/incorrect_words = list()
 


### PR DESCRIPTION
Refer to #24418.  Here I make use of the same preloading TG uses for their VOX.  This may not work very well since there are 4,500 oggs to load and stoplag() is called between them.

## Changelog

:cl:
 * bugfix: Try to fix VOX announcements by preloading sounds.  If they load out of order, players receive jumbled announcements.
 * wip: Added debugging information that pops up a notice telling the AI the words it received in the announcement.