### PR TITLE
Fixes rig modules trying to scream with no mouth

### DIFF
--- a/code/modules/clothing/spacesuits/rig_modules/rig_modules.dm
+++ b/code/modules/clothing/spacesuits/rig_modules/rig_modules.dm
@@ -25,8 +25,10 @@
 	return
 
 /obj/item/rig_module/proc/say_to_wearer(var/string)
-	ASSERT(rig.wearer)
-	to_chat(rig.wearer, "\The [src] reports: <span class = 'binaryradio'>[string]</span>")
+	if(!ishuman(rig.wearer))
+		return
+	var/mob/living/carbon/human/H = rig.wearer
+	to_chat(H, "\The [src] reports: <span class = 'binaryradio'>[string]</span>")
 
 /obj/item/rig_module/speed_boost
 	name = "rig speed module"

--- a/code/modules/clothing/spacesuits/rig_modules/rig_modules.dm
+++ b/code/modules/clothing/spacesuits/rig_modules/rig_modules.dm
@@ -27,8 +27,7 @@
 /obj/item/rig_module/proc/say_to_wearer(var/string)
 	if(!ishuman(rig.wearer))
 		return
-	var/mob/living/carbon/human/H = rig.wearer
-	to_chat(H, "\The [src] reports: <span class = 'binaryradio'>[string]</span>")
+	to_chat(rig.wearer, "\The [src] reports: <span class = 'binaryradio'>[string]</span>")
 
 /obj/item/rig_module/speed_boost
 	name = "rig speed module"


### PR DESCRIPTION
```
[16:12:53] Runtime in rig_modules.dm,28: code/modules/clothing/spacesuits/rig_modules/rig_modules.dm:28:Assertion Failed: rig.wearer
  proc name: say to wearer (/obj/item/rig_module/proc/say_to_wearer)
  src: the plasma-proof sealing autho... (/obj/item/rig_module/plasma_proof)
  src.loc: Captain\'s rig armor (/obj/item/clothing/suit/space/rig/captain)
  call stack:
  the plasma-proof sealing autho... (/obj/item/rig_module/plasma_proof): say to wearer("Plasma seal disengaged.")
  the plasma-proof sealing autho... (/obj/item/rig_module/plasma_proof): deactivate()
  Captain\'s rig armor (/obj/item/clothing/suit/space/rig/captain): deactivate suit(0, null)
  Captain\'s rig armor (/obj/item/clothing/suit/space/rig/captain): process()
  Objects (/datum/subsystem/obj): fire(0)
  Objects (/datum/subsystem/obj): ignite(0)
  Master (/datum/controller/master): RunQueue()
  Master (/datum/controller/master): Loop()
  Master (/datum/controller/master): StartProcessing()
```