### PR TITLE
Fixes an obscure yet annoying examine bug

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1236,7 +1236,7 @@ Use this proc preferably at the end of an equipment loadout
 		memory()
 
 //mob verbs are faster than object verbs. See http://www.byond.com/forum/?post=1326139&page=2#comment8198716 for why this isn't atom/verb/examine()
-/mob/verb/examination(atom/A as mob|obj|turf in view(src)) //It used to be oview(12), but I can't really say why
+/mob/verb/examination(atom/A as mob|obj|turf in view(get_turf(src))) //It used to be oview(12), but I can't really say why
 	set name = "Examine"
 	set category = "IC"
 


### PR DESCRIPTION
This shit existed for years
:cl:
 * bugfix: Fixes an obscure examine bug that gave you an error message if you were right-click examining things.