### PR TITLE
=-

### DIFF
--- a/code/modules/events/meteors.dm
+++ b/code/modules/events/meteors.dm
@@ -231,7 +231,7 @@ var/global/list/thing_storm_types = list(
 			return
 		var/obj/item/projectile/meteor/blob/core/C = spawn_meteor(chosen_dir, /obj/item/projectile/meteor/blob/core)
 		var/client/candidate = pick(candidates)
-		candidates =- candidate
+		candidates -= candidate
 		C.AssignMob(candidate.mob)
 
 /datum/event/thing_storm/blob_storm/announce()


### PR DESCRIPTION
=-

It looks like this typo would have caused blobstorms to select no more than one overmind per wave, but I don't know if they can even spawn more than one core per wave, so it might not have even mattered
Fixes it anyway

EDIT: They can spawn more than one core per wave but only if there are at least 30 living and conscious players