### PR TITLE
Better Viro Round-end Stats

### DIFF
--- a/__DEFINES/global.dm
+++ b/__DEFINES/global.dm
@@ -251,6 +251,10 @@ var/list/score=list(
 	"litter"		 = 0, //How much trash is laying on the station floor
 	"meals"          = 0, //How much food was actively cooked that day
 	"disease_good"        = 0, //How many unique diseases currently affecting living mobs of cumulated danger <3
+	"disease_vaccine"	= null, //Which many vaccine antibody isolated
+	"disease_vaccine_score"	= 0, //the associated score
+	"disease_extracted"	= 0, //Score based on the unique extracted effects
+	"disease_effects"	= 0, //Score based on the unique extracted effects
 	"disease_bad"        = 0, //How many unique diseases currently affecting living mobs of cumulated danger >= 3
 	"disease_most"        = null, //Most spread disease
 	"disease_most_count"        = 0, //Most spread disease
@@ -292,6 +296,23 @@ var/list/score=list(
 	"arenafights"   = 0,
 	"arenabest"		= null,
 )
+
+var/list/isolated_antibodies = list(
+	ANTIGEN_O	= 0,
+	ANTIGEN_A	= 0,
+	ANTIGEN_B	= 0,
+	ANTIGEN_RH	= 0,
+	ANTIGEN_Q	= 0,
+	ANTIGEN_U	= 0,
+	ANTIGEN_V	= 0,
+	ANTIGEN_M	= 0,
+	ANTIGEN_N	= 0,
+	ANTIGEN_P	= 0,
+	ANTIGEN_X	= 0,
+	ANTIGEN_Y	= 0,
+	ANTIGEN_Z	= 0,
+	)
+var/list/extracted_gna = list()
 
 var/list/trash_items = list()
 var/list/decals = list()

--- a/code/game/gamemodes/scoreboard.dm
+++ b/code/game/gamemodes/scoreboard.dm
@@ -278,7 +278,27 @@
 		messpoints = score["mess"] //If there are any messes, let's count them
 	//if(score["airloss"] != 0)
 		//atmos = score["airloss"] * 20 //Air issues are bad, but since it's space, don't stress it too much
-	var/beneficialpoints = score["disease_good"] * 20
+	//var/beneficialpoints = score["disease_good"] * 20
+
+	score["disease_vaccine"] = ""
+
+	for (var/antigen in all_antigens)
+		if (isolated_antibodies[antigen] == 1)
+			score["disease_vaccine"] += "[antigen]"
+			if (antigen in blood_antigens)
+				score["disease_vaccine_score"] += 10
+			else if (antigen in common_antigens)
+				score["disease_vaccine_score"] += 30
+			else if (antigen in rare_antigens)
+				score["disease_vaccine_score"] += 50
+			else if (antigen in alien_antigens)
+				score["disease_vaccine_score"] += 100
+		else
+			score["disease_vaccine"] += "-"
+
+	if (score["disease_vaccine_score"] == 580)
+		score["disease_vaccine_score"] = 1000
+
 	var/plaguepoints = score["disease_bad"] * 50 //A diseased crewman is half-dead, as they say, and a double diseased is double half-dead
 
 	/*//Mode Specific
@@ -310,7 +330,9 @@
 	score["crewscore"] += escapoints
 	score["crewscore"] += meals
 	score["crewscore"] += time
-	score["crewscore"] += beneficialpoints
+	//score["crewscore"] += beneficialpoints
+	score["crewscore"] += score["disease_vaccine_score"]
+	score["crewscore"] += score["disease_effects"]
 
 	if(!power) //No APCs with bad power
 		score["crewscore"] += 2500 //Give the Engineers a pat on the back for bothering
@@ -476,6 +498,8 @@
 	*/
 
 //	var/totalfunds = wagesystem.station_budget + wagesystem.research_budget + wagesystem.shipping_budget
+//	<B>Beneficial diseases in living mobs:</B> [score["disease_good"]] ([score["disease_good"] * 20] Points)<BR><BR>
+
 	dat += {"<B><U>GENERAL STATS</U></B><BR>
 
 	<U>THE GOOD:</U><BR>
@@ -487,7 +511,8 @@
 	<B>Random Events Endured:</B> [score["eventsendured"]] ([score["eventsendured"] * 200] Points)<BR>
 	<B>Whole Station Powered:</B> [score["powerbonus"] ? "Yes" : "No"] ([score["powerbonus"] * 2500] Points)<BR>
 	<B>Ultra-Clean Station:</B> [score["messbonus"] ? "Yes" : "No"] ([score["messbonus"] * 10000] Points)<BR>
-	<B>Beneficial diseases in living mobs:</B> [score["disease_good"]] ([score["disease_good"] * 20] Points)<BR><BR>
+	<B>Isolated Vaccines:</B> [score["disease_vaccine"]] ([score["disease_vaccine_score"]] Points)<BR><BR>
+	<B>Extracted Symptoms:</B> [score["disease_extracted"]] ([score["disease_effects"]] Points)<BR><BR>
 
 	<U>THE BAD:</U><BR>
 	<B>Dead Crewmen:</B> [score["deadcrew"]] (-[score["deadcrew"] * 250] Points)<BR>

--- a/code/game/gamemodes/scoreboard.dm
+++ b/code/game/gamemodes/scoreboard.dm
@@ -511,7 +511,7 @@
 	<B>Random Events Endured:</B> [score["eventsendured"]] ([score["eventsendured"] * 200] Points)<BR>
 	<B>Whole Station Powered:</B> [score["powerbonus"] ? "Yes" : "No"] ([score["powerbonus"] * 2500] Points)<BR>
 	<B>Ultra-Clean Station:</B> [score["messbonus"] ? "Yes" : "No"] ([score["messbonus"] * 10000] Points)<BR>
-	<B>Isolated Vaccines:</B> [score["disease_vaccine"]] ([score["disease_vaccine_score"]] Points)<BR><BR>
+	<B>Isolated Vaccines:</B> [score["disease_vaccine"]] ([score["disease_vaccine_score"]] Points)<BR>
 	<B>Extracted Symptoms:</B> [score["disease_extracted"]] ([score["disease_effects"]] Points)<BR><BR>
 
 	<U>THE BAD:</U><BR>

--- a/code/modules/virus2/centrifuge.dm
+++ b/code/modules/virus2/centrifuge.dm
@@ -323,7 +323,7 @@
 
 				var/data = list("antigen" = list(task.target_name))
 				vial_datum.vial.reagents.add_reagent(VACCINE, amount, data)
-
+				isolated_antibodies[task.target_name] = 1
 				vial_datum.current_task = null
 
 				alert_noise("ping")

--- a/code/modules/virus2/diseasesplicer.dm
+++ b/code/modules/virus2/diseasesplicer.dm
@@ -131,6 +131,22 @@
 			else
 				d.name = "unknown GNA disk (Stage: [memorybank.stage])"
 			d.effect = memorybank
+			if (!(memorybank.type in extracted_gna))
+				extracted_gna |= memorybank.type
+				score["disease_extracted"] += 1
+				switch (memorybank.badness)
+					if (EFFECT_DANGER_HELPFUL)
+						score["disease_effects"] += 20
+					if (EFFECT_DANGER_FLAVOR)
+						score["disease_effects"] += 2
+					if (EFFECT_DANGER_ANNOYING)
+						score["disease_effects"] += 1
+					if (EFFECT_DANGER_HINDRANCE)
+						score["disease_effects"] += 5
+					if (EFFECT_DANGER_HARMFUL)
+						score["disease_effects"] += 10
+					if (EFFECT_DANGER_DEADLY)
+						score["disease_effects"] += 30
 			alert_noise("ping")
 			spawn(10)
 				d.forceMove(loc)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7573912/83832269-8b20e100-a6e9-11ea-832a-6cc36501c6c9.png)



:cl:
* rscadd: Instead of being rewarded for spreading beneficial diseases in living mobs, Virologists can now contribute to the crew score by just doing their job of isolating vaccines and extracting disease symptoms. Rarer antibodies award more points. Helpful and Dangerous symptoms as well.