### PR TITLE
Fixes vox shoal prisonners not counting

### DIFF
--- a/code/datums/gamemode/factions/vox_shoal.dm
+++ b/code/datums/gamemode/factions/vox_shoal.dm
@@ -192,6 +192,14 @@ var/list/potential_bonus_items = list(
 
 
 /datum/faction/vox_shoal/proc/count_human_score(var/mob/living/carbon/human/H)
+	if (!H.mind)
+		if (H.old_assigned_role in command_positions)
+			total_points += 300
+		if (H.old_assigned_role in dept_objective)
+			total_points += 200
+			got_personnel++
+		return
+
 	if (H.mind.assigned_role in command_positions)
 		total_points += 300
 	if (H.mind.assigned_role in dept_objective)
@@ -208,7 +216,7 @@ var/list/potential_bonus_items = list(
 
 /mob/living/proc/send_back_to_main_station(var/complete_failure = FALSE)
 	if (complete_failure) // Non-vox somehow used the vox shuttle.
-		to_chat(src, "<span class='danger'>After hours of aimlessly wandering through space in hostile Vox territory, the shuttle quickly ran out of fuel. You and your companions decided to abandon the ship and throw escape shelters in the general direction of the station.</span>")	
+		to_chat(src, "<span class='danger'>After hours of aimlessly wandering through space in hostile Vox territory, the shuttle quickly ran out of fuel. You and your companions decided to abandon the ship and throw escape shelters in the general direction of the station.</span>")
 		var/obj/structure/inflatable/shelter/S = new(get_turf(src))
 		forceMove(S)
 		S.ThrowAtStation()

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -85,6 +85,7 @@
 		R.PreMindTransfer(current)
 
 	if(current)					//remove ourself from our old body's mind variable
+		current.old_assigned_role = assigned_role
 		current.mind = null
 	if(new_character.mind)		//remove any mind currently in our new body's mind variable
 		new_character.mind.current = null

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -293,6 +293,7 @@
 	var/mob/transmogged_to		//holds a reference to the mob which holds a reference to this mob in its transmogged_from var
 
 	var/forced_density = 0 // If the mob was made non-dense by an admin.
+	var/old_assigned_role // If they ghosted, what role did they have?
 
 /mob/resetVariables()
 	..("callOnFace", "pinned", "embedded", "abilities", "grabbed_by", "requests", "mapobjs", "mutations", "spell_list", "viruses", "resistances", "radar_blips", "active_genes", \


### PR DESCRIPTION
This was because they ghosted and got in a new body (Mice, etc...) setting their mind to `null`.

Closes #26468 