### PR TITLE
Cleans up solder code, adds directly repairing airlocks using a solder instead of the airlock circuitboard

### DIFF
--- a/code/datums/circuits.dm
+++ b/code/datums/circuits.dm
@@ -109,7 +109,7 @@
 			if(href_list["fuse"]) // Toggles the fuse/unfuse status
 				if(issolder(I))
 					var/obj/item/weapon/solder/S = I
-					if(S.remove_fuel(1,L))
+					if(S.handle_solder(1))
 						playsound(L.loc, 'sound/items/Welder.ogg', 25, 1)
 						var/greek = href_list["fuse"]
 						togglefuse(text2num(greek))

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -349,7 +349,7 @@
 /obj/item/weapon/circuitboard/attackby(obj/item/I as obj, mob/user as mob)
 	if(issolder(I))
 		var/obj/item/weapon/solder/S = I
-		if(S.remove_fuel(2,user))
+		if(S.handle_solder(2, user))
 			solder_improve(user)
 	else if(iswelder(I))
 		var/obj/item/weapon/weldingtool/WT = I

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -318,25 +318,29 @@ to destroy them and players will be able to make replacements.
 			else
 				to_chat(user, "<span class='warning'>A fatal error with the board type occurred. Report this message.</span>")
 		else
-			to_chat(user, "<span class='warning'>The multitool flashes red briefly.</span>")
-	else
-		*/if(!soldering&&issolder(O))
+			to_chat(user, "<span class='warning'>The multitool flashes red briefly.</span>")*/
+
+	if(!soldering && issolder(O))
 		//local_fuses.Interact(user)
 		var/t = input(user, "Which board should be designed?") as null|anything in allowed_boards
 		if(!t)
 			return
 		var/obj/item/weapon/solder/S = O
-		if(!S.remove_fuel(4,user))
+		if(!S.check_fuel(4, user))
 			return
 		playsound(loc, 'sound/items/Welder.ogg', 50, 1)
 		soldering = 1
 		if(do_after(user, src,40))
+			if(!S.check_fuel(4, user))
+				return
+			S.remove_fuel(4)
 			var/boardType = allowed_boards[t]
 			var/obj/item/I = new boardType(get_turf(user))
 			to_chat(user, "<span class='notice'>You fashion a crude [I] from the blank circuitboard.</span>")
 			qdel(src)
 			user.put_in_hands(I)
-		soldering = 0
+		else
+			soldering = 0
 	else if(iswelder(O))
 		var/obj/item/weapon/weldingtool/WT = O
 		if(WT.remove_fuel(1,user))

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1252,6 +1252,22 @@ About the new airlock wires panel:
 				sleep(6)
 				open(1)
 			operating = -1
+	else if(issolder(I))
+		var/obj/item/weapon/solder/S = I
+		if(operating == -1)
+			if(!S.check_fuel(4, user))
+				return
+			playsound(loc, 'sound/items/Welder.ogg', 100, 1)
+			to_chat(user, "<span class='notice'>You start repairing the airlock.</span>")
+			if(do_after(user, src, 100))
+				if(!S.check_fuel(4, user))
+					return
+				playsound(loc, 'sound/items/Welder2.ogg', 100, 1)
+				S.remove_fuel(4)
+				operating = 0
+				to_chat(user, "<span class='notice'>You finish repairing the airlock.</span>")
+		else
+			to_chat(user, "<span class='warning'>The airlock doesn't require repairing.</span>")
 	else
 		..(I, user)
 	add_fingerprint(user)

--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -28,11 +28,15 @@
 	if(issolder(W))
 		var/obj/item/weapon/solder/S = W
 		if(icon_state == "door_electronics_smoked")
-			if(!S.remove_fuel(4,user))
+			if(!S.check_fuel(4, user))
 				return
+			to_chat(user, "<span class='notice'>You start repairing the blown fuses on the circuitboard.</span>")
 			playsound(loc, 'sound/items/Welder.ogg', 100, 1)
 			if(do_after(user, src,40))
+				if(!S.check_fuel(4, user))
+					return
 				playsound(loc, 'sound/items/Welder.ogg', 100, 1)
+				S.remove_fuel(4)
 				icon_state = "door_electronics"
 				to_chat(user, "<span class='notice'>You repair the blown fuses on the circuitboard.</span>")
 

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -584,11 +584,14 @@
 /obj/machinery/suit_storage_unit/attackby(obj/item/I as obj, mob/user as mob)
 	if((stat & BROKEN) && issolder(I))
 		var/obj/item/weapon/solder/S = I
-		if(!S.remove_fuel(4,user))
+		if(!S.check_fuel(4,user))
 			return
 		playsound(loc, 'sound/items/Welder.ogg', 100, 1)
 		if(do_after(user, src,40))
+			if(!S.check_fuel(4, user))
+				return
 			playsound(loc, 'sound/items/Welder.ogg', 100, 1)
+			S.remove_fuel(4)
 			stat &= !BROKEN
 			to_chat(user, "<span class='notice'>You repair the blown out electronics in the suit storage unit.</span>")
 	if((stat & NOPOWER) && iscrowbar(I) && !islocked)

--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -25,8 +25,7 @@
 			to_chat(user, "It's not damaged.")
 			return
 		var/obj/item/weapon/solder/S = W
-		if (!S.remove_fuel(2, user))
-			to_chat(user, "You need more fuel.")
+		if (!S.handle_solder(2, user))
 			return
 		playsound(user, 'sound/items/Welder.ogg', 100, 1)
 		integrity = TELECOMMS_MAX_INTEGRITY

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -784,18 +784,28 @@
 	else
 		return ..()
 
-/obj/item/weapon/solder/proc/remove_fuel(var/amount, mob/user as mob)
-	if(reagents.get_reagent_amount(SACID) + reagents.get_reagent_amount(FORMIC_ACID) >= amount)
-		var/facid_amount = amount - reagents.get_reagent_amount(SACID)
-		reagents.remove_reagent(SACID, amount)
-		if(facid_amount > 0)
-			reagents.remove_reagent(FORMIC_ACID, facid_amount)
-		update_icon()
-		return 1
-	else
-		user.simple_message("<span class='warn'>The tool does not have enough acid!</span>",
-			"<span class='warn'>The tool is too thirsty!</span>")
+//To be used in simple checks, if you bundle soldering with a do_after it's advised to use check_fuel and remove_fuel separately instead
+/obj/item/weapon/solder/proc/handle_solder(var/amount, mob/user)
+	if(check_fuel(amount))
+		remove_fuel(amount)
+	else if(user)
+		to_chat(user, "<span class='warning'>You require [amount] unit\s, you have [!reagents.total_volume ? "no units left" : "[amount] unit\s"].</span>")
+
+//When used individually in a do_after check, it is used twice, before and after to avoid consuming more fuel than what you have
+/obj/item/weapon/solder/proc/check_fuel(var/amount, mob/user)
+	if(reagents.total_volume <= amount)
+		if(user)
+			to_chat(user, "<span class='warning'>You require [amount] unit\s, you have [!reagents.total_volume ? "no units left" : "[amount] unit\s"].</span>")
 		return 0
+	else
+		return 1
+
+/obj/item/weapon/solder/proc/remove_fuel(var/amount)
+	var/facid_amount = amount - reagents.get_reagent_amount(SACID)
+	reagents.remove_reagent(SACID, amount)
+	if(facid_amount > 0)
+		reagents.remove_reagent(FORMIC_ACID, facid_amount)
+	update_icon()
 
 /obj/item/weapon/solder/pre_fueled/New()
 	. = ..()

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -66,11 +66,14 @@
 	else if(broken)
 		if(issolder(W))
 			var/obj/item/weapon/solder/S = W
-			if(!S.remove_fuel(4,user))
+			if(!S.check_fuel(4,user))
 				return
 			playsound(loc, 'sound/items/Welder.ogg', 100, 1)
 			if(do_after(user, src,40))
+				if(!S.check_fuel(4, user))
+					return
 				playsound(loc, 'sound/items/Welder.ogg', 100, 1)
+				S.remove_fuel(4)
 				broken = 0
 				to_chat(user, "<span class='notice'>You repair the electronics inside the locking mechanism!</span>")
 				icon_state = icon_closed

--- a/code/game/turfs/simulated/invulnerable_wall.dm
+++ b/code/game/turfs/simulated/invulnerable_wall.dm
@@ -23,7 +23,7 @@
 
 	if(istype(W,/obj/item/weapon/solder) && bullet_marks)
 		var/obj/item/weapon/solder/S = W
-		if(!S.remove_fuel(bullet_marks*2,user))
+		if(!S.handle_solder(bullet_marks*2,user))
 			return
 		playsound(loc, 'sound/items/Welder.ogg', 100, 1)
 		to_chat(user, "<span class='notice'>You remove the bullet marks with \the [W].</span>")

--- a/code/game/turfs/simulated/shuttle.dm
+++ b/code/game/turfs/simulated/shuttle.dm
@@ -27,7 +27,7 @@
 		return
 	if(istype(W,/obj/item/weapon/solder) && bullet_marks)
 		var/obj/item/weapon/solder/S = W
-		if(!S.remove_fuel(bullet_marks*2,user))
+		if(!S.handle_solder(bullet_marks*2,user))
 			return
 		playsound(loc, 'sound/items/Welder.ogg', 100, 1)
 		to_chat(user, "<span class='notice'>You remove the bullet marks with \the [W].</span>")

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -170,7 +170,7 @@
 
 	if(istype(W,/obj/item/weapon/solder) && bullet_marks)
 		var/obj/item/weapon/solder/S = W
-		if(!S.remove_fuel(bullet_marks*2,user))
+		if(!S.handle_solder(bullet_marks*2,user))
 			return
 		playsound(loc, 'sound/items/Welder.ogg', 100, 1)
 		to_chat(user, "<span class='notice'>You remove the bullet marks with \the [W].</span>")

--- a/code/game/turfs/simulated/walls_reinforced.dm
+++ b/code/game/turfs/simulated/walls_reinforced.dm
@@ -62,7 +62,7 @@
 
 	if(istype(W,/obj/item/weapon/solder) && bullet_marks)
 		var/obj/item/weapon/solder/S = W
-		if(!S.remove_fuel(bullet_marks*2,user))
+		if(!S.handle_solder(bullet_marks*2,user))
 			return
 		playsound(loc, 'sound/items/Welder.ogg', 100, 1)
 		to_chat(user, "<span class='notice'>You remove the bullet marks with \the [W].</span>")

--- a/code/game/turfs/unsimulated/walls.dm
+++ b/code/game/turfs/unsimulated/walls.dm
@@ -47,7 +47,7 @@
 		return
 	if(istype(W,/obj/item/weapon/solder) && bullet_marks)
 		var/obj/item/weapon/solder/S = W
-		if(!S.remove_fuel(bullet_marks*2,user))
+		if(!S.handle_solder(bullet_marks*2,user))
 			return
 		playsound(loc, 'sound/items/Welder.ogg', 100, 1)
 		to_chat(user, "<span class='notice'>You remove the bullet marks with \the [W].</span>")

--- a/code/modules/media/broadcast/transmitters/broadcast.dm
+++ b/code/modules/media/broadcast/transmitters/broadcast.dm
@@ -100,11 +100,14 @@
 			to_chat(user, "<span class='warning'>[src] doesn't need to be repaired!</span>")
 			return
 		var/obj/item/weapon/solder/S = W
-		if(!S.remove_fuel(4,user))
+		if(!S.check_fuel(4,user))
 			return
 		playsound(loc, 'sound/items/Welder.ogg', 100, 1)
 		if(do_after(user, src,40))
+			if(!S.check_fuel(4, user))
+				return
 			playsound(loc, 'sound/items/Welder.ogg', 100, 1)
+			S.remove_fuel(4)
 			integrity = 100
 			to_chat(user, "<span class='notice'>You repair the blown fuses on [src].</span>")
 


### PR DESCRIPTION
Phew. What originally started as adding a solder interaction against emagged items to repair them has turned into a code clean-up.
Also now you can repair airlocks directly with the solder instead of taking out the circuitboard.
Remember, solders require sulphuric acid and you can get them from tool vendors most of the time. They can do a surprising amount of things, like repairing circuit boards, upgrading security camera consoles, unlocking cargo contraband, hacking the floral somatoray, repairing suit storages and so on.

:cl:
 * tweak: Now you can directly repair emagged airlocks by using a solder on them, you could already do this by using a solder on the extracted airlock circuitboard.