### PR TITLE
Disorient gets blocked by tinfoil hat

### DIFF
--- a/code/modules/spells/targeted/disorient.dm
+++ b/code/modules/spells/targeted/disorient.dm
@@ -17,6 +17,7 @@
 	amt_dizziness = 86
 	amt_confused = 86 // 2.1 seconds per = 180.6s
 	amt_stuttering = 86
+	mind_affecting = 1
 
 	compatible_mobs = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 	spell_flags = WAIT_FOR_CLICK


### PR DESCRIPTION
I was arguing about #26329 and then it turns out tinfoil hats don't block Disorient.
Try to tell me about more mind-affecting spells that don't have a tinfoil hat check and I'll try to add it to em, I don't feel like digging the code yet

:cl:
 * tweak: Disorient is now blocked by tinfoil hats.