### PR TITLE
Far sliding

### DIFF
--- a/__DEFINES/math_physics.dm
+++ b/__DEFINES/math_physics.dm
@@ -52,3 +52,7 @@
 // The highest number supported is a signed 32-bit floating point number.
 // Integers beyond the 24 bit range are represented as single-precision floating points, and thus will lose accuracy beyond the range of +/- 16777216
 #define SHORT_REAL_LIMIT 16777216
+
+#define manhattan_distance(a, b) (abs(a.x - b.x) + abs(a.y - b.y))
+
+#define IS_INT(x) (x == round(x))

--- a/code/__HELPERS/maths.dm
+++ b/code/__HELPERS/maths.dm
@@ -326,3 +326,61 @@ proc/arctan(x)
 	assert_eq(count_set_bitflags(65536|32768), 2)
 	assert_eq(count_set_bitflags(1|4|16), 3)
 #endif
+
+// Basic geometry things.
+
+/vector/
+	var/x = 0
+	var/y = 0
+
+/vector/New(var/x, var/y)
+	src.x = x
+	src.y = y
+
+/vector/proc/duplicate()
+	return new /vector(x, y)
+
+/vector/proc/euclidian_norm()
+	return sqrt(x*x + y*y)
+
+/vector/proc/squared_norm()
+	return x*x + y*y
+
+/vector/proc/noramlise()
+	var/norm = euclidian_norm()
+	x = x/norm
+	y = y/norm
+	return src
+
+/vector/proc/chebyshev_norm()
+	return max(abs(x), abs(y))
+
+/vector/proc/chebyshev_normalise()
+	var/norm = chebyshev_norm()
+	x = x/norm
+	y = y/norm
+	return src
+
+/vector/proc/is_integer()
+	return IS_INT(x) && IS_INT(y)
+
+/atom/movable/proc/vector_translate(var/vector/V, var/delay)
+	var/turf/T = get_turf(src)
+	var/turf/destination = locate(T.x + V.x, T.y + V.y, z)
+	var/vector/V_norm = V.duplicate()
+	V_norm.chebyshev_normalise()
+	if (!V_norm.is_integer())
+		return
+	var/turf/destination_temp
+	while (destination_temp != destination)
+		destination_temp = locate(T.x + V_norm.x, T.y + V_norm.y, z)
+		forceMove(destination_temp, glide_size_override = DELAY2GLIDESIZE(delay))
+		T = get_turf(src)
+		sleep(delay + world.tick_lag) // Shortest possible time to sleep
+
+/atom/proc/get_translated_turf(var/vector/V)
+	var/turf/T = get_turf(src)
+	return locate(T.x + V.x, T.y + V.y, z)
+
+/proc/atmos2vector(var/atom/A, var/atom/B)
+	return new /vector((B.x - A.x), (B.y - A.y)) // Vector from A -> B

--- a/code/__HELPERS/maths.dm
+++ b/code/__HELPERS/maths.dm
@@ -346,7 +346,7 @@ proc/arctan(x)
 /vector/proc/squared_norm()
 	return x*x + y*y
 
-/vector/proc/noramlise()
+/vector/proc/noramlize()
 	var/norm = euclidian_norm()
 	x = x/norm
 	y = y/norm
@@ -355,7 +355,7 @@ proc/arctan(x)
 /vector/proc/chebyshev_norm()
 	return max(abs(x), abs(y))
 
-/vector/proc/chebyshev_normalise()
+/vector/proc/chebyshev_normalize()
 	var/norm = chebyshev_norm()
 	x = x/norm
 	y = y/norm
@@ -368,7 +368,7 @@ proc/arctan(x)
 	var/turf/T = get_turf(src)
 	var/turf/destination = locate(T.x + V.x, T.y + V.y, z)
 	var/vector/V_norm = V.duplicate()
-	V_norm.chebyshev_normalise()
+	V_norm.chebyshev_normalize()
 	if (!V_norm.is_integer())
 		return
 	var/turf/destination_temp
@@ -382,5 +382,5 @@ proc/arctan(x)
 	var/turf/T = get_turf(src)
 	return locate(T.x + V.x, T.y + V.y, z)
 
-/proc/atmos2vector(var/atom/A, var/atom/B)
+/proc/atoms2vector(var/atom/A, var/atom/B)
 	return new /vector((B.x - A.x), (B.y - A.y)) // Vector from A -> B

--- a/code/__HELPERS/maths.dm
+++ b/code/__HELPERS/maths.dm
@@ -346,7 +346,7 @@ proc/arctan(x)
 /vector/proc/squared_norm()
 	return x*x + y*y
 
-/vector/proc/noramlize()
+/vector/proc/normalize()
 	var/norm = euclidian_norm()
 	x = x/norm
 	y = y/norm

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -1644,7 +1644,7 @@
 			if (!user.Adjacent(src) || !src_location.Adjacent(over_location)) // Regular users can only do short slides.
 				return ..()
 			if ((M_CLUMSY in user.mutations) && prob(10))
-				user.visible_message("<span class='warning'>\The [user] tries to slide \the [src] down the table, but fails miserably.</span>", "<span class='notice'>You <b>fail</b> to slide \the [src] down the table!</span>")
+				user.visible_message("<span class='warning'>\The [user] tries to slide \the [src] down the table, but fails miserably.</span>", "<span class='warning'>You <b>fail</b> to slide \the [src] down the table!</span>")
 				create_broken_bottle()
 				return
 			user.visible_message("<span class='notice'>\The [user] slides \the [src] down the table.</span>", "<span class='notice'>You slide \the [src] down the table!</span>")

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -1477,8 +1477,8 @@
 	Q.SwapColor(rgb(255, 0, 220, 255), rgb(0, 0, 0, 0))
 	B.icon = Q
 	src.transfer_fingerprints_to(B)
-	spawn(50)
-		qdel(src)
+	playsound(src, "shatter", 70, 1)
+	qdel(src)
 
 //////////////////////
 // molotov cocktail //
@@ -1606,12 +1606,12 @@
 	if (!user || user.incapacitated())
 		return
 	// Attempted drink sliding
-	if ((locate(/obj/structure/table) in src_location) && (locate(/obj/structure/table) in over_location))
+	if (locate(/obj/structure/table) in src_location)
 		if (M_SOBER in user.mutations)
 			if (!user.Adjacent(src))
 				return
 			var/distance = manhattan_distance(over_location, src)
-			if (distance >= 3) // More than 3 tiles to go
+			if (distance >= 8) // More than a full screen to go
 				return ..()
 		
 			// Geometrically checking if we're on a straight line.
@@ -1623,19 +1623,27 @@
 			
 			// Checks if there's tables on the path.
 			var/turf/dest = get_translated_turf(V)
-			var/turf/temp_turf = get_translated_turf(V_norm)
-			while (temp_turf != dest)
-				if (!locate(/obj/structure/table) in temp_turf)
-					return ..()
+			var/turf/temp_turf = src_location
+
+			do
 				temp_turf = temp_turf.get_translated_turf(V_norm)
-			
-			vector_translate(V, 0.2 SECONDS)
+				if (!locate(/obj/structure/table) in temp_turf)
+					var/vector/V2 = atoms2vector(src, temp_turf)
+					vector_translate(V2, 0.1 SECONDS)
+					user.visible_message("<span class='warning'>\The [user] slides \the [src] down the table... and straight into the ground!</span>", "<span class='warning'>You slide \the [src] down the table, and straight into the ground!</span>")
+					create_broken_bottle()
+					return
+			while (temp_turf != dest)
+
+			vector_translate(V, 0.1 SECONDS)
 			user.visible_message("<span class='notice'>\The [user] expertly slides \the [src] down the table.</span>", "<span class='notice'>You slide \the [src] down the table. What a pro.</span>")
 			return
 		else
+			if (!(locate(/obj/structure/table) in over_location))
+				return ..()
 			if (!user.Adjacent(src) || !src_location.Adjacent(over_location)) // Regular users can only do short slides.
 				return ..()
-			if (M_CLUMSY in user.mutations && prob(10))
+			if ((M_CLUMSY in user.mutations) && prob(10))
 				user.visible_message("<span class='warning'>\The [user] tries to slide \the [src] down the table, but fails miserably.</span>", "<span class='notice'>You <b>fail</b> to slide \the [src] down the table!</span>")
 				create_broken_bottle()
 				return

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -1611,13 +1611,13 @@
 			if (!user.Adjacent(src))
 				return
 			var/distance = manhattan_distance(over_location, src)
-			if (distance > 3) // More than 3 tiles to go
+			if (distance >= 3) // More than 3 tiles to go
 				return ..()
 		
 			// Geometrically checking if we're on a straight line.
-			var/vector/V = atmos2vector(src, over_location)
+			var/vector/V = atoms2vector(src, over_location)
 			var/vector/V_norm = V.duplicate()
-			V_norm.noramlise()
+			V_norm.noramlize()
 			if (!V_norm.is_integer())
 				return ..() // Only a cardinal vector (north, south, east, west) can pass this test
 			

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -1400,13 +1400,7 @@
 	..()
 	reagents.add_reagent(GREYVODKA, 100)
 
-
-
-
-
 /obj/item/weapon/reagent_containers/food/drinks/proc/smash(mob/living/M as mob, mob/living/user as mob)
-
-
 	if(molotov == 1) //for molotovs
 		if(lit)
 			new /obj/effect/decal/cleanable/ash(get_turf(src))
@@ -1463,30 +1457,28 @@
 					loca.hotspot_expose(700, 1000,surfaces=istype(loc,/turf))
 			else
 				new /obj/item/weapon/reagent_containers/glass/rag(get_turf(src))
+		
+		create_broken_bottle()
 
+/obj/item/weapon/reagent_containers/food/drinks/proc/create_broken_bottle()
+	//create new broken bottle
+	var/obj/item/weapon/broken_bottle/B = new /obj/item/weapon/broken_bottle(loc)
+	B.name = src.smashname
+	B.icon_state = src.icon_state
 
-		//create new broken bottle
-		var/obj/item/weapon/broken_bottle/B = new /obj/item/weapon/broken_bottle(loc)
-		B.name = src.smashname
-		B.icon_state = src.icon_state
+	if(istype(src, /obj/item/weapon/reagent_containers/food/drinks/drinkingglass))  //for drinking glasses
+		B.icon_state = "glass_empty"
 
-		if(istype(src, /obj/item/weapon/reagent_containers/food/drinks/drinkingglass))  //for drinking glasses
-			B.icon_state = "glass_empty"
+	if(prob(33))
+		getFromPool(/obj/item/weapon/shard, get_turf(src)) // Create a glass shard at the hit location!
 
-		if(prob(33))
-			getFromPool(/obj/item/weapon/shard, get_turf(src)) // Create a glass shard at the hit location!
-
-		var/icon/Q = new('icons/obj/drinks.dmi', B.icon_state)
-		Q.Blend(B.broken_outline, ICON_OVERLAY, rand(5), 1)
-		Q.SwapColor(rgb(255, 0, 220, 255), rgb(0, 0, 0, 0))
-		B.icon = Q
-		src.transfer_fingerprints_to(B)
-
-
-		spawn(50)
-			qdel(src)
-
-
+	var/icon/Q = new('icons/obj/drinks.dmi', B.icon_state)
+	Q.Blend(B.broken_outline, ICON_OVERLAY, rand(5), 1)
+	Q.SwapColor(rgb(255, 0, 220, 255), rgb(0, 0, 0, 0))
+	B.icon = Q
+	src.transfer_fingerprints_to(B)
+	spawn(50)
+		qdel(src)
 
 //////////////////////
 // molotov cocktail //
@@ -1559,6 +1551,26 @@
 	else
 		set_light(0)
 
+//todo: can light cigarettes with
+//todo: is force = 15 overwriting the force? //Yes, of broken bottles, but that's been fixed now
+
+////////  Could be expanded upon:
+//  make it work with more chemicals and reagents, more like a chem grenade
+//  only allow the bottle to be stuffed if there are certain reagents inside, like fuel
+//  different flavor text for different means of lighting
+//  new fire overlay - current is edited version of the IED one
+//  a chance to not break, if desired
+//  fingerprints appearing on the object, which might already happen, and the shard
+//  belt sprite and new hand sprite
+//	ability to put out with water or otherwise
+//	burn out after a time causing the contents to ignite
+//	make into its own item type so they could be spawned full of fuel with New()
+//  colored light instead of white light
+//	the rag can store chemicals as well so maybe the rag's chemicals could react with the bottle's chemicals before or upon breaking
+//  somehow make it possible to wipe down the bottles instead of exclusively stuffing rags into them
+//  make rag retain chemical properties or color (if implemented) after smashing
+////////
+
 /obj/item/weapon/reagent_containers/food/drinks/update_icon()
 	src.overlays.len = 0
 	var/image/Im
@@ -1587,36 +1599,47 @@
 	return
 
 // Sliding from one table to another
-/obj/item/weapon/reagent_containers/food/drinks/MouseDropFrom(atom/over_object,atom/src_location,over_location,src_control,over_control,params)
+/obj/item/weapon/reagent_containers/food/drinks/MouseDropFrom(atom/over_object,atom/src_location,atom/over_location,src_control,over_control,params)
 	var/mob/user = usr
 	if (!istype(src_location))
 		return
 	if (!user || user.incapacitated())
 		return
-	if (!user.Adjacent(src) || !src_location.Adjacent(over_location))
-		return
+	// Attempted drink sliding
 	if ((locate(/obj/structure/table) in src_location) && (locate(/obj/structure/table) in over_location))
-		user.visible_message("<span class='notice'>\The [user] slides \the [src] down the table.</span>", "<span class='notice'>You slide \the [src] down the table!</span>")
-		forceMove(over_location, glide_size_override = DELAY2GLIDESIZE(2))
-		return
+		if (M_SOBER in user.mutations)
+			if (!user.Adjacent(src))
+				return
+			var/distance = manhattan_distance(over_location, src)
+			if (distance > 3) // More than 3 tiles to go
+				return ..()
+		
+			// Geometrically checking if we're on a straight line.
+			var/vector/V = atmos2vector(src, over_location)
+			var/vector/V_norm = V.duplicate()
+			V_norm.noramlise()
+			if (!V_norm.is_integer())
+				return ..() // Only a cardinal vector (north, south, east, west) can pass this test
+			
+			// Checks if there's tables on the path.
+			var/turf/dest = get_translated_turf(V)
+			var/turf/temp_turf = get_translated_turf(V_norm)
+			while (temp_turf != dest)
+				if (!locate(/obj/structure/table) in temp_turf)
+					return ..()
+				temp_turf = temp_turf.get_translated_turf(V_norm)
+			
+			vector_translate(V, 0.2 SECONDS)
+			user.visible_message("<span class='notice'>\The [user] expertly slides \the [src] down the table.</span>", "<span class='notice'>You slide \the [src] down the table. What a pro.</span>")
+			return
+		else
+			if (!user.Adjacent(src) || !src_location.Adjacent(over_location)) // Regular users can only do short slides.
+				return ..()
+			if (M_CLUMSY in user.mutations && prob(10))
+				user.visible_message("<span class='warning'>\The [user] tries to slide \the [src] down the table, but fails miserably.</span>", "<span class='notice'>You <b>fail</b> to slide \the [src] down the table!</span>")
+				create_broken_bottle()
+				return
+			user.visible_message("<span class='notice'>\The [user] slides \the [src] down the table.</span>", "<span class='notice'>You slide \the [src] down the table!</span>")
+			forceMove(over_location, glide_size_override = DELAY2GLIDESIZE(0.4 SECONDS))
+			return
 	return ..()
-
-//todo: can light cigarettes with
-//todo: is force = 15 overwriting the force? //Yes, of broken bottles, but that's been fixed now
-
-////////  Could be expanded upon:
-//  make it work with more chemicals and reagents, more like a chem grenade
-//  only allow the bottle to be stuffed if there are certain reagents inside, like fuel
-//  different flavor text for different means of lighting
-//  new fire overlay - current is edited version of the IED one
-//  a chance to not break, if desired
-//  fingerprints appearing on the object, which might already happen, and the shard
-//  belt sprite and new hand sprite
-//	ability to put out with water or otherwise
-//	burn out after a time causing the contents to ignite
-//	make into its own item type so they could be spawned full of fuel with New()
-//  colored light instead of white light
-//	the rag can store chemicals as well so maybe the rag's chemicals could react with the bottle's chemicals before or upon breaking
-//  somehow make it possible to wipe down the bottles instead of exclusively stuffing rags into them
-//  make rag retain chemical properties or color (if implemented) after smashing
-////////

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -1617,7 +1617,7 @@
 			// Geometrically checking if we're on a straight line.
 			var/vector/V = atoms2vector(src, over_location)
 			var/vector/V_norm = V.duplicate()
-			V_norm.noramlize()
+			V_norm.normalize()
 			if (!V_norm.is_integer())
 				return ..() // Only a cardinal vector (north, south, east, west) can pass this test
 			


### PR DESCRIPTION
Better version of my PR to slide drinks across tables : bartender can now slide drinks up to 2 tables, if in a straight line.
Clumsy people will hurt themselves trying to perform sliding.

_Still WiP because I can't get a smooth animation for sliding down to 2 tables. What gives?????
Finally the implementation might be a bit shit and overcomplicated, but it's honestly the first way to do it that I found._

Nevermind, I solved the problem. Ready for review

:cl:

- rscadd: People with the "Sober" gene can now slide their drinks further away than regular bar patrons.