### PR TITLE
Upgrading the cloning pod with T4 components makes it able to make perfect clones

### DIFF
--- a/code/modules/medical/cloning.dm
+++ b/code/modules/medical/cloning.dm
@@ -26,7 +26,7 @@
 	var/time_coeff = 1 //Upgraded via part upgrading
 	var/resource_efficiency = 1
 	var/id_tag = "clone_pod"
-	var/super = 0 //if upgraded enough, it will go super and unlock a cool thing
+	var/upgraded = 0 //if fully upgraded with T4 components, it will drastically improve and allow for some stuff
 	var/obj/machinery/computer/cloning/cloning_computer = null
 
 
@@ -74,9 +74,9 @@
 	resource_efficiency = T/2
 	T = 0
 	if(total >= 16)
-		super = 1
+		upgraded = 1
 	else
-		super = 0
+		upgraded = 0
 
 //The return of data disks?? Just for transferring between genetics machine/cloning machine.
 //TO-DO: Make the genetics machine accept them.
@@ -218,7 +218,7 @@
 					if((G.mind && (G.mind.current.stat != DEAD) ||  G.mind != clonemind))
 						return FALSE
 
-	heal_level = super ? 100 : rand(10,40) //Randomizes what health the clone is when ejected
+	heal_level = upgraded ? 100 : rand(10,40) //Randomizes what health the clone is when ejected
 	working = TRUE //One at a time!!
 	locked = TRUE
 
@@ -249,7 +249,7 @@
 		H.set_species(H.dna.species, TRUE)
 
 	H.adjustCloneLoss(150) //new damage var so you can't eject a clone early then stab them to abuse the current damage system --NeoFite
-	H.adjustBrainLoss(super ? 0 : (heal_level + 50 + rand(10, 30))) // The rand(10, 30) will come out as extra brain damage
+	H.adjustBrainLoss(upgraded ? 0 : (heal_level + 50 + rand(10, 30))) // The rand(10, 30) will come out as extra brain damage
 	H.Paralyse(4)
 	H.stat = UNCONSCIOUS //There was a bug which allowed you to talk for a few seconds after being cloned, because your stat wasn't updated until next Life() tick. This is a fix for this!
 
@@ -269,7 +269,7 @@
 
 	H.UpdateAppearance()
 	H.set_species(R.dna.species)
-	if(!super)
+	if(!upgraded)
 		randmutb(H) // sometimes the clones come out wrong.
 	H.dna.mutantrace = R.dna.mutantrace
 	H.update_mutantrace()

--- a/code/modules/medical/cloning.dm
+++ b/code/modules/medical/cloning.dm
@@ -26,6 +26,7 @@
 	var/time_coeff = 1 //Upgraded via part upgrading
 	var/resource_efficiency = 1
 	var/id_tag = "clone_pod"
+	var/super = 0 //if upgraded enough, it will go super and unlock a cool thing
 	var/obj/machinery/computer/cloning/cloning_computer = null
 
 
@@ -60,15 +61,22 @@
 	RefreshParts()
 
 /obj/machinery/cloning/clonepod/RefreshParts()
+	var/total = 0
 	var/T = 0
 	for(var/obj/item/weapon/stock_parts/scanning_module/SM in component_parts)
 		T += SM.rating //First rank is two times more efficient, second rank is two and a half times, third is three times. For reference, there's TWO scanning modules
+		total += SM.rating
 	time_coeff = T/2
 	T = 0
 	for(var/obj/item/weapon/stock_parts/manipulator/MA in component_parts)
 		T += MA.rating //Ditto above
+		total += MA.rating
 	resource_efficiency = T/2
 	T = 0
+	if(total >= 16)
+		super = 1
+	else
+		super = 0
 
 //The return of data disks?? Just for transferring between genetics machine/cloning machine.
 //TO-DO: Make the genetics machine accept them.
@@ -210,7 +218,7 @@
 					if((G.mind && (G.mind.current.stat != DEAD) ||  G.mind != clonemind))
 						return FALSE
 
-	heal_level = rand(10,40) //Randomizes what health the clone is when ejected
+	heal_level = super ? 100 : rand(10,40) //Randomizes what health the clone is when ejected
 	working = TRUE //One at a time!!
 	locked = TRUE
 
@@ -241,7 +249,7 @@
 		H.set_species(H.dna.species, TRUE)
 
 	H.adjustCloneLoss(150) //new damage var so you can't eject a clone early then stab them to abuse the current damage system --NeoFite
-	H.adjustBrainLoss(heal_level + 50 + rand(10, 30)) // The rand(10, 30) will come out as extra brain damage
+	H.adjustBrainLoss(super ? 0 : (heal_level + 50 + rand(10, 30))) // The rand(10, 30) will come out as extra brain damage
 	H.Paralyse(4)
 	H.stat = UNCONSCIOUS //There was a bug which allowed you to talk for a few seconds after being cloned, because your stat wasn't updated until next Life() tick. This is a fix for this!
 

--- a/code/modules/medical/cloning.dm
+++ b/code/modules/medical/cloning.dm
@@ -269,7 +269,8 @@
 
 	H.UpdateAppearance()
 	H.set_species(R.dna.species)
-	randmutb(H) // sometimes the clones come out wrong.
+	if(!super)
+		randmutb(H) // sometimes the clones come out wrong.
 	H.dna.mutantrace = R.dna.mutantrace
 	H.update_mutantrace()
 	for(var/datum/language/L in R.languages)


### PR DESCRIPTION
T4 are rare, this is part of the attempt to make them more useful because they are so rare, so far only one thing actually has an unique feature from T4 components (cryo pods)

If fully upgraded, the cloning pod has a bunch of cool tweaks:
- If you let it cook for long enough it is able to print clones without any damage or required cryo treatment, you can still eject them prematurely
- Speed-cloned clones no longer have brain damage
- Clones no longer get any negative mutation

For comparison, T3 lets you print a clone that has 90 clone damage in 40 seconds, T4 lets you print a fully healed clone in 76 seconds

:cl:
 * tweak: Upgrading the cloning pod with rare tier 4 components will allow you to print clones at full health given enough time, while also preventing any negative mutations and brian damage.