### PR TITLE
Self-recharging batteries now recharge 10x faster

### DIFF
--- a/code/game/objects/items/weapons/power_cells.dm
+++ b/code/game/objects/items/weapons/power_cells.dm
@@ -227,7 +227,7 @@
 	icon_state = "rcell"
 	maxcharge = 1000
 	starting_materials = list(MAT_IRON = 600, MAT_GLASS = 90, MAT_URANIUM = 40)
-	var/charge_rate = 10
+	var/charge_rate = 100
 
 /obj/item/weapon/cell/rad/empty/New()
 	..()
@@ -259,7 +259,7 @@
 	icon_state = "pcell"
 	maxcharge = 2500
 	starting_materials = list(MAT_IRON = 600, MAT_GLASS = 90, MAT_PHAZON = 100)
-	charge_rate = 25
+	charge_rate = 250
 
 /obj/item/weapon/cell/rad/large/empty/New()
 	..()

--- a/code/game/objects/items/weapons/power_cells.dm
+++ b/code/game/objects/items/weapons/power_cells.dm
@@ -251,7 +251,7 @@
 	charge += power_used
 	if(prob(5))
 		for(var/mob/living/L in view(get_turf(src), max(5,(maxcharge/charge))))
-			L.apply_radiation(charge_rate, RAD_EXTERNAL)
+			L.apply_radiation(charge_rate/10, RAD_EXTERNAL)
 
 /obj/item/weapon/cell/rad/large
 	name = "PDTG power cell"


### PR DESCRIPTION
Alright, so the problem is that literally nobody who is a non-antag uses the self-recharging batteries because they irradiate everyone nearby, and you can't even place them inside borgs because that'd make the borgs harmful to the crew. The worst part is that it also recharged far too slowly, where it would take about 100 ticks, or about 200 seconds for the extremely small batteries (literally worse than almost every battery present roundstart on the station) to fully recharge by themselves. Now here's an incentive, **the recharge rate has been multiplied by 10,** so that means it would take 20 seconds for it to recharge. Doesn't suck so much anymore, right? It still irradiates you but at least you have a pretty reliable self-charging low-capacity battery.
They are still slower than just placing a battery on a battery recharger, even more so if it is upgraded.
:cl:
 * tweak: Self-recharging batteries (the RTG and phazon RTG) now generate 10x as much power.