### PR TITLE
New medbay machine: the patient processor

### DIFF
--- a/code/modules/medical/patientprocessor.dm
+++ b/code/modules/medical/patientprocessor.dm
@@ -1,4 +1,4 @@
-/obj/machinery/medical/patient_processor
+/obj/machinery/patient_processor
 	name = "patient processor"
 	desc = "A device that uses advanced AutoDoc technology to heal patients."
 	icon = 'icons/obj/machines/mining_machines.dmi'
@@ -8,14 +8,61 @@
 	var/input_dir = 1
 	var/output_dir = 2
 
-/obj/machinery/medical/patient_processor/process()
+/obj/machinery/patient_processor/proc/notify_ghost(var/mob/M)
+	if(!M.client)
+		var/mob/dead/observer/ghost = mind_can_reenter(M.mind)
+		if(ghost)
+			var/mob/ghostmob = ghost.get_top_transmogrification()
+			if(ghostmob)
+				ghostmob << 'sound/effects/adminhelp.ogg'
+				to_chat(ghostmob, "<span class='interface big'><span class='bold'>You've been healed by the patient processor! Return to your body to get back into the round like you deserve.</span> \
+					(Verbs -> Ghost -> Re-enter corpse, or <a href='?src=\ref[ghost];reentercorpse=1'>click here!</a>)</span>")
+
+/obj/machinery/patient_processor/process()
 	if((!output_dir || !input_dir) || output_dir == input_dir)
 		return
 	var/input = get_step(src, input_dir)
 	var/output = get_step(src, output_dir)
 	var/mob/living/M = locate(/mob/living, input)
 	if(M)
-		M.rejuvenate(animation = TRUE)
+		notify_ghost(M)
 		M.forceMove(output)
+		M.rejuvenate(animation = TRUE)
 		return
-	//TODO: generate bodies for patients who have been reduced to brains or heads
+
+	//if we didn't fix a mob, we'll fix a head/brain
+	var/mob/living/carbon/brain/brainmob
+	var/obj/item/organ/O = locate(/obj/item/organ/, input)
+	if(!O)
+		return
+	var/obj/item/organ/external/head/head = O
+	var/obj/item/organ/internal/brain/brain = O
+	if(istype(head))
+		brainmob = head.brainmob
+	else if(istype(brain))
+		brainmob = brain.brainmob
+	if(!brainmob)
+		return
+	notify_ghost(brainmob)
+
+	//produce a new body
+	var/datum/dna/new_dna = brainmob.dna.Clone()
+	var/mob/living/carbon/human/new_body = new /mob/living/carbon/human(src, new_dna.species, delay_ready_dna = TRUE)
+	new_body.dna = new_dna
+	new_body.real_name = new_dna.real_name
+	new_body.flavor_text = new_dna.flavor_text
+	new_body.ckey = brainmob.ckey
+	brainmob.ckey = null
+	brainmob.mind.transfer_to(new_body)
+	to_chat(new_body, "<span class='notice'><b>You suddenly awaken inside some strange machine.</b></span>")
+	if (new_body.mind.miming)
+		new_body.add_spell(new /spell/aoe_turf/conjure/forcewall/mime, "grey_spell_ready")
+		if (new_body.mind.miming == MIMING_OUT_OF_CHOICE)
+			new_body.add_spell(new /spell/targeted/oathbreak/)
+	new_body.UpdateAppearance()
+	for(var/datum/language/L in brainmob.languages)
+		new_body.add_language(L.name)
+	qdel(brainmob)
+	new_body.forceMove(output)
+	new_body.rejuvenate(animation = TRUE)
+	qdel(O)

--- a/code/modules/medical/patientprocessor.dm
+++ b/code/modules/medical/patientprocessor.dm
@@ -19,7 +19,7 @@
 					(Verbs -> Ghost -> Re-enter corpse, or <a href='?src=\ref[ghost];reentercorpse=1'>click here!</a>)</span>")
 
 /obj/machinery/patient_processor/process()
-	if((!(output_dir in cardinal) || !(input_dir in cardinal)) || output_dir == input_dir)
+	if((!(output_dir in cardinal) || !(input_dir in cardinal)) || output_dir == input_dir || !anchored)
 		return
 	var/input = get_step(src, input_dir)
 	var/output = get_step(src, output_dir)

--- a/code/modules/medical/patientprocessor.dm
+++ b/code/modules/medical/patientprocessor.dm
@@ -1,0 +1,21 @@
+/obj/machinery/medical/patient_processor
+	name = "patient processor"
+	desc = "A device that uses advanced AutoDoc technology to heal patients."
+	icon = 'icons/obj/machines/mining_machines.dmi'
+	icon_state = "unloader"
+	density = 1
+	anchored = 1
+	var/input_dir = 1
+	var/output_dir = 2
+
+/obj/machinery/medical/patient_processor/process()
+	if((!output_dir || !input_dir) || output_dir == input_dir)
+		return
+	var/input = get_step(src, input_dir)
+	var/output = get_step(src, output_dir)
+	var/mob/living/M = locate(/mob/living, input)
+	if(M)
+		M.rejuvenate(animation = TRUE)
+		M.forceMove(output)
+		return
+	//TODO: generate bodies for patients who have been reduced to brains or heads

--- a/code/modules/medical/patientprocessor.dm
+++ b/code/modules/medical/patientprocessor.dm
@@ -53,8 +53,7 @@
 	new_body.flavor_text = new_dna.flavor_text
 	new_body.ckey = brainmob.ckey
 	brainmob.ckey = null
-	if(brainmob.mind)
-		brainmob.mind.transfer_to(new_body)
+	brainmob.mind?.transfer_to(new_body)
 	to_chat(new_body, "<span class='notice'><b>You suddenly awaken inside some strange machine.</b></span>")
 	if(new_body.mind?.miming) //yes I know I'm using the forbidden operator
 		new_body.add_spell(new /spell/aoe_turf/conjure/forcewall/mime, "grey_spell_ready")

--- a/code/modules/medical/patientprocessor.dm
+++ b/code/modules/medical/patientprocessor.dm
@@ -53,16 +53,16 @@
 	new_body.flavor_text = new_dna.flavor_text
 	new_body.ckey = brainmob.ckey
 	brainmob.ckey = null
-	brainmob.mind.transfer_to(new_body)
+	if(brainmob.mind)
+		brainmob.mind.transfer_to(new_body)
 	to_chat(new_body, "<span class='notice'><b>You suddenly awaken inside some strange machine.</b></span>")
-	if (new_body.mind.miming)
+	if(new_body.mind?.miming) //yes I know I'm using the forbidden operator
 		new_body.add_spell(new /spell/aoe_turf/conjure/forcewall/mime, "grey_spell_ready")
-		if (new_body.mind.miming == MIMING_OUT_OF_CHOICE)
+		if(new_body.mind.miming == MIMING_OUT_OF_CHOICE)
 			new_body.add_spell(new /spell/targeted/oathbreak/)
 	new_body.UpdateAppearance()
 	for(var/datum/language/L in brainmob.languages)
 		new_body.add_language(L.name)
-	qdel(brainmob)
 	qdel(O)
 	new_body.forceMove(output)
 	new_body.rejuvenate(animation = TRUE)

--- a/code/modules/medical/patientprocessor.dm
+++ b/code/modules/medical/patientprocessor.dm
@@ -19,7 +19,7 @@
 					(Verbs -> Ghost -> Re-enter corpse, or <a href='?src=\ref[ghost];reentercorpse=1'>click here!</a>)</span>")
 
 /obj/machinery/patient_processor/process()
-	if((!output_dir || !input_dir) || output_dir == input_dir)
+	if((!(output_dir in cardinal) || !(input_dir in cardinal)) || output_dir == input_dir)
 		return
 	var/input = get_step(src, input_dir)
 	var/output = get_step(src, output_dir)

--- a/code/modules/medical/patientprocessor.dm
+++ b/code/modules/medical/patientprocessor.dm
@@ -63,6 +63,6 @@
 	for(var/datum/language/L in brainmob.languages)
 		new_body.add_language(L.name)
 	qdel(brainmob)
+	qdel(O)
 	new_body.forceMove(output)
 	new_body.rejuvenate(animation = TRUE)
-	qdel(O)

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -1554,6 +1554,7 @@
 #include "code\modules\media\broadcast\receivers\radio.dm"
 #include "code\modules\media\broadcast\transmitters\broadcast.dm"
 #include "code\modules\medical\cloning.dm"
+#include "code\modules\medical\patientprocessor.dm"
 #include "code\modules\medical\computer\cloning.dm"
 #include "code\modules\migrations\migration.dm"
 #include "code\modules\migrations\migration_controller.dm"


### PR DESCRIPTION
Discussion with players in general has brought to my attention that medbay as a whole is seen as a negative experience for nearly everyone involved. Doctors hate treating patients, and patients hate having to be treated.

This PR adds a new medbay machine: the patient processor. It's intended to be combined with conveyor belts to automate the healing of patients. Injured or dead patients go in one end and come out the other end hale and hearty, reducing the wild ride to a mild, pleasant ride and giving everyone the free ticket back into the round they're entitled to.

I have not mapped it in anywhere yet, because I couldn't figure out what to put in the big hole left by the rest of medbay after the introduction of this machine. Rest assured I'm hard at work thinking of a solution, but if you have any suggestions I'm all ears. Right now I think the space could be filled by a section of derelict maintenance.

:cl:
 * rscadd: Did stuff!
 * rscdel: did other stuff!