### PR TITLE
Meme disease type is now admin-only. Fungii can only appear in random dishes.

### DIFF
--- a/__DEFINES/disease2.dm
+++ b/__DEFINES/disease2.dm
@@ -2,6 +2,7 @@
 #define BUMP "bump"
 #define HAND "hand"
 
-#define WDISH	 1
-#define WLATEJOIN 2
-#define WMOUSE	 3
+#define WDISH	1
+#define WMOUSE	2
+#define WINFECTION	3
+#define WOUTBREAK	4

--- a/code/modules/events/viral_infection.dm
+++ b/code/modules/events/viral_infection.dm
@@ -13,8 +13,7 @@
 	biohazard_alert_minor()
 
 /datum/event/viral_infection/start()
-	var/virus_choice = pick(subtypesof(/datum/disease2/disease) - /datum/disease2/disease/prion)
-	var/datum/disease2/disease/D = new virus_choice
+	var/datum/disease2/disease/D = get_random_weighted_disease(WINFECTION)
 
 	var/list/anti = list(
 		ANTIGEN_BLOOD	= 1,

--- a/code/modules/events/viral_outbreak.dm
+++ b/code/modules/events/viral_outbreak.dm
@@ -14,8 +14,7 @@ datum/event/viral_outbreak/announce()
 	biohazard_alert_major()
 
 datum/event/viral_outbreak/start()
-	var/virus_choice = pick(subtypesof(/datum/disease2/disease) - /datum/disease2/disease/bacteria)
-	var/datum/disease2/disease/D = new virus_choice
+	var/datum/disease2/disease/D = get_random_weighted_disease(WOUTBREAK)
 
 	var/list/anti = list(
 		ANTIGEN_BLOOD	= 0,

--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -58,7 +58,7 @@ var/global/list/disease2_list = list()
 	//pathogenic warfare
 	var/list/can_kill = list("Bacteria")
 
-	var/list/type_weight = list(0,0,0) //weight that it will appear in dish, new player, mouse; 4 is base
+	var/list/type_weight = list(1,1,1,1) //weight that it will appear in dish, new player, mouse; 4 is base
 
 /datum/disease2/disease/virus
 	form = "Virus"
@@ -68,7 +68,7 @@ var/global/list/disease2_list = list()
 	stageprob = 10
 	stage_variance = -1
 	can_kill = list("Bacteria")
-	type_weight = list(4,5,2) //more common in humans, less in mice
+	type_weight = list(2,1,1,1)
 
 /datum/disease2/disease/bacteria//faster spread and progression, but only 3 stages max, and reset to stage 1 on every spread
 	form = "Bacteria"
@@ -78,7 +78,7 @@ var/global/list/disease2_list = list()
 	stageprob = 30
 	stage_variance = -4
 	can_kill = list("Parasite")
-	type_weight = list(2,4,4) //reduced appearance in dishes
+	type_weight = list(2,3,1,0) //more common in mice
 
 /datum/disease2/disease/parasite//slower spread. stage preserved on spread
 	form = "Parasite"
@@ -87,7 +87,7 @@ var/global/list/disease2_list = list()
 	stageprob = 10
 	stage_variance = 0
 	can_kill = list("Virus")
-	type_weight = list(4,2,5) //less common in people, more common in mice
+	type_weight = list(2,1,1,1)
 
 /datum/disease2/disease/prion//very fast progression, but very slow spread and resets to stage 1.
 	form = "Prion"
@@ -96,7 +96,7 @@ var/global/list/disease2_list = list()
 	stageprob = 80
 	stage_variance = -10
 	can_kill = list()
-	type_weight = list(4,4,1) //rare in mice
+	type_weight = list(2,0,0,1)
 
 /datum/disease2/disease/fungus //most infectious, but with a greater stage setback; has special transmission
 	form = "Fungus"
@@ -105,7 +105,7 @@ var/global/list/disease2_list = list()
 	stageprob = 15
 	stage_variance = -2
 	allowed_transmission = SPREAD_BLOOD | SPREAD_CONTACT | SPREAD_AIRBORNE | SPREAD_COLONY
-	type_weight = list(4,5,2)
+	type_weight = list(1,0,0,0)
 
 /datum/disease2/disease/meme //infectious and fast progressing, but limited stages; has special transmission
 	form = "Meme"
@@ -115,7 +115,7 @@ var/global/list/disease2_list = list()
 	stageprob = 30
 	stage_variance = -1
 	allowed_transmission = SPREAD_BLOOD | SPREAD_MEMETIC
-	type_weight = list(1,6,0) //rare in dishes and never in mice, very common in people
+	type_weight = list(0,0,0,0) //rare in dishes and never in mice, very common in people
 	//Note: if more types of creatures become infectable than humans/monkeys/mice, give them HEAR_ALWAYS
 
 /datum/disease2/disease/proc/update_global_log()

--- a/code/modules/virus2/helpers.dm
+++ b/code/modules/virus2/helpers.dm
@@ -4,7 +4,9 @@ proc/get_random_weighted_disease(var/operation = WDISH)
 	var/list/weighted_list = list()
 	for(var/P in possibles)
 		var/datum/disease2/disease/D = new P
-		weighted_list[D] = D.type_weight[operation]
+		var/weight = D.type_weight[operation]
+		if (weight != 0)
+			weighted_list[D] = weight
 	return pickweight(weighted_list)
 
 ////////////////////////////////////////////////////


### PR DESCRIPTION
I'm pretty sure memes alone made latejoin diseases way worse than they originally were.

:cl:
* rscdel: Meme diseases can no longer appear outside of adminbus.
* tweak: Fungii may now only appear in random dishes.