### PR TITLE
Speeds up pipe initialization

### DIFF
--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -239,12 +239,16 @@ Pipelines + Other Objects -> Pipe network
 					return
 			if(!found)
 				continue
-			var/node_var="node[node_id]"
-			if(!(node_var in vars))
-				//testing("[node_var] not in vars.")
-				return
-			if(!vars[node_var])
-				vars[node_var] = found
+			if(!get_node(node_id))
+				set_node(node_id, found)
+
+//These two procs are a shitty compromise to speed up pipe initialization without completely rewriting pipecode.
+//get_node(<n>) should return the var node<n> and set_node(<n>, <v>) should set node<n> to <v>.
+/obj/machinery/atmospherics/proc/get_node(node_id)
+	CRASH("Uh oh! Somebody didn't override get_node()!")
+
+/obj/machinery/atmospherics/proc/set_node(node_id, value)
+	CRASH("Uh oh! Somebody didn't override set_node()!")
 
 // Wait..  What the fuck?
 // I asked /tg/ and bay and they have no idea why this is here, so into the trash it goes. - N3X

--- a/code/ATMOSPHERICS/components/binary_devices/binary_atmos_base.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/binary_atmos_base.dm
@@ -36,6 +36,26 @@
 	air1.volume = 200
 	air2.volume = 200
 
+
+/obj/machinery/atmospherics/binary/get_node(node_id)
+	switch(node_id)
+		if(1)
+			return node1
+		if(2)
+			return node2
+		else
+			CRASH("Invalid node_id!")
+
+/obj/machinery/atmospherics/binary/set_node(node_id, value)
+	switch(node_id)
+		if(1)
+			node1 = value
+		if(2)
+			node2 = value
+		else
+			CRASH("Invalid node_id!")
+
+
 /obj/machinery/atmospherics/binary/update_planes_and_layers()
 	if (level == LEVEL_BELOW_FLOOR)
 		layer = BINARY_PIPE_LAYER

--- a/code/ATMOSPHERICS/components/trinary_devices/trinary_base.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/trinary_base.dm
@@ -77,6 +77,30 @@ obj/machinery/atmospherics/trinary/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
 		node3.build_network()
 	return 1
 
+
+/obj/machinery/atmospherics/trinary/get_node(node_id)
+	switch(node_id)
+		if(1)
+			return node1
+		if(2)
+			return node2
+		if(3)
+			return node3
+		else
+			CRASH("Invalid node_id!")
+
+/obj/machinery/atmospherics/trinary/set_node(node_id, value)
+	switch(node_id)
+		if(1)
+			node1 = value
+		if(2)
+			node2 = value
+		if(3)
+			node3 = value
+		else
+			CRASH("Invalid node_id!")
+
+
 // Housekeeping and pipe network stuff below
 obj/machinery/atmospherics/trinary/network_expand(datum/pipe_network/new_network, obj/machinery/atmospherics/pipe/reference)
 	if(reference == node1)

--- a/code/ATMOSPHERICS/components/unary/unary_base.dm
+++ b/code/ATMOSPHERICS/components/unary/unary_base.dm
@@ -15,6 +15,22 @@
 	air_contents.temperature = T0C
 	air_contents.volume = starting_volume
 
+
+/obj/machinery/atmospherics/unary/get_node(node_id)
+	switch(node_id)
+		if(1)
+			return node1
+		else
+			CRASH("Invalid node_id!")
+
+/obj/machinery/atmospherics/unary/set_node(node_id, value)
+	switch(node_id)
+		if(1)
+			node1 = value
+		else
+			CRASH("Invalid node_id!")
+
+
 /obj/machinery/atmospherics/unary/update_planes_and_layers()
 	if (level == LEVEL_BELOW_FLOOR)
 		layer = UNARY_PIPE_LAYER

--- a/code/ATMOSPHERICS/he_pipes.dm
+++ b/code/ATMOSPHERICS/he_pipes.dm
@@ -88,7 +88,7 @@
 					h_r = 64 + (h_r - 64)*scale
 					h_g = 64 + (h_g - 64)*scale
 					h_b = 64 + (h_b - 64)*scale
-				
+
 				var/heat_color = rgb(h_r, h_g, h_b)
 
 				animate(src, color = heat_color, time = 2 SECONDS, easing = SINE_EASING)
@@ -261,6 +261,30 @@
 		node3.build_network()
 	return 1
 
+
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/he_manifold/get_node(node_id)
+	switch(node_id)
+		if(1)
+			return node1
+		if(2)
+			return node2
+		if(3)
+			return node3
+		else
+			CRASH("Invalid node_id!")
+
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/he_manifold/set_node(node_id, value)
+	switch(node_id)
+		if(1)
+			node1 = value
+		if(2)
+			node2 = value
+		if(3)
+			node3 = value
+		else
+			CRASH("Invalid node_id!")
+
+
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/he_manifold/update_icon()
 	if(!node1&&!node2&&!node3)
 		qdel(src)
@@ -309,6 +333,34 @@
 		node4.initialize()
 		node4.build_network()
 	return 1
+
+
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/he_manifold4w/get_node(node_id)
+	switch(node_id)
+		if(1)
+			return node1
+		if(2)
+			return node2
+		if(3)
+			return node3
+		if(4)
+			return node4
+		else
+			CRASH("Invalid node_id!")
+
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/he_manifold4w/set_node(node_id, value)
+	switch(node_id)
+		if(1)
+			node1 = value
+		if(2)
+			node2 = value
+		if(3)
+			node3 = value
+		if(4)
+			node4 = value
+		else
+			CRASH("Invalid node_id!")
+
 
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/he_manifold4w/update_icon()
 	if(!node1&&!node2&&!node3&&!node4)

--- a/code/ATMOSPHERICS/pipes.dm
+++ b/code/ATMOSPHERICS/pipes.dm
@@ -166,6 +166,25 @@
 	return 1
 
 
+/obj/machinery/atmospherics/pipe/simple/get_node(node_id)
+	switch(node_id)
+		if(1)
+			return node1
+		if(2)
+			return node2
+		else
+			CRASH("Invalid node_id!")
+
+/obj/machinery/atmospherics/pipe/simple/set_node(node_id, value)
+	switch(node_id)
+		if(1)
+			node1 = value
+		if(2)
+			node2 = value
+		else
+			CRASH("Invalid node_id!")
+
+
 /obj/machinery/atmospherics/pipe/simple/hide(var/i)
 	update_icon()
 
@@ -501,6 +520,29 @@
 	..()
 
 
+/obj/machinery/atmospherics/pipe/manifold/get_node(node_id)
+	switch(node_id)
+		if(1)
+			return node1
+		if(2)
+			return node2
+		if(3)
+			return node3
+		else
+			CRASH("Invalid node_id!")
+
+/obj/machinery/atmospherics/pipe/manifold/set_node(node_id, value)
+	switch(node_id)
+		if(1)
+			node1 = value
+		if(2)
+			node2 = value
+		if(3)
+			node3 = value
+		else
+			CRASH("Invalid node_id!")
+
+
 /obj/machinery/atmospherics/pipe/manifold/hide(var/i)
 	update_icon()
 
@@ -715,6 +757,34 @@
 	centre_overlay = manifold4w_centre
 	centre_overlay.color = color
 	overlays += centre_overlay
+
+
+/obj/machinery/atmospherics/pipe/manifold4w/get_node(node_id)
+	switch(node_id)
+		if(1)
+			return node1
+		if(2)
+			return node2
+		if(3)
+			return node3
+		if(4)
+			return node4
+		else
+			CRASH("Invalid node_id!")
+
+/obj/machinery/atmospherics/pipe/manifold4w/set_node(node_id, value)
+	switch(node_id)
+		if(1)
+			node1 = value
+		if(2)
+			node2 = value
+		if(3)
+			node3 = value
+		if(4)
+			node4 = value
+		else
+			CRASH("Invalid node_id!")
+
 
 /obj/machinery/atmospherics/pipe/manifold4w/hide(var/i)
 	update_icon()


### PR DESCRIPTION
This is a shitty method, but less shitty than what we're using now. The copypaste hurts me though. Doing it without that copypaste would require a not-insignificant rewrite of pipecode, which nobody wants to do.
On my machine running Box, this cuts down the time the object subsystem takes to initialize from ~18 seconds to ~12 seconds.