### PR TITLE
Rigsuit modification stations can only be activated once while operating

### DIFF
--- a/code/game/machinery/suit_modifier.dm
+++ b/code/game/machinery/suit_modifier.dm
@@ -20,6 +20,7 @@
 	var/list/modules_to_install = list()
 	var/obj/item/weapon/cell/cell = null
 	var/image/suit_overlay
+	var/activated = FALSE
 	idle_power_usage = 50
 	active_power_usage = 300
 
@@ -68,6 +69,9 @@
 			process_module_installation(H)
 
 /obj/machinery/suit_modifier/proc/process_module_installation(var/mob/living/carbon/human/H)
+	if(activated)
+		return
+	activated = TRUE
 	suit_overlay.icon_state = "suitmodifier_activate"
 	overlays.Add(suit_overlay)
 	use_power = 2
@@ -107,6 +111,7 @@
 	suit_overlay.icon_state = null
 	R.initialize_suit()
 	use_power = 1
+	activated = FALSE
 
 /obj/machinery/suit_modifier/get_cell()
 	return cell


### PR DESCRIPTION
closes #26795
prevents hardsuit modification stations from being clicked repeatedly to install modules repeatedly
while the idea of installing a single speed module multiple times for a no slowdown hardsuit would be nice, it's kind of a bug right now
maybe the speed module could be upgradable in the future for quirky shit like that
:cl:
 * bugfix: Rigsuit modification stations can no longer be activated multiple times.