### PR TITLE
Fixes Vox Skin-Color Preview

### DIFF
--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -184,7 +184,7 @@
 					icobase = 'icons/mob/human_races/vox/r_voxbrn.dmi'
 				else
 					icobase = 'icons/mob/human_races/vox/r_vox.dmi'
-		if(current_species.name == "Grey")
+		else if(current_species.name == "Grey")
 			switch(s_tone)
 				if(4)
 					icobase = 'icons/mob/human_races/grey/r_greyblue.dmi'


### PR DESCRIPTION
Fixes a bug where no matter what skin skin you set your vox to, it didn't reflect it in the preview, staying the default color.

Whoops, I made a silly mistake.
<!-- [bugfix] -->
:cl:
 * bugfix: Vox character preview actually updates.
