### PR TITLE
Fixes scrubbers getting stuck on green

### DIFF
--- a/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
@@ -177,7 +177,7 @@
 	//scrubbing mode
 	if(scrubbing)
 		//if internal pressure limit is enabled and met, we don't do anything
-		if((pressure_checks & 2) && (internal_pressure_bound - air_contents.return_pressure()) < 0.05)
+		if((pressure_checks & 2) && (internal_pressure_bound - air_contents.return_pressure()) =< 0.05)
 			if(reducing_pressure)
 				reducing_pressure = 0
 				update_icon()

--- a/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
@@ -177,7 +177,7 @@
 	//scrubbing mode
 	if(scrubbing)
 		//if internal pressure limit is enabled and met, we don't do anything
-		if((pressure_checks & 2) && (internal_pressure_bound - air_contents.return_pressure()) =< 0.05)
+		if((pressure_checks & 2) && (internal_pressure_bound - air_contents.return_pressure()) <= 0.05)
 			if(reducing_pressure)
 				reducing_pressure = 0
 				update_icon()

--- a/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
@@ -252,6 +252,11 @@
 			if(network)
 				network.update = 1
 
+		//turn off pressure reduction flag if we were within the margin on the "I'm sorry you had to see this" check.
+		else if(reducing_pressure)
+			reducing_pressure = 0
+			update_icon()
+
 	else //Just siphoning all air
 		if(reducing_pressure)
 			reducing_pressure = 0


### PR DESCRIPTION
Noticed during some unrelated local testing that scrubbers were occasionally getting stuck on green if the current pressure in the room was within 0.05 kPa of the target pressure.  This would have been caused by #23805. Couldn't notice any bug reports related to this, so either people didn't care or it didn't happen very often.

I gotta say the code here really needs some refactoring, just like all our other atmos machine code. It needed refactoring before this feature, and the feature didn't make it any better. In fact it kinda made it worse. What idiot wrote this? Oh, right...

:cl:
 * bugfix: Scrubbers should no longer get stuck on the green mode.