### PR TITLE
Danger, danger, high voltage

### DIFF
--- a/code/game/objects/items/devices/radio/electropack.dm
+++ b/code/game/objects/items/devices/radio/electropack.dm
@@ -57,6 +57,11 @@
 
 /obj/item/device/radio/electropack/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	..()
+	if (W.is_screwdriver())
+		b_stat = !b_stat
+		if (b_stat)
+			to_chat(user, "<span class='notice'>[src] is now ready to be attached!</span>")
+		return
 	if(istype(W, /obj/item/clothing/head/helmet))
 		if(!b_stat)
 			to_chat(user, "<span class='notice'>[src] is not ready to be attached!</span>")


### PR DESCRIPTION
Electric chairs were bugged in the sense that you couldn't even build electric chairs, because the helmet-electropack assembly couldn't even be correctly prepared in the first place.

I don't know for how long this code existed and if it ever worked at one point in its life.

:cl:
- :bugfix: Using a screwdriver on an electropack will now let you attach a helmet to it. This assembly can then be used to construct an electric chair.