### PR TITLE
Ammunition tweaks

### DIFF
--- a/code/game/machinery/ammolathe.dm
+++ b/code/game/machinery/ammolathe.dm
@@ -21,11 +21,7 @@
 		new /obj/item/weapon/gun/projectile/rocketlauncher/nanotrasen/lockbox(), \
 		),
 		"Single_ammunition"=list(
-		new /obj/item/ammo_casing/shotgun/flare(), \
-		new /obj/item/ammo_casing/shotgun/beanbag(), \
-		new /obj/item/ammo_casing/shotgun/stunshell(), \
-		new /obj/item/ammo_casing/shotgun(), \
-		new /obj/item/ammo_casing/shotgun/buckshot(),\
+		new /obj/item/ammo_casing/shotgun/blank(), \
 		new /obj/item/ammo_casing/rocket_rpg/lowyield(),\
 		new /obj/item/ammo_casing/rocket_rpg/blank(),\
 		new /obj/item/ammo_casing/rocket_rpg/emp(),\
@@ -35,6 +31,16 @@
 		new /obj/item/ammo_storage/box/b380auto(), \
 		new /obj/item/ammo_storage/box/b380auto/practice(), \
 		new /obj/item/ammo_storage/box/b380auto/rubber(), \
+		new /obj/item/ammo_storage/box/c9mm(), \
+		new /obj/item/ammo_storage/box/c38(), \
+		new /obj/item/ammo_storage/box/a357(), \
+		new /obj/item/ammo_storage/box/c12mm/assault(), \
+		new /obj/item/weapon/storage/box/lethalshells(), \
+		new /obj/item/weapon/storage/box/buckshotshells(), \
+		new /obj/item/weapon/storage/box/beanbagshells(), \
+		new /obj/item/weapon/storage/box/stunshells(), \
+		new /obj/item/weapon/storage/box/dartshells(), \
+		new /obj/item/ammo_storage/box/flare(), \
 		),
 		"Magazines"=list(
 		new /obj/item/ammo_storage/magazine/smg9mm/empty(), \
@@ -49,6 +55,7 @@
 		new /obj/item/ammo_storage/magazine/a75/empty(), \
 		new /obj/item/ammo_storage/magazine/a762/empty(), \
 		new /obj/item/ammo_storage/magazine/a12ga/empty(), \
+		new /obj/item/ammo_storage/magazine/a12mm/empty(), \
 		),
 		"Misc_Other"=list(
 		new /obj/item/ammo_storage/speedloader/c38/empty(), \

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -374,7 +374,7 @@ to destroy them and players will be able to make replacements.
 	desc = "A circuit board used to run a machine that fabricates guns, ammunition, and firearm accessories."
 	build_path = /obj/machinery/r_n_d/fabricator/mechanic_fab/autolathe/ammolathe
 	board_type = MACHINE
-	//origin_tech = Tc_ENGINEERING + "=2;" + Tc_PROGRAMMING + "=2;" + Tc_COMBAT + "=4"
+	origin_tech = Tc_ENGINEERING + "=2;" + Tc_PROGRAMMING + "=2;" + Tc_COMBAT + "=4"
 	req_components = list(
 							/obj/item/weapon/stock_parts/matter_bin = 3,
 							/obj/item/weapon/stock_parts/manipulator = 1,

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -600,7 +600,7 @@
 		new /obj/item/weapon/storage/pill_bottle(src)
 
 /obj/item/weapon/storage/box/lethalshells
-	name = "lethal shells"
+	name = "12-gauge slugs"
 	icon_state = "lethal shells"
 	storage_slots = 16
 
@@ -610,7 +610,7 @@
 		new /obj/item/ammo_casing/shotgun(src)
 
 /obj/item/weapon/storage/box/beanbagshells
-	name = "bean bag shells"
+	name = "12-gauge beanbag shells"
 	icon_state = "bean bag shells"
 	storage_slots = 16
 
@@ -620,7 +620,7 @@
 		new /obj/item/ammo_casing/shotgun/beanbag(src)
 
 /obj/item/weapon/storage/box/stunshells
-	name = "stun shells"
+	name = "12-gauge stun shells"
 	icon_state = "stun shells"
 	storage_slots = 16
 
@@ -630,7 +630,7 @@
 		new /obj/item/ammo_casing/shotgun/stunshell(src)
 
 /obj/item/weapon/storage/box/dartshells
-	name = "shotgun darts"
+	name = "12-gauge darts"
 	icon_state = "dart shells"
 	storage_slots = 16
 
@@ -640,7 +640,7 @@
 		new /obj/item/ammo_casing/shotgun/dart(src)
 
 /obj/item/weapon/storage/box/buckshotshells
-	name = "buckshot shells"
+	name = "12-gauge 00 buckshot shells"
 	icon_state = "lethal shells"
 	storage_slots = 16
 
@@ -1060,7 +1060,7 @@
 	new /obj/item/clothing/glasses/gglasses(src)
 	new /obj/item/clothing/shoes/jackboots(src)
 	..()
-	
+
 /obj/item/weapon/storage/box/smartbox/clothing_box/schoolgirloutfit
 	name = "School girl outfit box"
 
@@ -1131,7 +1131,7 @@
 	new /obj/item/clothing/mask/gas/sexymime(src)
 	new /obj/item/clothing/under/sexymime(src)
 	..()
-	
+
 /obj/item/weapon/storage/box/smartbox/clothing_box/jester
 	name = "Jester outfit box"
 
@@ -1259,14 +1259,14 @@
 //Premium boxes, no different than clothing_box, just sorting for clarity.
 /obj/item/weapon/storage/box/smartbox/clothing_box/joe
 	name = "Sniper outfit box"
-	
+
 /obj/item/weapon/storage/box/smartbox/clothing_box/joe/New()
 	new /obj/item/clothing/head/helmet/joehelmet(src)
 	new /obj/item/clothing/under/joe(src)
 	new /obj/item/clothing/gloves/joegloves(src)
 	new /obj/item/clothing/shoes/joeboots(src)
 	..()
-	
+
 /obj/item/weapon/storage/box/smartbox/clothing_box/lola
 	name = "Fighting clown outfit box"
 

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -20,7 +20,7 @@
 	ammo_type = "/obj/item/ammo_casing/c38"
 	max_ammo = 6
 	multiple_sprites = 1
-	
+
 /obj/item/ammo_storage/box/c762x38r
 	name = "ammo box (7.62x38R)"
 	desc = "A box of neo-russian revolver ammo."
@@ -125,3 +125,4 @@
 	ammo_type = "/obj/item/ammo_casing/shotgun/flare"
 	max_ammo = 7
 	multiple_sprites = 1
+	starting_materials = list(MAT_IRON = 8000)

--- a/code/modules/research/designs/boards/machine_misc.dm
+++ b/code/modules/research/designs/boards/machine_misc.dm
@@ -145,7 +145,7 @@
 	name = "Circuit Design (Ammolathe)"
 	desc = "Allows for the construction of circuit boards used to build ammolathes."
 	id = "ammolathe"
-	req_tech = list(Tc_PROGRAMMING = 2, Tc_ENGINEERING = 2, Tc_COMBAT = 4, Tc_NANOTRASEN = 1)
+	req_tech = list(Tc_PROGRAMMING = 2, Tc_ENGINEERING = 2, Tc_COMBAT = 4)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 2000, SACID = 20)
 	category = "Machine Boards"

--- a/code/modules/research/designs/boards/machine_misc.dm
+++ b/code/modules/research/designs/boards/machine_misc.dm
@@ -145,7 +145,7 @@
 	name = "Circuit Design (Ammolathe)"
 	desc = "Allows for the construction of circuit boards used to build ammolathes."
 	id = "ammolathe"
-	req_tech = list(Tc_PROGRAMMING = 2, Tc_ENGINEERING = 2, Tc_COMBAT = 4, Tc_NANOTRASEN = 5)
+	req_tech = list(Tc_PROGRAMMING = 2, Tc_ENGINEERING = 2, Tc_COMBAT = 4, Tc_NANOTRASEN = 1)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 2000, SACID = 20)
 	category = "Machine Boards"

--- a/code/modules/research/designs/boards/machine_misc.dm
+++ b/code/modules/research/designs/boards/machine_misc.dm
@@ -150,6 +150,8 @@
 	materials = list(MAT_GLASS = 2000, SACID = 20)
 	category = "Machine Boards"
 	build_path = /obj/item/weapon/circuitboard/ammolathe
+	locked = TRUE
+	req_lock_access = list(access_armory, access_weapons)
 
 /datum/design/chem_dispenser/brewer
 	name = "Circuit Design (Brewer)"

--- a/code/modules/research/designs/weapons.dm
+++ b/code/modules/research/designs/weapons.dm
@@ -130,26 +130,6 @@
 	locked = TRUE
 	req_lock_access = list(access_armory, access_weapons)
 
-/datum/design/ammo_12mm
-	name = "Ammunition Box (12mm)"
-	desc = "A box of 12mm ammunition."
-	id = "ammo_12mm"
-	req_tech = list(Tc_COMBAT = 3, Tc_MATERIALS = 2)
-	build_type = PROTOLATHE
-	materials = list(MAT_IRON = 4250, MAT_SILVER = 250)
-	category = "Weapons"
-	build_path = /obj/item/ammo_storage/box/c12mm/assault
-
-/datum/design/magazine_12mm
-	name = "Magazine (12mm)"
-	desc = "A magazine that holds 12mm ammunition."
-	id = "magazine_12mm"
-	req_tech = list(Tc_COMBAT = 2)
-	build_type = PROTOLATHE
-	materials = list(MAT_IRON = 400)
-	category = "Weapons"
-	build_path = /obj/item/ammo_storage/magazine/a12mm/empty
-
 /datum/design/decloner
 	name = "Decloner"
 	desc = "Your opponent will bubble into a messy pile of goop."
@@ -242,36 +222,6 @@
 	locked = TRUE
 	req_lock_access = list(access_armory, access_weapons)
 
-/datum/design/ammo_9mm
-	name = "Ammunition Box (9mm)"
-	desc = "A box of prototype 9mm ammunition."
-	id = "ammo_9mm"
-	req_tech = list(Tc_COMBAT = 4, Tc_MATERIALS = 3)
-	build_type = PROTOLATHE
-	materials = list(MAT_IRON = 3750, MAT_SILVER = 100)
-	category = "Weapons"
-	build_path = /obj/item/ammo_storage/box/c9mm
-
-/datum/design/magazine_9mm
-	name = "Magazine (9mm SMG)"
-	desc = "A SMG magazine that holds 9mm ammunition."
-	id = "magazine_9mm"
-	req_tech = list(Tc_COMBAT = 2)
-	build_type = PROTOLATHE
-	materials = list(MAT_IRON = 300)
-	category = "Weapons"
-	build_path = /obj/item/ammo_storage/magazine/smg9mm/empty
-
-/datum/design/stunshell
-	name = "Stun Shell"
-	desc = "A stunning shell for a shotgun."
-	id = "stunshell"
-	req_tech = list(Tc_COMBAT = 3, Tc_MATERIALS = 3)
-	build_type = PROTOLATHE
-	materials = list(MAT_IRON = 4000)
-	category = "Weapons"
-	build_path = /obj/item/ammo_casing/shotgun/stunshell
-
 /datum/design/pneumatic
 	name = "Pneumatic Cannon"
 	desc = "A launcher powered by compressed air."
@@ -349,30 +299,159 @@
 	materials = list(MAT_IRON = 20000, MAT_SILVER = 1000)
 	build_path = /obj/item/ammo_casing/rocket_rpg/stun
 
+//Shotgun single ammunition (mostly) isn't printable, but is defined here to keep the material cost consistent
+/datum/design/shotgun_shell/slug
+	name = "12ga. slug"
+	desc = "A 12-gauge slug for a shotgun."
+	id = "slugshell"
+	build_type = AMMOLATHE
+	materials = list(MAT_IRON = 500)
+	build_path = /obj/item/ammo_casing/shotgun
+
+/datum/design/shotgun_shell/buckshot
+	name = "12ga. buckshot"
+	desc = "A 12-gauge, 00 buckshot shell for a shotgun."
+	id = "buckshotshell"
+	build_type = AMMOLATHE
+	materials = list(MAT_IRON = 500)
+	build_path = /obj/item/ammo_casing/shotgun/buckshot
+
+/datum/design/shotgun_shell/beanbag
+	name = "12ga. beanbag"
+	desc = "A non-lethal 12-gauge beanbag shell for a shotgun."
+	id = "beanbagshell"
+	build_type = AMMOLATHE
+	materials = list(MAT_IRON = 500)
+	build_path = /obj/item/ammo_casing/shotgun/beanbag
+
+/datum/design/shotgun_shell/stun
+	name = "12ga. stun shell"
+	desc = "A stunning shell for a shotgun."
+	id = "stunshell"
+	build_type = AMMOLATHE
+	materials = list(MAT_IRON = 500)
+	build_path = /obj/item/ammo_casing/shotgun/stunshell
+
+/datum/design/shotgun_shell/flare
+	name = "12ga. flare shell"
+	desc = "A flare shell for a shotgun."
+	id = "flareshell"
+	build_type = AMMOLATHE
+	materials = list(MAT_IRON = 500)
+	build_path = /obj/item/ammo_casing/shotgun/flare
+
+/datum/design/shotgun_shell/dart
+	name = "12ga. dart shell"
+	desc = "A shotgun shell with a dart inside."
+	id = "dartshell"
+	build_type = AMMOLATHE
+	materials = list(MAT_IRON = 500)
+	build_path = /obj/item/ammo_casing/shotgun/dart
+
+/datum/design/shotgun_shell/blank
+	name = "12ga. blank shell"
+	desc = "A blank 12-gauge shotgun shell that contains no projectile material."
+	id = "dartshell"
+	build_type = AMMOLATHE
+	materials = list(MAT_IRON = 250)
+	build_path = /obj/item/ammo_casing/shotgun/blank
+
 //Box ammunition
 /datum/design/ammo_b380auto
 	name = "Ammunition Box (.380AUTO)"
-	desc = "A box of .380AUTO bullets."
+	desc = "A box of .380AUTO cartridges."
 	id = "ammo_380auto"
 	build_type = AMMOLATHE
-	materials = list(MAT_IRON = 3750, MAT_SILVER = 100)
+	materials = list(MAT_IRON = 4000)
 	build_path = /obj/item/ammo_storage/box/b380auto
 
 /datum/design/ammo_b380auto/practice
 	name = "Ammunition Box (.380AUTO practice)"
-	desc = "A box of .380AUTO practice bullets."
+	desc = "A box of .380AUTO practice cartridges."
 	id = "ammo_380auto_P"
 	build_type = AMMOLATHE
-	materials = list(MAT_IRON = 3750, MAT_SILVER = 100)
+	materials = list(MAT_IRON = 4000)
 	build_path = /obj/item/ammo_storage/box/b380auto/practice
 
 /datum/design/ammo_b380auto/rubber
 	name = "Ammunition Box (.380AUTO rubber)"
-	desc = "A box of .380AUTO rubber bullets."
+	desc = "A box of .380AUTO rubber cartridges."
 	id = "ammo_380auto_R"
 	build_type = AMMOLATHE
-	materials = list(MAT_IRON = 3750, MAT_SILVER = 100)
+	materials = list(MAT_IRON = 4000)
 	build_path = /obj/item/ammo_storage/box/b380auto/rubber
+
+/datum/design/ammo_38rubber
+	name = "Ammunition Box (.38 rubber)"
+	desc = "A box of nonlethal .38 special cartridges."
+	id = "ammo_38_R"
+	build_type = AMMOLATHE
+	materials = list(MAT_IRON = 4000)
+	build_path = /obj/item/ammo_storage/box/c38
+
+/datum/design/ammo_357
+	name = "Ammunition Box (.357)"
+	desc = "A box of .357 magnum cartridges."
+	id = "ammo_357"
+	build_type = AMMOLATHE
+	materials = list(MAT_IRON = 4000)
+	build_path = /obj/item/ammo_storage/box/a357
+
+/datum/design/ammo_9mm
+	name = "Ammunition Box (9mm)"
+	desc = "A box of 9mm cartridges."
+	id = "ammo_9mm"
+	build_type = AMMOLATHE
+	materials = list(MAT_IRON = 4000)
+	build_path = /obj/item/ammo_storage/box/c9mm
+
+/datum/design/ammo_shotgun/slug
+	name = "Ammunition Box (12ga. slug)"
+	desc = "A box of 12-gauge slugs."
+	id = "ammo_12ga_slug"
+	build_type = AMMOLATHE
+	materials = list(MAT_IRON = 8000)
+	build_path = /obj/item/weapon/storage/box/lethalshells
+
+/datum/design/ammo_shotgun/buckshot
+	name = "Ammunition Box (12ga. 00 buckshot)"
+	desc = "A box of 12-gauge 00 buckshot shells."
+	id = "ammo_12ga_buckshot"
+	build_type = AMMOLATHE
+	materials = list(MAT_IRON = 8000)
+	build_path = /obj/item/weapon/storage/box/buckshotshells
+
+/datum/design/ammo_shotgun/beanbag
+	name = "Ammunition Box (12ga. beanbag)"
+	desc = "A box of non-lethal 12-gauge beanbag shells."
+	id = "ammo_12ga_beanbag"
+	build_type = AMMOLATHE
+	materials = list(MAT_IRON = 8000)
+	build_path = /obj/item/weapon/storage/box/beanbagshells
+
+/datum/design/ammo_shotgun/stun
+	name = "Ammunition Box (12ga. stun shell)"
+	desc = "A box of 12-gauge stun shells."
+	id = "ammo_12ga_stun"
+	build_type = AMMOLATHE
+	materials = list(MAT_IRON = 8000)
+	build_path = /obj/item/weapon/storage/box/stunshells
+
+/datum/design/ammo_shotgun/dart
+	name = "Ammunition Box (12ga. dart)"
+	desc = "A box of 12-gauge dart shells."
+	id = "ammo_12ga_dart"
+	build_type = AMMOLATHE
+	materials = list(MAT_IRON = 8000)
+	build_path = /obj/item/weapon/storage/box/dartshells
+
+/datum/design/ammo_12mm
+	name = "Ammunition Box (12mm)"
+	desc = "A box of 12mm ammunition."
+	id = "ammo_12mm"
+	build_type = AMMOLATHE
+	materials = list(MAT_IRON = 5000)
+	build_path = /obj/item/ammo_storage/box/c12mm/assault
 
 //Magazines
 //Normal 9mm and 12mm already have a designs above.
@@ -383,6 +462,14 @@
 	build_type = AMMOLATHE
 	materials = list(MAT_IRON = 400)
 	build_path = /obj/item/ammo_storage/magazine/beretta/empty
+
+/datum/design/magazine_9mm
+	name = "Magazine (9mm SMG)"
+	desc = "A SMG magazine that holds 9mm ammunition."
+	id = "magazine_9mm"
+	build_type = AMMOLATHE
+	materials = list(MAT_IRON = 400)
+	build_path = /obj/item/ammo_storage/magazine/smg9mm/empty
 
 /datum/design/magazine_357
 	name = "Automag magazine (.357)"
@@ -455,6 +542,14 @@
 	build_type = AMMOLATHE
 	materials = list(MAT_IRON = 400)
 	build_path = /obj/item/ammo_storage/magazine/a12ga/empty
+
+/datum/design/magazine_12mm
+	name = "Magazine (12mm)"
+	desc = "A magazine that holds 12mm ammunition."
+	id = "magazine_12mm"
+	build_type = AMMOLATHE
+	materials = list(MAT_IRON = 400)
+	build_path = /obj/item/ammo_storage/magazine/a12mm/empty
 
 //Misc
 /datum/design/vectorreceiver


### PR DESCRIPTION
[balance][consistency]

Everything about our ammunition "ecosystem" was retarded.

- Ammunition required silver to print, which was a good way to ensure it was never fucking printed unless a secman robbed the vault.
- We have a machine whose one purpose in life is to print ammo, but it couldn't print the ammo for half the fucking guns in the armory.
- Ammo costs were all over the place.

This PR changes it so that the ammolathe prints *most* of the ammo used by the standard guns, and printing it no longer requires silver. It can now print 9mm and 12mm ammo and mags. It can now print all the shotgun ammo as boxes, most the single-print shotgun ammo was removed except for blanks which had no box. It can even print .357 ammo. Whatever was available in the autolathe is still in the autolathe too.

9mm and 12mm ammo has been removed from the protolathe. If ablinos want to print ammo for the guns that they can print, they're gonna have to ~~get that NT research and~~ build themselves an ammolathe.

I also changed some wording and grammar, mostly for tacticoolness factor.

:cl:
 * tweak: The ammolathe now prints more useful ammo. Printing ammo from the ammolathe no longer requires silver aside from a couple of special types.
 * tweak: The protolathe no longer prints 9mm or 12mm ammo, nor shotgun stun shells. These have all been moved into the ammolathe.
 * tweak: The ammolathe circuit board can now be constructed at the circuit imprinter, requiring 2 Programming (data theory?), 2 Engineering, 4 Combat. It comes in a locked box.
