### PR TITLE
Makes Status the default panel

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1499,6 +1499,7 @@ Use this proc preferably at the end of an equipment loadout
 /mob/Stat()
 	..()
 
+	statpanel("Status") //Default tab
 	if(client && client.holder && client.inactivity < 1200)
 		if(statpanel("MC"))
 			stat("Location:", "([x], [y], [z])")


### PR DESCRIPTION
![Yeah](https://i.imgur.com/mR4Ec9r.png)
Fixes #25576 
:cl:
 * tweak: The "Status" panel is now the default panel. This benefits admins because MC is no longer the default panel, which lags clients.