### PR TITLE
fixes a runtime I found while testing gibself

### DIFF
--- a/goon/code/datums/browserOutput.dm
+++ b/goon/code/datums/browserOutput.dm
@@ -263,6 +263,8 @@ For the main html chat area
 /proc/to_chat(target, message)
 	//Ok so I did my best but I accept that some calls to this will be for shit like sound and images
 	//It stands that we PROBABLY don't want to output those to the browser output so just handle them here
+	if(!target)
+		return
 	if (istype(target, /datum/zLevel)) //Passing it to an entire z level
 		for(var/mob/M in player_list) //List of all mobs with clients, excluding new_player
 			if(!istype(get_z_level(M),target))


### PR DESCRIPTION
if you gib yourself or someone else who is wearing an accessory, it calls on_removed on the accessory when it drops which runtimes @ to_chat

might as well just add a catchall to to_chat to not try sending to a null target