### PR TITLE
Adds a file which allows VSCode to recommend essential extensions on opening the project.

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+    "recommendations": [
+        "gbasood.byond-dm-language-support",
+        "platymuus.dm-langclient",
+        "EditorConfig.EditorConfig"
+    ]
+}


### PR DESCRIPTION
[system]
The list includes: 
 - DM syntax highlighting extensions
 - DM langclient that gives you the language server
 - Editorconfig because we're not barbarians