### PR TITLE
Moves default admin verbs to +ADMIN

### DIFF
--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -90,7 +90,7 @@
 	if (holder)
 		for (var/client/C in admins)
 			var/displayrank = "\improper [C.holder.rank]"
-			if (R_ADMIN & C.holder.rights || !(R_MOD & C.holder.rights))
+			if (R_ADMIN & C.holder.rights)
 				aNames += "\t[C] is \an [displayrank]"
 
 				if (C.holder.fakekey)
@@ -129,7 +129,7 @@
 	else
 		for (var/client/C in admins)
 			var/displayrank = "\improper [C.holder.rank]"
-			if (R_ADMIN & C.holder.rights || !(R_MOD & C.holder.rights))
+			if (R_ADMIN & C.holder.rights)
 				if (!C.holder.fakekey)
 					aNames += "\t[C] is \an [displayrank]\n"
 					numAdminsOnline++

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -1,5 +1,12 @@
 //admin verb groups - They can overlap if you so wish. Only one of each verb will exist in the verbs list regardless
 var/list/admin_verbs_default = list(
+
+// Everyone has +ADMIN so we don't actually need anything in here.
+// Downside: The observers no longer have msay if we lack defaults.
+
+	)
+var/list/admin_verbs_admin = list(
+
 	/datum/admins/proc/show_player_panel,	/*shows an interface for individual players, with various links (links require additional flags*/
 	/client/proc/deadmin_self,			/*destroys our own admin datum so we can play as a regular player*/
 	/client/proc/hide_verbs,			/*hides all our adminverbs*/
@@ -8,10 +15,9 @@ var/list/admin_verbs_default = list(
 	/client/proc/check_antagonists,		/*shows all antags*/
 	/client/proc/advwho,				/*in addition to listing connected ckeys, shows character name and living/dead/antag status for each*/
 	/datum/admins/proc/checkCID,
-	/datum/admins/proc/checkCKEY
-//	/client/proc/deadchat				/*toggles deadchat on/off*/
-	)
-var/list/admin_verbs_admin = list(
+	/datum/admins/proc/checkCKEY,
+	//	/client/proc/deadchat				/*toggles deadchat on/off*/
+
 	/client/proc/set_base_turf,
 	/datum/admins/proc/delay,
 	/client/proc/SendCentcommFax,		/*sends a fax to all fax machines*/

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -3,12 +3,12 @@ var/list/admin_verbs_default = list(
 
 // Everyone has +ADMIN so we don't actually need anything in here.
 // Downside: The observers no longer have msay if we lack defaults.
+	/client/proc/deadmin_self,			/*destroys our own admin datum so we can play as a regular player*/
 
 	)
 var/list/admin_verbs_admin = list(
 
 	/datum/admins/proc/show_player_panel,	/*shows an interface for individual players, with various links (links require additional flags*/
-	/client/proc/deadmin_self,			/*destroys our own admin datum so we can play as a regular player*/
 	/client/proc/hide_verbs,			/*hides all our adminverbs*/
 	/client/proc/hide_most_verbs,		/*hides all our hideable adminverbs*/
 	/client/proc/debug_variables,		/*allows us to -see- the variables of any instance in the game. +VAREDIT needed to modify*/


### PR DESCRIPTION
[administration][discussion][qol]

So, this is one that I was tossing around and one that was requested. You might recall that nuke was deadminned by probe because, while he had +SOUND and played some nice music for us, the default admin verbs also happened to give him msay and access to admin controls.

This didn't sit right with me, since EVERY admin and codermin also has +ADMIN, apart from our single cross server observer, who could just have an observer verb role assigned to him.

Anyway, this fixes that. A new DJ role can easily be made that gives +SOUND and lacks msay and vv and all the other stuff. Tested it locally, seems fine. This shouldnt affect anything if you're locally hosting as the highest rank of 'host'.

-->
:cl:
 * tweak: Default admin verbs no longer exist. They are now under +ADMIN.
 * bugfix: Moderators are now a supported admin rank for those without +ADMIN