### PR TITLE
Increases the time until you're knocked out with chloral to 10 seconds from 2

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -3735,10 +3735,10 @@
 	if(..())
 		return 1
 	switch(data)
-		if(1)
+		if(1 to 5)
 			M.confused += 2
 			M.drowsyness += 2
-		if(2 to 80)
+		if(6 to 80)
 			M.sleeping++
 		if(81 to INFINITY)
 			M.sleeping++


### PR DESCRIPTION
The drowsiness also really slows you down so you don't have much to escape, but you can retaliate a little or whatever
Do not merge if #25504 is merged
:cl:
 * tweak: Chloral now takes 10 seconds before it knocks you out instead of 2.