### PR TITLE
Make the NT report falsifier more costly, requires traitor collaboration

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -470,8 +470,8 @@ var/list/uplink_items = list()
 	name = "NT Central Command Report Falsifier"
 	desc = "A command report intercom stolen from Nanotrasen Command that allows for a single fake Command Update to be sent. Ensure tastefulness so that the crew actually falls for the message. Item is particular obvious and will have to be manually discarded after use."
 	item = /obj/item/device/reportintercom
-	cost = 6
-	discounted_cost = 4
+	cost = 24
+	discounted_cost = 16
 	jobs_with_discount = list("Nuclear Operative")
 
 /datum/uplink_item/sabotage_tools/plastic_explosives

--- a/code/game/objects/items/devices/reportintercom.dm
+++ b/code/game/objects/items/devices/reportintercom.dm
@@ -8,10 +8,10 @@
 	flags = FPRINT
 	siemens_coefficient = 1
 
-	var/used = 0
+	var/uses = 4
 
 /obj/item/device/reportintercom/attack_self(mob/user) // can create a custom announcement once
-	if(used)
+	if(uses <= 0)
 		to_chat(user, "<span class='notice'>You press the [src]'s button, but nothing happens.</span>")
 		return
 
@@ -47,11 +47,11 @@
 
 	icon_state = "intercom-p-open"
 	desc = "Looks like a typical intercom. The wires look burnt out. 'PROPERTY OF NANOTRASEN CENTRAL COMMAND' is stamped on the side."
-	used = 1
+	uses--
 	return 1
 
 /obj/item/device/reportintercom/emag_act(mob/user) //Please don't do this
-	if(!used)
+	if(uses)
 		to_chat(user, "<span class='warning'>You overload the [src] and hear an unearthly noise.</span>")
 
 		world << sound('sound/items/AirHorn.ogg')
@@ -64,7 +64,7 @@
 
 		icon_state = "intercom-p-open"
 		desc = "Looks like a typical intercom. The wires look burnt out. 'PROPERTY OF NANOTRASEN CENTRAL COMMAND' is stamped on the side."
-		used = 1
+		uses = 0
 
 		return
 	return

--- a/code/game/objects/items/devices/uplinks.dm
+++ b/code/game/objects/items/devices/uplinks.dm
@@ -32,6 +32,10 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 /obj/item/device/uplink/proc/refund(mob/user, obj/item/I)
 	if(!user || !I)
 		return
+	if (istype(I, /obj/item/stack/sheet/mineral/telecrystal/refined))
+		var/obj/item/stack/sheet/S = I
+		uses += S.amount
+		qdel(S)
 	if(!uplink_items)
 		get_uplink_items()
 	for(var/category in uplink_items)
@@ -114,8 +118,12 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 		// Break up the categories, if it isn't the last.
 		if(buyable_items.len != index)
 			dat += "<br>"
-
+		
 	dat += "<HR>"
+	if (uses)
+		dat + "<A href='byond://?src=\ref[src];get_tc=1;'>Extract telecrystals</A>"
+	else
+		dat += "<font color='grey'><i>Extract telecrystals </i></font>"
 	dat = jointext(dat,"") //Optimize BYOND's shittiness by making "dat" actually a list of strings and join it all together afterwards! Yes, I'm serious, this is actually a big deal
 	return dat
 
@@ -171,6 +179,18 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 	else if(href_list["show_desc"])
 		show_description = text2num(href_list["show_desc"])
 		interact(usr)
+
+	else if(href_list["get_tc"])
+		if (uses <= 0)
+			return
+		var/amount = input("How many telecrystals do you wish to withdraw?:", "Extract telecrystals", null) as num
+		if (amount > uses)
+			return
+		uses -= amount
+		var/obj/item/stack/sheet/mineral/telecrystal/refined/R = new /obj/item/stack/sheet/mineral/telecrystal/refined(usr, amount)
+		var/mob/living/carbon/human/H = usr
+		H.put_in_hands(R)
+		return
 
 // HIDDEN UPLINK - Can be stored in anything but the host item has to have a trigger for it.
 /* How to create an uplink in 3 easy steps!

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -505,6 +505,8 @@ var/list/datum/stack_recipe/mythril_recipes = list ( \
 	origin_tech = Tc_MATERIALS + "=5"
 	perunit = CC_PER_SHEET_TELECRYSTAL
 
+/obj/item/stack/sheet/mineral/telecrystal/refined
+	name = "refined telecrystal"
 
 /obj/item/stack/sheet/mineral/mauxite
 	name = "mauxite"


### PR DESCRIPTION
What it says on the tin.

- costs 4 times as much.
- needs two traitors to meet up and collaborate to get the tiem.
- add a way to trade TCs physically between traitors.

Need to be tested.
 
**Reasoning :** 
The item gunks rounds and should require some planning by the traitors to be used.