### PR TITLE
fixes VV not being able to delete vars

### DIFF
--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -1168,7 +1168,7 @@ function loadPage(list) {
 			else
 				return FALSE
 
-		if (!(index in L))
+		if (index < 1 || index > L.len)
 			return FALSE
 
 		log_admin("[key_name(usr)] has deleted the value [L[index]] in the list [L][D ? ", belonging to the datum [D] of type [D.type]." : "."]")


### PR DESCRIPTION
fixes #24537
big thanks to @N3X15 for literally walking me through it

prepare for unforeseen consequences
<!-- [hotfix] -->

🆑 
 - bugfix: Admemes can now properly remove items from lists using VV again