### PR TITLE
Simpolinol

### DIFF
--- a/__DEFINES/reagents.dm
+++ b/__DEFINES/reagents.dm
@@ -90,6 +90,7 @@
 #define DEXALIN 			"dexalin"
 #define DEXALINP 			"dexalinp"
 #define TRICORDRAZINE 			"tricordrazine"
+#define SIMPOLINOL			"simpolinol"
 #define ADMINORDRAZINE 			"adminordrazine"
 #define SYNAPTIZINE 			"synaptizine"
 #define IMPEDREZENE 			"impedrezene"

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -178,6 +178,9 @@ Subject's pulse: ??? BPM"})
 		message += "<span class='notice'>Analyzing Results for [M]:<br>Overall Status: Dead</span><br>"
 	else
 		message += "<span class='notice'>Analyzing Results for [M]:<br>Overall Status: [M.stat > 1 ? "Dead" : "[M.health - M.halloss]% Healthy"]</span>"
+	if(isanimal(M))
+		to_chat(user, message)//Simple animal, we don't care about anything else.
+		return message
 	message += "<br>Key: <span class='notice'>Suffocation</span>/<font color='green'>Toxin</font>/<font color='#FFA500'>Burns</font>/<span class='red'>Brute</span>"
 	message += "<br>Damage Specifics: <span class='notice'>[OX]</span> - <font color='green'>[TX]</font> - <font color='#FFA500'>[BU]</font> - <span class='red'>[BR]</span>"
 	message += "<br>[(M.undergoing_hypothermia()) ?  "<span class='warning'>" : "<span class='notice'>"]Body Temperature: [round(M.bodytemperature-T0C,0.1)]&deg;C ([round(M.bodytemperature*1.8-459.67,0.1)]&deg;F)</span>"

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -2514,6 +2514,24 @@
 	if(M.getToxLoss())
 		M.adjustToxLoss(-REM)
 
+/datum/reagent/simpolinol
+	name = "Simpolinol"
+	id = SIMPOLINOL
+	description = "A broad spectrum rejuvenant used to heal fauna with less complex cardiovascular systems. Not for human injestion."
+	reagent_state = REAGENT_STATE_LIQUID
+	color = "#A5A5FF" //rgb: 165, 165, 255
+	density = 1.58
+	specheatcap = 0.44
+
+/datum/reagent/simpolinol/on_mob_life(var/mob/living/M)
+
+	if(..())
+		return 1
+	if(isanimal(M))
+		M.health = min(M.maxHealth, M.health + REM)
+	else
+		M.adjustToxLoss(5)
+
 //An OP chemical for admins and detecting exploits
 /datum/reagent/adminordrazine
 	name = "Adminordrazine"
@@ -6777,7 +6795,7 @@
 			H.remove_spell(spell)
 		if (istype(H.wear_mask, /obj/item/clothing/mask/gas/mime/stickymagic))
 			qdel(H.wear_mask)
-			H.visible_message("<span class='warning'>\The [H]'s mask melts!</span>")			
+			H.visible_message("<span class='warning'>\The [H]'s mask melts!</span>")
 		H.visible_message("<span class='notice'>\The [H]'s face goes pale for a split second, and then regains some colour.</span>", "<span class='notice'><i>Where did Marcel go...?</i></span>'")
 
 

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -367,6 +367,21 @@
 	required_reagents = list(INAPROVALINE = 1, ANTI_TOXINS = 1)
 	result_amount = 2
 
+/datum/chemical_reaction/simpolinol
+	name = "Simpolinol"
+	id = SIMPOLINOL
+	result = SIMPOLINOL
+	required_reagents = list(METHYLIN = 20, SILVER = 20)
+	result_amount = 40
+
+/datum/chemical_reaction/simpolinol2
+	name = "Simpolinol"
+	id = "simpolinol_alternate"
+	result = SIMPOLINOL
+	required_reagents = list(VAPORSALT = 1)
+	required_container = /obj/item/weapon/reagent_containers/food/drinks/soda_cans
+	result_amount = 1
+
 /datum/chemical_reaction/alkysine
 	name = "Alkysine"
 	id = ALKYSINE


### PR DESCRIPTION
I think Bomber Harris requested this
![image](https://user-images.githubusercontent.com/9782036/79696985-9c02b980-8245-11ea-9c45-853213970fc1.png)


🆑 
* rscadd: New from NT labs, it's Simpolinol. Inject it into simple animals to heal them. Poisons more complex organisms. Great for miners, ranchers, or even just pet enthusiasts.
* rscadd: You can mix up your own, just mix methylin with some ground up silver. Bootleggers can duplicate the process by pouring vapor salts into any sort of aluminum can, like those used in soda...
* tweak: When using the health analyzer on simple mobs, it no longer shows all the damage types they don't have. Instead it just shows their current health.