### PR TITLE
Adds Code for Derelict R&D Server and Derelict R&D Console

### DIFF
--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -218,7 +218,7 @@
 	name = "Circuit Board (Pod Bay R&D Console)"
 	desc = "A circuit board for running a R&D console for the Pod Bay."
 	build_path = /obj/machinery/computer/rdconsole/pod
-/obj/item/weapon/circuitboard/rdconsole/pod
+/obj/item/weapon/circuitboard/rdconsole/derelict
 	name = "Circuit Board (Derelict R&D Console)"
 	desc = "A circuit board for running a R&D console for the Derelict."
 	build_path = /obj/machinery/computer/rdconsole/derelict

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -218,6 +218,10 @@
 	name = "Circuit Board (Pod Bay R&D Console)"
 	desc = "A circuit board for running a R&D console for the Pod Bay."
 	build_path = /obj/machinery/computer/rdconsole/pod
+/obj/item/weapon/circuitboard/rdconsole/pod
+	name = "Circuit Board (Derelict R&D Console)"
+	desc = "A circuit board for running a R&D console for the Derelict."
+	build_path = /obj/machinery/computer/rdconsole/derelict
 
 /obj/item/weapon/circuitboard/mecha_control
 	name = "Circuit Board (Exosuit Control Console)"

--- a/code/modules/research/designs/boards/computer_science.dm
+++ b/code/modules/research/designs/boards/computer_science.dm
@@ -60,6 +60,11 @@
 	id = "rdconsole_pod"
 	build_path = /obj/item/weapon/circuitboard/rdconsole/pod
 
+/datum/design/rdconsole/derelict
+	name = "Circuit Design (Derelict R&D Console)"
+	id = "rdconsole_derelict"
+	build_path = /obj/item/weapon/circuitboard/rdconsole/derelict
+
 /datum/design/aifixer
 	name = "Circuit Design (AI Integrity Restorer)"
 	desc = "Allows for the construction of circuit boards used to build an AI Integrity Restorer."

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -1115,3 +1115,9 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	id = 5
 	req_access=list()
 	circuit = "/obj/item/weapon/circuitboard/rdconsole/pod"
+
+/obj/machinery/computer/rdconsole/derelict
+	name = "Derelict R&D Console"
+	id = 6
+	req_access=list()
+	circuit = "/obj/item/weapon/circuitboard/rdconsole/derelict"

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -336,13 +336,17 @@
 	src.updateUsrDialog()
 	return
 
+/obj/machinery/r_n_d/server/derelict
+	name = "Derelict R&D Server"
+	id_with_upload_string = "6"
+	id_with_download_string = "6"
+	server_id = 3
 
 /obj/machinery/r_n_d/server/robotics
 	name = "Robotics R&D Server"
 	id_with_upload_string = "1;2"
 	id_with_download_string = "1;2;3;4;5"
 	server_id = 2
-
 
 /obj/machinery/r_n_d/server/core
 	name = "Core R&D Server"


### PR DESCRIPTION
Related to #4057 and #24587.
While the system for removing a design entirely from the R&D computers is a little unintuitive and convoluted, the reason why it doesn't *work* is because mappers decided to just plop down an exact duplicate R&D server on the Derelict instead of making a unique type for it.
A complete fix for this is likely to touch every map at once, and there are multiple mapping PRs open currently, so that can be done later. But this at least accomplishes the introductory phase of actually having a unique server and console available for mappers to add in order to fix the bug.

Were these to replace the Derelict versions in their current state it would, technically, constitute a balance change, as I have designed the Derelict server and console to only be capable of syncing with each other, so Derelict MoMMIs would not share research with the main station. Personally, I think that's better, but it could easily be changed back. As long as the `server_id` of the server is different, the bug would be fixed.