### PR TITLE
Adds a 2-second cooldown to warping claws

### DIFF
--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -321,15 +321,16 @@
 	sharpness_added = 2
 	hitsound_added = 'sound/weapons/slice.ogg'
 	attack_verb_override = "claws"
+	var/delay = 2 //2 seconds cooldown before you can use it again
 	var/last_used
 
 /obj/item/clothing/gloves/warping_claws/dexterity_check()
 	return FALSE
 
 /obj/item/clothing/gloves/warping_claws/on_wearer_threw_item(mob/user, atom/target, atom/movable/thrown)
-	if(world.time - last_used < 5 SECONDS)
-		var/cooldown = round(((50 - (world.time - last_used))/10), 1)
-		to_chat(user, "<span class='warning'>You have to wait [cooldown] second[cooldown == 1 ? "" : "s"] until \the [src.name] recharge!")
+	if(world.time - last_used < delay SECONDS)
+		var/cooldown = round(((delay * 10 - (world.time - last_used))/10), 1)
+		to_chat(user, "<span class='warning'>You have to wait [cooldown] second[cooldown == 1 ? "" : "s"] until you can use \the [src.name] again!")
 		return
 	if(target && !thrown)
 		var/obj/effect/portal/tear/P1 = new (get_turf(user),5 SECONDS)

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -321,11 +321,16 @@
 	sharpness_added = 2
 	hitsound_added = 'sound/weapons/slice.ogg'
 	attack_verb_override = "claws"
+	var/last_used
 
 /obj/item/clothing/gloves/warping_claws/dexterity_check()
 	return FALSE
 
 /obj/item/clothing/gloves/warping_claws/on_wearer_threw_item(mob/user, atom/target, atom/movable/thrown)
+	if(world.time - last_used < 5 SECONDS)
+		var/cooldown = round(((50 - (world.time - last_used))/10), 1)
+		to_chat(user, "<span class='warning'>You have to wait [cooldown] second[cooldown == 1 ? "" : "s"] until \the [src.name] recharge!")
+		return
 	if(target && !thrown)
 		var/obj/effect/portal/tear/P1 = new (get_turf(user),5 SECONDS)
 		var/obj/effect/portal/tear/P2 = new (get_turf(target),5 SECONDS)
@@ -336,6 +341,7 @@
 		P1.owner = user
 		P2.owner = user
 		P1.teleport(user)
+		last_used = world.time
 
 /obj/item/clothing/gloves/mining
 	name = "fists of the rockernaut"


### PR DESCRIPTION
These have no cooldown, you can spam portals endlessly
:cl:
 * tweak: Warping claws now have a 2-second cooldown. This change is brought to you by that wizard who used the warping claws.