### PR TITLE
The station time will now be exported with a status() call

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -19,7 +19,7 @@ var/savefile/panicfile
 		// warn on missing library
 		// extools on linux does not exist and is not in the repository as of yet
 		warning("There is no extools library for this system included with this build. Performance may differ significantly than if it were present. This warning will not show if [extools_path] is added to the root of the game directory.")
-	
+
 	// Honk honk, fuck you science
 	for(var/i=1, i<=map.zLevels.len, i++)
 		WORLD_X_OFFSET += rand(-50,50)
@@ -203,6 +203,7 @@ var/savefile/panicfile
 		s["host"] = host ? host : null
 		s["players"] = list()
 		s["map_name"] = map.nameLong
+		s["station_time"] = worldtime2text()
 		s["gamestate"] = 1
 		if(ticker)
 			s["gamestate"] = ticker.current_state


### PR DESCRIPTION
In practical terms, this + a PR on PJB's repo will allow us to get the station time when you ask the MoMMibot for status on d*scord.
It could also be used to display the station time on the dynamically generated pngs of ss13.moe, but I have no control over that.