### PR TITLE
Magivend outfit smartboxes

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -2134,41 +2134,28 @@ var/global/num_vending_terminals = 1
 		"Space-time bending hardware!"
 	)
 	products = list(
-		/obj/item/clothing/head/wizard = 5,
-		/obj/item/clothing/suit/wizrobe = 5,
-		/obj/item/clothing/head/wizard/red = 5,
-		/obj/item/clothing/suit/wizrobe/red = 5,
-		/obj/item/clothing/head/wizard/clown = 5,
-		/obj/item/clothing/suit/wizrobe/clown = 5,
-		/obj/item/clothing/mask/gas/clown_hat/wiz = 5,
-		/obj/item/clothing/head/wizard/marisa = 5,
-		/obj/item/clothing/suit/wizrobe/marisa = 5,
-		/obj/item/clothing/suit/wizrobe/magician = 5,
-		/obj/item/clothing/head/that/magic = 5,
-		/obj/item/clothing/head/wizard/necro = 5,
-		/obj/item/clothing/suit/wizrobe/necro = 5,
+		/obj/item/weapon/storage/box/smartbox/clothing_box/wizard_robes = 5,
+		/obj/item/weapon/storage/box/smartbox/clothing_box/red_wizrobes = 5,
+		/obj/item/weapon/storage/box/smartbox/clothing_box/clown_wizrobes = 5,
+		/obj/item/weapon/storage/box/smartbox/clothing_box/marisa_wiz = 5,
+		/obj/item/weapon/storage/box/smartbox/clothing_box/hallowiz = 5,
+		/obj/item/weapon/storage/box/smartbox/clothing_box/magician = 5,
+		/obj/item/weapon/storage/box/smartbox/clothing_box/necromancer = 5,
+		/obj/item/weapon/storage/box/smartbox/clothing_box/pharaoh = 5,
+		/obj/item/clothing/suit/storage/wintercoat/druid = 5,
 		/obj/item/clothing/head/wizard/magus = 5,
 		/obj/item/clothing/suit/wizrobe/magusred = 5,
 		/obj/item/clothing/suit/wizrobe/magusblue = 5,
 		/obj/item/clothing/head/wizard/amp = 5,
 		/obj/item/clothing/suit/wizrobe/psypurple = 5,
-		/obj/item/clothing/head/pharaoh = 5,
-		/obj/item/clothing/suit/wizrobe/pharaoh = 5,
+		/obj/item/clothing/shoes/sandal = 5,
 		/obj/item/clothing/shoes/sandal/marisa/leather = 5,
-		/obj/item/clothing/shoes/sandal = 10,
 		/obj/item/clothing/shoes/sandal/marisa = 5,
 		/obj/item/weapon/staff = 5,
 		/obj/item/weapon/staff/broom = 5,
 		/obj/item/clothing/glasses/monocle = 5,
 		/obj/item/weapon/storage/bag/wiz_cards/full = 1,
-		/obj/item/weapon/storage/bag/potion = 5,
-		/obj/item/clothing/suit/wizrobe/hallowiz = 5,
-		/obj/item/clothing/head/wizard/hallowiz = 5,
-		/obj/item/clothing/head/wizard/mystic = 5,
-		/obj/item/clothing/suit/wizrobe/mystic = 5,
-		/obj/item/clothing/head/wizard/winter = 5,
-		/obj/item/clothing/suit/wizrobe/winter = 5,
-		/obj/item/clothing/suit/storage/wintercoat/druid = 5
+		/obj/item/weapon/storage/bag/potion = 5
 		)
 	contraband = list(
 		/obj/item/weapon/reagent_containers/glass/bottle/wizarditis = 1,
@@ -2443,7 +2430,8 @@ var/global/num_vending_terminals = 1
 
 	pack = /obj/structure/vendomatpack/undefined
 
-#define AUTO_DROBE_DEFAULT_STOCK 3
+#define AUTO_DROBE_DEFAULT_STOCK 5
+
 /obj/machinery/vending/autodrobe
 	name = "\improper AutoDrobe"
 	desc = "A vending machine containing costumes."
@@ -2483,7 +2471,7 @@ var/global/num_vending_terminals = 1
 		/obj/item/weapon/storage/box/smartbox/clothing_box/pirateoutfit = AUTO_DROBE_DEFAULT_STOCK,
 		/obj/item/weapon/storage/box/smartbox/clothing_box/lordadmiral = AUTO_DROBE_DEFAULT_STOCK,
 		/obj/item/weapon/storage/box/smartbox/clothing_box/plaguedoctor = AUTO_DROBE_DEFAULT_STOCK,
-		/obj/item/weapon/storage/box/smartbox/clothing_box/rotten = 5,
+		/obj/item/weapon/storage/box/smartbox/clothing_box/rotten = AUTO_DROBE_DEFAULT_STOCK,
 		/obj/item/weapon/storage/box/smartbox/clothing_box/frank = AUTO_DROBE_DEFAULT_STOCK,
 		/obj/item/weapon/storage/box/smartbox/clothing_box/mexican = AUTO_DROBE_DEFAULT_STOCK,
 		/obj/item/clothing/head/beret = 3,
@@ -2515,7 +2503,7 @@ var/global/num_vending_terminals = 1
 		/obj/item/clothing/head/cowboy = 3,
 		/obj/item/clothing/suit/kimono/sakura = 3,
 		/obj/item/clothing/head/widehat_red = 3,
-		/obj/item/clothing/suit/red_suit = 3,
+		/obj/item/clothing/suit/red_suit = 3
 		) //Pretty much everything that had a chance to spawn.
 	contraband = list(
 		/obj/item/clothing/suit/cardborg = 3,

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -1275,3 +1275,93 @@
 	new /obj/item/clothing/under/lola(src)
 	new /obj/item/clothing/shoes/clown_shoes/lola(src)
 	..()
+
+/obj/item/weapon/storage/box/smartbox/clothing_box/wizard_robes
+	name = "Wizard robe box"
+
+/obj/item/weapon/storage/box/smartbox/clothing_box/wizard_robes/New()
+	new /obj/item/clothing/head/wizard(src)
+	new /obj/item/clothing/suit/wizrobe(src)
+	new /obj/item/clothing/shoes/sandal(src)
+	..()
+
+/obj/item/weapon/storage/box/smartbox/clothing_box/red_wizrobes
+	name = "Red wizard robe box"
+
+/obj/item/weapon/storage/box/smartbox/clothing_box/red_wizrobes/New()
+	new /obj/item/clothing/head/wizard/red(src)
+	new /obj/item/clothing/suit/wizrobe/red(src)
+	new /obj/item/clothing/shoes/sandal(src)
+	..()
+
+/obj/item/weapon/storage/box/smartbox/clothing_box/clown_wizrobes
+	name = "Clown wizard outfit box"
+
+/obj/item/weapon/storage/box/smartbox/clothing_box/clown_wizrobes/New()
+	new /obj/item/clothing/head/wizard/clown(src)
+	new /obj/item/clothing/suit/wizrobe/clown(src)
+	new /obj/item/clothing/mask/gas/clown_hat/wiz(src)
+	new /obj/item/clothing/shoes/sandal/slippers(src)
+	..()
+	
+/obj/item/weapon/storage/box/smartbox/clothing_box/marisa_wiz
+	name = "Ordinary witch robe box"
+
+/obj/item/weapon/storage/box/smartbox/clothing_box/marisa_wiz/New()
+	new /obj/item/clothing/head/wizard/marisa(src)
+	new /obj/item/clothing/suit/wizrobe/marisa(src)
+	new /obj/item/clothing/shoes/sandal/marisa/leather(src)
+	new /obj/item/weapon/staff/broom(src)
+	..()
+
+/obj/item/weapon/storage/box/smartbox/clothing_box/hallowiz
+	name = "Halloween robe box"
+
+/obj/item/weapon/storage/box/smartbox/clothing_box/hallowiz/New()
+	new /obj/item/clothing/head/wizard/hallowiz(src)
+	new /obj/item/clothing/suit/wizrobe/hallowiz(src)
+	new /obj/item/clothing/shoes/sandal(src)
+	..()
+
+/obj/item/weapon/storage/box/smartbox/clothing_box/mystic_robes
+	name = "Mystic robe box"
+
+/obj/item/weapon/storage/box/smartbox/clothing_box/mystic_robes/New()
+	new /obj/item/clothing/head/wizard/mystic(src)
+	new /obj/item/clothing/suit/wizrobe/mystic(src)
+	new /obj/item/clothing/shoes/sandal(src)
+	..()
+
+/obj/item/weapon/storage/box/smartbox/clothing_box/winter_wiz
+	name = "\"Winter robes\" box"
+
+/obj/item/weapon/storage/box/smartbox/clothing_box/winter_wiz/New()
+	new /obj/item/clothing/head/wizard/winter(src)
+	new /obj/item/clothing/suit/wizrobe/winter(src)
+	new /obj/item/clothing/shoes/sandal(src)
+	..()
+
+/obj/item/weapon/storage/box/smartbox/clothing_box/magician
+	name = "Magician outfit box"
+
+/obj/item/weapon/storage/box/smartbox/clothing_box/magician/New()
+	new /obj/item/clothing/head/that/magic(src)
+	new /obj/item/clothing/suit/wizrobe/magician(src)
+	new /obj/item/clothing/shoes/sandal/marisa/leather(src)
+	..()
+
+/obj/item/weapon/storage/box/smartbox/clothing_box/necromancer
+	name = "Necromancer robe box"
+
+/obj/item/weapon/storage/box/smartbox/clothing_box/necromancer/New()
+	new /obj/item/clothing/head/wizard/necro(src)
+	new /obj/item/clothing/suit/wizrobe/necro(src)
+	..()
+
+/obj/item/weapon/storage/box/smartbox/clothing_box/pharaoh
+	name = "Pharaoh robe box"
+
+/obj/item/weapon/storage/box/smartbox/clothing_box/pharaoh/New()
+	new /obj/item/clothing/head/pharaoh(src)
+	new /obj/item/clothing/suit/wizrobe/pharaoh(src)
+	..()

--- a/code/modules/clothing/suits/wintercoat.dm
+++ b/code/modules/clothing/suits/wintercoat.dm
@@ -20,6 +20,8 @@
 /obj/item/clothing/suit/storage/wintercoat/New()
 	if(!nohood)
 		hood = new(src)
+	if(wizard_garb)
+		hood.wizard_garb = 1
 	else
 		actions_types = null
 


### PR DESCRIPTION
No meme game references, just adding smartboxes for existing wizard clothing. Also fixes a bug with the wizard winter coat hood to make sure it counts as wizard garb and increases autodrobe default stock to 5 so that any size nukeop team can do a group costume gimmick.

:cl:
 * rscadd: Wizard outfits now come in smartboxes like with the autodrobe.