### PR TITLE
Table slight rework

### DIFF
--- a/code/game/objects/items/weapons/table_rack_parts.dm
+++ b/code/game/objects/items/weapons/table_rack_parts.dm
@@ -58,14 +58,28 @@
 			to_chat(user, "<span class='notice'>You add plasma glass panes to \the [name].</span>")
 			plasma.use(1)
 			qdel(src)
-/obj/item/weapon/table_parts/attack_self(mob/user)
-	if(locate(/obj/structure/table) in get_turf(user))
+
+//All of these return 1 because we aren't attacking people or objects with table parts
+/obj/item/weapon/table_parts/preattack(target, mob/user, proximity_flag, click_parameters)
+	. = 1
+	if(!proximity_flag)
+		return
+	if(!isturf(target))
+		return
+	var/turf/T = target //I could've just used var/turf/T at the top but it would runtime and you could place items inside objects
+	if(locate(/obj/structure/table) in T) //There is a table, don't do it
 		to_chat(user, "<span class='warning'>There is already a table here!</span>")
 		return
-
-	new table_type(user.loc)
+	if(locate(/mob/living) in T) //Don't build tables on top of anyone, otherwise they can walk over other tables
+		to_chat(user, "<span class='warning'>You can't build a table on top of beings!</span>")
+		return
+	if(T.density) //Don't build into walls, airlocks or anywhere that just can't be passed over
+		to_chat(user, "<span class='warning'>You can't build a table there!</span>")
+		return
+	new table_type(T)
 	user.drop_item(src, force_drop = 1)
 	qdel(src)
+	return
 
 /obj/item/weapon/table_parts/clockworkify()
 	GENERIC_CLOCKWORK_CONVERSION(src, /obj/item/weapon/table_parts/clockwork, CLOCKWORK_GENERIC_GLOW)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -306,6 +306,8 @@
 		var/mob/M = mover
 		if(M.flying)
 			return 1
+		if(istype(M.loc, /obj/structure/table))
+			return 1
 	if(istype(mover) && mover.checkpass(PASSTABLE))
 		return 1
 	if(flipped)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -306,7 +306,8 @@
 		var/mob/M = mover
 		if(M.flying)
 			return 1
-		if(istype(M.loc, /obj/structure/table))
+		var/obj/structure/table/t = locate() in M.loc
+		if(t)
 			return 1
 	if(istype(mover) && mover.checkpass(PASSTABLE))
 		return 1


### PR DESCRIPTION
Thanks to @PJB3005 for helping!
Tables have been slightly reworked

- **Instead of building tables on top of you, you must build tables by clicking adjacent tiles**

This will allow for easier creation of tables for stuff like machineries, wanted that microwave on the table? Now you can do it. The side-effect is that it will prevent a powergaming method caused by the following feature addition:
-Added a feature where you can move across tables. This used to be a problematic feature because it could allow people to build tables on top of themselves to get on top of nearby tables.

:cl:
 * rscadd: Tables have been slightly reworked. You can no longer build them on your position, instead you must click adjacent tiles with table parts to build tables. Now you can place a table where you would want the microwave to be on top of!
 * rscadd: You can now actually move on tables if you're on a table.