### PR TITLE
Small scream changes

### DIFF
--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -284,7 +284,7 @@
 	if(H.stat == DEAD)
 		return
 	if (!H.is_muzzled() && !issilent(H)) // Silent = mime, mute species.
-		if(params == TRUE) // Forced scream
+		if((params == TRUE) || (holiday == APRIL_FOOLS_DAY) || H.manual_emote_sound_override) // Forced scream or april fools or admin override
 			if(world.time-H.last_emote_sound >= 30)//prevent scream spam with things like poly spray
 				if(sound_message)
 					message = sound_message

--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -284,7 +284,7 @@
 	if(H.stat == DEAD)
 		return
 	if (!H.is_muzzled() && !issilent(H)) // Silent = mime, mute species.
-		if((params == TRUE) || (holiday == APRIL_FOOLS_DAY) || H.manual_emote_sound_override) // Forced scream or april fools or admin override
+		if((params == TRUE) || (Holiday == APRIL_FOOLS_DAY) || H.manual_emote_sound_override) // Forced scream or april fools or admin override
 			if(world.time-H.last_emote_sound >= 30)//prevent scream spam with things like poly spray
 				if(sound_message)
 					message = sound_message

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -80,3 +80,4 @@
 	var/talkcount = 0 // How many times a person has talked - used for determining who's been the "star" for the purposes of round end credits
 	var/calorie_burn_rate = HUNGER_FACTOR
 	var/time_last_speech = 0 //When was the last time we talked?
+	var/manual_emote_sound_override = 0 //If toggled on, allows humans to make audible emotes


### PR DESCRIPTION
- Manual emoting can be done on april fools
- Admins can toggle a var to allow humans to manually emote

The next step (regardless if the PR gets merged or not) would be to move the entire audible emote system a few parents up to give mobs the capability to do audible emotes so that someone can finally allow goliaths to do cool stuff like roaring

And finally...
@Buchse

:cl:
 * tweak: You can manually do audible emotes during April Fools day.
 * rscadd: Admins now have access to a variable that when toggled on allows anyone to manually audibly emote.