### PR TITLE
Closed falsewall subtype opacity fix

### DIFF
--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -111,6 +111,7 @@
 
 /obj/structure/falsewall/closed
 	density = 1
+	opacity = 1
 
 /obj/structure/falsewall/New()
 	..()


### PR DESCRIPTION
[general]

This subtype started with `opacity = 0` so it was see-through even though it's supposed to be closed. This should fix that.