### PR TITLE
Sterile CMO

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -183,9 +183,10 @@
 
 /obj/item/device/radio/headset/heads/cmo
 	name = "chief medical officer's headset"
-	desc = "The headset of the highly trained medical chief. To access the medical channel, use :m. For command, use :c."
+	desc = "The headset of the highly trained medical chief. This one is sterilized against memetic infection. To access the medical channel, use :m. For command, use :c."
 	icon_state = "com_headset"
 	item_state = "headset"
+	sterility = 100
 
 /obj/item/device/radio/headset/heads/cmo/New()
 	keyslot2 = new /obj/item/device/encryptionkey/heads/cmo


### PR DESCRIPTION
🆑 
* rscadd: The CMO headset is now always sterilized against memes.