### PR TITLE
Telescience computers no longer create free infinite 1000 unit cells.

### DIFF
--- a/code/modules/telesci/telesci_computer.dm
+++ b/code/modules/telesci/telesci_computer.dm
@@ -52,7 +52,8 @@
 	y_off = rand(-10,10)
 	x_player_off = 0
 	y_player_off = 0
-	cell = new/obj/item/weapon/cell(src)
+	//cell = new/obj/item/weapon/cell(src) // Exploitable: Spawns many cells that can be recycled.
+	//This means new telescience computers won't have a cell, but most maps provide easy cell access.
 
 /obj/machinery/computer/telescience/initialize()
 	..()

--- a/code/modules/telesci/telesci_computer.dm
+++ b/code/modules/telesci/telesci_computer.dm
@@ -52,11 +52,11 @@
 	y_off = rand(-10,10)
 	x_player_off = 0
 	y_player_off = 0
-	//cell = new/obj/item/weapon/cell(src) // Exploitable: Spawns many cells that can be recycled.
-	//This means new telescience computers won't have a cell, but most maps provide easy cell access.
 
 /obj/machinery/computer/telescience/initialize()
 	..()
+	if(ticker && ticker.current_state < GAME_STATE_PLAYING)
+		cell = new/obj/item/weapon/cell(src) // Stops cell duping, provides one 1000 cell at roundstart
 	for(var/obj/machinery/telepad/possible_telepad in range(src, 7))
 		if(telepad)
 			return //Stop checking if we are linked


### PR DESCRIPTION
[oversight][tweak][bugfix]

Fixes #25058 

"It takes 2 seconds to screw/unscrew the monitor to spawn a cell. Recycling one of them on the autolathe gives 700 metal and 50 glass. That's 21000 of metal and 1500 glass per minute. Not a lot but definitely exploitable" - Zth--

Not anymore! Get your own damn cell you dirty ablinos.

:cl:
 * bugfix: Telescience consoles no longer spawn infinite cells.