### PR TITLE
Adds a second empowerment level to Disorient

### DIFF
--- a/code/modules/spells/targeted/disorient.dm
+++ b/code/modules/spells/targeted/disorient.dm
@@ -39,8 +39,8 @@
 		if(spell_levels[Sp_POWER] >= 2)
 			for(var/mob/target in targets)
 				var/client/C = target.client
+				var/record_angle //Spin the view by negative record angle to return it back to normal, instead of using initial
 				for(var/i, i <= spinning_duration, i++) //Do this (spinning_duration) times
-					var/record_angle //Spin the view by negative record angle to return it back to normal, instead of using initial
 					var/angle = pick(90, 180, 270)
 					if(C)
 						if(i == spinning_duration)

--- a/code/modules/spells/targeted/disorient.dm
+++ b/code/modules/spells/targeted/disorient.dm
@@ -10,13 +10,14 @@
 	invocation = "DII ODA BAJI"
 	invocation_type = SpI_WHISPER
 	message = "<span class='danger'>You suddenly feel completely overwhelmed!<span>"
-	level_max = list(Sp_TOTAL = 5, Sp_SPEED = 4, Sp_POWER = 1)
+	level_max = list(Sp_TOTAL = 6, Sp_SPEED = 4, Sp_POWER = 2)
 
 	max_targets = 1
 
 	amt_dizziness = 86
 	amt_confused = 86 // 2.1 seconds per = 180.6s
 	amt_stuttering = 86
+	var/spinning_duration = 30 //Currently used for the second power level
 
 	compatible_mobs = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 	spell_flags = WAIT_FOR_CLICK
@@ -25,21 +26,41 @@
 
 /spell/targeted/disorient/cast(var/list/targets)
 	..()
-	if(spell_levels[Sp_POWER] >= 1)
-		for(var/mob/target in targets)
-			var/angle = pick(90, 180, 270)
-			var/client/C = target.client
-			if(C)
-				C.dir = turn(C.dir, angle)
-				spawn(30 SECONDS) //This will confuse someone for a while and end up very annoying
+	spawn(0) //So that the "you suddenly feel completely overwhelmed!" message appears at the start and not the end
+		if(spell_levels[Sp_POWER] == 1)
+			for(var/mob/target in targets)
+				var/angle = pick(90, 180, 270)
+				var/client/C = target.client
+				if(C)
+					C.dir = turn(C.dir, angle)
+					spawn(30 SECONDS) //This will confuse someone for a while and end up very annoying
+						if(C)
+							C.dir = turn(C.dir, -angle)
+		if(spell_levels[Sp_POWER] >= 2)
+			for(var/mob/target in targets)
+				var/client/C = target.client
+				for(var/i, i <= spinning_duration, i++) //Do this (spinning_duration) times
+					var/record_angle //Spin the view by negative record angle to return it back to normal, instead of using initial
+					var/angle = pick(90, 180, 270)
 					if(C)
-						C.dir = turn(C.dir, -angle)
+						if(i == spinning_duration)
+							C.dir = turn(C.dir, -record_angle)
+							break
+						C.dir = turn(C.dir, angle)
+						record_angle += angle
+						sleep(1 SECONDS)
+					else break //Client quit, stop doing this
 
 /spell/targeted/disorient/empower_spell()
 	spell_levels[Sp_POWER]++
-	name = "Empowered Disorient"
-	desc = "This spell will very thoroughly disorient a target for 30 seconds."
-	return "You have upgraded the spell to turn the target's perception in another direction, further debilitating them."
+	if(spell_levels[Sp_POWER] == 1)
+		name = "Empowered Disorient"
+		desc = "This spell will very thoroughly disorient a target for 30 seconds."
+		return "You have upgraded the spell to turn the target's perception in another direction, further debilitating them."
+	if(spell_levels[Sp_POWER] >= 2)
+		name = "Incredible Disorient"
+		desc = "This spell will completely debilitate your target."
+		return "You have upgraded the spell to spin the target's view in any direction for 30 seconds. You monster."
 
 /spell/targeted/disorient/get_upgrade_info(upgrade_type, level)
 	if(upgrade_type == Sp_POWER)


### PR DESCRIPTION
The sun was shining into my screen and I couldn't see a thing, I wanted for it to be cloudy so the best way to do that was to make God cry with the existence of this PR
For 60 points you can make someone wish they were dead, this is a second-level empowerment of the Disorient spell that will **spin their screen in a random direction every second for 30 seconds**
Fixed a forgotten bug caused by my PR (that added the first empowerment) that made the message the target sees (You suddenly feel completely overwhelmed!) appear after the empowered spell wears off

:cl:
 * rscadd: Added a new level of empowerment to the Disorient spell that will mess up the victim's view hard.
 * bugfix: Fixed an obscure bug that made the empowered Disorient message to appear at the end of the effect instead of at the beginning.