### PR TITLE
It now takes 1 minute to resist out of cuffs instead of 2

### DIFF
--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -19,7 +19,7 @@
 	melt_temperature = MELTPOINT_STEEL
 	origin_tech = Tc_MATERIALS + "=1"
 	restraint_apply_sound = 'sound/weapons/handcuffs.ogg'
-	restraint_resist_time = 2 MINUTES
+	restraint_resist_time = 1 MINUTES
 	var/list/mutual_handcuffed_mobs = list()
 
 /obj/item/weapon/handcuffs/Destroy()


### PR DESCRIPTION
### Why?
Restraints of most kinds are too long and can be lengthened by just moving someone around, I plan to shorten this for cable restraints to 30 seconds. This change is not an issue for most people because you can still very easily reapply stuns, just moving the person around is enough to stop the "timer".
It could be a controversial change, so please discuss. As for my reasoning why it's partly because I think I remember having had this idea to do this change and mostly because of an over-reaching agenda of reducing reliance on easy incapacitation, which is a very difficult thing to "balance" without making the game worse, preferably there'd be a rework but no one can agree and no one wants to shake the game from the ground up. No, I don't actually hate security even if I am biased against certain security players, I know just as well how they play out and what challenges they face.
Please discuss the changes.

:cl:
 * tweak: You can now break out of handcuffs in 1 minute instead of 2.