### PR TITLE
Hopefully the last A* runtime PR

### DIFF
--- a/code/game/machinery/bots/bots.dm
+++ b/code/game/machinery/bots/bots.dm
@@ -70,6 +70,7 @@
 	var/list/patrol_path = list() //Our patroling path
 
 	var/current_pathing = 0
+	var/look_for_target = FALSE
 
 /obj/machinery/bot/New()
 	. = ..()

--- a/code/game/machinery/bots/bots.dm
+++ b/code/game/machinery/bots/bots.dm
@@ -38,7 +38,7 @@
 	var/brute_dam_coeff = 1.0
 	var/open = 0//Maint panel
 	var/locked = 1
-	var/bot_type
+	var/bot_type // For HuD users.
 	var/declare_message = "" //What the bot will display to the HUD user.
 	var/bot_flags
 
@@ -49,7 +49,7 @@
 	var/next_destination	// the next destination in the patrol route
 
 	var/steps_per = 1 //How many steps we take per process
-	var/initial_steps_per = 1
+	var/initial_steps_per = 1 // What should we go back to when we are done chasing a target ?
 
 	var/atom/target 				//The target of our path, could be a turf, could be a person, could be mess
 	var/list/old_targets = list()			//Our previous targets, so we don't get caught constantly going to the same spot. Order as pointer => int (Time to forget)
@@ -66,13 +66,14 @@
 	var/type_for_sig = "secbot"
 	var/turf/patrol_target	// this is turf to navigate to (location of beacon)
 	var/auto_patrol = 0		// set to make bot automatically patrol
-	var/waiting_for_patrol = FALSE
+	var/waiting_for_patrol = FALSE // Are we waiting for a beacon to give us a clear path? (in order to avoid calling for a path more than once)
 	var/list/patrol_path = list() //Our patroling path
 
-	var/current_pathing = 0
-	var/look_for_target = FALSE
-	var/target_chasing_distance = 7
+	var/current_pathing = 0 // Safety check for recursive movement
+	var/look_for_target = FALSE // Are we currently calculating a path to a target?
+	var/target_chasing_distance = 7 // Default view
 
+// Adding the bots to global lists; initialize if not.
 /obj/machinery/bot/New()
 	. = ..()
 	for(var/datum/event/ionstorm/I in events)
@@ -83,6 +84,7 @@
 	if (ticker && ticker.current_state == GAME_STATE_PLAYING)
 		initialize()
 
+// Associate the bot with a radio controller created in world/New().
 /obj/machinery/bot/initialize()
 	if(radio_controller)
 		if(bot_flags & BOT_CONTROL)
@@ -107,6 +109,7 @@
 	patrol_path.Cut()
 	path.Cut()
 
+// Reset the safety counter, look or move along a path, and then do bot things.
 /obj/machinery/bot/process()
 	current_pathing = 0
 	if(!src.on)
@@ -116,13 +119,16 @@
 	process_pathing()
 	process_bot()
 
+// Makes the bot busy while it looks for a target.
 /obj/machinery/bot/proc/find_target()
 	look_for_target = TRUE
 	target_selection()
 	look_for_target = FALSE
 
+// Concrete logic of selecting a target, depending on each bot.
 /obj/machinery/bot/proc/target_selection()
 
+// Will we continue chasing our target or not?
 /obj/machinery/bot/proc/can_abandon_target()
 	return (!target || target.gcDestroyed || get_dist(src, target) > target_chasing_distance) && !look_for_target
 
@@ -131,6 +137,7 @@
 	old_targets[old_target] = time_to_forget
 	log_astar_bot("[old_target] = [old_targets[old_target]]")
 
+// Remove an old target. Override for more complicated logic.
 /obj/machinery/bot/proc/remove_oldtarget(var/old_target)
 	old_targets.Remove(old_target)
 
@@ -157,6 +164,7 @@
 // If we have a path, we step.
 // Speed of the bot is controlled through steps_per.
 // return true to avoid calling process_patrol
+// Move "recursively" in order to respect the subsystem's waitfor = FALSE.
 /obj/machinery/bot/proc/process_path(var/remaining_steps = steps_per)
 	current_pathing++
 	if (current_pathing > MAX_PATHING_ATTEMPTS)

--- a/code/game/machinery/bots/bots.dm
+++ b/code/game/machinery/bots/bots.dm
@@ -71,6 +71,7 @@
 
 	var/current_pathing = 0
 	var/look_for_target = FALSE
+	var/target_chasing_distance = 7
 
 /obj/machinery/bot/New()
 	. = ..()
@@ -116,6 +117,14 @@
 	process_bot()
 
 /obj/machinery/bot/proc/find_target()
+	look_for_target = TRUE
+	target_selection()
+	look_for_target = FALSE
+
+/obj/machinery/bot/proc/target_selection()
+
+/obj/machinery/bot/proc/can_abandon_target()
+	return (!target || target.gcDestroyed || get_dist(src, target) > target_chasing_distance) && !look_for_target
 
 //Set time_to_forget to -1 to never forget it
 /obj/machinery/bot/proc/add_oldtarget(var/old_target, var/time_to_forget = BOT_OLDTARGET_FORGET_DEFAULT)

--- a/code/game/machinery/bots/draculabot.dm
+++ b/code/game/machinery/bots/draculabot.dm
@@ -195,16 +195,14 @@
 		set_glide_size(DELAY2GLIDESIZE(SS_WAIT_MACHINERY))
 		Move(get_step(src, pick(cardinal)))
 
-/obj/machinery/bot/bloodbot/find_target()
+/obj/machinery/bot/bloodbot/target_selection()
 	if (emagged)
 		var/list/possible_targets = list()
-		for(var/mob/living/carbon/human/H in view(7,src))
+		for(var/mob/living/carbon/human/H in view(target_chasing_distance,src))
 			if(H.vessel.has_reagent(BLOOD) && !(H.species.anatomy_flags & NO_BLOOD))
-				to_chat(world, "[H] is a possible target")
 				possible_targets += H
 		if (possible_targets.len)
 			target = pick(possible_targets)
-			to_chat(world, "final target is [target]")
 			process_path() // Let's waste no time
 
 /obj/machinery/bot/bloodbot/proc/drink(mob/living/carbon/human/H)

--- a/code/game/machinery/bots/ed209bot.dm
+++ b/code/game/machinery/bots/ed209bot.dm
@@ -45,6 +45,7 @@
 		/obj/item/weapon/melee/defibrillator
 		)
 
+	target_chasing_distance = 12
 
 /obj/item/weapon/ed209_assembly
 	name = "ED-209 assembly"
@@ -240,10 +241,10 @@ Auto Patrol: []"},
 		arrest_type = 1//Don't even try to cuff
 		declare_arrests = 0
 
-/obj/machinery/bot/ed209/find_target()
+/obj/machinery/bot/ed209/target_selection()
 	anchored = 0
 	threatlevel = 0
-	for (var/mob/living/carbon/C in view(12,src)) //Let's find us a criminal
+	for (var/mob/living/carbon/C in view(target_chasing_distance,src)) //Let's find us a criminal
 		if ((C.stat) || (C.handcuffed))
 			continue
 
@@ -343,7 +344,7 @@ Auto Patrol: []"},
 	return !cuffing
 
 /obj/machinery/bot/ed209/process_bot()
-	if (!target || target.gcDestroyed || get_dist(src, target) > 12)
+	if (can_abandon_target())
 		target = null
 		find_target()
 

--- a/code/game/machinery/bots/farmbot.dm
+++ b/code/game/machinery/bots/farmbot.dm
@@ -287,7 +287,7 @@
 
 
 
-/obj/machinery/bot/farmbot/find_target()
+/obj/machinery/bot/farmbot/target_selection()
 	if ( emagged ) //Find a human and help them!
 		for ( var/mob/living/carbon/human/human in view(7,src) )
 			if (human.isDead())

--- a/code/game/machinery/bots/floorbot.dm
+++ b/code/game/machinery/bots/floorbot.dm
@@ -238,7 +238,7 @@ var/global/list/floorbot_targets=list()
 /obj/machinery/bot/floorbot/proc/checkforwork()
 	if(have_target())
 		return 0
-	var/list/can_see = view(7, src)
+	var/list/can_see = view(target_chasing_distance, src)
 
 	if(amount < 50)
 		if(eattiles && hunt_for_tiles(can_see))

--- a/code/game/machinery/bots/medbot.dm
+++ b/code/game/machinery/bots/medbot.dm
@@ -285,7 +285,7 @@
 		stunned--
 		return
 
-	if ((!target || target.gcDestroyed) && !look_for_target)
+	if ((!target || target.gcDestroyed || get_dist(src, target) > 7) && !look_for_target)
 		target = null
 		currently_healing = 0
 		find_target()

--- a/code/game/machinery/bots/medbot.dm
+++ b/code/game/machinery/bots/medbot.dm
@@ -456,9 +456,9 @@
 	qdel(src)
 	return
 
-/obj/machinery/bot/medbot/find_target()
+/obj/machinery/bot/medbot/target_selection()
 	look_for_target = TRUE
-	for (var/mob/living/carbon/C in view(7,src)) //Time to find a patient!
+	for (var/mob/living/carbon/C in view(target_chasing_distance,src)) //Time to find a patient!
 		if ((C.isDead()) || !istype(C, /mob/living/carbon/human))
 			continue
 

--- a/code/game/machinery/bots/medbot.dm
+++ b/code/game/machinery/bots/medbot.dm
@@ -285,8 +285,9 @@
 		stunned--
 		return
 
-	if (!target || target.gcDestroyed)
+	if ((!target || target.gcDestroyed) && !look_for_target)
 		target = null
+		currently_healing = 0
 		find_target()
 
 	decay_oldtargets()
@@ -456,6 +457,7 @@
 	return
 
 /obj/machinery/bot/medbot/find_target()
+	look_for_target = TRUE
 	for (var/mob/living/carbon/C in view(7,src)) //Time to find a patient!
 		if ((C.isDead()) || !istype(C, /mob/living/carbon/human))
 			continue
@@ -474,7 +476,9 @@
 					broadcast_medical_hud_message("[name] is treating <b>[C]</b> in <b>[location]</b>", src)
 			visible_message("<b>[src]</b> points at [C.name]!")
 			process_path() // Let's waste no time
+			look_for_target = FALSE
 			break
+	look_for_target = FALSE
 
 /obj/machinery/bot/medbot/proc/assess_patient(mob/living/carbon/C)
 	//Time to see if they need medical help!

--- a/code/game/machinery/bots/secbot.dm
+++ b/code/game/machinery/bots/secbot.dm
@@ -231,6 +231,7 @@ Auto Patrol: []"},
 /obj/machinery/bot/secbot/find_target()
 	anchored = 0
 	threatlevel = 0
+	look_for_target = TRUE
 	for (var/mob/living/carbon/C in view(12,src)) //Let's find us a criminal
 		if ((C.stat) || (C.handcuffed))
 			continue
@@ -253,8 +254,10 @@ Auto Patrol: []"},
 			playsound(src, pick('sound/voice/bcriminal.ogg', 'sound/voice/bjustice.ogg', 'sound/voice/bfreeze.ogg'), 50, 0)
 			visible_message("<b>[src]</b> points at [C.name]!")
 
+	look_for_target = FALSE
+
 /obj/machinery/bot/secbot/process_bot()
-	if (!target || target.gcDestroyed || get_dist(src, target) > 7)
+	if ((!target || target.gcDestroyed || get_dist(src, target) > 7) && !look_for_target)
 		target = null
 		steps_per = initial_steps_per
 		find_target()

--- a/code/game/machinery/bots/secbot.dm
+++ b/code/game/machinery/bots/secbot.dm
@@ -228,11 +228,10 @@ Auto Patrol: []"},
 		src.on = 1
 		src.icon_state = "[src.icon_initial][src.on]"
 
-/obj/machinery/bot/secbot/find_target()
+/obj/machinery/bot/secbot/target_selection()
 	anchored = 0
 	threatlevel = 0
-	look_for_target = TRUE
-	for (var/mob/living/carbon/C in view(12,src)) //Let's find us a criminal
+	for (var/mob/living/carbon/C in view(target_chasing_distance,src)) //Let's find us a criminal
 		if ((C.stat) || (C.handcuffed))
 			continue
 
@@ -254,10 +253,8 @@ Auto Patrol: []"},
 			playsound(src, pick('sound/voice/bcriminal.ogg', 'sound/voice/bjustice.ogg', 'sound/voice/bfreeze.ogg'), 50, 0)
 			visible_message("<b>[src]</b> points at [C.name]!")
 
-	look_for_target = FALSE
-
 /obj/machinery/bot/secbot/process_bot()
-	if ((!target || target.gcDestroyed || get_dist(src, target) > 7) && !look_for_target)
+	if (can_abandon_target())
 		target = null
 		steps_per = initial_steps_per
 		find_target()


### PR DESCRIPTION
I finally reproduced the runtimes, it's when a single Beeper has more than one target.
Because of some weird things with sleepîng and spawning and subsystems and shit, it can suddenly decide to get a target while a path for the previous target is calculated. This causes the runtimes.

A fix (a bit of a hack, tbh) is to forbid Beepsky from calculating a quick path when it's already looking for a target.