### PR TITLE
Makes beanbag shells not retarded again. 

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -37,10 +37,10 @@
 	name = "weak bullet"
 	icon_state = "bbshell"
 	damage = 10
-	stun = 5
+	stun = 3
 	weaken = 5
 	embed = 0
-	projectile_speed = 1
+	projectile_speed = 0.5
 
 /obj/item/projectile/bullet/weakbullet/booze
 	name = "booze bullet"
@@ -207,7 +207,7 @@ obj/item/projectile/bullet/suffocationbullet
 	..()
 	explosion(target, 0,1,1,5)
 	qdel(src)
-	
+
 /obj/item/projectile/bullet/boombullet
 	name = "small exploding bullet"
 	embed = 0
@@ -750,7 +750,7 @@ obj/item/projectile/bullet/suffocationbullet
 	burn_damage = 10
 	jet_pressure = 0
 	gas_jet = null
-	
+
 /obj/item/projectile/bullet/fire_plume/dragonsbreath/New()
 	..()
 	var/datum/gas_mixture/firemix = new /datum/gas_mixture


### PR DESCRIPTION
Shifty's stun bullet speed rework was dumb, and makes all stun bullets as slow as tasers, so I'm taking a swing at rebalancing them in the other direction. Bullet speed returned to normal, but the stun is reduced from 10 seconds to 6 seconds.

If this is well recieved I'll make some more PRs applying similar reworks to the rest of the stun bullets shifty touched, which will trade stun time for speed to a more drastic degree. 
-->
:cl:
 * tweak: Returned Beanbag shotgun shells to regular speed.
 * tweak: Cut stun time from 10 seconds to 6 seconds.
