### PR TITLE
Rigsuits 3.1 : You can (not) UI

### DIFF
--- a/__DEFINES/_macros.dm
+++ b/__DEFINES/_macros.dm
@@ -230,6 +230,10 @@
 
 #define isbelt(O) (istype(O, /obj/item/weapon/storage/belt) || istype(O, /obj/item/red_ribbon_arm))
 
+#define isrig(O) (istype(O, /obj/item/clothing/suit/space/rig))
+
+#define isrighelmet(O) (istype(O, /obj/item/clothing/head/helmet/space/rig))
+
 #define format_examine(A,B) "<span class = 'info'><a HREF='?src=\ref[user];lookitem=\ref[A]'>[B].</a></span>"
 
 //Macros for roles/antags

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -214,13 +214,13 @@
 	..()
 	name = "Toggle [target]"
 
-/datum/action/item_action/toggle_rig_helmet
-	name = "Toggle rig helmet"
+/datum/action/item_action/toggle_rig_suit
+	name = "Toggle rig suit"
 
-/datum/action/item_action/toggle_rig_helmet/Trigger()
-	if(IsAvailable() && owner && target && istype(target,/obj/item/clothing/suit/space/rig))
+/datum/action/item_action/toggle_rig_suit/Trigger()
+	if(IsAvailable() && owner && target && isrig(target))
 		var/obj/item/clothing/suit/space/rig/R = target
-		R.toggle_helmet(owner)
+		R.toggle_suit()
 		return TRUE
 	return FALSE
 
@@ -228,7 +228,7 @@
 	name = "Toggle rig light"
 
 /datum/action/item_action/toggle_rig_light/Trigger()
-	if(IsAvailable() && target && istype(target, /obj/item/clothing/head/helmet/space/rig))
+	if(IsAvailable() && target && isrighelmet(target))
 		var/obj/item/clothing/head/helmet/space/rig/R = target
 		R.toggle_light(owner)
 		return TRUE

--- a/code/game/machinery/suit_modifier.dm
+++ b/code/game/machinery/suit_modifier.dm
@@ -49,6 +49,8 @@
 	.=..()
 
 /obj/machinery/suit_modifier/attack_hand(mob/user)
+	if(!isliving(user))
+		return
 	if(is_locking(/mob/living/carbon/human))
 		playsound(src, 'sound/machines/buzz-two.ogg', 50, 0)
 		say("Unit Occupied.", class = "binaryradio")
@@ -74,8 +76,7 @@
 	suit_overlay.icon_state = "suitmodifier_working"
 	overlays.Add(suit_overlay)
 	var/obj/item/clothing/suit/space/rig/R = H.is_wearing_item(/obj/item/clothing/suit/space/rig, slot_wear_suit)
-	if(H.head && istype(H.head, R.head_type))
-		R.toggle_helmet(H)
+	R.deactivate_suit(git )
 	var/list/modules_to_activate = list()
 	for(var/obj/item/rig_module/RM in modules_to_install)
 		if(locate(RM.type) in R.modules) //One already installed
@@ -104,7 +105,7 @@
 	unlock_atom(H)
 	overlays.Remove(suit_overlay)
 	suit_overlay.icon_state = null
-	R.toggle_helmet(H)
+	R.initialize_suit()
 	use_power = 1
 
 /obj/machinery/suit_modifier/get_cell()

--- a/code/game/machinery/suit_modifier.dm
+++ b/code/game/machinery/suit_modifier.dm
@@ -76,7 +76,7 @@
 	suit_overlay.icon_state = "suitmodifier_working"
 	overlays.Add(suit_overlay)
 	var/obj/item/clothing/suit/space/rig/R = H.is_wearing_item(/obj/item/clothing/suit/space/rig, slot_wear_suit)
-	R.deactivate_suit(git )
+	R.deactivate_suit()
 	var/list/modules_to_activate = list()
 	for(var/obj/item/rig_module/RM in modules_to_install)
 		if(locate(RM.type) in R.modules) //One already installed

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -466,6 +466,17 @@
 				if(suit)
 					suit.clean_blood()
 					suit.decontaminate()
+					if(isrig(suit))
+						var/obj/item/clothing/suit/space/rig/rigsuit = suit
+						if(rigsuit.H) //Internal helmet
+							rigsuit.H.clean_blood()
+							rigsuit.H.decontaminate()
+						if(rigsuit.G) //Internal Gloves
+							rigsuit.G.clean_blood()
+							rigsuit.G.decontaminate()
+						if(rigsuit.MB) //Internal Boots
+							rigsuit.MB.clean_blood()
+							rigsuit.MB.decontaminate()
 				if(mask)
 					mask.clean_blood()
 					mask.decontaminate()

--- a/code/game/objects/items/devices/modkit.dm
+++ b/code/game/objects/items/devices/modkit.dm
@@ -17,11 +17,8 @@
 	finished = new/list(2)
 
 	parts[1] =	1
-	original[1] = /obj/item/clothing/head/helmet/space/rig
-	finished[1] = /obj/item/clothing/head/cardborg
-	parts[2] =	1
-	original[2] = /obj/item/clothing/suit/space/rig
-	finished[2] = /obj/item/clothing/suit/cardborg
+	original[1] = /obj/item/clothing/suit/space/rig
+	finished[1] = /obj/item/clothing/suit/cardborg
 
 /obj/item/device/modkit/afterattack(obj/O, mob/user as mob)
 	if(get_dist(O,user) > 1)//For all those years you could use it at any range, what the actual fuck?
@@ -74,14 +71,11 @@
 	finished = new/list(3)
 
 	parts[1] =	1
-	original[1] = /obj/item/clothing/head/helmet/space/rig/security
-	finished[1] = /obj/item/clothing/head/helmet/space/rig/security/stormtrooper
-	parts[2] =	1
-	original[2] = /obj/item/clothing/suit/space/rig/security
-	finished[2] = /obj/item/clothing/suit/space/rig/security/stormtrooper
-	parts[3] =	3
-	original[3] = /obj/item/weapon/gun/energy/laser
-	finished[3] = /obj/item/weapon/gun/energy/laser/blaster
+	original[1] = /obj/item/clothing/suit/space/rig/security
+	finished[1] = /obj/item/clothing/suit/space/rig/security/stormtrooper
+	parts[2] =	3
+	original[2] = /obj/item/weapon/gun/energy/laser
+	finished[2] = /obj/item/weapon/gun/energy/laser/blaster
 
 // /vg/: Old atmos hardsuit.
 /obj/item/device/modkit/gold_rig
@@ -94,11 +88,8 @@
 	finished = new/list(2)
 
 	parts[1] =	1
-	original[1] = /obj/item/clothing/head/helmet/space/rig/atmos
-	finished[1] = /obj/item/clothing/head/helmet/space/rig/atmos/gold
-	parts[2] =	1
-	original[2] = /obj/item/clothing/suit/space/rig/atmos
-	finished[2] = /obj/item/clothing/suit/space/rig/atmos/gold
+	original[1] = /obj/item/clothing/suit/space/rig/atmos
+	finished[1] = /obj/item/clothing/suit/space/rig/atmos/gold
 
 /obj/item/device/modkit/fatsec_rig
 	name = "gut expansion hardsuit modification kit"
@@ -123,26 +114,6 @@
 	parts =	list(1) //less shitcode when you only got one part
 	original = list(/obj/item/clothing/suit/space/rig/syndi)
 	finished = list(/obj/item/clothing/suit/space/rig/syndi/commander)
-
-
-/* /vg/ - Not needed
-/obj/item/device/modkit/tajaran
-	name = "tajara hardsuit modification kit"
-	desc = "A kit containing all the needed tools and parts to modify a hardsuit for another user. This one looks like it's meant for Tajara."
-
-/obj/item/device/modkit/tajaran/New()
-	..()
-	parts = new/list(2)
-	original = new/list(2)
-	finished = new/list(2)
-
-	parts[1] =	1
-	original[1] = /obj/item/clothing/head/helmet/space/rig
-	finished[1] = /obj/item/clothing/head/helmet/space/rig/tajara
-	parts[2] =	1
-	original[2] = /obj/item/clothing/suit/space/rig
-	finished[2] = /obj/item/clothing/suit/space/rig/tajara
-*/
 
 /obj/item/device/modkit/spur_parts
 	name = "suspicious set of metallic parts"

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -121,6 +121,9 @@
 		if(istype(L))
 			src.corpseshoes = pick(L)
 		M.equip_to_slot_or_del(new src.corpseshoes(M), slot_shoes)
+		if(isrig(M.wear_suit))
+			var/obj/item/clothing/suit/space/rig/R = M.wear_suit
+			R.initialize_suit()
 
 	if(src.corpsegloves)
 		var/list/L = src.corpsegloves

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -114,6 +114,9 @@
 		if(istype(L))
 			src.corpsesuit = pick(L)
 		M.equip_to_slot_or_del(new src.corpsesuit(M), slot_wear_suit)
+		if(isrig(M.wear_suit))
+			var/obj/item/clothing/suit/space/rig/R = M.wear_suit
+			R.initialize_suit()
 
 	if(src.corpseshoes)
 		var/list/L = src.corpseshoes
@@ -121,9 +124,6 @@
 		if(istype(L))
 			src.corpseshoes = pick(L)
 		M.equip_to_slot_or_del(new src.corpseshoes(M), slot_shoes)
-		if(isrig(M.wear_suit))
-			var/obj/item/clothing/suit/space/rig/R = M.wear_suit
-			R.initialize_suit()
 
 	if(src.corpsegloves)
 		var/list/L = src.corpsegloves

--- a/code/modules/clothing/spacesuits/rig.dm
+++ b/code/modules/clothing/spacesuits/rig.dm
@@ -1,3 +1,11 @@
+#define ONLY_DEPLOY 1
+#define ONLY_RETRACT 2
+#define HARDSUIT_HEADGEAR "h_head"
+#define HARDSUIT_GLOVES "h_gloves"
+#define HARDSUIT_BOOTS "h_boots"
+
+var/list/all_hardsuit_pieces = list(HARDSUIT_HEADGEAR,HARDSUIT_GLOVES,HARDSUIT_BOOTS)
+
 //Regular rig suits
 /obj/item/clothing/head/helmet/space/rig
 	name = "engineering hardsuit helmet"
@@ -41,14 +49,14 @@
 /obj/item/clothing/head/helmet/space/rig/proc/check_light()
 	if(no_light) //There's no light on the helmet
 		if(on) //The helmet light is currently on
-			on = 0 //Force it off
+			on = FALSE //Force it off
 			update_brightness() //Update as neccesary
 		actions_types.Remove(/datum/action/item_action/toggle_rig_light)//Disable the action button (which is only used to toggle the light, in theory)
 	else //We have a light
 		actions_types |= /datum/action/item_action/toggle_rig_light //Make sure we restore the action button
 
-/obj/item/clothing/head/helmet/space/rig/process()
-	if(on && rig)
+/obj/item/clothing/head/helmet/space/rig/process() //Helmets are directly linked to the suit's power cell, they don't need it to be activated at all.
+	if(on && rig)	
 		if(!rig.cell.use(1) || rig.loc != loc)
 			toggle_light()
 
@@ -62,6 +70,8 @@
 		update_brightness()
 		if(user)
 			user.update_inv_head()
+	else
+		to_chat(user, "<span class = 'warning'>\The [src] has no linked suit!</span>")
 
 /obj/item/clothing/head/helmet/space/rig/proc/update_brightness()
 	if(on)
@@ -79,11 +89,19 @@
 /obj/item/clothing/head/helmet/space/rig/unequipped(mob/living/carbon/human/user, var/from_slot = null)
 	..()
 	if(from_slot == slot_head && istype(user))
-		if(rig && rig.is_worn_by(user))
-			rig.deactivate_suit(user)
-			if(on)
-				toggle_light(user)
-			rig = null
+		if(rig && rig.is_worn_by(user) && rig.activated)
+			rig.deactivate_suit(FALSE) //Do not unequip everything if they're just retracting their helmet.
+		if(on)
+			toggle_light(user)
+
+/obj/item/clothing/head/helmet/space/rig/equipped(mob/living/carbon/human/user, var/slot)
+	..()
+	if(slot == slot_head && !rig && user.is_wearing_item(/obj/item/clothing/suit/space/rig, slot_wear_suit)) //Autolink, if possible.
+		var/obj/item/clothing/suit/space/rig/RS = user.wear_suit
+		if(RS.H) //They already have a helmet.
+			return
+		if(RS.head_type && istype(src, RS.head_type)) //It's my suit! It was made for me!
+			rig = user.wear_suit
 
 /obj/item/clothing/suit/space/rig
 	name = "engineering hardsuit"
@@ -97,27 +115,70 @@
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/weapon/storage/bag/ore,/obj/item/device/t_scanner,/obj/item/weapon/pickaxe, /obj/item/device/rcd, /obj/item/weapon/wrench/socket)
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	pressure_resistance = 200 * ONE_ATMOSPHERE
-	var/obj/item/clothing/head/helmet/space/rig/H = null
-	var/head_type = /obj/item/clothing/head/helmet/space/rig
-	var/obj/item/weapon/cell/cell = null
-	var/cell_type = /obj/item/weapon/cell/high //The cell_type we're actually using
+	actions_types = list(/datum/action/item_action/toggle_rig_suit)
+
+	var/activated = FALSE
 	var/list/modules = list()
-	actions_types = list(/datum/action/item_action/toggle_rig_helmet)
+	var/list/initial_modules = list()
+
+	var/obj/item/clothing/head/helmet/space/rig/H = null
+	var/obj/item/clothing/gloves/G = null
+	var/obj/item/clothing/shoes/magboots/MB = null
+	var/obj/item/weapon/tank/T = null
+	var/obj/item/weapon/cell/cell = null
+	var/list/all_hardsuit_parts = list()
+	var/list/external_hardsuit_parts = list()
+
+	var/head_type = /obj/item/clothing/head/helmet/space/rig
+	var/boots_type =  null
+	var/gloves_type = null
+	var/tank_type = null
+	var/cell_type = /obj/item/weapon/cell/high //The cell_type we're actually using
+
+	var/mob/living/carbon/human/wearer = null
 
 /obj/item/clothing/suit/space/rig/New()
 	..()
-	cell = new cell_type
-	H = new head_type
+	if(cell_type)
+		cell = new cell_type(src)
+	if(head_type)
+		H = new head_type(src)
+		H.canremove = FALSE
+		H.rig = src
+	if(gloves_type)
+		G = new gloves_type(src)
+		G.canremove = FALSE
+	if(boots_type)
+		MB = new boots_type(src)
+		MB.canremove = FALSE
+	if(tank_type)
+		T = new tank_type(src)
+	for(var/part in list(H,G,T,MB))
+		all_hardsuit_parts += part
+	for(var/part in list(H,G,MB))
+		external_hardsuit_parts += part
+	if(initial_modules && initial_modules.len)
+		for(var/path in initial_modules)
+			var/obj/item/rig_module/new_module = new path(src)
+			modules += new_module
+	processing_objects |= src
 
 /obj/item/clothing/suit/space/rig/Destroy()
-	qdel(cell)
-	cell = null
-	if(H && (H.loc == src || !H.loc))
-		qdel(H)
+	processing_objects -= src
+	for(var/obj/item/I in all_hardsuit_parts)
+		if(I && (I.loc == src || !I.loc))
+			qdel(I)
 	H = null
+	G = null
+	T = null
+	MB = null
 	for(var/obj/M in modules)
 		qdel(M)
-	modules.Cut()
+	modules = null
+	if(cell)
+		qdel(cell)
+	cell = null
+	wearer = null
 	..()
 
 /obj/item/clothing/suit/space/rig/examine(mob/user)
@@ -125,616 +186,191 @@
 	for(var/obj/item/rig_module/M in modules)
 		M.examine_addition(user)
 
+/obj/item/clothing/suit/space/rig/get_cell()
+	return cell
+
+/obj/item/clothing/suit/space/rig/equipped(mob/living/carbon/human/user, var/slot)
+	if(slot == slot_wear_suit)
+		wearer = user
+	..()
+
 /obj/item/clothing/suit/space/rig/unequipped(mob/living/carbon/human/user, var/from_slot = null)
+	if(from_slot == slot_wear_suit)
+		deactivate_suit(TRUE)
+	wearer = null
 	..()
-	if(from_slot == slot_wear_suit && istype(user))
-		deactivate_suit(user)
 
-/obj/item/clothing/suit/space/rig/proc/toggle_helmet(mob/living/carbon/human/user)
-	if(!user.is_wearing_item(src, slot_wear_suit))
+/obj/item/clothing/suit/space/rig/dropped()
+	..()
+	for(var/piece in all_hardsuit_pieces)
+		toggle_piece(piece, wearer, ONLY_RETRACT)
+	wearer = null
+
+/obj/item/clothing/suit/space/rig/proc/is_fully_equipped()
+	if(!istype(wearer) || loc != wearer || wearer.wear_suit != src)
+		return FALSE
+	if(head_type && !(H && wearer.head == H))
+		return FALSE
+	if(gloves_type && !(G && wearer.gloves == G))
+		return FALSE
+	if(boots_type && !(MB && wearer.shoes == MB))
+		return FALSE
+	return TRUE
+
+/obj/item/clothing/suit/space/rig/process()
+	if(gcDestroyed)
 		return
-	if(H)
-		if(!user.head)
-			to_chat(user, "<span class = 'notice'>\The [H] extends from \the [src].</span>")
-			user.equip_to_slot(H, slot_head)
-			H.rig = src
-			H = null
-			initialize_suit(user)
-	else
-		if(user.head && istype(user.head, head_type))
-			var/obj/I = user.head
-			to_chat(user, "<span class = 'notice'>\The [I] retracts into \the [src].</span>")
-			user.u_equip(I,0)
-			I.forceMove(src)
-			H = I
-			deactivate_suit(user)
 
+	check_builtin_pieces()
 
-/obj/item/clothing/suit/space/rig/proc/initialize_suit(mob/user)
+	if(!is_fully_equipped())
+		deactivate_suit(FALSE)
+
+	if(activated)
+		process_rig_modules()
+
+/obj/item/clothing/suit/space/rig/proc/process_rig_modules()
+	if(istype(wearer) && wearer.timestopped)
+		return
+
 	for(var/obj/item/rig_module/R in modules)
-		R.activate(user,src)
+		if(R.activated && R.active_power_usage)
+			if(!cell.use(R.active_power_usage))
+				R.say_to_wearer("Not enough power available in [src]!")
+				R.deactivate()	
+				continue
+			R.do_process()
 
-/obj/item/clothing/suit/space/rig/proc/deactivate_suit(mob/user)
+/obj/item/clothing/suit/space/rig/proc/check_builtin_pieces()
+	var/mob/living/M = null
+
+	for(var/obj/item/piece in external_hardsuit_parts)
+		if(piece && piece.loc != src && !(wearer && wearer.is_wearing_item(piece)))
+			if(istype(piece.loc, /mob/living))
+				M = piece.loc
+				M.drop_from_inventory(piece)
+			piece.forceMove(src)
+
+/obj/item/clothing/suit/space/rig/proc/toggle_suit()
+	if(!wearer.is_wearing_item(src, slot_wear_suit))
+		return
+	if(!activated)
+		initialize_suit()
+	else
+		deactivate_suit(FALSE, HARDSUIT_HEADGEAR)
+
+/obj/item/clothing/suit/space/rig/proc/initialize_suit(var/equip_all = TRUE)
+	if(equip_all)
+		for(var/piece in all_hardsuit_pieces)
+			toggle_piece(piece, wearer, ONLY_DEPLOY)
+	if(is_fully_equipped()) //Fully equipped? GOOD!
+		if(H && wearer.is_wearing_item(H, slot_head)) //I know we JUST ran a check, but still...
+			H.toggle_light(wearer) //Lights on
+			if(T && (wearer.wear_mask?.clothing_flags & MASKINTERNALS)) //We have a built-in tank, mask and our built-in helmet is equipped.
+				wearer.toggle_internals(wearer, T)
+		for(var/obj/item/rig_module/module in modules)
+			if(!module.activated) //Skip what is already activated.
+				module.activate(wearer,src)
+		activated = TRUE
+
+/obj/item/clothing/suit/space/rig/proc/deactivate_suit(var/unequip_all = TRUE, var/unequip_single_piece = null)
+	if(unequip_all)
+		for(var/piece in all_hardsuit_pieces)
+			toggle_piece(piece, wearer, ONLY_RETRACT)
+	if(unequip_single_piece)
+		toggle_piece(unequip_single_piece,wearer)
 	for(var/obj/item/rig_module/R in modules)
-		R.deactivate(user,src)
+		R.deactivate()
+	activated = FALSE
 
-/obj/item/clothing/suit/space/rig/attackby(obj/W, mob/user)
-	if(!H && istype(W, head_type) && user.drop_item(W, src, force_drop = 1))
-		to_chat(user, "<span class = 'notice'>You attach \the [W] to \the [src].</span>")
-		H = W
+/obj/item/clothing/suit/space/rig/proc/toggle_piece(var/piece, var/mob/living/initiator, var/deploy_mode)
+	if(!cell || !cell.charge)
 		return
-	..()
-
-
-//Chief Engineer's rig
-/obj/item/clothing/head/helmet/space/rig/elite
-	name = "advanced hardsuit helmet"
-	desc = "An advanced helmet designed for work in a hazardous, low pressure environment. Shines with a high polish."
-	icon_state = "rig0-white"
-	item_state = "ce_helm"
-	_color = "white"
-	species_fit = list(GREY_SHAPED, INSECT_SHAPED)
-	species_restricted = list("exclude",VOX_SHAPED)
-	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
-	clothing_flags = PLASMAGUARD
-
-/obj/item/clothing/suit/space/rig/elite
-	icon_state = "rig-white"
-	name = "advanced hardsuit"
-	species_fit = list(GREY_SHAPED, INSECT_SHAPED)
-	species_restricted = list("exclude",VOX_SHAPED)
-	desc = "An advanced suit that protects against hazardous, low pressure environments. Shines with a high polish."
-	item_state = "ce_hardsuit"
-	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
-	clothing_flags = PLASMAGUARD
-	cell_type = /obj/item/weapon/cell/super
-	head_type = /obj/item/clothing/head/helmet/space/rig/elite
-
-//Mining rig
-/obj/item/clothing/head/helmet/space/rig/mining
-	name = "mining hardsuit helmet"
-	desc = "A special helmet designed for work in a hazardous, low pressure environment. Has reinforced plating."
-	icon_state = "rig0-mining"
-	item_state = "rig0-mining"
-	_color = "mining"
-	species_fit = list(GREY_SHAPED, INSECT_SHAPED)
-	species_restricted = list("exclude",VOX_SHAPED)
-	pressure_resistance = 40 * ONE_ATMOSPHERE
-	clothing_flags = GOLIATHREINFORCE
-
-/obj/item/clothing/suit/space/rig/mining
-	icon_state = "rig-mining"
-	name = "mining hardsuit"
-	desc = "A special suit that protects against hazardous, low pressure environments. Has reinforced plating."
-	item_state = "rig-mining"
-	species_fit = list(INSECT_SHAPED)
-	species_restricted = list("exclude",VOX_SHAPED)
-	pressure_resistance = 40 * ONE_ATMOSPHERE
-	clothing_flags = GOLIATHREINFORCE
-	head_type = /obj/item/clothing/head/helmet/space/rig/mining
-
-//Syndicate rig
-/obj/item/clothing/head/helmet/space/rig/syndi
-	name = "blood-red hardsuit helmet"
-	desc = "An advanced helmet designed for work in special operations. A tag on it says \"Property of Gorlex Marauders\"."
-	icon_state = "rig0-syndi"
-	item_state = "syndie_helm"
-	species_fit = list(VOX_SHAPED, GREY_SHAPED, SKRELL_SHAPED, UNATHI_SHAPED, TAJARAN_SHAPED, INSECT_SHAPED)
-	_color = "syndi"
-	armor = list(melee = 60, bullet = 50, laser = 30,energy = 15, bomb = 35, bio = 100, rad = 60)
-	actions_types = list(/datum/action/item_action/toggle_helmet_camera) //This helmet does not have a light, but we'll do as if
-	siemens_coefficient = 0.6
-	var/obj/machinery/camera/camera
-	pressure_resistance = 40 * ONE_ATMOSPHERE
-
-	species_restricted = null
-
-/obj/item/clothing/head/helmet/space/rig/syndi/attack_self(mob/user)
-	if(camera)
-		..(user)
-	else
-		camera = new /obj/machinery/camera(src)
-		camera.network = list(CAMERANET_NUKE)
-		cameranet.removeCamera(camera)
-		camera.c_tag = user.name
-		to_chat(user, "<span class='notice'>User scanned as [camera.c_tag]. Camera activated.</span>")
-
-/obj/item/clothing/head/helmet/space/rig/syndi/examine(mob/user)
-	..()
-	if(get_dist(user,src) <= 1)
-		to_chat(user, "<span class='info'>This helmet has a built-in camera. It's [camera ? "" : "in"]active.</span>")
-
-/obj/item/clothing/suit/space/rig/syndi
-	icon_state = "rig-syndi"
-	name = "blood-red hardsuit"
-	desc = "An advanced suit that protects against injuries during special operations. A tag on it says \"Property of Gorlex Marauders\"."
-	item_state = "syndie_hardsuit"
-	species_fit = list(VOX_SHAPED, SKRELL_SHAPED, UNATHI_SHAPED, TAJARAN_SHAPED, INSECT_SHAPED)
-	w_class = W_CLASS_MEDIUM
-	armor = list(melee = 60, bullet = 50, laser = 30, energy = 15, bomb = 35, bio = 100, rad = 60)
-	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/weapon/gun,/obj/item/ammo_storage,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/melee/energy/sword,/obj/item/weapon/handcuffs)
-	siemens_coefficient = 0.6
-	pressure_resistance = 40 * ONE_ATMOSPHERE
-
-	species_restricted = null
-	head_type = /obj/item/clothing/head/helmet/space/rig/syndi
-
-/obj/item/clothing/head/helmet/space/rig/syndi/commander
-	name = "large blood-red hardsuit helmet"
-	desc = "An advanced helmet designed for work in special operations. Slightly bulkier than usual. A tag on it says \"Property of Gorlex Marauders\"."
-	armor = list(melee = 65, bullet = 55, laser = 35, energy = 20, bomb = 40, bio = 100, rad = 60)
-	icon_state = "rig0-syndi-commander"
-	item_state = "syndie_helm_commander"
-	_color = "syndi-commander"
-	species_fit = list()
-
-/obj/item/clothing/suit/space/rig/syndi/commander
-	name = "large blood-red hardsuit"
-	desc = "An advanced suit that protects against injuries during special operations. Slightly bulkier than usual. A tag on it says \"Property of Gorlex Marauders\"."
-	icon_state = "rig-syndi-commander"
-	armor = list(melee = 65, bullet = 55, laser = 35, energy = 20, bomb = 40, bio = 100, rad = 60)
-	head_type = /obj/item/clothing/head/helmet/space/rig/syndi/commander
-	species_fit = list()
-
-//Elite Strike Team rig
-/obj/item/clothing/head/helmet/space/rig/syndicate_elite
-	name = "syndicate elite hardsuit helmet"
-	desc = "The result of reverse-engineered deathsquad technology combined with nuclear operative hardsuit."
-	icon_state = "rig0-syndicate_elite"
-	item_state = "syndicate-helm-black"
-	_color = "syndicate_elite"
-	armor = list(melee = 65, bullet = 55, laser = 35,energy = 20, bomb = 40, bio = 100, rad = 60)
-	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
-	siemens_coefficient = 0.4
-	clothing_flags = PLASMAGUARD
-
-	species_restricted = null
-
-/obj/item/clothing/suit/space/rig/syndicate_elite
-	icon_state = "rig-syndicate_elite"
-	name = "syndicate elite hardsuit"
-	desc = "The result of reverse-engineered deathsquad technology combined with nuclear operative hardsuit."
-	item_state = "syndicate-black"
-	w_class = W_CLASS_MEDIUM
-	armor = list(melee = 70, bullet = 60, laser = 40, energy = 25, bomb = 50, bio = 100, rad = 60)
-	allowed = list(/obj/item/weapon/gun/osipr, /obj/item/device/flashlight, /obj/item/weapon/tank, /obj/item/weapon/gun, /obj/item/ammo_storage, /obj/item/ammo_casing, /obj/item/weapon/melee/baton, /obj/item/weapon/melee/energy/sword, /obj/item/weapon/handcuffs)
-	siemens_coefficient = 0.5
-	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
-	clothing_flags = PLASMAGUARD
-
-	species_restricted = null
-	head_type = /obj/item/clothing/head/helmet/space/rig/syndicate_elite
-
-
-//Wizard Rig
-/obj/item/clothing/head/helmet/space/rig/wizard
-	name = "gem-encrusted hardsuit helmet"
-	desc = "A bizarre gem-encrusted helmet that radiates magical energies."
-	icon_state = "rig0-wiz"
-	item_state = "wiz_helm"
-	_color = "wiz"
-	species_fit = list(GREY_SHAPED)
-	species_restricted = list("exclude",VOX_SHAPED)
-	armor = list(melee = 40, bullet = 20, laser = 20,energy = 20, bomb = 35, bio = 100, rad = 60)
-	siemens_coefficient = 0.7
-
-	wizard_garb = 1
-
-	species_restricted = null
-
-/obj/item/clothing/head/helmet/space/rig/wizard/acidable()
-	return 0
-
-/obj/item/clothing/suit/space/rig/wizard
-	icon_state = "rig-wiz"
-	name = "gem-encrusted hardsuit"
-	desc = "A bizarre gem-encrusted suit that radiates magical energies."
-	item_state = "wiz_hardsuit"
-	w_class = W_CLASS_MEDIUM
-	species_fit = list(GREY_SHAPED)
-	species_restricted = list("exclude",VOX_SHAPED)
-	armor = list(melee = 40, bullet = 20, laser = 20,energy = 20, bomb = 35, bio = 100, rad = 60)
-	siemens_coefficient = 0.7
-
-	wizard_garb = 1
-
-	species_restricted = null
-	head_type = /obj/item/clothing/head/helmet/space/rig/wizard
-	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/weapon/teleportation_scroll,/obj/item/weapon/gun/energy/staff)
-
-/obj/item/clothing/suit/space/rig/wizard/acidable()
-	return 0
-
-/obj/item/clothing/head/helmet/space/rig/wizard/lich_king
-	name = "helm of domination"
-	desc = "Worn by a lich with too much summoning time on their hands."
-	icon_state = "rig0-domination"
-	item_state = "lich_helm"
-	_color = "domination"
-	species_restricted = list(UNDEAD_SHAPED)
-
-/obj/item/clothing/suit/space/rig/wizard/lich_king
-	name = "plate of the damned"
-	desc = "Previous incarnations were rumoured to make the user invulnerable. This itteration is famous for having its own in-built cloak."
-	icon_state = "lichking_armour"
-	item_state = "lichking_armour"
-	species_restricted = list(UNDEAD_SHAPED)
-	body_parts_covered = ARMS|LEGS|FULL_TORSO|HANDS
-
-//Medical Rig
-/obj/item/clothing/head/helmet/space/rig/medical
-	name = "medical hardsuit helmet"
-	desc = "A special helmet designed for work in a hazardous, low pressure environment. Has minor radiation shielding."
-	icon_state = "rig0-medical"
-	item_state = "medical_helm"
-	_color = "medical"
-	species_fit = list(GREY_SHAPED, INSECT_SHAPED)
-	species_restricted = list("exclude",VOX_SHAPED)
-	pressure_resistance = 40 * ONE_ATMOSPHERE
-
-/obj/item/clothing/suit/space/rig/medical
-	icon_state = "rig-medical"
-	name = "medical hardsuit"
-	desc = "A special suit that protects against hazardous, low pressure environments. Has minor radiation shielding."
-	item_state = "medical_hardsuit"
-	species_fit = list(GREY_SHAPED, INSECT_SHAPED)
-	species_restricted = list("exclude",VOX_SHAPED)
-	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/weapon/storage/firstaid,/obj/item/device/healthanalyzer,/obj/item/stack/medical, /obj/item/roller)
-	pressure_resistance = 40 * ONE_ATMOSPHERE
-	head_type = /obj/item/clothing/head/helmet/space/rig/medical
-
-
-	//Security
-/obj/item/clothing/head/helmet/space/rig/security
-	name = "security hardsuit helmet"
-	desc = "A special helmet designed for work in a hazardous low pressure environment. Has an additional layer of armor."
-	icon_state = "rig0-sec"
-	item_state = "sec_helm"
-	_color = "sec"
-	species_fit = list(GREY_SHAPED, INSECT_SHAPED)
-	species_restricted = list("exclude",VOX_SHAPED)
-	armor = list(melee = 60, bullet = 10, laser = 30, energy = 5, bomb = 45, bio = 100, rad = 10)
-	siemens_coefficient = 0.7
-	pressure_resistance = 40 * ONE_ATMOSPHERE
-
-/obj/item/clothing/suit/space/rig/security
-	icon_state = "rig-sec"
-	name = "security hardsuit"
-	desc = "A special suit that protects against hazardous low pressure environments. Has an additional layer of armor."
-	item_state = "sec_hardsuit"
-	species_fit = list(GREY_SHAPED, INSECT_SHAPED)
-	species_restricted = list("exclude",VOX_SHAPED)
-	armor = list(melee = 60, bullet = 10, laser = 30, energy = 5, bomb = 45, bio = 100, rad = 10)
-	allowed = list(
-		/obj/item/weapon/gun,
-		/obj/item/device/flashlight,
-		/obj/item/weapon/tank,
-		/obj/item/weapon/melee/baton,
-		/obj/item/weapon/reagent_containers/spray/pepper,
-		/obj/item/ammo_storage,
-		/obj/item/ammo_casing,
-		/obj/item/weapon/handcuffs,
-		/obj/item/weapon/bikehorn/baton,
-		/obj/item/weapon/blunderbuss,
-		/obj/item/weapon/legcuffs/bolas,
-	)
-	siemens_coefficient = 0.7
-	pressure_resistance = 40 * ONE_ATMOSPHERE
-	head_type = /obj/item/clothing/head/helmet/space/rig/security
-
-/obj/item/clothing/suit/space/rig/security/fat
-	name = "expanded security hardsuit"
-	desc = "An armored suit that has been expanded to accomodate a donut gut."
-	clothing_flags = ONESIZEFITSALL
-
-/obj/item/clothing/suit/space/rig/security/fat/step_action()
-	if(!ishuman(loc))
+	if(!wearer)
 		return
-	var/mob/living/carbon/human/H = loc
-	if(!(M_FAT in H.mutations))
-		if(!heat_conductivity) //Not fat and not yet broken
-			sterility = 50
-			heat_conductivity = 0.5
-			to_chat(H,"<span class='danger'>\The [src] is too loose and can't form a perfect seal around your gaunt body!</span>")
-	else
-		if(heat_conductivity) //Fat, but not yet restored
-			sterility = 100
-			heat_conductivity = SPACESUIT_HEAT_CONDUCTIVITY //0
-			to_chat(H,"<span class='good'>\The [src] forms a robust seal around your girth!</span>")
+	if(initiator == wearer && wearer.incapacitated()) // If the initiator isn't wearing the suit it's probably something like an AI/Bus.
+		return
 
-	// stormtroopers
+	var/obj/item/check_slot
+	var/equip_to
+	var/obj/item/use_obj
 
-/obj/item/clothing/head/helmet/space/rig/security/stormtrooper
-	icon_state = "rig0-storm"
-	_color = "storm"
-	name = "stormtrooper helmet"
-	desc = "Even with the finest vision enhancement tech, you still can't hit shit."
-	no_light = 1
+	switch(piece)
+		if(HARDSUIT_HEADGEAR)
+			equip_to = slot_head
+			use_obj = H
+			check_slot = wearer.head
+		if(HARDSUIT_GLOVES)
+			equip_to = slot_gloves
+			use_obj = G
+			check_slot = wearer.gloves
+		if(HARDSUIT_BOOTS)
+			equip_to = slot_shoes
+			use_obj = MB
+			check_slot = wearer.shoes
 
-/obj/item/clothing/suit/space/rig/security/stormtrooper
-	icon_state = "rig-storm"
-	name = "stormtrooper hardsuit"
-	desc = "Now even more vulnerable to teddy bears!"
-	head_type = /obj/item/clothing/head/helmet/space/rig/security/stormtrooper
+	if(use_obj)
+		if(check_slot == use_obj && deploy_mode != ONLY_DEPLOY)
+			var/mob/living/carbon/human/holder
+			if(use_obj)
+				holder = use_obj.loc
+				if(istype(holder))
+					if(use_obj && check_slot == use_obj)
+						if(wearer.remove_from_mob(use_obj,))
+							to_chat(wearer, "<font color='blue'><b>Your [use_obj.name] retracts swiftly.</b></font>")
+						use_obj.forceMove(src)
+		else
+			if(deploy_mode != ONLY_RETRACT)
+				if(check_slot && check_slot == use_obj)
+					return
+				use_obj.forceMove(wearer)
+				if(!wearer.equip_to_slot_if_possible(use_obj, equip_to, 0, 1))
+					use_obj.forceMove(src)
+					if(check_slot)
+						if(initiator)
+							to_chat(initiator, "<span class='danger'>You are unable to deploy \the [use_obj.name] as \the [check_slot] [check_slot.gender == PLURAL ? "are" : "is"] in the way.</span>")
+						return
+				else
+					to_chat(wearer, "<span class='notice'>\The [use_obj.name] deploys swiftly.</span>")
 
-//Atmospherics Rig (BS12)
-/obj/item/clothing/head/helmet/space/rig/atmos
-	desc = "A special helmet designed for work in hazardous low pressure environments. Has reduced radiation shielding to allow for greater mobility."
-	name = "atmospherics hardsuit helmet"
-	icon_state = "rig0-atmos"
-	item_state = "atmos_helm"
-	_color = "atmos"
-	species_fit = list(GREY_SHAPED, INSECT_SHAPED)
-	species_restricted = list("exclude",VOX_SHAPED)
-	clothing_flags = PLASMAGUARD
-	armor = list(melee = 40, bullet = 0, laser = 0, energy = 0, bomb = 25, bio = 100, rad = 0)
-	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
+/obj/item/clothing/suit/space/rig/verb/toggle_helmet()
 
-/obj/item/clothing/suit/space/rig/atmos
-	desc = "A special suit that protects against hazardous low pressure environments. Has reduced radiation shielding to allow for greater mobility."
-	icon_state = "rig-atmos"
-	name = "atmos hardsuit"
-	item_state = "atmos_hardsuit"
-	species_restricted = list("exclude",VOX_SHAPED)
-	clothing_flags = PLASMAGUARD
-	species_fit = list(GREY_SHAPED, INSECT_SHAPED)
-	armor = list(melee = 40, bullet = 0, laser = 0, energy = 0, bomb = 25, bio = 100, rad = 0)
-	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
-	head_type = /obj/item/clothing/head/helmet/space/rig/atmos
+	set name = "Toggle Helmet"
+	set desc = "Deploys or retracts your helmet."
+	set category = "Hardsuit"
+	set hidden = TRUE
+	set src = usr.contents
 
-//Firefighting/Atmos RIG (old /vg/)
-/obj/item/clothing/head/helmet/space/rig/atmos/gold
-	desc = "A special helmet designed for work in hazardous low pressure environments and extreme temperatures. In other words, perfect for atmos."
-	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE*2
-	name = "atmos hardsuit helmet"
-	icon_state = "rig0-atmos_gold"
-	item_state = "atmos_gold_helm"
-	_color = "atmos_gold"
-	species_fit = list(GREY_SHAPED, INSECT_SHAPED)
-	species_restricted = list("exclude",VOX_SHAPED)
-	no_light = 1
+	if(!wearer || !wearer.is_wearing_item(src, slot_wear_suit))
+		to_chat(usr,"<span class='warning'>\The [src] is not being worn.</span>") 
+		return
 
-/obj/item/clothing/suit/space/rig/atmos/gold
-	desc = "A special suit that protects against hazardous low pressure environments and extreme temperatures. In other words, perfect for atmos."
-	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE*4
-	gas_transfer_coefficient = 0.80
-	permeability_coefficient = 0.25
-	icon_state = "rig-atmos_gold"
-	name = "atmos hardsuit"
-	item_state = "atmos_gold_hardsuit"
-	slowdown = HARDSUIT_SLOWDOWN_HIGH
-	species_fit = list(GREY_SHAPED,INSECT_SHAPED)
-	armor = list(melee = 30, bullet = 5, laser = 40,energy = 5, bomb = 35, bio = 100, rad = 60)
-	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/weapon/storage/backpack/satchel_norm,/obj/item/device/t_scanner,/obj/item/weapon/pickaxe, /obj/item/device/rcd, /obj/item/weapon/extinguisher, /obj/item/weapon/extinguisher/foam, /obj/item/weapon/storage/toolbox, /obj/item/weapon/wrench/socket)
-	head_type = /obj/item/clothing/head/helmet/space/rig/atmos/gold
+	toggle_piece(HARDSUIT_HEADGEAR,wearer)
 
-//ADMINBUS RIGS. SOVIET + NAZI
-/obj/item/clothing/head/helmet/space/rig/nazi
-	name = "nazi hardhelmet"
-	desc = "This is the face of das vaterland's top elite. Gas or energy are your only escapes."
-	item_state = "rig0-nazi"
-	icon_state = "rig0-nazi"
-	species_fit = list(GREY_SHAPED)
-	species_restricted = list("exclude",VOX_SHAPED)//GAS THE VOX
-	armor = list(melee = 40, bullet = 30, laser = 30, energy = 15, bomb = 35, bio = 100, rad = 20)
-	_color = "nazi"
-	pressure_resistance = 40 * ONE_ATMOSPHERE
-	color_on = "#FF2222"
+/obj/item/clothing/suit/space/rig/verb/toggle_boots()
 
-/obj/item/clothing/suit/space/rig/nazi
-	name = "nazi hardsuit"
-	desc = "The attire of a true krieger. All shall fall, and only das vaterland will remain."
-	item_state = "rig-nazi"
-	icon_state = "rig-nazi"
-	species_fit = list(GREY_SHAPED)
-	species_restricted = list("exclude",VOX_SHAPED)//GAS THE VOX
-	armor = list(melee = 40, bullet = 30, laser = 30, energy = 15, bomb = 35, bio = 100, rad = 20)
-	allowed = list(/obj/item/weapon/gun,/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/weapon/melee/)
-	pressure_resistance = 40 * ONE_ATMOSPHERE
-	head_type = /obj/item/clothing/head/helmet/space/rig/nazi
+	set name = "Toggle Boots"
+	set desc = "Deploys or retracts your boots."
+	set category = "Hardsuit"
+	set hidden = TRUE
+	set src = usr.contents
 
-/obj/item/clothing/head/helmet/space/rig/soviet
-	name = "soviet hardhelmet"
-	desc = "Crafted with the pride of the proletariat. The vengeful gaze of the visor roots out all fascists and capitalists."
-	item_state = "rig0-soviet"
-	icon_state = "rig0-soviet"
-	species_fit = list(GREY_SHAPED)
-	species_restricted = list("exclude",VOX_SHAPED)//HET
-	armor = list(melee = 40, bullet = 30, laser = 30, energy = 15, bomb = 35, bio = 100, rad = 20)
-	_color = "soviet"
-	pressure_resistance = 40 * ONE_ATMOSPHERE
+	if(!wearer || !wearer.is_wearing_item(src, slot_wear_suit))
+		to_chat(usr,"<span class='warning'>\The [src] is not being worn.</span>") 
+		return
 
-/obj/item/clothing/suit/space/rig/soviet
-	name = "soviet hardsuit"
-	desc = "Crafted with the pride of the proletariat. The last thing the enemy sees is the bottom of this armor's boot."
-	item_state = "rig-soviet"
-	icon_state = "rig-soviet"
-	slowdown = 1
-	species_fit = list(GREY_SHAPED)
-	species_restricted = list("exclude",VOX_SHAPED)//HET
-	armor = list(melee = 40, bullet = 30, laser = 30, energy = 15, bomb = 35, bio = 100, rad = 20)
-	allowed = list(/obj/item/weapon/gun,/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/weapon/melee/)
-	pressure_resistance = 40 * ONE_ATMOSPHERE
-	head_type = /obj/item/clothing/head/helmet/space/rig/soviet
+	toggle_piece(HARDSUIT_BOOTS,wearer)
 
-//Death squad rig
-/obj/item/clothing/head/helmet/space/rig/deathsquad
-	name = "deathsquad helmet"
-	desc = "That's not red paint. That's real blood."
-	icon_state = "rig0-deathsquad"
-	item_state = "rig0-deathsquad"
-	armor = list(melee = 65, bullet = 55, laser = 35,energy = 20, bomb = 40, bio = 100, rad = 60)
-	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
-	siemens_coefficient = 0.2
-	species_fit = list(GREY_SHAPED)
-	species_restricted = list("exclude",VOX_SHAPED)
-	_color = "deathsquad"
-	clothing_flags = PLASMAGUARD
+/obj/item/clothing/suit/space/rig/verb/toggle_gloves()
 
-/obj/item/clothing/suit/space/rig/deathsquad
-	name = "deathsquad suit"
-	desc = "A heavily armored suit that protects against a lot of things. Used in special operations."
-	icon_state = "rig-deathsquad"
-	item_state = "rig-deathsquad"
-	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_storage,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/handcuffs,/obj/item/weapon/tank/emergency_oxygen,/obj/item/weapon/tank/emergency_nitrogen,/obj/item/weapon/pinpointer,/obj/item/weapon/shield/energy,/obj/item/weapon/c4,/obj/item/weapon/disk/nuclear)
-	armor = list(melee = 80, bullet = 60, laser = 50,energy = 25, bomb = 60, bio = 100, rad = 60)
-	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
-	siemens_coefficient = 0.5
-	species_fit = list(GREY_SHAPED)
-	species_restricted = list("exclude",VOX_SHAPED)
-	clothing_flags = PLASMAGUARD
-	head_type = /obj/item/clothing/head/helmet/space/rig/deathsquad
+	set name = "Toggle Gloves"
+	set desc = "Deploys or retracts your gloves."
+	set category = "Hardsuit"
+	set hidden = TRUE
+	set src = usr.contents
 
+	if(!wearer || !wearer.is_wearing_item(src, slot_wear_suit))
+		to_chat(usr,"<span class='warning'>\The [src] is not being worn.</span>") 
+		return
 
-//Knight armour rigs
-/obj/item/clothing/head/helmet/space/rig/knight
-	name = "Space-Knight helm"
-	desc = "A well polished helmet belonging to a Space-Knight. Favored by space-jousters for its ability to stay on tight after being launched from a mass driver."
-	icon_state = "rig0-knight"
-	item_state = "rig0-knight"
-	armor = list(melee = 60, bullet = 40, laser = 40,energy = 30, bomb = 50, bio = 100, rad = 60)
-	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
-	siemens_coefficient = 0.2
-	species_fit = list(GREY_SHAPED)
-	species_restricted = list("exclude",VOX_SHAPED)
-	_color = "knight"
-	clothing_flags = PLASMAGUARD|GOLIATHREINFORCE
-
-
-/obj/item/clothing/suit/space/rig/knight
-	name = "Space-Knight armour"
-	desc = "A well polished set of armour belonging to a Space-Knight. Maidens Rescued in Space: 100, Maidens who have slept with me in Space: 0."
-	icon_state = "rig-knight"
-	item_state = "rig-knight"
-	allowed = list(/obj/item/weapon/gun,/obj/item/weapon/melee/baton,/obj/item/weapon/tank,/obj/item/weapon/shield/energy,/obj/item/weapon/claymore)
-	armor = list(melee = 60, bullet = 40, laser = 40,energy = 30, bomb = 50, bio = 100, rad = 60)
-	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
-	siemens_coefficient = 0.5
-	species_fit = list(GREY_SHAPED)
-	species_restricted = list("exclude",VOX_SHAPED)
-	clothing_flags = PLASMAGUARD|GOLIATHREINFORCE
-	head_type = /obj/item/clothing/head/helmet/space/rig/knight
-
-/obj/item/clothing/head/helmet/space/rig/knight/black
-	name = "Black Knight's helm"
-	desc = "An ominous black helmet with a gold trim. The small viewports create an intimidating look, while also making it nearly impossible to see anything."
-	icon_state = "rig0-blackknight"
-	item_state = "rig0-blackknight"
-	armor = list(melee = 70, bullet = 65, laser = 50,energy = 25, bomb = 60, bio = 100, rad = 60)
-	_color="blackknight"
-	species_fit = list(GREY_SHAPED)
-
-/obj/item/clothing/suit/space/rig/knight/black
-	name = "Black Knight's armour"
-	desc = "An ominous black suit of armour with a gold trim. Surprisingly good at preventing accidental loss of limbs."
-	icon_state = "rig-blackknight"
-	item_state = "rig-blackknight"
-	armor = list(melee = 70, bullet = 65, laser = 50,energy = 25, bomb = 60, bio = 100, rad = 60)
-	species_fit = list(GREY_SHAPED)
-	head_type = /obj/item/clothing/head/helmet/space/rig/knight/black
-
-/obj/item/clothing/head/helmet/space/rig/knight/solaire
-	name = "Solar helm"
-	desc = "A simple helmet. 'Made in Astora' is inscribed on the back."
-	icon_state = "rig0-solaire"
-	item_state = "rig0-solaire"
-	armor = list(melee = 60, bullet = 65, laser = 90,energy = 30, bomb = 60, bio = 100, rad = 100)
-	_color="solaire"
-
-/obj/item/clothing/suit/space/rig/knight/solaire
-	name = "Solar armour"
-	desc = "A solar powered hardsuit with a fancy insignia on the chest. Perfect for stargazers and adventurers alike."
-	icon_state = "rig-solaire"
-	item_state = "rig-solaire"
-	armor = list(melee = 60, bullet = 65, laser = 90,energy = 30, bomb = 60, bio = 100, rad = 100)
-	head_type = /obj/item/clothing/head/helmet/space/rig/knight/solaire
-
-
-/obj/item/clothing/suit/space/rig/t51b
-	name = "T-51b Power Armor"
-	desc = "Relic of a bygone era, the T-51b is powered by a TX-28 MicroFusion Pack, which holds enough fuel to power its internal hydraulics for a century!"
-	icon_state = "rig-t51b"
-	item_state = "rig-t51b"
-	armor = list(melee = 35, bullet = 35, laser = 40, energy = 40, bomb = 80, bio = 100, rad = 100)
-	head_type = /obj/item/clothing/head/helmet/space/rig/t51b
-
-/obj/item/clothing/head/helmet/space/rig/t51b
-	name = "T-51b Power Armor Helmet"
-	desc = "Relic of a bygone era, the T-51b is powered by a TX-28 MicroFusion Pack, which holds enough fuel to power its internal hydraulics for a century!"
-	icon_state = "rig0-t51b"
-	item_state = "rig0-t51b"
-	armor = list(melee = 35, bullet = 35, laser = 40, energy = 40, bomb = 80, bio = 100, rad = 100)
-	_color="t51b"
-
-//Ghetto space suit
-/obj/item/clothing/head/helmet/space/ghetto
-	name = "jury-rigged space-proof fire helmet"
-	desc = "A firefighter helmet and gas mask combined and jury-rigged into being 'space-proof' somehow."
-	icon_state = "ghettorig"
-	item_state = "ghettorig"
-	_color = "ghetto"
-	pressure_resistance = 4 * ONE_ATMOSPHERE
-	armor = list(melee = 30, bullet = 5, laser = 20,energy = 10, bomb = 20, bio = 10, rad = 20)
-	body_parts_covered = FULL_HEAD|BEARD
-	body_parts_visible_override = EYES
-	heat_conductivity = 0
-	gas_transfer_coefficient = 0.01
-	permeability_coefficient = 0.01
-	eyeprot = 0
-	species_fit = list(GREY_SHAPED, INSECT_SHAPED)
-
-/obj/item/clothing/suit/space/ghettorig
-	name = "jury-rigged space-proof firesuit"
-	icon_state = "ghettorig"
-	item_state = "ghettorig"
-	desc = "A firesuit jury-rigged into being 'space-proof' somehow."
-	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
-	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank/emergency_oxygen,/obj/item/weapon/tank/emergency_nitrogen,/obj/item/weapon/extinguisher)
-	pressure_resistance = 4 * ONE_ATMOSPHERE
-	slowdown = 5 //just wear a firesuit instead if you want to go fast
-	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
-	heat_conductivity = 0 //thanks, blanket
-	gas_transfer_coefficient = 0.60
-	permeability_coefficient = 0.30
-	species_fit = list(INSECT_SHAPED)
-
-//RoR survivor Rig
-/obj/item/clothing/suit/space/rig/ror
-	name = "survivor's hardsuit"
-	desc = "...and so he left the asteroid, with everything but his humanity."
-	icon_state = "rorsuit"
-	item_state = "rorsuit"
-	armor = list(melee = 40, bullet = 0, laser = 0,energy = 0, bomb = 65, bio = 100, rad = 50)
-	clothing_flags = GOLIATHREINFORCE
-	head_type = /obj/item/clothing/head/helmet/space/rig/ror
-
-/obj/item/clothing/head/helmet/space/rig/ror
-	name = "survivor's hardsuit helmet"
-	desc = "...and so he left the asteroid, with everything but his humanity."
-	icon_state = "rorhelm"
-	item_state = "rorhelm"
-	armor = list(melee = 40, bullet = 0, laser = 0,energy = 0, bomb = 65, bio = 100, rad = 50)
-	clothing_flags = GOLIATHREINFORCE
-
-/obj/item/clothing/head/helmet/space/rig/ror/update_icon()
-	return
-
-//[Xeno]Archaeologist Rig
-/obj/item/clothing/suit/space/rig/arch
-	name = "archaeology hardsuit"
-	desc = "A hardsuit designed for archaeology expeditions. It's yellow and orange materials provide high visibility and resistance to exotic particles."
-	icon_state = "rig-arch"
-	item_state = "arch_hardsuit"
-	armor = list(melee = 40, bullet = 0, laser = 0,energy = 0, bomb = 65, bio = 100, rad = 50)
-	head_type = /obj/item/clothing/head/helmet/space/rig/arch
-	species_fit = list(INSECT_SHAPED)
-
-/obj/item/clothing/head/helmet/space/rig/arch
-	name = "archaeology hardsuit helmet"
-	desc = "A hardsuit helmet designed for archaeology expeditions. It's orange materials provide high visibility and resistance to exotic particles."
-	icon_state = "rig0-arch"
-	item_state = "arch_helm"
-	_color = "arch"
-	armor = list(melee = 40, bullet = 0, laser = 0,energy = 0, bomb = 65, bio = 100, rad = 50)
-	color_on = "#81F9C6" //Aquamarine. A combination of the colors from the lamp and rail light.
-	species_fit = list(INSECT_SHAPED)
+	toggle_piece(HARDSUIT_GLOVES,wearer)

--- a/code/modules/clothing/spacesuits/rig.dm
+++ b/code/modules/clothing/spacesuits/rig.dm
@@ -102,6 +102,7 @@ var/list/all_hardsuit_pieces = list(HARDSUIT_HEADGEAR,HARDSUIT_GLOVES,HARDSUIT_B
 			return
 		if(RS.head_type && istype(src, RS.head_type)) //It's my suit! It was made for me!
 			rig = user.wear_suit
+			canremove = FALSE
 
 /obj/item/clothing/suit/space/rig
 	name = "engineering hardsuit"
@@ -316,7 +317,7 @@ var/list/all_hardsuit_pieces = list(HARDSUIT_HEADGEAR,HARDSUIT_GLOVES,HARDSUIT_B
 				holder = use_obj.loc
 				if(istype(holder))
 					if(use_obj && check_slot == use_obj)
-						if(wearer.remove_from_mob(use_obj,))
+						if(wearer.remove_from_mob(use_obj))
 							to_chat(wearer, "<font color='blue'><b>Your [use_obj.name] retracts swiftly.</b></font>")
 						use_obj.forceMove(src)
 		else

--- a/code/modules/clothing/spacesuits/rig_modules/rig_modules.dm
+++ b/code/modules/clothing/spacesuits/rig_modules/rig_modules.dm
@@ -5,34 +5,43 @@
 	icon_state = "std_mod"
 	var/mob/living/wearer
 	var/obj/item/clothing/suit/space/rig/rig
+	var/requires_component = TRUE //This module needs a removable component(helmet,gloves,boot,tank) and should be activated before they're deployed from the suit.
+	var/activated = FALSE
+	var/active_power_usage = 0 //Energy consumption per tick
 
 /obj/item/rig_module/proc/examine_addition(mob/user)
+	return
 
-/obj/item/rig_module/proc/activate(var/mob/user,var/obj/item/clothing/suit/space/rig/R)
+/obj/item/rig_module/proc/activate(var/mob/user,var/obj/item/clothing/suit/space/rig/R)//We do not set activated to TRUE in the default activate() proc.
 	wearer = user
 	rig = R
 
-/obj/item/rig_module/proc/deactivate(var/mob/user, var/obj/item/clothing/suit/space/rig/R)
+/obj/item/rig_module/proc/deactivate()
 	wearer = null
 	rig = null
+	activated = FALSE
+
+/obj/item/rig_module/proc/do_process()
+	return
 
 /obj/item/rig_module/proc/say_to_wearer(var/string)
 	ASSERT(wearer)
 	to_chat(wearer, "\The [src] reports: <span class = 'binaryradio'>[string]</span>")
 
 /obj/item/rig_module/speed_boost
-	name = "Rig speed module"
+	name = "rig speed module"
 	desc = "Self-lubricating joints allow for ease of movement when walking in a rigsuit."
+	active_power_usage = 10
 
 /obj/item/rig_module/speed_boost/activate(var/mob/user,var/obj/item/clothing/suit/space/rig/R)
 	..()
-	if(R.cell.use(500))
-		say_to_wearer("Speed module engaged.")
-		R.slowdown = max(1, slowdown/1.25)
+	say_to_wearer("Speed module engaged.")
+	rig.slowdown = max(1, slowdown/1.25)
+	activated = TRUE
 
-/obj/item/rig_module/speed_boost/deactivate(var/mob/user, var/obj/item/clothing/suit/space/rig/R)
+/obj/item/rig_module/speed_boost/deactivate()
+	rig.slowdown = initial(rig.slowdown)
 	..()
-	R.slowdown = initial(R.slowdown)
 
 /obj/item/rig_module/health_readout
 	name = "articulated spine"
@@ -47,6 +56,7 @@
 	desc = "When in atmosphere, syphons from the air to refill the tank connected to your internals."
 	var/gas_id
 	var/amount = 50
+	active_power_usage = 50
 
 /obj/item/rig_module/tank_refiller/activate(var/mob/user, var/obj/item/clothing/suit/space/rig/R)
 	..()
@@ -58,24 +68,22 @@
 		if(L)
 			var/datum/lung_gas/metabolizable/M = locate() in L.gasses
 			gas_id = M.id
-		processing_objects.Add(src)
+		activated = TRUE
 		say_to_wearer("Internals pressurizer online. Syphoning [gas_id] from environment to [H.internal].")
 	else
 		say_to_wearer("Internals pressurizer failed to find internals. Aborting.")
+		deactivate()
 
-/obj/item/rig_module/tank_refiller/deactivate(var/mob/user, var/obj/item/clothing/suit/space/rig/R)
-	..()
-	if(processing_objects.Find(src))
-		processing_objects.Remove(src)
-
-/obj/item/rig_module/tank_refiller/process()
+/obj/item/rig_module/tank_refiller/do_process()
 	if(!wearer || !ishuman(wearer))
-		processing_objects.Remove(src)
+		deactivate()
+		return
 
 	var/mob/living/carbon/human/H = wearer
 	if(!H.internal)
 		say_to_wearer("Internals pressurizer failed to find internals. Aborting.")
-		processing_objects.Remove(src)
+		deactivate()
+		return
 	else
 		var/obj/item/weapon/tank/T = H.internal
 		var/datum/gas_mixture/internals = T.air_contents
@@ -83,7 +91,7 @@
 			return
 		var/datum/gas_mixture/M = H.loc.return_air()
 		var/datum/gas_mixture/sample = M.remove_volume(amount) //So we don't just succ the entire room up
-		if(sample[gas_id] && rig.cell.use(50))
+		if(sample[gas_id])
 			var/pressure_delta = 10*ONE_ATMOSPHERE - internals.pressure //How much pressure we have left to work with
 			var/transfer_moles = (pressure_delta/R_IDEAL_GAS_EQUATION/internals.temperature)*internals.volume //How many moles can we transfer?
 			transfer_moles = min(sample[gas_id],transfer_moles)
@@ -94,8 +102,6 @@
 				sample.adjust_gas(gas_id, -transfer_moles)
 				internals.merge(to_add)
 				M.merge(sample)
-
-
 
 		//NEED TO GET MAXIMUM AMOUNT OF MOLES WITHOUT GOING OVER 10*ONE_ATMOSPHERE
 		//pressure = total_moles * R_IDEAL_GAS_EQUATION * temperature / volume
@@ -108,63 +114,39 @@
 
 /obj/item/rig_module/plasma_proof/activate(var/mob/user,var/obj/item/clothing/suit/space/rig/R)
 	..()
-	if(R.cell.use(250))
+	if(rig.cell && rig.cell.use(250))
 		say_to_wearer("Plasma seal initialized.")
-		R.clothing_flags |= PLASMAGUARD
-		if(R.H)
-			R.H.clothing_flags |= PLASMAGUARD
+		rig.clothing_flags |= PLASMAGUARD
+		if(rig.H)
+			rig.H.clothing_flags |= PLASMAGUARD
+		activated = TRUE
 
-/obj/item/rig_module/plasma_proof/deactivate(var/mob/user, var/obj/item/clothing/suit/space/rig/R)
-	..()
+/obj/item/rig_module/plasma_proof/deactivate()
 	say_to_wearer("Plasma seal disengaged.")
-	R.clothing_flags &= ~PLASMAGUARD
-	if(R.H)
-		R.H.clothing_flags &= ~PLASMAGUARD
+	rig.clothing_flags &= ~PLASMAGUARD
+	if(rig.H)
+		rig.H.clothing_flags &= ~PLASMAGUARD
+	..()
 
 /obj/item/rig_module/muscle_tissue
 	name = "artificial muscle tissue"
 	desc = "A flexible tissue with a number of sensors stretched between its surface and interior of the suit. When these sensors detected an impact, the artificial muscle reacts instantaneously, contracting and diffusing the damage."
+	active_power_usage = 100
 
 /obj/item/rig_module/muscle_tissue/activate(var/mob/user,var/obj/item/clothing/suit/space/rig/R)
 	..()
-	if(R.cell.use(1000))
-		user.mutations.Add(M_HULK) //I'M FUCKING INVINCIBLE!
-		user.update_mutations()
-		say_to_wearer("Reactive sensors online.")
-		processing_objects.Add(src)
-		R.cant_drop = TRUE
-		if(R.H)
-			R.H.cant_drop = TRUE
-		say_to_wearer("Safety lock enabled.")
-		return
-	say_to_wearer("<span class='warning'>Not enough power available in [R]!</span>")
+	wearer.mutations.Add(M_HULK) //I'M FUCKING INVINCIBLE!
+	wearer.update_mutations()
+	say_to_wearer("Reactive sensors online.")
+	rig.canremove = FALSE
+	say_to_wearer("Safety lock enabled.")
+	activated = TRUE
+	
 
-/obj/item/rig_module/muscle_tissue/deactivate(var/mob/user, var/obj/item/clothing/suit/space/rig/R)
-	..()
-	user.mutations.Remove(M_HULK)
-	user.update_mutations()
+/obj/item/rig_module/muscle_tissue/deactivate()
+	wearer.mutations.Remove(M_HULK)
+	wearer.update_mutations()
 	say_to_wearer("Reactive sensors offline.")
-	if(processing_objects.Find(src))
-		processing_objects.Remove(src)
-	R.cant_drop = FALSE
-	if(R.H)
-		R.H.cant_drop = FALSE
+	rig.canremove = TRUE
 	say_to_wearer("Safety lock disabled.")
-
-/obj/item/rig_module/muscle_tissue/Destroy()
-	if(processing_objects.Find(src))
-		processing_objects.Remove(src)
 	..()
-
-/obj/item/rig_module/muscle_tissue/process()
-	if(gcDestroyed)
-		return
-	if(!wearer || !ishuman(wearer))
-		processing_objects.Remove(src)
-		return
-	if(wearer.timestopped)
-		return
-	if(!rig.cell.use(50))
-		say_to_wearer("<span class='warning'>Not enough power available in [rig]!</span>")
-		deactivate(wearer,rig)
-		processing_objects.Remove(src)

--- a/code/modules/clothing/spacesuits/rig_modules/rig_modules.dm
+++ b/code/modules/clothing/spacesuits/rig_modules/rig_modules.dm
@@ -111,15 +111,15 @@
 /obj/item/rig_module/plasma_proof
 	name = "plasma-proof sealing authority"
 	desc = "Brings the suit it is installed into up to plasma environment standards."
+	active_power_usage = 5
 
 /obj/item/rig_module/plasma_proof/activate(var/mob/user,var/obj/item/clothing/suit/space/rig/R)
 	..()
-	if(rig.cell && rig.cell.use(250))
-		say_to_wearer("Plasma seal initialized.")
-		rig.clothing_flags |= PLASMAGUARD
-		if(rig.H)
-			rig.H.clothing_flags |= PLASMAGUARD
-		activated = TRUE
+	say_to_wearer("Plasma seal initialized.")
+	rig.clothing_flags |= PLASMAGUARD
+	if(rig.H)
+		rig.H.clothing_flags |= PLASMAGUARD
+	activated = TRUE
 
 /obj/item/rig_module/plasma_proof/deactivate()
 	say_to_wearer("Plasma seal disengaged.")

--- a/code/modules/clothing/spacesuits/rig_subtypes/rig_subtypes.dm
+++ b/code/modules/clothing/spacesuits/rig_subtypes/rig_subtypes.dm
@@ -1,0 +1,589 @@
+//Chief Engineer's rig
+/obj/item/clothing/head/helmet/space/rig/elite
+	name = "advanced hardsuit helmet"
+	desc = "An advanced helmet designed for work in a hazardous, low pressure environment. Shines with a high polish."
+	icon_state = "rig0-white"
+	item_state = "ce_helm"
+	_color = "white"
+	species_fit = list(GREY_SHAPED, INSECT_SHAPED)
+	species_restricted = list("exclude",VOX_SHAPED)
+	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
+	clothing_flags = PLASMAGUARD
+
+/obj/item/clothing/suit/space/rig/elite
+	icon_state = "rig-white"
+	name = "advanced hardsuit"
+	species_fit = list(GREY_SHAPED, INSECT_SHAPED)
+	species_restricted = list("exclude",VOX_SHAPED)
+	desc = "An advanced suit that protects against hazardous, low pressure environments. Shines with a high polish."
+	item_state = "ce_hardsuit"
+	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
+	clothing_flags = PLASMAGUARD
+	cell_type = /obj/item/weapon/cell/super
+	head_type = /obj/item/clothing/head/helmet/space/rig/elite
+
+/obj/item/clothing/head/helmet/space/rig/elite/test
+	name = "prototype advanced hardsuit helmet"
+	desc = "A bleeding-edge helmet designed to protect its wearer against extreme environments. The armored padding in this helmet was totally removed to give place for its experimental plasmovsky alloy."
+	armor = list(melee = 0, bullet = 0, laser = 0, energy = 100, bomb = 100, bio = 100, rad = 100)
+
+//Self-charging, auto-refiller high-test suit.
+/obj/item/clothing/suit/space/rig/elite/test
+	name = "prototype advanced hardsuit"
+	desc = "A bleeding-edge prototype designed to protect its wearer against extreme environments. The armored padding in this suit was totally removed to give place for its experimental plasmovsky alloy."
+	armor = list(melee = 0, bullet = 0, laser = 0, energy = 100, bomb = 100, bio = 100, rad = 100)
+	head_type = /obj/item/clothing/head/helmet/space/rig/elite/test
+	gloves_type = /obj/item/clothing/gloves/yellow
+	boots_type = /obj/item/clothing/shoes/magboots/elite
+	tank_type = /obj/item/weapon/tank/oxygen
+	cell_type = /obj/item/weapon/cell/rad/large
+	initial_modules = list(/obj/item/rig_module/health_readout, /obj/item/rig_module/tank_refiller)
+
+//Mining rig
+/obj/item/clothing/head/helmet/space/rig/mining
+	name = "mining hardsuit helmet"
+	desc = "A special helmet designed for work in a hazardous, low pressure environment. Has reinforced plating."
+	icon_state = "rig0-mining"
+	item_state = "rig0-mining"
+	_color = "mining"
+	species_fit = list(GREY_SHAPED, INSECT_SHAPED)
+	species_restricted = list("exclude",VOX_SHAPED)
+	pressure_resistance = 40 * ONE_ATMOSPHERE
+	clothing_flags = GOLIATHREINFORCE
+
+/obj/item/clothing/suit/space/rig/mining
+	icon_state = "rig-mining"
+	name = "mining hardsuit"
+	desc = "A special suit that protects against hazardous, low pressure environments. Has reinforced plating."
+	item_state = "rig-mining"
+	species_fit = list(INSECT_SHAPED)
+	species_restricted = list("exclude",VOX_SHAPED)
+	pressure_resistance = 40 * ONE_ATMOSPHERE
+	clothing_flags = GOLIATHREINFORCE
+	head_type = /obj/item/clothing/head/helmet/space/rig/mining
+
+//Syndicate rig
+/obj/item/clothing/head/helmet/space/rig/syndi
+	name = "blood-red hardsuit helmet"
+	desc = "An advanced helmet designed for work in special operations. A tag on it says \"Property of Gorlex Marauders\"."
+	icon_state = "rig0-syndi"
+	item_state = "syndie_helm"
+	species_fit = list(VOX_SHAPED, GREY_SHAPED, SKRELL_SHAPED, UNATHI_SHAPED, TAJARAN_SHAPED, INSECT_SHAPED)
+	_color = "syndi"
+	armor = list(melee = 60, bullet = 50, laser = 30,energy = 15, bomb = 35, bio = 100, rad = 60)
+	actions_types = list(/datum/action/item_action/toggle_helmet_camera) //This helmet does not have a light, but we'll do as if
+	siemens_coefficient = 0.6
+	var/obj/machinery/camera/camera
+	pressure_resistance = 40 * ONE_ATMOSPHERE
+
+	species_restricted = null
+
+/obj/item/clothing/head/helmet/space/rig/syndi/attack_self(mob/user)
+	if(camera)
+		..(user)
+	else
+		camera = new /obj/machinery/camera(src)
+		camera.network = list(CAMERANET_NUKE)
+		cameranet.removeCamera(camera)
+		camera.c_tag = user.name
+		to_chat(user, "<span class='notice'>User scanned as [camera.c_tag]. Camera activated.</span>")
+
+/obj/item/clothing/head/helmet/space/rig/syndi/examine(mob/user)
+	..()
+	if(get_dist(user,src) <= 1)
+		to_chat(user, "<span class='info'>This helmet has a built-in camera. It's [camera ? "" : "in"]active.</span>")
+
+/obj/item/clothing/suit/space/rig/syndi
+	icon_state = "rig-syndi"
+	name = "blood-red hardsuit"
+	desc = "An advanced suit that protects against injuries during special operations. A tag on it says \"Property of Gorlex Marauders\"."
+	item_state = "syndie_hardsuit"
+	species_fit = list(VOX_SHAPED, SKRELL_SHAPED, UNATHI_SHAPED, TAJARAN_SHAPED, INSECT_SHAPED)
+	w_class = W_CLASS_MEDIUM
+	armor = list(melee = 60, bullet = 50, laser = 30, energy = 15, bomb = 35, bio = 100, rad = 60)
+	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/weapon/gun,/obj/item/ammo_storage,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/melee/energy/sword,/obj/item/weapon/handcuffs)
+	siemens_coefficient = 0.6
+	pressure_resistance = 40 * ONE_ATMOSPHERE
+
+	species_restricted = null
+	head_type = /obj/item/clothing/head/helmet/space/rig/syndi
+
+/obj/item/clothing/head/helmet/space/rig/syndi/commander
+	name = "large blood-red hardsuit helmet"
+	desc = "An advanced helmet designed for work in special operations. Slightly bulkier than usual. A tag on it says \"Property of Gorlex Marauders\"."
+	armor = list(melee = 65, bullet = 55, laser = 35, energy = 20, bomb = 40, bio = 100, rad = 60)
+	icon_state = "rig0-syndi-commander"
+	item_state = "syndie_helm_commander"
+	_color = "syndi-commander"
+	species_fit = list()
+
+/obj/item/clothing/suit/space/rig/syndi/commander
+	name = "large blood-red hardsuit"
+	desc = "An advanced suit that protects against injuries during special operations. Slightly bulkier than usual. A tag on it says \"Property of Gorlex Marauders\"."
+	icon_state = "rig-syndi-commander"
+	armor = list(melee = 65, bullet = 55, laser = 35, energy = 20, bomb = 40, bio = 100, rad = 60)
+	head_type = /obj/item/clothing/head/helmet/space/rig/syndi/commander
+	species_fit = list()
+
+//Elite Strike Team rig
+/obj/item/clothing/head/helmet/space/rig/syndicate_elite
+	name = "syndicate elite hardsuit helmet"
+	desc = "The result of reverse-engineered deathsquad technology combined with nuclear operative hardsuit."
+	icon_state = "rig0-syndicate_elite"
+	item_state = "syndicate-helm-black"
+	_color = "syndicate_elite"
+	armor = list(melee = 65, bullet = 55, laser = 35,energy = 20, bomb = 40, bio = 100, rad = 60)
+	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
+	siemens_coefficient = 0.4
+	clothing_flags = PLASMAGUARD
+
+	species_restricted = null
+
+/obj/item/clothing/suit/space/rig/syndicate_elite
+	icon_state = "rig-syndicate_elite"
+	name = "syndicate elite hardsuit"
+	desc = "The result of reverse-engineered deathsquad technology combined with nuclear operative hardsuit."
+	item_state = "syndicate-black"
+	w_class = W_CLASS_MEDIUM
+	armor = list(melee = 70, bullet = 60, laser = 40, energy = 25, bomb = 50, bio = 100, rad = 60)
+	allowed = list(/obj/item/weapon/gun/osipr, /obj/item/device/flashlight, /obj/item/weapon/tank, /obj/item/weapon/gun, /obj/item/ammo_storage, /obj/item/ammo_casing, /obj/item/weapon/melee/baton, /obj/item/weapon/melee/energy/sword, /obj/item/weapon/handcuffs)
+	siemens_coefficient = 0.5
+	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
+	clothing_flags = PLASMAGUARD
+
+	species_restricted = null
+	head_type = /obj/item/clothing/head/helmet/space/rig/syndicate_elite
+
+
+//Wizard Rig
+/obj/item/clothing/head/helmet/space/rig/wizard
+	name = "gem-encrusted hardsuit helmet"
+	desc = "A bizarre gem-encrusted helmet that radiates magical energies."
+	icon_state = "rig0-wiz"
+	item_state = "wiz_helm"
+	_color = "wiz"
+	species_fit = list(GREY_SHAPED)
+	species_restricted = list("exclude",VOX_SHAPED)
+	armor = list(melee = 40, bullet = 20, laser = 20,energy = 20, bomb = 35, bio = 100, rad = 60)
+	siemens_coefficient = 0.7
+
+	wizard_garb = 1
+
+	species_restricted = null
+
+/obj/item/clothing/head/helmet/space/rig/wizard/acidable()
+	return 0
+
+/obj/item/clothing/suit/space/rig/wizard
+	icon_state = "rig-wiz"
+	name = "gem-encrusted hardsuit"
+	desc = "A bizarre gem-encrusted suit that radiates magical energies."
+	item_state = "wiz_hardsuit"
+	w_class = W_CLASS_MEDIUM
+	species_fit = list(GREY_SHAPED)
+	species_restricted = list("exclude",VOX_SHAPED)
+	armor = list(melee = 40, bullet = 20, laser = 20,energy = 20, bomb = 35, bio = 100, rad = 60)
+	siemens_coefficient = 0.7
+
+	wizard_garb = 1
+
+	species_restricted = null
+	head_type = /obj/item/clothing/head/helmet/space/rig/wizard
+	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/weapon/teleportation_scroll,/obj/item/weapon/gun/energy/staff)
+
+/obj/item/clothing/suit/space/rig/wizard/acidable()
+	return 0
+
+/obj/item/clothing/head/helmet/space/rig/wizard/lich_king
+	name = "helm of domination"
+	desc = "Worn by a lich with too much summoning time on their hands."
+	icon_state = "rig0-domination"
+	item_state = "lich_helm"
+	_color = "domination"
+	species_restricted = list(UNDEAD_SHAPED)
+
+/obj/item/clothing/suit/space/rig/wizard/lich_king
+	name = "plate of the damned"
+	desc = "Previous incarnations were rumoured to make the user invulnerable. This itteration is famous for having its own in-built cloak."
+	icon_state = "lichking_armour"
+	item_state = "lichking_armour"
+	species_restricted = list(UNDEAD_SHAPED)
+	body_parts_covered = ARMS|LEGS|FULL_TORSO|HANDS
+
+//Medical Rig
+/obj/item/clothing/head/helmet/space/rig/medical
+	name = "medical hardsuit helmet"
+	desc = "A special helmet designed for work in a hazardous, low pressure environment. Has minor radiation shielding."
+	icon_state = "rig0-medical"
+	item_state = "medical_helm"
+	_color = "medical"
+	species_fit = list(GREY_SHAPED, INSECT_SHAPED)
+	species_restricted = list("exclude",VOX_SHAPED)
+	pressure_resistance = 40 * ONE_ATMOSPHERE
+
+/obj/item/clothing/suit/space/rig/medical
+	icon_state = "rig-medical"
+	name = "medical hardsuit"
+	desc = "A special suit that protects against hazardous, low pressure environments. Has minor radiation shielding."
+	item_state = "medical_hardsuit"
+	species_fit = list(GREY_SHAPED, INSECT_SHAPED)
+	species_restricted = list("exclude",VOX_SHAPED)
+	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/weapon/storage/firstaid,/obj/item/device/healthanalyzer,/obj/item/stack/medical, /obj/item/roller)
+	pressure_resistance = 40 * ONE_ATMOSPHERE
+	head_type = /obj/item/clothing/head/helmet/space/rig/medical
+
+
+	//Security
+/obj/item/clothing/head/helmet/space/rig/security
+	name = "security hardsuit helmet"
+	desc = "A special helmet designed for work in a hazardous low pressure environment. Has an additional layer of armor."
+	icon_state = "rig0-sec"
+	item_state = "sec_helm"
+	_color = "sec"
+	species_fit = list(GREY_SHAPED, INSECT_SHAPED)
+	species_restricted = list("exclude",VOX_SHAPED)
+	armor = list(melee = 60, bullet = 10, laser = 30, energy = 5, bomb = 45, bio = 100, rad = 10)
+	siemens_coefficient = 0.7
+	pressure_resistance = 40 * ONE_ATMOSPHERE
+
+/obj/item/clothing/suit/space/rig/security
+	icon_state = "rig-sec"
+	name = "security hardsuit"
+	desc = "A special suit that protects against hazardous low pressure environments. Has an additional layer of armor."
+	item_state = "sec_hardsuit"
+	species_fit = list(GREY_SHAPED, INSECT_SHAPED)
+	species_restricted = list("exclude",VOX_SHAPED)
+	armor = list(melee = 60, bullet = 10, laser = 30, energy = 5, bomb = 45, bio = 100, rad = 10)
+	allowed = list(
+		/obj/item/weapon/gun,
+		/obj/item/device/flashlight,
+		/obj/item/weapon/tank,
+		/obj/item/weapon/melee/baton,
+		/obj/item/weapon/reagent_containers/spray/pepper,
+		/obj/item/ammo_storage,
+		/obj/item/ammo_casing,
+		/obj/item/weapon/handcuffs,
+		/obj/item/weapon/bikehorn/baton,
+		/obj/item/weapon/blunderbuss,
+		/obj/item/weapon/legcuffs/bolas,
+	)
+	siemens_coefficient = 0.7
+	pressure_resistance = 40 * ONE_ATMOSPHERE
+	head_type = /obj/item/clothing/head/helmet/space/rig/security
+
+/obj/item/clothing/suit/space/rig/security/fat
+	name = "expanded security hardsuit"
+	desc = "An armored suit that has been expanded to accomodate a donut gut."
+	clothing_flags = ONESIZEFITSALL
+
+/obj/item/clothing/suit/space/rig/security/fat/step_action()
+	if(!ishuman(loc))
+		return
+	var/mob/living/carbon/human/H = loc
+	if(!(M_FAT in H.mutations))
+		if(!heat_conductivity) //Not fat and not yet broken
+			sterility = 50
+			heat_conductivity = 0.5
+			to_chat(H,"<span class='danger'>\The [src] is too loose and can't form a perfect seal around your gaunt body!</span>")
+	else
+		if(heat_conductivity) //Fat, but not yet restored
+			sterility = 100
+			heat_conductivity = SPACESUIT_HEAT_CONDUCTIVITY //0
+			to_chat(H,"<span class='good'>\The [src] forms a robust seal around your girth!</span>")
+
+	// stormtroopers
+
+/obj/item/clothing/head/helmet/space/rig/security/stormtrooper
+	icon_state = "rig0-storm"
+	_color = "storm"
+	name = "stormtrooper helmet"
+	desc = "Even with the finest vision enhancement tech, you still can't hit shit."
+	no_light = 1
+
+/obj/item/clothing/suit/space/rig/security/stormtrooper
+	icon_state = "rig-storm"
+	name = "stormtrooper hardsuit"
+	desc = "Now even more vulnerable to teddy bears!"
+	head_type = /obj/item/clothing/head/helmet/space/rig/security/stormtrooper
+
+//Atmospherics Rig (BS12)
+/obj/item/clothing/head/helmet/space/rig/atmos
+	desc = "A special helmet designed for work in hazardous low pressure environments. Has reduced radiation shielding to allow for greater mobility."
+	name = "atmospherics hardsuit helmet"
+	icon_state = "rig0-atmos"
+	item_state = "atmos_helm"
+	_color = "atmos"
+	species_fit = list(GREY_SHAPED, INSECT_SHAPED)
+	species_restricted = list("exclude",VOX_SHAPED)
+	clothing_flags = PLASMAGUARD
+	armor = list(melee = 40, bullet = 0, laser = 0, energy = 0, bomb = 25, bio = 100, rad = 0)
+	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
+
+/obj/item/clothing/suit/space/rig/atmos
+	desc = "A special suit that protects against hazardous low pressure environments. Has reduced radiation shielding to allow for greater mobility."
+	icon_state = "rig-atmos"
+	name = "atmos hardsuit"
+	item_state = "atmos_hardsuit"
+	species_restricted = list("exclude",VOX_SHAPED)
+	clothing_flags = PLASMAGUARD
+	species_fit = list(GREY_SHAPED, INSECT_SHAPED)
+	armor = list(melee = 40, bullet = 0, laser = 0, energy = 0, bomb = 25, bio = 100, rad = 0)
+	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
+	head_type = /obj/item/clothing/head/helmet/space/rig/atmos
+
+//Firefighting/Atmos RIG (old /vg/)
+/obj/item/clothing/head/helmet/space/rig/atmos/gold
+	desc = "A special helmet designed for work in hazardous low pressure environments and extreme temperatures. In other words, perfect for atmos."
+	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE*2
+	name = "atmos hardsuit helmet"
+	icon_state = "rig0-atmos_gold"
+	item_state = "atmos_gold_helm"
+	_color = "atmos_gold"
+	species_fit = list(GREY_SHAPED, INSECT_SHAPED)
+	species_restricted = list("exclude",VOX_SHAPED)
+	no_light = 1
+
+/obj/item/clothing/suit/space/rig/atmos/gold
+	desc = "A special suit that protects against hazardous low pressure environments and extreme temperatures. In other words, perfect for atmos."
+	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE*4
+	gas_transfer_coefficient = 0.80
+	permeability_coefficient = 0.25
+	icon_state = "rig-atmos_gold"
+	name = "atmos hardsuit"
+	item_state = "atmos_gold_hardsuit"
+	slowdown = HARDSUIT_SLOWDOWN_HIGH
+	species_fit = list(GREY_SHAPED,INSECT_SHAPED)
+	armor = list(melee = 30, bullet = 5, laser = 40,energy = 5, bomb = 35, bio = 100, rad = 60)
+	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/weapon/storage/backpack/satchel_norm,/obj/item/device/t_scanner,/obj/item/weapon/pickaxe, /obj/item/device/rcd, /obj/item/weapon/extinguisher, /obj/item/weapon/extinguisher/foam, /obj/item/weapon/storage/toolbox, /obj/item/weapon/wrench/socket)
+	head_type = /obj/item/clothing/head/helmet/space/rig/atmos/gold
+
+//ADMINBUS RIGS. SOVIET + NAZI
+/obj/item/clothing/head/helmet/space/rig/nazi
+	name = "nazi hardhelmet"
+	desc = "This is the face of das vaterland's top elite. Gas or energy are your only escapes."
+	item_state = "rig0-nazi"
+	icon_state = "rig0-nazi"
+	species_fit = list(GREY_SHAPED)
+	species_restricted = list("exclude",VOX_SHAPED)//GAS THE VOX
+	armor = list(melee = 40, bullet = 30, laser = 30, energy = 15, bomb = 35, bio = 100, rad = 20)
+	_color = "nazi"
+	pressure_resistance = 40 * ONE_ATMOSPHERE
+	color_on = "#FF2222"
+
+/obj/item/clothing/suit/space/rig/nazi
+	name = "nazi hardsuit"
+	desc = "The attire of a true krieger. All shall fall, and only das vaterland will remain."
+	item_state = "rig-nazi"
+	icon_state = "rig-nazi"
+	species_fit = list(GREY_SHAPED)
+	species_restricted = list("exclude",VOX_SHAPED)//GAS THE VOX
+	armor = list(melee = 40, bullet = 30, laser = 30, energy = 15, bomb = 35, bio = 100, rad = 20)
+	allowed = list(/obj/item/weapon/gun,/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/weapon/melee/)
+	pressure_resistance = 40 * ONE_ATMOSPHERE
+	head_type = /obj/item/clothing/head/helmet/space/rig/nazi
+
+/obj/item/clothing/head/helmet/space/rig/soviet
+	name = "soviet hardhelmet"
+	desc = "Crafted with the pride of the proletariat. The vengeful gaze of the visor roots out all fascists and capitalists."
+	item_state = "rig0-soviet"
+	icon_state = "rig0-soviet"
+	species_fit = list(GREY_SHAPED)
+	species_restricted = list("exclude",VOX_SHAPED)//HET
+	armor = list(melee = 40, bullet = 30, laser = 30, energy = 15, bomb = 35, bio = 100, rad = 20)
+	_color = "soviet"
+	pressure_resistance = 40 * ONE_ATMOSPHERE
+
+/obj/item/clothing/suit/space/rig/soviet
+	name = "soviet hardsuit"
+	desc = "Crafted with the pride of the proletariat. The last thing the enemy sees is the bottom of this armor's boot."
+	item_state = "rig-soviet"
+	icon_state = "rig-soviet"
+	slowdown = 1
+	species_fit = list(GREY_SHAPED)
+	species_restricted = list("exclude",VOX_SHAPED)//HET
+	armor = list(melee = 40, bullet = 30, laser = 30, energy = 15, bomb = 35, bio = 100, rad = 20)
+	allowed = list(/obj/item/weapon/gun,/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/weapon/melee/)
+	pressure_resistance = 40 * ONE_ATMOSPHERE
+	head_type = /obj/item/clothing/head/helmet/space/rig/soviet
+
+//Death squad rig
+/obj/item/clothing/head/helmet/space/rig/deathsquad
+	name = "deathsquad helmet"
+	desc = "That's not red paint. That's real blood."
+	icon_state = "rig0-deathsquad"
+	item_state = "rig0-deathsquad"
+	armor = list(melee = 65, bullet = 55, laser = 35,energy = 20, bomb = 40, bio = 100, rad = 60)
+	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
+	siemens_coefficient = 0.2
+	species_fit = list(GREY_SHAPED)
+	species_restricted = list("exclude",VOX_SHAPED)
+	_color = "deathsquad"
+	clothing_flags = PLASMAGUARD
+
+/obj/item/clothing/suit/space/rig/deathsquad
+	name = "deathsquad suit"
+	desc = "A heavily armored suit that protects against a lot of things. Used in special operations."
+	icon_state = "rig-deathsquad"
+	item_state = "rig-deathsquad"
+	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_storage,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/handcuffs,/obj/item/weapon/tank/emergency_oxygen,/obj/item/weapon/tank/emergency_nitrogen,/obj/item/weapon/pinpointer,/obj/item/weapon/shield/energy,/obj/item/weapon/c4,/obj/item/weapon/disk/nuclear)
+	armor = list(melee = 80, bullet = 60, laser = 50,energy = 25, bomb = 60, bio = 100, rad = 60)
+	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
+	siemens_coefficient = 0.5
+	species_fit = list(GREY_SHAPED)
+	species_restricted = list("exclude",VOX_SHAPED)
+	clothing_flags = PLASMAGUARD
+	head_type = /obj/item/clothing/head/helmet/space/rig/deathsquad
+
+
+//Knight armour rigs
+/obj/item/clothing/head/helmet/space/rig/knight
+	name = "Space-Knight helm"
+	desc = "A well polished helmet belonging to a Space-Knight. Favored by space-jousters for its ability to stay on tight after being launched from a mass driver."
+	icon_state = "rig0-knight"
+	item_state = "rig0-knight"
+	armor = list(melee = 60, bullet = 40, laser = 40,energy = 30, bomb = 50, bio = 100, rad = 60)
+	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
+	siemens_coefficient = 0.2
+	species_fit = list(GREY_SHAPED)
+	species_restricted = list("exclude",VOX_SHAPED)
+	_color = "knight"
+	clothing_flags = PLASMAGUARD|GOLIATHREINFORCE
+
+
+/obj/item/clothing/suit/space/rig/knight
+	name = "Space-Knight armour"
+	desc = "A well polished set of armour belonging to a Space-Knight. Maidens Rescued in Space: 100, Maidens who have slept with me in Space: 0."
+	icon_state = "rig-knight"
+	item_state = "rig-knight"
+	allowed = list(/obj/item/weapon/gun,/obj/item/weapon/melee/baton,/obj/item/weapon/tank,/obj/item/weapon/shield/energy,/obj/item/weapon/claymore)
+	armor = list(melee = 60, bullet = 40, laser = 40,energy = 30, bomb = 50, bio = 100, rad = 60)
+	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
+	siemens_coefficient = 0.5
+	species_fit = list(GREY_SHAPED)
+	species_restricted = list("exclude",VOX_SHAPED)
+	clothing_flags = PLASMAGUARD|GOLIATHREINFORCE
+	head_type = /obj/item/clothing/head/helmet/space/rig/knight
+
+/obj/item/clothing/head/helmet/space/rig/knight/black
+	name = "Black Knight's helm"
+	desc = "An ominous black helmet with a gold trim. The small viewports create an intimidating look, while also making it nearly impossible to see anything."
+	icon_state = "rig0-blackknight"
+	item_state = "rig0-blackknight"
+	armor = list(melee = 70, bullet = 65, laser = 50,energy = 25, bomb = 60, bio = 100, rad = 60)
+	_color="blackknight"
+	species_fit = list(GREY_SHAPED)
+
+/obj/item/clothing/suit/space/rig/knight/black
+	name = "Black Knight's armour"
+	desc = "An ominous black suit of armour with a gold trim. Surprisingly good at preventing accidental loss of limbs."
+	icon_state = "rig-blackknight"
+	item_state = "rig-blackknight"
+	armor = list(melee = 70, bullet = 65, laser = 50,energy = 25, bomb = 60, bio = 100, rad = 60)
+	species_fit = list(GREY_SHAPED)
+	head_type = /obj/item/clothing/head/helmet/space/rig/knight/black
+
+/obj/item/clothing/head/helmet/space/rig/knight/solaire
+	name = "Solar helm"
+	desc = "A simple helmet. 'Made in Astora' is inscribed on the back."
+	icon_state = "rig0-solaire"
+	item_state = "rig0-solaire"
+	armor = list(melee = 60, bullet = 65, laser = 90,energy = 30, bomb = 60, bio = 100, rad = 100)
+	_color="solaire"
+
+/obj/item/clothing/suit/space/rig/knight/solaire
+	name = "Solar armour"
+	desc = "A solar powered hardsuit with a fancy insignia on the chest. Perfect for stargazers and adventurers alike."
+	icon_state = "rig-solaire"
+	item_state = "rig-solaire"
+	armor = list(melee = 60, bullet = 65, laser = 90,energy = 30, bomb = 60, bio = 100, rad = 100)
+	head_type = /obj/item/clothing/head/helmet/space/rig/knight/solaire
+
+
+/obj/item/clothing/suit/space/rig/t51b
+	name = "T-51b Power Armor"
+	desc = "Relic of a bygone era, the T-51b is powered by a TX-28 MicroFusion Pack, which holds enough fuel to power its internal hydraulics for a century!"
+	icon_state = "rig-t51b"
+	item_state = "rig-t51b"
+	armor = list(melee = 35, bullet = 35, laser = 40, energy = 40, bomb = 80, bio = 100, rad = 100)
+	head_type = /obj/item/clothing/head/helmet/space/rig/t51b
+
+/obj/item/clothing/head/helmet/space/rig/t51b
+	name = "T-51b Power Armor Helmet"
+	desc = "Relic of a bygone era, the T-51b is powered by a TX-28 MicroFusion Pack, which holds enough fuel to power its internal hydraulics for a century!"
+	icon_state = "rig0-t51b"
+	item_state = "rig0-t51b"
+	armor = list(melee = 35, bullet = 35, laser = 40, energy = 40, bomb = 80, bio = 100, rad = 100)
+	_color="t51b"
+
+//Ghetto space suit
+/obj/item/clothing/head/helmet/space/ghetto
+	name = "jury-rigged space-proof fire helmet"
+	desc = "A firefighter helmet and gas mask combined and jury-rigged into being 'space-proof' somehow."
+	icon_state = "ghettorig"
+	item_state = "ghettorig"
+	_color = "ghetto"
+	pressure_resistance = 4 * ONE_ATMOSPHERE
+	armor = list(melee = 30, bullet = 5, laser = 20,energy = 10, bomb = 20, bio = 10, rad = 20)
+	body_parts_covered = FULL_HEAD|BEARD
+	body_parts_visible_override = EYES
+	heat_conductivity = 0
+	gas_transfer_coefficient = 0.01
+	permeability_coefficient = 0.01
+	eyeprot = 0
+	species_fit = list(GREY_SHAPED, INSECT_SHAPED)
+
+/obj/item/clothing/suit/space/ghettorig
+	name = "jury-rigged space-proof firesuit"
+	icon_state = "ghettorig"
+	item_state = "ghettorig"
+	desc = "A firesuit jury-rigged into being 'space-proof' somehow."
+	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
+	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank/emergency_oxygen,/obj/item/weapon/tank/emergency_nitrogen,/obj/item/weapon/extinguisher)
+	pressure_resistance = 4 * ONE_ATMOSPHERE
+	slowdown = 5 //just wear a firesuit instead if you want to go fast
+	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
+	heat_conductivity = 0 //thanks, blanket
+	gas_transfer_coefficient = 0.60
+	permeability_coefficient = 0.30
+	species_fit = list(INSECT_SHAPED)
+
+//RoR survivor Rig
+/obj/item/clothing/suit/space/rig/ror
+	name = "survivor's hardsuit"
+	desc = "...and so he left the asteroid, with everything but his humanity."
+	icon_state = "rorsuit"
+	item_state = "rorsuit"
+	armor = list(melee = 40, bullet = 0, laser = 0,energy = 0, bomb = 65, bio = 100, rad = 50)
+	clothing_flags = GOLIATHREINFORCE
+	head_type = /obj/item/clothing/head/helmet/space/rig/ror
+
+/obj/item/clothing/head/helmet/space/rig/ror
+	name = "survivor's hardsuit helmet"
+	desc = "...and so he left the asteroid, with everything but his humanity."
+	icon_state = "rorhelm"
+	item_state = "rorhelm"
+	armor = list(melee = 40, bullet = 0, laser = 0,energy = 0, bomb = 65, bio = 100, rad = 50)
+	clothing_flags = GOLIATHREINFORCE
+
+/obj/item/clothing/head/helmet/space/rig/ror/update_icon()
+	return
+
+//[Xeno]Archaeologist Rig
+/obj/item/clothing/suit/space/rig/arch
+	name = "archaeology hardsuit"
+	desc = "A hardsuit designed for archaeology expeditions. It's yellow and orange materials provide high visibility and resistance to exotic particles."
+	icon_state = "rig-arch"
+	item_state = "arch_hardsuit"
+	armor = list(melee = 40, bullet = 0, laser = 0,energy = 0, bomb = 65, bio = 100, rad = 50)
+	head_type = /obj/item/clothing/head/helmet/space/rig/arch
+	species_fit = list(INSECT_SHAPED)
+
+/obj/item/clothing/head/helmet/space/rig/arch
+	name = "archaeology hardsuit helmet"
+	desc = "A hardsuit helmet designed for archaeology expeditions. It's orange materials provide high visibility and resistance to exotic particles."
+	icon_state = "rig0-arch"
+	item_state = "arch_helm"
+	_color = "arch"
+	armor = list(melee = 40, bullet = 0, laser = 0,energy = 0, bomb = 65, bio = 100, rad = 50)
+	color_on = "#81F9C6" //Aquamarine. A combination of the colors from the lamp and rail light.
+	species_fit = list(INSECT_SHAPED)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -285,6 +285,13 @@
 			stat("Spacepod Charge", "[istype(S.battery) ? "[S.battery.charge] / [S.battery.maxcharge]" : "No cell detected"]")
 			stat("Spacepod Integrity", "[!S.health ? "0" : "[(S.health / initial(S.health)) * 100]"]%")
 
+		if(is_wearing_item(/obj/item/clothing/suit/space/rig, slot_wear_suit))
+			var/obj/item/clothing/suit/space/rig/R = wear_suit
+			if(R.cell)
+				stat("\The [R.name]", "Charge: [R.cell.charge]")
+			if(R.activated)
+				stat("\The [R.name]", "Modules: [english_list(R.modules)]")
+
 		if (mind)
 			for (var/role in mind.antag_roles)
 				var/datum/role/R = mind.antag_roles[role]

--- a/code/modules/mob/living/carbon/human/life/handle_breath.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_breath.dm
@@ -114,7 +114,12 @@
 /mob/living/carbon/human/proc/get_breath_from_internal(volume_needed)
 	if(internal)
 		if(!contents.Find(internal))
-			internal = null
+			if(wear_suit && isrig(wear_suit)) //But what if he's wearing a rigsuit?
+				var/obj/item/clothing/suit/space/rig/rig = wear_suit
+				if(!rig.T) //But if the rig has no internal tank...
+					internal = null
+			else
+				internal = null
 		if(!wear_mask || !(wear_mask.clothing_flags & MASKINTERNALS))
 			internal = null
 		if(internal)

--- a/code/modules/mob/living/carbon/internals.dm
+++ b/code/modules/mob/living/carbon/internals.dm
@@ -6,6 +6,10 @@
 
 /mob/living/carbon/human/internals_candidates() //Humans have a lot of slots, so let's give priority to some of them
 	var/list/priority = list(s_store, back, belt, l_store, r_store)
+	if(wear_suit && isrig(wear_suit)) //Don't forget the rigsuit!
+		var/obj/item/clothing/suit/space/rig/rig = wear_suit
+		if(rig.T)
+			priority += rig.T
 	return priority | get_all_slots() | held_items //| operator ensures there are no duplicates
 
 /mob/living/carbon/proc/get_internals_tank()

--- a/code/modules/mob/living/simple_animal/friendly/corgi.dm
+++ b/code/modules/mob/living/simple_animal/friendly/corgi.dm
@@ -272,6 +272,9 @@
 
 					usr.drop_item(item_to_add, src, force_drop = 1)
 					src.inventory_back = item_to_add
+					if(isrig(item_to_add)) //TIME TO HACKINTOSH
+						var/obj/item/clothing/head/helmet/space/rig/rig_helmet = new (src)
+						place_on_head(rig_helmet)
 					regenerate_icons()
 
 		show_inv(usr)
@@ -495,21 +498,27 @@
                         dir = i
                         sleep(1)
 
+/mob/living/simple_animal/corgi/proc/reset_appearance()
+	name = real_name
+	desc = initial(desc)
+	speak = list("YAP!", "Woof!", "Bark!", "Arf!")
+	speak_emote = list("barks.", "woofs.")
+	emote_hear = list("barks.", "woofs.", "yaps.")
+	emote_see = list("shakes its head.", "shivers.", "pants.")
+	emote_sound = list("sound/voice/corgibark.ogg")
+	min_oxy = initial(min_oxy)
+	minbodytemp = initial(minbodytemp)
+	maxbodytemp = initial(maxbodytemp)
+	set_light(0)
+
 /mob/living/simple_animal/corgi/proc/remove_inventory(var/remove_from = "head", mob/user)
 	switch(remove_from)
 		if("head")
 			if(inventory_head)
-				name = real_name
-				desc = initial(desc)
-				speak = list("YAP!", "Woof!", "Bark!", "Arf!")
-				speak_emote = list("barks.", "woofs.")
-				emote_hear = list("barks.", "woofs.", "yaps.")
-				emote_see = list("shakes its head.", "shivers.", "pants.")
-				emote_sound = list("sound/voice/corgibark.ogg")
-				min_oxy = initial(min_oxy)
-				minbodytemp = initial(minbodytemp)
-				maxbodytemp = initial(maxbodytemp)
-				set_light(0)
+				if(isrighelmet(inventory_head) && inventory_back && isrig(inventory_back)) //You've activated my trap card!
+					remove_inventory("back", user)
+					return
+				reset_appearance()
 				inventory_head.forceMove(src.loc)
 				inventory_head = null
 				regenerate_icons()
@@ -519,6 +528,10 @@
 				return
 		if("back")
 			if(inventory_back)
+				if(isrig(inventory_back) && inventory_head && isrighelmet(inventory_head)) //Now we undo the hack
+					qdel(inventory_head)
+					reset_appearance()
+					inventory_head = null
 				inventory_back.forceMove(src.loc)
 				inventory_back = null
 				regenerate_icons()

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -538,9 +538,6 @@ obj/item/asteroid/basilisk_hide/New()
 	if(proximity_flag && istype(target, /obj/item/clothing))
 		var/obj/item/clothing/C = target
 		var/current_armor = C.armor
-		if(!isturf(C.loc))
-			to_chat(user, "<span class='warning'>\The [C] must be safely placed on the ground for modification.</span>")
-			return
 		if(C.clothing_flags & GOLIATHREINFORCE)
 			C.hidecount ++
 			if(current_armor["melee"] < 90)
@@ -554,6 +551,8 @@ obj/item/asteroid/basilisk_hide/New()
 			C.item_state = "[initial(C.item_state)]_goliath[C.hidecount]"
 			C.icon_state = "[initial(C.icon_state)]_goliath[C.hidecount]"
 			C._color = "mining_goliath[C.hidecount]"
+		if(user.is_wearing_item(C))
+			user.regenerate_icons()
 
 /mob/living/simple_animal/hostile/asteroid/goliath/david
 	name = "david"

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -1390,6 +1390,7 @@
 #include "code\modules\clothing\spacesuits\time.dm"
 #include "code\modules\clothing\spacesuits\void.dm"
 #include "code\modules\clothing\spacesuits\rig_modules\rig_modules.dm"
+#include "code\modules\clothing\spacesuits\rig_subtypes\rig_subtypes.dm"
 #include "code\modules\clothing\suits\alien.dm"
 #include "code\modules\clothing\suits\armor.dm"
 #include "code\modules\clothing\suits\bio.dm"


### PR DESCRIPTION
**Only merge this PR once hardsuit helmets are purged from all maps and cannot be obtained outside adminbus.**

* Hardsuits don't need to have compulsory components anymore
* Hardsuits can can now have their own built-in gloves/shoes/tanks
* Built-in parts cannot be removed from your mob, only retracted(They will teleport themselves to inside the suit, so don't even waste your time)
* Removing the hardsuit from its wearer will also retract its built-in parts.
* Added a testing CE hardsuit subtype that comes with CE boots, insulated gloves, double extended tank and a air refiller module as proof of concept
* Unlinked helmets now give you a warning for trying to use them with no linked hardsuit(This shouldn't ever happen now)
* Rig helmets will try to link themselves to the equipped hardsuit, if possible(Again, this shouldn't ever happen, but better safe than sorry.)
* SSUs will also clean hardsuit's built-in helmet/gloves/magboots
* Added a sanity check suit modifiers, preventing ghosts from messing with them
* Hardsuit cell/modules now appear in the status tab
* Heavily tweaked rig modules power management
* Fixed a few rig modules bugs

:cl:
 * tweak: Hardsuit cannot have their helmets removed anymore. Toggling/removing the suit will retract them.
 * tweak: Hardsuit power cell charge and modules can now be seen in your status tab.
 * tweak: SSUs will now properly clean the your hardsuit.
 * tweak: Goliath reinforcing does not need the target clothing to be on the ground anymore.