### PR TITLE
Allows transparent clothing such as helmets to display "some" of the item slots they are covering

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult_items.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_items.dm
@@ -988,6 +988,7 @@ var/list/arcane_tomes = list()
 	desc = "A hood worn by the followers of Nar-Sie."
 	armor = list(melee = 30, bullet = 10, laser = 10,energy = 5, bomb = 10, bio = 25, rad = 0)
 	body_parts_covered = EARS|HEAD|HIDEHAIR
+	body_parts_visible_override = FACE
 	siemens_coefficient = 0
 	heat_conductivity = SPACESUIT_HEAT_CONDUCTIVITY
 	species_fit = list(VOX_SHAPED)

--- a/code/datums/gamemode/factions/legacy_cult/cult_items.dm
+++ b/code/datums/gamemode/factions/legacy_cult/cult_items.dm
@@ -53,6 +53,7 @@
 /obj/item/clothing/head/legacy_culthood/alt
 	icon_state = "culthelmet_old"
 	item_state = "culthelmet_old"
+	body_parts_visible_override = EYES
 
 /obj/item/clothing/suit/legacy_cultrobes/alt
 	icon_state = "cultarmor_old"

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -29,6 +29,7 @@
 	//Since any item can now be a piece of clothing, this has to be put here so all items share it.
 	var/_color = null
 	var/body_parts_covered = 0 //see setup.dm for appropriate bit flags
+	var/body_parts_visible_override = 0 //for when you want specific parts to be visible while covered (and not all of them), same flags as above.
 	//var/heat_transfer_coefficient = 1 //0 prevents all transfers, 1 is invisible
 	var/gas_transfer_coefficient = 1 // for leaking gas from turf to mask and vice-versa (for masks right now, but at some point, i'd like to include space helmets)
 	var/permeability_coefficient = 1 // for chemicals/diseases

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -375,19 +375,19 @@
 			var/washglasses = 1
 
 			if(H.wear_suit)
-				washgloves = !(is_slot_hidden(H.wear_suit.body_parts_covered, HIDEGLOVES))
-				washshoes = !(is_slot_hidden(H.wear_suit.body_parts_covered, HIDESHOES))
+				washgloves = !(is_slot_hidden(H.wear_suit.body_parts_covered, HIDEGLOVES, 0, H.wear_suit.body_parts_visible_override))
+				washshoes = !(is_slot_hidden(H.wear_suit.body_parts_covered, HIDESHOES, 0, H.wear_suit.body_parts_visible_override))
 
 			if(H.head)
-				washmask = !(is_slot_hidden(H.head.body_parts_covered, HIDEMASK))
-				washglasses = !(is_slot_hidden(H.head.body_parts_covered, HIDEEYES))
-				washears = !(is_slot_hidden(H.head.body_parts_covered, HIDEEARS))
+				washmask = !(is_slot_hidden(H.head.body_parts_covered, HIDEMASK, 0, H.head.body_parts_visible_override))
+				washglasses = !(is_slot_hidden(H.head.body_parts_covered, HIDEEYES, 0, H.head.body_parts_visible_override))
+				washears = !(is_slot_hidden(H.head.body_parts_covered, HIDEEARS, 0, H.head.body_parts_visible_override))
 
 			if(H.wear_mask)
 				if(washears)
-					washears = !(is_slot_hidden(H.wear_mask.body_parts_covered, HIDEEARS))
+					washears = !(is_slot_hidden(H.wear_mask.body_parts_covered, HIDEEARS, 0, H.wear_mask.body_parts_visible_override))
 				if(washglasses)
-					washglasses = !(is_slot_hidden(H.wear_mask.body_parts_covered, HIDEEYES))
+					washglasses = !(is_slot_hidden(H.wear_mask.body_parts_covered, HIDEEYES, 0, H.wear_mask.body_parts_visible_override))
 
 			if(H.head)
 				if(prob(CLEAN_PROB) && H.head.clean_blood())

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -542,6 +542,7 @@
 	permeability_coefficient = 0.01
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 100, rad = 50)
 	body_parts_covered = FULL_HEAD|HIDEHAIR
+	body_parts_visible_override = EYES
 	siemens_coefficient = 0.9
 	heat_conductivity = SPACESUIT_HEAT_CONDUCTIVITY
 	species_restricted = list("exclude","Diona","Muton")

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -5,6 +5,7 @@
 	flags = FPRINT
 	armor = list(melee = 50, bullet = 15, laser = 50, energy = 10, bomb = 25, bio = 0, rad = 0)
 	body_parts_covered = HEAD|EARS|EYES|MASKHEADHAIR
+	body_parts_visible_override = FACE
 	heat_conductivity = HELMET_HEAT_CONDUCTIVITY
 	max_heat_protection_temperature = HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
 	siemens_coefficient = 0.7
@@ -18,6 +19,7 @@
 	armor = list(melee = 50, bullet = 25, laser = 45, energy = 15, bomb = 30, bio = 0, rad = 0)
 	actions_types = list(/datum/action/item_action/toggle_helmet)
 	body_parts_covered = FULL_HEAD|MASKHEADHAIR
+	body_parts_visible_override = EYES|BEARD
 	var/state = 1
 
 /obj/item/clothing/head/helmet/visor/New()
@@ -89,6 +91,7 @@
 	pressure_resistance = 200 * ONE_ATMOSPHERE
 	siemens_coefficient = 0.5
 	eyeprot = 1
+	body_parts_visible_override = BEARD
 
 /obj/item/clothing/head/helmet/thunderdome
 	name = "\improper Thunderdome helmet"
@@ -167,6 +170,7 @@
 	body_parts_covered = HEAD|EARS|MASKHEADHAIR
 	item_state = "megahelmet"
 	siemens_coefficient = 1
+	body_parts_visible_override = BEARD
 
 /obj/item/clothing/head/helmet/protohelmet
 	name = "Prototype Helmet"

--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -84,6 +84,7 @@
 	desc = "It's unspeakably stylish."
 	icon_state = "hasturhood"
 	body_parts_covered = EARS|HEAD|HIDEHEADHAIR
+	body_parts_visible_override = FACE
 
 /obj/item/clothing/head/vamphunter
 	name = "vampire hunter circlet"

--- a/code/modules/clothing/head/tactical.dm
+++ b/code/modules/clothing/head/tactical.dm
@@ -42,3 +42,4 @@
 	pressure_resistance = 200 * ONE_ATMOSPHERE
 	siemens_coefficient = 0.5
 	eyeprot = 1
+	body_parts_visible_override = FACE

--- a/code/modules/clothing/spacesuits/captain.dm
+++ b/code/modules/clothing/spacesuits/captain.dm
@@ -5,6 +5,7 @@
 	item_state = "capspacehelmet"
 	desc = "A special helmet designed for work in a hazardous, low-pressure environment. Only for the most fashionable of military figureheads."
 	body_parts_covered = HEAD|EARS|EYES
+	body_parts_visible_override = EYES
 	permeability_coefficient = 0.01
 	armor = list(melee = 65, bullet = 50, laser = 50,energy = 25, bomb = 50, bio = 100, rad = 50)
 	allowed = list(/obj/item/device/flashlight)

--- a/code/modules/clothing/spacesuits/rig.dm
+++ b/code/modules/clothing/spacesuits/rig.dm
@@ -676,6 +676,7 @@
 	pressure_resistance = 4 * ONE_ATMOSPHERE
 	armor = list(melee = 30, bullet = 5, laser = 20,energy = 10, bomb = 20, bio = 10, rad = 20)
 	body_parts_covered = FULL_HEAD|BEARD
+	body_parts_visible_override = EYES
 	heat_conductivity = 0
 	gas_transfer_coefficient = 0.01
 	permeability_coefficient = 0.01

--- a/code/modules/clothing/spacesuits/syndi.dm
+++ b/code/modules/clothing/spacesuits/syndi.dm
@@ -7,6 +7,7 @@
 	desc = "Has a tag on it: Totally not property of a hostile corporation, honest!"
 	armor = list(melee = 60, bullet = 50, laser = 30,energy = 15, bomb = 30, bio = 30, rad = 30)
 	siemens_coefficient = 0.8
+	body_parts_visible_override = EYES|BEARD
 
 /obj/item/clothing/suit/space/syndicate
 	name = "red space suit"

--- a/code/modules/clothing/spacesuits/void.dm
+++ b/code/modules/clothing/spacesuits/void.dm
@@ -7,6 +7,7 @@
 	species_restricted = list("exclude",VOX_SHAPED)
 	icon_state = "void"
 	item_state = "void"
+	body_parts_visible_override = EYES
 
 /obj/item/clothing/suit/space/nasavoid
 	name = "NASA Voidsuit"

--- a/code/modules/clothing/suits/bio.dm
+++ b/code/modules/clothing/suits/bio.dm
@@ -8,6 +8,7 @@
 	clothing_flags = PLASMAGUARD
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 100, rad = 20)
 	body_parts_covered = HEAD|EARS|EYES|MOUTH|HIDEHAIR
+	body_parts_visible_override = EYES|BEARD
 	siemens_coefficient = 0.9
 	sterility = 100
 	species_fit = list(GREY_SHAPED, INSECT_SHAPED)
@@ -114,6 +115,8 @@
 
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 30, rad = 0)
 	sterility = 50
+
+	body_parts_visible_override = FACE
 
 
 //Plague Dr mask can be found in clothing/masks/gasmask.dm

--- a/code/modules/clothing/suits/utility.dm
+++ b/code/modules/clothing/suits/utility.dm
@@ -65,6 +65,7 @@
 	flags = FPRINT
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 100, bio = 0, rad = 0)
 	body_parts_covered = FULL_HEAD|BEARD|HIDEHAIR
+	body_parts_visible_override = EYES
 	siemens_coefficient = 0
 	species_fit = list(VOX_SHAPED)
 
@@ -132,6 +133,7 @@
 	body_parts_covered = FULL_HEAD|HIDEHAIR
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 60, rad = 100)
 	species_fit = list(VOX_SHAPED, INSECT_SHAPED)
+	body_parts_visible_override = EYES|BEARD
 
 /obj/item/clothing/suit/radiation
 	name = "radiation suit"

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -59,18 +59,18 @@
 	var/list/obscured = list()
 
 	if(wear_suit)
-		if(is_slot_hidden(wear_suit.body_parts_covered,HIDEGLOVES))
+		if(is_slot_hidden(wear_suit.body_parts_covered, HIDEGLOVES, 0, wear_suit.body_parts_visible_override))
 			obscured |= slot_gloves
-		if(is_slot_hidden(wear_suit.body_parts_covered,HIDEJUMPSUIT))
+		if(is_slot_hidden(wear_suit.body_parts_covered, HIDEJUMPSUIT, 0, wear_suit.body_parts_visible_override))
 			obscured |= slot_w_uniform
-		if(is_slot_hidden(wear_suit.body_parts_covered,HIDESHOES))
+		if(is_slot_hidden(wear_suit.body_parts_covered, HIDESHOES, 0, wear_suit.body_parts_visible_override))
 			obscured |= slot_shoes
 	if(head)
-		if(is_slot_hidden(head.body_parts_covered,HIDEMASK))
+		if(is_slot_hidden(head.body_parts_covered, HIDEMASK, 0, wear_suit.body_parts_visible_override))
 			obscured |= slot_wear_mask
-		if(is_slot_hidden(head.body_parts_covered,HIDEEYES))
+		if(is_slot_hidden(head.body_parts_covered, HIDEEYES, 0, wear_suit.body_parts_visible_override))
 			obscured |= slot_glasses
-		if(is_slot_hidden(head.body_parts_covered,HIDEEARS))
+		if(is_slot_hidden(head.body_parts_covered, HIDEEARS, 0, wear_suit.body_parts_visible_override))
 			obscured |= slot_ears
 	if(obscured.len > 0)
 		return obscured
@@ -97,7 +97,7 @@
 		ignore_slot = (equipped == wear_mask) ? MOUTH : 0
 		if(!equipped)
 			continue
-		else if(is_slot_hidden(equipped.body_parts_covered,hidden_flags,ignore_slot))
+		else if(is_slot_hidden(equipped.body_parts_covered,hidden_flags,ignore_slot,equipped.body_parts_visible_override))
 			return 1
 	return 0
 

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -623,7 +623,7 @@ var/global/list/damage_icon_parts = list()
 			if((gender == FEMALE) && (ID_worn.clothing_flags & GENDERFIT)) //genderfit
 				if(has_icon(O.icon,"[ID_worn.icon_state]_f"))
 					O.icon_state = "[ID_worn.icon_state]_f"
-	
+
 			O.overlays.len = 0
 			if(wear_id.dynamic_overlay)
 				if(wear_id.dynamic_overlay["[ID_LAYER]"])
@@ -1004,7 +1004,7 @@ var/global/list/damage_icon_parts = list()
 		else
 			if(SP.name in wear_suit.species_fit) //Allows clothes to display differently for multiple species
 				if(SP.wear_suit_icons && has_icon(SP.wear_suit_icons, wear_suit.icon_state))
-					standing.icon = SP.wear_suit_icons					
+					standing.icon = SP.wear_suit_icons
 			if((gender == FEMALE) && (wear_suit.clothing_flags & GENDERFIT)) //genderfit
 				if(has_icon(standing.icon,"[wear_suit.icon_state]_f"))
 					standing.icon_state = "[wear_suit.icon_state]_f"
@@ -1257,7 +1257,7 @@ var/global/list/damage_icon_parts = list()
 	//overlays_standing[TAIL_LAYER] = null
 	overlays -= obj_overlays[TAIL_LAYER]
 	if(species && species.tail && species.anatomy_flags & HAS_TAIL)
-		if(!wear_suit || !is_slot_hidden(wear_suit.body_parts_covered,HIDEJUMPSUIT))
+		if(!wear_suit || !is_slot_hidden(wear_suit.body_parts_covered, HIDEJUMPSUIT, 0, wear_suit.body_parts_visible_override))
 			var/obj/abstract/Overlays/O = obj_overlays[TAIL_LAYER]
 			O.icon = 'icons/effects/species.dmi'
 			O.icon_state = "[species.tail]_s"
@@ -1315,22 +1315,22 @@ var/global/list/damage_icon_parts = list()
 	if(!W || gcDestroyed)
 		return
 
-	if(is_slot_hidden(W.body_parts_covered,HIDEHEADHAIR) || is_slot_hidden(W.body_parts_covered,MASKHEADHAIR) || is_slot_hidden(W.body_parts_covered,HIDEBEARDHAIR))
+	if(is_slot_hidden(W.body_parts_covered, HIDEHEADHAIR, 0, W.body_parts_visible_override) || is_slot_hidden(W.body_parts_covered, MASKHEADHAIR, 0, W.body_parts_visible_override) || is_slot_hidden(W.body_parts_covered, HIDEBEARDHAIR, 0, W.body_parts_visible_override))
 		update_hair()
-	if(is_slot_hidden(W.body_parts_covered,(HIDEMASK)))
+	if(is_slot_hidden(W.body_parts_covered, HIDEMASK, 0, W.body_parts_visible_override))
 		update_inv_wear_mask()
-	if(is_slot_hidden(W.body_parts_covered,(HIDEGLOVES)))
+	if(is_slot_hidden(W.body_parts_covered, HIDEGLOVES, 0, W.body_parts_visible_override))
 		update_inv_gloves()
-	if(is_slot_hidden(W.body_parts_covered,HIDESHOES))
+	if(is_slot_hidden(W.body_parts_covered, HIDESHOES, 0, W.body_parts_visible_override))
 		update_inv_shoes()
-	if(is_slot_hidden(W.body_parts_covered,(HIDEJUMPSUIT)))
+	if(is_slot_hidden(W.body_parts_covered, HIDEJUMPSUIT, 0, W.body_parts_visible_override))
 		update_inv_w_uniform()
-	if(is_slot_hidden(W.body_parts_covered,(HIDEEYES)))
+	if(is_slot_hidden(W.body_parts_covered, HIDEEYES, 0, W.body_parts_visible_override))
 		update_inv_glasses()
-	if(is_slot_hidden(W.body_parts_covered, (HIDEEARS)))
+	if(is_slot_hidden(W.body_parts_covered, HIDEEARS, 0, W.body_parts_visible_override))
 		update_inv_ears()
 
-proc/is_slot_hidden(var/clothes, var/slot = -1,var/ignore_slot = 0)
+proc/is_slot_hidden(var/clothes, var/slot = -1,var/ignore_slot = 0, var/visibility_override = 0)
 	if(!clothes)
 		return 0
 	var/true_body_parts_covered = clothes
@@ -1338,6 +1338,8 @@ proc/is_slot_hidden(var/clothes, var/slot = -1,var/ignore_slot = 0)
 		slot = true_body_parts_covered
 	if(true_body_parts_covered & IGNORE_INV)
 		true_body_parts_covered = 0
+	if(visibility_override & slot)//lets you see things like glasses behind transparent helmets, while still hiding hair or other specific flags.
+		return 0
 	if(true_body_parts_covered & ignore_slot)
 		true_body_parts_covered ^= ignore_slot
 	if((true_body_parts_covered & slot) == slot)

--- a/code/modules/research/xenoarchaeology/tools/anomaly_suit.dm
+++ b/code/modules/research/xenoarchaeology/tools/anomaly_suit.dm
@@ -18,6 +18,7 @@
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/xenoarch.dmi', "right_hand" = 'icons/mob/in-hand/right/xenoarch.dmi')
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 100, rad = 100)
 	heat_conductivity = SPACESUIT_HEAT_CONDUCTIVITY
+	body_parts_visible_override = EYES|BEARD
 
 /obj/item/clothing/suit/bio_suit/anomaly/old
 	name = "Anomaly suit"
@@ -50,3 +51,4 @@
 	icon_state = "cespace_helmet"
 	item_state = "cespace_helmet"
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 100, rad = 100)
+	body_parts_visible_override = EYES|BEARD


### PR DESCRIPTION
Fixes #26684

![image](https://user-images.githubusercontent.com/7573912/83972952-74de7500-a8e3-11ea-9d45-f7e67e9d9b17.png)![image](https://user-images.githubusercontent.com/7573912/83972962-84f65480-a8e3-11ea-96a5-41d635f796b5.png)![image](https://user-images.githubusercontent.com/7573912/83972958-80ca3700-a8e3-11ea-98b0-0e36b01dd965.png)

Currently the IGNORE_INV flag allows a clothing item to hide none of the slots it covers, but you couldn't have an in-between, until now.

:cl:
* rscadd: Eye-wear and beards are now visible behind transparent helmets, hoods, etc...