### PR TITLE
Spessmart destination disk now spawns in the black market uplink

### DIFF
--- a/__DEFINES/global.dm
+++ b/__DEFINES/global.dm
@@ -333,6 +333,9 @@ var/list/bees_species = list()
 
 var/datum/stat_collector/stat_collection = new
 
+//If 1, Spessmart exists
+var/spessmart_exists
+
 //Hardcore mode
 //When enabled, starvation kills
 var/global/hardcore_mode = 0

--- a/code/datums/black_market_item.dm
+++ b/code/datums/black_market_item.dm
@@ -357,6 +357,25 @@ for anyone but the person committing mass murder.
 /datum/black_market_item/tool
 	category = "Utility Items"
 
+/datum/black_market_item/tool/spessmart_disk
+	name = "Spessmart Disk"
+	desc = "A destination disk that contains the coordinates to Spessmart."
+	item = /obj/item/weapon/disk/shuttle_coords/vault/supermarket
+	sps_chances = list(0, 0, 100)
+	delivery_fees = list(0, 0, 0)
+	delivery_available = list(0, 0, 1)
+	stock_min = 1
+	stock_max = 1
+	cost_min = 600 //You need lots of money to buy stuff from Spessmart in the first place
+	cost_max = 600
+	display_chance = 0 //Special conditions to unlock
+
+/datum/black_market_item/tool/spessmart_disk/is_active()
+	if(spessmart_exists)
+		return 1
+	else
+		..()
+
 /datum/black_market_item/tool/stethoscope
 	name = "Stethoscope"
 	desc = "For medical use only, honest!"

--- a/maps/randomvaults/spessmart.dm
+++ b/maps/randomvaults/spessmart.dm
@@ -176,6 +176,10 @@ var/list/shop_prices = list( //Cost in space credits
 	var/goods_purchased = 0
 	var/alarm_activated = "" //Holds the explanation for alarm's activation
 
+/datum/map_element/vault/supermarket/pre_load()
+	..()
+	spessmart_exists = 1
+
 /datum/map_element/vault/supermarket/process_scoreboard()
 	var/list/L = list()
 


### PR DESCRIPTION
The idea was pretty liked in https://github.com/vgstation-coders/vgstation13/pull/25299#issuecomment-561829427 so I'm doing this here.
Details:
- Spessmart disk appears in the utility section and only if there is a spessmart in the game
- It costs 600 credits (you should have money on you when you go to spessmart)
- It will teleport in your hand
- It will trigger every SPS alarm

No this is not actually related to the pyrite slimes believe it or not
No this won't make black market harder to remove if people want that, I'll just give it to the vox if it ends up removed so don't worry if you hate the black market
For the black market supporters this adds a finally useful item to the uplink because it's been barebones for the last months

:cl:
 * rscadd: If there is a spessmart in the game, a destination disk will appear on sale in the black market uplink. However, it has a guaranteed chance to trigger the SPS alarm!