### PR TITLE
Fixes some issues with midround malf

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -260,10 +260,9 @@
 	var/mob/living/silicon/ai/M = pick(candidates)
 	assigned += M
 	candidates -= M
-	var/datum/role/malfAI/AI = new
-	AI.AssignToRole(M.mind,1)
-	unction.HandleNewMind(M.mind)
-	AI.Greet()
+	var/datum/role/malfAI/malf = unction.HandleNewMind(M.mind)
+	malf.OnPostSetup()
+	malf.Greet()
 	for(var/mob/living/silicon/robot/R in M.connected_robots)
 		unction.HandleRecruitedMind(R.mind)
 	unction.forgeObjectives()
@@ -457,7 +456,7 @@
 	if (!spoider)
 		spoider = ticker.mode.CreateFaction(/datum/faction/spider_clan, null, 1)
 	spoider.HandleRecruitedRole(newninja)
-	
+
 	return ..()
 
 //////////////////////////////////////////////


### PR DESCRIPTION
Notably, it gives them spells, it gives them the laws, and it gives them the ability to hack APCs.

From a technical point of view, the problem was that you were trying to add a mind to a faction when this mind already had a role.

Solves some issues of #23072