### PR TITLE
It Just Works

### DIFF
--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -118,3 +118,6 @@
 
 	if(client)
 		client.CAN_MOVE_DIAGONALLY = 0
+
+	add_client(client)
+	contained_clients.Swap(1, contained_clients.len) //Put our own client at the beginning so we know which one to remove in Logout() (as client is already nulled by then)

--- a/code/modules/mob/logout.dm
+++ b/code/modules/mob/logout.dm
@@ -48,4 +48,7 @@
 
 	INVOKE_EVENT(on_logout, list())
 
+	if(contained_clients)
+		remove_client(contained_clients[1])
+
 	..()

--- a/code/world.dm
+++ b/code/world.dm
@@ -156,6 +156,11 @@ var/savefile/panicfile
 	process_adminbus_teleport_locs()	//Sets up adminbus teleport locations.
 	SortAreas()							//Build the list of all existing areas and sort it alphabetically
 
+	//The following block serves to force the server to use pixel movement even though everything is tile-aligned. If you know of a better way to do this, please replace this with it.
+	var/obj/forcepixel = new()
+	forcepixel.step_x = 1
+	qdel(forcepixel)
+
 	spawn(2000)		//so we aren't adding to the round-start lag
 		if(config.ToRban)
 			ToRban_autoupdate()


### PR DESCRIPTION
An experimental attempt to make the server internally use pixel movement while keeping gameplay more or less identical to how it is currently. This is done by just manually reimplementing gliding.
I tested this quite a bit locally, but there are lots of things in this game that move, and I only had one person online, so saying it's 100% tested would be quite bold.
If this causes problems, feel free to just revert it. It's more of a test than anything.

Movement animations can get a bit janky if the server is lagging, but hopefully that won't be too big an issue. On the plus side, though, the way it's coded, it just magically makes some things that weren't previously animated animate, such as walking out of a locker or opening (but sadly not closing) a morgue tray.

I kind of don't want to add a changelog because in the likely event this gets reverted, the changelog would still be there, and the results of telling admins "you can modify `step_`whatever now" would be potentially catastrophic