### PR TITLE
**PROBABLY** fixes the gazillion AStar runtimes

### DIFF
--- a/code/controllers/subsystem/bots.dm
+++ b/code/controllers/subsystem/bots.dm
@@ -19,8 +19,7 @@ var/datum/subsystem/bots/SSBots
 		return ..()
 
 	..("B:[global.bots_list.len]")
-
-
+	
 // This is to allow the near identical fast machinery process to use it.
 /datum/subsystem/bots/proc/get_currenrun()
 	return bots_list.Copy()
@@ -38,8 +37,7 @@ var/datum/subsystem/bots/SSBots
 			continue
 
 		if (M.process() == PROCESS_KILL)
-			M.inMachineList = 0
-			machines.Remove(M)
+			bots_list.Remove(M)
 			continue
 
 		if (M.use_power)

--- a/code/game/machinery/bots/bots.dm
+++ b/code/game/machinery/bots/bots.dm
@@ -124,8 +124,14 @@
 		if(--old_targets[i] == 0)
 			remove_oldtarget(i)
 
+// Decides if we can move or if we are busy doing something.
+/obj/machinery/bot/proc/can_path()
+	return TRUE
+
 // If we get a path through process_path(), which means we have a target, and we're not set to autopatrol, we get a patrol path.
 /obj/machinery/bot/proc/process_pathing()
+	if (!can_path())
+		return
 	if(!process_path() && (bot_flags & BOT_PATROL) && auto_patrol)
 		process_patrol()
 
@@ -142,6 +148,8 @@
 		return
 	if (!isturf(src.loc))
 		return // Stay in the closet, little bot. The world isn't ready to accept you yet ;_;
+	if (!can_path()) // We're busy.
+		return
 	var/turf/T = get_turf(src)
 	set_glide_size(DELAY2GLIDESIZE(SS_WAIT_BOTS/steps_per))
 	log_astar_bot("Step [i] of [steps_per]")
@@ -208,6 +216,8 @@
 /obj/machinery/bot/proc/process_patrol(var/remaining_steps = steps_per)
 	astar_debug("process patrol called [src] [patrol_path.len]")
 	set_glide_size(DELAY2GLIDESIZE(SS_WAIT_BOTS/steps_per))
+	if (!can_path()) // We're busy.
+		return TRUE
 	if (remaining_steps == 0)
 		return TRUE
 	if(!patrol_path.len)

--- a/code/game/machinery/bots/cleanbot.dm
+++ b/code/game/machinery/bots/cleanbot.dm
@@ -165,6 +165,9 @@ text("<A href='?src=\ref[src];operation=oddbutton'>[src.oddbutton ? "Yes" : "No"
 		src.oddbutton = 1
 		src.screwloose = 1
 
+/obj/machinery/bot/cleanbot/can_path()
+	return !cleaning
+
 /obj/machinery/bot/cleanbot/process_bot()
 	if(!target)
 		find_target()

--- a/code/game/machinery/bots/draculabot.dm
+++ b/code/game/machinery/bots/draculabot.dm
@@ -174,6 +174,9 @@
 		locked = 0
 		visible_message("<span class='danger'>[src]'s panel clicks open.</span>", 1)
 
+/obj/machinery/bot/bloodbot/can_path()
+	return !currently_drawing_blood
+
 /obj/machinery/bot/bloodbot/process_bot()
 	// Emagged behaviour
 	if (emagged)

--- a/code/game/machinery/bots/ed209bot.dm
+++ b/code/game/machinery/bots/ed209bot.dm
@@ -339,6 +339,8 @@ Auto Patrol: []"},
 
 	return threatcount
 
+/obj/machinery/bot/ed209/can_path()
+	return !cuffing
 
 /obj/machinery/bot/ed209/process_bot()
 	if (!target || target.gcDestroyed || get_dist(src, target) > 12)
@@ -353,6 +355,7 @@ Auto Patrol: []"},
 		if (Adjacent(target))		// if right next to perp
 			var/mob/living/carbon/M = target
 			target = null // Don't teabag them
+			path = list() // Kill our path
 			add_oldtarget(M.name, 12)
 			var/beat_them = (!M.incapacitated() || emagged) // Only stun people non-stunned. Stun forever if we're emagged
 			if (beat_them)

--- a/code/game/machinery/bots/farmbot.dm
+++ b/code/game/machinery/bots/farmbot.dm
@@ -214,6 +214,9 @@
 	qdel(src)
 	return
 
+/obj/machinery/bot/farmbot/can_path()
+	return !mode
+
 /obj/machinery/bot/farmbot/process_bot()
 	//set background = 1
 
@@ -239,6 +242,7 @@
 
 	if ( mode && target )
 		if ( get_dist(target,src) <= 1 || ( emagged && mode == FARMBOT_MODE_FERTILIZE ) )
+			path = list() // Kill our path
 			// If we are in emagged fertilize mode, we throw the fertilizer, so distance doesn't matter
 			frustration = 0
 			use_farmbot_item()

--- a/code/game/machinery/bots/floorbot.dm
+++ b/code/game/machinery/bots/floorbot.dm
@@ -186,6 +186,9 @@ var/global/list/floorbot_targets=list()
 /obj/machinery/bot/floorbot/proc/have_target()
 	return (target != null && !target.gcDestroyed)
 
+/obj/machinery/bot/floorbot/can_path()
+	return !repairing
+
 /obj/machinery/bot/floorbot/process_bot()
 	if(repairing)
 		return

--- a/code/game/machinery/bots/medbot.dm
+++ b/code/game/machinery/bots/medbot.dm
@@ -277,6 +277,9 @@
 		on = 1
 		icon_state = "[icon_initial][on]"
 
+/obj/machinery/bot/medbot/can_path()
+	return !(stunned || currently_healing)
+
 /obj/machinery/bot/medbot/process_bot()
 	if(stunned)
 		stunned--
@@ -289,6 +292,7 @@
 	decay_oldtargets()
 
 	if (get_dist(src, target) <= 1)
+		path = list() // Kill our path
 		if(!currently_healing)
 			currently_healing = TRUE
 			medicate_patient(target)

--- a/code/game/machinery/bots/secbot.dm
+++ b/code/game/machinery/bots/secbot.dm
@@ -247,6 +247,9 @@ Auto Patrol: []"},
 			playsound(src, pick('sound/voice/bcriminal.ogg', 'sound/voice/bjustice.ogg', 'sound/voice/bfreeze.ogg'), 50, 0)
 			visible_message("<b>[src]</b> points at [C.name]!")
 
+/obj/machinery/bot/secbot/can_path()
+	return !cuffing
+
 /obj/machinery/bot/secbot/process_bot()
 	if (!target || target.gcDestroyed || get_dist(src, target) > 7)
 		target = null
@@ -260,6 +263,7 @@ Auto Patrol: []"},
 			return
 		if (Adjacent(target))		// if right next to perp
 			var/mob/living/carbon/M = target
+			path = list() // Kill our path
 			target = null // Don't teabag them
 			add_oldtarget(M.name, 12)
 			var/beat_them = (!M.incapacitated() || emagged) // Only stun people non-stunned. Stun forever if we're emagged


### PR DESCRIPTION
** PROBABLY ** because I still can't reproduce those on local. I've pinpointed what happens, but I can't get it to happen on my machine.

Basically, the bot gets `process_pathing` called twice, the path is calculated twice, and since the turfs are supposed to belong to a single, unique path, they overwrite each other and it doesn't work.

Investigating this, I ended up realising that this happens a lot more often that I would like.
As @DamianX helpfully told me, it's because you can't use `sleep` in a subsystem. The entire code relied entirely on the assumption of carefully delayed `for` block, which we don't have here.

I've fixed it, tested it, and there's no apparent bugs. There's STILL a minor issue to fix (Beepsky doesn't stop if he crosses his target, but he does stun them), but I don't have time for that tonight, so i'll fix that bit tommorow.