### PR TITLE
Failsafe for tcomms server

### DIFF
--- a/code/game/machinery/telecomms/logbrowser.dm
+++ b/code/game/machinery/telecomms/logbrowser.dm
@@ -67,7 +67,7 @@
 			for(var/datum/comm_log_entry/C in SelectedServer.log_entries)
 				i++
 
-				if (i > 25) // No more than 25 entries at the same time
+				if (i > 75) // No more than 75 entries at the same time
 					break
 
 				// If the log is a speech file

--- a/code/game/machinery/telecomms/logbrowser.dm
+++ b/code/game/machinery/telecomms/logbrowser.dm
@@ -67,6 +67,8 @@
 			for(var/datum/comm_log_entry/C in SelectedServer.log_entries)
 				i++
 
+				if (i > 25) // No more than 25 entries at the same time
+					break
 
 				// If the log is a speech file
 				if(C.input_type == "Speech File")
@@ -138,6 +140,7 @@
 						<u><font color = #787700>Output</font color></u>: \"[C.parameters["message"]]\"<br>
 						</li><br>"}
 
+				CHECK_TICK
 
 			dat += "</ol>"
 


### PR DESCRIPTION
As it turns out, there is quite a lot of work involved when displaying and processing all those messages. 
This limits the messages stored to the last 75 entries, and ensures the server doesn't crash (too much) when processing the archive.