### PR TITLE
Fixes being able to harmbaton people with an inactive baton

### DIFF
--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -178,14 +178,14 @@
 				self_drugged_message="<span class='warning'>\The [name] decides to spare this one.</span>")
 			return
 
-	if(status && . != FALSE) // This is charged : we stun
-		user.lastattacked = L
-		L.lastattacker = user
-
 	if(iscarbon(L))
 		var/mob/living/carbon/C = L
 		if(C.check_shields(force,src))
-			return FALSE
+			return FALSE //That way during a harmbaton it will not check for the shield twice
+
+	if(status && . != FALSE) // This is charged : we stun
+		user.lastattacked = L
+		L.lastattacker = user
 
 		L.Stun(stunforce)
 		L.apply_effect(10, STUTTER, 0)


### PR DESCRIPTION
Problem is as such:
- A recent PR added a check in order to not allow blocked stunbatons on help intent stun
- The check was placed in the wrong spot, namely near the start of of the chain the actual stun is applied, meaning that the original sanity check (which was checking if the baton is active to stun) was doing almost nothing while the application of stun was now checking if the victim was a carbon
- With the way the code worked, being on help intent and hitting someone with an inactive baton would stop the whole thing from happening altogether, which was good. However, having the harm intent on would continue the proc and reach the carbon check.
- In short, if the victim was carbon (read: humans and what-else) and you had your harm intent on it would allow you to stun the victim with an inactive baton, bypassing frivolous mortal things such as whether the baton has enough battery power.

:cl:
 * bugfix: Stunbatons will no longer stun if the baton is off while harm intent is on.