### PR TITLE
Pickpocketing improvements and additions

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -791,8 +791,16 @@ var/list/uplink_items = list()
 	name = "Pickpocket's Gloves"
 	desc = "A pair of sleek gloves to aid in pickpocketing, while wearing these you can sneakily strip any item without the other person being alerted. Pickpocketed items will also be put into your hand rather than fall to the ground."
 	item = /obj/item/clothing/gloves/black/thief
-	cost = 8
-	discounted_cost = 6
+	cost = 4
+	discounted_cost = 2
+	jobs_with_discount = list("Assistant")
+
+/datum/uplink_item/jobspecific/pickpocketglovestorage
+	name = "Pickpocket's Gloves with Storage"
+	desc = "A pair of sleek gloves to aid in pickpocketing, these come with their own small storage where pickpocketed items will automatically be placed in if there is room"
+	item = /obj/item/clothing/gloves/black/thief/storage
+	cost = 7
+	discounted_cost = 4
 	jobs_with_discount = list("Assistant")
 
 /datum/uplink_item/jobspecific/greytide

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1343,6 +1343,9 @@ var/global/list/image/blood_overlays = list()
 /obj/item/proc/on_mousedrop_to_inventory_slot()
 	return
 
+/obj/item/proc/stealthy(var/mob/living/carbon/human/H)
+	return H.isGoodPickpocket()
+
 /obj/item/proc/can_be_stored(var/obj/item/weapon/storage/S)
 	return TRUE
 

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -16,7 +16,8 @@
 	max_combined_w_class = 21
 
 /obj/item/weapon/storage/backpack/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	playsound(src, "rustle", 50, 1, -5)
+	if(!stealthy(user))
+		playsound(src, "rustle", 50, 1, -5)
 	. = ..()
 
 /*

--- a/code/game/objects/items/weapons/storage/bible.dm
+++ b/code/game/objects/items/weapons/storage/bible.dm
@@ -165,7 +165,8 @@
 			A.reagents.add_reagent(HOLYWATER, water2holy)
 
 /obj/item/weapon/storage/bible/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	playsound(src, "rustle", 50, 1, -5)
+	if(!stealthy(user))
+		playsound(src, "rustle", 50, 1, -5)
 	. = ..()
 
 /obj/item/weapon/storage/bible/pickup(mob/living/user as mob)

--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -162,7 +162,8 @@
 	if ((src.loc == user) && (src.locked == 1))
 		to_chat(user, "<span class='warning'>[src] is locked and cannot be opened!</span>")
 	else if ((src.loc == user) && (!src.locked))
-		playsound(src, "rustle", 50, 1, -5)
+		if(!stealthy(user))
+			playsound(src, "rustle", 50, 1, -5)
 		if (user.s_active)
 			user.s_active.close(user) //Close and re-open
 		src.show_to(user)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -338,9 +338,9 @@
 			for(var/mob/M in viewers(usr, null))
 				if (M == usr)
 					to_chat(usr, "<span class='notice'>You put \the [W] into \the [src].</span>")
-				else if (M in range(1)) //If someone is standing close enough, they can tell what it is...
+				else if (M in range(1) && !stealthy(usr)) //If someone is standing close enough, they can tell what it is...
 					M.show_message("<span class='notice'>[usr] puts \the [W] into \the [src].</span>")
-				else if (W.w_class >= W_CLASS_MEDIUM) //Otherwise they can only see large or normal items from a distance...
+				else if (W.w_class >= W_CLASS_MEDIUM && !stealthy(usr)) //Otherwise they can only see large or normal items from a distance...
 					M.show_message("<span class='notice'>[usr] puts \the [W] into \the [src].</span>")
 
 
@@ -441,7 +441,8 @@
 	..()
 
 /obj/item/weapon/storage/attack_hand(mob/user as mob)
-	playsound(src, rustle_sound, 50, 1, -5)
+	if(!stealthy(user))
+		playsound(src, rustle_sound, 50, 1, -5)
 
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -102,6 +102,61 @@
 	pickpocket = 1
 
 
+//Storage pickpocket gloves! Currently only used for thief gloves, feel free to change it when you make storage gloves of any kind
+/obj/item/clothing/gloves/black/thief/storage
+	pickpocket = 2 //Will make pickpocketed items try to search for the gloves' storage to be quietly placed in
+	var/obj/item/weapon/storage/internal/hold
+	var/list/can_only_hold = new/list()
+	var/list/cant_hold = list("/obj/item/clothing/gloves/black/thief/storage") //ISHYGDDT
+	var/fits_max_w_class = W_CLASS_SMALL
+	var/max_combined_w_class = 4
+	var/storage_slots = 2 //Two gloves
+
+//Copypasted storage suit code
+/obj/item/clothing/gloves/black/thief/storage/New()
+	..()
+	hold = new (src)
+	hold.name = name //So that you don't just put things into "the storage"
+	hold.master_item = src
+	hold.can_only_hold = can_only_hold
+	hold.cant_hold = cant_hold
+	hold.fits_max_w_class = fits_max_w_class
+	hold.max_combined_w_class = max_combined_w_class
+	hold.storage_slots = storage_slots
+
+/obj/item/clothing/gloves/black/thief/storage/Destroy()
+	if(hold)
+		qdel(hold)
+		hold = null
+	return ..()
+
+/obj/item/clothing/gloves/black/thief/storage/attack_hand(mob/user)
+	if(user == src.loc)
+		return hold.attack_hand(user)
+	else
+		return ..()
+
+/obj/item/clothing/gloves/black/thief/storage/attackby(obj/item/weapon/W as obj, mob/user as mob)
+	hold.attackby(W,user)
+	return 1
+
+/obj/item/clothing/gloves/black/thief/storage/emp_act(severity)
+	hold.emp_act(severity)
+	..()
+
+/obj/item/clothing/gloves/black/thief/storage/MouseDropFrom(atom/over_object)
+	if(over_object == usr) //show container to user
+		return hold.MouseDropFrom(over_object)
+	else if(istype(over_object, /obj/structure/table)) //empty on table
+		return hold.MouseDropFrom(over_object)
+	return ..()
+
+/obj/item/clothing/gloves/black/thief/storage/AltClick(mob/user as mob)
+	if(user == src.loc)
+		return hold.attack_hand(user)
+	else
+		return ..()
+
 /obj/item/clothing/gloves/orange
 	name = "orange gloves"
 	desc = "A pair of gloves, they don't look special in any way."

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -105,24 +105,20 @@
 //Storage pickpocket gloves! Currently only used for thief gloves, feel free to change it when you make storage gloves of any kind
 /obj/item/clothing/gloves/black/thief/storage
 	pickpocket = 2 //Will make pickpocketed items try to search for the gloves' storage to be quietly placed in
-	var/obj/item/weapon/storage/internal/hold
-	var/list/can_only_hold = new/list()
-	var/list/cant_hold = list("/obj/item/clothing/gloves/black/thief/storage") //ISHYGDDT
-	var/fits_max_w_class = W_CLASS_SMALL
-	var/max_combined_w_class = 4
-	var/storage_slots = 2 //Two gloves
+	var/obj/item/weapon/storage/internal/thief_gloves/hold
+
+/obj/item/weapon/storage/internal/thief_gloves //This is the internal storage
+	name = "black gloves"
+	cant_hold = list("/obj/item/clothing/gloves/black/thief/storage") //ISHYGDDT
+	fits_max_w_class = W_CLASS_SMALL
+	max_combined_w_class = 4
+	storage_slots = 2 //Two gloves
 
 //Copypasted storage suit code
 /obj/item/clothing/gloves/black/thief/storage/New()
 	..()
 	hold = new (src)
-	hold.name = name //So that you don't just put things into "the storage"
 	hold.master_item = src
-	hold.can_only_hold = can_only_hold
-	hold.cant_hold = cant_hold
-	hold.fits_max_w_class = fits_max_w_class
-	hold.max_combined_w_class = max_combined_w_class
-	hold.storage_slots = storage_slots
 
 /obj/item/clothing/gloves/black/thief/storage/Destroy()
 	if(hold)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -653,6 +653,18 @@
 	if(istype(G))
 		return G.pickpocket
 
+//Don't forget to change this too if you universalize the gloves
+/mob/living/carbon/human/proc/place_in_glove_storage(var/obj/item/I)
+	var/obj/item/clothing/gloves/black/thief/storage/S = gloves
+	if(!I) //How did you do this
+		return 0
+	if(istype(S))
+		if(S.hold.can_be_inserted(I, 1)) //There is no check in handling item insertion
+			S.hold.handle_item_insertion(I, 1)
+		else
+			put_in_hands(I)
+
+
 /mob/living/carbon/human/abiotic(var/full_body = 0)
 	for(var/obj/item/I in held_items)
 		if(I.abstract)

--- a/code/modules/mob/living/carbon/stripping.dm
+++ b/code/modules/mob/living/carbon/stripping.dm
@@ -25,8 +25,11 @@
 
 		drop_from_inventory(target_item)
 		target_item.stripped(src, user)
-		if(pickpocket)
-			user.put_in_hands(target_item)
+		var/mob/living/carbon/human/H = user
+		if(pickpocket == 2) //Search for the glove's storage suits and see if they are full as only the thief storage gloves use this
+			H.place_in_glove_storage(target_item) //Defined in human.dm
+		else if(pickpocket)
+			H.put_in_hands(target_item)
 
 		return TRUE
 


### PR DESCRIPTION
The imprinter might or might not come depending if I get sprites.

Contents:
- Added **Pickpocket gloves with storage**, they can hold up to two small items and pickpocketing with these gloves will automatically make the stolen item go into the gloves. Available for 7 TC, or 4 if you're an Assistant
- Original pickpocket gloves have been made cheaper, 4 TC by default and 2 if you're an Assistant. Good if you want to field other people with stealing implements.
- **Pickpocketing gloves of any kind will make you more quiet**, that means you won't make any sound to anyone when you shuffle your items around. Now you can steal something and put it in your backpack without as much as a noise or indication it ever happened.

Code review appreciated because I feel it's too much spaghetti.
It's all been tested.

:cl:
 * rscadd: Added new pickpocket gloves that come with their own storage to place stolen items in automatically.
 * tweak: Regular pickpocket gloves have been made cheaper.
 * tweak: Being a pickpocket of any kind will make your object shuffling inaudible.