### PR TITLE
Improves malf timer

### DIFF
--- a/code/datums/gamemode/factions/malf.dm
+++ b/code/datums/gamemode/factions/malf.dm
@@ -82,5 +82,5 @@ You should now be able to use your Explode spell to interface with the nuclear f
 
 /datum/faction/malf/get_statpanel_addition()
 	if(stage >= FACTION_ENDGAME)
-		return "Station integrity: [round(100-(AI_win_timeleft/MALF_INITIAL_TIMER)*100)]%"
+		return "Station integrity: [round((AI_win_timeleft/MALF_INITIAL_TIMER)*100)]%"
 	return null

--- a/code/datums/gamemode/factions/malf.dm
+++ b/code/datums/gamemode/factions/malf.dm
@@ -1,3 +1,5 @@
+#define MALF_INITIAL_TIMER 1800
+
 /datum/faction/malf
 	name = "Malfunctioning AI"
 	desc = "ERROR"
@@ -80,5 +82,5 @@ You should now be able to use your Explode spell to interface with the nuclear f
 
 /datum/faction/malf/get_statpanel_addition()
 	if(stage >= FACTION_ENDGAME)
-		return "Time left: [max(AI_win_timeleft/(apcs/3), 0)]"
+		return "Station integrity: [round(100-(AI_win_timeleft/MALF_INITIAL_TIMER)*100)]%"
 	return null


### PR DESCRIPTION
Instead of being an amount of process() ticks left it's a station integrity percentage until it reaches 0%.
Functionally still the same

:cl:
 * tweak: The malf AI station takeover timer is now a station integrity percentage