### PR TITLE
hotfix for rev flash runtime, which did not prevent execution of any related code

### DIFF
--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -289,10 +289,9 @@
 							icon_state = "flashburnt"
 
 						// log the recruitment
-						var/datum/role/revolutionary/R = user.mind.GetRoleByType(/datum/role/revolutionary/leader)
-						if(istype(R.stat_datum, /datum/stat/role/revolutionary/leader))
-							var/datum/stat/role/revolutionary/leader/SD = R.stat_datum
-							SD.recruits_converted++
+						var/datum/stat/role/revolutionary/leader/SD = rev.stat_datum
+						SD.recruits_converted++
+
 					else if(result == ADD_REVOLUTIONARY_FAIL_IS_COMMAND)
 						to_chat(user, "<span class='warning'>This mind seems resistant to the flash!</span>")
 					else if(result == ADD_REVOLUTIONARY_FAIL_IS_JOBBANNED) // rev jobbanned


### PR DESCRIPTION
[hotfix]
As said in title, it didn't prevent conversions or anything else. It was at the end of an if block with no code after that block outside of an else