### PR TITLE
Fixes the roundstart assistant-to-sec ratio.

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -42,6 +42,8 @@
 	var/role_alt_title
 
 	var/datum/job/assigned_job
+	var/job_priority // How much did we want the job we ended up having? Used for assistant rerolls.
+
 	var/datum/religion/faith
 
 	var/list/kills=list()

--- a/code/game/jobs/job/assistant.dm
+++ b/code/game/jobs/job/assistant.dm
@@ -14,6 +14,8 @@
 
 	no_random_roll = 1 //Don't become assistant randomly
 
+	var/static/list/assistant_second_chance = list()
+
 /datum/job/assistant/equip(var/mob/living/carbon/human/H)
 	if(!H)
 		return 0

--- a/code/game/jobs/job/assistant.dm
+++ b/code/game/jobs/job/assistant.dm
@@ -14,8 +14,6 @@
 
 	no_random_roll = 1 //Don't become assistant randomly
 
-	var/static/list/assistant_second_chance = list()
-
 /datum/job/assistant/equip(var/mob/living/carbon/human/H)
 	if(!H)
 		return 0

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -356,7 +356,7 @@ var/global/datum/controller/occupations/job_master
 	for(var/mob/new_player/player in unassigned)
 		if(player.client.prefs.alternate_option == BE_ASSISTANT)
 			if(config.assistantlimit)
-				if(master_assistant.current_positions+1 > (config.assistantratio * count))
+				if(master_assistant.current_positions-1 > (config.assistantratio * count))
 					if(count < 5) // if theres more than 5 security on the station just let assistants join regardless, they should be able to handle the tide
 						to_chat(player, "You have been returned to lobby because there's not enough security to make you an assistant.")
 						player.ready = 0
@@ -371,7 +371,7 @@ var/global/datum/controller/occupations/job_master
 		if (player.ckey in assistant_second_chance)
 			var/assistant_pref = assistant_second_chance[player.ckey]
 			Debug("AC3: [player] running the second chances for priority [assistant_pref]")
-			if(master_assistant.current_positions+1 > (config.assistantratio * count))
+			if(master_assistant.current_positions-1 > (config.assistantratio * count))
 				if(count < 5)
 					Debug("AC3: [player] failed the lottery.")
 			if (assistant_pref < player.mind.job_priority)

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -293,6 +293,10 @@ var/global/datum/controller/occupations/job_master
 
 	// Loop through all levels from high to low
 	var/list/shuffledoccupations = shuffle(occupations)
+	// Assistant is picked last.
+	var/datum/job/assistant/assist = locate() in shuffledoccupations
+	shuffledoccupations.Remove(assist)
+	shuffledoccupations[shuffledoccupations.len + 1] = assist
 	for(var/level = 1 to 3)
 		//Check the head jobs first each level
 		CheckHeadPositions(level)

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -12,7 +12,7 @@ var/global/datum/controller/occupations/job_master
 
 	var/priority_jobs_remaining = 3 //Limit on how many prioritized jobs can be had at once.
 	var/list/labor_consoles = list()
-
+	var/list/assistant_second_chance = list()
 
 /datum/controller/occupations/proc/SetupOccupations(var/faction = "Station")
 	occupations = list()
@@ -62,7 +62,7 @@ var/global/datum/controller/occupations/job_master
 /datum/controller/occupations/proc/GetPlayerAltTitle(mob/new_player/player, rank)
 	return player.client.prefs.GetPlayerAltTitle(GetJob(rank))
 
-/datum/controller/occupations/proc/AssignRole(var/mob/new_player/player, var/rank, var/latejoin = 0)
+/datum/controller/occupations/proc/AssignRole(var/mob/new_player/player, var/rank, var/latejoin = 0, var/pref_level = 5) // We assume we got the job we wanted (latejoin, etc).
 	Debug("Running AR, Player: [player], Rank: [rank], LJ: [latejoin]")
 	if(player && player.mind && rank)
 		var/datum/job/job = GetJob(rank)
@@ -78,6 +78,7 @@ var/global/datum/controller/occupations/job_master
 		if((job.current_positions < position_limit) || position_limit == -1)
 			Debug("Player: [player] is now Rank: [rank], JCP:[job.current_positions], JPL:[position_limit]")
 			player.mind.assigned_role = rank
+			player.mind.job_priority = pref_level
 			player.mind.role_alt_title = GetPlayerAltTitle(player, rank)
 
 			unassigned -= player
@@ -89,6 +90,15 @@ var/global/datum/controller/occupations/job_master
 			return 1
 	Debug("AR has failed, Player: [player], Rank: [rank]")
 	return 0
+
+/datum/controller/occupations/proc/UnassignRole(var/mob/new_player/player)
+	Debug("Unassigning role for [player]")
+	var/datum/job/job = GetJob(player.mind.assigned_role)
+	player.mind.assigned_role = ""
+	player.mind.role_alt_title = ""
+	job.current_positions--
+	for(var/obj/machinery/computer/labor/L in labor_consoles)
+		L.updateUsrDialog()
 
 /datum/controller/occupations/proc/FreeRole(var/rank, mob/user)	//making additional slot on the fly
 	var/datum/job/job = GetJob(rank)
@@ -293,10 +303,6 @@ var/global/datum/controller/occupations/job_master
 
 	// Loop through all levels from high to low
 	var/list/shuffledoccupations = shuffle(occupations)
-	// Assistant is picked last.
-	var/datum/job/assistant/assist = locate() in shuffledoccupations
-	shuffledoccupations.Remove(assist)
-	shuffledoccupations[shuffledoccupations.len + 1] = assist
 	for(var/level = 1 to 3)
 		//Check the head jobs first each level
 		CheckHeadPositions(level)
@@ -336,6 +342,7 @@ var/global/datum/controller/occupations/job_master
 
 	Debug("DO, Standard Check end")
 
+	// Rejoice, for you have been given a second chance to be a greytider.
 	Debug("DO, Running AC2")
 
 	var/count = 0
@@ -349,8 +356,7 @@ var/global/datum/controller/occupations/job_master
 	for(var/mob/new_player/player in unassigned)
 		if(player.client.prefs.alternate_option == BE_ASSISTANT)
 			if(config.assistantlimit)
-				count = (officer.current_positions + warden.current_positions + hos.current_positions)
-				if(master_assistant.current_positions > (config.assistantratio * count))
+				if(master_assistant.current_positions+1 > (config.assistantratio * count))
 					if(count < 5) // if theres more than 5 security on the station just let assistants join regardless, they should be able to handle the tide
 						to_chat(player, "You have been returned to lobby because there's not enough security to make you an assistant.")
 						player.ready = 0
@@ -359,6 +365,19 @@ var/global/datum/controller/occupations/job_master
 
 			Debug("AC2 Assistant located, Player: [player]")
 			AssignRole(player, "Assistant")
+
+	// Those that got assigned a role, but had assistant higher.
+	for (var/mob/new_player/player in shuffle(player_list))
+		if (player.ckey in assistant_second_chance)
+			var/assistant_pref = assistant_second_chance[player.ckey]
+			Debug("AC3: [player] running the second chances for priority [assistant_pref]")
+			if(master_assistant.current_positions+1 > (config.assistantratio * count))
+				if(count < 5)
+					Debug("AC3: [player] failed the lottery.")
+			if (assistant_pref < player.mind.job_priority)
+				Debug("AC3: got made an assistant as a second chance.")
+				UnassignRole(player)
+				AssignRole(player, "Assistant")
 
 	//For ones returning to lobby
 	for(var/mob/new_player/player in unassigned)
@@ -377,37 +396,38 @@ var/global/datum/controller/occupations/job_master
 	if(!job.player_old_enough(player.client))
 		Debug("DO player not old enough, Player: [player], Job:[job.title]")
 		return FALSE
-	if (job.title == "Assistant" && !CheckAssistantCount(player))
-		return FALSE
 	// If the player wants that job on this level, then try give it to him.
 	if(player.client.prefs.GetJobDepartment(job, level) & job.flag)
-
+		if (job.title == "Assistant" && !CheckAssistantCount(player, level))
+			return FALSE
 		// If the job isn't filled
 		if((job.current_positions < job.spawn_positions) || job.spawn_positions == -1)
 			Debug("DO pass, Player: [player], Level:[level], Job:[job.title]")
-			AssignRole(player, job.title)
+			AssignRole(player, job.title, pref_level = level)
 			return TRUE
 
 // -- Snowflaked proc which can be adjusted to more jobs than assistants if needed.
-/datum/controller/occupations/proc/CheckAssistantCount(var/mob/new_player/player)
+/datum/controller/occupations/proc/CheckAssistantCount(var/mob/new_player/player, var/level)
 	//People who wants to be assistants, sure, go on.
 	var/count = 0
 	var/datum/job/officer = job_master.GetJob("Security Officer")
 	var/datum/job/warden = job_master.GetJob("Warden")
 	var/datum/job/hos = job_master.GetJob("Head of Security")
 	count = (officer.current_positions + warden.current_positions + hos.current_positions)
-	Debug("DO, Running Assistant Check 1")
-	var/datum/job/assist = new /datum/job/assistant()
+	Debug("DO, Running Assistant Check 1 for [player]")
 	var/datum/job/master_assistant = GetJob("Assistant")
-	var/list/assistant_candidates = FindOccupationCandidates(assist, 3) + FindOccupationCandidates(assist, 2) + FindOccupationCandidates(assist, 1)
-	var/enough_sec = (master_assistant.current_positions) > (config.assistantratio * count)
+	var/enough_sec = (master_assistant.current_positions + 1) > (config.assistantratio * count)
 	if(enough_sec && (count < 5))
 		Debug("AC1 failed, not enough sec.")
-		to_chat(player, "You have been returned to lobby because there's not enough security to make you an assistant.")
-		player.ready = 0
-		unassigned -= player
+		// Does he want anything else...?
+		for (var/datum/job/J in occupations)
+			if (player.client.prefs.GetJobDepartment(J, level) & J.flag)
+				Debug("AC1 failed, but other job slots for [player]. Adding them to the list of backup assistant slots.")
+				assistant_second_chance[player.ckey] = level
+				return FALSE
+		// If this failed, then we don't want anything else, so we'll for the second assistant check.
 		return FALSE
-	assistant_candidates -= player
+
 	Debug("DO, AC1 end")
 	return TRUE
 


### PR DESCRIPTION
# About this PR

The bug was caused by #21320, unintentionally, as the assistant checks relied on them being picked **last** and always as a **LOW** priority option.
Unslowflaking it meant that the assistant role could be given as any normal role, before sec roles could be attributed, and as such before the check was done.

I personally don't think this is really needed, but there's been a demand for it, so here it is.

It is more or a less a "de facto feature", or a legacy bug, so I'll let other admins decide if it needs a poll, balance tag, etc. At any rate I don't believe this should be merged without some discussion.

# Technical notes

Tested the best I could. The first assistant is always allowed, so I simulated that one assistant was always present in the game.
Then, I readied up as a lone assistant (fail), and with two accounts, as an assistant and a sec off (success).

I'm not sure if the old logic of the check worked. It looked weird and buggy to me. (entire job controller is god dammit, rework when ?)

# Changelog

:cl:
- bugfix: The sec-to-assistant ratio of 1 for 2 is now enabled at roundstart.