### PR TITLE
Slime extracts now disappear after fully used, code clean-up, a small bugfix

### DIFF
--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -589,9 +589,6 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 		if(enhanced == 1)
 			to_chat(user, "<span class='warning'>This extract has already been enhanced!</span>")
 			return ..()
-		if(Uses == 0)
-			to_chat(user, "<span class='warning'>You can't enhance a used extract!</span>")
-			return ..()
 		to_chat(user, "You apply the enhancer. It now has triple the amount of uses.")
 		Uses = 3
 		enhanced = 1
@@ -855,19 +852,6 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "bottle17"
 	w_class = W_CLASS_TINY
-
-	/*afterattack(obj/target, mob/user , flag)
-		if(istype(target, /obj/item/slime_extract))
-			if(target.enhanced == 1)
-				to_chat(user, "<span class='warning'>This extract has already been enhanced!</span>")
-				return ..()
-			if(target.Uses == 0)
-				to_chat(user, "<span class='warning'>You can't enhance a used extract!</span>")
-				return ..()
-			to_chat(user, "You apply the enhancer. It now has triple the amount of uses.")
-			target.Uses = 3
-			target.enahnced = 1
-			del (src)*/
 
 /obj/item/weapon/slimedupe
 	name = "slime duplicator"

--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -616,7 +616,7 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 /obj/item/slime_extract/grey
 	name = "grey slime extract"
 	icon_state = "grey slime extract"
-	primarytype = /mob/living/carbon/slime/gold
+	primarytype = /mob/living/carbon/slime
 
 /obj/item/slime_extract/gold
 	name = "gold slime extract"

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -386,7 +386,7 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 				var/total_required_catalysts = C.required_catalysts.len
 				var/total_matching_catalysts= 0
 				var/matching_container = 0
-				var/matching_other = 0
+				var/required_conditions = 0
 				var/list/multipliers = new/list()
 				var/required_temp = C.required_temp
 				var/is_cold_recipe = C.is_cold_recipe
@@ -422,25 +422,13 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 					if(istype(my_atom, C.required_container))
 						matching_container = 1
 
-				if(!C.required_other)
-					matching_other = 1
-
-				else
-					/*if(istype(my_atom, /obj/item/slime_core))
-						var/obj/item/slime_core/M = my_atom
-
-						if(M.POWERFLAG == C.required_other && M.Uses > 0) // added a limit to slime cores -- Muskets requested this
-							matching_other = 1*/
-					if(istype(my_atom, /obj/item/slime_extract))
-						var/obj/item/slime_extract/M = my_atom
-
-						if(M.Uses > 0) // added a limit to slime cores -- Muskets requested this
-							matching_other = 1
+				if(C.required_condition_check(src))
+					required_conditions = 1
 
 				if(required_temp == 0 || (is_cold_recipe && chem_temp <= required_temp) || (!is_cold_recipe && chem_temp >= required_temp))
 					meets_temp_requirement = 1
 
-				if(total_matching_reagents == total_required_reagents && total_matching_catalysts == total_required_catalysts && matching_container && matching_other && meets_temp_requirement)
+				if(total_matching_reagents == total_required_reagents && total_matching_catalysts == total_required_catalysts && matching_container && required_conditions && meets_temp_requirement)
 					var/multiplier = min(multipliers)
 					var/preserved_data = null
 					for(var/B in C.required_reagents)
@@ -479,15 +467,6 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 						if(!quiet)
 							my_atom.visible_message("<span class='notice'>[bicon(my_atom)] The solution begins to bubble.</span>")
 						C.log_reaction(src, created_volume)
-
-					if(istype(my_atom, /obj/item/slime_extract))
-						var/obj/item/slime_extract/ME2 = my_atom
-						ME2.Uses--
-						if(ME2.Uses <= 0) // give the notification that the slime core is dead
-							if (!istype(ME2.loc, /obj/item/weapon/grenade/chem_grenade) && !quiet)
-								ME2.visible_message("<span class='notice'>[bicon(my_atom)] \The [my_atom]'s power is consumed in the reaction.</span>")
-							ME2.name = "used slime extract"
-							ME2.desc = "This extract has been used up."
 
 					if(!quiet && !(my_atom.flags & SILENTCONTAINER))
 						playsound(my_atom, 'sound/effects/bubbles.ogg', 80, 1)

--- a/code/modules/reagents/Chemistry-Readme.dm
+++ b/code/modules/reagents/Chemistry-Readme.dm
@@ -255,10 +255,6 @@ About Recipes:
 			The container the recipe has to take place in in order to happen. Leave this blank/null
 			if you want the reaction to happen anywhere.
 
-		required_other
-			Basically like a reagent's data variable. You can set extra requirements for a
-			reaction with this.
-
 
 About the Tools:
 


### PR DESCRIPTION
What originally started as an idea has left me trying out to fix the code before it got any worse. Sorry for the unatomicity, I wanted to wrap this up.
**The feature:** Slime extracts now disappear after use. Extracts that contained chemicals now drop them in convenient bottles, which was already a thing for about 2-3 reactions such as the black slime's peridaxon. 
**The upside:** No more unused slime extracts laying around as unusable junk.
**The downside:** Detectives won't be able to scan extracts that don't exist. Now I raise this point because two people told me about it, and I'd like to argue that the circumstances in which a detective gets an outcome out of scanning used slime extracts are so rare they might as well not exist. I'm up for debating but I don't want to piss people off with this change because of the downside. Thank you.

Fixed a minor bug where revived grey slimes from slime extracts would end up as gold slimes instead.

Cleaned up reaction-related code: Changed matching_other in handle_reactions() to required_conditions and required_conditions is toggled on by a proc that returns 1 by default, removed extract hardcoding from handle_reactions(), moved every slime extract chemical reaction to a parent chemical reaction called slime_extract, which should reduce a lot of copypaste and copied vars in exchange of adding a ..() at the end of every on_reaction()

:cl:
 * tweak: Slime extracts now disappear after use.
 * bugfix: Fixed a bug where reviving a slime from a grey extract would make a gold slime instead of a grey slime.