### PR TITLE
Makes Honk Serum overdose break miming.

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -6758,6 +6758,17 @@
 	color = "#F2C900" //rgb: 242, 201, 0
 	custom_metabolism = 0.05
 
+/datum/reagent/honkserum/on_overdose(var/mob/living/H)
+
+	if (H.mind.miming)
+		H.mind.miming = 0
+		for(var/spell/aoe_turf/conjure/forcewall/mime/spell in H.spell_list)
+			H.remove_spell(spell)
+		for(var/spell/targeted/oathbreak/spell in H.spell_list)
+			H.remove_spell(spell)
+		H.visible_message("<span class='notice'>\The [H]'s face goes pale for a split second, and then regains some colour.</span>, <span class='notice><i>Where did Marcel go...?</i></span>'")
+
+
 /datum/reagent/honkserum/on_mob_life(var/mob/living/M)
 
 	if(..())

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -6766,7 +6766,7 @@
 			H.remove_spell(spell)
 		for(var/spell/targeted/oathbreak/spell in H.spell_list)
 			H.remove_spell(spell)
-		H.visible_message("<span class='notice'>\The [H]'s face goes pale for a split second, and then regains some colour.</span>, <span class='notice><i>Where did Marcel go...?</i></span>'")
+		H.visible_message("<span class='notice'>\The [H]'s face goes pale for a split second, and then regains some colour.</span>, <span class='notice'><i>Where did Marcel go...?</i></span>'")
 
 
 /datum/reagent/honkserum/on_mob_life(var/mob/living/M)


### PR DESCRIPTION
As suggested in #25902 
[balance]

:cl:
- tweak: Overdosing on Honk Serum will now un-mime people.