### PR TITLE
chem dispensers accept any reagent amount

### DIFF
--- a/code/modules/reagents/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/machinery/chem_dispenser.dm
@@ -221,11 +221,11 @@ USE THIS CHEMISTRY DISPENSER FOR MAPS SO THEY START AT 100 ENERGY
 		if(href_list["amount"] == "0")
 			var/num = input("Enter desired output amount", "Amount", useramount) as num
 			if (num)
-				amount = num
+				amount = round(text2num(num), 1)
 				custom = 1
 		else
 			custom = 0
-			amount = text2num(href_list["amount"])
+			amount = round(text2num(href_list["amount"]), 1)
 		amount = clamp(amount, 1, container ? container.volume : 100)
 		if (custom)
 			useramount = amount

--- a/code/modules/reagents/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/machinery/chem_dispenser.dm
@@ -221,12 +221,11 @@ USE THIS CHEMISTRY DISPENSER FOR MAPS SO THEY START AT 100 ENERGY
 		if(href_list["amount"] == "0")
 			var/num = input("Enter desired output amount", "Amount", useramount) as num
 			if (num)
-				amount = round(text2num(num), 5)
+				amount = num
 				custom = 1
 		else
 			custom = 0
-			amount = round(text2num(href_list["amount"]), 5) // round to nearest 5
-		amount = clamp(amount, 5, 100) // Since the user can actually type the commands himself, some sanity checking
+			amount = text2num(href_list["amount"])
 		if (custom)
 			useramount = amount
 

--- a/code/modules/reagents/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/machinery/chem_dispenser.dm
@@ -226,6 +226,7 @@ USE THIS CHEMISTRY DISPENSER FOR MAPS SO THEY START AT 100 ENERGY
 		else
 			custom = 0
 			amount = text2num(href_list["amount"])
+		amount = clamp(amount, 1, container ? container.volume : 100)
 		if (custom)
 			useramount = amount
 


### PR DESCRIPTION
when you hit the Custom button in the chem dispenser, it rounds it to the nearest 5. I have no idea why, so this stops that from happening
it also lets you do custom amounts greater than 100, since I also have no idea why you wouldn't be able to do that

100% tested™ that it compiles and I could dispense reagents of any volume with the expected constraints:
![image](https://user-images.githubusercontent.com/5942183/71798701-61d52980-3053-11ea-8b00-f2a42819ea1e.png)

some poor auto-generated user is getting blamed for this commit for some reason

:cl:
 * rscadd: Chem dispensers can dispense reagents in any (whole) volume, not just multiples of 5.