### PR TITLE
Working version of AStar pathing fix

### DIFF
--- a/code/defines/procs/AStar.dm
+++ b/code/defines/procs/AStar.dm
@@ -198,11 +198,12 @@ proc/quick_AStar(start,end,adjacent,dist,maxnodes,maxnodedepth = 30,mintargetdis
 	ASSERT(!istype(end,/area)) //Because yeah some things might be doing this and we want to know what
 	var/PriorityQueue/open = new /PriorityQueue(/proc/PathWeightCompare) //the open list, ordered using the PathWeightCompare proc, from lower f to higher
 	var/list/closed = new() //the closed list
-	var/list/path = list() //the returned path, if any
+	var/list/path = null //the returned path, if any
 	var/PathNode/cur //current processed turf
 	start = get_turf(start)
 
 	if(!start)
+		astar_debug("aborted - no start.")
 		return list()
 
 	//initialization
@@ -237,7 +238,11 @@ proc/quick_AStar(start,end,adjacent,dist,maxnodes,maxnodedepth = 30,mintargetdis
 		var/list/L = call(cur.source,adjacent)(id,closed)
 
 		for(var/turf/T in L)
+			if(ASTAR_DEBUG && T.color != "#00ff00")
+				T.color = "#FFA500" //orange
 			if(T == exclude)
+				if(ASTAR_DEBUG && T.color != "#00ff00")
+					T.color = "#FF0000" //red
 				continue
 
 			var/newenddist = call(T,dist)(end)
@@ -275,9 +280,6 @@ proc/quick_AStar(start,end,adjacent,dist,maxnodes,maxnodedepth = 30,mintargetdis
 			path.Swap(i,path.len-i+1)
 
 	return path
-
-
-
 
 ///////////////////
 //A* helpers procs

--- a/code/game/machinery/bots/cleanbot.dm
+++ b/code/game/machinery/bots/cleanbot.dm
@@ -165,6 +165,9 @@ text("<A href='?src=\ref[src];operation=oddbutton'>[src.oddbutton ? "Yes" : "No"
 		src.oddbutton = 1
 		src.screwloose = 1
 
+/obj/machinery/bot/cleanbot/can_path()
+	return !cleaning
+
 /obj/machinery/bot/cleanbot/process_bot()
 	if(!target)
 		find_target()

--- a/code/game/machinery/bots/draculabot.dm
+++ b/code/game/machinery/bots/draculabot.dm
@@ -174,6 +174,9 @@
 		locked = 0
 		visible_message("<span class='danger'>[src]'s panel clicks open.</span>", 1)
 
+/obj/machinery/bot/bloodbot/can_path()
+	return !currently_drawing_blood
+
 /obj/machinery/bot/bloodbot/process_bot()
 	// Emagged behaviour
 	if (emagged)

--- a/code/game/machinery/bots/ed209bot.dm
+++ b/code/game/machinery/bots/ed209bot.dm
@@ -339,6 +339,9 @@ Auto Patrol: []"},
 
 	return threatcount
 
+/obj/machinery/bot/ed209/can_path()
+	return !cuffing
+
 /obj/machinery/bot/ed209/process_bot()
 	if (!target || target.gcDestroyed || get_dist(src, target) > 12)
 		target = null

--- a/code/game/machinery/bots/farmbot.dm
+++ b/code/game/machinery/bots/farmbot.dm
@@ -214,6 +214,9 @@
 	qdel(src)
 	return
 
+/obj/machinery/bot/farmbot/can_path()
+	return !mode
+
 /obj/machinery/bot/farmbot/process_bot()
 	//set background = 1
 

--- a/code/game/machinery/bots/floorbot.dm
+++ b/code/game/machinery/bots/floorbot.dm
@@ -186,6 +186,9 @@ var/global/list/floorbot_targets=list()
 /obj/machinery/bot/floorbot/proc/have_target()
 	return (target != null && !target.gcDestroyed)
 
+/obj/machinery/bot/floorbot/can_path()
+	return !repairing
+
 /obj/machinery/bot/floorbot/process_bot()
 	if(repairing)
 		return

--- a/code/game/machinery/bots/medbot.dm
+++ b/code/game/machinery/bots/medbot.dm
@@ -277,6 +277,9 @@
 		on = 1
 		icon_state = "[icon_initial][on]"
 
+/obj/machinery/bot/medbot/can_path()
+	return !(stunned || currently_healing)
+
 /obj/machinery/bot/medbot/process_bot()
 	if(stunned)
 		stunned--

--- a/code/game/machinery/bots/secbot.dm
+++ b/code/game/machinery/bots/secbot.dm
@@ -91,7 +91,7 @@
 /obj/machinery/bot/secbot/turn_off()
 	..()
 	target = null
-	steps_per = initial(steps_per)
+	steps_per = initial_steps_per
 	old_targets = list()
 	anchored = 0
 	start_walk_to(0)
@@ -170,10 +170,16 @@ Auto Patrol: []"},
 			src.declare_arrests = !src.declare_arrests
 			src.updateUsrDialog()
 
+/obj/machinery/bot/secbot/can_path()
+	return !cuffing
+
 /obj/machinery/bot/secbot/proc/set_target(var/mob/M)
 	target = M
 	steps_per = 3
-	process_path()
+	//process_path()
+
+/obj/machinery/bot/secbot/can_patrol()
+	return steps_per == initial_steps_per
 
 /obj/machinery/bot/secbot/attackby(obj/item/weapon/W, mob/user)
 	if(istype(W, /obj/item/weapon/card/id)||istype(W, /obj/item/device/pda))
@@ -214,7 +220,7 @@ Auto Patrol: []"},
 		for(var/mob/O in hearers(src))
 			O.show_message("<span class='danger'>[src] buzzes oddly!</span>", 1)
 		src.target = null
-		steps_per = initial(steps_per)
+		steps_per = initial_steps_per
 		if(user)
 			add_oldtarget(user, 12)
 		src.anchored = 0
@@ -250,7 +256,7 @@ Auto Patrol: []"},
 /obj/machinery/bot/secbot/process_bot()
 	if (!target || target.gcDestroyed || get_dist(src, target) > 7)
 		target = null
-		steps_per = initial(steps_per)
+		steps_per = initial_steps_per
 		find_target()
 
 	decay_oldtargets()
@@ -282,7 +288,6 @@ Auto Patrol: []"},
 				cuffing = 1
 				var/cuff_time = emagged ? 2 SECONDS : 6 SECONDS
 				spawn(cuff_time)
-					cuffing = 0
 					if (Adjacent(M))
 						if (!istype(M))
 							return
@@ -291,6 +296,8 @@ Auto Patrol: []"},
 						M.handcuffed = new /obj/item/weapon/handcuffs(M)
 						M.update_inv_handcuffed()	//update handcuff overlays
 						playsound(src, pick('sound/voice/bgod.ogg', 'sound/voice/biamthelaw.ogg', 'sound/voice/bsecureday.ogg', 'sound/voice/bradio.ogg', 'sound/voice/binsult.ogg', 'sound/voice/bcreep.ogg'), 50, 0)
+						spawn (1.5 SECONDS)
+							cuffing = 0
 			if(declare_arrests)
 				var/area/location = get_area(src)
 				broadcast_security_hud_message("[name] is [arrest_type ? "detaining" : "arresting"] level [threatlevel] suspect <b>[M]</b> in <b>[location]</b>", src)
@@ -484,7 +491,7 @@ Auto Patrol: []"},
 /obj/machinery/bot/secbot/beepsky/cheapsky/process_bot()
 	if (!target || target.gcDestroyed)
 		target = null
-		steps_per = initial(steps_per)
+		steps_per = initial_steps_per
 		find_target()
 
 	decay_oldtargets()
@@ -506,7 +513,7 @@ Auto Patrol: []"},
 
 			add_oldtarget(target.name, 6)
 			target = null
-			steps_per = initial(steps_per)
+			steps_per = initial_steps_per
 
 			if(declare_arrests)
 				var/area/location = get_area(src)


### PR DESCRIPTION
Working as in, "won't crash the server if it's used on P*cked with its  short patrol paths". (tested)

Difference compared to #26365 :
- added a failsafe for maximum moving per process turn.
- differentiate pathing behaviour when chasing a target and patrolling.
- more debug