### PR TITLE
Snaxi Event Blacklist

### DIFF
--- a/maps/snaxi.dm
+++ b/maps/snaxi.dm
@@ -27,7 +27,8 @@
 	enabled_jobs = list(/datum/job/trader)
 
 	event_blacklist = list(/datum/event/radiation_storm,/datum/event/carp_migration,/datum/event/rogue_drone,/datum/event/immovable_rod,
-						/datum/event/meteor_wave,/datum/event/meteor_shower,/datum/event/thing_storm)
+						/datum/event/meteor_wave,/datum/event/meteor_shower,/datum/event/thing_storm/meaty_gore,/datum/event/thing_storm/blob_shower,
+						/datum/event/thing_storm/blob_storm,/datum/event/thing_storm/fireworks)
 	load_map_elements = list(
 	/datum/map_element/dungeon/holodeck
 	)


### PR DESCRIPTION
closes #25358

I could've done this as a refactor to type check but I decided that this is actually better as an exact match check. There may come a day when we want this precision.

:cl:
* bugfix: Storm events (like blob storm) no longer happen on Snaxi