### PR TITLE
Puts a decent attack cooldown on roombas.

### DIFF
--- a/code/game/machinery/bots/cleanbot.dm
+++ b/code/game/machinery/bots/cleanbot.dm
@@ -46,7 +46,7 @@
 	var/next_dest_loc
 
 	var/coolingdown = FALSE
-	var/attackcooldown = 1 SECONDS // for admin cancer
+	var/attackcooldown = 10 SECONDS // for admin cancer
 
 	can_take_pai = TRUE
 


### PR DESCRIPTION
[bugfix][tweak][discussion]
Closes #23154
Closes #23203

So, I made pAI controlled roombas which wasn't bad but very quickly we learned that if you put a fork on them they become MURDERBOT6000 and can crit you really, really fast as well as being super mobile and agile and easy to replace/recover the pAI.

The fun unfortunately ends with this: An attack cooldown that's 10 seconds long. I've tested it by running myself over intentionally trying to kill the human and only did 10-20 damage in a period of several minutes, much like getting hit by a rogue laser blast or sudden toolboxing.

This would be fine, BUT we have the issue of several roombas not sharing attack cooldowns so you can still theoretically make an army of the bastards and they will prong/burn you with cooldowns on each unit. They die in 5 kicks, though, but if you have like 20 on the same tile you're gonna have a bad time. I assume nobody will accumulate 20 pAIs to make this happen. _Haha...._

As a sidenote, I think all pAI bots have spacewalk and no battery life. I should fix the spacewalking, at least.

:cl:
 * tweak: Battle roombas now have a 10 second attack cooldown.