### PR TITLE
Fix a runtime preventing rev spawning via one-click antag

### DIFF
--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -96,7 +96,7 @@ client/proc/one_click_antag()
 				var/datum/role/RR = FF.get_member_by_mind(M)
 				RR.OnPostSetup()
 				RR.Greet(GREET_LATEJOIN)
-				message_admins("[key_name(H)] has been recruited as recruit of [F.name] via create antagonist verb.")
+				message_admins("[key_name(H)] has been recruited as recruit of [FF.name] via create antagonist verb.")
 				recruit_count++
 
 		FF.OnPostSetup()


### PR DESCRIPTION
Sample text, wrong var name
Closes #26154