### PR TITLE
Some clean-up stuff for research

### DIFF
--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -89,7 +89,8 @@ Note: Must be placed within 3 tiles of the R&D Console
 			spawn(10)
 				icon_state = "d_analyzer_l"
 				busy = 0
-				updateUsrDialog()
+				if(linked_console)
+					linked_console.updateUsrDialog()
 	return 1
 
 /obj/machinery/r_n_d/destructive_analyzer/attack_hand(mob/user as mob)

--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -89,6 +89,7 @@ Note: Must be placed within 3 tiles of the R&D Console
 			spawn(10)
 				icon_state = "d_analyzer_l"
 				busy = 0
+				updateUsrDialog()
 	return 1
 
 /obj/machinery/r_n_d/destructive_analyzer/attack_hand(mob/user as mob)

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -267,7 +267,10 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 						linked_destroy.loaded_item.materials.TransferAll(linked_lathe.materials)
 					qdel(linked_destroy.loaded_item)
 					linked_destroy.loaded_item = null
-			linked_destroy.icon_state = "d_analyzer"
+			if(linked_destroy.loaded_item) //It deconstructed something with stacks, make it show up full
+				linked_destroy.icon_state = "d_analyzer_l"
+			else
+				linked_destroy.icon_state = "d_analyzer"
 			use_power(250)
 			screen = 1.0
 			updateUsrDialog()
@@ -716,13 +719,13 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			dat += "<A href='?src=\ref[src];menu=1.6'>Settings</A>"
 
 		if(1.1) //Research viewer
+			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A><BR>"
 			dat += "Current Research Levels:<BR><BR>"
 			for(var/ID in files.known_tech)
 				var/datum/tech/T = files.known_tech[ID]
 				dat += {"[T.name]<BR>
 					* Level: [T.level]<BR>
 					* Summary: [T.desc]<HR>"}
-			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A>"
 
 		if(1.2) //Technology Disk Menu
 


### PR DESCRIPTION
Thanks @PJB3005 

- Destructive analyzer now looks as if it still has an item inside if the item wasn't destroyed, instead of looking like it had no item inside at all (in cases like sheets and such)
- Your screen gets updated when you insert an object in the destructive analyzer
- Moved the "main menu" button on research levels to the top

:cl:
 * bugfix: The destructive analyzer no longer looks empty if whatever it deconstructed wasn't gone (in the case of material sheets, nanopaste and what have you)
 * tweak: The destructive analyzer updates your screen when an item is inserted.
 * qol: The main menu button on "research levels" is now at the top instead of bottom.