### PR TITLE
Robotics console clean-up

### DIFF
--- a/__DEFINES/silicon.dm
+++ b/__DEFINES/silicon.dm
@@ -57,9 +57,9 @@ var/global/list/all_robot_modules = default_nanotrasen_robot_modules + emergency
 	return pickable_modules
 
 //Emagged silicon defines
-#define UNHACKED 0
-#define HACKED 1
-#define MALFHACKED 2
+#define ROBOT_UNHACKED 0
+#define ROBOT_HACKED 1
+#define ROBOT_MALFHACKED 2
 
 //Module quirks
 #define MODULE_CAN_BE_PUSHED 1			//What says on the tin.

--- a/__DEFINES/silicon.dm
+++ b/__DEFINES/silicon.dm
@@ -56,6 +56,10 @@ var/global/list/all_robot_modules = default_nanotrasen_robot_modules + emergency
 		pickable_modules += emergency_nanotrasen_robot_modules
 	return pickable_modules
 
+//Emagged silicon defines
+#define UNHACKED 0
+#define HACKED 1
+#define MALFHACKED 2
 
 //Module quirks
 #define MODULE_CAN_BE_PUSHED 1			//What says on the tin.

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -32,8 +32,6 @@
 				continue
 		if(R.scrambledcodes)
 			continue
-		if(z != R.z) //Not on the same z-level
-			continue
 		dat += "[R.name] |"
 		if(R.stat)
 			dat += " Not Responding |"
@@ -54,19 +52,22 @@
 			dat += " Slaved to [R.connected_ai.name] |"
 		else
 			dat += " Independent from AI |"
-		if(ismalf(user) && R.connected_ai == user)
-			if(R.emagged != MALFHACKED)
-				dat += "<A href='?src=\ref[src];hackbot=\ref[R]'>(<font color=blue><i>Hack</i></font>)</A>"
-			else
-				dat += "<font color=green>Hacked</font>"
+		if(z == R.z)
+			if(ismalf(user) && R.connected_ai == user)
+				if(R.emagged != ROBOT_MALFHACKED)
+					dat += "<A href='?src=\ref[src];hackbot=\ref[R]'>(<font color=blue><i>Hack</i></font>)</A>"
+				else
+					dat += "<font color=green>Hacked</font>"
 /*
-			else if(R.emagged == MALFHACKED)
-				dat += "<A href='?src=\ref[src];unhackbot=\ref[R]'>(<font color=blue><i>Repair</i></font>)</A>"
+				else if(R.emagged == ROBOT_MALFHACKED)
+					dat += "<A href='?src=\ref[src];unhackbot=\ref[R]'>(<font color=blue><i>Repair</i></font>)</A>"
 */
-		dat += {"<A href='?src=\ref[src];stopbot=\ref[R]'>(<font color=green><i>[R.canmove ? "Lockdown" : "Release"]</i></font>)</A>
-			<A href='?src=\ref[src];lockbot=\ref[R]'>(<font color=orange><i>[R.modulelock ? "Module-unlock" : "Module-lock"]</i></font>)</A>
-			<A href='?src=\ref[src];killbot=\ref[R]'>(<font color=red><i>Destroy</i></font>)</A>
-			<BR><BR>"}
+			dat += {"<A href='?src=\ref[src];stopbot=\ref[R]'>(<font color=green><i>[R.canmove ? "Lockdown" : "Release"]</i></font>)</A>
+				<A href='?src=\ref[src];lockbot=\ref[R]'>(<font color=orange><i>[R.modulelock ? "Module-unlock" : "Module-lock"]</i></font>)</A>
+				<A href='?src=\ref[src];killbot=\ref[R]'>(<font color=red><i>Destroy</i></font>)</A>
+				<BR><BR>"}
+		else
+			dat += "Out of range"
 
 	user << browse(dat, "window=computer;size=400x500")
 	onclose(user, "computer")
@@ -125,7 +126,7 @@
 				if(!sanity_check(usr, R))
 					return
 				log_game("[key_name(usr)] hacked [R.name] using the robotics console!")
-				R.SetEmagged(MALFHACKED)
+				R.SetEmagged(ROBOT_MALFHACKED)
 				if(R.mind.special_role)
 					R.verbs += /mob/living/silicon/robot/proc/ResetSecurityCodes
 /* //Unhacking borgs doesn't remove their emagged module currently
@@ -135,7 +136,7 @@
 				if(!sanity_check(usr, R))
 					return
 				log_game("[key_name(usr)] un-hacked [R.name] using the robotics console!")
-				R.SetEmagged(UNHACKED)
+				R.SetEmagged(ROBOT_UNHACKED)
 */
 		src.add_fingerprint(usr)
 	src.updateUsrDialog()


### PR DESCRIPTION
It looks a bit nicer.

- Removed self-destruct sequence from the robotics console. Nobody used it, it took 60 seconds to detonate borgs when you could do it manually
- Because there's no self-destruct sequence page, there is no reason for a main menu, so now the only screen is the cyborg status screen
- Malf AI can now see if their borg is already hacked and their emagged module is unlocked. They won't notice if the borg is a rogue borg though
- Robotics console now checks if the robot is on the same z-level as it, if it isn't it can't send commands.
- Added defines that will be used in the future for borgs' emagged status (ROBOT_UNHACKED, ROBOT_HACKED, ROBOT_MALFHACKED)
- A little bit of clean-up

:cl:
 * tweak: The robotics console looks a bit cleaner.
 * tweak: Malfunctioning AI can now see if their robot is hacked by them. Subverted and traitor robots are still indistinguishable however.
 * tweak: The robotics console now only works on robots that are on the same z-level as it.
 * rscdel: Removed the robotics console self-destruct sequence.