### PR TITLE
Universal Key In Ignition

### DIFF
--- a/code/game/objects/structures/vehicles/snowmobile.dm
+++ b/code/game/objects/structures/vehicles/snowmobile.dm
@@ -35,7 +35,7 @@
 
 /obj/structure/bed/chair/vehicle/snowmobile/universal/set_keys()
 	if(keytype && !vin)
-		new keytype(loc)
+		heldkey = new keytype(src)
 
 /obj/structure/bed/chair/vehicle/snowmobile/getMovementDelay()
 	var/turf/T = loc


### PR DESCRIPTION
closes #24716

🆑 
* tweak: Public snowmobiles now spawn with the key in their ignition instead of on the ground.