### PR TITLE
Borers are no longer harmed by the environment while inside a host.

### DIFF
--- a/code/modules/mob/living/simple_animal/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer.dm
@@ -96,6 +96,9 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 	var/name_prefix_index = 1
 	held_items = list()
 
+/mob/living/simple_animal/borer/check_environment_susceptibility()
+	return !host
+
 /mob/living/simple_animal/borer/whisper()
 	return FALSE
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -157,6 +157,9 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 			set_glide_size(DELAY2GLIDESIZE(0.5 SECONDS))
 		Move(dest)
 
+/mob/living/simple_animal/proc/check_environment_susceptibility()
+	return TRUE
+
 /mob/living/simple_animal/Life()
 	if(timestopped)
 		return 0 //under effects of time magick
@@ -240,7 +243,7 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 
 	var/datum/gas_mixture/Environment = A.return_air()
 
-	if(Environment)
+	if(Environment && check_environment_susceptibility())
 		if(abs(Environment.temperature - bodytemperature) > 40)
 			bodytemperature += ((Environment.temperature - bodytemperature) / 5)
 


### PR DESCRIPTION
Fixes #24872.
Fixes #24937.

I would have liked to make *all* mobs that can be inside mobs immune to the environment, for future proofing. Unfortunately, there's no good way to distinguish between something that's inside a mob, as in it's inventory, and something that's *inside* a mob, like a borer.
So, for now, borers specifically are immune to the environment while they have a host.

:cl:
 * bugfix: Fixes borers taking environment damage while inside hosts.