### PR TITLE
Enables fun

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -73,7 +73,7 @@
 	var/turf/T = loc
 	if (opacity && istype(T))
 		T.reconsider_lights()
-		
+
 	if(materials)
 		returnToPool(materials)
 		materials = null
@@ -181,7 +181,7 @@
 		return
 
 	//We always split up movements into cardinals for issues with diagonal movements.
-	if(loc != NewLoc)
+	if(Dir || (loc != NewLoc))
 		if (!(Dir & (Dir - 1))) //Cardinal move
 			. = ..()
 		else //Diagonal move, split it into cardinal moves


### PR DESCRIPTION
For some reason, this check failed on any `step_size` other than exactly one tile. This should change that.
Note that, while gliding doesn't work for any step with a `step_size` other than exactly one tile, it doesn't break gliding for the whole server unless the `step_size` isn't a *multiple* of one tile.

I'm pretty sure this will work just fine, but I want to test a couple things just to make sure