### PR TITLE
ethylredoxrazine now removes alcohol when metabolized

### DIFF
--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -955,16 +955,13 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 
 
 //written for ethylredoxrazine, but might be fun for turning water into wine or something
-/datum/reagents/proc/convert_some_of_type(var/datum/reagent/convert_from_type, var/datum/reagent/convert_to_type,var/convert_amount = 0)
+/datum/reagents/proc/convert_some_of_type(var/datum/reagent/convert_from_type, var/datum/reagent/convert_to_type,var/convert_amount)
 	var/total_amount_converted = 0
 
 	for(var/datum/reagent/itsareagent in reagent_list)
 		if(istype(itsareagent, convert_from_type))
 			var/amount_to_convert
-			if(convert_amount == 0)
-				amount_to_convert = min(itsareagent.volume, 2 * REM)
-			else
-				amount_to_convert = min(itsareagent.volume, convert_amount)
+			amount_to_convert = min(itsareagent.volume, convert_amount)
 			total_amount_converted += amount_to_convert
 			remove_that_reagent(itsareagent, amount_to_convert)
 	return add_reagent(initial(convert_to_type.id), total_amount_converted)

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -952,3 +952,20 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 		if(my_atom)
 			var/atom/A = my_atom
 			A.reagents = src
+
+
+//written for ethylredoxrazine, but might be fun for turning water into wine or something
+/datum/reagents/proc/convert_some_of_type(var/datum/reagent/convert_from_type, var/datum/reagent/convert_to_type,var/convertall = FALSE)
+	var/total_amount_converted = 0
+
+	for(var/datum/reagent/itsareagent in reagent_list)
+		if(istype(itsareagent, convert_from_type))
+			var/amount_to_convert
+			if(!convertall)
+				amount_to_convert = min(itsareagent.volume, 2 * REM)
+			else
+				amount_to_convert = itsareagent.volume
+			total_amount_converted += amount_to_convert
+			remove_that_reagent(itsareagent, amount_to_convert)
+	return add_reagent(initial(convert_to_type.id), total_amount_converted)
+

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -955,16 +955,16 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 
 
 //written for ethylredoxrazine, but might be fun for turning water into wine or something
-/datum/reagents/proc/convert_some_of_type(var/datum/reagent/convert_from_type, var/datum/reagent/convert_to_type,var/convertall = FALSE)
+/datum/reagents/proc/convert_some_of_type(var/datum/reagent/convert_from_type, var/datum/reagent/convert_to_type,var/convert_amount = 0)
 	var/total_amount_converted = 0
 
 	for(var/datum/reagent/itsareagent in reagent_list)
 		if(istype(itsareagent, convert_from_type))
 			var/amount_to_convert
-			if(!convertall)
+			if(convert_amount == 0)
 				amount_to_convert = min(itsareagent.volume, 2 * REM)
 			else
-				amount_to_convert = itsareagent.volume
+				amount_to_convert = min(itsareagent.volume, convert_amount)
 			total_amount_converted += amount_to_convert
 			remove_that_reagent(itsareagent, amount_to_convert)
 	return add_reagent(initial(convert_to_type.id), total_amount_converted)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -3763,7 +3763,7 @@
 	M.drowsyness = 0
 	M.stuttering = 0
 	M.confused = 0
-	holder.convert_some_of_type(/datum/reagent/ethanol, /datum/reagent/water) //booze-b-gone
+	holder.convert_some_of_type(/datum/reagent/ethanol, /datum/reagent/water, 2 * REM) //booze-b-gone
 
 //Otherwise known as a "Mickey Finn"
 /datum/reagent/chloralhydrate

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -3763,10 +3763,7 @@
 	M.drowsyness = 0
 	M.stuttering = 0
 	M.confused = 0
-	/*if(holder.has_reagent_type(/datum/reagent/ethanol)) //ethylred turns pure ethanol into water, slowly removes other drinks.
-		holder.remove_all_type(/datum/reagent/ethanol, 2 * REM) //booze-b-gone 
-	*/
-	holder.convert_some_of_type(/datum/reagent/ethanol, /datum/reagent/water)
+	holder.convert_some_of_type(/datum/reagent/ethanol, /datum/reagent/water) //booze-b-gone
 
 //Otherwise known as a "Mickey Finn"
 /datum/reagent/chloralhydrate

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -3763,6 +3763,10 @@
 	M.drowsyness = 0
 	M.stuttering = 0
 	M.confused = 0
+	/*if(holder.has_reagent_type(/datum/reagent/ethanol)) //ethylred turns pure ethanol into water, slowly removes other drinks.
+		holder.remove_all_type(/datum/reagent/ethanol, 2 * REM) //booze-b-gone 
+	*/
+	holder.convert_some_of_type(/datum/reagent/ethanol, /datum/reagent/water)
 
 //Otherwise known as a "Mickey Finn"
 /datum/reagent/chloralhydrate

--- a/code/modules/spells/targeted/watertowine.dm
+++ b/code/modules/spells/targeted/watertowine.dm
@@ -16,4 +16,4 @@
 /spell/targeted/watertowine/cast(var/list/targets, mob/user)
 	for(var/atom/A in targets)
 		var/datum/reagents/thereagents = A.reagents
-		thereagents.convert_some_of_type(convert_from_type,convert_to_type, TRUE)
+		thereagents.convert_some_of_type(convert_from_type,convert_to_type, 1000)

--- a/code/modules/spells/targeted/watertowine.dm
+++ b/code/modules/spells/targeted/watertowine.dm
@@ -1,0 +1,19 @@
+/spell/targeted/watertowine
+	name = "Water to Wine"
+	desc = "Turns all water in a container into wine."
+	abbreviation = "WtW"
+
+	school = "evocation"
+	invocation = "Th's'n"
+	invocation_type = SpI_WHISPER
+	range = 7
+	spell_flags = GHOSTCAST|STATALLOWED|WAIT_FOR_CLICK
+	level_max = list()
+	hud_state = "bucket"
+	var/convert_from_type = /datum/reagent/water
+	var/convert_to_type = /datum/reagent/ethanol/deadrum/wine
+
+/spell/targeted/watertowine/cast(var/list/targets, mob/user)
+	for(var/atom/A in targets)
+		var/datum/reagents/thereagents = A.reagents
+		thereagents.convert_some_of_type(convert_from_type,convert_to_type, TRUE)

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -2445,6 +2445,7 @@
 #include "code\modules\spells\targeted\retard.dm"
 #include "code\modules\spells\targeted\shoesnatch.dm"
 #include "code\modules\spells\targeted\targeted.dm"
+#include "code\modules\spells\targeted\watertowine.dm"
 #include "code\modules\spells\targeted\wrap.dm"
 #include "code\modules\spells\targeted\equip\cape.dm"
 #include "code\modules\spells\targeted\equip\clowncurse.dm"


### PR DESCRIPTION
ethylredoxrazine turns normal ethanol into water
but not any of its children
so now it does

big thanks to @DamianX for basically writing 90% of the code

Also adds a `watertowine` spell that turns water into wine. 
Admemes can varedit the spell to change which reagent gets turned into which.

- [x] [update wiki]

🆑 
 - rscadd: ethylredoxrazine now removes alcohol when metabolized
 - wip: added a new spell for admemes to mess with called watertowine - can be VV'd to turn other stuff into other stuff