### PR TITLE
Fixes not being able to attack mime goblin with items

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/retaliate/faguette.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/faguette.dm
@@ -62,6 +62,7 @@
 /mob/living/simple_animal/hostile/retaliate/faguette/attackby(obj/item/weapon/O, mob/user)
 	if(istype(O,/obj/item/weapon/book))
 		gib()
+	..()
 
 /mob/living/simple_animal/hostile/retaliate/faguette/proc/handle_disabilities()
 	if ((prob(5) && paralysis < 10))


### PR DESCRIPTION
Closes #25481 

:cl:
 * bugfix: Fixed not being able to attack mime goblin with items