### PR TITLE
Nerfs Mime curse.

### DIFF
--- a/__DEFINES/human.dm
+++ b/__DEFINES/human.dm
@@ -1,6 +1,3 @@
 // Amount of nutrition at which point overeatduration starts to tick up.
 // AKA from this point on you get fat.
 #define OVEREAT_THRESHOLD 450
-
-#define MIMING_OUT_OF_CHOICE 1
-#define MIMING_OUT_OF_CURSE  2

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -426,7 +426,7 @@
 		H.equip_or_collect(new /obj/item/weapon/stamp/mime(H), slot_in_backpack)
 	H.add_spell(new /spell/aoe_turf/conjure/forcewall/mime, "grey_spell_ready")
 	H.add_spell(new /spell/targeted/oathbreak/)
-	H.mind.miming = MIMING_OUT_OF_CHOICE
+	H.mind.miming = 1
 	mob_rename_self(H,"mime")
 	return 1
 

--- a/code/modules/medical/cloning.dm
+++ b/code/modules/medical/cloning.dm
@@ -264,8 +264,7 @@
 
 	if (H.mind.miming)
 		H.add_spell(new /spell/aoe_turf/conjure/forcewall/mime, "grey_spell_ready")
-		if (H.mind.miming == MIMING_OUT_OF_CHOICE)
-			H.add_spell(new /spell/targeted/oathbreak/)
+		H.add_spell(new /spell/targeted/oathbreak/)
 
 	H.UpdateAppearance()
 	H.set_species(R.dna.species)

--- a/code/modules/medical/patientprocessor.dm
+++ b/code/modules/medical/patientprocessor.dm
@@ -57,8 +57,7 @@
 	to_chat(new_body, "<span class='notice'><b>You suddenly awaken inside some strange machine.</b></span>")
 	if(new_body.mind?.miming) //yes I know I'm using the forbidden operator
 		new_body.add_spell(new /spell/aoe_turf/conjure/forcewall/mime, "grey_spell_ready")
-		if(new_body.mind.miming == MIMING_OUT_OF_CHOICE)
-			new_body.add_spell(new /spell/targeted/oathbreak/)
+		new_body.add_spell(new /spell/targeted/oathbreak/)
 	new_body.UpdateAppearance()
 	for(var/datum/language/L in brainmob.languages)
 		new_body.add_language(L.name)

--- a/code/modules/spells/targeted/equip/frenchcurse.dm
+++ b/code/modules/spells/targeted/equip/frenchcurse.dm
@@ -29,7 +29,7 @@
 	..()
 	for(var/mob/living/carbon/human/target in targets)
 		target.flash_eyes(visual = 1)
-		target.mind.miming = MIMING_OUT_OF_CURSE
+		target.mind.miming = 1
 		var/spell = /spell/aoe_turf/conjure/forcewall/mime
 		if(!(locate(spell) in target.spell_list))
 			target.add_spell(new /spell/aoe_turf/conjure/forcewall/mime)//They can't even acid the mime mask off, if they're going to be permanently muted they may as well get the benefits of the mime. Also they can't oathbreak.


### PR DESCRIPTION
I may have gone too far in a few places back then.
This makes it so mimes created by the French Curse can now free themselves of it after dying.

:cl:
- rscadd: Being Mime-cursed no longer condemns you to be French forever.