### PR TITLE
AStar optimisations

### DIFF
--- a/code/controllers/subsystem/pathing.dm
+++ b/code/controllers/subsystem/pathing.dm
@@ -146,7 +146,6 @@ var/global/list/pathmakers = list()
 	for(var/turf/T in closed)
 		var/PathNode/PN = T.FindPathNode(PM_id)
 		T.PathNodes[PM_id] = null
-		T.PathNodes.Remove("[PM_id]")
 		qdel(PN)
 	owner = null
 	start = null

--- a/code/controllers/subsystem/pathing.dm
+++ b/code/controllers/subsystem/pathing.dm
@@ -146,6 +146,7 @@ var/global/list/pathmakers = list()
 	for(var/turf/T in closed)
 		var/PathNode/PN = T.FindPathNode(PM_id)
 		T.PathNodes[PM_id] = null
+		T.PathNodes.Remove("[PM_id]")
 		qdel(PN)
 	owner = null
 	start = null

--- a/code/defines/procs/AStar.dm
+++ b/code/defines/procs/AStar.dm
@@ -252,7 +252,6 @@ proc/quick_AStar(start,end,adjacent,dist,maxnodes,maxnodedepth = 30,mintargetdis
 				open.Enqueue(new /PathNode(T,cur,call(cur.source,dist)(T),newenddist,cur.nodecount+1,"unique_[reference]"))
 			else //is already in open list, check if it's a better way from the current turf
 				if(newenddist < PNode.distance_from_end)
-
 					PNode.prevNode = cur
 					PNode.distance_from_start = newenddist
 					PNode.calc_f()

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -23,7 +23,7 @@
 
 	var/blocks_air = 0
 
-	var/list/PathNodes = list()
+	var/list/PathNodes = null
 
 	// Bot shit
 	var/targetted_by=null
@@ -744,8 +744,10 @@
 //Pathnode stuff
 
 /turf/proc/FindPathNode(var/id)
-	return PathNodes["[id]"]
+	return PathNodes && PathNodes["[id]"]
 
 /turf/proc/AddPathNode(var/PathNode/PN, var/id)
-	ASSERT(!PathNodes["[id]"])
+	ASSERT(!PathNodes || !PathNodes["[id]"])
+	if (!PathNodes)
+		PathNodes = list()
 	PathNodes["[id]"] = PN

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -744,7 +744,7 @@
 //Pathnode stuff
 
 /turf/proc/FindPathNode(var/id)
-	return PathNodes && PathNodes["[id]"]
+	return PathNodes ? PathNodes["[id]"] : null
 
 /turf/proc/AddPathNode(var/PathNode/PN, var/id)
 	ASSERT(!PathNodes || !PathNodes["[id]"])


### PR DESCRIPTION
No need to have a `PathNodes` list by default when the bot is probably going to visit less than 15% of the Z-level.
Not sure if I should cycle the list when it's empty or not.
Suggested by @Exxion, tested.