### PR TITLE
Decreased roundstart traitor weight from 5 to 2

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -13,7 +13,7 @@
 							"Head of Security", "Captain", "Chief Engineer", "Chief Medical Officer", "Research Director")
 	restricted_from_jobs = list("AI","Mobile MMI")
 	required_candidates = 1
-	weight = 5
+	weight = 2
 	cost = 10
 	var/traitor_threshold = 3
 	var/additional_cost = 5


### PR DESCRIPTION
There really is an awful lot of traitor lately.
If the reason for that is that everyone has all other antags off, then this will change nothing.
If the reason is that the weight was too high relative to the others, then this will make other roundstart rulesets more common.

I just want some nuke ops, man.

:cl:
 * tweak: Decreased the odds of round-start traitors spawning relative to other antags.