### PR TITLE
Fixes a rare bug where the safe could not be opened

### DIFF
--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -24,10 +24,10 @@ FLOOR SAFES
 
 /obj/structure/safe/New()
 	tumbler_1_pos = rand(0, 71)
-	tumbler_1_open = rand(0, 71)
+	tumbler_1_open = rand(2, 71)
 
 	tumbler_2_pos = rand(0, 71)
-	tumbler_2_open = rand(0, 71)
+	tumbler_2_open = rand(2, 71)
 
 /obj/structure/safe/initialize()
 	for(var/obj/item/I in loc)
@@ -36,11 +36,6 @@ FLOOR SAFES
 		if(I.w_class + space <= maxspace)
 			space += I.w_class
 			I.forceMove(src)
-
-	//Trying to track down issue #18719
-	var/area/this_area = get_area(src)
-	log_debug("[this_area.name] safe has starting tumbler positions [tumbler_1_pos]-[tumbler_2_pos] and opening positions [tumbler_1_open]-[tumbler_2_open].")
-
 
 /obj/structure/safe/proc/check_unlocked(mob/user as mob, canhear)
 	if(user && canhear)


### PR DESCRIPTION
Fuck off, I hate safes. What happened was that the tumbler opening positions spawned in such a way that they could not be reached using the formula that the safe uses for tumbler movement and one tumbler would be off from its opening position by 1-2 as it would reset, but I'm not taking any risks so I've narrowed the random tumbler opening position from 0-71 to 2-71
Fixes #18719
:cl:
 * bugfix: Fixed a rare bug where the safe could not be cracked open due to RNG.