### PR TITLE
Revert "Fixes cargo carts being able to load anchored atoms (#26696)"

### DIFF
--- a/code/game/objects/structures/vehicles/carts/cargo.dm
+++ b/code/game/objects/structures/vehicles/carts/cargo.dm
@@ -19,14 +19,11 @@
 
 /obj/machinery/cart/cargo/MouseDropTo(var/atom/movable/C, mob/user)
 	..()
-	if(C.anchored)
-		to_chat(user, "\The [C] is fastened to the floor!")
-		return
 	if(user.incapacitated() || user.lying)
 		return
 	if(!Adjacent(user) || !user.Adjacent(src) || !src.Adjacent(C))
 		return
-	if(is_locking(/datum/locking_category/cargocart) || istype(C, /obj/machinery/cart/))
+	if (is_locking(/datum/locking_category/cargocart) || istype(C, /obj/machinery/cart/))
 		return
 
 	load(C)
@@ -48,7 +45,7 @@
 	if(!isturf(C.loc)) //To prevent the loading from stuff from someone's inventory, which wouldn't get handled properly.
 		return FALSE
 
-	if(C.locked_to || C.is_locking())
+	if(C.locked_to || C.is_locking() || C.anchored)
 		return FALSE
 
 	if(get_dist(C, src) > 1 || is_locking(/datum/locking_category/cargocart))


### PR DESCRIPTION
<!-- [gameplay] -->
This reverts #26696.
People like it, so why remove it? 
![image](https://user-images.githubusercontent.com/57536342/83980107-0b5d6700-a8e1-11ea-85d1-f019361f0d93.png)

:cl:
 * tweak: allows cargo carts to load anchored atoms