### PR TITLE
Reduces cult endgame from 3 minutes and 20 seconds to 2 minutes

### DIFF
--- a/code/datums/gamemode/objectives/bloodcult.dm
+++ b/code/datums/gamemode/objectives/bloodcult.dm
@@ -221,7 +221,7 @@
 /datum/objective/bloodcult_feast
 	explanation_text = "The Feast: This is your victory, you may take part in the celebrations of a work well done."
 	name = "Blood Cult: Epilogue"
-	var/timer = 200 SECONDS
+	var/timer = 2 MINUTES
 
 /datum/objective/bloodcult_feast/PostAppend()
 	message_admins("Blood Cult: The cult has won.")

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -130,11 +130,9 @@
 		if(!suiciding) //Cowards don't count
 			score["deadcrew"]++ //Someone died at this point, and that's terrible
 	if(ticker && ticker.mode)
-//		world.log << "k"
 		sql_report_death(src)
-		//ticker.mode.check_win() //Calls the rounds wincheck, mainly for wizard, malf, and changeling now
 	species.handle_death(src)
-	if(become_zombie_after_death && isjusthuman(src)) //2 if they retain their mind, 1 if they don't
+	if(become_zombie_after_death && isjusthuman(src))
 		spawn(30 SECONDS)
 			if(!gcDestroyed)
 				make_zombie(retain_mind = become_zombie_after_death-1)

--- a/code/modules/mob/living/carbon/monkey/death.dm
+++ b/code/modules/mob/living/carbon/monkey/death.dm
@@ -36,7 +36,5 @@
 
 	update_canmove()
 	update_icons()
-	/*if(ticker.mode) WHY
-		ticker.mode.check_win()*/
 
 	return ..(gibbed)

--- a/code/modules/mob/living/carbon/slime/death.dm
+++ b/code/modules/mob/living/carbon/slime/death.dm
@@ -24,6 +24,4 @@
 
 	update_canmove()
 
-	//ticker.mode.check_win() WHY
-
 	return ..(gibbed)


### PR DESCRIPTION
Our crew is getting bored

Did not test it

:cl:
 * tweak: Cult endgame now lasts 2 minutes instead of 3:20.