### PR TITLE
Pickweight Respects Zero

### DIFF
--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -135,7 +135,7 @@
 	var/total = 0
 	var/item
 	for (item in L)
-		if (!L[item])
+		if (isnull(L[item]))
 			L[item] = 1
 		total += L[item]
 


### PR DESCRIPTION
No CL, all backend

Pickweight now respects 0 and will not overwrite it with 1 weight, while still giving a null value weight of 1.