### PR TITLE
Gamer fixes

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult_items.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_items.dm
@@ -1277,7 +1277,6 @@ var/list/arcane_tomes = list()
 /obj/item/weapon/reagent_containers/food/drinks/cult/gamer
 	name = "gamer goblet"
 	desc = "A plastic cup in the shape of a skull. Typically full of Geometer-Fuel."
-	icon_state = "cult_gamer"
 
 ///////////////////////////////////////BLOOD TESSERACT////////////////////////////////////////////////
 

--- a/code/datums/gamemode/role/streamer.dm
+++ b/code/datums/gamemode/role/streamer.dm
@@ -45,7 +45,7 @@
 		text = {"[show_logo ? "<img src='data:image/png;base64,[icon2base64(logo)]' style='position: relative; top: 10;'/> " : "" ]
 [name] <a href='?_src_=holder;adminplayeropts=\ref[M]'>[key_name(M)]</a>[M.client ? "" : " <i> - (logged out)</i>"][M.stat == DEAD ? " <b><font color=red> - (DEAD)</font></b>" : ""]
  - <a href='?src=\ref[usr];priv_msg=\ref[M]'>(priv msg)</a>
- - <a href='?_src_=holder;traitor=\ref[M]'>(role panel)</a> - <a href='?src=\ref[src]&mind=\ref[antag]&giveblood=1'>Give blood</a>"}
+ - <a href='?_src_=holder;traitor=\ref[M]'>(role panel)</a>"}
 	return text
 
 /datum/role/streamer/ForgeObjectives()

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -51,6 +51,9 @@
 /obj/item/weapon/circuitboard/security/wooden_tv
 	name = "Circuit board (Security Cameras TV)"
 	build_path = /obj/machinery/computer/security/wooden_tv
+/obj/item/weapon/circuitboard/security/spesstv
+	name = "Circuit board (high-definition Spess.TV telescreen)"
+	build_path = /obj/machinery/computer/security/telescreen/entertainment/spesstv/flatscreen
 /obj/item/weapon/circuitboard/security/engineering
 	name = "Circuit board (Engineering Cameras)"
 	desc = "A circuit board for running a computer used for viewing engineering cameras."

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -151,6 +151,7 @@ var/list/obj/machinery/camera/cyborg_cams = list(
 	name = "high-definition Spess.TV telescreen"
 	icon = 'icons/obj/status_display.dmi'
 	icon_state = "entertainment"
+	circuit = /obj/item/weapon/circuitboard/security/spesstv
 
 /obj/machinery/computer/security/telescreen/entertainment/spesstv/flatscreen/New()
 	..()

--- a/code/modules/clothing/accessories/spesstv.dm
+++ b/code/modules/clothing/accessories/spesstv.dm
@@ -4,6 +4,8 @@
 	icon_state = "small_camera" // Credits to https://github.com/discordia-space/CEV-Eris
 	accessory_exclusion = ACCESSORY_LIGHT
 	var/obj/machinery/camera/arena/spesstv/internal_camera
+	origin_tech = Tc_PROGRAMMING + "=2"
+	mech_flags = MECH_SCAN_ILLEGAL
 
 /obj/item/clothing/accessory/spesstv_tactical_camera/New()
 	..()

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -817,6 +817,7 @@
 	_color = "teamsec_light"
 	jersey_overlays = 'icons/mob/uniform_overlays.dmi'
 	clothing_flags = ONESIZEFITSALL
+	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/clothing.dmi', "right_hand" = 'icons/mob/in-hand/right/clothing.dmi')
 
 /obj/item/clothing/under/team_security/dark
 	name = "dark Team Security suit"
@@ -832,6 +833,7 @@
 	_color = "spesstv"
 	jersey_overlays = 'icons/mob/uniform_overlays.dmi'
 	clothing_flags = ONESIZEFITSALL
+	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/clothing.dmi', "right_hand" = 'icons/mob/in-hand/right/clothing.dmi')
 
 /obj/item/clothing/under/team_geometer
 	name = "\improper Team Geometer suit"
@@ -840,6 +842,7 @@
 	_color = "teamgeometer"
 	jersey_overlays = 'icons/mob/uniform_overlays.dmi'
 	clothing_flags = ONESIZEFITSALL
+	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/clothing.dmi', "right_hand" = 'icons/mob/in-hand/right/clothing.dmi')
 
 /obj/item/clothing/under/team_nt
 	name = "\improper NanoTrasen sports suit"
@@ -848,3 +851,4 @@
 	_color = "teamnt"
 	jersey_overlays = 'icons/mob/uniform_overlays.dmi'
 	clothing_flags = ONESIZEFITSALL
+	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/clothing.dmi', "right_hand" = 'icons/mob/in-hand/right/clothing.dmi')

--- a/code/modules/research/mechanic/flatpacker.dm
+++ b/code/modules/research/mechanic/flatpacker.dm
@@ -64,7 +64,7 @@
 	src.overlays -= image(icon = icon, icon_state = "[base_state]_ani")
 	if(being_built)
 		var/obj/structure/closet/crate/flatpack/FP = new
-		FP.insert(being_built)
+		FP.insert_machine(being_built)
 		var/turf/output = get_output()
 		FP.forceMove(get_turf(output))
 		src.visible_message("[bicon(src)] \The [src] beeps: \"Successfully completed \the [being_built.name].\"")


### PR DESCRIPTION
Closes #26086

:cl:
* tweak: Spess.TV telescreens can be cloned by mechanics. Spess.TV tactical cameras can only be scanned by syndicate analysers because they've got DRM.