### PR TITLE
AI radio starts with all channels enabled

### DIFF
--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -176,4 +176,4 @@
 	name = "AI Encryption Key"
 	desc = "An encryption key for a radio headset.  Contains cypherkeys."
 	icon_state = "cap_cypherkey"
-	channels = list("AI Private" = 1, "Command" = 1, "Security" = 1, "Engineering" = 0, "Science" = 0, "Medical" = 0, "Supply" = 0, "Service" = 0)
+	channels = list("AI Private" = 1, "Command" = 1, "Security" = 1, "Engineering" = 1, "Science" = 1, "Medical" = 1, "Supply" = 1, "Service" = 1)


### PR DESCRIPTION
[tweak]

![1574066260658](https://user-images.githubusercontent.com/5822375/69037113-eb6f6000-09ef-11ea-8cbe-a7539cc80627.png)

I can't be the only one whose roundstart AI ritual is clicking on all the links here to turn on all the channels, as by default only AI Private, Command and Security are enabled.

This should cut down on the roundstart busywork for most AIs, while increasing the roundstart busywork of the (I'm assuming) inexistent subset of AI players who don't want to hear all the radio channels.

:cl:
 * tweak: AI integrated radio now starts with all channels enabled