### PR TITLE
Xenos can no longer be autotraitored

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -193,6 +193,9 @@
 		if(isanimal(player) && !isborer(player))
 			living_players -= player //No animal traitors except borers.
 			continue
+		if(isalien(player))
+			living_players -= player //Xenos don't bother with the syndicate
+			continue
 		if(player.z == map.zCentcomm)
 			living_players -= player//we don't autotator people on Z=2
 			continue


### PR DESCRIPTION
closes #20941

:cl:
 * bugfix: Xenos can no longer be auto traitored by the dynamic midround ruleset