### PR TITLE
Nu Cryo: Feedbackcreep

### DIFF
--- a/__DEFINES/_macros.dm
+++ b/__DEFINES/_macros.dm
@@ -188,6 +188,8 @@
 
 #define isholyweapon(I) (istype(I, /obj/item/weapon/nullrod))
 
+#define iscryotube(T) (istype(T, /obj/machinery/atmospherics/unary/cryo_cell))
+
 #define isholyprotection(I) (istype(I, /obj/item/weapon/nullrod))
 
 #define isAPC(A) istype(A, /obj/machinery/power/apc)

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -2441,6 +2441,9 @@ obj/item/device/pda/AltClick()
 		if(SCANMODE_REAGENT)
 			if(!A.Adjacent(user))
 				return
+			if(iscryotube(A))
+				var/obj/machinery/atmospherics/unary/cryo_cell/T = A
+				A = T.occupant
 			if(!isnull(A.reagents))
 				if(A.reagents.reagent_list.len > 0)
 					var/reagents_length = A.reagents.reagent_list.len

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -2443,7 +2443,8 @@ obj/item/device/pda/AltClick()
 				return
 			if(iscryotube(A))
 				var/obj/machinery/atmospherics/unary/cryo_cell/T = A
-				A = T.occupant
+				if(T.occupant)
+					A = T.occupant
 			if(!isnull(A.reagents))
 				if(A.reagents.reagent_list.len > 0)
 					var/reagents_length = A.reagents.reagent_list.len

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -496,7 +496,8 @@ Subject's pulse: ??? BPM"})
 		return
 	if(iscryotube(O))
 		var/obj/machinery/atmospherics/unary/cryo_cell/T = O
-		O = T.occupant
+		if(T.occupant)
+			O = T.occupant
 	if(O.reagents)
 		playsound(user, 'sound/items/healthanalyzer.ogg', 50, 1)
 		var/dat = ""

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -494,6 +494,9 @@ Subject's pulse: ??? BPM"})
 	if(!user.dexterity_check())
 		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
 		return
+	if(iscryotube(O))
+		var/obj/machinery/atmospherics/unary/cryo_cell/T = O
+		O = T.occupant
 	if(O.reagents)
 		playsound(user, 'sound/items/healthanalyzer.ogg', 50, 1)
 		var/dat = ""

--- a/nano/templates/cryo.tmpl
+++ b/nano/templates/cryo.tmpl
@@ -110,7 +110,7 @@ Used In File(s): \code\game\machinery\cryo.dm
 	<div class="itemContent" style="width: 40%;">
 		<table width="100%"><tbody>
 		{{for data.cryo_contents}}
-			<tr><td><span class="highlight">{{:value.name}}{{if data.scan_level > 1}} - {{:value.volume}} units{{/if}}</span>
+			<tr><td><span class="highlight">{{:value.name}} - {{:value.volume}} units</span>
 		{{empty}}
 			<span class="bad">Cell is empty</span>
 		{{/for}}


### PR DESCRIPTION
![feedback](https://user-images.githubusercontent.com/17928298/70758840-00a38a00-1d23-11ea-815a-e5438a9815c1.png)
Having upgrades is fine and all, but having a visual feedback of the actual amount of chems that your cryo tube has is more important. I was also requested to give medbay a way to check the occupant's reagents, so you can now use your reagent scanner on the tube to check'em.

:cl:
 * rscadd: You can now use your reagent scanner 
 * rscdel: You can now see the amount of the reagents inside the cryo tube without scanning module upgrades