### PR TITLE
Only one proc to activate away missions

### DIFF
--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -272,7 +272,10 @@ obj/machinery/gateway/centerstation/process()
 			calibrated = 1
 			return
 
-/obj/machinery/gateway/centerstation/attack_ghost(mob/user as mob)
+/obj/machinery/gateway/centerstation/attack_ghost(mob/user)
+	if (isAdminGhost(user) && existing_away_missions.len)
+		admin_active()
+		return
 	return src.Bumped(user)
 
 /obj/machinery/gateway/centeraway/attack_ghost(mob/user as mob)

--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -37,6 +37,12 @@ var/list/gateways = list() //List containing the gateways on away missions
 	var/wait = 0				//this just grabs world.time at world start
 	var/obj/machinery/gateway/centeraway/awaygate = null
 
+/obj/machinery/gateway/centerstation/proc/admin_active()
+	detect()
+	initialize()
+	wait = 0
+	toggleon()
+
 /obj/machinery/gateway/centerstation/initialize()
 	update_icon()
 	wait = world.time + config.gateway_delay	//+ thirty minutes default


### PR DESCRIPTION
Which is prosaically called `admin_active()`