### PR TITLE
fixes some weird errors with BSQL roundstart

### DIFF
--- a/code/controllers/subsystem/dbcore.dm
+++ b/code/controllers/subsystem/dbcore.dm
@@ -110,6 +110,7 @@ var/datum/subsystem/dbcore/SSdbcore
 	else
 		SSdbcore.last_error = null
 		connectOperation = connection.BeginConnect(address, port, user, pass, db)
+		initialized = TRUE
 		if(SSdbcore.last_error)
 			CRASH(SSdbcore.last_error)
 		UNTIL(connectOperation.IsComplete())

--- a/code/controllers/subsystem/dbcore.dm
+++ b/code/controllers/subsystem/dbcore.dm
@@ -110,6 +110,9 @@ var/datum/subsystem/dbcore/SSdbcore
 	else
 		SSdbcore.last_error = null
 		connectOperation = connection.BeginConnect(address, port, user, pass, db)
+		// This is a bit of a hack. It sets initialized to be true BEFORE 'UNTIL', which sleeps. All the code done before is done synchronously.
+		// This ensures that the server establish a connection and a connection operation before any call to IsBanned(), for instance is made.
+		// Now IsBanned() calls will patiently wait on a DB connection to exist to be resolved, preventing queries to be queued up before an actual connection is made.
 		initialized = TRUE
 		if(SSdbcore.last_error)
 			CRASH(SSdbcore.last_error)

--- a/code/controllers/subsystem/dbcore.dm
+++ b/code/controllers/subsystem/dbcore.dm
@@ -81,7 +81,7 @@ var/datum/subsystem/dbcore/SSdbcore
 	world.BSQL_Shutdown()
 
 /datum/subsystem/dbcore/proc/Connect()
-	if(IsConnected())
+	if(initialized && IsConnected())
 		return TRUE
 
 	if(failed_connection_timeout <= world.time) //it's been more than 5 seconds since we failed to connect, reset the counter
@@ -202,8 +202,6 @@ var/datum/subsystem/dbcore/SSdbcore
 
 /datum/subsystem/dbcore/proc/IsConnected()
 	if(!config.sql_enabled)
-		return FALSE
-	if (!initialized)
 		return FALSE
 	//block until any connect operations finish
 	var/datum/BSQL_Connection/_connection = connection

--- a/code/modules/admin/IsBanned.dm
+++ b/code/modules/admin/IsBanned.dm
@@ -55,7 +55,7 @@
 			world.log << "Ban database connection failure. Key [ckeytext] not checked"
 			diary << "Ban database connection failure. Key [ckeytext] not checked"
 			return
-		world.log << "DB connect established....."
+
 		var/failedcid = 1
 		var/failedip = 1
 

--- a/code/modules/admin/IsBanned.dm
+++ b/code/modules/admin/IsBanned.dm
@@ -55,6 +55,7 @@
 			world.log << "Ban database connection failure. Key [ckeytext] not checked"
 			diary << "Ban database connection failure. Key [ckeytext] not checked"
 			return
+		world.log << "DB connect established....."
 		var/failedcid = 1
 		var/failedip = 1
 

--- a/code/world.dm
+++ b/code/world.dm
@@ -19,7 +19,6 @@ var/savefile/panicfile
 		// warn on missing library
 		// extools on linux does not exist and is not in the repository as of yet
 		warning("There is no extools library for this system included with this build. Performance may differ significantly than if it were present. This warning will not show if [extools_path] is added to the root of the game directory.")
-
 	// Honk honk, fuck you science
 	for(var/i=1, i<=map.zLevels.len, i++)
 		WORLD_X_OFFSET += rand(-50,50)
@@ -74,7 +73,6 @@ var/savefile/panicfile
 	make_datum_references_lists()	//initialises global lists for referencing frequently used datums (so that we only ever do it once)
 
 	load_configuration()
-
 	SSdbcore.Initialize() // Get a database running, first thing
 
 	load_mode()


### PR DESCRIPTION
This came from a misunderstanding of BSQL connection works.

You are supposed to call `Connect()` during world initialisation *without* lazily checking if it's connected or not. Then, **all** other calls must wait for `IsConnected()` to resolve before proceeding.

This makes sure that each and every call to the database is done with a working connection. Previously, some calls could be made while the DB was still waiting on a connection, which caused some errors as BSQL suddenly had to deal with multiple connection initialisations.