### PR TITLE
Bomb Armor Is Better

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -402,6 +402,7 @@ emp_act
 
 			if (gotarmor)
 				b_loss *= (100-gotarmor)/100 //reduce damage by percent equal to bomb armor
+				f_loss *= (100-gotarmor)/100
 
 			if (!earprot())
 				ear_damage += 30

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -365,19 +365,25 @@ emp_act
 	var/shielded = 0
 	var/b_loss = null
 	var/f_loss = null
-
+	var/gotarmor = clamp(getarmor(null, "bomb"),0,100)
 	switch (severity)
 		if (BLOB_ACT_STRONG)
-			b_loss += 500
-			if (!prob(getarmor(null, "bomb")))
+			b_loss += 300
+			if(!prob(gotarmor)) //Percent chance equal to their armor resist to not gib instantly.
 				gib()
 				return
 			else
 				var/atom/target = get_edge_target_turf(src, get_dir(src, get_step_away(src, src)))
 				throw_at(target, 200, 4)
-			//return
-//				var/atom/target = get_edge_target_turf(user, get_dir(src, get_step_away(user, src)))
-				//user.throw_at(target, 200, 4)
+				b_loss *= (120-gotarmor)/100 //Reduce blast power by a function of bomb armor, but even 100 won't be enough.
+				//100 = 20%,  60  b_loss (bomb suit, advanced EOD suit)
+				//50  = 70%,  210 b_loss (captain's armor/rig, ancient space suit)
+				//45  = 65%,  225 b_loss (sec hardsuit)
+				//35  = 85%,  255 b_loss (eng hardsuit, blood red hardsuit, gem encrusted hardsuit)
+				//30  = 90%,  270 b_loss (ERT armor, red syndie suit)
+				//25  = 95%,  285 b_loss (security armor)
+				//20  = 100%, 300 b_loss (RD's labcoat)
+				//0   = 120%, 360 b_loss (most suits)
 
 		if (BLOB_ACT_MEDIUM)
 			if (stat == 2 && client)
@@ -394,9 +400,8 @@ emp_act
 
 			f_loss += 60
 
-			if (prob(getarmor(null, "bomb")))
-				b_loss = b_loss/1.5
-				f_loss = f_loss/1.5
+			if (gotarmor)
+				b_loss *= (100-gotarmor)/100 //reduce damage by percent equal to bomb armor
 
 			if (!earprot())
 				ear_damage += 30
@@ -406,10 +411,8 @@ emp_act
 
 		if(BLOB_ACT_WEAK)
 			b_loss += 30
-			var/gotarmor = min(100,max(0,getarmor(null, "bomb")))
-
-			if (prob(gotarmor))
-				b_loss = (b_loss*((gotarmor-100)*-1))/100//equipments with armor[bomb]=100 will fully negate the damage of light explosives.
+			if(gotarmor)
+				b_loss *= (100-gotarmor)/100 //reduce damage by percent equal to bomb armor
 			if (!earprot())
 				ear_damage += 15
 				ear_deaf += 60


### PR DESCRIPTION
TL;DNR: bomb armor currently sucks, this buffs it (but not very usefully for bombers themselves)

I always kinda wanted sec to be able to be bomb squaddies but bomb armor sucks. Even if you survive the blast due to wearing full bomb suit you take 500 brute, so what was the point? It probably mashes your head apart.

| **Severity** | **Old Behavior** | **New Behavior** |
| ------------- | ------------- | ------------- |
| Light  | 30 brute, armor% chance to reduce damage by armor%  | 30 brute always reduced by armor% |
| Heavy  | 60 brute, armor% chance to reduce damage by 33%; 60 fire guaranteed  | 60 brute 60 fire each always reduced by armor%  |
| Devastated  | armor% chance to take 500 brute, otherwise gib  | armor% chance to reduce 300 brute by (armor-20)%, otherwise instantly gib  |

**Examples:**
1. You get hit by light explosion wearing an engineering hardsuit (bomb armor = 35). 
Old: You have a 35% chance to reduce your 30 incoming brute by 35%, to 19.5
New: You reduce your incoming brute by 35% to 19.5

2. You get hit by a heavy explosion wearing a security hardsuit (bomb armor = 40)
Old: You have a 40% chance to reduce your 60 incoming brute by 33%, to 40. You take 60 fire no matter what. Total of 100 or 120 damage.
New: You reduce your 60 brute and 60 fire each by 40%, to a total of 72 damage.

3. You get hit by a devastating explosion wearing a bomb suit (bomb armor = 100)
Old: You have a 0% chance to instantly gib. You take 500 brute.
New: You have a 0% chance to instantly gib. You reduce 300 brute by 80% to 60.

**Big Picture**
100 bomb armor will fully protect you from light and heavy explosions. You can survive a devastating blast, but you won't be walking around doing it again any time soon, 60 brute is guaranteed breaks and bleeds and you'll now be in a bomb suit on top of a space tile with no air or warmth.

Bomb protection on most hardsuits is now more reliable at light and heavy levels, but still affords essentially no protection against a dev blast. Even Captain's Armor/Rig (bomb=50) only has a 50% chance to not gib from a dev and it reduces damage to 210.

**Minutiae**
*How is armor calculated if I'm not wearing a complete suit? For example, say my helmet is retracted when the bomb goes off with sec hardsuit?*
Averaged across each external organ and whatever covers it. This means just a sec vest is pretty garbage against explosions since it's not covering any head or limbs - you're repeatedly averaging with 0 protection. If just your hardsuit helmet is retracted though, you only have to average 0 one time with several 40s all over the rest of your body.

*What are some example bomb armor values?*
I put a bunch of common ones in the diff next to the dev calculation if you wanna check those out.

🆑 
* tweak: Bomb armor is more effective at stopping bombs.