### PR TITLE
Updates admin achievements

### DIFF
--- a/__DEFINES/global.dm
+++ b/__DEFINES/global.dm
@@ -302,7 +302,7 @@ var/global/list/volunteer_gladiators = list()
 var/global/list/ready_gladiators = list()
 var/global/list/never_gladiators = list()
 
-var/global/list/achievements = list()
+//var/global/list/achievements = list()
 
 //icons that appear on the Round End pop-up browser
 var/global/list/end_icons = list()

--- a/__DEFINES/global.dm
+++ b/__DEFINES/global.dm
@@ -302,8 +302,6 @@ var/global/list/volunteer_gladiators = list()
 var/global/list/ready_gladiators = list()
 var/global/list/never_gladiators = list()
 
-//var/global/list/achievements = list()
-
 //icons that appear on the Round End pop-up browser
 var/global/list/end_icons = list()
 

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -700,13 +700,12 @@ var/datum/controller/gameticker/ticker
 	return text
 
 /datum/controller/gameticker/proc/achievement_declare_completion()
+	if((achievements.len == 0) || (achievements.len == null))
+		return
 	var/text = "<br><FONT size = 5><b>Additionally, the following players earned achievements:</b></FONT>"
-	var/icon/cup = icon('icons/obj/drinks.dmi', "golden_cup")
-	end_icons += cup
-	var/tempstate = end_icons.len
-	for(var/winner in achievements)
-		text += {"<br><img src="logo_[tempstate].png"> [winner]"}
-
+	//ITEM, CKEY, MOB NAME, AWARD NAME, AWARD DESC
+	for(var/i = 1, i < achievements.len, i+=5)
+		text += {"<br>[bicon(achievements[i])] <b>[achievements[i+1]]</b> as <b>[achievements[i+2]]</b> won <b>[achievements[i+3]]</b>, <b>[achievements[i+4]]!</b>"}
 	return text
 
 /datum/controller/gameticker/proc/get_all_heads()

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -700,7 +700,7 @@ var/datum/controller/gameticker/ticker
 	return text
 
 /datum/controller/gameticker/proc/achievement_declare_completion()
-	if((achievements.len == 0) || (achievements.len == null))
+	if(!achievements)
 		return
 	var/text = "<br><FONT size = 5><b>Additionally, the following players earned achievements:</b></FONT>"
 	//ITEM, CKEY, MOB NAME, AWARD NAME, AWARD DESC

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -16,6 +16,8 @@ var/datum/controller/gameticker/ticker
 	var/event_time = null
 	var/event = 0
 
+	var/list/achievements = list()
+
 	var/login_music			// music played in pregame lobby
 
 	var/list/datum/mind/minds = list()//The people in the game. Used for objective tracking.
@@ -700,12 +702,11 @@ var/datum/controller/gameticker/ticker
 	return text
 
 /datum/controller/gameticker/proc/achievement_declare_completion()
-	if(!achievements)
+	if(!ticker.achievements.len)
 		return
 	var/text = "<br><FONT size = 5><b>Additionally, the following players earned achievements:</b></FONT>"
-	//ITEM, CKEY, MOB NAME, AWARD NAME, AWARD DESC
-	for(var/i = 1, i < achievements.len, i+=5)
-		text += {"<br>[bicon(achievements[i])] <b>[achievements[i+1]]</b> as <b>[achievements[i+2]]</b> won <b>[achievements[i+3]]</b>, <b>[achievements[i+4]]!</b>"}
+	for(var/datum/achievement/achievement in ticker.achievements)
+		text += {"<br>[bicon(achievement.item)] <b>[achievement.ckey]</b> as <b>[achievement.mob_name]</b> won <b>[achievement.award_name]</b>, <b>[achievement.award_desc]!</b>"}
 	return text
 
 /datum/controller/gameticker/proc/get_all_heads()

--- a/code/game/gamemodes/scoreboard.dm
+++ b/code/game/gamemodes/scoreboard.dm
@@ -14,7 +14,7 @@
 	if(bomberman_mode)
 		completions += "<br>[bomberman_declare_completion()]"
 
-	if(achievements.len)
+	if(ticker.achievements.len)
 		completions += "<br>[achievement_declare_completion()]"
 
 	var/ai_completions = ""
@@ -622,3 +622,17 @@
 	popup.open()
 
 	return
+
+/datum/achievement
+    var/item
+    var/ckey
+    var/mob_name
+    var/award_name
+    var/award_desc
+
+/datum/achievement/New(var/item, var/ckey, var/mob_name, var/award_name, var/award_desc)
+	src.item = item
+	src.ckey = ckey
+	src.mob_name = mob_name
+	src.award_name = award_name
+	src.award_desc = award_desc

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -962,7 +962,7 @@ var/list/admin_verbs_mod = list(
 		award = new /obj/item/weapon/reagent_containers/food/drinks/golden_cup(get_turf(winner))
 	if(achoice == "Gold medal")
 		award = new /obj/item/clothing/accessory/medal/gold(get_turf(winner))
-	if(achoice == "Dunce Cap")
+	if(achoice == "Dunce cap")
 		award = new /obj/item/clothing/head/dunce_cap(get_turf(winner))
 	award.name = name
 	award.desc = desc
@@ -978,7 +978,9 @@ var/list/admin_verbs_mod = list(
 		to_chat(world, "<span class='danger'>[bicon(award)] <b>[winner.name]</b> wins \"<b>[name]</b>\"!</span>")
 
 	to_chat(winner, "<span class='danger'>[bicon(award)] Congratulations to you, <b>[winner.name]</b>! You have won \"<b>[name]</b>\"!</span>")
-	achievements.Add(award,winner.key,winner.name,name,desc)
+
+	var/datum/achievement = new /datum/achievement(award, winner.key, winner.name, name, desc)
+	ticker.achievements.Add(achievement)
 
 	message_admins("[key_name_admin(usr)] has awarded <b>[winner.key]</b>([winner.name]) with the achievement \"<b>[name]</b>\"! \"[desc]\".", 1)
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -975,11 +975,11 @@ var/list/admin_verbs_mod = list(
 	var/icon/cup = icon('icons/obj/drinks.dmi', "golden_cup")
 
 	if(glob == "No!")
-		winner.client << sound('sound/misc/achievement.ogg')
+		winner.client << sound('sound/misc/achievement.ogg', volume=35)
 		for(var/mob/dead/observer/O in player_list)
 			to_chat(O, "<span class='danger'>[bicon(cup)] <b>[winner.name]</b> wins \"<b>[name]</b>\"!</span>")
 	else
-		world << sound('sound/misc/achievement.ogg')
+		world << sound('sound/misc/achievement.ogg', volume=35)
 		to_chat(world, "<span class='danger'>[bicon(cup)] <b>[winner.name]</b> wins \"<b>[name]</b>\"!</span>")
 
 	to_chat(winner, "<span class='danger'>Congratulations!</span>")

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -950,40 +950,35 @@ var/list/admin_verbs_mod = list(
 		return
 
 	if(istype(winner, /mob/living))
-		achoice = alert("Give our winner his own award?","Achievement award", "Confirm", "Cancel")
+		achoice = alert("Are you sure you want to give them an award?","Achievement award", "Confirm", "Cancel")
 		if(achoice == "Cancel")
 			return
 
 	var/glob = alert("Announce the achievement globally? (Beware! Ruins immersion!)", "Announce To All Players", "No!","Yes!")
 
-	var/icon/award
-	if(achoice == "Confirm")
-		var/obj/item/I
-		achoice = alert("What award should they be given?","Award choice","Gold medal","Gold cup")
-		if(achoice == "Gold cup")
-			I = new /obj/item/weapon/reagent_containers/food/drinks/golden_cup(get_turf(winner))
-		if(achoice == "Gold medal")
-			I = new /obj/item/clothing/accessory/medal/gold(get_turf(winner))
-		I.name = name
-		I.desc = desc
-		award = I
-		if(iscarbon(winner) && (winner.stat == CONSCIOUS))
-			winner.put_in_hands(I)
-
-	else
-		to_chat(winner, "<span class='danger'>You win [name]! [desc]</span>")
+	var/obj/item/award
+	achoice = alert("What award should they be given?","Award choice","Gold medal","Gold cup","Dunce Cap")
+	if(achoice == "Gold cup")
+		award = new /obj/item/weapon/reagent_containers/food/drinks/golden_cup(get_turf(winner))
+	if(achoice == "Gold medal")
+		award = new /obj/item/clothing/accessory/medal/gold(get_turf(winner))
+	if(achoice == "Dunce Cap")
+		award = new /obj/item/clothing/head/dunce_cap(get_turf(winner))
+	award.name = name
+	award.desc = desc
+	if(iscarbon(winner) && (winner.stat == CONSCIOUS))
+		winner.put_in_hands(award)
 
 	if(glob == "No!")
 		winner.client << sound('sound/misc/achievement.ogg', volume=35)
 		for(var/mob/dead/observer/O in player_list)
-			to_chat(O, "<span class='danger'>[bicon(award)] <b>[winner.name]</b> wins \"<b>[name]</b>\"!</span>")
+			to_chat(O, "<span class='danger'>[bicon(award)] Attention all ghosts, <b>[winner.name]</b> wins \"<b>[name]</b>\"!</span>")
 	else
 		world << sound('sound/misc/achievement.ogg', volume=35)
 		to_chat(world, "<span class='danger'>[bicon(award)] <b>[winner.name]</b> wins \"<b>[name]</b>\"!</span>")
 
 	to_chat(winner, "<span class='danger'>[bicon(award)] Congratulations to you, <b>[winner.name]</b>! You have won \"<b>[name]</b>\"!</span>")
-
-	achievements += "<b>[winner.key]</b> as <b>[winner.name]</b> won \"<b>[name]</b>\"! \"[desc]\""
+	achievements.Add(award,winner.key,winner.name,name,desc)
 
 	message_admins("[key_name_admin(usr)] has awarded <b>[winner.key]</b>([winner.name]) with the achievement \"<b>[name]</b>\"! \"[desc]\".", 1)
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -956,33 +956,32 @@ var/list/admin_verbs_mod = list(
 
 	var/glob = alert("Announce the achievement globally? (Beware! Ruins immersion!)", "Announce To All Players", "No!","Yes!")
 
+	var/icon/award
 	if(achoice == "Confirm")
-
-		achoice = alert("What award should they be given?","Award choice","Gold medal","Gold cup")
 		var/obj/item/I
+		achoice = alert("What award should they be given?","Award choice","Gold medal","Gold cup")
 		if(achoice == "Gold cup")
 			I = new /obj/item/weapon/reagent_containers/food/drinks/golden_cup(get_turf(winner))
 		if(achoice == "Gold medal")
 			I = new /obj/item/clothing/accessory/medal/gold(get_turf(winner))
 		I.name = name
 		I.desc = desc
+		award = I
 		if(iscarbon(winner) && (winner.stat == CONSCIOUS))
 			winner.put_in_hands(I)
 
 	else
 		to_chat(winner, "<span class='danger'>You win [name]! [desc]</span>")
 
-	var/icon/cup = icon('icons/obj/drinks.dmi', "golden_cup")
-
 	if(glob == "No!")
 		winner.client << sound('sound/misc/achievement.ogg', volume=35)
 		for(var/mob/dead/observer/O in player_list)
-			to_chat(O, "<span class='danger'>[bicon(cup)] <b>[winner.name]</b> wins \"<b>[name]</b>\"!</span>")
+			to_chat(O, "<span class='danger'>[bicon(award)] <b>[winner.name]</b> wins \"<b>[name]</b>\"!</span>")
 	else
 		world << sound('sound/misc/achievement.ogg', volume=35)
-		to_chat(world, "<span class='danger'>[bicon(cup)] <b>[winner.name]</b> wins \"<b>[name]</b>\"!</span>")
+		to_chat(world, "<span class='danger'>[bicon(award)] <b>[winner.name]</b> wins \"<b>[name]</b>\"!</span>")
 
-	to_chat(winner, "<span class='danger'>Congratulations!</span>")
+	to_chat(winner, "<span class='danger'>[bicon(award)] Congratulations to you, <b>[winner.name]</b>! You have won \"<b>[name]</b>\"!</span>")
 
 	achievements += "<b>[winner.key]</b> as <b>[winner.name]</b> won \"<b>[name]</b>\"! \"[desc]\""
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -957,7 +957,7 @@ var/list/admin_verbs_mod = list(
 	var/glob = alert("Announce the achievement globally? (Beware! Ruins immersion!)", "Announce To All Players", "No!","Yes!")
 
 	var/obj/item/award
-	achoice = alert("What award should they be given?","Award choice","Gold medal","Gold cup","Dunce Cap")
+	achoice = alert("What award should they be given?","Award choice","Gold medal","Gold cup","Dunce cap")
 	if(achoice == "Gold cup")
 		award = new /obj/item/weapon/reagent_containers/food/drinks/golden_cup(get_turf(winner))
 	if(achoice == "Gold medal")

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -950,18 +950,25 @@ var/list/admin_verbs_mod = list(
 		return
 
 	if(istype(winner, /mob/living))
-		achoice = alert("Give our winner his own trophy?","Achievement Trophy", "Confirm", "Cancel")
+		achoice = alert("Give our winner his own award?","Achievement award", "Confirm", "Cancel")
 		if(achoice == "Cancel")
 			return
 
-	var/glob = alert("Announce the achievement globally? (Beware! Ruins immersion!)", "Last Question", "No!","Yes!")
+	var/glob = alert("Announce the achievement globally? (Beware! Ruins immersion!)", "Announce To All Players", "No!","Yes!")
 
 	if(achoice == "Confirm")
-		var/obj/item/weapon/reagent_containers/food/drinks/golden_cup/C = new(get_turf(winner))
-		C.name = name
-		C.desc = desc
+
+		achoice = alert("What award should they be given?","Award choice","Gold medal","Gold cup")
+		var/obj/item/I
+		if(achoice == "Gold cup")
+			I = new /obj/item/weapon/reagent_containers/food/drinks/golden_cup(get_turf(winner))
+		if(achoice == "Gold medal")
+			I = new /obj/item/clothing/accessory/medal/gold(get_turf(winner))
+		I.name = name
+		I.desc = desc
 		if(iscarbon(winner) && (winner.stat == CONSCIOUS))
-			winner.put_in_hands(C)
+			winner.put_in_hands(I)
+
 	else
 		to_chat(winner, "<span class='danger'>You win [name]! [desc]</span>")
 


### PR DESCRIPTION
[qol][featurerequest][administration]

Dorms asked for this. You can give people a trophy, a medal or a dunce cap. I could add more.

![image](https://user-images.githubusercontent.com/28162068/69503903-6d8ee580-0f16-11ea-9afd-d27b0dc1586a.png)

![image](https://user-images.githubusercontent.com/28162068/69503998-09205600-0f17-11ea-91e2-d30b14b65226.png)

:cl:
 * rscadd: Admins can now give out gold medals and dunce caps as achievements.
 * tweak: Changes some of the text for achievements to better reflect what's going on.