### PR TITLE
Fixes paper bins making ashes forever

### DIFF
--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -14,15 +14,29 @@
 	autoignition_temperature = 519.15 // Kelvin
 
 
+/obj/item/weapon/paper_bin/ignite()
+	if(amount || papers.len)
+		..()
+
 /obj/item/weapon/paper_bin/ashify()
-	var/ashtype = ashtype()
-	new ashtype(src.loc)
-	papers=0
-	amount=0
+	if(!on_fire)
+		return
+	if(amount || papers.len)
+		var/ashtype = ashtype()
+		new ashtype(src.loc)
+		amount = 0
+		for(var/obj/item/weapon/paper/p in papers)
+			qdel(p)
+		papers = list() //In case somehow there's still something in it
+	extinguish()
 	update_icon()
 
 /obj/item/weapon/paper_bin/getFireFuel()
-	return amount
+	return amount + papers.len
+
+/obj/item/weapon/paper_bin/Exited(atom/movable/Obj, atom/newloc)
+	papers -= Obj
+	..()
 
 /obj/item/weapon/paper_bin/MouseDropFrom(over_object)
 	if(!usr.incapacitated() && (usr.contents.Find(src) || Adjacent(usr)))


### PR DESCRIPTION
Does not fix any of the many other bugs and odd behaviors I found while doing so because I don't really want to rewrite that much stuff right now

Paper bins will now only burn if they have paper in them. The paper all burns immediately as soon as the bin starts burning due to the bugs/odd behavior mentioned above, so they only burn for zero ticks, but there's no real difference other than that they no longer produce ash constantly and they don't get a little fire sprite on them.