### PR TITLE
Sports Makes You Strong

### DIFF
--- a/code/modules/mob/living/helper_procs.dm
+++ b/code/modules/mob/living/helper_procs.dm
@@ -33,6 +33,8 @@ default behaviour is:
 
 	strength += (M_HULK in src.mutations)
 	strength += (M_STRONG in src.mutations)
+	if(reagents)
+		strength += (reagents.get_sportiness() >= 5)
 
 	. = strength
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1763,8 +1763,7 @@ Thanks.
 		if(istype(src,/mob/living/carbon/human))
 			var/mob/living/carbon/human/H=src
 			throw_mult = H.species.throw_mult
-			if((M_HULK in H.mutations) || (M_STRONG in H.mutations))
-				throw_mult+=0.5
+			throw_mult += (H.get_strength()-1)/2 //For each level of strength above 1, add 0.5
 		item.throw_at(target, item.throw_range*throw_mult, item.throw_speed*throw_mult)
 		return THREW_SOMETHING
 


### PR DESCRIPTION
Not as atomic as it could be but I thought the throwing thing seemed like an oversight. I can split it up if people care. It's not a huge change, most people probably won't even notice it since it's incremented by 0.5

Strength is used in many things, like speed of chopping down trees, punching windows, resisting cages, throw/kick force/distance etc. The main way to get 5 sport is by drinking brawndo or inhaling vale incense (xenoarch incense, or spawn as one of the few sporty religion chaplains).

🆑 
* tweak: Throwing speed/force now increases for each level of strength you have instead of just once if you have any strength increase.
* rscadd: Having 5 or higher sportiness now grants a strength level.