### PR TITLE
pAI Chem Synth Tweak

### DIFF
--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -76,6 +76,7 @@
 		"Anti-Toxin" = ANTI_TOXIN,
 		"Inaprovaline" = INAPROVALINE,
 		"Coffee" = COFFEE,
+		"Tea" = TEA,
 		"Salt" = SODIUMCHLORIDE,
 		"Smoke" = PAISMOKE,
 	)

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -73,7 +73,8 @@
 	)
 
 	var/list/synthable_default_chems = list(
-		"Tricordrazine" = TRICORDRAZINE,
+		"Anti-Toxin" = ANTI_TOXIN,
+		"Inaprovaline" = INAPROVALINE,
 		"Coffee" = COFFEE,
 		"Salt" = SODIUMCHLORIDE,
 		"Smoke" = PAISMOKE,


### PR DESCRIPTION
[powercreep][tweak] The reasoning behind this is that the oxyloss damage from crit outclasses tricordazine's healing which makes it impossible to stabilize your holder with. Inaprov lets you stop crit oxyloss, antitox allows you to mix your own tricord if you want. This also lets pAIs gas vox that pick them up which is a plus and a minus depending on how you look at it. 

Also adds tea because why not. Unapologetic powercreep in attempt to make pAIs more level with powergay worms.

:cl:
 * tweak: Removes tricordazine from the pAI chem synth and adds antitoxin, inaprovaline and tea in its place.