### PR TITLE
Adds Buckle In & Buckle Out verbs for beds, chairs and vehicles

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -64,6 +64,9 @@
 	manual_unbuckle(usr)
 
 /obj/structure/bed/proc/manual_unbuckle(var/mob/user)
+	if(user.incapacitated())
+		return FALSE
+
 	if(user.size <= SIZE_TINY)
 		to_chat(user, "<span class='warning'>You are too small to do that.</span>")
 		return FALSE

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -15,6 +15,7 @@
 	..()
 	if(material_type)
 		sheet_type = material_type.sheettype
+	verbs -= /obj/structure/bed/verb/buckle_out
 
 /obj/structure/bed/cultify()
 	var/obj/structure/bed/chair/wood/wings/I = new /obj/structure/bed/chair/wood/wings(loc)
@@ -50,6 +51,18 @@
 /obj/structure/bed/AltClick(mob/user as mob)
 	buckle_mob(user, user)
 
+/obj/structure/bed/verb/buckle_in()
+	set name = "Buckle In"
+	set category = "Object"
+	set src in range(0)
+	buckle_mob(usr, usr)
+
+/obj/structure/bed/verb/buckle_out()
+	set name = "Buckle Out"
+	set category = "Object"
+	set src in range(0)
+	manual_unbuckle(usr)
+
 /obj/structure/bed/proc/manual_unbuckle(var/mob/user)
 	if(user.size <= SIZE_TINY)
 		to_chat(user, "<span class='warning'>You are too small to do that.</span>")
@@ -81,6 +94,8 @@
 				"You hear metal clanking.")
 		playsound(src, 'sound/misc/buckle_unclick.ogg', 50, 1)
 		M.clear_alert(SCREEN_ALARM_BUCKLE)
+		verbs += /obj/structure/bed/verb/buckle_in
+		verbs -= /obj/structure/bed/verb/buckle_out
 		return TRUE
 
 /obj/structure/bed/proc/buckle_mob(mob/M as mob, mob/user as mob)
@@ -89,7 +104,7 @@
 
 	if(!ismob(M) || (M.loc != src.loc)  || M.locked_to)
 		return
-		
+
 	if(!user.Adjacent(M))
 		return
 
@@ -126,6 +141,8 @@
 
 	lock_atom(M, mob_lock_type)
 	M.throw_alert(SCREEN_ALARM_BUCKLE, /obj/abstract/screen/alert/object/buckled, new_master = src)
+	verbs -= /obj/structure/bed/verb/buckle_in
+	verbs += /obj/structure/bed/verb/buckle_out
 
 	if(M.pulledby)
 		M.pulledby.start_pulling(src)

--- a/code/game/objects/structures/vehicles/vehicle.dm
+++ b/code/game/objects/structures/vehicles/vehicle.dm
@@ -82,6 +82,8 @@
 	make_offsets()
 	if(headlights)
 		new /datum/action/vehicle/toggle_headlights(src)
+	verbs -= /obj/structure/bed/verb/buckle_in //idk how to do this properly
+	verbs -= /obj/structure/bed/chair/vehicle/buckle_out
 
 /obj/structure/bed/chair/vehicle/Destroy()
 	vehicle_list.Remove(src)
@@ -229,6 +231,13 @@
 			return 0
 	return 1
 
+/obj/structure/bed/chair/vehicle/buckle_in()
+	set src in range(1)
+	buckle_mob(usr, usr)
+
+/obj/structure/bed/chair/vehicle/buckle_out()
+	manual_unbuckle(usr)
+
 /obj/structure/bed/chair/vehicle/buckle_mob(mob/M, mob/user)
 	if(!can_buckle(M,user))
 		return
@@ -246,11 +255,16 @@
 		if (action.owner && action.owner != user)
 			action.Remove(action.owner)
 		action.Grant(user)
+	verbs -= /obj/structure/bed/chair/vehicle/buckle_in
+	verbs += /obj/structure/bed/chair/vehicle/buckle_out
 
 /obj/structure/bed/chair/vehicle/manual_unbuckle(user)
 	..()
 	for (var/datum/action/action in vehicle_actions)
 		action.Remove(user)
+	verbs += /obj/structure/bed/chair/vehicle/buckle_in
+	verbs -= /obj/structure/bed/verb/buckle_in //here too
+	verbs -= /obj/structure/bed/chair/vehicle/buckle_out
 
 /obj/structure/bed/chair/vehicle/handle_layer()
 	if(dir == SOUTH)


### PR DESCRIPTION
[qol] [tested]
Mostly intended for buckling out of shuttle's chair with your hands full without robusting yourself.
Tested with beds, rollerbeds, chairs and snowmobiles.
Vehicle verbs work by removing bed's verbs, looks wonky to me, do tell if there's a better way around that.
:cl:
 * rscadd: Added "Buckle In" & "Buckle Out" verbs for beds, chairs and vehicles.