### PR TITLE
adds some melee damage logging

### DIFF
--- a/code/modules/mob/living/carbon/combat.dm
+++ b/code/modules/mob/living/carbon/combat.dm
@@ -38,9 +38,11 @@
 		target_zone = user.zone_sel.selecting
 	if(!target_zone && !src.stat)
 		visible_message("<span class='borange'>[user] misses [src] with \the [I]!</span>")
+		add_logs(user, src, "missed", admin=0, object=I, addition="intended damage: [I.force]")
 		return FALSE
 
 	if((user != src) && check_shields(I.force, I))
+		add_logs(user, src, "shieldbounced", admin=0, object=I, addition="intended damage: [I.force]")
 		return FALSE
 
 	user.do_attack_animation(src, I)
@@ -51,15 +53,17 @@
 		var/hit_area = affecting.display_name
 		armor = run_armor_check(affecting, "melee", "Your armor protects your [hit_area].", "Your armor softens the hit to your [hit_area].", armor_penetration = I.armor_penetration)
 		if(armor >= 100)
+			add_logs(user, src, "armor bounced", admin=0, object=I, addition="weapon force vs armor: [I.force] - [armor]")
 			return TRUE //We still connected
 		if(!I.force)
+			add_logs(user, src, "ineffectively attacked", admin=0, object=I, addition="weapon force: [I.force]")
 			return TRUE
 	var/damage = run_armor_absorb(target_zone, I.damtype, I.force)
-	if(damage)
-		if(originator)
-			add_logs(originator, src, "damaged", admin=1, object=I, addition="DMG: [damage]")
-		else
-			add_logs(user, src, "damaged", admin=1, object=I, addition="DMG: [damage]")
+	if(originator)
+		add_logs(originator, src, "damaged", admin=0, object=I, addition="DMG: [max(damage - armor, 0)]")
+	else
+		add_logs(user, src, "damaged", admin=0, object=I, addition="DMG: [max(damage - armor, 0)]")
+		
 	apply_damage(damage, I.damtype, affecting, armor , I.is_sharp(), used_weapon = I)
 	INVOKE_EVENT(on_touched, list("user" = src, "attacked by" = I))
 	return TRUE

--- a/code/modules/mob/living/carbon/combat.dm
+++ b/code/modules/mob/living/carbon/combat.dm
@@ -55,6 +55,11 @@
 		if(!I.force)
 			return TRUE
 	var/damage = run_armor_absorb(target_zone, I.damtype, I.force)
+	if(damage)
+		if(originator)
+			add_logs(originator, src, "damaged", admin=1, object=I, addition="DMG: [damage]")
+		else
+			add_logs(user, src, "damaged", admin=1, object=I, addition="DMG: [damage]")
 	apply_damage(damage, I.damtype, affecting, armor , I.is_sharp(), used_weapon = I)
 	INVOKE_EVENT(on_touched, list("user" = src, "attacked by" = I))
 	return TRUE

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -184,13 +184,13 @@
 	if(!damage)
 		playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
 		visible_message("<span class='borange'>\The [M] has attempted to bite \the [src]!</span>")
+		add_logs(M, src, "miss-bit", admin=0, object=null, addition="DMG: [damage]")
 		return 0
 
 	playsound(loc, 'sound/weapons/bite.ogg', 50, 1, -1)
 	src.visible_message("<span class='danger'>\The [M] has bitten \the [src]!</span>", "<span class='userdanger'>You were bitten by \the [M]!</span>")
 
-	if(damage)
-		add_logs(M, src, "bit", admin=0, object=null, addition="DMG: [damage]")
+	add_logs(M, src, "bit", admin=0, object=null, addition="DMG: [damage]")
 	adjustBruteLoss(damage)
 	return
 
@@ -226,6 +226,7 @@
 	if(!damage)
 		playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
 		visible_message("<span class='borange'>\The [M] attempts to kick \the [src]!</span>")
+		add_logs(M, src, "miss-kicked", admin=0, object=null, addition="DMG: [damage]")
 		return 0
 
 	//Handle shoes
@@ -243,8 +244,7 @@
 	if(M.size != size) //The bigger the kicker, the more damage
 		damage = max(damage + (rand(1,5) * (1 + M.size - size)), 0)
 
-	if(damage)
-		add_logs(M, src, "kicked", admin=0, object=null, addition="DMG: [damage]")
+	add_logs(M, src, "kicked", admin=0, object=null, addition="DMG: [damage]")
 	adjustBruteLoss(damage)
 
 /mob/living/proc/near_wall(var/direction,var/distance=1)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -184,7 +184,7 @@
 	if(!damage)
 		playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
 		visible_message("<span class='borange'>\The [M] has attempted to bite \the [src]!</span>")
-		add_logs(M, src, "miss-bit", admin=0, object=null, addition="DMG: [damage]")
+		add_logs(M, src, "miss-bit", admin=0, object=null, addition=null)
 		return 0
 
 	playsound(loc, 'sound/weapons/bite.ogg', 50, 1, -1)
@@ -226,7 +226,7 @@
 	if(!damage)
 		playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
 		visible_message("<span class='borange'>\The [M] attempts to kick \the [src]!</span>")
-		add_logs(M, src, "miss-kicked", admin=0, object=null, addition="DMG: [damage]")
+		add_logs(M, src, "miss-kicked", admin=0, object=null, addition=null)
 		return 0
 
 	//Handle shoes

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -189,6 +189,8 @@
 	playsound(loc, 'sound/weapons/bite.ogg', 50, 1, -1)
 	src.visible_message("<span class='danger'>\The [M] has bitten \the [src]!</span>", "<span class='userdanger'>You were bitten by \the [M]!</span>")
 
+	if(damage)
+		add_logs(M, src, "bit", admin=0, object=null, addition="DMG: [damage]")
 	adjustBruteLoss(damage)
 	return
 
@@ -241,6 +243,8 @@
 	if(M.size != size) //The bigger the kicker, the more damage
 		damage = max(damage + (rand(1,5) * (1 + M.size - size)), 0)
 
+	if(damage)
+		add_logs(M, src, "kicked", admin=0, object=null, addition="DMG: [damage]")
 	adjustBruteLoss(damage)
 
 /mob/living/proc/near_wall(var/direction,var/distance=1)


### PR DESCRIPTION
This adds some damage logging for melee attacks. They go in the attack logs.
I can't promise it'll work for everything, but it works for punches, kicks, bites and weapon attacks
and by weapon attacks I mean I tested it with toolboxes, rusty energy axes, holo eswords, batons and rubber ducks - those all worked.
The total damage accounts for armor, so it (supposedly) only logs the actual damage done.

![damage_logs](https://user-images.githubusercontent.com/8468269/83154584-929c2500-a100-11ea-8a1f-14d15711d23c.png)


Some things to consider:
 - This is just melee logging... what about ranged attacks?
 - Hits from thrown weapons?
 - Edge cases?
 - Log all mobs or just target / assailant mobs with minds?
 - add coordinates?
 - remove "old" hit message and only use the new one?