### PR TITLE
Fixes a typo in the nuclear operative shuttle

### DIFF
--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -177,7 +177,7 @@ proc/process_adminbus_teleport_locs()
 	requires_power = 0
 	dynamic_lighting = 0
 	shuttle_can_crush = FALSE
-	flags = NO_PERSISTENCE 
+	flags = NO_PERSISTENCE
 
 //These are shuttle areas, they must contain two areas in a subgroup if you want to move a shuttle from one
 //place to another. Look at escape shuttle for example.
@@ -348,7 +348,7 @@ proc/process_adminbus_teleport_locs()
 	icon_state = "shuttlered"
 
 /area/shuttle/nuclearops
-	name = "\improper Nuclear Opeartive Shuttle"
+	name = "\improper Nuclear Operative Shuttle"
 	icon_state = "yellow"
 	requires_power = 0
 	dynamic_lighting = 1


### PR DESCRIPTION
closes #26258 

:cl:
 * spellcheck: No more pears in the nukeop shuttle