### PR TITLE
Changes firelocks to change density earlier/later when opening/closing.

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -44,7 +44,11 @@ var/list/all_doors = list()
 
 	// TODO: refactor to best :(
 	var/animation_delay = 10
-	var/animation_delay_2 = null
+	// These two vars control animation delays for changing density when the door opens/closes.
+	// If they are not 0, the density change of a door will happen only after the delay.
+	// Total animation delay is still animation_delay, these just give a "sub section".
+	var/animation_delay_predensity_opening = 0
+	var/animation_delay_predensity_closing = 0
 
 	// turf animation
 	var/atom/movable/overlay/c_animation = null
@@ -78,7 +82,7 @@ var/list/all_doors = list()
 	return TRUE
 
 /obj/machinery/door/Bumped(atom/AM)
-		
+
 	if (ismob(AM))
 		var/mob/M = AM
 
@@ -231,8 +235,6 @@ var/list/all_doors = list()
 	else
 		icon_state = "[prefix]door_closed"
 
-	sleep(animation_delay_2)
-
 
 /obj/machinery/door/proc/open()
 	if(!density)
@@ -249,13 +251,18 @@ var/list/all_doors = list()
 
 	set_opacity(0)
 	door_animate("opening")
-	sleep(animation_delay)
+	if (animation_delay_predensity_opening)
+		sleep(animation_delay_predensity_opening)
+	else
+		sleep(animation_delay)
 	layer = open_layer
 	setDensity(FALSE)
+	update_nearby_tiles()
 	explosion_resistance = 0
+	if (animation_delay_predensity_opening)
+		sleep(animation_delay - animation_delay_predensity_opening)
 	update_icon()
 	set_opacity(0)
-	update_nearby_tiles()
 	//update_freelook_sight()
 
 	if(operating == 1)
@@ -279,24 +286,32 @@ var/list/all_doors = list()
 	if (makes_noise)
 		playsound(src, soundeffect, soundpitch, 1)
 
-	setDensity(TRUE)
 	door_animate("closing")
-	sleep(animation_delay)
-	update_icon()
+
+	if (animation_delay_predensity_closing)
+		sleep(animation_delay_predensity_closing)
+	else
+		sleep(animation_delay)
+
+	setDensity(TRUE)
+	update_nearby_tiles()
 
 	if (!glass)
 		src.set_opacity(1)
-		// Copypasta!!!
-		var/obj/effect/beam/B = locate() in loc
-		if(B)
-			qdel(B)
+	// Copypasta!!!
+	var/obj/effect/beam/B = locate() in loc
+	if(B)
+		qdel(B)
+
+	if (animation_delay_predensity_closing)
+		sleep(animation_delay - animation_delay_predensity_closing)
+	update_icon()
 
 	// TODO: rework how fire works on doors
 	var/obj/effect/fire/F = locate() in loc
 	if(F)
 		qdel(F)
 
-	update_nearby_tiles()
 	operating = 0
 
 /obj/machinery/door/New()

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -70,6 +70,9 @@ var/global/list/alert_overlays_global = list()
 
 	dir = 2
 
+	animation_delay_predensity_opening = 3
+	animation_delay_predensity_closing = 7
+
 	var/list/alert_overlays_local
 
 	var/blocked = 0


### PR DESCRIPTION
[qol]

So basically, you can still walk through just after they start closing and you can walk through before the animation ends when opening them.

Only did this for border firelocks since there's no risk of somebody getting stuck on a tile while the closing is happening.

:cl:
 * tweak: You can still walk through firelocks as it starts closing, and can walk through them a bit earlier durign the walking animation.