### PR TITLE
Deleting smartglass electronics or supermatter shards/crystals no longer bricks all radio connections on the same frequency

### DIFF
--- a/code/game/machinery/smartglass.dm
+++ b/code/game/machinery/smartglass.dm
@@ -17,21 +17,21 @@
 	active_power_usage = 50
 	power_channel = ENVIRON
 	machine_flags = MULTITOOL_MENU
-	
+
 	//Smartglass vars
 	var/smart_transparency = 0
 	var/obj/structure/window/Ourwindow //Ref to the window we're in
-	
+
 	//Radio vars
-	var/id_tag	
+	var/id_tag
 	var/frequency = 1449
 	var/datum/radio_frequency/radio_connection
-	
-	
+
+
 /obj/machinery/smartglass_electronics/cultify()
 	qdel(src)
 	return
-	
+
 /obj/machinery/smartglass_electronics/New()
 	..()
 	radio_connection = radio_controller.add_object(src, frequency, RADIO_AIRLOCK)
@@ -39,14 +39,14 @@
 
 /obj/machinery/smartglass_electronics/Destroy()
 	radio_controller.remove_object(src, frequency)
-	qdel(radio_connection)
 	radio_connection = null
+	Ourwindow = null
 	..()
-	
+
 /**********************
 // SMARTOurwindow PROCS
 **********************/
-			
+
 /obj/machinery/smartglass_electronics/proc/toggle_smart_transparency()
 	smart_transparency = !smart_transparency
 	Ourwindow.smart_toggle()
@@ -67,8 +67,8 @@
 			<li>[format_tag("ID Tag", "id_tag","set_id")]</a></li>
 			<li><a href='?src=\ref[src];transparentoggle=1'>Toggle Transparency</a></li>
 		</ul>
-		"}	
-		
+		"}
+
 // Overwrite standard behavior else it'll never work
 /obj/machinery/smartglass_electronics/Topic(href, href_list)
 	if(stat & (NOPOWER|BROKEN))
@@ -89,10 +89,10 @@
 		log_adminghost("[key_name(usr)] screwed with [src] ([href])!")
 
 	return handle_multitool_topic(href,href_list,usr)
-	
+
 /obj/machinery/smartglass_electronics/canClone(var/obj/O)
 	return istype(O, /obj/machinery/smartglass_electronics)
-	
+
 /obj/machinery/smartglass_electronics/clone(var/obj/machinery/smartglass_electronics/O)
 	id_tag = O.id_tag
 	return 1
@@ -100,7 +100,7 @@
 /*************************************
 // RADIO SHIT
 *************************************/
-		
+
 /obj/machinery/smartglass_electronics/multitool_topic(var/mob/user, var/list/href_list, var/obj/structure/window/Ourwindow)
 	if("set_id" in href_list)
 		var/newid = copytext(reject_bad_text(input(usr, "Specify the new ID tag for this machine", src, id_tag) as null|text), 1, MAX_MESSAGE_LEN)
@@ -108,13 +108,13 @@
 			id_tag = newid
 			initialize()
 		return MT_UPDATE
-	
+
 	if("transparentoggle" in href_list)
 		toggle_smart_transparency()
-		return MT_UPDATE	
-	
+		return MT_UPDATE
+
 	return ..()
-	
+
 /obj/machinery/smartglass_electronics/receive_signal(datum/signal/signal)
 	if(!signal || signal.encryption)
 		return
@@ -123,6 +123,6 @@
 		return
 
 	switch(signal.data["command"])
-		
+
 		if("toggle_transparency", "toggle", "cycle")
-			toggle_smart_transparency()	
+			toggle_smart_transparency()

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -104,7 +104,7 @@
 /obj/machinery/power/supermatter/Destroy()
 	qdel(radio)
 	radio = null
-	qdel(radio_connection)
+	radio_controller.remove_object(src, frequency)
 	radio_connection = null
 	. = ..()
 


### PR DESCRIPTION
Radio frequencies are shared. Don't delete them.
I'm guessing this caused in-game bugs, but I didn't make sure. Definitely caused lots of runtimes though.

Also nulled a variable that was not previously nulled in `smartglass_electronics/Destroy()` while I was there
And apparently my editor cleaned up a fuckton of trailing whitespace, too
What even happened in that file