### PR TITLE
Fixed unbuckling while handcuffed not working

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -64,7 +64,7 @@
 	manual_unbuckle(usr)
 
 /obj/structure/bed/proc/manual_unbuckle(var/mob/user)
-	if(user.incapacitated())
+	if(user.isStunned())
 		return FALSE
 
 	if(user.size <= SIZE_TINY)


### PR DESCRIPTION
Closes #26134

please subscribe to my patreon
[![Patreon](https://c5.patreon.com/external/logo/become_a_patron_button.png)](https://www.patreon.com/damianspessmen)
:cl:
 * bugfix: Fixed a bug that prevented handcuffed people from unbuckling themselves from chairs.