### PR TITLE
Tweaks Colorful Syndrome so it cannot activate in Mice, and lowers its danger level

### DIFF
--- a/code/modules/virus2/effect/stage_3.dm
+++ b/code/modules/virus2/effect/stage_3.dm
@@ -516,10 +516,13 @@ datum/disease2/effect/lubefoot/deactivate(var/mob/living/mob)
 	badness = EFFECT_DANGER_HINDRANCE
 
 /datum/disease2/effect/colorsmoke/activate(var/mob/living/mob)
-	if (!ismouse(mob))//people don't like infected mice ruining maint
-		to_chat(mob, "<span class='notice'>You feel colorful!</span>")
-		mob.reagents.add_reagent(COLORFUL_REAGENT, 5)
-		mob.reagents.add_reagent(PAISMOKE, 5)
+	if (ismouse(mob))//people don't like infected mice ruining maint
+		var/mob/living/simple_animal/mouse/M = mob
+		if (!initial(M.infectable))
+			return
+	to_chat(mob, "<span class='notice'>You feel colorful!</span>")
+	mob.reagents.add_reagent(COLORFUL_REAGENT, 5)
+	mob.reagents.add_reagent(PAISMOKE, 5)
 
 /datum/disease2/effect/cleansmoke
 	name = "Cleaning Syndrome"

--- a/code/modules/virus2/effect/stage_3.dm
+++ b/code/modules/virus2/effect/stage_3.dm
@@ -513,12 +513,13 @@ datum/disease2/effect/lubefoot/deactivate(var/mob/living/mob)
 	name = "Colorful Syndrome"
 	desc = "Causes the infected to synthesize smoke & rainbow colourant."
 	stage = 3
-	badness = EFFECT_DANGER_HARMFUL
+	badness = EFFECT_DANGER_HINDRANCE
 
 /datum/disease2/effect/colorsmoke/activate(var/mob/living/mob)
-	to_chat(mob, "<span class='notice'>You feel colorful!</span>")
-	mob.reagents.add_reagent(COLORFUL_REAGENT, 5)
-	mob.reagents.add_reagent(PAISMOKE, 5)
+	if (!ismouse(mob))//people don't like infected mice ruining maint
+		to_chat(mob, "<span class='notice'>You feel colorful!</span>")
+		mob.reagents.add_reagent(COLORFUL_REAGENT, 5)
+		mob.reagents.add_reagent(PAISMOKE, 5)
 
 /datum/disease2/effect/cleansmoke
 	name = "Cleaning Syndrome"


### PR DESCRIPTION
:cl:
* tweak: Colorful Syndrome is once again a Danger 3 symptom, down from 4. Additionally it cannot activate from inside a maintenance mouse (only inside lab mice, or plague mice).