### PR TITLE
Changes the IV drip message

### DIFF
--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -103,7 +103,7 @@
 /obj/machinery/iv_drip/process()
 	if(src.attached)
 		if(!(get_dist(src, src.attached) <= 1 && isturf(src.attached.loc)))
-			visible_message("The needle is ripped out of [src.attached], doesn't that hurt?")
+			visible_message("The needle is ripped out of [src.attached] as they move out of range of the IV drip.")
 			src.attached:apply_damage(3, BRUTE, pick(LIMB_RIGHT_ARM, LIMB_LEFT_ARM))
 			src.detach()
 			return


### PR DESCRIPTION
This message has always bothered me, because (1) it doesn't explicitly mention what the actual cause of the message is, and (2) it has a comma splice in it.

:cl:
 * bugfix: Changed the IV drip distance disconnect message to be more descriptive