### PR TITLE
Shields now properly block stun batons and syringes

### DIFF
--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -182,6 +182,11 @@
 		user.lastattacked = L
 		L.lastattacker = user
 
+	if(iscarbon(L))
+		var/mob/living/carbon/C = L
+		if(C.check_shields(force,src))
+			return FALSE
+
 		L.Stun(stunforce)
 		L.apply_effect(10, STUTTER, 0)
 		L.Knockdown(stunforce)

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -202,7 +202,7 @@ obj/item/projectile/bullet/suffocationbullet
 	..()
 	explosion(target, 0,1,1,5)
 	qdel(src)
-	
+
 /obj/item/projectile/bullet/boombullet
 	name = "small exploding bullet"
 	embed = 0
@@ -744,7 +744,7 @@ obj/item/projectile/bullet/suffocationbullet
 	burn_damage = 10
 	jet_pressure = 0
 	gas_jet = null
-	
+
 /obj/item/projectile/bullet/fire_plume/dragonsbreath/New()
 	..()
 	var/datum/gas_mixture/firemix = new /datum/gas_mixture
@@ -947,7 +947,8 @@ obj/item/projectile/bullet/suffocationbullet
 /obj/item/projectile/bullet/syringe/on_hit(atom/A as mob|obj|turf|area)
 	if(!A)
 		return
-	..()
+	if(!..())
+		return FALSE
 	if(ismob(A))
 		var/mob/M = A
 		var/blocked


### PR DESCRIPTION
Revival of a months old PR (Thanks for the help on the first one, Kurfurst). Shields can now properly block stun batons (before it would apply the stun regardless) and you can no longer get chloral'd by a syringe gun if you blocked the syringe. 

[bugfix]
:cl:
 * bugfix: Stun batons can be blocked by shields, syringes no longer transfer reagants if blocked.