### PR TITLE
Fixes cameras keeping a ref on tracked mobs that were deleted

### DIFF
--- a/code/game/machinery/camera/motion.dm
+++ b/code/game/machinery/camera/motion.dm
@@ -34,6 +34,7 @@
 		detectTime = world.time // start the clock
 	if (!(target in motionTargets))
 		motionTargets += target
+		target.on_destroyed.Add(src, "clearDeletedTarget")
 	return 1
 
 /obj/machinery/camera/proc/lostTarget(var/mob/target)
@@ -41,6 +42,10 @@
 		motionTargets -= target
 	if (motionTargets.len == 0)
 		cancelAlarm()
+
+/obj/machinery/camera/proc/clearDeletedTarget(list/params)
+	var/atom/destroyed = params["atom"]
+	lostTarget(destroyed)
 
 /obj/machinery/camera/proc/cancelAlarm()
 	if (detectTime == -1)

--- a/code/game/machinery/camera/motion.dm
+++ b/code/game/machinery/camera/motion.dm
@@ -40,6 +40,7 @@
 /obj/machinery/camera/proc/lostTarget(var/mob/target)
 	if (target in motionTargets)
 		motionTargets -= target
+		target.on_destroyed.Remove("\ref[src]:clearDeletedTarget")
 	if (motionTargets.len == 0)
 		cancelAlarm()
 


### PR DESCRIPTION
This one was causing one hard del on the best scenario, and more than 30 on the worst: either having a botanist growing animals or a xenobiologist growing slimes