### PR TITLE
Revert "Possibly fixed the bug that caused locker contents to spawn twice"

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -202,7 +202,6 @@ var/MAX_EXPLOSION_RANGE = 14
 #define TIMELESS		32768 // Immune to time manipulation.
 
 #define SILENTCONTAINER	65536 //reactions inside make no noise
-#define ATOM_INITIALIZED 131072 // initialize() was called
 
 #define ALL ~0
 #define NONE 0

--- a/code/controllers/subsystem/objects.dm
+++ b/code/controllers/subsystem/objects.dm
@@ -19,10 +19,7 @@ var/list/processing_objects = list()
 
 /datum/subsystem/obj/Initialize()
 	for(var/atom/object in world)
-		if(!(flags & ATOM_INITIALIZED))
-			object.initialize()
-		else
-			stack_trace("[object.type] initialized twice")
+		object.initialize()
 		CHECK_TICK
 	for(var/area/place in areas)
 		var/obj/machinery/power/apc/place_apc = place.areaapc

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -879,7 +879,7 @@ its easier to just keep the beam vertical.
 			return C.mob
 
 /atom/proc/initialize()
-	flags |= ATOM_INITIALIZED
+	return
 
 /atom/proc/get_cell()
 	return


### PR DESCRIPTION
Reverts vgstation-coders/vgstation13#26283

May or may not be breaking the server, `stack_trace` already did it with AStar bots.