### PR TITLE
You now only need 5 units of virus food to fully incubate a dish instead of roughly 6.5

### DIFF
--- a/code/modules/virus2/dishincubator.dm
+++ b/code/modules/virus2/dishincubator.dm
@@ -25,7 +25,7 @@
 	var/on = FALSE
 
 	var/mutatechance = 5
-	var/growthrate = 3
+	var/growthrate = 4
 
 
 /obj/machinery/disease2/incubator/New()


### PR DESCRIPTION
A syringe shot's worth basically
:cl:
 * tweak: You only need 5u virus food to fully incubate a petri dish.