### PR TITLE
fixes runtimes during map vault generation

### DIFF
--- a/code/modules/html_interface/map/station_map.dm
+++ b/code/modules/html_interface/map/station_map.dm
@@ -94,6 +94,8 @@
 	var/icon/canvas = icon('icons/480x480.dmi', "blank")
 
 	if(!map.disable_holominimap_generation)
+		if (zLevel > map.zDeepSpace)
+			return // No need to generate an holomap for something that didn't spawn.
 		if(zLevel != map.zCentcomm)
 			for(var/i = 1 to ((2 * world.view + 1)*WORLD_ICON_SIZE))
 				for(var/r = 1 to ((2 * world.view + 1)*WORLD_ICON_SIZE))

--- a/code/modules/randomMaps/vaults.dm
+++ b/code/modules/randomMaps/vaults.dm
@@ -101,7 +101,7 @@
 	return result
 
 /proc/stay_on_map(var/datum/map_element/E, var/turf/start_turf)
-	return start_turf && (start_turf.z < map.zDeepSpace)
+	return start_turf && (start_turf.z <= map.zDeepSpace)
 
 //Proc that populates a single area with many vaults, randomly
 //A is the area OR a list of turfs where the placement happens

--- a/code/modules/randomMaps/vaults.dm
+++ b/code/modules/randomMaps/vaults.dm
@@ -79,7 +79,7 @@
 	message_admins("<span class='info'>Spawning [vault_number] vaults in space!</span>")
 
 	var/area/A = locate(/area/random_vault)
-	var/result = populate_area_with_vaults(A, amount = vault_number, population_density = POPULATION_SCARCE)
+	var/result = populate_area_with_vaults(A, amount = vault_number, population_density = POPULATION_SCARCE, filter_function=/proc/stay_on_map)
 
 	for(var/turf/TURF in A) //Replace all of the temporary areas with space
 		TURF.set_area(space)
@@ -99,6 +99,10 @@
 	var/list/dimensions = E.get_dimensions()
 	var/result = check_complex_placement(start_turf,dimensions[1], dimensions[2])
 	return result
+
+/proc/stay_on_map(var/datum/map_element/E, var/turf/start_turf)
+	return start_turf && (start_turf.z < map.zDeepSpace)
+
 //Proc that populates a single area with many vaults, randomly
 //A is the area OR a list of turfs where the placement happens
 //map_element_objects is a list of vaults that have to be placed. Defaults to subtypes of /datum/map_element/vault (meaning all vaults are spawned)


### PR DESCRIPTION
If vaults are too thick, the latest to spawn will sometimes spawn on `z = 7`. Not only players can't access it, it has also no base turf, so it gives us this :

![image](https://user-images.githubusercontent.com/31417754/82437327-79a7ca00-9a97-11ea-802f-10bcd4c35488.png)

```
Runtime in _map.dm, line 274: list index out of bounds
proc name: get base turf (/proc/get_base_turf)
src: null
call stack:
get base turf(7)
generateHoloMinimap(7)
generateHoloMinimaps()
Uncategorized Init (/datum/subsystem/more_init): Initialize(301947)
Master (/datum/controller/master): Setup()
```