### PR TITLE
You can summon stuff only one time now

### DIFF
--- a/code/game/gamemodes/wizard/artifacts.dm
+++ b/code/game/gamemodes/wizard/artifacts.dm
@@ -7,7 +7,7 @@
 	var/list/spawned_items = list()
 	var/price = Sp_BASE_PRICE
 
-/datum/spellbook_artifact/proc/purchased(mob/living/user)
+/datum/spellbook_artifact/proc/purchased(mob/living/user, var/obj/item/weapon/spellbook/S)
 	to_chat(user, "<span class='info'>You have purchased [name].</span>")
 	for(var/path in spawned_items)
 		var/obj/item/I = new path(get_turf(user))
@@ -19,7 +19,7 @@
 				var/tempstate = end_icons.len
 				W.artifacts_bought += {"<img src="logo_[tempstate].png"> [name]<BR>"}
 
-/datum/spellbook_artifact/proc/can_buy(var/mob/user)
+/datum/spellbook_artifact/proc/can_buy(var/mob/user, var/obj/item/weapon/spellbook/S)
 	return TRUE
 
 /datum/spellbook_artifact/staff_of_change
@@ -180,16 +180,16 @@
 	desc = "Nothing could possibly go wrong with arming a crew of lunatics just itching for an excuse to kill eachother. Just be careful not to get hit in the crossfire!"
 	abbreviation = "SG"
 
-/datum/spellbook_artifact/summon_guns/can_buy(var/mob/user)
+/datum/spellbook_artifact/summon_guns/can_buy(var/mob/user, obj/item/weapon/spellbook/S)
 	//Only roundstart wizards may summon guns, magic, or blades
-	return is_roundstart_wizard(user)
+	return is_roundstart_wizard(user) && !S.hassummoned
 
-
-/datum/spellbook_artifact/summon_guns/purchased(mob/living/carbon/human/H)
+/datum/spellbook_artifact/summon_guns/purchased(mob/living/carbon/human/H, obj/item/weapon/spellbook/S)
 	..()
 
 	H.rightandwrong("guns")
 	to_chat(H, "<span class='userdanger'>You have summoned guns.</span>")
+	S.hassummoned = 1
 
 //SUMMON MAGIC
 /datum/spellbook_artifact/summon_magic
@@ -197,15 +197,16 @@
 	desc = "Share the power of magic with the crew and turn them against each other. Or just empower them against you."
 	abbreviation = "SM"
 
-/datum/spellbook_artifact/summon_magic/can_buy(var/mob/user)
+/datum/spellbook_artifact/summon_magic/can_buy(var/mob/user, obj/item/weapon/spellbook/S)
 	//Only roundstart wizards may summon guns, magic, or blades
-	return is_roundstart_wizard(user)
+	return is_roundstart_wizard(user) && !S.hassummoned
 
-/datum/spellbook_artifact/summon_magic/purchased(mob/living/carbon/human/H)
+/datum/spellbook_artifact/summon_magic/purchased(mob/living/carbon/human/H, obj/item/weapon/spellbook/S)
 	..()
 
 	H.rightandwrong("magic")
 	to_chat(H, "<span class='userdanger'>You have shared the gift of magic with everyone.</span>")
+	S.hassummoned = 1
 
 //SUMMON SWORDS
 /datum/spellbook_artifact/summon_swords
@@ -213,15 +214,16 @@
 	desc = "Launch a crusade or just spark a blood bath. Either way there will be limbs flying and blood spraying."
 	abbreviation = "SS"
 
-/datum/spellbook_artifact/summon_swords/can_buy(var/mob/user)
+/datum/spellbook_artifact/summon_swords/can_buy(var/mob/user, obj/item/weapon/spellbook/S)
 	//Only roundstart wizards may summon guns, magic, or blades
-	return is_roundstart_wizard(user)
+	return is_roundstart_wizard(user) && !S.hassummoned
 
-/datum/spellbook_artifact/summon_swords/purchased(mob/living/carbon/human/H)
+/datum/spellbook_artifact/summon_swords/purchased(mob/living/carbon/human/H, obj/item/weapon/spellbook/S)
 	..()
 
 	H.rightandwrong("swords")
 	to_chat(H, "<span class='userdanger'>DEUS VULT!</span>")
+	S.hassummoned = 1
 
 /datum/spellbook_artifact/glow_orbs
 	name = "Bundle of glow orbs"

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -51,6 +51,7 @@
 	var/max_uses = STARTING_USES
 
 	var/op = 1
+	var/hassummoned //If 1, the wizard cannot buy summon guns/spells/swords
 
 /obj/item/weapon/spellbook/admin
 	uses = 30 * Sp_BASE_PRICE
@@ -177,7 +178,7 @@
 	dat += "<hr><span style=\"color:purple\"><strong>ARTIFACTS AND BUNDLES<sup>*</sup></strong></span><br><small>* Non-refundable</small><br><br>"
 
 	for(var/datum/spellbook_artifact/A in available_artifacts)
-		if(!A.can_buy(user))
+		if(!A.can_buy(user, src))
 			continue
 
 		var/artifact_name = A.name
@@ -342,8 +343,8 @@
 			var/datum/spellbook_artifact/SA = locate(href_list["spell"])
 
 			if(istype(SA) && (SA in available_artifacts))
-				if(SA.can_buy(usr) && use(SA.price))
-					SA.purchased(usr)
+				if(SA.can_buy(usr, src) && use(SA.price))
+					SA.purchased(usr, src)
 					if(SA.one_use)
 						available_artifacts.Remove(SA)
 					feedback_add_details("wizard_spell_learned", SA.abbreviation)


### PR DESCRIPTION
That should be all.
Should reduce the impact on the round in case wizards bought more than one time, which is the difference between a round where some things are gunked but manageable to shuttle call and round end at 12:31
:cl:
 * tweak: Wizards can now summon guns/magic/swords only once, which is shared between them.