### PR TITLE
Fixes runtime when objects talk

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1921,7 +1921,7 @@ mob/living/carbon/human/isincrit()
 		return //If we aren't religious or hearing a long message, don't check further
 	var/mob/living/H = speech.speaker
 	if(dizziness || stuttering || jitteriness || hallucination || confused || drowsyness || pain_shock_stage)
-		if(ismob(H) && H.mind == mind.faith.religiousLeader)
+		if(isliving(H) && H.mind == mind.faith.religiousLeader)
 			AdjustDizzy(rand(-8,-10))
 			stuttering = max(0,stuttering-rand(8,10))
 			jitteriness = max(0,jitteriness-rand(8,10))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1921,7 +1921,7 @@ mob/living/carbon/human/isincrit()
 		return //If we aren't religious or hearing a long message, don't check further
 	var/mob/living/H = speech.speaker
 	if(dizziness || stuttering || jitteriness || hallucination || confused || drowsyness || pain_shock_stage)
-		if(H.mind == mind.faith.religiousLeader)
+		if(ismob(H) && H.mind == mind.faith.religiousLeader)
 			AdjustDizzy(rand(-8,-10))
 			stuttering = max(0,stuttering-rand(8,10))
 			jitteriness = max(0,jitteriness-rand(8,10))


### PR DESCRIPTION
```
[17:58:16] Runtime in human.dm, line 1924: undefined variable /obj/machinery/vending/snack/var/mind
proc name: Hear (/mob/living/carbon/human/Hear)
src: Baldric Pearsall (/mob/living/carbon/human)
src.loc: the floor (288,268,1) (/turf/simulated/floor)
call stack:
Baldric Pearsall (/mob/living/carbon/human): Hear(Getmore Chocolate Corp (/datum/speech), "<span class=\'\'><span class=\...")
the Getmore Chocolate Corp (/obj/machinery/vending/snack): send speech(Getmore Chocolate Corp (/datum/speech), 7)
the Getmore Chocolate Corp (/obj/machinery/vending/snack): say("It\'s better than Dan\'s!", null, the Getmore Chocolate Corp (/obj/machinery/vending/snack), null)
the Getmore Chocolate Corp (/obj/machinery/vending/snack): speak("It\'s better than Dan\'s!")
the Getmore Chocolate Corp (/obj/machinery/vending/snack): process()
Machinery (/datum/subsystem/machinery): fire(0)
Machinery (/datum/subsystem/machinery): ignite(0)
Master (/datum/controller/master): RunQueue()
Master (/datum/controller/master): Loop()
Master (/datum/controller/master): StartProcessing()
```