### PR TITLE
Instrument fix

### DIFF
--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -260,6 +260,8 @@
 	else if(href_list["tempo"])
 		tempo = sanitize_tempo(tempo + text2num(href_list["tempo"]))
 	else if(href_list["play"])
+		if(playing)
+			return
 		playing = 1
 		spawn()
 			playsong(usr)


### PR DESCRIPTION
Ever since the nanoUI rework instruments were missing a sanity check, and because of that you could just spam click the "play" button

:cl:
 * bugfix: You can no longer repeatedly play the same instrument and in the process both slow down the server and create a zone of silence around you.