### PR TITLE
Fix IEDs breaking the fabric of space and time

### DIFF
--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -580,9 +580,6 @@
 
 		var/mob/living/L = AM
 
-		if (L.pulledby)
-			return ..()// Would be too easy.
-
 		if(L.on_foot() && ishuman(L)) //Flying mobs can't get caught in beartraps! Note that this also prevents lying mobs from triggering traps
 			var/mob/living/carbon/human/H = L
 			H.visible_message("<span class='danger'>[H] steps on \the [src].</span>",\

--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -417,6 +417,8 @@
 	var/obj/item/weapon/grenade/iedcasing/IED = null
 	var/image/ied_overlay
 
+	var/trapped_user_key
+
 /obj/item/weapon/beartrap/New()
 	..()
 	ied_overlay = image('icons/obj/items.dmi')
@@ -485,8 +487,10 @@
 				to_chat(L, "<span class='warning'>With your leg missing, you slip out of the bear trap.</span>")
 				trapped = 0
 				unlock_atom(L)
+				L.on_moved.Remove(trapped_user_key)
 				trappeduser = null
 				anchored = FALSE
+				return
 			else
 				user.visible_message("<span class='notice'>[H] tries to pry \the [src] off of [L]!</span>", \
 				"<span class='notice'>You try to pry open \the [src] with your bear hands.</span>")
@@ -499,7 +503,9 @@
 					trapped = 0
 					trappeduser = null
 					unlock_atom(L)
+					L.on_moved.Remove(trapped_user_key)
 					anchored = FALSE
+					return
 				else
 					user.visible_message("<span class='warning'>\The [H] fails to pry \the [src] off of [L], and crushes their leg even more!</span>", \
 					"<span class='warning'>You fail to pry \the [src] off of [L], and you crush their leg even more!</span>")
@@ -508,6 +514,7 @@
 					if(trappedorgan.take_damage(5,0,0)) //holy fuck it's easy to knock out legs
 						L.UpdateDamageIcon()
 					L.updatehealth()
+					return
 	..()
 
 /obj/item/weapon/beartrap/attackby(var/obj/item/I, mob/user) //Let's get explosive.
@@ -550,6 +557,7 @@
 			trapped = 0
 			anchored = FALSE
 			unlock_atom(trappeduser)
+			trappeduser.on_moved.Remove(trapped_user_key)
 			trappeduser = null
 		else
 			to_chat(user, "<span class='notice'>You begin to pry the bear trap off of [trappeduser.name].</span>")
@@ -558,6 +566,7 @@
 				trapped = 0
 				anchored = FALSE
 				unlock_atom(trappeduser)
+				trappeduser.on_moved.Remove(trapped_user_key)
 				trappeduser = null
 	else
 		to_chat(user, "<span class='notice'>You carefully set the bear trap off with \the [I.name].</span>")
@@ -570,6 +579,9 @@
 	if(armed && isliving(AM) && isturf(src.loc))
 
 		var/mob/living/L = AM
+
+		if (L.pulledby)
+			return ..()// Would be too easy.
 
 		if(L.on_foot() && ishuman(L)) //Flying mobs can't get caught in beartraps! Note that this also prevents lying mobs from triggering traps
 			var/mob/living/carbon/human/H = L
@@ -588,6 +600,7 @@
 				playsound(src, 'sound/effects/snap.ogg', 60, 1)
 				H.audible_scream()
 				lock_atom(H, /datum/locking_category/beartrap)
+				trapped_user_key = H.on_moved.Add(src, .proc/forcefully_remove)
 
 				to_chat(H, "<span class='danger'>The bear trap latches to your legs as you hear a hissing sound!</span>")
 
@@ -605,7 +618,15 @@
 					IED.prime()
 					src.desc = initial(src.desc)
 					overlays.Remove(ied_overlay)
-				return
+					var/mob/living/carbon/human/H2 = trappeduser
+					if(H2 && !H2.pick_usable_organ(trappedorgan)) //check if they lost their leg, and get them out of the trap
+						to_chat(L, "<span class='warning'>With your leg missing, you slip out of the bear trap.</span>")
+						trapped = 0
+						unlock_atom(H2)
+						trappeduser.on_moved.Remove(trapped_user_key)
+						trappeduser = null
+						anchored = FALSE
+					return
 
 			if(H.m_intent == "run") //This is where the real fun begins
 				trap(H)
@@ -635,14 +656,36 @@
 			H.updatehealth()
 
 	if(!H.pick_usable_organ(affecting)) //check if they lost their leg, and get them out of the trap
-		to_chat(H, "<span class='warning'>With your leg missing, you slip out of the bear trap</span>")
+		to_chat(H, "<span class='warning'>With your leg missing, you slip out of the bear trap!</span>")
 		trapped = 0
 		trappeduser = null
 		unlock_atom(H)
+		trappeduser.on_moved.Remove(trapped_user_key)
 		anchored = FALSE
 
 	H.update_canmove()
 
+// Called when the dude is moved from the trap on way or the other.
+/obj/item/weapon/beartrap/proc/forcefully_remove(var/list/arguments, var/mob/holder)
+	if (get_turf(holder) != src.loc)
+		if (ishuman(holder))
+			var/mob/living/carbon/human/H = holder
+			playsound(holder, 'sound/effects/snap.ogg', 60, 1)
+			H.audible_scream()
+
+			var/datum/organ/external/affecting = H.pick_usable_organ(LIMB_LEFT_LEG, LIMB_RIGHT_LEG)
+			if(affecting)
+				if(affecting.take_damage(30, 0, 50, SERRATED_BLADE & SHARP_BLADE)) // This is going to hurt.
+					H.UpdateDamageIcon()
+					H.updatehealth()
+		visible_message("<span class='warning'>The wound on [holder]'s leg worsens terribly as the trap let go of them.</span>")
+		trapped = 0
+		unlock_atom(trappeduser)
+		trappeduser.on_moved.Remove(trapped_user_key)
+		anchored = FALSE
+		trappeduser.update_canmove()
+		trappeduser = null
+		return
 
 /obj/item/weapon/batteringram
 	name = "battering ram"

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -282,6 +282,9 @@
 				returnToPool(G)
 
 	AM.locked_to = src
+	if (ismob(AM))
+		var/mob/M = AM
+		M.canmove = 0
 
 	locked_atoms[AM] = category
 	category.lock(AM)
@@ -295,6 +298,10 @@
 	var/datum/locking_category/category = locked_atoms[AM]
 	locked_atoms    -= AM
 	AM.locked_to     = null
+	if (ismob(AM))
+		var/mob/M = AM
+		M.canmove = 1
+
 	category.unlock(AM)
 	//AM.reset_glide_size() // FIXME: Currently broken.
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -940,6 +940,14 @@ Thanks.
 
 
 	if(L.locked_to && !L.isUnconscious())
+		// unbeartrapping yourself
+		if (istype(L.locked_to, /obj/item/weapon/beartrap/))
+			if (iscarbon(L))
+				var/mob/living/carbon/C = L
+				if (C.handcuffed)
+					return
+			L.locked_to.attack_hand(L)
+			return
 		//unbuckling yourself
 		if(istype(L.locked_to, /obj/structure/bed))
 			var/obj/structure/bed/B = L.locked_to

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -1655,6 +1655,7 @@
 #include "code\modules\mob\dead\observer\say.dm"
 #include "code\modules\mob\dead\observer\spells.dm"
 #include "code\modules\mob\hearing\virtualhearer.dm"
+#include "code\modules\mob\living\Astar_test.dm"
 #include "code\modules\mob\living\combat.dm"
 #include "code\modules\mob\living\damage_procs.dm"
 #include "code\modules\mob\living\death.dm"

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -1655,7 +1655,6 @@
 #include "code\modules\mob\dead\observer\say.dm"
 #include "code\modules\mob\dead\observer\spells.dm"
 #include "code\modules\mob\hearing\virtualhearer.dm"
-#include "code\modules\mob\living\Astar_test.dm"
 #include "code\modules\mob\living\combat.dm"
 #include "code\modules\mob\living\damage_procs.dm"
 #include "code\modules\mob\living\death.dm"


### PR DESCRIPTION
[bugfix]
Closes #26162 
Closes #26161 

"Resisting" out of a bear trap will help you get rid of it (QoL). You can still try to free yourself of the trap by clicking on it with a crowbar or an empty hand.
You may no longer pick up traps if someone is trapped on them, and you can help them to get rid of it
Bumping into someone who's trapped let them go of it, but terribly worsens their leg
You may no longer pull people into bear traps
If the bomb destroyed your leg, you'll be let go normally

Tested
:cl:
- bugfix: You will no longer be able to pick up beartraps if someone is stuck trapped on them. You will attempt to free them instead.
- tweak: You can use the verb "Resist" to try and free yourself from an armed beartrap.
- bugfix: You can no longer use help intent to tile swap with someone whose leg is stuck in an armed beartrap.