### PR TITLE
Ghost tweaks

### DIFF
--- a/__DEFINES/global.dm
+++ b/__DEFINES/global.dm
@@ -474,3 +474,6 @@ var/list/variables_not_to_be_copied = list(
 
 //Item lists
 var/global/list/ties = list(/obj/item/clothing/accessory/tie/blue,/obj/item/clothing/accessory/tie/red,/obj/item/clothing/accessory/tie/horrible)
+
+//Observers
+var/global_poltergeist_cooldown = 300 //30s by default, badmins can var-edit this to reduce the poltergeist cooldown globally

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -1,5 +1,3 @@
-#define POLTERGEIST_COOLDOWN 300 // 30s
-
 #define GHOST_CAN_REENTER 1
 #define GHOST_IS_OBSERVER 2
 /mob/dead/observer
@@ -41,6 +39,7 @@
 	var/movespeed = 0.75
 	var/lastchairspin
 	var/pathogenHUD = FALSE
+	var/manual_poltergeist_cooldown //var-edit this to manually modify a ghost's poltergeist cooldown, set it to null to reset to global
 
 /mob/dead/observer/New(var/mob/body=null, var/flags=1)
 	change_sight(adding = SEE_TURFS | SEE_MOBS | SEE_OBJS | SEE_SELF)
@@ -433,7 +432,10 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	return FALSE
 
 /mob/dead/observer/proc/start_poltergeist_cooldown()
-	next_poltergeist=world.time + POLTERGEIST_COOLDOWN
+	if(isnull(manual_poltergeist_cooldown))
+		next_poltergeist=world.time + global_poltergeist_cooldown
+	else
+		next_poltergeist=world.time + manual_poltergeist_cooldown
 
 /mob/dead/observer/proc/reset_poltergeist_cooldown()
 	next_poltergeist=0

--- a/code/modules/mob/dead/observer/spells.dm
+++ b/code/modules/mob/dead/observer/spells.dm
@@ -53,6 +53,10 @@ var/global/list/boo_phrases_silicon=list(
 	override_base = "grey"
 	hud_state = "boo"
 
+/spell/aoe_turf/boo/New()
+	..()
+	charge_counter = 0 //Prevent re-entering body to recharge Boo!
+
 /spell/aoe_turf/boo/cast(list/targets)
 	for(var/turf/T in targets)
 		for(var/atom/A in T.contents)


### PR DESCRIPTION
- Boo!'s charge now resets to 0 when you come out of a body instead of being fully charged
- Turned the poltergeist cooldown define into a global variable called global_poltergeist_cooldown, for when I will maybe get around to adding an event that reduces the poltergeist cooldown or whatever. Scary future. Haha. Scary, ghosts. Hahaha.
- Added a variable for ghosts called manual_poltergeist_cooldown that lets badmins tweak poltergeist cooldown. Reset to null to make it do the global cooldown instead
Shout-out to @Exxion for help

:cl:
 * rscadd: Badmins now have better control on how often a ghost can poltergeist.
 * tweak: The ghost "Boo!" spell now starts on a cooldown when a ghost comes out of their body instead of being fully charged.