### PR TITLE
Fixes a few runtimes with AStar

### DIFF
--- a/code/controllers/subsystem/pathing.dm
+++ b/code/controllers/subsystem/pathing.dm
@@ -209,7 +209,7 @@ var/global/list/pathmakers = list()
 				PNode.distance_from_start = call(cur.source,dist)(T)
 				PNode.distance_from_end = newenddist
 				PNode.calc_f()
-				if(!open.ReSort(PNode))//reorder the changed element in the list
+				if(!open.ReSort(PNode.source))//reorder the changed element in the list
 					astar_debug("failed to reorder, requeuing")
 					open.Enqueue(PNode)
 	astar_debug("open:[open.List().len]")

--- a/code/defines/procs/AStar.dm
+++ b/code/defines/procs/AStar.dm
@@ -250,7 +250,7 @@ proc/quick_AStar(start,end,adjacent,dist,maxnodes,maxnodedepth = 30,mintargetdis
 					PNode.prevNode = cur
 					PNode.distance_from_start = newenddist
 					PNode.calc_f()
-					open.ReSort(PNode)//reorder the changed element in the list
+					open.ReSort(PNode.source)//reorder the changed element in the list
 
 	}
 


### PR DESCRIPTION
`ReSort` is expecting an atom, it is passed a datum *containing* an atom.

Tested locally, it doesn't break any existing behaviour, probably fixes a ton of runtimes, and might even fix a few issues related to calculating a path after being off-target for too long.