### PR TITLE
Hammer strike based on quality is now rounded

### DIFF
--- a/code/WorkInProgress/MadmanMartian/blacksmithing/blacksmithing.dm
+++ b/code/WorkInProgress/MadmanMartian/blacksmithing/blacksmithing.dm
@@ -105,7 +105,7 @@
 		return
 	playsound(loc, 'sound/items/hammer_strike.ogg', 50, 1)
 	if(istype(A,/obj/item/weapon/hammer))
-		strikes+=max(1, round(A.quality/2))
+		strikes+=max(1, round(A.quality/2, 1))
 	else if(istype(A,/obj/item/weapon/storage/toolbox))
 		strikes+=0.25
 	if(strikes == strikes_required)


### PR DESCRIPTION
The most noticeable change is that legendary hammers can do 5 strikes instead of 4.

Current system of how many strikes a hammer would count for based on its quality:
Awful - 1, Shoddy - 1, Poor - 1, Average - 2, Good - 2, Superior - 3, Excellent - 3, Masterwork - 4, Legendary - 4

PR's system
Awful - 1, Shoddy - 1, Poor - 2, Average - 2, Good - 3, Superior - 3, Excellent - 4, Masterwork - 4, Legendary - 5

:cl:
 * tweak: Blacksmithing hammers have been tweaked a little and will generally count for more strikes at one quality level lower. Legendary hammers can now count for 5 strikes per strike.