### PR TITLE
Three Items Stuck

### DIFF
--- a/code/WorkInProgress/pomf/spacepods/spacepods.dm
+++ b/code/WorkInProgress/pomf/spacepods/spacepods.dm
@@ -187,6 +187,14 @@
 	if(iscrowbar(W))
 		hatch_open = !hatch_open
 		to_chat(user, "<span class='notice'>You [hatch_open ? "open" : "close"] the maintenance hatch.</span>")
+		if(hatch_open && contents.len)
+			var/anyitem = 0
+			for(var/atom/movable/AM in contents)
+				if(istype(AM,/obj/item))
+					anyitem++
+					AM.forceMove(get_turf(user))
+			if(anyitem)
+				visible_message("<span class='warning'>With a clatter, [anyitem > 1 ? "some items" : "an item"] lands at the feet of [user].</span>")
 		return
 	if(health < maxHealth && iswelder(W))
 		var/obj/item/weapon/weldingtool/WT = W

--- a/code/WorkInProgress/pomf/spacepods/spacepods.dm
+++ b/code/WorkInProgress/pomf/spacepods/spacepods.dm
@@ -196,7 +196,7 @@
 					anyitem++
 					AM.forceMove(get_turf(user))
 			if(anyitem)
-				visible_message("<span class='warning'>With a clatter, [anyitem > 1 ? "some items" : "an item"] lands at the feet of [user].</span>")
+				visible_message("<span class='warning'>With a clatter, [anyitem > 1 ? "some items land" : "an item lands"] at the feet of [user].</span>")
 		return
 	if(health < maxHealth && iswelder(W))
 		var/obj/item/weapon/weldingtool/WT = W

--- a/code/WorkInProgress/pomf/spacepods/spacepods.dm
+++ b/code/WorkInProgress/pomf/spacepods/spacepods.dm
@@ -191,6 +191,8 @@
 			var/anyitem = 0
 			for(var/atom/movable/AM in contents)
 				if(istype(AM,/obj/item))
+					if(AM == battery)
+						continue //don't eject this particular item!
 					anyitem++
 					AM.forceMove(get_turf(user))
 			if(anyitem)

--- a/code/game/objects/items/stacks/packagewrap.dm
+++ b/code/game/objects/items/stacks/packagewrap.dm
@@ -191,6 +191,11 @@
 	else if(istype(target,/obj/structure/closet))
 		icon_state = "deliverycloset" //Only IF it isn't a crate-type
 
+/obj/item/delivery/large/Destroy()
+	for(var/atom/movable/AM in contents)
+		AM.forceMove(get_turf(src))
+	..()
+
 /obj/item/delivery/large/attack_paw(mob/user as mob)
 	return attack_hand(user)
 

--- a/code/game/objects/items/weapons/gift_wrappaper.dm
+++ b/code/game/objects/items/weapons/gift_wrappaper.dm
@@ -23,7 +23,7 @@
 	w_class = W
 	gift = target
 	update_icon()
-	
+
 /obj/item/weapon/gift/attackby(obj/item/W as obj, mob/user as mob)
 	if(istype(W, /obj/item/weapon/pen))
 		var/str = copytext(sanitize(input(user,"What should the label read? (max 52 characters)","Write a personal message!","") as message|null),1,MAX_NAME_LEN * 2)
@@ -301,6 +301,11 @@
 	density = 1
 	anchored = 0
 	w_type=NOT_RECYCLABLE
+
+/obj/structure/strange_present/Destroy()
+	for(var/atom/movable/AM in contents)
+		AM.forceMove(get_turf(src))
+	..()
 
 /obj/structure/strange_present/relaymove(mob/user as mob)
 	if (user.stat)


### PR DESCRIPTION
Items will no longer be nullspaced if they get dropped when you are
* wrapped in a christmas gift
* wrapped by syndie paper fixes #23888
* incapacitated in a spacepod fixes #15369

in the first two cases, just open the gift
in the last, pop open the hatch and the items will fall out

🆑 
* bugfix: On the third day of Christmas, my coders fixed for me: three items stuck, two vending bugs, and magboots are now less spammy.