### PR TITLE
Allows voice changers to properly mimick robotic voices

### DIFF
--- a/__DEFINES/clothing.dm
+++ b/__DEFINES/clothing.dm
@@ -30,3 +30,8 @@
 #define LT_MODE_FFA "free for all"
 #define LT_FIREMODE_LASER "laser"
 #define LT_FIREMODE_TASER "taser"
+
+// voice changer
+
+#define VOICE_CHANGER_SAYS "says"
+#define VOICE_CHANGER_STATES "states"

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -157,6 +157,9 @@ var/global/lastDecTalkUse = 0
 		return " ([speech.job])"
 	return ""
 
+// This is obsolete for any atom movable which actually uses a language whilst speaking.
+// The verb for those atoms will be given in /datum/language/get_spoken_verb()
+// An override depending on the status of the mob is possible with the proc /mob/proc/get_spoken_verb()
 /atom/movable/proc/say_quote(var/text)
 	if(!text)
 		return "says, \"...\""	//not the best solution, but it will stop a large number of runtimes. The cause is somewhere in the Tcomms code

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -136,7 +136,7 @@
 			to_chat(owner, "<span class='notice'>You will now <i>state</i> things like a machine would.</span>")
 		if (VOICE_CHANGER_STATES)
 			T.speech_mode = VOICE_CHANGER_SAYS
-			to_chat(owner, "<span class='notice'>You will now <i>say</i> things like a machine would.</span>")
+			to_chat(owner, "<span class='notice'>You will now <i>say</i> things like a human would.</span>")
 
 /obj/item/clothing/mask/gas/voice/proc/change()
 	var/choice = input(usr, "Select Form to change it to", "BOOYEA") as null|anything in clothing_choices

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -97,9 +97,10 @@
 	var/mode = 0// 0==Scouter | 1==Night Vision | 2==Thermal | 3==Meson
 	var/voice = "Unknown"
 	var/vchange = 1//This didn't do anything before. It now checks if the mask has special functions/N
+	var/speech_mode = VOICE_CHANGER_SAYS
 	canstage = 0
 	origin_tech = Tc_SYNDICATE + "=4"
-	actions_types = list(/datum/action/item_action/toggle_mask, /datum/action/item_action/change_appearance_mask, /datum/action/item_action/toggle_voicechanger)
+	actions_types = list(/datum/action/item_action/toggle_mask, /datum/action/item_action/change_appearance_mask, /datum/action/item_action/toggle_voicechanger,)
 	species_fit = list(VOX_SHAPED, GREY_SHAPED,INSECT_SHAPED)
 	permeability_coefficient = 0.90
 	var/static/list/clothing_choices
@@ -121,6 +122,21 @@
 	if(!istype(T))
 		return
 	T.change()
+
+/datum/action/item_action/change_voice_mode
+	name = "Change Voice Mode"
+
+/datum/action/item_action/change_voice_mode/Trigger()
+	var/obj/item/clothing/mask/gas/voice/T = target
+	if(!istype(T))
+		return
+	switch (T.speech_mode)
+		if (VOICE_CHANGER_SAYS)
+			T.speech_mode = VOICE_CHANGER_STATES
+			to_chat(owner, "<span class='notice'>You will now <i>state</i> things like a machine would.</span>")
+		if (VOICE_CHANGER_STATES)
+			T.speech_mode = VOICE_CHANGER_SAYS
+			to_chat(owner, "<span class='notice'>You will now <i>say</i> things like a machine would.</span>")
 
 /obj/item/clothing/mask/gas/voice/proc/change()
 	var/choice = input(usr, "Select Form to change it to", "BOOYEA") as null|anything in clothing_choices

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -16,7 +16,10 @@
 	var/list/syllables
 	var/list/space_chance = 55       // Likelihood of getting a space in the random scramble string.
 
-/datum/language/proc/get_spoken_verb(var/msg, var/silicon, var/mode)
+/datum/language/proc/get_spoken_verb(var/msg, var/silicon, var/mode, var/mob/speaker)
+	var/speaker_verb_override = speaker.get_spoken_verb(msg)
+	if (speaker_verb_override)
+		return speaker_verb_override
 	switch(mode)
 		if(SPEECH_MODE_WHISPER)
 			return "[whisper_verb]"
@@ -44,7 +47,7 @@
 
 /datum/language/proc/render_speech(var/datum/speech/speech, var/html_message)
 	// html_message is the message itself + <span> tags. Do NOT filter it.
-	return "[get_spoken_verb(speech.message,issilicon(speech.speaker),speech.mode)], [html_message]"
+	return "[get_spoken_verb(speech.message,issilicon(speech.speaker),speech.mode, speech.speaker)], [html_message]"
 
 /* Obsolete, here for reference
 /datum/language/proc/format_message(mob/M, message)

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -26,7 +26,7 @@
 
 // Use this for an override of the spoken verb.
 /mob/living/carbon/human/get_spoken_verb(var/msg)
-	if(istype(wear_mask, /obj/item/clothing/mask/gas/voice) || istype(wear_mask, /obj/item/clothing/head/cardborg/))
+	if(istype(wear_mask, /obj/item/clothing/mask/gas/voice) || istype(wear_mask, /obj/item/clothing/head/cardborg))
 		if (istype(wear_mask, /obj/item/clothing/mask/gas/voice))
 			var/obj/item/clothing/mask/gas/voice/V = wear_mask
 			if (!(V.vchange) || V.speech_mode == VOICE_CHANGER_SAYS)

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -29,7 +29,7 @@
 	if(istype(wear_mask, /obj/item/clothing/mask/gas/voice) || istype(wear_mask, /obj/item/clothing/head/cardborg/))
 		if (istype(wear_mask, /obj/item/clothing/mask/gas/voice))
 			var/obj/item/clothing/mask/gas/voice/V = wear_mask
-			if (!(V.vchange) || V.speech_mode == SPEECH_MODE_SAYS)
+			if (!(V.vchange) || V.speech_mode == VOICE_CHANGER_SAYS)
 				return ..()
 		var/ending = copytext(msg, length(msg))
 		if (ending == "?")

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -28,7 +28,9 @@
 /mob/living/carbon/human/get_spoken_verb(var/msg)
 	if(istype(wear_mask, /obj/item/clothing/mask/gas/voice) || istype(wear_mask, /obj/item/clothing/head/cardborg/))
 		if (istype(wear_mask, /obj/item/clothing/mask/gas/voice))
+			var/obj/item/clothing/mask/gas/voice/V = wear_mask
 			if (!(V.vchange) || V.speech_mode == SPEECH_MODE_SAYS)
+				return ..()
 		var/ending = copytext(msg, length(msg))
 		if (ending == "?")
 			return "queries"

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -1,6 +1,9 @@
 ///mob/living/carbon/human/say(var/message)
 //	..(message)
 
+// This is obsolete if the human is using a language.
+// Verbs in such a situation are given in /datum/language/get_spoken_verb().
+// The proc get_spoken_verb(var/msg) allows you to override the spoken verb depending on the mob.
 /mob/living/carbon/human/say_quote(text)
 	if(!text)
 		return "says, \"...\"";	//not the best solution, but it will stop a large number of runtimes. The cause is somewhere in the Tcomms code
@@ -20,6 +23,20 @@
 //		return "[dna.species.say_mod], \"[text]\"";
 
 	return "says, [text]";
+
+// Use this for an override of the spoken verb.
+/mob/living/carbon/human/get_spoken_verb(var/msg)
+	if(istype(wear_mask, /obj/item/clothing/mask/gas/voice))
+		var/obj/item/clothing/mask/gas/voice/V = wear_mask
+		if (V.vchange && V.speech_mode == VOICE_CHANGER_STATES)
+			var/ending = copytext(msg, length(msg))
+			if (ending == "?")
+				return "queries"
+			if (ending == "!")
+				return "declares"
+			return "states"
+
+	return ..()
 
 /mob/living/carbon/human/treat_speech(var/datum/speech/speech, var/genesay=0)
 	if ((M_HULK in mutations) && health >= 25 && length(speech.message))

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -26,15 +26,15 @@
 
 // Use this for an override of the spoken verb.
 /mob/living/carbon/human/get_spoken_verb(var/msg)
-	if(istype(wear_mask, /obj/item/clothing/mask/gas/voice))
-		var/obj/item/clothing/mask/gas/voice/V = wear_mask
-		if (V.vchange && V.speech_mode == VOICE_CHANGER_STATES)
-			var/ending = copytext(msg, length(msg))
-			if (ending == "?")
-				return "queries"
-			if (ending == "!")
-				return "declares"
-			return "states"
+	if(istype(wear_mask, /obj/item/clothing/mask/gas/voice) || istype(wear_mask, /obj/item/clothing/head/cardborg/))
+		if (istype(wear_mask, /obj/item/clothing/mask/gas/voice))
+			if (!(V.vchange) || V.speech_mode == SPEECH_MODE_SAYS)
+		var/ending = copytext(msg, length(msg))
+		if (ending == "?")
+			return "queries"
+		if (ending == "!")
+			return "declares"
+		return "states"
 
 	return ..()
 

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -501,11 +501,23 @@ var/list/department_radio_keys = list(
 		if(setting == 2)
 			return 1
 
+// Obsolete for any mob which uses a language.
 /mob/living/say_quote()
 	if (stuttering)
 		return "stammers, [text]"
 	if (getBrainLoss() >= 60)
 		return "gibbers, [text]"
+	return ..()
+
+// Use this when the mob speaks a given language.
+/mob/proc/get_spoken_verb(var/msg)
+	return ""
+
+/mob/living/get_spoken_verb(var/msg)
+	if (stuttering)
+		return "stammers"
+	if (getBrainLoss() >= 60)
+		return "gibbers"
 	return ..()
 
 /mob/living/proc/send_speech_bubble(var/message,var/bubble_type, var/list/hearers)


### PR DESCRIPTION
Say code is a mess. Half of the procs in its `readme` aren't even used anymore except in the very edge case the mob doesn't speak a language.

This PR fixes that by adding helpful documentation so that future coders (if they even exist) won't be as confused as I was.

It also allows people wearing a voice changer to properly mimic silicons.

[bugfix]
:cl:
- rscadd: The syndicate voice changer can now properly mimic silicons.