### PR TITLE
URLs in chat no longer automatically made into hyperlinks

### DIFF
--- a/goon/browserassets/js/browserOutput.js
+++ b/goon/browserassets/js/browserOutput.js
@@ -210,10 +210,11 @@ function output(message, flag) {
 		}
 	}
 
-	//Url stuff
+/* 	//Url stuff
 	if (message.length && flag != 'preventLink') {
 		message = linkify(message);
-	}
+	} 
+*/
 
 	opts.messageCount++;
 


### PR DESCRIPTION
[tweak] [goonchat]

This comments out the functionality in goonchat which detects URLs in chat messages to auto-create hyperlinks. It does not affect any pre-formatted links sent to chat (ie. admin warn stuff). 

This means links in OOC won't be automatically clickable so to visit them you'll have to copypaste. If someone wants to change saycode or the regex to allow OOC messages then that would obviously be a better solution, this is just to address the immediate concern.