### PR TITLE
Spellbooks should be fixed for real this time

### DIFF
--- a/code/game/gamemodes/wizard/artifacts.dm
+++ b/code/game/gamemodes/wizard/artifacts.dm
@@ -99,7 +99,7 @@
 	desc = "Feeling adventurous? Buy this bundle and recieve seven random spellbooks! Who knows what spells you will get? (Warning, each spell book may only be used once! No refunds)."
 	abbreviation = "SB"
 	price = 4 * Sp_BASE_PRICE
-	spawned_items = list(/obj/item/weapon/storage/box/spellbook/random)
+	spawned_items = list(/obj/item/weapon/storage/box/spellbook)
 
 /datum/spellbook_artifact/potion_bundle
 	name = "Potion bundle"

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -875,17 +875,15 @@
 /obj/item/weapon/storage/box/spellbook/New()
 	..()
 	var/list/possible_books = subtypesof(/obj/item/weapon/spellbook/oneuse)
-	for(var/obj/item/weapon/spellbook/oneuse/S in possible_books)
-		if(S.disabled_from_bundle)
-			possible_books -= S
+	for(var/S in possible_books)
+		var/obj/item/weapon/spellbook/oneuse/O = S
+		if(initial(O.disabled_from_bundle))
+			possible_books -= O
 	for(var/i =1; i <= 7; i++)
 		var/randombook = pick(possible_books)
 		var/book = new randombook(src)
 		src.contents += book
 		possible_books -= randombook
-
-/obj/item/weapon/storage/box/spellbook/random/New()
-	..()
 	var/randomsprite = pick("a","b")
 	icon_state = "wizbox-[randomsprite]"
 


### PR DESCRIPTION
Turns out it has to be done this specific way or else it wouldn't work. I blame BYOND
I took the liberty of cleaning up the code a little since the normal box was unused

:cl:
 * bugfix: Spellbooks that aren't supposed to appear in the spellbook bundle (sith lightning, highlander and charge) are properly blacklisted now.