### PR TITLE
Allows spacepods to be constructed again

### DIFF
--- a/code/WorkInProgress/pomf/spacepods/construction.dm
+++ b/code/WorkInProgress/pomf/spacepods/construction.dm
@@ -38,7 +38,7 @@
 	construct = null
 
 /obj/structure/spacepod_frame/attackby(obj/item/W, mob/user)
-	if(!construct)
+	if(!construct || !construct.action(W, user))
 		if(istype(W,/obj/item/pod_parts/armor/civ))
 			construct = new /datum/construction/reversible/pod/unarmored/civ(src)
 		else if(istype(W, /obj/item/pod_parts/armor/taxi))


### PR DESCRIPTION
[bugfix][oversight]

Looks like one of the if statements wasn't updated from last time. Seems fine now.

Closes #25093
Closes #25078
Closes #25021
and was caused by the cleanup in #24978 

![image](https://user-images.githubusercontent.com/28162068/69176381-8ace4900-0afd-11ea-8753-223dd182267d.png)

![image](https://user-images.githubusercontent.com/28162068/69176401-915cc080-0afd-11ea-983b-7711c821191c.png)

Zooooooooooooooooooooooom

-->
:cl:
 * bugfix: You can now make spacepods again.