### PR TITLE
Centcomm orders

### DIFF
--- a/__DEFINES/materials.dm
+++ b/__DEFINES/materials.dm
@@ -1,0 +1,11 @@
+#define VALUE_IRON 0.2
+#define VALUE_GLASS 0.2
+#define VALUE_DIAMOND 4
+#define VALUE_PLASMA 0.2
+#define VALUE_GOLD 1
+#define VALUE_SILVER 1
+#define VALUE_URANIUM 1
+#define VALUE_CLOWN 1
+#define VALUE_PHAZON 1
+#define VALUE_MYTHRIL 1
+#define VALUE_TELECRYSTAL 1

--- a/code/game/centcomm_orders.dm
+++ b/code/game/centcomm_orders.dm
@@ -295,7 +295,7 @@ var/global/current_centcomm_order_id=124901
 	create_centcomm_order(new choice)
 
 /proc/create_random_orders(var/num_orders)
-	var/list/choices = pick(get_potential_orders())
-	for(var/i = 0 to num_orders)
+	var/list/choices = get_potential_orders()
+	for(var/i = 1 to num_orders)
 		var/choice = pick_n_take(choices)
 		create_centcomm_order(new choice)

--- a/code/game/centcomm_orders.dm
+++ b/code/game/centcomm_orders.dm
@@ -277,3 +277,25 @@ var/global/current_centcomm_order_id=124901
 		/obj/item/weapon/reagent_containers/food/snacks/sundayroast = rand(1,2)
 	)
 	worth = rand(400,900)*requested[requested[1]]
+
+/proc/create_centcomm_order(var/datum/centcomm_order/C)
+	SSsupply_shuttle.add_centcomm_order(C)
+
+/proc/get_potential_orders()
+	var/list/orders = list()
+	orders.Add(subtypesof(/datum/centcomm_order/department/cargo))
+	orders.Add(subtypesof(/datum/centcomm_order/department/science))
+	orders.Add(subtypesof(/datum/centcomm_order/department/medical))
+	orders.Add(subtypesof(/datum/centcomm_order/department/civilian))
+
+	return orders
+
+/proc/create_random_order()
+	var/choice = pick(get_potential_orders())
+	create_centcomm_order(new choice)
+
+/proc/create_random_orders(var/num_orders)
+	var/list/choices = pick(get_potential_orders())
+	for(var/i = 0 to num_orders)
+		var/choice = pick_n_take(choices)
+		create_centcomm_order(new choice)

--- a/code/game/centcomm_orders.dm
+++ b/code/game/centcomm_orders.dm
@@ -24,6 +24,7 @@ var/global/current_centcomm_order_id=124901
 /datum/centcomm_order/New()
 	..()
 	id = current_centcomm_order_id++
+	name = command_name()
 
 /datum/centcomm_order/proc/CheckShuttleObject(var/obj/O, var/in_crate)
 	if(must_be_in_crate && !in_crate)
@@ -132,3 +133,147 @@ var/global/current_centcomm_order_id=124901
 	unit_prices=list(
 		/obj/item/stack/sheet/mineral/plasma = 0.5 // 1 credit per two plasma sheets.
 	)
+
+/datum/centcomm_order/department/New()
+	..()
+	acct = department_accounts[acct_by_string]
+
+/datum/centcomm_order/department/cargo //Orders that cargo can manage
+	acct_by_string = "Cargo"
+
+/datum/centcomm_order/department/cargo/diamonds/New()
+	..()
+	requested = list(
+		/obj/item/stack/sheet/mineral/diamond = rand(5,50)
+	)
+	worth = (VALUE_DIAMOND+rand(1,3))*requested[requested[1]]
+
+/datum/centcomm_order/department/cargo/uranium/New()
+	..()
+	requested = list(
+		/obj/item/stack/sheet/mineral/uranium = rand(5,50)
+	)
+	worth = (VALUE_URANIUM*rand(1,3))*requested[requested[1]]
+
+/datum/centcomm_order/department/cargo/gold/New()
+	..()
+	requested = list(
+		/obj/item/stack/sheet/mineral/gold = rand(5,50)
+	)
+	worth = (VALUE_GOLD*rand(1,3))*requested[requested[1]]
+
+/datum/centcomm_order/department/cargo/silver/New()
+	..()
+	requested = list(
+		/obj/item/stack/sheet/mineral/silver = rand(5,50)
+	)
+	worth = (VALUE_SILVER*rand(1,3))*requested[requested[1]]
+
+/datum/centcomm_order/department/cargo/phazon/New()
+	..()
+	requested = list(
+		/obj/item/stack/sheet/mineral/phazon = rand(1,10)
+	)
+	worth = (VALUE_PHAZON*rand(1,3))*requested[requested[1]]
+
+/datum/centcomm_order/department/cargo/clown/New()
+	..()
+	requested = list(
+		/obj/item/stack/sheet/mineral/clown = rand(1,10)
+	)
+	worth = (VALUE_CLOWN*rand(1,3))*requested[requested[1]]
+
+
+/datum/centcomm_order/department/science //Orders that science can manage
+	acct_by_string = "Science"
+
+/datum/centcomm_order/department/science/nuclear_gun/New()
+	..()
+	requested = list(
+		/obj/item/weapon/gun/energy/gun/nuclear = rand(1,5)
+	)
+	worth = rand(350,750)*requested[requested[1]]
+
+/datum/centcomm_order/department/science/subspace_tunnel/New()
+	..()
+	requested = list(
+		/obj/item/weapon/subspacetunneler = rand(1,3)
+	)
+	worth = rand(350,750)*requested[requested[1]]
+
+/datum/centcomm_order/department/medical
+	acct_by_string = "Medical"
+
+/datum/centcomm_order/department/medical/kidneys/New()
+	..()
+	requested = list(
+		/obj/item/organ/internal/kidneys = rand(1,3)
+	)
+	worth = rand(100,300)*requested[requested[1]]
+
+/datum/centcomm_order/department/civilian
+	acct_by_string = "Civilian"
+
+/datum/centcomm_order/department/civilian/pie/New()
+	..()
+	requested = list(
+		/obj/item/weapon/reagent_containers/food/snacks/pie = rand(3,12)
+	)
+	worth = rand(15,30)*requested[requested[1]]
+	name = "Clown Federation" //honk
+
+/datum/centcomm_order/department/civilian/poutinecitadel/New()
+	..()
+	requested = list(
+		/obj/structure/poutineocean/poutinecitadel = 1
+	)
+	worth = rand(1000,3000)*requested[requested[1]]
+
+/datum/centcomm_order/department/civilian/sweetsundaeramen/New()
+	..()
+	requested = list(
+		/obj/item/weapon/reagent_containers/food/snacks/sweetsundaeramen = rand(1,3)
+	)
+	worth = rand(150,300)*requested[requested[1]]
+
+/datum/centcomm_order/department/civilian/superburger/New()
+	..()
+	requested = list(
+		/obj/item/weapon/reagent_containers/food/snacks/superbiteburger = rand(1,3)
+	)
+	worth = rand(250,500)*requested[requested[1]]
+
+/datum/centcomm_order/department/civilian/turkey/New()
+	..()
+	requested = list(
+		/obj/item/weapon/reagent_containers/food/snacks/sliceable/turkey = rand(1,2)
+	)
+	worth = rand(200,400)*requested[requested[1]]
+
+/datum/centcomm_order/department/civilian/popcake/New()
+	..()
+	requested = list(
+		/obj/structure/popout_cake = 1
+	)
+	worth = rand(600,1200)*requested[requested[1]]
+
+/datum/centcomm_order/department/civilian/bkipper/New()
+	..()
+	requested = list(
+		/obj/item/weapon/reagent_containers/food/snacks/bleachkipper = rand(2,5)
+	)
+	worth = rand(120,500)*requested[requested[1]]
+
+/datum/centcomm_order/department/civilian/potentham/New()
+	..()
+	requested = list(
+		/obj/item/weapon/reagent_containers/food/snacks/potentham = rand(1,2)
+	)
+	worth = rand(400,2001)*requested[requested[1]]
+
+/datum/centcomm_order/department/civilian/sundayroast/New()
+	..()
+	requested = list(
+		/obj/item/weapon/reagent_containers/food/snacks/sundayroast = rand(1,2)
+	)
+	worth = rand(400,900)*requested[requested[1]]

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -260,7 +260,7 @@ var/datum/controller/gameticker/ticker
 		//Holiday Round-start stuff	~Carn
 		Holiday_Game_Start()
 		//mode.Clean_Antags()
-
+		create_random_orders(3) //Populate the order system so cargo has something to do
 	//start_events() //handles random events and space dust.
 	//new random event system is handled from the MC.
 

--- a/code/modules/events/centcomm_order.dm
+++ b/code/modules/events/centcomm_order.dm
@@ -6,132 +6,16 @@
 	return 25
 
 /datum/event/centcomm_order/start()
-	var/datum/centcomm_order/C = new
-	C.name = command_name()
-	if(prob(50))
-		C.must_be_in_crate = rand(0,1)
-
 	//Who is it paying to
+	var/choice
 	var/department = pick("Cargo","Medical","Science","Civilian")
-	var/list/choices
-	C.acct = department_accounts[department]
-	C.acct_by_string = department
 	switch(department)
 		if("Cargo") //Minerals
-			choices = list(
-				list(
-					"item" = /obj/item/stack/sheet/mineral/diamond,
-					"amount" = rand(5,50),
-					"value" = rand(400, 2500)
-					),
-				list(
-					"item" = /obj/item/stack/sheet/mineral/uranium,
-					"amount" = rand(5,50),
-					"value" = rand(200, 1500)
-					),
-				list(
-					"item" = /obj/item/stack/sheet/mineral/gold,
-					"amount" = rand(5,50),
-					"value" = rand(200, 1500)
-					),
-				list(
-					"item" = /obj/item/stack/sheet/mineral/silver,
-					"amount" = rand(5,50),
-					"value" = rand(200, 1500)
-					),
-				list(
-					"item" = /obj/item/stack/sheet/mineral/phazon,
-					"amount" = rand(1,10),
-					"value" = rand(400, 5000)
-					),
-				list(
-					"item" = /obj/item/stack/sheet/mineral/clown,
-					"amount" = rand(1,10),
-					"value" = rand(200, 3500)
-					)
-				)
-
+			choice = pick(subtypesof(/datum/centcomm_order/department/cargo))
 		if("Science") //Guns
-			choices = list(
-				list(
-					"item" = /obj/item/weapon/gun/energy/gun/nuclear,
-					"amount" = rand(1,5),
-					"value" = rand(350,1250),
-					),
-				list(
-					"item" = /obj/item/weapon/subspacetunneler,
-					"amount" = rand(1,3),
-					"value" = rand(350,1250),
-					)
-				)
+			choice = pick(subtypesof(/datum/centcomm_order/department/science))
 		if("Medical") //Stolen organs
-			choices = list(
-				list(
-					"item" = /obj/item/organ/internal/kidneys,
-					"amount" = rand(1,3),
-					"value" = rand(300,900),
-					),
-				)
+			choice = pick(subtypesof(/datum/centcomm_order/department/medical))
 		if("Civilian") //FOOD
-			choices = list(
-				list(
-					"item" = /obj/item/weapon/reagent_containers/food/snacks/pie,
-					"amount" = rand(3,12),
-					"value" = rand(60,190),
-					"name_override" = "Clown Federation" //Honk
-					),
-				list(
-					"item" = /obj/structure/poutineocean/poutinecitadel,
-					"amount" = 1,
-					"value" = rand(1000,3000),
-					),
-				list(
-					"item" = /obj/item/weapon/reagent_containers/food/snacks/sweetsundaeramen,
-					"amount" = rand(1,3),
-					"value" = rand(150,700),
-					),
-				list(
-					"item" = /obj/item/weapon/reagent_containers/food/snacks/superbiteburger,
-					"amount" = rand(1,3),
-					"value" = rand(300,800),
-					),
-				list(
-					"item" = /obj/item/weapon/reagent_containers/food/snacks/sliceable/turkey,
-					"amount" = rand(1,2),
-					"value" = rand(100,400),
-					),
-				list(
-					"item" = /obj/structure/popout_cake,
-					"amount" = 1,
-					"value" = rand(600,2000),
-					),
-				list(
-					"item" = /obj/item/weapon/reagent_containers/food/snacks/bleachkipper,
-					"amount" = rand(2,5),
-					"value" = rand(120,500),
-					),
-				list(
-					"item" = /obj/item/weapon/reagent_containers/food/snacks/potentham,
-					"amount" = rand(1,2),
-					"value" = rand(400,2001),
-					),
-				list(
-					"item" = /obj/item/weapon/reagent_containers/food/snacks/sundayroast,
-					"amount" = rand(1,2),
-					"value" = rand(400,900),
-					),
-				)
-
-
-	var/list/chosen = pick(choices)
-	var/item = chosen["item"]
-	var/amount = chosen["amount"]
-	var/value = chosen["value"]
-	if(chosen["name_override"])
-		C.name = chosen["name_override"]
-	var/list/product = list(item)
-	product[item] = amount
-	C.requested = product
-	C.worth = value
-	C.acct_by_string = department
-	SSsupply_shuttle.add_centcomm_order(C)
+			choice = pick(subtypesof(/datum/centcomm_order/department/civilian))
+	SSsupply_shuttle.add_centcomm_order(new choice)

--- a/code/modules/events/centcomm_order.dm
+++ b/code/modules/events/centcomm_order.dm
@@ -6,16 +6,4 @@
 	return 25
 
 /datum/event/centcomm_order/start()
-	//Who is it paying to
-	var/choice
-	var/department = pick("Cargo","Medical","Science","Civilian")
-	switch(department)
-		if("Cargo") //Minerals
-			choice = pick(subtypesof(/datum/centcomm_order/department/cargo))
-		if("Science") //Guns
-			choice = pick(subtypesof(/datum/centcomm_order/department/science))
-		if("Medical") //Stolen organs
-			choice = pick(subtypesof(/datum/centcomm_order/department/medical))
-		if("Civilian") //FOOD
-			choice = pick(subtypesof(/datum/centcomm_order/department/civilian))
-	SSsupply_shuttle.add_centcomm_order(new choice)
+	create_random_order()

--- a/code/modules/mining/materials.dm
+++ b/code/modules/mining/materials.dm
@@ -192,7 +192,7 @@ var/global/list/initial_materials	//Stores all the matids = 0 in helping New
 /datum/material/iron
 	name="Iron"
 	id=MAT_IRON
-	value=0.2
+	value=VALUE_IRON
 	cc_per_sheet=CC_PER_SHEET_METAL
 	oretype=/obj/item/stack/ore/iron
 	sheettype=/obj/item/stack/sheet/metal
@@ -207,7 +207,7 @@ var/global/list/initial_materials	//Stores all the matids = 0 in helping New
 	name="Sand"
 	processed_name="Glass"
 	id=MAT_GLASS
-	value=0.2
+	value=VALUE_GLASS
 	cc_per_sheet=CC_PER_SHEET_GLASS
 	oretype=/obj/item/stack/ore/glass
 	sheettype=/obj/item/stack/sheet/glass/glass
@@ -229,7 +229,7 @@ var/global/list/initial_materials	//Stores all the matids = 0 in helping New
 /datum/material/diamond
 	name="Diamond"
 	id=MAT_DIAMOND
-	value=4
+	value=VALUE_DIAMOND
 	cc_per_sheet = 1750
 	oretype=/obj/item/stack/ore/diamond
 	sheettype=/obj/item/stack/sheet/mineral/diamond
@@ -244,7 +244,7 @@ var/global/list/initial_materials	//Stores all the matids = 0 in helping New
 /datum/material/plasma
 	name="Plasma"
 	id=MAT_PLASMA
-	value=0.2
+	value=VALUE_PLASMA
 	oretype=/obj/item/stack/ore/plasma
 	sheettype=/obj/item/stack/sheet/mineral/plasma
 	cointype=/obj/item/weapon/coin/plasma
@@ -263,7 +263,7 @@ var/global/list/initial_materials	//Stores all the matids = 0 in helping New
 /datum/material/gold
 	name="Gold"
 	id=MAT_GOLD
-	value=1
+	value=VALUE_GOLD
 	oretype=/obj/item/stack/ore/gold
 	sheettype=/obj/item/stack/sheet/mineral/gold
 	cointype=/obj/item/weapon/coin/gold
@@ -276,7 +276,7 @@ var/global/list/initial_materials	//Stores all the matids = 0 in helping New
 /datum/material/silver
 	name="Silver"
 	id=MAT_SILVER
-	value=1
+	value=VALUE_SILVER
 	oretype=/obj/item/stack/ore/silver
 	sheettype=/obj/item/stack/sheet/mineral/silver
 	cointype=/obj/item/weapon/coin/silver
@@ -290,7 +290,7 @@ var/global/list/initial_materials	//Stores all the matids = 0 in helping New
 /datum/material/uranium
 	name="Uranium"
 	id=MAT_URANIUM
-	value=1
+	value=VALUE_URANIUM
 	oretype=/obj/item/stack/ore/uranium
 	sheettype=/obj/item/stack/sheet/mineral/uranium
 	cointype=/obj/item/weapon/coin/uranium
@@ -311,7 +311,7 @@ var/global/list/initial_materials	//Stores all the matids = 0 in helping New
 /datum/material/clown
 	name="Bananium"
 	id=MAT_CLOWN
-	value=1
+	value=VALUE_CLOWN
 	oretype=/obj/item/stack/ore/clown
 	sheettype=/obj/item/stack/sheet/mineral/clown
 	cointype=/obj/item/weapon/coin/clown
@@ -339,7 +339,7 @@ var/global/list/initial_materials	//Stores all the matids = 0 in helping New
 /datum/material/phazon
 	name="Phazon"
 	id=MAT_PHAZON
-	value=1
+	value=VALUE_PHAZON
 	cc_per_sheet = 1500
 	oretype=/obj/item/stack/ore/phazon
 	sheettype=/obj/item/stack/sheet/mineral/phazon
@@ -423,7 +423,7 @@ var/global/list/initial_materials	//Stores all the matids = 0 in helping New
 /datum/material/mythril
 	name="mythril"
 	id=MAT_MYTHRIL
-	value=1
+	value=VALUE_MYTHRIL
 	oretype=/obj/item/stack/ore/mythril
 	sheettype=/obj/item/stack/sheet/mineral/mythril
 	cointype=/obj/item/weapon/coin/mythril
@@ -436,7 +436,7 @@ var/global/list/initial_materials	//Stores all the matids = 0 in helping New
 /datum/material/telecrystal
 	name="telecrystal"
 	id=MAT_TELECRYSTAL
-	value=1
+	value=VALUE_TELECRYSTAL
 	oretype=/obj/item/stack/ore/telecrystal
 	sheettype=/obj/item/bluespace_crystal
 	cointype=null

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -40,6 +40,7 @@
 #include "__DEFINES\lighting.dm"
 #include "__DEFINES\limb_defines.dm"
 #include "__DEFINES\machinery.dm"
+#include "__DEFINES\materials.dm"
 #include "__DEFINES\math_physics.dm"
 #include "__DEFINES\MC.dm"
 #include "__DEFINES\mobs.dm"


### PR DESCRIPTION
It's been about 2 years since I mucked up salvaging centcomm orders, this should be a better system.

 - Material worth moved to defines
 - Removes the switch statement that was the previous centcomm order, moves them to datum defines so it's easier to make new ones
 - 3 Centcomm orders are generated at roundstart for cargo to pursue

:cl:
 * rscadd: 3 Centcomm orders are now generated at roundstart