### PR TITLE
Food processor can now process multiple things at a time

### DIFF
--- a/code/game/machinery/kitchen/processor.dm
+++ b/code/game/machinery/kitchen/processor.dm
@@ -15,6 +15,7 @@
 	idle_power_usage = 20
 	active_power_usage = 500
 	var/time_coeff = 1
+	var/content_limit = 3
 
 /********************************************************************
 **   Adding Stock Parts to VV so preconstructed shit has its candy **
@@ -33,10 +34,14 @@
 
 /obj/machinery/processor/RefreshParts()
 	var/manipcount = 0
+	var/scancount = 0
 	for(var/obj/item/weapon/stock_parts/SP in component_parts)
 		if(istype(SP, /obj/item/weapon/stock_parts/manipulator))
 			manipcount += SP.rating
+		if(istype(SP, /obj/item/weapon/stock_parts/scanning_module))
+			scancount += SP.rating
 	time_coeff = 2/manipcount
+	content_limit = 3 * scancount
 
 /datum/food_processor_process
 	var/input
@@ -97,7 +102,7 @@
 	var/C = S.cores
 	if(S.stat != DEAD)
 		S.forceMove(loc)
-		S.visible_message("<span class='notice'>[C] crawls free of the processor!</span>")
+		S.visible_message("<span class='notice'>[S] crawls free of the processor!</span>")
 		return
 	for(var/i = 1, i <= C, i++)
 		new S.coretype(loc)
@@ -192,8 +197,8 @@
 	if(src.processing)
 		to_chat(user, "<span class='warning'>[src] is already processing!</span>")
 		return 1
-	if(src.contents.len > 0) //TODO: several items at once? several different items?
-		to_chat(user, "<span class='warning'>Something is already in [src]</span>.")
+	if(src.contents.len >= content_limit) //TODO: several items at once? several different items?
+		to_chat(user, "<span class='warning'>\The [src] is full, it cannot fit anymore.</span>")
 		return 1
 	if (istype(A, /obj/item/weapon/grab))
 		var/obj/item/weapon/grab/G = A
@@ -225,15 +230,15 @@
 	if(src.contents.len == 0)
 		to_chat(user, "<span class='warning'>[src] is empty!</span>")
 		return 1
+	user.visible_message("<span class='notice'>[user] turns on [src]</span>.", \
+	"You turn on \a [src].", \
+	"You hear [src] start")
 	for(var/O in src.contents)
 		var/datum/food_processor_process/P = select_recipe(O)
 		if (!P)
 			log_admin("DEBUG: [O] in processor is not suitable. How did you put it in?") //-rastaf0
 			continue
 		src.processing = 1
-		user.visible_message("<span class='notice'>[user] turns on [src]</span>.", \
-			"You turn on \a [src].", \
-			"You hear [src] start")
 		playsound(src, 'sound/machines/blender.ogg', 50, 1)
 		use_power(500)
 		sleep(P.time*time_coeff)
@@ -244,6 +249,10 @@
 
 /obj/machinery/processor/attack_ghost(mob/user as mob)
 	user.examination(src)
+
+/obj/machinery/processor/examine(mob/user)
+	..()
+	to_chat(user, "<span class='notice'>It can fit up to [content_limit] foodstuffs!")
 
 /obj/machinery/processor/MouseDropTo(atom/movable/O, mob/user)
 	if(O.loc == user || !isturf(O.loc) || !isturf(user.loc) || !user.Adjacent(O))

--- a/code/game/machinery/kitchen/processor.dm
+++ b/code/game/machinery/kitchen/processor.dm
@@ -252,7 +252,7 @@
 
 /obj/machinery/processor/examine(mob/user)
 	..()
-	to_chat(user, "<span class='notice'>It can fit up to [content_limit] foodstuffs!")
+	to_chat(user, "<span class='notice'>It can fit up to [content_limit] things!")
 
 /obj/machinery/processor/MouseDropTo(atom/movable/O, mob/user)
 	if(O.loc == user || !isturf(O.loc) || !isturf(user.loc) || !user.Adjacent(O))


### PR DESCRIPTION
The recipe timer per thing shoved into the food processor, it will take about 8 seconds to turn 2 potatoes into 2 space fries and it will output the first space dry dish at the 4 second mark.
The amount it can fit at a time is increased by the scanning module quality in a linear fashion of 3/6/9/12 things in the processor at a time

Also fixed a minor bug where a slime crawling free would say the amount of cores the slime has instead of the slime's name so it would be like "1 crawls free of the processor!"

:cl:
 * rscadd: The food processor can now fit and process multiple things at a time. The amount of things that can fit at a time is increased by the scanning module's quality.
 * bugfix: Fixed a minor bug where a slime crawling free out of a processor would say its core amount instead of name.