### PR TITLE
A dispassionate attempt at testing the game without (roundstart) AIs

### DIFF
--- a/config-example/config.txt
+++ b/config-example/config.txt
@@ -142,7 +142,7 @@ VOTE_PERIOD 600
 DEFAULT_NO_VOTE
 
 ## allow AI job
-ALLOW_AI
+#ALLOW_AI
 
 
 ## disable abandon mob


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/17928298/68595861-0afb0b80-0479-11ea-8e55-41b12319ee21.png)


#21036 was attempted a little less than a year ago. It got closed. I want to bring this idea back.

I'll copypaste the argument I made at the time for the PR to be, at least, test-merged.

I think that AIs don't make a positive contribution on the vast majoriry of rounds.
AIs gimp round progression by being the invincible eye in the Sky which spies on every antag and every crewmember.

As a result, the #1 priority for an antagonist is to kill, or subvert, the AI. And for security, in the event of, say, Cult or Revs, their #1 priority is to get the AI off Asimov because it'll impede their ability to work properly.

This is not a problem with Asimov, as often said. Asimov is the only way to make AIs bearable on non-cult/non-revs, but it does not work anyways because of the extreme lust for valids an AI has.

The problem is that we have to do that almost every time. It's frustrating, it's bad for round variety and round progression. In short, AIs reduce the general fun of the game simply by existing and this, funnily, without even breaking their laws.

>I died

Not that it matters but I rarely if ever play antag ; I just had too many rounds where the AI just valided the antagonist 30 minutes in, without trying to engage in any sort of gimmick. And that's frustrating.

>Just kill the AI

Killing AIs is trivial. It's akin to a washing machine laundry program. It's not fun to do because they're griefing or have been subverted.

>Get it off Asimov

Same as above. Not to mention that silicons feel more free to grief people on other lawsets (not even getting banned for it because of some retarded logic that EVERYTHING a silicon does on non-Asimov is the fault of the uploader) and the laundry rountine of carding the AI is more present.

>It's a player problem, not a problem with the role

I disagree with this on the basis that an omniscient, quasi-omnipotent eye in the sky, even played PERFECTLY (as in, don't snitch on harmless antags, is not a cunt to people on purpose...) is still compelled by Asimov to hunt & kill that Vox trader or that vampire, and so on.
The traitor himself has no way to know if the AI will play nice or not and as such will be encouraged to take the AI out.
Finally, the AI remains due to its sheer power the number 1 priority on cult or revs. The flaw is within a role that is too powerful, rather than a player issue.

Those arguments, I think, still apply. I will admit that the frequency of me coming into conflicts with AIs as a player isn't the same, but again I played a tad more in 2018 than I do today.

I think it's telling that even with how highly different the playerbase is when compared to late 2018 (a certain youtuber made his mark on the game), most of the problems of the AI role are still here.

I also want to finish this by saying that I'm fully aware this is a "inflammatory" changes, and I might come across as trying to start shit and forcing views unto people. For this PR, I want to stress this isn't my intention.

I know there are good AI players & good silicons players. I just believe that, from a game standpoint, the constraints and negative of AI outweigh its presence. I don't feel as strong in that belief as I felt a year ago, though. If this PR gets too much controversy, I'll happily close it down.