### PR TITLE
Fixes Speech Being Audible in Space

### DIFF
--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -45,12 +45,36 @@ var/global/lastDecTalkUse = 0
 	say_testing(src, "/atom/movable/proc/send_speech() start, msg = [speech.message]; message_range = [range]; language = [speech.language ? speech.language.name : "None"];")
 	if(isnull(range))
 		range = 7
+	range = atmospheric_speech(speech,range)
 	var/rendered = render_speech(speech)
 	var/list/listeners = get_hearers_in_view(range, src)
 	if(speech.speaker.GhostsAlwaysHear())
 		listeners |= observers
 	for(var/atom/movable/AM in listeners)
 		AM.Hear(speech, rendered)
+
+/atom/movable/proc/atmospheric_speech(var/datum/speech/speech, var/range=7)
+	var/turf/T = get_turf(speech.speaker)
+	if(T && !T.c_airblock(T)) //we are on an airflowing tile
+		var/atmos = 0
+		var/datum/gas_mixture/current_air = T.return_air()
+		if(current_air)
+			atmos = round(current_air.return_pressure()/ONE_ATMOSPHERE, 0.1)
+		else
+			atmos = 0 //no air
+
+		range = min(round(range * sqrt(atmos)), range) //Range technically falls off with the root of pressure (see Newtonian sound)
+		/*Rough range breakpoints for default 7-range speech
+		10kpa: 0 (round 0.09 down to 0 for atmos value)
+		11kpa: 2
+		21kpa: 3
+		51kpa: 4
+		61kpa: 5
+		81kpa: 6
+		101kpa: 7 (normal)
+		*/
+
+	return range
 
 /atom/movable/proc/GhostsAlwaysHear()
 	return FALSE

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -64,6 +64,7 @@ var/global/lastDecTalkUse = 0
 			atmos = 0 //no air
 
 		range = min(round(range * sqrt(atmos)), range) //Range technically falls off with the root of pressure (see Newtonian sound)
+		range = max(range, 1) //If you get right next to someone you can read their lips, or something.
 		/*Rough range breakpoints for default 7-range speech
 		10kpa: 0 (round 0.09 down to 0 for atmos value)
 		11kpa: 2

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -104,8 +104,7 @@ var/global/list/organ_damage_overlays = list(
 		update_mutations()
 
 /mob/living/carbon/human/Life()
-	if(!key)
-		say("FUCK")
+
 	//set background = 1
 	if(timestopped)
 		return 0 //under effects of time magick

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -104,7 +104,8 @@ var/global/list/organ_damage_overlays = list(
 		update_mutations()
 
 /mob/living/carbon/human/Life()
-
+	if(!key)
+		say("FUCK")
 	//set background = 1
 	if(timestopped)
 		return 0 //under effects of time magick

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -263,6 +263,8 @@ var/list/department_radio_keys = list(
 	if(isnull(message_range))
 		message_range = 7
 
+	message_range = atmospheric_speech(speech,message_range)
+
 	var/list/listeners = get_hearers_in_view(message_range, speech.speaker) | observers
 
 	var/rendered = render_speech(speech)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -259,22 +259,29 @@ var/list/department_radio_keys = list(
 	return 0
 
 /mob/living/send_speech(var/datum/speech/speech, var/message_range=7, var/bubble_type) // what is bubble type?
+	var/visual_range = message_range //the range of hearers who can see that something was said, but not hear the message
 	say_testing(src, "/mob/living/send_speech() start, msg = [speech.message]; message_range = [message_range]; language = [speech.language ? speech.language.name : "None"]; speaker = [speech.speaker];")
 	if(isnull(message_range))
 		message_range = 7
 
 	message_range = atmospheric_speech(speech,message_range)
 
-	var/list/listeners = get_hearers_in_view(message_range, speech.speaker) | observers
+	var/list/total_listeners = get_hearers_in_view(visual_range, speech.speaker)
+	var/list/actual_listeners = observers.Copy()
+	for(var/atom/A in total_listeners)
+		if((A in range(message_range,src)) && !(A in actual_listeners))
+			actual_listeners.Add(A)
+		else
+			to_chat(A, "\The [speech.speaker] appears to say something, but you can't make it out from here.")
 
 	var/rendered = render_speech(speech)
 
-	var/list/listening_nonmobs = listeners.Copy()
-	for(var/mob/M in listeners)
+	var/list/listening_nonmobs = actual_listeners.Copy()
+	for(var/mob/M in actual_listeners)
 		listening_nonmobs -= M
 		M.Hear(speech, rendered)
 
-	send_speech_bubble(speech.message, bubble_type, listeners)
+	send_speech_bubble(speech.message, bubble_type, total_listeners)
 
 	for (var/atom/movable/listener in listening_nonmobs)
 		listener.Hear(speech, rendered)


### PR DESCRIPTION
Fixes #6124.
Fixes #14385.
Resurrects #19590.

The PR remains mostly unchanged from the last one. The difference is that with this PR, crewmembers are audible in any conditions while standing next to them. Lip reading or something, I don't know.
If someone speaks within your view but you are too far away to hear them at that pressure, you will see a message like this:
![image](https://user-images.githubusercontent.com/3991927/67893941-95f90f00-fb25-11e9-912e-899ab33420e1.png)
Additionally, you will still see the speech bubble as well.

Also, there was a concern raised in the last PR over locations with their own atmosphere such as inflatable shelters. However, I don't see why that would be an issue, since even if you're inside an atmosphere, the shelter being on a turf with a vacuum would still logically prevent the sound from leaving the shelter, so a turf check should be sufficient.

:cl:
 * rscadd: In space, no one can hear you talk. Unless you use the radio or stand right next to them, that is. The distance which speech travels now scales with atmospheric pressure.