### PR TITLE
Removes infinite TC where you could gain infinite TC by extracting 0 telecrystals from the uplink while having telecrystals, giving you one telecrystal and consuming none[balance] [ohgoditsloose] [controversial]

### DIFF
--- a/code/game/objects/items/devices/uplinks.dm
+++ b/code/game/objects/items/devices/uplinks.dm
@@ -186,6 +186,10 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 		if (uses <= 0)
 			return
 		var/amount = input("How many telecrystals do you wish to withdraw?:", "Extract telecrystals", null) as num
+		if(amount <= 0)
+			return
+		if(get_dist(usr, src) >= 1)
+			return
 		if (amount > uses)
 			amount = uses
 		uses -= amount


### PR DESCRIPTION
[balance] [qol]
I think it's too unbalanced, removes the whole point of having a limited amount of telecrystals. You can use the telecrystals to buy pretty strong items such as bundles and singularity magnets and bombs, so I don't see why this feature shouldn't be nerfed.
I'll wait for the community's opinion about it in the mean time, I hope you can understand that I'm doing this for the good of the server, for the good of /vg/station, so don't judge this nerf too badly

:cl:
 * rscdel: Syndicate agents can no longer gain unlimited telecrystals by asking for a 0 amount of telecrystals. 
 * rscdel: Syndicate agents can no longer telekinetically take telecrystals from PDAs.