### PR TITLE
Fixed EMP'd AI shuttle call and more

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -212,9 +212,7 @@ var/list/shuttle_log = list()
 					return
 				var/response = alert("Are you sure you wish to call the shuttle?", "Confirm", "Yes", "Cancel")
 				if(response == "Yes")
-					if(call_shuttle_proc(usr, justification))
-						if(!isobserver(usr))
-							shuttle_log += "\[[worldtime2text()]] Called from [get_area(usr)]."
+					call_shuttle_proc(usr, justification)
 					if(emergency_shuttle.online)
 						post_status("shuttle")
 			setMenuState(usr,COMM_SCREEN_MAIN)
@@ -558,6 +556,8 @@ var/list/shuttle_log = list()
 	emergency_shuttle.incall()
 	if(!justification)
 		justification = "#??!7E/_1$*/ARR-CON�FAIL!!*$^?" //Can happen for reasons, let's deal with it IC
+	if(!isobserver(user))
+		shuttle_log += "\[[worldtime2text()]] Called from [get_area(user)]."
 	log_game("[key_name(user)] has called the shuttle. Justification given : '[justification]'")
 	message_admins("[key_name_admin(user)] has called the shuttle. Justification given : '[justification]'.", 1)
 	captain_announce("The emergency shuttle has been called. It will arrive in [round(emergency_shuttle.timeleft()/60)] minutes. Justification : '[justification]'")

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -353,9 +353,7 @@ var/list/ai_list = list()
 		return
 	var/confirm = alert("Are you sure you want to call the shuttle?", "Confirm Shuttle Call", "Yes", "Cancel")
 	if(confirm == "Yes")
-		if(call_shuttle_proc(src, justification))
-			if(!isobserver(usr))
-				shuttle_log += "\[[worldtime2text()]] Called from [get_area(usr)]."
+		call_shuttle_proc(src, justification)
 
 	// hack to display shuttle timer
 	if(emergency_shuttle.online)
@@ -409,7 +407,8 @@ var/list/ai_list = list()
 			if(1)
 				view_core()
 			if(2)
-				ai_call_shuttle()
+				if(call_shuttle_proc(src))
+					message_admins("[key_name_admin(src)] called the shuttle due to being hit with an EMP.'.")
 	..()
 
 /mob/living/silicon/ai/ex_act(severity)


### PR DESCRIPTION
Closes #14720, also improved logging

[![Patreon](https://c5.patreon.com/external/logo/become_a_patron_button.png)](https://www.patreon.com/damianspessmen)

:cl:
 * bugfix: Fixed a bug that caused shooting an AI with EMPs to open a popup to call the shuttle.
 * bugfix: Fixed a bug that caused entries to be added to the communication's console shuttle log when the shuttle wasn't actually called.