### PR TITLE
The search for AStar runtimes part 2

### DIFF
--- a/code/controllers/subsystem/pathing.dm
+++ b/code/controllers/subsystem/pathing.dm
@@ -90,7 +90,7 @@ var/global/list/pathmakers = list()
 	var/debug = FALSE //Whether we paint our turfs as we calculate
 	var/PM_id //How we will identify PathNodes associated with this, to prevent PathNode conflict
 
-/datum/path_maker/New(var/nowner, var/nproc_to_call, var/turf/nstart, var/turf/nend, var/atom/ntarget, var/nadjacent, var/ndist, var/nmaxnodes, var/nmaxnodedepth, var/nmintargetdist, var/nid=null, var/turf/nexclude, var/ndebug = TRUE)
+/datum/path_maker/New(var/nowner, var/nproc_to_call, var/turf/nstart, var/turf/nend, var/atom/ntarget, var/nadjacent, var/ndist, var/nmaxnodes, var/nmaxnodedepth, var/nmintargetdist, var/nid=null, var/turf/nexclude, var/ndebug = FALSE)
 	ASSERT(nowner)
 	ASSERT(nstart)
 	ASSERT(nend)

--- a/code/controllers/subsystem/pathing.dm
+++ b/code/controllers/subsystem/pathing.dm
@@ -90,7 +90,7 @@ var/global/list/pathmakers = list()
 	var/debug = FALSE //Whether we paint our turfs as we calculate
 	var/PM_id //How we will identify PathNodes associated with this, to prevent PathNode conflict
 
-/datum/path_maker/New(var/nowner, var/nproc_to_call, var/turf/nstart, var/turf/nend, var/atom/ntarget, var/nadjacent, var/ndist, var/nmaxnodes, var/nmaxnodedepth, var/nmintargetdist, var/nid=null, var/turf/nexclude, var/ndebug)
+/datum/path_maker/New(var/nowner, var/nproc_to_call, var/turf/nstart, var/turf/nend, var/atom/ntarget, var/nadjacent, var/ndist, var/nmaxnodes, var/nmaxnodedepth, var/nmintargetdist, var/nid=null, var/turf/nexclude, var/ndebug = TRUE)
 	ASSERT(nowner)
 	ASSERT(nstart)
 	ASSERT(nend)
@@ -115,6 +115,9 @@ var/global/list/pathmakers = list()
 	pathmakers.Add(src)
 
 /datum/path_maker/proc/can_process()
+	if(gcDestroyed)
+		astar_debug("we can no longer make a path as we are dying")
+		return FALSE
 	if(!owner || owner.gcDestroyed) //crit fail
 		astar_debug("owner no longer exists [owner?"owner is destroyed":"no owner"]")
 		qdel(src)
@@ -209,7 +212,10 @@ var/global/list/pathmakers = list()
 				PNode.distance_from_start = call(cur.source,dist)(T)
 				PNode.distance_from_end = newenddist
 				PNode.calc_f()
-				if(!open.ReSort(PNode.source))//reorder the changed element in the list
+				if (!(PNode in open.L))
+					stack_trace("we found a pathnode, but it wasn't in our list! [PM_id] for a PM belonging to [owner]")
+					open.L.Add(PNode)
+				if(!open.ReSort(PNode))//reorder the changed element in the list
 					astar_debug("failed to reorder, requeuing")
 					open.Enqueue(PNode)
 	astar_debug("open:[open.List().len]")

--- a/code/defines/procs/AStar.dm
+++ b/code/defines/procs/AStar.dm
@@ -63,7 +63,7 @@ length to avoid portals or something i guess?? Not that they're counted right no
 
 //add an element in the list,
 //immediatly ordering it to its position using Insertion sort
-/PriorityQueue/proc/Enqueue(var/atom/A)
+/PriorityQueue/proc/Enqueue(var/PathNode/A)
 	var/i
 	L.Add(A)
 	i = L.len -1
@@ -79,7 +79,7 @@ length to avoid portals or something i guess?? Not that they're counted right no
 	return .
 
 //removes an element
-/PriorityQueue/proc/Remove(var/atom/A)
+/PriorityQueue/proc/Remove(var/PathNode/A)
 	return L.Remove(A)
 
 //returns a copy of the elements list
@@ -88,7 +88,7 @@ length to avoid portals or something i guess?? Not that they're counted right no
 	return ret
 
 //return the position of an element or 0 if not found
-/PriorityQueue/proc/Seek(var/atom/A)
+/PriorityQueue/proc/Seek(var/PathNode/A)
 	return L.Find(A)
 
 //return the element at the i_th position
@@ -97,7 +97,7 @@ length to avoid portals or something i guess?? Not that they're counted right no
 	return L[i]
 
 //replace the passed element at it's right position using the cmp proc
-/PriorityQueue/proc/ReSort(var/atom/A)
+/PriorityQueue/proc/ReSort(var/PathNode/A)
 	var/i = Seek(A)
 	if (i == 0)
 		CRASH("[src] was seeking [A] but could not find it.")
@@ -250,7 +250,10 @@ proc/quick_AStar(start,end,adjacent,dist,maxnodes,maxnodedepth = 30,mintargetdis
 					PNode.prevNode = cur
 					PNode.distance_from_start = newenddist
 					PNode.calc_f()
-					open.ReSort(PNode.source)//reorder the changed element in the list
+					if (!(PNode in open.L))
+						stack_trace("we found a pathnode, but it wasn't in our list! quick_astar, so PMid is 'unique'.")
+						open.L.Add(PNode)
+					open.ReSort(PNode)//reorder the changed element in the list
 
 	}
 

--- a/code/game/machinery/bots/cleanbot.dm
+++ b/code/game/machinery/bots/cleanbot.dm
@@ -265,7 +265,7 @@ text("<A href='?src=\ref[src];operation=oddbutton'>[src.oddbutton ? "Yes" : "No"
 	if(isliving(A))
 		var/mob/living/L = A
 		annoy(L)
-		..()
+	..()
 
 /obj/machinery/bot/cleanbot/proc/attack_cooldown()
 	coolingdown = TRUE


### PR DESCRIPTION
I was mistaken with my first "runtime bugfix". The PriorityQueue actually *wants* PathNodes datums ; it just so happen that the procs prototypes are confusing regarding this.

I have noticed that the `Crossed()` code of the Roomba is not working properly and lacks a call to the parent. This fixes that.

PathMakers will no longer try to make a path if they've been destroyed (for instance, if the bot dies before reaching its destination).

I think the real reason for those runtimes is that a single PathNode belongs to more than one path, which may be causing trouble down the road. I could not reproduce it locally, so I've spammed the runtime log with more informative messages than previously.
The issue is that the PriorityQueue is seeking a PathNode but cannot find it, so I've made it so the node is actually added to the queue if/when that happens.

The next step is of course to prevent this kind of error from happening in the first place.