### PR TITLE
Fixes #26737

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -303,7 +303,7 @@ var/MAX_EXPLOSION_RANGE = 14
 // bitflags for clothing parts
 
 #define FULL_TORSO		(UPPER_TORSO|LOWER_TORSO)
-#define FACE			(EYES|MOUTH|BEARD)
+#define FACE			(EYES|MOUTH|BEARD)	//38912
 #define BEARD			32768
 #define FULL_HEAD		(HEAD|EYES|MOUTH|EARS)
 #define LEGS			(LEG_LEFT|LEG_RIGHT) 		// 24
@@ -327,7 +327,7 @@ var/MAX_EXPLOSION_RANGE = 14
 #define HIDEHEADHAIR 		65536
 #define MASKHEADHAIR		131072
 #define HIDEBEARDHAIR		BEARD
-#define HIDEHAIR			(HIDEHEADHAIR|HIDEBEARDHAIR)
+#define HIDEHAIR			(HIDEHEADHAIR|HIDEBEARDHAIR)//98304
 #define	HIDESUITSTORAGE		LOWER_TORSO
 
 // bitflags for the percentual amount of protection a piece of clothing which covers the body part offers.

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -59,18 +59,18 @@
 	var/list/obscured = list()
 
 	if(wear_suit)
-		if(is_slot_hidden(wear_suit.body_parts_covered, HIDEGLOVES, 0, wear_suit.body_parts_visible_override))
+		if(is_slot_hidden(wear_suit.body_parts_covered, (HIDEGLOVES), 0, wear_suit.body_parts_visible_override))
 			obscured |= slot_gloves
-		if(is_slot_hidden(wear_suit.body_parts_covered, HIDEJUMPSUIT, 0, wear_suit.body_parts_visible_override))
+		if(is_slot_hidden(wear_suit.body_parts_covered, (HIDEJUMPSUIT), 0, wear_suit.body_parts_visible_override))
 			obscured |= slot_w_uniform
-		if(is_slot_hidden(wear_suit.body_parts_covered, HIDESHOES, 0, wear_suit.body_parts_visible_override))
+		if(is_slot_hidden(wear_suit.body_parts_covered, (HIDESHOES), 0, wear_suit.body_parts_visible_override))
 			obscured |= slot_shoes
 	if(head)
-		if(is_slot_hidden(head.body_parts_covered, HIDEMASK, 0, wear_suit.body_parts_visible_override))
+		if(is_slot_hidden(head.body_parts_covered, (HIDEMASK), 0, head.body_parts_visible_override))
 			obscured |= slot_wear_mask
-		if(is_slot_hidden(head.body_parts_covered, HIDEEYES, 0, wear_suit.body_parts_visible_override))
+		if(is_slot_hidden(head.body_parts_covered, (HIDEEYES), 0, head.body_parts_visible_override))
 			obscured |= slot_glasses
-		if(is_slot_hidden(head.body_parts_covered, HIDEEARS, 0, wear_suit.body_parts_visible_override))
+		if(is_slot_hidden(head.body_parts_covered, (HIDEEARS), 0, head.body_parts_visible_override))
 			obscured |= slot_ears
 	if(obscured.len > 0)
 		return obscured
@@ -97,7 +97,7 @@
 		ignore_slot = (equipped == wear_mask) ? MOUTH : 0
 		if(!equipped)
 			continue
-		else if(is_slot_hidden(equipped.body_parts_covered,hidden_flags,ignore_slot,equipped.body_parts_visible_override))
+		else if(is_slot_hidden(equipped.body_parts_covered,(hidden_flags),ignore_slot,equipped.body_parts_visible_override))
 			return 1
 	return 0
 

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -1056,7 +1056,7 @@ var/global/list/damage_icon_parts = list()
 
 /mob/living/carbon/human/update_inv_wear_mask(var/update_icons=1)
 	overlays -= obj_overlays[FACEMASK_LAYER]
-	if( wear_mask && !check_hidden_head_flags(HIDEMASK) && wear_mask.is_visible())
+	if( wear_mask && !check_hidden_head_flags(EYES) && !check_hidden_head_flags(MOUTH) && !check_hidden_head_flags(BEARD) && wear_mask.is_visible())
 		var/obj/abstract/Overlays/O = obj_overlays[FACEMASK_LAYER]
 		O.overlays.len = 0
 		wear_mask.screen_loc = ui_mask	//TODO
@@ -1315,19 +1315,19 @@ var/global/list/damage_icon_parts = list()
 	if(!W || gcDestroyed)
 		return
 
-	if(is_slot_hidden(W.body_parts_covered, HIDEHEADHAIR, 0, W.body_parts_visible_override) || is_slot_hidden(W.body_parts_covered, MASKHEADHAIR, 0, W.body_parts_visible_override) || is_slot_hidden(W.body_parts_covered, HIDEBEARDHAIR, 0, W.body_parts_visible_override))
+	if(is_slot_hidden(W.body_parts_covered, (HIDEHEADHAIR), 0, W.body_parts_visible_override) || is_slot_hidden(W.body_parts_covered, (MASKHEADHAIR), 0, W.body_parts_visible_override) || is_slot_hidden(W.body_parts_covered, (HIDEBEARDHAIR), 0, W.body_parts_visible_override))
 		update_hair()
-	if(is_slot_hidden(W.body_parts_covered, HIDEMASK, 0, W.body_parts_visible_override))
+	if(is_slot_hidden(W.body_parts_covered, (EYES), 0, W.body_parts_visible_override) || is_slot_hidden(W.body_parts_covered, (MOUTH), 0, W.body_parts_visible_override) || is_slot_hidden(W.body_parts_covered, (BEARD), 0, W.body_parts_visible_override))
 		update_inv_wear_mask()
-	if(is_slot_hidden(W.body_parts_covered, HIDEGLOVES, 0, W.body_parts_visible_override))
+	if(is_slot_hidden(W.body_parts_covered, (HIDEGLOVES), 0, W.body_parts_visible_override))
 		update_inv_gloves()
-	if(is_slot_hidden(W.body_parts_covered, HIDESHOES, 0, W.body_parts_visible_override))
+	if(is_slot_hidden(W.body_parts_covered, (HIDESHOES), 0, W.body_parts_visible_override))
 		update_inv_shoes()
-	if(is_slot_hidden(W.body_parts_covered, HIDEJUMPSUIT, 0, W.body_parts_visible_override))
+	if(is_slot_hidden(W.body_parts_covered, (HIDEJUMPSUIT), 0, W.body_parts_visible_override))
 		update_inv_w_uniform()
-	if(is_slot_hidden(W.body_parts_covered, HIDEEYES, 0, W.body_parts_visible_override))
+	if(is_slot_hidden(W.body_parts_covered, (HIDEEYES), 0, W.body_parts_visible_override))
 		update_inv_glasses()
-	if(is_slot_hidden(W.body_parts_covered, HIDEEARS, 0, W.body_parts_visible_override))
+	if(is_slot_hidden(W.body_parts_covered, (HIDEEARS), 0, W.body_parts_visible_override))
 		update_inv_ears()
 
 proc/is_slot_hidden(var/clothes, var/slot = -1,var/ignore_slot = 0, var/visibility_override = 0)
@@ -1340,7 +1340,7 @@ proc/is_slot_hidden(var/clothes, var/slot = -1,var/ignore_slot = 0, var/visibili
 		true_body_parts_covered = 0
 	if(visibility_override & slot)//lets you see things like glasses behind transparent helmets, while still hiding hair or other specific flags.
 		return 0
-	if(true_body_parts_covered & ignore_slot)
+	if((true_body_parts_covered) & ignore_slot)
 		true_body_parts_covered ^= ignore_slot
 	if((true_body_parts_covered & slot) == slot)
 		return 1


### PR DESCRIPTION
Fixes #26737

:cl:
* bugfix: Fixed gas masks showing through various headgears. Masks in general are now only visible if eyes, mouth, and beard are all visible, and not just one of them.