### PR TITLE
Revs announcement is now delayed by 60 seconds, and head revs are warned.

### DIFF
--- a/code/datums/gamemode/factions/syndicate/rev.dm
+++ b/code/datums/gamemode/factions/syndicate/rev.dm
@@ -131,8 +131,11 @@
 		if(living_revs > 0 && total_valid_living > 0)
 			var/revs_percentage = round((living_revs * 100)/total_valid_living)
 			if(revs_percentage >= threshold)
-				stage(FACTION_ENDGAME)
-				command_alert(/datum/command_alert/revolution)
+				for (var/datum/role/revolutionary/leader/comrade in members)
+					to_chat(comrade.antag.current, "<span class='warning'>The time to act is upon us. Nanotrasen must have noticed us by now. Let's waste no time!</span>")
+				spawn(60 SECONDS)
+					stage(FACTION_ENDGAME)
+					command_alert(/datum/command_alert/revolution)
 
 	switch(remaining_targets)
 		if(0)


### PR DESCRIPTION
I read that people weren't happy about this on the thread. But I don't think it should be entirely removed either, as it would encourage stealth-antagging, which is imo a bad thing.

I came to this compromise, which is simple to understand. The crew is still warned that "ITS REVS", but at least the revs aren't completely caught with their pants down and can prepare, or retreat in maint, before the big message happens.

It doesn't delay the announcement if there's only head of staff left on the station.

Feel free to discuss.
[balance]

:cl:
- tweak: The message which alerts the crew of revolutionary activities is now delayed by 60 seconds, and the head revolutionaries are warned. This allows them to retreat in maint or do something before the crew gets the announcement.