### PR TITLE
Xenoarch Core Sampler fixes

### DIFF
--- a/code/modules/research/xenoarchaeology/tools/tools_coresampler.dm
+++ b/code/modules/research/xenoarchaeology/tools/tools_coresampler.dm
@@ -1,3 +1,4 @@
+#define MAX_STORED_BAGS 10
 //device to take core samples from mineral turfs - used for various types of analysis
 
 /obj/item/weapon/storage/box/samplebags
@@ -6,11 +7,8 @@
 
 /obj/item/weapon/storage/box/samplebags/New()
 	for(var/i=0, i<7, i++)
-		var/obj/item/weapon/storage/evidencebag/S = new(src)
-		S.name = "sample bag"
-		S.desc = "a bag for holding research samples."
+		new/obj/item/weapon/storage/evidencebag/sample(src)
 	..()
-	return
 
 //////////////////////////////////////////////////////////////////
 
@@ -23,29 +21,33 @@
 	w_class = W_CLASS_TINY
 	flags = FPRINT
 	//slot_flags = SLOT_BELT
-	var/sampled_turf = ""
-	var/num_stored_bags = 10
-	var/obj/item/weapon/storage/evidencebag/filled_bag
+	var/num_stored_bags = MAX_STORED_BAGS
+	var/obj/item/weapon/storage/evidencebag/sample/filled_bag
 
 /obj/item/device/core_sampler/examine(mob/user)
 	..()
 	if(get_dist(src, user) < 2)
-		to_chat(user, "<span class='info'>This one is [sampled_turf ? "full" : "empty"], and has [num_stored_bags] bag[num_stored_bags != 1 ? "s" : ""] remaining.</span>")
+		to_chat(user, "<span class='info'>This one is [filled_bag ? "full" : "empty"], and has [num_stored_bags] bag[num_stored_bags != 1 ? "s" : ""] remaining.</span>")
 
-/obj/item/device/core_sampler/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if(istype(W,/obj/item/weapon/storage/evidencebag))
-		if(num_stored_bags < 10)
-			to_chat(user, "<span class='notice'>You insert the [W] into the core sampler.</span>")
-			qdel(W)
-			W = null
-			num_stored_bags += 1
-			return 1
-		else
-			to_chat(user, "<span class='warning'>The core sampler can not fit any more bags!</span>")
+/obj/item/device/core_sampler/attackby(obj/item/weapon/W, mob/user)
+	if(istype(W,/obj/item/weapon/storage/evidencebag/sample))
+		insert_bag_maybe(W, user)
+		return TRUE
 	else
 		return ..()
 
-/obj/item/device/core_sampler/proc/sample_item(var/item_to_sample, var/mob/user as mob)
+/obj/item/device/core_sampler/proc/insert_bag_maybe(obj/item/weapon/storage/evidencebag/sample/W, mob/user)
+	if(num_stored_bags >= MAX_STORED_BAGS)
+		to_chat(user, "<span class='warning'>\The [src] can not fit any more bags!</span>")
+	else if (W.contents.len > 0)
+		to_chat(user, "<span class='warning'>Empty the bag first!</span>")
+	else
+		to_chat(user, "<span class='notice'>You insert \the [W] into \the [src].</span>")
+		qdel(W)
+		num_stored_bags += 1
+
+
+/obj/item/device/core_sampler/proc/sample_item(var/item_to_sample, var/mob/user)
 	var/datum/geosample/geo_data
 	if(istype(item_to_sample, /turf/unsimulated/mineral))
 		var/turf/unsimulated/mineral/T = item_to_sample
@@ -57,14 +59,12 @@
 
 	if(geo_data)
 		if(filled_bag)
-			to_chat(user, "<span class='warning'>The core sampler is full!</span>")
+			to_chat(user, "<span class='warning'>\The [src] is full!</span>")
 		else if(num_stored_bags < 1)
-			to_chat(user, "<span class='warning'>The core sampler is out of sample bags!</span>")
+			to_chat(user, "<span class='warning'>\The [src] is out of sample bags!</span>")
 		else
 			//create a new sample bag which we'll fill with rock samples
-			filled_bag = new /obj/item/weapon/storage/evidencebag(src)
-			filled_bag.name = "sample bag"
-			filled_bag.desc = "a bag for holding research samples."
+			filled_bag = new /obj/item/weapon/storage/evidencebag/sample(src)
 
 			icon_state = "sampler1"
 			num_stored_bags--
@@ -74,20 +74,15 @@
 			R.geological_data = geo_data
 			R.forceMove(filled_bag)
 
-			//update the sample bag
-			filled_bag.icon_state = "evidence"
-			var/image/I = image("icon"=R, "layer"=FLOAT_LAYER)
-			I.plane = FLOAT_PLANE
-			filled_bag.underlays += I
-			filled_bag.w_class = W_CLASS_TINY
+			filled_bag.update_icon()
 
-			to_chat(user, "<span class='notice'>You take a core sample of the [item_to_sample].</span>")
+			to_chat(user, "<span class='notice'>You take a core sample of \the [item_to_sample].</span>")
 	else
 		to_chat(user, "<span class='warning'>You are unable to take a sample of [item_to_sample].</span>")
 
-/obj/item/device/core_sampler/attack_self()
+/obj/item/device/core_sampler/attack_self(mob/user)
 	if(filled_bag)
-		to_chat(usr, "<span class='notice'>You eject the full sample bag.</span>")
+		to_chat(user, "<span class='notice'>You eject the full sample bag.</span>")
 		var/success = 0
 		if(istype(src.loc, /mob))
 			var/mob/M = src.loc
@@ -97,4 +92,20 @@
 		filled_bag = null
 		icon_state = "sampler0"
 	else
-		to_chat(usr, "<span class='warning'>The core sampler is empty.</span>")
+		to_chat(user, "<span class='warning'>The core sampler is empty.</span>")
+
+
+/obj/item/weapon/storage/evidencebag/sample
+	name = "sample bag"
+	desc = "A bag for holding research samples."
+	use_to_pickup = FALSE
+
+/obj/item/weapon/storage/evidencebag/sample/attackby(obj/item/W, mob/user)
+	if (istype(W, /obj/item/device/core_sampler))
+		var/obj/item/device/core_sampler/sampler = W
+		sampler.insert_bag_maybe(src, user)
+		return TRUE
+
+	return ..()
+
+#undef MAX_STORED_BAGS


### PR DESCRIPTION
Cleaned up the code to be less awful.
Fixed "can't re-insert bags into core sampler"
Fixed examine text always listing it as empty.
Fixed the bags sprite not correctly clearing when you empty them.
Made a subtype of evidence bag for the core sampler.
Fixed a while bunch of formatting problems too probably.

Fixes #25631 fixes #25629 fixes #24973 fixes #22579 fixes #20515

[bugfix]

<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation or the coding discord (you can find an invite link on the irc or the thread) to discuss your changes, or if you need help.

== SELF LABELLING PRs ==
You can now self-label your PR! The syntax is simple. Just put [<labeltag>] anywhere in your PR,
where <labeltag> is to be replaced by one of the following (allowing with the resultant tag)
just ctrl+f the list or something. I know it's long.

administration = "Logging / Administration"
away = "Mapping (Away Mission :earth_africa:)"
bagel = "Mapping (Bagel :o:)"
box = "Mapping (Box :baby:)"
bugfix = "Bug / Fix"
bus = "Mapping (Bus :bus:)"
byond = "T-Thanks BYOND"
consistency = "Consistency Issue"
controversial = "Controversial"
deff = "Mapping (Deff :wastebasket:)"
discussion = "Discussion"
dnm = "✋ Do Not Merge ✋"
easy = "Easy Fix"
exploitable = "Exploitable"
featureloss = "Feature Loss"
featurerequest = "Feature Request"
first = "good first issue"
formatting = "Grammar / Formatting"
gamemode = "Gameplay / Gamemode"
gameplay = "Gameplay / Gamemode"
general = "Mapping (General :world_map:)"
goonchat = "Goonchat"
grammar = "Grammar / Formatting"
help = "help wanted"
hotfix = "Hotfix"
libvg = "libvg"
logging = "Logging / Administration"
meta = "Mapping (Meta :no_mobile_phones:)"
needspritework = "Needs Spritework"
oversight = "Oversight"
packed = "Mapping (Packed :package:)"
parallax = "Parallax"
qol = "❤️ Quality of Life ❤️"
roid = "Mapping (Roidstation :pick:)"
role = "Role Datums"
roleissue = "Role Datums Issue"
runtime = "Runtime Log"
sanity = "Sanity / Ghosthands"
snowmap = "Mapping (Snowmap ❄)"
sound = "Sound"
sprites = "Sprites"
spriteworkdone = "Spritework Done Needs Coder"
system = "System"
taxi = "Mapping (Taxi :taxi:)"
tested = "100%  tested"
tweak = "Tweak"
ui = "UI"
vault = "Mapping (Vault :question:)"
vote = "⛔ Requires Server Vote ⛔"
wip = "WiP"

== CHANGELOGS ==
Changelogs can be attached either by following the instructions in html/changelogs/example.yml, or by attaching an in-body changelog like the one attached to your PR automatically.

For the keys you can use in an in-body changelog, they are the same as described in example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!

Valid Prefixes:
bugfix
wip (For works in progress)
tweak
soundadd
sounddel
rscdel (general deleting of nice things)
rscadd (general adding of nice things)
imageadd
imagedel
spellcheck (typo fixes)
experiment
tgs (TG-ported fixes?)

An example changelog is attached to this PR for your convenience:
-->
:cl:
 * bugfix: You can insert bags into the xenoarch core sampler again. Also fixed a ton of other stupid stuff with it.