### PR TITLE
Silicon Movement Parity

### DIFF
--- a/__DEFINES/silicon.dm
+++ b/__DEFINES/silicon.dm
@@ -89,7 +89,8 @@ var/global/list/all_robot_modules = default_nanotrasen_robot_modules + emergency
 #define MOMMI_MAX_COIL 50
 
 //Speed-related defines
-#define SILICON_NO_CHARGE_SLOWDOWN 1.4
+#define SILI_LOW_SLOW 1.4
+#define SILI_LOW_TRIGGER 1875 //25% of starter cell
 #define SILICON_NO_CELL_SLOWDOWN 15
 
 #define CYBORG_ENGINEERING_SPEED_MODIFIER 1

--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -40,8 +40,12 @@
 			. *= SILICON_HIGH_DAMAGE_SLOWDOWN_MULTIPLIER
 		if(module_active && istype(module_active,/obj/item/borg/combat/mobility))
 			. *= SILICON_MOBILITY_MODULE_SPEED_MODIFIER
-		if(cell.charge <= 0)
-			. *= SILICON_NO_CHARGE_SLOWDOWN
+		if(cell.charge <= SILI_LOW_TRIGGER) //25% of a starter cell
+			if(cell.charge <= 0)
+				. *= SILICON_NO_CELL_SLOWDOWN
+			else
+				//This should be +1.4 at the trigger point and +2 at maximum
+				. += SILI_LOW_SLOW + 0.6*(SILI_LOW_TRIGGER-cell.charge)/SILI_LOW_TRIGGER
 		else
 			if(module)
 				. *= module.speed_modifier


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9782036/70002911-1779fd80-1527-11ea-95bd-ff781c0a386c.png)


Previously silicons did not suffer any slowdown from neglecting their battery. If they ran all the way out (usually due to ninja attack), they only got hit with a 1.4 multiplier (which in practice is usually actually only +0.4 for them). Meanwhile humans would get a _flat +1.4_ immediately upon reaching 25% nutrition (125/500), which scales up to +2 at fully hungry (0/500).

This brings it into parity. Silicons will notice when they reach 1875 charge (25% of a borg starting cell at 7500) that they feel the hungry slow of +1.4, which scales up toward +2 as you get down near 0 charge. At 0 charge, you get the slowdown you experience when you have no cell inserted, so don't let this happen. This makes sense, what's the difference between 0 charge and no cell present?

_But wait_, won't that mean upgraded borgs who have an ultra cell [50,000 max] will only experience slowdown at 3.7% charge, while hungry humans slow at 25%? Yes, that's true. Consider it an edge silicons have. More reason to upgrade your cell, it gets you further away from the 1875 slow zone.

_End note: MoMMIs enjoy a larger starting battery with 10,000 charge, so for them the slow obviously doesn't kick in until later than cyborgs._

:cl:
* tweak: Silicons now experience a scaling slow when under 1875 charge, and a much more intense slow at 0 charge.