### PR TITLE
Fixes airlock stuff

### DIFF
--- a/code/game/machinery/door_control.dm
+++ b/code/game/machinery/door_control.dm
@@ -52,7 +52,6 @@
 
 /obj/machinery/door_control/attackby(obj/item/weapon/W, mob/user as mob)
 	..()
-	..()
 	/* For later implementation
 	if (W.is_screwdriver(user))
 	{
@@ -89,21 +88,21 @@
 		for(var/obj/machinery/door/airlock/D in range(range, src))
 			if(D.id_tag == src.id_tag)
 				spawn(0)
-				if(specialfunctions & IDSCAN)
-					D.aiDisabledIdScanner = !D.aiDisabledIdScanner
-				if(specialfunctions & BOLTS)
-					if(!D.isWireCut(4) && D.arePowerSystemsOn())
-						D.toggle_bolts()
-						D.update_icon()
-				if(specialfunctions & SHOCK)
-					D.secondsElectrified = D.secondsElectrified ? 0 : -1
-				if(specialfunctions & SAFE)
-					D.safe = !D.safe
-				if(specialfunctions & OPEN)
-					if(D.density)
-						D.open()
-					else
-						D.close()
+					if(specialfunctions & IDSCAN)
+						D.aiDisabledIdScanner = !D.aiDisabledIdScanner
+					if(specialfunctions & BOLTS)
+						if(!D.isWireCut(4) && D.arePowerSystemsOn())
+							D.toggle_bolts()
+							D.update_icon()
+					if(specialfunctions & SHOCK)
+						D.secondsElectrified = D.secondsElectrified ? 0 : -1
+					if(specialfunctions & SAFE)
+						D.safe = !D.safe
+					if(specialfunctions & OPEN)
+						if(D.density)
+							D.open()
+						else
+							D.close()
 
 	else
 		for(var/obj/machinery/door/poddoor/M in poddoors)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1318,6 +1318,9 @@ About the new airlock wires panel:
 	if(!forced)
 		if( !arePowerSystemsOn() || (stat & NOPOWER) || isWireCut(AIRLOCK_WIRE_OPEN_DOOR) )
 			return 0
+	for(var/obj/O in loc) //A redundant check that exists in the parent
+		if (O.blocks_doors()) //But it exists in the parent because it also affects firelocks.
+			return 0
 	use_power(50)
 	playsound(src, soundeffect, pitch, 1)
 	if(src.closeOther != null && istype(src.closeOther, /obj/machinery/door/airlock/) && !src.closeOther.density)


### PR DESCRIPTION
Airlocks will now open all at the same time instead of one at a time when you press the button
Airlocks will no longer try opening if they are taped

Why the fuck were there TWO ..()

:cl:
 * bugfix: Airlock buttons such as those in Medbay will now properly open all the doors instead of one at a time.
 * bugfix: Airlocks that are taped will no longer play a sound if you try opening them.