### PR TITLE
Disables staff of change from being bought by wizards

### DIFF
--- a/code/game/gamemodes/wizard/artifacts.dm
+++ b/code/game/gamemodes/wizard/artifacts.dm
@@ -22,12 +22,15 @@
 /datum/spellbook_artifact/proc/can_buy(var/mob/user)
 	return TRUE
 
+//Disabled because it is too powerful
+/*
 /datum/spellbook_artifact/staff_of_change
 	name = "Staff of Change"
 	desc = "An artefact that spits bolts of coruscating energy which cause the target's very form to reshape itself."
 	abbreviation = "ST"
 	price = 2 * Sp_BASE_PRICE
 	spawned_items = list(/obj/item/weapon/gun/energy/staff/change)
+*/
 
 /datum/spellbook_artifact/staff_of_swapping
 	name = "Staff of Swapping"


### PR DESCRIPTION
### Why?
The staff of change is too strong.
No I haven't been SoC'd in months, instead I've seen enough and I've participated in it.
Staff of change causes too much damage to the crew by turning them into various mobs to various debilitating effects, but the most debilitating is the option to turn people into xenomorphs, xenomorphs that are also considered antagonists, causing a sudden xenomorph outbreak alongside a wizard problem. That sucks. When memes are gone all that's left is a staff that's really, really strong.
I'm open to alternative suggestions on how to nerf the staff of change.
:cl:
 * rscdel: Wizards can no longer buy the staff of change.