### PR TITLE
Ability to disable VOX entirely for event maps.

### DIFF
--- a/code/defines/vox_sounds.dm
+++ b/code/defines/vox_sounds.dm
@@ -3,6 +3,9 @@
 // Dynamically loading it has bad results with sounds overtaking each other, even with the wait variable.
 // If you need to modify this for whatever reason, please modify the template at https://github.com/N3X15/ss13-vox/blob/master/templates/vglist.jinja
 
+// DEFINES
+// * DISABLE_VOX - When defined, VOX sounds will not be loaded.  Useful for events like Lamprey where memory is scarce.
+
 // A list of sounds
 // Structure: vox_sound["(fem|mas|default)"]["soundid"] = 'sound/vox_sex/soundid.ogg'
 var/list/vox_sounds = list()
@@ -18,6 +21,7 @@ var/list/vox_sound_lengths = list()
 // STATS:
 //  10690 instructions spread over 11 procs.
 //
+#ifndef DISABLE_VOX
 /__vox_sound_meta_init/New()
   src.__init_0()
   src.__init_1()
@@ -10733,3 +10737,4 @@ var/list/vox_sound_lengths = list()
   vox_wordlen["woody"] = 2
 
 /var/__vox_sound_meta_init/__vox_sound_meta_instance = new
+#endif

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -464,9 +464,11 @@ var/list/ai_list = list()
 			else
 				to_chat(src, "<span class='notice'>Unable to locate the holopad.</span>")
 
+	#ifndef DISABLE_VOX
 	if(href_list["say_word"])
 		play_vox_word(href_list["say_word"], vox_voice, null, src)
 		return
+	#endif
 
 	if(href_list["track"])
 		var/mob/target = locate(href_list["track"]) in mob_list
@@ -499,6 +501,7 @@ var/list/ai_list = list()
 			A.open_nearest_door(target)
 		return
 
+	#ifndef DISABLE_VOX
 	// set_voice=(fem|mas) - Sets VOX voicepack.
 	if(href_list["set_voice"])
 		// Never trust the client.
@@ -517,6 +520,7 @@ var/list/ai_list = list()
 		if(announcement_checks())
 			play_announcement(href_list["play_announcement"])
 		return
+	#endif
 
 /mob/living/silicon/ai/bullet_act(var/obj/item/projectile/Proj)
 	..(Proj)

--- a/code/modules/mob/living/silicon/ai/say.dm
+++ b/code/modules/mob/living/silicon/ai/say.dm
@@ -118,7 +118,7 @@ var/VOX_AVAILABLE_VOICES = list(
 	"mas" = "Masculine"
 );
 
-// N3X TODO: Make a JS clientside validation and autosuggest thing.
+#ifndef DISABLE_VOX
 /mob/living/silicon/ai/verb/make_announcement()
 	set name = "Make Announcement"
 	set desc = "Display a list of vocal words to announce to the crew."
@@ -239,6 +239,7 @@ var/VOX_AVAILABLE_VOICES = list(
 
 	for(var/word in words)
 		play_vox_word(word, vox_voice, src.z, null, TRUE)
+#endif // DISABLE_VOX
 
 var/list/vox_digits=list(
 	'sound/AI/one.ogg',

--- a/data/vox_data.json
+++ b/data/vox_data.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "compiled": 1572309080.284967,
+  "compiled": 1572564844.934283,
   "voices": {
     "fem": {
       "id": "us-clb",


### PR DESCRIPTION
This changeset allows map overrides to specify `#define DISABLE_VOX`, which will completely disable VOX verbs and will skip loading sounds from disk (except for announcements). This is useful when we have like 5MB of RAM to spare.

[hotfix][performance]

## Caveats

* Maps will need to be updated to use this.

## Changelog
:cl:
 - bugfix: Maps can request that VOX announcements be disabled for performance reasons.