### PR TITLE
Fixes Nuke Ops Grenade Launcher (and the regular one as well) firing when getting put in a backpack

### DIFF
--- a/code/modules/reagents/grenade_launcher.dm
+++ b/code/modules/reagents/grenade_launcher.dm
@@ -38,6 +38,8 @@
 			to_chat(user, "<span class='warning'>The [src.name] cannot hold more grenades.</span>")
 
 /obj/item/weapon/gun/grenadelauncher/afterattack(atom/A, mob/living/user, flag, params, struggle = 0)
+	if(flag)
+		return //we're placing gun on a table or in backpack
 
 	if (istype(target, /obj/item/weapon/storage/backpack ))
 		return


### PR DESCRIPTION
![syndieship](https://user-images.githubusercontent.com/7573912/83979491-0f07e280-a90f-11ea-9f48-8176084c478e.png)

One too many Op team died for this to get done.

:cl:
* bugfix: The grenade launcher (both normal and syndicate) no longer fire when you try to place them in a backpack.