### PR TITLE
Removes session keys for admins.

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -40,8 +40,6 @@ var/global/floorIsLava = 0
 	if (!istype(src,/datum/admins))
 		to_chat(usr, "Error: you are not an admin!")
 		return
-
-	checkSessionKey()
 	var/body = {"<html><head><title>Options for [M.key]</title></head>
 <body>Options panel for <b>[M]</b>"}
 	var/species_description
@@ -272,11 +270,9 @@ var/global/floorIsLava = 0
 	if (!istype(src,/datum/admins))
 		to_chat(usr, "Error: you are not an admin!")
 		return
-	checkSessionKey()
 	var/cid = input("Type computer ID", "CID", 0) as num | null
 	if(cid)
 		usr << link(getVGPanel("rapsheet", admin = 1, query = list("cid" = cid)))
-//	to_chat(usr, link("[config.vgws_base_url]/index.php/rapsheet/?s=[sessKey]&cid=[cid]"))
 	return
 
 /datum/admins/proc/checkCKEY()
@@ -290,10 +286,8 @@ var/global/floorIsLava = 0
 	if (!istype(src,/datum/admins))
 		to_chat(usr, "Error: you are not an admin!")
 		return
-	checkSessionKey()
 	var/ckey = lowertext(input("Type player ckey", "ckey", null) as text | null)
 	usr << link(getVGPanel("rapsheet", admin = 1, query = list("ckey" = ckey)))
-//	usr << link("[config.vgws_base_url]/index.php/rapsheet/?s=[sessKey]&ckey=[ckey]")
 	return
 
 /datum/admins/proc/PlayerNotesPage(page)
@@ -1622,7 +1616,7 @@ proc/formatPlayerPanel(var/mob/U,var/text="PP")
 /datum/admins/proc/ViewAllRods()
 	if(!check_rights(0))
 		return
-	
+
 	var/dat = "<center><B>View all active rods</B></center><hr>"
 
 	for (var/obj/item/projectile/immovablerod/rod in all_rods)

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -13,7 +13,6 @@ var/list/admin_datums = list()
 	var/datum/feed_message/admincaster_feed_message = new /datum/feed_message   //These two will act as holders.
 	var/datum/feed_channel/admincaster_feed_channel = new /datum/feed_channel
 	var/admincaster_signature	//What you'll sign the newsfeeds as
-	var/sessKey		= 0
 
 /datum/admins/New(initial_rank = "Temporary Admin", initial_rights = 0, ckey)
 	if(!ckey)
@@ -24,6 +23,12 @@ var/list/admin_datums = list()
 	rank = initial_rank
 	rights = initial_rights
 	admin_datums[ckey] = src
+
+/datum/admins/Destroy()
+	marked_datum = null
+	marked_appearance = null
+	disassociate()
+	return ..()
 
 /datum/admins/proc/associate(client/C)
 	if(istype(C))
@@ -124,45 +129,5 @@ you will have to do something like if(client.rights & R_ADMIN) yourself.
 	admin_datums -= ckey
 	if(holder)
 		holder.disassociate()
-		del(holder)
+		qdel(holder)
 	return 1
-
-/datum/admins/proc/checkSessionKey(var/recurse=0)
-	if(recurse==5)
-		return "\[BROKEN\]";
-	recurse++
-	var/datum/DBQuery/query = SSdbcore.NewQuery("DELETE FROM admin_sessions WHERE expires < Now()")
-	if(!query.Execute())
-		message_admins("Error: [query.ErrorMsg()]")
-		log_sql("Error: [query.ErrorMsg()]")
-		qdel(query)
-		return
-	var/datum/DBQuery/sel_query = SSdbcore.NewQuery("SELECT sessID FROM admin_sessions WHERE ckey = '[owner.ckey]' AND expires > Now()")
-	if(!sel_query.Execute())
-		message_admins("Error: [sel_query.ErrorMsg()]")
-		log_sql("Error: [sel_query.ErrorMsg()]")
-		qdel(sel_query)
-		return
-	qdel(sel_query)
-
-	sessKey=0
-	while(query.NextRow())
-		sessKey = query.item[1]
-		var/datum/DBQuery/up_query=SSdbcore.NewQuery("UPDATE admin_sessions SET expires=DATE_ADD(NOW(), INTERVAL 24 HOUR), IP='[owner.address]' WHERE ckey = '[owner.ckey]")
-		if(!up_query.Execute())
-			message_admins("Error: [up_query.ErrorMsg()]")
-			log_sql("Error: [up_query.ErrorMsg()]")
-			qdel(up_query)
-			return
-		qdel(up_query)
-		return sessKey
-	qdel(query)
-
-	var/datum/DBQuery/insert_query=SSdbcore.NewQuery("INSERT INTO admin_sessions (sessID,ckey,expires, IP) VALUES (UUID(), '[owner.ckey]', DATE_ADD(NOW(), INTERVAL 24 HOUR), '[owner.address]')")
-	if(!insert_query.Execute())
-		message_admins("Error: [insert_query.ErrorMsg()]")
-		log_sql("Error: [insert_query.ErrorMsg()]")
-		qdel(insert_query)
-		return
-	qdel(insert_query)
-	return checkSessionKey(recurse)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2969,18 +2969,10 @@
 		usr.client.cmd_admin_subtle_message(M)
 
 	else if(href_list["rapsheet"])
-		checkSessionKey()
-		// build the link
-		//var/dat = "[config.vgws_base_url]/index.php/rapsheet/?s=[sessKey]"
-		//if(href_list["rsckey"])
-		//.	dat += "&ckey=[href_list["rsckey"]]"
-//		to_chat(usr, link(dat))
 		usr << link(getVGPanel("rapsheet", admin = 1, query = list("ckey" = href_list["rsckey"])))
 		return
 
 	else if(href_list["bansheet"])
-		//checkSessionKey()
-//		to_chat(usr, link("[config.vgws_base_url]/index.php/rapsheet/?s=[sessKey]"))
 		usr << link(getVGPanel("rapsheet", admin = 1))
 		return
 

--- a/code/modules/admin/vg-web.dm
+++ b/code/modules/admin/vg-web.dm
@@ -13,10 +13,7 @@
 // [config.vgws_base_url]/index.php/route?get_var=value
 // s is automatically added when admin=1.
 /datum/admins/proc/getVGPanel(var/route,var/list/query=list(),var/admin=0)
-	checkSessionKey()
 	var/url="[config.vgws_base_url]/index.php/[route]"
-	if(admin)
-		query["s"]=sessKey
 	url += buildurlquery(query)
 	return url
 


### PR DESCRIPTION
Unused feature (something else is used to see if admins recently connected to the live serb), the SQL doesn't work with the DB schema we have (it never did, old DBcode just failed silently). This table has been empty for years.

Burn it all down.
Also changes a `del` to a `qdel`. It literally doesn't matter since holder datums are destroyed maybe twice during the average round, but that's that.