### PR TITLE
Removes Blink's cooldown reduction, gives its smoke back

### DIFF
--- a/code/modules/spells/aoe_turf/blink.dm
+++ b/code/modules/spells/aoe_turf/blink.dm
@@ -11,8 +11,8 @@
 	invocation = "none"
 	invocation_type = SpI_NONE
 	range = 7
+	level_max = list(Sp_TOTAL = 0, Sp_SPEED = 0, Sp_POWER = 0)
 	inner_radius = 1
-	cooldown_min = 5 //4 deciseconds reduction per rank
 	hud_state = "wiz_blink"
 	selection_type = "range"
 
@@ -31,7 +31,7 @@
 
 /spell/aoe_turf/blink/proc/makeAnimation(var/turf/T, var/turf/starting)
 	var/datum/effect/effect/system/smoke_spread/smoke = new /datum/effect/effect/system/smoke_spread()
-	smoke.set_up(1, 0, T)
+	smoke.set_up(3, 0, T)
 	smoke.start()
 
 /spell/aoe_turf/blink/vamp


### PR DESCRIPTION
Oh boy.
Blink has become the bread and butter of the wizard's arsenal but reducing the cooldown has led to wizards being almost untouchable because they teleport everywhere and stuff. So now the minimum cooldown it gets is also the one it starts with, 2 seconds. It's great as an on-the-moment possible escape tool. However, it has been given the smoke back. It's still a great spell but wizards shouldn't be impossible to catch anymore.

:cl:
 * tweak: Blink can no longer have its cooldown reduced, but it now makes its previous amount of smoke.