### PR TITLE
Simplemobs will no longer make sounds twice simultaneously

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -125,9 +125,9 @@
 				heart.plane = ABOVE_HUMAN_PLANE
 				flick_overlay(heart, list(M.client), 20)
 				emote("me", EMOTE_AUDIBLE, "purrs.")
-				playsound(loc, 'sound/voice/catpurr.ogg', 80, 1)
+				playsound(loc, 'sound/voice/catpurr.ogg', 50, 1)
 			if(I_HURT)
-				playsound(loc, 'sound/voice/cathiss.ogg', 80, 1)
+				playsound(loc, 'sound/voice/cathiss.ogg', 50, 1)
 				emote("me", EMOTE_AUDIBLE, "hisses.")
 
 /mob/living/simple_animal/cat/snek/react_to_touch(mob/M)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -366,9 +366,7 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 
 			switch(mode)
 				if(1)
-					say(pick(speak))
-					if(emote_sound.len)
-						playsound(loc, "[pick(emote_sound)]", 80, 1)
+					say(pick(speak)) // The sound is in say_quote
 				if(2)
 					emote("me", MESSAGE_HEAR, "[pick(emote_hear)].")
 					if(emote_sound.len)


### PR DESCRIPTION
[bugfix][oversight][tested]

Lowers the volume of the cats emotes from 80 to 50, as otatoh submitted a worry that they were too loud. Corrects the long overdue bug in simplemob code that made them emote_sound TWICE if they also spoke.

Can you believe this bug has been here since _**MAY**_?

:cl:
 * bugfix: Simplemobs no longer make two sounds simultaneously.
 * tweak: Cat volumes are slightly lower now.