### PR TITLE
Most complete fix to jukebox music playing too long

### DIFF
--- a/code/modules/media/mediamanager.dm
+++ b/code/modules/media/mediamanager.dm
@@ -261,13 +261,14 @@ function SetMusic(url, time, volume) {
 		targetURL = M.media_url
 		targetStartTime = M.media_start_time
 		targetVolume = M.volume
-		src.finish_time = M.media_finish_time
 		if ((targetURL != current_url) && (finish_time > 0) && ((world.time - finish_time) < -10 SECONDS)) // We caught a music. Let's see if we can make a graceful fadeout for the music currently playing. If not, the other music is killed.
 			MP_DEBUG("<span class='good'>Should be cutting off music.<span>")
 			stop_music()
-			sleep(1 SECONDS) // Have to wait for the media player response.
-
-//			to_chat(owner, "Found audio source: [M.media_url] @ [(world.time - start_time) / 10]s.")
+			sleep(0.1 SECONDS) // Have to wait for the media player response.
+		src.finish_time = M.media_finish_time
+	else
+		MP_DEBUG("<span class='good'>Nothing playing, cutting off music.<span>")
+		stop_music()
 	//else
 	//	testing("M is not playing or null.")
 	push_music(targetURL,targetStartTime,targetVolume)


### PR DESCRIPTION
Closes #26618
Did not really understand the difference between an area playing a "null music" and an area playing no music at all

Tested as much as I could, VLC, WMP, Ghosts AND living players since it caused issues in the past