### PR TITLE
Hazard vest suit storage accepts several cargo-related items

### DIFF
--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -192,7 +192,16 @@
 		/obj/item/weapon/tank/emergency_oxygen,
 		/obj/item/weapon/tank/emergency_nitrogen,
 		/obj/item/device/device_analyser,
-		/obj/item/device/rcd)
+		/obj/item/device/rcd,
+		/obj/item/weapon/rcs,
+		/obj/item/weapon/storage/bag/clipboard,
+		/obj/item/weapon/folder,
+		/obj/item/weapon/stamp,
+		/obj/item/device/destTagger,
+		/obj/item/weapon/hand_labeler,
+		/obj/item/device/flashlight,
+		/obj/item/stack/package_wrap,
+		/obj/item/weapon/card/debit)
 	species_fit = list(VOX_SHAPED, INSECT_SHAPED)
 
 //Lawyer

--- a/code/modules/paperwork/envelope.dm
+++ b/code/modules/paperwork/envelope.dm
@@ -37,8 +37,7 @@
 
 /obj/item/weapon/paper/envelope/proc/reapply_stamps()
 	if(!src.stamped)
-		return
-	// var/STAMP_TYPES = list("qm", "cap", "hop", "iaa", "hos", "warden", "ce", "rd", "cmo", "deny", "clown", "mime")
+		return	
 	for(var/typepath in src.stamped)
 		var/suffix = ""
 		if(typepath == /obj/item/weapon/stamp/denied)
@@ -54,7 +53,7 @@
 
 /obj/item/weapon/paper/envelope/attackby(obj/item/weapon/P, mob/user)
 	. = ..()
-	if(.)		
+	if(.)
 		return
 	if(open)
 		if(!is_type_in_list(P, not_allowed))

--- a/code/modules/paperwork/envelope.dm
+++ b/code/modules/paperwork/envelope.dm
@@ -29,9 +29,32 @@
 	else
 		icon_state = "envelope_closed"
 
+	if(sortTag)
+		var/image/tag_overlay = image('icons/obj/storage/storage.dmi', src, "deliverytag")
+		overlays += tag_overlay
+
+	reapply_stamps()
+
+/obj/item/weapon/paper/envelope/proc/reapply_stamps()
+	if(!src.stamped)
+		return
+	// var/STAMP_TYPES = list("qm", "cap", "hop", "iaa", "hos", "warden", "ce", "rd", "cmo", "deny", "clown", "mime")
+	for(var/typepath in src.stamped)
+		var/suffix = ""
+		if(typepath == /obj/item/weapon/stamp/denied)
+			suffix = "deny"
+		else if(typepath == /obj/item/weapon/stamp/judge || typepath == /obj/item/weapon/stamp/captain)
+			suffix = "cap"			
+		else
+			suffix = copytext("[typepath]", 24)			
+		var/image/overlay = image('icons/obj/bureaucracy.dmi', "paper_stamp-[suffix]")
+		overlay.pixel_x = 5 * PIXEL_MULTIPLIER
+		overlay.pixel_y = -2 * PIXEL_MULTIPLIER
+		overlays += overlay;		
+
 /obj/item/weapon/paper/envelope/attackby(obj/item/weapon/P, mob/user)
 	. = ..()
-	if(.)
+	if(.)		
 		return
 	if(open)
 		if(!is_type_in_list(P, not_allowed))
@@ -51,6 +74,7 @@
 			var/tag = uppertext(O.destinations[O.currTag])
 			to_chat(user, "<span class='notice'>*[tag]*</span>")
 			sortTag = tag
+			update_icon()
 			playsound(src, 'sound/machines/twobeep.ogg', 100, 1)			
 			desc = "It has a label reading [tag]."
 

--- a/code/modules/paperwork/envelope.dm
+++ b/code/modules/paperwork/envelope.dm
@@ -51,9 +51,7 @@
 			var/tag = uppertext(O.destinations[O.currTag])
 			to_chat(user, "<span class='notice'>*[tag]*</span>")
 			sortTag = tag
-			playsound(src, 'sound/machines/twobeep.ogg', 100, 1)
-			overlays = 0
-			overlays += image(icon = icon, icon_state = "deliverytag")
+			playsound(src, 'sound/machines/twobeep.ogg', 100, 1)			
 			desc = "It has a label reading [tag]."
 
 /obj/item/weapon/paper/envelope/AltClick(mob/user)

--- a/code/modules/paperwork/stamps.dm
+++ b/code/modules/paperwork/stamps.dm
@@ -19,9 +19,14 @@
 	P.stamps += (P.stamps=="" ? "<HR>" : "<BR>") + "<i>This [P.name] has been stamped with \the [name].</i>"
 
 	var/image/stampoverlay = image('icons/obj/bureaucracy.dmi')
-	stampoverlay.pixel_x = rand(-2, 2) * PIXEL_MULTIPLIER
-	stampoverlay.pixel_y = rand(-3, 2) * PIXEL_MULTIPLIER
-	stampoverlay.icon_state = "paper_[icon_state]"
+	stampoverlay.icon_state = "paper_[icon_state]"	
+	// We have to reapply overlays on envelopes so we can't have random offsets
+	if(istype(P, /obj/item/weapon/paper/envelope))
+		stampoverlay.pixel_x = 5 * PIXEL_MULTIPLIER
+		stampoverlay.pixel_y = -2 * PIXEL_MULTIPLIER
+	else
+		stampoverlay.pixel_x = rand(-2, 2) * PIXEL_MULTIPLIER
+		stampoverlay.pixel_y = rand(-3, 2) * PIXEL_MULTIPLIER
 
 	if(!P.stamped)
 		P.stamped = new


### PR DESCRIPTION
:cl:
 * rscadd: Hazard vest suit storage now accepts clipboards and other cargo-related items
 * bugfix: Fixed a bug that caused the grey destination tagger tag overlay on envelopes to not be applied
 * bugfix: Fixed destination tagger removing stamp overlays on envelopes
 * bugfix: Fixed a bug where the destination tagger would not put a tag overlay on envelopes when used on them.