### PR TITLE
bananium coins now have their proper name

### DIFF
--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -479,7 +479,7 @@
 
 /obj/item/weapon/coin/clown
 	material=MAT_CLOWN
-	name = "bananaium coin"
+	name = "bananium coin"
 	desc = "A funny, rare coin minted from pure banana essence. Honk!"
 	icon_state = "coin_clown"
 	credits = 10


### PR DESCRIPTION
[grammar]
Bananium coins are now called bananium coins instead of bananaium coins
:cl:
 * spellcheck: we have replaced the bananaium in coins with much less expensive bananium, sorry to disappoint.