### PR TITLE
Removes autoborger cooldown

### DIFF
--- a/code/game/machinery/autoborger.dm
+++ b/code/game/machinery/autoborger.dm
@@ -3,7 +3,7 @@
 
 /obj/machinery/autoborger
 	name = "Automatic Robotic Factory 5000"
-	desc = "A large metallic machine with an entrance and an exit. A sign on the side reads 'human goes in, robot comes out'. Human must be lying down and alive. Has to cooldown between each use."
+	desc = "A large metallic machine with an entrance and an exit. A sign on the side reads 'human goes in, robot comes out'. Human must be lying down and alive."
 	icon = 'icons/obj/recycling.dmi'
 	icon_state = "separator-AO1"
 	plane = ABOVE_HUMAN_PLANE
@@ -11,9 +11,6 @@
 	density = 1
 	var/transform_dead = 0 //This variable doesn't seem to do anything
 	var/transform_standing = 0
-	var/cooldown_duration = 900 // 1.5 minutes
-	var/cooldown_time = 0
-	var/cooldown_state = 0 // Just for icons.
 	var/robot_cell_charge = 5000
 	use_power = 1
 	idle_power_usage = 10
@@ -36,15 +33,12 @@
 
 /obj/machinery/autoborger/update_icon()
 	..()
-	if(stat & (BROKEN|NOPOWER) || cooldown_time > world.time)
+	if(stat & (BROKEN|NOPOWER))
 		icon_state = "separator-AO0"
 	else
 		icon_state = initial(icon_state)
 
 /obj/machinery/autoborger/Bumped(var/atom/movable/AM)
-	if(cooldown_state)
-		return
-
 	// Crossed didn't like people lying down.
 	if(ishuman(AM))
 		// Only humans can enter from the west side, while lying down.
@@ -61,8 +55,6 @@
 
 /obj/machinery/autoborger/proc/do_transform(var/mob/living/carbon/human/H)
 	if(stat & (BROKEN|NOPOWER))
-		return
-	if(cooldown_state)
 		return
 
 	if(!transform_dead && H.stat == DEAD)
@@ -118,19 +110,7 @@
 		if(R)
 			R.SetKnockdown(0)
 
-	// Activate the cooldown
-	cooldown_time = world.time + cooldown_duration
-	cooldown_state = 1
 	update_icon()
-
-/obj/machinery/autoborger/process()
-	..()
-	var/old_cooldown_state=cooldown_state
-	cooldown_state = cooldown_time > world.time
-	if(cooldown_state!=old_cooldown_state)
-		update_icon()
-		if(!cooldown_state)
-			playsound(src, 'sound/machines/ping.ogg', 50, 0)
 
 /obj/machinery/autoborger/conveyor/New()
 	..()
@@ -153,10 +133,7 @@
 
 /obj/machinery/autoborger/interact(var/mob/user)
 	var/data=""
-	if(cooldown_state)
-		data += {"<b>Recalibrating.</b> Time left: [(cooldown_time - world.time)/10] seconds."}
-	else
-		data += {"<p style="color:red;font-weight:bold;"><blink>ROBOTICIZER ACTIVE.</blink></p>"}
+	data += {"<p style="color:red;font-weight:bold;"><blink>ROBOTICIZER ACTIVE.</blink></p>"}
 	data += {"
 		<h2>Settings</h2>
 		<ul>


### PR DESCRIPTION
The autoburger is pretty bad because it disables the jaunt function and takes up all points in exchange of making borgs with only 5k battery power and too much time between borg conversions, in a gamemode where borgs are extremely susceptible to just being detonated remotely, and the AI can't really destroy the robot control console because it can't buy the machine detonation ability to destroy the console.

:cl:
 * tweak: The malf AI autoborger no longer has a cooldown between borg conversions