### PR TITLE
Fixes pAIs borking when you change screens 2.0

### DIFF
--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -162,6 +162,7 @@
 	overlays += new_overlay
 	var/mutable_appearance/pai_icon = new(src) //we also update the mob's appearance so it appears properly on the scoreboard.
 	pai_icon.name = pai.name //But don't override their name
+	pai_icon.verbs = pai.verbs //THANKS, LUMMOX
 	pai.appearance = pai_icon 
 
 /obj/item/device/paicard/proc/alertUpdate()


### PR DESCRIPTION
Turns out mutable_appearance contains verbs.
Thanks @Exxion for helping with the debug.

Closes #24880 
Closes #24844
Closes #24848

:cl:
 * bugfix: Fixes pAIs BSODing after they change their wallpapers