### PR TITLE
Transferring blocks via DNA modifier activates the blocks first try

### DIFF
--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -1056,7 +1056,7 @@
 			else if (buf.types & DNA2_BUF_SE)
 				src.connected.occupant.dna.SE = buf.dna.SE
 				src.connected.occupant.dna.UpdateSE()
-				domutcheck(src.connected.occupant,src.connected)
+				domutcheck(src.connected.occupant,src.connected, MUTCHK_FORCED)
 			src.connected.occupant.radiation += rand(20,50)
 			return 1
 


### PR DESCRIPTION
Makes them superior to injectors because there hasn't been really a point to transfer instead of using an SE injector that does far less radiation (1-10 radiation compared to the machine's 20-50)
But at the same time I feel it's too cheap and doesn't sit right with me, how should I "balance" if the change shouldn't even be rejected in the first place?
This PR was made by geneticist gang.
:cl:
 * tweak: The DNA modifier transfer option now also activates every transferred block if they can be activated.