### PR TITLE
job blacklist now works for latejoins

### DIFF
--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -363,6 +363,11 @@ var/global/datum/controller/occupations/job_master
 						unassigned -= player
 						continue
 
+			if(master_assistant.species_blacklist.len && master_assistant.species_blacklist.Find(player.client.prefs.species))
+				to_chat(player, "You have been returned to lobby because your species is blacklisted from assistant.")
+				player.ready = 0
+				unassigned -= player
+				continue //no, you can't evade the blacklist just by not being picked for your available jobs
 			Debug("AC2 Assistant located, Player: [player]")
 			AssignRole(player, "Assistant")
 

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -341,6 +341,10 @@
 		if(!job.species_whitelist.Find(client.prefs.species))
 			to_chat(src, alert("[rank] is not available for [client.prefs.species]."))
 			return 0
+	if(job.species_blacklist.len)
+		if(job.species_blacklist.Find(client.prefs.species))
+			to_chat(src, alert("[rank] is not available for [client.prefs.species]."))
+			return 0
 
 	job_master.AssignRole(src, rank, 1)
 
@@ -481,6 +485,10 @@ Round Duration: [round(hours)]h [round(mins)]m<br>"}
 				active++
 			if(job.species_whitelist.len)
 				if(!job.species_whitelist.Find(client.prefs.species))
+					dat += "<s>[job.title] ([job.current_positions]) (Active: [active])</s><br>"
+					continue
+			if(job.species_blacklist.len)
+				if(job.species_blacklist.Find(client.prefs.species))
 					dat += "<s>[job.title] ([job.current_positions]) (Active: [active])</s><br>"
 					continue
 


### PR DESCRIPTION
![2020-05-27_10-39-39](https://user-images.githubusercontent.com/8468269/82997698-022de980-a007-11ea-8d17-f552d76691c0.png)

closes #26570 

🆑 
 - bugfix: Job blacklists now apply to latejoining as well