### PR TITLE
Powercreeper Stuff

### DIFF
--- a/code/game/gamemodes/events/powercreeper.dm
+++ b/code/game/gamemodes/events/powercreeper.dm
@@ -83,11 +83,14 @@
 		if(isturf(loc))
 			var/turf/T = loc
 			environment = T.return_air()
+			if(environment.temperature < T0C)
+				die()
+				return
 		//add power to powernet through converting atmospheric heat to power
 		add_avail(-(environment.add_thermal_energy(max(environment.get_thermal_energy_change(T0C),-POWER_PER_FRUIT*10)/10)))
 		if(growdirs)
 			var/grow_chance = clamp(MIN_SPREAD_CHANCE + (powernet.avail/1000), MIN_SPREAD_CHANCE, MAX_SPREAD_CHANCE)
-			if(prob(grow_chance))
+			if(prob(grow_chance) && (environment.temperature > T0C + 5))
 				var/chosen_dir = pick(cardinal)
 				if(growdirs & chosen_dir)
 					var/turf/target_turf = get_step(src, chosen_dir)
@@ -137,6 +140,8 @@
 
 /obj/structure/cable/powercreeper/proc/try_electrocution(var/mob/living/M)
 	if(!istype(M) || M.isDead())
+		return 0
+	if(M_NO_SHOCK in M.mutations)
 		return 0
 	Beam(M, "lighting", 'icons/obj/zap.dmi', 5, 2)
 	playsound(src,'sound/weapons/electriczap.ogg',50, 1) //we still want a sound

--- a/code/game/gamemodes/events/powercreeper.dm
+++ b/code/game/gamemodes/events/powercreeper.dm
@@ -141,8 +141,6 @@
 /obj/structure/cable/powercreeper/proc/try_electrocution(var/mob/living/M)
 	if(!istype(M) || M.isDead())
 		return 0
-	if(M_NO_SHOCK in M.mutations)
-		return 0
 	Beam(M, "lighting", 'icons/obj/zap.dmi', 5, 2)
 	playsound(src,'sound/weapons/electriczap.ogg',50, 1) //we still want a sound
 	return electrocute_mob(M, powernet, src)

--- a/code/modules/events/powercreeper.dm
+++ b/code/modules/events/powercreeper.dm
@@ -1,7 +1,7 @@
 /datum/event/powercreeper
 
 /datum/event/powercreeper/can_start()
-	return 0
+	return 15
 
 /datum/event/powercreeper/start()
 	spawn()

--- a/code/modules/power/powernet.dm
+++ b/code/modules/power/powernet.dm
@@ -292,6 +292,9 @@ var/global/powernets_broke = 0
 	if(istype(M.loc, /obj/mecha))											// feckin mechs are dumb
 		return 0
 
+	if(M_NO_SHOCK in M.mutations)
+		return 0
+
 	if(istype(M, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = M
 


### PR DESCRIPTION
fixes  #24562
closes #25041
closes #23614

Fully tested including with space, snow, and foaming down a room. Also tested the shock immunity thing.

You can pretty easily end a powercreeper infestation with a foam extinguisher, tweaking distro, or even smashing a window (to kill it locally). I think this is a great way to balance it out.

🆑 
* rscadd: Powercreeper can once again occur by random event
* tweak: Powercreeper will not spread at or below 5C, and dies when exposed to temperatures under 0C. This by extension means it dies if it attempts to spread to space or snow.
* bugfix: Powercreeper will not shock someone with the NO_SHOCK gene