### PR TITLE
NOBODY (almost) has maintenance access

### DIFF
--- a/code/game/jobs/job/assistant.dm
+++ b/code/game/jobs/job/assistant.dm
@@ -47,10 +47,7 @@
 	H.put_in_hands(new /obj/item/weapon/storage/toolbox/mechanical(get_turf(H)))
 
 /datum/job/assistant/get_access()
-	if(config.assistant_maint)
-		return list(access_maint_tunnels)
-	else
-		return list()
+	return list()
 
 /datum/job/assistant/get_total_positions()
 	if(!config.assistantlimit)

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -272,7 +272,7 @@
 	wage_payout = 30
 	selection_color = "#dddddd"
 	idtype = /obj/item/weapon/card/id/supply
-	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_mint, access_mining, access_mining_station)
+	access = list(access_mailsorting, access_cargo, access_cargo_bot, access_mint, access_mining, access_mining_station)
 	minimal_access = list(access_mining, access_mint, access_mining_station, access_mailsorting)
 
 	pdaslot=slot_belt
@@ -322,7 +322,7 @@
 	wage_payout = 15
 	selection_color = "#dddddd"
 	idtype = /obj/item/weapon/card/id/clown
-	access = list(access_clown, access_theatre, access_maint_tunnels)
+	access = list(access_clown, access_theatre)
 	minimal_access = list(access_clown, access_theatre)
 	alt_titles = list("Jester")
 
@@ -389,7 +389,7 @@
 	wage_payout = 15
 	selection_color = "#dddddd"
 	idtype = /obj/item/weapon/card/id/mime
-	access = list(access_mime, access_theatre, access_maint_tunnels)
+	access = list(access_mime, access_theatre)
 	minimal_access = list(access_mime, access_theatre)
 
 	pdaslot=slot_belt
@@ -529,7 +529,7 @@
 	supervisors = "the head of personnel"
 	wage_payout = 25
 	selection_color = "#dddddd"
-	access = list(access_library, access_maint_tunnels)
+	access = list(access_library)
 	minimal_access = list(access_library)
 	alt_titles = list("Journalist", "Game Master")
 

--- a/code/game/jobs/job/civilian_chaplain.dm
+++ b/code/game/jobs/job/civilian_chaplain.dm
@@ -9,7 +9,7 @@
 	supervisors = "The God(s), the Head of Personnel too"
 	wage_payout = 25
 	selection_color = "#dddddd"
-	access = list(access_morgue, access_chapel_office, access_crematorium, access_maint_tunnels)
+	access = list(access_morgue, access_chapel_office, access_crematorium)
 	minimal_access = list(access_morgue, access_chapel_office, access_crematorium)
 	pdaslot = slot_belt
 	pdatype = /obj/item/device/pda/chaplain


### PR DESCRIPTION
[tweak][balance][controversial]

Alright, while we're spamming stupid controversial PRs to raise discussion, here's the opposite PR to #25112 and therefore the UN-POWERCREEP PR.

The following jobs no longer have maintenance access:

- Miners (your home is on the roid & you get a powerful hardsuit & you get guns & artifacts, why the fuck do you need to be in maintenance?)
- Chaplain (you're a priest, not a tunnel rat)
- Librarian (you're a bookworm)
- Clown (your home is in the bar, or alternatively the brig)
- Mime (your home is also in the bar)
- **Assistant** (you're trash and don't deserve anything)

I should mention stripping assistants of their access should be done in the server config and not the way I did it, but this is not something I can do in a PR.

:cl:
 * tweak: the following jobs no longer have maintenance access: miner, chaplain, librarian, clown, mime, assistant