### PR TITLE
Summon spells are now challengey spells

### DIFF
--- a/code/game/gamemodes/wizard/artifacts.dm
+++ b/code/game/gamemodes/wizard/artifacts.dm
@@ -177,7 +177,8 @@
 //SUMMON GUNS
 /datum/spellbook_artifact/summon_guns
 	name = "Summon Guns"
-	desc = "Nothing could possibly go wrong with arming a crew of lunatics just itching for an excuse to kill eachother. Just be careful not to get hit in the crossfire!"
+	desc = "Arm the crew with a wide variety of guns, increasing the difficulty of facing the station."
+	one_use = TRUE
 	abbreviation = "SG"
 	price = -Sp_BASE_PRICE
 
@@ -195,7 +196,8 @@
 //SUMMON MAGIC
 /datum/spellbook_artifact/summon_magic
 	name = "Summon Magic"
-	desc = "Share the power of magic with the crew and turn them against each other. Or just empower them against you."
+	desc = "Share the power of magic with the crew, increasing the difficulty of facing the station."
+	one_use = TRUE
 	abbreviation = "SM"
 	price = -Sp_BASE_PRICE
 
@@ -212,7 +214,8 @@
 //SUMMON SWORDS
 /datum/spellbook_artifact/summon_swords
 	name = "Summon Swords"
-	desc = "Launch a crusade or just spark a blood bath. Either way there will be limbs flying and blood spraying."
+	desc = "Arm the crew with many melee weaponry, slightly increasing the difficulty of facing the station."
+	one_use = TRUE
 	abbreviation = "SS"
 	price = -Sp_BASE_PRICE/2
 

--- a/code/game/gamemodes/wizard/artifacts.dm
+++ b/code/game/gamemodes/wizard/artifacts.dm
@@ -179,6 +179,7 @@
 	name = "Summon Guns"
 	desc = "Nothing could possibly go wrong with arming a crew of lunatics just itching for an excuse to kill eachother. Just be careful not to get hit in the crossfire!"
 	abbreviation = "SG"
+	price = -Sp_BASE_PRICE
 
 /datum/spellbook_artifact/summon_guns/can_buy(var/mob/user)
 	//Only roundstart wizards may summon guns, magic, or blades
@@ -196,6 +197,7 @@
 	name = "Summon Magic"
 	desc = "Share the power of magic with the crew and turn them against each other. Or just empower them against you."
 	abbreviation = "SM"
+	price = -Sp_BASE_PRICE
 
 /datum/spellbook_artifact/summon_magic/can_buy(var/mob/user)
 	//Only roundstart wizards may summon guns, magic, or blades
@@ -212,6 +214,7 @@
 	name = "Summon Swords"
 	desc = "Launch a crusade or just spark a blood bath. Either way there will be limbs flying and blood spraying."
 	abbreviation = "SS"
+	price = -Sp_BASE_PRICE/2
 
 /datum/spellbook_artifact/summon_swords/can_buy(var/mob/user)
 	//Only roundstart wizards may summon guns, magic, or blades

--- a/code/game/gamemodes/wizard/rightandwrong.dm
+++ b/code/game/gamemodes/wizard/rightandwrong.dm
@@ -1,6 +1,6 @@
 
 
-/mob/proc/rightandwrong(var/summon_type) //0 = Summon Guns, 1 = Summon Magic, 2 = Summon Swords
+/mob/proc/rightandwrong(var/summon_type, var/summons_antags) //0 = Summon Guns, 1 = Summon Magic, 2 = Summon Swords
 	to_chat(usr, "<B>You summoned [summon_type]!</B>")
 	message_admins("[key_name_admin(usr, 1)] summoned [summon_type]!")
 	log_game("[key_name(usr)] summoned [summon_type]!")
@@ -20,7 +20,7 @@
 		if(H.stat == DEAD || !(H.client) || iswizard(H))
 			continue
 
-		if (prob(65))
+		if (prob(65) || !summons_antags)
 			H.equip_survivor(survivor_type)
 			continue
 

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -213,7 +213,10 @@
 	var/spell_name = initial(abstract_spell.name)
 	var/spell_cooldown = get_spell_cooldown_string(initial(abstract_spell.charge_max), initial(abstract_spell.charge_type))
 	var/spell_price = get_spell_price(abstract_spell)
-	dat += "<strong>[spell_name]</strong>[spell_cooldown] ([buy_href_link(spell_path, spell_price, "buy for [spell_price] point\s")])<br>"
+	if(spell_price < 0) //Done this way to not turn a line into spaghetti
+		dat += "<strong>[spell_name]</strong>[spell_cooldown] ([buy_href_link(spell_path, spell_price, "gain [-spell_price] point\s")])<br>"
+	else
+		dat += "<strong>[spell_name]</strong>[spell_cooldown] ([buy_href_link(spell_path, spell_price, "buy for [spell_price] point\s")])<br>"
 	dat += "<em>[initial(abstract_spell.desc)]</em><br>"
 	var/flags = initial(abstract_spell.spell_flags)
 	var/list/properties = get_spell_properties(flags, user)


### PR DESCRIPTION
They no longer create antags and instead only arm the crew with whatever was summoned, but now they instead **give** spell-points when summoned.
All 3 are **one-time** use.
Summon Guns and Summon Spells will grant 20 points, while Summon Swords grants 10 points for a total of 50 extra points.
I made this partly because I like the concept of wizard challenges for extra points and partly because at least a few people don't like premature round ends caused by a survivor or two deciding to survive by killing everyone else.
Also added a spellbook thing where if the price is negative it will tell you that you can gain points instead of that it costs points

Q: Wouldn't that give the crew enough self-defense tools to defend themselves against antagonists, thus making any existing antagonists antagonized by the wizard and inactive?
A: The same thing happens if the round survives the survivors, the round's dynamics have already changed by summoning stuff.
Q: Is this a good change?
A: I dunno, I'm not a good judge of quality even if I like to shitpost about how much of a good judge of quality I am.
Q: What's with the Q&A?
A: Hoping that it might elaborate some things but honestly I can't think of many questions and answers

:cl:
 * rscadd: The roundstart wizard's summon spells no longer create any survivors, but instead give the wizard up to 50 extra spell-points if all 3 are summoned.