### PR TITLE
Improved wizard cooldown logic

### DIFF
--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -153,78 +153,25 @@
 //<i>(Description)</i>
 //Requires robes to cast
 
-//I truly am sorry for this terrible copypaste, but there was no other way. - B2MTTF
 	if(shown_offensive_spells.len)
 		dat += "<span style=\"color:red\"><strong>OFFENSIVE SPELLS:</strong></span><br><br>"
 		for(var/spell_path in shown_offensive_spells)
-			var/spell/abstract_spell = spell_path
-			var/spell_name = initial(abstract_spell.name)
-			var/spell_cooldown = get_spell_cooldown_string(initial(abstract_spell.charge_max), initial(abstract_spell.charge_type))
-			var/spell_price = get_spell_price(abstract_spell)
-			dat += "<strong>[spell_name]</strong>[spell_cooldown] ([buy_href_link(spell_path, spell_price, "buy for [spell_price] point\s")])<br>"
-			dat += "<em>[initial(abstract_spell.desc)]</em><br>"
-			var/flags = initial(abstract_spell.spell_flags)
-			var/list/properties = get_spell_properties(flags, user)
-			var/property_data
-			for(var/P in properties)
-				property_data += "[P] "
-			if(property_data)
-				dat += "<span style=\"color:blue\">[property_data]</span><br>"
-			dat += "<br>"
+			dat += handle_spell_contents(user, spell_path)
 
 	if(shown_defensive_spells.len)
 		dat += "<span style=\"color:blue\"><strong>DEFENSIVE SPELLS:</strong></span><br><br>"
 		for(var/spell_path in shown_defensive_spells)
-			var/spell/abstract_spell = spell_path
-			var/spell_name = initial(abstract_spell.name)
-			var/spell_cooldown = get_spell_cooldown_string(initial(abstract_spell.charge_max), initial(abstract_spell.charge_type))
-			var/spell_price = get_spell_price(abstract_spell)
-			dat += "<strong>[spell_name]</strong>[spell_cooldown] ([buy_href_link(spell_path, spell_price, "buy for [spell_price] point\s")])<br>"
-			dat += "<em>[initial(abstract_spell.desc)]</em><br>"
-			var/flags = initial(abstract_spell.spell_flags)
-			var/list/properties = get_spell_properties(flags, user)
-			var/property_data
-			for(var/P in properties)
-				property_data += "[P] "
-			if(property_data)
-				dat += "<span style=\"color:blue\">[property_data]</span><br>"
-			dat += "<br>"
+			dat += handle_spell_contents(user, spell_path)
 
 	if(shown_utility_spells.len)
 		dat += "<span style=\"color:green\"><strong>UTILITY SPELLS:</strong></span><br><br>"
 		for(var/spell_path in shown_utility_spells)
-			var/spell/abstract_spell = spell_path
-			var/spell_name = initial(abstract_spell.name)
-			var/spell_cooldown = get_spell_cooldown_string(initial(abstract_spell.charge_max), initial(abstract_spell.charge_type))
-			var/spell_price = get_spell_price(abstract_spell)
-			dat += "<strong>[spell_name]</strong>[spell_cooldown] ([buy_href_link(spell_path, spell_price, "buy for [spell_price] point\s")])<br>"
-			dat += "<em>[initial(abstract_spell.desc)]</em><br>"
-			var/flags = initial(abstract_spell.spell_flags)
-			var/list/properties = get_spell_properties(flags, user)
-			var/property_data
-			for(var/P in properties)
-				property_data += "[P] "
-			if(property_data)
-				dat += "<span style=\"color:blue\">[property_data]</span><br>"
-			dat += "<br>"
+			dat += handle_spell_contents(user, spell_path)
 
 	if(shown_misc_spells.len)
 		dat += "<span style=\"color:orange\"><strong>MISCELLANEOUS SPELLS:</strong></span><br><br>"
 		for(var/spell_path in shown_misc_spells)
-			var/spell/abstract_spell = spell_path
-			var/spell_name = initial(abstract_spell.name)
-			var/spell_cooldown = get_spell_cooldown_string(initial(abstract_spell.charge_max), initial(abstract_spell.charge_type))
-			var/spell_price = get_spell_price(abstract_spell)
-			dat += "<strong>[spell_name]</strong>[spell_cooldown] ([buy_href_link(spell_path, spell_price, "buy for [spell_price] point\s")])<br>"
-			dat += "<em>[initial(abstract_spell.desc)]</em><br>"
-			var/flags = initial(abstract_spell.spell_flags)
-			var/list/properties = get_spell_properties(flags, user)
-			var/property_data
-			for(var/P in properties)
-				property_data += "[P] "
-			if(property_data)
-				dat += "<span style=\"color:blue\">[property_data]</span><br>"
-			dat += "<br><br>"
+			dat += handle_spell_contents(user, spell_path)
 
 	dat += "<hr><span style=\"color:purple\"><strong>ARTIFACTS AND BUNDLES<sup>*</sup></strong></span><br><small>* Non-refundable</small><br><br>"
 
@@ -258,6 +205,25 @@
 
 	user << browse(dat, "window=spellbook;size=[book_window_size]")
 	onclose(user, "spellbook")
+
+//Handles what shows up for spell contents to reduce copypaste
+/obj/item/weapon/spellbook/proc/handle_spell_contents(var/mob/user, var/spell_path)
+	var/dat
+	var/spell/abstract_spell = spell_path
+	var/spell_name = initial(abstract_spell.name)
+	var/spell_cooldown = get_spell_cooldown_string(initial(abstract_spell.charge_max), initial(abstract_spell.charge_type))
+	var/spell_price = get_spell_price(abstract_spell)
+	dat += "<strong>[spell_name]</strong>[spell_cooldown] ([buy_href_link(spell_path, spell_price, "buy for [spell_price] point\s")])<br>"
+	dat += "<em>[initial(abstract_spell.desc)]</em><br>"
+	var/flags = initial(abstract_spell.spell_flags)
+	var/list/properties = get_spell_properties(flags, user)
+	var/property_data
+	for(var/P in properties)
+		property_data += "[P] "
+	if(property_data)
+		dat += "<span style=\"color:blue\">[property_data]</span><br>"
+	dat += "<br><br>"
+	return dat
 
 /obj/item/weapon/spellbook/proc/get_spell_properties(flags, mob/user)
 	var/list/properties = list()

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -153,25 +153,78 @@
 //<i>(Description)</i>
 //Requires robes to cast
 
+//I truly am sorry for this terrible copypaste, but there was no other way. - B2MTTF
 	if(shown_offensive_spells.len)
 		dat += "<span style=\"color:red\"><strong>OFFENSIVE SPELLS:</strong></span><br><br>"
 		for(var/spell_path in shown_offensive_spells)
-			dat += handle_spell_contents(user, spell_path)
+			var/spell/abstract_spell = spell_path
+			var/spell_name = initial(abstract_spell.name)
+			var/spell_cooldown = get_spell_cooldown_string(initial(abstract_spell.charge_max), initial(abstract_spell.charge_type))
+			var/spell_price = get_spell_price(abstract_spell)
+			dat += "<strong>[spell_name]</strong>[spell_cooldown] ([buy_href_link(spell_path, spell_price, "buy for [spell_price] point\s")])<br>"
+			dat += "<em>[initial(abstract_spell.desc)]</em><br>"
+			var/flags = initial(abstract_spell.spell_flags)
+			var/list/properties = get_spell_properties(flags, user)
+			var/property_data
+			for(var/P in properties)
+				property_data += "[P] "
+			if(property_data)
+				dat += "<span style=\"color:blue\">[property_data]</span><br>"
+			dat += "<br>"
 
 	if(shown_defensive_spells.len)
 		dat += "<span style=\"color:blue\"><strong>DEFENSIVE SPELLS:</strong></span><br><br>"
 		for(var/spell_path in shown_defensive_spells)
-			dat += handle_spell_contents(user, spell_path)
+			var/spell/abstract_spell = spell_path
+			var/spell_name = initial(abstract_spell.name)
+			var/spell_cooldown = get_spell_cooldown_string(initial(abstract_spell.charge_max), initial(abstract_spell.charge_type))
+			var/spell_price = get_spell_price(abstract_spell)
+			dat += "<strong>[spell_name]</strong>[spell_cooldown] ([buy_href_link(spell_path, spell_price, "buy for [spell_price] point\s")])<br>"
+			dat += "<em>[initial(abstract_spell.desc)]</em><br>"
+			var/flags = initial(abstract_spell.spell_flags)
+			var/list/properties = get_spell_properties(flags, user)
+			var/property_data
+			for(var/P in properties)
+				property_data += "[P] "
+			if(property_data)
+				dat += "<span style=\"color:blue\">[property_data]</span><br>"
+			dat += "<br>"
 
 	if(shown_utility_spells.len)
 		dat += "<span style=\"color:green\"><strong>UTILITY SPELLS:</strong></span><br><br>"
 		for(var/spell_path in shown_utility_spells)
-			dat += handle_spell_contents(user, spell_path)
+			var/spell/abstract_spell = spell_path
+			var/spell_name = initial(abstract_spell.name)
+			var/spell_cooldown = get_spell_cooldown_string(initial(abstract_spell.charge_max), initial(abstract_spell.charge_type))
+			var/spell_price = get_spell_price(abstract_spell)
+			dat += "<strong>[spell_name]</strong>[spell_cooldown] ([buy_href_link(spell_path, spell_price, "buy for [spell_price] point\s")])<br>"
+			dat += "<em>[initial(abstract_spell.desc)]</em><br>"
+			var/flags = initial(abstract_spell.spell_flags)
+			var/list/properties = get_spell_properties(flags, user)
+			var/property_data
+			for(var/P in properties)
+				property_data += "[P] "
+			if(property_data)
+				dat += "<span style=\"color:blue\">[property_data]</span><br>"
+			dat += "<br>"
 
 	if(shown_misc_spells.len)
 		dat += "<span style=\"color:orange\"><strong>MISCELLANEOUS SPELLS:</strong></span><br><br>"
 		for(var/spell_path in shown_misc_spells)
-			dat += handle_spell_contents(user, spell_path)
+			var/spell/abstract_spell = spell_path
+			var/spell_name = initial(abstract_spell.name)
+			var/spell_cooldown = get_spell_cooldown_string(initial(abstract_spell.charge_max), initial(abstract_spell.charge_type))
+			var/spell_price = get_spell_price(abstract_spell)
+			dat += "<strong>[spell_name]</strong>[spell_cooldown] ([buy_href_link(spell_path, spell_price, "buy for [spell_price] point\s")])<br>"
+			dat += "<em>[initial(abstract_spell.desc)]</em><br>"
+			var/flags = initial(abstract_spell.spell_flags)
+			var/list/properties = get_spell_properties(flags, user)
+			var/property_data
+			for(var/P in properties)
+				property_data += "[P] "
+			if(property_data)
+				dat += "<span style=\"color:blue\">[property_data]</span><br>"
+			dat += "<br><br>"
 
 	dat += "<hr><span style=\"color:purple\"><strong>ARTIFACTS AND BUNDLES<sup>*</sup></strong></span><br><small>* Non-refundable</small><br><br>"
 
@@ -205,25 +258,6 @@
 
 	user << browse(dat, "window=spellbook;size=[book_window_size]")
 	onclose(user, "spellbook")
-
-//Handles what shows up for spell contents to reduce copypaste
-/obj/item/weapon/spellbook/proc/handle_spell_contents(var/mob/user, var/spell_path)
-	var/dat
-	var/spell/abstract_spell = spell_path
-	var/spell_name = initial(abstract_spell.name)
-	var/spell_cooldown = get_spell_cooldown_string(initial(abstract_spell.charge_max), initial(abstract_spell.charge_type))
-	var/spell_price = get_spell_price(abstract_spell)
-	dat += "<strong>[spell_name]</strong>[spell_cooldown] ([buy_href_link(spell_path, spell_price, "buy for [spell_price] point\s")])<br>"
-	dat += "<em>[initial(abstract_spell.desc)]</em><br>"
-	var/flags = initial(abstract_spell.spell_flags)
-	var/list/properties = get_spell_properties(flags, user)
-	var/property_data
-	for(var/P in properties)
-		property_data += "[P] "
-	if(property_data)
-		dat += "<span style=\"color:blue\">[property_data]</span><br>"
-	dat += "<br><br>"
-	return dat
 
 /obj/item/weapon/spellbook/proc/get_spell_properties(flags, mob/user)
 	var/list/properties = list()

--- a/code/modules/spells/spell_code.dm
+++ b/code/modules/spells/spell_code.dm
@@ -15,6 +15,7 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 	var/charge_type = Sp_RECHARGE //can be recharge or charges, see charge_max and charge_counter descriptions; can also be based on the holder's vars now, use "holder_var" for that; can ALSO be made to gradually drain the charge with Sp_GRADUAL
 	//The following are allowed: Sp_RECHARGE (Recharges), Sp_CHARGE (Limited uses), Sp_GRADUAL (Gradually lose charges), Sp_PASSIVE (Does not cast)
 
+	var/initial_charge_max = 100 //Used to calculate cooldown reduction
 	var/charge_max = 100 //recharge time in deciseconds if charge_type = Sp_RECHARGE or starting charges if charge_type = Sp_CHARGES
 	var/charge_counter = 0 //can only cast spells if it equals recharge, ++ each decisecond if charge_type = Sp_RECHARGE or -- each cast if charge_type = Sp_CHARGES
 	var/minimum_charge = 0 //if set, the minimum charge_counter necessary to cast Sp_GRADUAL spells
@@ -110,6 +111,7 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 
 	//still_recharging_msg = "<span class='notice'>[name] is still recharging.</span>"
 	charge_counter = charge_max
+	initial_charge_max = charge_max //Let's not add charge_max_initial to roughly 80 (at the time of this comment) spells
 
 /spell/proc/set_holder(var/new_holder)
 	if(holder == new_holder)
@@ -519,7 +521,7 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 		if(cooldown_reduc)
 			charge_max = max(cooldown_min, charge_max - cooldown_reduc)
 		else
-			charge_max = round( max(cooldown_min, initial(charge_max) * ((level_max[Sp_SPEED] - spell_levels[Sp_SPEED]) / level_max[Sp_SPEED] ) ) ) //the fraction of the way you are to max speed levels is the fraction you lose
+			charge_max = round(initial_charge_max - spell_levels[Sp_SPEED] * (initial_charge_max - cooldown_min)/ level_max[Sp_SPEED])
 	if(charge_max < charge_counter)
 		charge_counter = charge_max
 

--- a/code/modules/spells/spell_code.dm
+++ b/code/modules/spells/spell_code.dm
@@ -15,7 +15,6 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 	var/charge_type = Sp_RECHARGE //can be recharge or charges, see charge_max and charge_counter descriptions; can also be based on the holder's vars now, use "holder_var" for that; can ALSO be made to gradually drain the charge with Sp_GRADUAL
 	//The following are allowed: Sp_RECHARGE (Recharges), Sp_CHARGE (Limited uses), Sp_GRADUAL (Gradually lose charges), Sp_PASSIVE (Does not cast)
 
-	var/initial_charge_max = 100 //This is used as a point to compare charge_max of spells
 	var/charge_max = 100 //recharge time in deciseconds if charge_type = Sp_RECHARGE or starting charges if charge_type = Sp_CHARGES
 	var/charge_counter = 0 //can only cast spells if it equals recharge, ++ each decisecond if charge_type = Sp_RECHARGE or -- each cast if charge_type = Sp_CHARGES
 	var/minimum_charge = 0 //if set, the minimum charge_counter necessary to cast Sp_GRADUAL spells
@@ -111,7 +110,6 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 
 	//still_recharging_msg = "<span class='notice'>[name] is still recharging.</span>"
 	charge_counter = charge_max
-	initial_charge_max = charge_max //Let's not add charge_max_initial to roughly 80 (at the time of this comment) spells
 
 /spell/proc/set_holder(var/new_holder)
 	if(holder == new_holder)
@@ -521,7 +519,7 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 		if(cooldown_reduc)
 			charge_max = max(cooldown_min, charge_max - cooldown_reduc)
 		else
-			charge_max = round(initial_charge_max - spell_levels[Sp_SPEED] * (initial_charge_max - cooldown_min)/ level_max[Sp_SPEED])
+			charge_max = round( max(cooldown_min, initial(charge_max) * ((level_max[Sp_SPEED] - spell_levels[Sp_SPEED]) / level_max[Sp_SPEED] ) ) ) //the fraction of the way you are to max speed levels is the fraction you lose
 	if(charge_max < charge_counter)
 		charge_counter = charge_max
 

--- a/code/modules/spells/spell_code.dm
+++ b/code/modules/spells/spell_code.dm
@@ -15,6 +15,7 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 	var/charge_type = Sp_RECHARGE //can be recharge or charges, see charge_max and charge_counter descriptions; can also be based on the holder's vars now, use "holder_var" for that; can ALSO be made to gradually drain the charge with Sp_GRADUAL
 	//The following are allowed: Sp_RECHARGE (Recharges), Sp_CHARGE (Limited uses), Sp_GRADUAL (Gradually lose charges), Sp_PASSIVE (Does not cast)
 
+	var/initial_charge_max = 100 //This is used as a point to compare charge_max of spells
 	var/charge_max = 100 //recharge time in deciseconds if charge_type = Sp_RECHARGE or starting charges if charge_type = Sp_CHARGES
 	var/charge_counter = 0 //can only cast spells if it equals recharge, ++ each decisecond if charge_type = Sp_RECHARGE or -- each cast if charge_type = Sp_CHARGES
 	var/minimum_charge = 0 //if set, the minimum charge_counter necessary to cast Sp_GRADUAL spells
@@ -110,6 +111,7 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 
 	//still_recharging_msg = "<span class='notice'>[name] is still recharging.</span>"
 	charge_counter = charge_max
+	initial_charge_max = charge_max //Let's not add charge_max_initial to roughly 80 (at the time of this comment) spells
 
 /spell/proc/set_holder(var/new_holder)
 	if(holder == new_holder)
@@ -519,7 +521,7 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 		if(cooldown_reduc)
 			charge_max = max(cooldown_min, charge_max - cooldown_reduc)
 		else
-			charge_max = round( max(cooldown_min, initial(charge_max) * ((level_max[Sp_SPEED] - spell_levels[Sp_SPEED]) / level_max[Sp_SPEED] ) ) ) //the fraction of the way you are to max speed levels is the fraction you lose
+			charge_max = round(initial_charge_max - spell_levels[Sp_SPEED] * (initial_charge_max - cooldown_min)/ level_max[Sp_SPEED])
 	if(charge_max < charge_counter)
 		charge_counter = charge_max
 


### PR DESCRIPTION
The cooldown formula is from TG, tested without problems.
:cl:
 * tweak: Wizard spell cooldown reduction logic has been improved, please report if there is anything wrong. Noticeably, blink will reach the minimum 0.5 seconds cooldown at the fourth cooldown upgrade, not at the third one.