### PR TITLE
silicon unit link established notification

### DIFF
--- a/code/datums/wires/robot.dm
+++ b/code/datums/wires/robot.dm
@@ -75,7 +75,8 @@ var/const/BORG_WIRE_LAWCHECK    = 16 // Not used on MoMMIs
 	switch(index)
 		if (BORG_WIRE_AI_CONTROL) //pulse the AI wire to make the borg reselect an AI
 			if(!R.emagged && !isMoMMI(R))
-				R.connected_ai = select_active_ai()
+				R.disconnect_AI()
+				R.connect_AI(select_active_ai())
 
 		if (BORG_WIRE_CAMERA)
 			if(!isnull(R.camera) && R.camera.can_use() && !R.scrambledcodes)

--- a/code/modules/mob/living/silicon/robot/death.dm
+++ b/code/modules/mob/living/silicon/robot/death.dm
@@ -1,5 +1,6 @@
 /mob/living/silicon/robot/gib()
 	//robots don't die when gibbed. instead they drop their MMI'd brain
+	disconnect_AI()
 	monkeyizing = TRUE
 	canmove = FALSE
 	icon = null
@@ -17,6 +18,7 @@
 	qdel(src)
 
 /mob/living/silicon/robot/dust()
+	disconnect_AI()
 	death(1)
 	monkeyizing = TRUE
 	canmove = FALSE

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -179,10 +179,11 @@ var/list/cyborg_list = list()
 	else
 		lawupdate = FALSE
 
-/mob/living/silicon/robot/proc/disconnect_AI()
+/mob/living/silicon/robot/proc/disconnect_AI(var/announce = TRUE)
 	if(connected_ai)
-		to_chat(src, "<span class='alert' style=\"font-family:Courier\">Notice: Unlinked from [connected_ai].</span>")
-		to_chat(connected_ai, "<span class='alert' style=\"font-family:Courier\">Notice: Link to [src] lost.</span>")
+		if(announce)
+			to_chat(src, "<span class='alert' style=\"font-family:Courier\">Notice: Unlinked from [connected_ai].</span>")
+			to_chat(connected_ai, "<span class='alert' style=\"font-family:Courier\">Notice: Link to [src] lost.</span>")
 		connected_ai.connected_robots -= src
 		connected_ai = null
 
@@ -558,7 +559,7 @@ var/list/cyborg_list = list()
 					SetEmagged(TRUE)
 					SetLockdown(TRUE)
 					lawupdate = FALSE
-					disconnect_AI()
+					disconnect_AI(announce = FALSE)
 					to_chat(user, "You emag [src]'s interface")
 					message_admins("[key_name_admin(user)] emagged cyborg [key_name_admin(src)]. Laws overidden.")
 					log_game("[key_name(user)] emagged cyborg [key_name(src)].  Laws overridden.")

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -179,7 +179,7 @@ var/list/cyborg_list = list()
 	else
 		lawupdate = FALSE
 
-/mob/living/silicon/robot/proc/disconnect_AI(var/announce = TRUE)
+/mob/living/silicon/robot/proc/disconnect_AI(var/announce = FALSE)
 	if(connected_ai)
 		to_chat(src, "<span class='alert' style=\"font-family:Courier\">Notice: Unlinked from [connected_ai].</span>")
 		if(announce)
@@ -559,7 +559,7 @@ var/list/cyborg_list = list()
 					SetEmagged(TRUE)
 					SetLockdown(TRUE)
 					lawupdate = FALSE
-					disconnect_AI(announce = FALSE)
+					disconnect_AI()
 					to_chat(user, "You emag [src]'s interface")
 					message_admins("[key_name_admin(user)] emagged cyborg [key_name_admin(src)]. Laws overidden.")
 					log_game("[key_name(user)] emagged cyborg [key_name(src)].  Laws overridden.")

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -181,8 +181,8 @@ var/list/cyborg_list = list()
 
 /mob/living/silicon/robot/proc/disconnect_AI(var/announce = TRUE)
 	if(connected_ai)
+		to_chat(src, "<span class='alert' style=\"font-family:Courier\">Notice: Unlinked from [connected_ai].</span>")
 		if(announce)
-			to_chat(src, "<span class='alert' style=\"font-family:Courier\">Notice: Unlinked from [connected_ai].</span>")
 			to_chat(connected_ai, "<span class='alert' style=\"font-family:Courier\">Notice: Link to [src] lost.</span>")
 		connected_ai.connected_robots -= src
 		connected_ai = null

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -172,6 +172,8 @@ var/list/cyborg_list = list()
 	if(istype(new_AI))
 		connected_ai = new_AI
 		connected_ai.connected_robots += src
+		to_chat(src, "<span class='notice' style=\"font-family:Courier\">Notice: Linked to [connected_ai].</span>")
+		to_chat(connected_ai, "<span class='notice' style=\"font-family:Courier\">Notice: Link to [src] established.</span>")
 		lawsync()
 		lawupdate = TRUE
 	else
@@ -179,6 +181,8 @@ var/list/cyborg_list = list()
 
 /mob/living/silicon/robot/proc/disconnect_AI()
 	if(connected_ai)
+		to_chat(src, "<span class='alert' style=\"font-family:Courier\">Notice: Unlinked from [connected_ai].</span>")
+		to_chat(connected_ai, "<span class='alert' style=\"font-family:Courier\">Notice: Link to [src] lost.</span>")
 		connected_ai.connected_robots -= src
 		connected_ai = null
 


### PR DESCRIPTION
![AImsg](https://user-images.githubusercontent.com/8468269/84812732-26318900-b00f-11ea-89bf-e7271462dfc1.png)



🆑 
 - rscadd: Silicons now get a notification when they gain an AI link. This goes both ways.