### PR TITLE
Fix global definition of variable in proc header in hydroponics code

### DIFF
--- a/code/modules/hydroponics/hydro_tray.dm
+++ b/code/modules/hydroponics/hydro_tray.dm
@@ -579,7 +579,7 @@
 
 	..()
 
-/obj/machinery/portable_atmospherics/hydroponics/AltClick(/var/mob/usr)
+/obj/machinery/portable_atmospherics/hydroponics/AltClick(var/mob/usr)
 	if((usr.incapacitated() || !Adjacent(usr)))
 		return
 	close_lid()


### PR DESCRIPTION
This, technically, has no effect, since BYOND's internal `usr` has greater specificity than a globally-defined `usr` variable. Still bad though.