### PR TITLE
Fix traitor reaganomics

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -22,9 +22,8 @@
 	var/autotraitor_cooldown = 450//15 minutes (ticks once per 2 sec)
 
 /datum/dynamic_ruleset/roundstart/traitor/execute()
-
-	var/num_traitors = min(round(mode.roundstart_pop_ready / 10) + 1, candidates.len)
-
+	var/traitor_scaling_coeff = 10 - max(0,round(mode.threat_level/10)-5)//above 50 threat level, coeff goes down by 1 for every 10 levels	
+	var/num_traitors = min(round(mode.roundstart_pop_ready / traitor_scaling_coeff) + 1, candidates.len)
 	for (var/i = 1 to num_traitors)
 		var/mob/M = pick(candidates)
 		assigned += M
@@ -33,10 +32,11 @@
 		newTraitor.AssignToRole(M.mind,1)
 		newTraitor.Greet(GREET_ROUNDSTART)
 		// Above 3 traitors, we start to cost a bit more.
-		if (i > traitor_threshold && (mode.threat > additional_cost))
-			mode.spend_threat(additional_cost)
-		else
-			break
+		if (i > traitor_threshold)
+			if ((mode.threat > additional_cost))
+				mode.spend_threat(additional_cost)
+			else
+				break
 	return 1
 
 /datum/dynamic_ruleset/roundstart/traitor/process()
@@ -113,10 +113,11 @@
 		newVampire.Greet(GREET_MASTER)
 		newVampire.AnnounceObjectives()
 		// Above 2 vampires, we start to cost a bit more.
-		if (i >= 2 && (mode.threat > cost))
-			mode.spend_threat(cost)
-		else
-			break
+		if (i >= 2)
+			if (mode.threat > cost)
+				mode.spend_threat(cost)
+			else
+				break
 	update_faction_icons()
 	return 1
 

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -22,8 +22,9 @@
 	var/autotraitor_cooldown = 450//15 minutes (ticks once per 2 sec)
 
 /datum/dynamic_ruleset/roundstart/traitor/execute()
-	var/traitor_scaling_coeff = 10 - max(0,round(mode.threat_level/10)-5)//above 50 threat level, coeff goes down by 1 for every 10 levels
-	var/num_traitors = min(round(mode.roundstart_pop_ready / traitor_scaling_coeff) + 1, candidates.len)
+
+	var/num_traitors = min(round(mode.roundstart_pop_ready / 10) + 1, candidates.len)
+
 	for (var/i = 1 to num_traitors)
 		var/mob/M = pick(candidates)
 		assigned += M


### PR DESCRIPTION
Fix the bug regarding traitors (1 and only 1 at roundstart)

[bugfix]

:cl:
- bugfix: There should be more than one and only one roundstart traitor now