### PR TITLE
Tile painter bugfix

### DIFF
--- a/code/modules/RCD/schematics/tile.dm
+++ b/code/modules/RCD/schematics/tile.dm
@@ -588,7 +588,7 @@ var/global/list/paint_variants = list(
 
 	"Chapel" = list(
 		new /datum/paint_info(DIR_ALL,		"chapel"),
-		new /datum/paint_info(DIR_ALL,		"chapeldark")
+		new /datum/paint_info(DIR_ONE,		"chapeldark")
 	),
 
 	"SS13 logo" = list(


### PR DESCRIPTION
Back when I added this tile I apparently used DIR_ALL, causing the tile painter to render lots of directions for it, when I should've used DIR_ONE because it was a single-directional tile. Whoops.

![uh](https://user-images.githubusercontent.com/5822375/67158398-3e49ef00-f340-11e9-8c28-52662ef4513f.png)


:cl:
 * bugfix: chapel tiles in tile painter don't try to display extradimensional directions anymore