### PR TITLE
EVERYBODY (almost) has maintenance access

### DIFF
--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -9,7 +9,7 @@
 	supervisors = "the head of personnel"
 	wage_payout = 20
 	selection_color = "#dddddd"
-	access = list(access_hydroponics, access_bar, access_kitchen, access_morgue, access_weapons)
+	access = list(access_hydroponics, access_bar, access_kitchen, access_morgue, access_weapons, access_maint_tunnels)
 	minimal_access = list(access_bar,access_weapons)
 
 	pdaslot=slot_belt
@@ -72,7 +72,7 @@
 	supervisors = "the head of personnel"
 	wage_payout = 20
 	selection_color = "#dddddd"
-	access = list(access_hydroponics, access_bar, access_kitchen, access_morgue)
+	access = list(access_hydroponics, access_bar, access_kitchen, access_morgue, access_maint_tunnels)
 	minimal_access = list(access_kitchen, access_morgue, access_bar)
 	alt_titles = list("Cook")
 
@@ -121,8 +121,8 @@
 	supervisors = "the head of personnel"
 	wage_payout = 20
 	selection_color = "#dddddd"
-	access = list(access_hydroponics, access_bar, access_kitchen, access_morgue) // Removed tox and chem access because STOP PISSING OFF THE CHEMIST GUYS // //Removed medical access because WHAT THE FUCK YOU AREN'T A DOCTOR YOU GROW WHEAT //Given Morgue access because they have a viable means of cloning.
-	minimal_access = list(access_hydroponics, access_morgue) // Removed tox and chem access because STOP PISSING OFF THE CHEMIST GUYS // //Removed medical access because WHAT THE FUCK YOU AREN'T A DOCTOR YOU GROW WHEAT //Given Morgue access because they have a viable means of cloning.
+	access = list(access_hydroponics, access_bar, access_kitchen, access_morgue, access_maint_tunnels)
+	minimal_access = list(access_hydroponics, access_morgue)
 	alt_titles = list("Hydroponicist", "Beekeeper", "Gardener")
 
 	pdaslot=slot_belt
@@ -583,7 +583,8 @@
 	supervisors = "Nanotrasen Law, CentComm Officals, and the station's captain."
 	wage_payout = 55
 	selection_color = "#dddddd"
-	access = list(access_lawyer, access_court, access_heads, access_RC_announce, access_sec_doors, access_cargo, access_medical, access_bar, access_kitchen, access_hydroponics)
+	access = list(access_lawyer, access_court, access_heads, access_RC_announce, access_sec_doors, access_cargo,
+				access_medical, access_bar, access_kitchen, access_hydroponics, access_maint_tunnels)
 	minimal_access = list(access_lawyer, access_court, access_heads, access_RC_announce, access_sec_doors, access_cargo,  access_bar, access_kitchen)
 	alt_titles = list("Lawyer", "Bridge Officer")
 

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -12,7 +12,7 @@
 	req_admin_notify = 1
 	access = list(access_medical, access_morgue, access_genetics, access_heads,
 			access_chemistry, access_virology, access_biohazard, access_cmo, access_surgery, access_RC_announce,
-			access_keycard_auth, access_sec_doors, access_paramedic, access_eva)
+			access_keycard_auth, access_sec_doors, access_paramedic, access_eva, access_maint_tunnels)
 	minimal_access = list(access_medical, access_morgue, access_genetics, access_heads,
 			access_chemistry, access_virology, access_biohazard, access_cmo, access_surgery, access_RC_announce,
 			access_keycard_auth, access_sec_doors, access_paramedic)
@@ -66,7 +66,7 @@
 	wage_payout = 65
 	selection_color = "#ffeef0"
 	idtype = /obj/item/weapon/card/id/medical
-	access = list(access_medical, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics, access_eva)
+	access = list(access_medical, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics, access_eva, access_maint_tunnels)
 	minimal_access = list(access_medical, access_morgue, access_surgery, access_virology)
 	alt_titles = list("Emergency Physician", "Nurse", "Surgeon")
 
@@ -140,7 +140,7 @@
 	wage_payout = 65
 	selection_color = "#ffeef0"
 	idtype = /obj/item/weapon/card/id/medical
-	access = list(access_medical, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics, access_eva)
+	access = list(access_medical, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics, access_eva, access_maint_tunnels)
 	minimal_access = list(access_medical, access_chemistry)
 	alt_titles = list("Pharmacist")
 
@@ -191,7 +191,7 @@
 	wage_payout = 55
 	selection_color = "#ffeef0"
 	idtype = /obj/item/weapon/card/id/medical
-	access = list(access_medical, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics, access_science, access_eva)
+	access = list(access_medical, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics, access_science, access_eva, access_maint_tunnels)
 	minimal_access = list(access_medical, access_morgue, access_genetics, access_science)
 
 	pdaslot=slot_belt
@@ -237,7 +237,7 @@
 	supervisors = "the chief medical officer"
 	wage_payout = 45
 	selection_color = "#ffeef0"
-	access = list(access_medical, access_morgue, access_surgery, access_chemistry, access_virology, access_biohazard, access_genetics, access_eva)
+	access = list(access_medical, access_morgue, access_surgery, access_chemistry, access_virology, access_biohazard, access_genetics, access_eva, access_maint_tunnels)
 	minimal_access = list(access_medical, access_virology, access_biohazard)
 	alt_titles = list("Pathologist", "Microbiologist")
 

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -13,7 +13,8 @@
 	access = list(access_rd, access_heads, access_rnd, access_genetics, access_morgue,
 			            access_tox_storage, access_teleporter, access_sec_doors,
 			            access_science, access_robotics, access_xenobiology, access_ai_upload,
-			            access_RC_announce, access_keycard_auth, access_tcomsat, access_gateway, access_mechanic)
+			            access_RC_announce, access_keycard_auth, access_tcomsat, access_gateway, access_mechanic,
+						access_maint_tunnels)
 	minimal_access = list(access_rd, access_heads, access_rnd, access_genetics, access_morgue,
 			            access_tox_storage, access_teleporter, access_sec_doors,
 			            access_science, access_robotics, access_xenobiology, access_ai_upload,
@@ -59,7 +60,7 @@
 	wage_payout = 55
 	selection_color = "#ffeeff"
 	idtype = /obj/item/weapon/card/id/research
-	access = list(access_robotics, access_rnd, access_tox_storage, access_science, access_xenobiology)
+	access = list(access_robotics, access_rnd, access_tox_storage, access_science, access_xenobiology, access_maint_tunnels)
 	minimal_access = list(access_rnd, access_tox_storage, access_science, access_xenobiology)
 	alt_titles = list("Xenoarcheologist", "Anomalist", "Plasma Researcher", "Xenobiologist", "Research Botanist")
 
@@ -118,7 +119,7 @@
 	wage_payout = 55
 	selection_color = "#ffeeff"
 	idtype = /obj/item/weapon/card/id/research
-	access = list(access_robotics, access_tech_storage, access_morgue, access_science, access_rnd) //As a job that handles so many corpses, it makes sense for them to have morgue access.
+	access = list(access_robotics, access_tech_storage, access_morgue, access_science, access_rnd, access_maint_tunnels) //As a job that handles so many corpses, it makes sense for them to have morgue access.
 	minimal_access = list(access_robotics, access_tech_storage, access_morgue, access_science) //As a job that handles so many corpses, it makes sense for them to have morgue access.
 	alt_titles = list("Biomechanical Engineer","Mechatronic Engineer")
 


### PR DESCRIPTION
[powercreep][balance]

Now this is a real-time slippery slope demonstration.

Who does and doesn't have maintenance access seems completely arbitrary: cargo techs do, clown and mime do, **chaplain** and **librarian** do (why the fuck), but bartender, chef, botanist don't. Neither do doctors or scientists. This adds maintenance access to fucking errybody except for vox traders.

As to why: lack of maintenance access makes it, among other more minor things, really limiting to antag on these roles. However, I'm more concerned with the question *why not*. The lowliest assistant has maint access, and if jobbie roles like barkeep or medical doctor are prowling maint all round then at the very least you should get them demoted for abandoning their workplace (and probably revoke their maint access as punishment), and more likely should be suspecting them of being up to no good.

At the very least I'd like to see some discussion on what good these roles not having maintenance access is doing for the game as it is played.

:cl:
 * tweak: literally every crew member now has maintenance access.