### PR TITLE
Fix landmark hard-deleting

### DIFF
--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -9,7 +9,8 @@
 	. = ..()
 	tag = text("landmark*[]", name)
 	invisibility = 101
-
+	landmarks_list += src
+	
 	switch(name)			//some of these are probably obsolete
 		if("shuttle")
 			shuttle_z = z
@@ -89,8 +90,6 @@
 			
 		if("ninjastart")
 			ninjastart += loc
-
-	landmarks_list += src
 	return 1
 
 /obj/effect/landmark/Destroy()

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -10,7 +10,7 @@
 	tag = text("landmark*[]", name)
 	invisibility = 101
 	landmarks_list += src
-	
+
 	switch(name)			//some of these are probably obsolete
 		if("shuttle")
 			shuttle_z = z
@@ -104,7 +104,6 @@
 
 /obj/effect/landmark/start/New()
 	..()
-	tag = "start*[name]"
 	invisibility = 101
 
 	return 1


### PR DESCRIPTION
Closes #26043
Two possible causes:
- it inserted itself in the `landmark_list` AFTER being soft-deleted, resulting in a hoarded reference
- it somehow changed its own 'tag' var, which meant it created a reference to itself, stored in the program, if someone were to make a link point to `[start*start]`

I commited both, tested, and the hard-del seems to be gone.