### PR TITLE
Fixes Bloodbank powering problems

### DIFF
--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -34,12 +34,12 @@
 /obj/machinery/smartfridge/power_change()
 	if( powered() )
 		stat &= ~NOPOWER
-		set_light(0)
+		set_light(2)
 	else
 		spawn(rand(0, 15))
 		stat |= NOPOWER
 		if(!(stat & BROKEN))
-			set_light(2)
+			set_light(0)
 			
 
 /datum/fridge_pile

--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -27,15 +27,20 @@
 									/obj/item/weapon/reagent_containers/food/snacks/egg,
 									/obj/item/weapon/reagent_containers/food/condiment)
 
-	machine_flags = SCREWTOGGLE | CROWDESTROY | EJECTNOTDEL | WRENCHMOVE
+	machine_flags = SCREWTOGGLE | CROWDESTROY | EJECTNOTDEL | WRENCHMOVE | FIXED2WORK
 
 	light_color = LIGHT_COLOR_CYAN
-	power_change()
-		..()
-		if(!(stat & (BROKEN|NOPOWER)))
+
+/obj/machinery/smartfridge/power_change()
+	if( powered() )
+		stat &= ~NOPOWER
+		set_light(0)
+	else
+		spawn(rand(0, 15))
+		stat |= NOPOWER
+		if(!(stat & BROKEN))
 			set_light(2)
-		else
-			set_light(0)
+			
 
 /datum/fridge_pile
 	var/name = ""
@@ -278,8 +283,7 @@
 		insert_item(new /obj/item/weapon/reagent_containers/blood/OMinus(src))
 		insert_item(new /obj/item/weapon/reagent_containers/blood/empty(src))
 
-
-/obj/machinery/smartfridge/power_change()
+/obj/machinery/smartfridge/bloodbank/power_change()
 	if( powered() )
 		stat &= ~NOPOWER
 		if(!(stat & BROKEN))

--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -37,9 +37,9 @@
 		set_light(2)
 	else
 		spawn(rand(0, 15))
-		stat |= NOPOWER
-		if(!(stat & BROKEN))
-			set_light(0)
+			stat |= NOPOWER
+			if(!(stat & BROKEN))
+				set_light(0)
 			
 
 /datum/fridge_pile

--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -290,9 +290,9 @@
 			icon_state = icon_on
 	else
 		spawn(rand(0, 15))
-		stat |= NOPOWER
-		if(!(stat & BROKEN))
-			icon_state = icon_off
+			stat |= NOPOWER
+			if(!(stat & BROKEN))
+				icon_state = icon_off
 
 /*******************
 *   Item Adding


### PR DESCRIPTION
This is halfway through the bugfix and exploit-fix:
By Bloodbank, I mean in fact, _any smartfridge_.
- you couldn't get the Bloodbank to work in a powered area after moving it out of an unpowered area unless you switched the power on-and-off
- you could drag around the Bloodbank and use it without needing to actually wrench it ; this included dragging the bank from a powered area to an unpowered one

This fixes both behaviours by adding the `FIXED2WORK` flag to the object (I'm not sure *why* it wasn't here in the first place).

:cl:
- bugfix: Fix the Smartfridges not powering themselves after being wrenched from a powerless area to a powered one.
- rscdel: Smartfridges no longer work unwrenched.