### PR TITLE
The ballistic buff and its consequences have been a disaster for ss13

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -8,7 +8,6 @@
 	penetration = 5 //bullets can now by default move through up to 5 windows, or 2 reinforced windows, or 1 plasma window. (reinforced plasma windows still have enough dampening to completely block them)
 	flag = "bullet"
 	fire_sound = 'sound/weapons/Gunshot_smg.ogg'
-	projectile_speed = 0.5
 	var/embed = 1
 	var/embed_message = TRUE
 


### PR DESCRIPTION
## Justification

A little more than a year ago, there's been a PR to drastically buff ballistic-based weapons by making them go faster.

While the PR did achieve its goals, and made using a shotgun, a lawgiver rapid fire mode, much more fun and powerful, it had several unintended effects which dramatically offset the fun they offered

- NT Glocks, from a cheap sidearm you were supposed to use as a last resort or when you had been EMP'd, became the primary weapon of powerbabies because they were, essentially, a hitscan stun which you could follow up lethals, cuffs, or anything you wanted
- Vectors (even after the overpowered ammo type was removed) suffered from the same issue, except they were worse because you could hold more ammunition and switch from stun to lethal
- the dreaded CR-20r, with this ballistic buff, almost single-handily transformed nuke ops from "very powerful enemy, but you can beat them if you're careful enough and coordinate well with the team" to "abandon all hope and just flee while wetting floors behind you"

These three consequences made combat in ss13 (which is already very binary) even less fun in all the encounters where one party used one of these.

This is why I think we should close this parenthesis and find another way to make the shotgun don't miss and feel fun to use.

:cl:

- tweak: The ballistic buff from December 2018 has been reverted. Bullets will now be slower.