### PR TITLE
Hotfixes

### DIFF
--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -175,7 +175,7 @@
 	name = "energy shotgun"
 	desc = "An experimental energy shotgun from Alcatraz IV. It has two modes that fire experimental stun electrodes codenamed HUNTER and SWEEPER."
 	icon_state = "eshotgun"
-	item_state = null
+	item_state = "shotgun"
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/guninhands_left.dmi', "right_hand" = 'icons/mob/in-hand/right/guninhands_right.dmi')
 	origin_tech = Tc_COMBAT + "=5;" + Tc_MATERIALS + "=2"
 	projectile_type = "/obj/item/projectile/energy/electrode/fast"

--- a/code/modules/research/mechanic/flatpack.dm
+++ b/code/modules/research/mechanic/flatpack.dm
@@ -19,6 +19,7 @@
 
 /obj/structure/closet/crate/flatpack/ancient
 	name = "ancient flatpack"
+	desc = "A ready-to-assemble machine flatpack produced in the space-Swedish style. These older ones come with an instruction manual for assembly."
 	assembling = UNASSEMBLED
 
 /obj/structure/closet/crate/flatpack/examine(mob/user)
@@ -65,7 +66,7 @@
 
 /obj/structure/closet/crate/flatpack/attackby(var/atom/A, mob/user)
 	if(assembling == ASSEMBLING)
-		if(unpacking.action(A, user))
+		if(unpacking.action(A, user) || iscrowbar(A))
 			return 1
 	if(iscrowbar(A))
 		if(stacked.len)
@@ -309,8 +310,10 @@
 
 /obj/structure/closet/crate/flatpack/ancient/condiment_dispenser/New()
 	..()
+	name = "ancient flatpack (condiment dispenser)"
 	machine = new /obj/machinery/chem_dispenser/condiment(src)
 
 /obj/structure/closet/crate/flatpack/ancient/chemmaster_electrolyzer/New()
 	..()
+	name = "ancient flatpack (electrolytic chemmaster)"
 	machine = new /obj/machinery/chem_master/electrolytic(src)


### PR DESCRIPTION
Not tested yet, I have to run to dinner

🆑 
* bugfix: You can't just skip the extra construction steps for ancient flatpacks
* tweak: Ancient flatpacks now indicate what is within with their name
* bugfix: Energy shotguns now have an inhand sprite (it just uses the combat shotgun sprite)