### PR TITLE
ninja latejoin with prompt

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets.dm
@@ -287,3 +287,13 @@
 		if(!check_enemy_jobs(FALSE))
 			return 0
 	return ..()
+
+/datum/dynamic_ruleset/proc/latejoinprompt(var/mob/user = usr, var/ruleset = null)
+	if(alert(user,"The gamemode is trying to select you for [ruleset], do you want this?",,"Yes","No") == "Yes")
+		return 1
+	return 0
+
+/datum/dynamic_ruleset/proc/generate_ruleset_body(mob/applicant)
+	var/mob/living/carbon/human/new_character = makeBody(applicant)
+	new_character.dna.ResetSE()
+	return new_character

--- a/code/datums/gamemode/dynamic/dynamic_rulesets.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets.dm
@@ -288,7 +288,7 @@
 			return 0
 	return ..()
 
-/datum/dynamic_ruleset/proc/latejoinprompt(var/mob/user = usr, var/ruleset = null)
+/datum/dynamic_ruleset/proc/latejoinprompt(var/mob/user, var/ruleset)
 	if(alert(user,"The gamemode is trying to select you for [ruleset], do you want this?",,"Yes","No") == "Yes")
 		return 1
 	return 0

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
@@ -86,6 +86,9 @@
 		log_admin("Cannot accept Wizard ruleset. Couldn't find any wizard spawn points.")
 		message_admins("Cannot accept Wizard ruleset. Couldn't find any wizard spawn points.")
 		return 0
+	/*for(var/mob/M in candidates)
+		if(!latejoinprompt(M,src))
+			return 0*/
 
 	return ..()
 
@@ -110,7 +113,7 @@
 //////////////////////////////////////////////
 
 
-/*/datum/dynamic_ruleset/latejoin/ninja
+/datum/dynamic_ruleset/latejoin/ninja
 	name = "Space Ninja Attack"
 	role_category = /datum/role/ninja
 	enemy_jobs = list("Security Officer","Detective", "Warden", "Head of Security", "Captain")
@@ -124,23 +127,30 @@
 
 	repeatable = TRUE
 
+/datum/dynamic_ruleset/latejoin/ninja/ready(var/forced = 0)
+	for(var/mob/M in candidates)
+		if(!latejoinprompt(M,src))
+			return 0
+	
+	return ..()
+
 /datum/dynamic_ruleset/latejoin/ninja/execute()
 	var/mob/M = pick(candidates)
+	M.loc = null
+	M.forceMove(null)
 	assigned += M
 	candidates -= M
 	var/datum/role/ninja/newninja = new
 	newninja.AssignToRole(M.mind,1)
-	newninja.Greet(GREET_DEFAULT)
+	var/datum/faction/spider_clan/spoider = find_active_faction_by_type(/datum/faction/spider_clan)
+	if (!spoider)
+		spoider = ticker.mode.CreateFaction(/datum/faction/spider_clan, null, 1)
+	spoider.HandleRecruitedRole(newninja)
 	newninja.OnPostSetup()
+	newninja.Greet(GREET_DEFAULT)
 	newninja.AnnounceObjectives()
-	spawn(1) //TODO - FIX THE NEED FOR THIS. CHECK PR, CHECK THE REVERTED COMMIT
-		if(!newninja.antag.current.ThrowAtStation())
-			newninja.antag.current.spawn_rand_maintenance()
 	return 1
-*/
-//TODO: ADD A "DO YOU WANT TO BE A [ROLE]?" PROMPT TO LATE-JOINERS BECAUSE PEOPLE HATE BEING A NINJA
-//TODO: ADD AN EQUIVALENT OF generate_ruleset_body() FOR LATEJOINS SO NINJAS DON'T SPAWN AS NAKED DYING VOX
-//DON'T RE-ENABLE TILL THAT'S DONE
+
 
 
 //////////////////////////////////////////////

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
@@ -86,9 +86,6 @@
 		log_admin("Cannot accept Wizard ruleset. Couldn't find any wizard spawn points.")
 		message_admins("Cannot accept Wizard ruleset. Couldn't find any wizard spawn points.")
 		return 0
-	/*for(var/mob/M in candidates)
-		if(!latejoinprompt(M,src))
-			return 0*/
 
 	return ..()
 
@@ -127,17 +124,11 @@
 
 	repeatable = TRUE
 
-/datum/dynamic_ruleset/latejoin/ninja/ready(var/forced = 0)
-	for(var/mob/M in candidates)
-		if(!latejoinprompt(M,src))
-			return 0
-	
-	return ..()
-
 /datum/dynamic_ruleset/latejoin/ninja/execute()
 	var/mob/M = pick(candidates)
-	M.loc = null //this is to prevent the latejoin player spawn system
-	M.forceMove(null) //from spawning the ninja in the arrivals shuttle
+	if(!latejoinprompt(M,src))
+		message_admins("[M.key] has opted out of becoming a ninja.")
+		return 0
 	assigned += M
 	candidates -= M
 	var/datum/role/ninja/newninja = new
@@ -146,9 +137,7 @@
 	if (!spoider)
 		spoider = ticker.mode.CreateFaction(/datum/faction/spider_clan, null, 1)
 	spoider.HandleRecruitedRole(newninja)
-	newninja.OnPostSetup()
 	newninja.Greet(GREET_DEFAULT)
-	newninja.AnnounceObjectives()
 	return 1
 
 

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
@@ -136,8 +136,8 @@
 
 /datum/dynamic_ruleset/latejoin/ninja/execute()
 	var/mob/M = pick(candidates)
-	M.loc = null
-	M.forceMove(null)
+	M.loc = null //this is to prevent the latejoin player spawn system
+	M.forceMove(null) //from spawning the ninja in the arrivals shuttle
 	assigned += M
 	candidates -= M
 	var/datum/role/ninja/newninja = new

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -119,11 +119,6 @@
 
 	applicants.Cut()
 
-/datum/dynamic_ruleset/midround/from_ghosts/proc/generate_ruleset_body(mob/applicant)
-	var/mob/living/carbon/human/new_character = makeBody(applicant)
-	new_character.dna.ResetSE()
-	return new_character
-
 /datum/dynamic_ruleset/midround/from_ghosts/proc/finish_setup(var/mob/new_character, var/index)
 	var/datum/role/new_role = new role_category
 	new_role.AssignToRole(new_character.mind,1)

--- a/code/datums/gamemode/role/ninja.dm
+++ b/code/datums/gamemode/role/ninja.dm
@@ -17,7 +17,8 @@
 	. =..()
 	if(!.)
 		return
-	antag.current.forceMove(pick(ninjastart))
+	spawn(3)
+		antag.current.forceMove(pick(ninjastart))
 	if(ishuman(antag.current))
 		antag.current << sound('sound/effects/yooooooooooo.ogg')
 		equip_ninja(antag.current)
@@ -44,7 +45,7 @@
 		if(!iscarbon(M) && !issilicon(M))
 			continue
 		var/turf/T = get_turf(M)
-		if(T.z != STATION_Z)
+		if(T && T.z != STATION_Z)
 			continue
 		if(M.stat != DEAD)
 			living++

--- a/code/datums/gamemode/role/ninja.dm
+++ b/code/datums/gamemode/role/ninja.dm
@@ -17,8 +17,7 @@
 	. =..()
 	if(!.)
 		return
-	spawn(3) //to ensure other running processes don't throw them somewhere else
-		antag.current.forceMove(pick(ninjastart))
+	antag.current.forceMove(pick(ninjastart))
 	if(ishuman(antag.current))
 		antag.current << sound('sound/effects/yooooooooooo.ogg')
 		equip_ninja(antag.current)

--- a/code/datums/gamemode/role/ninja.dm
+++ b/code/datums/gamemode/role/ninja.dm
@@ -17,7 +17,7 @@
 	. =..()
 	if(!.)
 		return
-	spawn(3)
+	spawn(3) //to ensure other running processes don't throw them somewhere else
 		antag.current.forceMove(pick(ninjastart))
 	if(ishuman(antag.current))
 		antag.current << sound('sound/effects/yooooooooooo.ogg')


### PR DESCRIPTION
Re-adds latejoin ninjas, but this time with a prompt asking the player if they want to ninja.
![prompt](https://user-images.githubusercontent.com/8468269/84667885-33714980-af23-11ea-8af7-f018d47217b3.png)
Minor adjustments to related systems to accompany the change.
Tested as far as I could think of, seems to work as intended without runtimes.

Closes #22199 and #22463.

🆑 
 - rscadd: Latejoin ninjas are back!