### PR TITLE
Fixes part of AStar runtimes-induced runtimes

### DIFF
--- a/code/defines/procs/AStar.dm
+++ b/code/defines/procs/AStar.dm
@@ -196,9 +196,10 @@ proc/AStar(source, proc_to_call, start,end,adjacent,dist,maxnodes,maxnodedepth =
 // You MUST have the start and end be turfs.
 proc/quick_AStar(start,end,adjacent,dist,maxnodes,maxnodedepth = 30,mintargetdist,minnodedist,id=null, var/turf/exclude=null, var/reference)
 	ASSERT(!istype(end,/area)) //Because yeah some things might be doing this and we want to know what
+	. = list() // In case of failure/runtimes, we want to return a list.
 	var/PriorityQueue/open = new /PriorityQueue(/proc/PathWeightCompare) //the open list, ordered using the PathWeightCompare proc, from lower f to higher
 	var/list/closed = new() //the closed list
-	var/list/path = null //the returned path, if any
+	var/list/path = list() //the returned path, if any
 	var/PathNode/cur //current processed turf
 	start = get_turf(start)
 


### PR DESCRIPTION
AStar would runtime, which wasn't expected from the main bot process loop, which would also runtime, which would clog the log and would be confusing.

There's absolutely no reason that `quick_Astar` should return anything else than a list, so there's that.