### PR TITLE
 Actually close BSQL connections the hard way but only when needed this time

### DIFF
--- a/code/controllers/subsystem/dbcore.dm
+++ b/code/controllers/subsystem/dbcore.dm
@@ -199,8 +199,8 @@ var/datum/subsystem/dbcore/SSdbcore
 
 /datum/subsystem/dbcore/proc/Disconnect()
 	failed_connections = 0
-	qdel(connectOperation)
-	qdel(connection)
+	BSQL_DEL_CALL(connectOperation)
+	BSQL_DEL_CALL(connection)
 	connectOperation = null
 	connection = null
 

--- a/code/world.dm
+++ b/code/world.dm
@@ -73,7 +73,7 @@ var/savefile/panicfile
 	make_datum_references_lists()	//initialises global lists for referencing frequently used datums (so that we only ever do it once)
 
 	load_configuration()
-	SSdbcore.Initialize(world.time) // Get a database running, first thing
+	SSdbcore.Initialize(world.timeofday) // Get a database running, first thing
 
 	load_mode()
 	load_motd()


### PR DESCRIPTION
#26818 without crashing the serb, and only using the hard del (which INSTANTLY severs the connection to the DB) in the Shutdown control flow. The previous PR used it (erroneously) on connection issues during the game, which would cause issues in some cases.

I tested it with my local wampserver