### PR TITLE
Fix unwanted splashing onto reagent dispenser

### DIFF
--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -204,6 +204,9 @@ var/list/LOGGED_SPLASH_REAGENTS = list(FUEL, THERMITE)
  * Helper proc to handle reagent splashes. A negative `amount` will splash all the reagents.
  */
 /proc/splash_sub(var/datum/reagents/reagents, var/atom/target, var/amount, var/mob/user = null)
+	if(user.a_intent != I_HURT)//Should stop splashing when you dont want it to happen.
+		return
+	
 	if (amount == 0 || reagents.is_empty())
 		if(user)
 			to_chat(user, "<span class='warning'>There's nothing to splash with!</span>")
@@ -269,7 +272,7 @@ var/list/LOGGED_SPLASH_REAGENTS = list(FUEL, THERMITE)
 				to_chat(user, "<span class='notice'>You transfer [success] units of the solution to \the [target].</span>")
 
 			return (success)
-	if(!success)
+	if(!success && user.a_intent == I_HURT)
 		// Mob splashing
 		if(splashable_units != 0)
 			var/to_splash = reagents.total_volume

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -203,10 +203,7 @@ var/list/LOGGED_SPLASH_REAGENTS = list(FUEL, THERMITE)
 /**
  * Helper proc to handle reagent splashes. A negative `amount` will splash all the reagents.
  */
-/proc/splash_sub(var/datum/reagents/reagents, var/atom/target, var/amount, var/mob/user = null)
-	if(user.a_intent != I_HURT)//Should stop splashing when you dont want it to happen.
-		return
-	
+/proc/splash_sub(var/datum/reagents/reagents, var/atom/target, var/amount, var/mob/user = null)	
 	if (amount == 0 || reagents.is_empty())
 		if(user)
 			to_chat(user, "<span class='warning'>There's nothing to splash with!</span>")

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -269,7 +269,7 @@ var/list/LOGGED_SPLASH_REAGENTS = list(FUEL, THERMITE)
 				to_chat(user, "<span class='notice'>You transfer [success] units of the solution to \the [target].</span>")
 
 			return (success)
-	if(!success && user.a_intent == I_HURT)
+	if(!success)
 		// Mob splashing
 		if(splashable_units != 0)
 			var/to_splash = reagents.total_volume
@@ -288,7 +288,7 @@ var/list/LOGGED_SPLASH_REAGENTS = list(FUEL, THERMITE)
 				return (to_splash)
 			// Non-mob splashing
 			else
-				if(!src.is_empty())
+				if(!src.is_empty() && user.a_intent == I_HURT)
 					for (var/reagent_id in LOGGED_SPLASH_REAGENTS)
 						if (reagents.has_reagent(reagent_id))
 							add_gamelogs(user, "poured '[reagent_id]' onto \the [target]", admin = TRUE, tp_link = TRUE, tp_link_short = FALSE, span_class = "danger")


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation or the coding discord (you can find an invite link on the irc or the thread) to discuss your changes, or if you need help.

== SELF LABELLING PRs ==
You can now self-label your PR! The syntax is simple. Just put [<labeltag>] anywhere in your PR,
where <labeltag> is to be replaced by one of the following (allowing with the resultant tag)
just ctrl+f the list or something. I know it's long.

administration = "Logging / Administration"
away = "Mapping (Away Mission :earth_africa:)"
bagel = "Mapping (Bagel :o:)"
box = "Mapping (Box :baby:)"
bugfix = "Bug / Fix"
bus = "Mapping (Bus :bus:)"
byond = "T-Thanks BYOND"
consistency = "Consistency Issue"
controversial = "Controversial"
deff = "Mapping (Deff :wastebasket:)"
discussion = "Discussion"
dnm = "✋ Do Not Merge ✋"
easy = "Easy Fix"
exploitable = "Exploitable"
featureloss = "Feature Loss"
featurerequest = "Feature Request"
first = "good first issue"
formatting = "Grammar / Formatting"
gamemode = "Gameplay / Gamemode"
gameplay = "Gameplay / Gamemode"
general = "Mapping (General :world_map:)"
goonchat = "Goonchat"
grammar = "Grammar / Formatting"
help = "help wanted"
hotfix = "Hotfix"
libvg = "libvg"
logging = "Logging / Administration"
meta = "Mapping (Meta :no_mobile_phones:)"
needspritework = "Needs Spritework"
oversight = "Oversight"
packed = "Mapping (Packed :package:)"
parallax = "Parallax"
qol = "❤️ Quality of Life ❤️"
roid = "Mapping (Roidstation :pick:)"
role = "Role Datums"
roleissue = "Role Datums Issue"
runtime = "Runtime Log"
sanity = "Sanity / Ghosthands"
snowmap = "Mapping (Snowmap ❄)"
sound = "Sound"
sprites = "Sprites"
spriteworkdone = "Spritework Done Needs Coder"
system = "System"
taxi = "Mapping (Taxi :taxi:)"
tested = "100%  tested"
tweak = "Tweak"
ui = "UI"
vault = "Mapping (Vault :question:)"
vote = "⛔ Requires Server Vote ⛔"
wip = "WiP"

== CHANGELOGS ==
Changelogs can be attached either by following the instructions in html/changelogs/example.yml, or by attaching an in-body changelog like the one attached to your PR automatically.

For the keys you can use in an in-body changelog, they are the same as described in example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!

Valid Prefixes:
bugfix
wip (For works in progress)
tweak
soundadd
sounddel
rscdel (general deleting of nice things)
rscadd (general adding of nice things)
imageadd
imagedel
spellcheck (typo fixes)
experiment
tgs (TG-ported fixes?)

An example changelog is attached to this PR for your convenience:
-->
Yeah, this is kind of roundabout actually. Stepping through the logic and fixing it there would be more ideal. This just adds intent checks before splashing in both ``transfer`` and ``splash_sub`` procs.
Fixes: #21747
:cl:
 * tweak: Reagent containers now require HURT intent to splash onto objects. NOT PEOPLE.