### PR TITLE
Bluespace Bananas now Contain honk serum

### DIFF
--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -1183,6 +1183,7 @@
 	plant_dmi = 'icons/obj/hydroponics/bluespacebanana.dmi'
 	products = list(/obj/item/weapon/reagent_containers/food/snacks/grown/bluespacebanana)
 	mutants = null
+	chems = list(BANANA = list(1,10), HONKSERUM = list(1,10))
 
 /datum/seed/corn
 	name = "corn"


### PR DESCRIPTION
Adds honk serum to bluespace bananas, replacing potassium bicarbonate. Mutated botany plants typically have alternative chems within them, and honk serum is a perfectly appropriate mutation reward (in addition to losing your shoes). Also I just want another thing to annoy the fuck out of everyone with.

:cl:
 * tweak : Adds honk serum to bluespace bananas, replacing potassium bicarbonate.

