### PR TITLE
Celldoor hotfixes

### DIFF
--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -179,21 +179,17 @@
 	usr.set_machine(src)
 	if(href_list["timing"])
 		timing = text2num(href_list["timing"])
-	else
-		if(href_list["tp"])
-			timeleft += text2num(href_list["tp"])
-			timeleft = clamp(round(timeleft), 0, 1 HOURS)
-		if(href_list["fc"])
-			for(var/obj/machinery/flasher/F in targets)
-				F.flash()
+	else if(href_list["tp"])
+		timeleft += text2num(href_list["tp"])
+		timeleft = clamp(round(timeleft), 0, 3600)
+	else if(href_list["fc"])
+		for(var/obj/machinery/flasher/F in targets)
+			F.flash()
 	add_fingerprint(usr)
 	updateUsrDialog()
 	update_icon()
 	if(timing)
 		timer_start()
-	else
-		timer_end()
-
 
 //icon update function
 // if NOPOWER, display blank

--- a/code/game/objects/items/sec_lawplanner.dm
+++ b/code/game/objects/items/sec_lawplanner.dm
@@ -100,8 +100,8 @@
 
 
 /obj/item/device/law_planner/proc/announce()
-	visible_message("[bicon(src)] <B>\The [src]</B> beeps, \"Charges: [english_list(rapsheet)]")
-	visible_message("[bicon(src)] <B>\The [src]</B> beeps, \"[total_time] minutes.")
+	visible_message("[bicon(src)] <B>\The [src]</B> beeps, \"Charges: [english_list(rapsheet)].\"")
+	visible_message("[bicon(src)] <B>\The [src]</B> beeps, \"[total_time] minutes.\"")
 
 /obj/item/device/law_planner/preattack(var/atom/A, var/mob/user, var/proximity_flag)
 	if(!proximity_flag)
@@ -143,6 +143,7 @@
 			timing = 0
 		var/obj/machinery/door_timer/D = A
 		D.timeleft += apply
+		D.timeleft = clamp(round(D.timeleft), 0, 3600)
 		if(start_timer && !D.timing)
 			D.timing = TRUE
 			D.timer_start()


### PR DESCRIPTION
🆑 
* bugfix: Fixed celldoors not working without a planning frame, added clamping to the law planner's max sentence, and fixed a minor typo in law planner charge announcing.