### PR TITLE
Slime friendship ended with monkey

### DIFF
--- a/code/modules/mob/living/carbon/slime/powers.dm
+++ b/code/modules/mob/living/carbon/slime/powers.dm
@@ -141,7 +141,7 @@
 			M.canmove = 0
 			if(!client)
 				if(Victim && !attacked)
-					if(Victim.LAssailant && Victim.LAssailant != Victim)
+					if(Victim.LAssailant && (Victim.LAssailant != Victim) && Victim.LAssailant.mind)
 						if(prob(50))
 							if(!(Victim.LAssailant in Friends))
 								Friends.Add(Victim.LAssailant) // no idea why i was using the |= operator


### PR DESCRIPTION
Slimes will now check if the last assailant has a mind when it comes to befriending them.

:cl:
 * tweak: Slimes will no longer befriend mindless mobs