### PR TITLE
Talisman will now shut down station bounced radios on the victim it's used on

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
@@ -1211,6 +1211,8 @@
 	anim(target = M, a_icon = 'icons/effects/64x64.dmi', flick_anim = "touch_stun", lay = NARSIE_GLOW, offX = -WORLD_ICON_SIZE/2, offY = -WORLD_ICON_SIZE/2, plane = LIGHTING_PLANE)
 
 	playsound(spell_holder, 'sound/effects/stun_talisman.ogg', 25, 0, -5)
+	for(var/obj/item/device/radio/R in recursive_type_check(M, /obj/item/device/radio))
+		R.broadcasting = 0
 	if (prob(15))//for old times' sake
 		invoke(activator,"Dream sign ''Evil sealing talisman''!",1)
 	else


### PR DESCRIPTION
TODO: Test this
Cultists can no longer be dabbed on via station bounced radios
The anti-cult metaclub will put my head on a pike
:cl:
 * tweak: Cultist stun talismans will now also shut down any station bounced radios the victim might have.