### PR TITLE
Fixed the mess with lamprey's splashscreen

### DIFF
--- a/maps/lampreystation/lamprey.dm
+++ b/maps/lampreystation/lamprey.dm
@@ -338,15 +338,9 @@
 
 /turf/unsimulated/wall/splashscreen/lamprey
 	name = "Lamprey Station"
-	icon = null
-	icon_state = null
-	plane = EFFECTS_PLANE
-/turf/unsimulated/wall/splashscreen/lamprey/canSmoothWith()
-	return null
 
 /turf/unsimulated/wall/splashscreen/lamprey/New()
-	icon = 'icons/splashworks/lampreysplash.dmi'
-	icon_state = "lamprey"
+	icon = 'icons/lampreysplash.dmi'
 
 // Items
 


### PR DESCRIPTION
[![Patreon](https://c5.patreon.com/external/logo/become_a_patron_button.png)](https://www.patreon.com/damianspessmen)
Closes #23814

- Changed the icon state inside lampreysplash.dmi from "lamprey" to null, then moved it out of the splashworks directory so that it doesn't show up on other maps
- Removed extra /turf from lampreystation.dmm
- Cleaned up unnecessary shit from /turf/unsimulated/wall/splashscreen/lamprey