### PR TITLE
Security Winter crate is now locked

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -737,8 +737,6 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	contains = list(/obj/item/clothing/suit/storage/wintercoat/engineering,
 					/obj/item/clothing/suit/storage/wintercoat/engineering,
 					/obj/item/clothing/suit/storage/wintercoat/engineering/atmos,
-					/obj/item/clothing/suit/storage/wintercoat/engineering/atmos,
-					/obj/item/clothing/suit/storage/wintercoat/engineering/mechanic,
 					/obj/item/clothing/suit/storage/wintercoat/engineering/mechanic,
 					/obj/item/clothing/suit/storage/wintercoat/engineering/ce)
 	cost = 50
@@ -762,19 +760,19 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	name = "Security Winterwear"
 	contains = list(/obj/item/clothing/suit/storage/wintercoat/security,
 					/obj/item/clothing/suit/storage/wintercoat/security,
-					/obj/item/clothing/suit/storage/wintercoat/security,
-					/obj/item/clothing/suit/storage/wintercoat/security,
+					/obj/item/clothing/head/ushanka/security,
+					/obj/item/clothing/head/ushanka/security,
 					/obj/item/clothing/suit/storage/wintercoat/security/warden,
 					/obj/item/clothing/suit/storage/wintercoat/security/hos)
-	cost = 50
-	containertype = /obj/structure/closet/crate/basic
+	cost = 150
+	containertype = /obj/structure/closet/crate/secure/basic
 	containername = "security winter coats"
+	access = list(access_security)
 	group = "Clothing"
 
 /datum/supply_packs/medwinter
 	name = "Medical Winterwear"
 	contains = list(/obj/item/clothing/suit/storage/wintercoat/medical,
-					/obj/item/clothing/suit/storage/wintercoat/medical,
 					/obj/item/clothing/suit/storage/wintercoat/medical,
 					/obj/item/clothing/suit/storage/wintercoat/medical,
 					/obj/item/clothing/suit/storage/wintercoat/medical/paramedic,
@@ -789,7 +787,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	name = "Service Winterwear"
 	contains = list(/obj/item/clothing/suit/storage/wintercoat/hydro,
 					/obj/item/clothing/suit/storage/wintercoat/hydro,
-					/obj/item/clothing/suit/storage/wintercoat/hydro,
+					/obj/item/clothing/suit/storage/wintercoat/bartender,
 					/obj/item/clothing/suit/storage/wintercoat/bartender
 					/* chef */)
 	cost = 50
@@ -814,9 +812,6 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	contains = list(/obj/item/clothing/suit/storage/wintercoat/cargo,
 					/obj/item/clothing/suit/storage/wintercoat/cargo,
 					/obj/item/clothing/suit/storage/wintercoat/cargo,
-					/obj/item/clothing/suit/storage/wintercoat/cargo,
-					/obj/item/clothing/suit/storage/wintercoat/cargo,
-					/obj/item/clothing/suit/storage/wintercoat/miner,
 					/obj/item/clothing/suit/storage/wintercoat/miner,
 					/obj/item/clothing/suit/storage/wintercoat/miner)
 	cost = 50

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -813,6 +813,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/clothing/suit/storage/wintercoat/cargo,
 					/obj/item/clothing/suit/storage/wintercoat/cargo,
 					/obj/item/clothing/suit/storage/wintercoat/miner,
+					/obj/item/clothing/suit/storage/wintercoat/miner,
 					/obj/item/clothing/suit/storage/wintercoat/miner)
 	cost = 50
 	containertype = /obj/structure/closet/crate/basic


### PR DESCRIPTION
Changed the security winter coat crate to be more expensive and to be locked, only unlockable by a security access level ID. Also removed two of the winter coats and replaced them with security ushankas.

Also cleaned up some of the crates to reduce clutter. No longer will we have as many random engineering coats just lying around the place because we ordered seven coats for a two man department.

:cl:
 * tweak: changed security winter coat crate to a locked crate and upped the price by 100 credits
 * rscadd: security ushankas to security winter coat crate
 * rscdel: removed some coats cluttering up winter coat crates