### PR TITLE
Fixes a few runtimes related to hitmarkers

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -971,7 +971,7 @@
 /atom/proc/do_hitmarker(mob/shooter)
 	spawn()
 		var/datum/role/streamer/streamer_role = shooter?.mind?.GetRole(STREAMER)
-		if(streamer_role?.team == ESPORTS_SECURITY)
+		if(streamer_role && streamer_role.team == ESPORTS_SECURITY)
 			streamer_role.hits += IS_WEEKEND ? 2 : 1
 			streamer_role.update_antag_hud()
 			playsound(src, 'sound/effects/hitmarker.ogg', 100, FALSE)

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -331,6 +331,8 @@ var/list/obj/machinery/camera/cyborg_cams = list(
 	if(usr.incapacitated())
 		return
 	var/obj/machinery/computer/security/telescreen/entertainment/spesstv/tv = target
+	if (!istype(tv))
+		return
 	if(!in_range(tv, usr))
 		return
 	var/obj/machinery/camera/arena/spesstv/camera = tv.current
@@ -348,6 +350,8 @@ var/list/obj/machinery/camera/cyborg_cams = list(
 	if(usr.incapacitated())
 		return
 	var/obj/machinery/computer/security/telescreen/entertainment/spesstv/tv = target
+	if (!istype(tv))
+		return
 	if(!in_range(tv, usr))
 		return
 	var/obj/machinery/camera/arena/spesstv/camera = tv.current


### PR DESCRIPTION
First one :

```
[04:45:49] Runtime in atoms_movable.dm, line 974: Cannot read 0.team
proc name: do hitmarker (/atom/proc/do_hitmarker)
usr: Corp.Jerry (zach666) (/mob/living/silicon/robot/mommi/nt)
usr.loc: The floor (242, 251, 1) (/turf/simulated/floor)
src: Robotics Desk (/obj/machinery/door/window)
src.loc: the floor (242,251,1) (/turf/simulated/floor)
call stack:
Robotics Desk (/obj/machinery/door/window): do hitmarker(Corp.Jerry (/mob/living/silicon/robot/mommi/nt))
```
Which appears to be a byond bug, as there's clearly a `.?` operator to check existence of `streamer_role`, so the code shouldn't execute if `streamer_role = 0`

See http://www.byond.com/forum/post/2558326

Second & third ones :

```
[05:27:54] Runtime in camera.dm, line 337: undefined variable /obj/machinery/camera/var/streamer
proc name: Trigger (/datum/action/camera/follow/Trigger)
usr: Singed Leaves (mastercasual) (/mob/living/carbon/human)
usr.loc: The floor (233, 249, 1) (/turf/simulated/floor)
src: Follow! (/datum/action/camera/follow)
call stack:
Follow! (/datum/action/camera/follow): Trigger()
Follow! (/obj/abstract/screen/movable/action_button): Click(null, "mapwindow.map", "icon-x=25;icon-y=14;left=1;scr...")
Mastercasual (/client): Click(Follow! (/obj/abstract/screen/movable/action_button), null, "mapwindow.map", "icon-x=25;icon-y=14;left=1;scr...")
```

Which I have more trouble to understand. It *seems* that they appear when someone tries to use the button when someone else is using the camera.