### PR TITLE
Fixes corn oil and makes robotic hearts immune to it

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -4411,7 +4411,7 @@
 			if(1 to 15)
 				if(prob(5))
 					H.emote("me", 1, "burps.")
-					holder.remove_reagent(src.id, 0.1 * FOOD_METABOLISM)
+					holder.remove_reagent(id, 0.1 * FOOD_METABOLISM)
 			if(15 to 100)
 				if(prob(10))
 					to_chat(H,"<span class='warning'>You really don't feel very good.</span>")
@@ -4420,7 +4420,7 @@
 						to_chat(H,"<span class='warning'>You feel a burn in your chest.</span>")
 						heart.take_damage(0.2, 1)
 			if(100 to INFINITY)//Too much corn oil holy shit, no one should ever get this high
-				if(heart)
+				if(heart && !heart.robotic)
 					to_chat(H, "<span class='danger'>You feel a terrible pain in your chest!</span>")
 					has_had_heart_explode = 1 //That way it doesn't blow up any new transplant hearts
 					qdel(H.remove_internal_organ(H,heart,H.get_organ(LIMB_CHEST)))

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -4396,41 +4396,6 @@
 	color = "#302000" //rgb: 48, 32, 0
 	var/has_had_heart_explode = 0
 
-/datum/reagent/cornoil/proc/decornoil(var/mob/living/M, heartdamage = 30, override_remove = 0, explodeheart = 1)
-	if(!has_had_heart_explode)
-		has_had_heart_explode = 1
-		if(!override_remove)
-			holder.remove_reagent(src.id) //Clean them out so medbay can replace the heart with a fresh one if they want to
-	
-		if(ishuman(M))
-		var/mob/living/carbon/human/H = M
-		switch(volume)
-			if(1 to 15)
-				if(prob(5))
-					H.emote("me", 1, "burps.")
-					holder.remove_reagent(src.id, 0.1 * FOOD_METABOLISM)
-					
-			if(15 to 100)
-				if(prob(10))
-					to_chat(H,"<span class='warning'>You really don't feel very good.</span>")
-				if(prob(5))
-					to_chat(H,"<span class='warning'>You feel a burn in your chest.</span>")
-					var/datum/organ/internal/heart/L = H.internal_organs_by_name["heart"]
-					if(istype(L))
-						L.take_damage(0.2, 1)
-						
-			if(100 to INFINITY)//Too much corn oil holy shit, no one should ever get this high
-				if(H.get_heart())//Got a heart?
-					var/datum/organ/internal/heart/damagedheart = H.get_heart()
-					if (heartdamage >= 30)
-						if(H.species.name != "Diona" && damagedheart) //fuck dionae
-							to_chat(H, "<span class='danger'>You feel a terrible pain in your chest!</span>")
-							damagedheart.damage += heartdamage //Bye heart.
-							if(explodeheart)
-								qdel(H.remove_internal_organ(H,damagedheart,H.get_organ(LIMB_CHEST)))
-						H.adjustOxyLoss(heartdamage*2)
-						H.adjustBruteLoss(heartdamage)
-
 /datum/reagent/cornoil/on_mob_life(var/mob/living/M)
 
 	if(..())
@@ -4438,6 +4403,29 @@
 
 	M.nutrition += nutriment_factor
 
+//Now handle corn oil interactions
+	if(!has_had_heart_explode && ishuman(M))
+		var/mob/living/carbon/human/H = M
+		var/datum/organ/internal/heart/heart = H.internal_organs_by_name["heart"]
+		switch(volume)
+			if(1 to 15)
+				if(prob(5))
+					H.emote("me", 1, "burps.")
+					holder.remove_reagent(src.id, 0.1 * FOOD_METABOLISM)
+			if(15 to 100)
+				if(prob(10))
+					to_chat(H,"<span class='warning'>You really don't feel very good.</span>")
+				if(prob(5))
+					if(heart && !heart.robotic)
+						to_chat(H,"<span class='warning'>You feel a burn in your chest.</span>")
+						heart.take_damage(0.2, 1)
+			if(100 to INFINITY)//Too much corn oil holy shit, no one should ever get this high
+				if(heart)
+					to_chat(H, "<span class='danger'>You feel a terrible pain in your chest!</span>")
+					has_had_heart_explode = 1 //That way it doesn't blow up any new transplant hearts
+					qdel(H.remove_internal_organ(H,heart,H.get_organ(LIMB_CHEST)))
+					H.adjustOxyLoss(60)
+					H.adjustBruteLoss(30)
 
 /datum/reagent/cornoil/reaction_turf(var/turf/simulated/T, var/volume)
 


### PR DESCRIPTION
Actually works
Tested
Robotic hearts won't get heart damage
Cleans up the code
Closes #25888 

:cl:
 * bugfix: Fixed corn oil, now it actually works
 * rscadd: Artificial hearts make you immune to the heart-busting effects of excessive corn oil consumption