### PR TITLE
Fixes Xenoarch Boxes being Foldable

### DIFF
--- a/code/modules/research/xenoarchaeology/finds/finds.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds.dm
@@ -280,9 +280,10 @@
 	responsive_reagent = MERCURY
 
 /datum/find/box/spawn_item()
-	var/obj/item/new_item = new /obj/item/weapon/storage/box
+	var/obj/item/weapon/storage/box/new_item = new /obj/item/weapon/storage/box
 	new_item.icon = 'icons/obj/xenoarchaeology.dmi'
 	new_item.icon_state = "box"
+	new_item.foldable = null
 	if(prob(30))
 		apply_image_decorations = TRUE
 	return new_item


### PR DESCRIPTION
[bugfix] Untested because I couldn't figure out how to spawn small artifacts. Closes #23603.

:cl:
 * bugfix: Xenoarchaeology boxes are no longer foldable.