### PR TITLE
Fix vox raiders

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -584,7 +584,8 @@
 		required_candidates = 1
 	if (required_candidates > (dead_players.len + list_observers.len))
 		return 0
-	return ..()
+	. = ..()
+	required_candidates = initial(required_candidates)
 
 /datum/dynamic_ruleset/midround/from_ghosts/faction_based/heist/finish_setup(var/mob/new_character, var/index)
 	var/datum/faction/vox_shoal/shoal = find_active_faction_by_type(/datum/faction/vox_shoal)

--- a/code/datums/gamemode/factions/vox_shoal.dm
+++ b/code/datums/gamemode/factions/vox_shoal.dm
@@ -295,4 +295,4 @@ var/list/potential_bonus_items = list(
 		/obj/item/weapon/storage/box/large/vox_equipment/saboteur = 2,
 		/obj/item/weapon/storage/box/large/vox_equipment/engineer = 2,
 		/obj/item/weapon/storage/box/large/vox_equipment/raider = 2
-		)
+	)

--- a/code/datums/gamemode/misc_gamemode_procs.dm
+++ b/code/datums/gamemode/misc_gamemode_procs.dm
@@ -507,14 +507,14 @@
 	H.equip_to_slot_or_del(new /obj/item/weapon/tank/nitrogen(src), slot_back)
 	H.equip_to_slot_or_del(new /obj/item/device/flashlight(src), slot_r_store)
 
-	var/obj/item/weapon/card/id/syndicate/C = new(src)
+	var/obj/item/weapon/card/id/syndicate/C = new(get_turf(src))
 	C.registered_name = H.real_name
 	C.assignment = "Trader"
 	C.UpdateName()
 	C.SetOwnerInfo(src)
 	C.icon_state = "trader"
 	C.access = list(access_syndicate, access_trade)
-	var/obj/item/weapon/storage/wallet/W = new(src)
+	var/obj/item/weapon/storage/wallet/W = new(get_turf(src))
 	W.handle_item_insertion(C)
 	W.handle_item_insertion(new /obj/item/weapon/coin/raider)
 	H.equip_to_slot_or_del(W, slot_wear_id)

--- a/code/datums/gamemode/role/vox_raider.dm
+++ b/code/datums/gamemode/role/vox_raider.dm
@@ -12,6 +12,7 @@
 		return
 	antag.current.forceMove(pick(voxstart))
 	equip_raider(antag.current)
+	equip_vox_raider(antag.current)
 
 /datum/role/vox_raider/chief_vox
 	logo_state = "vox-logo"

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -773,7 +773,7 @@ var/global/num_vending_terminals = 1
 	if (premium.len > 0)
 		dat += "<b>Coin slot:</b> [coin ? coin : "No coin inserted"] (<a href='byond://?src=\ref[src];remove_coin=1'>Remove</A>)<br><br>"
 
-	if (src.product_records.len == 0)
+	if (src.product_records.len == 0 && coin_records.len == 0)
 		dat += "<font color = 'red'>No products loaded!</font><br><br></TT>"
 	else
 		var/list/display_records = src.product_records.Copy()


### PR DESCRIPTION
Just a single line forgotten when Raiders were converted from a ruleset to also be an event.
The bug with the vendor was from something else (there would never be anything displayed if the vendor was only consisting of premium.)

The bug with having only one candidate was because we temporarily lowered the amount of required candidates for bus.

[bugfix]

Closes #25220