### PR TITLE
Makes Ammolathe Buttons Wider

### DIFF
--- a/nano/templates/ammolathe.tmpl
+++ b/nano/templates/ammolathe.tmpl
@@ -6,7 +6,7 @@ Used In File(s): \code\game\machinery\ammolathe.dm
 <style type='text/css'>
 	#costsmall
 	{
-		width:250px;
+		width:450px;
 		float:left;
 	}
 	#misc


### PR DESCRIPTION
[bugfix] [tweak]
Gaze upon my changelog and witness the incredibly daring coding change within.
This PR makes the buttons for the recipes in the ammolathe nanoUI 200 pixels(?) wider.

fixes #25169
fixes #26499

compiled and tested locally
Didn't test every nanoUI window but I did test the autolathe and it was the same as well as the ammolathe which was fixed.

:cl:
 * bugfix: The rocket launcher recipe is now correctly displayed.