### PR TITLE
TEC power tweaks

### DIFF
--- a/code/ATMOSPHERICS/components/binary_devices/heat_pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/heat_pump.dm
@@ -31,7 +31,8 @@ It also must be positive. Technically it can be 0 without breaking physics, but 
 
 	var/process_margin = 0.99 //Doesn't process when the current temperature difference is within 1% of MTD for performance reasons
 
-	active_power_usage = 5000
+	active_power_usage = 3000
+	power_channel = EQUIP
 
 	ghost_read = FALSE
 


### PR DESCRIPTION
* Drops the power consumption per TEC from 5KW to 3KW. I want the consumption to be significant, but in retrospect 5KW seems a bit gratuitous.
* Moves them to the equipment power channel from the environment one. If the APC they're on loses power, they'll no longer drain it completely and shut off even atmos equipment. (Unless you force the equipment breaker on, of course.)

:cl:
* tweak: Thermoelectric cooler power consumption has been lowered from 5KW to 3KW.
* tweak: Thermoelectric coolers have been moved from the environment power channel to the equipment power channel.