### PR TITLE
Fixes black slimecore reaction

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -1737,6 +1737,7 @@
 	alert_admins = ALERT_ALL_REAGENTS
 	reagent = AMUTATIONTOXIN
 	result_amount = 1
+	reagent_amount = 1
 
 /datum/chemical_reaction/slime_extract/slimenanobots
 	name = "Slime Nanobots"


### PR DESCRIPTION
Fixes #25676 
Done because TuringWept yelled at me to do it
tfw you analyse the code for over an hour and put a thousand `to_chat(world)`s just to see that it was in fact a missing/misspelt var name
[bugfix]

:cl:
- bugfix: Black slime extracts will give a unit of advanced mutagen again.