### PR TITLE
Makes qdel() call Exited(), etc.

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -88,7 +88,8 @@
 	if (opacity && isturf(loc))
 		un_opaque = loc
 
-	loc = null
+	forceMove(null, harderforce = TRUE)
+
 	if (un_opaque)
 		un_opaque.recalc_atom_opacity()
 


### PR DESCRIPTION
Specifically by making `/atom/movable/Destroy()` call `forceMove()` instead of just setting `loc` directly. I can't think of any reason it shouldn't do this. Most likely it's just that nobody bothered changing it. With a singularity running around, I couldn't find any issues this caused, and none of the relevant procs showed up high enough on the profiler to worry about, so it's probably fine.

We don't really make use of `Exited()` (or any of the default movement procs, for that matter) as much as we should, but it's very good for cleaning up references that make no sense to keep, either due to the object being deleted or simply moved. An example would be that machines should remove parts from their stock parts lists on `Exited()`. (I didn't check if they already do, so if they do, good on whoever did that)