### PR TITLE
AAC Importing

### DIFF
--- a/code/modules/atmos_automation/console.dm
+++ b/code/modules/atmos_automation/console.dm
@@ -323,7 +323,6 @@
 	return list2json(json)
 
 /obj/machinery/computer/general_air_control/atmos_automation/proc/ReadCode(var/jsonStr)
-	automations.len = 0
 	var/list/json=json2list(jsonStr)
 	if(json && json.len > 0)
 		for(var/list/cData in json)


### PR DESCRIPTION
[qol] importing AAC code will no longer clear the current code. i did this then forgot about it several weeks ago, testing and working but could break other stuff since i'm not sure why that line was there to begin with it's a mystery

:cl:
 * tweak: Importing AAC code no longer clears the current code.