### PR TITLE
Changes how isatom() works internally

### DIFF
--- a/__DEFINES/_macros.dm
+++ b/__DEFINES/_macros.dm
@@ -198,7 +198,7 @@
 
 #define isclient(A) (istype(A, /client))
 
-#define isatom(A) (istype(A, /atom))
+#define isatom(A) isloc(A)
 
 #define isatommovable(A) (istype(A, /atom/movable))
 


### PR DESCRIPTION
Noticed this while doing #24679. This one isn't new and has nothing to do with 513. I kept it as a define instead of regexing it because `isatom()` is a much better name than `isloc()`

From the Ref:
>This is equivalent to: (ismob(Loc) || isobj(Loc) || \ isturf(Loc) || isarea(Loc))

It may look like this wouldn't cover direct children of `/atom` or `/atom/movable`, but it does. All of these are based on an internal BYOND system called typeid, and not based on inheritance like `istype()` is. As far as I'm aware, the four typeids this checks for are all of the atomic ones. (Bare `/atom/movable`s use the typeid of objs and bare `/atom`s use the typeid of turfs.)
The fact that it checks typeid instead of inheritance makes it faster, though this macro is only used in a handful of places in the code and its performance is probably pretty much irrelevant

I was going to test this, but while looking around for cases this might not work in, I discovered that this is what several other codebases already use, so I'm pretty sure it's fine
I did test a few cases and was unable to find anything that they returned different values for