### PR TITLE
True Pitbulls Never Die

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/pitbull.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pitbull.dm
@@ -80,3 +80,14 @@
 
 /mob/living/simple_animal/hostile/pitbull/summoned_pitbull
 	faction = "wizard"
+	meat_type = /obj/item/weapon/ectoplasm //a magical dog
+
+/mob/living/simple_animal/hostile/pitbull/summoned_pitbull/death(var/gibbed = FALSE)
+	..()
+	if(!gibbed)
+		if(prob(95))
+			animate(src, alpha = 0, time = 4 SECONDS)
+			spawn(4 SECONDS)
+				qdel(src)
+		else
+			gib()


### PR DESCRIPTION
...They just fade away.

🆑 
* rscadd: Summoned pitbulls now have a 95% chance to fade away over 4 seconds after being killed. There is a 5% chance they will gib into ectoplasm.