### PR TITLE
Greys(Species) can play HoP

### DIFF
--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -77,7 +77,7 @@
 	req_admin_notify = 1
 	minimal_player_age = 20
 
-	species_whitelist = list("Human")
+	species_whitelist = list("Grey","Human")
 
 	access = list(access_security, access_sec_doors, access_brig, access_court, access_weapons, access_forensics_lockers,
 			            access_medical, access_engine, access_change_ids, access_ai_upload, access_eva, access_heads,


### PR DESCRIPTION
This PR allows greys to play the Head of Personnel role, but not Captain or HoS still. I saw people talking about it lore-wise so I figured it could be neat.

I know the wiki is outdated and lore is a meme, but since it says this:
> Only a few years ahead of Humanity as far as technology was concerned, the Greys and Humanity quickly began sharing technology and research and a golden age of space exploration soon begun. Due to this close co-operation with Humanity and over a century of familiarity with one another, Greys tend to be on very good terms with Humanity and rarely encounter Xenophobia from Human co-workers. 

I think it would be fine, and might even add a tidbit more diversity to the races.

<featurerequest><controversial>
:cl:
 * rscadd: Allows Greys to go HoP