### PR TITLE
Lets SDQL work on clients and datums

### DIFF
--- a/code/modules/admin/verbs/SDQL_2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL_2/SDQL_2.dm
@@ -73,13 +73,13 @@
 				if("select", "delete", "update")
 					select_types = query_tree[query_tree[1]]
 
-			if("/datum" in select_types)
-				to_chat(usr, "<span class='danger'>Querying /datum is not supported. Please use a more specific type.</span>")
-				return
-
 
 			from_objs = SDQL_from_objs(query_tree["from"])
 			CHECK_TICK
+
+			if(from_objs == world && ("/datum" in select_types))
+				to_chat(usr, "<span class='danger'>Querying all datums is not supported. Please use a more specific type or specify a list to search.</span>")
+				return
 
 			var/list/objs = list()
 

--- a/code/modules/admin/verbs/SDQL_2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL_2/SDQL_2.dm
@@ -252,6 +252,16 @@
 			if(istype(d, type))
 				out += d
 
+	else if(ispath(type, /client))
+		for(var/client/d in location)
+			if(istype(d, type))
+				out += d
+
+	else if(location == world) //The parser implicitly sets the location to world if none is specified.
+		for(var/datum/d) //Unlike all other types, looping through world and looping without a location are not equivalent for datums.
+			if(istype(d, type))
+				out += d
+
 	else
 		for(var/datum/d in location)
 			if(istype(d, type))

--- a/code/modules/admin/verbs/SDQL_2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL_2/SDQL_2.dm
@@ -86,25 +86,25 @@
 			if("where" in query_tree)
 				var/objs_temp = objs
 				objs = list()
-				for(var/datum/d in objs_temp)
+				for(var/d in objs_temp)
 					if(SDQL_expression(d, query_tree["where"]))
 						objs += d
 					CHECK_TICK
 
 			switch(query_tree[1])
 				if("call")
-					for(var/datum/d in objs)
+					for(var/d in objs)
 						SDQL_var(d, query_tree["call"][1], source = d)
 						CHECK_TICK
 
 				if("delete")
-					for(var/datum/d in objs)
+					for(var/d in objs)
 						qdel(d)
 						CHECK_TICK
 
 				if("select")
 					var/text = ""
-					for(var/datum/t in objs)
+					for(var/t in objs)
 						text += "<A HREF='?_src_=vars;Vars=\ref[t]'>\ref[t]</A>"
 						if(istype(t, /atom))
 							var/atom/a = t
@@ -121,12 +121,14 @@
 						else
 							text += ": [t]<br>"
 						CHECK_TICK
+					if(!text)
+						text = "None found."
 					usr << browse(text, "window=SDQL-result")
 
 				if("update")
 					if("set" in query_tree)
 						var/list/set_list = query_tree["set"]
-						for(var/datum/d in objs)
+						for(var/d in objs)
 							for(var/list/sets in set_list)
 								var/datum/temp = d
 								var/i = 0
@@ -252,13 +254,20 @@
 			if(istype(d, type))
 				out += d
 
+	//For non-atomic types, looping through world is not the same as looping without specifying a location.
+	//The only non-atoms one would often want to look at with SDQL are datums and clients, so those are handled here.
+	else if(location == world) //The parser implicitly sets the location to world if none is specified.
+		if(ispath(type, /datum))
+			for(var/datum/d)
+				if(istype(d, type))
+					out += d
+		else if(ispath(type, /client))
+			for(var/client/d)
+				if(istype(d, type))
+					out += d
+
 	else if(ispath(type, /client))
 		for(var/client/d in location)
-			if(istype(d, type))
-				out += d
-
-	else if(location == world) //The parser implicitly sets the location to world if none is specified.
-		for(var/datum/d) //Unlike all other types, looping through world and looping without a location are not equivalent for datums.
 			if(istype(d, type))
 				out += d
 

--- a/code/modules/admin/verbs/SDQL_2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL_2/SDQL_2.dm
@@ -255,7 +255,7 @@
 				out += d
 
 	//For non-atomic types, looping through world is not the same as looping without specifying a location.
-	//The only non-atoms one would often want to look at with SDQL are datums and clients, so those are handled here.
+	//The only non-atoms one would often want to use with SDQL are datums and clients, so those are handled here.
 	else if(location == world) //The parser implicitly sets the location to world if none is specified.
 		if(ispath(type, /datum))
 			for(var/datum/d)

--- a/code/modules/admin/verbs/SDQL_2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL_2/SDQL_2.dm
@@ -73,6 +73,10 @@
 				if("select", "delete", "update")
 					select_types = query_tree[query_tree[1]]
 
+			if("/datum" in select_types)
+				to_chat(usr, "<span class='danger'>Querying /datum is not supported. Please use a more specific type.</span>")
+				return
+
 
 			from_objs = SDQL_from_objs(query_tree["from"])
 			CHECK_TICK


### PR DESCRIPTION
:cl:
  * rscadd: SDQL can now search for datums without having to be provided with a list, like it already could for atoms. For obvious reasons, you still aren't allowed to query the type /datum without specifying a list to search, though.
  * rscadd: SDQL is no longer completely incapable of doing anything with clients whatsoever.
  * tweak: SDQL's SELECT query now returns a message when nothing is found instead of failing silently.