### PR TITLE
Gun recoil no longer shakes your screen

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -240,6 +240,9 @@
 		play_firesound(user, reflex)
 		return
 
+	if(recoil)
+		spawn()
+			shake_camera(user, recoil + 1, recoil)
 		if(user.locked_to && isobj(user.locked_to) && !user.locked_to.anchored )
 			var/direction = get_dir(user,target)
 			spawn()

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -240,9 +240,6 @@
 		play_firesound(user, reflex)
 		return
 
-	if(recoil)
-		spawn()
-			shake_camera(user, recoil + 1, recoil)
 		if(user.locked_to && isobj(user.locked_to) && !user.locked_to.anchored )
 			var/direction = get_dir(user,target)
 			spawn()

--- a/code/modules/projectiles/guns/energy/gravitywell.dm
+++ b/code/modules/projectiles/guns/energy/gravitywell.dm
@@ -7,7 +7,6 @@
 	slot_flags = SLOT_BELT
 	origin_tech = Tc_MATERIALS + "=7;" + Tc_BLUESPACE + "=5;" + Tc_MAGNETS + "=5"
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/guns_experimental.dmi', "right_hand" = 'icons/mob/in-hand/right/guns_experimental.dmi')
-	recoil = 0
 	flags = FPRINT
 	w_class = W_CLASS_MEDIUM
 	fire_delay = 0

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -715,7 +715,6 @@ obj/item/weapon/gun/energy/ricochet/Fire(atom/target as mob|obj|turf|area, mob/l
 	charge_cost = 100
 	cell_type = "/obj/item/weapon/cell"
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/guns_experimental.dmi', "right_hand" = 'icons/mob/in-hand/right/guns_experimental.dmi')
-	recoil = 1
 	var/firelevel = SPUR_FULL_POWER
 
 /obj/item/weapon/gun/energy/polarstar/isHandgun()
@@ -773,13 +772,10 @@ obj/item/weapon/gun/energy/ricochet/Fire(atom/target as mob|obj|turf|area, mob/l
 	switch(firelevel)
 		if(SPUR_HIGH_POWER,SPUR_FULL_POWER)
 			fire_sound = 'sound/weapons/spur_high.ogg'
-			recoil = 1
 		if(SPUR_MEDIUM_POWER)
 			fire_sound = 'sound/weapons/spur_medium.ogg'
-			recoil = 0
 		if(SPUR_LOW_POWER,SPUR_NO_POWER)
 			fire_sound = 'sound/weapons/spur_low.ogg'
-			recoil = 0
 	return
 
 /obj/item/weapon/gun/energy/polarstar/update_icon()

--- a/code/modules/projectiles/guns/hookshot.dm
+++ b/code/modules/projectiles/guns/hookshot.dm
@@ -8,7 +8,6 @@
 	origin_tech = Tc_MATERIALS + "=2;" + Tc_ENGINEERING + "=3;" + Tc_MAGNETS + "=2"
 	mech_flags = null // So it can be scanned by the Device Analyser
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/guns_experimental.dmi', "right_hand" = 'icons/mob/in-hand/right/guns_experimental.dmi')
-	recoil = 0
 	flags = FPRINT
 	w_class = W_CLASS_MEDIUM
 	fire_delay = 0

--- a/code/modules/projectiles/guns/lawgiver.dm
+++ b/code/modules/projectiles/guns/lawgiver.dm
@@ -45,7 +45,6 @@
 	fire_sound = 'sound/weapons/Gunshot_c20.ogg'
 	projectile_type = /obj/item/projectile/bullet/midbullet/lawgiver
 	fire_delay = 0
-	recoil = TRUE
 	activation_message = "RAPID FIRE."
 	ammo_casing_type = /obj/item/ammo_casing/a12mm
 
@@ -57,7 +56,6 @@
 	fire_sound = 'sound/weapons/shotgun.ogg'
 	projectile_type = /obj/item/projectile/flare
 	fire_delay = 5
-	recoil = TRUE
 	activation_message = "FLARE."
 	ammo_casing_type = /obj/item/ammo_casing/shotgun/flare
 
@@ -69,7 +67,6 @@
 	fire_sound = 'sound/weapons/elecfire.ogg'
 	projectile_type = /obj/item/projectile/bullet/gyro
 	fire_delay = 5
-	recoil = TRUE
 	activation_message = "HIGH EXPLOSIVE."
 	ammo_casing_type = /obj/item/ammo_casing/a75
 
@@ -81,7 +78,6 @@
 	fire_sound = 'sound/weapons/gatling_fire.ogg'
 	projectile_type = /obj/item/projectile/bullet/midbullet/bouncebullet/lawgiver
 	fire_delay = 5
-	recoil = TRUE
 	activation_message = "RICOCHET."
 	ammo_casing_type = /obj/item/ammo_casing/a12mm/bounce
 
@@ -300,15 +296,12 @@ var/list/lawgiver_modes = list(
 
 /obj/item/weapon/gun/lawgiver/proc/rapidFire(atom/target as mob|obj|turf|area, mob/living/user as mob|obj, params, struggle = 0) //Burst fires don't work well except by calling Fire() multiple times
 	rapidFirecheck = 1
-	recoil = 1
 	for (var/i = 1; i <= 3; i++)
 		if(i>1 && !in_chamber)
 			in_chamber = new projectile_type(src)
 		Fire(target, user, params, struggle)
-		recoil = 0
 		silenced = 1
 		fire_volume *= 5
-	recoil = 1
 	silenced = 0
 	fire_volume /= 5
 	rapidFirecheck = 0

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -11,7 +11,7 @@
 	w_class = W_CLASS_MEDIUM
 	starting_materials = list(MAT_IRON = 1000)
 	w_type = RECYK_METAL
-	recoil = 1
+	recoil = 0
 	var/ammo_type = "/obj/item/ammo_casing/a357"
 	var/list/loaded = list()
 	var/max_shells = 7 //only used by guns with no magazine

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -256,7 +256,6 @@
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/guninhands_left.dmi', "right_hand" = 'icons/mob/in-hand/right/guninhands_right.dmi')
 	item_state = "vector"
 	w_class = W_CLASS_MEDIUM
-	recoil = 0 //Super V tech.
 	/*max_shells = 25  I'm sure someone will put a mag larger than 25 in here some day so lets leave this open ended.*/
 	caliber = POINT380 //Its not a list but IT WORKS ON MY MACHINE.
 	ammo_type = "/obj/item/ammo_casing/c380auto"

--- a/code/modules/projectiles/guns/projectile/banannon.dm
+++ b/code/modules/projectiles/guns/projectile/banannon.dm
@@ -5,7 +5,6 @@
 	icon_state = "banannon"
 	item_state = "banannon"
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/guninhands_left.dmi', "right_hand" = 'icons/mob/in-hand/right/guninhands_right.dmi')
-	recoil = 0
 	slot_flags = SLOT_BELT
 	flags = FPRINT
 	w_class = W_CLASS_MEDIUM

--- a/code/modules/projectiles/guns/projectile/constructable/flamethrower.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/flamethrower.dm
@@ -22,7 +22,6 @@
 	fire_sound = null
 	conventional_firearm = 0
 	silenced = 1
-	recoil = 0
 	var/status = 0
 	var/throw_percent = 20
 	var/lit = 0	//on or off

--- a/code/modules/projectiles/guns/projectile/flare.dm
+++ b/code/modules/projectiles/guns/projectile/flare.dm
@@ -13,7 +13,6 @@
 	starting_materials = list(MAT_IRON = 15000, MAT_GLASS = 7500)
 	w_type = RECYK_METAL
 	force = 4
-	recoil = 1
 	fire_delay = 10
 	flags = FPRINT
 	siemens_coefficient = 1
@@ -24,7 +23,6 @@
 
 /obj/item/weapon/gun/projectile/flare/syndicate
 	desc = "An illegal flare gun with a modified hammer, allowing it to fire shotgun shells and flares at dangerous velocities."
-	recoil = 3
 	fire_delay = 5 //faster, because it's also meant to be a weapon
 	caliber = list(GAUGEFLARE = 1, GAUGE12 = 1)
 	origin_tech = Tc_COMBAT + "=4;" + Tc_MATERIALS + "=2;" + Tc_SYNDICATE + "=2"

--- a/code/modules/projectiles/guns/projectile/mahoguny.dm
+++ b/code/modules/projectiles/guns/projectile/mahoguny.dm
@@ -6,7 +6,6 @@
 	item_state = "mahoguny"
 	origin_tech = Tc_COMBAT + "=5;" + Tc_BIOTECH + "=6"
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/guninhands_left.dmi', "right_hand" = 'icons/mob/in-hand/right/guninhands_right.dmi')
-	recoil = 1
 	slot_flags = SLOT_BELT
 	flags = FPRINT
 	w_class = W_CLASS_MEDIUM

--- a/code/modules/projectiles/guns/projectile/minigun.dm
+++ b/code/modules/projectiles/guns/projectile/minigun.dm
@@ -6,7 +6,6 @@
 	item_state = "minigun0"
 	origin_tech = Tc_MATERIALS + "=4;" + Tc_COMBAT + "=6"
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/guns_experimental.dmi', "right_hand" = 'icons/mob/in-hand/right/guns_experimental.dmi')
-	recoil = 1
 	slot_flags = null
 	flags = FPRINT | TWOHANDABLE | SLOWDOWN_WHEN_CARRIED
 	slowdown = MINIGUN_SLOWDOWN_NONWIELDED
@@ -107,7 +106,6 @@
 	icon_state = "beegun"
 	item_state = "beegun0"
 	origin_tech = Tc_MATERIALS + "=4;" + Tc_COMBAT + "=6;" + Tc_BIOTECH + "=5"
-	recoil = 0
 	var/base_icon_state = "beegun"
 	var/bug_ammo = /obj/item/projectile/bullet/beegun
 

--- a/code/modules/projectiles/guns/projectile/osipr.dm
+++ b/code/modules/projectiles/guns/projectile/osipr.dm
@@ -11,7 +11,6 @@
 	slot_flags = SLOT_BELT
 	origin_tech = Tc_MATERIALS + "=5;" + Tc_COMBAT + "=5;" + Tc_MAGNETS + "=4;" + Tc_POWERSTORAGE + "=3"
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/guns_experimental.dmi', "right_hand" = 'icons/mob/in-hand/right/guns_experimental.dmi')
-	recoil = 1
 	fire_delay = 0
 	w_class = W_CLASS_MEDIUM
 	fire_sound = 'sound/weapons/osipr_fire.ogg'

--- a/code/modules/projectiles/guns/projectile/rocketlauncher.dm
+++ b/code/modules/projectiles/guns/projectile/rocketlauncher.dm
@@ -97,7 +97,6 @@
 	item_state = null
 	origin_tech = Tc_MATERIALS + "=5;" + Tc_COMBAT + "=6;" + Tc_PROGRAMMING + "=4"
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/guns_experimental.dmi', "right_hand" = 'icons/mob/in-hand/right/guns_experimental.dmi')
-	recoil = 1
 	flags = FPRINT
 	slot_flags = SLOT_BACK
 	w_class = W_CLASS_LARGE

--- a/code/modules/projectiles/guns/projectile/roulette.dm
+++ b/code/modules/projectiles/guns/projectile/roulette.dm
@@ -13,7 +13,6 @@
 	caliber = null
 	ammo_type = null
 	fire_sound = null
-	recoil = 1
 	conventional_firearm = 0
 	var/shots_left = 6
 	var/infinite = 0
@@ -83,11 +82,6 @@
 	if(!in_chamber || shots_left < 1)
 		click_empty(user)
 		return
-
-	if(istype(in_chamber, /obj/item/projectile/bullet))
-		recoil = 1
-	else
-		recoil = 0
 
 	if(user && user.client && user.client.gun_mode && !(A in target))
 		PreFire(A,user,params, "struggle" = struggle) //They're using the new gun system, locate what they're aiming at.

--- a/code/modules/projectiles/guns/projectile/siren.dm
+++ b/code/modules/projectiles/guns/projectile/siren.dm
@@ -6,7 +6,6 @@
 	item_state = "siren"
 	origin_tech = Tc_COMBAT + "=5"
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/guninhands_left.dmi', "right_hand" = 'icons/mob/in-hand/right/guninhands_right.dmi')
-	recoil = 1
 	slot_flags = SLOT_BELT
 	flags = FPRINT | NOREACT | OPENCONTAINER
 	w_class = W_CLASS_MEDIUM
@@ -54,12 +53,10 @@
 		to_chat(user, "<span class='info'>You set \the [src] to fire hard liquid.</span>")
 		desc = initial(desc)
 		fire_sound = initial(fire_sound)
-		recoil = 1
 	else
 		to_chat(user, "<span class='info'>You set \the [src] to fire soft liquid.</span>")
 		desc = "The most efficient ranged mass reagent delivery system there is."
 		fire_sound = 'sound/items/egg_squash.ogg'
-		recoil = 0
 
 /obj/item/weapon/gun/siren/afterattack(atom/A as mob|obj|turf|area, mob/living/user as mob|obj, flag, params, struggle = 0)
 	if(flag)
@@ -125,7 +122,6 @@
 	item_state = "gun"
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/items_lefthand.dmi', "right_hand" = 'icons/mob/in-hand/right/items_righthand.dmi')
 	origin_tech = Tc_COMBAT + "=1"
-	recoil = 0
 	flags = FPRINT | OPENCONTAINER
 	fire_sound = 'sound/items/egg_squash.ogg'
 	max_reagents = 200

--- a/code/modules/projectiles/guns/projectile/stickylauncher.dm
+++ b/code/modules/projectiles/guns/projectile/stickylauncher.dm
@@ -9,7 +9,6 @@
 	slot_flags = SLOT_BELT
 	origin_tech = Tc_MATERIALS + "=3;" + Tc_COMBAT + "=4;" + Tc_PROGRAMMING + "=3"
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/guns_experimental.dmi', "right_hand" = 'icons/mob/in-hand/right/guns_experimental.dmi')
-	recoil = 1
 	flags = FPRINT
 	w_class = W_CLASS_MEDIUM
 	fire_delay = 2

--- a/code/modules/projectiles/guns/special.dm
+++ b/code/modules/projectiles/guns/special.dm
@@ -7,7 +7,6 @@
 	slot_flags = SLOT_BELT
 	origin_tech = Tc_MATERIALS + "=7;" + Tc_BLUESPACE + "=6;" + Tc_MAGNETS + "=5"
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/guns_experimental.dmi', "right_hand" = 'icons/mob/in-hand/right/guns_experimental.dmi')
-	recoil = 0
 	flags = FPRINT
 	w_class = W_CLASS_MEDIUM
 	fire_delay = 0

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -359,7 +359,6 @@ obj/item/projectile/bullet/suffocationbullet
 			if(M_turf && (M_turf.z == starting.z))
 				M.playsound_local(starting, 'sound/weapons/hecate_fire_far.ogg', 25, 1)
 	for (var/mob/living/carbon/human/H in range(src,1))
-		shake_camera(H, 3, 2)
 		if(!H.earprot())
 			H.Knockdown(2)
 			H.Stun(2)

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -359,6 +359,7 @@ obj/item/projectile/bullet/suffocationbullet
 			if(M_turf && (M_turf.z == starting.z))
 				M.playsound_local(starting, 'sound/weapons/hecate_fire_far.ogg', 25, 1)
 	for (var/mob/living/carbon/human/H in range(src,1))
+		shake_camera(H, 3, 2)
 		if(!H.earprot())
 			H.Knockdown(2)
 			H.Stun(2)


### PR DESCRIPTION
I don't like my aiming going XCOM when I fire a revolver. Recoil itself still exists but it mostly affects inaccuracy in case the gun is defective. It's not that I hate recoil as a concept but BYOND is limited enough that the closest thing to a proper recoil was making your screen boogie whenever you fired a gun
:cl:
 * tweak: Guns with recoil will no longer shake your screen when fired.