### PR TITLE
Adds framework for clothing changing screams, adds half-life scientist screams to science labcoat

### DIFF
--- a/__DEFINES/clothing.dm
+++ b/__DEFINES/clothing.dm
@@ -14,3 +14,12 @@
 #define CONTAINPLASMAMAN 	256
 #define IGNORE_LUBE			512
 #define MAGPULSE			1024 //prevents slipping in space, singulo pulling, etc
+
+//clothing audible emote flags
+#define CLOTHING_SOUND_SCREAM "scream"
+#define CLOTHING_SOUND_COUGH "cough"
+
+//clothing sound priority flags, if it's higher it will play first
+#define CLOTHING_SOUND_LOW_PRIORITY 1
+#define CLOTHING_SOUND_MED_PRIORITY 2
+#define CLOTHING_SOUND_HIGH_PRIORITY 3

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -18,10 +18,10 @@
 //Sound stuff
 //sound_change flags are CLOTHING_SOUND_SCREAM and CLOTHING_SOUND_COUGH
 //sound_priority are CLOTHING_SOUND_[level]_PRIORITY, replace [level] with LOW/MED/HIGH
-	var/list/sound_change = list() //Clothing can change audible emotes, this will determine what is affected
+	var/list/sound_change //Clothing can change audible emotes, this will determine what is affected
 	var/sound_priority //The priority of the clothing when it comes to playing sounds, higher priority means it will always play first otherwise it will randomly pick
-	var/list/sound_file = list() //The actual files to be played, it will pick from the list
-	var/list/sound_respect_species = list() //Species will not play sounds from clothing
+	var/list/sound_file //The actual files to be played, it will pick from the list
+	var/list/sound_respect_species //Species will not play sounds from clothing
 
 /obj/item/clothing/Destroy()
 	for(var/obj/item/clothing/accessory/A in accessories)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -15,6 +15,14 @@
 	var/hidecount = 0
 	var/extinguishingProb = 15
 
+//Sound stuff
+//sound_change flags are CLOTHING_SOUND_SCREAM and CLOTHING_SOUND_COUGH
+//sound_priority are CLOTHING_SOUND_[level]_PRIORITY, replace [level] with LOW/MED/HIGH
+	var/list/sound_change //Clothing can change audible emotes, this will determine what is affected
+	var/sound_priority //The priority of the clothing when it comes to playing sounds, higher priority means it will always play first otherwise it will randomly pick
+	var/list/sound_file //The actual files to be played, it will pick from the list
+	var/list/respect_species //Species will not play sounds from clothing
+
 /obj/item/clothing/Destroy()
 	for(var/obj/item/clothing/accessory/A in accessories)
 		accessories.Remove(A)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -18,10 +18,10 @@
 //Sound stuff
 //sound_change flags are CLOTHING_SOUND_SCREAM and CLOTHING_SOUND_COUGH
 //sound_priority are CLOTHING_SOUND_[level]_PRIORITY, replace [level] with LOW/MED/HIGH
-	var/list/sound_change //Clothing can change audible emotes, this will determine what is affected
+	var/list/sound_change = list() //Clothing can change audible emotes, this will determine what is affected
 	var/sound_priority //The priority of the clothing when it comes to playing sounds, higher priority means it will always play first otherwise it will randomly pick
-	var/list/sound_file //The actual files to be played, it will pick from the list
-	var/list/respect_species //Species will not play sounds from clothing
+	var/list/sound_file = list() //The actual files to be played, it will pick from the list
+	var/list/sound_respect_species = list() //Species will not play sounds from clothing
 
 /obj/item/clothing/Destroy()
 	for(var/obj/item/clothing/accessory/A in accessories)

--- a/code/modules/clothing/suits/labcoat.dm
+++ b/code/modules/clothing/suits/labcoat.dm
@@ -83,6 +83,10 @@
 	desc = "A suit that protects against minor chemical spills. Has a purple stripe on the shoulder."
 	base_icon_state = "labcoat_tox"
 	species_fit = list(VOX_SHAPED, GREY_SHAPED)
+	sound_change = list(CLOTHING_SOUND_SCREAM)
+	sound_priority = CLOTHING_SOUND_LOW_PRIORITY
+	sound_file = list('sound/misc/science_scream1.ogg', 'sound/misc/science_scream2.ogg', 'sound/misc/science_scream3.ogg', 'sound/misc/science_scream4.ogg', 'sound/misc/science_scream5.ogg', 'sound/misc/science_scream6.ogg')
+	respect_species = list("Vox", "Skeletal Vox", "Diona")
 
 /obj/item/clothing/suit/storage/labcoat/oncologist
 	name = "oncologist labcoat"

--- a/code/modules/clothing/suits/labcoat.dm
+++ b/code/modules/clothing/suits/labcoat.dm
@@ -86,7 +86,7 @@
 	sound_change = list(CLOTHING_SOUND_SCREAM)
 	sound_priority = CLOTHING_SOUND_LOW_PRIORITY
 	sound_file = list('sound/misc/science_scream1.ogg', 'sound/misc/science_scream2.ogg', 'sound/misc/science_scream3.ogg', 'sound/misc/science_scream4.ogg', 'sound/misc/science_scream5.ogg', 'sound/misc/science_scream6.ogg')
-	respect_species = list("Vox", "Skeletal Vox", "Diona")
+	sound_respect_species = list("Vox", "Skeletal Vox", "Diona")
 
 /obj/item/clothing/suit/storage/labcoat/oncologist
 	name = "oncologist labcoat"

--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -341,8 +341,3 @@
 	else if(no_priority)
 		selected_clothing = pick(no_priority)
 	return selected_clothing
-
-//A proc to see at which emote the clothing will be played, coughs or screams
-//To be used with the result of selected_clothing
-/datum/emote/living/carbon/sound/proc/check_sound_clothing(var/obj/item/clothing/C)
-	return C.sound_change

--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -319,7 +319,7 @@
 	for(var/obj/item/clothing/C in user.get_equipped_items())
 		if(!C.sound_file)
 			continue
-		if(user.species && user.species.name in C.sound_respect_species)
+		if(user.species && (user.species.name in C.sound_respect_species))
 			continue
 		if(!(sound_key in C.sound_change))
 			continue
@@ -332,7 +332,7 @@
 				priority_low += C
 			else
 				no_priority += C
-	if(!priority_high && !priority_med && !priority_low && !no_priority) //We didn't grab any clothing, stop the proc
+	if(!priority_high.len && !priority_med.len && !priority_low.len && !no_priority.len) //We didn't grab any clothing, stop the proc
 		return 0
 	if(priority_high)
 		selected_clothing = pick(priority_high)

--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -334,12 +334,12 @@
 				no_priority += C
 	if(!priority_high.len && !priority_med.len && !priority_low.len && !no_priority.len) //We didn't grab any clothing, stop the proc
 		return 0
-	if(priority_high)
+	if(priority_high.len)
 		selected_clothing = pick(priority_high)
-	else if(priority_med)
+	else if(priority_med.len)
 		selected_clothing = pick(priority_med)
-	else if(priority_low)
+	else if(priority_low.len)
 		selected_clothing = pick(priority_low)
-	else if(no_priority)
+	else if(no_priority.len)
 		selected_clothing = pick(no_priority)
 	return selected_clothing

--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -288,9 +288,9 @@
 			if(world.time-H.last_emote_sound >= 30)//prevent scream spam with things like poly spray
 				if(sound_message)
 					message = sound_message
-				var/obj/item/clothing/C = search_sound_clothing(H)
+				var/obj/item/clothing/C = search_sound_clothing(H, key)
 				var/sound
-				if(!C || !(key in C.sound_change))
+				if(!C)
 					if(isvox(H) || isskelevox(H))
 						sound = pick(birb_sounds)
 					else
@@ -310,16 +310,18 @@
 	return ..()
 
 //A lengthy checks that returns the clothes to be used by other procs
-/datum/emote/living/carbon/sound/proc/search_sound_clothing(mob/living/carbon/human/user)
+/datum/emote/living/carbon/sound/proc/search_sound_clothing(mob/living/carbon/human/user, var/sound_key)
 	var/selected_clothing //Check the clothing we've selected to be played
-	var/list/priority_high
-	var/list/priority_med
-	var/list/priority_low
-	var/list/no_priority
+	var/list/priority_high = list()
+	var/list/priority_med = list()
+	var/list/priority_low = list()
+	var/list/no_priority = list()
 	for(var/obj/item/clothing/C in user.get_equipped_items())
 		if(!C.sound_file)
 			continue
-		if(user.species && user.species.name in C.respect_species)
+		if(user.species && user.species.name in C.sound_respect_species)
+			continue
+		if(!(sound_key in C.sound_change))
 			continue
 		switch(C.sound_priority)
 			if(CLOTHING_SOUND_HIGH_PRIORITY)


### PR DESCRIPTION
This took a while to work with but it's pretty fun
If anyone asks me to remove the current scientist labcoat functionality to make the PR atomic I will, because I think it might be a bit unatomic to bundle a thing with the framework.

- How does the change work? 

Clothing now has 4 variables
A) The circumstances in which it will play, such as the two (three if you include vox shrieking) sound emotes, screaming and coughing
B) Priority, which will determine if it always gets played first among clothing, if priority is not set it will default to the lowest priority. If multiple clothes have the same highest priority it will pick randomly among them
C) Sound files, the actual audio to be played. Conveniently, this also allows admins to modify what sound files are played upon the audio being played.
D) Respect species, which won't consider the clothing scream if the user a certain species. You can't scream like half life scientists as a vox for example.

Support for accessories might come at a later date provided there's a demand or I come up with something.

:cl:
 * rscadd: Added a mechanic where clothes may be able to change someone's screams or coughs.
 * rscadd: People wearing scientist labcoats will now scream differently.