### PR TITLE
Fixes being able to toggle tac lights while:

### DIFF
--- a/code/modules/clothing/accessories/tactical_light.dm
+++ b/code/modules/clothing/accessories/tactical_light.dm
@@ -5,7 +5,7 @@
 	accessory_exclusion = ACCESSORY_LIGHT
 	var/obj/item/device/flashlight/tactical/source_light
 	ignoreinteract = TRUE
-	
+
 /obj/item/clothing/accessory/taclight/New()
 	..()
 	if (!source_light)
@@ -15,7 +15,7 @@
 /obj/item/clothing/accessory/taclight/Destroy()
 	source_light = null
 	..()
-		
+
 /obj/item/clothing/accessory/taclight/proc/generate_icon_state()
 	if(!attached_to || !icon_state)
 		return
@@ -26,7 +26,7 @@
 		icon_state = "[initial(icon_state)]_armor"
 	if(source_light && source_light.on)
 		icon_state = "[icon_state]_on"
-		
+
 /obj/item/clothing/accessory/taclight/can_attach_to(obj/item/clothing/C)
 	return (istype(C, /obj/item/clothing/head) || istype(C, /obj/item/clothing/suit/armor))
 
@@ -49,24 +49,24 @@
 	if(ishuman(attached_to.loc))
 		var/mob/living/carbon/human/H = attached_to.loc
 		H.update_inv_by_slot(attached_to.slot_flags)
-		
+
 /obj/item/clothing/accessory/taclight/update_icon()
 	if(!attached_to)
 		return
 	generate_icon_state()
 	if(attached_to.overlays.len)
-		attached_to.overlays -= inv_overlay			
+		attached_to.overlays -= inv_overlay
 	if(icon_state)
 		inv_overlay = image("icon" = 'icons/obj/clothing/accessory_overlays.dmi', "icon_state" = "[icon_state]")
 		if (attached_to.overlays.len)
 			attached_to.overlays -= inv_overlay
-		attached_to.overlays += inv_overlay	
+		attached_to.overlays += inv_overlay
 	if(ishuman(attached_to.loc))
 		var/mob/living/carbon/human/H = attached_to.loc
 		H.update_inv_by_slot(attached_to.slot_flags)
-	
+
 	attached_to.update_icon()
-		
+
 /obj/item/clothing/accessory/taclight/on_removed(mob/user)
 	if(!attached_to)
 		return
@@ -87,8 +87,10 @@
 	update_brightness(attached_to)
 	attached_to = null
 	qdel(src)
-			
+
 /obj/item/clothing/accessory/taclight/attack_self(mob/user)
+	if(user.isUnconscious() || user.restrained())
+		return
 	if(source_light)
 		source_light.on = !source_light.on
 		source_light.update_brightness(user)
@@ -100,15 +102,15 @@
 /obj/item/clothing/accessory/taclight/attackby(var/obj/item/I, var/mob/user)
 	if(I.is_screwdriver(user) && attached_to)
 		to_chat(user, "<span class='notice'>You remove [src] from [attached_to].</span>")
-		attached_to.remove_accessory(user, src)	
-		
+		attached_to.remove_accessory(user, src)
+
 /obj/item/clothing/accessory/taclight/on_accessory_interact()
 	return -1 //override priority check since you can't pull it off anyway
-	
+
 /datum/action/item_action/toggle_taclight
 	name = "Toggle Tactical Light"
 	var/obj/item/clothing/accessory/taclight/ownerlight
-			
+
 /datum/action/item_action/toggle_taclight/Trigger()
 	ownerlight.attack_self()
 	ownerlight.update_brightness(ownerlight.attached_to)


### PR DESCRIPTION
Unconscious
Restrained

closes #25434

:cl:
 * bugfix: You can no longer toggle tactical lights while unconscious or restrained