### PR TITLE
Xenos from the staff of change can only be Hunters and Sentinels

### DIFF
--- a/code/modules/projectiles/projectile/change.dm
+++ b/code/modules/projectiles/projectile/change.dm
@@ -41,7 +41,7 @@
 			if(SOC_SLIME)
 				new_mob = M.slimeize()
 			if(SOC_XENO)
-				new_mob = M.Alienize()
+				new_mob = M.Alienize("Hunter")
 			if(SOC_HUMAN)
 				new_mob = M.Humanize()
 			if(SOC_CATBEAST)

--- a/code/modules/projectiles/projectile/change.dm
+++ b/code/modules/projectiles/projectile/change.dm
@@ -41,7 +41,7 @@
 			if(SOC_SLIME)
 				new_mob = M.slimeize()
 			if(SOC_XENO)
-				new_mob = M.Alienize("Hunter")
+				new_mob = M.Alienize(pick("Hunter", "Sentinel"))
 			if(SOC_HUMAN)
 				new_mob = M.Humanize()
 			if(SOC_CATBEAST)


### PR DESCRIPTION
I don't hate the staff of change but I hope this is a change people can agree on, xenos from a staff of change won't be able to cause an outbreak because of this but they'll still be a real threat to the station

:cl:
 * tweak: People turned into xenomorphs via Staff of Change can only be Hunters or Sentinels