### PR TITLE
The secure GPS will now trigger at the end of cult conversion instead of at the beginning

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
@@ -886,9 +886,6 @@
 	flick("rune_convert_start",conversion)
 	playsound(R, 'sound/effects/convert_start.ogg', 75, 0, -4)
 
-	for(var/obj/item/device/gps/secure/SPS in get_contents_in_object(victim))
-		SPS.OnMobDeath(victim)//Think carefully before converting a sec officer
-
 	if (victim.mind)
 		if (victim.mind.assigned_role in impede_medium)
 			to_chat(victim, "<span class='warning'>Your sense of duty impedes down the ritual.</span>")
@@ -1037,6 +1034,9 @@
 			else
 				message_admins("Blood Cult: A conversion ritual occured...but we cannot find the cult faction...")//failsafe in case of admin varedit fuckery
 			cult_risk(activator)//risk of exposing the cult early if too many conversions
+
+		for(var/obj/item/device/gps/secure/SPS in get_contents_in_object(victim)) //Place it here because the conversion ran its course
+			SPS.OnMobDeath(victim)//Think carefully before converting a sec officer
 
 		switch (success)
 			if (CONVERSION_ACCEPT)


### PR DESCRIPTION
This is mostly a change that I had in the backlog, but the quick rundown is that cult has it pretty bad in Act 1 where people with SPS are untouchable (because conversion start activates the SPS alarm) without going out of your way to make it not so (which involves grabbing an EMP or using a soulstone on a dying SPS wearer). The roughly 1-2 minute duration to convert someone (with an implant, that it, all of the default SPS wearers have loyalty implants) not only blew out the cult's cover very early on (in Act 1, in Act 2 they can get an EMP talisman which is fine) but also meant no converted victim. With this change, the alarm happens at the end of conversion, which moves the action from "ends the existence of cult" to "very risky", provided that you and your converted, implantless target can get out of there and leave no trace of what happened. Anyone looking at the SPS during the time the conversion happens can also notice an anomaly when an SPS coordinate stops moving completely.
:cl:
 * tweak: The SPS will now beep at the end of a cult conversion instead of at the start.