### PR TITLE
Some Cult Experiment

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -227,13 +227,11 @@
 							"Chief Engineer", "Chief Medical Officer", "Research Director")
 	enemy_jobs = list("Security Officer","Warden", "Detective","Head of Security", "Captain")
 	required_enemies = list(3,3,2,2,2,2,2,1,1,0)
-	//required_candidates = 4
 	required_candidates = 2
 	weight = 2
 	cost = 30
 	requirements = list(90,80,60,30,20,10,10,10,10,10)
 	high_population_requirement = 40
-	//var/cultist_cap = list(2,2,3,4,4,4,4,4,4,4)
 	var/cultist_cap = list(2,2,2,2,2,2,2,2,2,2)
 	flags = HIGHLANDER_RULESET
 

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -227,12 +227,14 @@
 							"Chief Engineer", "Chief Medical Officer", "Research Director")
 	enemy_jobs = list("Security Officer","Warden", "Detective","Head of Security", "Captain")
 	required_enemies = list(3,3,2,2,2,2,2,1,1,0)
-	required_candidates = 4
+	//required_candidates = 4
+	required_candidates = 2
 	weight = 2
 	cost = 30
 	requirements = list(90,80,60,30,20,10,10,10,10,10)
 	high_population_requirement = 40
-	var/cultist_cap = list(2,2,3,4,4,4,4,4,4,4)
+	//var/cultist_cap = list(2,2,3,4,4,4,4,4,4,4)
+	var/cultist_cap = list(2,2,2,2,2,2,2,2,2,2)
 	flags = HIGHLANDER_RULESET
 
 /datum/dynamic_ruleset/roundstart/bloodcult/ready(var/forced = 0)

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
@@ -408,7 +408,8 @@
 	while(failsafe < 1000)
 		failsafe++
 		//are our payers still here and about?
-		var/summoners = 0
+		//var/summoners = 0
+		var/summoners = 1
 		for(var/mob/living/L in contributors)
 			if (iscultist(L) && (L in range(spell_holder,1)) && (L.stat == CONSCIOUS))
 				summoners++

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
@@ -408,8 +408,7 @@
 	while(failsafe < 1000)
 		failsafe++
 		//are our payers still here and about?
-		//var/summoners = 0
-		var/summoners = 1
+		var/summoners = 1//the higher, the easier it is to perform the ritual without many cultists. default=0
 		for(var/mob/living/L in contributors)
 			if (iscultist(L) && (L in range(spell_holder,1)) && (L.stat == CONSCIOUS))
 				summoners++


### PR DESCRIPTION
An attempt at quality over quantity I guess.

I'm counting on everyone to share their thoughts in the comments, this took no time to code so I won't care much if people would rather have it stay the way it is.

:cl:
* experiment: Lowered the amount of roundstart cultists to 2.
* experiment: The Raise Structure rune now works as if there was always 1 extra cultist using it, making it much faster to raise the Altar with only 2 cultists, and do-able without passing out alone.