### PR TITLE
Allow all Silicon jobs to latejoin

### DIFF
--- a/code/game/jobs/job/silicon.dm
+++ b/code/game/jobs/job/silicon.dm
@@ -4,7 +4,7 @@
 	info_flag = JINFO_SILICON
 	department_flag = ENGSEC
 	faction = "Station"
-	total_positions = 0
+	total_positions = 1
 	spawn_positions = 1
 	selection_color = "#ccffcc"
 	supervisors = "your laws"
@@ -22,7 +22,7 @@
 	info_flag = JINFO_SILICON
 	department_flag = ENGSEC
 	faction = "Station"
-	total_positions = 0
+	total_positions = 2
 	spawn_positions = 2
 	supervisors = "your laws and the AI"
 	selection_color = "#ddffdd"
@@ -40,7 +40,7 @@
 	info_flag = JINFO_SILICON
 	department_flag = ENGSEC
 	faction = "Station"
-	total_positions = 0
+	total_positions = 2
 	spawn_positions = 2
 	supervisors = "your laws and the AI"
 	selection_color = "#ddffdd"

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -368,6 +368,18 @@
 
 	ticker.mode.latespawn(src)//can we make them a latejoin antag?
 
+	//Do this immediately so this works properly
+	if(rank == "AI")
+		close_spawn_windows()
+		AIize()
+		return
+	if(rank == "Cyborg")
+		create_roundstart_cyborg()
+		return
+	if(rank == "Mobile MMI")
+		MoMMIfy()
+		return
+
 	var/mob/living/carbon/human/character = create_character()	//creates the human and transfers vars and mind
 	if(character.client.prefs.randomslot)
 		character.client.prefs.random_character_sqlite(character, character.ckey)


### PR DESCRIPTION
Where do I begin with this change ? New Player code is an absolute shitheap, our job code is nearly 6-7 years of changes on top of changes to the point where touching anything is a massive danger, and obviously that's not a minor balance change

This is tested only to the degree that you can start the round, latejoin as an AI and it will spawn you in properly and all that. I can't even tell if the job listings are updated or the role cleared from the latejoin list because I can't even return myself to the lobby (if someone knows where that button is, please tell me, I looked)

Needless to say this is super fucking experimental, and the only reason I'm even putting it out this raw is that there's no point getting into a heart-stopping rework if people say no. This should probably be polled but I'll let the collabs handle it or something

Also for the love of god test that shit thoroughly and tell me what works, what doesn't, etc. Apparently the old coders did not conceptualize the fact that we could have silicons as a job, and all this shit is handled in the gameticker normally, and poorly at that. It's all over the place

:cl:
 * experiment: Silicons (AIs, Cyborgs and MoMMIs) can now latejoin. Buckle the fuck up