### PR TITLE
You can now fit mesons, science, thermal and material scanners over prescription glasses

### DIFF
--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -16,6 +16,9 @@
 	harm_label_examine = list("<span class='info'>A label is covering one lens, but doesn't reach the other.</span>","<span class='warning'>A label covers the lenses!</span>")
 	species_restricted = list("exclude","Muton")
 	species_fit = list(INSECT_SHAPED)
+
+	var/obj/item/clothing/glasses/stored_glasses = null
+	var/glasses_fit = FALSE
 /*
 SEE_SELF  // can see self, no matter what
 SEE_MOBS  // can see all mobs, no matter what
@@ -25,6 +28,36 @@ SEE_PIXELS// if an object is located on an unlit area, but some of its pixels ar
           // in a lit area (via pixel_x,y or smooth movement), can see those pixels
 BLIND     // can't see anything
 */
+
+/obj/item/clothing/glasses/mob_can_equip(mob/living/carbon/human/user, slot, disable_warning = 0)
+	var/mob/living/carbon/human/H = user
+	if(!istype(H) || stored_glasses || !glasses_fit)
+		return ..()
+	if(slot != slot_glasses)
+		return CANNOT_EQUIP
+	if(H.glasses)
+		stored_glasses = H.glasses
+		if(stored_glasses.w_class >= w_class)
+			if(!disable_warning)
+				to_chat(H, "<span class='danger'>You are unable to wear \the [src] as \the [H.glasses] are in the way.</span>")
+			stored_glasses = null
+			return CANNOT_EQUIP
+		H.remove_from_mob(stored_glasses)
+		stored_glasses.forceMove(src)
+
+	if(!..())
+		if(stored_glasses)
+			if(!H.equip_to_slot_if_possible(stored_glasses, slot_glasses))
+				stored_glasses.forceMove(get_turf(src))
+			stored_glasses = null
+		return FALSE
+
+	if(stored_glasses)
+		to_chat(H, "<span class='info'>You place \the [src] on over \the [stored_glasses].</span>")
+		prescription = stored_glasses.prescription
+	return TRUE
+
+
 /obj/item/clothing/glasses/harm_label_update()
 	if(harm_labeled >= min_harm_label)
 		vision_flags |= BLIND
@@ -36,9 +69,15 @@ BLIND     // can't see anything
 	if(slot == slot_glasses)
 		M.handle_regular_hud_updates()
 
-/obj/item/clothing/glasses/unequipped(mob/M, var/from_slot = null)
+/obj/item/clothing/glasses/unequipped(var/mob/living/carbon/human/M, var/from_slot = null)
 	..()
 	if(from_slot == slot_glasses)
+		if (istype(M))
+			if(stored_glasses)
+				if(!M.equip_to_slot_if_possible(stored_glasses, slot_glasses))
+					stored_glasses.forceMove(get_turf(src))
+				stored_glasses = null
+		prescription = initial(prescription)
 		M.handle_regular_hud_updates()
 
 /obj/item/clothing/glasses/scanner/meson/prescription
@@ -71,6 +110,8 @@ var/list/science_goggles_wearers = list()
 	origin_tech = Tc_MATERIALS + "=1"
 	species_fit = list(GREY_SHAPED, INSECT_SHAPED)
 	actions_types = list(/datum/action/item_action/toggle_goggles)
+
+	glasses_fit = TRUE
 	var/on = FALSE
 
 /obj/item/clothing/glasses/science/prescription
@@ -182,6 +223,7 @@ var/list/science_goggles_wearers = list()
 	item_state = "glasses"
 	prescription = 1
 	species_fit = list(GREY_SHAPED, INSECT_SHAPED)
+	w_class = W_CLASS_TINY
 
 /obj/item/clothing/glasses/regular/kick_act(mob/living/carbon/human/H)
 	H.visible_message("<span class='danger'>[H] stomps on \the [src], crushing them!</span>", "<span class='danger'>You crush \the [src] under your foot.</span>")
@@ -449,6 +491,8 @@ var/list/science_goggles_wearers = list()
 	see_invisible = SEE_INVISIBLE_MINIMUM
 	invisa_view = 2
 	eyeprot = -2 //prepare for your eyes to get shit on
+
+	glasses_fit = TRUE
 
 /obj/item/clothing/glasses/thermal/emp_act(severity)
 	if(istype(src.loc, /mob/living/carbon/human))

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -50,12 +50,12 @@ BLIND     // can't see anything
 			if(!H.equip_to_slot_if_possible(stored_glasses, slot_glasses))
 				stored_glasses.forceMove(get_turf(src))
 			stored_glasses = null
-		return FALSE
+		return CANNOT_EQUIP
 
 	if(stored_glasses)
 		to_chat(H, "<span class='info'>You place \the [src] on over \the [stored_glasses].</span>")
 		prescription = stored_glasses.prescription
-	return TRUE
+	return CAN_EQUIP
 
 
 /obj/item/clothing/glasses/harm_label_update()

--- a/code/modules/clothing/glasses/scanners.dm
+++ b/code/modules/clothing/glasses/scanners.dm
@@ -131,6 +131,8 @@
 	actions_types = list(/datum/action/item_action/toggle_goggles)
 	species_fit = list(VOX_SHAPED, GREY_SHAPED, INSECT_SHAPED)
 
+	glasses_fit = TRUE
+
 /obj/item/clothing/glasses/scanner/meson/enable(var/mob/C)
 	var/area/A = get_area(src)
 	if(A.flags & NO_MESONS)
@@ -162,6 +164,8 @@
 	origin_tech = Tc_MAGNETS + "=3;" + Tc_ENGINEERING + "=3"
 	actions_types = list(/datum/action/item_action/toggle_goggles)
 	// vision_flags = SEE_OBJS
+
+	glasses_fit = TRUE
 
 	var/list/image/showing = list()
 	var/mob/viewing

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -38,11 +38,11 @@
 			if(!H.equip_to_slot_if_possible(stored_shoes, slot_shoes))
 				stored_shoes.forceMove(get_turf(src))
 			stored_shoes = null
-		return FALSE
+		return CANNOT_EQUIP
 
 	if(stored_shoes)
 		to_chat(H, "<span class='info'>You slip \the [src] on over \the [stored_shoes].</span>")
-	return TRUE
+	return CAN_EQUIP
 
 /obj/item/clothing/shoes/magboots/unequipped(mob/living/carbon/human/H, var/from_slot = null)
 	..()


### PR DESCRIPTION
Near-sighted bros rise up!

![harrharr](https://user-images.githubusercontent.com/7573912/83974521-17035a80-a8ee-11ea-95a0-c6a7c8f37bf2.gif)


:cl:
* rscadd: Just like magboots can be worn over smaller shoes, Science Googles, Thermals, Mesons, and Material Scanners can now be worn over prescription glasses (which are now of size Tiny).