### PR TITLE
Blacklists Some Events for Snaxi

### DIFF
--- a/maps/snaxi.dm
+++ b/maps/snaxi.dm
@@ -26,7 +26,8 @@
 		)
 	enabled_jobs = list(/datum/job/trader)
 
-	event_blacklist = list(/datum/event/radiation_storm)
+	event_blacklist = list(/datum/event/radiation_storm,/datum/event/carp_migration,/datum/event/rogue_drone,/datum/event/immovable_rod,
+						/datum/event/meteor_wave,/datum/event/meteor_shower,/datum/event/thing_storm)
 	load_map_elements = list(
 	/datum/map_element/dungeon/holodeck
 	)


### PR DESCRIPTION
closes #24965

🆑 
* rscdel: These events will no longer take place on Snaxi: meteor wave, meteor shower, thing storm, immovable rod, carp migration, rogue drone.