### PR TITLE
Adds QoL Ban panel functionality

### DIFF
--- a/code/modules/admin/DB ban/functions.dm
+++ b/code/modules/admin/DB ban/functions.dm
@@ -223,7 +223,9 @@ datum/admins/proc/DB_ban_edit(var/banid = null, var/param = null)
 			message_admins("[key_name_admin(usr)] has edited a ban for [pckey]'s reason from [reason] to [value]",1)
 		if("duration")
 			if(!value)
-				value = input("Insert the new duration (in minutes) for [pckey]'s ban", "New Duration", "[duration]", null) as null|num
+				value = 1440*input("Add to the new duration (in days) for [pckey]'s ban", "Days Duration", "[duration]", null) as null|num
+				value += 60*input("Add to the new duration (in hours) for [pckey]'s ban", "Hours Duration", "[duration]", null) as null|num
+				value += input("Add to the new duration (in minutes) for [pckey]'s ban", "Minutes Duration", "[duration]", null) as null|num
 				if(!isnum(value) || !value)
 					to_chat(usr, "Cancelled")
 					return

--- a/code/modules/admin/DB ban/functions.dm
+++ b/code/modules/admin/DB ban/functions.dm
@@ -223,9 +223,9 @@ datum/admins/proc/DB_ban_edit(var/banid = null, var/param = null)
 			message_admins("[key_name_admin(usr)] has edited a ban for [pckey]'s reason from [reason] to [value]",1)
 		if("duration")
 			if(!value)
-				value = 1440*input("Add to the new duration (in days) for [pckey]'s ban", "Days Duration", "[duration]", null) as null|num
-				value += 60*input("Add to the new duration (in hours) for [pckey]'s ban", "Hours Duration", "[duration]", null) as null|num
-				value += input("Add to the new duration (in minutes) for [pckey]'s ban", "Minutes Duration", "[duration]", null) as null|num
+				value = 1440*input("Add the new duration (in days) for [pckey]'s ban", "Days Duration", "[duration]", null) as null|num
+				value += 60*input("Add the new duration (in hours) for [pckey]'s ban", "Hours Duration", "[duration]", null) as null|num
+				value += input("Add the new duration (in minutes) for [pckey]'s ban", "Minutes Duration", "[duration]", null) as null|num
 				if(!isnum(value) || !value)
 					to_chat(usr, "Cancelled")
 					return

--- a/code/modules/admin/DB ban/functions.dm
+++ b/code/modules/admin/DB ban/functions.dm
@@ -231,7 +231,7 @@ datum/admins/proc/DB_ban_edit(var/banid = null, var/param = null)
 					return
 
 			var/DBQuery/update_query = dbcon.NewQuery("UPDATE erro_ban SET duration = [value], edits = CONCAT(edits,'- [eckey] changed ban duration from [duration] to [value]<br>'), expiration_time = DATE_ADD(bantime, INTERVAL [value] MINUTE) WHERE id = [banid]")
-			message_admins("[key_name_admin(usr)] has edited a ban for [pckey]'s duration from [duration] to [value]",1)
+			message_admins("[key_name_admin(usr)] has edited a ban for [pckey]'s duration from [round_ban_time(duration)] to [round_ban_time(value)]",1)
 			update_query.Execute()
 		if("unban")
 			if(alert("Unban [pckey]?", "Unban?", "Yes", "No") == "Yes")

--- a/code/modules/admin/NewBan.dm
+++ b/code/modules/admin/NewBan.dm
@@ -168,6 +168,16 @@ var/savefile/Banlist
 			timeleftstring = "[exp] Minutes"
 		return timeleftstring
 
+/proc/round_ban_time(minutes as num)
+	var/timestring
+	if (minutes >= 1440) //1440 = 1 day in minutes
+		timestring = "[round(minutes / 1440, 0.1)] Days"
+	else if (minutes >= 60) //60 = 1 hour in minutes
+		timestring = "[round(minutes / 60, 0.1)] Hours"
+	else
+		timestring = "[minutes] Minutes"
+	return timestring
+
 /datum/admins/proc/unbanpanel()
 	var/count = 0
 	var/dat

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -759,7 +759,7 @@
 				var/mins = 0
 				if(minutes > CMinutes)
 					mins = minutes - CMinutes
-				to_chat(usr, "<span class='info'>The remaining time on this ban is [mins] minutes")
+				to_chat(usr, "<span class='info'>The remaining time on this ban is [round_ban_time(mins)]")
 				mins = 1440*input(usr,"How long (in days)?","Ban time", mins ? mins : 1440) as num|null
 				mins += 60*input(usr,"How long (in hours)?","Ban time", mins ? mins : 1440) as num|null
 				mins += input(usr,"How long (in minutes)?","Ban time", mins ? mins : 1440) as num|null
@@ -827,9 +827,9 @@
 							var/reason = input(usr,"Reason?","reason","Shinposting") as text|null
 							if(!reason)
 								return
-							ban_unban_log_save("[usr.client.ckey] has banned [M.ckey]. - Reason: [reason] - This will be removed in [mins] minutes.")
+							ban_unban_log_save("[usr.client.ckey] has banned [M.ckey]. - Reason: [reason] - This will be removed in [round_ban_time(mins)].")
 							to_chat(M, "<span class='warning'><BIG><B>You have been OOC banned by [usr.client.ckey].\nReason: [reason].</B></BIG></span>")
-							to_chat(M, "<span class='warning'>This is a temporary ooc ban, it will be removed in [mins] minutes.</span>")
+							to_chat(M, "<span class='warning'>This is a temporary ooc ban, it will be removed in [round_ban_time(mins)].</span>")
 							feedback_inc("ban_ooc_tmp",1)
 							DB_ban_record(BANTYPE_OOC_TEMP, M, mins, reason)
 							feedback_inc("ban_ooc_tmp_mins",mins)
@@ -837,8 +837,8 @@
 								to_chat(M, "<span class='warning'>To try to resolve this matter head to [config.banappeals] or consider not being a shithead in OOC</span>")
 							else
 								to_chat(M, "<span class='warning'>No ban appeals URL has been set.</span>")
-							log_admin("[usr.client.ckey] has ooc banned [M.ckey].\nReason: [reason]\nThis will be removed in [mins] minutes.")
-							message_admins("<span class='warning'>[usr.client.ckey] has ooc banned [M.ckey].\nReason: [reason]\nThis will be removed in [mins] minutes.</span>")
+							log_admin("[usr.client.ckey] has ooc banned [M.ckey].\nReason: [reason]\nThis will be removed in [round_ban_time(mins)].")
+							message_admins("<span class='warning'>[usr.client.ckey] has ooc banned [M.ckey].\nReason: [reason]\nThis will be removed in [round_ban_time(mins)].</span>")
 
 						if("No")
 							var/reason = input(usr,"Reason?","reason","Shinposting") as text|null
@@ -1360,8 +1360,8 @@
 
 					var/msg
 					for(var/job in notbannedlist)
-						ban_unban_log_save("[key_name(usr)] temp-jobbanned [key_name(M)] from [job] for [mins] minutes. reason: [reason]")
-						log_admin("[key_name(usr)] temp-jobbanned [key_name(M)] from [job] for [mins] minutes")
+						ban_unban_log_save("[key_name(usr)] temp-jobbanned [key_name(M)] from [job] for [round_ban_time(mins)]. reason: [reason]")
+						log_admin("[key_name(usr)] temp-jobbanned [key_name(M)] from [job] for [round_ban_time(mins)]")
 						feedback_inc("ban_job_tmp",1)
 						DB_ban_record(BANTYPE_JOB_TEMP, M, mins, reason, job)
 						feedback_add_details("ban_job_tmp","- [job]")
@@ -1371,10 +1371,10 @@
 						else
 							msg += ", [job]"
 					notes_add(M.ckey, "Banned  from [msg] - [reason]")
-					message_admins("<span class='notice'>[key_name_admin(usr)] banned [key_name_admin(M)] from [msg] for [mins] minutes</span>", 1)
+					message_admins("<span class='notice'>[key_name_admin(usr)] banned [key_name_admin(M)] from [msg] for [round_ban_time(mins)]</span>", 1)
 					to_chat(M, "<span class='warning'><BIG><B>You have been jobbanned by [usr.client.ckey] from: [msg].</B></BIG></span>")
 					to_chat(M, "<span class='danger'>The reason is: [reason]</span>")
-					to_chat(M, "<span class='warning'>This jobban will be lifted in [mins] minutes.</span>")
+					to_chat(M, "<span class='warning'>This jobban will be lifted in [round_ban_time(mins)].</span>")
 					href_list["jobban2"] = 1 // lets it fall through and refresh
 					return 1
 				if("No")
@@ -1505,9 +1505,9 @@
 				if(!reason)
 					return
 				AddBan(M.ckey, M.computer_id, reason, usr.ckey, 1, mins)
-				ban_unban_log_save("[usr.client.ckey] has banned [M.ckey]. - Reason: [reason] - This will be removed in [mins] minutes.")
+				ban_unban_log_save("[usr.client.ckey] has banned [M.ckey]. - Reason: [reason] - This will be removed in [round_ban_time(mins)].")
 				to_chat(M, "<span class='warning'><BIG><B>You have been banned by [usr.client.ckey].\nReason: [reason].</B></BIG></span>")
-				to_chat(M, "<span class='warning'>This is a temporary ban, it will be removed in [mins] minutes.</span>")
+				to_chat(M, "<span class='warning'>This is a temporary ban, it will be removed in [round_ban_time(mins)].</span>")
 				feedback_inc("ban_tmp",1)
 				DB_ban_record(BANTYPE_TEMP, M, mins, reason)
 				feedback_inc("ban_tmp_mins",mins)
@@ -1515,8 +1515,8 @@
 					to_chat(M, "<span class='warning'>To try to resolve this matter head to [config.banappeals]</span>")
 				else
 					to_chat(M, "<span class='warning'>No ban appeals URL has been set.</span>")
-				log_admin("[usr.client.ckey] has banned [M.ckey].\nReason: [reason]\nThis will be removed in [mins] minutes.")
-				message_admins("<span class='warning'>[usr.client.ckey] has banned [M.ckey].\nReason: [reason]\nThis will be removed in [mins] minutes.</span>")
+				log_admin("[usr.client.ckey] has banned [M.ckey].\nReason: [reason]\nThis will be removed in [round_ban_time(mins)].")
+				message_admins("<span class='warning'>[usr.client.ckey] has banned [M.ckey].\nReason: [reason]\nThis will be removed in [round_ban_time(mins)].</span>")
 
 				del(M.client)
 				//del(M)	// See no reason why to delete mob. Important stuff can be lost. And ban can be lifted before round ends.

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -758,16 +758,15 @@
 				temp = 1
 				var/mins = 0
 				if(minutes > CMinutes)
-					mins = minutes - CMinutes
-				to_chat(usr, "<span class='info'>The remaining time on this ban is [round_ban_time(mins)]")
-				mins = 1440*input(usr,"How long (in days)?","Ban time", mins ? mins : 1440) as num|null
-				mins += 60*input(usr,"How long (in hours)?","Ban time", mins ? mins : 1440) as num|null
-				mins += input(usr,"How long (in minutes)?","Ban time", mins ? mins : 1440) as num|null
+					mins = minutes - CMinutes // CMinutes is actually the current time, in minutes, and the ban stores a large value that isn't our ban length
+				mins = 1440*input(usr,"How long (in days)?","Ban time", 0) as num|null
+				mins += 60*input(usr,"How long (in hours)?","Ban time", 0) as num|null
+				mins += input(usr,"How long (in minutes)?","Ban time", 0) as num|null
 				if(!mins)
 					return
 				mins = min(525599,mins)
-				minutes = CMinutes + mins
-				duration = GetExp(minutes)
+				minutes = CMinutes + mins // Converts this back into something we can store on file
+				duration = mins
 				reason = input(usr,"Reason?","reason",reason2) as text|null
 				if(!reason)
 					return
@@ -778,9 +777,9 @@
 				if(!reason)
 					return
 
-		log_admin("[key_name(usr)] edited [banned_key]'s ban. Reason: [reason] Duration: [duration]")
-		ban_unban_log_save("[key_name(usr)] edited [banned_key]'s ban. Reason: [reason] Duration: [duration]")
-		message_admins("<span class='notice'>[key_name_admin(usr)] edited [banned_key]'s ban. Reason: [reason] Duration: [duration]</span>", 1)
+		log_admin("[key_name(usr)] edited [banned_key]'s ban. Reason: [reason] Duration: [round_ban_time(duration)]")
+		ban_unban_log_save("[key_name(usr)] edited [banned_key]'s ban. Reason: [reason] Duration: [round_ban_time(duration)]")
+		message_admins("<span class='notice'>[key_name_admin(usr)] edited [banned_key]'s ban. Reason: [reason] Duration: [round_ban_time(duration)]</span>", 1)
 		Banlist.cd = "/base/[banfolder]"
 		to_chat(Banlist["reason"], reason)
 		to_chat(Banlist["temp"], temp)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -753,15 +753,16 @@
 
 		var/duration
 
-		switch(alert("Temporary Ban?",,"Yes","No"))
+		switch(alert("Edit This Ban?",,"Yes","No"))
 			if("Yes")
 				temp = 1
 				var/mins = 0
 				if(minutes > CMinutes)
 					mins = minutes - CMinutes
-				mins += 1440*input(usr,"How long (in days)?","Ban time",0) as num|null
-				mins += 60*input(usr,"How long (in hours)?","Ban time",0) as num|null
-				mins += input(usr,"How long (in minutes)?","Ban time",0) as num|null
+				to_chat(usr, "<span class='info'>The remaining time on this ban is [mins] minutes")
+				mins = 1440*input(usr,"How long (in days)?","Ban time", mins ? mins : 1440) as num|null
+				mins += 60*input(usr,"How long (in hours)?","Ban time", mins ? mins : 1440) as num|null
+				mins += input(usr,"How long (in minutes)?","Ban time", mins ? mins : 1440) as num|null
 				if(!mins)
 					return
 				mins = min(525599,mins)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -759,7 +759,9 @@
 				var/mins = 0
 				if(minutes > CMinutes)
 					mins = minutes - CMinutes
-				mins = input(usr,"How long (in minutes)? (Default: 1440)","Ban time",mins ? mins : 1440) as num|null
+				mins += 1440*input(usr,"How long (in days)?","Ban time",0) as num|null
+				mins += 60*input(usr,"How long (in hours)?","Ban time",0) as num|null
+				mins += input(usr,"How long (in minutes)?","Ban time",0) as num|null
 				if(!mins)
 					return
 				mins = min(525599,mins)
@@ -814,7 +816,9 @@
 				if("Yes")
 					switch(alert("Temporary Ban?",,"Yes","No", "Cancel"))
 						if("Yes")
-							var/mins = input(usr,"How long (in minutes)?","OOC Ban time",1440) as num|null
+							var/mins = 1440*input(usr,"How long (in days)?","OOC Ban time",0) as num|null
+							mins += 60*input(usr,"How long (in hours)?","OOC Ban time",0) as num|null
+							mins += input(usr,"How long (in minutes)?","OOC Ban time",0) as num|null
 							if(!mins)
 								return
 							if(mins >= 525600)
@@ -1344,7 +1348,9 @@
 					if(config.ban_legacy_system)
 						to_chat(usr, "<span class='warning'>Your server is using the legacy banning system, which does not support temporary job bans. Consider upgrading. Aborting ban.</span>")
 						return
-					var/mins = input(usr,"How long (in minutes)?","Ban time",1440) as num|null
+					var/mins = 1440*input(usr,"How long (in days)?","Ban time",0) as num|null
+					mins += 60*input(usr,"How long (in hours)?","Ban time",0) as num|null
+					mins += input(usr,"How long (in minutes)?","Ban time",0) as num|null
 					if(!mins)
 						return
 					var/reason = input(usr,"Reason?","Please State Reason","") as text|null
@@ -1486,7 +1492,10 @@
 
 		switch(alert("Temporary Ban?",,"Yes","No", "Cancel"))
 			if("Yes")
-				var/mins = input(usr,"How long (in minutes)?","Ban time",1440) as num|null
+				var/mins
+				mins = 1440*input(usr,"How long (in days)?","Ban time",0) as num|null
+				mins += 60*input(usr,"How long (in hours)?","Ban time",0) as num|null
+				mins += input(usr,"How long (in minutes)?","Ban time",0) as num|null
 				if(!mins)
 					return
 				if(mins >= 525600)


### PR DESCRIPTION
[WiP][administration][discussion][qol][featurerequest]

The aim of this PR is to make it easier to ban people. I'm not able to addess the database, so we will likely need to test merge this PR to the test server for some testing.

Anyway, the goals:

1. To provide a means for admins to put in DD/HH/MM instead of just minutes like 1440 for a day to save them spending time calculating exactly what they want to put in.
2. To give more means of feedback to the admin and player, such as when they got banned, how long the ban is approximately in days/hours/minutes.
3. To make it easier to edit bans through the respective ban panels.

I'm currently having some issues getting the formatting right but currently it does assign the bans in minutes and performs the arithmetic just fine, but recalling those values and editting them seems to be playing up with me and I don't know why yet. Feedback appreciated.

:cl:
 * tweak: Admins banning in game can now select days/hours/minutes for the ban length.
 * bugfix: The ban panel in game is now slightly more informative than before.