### PR TITLE
Terrorist envelopes

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -777,6 +777,14 @@ var/list/uplink_items = list()
 	discounted_cost = 4
 	jobs_with_discount = list("Cargo Technician", "Quartermaster")
 
+/datum/uplink_item/jobspecific/cargo/terrorist_envelope
+	name = "Terrorist Envelope"
+	desc = "An indistinguishable envelope rigged to release a cloud of polytrinic acid smoke upon being opened. Can be tagged and mailed via disposals."
+	item = /obj/item/weapon/paper/envelope/terrorist
+	cost = 6
+	discounted_cost = 5
+	jobs_with_discount = list("Cargo Technician", "Quartermaster")
+
 /datum/uplink_item/jobspecific/cargo/mastertrainer
 	name = "Master Trainer's Belt"
 	desc = "A trainer's belt containing 6 Lazarus capsules loaded with random but particularly hostile and lethal mobs loyal to you alone. You can inspect what the Lazarus capsules contain before throwing them."

--- a/code/modules/paperwork/envelope.dm
+++ b/code/modules/paperwork/envelope.dm
@@ -128,4 +128,5 @@
 /obj/item/weapon/paper/envelope/proc/open()
 	open = TRUE
 	torn = TRUE
+	sortTag = null;
 	update_icon()

--- a/code/modules/paperwork/envelope.dm
+++ b/code/modules/paperwork/envelope.dm
@@ -130,3 +130,29 @@
 	torn = TRUE
 	sortTag = null;
 	update_icon()
+
+/obj/item/weapon/paper/envelope/terrorist
+	icon_state = "envelope_closed"
+	open = FALSE;
+
+/obj/item/weapon/paper/envelope/terrorist/New()
+	..()
+	var/obj/item/weapon/reagent_containers/glass/beaker/beaker = new /obj/item/weapon/reagent_containers/glass/beaker
+	beaker.reagents.add_reagent(PACID, 50)
+	beaker.forceMove(src)
+	contained_item = beaker;
+
+/obj/item/weapon/paper/envelope/terrorist/open()
+	..()
+	if(is_in_airtight_object(src)) //Don't pop while ventcrawling.
+		return
+	var/location = get_turf(src)	
+	var/datum/effect/effect/system/smoke_spread/chem/S = new /datum/effect/effect/system/smoke_spread/chem
+	S.attach(location)
+	S.set_up(contained_item.reagents, 10, 0, location)
+	playsound(location, 'sound/effects/smoke.ogg', 50, 1, -3)
+	spawn(0)
+		S.start()
+		sleep(10)
+		S.start()
+	contained_item.reagents.clear_reagents()


### PR DESCRIPTION
:cl:
 * rscadd: Added terrorist envelope traitor uplink item. An indistinguishable envelope rigged to release a cloud of polytrinic acid smoke upon being opened. Can be tagged and mailed via disposals. Costs 6 TC, 5 TC for cargo techs and quartermasters.