### PR TITLE
Fixed roundstart skeles using human's movement speed modifier

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1191,6 +1191,7 @@
 		src.do_deferred_species_setup = 1
 	meat_type = species.meat_type
 	spawn()
+		src.movement_speed_modifier = species.move_speed_multiplier
 		src.dna.species = new_species_name
 		src.species.handle_post_spawn(src)
 		src.update_icons()

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -402,7 +402,7 @@ var/global/list/whitelisted_species = list("Human")
 	species_intro = "You are a Skellington<br>\
 					You have no skin, no blood, no lips, and only just enough brain to function.<br>\
 					You can not eat normally, as your necrotic state only permits you to only eat raw flesh. As you lack skin, you can not be injected via syringe.<br>\
-					You are also incredibly weak to brute damage and are rather slow, but you don't need to breathe, so that's going for you."
+					You are also incredibly weak to brute damage, but you're fast and don't need to breathe, so that's going for you."
 
 /datum/species/skellington/conditional_whitelist()
 	var/MM = text2num(time2text(world.timeofday, "MM"))


### PR DESCRIPTION
Fixes  #20000 

:cl:
 * bugfix: Roundstart skeles are no longer slow until cloned