### PR TITLE
Fixes Security Rockets

### DIFF
--- a/code/modules/projectiles/ammunition/rocket.dm
+++ b/code/modules/projectiles/ammunition/rocket.dm
@@ -8,7 +8,7 @@
 	w_type = RECYK_METAL
 	w_class = W_CLASS_MEDIUM // Rockets don't exactly fit in pockets and cardboard boxes last I heard, try your backpack
 	shrapnel_amount = 0
-	
+
 /obj/item/ammo_casing/rocket_rpg/update_icon()
 	return
 
@@ -35,8 +35,3 @@
 	desc = "Stun rocket for the Nanotrasen rocket launcher. Not a flashbang."
 	projectile_type = "/obj/item/projectile/rocket/blank/stun"
 	starting_materials = list(MAT_IRON = 50000, MAT_SILVER = 1000)
-	
-/obj/item/ammo_casing/rocket_rpg/extreme
-	name = "extreme rocket" //don't even map or spawn this in or you'll be very sad
-	desc = "Extreme-yield rocket. Fire from very very far away."
-	projectile_type = "/obj/item/projectile/rocket/lowyield/extreme"

--- a/code/modules/projectiles/ammunition/rocket.dm
+++ b/code/modules/projectiles/ammunition/rocket.dm
@@ -35,3 +35,8 @@
 	desc = "Stun rocket for the Nanotrasen rocket launcher. Not a flashbang."
 	projectile_type = "/obj/item/projectile/rocket/blank/stun"
 	starting_materials = list(MAT_IRON = 50000, MAT_SILVER = 1000)
+
+/obj/item/ammo_casing/rocket_rpg/extreme
+	name = "extreme rocket" //don't even map or spawn this in or you'll be very sad
+	desc = "Extreme-yield rocket. Fire from very very far away."
+	projectile_type = "/obj/item/projectile/rocket/lowyield/extreme"

--- a/code/modules/projectiles/projectile/rocket.dm
+++ b/code/modules/projectiles/projectile/rocket.dm
@@ -69,8 +69,6 @@
 /obj/item/projectile/rocket/blank/emp/to_bump(var/atom/A)
 	empulse(A, 3, 5)
 	..()
-	if(!gcDestroyed)
-		qdel(src)
 
 
 /obj/item/projectile/rocket/blank/stun
@@ -84,8 +82,7 @@
 /obj/item/projectile/rocket/blank/stun/to_bump(var/atom/A)
 	flashbangprime(TRUE, FALSE, FALSE)
 	..()
-	if(!gcDestroyed)
-		qdel(src)
+
 
 
 /obj/item/projectile/rocket/lowyield/extreme

--- a/code/modules/projectiles/projectile/rocket.dm
+++ b/code/modules/projectiles/projectile/rocket.dm
@@ -95,6 +95,14 @@
 	if(!gcDestroyed)
 		qdel(src)
 
+/obj/item/projectile/rocket/lowyield/extreme
+	name = "extreme yield rocket"
+	damage = 200
+	exdev 	= 7
+	exheavy = 14
+	exlight = 28
+	exflash = 32
+
 /obj/item/projectile/rocket/nikita
 	name = "\improper Nikita missile"
 	desc = "One does not simply dodge a nikita missile."

--- a/code/modules/projectiles/projectile/rocket.dm
+++ b/code/modules/projectiles/projectile/rocket.dm
@@ -11,7 +11,7 @@
 	var/explosive = 1
 	var/picked_up_speed = 0.66 //This is basically projectile speed, so
 	fire_sound = 'sound/weapons/rocket.ogg'
-	var/exdev 	= 1 //RPGs pack a serious punch and will cause massive structural damage in your average room, 
+	var/exdev 	= 1 //RPGs pack a serious punch and will cause massive structural damage in your average room,
 	var/exheavy = 3 //but won't punch through reinforced walls
 	var/exlight = 5
 	var/exflash = 8
@@ -34,7 +34,7 @@
 
 /obj/item/projectile/rocket/to_bump(var/atom/A)
 	if(explosive == 1)
-		explosion(A, exdev, exheavy, exlight, exflash) 
+		explosion(A, exdev, exheavy, exlight, exflash)
 		if(!gcDestroyed)
 			qdel(src)
 	else
@@ -45,9 +45,6 @@
 /obj/item/projectile/rocket/lowyield
 	name = "low yield rocket"
 	icon_state = "rpground"
-	damage = 45
-	stun = 10
-	weaken = 10
 	exdev 	= -1
 	exheavy = 0
 	exlight = 3
@@ -56,12 +53,16 @@
 /obj/item/projectile/rocket/blank
 	name = "blank rocket"
 	damage = 5
+	stun = 5
 	weaken = 10
 	agony = 10
-	exdev 	= -1
-	exheavy = 0
-	exlight = 0
-	exflash = 0
+	explosive = 0
+
+/obj/item/projectile/rocket/blank/to_bump(var/atom/A)
+	explosion(A, -1, 0, 0, 0)
+	..()
+	if(!gcDestroyed)
+		qdel(src)
 
 /obj/item/projectile/rocket/blank/emp
 	name = "EMP rocket"
@@ -69,29 +70,30 @@
 	agony = 30
 	emheavy = 3
 	emlight = 5
+	explosive = 0
 
-/obj/item/projectile/rocket/emp/to_bump(var/atom/A)
+/obj/item/projectile/rocket/blank/emp/to_bump(var/atom/A)
 	empulse(A, 3, 5)
+	explosion(A, -1, 0, 0, 0)
 	..()
-	
+	if(!gcDestroyed)
+		qdel(src)
+
 /obj/item/projectile/rocket/blank/stun
 	name = "stun rocket"
 	damage = 15
 	stun = 20
 	weaken = 20
 	agony = 30
+	explosive = 0
 
-/obj/item/projectile/rocket/stun/to_bump(var/atom/A)
+
+/obj/item/projectile/rocket/blank/stun/to_bump(var/atom/A)
 	flashbangprime(TRUE, FALSE, FALSE)
+	explosion(A, -1, 0, 0, 0)
 	..()
-		
-/obj/item/projectile/rocket/lowyield/extreme
-	name = "extreme yield rocket"
-	damage = 200
-	exdev 	= 7
-	exheavy = 14
-	exlight = 28
-	exflash = 32
+	if(!gcDestroyed)
+		qdel(src)
 
 /obj/item/projectile/rocket/nikita
 	name = "\improper Nikita missile"

--- a/code/modules/projectiles/projectile/rocket.dm
+++ b/code/modules/projectiles/projectile/rocket.dm
@@ -8,7 +8,6 @@
 	nodamage = 0
 	flag = "bullet"
 	var/embed = 1
-	var/explosive = 1
 	var/picked_up_speed = 0.66 //This is basically projectile speed, so
 	fire_sound = 'sound/weapons/rocket.ogg'
 	var/exdev 	= 1 //RPGs pack a serious punch and will cause massive structural damage in your average room,
@@ -33,15 +32,10 @@
 		sleep(picked_up_speed)
 
 /obj/item/projectile/rocket/to_bump(var/atom/A)
-	if(explosive == 1)
-		..()
-		explosion(A, exdev, exheavy, exlight, exflash)
-		if(!gcDestroyed)
-			qdel(src)
-	else
-		..()
-		if(!gcDestroyed)
-			qdel(src)
+	..()
+	explosion(A, exdev, exheavy, exlight, exflash)
+	if(!gcDestroyed)
+		qdel(src)
 
 /obj/item/projectile/rocket/lowyield
 	name = "low yield rocket"
@@ -85,7 +79,6 @@
 	stun = 20
 	weaken = 20
 	agony = 30
-	explosive = 0
 
 
 /obj/item/projectile/rocket/blank/stun/to_bump(var/atom/A)

--- a/code/modules/projectiles/projectile/rocket.dm
+++ b/code/modules/projectiles/projectile/rocket.dm
@@ -34,6 +34,7 @@
 
 /obj/item/projectile/rocket/to_bump(var/atom/A)
 	if(explosive == 1)
+		..()
 		explosion(A, exdev, exheavy, exlight, exflash)
 		if(!gcDestroyed)
 			qdel(src)
@@ -45,6 +46,9 @@
 /obj/item/projectile/rocket/lowyield
 	name = "low yield rocket"
 	icon_state = "rpground"
+	damage = 45
+	stun = 10
+	weaken = 10
 	exdev 	= -1
 	exheavy = 0
 	exlight = 3
@@ -53,16 +57,12 @@
 /obj/item/projectile/rocket/blank
 	name = "blank rocket"
 	damage = 5
-	stun = 5
 	weaken = 10
 	agony = 10
-	explosive = 0
-
-/obj/item/projectile/rocket/blank/to_bump(var/atom/A)
-	explosion(A, -1, 0, 0, 0)
-	..()
-	if(!gcDestroyed)
-		qdel(src)
+	exdev 	= -1
+	exheavy = 0
+	exlight = 0
+	exflash = 0
 
 /obj/item/projectile/rocket/blank/emp
 	name = "EMP rocket"
@@ -70,14 +70,14 @@
 	agony = 30
 	emheavy = 3
 	emlight = 5
-	explosive = 0
+
 
 /obj/item/projectile/rocket/blank/emp/to_bump(var/atom/A)
 	empulse(A, 3, 5)
-	explosion(A, -1, 0, 0, 0)
 	..()
 	if(!gcDestroyed)
 		qdel(src)
+
 
 /obj/item/projectile/rocket/blank/stun
 	name = "stun rocket"
@@ -90,10 +90,10 @@
 
 /obj/item/projectile/rocket/blank/stun/to_bump(var/atom/A)
 	flashbangprime(TRUE, FALSE, FALSE)
-	explosion(A, -1, 0, 0, 0)
 	..()
 	if(!gcDestroyed)
 		qdel(src)
+
 
 /obj/item/projectile/rocket/lowyield/extreme
 	name = "extreme yield rocket"


### PR DESCRIPTION
[bugfix] [tweak]

This PR fixes EMP, stun, and blank rockets.
I was probably unnecessarily hostile to Sonix in the first OP and he still helped me fix the rockets so I would like to thank him. Further, the PR now also fixes low yield rocket damage as well as the stun time on nuke ops rockets. Ops rockets gib all but the most armored targets but this still changes behavior so it should be mentioned. To be clear, this is just fixing the rockets to apply the damage and stun values before they explode.

:cl:
 * bugfix: EMP, stun, and blank rockets now actually work.
 * bugfix: Low yield rockets AND nuclear ops rockets now properly apply damage and stun on direct hits.
