### PR TITLE
Fixes Xeno Captives Being Able to Punch Their Captors

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
@@ -17,12 +17,14 @@
 	..()
 
 /obj/structure/bed/nest/manual_unbuckle(mob/user as mob)
-	if( user.restrained() || istype(user, /mob/living/silicon/pai) ) //added istype(user, /mob/living/silicon/pai) cause it was in buckle_mob, dunno why tho
+	if(istype(user, /mob/living/silicon/pai)) //added istype(user, /mob/living/silicon/pai) cause it was in buckle_mob, dunno why tho
 		return
 
 	if(is_locking(/datum/locking_category/buckle/bed/nest))
 		var/mob/M = get_locked(/datum/locking_category/buckle/bed/nest)[1]
 		if(M != user)
+			if(user.restrained())
+				return
 			M.visible_message(\
 				"<span class='notice'>[user.name] pulls [M.name] free from the sticky nest!</span>",\
 				"<span class='notice'>[user.name] pulls you free from the gelatinous resin.</span>",\

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -622,7 +622,7 @@
 					E.on_touch(src, toucher, touched, touch_type)
 
 /mob/living/carbon/proc/check_handcuffs()
-	return handcuffed
+	return handcuffed || istype(locked_to, /obj/structure/bed/nest)
 
 /mob/living/carbon/proc/get_lowest_body_alpha()
 	if(!body_alphas.len)


### PR DESCRIPTION
Fixes #8399.
Resin nests now count as restraints, so no beating up on the xenos as they walk by while you wait to break free.
This does have the side effect of no longer allowing you to resist out by clicking the nest, for reasons I don't know. However, you can still break free using the resist verb, which is consistent with being locked into other things, so I don't think it's a big deal.
:cl:
 * bugfix: You can no longer punch nearby xenos while stuck inside a resin nest.