### PR TITLE
updates preview generator to include hair accessories

### DIFF
--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -238,8 +238,11 @@
 	var/datum/sprite_accessory/hair_style = hair_styles_list[h_style]
 	if(hair_style)
 		var/icon/hair_s = new/icon("icon" = hair_style.icon, "icon_state" = "[hair_style.icon_state]_s")
-		hair_s.Blend(rgb(r_hair, g_hair, b_hair), ICON_ADD)
-		eyes_s.Blend(hair_s, ICON_OVERLAY)
+		if(hair_style.do_colouration)
+			hair_s.Blend(rgb(r_hair, g_hair, b_hair), ICON_ADD)
+		if(hair_style.additional_accessories)
+			hair_s.Blend(icon("icon" = hair_style.icon, "icon_state" = "[hair_style.icon_state]_acc"), ICON_OVERLAY)
+		eyes_s.Blend(hair_s, ICON_OVERLAY)		
 
 	var/datum/sprite_accessory/facial_hair_style = facial_hair_styles_list[f_style]
 	if(facial_hair_style)


### PR DESCRIPTION
not sure how to test properly but it works far as i can tell
![image](https://user-images.githubusercontent.com/8468269/82598277-b1ebfd00-9baa-11ea-8cfb-d32f1c847889.png)
![image](https://user-images.githubusercontent.com/8468269/82598319-c3350980-9baa-11ea-8889-bba457ed0fcb.png)
code in question is *very* outdated compared to currentcode

🆑 
 - tweak: Character previewer should now show certain hairstyles better.