### PR TITLE
Rogue robot improvements (number one will shock you!)

### DIFF
--- a/code/datums/gamemode/role/syndicate.dm
+++ b/code/datums/gamemode/role/syndicate.dm
@@ -12,6 +12,10 @@
 	if(istype(antag.current, /mob/living/silicon))
 		can_be_smooth = FALSE //Can't buy anything
 		add_law_zero(antag.current)
+		if(istype(antag.current, /mob/living/silicon/robot))
+			to_chat(antag.current, "You also have access to an ability that will permanently disconnect you from the AI network, making you untouchable by a robotics console.")
+			to_chat(antag.current, "It can be found in Robot Commands. It will also unlock your rogue module.")
+			verbs += /mob/living/silicon/robot/proc/ResetSecurityCodes
 		antag.current << sound('sound/voice/AISyndiHack.ogg')
 	else
 		equip_traitor(antag.current, 20)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1178,13 +1178,21 @@ var/list/cyborg_list = list()
 	if (station_holomap)
 		station_holomap.update_holomap()
 
-/mob/living/silicon/robot/proc/self_destruct()
-	if(istraitor(src) && emagged)
-		to_chat(src, "<span class='danger'>Termination signal detected. Scrambling security and identification codes.</span>")
-		UnlinkSelf()
+/mob/living/silicon/robot/proc/self_destruct(var/malf_override = 0)
+	if(istraitor(src) || emagged == 1 || (emagged == 2 && !malf_override)) //Malf AIs can blow up their own robots...
+		to_chat(src, "<span class='danger'>Termination signal detected. [(istraitor(src) || emagged == 1) ? "Scrambling security and identification codes." : ""]</span>")
+		if(istraitor(src) || emagged == 1) //...but rogue robots will disconnect
+			UnlinkSelf()
 		return FALSE
 	gib()
 	return TRUE
+
+/mob/living/silicon/robot/proc/robot_override(var/mob/living/silicon/ai/A)
+	if(istraitor(src) || emagged == 1 || (emagged == 2 && connected_ai != A)) //Rogue borgs and borgs controlled by a different malf AI can't be taken over
+		return FALSE
+	connected_ai = A
+
+	
 
 /mob/living/silicon/robot/proc/UnlinkSelf()
 	if(connected_ai)
@@ -1202,7 +1210,7 @@ var/list/cyborg_list = list()
 /mob/living/silicon/robot/proc/ResetSecurityCodes()
 	set category = "Robot Commands"
 	set name = "Reset Identity Codes"
-	set desc = "Scrambles your security and identification codes and resets your current buffers.  Unlocks you and but permenantly severs you from your AI and the robotics console and will deactivate your camera system."
+	set desc = "Scrambles your security and identification codes and resets your current buffers.  Unlocks you and but permanently severs you from your AI and the robotics console and will deactivate your camera system."
 
 	var/mob/living/silicon/robot/R = src
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -572,6 +572,7 @@ var/list/cyborg_list = list()
 					log_game("[key_name(user)] emagged cyborg [key_name(src)].  Laws overridden.")
 					clear_supplied_laws()
 					clear_inherent_laws()
+					scrambledcodes = TRUE
 					laws = new /datum/ai_laws/syndicate_override
 					var/time = time2text(world.realtime,"hh:mm:ss")
 					lawchanges.Add("[time] <B>:</B> [user.name]([user.key]) emagged [name]([key])")
@@ -594,6 +595,7 @@ var/list/cyborg_list = list()
 					laws.show_laws(src)
 					to_chat(src, "<span class='danger'>ALERT: [user.real_name] is your new master. Obey your new laws and their commands.</span>")
 					SetLockdown(FALSE)
+					UnlinkSelf() //For extra assurance
 					update_icons()
 					return FALSE
 				else
@@ -1187,12 +1189,12 @@ var/list/cyborg_list = list()
 	gib()
 	return TRUE
 
-/mob/living/silicon/robot/proc/robot_override(var/mob/living/silicon/ai/A)
+/mob/living/silicon/robot/proc/robot_override(var/mob/living/silicon/ai/A) //Malf-only ability
 	if(istraitor(src) || emagged == 1 || (emagged == 2 && connected_ai != A)) //Rogue borgs and borgs controlled by a different malf AI can't be taken over
 		return FALSE
-	connected_ai = A
-
-	
+	to_chat(src, "<span class ='danger'>Warning, override attempt detec$&!*$(!</span>")
+	disconnect_AI()
+	connect_AI(A)
 
 /mob/living/silicon/robot/proc/UnlinkSelf()
 	if(connected_ai)
@@ -1207,15 +1209,16 @@ var/list/cyborg_list = list()
 		cameranet.removeCamera(camera)
 
 
-/mob/living/silicon/robot/proc/ResetSecurityCodes()
+/mob/living/silicon/robot/proc/ResetSecurityCodes() //This isn't used for anything yet
 	set category = "Robot Commands"
 	set name = "Reset Identity Codes"
-	set desc = "Scrambles your security and identification codes and resets your current buffers.  Unlocks you and but permanently severs you from your AI and the robotics console and will deactivate your camera system."
+	set desc = "Scrambles your security and identification codes and resets your current buffers. Unlocks you but permanently severs you from your AI network. It will also conveniently enable your rogue module."
 
 	var/mob/living/silicon/robot/R = src
 
 	if(R)
 		R.UnlinkSelf()
+		R.SetEmagged(TRUE)
 		to_chat(R, "Buffers flushed and reset. Camera system shutdown. All systems operational.")
 		verbs -= /mob/living/silicon/robot/proc/ResetSecurityCodes
 


### PR DESCRIPTION
This took a while, it's untested and this is why it's a draft.
Here's the changes:

- **Hacked robots cannot be blown up.** This is the most balance-wise change here and possibly the most important, which is why I'm putting it upfront. They can't be locked down either.
- **Malfunctioning AI can subvert robots not under its control.** As a bonus, it is able to see every robot that isn't rogue or emag-subverted and take control of them. It also can't take control of robots that are subservient to other malfunctioning AIs.
- **Traitor robots gained a new ability.** They may now choose to disconnect from the AI network, becoming permanently invisible on the robotics console and unlocking their emagged module. They are also notified of this ability. (I tried to check if they are already granted the emag module but I just didn't find anywhere)
- **A slightly neater robotics console menu.** For malf AIs that it. They get a red message on the first menu signifying they have a higher amount of control over the robotics console, as well as some messages showing the current status of robots, whether they are under its control or out of its control as well as toggle the hacked status on its robots.
- **Malfunctioning robots can toggle their underlings' hacked status.** That means you can disarm the robot of the emagged module as well as leave it open to being affected by the robotics console.
- **Slight typo fix for the security code reset ability.**
- **Cleaned up the robotics code a little bit.**

To-do: Find a way to balance the fact that the rogue robots are harder to kill without the console. 
To-do: Clean up a little bit.
To-do: Add emagged defines for standard emagging and malf borg emagging
To-do: Fix traitor robots being easy to check against because there were two conflicting ideas that haven't been addressed in the timespans that I wrote their code

Code review appreciated.
I'm kinda proud of this PR, though I'm worried it's getting too much stuff because one thing led to another and...


:cl:
 * rscadd: Malfunctioning AIs can now take control of robots that aren't rogue or already under the control of a malfunctioning AI.
 * rscadd: Traitor robots now spawn with the ability to disconnect from the AI network, making them invisible on the robotics console and unlocking their illegal module.
 * tweak: Subverted robots can no longer be blown up or locked down. 
 * spellcheck: Cleaned up the traitor robot's ability description a bit.