### PR TITLE
Dynamic has been unleashed

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets.dm
@@ -97,13 +97,13 @@
 			if (M.mind && M.mind.assigned_role && (M.mind.assigned_role in enemy_jobs) && (!(M in candidates) || (M.mind.assigned_role in restricted_from_jobs)))
 				enemies_count++//checking for "enemies" (such as sec officers). To be counters, they must either not be candidates to that rule, or have a job that restricts them from it
 
-	var/pop_and_ennemies = mode.living_players.len + enemies_count // Ennemies count twice
+	var/pop_and_enemies = mode.living_players.len + enemies_count // Enemies count twice
 
 	var/threat = round(mode.threat_level/10)
-	if (pop_and_ennemies >= required_pop[threat])
+	if (pop_and_enemies >= required_pop[threat])
 		return TRUE
 	if (!dead_dont_count)//roundstart check only
-		message_admins("Dynamic Mode: Despite [name] having enough candidates, there are not enough poo and enemy jobs ready ([enemies_count] and [mode.living_players.len] out of [required_pop[threat]])")
+		message_admins("Dynamic Mode: Despite [name] having enough candidates, there are not enough pop and enemy jobs ready ([enemies_count] and [mode.living_players.len] out of [required_pop[threat]])")
 		log_admin("Dynamic Mode: Despite [name] having enough candidates, there are not enough enemy jobs ready ([enemies_count] and [mode.living_players.len] out of [required_pop[threat]])")
 	return FALSE
 

--- a/code/datums/gamemode/dynamic/dynamic_rulesets.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets.dm
@@ -10,7 +10,7 @@
 	var/list/exclusive_to_jobs = list()//if set, rule will only accept candidates from those jobs
 	var/list/job_priority = list() //May be used by progressive_job_search for prioritizing some jobs for a role. Order matters.
 	var/list/enemy_jobs = list()//if set, there needs to be a certain amount of players doing those jobs (among the players who won't be drafted) for the rule to be drafted
-	var/required_enemies = list(1,1,0,0,0,0,0,0,0,0)//if enemy_jobs was set, this is the amount of enemy job workers needed per threat_level range (0-10,10-20,etc)
+	var/required_pop = list(10,10,0,0,0,0,0,0,0,0)//if enemy_jobs was set, this is the amount of population required for the ruleset to fire. enemy jobs count double
 	var/required_candidates = 0//the rule needs this many candidates (post-trimming) to be executed (example: Cult need 4 players at round start)
 	var/weight = 5//1 -> 9, probability for this rule to be picked against other rules
 	var/cost = 0//threat cost for this rule.
@@ -80,7 +80,7 @@
 		return 0
 	return 1
 
-// Returns TRUE if there are sufficient enemies to execute this ruleset
+// Returns TRUE if there is enough pop to execute this ruleset
 /datum/dynamic_ruleset/proc/check_enemy_jobs(var/dead_dont_count = FALSE)
 	if (!enemy_jobs.len)
 		return TRUE
@@ -97,12 +97,14 @@
 			if (M.mind && M.mind.assigned_role && (M.mind.assigned_role in enemy_jobs) && (!(M in candidates) || (M.mind.assigned_role in restricted_from_jobs)))
 				enemies_count++//checking for "enemies" (such as sec officers). To be counters, they must either not be candidates to that rule, or have a job that restricts them from it
 
+	var/pop_and_ennemies = mode.living_players.len + enemies_count // Ennemies count twice
+
 	var/threat = round(mode.threat_level/10)
-	if (enemies_count >= required_enemies[threat])
+	if (pop_and_ennemies >= required_pop[threat])
 		return TRUE
 	if (!dead_dont_count)//roundstart check only
-		message_admins("Dynamic Mode: Despite [name] having enough candidates, there are not enough enemy jobs ready ([enemies_count] out of [required_enemies[threat]])")
-		log_admin("Dynamic Mode: Despite [name] having enough candidates, there are not enough enemy jobs ready ([enemies_count] out of [required_enemies[threat]])")
+		message_admins("Dynamic Mode: Despite [name] having enough candidates, there are not enough poo and enemy jobs ready ([enemies_count] and [mode.living_players.len] out of [required_pop[threat]])")
+		log_admin("Dynamic Mode: Despite [name] having enough candidates, there are not enough enemy jobs ready ([enemies_count] and [mode.living_players.len] out of [required_pop[threat]])")
 	return FALSE
 
 /datum/dynamic_ruleset/proc/get_weight()

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
@@ -73,7 +73,7 @@
 	name = "Ragin' Mages"
 	role_category = /datum/role/wizard
 	enemy_jobs = list("Security Officer","Detective", "Warden", "Head of Security", "Captain")
-	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
+	required_pop = list(15,15,10,10,10,10,10,0,0,0)
 	required_candidates = 1
 	weight = 1
 	cost = 20
@@ -114,7 +114,7 @@
 	name = "Space Ninja Attack"
 	role_category = /datum/role/ninja
 	enemy_jobs = list("Security Officer","Detective", "Warden", "Head of Security", "Captain")
-	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
+	required_pop = list(15,15,10,10,10,10,10,0,0,0)
 	required_candidates = 1
 	weight = 3
 	cost = 20
@@ -154,7 +154,7 @@
 	role_category = /datum/role/revolutionary
 	restricted_from_jobs = list("Merchant","AI", "Cyborg", "Mobile MMI", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Chief Medical Officer", "Research Director", "Internal Affairs Agent")
 	enemy_jobs = list("AI", "Cyborg", "Security Officer","Detective","Head of Security", "Captain", "Warden")
-	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
+	required_pop = list(20,20,15,15,15,15,15,0,0,0)
 	required_candidates = 1
 	weight = 2
 	cost = 20

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -230,7 +230,7 @@
 	role_category = /datum/role/malfAI
 	enemy_jobs = list("Security Officer", "Warden","Detective","Head of Security", "Captain", "Scientist", "Chemist", "Research Director", "Chief Engineer")
 	exclusive_to_jobs = list("AI")
-	required_enemies = list(3,3,3,2,2,2,1,1,1,1)
+	required_pop = list(25,25,25,20,20,20,15,15,15,15)
 	required_candidates = 1
 	weight = 1
 	cost = 35
@@ -281,7 +281,7 @@
 	role_category = /datum/role/wizard
 	my_fac = /datum/faction/wizard
 	enemy_jobs = list("Security Officer","Detective","Head of Security", "Captain")
-	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
+	required_pop = list(20,20,15,15,15,15,15,10,10,0)
 	required_candidates = 1
 	weight = 1
 	cost = 20
@@ -322,7 +322,7 @@
 	role_category = /datum/role/nuclear_operative
 	my_fac = /datum/faction/syndicate/nuke_op/
 	enemy_jobs = list("AI", "Cyborg", "Security Officer", "Warden","Detective","Head of Security", "Captain")
-	required_enemies = list(3, 3, 3, 3, 3, 2, 1, 1, 0, 0)
+	required_pop = list(25, 25, 25, 25, 25, 20, 15, 15, 10, 10)
 	required_candidates = 5
 	weight = 5
 	cost = 35
@@ -360,7 +360,7 @@
 	role_category = /datum/role/blob_overmind/
 	my_fac = /datum/faction/blob_conglomerate/
 	enemy_jobs = list("AI", "Cyborg", "Security Officer", "Station Engineer","Chief Engineer", "Roboticist","Head of Security", "Captain")
-	required_enemies = list(3,2,2,1,1,1,0,0,0,0)
+	required_pop = list(25,20,20,15,15,15,10,10,10,10)
 	required_candidates = 1
 	weight = 2
 	cost = 30
@@ -396,7 +396,7 @@
 	name = "Revolutionary Squad"
 	role_category = /datum/role/revolutionary/leader
 	enemy_jobs = list("AI", "Cyborg", "Security Officer", "Warden","Detective","Head of Security", "Captain")
-	required_enemies = list(3,3,3,3,3,2,1,1,0,0)
+	required_pop = list(25,25,25,25,25,20,15,15,10,10)
 	required_candidates = 3
 	weight = 5
 	cost = 45
@@ -434,7 +434,7 @@
 	name = "Space Ninja Attack"
 	role_category = /datum/role/ninja
 	enemy_jobs = list("Security Officer","Detective", "Warden", "Head of Security", "Captain")
-	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
+	required_pop = list(15,15,15,15,15,10,10,10,5,5)
 	required_candidates = 1
 	weight = 3
 	cost = 20
@@ -470,7 +470,7 @@
 	name = "Soul Rambler Migration"
 	role_category = /datum/role/rambler
 	enemy_jobs = list("Librarian","Detective", "Chaplain", "Internal Affairs Agent")
-	required_enemies = list(0,0,1,1,2,2,3,3,3,4)
+	required_pop = list(0,0,10,10,15,15,20,20,20,25)
 	required_candidates = 1
 	weight = 1
 	cost = 5
@@ -507,7 +507,7 @@
 	role_category = /datum/role/grinch
 	restricted_from_jobs = list()
 	enemy_jobs = list()
-	required_enemies = list(0,0,0,0,0,0,0,0,0,0)
+	required_pop = list(0,0,0,0,0,0,0,0,0,0)
 	required_candidates = 1
 	weight = 3
 	cost = 10
@@ -564,7 +564,7 @@
 	role_category = /datum/role/vox_raider
 	my_fac = /datum/faction/vox_shoal
 	enemy_jobs = list("AI", "Cyborg", "Security Officer", "Warden","Detective","Head of Security", "Captain")
-	required_enemies = list(2,2,2,1,1,1,1,1,0,0)
+	required_pop = list(20,20,20,15,15,15,15,15,10,10)
 	required_candidates = 5
 	weight = 5
 	cost = 30
@@ -606,7 +606,7 @@
 	name = "Plague Mice Invasion"
 	role_category = /datum/role/plague_mouse
 	enemy_jobs = list("Chief Medical Officer", "Medical Doctor", "Virologist")
-	required_enemies = list(2,2,2,2,2,2,2,2,2,2)
+	required_pop = list(15,15,15,15,15,15,15,15,15,15)
 	required_candidates = 1
 	max_candidates = 5
 	weight = 5

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -54,7 +54,7 @@
 							"Head of Security", "Captain", "Chief Engineer", "Chief Medical Officer", "Research Director")
 	restricted_from_jobs = list("AI","Cyborg","Mobile MMI")
 	enemy_jobs = list("Security Officer","Detective", "Warden", "Head of Security", "Captain")
-	required_enemies = list(2,2,2,1,1,1,1,0,0,0)
+	required_pop = list(15,15,15,10,10,10,10,5,5,0)
 	required_candidates = 1
 	weight = 3
 	cost = 18
@@ -86,7 +86,7 @@
 							"Head of Security", "Captain", "Chief Engineer", "Chief Medical Officer", "Research Director")
 	restricted_from_jobs = list("AI","Cyborg","Mobile MMI", "Chaplain")
 	enemy_jobs = list("Security Officer","Detective", "Warden", "Head of Security", "Captain", "Chaplain")
-	required_enemies = list(2,2,2,1,1,1,1,0,0,0)
+	required_pop = list(15,15,15,10,10,10,10,5,5,0)
 	required_candidates = 1
 	weight = 2
 	cost = 15
@@ -124,7 +124,7 @@
 	role_category = /datum/role/wizard
 	restricted_from_jobs = list("Head of Security", "Captain")//just to be sure that a wizard getting picked won't ever imply a Captain or HoS not getting drafted
 	enemy_jobs = list("Security Officer","Detective","Head of Security", "Captain")
-	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
+	required_pop = list(15,15,15,10,10,10,10,5,5,0)
 	required_candidates = 1
 	weight = 3
 	cost = 30
@@ -165,7 +165,7 @@
 	role_category = /datum/role/wizard
 	restricted_from_jobs = list("Head of Security", "Captain")//just to be sure that a wizard getting picked won't ever imply a Captain or HoS not getting drafted
 	enemy_jobs = list("Security Officer","Detective","Warden","Head of Security", "Captain")
-	required_enemies = list(3,3,2,2,2,2,2,1,1,0)
+	required_pop = list(25,25,20,20,20,20,15,15,15,5)
 	required_candidates = 1
 	weight = 2
 	cost = 45
@@ -219,7 +219,7 @@
 							"Head of Security", "Captain", "Chaplain", "Head of Personnel", "Internal Affairs Agent",
 							"Chief Engineer", "Chief Medical Officer", "Research Director")
 	enemy_jobs = list("Security Officer","Warden", "Detective","Head of Security", "Captain")
-	required_enemies = list(3,3,2,2,2,2,2,1,1,0)
+	required_pop = list(25,25,20,20,20,20,20,15,15,10)
 	required_candidates = 4
 	weight = 2
 	cost = 30
@@ -268,7 +268,7 @@
 	protected_from_jobs = list("Merchant")
 	restricted_from_jobs = list("AI", "Cyborg", "Mobile MMI", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Chaplain", "Head of Personnel", "Internal Affairs Agent", "Chaplain")
 	enemy_jobs = list("AI", "Cyborg", "Security Officer","Detective","Head of Security", "Captain", "Chaplain")
-	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
+	required_pop = list(25,25,20,20,20,20,20,15,15,10)
 	required_candidates = 4
 	weight = 3
 	cost = 25
@@ -305,7 +305,7 @@
 	role_category = /datum/role/nuclear_operative
 	restricted_from_jobs = list("Head of Security", "Captain") //Just to be sure that a nukie getting picked won't ever imply a Captain or HoS not getting drafted
 	enemy_jobs = list("AI", "Cyborg", "Security Officer", "Warden","Detective","Head of Security", "Captain")
-	required_enemies = list(3, 3, 3, 3, 3, 2, 1, 1, 0, 0)
+	required_pop = list(25, 25, 25, 25, 25, 20, 15, 15, 10, 10)
 	required_candidates = 5 //This value is useless, see operative_cap
 	weight = 3
 	cost = 40
@@ -360,7 +360,7 @@
 	enemy_jobs = list("Security Officer", "Warden","Detective","Head of Security", "Captain", "Scientist", "Chemist", "Research Director", "Chief Engineer")
 	restricted_from_jobs = list("Security Officer", "Warden","Detective","Head of Security", "Captain", "Research Director", "Chief Engineer")
 	job_priority = list("AI","Cyborg")
-	required_enemies = list(3,3,3,2,2,2,1,1,1,1)
+	required_pop = list(25,25,25,20,20,20,15,15,15,15)
 	required_candidates = 1
 	weight = 2
 	cost = 40
@@ -418,7 +418,7 @@
 	role_category = /datum/role/blob_overmind/
 	restricted_from_jobs = list("AI", "Cyborg", "Mobile MMI", "Security Officer", "Warden","Detective","Head of Security", "Captain", "Head of Personnel")
 	enemy_jobs = list("AI", "Cyborg", "Security Officer", "Warden","Detective","Head of Security", "Captain")
-	required_enemies = list(3,3,3,3,3,2,1,1,0,0)
+	required_pop = list(30,25,25,20,20,20,15,15,15,15)
 	required_candidates = 1
 	weight = 3
 	cost = 45
@@ -457,7 +457,7 @@
 	role_category = null
 	restricted_from_jobs = list()
 	enemy_jobs = list()
-	required_enemies = list(0,0,0,0,0,0,0,0,0,0)
+	required_pop = list(0,0,0,0,0,0,0,0,0,0)
 	required_candidates = 0
 	weight = 3
 	cost = 0
@@ -480,7 +480,7 @@
 	role_category = /datum/role/revolutionary
 	restricted_from_jobs = list("Merchant","AI", "Cyborg", "Mobile MMI", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Chief Medical Officer", "Research Director", "Internal Affairs Agent")
 	enemy_jobs = list("Security Officer","Detective","Head of Security", "Captain", "Warden")
-	required_enemies = list(3,3,3,3,3,2,2,1,0,0)
+	required_pop = list(25,25,25,20,20,20,15,15,15,15)
 	required_candidates = 3
 	weight = 2
 	cost = 40
@@ -533,7 +533,7 @@
 	role_category = /datum/role/grinch
 	restricted_from_jobs = list()
 	enemy_jobs = list()
-	required_enemies = list(0,0,0,0,0,0,0,0,0,0)
+	required_pop = list(0,0,0,0,0,0,0,0,0,0)
 	required_candidates = 1
 	weight = 3
 	cost = 10


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/31417754/78659538-fdcd3600-78cb-11ea-8bf9-a8a2bee5c154.png)

Remove the hard dependency of dynamic on sec population count and replace it with a player count (which is how ye old secret did it). The higher the threat, the *less* pop is needed for dangerous rulesets.

Enemies job count twice for those rulesets. This means that a station with only 21 pop roundstart, but 3 officers and an HoS, can get nuke ops.

[balance] [gamemode] [FUCK dynamic]

:cl: 
- tweak: Dynamic mode will no longer look at the security player count but rather the global player count for executing rulesets.