### PR TITLE
Fix non-vox raider return

### DIFF
--- a/code/datums/gamemode/factions/vox_shoal.dm
+++ b/code/datums/gamemode/factions/vox_shoal.dm
@@ -63,6 +63,8 @@ var/list/potential_bonus_items = list(
 	var/list/dept_objective = list()
 	var/list/bonus_items_of_the_day = list()
 
+	var/complete_failure = FALSE // Set to TRUE when a non-raider uses the shuttle to return home.
+
 	var/got_personnel = 0
 	var/got_items = 0
 
@@ -151,8 +153,7 @@ var/list/potential_bonus_items = list(
 					total_points += 500
 			else
 				count_score(H)
-				to_chat(H, "<span class='warning'>You can't really remember the details, but somehow, you managed to escape. Your situation is still far from ideal, however.")
-				H.send_back_to_main_station()
+				H.send_back_to_main_station(complete_failure)
 
 		for (var/obj/structure/closet/loot/L in our_bounty_lockers)
 			for (var/obj/O in L)
@@ -205,7 +206,14 @@ var/list/potential_bonus_items = list(
 
 // -- Mobs procs --
 
-/mob/living/proc/send_back_to_main_station()
+/mob/living/proc/send_back_to_main_station(var/complete_failure = FALSE)
+	if (complete_failure) // Non-vox somehow used the vox shuttle.
+		to_chat(src, "<span class='danger'>After hours of aimlessly wandering through space in hostile Vox territory, the shuttle quickly ran out of fuel. You and your companions decided to abandon the ship and throw escape shelters in the general direction of the station.</span>")	
+		var/obj/structure/inflatable/shelter/S = new(get_turf(src))
+		forceMove(S)
+		S.ThrowAtStation()
+		return
+	to_chat(src, "<span class='warning'>You can't really remember the details, but somehow, you managed to escape. Your situation is still far from ideal, however.</span>")
 	delete_all_equipped_items()
 	if (ishuman(src))
 		var/obj/item/clothing/under/color/grey/G = new(src)
@@ -214,7 +222,7 @@ var/list/potential_bonus_items = list(
 		equip_to_appropriate_slot(B)
 		var/obj/item/device/radio/R = new(src)
 		put_in_hands(R)
-	var/obj/structure/inflatable/shelter/S = new(src)
+	var/obj/structure/inflatable/shelter/S = new(get_turf(src))
 	forceMove(S)
 	S.ThrowAtStation()
 

--- a/code/game/shuttles/vox.dm
+++ b/code/game/shuttles/vox.dm
@@ -77,7 +77,7 @@ var/global/datum/shuttle/vox/vox_shuttle = new(starting_area=/area/shuttle/vox/s
 
 /datum/shuttle/vox/actually_travel_to(var/obj/docking_port/D, var/obj/machinery/computer/shuttle_control/broadcast = null, var/mob/user)
 	. = ..()
-	if (!(user.mind.GetRole(VOXRAIDER)))
+	if (!(user.mind.GetRole(VOXRAIDER)) && (D == dock_home))
 		var/datum/faction/vox_shoal/our_raiders = find_active_faction_by_type(/datum/faction/vox_shoal)
 		our_raiders.complete_failure = TRUE // they completely failed if a non-raider manages to access the shuttle.
 

--- a/code/game/shuttles/vox.dm
+++ b/code/game/shuttles/vox.dm
@@ -75,6 +75,12 @@ var/global/datum/shuttle/vox/vox_shuttle = new(starting_area=/area/shuttle/vox/s
 		returned_home = 1	//If the round type is heist, this will cause the round to end
 							//See code/game/gamemodes/heist/heist.dm, 294
 
+/datum/shuttle/vox/actually_travel_to(var/obj/docking_port/D, var/obj/machinery/computer/shuttle_control/broadcast = null, var/mob/user)
+	. = ..()
+	if (!(user.mind.GetRole(VOXRAIDER)))
+		var/datum/faction/vox_shoal/our_raiders = find_active_faction_by_type(/datum/faction/vox_shoal)
+		our_raiders.complete_failure = TRUE // they completely failed if a non-raider manages to access the shuttle.
+
 /obj/machinery/computer/shuttle_control/vox
 	icon_state = "syndishuttle"
 	allow_silicons = 0


### PR DESCRIPTION
Some things were bugged and the shelter that was supposed to be your taxi to the station didn't spawn properly.

There is a special message if a non-raider managed to hijack the raider shuttle, unfortunatly, there's nothing to actually explore at the vox home base, so it just tells the players that they ran out of fuel and used the escape shelters (vox being too poor for proper pods).

Closes #25922 