### PR TITLE
Properly adds hiding hair to the given items, can no longer two hand helmets

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -185,7 +185,6 @@ var/MAX_EXPLOSION_RANGE = 14
 #define INVULNERABLE 8
 #define HEAR		16 // This flag is necessary to give an item (or mob) the ability to hear spoken messages! Mobs without a client still won't hear anything unless given HEAR_ALWAYS
 #define HEAR_ALWAYS 32 // Assign a virtualhearer to the mob even when no client is controlling it. (technically not an item flag, but related to the above)
-#define HIDEHAIRCOMPLETELY 64
 
 #define TWOHANDABLE	64
 #define MUSTTWOHAND	128
@@ -315,6 +314,7 @@ var/MAX_EXPLOSION_RANGE = 14
 
 
 // bitflags for invisibility
+// Used in body_parts_covered
 
 #define HIDEGLOVES			HANDS
 #define HIDEJUMPSUIT		(ARMS|LEGS|FULL_TORSO)

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_items.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_items.dm
@@ -984,9 +984,8 @@ var/list/arcane_tomes = list()
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/cultstuff.dmi', "right_hand" = 'icons/mob/in-hand/right/cultstuff.dmi')
 	icon_state = "culthood"
 	desc = "A hood worn by the followers of Nar-Sie."
-	flags = FPRINT|HIDEHAIRCOMPLETELY
 	armor = list(melee = 30, bullet = 10, laser = 10,energy = 5, bomb = 10, bio = 25, rad = 0)
-	body_parts_covered = EARS|HEAD
+	body_parts_covered = EARS|HEAD|HIDEHAIR
 	siemens_coefficient = 0
 	heat_conductivity = SPACESUIT_HEAT_CONDUCTIVITY
 	species_fit = list(VOX_SHAPED)

--- a/code/datums/gamemode/factions/legacy_cult/cult_items.dm
+++ b/code/datums/gamemode/factions/legacy_cult/cult_items.dm
@@ -42,9 +42,8 @@
 	name = "cult hood"
 	icon_state = "culthood"
 	desc = "A hood worn by the followers of Nar-Sie."
-	flags = FPRINT|HIDEHAIRCOMPLETELY
 	armor = list(melee = 30, bullet = 10, laser = 5,energy = 5, bomb = 0, bio = 0, rad = 0)
-	body_parts_covered = EARS|HEAD
+	body_parts_covered = EARS|HEAD|HIDEHAIR
 	siemens_coefficient = 0
 	heat_conductivity = SPACESUIT_HEAT_CONDUCTIVITY
 

--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -622,7 +622,6 @@
 
 	species_fit = list(VOX_SHAPED)
 
-	flags = HIDEHAIRCOMPLETELY
 	body_parts_covered = FULL_HEAD
 	w_class = W_CLASS_LARGE
 	slot_flags = SLOT_HEAD

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -20,13 +20,13 @@
 		accessories.Remove(A)
 		qdel(A)
 	..()
-	
+
 /obj/item/clothing/CtrlClick(var/mob/user)
 	if(isturf(loc))
 		return ..()
 	if(isliving(user) && !user.incapacitated() && user.Adjacent(src) && accessories.len)
 		removeaccessory()
-	
+
 /obj/item/clothing/examine(mob/user)
 	..()
 	for(var/obj/item/clothing/accessory/A in accessories)
@@ -484,7 +484,7 @@
 	if(user.equip_to_slot_if_possible(src, slot_shoes))
 		user.visible_message("<span class='notice'>[user] kicks \the [src] and slips them on!</span>", "<span class='notice'>You kick \the [src] and slip them on!</span>")
 	else
-		..()	
+		..()
 
 /obj/item/clothing/shoes/clean_blood()
 	. = ..()
@@ -527,13 +527,12 @@
 	name = "Space helmet"
 	icon_state = "space"
 	desc = "A special helmet designed for work in a hazardous, low-pressure environment."
-	flags = FPRINT|HIDEHAIRCOMPLETELY
 	pressure_resistance = 5 * ONE_ATMOSPHERE
 	item_state = "space"
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/spacesuits.dmi', "right_hand" = 'icons/mob/in-hand/right/spacesuits.dmi')
 	permeability_coefficient = 0.01
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 100, rad = 50)
-	body_parts_covered = FULL_HEAD|BEARD
+	body_parts_covered = FULL_HEAD|HIDEHAIR
 	siemens_coefficient = 0.9
 	heat_conductivity = SPACESUIT_HEAT_CONDUCTIVITY
 	species_restricted = list("exclude","Diona","Muton")

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -42,8 +42,7 @@
 	name = "chaplain's hood"
 	desc = "It's hood that covers the head. It keeps you warm during the space winters."
 	icon_state = "chaplain_hood"
-	flags = FPRINT|HIDEHAIRCOMPLETELY
-	body_parts_covered = EARS|HEAD
+	body_parts_covered = EARS|HEAD|HIDEHAIR
 	siemens_coefficient = 0.9
 
 //Chaplain
@@ -51,8 +50,7 @@
 	name = "nun hood"
 	desc = "Maximum piety in this star system."
 	icon_state = "nun_hood"
-	flags = FPRINT|HIDEHAIRCOMPLETELY
-	body_parts_covered = EARS|HEAD
+	body_parts_covered = EARS|HEAD|HIDEHAIR
 	siemens_coefficient = 0.9
 
 //Mime
@@ -75,8 +73,7 @@
 	name = "surgical cap"
 	desc = "A cap surgeons wear during operations. Keeps their hair from tickling your internal organs."
 	icon_state = "surgcap_blue"
-	flags = FPRINT|HIDEHAIRCOMPLETELY
-	body_parts_covered = EARS|HEAD
+	body_parts_covered = EARS|HEAD|HIDEHAIR
 
 /obj/item/clothing/head/surgery/purple
 	desc = "A cap surgeons wear during operations. Keeps their hair from tickling your internal organs. This one is deep purple."

--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -82,8 +82,7 @@
 	name = "hastur's hood"
 	desc = "It's unspeakably stylish."
 	icon_state = "hasturhood"
-	flags = FPRINT|HIDEHAIRCOMPLETELY
-	body_parts_covered = EARS|HEAD
+	body_parts_covered = EARS|HEAD|HIDEHAIR
 
 /obj/item/clothing/head/nursehat
 	name = "nurse's hat"
@@ -289,8 +288,7 @@
 	desc = "Eeeee~heheheheheheh!"
 	icon_state = "witch"
 	item_state = "witch"
-	flags = FPRINT|HIDEHAIRCOMPLETELY
-	body_parts_covered = EARS|HEAD
+	body_parts_covered = EARS|HEAD|HIDEHAIR
 	siemens_coefficient = 2.0
 
 /obj/item/clothing/head/chicken
@@ -298,8 +296,7 @@
 	desc = "Bkaw!"
 	icon_state = "chickenhead"
 	item_state = "chickensuit"
-	flags = FPRINT|HIDEHAIRCOMPLETELY
-	body_parts_covered = FULL_HEAD|BEARD
+	body_parts_covered = FULL_HEAD|BEARD|HIDEHAIR
 	siemens_coefficient = 2.0
 
 /obj/item/clothing/head/bearpelt
@@ -307,8 +304,7 @@
 	desc = "Not as fuzzy as the real thing."
 	icon_state = "bearpelt"
 	item_state = "bearpelt"
-	flags = FPRINT|HIDEHAIRCOMPLETELY
-	body_parts_covered = EARS|HEAD
+	body_parts_covered = EARS|HEAD|HIDEHAIR
 	siemens_coefficient = 2.0
 
 /obj/item/clothing/head/bearpelt/real
@@ -330,8 +326,7 @@
 	icon_state = "xenos"
 	item_state = "xenos_helm"
 	desc = "A helmet made out of chitinous alien hide."
-	flags = FPRINT|HIDEHAIRCOMPLETELY
-	body_parts_covered = FULL_HEAD|BEARD
+	body_parts_covered = FULL_HEAD|BEARD|HIDEHAIR
 	siemens_coefficient = 2.0
 
 /obj/item/clothing/head/batman

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -75,7 +75,7 @@
 	desc = "LOADSAMONEY"
 	icon_state = "balaclava"
 	item_state = "balaclava"
-	flags = FPRINT|HIDEHAIRCOMPLETELY
+	flags = FPRINT
 	body_parts_covered = HIDEHAIR | MOUTH
 	w_class = W_CLASS_SMALL
 	species_fit = list(VOX_SHAPED, GREY_SHAPED)

--- a/code/modules/clothing/spacesuits/alien.dm
+++ b/code/modules/clothing/spacesuits/alien.dm
@@ -8,7 +8,7 @@
 	item_state = "rig_helm"
 	_color = "unathi_breacher"
 	clothing_flags = PLASMAGUARD
-	
+
 /obj/item/clothing/suit/space/unathi/breacher
 	name = "unathi breacher armor"
 	desc = "Some sort of ancient Unathi power suit with ridiculous armor plating."
@@ -69,7 +69,7 @@
 /obj/item/clothing/head/helmet/space/unathi/soghun
 	name = "unathi soghun helmet"
 	desc = "A Unathi helmet designed after ancient soghun outfits."
-	armor = list(melee = 50, bullet = 15, laser = 50, energy = 10, bomb = 25, bio = 0, rad = 0)	
+	armor = list(melee = 50, bullet = 15, laser = 50, energy = 10, bomb = 25, bio = 0, rad = 0)
 	species_restricted = list(UNATHI_SHAPED)
 	species_fit = list(UNATHI_SHAPED)
 	icon_state = "unathi_soghun"
@@ -333,7 +333,7 @@
 	icon_state = "vox-civ-assistant"
 	item_state = "vox-pressure-normal"
 	desc = "A very alien-looking helmet for vox crewmembers."
-	flags = FPRINT|HIDEHAIRCOMPLETELY //Flags need updating from inheritance above
+	flags = FPRINT //Flags need updating from inheritance above
 	armor = list(melee = 5, bullet = 5, laser = 5, energy = 5, bomb = 0, bio = 100, rad = 25)
 	pressure_resistance = 5 * ONE_ATMOSPHERE
 	eyeprot = 0
@@ -725,8 +725,8 @@
 	..()
 	if(tank)
 		to_chat(user, "<span class = 'notice'>It has a [bicon(tank)][tank] attached to the back.</span>")
-		
-		
+
+
 /obj/item/clothing/head/helmet/space/skrell/black
 	name = "skrell combat helmet"
 	desc = "a military Skrell space helmet."
@@ -759,7 +759,7 @@
 		/obj/item/weapon/legcuffs/bolas,
 	)
 	slowdown = HARDSUIT_SLOWDOWN_LOW
-	
+
 /obj/item/clothing/head/helmet/space/skrell/white
 	name = "skrell space helmet"
 	desc = "a civilian Skrell space helmet."

--- a/code/modules/clothing/suits/wintercoat.dm
+++ b/code/modules/clothing/suits/wintercoat.dm
@@ -31,8 +31,7 @@
 	name = "winter hood"
 	desc = "A hood attached to a heavy winter jacket."
 	icon_state = "whood"
-	body_parts_covered = HIDEHEADHAIR
-	flags = HIDEHAIRCOMPLETELY
+	body_parts_covered = HIDEHAIR
 	heat_conductivity = SNOWGEAR_HEAT_CONDUCTIVITY
 	var/obj/item/clothing/suit/storage/wintercoat/coat
 

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -791,5 +791,4 @@
 	_color = "skelesuit"
 	species_fit = list(VOX_SHAPED)
 	clothing_flags = ONESIZEFITSALL
-	flags = HIDEHAIRCOMPLETELY | HIDEBEARDHAIR
-	body_parts_covered = FULL_HEAD|BEARD
+	body_parts_covered = FULL_HEAD|BEARD|HIDEHAIR

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -315,8 +315,7 @@ var/global/list/damage_icon_parts = list()
 	var/icon/face_standing	= new /icon('icons/mob/human_face.dmi',"bald_s")
 	var/hair_suffix = check_hidden_head_flags(HIDEHEADHAIR) ? "s2" : "s" // s2 = cropped icon
 
-	if(my_appearance.f_style && !(check_hidden_head_flags(HIDEBEARDHAIR)||\
-		src.w_uniform && (src.w_uniform.body_parts_covered & HIDEBEARDHAIR)) )//you may be wondering why a uniform check. this exist for body suits like the skelesuit
+	if(my_appearance.f_style && !(check_hidden_flags(get_clothing_items(),HIDEBEARDHAIR)))
 		var/datum/sprite_accessory/facial_hair_style = facial_hair_styles_list[my_appearance.f_style]
 		if((facial_hair_style) && (src.species.name in facial_hair_style.species_allowed))
 			var/icon/facial_s = new/icon("icon" = facial_hair_style.icon, "icon_state" = "[facial_hair_style.icon_state]_s")
@@ -326,9 +325,7 @@ var/global/list/damage_icon_parts = list()
 //		else
 			//warning("Invalid my_appearance.f_style for [species.name]: [my_appearance.f_style]")
 
-	if(my_appearance.h_style && !(src.head && ( src.head.flags & HIDEHAIRCOMPLETELY ) || \
-								  src.wear_mask && (src.wear_mask.body_parts_covered & HIDEHEADHAIR) ||\
-								  src.w_uniform && (src.w_uniform.body_parts_covered & HIDEHEADHAIR)) ) //ditto the comment above
+	if(my_appearance.h_style && !(check_hidden_flags(get_clothing_items(),HIDEHEADHAIR)))
 		var/datum/sprite_accessory/hair_style = hair_styles_list[my_appearance.h_style]
 		if((hair_style) && (src.species.name in hair_style.species_allowed))
 			var/icon/hair_s = new/icon("icon" = hair_style.icon, "icon_state" = "[hair_style.icon_state]_[hair_suffix]")
@@ -336,7 +333,6 @@ var/global/list/damage_icon_parts = list()
 				hair_s.Blend(rgb(my_appearance.r_hair, my_appearance.g_hair, my_appearance.b_hair), ICON_ADD)
 			if(hair_style.additional_accessories)
 				hair_s.Blend(icon("icon" = hair_style.icon, "icon_state" = "[hair_style.icon_state]_acc"), ICON_OVERLAY)
-
 			face_standing.Blend(hair_s, ICON_OVERLAY)
 //		else
 			//warning("Invalid my_appearance.h_style for [species.name]: [my_appearance.h_style]")


### PR DESCRIPTION
In #24900 it was pointed out that hidehaircompletely was interacting with twohandable, due to sharing the same bit

Turns out it was implemented in a way that was already implemented.

This PR removes the bad bitflag, uses the hide hair flag that was already in place, and fixes the initial issue that was causing it (Only mask and uniform slots were being checked if they could hide your hair). Now, it checks every piece of uniform you are wearing.