### PR TITLE
Nuclear Operatives uplink bomb is now a timer bomb as intended

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -260,7 +260,7 @@ var/list/uplink_items = list()
 /datum/uplink_item/dangerous/dude_bombs_lmao
 	name = "Modified Tank Transfer Valve"
 	desc = "A small, expensive and powerful plasma-oxygen explosive. Handle very carefully."
-	item = /obj/effect/spawner/newbomb
+	item = /obj/effect/spawner/newbomb/timer
 	cost = 25
 	jobs_exclusive = list("Nuclear Operative")
 	refundable = TRUE


### PR DESCRIPTION
Don't trust code you haven't written, it'll bite you in the ass

Note that the syndicate sub-type only makes it gay and not spawn in when ordered. So not what we want. It does have the big booms you expect too (3, 7, 14)

:cl:
 * bugfix: Fixed Nuclear Operatives bombs having a remote signaller instead of a timer. Now with 90 % less "oh god" factor for that fool who buys a bomb to gift to the station