### PR TITLE
Makes code compile on 513

### DIFF
--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -40,10 +40,12 @@
 			return L[index]
 	return
 
+#if DM_VERSION < 513
 /proc/islist(list/L)
 	if(istype(L))
 		return 1
 	return 0
+#endif
 
 //Return either pick(list) or null if list is not of type /list or is empty
 /proc/safepick(list/L)

--- a/code/__HELPERS/maths.dm
+++ b/code/__HELPERS/maths.dm
@@ -25,9 +25,11 @@ var/list/sqrtTable = list(1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 
 	var/invcos = arccos(x / sqrt(x * x + y * y))
 	return y >= 0 ? invcos : -invcos
 
+#if DM_VERSION < 513
 proc/arctan(x)
 	var/y=arcsin(x/sqrt(1+x*x))
 	return y
+#endif
 
 /proc/Ceiling(x, y = 1)
 	. = -round(-x / y) * y
@@ -66,7 +68,7 @@ proc/arctan(x)
 		x = rand()
 	var/y = -(1/lambda)*log(1-x)
 	return y
-	
+
 // -- Returns the Lorentz cummulative distribution of the real x, with mean lambda
 
 /proc/exp_cummulative_distribution(var/x, var/lambda)
@@ -227,7 +229,7 @@ proc/arctan(x)
 /*
  * Tangent.
  */
-/proc/Tan(const/x) 
+/proc/Tan(const/x)
 	return sin(x) / cos(x)
 
 /proc/tan_rad(const/x) // This one assumes that x is in radians.

--- a/code/modules/mob/living/simple_animal/shade_powers.dm
+++ b/code/modules/mob/living/simple_animal/shade_powers.dm
@@ -304,7 +304,7 @@
 		var/mob/living/carbon/human/H = wielder
 		for(var/datum/organ/external/temp in H.organs)
 			if(temp.status & ORGAN_BLEEDING)
-				temp.clamp()
+				temp.clamp_wounds()
 
 	playsound(wielder.loc, 'sound/effects/mend.ogg', 50, 0, -2)
 	wielder.heal_organ_damage(10, 0)

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -937,7 +937,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		W.germ_level = 0
 	return rval
 
-/datum/organ/external/proc/clamp()
+/datum/organ/external/proc/clamp_wounds() //Inconsistent with the other names but clamp is a reserved word now
 	var/rval = 0
 	src.status &= ~ORGAN_BLEEDING
 	for(var/datum/wound/W in wounds)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -3347,7 +3347,7 @@
 		var/mob/living/carbon/human/H = M
 		for(var/datum/organ/external/temp in H.organs)
 			if(temp.status & ORGAN_BLEEDING)
-				temp.clamp()
+				temp.clamp_wounds()
 
 	if(M.losebreath >= 10)
 		M.losebreath = max(10, M.losebreath - 5)

--- a/code/modules/surgery/butt.dm
+++ b/code/modules/surgery/butt.dm
@@ -339,7 +339,7 @@
 	"<span class='notice'>You have cauterized [target]'s ass with \the [tool].</span>")
 	target.op_stage.butt_replace = SURGERY_HAS_A_BUTT
 	affected.open = 0
-	affected.clamp()
+	affected.clamp_wounds()
 
 /datum/surgery_step/butt_replace/cauterize/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	user.visible_message("<span class='warning'>[user]'s hand slips, burning the flesh around [target]'s butt with /the [tool]!</span>" , \

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -67,7 +67,7 @@
 	affected.open = 1
 	affected.status |= ORGAN_BLEEDING
 	affected.createwound(CUT, 1)
-	affected.clamp()
+	affected.clamp_wounds()
 	//spread_germs_to_organ(affected, user) //a laser scalpel shouldn't spread germs.
 
 /datum/surgery_step/generic/cut_with_laser/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -119,7 +119,7 @@
 	affected.open = 1
 	affected.status |= ORGAN_BLEEDING
 	affected.createwound(CUT, 1)
-	affected.clamp()
+	affected.clamp_wounds()
 	affected.open = 2
 	tool.icon_state = "[initial(tool.icon_state)]_off"
 
@@ -216,7 +216,7 @@
 	var/datum/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'>[user] clamps bleeders in [target]'s [affected.display_name] with \the [tool].</span>",	\
 	"<span class='notice'>You clamp bleeders in [target]'s [affected.display_name] with \the [tool].</span>")
-	affected.clamp()
+	affected.clamp_wounds()
 	spread_germs_to_organ(affected, user)
 
 /datum/surgery_step/generic/clamp_bleeders/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)


### PR DESCRIPTION
* `islist()` and `arctan()` are builtins in 513, so this undefines them in 513 and above
  * Whenever we *do* update to 513, we should completely remove these blocks
* `clamp()` is also a builtin in 513, which means it's a reserved word, so this changes the name of an organ proc to something else
  * I'll rename our `Clamp()` define to `clamp()` in a separate PR so that we can just remove the define whenever we update to 513

0% tested but the only thing that could conceivably go wrong is that it could fail to compile, which Travis would catch