### PR TITLE
create-command-report now cancels correctly, overall less ass

### DIFF
--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -655,11 +655,21 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		if(confirmation == "No")
 			return
 	var/input = input(usr, "Please enter anything you want. Anything. Serious.", "What?", "") as message|null
-	var/customname = input(usr, "Pick a title for the report.", "Title") as text|null
 	if(!input)
 		return
+
+	var/customname = input(usr, "Pick a title for the report, or just leave it as Nanotrasen Update. \nLeaving this blank will cancel the command report.", "Choose a title", "Nanotrasen Update") as text|null
 	if(!customname)
-		customname = "Nanotrasen Update"
+		return
+
+	switch(alert("\t[customname] \n\n[input] \n---------- \nShould this be announced to the general population?", "Please verify your message", "Yes", "No", "Cancel"))
+		if("Yes")
+			command_alert(input, customname,1);
+		if("No")
+			to_chat(world, "<span class='warning'>New Nanotrasen Update available at all communication consoles.</span>")
+		else
+			return
+
 	for (var/obj/machinery/computer/communications/C in machines)
 		if(! (C.stat & (BROKEN|NOPOWER) ) )
 			var/obj/item/weapon/paper/P = new /obj/item/weapon/paper( C.loc )
@@ -668,12 +678,6 @@ Traitors and the like can also be revived with the previous role mostly intact.
 			P.update_icon()
 			C.messagetitle.Add("[command_name()] Update")
 			C.messagetext.Add(P.info)
-
-	switch(alert("Should this be announced to the general population?",,"Yes","No"))
-		if("Yes")
-			command_alert(input, customname,1);
-		if("No")
-			to_chat(world, "<span class='warning'>New Nanotrasen Update available at all communication consoles.</span>")
 
 	world << sound('sound/AI/commandreport.ogg', volume = 60)
 	log_admin("[key_name(src)] has created a command report: [input]")

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -662,7 +662,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(!customname)
 		return
 
-	switch(alert("\t[customname] \n\n[input] \n---------- \nShould this be announced to the general population?", "Please verify your message", "Yes", "No", "Cancel"))
+	switch(alert("\t[customname] \n\n[input] \n---------- \nIf this message is correct, who is it intended for?", "Please verify your message", "All Crew", "Heads Only", "Cancel"))
 		if("Yes")
 			command_alert(input, customname,1);
 		if("No")

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -662,10 +662,13 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(!customname)
 		return
 
+	var/headsonly = FALSE
+
 	switch(alert("\t[customname] \n\n[input] \n---------- \nIf this message is correct, who is it intended for?", "Please verify your message", "All Crew", "Heads Only", "Cancel"))
-		if("Yes")
+		if("All Crew")
 			command_alert(input, customname,1);
-		if("No")
+		if("Heads Only")
+			headsonly = TRUE
 			to_chat(world, "<span class='warning'>New Nanotrasen Update available at all communication consoles.</span>")
 		else
 			return
@@ -680,7 +683,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 			C.messagetext.Add(P.info)
 
 	world << sound('sound/AI/commandreport.ogg', volume = 60)
-	log_admin("[key_name(src)] has created a command report: [input]")
+	log_admin("[key_name(src)] has created a [headsonly ? "heads only" : "publicly announced"] command report titled [customname]: [input]")
 	message_admins("[key_name_admin(src)] has created a command report", 1)
 	feedback_add_details("admin_verb","CCR") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 


### PR DESCRIPTION
by request

![10-17-2019_19-29-08](https://user-images.githubusercontent.com/4043940/67061270-ab793c80-f114-11e9-9370-81462d2cc18e.png)

Note: the above image has had its choices changed.
-----
If this message is correct, who is it intended for?

Choices are "All Crew" and "Heads Only" in an attempt to make it more clear what's going to happen when you click either. Cancel unchanged.

![10-17-2019_19-29-18](https://user-images.githubusercontent.com/4043940/67061271-ab793c80-f114-11e9-815a-2d19b61bc1e8.png)
