### PR TITLE
CMO & RD maintenance access

### DIFF
--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -12,7 +12,7 @@
 	req_admin_notify = 1
 	access = list(access_medical, access_morgue, access_genetics, access_heads,
 			access_chemistry, access_virology, access_biohazard, access_cmo, access_surgery, access_RC_announce,
-			access_keycard_auth, access_sec_doors, access_paramedic, access_eva)
+			access_keycard_auth, access_sec_doors, access_paramedic, access_eva, access_maint_tunnels)
 	minimal_access = list(access_medical, access_morgue, access_genetics, access_heads,
 			access_chemistry, access_virology, access_biohazard, access_cmo, access_surgery, access_RC_announce,
 			access_keycard_auth, access_sec_doors, access_paramedic)

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -13,7 +13,8 @@
 	access = list(access_rd, access_heads, access_rnd, access_genetics, access_morgue,
 			            access_tox_storage, access_teleporter, access_sec_doors,
 			            access_science, access_robotics, access_xenobiology, access_ai_upload,
-			            access_RC_announce, access_keycard_auth, access_tcomsat, access_gateway, access_mechanic)
+			            access_RC_announce, access_keycard_auth, access_tcomsat, access_gateway, access_mechanic,
+						access_maint_tunnels)
 	minimal_access = list(access_rd, access_heads, access_rnd, access_genetics, access_morgue,
 			            access_tox_storage, access_teleporter, access_sec_doors,
 			            access_science, access_robotics, access_xenobiology, access_ai_upload,


### PR DESCRIPTION
This is a pet peeve of mine that I remembered while doing #25110.

The lowliest assistant on the station has maint access, but these so-called heads of staff with access to high-security areas like the bridge and the AI upload do not, even when some of their underlings (paramedics for the CMO) do? Ridiculous.

This adds maint access to the CMO and RD on the non-minimal access config setting (ie. what we use by default).

:cl:
 * tweak: CMO and RD now have maintenance access.