### PR TITLE
Disables summon stuff from being bought by wizards

### DIFF
--- a/code/game/gamemodes/wizard/artifacts.dm
+++ b/code/game/gamemodes/wizard/artifacts.dm
@@ -175,6 +175,7 @@
 	return FALSE
 
 //SUMMON GUNS
+/*
 /datum/spellbook_artifact/summon_guns
 	name = "Summon Guns"
 	desc = "Nothing could possibly go wrong with arming a crew of lunatics just itching for an excuse to kill eachother. Just be careful not to get hit in the crossfire!"
@@ -222,7 +223,7 @@
 
 	H.rightandwrong("swords")
 	to_chat(H, "<span class='userdanger'>DEUS VULT!</span>")
-
+*/
 /datum/spellbook_artifact/glow_orbs
 	name = "Bundle of glow orbs"
 	desc = "Useful for lighting up the dark so you can read more books, touch-sensitive to assign a user. Warning - Do not expose to electricity."


### PR DESCRIPTION
It's causing a lot of ruined rounds when you arm everyone with powerful stuff and turn 35% of them into antagonists, ending the round prematurely because security is overwhelmed and one or two antagonists are going on a murder spree with the powerful thing they've got.

:cl:
 * rscdel: Wizards can no longer buy summon guns, spells, or swords.