### PR TITLE
Converting a gondola to the cult now updates their sprite, and they can respawn as a gondola shade

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
@@ -1071,6 +1071,11 @@
 					if (isrobot(S))
 						var/mob/living/silicon/robot/robit = S
 						robit.disconnect_AI()
+				if (istype(victim, /mob/living/carbon/complex/gondola)) //fug.....
+					victim.icon_state_standing = pick("gondola_c","gondola_c_tome")
+					victim.icon_state_lying = "[icon_state_standing]_lying"
+					victim.icon_state_dead = "gondola_skull"
+					victim.icon_state = victim.icon_state_standing
 				return
 			if (CONVERSION_NOCHOICE)
 				to_chat(victim, "<span class='danger'>As you stood there, unable to make a choice for yourself, the Geometer of Blood ran out of patience and chose for you.</span>")

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
@@ -1072,10 +1072,11 @@
 						var/mob/living/silicon/robot/robit = S
 						robit.disconnect_AI()
 				if (istype(victim, /mob/living/carbon/complex/gondola)) //fug.....
-					victim.icon_state_standing = pick("gondola_c","gondola_c_tome")
-					victim.icon_state_lying = "[icon_state_standing]_lying"
-					victim.icon_state_dead = "gondola_skull"
-					victim.icon_state = victim.icon_state_standing
+					var/mob/living/carbon/complex/gondola/gondola = victim
+					gondola.icon_state_standing = pick("gondola_c","gondola_c_tome")
+					gondola.icon_state_lying = "[gondola.icon_state_standing]_lying"
+					gondola.icon_state_dead = "gondola_skull"
+					gondola.icon_state = gondola.icon_state_standing
 				return
 			if (CONVERSION_NOCHOICE)
 				to_chat(victim, "<span class='danger'>As you stood there, unable to make a choice for yourself, the Geometer of Blood ran out of patience and chose for you.</span>")

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -402,7 +402,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	set name = "Ghost"
 	set desc = "Relinquish your life and enter the land of the dead."
 
-	if(iscultist(src) && (ishuman(src)||isconstruct(src)) && veil_thickness > CULT_PROLOGUE)
+	if(iscultist(src) && (ishuman(src)||isconstruct(src)||istype(src,/mob/living/carbon/complex/gondola)) && veil_thickness > CULT_PROLOGUE)
 		var/response = alert(src, "It doesn't have to end here, the veil is thin and the dark energies in you soul cling to this plane. You may forsake this body and materialize as a Shade.","Sacrifice Body","Shade","Ghost","Stay in body")
 		switch (response)
 			if ("Shade")

--- a/code/modules/mob/living/carbon/complex/gondola.dm
+++ b/code/modules/mob/living/carbon/complex/gondola.dm
@@ -26,6 +26,19 @@
 	icon_state_dead = "[icon_state_dead]_dead"
 	..()
 
+/mob/living/carbon/complex/gondola/Destroy()
+	if(client && iscultist(src) && veil_thickness > CULT_PROLOGUE)
+		var/turf/T = get_turf(src)
+		if (T)
+			var/mob/living/simple_animal/shade/gondola/shade = new (T)
+			playsound(T, 'sound/hallucinations/growl1.ogg', 50, 1)
+			shade.name = "[real_name] the Shade"
+			shade.real_name = "[real_name]"
+			mind.transfer_to(shade)
+			update_faction_icons()
+			to_chat(shade, "<span class='sinister'>Dark energies rip your dying body appart, anchoring your soul inside the form of a Shade. You retain your memories, and devotion to the cult.</span>")
+	..()
+
 /mob/living/carbon/complex/gondola/say()
 	return
 


### PR DESCRIPTION
:cl:
* rscadd: Converting a gondola now automatically updates its sprite to use one of the cult ones.
* rscadd: If a cultist gondola has its body destroyed, or ghosts when the veil permits it, it may respawn as a gondola shade.