### PR TITLE
Stun Bullet Rework Part II

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -104,10 +104,10 @@
 
 /obj/item/projectile/bullet/midbullet
 	damage = 20
-	stun = 5
+	stun = 2
 	weaken = 5
 	fire_sound = 'sound/weapons/Gunshot_c20.ogg'
-	projectile_speed = 1
+	projectile_speed = 0.5
 
 /obj/item/projectile/bullet/midbullet/lawgiver
 	damage = 10
@@ -149,10 +149,10 @@
 
 /obj/item/projectile/bullet/fourtyfive/rubber
 	damage = 10
-	stun = 5
+	stun = 2
 	weaken = 5
 	penetration = 1
-	projectile_speed = 1
+	projectile_speed = 0.5
 
 /obj/item/projectile/bullet/auto380 //new sec pistol ammo, reverse name because lol compiler
 	damage = 15
@@ -169,11 +169,11 @@
 
 /obj/item/projectile/bullet/auto380/rubber
 	damage = 8
-	stun = 5
+	stun = 2
 	weaken = 5
 	embed = 0
 	penetration = 0
-	projectile_speed = 1
+	projectile_speed = 0.5
 
 /obj/item/projectile/bullet/stunshot
 	name = "stunshot"


### PR DESCRIPTION
I've made an attempt at rebalancing ballistic stuns in the other direction from Shifty's old PR. I've returned all ballistic stun bullets, (rubbers, C20, etc) to their original speed. In exchange I've reduced their stun times from the full 10 seconds to 4 seconds. This will hopefully make them less "one and done" tools for every scenario. It should also give a distinct reason to use a taser over ballistic stuns.

As I've mentioned this before, this won't prevent them from being effective tools at close range, but should give someone tagged by one from afar a better chance to get up. 

[tweak]

:cl:
 * tweak: Made C20R rounds, .380 and .45 rubber rounds standard ballistic speed, reduced stun time from 10 to 4 seconds. 
