### PR TITLE
Expunges hasvar()

### DIFF
--- a/__DEFINES/_macros.dm
+++ b/__DEFINES/_macros.dm
@@ -400,3 +400,6 @@ proc/get_space_area()
 
 // strips all newlines from a string, replacing them with null
 #define STRIP_NEWLINE(S) replacetextEx(S, "\n", null)
+
+#define istransformable(A) istype(A, /atom)
+#define isapperanceeditable(A) istype(A, /atom)

--- a/__DEFINES/_macros.dm
+++ b/__DEFINES/_macros.dm
@@ -401,5 +401,5 @@ proc/get_space_area()
 // strips all newlines from a string, replacing them with null
 #define STRIP_NEWLINE(S) replacetextEx(S, "\n", null)
 
-#define istransformable(A) istype(A, /atom)
-#define isapperanceeditable(A) istype(A, /atom)
+#define istransformable(A) (isatom(A))
+#define isapperanceeditable(A) (isatom(A))

--- a/code/ATMOSPHERICS/components/binary_devices/binary_atmos_base.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/binary_atmos_base.dm
@@ -15,6 +15,7 @@
 	var/activity_log = ""
 	layer = BINARY_PIPE_LAYER
 	var/on = FALSE
+	 
 
 /obj/machinery/atmospherics/binary/investigation_log(var/subject, var/message)
 	activity_log += ..()

--- a/code/ATMOSPHERICS/components/binary_devices/dp_vent_pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/dp_vent_pump.dm
@@ -22,7 +22,7 @@
 	//4: Do not pass output_pressure_max
 
 	var/frequency = 0
-
+	
 	var/datum/radio_frequency/radio_connection
 
 	machine_flags = MULTITOOL_MENU

--- a/code/ATMOSPHERICS/components/binary_devices/dp_vent_pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/dp_vent_pump.dm
@@ -22,7 +22,7 @@
 	//4: Do not pass output_pressure_max
 
 	var/frequency = 0
-	var/id_tag = null
+
 	var/datum/radio_frequency/radio_connection
 
 	machine_flags = MULTITOOL_MENU

--- a/code/ATMOSPHERICS/components/binary_devices/heat_pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/heat_pump.dm
@@ -36,7 +36,7 @@ It also must be positive. Technically it can be 0 without breaking physics, but 
 
 	ghost_read = FALSE
 
-	var/id_tag
+	id_tag
 	var/frequency = 0
 	var/datum/radio_frequency/radio_connection
 	machine_flags = MULTITOOL_MENU

--- a/code/ATMOSPHERICS/components/binary_devices/heat_pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/heat_pump.dm
@@ -36,7 +36,6 @@ It also must be positive. Technically it can be 0 without breaking physics, but 
 
 	ghost_read = FALSE
 
-	id_tag
 	var/frequency = 0
 	var/datum/radio_frequency/radio_connection
 	machine_flags = MULTITOOL_MENU

--- a/code/ATMOSPHERICS/components/binary_devices/passive_gate.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/passive_gate.dm
@@ -10,7 +10,7 @@
 	var/open = FALSE
 
 	var/frequency = 0
-	var/id_tag = null
+
 	var/datum/radio_frequency/radio_connection
 	machine_flags = MULTITOOL_MENU
 

--- a/code/ATMOSPHERICS/components/binary_devices/pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/pump.dm
@@ -24,7 +24,7 @@ air2.volume
 	var/target_pressure = ONE_ATMOSPHERE
 
 	var/frequency = 0
-	var/id_tag = null
+
 	var/datum/radio_frequency/radio_connection
 
 	machine_flags = MULTITOOL_MENU

--- a/code/ATMOSPHERICS/components/binary_devices/valve.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/valve.dm
@@ -112,7 +112,7 @@
 	desc = "A digitally controlled valve."
 	icon = 'icons/obj/atmospherics/digital_valve.dmi'
 	var/frequency = 0
-	var/id_tag = null
+
 	var/datum/radio_frequency/radio_connection
 
 	machine_flags = MULTITOOL_MENU

--- a/code/ATMOSPHERICS/components/binary_devices/volume_pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/volume_pump.dm
@@ -25,7 +25,7 @@ Thus, the two variables affect pump operation are set in New():
 
 	var/frequency = 0
 	var/pump_stalled = 0
-	var/id_tag = null
+
 	var/datum/radio_frequency/radio_connection
 
 	machine_flags = MULTITOOL_MENU
@@ -59,7 +59,7 @@ Thus, the two variables affect pump operation are set in New():
 		return
 	else
 		pump_stalled = 0
-		update_icon() 
+		update_icon()
 
 	var/transfer_ratio = max(1, transfer_rate/air1.volume)
 

--- a/code/ATMOSPHERICS/components/trinary_devices/t_valve.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/t_valve.dm
@@ -181,7 +181,7 @@
 	icon = 'icons/obj/atmospherics/digital_valve.dmi'
 
 	var/frequency = 0
-	var/id_tag = null
+
 	var/datum/radio_frequency/radio_connection
 
 	mirror = /obj/machinery/atmospherics/trinary/tvalve/digital/mirrored
@@ -202,7 +202,7 @@
 			id_tag = newid
 			initialize()
 		return MT_UPDATE
-		
+
 	if("set_freq" in href_list)
 		var/newfreq=frequency
 		if(href_list["set_freq"]!="-1")

--- a/code/ATMOSPHERICS/components/unary/outlet_injector.dm
+++ b/code/ATMOSPHERICS/components/unary/outlet_injector.dm
@@ -13,7 +13,7 @@
 	var/max_rate=50
 
 	var/frequency = 0
-	var/id_tag = null
+	 
 	var/datum/radio_frequency/radio_connection
 
 	level = 1

--- a/code/ATMOSPHERICS/components/unary/outlet_injector.dm
+++ b/code/ATMOSPHERICS/components/unary/outlet_injector.dm
@@ -13,7 +13,6 @@
 	var/max_rate=50
 
 	var/frequency = 0
-	 
 	var/datum/radio_frequency/radio_connection
 
 	level = 1

--- a/code/ATMOSPHERICS/components/unary/vent_pump.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_pump.dm
@@ -8,7 +8,7 @@
 
 	level = 1
 	var/area_uid
-	var/id_tag = null
+	 
 
 	var/hibernate = 0 //Optimization
 	var/on = 0

--- a/code/ATMOSPHERICS/components/unary/vent_pump.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_pump.dm
@@ -8,7 +8,6 @@
 
 	level = 1
 	var/area_uid
-	 
 
 	var/hibernate = 0 //Optimization
 	var/on = 0

--- a/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
@@ -9,7 +9,6 @@
 
 	level				= 1
 
-	var/id_tag			= null
 	var/frequency		= 1439
 	var/datum/radio_frequency/radio_connection
 

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -869,7 +869,7 @@ proc/GaussRandRound(var/sigma,var/roundto)
 //Takes: Anything that could possibly have variables and a varname to check.
 //Returns: 1 if found, 0 if not.
 /proc/hasvar(var/datum/A, var/varname)
-	if(A.vars.Find(lowertext(varname)))
+	if(lowertext(varname) in A.vars)
 		return 1
 	else
 		return 0

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -866,14 +866,6 @@ proc/GaussRandRound(var/sigma,var/roundto)
 	sleep(time)
 	return 1
 
-//Takes: Anything that could possibly have variables and a varname to check.
-//Returns: 1 if found, 0 if not.
-/proc/hasvar(var/datum/A, var/varname)
-	if(lowertext(varname) in A.vars)
-		return 1
-	else
-		return 0
-
 //Returns sortedAreas list if populated
 //else populates the list first before returning it
 /proc/SortAreas()

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -138,9 +138,9 @@
 	if(istype(D,/atom))
 		body += "<option value='?_src_=vars;teleport_to=\ref[D]'>Teleport To</option>"
 
-	if(hasvar(D, "transform"))
+	if(istransformable(D))
 		body += "<option value='?_src_=vars;edit_transform=\ref[D]'>Edit Transform Matrix</option>"
-	if(hasvar(D, "appearance_flags"))
+	if(isapperanceeditable(D))
 		body += "<option value='?_src_=vars;toggle_aliasing=\ref[D]'>Toggle Transform Aliasing</option>"
 
 	body += "<option value='?_src_=vars;proc_call=\ref[D]'>Proc call</option>"
@@ -859,7 +859,7 @@ function loadPage(list) {
 			if ("Monolith")
 				rod_type = /obj/item/projectile/immovablerod/hyper
 
-		if(alert("Are you sure you want to do this?","Confirm","Yes","No") != "Yes")	
+		if(alert("Are you sure you want to do this?","Confirm","Yes","No") != "Yes")
 			return
 
 		var/obj/item/projectile/immovablerod/rod = new rod_type(random_start_turf(A.z))
@@ -1163,7 +1163,7 @@ function loadPage(list) {
 			return
 
 		var/datum/DAT = locate(href_list["edit_transform"])
-		if (!hasvar(DAT, "transform"))
+		if (!istransformable(DAT))
 			to_chat(src, "This object does not have a transform variable to edit!")
 			return
 
@@ -1180,7 +1180,7 @@ function loadPage(list) {
 			return
 
 		var/datum/DAT = locate(href_list["toggle_aliasing"])
-		if(!hasvar(DAT, "appearance_flags"))
+		if(!isapperanceeditable(DAT))
 			to_chat(src, "This object does not support appearance flags!")
 			return
 

--- a/code/datums/disease.dm
+++ b/code/datums/disease.dm
@@ -191,6 +191,7 @@ var/list/diseases = typesof(/datum/disease) - /datum/disease
 	active_diseases -= src
 	if(affected_mob)
 		affected_mob.viruses -= src
+	holder = null
 	..()
 
 /datum/disease/New(var/process=1, var/datum/disease/D)//process = 1 - adding the object to global list. List is processed by master controller.

--- a/code/datums/helper_datums/construction_datum.dm
+++ b/code/datums/helper_datums/construction_datum.dm
@@ -37,6 +37,10 @@
 	add_max_amounts()
 	return
 
+/datum/construction/Destroy()
+	holder = null
+	return ..()
+
 /datum/construction/proc/next_step(mob/user as mob)
 	steps.len--
 	if(!steps.len)

--- a/code/game/machinery/airlock_control.dm
+++ b/code/game/machinery/airlock_control.dm
@@ -7,7 +7,7 @@
 
 // This code allows for airlocks to be controlled externally by setting an id_tag and comm frequency (disables ID access)
 /obj/machinery/door/airlock
-	var/id_tag
+
 	var/frequency
 	var/shockedby = list()
 	var/datum/radio_frequency/radio_connection
@@ -169,7 +169,7 @@ obj/machinery/airlock_sensor
 	anchored = 1
 	power_channel = ENVIRON
 
-	var/id_tag
+
 	var/master_tag
 	var/frequency = 1449
 	var/command = "cycle"

--- a/code/game/machinery/atmo_control.dm
+++ b/code/game/machinery/atmo_control.dm
@@ -5,7 +5,7 @@
 
 	anchored = 1
 
-	var/id_tag
+
 	var/frequency = 1439
 
 	var/on = 1

--- a/code/game/machinery/atmoalter/meter.dm
+++ b/code/game/machinery/atmoalter/meter.dm
@@ -8,7 +8,7 @@
 	anchored = 1.0
 	power_channel = ENVIRON
 	var/frequency = 1439
-	var/id_tag
+
 	use_power = 1
 	idle_power_usage = 2
 	active_power_usage = 4

--- a/code/game/machinery/bots/bots.dm
+++ b/code/game/machinery/bots/bots.dm
@@ -652,7 +652,7 @@
 	else if (istype(W, /obj/item/weapon/card/emag) && emagged < 2)
 		Emag(user)
 	else
-		if(hasvar(W,"force") && hasvar(W,"damtype"))
+		if(isobj(W))
 			W.on_attack(src, user)
 			visible_message("<span class='danger'>[src] has been hit by [user] with [W].</span>")
 			switch(W.damtype)

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -3,7 +3,7 @@
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "launcherbtt"
 	desc = "A remote control switch for a mass driver."
-	id_tag  = "default"
+	id_tag = "default"
 	var/active = 0
 	anchored = 1.0
 	use_power = 1

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -3,7 +3,7 @@
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "launcherbtt"
 	desc = "A remote control switch for a mass driver."
-	var/id_tag = "default"
+	id_tag  = "default"
 	var/active = 0
 	anchored = 1.0
 	use_power = 1
@@ -34,7 +34,7 @@
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "launcherbtt"
 	desc = "A remote control switch for a mounted igniter."
-	var/id_tag = null
+
 	var/active = 0
 	anchored = 1.0
 	use_power = 1
@@ -52,7 +52,7 @@
 	desc = "A remote control switch for a mounted flasher."
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "launcherbtt"
-	var/id_tag = null
+
 	var/active = 0
 	anchored = 1.0
 	use_power = 1

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -353,7 +353,7 @@
 	desc = "A circuit board for running a computer used to operate stacking machines."
 	build_path = /obj/machinery/computer/stacking_unit
 	origin_tech = Tc_PROGRAMMING + "=2;" + Tc_MATERIALS + "=2"
-	
+
 /obj/item/weapon/circuitboard/attackby(obj/item/I as obj, mob/user as mob)
 	if(issolder(I))
 		var/obj/item/weapon/solder/S = I

--- a/code/game/machinery/door_control.dm
+++ b/code/game/machinery/door_control.dm
@@ -5,7 +5,7 @@
 	icon_state = "doorctrl0"
 	desc = "A remote control-switch for a door."
 	power_channel = ENVIRON
-	var/id_tag = null
+	 
 	var/range = 10
 	var/normaldoorcontrol = 0
 	var/specialfunctions = 1

--- a/code/game/machinery/door_control.dm
+++ b/code/game/machinery/door_control.dm
@@ -5,7 +5,6 @@
 	icon_state = "doorctrl0"
 	desc = "A remote control-switch for a door."
 	power_channel = ENVIRON
-	 
 	var/range = 10
 	var/normaldoorcontrol = 0
 	var/specialfunctions = 1

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -16,7 +16,7 @@
 	req_access = list(access_brig)
 	anchored = TRUE
 	density = FALSE
-	var/id_tag = null     	// id of door it controls
+	      	// id of door it controls
 	var/timeleft = 0		// in seconds
 	var/timing = FALSE
 	var/picture_state		// icon_state of alert picture, if not displaying text/numbers

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -16,7 +16,6 @@
 	req_access = list(access_brig)
 	anchored = TRUE
 	density = FALSE
-	      	// id of door it controls
 	var/timeleft = 0		// in seconds
 	var/timing = FALSE
 	var/picture_state		// icon_state of alert picture, if not displaying text/numbers

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -12,7 +12,7 @@ var/list/poddoors = list()
 	explosion_block = 3
 	penetration_dampening = 20
 
-	id_tag  = 1.0
+	id_tag = 1.0
 
 	prefix = "r_"
 	animation_delay = 5

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -12,7 +12,7 @@ var/list/poddoors = list()
 	explosion_block = 3
 	penetration_dampening = 20
 
-	var/id_tag = 1.0
+	id_tag  = 1.0
 
 	prefix = "r_"
 	animation_delay = 5

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -24,7 +24,7 @@
 	var/obj/machinery/smartglass_electronics/smartwindow
 	var/window_is_opaque = FALSE //The var that helps darken the glass when the door opens/closes
 	var/assembly_type = /obj/structure/windoor_assembly
-	var/id_tag = null
+	 
 
 /obj/machinery/door/window/New()
 	..()

--- a/code/game/machinery/embedded_controller/embedded_controller_base.dm
+++ b/code/game/machinery/embedded_controller/embedded_controller_base.dm
@@ -163,7 +163,7 @@
 	density = 0
 
 	// Setup parameters only
-	var/id_tag
+
 	var/tag_exterior_door
 	var/tag_interior_door
 	var/tag_airpump
@@ -273,10 +273,11 @@
 
 		if("buffer" in href_list)
 			if(istype(src, /obj/machinery/telecomms))
-				if(!hasvar(src, "id"))
+				var/obj/machinery/telecomms/T = src
+				if(!T.id) // Telecomms are identified by ID
 					to_chat(usr, "<span class='danger'>A red light flashes and nothing changes.</span>")
 					return
-			else if(!hasvar(src, "id_tag"))
+			else if(!id_tag)
 				to_chat(usr, "<span class='danger'>A red light flashes and nothing changes.</span>")
 				return
 			P.buffer = src

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -6,7 +6,7 @@ var/list/obj/machinery/flasher/flashers = list()
 	desc = "A wall-mounted flashbulb device."
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "mflash1"
-	var/id_tag = null
+	 
 	var/range = 2 //this is roughly the size of brig cell
 	var/disable = 0
 	var/last_flash = 0 //Don't want it getting spammed like regular flashes

--- a/code/game/machinery/holosign.dm
+++ b/code/game/machinery/holosign.dm
@@ -12,7 +12,6 @@ var/list/obj/machinery/holosign/holosigns = list()
 	ghost_read = 0 // Deactivate ghost touching.
 	ghost_write = 0
 	var/lit = 0
-	 
 	var/on_icon = "sign_on"
 
 /obj/machinery/holosign/New()
@@ -51,7 +50,6 @@ var/list/obj/machinery/holosign/holosigns = list()
 	icon = 'icons/obj/power.dmi'
 	icon_state = "light1"
 	desc = "A remote control switch for holosign."
-	 
 	var/active = 0
 	anchored = 1.0
 	use_power = 1

--- a/code/game/machinery/holosign.dm
+++ b/code/game/machinery/holosign.dm
@@ -12,7 +12,7 @@ var/list/obj/machinery/holosign/holosigns = list()
 	ghost_read = 0 // Deactivate ghost touching.
 	ghost_write = 0
 	var/lit = 0
-	var/id_tag = null
+	 
 	var/on_icon = "sign_on"
 
 /obj/machinery/holosign/New()
@@ -51,7 +51,7 @@ var/list/obj/machinery/holosign/holosigns = list()
 	icon = 'icons/obj/power.dmi'
 	icon_state = "light1"
 	desc = "A remote control switch for holosign."
-	var/id_tag = null
+	 
 	var/active = 0
 	anchored = 1.0
 	use_power = 1

--- a/code/game/machinery/igniter.dm
+++ b/code/game/machinery/igniter.dm
@@ -4,7 +4,6 @@ var/global/list/igniters = list()
 	desc = "It's useful for igniting plasma."
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "igniter1"
-	 
 	var/on = 1.0
 	var/obj/item/device/assembly_holder/assembly=null
 	anchored = 1.0
@@ -86,7 +85,6 @@ var/global/list/igniters = list()
 	desc = "A wall-mounted ignition device."
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "migniter"
-	 
 	var/disable = 0
 	var/last_spark = 0
 	var/base_state = "migniter"

--- a/code/game/machinery/igniter.dm
+++ b/code/game/machinery/igniter.dm
@@ -4,7 +4,7 @@ var/global/list/igniters = list()
 	desc = "It's useful for igniting plasma."
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "igniter1"
-	var/id_tag = null
+	 
 	var/on = 1.0
 	var/obj/item/device/assembly_holder/assembly=null
 	anchored = 1.0
@@ -86,7 +86,7 @@ var/global/list/igniters = list()
 	desc = "A wall-mounted ignition device."
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "migniter"
-	var/id_tag = null
+	 
 	var/disable = 0
 	var/last_spark = 0
 	var/base_state = "migniter"

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -153,6 +153,7 @@ Class Procs:
 
 	var/inMachineList = 1 // For debugging.
 	var/obj/item/weapon/card/id/scan = null	//ID inserted for identification, if applicable
+	var/id_tag = null // Identify the machine
 
 /obj/machinery/cultify()
 	var/list/random_structure = list(
@@ -332,10 +333,11 @@ Class Procs:
 
 		if("buffer" in href_list)
 			if(istype(src, /obj/machinery/telecomms))
-				if(!hasvar(src, "id"))
+				var/obj/machinery/telecomms/T = src
+				if(!T.id)
 					to_chat(usr, "<span class='danger'>A red light flashes and nothing changes.</span>")
 					return
-			else if(!hasvar(src, "id_tag"))
+			else if(!id_tag)
 				to_chat(usr, "<span class='danger'>A red light flashes and nothing changes.</span>")
 				return
 			P.buffer = src

--- a/code/game/machinery/mass_driver.dm
+++ b/code/game/machinery/mass_driver.dm
@@ -13,7 +13,7 @@ var/list/mass_drivers = list()
 
 	var/power = 1.0
 	var/code = 1.0
-	id_tag  = "default"
+	id_tag = "default"
 	var/drive_range = 50 //this is mostly irrelevant since current mass drivers throw into space, but you could make a lower-range mass driver for interstation transport or something I guess.
 
 /obj/machinery/mass_driver/New()

--- a/code/game/machinery/mass_driver.dm
+++ b/code/game/machinery/mass_driver.dm
@@ -13,7 +13,7 @@ var/list/mass_drivers = list()
 
 	var/power = 1.0
 	var/code = 1.0
-	var/id_tag = "default"
+	id_tag  = "default"
 	var/drive_range = 50 //this is mostly irrelevant since current mass drivers throw into space, but you could make a lower-range mass driver for interstation transport or something I guess.
 
 /obj/machinery/mass_driver/New()

--- a/code/game/machinery/metaldetector.dm
+++ b/code/game/machinery/metaldetector.dm
@@ -6,7 +6,7 @@
 	desc = "This state of the art unit allows NT security personnel to contain a situation or secure an area better and faster."
 	icon = 'icons/obj/detector.dmi'
 	icon_state = "detector1"
-	var/id_tag = null
+	 
 	var/range = 3
 	var/disable = 0
 	var/last_read = 0

--- a/code/game/machinery/metaldetector.dm
+++ b/code/game/machinery/metaldetector.dm
@@ -6,7 +6,6 @@
 	desc = "This state of the art unit allows NT security personnel to contain a situation or secure an area better and faster."
 	icon = 'icons/obj/detector.dmi'
 	icon_state = "detector1"
-	 
 	var/range = 3
 	var/disable = 0
 	var/last_read = 0

--- a/code/game/machinery/smartglass.dm
+++ b/code/game/machinery/smartglass.dm
@@ -23,7 +23,6 @@
 	var/obj/structure/window/Ourwindow //Ref to the window we're in
 
 	//Radio vars
-
 	var/frequency = 1449
 	var/datum/radio_frequency/radio_connection
 

--- a/code/game/machinery/smartglass.dm
+++ b/code/game/machinery/smartglass.dm
@@ -23,7 +23,7 @@
 	var/obj/structure/window/Ourwindow //Ref to the window we're in
 
 	//Radio vars
-	var/id_tag
+
 	var/frequency = 1449
 	var/datum/radio_frequency/radio_connection
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -92,13 +92,8 @@
 	if(istype(loc, /mob))
 		var/mob/H = loc
 		H.drop_from_inventory(src) // items at the very least get unequipped from their mob before being deleted
-	if(hasvar(src, "holder"))
-		src:holder = null
 	for(var/x in actions)
 		qdel(x)
-	/*  BROKEN, FUCK BYOND
-	if(hasvar(src, "my_atom"))
-		src:my_atom = null*/
 	..()
 
 

--- a/code/game/objects/items/devices/remote/remote_buttons.dm
+++ b/code/game/objects/items/devices/remote/remote_buttons.dm
@@ -20,6 +20,10 @@
 	base_state = icon_state
 	button_icon = image(src.icon)
 
+/obj/item/device/remote_button/Destroy()
+	holder = null
+	return ..()
+
 /obj/item/device/remote_button/update_icon(button_id = 0)
 	if(holder)
 		holder.overlays -= button_icon

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -15,6 +15,7 @@
 	var/icon_off = "secureoff"
 	wall_mounted = 0 //never solid (You can always pass over it)
 	health = 200
+	var/id_tag = null
 
 /obj/structure/closet/secure_closet/basic
 	has_lockless_type = /obj/structure/closet/basic
@@ -22,7 +23,7 @@
 /obj/structure/closet/secure_closet/can_open()
 	if(!..())
 		return 0
-	if(src.locked)	
+	if(src.locked)
 		return 0
 	return 1
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -264,7 +264,6 @@
 	name = "Brig Locker"
 	req_access = list(access_brig)
 	anchored = 1
-	 
 
 /obj/structure/closet/secure_closet/brig/atoms_to_spawn()
 	return list(

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -264,7 +264,7 @@
 	name = "Brig Locker"
 	req_access = list(access_brig)
 	anchored = 1
-	var/id_tag = null
+	 
 
 /obj/structure/closet/secure_closet/brig/atoms_to_spawn()
 	return list(

--- a/code/game/objects/structures/docking_port.dm
+++ b/code/game/objects/structures/docking_port.dm
@@ -266,7 +266,7 @@ var/global/list/dockinglights = list()
 	light_color = LIGHT_COLOR_ORANGE
 	machine_flags = MULTITOOL_MENU
 	var/triggered = 0
-	var/id_tag = "" //Mappers: This should match the areaname of the target destination port.
+	id_tag  = "" //Mappers: This should match the areaname of the target destination port.
 	//Examples: "main research department", "research outpost", "deep space", "station auxillary docking", "north of the station", etc.
 
 /obj/machinery/docklight/New()

--- a/code/game/objects/structures/docking_port.dm
+++ b/code/game/objects/structures/docking_port.dm
@@ -266,7 +266,7 @@ var/global/list/dockinglights = list()
 	light_color = LIGHT_COLOR_ORANGE
 	machine_flags = MULTITOOL_MENU
 	var/triggered = 0
-	id_tag  = "" //Mappers: This should match the areaname of the target destination port.
+	id_tag = "" //Mappers: This should match the areaname of the target destination port.
 	//Examples: "main research department", "research outpost", "deep space", "station auxillary docking", "north of the station", etc.
 
 /obj/machinery/docklight/New()

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -753,7 +753,7 @@ var/list/one_way_windows
 // Smartglass for mappers, smartglassified on roundstart.
 //the id_tag of the actual pane itself is passed to the smartglass electronics on initialization, it's not used for anything else
 /obj/structure/window/smart
-	var/id_tag = null
+	var/id_tag
 	var/frequency = 1449
 
 /obj/structure/window/smart/initialize()
@@ -762,7 +762,7 @@ var/list/one_way_windows
 	smartwindow.frequency = frequency
 
 /obj/structure/window/full/smart
-	var/id_tag = null
+	var/id_tag
 	var/frequency = 1449
 
 /obj/structure/window/full/smart/initialize()
@@ -771,7 +771,7 @@ var/list/one_way_windows
 	smartwindow.frequency = frequency
 
 /obj/structure/window/reinforced/smart
-	var/id_tag = null
+	var/id_tag
 	var/frequency = 1449
 
 /obj/structure/window/reinforced/smart/initialize()
@@ -780,7 +780,7 @@ var/list/one_way_windows
 	smartwindow.frequency = frequency
 
 /obj/structure/window/full/reinforced/smart
-	var/id_tag = null
+	var/id_tag
 	var/frequency = 1449
 
 /obj/structure/window/full/reinforced/smart/initialize()
@@ -789,7 +789,7 @@ var/list/one_way_windows
 	smartwindow.frequency = frequency
 
 /obj/structure/window/plasma/smart
-	var/id_tag = null
+	var/id_tag
 	var/frequency = 1449
 
 /obj/structure/window/plasma/smart/initialize()
@@ -798,7 +798,7 @@ var/list/one_way_windows
 	smartwindow.frequency = frequency
 
 /obj/structure/window/full/plasma/smart
-	var/id_tag = null
+	var/id_tag
 	var/frequency = 1449
 
 /obj/structure/window/full/plasma/smart/initialize()
@@ -807,7 +807,7 @@ var/list/one_way_windows
 	smartwindow.frequency = frequency
 
 /obj/structure/window/reinforced/plasma/smart
-	var/id_tag = null
+	var/id_tag
 	var/frequency = 1449
 
 /obj/structure/window/reinforced/plasma/smart/initialize()
@@ -816,7 +816,7 @@ var/list/one_way_windows
 	smartwindow.frequency = frequency
 
 /obj/structure/window/full/reinforced/plasma/smart
-	var/id_tag = null
+	var/id_tag
 	var/frequency = 1449
 
 /obj/structure/window/full/reinforced/plasma/smart/initialize()

--- a/code/modules/components/ai/controller.dm
+++ b/code/modules/components/ai/controller.dm
@@ -10,6 +10,10 @@
 	..(container)
 	holder=_holder
 
+/datum/component/controller/Destroy()
+	holder = null
+	return ..()
+
 // Called when we are bumped by another movable atom.
 /datum/component/controller/proc/OnBumped(var/atom/A)
 	if(istype(A, /atom/movable))

--- a/code/modules/context_click/context_click.dm
+++ b/code/modules/context_click/context_click.dm
@@ -12,6 +12,10 @@ IDs can then be used to cause certain behaviour using the action() proc
 	..()
 	holder = to_hold
 
+/datum/context_click/Destroy()
+	holder = null
+	return ..()
+
 //Gives the id clicked in this particular handler
 /datum/context_click/proc/return_clicked_id(var/x_pos, var/y_pos)
 	return

--- a/code/modules/media/machinery.dm
+++ b/code/modules/media/machinery.dm
@@ -12,7 +12,7 @@
 	var/exclusive_hook=null // Disables output to the room
 
 	// Media system autolink.
-	id_tag  = "???"
+	id_tag = "???"
 
 /obj/machinery/media/proc/hookMediaOutput(var/obj/machinery/media/transmitter/T, exclusive=0)
 	if(exclusive)

--- a/code/modules/media/machinery.dm
+++ b/code/modules/media/machinery.dm
@@ -12,7 +12,7 @@
 	var/exclusive_hook=null // Disables output to the room
 
 	// Media system autolink.
-	var/id_tag = "???"
+	id_tag  = "???"
 
 /obj/machinery/media/proc/hookMediaOutput(var/obj/machinery/media/transmitter/T, exclusive=0)
 	if(exclusive)

--- a/code/modules/medical/cloning.dm
+++ b/code/modules/medical/cloning.dm
@@ -25,7 +25,7 @@
 	var/biomass = 0
 	var/time_coeff = 1 //Upgraded via part upgrading
 	var/resource_efficiency = 1
-	var/id_tag = "clone_pod"
+	id_tag  = "clone_pod"
 	var/upgraded = 0 //if fully upgraded with T4 components, it will drastically improve and allow for some stuff
 	var/obj/machinery/computer/cloning/cloning_computer = null
 

--- a/code/modules/medical/cloning.dm
+++ b/code/modules/medical/cloning.dm
@@ -25,7 +25,7 @@
 	var/biomass = 0
 	var/time_coeff = 1 //Upgraded via part upgrading
 	var/resource_efficiency = 1
-	id_tag  = "clone_pod"
+	id_tag = "clone_pod"
 	var/upgraded = 0 //if fully upgraded with T4 components, it will drastically improve and allow for some stuff
 	var/obj/machinery/computer/cloning/cloning_computer = null
 

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -277,7 +277,6 @@
 	var/atom/movable/mover //Virtual atom used to check passing ability on the out turf.
 
 	var/frequency = FREQ_DISPOSAL //Same as conveyors
-	 
 	var/datum/radio_frequency/radio_connection
 
 	var/datum/materials/ore
@@ -293,15 +292,11 @@
 
 /obj/machinery/mineral/processing_unit/Destroy()
 	. = ..()
-
-	 
-
 	qdel(mover)
 	mover = null
 
 /obj/machinery/mineral/processing_unit/power_change()
 	. = ..()
-
 	update_icon()
 
 /obj/machinery/mineral/processing_unit/update_icon()

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -277,7 +277,7 @@
 	var/atom/movable/mover //Virtual atom used to check passing ability on the out turf.
 
 	var/frequency = FREQ_DISPOSAL //Same as conveyors
-	var/id_tag = null
+	 
 	var/datum/radio_frequency/radio_connection
 
 	var/datum/materials/ore
@@ -294,7 +294,7 @@
 /obj/machinery/mineral/processing_unit/Destroy()
 	. = ..()
 
-	id_tag = null
+	 
 
 	qdel(mover)
 	mover = null

--- a/code/modules/mining/machine_stacking.dm
+++ b/code/modules/mining/machine_stacking.dm
@@ -141,7 +141,7 @@
 	var/stack_amt = 50 //amount to stack before releassing.
 	var/max_moved = 100
 
-	var/id_tag//The ID of the stacker this console should control
+	 //The ID of the stacker this console should control
 	var/frequency = FREQ_DISPOSAL
 	var/datum/radio_frequency/radio_connection
 
@@ -338,7 +338,7 @@
 	return ..()
 
 /obj/machinery/mineral/stacking_machine/Destroy()
-	id_tag = null
+
 
 	qdel(mover)
 	mover = null

--- a/code/modules/mining/machine_stacking.dm
+++ b/code/modules/mining/machine_stacking.dm
@@ -141,7 +141,6 @@
 	var/stack_amt = 50 //amount to stack before releassing.
 	var/max_moved = 100
 
-	 //The ID of the stacker this console should control
 	var/frequency = FREQ_DISPOSAL
 	var/datum/radio_frequency/radio_connection
 
@@ -338,9 +337,6 @@
 	return ..()
 
 /obj/machinery/mineral/stacking_machine/Destroy()
-
-
 	qdel(mover)
 	mover = null
-
 	. = ..()

--- a/code/modules/mining/materials.dm
+++ b/code/modules/mining/materials.dm
@@ -37,6 +37,7 @@ var/global/list/initial_materials	//Stores all the matids = 0 in helping New
 
 /datum/materials/Destroy()
 	holder = null
+	return ..()
 
 /datum/materials/resetVariables(args)
 	var/newargs

--- a/code/modules/power/rust/core_gen.dm
+++ b/code/modules/power/rust/core_gen.dm
@@ -60,7 +60,6 @@ max volume of plasma storeable by the field = the total volume of a number of ti
 	var/field_strength = 1//0.01
 	var/field_frequency = 1
 
-
 	use_power = 1
 	idle_power_usage = 50
 	active_power_usage = 500	//multiplied by field strength

--- a/code/modules/power/rust/core_gen.dm
+++ b/code/modules/power/rust/core_gen.dm
@@ -59,7 +59,7 @@ max volume of plasma storeable by the field = the total volume of a number of ti
 	var/obj/effect/rust_em_field/owned_field
 	var/field_strength = 1//0.01
 	var/field_frequency = 1
-	var/id_tag
+
 
 	use_power = 1
 	idle_power_usage = 50

--- a/code/modules/power/rust/fuel_injector.dm
+++ b/code/modules/power/rust/fuel_injector.dm
@@ -12,7 +12,7 @@
 
 	var/obj/item/weapon/fuel_assembly/cur_assembly
 	var/fuel_usage = 0.0001			//percentage of available fuel to use per cycle
-	var/id_tag
+	 
 	var/injecting = FALSE
 
 	use_power = 1

--- a/code/modules/power/rust/gyrotron.dm
+++ b/code/modules/power/rust/gyrotron.dm
@@ -13,7 +13,6 @@
 	var/rate = 10
 	var/mega_energy = 0.001
 
-
 	req_access = list(access_engine)
 
 	use_power = 1

--- a/code/modules/power/rust/gyrotron.dm
+++ b/code/modules/power/rust/gyrotron.dm
@@ -12,7 +12,7 @@
 	var/emitting = 0
 	var/rate = 10
 	var/mega_energy = 0.001
-	var/id_tag
+
 
 	req_access = list(access_engine)
 

--- a/code/modules/power/rust/gyrotron_controller.dm
+++ b/code/modules/power/rust/gyrotron_controller.dm
@@ -4,7 +4,7 @@
 	circuit = /obj/item/weapon/circuitboard/rust_gyrotron_control
 	light_color = LIGHT_COLOR_BLUE
 
-	var/id_tag // Required for multitool buffering
+	  // Required for multitool buffering
 	var/list/linked_gyrotrons[0] //List of linked gyrotrons.
 
 /obj/machinery/computer/rust_gyrotron_controller/initialize()

--- a/code/modules/power/rust/gyrotron_controller.dm
+++ b/code/modules/power/rust/gyrotron_controller.dm
@@ -3,8 +3,6 @@
 	icon_state = "engine"
 	circuit = /obj/item/weapon/circuitboard/rust_gyrotron_control
 	light_color = LIGHT_COLOR_BLUE
-
-	  // Required for multitool buffering
 	var/list/linked_gyrotrons[0] //List of linked gyrotrons.
 
 /obj/machinery/computer/rust_gyrotron_controller/initialize()

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -24,7 +24,6 @@
 	machine_flags = EMAGGABLE | WRENCHMOVE | FIXED2WORK | WELD_FIXED | MULTITOOL_MENU
 
 	var/frequency = 0
-	 
 	var/datum/radio_frequency/radio_connection
 
 	//Now uses a constant beam.

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -24,7 +24,7 @@
 	machine_flags = EMAGGABLE | WRENCHMOVE | FIXED2WORK | WELD_FIXED | MULTITOOL_MENU
 
 	var/frequency = 0
-	var/id_tag = null
+	 
 	var/datum/radio_frequency/radio_connection
 
 	//Now uses a constant beam.

--- a/code/modules/power/solars/control.dm
+++ b/code/modules/power/solars/control.dm
@@ -13,7 +13,7 @@
 	use_power = 1
 	idle_power_usage = 50
 	active_power_usage = 300
-	id_tag  = 0
+	id_tag = 0
 	var/cdir = 0
 	var/gen = 0
 	var/lastgen = 0

--- a/code/modules/power/solars/control.dm
+++ b/code/modules/power/solars/control.dm
@@ -13,7 +13,7 @@
 	use_power = 1
 	idle_power_usage = 50
 	active_power_usage = 300
-	var/id_tag = 0
+	id_tag  = 0
 	var/cdir = 0
 	var/gen = 0
 	var/lastgen = 0

--- a/code/modules/power/solars/panel.dm
+++ b/code/modules/power/solars/panel.dm
@@ -1,6 +1,6 @@
 /obj/machinery/power/solar/panel
 	icon_state = "sp_base"
-	id_tag  = 0
+	id_tag = 0
 	var/health = 15 //Fragile shit, even with state-of-the-art reinforced glass
 	var/maxhealth = 15 //If ANYONE ever makes it so that solars can be directly repaired without glass, also used for fancy calculations
 	var/obscured = 0

--- a/code/modules/power/solars/panel.dm
+++ b/code/modules/power/solars/panel.dm
@@ -1,6 +1,6 @@
 /obj/machinery/power/solar/panel
 	icon_state = "sp_base"
-	var/id_tag = 0
+	id_tag  = 0
 	var/health = 15 //Fragile shit, even with state-of-the-art reinforced glass
 	var/maxhealth = 15 //If ANYONE ever makes it so that solars can be directly repaired without glass, also used for fancy calculations
 	var/obscured = 0

--- a/code/modules/power/turbine.dm
+++ b/code/modules/power/turbine.dm
@@ -34,7 +34,7 @@
 	density = 1
 	var/obj/machinery/compressor/compressor
 	var/list/obj/machinery/door/poddoor/doors
-	var/id_tag = 0
+	id_tag  = 0
 	var/door_status = 0
 
 	light_color = LIGHT_COLOR_BLUE

--- a/code/modules/power/turbine.dm
+++ b/code/modules/power/turbine.dm
@@ -34,7 +34,7 @@
 	density = 1
 	var/obj/machinery/compressor/compressor
 	var/list/obj/machinery/door/poddoor/doors
-	id_tag  = 0
+	id_tag = 0
 	var/door_status = 0
 
 	light_color = LIGHT_COLOR_BLUE

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -21,7 +21,7 @@
 	var/movedir			// the actual direction to move stuff in
 
 	var/list/affecting	// the list of all items that will be moved this ptick
-	var/id_tag = ""			// the control ID	- must match controller ID
+	id_tag  = ""			// the control ID	- must match controller ID
 
 	var/frequency = 1367
 	var/datum/radio_frequency/radio_connection
@@ -403,7 +403,7 @@
 	var/convdir = 0 			// lock to one direction. -1 = reverse, 0 = not locked, 1 = forward
 	var/operated = 1			// true if just operated
 
-	var/id_tag = "" 			// must match conveyor IDs to control them
+	id_tag  = "" 			// must match conveyor IDs to control them
 
 	var/frequency = 1367
 	var/datum/radio_frequency/radio_connection

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -21,7 +21,7 @@
 	var/movedir			// the actual direction to move stuff in
 
 	var/list/affecting	// the list of all items that will be moved this ptick
-	id_tag  = ""			// the control ID	- must match controller ID
+	id_tag = ""			// the control ID	- must match controller ID
 
 	var/frequency = 1367
 	var/datum/radio_frequency/radio_connection
@@ -403,7 +403,7 @@
 	var/convdir = 0 			// lock to one direction. -1 = reverse, 0 = not locked, 1 = forward
 	var/operated = 1			// true if just operated
 
-	id_tag  = "" 			// must match conveyor IDs to control them
+	id_tag = "" 			// must match conveyor IDs to control them
 
 	var/frequency = 1367
 	var/datum/radio_frequency/radio_connection

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -65,7 +65,7 @@
 
 	// Monitoring shit
 	var/frequency = 1333
-	var/id_tag
+
 	var/datum/radio_frequency/radio_connection
 
 	//Add types to this list so it doesn't make a message or get desroyed by the Supermatter on touch.
@@ -504,7 +504,7 @@
 	circuit = "/obj/item/weapon/circuitboard/supermatter"
 	light_color = LIGHT_COLOR_YELLOW
 	var/frequency = 1333
-	var/id_tag //mappable
+	  //mappable
 	var/datum/radio_frequency/radio_connection
 	var/obj/machinery/power/supermatter/linked = null //Gets cleared in process if the shard explodes
 	//"LIST" BUTTON

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -65,7 +65,6 @@
 
 	// Monitoring shit
 	var/frequency = 1333
-
 	var/datum/radio_frequency/radio_connection
 
 	//Add types to this list so it doesn't make a message or get desroyed by the Supermatter on touch.
@@ -504,7 +503,6 @@
 	circuit = "/obj/item/weapon/circuitboard/supermatter"
 	light_color = LIGHT_COLOR_YELLOW
 	var/frequency = 1333
-	  //mappable
 	var/datum/radio_frequency/radio_connection
 	var/obj/machinery/power/supermatter/linked = null //Gets cleared in process if the shard explodes
 	//"LIST" BUTTON

--- a/code/modules/telesci/telepad.dm
+++ b/code/modules/telesci/telepad.dm
@@ -9,7 +9,7 @@
 	idle_power_usage = 200
 	active_power_usage = 5000
 	machine_flags = MULTITOOL_MENU
-	id_tag  = "telepad"
+	id_tag = "telepad"
 
 	var/obj/machinery/computer/telescience/linked
 

--- a/code/modules/telesci/telepad.dm
+++ b/code/modules/telesci/telepad.dm
@@ -9,7 +9,7 @@
 	idle_power_usage = 200
 	active_power_usage = 5000
 	machine_flags = MULTITOOL_MENU
-	var/id_tag = "telepad"
+	id_tag  = "telepad"
 
 	var/obj/machinery/computer/telescience/linked
 

--- a/code/modules/telesci/telesci_computer.dm
+++ b/code/modules/telesci/telesci_computer.dm
@@ -33,7 +33,7 @@
 	var/obj/item/weapon/cell/cell
 	var/teleport_cell_usage=1000 // 100% of a standard cell
 	processing=1
-	id_tag  = "teleconsole"
+	id_tag = "teleconsole"
 
 
 	light_color = LIGHT_COLOR_BLUE

--- a/code/modules/telesci/telesci_computer.dm
+++ b/code/modules/telesci/telesci_computer.dm
@@ -33,7 +33,7 @@
 	var/obj/item/weapon/cell/cell
 	var/teleport_cell_usage=1000 // 100% of a standard cell
 	processing=1
-	var/id_tag = "teleconsole"
+	id_tag  = "teleconsole"
 
 
 	light_color = LIGHT_COLOR_BLUE


### PR DESCRIPTION
In no context is it ever warranted to use it.
I delegated some `id_tag` variables to `/obj/machinery` because 95% of the machinery in the game already store that anyways.