### PR TITLE
Fixes small delay on area change as a ghost

### DIFF
--- a/code/modules/media/mediamanager.dm
+++ b/code/modules/media/mediamanager.dm
@@ -96,7 +96,8 @@ function SetMusic(url, time, volume) {
 	//if(istype(M, /mob/living/carbon/human)||istype(M, /mob/dead/observer))
 	//	testing("Received OnMobAreaChange for [M.type] [M] (M.client=[M.client==null?"null":"/client"]).")
 	if(M.client && M.client.media && !M.client.media.forced)
-		M.update_music()
+		spawn()
+			M.update_music()
 
 
 /hook_handler/shuttlejukes/proc/OnEmergencyShuttleDeparture(var/list/args)


### PR DESCRIPTION
Closes #26595 
Closes #26585

I make the event sleep to make sure VLC is properly loaded, but it also locks movement, so let's have it spawned.
Could reproduce and isolate the bug, tested jukebox with the spawn, nothing changed.