### PR TITLE
Fixes boozey shotgun shells traitor box being empty

### DIFF
--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -249,7 +249,7 @@
 /obj/item/weapon/storage/box/syndie_kit/boolets
 	name = "Shotgun shells"
 
-/obj/item/weapon/storage/box/syndie_kit/greytide/New()
+/obj/item/weapon/storage/box/syndie_kit/boolets/New()
 	..()
 	new /obj/item/ammo_casing/shotgun/fakebeanbag(src)
 	new /obj/item/ammo_casing/shotgun/fakebeanbag(src)


### PR DESCRIPTION
shame on you #22593
Closes #23974

:cl:
 * bugfix: Boozey shotgun shells box no longer comes empty