### PR TITLE
Restricts Vox from Head of Staff positions

### DIFF
--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -591,6 +591,7 @@
 
 	pdaslot=slot_belt
 	pdatype=/obj/item/device/pda/lawyer
+	species_blacklist = list("Vox")
 
 /datum/job/lawyer/equip(var/mob/living/carbon/human/H)
 	if(!H)

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -22,7 +22,7 @@
 
 	pdaslot=slot_l_store
 	pdatype=/obj/item/device/pda/heads/ce
-
+	species_blacklist = list("Vox")
 
 /datum/job/chief_engineer/equip(var/mob/living/carbon/human/H)
 	if(!H)

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -21,6 +21,7 @@
 
 	pdaslot=slot_belt
 	pdatype=/obj/item/device/pda/heads/cmo
+	species_blacklist = list("Vox")
 
 /datum/job/cmo/equip(var/mob/living/carbon/human/H)
 	if(!H)

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -22,6 +22,7 @@
 
 	pdaslot=slot_belt
 	pdatype=/obj/item/device/pda/heads/rd
+	species_blacklist = list("Vox")
 
 /datum/job/rd/equip(var/mob/living/carbon/human/H)
 	if(!H)


### PR DESCRIPTION
Please discuss
Personally I think most alien races shouldn't have head of staff roles citing alien discrimination by a human-dominated station-owning corporation, but you're free to vote for your own reasons
Do NOT merge the PR until the server vote for head of staff vox concludes. Close it if the vote fails at 50/50 or higher negative votes.

:cl:
 * tweak: Vox can no longer be head of staff. That includes Chief Medical Officer, Research Director, Internal Affairs Agent and Chief Engineer.