### PR TITLE
Readds a baby version of disposals damage

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -621,7 +621,7 @@
 	while(active)
 		if(hasmob && prob(3))
 			for(var/mob/living/H in src)
-				H.take_overall_damage(7, 0)
+				H.take_overall_damage(5, 0)
 
 
 		if(prob(2)) // chance of becoming stuck per segment if contains a fat guy

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -619,11 +619,10 @@
 /obj/structure/disposalholder/proc/move()
 	var/obj/structure/disposalpipe/last
 	while(active)
-		/* vg edit
 		if(hasmob && prob(3))
 			for(var/mob/living/H in src)
-				H.take_overall_damage(20, 0, "Blunt Trauma")//horribly maim any living creature jumping down disposals.  c'est la vie
-				*/
+				H.take_overall_damage(7, 0)
+
 
 		if(prob(2)) // chance of becoming stuck per segment if contains a fat guy
 			if(has_fat_guy())


### PR DESCRIPTION
[tweak]

Lack of disposals damage is zoom zoom powercreep. It may be zoom zoom powercreep from 2014 but it's still zoom zoom powercreep.

This readds disposals damage, though not as strong as it used to be. The 20 damage it used to apply would have you come out the other side with multiple broken bones and internal bleeding, if you lived through it in the first place. The 5 damage this PR applies has you come out the other side with some cuts and bruises.

In practical terms I took three rides through the full length of Box disposals, jumping in in the Custodial Closet, and the results were:

![1574441908578](https://user-images.githubusercontent.com/5822375/69445051-3a075c00-0d5a-11ea-9e4c-135ffdf9de19.png)

![1574441963362](https://user-images.githubusercontent.com/5822375/69445055-3b388900-0d5a-11ea-9635-2cdf09a6fb73.png)

![1574442084656](https://user-images.githubusercontent.com/5822375/69445166-7c309d80-0d5a-11ea-8fb3-da6cb80204c8.png)

:cl:
 * tweak: Disposals now deals brute damage to you for the first time in five years