### PR TITLE
Cell timer layer fix

### DIFF
--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -22,6 +22,7 @@
 	var/picture_state		// icon_state of alert picture, if not displaying text/numbers
 	var/list/obj/machinery/targets = list()
 	var/last_call = 0
+	layer = ABOVE_WINDOW_LAYER
 
 /obj/machinery/door_timer/initialize()
 	..()


### PR DESCRIPTION
This is like #24622 but for cell timers. I could've sworn these render above windows in-game already, so this is potentially just a mapper issue; I'm too lazy to cross-compare with or without this in-game. Either way it can't hurt.