### PR TITLE
Forgot this for #26231

### DIFF
--- a/code/modules/paperwork/envelope.dm
+++ b/code/modules/paperwork/envelope.dm
@@ -43,7 +43,9 @@
 		if(typepath == /obj/item/weapon/stamp/denied)
 			suffix = "deny"
 		else if(typepath == /obj/item/weapon/stamp/judge || typepath == /obj/item/weapon/stamp/captain)
-			suffix = "cap"			
+			suffix = "cap"
+		else if(typepath == /obj/item/weapon/stamp)		
+			suffix = "qm"
 		else
 			suffix = copytext("[typepath]", 24)			
 		var/image/overlay = image('icons/obj/bureaucracy.dmi', "paper_stamp-[suffix]")


### PR DESCRIPTION
I forgot a case for the base /obj/item/weapon/stamp which caused the bugfix to not apply to it while working with all the other stamps. The quartermaster's stamp on box uses the base class so that's an issue