### PR TITLE
Add a reply warning to admin PMs to minimize duplicates

### DIFF
--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -70,6 +70,9 @@
 			if(alert("That player has been PM'd in the last [config.simultaneous_pm_warning_timeout / 10] seconds by: [C.ckey_last_pm]","Simultaneous PMs warning","Continue","Cancel") == "Cancel")
 				return*/
 
+	if(check_rights(R_ADMIN)) //Only send the warning if the source is an admin since clients also use this proc
+		output_to_msay("<span class = 'bold'>[key_name_admin(src)] is sending an admin PM to [key_name_admin(C)]</span>.")
+
 	//get message text, limit it's length.and clean/escape html
 	if(!msg)
 		msg = input(src, "Message:", "Private message to [key_name(C, 0, 0, showantag = FALSE)]", "") as text | null


### PR DESCRIPTION
If an admin is generating an admin PM (from either replying to an adminhelp or sending a direct PM to someone), it will now throw a msay log to warn other admins to keep their sticky fingers away from it. Dibs!

This is the exact same method currently used by Prayers, Faxes and Centcomm messages

Example test. I sent an adminhelp, replied to it, then PMed -myself- (I know it's not clear but it's all the basic test cases covered)

![oof](https://user-images.githubusercontent.com/6137403/70843011-7e52bd00-1e2b-11ea-8096-8d18dd237f5f.png)

This could generate a bit of spam on longer exchanges or if admins use five replies to say one thing, but more clarity is good, right ?

:cl:
 * rscadd: Admin PMs now properly indicate when an admin is replying to them to minimize duplicate replies (hopefully). Also includes direct PMs. Players should NOT trigger this warning when replying to an admin