### PR TITLE
Goonesat tweaks

### DIFF
--- a/maps/randomvaults/goonesat.dmm
+++ b/maps/randomvaults/goonesat.dmm
@@ -8,7 +8,7 @@
 "ah" = (/obj/structure/grille,/turf/simulated/floor/plating/airless,/area)
 "ai" = (/turf/simulated/wall/r_wall,/area)
 "aj" = (/turf/simulated/wall/r_wall,/area/turret_protected/tcomsat)
-"ak" = (/mob/living/simple_animal/hostile/viscerator{harm_intent_damage = 0; health = 1; heat_damage_per_tick = 0; locked_to_z = 1; luminosity = 3; maxHealth = 1; melee_damage_lower = 45; melee_damage_upper = 45; name = "slasher"; wander = 0},/turf/simulated/floor/engine,/area)
+"ak" = (/obj/item/weapon/coin/clown,/obj/item/weapon/winter_gift/special,/obj/item/clothing/head/collectable/petehat,/mob/living/simple_animal/hostile/viscerator{harm_intent_damage = 0; health = 1; heat_damage_per_tick = 0; locked_to_z = 1; luminosity = 3; maxHealth = 1; melee_damage_lower = 45; melee_damage_upper = 45; name = "slasher"; wander = 0},/turf/simulated/floor/engine,/area/tcommsat/computer)
 "al" = (/turf/simulated/wall/r_wall,/area/tcommsat/computer)
 "am" = (/mob/living/simple_animal/hostile/viscerator{harm_intent_damage = 0; health = 1; heat_damage_per_tick = 0; locked_to_z = 1; luminosity = 3; maxHealth = 1; melee_damage_lower = 45; melee_damage_upper = 45; name = "slasher"; wander = 0},/turf/simulated/floor/engine,/area/tcommsat/computer)
 "an" = (/obj/structure/lattice,/turf/space,/area/turret_protected/tcomsat)
@@ -19,7 +19,7 @@
 "as" = (/obj/machinery/atmospherics/pipe/simple/supply/hidden{dir = 4},/obj/structure/cable{d1 = 2; d2 = 8; icon_state = "2-8"},/turf/simulated/floor/plating,/area/turret_protected/tcomsat)
 "at" = (/obj/machinery/atmospherics/pipe/manifold/supply/hidden{dir = 1},/turf/simulated/floor/plating,/area/turret_protected/tcomsat)
 "au" = (/obj/machinery/atmospherics/unary/tank/air{dir = 8},/turf/simulated/floor/plating,/area/turret_protected/tcomsat)
-"av" = (/obj/item/weapon/coin/clown,/obj/item/weapon/winter_gift/special,/obj/item/clothing/head/collectable/petehat,/turf/simulated/floor/engine,/area/tcommsat/computer)
+"av" = (/obj/item/weapon/syntiflesh{name = "Cuban Pete-Meat"},/mob/living/simple_animal/hostile/viscerator{harm_intent_damage = 0; health = 1; heat_damage_per_tick = 0; locked_to_z = 1; luminosity = 3; maxHealth = 1; melee_damage_lower = 45; melee_damage_upper = 45; name = "slasher"; wander = 0},/turf/simulated/floor/engine,/area/tcommsat/computer)
 "aw" = (/obj/structure/lattice,/obj/structure/window/reinforced/plasma{dir = 4},/turf/space,/area/turret_protected/tcomsat)
 "ax" = (/obj/machinery/atmospherics/unary/vent_pump{on = 1},/turf/simulated/floor/plating,/area/turret_protected/tcomsat)
 "ay" = (/obj/machinery/atmospherics/pipe/simple/supply/hidden,/obj/machinery/meter,/turf/simulated/floor/plating,/area/turret_protected/tcomsat)
@@ -32,11 +32,11 @@
 "aF" = (/obj/structure/table,/obj/item/weapon/pen/blue{pixel_x = -3; pixel_y = 2},/obj/item/weapon/soap/syndie,/turf/simulated/floor{icon_state = "white"},/area/tcommsat/computer)
 "aG" = (/obj/machinery/power/apc{dir = 1; pixel_y = 24},/obj/structure/cable{icon_state = "0-2"; pixel_y = 1; d2 = 2},/obj/structure/table,/obj/item/weapon/paper_bin,/turf/simulated/floor{icon_state = "white"},/area/tcommsat/computer)
 "aH" = (/obj/structure/table,/obj/item/device/flashlight/lamp,/turf/simulated/floor{icon_state = "white"},/area/tcommsat/computer)
-"aI" = (/obj/item/weapon/syntiflesh{name = "Cuban Pete-Meat"},/turf/simulated/floor/engine,/area/tcommsat/computer)
+"aI" = (/obj/machinery/light{dir = 1},/turf/simulated/floor,/area/tcommsat/computer)
 "aJ" = (/obj/structure/bed,/obj/item/weapon/bedsheet/green,/turf/simulated/floor,/area/tcommsat/computer)
-"aK" = (/obj/machinery/light{dir = 1},/obj/item/weapon/tank/emergency_oxygen/double,/turf/simulated/floor,/area/tcommsat/computer)
+"aK" = (/obj/structure/bed/chair,/mob/living/simple_animal/hostile/humanoid/russian/ranged,/turf/simulated/floor,/area/tcommsat/computer)
 "aL" = (/obj/structure/bed,/obj/item/weapon/bedsheet/brown,/turf/simulated/floor,/area/tcommsat/computer)
-"aM" = (/obj/item/weapon/blunderbuss/flawless,/turf/simulated/floor,/area/tcommsat/computer)
+"aM" = (/obj/machinery/light{dir = 4},/obj/structure/rack,/obj/item/weapon/blunderbuss/flawless,/obj/item/weapon/tank/emergency_oxygen/double,/turf/simulated/floor,/area/tcommsat/computer)
 "aN" = (/obj/structure/bed,/obj/item/weapon/bedsheet/red,/turf/simulated/floor,/area/tcommsat/computer)
 "aO" = (/obj/machinery/teleport/station,/turf/simulated/floor,/area/tcommsat/computer)
 "aP" = (/obj/machinery/atmospherics/pipe/simple/supply/hidden{req_access_txt = "0"},/turf/simulated/floor/plating,/area/turret_protected/tcomsat)
@@ -49,9 +49,9 @@
 "aW" = (/obj/structure/bed/chair/office/dark{dir = 1},/mob/living/simple_animal/hostile/humanoid/russian,/turf/simulated/floor{icon_state = "white"},/area/tcommsat/computer)
 "aX" = (/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor{icon_state = "white"},/area/tcommsat/computer)
 "aY" = (/obj/structure/bed,/obj/item/weapon/bedsheet/orange,/obj/machinery/light{dir = 8},/turf/simulated/floor,/area/tcommsat/computer)
-"aZ" = (/mob/living/simple_animal/hostile/humanoid/russian/ranged,/turf/simulated/floor,/area/tcommsat/computer)
-"ba" = (/obj/structure/bed/chair,/turf/simulated/floor,/area/tcommsat/computer)
-"bb" = (/obj/machinery/light{dir = 4},/turf/simulated/floor,/area/tcommsat/computer)
+"aZ" = (/obj/item/weapon/syntiflesh{name = "Cuban Pete-Meat"},/obj/item/weapon/spacecash,/mob/living/simple_animal/hostile/viscerator{harm_intent_damage = 0; health = 1; heat_damage_per_tick = 0; locked_to_z = 1; luminosity = 3; maxHealth = 1; melee_damage_lower = 45; melee_damage_upper = 45; name = "slasher"; wander = 0},/turf/simulated/floor/engine,/area/tcommsat/computer)
+"ba" = (/obj/machinery/atmospherics/unary/vent_pump{dir = 4; on = 1},/turf/simulated/floor,/area/tcommsat/computer)
+"bb" = (/obj/machinery/atmospherics/pipe/simple/supply/hidden{dir = 10},/turf/simulated/floor,/area/tcommsat/computer)
 "bc" = (/obj/machinery/atmospherics/pipe/simple/supply/hidden{dir = 5},/obj/structure/lattice,/obj/structure/window/reinforced/plasma{dir = 1},/obj/structure/window/reinforced/plasma,/turf/space,/area/turret_protected/tcomsat)
 "bd" = (/obj/structure/lattice,/obj/machinery/atmospherics/pipe/manifold/supply/hidden{dir = 4},/obj/structure/window/reinforced/plasma{dir = 1},/obj/structure/window/reinforced/plasma,/obj/structure/window/reinforced/plasma{dir = 4},/turf/space,/area/turret_protected/tcomsat)
 "be" = (/obj/structure/window/reinforced/plasma{dir = 1},/obj/structure/window/reinforced/plasma{dir = 8},/obj/structure/window/reinforced/plasma,/turf/space,/area/turret_protected/tcomsat)
@@ -62,12 +62,11 @@
 "bj" = (/obj/machinery/atmospherics/unary/vent_pump{dir = 8; on = 1},/turf/simulated/floor{icon_state = "white"},/area/tcommsat/computer)
 "bk" = (/mob/living/simple_animal/hostile/humanoid/russian/ranged,/turf/simulated/floor{icon_state = "white"},/area/tcommsat/computer)
 "bl" = (/obj/item/device/radio/intercom{freerange = 1; name = "General Listening Channel"; pixel_x = 28},/turf/simulated/floor{icon_state = "white"},/area/tcommsat/computer)
-"bm" = (/obj/item/weapon/syntiflesh{name = "Cuban Pete-Meat"},/obj/item/weapon/spacecash,/turf/simulated/floor/engine,/area/tcommsat/computer)
-"bn" = (/obj/machinery/atmospherics/unary/vent_pump{dir = 4; on = 1},/obj/item/weapon/spacecash/c1000,/turf/simulated/floor,/area/tcommsat/computer)
-"bo" = (/obj/machinery/atmospherics/pipe/simple/supply/hidden{dir = 10},/obj/item/weapon/spacecash/c1000,/turf/simulated/floor,/area/tcommsat/computer)
-"bp" = (/obj/structure/bed/chair{dir = 4},/turf/simulated/floor,/area/tcommsat/computer)
-"bq" = (/obj/structure/table,/obj/item/weapon/storage/fancy/cigarettes,/turf/simulated/floor,/area/tcommsat/computer)
-"br" = (/obj/structure/bed/chair{dir = 8},/turf/simulated/floor,/area/tcommsat/computer)
+"bm" = (/obj/structure/bed/chair{dir = 4},/mob/living/simple_animal/hostile/humanoid/russian/ranged{icon_state = "russianranged"; dir = 4},/turf/simulated/floor,/area/tcommsat/computer)
+"bn" = (/obj/structure/table,/obj/item/weapon/storage/fancy/cigarettes,/obj/item/toy/cards,/obj/item/weapon/spacecash/c1000,/obj/item/weapon/spacecash/c10,/obj/item/weapon/spacecash/c100,/turf/simulated/floor,/area/tcommsat/computer)
+"bo" = (/obj/structure/bed/chair{dir = 8},/mob/living/simple_animal/hostile/humanoid/russian/ranged{icon_state = "russianranged"; dir = 8},/turf/simulated/floor,/area/tcommsat/computer)
+"bp" = (/obj/structure/bed/chair{dir = 1},/mob/living/simple_animal/hostile/humanoid/russian/ranged{icon_state = "russianranged"; dir = 1},/turf/simulated/floor,/area/tcommsat/computer)
+"bq" = (/obj/structure/disposalpipe/segment{dir = 4},/mob/living/simple_animal/hostile/viscerator{harm_intent_damage = 0; health = 1; heat_damage_per_tick = 0; locked_to_z = 1; luminosity = 3; maxHealth = 1; melee_damage_lower = 45; melee_damage_upper = 45; name = "slasher"; wander = 0},/turf/simulated/floor/engine,/area/tcommsat/computer)
 "bs" = (/obj/machinery/atmospherics/pipe/simple/supply/hidden{dir = 6},/turf/simulated/floor{icon_state = "dark vault full"},/area/turret_protected/tcomsat)
 "bt" = (/obj/machinery/atmospherics/pipe/manifold/supply/hidden,/turf/simulated/floor{icon_state = "dark vault full"},/area/turret_protected/tcomsat)
 "bu" = (/obj/machinery/atmospherics/pipe/simple/supply/hidden{dir = 4},/obj/structure/cable{d1 = 1; d2 = 4; icon_state = "1-4"},/turf/simulated/floor{icon_state = "dark vault full"},/area/turret_protected/tcomsat)
@@ -84,10 +83,8 @@
 "bF" = (/obj/machinery/atmospherics/pipe/simple/supply/hidden,/obj/machinery/vending/groans,/turf/simulated/floor,/area/tcommsat/computer)
 "bG" = (/turf/simulated/floor,/area/tcommsat/computer)
 "bH" = (/obj/item/trash/cigbutt,/obj/machinery/light,/turf/simulated/floor,/area/tcommsat/computer)
-"bI" = (/obj/structure/bed/chair{dir = 1},/turf/simulated/floor,/area/tcommsat/computer)
 "bJ" = (/obj/machinery/disposal,/obj/structure/disposalpipe/trunk{dir = 4},/turf/simulated/floor,/area/tcommsat/computer)
 "bK" = (/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/wall/r_wall,/area/tcommsat/computer)
-"bL" = (/obj/structure/disposalpipe/segment{dir = 4},/mob/living/simple_animal/hostile/viscerator{harm_intent_damage = 0; health = 1; heat_damage_per_tick = 0; locked_to_z = 1; luminosity = 3; maxHealth = 1; melee_damage_lower = 45; melee_damage_upper = 45; name = "slasher"; wander = 0},/turf/simulated/floor/engine,/area)
 "bM" = (/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/wall/r_wall,/area)
 "bN" = (/obj/structure/disposalpipe/segment{dir = 4},/obj/structure/grille,/turf/simulated/floor/plating/airless,/area)
 "bO" = (/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor/plating/airless,/area)
@@ -105,7 +102,7 @@
 "ca" = (/obj/machinery/light/small{dir = 1},/obj/machinery/turretid{ailock = 1; control_area = /area/turret_protected/goonroom; desc = "A firewall prevents AIs from interacting with this device."; icon_state = "motion1"; lethal = 1; name = "Goonecode lethal turret control"; pixel_x = 29; req_access = list(61)},/obj/effect/decal/warning_stripes{tag = "icon-warning"; icon_state = "warning"; dir = 2},/obj/effect/decal/warning_stripes{icon_state = "nitrogen"},/turf/simulated/floor{icon_state = "dark vault full"},/area/tcommsat/chamber)
 "cb" = (/obj/machinery/atmospherics/pipe/simple/supply/hidden,/turf/simulated/wall/r_wall,/area/tcommsat/computer)
 "cc" = (/obj/machinery/door/airlock/hatch{name = "Telecoms Lounge"; req_access_txt = "61"},/turf/simulated/floor{icon_state = "dark vault full"},/area/tcommsat/computer)
-"cd" = (/obj/machinery/turret{lasers = 1; lasertype = 2},/turf/simulated/floor/plating/airless,/area/turret_protected/tcomsat)
+"cd" = (/obj/machinery/turret/russian,/turf/simulated/floor/plating/airless,/area/turret_protected/tcomsat)
 "ce" = (/turf/simulated/wall/r_wall,/area/turret_protected/goonroom)
 "cf" = (/obj/structure/grille,/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced{dir = 8},/obj/structure/cable{icon_state = "0-4"; d2 = 4},/obj/structure/window/full/reinforced,/obj/machinery/atmospherics/pipe/simple/insulated/hidden/blue,/turf/simulated/floor/plating,/area/turret_protected/goonroom)
 "cg" = (/obj/structure/grille,/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 1},/obj/structure/cable{icon_state = "0-4"; d2 = 4},/obj/structure/cable{d2 = 8; icon_state = "0-8"},/obj/structure/window/full/reinforced,/turf/simulated/floor/plating,/area/turret_protected/goonroom)
@@ -119,7 +116,7 @@
 "co" = (/obj/machinery/atmospherics/pipe/simple/supply/hidden{dir = 5},/turf/simulated/floor{icon_state = "dark vault full"},/area/turret_protected/tcomsat)
 "cp" = (/obj/machinery/atmospherics/pipe/simple/supply/hidden{dir = 10},/obj/structure/lattice,/obj/structure/window/reinforced/plasma{dir = 8},/turf/space,/area/turret_protected/tcomsat)
 "cq" = (/turf/simulated/floor/bluegrid{name = "Mainframe Base"; nitrogen = 100; oxygen = 0; temperature = 80},/area/turret_protected/goonroom)
-"cr" = (/obj/machinery/turret{lasers = 1; lasertype = 2},/obj/effect/decal/warning_stripes{icon_state = "unloading"},/turf/simulated/floor/bluegrid{icon_state = "dark"; name = "Mainframe Floor"; nitrogen = 100; oxygen = 0; temperature = 80},/area/turret_protected/goonroom)
+"cr" = (/obj/effect/decal/warning_stripes{icon_state = "unloading"},/obj/machinery/turret/russian,/turf/simulated/floor/bluegrid{icon_state = "dark"; name = "Mainframe Floor"; nitrogen = 100; oxygen = 0; temperature = 80},/area/turret_protected/goonroom)
 "cs" = (/obj/structure/cable{icon_state = "0-4"; d2 = 4},/obj/machinery/power/apc{dir = 1; pixel_y = 24},/turf/simulated/floor/bluegrid{name = "Mainframe Base"; nitrogen = 100; oxygen = 0; temperature = 80},/area/turret_protected/goonroom)
 "ct" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/atmospherics/pipe/simple/insulated/hidden/blue,/turf/simulated/floor/bluegrid{name = "Mainframe Base"; nitrogen = 100; oxygen = 0; temperature = 80},/area/turret_protected/goonroom)
 "cu" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/bluegrid{name = "Mainframe Base"; nitrogen = 100; oxygen = 0; temperature = 80},/area/turret_protected/goonroom)
@@ -205,7 +202,7 @@
 "dW" = (/obj/structure/sign/securearea{desc = "A warning sign which reads 'LETHAL TURRETS'. Enter at your own risk!"; name = "LETHAL TURRETS"; pixel_x = -32},/obj/effect/decal/warning_stripes{tag = "icon-warning (NORTHWEST)"; icon_state = "warning"; dir = 9},/turf/simulated/floor,/area/turret_protected/tcomfoyer)
 "dX" = (/obj/machinery/power/apc{dir = 1; pixel_y = 24},/obj/structure/cable{icon_state = "0-4"; d2 = 4},/obj/effect/decal/warning_stripes{tag = "icon-warning_corner (NORTH)"; icon_state = "warning_corner"; dir = 1},/mob/living/simple_animal/hostile/humanoid/russian,/turf/simulated/floor,/area/turret_protected/tcomfoyer)
 "dY" = (/obj/machinery/atmospherics/pipe/simple/supply/hidden{dir = 6},/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/effect/decal/warning_stripes{tag = "icon-warning_corner (EAST)"; icon_state = "warning_corner"; dir = 4},/obj/item/device/radio/intercom{name = "Station Intercom (General)"; pixel_y = 20},/turf/simulated/floor,/area/turret_protected/tcomfoyer)
-"dZ" = (/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/turretid{ailock = 1; control_area = /area/turret_protected/tcomsat; desc = "A firewall prevents AIs from interacting with this device."; icon_state = "motion1"; lethal = 1; name = "Telecoms lethal turret control"; pixel_y = 29; req_access = list(61)},/obj/structure/cable{d1 = 2; d2 = 8; icon_state = "2-8"},/obj/machinery/atmospherics/pipe/simple/supply/hidden{dir = 4},/obj/effect/decal/warning_stripes{tag = "icon-warning (NORTH)"; icon_state = "warning"; dir = 1},/turf/simulated/floor,/area/turret_protected/tcomfoyer)
+"dZ" = (/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/cable{d1 = 2; d2 = 8; icon_state = "2-8"},/obj/machinery/atmospherics/pipe/simple/supply/hidden{dir = 4},/obj/effect/decal/warning_stripes{tag = "icon-warning (NORTH)"; icon_state = "warning"; dir = 1},/turf/simulated/floor,/area/turret_protected/tcomfoyer)
 "ea" = (/obj/machinery/atmospherics/pipe/manifold/supply/hidden{dir = 1},/obj/effect/decal/warning_stripes{tag = "icon-warning_corner (NORTH)"; icon_state = "warning_corner"; dir = 1},/turf/simulated/floor,/area/turret_protected/tcomfoyer)
 "eb" = (/obj/machinery/atmospherics/pipe/simple/supply/hidden{dir = 10},/obj/effect/decal/warning_stripes{tag = "icon-warning_corner (EAST)"; icon_state = "warning_corner"; dir = 4},/mob/living/simple_animal/hostile/humanoid/russian,/turf/simulated/floor,/area/turret_protected/tcomfoyer)
 "ec" = (/obj/structure/sign/securearea{desc = "A warning sign which reads 'LETHAL TURRETS'. Enter at your own risk!"; name = "LETHAL TURRETS"; pixel_x = 32},/obj/effect/decal/warning_stripes{tag = "icon-warning (NORTHEAST)"; icon_state = "warning"; dir = 5},/turf/simulated/floor,/area/turret_protected/tcomfoyer)
@@ -302,13 +299,13 @@ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabacacaeaeaeaeaeaeae
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabaaaaacaaaaaeaaaaacaaaaabaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaababababababababababababababahababababababababababababababababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaababaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiabaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaababaiaiajajajajajajajajajaiakakakakakakaiaialamamamamamamamakaiabaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabaiaiajanaoapaqarasatauajalalalalalalalalavalalalalalalalamakaiabaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabaiajanananawaxayazaAauaBalaCaDaEaFaGaHalaIalaJaKaLaMaNaOalakaiabaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabaiajaoanaoapaPaQazaqaRaSalaTaUaVaWaXaValaIalaYaZaZaZbabbalakaiabaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabaiajaoanaoaobcbdazbebfbgbhbibjbkaVaXblalbmalbnboaZbpbqbralakaiabaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabaiajaoanaoapbsbtbubvbvbvbwbxbybzbAbBbCbDbDalbEbFbGbHbIbJbKbLbMbNbObPaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-abababababababababafabababababababababababaiajaoanaoapbQbRbSbTbTbTalbUbVbWbXbXbYbZcaalalcbccalalalalaiaiabababababababababababababababababafabababab
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaababaiaiajajajajajajajajajalamamamamamamalalalamamamamamamamamaiabaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabaiaiajanaoapaqarasatauajalalalalalalalalakalalalalalalalamamaiabaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabaiajanananawaxayazaAauaBalaCaDaEaFaGaHalavalaJaIaLbGaNaOalamaiabaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabaiajaoanaoapaPaQazaqaRaSalaTaUaVaWaXaValavalaYbGbGbGaKaMalamaiabaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabaiajaoanaoaobcbdazbebfbgbhbibjbkaVaXblalaZalbabbbGbmbnboalamaiabaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabaiajaoanaoapbsbtbubvbvbvbwbxbybzbAbBbCbDbDalbEbFbGbHbpbJbKbqbMbNbObPaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+abababababababababafabababababababababababaiajaoanaoapbQbRbSbTbTbTalbUbVbWbXbXbYbZcaalalcbccalalalalalaiabababababababababababababababababafabababab
 abaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacabaiajancdanawbQaBcecececececfcgchcgcicjckclckcecmcnaBancdanajaiabababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab
 abacadadadadadadadadadadadadadadadadaaaaabaiajaoanaoapcocpcecqcqcrcsctcucvcqcqcwcrcxcqcecmcnaSaoanaoajaiababaaacadadadadadadadadadadadadadadadadaaab
 abaaaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaaabaiajaoanaoapcyczcecqcAcAcBcCcDcEcDcDcFcAcAcqcecmcnaScGcHcIajaiaiabacaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeacab

--- a/maps/randomvaults/objects.dm
+++ b/maps/randomvaults/objects.dm
@@ -921,3 +921,8 @@
 		/obj/item/weapon/stock_parts/console_screen\
 	)
 
+
+/obj/machinery/turret/russian
+	faction = "russian"
+	lasers = 1
+	lasertype = 2


### PR DESCRIPTION
Makes the goonesat turrets the same faction as the russians on board, so the turrets don't shoot the russians

Removes one of the goonesat turret control, so no easy cheesy with the captains spare

Fills up the rest of the cavity with slashers, so you can't just bust in through the back wall without any challenge and asphyxiate the russians

![image](https://user-images.githubusercontent.com/30557196/69246191-29ab8180-0ba0-11ea-8b09-b795d7ddc9c1.png)


:cl:
 * tweak: The goone satellite turrets now no longer shoot the russians