### PR TITLE
If assistants don't get maintenance, then neither should security

### DIFF
--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -67,11 +67,11 @@
 	else
 		return "Red Alert"
 
-/datum/job/hos/priority_reward_equip(var/mob/living/carbon/human/H) 
+/datum/job/hos/priority_reward_equip(var/mob/living/carbon/human/H)
 	equip_accessory(H, /obj/item/clothing/accessory/holster/handgun/preloaded/glock/fancy, /obj/item/clothing/under, 5)
 	H.equip_or_collect(new /obj/item/weapon/reagent_containers/food/drinks/soda_cans/cannedcopcoffee(H.back), slot_in_backpack)
 	H.equip_or_collect(new /obj/item/weapon/reagent_containers/food/snacks/donut/normal(H.back), slot_in_backpack)
-	
+
 
 /datum/job/warden
 	title = "Warden"
@@ -84,8 +84,8 @@
 	wage_payout = 65
 	selection_color = "#ffeeee"
 	idtype = /obj/item/weapon/card/id/security
-	access = list(access_weapons, access_security, access_sec_doors, access_brig, access_armory, access_court, access_maint_tunnels, access_morgue, access_eva)
-	minimal_access = list(access_weapons, access_security, access_sec_doors, access_brig, access_armory, access_court, access_maint_tunnels)
+	access = list(access_weapons, access_security, access_sec_doors, access_brig, access_armory, access_court, access_morgue, access_eva)
+	minimal_access = list(access_weapons, access_security, access_sec_doors, access_brig, access_armory, access_court)
 	minimal_player_age = 7
 
 	pdaslot=slot_belt
@@ -127,12 +127,12 @@
 	H.mind.store_memory("Frequencies list: <b>Security:</b> [SEC_FREQ]<br/>")
 	return 1
 
-/datum/job/warden/priority_reward_equip(var/mob/living/carbon/human/H) 
+/datum/job/warden/priority_reward_equip(var/mob/living/carbon/human/H)
 	equip_accessory(H, /obj/item/clothing/accessory/holster/knife/boot/preloaded/tactical, /obj/item/clothing/shoes, 5)
 	equip_accessory(H, /obj/item/clothing/accessory/holster/handgun/preloaded/glock, /obj/item/clothing/under, 5)
 	H.equip_or_collect(new /obj/item/weapon/reagent_containers/food/drinks/soda_cans/cannedcopcoffee(H.back), slot_in_backpack)
 	H.equip_or_collect(new /obj/item/weapon/storage/fancy/donut_box(H.back), slot_in_backpack)
-	
+
 
 /datum/job/detective
 	title = "Detective"
@@ -213,12 +213,12 @@
 	H.mind.store_memory("Frequencies list: <b>Security:</b> [SEC_FREQ]<br/>")
 	return 1
 
-/datum/job/detective/priority_reward_equip(var/mob/living/carbon/human/H) 
+/datum/job/detective/priority_reward_equip(var/mob/living/carbon/human/H)
 	equip_accessory(H, /obj/item/clothing/accessory/holster/knife/boot/preloaded/tactical, /obj/item/clothing/shoes, 5)
 	var/obj/item/weapon/reagent_containers/food/drinks/flask/detflask/bonusflask = new /obj/item/weapon/reagent_containers/food/drinks/flask/detflask(H.back)
 	bonusflask.reagents.add_reagent(DETCOFFEE, 60)
 	H.equip_or_collect(bonusflask, slot_in_backpack)
-	
+
 
 
 /datum/job/officer
@@ -232,8 +232,8 @@
 	wage_payout = 55
 	selection_color = "#ffeeee"
 	idtype = /obj/item/weapon/card/id/security
-	access = list(access_weapons, access_security, access_sec_doors, access_brig, access_court, access_maint_tunnels, access_morgue, access_eva)
-	minimal_access = list(access_weapons, access_security, access_sec_doors, access_brig, access_court, access_maint_tunnels)
+	access = list(access_weapons, access_security, access_sec_doors, access_brig, access_court, access_morgue, access_eva)
+	minimal_access = list(access_weapons, access_security, access_sec_doors, access_brig, access_court)
 	minimal_player_age = 7
 
 	pdaslot=slot_belt
@@ -281,8 +281,7 @@
 	if(assistant.current_positions > 5)
 		. = clamp(. + assistant.current_positions - 5, 0, 99)
 
-/datum/job/officer/priority_reward_equip(var/mob/living/carbon/human/H) 
+/datum/job/officer/priority_reward_equip(var/mob/living/carbon/human/H)
 	equip_accessory(H, /obj/item/clothing/accessory/holster/knife/boot/preloaded/tactical, /obj/item/clothing/shoes, 5)
 	H.equip_or_collect(new /obj/item/weapon/reagent_containers/food/drinks/soda_cans/cannedcopcoffee(H.back), slot_in_backpack)
 	H.equip_or_collect(new /obj/item/weapon/reagent_containers/food/snacks/donut/normal(H.back), slot_in_backpack)
-	


### PR DESCRIPTION
Addition to the dumbness that is #25113

merge it and revert it with that mess

:cl:
* tweak: the following jobs no longer have maintenance access: warden, security officer