### PR TITLE
Fixes Lawgiver Suicide Music and Makes All Gun Suicide Music Louder

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -348,7 +348,7 @@
 				user.apply_damage(in_chamber.damage*2.5, in_chamber.damage_type, LIMB_HEAD, used_weapon = "Point blank shot in the mouth with \a [in_chamber]")
 				user.death()
 				var/suicidesound = pick('sound/misc/suicide/suicide1.ogg','sound/misc/suicide/suicide2.ogg','sound/misc/suicide/suicide3.ogg','sound/misc/suicide/suicide4.ogg','sound/misc/suicide/suicide5.ogg','sound/misc/suicide/suicide6.ogg')
-				playsound(src, pick(suicidesound), 10, channel = 125)
+				playsound(src, pick(suicidesound), 30, channel = 125)
 				log_attack("<font color='red'>[key_name(user)] committed suicide with \the [src].</font>")
 				user.attack_log += "\[[time_stamp()]\] <font color='red'> [user.real_name] committed suicide with \the [src]</font>"
 			else


### PR DESCRIPTION
Fixes #7595.
The Lawgiver has been made a bit more OOP, and as a result its overridden `attack()` has been removed so that it can now play suicide music properly.
Additionally, all gun-based suicide music is now thrice as loud.

:cl:
 * tweak: Gun-based suicide music is now louder.