### PR TITLE
Just

### DIFF
--- a/code/game/machinery/navbeacon.dm
+++ b/code/game/machinery/navbeacon.dm
@@ -34,9 +34,9 @@ var/list/navbeacons = list()
 
 	navbeacons.Add(src)
 
-	spawn(5)	// must wait for map loading to finish
-		if(radio_controller)
-			radio_controller.add_object(src, freq, RADIO_NAVBEACONS)
+/obj/machinery/navbeacon/initialize()
+	if(radio_controller)
+		radio_controller.add_object(src, freq, RADIO_NAVBEACONS)
 
 /obj/machinery/navbeacon/Destroy()
 	navbeacons.Remove(src)

--- a/code/game/machinery/navbeacon.dm
+++ b/code/game/machinery/navbeacon.dm
@@ -33,6 +33,8 @@ var/list/navbeacons = list()
 	hide(T.intact)
 
 	navbeacons.Add(src)
+	if(ticker && ticker.current_state == GAME_STATE_PLAYING)
+		initialize()
 
 /obj/machinery/navbeacon/initialize()
 	if(radio_controller)


### PR DESCRIPTION
After 3 hours of testing on the test serb to see why it wouldn't happen locally but would happen on live, the answer is extremely dumb (but not too far away from what I imagined) : navbeacons don't get properly connected to the radio controller. They assume map loading or all that shit takes place in about 0.5 seconds. 

This is true locally, *was* true on the serb for a long time, but now we went above that threshold, and as a result bots are waiting for mute navbeacons.

This ends one of the worst weeks of my coding life