### PR TITLE
Monkey recycler fixes

### DIFF
--- a/code/game/machinery/kitchen/monkeyrecycler.dm
+++ b/code/game/machinery/kitchen/monkeyrecycler.dm
@@ -35,8 +35,8 @@
 			manipcount += SP.rating
 		if(istype(SP, /obj/item/weapon/stock_parts/micro_laser))
 			lasercount += SP.rating
-	minimum_monkeys = 4 - (manipcount/2) //Tier 1 = 3, Tier 2 = 2, Tier 3 = 1
-	if(lasercount == 3)
+	minimum_monkeys = max(1,4 - (manipcount/2)) //Tier 1 = 3, Tier 2 = 2, Tier 3 = 1
+	if(lasercount >= 3)
 		can_recycle_live = TRUE
 
 /obj/machinery/monkey_recycler/attackby(var/obj/item/O, var/mob/user)


### PR DESCRIPTION
closes #25693 

Adds an actual minimum to the minimum monkeys

fixes T4 lasers bricking a feature on the monkey recycler

🆑 
* bugfix: T4 lasers will no longer make the monkey recycler go ape.
