### PR TITLE
Unhides swap hands

### DIFF
--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -123,7 +123,11 @@
 	usr.stop_pulling()
 
 /client/verb/swap_hand()
-	set hidden = 1
+
+	set name = "Swap-hands"
+	set category = "IC"
+	set desc = "Swap your current active hand."
+
 	if(istype(mob,/mob/living/silicon/robot/mommi))
 		return // MoMMIs only have one tool slot.
 	if(istype(mob,/mob/living/silicon/robot))//Oh nested logic loops, is there anything you can't do? -Sieve
@@ -415,7 +419,7 @@
 			step(src, pick(SOUTH, EAST))
 		if(SOUTHWEST)
 			step(src, pick(SOUTH, WEST))
-				
+
 	last_movement=world.time
 	if(dir != old_dir)
 		Facing()


### PR DESCRIPTION
The verb is here, it's called by a hotkey, but because it's hidden you can't change the hotkey or set a custom one.

I'm also not even sure if the hotkey *works* since swap-hands is hidden.

:cl:
- tweak: Swap-hands verb can now be typed and hotkeyed.