### PR TITLE
Improved travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
-#pretending we're C because otherwise ruby/rvm will initialize, even with "language: dm".
-language: rust
-rust:
-- stable
+language: generic
+dist: xenial
 sudo: false
 
 env:
@@ -11,45 +9,71 @@ env:
   - ALL_MAPS="tgstation metaclub defficiency packedstation roidstation wheelstation nrvhorizon test_box test_tiny"
   - RUST_BACKTRACE="1"
   - RUST_TEST_THREADS=1
-  matrix:
-  - DM_UNIT_TESTS="1"
-  - DM_UNIT_TESTS="0"
 
-cache:
-  directories:
-  - $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}
-  - $HOME/.cache/pip
-  - $TRAVIS_BUILD_DIR/libvg/target
-  - $HOME/.cargo
-
-addons:
-  apt:
-    packages:
-    - libc6-i386
-    - libgcc1:i386
-    - libstdc++6:i386
-    - moreutils
-
-install:
-- pip install --user PyYaml beautifulsoup4 subprocess32 colorama -q
-
-before_script:
-- tools/travis/install-byond.sh
-
-script:
-# Has to use Python 2 instead of 3 because else it won't find colorama.
-- python tools/travis/check_map_files.py maps/
-- find -name '*.dme' -exec cat {} \; | awk '/maps\\test.*/ { exit 1 }'
-# Python 2 is EOL but travis chokes on Python 3 for a wide variety of reasons.
-#- python tools/changelog/ss13_genchangelog.py html/changelog.html html/changelogs --dry-run
-- source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup
-- cd libvg
-# --jobs 1 to prevent threading problems with the BYOND crate.
-- cargo test --jobs 1 --verbose
-- cd -
-- tools/travis/build.py
-- cp tools/travis/config/config.txt config/
-- tools/travis/run_tests.py 2>&1 | tee /dev/stderr | sponge | awk '/UNIT TEST FAIL/ { exit 1 }'
+matrix:
+  include:
+    - name: "Run linters"
+      env:
+        - SPACEMAN_DMM_GIT_TAG="suite-1.4"
+      addons:
+        apt:
+          packages:
+            - python3
+            - python3-pip
+            - python3-setuptools
+      cache:
+        directories:
+          - $HOME/SpacemanDMM
+          - $HOME/.cache/pip
+      install:
+      - pip install --user PyYaml beautifulsoup4 subprocess32 colorama -q
+      - tools/travis/install_spaceman_dmm.sh dreamchecker
+      script:
+      - python tools/travis/check_map_files.py maps/
+      - find -name '*.dme' -exec cat {} \; | awk '/maps\\test.*/ { exit 1 }'
+      - ~/dreamchecker || true
+    - name: "Compile all maps"
+      env:
+        DM_UNIT_TESTS="0"
+      addons:
+        apt:
+          packages:
+            - libstdc++6:i386
+      cache:
+        directories:
+          - $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}
+      install:
+        - tools/travis/install-byond.sh
+        - source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup
+      script:
+        - tools/travis/build.py
+    - name: "Compile and run tests"
+      env:
+        DM_UNIT_TESTS="1"
+      addons:
+        apt:
+          packages:
+            - libstdc++6:i386
+            - libc6-i386
+            - libgcc1:i386
+            - rustc
+            - cargo
+            - moreutils
+      cache:
+        directories:
+          - $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}
+          - $TRAVIS_BUILD_DIR/libvg/target
+          - $HOME/.cargo
+      install:
+        - tools/travis/install-byond.sh
+        - source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup
+        - cd libvg
+        # --jobs 1 to prevent threading problems with the BYOND crate.
+        - cargo test --jobs 1 --verbose
+        - cd -
+        - tools/travis/build.py
+        - cp tools/travis/config/config.txt config/
+        - tools/travis/run_tests.py 2>&1 | tee /dev/stderr | sponge | awk '/UNIT TEST FAIL/ { exit 1 }'
 
 notifications:
   irc:

--- a/__DEFINES/__spaceman_dmm.dm
+++ b/__DEFINES/__spaceman_dmm.dm
@@ -1,0 +1,25 @@
+#ifdef SPACEMAN_DMM
+	#define RETURN_TYPE(X) set SpacemanDMM_return_type = X
+	#define SHOULD_CALL_PARENT(X) set SpacemanDMM_should_call_parent = X
+	#define UNLINT(X) SpacemanDMM_unlint(X)
+	#define SHOULD_NOT_OVERRIDE(X) set SpacemanDMM_should_not_override = X
+	#define SHOULD_NOT_SLEEP(X) set SpacemanDMM_should_not_sleep = X
+	#define SHOULD_BE_PURE(X) set SpacemanDMM_should_be_pure = X
+	#define PRIVATE_PROC(X) set SpacemanDMM_private_proc = X
+	#define PROTECTED_PROC(X) set SpacemanDMM_protected_proc = X
+	#define VAR_FINAL var/SpacemanDMM_final
+	#define VAR_PRIVATE var/SpacemanDMM_private
+	#define VAR_PROTECTED var/SpacemanDMM_protected
+#else
+	#define RETURN_TYPE(X)
+	#define SHOULD_CALL_PARENT(X)
+	#define UNLINT(X) X
+	#define SHOULD_NOT_OVERRIDE(X)
+	#define SHOULD_NOT_SLEEP(X)
+	#define SHOULD_BE_PURE(X)
+	#define PRIVATE_PROC(X)
+	#define PROTECTED_PROC(X)
+	#define VAR_FINAL var
+	#define VAR_PRIVATE var
+	#define VAR_PROTECTED var
+#endif

--- a/tools/travis/install_spaceman_dmm.sh
+++ b/tools/travis/install_spaceman_dmm.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+
+wget -O ~/$1 "https://github.com/SpaceManiac/SpacemanDMM/releases/download/$SPACEMAN_DMM_GIT_TAG/$1"
+chmod +x ~/$1
+~/$1 --version

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -11,6 +11,7 @@
 // END_PREFERENCES
 // BEGIN_INCLUDE
 #include "__DEFINES\__compile_options.dm"
+#include "__DEFINES\__spaceman_dmm.dm"
 #include "__DEFINES\_macros.dm"
 #include "__DEFINES\accessories.dm"
 #include "__DEFINES\archaeo_defines.dm"


### PR DESCRIPTION
Rewrote travis.yml so that it doesn't repeat unnecessary work three times, shaving off like 20 seconds of runtime.
We now use python 3 instead of python 2.
Added support for [SpacemanDMM](https://github.com/SpaceManiac/SpacemanDMM/tree/master/src/dreamchecker): the linter runs so that output is produced but the exit code is currently ignored, because our code doesn't currently pass. Once we're compliant we can remove the `|| true` after the invocation.
