### PR TITLE
You can no longer get spells you're not supposed to get from the spellbook bundle

### DIFF
--- a/code/game/gamemodes/wizard/spellbook_oneuse.dm
+++ b/code/game/gamemodes/wizard/spellbook_oneuse.dm
@@ -10,6 +10,7 @@
 	uses = 1
 	max_uses = 1
 	desc = "This template spellbook was never meant for the eyes of man..."
+	var/disabled_from_bundle //if 1, this will not appear in the spellbook bundle
 
 /obj/item/weapon/spellbook/oneuse/New()
 	..()
@@ -142,6 +143,7 @@
 	spellname = "charging"
 	icon_state ="bookcharge"
 	desc = "This book is made of 100% post-consumer wizard."
+	disabled_from_bundle = 1
 
 /obj/item/weapon/spellbook/oneuse/charge/recoil(mob/user as mob)
 	..()
@@ -258,6 +260,7 @@
 	spellname  = "highlander power"
 	icon_state = "bookhighlander"
 	desc = "You can hear the bagpipes playing already."
+	disabled_from_bundle = 1
 
 /obj/item/weapon/spellbook/oneuse/disorient
 	spell = /spell/targeted/disorient
@@ -330,6 +333,7 @@
 	spell = /spell/lightning/sith
 	spellname = "sith lightning"
 	desc = "You can hear it crackle with malevolent electricity."
+	disabled_from_bundle = 1
 
 /obj/item/weapon/spellbook/oneuse/timestop
 	spell = /spell/aoe_turf/fall

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -648,7 +648,7 @@
 	..()
 	for(var/i in 1 to 16)
 		new /obj/item/ammo_casing/shotgun/buckshot(src)
-		
+
 /obj/item/weapon/storage/box/dragonsbreathshells
 	name = "12-gauge dragon's breath shells"
 	icon_state = "dragonsbreath_shells"
@@ -658,12 +658,12 @@
 	..()
 	for(var/i in 1 to 16)
 		new /obj/item/ammo_casing/shotgun/dragonsbreath(src)
-		
+
 /obj/item/weapon/storage/box/fragshells
 	name = "12-gauge high-explosive fragmentation shells"
 	icon_state = "frag_shells"
-	storage_slots = 16		
-		
+	storage_slots = 16
+
 /obj/item/weapon/storage/box/fragshells/New()
 	..()
 	for(var/i in 1 to 16)
@@ -874,9 +874,10 @@
 
 /obj/item/weapon/storage/box/spellbook/New()
 	..()
-	var/list/possible_books = typesof(/obj/item/weapon/spellbook/oneuse)
-	possible_books -= /obj/item/weapon/spellbook/oneuse
-	possible_books -= /obj/item/weapon/spellbook/oneuse/charge
+	var/list/possible_books = subtypesof(/obj/item/weapon/spellbook/oneuse)
+	for(var/obj/item/weapon/spellbook/oneuse/S in possible_books)
+		if(S.disabled_from_bundle)
+			possible_books -= S
 	for(var/i =1; i <= 7; i++)
 		var/randombook = pick(possible_books)
 		var/book = new randombook(src)


### PR DESCRIPTION
That includes the highlander and sith lightning spells
I tried to find prestidigitation spellbooks but they don't exist
I took the liberty to clean up the code a little in the process

:cl:
 * rscdel: You can no longer get the "Highlander" spellbook and the "Sith lightning" spellbook from the wizard bundle.