### PR TITLE
Fix greytide implants being unintuitive

### DIFF
--- a/code/datums/gamemode/role/role.dm
+++ b/code/datums/gamemode/role/role.dm
@@ -623,6 +623,19 @@ Once done, you will be able to interface with all systems, notably the onboard n
 	id = IMPLANTSLAVE
 	logo_state = "greytide-logo"
 
+/datum/role/greytide/Drop(silent = TRUE)
+	if (!silent)
+		antag.current.visible_message("<span class='userdanger'>[antag.current] briefly convulses!</span>" ,"<span class='userdanger'>Your loyalty to the greytide fades and vanishes. You are free of your actions again.</span>")
+	return ..()
+
+/datum/role/greytide/PostMindTransfer(var/mob/living/new_character, var/mob/living/old_character)
+	for(var/obj/item/weapon/implant/I in new_character)
+		if(istype(I, /obj/item/weapon/implant/traitor))
+			return
+	Drop()
+	return ..()
+
+
 /datum/role/greytide_leader
 	name = IMPLANTLEADER
 	id = IMPLANTLEADER

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -17,6 +17,9 @@
 /obj/item/weapon/implant/proc/activate()
 	return
 
+// What do the implant does when it's removed?
+/obj/item/weapon/implant/proc/handle_removal(var/mob/remover)
+	return
 
 // What does the implant do upon injection?
 // return 0 if the implant fails (ex. Revhead and loyalty implant.)
@@ -305,9 +308,6 @@ the implant may become unstable and either pre-maturely inject the subject or si
 	if(isrevnothead(H))
 		var/datum/role/R = H.mind.GetRole(REV)
 		R.Drop()
-	if(H.mind && H.mind.GetRole(IMPLANTSLAVE))
-		var/datum/role/R = H.mind.GetRole(IMPLANTSLAVE)
-		R.Drop()
 
 	to_chat(H, "<span class = 'notice'>You feel a surge of loyalty towards Nanotrasen.</span>")
 	return 1
@@ -373,6 +373,15 @@ the implant may become unstable and either pre-maturely inject the subject or si
 	update_faction_icons()
 	log_admin("[ckey(user.key)] has mind-slaved [ckey(H.key)].")
 	return 1
+
+/obj/item/weapon/implant/traitor/handle_removal(var/mob/remover)
+	if (!imp_in.mind)
+		return
+	var/datum/role/R = imp_in.mind.GetRole(IMPLANTSLAVE)
+	if (!R)
+		return
+	log_admin("[key_name(remover)] has removed a greytide implant from [key_name(imp_in)].")
+	R.Drop(FALSE)
 
 /obj/item/weapon/implant/adrenalin
 	name = "adrenalin implant"

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -17,7 +17,7 @@
 /obj/item/weapon/implant/proc/activate()
 	return
 
-// What do the implant does when it's removed?
+// What does the implant do when it's removed?
 /obj/item/weapon/implant/proc/handle_removal(var/mob/remover)
 	return
 

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -211,6 +211,7 @@
 		obj.forceMove(get_turf(target))
 		if(istype(obj,/obj/item/weapon/implant))
 			var/obj/item/weapon/implant/imp = obj
+			imp.handle_removal(user)
 			imp.imp_in = null
 			imp.implanted = 0
 			affected.implants -= imp


### PR DESCRIPTION
Rather than removing the implant and then adding a loyalty implant, the role is dropped as soon as you remove the implant. This was counter-intuitive, and bugged, as the role was supposed to be dropped as soon as you implanted the person.
You will also lose your greytide implant if you die and get cloned.

On the other hand, adding a loyalty implant on top of the greytide one does nothing.

This second part can be changed if needed.

Closes #23302

[bugfix] [balance]

:cl:
- tweak: You are now free from a greytide implant as soon as the greytide implant is removed, or if you get cloned.