### PR TITLE
you can now write on gifts

### DIFF
--- a/code/game/objects/items/weapons/gift_wrappaper.dm
+++ b/code/game/objects/items/weapons/gift_wrappaper.dm
@@ -23,6 +23,18 @@
 	w_class = W
 	gift = target
 	update_icon()
+	
+/obj/item/weapon/gift/attackby(obj/item/W as obj, mob/user as mob)
+	if(istype(W, /obj/item/weapon/pen))
+		var/str = copytext(sanitize(input(user,"What should the label read? (max 26 characters)","Write a personal message!","")),1,MAX_NAME_LEN)
+		if (!Adjacent(user) || user.stat)
+			return
+		if(!str || !length(str))
+			to_chat(user, "<span class='warning'>Invalid text.</span>")
+			src.desc = "A wrapped item."
+			return
+		to_chat(M, "<span class='notice'>You write [str] on the label.</span>")
+		src.desc = "A wrapped item. The label reads: [str]"
 
 /obj/item/weapon/gift/update_icon()
 	switch(w_class)

--- a/code/game/objects/items/weapons/gift_wrappaper.dm
+++ b/code/game/objects/items/weapons/gift_wrappaper.dm
@@ -26,15 +26,16 @@
 	
 /obj/item/weapon/gift/attackby(obj/item/W as obj, mob/user as mob)
 	if(istype(W, /obj/item/weapon/pen))
-		var/str = copytext(sanitize(input(user,"What should the label read? (max 26 characters)","Write a personal message!","")),1,MAX_NAME_LEN)
+		var/str = copytext(sanitize(input(user,"What should the label read? (max 52 characters)","Write a personal message!","") as message|null),1,MAX_NAME_LEN * 2)
 		if (!Adjacent(user) || user.stat)
 			return
 		if(!str || !length(str))
-			to_chat(user, "<span class='warning'>Invalid text.</span>")
+			to_chat(user, "<span class='warning'>You clear the label.</span>")
 			src.desc = "A wrapped item."
 			return
-		to_chat(M, "<span class='notice'>You write [str] on the label.</span>")
+		to_chat(user, "<span class='notice'>You write [str] on the label.</span>")
 		src.desc = "A wrapped item. The label reads: [str]"
+		log_admin("[user.key]/([user.name]) tagged a gift with \"[str]\" at [get_turf(user)]")
 
 /obj/item/weapon/gift/update_icon()
 	switch(w_class)


### PR DESCRIPTION
It always made me sad that I couldn't write my waifu's name on a gift for her. So now you can.
![labeltext](https://user-images.githubusercontent.com/8468269/69498860-bd58b700-0eec-11ea-9261-a54e37c1eac2.png)
(max is 56 chars, didn't feel like taking another screenshot)


<!--[qol]-->

:cl:
 * rscadd: You can now write personal messages on gift-wrapped items!

