### PR TITLE
Nu cryo tweaks

### DIFF
--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -29,6 +29,7 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 	var/last_injection
 	var/injecting = TRUE
 	var/current_heat_capacity = 50
+	var/occupant_reagent_threshold = 0 //If we have an occupant, check if their reagent holder's volume is less than or equal to this value. If so, we inject.
 	var/running_bob_animation = FALSE // This is used to prevent threads from building up if update_icons is called multiple times
 	var/scan_level = 0 //Current scanner level
 	var/auto_eject = FALSE
@@ -302,6 +303,7 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 	data["controls"] = controls
 	data["dump_loc"] = dump_loc
 	data["scan_level"] = scan_level
+	data["occupant_reagent_threshold"] = occupant_reagent_threshold
 	// update the ui if it exists, returns null if no ui is passed/found
 	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)
@@ -357,6 +359,12 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 			return 0
 		inject_rate = clamp(newval, 0, inject_rate_max)
 		return 1
+
+	if(href_list["set_reagent_threshold"])
+		var/newval = input("Enter new reagent threshold") as num|null
+		if(isnull(newval))
+			return 0
+		occupant_reagent_threshold = clamp(newval, 0, inject_rate_max)
 
 	if(href_list["toggle_inject"])
 		injecting = !injecting
@@ -541,7 +549,8 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 		if(beaker && injecting && world.time > (last_injection + 10 SECONDS))
 			beaker.reagents.trans_to(src, inject_rate)
 			last_injection = world.time
-		reagents.reaction(occupant, remove_reagents = TRUE)
+		if(!occupant_reagent_threshold || occupant_reagent_threshold > occupant.reagents.total_volume)
+			reagents.reaction(occupant, remove_reagents = TRUE)
 
 /obj/machinery/atmospherics/unary/cryo_cell/proc/modify_occupant_bodytemp()
 	if(!occupant)

--- a/nano/templates/cryo.tmpl
+++ b/nano/templates/cryo.tmpl
@@ -134,22 +134,27 @@ Used In File(s): \code\game\machinery\cryo.dm
 				</div>
 			<br>
 			{{if data.scan_level >= 2}}
-					Injection rate (units):
-					<div class="floatRight">
-					{{:helper.link(data.injection_rate, 'carat-2-n-s', {'set_inject_rate': 1})}}
-					</div>
-					<br>
-			{{/if}}
-				Current dump location:
+				Injection rate (units):
 				<div class="floatRight">
-				{{:helper.link(data.dump_loc==1?"Beaker":"Vicinity", null, {'toggle_dump': 1})}}
-			  </div>
+				{{:helper.link(data.injection_rate, 'carat-2-n-s', {'set_inject_rate': 1})}}
+				</div>
 				<br>
+			{{/if}}
+			Reagent threshold (units):
+			<div class="floatRight">
+			{{:helper.link(data.occupant_reagent_threshold, 'carat-2-n-s', {'set_reagent_threshold': 1})}}
+			</div>
+			<br>
+			Current dump location:
+			<div class="floatRight">
+			{{:helper.link(data.dump_loc==1?"Beaker":"Vicinity", null, {'toggle_dump': 1})}}
+			</div>
+			<br>
 			{{if data.scan_level >= 4}}
-					Auto ejection:
-					<div class="floatRight">
-					{{:helper.link(data.auto_eject?"Active":"Inactive", null, {'toggle_autoeject': 1})}}
-					</div>
+				Auto ejection:
+				<div class="floatRight">
+				{{:helper.link(data.auto_eject?"Active":"Inactive", null, {'toggle_autoeject': 1})}}
+				</div>
 				<br>
 			{{/if}}
 			</div>


### PR DESCRIPTION
I was looking back on my changes in the cryo tweak, and I noticed one QOL that I'd deleted: When the cryo tube found that the occupant had cryox or clonex in their system, it would not inject any reagents into that person.

As the primary complaint seems to be "cryo consumes too much", I looked into it, and found that the occupant is receiving a lot of reagent that goes unused should they be fully treated of their ails.

I've mirrored the QOL and unsnowflaked it from just checking cryox and clonex. It now checks the occupants reagents, and if the occupants reagents total volume is greater than a certain threshold, it does not inject any reagents.

This goes against my previous idea of the cryo tube being "just immerse the occupant in reagents" and does open up a method of exploitation, by avoiding a dunk in a polyacid tube through consuming enough reagents to forego the threshold should it be initialized.

It defaults to 0, which is the equivalent of "off", so it's just something a medical doctor would need to tweak during initial setup of the cryo tubes.

:cl:
 * rscadd: Adds a reagent threshold to cryo. Should the occupant have more than the threshold, they do not have any reagents applied to them.