### PR TITLE
Admin titles shouldn't show up in ahelps when invisimin'd anymore

### DIFF
--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -108,6 +108,7 @@
 				recieve_color = "red"
 			if(holder.fakekey)
 				recieve_pm_type = "Admin"
+				send_pm_type = "Admin"
 			else
 				send_pm_type = holder.rank + " "
 				recieve_pm_type = holder.rank

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -107,7 +107,6 @@
 			else
 				recieve_color = "red"
 			if(holder.fakekey)
-				send_pm_type = " "
 				recieve_pm_type = "Admin"
 			else
 				send_pm_type = holder.rank + " "

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -106,8 +106,12 @@
 				recieve_color = "maroon"
 			else
 				recieve_color = "red"
-			send_pm_type = holder.rank + " "
-			recieve_pm_type = holder.rank
+			if(holder.fakekey)
+				send_pm_type = " "
+				recieve_pm_type = "Admin"
+			else
+				send_pm_type = holder.rank + " "
+				recieve_pm_type = holder.rank
 
 	else if(!C.holder)
 		to_chat(src, "<span class='red'>Error: Admin-PM: Non-admin to non-admin PM communication is forbidden.</span>")


### PR DESCRIPTION
They're supposed to show up as "Admin" now
:cl:
 * bugfix: Custom admin titles when adminhelped don't show up anymore if the admins are invisible.