### PR TITLE
The return of brian damag damage

### DIFF
--- a/code/modules/spells/targeted/retard.dm
+++ b/code/modules/spells/targeted/retard.dm
@@ -9,7 +9,7 @@
 	//Invocation is noted below
 	invocation_type = SpI_WHISPER //Wizard will whisper what they say instead of shouting
 	range = 3 // Target anyone within 3 tiles of you
-	amt_dam_brain = 30 //30 brain damage
+	amt_dam_brain = 90 //90 brain damage
 	max_targets = 1 // Can only target one person
 	compatible_mobs = list(/mob/living/carbon/human, /mob/living/carbon/monkey) // Only works on humans and monkeys
 	spell_flags = WAIT_FOR_CLICK | IS_HARMFUL //Click on whoever you want to get brain damaged


### PR DESCRIPTION
Ever since it was removed and then brought back in #23324 it was too weak for an ancient spellbook spell, this PR brings the value back to 90 brain damage, the equivalent of what used to be an empowered brain damage spell before

:cl:
 * tweak: The brain damage spell now deals increased brain damage