### PR TITLE
Clowncart fixes

### DIFF
--- a/code/game/objects/structures/vehicles/clowncart.dm
+++ b/code/game/objects/structures/vehicles/clowncart.dm
@@ -282,6 +282,7 @@
 	if(reagents.total_volume <= 0 && max_health < HEALTH_FOR_FREE_MOVEMENT) //No fuel
 		if(user)
 			to_chat(user, "<span class='warning'>[src] has no fuel, it activates its ejection seat as soon as you jam down the pedal!</span>")
+			user.clear_alert(SCREEN_ALARM_BUCKLE)
 			unlock_atom(user)
 			activated = 0
 			user.Knockdown(5) //Only Weaken after unbuckling

--- a/code/game/objects/structures/vehicles/clowncart.dm
+++ b/code/game/objects/structures/vehicles/clowncart.dm
@@ -266,7 +266,8 @@
 
 /obj/structure/bed/chair/vehicle/clowncart/relaymove(mob/user, direction)
 	if(user.incapacitated())
-		unlock_atom(user)
+		if(unlock_atom(user))
+			user.clear_alert(SCREEN_ALARM_BUCKLE)
 		return
 	var/turf/T = get_turf(loc)
 	if(!T)
@@ -281,12 +282,12 @@
 		return
 	if(reagents.total_volume <= 0 && max_health < HEALTH_FOR_FREE_MOVEMENT) //No fuel
 		if(user)
-			to_chat(user, "<span class='warning'>[src] has no fuel, it activates its ejection seat as soon as you jam down the pedal!</span>")
-			user.clear_alert(SCREEN_ALARM_BUCKLE)
-			unlock_atom(user)
 			activated = 0
-			user.Knockdown(5) //Only Weaken after unbuckling
-			user.Stun(5)
+			to_chat(user, "<span class='warning'>[src] has no fuel, it activates its ejection seat as soon as you jam down the pedal!</span>")
+			if(unlock_atom(user))
+				user.clear_alert(SCREEN_ALARM_BUCKLE)
+				user.Knockdown(5) //Only Weaken after unbuckling
+				user.Stun(5)
 		return
 	if(activated)
 		var/old_pos = get_turf(src)


### PR DESCRIPTION
Also made it check if the unlocking was actually done before applying the stun/knockdown

:cl:
 * bugfix: Fixes clowncart's eject seat not clearing its buckle screen alarm.
 * bugfix: Superglued clowncart won't stun you anymore when it fails to eject its user. It will still shut off though.