### PR TITLE
Loose catbeasts will no longer vomit a hairball once in a while

### DIFF
--- a/code/modules/mob/living/carbon/human/life/handle_disabilities.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_disabilities.dm
@@ -85,7 +85,7 @@
 					emote("drool")
 
 	if(species.name == "Tajaran")
-		if(prob(1)) //Was 3
+		if(prob(1) && !isloosecatbeast(src)) //Was 3
 			vomit(1) //Hairball
 
 	if(stat != DEAD)


### PR DESCRIPTION
Well it's mostly because it ruins good chases if the catbeast just gets stunned out of RNG
This does **NOT** apply to normal catbeasts, only the loose catbeasts that are announced and all that.

:cl:
 * tweak: Loose catbeasts will no longer vomit once in a while.