### PR TITLE
Dynamic now kicks in at 20 players

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic.dm
+++ b/code/datums/gamemode/dynamic/dynamic.dm
@@ -282,7 +282,7 @@ var/stacking_limit = 90
 				if (threat_level > 75)
 					extra_rulesets_amount++
 		else
-			if (rst_pop >= high_pop_limit - 10)
+			if (rst_pop >= high_pop_limit - 25)
 				if (threat_level >= second_rule_req[indice_pop])
 					extra_rulesets_amount++
 					if (threat_level >= third_rule_req[indice_pop])


### PR DESCRIPTION
Dynamic only kicked in at 35 players
Why the change?

- Combined with a general amount of lowpop during roughly 12 hours only traitors and other high-priority roles would spawn, making most other antags rare during such hours.
- The change made ninja and catbeast far, far rarer than other antags and made the soul rambler impossible to naturally appear. It still doesn't appear right now because it only spawns at up to 20 players but I am testing the waters for the public reception to such a change. On the other hand the antag ruleset itself could be changed instead to be allowed to kick in at more players.
- Traitors rolling constantly are distracting people from the cult psyop and making them dislike traitor a little bit more 


:cl:
 * tweak: Dynamic now kicks in at 20 players instead of 35.