### PR TITLE
Makes the plasma cutter generate logs

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1681,7 +1681,8 @@ Game Mode config tags:
 	for(var/client/C in admins)
 		C.output_to_special_tab(sane_msg)
 
-/proc/generic_projectile_fire(var/atom/target, var/atom/source, var/obj/item/projectile/projectile, var/shot_sound)
+// This is awful and probably should be thrown away at some point.
+/proc/generic_projectile_fire(var/atom/target, var/atom/source, var/obj/item/projectile/projectile, var/shot_sound, var/mob/firer)
 	var/turf/T = get_turf(source)
 	var/turf/U = get_turf(target)
 	if (!T || !U)
@@ -1699,8 +1700,8 @@ Game Mode config tags:
 	projectile.original = target
 	projectile.target = U
 	projectile.shot_from = source
-	if(istype(source, /mob))
-		projectile.firer = source
+	projectile.firer = firer
+
 	projectile.current = T
 	projectile.starting = T
 	projectile.yo = U.y - T.y

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_mobs_and_constructs.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_mobs_and_constructs.dm
@@ -130,7 +130,7 @@
 /mob/living/simple_animal/construct/wraith/perfect/RangedAttack(var/atom/A, var/params)
 	if(ranged_cooldown <= 0 && ammo)
 		ammo--
-		generic_projectile_fire(A, src, /obj/item/projectile/wraithnail, 'sound/weapons/hivehand.ogg')
+		generic_projectile_fire(A, src, /obj/item/projectile/wraithnail, 'sound/weapons/hivehand.ogg', src)
 	return ..()
 
 /obj/item/projectile/wraithnail

--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -1063,7 +1063,7 @@ var/list/datum/dna/hivemind_bank = list()
 		var/obj/item/projectile/puke/P = new /obj/item/projectile/puke/clear
 		P.reagents.add_reagent(S, amount)
 		M.visible_message("<span class = 'warning'>\The [M] spits a globule of chemicals!</span>")
-		generic_projectile_fire(get_ranged_target_turf(M, M.dir, 10), M, P, 'sound/weapons/pierce.ogg')
+		generic_projectile_fire(get_ranged_target_turf(M, M.dir, 10), M, P, 'sound/weapons/pierce.ogg', M)
 
 /obj/item/verbs/changeling/proc/changeling_transformation_sting()
 	set category = "Changeling"

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -286,7 +286,7 @@ proc/move_mining_shuttle()
 		return
 	if(current_ammo >0)
 		current_ammo--
-		generic_projectile_fire(A, src, /obj/item/projectile/kinetic/cutter/, 'sound/weapons/Taser.ogg')
+		generic_projectile_fire(A, src, /obj/item/projectile/kinetic/cutter/, 'sound/weapons/Taser.ogg', user)
 		user.delayNextAttack(4)
 	else
 		src.visible_message("*click click*")

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -679,7 +679,7 @@ obj/item/asteroid/basilisk_hide/New()
 
 	switch(fire_extremity)
 		if(1) // Fire spout
-			generic_projectile_fire(get_ranged_target_turf(src, dir, 10), src, /obj/item/projectile/fire_breath, 'sound/weapons/flamethrower.ogg')
+			generic_projectile_fire(get_ranged_target_turf(src, dir, 10), src, /obj/item/projectile/fire_breath, 'sound/weapons/flamethrower.ogg', src)
 			if(environment)
 				environment.add_thermal_energy(350000)
 		if(2) //Fire blast

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -71,7 +71,7 @@ var/list/impact_master = list()
 	var/inaccurate = 0
 
 	var/turf/target = null
-	var/datum/tracker/tracker_datum = null 
+	var/datum/tracker/tracker_datum = null
 	var/tracking = FALSE
 
 	var/dist_x = 0
@@ -372,7 +372,7 @@ var/list/impact_master = list()
 	target = get_turf(proj_target)
 
 	if (tracking)
-		if (istype(proj_target, /atom/movable))	
+		if (istype(proj_target, /atom/movable))
 			var/atom/movable/the_target = proj_target
 			var/datum/tracker/T = new
 			T.name = "[src] tracker on [proj_target]"
@@ -459,7 +459,7 @@ var/list/impact_master = list()
 
 				dist_x = abs(target.x - current.x)
 				dist_y = abs(target.y - current.y)
-				
+
 				if(dist_x > dist_y)
 					error = dist_x/2 - dist_y
 				else


### PR DESCRIPTION
The `generic_projectile_fire()` proc was not passing a firer in 99% of cases.
This fixes that, and make the plasma cutter PKA throw admin logs.