### PR TITLE
Fixes a couple of things

### DIFF
--- a/code/game/machinery/bots/ed209bot.dm
+++ b/code/game/machinery/bots/ed209bot.dm
@@ -862,7 +862,7 @@ Auto Patrol: []"},
 
 	spark(src)
 
-	var/obj/effect/decal/cleanable/blood/oil/gib = getFromPool(/obj/effect/decal/cleanable/blood/oil, src.loc)
+	getFromPool(/obj/effect/decal/cleanable/blood/oil, src.loc)
 	qdel(src)
 
 

--- a/code/modules/research/fabricators.dm
+++ b/code/modules/research/fabricators.dm
@@ -291,7 +291,7 @@
 
 //The build_part_loop fires independently and will build stuff until the queue is over or when it is stopped.
 /obj/machinery/r_n_d/fabricator/proc/build_part_loop()
-	if(busy || stopped || being_built || stat&(NOPOWER|BROKEN))
+	if(busy || stopped || being_built || stat&(NOPOWER|BROKEN) || queue.len == 0)
 		return
 	var/datum/design/D = queue_pop()
 	if(!build_part(D))


### PR DESCRIPTION
Fabricators will no longer runtime because it would try to grab an element from an empty list
Fixed a compile warning because a variable became unused