### PR TITLE
Fixes some exploits with telecrystals

### DIFF
--- a/code/game/objects/items/devices/mat_synth.dm
+++ b/code/game/objects/items/devices/mat_synth.dm
@@ -30,7 +30,7 @@
 							/obj/item/stack/sheet/wood,
 							/obj/item/stack/sheet/plasteel,
 							/obj/item/stack/sheet/mineral)
-	var/list/cant_scan = list(/obj/item/stack/sheet/mineral/telecrystal/refined)
+	var/list/cant_scan = list()
 	var/matter = 0
 
 /obj/item/device/material_synth/robot/engiborg //Cyborg version, has less materials but can make rods n shit as well as scan.
@@ -42,7 +42,7 @@
 
 /obj/item/device/material_synth/robot/engiborg/New() //We have to do this during New() because BYOND can't pull a typesof() during compile time.
 	. = ..()
-	cant_scan = list(/obj/item/stack/sheet/mineral/clown, /obj/item/stack/sheet/mineral/phazon, /obj/item/stack/sheet/mineral/telecrystal/refined)
+	cant_scan = list(/obj/item/stack/sheet/mineral/clown, /obj/item/stack/sheet/mineral/phazon)
 
 /obj/item/device/material_synth/robot/mommi //MoMMI version, a few more materials to start with.
 	materials_scanned = list("metal" = /obj/item/stack/sheet/metal,

--- a/code/game/objects/items/devices/uplinks.dm
+++ b/code/game/objects/items/devices/uplinks.dm
@@ -32,8 +32,8 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 /obj/item/device/uplink/proc/refund(mob/living/carbon/human/user, obj/item/I)
 	if(!user || !I)
 		return
-	if (istype(I, /obj/item/stack/sheet/mineral/telecrystal/refined))
-		var/obj/item/stack/sheet/S = I
+	if (istype(I, /obj/item/stack/telecrystal))
+		var/obj/item/stack/telecrystal/S = I
 		uses += S.amount
 		user.drop_item(S, src)
 		to_chat(user, "<span class='notice'>You insert [S.amount] telecrystal[S.amount > 1 ? "s" : ""] into the uplink.</span>")
@@ -189,10 +189,10 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 		if(!usr.Adjacent(src))
 			return
 		amount = clamp(amount, 0, uses)
-		if (amount < 0)
+		if (amount <= 0)
 			return
 		uses -= amount
-		var/obj/item/stack/sheet/mineral/telecrystal/refined/R = new /obj/item/stack/sheet/mineral/telecrystal/refined(usr, amount)
+		var/obj/item/stack/telecrystal/R = new /obj/item/stack/telecrystal(usr, amount)
 		var/mob/living/carbon/human/H = usr
 		to_chat(usr, "<span class='notice'>You withdraw [amount] telecrystal[amount > 1 ? "s" : ""] from your uplink.</span>")
 		H.put_in_hands(R)

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -166,3 +166,12 @@ var/list/datum/stack_recipe/chain_recipes = list (
 	new/datum/stack_recipe/blacksmithing("Suit of Chainmail",		/obj/item/clothing/suit/armor/vest/chainmail,					10,	time = 100,required_strikes = 15),
 	new/datum/stack_recipe/blacksmithing("Chainmail Coif",		/obj/item/clothing/head/helmet/chainmail,					5,	time = 100,required_strikes = 15),
 	)
+
+
+/obj/item/stack/telecrystal
+	name = "refined telecrystals"
+	singular_name = "telecrystal"
+	desc = "A method of creating an untraceable bluespace teleportation link between two points."
+	icon = 'icons/obj/stock_parts.dmi'
+	icon_state = "ansible_crystal"
+	mech_flags = MECH_SCAN_FAIL

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -505,10 +505,6 @@ var/list/datum/stack_recipe/mythril_recipes = list ( \
 	origin_tech = Tc_MATERIALS + "=5"
 	perunit = CC_PER_SHEET_TELECRYSTAL
 
-/obj/item/stack/sheet/mineral/telecrystal/refined
-	name = "refined telecrystals"
-	mech_flags = MECH_SCAN_FAIL
-
 /obj/item/stack/sheet/mineral/mauxite
 	name = "mauxite"
 	icon_state = "sheet-mauxite"


### PR DESCRIPTION
Fixes being able to dupe telecrystals with the device analyser.

Fixes being able to dupe telecrystals with the material synthesizer.

Fixes being able to drop a 0-stack of telecrystals, so you could gain 1 telecrystal.

:cl:
 * bugfix: Fixes some exploits with telecrystal trading.