### PR TITLE
no more spare nuke op helmets

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/syndicate.dm
+++ b/code/game/objects/structures/crates_lockers/closets/syndicate.dm
@@ -14,8 +14,7 @@
 		/obj/item/weapon/tank/jetpack/oxygen/nukeops,
 		/obj/item/clothing/mask/gas/syndicate,
 		/obj/item/clothing/under/syndicate,
-		/obj/item/clothing/head/helmet/space/rig/syndi,
-		/obj/item/clothing/suit/space/rig/syndi,
+		/obj/item/clothing/suit/space/rig/syndi, //Helmet's in the rig.
 		/obj/item/weapon/cell/high,
 		/obj/item/device/pda/syndicate/door,
 		/obj/item/weapon/pinpointer/nukeop,


### PR DESCRIPTION
[hotfix]
nuke op lockers come with a spare helmet which is bad