### PR TITLE
Clown Ops Rainbow Laser Gun Edition

### DIFF
--- a/code/game/objects/loadouts.dm
+++ b/code/game/objects/loadouts.dm
@@ -187,6 +187,13 @@
 						/obj/item/clothing/shoes/black,
 						/obj/item/clothing/head/ushanka)
 
+/obj/abstract/loadout/clown_ops
+	items_to_spawn = list(/obj/item/clothing/under/clownpsyche,
+						/obj/item/clothing/shoes/clownshoespsyche,
+						/obj/item/clothing/mask/gas/clownmaskpsyche,
+						/obj/item/weapon/storage/backpack/clownpackpsyche,
+						/obj/item/weapon/gun/energy/laser/rainbow)
+
 /obj/abstract/loadout/tunnel_clown
 	items_to_spawn = list(/obj/item/clothing/under/rank/clown,
 						/obj/item/clothing/shoes/clown_shoes,

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -674,7 +674,7 @@
 /obj/structure/closet/crate/secure/weapon/experimental/New()
 	..()
 	if(!chosen_set)
-		chosen_set = pick("ricochet","bison","spur","gatling","stickybomb","nikita","osipr","hecate","gravitywell")
+		chosen_set = pick("ricochet","bison","spur","gatling","stickybomb","nikita","osipr","hecate","gravitywell", "clown")
 
 	switch(chosen_set)
 		if("ricochet")
@@ -721,6 +721,13 @@
 			new/obj/item/clothing/head/radiation(src)
 			new/obj/item/clothing/shoes/magboots(src)
 			new/obj/item/weapon/gun/gravitywell(src)
+		if("clown")
+			new/obj/item/clothing/under/clownpsyche(src)
+			new/obj/item/clothing/mask/gas/clownmaskpsyche(src)
+			new/obj/item/clothing/shoes/clownshoespsyche(src)
+			new/obj/item/weapon/storage/backpack/clownpackpsyche(src)
+			new/obj/item/weapon/gun/energy/laser/rainbow(src)
+			new/obj/item/weapon/gun/energy/laser/rainbow(src)
 
 /obj/structure/closet/crate/secure/weapon/experimental/ricochet
 	chosen_set = "ricochet"

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -383,7 +383,6 @@
 	charge_cost = 100
 	cell_type = "/obj/item/weapon/cell"
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/guns.dmi', "right_hand" = 'icons/mob/in-hand/right/guns.dmi')
-	fire_delay = 3
 	var/pumping = 0
 
 /obj/item/weapon/gun/energy/laser/rainbow/attack_self(mob/user as mob)
@@ -401,6 +400,19 @@
 	sleep(5)
 	pumping = 0
 	update_icon()
+
+/obj/item/weapon/gun/energy/bison/update_icon()
+	if(power_supply.charge >= power_supply.maxcharge)
+		icon_state = "rainbow_laser100"
+	else if (power_supply.charge >= 75 && power_supply.charge < 100)
+		icon_state = "rainbow_laser75"
+	else if (power_supply.charge >= 50 && power_supply.charge < 75)
+		icon_state = "rainbow_laser50"
+	else if (power_supply.charge > 0 && power_supply.charge < 50)
+		icon_state = "rainbow_laser25"
+	else
+		icon_state = "rainbow_laser0"
+	return
 
 /obj/item/weapon/gun/energy/laser/rainbow/Fire(atom/target, mob/living/user, params, reflex = 0, struggle = 0, var/use_shooter_turf = FALSE)
 

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -401,19 +401,6 @@
 	pumping = 0
 	update_icon()
 
-/obj/item/weapon/gun/energy/bison/update_icon()
-	if(power_supply.charge >= power_supply.maxcharge)
-		icon_state = "rainbow_laser100"
-	else if (power_supply.charge >= 75 && power_supply.charge < 100)
-		icon_state = "rainbow_laser75"
-	else if (power_supply.charge >= 50 && power_supply.charge < 75)
-		icon_state = "rainbow_laser50"
-	else if (power_supply.charge > 0 && power_supply.charge < 50)
-		icon_state = "rainbow_laser25"
-	else
-		icon_state = "rainbow_laser0"
-	return
-
 /obj/item/weapon/gun/energy/laser/rainbow/Fire(atom/target, mob/living/user, params, reflex = 0, struggle = 0, var/use_shooter_turf = FALSE)
 
 	projectile_color = color_list[current_color]

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -379,7 +379,28 @@
 	var/static/list/color_list = list("#FF0000","#FF8C00","#FFFF00","#00FF00","#00BFFF","#0000FF","#9400D3")
 	icon_state = "rainbow_laser"
 	item_state = null
+	slot_flags = SLOT_BELT
+	charge_cost = 100
+	cell_type = "/obj/item/weapon/cell"
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/guns.dmi', "right_hand" = 'icons/mob/in-hand/right/guns.dmi')
+	fire_delay = 3
+	var/pumping = 0
+
+/obj/item/weapon/gun/energy/laser/rainbow/attack_self(mob/user as mob)
+
+	if(pumping || !power_supply)
+		return
+	pumping = 1
+	power_supply.charge = min(power_supply.charge + 200,power_supply.maxcharge)
+	if(power_supply.charge >= power_supply.maxcharge)
+		playsound(src, 'sound/items/AirHorn.ogg', 25, 1)
+		to_chat(user, "<span class='rose'>You squeeze the pump at the back of the gun. The gun is brimming with love!</span>")
+	else
+		playsound(src, 'sound/items/bikehorn.ogg', 25, 1)
+		to_chat(user, "<span class='rose'>You squeeze the pump at the back of the gun. The gun seems a little happier.</span>")
+	sleep(5)
+	pumping = 0
+	update_icon()
 
 /obj/item/weapon/gun/energy/laser/rainbow/Fire(atom/target, mob/living/user, params, reflex = 0, struggle = 0, var/use_shooter_turf = FALSE)
 

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -388,13 +388,13 @@
 /obj/item/weapon/gun/energy/laser/rainbow/attack_self(mob/user as mob)
 
 	if(pumping || !power_supply)
-		return
-	pumping = 1
+		return TRUE
 	power_supply.charge = min(power_supply.charge + 200,power_supply.maxcharge)
 	if(power_supply.charge >= power_supply.maxcharge)
 		playsound(src, 'sound/items/AirHorn.ogg', 25, 1)
 		to_chat(user, "<span class='rose'>You squeeze the pump at the back of the gun. The gun is brimming with love!</span>")
 	else
+		pumping = 1
 		playsound(src, 'sound/items/bikehorn.ogg', 25, 1)
 		to_chat(user, "<span class='rose'>You squeeze the pump at the back of the gun. The gun seems a little happier.</span>")
 	sleep(5)

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -389,7 +389,7 @@
 
 	if(pumping || !power_supply)
 		return TRUE
-	power_supply.charge = min(power_supply.charge + 200,power_supply.maxcharge)
+	power_supply.charge = min(power_supply.charge + charge_cost * 2,power_supply.maxcharge)
 	if(power_supply.charge >= power_supply.maxcharge)
 		playsound(src, 'sound/items/AirHorn.ogg', 25, 1)
 		to_chat(user, "<span class='rose'>You squeeze the pump at the back of the gun. The gun is brimming with love!</span>")

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -664,7 +664,7 @@ var/list/laser_tag_vests = list(/obj/item/clothing/suit/tag/redtag, /obj/item/cl
 					var/obj/item/weapon/gun/energy/tag/their_gun = M.held_items[taggun_index]
 					their_gun.cooldown(target_tag.my_laser_tag_game.disable_time/2)
 				M.Knockdown(target_tag.my_laser_tag_game.stun_time/2)
-				M.Stun(target_tag.my_laser_tag_game.stun_time/2)	
+				M.Stun(target_tag.my_laser_tag_game.stun_time/2)
 				var/obj/item/weapon/gun/energy/tag/taggun = shot_from
 				if(istype(taggun))
 					taggun.score()
@@ -945,6 +945,16 @@ var/list/laser_tag_vests = list(/obj/item/clothing/suit/tag/redtag, /obj/item/cl
 
 /obj/item/projectile/beam/white
 	icon_state = "whitelaser"
+
+/obj/item/projectile/beam/white/to_bump(atom/A)
+	if(!A)
+		return
+	..()
+	if(istype(A, /mob))
+		A.reagents.add_reagent(SPACE_DRUGS, 1)
+		var/hit_verb = pick("covers","completely soaks","fills","splashes")
+		A.visible_message("<span class='warning'>\The [src] [hit_verb] [A] with love!</span>",
+			"<span class='warning'>\The [src] [hit_verb] you!</span>")
 
 /obj/item/projectile/beam/liquid_stream
 	name = "stream of liquid"

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -952,9 +952,10 @@ var/list/laser_tag_vests = list(/obj/item/clothing/suit/tag/redtag, /obj/item/cl
 	..()
 	if(istype(A, /mob))
 		A.reagents.add_reagent(SPACE_DRUGS, 1)
+		A.reagents.add_reagent(HONKSERUM, 10)
 		var/hit_verb = pick("covers","completely soaks","fills","splashes")
 		A.visible_message("<span class='warning'>\The [src] [hit_verb] [A] with love!</span>",
-			"<span class='warning'>\The [src] [hit_verb] you!</span>")
+			"<span class='warning'>\The [src] [hit_verb] you with love!</span>")
 
 /obj/item/projectile/beam/liquid_stream
 	name = "stream of liquid"


### PR DESCRIPTION
Farther develops Nanotransen's experimental Rainbow Gun. This was developed with the Nuclear Clown Ops in mind.

Rainbow Clown Gun now acts like the Bison where you click on it to recharge.
Icon also updates on charge.
Honks on every charge! Plays an airhorn on max charge! 
Injects people with 1 space drug on hit. 
Injects people with 10 Honk Serum on hit. 
Created clown ops loadout for easy admin equipping.
Added the gun to the experimental weapons crate, so now you gotta get lucky you little bitch jobbies.

:cl:
 * rscadd: Rainbow clown gun has been improved, now injects drugs and honk serum, and appears in the experimental weapons crate.