### PR TITLE
Fixes required_upgrades doing nothing

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -40,7 +40,7 @@
 	
 	if(required_upgrades.len)
 		for(var/U in required_upgrades)
-			if(!U in R.module.upgrades)
+			if(!R.module.upgrades.Find(U))
 				to_chat(user, "<span class='warning'>\The [R] is missing a required upgrade to install [src].</span>")
 				return FAILED_TO_ADD
 


### PR DESCRIPTION
Closes #25431

:cl:
 * bugfix: Fixed cyborg upgrades being able to be installed even if the cyborg is mising required upgrades.