### PR TITLE
fixed in-hand icon for /obj/item/stack/cable_coil/cut

### DIFF
--- a/code/game/objects/items/stacks/cable.dm
+++ b/code/game/objects/items/stacks/cable.dm
@@ -272,7 +272,6 @@ var/global/list/datum/stack_recipe/cable_recipes = list ( \
 /////////////////////////////
 
 /obj/item/stack/cable_coil/cut
-	item_state = "coil_red2"
 
 /obj/item/stack/cable_coil/cut/New(loc, amount, var/param_color = null)
 	..(loc)


### PR DESCRIPTION
It was supposed to set icon_state but even that is irrelevant because it's all handled in update_icon, called by New()