### PR TITLE
Actually fixes AStar runtimes

### DIFF
--- a/code/controllers/subsystem/pathing.dm
+++ b/code/controllers/subsystem/pathing.dm
@@ -110,7 +110,7 @@ var/global/list/pathmakers = list()
 	exclude = nexclude
 	debug = ndebug
 	path_count++
-	PM_id = "PM_[path_count]"
+	PM_id = "PM_[path_count]_\ref[owner]"
 	open.Enqueue(new /PathNode(start,null,0,call(start,dist)(end),0,PM_id))
 	pathmakers.Add(src)
 
@@ -118,6 +118,9 @@ var/global/list/pathmakers = list()
 	if(!owner || owner.gcDestroyed) //crit fail
 		astar_debug("owner no longer exists [owner?"owner is destroyed":"no owner"]")
 		qdel(src)
+		return FALSE
+	if(gcDestroyed)
+		astar_debug("We are being deleted")
 		return FALSE
 	if(get_turf(owner) != start)
 		astar_debug("owner not in start position")
@@ -209,7 +212,7 @@ var/global/list/pathmakers = list()
 				PNode.distance_from_start = call(cur.source,dist)(T)
 				PNode.distance_from_end = newenddist
 				PNode.calc_f()
-				if(!open.ReSort(PNode.source))//reorder the changed element in the list
+				if(!open.ReSort(PNode))//reorder the changed element in the list
 					astar_debug("failed to reorder, requeuing")
 					open.Enqueue(PNode)
 	astar_debug("open:[open.List().len]")

--- a/code/datums/disease.dm
+++ b/code/datums/disease.dm
@@ -145,7 +145,7 @@ var/list/diseases = typesof(/datum/disease) - /datum/disease
 
 	if(isturf(source.loc))
 		for(var/mob/living/carbon/M in oview(check_range, source))
-			if(isturf(M.loc) && quick_AStar(source.loc, M, /turf/proc/AdjacentTurfs, /turf/proc/Distance, check_range))
+			if(isturf(M.loc) && quick_AStar(source.loc, M, /turf/proc/AdjacentTurfs, /turf/proc/Distance, check_range, reference="\ref[src]"))
 				M.contract_disease(src, 0, 1, force_spread)
 
 /datum/disease/proc/process()

--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -960,7 +960,7 @@ var/list/datum/dna/hivemind_bank = list()
 		return 0 //One is inside, the other is outside something.
 	if(sting_range < 2)
 		return Adjacent(M)
-	if(quick_AStar(src.loc, M.loc, /turf/proc/AdjacentTurfs, /turf/proc/Distance, sting_range)) //If a path exists, good!
+	if(quick_AStar(src.loc, M.loc, /turf/proc/AdjacentTurfs, /turf/proc/Distance, sting_range, reference="\ref[src]")) //If a path exists, good!
 		return 1
 	return 0
 

--- a/code/game/machinery/bots/bots.dm
+++ b/code/game/machinery/bots/bots.dm
@@ -379,7 +379,7 @@
 	log_astar_beacon("[new_destination]")
 	if ((get_dist(src, target) < 13) && !(flags & BOT_NOT_CHASING)) // For beepers and ED209
 		// IMPORTANT: Quick AStar only takes TURFS as arguments.
-		path = quick_AStar(src.loc, get_turf(target), /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance_cardinal, 0, max(10,get_dist(src,target)*3), id=botcard, exclude=avoid)
+		path = quick_AStar(src.loc, get_turf(target), /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance_cardinal, 0, max(10,get_dist(src,target)*3), id=botcard, exclude=avoid, reference="\ref[src]")
 		if (!path) // Important because if quick_Astar fails, it returns null, not an empty list.
 			path = list()
 		return TRUE

--- a/code/game/machinery/bots/cleanbot.dm
+++ b/code/game/machinery/bots/cleanbot.dm
@@ -265,7 +265,7 @@ text("<A href='?src=\ref[src];operation=oddbutton'>[src.oddbutton ? "Yes" : "No"
 	if(isliving(A))
 		var/mob/living/L = A
 		annoy(L)
-		..()
+	..()
 
 /obj/machinery/bot/cleanbot/proc/attack_cooldown()
 	coolingdown = TRUE

--- a/code/modules/spells/aoe_turf/conjure/bats.dm
+++ b/code/modules/spells/aoe_turf/conjure/bats.dm
@@ -32,7 +32,7 @@
 		if(locs.len >= 3) //we found 3 locations and thats all we need
 			break
 		var/turf/T = get_step(user, direction) //getting a loc in that direction
-		if(quick_AStar(user.loc, T, /turf/proc/AdjacentTurfs, /turf/proc/Distance, 1)) // if a path exists, so no dense objects in the way its valid salid
+		if(quick_AStar(user.loc, T, /turf/proc/AdjacentTurfs, /turf/proc/Distance, 1, reference="\ref[src]")) // if a path exists, so no dense objects in the way its valid salid
 			locs += T
 		else
 

--- a/code/modules/spells/aoe_turf/conjure/pitbulls.dm
+++ b/code/modules/spells/aoe_turf/conjure/pitbulls.dm
@@ -31,7 +31,7 @@ var/list/pitbulls_exclude_kinlist = list() //all pitbulls go in here so pitbulls
 		if(locs.len >= 3) //we found 3 locations and thats all we need
 			break
 		var/turf/T = get_step(user, direction) //getting a loc in that direction
-		if(quick_AStar(get_turf(user), T, /turf/proc/AdjacentTurfs, /turf/proc/Distance, 1)) // if a path exists, so no dense objects in the way its valid salid
+		if(quick_AStar(get_turf(user), T, /turf/proc/AdjacentTurfs, /turf/proc/Distance, 1, reference="\ref[src]")) // if a path exists, so no dense objects in the way its valid salid
 			locs += T
 
 	if(locs.len < 3) //if we only found one location, spawn more on top of our tile so we dont get stacked pitbulls


### PR DESCRIPTION
First, apologies for crashing the serb, I didn't know that `stack_trace` would end up being so heavy. 
But at least it gave me a clear insight on the problem, which was that bots would sometimes give the same pathnode ID to the same turf.

The way to fix that is to give a unique reference to each and every AStar proc or pathing subs. This way, if 4 Beepksies share the same patrol path, they will no longer runtime at each other.

Likewise, 3 Beepskies chasing the same criminal will no longer brick two of them.

I tested it ; no runtimes on the behaviour which I suspect caused runtimes before, bots can still patrol and reach targets properly.
