### PR TITLE
Removes the NT report falsifier

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -470,7 +470,7 @@ var/list/uplink_items = list()
 	name = "NT Central Command Report Falsifier"
 	desc = "A command report intercom stolen from Nanotrasen Command that allows for a single fake Command Update to be sent. Ensure tastefulness so that the crew actually falls for the message. Item is particular obvious and will have to be manually discarded after use."
 	item = /obj/item/device/reportintercom
-	cost = 6
+	cost = 99
 	discounted_cost = 4
 	jobs_with_discount = list("Nuclear Operative")
 


### PR DESCRIPTION
Harder PR than #25717, using the dreaded R-word.
Same reasoning that it's a bad item.
 
The item is now too expensive to be even purchased by a random traitor.
A nuke ops team can still purchase it. The reason why, is that operatives are much louder in what they do, so there is much less confusion and apathy to the announcement when it arrives.

**Reasons for removal specifically :** 
The item creates situations that are borderline ban-baiting, not fun to resolve, investigate, or care about by admins, and it also devaluates the value of actual buses.

Suggestion of downright removal was made first by @small-boss. I agree with it.