### PR TITLE
Raises the amount of roundstart cultists back to 4

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -227,7 +227,7 @@
 							"Chief Engineer", "Chief Medical Officer", "Research Director")
 	enemy_jobs = list("Security Officer","Warden", "Detective","Head of Security", "Captain")
 	required_enemies = list(3,3,2,2,2,2,2,1,1,0)
-	required_candidates = 2
+	required_candidates = 4
 	weight = 2
 	cost = 30
 	requirements = list(90,80,60,30,20,10,10,10,10,10)

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -232,7 +232,7 @@
 	cost = 30
 	requirements = list(90,80,60,30,20,10,10,10,10,10)
 	high_population_requirement = 40
-	var/cultist_cap = list(2,2,2,2,2,2,2,2,2,2)
+	var/cultist_cap = list(2,2,3,4,4,4,4,4,4,4)
 	flags = HIGHLANDER_RULESET
 
 /datum/dynamic_ruleset/roundstart/bloodcult/ready(var/forced = 0)

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
@@ -408,7 +408,7 @@
 	while(failsafe < 1000)
 		failsafe++
 		//are our payers still here and about?
-		var/summoners = 1//the higher, the easier it is to perform the ritual without many cultists. default=0
+		var/summoners = 0//the higher, the easier it is to perform the ritual without many cultists. default=0
 		for(var/mob/living/L in contributors)
 			if (iscultist(L) && (L in range(spell_holder,1)) && (L.stat == CONSCIOUS))
 				summoners++


### PR DESCRIPTION
Essentially, reverts #25519 

## Why

- the PR was an attempt at raising the "quality" of cult by removing points of failure (now only two people can draw illegal Ws)
- the PR did not change the frequency of people drawing illegal Ws
- if someone is caught drawing an illegal W, that's already 50% of the cult gone

If we cannot remove cult, then at least let's make it something else than "catch a guy being a shitter and find a way to have the shuttle called" simulator

:cl:
- tweak: The amount of roundstart cultists has been raised back to 4