### PR TITLE
Fix belts

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -529,7 +529,7 @@
 					if(automatic)
 						if(H.check_for_open_slot(src))
 							return CANNOT_EQUIP
-					if(H.belt.canremove && !isbelt(src))
+					if(H.belt.canremove)
 						return CAN_EQUIP_BUT_SLOT_TAKEN
 					else
 						return CANNOT_EQUIP


### PR DESCRIPTION
Apparently it was explicitly hard-coded that, to get the words of an anonymous poster in the thread, the game would go "Whitaker Evans on you" if you tried to hotswap a non-belt and a belt.

What kind of devious mindset would you need to code such a thing ?