### PR TITLE
Two Vending Bugs

### DIFF
--- a/code/datums/wires/vending.dm
+++ b/code/datums/wires/vending.dm
@@ -41,6 +41,7 @@ var/const/VENDING_WIRE_IDSCAN = 8
 	. += "The red light is [V.shoot_inventory ? "off" : "blinking"].<BR>"
 	. += "The green light is [V.extended_inventory ? "on" : "off"].<BR>"
 	. += "A [V.scan_id ? "purple" : "yellow"] light is on.<BR>"
+	. += "The return box printer is <B>[V.cardboard ? "loaded</B>. Ready for disassembly." : "unloaded</B>. Insert cardboard."]<BR>"
 
 /datum/wires/vending/UpdateCut(var/index, var/mended)
 	var/obj/machinery/vending/V = holder

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -186,6 +186,7 @@ var/global/num_vending_terminals = 1
 			newpack.product_records = product_records
 			newpack.hidden_records = hidden_records
 			newpack.coin_records = coin_records
+			newpack.targetvendomat = src.type
 
 	if(coinbox)
 		coinbox.forceMove(get_turf(src))
@@ -220,6 +221,11 @@ var/global/num_vending_terminals = 1
 		if(!anchored)
 			to_chat(user, "<span class='warning'>You need to anchor the vending machine before you can refill it.</span>")
 			return
+		if(P.targetvendomat != type)
+			var/list/any_records = get_all_records()
+			if(any_records.len)
+				to_chat(user, "<span class='warning'>That vending machine is neither empty nor a matching type.</span>")
+				return
 		if(!pack)
 			if(is_being_filled)
 				to_chat(user, "<span class='warning'>\The [src] is already in use!</span>")
@@ -256,7 +262,7 @@ var/global/num_vending_terminals = 1
 				is_being_filled = FALSE
 				P.in_use = FALSE
 		else
-			if(istype(P,pack))
+			if(P.targetvendomat == type)
 				if(is_being_filled)
 					to_chat(user, "<span class='warning'>\The [src] is already in use!</span>")
 					return
@@ -370,13 +376,17 @@ var/global/num_vending_terminals = 1
 			R.product_name = initial(initializer.name)
 		R.subcategory = initial(initializer.vending_cat)
 
-/obj/machinery/vending/proc/get_item_by_type(var/this_type)
+/obj/machinery/vending/proc/get_all_records()
 	var/list/datum_products = list()
 	datum_products |= hidden_records
 	datum_products |= coin_records
 	datum_products |= voucher_records
 	datum_products |= holiday_records
 	datum_products |= product_records
+	return datum_products
+
+/obj/machinery/vending/proc/get_item_by_type(var/this_type)
+	var/list/datum_products = get_all_records()
 	for(var/datum/data/vending_product/product in datum_products)
 		if(product.product_path == this_type)
 			return product

--- a/code/modules/Economy/utils.dm
+++ b/code/modules/Economy/utils.dm
@@ -327,7 +327,8 @@ var/global/no_pin_for_debit = TRUE
 		// If we have a vaild secondary amount, charge the secondary payment method.
 		secondary_money_account.charge(transaction_amount_secondary, dest, transaction_purpose, terminal_name, terminal_id, dest_name, authorized)
 
-	primary_money_account.charge(transaction_amount_primary, dest, transaction_purpose, terminal_name, terminal_id, dest_name, authorized)
+	if(!primary_money_account.charge(transaction_amount_primary, dest, transaction_purpose, terminal_name, terminal_id, dest_name, authorized))
+		return CARD_CAPTURE_FAILURE_NOT_ENOUGH_FUNDS
 	// Finally charge the primary
 	var/account_type = primary_money_account.virtual ? "virtual wallet" : "bank account"
 	to_chat(user, "[bicon(src)] <span class='notice'>Remaining balance on [account_type], $[num2septext(primary_money_account.money)].</span>")


### PR DESCRIPTION
fixes #23751
fixes #19025
When you unscrew a vending machine there is now a prominent message below wires telling you if it has been cardboard loaded.

No longer can you refill a partial-filled vending machine with any partial pack - it must be the right type. And now you can properly refill a partial-filled vending machine with an original pack as long as it matches type.

Also you can't buy shit if you don't have enough money for it.

:cl:
* bugfix: On the second day of Christmas my coders fixed for me: two vending bugs and magboots are now less spammy.

