### PR TITLE
Envelopes now lose their disposals sorting tag after being opened

### DIFF
--- a/code/modules/paperwork/envelope.dm
+++ b/code/modules/paperwork/envelope.dm
@@ -128,4 +128,5 @@
 /obj/item/weapon/paper/envelope/proc/open()
 	open = TRUE
 	torn = TRUE
+	sortTag = null;
 	update_icon()

--- a/code/modules/paperwork/envelope.dm
+++ b/code/modules/paperwork/envelope.dm
@@ -128,5 +128,5 @@
 /obj/item/weapon/paper/envelope/proc/open()
 	open = TRUE
 	torn = TRUE
-	sortTag = null;
+	sortTag = null
 	update_icon()


### PR DESCRIPTION
Currently you can't put envelopes that were mailed to you back down disposals because they retain their sorting tag and will just pop back right out

:cl:
 * rscadd: Envelopes now lose their disposals sorting tag after being opened