### PR TITLE
adds support for shroomboi traders

### DIFF
--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -46,7 +46,7 @@
 	var/pdatype=/obj/item/device/pda
 	var/pdaslot=slot_belt
 
-	var/list/species_blacklist = list() //Job not available to species in this list
+	var/list/species_blacklist = list("Mushroom") //Job not available to species in this list - shrooms can only be traders
 	var/list/species_whitelist = list() //If this list isn't empty, job is only available to species in this list
 
 	var/must_be_map_enabled = 0	//If 1, this job only appears on maps on which it's enabled (its type must be in the map's "enabled_jobs" list)

--- a/code/game/jobs/job/whitelisted.dm
+++ b/code/game/jobs/job/whitelisted.dm
@@ -11,7 +11,8 @@
 	minimal_access = list(access_trade)
 	alt_titles = list("Merchant","Salvage Broker")
 
-	species_whitelist = list("Vox")
+	species_whitelist = list("Vox", "Mushroom")
+	species_blacklist = list() //for shrooms
 	must_be_map_enabled = 1
 
 	no_random_roll = 1 //Don't become a vox trader randomly
@@ -33,8 +34,14 @@
 /datum/job/trader/equip(var/mob/living/carbon/human/H)
 	if(!H)
 		return 0
-	H.equip_or_collect(new /obj/item/clothing/under/vox/vox_robes(H), slot_w_uniform)
-	H.equip_or_collect(new /obj/item/clothing/shoes/magboots/vox(H), slot_shoes)
+	if(ismushroom(H))
+		H.equip_or_collect(new /obj/item/clothing/under/stilsuit(H), slot_w_uniform)
+		H.equip_or_collect(new /obj/item/clothing/suit/space/vox/civ/mushmen(H), slot_wear_suit)
+		H.equip_or_collect(new /obj/item/clothing/head/helmet/space/vox/civ/mushmen(H), slot_head)
+		H.equip_or_collect(new /obj/item/clothing/shoes/magboots(H), slot_shoes)
+	if(isvox(H))
+		H.equip_or_collect(new /obj/item/clothing/under/vox/vox_robes(H), slot_w_uniform)
+		H.equip_or_collect(new /obj/item/clothing/shoes/magboots/vox(H), slot_shoes)
 
 	switch(H.backbag) //BS12 EDIT
 		if(2)


### PR DESCRIPTION
This PR makes it so shroombois get equipped as traders properly.
It also blacklists shrooms from every job but trader.
**Shrooms will need to be whitelisted by the host to be playable.**

~~However a quick glance at `alienwhitelist.txt` in the configs shows that maybe the blacklist isn't necessary? Something about whitelisting species but only for certain jobs? 
Would like input from @d3athrow and/or the collaborators.~~ 
Has apparently never worked.

:cl:
 - tweak: Your beliefs have paid off. Mushmen traders now.