### PR TITLE
Renames isatommovable() to ismovable()

### DIFF
--- a/__DEFINES/_macros.dm
+++ b/__DEFINES/_macros.dm
@@ -200,7 +200,9 @@
 
 #define isatom(A) (istype(A, /atom))
 
-#define isatommovable(A) (istype(A, /atom/movable))
+#if DM_VERSION < 513
+#define ismovable(A) (istype(A, /atom/movable))
+#endif
 
 #define isrealobject(A) (istype(A, /obj/item) || istype(A, /obj/structure) || istype(A, /obj/machinery) || istype(A, /obj/mecha))
 

--- a/code/game/objects/effects/beam.dm
+++ b/code/game/objects/effects/beam.dm
@@ -213,7 +213,7 @@
 /obj/effect/beam/proc/disconnect(var/re_emit=1)
 	var/obj/effect/beam/_master=get_master()
 	if(_master.target)
-		if(isatommovable(_master.target) && _master.target.on_moved)
+		if(ismovable(_master.target) && _master.target.on_moved)
 			_master.target.on_moved.Remove(_master.targetMoveKey)
 		_master.target.on_destroyed.Remove(_master.targetDestroyKey)
 		_master.target.beam_disconnect(_master)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -955,7 +955,7 @@
 			return FALSE
 		if (prob(50 - round(damage / 3)))
 			visible_message("<span class='borange'>[loc] blocks \the [blocked] with \the [src]!</span>")
-			if(isatommovable(blocked))
+			if(ismovable(blocked))
 				var/atom/movable/M = blocked
 				M.throwing = FALSE
 			return TRUE

--- a/code/game/objects/items/devices/camera_bug.dm
+++ b/code/game/objects/items/devices/camera_bug.dm
@@ -32,7 +32,7 @@
 		to_chat(user, "<span class='warning'>You can't seem to reach \the [A].</span>")
 		return 0
 	var/atom/movable/AM = A
-	if(isatommovable(AM))
+	if(ismovable(AM))
 		var/turf/atom_turf = get_turf(A)
 		if(AM.level == LEVEL_BELOW_FLOOR && isturf(atom_turf) && atom_turf.intact)
 			to_chat(user, "<span class='notice'>You need to remove the plating first.</span>")

--- a/code/game/objects/items/potions.dm
+++ b/code/game/objects/items/potions.dm
@@ -127,7 +127,7 @@
 	user.make_invisible(INVISIBLEPOTION, time, include_clothes)
 
 /obj/item/potion/invisibility/impact_atom(atom/target)
-	if(isatommovable(target))
+	if(ismovable(target))
 		var/atom/movable/AM = target
 		AM.make_invisible(INVISIBLEPOTION, time)
 
@@ -273,7 +273,7 @@
 		user.alphas -= TRANSPARENCYPOTION
 
 /obj/item/potion/transparency/impact_atom(atom/target)
-	if(!isatommovable(target))
+	if(!ismovable(target))
 		return
 	target.alpha = 125
 	spawn(10 MINUTES)

--- a/code/game/turfs/turf_flick_animations.dm
+++ b/code/game/turfs/turf_flick_animations.dm
@@ -66,7 +66,7 @@ proc/anim(turf/location as turf,target as mob|obj,a_icon,a_icon_state as text,fl
 		animation.color = col
 	if(trans)
 		animation.transform = trans
-	if (target && isatommovable(target))
+	if (target && ismovable(target))
 		var/atom/movable/AM = target
 		AM.lock_atom(animation, /datum/locking_category/buckle)
 	if(a_icon_state)

--- a/code/modules/projectiles/projectile/force.dm
+++ b/code/modules/projectiles/projectile/force.dm
@@ -24,7 +24,7 @@
 		if(isliving(target))
 			..()
 			to_chat(target, "<span class='warning'>The force knocks you off your feet!</span>")
-	if(isatommovable(target))
+	if(ismovable(target))
 		var/atom/movable/AM = target
 		AM.throw_at(get_edge_target_turf(target, throwdir),throw_distance,1)
 	return 1


### PR DESCRIPTION
I forgot about this one. This is also added as a builtin in 513.
0% tested because there's nothing that could conceivably go wrong other than compile failure, which Travis would catch (unless the change notes lied about how it works, but even then it would only break in 513)