### PR TITLE
Fixes Simple Animals Becoming Traitors

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -189,8 +189,8 @@
 		if(isAI(player) || isMoMMI(player))
 			living_players -= player //Your assigned role doesn't change when you are turned into a MoMMI or AI
 			continue
-		if(isanimal(player))
-			living_players -= player //No animal traitors.
+		if(isanimal(player) && !isborer(player))
+			living_players -= player //No animal traitors except borers.
 			continue
 		if(player.z == map.zCentcomm)
 			living_players -= player//we don't autotator people on Z=2

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -189,6 +189,9 @@
 		if(isAI(player) || isMoMMI(player))
 			living_players -= player //Your assigned role doesn't change when you are turned into a MoMMI or AI
 			continue
+		if(isanimal(player))
+			living_players -= player //No animal traitors.
+			continue
 		if(player.z == map.zCentcomm)
 			living_players -= player//we don't autotator people on Z=2
 			continue


### PR DESCRIPTION
Fixes #8446.

This excludes simple animals, except borers, from becoming traitors. While I personally think it's pretty funny, and would be happy to change the PR to exclude mice specifically (since they can't even drag things), the bug does appear to be that animals at all are included.

Also, I don't know enough about role datums to test this, so I'll need someone to let me know what admin buttons to push in order to do so.

:cl:
 * bugfix: Simple animals can no longer be autotraitored, except for borers.