### PR TITLE
Jukebox stops faster on logout

### DIFF
--- a/code/modules/mob/logout.dm
+++ b/code/modules/mob/logout.dm
@@ -31,6 +31,9 @@
 			for (var/obj/effect/decal/cleanable/C in infected_cleanables)
 				client.images -= C.pathogen
 
+	if(client && client.media)
+		client.media.stop_music()
+
 	if(admin_datums[src.ckey])
 		if (ticker && ticker.current_state == GAME_STATE_PLAYING) //Only report this stuff if we are currently playing.
 			var/admins_number = admins.len


### PR DESCRIPTION
Not really "instant" because it still takes time for `Logout()` to be called, but the music does stop as soon as I see `Shifty_rail logout` on my DD window