### PR TITLE
revolvers being revolvers

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -1117,18 +1117,6 @@ var/default_colour_matrix = list(1,0,0,0,\
 
 #define MAX_N_OF_ITEMS 999 // Used for certain storage machinery, BYOND infinite loop detector doesn't look things over 1000.
 
-//gun shit - prepare to have various things added to this
-#define SILENCECOMP  1 		//Silencer-compatible
-#define AUTOMAGDROP  2		//Does the mag drop when it's empty?
-#define EMPTYCASINGS 4		//Does the gun eject empty casings?
-#define SCOPED		 8		//Attachable scope?
-
-//projectiles bouncing off and phasing through obstacles
-#define PROJREACT_WALLS		1//includes opaque doors
-#define PROJREACT_WINDOWS	2//includes transparent doors
-#define PROJREACT_OBJS		4//structures, machines and items
-#define PROJREACT_MOBS		8//all mobs
-#define PROJREACT_BLOB		16//blob
 
 ///////////////////////
 ///////RESEARCH////////

--- a/__DEFINES/weapons.dm
+++ b/__DEFINES/weapons.dm
@@ -26,3 +26,17 @@
 #define LAWGIVER_MODE_KIND_ENERGY "energy"
 #define LAWGIVER_MODE_KIND_BULLET "bullet"
 #define LAWGIVER_MAX_AMMO 5
+
+//gun shit - prepare to have various things added to this, also, moved here because it's more tidy
+#define SILENCECOMP  1 		//Silencer-compatible
+#define AUTOMAGDROP  2		//Does the mag drop when it's empty?
+#define EMPTYCASINGS 4		//Does the gun eject empty casings?
+#define SCOPED		 8		//Attachable scope?
+#define CHAMBER 	 16		//Revolvers usually don't release casing when shot, only when reloaded
+
+//projectiles bouncing off and phasing through obstacles
+#define PROJREACT_WALLS		1//includes opaque doors
+#define PROJREACT_WINDOWS	2//includes transparent doors
+#define PROJREACT_OBJS		4//structures, machines and items
+#define PROJREACT_MOBS		8//all mobs
+#define PROJREACT_BLOB		16//blob

--- a/__DEFINES/weapons.dm
+++ b/__DEFINES/weapons.dm
@@ -32,7 +32,7 @@
 #define AUTOMAGDROP  2		//Does the mag drop when it's empty?
 #define EMPTYCASINGS 4		//Does the gun eject empty casings?
 #define SCOPED		 8		//Attachable scope?
-#define CHAMBER 	 16		//Revolvers usually don't release casing when shot, only when reloaded
+#define CHAMBERSPENT 16		//Spent casings stay in the gun untill reloaded
 
 //projectiles bouncing off and phasing through obstacles
 #define PROJREACT_WALLS		1//includes opaque doors

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -223,7 +223,7 @@ var/list/uplink_items = list()
 /datum/uplink_item/dangerous/revolver
 	name = "Loaded .357 Revolver"
 	desc = "A traditional repeating handgun with seven chambers which fires .357 rounds. Can incapacitate most unarmored targets in two shots."
-	item = /obj/item/weapon/gun/projectile
+	item = /obj/item/weapon/gun/projectile/revolver
 	cost = 12
 
 /datum/uplink_item/dangerous/ammo

--- a/code/game/gamemodes/wizard/rightandwrong.dm
+++ b/code/game/gamemodes/wizard/rightandwrong.dm
@@ -73,7 +73,7 @@
 		if("plasmarifle")
 			new /obj/item/weapon/gun/energy/plasma/light(get_turf(src))
 		if("revolver")
-			new /obj/item/weapon/gun/projectile(get_turf(src))
+			new /obj/item/weapon/gun/projectile/revolver(get_turf(src))
 		if("detective")
 			new /obj/item/weapon/gun/projectile/detective(get_turf(src))
 		if("c20r")

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -30,7 +30,7 @@
 			new /obj/item/clothing/head/helmet/space/syndicate(src)
 
 		if("guns")//13+4+6+4=27
-			new /obj/item/weapon/gun/projectile(src)
+			new /obj/item/weapon/gun/projectile/revolver(src)
 			new /obj/item/ammo_storage/box/a357(src)
 			new /obj/item/weapon/card/emag(src)
 			new /obj/item/weapon/c4(src)

--- a/code/game/objects/loadouts.dm
+++ b/code/game/objects/loadouts.dm
@@ -132,7 +132,7 @@
 						/obj/item/clothing/glasses/thermal/monocle,
 						/obj/item/clothing/head/det_hat,
 						/obj/item/weapon/cloaking_device,
-						/obj/item/weapon/gun/projectile,
+						/obj/item/weapon/gun/projectile/revolver,
 						/obj/item/ammo_storage/box/a357)
 
 /obj/abstract/loadout/tournament_chef

--- a/code/modules/mob/living/simple_animal/hostile/human/civilian.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/civilian.dm
@@ -95,7 +95,7 @@
 	icon_state = "pilot"
 
 	corpse = /obj/effect/landmark/corpse/pilot
-	items_to_drop = list(/obj/item/weapon/gun/projectile)
+	items_to_drop = list(/obj/item/weapon/gun/projectile/revolver)
 
 	faction = "syndicate"
 

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -145,7 +145,7 @@
 	var/trying_to_load = 0
 	if(istype(target, /obj/item/weapon/gun/projectile))
 		var/obj/item/weapon/gun/projectile/PW = target
-		trying_to_load = min(PW.max_shells - PW.loaded.len, bullets_from.stored_ammo.len) //either we fill to max, or we fill as much as possible
+		trying_to_load = min(PW.max_shells - PW.loaded.len - PW.refuse.len, bullets_from.stored_ammo.len) //either we fill to max, or we fill as much as possible
 	else
 		var/obj/item/ammo_storage/AS = target
 		trying_to_load = min(AS.max_ammo - AS.stored_ammo.len, bullets_from.stored_ammo.len) //either we fill to max, or we fill as much as possible
@@ -194,7 +194,7 @@
 				return 0
 		var/obj/item/weapon/gun/projectile/PW = target
 		for(var/obj/item/ammo_casing/loading in bullets_from.stored_ammo)
-			if(PW.loaded.len >= PW.max_shells)
+			if(PW.loaded.len + PW.refuse.len >= PW.max_shells)
 				break
 			if(PW.caliber && PW.caliber[loading.caliber]) //hurrah for gun variables.
 				bullets_from.stored_ammo -= loading

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -300,9 +300,6 @@
 		for(var/obj/item/ammo_casing/AC in loaded)
 			if(istype(AC))
 				bullets += 1
-		/*for(var/obj/item/ammo_casing/AC in refuse)
-			if(istype(AC))
-				bullets += 1*/
 	return bullets
 
 /obj/item/weapon/gun/projectile/proc/getSpent()

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -78,7 +78,7 @@
 				for(var/i = 1; i<=min(to_drop, stored_magazine.stored_ammo.len); i++)
 					var/obj/item/ammo_casing/AC = stored_magazine.stored_ammo[1]
 					stored_magazine.stored_ammo -= AC
-					AC.forceMove(get_turf(user))
+					AC.forceMove(user.loc)
 					dropped_bullets++
 					stored_magazine.update_icon()
 				to_chat(usr, "<span class='notice'>You unjam the [name], and spill [dropped_bullets] bullet\s in the process.</span>")
@@ -86,7 +86,7 @@
 				update_icon()
 				return 0
 			return 0
-		stored_magazine.forceMove(get_turf(src.loc))
+		stored_magazine.forceMove(user.loc)
 		if(user)
 			user.put_in_hands(stored_magazine)
 			to_chat(usr, "<span class='notice'>You pull the magazine out of \the [src]!</span>")
@@ -130,7 +130,7 @@
 		AC = loaded[1] //load next casing.
 	return AC
 
-/obj/item/weapon/gun/projectile/process_chambered()
+/obj/item/weapon/gun/projectile/process_chambered(mob/user as mob)
 	var/obj/item/ammo_casing/AC = getAC()
 	if(in_chamber)
 		return 1 //{R}
@@ -145,7 +145,7 @@
 		if(gun_flags &CHAMBER)
 			refuse += AC
 		else
-			AC.forceMove(get_turf(src)) //Eject casing onto ground.
+			AC.forceMove(user.loc) //Eject casing onto ground or closet you're inside.
 			playsound(AC, casingsound, 25, 1)
 	if(AC.BB)
 		in_chamber = AC.BB //Load projectile into chamber.
@@ -234,17 +234,17 @@
 			if(!gun_flags &CHAMBER)
 				var/obj/item/ammo_casing/AC = loaded[1]
 				loaded -= AC
-				AC.forceMove(get_turf(src)) //Eject casing onto ground.
+				AC.forceMove(user.loc)
 				to_chat(user, "<span class='notice'>You unload \the [AC] from \the [src]!</span>")
 				update_icon()
 			else
 				for(var/obj/item/ammo_casing/AC in loaded)
 					loaded -= AC
-					AC.forceMove(get_turf(src))
+					AC.forceMove(user.loc)
 					playsound(AC, casingsound, 25, 1)
 				for(var/obj/item/ammo_casing/AC in refuse)
 					refuse -= AC
-					AC.forceMove(get_turf(src))
+					AC.forceMove(user.loc)
 					playsound(AC, casingsound, 25, 1)
 				to_chat(user, "<span class='notice'>You empty \the [src]!</span>")
 			return
@@ -253,7 +253,7 @@
 	else if(loc == user)
 		if(chambered) // So it processing unloading of a bullet first
 			var/obj/item/ammo_casing/AC = chambered
-			AC.forceMove(get_turf(src)) //Eject casing onto ground.
+			AC.forceMove(user.loc)
 			chambered = null
 			to_chat(user, "<span class='notice'>You unload \the [AC] from \the [src]!</span>")
 			update_icon()

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -86,10 +86,14 @@
 				update_icon()
 				return 0
 			return 0
-		stored_magazine.forceMove(user.loc)
+		stored_magazine.forceMove(get_turf(src.loc)) //this first drops the magazine onto the turf, it's here in case there is no applicable user
 		if(user)
-			user.put_in_hands(stored_magazine)
-			to_chat(usr, "<span class='notice'>You pull the magazine out of \the [src]!</span>")
+			if(user.put_in_any_hand_if_possible(stored_magazine)) //if you have empty hands, you'll get the mag
+				user.put_in_hands(stored_magazine)
+				to_chat(usr, "<span class='notice'>You pull the magazine out of \the [src]!</span>")
+			else
+				stored_magazine.forceMove(user.loc) //otherwise, it drops to the place you are existing
+				to_chat(usr, "<span class='notice'>You drop the magazine out of \the [src]!</span>")
 		stored_magazine.update_icon()
 		stored_magazine = null
 		update_icon()

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -134,7 +134,7 @@
 		AC = loaded[1] //load next casing.
 	return AC
 
-/obj/item/weapon/gun/projectile/process_chambered(mob/user as mob)
+/obj/item/weapon/gun/projectile/process_chambered(mob/user)
 	var/obj/item/ammo_casing/AC = getAC()
 	if(in_chamber)
 		return 1 //{R}
@@ -146,7 +146,7 @@
 	else
 		loaded -= AC //Remove casing from loaded list.
 	if(gun_flags &EMPTYCASINGS)
-		if(gun_flags &CHAMBER)
+		if(gun_flags &CHAMBERSPENT)
 			refuse += AC
 		else
 			AC.forceMove(user.loc) //Eject casing onto ground or closet you're inside.
@@ -235,7 +235,7 @@
 		return ..()
 	if (loaded.len || stored_magazine || refuse.len)
 		if (load_method == SPEEDLOADER)
-			if(!gun_flags &CHAMBER)
+			if(!gun_flags &CHAMBERSPENT)
 				var/obj/item/ammo_casing/AC = loaded[1]
 				loaded -= AC
 				AC.forceMove(user.loc)

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -146,7 +146,7 @@
 			refuse += AC
 		else
 			AC.forceMove(get_turf(src)) //Eject casing onto ground.
-			playsound(AC, casingsound, 25, 0.2, 1)
+			playsound(AC, casingsound, 25, 1)
 	if(AC.BB)
 		in_chamber = AC.BB //Load projectile into chamber.
 		AC.BB.forceMove(src) //Set projectile loc to gun.
@@ -241,12 +241,12 @@
 				for(var/obj/item/ammo_casing/AC in loaded)
 					loaded -= AC
 					AC.forceMove(get_turf(src))
-					playsound(AC, casingsound, 25, 0.2, 1) //muh, sounds of casing falling, such finery
+					playsound(AC, casingsound, 25, 1)
 				for(var/obj/item/ammo_casing/AC in refuse)
 					refuse -= AC
 					AC.forceMove(get_turf(src))
-					playsound(AC, casingsound, 25, 0.2, 1)
-				to_chat(user, "<span class='notice'>You empty the [src]!</span>")
+					playsound(AC, casingsound, 25, 1)
+				to_chat(user, "<span class='notice'>You empty \the [src]!</span>")
 			return
 		if (load_method == MAGAZINE && stored_magazine)
 			RemoveMag(user)
@@ -305,8 +305,7 @@
 /obj/item/weapon/gun/projectile/proc/getSpent()
 	var/spent = 0
 	for(var/obj/item/ammo_casing/AC in refuse)
-		if(istype(AC))
-			spent += 1
+		spent += 1
 	return spent
 
 /obj/item/weapon/gun/projectile/failure_check(var/mob/living/carbon/human/M)

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -266,6 +266,7 @@
 	var/cocked = FALSE
 	var/last_spin = 0
 	var/spin_delay = 1 SECONDS	//let's not get crazy
+	gun_flags = EMPTYCASINGS | CHAMBER //just alt-click to unload it, thanks to someone with foresight
 
 /obj/item/weapon/gun/projectile/colt/update_icon()
 	if(cocked)

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -105,7 +105,7 @@
 	gun_flags = SILENCECOMP
 	fire_sound = 'sound/weapons/nagant.ogg'
 	recoil = 3
-	gun_flags = EMPTYCASINGS | CHAMBER
+	gun_flags = EMPTYCASINGS | CHAMBER | SILENCECOMP
 
 /obj/item/weapon/gun/projectile/nagant/update_icon()
 	..()

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -8,7 +8,7 @@
 	ammo_type = "/obj/item/ammo_casing/c38"
 	recoil = 3
 	var/perfect = 0
-	gun_flags = EMPTYCASINGS | CHAMBER
+	gun_flags = EMPTYCASINGS | CHAMBERSPENT
 
 	special_check(var/mob/living/carbon/human/M) //to see if the gun fires 357 rounds safely. A non-modified revolver randomly blows up
 		if(getAmmo()) //this is a good check, I like this check
@@ -92,7 +92,7 @@
 	icon_state = "mateba"
 	origin_tech = Tc_COMBAT + "=2;" + Tc_MATERIALS + "=2"
 	recoil = 3
-	gun_flags = EMPTYCASINGS | CHAMBER
+	gun_flags = EMPTYCASINGS | CHAMBERSPENT
 
 /obj/item/weapon/gun/projectile/nagant //revolver that simple mob russians use
 	name = "nagant revolver"
@@ -105,7 +105,7 @@
 	gun_flags = SILENCECOMP
 	fire_sound = 'sound/weapons/nagant.ogg'
 	recoil = 3
-	gun_flags = EMPTYCASINGS | CHAMBER | SILENCECOMP
+	gun_flags = EMPTYCASINGS | CHAMBERSPENT | SILENCECOMP
 
 /obj/item/weapon/gun/projectile/nagant/update_icon()
 	..()
@@ -266,7 +266,7 @@
 	var/cocked = FALSE
 	var/last_spin = 0
 	var/spin_delay = 1 SECONDS	//let's not get crazy
-	gun_flags = EMPTYCASINGS | CHAMBER //just alt-click to unload it, thanks to someone with foresight
+	gun_flags = EMPTYCASINGS | CHAMBERSPENT //just alt-click to unload it, thanks to someone with foresight
 
 /obj/item/weapon/gun/projectile/colt/update_icon()
 	if(cocked)
@@ -331,4 +331,4 @@
 		user.visible_message("<span class='danger'>\The [src] explodes as \the [user] bites into it!</span>","<span class='danger'>\The [src] explodes as you bite into it!</span>")
 
 /obj/item/weapon/gun/projectile/revolver	//a copy of parent to define traitor revolver as separate, because fuck you for making a class prototype not just that
-	gun_flags = EMPTYCASINGS | CHAMBER
+	gun_flags = EMPTYCASINGS | CHAMBERSPENT

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -8,6 +8,7 @@
 	ammo_type = "/obj/item/ammo_casing/c38"
 	recoil = 3
 	var/perfect = 0
+	gun_flags = EMPTYCASINGS | CHAMBER
 
 	special_check(var/mob/living/carbon/human/M) //to see if the gun fires 357 rounds safely. A non-modified revolver randomly blows up
 		if(getAmmo()) //this is a good check, I like this check
@@ -91,7 +92,7 @@
 	icon_state = "mateba"
 	origin_tech = Tc_COMBAT + "=2;" + Tc_MATERIALS + "=2"
 	recoil = 3
-
+	gun_flags = EMPTYCASINGS | CHAMBER
 
 /obj/item/weapon/gun/projectile/nagant //revolver that simple mob russians use
 	name = "nagant revolver"
@@ -104,6 +105,7 @@
 	gun_flags = SILENCECOMP
 	fire_sound = 'sound/weapons/nagant.ogg'
 	recoil = 3
+	gun_flags = EMPTYCASINGS | CHAMBER
 
 /obj/item/weapon/gun/projectile/nagant/update_icon()
 	..()
@@ -326,3 +328,6 @@
 		in_chamber = null
 		make_peel(user)
 		user.visible_message("<span class='danger'>\The [src] explodes as \the [user] bites into it!</span>","<span class='danger'>\The [src] explodes as you bite into it!</span>")
+
+/obj/item/weapon/gun/projectile/revolver	//a copy of parent to define traitor revolver as separate, because fuck you for making a class prototype not just that
+	gun_flags = EMPTYCASINGS | CHAMBER


### PR DESCRIPTION
revolvers now don't spew empty casings when shooting, instead you'll have to empty them by hand which now empties all of the bullets, useful because you leave evidence where you want not where you shoot
this works with traitor, detective, mateba, nagant and colt revolvers

tidying up the code: this also add a new child of traitor revolver and replaces instances where parent is used, because why prototype would be actually used at this point, guncreep is too big (the child is almost same as parent with exception of this new feature I'm adding)
oh and I placed gun defines in  __DEFINES/weapons.dm (it's their rightful place)
edit: unloading guns now drops casings inside the structures you're inside, like closets or inflatable shelters

closes #14204

:cl:
 * tweak: Revolvers now don't spew spent casings, you need to break them open to reload.
 * bugfix: Guns you unload should no longer drop casings or magazines straight on the ground if you're in a closet.