### PR TITLE
Broken tube light subtype and minor icon bugfixes for mapping

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -157,6 +157,10 @@ var/global/list/obj/machinery/light/alllights = list()
 	H.apply_damage(rand(1,2), BRUTE, pick(LIMB_RIGHT_LEG, LIMB_LEFT_LEG, LIMB_RIGHT_FOOT, LIMB_LEFT_FOOT))
 	return SPECIAL_ATTACK_FAILED
 
+/obj/machinery/light/broken
+	icon_state = "ltube_broken" //for the mapper
+	spawn_with_bulb = /obj/item/weapon/light/tube/broken
+
 /obj/machinery/light/small
 	icon_state = "lbulb1"
 	fitting = "bulb"
@@ -164,6 +168,7 @@ var/global/list/obj/machinery/light/alllights = list()
 	spawn_with_bulb = /obj/item/weapon/light/bulb
 
 /obj/machinery/light/small/broken
+	icon_state = "lbulb_broken" //for the mapper
 	spawn_with_bulb = /obj/item/weapon/light/bulb/broken
 
 /obj/machinery/light/spot
@@ -172,9 +177,11 @@ var/global/list/obj/machinery/light/alllights = list()
 	spawn_with_bulb = /obj/item/weapon/light/tube/large
 
 /obj/machinery/light/built
+	icon_state = "ltube-empty" //for the mapper
 	spawn_with_bulb = null
 
 /obj/machinery/light/small/built
+	icon_state = "lbulb_empty" //for the mapper
 	spawn_with_bulb = null
 
 /obj/machinery/light/initialize()
@@ -597,6 +604,9 @@ var/global/list/obj/machinery/light/alllights = list()
 	brightness_range = 8
 	brightness_power = 3
 	cost = 8
+
+/obj/item/weapon/light/tube/broken
+	status = LIGHT_BROKEN
 
 /obj/item/weapon/light/tube/he
 	name = "high efficiency light tube"

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -180,7 +180,7 @@ var/global/list/obj/machinery/light/alllights = list()
 	spawn_with_bulb = /obj/item/weapon/light/bulb
 
 /obj/machinery/light/small/broken
-	icon_state = "lbulb_broken" //for the mapper
+	icon_state = "lbulb-broken" //for the mapper
 	spawn_with_bulb = /obj/item/weapon/light/bulb/broken
 
 /obj/machinery/light/spot
@@ -193,7 +193,7 @@ var/global/list/obj/machinery/light/alllights = list()
 	spawn_with_bulb = null
 
 /obj/machinery/light/small/built
-	icon_state = "lbulb_empty" //for the mapper
+	icon_state = "lbulb-empty" //for the mapper
 	spawn_with_bulb = null
 
 /obj/machinery/light/initialize()

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -158,7 +158,7 @@ var/global/list/obj/machinery/light/alllights = list()
 	return SPECIAL_ATTACK_FAILED
 
 /obj/machinery/light/broken
-	icon_state = "ltube_broken" //for the mapper
+	icon_state = "ltube-broken" //for the mapper
 	spawn_with_bulb = /obj/item/weapon/light/tube/broken
 
 /obj/machinery/light/he

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -161,6 +161,18 @@ var/global/list/obj/machinery/light/alllights = list()
 	icon_state = "ltube_broken" //for the mapper
 	spawn_with_bulb = /obj/item/weapon/light/tube/broken
 
+/obj/machinery/light/he
+	icon_state = "lhetube1"
+	spawn_with_bulb = /obj/item/weapon/light/he
+
+/obj/machinery/light/he/broken
+	icon_state = "lhetube-broken"
+	spawn_with_bulb = /obj/item/weapon/light/he/broken
+
+/obj/machinery/light/he/burned
+	icon_state = "lhetube-burned"
+	spawn_with_bulb = /obj/item/weapon/light/he/burned
+
 /obj/machinery/light/small
 	icon_state = "lbulb1"
 	fitting = "bulb"
@@ -605,9 +617,6 @@ var/global/list/obj/machinery/light/alllights = list()
 	brightness_power = 3
 	cost = 8
 
-/obj/item/weapon/light/tube/broken
-	status = LIGHT_BROKEN
-
 /obj/item/weapon/light/tube/he
 	name = "high efficiency light tube"
 	desc = "An efficient light used to reduce strain on the station's power grid."
@@ -615,8 +624,19 @@ var/global/list/obj/machinery/light/alllights = list()
 	starting_materials = list(MAT_GLASS = 300, MAT_IRON = 60)
 	cost = 2
 
+/obj/item/weapon/light/tube/broken
+	status = LIGHT_BROKEN
+
 /obj/item/weapon/light/tube/burned
 	status = LIGHT_BURNED
+
+/obj/item/weapon/light/tube/he/broken
+	status = LIGHT_BROKEN
+
+/obj/item/weapon/light/tube/he/burned
+	status = LIGHT_BURNED
+
+
 
 /obj/item/weapon/light/tube/large
 	w_class = W_CLASS_SMALL

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -163,15 +163,15 @@ var/global/list/obj/machinery/light/alllights = list()
 
 /obj/machinery/light/he
 	icon_state = "lhetube1"
-	spawn_with_bulb = /obj/item/weapon/light/he
+	spawn_with_bulb = /obj/item/weapon/light/tube/he
 
 /obj/machinery/light/he/broken
 	icon_state = "lhetube-broken" //for the mapper
-	spawn_with_bulb = /obj/item/weapon/light/he/broken
+	spawn_with_bulb = /obj/item/weapon/light/tube/he/broken
 
 /obj/machinery/light/he/burned
 	icon_state = "lhetube-burned" //for the mapper
-	spawn_with_bulb = /obj/item/weapon/light/he/burned
+	spawn_with_bulb = /obj/item/weapon/light/tube/he/burned
 
 /obj/machinery/light/small
 	icon_state = "lbulb1"

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -166,11 +166,11 @@ var/global/list/obj/machinery/light/alllights = list()
 	spawn_with_bulb = /obj/item/weapon/light/he
 
 /obj/machinery/light/he/broken
-	icon_state = "lhetube-broken"
+	icon_state = "lhetube-broken" //for the mapper
 	spawn_with_bulb = /obj/item/weapon/light/he/broken
 
 /obj/machinery/light/he/burned
-	icon_state = "lhetube-burned"
+	icon_state = "lhetube-burned" //for the mapper
 	spawn_with_bulb = /obj/item/weapon/light/he/burned
 
 /obj/machinery/light/small
@@ -635,8 +635,6 @@ var/global/list/obj/machinery/light/alllights = list()
 
 /obj/item/weapon/light/tube/he/burned
 	status = LIGHT_BURNED
-
-
 
 /obj/item/weapon/light/tube/large
 	w_class = W_CLASS_SMALL


### PR DESCRIPTION
This apparently didn't exist. Also, used to be all the broken/no-bulb subtypes just looked like regular lit lights in the mapper. Fixed both of these things.