### PR TITLE
Fixes being able to use the nuclear disk to yakkety sax nuke ops

### DIFF
--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -311,6 +311,7 @@ var/obj/item/weapon/disk/nuclear/nukedisk
 
 /obj/machinery/nuclearbomb/isacidhardened() // Requires Aliens to channel acidspit on the nuke.
 	return TRUE
+
 /obj/item/weapon/disk/nuclear
 	name = "nuclear authentication disk"
 	desc = "Better keep this safe."

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -203,9 +203,9 @@
 			if(ZL.transitionLoops)
 				locked_to_current_z = z
 
-			for(var/obj/item/weapon/disk/nuclear/nuclear in contents_brought)
-				locked_to_current_z = map.zMainStation
-				break
+			var/obj/item/weapon/disk/nuclear/nuclear = locate() in contents_brought
+			if(nuclear)
+				qdel(nuclear)
 
 			//Check if it's a mob pulling an object
 			var/obj/was_pulling = null


### PR DESCRIPTION
Now the nuke disk just self destructs, which will spawn a new one on the station

closes #24271

:cl:
 * tweak: The nuclear disk now self destructs and respawns when a person tries to move across the z level transition point, rather than locking them to the station