### PR TITLE
Fixing a runtime in the bloodstone Destroy proc

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
@@ -1423,7 +1423,7 @@ var/list/bloodstone_list = list()
 		if (cult)
 			cult.fail()
 		if(anchor)
-			global_anchor_bloodstone -= src
+			global_anchor_bloodstone = null
 	..()
 
 /obj/structure/cult/bloodstone/attack_construct(var/mob/user)


### PR DESCRIPTION
:cl:
* bugfix: Fixing a runtime that'd occur when attempting to destroy the anchor bloodstone