### PR TITLE
Adds the staff of swapping to the spellbook

### DIFF
--- a/code/game/gamemodes/wizard/artifacts.dm
+++ b/code/game/gamemodes/wizard/artifacts.dm
@@ -29,6 +29,13 @@
 	price = 2 * Sp_BASE_PRICE
 	spawned_items = list(/obj/item/weapon/gun/energy/staff/change)
 
+/datum/spellbook_artifact/staff_of_swapping
+	name = "Staff of Swapping"
+	desc = "An artefact that fires a glowing bolt of energy which transfers the caster and targets position in space. Wielding in it both hands increases the power of the staff, and allows it to pass through certain objects.."
+	abbreviation = "SW"
+	price = 20
+	spawned_items = list(/obj/item/weapon/gun/energy/staff/swapper)
+
 /datum/spellbook_artifact/mental_focus
 	name = "Mental Focus"
 	desc = "An artefact that channels the will of the user into destructive bolts of force."


### PR DESCRIPTION
<!-- [gameplay] -->

While this was already in the code, wiznerds couldn't actually buy it. It's a staff that switches the location of the shooter and the target. If you two hand the staff, it becomes more powerful and allows you to shoot it through glass, grates, and some other shit, who knows. Just thought it would be neat, and some fun stuff could be done while using it.

It costs twenty points.

:cl:
 * rscadd: Adds the staff of swapping, which switches the location of two people, to the spellbook.
