### PR TITLE
Supplyborgs can now close closets and crates

### DIFF
--- a/__DEFINES/silicon.dm
+++ b/__DEFINES/silicon.dm
@@ -73,6 +73,7 @@ var/global/list/all_robot_modules = default_nanotrasen_robot_modules + emergency
 #define MODULE_HAS_PROJ_RES 4096		//Doesn't slow down from being hit by boolets
 #define MODULE_HAS_FLASH_RES 8192		//Recovers from being flashed twice as fast.
 #define MODULE_IS_FLASHPROOF 16384		//Flashes do nothing.
+#define MODULE_CAN_CLOSE_CLOSETS 32768	//Can open and close closets.
 
 #define HAS_MODULE_QUIRK(R, Q) (R.module && (R.module.quirk_flags & Q))
 

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -21,7 +21,7 @@
 							  //then open it in a populated area to crash clients.
 	var/breakout_time = 2 //2 minutes by default
 	var/sound_file = 'sound/machines/click.ogg'
-
+	var/required_quirk = MODULE_CAN_CLOSE_CLOSETS
 	var/has_electronics = 0
 	var/has_lock_type = null //The type this closet should be converted to if made ID secured
 	var/has_lockless_type = null //The type this closet should be converted to if made no longer ID secured
@@ -396,7 +396,7 @@
 
 // This is broken, see attack_ai.
 /obj/structure/closet/attack_robot(mob/living/silicon/robot/user as mob)
-	if(isMoMMI(user))
+	if(isMoMMI(user) || HAS_MODULE_QUIRK(user, required_quirk))
 		src.add_hiddenprint(user)
 		add_fingerprint(user)
 		return src.attack_hand(user)
@@ -576,13 +576,17 @@
 	if(usr.incapacitated())
 		return
 
-	if(ishuman(usr) || isMoMMI(usr))
-		if(isMoMMI(usr))
-			src.add_hiddenprint(usr)
-			add_fingerprint(usr)
+	if (isrobot(usr))
+		var/mob/living/silicon/robot/R = usr
+		if(isMoMMI(R) || HAS_MODULE_QUIRK(R, required_quirk))
+			src.attack_robot(R)
+			return
+
+	if(ishuman(usr))
 		src.attack_hand(usr)
-	else
-		to_chat(usr, "<span class='warning'>This mob type can't use this verb.</span>")
+		return
+
+	to_chat(usr, "<span class='warning'>This mob type can't use this verb.</span>")
 
 /obj/structure/closet/update_icon()//Putting the welded stuff in updateicon() so it's easy to overwrite for special cases (Fridges, cabinets, and whatnot)
 	overlays.len = 0

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -586,7 +586,7 @@
 		src.attack_hand(usr)
 		return
 
-	to_chat(usr, "<span class='warning'>This mob type can't use this verb.</span>")
+	to_chat(usr, "<span class='warning'>You can't toggle the open state of [src].</span>")
 
 /obj/structure/closet/update_icon()//Putting the welded stuff in updateicon() so it's easy to overwrite for special cases (Fridges, cabinets, and whatnot)
 	overlays.len = 0

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -470,6 +470,7 @@
 /obj/item/weapon/robot_module/miner
 	name = "supply robot module"
 	module_holder = "miner"
+	quirk_flags = MODULE_CAN_CLOSE_CLOSETS
 	networks = list(CAMERANET_MINE)
 	radio_key = /obj/item/device/encryptionkey/headset_mining
 	sprites = list(
@@ -500,6 +501,7 @@
 	modules += new /obj/item/weapon/gun/energy/kinetic_accelerator/cyborg(src)
 	modules += new /obj/item/weapon/gripper/no_use/inserter(src)
 	modules += new /obj/item/device/destTagger/cyborg(src)
+	modules += new /obj/item/weapon/storage/bag/clipboard(src)
 	modules += new /obj/item/device/gps/cyborg(src)
 	var/obj/item/stack/package_wrap/W = new /obj/item/stack/package_wrap(src)
 	W.amount = SUPPLY_MAX_WRAP


### PR DESCRIPTION
Fixes #25325
Adding a clipboard was also requested in the thread, didn't see a problem with it.
The toggle_open verb will also work for them, its suprising just how much stuff can't use that but should be able to.
Theres a comment claiming attack_robot is broken but using attack_ai I managed to break everything so... yeah. I'm hoping thats not going to be an issue because I tried it both ways.
Tested using human, mommi, robot (not supply),robot (supply) and even ai and it seems to be working fine.

![ezgif com-optimize](https://user-images.githubusercontent.com/14299601/70376721-d9ecea00-1903-11ea-842b-44ea5a56cc08.gif)
[featurerequest][qol]
:cl:
 * rscadd: Supply borgs get a clipboard. They can also open and close crates/lockers.