### PR TITLE
Spell specialization clean-up

### DIFF
--- a/__DEFINES/spell_defines.dm
+++ b/__DEFINES/spell_defines.dm
@@ -75,7 +75,10 @@
 #define SPELL_NECROTIC 16 //Necromantic spells
 
 //Spell specializations, used for spellbook lists
-#define SPELL_SPECIALIZATION_DEFAULT 1 //So it doesn't gorge on a word that could be used for better things
-#define OFFENSIVE 2
-#define DEFENSIVE 4
-#define UTILITY 8
+#define SPELL_SPECIALIZATION_OFFENSIVE 1
+#define SPELL_SPECIALIZATION_DEFENSIVE 2
+#define SPELL_SPECIALIZATION_UTILITY 4
+
+#define SSOFFENSIVE SPELL_SPECIALIZATION_OFFENSIVE
+#define SSDEFENSIVE SPELL_SPECIALIZATION_DEFENSIVE
+#define SSUTILITY SPELL_SPECIALIZATION_UTILITY

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -65,13 +65,13 @@
 		var/spell/S = new wizard_spell
 		all_spells += wizard_spell
 		if (!S.holiday_required.len || (Holiday in S.holiday_required))
-			if(S.specialization == OFFENSIVE)
+			if(S.specialization == SSOFFENSIVE)
 				offensive_spells += wizard_spell
-			if(S.specialization == DEFENSIVE)
+			if(S.specialization == SSDEFENSIVE)
 				defensive_spells += wizard_spell
-			if(S.specialization == UTILITY)
+			if(S.specialization == SSUTILITY)
 				utility_spells += wizard_spell
-			if(S.specialization == SPELL_SPECIALIZATION_DEFAULT)
+			else
 				misc_spells += wizard_spell
 
 	for(var/T in available_artifacts)

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -64,15 +64,16 @@
 	for(var/wizard_spell in getAllWizSpells())
 		var/spell/S = new wizard_spell
 		all_spells += wizard_spell
-		if (!S.holiday_required.len || (Holiday in S.holiday_required))
-			if(S.specialization == SSOFFENSIVE)
-				offensive_spells += wizard_spell
-			if(S.specialization == SSDEFENSIVE)
-				defensive_spells += wizard_spell
-			if(S.specialization == SSUTILITY)
-				utility_spells += wizard_spell
-			else
-				misc_spells += wizard_spell
+		if(!S.holiday_required.len || (Holiday in S.holiday_required))
+			switch(S.specialization)
+				if(SSOFFENSIVE)
+					offensive_spells += wizard_spell
+				if(SSDEFENSIVE)
+					defensive_spells += wizard_spell
+				if(SSUTILITY)
+					utility_spells += wizard_spell
+				else
+					misc_spells += wizard_spell
 
 	for(var/T in available_artifacts)
 		available_artifacts.Add(new T) //Create a new object with the path T

--- a/code/modules/spells/aoe_turf/blink.dm
+++ b/code/modules/spells/aoe_turf/blink.dm
@@ -2,7 +2,7 @@
 	name = "Blink"
 	desc = "This spell randomly teleports you a short distance."
 	user_type = USER_TYPE_WIZARD
-	specialization = DEFENSIVE
+	specialization = SSDEFENSIVE
 	abbreviation = "BL"
 
 	school = "abjuration"

--- a/code/modules/spells/aoe_turf/charge.dm
+++ b/code/modules/spells/aoe_turf/charge.dm
@@ -2,7 +2,7 @@
 	name = "Charge"
 	desc = "This spell can be used to charge up spent magical artifacts, among other things."
 	user_type = USER_TYPE_SPELLBOOK
-	specialization = UTILITY
+	specialization = SSUTILITY
 
 	school = "transmutation"
 	charge_max = 600

--- a/code/modules/spells/aoe_turf/conjure/arcane_golem.dm
+++ b/code/modules/spells/aoe_turf/conjure/arcane_golem.dm
@@ -4,7 +4,7 @@
 	name = "Forge Arcane Golem"
 	desc = "Creates a fragile construct that follows you around. It knows a basic version of all of your spells, and will cast them simultaneously with you - at the same target. If cast while an arcane golem is already summoned, your arcane golems will be teleported to you instead. It's unable to learn Mind Transfer and Forge Arcane Golem."
 	user_type = USER_TYPE_WIZARD
-	specialization = UTILITY
+	specialization = SSUTILITY
 
 	charge_max = 20 SECONDS
 	cooldown_min = 1 SECONDS

--- a/code/modules/spells/aoe_turf/conjure/doppelganger.dm
+++ b/code/modules/spells/aoe_turf/conjure/doppelganger.dm
@@ -2,7 +2,7 @@
 	name = "Doppelganger"
 	desc = "This spell summons a construct with your appearance."
 	user_type = USER_TYPE_WIZARD
-	specialization = OFFENSIVE
+	specialization = SSOFFENSIVE
 
 	summon_type = list(/mob/living/simple_animal/hostile/humanoid/wizard/doppelganger/melee)
 

--- a/code/modules/spells/aoe_turf/conjure/forcewall.dm
+++ b/code/modules/spells/aoe_turf/conjure/forcewall.dm
@@ -2,7 +2,7 @@
 	name = "Forcewall"
 	desc = "Create a wall of pure energy at your location."
 	user_type = USER_TYPE_WIZARD
-	specialization = DEFENSIVE
+	specialization = SSDEFENSIVE
 	abbreviation = "FW"
 	summon_type = list(/obj/effect/forcefield/wizard)
 	duration = 300

--- a/code/modules/spells/aoe_turf/conjure/pontiac.dm
+++ b/code/modules/spells/aoe_turf/conjure/pontiac.dm
@@ -5,7 +5,7 @@
 	desc = "This spell summons a glorious, flaming chariot that can move in space."
 	abbreviation = "WM"
 	user_type = USER_TYPE_WIZARD
-	specialization = UTILITY
+	specialization = SSUTILITY
 
 	charge_type = Sp_CHARGES
 	charge_max = 1

--- a/code/modules/spells/aoe_turf/conjure/snakes.dm
+++ b/code/modules/spells/aoe_turf/conjure/snakes.dm
@@ -2,7 +2,7 @@
 	name = "Become Snakes"
 	desc = "This spell transforms your body into a den of snakes."
 	user_type = USER_TYPE_WIZARD
-	specialization = DEFENSIVE
+	specialization = SSDEFENSIVE
 
 	summon_type = list(/mob/living/simple_animal/cat/snek/wizard)
 

--- a/code/modules/spells/aoe_turf/disable_tech.dm
+++ b/code/modules/spells/aoe_turf/disable_tech.dm
@@ -2,7 +2,7 @@
 	name = "Disable Tech"
 	desc = "This spell disables all weapons, cameras and most other technology in range."
 	user_type = USER_TYPE_WIZARD
-	specialization = UTILITY
+	specialization = SSUTILITY
 	abbreviation = "DT"
 
 	charge_max = 400

--- a/code/modules/spells/aoe_turf/fall.dm
+++ b/code/modules/spells/aoe_turf/fall.dm
@@ -5,7 +5,7 @@ var/global/list/falltempoverlays = list()
 	name = "Time Stop"
 	desc = "This spell temporarily stops time for everybody around you, except for you. The spell lasts 3 seconds, and upgrading its power can further increase the duration."
 	user_type = USER_TYPE_WIZARD
-	specialization = UTILITY
+	specialization = SSUTILITY
 
 	abbreviation = "MS"
 

--- a/code/modules/spells/aoe_turf/knock.dm
+++ b/code/modules/spells/aoe_turf/knock.dm
@@ -3,7 +3,7 @@
 	desc = "This spell opens nearby doors and does not require wizard garb."
 	abbreviation = "KN"
 	user_type = USER_TYPE_WIZARD
-	specialization = UTILITY
+	specialization = SSUTILITY
 
 	school = "transmutation"
 	charge_max = 100

--- a/code/modules/spells/aoe_turf/lightbulb.dm
+++ b/code/modules/spells/aoe_turf/lightbulb.dm
@@ -2,7 +2,7 @@
 	name = "Break Lightbulbs"
 	desc = "This spell breaks lightbulbs within 7 tiles of you."
 	user_type = USER_TYPE_WIZARD
-	specialization = UTILITY
+	specialization = SSUTILITY
 	abbreviation = "LB"
 
 	charge_max = 150

--- a/code/modules/spells/aoe_turf/smoke.dm
+++ b/code/modules/spells/aoe_turf/smoke.dm
@@ -3,7 +3,7 @@
 	desc = "This spell spawns a cloud of choking smoke at your location and does not require wizard garb."
 	abbreviation = "SM"
 	user_type = USER_TYPE_WIZARD
-	specialization = DEFENSIVE //Provides cover
+	specialization = SSDEFENSIVE //Provides cover
 
 	school = "conjuration"
 	charge_max = 120

--- a/code/modules/spells/general/area_teleport.dm
+++ b/code/modules/spells/general/area_teleport.dm
@@ -3,7 +3,7 @@
 	desc = "This spell teleports you to a type of area of your selection."
 	abbreviation = "TP"
 	user_type = USER_TYPE_WIZARD
-	specialization = UTILITY
+	specialization = SSUTILITY
 
 	school = "abjuration"
 	spell_flags = NEEDSCLOTHES

--- a/code/modules/spells/general/lightning.dm
+++ b/code/modules/spells/general/lightning.dm
@@ -3,7 +3,7 @@
 	abbreviation = "LS"
 	desc = "Strike an enemy with a bolt of lightning."
 	user_type = USER_TYPE_WIZARD
-	specialization = OFFENSIVE
+	specialization = SSOFFENSIVE
 	charge_max = 100
 	cooldown_min = 40
 	cooldown_reduc = 30

--- a/code/modules/spells/general/reflect_pain.dm
+++ b/code/modules/spells/general/reflect_pain.dm
@@ -3,7 +3,7 @@
 	name = "Pain Mirror"
 	desc = "An unholy charm that lasts for 5 seconds. While active, it redirects all incoming damage to everybody around you, leaving you unharmed."
 	user_type = USER_TYPE_WIZARD
-	specialization = DEFENSIVE
+	specialization = SSDEFENSIVE
 
 	school = "necromancy"
 	charge_max = 90 SECONDS

--- a/code/modules/spells/general/ring_of_fire.dm
+++ b/code/modules/spells/general/ring_of_fire.dm
@@ -2,7 +2,7 @@
 	name = "Ring of Fire"
 	desc = "Summon a stationary ring of flames around your current location for 10 seconds. While the ring is active, you are fully immune to fire and burns."
 	user_type = USER_TYPE_WIZARD
-	specialization = OFFENSIVE
+	specialization = SSOFFENSIVE
 	school = "conjuration"
 	charge_max = 300
 	cooldown_min = 100

--- a/code/modules/spells/passive/no_clothes.dm
+++ b/code/modules/spells/passive/no_clothes.dm
@@ -5,5 +5,5 @@
 	desc = "Removes the need of wizard robes to cast powerful spells."
 	hud_state = "wiz_noclothes"
 	price = 2 * Sp_BASE_PRICE
-	specialization = UTILITY
+	specialization = SSUTILITY
 //The no_clothes check exists in spell_code.dm

--- a/code/modules/spells/spell_code.dm
+++ b/code/modules/spells/spell_code.dm
@@ -10,7 +10,7 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 
 	var/school = "evocation" //not relevant at now, but may be important later if there are changes to how spells work. the ones I used for now will probably be changed... maybe spell presets? lacking flexibility but with some other benefit?
 	var/user_type = USER_TYPE_NOUSER // What kind of mob uses this spell
-	var/specialization = SPELL_SPECIALIZATION_DEFAULT //Used for what list they belong to in the spellbook. SPELL_SPECIALIZATION_DEFAULT, OFFENSIVE, DEFENSIVE, UTILITY
+	var/specialization //Used for what list they belong to in the spellbook. SSOFFENSIVE, SSDEFENSIVE, SSUTILITY
 
 	var/charge_type = Sp_RECHARGE //can be recharge or charges, see charge_max and charge_counter descriptions; can also be based on the holder's vars now, use "holder_var" for that; can ALSO be made to gradually drain the charge with Sp_GRADUAL
 	//The following are allowed: Sp_RECHARGE (Recharges), Sp_CHARGE (Limited uses), Sp_GRADUAL (Gradually lose charges), Sp_PASSIVE (Does not cast)

--- a/code/modules/spells/targeted/buttbots_revenge.dm
+++ b/code/modules/spells/targeted/buttbots_revenge.dm
@@ -2,7 +2,7 @@
 	name = "Butt-Bot's Revenge"
 	desc = "This spell removes the target's ass in a firey explosion."
 	user_type = USER_TYPE_WIZARD
-	specialization = OFFENSIVE
+	specialization = SSOFFENSIVE
 	abbreviation = "AN"
 
 	school = "evocation"

--- a/code/modules/spells/targeted/disorient.dm
+++ b/code/modules/spells/targeted/disorient.dm
@@ -3,7 +3,7 @@
 	desc = "This spell temporarily disorients a target."
 	abbreviation = "SJ"
 	user_type = USER_TYPE_WIZARD
-	specialization = OFFENSIVE
+	specialization = SSOFFENSIVE
 
 	school = "transmutation"
 	charge_max = 300

--- a/code/modules/spells/targeted/equip/clowncurse.dm
+++ b/code/modules/spells/targeted/equip/clowncurse.dm
@@ -3,7 +3,7 @@
 	desc = "A curse that will turn its victim into a miserable clown."
 	abbreviation = "CC"
 	user_type = USER_TYPE_WIZARD
-	specialization = OFFENSIVE
+	specialization = SSOFFENSIVE
 
 	school = "evocation"
 	charge_max = 300

--- a/code/modules/spells/targeted/equip/frenchcurse.dm
+++ b/code/modules/spells/targeted/equip/frenchcurse.dm
@@ -3,7 +3,7 @@
 	desc = "This curse will silence your target for a very long time."
 	abbreviation = "FC"
 	user_type = USER_TYPE_WIZARD
-	specialization = OFFENSIVE
+	specialization = SSOFFENSIVE
 
 	school = "evocation"
 	charge_max = 300

--- a/code/modules/spells/targeted/equip/horsemask.dm
+++ b/code/modules/spells/targeted/equip/horsemask.dm
@@ -3,7 +3,7 @@
 	desc = "This spell triggers a curse on a target, causing them to wield an unremovable horse head mask. They will speak like a horse! Any masks they are wearing will be disintegrated. This spell does not require robes."
 	abbreviation = "HH"
 	user_type = USER_TYPE_WIZARD
-	specialization = OFFENSIVE
+	specialization = SSOFFENSIVE
 
 	school = "transmutation"
 	charge_type = Sp_RECHARGE

--- a/code/modules/spells/targeted/equip/robesummon.dm
+++ b/code/modules/spells/targeted/equip/robesummon.dm
@@ -8,7 +8,7 @@
 	desc = "A spell which will summon you a new set of robes."
 	abbreviation = "RS"
 	user_type = USER_TYPE_WIZARD
-	specialization = UTILITY
+	specialization = SSUTILITY
 
 	school = "evocation"
 	charge_max = 300

--- a/code/modules/spells/targeted/ethereal_jaunt.dm
+++ b/code/modules/spells/targeted/ethereal_jaunt.dm
@@ -3,7 +3,7 @@
 	desc = "This spell creates your ethereal form, temporarily making you invisible and able to pass through walls."
 	abbreviation = "EJ"
 	user_type = USER_TYPE_WIZARD
-	specialization = UTILITY
+	specialization = SSUTILITY
 
 	school = "transmutation"
 	charge_max = 300

--- a/code/modules/spells/targeted/feint.dm
+++ b/code/modules/spells/targeted/feint.dm
@@ -3,7 +3,7 @@
 	desc = "This spell grants you a magic weapon and causes you to vanish, before reappearing behind the enemy."
 	abbreviation = "FT"
 	user_type = USER_TYPE_WIZARD
-	specialization = OFFENSIVE
+	specialization = SSOFFENSIVE
 
 	school = "transmutation"
 	charge_max = 300

--- a/code/modules/spells/targeted/fist.dm
+++ b/code/modules/spells/targeted/fist.dm
@@ -3,7 +3,7 @@
 	desc = "This spell punches up to three beings in view."
 	abbreviation = "FS"
 	user_type = USER_TYPE_WIZARD
-	specialization = OFFENSIVE
+	specialization = SSOFFENSIVE
 
 	charge_max = 50
 	spell_flags = 0 //So that it doesn't open a dialog box.

--- a/code/modules/spells/targeted/flesh_to_stone.dm
+++ b/code/modules/spells/targeted/flesh_to_stone.dm
@@ -3,7 +3,7 @@
 	desc = "This spell turns a single person into an inert statue for a long period of time."
 	abbreviation = "FS"
 	user_type = USER_TYPE_WIZARD
-	specialization = OFFENSIVE
+	specialization = SSOFFENSIVE
 
 	school = "transmutation"
 	charge_max = 600

--- a/code/modules/spells/targeted/genetic.dm
+++ b/code/modules/spells/targeted/genetic.dm
@@ -33,7 +33,7 @@ code\game\\dna\genes\goon_powers.dm
 	name = "Blind"
 	desc = "Temporarily blind a single person."
 	abbreviation = "BD"
-	specialization = OFFENSIVE
+	specialization = SSOFFENSIVE
 	disabilities = 1
 	duration = 300
 
@@ -60,7 +60,7 @@ code\game\\dna\genes\goon_powers.dm
 	name = "Mutate"
 	desc = "This spell causes you to turn into a hulk and gain laser vision for a short while."
 	abbreviation = "MU"
-	specialization = UTILITY
+	specialization = SSUTILITY
 
 	school = "transmutation"
 	charge_max = 400

--- a/code/modules/spells/targeted/grease.dm
+++ b/code/modules/spells/targeted/grease.dm
@@ -3,7 +3,7 @@
 	desc = "Slick grease covers the ground in a radius, turning the terrain into difficult terrain. Has spell congruency with fire-based spells."
 	abbreviation = "GR"
 	user_type = USER_TYPE_WIZARD
-	specialization = OFFENSIVE
+	specialization = SSOFFENSIVE
 
 	school = "evocation"
 	charge_max = 300

--- a/code/modules/spells/targeted/heal.dm
+++ b/code/modules/spells/targeted/heal.dm
@@ -3,7 +3,7 @@
 	desc = "Mends basic wounds in the target."
 	abbreviation = "HL"
 	user_type = USER_TYPE_WIZARD
-	specialization = UTILITY
+	specialization = SSUTILITY
 	spell_levels = list(Sp_SPEED = 0, Sp_POWER = 0, Sp_RANGE = 0)
 
 	school = "transmutation"

--- a/code/modules/spells/targeted/mind_transfer.dm
+++ b/code/modules/spells/targeted/mind_transfer.dm
@@ -3,7 +3,7 @@
 	desc = "Switch bodies with somebody adjacent to you. Both you and your target regain your mind and knowledge of spells."
 	abbreviation = "MT"
 	user_type = USER_TYPE_WIZARD
-	specialization = UTILITY
+	specialization = SSUTILITY
 
 	school = "transmutation"
 	charge_max = 600

--- a/code/modules/spells/targeted/pacify.dm
+++ b/code/modules/spells/targeted/pacify.dm
@@ -2,7 +2,7 @@
 	name = "Pacify"
 	desc = "Generates a burst of calming energies which inhibit hostile behavior in living beings. The caster is slightly affected by channeling these energies."
 	user_type = USER_TYPE_WIZARD
-	specialization = DEFENSIVE
+	specialization = SSDEFENSIVE
 
 	charge_max = 45 SECONDS
 	cooldown_reduc = 15 SECONDS

--- a/code/modules/spells/targeted/projectile/fireball.dm
+++ b/code/modules/spells/targeted/projectile/fireball.dm
@@ -3,7 +3,7 @@
 	abbreviation = "FB"
 	desc = "This spell conjures a fireball that will fly in the direction you're facing and explode on collision with anything, or when it gets close to anyone else."
 	user_type = USER_TYPE_WIZARD
-	specialization = OFFENSIVE
+	specialization = SSOFFENSIVE
 
 	proj_type = /obj/item/projectile/spell_projectile/fireball
 

--- a/code/modules/spells/targeted/projectile/firebreath.dm
+++ b/code/modules/spells/targeted/projectile/firebreath.dm
@@ -2,7 +2,7 @@
 	name = "Fire Breath"
 	desc = "This spell allows you to spew a plume of fire."
 	user_type = USER_TYPE_WIZARD
-	specialization = OFFENSIVE
+	specialization = SSOFFENSIVE
 
 	proj_type = /obj/item/projectile/fire_breath
 

--- a/code/modules/spells/targeted/projectile/magic_missile.dm
+++ b/code/modules/spells/targeted/projectile/magic_missile.dm
@@ -3,7 +3,7 @@
 	abbreviation = "MM"
 	desc = "This spell fires several, slow moving, magic projectiles at nearby targets."
 	user_type = USER_TYPE_WIZARD
-	specialization = OFFENSIVE
+	specialization = SSOFFENSIVE
 
 	school = "evocation"
 	charge_max = 150

--- a/code/modules/spells/targeted/projectile/pie_throw.dm
+++ b/code/modules/spells/targeted/projectile/pie_throw.dm
@@ -3,7 +3,7 @@
 	abbreviation = "PP"
 	desc = "This spell summons a random pie, and throws it at the location of your choosing. More power means more pies."
 	user_type = USER_TYPE_WIZARD
-	specialization = OFFENSIVE
+	specialization = SSOFFENSIVE
 
 	school = "evocation"
 	charge_max = 100

--- a/code/modules/spells/targeted/pumpkinhead.dm
+++ b/code/modules/spells/targeted/pumpkinhead.dm
@@ -3,7 +3,7 @@
 	desc = "whomever you select with this spell is given a carnivorous pumpkin, that will eat the head of whomever is holding it after 60 seconds"
 	abbreviation = "PTP"
 	user_type = USER_TYPE_WIZARD
-	specialization = OFFENSIVE
+	specialization = SSOFFENSIVE
 
 	school = "transmutation"
 	charge_max = 600

--- a/code/modules/spells/targeted/push.dm
+++ b/code/modules/spells/targeted/push.dm
@@ -3,7 +3,7 @@
 	desc = "This spell takes the thing you're touching, and pushes it somewhere else."
 	abbreviation = "DP"
 	user_type = USER_TYPE_WIZARD
-	specialization = OFFENSIVE
+	specialization = SSOFFENSIVE
 
 	school = "evocation"
 	charge_max = 300

--- a/code/modules/spells/targeted/recall.dm
+++ b/code/modules/spells/targeted/recall.dm
@@ -2,7 +2,7 @@
 	name = "Bound Object"
 	desc = "This spell allows a wizard to bind an object to themselves, then teleport it to them at will. Middle click the spell icon or use the 'Unbind' spell to select a new object."
 	user_type = USER_TYPE_WIZARD
-	specialization = UTILITY
+	specialization = SSUTILITY
 	abbreviation = "BO"
 
 	school = "abjuration"

--- a/code/modules/spells/targeted/shoesnatch.dm
+++ b/code/modules/spells/targeted/shoesnatch.dm
@@ -3,7 +3,7 @@
 	desc = "This spell allows you to steal somebody's shoes right off of their feet!"
 	abbreviation = "SS"
 	user_type = USER_TYPE_WIZARD
-	specialization = OFFENSIVE
+	specialization = SSOFFENSIVE
 
 	school = "evocation"
 	charge_type = Sp_RECHARGE


### PR DESCRIPTION
- Removed default specialization because the way the spellbook has been adding spells to the spellbook has been slightly tweaked so now there's no need for it, also it meant that you needed TWO flags for a spell to be in the spellbook (whether it had at least one of the specializations and if it was for wizards)
- Changed the abbreviation a little, now it's S(pell)S(pecialization)OFFENSIVE, SSDEFENSIVE, and SSUTILITY