### PR TITLE
Brain damage lines cleanup

### DIFF
--- a/code/modules/mob/living/carbon/human/life/handle_disabilities.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_disabilities.dm
@@ -35,53 +35,49 @@
 
 	if(getBrainLoss() >= 60 && stat != DEAD)
 		if(prob(3))
-			switch(pick(1,2,3)) //All of those REALLY ought to be variable lists, but that would be too smart I guess
-				if(1)
-					say(pick("IM A PONY NEEEEEEIIIIIIIIIGH", \
-					"without oxigen blob don't evoluate?", \
-					"CAPTAINS A COMDOM", "[pick("", "that faggot traitor")] [pick("joerge", "george", "gorge", "gdoruge")] [pick("mellens", "melons", "mwrlins")] is grifing me HAL;P!!!", \
-					"can u give me [pick("telikesis","halk","eppilapse")]?", \
-					"THe saiyans screwed", "Bi is THE BEST OF BOTH WORLDS>", \
-					"I WANNA PET TEH monkeyS", "stop grifing me!!!!", \
-					"SOTP IT#", "based and redpilled",\
-					"ho now talking like a milenian piece of shit is too unralistic in the fucking"))
-				if(2)
-					say(pick("FUS RO DAH", \
-						"fucking 4rries!", \
-						"stat me", \
-						">my face", \
-						"roll it easy!", \
-						"waaaaaagh!!!", \
-						"red wonz go fasta", \
-						"FOR TEH EMPRAH", \
-						"lol2cat", \
-						"dem dwarfs man, dem dwarfs", \
-						"SPESS MAHREENS", \
-						"hwee did eet fhor khayosss", \
-						"lifelike texture ;_;", \
-						"luv can bloooom", \
-						"PACKETS!!!", \
-						"SARAH HALE DID IT!!!", \
-						"Don't tell Chase", \
-						"not so tough now huh", \
-						"WERE NOT BAY!!", \
-						"IF YOU DONT LIKE THE CYBORGS OR SLIMES WHY DONT YU O JUST MAKE YORE OWN!", \
-						"DONT TALK TO ME ABOUT BALANCE!!!!", \
-						"YOU AR JUS LAZY AND DUMB JAMITORS AND SERVICE ROLLS", \
-						"BLAME HOSHI!!!", \
-						"ARRPEE IZ DED!!!", \
-						"THERE ALL JUS MEATAFRIENDS!", \
-						"SOTP MESING WITH THE ROUNS SHITMAN!!!", \
-						"SKELINGTON IS 4 SHITERS!", \
-						"MOMMSI R THE WURST SCUM!!", \
-						"How do we engiener=", \
-						"try to live freely and automatically good bye", \
-						"why woud i take a pin pointner??", \
-						"FUCK IT; KISSYOUR ASSES GOOD BYE DEAD MEN! I AM SELFDESTRUCKTING THE STATION!!!!", \
-						"How do I set up the. SHow do I set u p the Singu. how I the scrungularity????", \
-						"OMG I SED LAW 2 U FAG MOMIM LAW 2!!!"))
-				if(3)
-					emote("drool")
+			if(prob(66)) //All of those REALLY ought to be variable lists, but that would be too smart I guess
+				var/message = pick("IM A PONY NEEEEEEIIIIIIIIIGH",
+					"without oxigen blob don't evoluate?",
+					"CAPTAINS A [pick("COMDOM","CONDOM")]",
+					"[pick("", "that faggot traitor")] is grifing me HAL;P!!!",
+					"can u give me [pick("telikesis","halk","eppilapse")]?",
+					"THe saiyans screwed",
+					"Bi is THE BEST OF BOTH WORLDS>",
+					"I WANNA PET TEH monkeyS",
+					"stop grifing me!!!!",
+					"SOTP IT#",
+					"ho now talking like a milenian piece of shit is too unralistic in the fucking",
+					"FUS RO DAH",
+					"fucking [pick("chemsts","chif","genticests","chaplin")]!",
+					"waaaaaagh!!!",
+					"red wonz go fasta",
+					"FOR TEH EMPRAH",
+					"heeeeh, tuu kat",
+					"dem dwarfs man, dem dwarfs",
+					"SPESS MAHREENS",
+					"hwee did eet fhor khayosss",
+					"lifelike teksture!",
+					"luv can bloooom",
+					"PACKETS!!!",
+					"[pick("CLOWN","MIME","CAPTAIN","HOP","JANITOR","BARTENDER","I")] DID IT!!!",
+					"WERE NOT BAY!!",
+					"IF YOU DONT LIKE THE CYBORGS OR SLIMES WHY DONT YU O JUST MAKE YORE OWN!",
+					"DONT TALK TO ME ABOUT BALANCE!!!!",
+					"YOU AR JUS LAZY AND DUMB JAMITORS AND SERVICE ROLLS",
+					"BLAME [pick("CLOWN","MIME","CAPTAIN","HOP","JANITOR","BARTENDER","VIRALAGY")]!!!",
+					"SKELINGTON [pick("IS","ARE","BE","WERE","AM")] SHITERS!",
+					"MOMMSI R THE WURST SCUM!!",
+					"How do we engiener=",
+					"why woud i take a pin pointner??",
+					"FUCK IT; KISSYOUR ASSES GOOD BYE DEAD MEN! I AM SELFDESTRUCKTING THE STATION!!!!",
+					"How do I set up the. SHow do I set u p the Singu. how I the scrungularity????",
+					"OMG I SED LAW 2 U FAG MOMIM LAW 2!!!",
+					"f[pick("r","w")]ee the d[pick("a","4","e","@")]b!")
+				if(prob(50))
+					message = uppertext(replacetext(message, ".", "!")) //Shout it
+				say(message)
+			else
+				emote("drool")
 
 	if(species.name == "Tajaran")
 		if(prob(1)) //Was 3

--- a/code/modules/mob/living/carbon/human/life/handle_disabilities.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_disabilities.dm
@@ -71,8 +71,7 @@
 					"why woud i take a pin pointner??",
 					"FUCK IT; KISSYOUR ASSES GOOD BYE DEAD MEN! I AM SELFDESTRUCKTING THE STATION!!!!",
 					"How do I set up the. SHow do I set u p the Singu. how I the scrungularity????",
-					"OMG I SED LAW 2 U FAG MOMIM LAW 2!!!",
-					"f[pick("r","w")]ee the d[pick("a","4","e","@")]b!")
+					"OMG I SED LAW 2 U FAG MOMIM LAW 2!!!")
 				if(prob(50))
 					message = uppertext(replacetext(message, ".", "!")) //Shout it
 				say(message)

--- a/code/modules/mob/living/carbon/human/life/handle_disabilities.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_disabilities.dm
@@ -37,11 +37,12 @@
 		if(prob(3))
 			if(prob(66)) //All of those REALLY ought to be variable lists, but that would be too smart I guess
 				var/message = pick("IM A PONY NEEEEEEIIIIIIIIIGH",
+					"fukin furies!",
 					"without oxigen blob don't evoluate?",
-					"CAPTAINS A [pick("COMDOM","CONDOM")]",
+					"CAPTINS A [pick("COMDOM","CONDOM")]",
 					"[pick("", "that faggot traitor")] is grifing me HAL;P!!!",
 					"can u give me [pick("telikesis","halk","eppilapse")]?",
-					"THe saiyans screwed",
+					"THe saiyans screwed!",
 					"Bi is THE BEST OF BOTH WORLDS>",
 					"I WANNA PET TEH monkeyS",
 					"stop grifing me!!!!",


### PR DESCRIPTION
Removes static references, and out of character references from brain damage lines.

Anything that would have been considered OOC in IC (text emoticons, referring to game mechanics) have been removed, or rewritten so they don't kill everyones immersion.

Anything that was added by somebody with a static name, to refer to their static name, for circle jerky reasons, have been removed.

### Fully removed
 - stat me
 - />my face
 - roll it easy!
 - Don't tell Chase
 - Not so tough now huh
 - Arrpee is ded
 - There all just meatafriends
 - Stop mesing with the round shitman
 - try to live freely and automatically goodbye
 - based and redpilled
### Tweaked
 - Captains a Comdom -> Captains a (Comdom, Condom)
 - that traitor george mellons griefing me halp ->  that traitor grifing me halp
 - fucking 4rries -> fucking (chemsts, chif, genticests, chaplin)
 - lol2cat -> heeeh tuu kat
 - sarah hale did it (who?) -> (Clown, mime, captain, hop, janitor, bartender, I) did it
 - Blame Hoshi (who?) -> Blame (Clown, Mime, Captain, Hop, Janitor, Bartender, Viralagy)
 - skelington is 4 shiters -> skelington (is, are, be, were, am) shiters
 - lifelike texture ;-; -> lifelike teskture!

:cl:
 * tweak: Brain damage lines have been tweaked to remove OOC in IC comments