### PR TITLE
Replaces light overlays for radstorm, emergency call and firealarms

### DIFF
--- a/__DEFINES/lighting.dm
+++ b/__DEFINES/lighting.dm
@@ -62,6 +62,7 @@
 #define LIGHT_COLOR_PURPLE	   "#99149b"  //Sinister. (153, 20, 155)
 
 //These ones aren't a direct colour like the ones above, because nothing would fit
+#define LIGHT_COLOR_EMERGENCY  "#B11623" //Emergency red light (177, 22, 35)
 #define LIGHT_COLOR_FIRE       "#FAA019" //Warm orange color, leaning strongly towards yellow. rgb(250, 160, 25)
 #define LIGHT_COLOR_FLARE      "#FA644B" //Bright, non-saturated red. Leaning slightly towards pink for visibility. rgb(250, 100, 75)
 #define LIGHT_COLOR_SLIME_LAMP "#AFC84B" //Weird color, between yellow and green, very slimy. rgb(175, 200, 75)

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -238,7 +238,7 @@ var/area/space_area
 /area/proc/firealert()
 	if(isspace(src)) //no fire alarms in space
 		return
-	if( !fire )
+	if(!fire)
 		fire = 1
 		updateicon()
 		mouse_opacity = 0
@@ -339,28 +339,26 @@ var/area/space_area
 /area/proc/updateicon()
 	if ((fire || eject || party || radalert) && ((!requires_power)?(!requires_power):power_environ))//If it doesn't require power, can still activate this proc.
 		// Highest priority at the top.
+		var/color_to_set
 		if(radalert && !fire)
-			icon_state = "radiation"
+			color_to_set = LIGHT_COLOR_GREEN
 		else if(fire && !radalert && !eject && !party)
-			icon_state = "blue"
-		/*else if(atmosalm && !fire && !eject && !party)
-			icon_state = "bluenew"*/
+			color_to_set = LIGHT_COLOR_BLUE
 		else if(!fire && eject && !party)
-			icon_state = "red"
+			color_to_set = LIGHT_COLOR_EMERGENCY
 		else if(party && !fire && !eject)
 			icon_state = "party"
+			return
 		else
 			icon_state = "blue-red"
+			return
+		for(var/obj/machinery/light/L in src)
+			L.set_light(L.light_range, L.light_power, color_to_set)
 	else
 	//	new lighting behaviour with obj lights
 		icon_state = null
-
-
-/*
-#define EQUIP 1
-#define LIGHT 2
-#define ENVIRON 3
-*/
+		for(var/obj/machinery/light/L in src)
+			L.set_light(L.light_range, L.light_power, LIGHT_COLOR_TUNGSTEN)
 
 /area/proc/powered(var/chan)		// return true if the area has power to given channel
 


### PR DESCRIPTION
Replaces them with changing light colors for areas.

radstorm:
![radstorm](https://i.imgur.com/4W3Yn8Z.png)

emergency hallways:
![emergency](https://i.imgur.com/Lr7I2aZ.png)

firealarm:
![firealarm](https://i.imgur.com/YaknJOa.png)

I'm open to suggestions

:cl:
 * tweak: Lights for firealarms, radstorm, and emergency call are now different.