### PR TITLE
An experiment on making higher threat rulesets more common.

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic.dm
+++ b/code/datums/gamemode/dynamic/dynamic.dm
@@ -261,15 +261,6 @@ var/stacking_limit = 90
 	if (forced_extended)
 		message_admins("Starting a round of forced extended.")
 		return 1
-	var/list/drafted_rules = list()
-	var/i = 0
-	for (var/datum/dynamic_ruleset/roundstart/rule in roundstart_rules)
-		if (rule.acceptable(roundstart_pop_ready,threat_level) && threat >= rule.cost)	//if we got the population and threat required
-			i++																			//we check whether we've got eligible players
-			rule.candidates = candidates.Copy()
-			rule.trim_candidates()
-			if (rule.ready())
-				drafted_rules[rule] = rule.weight
 
 	var/indice_pop = min(10,round(roundstart_pop_ready/5)+1)
 	var/extra_rulesets_amount = 0
@@ -294,10 +285,27 @@ var/stacking_limit = 90
 
 	if	(extra_rulesets_amount && prob(50))
 		message_admins("Rather than extra rulesets, we'll try to draft spicier ones.")
-		for (var/datum/dynamic_ruleset/rule in subtypesof(/datum/dynamic_ruleset))
+		for (var/datum/dynamic_ruleset/rule in roundstart_rules)
+			if (rule.flags & HIGHLANDER_RULESET)
+				rule.weight += extra_rulesets_amount
+		for (var/datum/dynamic_ruleset/rule in midround_rules)
+			if (rule.flags & HIGHLANDER_RULESET)
+				rule.weight += extra_rulesets_amount
+		for (var/datum/dynamic_ruleset/rule in latejoin_rules)
 			if (rule.flags & HIGHLANDER_RULESET)
 				rule.weight += extra_rulesets_amount
 		extra_rulesets_amount = 0
+
+	var/i = 0
+	var/list/drafted_rules = list()
+	
+	for (var/datum/dynamic_ruleset/roundstart/rule in roundstart_rules)
+		if (rule.acceptable(roundstart_pop_ready,threat_level) && threat >= rule.cost)	//if we got the population and threat required
+			i++																			//we check whether we've got eligible players
+			rule.candidates = candidates.Copy()
+			rule.trim_candidates()
+			if (rule.ready())
+				drafted_rules[rule] = rule.weight
 
 	if (classic_secret)
 		message_admins("Classic secret was forced.")

--- a/code/datums/gamemode/dynamic/dynamic.dm
+++ b/code/datums/gamemode/dynamic/dynamic.dm
@@ -292,6 +292,13 @@ var/stacking_limit = 90
 				if (threat_level >= third_rule_req[indice_pop])
 					extra_rulesets_amount++
 
+	if	(extra_rulesets_amount && prob(50))
+		message_admins("Rather than extra rulesets, we'll try to draft spicier ones.")
+		for (var/datum/dynamic_ruleset/rule in subtypesof(/datum/dynamic_ruleset))
+			if (rule.flags & HIGHLANDER_RULESET)
+				rule.weight += extra_rulesets_amount
+		extra_rulesets_amount = 0
+
 	if (classic_secret)
 		message_admins("Classic secret was forced.")
 	else

--- a/code/datums/gamemode/dynamic/dynamic_rulesets.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets.dm
@@ -118,6 +118,8 @@
 		for(var/datum/dynamic_ruleset/DR in mode.executed_rules)
 			if(istype(DR,src.type))
 				weight = max(weight-2,1)
+			if(DR.role_category == src.role_category) // Same kind of antag.
+				weight = max(weight-1,1)
 	message_admins("[name] had [weight] weight (-[initial(weight) - weight]).")
 	return weight
 

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
@@ -46,7 +46,7 @@
 							"Captain", "Merchant", "Chief Engineer", "Chief Medical Officer", "Research Director")
 	restricted_from_jobs = list("AI","Cyborg","Mobile MMI")
 	required_candidates = 1
-	weight = 7
+	weight = 6
 	cost = 5
 	requirements = list(40,30,20,10,10,10,10,10,10,10)
 	high_population_requirement = 10

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -168,7 +168,7 @@
 							"Cyborg", "Merchant", "Chief Engineer", "Chief Medical Officer", "Research Director")
 	restricted_from_jobs = list("AI","Mobile MMI")
 	required_candidates = 1
-	weight = 7
+	weight = 6
 	cost = 10
 	requirements = list(50,40,30,20,10,10,10,10,10,10)
 	repeatable = TRUE


### PR DESCRIPTION
Without making rounds more gunked.

### Foreword

Yet another PR to throw numbers at dynamic. But we try to throw numbers in a *smart* way.
The key intent of this PR is to make traitor slightly less common, spicer gamemodes more common, without trying to slip back into "cultmalfrev" of early dynamic.

There's 3 changes.

### Changes

First, the *weight* of traitor-type rulesets has been lowered for midround and latejoin. (7 => 6)
**Reasoning :** This brings midround traitor and latejoin infiltrator more in line to roundstrart traitor. They shouldn't dwarf the other rulesets when dynamic picks a ruleset.

Secondly, the weight of a ruleset is reduced if a "sister" ruleset has been drafted is reduced a bit. If there's been traitor roundstart, perhaps it's better to send in another antag midround. Again, this is so midround traitor and latejoin traitor are no longer always bigger in weight than other rulesets.

Thirdly, and most importantly, if there's enough pop, and enough threat, instead of drafting more rulesets, there's a chance that "spicer" rulesets (the round-enders, which can't normally be drafted at the same time) will get a boost instead.

In short, if you've got a lot of threat and pop, there's less chance of "Vampire+Traitors" and more of "Nuclear Operatives" (alone).

:cl:
- tweak: Dynamic mode changes! (again!)
- tweak: Frequency of midround and latejoin traitor reduced, to give more room for other antag types.
- tweak: If the threat is high enough, there's a chance of boosting "round-ending" rulesets (like Revolution, Nuclear Operatives, Cult, AI malfunction...) instead of simply drafting more rulesets.