### PR TITLE
Skin Dye

### DIFF
--- a/code/datums/gamemode/misc_gamemode_procs.dm
+++ b/code/datums/gamemode/misc_gamemode_procs.dm
@@ -182,6 +182,7 @@
 	if(wizard_mob.backbag == 4)
 		wizard_mob.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel(wizard_mob), slot_back)
 	wizard_mob.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(wizard_mob), slot_in_backpack)
+	wizard_mob.equip_to_slot_or_del(new /obj/item/weapon/hair_dye/skin_dye(wizard_mob), slot_in_backpack)
 //	wizard_mob.equip_to_slot_or_del(new /obj/item/weapon/scrying_gem(wizard_mob), slot_l_store) For scrying gem.
 	var/scroll_type = apprentice ? /obj/item/weapon/teleportation_scroll/apprentice : /obj/item/weapon/teleportation_scroll
 	wizard_mob.equip_to_slot_or_del(new scroll_type(wizard_mob), slot_r_store)

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -3080,6 +3080,7 @@ var/global/num_vending_terminals = 1
 		/obj/item/weapon/storage/bag/gadgets/part_replacer/injector/super = 4,
 		/obj/structure/wetdryvac = 1,
 		/obj/structure/bed/therapy = 1,
+		/obj/item/weapon/hair_dye/skin_dye/discount = 5,
 		)
 	prices = list(
 		/obj/item/clothing/suit/storage/trader = 100,
@@ -3116,6 +3117,7 @@ var/global/num_vending_terminals = 1
 		/obj/item/weapon/storage/bag/gadgets/part_replacer/injector/super = 50,
 		/obj/structure/wetdryvac = 50,
 		/obj/structure/bed/therapy = 50,
+		/obj/item/weapon/hair_dye/skin_dye/discount = 10,
 		)
 
 /obj/machinery/vending/trader/New()

--- a/code/game/objects/items/weapons/cosmetics.dm
+++ b/code/game/objects/items/weapons/cosmetics.dm
@@ -270,7 +270,7 @@
 	..()
 	to_chat(user,"<span class='info'>It has [uses] uses left.</span>")
 
-/obj/item/weapon/hair_dye/skin_dye/attack(mob/M as mob, mob/user as mob)
+/obj/item/weapon/hair_dye/skin_dye/attack(mob/M, mob/user)
 	if(!ishuman(M))
 		return
 	var/mob/living/carbon/human/H = M

--- a/code/game/objects/items/weapons/cosmetics.dm
+++ b/code/game/objects/items/weapons/cosmetics.dm
@@ -261,6 +261,47 @@
 	H.update_hair()
 	playsound(src, 'sound/effects/spray2.ogg', 50, 1, -6)
 
+/obj/item/weapon/hair_dye/skin_dye
+	name = "magic skin dye"
+	desc = "Bubble, bubble, toil and trouble!"
+	uses = 3
+
+/obj/item/weapon/hair_dye/skin_dye/examine(mob/user)
+	..()
+	to_chat(user,"<span class='info'>It has [uses] uses left.</span>")
+
+/obj/item/weapon/hair_dye/skin_dye/attack(mob/M as mob, mob/user as mob)
+	if(!ishuman(M))
+		return
+	var/mob/living/carbon/human/H = M
+	if(H.w_uniform && (H.w_uniform.body_parts_covered & UPPER_TORSO))
+		to_chat(user,"<span class='warning'>[H] needs to have an uncovered chest to really let the dye sink in.</span>")
+	if(H != user)
+		to_chat(user,"<span class='danger'>[user] is trying to spray down [H] with skin dye!</span>")
+		if(do_after(user,H, 10 SECONDS))
+			to_chat(user,"<span class='info'>[user] dyed [H].</span>")
+			dye(H)
+	else
+		dye(H)
+
+/obj/item/weapon/hair_dye/skin_dye/proc/dye(mob/living/carbon/human/H)
+	H.species.anatomy_flags |= MULTICOLOR
+	H.multicolor_skin_r = color_r
+	H.multicolor_skin_g = color_g
+	H.multicolor_skin_b = color_b
+	H.update_body()
+	uses--
+	if(!uses)
+		qdel(src)
+
+/obj/item/weapon/hair_dye/skin_dye/discount
+	name = "discount skin dye"
+	desc = "This is... probably no more unhealthy than a spray-on tan, right?"
+
+/obj/item/weapon/hair_dye/skin_dye/discount/dye(mob/living/carbon/human/H)
+	..()
+	H.reagents.add_reagent(TOXIN,1)
+
 /obj/item/weapon/invisible_spray
 	name = "can of invisible spray"
 	desc = "A can of... invisibility? The label reads: \"Wears off after five minutes.\""

--- a/code/game/objects/items/weapons/cosmetics.dm
+++ b/code/game/objects/items/weapons/cosmetics.dm
@@ -264,7 +264,7 @@
 /obj/item/weapon/hair_dye/skin_dye
 	name = "magic skin dye"
 	desc = "Bubble, bubble, toil and trouble!"
-	uses = 3
+	var/uses = 3
 
 /obj/item/weapon/hair_dye/skin_dye/examine(mob/user)
 	..()

--- a/code/game/objects/items/weapons/cosmetics.dm
+++ b/code/game/objects/items/weapons/cosmetics.dm
@@ -276,10 +276,11 @@
 	var/mob/living/carbon/human/H = M
 	if(H.w_uniform && (H.w_uniform.body_parts_covered & UPPER_TORSO))
 		to_chat(user,"<span class='warning'>[H] needs to have an uncovered chest to really let the dye sink in.</span>")
+		return
 	if(H != user)
-		to_chat(user,"<span class='danger'>[user] is trying to spray down [H] with skin dye!</span>")
+		visible_message(user,"<span class='danger'>[user] is trying to spray down [H] with skin dye!</span>")
 		if(do_after(user,H, 10 SECONDS))
-			to_chat(user,"<span class='info'>[user] dyed [H].</span>")
+			visible_message(user,"<span class='info'>[user] dyed [H].</span>")
 			dye(H)
 	else
 		dye(H)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -2209,8 +2209,8 @@
 	M.color = ""
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
-		if(H.species.anatomy_flags & MULTICOLOR)
-			H.species.anatomy_flags = initial(H.species.anatomy_flags) //clear out any skin dye if it exists
+		if(H.species.anatomy_flags & MULTICOLOR && !(initial(H.species.anatomy_flags) & MULTICOLOR))
+			H.species.anatomy_flags &= ~MULTICOLOR
 			H.update_body()
 	M.adjustToxLoss(4 * REM)
 

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -2207,6 +2207,11 @@
 					H.vomit()
 	data++
 	M.color = ""
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(H.species.anatomy_flags & MULTICOLOR)
+			H.species.anatomy_flags = initial(H.species.anatomy_flags) //clear out any skin dye if it exists
+			H.update_body()
 	M.adjustToxLoss(4 * REM)
 
 /datum/reagent/space_cleaner/bleach/reaction_mob(var/mob/living/M, var/method = TOUCH, var/volume)


### PR DESCRIPTION
Skin dye, turns you funky colors. It has 3 uses. Wizard gets one in their backpack.
To apply, they need to not be wearing a uniform that covers their upper torso. Instant if used on self, 10 second apply time on someone else.
To clear the effect, drink bleach.
Wizard gets one in backpack. Traders sell a discount one that gives you some toxin.

Tested on human, vox, grey.

🆑 
* rscadd: Wizards now have magic skin dye for their gimmicks. Traders have a toxic discount version, but you can clear it by drinking bleach.