### PR TITLE
Improves phylactery

### DIFF
--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -274,8 +274,8 @@
 			original.remove_spell(S)
 			H.add_spell(S)
 		//Let's give the lich some spooky clothes. Including non-wizards.
-		H.equip_to_slot_or_del(new /obj/item/clothing/head/wizard/necro(H), slot_head)
-		H.equip_to_slot_or_del(new /obj/item/clothing/suit/wizrobe/necro(H), slot_wear_suit)
+		H.equip_to_slot_or_del(new /obj/item/clothing/head/wizard/skelelich(H), slot_head)
+		H.equip_to_slot_or_del(new /obj/item/clothing/suit/wizrobe/skelelich(H), slot_wear_suit)
 		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/sandal(H), slot_shoes)
 		H.equip_to_slot_or_del(new /obj/item/clothing/under/lightpurple(H), slot_w_uniform)
 		original.mind.transfer_to(H) // rebinding on transfer now handled by mind

--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -204,6 +204,11 @@
 	var/mob/bound_soul
 	var/datum/mind/bound_mind
 
+/obj/item/phylactery/examine(mob/user, size, show_name)
+	..()
+	if(iswizard(user))
+		to_chat(user, "<span class='sinister'>You can use charged soulstones to refill it. The more charges you have, the faster you will revive.</span>")
+
 /obj/item/phylactery/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/device/soulstone))
 		var/obj/item/device/soulstone/S = I
@@ -268,11 +273,16 @@
 		for(var/spell/S in original.spell_list)
 			original.remove_spell(S)
 			H.add_spell(S)
-		H.Paralyse(30)
+		//Let's give the lich some spooky clothes. Including non-wizards.
+		H.equip_to_slot_or_del(new /obj/item/clothing/head/wizard/necro(H), slot_head)
+		H.equip_to_slot_or_del(new /obj/item/clothing/suit/wizrobe/necro(H), slot_wear_suit)
+		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/sandal(H), slot_shoes)
+		H.equip_to_slot_or_del(new /obj/item/clothing/under/lightpurple(H), slot_w_uniform)
 		original.mind.transfer_to(H) // rebinding on transfer now handled by mind
 		if(!arguments["body_destroyed"])
 			original.dust()
-		var/release_time = rand(60 SECONDS, 120 SECONDS)/charges
+		var/release_time = round(rand(60 SECONDS, 120 SECONDS)/charges, 10) //In deciseconds
+		H.Paralyse(release_time/20) //Divide by 20 because Paralyse goes down by 1 every Life() tick (roughly every 2 secs)
 		to_chat(H, "<span class = 'notice'>\The [src] will permit you exit in [release_time/10] seconds.</span>")
 		spawn(release_time)
 			to_chat(H, "<span class = 'notice'>\The [src] permits you exit from it.</span>")
@@ -382,7 +392,7 @@
 	if (current_step >= max_steps)
 		deactivate()
 		return ..()
-	
+
 	var/mob/living/carbon/human/H = loc
 	H.delayNextMove(step_cooldown)
 	playsound(H, step_sound, 50, 1)

--- a/code/game/gamemodes/wizard/artifacts.dm
+++ b/code/game/gamemodes/wizard/artifacts.dm
@@ -282,7 +282,7 @@
 /datum/spellbook_artifact/phylactery
 	name = "phylactery"
 	desc = "Creates a soulbinding artifact that, upon the death of the user, resurrects them as best it can. You must bind yourself to this through making an incision on your palm, holding the phylactery in that hand, and squeezing it."
-	spawned_items = list(/obj/item/phylactery)
+	spawned_items = list(/obj/item/phylactery, /obj/item/clothing/head/wizard/lich, /obj/item/clothing/suit/wizrobe/lich)
 
 
 /datum/spellbook_artifact/darkness


### PR DESCRIPTION
- Now gives you lich clothes
- Only takes full seconds, does not include additional deciseconds (such as 80.**5**) anymore
- Paralysis is no longer hard-capped to 60 seconds, now lasts as long as the time it takes to be revived by the stone lasts
- Added an additional description for the wizards that aspire for lichhood, detailing the ability to use soulstones to recharge the phylactery as well as multiple charges reducing the amount of time required for revival.

:cl:
 * rscadd: The phylactery now grants you clothes when you die.
 * rscadd: Wizards can now see an additional description for the phylactery, detailing an almost-unknown ability.
 * tweak: The paralysis caused by the phylactery is no longer 60 seconds, instead it's as long as the time it takes to revive.
 * tweak: The time it takes to revive no longer has any additional deciseconds in it.