### PR TITLE
Adds a new credit song if the station was nuked, adds support for context-sensitive credits

### DIFF
--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -453,8 +453,6 @@ var/datum/controller/gameticker/ticker
 		spawn
 			declare_completion()
 
-			end_credits.on_round_end()
-
 			gameend_time = world.time / 10
 			if(config.map_voting)
 				//testing("Vote picked [chosen_map]")
@@ -482,6 +480,8 @@ var/datum/controller/gameticker/ticker
 				feedback_set_details("end_proper","\proper completion")
 				if(!delay_end && !watchdog.waiting)
 					to_chat(world, "<span class='notice'><B>Restarting in [restart_timeout/10] seconds</B></span>")
+
+			end_credits.on_round_end()
 
 			if(blackbox)
 				if(config.map_voting)

--- a/code/modules/credits/credits.dm
+++ b/code/modules/credits/credits.dm
@@ -31,7 +31,7 @@ var/global/datum/credits/end_credits = new
 	var/finalized = FALSE
 	var/js_args = list()
 
-	var/do_not_change_credits_song = 0 //If toggled on, will not change the selection of credits songs.
+	var/change_credits_song = 1 //If positive, will change the credits song based on criteria
 	var/audio_link = "http://ss13.moe/media/m2/source/roundend/credits/Frolic_Luciano_Michelini.mp3"
 	var/list/classic_roundend_jingles = list(
 		"http://ss13.moe/media/m2/source/roundend/jingleclassic/bangindonk.mp3",
@@ -127,7 +127,7 @@ var/global/datum/credits/end_credits = new
  */
 /datum/credits/proc/on_round_end()
 	draft()
-	if(!do_not_change_credits_song)
+	if(change_credits_song)
 		determine_round_end_song()
 	for(var/client/C in clients)
 		C.credits_audio(preload_only = TRUE) //Credits preference set to "No Reruns" should still preload, since we still don't know if the episode is a rerun. If audio time comes and the episode is a rerun, then we can start preloading the jingle instead.
@@ -268,9 +268,7 @@ var/global/datum/credits/end_credits = new
 //This proc will run at round-end and run various conditions to change audio_link
 //Currently only hosts one additional song
 /datum/credits/proc/determine_round_end_song()
-	if(do_not_change_credits_song) //How did this happen?
-		return
-	var/list/candidates
+	var/list/candidates = list()
 	if(ticker.station_was_nuked)
 		candidates += pick("http://ss13.moe/media/m2/source/roundend/credits/RA2_Blow_It_Up.mp3",
 						"http://ss13.moe/media/m2/source/roundend/credits/Castanets_You_Are_The_Blood.mp3",

--- a/code/modules/credits/credits.dm
+++ b/code/modules/credits/credits.dm
@@ -126,6 +126,7 @@ var/global/datum/credits/end_credits = new
  */
 /datum/credits/proc/on_round_end()
 	draft()
+	determine_round_end_song()
 	for(var/client/C in clients)
 		C.credits_audio(preload_only = TRUE) //Credits preference set to "No Reruns" should still preload, since we still don't know if the episode is a rerun. If audio time comes and the episode is a rerun, then we can start preloading the jingle instead.
 
@@ -261,6 +262,15 @@ var/global/datum/credits/end_credits = new
 		var/true_story_bro = "<br>[pick("BASED ON","INSPIRED BY","A RE-ENACTMENT OF")] [pick("A TRUE STORY","REAL EVENTS","THE EVENTS ABOARD [uppertext(station_name())]")]"
 		cast_string += "<h3>[true_story_bro]</h3><br>In memory of those that did not make it.<br>[english_list(corpses)].<br>"
 	cast_string += "</div><br>"
+
+//This proc will run at round-end and run various conditions to change audio_link
+//Currently only hosts one additional song
+/datum/credits/proc/determine_round_end_song()
+	var/list/candidates
+	if(ticker.station_was_nuked)
+		candidates += "http://ss13.moe/media/m2/source/roundend/credits/RA2_Blow_It_Up.mp3"
+	if(candidates)
+		audio_link = pick(candidates)
 
 /proc/gender_credits(var/mob/living/carbon/human/H)
 	if(H.mind && H.mind.key)

--- a/code/modules/credits/credits.dm
+++ b/code/modules/credits/credits.dm
@@ -31,6 +31,7 @@ var/global/datum/credits/end_credits = new
 	var/finalized = FALSE
 	var/js_args = list()
 
+	var/do_not_change_credits_song = 0 //If toggled on, will not change the selection of credits songs.
 	var/audio_link = "http://ss13.moe/media/m2/source/roundend/credits/Frolic_Luciano_Michelini.mp3"
 	var/list/classic_roundend_jingles = list(
 		"http://ss13.moe/media/m2/source/roundend/jingleclassic/bangindonk.mp3",
@@ -126,7 +127,8 @@ var/global/datum/credits/end_credits = new
  */
 /datum/credits/proc/on_round_end()
 	draft()
-	determine_round_end_song()
+	if(!do_not_change_credits_song)
+		determine_round_end_song()
 	for(var/client/C in clients)
 		C.credits_audio(preload_only = TRUE) //Credits preference set to "No Reruns" should still preload, since we still don't know if the episode is a rerun. If audio time comes and the episode is a rerun, then we can start preloading the jingle instead.
 
@@ -266,9 +268,15 @@ var/global/datum/credits/end_credits = new
 //This proc will run at round-end and run various conditions to change audio_link
 //Currently only hosts one additional song
 /datum/credits/proc/determine_round_end_song()
+	if(do_not_change_credits_song) //How did this happen?
+		return
 	var/list/candidates
 	if(ticker.station_was_nuked)
-		candidates += "http://ss13.moe/media/m2/source/roundend/credits/RA2_Blow_It_Up.mp3"
+		candidates += pick("http://ss13.moe/media/m2/source/roundend/credits/RA2_Blow_It_Up.mp3",
+						"http://ss13.moe/media/m2/source/roundend/credits/Castanets_You_Are_The_Blood.mp3",
+						"http://ss13.moe/media/m2/source/roundend/credits/Twin_Peaks_Theme_Instrumental.mp3",
+						"http://ss13.moe/media/m2/source/roundend/credits/Mike_Oldfield_Nuclear.mp3")
+
 	if(candidates)
 		audio_link = pick(candidates)
 

--- a/code/modules/credits/credits.dm
+++ b/code/modules/credits/credits.dm
@@ -274,7 +274,8 @@ var/global/datum/credits/end_credits = new
 	if(ticker.station_was_nuked)
 		candidates += pick("http://ss13.moe/media/m2/source/roundend/credits/RA2_Blow_It_Up.mp3",
 						"http://ss13.moe/media/m2/source/roundend/credits/Castanets_You_Are_The_Blood.mp3",
-						"http://ss13.moe/media/m2/source/roundend/credits/Twin_Peaks_Theme_Instrumental.mp3",
+						"http://ss13.moe/media/m2/source/roundend/credits/Julee_Cruise_Falling_Intrumental.mp3",
+						"http://ss13.moe/media/m2/source/roundend/credits/Julee_Cruise_The_World_Spins.mp3",
 						"http://ss13.moe/media/m2/source/roundend/credits/Mike_Oldfield_Nuclear.mp3")
 
 	if(candidates)


### PR DESCRIPTION
I'll need @I-VAPE-VOX-CLOACA-EVERY-DAY-OF-MY-LIFE to tell me if moving on_round_end further down the line breaks anything
I'll need @d3athrow to add a bunch of songs to the media repo

:cl:
 * rscadd: Added a new credits song, it will play if the station was nuked.