### PR TITLE
Removes Flamethrowers

### DIFF
--- a/code/game/objects/effects/step_triggers.dm
+++ b/code/game/objects/effects/step_triggers.dm
@@ -124,7 +124,10 @@
 	var/teleport_z_offset = 0
 
 /obj/effect/step_trigger/teleporter/random/Trigger(var/atom/movable/A)
-	if(!istype(A) || istype(A,/obj/item/projectile/fire_breath/shuttle_exhaust))
+	if(!istype(A))
+		return
+	if(istype(A,/obj/item/projectile/fire_breath/shuttle_exhaust))
+		qdel(A)
 		return
 	if(teleport_x && teleport_y && teleport_z)
 		if(teleport_x_offset && teleport_y_offset && teleport_z_offset)

--- a/code/game/objects/effects/step_triggers.dm
+++ b/code/game/objects/effects/step_triggers.dm
@@ -123,15 +123,15 @@
 	var/teleport_y_offset = 0
 	var/teleport_z_offset = 0
 
-	Trigger(var/atom/movable/A)
-		if(!istype(A))
-			return
-		if(teleport_x && teleport_y && teleport_z)
-			if(teleport_x_offset && teleport_y_offset && teleport_z_offset)
+/obj/effect/step_trigger/teleporter/random/Trigger(var/atom/movable/A)
+	if(!istype(A) || istype(A,/obj/item/projectile/fire_breath/shuttle_exhaust))
+		return
+	if(teleport_x && teleport_y && teleport_z)
+		if(teleport_x_offset && teleport_y_offset && teleport_z_offset)
 
-				A.x = rand(teleport_x, teleport_x_offset)
-				A.y = rand(teleport_y, teleport_y_offset)
-				A.z = rand(teleport_z, teleport_z_offset)
+			A.x = rand(teleport_x, teleport_x_offset)
+			A.y = rand(teleport_y, teleport_y_offset)
+			A.z = rand(teleport_z, teleport_z_offset)
 
 /obj/effect/step_trigger/teleporter/random/shuttle_transit
 	teleport_x = 25


### PR DESCRIPTION
Is this it? Have I finally gone mad with collab overwork?

The dreaded R word. And yet, after reading this, I am sure you will agree it is the best solution.

-
-
-

Alright, are we past the summary that gets sent to Discord?

This just prevents the shuttle transit zone teleporters from throwing exhaust fire into deep space, which on most maps does nothing but on Snaxi can cook miners, traders, or anyone else unfortunate enough to be chilling in the spaceport on Z6. This actually was first identified ages ago on Metaclub but no one fixed it back then.

To be clear this does nothing to the flamethrower item, shuttles will still shoot flames, you just won't see magic fire appear from nowhere on Z6.

fixes #25384
fixes #25319

🆑
* bugfix: Mysterious flames will no longer appear on Z6 when the emergency shuttle is flying home.