### PR TITLE
Punchline/gingerbread bug fix

### DIFF
--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -392,6 +392,8 @@
 	icon_state = ""
 	mineral = "gingerbread"
 	density = 1
+	opacity = 1
+	anchored = 1
 
 //-----------wtf?-----------start
 /obj/structure/falsewall/clown

--- a/code/modules/projectiles/projectile/hookshot.dm
+++ b/code/modules/projectiles/projectile/hookshot.dm
@@ -325,6 +325,6 @@
 					K.forceMove(endLocation, no_tp=1, harderforce=0, glide_size_override=0)
 					var/oldIcon = K.icon
 					K.icon = 'icons/obj/wind_up.dmi'//flick is dumb, it works dumb
-					K.alpha = 100
+					K.alpha = OPAQUE
 					flick("bananaphaz_flick", K)
 					K.icon = oldIcon


### PR DESCRIPTION
[bugfix]
Today I learned alpha goes up to 255, not 100. 
Changed the animation on Punchline's phase out accordingly. Also made gingerbread falsewalls opaque so that all the secrets in that vault aren't immediately obvious.

:cl:
 * rscdel: The potential threat of an clown based invisible monkey menace