### PR TITLE
SAC: Lockbox alerts

### DIFF
--- a/code/game/machinery/computer/security_alert.dm
+++ b/code/game/machinery/computer/security_alert.dm
@@ -17,7 +17,7 @@ TODO: literally every alarm but SPS alarms.
 	circuit = "/obj/item/weapon/circuitboard/security_alerts"
 	icon_state = "secalert"
 	var/list/saved_security_alerts = list()
-	var/last_alert_time = 0
+	var/new_alert_indicator = FALSE
 
 	light_color = LIGHT_COLOR_RED
 
@@ -42,15 +42,15 @@ TODO: literally every alarm but SPS alarms.
 /obj/machinery/computer/security_alerts/attack_hand(mob/user as mob)
 	add_fingerprint(user)
 	ui_interact(user)
-	update_icon(showalert = FALSE)
+	update_icon(new_alert_indicator = FALSE)
 
-/obj/machinery/computer/security_alerts/update_icon(var/showalert = FALSE)
+/obj/machinery/computer/security_alerts/update_icon()
 	..()
 	if(stat & (NOPOWER|BROKEN))
 		return
 	else
 		icon_state = "secalert"
-	if(showalert)
+	if(new_alert_indicator)
 		overlays += image(icon = icon, icon_state = "secalert-newalerts")
 	else
 		overlays = 0
@@ -108,9 +108,10 @@ TODO: literally every alarm but SPS alarms.
 	if(verbose)
 		say(message)
 		playsound(src,'sound/machines/radioboop.ogg',40,1)
+		new_alert_indicator = TRUE
 	flick("secalert-update", src)
 	nanomanager.update_uis(src)
-	update_icon(showalert = verbose)
+	update_icon()
 
 /obj/machinery/computer/security_alerts/say_quote(text)
 	return "reports, [text]."

--- a/code/game/machinery/computer/security_alert.dm
+++ b/code/game/machinery/computer/security_alert.dm
@@ -107,7 +107,7 @@ TODO: literally every alarm but SPS alarms.
 	var/message = "Alert. [alerttype]"
 	if(verbose)
 		say(message)
-	playsound(src,'sound/machines/radioboop.ogg',40,1)
+		playsound(src,'sound/machines/radioboop.ogg',40,1)
 	flick("secalert-update", src)
 	nanomanager.update_uis(src)
 	update_icon(showalert = verbose)

--- a/code/game/machinery/computer/security_alert.dm
+++ b/code/game/machinery/computer/security_alert.dm
@@ -110,7 +110,7 @@ TODO: literally every alarm but SPS alarms.
 	playsound(src,'sound/machines/radioboop.ogg',40,1)
 	flick("secalert-update", src)
 	nanomanager.update_uis(src)
-	update_icon(showalert = TRUE)
+	update_icon(showalert = verbose)
 
 /obj/machinery/computer/security_alerts/say_quote(text)
 	return "reports, [text]."

--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -185,7 +185,7 @@
 	var/alerttype = code
 	var/alertarea = get_area(src)
 	var/alerttime = worldtime2text()
-	var/verbose = TRUE
+	var/verbose = FALSE
 	var/transmission_data = "[alerttype] - [alerttime] - [alertarea] ([x0],[y0],[z0])"
 	for(var/obj/machinery/computer/security_alerts/receiver in security_alerts_computers)
 		if(receiver && !receiver.stat)

--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -121,7 +121,7 @@
 	if(health <= 0)
 		for(var/atom/movable/A in src)
 			remove_from_storage(A, get_turf(src))
-
+		send_signal("Lockbox: Code Orange")
 		qdel(src)
 	return
 
@@ -134,11 +134,13 @@
 				for(var/atom/movable/A in src)
 					remove_from_storage(A, get_turf(src))
 					A.ex_act(3)
+				send_signal("Lockbox: Code Orange")
 				qdel(src)
 		if(3)
 			if(prob(50))
 				for(var/atom/movable/A in src)
 					remove_from_storage(A, get_turf(src))
+				send_signal("Lockbox: Code Orange")
 				qdel(src)
 
 /obj/item/weapon/storage/lockbox/emp_act(severity)
@@ -173,6 +175,24 @@
 	else
 		icon_state = src.icon_closed
 	return
+
+/obj/item/weapon/storage/lockbox/proc/send_signal(var/code)
+	var/boop = FALSE
+	var/turf/pos = get_turf(src)
+	var/x0 = pos.x-WORLD_X_OFFSET[pos.z]
+	var/y0 = pos.x-WORLD_Y_OFFSET[pos.z]
+	var/z0 = pos.z
+	var/alerttype = code
+	var/alertarea = get_area(src)
+	var/alerttime = worldtime2text()
+	var/verbose = TRUE
+	var/transmission_data = "[alerttype] - [alerttime] - [alertarea] ([x0],[y0],[z0])"
+	for(var/obj/machinery/computer/security_alerts/receiver in security_alerts_computers)
+		if(receiver && !receiver.stat)
+			receiver.receive_alert(alerttype, transmission_data, verbose)
+			boop = TRUE
+	if (boop)
+		playsound(src,'sound/machines/radioboop.ogg',40,1)
 
 /obj/item/weapon/storage/lockbox/loyalty
 	name = "lockbox (loyalty implants)"


### PR DESCRIPTION
### What
Adds SAC alerts when lockboxes are broken into.
This only happens if the lockbox is destroyed, be it through bullets or explosions (or mech drills).
EMPs and emagging isn't affected.
The alert won't be announced, and the SAC won't show that there's a new alert if this is the only newest alert, so it's not a 'priority'.
![2020-06-06_16-03-50](https://user-images.githubusercontent.com/8468269/83946180-7a6a8b00-a80f-11ea-9ea6-eba48339df8d.png)

### Why
Scientists always having pocket guns has been a long-standing issue with constant discussion, and there's never been a pleasing answer to it.
I think this change allows for antag and non-antag escalation without 100% locking out people's abilities to gain useful stuff from science. And that's a good thing! People should be able to do 'bad'things without having to be an antag or having sec up their ass.  But if there's sec, and they're paying attention, and the scientists aren't, someone might notice, and that might be interesting for a change.
I also believe that lockboxes are completely pointless if they can very easily be broken open without anyone ever noticing. They don't leave behind any evidence apart from their contents. Surely they would have *some* sort of safety feature, right?

🆑 
 - experiment: Lockboxes now send a security alert when broken with brute force. This doesn't apply to EMPs or emagging.