### PR TITLE
Primetime

### DIFF
--- a/__DEFINES/dates.dm
+++ b/__DEFINES/dates.dm
@@ -41,3 +41,9 @@
 #define BOXING_DAY "Boxing Day"
 #define NEW_YEARS_EVE "New Year's Eve"
 #define FRIDAY_THE_13TH "Friday the 13th"
+
+#define SLEEPTIME "timeslot_sleep" //3 to 11
+#define EUROTIME "timeslot_euro" //12 to 15
+#define DAYTIME "timeslot_day" //16 to 18
+#define PRIMETIME "timeslot_prime" //19 to 22
+#define LATETIME "timeslot_late" //23 to 2

--- a/__DEFINES/dates.dm
+++ b/__DEFINES/dates.dm
@@ -42,8 +42,15 @@
 #define NEW_YEARS_EVE "New Year's Eve"
 #define FRIDAY_THE_13TH "Friday the 13th"
 
-#define SLEEPTIME "timeslot_sleep" //3 to 11
-#define EUROTIME "timeslot_euro" //12 to 15
-#define DAYTIME "timeslot_day" //16 to 18
-#define PRIMETIME "timeslot_prime" //19 to 22
-#define LATETIME "timeslot_late" //23 to 2
+//timeslots as strings
+#define SLEEPTIME "the morning shift" //3 to 11
+#define EUROTIME "the European shift" //12 to 15
+#define DAYTIME "the day shift" //16 to 18
+#define PRIMETIME "primetime" //19 to 22
+#define LATETIME "the late shift" //23 to 2
+//timeslots as hour values
+#define SLEEPTIME_HOURS 3 to 11
+#define EUROTIME_HOURS 12 to 15
+#define DAYTIME_HOURS 16 to 18
+#define PRIMETIME_HOURS 19 to 22
+#define LATETIME_HOURS 23, 0 to 2

--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -102,14 +102,21 @@
 //Returns time as a "slot", a predefined type of time, see dates.dm for defines
 /proc/getTimeslot()
 	switch(text2num(time2text(world.timeofday, "hh")))
-		if(3 to 11)
+		if(SLEEPTIME_HOURS)
 			return SLEEPTIME
-		if(12 to 15)
+		if(EUROTIME_HOURS)
 			return EUROTIME
-		if(16 to 18)
+		if(DAYTIME_HOURS)
 			return DAYTIME
-		if(19 to 22)
+		if(PRIMETIME_HOURS)
 			return PRIMETIME
-		if(23, 0 to 2)
+		if(LATETIME_HOURS)
 			return LATETIME
 	CRASH("getTimeslot: Hour not found.")
+
+
+var/global/obj/effect/statclick/time/time_statclick
+/proc/timeStatEntry()
+	if(!time_statclick)
+		time_statclick = new /obj/effect/statclick/time("loading...")
+	stat("Station Time:", time_statclick.update("[worldtime2text()]"))

--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -98,3 +98,18 @@
 //returns timestamp in a sql and ISO 8601 friendly format
 /proc/SQLtime()
 	return time2text(world.realtime, "YYYY-MM-DD hh:mm:ss")
+
+//Returns time as a "slot", a predefined type of time, see dates.dm for defines
+/proc/getTimeslot()
+	switch(text2num(time2text(world.timeofday, "hh")))
+		if(3 to 11)
+			return SLEEPTIME
+		if(12 to 15)
+			return EUROTIME
+		if(16 to 18)
+			return DAYTIME
+		if(19 to 22)
+			return PRIMETIME
+		if(23, 0 to 2)
+			return LATETIME
+	CRASH("getTimeslot: Hour not found.")

--- a/code/controllers/mc/admin.dm
+++ b/code/controllers/mc/admin.dm
@@ -10,6 +10,9 @@
 	name = text
 	return src
 
+/obj/effect/statclick/time/Click()
+	to_chat(usr,"<span class='notice'>The server time is [time2text(world.timeofday, "hh:mm:ss")]. The time slot is [getTimeslot()].</span>")
+
 /obj/effect/statclick/debug
 	var/class
 

--- a/code/datums/gamemode/dynamic/dynamic_rulesets.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets.dm
@@ -13,6 +13,8 @@
 	var/required_pop = list(10,10,0,0,0,0,0,0,0,0)//if enemy_jobs was set, this is the amount of population required for the ruleset to fire. enemy jobs count double
 	var/required_candidates = 0//the rule needs this many candidates (post-trimming) to be executed (example: Cult need 4 players at round start)
 	var/weight = 5//1 -> 9, probability for this rule to be picked against other rules
+	var/list/weekday_rule_boost = list()
+	var/list/timeslot_rule_boost = list()
 	var/cost = 0//threat cost for this rule.
 	var/logo = ""//any state from /icons/logos.dmi
 	var/calledBy //who dunnit, for round end scoreboard
@@ -114,12 +116,22 @@
 	return FALSE
 
 /datum/dynamic_ruleset/proc/get_weight()
+	weight *= weight_time_day()
 	if(repeatable && weight > 1)
 		for(var/datum/dynamic_ruleset/DR in mode.executed_rules)
 			if(istype(DR,src.type))
 				weight = max(weight-2,1)
 	message_admins("[name] had [weight] weight (-[initial(weight) - weight]).")
 	return weight
+
+//Return a multiplicative weight. 1 for nothing special.
+/datum/dynamic_ruleset/proc/weight_time_day()
+	var/weigh = 1
+	if(time2text(world.timeofday, "DDD") in weekday_rule_boost)
+		weigh *= 2
+	if(getTimeslot() in timeslot_rule_boost)
+		weigh *= 2
+	return weigh
 
 /datum/dynamic_ruleset/proc/trim_candidates()
 	return

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -363,6 +363,7 @@
 	required_pop = list(25,20,20,15,15,15,10,10,10,10)
 	required_candidates = 1
 	weight = 2
+	weekday_rule_boost = list("Tue")
 	cost = 30
 	requirements = list(90,90,90,80,60,40,30,20,10,10)
 	high_population_requirement = 70
@@ -457,7 +458,7 @@
 	if (!spoider)
 		spoider = ticker.mode.CreateFaction(/datum/faction/spider_clan, null, 1)
 	spoider.HandleRecruitedRole(newninja)
-	
+
 	return ..()
 
 //////////////////////////////////////////////
@@ -473,6 +474,7 @@
 	required_pop = list(0,0,10,10,15,15,20,20,20,25)
 	required_candidates = 1
 	weight = 1
+	timeslot_rule_boost = list(SLEEPTIME)
 	cost = 5
 	requirements = list(5,5,15,15,25,25,55,55,55,75)
 	logo = "rambler-logo"

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -21,7 +21,7 @@
 	high_population_requirement = 10
 
 /datum/dynamic_ruleset/roundstart/traitor/execute()
-	var/traitor_scaling_coeff = 10 - max(0,round(mode.threat_level/10)-5)//above 50 threat level, coeff goes down by 1 for every 10 levels	
+	var/traitor_scaling_coeff = 10 - max(0,round(mode.threat_level/10)-5)//above 50 threat level, coeff goes down by 1 for every 10 levels
 	var/num_traitors = min(round(mode.roundstart_pop_ready / traitor_scaling_coeff) + 1, candidates.len)
 	for (var/i = 1 to num_traitors)
 		var/mob/M = pick(candidates)
@@ -421,6 +421,7 @@
 	required_pop = list(30,25,25,20,20,20,15,15,15,15)
 	required_candidates = 1
 	weight = 3
+	weekday_rule_boost = list("Tue")
 	cost = 45
 	requirements = list(90,90,90,80,60,40,30,20,10,10)
 	high_population_requirement = 70

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -477,7 +477,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 /mob/dead/observer/Stat()
 	..()
 	if(statpanel("Status"))
-		stat(null, "Station Time: [worldtime2text()]")
+		timeStatEntry()
 		if(ticker.mode)
 			for(var/datum/faction/F in ticker.mode.factions)
 				var/f_stat = F.get_statpanel_addition()

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -71,7 +71,7 @@
 
 	if(statpanel("Status") && ticker)
 		if (ticker.current_state != GAME_STATE_PREGAME)
-			stat("Station Time:", "[worldtime2text()]")
+			timeStatEntry()
 		if(ticker.hide_mode)
 			stat("Game Mode:", "Secret")
 		else
@@ -318,7 +318,7 @@
 		H.dna.GiveRandomSE(notflags = GENE_UNNATURAL,genetype = GENETYPE_BAD)
 		if(prob(10)) // 10% of those have a good mut.
 			H.dna.GiveRandomSE(notflags = GENE_UNNATURAL,genetype = GENETYPE_GOOD)
-	
+
 /mob/new_player/proc/AttemptLateSpawn(rank)
 	if (src != usr)
 		return 0


### PR DESCRIPTION
Every few months it feels like we tweak the weight of modes so that one or the other gets more favor. And people seem to like that in the short term. I thought... what if we did that automatically? Some days and some hours could be more prone to one mode or another. This adds a system for weighting the mode based on time and day of the week. Timeslots are as follows (only cares about hour digits, so 12:01 == 12:59) and affected by server time.
SLEEPTIME: 3a-11a
EUROTIME: 12p-3p
DAYTIME: 4p-6p
PRIMETIME: 7p-10p
LATETIME: 11p-2a
It's fully customizable but right now I just have a basic system for 2x weight on the day/time (stacks if applicable, right now impossible).
As an experiment, Tuesday is now Blob day and Soul Ramblers like to show up during real deadpop hours.

🆑 
* tweak: Blob is now 2x more common on Tuesdays.
* tweak: Soul Rambler Migration is now 2x more common from 3am to 11:59am server time.