### PR TITLE
Fixes Ghosts Getting Duplicate Chat Messages

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -269,10 +269,11 @@ var/list/department_radio_keys = list(
 	var/list/total_listeners = get_hearers_in_view(visual_range, speech.speaker)
 	var/list/actual_listeners = observers.Copy()
 	for(var/atom/A in total_listeners)
-		if(get_dist(src, A) <= message_range)
-			actual_listeners.Add(A)
-		else
-			to_chat(A, "\The [speech.speaker] appears to say something, but you can't make it out from here.")
+		if(!(A in actual_listeners))
+			if(get_dist(src, A) <= message_range)
+				actual_listeners.Add(A)
+			else
+				to_chat(A, "\The [speech.speaker] appears to say something, but you can't make it out from here.")
 
 	var/rendered = render_speech(speech)
 


### PR DESCRIPTION
Fixes #24717.
It turns out that the code I removed in the previous fix, which I had initially added just for debugging, was preventing this bug.