### PR TITLE
Simple Sun Object

### DIFF
--- a/code/controllers/subsystem/sun.dm
+++ b/code/controllers/subsystem/sun.dm
@@ -1,4 +1,5 @@
 var/datum/subsystem/sun/SSsun
+var/obj/sun_object/sun_obj
 
 
 /datum/subsystem/sun
@@ -16,6 +17,7 @@ var/datum/subsystem/sun/SSsun
 
 /datum/subsystem/sun/Initialize(timeofday)
 	sun = new
+	sun_obj = new
 
 	..()
 

--- a/code/datums/sun.dm
+++ b/code/datums/sun.dm
@@ -1,4 +1,9 @@
 var/global/datum/sun/sun
+#define SUNLIGHT_STRONG 3
+#define SUNLIGHT_MEDIUM 2
+#define SUNLIGHT_WEAK 1
+#define SUNLIGHT_NONE 0
+#define SUNLIGHT_RANGE 2500
 
 /datum/sun
 	var/angle
@@ -23,6 +28,14 @@ var/global/datum/sun/sun
 	rotationRate = rand(850, 1150) / 1000 //Slight deviation, no more than 15 %, budget orbital stabilization system
 	if(prob(50))
 		rotationRate = -rotationRate
+
+/obj/sun_object
+	name = "sun"
+	desc = "source of light"
+	never_transition_z = TRUE
+
+/obj/sun_object/New()
+	set_light(SUNLIGHT_RANGE, SUNLIGHT_STRONG, "#FFFFFF")
 
 /*
  * Calculate the sun's position given the time of day.
@@ -62,12 +75,29 @@ var/global/datum/sun/sun
 
 	var/obj/machinery/power/solar/panel/S
 
+	if(sun_obj)
+		sun_obj.forceMove(get_position())
+
 	for(S in solars_list)
 		if(!S.powernet)
 			solars_list.Remove(S)
 
 		if(S.control)
 			occlusion(S)
+
+/datum/sun/proc/get_position()
+	var/ax = map.center_x
+	var/ay = map.center_y
+	for(var/i = 1 to 256)
+		ax += dx //Do step
+		ay += dy
+
+		if(ax == world.maxx || ay == world.maxy)
+			break
+
+	var/turf/T = locate(round(ax, 0.5), round(ay, 0.5), STATION_Z)
+
+	return T
 
 //For a solar panel, trace towards sun to see if we're in shadow.
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -57,6 +57,8 @@
 
 	var/last_explosion_push = 0
 
+	var/never_transition_z = FALSE //totally ignore z transitions, don't loop at all at edge
+
 /atom/movable/New()
 	. = ..()
 	if((flags & HEAR) && !ismob(src))

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -159,6 +159,7 @@
 	if(movement_disabled)
 		to_chat(usr, "<span class='warning'>Movement is admin-disabled.</span>")//This is to identify lag problems
 		return
+
 	//THIS IS OLD TURF ENTERED CODE
 	var/loopsanity = 100
 
@@ -166,8 +167,9 @@
 		inertial_drift(A)
 	else
 		A.inertia_dir = 0
-
 	..()
+	if(A.never_transition_z)
+		return
 	var/objects = 0
 	if(A && A.flags & PROXMOVE)
 		for(var/atom/Obj in range(1, src))

--- a/code/modules/events/blizzard.dm
+++ b/code/modules/events/blizzard.dm
@@ -66,6 +66,7 @@ var/blizzard_cooldown = 3000 //5 minutes minimum
 		tile.snow_state = snow_intensity
 		tile.update_environment()
 	force_update_snowfall_sfx()
+	adjust_sun()
 
 /proc/lessen_snowfall()
 	if(snow_intensity == SNOW_CALM)
@@ -77,6 +78,7 @@ var/blizzard_cooldown = 3000 //5 minutes minimum
 		tile.snow_state = snow_intensity
 		tile.update_environment()
 	force_update_snowfall_sfx()
+	adjust_sun()
 
 /proc/snowfall_tick()
 	switch(snow_intensity)
@@ -88,6 +90,18 @@ var/blizzard_cooldown = 3000 //5 minutes minimum
 			snowfall_hard_tick()
 		if(SNOW_BLIZZARD)
 			snowfall_blizzard_tick()
+
+/proc/adjust_sun()
+	if(sun_obj)
+		switch(snow_intensity)
+			if(SNOW_CALM)
+				sun_obj.set_light(l_power = SUNLIGHT_STRONG)
+			if(SNOW_AVERAGE)
+				sun_obj.set_light(l_power = SUNLIGHT_MEDIUM)
+			if(SNOW_HARD)
+				sun_obj.set_light(l_power = SUNLIGHT_WEAK)
+			if(SNOW_BLIZZARD)
+				sun_obj.set_light(l_power = SUNLIGHT_NONE)
 
 /proc/snowfall_calm_tick()
 	var/tile_interval = 5


### PR DESCRIPTION
This doesn't really work, but maybe it could if someone wants to root around a bit in our lighting code.

Basically, every time the sun controller updates (for solars), this relocates a giant light source. The light source can be dimmed by blizzards. In a perfect world this would work great on all maps - lighting up one side of maint at a time, casting dramatic shadows on snaxi, etc... but it seems that the maximum light range is something like 40 tiles away.

I think instead of developing this idea further, I'm going to try a different approach for snaxi where all exterior snow puts off a certain amount of illumination based on day-night cycle or something. But if someone wants to rescue this design for use on space stations, it's yours.