### PR TITLE
Snow Tweaks

### DIFF
--- a/code/datums/climate.dm
+++ b/code/datums/climate.dm
@@ -150,7 +150,7 @@ var/list/snowstorm_ambience_volumes = list(30,40,60,80)
 /datum/weather/snow/calm
 	name = "calm"
 	snow_intensity = SNOW_CALM
-	next_weather = list(/datum/weather/snow/calm = 40, /datum/weather/snow/light = 60)
+	next_weather = list(/datum/weather/snow/calm = 60, /datum/weather/snow/light = 40)
 	snowfall_prob = 3
 	snowfall_rate = list(-1,0)
 	temperature = T_ARCTIC
@@ -165,7 +165,7 @@ var/list/snowstorm_ambience_volumes = list(30,40,60,80)
 /datum/weather/snow/light
 	name = "light"
 	snow_intensity = SNOW_AVERAGE
-	next_weather = list(/datum/weather/snow/calm = 20, /datum/weather/snow/light = 55, /datum/weather/snow/heavy = 20, /datum/weather/snow/blizzard = 5)
+	next_weather = list(/datum/weather/snow/calm = 25, /datum/weather/snow/light = 55, /datum/weather/snow/heavy = 20)
 	snowfall_prob = 5
 	snowfall_rate = list(1,8)
 	temperature = T_ARCTIC - 5
@@ -180,7 +180,7 @@ var/list/snowstorm_ambience_volumes = list(30,40,60,80)
 /datum/weather/snow/heavy
 	name = "<font color='orange'>heavy</font>"
 	snow_intensity = SNOW_HARD
-	next_weather = list(/datum/weather/snow/light = 20, /datum/weather/snow/heavy = 60, /datum/weather/snow/blizzard = 20)
+	next_weather = list(/datum/weather/snow/light = 30, /datum/weather/snow/heavy = 60, /datum/weather/snow/blizzard = 10)
 	snowfall_prob = 8
 	snowfall_rate = list(2,15)
 	temperature = T_ARCTIC - 10
@@ -195,7 +195,7 @@ var/list/snowstorm_ambience_volumes = list(30,40,60,80)
 /datum/weather/snow/blizzard
 	name = "<font color='red'>blizzard</font>"
 	snow_intensity = SNOW_BLIZZARD
-	next_weather = list(/datum/weather/snow/heavy = 60, /datum/weather/snow/blizzard = 40)
+	next_weather = list(/datum/weather/snow/heavy = 50, /datum/weather/snow/blizzard = 50)
 	tile_interval = 3
 	snowfall_prob = 12
 	snowfall_rate = list(3,20)

--- a/code/game/objects/structures/vehicles/snowmobile.dm
+++ b/code/game/objects/structures/vehicles/snowmobile.dm
@@ -54,7 +54,7 @@
 	icon_state = "snowcurity"
 	headlights = FALSE
 
-/obj/structure/bed/chair/vehicle/snowmobile/New()
+/obj/structure/bed/chair/vehicle/snowmobile/security/New()
 	..()
 	new /datum/action/vehicle/toggle_headlights/siren(src)
 

--- a/code/game/turfs/unsimulated/snow.dm
+++ b/code/game/turfs/unsimulated/snow.dm
@@ -74,16 +74,16 @@
 	switch(snow_state)
 		if(SNOW_CALM)
 			temperature = T_ARCTIC
-			turf_speed_multiplier = 1
+			turf_speed_multiplier = 1 //higher numbers mean slower
 		if(SNOW_AVERAGE)
 			temperature = T_ARCTIC-5
-			turf_speed_multiplier = 1.15 //For some reason, higher numbers mean slower.
+			turf_speed_multiplier = 1
 		if(SNOW_HARD)
 			temperature = T_ARCTIC-10
-			turf_speed_multiplier = 1.6
+			turf_speed_multiplier = 1.4
 		if(SNOW_BLIZZARD)
 			temperature = T_ARCTIC-20
-			turf_speed_multiplier = 2.9
+			turf_speed_multiplier = 2.8
 	turf_speed_multiplier *= 1+(snowballs/10)
 
 /turf/unsimulated/floor/snow/Exited(atom/A, atom/newloc)
@@ -237,20 +237,18 @@
 			to_chat(user,"<span class='info'>It seems almost entirely devoid of snow, exposing the permafrost below.</span>")
 
 /turf/unsimulated/floor/snow/proc/change_snowballs(var/delta, var/limit) //Changes snowball count by delta, but to be no lower/greater than limit. Updates texture, too.
-	if(delta >= 0)
-		snowballs += delta
-		if(snowballs > limit)
-			snowballs = limit
+	snowballs += delta //this can be negative, in which case it subtracts
+	if(delta>=0)
+		snowballs = min(snowballs, limit) //no more than the limit
 	else
-		snowballs -= delta
-		if(snowballs < limit)
-			snowballs = limit
-		else if(snowballs < 0)
-			snowballs = 0
+		snowballs = max(snowballs, 0)
+	//This is a rare situation where we can't use Clamp(), because we don't want the limit to apply if subtracting
 	update_environment()
 
 /turf/unsimulated/floor/snow/proc/extract_snowballs(var/snowball_amount = 0, var/pick_up = FALSE, var/mob/user, var/obj/item/stack/sheet/snow/snowball_stack = null)
-
+	if(!Adjacent(user))
+		to_chat(user,"<span class='warning'>You're too far away to scoop snow.</span>")
+		return
 	if(!snowball_amount)
 		return
 


### PR DESCRIPTION
I know this is unatomic but these are all very small and I think none will be disagreeable.

fixes #25356
fixes #25442

🆑 
* bugfix: Fixed a bug where all snowmobiles had sirens instead of just security mobiles.
* bugfix: Fixed a bug where you could gather snow at a distance with ctrlclick.
* bugfix: Fixed a Glasscode issue where accumulating snow levels would not melt in calm weather, ever.
* tweak: Snowy weather slowdown slightly decreased (~15%) at all stages. Most importantly, this means no slowdown at calm or light from weather (off asphalt, you may still be slowed by snow buildup on the ground)
* tweak: Light snow will never skip straight to a blizzard and is more likely to decay to calm. Heavy is less likely to become a blizzard and is more likely to decay to light. Blizzards are slightly more likely to decay to heavy.