### PR TITLE
Fixes beepsky sometimes glitching midpatrol

### DIFF
--- a/__DEFINES/_macros.dm
+++ b/__DEFINES/_macros.dm
@@ -1,12 +1,3 @@
-//#define ASTAR_DEBUG 1
-
-#ifdef ASTAR_DEBUG
-#warn "Astar debug is on. Don't forget to turn it off after you've done :)"
-#define astar_debug(text) to_chat(world, text)
-#else
-#define astar_debug(text)
-#endif
-
 //Define your macros here if they're used in general code
 
 //Typechecking macros

--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -1295,6 +1295,14 @@ var/default_colour_matrix = list(1,0,0,0,\
 //	null << "[x][a]")
 #endif
 
+#define ASTAR_DEBUG 0
+#if ASTAR_DEBUG == 1
+#warn "Astar debug is on. Don't forget to turn it off after you've done :)"
+#define astar_debug(text) to_chat(world, text)
+#else
+#define astar_debug(text)
+#endif
+
 //#define JUSTFUCKMYSHITUP 1
 #ifdef JUSTFUCKMYSHITUP
 #define writepanic(a) if(ticker && ticker.current_state >= 3 && world.cpu > 100) write_panic(a)

--- a/code/defines/procs/AStar.dm
+++ b/code/defines/procs/AStar.dm
@@ -175,7 +175,7 @@ proc/SeekTurf(var/PriorityQueue/Queue, var/turf/T)
  * Creates a pathmaker datum to process the path if we aren't processing the path.
  * Returns nothing if this path is already being processed.
  */
-proc/AStar(source, proc_to_call, start,end,adjacent,dist,maxnodes,maxnodedepth = 30,mintargetdist,minnodedist,id=null, var/turf/exclude=null, var/debug = FALSE)
+proc/AStar(source, proc_to_call, start,end,adjacent,dist,maxnodes,maxnodedepth = 30,mintargetdist,minnodedist,id=null, var/turf/exclude=null, var/debug = ASTAR_DEBUG)
 	ASSERT(!istype(end,/area)) //Because yeah some things might be doing this and we want to know what
 	if(start:z != end:z) //if you're feeling ambitious and make something that can ASTAR through z levels, feel free to remove this check
 		return ASTAR_FAIL
@@ -203,7 +203,7 @@ proc/quick_AStar(start,end,adjacent,dist,maxnodes,maxnodedepth = 30,mintargetdis
 	start = get_turf(start)
 
 	if(!start)
-		return 0
+		return list()
 
 	//initialization
 	open.Enqueue(new /PathNode(start,null,0,call(start,dist)(end),0,"unique_[reference]"))
@@ -221,7 +221,7 @@ proc/quick_AStar(start,end,adjacent,dist,maxnodes,maxnodedepth = 30,mintargetdis
 
 		//if too many steps, abandon that path
 		if(maxnodedepth && (cur.nodecount > maxnodedepth))
-			return
+			return list()
 
 		//found the target turf (or close enough), let's create the path to it
 		if(cur.source == end || closeenough)
@@ -267,7 +267,7 @@ proc/quick_AStar(start,end,adjacent,dist,maxnodes,maxnodedepth = 30,mintargetdis
 
 	//if the path is longer than maxnodes, then don't return it
 	if(path && maxnodes && path.len > (maxnodes + 1))
-		return 0
+		return list()
 
 	//reverse the path to get it from start to finish
 	if(path)

--- a/code/game/machinery/bots/bots.dm
+++ b/code/game/machinery/bots/bots.dm
@@ -13,9 +13,9 @@
 
 #define BOT_OLDTARGET_FORGET_DEFAULT 100 //100*WaitMachinery
 
-#ifdef ASTAR_DEBUG
-#define log_astar_bot(text) visible_message("[src] : text")
-#define log_astar_beacon(text) to_chat(world, "[src] : text")
+#if ASTAR_DEBUG == 1
+#define log_astar_bot(text) visible_message("[src] : [text]")
+#define log_astar_beacon(text) to_chat(world, "[src] : [text]")
 #else
 #define log_astar_bot(text)
 #define log_astar_beacon(text)
@@ -379,10 +379,8 @@
 	log_astar_beacon("[new_destination]")
 	if ((get_dist(src, target) < 13) && !(flags & BOT_NOT_CHASING)) // For beepers and ED209
 		// IMPORTANT: Quick AStar only takes TURFS as arguments.
-		path = quick_AStar(src.loc, get_turf(target), /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance_cardinal, 0, max(10,get_dist(src,target)*3), id=botcard, exclude=avoid, reference="\ref[src]")
-		if (!path) // Important because if quick_Astar fails, it returns null, not an empty list.
-			path = list()
-		return TRUE
+		waiting_for_patrol = FALSE // Case we are calculating a quick path for a patrol.
+		return quick_AStar(src.loc, get_turf(target), /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance_cardinal, 0, max(10,get_dist(src,target)*3), id=botcard, exclude=avoid, reference="\ref[src]")
 	return AStar(src, proc_to_call, src.loc, target, /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance_cardinal, 0, max(10,get_dist(src,target)*3), id=botcard, exclude=avoid)
 
 // This proc is called by the path maker once it has calculated a path.
@@ -411,6 +409,7 @@
 		return 0
 	on = 1
 	set_light(initial(luminosity))
+	waiting_for_patrol = FALSE
 	return 1
 
 /obj/machinery/bot/proc/turn_off()


### PR DESCRIPTION
The issue was that Beepsky would sometimes call the quick AStar to get to his patrol path. I didn't plan for that.
I also improved the debug output a bit.

Closes #26300 