### PR TITLE
Fixes mutual handcuffs z-transition logic

### DIFF
--- a/__DEFINES/global.dm
+++ b/__DEFINES/global.dm
@@ -465,7 +465,7 @@ var/list/variables_not_to_be_copied = list(
 	"type","loc","locs","vars","parent","parent_type","verbs","ckey","key",
 	"group","on_login","on_ban","on_unban","on_pipenet_tick","on_item_added",
 	"on_item_removed","on_moved","on_destroyed","on_density_change",
-	"on_z_transition","on_use","on_emote","on_life","on_resist",
+	"on_z_transition","on_use","on_emote","on_life","on_resist","post_z_transition",
 	"on_spellcast","on_uattack","on_ruattack","on_logout","on_damaged",
 	"on_irradiate","on_death","on_clickon","on_attackhand","on_attackby",
 	"on_explode","on_projectile","in_chamber","power_supply","contents",

--- a/code/_onclick/mutual_cuff.dm
+++ b/code/_onclick/mutual_cuff.dm
@@ -50,6 +50,11 @@
 	second.equip_to_slot(cuffs, slot_handcuffed)
 	first.equip_to_slot(cuffs, slot_handcuffed)
 
+	first.z_transition_bringalong_key = first.on_z_transition.Add(first, "z_transition_bringalong")
+	second.z_transition_bringalong_key = second.on_z_transition.Add(second, "z_transition_bringalong")
+	first.post_z_transition_bringalong_key = first.post_z_transition.Add(first, "post_z_transition_bringalong")
+	second.post_z_transition_bringalong_key = second.post_z_transition.Add(second, "post_z_transition_bringalong")
+
 	second.mutual_handcuffed_to_event_key = second.on_moved.Add(first, "on_mutual_cuffed_move")
 	first.mutual_handcuffed_to_event_key = first.on_moved.Add(second, "on_mutual_cuffed_move")
 
@@ -71,6 +76,12 @@
 		//remove from the event
 		C.on_moved.Remove(C.mutual_handcuffed_to_event_key)
 		handcuffed_to.on_moved.Remove(handcuffed_to.mutual_handcuffed_to_event_key)
+
+		C.on_z_transition.Remove(C.z_transition_bringalong_key)
+		handcuffed_to.on_z_transition.Remove(handcuffed_to.z_transition_bringalong_key)
+
+		C.post_z_transition.Remove(C.post_z_transition_bringalong_key)
+		handcuffed_to.post_z_transition.Remove(handcuffed_to.post_z_transition_bringalong_key)
 
 		//reset the mob's vars
 		handcuffed_to.mutual_handcuffed_to = null
@@ -99,3 +110,20 @@
 		//last_call as not to get too many nested calls
 		mutual_handcuff_forcemove_time = world.time
 
+/mob/living/carbon/proc/z_transition_bringalong(var/mob/user, var/from_z, var/to_z)
+	if (mutual_handcuffed_to)
+		// Remove the ability to bring his buddy, since his buddy already brought him here
+		mutual_handcuffed_to.on_z_transition.Remove(mutual_handcuffed_to.z_transition_bringalong_key)
+		mutual_handcuffed_to.z_transition_bringalong_key = null
+		mutual_handcuffed_to.post_z_transition.Remove(mutual_handcuffed_to.post_z_transition_bringalong_key)
+		mutual_handcuffed_to.post_z_transition_bringalong_key = null
+		mutual_handcuffed_to.on_moved.Remove(mutual_handcuffed_to.mutual_handcuffed_to_event_key)
+		mutual_handcuffed_to_event_key = null
+
+/mob/living/carbon/proc/post_z_transition_bringalong(var/mob/user, var/from_z, var/to_z)
+	if (mutual_handcuffed_to)
+		// Re-adds the events on the fly once the transition is done.
+		mutual_handcuffed_to.forceMove(get_turf(src))
+		mutual_handcuffed_to.z_transition_bringalong_key = mutual_handcuffed_to.on_z_transition.Add(mutual_handcuffed_to, "z_transition_bringalong")
+		mutual_handcuffed_to.post_z_transition_bringalong_key = mutual_handcuffed_to.post_z_transition.Add(mutual_handcuffed_to, "post_z_transition_bringalong")
+		mutual_handcuffed_to_event_key = mutual_handcuffed_to.on_moved.Add(src, "on_mutual_cuffed_move")

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -38,7 +38,7 @@ var/global/list/ghdel_profiling = list()
 	// When density is changed
 	var/event/on_density_change
 	var/event/on_z_transition
-
+	var/event/post_z_transition
 
 	var/labeled //Stupid and ugly way to do it, but the alternative would probably require rewriting everywhere a name is read.
 	var/min_harm_label = 0 //Minimum langth of harm-label to be effective. 0 means it cannot be harm-labeled. If any label should work, set this to 1 or 2.
@@ -175,6 +175,10 @@ var/global/list/ghdel_profiling = list()
 		on_z_transition.holder = null
 		qdel(on_z_transition)
 		on_z_transition = null
+	if(post_z_transition)
+		post_z_transition.holder = null
+		qdel(post_z_transition)
+		post_z_transition = null
 	if(istype(beams, /list) && beams.len)
 		beams.len = 0
 	/*if(istype(beams) && beams.len)
@@ -191,6 +195,7 @@ var/global/list/ghdel_profiling = list()
 	on_destroyed = new("owner"=src)
 	on_density_change = new("owner"=src)
 	on_z_transition = new("owner"=src)
+	post_z_transition = new("owner"=src)
 	. = ..()
 	AddToProfiler()
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -272,6 +272,10 @@
 					var/obj/item/projectile/P = A
 					P.reset()//fixing linear projectile movement
 
+			INVOKE_EVENT(A.post_z_transition, list("user" = A, "from_z" = A.z, "to_z" = move_to_z))
+			for(var/atom/AA in contents_brought)
+				INVOKE_EVENT(AA.post_z_transition, list("user" = AA, "from_z" = AA.z, "to_z" = move_to_z))
+
 	if(A && A.opacity)
 		has_opaque_atom = TRUE // Make sure to do this before reconsider_lights(), incase we're on instant updates. Guaranteed to be on in this case.
 		reconsider_lights()

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -10,6 +10,8 @@
 
 	var/mob/living/carbon/mutual_handcuffed_to = null
 	var/mutual_handcuffed_to_event_key = null
+	var/z_transition_bringalong_key = null
+	var/post_z_transition_bringalong_key = null
 	var/obj/item/handcuffed = null //Whether or not the mob is handcuffed.
 	var/obj/item/weapon/handcuffs/mutual_handcuffs = null // whether or not cuffed to somebody else
 	var/mutual_handcuff_forcemove_time = 0 //last teleport time when user moves ontop of another


### PR DESCRIPTION
Closes #25759
[bugfix]
This was actually much harder to do than I thought, but at least, it looks smart. (it probably isn't smart, though.)
Z-transition => temporarily removes the dependency of cuffed party being dragged => drags the guy => re-adds the events.

Tested. Doesn't lag.