### PR TITLE
Remove roundstart camera failure waiting for a proper fix

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -22,7 +22,7 @@ var/list/camera_names=list()
 	anchored = 1.0
 	var/invuln = null
 	var/bugged = 0
-	var/failure_chance = 10
+	var/failure_chance = 0
 	var/obj/item/weapon/camera_assembly/assembly = null
 	var/light_on = 0
 


### PR DESCRIPTION
This is intended as a neutering/"revert" change to #22846. This doesn't totally remove all code artifacts (notably the flawless camera subtype) so this doesn't hold up the maps, but this would be trivial to do in a follow-up PR or in a PR redoing these changes in a more stable manner. Plus the cam placement is interesting for other reasons since it's important cams

Let's roll down the reasoning from top to bottom why this change is just causing problems:

- **It's coded in a way that causes cascading issues when you try to tweak it, notably regarding camera alarms**

One of the most pressing issues raised by the PR outside of the volume of cameras broken at roundstart is that it did not properly register on the camera alarms listing, which is still a major consistency and QoL issue. An attempt was made to address it in #23269 but it totally failed because the change was done without any concern for the quality of the rest of the code

As it stands, the code is in initialize, which mirrors the proc that is used to randomly break lightbulbs. The issue, naturally, is that lightbulbs aren't cams. Cams are registered to a network, there are multiple computers that tracks what cameras are broken, etc. This is all critical so the Silicons and Engineers can tell what cameras are broken and fix it. As far as I'm aware, the way this was coded totally busts this and would need a major rework of the camera system, since cameras broken during initialization are broken because the AI/alert computers that would collect the camera warnings are here

This also busts other fixes I've tried to moderate the issue. Delaying the camera malfunction to be disguised as a camera being snipped but still alerting the AI (putting delays in init() blows up round start), making it a random event, etc

To put it simply: This works with lightbulbs because all you do is break them. This barely works with cameras but causes a TON of background issues that were ignored in the original PR and are still in the game to this day

- **It's very RNG and can cut the AI access to critical/important items at roundstart for no reason, or literally have no effect**

For starters, it breaks 10 % of the station's entire camera coverage, which is gigantic in perspective. That's about 30-32 cameras on Boxstation. While there was a PR made to avoid the -most- important cameras from being broken over at #22962 but I don't believe that can really be a lasting solution

The core issue is that MOST cameras are important for station functionality or helping the crew. Having your cameras broken in Medbay can prevent you from assisting the crew with medical issues. Having cameras looking at important doors broken prevent you from opening doors for people, which is literally the ONE totally uncontroversial function the AI has and a pain for any self-respecting AI that is here to help the crew and not validhunt. And I highly doubt having cameras broken in the hallway is gonna protect antagonists, but it can definitely cause the aforementioned problems (example: If it's the only camera covering the emergency Medbay entrance, no more shortcut for wounded peeps)

It's also very rare that noteworthy rooms only have a single camera. Virology, Xenobiology, Cargo Bay, Abandoned Office, etc. Which means that the change failed to fundamentally make some of these rooms actually hidden at roundstart to give antagonists opportunity windows to act. Meanwhile, it breaks five of Xenobiology's six slime pens, severely destroying the AI's metagame potential of knowing which slimes the Xenobio is breeding

- **The AI can still very trivially powergame/metagame around it. This only inconveniences AIs who aren't**

It only takes five minutes to see blatant weaknesses that an AI who genuinely wants to harm the round and shut down the antagonists can take advantage of

For starters, since this change seems to have been majorly pushed to protect team antags (read: Cult), if a SINGLE Cult member fucks up a camera cut and snips the camera alarm (assuming the Cultists are even stealth cutting the cams to begin with), this will throw a big, loud camera alarm with the exact location of the camera cut. If this is a place where antagonists are setting up, the round crashes. This change did literally nothing to address this because all the camera malfunctions happen at roundstart, so ANY camera alarm during the round can be deduced to be an antag or vandal

Then, even if the antags play -perfectly- and stealth cut EVERY SINGLE CAMERA, the AI can still make a mental note of what departments it can see properly or not... or just send the borgs when the camera cuts are suspiciously "convenient" (ex: All of Virology is suddenly off camera, which would be unlikely normally given all 4-5 cams would have to have been picked)

- **This change burdens two role groups that are severely underplayed already**

Despite the AI being a crutch for most rounds (allowing people to bypass doors with dumb access requirements, handling machinery from roles that aren't played), AI isn't really picked that often compared to the need for one. I don't see the need to damage its QoL to dissuade powergaming

This also screws over Cyborgs and Engineers to a degree. Engineer Cyborgs and Engineers are forced to repair the cameras EVERY round (or just ignore it), which is a huge pain in the ass knowing the random spread of the cameras and given you literally have no way of telling which are broken or not unless you see it for yourself or the AI carefully guides you around every single one. Other Cyborgs are forced to shuttle across the station to open one dumb door or push a button because the AI can't see it due to an unlucky camera break

- **To a degree, this can be considered a policy problem. We can change policy instead of using rushed code "hotfixes" that have secondary effects**

We all know the AI is omniscient and has a ton of impact on the round, the "player observer". For years there's been a fine balance in shackling the AI so it doesn't just shag the antagonists at any chance it gets. I'm not sure why we stopped in that regard

The potent ham/prob ham debate, AIs going out of their way to personally hunt the antagonists and AI being on the Security channel 90 % of the round might be memes, but these aren't code issues. The AI was always a power role and power roles need drawbacks. That change did nothing to affect AI validhunting, whereas some policy changes could easily help here. We literally just established that not everything was a code issue and that sometimes we need to update our rules, like with the greytiding drama, so why not here if AIs hunting antags is that bad ?

- **We have plenty of other ways to address the issue of making camera sabotage more interesting via code (ignoring policy note above)**

To list a few :

- Make the camera malfunction happen during the round so it's both actually probable to confuse with sabotage so camera snips don't scream "ANTAG CALL SEC", and can warn the AI/Engineers directly so they can repair it if need be, instead of being a pain in the ass to track down as current. Or tie it to a random event/pulse
- Rework camera alarms in some way so you don't get instantly fucked if you cut out a camera improperly, especially for team antags (solo antags don't care in theory because they can roam)
- Add some sort of item that can freeze frame/stop updating the camera view, kind of like tapping a still photo in front of the lens in comedy shows, so you can sabotage a cam while giving the AI a view that looks non-suspicious for antags that really need an area stealthed
- Add a way to sabotage the camera system on a bigger scale, like turn off every camera on an APC/in a department. Could be a central cam console, or just tie the cameras to APC equipment. This would make it harder to pick out -which- camera was cut while still giving the crew a playing chance of repairing the sabotage and make it so you can just slam down the entire network if you need clearance to do nefarious stuff like sabotaging tcomms

- **Code/balance quality follow-up wasn't done despite issues being raised**

The change was merged due to emojicracy without being polled by @Kurfursten who assured that there would be quality control a week after or such. So far I haven't seen it besides some vague notion that "AIs have not been complaining". As far as I am aware there was no follow-up poll, no consultation of people playing AI, nothing really, just a "feeling"

This reminds me of the issue with MoMMI static where the change gutted MoMMIs and caused many of them to stop playing until an admin just went ahead and stealth disabled it. Since it didn't affect 95 % of players there never was any kind of cohesive outcry, and no-one did any follow-up checks. This change only affects the AI and Warden directly, and Cyborgs/Engineers indirectly if they choose to care, which is about the same ballpark

Likewise, the issues that were raised failed to be fixed (notably the camera alarm issue) but despite this this system is still in place. The alarm PR was finally closed in September because no-one could make it work. It's November now

**In Conclusion**

I rest my long-ass case for "just changing one number", but there's a metric ton of issues with this 6-month old PR that aren't being addressed. We need to stop making rushed, feel-good changes to roles when we could be doing a proper job with good overhauls that augment the game (add more complexity and interesting twists to camera sabotage instead of just gimping the camera network, basically) or making policy changes to address the core issue (AI is abusing its role to validhunt and shut down antags instead of adding to the round experience)

I was pretty sure we addressed this years ago with the MoMMI static change. The big code change that ruined the role's QoL but still got pushed through by emojicracy was a terrible idea. We neutered it. We made a policy change that gave harsher punishments to dumb MoMMIs who grief players passively. Problem solved

:cl:
 * rscdel: Remove roundstart camera malfunction chance waiting for a more interesting camera sabotage balance PR