### PR TITLE
Small thing

### DIFF
--- a/code/datums/gamemode/role/catbeast.dm
+++ b/code/datums/gamemode/role/catbeast.dm
@@ -46,7 +46,7 @@ var/list/catbeast_names = list("Meowth","Fluffy","Subject 246","Experiment 35a",
 	D1.origin = "Loose Catbeast"
 	D1.makerandom(str, rob, anti, bad)
 	H.infect_disease2(D1, 1, "Loose Catbeast")
-	antag.store_memory(D1.get_info())
+	antag.store_memory(D1.get_info(), 1)
 	antag.store_memory("<hr>")
 
 /datum/role/catbeast/proc/infect_catbeast_tier1(mob/living/carbon/human/H)

--- a/code/datums/gamemode/role/catbeast.dm
+++ b/code/datums/gamemode/role/catbeast.dm
@@ -46,7 +46,7 @@ var/list/catbeast_names = list("Meowth","Fluffy","Subject 246","Experiment 35a",
 	D1.origin = "Loose Catbeast"
 	D1.makerandom(str, rob, anti, bad)
 	H.infect_disease2(D1, 1, "Loose Catbeast")
-	antag.store_memory(D1.get_info(), 1)
+	antag.store_memory(D1.get_info(), forced = 1)
 	antag.store_memory("<hr>")
 
 /datum/role/catbeast/proc/infect_catbeast_tier1(mob/living/carbon/human/H)

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -122,15 +122,19 @@
 	if (hasFactionsWithHUDIcons())
 		update_faction_icons()
 
-/datum/mind/proc/store_memory(new_text)
-	if(length(memory) > MAX_PAPER_MESSAGE_LEN)
-		to_chat(current, "<span class = 'warning'>Your memory, however hazy, is full.</span>")
-		return
-	if(length(new_text) > MAX_MESSAGE_LEN)
-		to_chat(current, "<span class = 'warning'>That's a lot to memorize at once.</span>")
-		return
-	if(new_text)
-		memory += "[new_text]<BR>"
+/datum/mind/proc/store_memory(new_text, var/forced)
+	if(forced)
+		if(new_text)
+			memory += "[new_text]<BR>"
+	else
+		if(length(memory) > MAX_PAPER_MESSAGE_LEN)
+			to_chat(current, "<span class = 'warning'>Your memory, however hazy, is full.</span>")
+			return
+		if(length(new_text) > MAX_MESSAGE_LEN)
+			to_chat(current, "<span class = 'warning'>That's a lot to memorize at once.</span>")
+			return
+		if(new_text)
+			memory += "[new_text]<BR>"
 
 
 /datum/mind/proc/hasFactionsWithHUDIcons()

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -123,18 +123,15 @@
 		update_faction_icons()
 
 /datum/mind/proc/store_memory(new_text, var/forced)
-	if(forced)
-		if(new_text)
-			memory += "[new_text]<BR>"
-	else
+	if(!forced)
 		if(length(memory) > MAX_PAPER_MESSAGE_LEN)
 			to_chat(current, "<span class = 'warning'>Your memory, however hazy, is full.</span>")
 			return
 		if(length(new_text) > MAX_MESSAGE_LEN)
 			to_chat(current, "<span class = 'warning'>That's a lot to memorize at once.</span>")
 			return
-		if(new_text)
-			memory += "[new_text]<BR>"
+	if(new_text)
+		memory += "[new_text]<BR>"
 
 
 /datum/mind/proc/hasFactionsWithHUDIcons()


### PR DESCRIPTION
store_memory (the thing that adds notes to your notes) now has a forced variable that when toggled on ignores the limits of the note
added the forced thing to catbeast disease information
if you ever get the message "that's a lot of information to memorize at once" or "your memory, however hazy, is full" when you spawn as an antag tell me
:cl:
 * bugfix: Fixed a bug where the catbeast wouldn't be able to see the symptoms of the diseases it was carrying because it went past the limit of how long a message can be when it appears in your notes.