### PR TITLE
Disease Weights

### DIFF
--- a/__DEFINES/disease2.dm
+++ b/__DEFINES/disease2.dm
@@ -1,3 +1,7 @@
 //touch types for on_touch()
 #define BUMP "bump"
 #define HAND "hand"
+
+#define WDISH	 1
+#define WLATEJOIN 2
+#define WMOUSE	 3

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -234,8 +234,7 @@
 
 /mob/living/simple_animal/mouse/proc/MaintInfection()
 	infectable = TRUE
-	var/virus_choice = get_random_disease_type(WMOUSE)
-	var/datum/disease2/disease/D = new virus_choice
+	var/datum/disease2/disease/D = get_random_weighted_disease(WMOUSE)
 
 	var/list/anti = list(
 		ANTIGEN_BLOOD	= 1,

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -234,7 +234,7 @@
 
 /mob/living/simple_animal/mouse/proc/MaintInfection()
 	infectable = TRUE
-	var/virus_choice = pick(subtypesof(/datum/disease2/disease))
+	var/virus_choice = get_random_disease_type(WMOUSE)
 	var/datum/disease2/disease/D = new virus_choice
 
 	var/list/anti = list(

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -298,8 +298,7 @@
 /mob/new_player/proc/DiseaseCarrierCheck(var/mob/living/carbon/human/H)
 	// 5% of players are joining the station with some minor disease
 	if(prob(5))
-		var/virus_choice = get_random_disease_type(WLATEJOIN)
-		var/datum/disease2/disease/D = new virus_choice
+		var/datum/disease2/disease/D = get_random_weighted_disease(WLATEJOIN)
 
 		var/list/anti = list(
 			ANTIGEN_BLOOD	= 1,

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -298,7 +298,7 @@
 /mob/new_player/proc/DiseaseCarrierCheck(var/mob/living/carbon/human/H)
 	// 5% of players are joining the station with some minor disease
 	if(prob(5))
-		var/virus_choice = pick(subtypesof(/datum/disease2/disease))
+		var/virus_choice = get_random_disease_type(WLATEJOIN)
 		var/datum/disease2/disease/D = new virus_choice
 
 		var/list/anti = list(

--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -1,7 +1,7 @@
 
 var/global/list/disease2_list = list()
 /datum/disease2/disease
-	var/form = "Virus"	//Virus, Bacteria, Parasite, Prion
+	var/form = "Virus"	//Virus, Bacteria, Parasite, Prion, Fungus, Meme
 	var/spread = 0 //if it remains at 0, the virus can never be transmitted or extracted from the carrier, therefore it cannot either be cured.
 	var/uniqueID = 0// 0000 to 9999, set when the pathogen gets initially created
 	var/subID = 0// 000 to 9999, set if the pathogen underwent effect or antigen mutation
@@ -58,6 +58,8 @@ var/global/list/disease2_list = list()
 	//pathogenic warfare
 	var/list/can_kill = list("Bacteria")
 
+	var/list/type_weight = list(0,0,0) //weight that it will appear in dish, new player, mouse; 4 is base
+
 /datum/disease2/disease/virus
 	form = "Virus"
 	max_stage = 4
@@ -66,6 +68,7 @@ var/global/list/disease2_list = list()
 	stageprob = 10
 	stage_variance = -1
 	can_kill = list("Bacteria")
+	type_weight = list(4,5,2) //more common in humans, less in mice
 
 /datum/disease2/disease/bacteria//faster spread and progression, but only 3 stages max, and reset to stage 1 on every spread
 	form = "Bacteria"
@@ -75,6 +78,7 @@ var/global/list/disease2_list = list()
 	stageprob = 30
 	stage_variance = -4
 	can_kill = list("Parasite")
+	type_weight = list(2,4,4) //reduced appearance in dishes
 
 /datum/disease2/disease/parasite//slower spread. stage preserved on spread
 	form = "Parasite"
@@ -83,6 +87,7 @@ var/global/list/disease2_list = list()
 	stageprob = 10
 	stage_variance = 0
 	can_kill = list("Virus")
+	type_weight = list(4,2,5) //less common in people, more common in mice
 
 /datum/disease2/disease/prion//very fast progression, but very slow spread and resets to stage 1.
 	form = "Prion"
@@ -91,6 +96,7 @@ var/global/list/disease2_list = list()
 	stageprob = 80
 	stage_variance = -10
 	can_kill = list()
+	type_weight = list(4,4,1) //rare in mice
 
 /datum/disease2/disease/fungus //most infectious, but with a greater stage setback; has special transmission
 	form = "Fungus"
@@ -99,6 +105,7 @@ var/global/list/disease2_list = list()
 	stageprob = 15
 	stage_variance = -2
 	allowed_transmission = SPREAD_BLOOD | SPREAD_CONTACT | SPREAD_AIRBORNE | SPREAD_COLONY
+	type_weight = list(4,5,2)
 
 /datum/disease2/disease/meme //infectious and fast progressing, but limited stages; has special transmission
 	form = "Meme"
@@ -108,6 +115,7 @@ var/global/list/disease2_list = list()
 	stageprob = 30
 	stage_variance = -1
 	allowed_transmission = SPREAD_BLOOD | SPREAD_MEMETIC
+	type_weight = list(1,6,0) //rare in dishes and never in mice, very common in people
 	//Note: if more types of creatures become infectable than humans/monkeys/mice, give them HEAR_ALWAYS
 
 /datum/disease2/disease/proc/update_global_log()

--- a/code/modules/virus2/helpers.dm
+++ b/code/modules/virus2/helpers.dm
@@ -1,10 +1,10 @@
 //Build random disease type
-proc/get_random_disease_type(var/operation = WDISH)
+proc/get_random_weighted_disease(var/operation = WDISH)
 	var/list/possibles = subtypesof(/datum/disease2/disease)
 	var/list/weighted_list = list()
 	for(var/P in possibles)
 		var/datum/disease2/disease/D = new P
-		weighted_list[D.type] = D.type_weight[operation]
+		weighted_list[D] = D.type_weight[operation]
 	return pickweight(weighted_list)
 
 ////////////////////////////////////////////////////

--- a/code/modules/virus2/helpers.dm
+++ b/code/modules/virus2/helpers.dm
@@ -1,3 +1,14 @@
+//Build random disease type
+proc/get_random_disease_type(var/operation = WDISH)
+	var/list/possibles = subtypesof(/datum/disease2/disease)
+	var/list/weighted_list = list()
+	for(var/P in possibles)
+		var/datum/disease2/disease/D = new P
+		weighted_list[D.type] = D.type_weight[operation]
+	return pickweight(weighted_list)
+
+////////////////////////////////////////////////////
+
 //Checks if table-passing table can reach target (5 tile radius)
 //For the record that proc is only used by the "Gregarious Impetus" symptom and super/toxic farts.
 proc/airborne_can_reach(turf/source, turf/target, var/radius=5)

--- a/code/modules/virus2/items_devices.dm
+++ b/code/modules/virus2/items_devices.dm
@@ -277,8 +277,7 @@ var/list/virusdishes = list()
 /obj/item/weapon/virusdish/random/New(loc)
 	..(loc)
 	if (loc)//because fuck you /datum/subsystem/supply_shuttle/Initialize()
-		var/virus_choice = get_random_disease_type(WDISH)
-		contained_virus = new virus_choice
+		contained_virus = get_random_weighted_disease(WDISH)
 		var/list/anti = list(
 			ANTIGEN_BLOOD	= 1,
 			ANTIGEN_COMMON	= 1,

--- a/code/modules/virus2/items_devices.dm
+++ b/code/modules/virus2/items_devices.dm
@@ -277,7 +277,7 @@ var/list/virusdishes = list()
 /obj/item/weapon/virusdish/random/New(loc)
 	..(loc)
 	if (loc)//because fuck you /datum/subsystem/supply_shuttle/Initialize()
-		var/virus_choice = pick(subtypesof(/datum/disease2/disease))
+		var/virus_choice = get_random_disease_type(WDISH)
 		contained_virus = new virus_choice
 		var/list/anti = list(
 			ANTIGEN_BLOOD	= 1,


### PR DESCRIPTION
Diseases can now have weights (how common they are) based on their type and original vector.

![image](https://user-images.githubusercontent.com/9782036/67237920-d1068e80-f411-11e9-9aed-88ae2b99c239.png)

Reduced odds of meme or bacteria in crates because annoying for virologists who want more symptoms. Mice don't get memes because to spread they would need a talking symptom. The rest is based off my idea of flavor.

**Tested!**

:cl:
* rscadd: Disease type is now based on vector. In general, expect no memes from mice, and less memes or bacteria in crates.