### PR TITLE
Fix another yet undiscovered AStar runtimes

### DIFF
--- a/code/defines/procs/AStar.dm
+++ b/code/defines/procs/AStar.dm
@@ -198,7 +198,7 @@ proc/quick_AStar(start,end,adjacent,dist,maxnodes,maxnodedepth = 30,mintargetdis
 	ASSERT(!istype(end,/area)) //Because yeah some things might be doing this and we want to know what
 	var/PriorityQueue/open = new /PriorityQueue(/proc/PathWeightCompare) //the open list, ordered using the PathWeightCompare proc, from lower f to higher
 	var/list/closed = new() //the closed list
-	var/list/path = null //the returned path, if any
+	var/list/path = list() //the returned path, if any
 	var/PathNode/cur //current processed turf
 	start = get_turf(start)
 

--- a/code/game/machinery/bots/bots.dm
+++ b/code/game/machinery/bots/bots.dm
@@ -388,7 +388,7 @@
 // proc_to_call is the proc which is called by the pathmaker once it's done its work and wishes to return a path.
 // avoid is a turf the path should NOT go through. (a previous obstacle.) This info is then given to the pathmaker.
 // Fast bots use quick_AStar method to direcly calculate a path and move on it.
-/obj/machinery/bot/proc/calc_path(var/target, var/proc_to_call, var/turf/avoid = null, var/mode = PATH)
+/obj/machinery/bot/proc/calc_path(var/target, var/proc_to_call, var/turf/avoid = null)
 	ASSERT(target && proc_to_call)
 	log_astar_beacon("[new_destination]")
 	if ((get_dist(src, target) < 13) && !(flags & BOT_NOT_CHASING)) // For beepers and ED209

--- a/code/game/machinery/bots/bots.dm
+++ b/code/game/machinery/bots/bots.dm
@@ -155,7 +155,7 @@
 	log_astar_bot("Step [i] of [steps_per]")
 	if(!path.len) //It is assumed we gain a path through process_bot()
 		if(target)
-			path = calc_path(target, .proc/get_path)
+			calc_path(target, .proc/get_path)
 			process_path() // I love recursivity.
 			return 1
 		return  0
@@ -191,7 +191,7 @@
 			return TRUE
 	if(frustration > 5)
 		if (target && !target.gcDestroyed)
-			path = calc_path(target, .proc/get_path, next)
+			calc_path(target, .proc/get_path, next)
 		else
 			target = null
 			path = list()
@@ -388,13 +388,14 @@
 // proc_to_call is the proc which is called by the pathmaker once it's done its work and wishes to return a path.
 // avoid is a turf the path should NOT go through. (a previous obstacle.) This info is then given to the pathmaker.
 // Fast bots use quick_AStar method to direcly calculate a path and move on it.
-/obj/machinery/bot/proc/calc_path(var/target, var/proc_to_call, var/turf/avoid = null)
+/obj/machinery/bot/proc/calc_path(var/target, var/proc_to_call, var/turf/avoid = null, var/mode = PATH)
 	ASSERT(target && proc_to_call)
 	log_astar_beacon("[new_destination]")
 	if ((get_dist(src, target) < 13) && !(flags & BOT_NOT_CHASING)) // For beepers and ED209
 		// IMPORTANT: Quick AStar only takes TURFS as arguments.
 		waiting_for_patrol = FALSE // Case we are calculating a quick path for a patrol.
-		return quick_AStar(src.loc, get_turf(target), /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance_cardinal, 0, max(10,get_dist(src,target)*3), id=botcard, exclude=avoid, reference="\ref[src]")
+		path = quick_AStar(src.loc, get_turf(target), /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance_cardinal, 0, max(10,get_dist(src,target)*3), id=botcard, exclude=avoid, reference="\ref[src]", return_proc=proc_to_call)
+		return TRUE
 	return AStar(src, proc_to_call, src.loc, target, /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance_cardinal, 0, max(10,get_dist(src,target)*3), id=botcard, exclude=avoid)
 
 // This proc is called by the path maker once it has calculated a path.

--- a/code/game/machinery/bots/cleanbot.dm
+++ b/code/game/machinery/bots/cleanbot.dm
@@ -125,7 +125,7 @@ text("<A href='?src=\ref[src];operation=oddbutton'>[src.oddbutton ? "Yes" : "No"
 			src.updateUsrDialog()
 		if("patrol")
 			src.auto_patrol =!src.auto_patrol
-			src.patrol_path = null
+			src.patrol_path = list()
 			src.updateUsrDialog()
 		if("freq")
 			var/freq = text2num(input("Select frequency for  navigation beacons", "Frequnecy", num2text(beacon_freq / 10))) * 10

--- a/code/game/machinery/bots/farmbot.dm
+++ b/code/game/machinery/bots/farmbot.dm
@@ -77,7 +77,7 @@
 
 /obj/machinery/bot/farmbot/turn_off()
 	..()
-	src.path = new()
+	src.path = list()
 	src.icon_state = "[src.icon_initial][src.on]"
 	src.updateUsrDialog()
 

--- a/code/game/machinery/bots/medbot.dm
+++ b/code/game/machinery/bots/medbot.dm
@@ -122,7 +122,7 @@
 	..()
 	target = null
 	old_targets = list()
-	path = new()
+	path = list()
 	currently_healing = 0
 	icon_state = "[icon_initial][on]"
 	updateUsrDialog()


### PR DESCRIPTION
Whoops haha.
I was (wrongly) assuming that all calls for the path in `process_pathing` would be to `quick_astar`, which is extraordinarily silly and dumb. Sometimes, it's not the case, and it leaves the bot with a non-list when it expects a list. 

This has no measurable effects on players or on the server, but it does clogs up the runtime log A LOT.

I'm starting to have nightmare about A* runtimes.