### PR TITLE
Reduces percentage of crew turned into antags from summon stuff from 35% to 10%

### DIFF
--- a/code/game/gamemodes/wizard/rightandwrong.dm
+++ b/code/game/gamemodes/wizard/rightandwrong.dm
@@ -20,7 +20,7 @@
 		if(H.stat == DEAD || !(H.client) || iswizard(H))
 			continue
 
-		if (prob(65))
+		if (prob(90))
 			H.equip_survivor(survivor_type)
 			continue
 


### PR DESCRIPTION
Now the rounds shouldn't be gunked so hard anymore. Reduces the amount of antagonists spawned to a more manageable amount. There's a drastic difference (assuming 50 pop) between roughly 5 players becoming antagonists and roughly 18.

:cl:
 * tweak: The wizard's summon guns/spells/swords will spawn less survivors.