### PR TITLE
Fixes Objects Burning Forever

### DIFF
--- a/code/ZAS/Fire.dm
+++ b/code/ZAS/Fire.dm
@@ -36,12 +36,10 @@ Attach to transfer valve and open. BOOM.
 
 /atom/proc/burnItselfUp()
 	while(on_fire)
-		var/turf/T = get_turf(src)
 		var/in_fire = FALSE
-		for(var/A in T.contents)
-			if(istype(A, /obj/effect/fire))
-				in_fire = TRUE
-				break
+		for(var/obj/effect/fire/F in loc)
+			in_fire = TRUE
+			break
 		if(!in_fire)
 			fire_fuel -= 0.2
 			if(fire_fuel<=0.1)

--- a/code/ZAS/Fire.dm
+++ b/code/ZAS/Fire.dm
@@ -34,11 +34,26 @@ Attach to transfer valve and open. BOOM.
 		//testing("[src] ashifying (BFF)!")
 		ashify()
 
+/atom/proc/burnItselfUp()
+	while(on_fire)
+		var/turf/T = get_turf(src)
+		var/in_fire = FALSE
+		for(var/A in T.contents)
+			if(istype(A, /obj/effect/fire))
+				in_fire = TRUE
+				break
+		if(!in_fire)
+			fire_fuel -= 0.2
+			if(fire_fuel<=0.1)
+				ashify()
+		sleep(2 SECONDS)
+
 /atom/proc/ashify()
 	if(!on_fire)
 		return
 	var/ashtype = ashtype()
 	new ashtype(src.loc)
+	extinguish()
 	qdel(src)
 
 /atom/proc/extinguish()
@@ -52,6 +67,8 @@ Attach to transfer valve and open. BOOM.
 	if(fire_dmi && fire_sprite)
 		fire_overlay = image(fire_dmi,fire_sprite)
 		overlays += fire_overlay
+	spawn()
+		burnItselfUp()
 
 /atom/proc/melt()
 	return //lolidk


### PR DESCRIPTION
Fixes #9218.
Specifically, this makes it so that while items are not in a fire, they still burn up their own `fire_fuel`, so that they turn to ash if not extinguished instead of just being on fire forever.
I didn't really have a metric for how much `fire_fuel` to consume since there's no gas interactions. I figured 0.2/tick would be good enough seeing as pieces of paper have 1 `fire_fuel`.

:cl:
 * bugfix: Flammable items removed from burning rooms will now continue burning to ash instead of being on fire forever. Better grab those extinguishers if you want to save them.