### PR TITLE
Fix door control specialfunctions

### DIFF
--- a/code/game/machinery/door_control.dm
+++ b/code/game/machinery/door_control.dm
@@ -89,11 +89,6 @@
 		for(var/obj/machinery/door/airlock/D in range(range, src))
 			if(D.id_tag == src.id_tag)
 				spawn(0)
-				if(specialfunctions & OPEN)
-					if(D.density)
-						D.open()
-					else
-						D.close()
 				if(specialfunctions & IDSCAN)
 					D.aiDisabledIdScanner = !D.aiDisabledIdScanner
 				if(specialfunctions & BOLTS)
@@ -104,6 +99,11 @@
 					D.secondsElectrified = D.secondsElectrified ? 0 : -1
 				if(specialfunctions & SAFE)
 					D.safe = !D.safe
+				if(specialfunctions & OPEN)
+					if(D.density)
+						D.open()
+					else
+						D.close()
 
 	else
 		for(var/obj/machinery/door/poddoor/M in poddoors)

--- a/code/game/machinery/door_control.dm
+++ b/code/game/machinery/door_control.dm
@@ -89,12 +89,11 @@
 		for(var/obj/machinery/door/airlock/D in range(range, src))
 			if(D.id_tag == src.id_tag)
 				spawn(0)
-				if(D)
+				if(specialfunctions & OPEN)
 					if(D.density)
 						D.open()
 					else
 						D.close()
-					return
 				if(specialfunctions & IDSCAN)
 					D.aiDisabledIdScanner = !D.aiDisabledIdScanner
 				if(specialfunctions & BOLTS)


### PR DESCRIPTION
Door controls are supposed to have a bitflag that decides whether the control opens, bolts, shocks, etc. the airlock it's affecting. They didn't respect the bitflag's `OPEN` setting and always tried to open the door, so if you had a door control that only toggles the bolts it would still try to open anyway.

This fixes that. 

:cl:
  * bugfix: Dorm doors no longer instantly open after unbolting them using the door control switch.