### PR TITLE
Removes the rest of the calls to lentext()

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -129,10 +129,10 @@
 		update_faction_icons()
 
 /datum/mind/proc/store_memory(new_text)
-	if(lentext(memory) > MAX_PAPER_MESSAGE_LEN)
+	if(length(memory) > MAX_PAPER_MESSAGE_LEN)
 		to_chat(current, "<span class = 'warning'>Your memory, however hazy, is full.</span>")
 		return
-	if(lentext(new_text) > MAX_MESSAGE_LEN)
+	if(length(new_text) > MAX_MESSAGE_LEN)
 		to_chat(current, "<span class = 'warning'>That's a lot to memorize at once.</span>")
 		return
 	if(new_text)

--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -98,13 +98,13 @@
 					if(!playing || shouldStopPlaying(user))//If the instrument is playing, or special case
 						playing = 0
 						return
-					if(lentext(note) == 0)
+					if(length(note) == 0)
 						continue
 					//world << "Parse: [copytext(note,1,2)]"
 					var/cur_note = text2ascii(note) - 96
 					if(cur_note < 1 || cur_note > 7)
 						continue
-					for(var/i=2 to lentext(note))
+					for(var/i=2 to length(note))
 						var/ni = copytext(note,i,i+1)
 						if(!text2num(ni))
 							if(ni == "#" || ni == "b" || ni == "n")
@@ -221,11 +221,11 @@
 			t = html_encode(input(usr, "Please paste the entire song, formatted:", text("[]", name), t)  as message)
 			if(!in_range(instrumentObj, usr))
 				return
-			if(lentext(t) >= INSTRUMENT_MAX_LINE_LENGTH*INSTRUMENT_MAX_LINE_NUMBER)
+			if(length(t) >= INSTRUMENT_MAX_LINE_LENGTH*INSTRUMENT_MAX_LINE_NUMBER)
 				var/cont = input(usr, "Your message is too long! Would you like to continue editing it?", "", "yes") in list("yes", "no")
 				if(cont == "no")
 					break
-		while(lentext(t) > INSTRUMENT_MAX_LINE_LENGTH*INSTRUMENT_MAX_LINE_NUMBER)
+		while(length(t) > INSTRUMENT_MAX_LINE_LENGTH*INSTRUMENT_MAX_LINE_NUMBER)
 		//split into lines
 		spawn()
 			lines = splittext(t, "\n")
@@ -243,7 +243,7 @@
 				lines.Cut(INSTRUMENT_MAX_LINE_NUMBER+1)
 			var/linenum = 1
 			for(var/l in lines)
-				if(lentext(l) > INSTRUMENT_MAX_LINE_LENGTH)
+				if(length(l) > INSTRUMENT_MAX_LINE_LENGTH)
 					alert(usr, "Line [linenum] too long! Removing...")
 					lines.Remove(l)
 				else
@@ -270,7 +270,7 @@
 			return
 		if(lines.len > INSTRUMENT_MAX_LINE_NUMBER)
 			return
-		if(lentext(newline) > INSTRUMENT_MAX_LINE_LENGTH)
+		if(length(newline) > INSTRUMENT_MAX_LINE_LENGTH)
 			newline = copytext(newline, 1, INSTRUMENT_MAX_LINE_LENGTH)
 		lines.Add(newline)
 	else if(href_list["deleteline"])
@@ -285,7 +285,7 @@
 		var/content = html_encode(input("Enter your line: ", instrumentObj.name, lines[num]) as text|null)
 		if(!content || !in_range(instrumentObj, usr))
 			return
-		if(lentext(content) > INSTRUMENT_MAX_LINE_LENGTH)
+		if(length(content) > INSTRUMENT_MAX_LINE_LENGTH)
 			content = copytext(content, 1, INSTRUMENT_MAX_LINE_LENGTH)
 		if(num > lines.len || num < 1)
 			return

--- a/code/libs/s_html/hexadecimal.dm
+++ b/code/libs/s_html/hexadecimal.dm
@@ -22,7 +22,7 @@ proc/hex2num(hex)
 	var/num = 0
 	var/power = 0
 
-	for(var/i = lentext(hex), i > 0, i--)
+	for(var/i = length(hex), i > 0, i--)
 		var/char = copytext(hex, i, i+1) //extract hexadecimal character from string
 		switch(char)
 			if("0")

--- a/code/libs/s_html/inverthtml.dm
+++ b/code/libs/s_html/inverthtml.dm
@@ -23,11 +23,11 @@ proc/invertHTML(HTMLstring)
 	textr = num2hex(255-r)
 	textg = num2hex(255-g)
 	textb = num2hex(255-b)
-	if(lentext(textr) < 2)
+	if(length(textr) < 2)
 		textr = "0[textr]"
-	if(lentext(textg) < 2)
+	if(length(textg) < 2)
 		textr = "0[textg]"
-	if(lentext(textb) < 2)
+	if(length(textb) < 2)
 		textr = "0[textb]"
 
 	return("#[textr][textg][textb]")

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -359,8 +359,8 @@ proc/blood_incompatible(donor,receiver)
 	if(!donor || !receiver)
 		return 0
 
-	var/donor_antigen = copytext(donor,1,lentext(donor))
-	var/receiver_antigen = copytext(receiver,1,lentext(receiver))
+	var/donor_antigen = copytext(donor, 1, -1)
+	var/receiver_antigen = copytext(receiver, 1, -1)
 	var/donor_rh = (findtext(donor,"+")>0)
 	var/receiver_rh = (findtext(receiver,"+")>0)
 

--- a/tools/Redirector/textprocs.dm
+++ b/tools/Redirector/textprocs.dm
@@ -40,12 +40,12 @@ proc/dd_replaceText(text, search_string, replacement_string)
 /////////////////////
 proc/dd_hasprefix(text, prefix)
 	var/start = 1
-	var/end = lentext(prefix) + 1
+	var/end = length(prefix) + 1
 	return findtext(text, prefix, start, end)
 
 proc/dd_hasPrefix(text, prefix)
 	var/start = 1
-	var/end = lentext(prefix) + 1
+	var/end = length(prefix) + 1
 	return findtextEx(text, prefix, start, end)
 
 
@@ -66,8 +66,8 @@ proc/dd_hasSuffix(text, suffix)
 // Turning text into lists //
 /////////////////////////////
 proc/dd_splittext(text, separator)
-	var/textlength      = lentext(text)
-	var/separatorlength = lentext(separator)
+	var/textlength      = length(text)
+	var/separatorlength = length(separator)
 	var/list/textList   = new /list()
 	var/searchPosition  = 1
 	var/findPosition    = 1
@@ -86,8 +86,8 @@ proc/dd_splittext(text, separator)
 				return textList
 
 proc/dd_text2List(text, separator)
-	var/textlength      = lentext(text)
-	var/separatorlength = lentext(separator)
+	var/textlength      = length(text)
+	var/separatorlength = length(separator)
 	var/list/textList   = new /list()
 	var/searchPosition  = 1
 	var/findPosition    = 1


### PR DESCRIPTION
It's deprecated and the compiler sporadically throws warnings about it sometimes, at least in newer builds.
Two of them were unnecessary because `copytext()` supports negative indices. The rest were replaced with `length()` as the compiler warnings and the Ref say to do.

0% tested because I don't have time at the moment but What's the Worst That Could Happen?