### PR TITLE
Fixes solars automatic tracking

### DIFF
--- a/code/modules/power/solars/control.dm
+++ b/code/modules/power/solars/control.dm
@@ -115,7 +115,7 @@
 
 // called by solar tracker when sun position changes (somehow, that's not supposed to be in process)
 /obj/machinery/power/solar/control/proc/tracker_update(angle)
-	if(track != 2 || stat & (NOPOWER | BROKEN))
+	if(track != TRACK_AUTOMATIC || stat & (NOPOWER | BROKEN))
 		return
 
 	cdir = angle

--- a/code/modules/power/solars/tracker.dm
+++ b/code/modules/power/solars/tracker.dm
@@ -12,26 +12,12 @@
 	//Set icon dir to show sun illumination
 	dir = turn(NORTH, -angle - 22.5)	//22.5 deg bias ensures, e.g. 67.5-112.5 is EAST
 
-	//Check we can draw power
-	if(stat & NOPOWER)
-		return
-
 	//Find all solar controls and update them
 	//Currently, just update all controllers in world
 	// ***TODO: better communication system using network
 	for(var/obj/machinery/power/solar/control/C in getPowernetNodes())
 		if(get_dist(C, src) < SOLAR_MAX_DIST)
 			C.tracker_update(angle)
-
-// make sure we can draw power from the powernet
-/obj/machinery/power/solar/panel/tracker/process()
-	var/avail = surplus()
-
-	if(avail > 500)
-		add_load(500)
-		stat &= ~NOPOWER
-	else
-		stat |= NOPOWER
 
 // tracker Electronic
 /obj/item/weapon/tracker_electronics


### PR DESCRIPTION
The tracker was running out of energy. I'm removing the energy requirement. Explanation below

[7:31 PM] zth: here's what's probably happening:
[7:31 PM] zth: someone sets up the solars and everything is working fine, he sets up the smes and everyone's happy
[7:32 PM] zth: then at some point solars stop producing energy because the sun is on the other side of the station
![solars](https://cdn.discordapp.com/attachments/239823463802470400/661698475523702804/unknown.png)
[7:33 PM] zth: if the solar is setup like this image it means the tracker can no longer draw power from the powernet
[7:34 PM] zth: so at this point the tracker stops working because it can't draw any energy
[7:34 PM] zth: and therefore the automatic setting stops working
[7:35 PM] zth: (before this it was drawing power from its own solars)
7:36 PM] zth: so
[7:36 PM] zth: there's multiple solutions for this
[7:36 PM] zth: 1) make it clear on the console that the fucking tracker does not have energy
[7:36 PM] zth: 2) remove the fucking energy requirement from the tracker
[7:37 PM] zth: 3) rewire the solars on every station
[7:37 PM] zth: 4) tell the playerbase to git gud

I'm going with solution 2

:cl:
 * bugfix: Solars automatic tracker no longer stops working after some minutes