### PR TITLE
Mapload rules

### DIFF
--- a/code/datums/map_elements.dm
+++ b/code/datums/map_elements.dm
@@ -24,6 +24,7 @@ var/list/datum/map_element/map_elements = list()
 	if(x + width > world.maxx || y + height > world.maxy)
 		WARNING("Cancelled loading [src]. Map enlargement is forbidden.")
 		return FALSE
+	return TRUE
 
 /datum/map_element/proc/initialize(list/objects) //Called after loading the element. The "objects" list contains all spawned atoms
 	map_elements.Add(src)

--- a/code/datums/map_elements.dm
+++ b/code/datums/map_elements.dm
@@ -18,6 +18,13 @@ var/list/datum/map_element/map_elements = list()
 /datum/map_element/proc/pre_load() //Called before loading the element
 	return
 
+/datum/map_element/proc/can_load(x, y)
+	if(map.can_enlarge)
+		return TRUE
+	if(x + width > world.maxx || y + height > world.maxy)
+		WARNING("Cancelled loading [src]. Map enlargement is forbidden.")
+		return FALSE
+
 /datum/map_element/proc/initialize(list/objects) //Called after loading the element. The "objects" list contains all spawned atoms
 	map_elements.Add(src)
 
@@ -32,6 +39,9 @@ var/list/datum/map_element/map_elements = list()
 	//In some cases, location is set to null (when creating a new z-level, for example)
 	//To account for that, location is set again in maploader's load_map() proc
 	location = locate(x+1, y+1, z)
+
+	if(!can_load(x,y))
+		return 0
 
 	pre_load()
 

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -118,11 +118,19 @@ var/list/map_dimension_cache = list()
 		var/map_width = x_depth / key_len //To get the map's width, divide the length of the line by the length of the key
 
 		if(world.maxx < map_width + x_offset)
+			if(!map.can_enlarge)
+				WARNING("Cancelled load of [map_element] due to map bounds.")
+				return list()
 			world.maxx = map_width + x_offset
+			WARNING("Loading [map_element] enlarged the map. New max x = [world.maxx]")
 
 		var/y_depth = z_depth / (x_depth+1) //x_depth + 1 because we're counting the '\n' characters in z_depth
 		if(world.maxy < y_depth + y_offset)
+			if(!map.can_enlarge)
+				WARNING("Cancelled load of [map_element] due to map bounds.")
+				return list()
 			world.maxy = y_depth + y_offset
+			WARNING("Loading [map_element] enlarged the map. New max y = [world.maxy]")
 
 		//then proceed it line by line, starting from top
 		ycrd = y_offset + y_depth

--- a/maps/_map.dm
+++ b/maps/_map.dm
@@ -99,6 +99,8 @@
 	var/center_x = 226
 	var/center_y = 254
 
+	var/can_enlarge = TRUE //can map elements expand this map? turn off for surface maps
+
 /datum/map/New()
 	. = ..()
 

--- a/maps/snaxi.dm
+++ b/maps/snaxi.dm
@@ -39,6 +39,7 @@
 	center_y = 150
 
 	snow_theme = 1
+	can_enlarge = FALSE
 
 /datum/map/active/New()
 	.=..()


### PR DESCRIPTION
This should finally fix the bug where Snaxi can sometimes get stretched by vault placement

Tested a few times but even before the fix it took 8 map generations before the bug happened [map borders only fucked up on the one time vaults loading increased the mapsize]
Only tested twice after the fix, it did not appear again but as you can see that is a small sample size. Vaults still loaded and map borders were good.

🆑 
* bugfix: Fixed a vault loading bug that sometimes caused space to appear on Z1 of Snaxi