### PR TITLE
Sounds are Wakeful

### DIFF
--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -138,9 +138,8 @@ var/const/SURROUND_CAP = 7
 		S.falloff = (falloff ? falloff : FALLOFF_SOUNDS)
 
 	src << S
-	if(stat == UNCONSCIOUS || sleeping > 0)
-		sleeping = max(0,sleeping - vol*0.05)
-		drowsyness = max(0,drowsyness - vol*0.1)
+	sleeping = max(0,sleeping - vol*0.05)
+	drowsyness = max(0,drowsyness - vol*0.05)
 
 /client/proc/playtitlemusic()
 	if(!ticker || !ticker.login_music || config.no_lobby_music)

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -138,6 +138,9 @@ var/const/SURROUND_CAP = 7
 		S.falloff = (falloff ? falloff : FALLOFF_SOUNDS)
 
 	src << S
+	if(stat == UNCONSCIOUS || sleeping > 0)
+		sleeping = max(0,sleeping - vol*0.05)
+		drowsyness = max(0,drowsyness - vol*0.1)
 
 /client/proc/playtitlemusic()
 	if(!ticker || !ticker.login_music || config.no_lobby_music)


### PR DESCRIPTION
TODO: Add in a sleep deduction for people who don't hear voice/instrument noises because of prefs.

Each 1 unit of sleep represents 1 tick or 2 seconds. For example, if you use the Sleep verb you gain 150 ticks of sleep, or 300 seconds (5 minutes). With this new PR, each time someone talks within your earshot (volume 50 sound) it would reduce your ticks by 2.5, or 5 seconds. If you fell asleep in the middle of the bar and slept through 60 messages of talking, you'd wake up (minus any time that it took for those conversations as well). This only applies if you aren't deaf of course. Yes, it works through walls - anything you hear.

Other examples (I didn't choose these)
Honkerblast: 100
Mech turn: 40
Mech step: 25
Punching bag hit: 50
Wrenching/screwing most things: 50
Grabbing a coat from the rack: 50
Buckling into/out of chair: 50
Deconstructing a reinforced wall (any step): 100
Gibbing a big roach: 40
Quaffing a potion: 10-50
Firing most guns: 50
Flashbang w/o protection: 60
Flashbang w/ protection: 25
Clusterbang split: 75
Superfart: 50
Opening/closing a mineral door: 100
Pumping a shotgun: 60
Explosion: 100

🆑 
* rscadd: Sounds will now reduce sleeping and drowsiness by 5% of volume