### PR TITLE
Fix runtime that happened when importing empty song

### DIFF
--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -113,7 +113,7 @@
 								cur_acc[cur_note] = "#" // so shift is never required
 						else
 							cur_oct[cur_note] = text2num(ni)
-					playnote(cur_note, cur_acc[cur_note], cur_oct[cur_note],user)		
+					playnote(cur_note, cur_acc[cur_note], cur_oct[cur_note],user)
 				var/datum/nanoui/ui = nanomanager.get_open_ui(user, src, "instrument")
 				if (ui)
 					ui.send_message("activeChord", list2params(list(lineCount, chordCount)))
@@ -123,7 +123,7 @@
 				else
 					sleep(tempo)
 				chordCount++
-				
+
 			lineCount++
 		repeat--
 	playing = 0
@@ -229,6 +229,10 @@
 		//split into lines
 		spawn()
 			lines = splittext(t, "\n")
+			//if the user didn't paste in a song, we have nothing to do here
+			if(lines.len == 0)
+				alert("You can't import an empty song!")
+				return
 			if(copytext(lines[1],1,6) == "BPM: ")
 				tempo = sanitize_tempo(600 / text2num(copytext(lines[1],6)))
 				lines.Cut(1,2)
@@ -307,7 +311,7 @@
 
 		lines.Swap(index, index+dir)
 	interact(usr)
-	
+
 	return
 /datum/song/proc/sanitize_tempo(new_tempo)
 	new_tempo = abs(new_tempo)

--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -113,7 +113,7 @@
 								cur_acc[cur_note] = "#" // so shift is never required
 						else
 							cur_oct[cur_note] = text2num(ni)
-					playnote(cur_note, cur_acc[cur_note], cur_oct[cur_note],user)
+					playnote(cur_note, cur_acc[cur_note], cur_oct[cur_note],user)		
 				var/datum/nanoui/ui = nanomanager.get_open_ui(user, src, "instrument")
 				if (ui)
 					ui.send_message("activeChord", list2params(list(lineCount, chordCount)))
@@ -123,7 +123,7 @@
 				else
 					sleep(tempo)
 				chordCount++
-
+				
 			lineCount++
 		repeat--
 	playing = 0
@@ -229,10 +229,6 @@
 		//split into lines
 		spawn()
 			lines = splittext(t, "\n")
-			//if the user didn't paste in a song, we have nothing to do here
-			if(lines.len == 0)
-				alert("You can't import an empty song!")
-				return
 			if(copytext(lines[1],1,6) == "BPM: ")
 				tempo = sanitize_tempo(600 / text2num(copytext(lines[1],6)))
 				lines.Cut(1,2)
@@ -311,7 +307,7 @@
 
 		lines.Swap(index, index+dir)
 	interact(usr)
-
+	
 	return
 /datum/song/proc/sanitize_tempo(new_tempo)
 	new_tempo = abs(new_tempo)


### PR DESCRIPTION
When you opened the instrument menu and tried to import an empty song, a runtime error would occur because of a hardcoded index into a list of lines. I added a simple check to make sure that the line list has a non-zero length. 

I hope I didn't fuck everything up with my branch nonsense, I'm a git brainlet and I put my changes on my Bleeding-Edge branch instead of the branch for the pull request. 

[bugfix]

:cl:
* bugfix: Fix runtime error that occurred when importing an empty song into an instrument