### PR TITLE
Abandoned crates can now be emagged properly

### DIFF
--- a/code/modules/mining/abandonedcrates.dm
+++ b/code/modules/mining/abandonedcrates.dm
@@ -49,8 +49,8 @@ var/global/list/valid_abandoned_crate_types = typesof(/obj/structure/closet/crat
 /obj/structure/closet/crate/secure/loot/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(locked)
 		if (istype(W, /obj/item/weapon/card/emag))
-			to_chat(user, "<span class='notice'>The crate unlocks!</span>")
-			locked = 0
+			..()
+			return
 		if (istype(W, /obj/item/device/multitool))
 			to_chat(user, "<span class='notice'>DECA-CODE LOCK REPORT:</span>")
 			if (attempts == 1)

--- a/code/modules/mining/abandonedcrates.dm
+++ b/code/modules/mining/abandonedcrates.dm
@@ -48,9 +48,6 @@ var/global/list/valid_abandoned_crate_types = typesof(/obj/structure/closet/crat
 
 /obj/structure/closet/crate/secure/loot/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(locked)
-		if (istype(W, /obj/item/weapon/card/emag))
-			..()
-			return
 		if (istype(W, /obj/item/device/multitool))
 			to_chat(user, "<span class='notice'>DECA-CODE LOCK REPORT:</span>")
 			if (attempts == 1)


### PR DESCRIPTION
Fixes #25655 
Using an emag on an abandoned crate is already handled by the parent, in this case what happened was that after using an emag, it went on with the proc, it afterwards checked (after having the emag used on it) if it was attacked by a multitool, it fails that check which kicks in the "else if" check that makes it return the parent's attackby. Because "locked = 0" (because of the abandoned crate's attackby), the check for the emag in the crate's attackby fails because the crate has to be locked (which it isn't, because the parent's attackby was called after the abandoned crate's attackby made locked == 0), so it goes to the "else if" check that checks whether the item is a card (which the emag is), if it's not opened and if it's not locked (all of which are true) which would make it turn locked back to 1, meaning the crate would remain locked.
Tested.
:cl:
 * bugfix: Fixed abandoned crates not being able to be busted open with an emag.