### PR TITLE
Renames Clamp() to clamp()

### DIFF
--- a/__DEFINES/_macros.dm
+++ b/__DEFINES/_macros.dm
@@ -330,15 +330,17 @@ proc/get_space_area()
 	return 0
 
 //1 line helper procs compressed into defines.
-#define Clamp(x, y, z) 	min(max(x, y), z)
+#if DM_VERSION < 513
+#define clamp(x, y, z) 	min(max(x, y), z)
 //x is the number you want to clamp
 //y is the minimum
 //z is the maximum
+#endif
 
 //Returns 1 if the variable contains a protected list that can't be edited
 #define variable_contains_protected_list(var_name) (((var_name) == "contents") || ((var_name) == "locs") || ((var_name) == "vars"))
 
-#define CLAMP01(x) 		(Clamp(x, 0, 1))
+#define CLAMP01(x) 		(clamp(x, 0, 1))
 
 //CPU lag shit
 #define calculateticks(x)	x * world.tick_lag // Converts your ticks to proper tenths.

--- a/code/ATMOSPHERICS/components/binary_devices/MSGS.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/MSGS.dm
@@ -146,11 +146,11 @@
 
 	var/total_moles = air.total_moles
 	if(round(total_moles, 0.01))	//Check if there's total moles to avoid divisions by zero.
-		interface.updateContent("oxypercent", Clamp(round(100 * air[GAS_OXYGEN]			/ total_moles, 0.1), 0, 100))
-		interface.updateContent("nitpercent", Clamp(round(100 * air[GAS_NITROGEN]		/ total_moles, 0.1), 0, 100))
-		interface.updateContent("co2percent", Clamp(round(100 * air[GAS_CARBON]			/ total_moles, 0.1), 0, 100))
-		interface.updateContent("plapercent", Clamp(round(100 * air[GAS_PLASMA]			/ total_moles, 0.1), 0, 100))
-		interface.updateContent("n2opercent", Clamp(round(100 * air[GAS_SLEEPING]		/ total_moles, 0.1), 0, 100))
+		interface.updateContent("oxypercent", clamp(round(100 * air[GAS_OXYGEN]			/ total_moles, 0.1), 0, 100))
+		interface.updateContent("nitpercent", clamp(round(100 * air[GAS_NITROGEN]		/ total_moles, 0.1), 0, 100))
+		interface.updateContent("co2percent", clamp(round(100 * air[GAS_CARBON]			/ total_moles, 0.1), 0, 100))
+		interface.updateContent("plapercent", clamp(round(100 * air[GAS_PLASMA]			/ total_moles, 0.1), 0, 100))
+		interface.updateContent("n2opercent", clamp(round(100 * air[GAS_SLEEPING]		/ total_moles, 0.1), 0, 100))
 
 	else
 		interface.updateContent("oxypercent", 0)
@@ -172,13 +172,13 @@
 		return
 
 	if(href_list["power"])
-		on = round(Clamp(text2num(href_list["power"]), 0, 1))
+		on = round(clamp(text2num(href_list["power"]), 0, 1))
 		updateUsrDialog()
 		update_icon()
 		return 1
 
 	if(href_list["set_pressure"])
-		target_pressure = round(Clamp(text2num(href_list["set_pressure"]), 0, 4500))
+		target_pressure = round(clamp(text2num(href_list["set_pressure"]), 0, 4500))
 		update_icon()
 		updateUsrDialog()
 		return 1
@@ -219,7 +219,7 @@
 		update = 1
 
 	var/pressure = air.return_pressure() // null ref error here.
-	var/i = Clamp(round(pressure / (max_pressure / 5)), 0, 5)
+	var/i = clamp(round(pressure / (max_pressure / 5)), 0, 5)
 	if(i != last_pressure)
 		update = 1
 

--- a/code/ATMOSPHERICS/components/binary_devices/dp_vent_pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/dp_vent_pump.dm
@@ -86,7 +86,7 @@
 
 				if(network1)
 					network1.update = 1
-		
+
 		else //external -> internal
 			if(node2 && (environment.temperature || air2.temperature))
 				var/air_temperature = (environment.temperature > 0) ? environment.temperature : air2.temperature
@@ -174,13 +174,13 @@
 		pressure_checks = text2num(signal.data["checks"])
 
 	if("set_input_pressure" in signal.data)
-		input_pressure_min = Clamp(text2num(signal.data["set_input_pressure"]), 0, ONE_ATMOSPHERE * 50)
+		input_pressure_min = clamp(text2num(signal.data["set_input_pressure"]), 0, ONE_ATMOSPHERE * 50)
 
 	if("set_output_pressure" in signal.data)
-		output_pressure_max = Clamp(text2num(signal.data["set_output_pressure"]), 0, ONE_ATMOSPHERE * 50)
+		output_pressure_max = clamp(text2num(signal.data["set_output_pressure"]), 0, ONE_ATMOSPHERE * 50)
 
 	if("set_external_pressure" in signal.data)
-		external_pressure_bound = Clamp(text2num(signal.data["set_external_pressure"]), 0, ONE_ATMOSPHERE * 50)
+		external_pressure_bound = clamp(text2num(signal.data["set_external_pressure"]), 0, ONE_ATMOSPHERE * 50)
 
 	if("status" in signal.data)
 		spawn(2)

--- a/code/ATMOSPHERICS/components/binary_devices/pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/pump.dm
@@ -126,7 +126,7 @@ air2.volume
 		if("power")
 			on = text2num(signal.data["value"])
 		if("set_target_pressure")
-			target_pressure = Clamp(text2num(signal.data["value"]), 0, MAX_PRESSURE)
+			target_pressure = clamp(text2num(signal.data["value"]), 0, MAX_PRESSURE)
 			investigation_log(I_ATMOS, "was set to [target_pressure] kPa by a remote signal.")
 	if("status" in signal.data)
 		spawn(2)

--- a/code/ATMOSPHERICS/components/binary_devices/volume_pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/volume_pump.dm
@@ -125,7 +125,7 @@ Thus, the two variables affect pump operation are set in New():
 		if("power")
 			on = text2num(signal.data["value"])
 		if("set_transfer_rate")
-			transfer_rate = Clamp(text2num(signal.data["value"]), 0, MAX_TRANSFER_RATE)
+			transfer_rate = clamp(text2num(signal.data["value"]), 0, MAX_TRANSFER_RATE)
 			investigation_log(I_ATMOS, "was set to [transfer_rate] L/s by a remote signal.")
 
 	if("status" in signal.data)
@@ -171,7 +171,7 @@ Thus, the two variables affect pump operation are set in New():
 			id_tag = newid
 			initialize()
 		return MT_UPDATE
-		
+
 	if("set_freq" in href_list)
 		var/newfreq=frequency
 		if(href_list["set_freq"]!="-1")

--- a/code/ATMOSPHERICS/components/unary/outlet_injector.dm
+++ b/code/ATMOSPHERICS/components/unary/outlet_injector.dm
@@ -131,7 +131,7 @@
 
 	if("set_volume_rate" in signal.data)
 		var/number = text2num(signal.data["set_volume_rate"])
-		volume_rate = Clamp(number, 0, air_contents.volume)
+		volume_rate = clamp(number, 0, air_contents.volume)
 
 	if("status" in signal.data)
 		spawn(2)

--- a/code/ATMOSPHERICS/components/unary/vent_pump.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_pump.dm
@@ -119,7 +119,7 @@
 			var/transfer_moles = (pressure_delta * environment.volume) / (air_temperature * R_IDEAL_GAS_EQUATION)
 			var/datum/gas_mixture/removed = air_contents.remove(transfer_moles)
 			loc.assume_air(removed)
-		
+
 		else //external -> internal
 			var/air_temperature = (environment.temperature > 0) ? environment.temperature : air_contents.temperature
 			var/output_volume = air_contents.volume + (network ? network.volume : 0)
@@ -130,7 +130,7 @@
 			if(isnull(removed)) //in space
 				return
 			air_contents.merge(removed)
-		
+
 		if(network)
 			network.update = 1
 	else
@@ -245,16 +245,16 @@
 		pump_direction = text2num(signal.data["direction"])
 
 	if("set_internal_pressure" in signal.data)
-		internal_pressure_bound = Clamp(text2num(signal.data["set_internal_pressure"]), 0, ONE_ATMOSPHERE * 50)
+		internal_pressure_bound = clamp(text2num(signal.data["set_internal_pressure"]), 0, ONE_ATMOSPHERE * 50)
 
 	if("set_external_pressure" in signal.data)
-		external_pressure_bound = Clamp(text2num(signal.data["set_external_pressure"]), 0, ONE_ATMOSPHERE * 50)
+		external_pressure_bound = clamp(text2num(signal.data["set_external_pressure"]), 0, ONE_ATMOSPHERE * 50)
 
 	if("adjust_internal_pressure" in signal.data)
-		internal_pressure_bound = Clamp(internal_pressure_bound + text2num(signal.data["adjust_internal_pressure"]), 0, ONE_ATMOSPHERE * 50)
+		internal_pressure_bound = clamp(internal_pressure_bound + text2num(signal.data["adjust_internal_pressure"]), 0, ONE_ATMOSPHERE * 50)
 
 	if("adjust_external_pressure" in signal.data)
-		external_pressure_bound = Clamp(external_pressure_bound + text2num(signal.data["adjust_external_pressure"]), 0, ONE_ATMOSPHERE * 50)
+		external_pressure_bound = clamp(external_pressure_bound + text2num(signal.data["adjust_external_pressure"]), 0, ONE_ATMOSPHERE * 50)
 
 	if("init" in signal.data)
 		name = signal.data["init"]

--- a/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
@@ -342,16 +342,16 @@
 		pressure_checks = (pressure_checks?0:3)
 
 	if("set_internal_pressure" in signal.data)
-		internal_pressure_bound = Clamp(text2num(signal.data["set_internal_pressure"]), 0, ONE_ATMOSPHERE * 50)
+		internal_pressure_bound = clamp(text2num(signal.data["set_internal_pressure"]), 0, ONE_ATMOSPHERE * 50)
 
 	if("set_external_pressure" in signal.data)
-		external_pressure_bound = Clamp(text2num(signal.data["set_external_pressure"]), 0, ONE_ATMOSPHERE * 50)
+		external_pressure_bound = clamp(text2num(signal.data["set_external_pressure"]), 0, ONE_ATMOSPHERE * 50)
 
 	if("adjust_internal_pressure" in signal.data)
-		internal_pressure_bound = Clamp(internal_pressure_bound + text2num(signal.data["adjust_internal_pressure"]), 0, ONE_ATMOSPHERE * 50)
+		internal_pressure_bound = clamp(internal_pressure_bound + text2num(signal.data["adjust_internal_pressure"]), 0, ONE_ATMOSPHERE * 50)
 
 	if("adjust_external_pressure" in signal.data)
-		external_pressure_bound = Clamp(external_pressure_bound + text2num(signal.data["adjust_external_pressure"]), 0, ONE_ATMOSPHERE * 50)
+		external_pressure_bound = clamp(external_pressure_bound + text2num(signal.data["adjust_external_pressure"]), 0, ONE_ATMOSPHERE * 50)
 
 	if(signal.data["init"] != null)
 		name = signal.data["init"]

--- a/code/ATMOSPHERICS/hvac/chiller.dm
+++ b/code/ATMOSPHERICS/hvac/chiller.dm
@@ -65,7 +65,7 @@
 				var/value = text2num(href_list["val"])
 
 				// limit to 0c and 25c(room temp)
-				set_temperature = Clamp(set_temperature + value, 0, 25)
+				set_temperature = clamp(set_temperature + value, 0, 25)
 
 			if("cellremove")
 				if(panel_open && cell && !usr.get_active_hand())

--- a/code/ATMOSPHERICS/hvac/spaceheater.dm
+++ b/code/ATMOSPHERICS/hvac/spaceheater.dm
@@ -161,7 +161,7 @@
 		return
 	if(istype(I, /obj/item/stack/sheet/wood) && ((on)||(nocell == 2)))
 		var/woodnumber = input(user, "You may insert a maximum of four planks.", "How much wood would you like to add to \the [src]?", 0) as num
-		woodnumber = Clamp(woodnumber,0,4)
+		woodnumber = clamp(woodnumber,0,4)
 		var/obj/item/stack/sheet/wood/woody = I
 		woody.use(woodnumber)
 		user.visible_message("<span class='notice'>[user] adds some wood to \the [src].</span>", "<span class='notice'>You add some wood to \the [src].</span>")
@@ -249,7 +249,7 @@
 				var/value = text2num(href_list["val"])
 
 				// limit to 20-90 degC
-				set_temperature = Clamp(set_temperature + value, 20, 90)
+				set_temperature = clamp(set_temperature + value, 20, 90)
 
 			if("cellremove")
 				if(panel_open && cell && !usr.get_active_hand())

--- a/code/ATMOSPHERICS/pipe/pipe_dispenser.dm
+++ b/code/ATMOSPHERICS/pipe/pipe_dispenser.dm
@@ -129,7 +129,7 @@
 	if(href_list["editlayer"])
 		if(!wait)
 			var/num_input = input(usr, "Alignment", "Calibrate Dispenser", "") as num
-			num_input = Clamp(round(num_input, PIPING_LAYER_INCREMENT), PIPING_LAYER_MIN, PIPING_LAYER_MAX)
+			num_input = clamp(round(num_input, PIPING_LAYER_INCREMENT), PIPING_LAYER_MIN, PIPING_LAYER_MAX)
 			layer_to_make = num_input
 			interact(usr)
 	return

--- a/code/ATMOSPHERICS/pipes.dm
+++ b/code/ATMOSPHERICS/pipes.dm
@@ -1124,7 +1124,7 @@
 			else
 				layer_mod = -1
 
-		user.ventcrawl_layer = Clamp(user.ventcrawl_layer + layer_mod, PIPING_LAYER_MIN, PIPING_LAYER_MAX)
+		user.ventcrawl_layer = clamp(user.ventcrawl_layer + layer_mod, PIPING_LAYER_MIN, PIPING_LAYER_MAX)
 		to_chat(user, "You align yourself with the [user.ventcrawl_layer]\th output.")
 		return 1
 	else

--- a/code/WorkInProgress/Cael_Aislinn/Rust/core_control.dm
+++ b/code/WorkInProgress/Cael_Aislinn/Rust/core_control.dm
@@ -7,7 +7,7 @@
 	var/list/connected_devices = list()
 	var/scan_range = 25
 	circuit = /obj/item/weapon/circuitboard/rust_core_control
-	
+
 	//currently viewed
 	var/obj/machinery/power/rust_core/cur_viewed_device
 
@@ -119,7 +119,7 @@
 		return
 
 	if(href_list["access_device"])
-		var/idx = Clamp(text2num(href_list["toggle_active"]), 1, connected_devices.len)
+		var/idx = clamp(text2num(href_list["toggle_active"]), 1, connected_devices.len)
 		cur_viewed_device = connected_devices[idx]
 		updateUsrDialog()
 		return 1

--- a/code/WorkInProgress/Cael_Aislinn/Rust/core_gen.dm
+++ b/code/WorkInProgress/Cael_Aislinn/Rust/core_gen.dm
@@ -158,14 +158,14 @@ max volume of plasma storeable by the field = the total volume of a number of ti
 	"}
 
 /obj/machinery/power/rust_core/proc/set_strength(var/value)
-	value = Clamp(value, MIN_FIELD_STR, MAX_FIELD_STR)
+	value = clamp(value, MIN_FIELD_STR, MAX_FIELD_STR)
 	field_strength = value
 	active_power_usage = RUST_CORE_STR_COST * value
 	if(owned_field)
 		owned_field.ChangeFieldStrength(value)
 
 /obj/machinery/power/rust_core/proc/set_frequency(var/value)
-	value = Clamp(value, MIN_FIELD_FREQ, MAX_FIELD_FREQ)
+	value = clamp(value, MIN_FIELD_FREQ, MAX_FIELD_FREQ)
 	field_frequency = value
 	if(owned_field)
 		owned_field.ChangeFieldFrequency(value)

--- a/code/WorkInProgress/Cael_Aislinn/Rust/gyrotron_controller.dm
+++ b/code/WorkInProgress/Cael_Aislinn/Rust/gyrotron_controller.dm
@@ -100,7 +100,7 @@
 	if(!href_list["gyro"])
 		return
 
-	var/idx = Clamp(text2num(href_list["gyro"]), 1, linked_gyrotrons.len)
+	var/idx = clamp(text2num(href_list["gyro"]), 1, linked_gyrotrons.len)
 	var/obj/machinery/rust/gyrotron/gyro = linked_gyrotrons[idx]
 
 	if(!gyro || gyro.stat & (NOPOWER | BROKEN))
@@ -112,7 +112,7 @@
 			to_chat(usr, "<span class='warning'>That's not a valid number.</span>")
 			return 1
 
-		gyro.mega_energy = Clamp(new_val, 0.001, 0.01)
+		gyro.mega_energy = clamp(new_val, 0.001, 0.01)
 		gyro.active_power_usage = gyro.mega_energy * 100000000 //1 MW for 0.01 TJ, 100 KW for 0.001 TJ.
 
 		updateUsrDialog()
@@ -124,7 +124,7 @@
 			to_chat(usr, "<span class='warning'>That's not a valid number.</span>")
 			return 1
 
-		gyro.rate = Clamp(new_val, 10, 100)
+		gyro.rate = clamp(new_val, 10, 100)
 
 		updateUsrDialog()
 		return 1
@@ -135,7 +135,7 @@
 			to_chat(usr, "<span class='warning'>That's not a valid number.</span>")
 			return 1
 
-		gyro.frequency = Clamp(new_val, 1, 50000)
+		gyro.frequency = clamp(new_val, 1, 50000)
 
 		updateUsrDialog()
 		return 1

--- a/code/WorkInProgress/Cael_Aislinn/ShieldGen/shield_capacitor.dm
+++ b/code/WorkInProgress/Cael_Aislinn/ShieldGen/shield_capacitor.dm
@@ -43,8 +43,8 @@
 	var/T = 0
 	for(var/obj/item/weapon/stock_parts/capacitor/Ca in component_parts)
 		T += Ca.rating - 1
-		max_charge = (initial(max_charge)+(T * 10000000))	
-		max_charge_rate = (initial(max_charge_rate)+(T * 10000000))	
+		max_charge = (initial(max_charge)+(T * 10000000))
+		max_charge_rate = (initial(max_charge_rate)+(T * 10000000))
 
 /obj/machinery/shield_capacitor/proc/toggle_lock(var/mob/user)
 	locked = !locked
@@ -131,7 +131,7 @@
 		active = !active
 		use_power = active ? 2 : 1
 	if(href_list["adjust_charge_rate"])
-		charge_rate = Clamp(charge_rate + text2num(href_list["adjust_charge_rate"]), min_charge_rate, max_charge_rate)
+		charge_rate = clamp(charge_rate + text2num(href_list["adjust_charge_rate"]), min_charge_rate, max_charge_rate)
 	return 1
 
 /obj/machinery/shield_capacitor/kick_act()
@@ -141,7 +141,7 @@
 		return
 	if(prob(50))
 		active = !active
-	
+
 /obj/machinery/shield_capacitor/proc/rotate(var/mob/user, var/degrees)
 	if(anchored)
 		to_chat(user, "\The [src] is fastened to the floor!")

--- a/code/WorkInProgress/Cael_Aislinn/ShieldGen/shield_gen.dm
+++ b/code/WorkInProgress/Cael_Aislinn/ShieldGen/shield_gen.dm
@@ -189,11 +189,11 @@
 	if(href_list["toggle_active"])
 		toggle()
 	else if(href_list["adjust_field_radius"])
-		field_radius = Clamp(field_radius + text2num(href_list["adjust_field_radius"]), MIN_FIELD_RADIUS, MAX_FIELD_RADIUS)
+		field_radius = clamp(field_radius + text2num(href_list["adjust_field_radius"]), MIN_FIELD_RADIUS, MAX_FIELD_RADIUS)
 	else if(href_list["adjust_strengthen_rate"])
-		strengthen_rate = Clamp(strengthen_rate + text2num(href_list["adjust_strengthen_rate"]), MIN_STRENGTHEN_RATE, MAX_STRENGTHEN_RATE)
+		strengthen_rate = clamp(strengthen_rate + text2num(href_list["adjust_strengthen_rate"]), MIN_STRENGTHEN_RATE, MAX_STRENGTHEN_RATE)
 	else if(href_list["adjust_field_strength_cap"])
-		field_strength_cap = Clamp(field_strength_cap + text2num(href_list["adjust_field_strength_cap"]), MIN_FIELD_STRENGTH_CAP, MAX_FIELD_STRENGTH_CAP)
+		field_strength_cap = clamp(field_strength_cap + text2num(href_list["adjust_field_strength_cap"]), MIN_FIELD_STRENGTH_CAP, MAX_FIELD_STRENGTH_CAP)
 	return 1
 
 /obj/machinery/shield_gen/update_icon()

--- a/code/WorkInProgress/pomf/spacepods/spacepods.dm
+++ b/code/WorkInProgress/pomf/spacepods/spacepods.dm
@@ -138,7 +138,7 @@
 
 /obj/spacepod/proc/adjust_health(var/damage)
 	var/oldhealth = health
-	health = Clamp(health-damage,0, maxHealth)
+	health = clamp(health-damage,0, maxHealth)
 	var/percentage = (health / initial(health)) * 100
 	var/mob/pilot = get_pilot()
 	if(pilot && oldhealth > health && percentage <= 25 && percentage > 0)

--- a/code/ZAS/Airflow.dm
+++ b/code/ZAS/Airflow.dm
@@ -158,7 +158,7 @@ atom/movable/GotoAirflowDest(n)
 		xo *= -1
 		yo *= -1
 
-	airflow_speed = Clamp(n * (9 / airflow_falloff), 1, 9)
+	airflow_speed = clamp(n * (9 / airflow_falloff), 1, 9)
 
 	airflow_dest = null
 
@@ -188,7 +188,7 @@ atom/movable/GotoAirflowDest(n)
 			if(od)
 				setDensity(TRUE)
 			if ((!( src.airflow_dest ) || src.loc == src.airflow_dest))
-				airflow_dest = locate(Clamp(x + xo, 1, world.maxx), Clamp(y + yo, 1, world.maxy), z)
+				airflow_dest = locate(clamp(x + xo, 1, world.maxx), clamp(y + yo, 1, world.maxy), z)
 			if ((src.x == 1 || src.x == world.maxx || src.y == 1 || src.y == world.maxy))
 				break
 			if(!isturf(loc))

--- a/code/ZAS/Fire.dm
+++ b/code/ZAS/Fire.dm
@@ -307,7 +307,7 @@ datum/gas_mixture/proc/zburn(var/turf/T, force_burn)
 		var/total_reactants = total_fuel + total_oxygen
 
 		//determine the amount of reactants actually reacting
-		var/used_reactants_ratio = Clamp(firelevel / zas_settings.Get(/datum/ZAS_Setting/fire_firelevel_multiplier), Clamp(0.2 / total_reactants, 0, 1), 1)
+		var/used_reactants_ratio = clamp(firelevel / zas_settings.Get(/datum/ZAS_Setting/fire_firelevel_multiplier), clamp(0.2 / total_reactants, 0, 1), 1)
 
 		//remove and add gasses as calculated
 		adjust_multi(

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -579,4 +579,4 @@ var/list/DummyCache = list()
 	//if(mixedcolor<0x00 || mixedcolor>0xFF)
 	//	return 0
 	// that's not the kind of operation we are running here, nerd
-	return Clamp(round(mixedcolor), 0, 255)
+	return clamp(round(mixedcolor), 0, 255)

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -90,9 +90,9 @@ proc/adjust_brightness(var/color, var/value)
 		return color
 
 	var/list/RGB = ReadRGB(color)
-	RGB[1] = Clamp(RGB[1]+value,0,255)
-	RGB[2] = Clamp(RGB[2]+value,0,255)
-	RGB[3] = Clamp(RGB[3]+value,0,255)
+	RGB[1] = clamp(RGB[1]+value,0,255)
+	RGB[2] = clamp(RGB[2]+value,0,255)
+	RGB[3] = clamp(RGB[3]+value,0,255)
 	return rgb(RGB[1],RGB[2],RGB[3])
 
 proc/adjust_RGB(var/color, var/red, var/green, var/blue)
@@ -102,9 +102,9 @@ proc/adjust_RGB(var/color, var/red, var/green, var/blue)
 		return color
 
 	var/list/RGB = ReadRGB(color)
-	RGB[1] = Clamp(RGB[1]+red,0,255)
-	RGB[2] = Clamp(RGB[2]+green,0,255)
-	RGB[3] = Clamp(RGB[3]+blue,0,255)
+	RGB[1] = clamp(RGB[1]+red,0,255)
+	RGB[2] = clamp(RGB[2]+green,0,255)
+	RGB[3] = clamp(RGB[3]+blue,0,255)
 	return rgb(RGB[1],RGB[2],RGB[3])
 
 /proc/ListColors(var/icon/I, var/ignoreGreyscale = 0)

--- a/code/__HELPERS/maths.dm
+++ b/code/__HELPERS/maths.dm
@@ -78,7 +78,7 @@ proc/arctan(x)
 
 //Moved to macros.dm to reduce pure calling overhead, this was being called shitloads, like, most calls of all procs.
 /*
-/proc/Clamp(const/val, const/min, const/max)
+/proc/clamp(const/val, const/min, const/max)
 	if (val <= min)
 		return min
 
@@ -188,7 +188,7 @@ proc/arctan(x)
 /proc/unmix(x, a, b, min = 0, max = 1)
 	if(a==b)
 		return 1
-	return Clamp( (b - x)/(b - a), min, max )
+	return clamp( (b - x)/(b - a), min, max )
 
 /proc/Mean(...)
 	var/values 	= 0

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -157,7 +157,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 
 //Ensure the frequency is within bounds of what it should be sending/recieving at
 /proc/sanitize_frequency(var/f)
-	f = Clamp(round(f), 1201, 1599) // 120.1, 159.9
+	f = clamp(round(f), 1201, 1599) // 120.1, 159.9
 
 	if ((f % 2) == 0) //Ensure the last digit is an odd number
 		f += 1
@@ -598,8 +598,8 @@ Turf and target are seperate in case you want to teleport some distance from a t
 // returns turf relative to A offset in dx and dy tiles
 // bound to map limits
 /proc/get_offset_target_turf(atom/A, dx, dy)
-	var/x = Clamp(A.x + dx, 1, world.maxx)
-	var/y = Clamp(A.y + dy, 1, world.maxy)
+	var/x = clamp(A.x + dx, 1, world.maxx)
+	var/y = clamp(A.y + dy, 1, world.maxy)
 
 	return locate(x, y, A.z)
 

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -73,7 +73,7 @@
 	if (!G) return
 	var/list/params_list = params2list(params)
 	if (params_list.len)
-		var/new_aim = Clamp(text2num(params_list["icon-y"]), 0, 480)
+		var/new_aim = clamp(text2num(params_list["icon-y"]), 0, 480)
 		if (new_aim>6)
 			G.aim = new_aim
 			G.update_aim()
@@ -296,8 +296,8 @@
 	var/view = world.view
 	if(user && user.client)
 		view = user.client.view
-	X = Clamp((origin.x + text2num(X) - (view + 1)), 1, world.maxx)
-	Y = Clamp((origin.y + text2num(Y) - (view + 1)), 1, world.maxy)
+	X = clamp((origin.x + text2num(X) - (view + 1)), 1, world.maxx)
+	Y = clamp((origin.y + text2num(Y) - (view + 1)), 1, world.maxy)
 	return locate(X, Y, origin.z)
 
 /obj/abstract/screen/Click(location, control, params)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -49,9 +49,9 @@
 
 obj/item/proc/get_clamped_volume()
 	if(src.force && src.w_class)
-		return Clamp((src.force + src.w_class) * 4, 30, 100)// Add the item's force to its weight class and multiply by 4, then clamp the value between 30 and 100
+		return clamp((src.force + src.w_class) * 4, 30, 100)// Add the item's force to its weight class and multiply by 4, then clamp the value between 30 and 100
 	else if(!src.force && src.w_class)
-		return Clamp(src.w_class * 6, 10, 100) // Multiply the item's weight class by 6, then clamp the value between 10 and 100
+		return clamp(src.w_class * 6, 10, 100) // Multiply the item's weight class by 6, then clamp the value between 10 and 100
 
 /obj/item/proc/attack(mob/living/M as mob, mob/living/user as mob, def_zone, var/originator = null)
 	if(restraint_resist_time > 0)

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -208,9 +208,9 @@ var/list/advance_cures = 	list(
 
 		hidden = list( (properties["stealth"] > 2), (properties["stealth"] > 3) )
 		// The more symptoms we have, the less transmittable it is but some symptoms can make up for it.
-		SetSpread(Clamp(properties["transmittable"] - symptoms.len, BLOODBORNE, AIRBORNE))
+		SetSpread(clamp(properties["transmittable"] - symptoms.len, BLOODBORNE, AIRBORNE))
 		permeability_mod = max(Ceiling(0.4 * properties["transmittable"]), 1)
-		cure_chance = 15 - Clamp(properties["resistance"], -5, 5) // can be between 10 and 20
+		cure_chance = 15 - clamp(properties["resistance"], -5, 5) // can be between 10 and 20
 		stage_prob = max(properties["stage_rate"], 2)
 		SetSeverity(properties["severity"])
 		GenerateCure(properties)
@@ -260,7 +260,7 @@ var/list/advance_cures = 	list(
 // Will generate a random cure, the less resistance the symptoms have, the harder the cure.
 /datum/disease/advance/proc/GenerateCure(var/list/properties = list())
 	if(properties && properties.len)
-		var/res = Clamp(properties["resistance"] - (symptoms.len / 2), 1, advance_cures.len)
+		var/res = clamp(properties["resistance"] - (symptoms.len / 2), 1, advance_cures.len)
 //		to_chat(world, "Res = [res]")
 		cure_id = advance_cures[res]
 

--- a/code/datums/gamemode/dynamic/dynamic.dm
+++ b/code/datums/gamemode/dynamic/dynamic.dm
@@ -181,10 +181,10 @@ var/stacking_limit = 90
 
 
 	var/latejoin_injection_cooldown_middle = 0.5*(LATEJOIN_DELAY_MAX + LATEJOIN_DELAY_MIN)
-	latejoin_injection_cooldown = round(Clamp(exp_distribution(latejoin_injection_cooldown_middle), LATEJOIN_DELAY_MIN, LATEJOIN_DELAY_MAX))
+	latejoin_injection_cooldown = round(clamp(exp_distribution(latejoin_injection_cooldown_middle), LATEJOIN_DELAY_MIN, LATEJOIN_DELAY_MAX))
 
 	var/midround_injection_cooldown_middle = 0.5*(MIDROUND_DELAY_MAX + MIDROUND_DELAY_MIN)
-	midround_injection_cooldown = round(Clamp(exp_distribution(midround_injection_cooldown_middle), MIDROUND_DELAY_MIN, MIDROUND_DELAY_MAX))
+	midround_injection_cooldown = round(clamp(exp_distribution(midround_injection_cooldown_middle), MIDROUND_DELAY_MIN, MIDROUND_DELAY_MAX))
 
 	message_admins("Dynamic Mode initialized with a Threat Level of... <font size='8'>[threat_level]</font>!")
 	log_admin("Dynamic Mode initialized with a Threat Level of... [threat_level]!")
@@ -477,7 +477,7 @@ var/stacking_limit = 90
 
 		if (injection_attempt())
 			var/midround_injection_cooldown_middle = 0.5*(MIDROUND_DELAY_MAX + MIDROUND_DELAY_MIN)
-			midround_injection_cooldown = round(Clamp(exp_distribution(midround_injection_cooldown_middle), MIDROUND_DELAY_MIN, MIDROUND_DELAY_MAX))
+			midround_injection_cooldown = round(clamp(exp_distribution(midround_injection_cooldown_middle), MIDROUND_DELAY_MIN, MIDROUND_DELAY_MAX))
 			var/list/drafted_rules = list()
 			var/list/current_players = list(CURRENT_LIVING_PLAYERS, CURRENT_LIVING_ANTAGS, CURRENT_DEAD_PLAYERS, CURRENT_OBSERVERS)
 			current_players[CURRENT_LIVING_PLAYERS] = living_players.Copy()
@@ -624,7 +624,7 @@ var/stacking_limit = 90
 
 		if (drafted_rules.len > 0 && picking_latejoin_rule(drafted_rules))
 			var/latejoin_injection_cooldown_middle = 0.5*(LATEJOIN_DELAY_MAX + LATEJOIN_DELAY_MIN)
-			latejoin_injection_cooldown = round(Clamp(exp_distribution(latejoin_injection_cooldown_middle), LATEJOIN_DELAY_MIN, LATEJOIN_DELAY_MAX))
+			latejoin_injection_cooldown = round(clamp(exp_distribution(latejoin_injection_cooldown_middle), LATEJOIN_DELAY_MIN, LATEJOIN_DELAY_MAX))
 
 /datum/gamemode/dynamic/mob_destroyed(var/mob/M)
 	for (var/datum/dynamic_ruleset/DR in midround_rules)

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -477,7 +477,7 @@
 	if(!mode.executed_rules)
 		return FALSE
 		//We have nothing to investigate!
-	weight = Clamp(300/(population^2),1,10) //1-5: 10; 8.3, 6.1, 4.6, 3.7, 3, ... , 1.2 (15)
+	weight = clamp(300/(population^2),1,10) //1-5: 10; 8.3, 6.1, 4.6, 3.7, 3, ... , 1.2 (15)
 	//We don't cotton to freaks in highpop
 	return ..()
 

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
@@ -821,7 +821,7 @@ var/list/cult_spires = list()
 	..()
 	cult_spires.Add(src)
 	set_light(1)
-	stage = Clamp(veil_thickness, 1, 3)
+	stage = clamp(veil_thickness, 1, 3)
 	flick("spire[stage]-spawn",src)
 	spawn(10)
 		update_stage()
@@ -840,7 +840,7 @@ var/list/cult_spires = list()
 	..()
 
 /obj/structure/cult/spire/proc/upgrade()
-	var/new_stage = Clamp(veil_thickness, 1, 3)
+	var/new_stage = clamp(veil_thickness, 1, 3)
 	if (new_stage>stage)
 		stage = new_stage
 		alpha = 255

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_effects.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_effects.dm
@@ -438,7 +438,7 @@ var/list/bloodstone_backup = 0
 		return
 
 	victim = loc
-	current_dots = Clamp(round(victim.knockdown/2.5),0,5)
+	current_dots = clamp(round(victim.knockdown/2.5),0,5)
 
 	if (!current_dots)
 		qdel(src)
@@ -458,7 +458,7 @@ var/list/bloodstone_backup = 0
 	while (victim && (victim.stat < DEAD) && victim.knockdown)
 		for (var/client/C in viewers)
 			C.images -= indicator
-		var/dots = Clamp(1+round(victim.knockdown/2.5),1,6)
+		var/dots = clamp(1+round(victim.knockdown/2.5),1,6)
 		var/anim = 0
 		if (dots!=current_dots)
 			anim = 1

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
@@ -954,7 +954,7 @@
 						progress = progress/4
 
 				if (delay)
-					progress = Clamp(progress,1,10)
+					progress = clamp(progress,1,10)
 				remaining -= progress
 				update_progbar()
 				victim.update_fullscreen_alpha("conversionred", 164-remaining, 8)

--- a/code/datums/gamemode/role/changeling.dm
+++ b/code/datums/gamemode/role/changeling.dm
@@ -70,7 +70,7 @@
 		return
 	var/changes = FALSE
 	var/changeby = chem_charges
-	chem_charges = Clamp(chem_charges + chem_recharge_rate, 0, chem_storage)
+	chem_charges = clamp(chem_charges + chem_recharge_rate, 0, chem_storage)
 	if(chem_charges != changeby)
 		changes = TRUE
 	changeby = geneticdamage
@@ -311,7 +311,7 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 // 	genomecost = 1
 // 	allowduringlesserform = 1
 // 	verbpath = /obj/item/verbs/changeling/proc/changeling_chemspit
-	
+
 /datum/power_holder
 	var/datum/role/R
 	var/list/purchasedpowers = list()

--- a/code/datums/gamemode/role/cultist.dm
+++ b/code/datums/gamemode/role/cultist.dm
@@ -229,7 +229,7 @@
 	if (!istype(H))
 		return
 	var/unholy = H.checkTattoo(TATTOO_HOLY)
-	var/current_act = Clamp(veil_thickness,CULT_MENDED,CULT_EPILOGUE)
+	var/current_act = clamp(veil_thickness,CULT_MENDED,CULT_EPILOGUE)
 	if (reagent_id == INCENSE_HAREBELLS)
 		if (unholy)
 			H.eye_blurry = max(H.eye_blurry, 3)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -54,7 +54,7 @@
 	var/obj/shadow/shadow
 
 	var/ignore_blocking = 0
-	
+
 	var/last_explosion_push = 0
 
 /atom/movable/New()
@@ -985,8 +985,8 @@
 		return 0
 	var/list/params_list = params2list(params)
 	if(clamp)
-		pixel_x = Clamp(base_pixx + text2num(params_list["icon-x"]) - WORLD_ICON_SIZE/2, -WORLD_ICON_SIZE/2, WORLD_ICON_SIZE/2)
-		pixel_y = Clamp(base_pixy + text2num(params_list["icon-y"]) - WORLD_ICON_SIZE/2, -WORLD_ICON_SIZE/2, WORLD_ICON_SIZE/2)
+		pixel_x = clamp(base_pixx + text2num(params_list["icon-x"]) - WORLD_ICON_SIZE/2, -WORLD_ICON_SIZE/2, WORLD_ICON_SIZE/2)
+		pixel_y = clamp(base_pixy + text2num(params_list["icon-y"]) - WORLD_ICON_SIZE/2, -WORLD_ICON_SIZE/2, WORLD_ICON_SIZE/2)
 	else
 		pixel_x = base_pixx + text2num(params_list["icon-x"]) - WORLD_ICON_SIZE/2
 		pixel_y = base_pixy + text2num(params_list["icon-y"]) - WORLD_ICON_SIZE/2

--- a/code/game/gamemodes/blob/blobs/core.dm
+++ b/code/game/gamemodes/blob/blobs/core.dm
@@ -74,7 +74,7 @@
 		return 0 //under effects of time magick
 
 	if(overmind)
-		var/points_to_collect = Clamp(point_rate*round((world.time-last_resource_collection)/10), 0, 10)
+		var/points_to_collect = clamp(point_rate*round((world.time-last_resource_collection)/10), 0, 10)
 		overmind.add_points(points_to_collect)
 		last_resource_collection = world.time
 

--- a/code/game/gamemodes/blob/blobs/factory.dm
+++ b/code/game/gamemodes/blob/blobs/factory.dm
@@ -103,7 +103,7 @@
 
 /mob/living/simple_animal/hostile/blobspore/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	..()
-	adjustBruteLoss(Clamp(0.01 * exposed_temperature, 1, 5))
+	adjustBruteLoss(clamp(0.01 * exposed_temperature, 1, 5))
 
 /mob/living/simple_animal/hostile/blobspore/blob_act()
 	return

--- a/code/game/gamemodes/blob/overmind.dm
+++ b/code/game/gamemodes/blob/overmind.dm
@@ -107,7 +107,7 @@
 
 /mob/camera/blob/proc/add_points(var/points)
 	if(points != 0)
-		blob_points = Clamp(blob_points + points, 0, max_blob_points)
+		blob_points = clamp(blob_points + points, 0, max_blob_points)
 	var/number_of_cores = blob_cores.len
 	//Updating the HUD
 	if(hud_used)

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -195,7 +195,7 @@ var/list/blob_overminds = list()
 
 /obj/effect/blob/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	..()
-	var/damage = Clamp(0.01 * exposed_temperature / fire_resist, 0, 4 - fire_resist)
+	var/damage = clamp(0.01 * exposed_temperature / fire_resist, 0, 4 - fire_resist)
 	if(damage)
 		health -= damage
 		update_health()

--- a/code/game/gamemodes/events/power_failure.dm
+++ b/code/game/gamemodes/events/power_failure.dm
@@ -55,7 +55,7 @@
 		command_alert(/datum/command_alert/power_restored)
 	for(var/obj/machinery/power/apc/C in power_machines)
 		if(C.cell && C.z == map.zMainStation)
-			C.cell.charge = Clamp(C.cell.charge, C.old_charge, C.cell.maxcharge)
+			C.cell.charge = clamp(C.cell.charge, C.old_charge, C.cell.maxcharge)
 			C.chargemode = 1
 	for(var/obj/machinery/power/battery/smes/S in power_machines)
 		if(S.z != map.zMainStation)

--- a/code/game/gamemodes/events/powercreeper.dm
+++ b/code/game/gamemodes/events/powercreeper.dm
@@ -83,7 +83,7 @@
 		//add power to powernet through converting atmospheric heat to power
 		add_avail(-(environment.add_thermal_energy(max(environment.get_thermal_energy_change(T0C),-POWER_PER_FRUIT*10)/10)))
 		if(growdirs)
-			var/grow_chance = Clamp(MIN_SPREAD_CHANCE + (powernet.avail/1000), MIN_SPREAD_CHANCE, MAX_SPREAD_CHANCE)
+			var/grow_chance = clamp(MIN_SPREAD_CHANCE + (powernet.avail/1000), MIN_SPREAD_CHANCE, MAX_SPREAD_CHANCE)
 			if(prob(grow_chance))
 				var/chosen_dir = pick(cardinal)
 				if(growdirs & chosen_dir)

--- a/code/game/jobs/job/assistant.dm
+++ b/code/game/jobs/job/assistant.dm
@@ -63,4 +63,4 @@
 	if(sec_jobs > 5)
 		return 99
 
-	return Clamp(sec_jobs * config.assistantratio + xtra_positions, total_positions, 99)
+	return clamp(sec_jobs * config.assistantratio + xtra_positions, total_positions, 99)

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -64,7 +64,7 @@
 	var/priority = FALSE //If TRUE, job will display in red in the latejoin menu and grant a priority_reward_equip on spawn.
 
 /datum/job/proc/get_total_positions()
-	return Clamp(total_positions + xtra_positions, 0, 99)
+	return clamp(total_positions + xtra_positions, 0, 99)
 
 /datum/job/proc/set_total_positions(var/nu)
 	total_positions = nu

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -260,4 +260,4 @@
 
 	var/datum/job/assistant = job_master.GetJob("Assistant")
 	if(assistant.current_positions > 5)
-		. = Clamp(. + assistant.current_positions - 5, 0, 99)
+		. = clamp(. + assistant.current_positions - 5, 0, 99)

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -335,7 +335,7 @@ var/global/list/airalarm_presets = list(
 		var/actual_target_temperature = target_temperature
 		if(get_danger_level(actual_target_temperature, TLV["temperature"]))
 			//use the max or min safe temperature
-			actual_target_temperature = Clamp(actual_target_temperature, TLV["temperature"][2], TLV["temperature"][3])
+			actual_target_temperature = clamp(actual_target_temperature, TLV["temperature"][2], TLV["temperature"][3])
 
 		if(!regulating_temperature)
 			regulating_temperature = 1

--- a/code/game/machinery/antiquemattersynth.dm
+++ b/code/game/machinery/antiquemattersynth.dm
@@ -136,7 +136,7 @@ list("category" = "machinery", "name" = "MSGS", "path" = /obj/machinery/atmosphe
 		toggle_power()
 	if(href_list["set_draw"])
 		consumption = input("Megajoules to draw per tick: ", "1MW = 1000kW = 1000000W", consumption/MEGAWATT) as num
-		consumption = round(Clamp(consumption*MEGAWATT, 0, 2*GIGAWATT)) //we're storing the actual number of watts but only displaying the users the mw conversion
+		consumption = round(clamp(consumption*MEGAWATT, 0, 2*GIGAWATT)) //we're storing the actual number of watts but only displaying the users the mw conversion
 	if(href_list["synth"])
 		locate_data(href_list["synth"]) //Even though the list contains a path, hrefs only pass text so let's use name here instead of path
 	if(href_list["category"])

--- a/code/game/machinery/atmo_control.dm
+++ b/code/game/machinery/atmo_control.dm
@@ -517,7 +517,7 @@ font-weight:bold;
 		var/response=input(usr,"Set new pressure, in kPa. \[0-[50*ONE_ATMOSPHERE]\]") as num
 		var/oldpressure = pressure_setting
 		pressure_setting = text2num(response)
-		pressure_setting = Clamp(pressure_setting, 0, 50*ONE_ATMOSPHERE)
+		pressure_setting = clamp(pressure_setting, 0, 50*ONE_ATMOSPHERE)
 		investigation_log(I_ATMOS,"'s output pressure set to [pressure_setting] from [oldpressure] by [key_name(usr)]")
 
 	if(!radio_connection)
@@ -537,7 +537,7 @@ font-weight:bold;
 		input_info = null
 		var/new_rate=input("Enter the new volume rate of the injector:","Injector Rate") as num
 		new_rate = text2num(new_rate)
-		new_rate = Clamp(new_rate, 0, new_rate)
+		new_rate = clamp(new_rate, 0, new_rate)
 		signal.data = list ("tag" = input_tag, "set_volume_rate"=new_rate)
 
 	else if(href_list["out_refresh_status"])

--- a/code/game/machinery/atmoalter/pump.dm
+++ b/code/game/machinery/atmoalter/pump.dm
@@ -154,7 +154,7 @@
 
 	if (href_list["pressure_adj"])
 		var/diff = text2num(href_list["pressure_adj"])
-		target_pressure = Clamp(target_pressure+diff, pressuremin, pressuremax)
+		target_pressure = clamp(target_pressure+diff, pressuremin, pressuremax)
 		update_icon()
 
 	src.add_fingerprint(usr)

--- a/code/game/machinery/atmoalter/vaporizer.dm
+++ b/code/game/machinery/atmoalter/vaporizer.dm
@@ -166,10 +166,10 @@
 		investigation_log(I_ATMOS, "had its valve [on ? "opened" : "closed"] by [key_name(usr)].")
 	if(href_list["set_mixrate"])
 		mixrate = input("New mix rate", "Units of vapor salts per tick: ", mixrate) as num
-		mixrate = round(Clamp(mixrate, 0, 50))
+		mixrate = round(clamp(mixrate, 0, 50))
 	if(href_list["set_mixratio"])
 		mixratio = input("New mix ratio", "Percentage of oxygen to synthesize: ", mixratio) as num
-		mixratio = round(Clamp(mixratio, 0, 100))
+		mixratio = round(clamp(mixratio, 0, 100))
 	if(href_list["prepare_dump"])
 		if(!screen && !allowed(usr)) //This is pretty much only to dump now
 			return

--- a/code/game/machinery/computer/cargo.dm
+++ b/code/game/machinery/computer/cargo.dm
@@ -349,7 +349,7 @@ For vending packs, see vending_packs.dm*/
 		var/crates = 1
 		if(multi)
 			var/tempcount = input(usr, "Amount:", "How many crates?", "") as num
-			crates = Clamp(round(text2num(tempcount)), 1, 20)
+			crates = clamp(round(text2num(tempcount)), 1, 20)
 
 		// Calculate money tied up in requests
 		var/total_money_req = 0
@@ -575,7 +575,7 @@ For vending packs, see vending_packs.dm*/
 		if(multi)
 			var/num_input = input(usr, "Amount:", "How many crates?", "") as num
 			// Maximum 20 crates ordered at a time
-			crates = Clamp(round(text2num(num_input)), 1, 20)
+			crates = clamp(round(text2num(num_input)), 1, 20)
 
 		// Calculate money tied up in usr's requests
 		var/total_money_req = 0

--- a/code/game/machinery/computer/slot_machine.dm
+++ b/code/game/machinery/computer/slot_machine.dm
@@ -135,7 +135,7 @@
 
 	//Pre-calculate results
 	if(rigged)
-		value_1 = Clamp(rigged, 1, TREE)
+		value_1 = clamp(rigged, 1, TREE)
 		value_2 = value_1
 		value_3 = value_1
 

--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -17,7 +17,7 @@
 	var/obj/item/weapon/circuitboard/telecomms/C = locate() in component_parts
 	if (!istype(C))
 		return
-	C.integrity = Clamp(new_integrity, 0, TELECOMMS_MAX_INTEGRITY)
+	C.integrity = clamp(new_integrity, 0, TELECOMMS_MAX_INTEGRITY)
 
 /obj/item/weapon/circuitboard/telecomms/attackby(var/obj/item/W, var/mob/user, var/params)
 	if(issolder(W))
@@ -70,7 +70,7 @@
 	dat = {"
 		<p>[temp]</p>
 		<p><b>Power Status:</b> <a href='?src=\ref[src];input=toggle'>[toggled ? "On" : "Off"]</a></p>
-		<p><b>Integrity:</b> [Clamp(get_integrity(), 0, TELECOMMS_MAX_INTEGRITY)]%</p>
+		<p><b>Integrity:</b> [clamp(get_integrity(), 0, TELECOMMS_MAX_INTEGRITY)]%</p>
 	"}
 	if(on && toggled)
 		dat += {"

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -124,7 +124,7 @@
 
 	if(href_list["dest"])
 		var/list/dests = get_avail_dests()
-		var/idx = Clamp(text2num(href_list["dest"]), 1, dests.len)
+		var/idx = clamp(text2num(href_list["dest"]), 1, dests.len)
 		locked = dests[dests[idx]]
 		say("Locked in")
 		updateUsrDialog()

--- a/code/game/machinery/turrets.dm
+++ b/code/game/machinery/turrets.dm
@@ -569,7 +569,7 @@
 				if(src)
 					src.process()
 	if(href_list["scan_range"])
-		src.scan_range = Clamp(src.scan_range + text2num(href_list["scan_range"]), 1, 8)
+		src.scan_range = clamp(src.scan_range + text2num(href_list["scan_range"]), 1, 8)
 	if(href_list["scan_for"])
 		if(href_list["scan_for"] in scan_for)
 			scan_for[href_list["scan_for"]] = !scan_for[href_list["scan_for"]]

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -69,7 +69,7 @@ var/explosion_shake_message_cooldown = 0
 					if(dist <= round(max_range + world.view - 2, 1))
 						if(devastation_range > 0)
 							M.playsound_local(epicenter, get_sfx("explosion"), 100, 1, frequency, falloff = 5) // get_sfx() is so that everyone gets the same sound
-							shake_camera(M, Clamp(devastation_range, 3, 10), 2)
+							shake_camera(M, clamp(devastation_range, 3, 10), 2)
 						else
 							M.playsound_local(epicenter, get_sfx("explosion_small"), 100, 1, frequency, falloff = 5)
 							shake_camera(M, 3, 1)
@@ -77,7 +77,7 @@ var/explosion_shake_message_cooldown = 0
 						//You hear a far explosion if you're outside the blast radius. Small bombs shouldn't be heard all over the station.
 
 					else if(dist <= far_dist)
-						var/far_volume = Clamp(far_dist, 30, 50) // Volume is based on explosion size and dist
+						var/far_volume = clamp(far_dist, 30, 50) // Volume is based on explosion size and dist
 						far_volume += (dist <= far_dist * 0.5 ? 50 : 0) // add 50 volume if the mob is pretty close to the explosion
 						if(devastation_range > 0)
 							M.playsound_local(epicenter, 'sound/effects/explosionfar.ogg', far_volume, 1, frequency, falloff = 5)

--- a/code/game/objects/items/changeling_vial.dm
+++ b/code/game/objects/items/changeling_vial.dm
@@ -22,7 +22,7 @@
 				sleep(100)
 				var/datum/role/changeling/C = new(M)
 				if(C)
-					C.geneticpoints = Clamp(genomes_to_give, 0, 100)
+					C.geneticpoints = clamp(genomes_to_give, 0, 100)
 					C.OnPostSetup()
 				to_chat(H, "<B><span class='red'>Finally, we once again have a suitable body. We are once again a proper changeling!</span></B>")
 				var/wikiroute = role_wiki[CHANGELING]

--- a/code/game/objects/items/devices/mat_synth.dm
+++ b/code/game/objects/items/devices/mat_synth.dm
@@ -80,7 +80,7 @@
 			if(initial(active_material.perunit) < 2000)
 				modifier = MAT_COST_RARE
 			var/amount = input(user, "How many sheets of [initial(material_type.name)] do you want to synthesize", "Material Synthesizer") as num
-			amount = Clamp(round(amount, 1), 0, 50)
+			amount = clamp(round(amount, 1), 0, 50)
 			if(amount)
 				if(TakeCost(amount, modifier, R))
 					var/obj/item/stack/sheet/inside_sheet = (locate(material_type) in R.module.modules)
@@ -144,7 +144,7 @@
 
 			if (unit_can_produce >= 1)
 				tospawn = input(user, "How many sheets of [initial(material_type.name)] do you want to synthesize? (0 - [unit_can_produce])", "Material Synthesizer") as num
-				tospawn = Clamp(round(tospawn), 0, unit_can_produce)
+				tospawn = clamp(round(tospawn), 0, unit_can_produce)
 
 				if (tospawn >= 1 && TakeCost(tospawn, modifier, user))
 					var/obj/item/stack/sheet/spawned_sheet = new material_type(get_turf(src))

--- a/code/game/objects/items/mountable_frames/trophy_mount.dm
+++ b/code/game/objects/items/mountable_frames/trophy_mount.dm
@@ -38,8 +38,8 @@
 		if(params_list && params_list.len)
 			var/clamp_x = clicked.Width() / 2
 			var/clamp_y = clicked.Height() / 2
-			temp.pixel_x = Clamp(text2num(params_list["icon-x"]) - clamp_x, -clamp_x, clamp_x)
-			temp.pixel_y = Clamp(text2num(params_list["icon-y"]) - clamp_y, -clamp_y, clamp_y)
+			temp.pixel_x = clamp(text2num(params_list["icon-x"]) - clamp_x, -clamp_x, clamp_x)
+			temp.pixel_y = clamp(text2num(params_list["icon-y"]) - clamp_y, -clamp_y, clamp_y)
 
 		overlays += temp
 

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -36,7 +36,7 @@
 
 /obj/item/weapon/storage/backpack/santabag/attack_hand(user)
 	if(contents.len < storage_slots)
-		var/empty_slots = Clamp((storage_slots - contents.len),0,storage_slots)
+		var/empty_slots = clamp((storage_slots - contents.len),0,storage_slots)
 		to_chat(user,"<span class='notice'>You look into the bag, and find it filled with [empty_slots] new presents!</span>")
 		for(var/i = 1,i <= empty_slots,i++)
 			var/gift = pick(/obj/item/weapon/winter_gift/cloth,/obj/item/weapon/winter_gift/regular,/obj/item/weapon/winter_gift/food)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -648,7 +648,7 @@ a {
 				surrounding_mod *= I.quality/rand(1,3)
 	*/
 	var/initial_quality = round(((rand(1,3)*surrounding_mod)*material_mod)+modifier)
-	quality = Clamp(initial_quality, B_AWFUL>min_quality?B_AWFUL:min_quality, B_LEGENDARY)
+	quality = clamp(initial_quality, B_AWFUL>min_quality?B_AWFUL:min_quality, B_LEGENDARY)
 
 /obj/proc/gen_description(mob/user)
 	var/material_mod = quality-B_GOOD>1 ? quality-B_GOOD : 0

--- a/code/game/objects/structures/flora/flora.dm
+++ b/code/game/objects/structures/flora/flora.dm
@@ -41,8 +41,8 @@
 
 			var/clamp_x = clicked.Width() / 2
 			var/clamp_y = clicked.Height() / 2
-			O.pixel_x = Clamp(text2num(params_list["icon-x"]) - clamp_x, -clamp_x, clamp_x)+(((((clicked.Width()/32)-1)*16)*PIXEL_MULTIPLIER))
-			O.pixel_y = (Clamp(text2num(params_list["icon-y"]) - clamp_y, -clamp_y, clamp_y)+((((clicked.Height()/32)-1)*16)*PIXEL_MULTIPLIER))-(5*PIXEL_MULTIPLIER)
+			O.pixel_x = clamp(text2num(params_list["icon-x"]) - clamp_x, -clamp_x, clamp_x)+(((((clicked.Width()/32)-1)*16)*PIXEL_MULTIPLIER))
+			O.pixel_y = (clamp(text2num(params_list["icon-y"]) - clamp_y, -clamp_y, clamp_y)+((((clicked.Height()/32)-1)*16)*PIXEL_MULTIPLIER))-(5*PIXEL_MULTIPLIER)
 			overlays += O
 			to_chat(user, "You hang \the [I] on \the [src].")
 			return 1

--- a/code/game/objects/structures/popout_cake.dm
+++ b/code/game/objects/structures/popout_cake.dm
@@ -170,7 +170,7 @@
 	check_slices()
 
 /obj/structure/popout_cake/bullet_act(var/obj/item/projectile/Proj)
-	slices_amount -= Clamp(round(Proj.damage / 3), 1, 4)
+	slices_amount -= clamp(round(Proj.damage / 3), 1, 4)
 
 	check_slices()
 

--- a/code/game/objects/structures/vehicles/wheelchair.dm
+++ b/code/game/objects/structures/vehicles/wheelchair.dm
@@ -83,7 +83,7 @@
 		else if(M.held_items[i])
 			available_hands -= 1
 
-	available_hands = Clamp(available_hands, 0, 4)
+	available_hands = clamp(available_hands, 0, 4)
 
 	return available_hands
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -121,7 +121,7 @@ var/list/one_way_windows
 		overlays -= damage_overlay
 
 		if(health < initial(health))
-			var/damage_fraction = Clamp(round((initial(health) - health) / initial(health) * 5) + 1, 1, 5) //gives a number, 1-5, based on damagedness
+			var/damage_fraction = clamp(round((initial(health) - health) / initial(health) * 5) + 1, 1, 5) //gives a number, 1-5, based on damagedness
 			damage_overlay.icon_state = "[cracked_base][damage_fraction]"
 			overlays += damage_overlay
 

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -127,10 +127,10 @@ var/const/SURROUND_CAP = 7
 		var/turf/T = get_turf(src)
 
 		var/dx = turf_source.x - T.x // Hearing from the right/left
-		S.x = round(Clamp(dx, -SURROUND_CAP, SURROUND_CAP), 1)
+		S.x = round(clamp(dx, -SURROUND_CAP, SURROUND_CAP), 1)
 
 		var/dz = turf_source.y - T.y // Hearing from infront/behind
-		S.z = round(Clamp(dz, -SURROUND_CAP, SURROUND_CAP), 1)
+		S.z = round(clamp(dz, -SURROUND_CAP, SURROUND_CAP), 1)
 
 		// The y value is for above your head, but there is no ceiling in 2d spessmens.
 		S.y = 1

--- a/code/game/turfs/simulated/floor_glass.dm
+++ b/code/game/turfs/simulated/floor_glass.dm
@@ -42,7 +42,7 @@
 			overlays -= current_damage_overlay
 			current_damage_overlay = null
 		return
-	var/damage_fraction = Clamp(round((max_health - current_health) / max_health * 5) + 1, 1, 5) //gives a number, 1-5, based on damagedness
+	var/damage_fraction = clamp(round((max_health - current_health) / max_health * 5) + 1, 1, 5) //gives a number, 1-5, based on damagedness
 	var/icon_state = "[cracked_base][damage_fraction]"
 	if(!damage_overlays[icon_state])
 		var/image/_damage_overlay = image('icons/obj/structures.dmi', icon_state)

--- a/code/modules/RCD/schematics/engi.dm
+++ b/code/modules/RCD/schematics/engi.dm
@@ -264,7 +264,7 @@
 
 /datum/rcd_schematic/con_airlock/Topic(var/href, var/href_list)
 	if(href_list["set_selected"])
-		var/idx = Clamp(text2num(href_list["set_selected"]), 1, schematics.len)
+		var/idx = clamp(text2num(href_list["set_selected"]), 1, schematics.len)
 		var/datum/selection_schematic/airlock_schematic/C = schematics[idx]
 
 		selected = C

--- a/code/modules/RCD/schematics/pipe.dm
+++ b/code/modules/RCD/schematics/pipe.dm
@@ -327,7 +327,7 @@
 		return 1
 
 	if(href_list["set_layer"] && layer) //Only handle this is layer is nonzero.
-		var/n_layer = Clamp(round(text2num(href_list["set_layer"])), PIPING_LAYER_MIN, PIPING_LAYER_MAX)
+		var/n_layer = clamp(round(text2num(href_list["set_layer"])), PIPING_LAYER_MIN, PIPING_LAYER_MAX)
 		if(layer == n_layer) //No point doing anything.
 			return 1
 

--- a/code/modules/RCD/schematics/tile.dm
+++ b/code/modules/RCD/schematics/tile.dm
@@ -81,7 +81,7 @@
 /datum/rcd_schematic/tile/Topic(var/href, var/href_list)
 	if(href_list["select_paint"])
 		var/list/our_list = get_our_list()
-		var/idx = Clamp(round(text2num(href_list["select_paint"])), 1, our_list.len)
+		var/idx = clamp(round(text2num(href_list["select_paint"])), 1, our_list.len)
 
 		selection = our_list[idx]
 		if(!(selected_dir in get_dir_list_by_dir_type(selection.adirs)))

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -1138,8 +1138,8 @@ var/list/admin_verbs_mod = list(
 			if(z_coord == null)
 				return
 
-			x_coord = Clamp(x_coord, 1, world.maxx)
-			y_coord = Clamp(y_coord, 1, world.maxy)
+			x_coord = clamp(x_coord, 1, world.maxx)
+			y_coord = clamp(y_coord, 1, world.maxy)
 
 		if(ML_LOAD_TO_Z2)
 			if(!dungeon_area)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -89,7 +89,7 @@
 		//testing("Lawtype: [lawtype]")
 		if(lawtype==1)
 			lawtype=text2num(input("Enter desired law priority. (15-50)","Priority", 15) as num)
-			lawtype=Clamp(lawtype,15,50)
+			lawtype=clamp(lawtype,15,50)
 		var/newlaw = copytext(sanitize(input(usr, "Please enter a new law for the AI.", "Freeform Law Entry", "")),1,MAX_MESSAGE_LEN)
 		if(newlaw=="")
 			return
@@ -2416,7 +2416,7 @@
 		if(new_amount == null)
 			return
 
-		new_amount = Clamp(new_amount, 0, max_hands)
+		new_amount = clamp(new_amount, 0, max_hands)
 
 		M.set_hand_amount(new_amount)
 		to_chat(usr, "<span class='info'>Changed [M]'s amount of hands to [new_amount].</span>")
@@ -3068,7 +3068,7 @@
 			alert("Removed:\n" + jointext(removed_paths, "\n"))
 
 		var/list/offset = splittext(href_list["offset"],",")
-		var/number = Clamp(text2num(href_list["object_count"]), 1, 100)
+		var/number = clamp(text2num(href_list["object_count"]), 1, 100)
 		var/X = offset.len > 0 ? text2num(offset[1]) : 0
 		var/Y = offset.len > 1 ? text2num(offset[2]) : 0
 		var/Z = offset.len > 2 ? text2num(offset[3]) : 0

--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -137,7 +137,7 @@ var/global/list/assembly_short_name_to_type = list() //Please, I beg you, don't 
 			return
 
 		if(L.len >= VALUE_VARIABLE_MAX)
-			new_value = Clamp(new_value, text2num(L[VALUE_VARIABLE_MIN]), text2num(L[VALUE_VARIABLE_MAX]))
+			new_value = clamp(new_value, text2num(L[VALUE_VARIABLE_MIN]), text2num(L[VALUE_VARIABLE_MAX]))
 
 	else if(L[VALUE_VARIABLE_TYPE] == VT_POINTER)
 		//When importing assembly frames, assemblies can't connect to stuff with a higher index (because it's not loaded yet)

--- a/code/modules/assembly/assembly_frame.dm
+++ b/code/modules/assembly/assembly_frame.dm
@@ -180,7 +180,7 @@
 		if(..())
 			return
 
-		new_index = Clamp(new_index, 1, assemblies.len)
+		new_index = clamp(new_index, 1, assemblies.len)
 
 		assemblies.Remove(AS)
 		assemblies.Insert(new_index, AS)

--- a/code/modules/assembly/logic/randomizer.dm
+++ b/code/modules/assembly/logic/randomizer.dm
@@ -38,7 +38,7 @@
 	if(!Adjacent(user) || user.isUnconscious()) //sanity 101
 		return
 
-	output_number = Clamp(new_output_num, 1, 512)
+	output_number = clamp(new_output_num, 1, 512)
 	to_chat(user, "<span class='info'>Number of outputs set to [output_number].</span>")
 
 /obj/item/device/assembly/randomizer/send_pulses_to_list(var/list/L) //The assembly frame will give us a list of devices to forward a pulse to.

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -173,7 +173,7 @@
 	if(href_list["range"])
 		var/r = text2num(href_list["range"])
 		range += r
-		range = Clamp(range, 1, 5)
+		range = clamp(range, 1, 5)
 
 	if(href_list["set_default_time"])
 		default_time = time

--- a/code/modules/atmos_automation/implementation/assemblies.dm
+++ b/code/modules/atmos_automation/implementation/assemblies.dm
@@ -38,7 +38,7 @@
 	if(href_list["set_ass_num"])
 		assembly_num = input("Select an assembly port to send a pulse to (max: [parent.max_linked_assembly_amount]).", "Assembly", assembly_num) as null|num
 
-		assembly_num = Clamp(assembly_num, 1, parent.max_linked_assembly_amount)
+		assembly_num = clamp(assembly_num, 1, parent.max_linked_assembly_amount)
 
 		parent.updateUsrDialog()
 		return 1

--- a/code/modules/atmos_automation/implementation/registers.dm
+++ b/code/modules/atmos_automation/implementation/registers.dm
@@ -14,7 +14,7 @@
 
 /datum/automation/get_register_data/Evaluate()
 	var/datum/automation/field = children[1]
-	var/registerid = Clamp(field.Evaluate(), 1, parent.register_amount)//Just in case.
+	var/registerid = clamp(field.Evaluate(), 1, parent.register_amount)//Just in case.
 
 	if(registerid)
 		return parent.registers[registerid]
@@ -62,7 +62,7 @@
 	var/datum/automation/valuefield = children[2]
 
 	var/registerid = idfield.Evaluate()
-	registerid = Clamp(registerid, 1, parent.register_amount)
+	registerid = clamp(registerid, 1, parent.register_amount)
 
 	parent.registers[registerid] = valuefield.Evaluate()
 

--- a/code/modules/atmos_automation/implementation/scrubbers.dm
+++ b/code/modules/atmos_automation/implementation/scrubbers.dm
@@ -204,14 +204,14 @@ var/global/list/gas_labels=list(
 	if(href_list["set_intpressure"])
 		var/response = input("Set new pressure in kPa. \[0-[50*ONE_ATMOSPHERE]\]") as num
 		intpressure = text2num(response)
-		intpressure = Clamp(intpressure, 0, 50*ONE_ATMOSPHERE)
+		intpressure = clamp(intpressure, 0, 50*ONE_ATMOSPHERE)
 		parent.updateUsrDialog()
 		return 1
 
 	if(href_list["set_extpressure"])
 		var/response = input(usr,"Set new pressure in kPa. \[0-[50*ONE_ATMOSPHERE]\]") as num
 		extpressure = text2num(response)
-		extpressure = Clamp(extpressure, 0, 50*ONE_ATMOSPHERE)
+		extpressure = clamp(extpressure, 0, 50*ONE_ATMOSPHERE)
 		parent.updateUsrDialog()
 		return 1
 

--- a/code/modules/atmos_automation/implementation/vent_pump.dm
+++ b/code/modules/atmos_automation/implementation/vent_pump.dm
@@ -198,21 +198,21 @@
 	if(href_list["set_intpressure_out"])
 		var/response = input("Set new pressure, in kPa. \[0-[50*ONE_ATMOSPHERE]\]") as num
 		intpressureout = text2num(response)
-		intpressureout = Clamp(intpressureout, 0, 50*ONE_ATMOSPHERE)
+		intpressureout = clamp(intpressureout, 0, 50*ONE_ATMOSPHERE)
 		parent.updateUsrDialog()
 		return 1
 
 	if(href_list["set_intpressure_in"])
 		var/response = input("Set new pressure, in kPa. \[0-[50*ONE_ATMOSPHERE]\]") as num
 		intpressurein = text2num(response)
-		intpressurein = Clamp(intpressurein, 0, 50*ONE_ATMOSPHERE)
+		intpressurein = clamp(intpressurein, 0, 50*ONE_ATMOSPHERE)
 		parent.updateUsrDialog()
 		return 1
 
 	if(href_list["set_external"])
 		var/response = input(usr,"Set new pressure, in kPa. \[0-[50*ONE_ATMOSPHERE]\]") as num
 		extpressure = text2num(response)
-		extpressure = Clamp(extpressure, 0, 50*ONE_ATMOSPHERE)
+		extpressure = clamp(extpressure, 0, 50*ONE_ATMOSPHERE)
 		parent.updateUsrDialog()
 		return 1
 

--- a/code/modules/clothing/suits/plate_carrier.dm
+++ b/code/modules/clothing/suits/plate_carrier.dm
@@ -14,13 +14,13 @@
 /obj/item/clothing/suit/armor/plate_carrier/get_armor(var/type)
 	var/armor_value = armor[type]
 	if(P)
-		armor_value = armor[type] <= 0 ? P.armor[type] : Clamp((armor[type]+P.armor[type])/2, armor[type], 100)
+		armor_value = armor[type] <= 0 ? P.armor[type] : clamp((armor[type]+P.armor[type])/2, armor[type], 100)
 	return armor_value
 
 /obj/item/clothing/suit/armor/plate_carrier/get_armor_absorb(var/type)
 	var/armor_value = armor_absorb[type]
 	if(P)
-		armor_value = armor_absorb[type] <= 0 ? P.armor_absorb[type] : Clamp((armor_absorb[type]+P.armor_absorb[type])/2, armor_absorb[type], 100)
+		armor_value = armor_absorb[type] <= 0 ? P.armor_absorb[type] : clamp((armor_absorb[type]+P.armor_absorb[type])/2, armor_absorb[type], 100)
 	return armor_value
 
 /obj/item/clothing/suit/armor/plate_carrier/equipped(var/mob/user, var/slot)

--- a/code/modules/context_click/context_click.dm
+++ b/code/modules/context_click/context_click.dm
@@ -22,8 +22,8 @@ IDs can then be used to cause certain behaviour using the action() proc
 		return
 
 	var/list/params_list = params2list(params)
-	var/x_pos_clicked = Clamp(text2num(params_list["icon-x"]), 1, WORLD_ICON_SIZE)
-	var/y_pos_clicked = Clamp(text2num(params_list["icon-y"]), 1, WORLD_ICON_SIZE)
+	var/x_pos_clicked = clamp(text2num(params_list["icon-x"]), 1, WORLD_ICON_SIZE)
+	var/y_pos_clicked = clamp(text2num(params_list["icon-y"]), 1, WORLD_ICON_SIZE)
 
 	return return_clicked_id(x_pos_clicked, y_pos_clicked)
 

--- a/code/modules/games/cards/playing_cards.dm
+++ b/code/modules/games/cards/playing_cards.dm
@@ -19,7 +19,7 @@
 /datum/context_click/cardhand/action(obj/item/used_item, mob/user, params)
 	var/obj/item/toy/cardhand/hand = holder
 	if(!used_item)
-		var/index = Clamp(return_clicked_id_by_params(params), 1, hand.currenthand.len)
+		var/index = clamp(return_clicked_id_by_params(params), 1, hand.currenthand.len)
 		var/obj/item/toy/singlecard/card = hand.currenthand[index]
 		hand.currenthand.Remove(card)
 		user.put_in_hands(card)
@@ -29,7 +29,7 @@
 			qdel(hand)
 			user.put_in_inactive_hand(C)
 	else if(istype(used_item, /obj/item/toy/singlecard))
-		var/index = Clamp(return_clicked_id_by_params(params), 1, hand.currenthand.len)
+		var/index = clamp(return_clicked_id_by_params(params), 1, hand.currenthand.len)
 		hand.currenthand.Insert(index, used_item) //We put it where we specified
 		hand.update_icon()
 

--- a/code/modules/hydroponics/hydro_tray.dm
+++ b/code/modules/hydroponics/hydro_tray.dm
@@ -568,7 +568,7 @@
 				return
 	else if(istype(Proj ,/obj/item/projectile/energy/florayield))
 		if(seed && !dead)
-			yield_mod = Clamp(yield_mod + (rand(3,5)/10), 1, 2)
+			yield_mod = clamp(yield_mod + (rand(3,5)/10), 1, 2)
 			if(yield_mod >= 2)
 				visible_message("<span class='notice'>\The [seed.display_name] looks lush and healthy.</span>")
 			return

--- a/code/modules/hydroponics/hydro_tray_process.dm
+++ b/code/modules/hydroponics/hydro_tray_process.dm
@@ -160,7 +160,7 @@
 	if(seed.alter_temp)
 		if((environment.temperature < seed.ideal_heat - seed.heat_tolerance) || (environment.temperature > seed.ideal_heat + seed.heat_tolerance))
 			var/energy_cap = seed.potency * 60 * MOLES_CELLSTANDARD //This is totally arbitrary. It just serves to approximate the behavior from when this modified temperature rather than thermal energy.
-			var/energy_change = Clamp(environment.get_thermal_energy_change(seed.ideal_heat), -energy_cap, energy_cap)
+			var/energy_change = clamp(environment.get_thermal_energy_change(seed.ideal_heat), -energy_cap, energy_cap)
 			environment.add_thermal_energy(energy_change)
 
 	// If we're attached to a pipenet, then we should let the pipenet know we might have modified some gasses
@@ -342,16 +342,16 @@
 /obj/machinery/portable_atmospherics/hydroponics/proc/check_level_sanity()
 	//Make sure various values are sane.
 	if(seed)
-		health = Clamp(health, 0, seed.endurance)
+		health = clamp(health, 0, seed.endurance)
 	else
 		health = 0
 		dead = 0
 
-	mutation_level = Clamp(mutation_level, 0, 100)
-	nutrilevel =     Clamp(nutrilevel, 0, 10)
-	waterlevel =     Clamp(waterlevel, 0, 100)
-	pestlevel =      Clamp(pestlevel, 0, 10)
-	weedlevel =      Clamp(weedlevel, 0, 10)
-	toxins =         Clamp(toxins, 0, 100)
-	yield_mod = 	 Clamp(yield_mod, 0, 2)
-	mutation_mod = 	 Clamp(mutation_mod, 0, 3)
+	mutation_level = clamp(mutation_level, 0, 100)
+	nutrilevel =     clamp(nutrilevel, 0, 10)
+	waterlevel =     clamp(waterlevel, 0, 100)
+	pestlevel =      clamp(pestlevel, 0, 10)
+	weedlevel =      clamp(weedlevel, 0, 10)
+	toxins =         clamp(toxins, 0, 100)
+	yield_mod = 	 clamp(yield_mod, 0, 2)
+	mutation_mod = 	 clamp(mutation_mod, 0, 3)

--- a/code/modules/hydroponics/hydroponics_mutations.dm
+++ b/code/modules/hydroponics/hydroponics_mutations.dm
@@ -45,11 +45,11 @@
 			// Most categories have an integer deducted from severity, this means that the chance for that mutation
 			// is 0 below said severity (e.g. you won't get dangerous shit if you use less than 14u mutagen).
 			15;								MUTCAT_GOOD, \
-			Clamp(0.4*severity, 	0, 7);	MUTCAT_BAD, \
-			Clamp(0.7*(severity-5), 0, 8); 	MUTCAT_WEIRD, \
-			Clamp(severity-12, 		0, 7); 	MUTCAT_WEIRD2, \
-			Clamp(severity-12, 		0, 14); MUTCAT_BAD2, \
-			Clamp(severity-14,		0, 20); MUTCAT_DANGEROUS \
+			clamp(0.4*severity, 	0, 7);	MUTCAT_BAD, \
+			clamp(0.7*(severity-5), 0, 8); 	MUTCAT_WEIRD, \
+			clamp(severity-12, 		0, 7); 	MUTCAT_WEIRD2, \
+			clamp(severity-12, 		0, 14); MUTCAT_BAD2, \
+			clamp(severity-14,		0, 20); MUTCAT_DANGEROUS \
 			)
 	var/mutation_type
 	//Now we'll pick a certain type of mutation from that category, special considerations in mind.
@@ -140,7 +140,7 @@
 
 	check_for_divergence()
 
-	//testing("Mutation Category: [mutation_category] - Mutation Type: [mutation_type]. Severity: [severity]. All category weights at this sev: GOOD=15/BAD=[Clamp(0.4*severity,0, 7)]/WEIRD=[Clamp(0.7*(severity-5),0,8)]/BIZZARE=[Clamp(severity-12,0,7)]/AWFUL=[Clamp(severity-12,0,14)]/DANGEROUS=[Clamp(severity-14,0,20)]")
+	//testing("Mutation Category: [mutation_category] - Mutation Type: [mutation_type]. Severity: [severity]. All category weights at this sev: GOOD=15/BAD=[clamp(0.4*severity,0, 7)]/WEIRD=[clamp(0.7*(severity-5),0,8)]/BIZZARE=[clamp(severity-12,0,7)]/AWFUL=[clamp(severity-12,0,14)]/DANGEROUS=[clamp(severity-14,0,20)]")
 	switch(mutation_type)
 		if("code_explanation")
 			// DEARIE ME, WHAT IS GOING ON HERE?
@@ -165,7 +165,7 @@
 			// Now that we have all the final modifiers, we can calculate the mutation's final strength.
 			var/deviation = severity * (rand(50, 125)/100) * cap_ratio
 			//Deviation per 10u Mutagen before cap: 5-12.5
-			seed.potency = Clamp(seed.potency + deviation, 0, 200)
+			seed.potency = clamp(seed.potency + deviation, 0, 200)
 			generic_mutation_message("quivers!")
 
 		if("plusstat_potency")
@@ -173,7 +173,7 @@
 			var/list/hardcap_values = list(35, 45, 100, 180, 250, 300)
 			var/deviation = severity * (rand(50, 125)/100) * get_ratio(severity, softcap_values, hardcap_values, seed.potency)
 			//Deviation per 10u Mutagen before cap: 5-12.5
-			seed.potency = Clamp(seed.potency + deviation, 0, 200)
+			seed.potency = clamp(seed.potency + deviation, 0, 200)
 			generic_mutation_message("quivers!")
 
 		if("plusstat_yield")
@@ -184,7 +184,7 @@
 			var/list/hardcap_values = list(4, 5, 10, 15, 17, 20)
 			var/deviation = severity * (rand(6, 12)/100) * get_ratio(severity, softcap_values, hardcap_values, seed.yield)
 			//Deviation per 10u Mutagen before cap: 0.6-1.2
-			seed.yield = Clamp(seed.yield + deviation, 0, 16)
+			seed.yield = clamp(seed.yield + deviation, 0, 16)
 			generic_mutation_message("quivers!")
 
 		if("plusstat_weed&toxins_tolerance")
@@ -192,13 +192,13 @@
 			var/list/hardcap_values = list(4, 5, 10, 12, 12, 12)
 			var/deviation = severity * (rand(6, 12)/100) * get_ratio(severity, softcap_values, hardcap_values, seed.weed_tolerance)
 			//Deviation per 10u Mutagen before cap: 0.6-1.2
-			seed.weed_tolerance = Clamp(seed.weed_tolerance + deviation, 0, 11)
+			seed.weed_tolerance = clamp(seed.weed_tolerance + deviation, 0, 11)
 
 			softcap_values = list(2, 3, 6,  9,  11, 11)
 			hardcap_values = list(4, 5, 10, 12, 12, 12)
 			deviation = severity * (rand(6, 12)/100) * get_ratio(severity, softcap_values, hardcap_values, seed.toxins_tolerance)
 			//Deviation per 10u Mutagen before cap: 0.6-1.2
-			seed.toxins_tolerance = Clamp(seed.toxins_tolerance + deviation, 0, 11)
+			seed.toxins_tolerance = clamp(seed.toxins_tolerance + deviation, 0, 11)
 			generic_mutation_message("quivers!")
 
 		if("plusstat_lifespan&endurance")
@@ -206,13 +206,13 @@
 			var/list/hardcap_values = list(4, 75, 100, 125, 150, 150)
 			var/deviation = severity * (rand(50, 80)/100) * get_ratio(severity, softcap_values, hardcap_values, seed.lifespan)
 			//Deviation per 10u Mutagen before cap: 5-8
-			seed.lifespan = Clamp(seed.lifespan + deviation, 10, 125)
+			seed.lifespan = clamp(seed.lifespan + deviation, 10, 125)
 
 			softcap_values = list(2, 65, 80,  95,  110, 125)
 			hardcap_values = list(4, 75, 100, 125, 150, 150)
 			deviation = severity * (rand(30, 50)/100) * get_ratio(severity, softcap_values, hardcap_values, seed.endurance)
 			//Deviation per 10u Mutagen before cap: 3-5
-			seed.endurance = Clamp(seed.endurance + deviation, 10, 125)
+			seed.endurance = clamp(seed.endurance + deviation, 10, 125)
 			generic_mutation_message("quivers!")
 
 		if("plusstat_production&maturation")
@@ -220,13 +220,13 @@
 			var/list/hardcap_values = list(5,  3.5, 2,  1,    0.75, 0)
 			var/deviation = severity * (rand(4, 8)/100) * get_ratio(severity, softcap_values, hardcap_values, seed.production)
 			//Deviation per 10u Mutagen before cap: 0.4-0.8
-			seed.production = Clamp(seed.production - deviation, 1, 10)
+			seed.production = clamp(seed.production - deviation, 1, 10)
 
 			softcap_values = list(10, 7.5, 5,  2.5, 2,    1)
 			hardcap_values = list(5,  3.5, 2,  1,   0.75, 0)
 			deviation = severity * (rand(8, 12)/100) * get_ratio(severity, softcap_values, hardcap_values, seed.maturation)
 			//Deviation per 10u Mutagen before cap: 0.8-1.2
-			seed.maturation = Clamp(seed.maturation - deviation, 1.1, 30)
+			seed.maturation = clamp(seed.maturation - deviation, 1.1, 30)
 			generic_mutation_message("quivers!")
 
 		if("plusstat_heat&pressure_tolerance")
@@ -234,19 +234,19 @@
 			var/list/hardcap_values = list(200, 300, 600, 900,    1200, 1200)
 			var/deviation = severity * (rand(100, 250)/100) * get_ratio(severity, softcap_values, hardcap_values, seed.heat_tolerance)
 			//Deviation per 10u Mutagen before cap: 10-25
-			seed.heat_tolerance = Clamp(seed.heat_tolerance + deviation, 1, 800)
+			seed.heat_tolerance = clamp(seed.heat_tolerance + deviation, 1, 800)
 
 			softcap_values = list(20, 12.5, 5, 0, 0, 0)
 			hardcap_values = list(15, 5,    0, 0, 0, 0)
 			deviation = severity * (rand(20, 50)/100) * get_ratio(severity, softcap_values, hardcap_values, seed.lowkpa_tolerance)
 			//Deviation per 10u Mutagen before cap: 2-5
-			seed.lowkpa_tolerance = Clamp(seed.lowkpa_tolerance - deviation, 0, 80)
+			seed.lowkpa_tolerance = clamp(seed.lowkpa_tolerance - deviation, 0, 80)
 
 			softcap_values = list(20, 275, 350, 450, 500, 500)
 			hardcap_values = list(15, 325, 450, 575, 575, 575)
 			deviation = severity * (rand(200, 300)/100) * get_ratio(severity, softcap_values, hardcap_values, seed.highkpa_tolerance)
 			//Deviation per 10u Mutagen before cap: 20-30
-			seed.highkpa_tolerance = Clamp(seed.highkpa_tolerance + deviation, 110, 500)
+			seed.highkpa_tolerance = clamp(seed.highkpa_tolerance + deviation, 110, 500)
 			generic_mutation_message("quivers!")
 
 		if("plusstat_light_tolerance")
@@ -254,7 +254,7 @@
 			var/list/hardcap_values = list(4, 7, 10, 12, 12, 12)
 			var/deviation = severity * (rand(6, 12)/100) * get_ratio(severity, softcap_values, hardcap_values, seed.light_tolerance)
 			//Deviation per 10u Mutagen before cap: 0.6-1.2
-			seed.light_tolerance = Clamp(seed.light_tolerance + deviation, 0, 10)
+			seed.light_tolerance = clamp(seed.light_tolerance + deviation, 0, 10)
 			generic_mutation_message("quivers!")
 
 		if("plusstat_nutrient&water_consumption")
@@ -262,13 +262,13 @@
 			var/list/hardcap_values = list(0.15, 0.10, 0.05, 0,    0, 0)
 			var/deviation = severity * (rand(3, 7)/1000) * get_ratio(severity, softcap_values, hardcap_values, seed.nutrient_consumption)
 			//Deviation per 10u Mutagen before cap: 0.03-0.07
-			seed.nutrient_consumption = Clamp(seed.nutrient_consumption - deviation, 0, 1)
+			seed.nutrient_consumption = clamp(seed.nutrient_consumption - deviation, 0, 1)
 
 			softcap_values = list(4, 3,   1.5, 0.5, 0, 0)
 			hardcap_values = list(2, 1.5, 0.5, 0,   0, 0)
 			deviation = severity * (rand(6, 12)/100) * get_ratio(severity, softcap_values, hardcap_values, seed.water_consumption)
 			//Deviation per 10u Mutagen before cap: 0.6-1.2
-			seed.water_consumption = Clamp(seed.water_consumption - deviation, 0, 10)
+			seed.water_consumption = clamp(seed.water_consumption - deviation, 0, 10)
 			generic_mutation_message("quivers!")
 
 		if("tox_increase")
@@ -306,7 +306,7 @@
 			if(!seed.alter_temp)
 				seed.alter_temp = 1
 				var/deviation = rand(severity*0.5,severity)*(prob(50) ? 3 : -3)
-				seed.heat_tolerance = Clamp(seed.heat_tolerance + (deviation*0.8), 1, 800)
+				seed.heat_tolerance = clamp(seed.heat_tolerance + (deviation*0.8), 1, 800)
 				seed.ideal_heat += deviation
 			else
 				seed.alter_temp = 0

--- a/code/modules/hydroponics/seed_datums.dm
+++ b/code/modules/hydroponics/seed_datums.dm
@@ -622,7 +622,7 @@ var/global/list/gene_tag_masks = list()   // Gene obfuscation for delicious tria
 						if(stinging)
 							if(chems && chems.len)
 								for(var/rid in chems)
-									H.reagents.add_reagent(rid, Clamp(1, 5, potency/10))
+									H.reagents.add_reagent(rid, clamp(1, 5, potency/10))
 								to_chat(H, "<span class='danger'>You are stung by \the [seed_name]!</span>")
 								if(hematophage)
 									if(tray && H.species && !(H.species.anatomy_flags & NO_BLOOD)) //the indentation gap doesn't stop from getting wider

--- a/code/modules/hydroponics/spreading/spreading_growth.dm
+++ b/code/modules/hydroponics/spreading/spreading_growth.dm
@@ -99,7 +99,7 @@
 
 	if(is_mature() && neighbors.len && prob(spread_chance))
 		//spread to 1-3 adjacent turfs depending on yield trait.
-		var/max_spread = Clamp(round(seed.yield*3/14), 1, 3) // 3/14? Why?
+		var/max_spread = clamp(round(seed.yield*3/14), 1, 3) // 3/14? Why?
 
 		for(var/i in 1 to max_spread)
 			if(prob(spread_chance))

--- a/code/modules/hydroponics/spreading/spreading_response.dm
+++ b/code/modules/hydroponics/spreading/spreading_response.dm
@@ -63,7 +63,7 @@
 	if(victim.get_exposed_body_parts() && prob(chance))
 		if(seed.chems && seed.chems.len)
 			for(var/rid in seed.chems)
-				victim.reagents.add_reagent(rid, Clamp(1, 5, seed.potency/10))
+				victim.reagents.add_reagent(rid, clamp(1, 5, seed.potency/10))
 			to_chat(victim, "<span class='danger'>You are stung by \the [src]!</span>")
 	last_special = world.time
 
@@ -109,7 +109,7 @@
 		var/mob/M = locked[1]
 		if(!user || !istype(user))
 			user = M //Since the event sytem can't hot-potato arguments, for now, assume if noone's trying to free you, then you're trying to free yourself.
-		if(prob(Clamp(140 - seed.potency, 20, 100)))
+		if(prob(clamp(140 - seed.potency, 20, 100)))
 			if(M != user)
 				M.visible_message(\
 					"<span class='notice'>[user.name] frees [M.name] from \the [src].</span>",\

--- a/code/modules/library/computers/checkout.dm
+++ b/code/modules/library/computers/checkout.dm
@@ -228,13 +228,13 @@
 		else
 			var/pn = text2num(href_list["pagenum"])
 			if(!isnull(pn))
-				page_num = Clamp(pn, 0, num_pages)
+				page_num = clamp(pn, 0, num_pages)
 
 	if(href_list["page"])
 		if(num_pages == 0)
 			page_num = 0
 		else
-			page_num = Clamp(text2num(href_list["page"]), 0, num_pages)
+			page_num = clamp(text2num(href_list["page"]), 0, num_pages)
 	if(href_list["settitle"])
 		var/newtitle = input("Enter a title to search for:") as text|null
 		if(newtitle)

--- a/code/modules/library/computers/public.dm
+++ b/code/modules/library/computers/public.dm
@@ -67,7 +67,7 @@
 		else
 			var/pn = text2num(href_list["pagenum"])
 			if(!isnull(pn))
-				page_num = Clamp(pn, 0, num_pages)
+				page_num = clamp(pn, 0, num_pages)
 
 	if(href_list["settitle"])
 		var/newtitle = input("Enter a title to search for:") as text|null
@@ -92,7 +92,7 @@
 		if(num_pages == 0)
 			page_num = 0
 		else
-			page_num = Clamp(text2num(href_list["page"]), 0, num_pages)
+			page_num = clamp(text2num(href_list["page"]), 0, num_pages)
 
 	if(href_list["search"])
 		num_results = src.get_num_results()

--- a/code/modules/media/broadcast/transmitters/broadcast.dm
+++ b/code/modules/media/broadcast/transmitters/broadcast.dm
@@ -242,7 +242,7 @@
 		var/datum/gas_mixture/environment = loc.return_air()
 		switch(environment.temperature)
 			if(T0C to (T20C + 20))
-				integrity = Clamp(integrity, 0, 100)
+				integrity = clamp(integrity, 0, 100)
 			if((T20C + 20) to INFINITY)
 				integrity = max(0, integrity - 1)
 

--- a/code/modules/media/jukebox.dm
+++ b/code/modules/media/jukebox.dm
@@ -633,7 +633,7 @@ var/global/list/loopModeNames=list(
 		if(isobserver(usr) && !canGhostWrite(usr,src,""))
 			to_chat(usr, "<span class='warning'>You can't do that.</span>")
 			return
-		selected_song=Clamp(text2num(href_list["song"]),1,playlist.len)
+		selected_song=clamp(text2num(href_list["song"]),1,playlist.len)
 		if(isAdminGhost(usr))
 			var/datum/song_info/song=playlist[selected_song]
 			log_adminghost("[key_name_admin(usr)] changed [src] next song to #[selected_song] ([song.display()]) at [formatJumpTo(src)]")

--- a/code/modules/media/mediamanager.dm
+++ b/code/modules/media/mediamanager.dm
@@ -119,9 +119,9 @@ function SetMusic(url, time, volume) {
 	set name = "Stop Admin Music"
 	set desc = "Stops all playing admin sounds."
 	set category = "OOC"
-	
+
 	src << sound(null, repeat = 0, wait = 0, volume = 0, channel = CHANNEL_ADMINMUSIC)
-			
+
 /mob/proc/force_music(var/url,var/start,var/volume=1)
 	if (client && client.media)
 		client.media.forced=(url!="")
@@ -186,7 +186,7 @@ to_chat(#define MP_DEBUG(x) owner, x)
 	if (url != targetURL || abs(targetStartTime - start_time) > 1 || abs(targetVolume - source_volume) > 0.1 /* 10% */)
 		url = targetURL
 		start_time = targetStartTime
-		source_volume = Clamp(targetVolume, 0, 1)
+		source_volume = clamp(targetVolume, 0, 1)
 		send_update()
 
 /datum/media_manager/proc/stop_music()

--- a/code/modules/mining/abandonedcrates.dm
+++ b/code/modules/mining/abandonedcrates.dm
@@ -22,7 +22,7 @@ var/global/list/valid_abandoned_crate_types = typesof(/obj/structure/closet/crat
 		to_chat(user, "<span class='notice'>The crate is locked with a Deca-code lock.</span>")
 		var/input = input(usr, "Enter digit from [min] to [max].", "Deca-Code Lock", "") as num
 		if(in_range(src, user))
-			input = Clamp(input, 0, 10)
+			input = clamp(input, 0, 10)
 			if (input == code)
 				to_chat(user, "<span class='notice'>The crate unlocks!</span>")
 				locked = 0

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -478,11 +478,11 @@
 			credits = 0
 
 	if(signal.data["inc_priority"])
-		var/idx = Clamp(signal.data["inc_priority"], 2, recipes.len)
+		var/idx = clamp(signal.data["inc_priority"], 2, recipes.len)
 		recipes.Swap(idx, idx - 1)
 
 	if(signal.data["dec_priority"])
-		var/idx = Clamp(signal.data["dec_priority"], 1, recipes.len - 1)
+		var/idx = clamp(signal.data["dec_priority"], 1, recipes.len - 1)
 		recipes.Swap(idx, idx + 1)
 
 /obj/machinery/mineral/processing_unit/multitool_menu(var/mob/user, var/obj/item/device/multitool/P)
@@ -500,7 +500,7 @@
 /obj/machinery/mineral/processing_unit/multitool_topic(mob/user, list/href_list, obj/item/device/multitool/P)
 	if("changedir" in href_list)
 		var/changingdir = text2num(href_list["changedir"])
-		changingdir = Clamp(changingdir, 1, 2)//No runtimes from HREF exploits.
+		changingdir = clamp(changingdir, 1, 2)//No runtimes from HREF exploits.
 
 		var/newdir = input("Select the new direction", name, "North") as null|anything in list("North", "South", "East", "West")
 		if(!newdir)

--- a/code/modules/mining/machine_stacking.dm
+++ b/code/modules/mining/machine_stacking.dm
@@ -312,7 +312,7 @@
 /obj/machinery/mineral/stacking_machine/multitool_topic(mob/user, list/href_list, obj/item/device/multitool/P)
 	if("changedir" in href_list)
 		var/changingdir = text2num(href_list["changedir"])
-		changingdir = Clamp(changingdir, 1, 2)//No runtimes from HREF exploits.
+		changingdir = clamp(changingdir, 1, 2)//No runtimes from HREF exploits.
 
 		var/newdir = input("Select the new direction", name, "North") as null|anything in list("North", "South", "East", "West")
 		if(!newdir)

--- a/code/modules/mining/mint.dm
+++ b/code/modules/mining/mint.dm
@@ -112,7 +112,7 @@
 
 /obj/machinery/mineral/mint/proc/Change_Dir(var/dir)
 	var/changingdir = dir //See ore processing_unit for original comments
-	changingdir = Clamp(changingdir, 1, 2)
+	changingdir = clamp(changingdir, 1, 2)
 
 	var/newdir = input("Select the new direction", name, "North") as null|anything in list("North", "South", "East", "West")
 	if(!newdir)
@@ -173,7 +173,7 @@
 	if("changedir" in href_list)
 		//Change_Dir()
 		var/changingdir = text2num(href_list["changedir"]) //See ore processing_unit for original comments
-		changingdir = Clamp(changingdir, 1, 2)
+		changingdir = clamp(changingdir, 1, 2)
 
 		var/newdir = input("Select the new direction", name, "North") as null|anything in list("North", "South", "East", "West")
 		if(!newdir)
@@ -197,7 +197,7 @@
 		chosen = href_list["choose"]
 
 	if(href_list["chooseAmt"])
-		coinsToProduce = Clamp(coinsToProduce + text2num(href_list["chooseAmt"]), 0, 1000)
+		coinsToProduce = clamp(coinsToProduce + text2num(href_list["chooseAmt"]), 0, 1000)
 
 	if(href_list["makeCoins"])
 		if(chosen == null)

--- a/code/modules/mining/ore_redemption.dm
+++ b/code/modules/mining/ore_redemption.dm
@@ -160,7 +160,7 @@
 				return 1
 			var/obj/item/stack/sheet/out = new mat.sheettype(output.loc)
 			out.redeemed = 1 //Central command will not pay for this mineral stack.
-			out.amount = Clamp(desired, 0, min(materials.storage[release], out.max_amount))
+			out.amount = clamp(desired, 0, min(materials.storage[release], out.max_amount))
 			materials.removeAmount(release, out.amount)
 	updateUsrDialog()
 	return

--- a/code/modules/mob/delays.dm
+++ b/code/modules/mob/delays.dm
@@ -15,7 +15,7 @@
 	max_delay=max
 
 /datum/delay_controller/proc/setDelay(var/delay)
-	next_allowed = world.time + Clamp(delay,min_delay,max_delay)
+	next_allowed = world.time + clamp(delay,min_delay,max_delay)
 
 /datum/delay_controller/proc/addDelay(var/delay)
 	var/current_delay = max(0,next_allowed - world.time)

--- a/code/modules/mob/living/carbon/complex/life.dm
+++ b/code/modules/mob/living/carbon/complex/life.dm
@@ -164,10 +164,10 @@
 
 	if(Toxins_pp > safe_toxins_max) // Too much toxins
 		var/ratio = (breath[GAS_PLASMA]/safe_toxins_max) * 10
-		//adjustToxLoss(Clamp(ratio, MIN_PLASMA_DAMAGE, MAX_PLASMA_DAMAGE))	//Limit amount of damage toxin exposure can do per second
+		//adjustToxLoss(clamp(ratio, MIN_PLASMA_DAMAGE, MAX_PLASMA_DAMAGE))	//Limit amount of damage toxin exposure can do per second
 		if(ratio)
 			if(reagents)
-				reagents.add_reagent(PLASMA, Clamp(ratio, MIN_PLASMA_DAMAGE, MAX_PLASMA_DAMAGE))
+				reagents.add_reagent(PLASMA, clamp(ratio, MIN_PLASMA_DAMAGE, MAX_PLASMA_DAMAGE))
 			toxins_alert = max(toxins_alert, 1)
 	else
 		toxins_alert = 0

--- a/code/modules/mob/living/carbon/complex/martian/martian.dm
+++ b/code/modules/mob/living/carbon/complex/martian/martian.dm
@@ -72,7 +72,7 @@
 	if(headwear)
 		protection = headwear.eyeprot
 
-	return Clamp(protection, -2, 2)
+	return clamp(protection, -2, 2)
 
 /mob/living/carbon/complex/martian/can_be_infected()
 	return 1

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -643,7 +643,7 @@
 	if(E)
 		. += E.eyeprot
 
-	return Clamp(., -2, 2)
+	return clamp(., -2, 2)
 
 
 /mob/living/carbon/human/IsAdvancedToolUser()

--- a/code/modules/mob/living/carbon/human/life/handle_mutations_and_radiation.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_mutations_and_radiation.dm
@@ -29,7 +29,7 @@
 
 			if(species.flags & RAD_GLOW)
 				// Lighting based on radiation.
-				var/rad_glow = Clamp(radiation/20,0.25,5)
+				var/rad_glow = clamp(radiation/20,0.25,5)
 				set_light(rad_glow, rad_glow/2, "#5dca31")
 
 

--- a/code/modules/mob/living/carbon/human/life/handle_shock.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_shock.dm
@@ -13,7 +13,7 @@
 	else if(health < config.health_threshold_softcrit)
 		pain_shock_stage = max(pain_shock_stage, 61)
 	else
-		pain_shock_stage = Clamp(pain_shock_stage - 1, 0, 160)
+		pain_shock_stage = clamp(pain_shock_stage - 1, 0, 160)
 		return
 
 	if(pain_shock_stage == 10)

--- a/code/modules/mob/living/carbon/monkey/life.dm
+++ b/code/modules/mob/living/carbon/monkey/life.dm
@@ -324,7 +324,7 @@
 
 	if(Toxins_pp > safe_toxins_max) // Too much toxins
 		var/ratio = (breath[GAS_PLASMA]/safe_toxins_max) * 10
-		//adjustToxLoss(Clamp(ratio, MIN_PLASMA_DAMAGE, MAX_PLASMA_DAMAGE))	//Limit amount of damage toxin exposure can do per second
+		//adjustToxLoss(clamp(ratio, MIN_PLASMA_DAMAGE, MAX_PLASMA_DAMAGE))	//Limit amount of damage toxin exposure can do per second
 		if(wear_mask)
 			if(wear_mask.clothing_flags & BLOCK_GAS_SMOKE_EFFECT)
 				if(breath[GAS_PLASMA] > safe_toxins_mask)
@@ -333,7 +333,7 @@
 					ratio = 0
 		if(ratio)
 			if(reagents)
-				reagents.add_reagent(PLASMA, Clamp(ratio, MIN_PLASMA_DAMAGE, MAX_PLASMA_DAMAGE))
+				reagents.add_reagent(PLASMA, clamp(ratio, MIN_PLASMA_DAMAGE, MAX_PLASMA_DAMAGE))
 			toxins_alert = max(toxins_alert, 1)
 	else
 		toxins_alert = 0

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -514,7 +514,7 @@
 			var/turf/T = loc
 			light_amount = T.get_lumcount() * 10
 
-		growth = Clamp(growth + rand(1,3)/(10*light_amount>1 ? light_amount : 1),0,100)
+		growth = clamp(growth + rand(1,3)/(10*light_amount>1 ? light_amount : 1),0,100)
 
 		if(growth >= 100)
 			growth = 0

--- a/code/modules/mob/living/holders.dm
+++ b/code/modules/mob/living/holders.dm
@@ -95,7 +95,7 @@
 	..()
 	if(M)
 		appearance = M.appearance
-		w_class = Clamp((M.size - SIZE_TINY) * W_CLASS_MEDIUM, W_CLASS_TINY, W_CLASS_HUGE)
+		w_class = clamp((M.size - SIZE_TINY) * W_CLASS_MEDIUM, W_CLASS_TINY, W_CLASS_HUGE)
 		//	SIZE		|	W_CLASS
 
 		//	SIZE_TINY	|	W_CLASS_TINY

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -279,7 +279,7 @@
 	return
 
 /mob/living/proc/adjust_fire_stacks(add_fire_stacks) //Adjusting the amount of fire_stacks we have on person
-	fire_stacks = Clamp(fire_stacks + add_fire_stacks, -20, 20)
+	fire_stacks = clamp(fire_stacks + add_fire_stacks, -20, 20)
 
 /mob/living/proc/handle_fire()
 	if((flags & INVULNERABLE) && on_fire)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -567,7 +567,7 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 	if(purge)
 		damage = damage * 2
 
-	health = Clamp(health - damage, 0, maxHealth)
+	health = clamp(health - damage, 0, maxHealth)
 	if(health < 1 && stat != DEAD)
 		death()
 
@@ -582,7 +582,7 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 		damage = damage * 2
 	if(purge)
 		damage = damage * 2
-	health = Clamp(health - damage, 0, maxHealth)
+	health = clamp(health - damage, 0, maxHealth)
 	if(health < 1 && stat != DEAD)
 		death()
 

--- a/code/modules/organs/internal/lungs/lung_gasses.dm
+++ b/code/modules/organs/internal/lungs/lung_gasses.dm
@@ -150,7 +150,7 @@
 	if(pp > max_pp) // Too much toxins
 		//testing("TOXIC: gasid=[id];pp=[pp]")
 		var/ratio = (pp/max_pp) * reagent_mult // WAS: (moles/max_moles) * 10
-		//adjustToxLoss(Clamp(ratio, MIN_PLASMA_DAMAGE, MAX_PLASMA_DAMAGE))	//Limit amount of damage toxin exposure can do per second
+		//adjustToxLoss(clamp(ratio, MIN_PLASMA_DAMAGE, MAX_PLASMA_DAMAGE))	//Limit amount of damage toxin exposure can do per second
 		if(max_pp_mask)
 			if(H.wear_mask)
 				if(H.wear_mask.clothing_flags & BLOCK_GAS_SMOKE_EFFECT)
@@ -160,9 +160,9 @@
 						ratio = 0
 		if(ratio)
 			if(H.reagents)
-				// H.reagents.add_reagent(PLASMA, Clamp(ratio, MIN_PLASMA_DAMAGE, MAX_PLASMA_DAMAGE))
+				// H.reagents.add_reagent(PLASMA, clamp(ratio, MIN_PLASMA_DAMAGE, MAX_PLASMA_DAMAGE))
 				// no this is bad n3x pls no
-				H.adjustToxLoss(Clamp(ratio, MIN_PLASMA_DAMAGE, MAX_PLASMA_DAMAGE))
+				H.adjustToxLoss(clamp(ratio, MIN_PLASMA_DAMAGE, MAX_PLASMA_DAMAGE))
 			H.toxins_alert = max(H.toxins_alert, 1)
 	else
 		H.toxins_alert = 0

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -550,7 +550,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		//Having an infection raises your body temperature
 		var/fever_temperature = (owner.species.heat_level_1 - owner.species.body_temperature - 5)* min(germ_level/INFECTION_LEVEL_TWO, 1) + owner.species.body_temperature
 		//Need to make sure we raise temperature fast enough to get around environmental cooling preventing us from reaching fever_temperature
-		owner.bodytemperature += Clamp((fever_temperature - T20C) / BODYTEMP_COLD_DIVISOR + 1, 0, fever_temperature - owner.bodytemperature)
+		owner.bodytemperature += clamp((fever_temperature - T20C) / BODYTEMP_COLD_DIVISOR + 1, 0, fever_temperature - owner.bodytemperature)
 
 		if(prob(round(germ_level/10)))
 			if(antibiotics < 5)

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -53,7 +53,7 @@
 		return
 
 	if(copy)
-		copies = Clamp(copies, 0, 10)
+		copies = clamp(copies, 0, 10)
 		spawn()
 			copying = 1
 			for(var/i = 0, i < copies, i++)
@@ -82,7 +82,7 @@
 			copying = 0
 		updateUsrDialog()
 	else if(photocopy)
-		copies = Clamp(copies, 0, 10)
+		copies = clamp(copies, 0, 10)
 		spawn()
 			copying = 1
 			for(var/i = 0, i < copies, i++)
@@ -121,7 +121,7 @@
 					break
 			copying = 0
 	else if(ass) //ASS COPY. By Miauw
-		copies = Clamp(copies, 0, 10)
+		copies = clamp(copies, 0, 10)
 		spawn()
 			copying = 1
 			for(var/i = 0, i < copies, i++)
@@ -281,11 +281,11 @@
 		var/xdim = input(usr, "Default paper width", "Formatting", 400) as num|null
 		if(!xdim)
 			return
-		xdim = Clamp(xdim,100,800)
+		xdim = clamp(xdim,100,800)
 		var/ydim = input(usr, "Default paper height", "Formatting", 400) as num|null
 		if(!ydim)
 			return
-		ydim = Clamp(ydim,100,900)
+		ydim = clamp(ydim,100,900)
 		copy.display_x = xdim
 		copy.display_y = ydim
 		to_chat(usr, "<span class='notice'>The machine hums a moment as it configures your document.</span>")

--- a/code/modules/power/battery.dm
+++ b/code/modules/power/battery.dm
@@ -148,7 +148,7 @@ var/global/list/battery_online =	list(
 		update_icon()
 
 /obj/machinery/power/battery/proc/chargedisplay()
-	return Clamp(round(5.5*charge/(capacity ? capacity : 5e6)), 0, battery_charge.len)
+	return clamp(round(5.5*charge/(capacity ? capacity : 5e6)), 0, battery_charge.len)
 
 /*
  * Called after all power processes are finished

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -308,7 +308,7 @@
 		circ2.network2.update = TRUE
 
 	//Update icon overlays and power usage only if displayed level has changed.
-	var/genlev = Clamp(round(11 * last_gen / max_power), 0, 11)
+	var/genlev = clamp(round(11 * last_gen / max_power), 0, 11)
 
 	if(last_gen > 100 && genlev == 0)
 		genlev = 1

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -324,13 +324,13 @@
 	if(!master)
 		invisibility = 101 //Make doubly sure
 		return
-	var/visible_power = Clamp(round(power/3) + 1, 1, 3)
+	var/visible_power = clamp(round(power/3) + 1, 1, 3)
 	//if(!master)
 		//testing("Visible power: [visible_power]")
 	icon_state = "[base_state]_[visible_power]"
 
 /obj/effect/beam/emitter/get_machine_underlay(var/mdir)
-	var/visible_power = Clamp(round(power/3) + 1, 1, 3)
+	var/visible_power = clamp(round(power/3) + 1, 1, 3)
 	return image(icon = icon, icon_state = "[base_state]_[visible_power] underlay", dir = mdir)
 
 /obj/effect/beam/emitter/get_damage()

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -45,7 +45,7 @@ var/global/list/obj/machinery/field_generator/field_gen_list = list()
 	// Scale % power to % num_power_levels and truncate value
 	var/p_level = round(num_power_levels * power / field_generator_max_power, 1)
 	// Clamp between 0 and num_power_levels for out of range power values
-	p_level = Clamp(p_level, 0, num_power_levels)
+	p_level = clamp(p_level, 0, num_power_levels)
 	if(p_level)
 		overlays += image(icon = icon, icon_state = "+p[p_level]")
 

--- a/code/modules/power/solars/control.dm
+++ b/code/modules/power/solars/control.dm
@@ -183,7 +183,7 @@ Manual Tracking Direction:"}
 
 	if(href_list["rate control"])
 		if(href_list["cdir"])
-			cdir = Clamp((360 + cdir + text2num(href_list["cdir"])) % 360, 0, 359)
+			cdir = clamp((360 + cdir + text2num(href_list["cdir"])) % 360, 0, 359)
 			spawn(1)
 				set_panels(cdir)
 				update_icon()
@@ -209,7 +209,7 @@ Manual Tracking Direction:"}
 	updateUsrDialog()
 
 /obj/machinery/power/solar/control/proc/set_trackrate(new_value)
-	trackrate = Clamp(new_value, 0, 360)
+	trackrate = clamp(new_value, 0, 360)
 	if(trackrate > 0)
 		nexttime = world.time + 6000 / trackrate
 

--- a/code/modules/power/solars/panel.dm
+++ b/code/modules/power/solars/panel.dm
@@ -116,7 +116,7 @@
 		return
 
 	if(adir != ndir)
-		adir = (360 + adir + Clamp(ndir - adir, -10, 10)) % 360
+		adir = (360 + adir + clamp(ndir - adir, -10, 10)) % 360
 		update_icon()
 		update_solar_exposure()
 

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -52,7 +52,7 @@
 	//If there's no power cell, the gun looks as if it had an empty power cell
 
 	ratio *= 100
-	ratio = Clamp(ratio, 0, 100) //Value between 0 and 100
+	ratio = clamp(ratio, 0, 100) //Value between 0 and 100
 
 	if(ratio >= 50)
 		ratio = Floor(ratio, icon_charge_multiple)

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -427,10 +427,10 @@
 	set category = "Object"
 	if(mode == 2)
 		mutstrength = input(usr, "Enter new mutation strength level (15-25):", "Somatoray Gamma Ray Threshold", mutstrength) as num
-		mutstrength = Clamp(round(mutstrength), 15, 25)
+		mutstrength = clamp(round(mutstrength), 15, 25)
 	else
 		mutstrength = input(usr, "Enter new mutation strength level (1-15):", "Somatoray Alpha Ray Threshold", mutstrength) as num
-		mutstrength = Clamp(round(mutstrength), 1, 15)
+		mutstrength = clamp(round(mutstrength), 1, 15)
 
 /obj/item/weapon/gun/energy/floragun/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(isEmag(W) || issolder(W))

--- a/code/modules/projectiles/guns/projectile/constructable/swords.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/swords.dm
@@ -97,7 +97,7 @@
 	if (N)
 		if(usr.incapacitated() || !(usr in range(src,0)))
 			return
-		inject_amount = Clamp(N, min_inject_amount, max_inject_amount)
+		inject_amount = clamp(N, min_inject_amount, max_inject_amount)
 		to_chat(usr, "<span class='notice'>\The [src] will now inject [inject_amount] units each hit.</span>")
 
 /obj/item/weapon/sword/venom/examine(mob/user)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -4098,7 +4098,7 @@
 
 	data++
 
-	var/stench_radius = Clamp(data * 0.1, 1, 6) //Stench starts out with 1 tile radius and grows after every 10 life ticks
+	var/stench_radius = clamp(data * 0.1, 1, 6) //Stench starts out with 1 tile radius and grows after every 10 life ticks
 
 	if(prob(5)) //5% chance of stinking per life()
 		for(var/mob/living/carbon/C in oview(stench_radius, M)) //All other carbons in 4 tile radius (excluding our mob)
@@ -6634,7 +6634,7 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 	id = PASSIONE
 	description = "Rejuvenating!"
 	nutriment_factor = 3 * REAGENTS_METABOLISM //because honey
-	
+
 /datum/reagent/drink/coffee/passione/on_mob_life(var/mob/living/M)
 	..()
 

--- a/code/modules/reagents/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/machinery/chem_dispenser.dm
@@ -226,7 +226,7 @@ USE THIS CHEMISTRY DISPENSER FOR MAPS SO THEY START AT 100 ENERGY
 		else
 			custom = 0
 			amount = round(text2num(href_list["amount"]), 5) // round to nearest 5
-		amount = Clamp(amount, 5, 100) // Since the user can actually type the commands himself, some sanity checking
+		amount = clamp(amount, 5, 100) // Since the user can actually type the commands himself, some sanity checking
 		if (custom)
 			useramount = amount
 

--- a/code/modules/reagents/machinery/chem_master.dm
+++ b/code/modules/reagents/machinery/chem_master.dm
@@ -381,7 +381,7 @@ var/global/list/pillIcon2Name = list("oblong purple-pink", "oblong green-white",
 				var/count = 1
 				if(href_list["createbottle_multiple"])
 					count = isgoodnumber(input("Select the number of bottles to make.", "Amount:", last_bottle_amt) as num)
-				count = Clamp(count, 1, 4)
+				count = clamp(count, 1, 4)
 				last_bottle_amt = count
 
 				var/amount_per_bottle = reagents.total_volume > 0 ? reagents.total_volume/count : 0

--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -224,7 +224,7 @@ var/list/special_fruits = list()
 		return 0
 
 	var/list/thingsweinjected = list()
-	var/injecting = Clamp(1, 3, potency/10)
+	var/injecting = clamp(1, 3, potency/10)
 
 	for(var/rid in seed.chems) //Only transfer reagents that the plant naturally produces, no injecting chloral into your nettles.
 		reagents.trans_id_to(H,rid,injecting)

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -88,12 +88,12 @@
 	add_fingerprint(usr)
 
 	if(href_list["nextTag"])
-		currTag = Clamp(text2num(href_list["nextTag"]), 0, destinations.len)
+		currTag = clamp(text2num(href_list["nextTag"]), 0, destinations.len)
 		interact(usr)
 		return 1
 
 	if(href_list["remove_dest"] && mode)
-		var/idx = Clamp(text2num(href_list["remove_dest"]), 1, destinations.len)
+		var/idx = clamp(text2num(href_list["remove_dest"]), 1, destinations.len)
 		if(currTag == destinations[idx])
 			currTag = 0 // In case the index was at the end of the list
 		destinations -= destinations[idx]
@@ -341,7 +341,7 @@
 
 	if("changedir" in href_list)
 		var/changingdir = text2num(href_list["changedir"])
-		changingdir = Clamp(changingdir, 1, 3)//No runtimes from HREF exploits.
+		changingdir = clamp(changingdir, 1, 3)//No runtimes from HREF exploits.
 
 		var/newdir = input("Select the new direction", "MinerX SortMaster 5000", "North") as null|anything in list("North", "South", "East", "West")
 		if(!newdir)
@@ -405,7 +405,7 @@
 	if(href_list["toggle_types"])
 		var/typeID = text2num(href_list["toggle_types"])
 
-		typeID = Clamp(typeID, 1, types.len)//No HREF exploits causing runtimes.
+		typeID = clamp(typeID, 1, types.len)//No HREF exploits causing runtimes.
 
 		if(types[typeID] in selected_types)//Toggle these
 			selected_types -= types[typeID]
@@ -507,7 +507,7 @@
 		return
 
 	if(href_list["toggle_dest"])
-		var/idx = Clamp(text2num(href_list["toggle_dest"]), 0, destinations.len)
+		var/idx = clamp(text2num(href_list["toggle_dest"]), 0, destinations.len)
 		if(destinations[idx] in sorting)
 			sorting -= destinations[idx]
 		else
@@ -516,7 +516,7 @@
 		return 1
 
 	if(href_list["remove_dest"])
-		var/idx = Clamp(text2num(href_list["remove_dest"]), 0, destinations.len)
+		var/idx = clamp(text2num(href_list["remove_dest"]), 0, destinations.len)
 		sorting -= destinations[idx]
 		destinations -= destinations[idx]
 		updateUsrDialog()

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -77,7 +77,7 @@ The required techs are the following:
 	for(var/datum/tech/T in temp_techs)
 		if(T.id in req_tech)
 			new_reliability += T.level
-	new_reliability = Clamp(new_reliability, reliability_base, 100)
+	new_reliability = clamp(new_reliability, reliability_base, 100)
 	reliability = new_reliability
 	return
 

--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -37,7 +37,7 @@ Note: Must be placed within 3 tiles of the R&D Console
 	var/T = 0
 	for(var/obj/item/weapon/stock_parts/S in component_parts)
 		T += S.rating * 0.1
-	T = Clamp(T, 0, 1)
+	T = clamp(T, 0, 1)
 	decon_mod = T
 
 /obj/machinery/r_n_d/destructive_analyzer/proc/ConvertReqString2List(var/list/source_list)

--- a/code/modules/research/fabricators.dm
+++ b/code/modules/research/fabricators.dm
@@ -606,7 +606,7 @@
 	if(href_list["eject"])
 		var/num = input("Enter amount to eject", "Amount", "5") as num
 		if(num)
-			amount = Clamp(round(text2num(num), 1), 0, 50)
+			amount = clamp(round(text2num(num), 1), 0, 50)
 		remove_material(href_list["eject"], amount)
 		return 1
 

--- a/code/modules/research/mechanic/flatpack.dm
+++ b/code/modules/research/mechanic/flatpack.dm
@@ -104,7 +104,7 @@
 
 		if(clicked_index == 0) //clicked the bottom pack? Too bad, nothing happens
 			return
-		clicked_index = Clamp(clicked_index, 1, stacked.len)
+		clicked_index = clamp(clicked_index, 1, stacked.len)
 
 		var/obj/structure/closet/crate/flatpack/bottom_pack = locate(stacked[clicked_index]) //so the very bottom pack is selected
 
@@ -270,11 +270,11 @@
 	..()
 	machine = new /obj/machinery/suit_modifier(src)
 	new /obj/item/rig_module/health_readout(src)
-	
+
 /obj/structure/closet/crate/flatpack/soda_dispenser/New()
 	..()
 	machine = new /obj/machinery/chem_dispenser/soda_dispenser(src)
-	
+
 /obj/structure/closet/crate/flatpack/booze_dispenser/New()
 	..()
 	machine = new /obj/machinery/chem_dispenser/booze_dispenser(src)
@@ -282,15 +282,15 @@
 /obj/structure/closet/crate/flatpack/brewer/New()
 	..()
 	machine = new /obj/machinery/chem_dispenser/brewer(src)
-	
+
 /obj/structure/closet/crate/flatpack/starscreen_generator/New()
 	..()
 	machine = new /obj/machinery/shield_gen(src)
-	
+
 /obj/structure/closet/crate/flatpack/starscreen_ex_generator/New()
 	..()
 	machine = new /obj/machinery/shield_gen/external(src)
-	
+
 /obj/structure/closet/crate/flatpack/starscreen_capacitor/New()
 	..()
 	machine = new /obj/machinery/shield_capacitor(src)

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -444,7 +444,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 						return //in case the 'lathe gets unlinked or destroyed or someshit while the popup is open
 				else
 					n = text2num(href_list["n"])
-				n = Clamp(n, 0, RESEARCH_MAX_Q_LEN - linked_lathe.queue.len)
+				n = clamp(n, 0, RESEARCH_MAX_Q_LEN - linked_lathe.queue.len)
 				for(var/i=1;i<=n;i++)
 					use_power(power)
 					linked_lathe.queue += being_built
@@ -477,7 +477,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 						return //in case the imprinter gets unlinked or destroyed or someshit while the popup is open
 				else
 					n = text2num(href_list["n"])
-				n = Clamp(n, 0, RESEARCH_MAX_Q_LEN - linked_imprinter.queue.len)
+				n = clamp(n, 0, RESEARCH_MAX_Q_LEN - linked_imprinter.queue.len)
 				for(var/i=1;i<=n;i++)
 					linked_imprinter.queue += being_built
 					use_power(power)
@@ -763,7 +763,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			else
 
 				dat += {"Name: [d_disk.blueprint.name]<BR>
-					Level: [Clamp(d_disk.blueprint.reliability + rand(-15,15), 0, 100)]<BR>"}
+					Level: [clamp(d_disk.blueprint.reliability + rand(-15,15), 0, 100)]<BR>"}
 				switch(d_disk.blueprint.build_type)
 					if(IMPRINTER)
 						dat += "Lathe Type: Circuit Imprinter<BR>"

--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -141,7 +141,7 @@ var/global/list/hidden_tech = list(
 			AddDesign2Known(PD)
 	for(var/ID in known_tech)
 		var/datum/tech/T = known_tech[ID]
-		T.level = Clamp(T.level, 1, 20)
+		T.level = clamp(T.level, 1, 20)
 	for(var/datum/design/D in known_designs)
 		D.CalcReliability(known_tech)
 	return

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -60,7 +60,7 @@
 		if(0 to T0C)
 			health = min(100, health + 1)
 		if(T0C to (T20C + 20))
-			health = Clamp(health, 0, 100)
+			health = clamp(health, 0, 100)
 		if((T20C + 20) to INFINITY)
 			health = max(0, health - 1)
 	if(health <= 0)

--- a/code/modules/scripting/Implementations/Telecomms.dm
+++ b/code/modules/scripting/Implementations/Telecomms.dm
@@ -284,7 +284,7 @@
 		freq = sanitize_frequency(freq)
 
 		code = round(code)
-		code = Clamp(code, 0, 100)
+		code = clamp(code, 0, 100)
 
 		var/datum/signal/signal = getFromPool(/datum/signal)
 		signal.source = S

--- a/code/modules/scripting/Implementations/_Logic.dm
+++ b/code/modules/scripting/Implementations/_Logic.dm
@@ -174,7 +174,7 @@ proc/n_str2num(var/string)
 // Clamps N between min and max
 /proc/n_clamp(var/num, var/min = 0, var/max = 1)
 	if(isnum(num) && isnum(min) && isnum(max))
-		return Clamp(num, min, max)
+		return clamp(num, min, max)
 
 // Number shit
 proc/n_num2str(var/num)

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -249,7 +249,7 @@
 	damage = max( damage + ( (removed.temperature - 800) / 150 ) , 0 )
 	//Ok, 100% oxygen atmosphere = best reaction
 	//Maxes out at 100% oxygen pressure
-	oxygen = Clamp((removed[GAS_OXYGEN] - removed[GAS_NITROGEN] * NITROGEN_RETARDATION_FACTOR) / MOLES_CELLSTANDARD, 0, 1) //0 unless O2>80%. At 99%, ~0.6
+	oxygen = clamp((removed[GAS_OXYGEN] - removed[GAS_NITROGEN] * NITROGEN_RETARDATION_FACTOR) / MOLES_CELLSTANDARD, 0, 1) //0 unless O2>80%. At 99%, ~0.6
 
 	var/temp_factor = 100
 
@@ -298,7 +298,7 @@
 
 	power -= (power/power_loss_modifier)**3
 
-	var/light_value = Clamp(round(Clamp(power / max_power, 0, 1) * max_luminosity), 0, max_luminosity)
+	var/light_value = clamp(round(clamp(power / max_power, 0, 1) * max_luminosity), 0, max_luminosity)
 
 	// Lighting based on power output.
 	set_light(light_value, light_value / 2)

--- a/code/modules/telesci/telesci_computer.dm
+++ b/code/modules/telesci/telesci_computer.dm
@@ -290,8 +290,8 @@ var/list/telesci_warnings = list(
 
 	var/trueX = x_co + x_off - x_player_off + WORLD_X_OFFSET[z_co]
 	var/trueY = y_co + y_off - y_player_off + WORLD_Y_OFFSET[z_co]
-	trueX = Clamp(trueX, 1, world.maxx)
-	trueY = Clamp(trueY, 1, world.maxy)
+	trueX = clamp(trueX, 1, world.maxx)
+	trueY = clamp(trueY, 1, world.maxy)
 
 	var/turf/target = locate(trueX, trueY, z_co)
 	var/area/A=target.loc
@@ -432,7 +432,7 @@ var/list/telesci_warnings = list(
 		if(cell)
 			if (usr.put_in_hands(cell))
 				usr.visible_message("<span class='notice'>[usr] removes the cell from \the [src].</span>", "<span class='notice'>You remove the cell from \the [src].</span>")
-			else 
+			else
 				visible_message("<span class='notice'>\The [src] beeps as its cell is removed.</span>")
 				cell.forceMove(get_turf(src))
 			cell.add_fingerprint(usr)

--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -324,14 +324,14 @@ var/global/list/disease2_list = list()
 				return
 			D.form = form_name
 			D.max_stage = input(C, "How many stages will your pathogen have?", "Custom Pathogen", D.max_stage) as num
-			D.max_stage = Clamp(D.max_stage,1,99)
+			D.max_stage = clamp(D.max_stage,1,99)
 			D.infectionchance = input(C, "What will be your pathogen's infection chance?", "Custom Pathogen", D.infectionchance) as num
-			D.infectionchance = Clamp(D.infectionchance,0,100)
+			D.infectionchance = clamp(D.infectionchance,0,100)
 			D.infectionchance_base = D.infectionchance
 			D.stageprob = input(C, "What will be your pathogen's progression speed?", "Custom Pathogen", D.stageprob) as num
-			D.stageprob = Clamp(D.stageprob,0,100)
+			D.stageprob = clamp(D.stageprob,0,100)
 			D.stage_variance = input(C, "What will be your pathogen's stage variance?", "Custom Pathogen", D.stage_variance) as num
-			D.stageprob = Clamp(D.stageprob,-1*D.max_stage,0)
+			D.stageprob = clamp(D.stageprob,-1*D.max_stage,0)
 			//D.can_kill = something something a while loop but probably not worth the effort. If you need it for your bus code it yourself.
 		else
 			var/d_type = known_forms[chosen_form]
@@ -345,10 +345,10 @@ var/global/list/disease2_list = list()
 			qdel(d_inst)
 
 		D.strength = input(C, "What will be your pathogen's strength? (1-50 is trivial to cure. 50-100 requires a bit more effort)", "Pathogen Strength", D.infectionchance) as num
-		D.strength = Clamp(D.strength,0,100)
+		D.strength = clamp(D.strength,0,100)
 
 		D.robustness = input(C, "What will be your pathogen's robustness? (1-100) Lower values mean that infected can carry the pathogen without getting affected by its symptoms.", "Pathogen Robustness", D.infectionchance) as num
-		D.robustness = Clamp(D.strength,0,100)
+		D.robustness = clamp(D.strength,0,100)
 
 		var/new_id = copytext(sanitize(input(C, "You can pick a 4 number ID for your Pathogen. Otherwise a random ID will be generated.", "Pick a unique ID", rand(0,9999)) as null | num),1,4)
 		if (!new_id)
@@ -367,13 +367,13 @@ var/global/list/disease2_list = list()
 			var/datum/disease2/effect/e = new symptom(D)
 			e.stage = i
 			e.chance = input(C, "Choose the default chance for this effect to activate", "Effect", e.chance) as null | num
-			e.chance = Clamp(e.chance,0,100)
+			e.chance = clamp(e.chance,0,100)
 			e.max_chance = input(C, "Choose the maximum chance for this effect to activate", "Effect", e.max_chance) as null | num
-			e.max_chance = Clamp(e.max_chance,0,100)
+			e.max_chance = clamp(e.max_chance,0,100)
 			e.multiplier = input(C, "Choose the default strength for this effect", "Effect", e.multiplier) as null | num
-			e.multiplier = Clamp(e.multiplier,0,100)
+			e.multiplier = clamp(e.multiplier,0,100)
 			e.max_multiplier = input(C, "Choose the maximum strength for this effect", "Effect", e.max_multiplier) as null | num
-			e.max_multiplier = Clamp(e.max_multiplier,0,100)
+			e.max_multiplier = clamp(e.max_multiplier,0,100)
 
 			D.log += "Added [e.name] at [e.chance]% chance and [e.multiplier] strength<br>"
 			D.effects += e
@@ -399,7 +399,7 @@ var/global/list/disease2_list = list()
 		if (alert("Do you want to specify the appearance of your pathogen in a petri dish?","Choose your appearance","Yes","No") == "Yes")
 			D.color = input(C, "Choose the color of the dish", "Cosmetic") as color
 			D.pattern = input(C, "Choose the shape of the pattern inside the dish (1 to 6)", "Cosmetic",rand(1,6)) as num
-			D.pattern = Clamp(D.pattern,1,6)
+			D.pattern = clamp(D.pattern,1,6)
 			D.pattern_color = input(C, "Choose the color of the pattern", "Cosmetic") as color
 
 		D.spread = 0
@@ -685,7 +685,7 @@ var/global/list/disease2_list = list()
 /datum/disease2/disease/proc/get_effect(var/index)
 	if(!index)
 		return pick(effects)
-	return effects[Clamp(index,0,effects.len)]
+	return effects[clamp(index,0,effects.len)]
 
 /datum/disease2/disease/proc/roll_antigen(var/list/factors = list())
 	if (factors.len <= 0)
@@ -750,7 +750,7 @@ var/global/list/disease2_list = list()
 /datum/disease2/disease/proc/minormutate(var/index)
 	var/datum/disease2/effect/e = get_effect(index)
 	e.minormutate()
-	infectionchance = Clamp(infectionchance_base + rand(-10,10),0,100)
+	infectionchance = clamp(infectionchance_base + rand(-10,10),0,100)
 	//infectionchance = min(50,infectionchance + rand(0,10))
 	log += "<br />[timestamp()] Infection chance now [infectionchance]%"
 

--- a/code/modules/virus2/effect/effect.dm
+++ b/code/modules/virus2/effect/effect.dm
@@ -80,7 +80,7 @@
 		chance = rand(initial(chance), max_chance)
 
 /datum/disease2/effect/proc/multiplier_tweak(var/tweak)
-	multiplier = Clamp(multiplier+tweak,1,max_multiplier)
+	multiplier = clamp(multiplier+tweak,1,max_multiplier)
 
 /datum/disease2/effect/proc/getcopy(var/datum/disease2/disease/disease)
 	var/datum/disease2/effect/new_e = new type(disease)

--- a/code/modules/virus2/helpers.dm
+++ b/code/modules/virus2/helpers.dm
@@ -172,7 +172,7 @@ var/list/infected_contact_mobs = list()
 		var/datum/disease2/disease/D = disease.getcopy()
 		if (D.infectionchance > 10)
 			D.infectionchance = max(10, D.infectionchance - 10)//The virus gets weaker as it jumps from people to people
-		D.stage = Clamp(D.stage+D.stage_variance, 1, D.max_stage)
+		D.stage = clamp(D.stage+D.stage_variance, 1, D.max_stage)
 		D.log += "<br />[timestamp()] Infected [key_name(src)] [notes]. Infection chance now [D.infectionchance]%"
 		virus2["[D.uniqueID]-[D.subID]"] = D
 


### PR DESCRIPTION
Also undefines it in 513 and above
It's a builtin in 513 so after this PR, we'll be able to simply remove its definition when we update to 513 rather than having to do... what this PR does

I at least glanced at every changed line and I didn't see any false changes, but given how many there are it's not impossible I missed something

In 512 and below this changes nothing at all, but in 513 it could potentially change something, since the update notes say that the builtin `clamp()` can deal with the second arg being larger than the third, which our macro implementation cannot. (The update notes notably don't actually say what happens in this case, though.) I'm pretty sure we made sure there were no cases where that occurred a while back, but I'm not certain.

There is a local var somewhere named `clamp`, and vars sharing names with macros are pretty sketchy, but in the particular case in which it's used it Just Works