### PR TITLE
Add a message to new players for pinging priority jobs

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -184,6 +184,7 @@
 			to_chat(src, "<span class='warning'>You have recently requested for heads of staff to open priority roles.</span>")
 			return
 		var/count_pings = 0
+		to_chat(src, "<span class='bnotice'>You have requested for heads of staff to open priority roles. Please stand by.</span>")
 		for(var/obj/item/device/pda/pingme in PDAs)
 			if(pingme.cartridge && pingme.cartridge.fax_pings && pingme.cartridge.access_status_display)
 				//This may seem like a strange check, but it's excluding the IAA for only HOP/Cap


### PR DESCRIPTION
This adds a simple bold notice message for new players to tell them that indeed, their button press has been noticed and they need to stand by (while the heads of staff -that totally exist and are not dead or AFK- trudge to the labor computer to prioritize jobs)

```You have requested for heads of staff to open priority roles. Please stand by.```

Fixes #24870

:cl:
 * tweak: Added a message for new players to tell them that pressing the "prioritize button" message does have an effect and they need to wait.