### PR TITLE
Randomize shrapnel damage

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -78,11 +78,16 @@
 /obj/item/projectile/bullet/shrapnel/New()
 	..()
 	kill_count = rand(6,10)
+	damage = rand(15,75)
 
 /obj/item/projectile/bullet/shrapnel/small
 
 	name = "small shrapnel"
 	damage = 25
+
+/obj/item/projectile/bullet/shrapnel/small/New()
+	..()
+	damage = rand(5,45)
 
 /obj/item/projectile/bullet/shrapnel/small/plasma
 
@@ -91,6 +96,9 @@
 	color = "#BF5FFF"
 	damage = 35
 
+/obj/item/projectile/bullet/shrapnel/small/plasma/New()
+	..()
+	damage = rand(10,60)
 
 /obj/item/projectile/bullet/midbullet
 	damage = 20


### PR DESCRIPTION
Didn't really fall into the spirit of IED's
Randomized damage and range should make them more unreliable, or more reliable, who knows, they're improvized bombs.

This can let you do enough damage to crit someone in 2 shrapnel shards, or you can survive with 3+ shrapnel shards in you, for more !!FUN!!

Shrapnel: 45 -> 15 - 75 (+/-30)
Small shrapnel: 25 -> 5 - 45 (+/-20)
Plasma shrapnel: 35 -> 10 - 60 (+/-25)

:cl:
tweak: IED shrapnel does random damage now