### PR TITLE
Shades made by non-cultists are not-cult shades

### DIFF
--- a/code/datums/gamemode/factions/legacy_cult/soulstone.dm
+++ b/code/datums/gamemode/factions/legacy_cult/soulstone.dm
@@ -315,7 +315,12 @@
 	log_admin("BLOODCULT: [key_name(body)] has been soul-stoned by [key_name(user)][iscultist(user) ? ", a cultist." : "a NON-cultist."].")
 
 	//Creating a shade inside the stone and putting the victim in control
-	var/mob/living/simple_animal/shade/shadeMob = new(src)//put shade in stone
+	var/AreYouACultShadeOrANormalShade = target
+	if(iscultist(user))
+		AreYouACultShadeOrANormalShade = new /mob/living/simple_animal/shade(src)//put shade in stone
+	else
+		AreYouACultShadeOrANormalShade = new /mob/living/simple_animal/shade/noncult(src)
+	var/mob/living/simple_animal/shade/shadeMob = AreYouACultShadeOrANormalShade
 	shadeMob.status_flags |= GODMODE //So they won't die inside the stone somehow
 	shadeMob.canmove = 0//Can't move out of the soul stone
 	shadeMob.name = "[true_name] the Shade"

--- a/code/datums/gamemode/factions/legacy_cult/soulstone.dm
+++ b/code/datums/gamemode/factions/legacy_cult/soulstone.dm
@@ -315,12 +315,11 @@
 	log_admin("BLOODCULT: [key_name(body)] has been soul-stoned by [key_name(user)][iscultist(user) ? ", a cultist." : "a NON-cultist."].")
 
 	//Creating a shade inside the stone and putting the victim in control
-	var/AreYouACultShadeOrANormalShade = target
+	var/mob/living/simple_animal/shade/shadeMob = target
 	if(iscultist(user))
-		AreYouACultShadeOrANormalShade = new /mob/living/simple_animal/shade(src)//put shade in stone
+		shadeMob = new /mob/living/simple_animal/shade(src)//put shade in stone
 	else
-		AreYouACultShadeOrANormalShade = new /mob/living/simple_animal/shade/noncult(src)
-	var/mob/living/simple_animal/shade/shadeMob = AreYouACultShadeOrANormalShade
+		shadeMob = new /mob/living/simple_animal/shade/noncult(src)
 	shadeMob.status_flags |= GODMODE //So they won't die inside the stone somehow
 	shadeMob.canmove = 0//Can't move out of the soul stone
 	shadeMob.name = "[true_name] the Shade"

--- a/code/datums/gamemode/factions/legacy_cult/soulstone.dm
+++ b/code/datums/gamemode/factions/legacy_cult/soulstone.dm
@@ -315,7 +315,7 @@
 	log_admin("BLOODCULT: [key_name(body)] has been soul-stoned by [key_name(user)][iscultist(user) ? ", a cultist." : "a NON-cultist."].")
 
 	//Creating a shade inside the stone and putting the victim in control
-	var/mob/living/simple_animal/shade/shadeMob = target
+	var/mob/living/simple_animal/shade/shadeMob
 	if(iscultist(user))
 		shadeMob = new /mob/living/simple_animal/shade(src)//put shade in stone
 	else

--- a/code/modules/clothing/masks/mystic.dm
+++ b/code/modules/clothing/masks/mystic.dm
@@ -69,7 +69,7 @@ var/list/has_been_shade = list()
 		flick("happiest_flash", src)
 		has_been_shade.Add(M.mind)
 		var/mob/dead/observer/G = M.ghostize(1)
-		var/mob/living/simple_animal/shade/happiest/S = G.transmogrify(/mob/living/simple_animal/shade/happiest, TRUE)
+		var/mob/living/simple_animal/shade/noncult/happiest/S = G.transmogrify(/mob/living/simple_animal/shade/noncult/happiest, TRUE)
 		S.name = "[M.real_name] the Shade"
 		S.real_name = "[M.real_name]"
 		S.cancel_camera()

--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -30,10 +30,12 @@
 	flying = TRUE
 	meat_type = /obj/item/weapon/ectoplasm
 	mob_property_flags = MOB_SUPERNATURAL
+	var/given_cult_language = 1 //1 means they will gain the cult language, 0 means they won't
 
 /mob/living/simple_animal/shade/New()
 	..()
-	add_language(LANGUAGE_CULT)
+	if(given_cult_language)
+		add_language(LANGUAGE_CULT)
 
 /mob/living/simple_animal/shade/death(var/gibbed = FALSE)
 	var/turf/T = get_turf(src)
@@ -229,8 +231,8 @@
 
 /mob/living/simple_animal/shade/noncult
 	desc = "A bound spirit. This one appears more in tune with the realm of the dead."
-	universal_speak = 1 //They're ghosts, ain't gonna explain stuff
-	universal_understand = 1
+	universal_understand = 1 //They're closer to their observer selves, hence can understand any language
 	faction = "neutral"
 	icon_state = "ghost-narsie"
 	icon_living = "ghost-narsie"
+	given_cult_language = 0

--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -168,7 +168,7 @@
 			else
 				healths.icon_state = "shade_health7"
 
-/mob/living/simple_animal/shade/happiest/death(var/gibbed = FALSE)
+/mob/living/simple_animal/shade/noncult/happiest/death(var/gibbed = FALSE)
 	..(TRUE)
 	transmogrify()
 	if(!gcDestroyed)
@@ -226,3 +226,8 @@
 			BS.perform(src)
 			return
 	..()
+
+/mob/living/simple_animal/shade/noncult/New()
+	..()
+	add_language(LANGUAGE_GALACTIC_COMMON)
+	faction = "neutral"

--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -229,5 +229,6 @@
 
 /mob/living/simple_animal/shade/noncult/New()
 	..()
-	add_language(LANGUAGE_GALACTIC_COMMON)
+	universal_speak = 1 //They're ghosts, ain't gonna explain stuff
+	universal_understand = 1
 	faction = "neutral"

--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -30,12 +30,10 @@
 	flying = TRUE
 	meat_type = /obj/item/weapon/ectoplasm
 	mob_property_flags = MOB_SUPERNATURAL
-	var/given_cult_language = 1 //1 means they will gain the cult language, 0 means they won't
 
 /mob/living/simple_animal/shade/New()
 	..()
-	if(given_cult_language)
-		add_language(LANGUAGE_CULT)
+	add_language(LANGUAGE_CULT)
 
 /mob/living/simple_animal/shade/death(var/gibbed = FALSE)
 	var/turf/T = get_turf(src)
@@ -235,4 +233,7 @@
 	faction = "neutral"
 	icon_state = "ghost-narsie"
 	icon_living = "ghost-narsie"
-	given_cult_language = 0
+
+/mob/living/simple_animal/shade/noncult/New()
+	..()
+	remove_language(LANGUAGE_CULT)

--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -227,8 +227,10 @@
 			return
 	..()
 
-/mob/living/simple_animal/shade/noncult/New()
-	..()
+/mob/living/simple_animal/shade/noncult
+	desc = "A bound spirit. This one appears more in tune with the realm of the dead."
 	universal_speak = 1 //They're ghosts, ain't gonna explain stuff
 	universal_understand = 1
 	faction = "neutral"
+	icon_state = "ghost-narsie"
+	icon_living = "ghost-narsie"


### PR DESCRIPTION
They can understand any language because they are closer to being observers. On top of that, because they are not corrupted by Nar'sie they can speak normally.
Happiest Mask shades are also non-cult shades
Thanks to @gbasood and @ShiftyRail for help

:cl:
 * rscadd: Added non-cult shades, they come out of the attempt of a non-cultist to make shades. They can understand any speech and speak normally.
 * tweak: Happiest Mask shades are non-cult shades.