### PR TITLE
mushroom darkvision eyes

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1628,8 +1628,8 @@ NOTE:  The change will take effect AFTER any current recruiting periods."}
 	character.backbag = backbag
 
 	//Debugging report to track down a bug, which randomly assigned the plural gender to people.
-	if(character.gender in list(PLURAL, NEUTER))
-		if(isliving(character)) //Ghosts get neuter by default
+	if(character.gender in list(PLURAL, NEUTER) && chosen_species != "Mushroom")
+		if(isliving(character)) //Ghosts & shrooms get neuter by default
 			message_admins("[character] ([character.ckey]) has spawned with their gender as plural or neuter. Please notify coders.")
 			character.setGender(MALE)
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1628,8 +1628,8 @@ NOTE:  The change will take effect AFTER any current recruiting periods."}
 	character.backbag = backbag
 
 	//Debugging report to track down a bug, which randomly assigned the plural gender to people.
-	if(character.gender in list(PLURAL, NEUTER) && chosen_species != "Mushroom")
-		if(isliving(character)) //Ghosts & shrooms get neuter by default
+	if(character.gender in list(PLURAL, NEUTER))
+		if(isliving(character)) //Ghosts get neuter by default
 			message_admins("[character] ([character.ckey]) has spawned with their gender as plural or neuter. Please notify coders.")
 			character.setGender(MALE)
 

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -1381,6 +1381,7 @@ var/list/has_died_as_golem = list()
 
 	has_organ = list(
 		"brain" =    /datum/organ/internal/brain/mushroom_brain,
+		"eyes" =     /datum/organ/internal/eyes/mushroom,
 		)
 
 	species_intro = "You are a Mushroom Person.<br>\

--- a/code/modules/organs/internal/eyes/eyes.dm
+++ b/code/modules/organs/internal/eyes/eyes.dm
@@ -56,6 +56,11 @@
 						 1, 1, 1)
 	removed_type = /obj/item/organ/internal/eyes/grue
 
+/datum/organ/internal/eyes/mushroom
+	name = "mushroom eyes"
+	see_in_dark = 8
+	removed_type = /obj/item/organ/internal/eyes/mushroom	
+
 ///////////////
 // BIONIC EYES
 ///////////////

--- a/code/modules/organs/organ_objects.dm
+++ b/code/modules/organs/organ_objects.dm
@@ -276,6 +276,12 @@
 //	icon_state = "eyes"
 	prosthetic_name = "grue visual prosthesis"
 	organ_type = /datum/organ/internal/eyes/grue
+	
+/obj/item/organ/internal/eyes/mushroom
+	name = "mushroom eyeballs"
+	icon_state = "eyes-tajaran"
+	prosthetic_name = "mushroom visual prosthesis"
+	organ_type = /datum/organ/internal/eyes/mushroom
 
 /obj/item/organ/internal/eyes/adv_1
 	name = "advanced prosthesis eyeballs"


### PR DESCRIPTION
adds darkvision to shroom eyes so they can actually see in the dark

i'm messing with matrices to see if i can figure out how to make inverted vision work without turning everything into pure white - once that's done or out the window this is ready to go

🆑 
 - tweak: Mushmen now have eyes with superior darkvision.