### PR TITLE
Atmospheric pipes, cable wires and disposal pipes are again visible in the map editor

### DIFF
--- a/code/ATMOSPHERICS/pipes.dm
+++ b/code/ATMOSPHERICS/pipes.dm
@@ -3,7 +3,7 @@
 	var/datum/pipeline/parent
 	var/volume = 0
 	force = 20
-	plane = ABOVE_PLATING_PLANE
+	plane = ABOVE_TURF_PLANE //Set above turf for mapping preview only, supposed to be ABOVE_PLATING_PLANE, handled in update_planes_and_layers() (called on New())
 	layer = PIPE_LAYER
 	use_power = 0
 	var/alert_pressure = 80*ONE_ATMOSPHERE
@@ -13,7 +13,7 @@
 	return FLOAT_PLANE
 
 /obj/machinery/atmospherics/pipe/update_planes_and_layers()
-	if (level == LEVEL_BELOW_FLOOR)
+	if(level == LEVEL_BELOW_FLOOR)
 		plane = ABOVE_PLATING_PLANE
 		layer = PIPE_LAYER
 	else

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -36,7 +36,7 @@ By design, d1 is the smallest direction and d2 is the highest
 	icon_state = "0-1"
 	var/d1 = 0								// cable direction 1 (see above)
 	var/d2 = 1								// cable direction 2 (see above)
-	plane = ABOVE_PLATING_PLANE
+	plane = ABOVE_TURF_PLANE //Set above turf for mapping preview only, supposed to be ABOVE_PLATING_PLANE, handled in New()
 	layer = WIRE_LAYER
 	var/obj/item/device/powersink/attached	// holding this here for qdel
 	var/_color = "red"
@@ -82,6 +82,8 @@ By design, d1 is the smallest direction and d2 is the highest
 // the power cable object
 /obj/structure/cable/New(loc)
 	..(loc)
+
+	plane = ABOVE_PLATING_PLANE //Set cables to the proper plane. They should NOT be on another plane outside of mapping preview
 
 	cableColor(_color)
 

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -730,7 +730,7 @@
 	dir = 0				// dir will contain dominant direction for junction pipes
 	var/health = 10 	// health points 0-10
 	layer = DISPOSALS_PIPE_LAYER
-	plane = ABOVE_PLATING_PLANE
+	plane = ABOVE_TURF_PLANE //Set above turf for mapping preview only, supposed to be ABOVE_PLATING_PLANE, handled in New()
 	var/base_icon_state	// initial icon state on map
 	var/deconstructable = TRUE
 
@@ -744,6 +744,7 @@
 // new pipe, set the icon_state as on map
 /obj/structure/disposalpipe/New()
 	..()
+	plane = ABOVE_PLATING_PLANE //Set cables to the proper plane. They should NOT be on another plane outside of mapping preview
 	base_icon_state = icon_state
 
 


### PR DESCRIPTION
I might be a very old fashioned mapper, but back in my day we used to be able to just -see- cables, pipes and disposals on the map without having to edit values. Sadly, for all the good the planepocalypse gave us in term of layering logic, it terminally fucked our mapping editor for years... because apparently no-one remembered how we used to fix that stuff back in the old days of the coding Far West ?

* Atmospheric pipes default plane set so they show above full floor tiles by default. This value is properly reset in the atmospherics master's New() instruction, that calls for a full layer update (the proc where I bopped a single space)
* Disposals pipe default plane set above floor tiles, and then reset to its normal position in New(). This works as long as no disposal types exist that are forced to show above the floor, which would be an easy fix anyways (just create a var called base_plane, but redundant since it can -only- be that)
* Power cable default plane set above floor tiles, and then reset to its normal position in New(). This works as long as no power cable types exist that are forced to show above the floor, which would be an easy fix anyways (just create a var called base_plane, but redundant since it can -only- be that)

Sadly some more stuff hasn't been fixed yet, notably the fact you can't tell for shit where atmospheric items like vents, scrubbers and pumps are facing in the map editor, but that's more to do about how horrendously complicated the new icon system is

I'll probably keep sweeping for more fucked up map editor/preview stuff I can fix, but I'll commit that first because it fixes basically 90 % of nervous breakdowns when mapping. Fuck having to guess work where pipes are going, or constantly messing with three different files before starting to map

:cl:
 * tweak: Map Editor should now display pipes, cables and disposals as expected (above floor tiles). This should have NO effect on gameplay, report any unexpected behavior with pipes showing/not showing properly