### PR TITLE
Revert newcryo

### DIFF
--- a/__DEFINES/__compile_options.dm
+++ b/__DEFINES/__compile_options.dm
@@ -25,7 +25,7 @@
 // test_box.dm:
 //#define MAP_OVERRIDE 5
 // test_tiny.dm:
-//#define MAP_OVERRIDE 6
+#define MAP_OVERRIDE 6
 // tgstation.dm:
 //#define MAP_OVERRIDE 7
 // wheelstation.dm
@@ -36,18 +36,18 @@
 
 // Toggles several features, explained in their respective comments.
 // You can turn those on and off manually if you prefer, instead of setting this
-#define DEVELOPER_MODE 0
+#define DEVELOPER_MODE 1
 
 // If 1, unit tests will be compiled
-#define UNIT_TESTS_ENABLED DEVELOPER_MODE
+#define UNIT_TESTS_ENABLED 0
 // If 1, unit tests run automatically
-#define UNIT_TESTS_AUTORUN DEVELOPER_MODE
+#define UNIT_TESTS_AUTORUN 0
 // If 1, the server stops after the tests are done
 #define UNIT_TESTS_STOP_SERVER_WHEN_DONE 0
 
 #if DEVELOPER_MODE
 // If defined, overrides the default lobby timer duration
-#define GAMETICKER_LOBBY_DURATION 5 SECONDS
+#define GAMETICKER_LOBBY_DURATION 10 SECONDS
 #endif
 // If 1, mob/Login checks for multiple connections from the same IP on different ckeys and warns the user
 #define WARN_FOR_CLIENTS_SHARING_IP !DEVELOPER_MODE

--- a/__DEFINES/__compile_options.dm
+++ b/__DEFINES/__compile_options.dm
@@ -25,7 +25,7 @@
 // test_box.dm:
 //#define MAP_OVERRIDE 5
 // test_tiny.dm:
-#define MAP_OVERRIDE 6
+//#define MAP_OVERRIDE 6
 // tgstation.dm:
 //#define MAP_OVERRIDE 7
 // wheelstation.dm
@@ -36,18 +36,18 @@
 
 // Toggles several features, explained in their respective comments.
 // You can turn those on and off manually if you prefer, instead of setting this
-#define DEVELOPER_MODE 1
+#define DEVELOPER_MODE 0
 
 // If 1, unit tests will be compiled
-#define UNIT_TESTS_ENABLED 0
+#define UNIT_TESTS_ENABLED DEVELOPER_MODE
 // If 1, unit tests run automatically
-#define UNIT_TESTS_AUTORUN 0
+#define UNIT_TESTS_AUTORUN DEVELOPER_MODE
 // If 1, the server stops after the tests are done
 #define UNIT_TESTS_STOP_SERVER_WHEN_DONE 0
 
 #if DEVELOPER_MODE
 // If defined, overrides the default lobby timer duration
-#define GAMETICKER_LOBBY_DURATION 10 SECONDS
+#define GAMETICKER_LOBBY_DURATION 5 SECONDS
 #endif
 // If 1, mob/Login checks for multiple connections from the same IP on different ckeys and warns the user
 #define WARN_FOR_CLIENTS_SHARING_IP !DEVELOPER_MODE

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -551,7 +551,7 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 		my_atom.on_reagent_change()
 	return 0
 
-/datum/reagents/proc/reaction(var/atom/A, var/method=TOUCH, var/volume_modifier=0, var/remove_reagents = FALSE)
+/datum/reagents/proc/reaction(var/atom/A, var/method=TOUCH, var/volume_modifier=0)
 
 	switch(method)
 		if(TOUCH)
@@ -560,7 +560,7 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 					if(isanimal(A))
 						R.reaction_animal(A, TOUCH, R.volume+volume_modifier)
 					else
-						R.reaction_mob(A, TOUCH, R.volume+volume_modifier, remove_reagents)
+						R.reaction_mob(A, TOUCH, R.volume+volume_modifier)
 				if(isturf(A))
 					R.reaction_turf(A, R.volume+volume_modifier)
 				if(istype(A, /obj))

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -40,7 +40,7 @@
 	var/density = 1 //(g/cm^3) Everything is water unless specified otherwise. round to 2dp
 	var/specheatcap = 1 //how much energy in joules it takes to heat this thing up by 1 degree (J/g). round to 2dp
 
-/datum/reagent/proc/reaction_mob(var/mob/living/M, var/method = TOUCH, var/volume, var/remove_reagents = FALSE)
+/datum/reagent/proc/reaction_mob(var/mob/living/M, var/method = TOUCH, var/volume)
 	set waitfor = 0
 
 	if(!holder)
@@ -76,8 +76,7 @@
 			if(prob(chance) && !block)
 				if(M.reagents)
 					M.reagents.add_reagent(self.id, self.volume/2) //Hardcoded, transfer half of volume
-					if(remove_reagents)
-						self.holder.remove_reagent(self.id, self.volume/2)
+
 	if (M.mind)
 		for (var/role in M.mind.antag_roles)
 			var/datum/role/R = M.mind.antag_roles[role]

--- a/nano/templates/cryo.tmpl
+++ b/nano/templates/cryo.tmpl
@@ -55,6 +55,7 @@ Used In File(s): \code\game\machinery\cryo.dm
 			</div>
 		{{/if}}
 	{{/if}}
+	<hr>
 	<div class="line">
 		<div class="statusLabel">Cell Temperature:</div><div class="statusValue">
 			<span class="{{:data.cellTemperatureStatus}}">{{:data.cellTemperature}} K</span>

--- a/nano/templates/cryo.tmpl
+++ b/nano/templates/cryo.tmpl
@@ -82,7 +82,7 @@ Used In File(s): \code\game\machinery\cryo.dm
 		{{:helper.link('Eject Occupant', 'arrowreturnthick-1-s', {'ejectOccupant' : 1}, data.hasOccupant ? null : 'disabled')}}
 	</div>
 </div>
-<br>
+<div class="item">&nbsp;</div>
 <div class="item">
 	<div class="itemLabel">
 		Beaker:
@@ -103,60 +103,6 @@ Used In File(s): \code\game\machinery\cryo.dm
 		{{:helper.link('Eject Beaker', 'eject', {'ejectBeaker' : 1}, data.isBeakerLoaded ? null : 'disabled')}}
 	</div>
 </div>
-<br>
-<div class="item">
-	<div class="itemLabel">
-		Cell contents:
-	</div>
-	<div class="itemContent" style="width: 40%;">
-		<table width="100%"><tbody>
-		{{for data.cryo_contents}}
-			<tr><td><span class="highlight">{{:value.name}}{{if data.scan_level > 1}} - {{:value.volume}} units{{/if}}</span>
-		{{empty}}
-			<span class="bad">Cell is empty</span>
-		{{/for}}
-		</tbody></table>
-	</div>
-	<div class="itemContent" style="width: 26%;">
-		{{:helper.link("Dump cell contents", null, {'dump_reagents': 1}, data.cryo_volume ? null : 'disabled')}}
-	</div>
-</div>
-<br>
-<div class="item">
-	<div class="itemLabel">
-		Controls: {{:helper.link(data.controls==1?"Hide":"Show", null, {'toggle_controls': 1})}}
-	</div>
-{{if data.controls}}
-		<div class="itemContent" style = "width: 40%;">
-			<div class="statusValue average">
-				Injection status:
-				<div class="floatRight">
-				{{:helper.link(data.injecting==1?"Active":"Inactive", null, {'toggle_inject': 1})}}
-				</div>
-			<br>
-			{{if data.scan_level >= 2}}
-					Injection rate (units):
-					<div class="floatRight">
-					{{:helper.link(data.injection_rate, 'carat-2-n-s', {'set_inject_rate': 1})}}
-					</div>
-					<br>
-			{{/if}}
-				Current dump location:
-				<div class="floatRight">
-				{{:helper.link(data.dump_loc==1?"Beaker":"Vicinity", null, {'toggle_dump': 1})}}
-			  </div>
-				<br>
-			{{if data.scan_level >= 4}}
-					Auto ejection:
-					<div class="floatRight">
-					{{:helper.link(data.auto_eject?"Active":"Inactive", null, {'toggle_autoeject': 1})}}
-					</div>
-				<br>
-			{{/if}}
-			</div>
-		</div>
-	</div>
-{{/if}}
 {{if data.ejecting}}
 	<div class="mask">
 		<div class="maskContent" style="margin: 160px 0">


### PR DESCRIPTION
Reverts #24475.
Discussion with medbay players brought to my attention that these changes only really made the experience worse for everyone, medbay or otherwise.
Agree? Disagree? Sound off in the comments below! Be sure to subscribe and leave a 👍.

🆑 
 - rscdel: Recent cryo changes have been reverted, and cryo chem duping is back.