### PR TITLE
Removes Glass From NanoTrasen Rocketlauncher Build Cost

### DIFF
--- a/code/modules/projectiles/guns/projectile/rocketlauncher.dm
+++ b/code/modules/projectiles/guns/projectile/rocketlauncher.dm
@@ -62,7 +62,7 @@
 	item_state = "rpg_nt"
 	max_shells = 1
 	w_class = W_CLASS_LARGE
-	starting_materials = list(MAT_IRON = 50000, MAT_GLASS = 50000, MAT_GOLD = 6000)
+	starting_materials = list(MAT_IRON = 50000, MAT_PLASTIC = 25000, MAT_GOLD = 6000)
 	w_type = RECYK_METAL
 	force = 10
 	recoil = 1

--- a/code/modules/research/designs/weapons.dm
+++ b/code/modules/research/designs/weapons.dm
@@ -270,7 +270,7 @@
 	desc = "Watch the backblast, you idiot."
 	id = "RPG"
 	build_type = AMMOLATHE
-	materials = list(MAT_IRON = 50000, MAT_GLASS = 15000, MAT_PLASTIC = 25000, MAT_GOLD = 6000)
+	materials = list(MAT_IRON = 50000, MAT_PLASTIC = 25000, MAT_GOLD = 6000)
 	build_path = /obj/item/weapon/gun/projectile/rocketlauncher/nanotrasen/lockbox
 	locked = TRUE
 	req_lock_access = list(access_armory, access_weapons)


### PR DESCRIPTION
This PR removes the glass requirement for the build cost for rocket launchers in the ammolathe. When plastic was added to the recipe, it made the material list so long that it no longer fit on the UI of the ammolathe meaning that the user had no way of knowing gold was required to make them without code diving. This is a bit of a dirty fix but I don't feel like the glass requirement was what is holding the rocket launcher mass production back. I have also made the rocket launcher starting materials the same as the building materials. The only place that is used is maybe recycling so please let me know if I have made some sort of error with it.
Compiled and lightly tested.
closes #25169

:cl:
 * rscdel: Removed glass from the Nanotrasen rocket launcher build cost so the entire recipe fits on the UI