### PR TITLE
Fix AI status display layer to be above windows

### DIFF
--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -341,6 +341,7 @@ var/global/list/status_display_images = list(
 	name = "AI display"
 	anchored = 1
 	density = 0
+	layer = ABOVE_WINDOW_LAYER
 
 	var/spookymode=0 // Ghosts
 


### PR DESCRIPTION
![1572225801358](https://user-images.githubusercontent.com/5822375/67645633-849be100-f932-11e9-8724-3248f292dda0.png)

:cl:
 * bugfix: AI status displays draw on top of windows now, like regular status displays.