### PR TITLE
Namepick alarm now lasts twice as long

### DIFF
--- a/code/_onclick/hud/screen_alarms.dm
+++ b/code/_onclick/hud/screen_alarms.dm
@@ -125,6 +125,8 @@ var/global/list/screen_alarms_locs = list(
 #define SCREEN_ALARM_ROBOT_HACK "robot_hack"
 #define SCREEN_ALARM_ROBOT_LOCK "robot_lock"
 
+#define SCREEN_ALARM_NAMEPICK "namepick"
+
 /obj/abstract/screen/alert
 	name = "Alert"
 	desc = "Something seems to have gone wrong with this alert, so report this bug please."
@@ -232,17 +234,14 @@ so as to remain in compliance with the most up-to-date laws."
 		S.show_laws()
 		S.clear_alert(SCREEN_ALARM_ROBOT_LAW)
 
-#define SCREEN_ALARM_NAMEPICK "namepick"
-
 /obj/abstract/screen/alert/name_pick
 	name = "Pick a name"
 	desc = "Click here to change your name."
 	icon_state = "text"
-	timeout = 30 SECONDS
+	timeout = 60 SECONDS
 	var/namepick_message
 	var/role
 	var/allow_numbers
-
 
 /obj/abstract/screen/alert/name_pick/Click()
 	..()


### PR DESCRIPTION
![pickyournameyoudumbfuck](https://user-images.githubusercontent.com/17928298/69527476-28d17180-0f4b-11ea-9f4e-fa1323b60646.png)

I truly don't know if the people ahelping because they "didn't get the name change popup" just don't notice the alarm before it is gone(when i manually throw another alarm at them and tell them to check the alarm it 'works now') of if there's something truly fucky about the equip() alarm(works for me) but for now, let's make the alarm last more than 30 seconds

:cl:
 * tweak: The namepick alarm now lasts 60 seconds.