### PR TITLE
Removes the toxin damage from the radgun but makes it cheaper

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -911,8 +911,8 @@ var/list/uplink_items = list()
 	name = "Radgun"
 	desc = "An experimental energy gun that fires radioactive projectiles that burn, irradiate, and scramble DNA, giving the victim a different appearance and name, and potentially harmful or beneficial mutations. Recharges on its own."
 	item = /obj/item/weapon/gun/energy/radgun
-	cost = 18
-	discounted_cost = 12
+	cost = 14
+	discounted_cost = 9
 	jobs_with_discount = list("Geneticist", "Chief Medical Officer")
 
 /datum/uplink_item/jobspecific/flaregun

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -148,9 +148,7 @@
 /obj/item/projectile/energy/rad
 	name = "radiation bolt"
 	icon_state = "rad"
-	damage = 30
-	damage_type = TOX
-	nodamage = 0
+	nodamage = 1
 	weaken = 10
 	stutter = 10
 	fire_sound = 'sound/weapons/radgun.ogg'


### PR DESCRIPTION
### Why?
The radgun is extremely powerful because it can kill very fast and most conventional protections do not work. However, by removing the toxin damage it is more manageable to deal with. To compensate however, its price was reduced from 18 to 12 (the radiation can kill over time in a shot or two depending on RNG) while the discounted price was reduced from 14 to 9 (are you a bad enough dude to dual-wield them at the cost of almost all your TC?)
:cl:
 * tweak: The radgun does not do any more initial damage anymore. To compensate, its price was reduced in the traitor uplink.