### PR TITLE
Removes the lower character limit when naming GPS

### DIFF
--- a/code/modules/telesci/gps.dm
+++ b/code/modules/telesci/gps.dm
@@ -123,8 +123,8 @@ var/list/SPS_list = list()
 			to_chat(usr, "<span class = 'caution'>The GPS needs to be kept in your active hand!</span>")
 			return TRUE
 		a = strict_ascii(a)
-		if(length(a) < 4 || length(a) > 5)
-			to_chat(usr, "<span class = 'caution'>The tag must be between four and five characters long!</span>")
+		if(length(a) > 5)
+			to_chat(usr, "<span class = 'caution'>The tag must have a maximum of five characters!</span>")
 		else
 			gpstag = a
 			update_name()

--- a/code/modules/telesci/gps.dm
+++ b/code/modules/telesci/gps.dm
@@ -116,13 +116,13 @@ var/list/SPS_list = list()
 			return TRUE
 
 		var/a = input("Please enter desired tag.", name, gpstag) as text|null
-		if(!a) //what a check
-			return TRUE
 
 		if(!builtin && (usr.get_active_hand() != src || usr.incapacitated())) //second check in case some chucklefuck drops the GPS while typing the tag
 			to_chat(usr, "<span class = 'caution'>The GPS needs to be kept in your active hand!</span>")
 			return TRUE
 		a = strict_ascii(a)
+		if(!a) //what a check
+			return TRUE
 		if(length(a) > 5)
 			to_chat(usr, "<span class = 'caution'>The tag must have a maximum of five characters!</span>")
 		else


### PR DESCRIPTION
It doesn't make any sense for it to be 4-5 from what I know, so now it's a maximum of 5 characters long so now you can have GPS tags of 1-5 characters instead of 4-5

:cl:
 * tweak: GPS tag lower limit has been removed, so now you can have a tag 1-5 letters long instead of 4-5.