### PR TITLE
Tweaks Dynamic so that less antagonists will spawn

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -169,7 +169,7 @@
 	restricted_from_jobs = list("AI","Mobile MMI")
 	required_candidates = 1
 	weight = 7
-	cost = 10
+	cost = 15
 	requirements = list(50,40,30,20,10,10,10,10,10,10)
 	repeatable = TRUE
 	high_population_requirement = 10
@@ -274,7 +274,7 @@
 //                                          //
 //              RAGIN' MAGES                ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //                                          //
-//////////////////////////////////////////////1.01 - Disabled because it caused a bit too many wizards in rounds
+//////////////////////////////////////////////
 
 /datum/dynamic_ruleset/midround/from_ghosts/faction_based/raginmages
 	name = "Ragin' Mages"
@@ -284,7 +284,7 @@
 	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
 	required_candidates = 1
 	weight = 1
-	cost = 20
+	cost = 40
 	requirements = list(90,90,70,40,30,20,10,10,10,10)
 	high_population_requirement = 50
 	logo = "raginmages-logo"
@@ -324,7 +324,7 @@
 	enemy_jobs = list("AI", "Cyborg", "Security Officer", "Warden","Detective","Head of Security", "Captain")
 	required_enemies = list(3, 3, 3, 3, 3, 2, 1, 1, 0, 0)
 	required_candidates = 5
-	weight = 5
+	weight = 3
 	cost = 35
 	requirements = list(90, 90, 90, 80, 60, 40, 30, 20, 10, 10)
 	high_population_requirement = 60

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -14,7 +14,7 @@
 	restricted_from_jobs = list("AI","Mobile MMI")
 	required_candidates = 1
 	weight = 5
-	cost = 10
+	cost = 20
 	var/traitor_threshold = 3
 	var/additional_cost = 5
 	requirements = list(10,10,10,10,10,10,10,10,10,10)
@@ -65,7 +65,7 @@
 	required_enemies = list(2,2,2,1,1,1,1,0,0,0)
 	required_candidates = 1
 	weight = 3
-	cost = 18
+	cost = 25
 	requirements = list(80,60,40,20,20,10,10,10,10,10)
 	high_population_requirement = 30
 
@@ -97,7 +97,7 @@
 	required_enemies = list(2,2,2,1,1,1,1,0,0,0)
 	required_candidates = 1
 	weight = 2
-	cost = 15
+	cost = 25
 	requirements = list(80,70,60,60,30,20,10,10,10,10)
 	high_population_requirement = 30
 
@@ -174,7 +174,7 @@
 	enemy_jobs = list("Security Officer","Detective","Warden","Head of Security", "Captain")
 	required_enemies = list(3,3,2,2,2,2,2,1,1,0)
 	required_candidates = 1
-	weight = 2
+	weight = 1 //YOU'RE GUNKING THE ROUND
 	cost = 45
 	requirements = list(90,90,70,40,30,20,10,10,10,10)
 	high_population_requirement = 40
@@ -229,7 +229,7 @@
 	required_enemies = list(3,3,2,2,2,2,2,1,1,0)
 	required_candidates = 2
 	weight = 2
-	cost = 30
+	cost = 50
 	requirements = list(90,80,60,30,20,10,10,10,10,10)
 	high_population_requirement = 40
 	var/cultist_cap = list(2,2,2,2,2,2,2,2,2,2)
@@ -427,7 +427,7 @@
 	enemy_jobs = list("AI", "Cyborg", "Security Officer", "Warden","Detective","Head of Security", "Captain")
 	required_enemies = list(3,3,3,3,3,2,1,1,0,0)
 	required_candidates = 1
-	weight = 3
+	weight = 1
 	cost = 45
 	requirements = list(90,90,90,80,60,40,30,20,10,10)
 	high_population_requirement = 70


### PR DESCRIPTION
No I am not going to change the formula
I've read the thread and talked to people (not in the thread, I've been rangebanned for days already) and there's a pretty common consensus that there needs to be less antags and the amount of antags has damaged the culture due to shorter rounds. There's a poll to support this too, tying with more antagonists but less round-ending ones (which was already addressed with the addition of the highlander ruleset flag in #22646 and #22679 not allowing the round-ending rulesets to stack unless there is 90 threat or more)
http://ss13.moe/index.php/poll/190
This PR will be tweaked over time based on feedback, opinions, suggestions, whatever.

### Current changes:
**Roundstart:**
- Traitors: Initial threat cost doubled (10 to 20)
- Changelings: Initial threat cost 18 -> 25
- Vampires: Initial threat cost 15 -> 25
- Civil War of Casters: Weight to roll halved (2 -> 1)
- Cult: Threat cost 30 -> 50
- Blob: Weight to roll reduced by 66% (3 -> 1)

**Midround:**
- Traitor: Threat cost 10 -> 15
- Ragin' Mages: Threat cost 20 -> 40
- Nuclear Operatives: Weight to roll reduced by 40% (5 -> 3)

:cl:
 * tweak: Dynamic has been tweaked and less antagonists will spawn overall.