### PR TITLE
Silicon movement parity now scales with the cell's capacity if the capacity is low enough

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1335,8 +1335,4 @@ var/list/cyborg_list = list()
 
 //Currently only used for borg movement, to avoid awkward situations where borgs with RTG or basic cells are always slowed down
 /mob/living/silicon/robot/proc/get_percentage_power_for_movement()
-	if(get_cell())
-		var/percentage = round(cell.maxcharge / 4)
-		return clamp(percentage, 0, SILI_LOW_TRIGGER)
-	else
-		return 0
+	return clamp(round(cell.maxcharge/4), 0, SILI_LOW_TRIGGER)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1333,8 +1333,7 @@ var/list/cyborg_list = list()
 	modulelock = !modulelock
 	return modulelock
 
-//Currently only used for borg movement, to avoid awkward situations where borgs with RTG cells are always slowed down while
-//borgs with ultra capacity power cells won't get
+//Currently only used for borg movement, to avoid awkward situations where borgs with RTG or basic cells are always slowed down
 /mob/living/silicon/robot/proc/get_percentage_power_for_movement()
 	if(get_cell())
 		var/percentage = round(cell.maxcharge / 4)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1332,3 +1332,12 @@ var/list/cyborg_list = list()
 /mob/living/silicon/robot/proc/toggle_modulelock()
 	modulelock = !modulelock
 	return modulelock
+
+//Currently only used for borg movement, to avoid awkward situations where borgs with RTG cells are always slowed down while
+//borgs with ultra capacity power cells won't get
+/mob/living/silicon/robot/proc/get_percentage_power_for_movement()
+	if(get_cell())
+		var/percentage = round(cell.maxcharge / 4)
+		return clamp(percentage, 0, SILI_LOW_TRIGGER)
+	else
+		return 0

--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -40,12 +40,13 @@
 			. *= SILICON_HIGH_DAMAGE_SLOWDOWN_MULTIPLIER
 		if(module_active && istype(module_active,/obj/item/borg/combat/mobility))
 			. *= SILICON_MOBILITY_MODULE_SPEED_MODIFIER
-		if(cell.charge <= SILI_LOW_TRIGGER) //25% of a starter cell
+		var/low_movement_speed_trigger = get_percentage_power_for_movement()
+		if(cell.charge <= low_movement_speed_trigger) //25% of the cell OR 25% of a normal cell, whatever is lower
 			if(cell.charge <= 0)
 				. *= SILICON_NO_CELL_SLOWDOWN
 			else
 				//This should be +1.4 at the trigger point and +2 at maximum
-				. += SILI_LOW_SLOW + 0.6*(SILI_LOW_TRIGGER-cell.charge)/SILI_LOW_TRIGGER
+				. += SILI_LOW_SLOW + 0.6*(low_movement_speed_trigger-cell.charge)/low_movement_speed_trigger
 		else
 			if(module)
 				. *= module.speed_modifier


### PR DESCRIPTION
That means robots with RTG cells aren't permanently slower because their charge is lower than the charge penalty threshold (1875 compared to the cell's 1000 max charge). Robots with higher battery capacity will not feel the bad effects of a low battery charge until the charge reaches 1875

:cl:
 * tweak: Silicons with lower-capacity batteries will instead start being slowed down when their charge reaches 25% of their battery's charge capacity, higher-capacity cells are not affected.