### PR TITLE
Fixes potential bugs related to qdel() and forceMove()

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -96,6 +96,8 @@
 
 	for (var/datum/locking_category/category in locking_categories)
 		qdel(category)
+	locking_categories      = null
+	locking_categories_name = null
 
 	break_all_tethers()
 
@@ -103,9 +105,6 @@
 
 	if (un_opaque)
 		un_opaque.recalc_atom_opacity()
-
-	locking_categories      = null
-	locking_categories_name = null
 
 	if((flags & HEAR) && !ismob(src))
 		for(var/mob/virtualhearer/VH in virtualhearers)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -88,11 +88,6 @@
 	if (opacity && isturf(loc))
 		un_opaque = loc
 
-	forceMove(null, harderforce = TRUE)
-
-	if (un_opaque)
-		un_opaque.recalc_atom_opacity()
-
 	for (var/atom/movable/AM in locked_atoms)
 		unlock_atom(AM)
 
@@ -102,10 +97,15 @@
 	for (var/datum/locking_category/category in locking_categories)
 		qdel(category)
 
+	break_all_tethers()
+
+	forceMove(null, harderforce = TRUE)
+
+	if (un_opaque)
+		un_opaque.recalc_atom_opacity()
+
 	locking_categories      = null
 	locking_categories_name = null
-
-	break_all_tethers()
 
 	if((flags & HEAR) && !ismob(src))
 		for(var/mob/virtualhearer/VH in virtualhearers)


### PR DESCRIPTION
0% tested because I'm very tired but it's just reordering existing code so What Could Possibly Go Wrong?
(I can test it later if you insist but that will basically just entail spawning a singularity and looking at runtimes because I don't even know what could go wrong)

Now all code related to unlocking atoms and breaking tethers happens before the object is moved to nullspace instead of after. That's it.