### PR TITLE
Removes bad Indentation on Path in Sprite_accessories.dm

### DIFF
--- a/code/modules/medical/cloning.dm
+++ b/code/modules/medical/cloning.dm
@@ -26,7 +26,6 @@
 	var/time_coeff = 1 //Upgraded via part upgrading
 	var/resource_efficiency = 1
 	var/id_tag = "clone_pod"
-	var/upgraded = 0 //if fully upgraded with T4 components, it will drastically improve and allow for some stuff
 	var/obj/machinery/computer/cloning/cloning_computer = null
 
 
@@ -61,22 +60,15 @@
 	RefreshParts()
 
 /obj/machinery/cloning/clonepod/RefreshParts()
-	var/total = 0
 	var/T = 0
 	for(var/obj/item/weapon/stock_parts/scanning_module/SM in component_parts)
 		T += SM.rating //First rank is two times more efficient, second rank is two and a half times, third is three times. For reference, there's TWO scanning modules
-		total += SM.rating
 	time_coeff = T/2
 	T = 0
 	for(var/obj/item/weapon/stock_parts/manipulator/MA in component_parts)
 		T += MA.rating //Ditto above
-		total += MA.rating
 	resource_efficiency = T/2
 	T = 0
-	if(total >= 16)
-		upgraded = 1
-	else
-		upgraded = 0
 
 //The return of data disks?? Just for transferring between genetics machine/cloning machine.
 //TO-DO: Make the genetics machine accept them.
@@ -218,7 +210,7 @@
 					if((G.mind && (G.mind.current.stat != DEAD) ||  G.mind != clonemind))
 						return FALSE
 
-	heal_level = upgraded ? 100 : rand(10,40) //Randomizes what health the clone is when ejected
+	heal_level = rand(10,40) //Randomizes what health the clone is when ejected
 	working = TRUE //One at a time!!
 	locked = TRUE
 
@@ -249,7 +241,7 @@
 		H.set_species(H.dna.species, TRUE)
 
 	H.adjustCloneLoss(150) //new damage var so you can't eject a clone early then stab them to abuse the current damage system --NeoFite
-	H.adjustBrainLoss(upgraded ? 0 : (heal_level + 50 + rand(10, 30))) // The rand(10, 30) will come out as extra brain damage
+	H.adjustBrainLoss(heal_level + 50 + rand(10, 30)) // The rand(10, 30) will come out as extra brain damage
 	H.Paralyse(4)
 	H.stat = UNCONSCIOUS //There was a bug which allowed you to talk for a few seconds after being cloned, because your stat wasn't updated until next Life() tick. This is a fix for this!
 
@@ -269,8 +261,7 @@
 
 	H.UpdateAppearance()
 	H.set_species(R.dna.species)
-	if(!upgraded)
-		randmutb(H) // sometimes the clones come out wrong.
+	randmutb(H) // sometimes the clones come out wrong.
 	H.dna.mutantrace = R.dna.mutantrace
 	H.update_mutantrace()
 	for(var/datum/language/L in R.languages)

--- a/code/modules/mob/new_player/sprite_accessories.dm
+++ b/code/modules/mob/new_player/sprite_accessories.dm
@@ -859,7 +859,7 @@
 	species_allowed = list("Diona")
 	do_colouration = 0
 
-	/datum/sprite_accessory/hair/hair_fullboom
+/datum/sprite_accessory/hair/hair_fullboom
 	name = "Bloomed"
 	icon_state = "hair_fullbloom"
 	species_allowed = list("Diona")


### PR DESCRIPTION
I stuck a message in that told me exactly what was actually being jammed into hair_styles in previews (more or less why aren't they bald instead of null), and It turns out there was a extra indentation on a sprite accessory path that was causing it to break for some reason or another.


![Untitled](https://user-images.githubusercontent.com/46565256/73091011-84ff3600-3ea7-11ea-98f5-43b76708fd5a.png)

-->
:cl: 
 * bugfix: Removed unneeded indent in sprite accessories.