### PR TITLE
Mixed Gas Miners

### DIFF
--- a/code/game/machinery/atmoalter/gas_mine.dm
+++ b/code/game/machinery/atmoalter/gas_mine.dm
@@ -122,8 +122,9 @@
 		loc.assume_air(removed)
 
 
-/obj/machinery/atmospherics/miner/proc/AirRate(datum/gas)
-	air_contents.adjust_gas(gas, internal_pressure * air_contents.volume / (R_IDEAL_GAS_EQUATION * air_contents.temperature))
+//Controls how fast gas comes out (in total)
+/obj/machinery/atmospherics/miner/proc/AirRate()
+  return internal_pressure * air_contents.volume / (R_IDEAL_GAS_EQUATION * air_contents.temperature)
 
 
 /obj/machinery/atmospherics/miner/sleeping_agent
@@ -131,7 +132,8 @@
 	overlay_color = "#FFCCCC"
 
 /obj/machinery/atmospherics/miner/sleeping_agent/AddAir()
-	AirRate(GAS_SLEEPING)
+	var/rate = AirRate()
+	air_contents.adjust_multi(GAS_SLEEPING, rate)
 
 
 /obj/machinery/atmospherics/miner/nitrogen
@@ -139,7 +141,8 @@
 	overlay_color = "#CCFFCC"
 
 /obj/machinery/atmospherics/miner/nitrogen/AddAir()
-	AirRate(GAS_NITROGEN)
+	var/rate = AirRate()
+	air_contents.adjust_multi(GAS_NITROGEN, rate)
 
 
 /obj/machinery/atmospherics/miner/oxygen
@@ -147,7 +150,8 @@
 	overlay_color = "#007FFF"
 
 /obj/machinery/atmospherics/miner/oxygen/AddAir()
-	AirRate(GAS_OXYGEN)
+	var/rate = AirRate()
+	air_contents.adjust_multi(GAS_OXYGEN, rate)
 
 
 /obj/machinery/atmospherics/miner/toxins
@@ -155,7 +159,8 @@
 	overlay_color = "#FF0000"
 
 /obj/machinery/atmospherics/miner/toxins/AddAir()
-	AirRate(GAS_PLASMA)
+	var/rate = AirRate()
+	air_contents.adjust_multi(GAS_PLASMA, rate)
 
 
 /obj/machinery/atmospherics/miner/carbon_dioxide
@@ -163,7 +168,8 @@
 	overlay_color = "#CDCDCD"
 
 /obj/machinery/atmospherics/miner/carbon_dioxide/AddAir()
-	AirRate(GAS_CARBON)
+	var/rate = AirRate()
+	air_contents.adjust_multi(GAS_CARBON, rate)
 
 
 /obj/machinery/atmospherics/miner/air
@@ -174,8 +180,9 @@
 	on = 0
 
 /obj/machinery/atmospherics/miner/air/AddAir()
-	AirRate(GAS_OXYGEN)
-	AirRate(GAS_NITROGEN)
+	var/rate = AirRate()
+	air_contents.adjust_multi(GAS_OXYGEN, 0.2*rate,
+	GAS_NITROGEN, 0.8*rate)
 
 
 /obj/machinery/atmospherics/miner/gas_giant
@@ -196,9 +203,10 @@
 	overlay_color = "#FF80BD"
 
 /obj/machinery/atmospherics/miner/mixed_nitrogen/AddAir()
-	AirRate(GAS_CARBON)
-	AirRate(GAS_NITROGEN)
-	AirRate(GAS_PLASMA)
+  var/rate = AirRate()
+  air_contents.adjust_multi(GAS_CARBON, 0.3*rate,
+  GAS_NITROGEN, 0.4*rate,
+  GAS_PLASMA, 0.3*rate)
 
 /obj/machinery/atmospherics/miner/mixed_oxygen
 	name = "\improper Mixed Gas Miner"
@@ -206,6 +214,6 @@
 	overlay_color = "#7EA7E0"
 
 /obj/machinery/atmospherics/miner/mixed_oxygen/AddAir()
-	AirRate(GAS_OXYGEN)
-	AirRate(GAS_SLEEPING)
-
+  var/rate = AirRate()
+  air_contents.adjust_multi(GAS_OXYGEN, 0.5*rate,
+  GAS_SLEEPING, 0.5*rate)

--- a/code/game/machinery/atmoalter/gas_mine.dm
+++ b/code/game/machinery/atmoalter/gas_mine.dm
@@ -184,3 +184,26 @@
 /obj/machinery/atmospherics/miner/gas_giant/AddAir()
 	if(ticker)
 		air_contents.copy_from(gas_giant.GM)
+
+
+/obj/machinery/atmospherics/miner/mixed_nitrogen
+	name = "\improper Mixed Gas Miner"
+	desc = "Pumping nitrogen, carbon dioxide, and plasma."
+	overlay_color = "#FF80BD"
+
+/obj/machinery/atmospherics/miner/mixed_nitrogen/AddAir()
+	air_contents.adjust_multi(
+		GAS_CARBON, 0.3 * internal_pressure * air_contents.volume / (R_IDEAL_GAS_EQUATION * air_contents.temperature),
+		GAS_NITROGEN, 0.4 * internal_pressure * air_contents.volume / (R_IDEAL_GAS_EQUATION * air_contents.temperature),
+		GAS_PLASMA, 0.3 * internal_pressure * air_contents.volume / (R_IDEAL_GAS_EQUATION * air_contents.temperature))
+
+
+/obj/machinery/atmospherics/miner/mixed_oxygen
+	name = "\improper Mixed Gas Miner"
+	desc = "Pumping oxygen and nitrous oxide."
+	overlay_color = "#7EA7E0"
+
+/obj/machinery/atmospherics/miner/mixed_oxygen/AddAir()
+	air_contents.adjust_multi(
+		GAS_OXYGEN, 0.5 * internal_pressure * air_contents.volume / (R_IDEAL_GAS_EQUATION * air_contents.temperature),
+		GAS_SLEEPING, 0.5 * internal_pressure * air_contents.volume / (R_IDEAL_GAS_EQUATION * air_contents.temperature))

--- a/code/game/machinery/atmoalter/gas_mine.dm
+++ b/code/game/machinery/atmoalter/gas_mine.dm
@@ -18,8 +18,6 @@
 
 	var/overlay_color = "#FFFFFF"
 
-	var/total_adjust = (internal_pressure * air_contents.volume / (R_IDEAL_GAS_EQUATION * air_contents.temperature))
-
 	machine_flags = WRENCHMOVE | FIXED2WORK
 
 /obj/machinery/atmospherics/miner/New()
@@ -124,12 +122,16 @@
 		loc.assume_air(removed)
 
 
+/obj/machinery/atmospherics/miner/proc/AirRate(datum/gas)
+	air_contents.adjust_gas(gas, internal_pressure * air_contents.volume / (R_IDEAL_GAS_EQUATION * air_contents.temperature))
+
+
 /obj/machinery/atmospherics/miner/sleeping_agent
 	name = "\improper N2O Gas Miner"
 	overlay_color = "#FFCCCC"
 
 /obj/machinery/atmospherics/miner/sleeping_agent/AddAir()
-	air_contents.adjust_gas(GAS_SLEEPING, internal_pressure * air_contents.volume / (R_IDEAL_GAS_EQUATION * air_contents.temperature))
+	AirRate(GAS_SLEEPING)
 
 
 /obj/machinery/atmospherics/miner/nitrogen
@@ -137,7 +139,7 @@
 	overlay_color = "#CCFFCC"
 
 /obj/machinery/atmospherics/miner/nitrogen/AddAir()
-	air_contents.adjust_gas(GAS_NITROGEN, internal_pressure * air_contents.volume / (R_IDEAL_GAS_EQUATION * air_contents.temperature))
+	AirRate(GAS_NITROGEN)
 
 
 /obj/machinery/atmospherics/miner/oxygen
@@ -145,7 +147,7 @@
 	overlay_color = "#007FFF"
 
 /obj/machinery/atmospherics/miner/oxygen/AddAir()
-	air_contents.adjust_gas(GAS_OXYGEN, internal_pressure * air_contents.volume / (R_IDEAL_GAS_EQUATION * air_contents.temperature))
+	AirRate(GAS_OXYGEN)
 
 
 /obj/machinery/atmospherics/miner/toxins
@@ -153,7 +155,7 @@
 	overlay_color = "#FF0000"
 
 /obj/machinery/atmospherics/miner/toxins/AddAir()
-	air_contents.adjust_gas(GAS_PLASMA, internal_pressure * air_contents.volume / (R_IDEAL_GAS_EQUATION * air_contents.temperature))
+	AirRate(GAS_PLASMA)
 
 
 /obj/machinery/atmospherics/miner/carbon_dioxide
@@ -161,7 +163,7 @@
 	overlay_color = "#CDCDCD"
 
 /obj/machinery/atmospherics/miner/carbon_dioxide/AddAir()
-	air_contents.adjust_gas(GAS_CARBON, internal_pressure * air_contents.volume / (R_IDEAL_GAS_EQUATION * air_contents.temperature))
+	AirRate(GAS_CARBON)
 
 
 /obj/machinery/atmospherics/miner/air
@@ -172,9 +174,9 @@
 	on = 0
 
 /obj/machinery/atmospherics/miner/air/AddAir()
-	air_contents.adjust_multi(
-		GAS_OXYGEN, O2STANDARD * total_adjust,
-		GAS_NITROGEN, N2STANDARD * total_adjust)
+	AirRate(GAS_OXYGEN)
+	AirRate(GAS_NITROGEN)
+
 
 /obj/machinery/atmospherics/miner/gas_giant
 	name = "\improper Gas Miner"
@@ -194,11 +196,9 @@
 	overlay_color = "#FF80BD"
 
 /obj/machinery/atmospherics/miner/mixed_nitrogen/AddAir()
-	air_contents.adjust_multi(
-		GAS_CARBON, 0.3 * total_adjust,
-		GAS_NITROGEN, 0.4 * total_adjust,
-		GAS_PLASMA, 0.3 * total_adjust)
-
+	AirRate(GAS_CARBON)
+	AirRate(GAS_NITROGEN)
+	AirRate(GAS_PLASMA)
 
 /obj/machinery/atmospherics/miner/mixed_oxygen
 	name = "\improper Mixed Gas Miner"
@@ -206,6 +206,6 @@
 	overlay_color = "#7EA7E0"
 
 /obj/machinery/atmospherics/miner/mixed_oxygen/AddAir()
-	air_contents.adjust_multi(
-		GAS_OXYGEN, 0.5 * total_adjust,
-		GAS_SLEEPING, 0.5 * total_adjust)
+	AirRate(GAS_OXYGEN)
+	AirRate(GAS_SLEEPING)
+

--- a/code/game/machinery/atmoalter/gas_mine.dm
+++ b/code/game/machinery/atmoalter/gas_mine.dm
@@ -18,6 +18,8 @@
 
 	var/overlay_color = "#FFFFFF"
 
+	var/total_adjust = (internal_pressure * air_contents.volume / (R_IDEAL_GAS_EQUATION * air_contents.temperature))
+
 	machine_flags = WRENCHMOVE | FIXED2WORK
 
 /obj/machinery/atmospherics/miner/New()
@@ -171,8 +173,8 @@
 
 /obj/machinery/atmospherics/miner/air/AddAir()
 	air_contents.adjust_multi(
-		GAS_OXYGEN, O2STANDARD * internal_pressure * air_contents.volume / (R_IDEAL_GAS_EQUATION * air_contents.temperature),
-		GAS_NITROGEN, N2STANDARD * internal_pressure * air_contents.volume / (R_IDEAL_GAS_EQUATION * air_contents.temperature))
+		GAS_OXYGEN, O2STANDARD * total_adjust,
+		GAS_NITROGEN, N2STANDARD * total_adjust)
 
 /obj/machinery/atmospherics/miner/gas_giant
 	name = "\improper Gas Miner"
@@ -193,9 +195,9 @@
 
 /obj/machinery/atmospherics/miner/mixed_nitrogen/AddAir()
 	air_contents.adjust_multi(
-		GAS_CARBON, 0.3 * internal_pressure * air_contents.volume / (R_IDEAL_GAS_EQUATION * air_contents.temperature),
-		GAS_NITROGEN, 0.4 * internal_pressure * air_contents.volume / (R_IDEAL_GAS_EQUATION * air_contents.temperature),
-		GAS_PLASMA, 0.3 * internal_pressure * air_contents.volume / (R_IDEAL_GAS_EQUATION * air_contents.temperature))
+		GAS_CARBON, 0.3 * total_adjust,
+		GAS_NITROGEN, 0.4 * total_adjust,
+		GAS_PLASMA, 0.3 * total_adjust)
 
 
 /obj/machinery/atmospherics/miner/mixed_oxygen
@@ -205,5 +207,5 @@
 
 /obj/machinery/atmospherics/miner/mixed_oxygen/AddAir()
 	air_contents.adjust_multi(
-		GAS_OXYGEN, 0.5 * internal_pressure * air_contents.volume / (R_IDEAL_GAS_EQUATION * air_contents.temperature),
-		GAS_SLEEPING, 0.5 * internal_pressure * air_contents.volume / (R_IDEAL_GAS_EQUATION * air_contents.temperature))
+		GAS_OXYGEN, 0.5 * total_adjust,
+		GAS_SLEEPING, 0.5 * total_adjust)


### PR DESCRIPTION
This PR adds two new gas miners to the code. One mines out nitrogen, plasma, and carbon dioxide. The other mines oxygen and nitrous oxide. The idea for these is to have a logical, in character reason for plasma gas to be to be so close to the distribution lines while also providing a trade off for cutting off plasma; doing so would result in a 100% oxygen line causing any fire that would break out to be far worse.
This does NOT map them in or add them anywhere in any way, this is just to be used in mapping. While possible to custom edit miners for a map, I felt it would be better to have them adding in proper.
I can add a changelog if needed but as this PR changes nothing in game I have not included one.

This PR now also adds a new proc, AirRate() and greatly reduces the size of AddAir() for most of the Gas Miners.
As no in game behavior has been changed, I still think there isn't a need for a changelog.