### PR TITLE
Fixes a weird but harmless runtime

### DIFF
--- a/code/modules/library/computers/base.dm
+++ b/code/modules/library/computers/base.dm
@@ -83,6 +83,7 @@
 	while(_query.NextRow())
 		. = text2num(_query.item[1])
 		qdel(_query)
+		return
 	qdel(_query)
 	return 0
 


### PR DESCRIPTION
The query is qdeleted twice, so it shows a weird error message.