### PR TITLE
Fixed mobs getting damaged by massless effects getting thrown around by explosions

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -83,7 +83,7 @@
 		return
 	if(flags & INVULNERABLE)
 		return
-	if(istype(AM,/obj/))
+	if(istype(AM,/obj/) && !istype(AM,/obj/effect/effect/))
 		var/obj/O = AM
 		var/zone = ran_zone(LIMB_CHEST,75)//Hits a random part of the body, geared towards the chest
 		var/dtype = BRUTE


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/7573912/74609562-8ceb7800-50eb-11ea-8e01-4988e6c6fa60.png)

I gave a quick look to other /obj/effect/effect in the game but I don't think any of them were ever intended to be thrown at mobs to damage them so this shouldn't break anything further.

:cl:
* bugfix: Massless thrown effects can no longer damage living mobs or stagger them.