### PR TITLE
Fixes smoke (or colorful syndrome?) runtime

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -124,7 +124,8 @@
 		if(L)
 			L.metabolize_reagent(src.id, custom_metabolism)
 			return
-	holder.remove_reagent(src.id, custom_metabolism) // If we aren't human, we don't have a liver, so just metabolize it the old fashioned way.
+	if(holder)
+		holder.remove_reagent(src.id, custom_metabolism) // If we aren't human, we don't have a liver, so just metabolize it the old fashioned way.
 
 /datum/reagent/proc/on_mob_life(var/mob/living/M, var/alien)
 	set waitfor = 0


### PR DESCRIPTION
[bugfix] [system]

I don't know what the fuck holder is supposed to do (the container of the reagents?) but I guess it's null for smoke so let's check for that.

```
[01:47:08] Runtime in Chemistry-Reagents.dm,127: Cannot execute null.remove reagent().
  proc name: metabolize (/datum/reagent/proc/metabolize)
  src: Smoke (/datum/reagent/paismoke)
  call stack:
  Smoke (/datum/reagent/paismoke): metabolize(the mouse (353) (/mob/living/simple_animal/mouse/common))
  /datum/reagents (/datum/reagents): metabolize(the mouse (353) (/mob/living/simple_animal/mouse/common), null)
  the mouse (353) (/mob/living/simple_animal/mouse/common): Life()
  the mouse (353) (/mob/living/simple_animal/mouse/common): Life()
  Mob (/datum/subsystem/mob): fire(0)
  Mob (/datum/subsystem/mob): ignite(0)
  Master (/datum/controller/master): RunQueue()
  Master (/datum/controller/master): Loop()
  Master (/datum/controller/master): StartProcessing()
```
