### PR TITLE
Buff condensedcapsaicin (pepperspray) and fix ghost peppers not being spicy at all.

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -3833,6 +3833,9 @@
 
 	if(..())
 		return 1
+	
+	if(prob(5))
+		to_chat(M,"<span class='notice'>Your face feels a little hot!</span>")
 
 	var/mob/living/carbon/human/H
 	if(ishuman(M))
@@ -3908,6 +3911,7 @@
 		return 1
 
 	if(prob(5))
+		to_chat(M,"<span class='notice'>Your face feels like it's on fire!</span>")
 		M.visible_message("<span class='warning'>[M] [pick("dry heaves!", "coughs!", "splutters!")]</span>")
 
 	//let's just copy capsaicin/on_mob_life does, but make it worse.
@@ -3916,21 +3920,24 @@
 		H = M
 	switch(data)
 		if(1 to 15)
-			M.bodytemperature += 0.9 * TEMPERATURE_DAMAGE_COEFFICIENT
+			M.bodytemperature += 0.9 * TEMPERATURE_DAMAGE_COEFFICIENT		
 			if(holder.has_reagent("frostoil"))
 				holder.remove_reagent("frostoil", 5)
 			if(isslime(M))
 				M.bodytemperature += rand(10,20)
 			if(isslimeperson(H))
 				M.bodytemperature += rand(10,20)
-		if(15 to 25)
+		if(15 to 30)
 			M.bodytemperature += 1.1 * TEMPERATURE_DAMAGE_COEFFICIENT
+			if(prob(6))//Start vomiting 
+				H.vomit(0,1)
 			if(isslime(M))
 				M.bodytemperature += rand(20,25)
 			if(isslimeperson(H))
 				M.bodytemperature += rand(20,25)
-		if(25 to 30)//whatever
-			H.vomit()
+		if(30 to 45)//Reagent dies out at about 50. Set up the vomiting to "fade out".
+			if(prob(9))
+				H.vomit()
 	data++
 
 

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -3868,6 +3868,7 @@
 	color = "#B31008" //rgb: 179, 16, 8
 	density = 0.9
 	specheatcap = 8.59
+	data = 1
 
 /datum/reagent/condensedcapsaicin/reaction_mob(var/mob/living/M, var/method = TOUCH, var/volume)
 
@@ -3903,12 +3904,35 @@
 				H.drop_item()
 
 /datum/reagent/condensedcapsaicin/on_mob_life(var/mob/living/M)
-
 	if(..())
 		return 1
 
 	if(prob(5))
 		M.visible_message("<span class='warning'>[M] [pick("dry heaves!", "coughs!", "splutters!")]</span>")
+
+	//let's just copy capsaicin/on_mob_life does, but make it worse.
+	var/mob/living/carbon/human/H
+	if(ishuman(M))
+		H = M
+	switch(data)
+		if(1 to 15)
+			M.bodytemperature += 0.9 * TEMPERATURE_DAMAGE_COEFFICIENT
+			if(holder.has_reagent("frostoil"))
+				holder.remove_reagent("frostoil", 5)
+			if(isslime(M))
+				M.bodytemperature += rand(10,20)
+			if(isslimeperson(H))
+				M.bodytemperature += rand(10,20)
+		if(15 to 25)
+			M.bodytemperature += 1.1 * TEMPERATURE_DAMAGE_COEFFICIENT
+			if(isslime(M))
+				M.bodytemperature += rand(20,25)
+			if(isslimeperson(H))
+				M.bodytemperature += rand(20,25)
+		if(25 to 30)//whatever
+			H.vomit()
+	data++
+
 
 /datum/reagent/blackcolor
 	name = "Black Food Coloring"


### PR DESCRIPTION
[tweak]

Fixes: https://github.com/vgstation-coders/vgstation13/issues/24495

This mirrors the ``on_mob_life`` behavior from ``capsaicin`` into ``condensedcapsaicin``, but makes it much worse. Lot's of vomit. This PR originally intended just to fix Ghost Peppers(they had basically 0 effect), but inadvertently buffed pepperspray. Some people say it is nearly useless and needs a buff anyway. 
:cl:
 * tweak: Pepperspray(condensedcapsaicin) now has a more brutal effect on its victims.
 * tweak: Ghost Peppers got buffed. You will vomit a few times if you eat 1 (One).