### PR TITLE
The reward for players joining as priority assistants will now include the captain's spare

### DIFF
--- a/code/game/jobs/job/assistant.dm
+++ b/code/game/jobs/job/assistant.dm
@@ -45,6 +45,7 @@
 /datum/job/assistant/priority_reward_equip(var/mob/living/carbon/human/H)
 	. = ..()
 	H.put_in_hands(new /obj/item/weapon/storage/toolbox/mechanical(get_turf(H)))
+	H.put_in_hands(new /obj/item/weapon/card/id/captains_spare(get_turf(H)))
 
 /datum/job/assistant/get_access()
 	if(config.assistant_maint)


### PR DESCRIPTION
This has been a long-planned solution since 3 years ago and this is the culmination. If assistants are demanded at the head of personnel's labor console and assistants join, they will also receive the captain's spare.

### Why this is good for the game
Assistants are almost limitless in number, and the solution itself will:
- Solve the spare-rushing problem that has plagued the server for months, disincentivizing assistants from breaking into the captain's office and stealing the spare ID card, they will already receive spare ID cards;
- Give a breather at the start of the round as every assistant will now late-join, allowing jobs to set up their departments before assistants start spawning, providing them with enough defenses set up to weather it most of the time;
- Make heads of personnel never set assistant to a priority job, meaning assistants will not receive free toolboxes anymore;
- Allow heads of personnel to farm assistants. With security's help, they will put assistant on the priority list and then kill any assistant that spawns for "spare-rushing", acquiring the all access ID card in the process. It will also allow for farming XP to increase your level of robust;
- Arguably allow assistants to be banned on the spot for spare-rushing.

### Downsides
**People will understandably be pissed** at the future of /vg/station and setting up an industrial killing machine in Arrivals, but to those people I can say there are no downsides, as assistants are based and redpilled, and I wouldn't trust any other job to appear with a spare in hand. If this PR passes, the next PR will be making AI malfunction every round, and by malfunction I mean it will get damaged and die fuck you AI stop bolting the doors when i am antag everyone knows u basically let humanharm hos away!!

:cl:
 * tweak: Priority assistants will now spawn with all access.