### PR TITLE
Aghost Toggle Windoor

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -215,6 +215,15 @@
 	add_hiddenprint(user)
 	return attack_hand(user)
 
+/obj/machinery/door/window/attack_ghost(mob/user)
+	if(isAdminGhost(user))
+		if (!density)
+			return close()
+		else
+			return open()
+	else
+		..()
+
 /obj/machinery/door/window/attack_paw(mob/living/user)
 	if(istype(user, /mob/living/carbon/alien/humanoid) || istype(user, /mob/living/carbon/slime/adult))
 		if(operating)


### PR DESCRIPTION
I come from the Alpha Worldline where you could always toggle windoors as an adminghost. I'm not exactly sure how I got into this timeline but I'm importing this feature from there.

Shouldn't be any licensing issues since we use the same license on the other worldline. No CL because admin change.

100% tested