### PR TITLE
BUGFIXES: Fixed a bunch of emitter issues

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -59,7 +59,8 @@ var/global/list/ghdel_profiling = list()
 	return 1
 
 /atom/proc/beam_disconnect(var/obj/effect/beam/B)
-	beams.Remove(B)
+	if (beams)
+		beams.Remove(B)
 
 /atom/proc/apply_beam_damage(var/obj/effect/beam/B)
 	return 1

--- a/code/game/objects/effects/beam.dm
+++ b/code/game/objects/effects/beam.dm
@@ -302,6 +302,14 @@
 	else
 		update_icon()
 
+/obj/effect/beam/can_shuttle_move(var/datum/shuttle/S)
+	var/obj/effect/beam/_master=get_master()
+	spawn(1)
+		if (!gcDestroyed && loc)
+			_master.killKids()
+			_master.emit(sources)
+	return 0
+
 /obj/effect/beam/blob_act()
 	// Act like Crossed.
 	// To do that, we need the blob.

--- a/code/game/objects/effects/step_triggers.dm
+++ b/code/game/objects/effects/step_triggers.dm
@@ -16,6 +16,8 @@
 		return
 	if(istype(H, /mob/dead/observer) && !affect_ghosts)
 		return
+	if(istype(H, /obj/effect/beam))//those things aren't meant to get moved
+		return
 	Trigger(H)
 
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1699,6 +1699,12 @@ Use this proc preferably at the end of an equipment loadout
 	..()
 	EndMoving()
 
+//Like forceMove(), but for dirs! used in atoms_movable.dm, mainly with chairs and vehicles
+/mob/change_dir(new_dir, var/changer)
+	StartMoving()
+	..()
+	EndMoving()
+
 /mob/proc/IsAdvancedToolUser()//This might need a rename but it should replace the can this mob use things check
 	return 0
 


### PR DESCRIPTION
I don't know if the following are fixed by this PR or the Afflictus Emittus one, but the issues were individually tested and appear as resolved as of now.
Closes #23810
Closes #25088
Closes #25276
Closes #25405

On top of that:
:cl:
* bugfix: Fixed beams emitted from Emitter Goggles or Afflictus Emittus not updating when the player rotates on a chair or vehicle.
* bugfix: Fixed emitters beams getting fucked up by shuttles moving in and out, they now properly update when a shuttle tries to move them.
* bugfix: Emitter beams no longer get swept in hyperspace.

